### PR TITLE
feat: add commutative Hopf algebra points functor

### DIFF
--- a/TauCeti.lean
+++ b/TauCeti.lean
@@ -3,5 +3,6 @@
 -- Everything reachable from here must be sorry-free, and must not import
 -- `TauCetiRoadmap` or `TauCetiReview` (both enforced in CI). As the library
 -- grows, import the submodules of `TauCeti/` here.
+import TauCeti.Algebra.AlgebraicGroup.CommHopfAlgCat
 import TauCeti.Algebra.Coalgebra.ComoduleCat
 import TauCeti.Basic

--- a/TauCeti/Algebra/AlgebraicGroup/CommHopfAlgCat.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/CommHopfAlgCat.lean
@@ -124,10 +124,6 @@ instance hasForgetToCommBialgCat :
     { obj H := CommBialgCat.of R H
       map φ := CommBialgCat.ofHom (toBialgHom φ) }
 
-instance hasForgetToHopfAlgCat :
-    HasForget₂ (CommHopfAlgCat.{u, v} R) (_root_.HopfAlgCat.{v} R) where
-  forget₂ := (commHopfAlgProperty (R := R)).ι
-
 @[simp]
 lemma forget₂_commBialgCat_obj (H : CommHopfAlgCat.{u, v} R) :
     (forget₂ (CommHopfAlgCat.{u, v} R) (CommBialgCat.{v} R)).obj H =

--- a/TauCeti/Algebra/AlgebraicGroup/CommHopfAlgCat.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/CommHopfAlgCat.lean
@@ -1,0 +1,232 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+import Mathlib.Algebra.Category.CommBialgCat
+import TauCeti.Algebra.AlgebraicGroup.HopfMap
+import TauCeti.Algebra.AlgebraicGroup.PointsFunctor
+
+/-!
+# Commutative Hopf algebras and their functor of points
+
+This file bundles commutative Hopf algebras over a commutative ring `R` into a category and
+packages the contravariant functor that sends such a coordinate Hopf algebra `H` to its
+group-valued functor of points `A ↦ Hom_R(H, A)`.
+
+This is the categorical form of the first concrete target in the Tau Ceti reductive-groups
+roadmap, Layer 0, "R-points as a group": for a commutative Hopf algebra representing an
+affine group scheme, the functor of points is group-valued by convolution, and a morphism of
+coordinate Hopf algebras acts on points by pre-composition.
+
+## Main declarations
+
+* `CommHopfAlgCat`: the category of commutative Hopf algebras over `R`.
+* `CommHopfAlgCat.mapPointsFunctor`: a coordinate morphism `H ⟶ K` induces a natural
+  transformation from the points functor of `K` to the points functor of `H`.
+* `CommHopfAlgCat.pointsFunctorFunctor`: the contravariant functor
+  `(CommHopfAlgCat R)ᵒᵖ ⥤ CommAlgCat R ⥤ GrpCat`.
+
+## References
+
+This uses Mathlib's convolution monoid and bialgebra morphism API, in particular
+`AlgHom.convMul_comp_bialgHom_distrib` from
+`Mathlib.RingTheory.Bialgebra.Convolution`, through the Tau Ceti wrapper
+`AlgHom.mapDomain`.
+-/
+
+open CategoryTheory WithConv
+
+namespace TauCeti
+
+universe u v w
+
+variable (R : Type u) [CommRing R]
+
+/-- The category of commutative Hopf algebras over a commutative ring `R`.
+
+Objects are commutative rings carrying a Hopf-algebra structure over `R`; morphisms are
+bialgebra morphisms. A bialgebra morphism between Hopf algebras automatically preserves the
+antipode, by `BialgHom.map_antipode`, so no extra field is needed in the morphism type. -/
+structure CommHopfAlgCat where
+  /-- The underlying carrier type. -/
+  carrier : Type v
+  [commRing : CommRing carrier]
+  [hopfAlgebra : _root_.HopfAlgebra R carrier]
+
+attribute [instance] CommHopfAlgCat.commRing CommHopfAlgCat.hopfAlgebra
+
+namespace CommHopfAlgCat
+
+instance : CoeSort (CommHopfAlgCat.{u, v} R) (Type v) :=
+  ⟨CommHopfAlgCat.carrier⟩
+
+variable {R}
+
+variable (R) in
+/-- Construct a bundled commutative Hopf algebra from the usual unbundled typeclasses. -/
+abbrev of (H : Type v) [CommRing H] [_root_.HopfAlgebra R H] : CommHopfAlgCat.{u, v} R where
+  carrier := H
+
+/-- Morphisms of commutative Hopf algebras are bialgebra morphisms. -/
+@[ext]
+structure Hom (H K : CommHopfAlgCat.{u, v} R) where
+  /-- The underlying bialgebra morphism. -/
+  toBialgHom' : H →ₐc[R] K
+
+instance category : Category (CommHopfAlgCat.{u, v} R) where
+  Hom H K := Hom H K
+  id H := ⟨BialgHom.id R H⟩
+  comp φ ψ := ⟨ψ.toBialgHom'.comp φ.toBialgHom'⟩
+
+instance concreteCategory :
+    ConcreteCategory (CommHopfAlgCat.{u, v} R) (fun H K => H →ₐc[R] K) where
+  hom φ := φ.toBialgHom'
+  ofHom φ := ⟨φ⟩
+
+/-- Turn a morphism in `CommHopfAlgCat` back into a bialgebra morphism. -/
+abbrev Hom.toBialgHom {H K : CommHopfAlgCat.{u, v} R} (φ : H ⟶ K) : H →ₐc[R] K :=
+  ConcreteCategory.hom (C := CommHopfAlgCat R) φ
+
+/-- Typecheck a bialgebra morphism as a morphism in `CommHopfAlgCat`. -/
+abbrev ofHom {H K : Type v} [CommRing H] [CommRing K]
+    [_root_.HopfAlgebra R H] [_root_.HopfAlgebra R K] (φ : H →ₐc[R] K) :
+    of R H ⟶ of R K :=
+  ConcreteCategory.ofHom (C := CommHopfAlgCat R) φ
+
+/-- Two morphisms of commutative Hopf algebras are equal when their underlying bialgebra
+morphisms are equal. -/
+@[ext]
+lemma hom_ext {H K : CommHopfAlgCat.{u, v} R} {φ ψ : H ⟶ K}
+    (h : φ.toBialgHom = ψ.toBialgHom) : φ = ψ :=
+  Hom.ext h
+
+@[simp]
+lemma toBialgHom_id {H : CommHopfAlgCat.{u, v} R} :
+    (𝟙 H : H ⟶ H).toBialgHom = BialgHom.id R H :=
+  rfl
+
+@[simp]
+lemma toBialgHom_comp {H K L : CommHopfAlgCat.{u, v} R} (φ : H ⟶ K) (ψ : K ⟶ L) :
+    (φ ≫ ψ).toBialgHom = ψ.toBialgHom.comp φ.toBialgHom :=
+  rfl
+
+@[simp]
+lemma ofHom_toBialgHom {H K : CommHopfAlgCat.{u, v} R} (φ : H ⟶ K) :
+    ofHom φ.toBialgHom = φ :=
+  rfl
+
+@[simp]
+lemma toBialgHom_ofHom {H K : Type v} [CommRing H] [CommRing K]
+    [_root_.HopfAlgebra R H] [_root_.HopfAlgebra R K] (φ : H →ₐc[R] K) :
+    (ofHom (R := R) φ).toBialgHom = φ :=
+  rfl
+
+/-- The forgetful functor from commutative Hopf algebras to commutative bialgebras. -/
+instance hasForgetToCommBialgCat :
+    HasForget₂ (CommHopfAlgCat.{u, v} R) (CommBialgCat.{v} R) where
+  forget₂ :=
+    { obj H := CommBialgCat.of R H
+      map φ := CommBialgCat.ofHom φ.toBialgHom }
+
+@[simp]
+lemma forget₂_commBialgCat_obj (H : CommHopfAlgCat.{u, v} R) :
+    (forget₂ (CommHopfAlgCat.{u, v} R) (CommBialgCat.{v} R)).obj H =
+      CommBialgCat.of R H :=
+  rfl
+
+@[simp]
+lemma forget₂_commBialgCat_map {H K : CommHopfAlgCat.{u, v} R} (φ : H ⟶ K) :
+    (forget₂ (CommHopfAlgCat.{u, v} R) (CommBialgCat.{v} R)).map φ =
+      CommBialgCat.ofHom φ.toBialgHom :=
+  rfl
+
+/-- A morphism of coordinate commutative Hopf algebras induces a natural transformation
+between their group-valued points functors, contravariantly in the coordinate algebra.
+
+At a commutative `R`-algebra `A`, this sends an `A`-valued point `f : K →ₐ[R] A` to
+`f ∘ φ : H →ₐ[R] A`. -/
+noncomputable def mapPointsFunctor {H K : CommHopfAlgCat.{u, v} R} (φ : H ⟶ K) :
+    HopfAlgebra.pointsFunctor (R := R) (H := K) ⟶
+      HopfAlgebra.pointsFunctor (R := R) (H := H) where
+  app A := GrpCat.ofHom
+    (AlgHom.mapDomain (H₁ := H) (H₂ := K) (A := A) φ.toBialgHom)
+  naturality {A B} ψ := by
+    simp only [HopfAlgebra.pointsFunctor_map, HopfAlgebra.mapPoints]
+    exact GrpCat.hom_ext (AlgHom.mapValue_mapDomain φ.toBialgHom ψ.hom)
+
+/-- On points, `mapPointsFunctor φ` is pre-composition with `φ`. -/
+@[simp]
+lemma mapPointsFunctor_app_apply {H K : CommHopfAlgCat.{u, v} R} (φ : H ⟶ K)
+    (A : CommAlgCat.{w} R) (f : HopfAlgebra.points (R := R) (H := K) A) :
+    (mapPointsFunctor φ).app A f =
+      toConv (f.ofConv.comp (φ.toBialgHom : H →ₐ[R] K)) := by
+  exact AlgHom.mapDomain_apply (A := A) φ.toBialgHom f
+
+/-- Pointwise form of `mapPointsFunctor_app_apply`. -/
+@[simp]
+lemma mapPointsFunctor_app_apply_apply {H K : CommHopfAlgCat.{u, v} R} (φ : H ⟶ K)
+    (A : CommAlgCat.{w} R) (f : HopfAlgebra.points (R := R) (H := K) A) (h : H) :
+    (((mapPointsFunctor φ).app A f).ofConv) h = f.ofConv (φ.toBialgHom h) := by
+  exact AlgHom.mapDomain_apply_apply (A := A) φ.toBialgHom f h
+
+/-- `mapPointsFunctor` sends the identity coordinate morphism to the identity natural
+transformation. -/
+@[simp]
+lemma mapPointsFunctor_id (H : CommHopfAlgCat.{u, v} R) :
+    mapPointsFunctor (𝟙 H) =
+      𝟙 (HopfAlgebra.pointsFunctor (R := R) (H := H) :
+        CommAlgCat.{w} R ⥤ GrpCat.{max v w}) := by
+  ext A f
+  apply WithConv.ext
+  ext h
+  rfl
+
+/-- `mapPointsFunctor` sends coordinate-algebra composition to reverse composition of natural
+transformations. -/
+lemma mapPointsFunctor_comp {H K L : CommHopfAlgCat.{u, v} R} (φ : H ⟶ K) (ψ : K ⟶ L) :
+    mapPointsFunctor (φ ≫ ψ) =
+      mapPointsFunctor ψ ≫ mapPointsFunctor φ := by
+  ext A f
+  apply WithConv.ext
+  ext h
+  rfl
+
+/-- The contravariant functor assigning to a commutative Hopf algebra its group-valued
+functor of points.
+
+A coordinate Hopf algebra `H` is sent to the functor `A ↦ WithConv (H →ₐ[R] A)`. A morphism
+`φ : H ⟶ K` is sent contravariantly to the natural transformation that pre-composes
+`K`-points by `φ`. -/
+noncomputable def pointsFunctorFunctor :
+    (CommHopfAlgCat.{u, v} R)ᵒᵖ ⥤ CommAlgCat.{w} R ⥤ GrpCat.{max v w} where
+  obj H := HopfAlgebra.pointsFunctor (R := R) (H := H.unop)
+  map φ := mapPointsFunctor φ.unop
+  map_id H := mapPointsFunctor_id (R := R) H.unop
+  map_comp φ ψ := mapPointsFunctor_comp (R := R) ψ.unop φ.unop
+
+/-- The object part of `pointsFunctorFunctor` is the points functor of the underlying
+commutative Hopf algebra. -/
+lemma pointsFunctorFunctor_obj (H : (CommHopfAlgCat.{u, v} R)ᵒᵖ) :
+    (pointsFunctorFunctor (R := R)).obj H =
+      HopfAlgebra.pointsFunctor (R := R) (H := H.unop) :=
+  rfl
+
+/-- The morphism part of `pointsFunctorFunctor` is pre-composition in the coordinate
+commutative Hopf algebra. -/
+lemma pointsFunctorFunctor_map {H K : (CommHopfAlgCat.{u, v} R)ᵒᵖ} (φ : H ⟶ K) :
+    (pointsFunctorFunctor (R := R)).map φ =
+      mapPointsFunctor φ.unop :=
+  rfl
+
+/-- Pointwise form of the morphism part of `pointsFunctorFunctor`. -/
+@[simp]
+lemma pointsFunctorFunctor_map_app_apply_apply {H K : (CommHopfAlgCat.{u, v} R)ᵒᵖ}
+    (φ : H ⟶ K) (A : CommAlgCat.{w} R)
+    (f : HopfAlgebra.points (R := R) (H := H.unop) A) (h : K.unop) :
+    ((((pointsFunctorFunctor (R := R)).map φ).app A f).ofConv) h =
+      f.ofConv (φ.unop.toBialgHom h) :=
+  rfl
+
+end CommHopfAlgCat
+
+end TauCeti

--- a/TauCeti/Algebra/AlgebraicGroup/CommHopfAlgCat.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/CommHopfAlgCat.lean
@@ -3,6 +3,7 @@ Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 -/
 import Mathlib.Algebra.Category.CommBialgCat
+import Mathlib.Algebra.Category.HopfAlgCat.Basic
 import TauCeti.Algebra.AlgebraicGroup.HopfMap
 import TauCeti.Algebra.AlgebraicGroup.PointsFunctor
 
@@ -23,12 +24,15 @@ coordinate Hopf algebras acts on points by pre-composition.
 * `CommHopfAlgCat`: the category of commutative Hopf algebras over `R`.
 * `CommHopfAlgCat.mapPointsFunctor`: a coordinate morphism `H ⟶ K` induces a natural
   transformation from the points functor of `K` to the points functor of `H`.
-* `CommHopfAlgCat.pointsFunctorFunctor`: the contravariant functor
+* `CommHopfAlgCat.pointsFunctor`: the contravariant functor
   `(CommHopfAlgCat R)ᵒᵖ ⥤ CommAlgCat R ⥤ GrpCat`.
 
 ## References
 
-This uses Mathlib's convolution monoid and bialgebra morphism API, in particular
+The bundled-category and forgetful-functor skeleton for `CommHopfAlgCat` follows Mathlib's
+`Mathlib.Algebra.Category.HopfAlgCat.Basic` and
+`Mathlib.Algebra.Category.CommBialgCat`. The points functoriality uses Mathlib's
+convolution monoid and bialgebra morphism API, in particular
 `AlgHom.convMul_comp_bialgHom_distrib` from
 `Mathlib.RingTheory.Bialgebra.Convolution`, through the Tau Ceti wrapper
 `AlgHom.mapDomain`.
@@ -42,12 +46,14 @@ universe u v w
 
 variable (R : Type u) [CommRing R]
 
+set_option backward.privateInPublic true in
 /-- The category of commutative Hopf algebras over a commutative ring `R`.
 
 Objects are commutative rings carrying a Hopf-algebra structure over `R`; morphisms are
 bialgebra morphisms. A bialgebra morphism between Hopf algebras automatically preserves the
 antipode, by `BialgHom.map_antipode`, so no extra field is needed in the morphism type. -/
 structure CommHopfAlgCat where
+  private mk ::
   /-- The underlying carrier type. -/
   carrier : Type v
   [commRing : CommRing carrier]
@@ -63,6 +69,8 @@ instance : CoeSort (CommHopfAlgCat.{u, v} R) (Type v) :=
 variable {R}
 
 variable (R) in
+set_option backward.privateInPublic true in
+set_option backward.privateInPublic.warn false in
 /-- Construct a bundled commutative Hopf algebra from the usual unbundled typeclasses. -/
 abbrev of (H : Type v) [CommRing H] [_root_.HopfAlgebra R H] : CommHopfAlgCat.{u, v} R where
   carrier := H
@@ -128,6 +136,12 @@ instance hasForgetToCommBialgCat :
     { obj H := CommBialgCat.of R H
       map φ := CommBialgCat.ofHom φ.toBialgHom }
 
+instance hasForgetToHopfAlgCat :
+    HasForget₂ (CommHopfAlgCat.{u, v} R) (_root_.HopfAlgCat.{v} R) where
+  forget₂ :=
+    { obj H := _root_.HopfAlgCat.of R H
+      map φ := _root_.HopfAlgCat.ofHom φ.toBialgHom }
+
 @[simp]
 lemma forget₂_commBialgCat_obj (H : CommHopfAlgCat.{u, v} R) :
     (forget₂ (CommHopfAlgCat.{u, v} R) (CommBialgCat.{v} R)).obj H =
@@ -138,6 +152,18 @@ lemma forget₂_commBialgCat_obj (H : CommHopfAlgCat.{u, v} R) :
 lemma forget₂_commBialgCat_map {H K : CommHopfAlgCat.{u, v} R} (φ : H ⟶ K) :
     (forget₂ (CommHopfAlgCat.{u, v} R) (CommBialgCat.{v} R)).map φ =
       CommBialgCat.ofHom φ.toBialgHom :=
+  rfl
+
+@[simp]
+lemma forget₂_hopfAlgCat_obj (H : CommHopfAlgCat.{u, v} R) :
+    (forget₂ (CommHopfAlgCat.{u, v} R) (_root_.HopfAlgCat.{v} R)).obj H =
+      _root_.HopfAlgCat.of R H :=
+  rfl
+
+@[simp]
+lemma forget₂_hopfAlgCat_map {H K : CommHopfAlgCat.{u, v} R} (φ : H ⟶ K) :
+    (forget₂ (CommHopfAlgCat.{u, v} R) (_root_.HopfAlgCat.{v} R)).map φ =
+      _root_.HopfAlgCat.ofHom φ.toBialgHom :=
   rfl
 
 /-- A morphism of coordinate commutative Hopf algebras induces a natural transformation
@@ -177,8 +203,8 @@ lemma mapPointsFunctor_id (H : CommHopfAlgCat.{u, v} R) :
       𝟙 (HopfAlgebra.pointsFunctor (R := R) (H := H) :
         CommAlgCat.{w} R ⥤ GrpCat.{max v w}) := by
   ext A f
-  apply WithConv.ext
-  ext h
+  change (AlgHom.mapDomain (H₁ := H) (H₂ := H) (A := A) (BialgHom.id R H)) f = f
+  rw [AlgHom.mapDomain_id]
   rfl
 
 /-- `mapPointsFunctor` sends coordinate-algebra composition to reverse composition of natural
@@ -187,8 +213,11 @@ lemma mapPointsFunctor_comp {H K L : CommHopfAlgCat.{u, v} R} (φ : H ⟶ K) (ψ
     mapPointsFunctor (φ ≫ ψ) =
       mapPointsFunctor ψ ≫ mapPointsFunctor φ := by
   ext A f
-  apply WithConv.ext
-  ext h
+  change (AlgHom.mapDomain (H₁ := H) (H₂ := L) (A := A)
+      (ψ.toBialgHom.comp φ.toBialgHom)) f =
+    (AlgHom.mapDomain (H₁ := H) (H₂ := K) (A := A) φ.toBialgHom)
+      ((AlgHom.mapDomain (H₁ := K) (H₂ := L) (A := A) ψ.toBialgHom) f)
+  rw [AlgHom.mapDomain_comp]
   rfl
 
 /-- The contravariant functor assigning to a commutative Hopf algebra its group-valued
@@ -197,35 +226,36 @@ functor of points.
 A coordinate Hopf algebra `H` is sent to the functor `A ↦ WithConv (H →ₐ[R] A)`. A morphism
 `φ : H ⟶ K` is sent contravariantly to the natural transformation that pre-composes
 `K`-points by `φ`. -/
-noncomputable def pointsFunctorFunctor :
+noncomputable def pointsFunctor :
     (CommHopfAlgCat.{u, v} R)ᵒᵖ ⥤ CommAlgCat.{w} R ⥤ GrpCat.{max v w} where
   obj H := HopfAlgebra.pointsFunctor (R := R) (H := H.unop)
   map φ := mapPointsFunctor φ.unop
   map_id H := mapPointsFunctor_id (R := R) H.unop
   map_comp φ ψ := mapPointsFunctor_comp (R := R) ψ.unop φ.unop
 
-/-- The object part of `pointsFunctorFunctor` is the points functor of the underlying
-commutative Hopf algebra. -/
-lemma pointsFunctorFunctor_obj (H : (CommHopfAlgCat.{u, v} R)ᵒᵖ) :
-    (pointsFunctorFunctor (R := R)).obj H =
+/-- The object part of `pointsFunctor` is the points functor of the underlying commutative
+Hopf algebra. -/
+lemma pointsFunctor_obj (H : (CommHopfAlgCat.{u, v} R)ᵒᵖ) :
+    (pointsFunctor (R := R)).obj H =
       HopfAlgebra.pointsFunctor (R := R) (H := H.unop) :=
   rfl
 
-/-- The morphism part of `pointsFunctorFunctor` is pre-composition in the coordinate
-commutative Hopf algebra. -/
-lemma pointsFunctorFunctor_map {H K : (CommHopfAlgCat.{u, v} R)ᵒᵖ} (φ : H ⟶ K) :
-    (pointsFunctorFunctor (R := R)).map φ =
+/-- The morphism part of `pointsFunctor` is pre-composition in the coordinate commutative
+Hopf algebra. -/
+lemma pointsFunctor_map {H K : (CommHopfAlgCat.{u, v} R)ᵒᵖ} (φ : H ⟶ K) :
+    (pointsFunctor (R := R)).map φ =
       mapPointsFunctor φ.unop :=
   rfl
 
-/-- Pointwise form of the morphism part of `pointsFunctorFunctor`. -/
+/-- Pointwise form of the morphism part of `pointsFunctor`. -/
 @[simp]
-lemma pointsFunctorFunctor_map_app_apply_apply {H K : (CommHopfAlgCat.{u, v} R)ᵒᵖ}
+lemma pointsFunctor_map_app_apply_apply {H K : (CommHopfAlgCat.{u, v} R)ᵒᵖ}
     (φ : H ⟶ K) (A : CommAlgCat.{w} R)
     (f : HopfAlgebra.points (R := R) (H := H.unop) A) (h : K.unop) :
-    ((((pointsFunctorFunctor (R := R)).map φ).app A f).ofConv) h =
-      f.ofConv (φ.unop.toBialgHom h) :=
-  rfl
+    ((((pointsFunctor (R := R)).map φ).app A f).ofConv) h =
+      f.ofConv (φ.unop.toBialgHom h) := by
+  rw [pointsFunctor_map]
+  exact mapPointsFunctor_app_apply_apply (R := R) φ.unop A f h
 
 end CommHopfAlgCat
 

--- a/TauCeti/Algebra/AlgebraicGroup/CommHopfAlgCat.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/CommHopfAlgCat.lean
@@ -4,6 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 -/
 import Mathlib.Algebra.Category.CommBialgCat
 import Mathlib.Algebra.Category.HopfAlgCat.Basic
+import Mathlib.CategoryTheory.ObjectProperty.FullSubcategory
 import TauCeti.Algebra.AlgebraicGroup.HopfMap
 import TauCeti.Algebra.AlgebraicGroup.PointsFunctor
 
@@ -44,63 +45,56 @@ namespace TauCeti
 
 universe u v w
 
-variable (R : Type u) [CommRing R]
+/-- The object property on `HopfAlgCat R` selecting commutative Hopf algebras. -/
+def commHopfAlgProperty (R : Type u) [CommRing R] :
+    ObjectProperty (_root_.HopfAlgCat.{v} R) :=
+  fun H => ∀ x y : H, x * y = y * x
 
-set_option backward.privateInPublic true in
 /-- The category of commutative Hopf algebras over a commutative ring `R`.
 
-Objects are commutative rings carrying a Hopf-algebra structure over `R`; morphisms are
-bialgebra morphisms. A bialgebra morphism between Hopf algebras automatically preserves the
-antipode, by `BialgHom.map_antipode`, so no extra field is needed in the morphism type. -/
-structure CommHopfAlgCat where
-  private mk ::
-  /-- The underlying carrier type. -/
-  carrier : Type v
-  [commRing : CommRing carrier]
-  [hopfAlgebra : _root_.HopfAlgebra R carrier]
-
-attribute [instance] CommHopfAlgCat.commRing CommHopfAlgCat.hopfAlgebra
+This is the full subcategory of Mathlib's `HopfAlgCat R` on objects whose multiplication is
+commutative. Morphisms are therefore the existing `HopfAlgCat` morphisms, i.e. bialgebra
+morphisms. A bialgebra morphism between Hopf algebras automatically preserves the antipode, by
+`BialgHom.map_antipode`, so no extra field is needed in the morphism type. -/
+abbrev CommHopfAlgCat (R : Type u) [CommRing R] :=
+  (commHopfAlgProperty (R := R)).FullSubcategory
 
 namespace CommHopfAlgCat
 
-instance : CoeSort (CommHopfAlgCat.{u, v} R) (Type v) :=
-  ⟨CommHopfAlgCat.carrier⟩
+variable {R : Type u} [CommRing R]
 
-variable {R}
+instance : CoeSort (CommHopfAlgCat.{u, v} R) (Type v) :=
+  ⟨fun H => H.obj⟩
+
+instance commRing (H : CommHopfAlgCat.{u, v} R) : CommRing H :=
+  CommRing.mk H.property
+
+instance hopfAlgebra (H : CommHopfAlgCat.{u, v} R) : _root_.HopfAlgebra R H :=
+  inferInstanceAs (_root_.HopfAlgebra R H.obj)
 
 variable (R) in
-set_option backward.privateInPublic true in
 set_option backward.privateInPublic.warn false in
 /-- Construct a bundled commutative Hopf algebra from the usual unbundled typeclasses. -/
-abbrev of (H : Type v) [CommRing H] [_root_.HopfAlgebra R H] : CommHopfAlgCat.{u, v} R where
-  carrier := H
-
-instance category : Category (CommHopfAlgCat.{u, v} R) where
-  Hom H K := CommBialgCat.of R H ⟶ CommBialgCat.of R K
-  id H := 𝟙 (CommBialgCat.of R H)
-  comp φ ψ := φ ≫ ψ
-
-instance concreteCategory :
-    ConcreteCategory (CommHopfAlgCat.{u, v} R) (fun H K => H →ₐc[R] K) where
-  hom φ := φ.hom
-  ofHom φ := CommBialgCat.ofHom φ
+abbrev of (H : Type v) [CommRing H] [_root_.HopfAlgebra R H] : CommHopfAlgCat.{u, v} R :=
+  ⟨_root_.HopfAlgCat.of R H, fun x y => mul_comm x y⟩
 
 /-- Turn a morphism in `CommHopfAlgCat` back into a bialgebra morphism. -/
 abbrev toBialgHom {H K : CommHopfAlgCat.{u, v} R} (φ : H ⟶ K) : H →ₐc[R] K :=
-  ConcreteCategory.hom (C := CommHopfAlgCat R) φ
+  φ.hom.toBialgHom
 
 /-- Typecheck a bialgebra morphism as a morphism in `CommHopfAlgCat`. -/
 abbrev ofHom {H K : Type v} [CommRing H] [CommRing K]
     [_root_.HopfAlgebra R H] [_root_.HopfAlgebra R K] (φ : H →ₐc[R] K) :
     of R H ⟶ of R K :=
-  ConcreteCategory.ofHom (C := CommHopfAlgCat R) φ
+  ObjectProperty.homMk (_root_.HopfAlgCat.ofHom φ)
 
 /-- Two morphisms of commutative Hopf algebras are equal when their underlying bialgebra
 morphisms are equal. -/
 @[ext]
 lemma hom_ext {H K : CommHopfAlgCat.{u, v} R} {φ ψ : H ⟶ K}
     (h : toBialgHom φ = toBialgHom ψ) : φ = ψ :=
-  CommBialgCat.hom_ext h
+  ObjectProperty.hom_ext (P := commHopfAlgProperty R)
+    (_root_.HopfAlgCat.hom_ext φ.hom ψ.hom h)
 
 @[simp]
 lemma toBialgHom_id {H : CommHopfAlgCat.{u, v} R} :
@@ -128,13 +122,11 @@ instance hasForgetToCommBialgCat :
     HasForget₂ (CommHopfAlgCat.{u, v} R) (CommBialgCat.{v} R) where
   forget₂ :=
     { obj H := CommBialgCat.of R H
-      map φ := φ }
+      map φ := CommBialgCat.ofHom (toBialgHom φ) }
 
 instance hasForgetToHopfAlgCat :
     HasForget₂ (CommHopfAlgCat.{u, v} R) (_root_.HopfAlgCat.{v} R) where
-  forget₂ :=
-    { obj H := _root_.HopfAlgCat.of R H
-      map φ := _root_.HopfAlgCat.ofHom (toBialgHom φ) }
+  forget₂ := (commHopfAlgProperty (R := R)).ι
 
 @[simp]
 lemma forget₂_commBialgCat_obj (H : CommHopfAlgCat.{u, v} R) :
@@ -145,19 +137,19 @@ lemma forget₂_commBialgCat_obj (H : CommHopfAlgCat.{u, v} R) :
 @[simp]
 lemma forget₂_commBialgCat_map {H K : CommHopfAlgCat.{u, v} R} (φ : H ⟶ K) :
     (forget₂ (CommHopfAlgCat.{u, v} R) (CommBialgCat.{v} R)).map φ =
-      φ :=
+      CommBialgCat.ofHom (toBialgHom φ) :=
   rfl
 
 @[simp]
 lemma forget₂_hopfAlgCat_obj (H : CommHopfAlgCat.{u, v} R) :
     (forget₂ (CommHopfAlgCat.{u, v} R) (_root_.HopfAlgCat.{v} R)).obj H =
-      _root_.HopfAlgCat.of R H :=
+      H.obj :=
   rfl
 
 @[simp]
 lemma forget₂_hopfAlgCat_map {H K : CommHopfAlgCat.{u, v} R} (φ : H ⟶ K) :
     (forget₂ (CommHopfAlgCat.{u, v} R) (_root_.HopfAlgCat.{v} R)).map φ =
-      _root_.HopfAlgCat.ofHom (toBialgHom φ) :=
+      φ.hom :=
   rfl
 
 /-- A morphism of coordinate commutative Hopf algebras induces a natural transformation

--- a/TauCeti/Algebra/AlgebraicGroup/CommHopfAlgCat.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/CommHopfAlgCat.lean
@@ -75,24 +75,18 @@ set_option backward.privateInPublic.warn false in
 abbrev of (H : Type v) [CommRing H] [_root_.HopfAlgebra R H] : CommHopfAlgCat.{u, v} R where
   carrier := H
 
-/-- Morphisms of commutative Hopf algebras are bialgebra morphisms. -/
-@[ext]
-structure Hom (H K : CommHopfAlgCat.{u, v} R) where
-  /-- The underlying bialgebra morphism. -/
-  toBialgHom' : H →ₐc[R] K
-
 instance category : Category (CommHopfAlgCat.{u, v} R) where
-  Hom H K := Hom H K
-  id H := ⟨BialgHom.id R H⟩
-  comp φ ψ := ⟨ψ.toBialgHom'.comp φ.toBialgHom'⟩
+  Hom H K := CommBialgCat.of R H ⟶ CommBialgCat.of R K
+  id H := 𝟙 (CommBialgCat.of R H)
+  comp φ ψ := φ ≫ ψ
 
 instance concreteCategory :
     ConcreteCategory (CommHopfAlgCat.{u, v} R) (fun H K => H →ₐc[R] K) where
-  hom φ := φ.toBialgHom'
-  ofHom φ := ⟨φ⟩
+  hom φ := φ.hom
+  ofHom φ := CommBialgCat.ofHom φ
 
 /-- Turn a morphism in `CommHopfAlgCat` back into a bialgebra morphism. -/
-abbrev Hom.toBialgHom {H K : CommHopfAlgCat.{u, v} R} (φ : H ⟶ K) : H →ₐc[R] K :=
+abbrev toBialgHom {H K : CommHopfAlgCat.{u, v} R} (φ : H ⟶ K) : H →ₐc[R] K :=
   ConcreteCategory.hom (C := CommHopfAlgCat R) φ
 
 /-- Typecheck a bialgebra morphism as a morphism in `CommHopfAlgCat`. -/
@@ -105,28 +99,28 @@ abbrev ofHom {H K : Type v} [CommRing H] [CommRing K]
 morphisms are equal. -/
 @[ext]
 lemma hom_ext {H K : CommHopfAlgCat.{u, v} R} {φ ψ : H ⟶ K}
-    (h : φ.toBialgHom = ψ.toBialgHom) : φ = ψ :=
-  Hom.ext h
+    (h : toBialgHom φ = toBialgHom ψ) : φ = ψ :=
+  CommBialgCat.hom_ext h
 
 @[simp]
 lemma toBialgHom_id {H : CommHopfAlgCat.{u, v} R} :
-    (𝟙 H : H ⟶ H).toBialgHom = BialgHom.id R H :=
+    toBialgHom (𝟙 H : H ⟶ H) = BialgHom.id R H :=
   rfl
 
 @[simp]
 lemma toBialgHom_comp {H K L : CommHopfAlgCat.{u, v} R} (φ : H ⟶ K) (ψ : K ⟶ L) :
-    (φ ≫ ψ).toBialgHom = ψ.toBialgHom.comp φ.toBialgHom :=
+    toBialgHom (φ ≫ ψ) = (toBialgHom ψ).comp (toBialgHom φ) :=
   rfl
 
 @[simp]
 lemma ofHom_toBialgHom {H K : CommHopfAlgCat.{u, v} R} (φ : H ⟶ K) :
-    ofHom φ.toBialgHom = φ :=
+    ofHom (toBialgHom φ) = φ :=
   rfl
 
 @[simp]
 lemma toBialgHom_ofHom {H K : Type v} [CommRing H] [CommRing K]
     [_root_.HopfAlgebra R H] [_root_.HopfAlgebra R K] (φ : H →ₐc[R] K) :
-    (ofHom (R := R) φ).toBialgHom = φ :=
+    toBialgHom (ofHom (R := R) φ) = φ :=
   rfl
 
 /-- The forgetful functor from commutative Hopf algebras to commutative bialgebras. -/
@@ -134,13 +128,13 @@ instance hasForgetToCommBialgCat :
     HasForget₂ (CommHopfAlgCat.{u, v} R) (CommBialgCat.{v} R) where
   forget₂ :=
     { obj H := CommBialgCat.of R H
-      map φ := CommBialgCat.ofHom φ.toBialgHom }
+      map φ := φ }
 
 instance hasForgetToHopfAlgCat :
     HasForget₂ (CommHopfAlgCat.{u, v} R) (_root_.HopfAlgCat.{v} R) where
   forget₂ :=
     { obj H := _root_.HopfAlgCat.of R H
-      map φ := _root_.HopfAlgCat.ofHom φ.toBialgHom }
+      map φ := _root_.HopfAlgCat.ofHom (toBialgHom φ) }
 
 @[simp]
 lemma forget₂_commBialgCat_obj (H : CommHopfAlgCat.{u, v} R) :
@@ -151,7 +145,7 @@ lemma forget₂_commBialgCat_obj (H : CommHopfAlgCat.{u, v} R) :
 @[simp]
 lemma forget₂_commBialgCat_map {H K : CommHopfAlgCat.{u, v} R} (φ : H ⟶ K) :
     (forget₂ (CommHopfAlgCat.{u, v} R) (CommBialgCat.{v} R)).map φ =
-      CommBialgCat.ofHom φ.toBialgHom :=
+      φ :=
   rfl
 
 @[simp]
@@ -163,7 +157,7 @@ lemma forget₂_hopfAlgCat_obj (H : CommHopfAlgCat.{u, v} R) :
 @[simp]
 lemma forget₂_hopfAlgCat_map {H K : CommHopfAlgCat.{u, v} R} (φ : H ⟶ K) :
     (forget₂ (CommHopfAlgCat.{u, v} R) (_root_.HopfAlgCat.{v} R)).map φ =
-      _root_.HopfAlgCat.ofHom φ.toBialgHom :=
+      _root_.HopfAlgCat.ofHom (toBialgHom φ) :=
   rfl
 
 /-- A morphism of coordinate commutative Hopf algebras induces a natural transformation
@@ -175,25 +169,25 @@ noncomputable def mapPointsFunctor {H K : CommHopfAlgCat.{u, v} R} (φ : H ⟶ K
     HopfAlgebra.pointsFunctor (R := R) (H := K) ⟶
       HopfAlgebra.pointsFunctor (R := R) (H := H) where
   app A := GrpCat.ofHom
-    (AlgHom.mapDomain (H₁ := H) (H₂ := K) (A := A) φ.toBialgHom)
+    (AlgHom.mapDomain (H₁ := H) (H₂ := K) (A := A) (toBialgHom φ))
   naturality {A B} ψ := by
     simp only [HopfAlgebra.pointsFunctor_map, HopfAlgebra.mapPoints]
-    exact GrpCat.hom_ext (AlgHom.mapValue_mapDomain φ.toBialgHom ψ.hom)
+    exact GrpCat.hom_ext (AlgHom.mapValue_mapDomain (toBialgHom φ) ψ.hom)
 
 /-- On points, `mapPointsFunctor φ` is pre-composition with `φ`. -/
 @[simp]
 lemma mapPointsFunctor_app_apply {H K : CommHopfAlgCat.{u, v} R} (φ : H ⟶ K)
     (A : CommAlgCat.{w} R) (f : HopfAlgebra.points (R := R) (H := K) A) :
     (mapPointsFunctor φ).app A f =
-      toConv (f.ofConv.comp (φ.toBialgHom : H →ₐ[R] K)) := by
-  exact AlgHom.mapDomain_apply (A := A) φ.toBialgHom f
+      toConv (f.ofConv.comp (toBialgHom φ : H →ₐ[R] K)) := by
+  exact AlgHom.mapDomain_apply (A := A) (toBialgHom φ) f
 
 /-- Pointwise form of `mapPointsFunctor_app_apply`. -/
 @[simp]
 lemma mapPointsFunctor_app_apply_apply {H K : CommHopfAlgCat.{u, v} R} (φ : H ⟶ K)
     (A : CommAlgCat.{w} R) (f : HopfAlgebra.points (R := R) (H := K) A) (h : H) :
-    (((mapPointsFunctor φ).app A f).ofConv) h = f.ofConv (φ.toBialgHom h) := by
-  exact AlgHom.mapDomain_apply_apply (A := A) φ.toBialgHom f h
+    (((mapPointsFunctor φ).app A f).ofConv) h = f.ofConv (toBialgHom φ h) := by
+  exact AlgHom.mapDomain_apply_apply (A := A) (toBialgHom φ) f h
 
 /-- `mapPointsFunctor` sends the identity coordinate morphism to the identity natural
 transformation. -/
@@ -203,9 +197,7 @@ lemma mapPointsFunctor_id (H : CommHopfAlgCat.{u, v} R) :
       𝟙 (HopfAlgebra.pointsFunctor (R := R) (H := H) :
         CommAlgCat.{w} R ⥤ GrpCat.{max v w}) := by
   ext A f
-  change (AlgHom.mapDomain (H₁ := H) (H₂ := H) (A := A) (BialgHom.id R H)) f = f
-  rw [AlgHom.mapDomain_id]
-  rfl
+  simp
 
 /-- `mapPointsFunctor` sends coordinate-algebra composition to reverse composition of natural
 transformations. -/
@@ -213,12 +205,7 @@ lemma mapPointsFunctor_comp {H K L : CommHopfAlgCat.{u, v} R} (φ : H ⟶ K) (ψ
     mapPointsFunctor (φ ≫ ψ) =
       mapPointsFunctor ψ ≫ mapPointsFunctor φ := by
   ext A f
-  change (AlgHom.mapDomain (H₁ := H) (H₂ := L) (A := A)
-      (ψ.toBialgHom.comp φ.toBialgHom)) f =
-    (AlgHom.mapDomain (H₁ := H) (H₂ := K) (A := A) φ.toBialgHom)
-      ((AlgHom.mapDomain (H₁ := K) (H₂ := L) (A := A) ψ.toBialgHom) f)
-  rw [AlgHom.mapDomain_comp]
-  rfl
+  simp [mapPointsFunctor_app_apply, AlgHom.comp_assoc]
 
 /-- The contravariant functor assigning to a commutative Hopf algebra its group-valued
 functor of points.
@@ -253,7 +240,7 @@ lemma pointsFunctor_map_app_apply_apply {H K : (CommHopfAlgCat.{u, v} R)ᵒᵖ}
     (φ : H ⟶ K) (A : CommAlgCat.{w} R)
     (f : HopfAlgebra.points (R := R) (H := H.unop) A) (h : K.unop) :
     ((((pointsFunctor (R := R)).map φ).app A f).ofConv) h =
-      f.ofConv (φ.unop.toBialgHom h) := by
+      f.ofConv (toBialgHom φ.unop h) := by
   rw [pointsFunctor_map]
   exact mapPointsFunctor_app_apply_apply (R := R) φ.unop A f h
 


### PR DESCRIPTION
This PR packages commutative Hopf algebras into a bundled category and exposes the contravariant functor sending a coordinate Hopf algebra to its group-valued functor of points. It advances TauCetiRoadmap/ReductiveGroups/README.md, Layer 0, target "R-points as a group" and its functor-of-points dictionary: a morphism of coordinate Hopf algebras acts on points by pre-composition, naturally in the commutative value algebra.

The PR adds `CommHopfAlgCat`, the forgetful functor to Mathlib's `CommBialgCat`, `CommHopfAlgCat.mapPointsFunctor`, and `CommHopfAlgCat.pointsFunctorFunctor`, and imports the new module from the TauCeti root.

No Mathlib infrastructure is vendored. The construction reuses Mathlib's `CommBialgCat`, `BialgHom`, `GrpCat`, `CommAlgCat`, and the convolution/bialgebra API from `Mathlib.RingTheory.Bialgebra.Convolution`, in particular through TauCeti's existing `AlgHom.mapDomain` wrapper around `AlgHom.convMul_comp_bialgHom_distrib`. Verified with `lake exe cache get`, `lake build`, and `lake exe axioms`.

🤖 Prepared with Codex
