### PR TITLE
feat: add deck transformations

### DIFF
--- a/TauCeti/AlgebraicTopology/UniversalCover/Deck.lean
+++ b/TauCeti/AlgebraicTopology/UniversalCover/Deck.lean
@@ -62,7 +62,10 @@ lemma mapsTo_fiber (φ : Deck p) (b : B) : Set.MapsTo φ.1 (p ⁻¹' {b}) (p ⁻
 /-- The inverse of a deck transformation also preserves each fibre of the projection. -/
 lemma mapsTo_fiber_symm (φ : Deck p) (b : B) :
     Set.MapsTo φ.1.symm (p ⁻¹' {b}) (p ⁻¹' {b}) := by
-  exact mapsTo_fiber (φ⁻¹ : Deck p) b
+  intro e he
+  simp only [Set.mem_preimage, Set.mem_singleton_iff] at he ⊢
+  rw [← map_proj φ (φ.1.symm e), Homeomorph.apply_symm_apply]
+  exact he
 
 /-- A deck transformation restricts to a homeomorphism of every fibre of the projection,
 the restriction of its underlying homeomorphism along `Homeomorph.subtype`. -/

--- a/TauCeti/AlgebraicTopology/UniversalCover/Deck.lean
+++ b/TauCeti/AlgebraicTopology/UniversalCover/Deck.lean
@@ -2,8 +2,8 @@
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 -/
-import Mathlib.Topology.Algebra.ConstMulAction
-import Mathlib.Topology.Homeomorph.Defs
+import Mathlib.Topology.Homeomorph.Lemmas
+import TauCeti.Topology.Algebra.HomeomorphAction
 
 /-!
 # Deck transformations of a map
@@ -13,8 +13,10 @@ viewed as a subgroup of the homeomorphism group `E ≃ₜ E`. This is the first 
 piece needed by the universal-covers roadmap Stage 0.4: for a covering projection `p`, the
 subgroup `Deck p` will be the deck transformation group.
 
-The action of `Deck p` on the total space is inherited from the ambient homeomorphism
-group. Each deck transformation preserves `p`, hence preserves every fibre of `p`.
+The action of `Deck p` on the total space is inherited, by subgroup transfer, from the
+tautological action of the ambient homeomorphism group `E ≃ₜ E` on `E`
+(`TauCeti.Homeomorph.applyMulAction`). Each deck transformation preserves `p`, hence
+preserves every fibre of `p`.
 
 ## References
 
@@ -48,7 +50,9 @@ variable {p}
 lemma mem_iff (φ : E ≃ₜ E) : φ ∈ Deck p ↔ ∀ e, p (φ e) = p e :=
   Iff.rfl
 
+set_option warning.simp.varHead false in
 /-- A deck transformation preserves the projection map pointwise. -/
+@[simp]
 lemma map_proj (φ : Deck p) (e : E) : p (φ.1 e) = p e :=
   φ.2 e
 
@@ -62,60 +66,41 @@ lemma mapsTo_fiber_symm (φ : Deck p) (b : B) :
     Set.MapsTo φ.1.symm (p ⁻¹' {b}) (p ⁻¹' {b}) := by
   exact mapsTo_fiber (φ⁻¹ : Deck p) b
 
-/-- A deck transformation restricts to an equivalence of every fibre of the projection. -/
-def fiberEquiv (φ : Deck p) (b : B) : p ⁻¹' {b} ≃ p ⁻¹' {b} where
-  toFun e := ⟨φ.1 e.1, mapsTo_fiber φ b e.2⟩
-  invFun e := ⟨φ.1.symm e.1, mapsTo_fiber_symm φ b e.2⟩
-  left_inv e := by
-    ext
-    simp
-  right_inv e := by
-    ext
-    simp
+/-- A deck transformation restricts to a homeomorphism of every fibre of the projection,
+the restriction of its underlying homeomorphism along `Homeomorph.subtype`. -/
+def fiberEquiv (φ : Deck p) (b : B) : p ⁻¹' {b} ≃ₜ p ⁻¹' {b} :=
+  φ.1.subtype fun e => by simp [Set.mem_preimage, eq_comm]
 
-/-- On points, the fibre equivalence induced by a deck transformation is just evaluation of
-that transformation. -/
+/-- On points, the fibre homeomorphism induced by a deck transformation is just evaluation
+of that transformation. -/
 @[simp]
 lemma fiberEquiv_apply (φ : Deck p) (b : B) (e : p ⁻¹' {b}) :
     (fiberEquiv φ b e : E) = φ.1 e.1 :=
   rfl
 
-/-- On points, the inverse fibre equivalence induced by a deck transformation is evaluation
-of the inverse homeomorphism. -/
+/-- On points, the inverse fibre homeomorphism induced by a deck transformation is
+evaluation of the inverse homeomorphism. -/
 @[simp]
 lemma fiberEquiv_symm_apply (φ : Deck p) (b : B) (e : p ⁻¹' {b}) :
     ((fiberEquiv φ b).symm e : E) = φ.1.symm e.1 :=
   rfl
 
-/-- Deck transformations act on the total space by evaluation of their underlying
-homeomorphisms. -/
-instance instSMul : SMul (Deck p) E where
-  smul φ e := φ.1 e
-
+/-- On points, the action of a deck transformation is evaluation of its underlying
+homeomorphism. The action itself is inherited, by subgroup transfer, from the tautological
+action of `E ≃ₜ E` on `E`. -/
 @[simp]
 lemma smul_eq_apply (φ : Deck p) (e : E) : φ • e = φ.1 e :=
   rfl
 
-instance instMulAction : MulAction (Deck p) E where
-  one_smul e := by
-    simp [smul_eq_apply]
-  mul_smul φ ψ e := by
-    simp [smul_eq_apply]
+/-- If two deck transformations act the same on every point, they are equal. This reuses
+faithfulness of the ambient action of `E ≃ₜ E` on `E`. -/
+instance instFaithfulSMul : FaithfulSMul (Deck p) E :=
+  ⟨fun h => Subtype.ext <| eq_of_smul_eq_smul h⟩
 
-/-- The action of deck transformations preserves the projection. -/
-lemma proj_smul (φ : Deck p) (e : E) : p (φ • e) = p e :=
-  map_proj φ e
-
-/-- If two deck transformations have the same action on every point, they are equal. -/
-instance instFaithfulSMul : FaithfulSMul (Deck p) E where
-  eq_of_smul_eq_smul hφψ := by
-    ext e
-    simpa only [smul_eq_apply] using hφψ e
-
-/-- Each deck transformation acts continuously on the total space. -/
-instance instContinuousConstSMul : ContinuousConstSMul (Deck p) E where
-  continuous_const_smul φ := by
-    simpa only [smul_eq_apply] using φ.1.continuous
+/-- Each deck transformation acts continuously on the total space, reusing continuity of the
+ambient action of `E ≃ₜ E` on `E`. -/
+instance instContinuousConstSMul : ContinuousConstSMul (Deck p) E :=
+  ⟨fun φ => continuous_const_smul (φ : E ≃ₜ E)⟩
 
 end Deck
 

--- a/TauCeti/AlgebraicTopology/UniversalCover/Deck.lean
+++ b/TauCeti/AlgebraicTopology/UniversalCover/Deck.lean
@@ -50,9 +50,7 @@ variable {p}
 lemma mem_iff (φ : E ≃ₜ E) : φ ∈ Deck p ↔ ∀ e, p (φ e) = p e :=
   Iff.rfl
 
-set_option warning.simp.varHead false in
 /-- A deck transformation preserves the projection map pointwise. -/
-@[simp]
 lemma map_proj (φ : Deck p) (e : E) : p (φ.1 e) = p e :=
   φ.2 e
 
@@ -69,7 +67,7 @@ lemma mapsTo_fiber_symm (φ : Deck p) (b : B) :
 /-- A deck transformation restricts to a homeomorphism of every fibre of the projection,
 the restriction of its underlying homeomorphism along `Homeomorph.subtype`. -/
 def fiberEquiv (φ : Deck p) (b : B) : p ⁻¹' {b} ≃ₜ p ⁻¹' {b} :=
-  φ.1.subtype fun e => by simp [Set.mem_preimage, eq_comm]
+  φ.1.subtype fun e => by simp [Set.mem_preimage, eq_comm, map_proj]
 
 /-- On points, the fibre homeomorphism induced by a deck transformation is just evaluation
 of that transformation. -/

--- a/TauCeti/AlgebraicTopology/UniversalCover/Deck.lean
+++ b/TauCeti/AlgebraicTopology/UniversalCover/Deck.lean
@@ -1,0 +1,122 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+import Mathlib.Topology.Algebra.ConstMulAction
+import Mathlib.Topology.Homeomorph.Defs
+
+/-!
+# Deck transformations of a map
+
+For a map `p : E → B`, its deck transformations are the homeomorphisms of `E` over `B`,
+viewed as a subgroup of the homeomorphism group `E ≃ₜ E`. This is the first algebraic
+piece needed by the universal-covers roadmap Stage 0.4: for a covering projection `p`, the
+subgroup `Deck p` will be the deck transformation group.
+
+The action of `Deck p` on the total space is inherited from the ambient homeomorphism
+group. Each deck transformation preserves `p`, hence preserves every fibre of `p`.
+
+## References
+
+This file follows the deck-transformation target in the Tau Ceti universal-covers roadmap,
+Stage 0.4, and the shape of the construction in Kim Morrison's mathlib4#40135.
+-/
+
+namespace TauCeti
+
+variable {E B : Type*} [TopologicalSpace E] (p : E → B)
+
+/-- The deck transformations of a map `p : E → B`, as the subgroup of homeomorphisms of `E`
+which commute with `p`. For a covering projection, this is the usual deck transformation
+group. -/
+def Deck : Subgroup (E ≃ₜ E) where
+  carrier := {φ | ∀ e, p (φ e) = p e}
+  one_mem' e := rfl
+  mul_mem' hφ hψ e := by
+    rw [Homeomorph.mul_apply, hφ, hψ]
+  inv_mem' := by
+    intro φ hφ e
+    have h := hφ (φ⁻¹ e)
+    simpa only [Homeomorph.inv_apply, Homeomorph.apply_symm_apply] using h.symm
+
+namespace Deck
+
+variable {p}
+
+/-- A homeomorphism lies in `Deck p` exactly when it preserves `p` pointwise. -/
+@[simp]
+lemma mem_iff (φ : E ≃ₜ E) : φ ∈ Deck p ↔ ∀ e, p (φ e) = p e :=
+  Iff.rfl
+
+/-- A deck transformation preserves the projection map pointwise. -/
+lemma map_proj (φ : Deck p) (e : E) : p (φ.1 e) = p e :=
+  φ.2 e
+
+/-- A deck transformation preserves each fibre of the projection. -/
+lemma mapsTo_fiber (φ : Deck p) (b : B) : Set.MapsTo φ.1 (p ⁻¹' {b}) (p ⁻¹' {b}) := by
+  intro e he
+  simpa only [Set.mem_preimage, Set.mem_singleton_iff, map_proj] using he
+
+/-- The inverse of a deck transformation also preserves each fibre of the projection. -/
+lemma mapsTo_fiber_symm (φ : Deck p) (b : B) :
+    Set.MapsTo φ.1.symm (p ⁻¹' {b}) (p ⁻¹' {b}) := by
+  exact mapsTo_fiber (φ⁻¹ : Deck p) b
+
+/-- A deck transformation restricts to an equivalence of every fibre of the projection. -/
+def fiberEquiv (φ : Deck p) (b : B) : p ⁻¹' {b} ≃ p ⁻¹' {b} where
+  toFun e := ⟨φ.1 e.1, mapsTo_fiber φ b e.2⟩
+  invFun e := ⟨φ.1.symm e.1, mapsTo_fiber_symm φ b e.2⟩
+  left_inv e := by
+    ext
+    simp
+  right_inv e := by
+    ext
+    simp
+
+/-- On points, the fibre equivalence induced by a deck transformation is just evaluation of
+that transformation. -/
+@[simp]
+lemma fiberEquiv_apply (φ : Deck p) (b : B) (e : p ⁻¹' {b}) :
+    (fiberEquiv φ b e : E) = φ.1 e.1 :=
+  rfl
+
+/-- On points, the inverse fibre equivalence induced by a deck transformation is evaluation
+of the inverse homeomorphism. -/
+@[simp]
+lemma fiberEquiv_symm_apply (φ : Deck p) (b : B) (e : p ⁻¹' {b}) :
+    ((fiberEquiv φ b).symm e : E) = φ.1.symm e.1 :=
+  rfl
+
+/-- Deck transformations act on the total space by evaluation of their underlying
+homeomorphisms. -/
+instance instSMul : SMul (Deck p) E where
+  smul φ e := φ.1 e
+
+@[simp]
+lemma smul_eq_apply (φ : Deck p) (e : E) : φ • e = φ.1 e :=
+  rfl
+
+instance instMulAction : MulAction (Deck p) E where
+  one_smul e := by
+    simp [smul_eq_apply]
+  mul_smul φ ψ e := by
+    simp [smul_eq_apply]
+
+/-- The action of deck transformations preserves the projection. -/
+lemma proj_smul (φ : Deck p) (e : E) : p (φ • e) = p e :=
+  map_proj φ e
+
+/-- If two deck transformations have the same action on every point, they are equal. -/
+instance instFaithfulSMul : FaithfulSMul (Deck p) E where
+  eq_of_smul_eq_smul hφψ := by
+    ext e
+    simpa only [smul_eq_apply] using hφψ e
+
+/-- Each deck transformation acts continuously on the total space. -/
+instance instContinuousConstSMul : ContinuousConstSMul (Deck p) E where
+  continuous_const_smul φ := by
+    simpa only [smul_eq_apply] using φ.1.continuous
+
+end Deck
+
+end TauCeti

--- a/TauCeti/AlgebraicTopology/UniversalCover/Deck.lean
+++ b/TauCeti/AlgebraicTopology/UniversalCover/Deck.lean
@@ -90,15 +90,8 @@ action of `E ≃ₜ E` on `E`. -/
 lemma smul_eq_apply (φ : Deck p) (e : E) : φ • e = φ.1 e :=
   rfl
 
-/-- If two deck transformations act the same on every point, they are equal. This reuses
-faithfulness of the ambient action of `E ≃ₜ E` on `E`. -/
-instance instFaithfulSMul : FaithfulSMul (Deck p) E :=
-  ⟨fun h => Subtype.ext <| eq_of_smul_eq_smul h⟩
-
-/-- Each deck transformation acts continuously on the total space, reusing continuity of the
-ambient action of `E ≃ₜ E` on `E`. -/
-instance instContinuousConstSMul : ContinuousConstSMul (Deck p) E :=
-  ⟨fun φ => continuous_const_smul (φ : E ≃ₜ E)⟩
+-- `FaithfulSMul (Deck p) E` and `ContinuousConstSMul (Deck p) E` are inherited from the generic
+-- subgroup instances in `TauCeti.Topology.Algebra.HomeomorphAction`; `Deck p` is a `Subgroup`.
 
 end Deck
 

--- a/TauCeti/AlgebraicTopology/UniversalCover/Deck.lean
+++ b/TauCeti/AlgebraicTopology/UniversalCover/Deck.lean
@@ -69,21 +69,21 @@ lemma mapsTo_fiber_symm (φ : Deck p) (b : B) :
 
 /-- A deck transformation restricts to a homeomorphism of every fibre of the projection,
 the restriction of its underlying homeomorphism along `Homeomorph.subtype`. -/
-def fiberEquiv (φ : Deck p) (b : B) : p ⁻¹' {b} ≃ₜ p ⁻¹' {b} :=
+def fiberHomeomorph (φ : Deck p) (b : B) : p ⁻¹' {b} ≃ₜ p ⁻¹' {b} :=
   φ.1.subtype fun e => by simp [Set.mem_preimage, eq_comm, map_proj]
 
 /-- On points, the fibre homeomorphism induced by a deck transformation is just evaluation
 of that transformation. -/
 @[simp]
-lemma fiberEquiv_apply (φ : Deck p) (b : B) (e : p ⁻¹' {b}) :
-    (fiberEquiv φ b e : E) = φ.1 e.1 :=
+lemma fiberHomeomorph_apply (φ : Deck p) (b : B) (e : p ⁻¹' {b}) :
+    (fiberHomeomorph φ b e : E) = φ.1 e.1 :=
   rfl
 
 /-- On points, the inverse fibre homeomorphism induced by a deck transformation is
 evaluation of the inverse homeomorphism. -/
 @[simp]
-lemma fiberEquiv_symm_apply (φ : Deck p) (b : B) (e : p ⁻¹' {b}) :
-    ((fiberEquiv φ b).symm e : E) = φ.1.symm e.1 :=
+lemma fiberHomeomorph_symm_apply (φ : Deck p) (b : B) (e : p ⁻¹' {b}) :
+    ((fiberHomeomorph φ b).symm e : E) = φ.1.symm e.1 :=
   rfl
 
 /-- On points, the action of a deck transformation is evaluation of its underlying

--- a/TauCeti/Topology/Algebra/HomeomorphAction.lean
+++ b/TauCeti/Topology/Algebra/HomeomorphAction.lean
@@ -1,0 +1,50 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+import Mathlib.Topology.Algebra.ConstMulAction
+import Mathlib.Topology.Homeomorph.Defs
+
+/-!
+# The tautological action of the homeomorphism group
+
+For a topological space `E`, the homeomorphism group `E ≃ₜ E` acts on `E` by evaluation:
+`φ • e = φ e`. This file records that action, that it is faithful, and that it is continuous
+in the point, mirroring `Equiv.Perm.applyMulAction` and the construction in Kim Morrison's
+mathlib4#40135.
+
+## Main definitions
+
+* `TauCeti.Homeomorph.applyMulAction`: the `MulAction (E ≃ₜ E) E` with `φ • e = φ e`.
+* `TauCeti.Homeomorph.smul_def`: the defining simp lemma `φ • e = φ e`.
+* `TauCeti.Homeomorph.applyFaithfulSMul`: the action is faithful.
+* `TauCeti.Homeomorph.applyContinuousConstSMul`: each homeomorphism acts continuously.
+-/
+
+namespace TauCeti
+
+namespace Homeomorph
+
+variable {E : Type*} [TopologicalSpace E]
+
+/-- The tautological action of the homeomorphism group `E ≃ₜ E` on `E` by evaluation. -/
+instance applyMulAction : MulAction (E ≃ₜ E) E where
+  smul φ e := φ e
+  one_smul _ := rfl
+  mul_smul _ _ _ := rfl
+
+/-- The tautological action of `E ≃ₜ E` on `E` is given by evaluation. -/
+@[simp]
+lemma smul_def (φ : E ≃ₜ E) (e : E) : φ • e = φ e := rfl
+
+/-- The tautological action of `E ≃ₜ E` on `E` is faithful. -/
+instance applyFaithfulSMul : FaithfulSMul (E ≃ₜ E) E :=
+  ⟨fun h => Homeomorph.ext h⟩
+
+/-- The tautological action of `E ≃ₜ E` on `E` is continuous in the point. -/
+instance applyContinuousConstSMul : ContinuousConstSMul (E ≃ₜ E) E :=
+  ⟨fun φ => φ.continuous⟩
+
+end Homeomorph
+
+end TauCeti

--- a/TauCeti/Topology/Algebra/HomeomorphAction.lean
+++ b/TauCeti/Topology/Algebra/HomeomorphAction.lean
@@ -4,6 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 -/
 import Mathlib.Topology.Algebra.ConstMulAction
 import Mathlib.Topology.Homeomorph.Defs
+import Mathlib.Algebra.Group.Subgroup.Actions
 
 /-!
 # The tautological action of the homeomorphism group
@@ -45,15 +46,13 @@ instance applyFaithfulSMul : FaithfulSMul (E ≃ₜ E) E :=
 instance applyContinuousConstSMul : ContinuousConstSMul (E ≃ₜ E) E :=
   ⟨fun φ => φ.continuous⟩
 
-/-- A subgroup of the homeomorphism group acts faithfully on `E`. Mathlib transfers the
-`MulAction` to a subgroup of `E ≃ₜ E` but not faithfulness, so we record it here from the
-ambient faithful action. Any `Subgroup (E ≃ₜ E)` — e.g. the deck transformation group of a
-map — inherits this rather than carrying its own instance. -/
-instance applySubgroupFaithfulSMul (H : Subgroup (E ≃ₜ E)) : FaithfulSMul H E :=
-  ⟨fun h => Subtype.ext <| eq_of_smul_eq_smul h⟩
+-- Faithfulness for a `Subgroup (E ≃ₜ E)` is already supplied by Mathlib's generic subgroup
+-- action transfer (`Mathlib.Algebra.Group.Subgroup.Actions`) from the ambient `applyFaithfulSMul`,
+-- so we do not restate it. Continuity in the point, however, has no such subgroup transfer:
 
 /-- A subgroup of the homeomorphism group acts continuously on `E` in the point, reusing
-continuity of the ambient action. -/
+continuity of the ambient action. Mathlib transfers `MulAction` and `FaithfulSMul` to a
+subgroup but not `ContinuousConstSMul`, so we record it here. -/
 instance applySubgroupContinuousConstSMul (H : Subgroup (E ≃ₜ E)) : ContinuousConstSMul H E :=
   ⟨fun φ => continuous_const_smul (φ : E ≃ₜ E)⟩
 

--- a/TauCeti/Topology/Algebra/HomeomorphAction.lean
+++ b/TauCeti/Topology/Algebra/HomeomorphAction.lean
@@ -45,6 +45,18 @@ instance applyFaithfulSMul : FaithfulSMul (E ≃ₜ E) E :=
 instance applyContinuousConstSMul : ContinuousConstSMul (E ≃ₜ E) E :=
   ⟨fun φ => φ.continuous⟩
 
+/-- A subgroup of the homeomorphism group acts faithfully on `E`. Mathlib transfers the
+`MulAction` to a subgroup of `E ≃ₜ E` but not faithfulness, so we record it here from the
+ambient faithful action. Any `Subgroup (E ≃ₜ E)` — e.g. the deck transformation group of a
+map — inherits this rather than carrying its own instance. -/
+instance applySubgroupFaithfulSMul (H : Subgroup (E ≃ₜ E)) : FaithfulSMul H E :=
+  ⟨fun h => Subtype.ext <| eq_of_smul_eq_smul h⟩
+
+/-- A subgroup of the homeomorphism group acts continuously on `E` in the point, reusing
+continuity of the ambient action. -/
+instance applySubgroupContinuousConstSMul (H : Subgroup (E ≃ₜ E)) : ContinuousConstSMul H E :=
+  ⟨fun φ => continuous_const_smul (φ : E ≃ₜ E)⟩
+
 end Homeomorph
 
 end TauCeti


### PR DESCRIPTION
This PR adds the deck transformation subgroup `Deck p` for a map `p : E → B`, advancing the Universal Covers roadmap Stage 0.4, “Deck transformation group” in `TauCetiRoadmap/UniversalCovers/README.md`. It adds the inherited action on the total space, fibre-preservation API, a fibre equivalence, and faithful/continuous action instances needed before packaging deck groups of covering projections; it vendors no Mathlib code, and credits Kim Morrison's mathlib4#40135 for the construction shape while reusing Mathlib's `Homeomorph`, `Subgroup`, `FaithfulSMul`, and `ContinuousConstSMul` infrastructure.

🤖 Prepared with Claude Code.