### PR TITLE
style: remove em-dashes from the axiom-audit docs and comments

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,7 +39,7 @@ jobs:
 
       # Axiom audit (replaces the old textual no-sorry grep). Inspects the built
       # TauCeti environment and rejects any axiom outside {propext, Classical.choice,
-      # Quot.sound} — catching sorry/admit (sorryAx), native_decide (Lean.ofReduceBool),
+      # Quot.sound}, catching sorry/admit (sorryAx), native_decide (Lean.ofReduceBool),
       # and home-rolled axioms, including ones reaching in through imports.
       - name: Axiom audit (TauCeti/ uses only allowlisted axioms)
         run: lake exe axioms

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Humans can raise issues against the code, and leave implementation (and review) 
 | `.github/`, `lakefile.toml`, `lean-toolchain`, `lake-manifest.json` | **humans** | The rules of the game and the machinery that enforces them. |
 
 This division is managed via the `CODEOWNERS` file and branch protection rules.
-The `main` branch is always green: it contains no `sorry`, and no axioms beyond the standard `propext`, `Classical.choice`, and `Quot.sound` — in particular, no `native_decide`. This is enforced in CI by an axiom audit (`lake exe axioms`; see `TauCetiReview/`).
+The `main` branch is always green: it contains no `sorry`, and no axioms beyond the standard `propext`, `Classical.choice`, and `Quot.sound`; in particular, no `native_decide`. This is enforced in CI by an axiom audit (`lake exe axioms`; see `TauCetiReview/`).
 
 ## Review
 

--- a/TauCetiReview/Axioms.lean
+++ b/TauCetiReview/Axioms.lean
@@ -12,7 +12,7 @@ declaration uses only the standard allowlist
 
 Because it works on the kernel environment rather than on source text, it catches what a
 `grep` cannot: `sorry`/`admit` (which surface as `sorryAx`), `native_decide` (which adds
-`Lean.ofReduceBool`), and any home-rolled `axiom` — including ones reaching in through
+`Lean.ofReduceBool`), and any home-rolled `axiom`, including ones reaching in through
 imports. Run via `lake exe axioms` (after `lake build`).
 -/
 
@@ -92,7 +92,7 @@ def main : IO UInt32 := do
   let (audited, messages) ← withImportedEnv modules audit
   if audited == 0 then
     -- Governance tooling must fail loudly if it audited nothing (e.g. miswired import).
-    IO.eprintln s!"axioms: audited 0 declarations in {auditedRoot} — the audit is miswired."
+    IO.eprintln s!"axioms: audited 0 declarations in {auditedRoot}: the audit is miswired."
     return 1
   if messages.isEmpty then
     IO.println s!"axioms: audited {audited} {auditedRoot} declaration(s); \

--- a/lakefile.toml
+++ b/lakefile.toml
@@ -7,8 +7,8 @@ git = "https://github.com/leanprover-community/mathlib4"
 rev = "master"
 
 # AI-owned: all the mathematics. No sorries (enforced in CI).
-# Glob all submodules so `lake build` builds every TauCeti/*.lean — including any not yet
-# imported from the root — so the axiom audit (which enumerates the source tree) can import
+# Glob all submodules so `lake build` builds every TauCeti/*.lean, including any not yet
+# imported from the root, so the axiom audit (which enumerates the source tree) can import
 # them, and an orphaned/broken module fails the build.
 [[lean_lib]]
 name = "TauCeti"


### PR DESCRIPTION
This PR removes the remaining em-dash constructions in the repo (the README axiom note, the ci.yml audit comment, the lakefile glob comment, and two in `TauCetiReview/Axioms.lean`), rewriting them with a semicolon, comma, or colon. After this the tree is em-dash-free outside `.lake/`.

🤖 Prepared with Claude Code