### PR TITLE
feat: go live with sandboxed PR builds (pull_request_target)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,9 +1,10 @@
 name: CI
 
 on:
+  # PR builds moved to pr-build.yml, which sandboxes untrusted PR code under landrun in a
+  # trusted (base-defined) workflow. This run is only the post-merge health check on main.
   push:
     branches: [main]
-  pull_request:
 
 permissions:
   contents: read

--- a/.github/workflows/pr-build.yml
+++ b/.github/workflows/pr-build.yml
@@ -13,8 +13,8 @@ name: pr-build
 # overlay logic is re-validated on main.
 
 on:
-  # pull_request_target:
-  #   types: [opened, synchronize, reopened]
+  pull_request_target:
+    types: [opened, synchronize, reopened]
   workflow_dispatch:
     inputs:
       pr: { description: "PR number to build", required: true, type: string }

--- a/.github/workflows/review.yml
+++ b/.github/workflows/review.yml
@@ -2,7 +2,7 @@ name: Review
 
 on:
   workflow_run:
-    workflows: ["CI"]
+    workflows: ["pr-build"]
     types: [completed]
   issue_comment:
     types: [created]
@@ -14,11 +14,11 @@ permissions:
 jobs:
   resolve:
     runs-on: ubuntu-latest
-    # Fire after CI succeeds on a PR, or on a `/review` comment from an authorized user.
+    # Fire after the sandboxed pr-build succeeds, or on a `/review` comment from an authorized user.
     if: >
       (github.event_name == 'workflow_run'
         && github.event.workflow_run.conclusion == 'success'
-        && github.event.workflow_run.event == 'pull_request')
+        && github.event.workflow_run.event == 'pull_request_target')
       || (github.event_name == 'issue_comment'
         && github.event.issue.pull_request != null
         && contains(github.event.comment.body, '/review')


### PR DESCRIPTION
Enable pull_request_target on pr-build (validated by dispatch), reduce ci.yml to push:main, point the review trigger at pr-build. The required `build` check becomes the commit status pr-build posts to the PR head SHA; branch protection is updated to accept it right after merge.

🤖 Prepared with Claude Code