### PR TITLE
feat: add deck fibre actions

### DIFF
--- a/TauCeti.lean
+++ b/TauCeti.lean
@@ -5,4 +5,5 @@
 -- grows, import the submodules of `TauCeti/` here.
 import TauCeti.Algebra.AlgebraicGroup.CommHopfAlgCat
 import TauCeti.Algebra.Coalgebra.ComoduleCat
+import TauCeti.AlgebraicTopology.UniversalCover.Deck.Fiber
 import TauCeti.Basic

--- a/TauCeti/AlgebraicTopology/UniversalCover/Deck/Fiber.lean
+++ b/TauCeti/AlgebraicTopology/UniversalCover/Deck/Fiber.lean
@@ -1,0 +1,160 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+import TauCeti.AlgebraicTopology.UniversalCover.Deck
+
+/-!
+# The action of deck transformations on a fibre
+
+A deck transformation preserves every fibre of the projection. This file packages that
+restriction as a multiplicative homomorphism from the deck transformation group to the
+homeomorphism group of a chosen fibre, and records the induced action on that fibre.
+
+This is bookkeeping for the universal-covers roadmap: the later comparison between deck
+transformations and the fundamental group, and the regular-cover statements, use the action of
+deck transformations on individual fibres rather than only on the total space.
+
+## Main definitions
+
+* `TauCeti.Deck.fiberHomeomorphHom`: the homomorphism
+  `Deck p →* (p ⁻¹' {b} ≃ₜ p ⁻¹' {b})`.
+* `TauCeti.Deck.fiberMulAction`: the induced action of `Deck p` on the fibre over `b`.
+
+## References
+
+This supplies a prerequisite for the Tau Ceti universal-covers roadmap, Stage 0.4
+(`Deck p` as the deck transformation group), and the later deck-group action on fibres in
+Stages 1 and 2.
+-/
+
+namespace TauCeti
+
+namespace Deck
+
+variable {E B : Type*} [TopologicalSpace E] {p : E → B} {b : B}
+
+/-- The homomorphism from deck transformations to homeomorphisms of the fibre over `b`.
+
+It sends a deck transformation to its restriction to the subtype `p ⁻¹' {b}`. -/
+def fiberHomeomorphHom (p : E → B) (b : B) : Deck p →* (p ⁻¹' {b} ≃ₜ p ⁻¹' {b}) where
+  toFun φ := fiberHomeomorph φ b
+  map_one' := by
+    ext e
+    rfl
+  map_mul' φ ψ := by
+    ext e
+    rfl
+
+/-- The fibre homomorphism evaluates by applying the deck transformation to the underlying
+point of the fibre. -/
+@[simp]
+lemma fiberHomeomorphHom_apply (φ : Deck p) (e : p ⁻¹' {b}) :
+    fiberHomeomorphHom p b φ e = fiberHomeomorph φ b e :=
+  rfl
+
+/-- On underlying points, the fibre homomorphism is evaluation of the underlying
+homeomorphism. -/
+@[simp]
+lemma fiberHomeomorphHom_apply_coe (φ : Deck p) (e : p ⁻¹' {b}) :
+    (fiberHomeomorphHom p b φ e : E) = φ.1 e.1 :=
+  rfl
+
+/-- The fibre homomorphism sends the identity deck transformation to the identity
+homeomorphism of the fibre. -/
+@[simp]
+lemma fiberHomeomorphHom_one :
+    fiberHomeomorphHom p b (1 : Deck p) = 1 := by
+  exact (fiberHomeomorphHom p b).map_one
+
+/-- The fibre homomorphism sends products of deck transformations to products of fibre
+homeomorphisms. -/
+@[simp]
+lemma fiberHomeomorphHom_mul (φ ψ : Deck p) :
+    fiberHomeomorphHom p b (φ * ψ) = fiberHomeomorphHom p b φ * fiberHomeomorphHom p b ψ := by
+  exact (fiberHomeomorphHom p b).map_mul φ ψ
+
+/-- The fibre homomorphism sends inverses of deck transformations to inverses of fibre
+homeomorphisms. -/
+@[simp]
+lemma fiberHomeomorphHom_inv (φ : Deck p) :
+    fiberHomeomorphHom p b φ⁻¹ = (fiberHomeomorphHom p b φ)⁻¹ := by
+  exact (fiberHomeomorphHom p b).map_inv φ
+
+/-- The fibre homeomorphism associated to the identity deck transformation is the identity. -/
+@[simp]
+lemma fiberHomeomorph_one :
+    fiberHomeomorph (1 : Deck p) b = 1 := by
+  exact fiberHomeomorphHom_one
+
+/-- The fibre homeomorphism associated to a product is the product of the associated fibre
+homeomorphisms. -/
+@[simp]
+lemma fiberHomeomorph_mul (φ ψ : Deck p) :
+    fiberHomeomorph (φ * ψ) b = fiberHomeomorph φ b * fiberHomeomorph ψ b := by
+  exact fiberHomeomorphHom_mul φ ψ
+
+/-- The fibre homeomorphism associated to an inverse is the inverse of the associated fibre
+homeomorphism. -/
+@[simp]
+lemma fiberHomeomorph_inv (φ : Deck p) :
+    fiberHomeomorph φ⁻¹ b = (fiberHomeomorph φ b)⁻¹ := by
+  exact fiberHomeomorphHom_inv φ
+
+/-- The fibre homeomorphism associated to a natural-number power is the corresponding power
+of the associated fibre homeomorphism. -/
+@[simp]
+lemma fiberHomeomorph_pow (φ : Deck p) (n : ℕ) :
+    fiberHomeomorph (φ ^ n) b = fiberHomeomorph φ b ^ n := by
+  exact (fiberHomeomorphHom p b).map_pow φ n
+
+/-- The fibre homeomorphism associated to an integer power is the corresponding power of the
+associated fibre homeomorphism. -/
+@[simp]
+lemma fiberHomeomorph_zpow (φ : Deck p) (n : ℤ) :
+    fiberHomeomorph (φ ^ n) b = fiberHomeomorph φ b ^ n := by
+  exact (fiberHomeomorphHom p b).map_zpow φ n
+
+/-- The action of deck transformations on the fibre over `b`, obtained by restricting the
+ambient action on the total space. -/
+abbrev fiberMulAction (p : E → B) (b : B) : MulAction (Deck p) (p ⁻¹' {b}) where
+  smul φ e := fiberHomeomorphHom p b φ e
+  one_smul e := by
+    ext
+    rfl
+  mul_smul φ ψ e := by
+    ext
+    rfl
+
+/-- Deck transformations act on each fibre by restricting their action on the total space. -/
+instance instFiberMulAction : MulAction (Deck p) (p ⁻¹' {b}) :=
+  fiberMulAction p b
+
+/-- The fibre action is evaluation of the fibre homeomorphism. -/
+@[simp]
+lemma fiber_smul_eq_fiberHomeomorph (φ : Deck p) (e : p ⁻¹' {b}) :
+    φ • e = fiberHomeomorph φ b e :=
+  rfl
+
+/-- On underlying points, the fibre action is evaluation of the underlying deck
+transformation. -/
+@[simp]
+lemma fiber_smul_coe (φ : Deck p) (e : p ⁻¹' {b}) :
+    (φ • e : E) = φ.1 e.1 :=
+  rfl
+
+/-- The projection value of a point in the fibre is unchanged after the restricted deck
+action. -/
+lemma fiber_smul_mem (φ : Deck p) (e : p ⁻¹' {b}) :
+    p (φ • e : E) = b := by
+  exact (φ • e).2
+
+/-- The restricted fibre action agrees with the ambient action on the total space after
+coercing out of the fibre subtype. -/
+lemma fiber_smul_coe_eq_smul (φ : Deck p) (e : p ⁻¹' {b}) :
+    (φ • e : E) = φ • (e : E) := by
+  rfl
+
+end Deck
+
+end TauCeti

--- a/TauCeti/AlgebraicTopology/UniversalCover/Deck/Fiber.lean
+++ b/TauCeti/AlgebraicTopology/UniversalCover/Deck/Fiber.lean
@@ -19,7 +19,7 @@ deck transformations on individual fibres rather than only on the total space.
 
 * `TauCeti.Deck.fiberHomeomorphHom`: the homomorphism
   `Deck p →* (p ⁻¹' {b} ≃ₜ p ⁻¹' {b})`.
-* `TauCeti.Deck.fiberMulAction`: the induced action of `Deck p` on the fibre over `b`.
+* `TauCeti.Deck.instFiberMulAction`: the induced action of `Deck p` on the fibre over `b`.
 
 ## References
 
@@ -115,20 +115,9 @@ lemma fiberHomeomorph_zpow (φ : Deck p) (n : ℤ) :
     fiberHomeomorph (φ ^ n) b = fiberHomeomorph φ b ^ n := by
   exact (fiberHomeomorphHom p b).map_zpow φ n
 
-/-- The action of deck transformations on the fibre over `b`, obtained by restricting the
-ambient action on the total space. -/
-abbrev fiberMulAction (p : E → B) (b : B) : MulAction (Deck p) (p ⁻¹' {b}) where
-  smul φ e := fiberHomeomorphHom p b φ e
-  one_smul e := by
-    ext
-    rfl
-  mul_smul φ ψ e := by
-    ext
-    rfl
-
 /-- Deck transformations act on each fibre by restricting their action on the total space. -/
 instance instFiberMulAction : MulAction (Deck p) (p ⁻¹' {b}) :=
-  fiberMulAction p b
+  MulAction.compHom (p ⁻¹' {b}) (fiberHomeomorphHom p b)
 
 /-- The fibre action is evaluation of the fibre homeomorphism. -/
 @[simp]
@@ -145,15 +134,23 @@ lemma fiber_smul_coe (φ : Deck p) (e : p ⁻¹' {b}) :
 
 /-- The projection value of a point in the fibre is unchanged after the restricted deck
 action. -/
-lemma fiber_smul_mem (φ : Deck p) (e : p ⁻¹' {b}) :
+lemma map_fiber_smul (φ : Deck p) (e : p ⁻¹' {b}) :
     p (φ • e : E) = b := by
   exact (φ • e).2
+
+/-- The restricted deck action keeps points in the fibre over `b`. -/
+@[simp]
+lemma fiber_smul_mem (φ : Deck p) (e : p ⁻¹' {b}) :
+    (φ • e : E) ∈ p ⁻¹' {b} := by
+  exact map_fiber_smul φ e
 
 /-- The restricted fibre action agrees with the ambient action on the total space after
 coercing out of the fibre subtype. -/
 lemma fiber_smul_coe_eq_smul (φ : Deck p) (e : p ⁻¹' {b}) :
     (φ • e : E) = φ • (e : E) := by
-  rfl
+  trans φ.1 e.1
+  · exact fiber_smul_coe φ e
+  · exact (smul_eq_apply φ (e : E)).symm
 
 end Deck
 


### PR DESCRIPTION
This PR adds the fibre-level action API for deck transformations, advancing TauCetiRoadmap/UniversalCovers/README.md, Stage 0, target 4 "Deck transformation group", and supplying bookkeeping needed for the later fibre actions in Stages 1 and 2. It packages the restriction of a deck transformation to a chosen fibre as `Deck.fiberHomeomorphHom`, exposes the natural `MulAction` on each fibre, and records the pointwise compatibility lemmas needed to use the action without unfolding definitions.

No Mathlib infrastructure is vendored. The implementation reuses Tau Ceti's existing `Deck.fiberHomeomorph` API together with Mathlib's `Homeomorph` group structure and `MonoidHom` API.

Verified with `lake exe cache get`, `lake build`, and `lake exe axioms`.

🤖 Prepared with Codex