### PR TITLE
feat: add Hopf algebra base change API

### DIFF
--- a/TauCeti/Algebra/AlgebraicGroup/HopfBaseChange.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/HopfBaseChange.lean
@@ -13,15 +13,15 @@ base ring gives the scalar extension `S ⊗[R] A` of an `R`-Hopf algebra `A` alo
 
 The reductive-groups roadmap needs this form of base change in Layer 0, both for changing the
 base field of an affine group scheme and for comparing functors of points before and after base
-change.  The facts here keep the construction explicit: the scalar-extended antipode and counit
-are described on pure tensors.  The underlying canonical inclusion and the tensor-product
-adjunction are Mathlib's `Algebra.TensorProduct.includeRight` and `AlgHom.liftEquiv`.
+change.  This file gives the construction the roadmap-facing name `BaseChange`; the Hopf,
+bialgebra, and coalgebra API is Mathlib's tensor-product API, including
+`TensorProduct.antipode_def`, `TensorProduct.counit_tmul`, `TensorProduct.comul_tmul`,
+`Algebra.TensorProduct.includeRight`, and `AlgHom.liftEquiv`.
 
 ## Main declarations
 
-* `HopfAlgebra.BaseChange`: the scalar extension `S ⊗[R] A` of an `R`-Hopf algebra.
-* `HopfAlgebra.baseChange_antipode_tmul`: the scalar-extended antipode on a pure tensor.
-* `HopfAlgebra.baseChange_counit_tmul`: the scalar-extended counit on a pure tensor.
+* `HopfAlgebra.BaseChange`: the scalar extension `S ⊗[R] A` of an `R`-algebra, carrying the
+  tensor-product Hopf algebra structure when `A` is a Hopf algebra over `R`.
 
 ## References
 
@@ -30,7 +30,6 @@ Tau Ceti reductive-groups roadmap.  The underlying tensor-product Hopf algebra i
 Amelia Livingston and Andrew Yang in Mathlib.
 -/
 
-open Coalgebra TensorProduct
 open scoped TensorProduct
 
 namespace TauCeti
@@ -44,52 +43,6 @@ variable (R S A : Type*) [CommSemiring R] [CommSemiring S] [Algebra R S]
 structure over `S`. -/
 abbrev BaseChange [Semiring A] [Algebra R A] :=
   S ⊗[R] A
-
-variable [Semiring A] [_root_.HopfAlgebra R A]
-
-/-- The antipode on the scalar extension is obtained by extending the antipode on `A` and using
-the identity antipode on the base ring. -/
-@[simp]
-lemma baseChange_antipode_tmul (s : S) (a : A) :
-    _root_.HopfAlgebraStruct.antipode S (A := BaseChange R S A) (s ⊗ₜ[R] a) =
-      s ⊗ₜ[R] _root_.HopfAlgebraStruct.antipode R a := by
-  simp [BaseChange]
-
-/-- The counit of the scalar extension sends a pure tensor `s ⊗ a` to
-`s * algebraMap R S (ε a)`. -/
-@[simp]
-lemma baseChange_counit_tmul (s : S) (a : A) :
-    counit (R := S) (A := BaseChange R S A) (s ⊗ₜ[R] a) =
-      s * algebraMap R S (counit (R := R) a) := by
-  simp [BaseChange, Algebra.smul_def, mul_comm]
-
-/-- The comultiplication of the scalar extension on a pure tensor, stated directly in terms of
-Mathlib's tensor-product coalgebra structure. -/
-@[simp]
-lemma baseChange_comul_tmul (s : S) (a : A) :
-    comul (R := S) (A := BaseChange R S A) (s ⊗ₜ[R] a) =
-      TensorProduct.AlgebraTensorModule.tensorTensorTensorComm R S R S S S A A
-        (comul (R := S) s ⊗ₜ[R] comul (R := R) a) := by
-  rfl
-
-/-- The scalar-extended counit after the canonical inclusion is the original counit followed by
-the base map. -/
-@[simp]
-lemma baseChange_counit_includeRight (a : A) :
-    counit (R := S) (A := BaseChange R S A)
-        (Algebra.TensorProduct.includeRight (R := R) (A := S) (B := A) a) =
-      algebraMap R S (counit (R := R) a) := by
-  simp [Algebra.smul_def]
-
-/-- The scalar-extended antipode after the canonical inclusion is the canonical inclusion after
-the original antipode. -/
-@[simp]
-lemma baseChange_antipode_includeRight (a : A) :
-    _root_.HopfAlgebraStruct.antipode S (A := BaseChange R S A)
-        (Algebra.TensorProduct.includeRight (R := R) (A := S) (B := A) a) =
-      Algebra.TensorProduct.includeRight (R := R) (A := S) (B := A)
-        (_root_.HopfAlgebraStruct.antipode R a) := by
-  simp
 
 end HopfAlgebra
 

--- a/TauCeti/Algebra/AlgebraicGroup/HopfBaseChange.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/HopfBaseChange.lean
@@ -60,24 +60,32 @@ theorem inclusion_apply [Semiring A] [Algebra R A] (a : A) :
     inclusion (R := R) (S := S) a = 1 ⊗ₜ[R] a :=
   Algebra.TensorProduct.includeRight_apply a
 
+/-- The antipode on the scalar extension acts on pure tensors by applying the antipodes in
+each tensor factor. -/
 @[simp]
 theorem antipode_tmul [Semiring A] [HopfAlgebra R A] (s : S) (a : A) :
     HopfAlgebra.antipode S (s ⊗ₜ[R] a : HopfAlgebra.BaseChange R S A) =
       HopfAlgebra.antipode S s ⊗ₜ[R] HopfAlgebra.antipode R a :=
-  rfl
+  by
+    rw [TensorProduct.antipode_def]
+    rfl
 
+/-- The counit on the scalar extension evaluates a pure tensor by applying the original counit
+to the algebra factor and using the result as a scalar on the base-changed coefficient. -/
 @[simp]
 theorem counit_tmul [Semiring A] [Algebra R A] [Coalgebra R A] (s : S) (a : A) :
     Coalgebra.counit (R := S) (s ⊗ₜ[R] a : HopfAlgebra.BaseChange R S A) =
       Coalgebra.counit (R := R) a • s :=
-  rfl
+  TensorProduct.counit_tmul s a
 
+/-- The comultiplication on the scalar extension is the tensor-product comultiplication,
+reassociated by `tensorTensorTensorComm`. -/
 @[simp]
 theorem comul_tmul [Semiring A] [Algebra R A] [Coalgebra R A] (s : S) (a : A) :
     Coalgebra.comul (R := S) (s ⊗ₜ[R] a : HopfAlgebra.BaseChange R S A) =
       TensorProduct.AlgebraTensorModule.tensorTensorTensorComm R S R S S S A A
         (Coalgebra.comul (R := S) s ⊗ₜ[R] Coalgebra.comul (R := R) a) :=
-  rfl
+  TensorProduct.comul_tmul s a
 
 end BaseChange
 
@@ -98,25 +106,33 @@ def baseChangeValueEquiv : (A →ₐ[R] B) ≃ (HopfAlgebra.BaseChange R S A →
 def baseChangeValue (f : A →ₐ[R] B) : HopfAlgebra.BaseChange R S A →ₐ[S] B :=
   baseChangeValueEquiv (R := R) (S := S) f
 
+/-- The base-changed value of an algebra point sends a pure tensor to scalar multiplication by
+the coefficient followed by the original point. -/
 @[simp]
 theorem baseChangeValue_tmul (f : A →ₐ[R] B) (s : S) (a : A) :
     baseChangeValue (R := R) (S := S) f (s ⊗ₜ[R] a) = s • f a :=
-  rfl
+  _root_.AlgHom.liftEquiv_tmul f s a
 
+/-- Restricting a base-changed point along the canonical inclusion recovers the original point. -/
 @[simp]
 theorem baseChangeValue_include (f : A →ₐ[R] B) (a : A) :
     baseChangeValue (R := R) (S := S) f
         (HopfAlgebra.BaseChange.inclusion (S := S) a) = f a := by
   simp [HopfAlgebra.BaseChange.inclusion]
 
+/-- Evaluating the inverse points equivalence is restriction along the canonical inclusion into
+the scalar extension. -/
 @[simp]
 theorem baseChangeValueEquiv_symm_apply (f : HopfAlgebra.BaseChange R S A →ₐ[S] B) (a : A) :
     (baseChangeValueEquiv (R := R) (S := S)).symm f a =
       f (HopfAlgebra.BaseChange.inclusion (S := S) a) :=
-  rfl
+  by
+    change ((AlgHom.liftEquiv R S A B).symm f) a = f (1 ⊗ₜ[R] a)
+    exact _root_.AlgHom.liftEquiv_symm_apply f a
 
 variable [Semiring C] [Algebra S C] [Algebra R C] [IsScalarTower R S C]
 
+/-- Base-changed values are natural in the target algebra under postcomposition. -/
 @[simp]
 theorem comp_baseChangeValue (g : B →ₐ[S] C) (f : A →ₐ[R] B) :
     g.comp (baseChangeValue (R := R) (S := S) f) =
@@ -124,6 +140,7 @@ theorem comp_baseChangeValue (g : B →ₐ[S] C) (f : A →ₐ[R] B) :
   ext a
   simp
 
+/-- The inverse points equivalence is natural in the target algebra under postcomposition. -/
 @[simp]
 theorem baseChangeValueEquiv_symm_comp (g : B →ₐ[S] C)
     (f : HopfAlgebra.BaseChange R S A →ₐ[S] B) :

--- a/TauCeti/Algebra/AlgebraicGroup/HopfBaseChange.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/HopfBaseChange.lean
@@ -14,15 +14,14 @@ base ring gives the scalar extension `S ⊗[R] A` of an `R`-Hopf algebra `A` alo
 The reductive-groups roadmap needs this form of base change in Layer 0, both for changing the
 base field of an affine group scheme and for comparing functors of points before and after base
 change.  The facts here keep the construction explicit: the scalar-extended antipode and counit
-are described on pure tensors, the canonical inclusion `A →ₐ[R] S ⊗[R] A` is named, and
-`AlgHom.baseChangeValue` packages the standard tensor-product adjunction for points.
+are described on pure tensors.  The underlying canonical inclusion and the tensor-product
+adjunction are Mathlib's `Algebra.TensorProduct.includeRight` and `AlgHom.liftEquiv`.
 
 ## Main declarations
 
 * `HopfAlgebra.BaseChange`: the scalar extension `S ⊗[R] A` of an `R`-Hopf algebra.
-* `HopfAlgebra.baseChangeIncludeRight`: the canonical map `A →ₐ[R] S ⊗[R] A`.
-* `AlgHom.baseChangeValue`: algebra maps out of the scalar extension are equivalent to
-  algebra maps out of the original algebra into the restricted target.
+* `HopfAlgebra.baseChange_antipode_tmul`: the scalar-extended antipode on a pure tensor.
+* `HopfAlgebra.baseChange_counit_tmul`: the scalar-extended counit on a pure tensor.
 
 ## References
 
@@ -39,12 +38,14 @@ namespace TauCeti
 namespace HopfAlgebra
 
 variable (R S A : Type*) [CommSemiring R] [CommSemiring S] [Algebra R S]
-variable [Semiring A] [_root_.HopfAlgebra R A]
 
-/-- The scalar extension of an `R`-Hopf algebra `A` along `R → S`, equipped with Mathlib's
-tensor-product Hopf algebra structure over `S`. -/
-abbrev BaseChange :=
+/-- The scalar extension of an `R`-algebra `A` along `R → S`.  When `A` is a Hopf algebra over
+`R`, Mathlib's tensor-product Hopf algebra instance equips this algebra with a Hopf algebra
+structure over `S`. -/
+abbrev BaseChange [Semiring A] [Algebra R A] :=
   S ⊗[R] A
+
+variable [Semiring A] [_root_.HopfAlgebra R A]
 
 /-- The antipode on the scalar extension is obtained by extending the antipode on `A` and using
 the identity antipode on the base ring. -/
@@ -71,21 +72,12 @@ lemma baseChange_comul_tmul (s : S) (a : A) :
         (comul (R := S) s ⊗ₜ[R] comul (R := R) a) := by
   rfl
 
-/-- The canonical algebra map from a Hopf algebra to its scalar extension. -/
-def baseChangeIncludeRight : A →ₐ[R] BaseChange R S A :=
-  Algebra.TensorProduct.includeRight
-
-/-- The canonical map into the scalar extension sends `a` to `1 ⊗ a`. -/
-@[simp]
-lemma baseChangeIncludeRight_apply (a : A) :
-    baseChangeIncludeRight R S A a = (1 : S) ⊗ₜ[R] a := by
-  rfl
-
 /-- The scalar-extended counit after the canonical inclusion is the original counit followed by
 the base map. -/
 @[simp]
 lemma baseChange_counit_includeRight (a : A) :
-    counit (R := S) (A := BaseChange R S A) (baseChangeIncludeRight R S A a) =
+    counit (R := S) (A := BaseChange R S A)
+        (Algebra.TensorProduct.includeRight (R := R) (A := S) (B := A) a) =
       algebraMap R S (counit (R := R) a) := by
   simp [Algebra.smul_def]
 
@@ -94,72 +86,11 @@ the original antipode. -/
 @[simp]
 lemma baseChange_antipode_includeRight (a : A) :
     _root_.HopfAlgebraStruct.antipode S (A := BaseChange R S A)
-        (baseChangeIncludeRight R S A a) =
-      baseChangeIncludeRight R S A (_root_.HopfAlgebraStruct.antipode R a) := by
+        (Algebra.TensorProduct.includeRight (R := R) (A := S) (B := A) a) =
+      Algebra.TensorProduct.includeRight (R := R) (A := S) (B := A)
+        (_root_.HopfAlgebraStruct.antipode R a) := by
   simp
 
 end HopfAlgebra
-
-namespace AlgHom
-
-variable {R S A B C : Type*} [CommSemiring R] [CommSemiring S] [Algebra R S]
-variable [Semiring A] [Algebra R A]
-variable [CommSemiring B] [Algebra S B] [Algebra R B] [IsScalarTower R S B]
-
-/-- Algebra maps from a scalar extension are the same as algebra maps from the original algebra
-into the restricted target.  For a Hopf algebra `A`, this identifies `S`-valued points of
-`S ⊗[R] A` with `R`-algebra maps `A → B`, where `B` is regarded as an `R`-algebra by restriction
-of scalars. -/
-noncomputable abbrev baseChangeValue : (A →ₐ[R] B) ≃ (S ⊗[R] A →ₐ[S] B) :=
-  AlgHom.liftEquiv R S A B
-
-/-- The base-change adjunction sends `f : A →ₐ[R] B` to its `S`-linear extension, so on pure
-tensors it is given by `s ⊗ a ↦ s • f a`. -/
-@[simp]
-lemma baseChangeValue_apply (f : A →ₐ[R] B) (s : S) (a : A) :
-    baseChangeValue (R := R) (S := S) (A := A) (B := B) f (s ⊗ₜ[R] a) = s • f a := by
-  rfl
-
-/-- The inverse of the base-change adjunction restricts an `S`-algebra map along `a ↦ 1 ⊗ a`. -/
-@[simp]
-lemma baseChangeValue_symm_apply (f : S ⊗[R] A →ₐ[S] B) (a : A) :
-    (baseChangeValue (R := R) (S := S) (A := A) (B := B)).symm f a = f (1 ⊗ₜ[R] a) := by
-  rfl
-
-/-- The inverse of `baseChangeValue` is precomposition with the canonical inclusion, after
-restricting scalars on the target. -/
-lemma baseChangeValue_symm_comp (f : S ⊗[R] A →ₐ[S] B) :
-    (baseChangeValue (R := R) (S := S) (A := A) (B := B)).symm f =
-      (f.restrictScalars R).comp Algebra.TensorProduct.includeRight := by
-  rfl
-
-/-- Two maps from the scalar extension are equal if they agree after precomposition with
-`a ↦ 1 ⊗ a`. -/
-lemma baseChangeValue_ext {f g : S ⊗[R] A →ₐ[S] B}
-    (h : (baseChangeValue (R := R) (S := S) (A := A) (B := B)).symm f =
-      (baseChangeValue (R := R) (S := S) (A := A) (B := B)).symm g) :
-    f = g :=
-  (baseChangeValue (R := R) (S := S) (A := A) (B := B)).symm.injective h
-
-variable [CommSemiring C] [Algebra S C] [Algebra R C] [IsScalarTower R S C]
-
-/-- `baseChangeValue` is natural in the target algebra. -/
-lemma baseChangeValue_comp (φ : B →ₐ[S] C) (f : A →ₐ[R] B) :
-    baseChangeValue (R := R) (S := S) (A := A) (B := C)
-        ((φ.restrictScalars R).comp f) =
-      φ.comp (baseChangeValue (R := R) (S := S) (A := A) (B := B) f) := by
-  apply Algebra.TensorProduct.ext_ring
-  ext a
-  simp
-
-/-- The inverse of `baseChangeValue` is natural in the target algebra. -/
-lemma baseChangeValue_symm_comp_target (φ : B →ₐ[S] C) (f : S ⊗[R] A →ₐ[S] B) :
-    (baseChangeValue (R := R) (S := S) (A := A) (B := C)).symm (φ.comp f) =
-      (φ.restrictScalars R).comp
-        ((baseChangeValue (R := R) (S := S) (A := A) (B := B)).symm f) := by
-  ext a
-  rfl
-
-end AlgHom
 
 end TauCeti

--- a/TauCeti/Algebra/AlgebraicGroup/HopfBaseChange.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/HopfBaseChange.lean
@@ -127,8 +127,8 @@ theorem baseChangeValueEquiv_symm_apply (f : HopfAlgebra.BaseChange R S A →ₐ
     (baseChangeValueEquiv (R := R) (S := S)).symm f a =
       f (HopfAlgebra.BaseChange.inclusion (S := S) a) :=
   by
-    change ((AlgHom.liftEquiv R S A B).symm f) a = f (1 ⊗ₜ[R] a)
-    exact _root_.AlgHom.liftEquiv_symm_apply f a
+    simp [baseChangeValueEquiv, HopfAlgebra.BaseChange.inclusion,
+      _root_.AlgHom.liftEquiv_symm_apply]
 
 variable [Semiring C] [Algebra S C] [Algebra R C] [IsScalarTower R S C]
 

--- a/TauCeti/Algebra/AlgebraicGroup/HopfBaseChange.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/HopfBaseChange.lean
@@ -22,6 +22,9 @@ bialgebra, and coalgebra API is Mathlib's tensor-product API, including
 
 * `HopfAlgebra.BaseChange`: the scalar extension `S ⊗[R] A` of an `R`-algebra, carrying the
   tensor-product Hopf algebra structure when `A` is a Hopf algebra over `R`.
+* `HopfAlgebra.BaseChange.inclusion`: the canonical map from `A` into its scalar extension.
+* `TauCeti.AlgHom.baseChangeValueEquiv`: algebra-valued points of the base change are
+  algebra-valued points of `A` after restriction of scalars.
 
 ## References
 
@@ -44,6 +47,91 @@ structure over `S`. -/
 abbrev BaseChange [Semiring A] [Algebra R A] :=
   S ⊗[R] A
 
+namespace BaseChange
+
+variable {R S A : Type*} [CommSemiring R] [CommSemiring S] [Algebra R S]
+
+/-- The canonical inclusion of an algebra into its scalar extension. -/
+def inclusion [Semiring A] [Algebra R A] : A →ₐ[R] HopfAlgebra.BaseChange R S A :=
+  Algebra.TensorProduct.includeRight
+
+@[simp]
+theorem inclusion_apply [Semiring A] [Algebra R A] (a : A) :
+    inclusion (R := R) (S := S) a = 1 ⊗ₜ[R] a :=
+  Algebra.TensorProduct.includeRight_apply a
+
+@[simp]
+theorem antipode_tmul [Semiring A] [HopfAlgebra R A] (s : S) (a : A) :
+    HopfAlgebra.antipode S (s ⊗ₜ[R] a : HopfAlgebra.BaseChange R S A) =
+      HopfAlgebra.antipode S s ⊗ₜ[R] HopfAlgebra.antipode R a :=
+  rfl
+
+@[simp]
+theorem counit_tmul [Semiring A] [Algebra R A] [Coalgebra R A] (s : S) (a : A) :
+    Coalgebra.counit (R := S) (s ⊗ₜ[R] a : HopfAlgebra.BaseChange R S A) =
+      Coalgebra.counit (R := R) a • s :=
+  rfl
+
+@[simp]
+theorem comul_tmul [Semiring A] [Algebra R A] [Coalgebra R A] (s : S) (a : A) :
+    Coalgebra.comul (R := S) (s ⊗ₜ[R] a : HopfAlgebra.BaseChange R S A) =
+      TensorProduct.AlgebraTensorModule.tensorTensorTensorComm R S R S S S A A
+        (Coalgebra.comul (R := S) s ⊗ₜ[R] Coalgebra.comul (R := R) a) :=
+  rfl
+
+end BaseChange
+
 end HopfAlgebra
+
+namespace AlgHom
+
+variable {R S A B C : Type*} [CommSemiring R] [CommSemiring S] [Algebra R S]
+variable [Semiring A] [Algebra R A]
+variable [Semiring B] [Algebra S B] [Algebra R B] [IsScalarTower R S B]
+
+/-- Algebra-valued points of a base-changed algebra are the same as algebra-valued points of the
+original algebra after restriction of scalars. -/
+def baseChangeValueEquiv : (A →ₐ[R] B) ≃ (HopfAlgebra.BaseChange R S A →ₐ[S] B) :=
+  _root_.AlgHom.liftEquiv R S A B
+
+/-- Extend an `R`-algebra-valued point of `A` to an `S`-algebra-valued point of the base change. -/
+def baseChangeValue (f : A →ₐ[R] B) : HopfAlgebra.BaseChange R S A →ₐ[S] B :=
+  baseChangeValueEquiv (R := R) (S := S) f
+
+@[simp]
+theorem baseChangeValue_tmul (f : A →ₐ[R] B) (s : S) (a : A) :
+    baseChangeValue (R := R) (S := S) f (s ⊗ₜ[R] a) = s • f a :=
+  rfl
+
+@[simp]
+theorem baseChangeValue_include (f : A →ₐ[R] B) (a : A) :
+    baseChangeValue (R := R) (S := S) f
+        (HopfAlgebra.BaseChange.inclusion (S := S) a) = f a := by
+  simp [HopfAlgebra.BaseChange.inclusion]
+
+@[simp]
+theorem baseChangeValueEquiv_symm_apply (f : HopfAlgebra.BaseChange R S A →ₐ[S] B) (a : A) :
+    (baseChangeValueEquiv (R := R) (S := S)).symm f a =
+      f (HopfAlgebra.BaseChange.inclusion (S := S) a) :=
+  rfl
+
+variable [Semiring C] [Algebra S C] [Algebra R C] [IsScalarTower R S C]
+
+@[simp]
+theorem comp_baseChangeValue (g : B →ₐ[S] C) (f : A →ₐ[R] B) :
+    g.comp (baseChangeValue (R := R) (S := S) f) =
+      baseChangeValue (R := R) (S := S) ((g.restrictScalars R).comp f) := by
+  ext a
+  simp
+
+@[simp]
+theorem baseChangeValueEquiv_symm_comp (g : B →ₐ[S] C)
+    (f : HopfAlgebra.BaseChange R S A →ₐ[S] B) :
+    (baseChangeValueEquiv (R := R) (S := S)).symm (g.comp f) =
+      (g.restrictScalars R).comp ((baseChangeValueEquiv (R := R) (S := S)).symm f) := by
+  ext a
+  simp [baseChangeValueEquiv]
+
+end AlgHom
 
 end TauCeti

--- a/TauCeti/Algebra/AlgebraicGroup/HopfBaseChange.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/HopfBaseChange.lean
@@ -1,0 +1,165 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+import Mathlib.RingTheory.HopfAlgebra.TensorProduct
+
+/-!
+# Base change of Hopf algebras
+
+This file records a small API for scalar extension of Hopf algebras.  Mathlib already supplies
+the Hopf algebra structure on a tensor product of Hopf algebras; specializing one factor to the
+base ring gives the scalar extension `S ⊗[R] A` of an `R`-Hopf algebra `A` along `R → S`.
+
+The reductive-groups roadmap needs this form of base change in Layer 0, both for changing the
+base field of an affine group scheme and for comparing functors of points before and after base
+change.  The facts here keep the construction explicit: the scalar-extended antipode and counit
+are described on pure tensors, the canonical inclusion `A →ₐ[R] S ⊗[R] A` is named, and
+`AlgHom.baseChangeValue` packages the standard tensor-product adjunction for points.
+
+## Main declarations
+
+* `HopfAlgebra.BaseChange`: the scalar extension `S ⊗[R] A` of an `R`-Hopf algebra.
+* `HopfAlgebra.baseChangeIncludeRight`: the canonical map `A →ₐ[R] S ⊗[R] A`.
+* `AlgHom.baseChangeValue`: algebra maps out of the scalar extension are equivalent to
+  algebra maps out of the original algebra into the restricted target.
+
+## References
+
+This supports the "Base change. `K ⊗[k] A` as a Hopf algebra over `K`" item in Layer 0 of the
+Tau Ceti reductive-groups roadmap.  The underlying tensor-product Hopf algebra instance is due to
+Amelia Livingston and Andrew Yang in Mathlib.
+-/
+
+open Coalgebra TensorProduct
+open scoped TensorProduct
+
+namespace TauCeti
+
+namespace HopfAlgebra
+
+variable (R S A : Type*) [CommSemiring R] [CommSemiring S] [Algebra R S]
+variable [Semiring A] [_root_.HopfAlgebra R A]
+
+/-- The scalar extension of an `R`-Hopf algebra `A` along `R → S`, equipped with Mathlib's
+tensor-product Hopf algebra structure over `S`. -/
+abbrev BaseChange :=
+  S ⊗[R] A
+
+/-- The antipode on the scalar extension is obtained by extending the antipode on `A` and using
+the identity antipode on the base ring. -/
+@[simp]
+lemma baseChange_antipode_tmul (s : S) (a : A) :
+    _root_.HopfAlgebraStruct.antipode S (A := BaseChange R S A) (s ⊗ₜ[R] a) =
+      s ⊗ₜ[R] _root_.HopfAlgebraStruct.antipode R a := by
+  simp [BaseChange]
+
+/-- The counit of the scalar extension sends a pure tensor `s ⊗ a` to
+`s * algebraMap R S (ε a)`. -/
+@[simp]
+lemma baseChange_counit_tmul (s : S) (a : A) :
+    counit (R := S) (A := BaseChange R S A) (s ⊗ₜ[R] a) =
+      s * algebraMap R S (counit (R := R) a) := by
+  simp [BaseChange, Algebra.smul_def, mul_comm]
+
+/-- The comultiplication of the scalar extension on a pure tensor, stated directly in terms of
+Mathlib's tensor-product coalgebra structure. -/
+@[simp]
+lemma baseChange_comul_tmul (s : S) (a : A) :
+    comul (R := S) (A := BaseChange R S A) (s ⊗ₜ[R] a) =
+      TensorProduct.AlgebraTensorModule.tensorTensorTensorComm R S R S S S A A
+        (comul (R := S) s ⊗ₜ[R] comul (R := R) a) := by
+  rfl
+
+/-- The canonical algebra map from a Hopf algebra to its scalar extension. -/
+def baseChangeIncludeRight : A →ₐ[R] BaseChange R S A :=
+  Algebra.TensorProduct.includeRight
+
+/-- The canonical map into the scalar extension sends `a` to `1 ⊗ a`. -/
+@[simp]
+lemma baseChangeIncludeRight_apply (a : A) :
+    baseChangeIncludeRight R S A a = (1 : S) ⊗ₜ[R] a := by
+  rfl
+
+/-- The scalar-extended counit after the canonical inclusion is the original counit followed by
+the base map. -/
+@[simp]
+lemma baseChange_counit_includeRight (a : A) :
+    counit (R := S) (A := BaseChange R S A) (baseChangeIncludeRight R S A a) =
+      algebraMap R S (counit (R := R) a) := by
+  simp [Algebra.smul_def]
+
+/-- The scalar-extended antipode after the canonical inclusion is the canonical inclusion after
+the original antipode. -/
+@[simp]
+lemma baseChange_antipode_includeRight (a : A) :
+    _root_.HopfAlgebraStruct.antipode S (A := BaseChange R S A)
+        (baseChangeIncludeRight R S A a) =
+      baseChangeIncludeRight R S A (_root_.HopfAlgebraStruct.antipode R a) := by
+  simp
+
+end HopfAlgebra
+
+namespace AlgHom
+
+variable {R S A B C : Type*} [CommSemiring R] [CommSemiring S] [Algebra R S]
+variable [Semiring A] [Algebra R A]
+variable [CommSemiring B] [Algebra S B] [Algebra R B] [IsScalarTower R S B]
+
+/-- Algebra maps from a scalar extension are the same as algebra maps from the original algebra
+into the restricted target.  For a Hopf algebra `A`, this identifies `S`-valued points of
+`S ⊗[R] A` with `R`-algebra maps `A → B`, where `B` is regarded as an `R`-algebra by restriction
+of scalars. -/
+noncomputable abbrev baseChangeValue : (A →ₐ[R] B) ≃ (S ⊗[R] A →ₐ[S] B) :=
+  AlgHom.liftEquiv R S A B
+
+/-- The base-change adjunction sends `f : A →ₐ[R] B` to its `S`-linear extension, so on pure
+tensors it is given by `s ⊗ a ↦ s • f a`. -/
+@[simp]
+lemma baseChangeValue_apply (f : A →ₐ[R] B) (s : S) (a : A) :
+    baseChangeValue (R := R) (S := S) (A := A) (B := B) f (s ⊗ₜ[R] a) = s • f a := by
+  rfl
+
+/-- The inverse of the base-change adjunction restricts an `S`-algebra map along `a ↦ 1 ⊗ a`. -/
+@[simp]
+lemma baseChangeValue_symm_apply (f : S ⊗[R] A →ₐ[S] B) (a : A) :
+    (baseChangeValue (R := R) (S := S) (A := A) (B := B)).symm f a = f (1 ⊗ₜ[R] a) := by
+  rfl
+
+/-- The inverse of `baseChangeValue` is precomposition with the canonical inclusion, after
+restricting scalars on the target. -/
+lemma baseChangeValue_symm_comp (f : S ⊗[R] A →ₐ[S] B) :
+    (baseChangeValue (R := R) (S := S) (A := A) (B := B)).symm f =
+      (f.restrictScalars R).comp Algebra.TensorProduct.includeRight := by
+  rfl
+
+/-- Two maps from the scalar extension are equal if they agree after precomposition with
+`a ↦ 1 ⊗ a`. -/
+lemma baseChangeValue_ext {f g : S ⊗[R] A →ₐ[S] B}
+    (h : (baseChangeValue (R := R) (S := S) (A := A) (B := B)).symm f =
+      (baseChangeValue (R := R) (S := S) (A := A) (B := B)).symm g) :
+    f = g :=
+  (baseChangeValue (R := R) (S := S) (A := A) (B := B)).symm.injective h
+
+variable [CommSemiring C] [Algebra S C] [Algebra R C] [IsScalarTower R S C]
+
+/-- `baseChangeValue` is natural in the target algebra. -/
+lemma baseChangeValue_comp (φ : B →ₐ[S] C) (f : A →ₐ[R] B) :
+    baseChangeValue (R := R) (S := S) (A := A) (B := C)
+        ((φ.restrictScalars R).comp f) =
+      φ.comp (baseChangeValue (R := R) (S := S) (A := A) (B := B) f) := by
+  apply Algebra.TensorProduct.ext_ring
+  ext a
+  simp
+
+/-- The inverse of `baseChangeValue` is natural in the target algebra. -/
+lemma baseChangeValue_symm_comp_target (φ : B →ₐ[S] C) (f : S ⊗[R] A →ₐ[S] B) :
+    (baseChangeValue (R := R) (S := S) (A := A) (B := C)).symm (φ.comp f) =
+      (φ.restrictScalars R).comp
+        ((baseChangeValue (R := R) (S := S) (A := A) (B := B)).symm f) := by
+  ext a
+  rfl
+
+end AlgHom
+
+end TauCeti


### PR DESCRIPTION
This PR adds a focused API for the ReductiveGroups roadmap target “Layer 0: Base change. `K ⊗[k] A` as a Hopf algebra over `K`” in `/home/kim/TauCetiWorker/state/refs/roadmap/TauCetiRoadmap/ReductiveGroups/README.md`. It names the scalar extension `HopfAlgebra.BaseChange`, records pure-tensor formulas for the scalar-extended antipode, counit, and comultiplication, names the canonical inclusion into the base change, and packages the algebra-points adjunction as `AlgHom.baseChangeValue` with naturality lemmas for the target algebra.

This consumes Mathlib infrastructure rather than rebuilding it: the Hopf structure comes from `Mathlib.RingTheory.HopfAlgebra.TensorProduct`, and the points adjunction is `AlgHom.liftEquiv` from Mathlib’s tensor-product algebra API. The tensor-product Hopf algebra instance is attributed in the module docstring to Amelia Livingston and Andrew Yang, matching the Mathlib source.

Verified with `lake exe cache get`, `lake build`, and `lake exe axioms`.

🤖 Prepared with Codex