### PR TITLE
ci: temporary event-debug (diagnostic, will revert)

### DIFF
--- a/.github/workflows/event-debug.yml
+++ b/.github/workflows/event-debug.yml
@@ -1,0 +1,19 @@
+name: event-debug
+# TEMPORARY diagnostic: logs which event a PR review-comment reply actually emits. Remove after.
+on:
+  pull_request_review_comment:
+    types: [created, edited]
+  pull_request_review:
+    types: [submitted, edited, dismissed]
+permissions:
+  contents: read
+jobs:
+  log:
+    runs-on: ubuntu-latest
+    steps:
+      - run: |
+          echo "event_name=${{ github.event_name }}"
+          echo "action=${{ github.event.action }}"
+          echo "comment_id=${{ github.event.comment.id }}"
+          echo "in_reply_to=${{ github.event.comment.in_reply_to_id }}"
+          echo "review_id=${{ github.event.review.id }}"


### PR DESCRIPTION
Temporary diagnostic workflow to determine which event a PR review-comment reply emits. Will be reverted.