### PR TITLE
feat: add Hopf points functor

### DIFF
--- a/TauCeti/Algebra/AlgebraicGroup/PointsFunctor.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/PointsFunctor.lean
@@ -89,26 +89,6 @@ lemma pointsFunctor_map_apply_apply {A B : CommAlgCat.{w} R} (φ : A ⟶ B)
       φ.hom (f.ofConv h) :=
   rfl
 
-/-- The points functor sends identity morphisms to identity maps. -/
-@[simp]
-lemma pointsFunctor_map_id (A : CommAlgCat.{w} R) :
-    (pointsFunctor (R := R) H).map (𝟙 A) =
-      𝟙 ((pointsFunctor (R := R) H).obj A) :=
-  (pointsFunctor (R := R) H).map_id A
-
-/-- The points functor sends composition of value-algebra maps to composition of group maps. -/
-@[simp]
-lemma pointsFunctor_map_comp {A B C : CommAlgCat.{w} R} (φ : A ⟶ B) (ψ : B ⟶ C) :
-    (pointsFunctor (R := R) H).map (φ ≫ ψ) =
-      (pointsFunctor (R := R) H).map φ ≫ (pointsFunctor (R := R) H).map ψ :=
-  (pointsFunctor (R := R) H).map_comp φ ψ
-
-/-- Multiplication in `points H A` is the convolution product. -/
-lemma points_mul_apply (A : CommAlgCat.{w} R) (f g : points (R := R) H A) (h : H) :
-    (f * g) h =
-      Algebra.TensorProduct.lift f.ofConv g.ofConv (fun _ _ => .all ..) (Coalgebra.comul h) :=
-  AlgHom.convMul_apply f g h
-
 /-- The map on points preserves convolution products. -/
 @[simp]
 lemma pointsFunctor_map_mul {A B : CommAlgCat.{w} R} (φ : A ⟶ B)

--- a/TauCeti/Algebra/AlgebraicGroup/PointsFunctor.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/PointsFunctor.lean
@@ -31,58 +31,51 @@ namespace TauCeti
 
 namespace HopfAlgebra
 
-universe u
+universe u v w
 
-variable {R H : Type u} [CommRing R] [Semiring H] [_root_.HopfAlgebra R H]
+variable {R : Type u} {H : Type v} [CommRing R] [Semiring H] [_root_.HopfAlgebra R H]
 
 /-- The convolution group of `A`-valued points of a Hopf algebra `H` over `R`.
 
 An element of `points H A` is an `R`-algebra homomorphism `H →ₐ[R] A`; multiplication is
 convolution, the identity is the counit, and inverse is post-composition with the antipode.
 -/
-abbrev points (H : Type u) [Semiring H] [_root_.HopfAlgebra R H] (A : CommAlgCat.{u} R) :
-    Type u :=
+abbrev points (H : Type v) [Semiring H] [_root_.HopfAlgebra R H] (A : CommAlgCat.{w} R) :
+    Type (max v w) :=
   WithConv (H →ₐ[R] A)
-
-noncomputable instance instGroupPoints (A : CommAlgCat.{u} R) : Group (points (R := R) H A) :=
-  inferInstanceAs (Group (WithConv (H →ₐ[R] A)))
 
 /-- The group-valued functor of points of a Hopf algebra.
 
 For a commutative `R`-algebra `A`, its value is the convolution group of algebra
 homomorphisms `H →ₐ[R] A`.  A morphism `A ⟶ B` acts by post-composition. -/
-noncomputable def pointsFunctor (H : Type u) [Semiring H] [_root_.HopfAlgebra R H] :
-    CommAlgCat.{u} R ⥤ GrpCat.{u} where
+noncomputable def pointsFunctor (H : Type v) [Semiring H] [_root_.HopfAlgebra R H] :
+    CommAlgCat.{w} R ⥤ GrpCat.{max v w} where
   obj A := GrpCat.of (points (R := R) H A)
   map {A B} φ := GrpCat.ofHom (TauCeti.AlgHom.mapValue (H := H) φ.hom)
   map_id A := by
     refine GrpCat.ext fun f => ?_
-    change TauCeti.AlgHom.mapValue (H := H) (AlgHom.id R A) f = f
-    rw [TauCeti.AlgHom.mapValue_id]
-    rfl
+    exact congrFun (congrArg DFunLike.coe (TauCeti.AlgHom.mapValue_id (H := H) (A := A))) f
   map_comp {A B C} φ ψ := by
     refine GrpCat.ext fun f => ?_
-    change TauCeti.AlgHom.mapValue (H := H) (ψ.hom.comp φ.hom) f =
-      TauCeti.AlgHom.mapValue (H := H) ψ.hom (TauCeti.AlgHom.mapValue (H := H) φ.hom f)
-    rw [TauCeti.AlgHom.mapValue_comp]
-    rfl
+    exact congrFun
+      (congrArg DFunLike.coe (TauCeti.AlgHom.mapValue_comp (H := H) ψ.hom φ.hom)) f
 
 /-- The functor of points sends `A` to the convolution group of algebra maps `H →ₐ[R] A`. -/
 @[simp]
-lemma pointsFunctor_obj (A : CommAlgCat.{u} R) :
+lemma pointsFunctor_obj (A : CommAlgCat.{w} R) :
     (pointsFunctor (R := R) H).obj A = GrpCat.of (points (R := R) H A) :=
   rfl
 
 /-- The functor of points sends a map of value algebras to post-composition. -/
 @[simp]
-lemma pointsFunctor_map {A B : CommAlgCat.{u} R} (φ : A ⟶ B) :
+lemma pointsFunctor_map {A B : CommAlgCat.{w} R} (φ : A ⟶ B) :
     (pointsFunctor (R := R) H).map φ =
       GrpCat.ofHom (TauCeti.AlgHom.mapValue (H := H) φ.hom) :=
   rfl
 
 /-- Pointwise, the functor of points acts on morphisms by post-composition. -/
 @[simp]
-lemma pointsFunctor_map_apply {A B : CommAlgCat.{u} R} (φ : A ⟶ B)
+lemma pointsFunctor_map_apply {A B : CommAlgCat.{w} R} (φ : A ⟶ B)
     (f : (pointsFunctor (R := R) H).obj A) :
     ((pointsFunctor (R := R) H).map φ f : WithConv (H →ₐ[R] B)) =
       toConv (φ.hom.comp f.ofConv) :=
@@ -90,7 +83,7 @@ lemma pointsFunctor_map_apply {A B : CommAlgCat.{u} R} (φ : A ⟶ B)
 
 /-- Evaluation after applying the functor of points is ordinary post-composition. -/
 @[simp]
-lemma pointsFunctor_map_apply_apply {A B : CommAlgCat.{u} R} (φ : A ⟶ B)
+lemma pointsFunctor_map_apply_apply {A B : CommAlgCat.{w} R} (φ : A ⟶ B)
     (f : (pointsFunctor (R := R) H).obj A) (h : H) :
     ((pointsFunctor (R := R) H).map φ f : WithConv (H →ₐ[R] B)).ofConv h =
       φ.hom (f.ofConv h) :=
@@ -98,33 +91,27 @@ lemma pointsFunctor_map_apply_apply {A B : CommAlgCat.{u} R} (φ : A ⟶ B)
 
 /-- The points functor sends identity morphisms to identity maps. -/
 @[simp]
-lemma pointsFunctor_map_id (A : CommAlgCat.{u} R) :
+lemma pointsFunctor_map_id (A : CommAlgCat.{w} R) :
     (pointsFunctor (R := R) H).map (𝟙 A) =
       𝟙 ((pointsFunctor (R := R) H).obj A) :=
   (pointsFunctor (R := R) H).map_id A
 
 /-- The points functor sends composition of value-algebra maps to composition of group maps. -/
 @[simp]
-lemma pointsFunctor_map_comp {A B C : CommAlgCat.{u} R} (φ : A ⟶ B) (ψ : B ⟶ C) :
+lemma pointsFunctor_map_comp {A B C : CommAlgCat.{w} R} (φ : A ⟶ B) (ψ : B ⟶ C) :
     (pointsFunctor (R := R) H).map (φ ≫ ψ) =
       (pointsFunctor (R := R) H).map φ ≫ (pointsFunctor (R := R) H).map ψ :=
   (pointsFunctor (R := R) H).map_comp φ ψ
 
-/-- The identity element of `points H A` is the counit followed by `algebraMap R A`. -/
-@[simp]
-lemma points_one_apply (A : CommAlgCat.{u} R) (h : H) :
-    (1 : points (R := R) H A) h = algebraMap R A (Coalgebra.counit h) :=
-  rfl
-
-/-- The inverse in `points H A` is post-composition with the Hopf-algebra antipode. -/
-@[simp]
-lemma points_inv_apply (A : CommAlgCat.{u} R) (f : points (R := R) H A) (h : H) :
-    f⁻¹ h = f.ofConv (antipode R h) :=
-  TauCeti.AlgHom.convInv_apply f h
+/-- Multiplication in `points H A` is the convolution product. -/
+lemma points_mul_apply (A : CommAlgCat.{w} R) (f g : points (R := R) H A) (h : H) :
+    (f * g) h =
+      Algebra.TensorProduct.lift f.ofConv g.ofConv (fun _ _ => .all ..) (Coalgebra.comul h) :=
+  AlgHom.convMul_apply f g h
 
 /-- The map on points preserves convolution products. -/
 @[simp]
-lemma pointsFunctor_map_mul {A B : CommAlgCat.{u} R} (φ : A ⟶ B)
+lemma pointsFunctor_map_mul {A B : CommAlgCat.{w} R} (φ : A ⟶ B)
     (f g : (pointsFunctor (R := R) H).obj A) :
     (pointsFunctor (R := R) H).map φ (f * g) =
       (pointsFunctor (R := R) H).map φ f * (pointsFunctor (R := R) H).map φ g :=
@@ -132,13 +119,13 @@ lemma pointsFunctor_map_mul {A B : CommAlgCat.{u} R} (φ : A ⟶ B)
 
 /-- The map on points preserves the identity point. -/
 @[simp]
-lemma pointsFunctor_map_one {A B : CommAlgCat.{u} R} (φ : A ⟶ B) :
+lemma pointsFunctor_map_one {A B : CommAlgCat.{w} R} (φ : A ⟶ B) :
     (pointsFunctor (R := R) H).map φ (1 : (pointsFunctor (R := R) H).obj A) = 1 :=
   map_one (TauCeti.AlgHom.mapValue (H := H) φ.hom)
 
 /-- The map on points preserves inverses. -/
 @[simp]
-lemma pointsFunctor_map_inv {A B : CommAlgCat.{u} R} (φ : A ⟶ B)
+lemma pointsFunctor_map_inv {A B : CommAlgCat.{w} R} (φ : A ⟶ B)
     (f : (pointsFunctor (R := R) H).obj A) :
     (pointsFunctor (R := R) H).map φ f⁻¹ =
       ((pointsFunctor (R := R) H).map φ f)⁻¹ :=
@@ -146,7 +133,7 @@ lemma pointsFunctor_map_inv {A B : CommAlgCat.{u} R} (φ : A ⟶ B)
 
 /-- The map on points preserves quotients in the convolution group. -/
 @[simp]
-lemma pointsFunctor_map_div {A B : CommAlgCat.{u} R} (φ : A ⟶ B)
+lemma pointsFunctor_map_div {A B : CommAlgCat.{w} R} (φ : A ⟶ B)
     (f g : (pointsFunctor (R := R) H).obj A) :
     (pointsFunctor (R := R) H).map φ (f / g) =
       (pointsFunctor (R := R) H).map φ f / (pointsFunctor (R := R) H).map φ g :=

--- a/TauCeti/Algebra/AlgebraicGroup/PointsFunctor.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/PointsFunctor.lean
@@ -1,0 +1,157 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+import Mathlib.Algebra.Category.CommAlgCat.Basic
+import Mathlib.Algebra.Category.Grp.Basic
+import TauCeti.Algebra.AlgebraicGroup.FunctorOfPoints
+
+/-!
+# The functor of points of a Hopf algebra
+
+The reductive-groups roadmap asks for the functor of points of an affine group scheme in
+Layer 0.  The file `TauCeti.Algebra.AlgebraicGroup.FunctorOfPoints` proves the algebraic
+ingredient: for a Hopf algebra `H` over `R` and a commutative `R`-algebra `A`, the
+convolution monoid on `H →ₐ[R] A` is a group, and post-composition in `A` is compatible
+with convolution.
+
+This file packages that data as the bundled functor
+`HopfAlgebra.pointsFunctor H : CommAlgCat R ⥤ GrpCat`.  On objects it sends `A` to the
+convolution group `WithConv (H →ₐ[R] A)`, and on morphisms it sends
+`φ : A ⟶ B` to post-composition with `φ`.
+
+This is not yet the full scheme-side representability statement.  It is the concrete
+`R`-algebra valued group functor that the affine group scheme `Spec H` represents when `H`
+is commutative.
+-/
+
+open CategoryTheory Coalgebra HopfAlgebra WithConv
+
+namespace TauCeti
+
+namespace HopfAlgebra
+
+universe u
+
+variable {R H : Type u} [CommRing R] [Semiring H] [_root_.HopfAlgebra R H]
+
+/-- The convolution group of `A`-valued points of a Hopf algebra `H` over `R`.
+
+An element of `points H A` is an `R`-algebra homomorphism `H →ₐ[R] A`; multiplication is
+convolution, the identity is the counit, and inverse is post-composition with the antipode.
+-/
+abbrev points (H : Type u) [Semiring H] [_root_.HopfAlgebra R H] (A : CommAlgCat.{u} R) :
+    Type u :=
+  WithConv (H →ₐ[R] A)
+
+noncomputable instance instGroupPoints (A : CommAlgCat.{u} R) : Group (points (R := R) H A) :=
+  inferInstanceAs (Group (WithConv (H →ₐ[R] A)))
+
+/-- The group-valued functor of points of a Hopf algebra.
+
+For a commutative `R`-algebra `A`, its value is the convolution group of algebra
+homomorphisms `H →ₐ[R] A`.  A morphism `A ⟶ B` acts by post-composition. -/
+noncomputable def pointsFunctor (H : Type u) [Semiring H] [_root_.HopfAlgebra R H] :
+    CommAlgCat.{u} R ⥤ GrpCat.{u} where
+  obj A := GrpCat.of (points (R := R) H A)
+  map {A B} φ := GrpCat.ofHom (TauCeti.AlgHom.mapValue (H := H) φ.hom)
+  map_id A := by
+    refine GrpCat.ext fun f => ?_
+    change TauCeti.AlgHom.mapValue (H := H) (AlgHom.id R A) f = f
+    rw [TauCeti.AlgHom.mapValue_id]
+    rfl
+  map_comp {A B C} φ ψ := by
+    refine GrpCat.ext fun f => ?_
+    change TauCeti.AlgHom.mapValue (H := H) (ψ.hom.comp φ.hom) f =
+      TauCeti.AlgHom.mapValue (H := H) ψ.hom (TauCeti.AlgHom.mapValue (H := H) φ.hom f)
+    rw [TauCeti.AlgHom.mapValue_comp]
+    rfl
+
+/-- The functor of points sends `A` to the convolution group of algebra maps `H →ₐ[R] A`. -/
+@[simp]
+lemma pointsFunctor_obj (A : CommAlgCat.{u} R) :
+    (pointsFunctor (R := R) H).obj A = GrpCat.of (points (R := R) H A) :=
+  rfl
+
+/-- The functor of points sends a map of value algebras to post-composition. -/
+@[simp]
+lemma pointsFunctor_map {A B : CommAlgCat.{u} R} (φ : A ⟶ B) :
+    (pointsFunctor (R := R) H).map φ =
+      GrpCat.ofHom (TauCeti.AlgHom.mapValue (H := H) φ.hom) :=
+  rfl
+
+/-- Pointwise, the functor of points acts on morphisms by post-composition. -/
+@[simp]
+lemma pointsFunctor_map_apply {A B : CommAlgCat.{u} R} (φ : A ⟶ B)
+    (f : (pointsFunctor (R := R) H).obj A) :
+    ((pointsFunctor (R := R) H).map φ f : WithConv (H →ₐ[R] B)) =
+      toConv (φ.hom.comp f.ofConv) :=
+  rfl
+
+/-- Evaluation after applying the functor of points is ordinary post-composition. -/
+@[simp]
+lemma pointsFunctor_map_apply_apply {A B : CommAlgCat.{u} R} (φ : A ⟶ B)
+    (f : (pointsFunctor (R := R) H).obj A) (h : H) :
+    ((pointsFunctor (R := R) H).map φ f : WithConv (H →ₐ[R] B)).ofConv h =
+      φ.hom (f.ofConv h) :=
+  rfl
+
+/-- The points functor sends identity morphisms to identity maps. -/
+@[simp]
+lemma pointsFunctor_map_id (A : CommAlgCat.{u} R) :
+    (pointsFunctor (R := R) H).map (𝟙 A) =
+      𝟙 ((pointsFunctor (R := R) H).obj A) :=
+  (pointsFunctor (R := R) H).map_id A
+
+/-- The points functor sends composition of value-algebra maps to composition of group maps. -/
+@[simp]
+lemma pointsFunctor_map_comp {A B C : CommAlgCat.{u} R} (φ : A ⟶ B) (ψ : B ⟶ C) :
+    (pointsFunctor (R := R) H).map (φ ≫ ψ) =
+      (pointsFunctor (R := R) H).map φ ≫ (pointsFunctor (R := R) H).map ψ :=
+  (pointsFunctor (R := R) H).map_comp φ ψ
+
+/-- The identity element of `points H A` is the counit followed by `algebraMap R A`. -/
+@[simp]
+lemma points_one_apply (A : CommAlgCat.{u} R) (h : H) :
+    (1 : points (R := R) H A) h = algebraMap R A (Coalgebra.counit h) :=
+  rfl
+
+/-- The inverse in `points H A` is post-composition with the Hopf-algebra antipode. -/
+@[simp]
+lemma points_inv_apply (A : CommAlgCat.{u} R) (f : points (R := R) H A) (h : H) :
+    f⁻¹ h = f.ofConv (antipode R h) :=
+  TauCeti.AlgHom.convInv_apply f h
+
+/-- The map on points preserves convolution products. -/
+@[simp]
+lemma pointsFunctor_map_mul {A B : CommAlgCat.{u} R} (φ : A ⟶ B)
+    (f g : (pointsFunctor (R := R) H).obj A) :
+    (pointsFunctor (R := R) H).map φ (f * g) =
+      (pointsFunctor (R := R) H).map φ f * (pointsFunctor (R := R) H).map φ g :=
+  map_mul (TauCeti.AlgHom.mapValue (H := H) φ.hom) f g
+
+/-- The map on points preserves the identity point. -/
+@[simp]
+lemma pointsFunctor_map_one {A B : CommAlgCat.{u} R} (φ : A ⟶ B) :
+    (pointsFunctor (R := R) H).map φ (1 : (pointsFunctor (R := R) H).obj A) = 1 :=
+  map_one (TauCeti.AlgHom.mapValue (H := H) φ.hom)
+
+/-- The map on points preserves inverses. -/
+@[simp]
+lemma pointsFunctor_map_inv {A B : CommAlgCat.{u} R} (φ : A ⟶ B)
+    (f : (pointsFunctor (R := R) H).obj A) :
+    (pointsFunctor (R := R) H).map φ f⁻¹ =
+      ((pointsFunctor (R := R) H).map φ f)⁻¹ :=
+  map_inv (TauCeti.AlgHom.mapValue (H := H) φ.hom) f
+
+/-- The map on points preserves quotients in the convolution group. -/
+@[simp]
+lemma pointsFunctor_map_div {A B : CommAlgCat.{u} R} (φ : A ⟶ B)
+    (f g : (pointsFunctor (R := R) H).obj A) :
+    (pointsFunctor (R := R) H).map φ (f / g) =
+      (pointsFunctor (R := R) H).map φ f / (pointsFunctor (R := R) H).map φ g :=
+  map_div (TauCeti.AlgHom.mapValue (H := H) φ.hom) f g
+
+end HopfAlgebra
+
+end TauCeti


### PR DESCRIPTION
This PR packages the convolution group of algebra homomorphisms out of a Hopf algebra as the bundled functor `HopfAlgebra.pointsFunctor : CommAlgCat R ⥤ GrpCat`, advancing the ReductiveGroups roadmap target Layer 0, “R-points as a group,” specifically the requirement to prove functoriality in the value algebra `R`. It adds the characteristic object, map, pointwise evaluation, identity, inverse, multiplication, and division lemmas for the functor-of-points API. It vendors no Mathlib infrastructure; it consumes Mathlib’s `CommAlgCat`, `GrpCat`, and the convolution monoid API from `Mathlib.RingTheory.Bialgebra.Convolution`, building on TauCeti’s existing Hopf-algebra convolution group construction.

🤖 Prepared with Codex