### PR TITLE
ci: trigger AI review after CI

### DIFF
--- a/.github/workflows/review.yml
+++ b/.github/workflows/review.yml
@@ -1,0 +1,50 @@
+name: Review
+
+on:
+  workflow_run:
+    workflows: ["CI"]
+    types: [completed]
+  issue_comment:
+    types: [created]
+
+permissions:
+  contents: read
+  pull-requests: read
+
+jobs:
+  resolve:
+    runs-on: ubuntu-latest
+    # Fire after CI succeeds on a PR, or on a `/review` comment from an authorized user.
+    if: >
+      (github.event_name == 'workflow_run'
+        && github.event.workflow_run.conclusion == 'success'
+        && github.event.workflow_run.event == 'pull_request')
+      || (github.event_name == 'issue_comment'
+        && github.event.issue.pull_request != null
+        && contains(github.event.comment.body, '/review')
+        && contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.comment.author_association))
+    outputs:
+      pr: ${{ steps.r.outputs.pr }}
+    steps:
+      - id: r
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          if [ "${{ github.event_name }}" = "issue_comment" ]; then
+            echo "pr=${{ github.event.issue.number }}" >> "$GITHUB_OUTPUT"
+          else
+            pr="${{ github.event.workflow_run.pull_requests[0].number }}"
+            if [ -z "$pr" ]; then
+              pr=$(gh api "repos/${{ github.repository }}/commits/${{ github.event.workflow_run.head_sha }}/pulls" --jq '.[0].number // empty')
+            fi
+            echo "pr=$pr" >> "$GITHUB_OUTPUT"
+          fi
+
+  review:
+    needs: resolve
+    if: ${{ needs.resolve.outputs.pr != '' }}
+    uses: FormalFrontier/TauCetiReview/.github/workflows/review.yml@main
+    with:
+      pr: ${{ needs.resolve.outputs.pr }}
+      trigger: ${{ github.event_name }}
+    secrets: inherit


### PR DESCRIPTION
Adds the Review workflow: after CI succeeds on a PR (or on an authorized `/review` comment) it calls the reusable review workflow in TauCetiReview, which runs the rubric agents and posts a verdict. Advisory; does not gate merges.

🤖 Prepared with Claude Code