### PR TITLE
feat: add PDE matrix bilinear forms

### DIFF
--- a/TauCeti.lean
+++ b/TauCeti.lean
@@ -6,4 +6,5 @@
 import TauCeti.Algebra.AlgebraicGroup.CommHopfAlgCat
 import TauCeti.Algebra.Coalgebra.ComoduleCat
 import TauCeti.AlgebraicTopology.UniversalCover.Deck.Fiber
+import TauCeti.Analysis.PDE.UniformEllipticity
 import TauCeti.Basic

--- a/TauCeti/Analysis/PDE/UniformEllipticity.lean
+++ b/TauCeti/Analysis/PDE/UniformEllipticity.lean
@@ -3,7 +3,7 @@ Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 -/
 import Mathlib.Analysis.InnerProductSpace.PiL2
-import Mathlib.Analysis.InnerProductSpace.LaxMilgram
+import Mathlib.Analysis.Normed.Operator.NormedSpace
 import Mathlib.LinearAlgebra.Matrix.BilinearForm
 import Mathlib.LinearAlgebra.QuadraticForm.Basic
 import Mathlib.Topology.Algebra.Module.FiniteDimensionBilinear
@@ -35,8 +35,8 @@ and Lax--Milgram arguments: constants are parameters, not hidden existential dat
   predicate.
 * `TauCeti.PDE.matrixBilinearForm`: the bounded bilinear form `η, ξ ↦ ηᵀ A ξ` attached to
   a coefficient matrix.
-* `TauCeti.PDE.UniformlyEllipticOn.point_isCoercive`: pointwise coercivity of the bilinear
-  form attached to a uniformly elliptic coefficient field.
+* `TauCeti.PDE.UniformlyEllipticOn.isCoercive_matrixBilinearForm`: pointwise coercivity of
+  the bilinear form attached to a uniformly elliptic coefficient field.
 
 The vectors are `EuclideanSpace ℝ n`, matching the roadmap's bounded open subsets of
 `ℝⁿ`; this type is reducibly a finite `L²` product, so Mathlib's matrix-vector API applies
@@ -65,20 +65,6 @@ lemma toQuadraticForm'_one (ξ : EuclideanSpace ℝ n) :
   simpa [dotProduct, sq] using (EuclideanSpace.real_norm_sq_eq ξ).symm
 
 omit [DecidableEq n] in
-/-- The dot-product expression `ηᵀ A ξ` is bilinear on Euclidean space. -/
-private lemma isBilinearMap_dotProduct_mulVec (A : Matrix n n ℝ) :
-    IsBilinearMap ℝ (fun η ξ : EuclideanSpace ℝ n => η ⬝ᵥ (A *ᵥ ξ)) := by
-  refine IsBilinearMap.mk ?_ ?_ ?_ ?_
-  · intro η₁ η₂ ξ
-    simp [add_dotProduct]
-  · intro c η ξ
-    simp [smul_dotProduct]
-  · intro η ξ₁ ξ₂
-    simp [Matrix.mulVec_add, dotProduct_add]
-  · intro c η ξ
-    simp [Matrix.mulVec_smul, dotProduct_smul]
-
-omit [DecidableEq n] in
 /-- The continuous bilinear form attached to a real matrix on Euclidean space.
 
 For a coefficient matrix `A`, this is the pointwise weak-form integrand
@@ -87,27 +73,29 @@ Mathlib's bounded-bilinear-form and Lax--Milgram APIs once the corresponding Sob
 are available. -/
 noncomputable def matrixBilinearForm (A : Matrix n n ℝ) :
     EuclideanSpace ℝ n →L[ℝ] EuclideanSpace ℝ n →L[ℝ] ℝ :=
-  (isBilinearMap_dotProduct_mulVec A).toContinuousBilinearMap
+  (A.toBilin'.comp (EuclideanSpace.equiv n ℝ).toLinearMap
+    (EuclideanSpace.equiv n ℝ).toLinearMap).toContinuousBilinearMap
 
-omit [DecidableEq n] in
 /-- The matrix bilinear form is the dot-product expression `ηᵀ A ξ`. -/
 @[simp]
 lemma matrixBilinearForm_apply (A : Matrix n n ℝ) (η ξ : EuclideanSpace ℝ n) :
     matrixBilinearForm A η ξ = η ⬝ᵥ (A *ᵥ ξ) := by
-  simp [matrixBilinearForm]
+  rw [matrixBilinearForm, LinearMap.toContinuousBilinearMap_apply,
+    LinearMap.BilinForm.comp_apply, Matrix.toBilin'_apply']
+  rfl
 
 /-- The matrix bilinear form associated to the identity matrix is the Euclidean dot product. -/
 @[simp]
 lemma matrixBilinearForm_one_apply (η ξ : EuclideanSpace ℝ n) :
     matrixBilinearForm (1 : Matrix n n ℝ) η ξ = η ⬝ᵥ ξ := by
-  simp
+  rw [matrixBilinearForm_apply, one_mulVec]
 
 /-- The quadratic part of the matrix bilinear form is the matrix quadratic form. -/
+@[simp]
 lemma matrixBilinearForm_self (A : Matrix n n ℝ) (ξ : EuclideanSpace ℝ n) :
     matrixBilinearForm A ξ ξ = A.toQuadraticForm' ξ := by
   rw [matrixBilinearForm_apply, toQuadraticForm'_eq_dotProduct]
 
-omit [DecidableEq n] in
 /-- A pointwise bilinear upper bound gives the corresponding norm estimate for the bundled
 continuous bilinear form. -/
 lemma norm_matrixBilinearForm_le_of_upper_bound (A : Matrix n n ℝ) {Lam : ℝ}
@@ -234,7 +222,8 @@ lemma norm_point_matrixBilinearForm_le (h : UniformlyEllipticOn Ω a lam Lam) {x
 
 /-- At every point of the domain, uniform ellipticity gives coercivity of the attached
 matrix bilinear form with coercivity constant `λ`. -/
-lemma point_isCoercive (h : UniformlyEllipticOn Ω a lam Lam) {x : X} (hx : x ∈ Ω) :
+lemma isCoercive_matrixBilinearForm (h : UniformlyEllipticOn Ω a lam Lam) {x : X}
+    (hx : x ∈ Ω) :
     IsCoercive (matrixBilinearForm (a x)) :=
   matrixBilinearForm_isCoercive_of_lower_bound (a x) h.pos (h.lower_bound hx)
 

--- a/TauCeti/Analysis/PDE/UniformEllipticity.lean
+++ b/TauCeti/Analysis/PDE/UniformEllipticity.lean
@@ -215,13 +215,15 @@ lemma of_bounds (hlam : 0 < lam) (hlamLam : lam ≤ Lam)
 
 /-- At every point of the domain, uniform ellipticity gives a norm bound for the attached
 matrix bilinear form. -/
+@[grind =>]
 lemma norm_point_matrixBilinearForm_le (h : UniformlyEllipticOn Ω a lam Lam) {x : X}
     (hx : x ∈ Ω) (η ξ : EuclideanSpace ℝ n) :
     ‖matrixBilinearForm (a x) η ξ‖ ≤ Lam * ‖η‖ * ‖ξ‖ :=
   norm_matrixBilinearForm_le_of_upper_bound (a x) (h.upper_bound hx) η ξ
 
-/-- At every point of the domain, uniform ellipticity gives coercivity of the attached
-matrix bilinear form with coercivity constant `λ`. -/
+/-- At every point of the domain, uniform ellipticity gives coercivity of the attached matrix
+bilinear form. -/
+@[grind =>]
 lemma isCoercive_matrixBilinearForm (h : UniformlyEllipticOn Ω a lam Lam) {x : X}
     (hx : x ∈ Ω) :
     IsCoercive (matrixBilinearForm (a x)) :=

--- a/TauCeti/Analysis/PDE/UniformEllipticity.lean
+++ b/TauCeti/Analysis/PDE/UniformEllipticity.lean
@@ -3,7 +3,10 @@ Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 -/
 import Mathlib.Analysis.InnerProductSpace.PiL2
+import Mathlib.Analysis.InnerProductSpace.LaxMilgram
+import Mathlib.LinearAlgebra.Matrix.BilinearForm
 import Mathlib.LinearAlgebra.QuadraticForm.Basic
+import Mathlib.Topology.Algebra.Module.FiniteDimensionBilinear
 
 /-!
 # Uniform ellipticity for divergence-form PDE coefficients
@@ -30,6 +33,10 @@ and Lax--Milgram arguments: constants are parameters, not hidden existential dat
   predicate.
 * `TauCeti.PDE.UniformlyEllipticOn.mono_set`: restriction to a smaller domain preserves the
   predicate.
+* `TauCeti.PDE.matrixBilinearForm`: the bounded bilinear form `η, ξ ↦ ηᵀ A ξ` attached to
+  a coefficient matrix.
+* `TauCeti.PDE.UniformlyEllipticOn.point_isCoercive`: pointwise coercivity of the bilinear
+  form attached to a uniformly elliptic coefficient field.
 
 The vectors are `EuclideanSpace ℝ n`, matching the roadmap's bounded open subsets of
 `ℝⁿ`; this type is reducibly a finite `L²` product, so Mathlib's matrix-vector API applies
@@ -56,6 +63,75 @@ lemma toQuadraticForm'_one (ξ : EuclideanSpace ℝ n) :
     (1 : Matrix n n ℝ).toQuadraticForm' ξ = ‖ξ‖ ^ 2 := by
   rw [toQuadraticForm'_eq_dotProduct, one_mulVec]
   simpa [dotProduct, sq] using (EuclideanSpace.real_norm_sq_eq ξ).symm
+
+omit [DecidableEq n] in
+/-- The dot-product expression `ηᵀ A ξ` is bilinear on Euclidean space. -/
+private lemma isBilinearMap_dotProduct_mulVec (A : Matrix n n ℝ) :
+    IsBilinearMap ℝ (fun η ξ : EuclideanSpace ℝ n => η ⬝ᵥ (A *ᵥ ξ)) := by
+  refine IsBilinearMap.mk ?_ ?_ ?_ ?_
+  · intro η₁ η₂ ξ
+    simp [add_dotProduct]
+  · intro c η ξ
+    simp [smul_dotProduct]
+  · intro η ξ₁ ξ₂
+    simp [Matrix.mulVec_add, dotProduct_add]
+  · intro c η ξ
+    simp [Matrix.mulVec_smul, dotProduct_smul]
+
+omit [DecidableEq n] in
+/-- The continuous bilinear form attached to a real matrix on Euclidean space.
+
+For a coefficient matrix `A`, this is the pointwise weak-form integrand
+`(η, ξ) ↦ ηᵀ A ξ`. It is bundled as a continuous bilinear map so it can feed directly into
+Mathlib's bounded-bilinear-form and Lax--Milgram APIs once the corresponding Sobolev spaces
+are available. -/
+noncomputable def matrixBilinearForm (A : Matrix n n ℝ) :
+    EuclideanSpace ℝ n →L[ℝ] EuclideanSpace ℝ n →L[ℝ] ℝ :=
+  (isBilinearMap_dotProduct_mulVec A).toContinuousBilinearMap
+
+omit [DecidableEq n] in
+/-- The matrix bilinear form is the dot-product expression `ηᵀ A ξ`. -/
+@[simp]
+lemma matrixBilinearForm_apply (A : Matrix n n ℝ) (η ξ : EuclideanSpace ℝ n) :
+    matrixBilinearForm A η ξ = η ⬝ᵥ (A *ᵥ ξ) := by
+  simp [matrixBilinearForm]
+
+/-- The matrix bilinear form associated to the identity matrix is the Euclidean dot product. -/
+@[simp]
+lemma matrixBilinearForm_one_apply (η ξ : EuclideanSpace ℝ n) :
+    matrixBilinearForm (1 : Matrix n n ℝ) η ξ = η ⬝ᵥ ξ := by
+  simp
+
+/-- The quadratic part of the matrix bilinear form is the matrix quadratic form. -/
+lemma matrixBilinearForm_self (A : Matrix n n ℝ) (ξ : EuclideanSpace ℝ n) :
+    matrixBilinearForm A ξ ξ = A.toQuadraticForm' ξ := by
+  rw [matrixBilinearForm_apply, toQuadraticForm'_eq_dotProduct]
+
+omit [DecidableEq n] in
+/-- A pointwise bilinear upper bound gives the corresponding norm estimate for the bundled
+continuous bilinear form. -/
+lemma norm_matrixBilinearForm_le_of_upper_bound (A : Matrix n n ℝ) {Lam : ℝ}
+    (hA : ∀ η ξ : EuclideanSpace ℝ n, |η ⬝ᵥ (A *ᵥ ξ)| ≤ Lam * ‖η‖ * ‖ξ‖)
+    (η ξ : EuclideanSpace ℝ n) :
+    ‖matrixBilinearForm A η ξ‖ ≤ Lam * ‖η‖ * ‖ξ‖ := by
+  simpa [Real.norm_eq_abs] using hA η ξ
+
+/-- A pointwise quadratic lower bound makes the associated matrix bilinear form coercive in
+Mathlib's Lax--Milgram sense. -/
+lemma matrixBilinearForm_isCoercive_of_lower_bound (A : Matrix n n ℝ) {lam : ℝ}
+    (hlam : 0 < lam)
+    (hA : ∀ ξ : EuclideanSpace ℝ n, lam * ‖ξ‖ ^ 2 ≤ A.toQuadraticForm' ξ) :
+    IsCoercive (matrixBilinearForm A) := by
+  refine ⟨lam, hlam, fun ξ => ?_⟩
+  rw [matrixBilinearForm_self]
+  simpa [sq, pow_two, mul_assoc] using hA ξ
+
+/-- The identity matrix bilinear form is coercive with constant `1`. -/
+lemma matrixBilinearForm_one_isCoercive :
+    IsCoercive (matrixBilinearForm (1 : Matrix n n ℝ)) := by
+  refine matrixBilinearForm_isCoercive_of_lower_bound (1 : Matrix n n ℝ) zero_lt_one ?_
+  intro ξ
+  simp
 
 /-- Uniform ellipticity and boundedness with explicit constants on a domain.
 
@@ -148,6 +224,19 @@ lemma of_bounds (hlam : 0 < lam) (hlamLam : lam ≤ Lam)
       |η ⬝ᵥ (a x *ᵥ ξ)| ≤ Lam * ‖η‖ * ‖ξ‖) :
     UniformlyEllipticOn Ω a lam Lam :=
   ⟨hlam, hlamLam, fun {_} hx => ⟨hbounds hx, hupper hx⟩⟩
+
+/-- At every point of the domain, uniform ellipticity gives a norm bound for the attached
+matrix bilinear form. -/
+lemma norm_point_matrixBilinearForm_le (h : UniformlyEllipticOn Ω a lam Lam) {x : X}
+    (hx : x ∈ Ω) (η ξ : EuclideanSpace ℝ n) :
+    ‖matrixBilinearForm (a x) η ξ‖ ≤ Lam * ‖η‖ * ‖ξ‖ :=
+  norm_matrixBilinearForm_le_of_upper_bound (a x) (h.upper_bound hx) η ξ
+
+/-- At every point of the domain, uniform ellipticity gives coercivity of the attached
+matrix bilinear form with coercivity constant `λ`. -/
+lemma point_isCoercive (h : UniformlyEllipticOn Ω a lam Lam) {x : X} (hx : x ∈ Ω) :
+    IsCoercive (matrixBilinearForm (a x)) :=
+  matrixBilinearForm_isCoercive_of_lower_bound (a x) h.pos (h.lower_bound hx)
 
 end UniformlyEllipticOn
 

--- a/TauCeti/Analysis/PDE/UniformEllipticity.lean
+++ b/TauCeti/Analysis/PDE/UniformEllipticity.lean
@@ -106,7 +106,7 @@ lemma norm_matrixBilinearForm_le_of_upper_bound (A : Matrix n n ℝ) {Lam : ℝ}
 
 /-- A pointwise quadratic lower bound makes the associated matrix bilinear form coercive in
 Mathlib's Lax--Milgram sense. -/
-lemma matrixBilinearForm_isCoercive_of_lower_bound (A : Matrix n n ℝ) {lam : ℝ}
+lemma isCoercive_matrixBilinearForm_of_lower_bound (A : Matrix n n ℝ) {lam : ℝ}
     (hlam : 0 < lam)
     (hA : ∀ ξ : EuclideanSpace ℝ n, lam * ‖ξ‖ ^ 2 ≤ A.toQuadraticForm' ξ) :
     IsCoercive (matrixBilinearForm A) := by
@@ -115,9 +115,9 @@ lemma matrixBilinearForm_isCoercive_of_lower_bound (A : Matrix n n ℝ) {lam : �
   simpa [sq, pow_two, mul_assoc] using hA ξ
 
 /-- The identity matrix bilinear form is coercive with constant `1`. -/
-lemma matrixBilinearForm_one_isCoercive :
+lemma isCoercive_matrixBilinearForm_one :
     IsCoercive (matrixBilinearForm (1 : Matrix n n ℝ)) := by
-  refine matrixBilinearForm_isCoercive_of_lower_bound (1 : Matrix n n ℝ) zero_lt_one ?_
+  refine isCoercive_matrixBilinearForm_of_lower_bound (1 : Matrix n n ℝ) zero_lt_one ?_
   intro ξ
   simp
 
@@ -225,7 +225,7 @@ matrix bilinear form with coercivity constant `λ`. -/
 lemma isCoercive_matrixBilinearForm (h : UniformlyEllipticOn Ω a lam Lam) {x : X}
     (hx : x ∈ Ω) :
     IsCoercive (matrixBilinearForm (a x)) :=
-  matrixBilinearForm_isCoercive_of_lower_bound (a x) h.pos (h.lower_bound hx)
+  isCoercive_matrixBilinearForm_of_lower_bound (a x) h.pos (h.lower_bound hx)
 
 end UniformlyEllipticOn
 


### PR DESCRIPTION
This PR adds the continuous matrix bilinear form API needed to pass from explicit uniformly elliptic coefficient matrices to the weak energy forms used by Lax--Milgram, advancing TauCetiRoadmap/PDE/README.md, Lane D target "existence and uniqueness of the weak solution of −Δu = f, u|∂Ω = 0, on a bounded domain, via IsCoercive + continuousLinearEquivOfBilin (Lax--Milgram)" and its Lane A prerequisite that the future Wkp0 energy form expose boundedness and coercivity hypotheses.

It defines `PDE.matrixBilinearForm A : EuclideanSpace ℝ n →L[ℝ] EuclideanSpace ℝ n →L[ℝ] ℝ` for the pointwise integrand `(η, ξ) ↦ ηᵀ A ξ`, proves the dot-product and quadratic-form simp/API lemmas, and packages the existing `UniformlyEllipticOn` lower and upper bounds as pointwise `IsCoercive` and norm-boundedness results. It also imports the PDE coefficient module from the TauCeti root so the API is reachable from `TauCeti`.

No Mathlib infrastructure is vendored. The PR reuses Mathlib `IsBilinearMap.toContinuousBilinearMap`, `Matrix.mulVec`/`dotProduct` API, `Matrix.toQuadraticForm'`, `EuclideanSpace`, and `IsCoercive` from the Lax--Milgram stack.

Verified with `lake exe cache get`, `lake build`, and `lake exe axioms`.

🤖 Prepared with Codex