### PR TITLE
feat: package Hopf algebra points functor

### DIFF
--- a/TauCeti/Algebra/AlgebraicGroup/FunctorOfPoints.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/FunctorOfPoints.lean
@@ -79,7 +79,7 @@ end HopfAlgebra
 
 namespace AlgHom
 
-universe u
+universe u v w
 
 variable {R H A : Type*} [CommSemiring R]
 
@@ -194,13 +194,13 @@ end Bialgebra
 
 section BialgebraFunctor
 
-variable {R H : Type u} [CommRing R] [Semiring H] [_root_.Bialgebra R H]
+variable {R : Type u} {H : Type v} [CommRing R] [Semiring H] [_root_.Bialgebra R H]
 
 /-- The functor of points of a bialgebra, valued in monoids: a commutative `R`-algebra `A`
 is sent to the convolution monoid of `R`-algebra homomorphisms `H →ₐ[R] A`, and a morphism
 `φ : A ⟶ B` is sent to post-composition with `φ`. -/
-noncomputable def convMonoidFunctor (R H : Type u) [CommRing R] [Semiring H]
-    [_root_.Bialgebra R H] : CommAlgCat.{u} R ⥤ MonCat.{u} where
+noncomputable def convMonoidFunctor (R : Type u) (H : Type v) [CommRing R] [Semiring H]
+    [_root_.Bialgebra R H] : CommAlgCat.{w} R ⥤ MonCat.{max v w} where
   obj A := MonCat.of (WithConv (H →ₐ[R] A))
   map {A B} φ := MonCat.ofHom (mapValue φ.hom)
   map_id A := by
@@ -212,18 +212,18 @@ noncomputable def convMonoidFunctor (R H : Type u) [CommRing R] [Semiring H]
 
 /-- On objects, `convMonoidFunctor` is the convolution monoid of algebra homomorphisms. -/
 @[simp]
-lemma convMonoidFunctor_obj (A : CommAlgCat.{u} R) :
+lemma convMonoidFunctor_obj (A : CommAlgCat.{w} R) :
     (convMonoidFunctor R H).obj A = MonCat.of (WithConv (H →ₐ[R] A)) := rfl
 
 /-- On morphisms, `convMonoidFunctor` is post-composition in the value algebra. -/
 @[simp]
-lemma convMonoidFunctor_map {A B : CommAlgCat.{u} R} (φ : A ⟶ B) :
+lemma convMonoidFunctor_map {A B : CommAlgCat.{w} R} (φ : A ⟶ B) :
     (convMonoidFunctor R H).map φ = MonCat.ofHom (mapValue φ.hom) := rfl
 
 /-- Pointwise, `convMonoidFunctor` maps a point by post-composition with the target
 algebra morphism. -/
 @[simp]
-lemma convMonoidFunctor_map_apply {A B : CommAlgCat.{u} R} (φ : A ⟶ B)
+lemma convMonoidFunctor_map_apply {A B : CommAlgCat.{w} R} (φ : A ⟶ B)
     (f : WithConv (H →ₐ[R] A)) :
     (convMonoidFunctor R H).map φ f = toConv (φ.hom.comp f.ofConv) := rfl
 
@@ -231,14 +231,14 @@ end BialgebraFunctor
 
 section HopfFunctor
 
-variable {R H : Type u} [CommRing R] [Semiring H] [_root_.HopfAlgebra R H]
+variable {R : Type u} {H : Type v} [CommRing R] [Semiring H] [_root_.HopfAlgebra R H]
 
 /-- The functor of points of a Hopf algebra, valued in groups: a commutative `R`-algebra `A`
 is sent to the convolution group of `R`-algebra homomorphisms `H →ₐ[R] A`, and a morphism
 `φ : A ⟶ B` is sent to post-composition with `φ`. For a commutative Hopf algebra `H`, this
 is the usual functor of points of the affine group scheme `Spec H`. -/
-noncomputable def convGroupFunctor (R H : Type u) [CommRing R] [Semiring H]
-    [_root_.HopfAlgebra R H] : CommAlgCat.{u} R ⥤ GrpCat.{u} where
+noncomputable def convGroupFunctor (R : Type u) (H : Type v) [CommRing R] [Semiring H]
+    [_root_.HopfAlgebra R H] : CommAlgCat.{w} R ⥤ GrpCat.{max v w} where
   obj A := GrpCat.of (WithConv (H →ₐ[R] A))
   map {A B} φ := GrpCat.ofHom (mapValue φ.hom)
   map_id A := by
@@ -250,18 +250,18 @@ noncomputable def convGroupFunctor (R H : Type u) [CommRing R] [Semiring H]
 
 /-- On objects, `convGroupFunctor` is the convolution group of algebra homomorphisms. -/
 @[simp]
-lemma convGroupFunctor_obj (A : CommAlgCat.{u} R) :
+lemma convGroupFunctor_obj (A : CommAlgCat.{w} R) :
     (convGroupFunctor R H).obj A = GrpCat.of (WithConv (H →ₐ[R] A)) := rfl
 
 /-- On morphisms, `convGroupFunctor` is post-composition in the value algebra. -/
 @[simp]
-lemma convGroupFunctor_map {A B : CommAlgCat.{u} R} (φ : A ⟶ B) :
+lemma convGroupFunctor_map {A B : CommAlgCat.{w} R} (φ : A ⟶ B) :
     (convGroupFunctor R H).map φ = GrpCat.ofHom (mapValue φ.hom) := rfl
 
 /-- Pointwise, `convGroupFunctor` maps a point by post-composition with the target algebra
 morphism. -/
 @[simp]
-lemma convGroupFunctor_map_apply {A B : CommAlgCat.{u} R} (φ : A ⟶ B)
+lemma convGroupFunctor_map_apply {A B : CommAlgCat.{w} R} (φ : A ⟶ B)
     (f : WithConv (H →ₐ[R] A)) :
     (convGroupFunctor R H).map φ f = toConv (φ.hom.comp f.ofConv) := rfl
 
@@ -269,7 +269,11 @@ lemma convGroupFunctor_map_apply {A B : CommAlgCat.{u} R} (φ : A ⟶ B)
 bialgebra-valued convolution monoid functor. -/
 @[simp]
 lemma convGroupFunctor_comp_forget₂ :
-    convGroupFunctor R H ⋙ forget₂ GrpCat MonCat = convMonoidFunctor R H := rfl
+    (convGroupFunctor R H : CommAlgCat.{w} R ⥤ GrpCat.{max v w}) ⋙ forget₂ GrpCat MonCat =
+      (convMonoidFunctor R H : CommAlgCat.{w} R ⥤ MonCat.{max v w}) := by
+  -- After forgetting from groups to monoids, the object and map fields are exactly the
+  -- bialgebra functor fields: both maps are `mapValue φ.hom`.
+  rfl
 
 end HopfFunctor
 

--- a/TauCeti/Algebra/AlgebraicGroup/FunctorOfPoints.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/FunctorOfPoints.lean
@@ -4,6 +4,8 @@ Released under Apache 2.0 license as described in the file LICENSE.
 -/
 import Mathlib.RingTheory.Bialgebra.Convolution
 import Mathlib.RingTheory.HopfAlgebra.Basic
+import Mathlib.Algebra.Category.CommAlgCat.Basic
+import Mathlib.Algebra.Category.Grp.Basic
 
 /-!
 # Convolution groups of algebra homomorphisms out of a Hopf algebra
@@ -42,6 +44,9 @@ as inverse.
 * `AlgHom.mapValue`: post-composition with `φ : A →ₐ[R] B` as a monoid homomorphism of
   convolution monoids, with `AlgHom.mapValue_id`, `AlgHom.mapValue_comp` recording its
   functoriality in the value algebra.
+* `AlgHom.convMonoidFunctor`: the functor from commutative `R`-algebras to monoids carried
+  by `A ↦ WithConv (H →ₐ[R] A)` for a bialgebra `H`.
+* `AlgHom.convGroupFunctor`: the same functor landing in groups when `H` is a Hopf algebra.
 
 ## References
 
@@ -51,6 +56,7 @@ Yaël Dillies, Michał Mrugała and Yunzhou Xie in Mathlib.
 -/
 
 open Coalgebra HopfAlgebra TensorProduct WithConv
+open CategoryTheory
 
 namespace TauCeti
 
@@ -72,6 +78,8 @@ lemma antipode_convMul_id :
 end HopfAlgebra
 
 namespace AlgHom
+
+universe u
 
 variable {R H A : Type*} [CommSemiring R]
 
@@ -183,6 +191,87 @@ lemma mapValue_comp (ψ : B →ₐ[R] C) (φ : A →ₐ[R] B) :
     AlgHom.comp_assoc]
 
 end Bialgebra
+
+section BialgebraFunctor
+
+variable {R H : Type u} [CommRing R] [Semiring H] [_root_.Bialgebra R H]
+
+/-- The functor of points of a bialgebra, valued in monoids: a commutative `R`-algebra `A`
+is sent to the convolution monoid of `R`-algebra homomorphisms `H →ₐ[R] A`, and a morphism
+`φ : A ⟶ B` is sent to post-composition with `φ`. -/
+noncomputable def convMonoidFunctor (R H : Type u) [CommRing R] [Semiring H]
+    [_root_.Bialgebra R H] : CommAlgCat.{u} R ⥤ MonCat.{u} where
+  obj A := MonCat.of (WithConv (H →ₐ[R] A))
+  map {A B} φ := MonCat.ofHom (mapValue φ.hom)
+  map_id A := by
+    ext f
+    simp
+  map_comp {A B C} φ ψ := by
+    ext f
+    simp [AlgHom.comp_assoc]
+
+/-- On objects, `convMonoidFunctor` is the convolution monoid of algebra homomorphisms. -/
+@[simp]
+lemma convMonoidFunctor_obj (A : CommAlgCat.{u} R) :
+    (convMonoidFunctor R H).obj A = MonCat.of (WithConv (H →ₐ[R] A)) := rfl
+
+/-- On morphisms, `convMonoidFunctor` is post-composition in the value algebra. -/
+@[simp]
+lemma convMonoidFunctor_map {A B : CommAlgCat.{u} R} (φ : A ⟶ B) :
+    (convMonoidFunctor R H).map φ = MonCat.ofHom (mapValue φ.hom) := rfl
+
+/-- Pointwise, `convMonoidFunctor` maps a point by post-composition with the target
+algebra morphism. -/
+@[simp]
+lemma convMonoidFunctor_map_apply {A B : CommAlgCat.{u} R} (φ : A ⟶ B)
+    (f : WithConv (H →ₐ[R] A)) :
+    (convMonoidFunctor R H).map φ f = toConv (φ.hom.comp f.ofConv) := rfl
+
+end BialgebraFunctor
+
+section HopfFunctor
+
+variable {R H : Type u} [CommRing R] [Semiring H] [_root_.HopfAlgebra R H]
+
+/-- The functor of points of a Hopf algebra, valued in groups: a commutative `R`-algebra `A`
+is sent to the convolution group of `R`-algebra homomorphisms `H →ₐ[R] A`, and a morphism
+`φ : A ⟶ B` is sent to post-composition with `φ`. For a commutative Hopf algebra `H`, this
+is the usual functor of points of the affine group scheme `Spec H`. -/
+noncomputable def convGroupFunctor (R H : Type u) [CommRing R] [Semiring H]
+    [_root_.HopfAlgebra R H] : CommAlgCat.{u} R ⥤ GrpCat.{u} where
+  obj A := GrpCat.of (WithConv (H →ₐ[R] A))
+  map {A B} φ := GrpCat.ofHom (mapValue φ.hom)
+  map_id A := by
+    ext f
+    simp
+  map_comp {A B C} φ ψ := by
+    ext f
+    simp [AlgHom.comp_assoc]
+
+/-- On objects, `convGroupFunctor` is the convolution group of algebra homomorphisms. -/
+@[simp]
+lemma convGroupFunctor_obj (A : CommAlgCat.{u} R) :
+    (convGroupFunctor R H).obj A = GrpCat.of (WithConv (H →ₐ[R] A)) := rfl
+
+/-- On morphisms, `convGroupFunctor` is post-composition in the value algebra. -/
+@[simp]
+lemma convGroupFunctor_map {A B : CommAlgCat.{u} R} (φ : A ⟶ B) :
+    (convGroupFunctor R H).map φ = GrpCat.ofHom (mapValue φ.hom) := rfl
+
+/-- Pointwise, `convGroupFunctor` maps a point by post-composition with the target algebra
+morphism. -/
+@[simp]
+lemma convGroupFunctor_map_apply {A B : CommAlgCat.{u} R} (φ : A ⟶ B)
+    (f : WithConv (H →ₐ[R] A)) :
+    (convGroupFunctor R H).map φ f = toConv (φ.hom.comp f.ofConv) := rfl
+
+/-- Forgetting the group structure of the Hopf-algebra functor of points recovers the
+bialgebra-valued convolution monoid functor. -/
+@[simp]
+lemma convGroupFunctor_comp_forget₂ :
+    convGroupFunctor R H ⋙ forget₂ GrpCat MonCat = convMonoidFunctor R H := rfl
+
+end HopfFunctor
 
 section CommHopf
 

--- a/TauCeti/Algebra/AlgebraicGroup/FunctorOfPoints.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/FunctorOfPoints.lean
@@ -271,8 +271,8 @@ bialgebra-valued convolution monoid functor. -/
 lemma convGroupFunctor_comp_forget₂ :
     (convGroupFunctor R H : CommAlgCat.{w} R ⥤ GrpCat.{max v w}) ⋙ forget₂ GrpCat MonCat =
       (convMonoidFunctor R H : CommAlgCat.{w} R ⥤ MonCat.{max v w}) := by
-  -- After forgetting from groups to monoids, the object and map fields are exactly the
-  -- bialgebra functor fields: both maps are `mapValue φ.hom`.
+  refine CategoryTheory.Functor.ext (fun A => rfl) (fun A B φ => ?_)
+  change MonCat.ofHom (mapValue φ.hom) = MonCat.ofHom (mapValue φ.hom)
   rfl
 
 end HopfFunctor

--- a/TauCeti/Algebra/AlgebraicGroup/FunctorOfPoints.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/FunctorOfPoints.lean
@@ -271,9 +271,11 @@ bialgebra-valued convolution monoid functor. -/
 lemma convGroupFunctor_comp_forget₂ :
     (convGroupFunctor R H : CommAlgCat.{w} R ⥤ GrpCat.{max v w}) ⋙ forget₂ GrpCat MonCat =
       (convMonoidFunctor R H : CommAlgCat.{w} R ⥤ MonCat.{max v w}) := by
-  refine CategoryTheory.Functor.ext (fun A => rfl) (fun A B φ => ?_)
-  change MonCat.ofHom (mapValue φ.hom) = MonCat.ofHom (mapValue φ.hom)
-  rfl
+  refine CategoryTheory.Functor.hext (fun A => rfl) (fun A B φ => ?_)
+  apply heq_of_eq
+  apply MonCat.hom_ext
+  ext f
+  simp [convGroupFunctor, convMonoidFunctor]
 
 end HopfFunctor
 


### PR DESCRIPTION
This PR packages the ReductiveGroups Layer 0 functor-of-points API as bundled category-theoretic functors. It advances the exact roadmap target in TauCetiRoadmap/ReductiveGroups/README.md, Layer 0, "R-points as a group": generalize AlgPoints R A for commutative value algebras, give the points their convolution group structure, and prove functoriality in the value algebra.

It adds AlgHom.convMonoidFunctor for bialgebras, landing in MonCat, and AlgHom.convGroupFunctor for Hopf algebras, landing in GrpCat. The object and morphism simp lemmas identify these functors with the existing convolution monoids/groups and post-composition maps, while convGroupFunctor_comp_forget₂ records that forgetting the group structure recovers the bialgebra monoid-valued functor.

No Mathlib infrastructure is vendored. The construction builds directly on Mathlib's convolution monoid for algebra homomorphisms, CommAlgCat, MonCat, and GrpCat, and on the existing TauCeti convolution inverse and mapValue API in TauCeti/Algebra/AlgebraicGroup/FunctorOfPoints.lean.

Validated with lake exe cache get, lake build, and lake exe axioms.

🤖 Prepared with Codex