### PR TITLE
chore: enable the Mathlib linter set on TauCeti

### DIFF
--- a/lakefile.toml
+++ b/lakefile.toml
@@ -13,6 +13,7 @@ rev = "master"
 [[lean_lib]]
 name = "TauCeti"
 globs = ["TauCeti.*"]
+leanOptions = { weak.linter.mathlibStandardSet = true, weak.linter.style.longFile = 1000, weak.linter.style.longFileDefValue = 1000, weak.linter.style.header = false, warningAsError = true }
 
 # Human-owned: roadmaps and target signatures. Sorries are allowed here:
 # these are goals, not proofs. `TauCeti` may not import this library (CI guard).


### PR DESCRIPTION
This PR turns on `linter.mathlibStandardSet` for the `TauCeti` library, caps file length at 1000 lines, and sets `warningAsError` so any lint violation fails the build. Enforcement rides on the existing `lake build` step, so no workflow change is needed; the audit step is unaffected. Verified locally that an unscoped `maxHeartbeats` and an over-long line both fail the `TauCeti` build, while the roadmap library (which carries `sorry` on purpose) still builds.

Two deliberate choices to confirm: the header linter is disabled pending a copyright-header / authors convention (flip it on once decided, and files get headers); and `warningAsError` means Mathlib deprecation warnings will also fail `TauCeti` on a bump, which keeps the code current but can break CI on upstream churn. The roadmap and review libraries are left unlinted on purpose.

🤖 Prepared with Claude Code