### PR TITLE
style: remove em-dashes from the PDE Targets.lean docstring

### DIFF
--- a/TauCetiRoadmap/PDE/Targets.lean
+++ b/TauCetiRoadmap/PDE/Targets.lean
@@ -1,10 +1,10 @@
 import Mathlib
 
 /-!
-# Partial differential equations — target signatures
+# Partial differential equations: target signatures
 
 The narrative roadmap, the build lanes (A–F), and the acceptance criteria are in
-`README.md`. Mathlib already carries a substantial prerequisite stack — distributions and
+`README.md`. Mathlib already carries a substantial prerequisite stack: distributions and
 test functions, the Schwartz space, the Fourier transform, convolution and mollifiers,
 the Gagliardo–Nirenberg–Sobolev inequality, the **Bessel-potential** Sobolev scale
 (`TemperedDistribution.memSobolev`), the Laplacian and harmonic-function theory,
@@ -14,8 +14,8 @@ alternative** for compact operators, and the spectral theorem for symmetric oper
 What is missing is the PDE theory on top: weak-derivative Sobolev spaces `W^{k,p}(Ω)` on
 a domain with their embedding/trace/compactness package (Lane A), the harmonic-analysis
 estimates (Lane B), maximum principles and potential theory (Lane C), elliptic existence
-via the energy method (Lane D), elliptic regularity — Schauder and De Giorgi–Nash–Moser
-(Lane E), and parabolic/evolution equations (Lane F). We build these here, in
+via the energy method (Lane D), elliptic regularity (Schauder and De Giorgi–Nash–Moser;
+Lane E), and parabolic/evolution equations (Lane F). We build these here, in
 `TauCeti/Analysis/PDE/`, with supporting theories under `TauCeti/Analysis/Sobolev/` and
 `TauCeti/Analysis/HarmonicAnalysis/`.
 
@@ -27,8 +27,8 @@ hand them to the AIs to discharge. The natural first targets, in order:
   Poincaré on `Wkp0 1 p Ω`; Rellich–Kondrachov compactness `W^{1,p}(Ω) ↪↪ L^p(Ω)`.
 * Lane D: existence and uniqueness of the weak solution of `−Δu = f`, `u|∂Ω = 0`, on a
   bounded domain, via `IsCoercive` + `continuousLinearEquivOfBilin` (Lax–Milgram).
-* Lane E: De Giorgi–Nash–Moser — a weak `H¹` solution of a divergence-form equation with
-  bounded measurable coefficients is locally Hölder continuous.
+* Lane E: De Giorgi–Nash–Moser, showing that a weak `H¹` solution of a divergence-form
+  equation with bounded measurable coefficients is locally Hölder continuous.
 
 The first end-to-end milestone (Lane D.17) is the shortest path to a genuine PDE existence
 theorem, because Lax–Milgram is already in Mathlib; it only awaits `Wkp0` and Poincaré


### PR DESCRIPTION
This PR removes the four em-dash constructions from `TauCetiRoadmap/PDE/Targets.lean`, which was added with the PDE roadmap and missed in the earlier repo-wide em-dash cleanup. Rewrites them with a colon, parentheses, or connective wording; name-joining en-dashes are left intact.

🤖 Prepared with Claude Code