### PR TITLE
feat: add Hopf algebra points functor

### DIFF
--- a/TauCeti/Algebra/AlgebraicGroup/FunctorOfPoints.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/FunctorOfPoints.lean
@@ -248,6 +248,7 @@ lemma one_hom_apply (h : H) :
   AlgHom.convOne_apply h
 
 /-- Pointwise, multiplication of points is convolution along the comultiplication. -/
+@[simp]
 lemma mul_hom_apply (f g : AlgPoints R H A) (h : H) :
     (f * g).hom h =
       Algebra.TensorProduct.lift f.hom g.hom (fun _ _ => .all ..) (comul h) :=

--- a/TauCeti/Algebra/AlgebraicGroup/FunctorOfPoints.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/FunctorOfPoints.lean
@@ -42,6 +42,8 @@ as inverse.
 * `AlgHom.mapValue`: post-composition with `φ : A →ₐ[R] B` as a monoid homomorphism of
   convolution monoids, with `AlgHom.mapValue_id`, `AlgHom.mapValue_comp` recording its
   functoriality in the value algebra.
+* `Bialgebra.AlgPoints`: a named type for `A`-points of a bialgebra, with constructor
+  `Bialgebra.AlgPoints.ofHom` and eliminator `Bialgebra.AlgPoints.hom`.
 
 ## References
 
@@ -196,5 +198,51 @@ noncomputable instance instCommGroup : CommGroup (WithConv (H →ₐ[R] A)) wher
 end CommHopf
 
 end AlgHom
+
+namespace Bialgebra
+
+universe u v w
+
+variable (R : Type u) (H : Type v) [CommSemiring R] [Semiring H] [_root_.Bialgebra R H]
+
+/-- The `A`-points represented by a bialgebra `H` over `R`.
+
+This is the type of `R`-algebra homomorphisms `H →ₐ[R] A`, equipped with the convolution
+monoid structure. When `H` is a Hopf algebra this monoid is the convolution group used by
+`HopfAlgebra.pointsFunctor`. The source algebra `H` is allowed to be noncommutative here; for
+the usual affine group-scheme interpretation one later adds commutativity of `H` so that
+`Spec H` exists as an affine scheme over `R`. -/
+abbrev AlgPoints (R : Type u) (H : Type v) [CommSemiring R] [Semiring H]
+    [_root_.Bialgebra R H] (A : Type w) [CommSemiring A] [Algebra R A] :
+    Type (max v w) :=
+  WithConv (H →ₐ[R] A)
+
+namespace AlgPoints
+
+variable {R : Type u} {H : Type v} [CommSemiring R] [Semiring H] [_root_.Bialgebra R H]
+variable {A : Type w} [CommSemiring A] [Algebra R A]
+
+/-- Build a point from an algebra homomorphism out of the representing bialgebra. -/
+abbrev ofHom (f : H →ₐ[R] A) : AlgPoints R H A :=
+  toConv f
+
+/-- The underlying algebra homomorphism of a point of a bialgebra. -/
+abbrev hom (f : AlgPoints R H A) : H →ₐ[R] A :=
+  f.ofConv
+
+/-- Building a point from an algebra homomorphism and taking its underlying homomorphism
+recovers the original algebra homomorphism. -/
+@[simp]
+lemma ofHom_hom (f : H →ₐ[R] A) : (ofHom f : AlgPoints R H A).hom = f :=
+  rfl
+
+/-- A point is recovered from its underlying algebra homomorphism. -/
+@[simp]
+lemma ofHom_hom_self (f : AlgPoints R H A) : ofHom f.hom = f :=
+  rfl
+
+end AlgPoints
+
+end Bialgebra
 
 end TauCeti

--- a/TauCeti/Algebra/AlgebraicGroup/FunctorOfPoints.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/FunctorOfPoints.lean
@@ -233,13 +233,38 @@ abbrev hom (f : AlgPoints R H A) : H →ₐ[R] A :=
 /-- Building a point from an algebra homomorphism and taking its underlying homomorphism
 recovers the original algebra homomorphism. -/
 @[simp]
-lemma ofHom_hom (f : H →ₐ[R] A) : (ofHom f : AlgPoints R H A).hom = f :=
+lemma hom_ofHom (f : H →ₐ[R] A) : (ofHom f : AlgPoints R H A).hom = f :=
   rfl
 
 /-- A point is recovered from its underlying algebra homomorphism. -/
 @[simp]
-lemma ofHom_hom_self (f : AlgPoints R H A) : ofHom f.hom = f :=
+lemma ofHom_hom (f : AlgPoints R H A) : ofHom f.hom = f :=
   rfl
+
+/-- The identity point is the counit followed by the structure map of the value algebra. -/
+@[simp]
+lemma one_hom_apply (h : H) :
+    (1 : AlgPoints R H A).hom h = algebraMap R A (counit h) :=
+  AlgHom.convOne_apply h
+
+/-- Pointwise, multiplication of points is convolution along the comultiplication. -/
+lemma mul_hom_apply (f g : AlgPoints R H A) (h : H) :
+    (f * g).hom h =
+      Algebra.TensorProduct.lift f.hom g.hom (fun _ _ => .all ..) (comul h) :=
+  AlgHom.convMul_apply f g h
+
+end AlgPoints
+
+namespace AlgPoints
+
+variable {R : Type u} {H : Type v} [CommSemiring R] [Semiring H] [_root_.HopfAlgebra R H]
+variable {A : Type w} [CommSemiring A] [Algebra R A]
+
+/-- Pointwise, the inverse of a point is precomposition with the antipode. -/
+@[simp]
+lemma inv_hom_apply (f : AlgPoints R H A) (h : H) :
+    (f⁻¹).hom h = f.hom (antipode R h) :=
+  AlgHom.convInv_apply f h
 
 end AlgPoints
 

--- a/TauCeti/Algebra/AlgebraicGroup/PointsFunctor.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/PointsFunctor.lean
@@ -24,64 +24,13 @@ reductive-groups roadmap. The convolution monoid and inverse are provided by the
 Tau Ceti file, which in turn builds on Mathlib's convolution API.
 -/
 
-open CategoryTheory WithConv
+open CategoryTheory
 
 namespace TauCeti
 
 namespace HopfAlgebra
 
-universe u v w x y
-
-variable (R : Type u) (H : Type v) [CommSemiring R] [Semiring H] [_root_.Bialgebra R H]
-
-/-- The `A`-points represented by a bialgebra `H` over `R`.
-
-This is the type of `R`-algebra homomorphisms `H →ₐ[R] A`, equipped with the convolution
-monoid structure. When `H` is a Hopf algebra this monoid is the convolution group used by
-`pointsFunctor`. The source algebra `H` is allowed to be noncommutative here; for the usual
-affine group-scheme interpretation one later adds commutativity of `H` so that `Spec H` exists
-as an affine scheme over `R`. -/
-abbrev AlgPoints (R : Type u) (H : Type v) [CommSemiring R] [Semiring H]
-    [_root_.Bialgebra R H] (A : Type w) [CommSemiring A] [Algebra R A] : Type (max v w) :=
-  WithConv (H →ₐ[R] A)
-
-namespace AlgPoints
-
-variable {R : Type u} {H : Type v} [CommSemiring R] [Semiring H] [_root_.Bialgebra R H]
-variable {A : Type w} {B : Type x} {C : Type y} [CommSemiring A] [Algebra R A]
-  [CommSemiring B] [Algebra R B] [CommSemiring C] [Algebra R C]
-
-/-- The underlying algebra homomorphism of a point of a Hopf algebra. -/
-abbrev hom (f : AlgPoints R H A) : H →ₐ[R] A :=
-  f.ofConv
-
-/-- Post-composition in the value algebra gives the functorial map on points. -/
-noncomputable abbrev map (φ : A →ₐ[R] B) : AlgPoints R H A →* AlgPoints R H B :=
-  AlgHom.mapValue (H := H) φ
-
-/-- The map on points induced by `φ : A →ₐ[R] B` is post-composition by `φ`. -/
-@[simp]
-lemma map_apply (φ : A →ₐ[R] B) (f : AlgPoints R H A) :
-    map (H := H) φ f = toConv (φ.comp f.hom) :=
-  rfl
-
-/-- On underlying functions, `map φ` sends `f` to `φ ∘ f`. -/
-@[simp]
-lemma map_apply_apply (φ : A →ₐ[R] B) (f : AlgPoints R H A) (h : H) :
-    map (H := H) φ f h = φ (f.hom h) :=
-  rfl
-
-/-- Mapping points along the identity algebra homomorphism is the identity. -/
-@[simp]
-lemma map_id : map (H := H) (AlgHom.id R A) = MonoidHom.id (AlgPoints R H A) :=
-  AlgHom.mapValue_id (H := H)
-
-/-- Mapping points is compatible with composition in the value algebra. -/
-lemma map_comp (ψ : B →ₐ[R] C) (φ : A →ₐ[R] B) :
-    map (H := H) (ψ.comp φ) = (map ψ).comp (map φ) :=
-  AlgHom.mapValue_comp (H := H) ψ φ
-
-end AlgPoints
+universe u v w
 
 /-- The functor of points of a Hopf algebra, valued in groups via convolution.
 
@@ -89,12 +38,12 @@ It sends a commutative `R`-algebra `A` to the convolution group of algebra maps
 `H →ₐ[R] A`, and sends `φ : A ⟶ B` to post-composition with `φ`. -/
 noncomputable def pointsFunctor (R : Type u) (H : Type v) [CommRing R] [Semiring H]
     [_root_.HopfAlgebra R H] : CommAlgCat.{w} R ⥤ GrpCat.{max v w} where
-  obj A := GrpCat.of (AlgPoints R H A)
-  map {A B} φ := GrpCat.ofHom (AlgPoints.map (H := H) φ.hom)
+  obj A := GrpCat.of (TauCeti.Bialgebra.AlgPoints R H A)
+  map {A B} φ := GrpCat.ofHom (AlgHom.mapValue (H := H) φ.hom)
   map_id A := by
-    rw [CommAlgCat.hom_id, AlgPoints.map_id, GrpCat.ofHom_id]
+    rw [CommAlgCat.hom_id, AlgHom.mapValue_id, GrpCat.ofHom_id]
   map_comp φ ψ := by
-    rw [CommAlgCat.hom_comp, AlgPoints.map_comp, GrpCat.ofHom_comp]
+    rw [CommAlgCat.hom_comp, AlgHom.mapValue_comp, GrpCat.ofHom_comp]
 
 namespace pointsFunctor
 
@@ -104,25 +53,29 @@ variable {A B : Type w} [CommRing A] [Algebra R A] [CommRing B] [Algebra R B]
 /-- Evaluating the points functor at `A` gives the convolution group of `A`-points. -/
 @[simp]
 lemma obj_of :
-    (pointsFunctor R H).obj (CommAlgCat.of R A) = GrpCat.of (AlgPoints R H A) :=
+    (pointsFunctor R H).obj (CommAlgCat.of R A) =
+      GrpCat.of (TauCeti.Bialgebra.AlgPoints R H A) :=
   rfl
 
-/-- The morphism induced by an algebra map on the points functor is `AlgPoints.map`. -/
+/-- The morphism induced by an algebra map on the points functor is `AlgHom.mapValue`. -/
 @[simp]
 lemma map_ofHom_hom (φ : A →ₐ[R] B) :
-    ((pointsFunctor R H).map (CommAlgCat.ofHom φ)).hom = AlgPoints.map (H := H) φ :=
+    ((pointsFunctor R H).map (CommAlgCat.ofHom φ)).hom = AlgHom.mapValue (H := H) φ :=
   rfl
 
 /-- Pointwise, the points functor acts by post-composition. -/
 @[simp]
-lemma map_ofHom_apply (φ : A →ₐ[R] B) (f : AlgPoints R H A) :
-    (pointsFunctor R H).map (CommAlgCat.ofHom φ) f = toConv (φ.comp f.hom) :=
+lemma map_ofHom_apply (φ : A →ₐ[R] B) (f : TauCeti.Bialgebra.AlgPoints R H A) :
+    (pointsFunctor R H).map (CommAlgCat.ofHom φ) f =
+      TauCeti.Bialgebra.AlgPoints.ofHom (φ.comp f.hom) :=
   rfl
 
 /-- Pointwise on `H`, the points functor acts by applying the value-algebra morphism. -/
 @[simp]
-lemma map_ofHom_apply_apply (φ : A →ₐ[R] B) (f : AlgPoints R H A) (h : H) :
-    ((pointsFunctor R H).map (CommAlgCat.ofHom φ) f : AlgPoints R H B).hom h =
+lemma map_ofHom_apply_apply (φ : A →ₐ[R] B)
+    (f : TauCeti.Bialgebra.AlgPoints R H A) (h : H) :
+    ((pointsFunctor R H).map (CommAlgCat.ofHom φ) f :
+        TauCeti.Bialgebra.AlgPoints R H B).hom h =
       φ (f.hom h) :=
   rfl
 

--- a/TauCeti/Algebra/AlgebraicGroup/PointsFunctor.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/PointsFunctor.lean
@@ -1,0 +1,130 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+import TauCeti.Algebra.AlgebraicGroup.FunctorOfPoints
+import Mathlib.Algebra.Category.CommAlgCat.Basic
+import Mathlib.Algebra.Category.Grp.Basic
+
+/-!
+# The functor of points of a Hopf algebra
+
+This file packages the convolution group from
+`TauCeti.Algebra.AlgebraicGroup.FunctorOfPoints` as the functor of points of a Hopf algebra.
+For a Hopf algebra `H` over a commutative ring `R`, its `A`-points are the `R`-algebra maps
+`H →ₐ[R] A`, with multiplication given by convolution. Post-composition in the value algebra
+then gives a functor
+
+```
+CommAlgCat R ⥤ GrpCat
+```
+
+This is the categorical form of the "R-points as a group" item in Layer 0 of the Tau Ceti
+reductive-groups roadmap. The convolution monoid and inverse are provided by the preceding
+Tau Ceti file, which in turn builds on Mathlib's convolution API.
+-/
+
+open CategoryTheory WithConv
+
+namespace TauCeti
+
+namespace HopfAlgebra
+
+universe u
+
+variable (R H : Type u) [CommRing R] [Ring H] [_root_.HopfAlgebra R H]
+
+/-- The `A`-points of the affine group represented by a Hopf algebra `H` over `R`.
+
+This is the type of `R`-algebra homomorphisms `H →ₐ[R] A`, equipped with the convolution group
+structure. The source algebra `H` is allowed to be noncommutative here; for the usual affine
+group-scheme interpretation one later adds commutativity of `H` so that `Spec H` exists as an
+affine scheme over `R`. -/
+abbrev AlgPoints (A : Type u) [CommRing A] [Algebra R A] : Type u :=
+  WithConv (H →ₐ[R] A)
+
+namespace AlgPoints
+
+variable {R H : Type u} [CommRing R] [Ring H] [_root_.HopfAlgebra R H]
+variable {A B C : Type u} [CommRing A] [Algebra R A] [CommRing B] [Algebra R B]
+  [CommRing C] [Algebra R C]
+
+/-- The underlying algebra homomorphism of a point of a Hopf algebra. -/
+abbrev hom (f : AlgPoints R H A) : H →ₐ[R] A :=
+  f.ofConv
+
+/-- Post-composition in the value algebra gives the functorial map on points. -/
+noncomputable abbrev map (φ : A →ₐ[R] B) : AlgPoints R H A →* AlgPoints R H B :=
+  AlgHom.mapValue (H := H) φ
+
+/-- The map on points induced by `φ : A →ₐ[R] B` is post-composition by `φ`. -/
+@[simp]
+lemma map_apply (φ : A →ₐ[R] B) (f : AlgPoints R H A) :
+    map (H := H) φ f = toConv (φ.comp f.hom) :=
+  rfl
+
+/-- On underlying functions, `map φ` sends `f` to `φ ∘ f`. -/
+@[simp]
+lemma map_apply_apply (φ : A →ₐ[R] B) (f : AlgPoints R H A) (h : H) :
+    map (H := H) φ f h = φ (f.hom h) :=
+  rfl
+
+/-- Mapping points along the identity algebra homomorphism is the identity. -/
+@[simp]
+lemma map_id : map (H := H) (AlgHom.id R A) = MonoidHom.id (AlgPoints R H A) :=
+  AlgHom.mapValue_id (H := H)
+
+/-- Mapping points is compatible with composition in the value algebra. -/
+lemma map_comp (ψ : B →ₐ[R] C) (φ : A →ₐ[R] B) :
+    map (H := H) (ψ.comp φ) = (map ψ).comp (map φ) :=
+  AlgHom.mapValue_comp (H := H) ψ φ
+
+end AlgPoints
+
+/-- The functor of points of a Hopf algebra, valued in groups via convolution.
+
+It sends a commutative `R`-algebra `A` to the convolution group of algebra maps
+`H →ₐ[R] A`, and sends `φ : A ⟶ B` to post-composition with `φ`. -/
+noncomputable def pointsFunctor : CommAlgCat.{u} R ⥤ GrpCat.{u} where
+  obj A := GrpCat.of (AlgPoints R H A)
+  map {A B} φ := GrpCat.ofHom (AlgPoints.map (H := H) φ.hom)
+  map_id A := by
+    rw [CommAlgCat.hom_id, AlgPoints.map_id, GrpCat.ofHom_id]
+  map_comp φ ψ := by
+    rw [CommAlgCat.hom_comp, AlgPoints.map_comp, GrpCat.ofHom_comp]
+
+namespace pointsFunctor
+
+variable {R H : Type u} [CommRing R] [Ring H] [_root_.HopfAlgebra R H]
+variable {A B : Type u} [CommRing A] [Algebra R A] [CommRing B] [Algebra R B]
+
+/-- Evaluating the points functor at `A` gives the convolution group of `A`-points. -/
+@[simp]
+lemma obj_of :
+    (pointsFunctor R H).obj (CommAlgCat.of R A) = GrpCat.of (AlgPoints R H A) :=
+  rfl
+
+/-- The morphism induced by an algebra map on the points functor is `AlgPoints.map`. -/
+@[simp]
+lemma map_ofHom_hom (φ : A →ₐ[R] B) :
+    ((pointsFunctor R H).map (CommAlgCat.ofHom φ)).hom = AlgPoints.map (H := H) φ :=
+  rfl
+
+/-- Pointwise, the points functor acts by post-composition. -/
+@[simp]
+lemma map_ofHom_apply (φ : A →ₐ[R] B) (f : AlgPoints R H A) :
+    (pointsFunctor R H).map (CommAlgCat.ofHom φ) f = toConv (φ.comp f.hom) :=
+  rfl
+
+/-- Pointwise on `H`, the points functor acts by applying the value-algebra morphism. -/
+@[simp]
+lemma map_ofHom_apply_apply (φ : A →ₐ[R] B) (f : AlgPoints R H A) (h : H) :
+    ((pointsFunctor R H).map (CommAlgCat.ofHom φ) f : AlgPoints R H B).hom h =
+      φ (f.hom h) :=
+  rfl
+
+end pointsFunctor
+
+end HopfAlgebra
+
+end TauCeti

--- a/TauCeti/Algebra/AlgebraicGroup/PointsFunctor.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/PointsFunctor.lean
@@ -48,6 +48,28 @@ noncomputable def pointsFunctor (R : Type u) (H : Type v) [CommRing R] [Semiring
 namespace pointsFunctor
 
 variable {R : Type u} {H : Type v} [CommRing R] [Semiring H] [_root_.HopfAlgebra R H]
+variable {A B : CommAlgCat.{w} R}
+
+/-- The morphism induced by a bundled commutative algebra map is `AlgHom.mapValue`. -/
+@[simp]
+lemma map_hom (φ : A ⟶ B) :
+    (pointsFunctor R H).map φ = GrpCat.ofHom (AlgHom.mapValue (H := H) φ.hom) :=
+  rfl
+
+/-- Pointwise, the points functor acts by post-composition with a bundled morphism. -/
+@[simp]
+lemma map_apply (φ : A ⟶ B) (f : TauCeti.Bialgebra.AlgPoints R H A) :
+    (pointsFunctor R H).map φ f =
+      TauCeti.Bialgebra.AlgPoints.ofHom (φ.hom.comp f.hom) :=
+  rfl
+
+/-- Pointwise on `H`, the points functor applies the bundled value-algebra morphism. -/
+@[simp]
+lemma map_apply_apply (φ : A ⟶ B) (f : TauCeti.Bialgebra.AlgPoints R H A) (h : H) :
+    ((pointsFunctor R H).map φ f : TauCeti.Bialgebra.AlgPoints R H B).hom h =
+      φ.hom (f.hom h) :=
+  rfl
+
 variable {A B : Type w} [CommRing A] [Algebra R A] [CommRing B] [Algebra R B]
 
 /-- Evaluating the points functor at `A` gives the convolution group of `A`-points. -/
@@ -60,7 +82,8 @@ lemma obj_of :
 /-- The morphism induced by an algebra map on the points functor is `AlgHom.mapValue`. -/
 @[simp]
 lemma map_ofHom_hom (φ : A →ₐ[R] B) :
-    ((pointsFunctor R H).map (CommAlgCat.ofHom φ)).hom = AlgHom.mapValue (H := H) φ :=
+    (pointsFunctor R H).map (CommAlgCat.ofHom φ) =
+      GrpCat.ofHom (AlgHom.mapValue (H := H) φ) :=
   rfl
 
 /-- Pointwise, the points functor acts by post-composition. -/

--- a/TauCeti/Algebra/AlgebraicGroup/PointsFunctor.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/PointsFunctor.lean
@@ -30,24 +30,26 @@ namespace TauCeti
 
 namespace HopfAlgebra
 
-universe u
+universe u v w x y
 
-variable (R H : Type u) [CommRing R] [Ring H] [_root_.HopfAlgebra R H]
+variable (R : Type u) (H : Type v) [CommSemiring R] [Semiring H] [_root_.Bialgebra R H]
 
-/-- The `A`-points of the affine group represented by a Hopf algebra `H` over `R`.
+/-- The `A`-points represented by a bialgebra `H` over `R`.
 
-This is the type of `R`-algebra homomorphisms `H →ₐ[R] A`, equipped with the convolution group
-structure. The source algebra `H` is allowed to be noncommutative here; for the usual affine
-group-scheme interpretation one later adds commutativity of `H` so that `Spec H` exists as an
-affine scheme over `R`. -/
-abbrev AlgPoints (A : Type u) [CommRing A] [Algebra R A] : Type u :=
+This is the type of `R`-algebra homomorphisms `H →ₐ[R] A`, equipped with the convolution
+monoid structure. When `H` is a Hopf algebra this monoid is the convolution group used by
+`pointsFunctor`. The source algebra `H` is allowed to be noncommutative here; for the usual
+affine group-scheme interpretation one later adds commutativity of `H` so that `Spec H` exists
+as an affine scheme over `R`. -/
+abbrev AlgPoints (R : Type u) (H : Type v) [CommSemiring R] [Semiring H]
+    [_root_.Bialgebra R H] (A : Type w) [CommSemiring A] [Algebra R A] : Type (max v w) :=
   WithConv (H →ₐ[R] A)
 
 namespace AlgPoints
 
-variable {R H : Type u} [CommRing R] [Ring H] [_root_.HopfAlgebra R H]
-variable {A B C : Type u} [CommRing A] [Algebra R A] [CommRing B] [Algebra R B]
-  [CommRing C] [Algebra R C]
+variable {R : Type u} {H : Type v} [CommSemiring R] [Semiring H] [_root_.Bialgebra R H]
+variable {A : Type w} {B : Type x} {C : Type y} [CommSemiring A] [Algebra R A]
+  [CommSemiring B] [Algebra R B] [CommSemiring C] [Algebra R C]
 
 /-- The underlying algebra homomorphism of a point of a Hopf algebra. -/
 abbrev hom (f : AlgPoints R H A) : H →ₐ[R] A :=
@@ -85,7 +87,8 @@ end AlgPoints
 
 It sends a commutative `R`-algebra `A` to the convolution group of algebra maps
 `H →ₐ[R] A`, and sends `φ : A ⟶ B` to post-composition with `φ`. -/
-noncomputable def pointsFunctor : CommAlgCat.{u} R ⥤ GrpCat.{u} where
+noncomputable def pointsFunctor (R : Type u) (H : Type v) [CommRing R] [Semiring H]
+    [_root_.HopfAlgebra R H] : CommAlgCat.{w} R ⥤ GrpCat.{max v w} where
   obj A := GrpCat.of (AlgPoints R H A)
   map {A B} φ := GrpCat.ofHom (AlgPoints.map (H := H) φ.hom)
   map_id A := by
@@ -95,8 +98,8 @@ noncomputable def pointsFunctor : CommAlgCat.{u} R ⥤ GrpCat.{u} where
 
 namespace pointsFunctor
 
-variable {R H : Type u} [CommRing R] [Ring H] [_root_.HopfAlgebra R H]
-variable {A B : Type u} [CommRing A] [Algebra R A] [CommRing B] [Algebra R B]
+variable {R : Type u} {H : Type v} [CommRing R] [Semiring H] [_root_.HopfAlgebra R H]
+variable {A B : Type w} [CommRing A] [Algebra R A] [CommRing B] [Algebra R B]
 
 /-- Evaluating the points functor at `A` gives the convolution group of `A`-points. -/
 @[simp]


### PR DESCRIPTION
This PR packages the convolution group of algebra homomorphisms out of a Hopf algebra as the functor of points `CommAlgCat R ⥤ GrpCat`. It advances `TauCetiRoadmap/ReductiveGroups/README.md`, Layer 0, "R-points as a group", which asks for `AlgPoints R A := A →ₐ[k] R`, convolution group structure, and functoriality in the value algebra.

It adds `HopfAlgebra.AlgPoints` as the convolution group `WithConv (H →ₐ[R] A)`, `AlgPoints.map` for post-composition along value-algebra morphisms, and `HopfAlgebra.pointsFunctor` as the categorical functor. The implementation reuses TauCeti’s existing convolution-group API and Mathlib’s `CommAlgCat`/`GrpCat`; no Mathlib infrastructure is vendored.

Validated with `lake exe cache get`, `lake build`, and `lake exe axioms`.

🤖 Prepared with Codex