### PR TITLE
doc: acknowledge the Zulip discussions each roadmap builds on

### DIFF
--- a/TauCetiRoadmap/JacobianChallenge/README.md
+++ b/TauCetiRoadmap/JacobianChallenge/README.md
@@ -1,7 +1,7 @@
 # Roadmap: the Jacobian challenge (Christian Merten's AG version)
 
 Background: Kevin Buzzard's "Jacobian challenge" (Zulip
-[#Autoformalization > Jacobian challenge](https://leanprover.zulipchat.com/#narrow/channel/417987-Autoformalization/topic/Jacobian.20challenge)),
+[#Autoformalization > Jacobian challenge](https://leanprover.zulipchat.com/#narrow/channel/583336-Autoformalization/topic/Jacobian.20challenge)),
 in the **algebraic-geometry formulation due to Christian Merten**. The challenge is
 designed with **checks along the way**, so a construction that satisfies them all has to
 have the definitions right; the point is autoformalizing *definitions*, not just
@@ -196,3 +196,16 @@ Large by design, expanded **iteratively**. Build Layer A, then B, … ; as each 
 the next layer's *types* expressible, state that layer's milestones in `Targets.lean` (with
 `sorry`) and hand them to the AIs to discharge in `TauCeti/`. Nothing here blocks on
 upstream Mathlib.
+
+## Acknowledgements
+
+This roadmap builds directly on earlier discussions on the [Lean
+Zulip](https://leanprover.zulipchat.com/), and would not have been possible without them:
+
+- [#Autoformalization > Jacobian challenge](https://leanprover.zulipchat.com/#narrow/channel/583336-Autoformalization/topic/Jacobian%20challenge),
+  where Kevin Buzzard posed the original Jacobian challenge.
+- Private project discussions with Christian Merten, Matthew Ballard, Adam Topaz,
+  Fabian Glöckle, and Jack McCarthy; the algebraic-geometry reformulation this roadmap
+  follows is due to Christian Merten.
+
+Thanks to everyone who contributed to these discussions.

--- a/TauCetiRoadmap/PDE/README.md
+++ b/TauCetiRoadmap/PDE/README.md
@@ -380,3 +380,19 @@ the long pole that Lane E's regularity depends on. Lane E is the deep core of th
 roadmap, and Lane F and the stretch goals come last. As each lane makes the next one's
 *types* expressible in `TauCeti/`, state those milestones in `Targets.lean` (with
 `sorry`) and hand them to the AIs to discharge. Nothing here blocks on upstream Mathlib.
+
+## Acknowledgements
+
+This roadmap builds directly on earlier discussions on the [Lean
+Zulip](https://leanprover.zulipchat.com/), and would not have been possible without them:
+
+- [#AI authored projects > De Giorgi–Nash–Moser](https://leanprover.zulipchat.com/#narrow/channel/583339-AI%20authored%20projects/topic/De%20Giorgi%E2%80%93Nash%E2%80%93Moser),
+  the De Giorgi–Nash–Moser formalization experiment that informed this roadmap's headline
+  regularity target, with Filippo A. E. Nuccio, Przemek Chojecki, and others.
+- [#mathlib4 > PDE Theory](https://leanprover.zulipchat.com/#narrow/channel/287929-mathlib4/topic/PDE%20Theory)
+  (Anatole Dedecker, Michael Rothgang, Filippo A. E. Nuccio, Aditya Ramabadran), scoping
+  the PDE theory to build on top of Mathlib's analysis stack.
+- [#new members > elliptic PDEs](https://leanprover.zulipchat.com/#narrow/channel/113489-new%20members/topic/elliptic%20PDEs),
+  discussing prerequisites for formalizing elliptic PDEs.
+
+Thanks to everyone who contributed to these discussions.

--- a/TauCetiRoadmap/ReductiveGroups/README.md
+++ b/TauCetiRoadmap/ReductiveGroups/README.md
@@ -265,3 +265,18 @@ parabolic API before the full root-data classification exists: another reason to
 - J. C. Jantzen, *Representations of Algebraic Groups*.
 - B. Conrad, *Reductive Group Schemes* (SGA3 exposition); **SGA3**, Exposé XIX.
 - B. Conrad, O. Gabber, G. Prasad, *Pseudo-reductive Groups* (relative theory).
+
+## Acknowledgements
+
+This roadmap builds directly on earlier discussions on the [Lean
+Zulip](https://leanprover.zulipchat.com/), and would not have been possible without them:
+
+- [#Is there code for X? > Algebraic groups](https://leanprover.zulipchat.com/#narrow/channel/217875-Is%20there%20code%20for%20X%3F/topic/Algebraic%20groups)
+  (Michael Rothgang, Bryan Gin-ge Chen, Yaël Dillies), on the Hopf / group-scheme
+  dictionary and the convolution-product work in mathlib4#39281.
+- [#maths > class and def (p-adic reps)](https://leanprover.zulipchat.com/#narrow/channel/116395-maths/topic/class%20and%20def%20%28p-adic%20reps%29)
+  (Kevin Buzzard, Shurui Liu, Stepan Nesterov), discussing the dynamic-parabolics /
+  BN-pair approach and the downstream p-adic-representation consumers cited above.
+
+Thanks to everyone who contributed to these discussions, and for the recurring Zulip
+guidance on keeping typeclass assumptions unbundled.

--- a/TauCetiRoadmap/UniversalCovers/README.md
+++ b/TauCetiRoadmap/UniversalCovers/README.md
@@ -153,3 +153,15 @@ Stage 3 is a larger, separable track, but lighter than it looks now that homotop
 is available; the cost is the `π_n` API, not lifting. As each milestone's prerequisite
 *types* exist in `TauCeti/`, state the milestone in `Targets.lean` (with `sorry`) and
 hand it to the AIs to discharge.
+
+## Acknowledgements
+
+This roadmap builds directly on earlier discussions on the [Lean
+Zulip](https://leanprover.zulipchat.com/), and would not have been possible without them:
+
+- [#Is there code for X? > Universal cover of a topological space](https://leanprover.zulipchat.com/#narrow/channel/217875-Is%20there%20code%20for%20X%3F/topic/Universal%20cover%20of%20a%20topological%20space)
+  (Laura Monk, Kim Morrison, Michael Rothgang, Damiano Testa, and others), where the
+  universal-cover work was consolidated into mathlib4#38292.
+
+Thanks to everyone who contributed to that discussion, and to the authors of
+mathlib4#31576, mathlib4#38292, and mathlib4#40135.


### PR DESCRIPTION
This PR adds an Acknowledgements section to each of the four roadmaps under `TauCetiRoadmap/`, linking the past discussions the roadmaps were distilled from and crediting the people who contributed them. The universal-covers, reductive-groups, and PDE roadmaps link public Lean Zulip threads; the Jacobian roadmap links Kevin Buzzard's public challenge thread and cites the private project discussions (with Christian Merten and others) for the algebraic-geometry reformulation it follows. Each section states the roadmap builds on, and would not have been possible without, those discussions. It also fixes the inline Autoformalization channel id in the Jacobian roadmap, which pointed at a stale stream (417987 -> 583336).

🤖 Prepared with Claude Code