### PR TITLE
test: throwaway lemma to exercise the review harness

### DIFF
--- a/TauCeti/Basic.lean
+++ b/TauCeti/Basic.lean
@@ -13,4 +13,8 @@ namespace TauCeti
 /-- A tiny sanity check that the library compiles against Mathlib. -/
 theorem hello : 1 + 1 = 2 := by norm_num
 
+
+/-- A throwaway lemma, used only to exercise the review harness. -/
+theorem two_pos : 0 < 2 := by norm_num
+
 end TauCeti


### PR DESCRIPTION
Throwaway PR used only to test the AI review harness end to end. It adds a trivial `two_pos` lemma. (Not on any roadmap target; the scope agent should say so.)