### PR TITLE
feat: enable auto-merge (I9 go-live)

### DIFF
--- a/.github/workflows/review.yml
+++ b/.github/workflows/review.yml
@@ -56,4 +56,5 @@ jobs:
     with:
       pr: ${{ needs.resolve.outputs.pr }}
       trigger: ${{ github.event_name }}
+      enable_automerge: true
     secrets: inherit


### PR DESCRIPTION
Pass `enable_automerge: true` to the review workflow. A PR auto-merges when every rubric approves on its current commit and it touches only `TauCeti/`; CI must be green and infra PRs still require `@humans`. Merge is performed by the `tauceti-review-bot` App via the review-bypass actor. Closes #15 (TauCetiReview).

🤖 Prepared with Claude Code