### PR TITLE
feat: add monodromy fiber action

### DIFF
--- a/TauCeti.lean
+++ b/TauCeti.lean
@@ -3,4 +3,6 @@
 -- Everything reachable from here must be sorry-free, and must not import
 -- `TauCetiRoadmap` or `TauCetiReview` (both enforced in CI). As the library
 -- grows, import the submodules of `TauCeti/` here.
+import TauCeti.AlgebraicTopology.FundamentalGroup
+import TauCeti.AlgebraicTopology.UniversalCover.MonodromyAction
 import TauCeti.Basic

--- a/TauCeti/AlgebraicTopology/FundamentalGroup.lean
+++ b/TauCeti/AlgebraicTopology/FundamentalGroup.lean
@@ -1,0 +1,60 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+import Mathlib.AlgebraicTopology.FundamentalGroupoid.FundamentalGroup
+
+/-!
+# Fundamental group path representatives
+
+This file records small API lemmas for the path-homotopy-class representative of an element
+of Mathlib's `FundamentalGroup`.
+-/
+
+namespace TauCeti
+
+open FundamentalGroup
+
+variable {X : Type*} [TopologicalSpace X] {x : X}
+
+/-- The identity element of the fundamental group is represented by the constant path. -/
+lemma fundamentalGroup_toPath_one :
+    (1 : FundamentalGroup X x).toPath = Path.Homotopic.Quotient.refl x :=
+  by
+    -- `FundamentalGroup.toPath` is the endomorphism hom coerced through
+    -- `End.asHom`; Mathlib has no named `toPath_one` lemma, so expose that
+    -- definitional bridge before using the categorical identity lemma.
+    change CategoryTheory.End.asHom
+      (1 : CategoryTheory.End (FundamentalGroupoid.mk x)) =
+      Path.Homotopic.Quotient.refl x
+    rw [CategoryTheory.End.one_def, FundamentalGroupoid.id_eq_path_refl]
+    -- The previous rewrite leaves the raw quotient constructor, while
+    -- `Path.Homotopic.Quotient.refl` is a wrapper around the same class.
+    change Path.Homotopic.Quotient.mk (Path.refl x) = Path.Homotopic.Quotient.refl x
+    rw [Path.Homotopic.Quotient.mk_refl]
+
+/-- Mathlib's multiplication convention for fundamental-group loops as path homotopy classes.
+
+The fundamental group is the endomorphism group of a fundamental-groupoid object, so
+multiplication follows categorical endomorphism multiplication. On path homotopy classes this
+means `γ * δ` is represented by first traversing `δ`, then `γ`. -/
+lemma fundamentalGroup_toPath_mul (γ δ : FundamentalGroup X x) :
+    (γ * δ).toPath = Path.Homotopic.Quotient.trans δ.toPath γ.toPath :=
+  by
+    -- There is no named Mathlib lemma bridging `(γ * δ).toPath` to
+    -- endomorphism multiplication, so first expose the underlying hom in the
+    -- fundamental groupoid and then use the named category/path lemmas below.
+    change (γ * δ : FundamentalGroupoid.mk x ⟶ FundamentalGroupoid.mk x) =
+      Path.Homotopic.Quotient.trans δ.toPath γ.toPath
+    calc
+      (γ * δ : FundamentalGroupoid.mk x ⟶ FundamentalGroupoid.mk x)
+          = CategoryTheory.CategoryStruct.comp
+              (δ : FundamentalGroupoid.mk x ⟶ FundamentalGroupoid.mk x)
+              (γ : FundamentalGroupoid.mk x ⟶ FundamentalGroupoid.mk x) := by
+            exact CategoryTheory.End.mul_def
+              (xs := (γ : CategoryTheory.End (FundamentalGroupoid.mk x)))
+              (ys := (δ : CategoryTheory.End (FundamentalGroupoid.mk x)))
+      _ = Path.Homotopic.Quotient.trans δ.toPath γ.toPath := by
+            rw [FundamentalGroupoid.comp_eq]
+
+end TauCeti

--- a/TauCeti/AlgebraicTopology/FundamentalGroup.lean
+++ b/TauCeti/AlgebraicTopology/FundamentalGroup.lean
@@ -18,6 +18,7 @@ open FundamentalGroup
 variable {X : Type*} [TopologicalSpace X] {x : X}
 
 /-- The identity element of the fundamental group is represented by the constant path. -/
+@[simp]
 lemma fundamentalGroup_toPath_one :
     (1 : FundamentalGroup X x).toPath = Path.Homotopic.Quotient.refl x :=
   by
@@ -38,6 +39,7 @@ lemma fundamentalGroup_toPath_one :
 The fundamental group is the endomorphism group of a fundamental-groupoid object, so
 multiplication follows categorical endomorphism multiplication. On path homotopy classes this
 means `γ * δ` is represented by first traversing `δ`, then `γ`. -/
+@[simp]
 lemma fundamentalGroup_toPath_mul (γ δ : FundamentalGroup X x) :
     (γ * δ).toPath = Path.Homotopic.Quotient.trans δ.toPath γ.toPath :=
   by

--- a/TauCeti/AlgebraicTopology/UniversalCover/MonodromyAction.lean
+++ b/TauCeti/AlgebraicTopology/UniversalCover/MonodromyAction.lean
@@ -28,10 +28,15 @@ variable {X : Type*} [TopologicalSpace X] {x : X}
 lemma fundamentalGroup_toPath_one :
     (1 : FundamentalGroup X x).toPath = Path.Homotopic.Quotient.refl x :=
   by
+    -- `FundamentalGroup.toPath` is the endomorphism hom coerced through
+    -- `End.asHom`; Mathlib has no named `toPath_one` lemma, so expose that
+    -- definitional bridge before using the categorical identity lemma.
     change CategoryTheory.End.asHom
       (1 : CategoryTheory.End (FundamentalGroupoid.mk x)) =
       Path.Homotopic.Quotient.refl x
     rw [CategoryTheory.End.one_def, FundamentalGroupoid.id_eq_path_refl]
+    -- The previous rewrite leaves the raw quotient constructor, while
+    -- `Path.Homotopic.Quotient.refl` is a wrapper around the same class.
     change Path.Homotopic.Quotient.mk (Path.refl x) = Path.Homotopic.Quotient.refl x
     rw [Path.Homotopic.Quotient.mk_refl]
 
@@ -43,6 +48,9 @@ means `γ * δ` is represented by first traversing `δ`, then `γ`. -/
 lemma fundamentalGroup_toPath_mul (γ δ : FundamentalGroup X x) :
     (γ * δ).toPath = Path.Homotopic.Quotient.trans δ.toPath γ.toPath :=
   by
+    -- There is no named Mathlib lemma bridging `(γ * δ).toPath` to
+    -- endomorphism multiplication, so first expose the underlying hom in the
+    -- fundamental groupoid and then use the named category/path lemmas below.
     change (γ * δ : FundamentalGroupoid.mk x ⟶ FundamentalGroupoid.mk x) =
       Path.Homotopic.Quotient.trans δ.toPath γ.toPath
     calc

--- a/TauCeti/AlgebraicTopology/UniversalCover/MonodromyAction.lean
+++ b/TauCeti/AlgebraicTopology/UniversalCover/MonodromyAction.lean
@@ -27,7 +27,13 @@ variable {X : Type*} [TopologicalSpace X] {x : X}
 /-- The identity element of the fundamental group is represented by the constant path. -/
 lemma fundamentalGroup_toPath_one :
     (1 : FundamentalGroup X x).toPath = Path.Homotopic.Quotient.refl x :=
-  rfl
+  by
+    change CategoryTheory.End.asHom
+      (1 : CategoryTheory.End (FundamentalGroupoid.mk x)) =
+      Path.Homotopic.Quotient.refl x
+    rw [CategoryTheory.End.one_def, FundamentalGroupoid.id_eq_path_refl]
+    change Path.Homotopic.Quotient.mk (Path.refl x) = Path.Homotopic.Quotient.refl x
+    rw [Path.Homotopic.Quotient.mk_refl]
 
 /-- Mathlib's multiplication convention for fundamental-group loops as path homotopy classes.
 
@@ -36,7 +42,19 @@ multiplication follows categorical endomorphism multiplication. On path homotopy
 means `γ * δ` is represented by first traversing `δ`, then `γ`. -/
 lemma fundamentalGroup_toPath_mul (γ δ : FundamentalGroup X x) :
     (γ * δ).toPath = Path.Homotopic.Quotient.trans δ.toPath γ.toPath :=
-  rfl
+  by
+    change (γ * δ : FundamentalGroupoid.mk x ⟶ FundamentalGroupoid.mk x) =
+      Path.Homotopic.Quotient.trans δ.toPath γ.toPath
+    calc
+      (γ * δ : FundamentalGroupoid.mk x ⟶ FundamentalGroupoid.mk x)
+          = CategoryTheory.CategoryStruct.comp
+              (δ : FundamentalGroupoid.mk x ⟶ FundamentalGroupoid.mk x)
+              (γ : FundamentalGroupoid.mk x ⟶ FundamentalGroupoid.mk x) := by
+            exact CategoryTheory.End.mul_def
+              (xs := (γ : CategoryTheory.End (FundamentalGroupoid.mk x)))
+              (ys := (δ : CategoryTheory.End (FundamentalGroupoid.mk x)))
+      _ = Path.Homotopic.Quotient.trans δ.toPath γ.toPath := by
+            rw [FundamentalGroupoid.comp_eq]
 
 /-- The map on fundamental groups is represented by mapping the underlying path homotopy class. -/
 lemma fundamentalGroup_map_toPath {Y : Type*} [TopologicalSpace Y] (f : C(X, Y))

--- a/TauCeti/AlgebraicTopology/UniversalCover/MonodromyAction.lean
+++ b/TauCeti/AlgebraicTopology/UniversalCover/MonodromyAction.lean
@@ -3,6 +3,7 @@ Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 -/
 import Mathlib.Topology.Homotopy.Lifting
+import TauCeti.AlgebraicTopology.FundamentalGroup
 
 /-!
 # The monodromy action on a fibre
@@ -21,54 +22,6 @@ group, and Stage 2 proposes the classification of connected covers through trans
 namespace TauCeti
 
 open FundamentalGroup
-
-variable {X : Type*} [TopologicalSpace X] {x : X}
-
-/-- The identity element of the fundamental group is represented by the constant path. -/
-lemma fundamentalGroup_toPath_one :
-    (1 : FundamentalGroup X x).toPath = Path.Homotopic.Quotient.refl x :=
-  by
-    -- `FundamentalGroup.toPath` is the endomorphism hom coerced through
-    -- `End.asHom`; Mathlib has no named `toPath_one` lemma, so expose that
-    -- definitional bridge before using the categorical identity lemma.
-    change CategoryTheory.End.asHom
-      (1 : CategoryTheory.End (FundamentalGroupoid.mk x)) =
-      Path.Homotopic.Quotient.refl x
-    rw [CategoryTheory.End.one_def, FundamentalGroupoid.id_eq_path_refl]
-    -- The previous rewrite leaves the raw quotient constructor, while
-    -- `Path.Homotopic.Quotient.refl` is a wrapper around the same class.
-    change Path.Homotopic.Quotient.mk (Path.refl x) = Path.Homotopic.Quotient.refl x
-    rw [Path.Homotopic.Quotient.mk_refl]
-
-/-- Mathlib's multiplication convention for fundamental-group loops as path homotopy classes.
-
-The fundamental group is the endomorphism group of a fundamental-groupoid object, so
-multiplication follows categorical endomorphism multiplication. On path homotopy classes this
-means `γ * δ` is represented by first traversing `δ`, then `γ`. -/
-lemma fundamentalGroup_toPath_mul (γ δ : FundamentalGroup X x) :
-    (γ * δ).toPath = Path.Homotopic.Quotient.trans δ.toPath γ.toPath :=
-  by
-    -- There is no named Mathlib lemma bridging `(γ * δ).toPath` to
-    -- endomorphism multiplication, so first expose the underlying hom in the
-    -- fundamental groupoid and then use the named category/path lemmas below.
-    change (γ * δ : FundamentalGroupoid.mk x ⟶ FundamentalGroupoid.mk x) =
-      Path.Homotopic.Quotient.trans δ.toPath γ.toPath
-    calc
-      (γ * δ : FundamentalGroupoid.mk x ⟶ FundamentalGroupoid.mk x)
-          = CategoryTheory.CategoryStruct.comp
-              (δ : FundamentalGroupoid.mk x ⟶ FundamentalGroupoid.mk x)
-              (γ : FundamentalGroupoid.mk x ⟶ FundamentalGroupoid.mk x) := by
-            exact CategoryTheory.End.mul_def
-              (xs := (γ : CategoryTheory.End (FundamentalGroupoid.mk x)))
-              (ys := (δ : CategoryTheory.End (FundamentalGroupoid.mk x)))
-      _ = Path.Homotopic.Quotient.trans δ.toPath γ.toPath := by
-            rw [FundamentalGroupoid.comp_eq]
-
-/-- The map on fundamental groups is represented by mapping the underlying path homotopy class. -/
-lemma fundamentalGroup_map_toPath {Y : Type*} [TopologicalSpace Y] (f : C(X, Y))
-    (γ : FundamentalGroup X x) :
-    (map f x γ).toPath = γ.toPath.map f :=
-  FundamentalGroup.map_apply f x γ
 
 namespace IsCoveringMap
 
@@ -132,6 +85,7 @@ noncomputable def monodromyMulAction : MulAction (FundamentalGroup X x) (p ⁻¹
   MulAction.compHom _ (monodromyPermHom cov x)
 
 /-- On points, the monodromy action is Mathlib's monodromy map. -/
+@[simp]
 lemma monodromy_smul_eq (γ : FundamentalGroup X x) (e : p ⁻¹' {x}) :
     letI := monodromyMulAction cov x
     γ • e = cov.monodromy γ.toPath e :=
@@ -148,10 +102,11 @@ starting point in the fibre. -/
 @[simp]
 lemma monodromyPerm_map_self (e : E) (γ : FundamentalGroup E e) :
     monodromyPerm cov (p e) (map ⟨p, cov.continuous⟩ e γ) ⟨e, rfl⟩ = ⟨e, rfl⟩ := by
-  rw [monodromyPerm_apply, fundamentalGroup_map_toPath]
+  rw [monodromyPerm_apply, FundamentalGroup.map_apply]
   exact cov.monodromy_map γ.toPath
 
 /-- The monodromy action fixes the starting point of a lifted loop. -/
+@[simp]
 lemma map_smul_self (e : E) (γ : FundamentalGroup E e) :
     letI := monodromyMulAction cov (p e)
     map ⟨p, cov.continuous⟩ e γ • (⟨e, by simp⟩ : p ⁻¹' {p e}) = ⟨e, by simp⟩ :=

--- a/TauCeti/AlgebraicTopology/UniversalCover/MonodromyAction.lean
+++ b/TauCeti/AlgebraicTopology/UniversalCover/MonodromyAction.lean
@@ -22,6 +22,28 @@ namespace TauCeti
 
 open FundamentalGroup
 
+variable {X : Type*} [TopologicalSpace X] {x : X}
+
+/-- The identity element of the fundamental group is represented by the constant path. -/
+lemma fundamentalGroup_toPath_one :
+    (1 : FundamentalGroup X x).toPath = Path.Homotopic.Quotient.refl x :=
+  rfl
+
+/-- Mathlib's multiplication convention for fundamental-group loops as path homotopy classes.
+
+The fundamental group is the endomorphism group of a fundamental-groupoid object, so
+multiplication follows categorical endomorphism multiplication. On path homotopy classes this
+means `γ * δ` is represented by first traversing `δ`, then `γ`. -/
+lemma fundamentalGroup_toPath_mul (γ δ : FundamentalGroup X x) :
+    (γ * δ).toPath = Path.Homotopic.Quotient.trans δ.toPath γ.toPath :=
+  rfl
+
+/-- The map on fundamental groups is represented by mapping the underlying path homotopy class. -/
+lemma fundamentalGroup_map_toPath {Y : Type*} [TopologicalSpace Y] (f : C(X, Y))
+    (γ : FundamentalGroup X x) :
+    (map f x γ).toPath = γ.toPath.map f :=
+  FundamentalGroup.map_apply f x γ
+
 namespace IsCoveringMap
 
 variable {E X : Type*} [TopologicalSpace E] [TopologicalSpace X] {p : E → X}
@@ -41,7 +63,7 @@ lemma monodromyPerm_apply (γ : FundamentalGroup X x) (e : p ⁻¹' {x}) :
 @[simp]
 lemma monodromyPerm_one : monodromyPerm cov x 1 = 1 := by
   ext e
-  rw [monodromyPerm_apply]
+  rw [monodromyPerm_apply, fundamentalGroup_toPath_one]
   exact congr_arg Subtype.val (congr_fun cov.monodromy_refl e)
 
 /-- Monodromy is compatible with the multiplication convention on Mathlib's fundamental group.
@@ -53,7 +75,7 @@ convention, monodromy is a monoid homomorphism to permutations of the fibre. -/
 lemma monodromyPerm_mul (γ δ : FundamentalGroup X x) :
     monodromyPerm cov x (γ * δ) = monodromyPerm cov x γ * monodromyPerm cov x δ := by
   ext e
-  rw [monodromyPerm_apply]
+  rw [monodromyPerm_apply, fundamentalGroup_toPath_mul]
   exact congr_arg Subtype.val (cov.monodromy_trans_apply δ.toPath γ.toPath e)
 
 /-- The inverse loop acts by the inverse monodromy permutation. -/
@@ -98,16 +120,16 @@ lemma monodromy_smul_eq_monodromyPerm (γ : FundamentalGroup X x) (e : p ⁻¹' 
 /-- If a loop in the total space projects to a loop in the base, its monodromy fixes the
 starting point in the fibre. -/
 @[simp]
-lemma monodromyPerm_map_toPath (e : E) (γ : FundamentalGroup E e) :
+lemma monodromyPerm_map_self (e : E) (γ : FundamentalGroup E e) :
     monodromyPerm cov (p e) (map ⟨p, cov.continuous⟩ e γ) ⟨e, rfl⟩ = ⟨e, rfl⟩ := by
-  rw [monodromyPerm_apply]
+  rw [monodromyPerm_apply, fundamentalGroup_map_toPath]
   exact cov.monodromy_map γ.toPath
 
 /-- The monodromy action fixes the starting point of a lifted loop. -/
-lemma map_toPath_smul (e : E) (γ : FundamentalGroup E e) :
+lemma map_smul_self (e : E) (γ : FundamentalGroup E e) :
     letI := monodromyMulAction cov (p e)
     map ⟨p, cov.continuous⟩ e γ • (⟨e, by simp⟩ : p ⁻¹' {p e}) = ⟨e, by simp⟩ :=
-  monodromyPerm_map_toPath cov e γ
+  monodromyPerm_map_self cov e γ
 
 /-- A projected loop from the total space fixes its starting point under monodromy. -/
 lemma smul_eq_self_of_mem_map_range (e : E) {γ : FundamentalGroup X (p e)}
@@ -115,7 +137,7 @@ lemma smul_eq_self_of_mem_map_range (e : E) {γ : FundamentalGroup X (p e)}
     letI := monodromyMulAction cov (p e)
     γ • (⟨e, by simp⟩ : p ⁻¹' {p e}) = ⟨e, by simp⟩ := by
   rcases hγ with ⟨δ, rfl⟩
-  exact map_toPath_smul cov e δ
+  exact map_smul_self cov e δ
 
 /-- The image of the fundamental group of the total space is contained in the stabilizer of the
 chosen point in the fibre under the monodromy action. -/

--- a/TauCeti/AlgebraicTopology/UniversalCover/MonodromyAction.lean
+++ b/TauCeti/AlgebraicTopology/UniversalCover/MonodromyAction.lean
@@ -1,0 +1,132 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+import Mathlib.Topology.Homotopy.Lifting
+
+/-!
+# The monodromy action on a fibre
+
+Mathlib's covering-space API associates to a covering map `p : E → X` a monodromy functor
+from the fundamental groupoid of `X` to types. This file packages the restriction of that
+functor to a based loop as a permutation of the fibre over the basepoint, then records the
+corresponding action of `π₁(X, x)` on that fibre.
+
+This is a small prerequisite for the universal-covers roadmap: Stage 1 asks to pin the
+composition convention in the comparison between deck transformations and the fundamental
+group, and Stage 2 proposes the classification of connected covers through transitive
+`π₁`-sets and Mathlib's `monodromyFunctor`.
+-/
+
+namespace TauCeti
+
+open FundamentalGroup
+
+namespace IsCoveringMap
+
+variable {E X : Type*} [TopologicalSpace E] [TopologicalSpace X] {p : E → X}
+variable (cov : IsCoveringMap p) (x : X)
+
+/-- The monodromy of a based loop, as a permutation of the fibre over the basepoint. -/
+noncomputable def monodromyPerm (γ : FundamentalGroup X x) : Equiv.Perm (p ⁻¹' {x}) :=
+  Equiv.ofBijective (cov.monodromy γ.toPath) (cov.monodromy_bijective γ.toPath)
+
+/-- The monodromy permutation is Mathlib's monodromy map on points of the fibre. -/
+@[simp]
+lemma monodromyPerm_apply (γ : FundamentalGroup X x) (e : p ⁻¹' {x}) :
+    monodromyPerm cov x γ e = cov.monodromy γ.toPath e :=
+  rfl
+
+/-- The identity loop acts by the identity permutation of the fibre. -/
+@[simp]
+lemma monodromyPerm_one : monodromyPerm cov x 1 = 1 := by
+  ext e
+  rw [monodromyPerm_apply]
+  exact congr_arg Subtype.val (congr_fun cov.monodromy_refl e)
+
+/-- Monodromy is compatible with the multiplication convention on Mathlib's fundamental group.
+
+The fundamental group is the endomorphism group of the basepoint in the fundamental groupoid;
+its multiplication is the endomorphism multiplication from category theory. With that
+convention, monodromy is a monoid homomorphism to permutations of the fibre. -/
+@[simp]
+lemma monodromyPerm_mul (γ δ : FundamentalGroup X x) :
+    monodromyPerm cov x (γ * δ) = monodromyPerm cov x γ * monodromyPerm cov x δ := by
+  ext e
+  rw [monodromyPerm_apply]
+  exact congr_arg Subtype.val (cov.monodromy_trans_apply δ.toPath γ.toPath e)
+
+/-- The inverse loop acts by the inverse monodromy permutation. -/
+@[simp]
+lemma monodromyPerm_inv (γ : FundamentalGroup X x) :
+    monodromyPerm cov x γ⁻¹ = (monodromyPerm cov x γ)⁻¹ := by
+  rw [eq_inv_iff_mul_eq_one, ← monodromyPerm_mul, inv_mul_cancel, monodromyPerm_one]
+
+/-- The monodromy representation of the fundamental group on the fibre over the basepoint. -/
+noncomputable def monodromyPermHom : FundamentalGroup X x →* Equiv.Perm (p ⁻¹' {x}) where
+  toFun := monodromyPerm cov x
+  map_one' := monodromyPerm_one cov x
+  map_mul' := monodromyPerm_mul cov x
+
+/-- The monodromy homomorphism evaluates to the monodromy permutation. -/
+@[simp]
+lemma monodromyPermHom_apply (γ : FundamentalGroup X x) :
+    monodromyPermHom cov x γ = monodromyPerm cov x γ :=
+  rfl
+
+/-- A covering map's fundamental group action on a fibre by monodromy.
+
+Use this locally with `letI := cov.monodromyMulAction x` when treating the fibre as a
+`π₁(X, x)`-set. It is a named definition rather than a global instance because the covering-map
+proof `cov` is not inferable from the action type. -/
+@[reducible]
+noncomputable def monodromyMulAction : MulAction (FundamentalGroup X x) (p ⁻¹' {x}) :=
+  MulAction.compHom _ (monodromyPermHom cov x)
+
+/-- On points, the monodromy action is Mathlib's monodromy map. -/
+lemma monodromy_smul_eq (γ : FundamentalGroup X x) (e : p ⁻¹' {x}) :
+    letI := monodromyMulAction cov x
+    γ • e = cov.monodromy γ.toPath e :=
+  rfl
+
+/-- The monodromy action agrees with the monodromy permutation. -/
+lemma monodromy_smul_eq_monodromyPerm (γ : FundamentalGroup X x) (e : p ⁻¹' {x}) :
+    letI := monodromyMulAction cov x
+    γ • e = monodromyPerm cov x γ e :=
+  rfl
+
+/-- If a loop in the total space projects to a loop in the base, its monodromy fixes the
+starting point in the fibre. -/
+@[simp]
+lemma monodromyPerm_map_toPath (e : E) (γ : FundamentalGroup E e) :
+    monodromyPerm cov (p e) (map ⟨p, cov.continuous⟩ e γ) ⟨e, rfl⟩ = ⟨e, rfl⟩ := by
+  rw [monodromyPerm_apply]
+  exact cov.monodromy_map γ.toPath
+
+/-- The monodromy action fixes the starting point of a lifted loop. -/
+lemma map_toPath_smul (e : E) (γ : FundamentalGroup E e) :
+    letI := monodromyMulAction cov (p e)
+    map ⟨p, cov.continuous⟩ e γ • (⟨e, by simp⟩ : p ⁻¹' {p e}) = ⟨e, by simp⟩ :=
+  monodromyPerm_map_toPath cov e γ
+
+/-- A projected loop from the total space fixes its starting point under monodromy. -/
+lemma smul_eq_self_of_mem_map_range (e : E) {γ : FundamentalGroup X (p e)}
+    (hγ : γ ∈ (map ⟨p, cov.continuous⟩ e).range) :
+    letI := monodromyMulAction cov (p e)
+    γ • (⟨e, by simp⟩ : p ⁻¹' {p e}) = ⟨e, by simp⟩ := by
+  rcases hγ with ⟨δ, rfl⟩
+  exact map_toPath_smul cov e δ
+
+/-- The image of the fundamental group of the total space is contained in the stabilizer of the
+chosen point in the fibre under the monodromy action. -/
+lemma map_range_le_stabilizer (e : E) :
+    letI := monodromyMulAction cov (p e)
+    (map ⟨p, cov.continuous⟩ e).range ≤
+      MulAction.stabilizer (FundamentalGroup X (p e)) (⟨e, by simp⟩ : p ⁻¹' {p e}) := by
+  intro γ hγ
+  letI := monodromyMulAction cov (p e)
+  exact MulAction.mem_stabilizer_iff.mpr (smul_eq_self_of_mem_map_range cov e hγ)
+
+end IsCoveringMap
+
+end TauCeti


### PR DESCRIPTION
This PR records the monodromy action of a covering map on a fibre, advancing `TauCetiRoadmap/UniversalCovers/README.md` Stage 1 (`Deck(proj) ≃* π₁(X, x₀)`, including the composition-convention check) and Stage 2 item 8 (classification through transitive `π₁`-sets / Mathlib's `monodromyFunctor`). It packages each based loop as a permutation of the fibre, proves the multiplication convention used by Mathlib's `FundamentalGroup`, exposes the induced local action, and records that the image of `π₁(E,e)` under `p_*` lies in the stabilizer of `e` under monodromy.

No Mathlib infrastructure is vendored. The file consumes Mathlib's `IsCoveringMap.monodromy`, `IsCoveringMap.monodromy_bijective`, `IsCoveringMap.monodromy_map`, and `FundamentalGroup.map` from `Mathlib.Topology.Homotopy.Lifting` / `Mathlib.AlgebraicTopology.FundamentalGroupoid.FundamentalGroup`.

Verified with `lake exe cache get`, `lake build`, and `lake exe axioms`.

🤖 Prepared with Codex