### PR TITLE
feat: add Hopf antipode map API

### DIFF
--- a/TauCeti/Algebra/AlgebraicGroup/FunctorOfPoints.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/FunctorOfPoints.lean
@@ -3,7 +3,7 @@ Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 -/
 import Mathlib.RingTheory.Bialgebra.Convolution
-import TauCeti.Algebra.AlgebraicGroup.HopfAlgebra
+import TauCeti.Algebra.HopfAlgebra
 
 /-!
 # Convolution groups of algebra homomorphisms out of a Hopf algebra

--- a/TauCeti/Algebra/AlgebraicGroup/FunctorOfPoints.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/FunctorOfPoints.lean
@@ -3,7 +3,7 @@ Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 -/
 import Mathlib.RingTheory.Bialgebra.Convolution
-import Mathlib.RingTheory.HopfAlgebra.Basic
+import TauCeti.Algebra.AlgebraicGroup.HopfAlgebra
 
 /-!
 # Convolution groups of algebra homomorphisms out of a Hopf algebra
@@ -53,23 +53,6 @@ Yaël Dillies, Michał Mrugała and Yunzhou Xie in Mathlib.
 open Coalgebra HopfAlgebra TensorProduct WithConv
 
 namespace TauCeti
-
-namespace HopfAlgebra
-
-variable {R H : Type*} [CommSemiring R] [Semiring H] [_root_.HopfAlgebra R H]
-
-/-- The antipode is a left convolution inverse of the identity in the convolution ring of
-linear maps: `S * id = 1`. This is a restatement of the antipode axiom
-`HopfAlgebra.mul_antipode_rTensor_comul`. -/
-lemma antipode_convMul_id :
-    (toConv (antipode R) : WithConv (H →ₗ[R] H)) * toConv LinearMap.id = 1 := by
-  refine WithConv.ext ?_
-  ext h
-  simp only [LinearMap.convMul_apply, LinearMap.convOne_apply,
-    ← LinearMap.rTensor_def]
-  exact mul_antipode_rTensor_comul_apply h
-
-end HopfAlgebra
 
 namespace AlgHom
 

--- a/TauCeti/Algebra/AlgebraicGroup/HopfAlgebra.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/HopfAlgebra.lean
@@ -1,0 +1,122 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+import Mathlib.RingTheory.Bialgebra.Convolution
+import Mathlib.RingTheory.HopfAlgebra.Basic
+
+/-!
+# Hopf algebra morphisms
+
+This file records Hopf-algebra API needed for the affine-group-scheme dictionary in the
+reductive-groups roadmap. Mathlib defines morphisms in `HopfAlgCat R` to be bialgebra
+morphisms; the missing algebraic fact is that such a morphism automatically preserves the
+antipode. We prove that here by the usual convolution-inverse uniqueness argument.
+
+## Main results
+
+* `TauCeti.HopfAlgebra.antipode_convMul_id` and
+  `TauCeti.HopfAlgebra.id_convMul_antipode`: the antipode is respectively a left and right
+  convolution inverse of the identity linear map.
+* `BialgHom.toLinearMap_comp_antipode` and `BialgHom.map_antipode`: a bialgebra morphism
+  between Hopf algebras commutes with the antipodes.
+
+## References
+
+This supplies a formal prerequisite for the Tau Ceti reductive-groups roadmap, Layer 0,
+"the functor of points and the three-way dictionary": morphisms in the Hopf-algebra model
+must respect the inverse map in the affine group-scheme model. The proof uses Mathlib's
+convolution product on linear maps, due to Yaël Dillies, Michał Mrugała and Yunzhou Xie.
+-/
+
+open Coalgebra HopfAlgebra TensorProduct WithConv
+
+namespace TauCeti
+
+namespace HopfAlgebra
+
+variable {R H : Type*} [CommSemiring R] [Semiring H] [_root_.HopfAlgebra R H]
+
+/-- The antipode is a left convolution inverse of the identity in the convolution ring of
+linear maps: `S * id = 1`. This is a restatement of the antipode axiom
+`HopfAlgebra.mul_antipode_rTensor_comul`. -/
+lemma antipode_convMul_id :
+    (toConv (antipode R) : WithConv (H →ₗ[R] H)) * toConv LinearMap.id = 1 := by
+  refine WithConv.ext ?_
+  ext h
+  simp only [LinearMap.convMul_apply, LinearMap.convOne_apply,
+    ← LinearMap.rTensor_def]
+  exact mul_antipode_rTensor_comul_apply h
+
+/-- The antipode is a right convolution inverse of the identity in the convolution ring of
+linear maps: `id * S = 1`. This is a restatement of the antipode axiom
+`HopfAlgebra.mul_antipode_lTensor_comul`. -/
+lemma id_convMul_antipode :
+    (toConv LinearMap.id : WithConv (H →ₗ[R] H)) * toConv (antipode R) = 1 := by
+  refine WithConv.ext ?_
+  ext h
+  simp only [LinearMap.convMul_apply, LinearMap.convOne_apply,
+    ← LinearMap.lTensor_def]
+  exact mul_antipode_lTensor_comul_apply h
+
+end HopfAlgebra
+
+namespace BialgHom
+
+variable {R A B : Type*} [CommSemiring R]
+variable [Semiring A] [Semiring B] [_root_.HopfAlgebra R A] [_root_.HopfAlgebra R B]
+
+/-- A bialgebra morphism between Hopf algebras commutes with the antipodes, as a statement
+about underlying linear maps. -/
+theorem toLinearMap_comp_antipode (φ : A →ₐc[R] B) :
+    φ.toLinearMap.comp (HopfAlgebra.antipode R (A := A)) =
+      (HopfAlgebra.antipode R (A := B)).comp φ.toLinearMap := by
+  let f : WithConv (A →ₗ[R] B) := toConv φ.toLinearMap
+  let g : WithConv (A →ₗ[R] B) :=
+    toConv (φ.toLinearMap.comp (HopfAlgebra.antipode R (A := A)))
+  let h : WithConv (A →ₗ[R] B) :=
+    toConv ((HopfAlgebra.antipode R (A := B)).comp φ.toLinearMap)
+  have hg_left : g * f = 1 := by
+    refine WithConv.ofConv_injective ?_
+    dsimp [g, f]
+    change
+      (toConv ((φ : A →ₐ[R] B).toLinearMap.comp (HopfAlgebra.antipode R (A := A))) *
+          toConv ((φ : A →ₐ[R] B).toLinearMap.comp LinearMap.id)).ofConv =
+        (1 : WithConv (A →ₗ[R] B)).ofConv
+    rw [← LinearMap.algHom_comp_convMul_distrib (φ : A →ₐ[R] B)
+      (toConv (HopfAlgebra.antipode R (A := A))) (toConv LinearMap.id)]
+    rw [HopfAlgebra.antipode_convMul_id]
+    ext a
+    exact (φ : A →ₐ[R] B).commutes (Coalgebra.counit a)
+  have hh_right : f * h = 1 := by
+    refine WithConv.ofConv_injective ?_
+    dsimp [f, h]
+    change
+      (toConv ((toConv (LinearMap.id : B →ₗ[R] B)).ofConv.comp
+            (φ : A →ₗc[R] B).toLinearMap) *
+          toConv ((toConv (HopfAlgebra.antipode R (A := B))).ofConv.comp
+            (φ : A →ₗc[R] B).toLinearMap)).ofConv =
+        (1 : WithConv (A →ₗ[R] B)).ofConv
+    rw [← LinearMap.convMul_comp_coalgHom_distrib
+      (toConv (LinearMap.id : B →ₗ[R] B)) (toConv (HopfAlgebra.antipode R (A := B)))
+      (φ : A →ₗc[R] B)]
+    rw [HopfAlgebra.id_convMul_antipode]
+    ext a
+    exact congr_arg (algebraMap R B) (CoalgHomClass.counit_comp_apply φ a)
+  have h_eq : g = h := by
+    calc
+      g = g * 1 := by rw [mul_one]
+      _ = g * (f * h) := by rw [hh_right]
+      _ = (g * f) * h := by rw [mul_assoc]
+      _ = 1 * h := by rw [hg_left]
+      _ = h := by rw [one_mul]
+  exact WithConv.toConv_injective h_eq
+
+/-- A bialgebra morphism between Hopf algebras commutes with the antipodes, pointwise. -/
+theorem map_antipode (φ : A →ₐc[R] B) (a : A) :
+    φ (HopfAlgebra.antipode R a) = HopfAlgebra.antipode R (φ a) :=
+  LinearMap.congr_fun (toLinearMap_comp_antipode φ) a
+
+end BialgHom
+
+end TauCeti

--- a/TauCeti/Algebra/AlgebraicGroup/HopfAlgebra.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/HopfAlgebra.lean
@@ -2,7 +2,7 @@
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 -/
-import Mathlib.RingTheory.Bialgebra.Convolution
+import Mathlib.RingTheory.Bialgebra.Hom
 import Mathlib.RingTheory.HopfAlgebra.Basic
 
 /-!
@@ -40,6 +40,7 @@ variable {R H : Type*} [CommSemiring R] [Semiring H] [_root_.HopfAlgebra R H]
 /-- The antipode is a left convolution inverse of the identity in the convolution ring of
 linear maps: `S * id = 1`. This is a restatement of the antipode axiom
 `HopfAlgebra.mul_antipode_rTensor_comul`. -/
+@[simp]
 lemma antipode_convMul_id :
     (toConv (antipode R) : WithConv (H →ₗ[R] H)) * toConv LinearMap.id = 1 := by
   refine WithConv.ext ?_
@@ -51,6 +52,7 @@ lemma antipode_convMul_id :
 /-- The antipode is a right convolution inverse of the identity in the convolution ring of
 linear maps: `id * S = 1`. This is a restatement of the antipode axiom
 `HopfAlgebra.mul_antipode_lTensor_comul`. -/
+@[simp]
 lemma id_convMul_antipode :
     (toConv LinearMap.id : WithConv (H →ₗ[R] H)) * toConv (antipode R) = 1 := by
   refine WithConv.ext ?_
@@ -68,6 +70,7 @@ variable [Semiring A] [Semiring B] [_root_.HopfAlgebra R A] [_root_.HopfAlgebra 
 
 /-- A bialgebra morphism between Hopf algebras commutes with the antipodes, as a statement
 about underlying linear maps. -/
+@[simp]
 theorem toLinearMap_comp_antipode (φ : A →ₐc[R] B) :
     φ.toLinearMap.comp (HopfAlgebra.antipode R (A := A)) =
       (HopfAlgebra.antipode R (A := B)).comp φ.toLinearMap := by
@@ -79,6 +82,9 @@ theorem toLinearMap_comp_antipode (φ : A →ₐc[R] B) :
   have hg_left : g * f = 1 := by
     refine WithConv.ofConv_injective ?_
     dsimp [g, f]
+    -- `algHom_comp_convMul_distrib` is stated after applying an algebra hom to a
+    -- convolution product. The definitions of `BialgHom.toAlgHom`, `LinearMap.comp`, and
+    -- `WithConv.ofConv` reduce this goal to that exact shape.
     change
       (toConv ((φ : A →ₐ[R] B).toLinearMap.comp (HopfAlgebra.antipode R (A := A))) *
           toConv ((φ : A →ₐ[R] B).toLinearMap.comp LinearMap.id)).ofConv =
@@ -91,6 +97,8 @@ theorem toLinearMap_comp_antipode (φ : A →ₐc[R] B) :
   have hh_right : f * h = 1 := by
     refine WithConv.ofConv_injective ?_
     dsimp [f, h]
+    -- Dually, `convMul_comp_coalgHom_distrib` is stated before wrapping the two composed
+    -- linear maps with `toConv`; unfolding the coalgebra-hom coercion gives that form.
     change
       (toConv ((toConv (LinearMap.id : B →ₗ[R] B)).ofConv.comp
             (φ : A →ₗc[R] B).toLinearMap) *
@@ -113,10 +121,25 @@ theorem toLinearMap_comp_antipode (φ : A →ₐc[R] B) :
   exact WithConv.toConv_injective h_eq
 
 /-- A bialgebra morphism between Hopf algebras commutes with the antipodes, pointwise. -/
+@[simp]
 theorem map_antipode (φ : A →ₐc[R] B) (a : A) :
     φ (HopfAlgebra.antipode R a) = HopfAlgebra.antipode R (φ a) :=
   LinearMap.congr_fun (toLinearMap_comp_antipode φ) a
 
 end BialgHom
+
+namespace BialgHomClass
+
+variable {R A B F : Type*} [CommSemiring R]
+variable [Semiring A] [Semiring B] [_root_.HopfAlgebra R A] [_root_.HopfAlgebra R B]
+variable [FunLike F A B] [BialgHomClass F R A B]
+
+/-- A bialgebra-hom-like map between Hopf algebras commutes with the antipodes, pointwise. -/
+@[simp]
+theorem map_antipode (φ : F) (a : A) :
+    φ (HopfAlgebra.antipode R a) = HopfAlgebra.antipode R (φ a) :=
+  BialgHom.map_antipode (φ : A →ₐc[R] B) a
+
+end BialgHomClass
 
 end TauCeti

--- a/TauCeti/Algebra/HopfAlgebra.lean
+++ b/TauCeti/Algebra/HopfAlgebra.lean
@@ -68,6 +68,60 @@ namespace BialgHom
 variable {R A B : Type*} [CommSemiring R]
 variable [Semiring A] [Semiring B] [_root_.HopfAlgebra R A] [_root_.HopfAlgebra R B]
 
+/-- The coalgebra-hom projection of a bialgebra hom has the same underlying linear map as the
+bialgebra hom itself. -/
+private lemma toCoalgHom_toLinearMap (φ : A →ₐc[R] B) :
+    (φ.toCoalgHom : A →ₗ[R] B) = φ.toLinearMap :=
+  rfl
+
+/-- Applying an algebra homomorphism to a convolution product, oriented so it rewrites the
+`WithConv.ofConv` shape arising from bialgebra morphism composition. -/
+private lemma algHom_comp_convMul_ofConv (φ : A →ₐc[R] B) (f g : A →ₗ[R] A) :
+    (toConv (φ.toLinearMap.comp f) *
+          toConv (φ.toLinearMap.comp g)).ofConv =
+      φ.toLinearMap.comp (toConv f * toConv g).ofConv := by
+  change
+    (toConv ((φ : A →ₐ[R] B).toLinearMap.comp f) *
+          toConv ((φ : A →ₐ[R] B).toLinearMap.comp g)).ofConv =
+      (φ : A →ₐ[R] B).toLinearMap.comp (toConv f * toConv g).ofConv
+  simpa using
+    (LinearMap.algHom_comp_convMul_distrib (φ : A →ₐ[R] B) (toConv f) (toConv g)).symm
+
+/-- Precomposing a convolution product with a coalgebra homomorphism, oriented so it rewrites
+the `WithConv.ofConv` shape arising from bialgebra morphism composition. -/
+private lemma convMul_comp_coalgHom_ofConv (f g : B →ₗ[R] B) (φ : A →ₐc[R] B) :
+    (toConv (f.comp φ.toLinearMap) *
+          toConv (g.comp φ.toLinearMap)).ofConv =
+      (toConv f * toConv g).ofConv.comp φ.toLinearMap := by
+  change
+    (toConv (f.comp (φ : A →ₗc[R] B).toLinearMap) *
+          toConv (g.comp (φ : A →ₗc[R] B).toLinearMap)).ofConv =
+      (toConv f * toConv g).ofConv.comp (φ : A →ₗc[R] B).toLinearMap
+  simpa using
+    (LinearMap.convMul_comp_coalgHom_distrib (toConv f) (toConv g)
+      (φ : A →ₗc[R] B)).symm
+
+/-- Applying a bialgebra homomorphism to the convolution product `S * id`, in the exact
+normal form used in the antipode-preservation proof. -/
+private lemma algHom_comp_antipode_id_ofConv (φ : A →ₐc[R] B) :
+    (toConv (φ.toLinearMap.comp (HopfAlgebra.antipode R (A := A))) *
+          toConv φ.toLinearMap).ofConv =
+      φ.toLinearMap.comp
+        (toConv (HopfAlgebra.antipode R (A := A)) * toConv LinearMap.id).ofConv := by
+  have h := algHom_comp_convMul_ofConv φ (HopfAlgebra.antipode R (A := A)) LinearMap.id
+  simpa only [LinearMap.comp_id] using h
+
+/-- Precomposing the convolution product `id * S` with a bialgebra homomorphism, in the
+exact normal form used in the antipode-preservation proof. -/
+private lemma id_antipode_comp_coalgHom_ofConv (φ : A →ₐc[R] B) :
+    (toConv φ.toLinearMap *
+          toConv ((HopfAlgebra.antipode R (A := B)).comp φ.toLinearMap)).ofConv =
+      (toConv LinearMap.id * toConv (HopfAlgebra.antipode R (A := B))).ofConv.comp
+        φ.toLinearMap := by
+  have h := convMul_comp_coalgHom_ofConv (LinearMap.id : B →ₗ[R] B)
+    (HopfAlgebra.antipode R (A := B)) φ
+  simpa only [LinearMap.id_comp] using h
+
 /-- A bialgebra morphism between Hopf algebras commutes with the antipodes, as a statement
 about underlying linear maps. -/
 @[simp]
@@ -82,32 +136,16 @@ theorem toLinearMap_comp_antipode (φ : A →ₐc[R] B) :
   have hg_left : g * f = 1 := by
     refine WithConv.ofConv_injective ?_
     dsimp [g, f]
-    -- `algHom_comp_convMul_distrib` is stated after applying an algebra hom to a
-    -- convolution product. The definitions of `BialgHom.toAlgHom`, `LinearMap.comp`, and
-    -- `WithConv.ofConv` reduce this goal to that exact shape.
-    change
-      (toConv ((φ : A →ₐ[R] B).toLinearMap.comp (HopfAlgebra.antipode R (A := A))) *
-          toConv ((φ : A →ₐ[R] B).toLinearMap.comp LinearMap.id)).ofConv =
-        (1 : WithConv (A →ₗ[R] B)).ofConv
-    rw [← LinearMap.algHom_comp_convMul_distrib (φ : A →ₐ[R] B)
-      (toConv (HopfAlgebra.antipode R (A := A))) (toConv LinearMap.id)]
+    rw [toCoalgHom_toLinearMap φ]
+    rw [algHom_comp_antipode_id_ofConv φ]
     rw [HopfAlgebra.antipode_convMul_id]
     ext a
     exact (φ : A →ₐ[R] B).commutes (Coalgebra.counit a)
   have hh_right : f * h = 1 := by
     refine WithConv.ofConv_injective ?_
     dsimp [f, h]
-    -- Dually, `convMul_comp_coalgHom_distrib` is stated before wrapping the two composed
-    -- linear maps with `toConv`; unfolding the coalgebra-hom coercion gives that form.
-    change
-      (toConv ((toConv (LinearMap.id : B →ₗ[R] B)).ofConv.comp
-            (φ : A →ₗc[R] B).toLinearMap) *
-          toConv ((toConv (HopfAlgebra.antipode R (A := B))).ofConv.comp
-            (φ : A →ₗc[R] B).toLinearMap)).ofConv =
-        (1 : WithConv (A →ₗ[R] B)).ofConv
-    rw [← LinearMap.convMul_comp_coalgHom_distrib
-      (toConv (LinearMap.id : B →ₗ[R] B)) (toConv (HopfAlgebra.antipode R (A := B)))
-      (φ : A →ₗc[R] B)]
+    rw [toCoalgHom_toLinearMap φ]
+    rw [id_antipode_comp_coalgHom_ofConv φ]
     rw [HopfAlgebra.id_convMul_antipode]
     ext a
     exact congr_arg (algebraMap R B) (CoalgHomClass.counit_comp_apply φ a)

--- a/TauCeti/Algebra/HopfAlgebra.lean
+++ b/TauCeti/Algebra/HopfAlgebra.lean
@@ -68,10 +68,22 @@ namespace BialgHom
 variable {R A B : Type*} [CommSemiring R]
 variable [Semiring A] [Semiring B] [_root_.HopfAlgebra R A] [_root_.HopfAlgebra R B]
 
+/-- The algebra-hom projection of a bialgebra hom has the same underlying linear map as the
+bialgebra hom itself. -/
+private lemma toAlgHom_toLinearMap (φ : A →ₐc[R] B) :
+    (φ : A →ₐ[R] B).toLinearMap = φ.toLinearMap :=
+  _root_.BialgHom.toAlgHom_toLinearMap φ
+
 /-- The coalgebra-hom projection of a bialgebra hom has the same underlying linear map as the
 bialgebra hom itself. -/
 private lemma toCoalgHom_toLinearMap (φ : A →ₐc[R] B) :
     (φ.toCoalgHom : A →ₗ[R] B) = φ.toLinearMap :=
+  rfl
+
+/-- The coalgebra-hom coercion of a bialgebra hom has the same underlying linear map as the
+bialgebra hom itself. -/
+private lemma coe_coalgHom_toLinearMap (φ : A →ₐc[R] B) :
+    ((φ : A →ₗc[R] B) : A →ₗ[R] B) = φ.toLinearMap :=
   rfl
 
 /-- Applying an algebra homomorphism to a convolution product, oriented so it rewrites the
@@ -80,10 +92,9 @@ private lemma algHom_comp_convMul_ofConv (φ : A →ₐc[R] B) (f g : A →ₗ[R
     (toConv (φ.toLinearMap.comp f) *
           toConv (φ.toLinearMap.comp g)).ofConv =
       φ.toLinearMap.comp (toConv f * toConv g).ofConv := by
-  change
-    (toConv ((φ : A →ₐ[R] B).toLinearMap.comp f) *
-          toConv ((φ : A →ₐ[R] B).toLinearMap.comp g)).ofConv =
-      (φ : A →ₐ[R] B).toLinearMap.comp (toConv f * toConv g).ofConv
+  have hφ : φ.toLinearMap = (φ : A →ₐ[R] B).toLinearMap :=
+    (toAlgHom_toLinearMap φ).symm
+  rw [hφ]
   simpa using
     (LinearMap.algHom_comp_convMul_distrib (φ : A →ₐ[R] B) (toConv f) (toConv g)).symm
 
@@ -93,10 +104,9 @@ private lemma convMul_comp_coalgHom_ofConv (f g : B →ₗ[R] B) (φ : A →ₐc
     (toConv (f.comp φ.toLinearMap) *
           toConv (g.comp φ.toLinearMap)).ofConv =
       (toConv f * toConv g).ofConv.comp φ.toLinearMap := by
-  change
-    (toConv (f.comp (φ : A →ₗc[R] B).toLinearMap) *
-          toConv (g.comp (φ : A →ₗc[R] B).toLinearMap)).ofConv =
-      (toConv f * toConv g).ofConv.comp (φ : A →ₗc[R] B).toLinearMap
+  have hφ : φ.toLinearMap = ((φ : A →ₗc[R] B) : A →ₗ[R] B) :=
+    (coe_coalgHom_toLinearMap φ).symm
+  rw [hφ]
   simpa using
     (LinearMap.convMul_comp_coalgHom_distrib (toConv f) (toConv g)
       (φ : A →ₗc[R] B)).symm


### PR DESCRIPTION
This PR adds Hopf-algebra morphism API for the TauCetiRoadmap/ReductiveGroups/README.md Layer 0 target "the functor of points and the three-way dictionary", specifically the Hopf-algebra side of the inverse map in the affine group-scheme model. It records both convolution inverse identities for the antipode and proves that every `BialgHom` between Hopf algebras commutes with the antipodes, so morphisms in the Hopf-algebra model respect inversion.

It reuses Mathlib’s convolution product on linear maps and its algebra/coalgebra composition distribution lemmas from `Mathlib.RingTheory.Coalgebra.Convolution` and `Mathlib.RingTheory.Bialgebra.Convolution`, due to Yaël Dillies, Michał Mrugała, and Yunzhou Xie. The existing left convolution inverse lemma from `FunctorOfPoints` is moved into the new Hopf API file so later algebraic-group files have one canonical import.

Checked with `lake exe cache get`, `lake build`, and `lake exe axioms`.

🤖 Prepared with Codex