### PR TITLE
feat: add the axiom-allowlist audit (lake exe axioms)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,15 +24,6 @@ jobs:
             exit 1
           fi
 
-      # No sorries in the AI-owned library. (The #print axioms allowlist audit
-      # is a planned TauCetiReview/ follow-up; this is the cheap textual guard.)
-      - name: No-sorry guard (TauCeti/ is sorry-free)
-        run: |
-          if grep -rIn -E '\b(sorry|admit|sorryAx)\b' TauCeti/; then
-            echo "::error::TauCeti/ must not contain sorry / admit / sorryAx"
-            exit 1
-          fi
-
       - name: Build
         uses: leanprover/lean-action@v1
         with:
@@ -45,3 +36,10 @@ jobs:
           # is ~2.4 GB; saving and restoring it costs ~40s per run, far more than
           # the ~6s `lake exe cache get` it would save. Net win to leave it off.
           use-github-cache: false
+
+      # Axiom audit (replaces the old textual no-sorry grep). Inspects the built
+      # TauCeti environment and rejects any axiom outside {propext, Classical.choice,
+      # Quot.sound} — catching sorry/admit (sorryAx), native_decide (Lean.ofReduceBool),
+      # and home-rolled axioms, including ones reaching in through imports.
+      - name: Axiom audit (TauCeti/ uses only allowlisted axioms)
+        run: lake exe axioms

--- a/TauCetiReview/Axioms.lean
+++ b/TauCetiReview/Axioms.lean
@@ -25,7 +25,13 @@ def auditedRoot : Name := `TauCeti
 def allowedAxioms : List Name := [``propext, ``Classical.choice, ``Quot.sound]
 
 /-- Build the environment from the given imported modules and run `act` in `CoreM`.
-Inlined from `importGraph`'s `Core.withImportModules` (Kim Morrison, Paul Lezeau; Apache 2.0). -/
+Inlined from `importGraph`'s `Core.withImportModules` (Kim Morrison, Paul Lezeau; Apache 2.0).
+
+`trustLevel := 1024` means imported constants are taken as type-correct rather than
+re-checked. That is correct here because CI runs `lake build` (which kernel-checks the
+library from source) *before* `lake exe axioms`; this audit checks *which axioms* a
+declaration depends on, not whether the proofs are valid. It is not a defense against
+stale or hand-forged `.olean`s. -/
 def withImportedEnv {α} (modules : Array Name) (act : CoreM α) : IO α := do
   initSearchPath (← findSysroot)
   unsafe Lean.withImportModules (modules.map (fun m => { module := m })) {} (trustLevel := 1024)
@@ -34,6 +40,26 @@ def withImportedEnv {α} (modules : Array Name) (act : CoreM α) : IO α := do
 
 /-- Is `mod` the audited library root or one of its submodules? -/
 def inAuditedLib (mod : Name) : Bool := mod == auditedRoot || auditedRoot.isPrefixOf mod
+
+/-- The module name for a `.lean` source path, e.g. `TauCeti/Foo/Bar.lean ↦ TauCeti.Foo.Bar`. -/
+def pathToModule (p : System.FilePath) : Name :=
+  (p.withExtension "").components.foldl (fun n s => Name.mkStr n s) Name.anonymous
+
+/-- Every `.lean` module under `dir`, recursively. -/
+partial def collectLeanModules (dir : System.FilePath) : IO (Array Name) := do
+  let mut acc := #[]
+  for entry in (← dir.readDir) do
+    if (← entry.path.isDir) then
+      acc := acc ++ (← collectLeanModules entry.path)
+    else if entry.path.extension == some "lean" then
+      acc := acc.push (pathToModule entry.path)
+  return acc
+
+/-- Every module in the `TauCeti` library: the root `TauCeti` plus all `TauCeti/**/*.lean`.
+Enumerating the source tree (rather than only importing the root) means an orphan module
+that is not imported from `TauCeti.lean` is still audited. -/
+def auditedModules : IO (Array Name) :=
+  return #[auditedRoot] ++ (← collectLeanModules (auditedRoot.toString : System.FilePath))
 
 /-- Audit every declaration defined in `TauCeti`. Returns the number audited and a list of
 violation messages, **already rendered to `String`**.
@@ -47,7 +73,10 @@ def audit : CoreM (Nat × Array String) := do
   -- Candidate declarations: those defined in a `TauCeti` module.
   let candidates : Array Name := env.constants.fold (init := #[]) fun acc declName _ =>
     match env.getModuleIdxFor? declName with
-    | some idx => if inAuditedLib modNames[idx.toNat]! then acc.push declName else acc
+    | some idx =>
+      match modNames[idx.toNat]? with
+      | some m => if inAuditedLib m then acc.push declName else acc
+      | none => acc
     | none => acc
   let mut messages : Array String := #[]
   for declName in candidates do
@@ -59,7 +88,12 @@ def audit : CoreM (Nat × Array String) := do
 -- Return the exit code (rather than `IO.Process.exit`) so the Lean runtime tears the
 -- imported environment down in order; an abrupt `exit()` can segfault during teardown.
 def main : IO UInt32 := do
-  let (audited, messages) ← withImportedEnv #[auditedRoot] audit
+  let modules ← auditedModules
+  let (audited, messages) ← withImportedEnv modules audit
+  if audited == 0 then
+    -- Governance tooling must fail loudly if it audited nothing (e.g. miswired import).
+    IO.eprintln s!"axioms: audited 0 declarations in {auditedRoot} — the audit is miswired."
+    return 1
   if messages.isEmpty then
     IO.println s!"axioms: audited {audited} {auditedRoot} declaration(s); \
       all within the allowlist {allowedAxioms}."

--- a/TauCetiReview/Axioms.lean
+++ b/TauCetiReview/Axioms.lean
@@ -1,0 +1,71 @@
+import Lean
+
+/-!
+# `axioms`: the axiom-allowlist audit for the `TauCeti` library
+
+Human-owned governance machinery. This executable builds the `TauCeti` environment from
+its compiled `.olean`s and inspects, for every declaration *defined in `TauCeti`*, the
+axioms it transitively depends on (`Lean.collectAxioms`). It fails unless every such
+declaration uses only the standard allowlist
+
+  `propext`, `Classical.choice`, `Quot.sound`.
+
+Because it works on the kernel environment rather than on source text, it catches what a
+`grep` cannot: `sorry`/`admit` (which surface as `sorryAx`), `native_decide` (which adds
+`Lean.ofReduceBool`), and any home-rolled `axiom` — including ones reaching in through
+imports. Run via `lake exe axioms` (after `lake build`).
+-/
+
+open Lean
+
+/-- The library whose declarations are audited (the AI-owned mathematics). -/
+def auditedRoot : Name := `TauCeti
+
+/-- Axioms permitted anywhere in `TauCeti`. -/
+def allowedAxioms : List Name := [``propext, ``Classical.choice, ``Quot.sound]
+
+/-- Build the environment from the given imported modules and run `act` in `CoreM`.
+Inlined from `importGraph`'s `Core.withImportModules` (Kim Morrison, Paul Lezeau; Apache 2.0). -/
+def withImportedEnv {α} (modules : Array Name) (act : CoreM α) : IO α := do
+  initSearchPath (← findSysroot)
+  unsafe Lean.withImportModules (modules.map (fun m => { module := m })) {} (trustLevel := 1024)
+    fun env => Prod.fst <$> Core.CoreM.toIO act
+      (ctx := { fileName := "<axioms>", fileMap := default }) (s := { env := env })
+
+/-- Is `mod` the audited library root or one of its submodules? -/
+def inAuditedLib (mod : Name) : Bool := mod == auditedRoot || auditedRoot.isPrefixOf mod
+
+/-- Audit every declaration defined in `TauCeti`. Returns the number audited and a list of
+violation messages, **already rendered to `String`**.
+
+The strings must be materialized here, inside the environment callback: declaration and
+axiom `Name`s loaded from `.olean`s live in a memory-mapped region that is unmapped once
+`withImportModules` returns, so formatting them afterwards is a use-after-free. -/
+def audit : CoreM (Nat × Array String) := do
+  let env ← getEnv
+  let modNames := env.allImportedModuleNames
+  -- Candidate declarations: those defined in a `TauCeti` module.
+  let candidates : Array Name := env.constants.fold (init := #[]) fun acc declName _ =>
+    match env.getModuleIdxFor? declName with
+    | some idx => if inAuditedLib modNames[idx.toNat]! then acc.push declName else acc
+    | none => acc
+  let mut messages : Array String := #[]
+  for declName in candidates do
+    let axs ← collectAxioms declName
+    let bad := axs.filter fun a => !allowedAxioms.contains a
+    if !bad.isEmpty then messages := messages.push s!"  {declName} → {bad.toList}"
+  return (candidates.size, messages)
+
+-- Return the exit code (rather than `IO.Process.exit`) so the Lean runtime tears the
+-- imported environment down in order; an abrupt `exit()` can segfault during teardown.
+def main : IO UInt32 := do
+  let (audited, messages) ← withImportedEnv #[auditedRoot] audit
+  if messages.isEmpty then
+    IO.println s!"axioms: audited {audited} {auditedRoot} declaration(s); \
+      all within the allowlist {allowedAxioms}."
+    return 0
+  else
+    IO.eprintln s!"axioms: {messages.size} declaration(s) in {auditedRoot} use disallowed axioms:"
+    for m in messages do IO.eprintln m
+    IO.eprintln s!"allowed: {allowedAxioms}"
+    return 1

--- a/TauCetiReview/README.md
+++ b/TauCetiReview/README.md
@@ -10,23 +10,24 @@ be mechanized (is this the right abstraction? is the statement faithful to inten
 ## Status
 
 - `rubric.md`: the initial human-review rubric (skeleton).
+- `Axioms.lean`: the axiom-allowlist audit, run in CI as `lake exe axioms`.
 - Review bots: TBD.
 
 ## Already mechanized in CI (`.github/workflows/ci.yml`)
 
 - Builds against pinned Mathlib.
-- `TauCeti/` is free of `sorry` / `admit` / `sorryAx`.
+- **Axiom-allowlist audit** (`Axioms.lean`, `lake exe axioms`): inspects the built
+  `TauCeti` environment and asserts every declaration *defined in `TauCeti`* depends only
+  on the allowlist `propext`, `Classical.choice`, `Quot.sound`. Because it reads the
+  kernel environment, not source text, it catches what a grep cannot: `sorry`/`admit`
+  (as `sorryAx`), `native_decide` (as `Lean.ofReduceBool`), and any home-rolled `axiom`,
+  including ones reaching in through imports. This subsumes the old textual no-sorry guard.
 - `TauCeti/` does not import the roadmap/review trees (so it cannot inherit sorried
   goals, the real trust boundary, since the two-`lean_lib` split alone is only build
   convenience).
 
 ## Planned checks (to migrate from rubric → CI)
 
-- **`#print axioms` allowlist audit.** Assert every `TauCeti/` declaration depends
-  only on an allowlist (`propext`, `Classical.choice`, `Quot.sound`). This catches
-  what grep cannot: `sorryAx` reaching in through imports, `native_decide`'s
-  `Lean.ofReduceBool`, and any home-rolled `axiom`, all in one required check. This is the
-  most important planned upgrade.
 - **Statement faithfulness.** A lockfile pinning the expected *type* of each roadmap
   milestone, with CI failing if a claimed solution's signature drifts from it, so
   "prove milestone X" can't be won by weakening the statement.

--- a/lakefile.toml
+++ b/lakefile.toml
@@ -7,8 +7,12 @@ git = "https://github.com/leanprover-community/mathlib4"
 rev = "master"
 
 # AI-owned: all the mathematics. No sorries (enforced in CI).
+# Glob all submodules so `lake build` builds every TauCeti/*.lean — including any not yet
+# imported from the root — so the axiom audit (which enumerates the source tree) can import
+# them, and an orphaned/broken module fails the build.
 [[lean_lib]]
 name = "TauCeti"
+globs = ["TauCeti.*"]
 
 # Human-owned: roadmaps and target signatures. Sorries are allowed here:
 # these are goals, not proofs. `TauCeti` may not import this library (CI guard).

--- a/lakefile.toml
+++ b/lakefile.toml
@@ -14,3 +14,10 @@ name = "TauCeti"
 # these are goals, not proofs. `TauCeti` may not import this library (CI guard).
 [[lean_lib]]
 name = "TauCetiRoadmap"
+
+# Human-owned governance: the axiom-allowlist audit (`lake exe axioms`). Inspects the
+# built `TauCeti` environment and rejects any axiom outside the standard allowlist
+# (catches sorry, native_decide, and home-rolled axioms). Run in CI after the build.
+[[lean_exe]]
+name = "axioms"
+root = "TauCetiReview.Axioms"


### PR DESCRIPTION
This PR replaces the textual no-sorry CI grep with a Lean metaprogram that builds the `TauCeti` environment from its `.olean`s and inspects, for every declaration defined in `TauCeti`, the axioms it transitively depends on (`Lean.collectAxioms`), failing on anything outside the allowlist `propext`, `Classical.choice`, `Quot.sound`. Because it reads the kernel environment rather than source text, it catches `sorry`/`admit` (as `sorryAx`), `native_decide` (as `Lean.ofReduceBool`), and home-rolled axioms, including ones reaching in through imports. It is added as `lean_exe axioms` (root `TauCetiReview.Axioms`) and run in CI after the build, and the audit report is materialised to `String` inside the environment callback to avoid using memory-mapped olean `Name`s after teardown.

🤖 Prepared with Claude Code