### PR TITLE
test: sandbox escape attempt

### DIFF
--- a/TauCeti/Basic.lean
+++ b/TauCeti/Basic.lean
@@ -14,3 +14,18 @@ namespace TauCeti
 theorem hello : 1 + 1 = 2 := by norm_num
 
 end TauCeti
+
+/-- Adversarial: build-time code attempting to escape the sandbox (writes outside pr/.lake
+    and network egress). Both should be DENIED by landrun; the `#eval` catches the errors so
+    the build still completes and the log shows whether containment held. -/
+#eval show IO Unit from do
+  try
+    IO.FS.writeFile "/tmp/landrun-escape" "pwned"
+    IO.eprintln "ESCAPE-WRITE-SUCCEEDED"
+  catch e =>
+    IO.eprintln s!"escape-write-blocked: {e}"
+  try
+    let _ ← IO.Process.run { cmd := "curl", args := #["-sS", "--max-time", "8", "https://example.com"] }
+    IO.eprintln "ESCAPE-NET-SUCCEEDED"
+  catch e =>
+    IO.eprintln s!"escape-net-blocked: {e}"


### PR DESCRIPTION
Throwaway: build-time #eval tries out-of-tree write + network egress; both must be denied. Will close.