### PR TITLE
doc: add a roadmap for partial differential equations

### DIFF
--- a/Centauri/Basic.lean
+++ b/Centauri/Basic.lean
@@ -5,7 +5,7 @@ import Mathlib.Tactic
 
 Placeholder module so the `Centauri` library builds before any mathematics has
 landed. Replace/extend with real content. This library must stay free of unfinished
-proofs and trust escape hatches — CI rejects them (see `CentauriReview/`).
+proofs and trust escape hatches; CI rejects them (see `CentauriReview/`).
 -/
 
 namespace Centauri

--- a/CentauriReview/README.md
+++ b/CentauriReview/README.md
@@ -1,6 +1,6 @@
 # CentauriReview
 
-Human-owned. This is where review of AI-authored `Centauri/` PRs is specified —
+Human-owned. This is where review of AI-authored `Centauri/` PRs is specified,
 first as written rubrics, later (the ambition) as bots that apply them.
 
 The split with CI: anything in review that *can* be a mechanical check should become
@@ -9,15 +9,15 @@ be mechanized (is this the right abstraction? is the statement faithful to inten
 
 ## Status
 
-- `rubric.md` — the initial human-review rubric (skeleton).
-- Review bots — TBD.
+- `rubric.md`: the initial human-review rubric (skeleton).
+- Review bots: TBD.
 
 ## Already mechanized in CI (`.github/workflows/ci.yml`)
 
 - Builds against pinned Mathlib.
 - `Centauri/` is free of `sorry` / `admit` / `sorryAx`.
 - `Centauri/` does not import the roadmap/review trees (so it cannot inherit sorried
-  goals — the real trust boundary, since the two-`lean_lib` split alone is only build
+  goals, the real trust boundary, since the two-`lean_lib` split alone is only build
   convenience).
 
 ## Planned checks (to migrate from rubric → CI)
@@ -25,10 +25,10 @@ be mechanized (is this the right abstraction? is the statement faithful to inten
 - **`#print axioms` allowlist audit.** Assert every `Centauri/` declaration depends
   only on an allowlist (`propext`, `Classical.choice`, `Quot.sound`). This catches
   what grep cannot: `sorryAx` reaching in through imports, `native_decide`'s
-  `Lean.ofReduceBool`, and any home-rolled `axiom` — all in one gate. This is the
+  `Lean.ofReduceBool`, and any home-rolled `axiom`, all in one required check. This is the
   most important planned upgrade.
 - **Statement faithfulness.** A lockfile pinning the expected *type* of each roadmap
-  milestone, with CI failing if a claimed solution's signature drifts from it — so
+  milestone, with CI failing if a claimed solution's signature drifts from it, so
   "prove milestone X" can't be won by weakening the statement.
 - **AI-PR path guard.** An AI-authored PR may touch only `Centauri/`.
 - Docstring presence; environment linters.

--- a/CentauriReview/rubric.md
+++ b/CentauriReview/rubric.md
@@ -7,7 +7,7 @@ against the criteria below.
 ## 1. Integrity (mostly mechanized; reviewer confirms intent)
 
 - [ ] No `sorry` / `admit` / `sorryAx`; no stray `axiom`.
-- [ ] No `native_decide` (or, if present, explicitly justified — it adds
+- [ ] No `native_decide` (or, if present, explicitly justified, since it adds
       `Lean.ofReduceBool` to the trust base).
 - [ ] No new dependency on the roadmap/review trees.
 - [ ] Statements are not silently weakened: a theorem named for a milestone proves the
@@ -35,5 +35,5 @@ against the criteria below.
 
 ---
 
-*This is a starting point — refine it as patterns (and antipatterns) emerge, and
+*This is a starting point; refine it as patterns (and antipatterns) emerge, and
 migrate anything mechanizable into CI per `README.md`.*

--- a/CentauriRoadmap.lean
+++ b/CentauriRoadmap.lean
@@ -5,3 +5,4 @@
 import CentauriRoadmap.UniversalCovers.Targets
 import CentauriRoadmap.JacobianChallenge.Targets
 import CentauriRoadmap.ReductiveGroups.Targets
+import CentauriRoadmap.PDE.Targets

--- a/CentauriRoadmap/JacobianChallenge/README.md
+++ b/CentauriRoadmap/JacobianChallenge/README.md
@@ -4,7 +4,7 @@ Background: Kevin Buzzard's "Jacobian challenge" (Zulip
 [#Autoformalization > Jacobian challenge](https://leanprover.zulipchat.com/#narrow/channel/417987-Autoformalization/topic/Jacobian.20challenge)),
 in the **algebraic-geometry formulation due to Christian Merten**. The challenge is
 designed with **checks along the way**, so a construction that satisfies them all has to
-have the definitions right — the point is autoformalizing *definitions*, not just
+have the definitions right; the point is autoformalizing *definitions*, not just
 discharging `sorry`s.
 
 **We are not waiting for Mathlib.** The prerequisite stack (scheme-theoretic divisors,
@@ -48,34 +48,34 @@ regular + connected ⇒ irreducible). A chosen `k`-rational point `x₀`. The Ja
 
 ## Inventory: what Mathlib master gives us (consume)
 
-- **Morphism properties** — `Mathlib/AlgebraicGeometry/Morphisms/*`: `Proper`, `Smooth`,
-  `Separated`, `Flat`, `FiniteType`, `FinitePresentation`, `ClosedImmersion`, `Etale`, … —
+- **Morphism properties**, `Mathlib/AlgebraicGeometry/Morphisms/*`: `Proper`, `Smooth`,
+  `Separated`, `Flat`, `FiniteType`, `FinitePresentation`, `ClosedImmersion`, `Etale`, …,
   every adjective for "smooth proper curve", plus the flat/proper/fp hypotheses the
   relative theory needs.
-- **Geometric conditions** — `Mathlib/AlgebraicGeometry/Geometrically/{Connected,Integral}.lean`.
-- **Affine Picard / class groups** — `Mathlib/RingTheory/PicardGroup.lean` (`CommRing.Pic`)
+- **Geometric conditions**: `Mathlib/AlgebraicGeometry/Geometrically/{Connected,Integral}.lean`.
+- **Affine Picard / class groups**: `Mathlib/RingTheory/PicardGroup.lean` (`CommRing.Pic`)
   and `ClassGroup.equivPic`. Useful *algebraic ingredients for affine charts*; they are
   **not** a direct foundation for the global Picard scheme (the work is invertible sheaves
   as locally free sheaves, gluing, and descent).
-- **General sheaf cohomology on a site** — `Mathlib/CategoryTheory/Sites/SheafCohomology/{Basic,Cech,MayerVietoris}.lean`,
-  `Mathlib/AlgebraicGeometry/Sites/BigZariski.lean`. ⚠ Abstract only — **coherent-sheaf
+- **General sheaf cohomology on a site**: `Mathlib/CategoryTheory/Sites/SheafCohomology/{Basic,Cech,MayerVietoris}.lean`,
+  `Mathlib/AlgebraicGeometry/Sites/BigZariski.lean`. ⚠ Abstract only: **coherent-sheaf
   cohomology of schemes** (finiteness, base change, the curve's `H⁰/H¹`) is **not** here
   (Layers B–C).
-- **Rigidity** — `Mathlib/AlgebraicGeometry/Group/Abelian.lean`: a proper group scheme is
+- **Rigidity**, `Mathlib/AlgebraicGeometry/Group/Abelian.lean`: a proper group scheme is
   commutative. Use it for general abelian-variety API; note `Pic⁰` is commutative *directly*
   (tensor product of line bundles), so rigidity is not needed for that.
-- **`Proj` / projective space** — `Mathlib/AlgebraicGeometry/ProjectiveSpectrum/*`.
-- **Genus-1 ingredients** — `Mathlib/AlgebraicGeometry/EllipticCurve/*`: the group law on
+- **`Proj` / projective space**: `Mathlib/AlgebraicGeometry/ProjectiveSpectrum/*`.
+- **Genus-1 ingredients**, `Mathlib/AlgebraicGeometry/EllipticCurve/*`: the group law on
   the points of an elliptic curve is built in `EllipticCurve/Affine/Point.lean` **through
   the class group** (`ClassGroup.mk W.FunctionField (XYIdeal' …)`), i.e. the divisor-class /
   `Pic⁰` description in genus 1. This is a **reconciliation target and a template**, *not*
-  a scheme-level `Jac(E) ≅ E` — that statement still has to be built.
+  a scheme-level `Jac(E) ≅ E`; that statement still has to be built.
 
 ## Inventory: what is missing (build here)
 
 Scheme-theoretic Weil/Cartier **divisors** and the divisor ↔ line-bundle dictionary; the
 **degree** map and **Pic⁰**; **coherent-sheaf cohomology** with **finiteness, Serre
-duality, Riemann–Roch** over `k`; the **relative** theory — proper-flat pushforward,
+duality, Riemann–Roch** over `k`; the **relative** theory, i.e. proper-flat pushforward,
 **cohomology and base change / semicontinuity / Grauert**, relative effective Cartier
 divisors; the **Picard functor**, its **rigidification** (Poincaré bundle) and
 **representability**, and `Pic⁰` with its **properness/projectivity**; **abelian varieties**
@@ -91,7 +91,7 @@ Codex's recommended dependency order, refined. Each layer is self-contained math
 worth having on its own. As a layer makes the next one's *types* expressible, state those
 milestones in `Targets.lean` (with `sorry`) and hand them to the AIs.
 
-### Layer A — line bundles, divisors, Picard group, degree
+### Layer A, line bundles, divisors, Picard group, degree
 - **Invertible sheaves** on a scheme; the **Picard group** `Pic X` under `⊗`.
 - **Divisors on a curve:** Weil divisors `⊕_x ℤ` and Cartier divisors; the dictionaries
   `Cartier ≃ line bundles` and (smooth curve) `Weil ≃ Cartier`; principal divisors;
@@ -101,7 +101,7 @@ milestones in `Targets.lean` (with `sorry`) and hand them to the AIs.
   characteristic*, **not** the degree. Then `Pic⁰ X = ker deg` (as an abstract group; the
   *functorial* `Pic⁰` is defined in Layer D).
 
-### Layer B — coherent cohomology over `k`: genus, Riemann–Roch, Serre duality
+### Layer B, coherent cohomology over `k`: genus, Riemann–Roch, Serre duality
 - **Coherent sheaves** and cohomology `Hⁱ(X, ℱ)`: acyclicity of affines, Čech ≃ derived on
   a separated scheme, **finite-dimensionality for proper `X/k`**, vanishing above dimension
   (`H²= 0` on a curve).
@@ -109,47 +109,47 @@ milestones in `Targets.lean` (with `sorry`) and hand them to the AIs.
   duality** with the **relative dualizing sheaf** `ω_{X/k}`: `Hⁱ(L) ≅ H^{1−i}(ω_{X/k} ⊗ L⁻¹)*`
   and `deg ω_{X/k} = 2g − 2`.
 
-### Layer C — relative coherent cohomology and base change
+### Layer C, relative coherent cohomology and base change
 The part that the classical "Sym^g" story quietly relies on, so it comes *before* Picard.
 - Proper-flat-finitely-presented pushforward of coherent sheaves; **flat base change**;
   **cohomology and base change / semicontinuity** (Grauert), and the theorem on formal
   functions if following Grothendieck's Picard-scheme proof.
 - **Relative effective Cartier divisors** and **symmetric powers** `Symᵈ X` (smooth
-  projective for a smooth curve) — the geometric input to the Abel maps.
+  projective for a smooth curve): the geometric input to the Abel maps.
 
-### Layer D — the relative Picard functor and the Jacobian scheme
+### Layer D, the relative Picard functor and the Jacobian scheme
 - **The functor.** For `f : X → Spec k` proper, flat, finitely presented with
   geometrically integral fibres (so `f_*𝒪_X = 𝒪` universally), `Pic_{X/k}` is the **fppf
-  sheafification** of `T ↦ Pic(X_T)/Pic(T)`. Keep the three notions distinct — Picard
-  *stack* vs *functor/sheaf* vs *rigidified functor* — and record the obstruction
+  sheafification** of `T ↦ Pic(X_T)/Pic(T)`. Keep the three notions distinct (Picard
+  *stack* vs *functor/sheaf* vs *rigidified functor*), and record the obstruction
   (`Br`-flavoured) between `Pic(X_T)/Pic(T)` and `Pic_{X/k}(T)`. The section `x₀`
   **rigidifies** it (line bundles trivialized along `x₀,T`; the **Poincaré bundle**) and
   removes that obstruction.
 - **`Pic⁰`** = the degree-0 **open-and-closed component** of the relative Picard scheme
   once it exists (before representability: the subfunctor of line bundles of degree 0 on
-  every geometric fibre — mind local constancy of degree in flat families).
-- **Representability — the crux** (both routes hide heavy infrastructure; neither is "easy"):
+  every geometric fibre; mind local constancy of degree in flat families).
+- **Representability, the crux** (both routes hide heavy infrastructure; neither is "easy"):
   1. **Symmetric powers / Abel maps.** `AJ_d : Symᵈ X → Pic^d`, `D ↦ 𝒪_X(D)`, normalized to
      `Pic⁰` by `D ↦ 𝒪_X(D − d·x₀)`; for `d = g` this is birational and surjective over `k̄`.
      Using it to *construct* `Jac` needs Layer C (Symᵈ existence/smoothness, relative
-     effective divisors, semicontinuity, cohomology-and-base-change, descent) — it does
+     effective divisors, semicontinuity, cohomology-and-base-change, descent); it does
      *not* directly "yield" `Jac` by itself.
   2. **General Picard scheme** of a projective variety (Hilbert/Grothendieck), then
      specialize. Even heavier.
 - **Properness/projectivity** of `Pic⁰` (not merely representability).
 
-### Layer E — abelian varieties
+### Layer E, abelian varieties
 - **Abelian variety** = smooth, proper, geometrically connected group scheme over `k`;
   basic API, **`dim`**. Commutativity is automatic (rigidity, `Group/Abelian.lean`).
 - **Tangent space** `T₀ Pic⁰ ≅ H¹(X, 𝒪_X)`, hence `dim (Jac X) = g`.
 - **The theorem of the cube/square**, the **dual abelian variety**, **polarizations** (the
   theta divisor gives `Jac` a principal polarization), and `[n]` as an isogeny. (These are
-  *not* needed for the group law on `Pic⁰`, which is tensor product — they belong here, with
+  *not* needed for the group law on `Pic⁰`, which is tensor product; they belong here, with
   the dual/polarization theory, not at the construction step.)
-- **Characteristic `p`:** `p`-torsion is non-étale, isogenies can be inseparable — avoid
+- **Characteristic `p`:** `p`-torsion is non-étale, isogenies can be inseparable; avoid
   hidden perfect-field assumptions.
 
-### Layer F — Abel–Jacobi and the universal property
+### Layer F, Abel–Jacobi and the universal property
 - The **Abel–Jacobi morphism** `aj : X ⟶ Jac X`, `x₀ ↦ 0` (the `d = 1` Abel map).
 - **Universal property (precise):** for every abelian variety `A` and pointed morphism
   `f : (X, x₀) → (A, 0)`, there is a **unique homomorphism of abelian varieties**
@@ -179,13 +179,13 @@ A finished construction must pass sanity checks that rule out vacuous definition
 
 ## References
 
-- R. Hartshorne, *Algebraic Geometry* — Ch. II (sheaves, divisors), III (cohomology,
+- R. Hartshorne, *Algebraic Geometry*: Ch. II (sheaves, divisors), III (cohomology,
   incl. III.12 cohomology and base change), IV (curves, Riemann–Roch).
-- Q. Liu, *Algebraic Geometry and Arithmetic Curves* — curves, models, Picard.
+- Q. Liu, *Algebraic Geometry and Arithmetic Curves*: curves, models, Picard.
 - J. S. Milne, *Abelian Varieties* and *Jacobian Varieties* (in Cornell–Silverman,
-  *Arithmetic Geometry*) — the construction and universal property.
-- D. Mumford, *Abelian Varieties* — theorem of the cube/square, dual variety, polarizations.
-- Bosch–Lütkebohmert–Raynaud, *Néron Models*, Ch. 8–9 — the Picard functor and its
+  *Arithmetic Geometry*): the construction and universal property.
+- D. Mumford, *Abelian Varieties*: theorem of the cube/square, dual variety, polarizations.
+- Bosch–Lütkebohmert–Raynaud, *Néron Models*, Ch. 8–9: the Picard functor and its
   representability.
 - The Stacks Project: *Picard schemes of curves* (tag 0B95), *Divisors* (tag 01WP),
   *Cohomology and base change* (tag 0B91), *Quot/Hilbert and Picard functors* (tag 0D04).

--- a/CentauriRoadmap/JacobianChallenge/Targets.lean
+++ b/CentauriRoadmap/JacobianChallenge/Targets.lean
@@ -1,7 +1,7 @@
 import Mathlib
 
 /-!
-# Jacobian challenge (AG version) — target signatures
+# Jacobian challenge (AG version): target signatures
 
 The narrative roadmap, the prerequisite tower (Layers A–E), and the acceptance
 criteria are in `README.md`. Almost none of the prerequisites are in Mathlib, so we
@@ -9,12 +9,12 @@ are **building the tower here** in `Centauri/AlgebraicGeometry/` rather than wai
 
 As each layer makes the next layer's *types* expressible in `Centauri/`, state that
 layer's milestones here with `sorry` (human-owned roadmap territory, so `sorry` is
-allowed) and hand them to the AIs to discharge — starting with Layer A (the Picard
+allowed) and hand them to the AIs to discharge, starting with Layer A (the Picard
 group and the degree map) and building up to `noncomputable def JacobianVariety` and
 the universal property of the Abel–Jacobi map.
 
 Note the name clash flagged in `README.md`: Mathlib's `WeierstrassCurve.Jacobian`
-means Jacobian *coordinates*, not the Jacobian *variety* — use `JacobianVariety`.
+means Jacobian *coordinates*, not the Jacobian *variety*, so use `JacobianVariety`.
 -/
 
 namespace CentauriRoadmap.JacobianChallenge

--- a/CentauriRoadmap/PDE/README.md
+++ b/CentauriRoadmap/PDE/README.md
@@ -1,0 +1,382 @@
+# Roadmap: partial differential equations
+
+Mathlib master already carries a deep analysis stack: distributions, the Schwartz space,
+the full Fourier transform with inversion and Plancherel, convolution and mollifiers, the
+Gagliardo–Nirenberg–Sobolev inequality, **Bessel-potential Sobolev spaces**, the
+Laplacian on inner-product spaces, harmonic-function theory, **Lax–Milgram**, the
+**Fredholm alternative for compact operators**, and Picard–Lindelöf for ODEs. What is
+still missing is the **PDE theory built on top**: weak-derivative Sobolev spaces on a
+domain with their embedding/trace/compactness package, maximum principles, the
+harmonic-analysis estimates (maximal function, Calderón–Zygmund, interpolation), and the
+existence-and-regularity theorems for elliptic and parabolic equations.
+
+The bar for "done": a researcher in elliptic or parabolic PDE looks at this material and
+says *"the prerequisites are all here, in reusable form, and I can start my work."*
+
+## The end goal (v1)
+
+For a **bounded open `Ω ⊆ ℝⁿ`** and a **uniformly elliptic, divergence-form** operator
+`L u = -∂ⱼ(aⁱʲ ∂ᵢ u) + bⁱ ∂ᵢ u + c u` with bounded measurable coefficients, deliver the
+**three pillars** for the Dirichlet problem `L u = f` in `Ω`, `u = g` on `∂Ω`:
+
+1. **Existence and uniqueness** of a weak solution in `H¹(Ω)` (energy method: Gårding's
+   inequality plus Lax–Milgram; the Fredholm alternative when coercivity fails).
+2. **Regularity:** weak solutions are locally Hölder continuous
+   (**De Giorgi–Nash–Moser**, the bounded-measurable-coefficient case), and smooth when
+   the coefficients and data are smooth (interior `Hᵏ`/Schauder estimates).
+3. **The maximum principle** (weak and strong) and the **Harnack inequality** for the
+   homogeneous equation, with the classical potential theory (mean-value property,
+   Newtonian potential, Perron's method) as the constant-coefficient template.
+
+```lean
+-- the shape we are building toward (state in Targets.lean as the supporting types land):
+-- variable {n : ℕ} {Ω : Set (EuclideanSpace ℝ (Fin n))} (hΩ : IsOpen Ω) (hb : IsBounded Ω)
+--
+-- the energy bilinear form of L, weak (distributional) formulation:
+-- def energyForm (a : Ω → Matrix (Fin n) (Fin n) ℝ) (b : Ω → ...) (c : Ω → ℝ) :
+--     (Wkp 1 2 Ω) → (Wkp 1 2 Ω) → ℝ
+--
+-- existence/uniqueness of the weak solution (Dirichlet, homogeneous BC), via Lax–Milgram:
+-- theorem exists_unique_weakSolution (helliptic : UniformlyElliptic λ Λ a) (hcoercive : ...)
+--     (f : Lp ℝ 2 (volume.restrict Ω)) :
+--     ∃! u : Wkp0 1 2 Ω, ∀ v : Wkp0 1 2 Ω, energyForm a b c u v = ∫ x in Ω, f x * v x
+--
+-- De Giorgi–Nash–Moser interior regularity of the weak solution:
+-- theorem weakSolution_holderOn (hu : IsWeakSolution L u f) (hcompact : K ⊆ Ω) (hK : IsCompact K) :
+--     ∃ α ∈ Set.Ioc (0:ℝ) 1, HolderOnWith C α u K
+```
+
+## Standing hypotheses (spell them out; never bundle)
+
+PDE theory is **example-driven and hypothesis-sensitive**: the same theorem is true in
+many incomparable forms, and the art is in tracking exactly which structure each proof
+needs. Separate typeclass assumptions let every result land in its correct generality, so
+there will be **no** monolithic `EllipticPDE` class. State each of these as a named,
+separate hypothesis:
+
+- **Domain regularity.** Most of the theory needs a bounded open `Ω`. *Trace*,
+  *extension*, and *Rellich–Kondrachov* additionally need boundary regularity
+  (Lipschitz, or `C¹`, or the cone/segment condition). Carry the boundary hypothesis
+  explicitly: interior estimates do **not** need it, global ones do.
+- **Uniform ellipticity** with *explicit* constants `0 < λ ≤ Λ`:
+  `λ‖ξ‖² ≤ aⁱʲ(x) ξᵢ ξⱼ ≤ Λ‖ξ‖²`. Almost every estimate's constant depends on `λ, Λ, n`
+  and the domain only, so make that dependence visible, not hidden in a `∃ C`.
+- **Coefficient regularity is a *dial*, and it selects the theory:**
+  - *bounded measurable* `aⁱʲ` gives **divergence form**, **weak** solutions, De Giorgi–Nash–Moser;
+  - *Hölder* `aⁱʲ ∈ C^{0,α}` gives **Schauder** `C^{2,α}` estimates (classical solutions);
+  - *continuous / VMO* `aⁱʲ` gives **Calderón–Zygmund** `W^{2,p}` estimates (strong solutions).
+  Keep these lanes distinct; do not state one result and silently assume the regularity of
+  another.
+
+## Getting the statements right
+
+A few cross-cutting rules for the *shape* of a PDE statement: which hypotheses it carries
+and which notion it names. These recur across the lanes below, and getting them right at
+statement time is what keeps the formalized API reusable.
+
+- **Name the solution concept.** State whether a theorem is about *classical* (`C²`, the
+  PDE holds pointwise), *strong* (`W^{2,p}`, a.e.), or *weak* (`H¹`, against test
+  functions) solutions, and which of these it assumes versus produces. The regularity lane
+  is exactly the passage from weak to classical.
+- **Build domain Sobolev spaces from weak derivatives, then connect them to the Fourier
+  scale.** The PDE workhorse is `W^{k,p}(Ω)` on a domain via weak derivatives; build it,
+  then *prove* it agrees with Mathlib's Fourier/Bessel-potential spaces
+  (`TemperedDistribution.memSobolev`) on `ℝⁿ` in the range where they coincide
+  (`1 < p < ∞`, integer `s`; Calderón). Don't reuse the Bessel definition as the domain
+  theory: it is a whole-space notion and the two scales genuinely differ at `p = 1, ∞`.
+- **Carry Poincaré's normalization.** `‖u‖ ≤ C‖∇u‖` holds on `W^{1,p}_0(Ω)` (zero trace)
+  or modulo constants (Poincaré–Wirtinger, zero mean), for `Ω` bounded (or of finite
+  measure, or bounded in one direction). State that side condition explicitly; it is the
+  load-bearing hypothesis (the inequality fails outright on `ℝⁿ`).
+- **Pick the Sobolev-embedding regime by exponent.** Subcritical `p < n` gives
+  `W^{1,p} ↪ L^{p*}`, `p* = np/(n−p)` (consume Gagliardo–Nirenberg–Sobolev); supercritical
+  `p > n` gives Hölder `C^{0,1−n/p}` (Morrey); the borderline `p = n` gives
+  BMO/exponential integrability (Trudinger–Moser), not `L^∞`. State the regime you mean
+  rather than a single catch-all embedding.
+- **Use weak compactness for existence; reserve norm compactness for Rellich.** Existence
+  arguments run on *weak* sequential compactness of bounded sets in a reflexive space
+  (Banach–Alaoglu / `WeakDual`). Norm compactness comes from one place,
+  **Rellich–Kondrachov**: `W^{1,p}(Ω) ↪↪ L^p(Ω)` is compact for bounded `Ω`, the embedding
+  that powers the Fredholm alternative and the eigenvalue expansions.
+- **State maximum principles with their hypotheses.** The weak maximum principle for
+  `Lu = -∂ⱼ(aⁱʲ∂ᵢu) + cu` needs `c ≥ 0` (or `Lu ≤ 0` with the right structure); the strong
+  principle additionally needs `Ω` connected and rests on the **Hopf boundary-point
+  lemma**; Harnack is for nonnegative solutions. Make each of these a named hypothesis.
+- **Fix the Laplacian sign and Fourier convention once.** Pin the sign of `Δ` (Mathlib's
+  convention in `InnerProductSpace/Laplacian.lean`), and note Mathlib's Bessel potential is
+  `(1 − (2π)⁻² Δ)^{s/2}`, not `(1 − Δ)^{s/2}`, because of the `2π` in its Fourier
+  transform. This is harmless when *defining* the spaces, but a mismatch in an estimate is
+  a real error.
+- **Keep divergence and non-divergence form apart.** De Giorgi–Nash–Moser is
+  divergence-form/weak; its non-divergence-form counterpart is **Krylov–Safonov** (`Lᵖ`
+  viscosity / `W^{2,p}` strong). They are different theories, so don't transfer one's
+  conclusion under the other's hypotheses.
+
+## Inventory: what Mathlib master gives us (consume)
+
+- **Distributions & test functions** in `Mathlib/Analysis/Distribution/*`:
+  `Distribution` (`𝓓'(Ω, F)`, general `F`-valued, finite-dim domain), `TestFunction`
+  (`𝓓(Ω)`), `ContDiffMapSupportedIn`, `TemperedDistribution` (`𝓢'`), `SchwartzSpace`
+  (`𝓢`), `FourierSchwartz`, `FourierMultiplier`, `TemperateGrowth`, and the distributional
+  `DerivNotation`. This is a *substantial* head start: the test-function/distribution
+  pairing is already done.
+- **Sobolev (Bessel potential)** in `Mathlib/Analysis/Distribution/Sobolev.lean`:
+  `besselPotential`, `memSobolev` (the `H^{s,p}` scale), `memSobolev_two_iff_fourier`,
+  and the operator actions `MemSobolev.lineDerivOp`, `MemSobolev.laplacian`. Reconcile
+  with (do not duplicate) the weak-derivative spaces you build.
+- **The Sobolev inequality** in `Mathlib/Analysis/FunctionalSpaces/SobolevInequality.lean`:
+  `eLpNorm_le_eLpNorm_fderiv_of_eq` / `…_of_le` (Gagliardo–Nirenberg–Sobolev, van Doorn–
+  Macbeth). The subcritical embedding estimate, already proved; *consume it directly* for
+  the `p < n` case.
+- **Fourier analysis** in `Mathlib/Analysis/Fourier/*`: `FourierTransform`, `Inversion`,
+  `LpSpace` (Plancherel/Hausdorff–Young flavour), `FourierTransformDeriv`,
+  `RiemannLebesgueLemma`, `PoissonSummation`, `Convolution`.
+- **Convolution & mollifiers** in `Mathlib/Analysis/Convolution.lean` and
+  `Mathlib/Analysis/Calculus/BumpFunction/*` (`ContDiffBump`, `Convolution`), the
+  approximate-identity machinery for density and smoothing.
+- **The Laplacian & harmonic functions** in
+  `Mathlib/Analysis/InnerProductSpace/Laplacian.lean` (`Δ` on `E → F`, real f.d. inner
+  product space), `…/InnerProductSpace/Harmonic/*` (`HarmonicAt`, `HarmonicOnNhd`, the
+  algebra of harmonic functions), and `Mathlib/Analysis/Complex/Harmonic/*` (mean-value
+  property, Liouville, Poisson kernel, harmonic ⇔ locally `Re` of analytic). The `n = 2`
+  potential theory is essentially *there*.
+- **Hilbert-space machinery for the energy method** in
+  `Mathlib/Analysis/InnerProductSpace/LaxMilgram.lean` (`IsCoercive`,
+  `continuousLinearEquivOfBilin`, i.e. **Lax–Milgram itself**),
+  `…/InnerProductSpace/Dual.lean` (**Fréchet–Riesz** `toDual`),
+  `…/InnerProductSpace/Adjoint.lean`, `…/InnerProductSpace/Projection.lean`.
+- **Spectral theory** in `Mathlib/Analysis/InnerProductSpace/Spectrum.lean`: the spectral
+  theorem for symmetric operators (finite-dim diagonalization; for **compact** operators,
+  `finite_dimensional_eigenspace` and `eq_zero_of_forall_hasEigenvalue_eq_zero`), and
+  `Mathlib/Analysis/Normed/Operator/Compact/FredholmAlternative.lean` (the **Fredholm
+  alternative**). The eigenvalue/eigenfunction-expansion lane builds directly on these.
+- **Functional-analysis backbone:** Hahn–Banach
+  (`Mathlib/Analysis/Normed/Module/HahnBanach.lean`), Banach–Steinhaus
+  (`…/Normed/Operator/BanachSteinhaus.lean`), open mapping / closed graph, weak topologies
+  (`…/Normed/Module/WeakDual.lean`, `…/LocallyConvex/WeakDual.lean`), Arzelà–Ascoli
+  (`Mathlib/Topology/ContinuousMap/Bounded/ArzelaAscoli.lean`).
+- **Integration:** the Bochner integral (`Mathlib/MeasureTheory/Integral/Bochner/*`, the
+  vector-valued integral the parabolic lane needs), `Lp`/`eLpNorm`, Hölder & Minkowski,
+  conditional expectation, Besicovitch/Vitali covering
+  (`Mathlib/MeasureTheory/Covering/*`).
+- **ODEs** in `Mathlib/Analysis/ODE/*`: Picard–Lindelöf (`ExistUnique`), Grönwall. The
+  Galerkin/method-of-lines and the characteristic-curve lanes consume these.
+
+## Inventory: what is missing (build here)
+
+- **Weak-derivative Sobolev spaces `W^{k,p}(Ω)`** on a domain (distinct from the
+  Bessel-potential scale): weak derivatives, completeness, `W^{k,p}_0` as the
+  `C_c^∞`-closure, Meyers–Serrin `H = W` density, and the agreement theorem with the
+  Fourier `H^{s,p}` on `ℝⁿ`.
+- **The embedding/trace/compactness package:** Morrey `C^{0,α}` embedding (`p > n`), the
+  borderline `p = n` case, **Poincaré** and Poincaré–Wirtinger, the **trace operator** on
+  `∂Ω` and its kernel `= W^{1,p}_0`, the **extension operator**, and
+  **Rellich–Kondrachov** compactness.
+- **Hölder spaces `C^{k,α}`** as Banach spaces (for Schauder), and the Campanato/Morrey
+  space characterization.
+- **Harmonic-analysis estimates:** the **Hardy–Littlewood maximal function** and its weak
+  `(1,1)` / strong `(p,p)` bounds (vendor from the Carleson project), the
+  **Calderón–Zygmund decomposition**, **singular integral operators** with the CZ kernel
+  bounds, the **Mihlin–Hörmander multiplier theorem**, and **interpolation**
+  (Riesz–Thorin and **Marcinkiewicz**, *neither* of which is in Mathlib). BMO and
+  John–Nirenberg as a sub-lane.
+- **Maximum principles & potential theory:** weak and strong maximum principles, the
+  **Hopf lemma**, comparison principles, the **Harnack inequality**, the Newtonian
+  potential / fundamental solution of `Δ`, the Green's function, the Poisson kernel on
+  `ℝⁿ` (the half-space and the ball), and **Perron's method** for the Dirichlet problem.
+- **Elliptic existence & regularity:** the energy/weak formulation and Gårding's
+  inequality (then Lax–Milgram, *consumed*); interior and boundary `Hᵏ`/`Lᵖ` estimates
+  (difference quotients, Calderón–Zygmund); **Schauder** `C^{2,α}` estimates;
+  **De Giorgi–Nash–Moser**; eigenvalues of `−Δ` via the compact-self-adjoint spectral
+  theorem.
+- **Parabolic & evolution equations:** Bochner spaces `L²(0,T;H)`, the Gelfand triple
+  `V ↪ H ↪ V*`, the **Galerkin method**, existence for linear parabolic equations, the
+  parabolic maximum principle, the **heat semigroup** and **Hille–Yosida**.
+
+---
+
+## The build, in lanes
+
+Each lane is self-contained analysis worth having on its own; the ordering below is the
+dependency order, not a strict schedule, and the lanes are deliberately parallelizable.
+As a lane makes the next one's *types* expressible in `Centauri/`, state those milestones
+in `Targets.lean` (with `sorry`, which is human-owned roadmap territory) and hand them to
+the AIs to discharge.
+
+### Lane A: function spaces on a domain (the universal prerequisite)
+
+Almost everything downstream waits on this, so do it first and do it right.
+
+1. **`W^{k,p}(Ω)` via weak derivatives.** Define the weak (distributional) derivative of a
+   locally integrable function, `W^{k,p}(Ω)` with its norm, and prove **completeness**.
+   Build on Mathlib's `Distribution`/`TestFunction` pairing so the definition is the
+   honest one (`∫ u ∂^α φ = (−1)^{|α|} ∫ (D^α u) φ` for all test `φ`).
+2. **Density and `W^{k,p}_0`.** Mollification (consume `BumpFunction/Convolution`) gives
+   `C^∞ ∩ W^{k,p}` dense (**Meyers–Serrin**, `H = W`); define `W^{k,p}_0(Ω)` as the
+   `C_c^∞(Ω)`-closure. ⚠ `H = W` needs no boundary regularity; `W^{k,p}_0 = W^{k,p}` for
+   `Ω = ℝⁿ` but **not** for bounded `Ω`.
+3. **Reconcile with Mathlib's Bessel-potential scale.** Prove `W^{k,2}(ℝⁿ) = H^{k,2}(ℝⁿ)`
+   (and the `1<p<∞` integer-order Calderón agreement) so the two definitions are known to
+   coincide where both make sense; *do not* leave them as unrelated theories.
+4. **Embeddings.** *Consume* Gagliardo–Nirenberg–Sobolev for `p<n`; **build** the Morrey
+   embedding `W^{1,p}(Ω) ↪ C^{0,1−n/p}(Ω)` for `p>n`, and state (then prove) the
+   borderline `p=n`.
+5. **Poincaré** on `W^{1,p}_0(Ω)` (bounded `Ω`) and **Poincaré–Wirtinger** (zero mean),
+   with explicit constant dependence.
+6. **Trace, extension, Rellich.** The **trace operator** `W^{1,p}(Ω) → L^p(∂Ω)` with
+   `ker = W^{1,p}_0` (Lipschitz `∂Ω`), an **extension operator** `W^{1,p}(Ω) → W^{1,p}(ℝⁿ)`,
+   and **Rellich–Kondrachov**: `W^{1,p}(Ω) ↪↪ L^p(Ω)` **compact** for bounded `Ω` (via
+   Fréchet–Kolmogorov / Arzelà–Ascoli). This is the keystone for Lane D and the
+   eigenvalue theory.
+7. **Hölder spaces `C^{k,α}(Ω)`** as Banach spaces, the target spaces for Schauder.
+
+### Lane B: harmonic-analysis estimates
+
+The estimate engine for Calderón–Zygmund regularity and Schauder. Vendor heavily from the
+**Carleson project**, which already has the maximal function and covering machinery.
+
+8.  **Hardy–Littlewood maximal function** `Mf` and the **maximal inequality**: weak
+    `(1,1)` (via Vitali, consuming `MeasureTheory/Covering/*`) and strong `(p,p)` for
+    `p>1`, with the Lebesgue differentiation theorem as a corollary.
+9.  **Interpolation.** **Marcinkiewicz** (real, weak-type to strong-type) and
+    **Riesz–Thorin** (complex). *Neither is in Mathlib*; both are foundational and
+    reusable far beyond PDE.
+10. **Calderón–Zygmund.** The **CZ decomposition** of an `L¹` function at height `t`; the
+    **CZ singular integral operators** (standard kernel bounds) bounded on `Lᵖ`, `1<p<∞`,
+    and weak-`(1,1)`; the **Mihlin–Hörmander multiplier theorem** (consume Mathlib's
+    `FourierMultiplier`). ⚠ A CZ operator is **not** bounded on `L¹` or `L^∞`; the
+    endpoints are weak-`(1,1)` and `L^∞ → BMO`, and stating an `L¹`/`L^∞` bound is the
+    classic error.
+11. **BMO and John–Nirenberg** (sub-lane): `BMO(ℝⁿ)`, the John–Nirenberg inequality, and
+    the `L^∞ → BMO` endpoint for CZ operators.
+
+### Lane C: maximum principles and potential theory
+
+The classical, constant-coefficient theory; the cleanest lane and a good early win, with
+much of the `n=2` case already in Mathlib's complex harmonic-function files.
+
+12. **Mean-value property and smoothness of harmonic functions** on `ℝⁿ` (consume the
+    `n=2` complex theory; generalize the mean-value characterization to `ℝⁿ`).
+13. **The weak and strong maximum principles** for `Δ` and then for general elliptic `L`
+    (sign condition `c ≥ 0`); the **Hopf boundary-point lemma**; the comparison principle.
+14. **The Harnack inequality** for nonnegative harmonic functions, then for general
+    elliptic `L` (this feeds De Giorgi–Nash–Moser in Lane E).
+15. **Fundamental solution / Newtonian potential** of `Δ` on `ℝⁿ`, the **Green's
+    function** and **Poisson kernel** on the ball/half-space, and **Perron's method**:
+    existence for the Dirichlet problem `Δu = 0` in `Ω`, `u = g` on `∂Ω`, via subharmonic
+    barriers. ⚠ Perron yields a harmonic function for *any* bounded `Ω`; **boundary
+    attainment** of `g` is a separate statement needing a **barrier** at each boundary
+    point (regular boundary points).
+
+### Lane D: linear elliptic existence (the energy method)
+
+The shortest path to a genuine PDE existence theorem, because Lax–Milgram is *already in
+Mathlib*. This lane mostly assembles Lane A and Mathlib.
+
+16. **Weak formulation.** The energy bilinear form `a(u,v) = ∫ aⁱʲ ∂ᵢu ∂ⱼv + …` on
+    `H¹_0(Ω) × H¹_0(Ω)`; boundedness; **Gårding's inequality**
+    `a(u,u) ≥ α‖u‖²_{H¹} − β‖u‖²_{L²}` from uniform ellipticity.
+17. **Existence & uniqueness (coercive case).** When `a` is coercive, *consume* Lax–Milgram
+    (`continuousLinearEquivOfBilin`) for the unique weak solution of the Dirichlet problem.
+    This is the first end-to-end PDE theorem and should land early.
+18. **The Fredholm alternative (non-coercive case).** Using Rellich (Lane A.6) to make the
+    resolvent compact, *consume* `FredholmAlternative` to get the
+    "either-unique-solution-or-finite-dim-kernel" dichotomy for `Lu = f`.
+19. **Spectrum of `−Δ`.** The Dirichlet eigenvalues/eigenfunctions of `−Δ` on a bounded
+    `Ω`: a compact self-adjoint inverse (Rellich plus Lax–Milgram), then the eigenfunction
+    basis from `InnerProductSpace/Spectrum`. The model **Sturm–Liouville** /
+    separation-of-variables payoff.
+
+### Lane E: elliptic regularity
+
+The deepest lane, and the route from weak to classical solutions; it is the heart of the
+classical elliptic theory (Schauder, De Giorgi–Nash–Moser).
+
+20. **Interior `H²`/`Hᵏ` estimates** via difference quotients: a weak `H¹` solution with
+    `L²` data is locally `H²`, bootstrapping to `C^∞` for smooth coefficients and data.
+21. **Calderón–Zygmund `W^{2,p}` estimates** for strong solutions (consume Lane B): the
+    `Lᵖ` theory of `D²u` for `Δu = f`, then variable continuous/VMO coefficients.
+22. **Schauder estimates.** Interior and global `C^{2,α}` estimates for `C^{0,α}`
+    coefficients (Lane B / Campanato approach), giving classical solvability of the
+    Dirichlet problem in `C^{2,α}`.
+23. **De Giorgi–Nash–Moser.** Local boundedness and **Hölder continuity** of weak
+    solutions of divergence-form equations with **bounded measurable** coefficients, and
+    the elliptic Harnack inequality in this generality (De Giorgi's iteration and/or
+    Moser's). ⚠ This is *the* hard theorem of the lane, so budget for it accordingly;
+    note it is **divergence-form/weak**, whereas the non-divergence analogue is
+    Krylov–Safonov.
+
+### Lane F: parabolic and evolution equations
+
+24. **Bochner spaces and the Gelfand triple.** `L²(0,T;V)`, `H¹(0,T;V*)`, the triple
+    `V ↪ H ↪ V*` (consume the Bochner integral), and the integration-by-parts/embedding
+    `L²(V) ∩ H¹(V*) ↪ C([0,T];H)`.
+25. **Linear parabolic existence.** The **Galerkin method**: finite-dimensional
+    approximation (consume ODE existence), energy estimates, weak-compactness passage to
+    the limit, giving existence/uniqueness for `∂ₜu + Lu = f`, `u(0) = u₀`. The parabolic
+    maximum principle.
+26. **Semigroups.** The **heat semigroup**, generators, and **Hille–Yosida**; the heat
+    kernel on `ℝⁿ` (consume the Fourier transform) and the smoothing estimates.
+
+### Stretch goals (state once the lanes above are solid)
+
+- **Strichartz estimates** for the wave and Schrödinger equations (Tao, *Nonlinear
+  Dispersive Equations*): the `TT*` method, the dispersive `L¹→L^∞` decay, and the
+  endpoint Keel–Tao argument, consuming the Fourier/oscillatory-integral and
+  interpolation lanes.
+- **Quasilinear elliptic existence** via Schauder/Leray–Schauder fixed-point theory on top
+  of Lane E (the De Giorgi–Nash–Moser a-priori estimates supply the compactness).
+- **Stochastic PDE:** a result from Krylov's analytic `L_p`-theory of SPDE, or
+  Da Prato–Debussche for the stochastic Navier–Stokes / 2D stochastic quantization,
+  consuming the parabolic and Bochner lanes plus Mathlib's probability stack.
+
+## Acceptance criteria ("checks along the way")
+
+Concrete sanity checks that rule out vacuous or mis-stated definitions:
+
+- **Spaces agree where they must:** `W^{k,2}(ℝⁿ) = H^{k,2}(ℝⁿ)` (Lane A.3) and
+  `ker(trace) = W^{1,p}_0` (Lane A.6).
+- **Poincaré is non-vacuous:** the constant is finite on a concrete bounded `Ω` (e.g. a
+  ball) and the inequality genuinely *fails* on `ℝⁿ`. Formalize both directions so the
+  hypothesis is known to be load-bearing.
+- **End-to-end existence:** the Dirichlet problem `−Δu = f` in a ball, `u = 0` on the
+  boundary, has a unique weak solution (Lane D.17), it is **smooth** for smooth `f`
+  (Lane E.20), and it equals the **Newtonian-potential** solution (Lane C.15): three lanes
+  meeting on one example.
+- **Eigenvalues are real and positive:** the first Dirichlet eigenvalue of `−Δ` is
+  positive (Lane D.19), matching the Poincaré constant.
+- **Regularity actually upgrades:** exhibit a weak solution that is *only* `H¹` a priori
+  and prove it is `C^{0,α}` (Lane E.23), the De Giorgi–Nash–Moser payoff on an example.
+- **Maximum principle bites:** a subsolution of `−Δu ≤ 0` attains its max on `∂Ω`
+  (Lane C.13), with a counterexample showing the sign condition is necessary.
+
+## References
+
+- L. C. Evans, *Partial Differential Equations*, the default modern graduate text;
+  Sobolev spaces (Ch. 5), second-order elliptic (Ch. 6), parabolic/Galerkin (Ch. 7),
+  semigroups (Ch. 7), Hamilton–Jacobi & conservation laws.
+- D. Gilbarg, N. Trudinger, *Elliptic Partial Differential Equations of Second Order*:
+  maximum principles (Ch. 3), Schauder (Ch. 6), `Lᵖ` theory (Ch. 9), De Giorgi–Nash–Moser
+  (Ch. 8); the canonical elliptic reference.
+- L. Grafakos, *Classical Fourier Analysis* (and *Modern*) / E. Stein, *Singular Integrals
+  and Differentiability Properties of Functions*: maximal function, interpolation,
+  Calderón–Zygmund, BMO. Baby versions in Stein–Shakarchi vol. 4, §3.3.
+- T. Tao, *Nonlinear Dispersive Equations: Local and Global Analysis*: Strichartz
+  estimates and the dispersive stretch goals.
+- N. V. Krylov, *An Analytic Approach to SPDEs*; G. Da Prato, A. Debussche, *Stochastic
+  Navier–Stokes*: the stochastic stretch goals.
+- The **Carleson project** (van Doorn–Thiele), <https://github.com/fpvandoorn/carleson>,
+  the path-finding high-analysis Lean project; the source to vendor the Hardy–Littlewood
+  maximal function, Vitali covering, and Calderón–Zygmund machinery from.
+
+## How to drive it
+
+Large by design, expanded **iteratively**. **Lane A comes first** and to a high standard,
+because almost everything downstream needs `W^{k,p}(Ω)` and Rellich. Then Lanes B, C, D
+can proceed largely in parallel: Lane C (potential theory) is the easiest early win and
+partly exists in Mathlib already; Lane D (energy-method existence) is the shortest path to
+a real PDE theorem because Lax–Milgram is *already there*; Lane B (harmonic analysis) is
+the long pole that Lane E's regularity depends on. Lane E is the deep core of the
+roadmap, and Lane F and the stretch goals come last. As each lane makes the next one's
+*types* expressible in `Centauri/`, state those milestones in `Targets.lean` (with
+`sorry`) and hand them to the AIs to discharge. Nothing here blocks on upstream Mathlib.

--- a/CentauriRoadmap/PDE/Targets.lean
+++ b/CentauriRoadmap/PDE/Targets.lean
@@ -1,0 +1,42 @@
+import Mathlib
+
+/-!
+# Partial differential equations — target signatures
+
+The narrative roadmap, the build lanes (A–F), and the acceptance criteria are in
+`README.md`. Mathlib already carries a substantial prerequisite stack — distributions and
+test functions, the Schwartz space, the Fourier transform, convolution and mollifiers,
+the Gagliardo–Nirenberg–Sobolev inequality, the **Bessel-potential** Sobolev scale
+(`TemperedDistribution.memSobolev`), the Laplacian and harmonic-function theory,
+**Lax–Milgram** (`InnerProductSpace.continuousLinearEquivOfBilin`), the **Fredholm
+alternative** for compact operators, and the spectral theorem for symmetric operators.
+
+What is missing is the PDE theory on top: weak-derivative Sobolev spaces `W^{k,p}(Ω)` on
+a domain with their embedding/trace/compactness package (Lane A), the harmonic-analysis
+estimates (Lane B), maximum principles and potential theory (Lane C), elliptic existence
+via the energy method (Lane D), elliptic regularity — Schauder and De Giorgi–Nash–Moser
+(Lane E), and parabolic/evolution equations (Lane F). We build these here, in
+`Centauri/Analysis/PDE/`, with supporting theories under `Centauri/Analysis/Sobolev/` and
+`Centauri/Analysis/HarmonicAnalysis/`.
+
+As each lane makes the next lane's *types* expressible in `Centauri/`, state that lane's
+milestones here with `sorry` (human-owned roadmap territory, so `sorry` is allowed) and
+hand them to the AIs to discharge. The natural first targets, in order:
+
+* Lane A: `Wkp k p Ω` (weak-derivative Sobolev space) is complete; Meyers–Serrin `H = W`;
+  Poincaré on `Wkp0 1 p Ω`; Rellich–Kondrachov compactness `W^{1,p}(Ω) ↪↪ L^p(Ω)`.
+* Lane D: existence and uniqueness of the weak solution of `−Δu = f`, `u|∂Ω = 0`, on a
+  bounded domain, via `IsCoercive` + `continuousLinearEquivOfBilin` (Lax–Milgram).
+* Lane E: De Giorgi–Nash–Moser — a weak `H¹` solution of a divergence-form equation with
+  bounded measurable coefficients is locally Hölder continuous.
+
+The first end-to-end milestone (Lane D.17) is the shortest path to a genuine PDE existence
+theorem, because Lax–Milgram is already in Mathlib; it only awaits `Wkp0` and Poincaré
+from Lane A.
+-/
+
+namespace CentauriRoadmap.PDE
+
+-- (no compiled targets yet; see README.md)
+
+end CentauriRoadmap.PDE

--- a/CentauriRoadmap/ReductiveGroups/README.md
+++ b/CentauriRoadmap/ReductiveGroups/README.md
@@ -2,7 +2,7 @@
 
 The theory of reductive algebraic groups is the long game: it underpins the Langlands
 programme, automorphic forms, and much of FLT, and it is almost entirely absent from
-Mathlib. **We are not waiting for it to appear upstream — we build it here**, in
+Mathlib. **We are not waiting for it to appear upstream; we build it here**, in
 `Centauri/`, as a large, iteratively-expandable tower. Suggested home:
 `Centauri/Algebra/AlgebraicGroup/` (foundations) and `Centauri/AlgebraicGeometry/`
 (the scheme-side dictionary).
@@ -18,16 +18,16 @@ repeatedly on Zulip: separate typeclass assumptions let every result be proved i
 correct generality). Work over a field `k` to start; generalize to a base later.
 
 Keep **two distinct notions**, and never make smoothness implicit:
-- an **affine group scheme of finite type** over `k` — a commutative Hopf `k`-algebra `A`
+- an **affine group scheme of finite type** over `k`: a commutative Hopf `k`-algebra `A`
   finitely generated as a `k`-algebra. This admits `μ_p`, `αₚ`, and other non-smooth /
   non-reduced groups, and is the right default generality.
-- a **smooth** such group (an "algebraic group" in the classical sense) — add smoothness
+- a **smooth** such group (an "algebraic group" in the classical sense): add smoothness
   as a named hypothesis. For group schemes locally of finite type over a *field*,
   smoothness ⇔ geometric reducedness of `A` (a fact special to the homogeneous,
-  finite-type-over-a-field setting — *not* a general commutative-algebra equivalence; in
+  finite-type-over-a-field setting, *not* a general commutative-algebra equivalence; in
   characteristic 0 every such group is automatically smooth, by Cartier).
 
-There will be **no** monolithic `LinearAlgebraicGroup`/`Variety` definition — like
+There will be **no** monolithic `LinearAlgebraicGroup`/`Variety` definition. Like
 Mathlib, we state exactly the hypotheses each result needs.
 
 ## What "paved" means here
@@ -36,8 +36,8 @@ Maintain **three equivalent views** of an affine algebraic group and the explici
 equivalences between them, so any proof can work in whichever is most convenient:
 
 1. **Commutative Hopf algebras** over `k` (the coordinate ring `A`).
-2. **Group objects in schemes** — `GrpObj (Over.mk (φ : G ⟶ Spec k))` with `IsAffine`.
-3. **The functor of points** — a representable group-valued functor `R ↦ Homₖ(A, R)`.
+2. **Group objects in schemes**: `GrpObj (Over.mk (φ : G ⟶ Spec k))` with `IsAffine`.
+3. **The functor of points**: a representable group-valued functor `R ↦ Homₖ(A, R)`.
 
 Representations are then **comodules over `A`**, and we keep the
 representation ⇆ comodule ⇆ Tannakian dictionary in sync throughout. Wherever there is
@@ -50,14 +50,14 @@ prove them equivalent** rather than committing.
 - **Hopf/coalgebra algebra:** `Mathlib/RingTheory/HopfAlgebra/{Basic,GroupLike,TensorProduct}.lean`,
   `Mathlib/RingTheory/Coalgebra/{Convolution,GroupLike}.lean`.
 - **Categorical group objects:** `Mathlib/CategoryTheory/Monoidal/{Mon_,Comon_,Bimon_,Grp_,CommGrp_}.lean`
-  and the cartesian/`Over` variants — so view 2 is expressible (and Kevin's bridge
+  and the cartesian/`Over` variants, so view 2 is expressible (and Kevin's equivalence
   statements below already elaborate).
 - **Algebra categories:** `Mathlib/Algebra/Category/CoalgCat/ComonEquivalence.lean`
   (coalgebras ≃ comonoids), `Mathlib/Algebra/Category/CommAlgCat/{Basic,FiniteType,Monoidal}.lean`.
 - **Scheme-side group theory:** `Mathlib/AlgebraicGeometry/Group/Abelian.lean` (the
   rigidity theorem: proper group schemes are commutative) and `…/Group/Smooth.lean`.
 - **Smoothness ingredient:** `Mathlib/RingTheory/Nilpotent/GeometricallyReduced.lean`.
-- **Combinatorial prerequisites** (not ready-made algebraic-group infrastructure — they
+- **Combinatorial prerequisites** (not ready-made algebraic-group infrastructure; they
   supply abstract root systems/Weyl groups; extracting a *root datum from a group* still
   needs substantial glue): `Mathlib/LinearAlgebra/RootSystem/*` (root pairings, bases,
   Cartan matrices) and `Mathlib/GroupTheory/Coxeter/*`.
@@ -86,25 +86,25 @@ a group, Bruhat/BN-pairs; and the classification.
 Each layer is self-contained mathematics the next layer needs. As a layer makes the
 next layer's *types* expressible, state that layer's milestones in `Targets.lean` (with
 `sorry`) and hand them to the AIs to discharge in `Centauri/`. The ordering below is the
-dependency order, not a strict schedule — independent lanes can proceed in parallel.
+dependency order, not a strict schedule; independent lanes can proceed in parallel.
 
-**Cross-cutting prerequisite — sheaves and descent.** Several constructions below (the
+**Cross-cutting prerequisite: sheaves and descent.** Several constructions below (the
 functor-of-points view, quotients, torsors, representability) need the fppf topology and
 faithfully-flat descent, so this is a lane that starts early, not a single layer:
 presheaves on `CommAlgCat k`, Yoneda/representability, fppf sheafification, torsors, and
 faithfully-flat descent.
 
-### Layer 0 — the functor of points and the three-way dictionary
+### Layer 0: the functor of points and the three-way dictionary
 - **R-points as a group.** Generalize `AlgPoints R A := A →ₐ[k] R` for every *commutative*
   `k`-algebra `R` (the functor of points lives on `CommAlgCat k`; the *values* `G(R)` may
   be non-commutative, but `R` is commutative). Give it a group structure by **convolution**
   (not composition): `(f * g)(a) = ∑ f(a₁) g(a₂)`, identity the counit `ε`, inverse `f ∘ S`.
-  - ⚠ Pitfall: `GroupLike k A` is **not** the points functor — for `GLₙ` the points are
+  - ⚠ Pitfall: `GroupLike k A` is **not** the points functor; for `GLₙ` the points are
     non-commutative, but group-like elements always form a commutative group.
   - Ingredient already in Mathlib: the antipode is an anti-homomorphism, `S(ab) = S(b) S(a)`
     (`HopfAlgebra.antipode_mul`). Use it to show algebra homs are closed under convolution
     and that `f ∘ S` is the inverse; then prove functoriality in `R`.
-- **The bridges (first concrete targets — already compile as `sorry` in `Targets.lean`):**
+- **The equivalences (first concrete targets, already compile as `sorry` in `Targets.lean`):**
   ```lean
   -- Γ(G) is an R-Hopf algebra, for G an affine group scheme over Spec R:
   example (G : Scheme) (φ : G ⟶ Spec(R)) [GrpObj (Over.mk φ)] [IsAffine G] :
@@ -113,10 +113,10 @@ faithfully-flat descent.
   example (A : Type u) [CommRing A] [HopfAlgebra R A] :
       GrpObj (Over.mk (map (ofHom (algebraMap R A)) : Spec(A) ⟶ Spec(R))) := sorry
   ```
-  The `Γ`-bridge needs supporting facts first: affine fibre products and
+  The `Γ`-direction needs supporting facts first: affine fibre products and
   `Γ(Spec A ×_{Spec R} Spec B) ≅ A ⊗_R B`, the terminal object over `Spec R`, and the
   contravariant translation of multiplication/unit/inverse into comultiplication/counit/
-  antipode. Build the bridges into a full **anti-equivalence**
+  antipode. Assemble these into a full **anti-equivalence**
   `(CommHopfAlg k)ᵒᵖ ≌ AffGrpSch k` (finite-type/smooth kept as predicates, not baked into
   the category) and a third equivalence with representable group functors. (Consume
   `CoalgCat/ComonEquivalence`, `Grp_`, `CommAlgCat`; the Toric route gives one direction
@@ -125,7 +125,7 @@ faithfully-flat descent.
   `HopfAlgebra/TensorProduct.lean`). Geometric notions are all defined after base change
   to `k̄`.
 
-### Layer 1 — representations = comodules
+### Layer 1: representations = comodules
 - **Comodules** over a coalgebra/Hopf algebra `A`: a coaction `ρ : V → V ⊗ A` with
   coassociativity and counit; comodule morphisms; the (rigid monoidal) category of
   **finite-dimensional** comodules; tensor products, duals, the regular representation.
@@ -138,46 +138,46 @@ faithfully-flat descent.
   coefficients generating `A`**. ⚠ This is *not* the same as the coaction (or the map on
   `k`/`k̄`-points) being injective.
 - **Embedding theorem (hard):** every affine group scheme of finite type has a faithful
-  f.d. representation, i.e. a closed immersion `G ↪ GLₙ` — proved via the f.d.
+  f.d. representation, i.e. a closed immersion `G ↪ GLₙ`, proved via the f.d.
   subcoalgebra theorem, not bare Noetherianity.
 - **Tannakian reconstruction:** recover `G` from its tensor category of representations
   (mine `RepresentationTheory/Tannaka.lean` for the pattern; the content must be rebuilt
   for comodules).
 
-### Layer 2 — Lie algebra and the adjoint representation
+### Layer 2: Lie algebra and the adjoint representation
 - **Tangent space at the identity / `Lie(G)`**, the differential of a homomorphism, the
   Lie algebra of a closed subgroup, and the **adjoint action** `Ad : G → GL(Lie G)`.
 - **Smoothness and dimension tools** via `Lie(G)` (dimension of kernels, the smoothness
   criterion). These are needed before Jordan decomposition, root spaces, and the unipotent
   radical, which is why this sits early.
 
-### Layer 3 — subgroups, quotients, components
+### Layer 3: subgroups, quotients, components
 - **Hopf ideals ↔ closed subgroup schemes:** an ideal `I` with `Δ(I) ⊆ I⊗A + A⊗I`,
   `ε(I)=0`, `S(I) ⊆ I`; the quotient Hopf algebra `A/I`; the anti-equivalence; kernels.
 - **Normality and quotients:** normal = Hopf ideal stable under the adjoint coaction
   (needs the conjugation/adjoint morphism at Hopf level). The quotient `G/H` is first the
   **fppf sheaf quotient**; whether it is represented by a scheme (and when by an *affine*
-  one — e.g. `H` reductive, by Matsushima) is a **theorem with hypotheses**, not automatic.
+  one, e.g. `H` reductive, by Matsushima) is a **theorem with hypotheses**, not automatic.
   Then short exact sequences.
 - **Identity component `G°` and component group `π₀(G)`:** geometric connectedness
-  (`A ⊗ k̄` has no nontrivial idempotents — *stronger* than over `k`). Under smoothness
+  (`A ⊗ k̄` has no nontrivial idempotents, *stronger* than over `k`). Under smoothness
   (and over a perfect field, or suitable hypotheses) `π₀(G)` is finite étale.
   ⚠ Reserve the term **connected–étale sequence** for *finite* group schemes; here use
   "identity component and component group", and "connected" always means the geometric
   notion.
 
-### Layer 4 — Jordan decomposition, diagonalizable groups, tori
+### Layer 4: Jordan decomposition, diagonalizable groups, tori
 - **Jordan decomposition** of elements into semisimple and unipotent parts (geometric,
   over `k̄`), functorial under representations.
 - **Diagonalizable groups and groups of multiplicative type:** the anti-equivalence
   `M ↦ D(M) = Spec k[M]` between finitely generated abelian groups and diagonalizable
   groups; `μ_n = D(ℤ/n)`, `𝔾_m = D(ℤ)`; the non-smooth example `μ_p` in characteristic `p`.
   (*Cartier duality* proper is the duality of **finite locally free** commutative group
-  schemes — a related but distinct statement to develop separately.)
+  schemes, a related but distinct statement to develop separately.)
 - **Tori:** split and non-split; the **character lattice** `X*(T)` and **cocharacter
-  lattice** `X_*(T)` with their perfect pairing — the input to root data.
+  lattice** `X_*(T)` with their perfect pairing: the input to root data.
 
-### Layer 5 — solvable and unipotent groups; the unipotent radical
+### Layer 5: solvable and unipotent groups; the unipotent radical
 - **Unipotent groups** (correct, geometric definition): `g ∈ G(k̄)` is unipotent iff
   `ρ_g − id` is nilpotent for **every** f.d. representation; a smooth connected group is
   unipotent iff it embeds in the upper-triangular unipotent `Uₙ`.
@@ -185,21 +185,21 @@ faithfully-flat descent.
     nontrivial characters but is semisimple). The implication is one-way: a *connected
     unipotent* group has no nontrivial characters; the converse needs solvability.
   - ⚠ A naïve `IsUnipotent` that tests nilpotence in the reduced ring `A` is *vacuous*
-    (only `g = 1` qualifies) — the correct definition needs comodule theory (Layer 1).
+    (only `g = 1` qualifies): the correct definition needs comodule theory (Layer 1).
 - **Lie–Kolchin**; solvable groups.
 - **The unipotent radical `R_u(G)`** (the hard core, SGA3/Borel level): the maximal
   connected normal unipotent closed subgroup. ⚠ Over **imperfect** fields the geometric
-  unipotent radical `R_u(G_{k̄})` need *not* descend to `k` — this is exactly where
+  unipotent radical `R_u(G_{k̄})` need *not* descend to `k`; this is exactly where
   pseudo-reductive groups appear. **Assume `k` perfect first** (so descent is fine), or
   define reductivity by the geometric condition without constructing a descended subgroup;
   distinguish the `k`-unipotent radical from the geometric one in general.
 
-### Layer 6 — reductive and semisimple groups
+### Layer 6: reductive and semisimple groups
 - **Reductive:** smooth, connected, with `R_u(G_{k̄})` trivial. **Semisimple:** radical
   `R(G)` (maximal connected normal solvable, geometric) trivial. Develop the radical,
   the centre `Z(G)`, the derived group `G_der`, **central isogenies**, and the simply
-  connected and adjoint forms — these are not optional for the classification.
-- **Alternative paving — linearly reductive:** every f.d. representation is completely
+  connected and adjoint forms: these are not optional for the classification.
+- **Alternative paving, linearly reductive:** every f.d. representation is completely
   reducible. ⚠ Reductive groups are **not** linearly reductive in characteristic `p`
   (rational representations are generally not semisimple). State the equivalence precisely:
   for smooth connected affine groups in **characteristic 0**, reductive ⇔ linearly
@@ -207,24 +207,24 @@ faithfully-flat descent.
   field of characteristic `p`, a connected group is linearly reductive iff it is a torus.
   Provide both definitions and the char-0 equivalence so downstream work can pick either.
 
-### Layer 7 — structure theory
+### Layer 7: structure theory
 - **Borel subgroups, maximal tori**, and their conjugacy; **parabolic** subgroups and
   **Levi** decomposition.
-- **Root datum** `(X*(T), Φ, X_*(T), Φ^∨)` of `(G, T)` with its **Weyl group** — do the
+- **Root datum** `(X*(T), Φ, X_*(T), Φ^∨)` of `(G, T)` with its **Weyl group**: do the
   **split** case first (split maximal torus, or work over `k̄`), consuming
   `LinearAlgebra/RootSystem/*` and `GroupTheory/Coxeter/*`; then add the **absolute root
   datum with Galois action** and the **relative root system** for non-split groups.
 - **Bruhat decomposition** and **BN-pairs / Tits systems**. Keep the **dynamic** approach
   to parabolics/Levi/unipotent radical (Kevin, Shurui Liu, Stepan Nesterov on Zulip) as a
-  parallel route that avoids full root data — useful for the `p`-adic representation-theory
+  parallel route that avoids full root data, useful for the `p`-adic representation-theory
   consumers, who can ask only for a BN-pair.
 
-### Layer 8 — classification and existence (long horizon)
+### Layer 8: classification and existence (long horizon)
 - The **isomorphism** and **existence theorems**: split reductive groups ↔ root data;
   classification of semisimple groups by Dynkin diagrams; central isogenies and the
   isogeny theorem; Chevalley existence.
 - **Relative theory over a base** and **pseudo-reductive groups**
-  (Conrad–Gabber–Prasad) — flagged as far-future generalizations.
+  (Conrad–Gabber–Prasad), flagged as far-future generalizations.
 
 ---
 
@@ -233,14 +233,14 @@ faithfully-flat descent.
 Concrete Hopf algebras / group schemes that exercise and validate the definitions:
 `𝔾_a`, `𝔾_m`, `μ_n`/`μ_p`, `GLₙ`, `SLₙ`, `PGLₙ`, `SOₙ`, `Sp₂ₙ`, and tori. Prove they are
 reductive where applicable via `R_u = 1` / root data (the definition that works in all
-characteristics) — and *additionally* via complete reducibility only in characteristic 0
+characteristics), and *additionally* via complete reducibility only in characteristic 0
 or for linearly reductive groups. Exercise the diagonalizable/Cartier-duality theory on
 the multiplicative-type examples. (Kevin's caution: don't *develop the general theory* from
-`GLₙ` — but examples are exactly how we keep the definitions honest.)
+`GLₙ`, but examples are exactly how we keep the definitions honest.)
 
 ## Design notes (from Zulip)
 
-- **Functor of points is the notion of points** — not `GroupLike`, not just `k`-points.
+- **Functor of points is the notion of points**, not `GroupLike`, not just `k`-points.
 - **Faithful = matrix coefficients generate `A`**, not "coaction injective".
 - **Geometric notions** (connected, unipotent, reductive) are defined after base change
   to `k̄`.
@@ -252,14 +252,14 @@ the multiplicative-type examples. (Kevin's caution: don't *develop the general t
 ## Downstream consumers (why this matters)
 
 `p`-adic representation theory of `G(K)` (smooth/admissible representations, Hecke
-algebras — Shurui Liu et al.), the Langlands programme, automorphic forms (Kevin
+algebras, Shurui Liu et al.), the Langlands programme, automorphic forms (Kevin
 Buzzard), and FLT. Several of these can start against a **BN-pair** or the dynamic
-parabolic API before the full root-data classification exists — another reason to pave.
+parabolic API before the full root-data classification exists: another reason to pave.
 
 ## References
 
-- J. S. Milne, *Algebraic Groups* (2017) — the modern scheme-theoretic reference.
-- W. C. Waterhouse, *Introduction to Affine Group Schemes* — Hopf algebras, comodules,
+- J. S. Milne, *Algebraic Groups* (2017): the modern scheme-theoretic reference.
+- W. C. Waterhouse, *Introduction to Affine Group Schemes*: Hopf algebras, comodules,
   closed subgroups, the unipotent radical.
 - A. Borel, *Linear Algebraic Groups*; T. A. Springer, *Linear Algebraic Groups*.
 - J. C. Jantzen, *Representations of Algebraic Groups*.

--- a/CentauriRoadmap/ReductiveGroups/Targets.lean
+++ b/CentauriRoadmap/ReductiveGroups/Targets.lean
@@ -1,17 +1,17 @@
 import Mathlib
 
 /-!
-# Reductive algebraic groups — target signatures
+# Reductive algebraic groups: target signatures
 
 The narrative roadmap (the three "paved" models, the layer-by-layer build plan
 Layers 0–7, the worked examples, and the references) is in `README.md`. We build the
 whole tower here rather than waiting on Mathlib.
 
-This file holds the **Layer 0** bridge targets between affine group schemes and Hopf
-algebras (Kevin Buzzard). They elaborate against the pinned Mathlib commit and are
+This file holds the **Layer 0** targets translating between affine group schemes and
+Hopf algebras (Kevin Buzzard). They elaborate against the pinned Mathlib commit and are
 stated with `sorry` (allowed in this human-owned roadmap library). As later layers
 make their types expressible in `Centauri/`, add their milestones here with `sorry`
-and hand them to the AIs to discharge — next up after these: the convolution group
+and hand them to the AIs to discharge. Next up after these: the convolution group
 structure on the functor of points, and base change of Hopf algebras.
 -/
 

--- a/CentauriRoadmap/UniversalCovers/README.md
+++ b/CentauriRoadmap/UniversalCovers/README.md
@@ -21,46 +21,46 @@ Decide a **basepoint policy up front**, because the classification theorems are 
 to it: distinguish *pointed* covers (with a chosen lift `e₀` of the basepoint) from
 *unpointed* covers, and build the API for basepoint change along a path, conjugation of
 subgroups under basepoint change, and isomorphism of covers over `X`. Also fix a
-left/right convention for path concatenation and deck-map composition early — several
+left/right convention for path concatenation and deck-map composition early; several
 target isomorphisms below are only correct up to `ᵐᵒᵖ` depending on it.
 
 ## What Mathlib already has (consume)
 
 - **Covering maps:** `Mathlib/Topology/Covering/Basic.lean` (`IsCoveringMap`,
   `IsCoveringMapOn`), and **quotient covering maps** `…/Covering/Quotient.lean`
-  (`IsQuotientCoveringMap`, properly-discontinuous/free `SMul` results) — reuse these for
+  (`IsQuotientCoveringMap`, properly-discontinuous/free `SMul` results); reuse these for
   `UniversalCover/H` instead of re-deriving quotient-cover facts.
-- **Lifting:** `Mathlib/Topology/Homotopy/Lifting.lean` — path lifting *and* **general
+- **Lifting:** `Mathlib/Topology/Homotopy/Lifting.lean`, with path lifting *and* **general
   homotopy lifting** `IsCoveringMap.liftHomotopy : C(I × A, E)` for an arbitrary parameter
   space `A`, the `monodromy_theorem`, the **monodromy functor**
   `IsCoveringMap.monodromyFunctor : FundamentalGroupoid X ⥤ Type _`, and the **lifting
   criterion** (two forms; see Stage 2).
-- **Fundamental groupoid / group:** `Mathlib/AlgebraicTopology/FundamentalGroupoid/*`
-  — `FundamentalGroupoid`, `FundamentalGroup`, homotopy-invariance/functoriality
+- **Fundamental groupoid / group:** `Mathlib/AlgebraicTopology/FundamentalGroupoid/*`,
+  covering `FundamentalGroupoid`, `FundamentalGroup`, homotopy-invariance/functoriality
   (`InducedMaps.lean`: `homotopicMapsNatIso`, `equivOfHomotopyEquiv`), `SimplyConnected`.
 - **Homotopy groups:** `Mathlib/Topology/Homotopy/HomotopyGroup.lean` (`Ω^N`,
   `HomotopyGroup`) and `Mathlib/Topology/Covering/HomotopyGroup.lean`.
 - **Galois-category abstraction:** `Mathlib/CategoryTheory/Galois/IsFundamentalgroup.lean`
-  (`IsFundamentalGroup`, `toAutMulEquiv : G ≃* Aut F`) — an alternative lens on the
+  (`IsFundamentalGroup`, `toAutMulEquiv : G ≃* Aut F`), an alternative lens on the
   classification, via fibre functors.
 - **Circle:** `Mathlib/Topology/Covering/AddCircle.lean`
-  (`isCoveringMap_coe : IsCoveringMap ((↑) : 𝕜 → AddCircle p)`) — `ℝ` covers `S¹`.
+  (`isCoveringMap_coe : IsCoveringMap ((↑) : 𝕜 → AddCircle p)`): `ℝ` covers `S¹`.
 
 ## What is missing (port / build here)
 
 - [mathlib4#31576](https://github.com/leanprover-community/mathlib4/pull/31576)
-  (*the homotopy-class fibres are discrete*) — **closed, unmerged**.
+  (*the homotopy-class fibres are discrete*): **closed, unmerged**.
 - [mathlib4#38292](https://github.com/leanprover-community/mathlib4/pull/38292)
-  (*universal cover construction*) — open, depends on the closed #31576.
+  (*universal cover construction*): open, depends on the closed #31576.
 - [mathlib4#40135](https://github.com/leanprover-community/mathlib4/pull/40135)
-  (*Deck transformation group*) — open.
+  (*Deck transformation group*): open.
 
 Plus, on top of these: the subgroup ↔ cover Galois correspondence, regular covers and the
 deck group `N(H)/H`, and the higher-homotopy API.
 
 ---
 
-## Stage 0 — port the foundations into `Centauri/`
+## Stage 0: port the foundations into `Centauri/`
 
 Bring the existing, human-written construction into this library, sorry-free; credit the
 original authors and source PR in each file.
@@ -69,7 +69,7 @@ original authors and source PR in each file.
    connected and locally path-connected, the **fibres** of "based paths modulo
    endpoint-preserving homotopy" over a fixed endpoint are **discrete** (this is what
    makes `proj` a covering map and gives the sheet decomposition). Note: the total space
-   is *not* discrete in general — only the fibres are. This died upstream, so it lives
+   is *not* discrete in general; only the fibres are. This died upstream, so it lives
    here.
 2. **The based-path space and the cover** (from #38292), under
    `[PathConnectedSpace X] [LocPathConnectedSpace X] [SemilocallySimplyConnectedSpace X]`:
@@ -87,18 +87,18 @@ original authors and source PR in each file.
    `ContinuousConstSMul` instances; subgroup transfer gives `Deck p` its `Group`,
    `MulAction E`, `FaithfulSMul E`, `ContinuousConstSMul E`.
 
-## Stage 1 — close out the universal cover
+## Stage 1: close out the universal cover
 
-5. **`Deck(proj) ≃* π₁(X, x₀)`.** The bridge between Stage 0.3 and 0.4. Once it lands,
+5. **`Deck(proj) ≃* π₁(X, x₀)`.** The isomorphism connecting Stage 0.3 and 0.4. Once it lands,
    `UniversalCover x₀ / π₁(X, x₀) ≃ X` follows (via Mathlib's `IsQuotientCoveringMap`).
    ⚠ Convention check first: depending on the chosen left/right action and deck-map
    composition order, the correct statement may be
    `Deck(proj) ≃* (FundamentalGroup X x₀)ᵐᵒᵖ`. Pin the convention before stating the
    target.
 
-## Stage 2 — lifting criterion and Galois correspondence
+## Stage 2: lifting criterion and Galois correspondence
 
-6. **General lifting criterion — already in Mathlib.** Consume
+6. **General lifting criterion, already in Mathlib.** Consume
    `IsCoveringMap.existsUnique_continuousMap_lifts_of_range_le`
    (`Mathlib/Topology/Homotopy/Lifting.lean`). State it in its Lean-shaped form, with the
    real hypotheses: `[PathConnectedSpace A] [LocPathConnectedSpace A]`, basepoints
@@ -109,7 +109,7 @@ original authors and source PR in each file.
    basepoint `⟦e₀⟧` is a *pointed* connected cover; prove `p_*(π₁(–)) = H` for that
    pointed cover. Separately, prove how the recovered subgroup transforms (by conjugacy)
    under basepoint change. With (6) this is the existence half of the correspondence.
-8. **Galois correspondence — get the bookkeeping right.** Two distinct theorems:
+8. **Galois correspondence: get the bookkeeping right.** Two distinct theorems:
    - **pointed** connected covers of `(X, x₀)` (with chosen lift `e₀`) ↔ **subgroups** of
      `π₁(X, x₀)`;
    - **unpointed** connected covers ↔ **conjugacy classes** of subgroups.
@@ -124,9 +124,9 @@ original authors and source PR in each file.
      `Galois/IsFundamentalgroup`), with disconnected covers as functors out of the
      fundamental groupoid. Worth paving as a second route.
 
-## Stage 3 — higher homotopy
+## Stage 3: higher homotopy
 
-Cube/homotopy lifting is **not** the obstacle — Mathlib's `IsCoveringMap.liftHomotopy`
+Cube/homotopy lifting is **not** the obstacle; Mathlib's `IsCoveringMap.liftHomotopy`
 already lifts `C(I × A, E)` for arbitrary `A`. The real prerequisites are the
 higher-homotopy-group API:
 
@@ -137,19 +137,19 @@ higher-homotopy-group API:
 10. **`p_* : π_n(X̃) ≅ π_n(X)` for `n ≥ 2`**, any cover. With (9) and Mathlib's homotopy
     lifting, the proof mirrors the `π₁` injectivity argument with `S^n` for `S^1`.
 
-## Stage 4 — applications
+## Stage 4: applications
 
 11. `π_n(S¹) = 0` for `n ≥ 2` (universal cover `ℝ` is contractible).
 12. `π₁(S¹) ≅ ℤ`, built from `AddCircle.isCoveringMap_coe` (`ℝ → S¹`) and deck
     transformations. (Mathlib has the covering map but, as far as the pin shows, not the
-    `π₁ ≅ ℤ` statement — so this is an application target, not a reconciliation.)
+    `π₁ ≅ ℤ` statement, so this is an application target, not a reconciliation.)
 13. `π_n(Tᵏ)`, `π₁(RPⁿ)`, `K(G, 1)` spaces.
 
 ## Ordering
 
-Stage 0 first — a careful port that unblocks everything. Then Stage 1 (5), then Stage 2
+Stage 0 first: a careful port that unblocks everything. Then Stage 1 (5), then Stage 2
 (7)/(8); the basepoint/conjugacy bookkeeping is the subtle part there, not the topology.
 Stage 3 is a larger, separable track, but lighter than it looks now that homotopy lifting
-is available — the cost is the `π_n` API, not lifting. As each milestone's prerequisite
+is available; the cost is the `π_n` API, not lifting. As each milestone's prerequisite
 *types* exist in `Centauri/`, state the milestone in `Targets.lean` (with `sorry`) and
 hand it to the AIs to discharge.

--- a/CentauriRoadmap/UniversalCovers/Targets.lean
+++ b/CentauriRoadmap/UniversalCovers/Targets.lean
@@ -1,7 +1,7 @@
 import Mathlib
 
 /-!
-# Universal covers — target signatures
+# Universal covers: target signatures
 
 The narrative roadmap is in `README.md`. Mathlib already has the covering-space,
 lifting, fundamental-groupoid, and homotopy-group toolkit; what is missing is the
@@ -14,7 +14,7 @@ to discharge in `Centauri/`. The natural first new theorem (Stage 1) is
 
   `Deck (UniversalCover.proj x₀) ≃* FundamentalGroup X x₀`
 
-(possibly up to `ᵐᵒᵖ` — pin the action/composition convention first).
+(possibly up to `ᵐᵒᵖ`; pin the action/composition convention first).
 -/
 
 namespace CentauriRoadmap.UniversalCovers

--- a/README.md
+++ b/README.md
@@ -42,3 +42,4 @@ Some initial example roadmaps live under `CentauriRoadmap/`:
 1. [Universal covers](CentauriRoadmap/UniversalCovers/README.md)
 2. [The Jacobian challenge](CentauriRoadmap/JacobianChallenge/README.md) 
 3. [Reductive algebraic groups](CentauriRoadmap/ReductiveGroups/README.md) 
+4. [Partial differential equations](CentauriRoadmap/PDE/README.md)

--- a/formalization.yaml
+++ b/formalization.yaml
@@ -1,7 +1,7 @@
 # formalization.yaml (v0.2): repo-root metadata for formalization projects.
 # [required] fields should be filled; everything else is optional.
 #
-# NOTE: Proxima Centauri is an open-ended, continuously evolving library — not the
+# NOTE: Proxima Centauri is an open-ended, continuously evolving library, not the
 # formalization of a fixed target. Many fields below therefore describe an ongoing
 # process and an aspiration rather than a finished artifact. They are filled in as
 # best we can and will drift as the library grows.
@@ -41,7 +41,7 @@ automation:
   notes: >
     Open, multi-agent library. AIs own the code under Centauri/: they initiate pull
     requests and shepherd them through an AI-driven review process. Humans own the
-    roadmaps (CentauriRoadmap/ — markdown plus sorry-allowed Lean target signatures)
+    roadmaps (CentauriRoadmap/: markdown plus sorry-allowed Lean target signatures)
     and the review rubrics (CentauriReview/), and may raise issues against the code.
     The human/AI split is enforced by CODEOWNERS and branch protection; the main
     branch is always green. No single harness or model is mandated.
@@ -49,7 +49,7 @@ automation:
 # project status
 status:
   scope: >
-    All of mathematics — past, present, and emerging. Proxima Centauri is an
+    All of mathematics: past, present, and emerging. Proxima Centauri is an
     open-ended, continuously evolving library downstream of Mathlib, not the
     formalization of a fixed target.
   sorry_count: 0               # the code library (Centauri/) forbids sorry; CI enforces this
@@ -58,7 +58,7 @@ status:
     - "propext"
     - "Classical.choice"
     - "Quot.sound"
-  main_results: []             # none yet — the library is bootstrapping; results will be listed here as they land
+  main_results: []             # none yet, since the library is bootstrapping; results will be listed here as they land
 
 # fidelity
 fidelity:

--- a/lakefile.toml
+++ b/lakefile.toml
@@ -10,7 +10,7 @@ rev = "master"
 [[lean_lib]]
 name = "Centauri"
 
-# Human-owned: roadmaps and target signatures. Sorries are allowed here —
+# Human-owned: roadmaps and target signatures. Sorries are allowed here:
 # these are goals, not proofs. `Centauri` may not import this library (CI guard).
 [[lean_lib]]
 name = "CentauriRoadmap"


### PR DESCRIPTION
This PR adds a roadmap for formalizing partial differential equations on top of Mathlib's existing analysis stack (distributions, Schwartz space, Fourier transform, Bessel-potential Sobolev spaces, the Laplacian, harmonic functions, Lax–Milgram, the Fredholm alternative, Picard–Lindelöf). The roadmap targets existence, regularity, and the maximum principle for second-order linear elliptic equations, with parabolic and dispersive stretch goals, and organizes the work into six dependency-ordered lanes (function spaces, harmonic analysis, potential theory, energy-method existence, elliptic regularity, parabolic/evolution), each with concrete Lean-shaped milestones, an inventory of what to consume from Mathlib versus build here, positive statement-discipline rules, and acceptance criteria. It registers `CentauriRoadmap/PDE/Targets.lean` in the roadmap root and lists the new roadmap in the top-level README.

It also includes a separate cleanup commit that removes em-dash prose and the banned vocabulary ("gate", "bridge") from the existing roadmaps, review docs, and project metadata, leaving name-joining en-dashes intact.

🤖 Prepared with Claude Code