### PR TITLE
feat: add degree-zero Weil divisor API

### DIFF
--- a/TauCeti.lean
+++ b/TauCeti.lean
@@ -5,5 +5,6 @@
 -- grows, import the submodules of `TauCeti/` here.
 import TauCeti.Algebra.AlgebraicGroup.CommHopfAlgCat
 import TauCeti.Algebra.Coalgebra.ComoduleCat
+import TauCeti.AlgebraicGeometry.WeilDivisor
 import TauCeti.AlgebraicTopology.UniversalCover.Deck.Fiber
 import TauCeti.Basic

--- a/TauCeti/AlgebraicGeometry/WeilDivisor.lean
+++ b/TauCeti/AlgebraicGeometry/WeilDivisor.lean
@@ -275,22 +275,6 @@ lemma mem_degreeZeroSubgroup (D : WeilDivisor X) :
   AddMonoidHom.mem_ker
 
 @[simp]
-lemma zero_mem_degreeZeroSubgroup : (0 : WeilDivisor X) ∈ degreeZeroSubgroup X := by
-  simp
-
-lemma degreeZeroSubgroup.add_mem {D E : WeilDivisor X} (hD : D ∈ degreeZeroSubgroup X)
-    (hE : E ∈ degreeZeroSubgroup X) : D + E ∈ degreeZeroSubgroup X :=
-  (degreeZeroSubgroup X).add_mem hD hE
-
-lemma degreeZeroSubgroup.neg_mem {D : WeilDivisor X} (hD : D ∈ degreeZeroSubgroup X) :
-    -D ∈ degreeZeroSubgroup X :=
-  (degreeZeroSubgroup X).neg_mem hD
-
-lemma degreeZeroSubgroup.sub_mem {D E : WeilDivisor X} (hD : D ∈ degreeZeroSubgroup X)
-    (hE : E ∈ degreeZeroSubgroup X) : D - E ∈ degreeZeroSubgroup X :=
-  (degreeZeroSubgroup X).sub_mem hD hE
-
-@[simp]
 lemma degree_coe_degreeZeroSubgroup (D : degreeZeroSubgroup X) :
     degree (D : WeilDivisor X) = 0 :=
   D.property
@@ -312,6 +296,22 @@ lemma coeff_pointDifference_left (x y : X) :
 lemma coeff_pointDifference_right (x y : X) :
     coeff (pointDifference x y) y = coeff (ofPoint x) y - 1 := by
   simp [pointDifference]
+
+@[simp]
+lemma coeff_pointDifference [DecidableEq X] (x y z : X) :
+    coeff (pointDifference x y) z =
+      (if z = x then 1 else 0) - (if z = y then 1 else 0) := by
+  by_cases hx : z = x
+  · by_cases hy : z = y
+    · subst hx
+      subst hy
+      simp [pointDifference, ofPoint, coeff]
+    · subst hx
+      simp [pointDifference, ofPoint, coeff, hy]
+  · by_cases hy : z = y
+    · subst hy
+      simp [pointDifference, ofPoint, coeff, hx]
+    · simp [pointDifference, ofPoint, coeff, hx, hy]
 
 lemma support_pointDifference_subset [DecidableEq X] (x y : X) :
     (pointDifference x y).support ⊆ {x, y} := by

--- a/TauCeti/AlgebraicGeometry/WeilDivisor.lean
+++ b/TauCeti/AlgebraicGeometry/WeilDivisor.lean
@@ -329,6 +329,11 @@ lemma degree_pointDifference (x y : X) : degree (pointDifference x y) = 0 := by
   simp [pointDifference]
 
 @[simp]
+lemma weightedDegree_pointDifference (w : X → ℤ) (x y : X) :
+    weightedDegree w (pointDifference x y) = w x - w y := by
+  simp [pointDifference]
+
+@[simp]
 lemma pointDifference_mem_degreeZeroSubgroup (x y : X) :
     pointDifference x y ∈ degreeZeroSubgroup X := by
   simp
@@ -389,7 +394,7 @@ lemma weightedDegree_coe_weightedDegreeZeroSubgroup (w : X → ℤ)
 @[simp]
 lemma pointDifference_mem_weightedDegreeZeroSubgroup {w : X → ℤ} {x y : X}
     (h : w x = w y) : pointDifference x y ∈ weightedDegreeZeroSubgroup w := by
-  simp [pointDifference, h]
+  simp [h]
 
 /-- Pushforward as a homomorphism on weighted degree-zero divisors, when the target weight
 pulls back to the source weight. -/

--- a/TauCeti/AlgebraicGeometry/WeilDivisor.lean
+++ b/TauCeti/AlgebraicGeometry/WeilDivisor.lean
@@ -10,21 +10,23 @@ import Mathlib.LinearAlgebra.Finsupp.LinearCombination
 # Weil divisors as finite integer combinations of points
 
 This file provides the first, purely combinatorial piece of the Jacobian roadmap's Layer A:
-Weil divisors are finite formal integer sums of points.  The scheme-theoretic predicates
+Weil divisors are finite formal integer sums of points. The scheme-theoretic predicates
 which decide which points are codimension-one points, the principal-divisor map, and the
 comparison with Cartier divisors are deliberately not bundled here; those are later geometric
 constructions.
 
 The API here records the free-abelian-group operations needed before that geometry exists:
 point divisors, effectivity, pushforward of formal sums along a map of point sets, and both
-the unweighted degree and the weighted degree used for curves over a field.
+the unweighted degree and the weighted degree used for curves over a field. It also packages
+the degree-zero subgroups that later receive principal divisors and model the abstract
+`Pic⁰` kernel before the Picard functor and Picard scheme exist.
 
 For a curve over `k`, the intended weighted degree has weight
 `x ↦ [κ(x) : k]`; this file only supplies the formal finite-sum operation against an arbitrary
 integer-valued weight.
 
 This advances the Tau Ceti Jacobian roadmap, Layer A, "Divisors on a curve: Weil divisors
-`⊕_x ℤ`" and "Degree".
+`⊕_x ℤ`", "Degree", and "`Pic⁰ X = ker deg` (as an abstract group)".
 -/
 
 namespace TauCeti
@@ -258,6 +260,174 @@ lemma weightedDegree_one_eq_degree (D : WeilDivisor X) :
     weightedDegree (fun _ : X => (1 : ℤ)) D = degree D := by
   rw [weightedDegree_apply, degree_apply]
   simp [Finsupp.sum]
+
+/-- The subgroup of divisors of unweighted degree zero.
+
+For a smooth proper curve over an algebraically closed field this is the formal divisor group
+whose quotient by principal divisors gives the abstract degree-zero Picard group. Over a
+general field, use `weightedDegreeZeroSubgroup` with residue-field degrees as weights. -/
+noncomputable def degreeZeroSubgroup (X : Type*) : AddSubgroup (WeilDivisor X) :=
+  (degree : WeilDivisor X →+ ℤ).ker
+
+@[simp]
+lemma mem_degreeZeroSubgroup (D : WeilDivisor X) :
+    D ∈ degreeZeroSubgroup X ↔ degree D = 0 :=
+  AddMonoidHom.mem_ker
+
+@[simp]
+lemma zero_mem_degreeZeroSubgroup : (0 : WeilDivisor X) ∈ degreeZeroSubgroup X := by
+  simp
+
+lemma degreeZeroSubgroup.add_mem {D E : WeilDivisor X} (hD : D ∈ degreeZeroSubgroup X)
+    (hE : E ∈ degreeZeroSubgroup X) : D + E ∈ degreeZeroSubgroup X :=
+  (degreeZeroSubgroup X).add_mem hD hE
+
+lemma degreeZeroSubgroup.neg_mem {D : WeilDivisor X} (hD : D ∈ degreeZeroSubgroup X) :
+    -D ∈ degreeZeroSubgroup X :=
+  (degreeZeroSubgroup X).neg_mem hD
+
+lemma degreeZeroSubgroup.sub_mem {D E : WeilDivisor X} (hD : D ∈ degreeZeroSubgroup X)
+    (hE : E ∈ degreeZeroSubgroup X) : D - E ∈ degreeZeroSubgroup X :=
+  (degreeZeroSubgroup X).sub_mem hD hE
+
+@[simp]
+lemma degree_coe_degreeZeroSubgroup (D : degreeZeroSubgroup X) :
+    degree (D : WeilDivisor X) = 0 :=
+  D.property
+
+/-- The formal divisor `[x] - [y]`, a basic source of degree-zero divisors. -/
+noncomputable def pointDifference (x y : X) : WeilDivisor X :=
+  ofPoint x - ofPoint y
+
+@[simp]
+lemma pointDifference_self (x : X) : pointDifference x x = 0 := by
+  simp [pointDifference]
+
+@[simp]
+lemma coeff_pointDifference_left (x y : X) :
+    coeff (pointDifference x y) x = 1 - coeff (ofPoint y) x := by
+  simp [pointDifference]
+
+@[simp]
+lemma coeff_pointDifference_right (x y : X) :
+    coeff (pointDifference x y) y = coeff (ofPoint x) y - 1 := by
+  simp [pointDifference]
+
+lemma support_pointDifference_subset [DecidableEq X] (x y : X) :
+    (pointDifference x y).support ⊆ {x, y} := by
+  intro z hz
+  rw [Finset.mem_insert, Finset.mem_singleton]
+  by_contra hzy
+  push Not at hzy
+  have hx : z ≠ x := hzy.1
+  have hy : z ≠ y := hzy.2
+  exact (Finsupp.mem_support_iff.mp hz)
+    (by simp [pointDifference, ofPoint, Finsupp.single_eq_of_ne hx, Finsupp.single_eq_of_ne hy])
+
+@[simp]
+lemma degree_pointDifference (x y : X) : degree (pointDifference x y) = 0 := by
+  simp [pointDifference]
+
+@[simp]
+lemma pointDifference_mem_degreeZeroSubgroup (x y : X) :
+    pointDifference x y ∈ degreeZeroSubgroup X := by
+  simp
+
+@[simp]
+lemma pushforward_pointDifference (f : X → Y) (x y : X) :
+    pushforward f (pointDifference x y) = pointDifference (f x) (f y) := by
+  rw [pointDifference, map_sub, pushforward_ofPoint, pushforward_ofPoint]
+  rfl
+
+/-- Pushforward as a homomorphism on unweighted degree-zero divisors. -/
+noncomputable def pushforwardDegreeZero (f : X → Y) :
+    degreeZeroSubgroup X →+ degreeZeroSubgroup Y where
+  toFun D :=
+    ⟨pushforward f D, by
+      rw [mem_degreeZeroSubgroup, degree_pushforward, degree_coe_degreeZeroSubgroup]⟩
+  map_zero' := by
+    apply Subtype.ext
+    exact pushforward_zero f
+  map_add' D E := by
+    apply Subtype.ext
+    exact pushforward_add f D E
+
+@[simp]
+lemma pushforwardDegreeZero_apply (f : X → Y) (D : degreeZeroSubgroup X) :
+    (pushforwardDegreeZero f D : WeilDivisor Y) = pushforward f D :=
+  rfl
+
+@[simp]
+lemma pushforwardDegreeZero_id :
+    pushforwardDegreeZero (fun x : X => x) = AddMonoidHom.id (degreeZeroSubgroup X) := by
+  ext D x
+  simp
+
+lemma pushforwardDegreeZero_comp (g : Y → Z) (f : X → Y) :
+    pushforwardDegreeZero (g ∘ f) =
+      (pushforwardDegreeZero g).comp (pushforwardDegreeZero f) := by
+  ext D z
+  simp [pushforward_comp]
+
+/-- The subgroup of divisors of weighted degree zero for a weight function on points.
+
+For a curve over a field `k`, the intended weight is `x ↦ [κ(x) : k]`, giving the formal
+degree-zero divisor group before principal divisors are introduced. -/
+noncomputable def weightedDegreeZeroSubgroup (w : X → ℤ) : AddSubgroup (WeilDivisor X) :=
+  (weightedDegree w).ker
+
+@[simp]
+lemma mem_weightedDegreeZeroSubgroup (w : X → ℤ) (D : WeilDivisor X) :
+    D ∈ weightedDegreeZeroSubgroup w ↔ weightedDegree w D = 0 :=
+  AddMonoidHom.mem_ker
+
+@[simp]
+lemma weightedDegree_coe_weightedDegreeZeroSubgroup (w : X → ℤ)
+    (D : weightedDegreeZeroSubgroup w) : weightedDegree w (D : WeilDivisor X) = 0 :=
+  D.property
+
+@[simp]
+lemma pointDifference_mem_weightedDegreeZeroSubgroup {w : X → ℤ} {x y : X}
+    (h : w x = w y) : pointDifference x y ∈ weightedDegreeZeroSubgroup w := by
+  simp [pointDifference, h]
+
+/-- Pushforward as a homomorphism on weighted degree-zero divisors, when the target weight
+pulls back to the source weight. -/
+noncomputable def pushforwardWeightedDegreeZero (wX : X → ℤ) (wY : Y → ℤ) (f : X → Y)
+    (hw : ∀ x, wY (f x) = wX x) :
+    weightedDegreeZeroSubgroup wX →+ weightedDegreeZeroSubgroup wY where
+  toFun D :=
+    ⟨pushforward f D, by
+      rw [mem_weightedDegreeZeroSubgroup, weightedDegree_pushforward]
+      simp [Function.comp_def, hw]⟩
+  map_zero' := by
+    apply Subtype.ext
+    exact pushforward_zero f
+  map_add' D E := by
+    apply Subtype.ext
+    exact pushforward_add f D E
+
+@[simp]
+lemma pushforwardWeightedDegreeZero_apply (wX : X → ℤ) (wY : Y → ℤ) (f : X → Y)
+    (hw : ∀ x, wY (f x) = wX x) (D : weightedDegreeZeroSubgroup wX) :
+    (pushforwardWeightedDegreeZero wX wY f hw D : WeilDivisor Y) = pushforward f D :=
+  rfl
+
+@[simp]
+lemma pushforwardWeightedDegreeZero_id (w : X → ℤ) :
+    pushforwardWeightedDegreeZero w w (fun x : X => x) (fun _ => rfl) =
+      AddMonoidHom.id (weightedDegreeZeroSubgroup w) := by
+  ext D x
+  simp
+
+lemma pushforwardWeightedDegreeZero_comp (wX : X → ℤ) (wY : Y → ℤ) (wZ : Z → ℤ)
+    (f : X → Y) (g : Y → Z) (hf : ∀ x, wY (f x) = wX x)
+    (hg : ∀ y, wZ (g y) = wY y) :
+    pushforwardWeightedDegreeZero wX wZ (g ∘ f) (fun x => by simp [hg (f x), hf x]) =
+      (pushforwardWeightedDegreeZero wY wZ g hg).comp
+        (pushforwardWeightedDegreeZero wX wY f hf) := by
+  ext D z
+  simp [pushforward_comp]
 
 end
 


### PR DESCRIPTION
This PR packages the degree-zero kernel API for formal Weil divisors, advancing TauCetiRoadmap/JacobianChallenge/README.md, Layer A, target "Pic⁰ X = ker deg" as an abstract group before principal divisors, line bundles, or the Picard functor are available.

It adds the unweighted and weighted degree-zero subgroups, point-difference divisors as basic degree-zero examples, and pushforward homomorphisms preserving those kernels. It also imports the existing Weil divisor module from the TauCeti root so the API is reachable from `TauCeti`.

No Mathlib infrastructure is vendored. The PR reuses Mathlib's `Finsupp.degree`, `Finsupp.linearCombination`, `AddMonoidHom.ker`, and existing Tau Ceti formal Weil-divisor pushforward and degree operations.

Verified with `lake exe cache get`, `lake build`, and `lake exe axioms`.

🤖 Prepared with Codex
