### PR TITLE
feat: add symmetric elliptic coefficients

### DIFF
--- a/TauCeti.lean
+++ b/TauCeti.lean
@@ -5,3 +5,4 @@
 -- grows, import the submodules of `TauCeti/` here.
 import TauCeti.Analysis.PDE.UniformEllipticity
 import TauCeti.Basic
+import TauCeti.LinearAlgebra.Matrix.SymmetricPart

--- a/TauCeti.lean
+++ b/TauCeti.lean
@@ -3,4 +3,5 @@
 -- Everything reachable from here must be sorry-free, and must not import
 -- `TauCetiRoadmap` or `TauCetiReview` (both enforced in CI). As the library
 -- grows, import the submodules of `TauCeti/` here.
+import TauCeti.Analysis.PDE.UniformEllipticity
 import TauCeti.Basic

--- a/TauCeti/Analysis/PDE/UniformEllipticity.lean
+++ b/TauCeti/Analysis/PDE/UniformEllipticity.lean
@@ -4,6 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 -/
 import Mathlib.Analysis.InnerProductSpace.PiL2
 import Mathlib.LinearAlgebra.QuadraticForm.Basic
+import Mathlib.LinearAlgebra.Matrix.Symmetric
 
 /-!
 # Uniform ellipticity for divergence-form PDE coefficients
@@ -26,10 +27,13 @@ and Lax--Milgram arguments: constants are parameters, not hidden existential dat
 
 * `TauCeti.PDE.UniformlyEllipticOn`: uniform lower and upper ellipticity bounds on a set.
 * `TauCeti.PDE.uniformlyEllipticOn_const_one`: the identity matrix is uniformly elliptic.
+* `TauCeti.PDE.symmetricPart`: the symmetric part `(A + Aᵀ) / 2` of a coefficient matrix.
 * `TauCeti.PDE.UniformlyEllipticOn.mono_constants`: weakening constants preserves the
   predicate.
 * `TauCeti.PDE.UniformlyEllipticOn.mono_set`: restriction to a smaller domain preserves the
   predicate.
+* `TauCeti.PDE.UniformlyEllipticOn.symmetricPart`: replacing coefficients by their
+  symmetric part preserves the same uniform ellipticity constants.
 
 The vectors are `EuclideanSpace ℝ n`, matching the roadmap's bounded open subsets of
 `ℝⁿ`; this type is reducibly a finite `L²` product, so Mathlib's matrix-vector API applies
@@ -42,20 +46,114 @@ namespace PDE
 
 open Matrix
 
-variable {X n : Type*} [Fintype n] [DecidableEq n]
+variable {X n : Type*}
 
 /-- Mathlib's matrix quadratic form is the dot-product expression `ξᵀ A ξ`. -/
-lemma toQuadraticForm'_eq_dotProduct (A : Matrix n n ℝ) (ξ : EuclideanSpace ℝ n) :
+lemma toQuadraticForm'_eq_dotProduct [Fintype n] [DecidableEq n] (A : Matrix n n ℝ)
+    (ξ : EuclideanSpace ℝ n) :
     A.toQuadraticForm' ξ = ξ ⬝ᵥ (A *ᵥ ξ) := by
   rw [Matrix.toQuadraticForm',
     LinearMap.BilinMap.toQuadraticMap_apply, Matrix.toLinearMap₂'_apply']
 
 /-- The identity matrix has quadratic form `‖ξ‖²`. -/
 @[simp]
-lemma toQuadraticForm'_one (ξ : EuclideanSpace ℝ n) :
+lemma toQuadraticForm'_one [Fintype n] [DecidableEq n] (ξ : EuclideanSpace ℝ n) :
     (1 : Matrix n n ℝ).toQuadraticForm' ξ = ‖ξ‖ ^ 2 := by
   rw [toQuadraticForm'_eq_dotProduct, one_mulVec]
   simpa [dotProduct, sq] using (EuclideanSpace.real_norm_sq_eq ξ).symm
+
+/-- The symmetric part `(A + Aᵀ) / 2` of a real square matrix.
+
+For divergence-form elliptic operators, coercivity only sees this part of the coefficient
+matrix, while the skew part has zero quadratic form. -/
+noncomputable def symmetricPart (A : Matrix n n ℝ) : Matrix n n ℝ :=
+  (2 : ℝ)⁻¹ • (A + Aᵀ)
+
+/-- The skew-symmetric part `(A - Aᵀ) / 2` of a real square matrix. -/
+noncomputable def skewPart (A : Matrix n n ℝ) : Matrix n n ℝ :=
+  (2 : ℝ)⁻¹ • (A - Aᵀ)
+
+/-- Entrywise formula for the symmetric part of a matrix. -/
+@[simp]
+lemma symmetricPart_apply (A : Matrix n n ℝ) (i j : n) :
+    symmetricPart A i j = (2 : ℝ)⁻¹ * (A i j + A j i) := by
+  rfl
+
+/-- Entrywise formula for the skew-symmetric part of a matrix. -/
+@[simp]
+lemma skewPart_apply (A : Matrix n n ℝ) (i j : n) :
+    skewPart A i j = (2 : ℝ)⁻¹ * (A i j - A j i) := by
+  rfl
+
+/-- The symmetric part of a matrix is symmetric. -/
+lemma symmetricPart_isSymm (A : Matrix n n ℝ) : (symmetricPart A).IsSymm := by
+  exact (Matrix.isSymm_add_transpose_self A).smul _
+
+/-- The skew-symmetric part changes sign under transpose. -/
+@[simp]
+lemma skewPart_transpose (A : Matrix n n ℝ) : (skewPart A)ᵀ = -skewPart A := by
+  ext i j
+  simp [skewPart, sub_eq_add_neg]
+
+/-- A symmetric matrix is equal to its symmetric part. -/
+@[simp]
+lemma symmetricPart_eq_self_of_isSymm {A : Matrix n n ℝ} (hA : A.IsSymm) :
+    symmetricPart A = A := by
+  ext i j
+  rw [symmetricPart_apply, hA.apply]
+  ring
+
+/-- The symmetric and skew-symmetric parts add back to the original matrix. -/
+@[simp]
+lemma symmetricPart_add_skewPart (A : Matrix n n ℝ) : symmetricPart A + skewPart A = A := by
+  ext i j
+  simp [symmetricPart, skewPart]
+  ring
+
+/-- A matrix and its transpose have the same diagonal bilinear form. -/
+lemma dotProduct_transpose_mulVec_self [Fintype n] (A : Matrix n n ℝ)
+    (ξ : EuclideanSpace ℝ n) :
+    ξ ⬝ᵥ (Aᵀ *ᵥ ξ) = ξ ⬝ᵥ (A *ᵥ ξ) := by
+  simpa using Matrix.dotProduct_transpose_mulVec (A := A) ξ ξ
+
+/-- The symmetric part has the same diagonal bilinear form as the original matrix. -/
+lemma dotProduct_symmetricPart_mulVec_self [Fintype n] (A : Matrix n n ℝ)
+    (ξ : EuclideanSpace ℝ n) :
+    ξ ⬝ᵥ (symmetricPart A *ᵥ ξ) = ξ ⬝ᵥ (A *ᵥ ξ) := by
+  rw [symmetricPart, smul_mulVec, dotProduct_smul, add_mulVec, dotProduct_add,
+    dotProduct_transpose_mulVec_self]
+  ring
+
+/-- The skew-symmetric part has zero diagonal bilinear form. -/
+@[simp]
+lemma dotProduct_skewPart_mulVec_self [Fintype n] (A : Matrix n n ℝ)
+    (ξ : EuclideanSpace ℝ n) :
+    ξ ⬝ᵥ (skewPart A *ᵥ ξ) = 0 := by
+  rw [skewPart, smul_mulVec, dotProduct_smul, sub_mulVec]
+  have htranspose : ξ ⬝ᵥ (Aᵀ *ᵥ ξ) = ξ ⬝ᵥ (A *ᵥ ξ) :=
+    dotProduct_transpose_mulVec_self A ξ
+  rw [dotProduct_sub, htranspose]
+  ring
+
+/-- The symmetric part has the same matrix quadratic form as the original matrix. -/
+@[simp]
+lemma toQuadraticForm'_symmetricPart [Fintype n] [DecidableEq n] (A : Matrix n n ℝ)
+    (ξ : EuclideanSpace ℝ n) :
+    (symmetricPart A).toQuadraticForm' ξ = A.toQuadraticForm' ξ := by
+  simp [toQuadraticForm'_eq_dotProduct, dotProduct_symmetricPart_mulVec_self]
+
+/-- The skew-symmetric part has zero matrix quadratic form. -/
+@[simp]
+lemma toQuadraticForm'_skewPart [Fintype n] [DecidableEq n] (A : Matrix n n ℝ)
+    (ξ : EuclideanSpace ℝ n) :
+    (skewPart A).toQuadraticForm' ξ = 0 := by
+  simp [toQuadraticForm'_eq_dotProduct]
+
+/-- The original matrix decomposes as symmetric plus skew-symmetric parts. -/
+lemma symmetricPart_add_skewPart_apply_mulVec [Fintype n] (A : Matrix n n ℝ)
+    (ξ : EuclideanSpace ℝ n) :
+    (symmetricPart A + skewPart A) *ᵥ ξ = A *ᵥ ξ := by
+  rw [symmetricPart_add_skewPart]
 
 /-- Uniform ellipticity and boundedness with explicit constants on a domain.
 
@@ -63,7 +161,8 @@ The predicate says that for every `x ∈ Ω`, the matrix `a x` has quadratic for
 by `λ‖ξ‖²` and bilinear form bounded above by `Λ‖η‖‖ξ‖`, uniformly in `x`, `η`, and `ξ`.
 The side conditions `0 < λ` and `λ ≤ Λ` are part of the predicate so later energy estimates can
 recover them directly. -/
-def UniformlyEllipticOn (Ω : Set X) (a : X → Matrix n n ℝ) (lam Lam : ℝ) : Prop :=
+def UniformlyEllipticOn [Fintype n] [DecidableEq n] (Ω : Set X) (a : X → Matrix n n ℝ)
+    (lam Lam : ℝ) : Prop :=
   0 < lam ∧ lam ≤ Lam ∧
     ∀ ⦃x⦄, x ∈ Ω →
       (∀ ξ : EuclideanSpace ℝ n,
@@ -71,7 +170,7 @@ def UniformlyEllipticOn (Ω : Set X) (a : X → Matrix n n ℝ) (lam Lam : ℝ) 
         ∀ η ξ : EuclideanSpace ℝ n, |η ⬝ᵥ (a x *ᵥ ξ)| ≤ Lam * ‖η‖ * ‖ξ‖
 
 /-- Characteristic restatement of uniform ellipticity and boundedness on a domain. -/
-lemma uniformlyEllipticOn_iff :
+lemma uniformlyEllipticOn_iff [Fintype n] [DecidableEq n] :
     UniformlyEllipticOn Ω a lam Lam ↔
       0 < lam ∧ lam ≤ Lam ∧
         ∀ ⦃x⦄, x ∈ Ω →
@@ -82,6 +181,7 @@ lemma uniformlyEllipticOn_iff :
 
 namespace UniformlyEllipticOn
 
+variable [Fintype n] [DecidableEq n]
 variable {Ω Ω' : Set X} {a : X → Matrix n n ℝ} {lam Lam lam' Lam' : ℝ}
 
 /-- The lower ellipticity constant is positive. -/
@@ -149,11 +249,44 @@ lemma of_bounds (hlam : 0 < lam) (hlamLam : lam ≤ Lam)
     UniformlyEllipticOn Ω a lam Lam :=
   ⟨hlam, hlamLam, fun {_} hx => ⟨hbounds hx, hupper hx⟩⟩
 
+/-- Replacing a coefficient field by its pointwise transpose preserves the same upper
+bilinear bound, with the arguments exchanged. -/
+lemma upper_bound_transpose (h : UniformlyEllipticOn Ω a lam Lam) {x : X} (hx : x ∈ Ω)
+    (η ξ : EuclideanSpace ℝ n) :
+    |η ⬝ᵥ ((a x)ᵀ *ᵥ ξ)| ≤ Lam * ‖η‖ * ‖ξ‖ := by
+  calc
+    |η ⬝ᵥ ((a x)ᵀ *ᵥ ξ)| = |ξ ⬝ᵥ (a x *ᵥ η)| := by
+      rw [Matrix.dotProduct_transpose_mulVec]
+    _ ≤ Lam * ‖ξ‖ * ‖η‖ := h.upper_bound hx ξ η
+    _ = Lam * ‖η‖ * ‖ξ‖ := by ring
+
+/-- The symmetric part of uniformly elliptic coefficients is uniformly elliptic with the same
+constants. The lower bound is unchanged because the skew part has zero quadratic form; the
+upper bound follows by averaging the bounds for `a` and `aᵀ`. -/
+lemma symmetricPart (h : UniformlyEllipticOn Ω a lam Lam) :
+    UniformlyEllipticOn Ω (fun x => PDE.symmetricPart (a x)) lam Lam := by
+  refine of_bounds h.pos h.le (fun {x} hx ξ => ?_) (fun {x} hx η ξ => ?_)
+  · simpa using h.lower_bound hx ξ
+  · rw [PDE.symmetricPart, smul_mulVec, dotProduct_smul, add_mulVec, dotProduct_add]
+    set C : ℝ := Lam * ‖η‖ * ‖ξ‖
+    have hA : |η ⬝ᵥ (a x *ᵥ ξ)| ≤ C := h.upper_bound hx η ξ
+    have hAT : |η ⬝ᵥ ((a x)ᵀ *ᵥ ξ)| ≤ C := h.upper_bound_transpose hx η ξ
+    calc
+      |(2 : ℝ)⁻¹ • (η ⬝ᵥ (a x *ᵥ ξ) + η ⬝ᵥ ((a x)ᵀ *ᵥ ξ))|
+          = (2 : ℝ)⁻¹ * |η ⬝ᵥ (a x *ᵥ ξ) + η ⬝ᵥ ((a x)ᵀ *ᵥ ξ)| := by
+            rw [smul_eq_mul, abs_mul, abs_of_nonneg]
+            · norm_num
+      _ ≤ (2 : ℝ)⁻¹ * (C + C) := by
+        exact mul_le_mul_of_nonneg_left ((abs_add_le _ _).trans (add_le_add hA hAT))
+          (by norm_num)
+      _ = C := by ring
+
 end UniformlyEllipticOn
 
 /-- The constant identity coefficient field is uniformly elliptic with any constants
 `λ ≤ 1 ≤ Λ` and `0 < λ`. This is the coefficient field of the Laplacian model problem. -/
-lemma uniformlyEllipticOn_const_one (Ω : Set X) {lam Lam : ℝ} (hlam : 0 < lam)
+lemma uniformlyEllipticOn_const_one [Fintype n] [DecidableEq n] (Ω : Set X) {lam Lam : ℝ}
+    (hlam : 0 < lam)
     (hlam_one : lam ≤ 1) (hone_Lam : 1 ≤ Lam) :
     UniformlyEllipticOn Ω (fun _ => (1 : Matrix n n ℝ)) lam Lam := by
   refine UniformlyEllipticOn.of_bounds hlam (hlam_one.trans hone_Lam) (fun {x} hx ξ => ?_)
@@ -172,7 +305,7 @@ lemma uniformlyEllipticOn_const_one (Ω : Set X) {lam Lam : ℝ} (hlam : 0 < lam
 
 /-- In particular, the identity coefficient field is uniformly elliptic with constants
 `λ = Λ = 1`. -/
-lemma uniformlyEllipticOn_const_one_one (Ω : Set X) :
+lemma uniformlyEllipticOn_const_one_one [Fintype n] [DecidableEq n] (Ω : Set X) :
     UniformlyEllipticOn Ω (fun _ => (1 : Matrix n n ℝ)) 1 1 :=
   uniformlyEllipticOn_const_one Ω zero_lt_one le_rfl le_rfl
 

--- a/TauCeti/Analysis/PDE/UniformEllipticity.lean
+++ b/TauCeti/Analysis/PDE/UniformEllipticity.lean
@@ -29,8 +29,8 @@ and Lax--Milgram arguments: constants are parameters, not hidden existential dat
   predicate.
 * `TauCeti.PDE.UniformlyEllipticOn.mono_set`: restriction to a smaller domain preserves the
   predicate.
-* `TauCeti.PDE.UniformlyEllipticOn.symmetricPart`: replacing coefficients by their
-  symmetric part preserves the same uniform ellipticity constants.
+* `TauCeti.PDE.UniformlyEllipticOn.selfAdjointPart`: replacing coefficients by their
+  self-adjoint part preserves the same uniform ellipticity constants.
 
 The vectors are `EuclideanSpace ℝ n`, matching the roadmap's bounded open subsets of
 `ℝⁿ`; this type is reducibly a finite `L²` product, so Mathlib's matrix-vector API applies
@@ -157,15 +157,14 @@ lemma upper_bound_transpose (h : UniformlyEllipticOn Ω a lam Lam) {x : X} (hx :
     _ ≤ Lam * ‖ξ‖ * ‖η‖ := h.upper_bound hx ξ η
     _ = Lam * ‖η‖ * ‖ξ‖ := by ring
 
-/-- The symmetric part of uniformly elliptic coefficients is uniformly elliptic with the same
+/-- The self-adjoint part of uniformly elliptic coefficients is uniformly elliptic with the same
 constants. -/
-lemma symmetricPart (h : UniformlyEllipticOn Ω a lam Lam) :
-    UniformlyEllipticOn Ω (fun x => TauCeti.Matrix.symmetricPart (a x)) lam Lam := by
+lemma selfAdjointPart (h : UniformlyEllipticOn Ω a lam Lam) :
+    UniformlyEllipticOn Ω (fun x => (selfAdjointPart ℝ (a x) : Matrix n n ℝ)) lam Lam := by
   refine of_bounds h.pos h.le (fun {x} hx ξ => ?_) (fun {x} hx η ξ => ?_)
-  · simpa using h.lower_bound hx ξ
-  · rw [show TauCeti.Matrix.symmetricPart (a x) = (2 : ℝ)⁻¹ • (a x + (a x)ᵀ) by
-        ext i j
-        simp [TauCeti.Matrix.symmetricPart],
+  · rw [TauCeti.Matrix.toQuadraticForm'_selfAdjointPart]
+    exact h.lower_bound hx ξ
+  · rw [TauCeti.Matrix.selfAdjointPart_eq,
       smul_mulVec, dotProduct_smul, add_mulVec, dotProduct_add]
     set C : ℝ := Lam * ‖η‖ * ‖ξ‖
     have hA : |η ⬝ᵥ (a x *ᵥ ξ)| ≤ C := h.upper_bound hx η ξ

--- a/TauCeti/Analysis/PDE/UniformEllipticity.lean
+++ b/TauCeti/Analysis/PDE/UniformEllipticity.lean
@@ -2,9 +2,7 @@
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 -/
-import Mathlib.Analysis.InnerProductSpace.PiL2
-import Mathlib.LinearAlgebra.QuadraticForm.Basic
-import Mathlib.LinearAlgebra.Matrix.Symmetric
+import TauCeti.LinearAlgebra.Matrix.SymmetricPart
 
 /-!
 # Uniform ellipticity for divergence-form PDE coefficients
@@ -27,7 +25,6 @@ and Lax--Milgram arguments: constants are parameters, not hidden existential dat
 
 * `TauCeti.PDE.UniformlyEllipticOn`: uniform lower and upper ellipticity bounds on a set.
 * `TauCeti.PDE.uniformlyEllipticOn_const_one`: the identity matrix is uniformly elliptic.
-* `TauCeti.PDE.symmetricPart`: the symmetric part `(A + Aᵀ) / 2` of a coefficient matrix.
 * `TauCeti.PDE.UniformlyEllipticOn.mono_constants`: weakening constants preserves the
   predicate.
 * `TauCeti.PDE.UniformlyEllipticOn.mono_set`: restriction to a smaller domain preserves the
@@ -44,116 +41,16 @@ namespace TauCeti
 
 namespace PDE
 
-open Matrix
+open _root_.Matrix
 
 variable {X n : Type*}
-
-/-- Mathlib's matrix quadratic form is the dot-product expression `ξᵀ A ξ`. -/
-lemma toQuadraticForm'_eq_dotProduct [Fintype n] [DecidableEq n] (A : Matrix n n ℝ)
-    (ξ : EuclideanSpace ℝ n) :
-    A.toQuadraticForm' ξ = ξ ⬝ᵥ (A *ᵥ ξ) := by
-  rw [Matrix.toQuadraticForm',
-    LinearMap.BilinMap.toQuadraticMap_apply, Matrix.toLinearMap₂'_apply']
 
 /-- The identity matrix has quadratic form `‖ξ‖²`. -/
 @[simp]
 lemma toQuadraticForm'_one [Fintype n] [DecidableEq n] (ξ : EuclideanSpace ℝ n) :
     (1 : Matrix n n ℝ).toQuadraticForm' ξ = ‖ξ‖ ^ 2 := by
-  rw [toQuadraticForm'_eq_dotProduct, one_mulVec]
+  rw [TauCeti.Matrix.toQuadraticForm'_eq_dotProduct, one_mulVec]
   simpa [dotProduct, sq] using (EuclideanSpace.real_norm_sq_eq ξ).symm
-
-/-- The symmetric part `(A + Aᵀ) / 2` of a real square matrix.
-
-For divergence-form elliptic operators, coercivity only sees this part of the coefficient
-matrix, while the skew part has zero quadratic form. -/
-noncomputable def symmetricPart (A : Matrix n n ℝ) : Matrix n n ℝ :=
-  (2 : ℝ)⁻¹ • (A + Aᵀ)
-
-/-- The skew-symmetric part `(A - Aᵀ) / 2` of a real square matrix. -/
-noncomputable def skewPart (A : Matrix n n ℝ) : Matrix n n ℝ :=
-  (2 : ℝ)⁻¹ • (A - Aᵀ)
-
-/-- Entrywise formula for the symmetric part of a matrix. -/
-@[simp]
-lemma symmetricPart_apply (A : Matrix n n ℝ) (i j : n) :
-    symmetricPart A i j = (2 : ℝ)⁻¹ * (A i j + A j i) := by
-  rfl
-
-/-- Entrywise formula for the skew-symmetric part of a matrix. -/
-@[simp]
-lemma skewPart_apply (A : Matrix n n ℝ) (i j : n) :
-    skewPart A i j = (2 : ℝ)⁻¹ * (A i j - A j i) := by
-  rfl
-
-/-- The symmetric part of a matrix is symmetric. -/
-lemma symmetricPart_isSymm (A : Matrix n n ℝ) : (symmetricPart A).IsSymm := by
-  exact (Matrix.isSymm_add_transpose_self A).smul _
-
-/-- The skew-symmetric part changes sign under transpose. -/
-@[simp]
-lemma skewPart_transpose (A : Matrix n n ℝ) : (skewPart A)ᵀ = -skewPart A := by
-  ext i j
-  simp [skewPart, sub_eq_add_neg]
-
-/-- A symmetric matrix is equal to its symmetric part. -/
-@[simp]
-lemma symmetricPart_eq_self_of_isSymm {A : Matrix n n ℝ} (hA : A.IsSymm) :
-    symmetricPart A = A := by
-  ext i j
-  rw [symmetricPart_apply, hA.apply]
-  ring
-
-/-- The symmetric and skew-symmetric parts add back to the original matrix. -/
-@[simp]
-lemma symmetricPart_add_skewPart (A : Matrix n n ℝ) : symmetricPart A + skewPart A = A := by
-  ext i j
-  simp [symmetricPart, skewPart]
-  ring
-
-/-- A matrix and its transpose have the same diagonal bilinear form. -/
-lemma dotProduct_transpose_mulVec_self [Fintype n] (A : Matrix n n ℝ)
-    (ξ : EuclideanSpace ℝ n) :
-    ξ ⬝ᵥ (Aᵀ *ᵥ ξ) = ξ ⬝ᵥ (A *ᵥ ξ) := by
-  simpa using Matrix.dotProduct_transpose_mulVec (A := A) ξ ξ
-
-/-- The symmetric part has the same diagonal bilinear form as the original matrix. -/
-lemma dotProduct_symmetricPart_mulVec_self [Fintype n] (A : Matrix n n ℝ)
-    (ξ : EuclideanSpace ℝ n) :
-    ξ ⬝ᵥ (symmetricPart A *ᵥ ξ) = ξ ⬝ᵥ (A *ᵥ ξ) := by
-  rw [symmetricPart, smul_mulVec, dotProduct_smul, add_mulVec, dotProduct_add,
-    dotProduct_transpose_mulVec_self]
-  ring
-
-/-- The skew-symmetric part has zero diagonal bilinear form. -/
-@[simp]
-lemma dotProduct_skewPart_mulVec_self [Fintype n] (A : Matrix n n ℝ)
-    (ξ : EuclideanSpace ℝ n) :
-    ξ ⬝ᵥ (skewPart A *ᵥ ξ) = 0 := by
-  rw [skewPart, smul_mulVec, dotProduct_smul, sub_mulVec]
-  have htranspose : ξ ⬝ᵥ (Aᵀ *ᵥ ξ) = ξ ⬝ᵥ (A *ᵥ ξ) :=
-    dotProduct_transpose_mulVec_self A ξ
-  rw [dotProduct_sub, htranspose]
-  ring
-
-/-- The symmetric part has the same matrix quadratic form as the original matrix. -/
-@[simp]
-lemma toQuadraticForm'_symmetricPart [Fintype n] [DecidableEq n] (A : Matrix n n ℝ)
-    (ξ : EuclideanSpace ℝ n) :
-    (symmetricPart A).toQuadraticForm' ξ = A.toQuadraticForm' ξ := by
-  simp [toQuadraticForm'_eq_dotProduct, dotProduct_symmetricPart_mulVec_self]
-
-/-- The skew-symmetric part has zero matrix quadratic form. -/
-@[simp]
-lemma toQuadraticForm'_skewPart [Fintype n] [DecidableEq n] (A : Matrix n n ℝ)
-    (ξ : EuclideanSpace ℝ n) :
-    (skewPart A).toQuadraticForm' ξ = 0 := by
-  simp [toQuadraticForm'_eq_dotProduct]
-
-/-- The original matrix decomposes as symmetric plus skew-symmetric parts. -/
-lemma symmetricPart_add_skewPart_apply_mulVec [Fintype n] (A : Matrix n n ℝ)
-    (ξ : EuclideanSpace ℝ n) :
-    (symmetricPart A + skewPart A) *ᵥ ξ = A *ᵥ ξ := by
-  rw [symmetricPart_add_skewPart]
 
 /-- Uniform ellipticity and boundedness with explicit constants on a domain.
 
@@ -261,13 +158,15 @@ lemma upper_bound_transpose (h : UniformlyEllipticOn Ω a lam Lam) {x : X} (hx :
     _ = Lam * ‖η‖ * ‖ξ‖ := by ring
 
 /-- The symmetric part of uniformly elliptic coefficients is uniformly elliptic with the same
-constants. The lower bound is unchanged because the skew part has zero quadratic form; the
-upper bound follows by averaging the bounds for `a` and `aᵀ`. -/
+constants. -/
 lemma symmetricPart (h : UniformlyEllipticOn Ω a lam Lam) :
-    UniformlyEllipticOn Ω (fun x => PDE.symmetricPart (a x)) lam Lam := by
+    UniformlyEllipticOn Ω (fun x => TauCeti.Matrix.symmetricPart (a x)) lam Lam := by
   refine of_bounds h.pos h.le (fun {x} hx ξ => ?_) (fun {x} hx η ξ => ?_)
   · simpa using h.lower_bound hx ξ
-  · rw [PDE.symmetricPart, smul_mulVec, dotProduct_smul, add_mulVec, dotProduct_add]
+  · rw [show TauCeti.Matrix.symmetricPart (a x) = (2 : ℝ)⁻¹ • (a x + (a x)ᵀ) by
+        ext i j
+        simp [TauCeti.Matrix.symmetricPart],
+      smul_mulVec, dotProduct_smul, add_mulVec, dotProduct_add]
     set C : ℝ := Lam * ‖η‖ * ‖ξ‖
     have hA : |η ⬝ᵥ (a x *ᵥ ξ)| ≤ C := h.upper_bound hx η ξ
     have hAT : |η ⬝ᵥ ((a x)ᵀ *ᵥ ξ)| ≤ C := h.upper_bound_transpose hx η ξ

--- a/TauCeti/Analysis/PDE/UniformEllipticity.lean
+++ b/TauCeti/Analysis/PDE/UniformEllipticity.lean
@@ -164,8 +164,11 @@ lemma selfAdjointPart (h : UniformlyEllipticOn Ω a lam Lam) :
   refine of_bounds h.pos h.le (fun {x} hx ξ => ?_) (fun {x} hx η ξ => ?_)
   · rw [TauCeti.Matrix.toQuadraticForm'_selfAdjointPart]
     exact h.lower_bound hx ξ
-  · rw [TauCeti.Matrix.selfAdjointPart_eq,
-      smul_mulVec, dotProduct_smul, add_mulVec, dotProduct_add]
+  · have hself :
+        (_root_.selfAdjointPart ℝ (a x) : Matrix n n ℝ) = (2 : ℝ)⁻¹ • (a x + (a x)ᵀ) := by
+      ext i j
+      simp
+    rw [hself, smul_mulVec, dotProduct_smul, add_mulVec, dotProduct_add]
     set C : ℝ := Lam * ‖η‖ * ‖ξ‖
     have hA : |η ⬝ᵥ (a x *ᵥ ξ)| ≤ C := h.upper_bound hx η ξ
     have hAT : |η ⬝ᵥ ((a x)ᵀ *ᵥ ξ)| ≤ C := h.upper_bound_transpose hx η ξ

--- a/TauCeti/LinearAlgebra/Matrix/SymmetricPart.lean
+++ b/TauCeti/LinearAlgebra/Matrix/SymmetricPart.lean
@@ -1,0 +1,129 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+import Mathlib.Algebra.Star.Module
+import Mathlib.Analysis.InnerProductSpace.PiL2
+import Mathlib.LinearAlgebra.Matrix.Hermitian
+import Mathlib.LinearAlgebra.QuadraticForm.Basic
+
+/-!
+# Symmetric and skew-symmetric parts of real matrices
+
+This file records the real square-matrix API for the decomposition of a matrix into its
+symmetric and skew-symmetric parts. The definitions are thin aliases for Mathlib's
+`selfAdjointPart` and `skewAdjointPart` star-module projections.
+-/
+
+namespace TauCeti
+
+namespace Matrix
+
+open _root_.Matrix
+
+variable {n : Type*}
+
+/-- Mathlib's matrix quadratic form is the dot-product expression `ξᵀ A ξ`. -/
+lemma toQuadraticForm'_eq_dotProduct [Fintype n] [DecidableEq n] (A : Matrix n n ℝ)
+    (ξ : EuclideanSpace ℝ n) :
+    A.toQuadraticForm' ξ = ξ ⬝ᵥ (A *ᵥ ξ) := by
+  rw [_root_.Matrix.toQuadraticForm',
+    LinearMap.BilinMap.toQuadraticMap_apply, _root_.Matrix.toLinearMap₂'_apply']
+
+/-- The symmetric part `(A + Aᵀ) / 2` of a real square matrix. -/
+noncomputable def symmetricPart (A : Matrix n n ℝ) : Matrix n n ℝ :=
+  (selfAdjointPart ℝ A : Matrix n n ℝ)
+
+/-- The skew-symmetric part `(A - Aᵀ) / 2` of a real square matrix. -/
+noncomputable def skewPart (A : Matrix n n ℝ) : Matrix n n ℝ :=
+  (skewAdjointPart ℝ A : Matrix n n ℝ)
+
+/-- Entrywise formula for the symmetric part of a matrix. -/
+@[simp]
+lemma symmetricPart_apply (A : Matrix n n ℝ) (i j : n) :
+    symmetricPart A i j = (2 : ℝ)⁻¹ * (A i j + A j i) := by
+  simp [symmetricPart, selfAdjointPart_apply_coe, invOf_eq_inv]
+
+/-- Entrywise formula for the skew-symmetric part of a matrix. -/
+@[simp]
+lemma skewPart_apply (A : Matrix n n ℝ) (i j : n) :
+    skewPart A i j = (2 : ℝ)⁻¹ * (A i j - A j i) := by
+  simp [skewPart, skewAdjointPart_apply_coe, invOf_eq_inv]
+
+/-- The symmetric part of a matrix is symmetric. -/
+lemma isSymm_symmetricPart (A : Matrix n n ℝ) : (symmetricPart A).IsSymm := by
+  ext i j
+  simp [add_comm]
+
+/-- The symmetric part is invariant under transpose. -/
+@[simp]
+lemma symmetricPart_transpose (A : Matrix n n ℝ) :
+    symmetricPart Aᵀ = symmetricPart A := by
+  ext i j
+  simp [add_comm]
+
+/-- The skew-symmetric part changes sign under transpose. -/
+@[simp]
+lemma skewPart_transpose (A : Matrix n n ℝ) : (skewPart A)ᵀ = -skewPart A := by
+  ext i j
+  simp [skewPart, sub_eq_add_neg]
+
+/-- A symmetric matrix is equal to its symmetric part. -/
+@[simp]
+lemma symmetricPart_eq_self_of_isSymm {A : Matrix n n ℝ} (hA : A.IsSymm) :
+    symmetricPart A = A := by
+  ext i j
+  rw [symmetricPart_apply, hA.apply]
+  ring
+
+/-- The symmetric and skew-symmetric parts add back to the original matrix. -/
+@[simp]
+lemma symmetricPart_add_skewPart (A : Matrix n n ℝ) : symmetricPart A + skewPart A = A := by
+  simpa [symmetricPart, skewPart] using
+    (StarModule.selfAdjointPart_add_skewAdjointPart ℝ A)
+
+/-- A matrix and its transpose have the same diagonal bilinear form. -/
+lemma dotProduct_transpose_mulVec_self [Fintype n] (A : Matrix n n ℝ)
+    (ξ : EuclideanSpace ℝ n) :
+    ξ ⬝ᵥ (Aᵀ *ᵥ ξ) = ξ ⬝ᵥ (A *ᵥ ξ) := by
+  simpa using _root_.Matrix.dotProduct_transpose_mulVec (A := A) ξ ξ
+
+/-- The symmetric part has the same diagonal bilinear form as the original matrix. -/
+@[simp]
+lemma dotProduct_symmetricPart_mulVec_self [Fintype n] (A : Matrix n n ℝ)
+    (ξ : EuclideanSpace ℝ n) :
+    ξ ⬝ᵥ (symmetricPart A *ᵥ ξ) = ξ ⬝ᵥ (A *ᵥ ξ) := by
+  rw [show symmetricPart A = (2 : ℝ)⁻¹ • (A + Aᵀ) by ext i j; simp [symmetricPart],
+    smul_mulVec, dotProduct_smul, add_mulVec, dotProduct_add,
+    dotProduct_transpose_mulVec_self]
+  ring
+
+/-- The skew-symmetric part has zero diagonal bilinear form. -/
+@[simp]
+lemma dotProduct_skewPart_mulVec_self [Fintype n] (A : Matrix n n ℝ)
+    (ξ : EuclideanSpace ℝ n) :
+    ξ ⬝ᵥ (skewPart A *ᵥ ξ) = 0 := by
+  rw [show skewPart A = (2 : ℝ)⁻¹ • (A - Aᵀ) by ext i j; simp [skewPart],
+    smul_mulVec, dotProduct_smul, sub_mulVec]
+  have htranspose : ξ ⬝ᵥ (Aᵀ *ᵥ ξ) = ξ ⬝ᵥ (A *ᵥ ξ) :=
+    dotProduct_transpose_mulVec_self A ξ
+  rw [dotProduct_sub, htranspose]
+  ring
+
+/-- The symmetric part has the same matrix quadratic form as the original matrix. -/
+@[simp]
+lemma toQuadraticForm'_symmetricPart [Fintype n] [DecidableEq n] (A : Matrix n n ℝ)
+    (ξ : EuclideanSpace ℝ n) :
+    (symmetricPart A).toQuadraticForm' ξ = A.toQuadraticForm' ξ := by
+  simp [toQuadraticForm'_eq_dotProduct, dotProduct_symmetricPart_mulVec_self]
+
+/-- The skew-symmetric part has zero matrix quadratic form. -/
+@[simp]
+lemma toQuadraticForm'_skewPart [Fintype n] [DecidableEq n] (A : Matrix n n ℝ)
+    (ξ : EuclideanSpace ℝ n) :
+    (skewPart A).toQuadraticForm' ξ = 0 := by
+  simp [toQuadraticForm'_eq_dotProduct]
+
+end Matrix
+
+end TauCeti

--- a/TauCeti/LinearAlgebra/Matrix/SymmetricPart.lean
+++ b/TauCeti/LinearAlgebra/Matrix/SymmetricPart.lean
@@ -84,19 +84,13 @@ lemma selfAdjointPart_eq_self_of_isSymm {A : Matrix n n ℝ} (hA : A.IsSymm) :
   rw [selfAdjointPart_apply, hA.apply]
   ring
 
-/-- A matrix and its transpose have the same diagonal bilinear form. -/
-lemma dotProduct_transpose_mulVec_self [Fintype n] [NonUnitalCommSemiring R]
-    (A : Matrix n n R) (ξ : n → R) :
-    ξ ⬝ᵥ (Aᵀ *ᵥ ξ) = ξ ⬝ᵥ (A *ᵥ ξ) := by
-  simpa using _root_.Matrix.dotProduct_transpose_mulVec (A := A) ξ ξ
-
 /-- The self-adjoint part has the same diagonal bilinear form as the original matrix. -/
 @[simp]
 lemma dotProduct_selfAdjointPart_mulVec_self [Fintype n] (A : Matrix n n ℝ)
     (ξ : n → ℝ) :
     ξ ⬝ᵥ ((selfAdjointPart ℝ A : Matrix n n ℝ) *ᵥ ξ) = ξ ⬝ᵥ (A *ᵥ ξ) := by
   rw [selfAdjointPart_eq, smul_mulVec, dotProduct_smul, add_mulVec, dotProduct_add,
-    dotProduct_transpose_mulVec_self]
+    _root_.Matrix.dotProduct_transpose_mulVec]
   ring
 
 /-- The skew-adjoint part has zero diagonal bilinear form. -/
@@ -106,7 +100,7 @@ lemma dotProduct_skewAdjointPart_mulVec_self [Fintype n] (A : Matrix n n ℝ)
     ξ ⬝ᵥ ((skewAdjointPart ℝ A : Matrix n n ℝ) *ᵥ ξ) = 0 := by
   rw [skewAdjointPart_eq, smul_mulVec, dotProduct_smul, sub_mulVec]
   have htranspose : ξ ⬝ᵥ (Aᵀ *ᵥ ξ) = ξ ⬝ᵥ (A *ᵥ ξ) :=
-    dotProduct_transpose_mulVec_self A ξ
+    by simpa using _root_.Matrix.dotProduct_transpose_mulVec (A := A) ξ ξ
   rw [dotProduct_sub, htranspose]
   ring
 

--- a/TauCeti/LinearAlgebra/Matrix/SymmetricPart.lean
+++ b/TauCeti/LinearAlgebra/Matrix/SymmetricPart.lean
@@ -4,15 +4,14 @@ Released under Apache 2.0 license as described in the file LICENSE.
 -/
 import Mathlib.Algebra.Star.Module
 import Mathlib.Analysis.InnerProductSpace.PiL2
-import Mathlib.LinearAlgebra.Matrix.Hermitian
 import Mathlib.LinearAlgebra.QuadraticForm.Basic
 
 /-!
-# Symmetric and skew-symmetric parts of real matrices
+# Self-adjoint and skew-adjoint parts of real matrices
 
 This file records the real square-matrix API for the decomposition of a matrix into its
-symmetric and skew-symmetric parts. The definitions are thin aliases for Mathlib's
-`selfAdjointPart` and `skewAdjointPart` star-module projections.
+self-adjoint and skew-adjoint parts, using Mathlib's `selfAdjointPart` and `skewAdjointPart`
+star-module projections.
 -/
 
 namespace TauCeti
@@ -21,108 +20,116 @@ namespace Matrix
 
 open _root_.Matrix
 
-variable {n : Type*}
+variable {n R : Type*}
 
 /-- Mathlib's matrix quadratic form is the dot-product expression `ξᵀ A ξ`. -/
-lemma toQuadraticForm'_eq_dotProduct [Fintype n] [DecidableEq n] (A : Matrix n n ℝ)
-    (ξ : EuclideanSpace ℝ n) :
+lemma toQuadraticForm'_eq_dotProduct [Fintype n] [DecidableEq n] [CommRing R]
+    (A : Matrix n n R) (ξ : n → R) :
     A.toQuadraticForm' ξ = ξ ⬝ᵥ (A *ᵥ ξ) := by
   rw [_root_.Matrix.toQuadraticForm',
     LinearMap.BilinMap.toQuadraticMap_apply, _root_.Matrix.toLinearMap₂'_apply']
 
-/-- The symmetric part `(A + Aᵀ) / 2` of a real square matrix. -/
-noncomputable def symmetricPart (A : Matrix n n ℝ) : Matrix n n ℝ :=
-  (selfAdjointPart ℝ A : Matrix n n ℝ)
+variable {n : Type*}
 
-/-- The skew-symmetric part `(A - Aᵀ) / 2` of a real square matrix. -/
-noncomputable def skewPart (A : Matrix n n ℝ) : Matrix n n ℝ :=
-  (skewAdjointPart ℝ A : Matrix n n ℝ)
+/-- Matrix-level formula for Mathlib's self-adjoint projection of a real square matrix. -/
+lemma selfAdjointPart_eq (A : Matrix n n ℝ) :
+    (selfAdjointPart ℝ A : Matrix n n ℝ) = (2 : ℝ)⁻¹ • (A + Aᵀ) := by
+  ext i j
+  simp [selfAdjointPart_apply_coe, invOf_eq_inv]
 
-/-- Entrywise formula for the symmetric part of a matrix. -/
+/-- Matrix-level formula for Mathlib's skew-adjoint projection of a real square matrix. -/
+lemma skewAdjointPart_eq (A : Matrix n n ℝ) :
+    (skewAdjointPart ℝ A : Matrix n n ℝ) = (2 : ℝ)⁻¹ • (A - Aᵀ) := by
+  ext i j
+  simp [skewAdjointPart_apply_coe, invOf_eq_inv]
+
+/-- Entrywise formula for the self-adjoint part of a real square matrix. -/
 @[simp]
-lemma symmetricPart_apply (A : Matrix n n ℝ) (i j : n) :
-    symmetricPart A i j = (2 : ℝ)⁻¹ * (A i j + A j i) := by
-  simp [symmetricPart, selfAdjointPart_apply_coe, invOf_eq_inv]
+lemma selfAdjointPart_apply (A : Matrix n n ℝ) (i j : n) :
+    (selfAdjointPart ℝ A : Matrix n n ℝ) i j = (2 : ℝ)⁻¹ * (A i j + A j i) := by
+  simp [selfAdjointPart_apply_coe, invOf_eq_inv]
 
-/-- Entrywise formula for the skew-symmetric part of a matrix. -/
+/-- Entrywise formula for the skew-adjoint part of a real square matrix. -/
 @[simp]
-lemma skewPart_apply (A : Matrix n n ℝ) (i j : n) :
-    skewPart A i j = (2 : ℝ)⁻¹ * (A i j - A j i) := by
-  simp [skewPart, skewAdjointPart_apply_coe, invOf_eq_inv]
+lemma skewAdjointPart_apply (A : Matrix n n ℝ) (i j : n) :
+    (skewAdjointPart ℝ A : Matrix n n ℝ) i j = (2 : ℝ)⁻¹ * (A i j - A j i) := by
+  simp [skewAdjointPart_apply_coe, invOf_eq_inv]
 
-/-- The symmetric part of a matrix is symmetric. -/
-lemma isSymm_symmetricPart (A : Matrix n n ℝ) : (symmetricPart A).IsSymm := by
+/-- The self-adjoint part of a real square matrix is symmetric. -/
+lemma isSymm_selfAdjointPart (A : Matrix n n ℝ) :
+    (selfAdjointPart ℝ A : Matrix n n ℝ).IsSymm := by
   ext i j
   simp [add_comm]
-
-/-- The symmetric part is invariant under transpose. -/
-@[simp]
-lemma symmetricPart_transpose (A : Matrix n n ℝ) :
-    symmetricPart Aᵀ = symmetricPart A := by
-  ext i j
-  simp [add_comm]
-
-/-- The skew-symmetric part changes sign under transpose. -/
-@[simp]
-lemma skewPart_transpose (A : Matrix n n ℝ) : (skewPart A)ᵀ = -skewPart A := by
-  ext i j
-  simp [skewPart, sub_eq_add_neg]
-
-/-- A symmetric matrix is equal to its symmetric part. -/
-@[simp]
-lemma symmetricPart_eq_self_of_isSymm {A : Matrix n n ℝ} (hA : A.IsSymm) :
-    symmetricPart A = A := by
-  ext i j
-  rw [symmetricPart_apply, hA.apply]
   ring
 
-/-- The symmetric and skew-symmetric parts add back to the original matrix. -/
+/-- The self-adjoint part is invariant under transpose. -/
 @[simp]
-lemma symmetricPart_add_skewPart (A : Matrix n n ℝ) : symmetricPart A + skewPart A = A := by
-  simpa [symmetricPart, skewPart] using
-    (StarModule.selfAdjointPart_add_skewAdjointPart ℝ A)
+lemma selfAdjointPart_transpose (A : Matrix n n ℝ) :
+    (selfAdjointPart ℝ Aᵀ : Matrix n n ℝ) = (selfAdjointPart ℝ A : Matrix n n ℝ) := by
+  ext i j
+  simp [add_comm]
+
+/-- The skew-adjoint part changes sign under transpose. -/
+@[simp]
+lemma skewAdjointPart_transpose (A : Matrix n n ℝ) :
+    (skewAdjointPart ℝ A : Matrix n n ℝ)ᵀ = -(skewAdjointPart ℝ A : Matrix n n ℝ) := by
+  ext i j
+  simp [sub_eq_add_neg]
+
+/-- A symmetric matrix is equal to its self-adjoint part. -/
+@[simp]
+lemma selfAdjointPart_eq_self_of_isSymm {A : Matrix n n ℝ} (hA : A.IsSymm) :
+    (selfAdjointPart ℝ A : Matrix n n ℝ) = A := by
+  ext i j
+  rw [selfAdjointPart_apply, hA.apply]
+  ring
+
+/-- The self-adjoint and skew-adjoint parts add back to the original matrix. -/
+@[simp]
+lemma selfAdjointPart_add_skewAdjointPart (A : Matrix n n ℝ) :
+    (selfAdjointPart ℝ A : Matrix n n ℝ) + (skewAdjointPart ℝ A : Matrix n n ℝ) = A :=
+  StarModule.selfAdjointPart_add_skewAdjointPart ℝ A
 
 /-- A matrix and its transpose have the same diagonal bilinear form. -/
 lemma dotProduct_transpose_mulVec_self [Fintype n] (A : Matrix n n ℝ)
-    (ξ : EuclideanSpace ℝ n) :
+    (ξ : n → ℝ) :
     ξ ⬝ᵥ (Aᵀ *ᵥ ξ) = ξ ⬝ᵥ (A *ᵥ ξ) := by
   simpa using _root_.Matrix.dotProduct_transpose_mulVec (A := A) ξ ξ
 
-/-- The symmetric part has the same diagonal bilinear form as the original matrix. -/
+/-- The self-adjoint part has the same diagonal bilinear form as the original matrix. -/
 @[simp]
-lemma dotProduct_symmetricPart_mulVec_self [Fintype n] (A : Matrix n n ℝ)
-    (ξ : EuclideanSpace ℝ n) :
-    ξ ⬝ᵥ (symmetricPart A *ᵥ ξ) = ξ ⬝ᵥ (A *ᵥ ξ) := by
-  rw [show symmetricPart A = (2 : ℝ)⁻¹ • (A + Aᵀ) by ext i j; simp [symmetricPart],
-    smul_mulVec, dotProduct_smul, add_mulVec, dotProduct_add,
+lemma dotProduct_selfAdjointPart_mulVec_self [Fintype n] (A : Matrix n n ℝ)
+    (ξ : n → ℝ) :
+    ξ ⬝ᵥ ((selfAdjointPart ℝ A : Matrix n n ℝ) *ᵥ ξ) = ξ ⬝ᵥ (A *ᵥ ξ) := by
+  rw [selfAdjointPart_eq, smul_mulVec, dotProduct_smul, add_mulVec, dotProduct_add,
     dotProduct_transpose_mulVec_self]
   ring
 
-/-- The skew-symmetric part has zero diagonal bilinear form. -/
+/-- The skew-adjoint part has zero diagonal bilinear form. -/
 @[simp]
-lemma dotProduct_skewPart_mulVec_self [Fintype n] (A : Matrix n n ℝ)
-    (ξ : EuclideanSpace ℝ n) :
-    ξ ⬝ᵥ (skewPart A *ᵥ ξ) = 0 := by
-  rw [show skewPart A = (2 : ℝ)⁻¹ • (A - Aᵀ) by ext i j; simp [skewPart],
-    smul_mulVec, dotProduct_smul, sub_mulVec]
+lemma dotProduct_skewAdjointPart_mulVec_self [Fintype n] (A : Matrix n n ℝ)
+    (ξ : n → ℝ) :
+    ξ ⬝ᵥ ((skewAdjointPart ℝ A : Matrix n n ℝ) *ᵥ ξ) = 0 := by
+  rw [skewAdjointPart_eq, smul_mulVec, dotProduct_smul, sub_mulVec]
   have htranspose : ξ ⬝ᵥ (Aᵀ *ᵥ ξ) = ξ ⬝ᵥ (A *ᵥ ξ) :=
     dotProduct_transpose_mulVec_self A ξ
   rw [dotProduct_sub, htranspose]
   ring
 
-/-- The symmetric part has the same matrix quadratic form as the original matrix. -/
+/-- The self-adjoint part has the same matrix quadratic form as the original matrix. -/
 @[simp]
-lemma toQuadraticForm'_symmetricPart [Fintype n] [DecidableEq n] (A : Matrix n n ℝ)
+lemma toQuadraticForm'_selfAdjointPart [Fintype n] [DecidableEq n] (A : Matrix n n ℝ)
     (ξ : EuclideanSpace ℝ n) :
-    (symmetricPart A).toQuadraticForm' ξ = A.toQuadraticForm' ξ := by
-  simp [toQuadraticForm'_eq_dotProduct, dotProduct_symmetricPart_mulVec_self]
+    (selfAdjointPart ℝ A : Matrix n n ℝ).toQuadraticForm' ξ = A.toQuadraticForm' ξ := by
+  rw [toQuadraticForm'_eq_dotProduct, toQuadraticForm'_eq_dotProduct,
+    dotProduct_selfAdjointPart_mulVec_self]
 
-/-- The skew-symmetric part has zero matrix quadratic form. -/
+/-- The skew-adjoint part has zero matrix quadratic form. -/
 @[simp]
-lemma toQuadraticForm'_skewPart [Fintype n] [DecidableEq n] (A : Matrix n n ℝ)
+lemma toQuadraticForm'_skewAdjointPart [Fintype n] [DecidableEq n] (A : Matrix n n ℝ)
     (ξ : EuclideanSpace ℝ n) :
-    (skewPart A).toQuadraticForm' ξ = 0 := by
-  simp [toQuadraticForm'_eq_dotProduct]
+    (skewAdjointPart ℝ A : Matrix n n ℝ).toQuadraticForm' ξ = 0 := by
+  rw [toQuadraticForm'_eq_dotProduct, dotProduct_skewAdjointPart_mulVec_self]
 
 end Matrix
 

--- a/TauCeti/LinearAlgebra/Matrix/SymmetricPart.lean
+++ b/TauCeti/LinearAlgebra/Matrix/SymmetricPart.lean
@@ -31,35 +31,12 @@ lemma toQuadraticForm'_eq_dotProduct [Fintype n] [DecidableEq n] [CommRing R]
 
 variable {n : Type*}
 
-/-- Matrix-level formula for Mathlib's self-adjoint projection of a real square matrix. -/
-lemma selfAdjointPart_eq (A : Matrix n n ℝ) :
-    (selfAdjointPart ℝ A : Matrix n n ℝ) = (2 : ℝ)⁻¹ • (A + Aᵀ) := by
-  ext i j
-  simp [selfAdjointPart_apply_coe, invOf_eq_inv]
-
-/-- Matrix-level formula for Mathlib's skew-adjoint projection of a real square matrix. -/
-lemma skewAdjointPart_eq (A : Matrix n n ℝ) :
-    (skewAdjointPart ℝ A : Matrix n n ℝ) = (2 : ℝ)⁻¹ • (A - Aᵀ) := by
-  ext i j
-  simp [skewAdjointPart_apply_coe, invOf_eq_inv]
-
-/-- Entrywise formula for the self-adjoint part of a real square matrix. -/
-@[simp]
-lemma selfAdjointPart_apply (A : Matrix n n ℝ) (i j : n) :
-    (selfAdjointPart ℝ A : Matrix n n ℝ) i j = (2 : ℝ)⁻¹ * (A i j + A j i) := by
-  simp [selfAdjointPart_apply_coe, invOf_eq_inv]
-
-/-- Entrywise formula for the skew-adjoint part of a real square matrix. -/
-@[simp]
-lemma skewAdjointPart_apply (A : Matrix n n ℝ) (i j : n) :
-    (skewAdjointPart ℝ A : Matrix n n ℝ) i j = (2 : ℝ)⁻¹ * (A i j - A j i) := by
-  simp [skewAdjointPart_apply_coe, invOf_eq_inv]
-
 /-- The self-adjoint part of a real square matrix is symmetric. -/
 lemma isSymm_selfAdjointPart (A : Matrix n n ℝ) :
     (selfAdjointPart ℝ A : Matrix n n ℝ).IsSymm := by
   ext i j
-  simp [add_comm]
+  simp [selfAdjointPart_apply_coe, invOf_eq_inv, Matrix.star_eq_conjTranspose,
+    Matrix.conjTranspose_eq_transpose_of_trivial, add_comm]
   ring
 
 /-- The self-adjoint part is invariant under transpose. -/
@@ -67,21 +44,24 @@ lemma isSymm_selfAdjointPart (A : Matrix n n ℝ) :
 lemma selfAdjointPart_transpose (A : Matrix n n ℝ) :
     (selfAdjointPart ℝ Aᵀ : Matrix n n ℝ) = (selfAdjointPart ℝ A : Matrix n n ℝ) := by
   ext i j
-  simp [add_comm]
+  simp [selfAdjointPart_apply_coe, invOf_eq_inv, Matrix.star_eq_conjTranspose,
+    Matrix.conjTranspose_eq_transpose_of_trivial, add_comm]
 
 /-- The skew-adjoint part changes sign under transpose. -/
 @[simp]
 lemma skewAdjointPart_transpose (A : Matrix n n ℝ) :
     (skewAdjointPart ℝ A : Matrix n n ℝ)ᵀ = -(skewAdjointPart ℝ A : Matrix n n ℝ) := by
   ext i j
-  simp [sub_eq_add_neg]
+  simp [skewAdjointPart_apply_coe, invOf_eq_inv, Matrix.star_eq_conjTranspose,
+    Matrix.conjTranspose_eq_transpose_of_trivial, sub_eq_add_neg]
 
 /-- A symmetric matrix is equal to its self-adjoint part. -/
 @[simp]
 lemma selfAdjointPart_eq_self_of_isSymm {A : Matrix n n ℝ} (hA : A.IsSymm) :
     (selfAdjointPart ℝ A : Matrix n n ℝ) = A := by
   ext i j
-  rw [selfAdjointPart_apply, hA.apply]
+  simp [selfAdjointPart_apply_coe, invOf_eq_inv, Matrix.star_eq_conjTranspose,
+    Matrix.conjTranspose_eq_transpose_of_trivial, hA.apply]
   ring
 
 /-- The self-adjoint part has the same diagonal bilinear form as the original matrix. -/
@@ -89,7 +69,12 @@ lemma selfAdjointPart_eq_self_of_isSymm {A : Matrix n n ℝ} (hA : A.IsSymm) :
 lemma dotProduct_selfAdjointPart_mulVec_self [Fintype n] (A : Matrix n n ℝ)
     (ξ : n → ℝ) :
     ξ ⬝ᵥ ((selfAdjointPart ℝ A : Matrix n n ℝ) *ᵥ ξ) = ξ ⬝ᵥ (A *ᵥ ξ) := by
-  rw [selfAdjointPart_eq, smul_mulVec, dotProduct_smul, add_mulVec, dotProduct_add,
+  have hself :
+      (selfAdjointPart ℝ A : Matrix n n ℝ) = (2 : ℝ)⁻¹ • (A + Aᵀ) := by
+    ext i j
+    simp [selfAdjointPart_apply_coe, invOf_eq_inv, Matrix.star_eq_conjTranspose,
+      Matrix.conjTranspose_eq_transpose_of_trivial]
+  rw [hself, smul_mulVec, dotProduct_smul, add_mulVec, dotProduct_add,
     _root_.Matrix.dotProduct_transpose_mulVec]
   ring
 
@@ -98,7 +83,12 @@ lemma dotProduct_selfAdjointPart_mulVec_self [Fintype n] (A : Matrix n n ℝ)
 lemma dotProduct_skewAdjointPart_mulVec_self [Fintype n] (A : Matrix n n ℝ)
     (ξ : n → ℝ) :
     ξ ⬝ᵥ ((skewAdjointPart ℝ A : Matrix n n ℝ) *ᵥ ξ) = 0 := by
-  rw [skewAdjointPart_eq, smul_mulVec, dotProduct_smul, sub_mulVec]
+  have hskew :
+      (skewAdjointPart ℝ A : Matrix n n ℝ) = (2 : ℝ)⁻¹ • (A - Aᵀ) := by
+    ext i j
+    simp [skewAdjointPart_apply_coe, invOf_eq_inv, Matrix.star_eq_conjTranspose,
+      Matrix.conjTranspose_eq_transpose_of_trivial]
+  rw [hskew, smul_mulVec, dotProduct_smul, sub_mulVec]
   have htranspose : ξ ⬝ᵥ (Aᵀ *ᵥ ξ) = ξ ⬝ᵥ (A *ᵥ ξ) :=
     by simpa using _root_.Matrix.dotProduct_transpose_mulVec (A := A) ξ ξ
   rw [dotProduct_sub, htranspose]

--- a/TauCeti/LinearAlgebra/Matrix/SymmetricPart.lean
+++ b/TauCeti/LinearAlgebra/Matrix/SymmetricPart.lean
@@ -84,15 +84,9 @@ lemma selfAdjointPart_eq_self_of_isSymm {A : Matrix n n ℝ} (hA : A.IsSymm) :
   rw [selfAdjointPart_apply, hA.apply]
   ring
 
-/-- The self-adjoint and skew-adjoint parts add back to the original matrix. -/
-@[simp]
-lemma selfAdjointPart_add_skewAdjointPart (A : Matrix n n ℝ) :
-    (selfAdjointPart ℝ A : Matrix n n ℝ) + (skewAdjointPart ℝ A : Matrix n n ℝ) = A :=
-  StarModule.selfAdjointPart_add_skewAdjointPart ℝ A
-
 /-- A matrix and its transpose have the same diagonal bilinear form. -/
-lemma dotProduct_transpose_mulVec_self [Fintype n] (A : Matrix n n ℝ)
-    (ξ : n → ℝ) :
+lemma dotProduct_transpose_mulVec_self [Fintype n] [NonUnitalCommSemiring R]
+    (A : Matrix n n R) (ξ : n → R) :
     ξ ⬝ᵥ (Aᵀ *ᵥ ξ) = ξ ⬝ᵥ (A *ᵥ ξ) := by
   simpa using _root_.Matrix.dotProduct_transpose_mulVec (A := A) ξ ξ
 


### PR DESCRIPTION
This PR adds the symmetric and skew-symmetric parts of real coefficient matrices, proves that only the symmetric part contributes to the diagonal quadratic form, and shows `UniformlyEllipticOn` is preserved by pointwise symmetrization. It advances `TauCetiRoadmap/PDE/README.md` under Standing hypotheses, target "Uniform ellipticity with explicit constants `0 < λ ≤ Λ`", and the Lane D prerequisite "the energy/weak formulation and Gårding's inequality (then Lax-Milgram)" for divergence-form elliptic operators.

No Mathlib infrastructure is vendored. The formal development consumes Mathlib's matrix transpose/symmetry and dot-product API from `Mathlib.LinearAlgebra.Matrix.Symmetric`, `Mathlib.LinearAlgebra.QuadraticForm.Basic`, and `Mathlib.Analysis.InnerProductSpace.PiL2`.

Verified with `lake exe cache get`, `lake build`, and `lake exe axioms`.

🤖 Prepared with Codex