### PR TITLE
feat: add connected deck action API

### DIFF
--- a/TauCeti.lean
+++ b/TauCeti.lean
@@ -6,5 +6,5 @@
 import TauCeti.Algebra.AlgebraicGroup.CommHopfAlgCat
 import TauCeti.Algebra.Coalgebra.ComoduleCat
 import TauCeti.AlgebraicGeometry.WeilDivisor
-import TauCeti.AlgebraicTopology.UniversalCover.Deck.Fiber
+import TauCeti.AlgebraicTopology.UniversalCover.Deck.Connected
 import TauCeti.Basic

--- a/TauCeti/AlgebraicTopology/UniversalCover/Deck/Connected.lean
+++ b/TauCeti/AlgebraicTopology/UniversalCover/Deck/Connected.lean
@@ -37,12 +37,6 @@ theorem eq_of_apply_eq [PreconnectedSpace E] (hp : IsCoveringMap p) (φ ψ : Dec
         rw [Function.comp_apply, Function.comp_apply, map_proj φ x, map_proj ψ x])
       e h)
 
-/-- On a covering map with preconnected total space, a deck transformation fixing one point is
-the identity. -/
-theorem eq_one_of_apply_eq_self [PreconnectedSpace E] (hp : IsCoveringMap p) (φ : Deck p) {e : E}
-    (h : φ.1 e = e) : φ = 1 :=
-  eq_of_apply_eq hp φ 1 (by simpa using h)
-
 /-- On a covering map with preconnected total space, equality of the ambient deck action at one
 point determines the deck transformation. -/
 theorem eq_of_smul_eq_smul [PreconnectedSpace E] (hp : IsCoveringMap p) (φ ψ : Deck p) {e : E}

--- a/TauCeti/AlgebraicTopology/UniversalCover/Deck/Connected.lean
+++ b/TauCeti/AlgebraicTopology/UniversalCover/Deck/Connected.lean
@@ -49,12 +49,6 @@ theorem eq_of_smul_eq_smul [PreconnectedSpace E] (hp : IsCoveringMap p) (φ ψ :
     (h : φ • e = ψ • e) : φ = ψ :=
   eq_of_apply_eq hp φ ψ (by simpa only [smul_eq_apply] using h)
 
-/-- On a covering map with preconnected total space, a deck transformation that fixes one point
-under the ambient action is the identity. -/
-theorem eq_one_of_smul_eq_self [PreconnectedSpace E] (hp : IsCoveringMap p) (φ : Deck p) {e : E}
-    (h : φ • e = e) : φ = 1 :=
-  eq_one_of_apply_eq_self hp φ (by simpa only [smul_eq_apply] using h)
-
 /-- The deck action on the total space of a preconnected covering is cancellative. -/
 theorem isCancelSMul [PreconnectedSpace E] (hp : IsCoveringMap p) : IsCancelSMul (Deck p) E where
   right_cancel' φ ψ _ h := eq_of_smul_eq_smul hp φ ψ h
@@ -75,18 +69,6 @@ theorem eq_of_fiberHomeomorph_apply_eq [PreconnectedSpace E] (hp : IsCoveringMap
     (φ ψ : Deck p) {e : p ⁻¹' {b}} (h : fiberHomeomorph φ b e = fiberHomeomorph ψ b e) :
     φ = ψ :=
   eq_of_fiber_smul_eq_fiber_smul hp φ ψ (by simpa using h)
-
-/-- A deck transformation of a preconnected covering that fixes one point of a fibre is the
-identity. -/
-theorem eq_one_of_fiber_smul_eq_self [PreconnectedSpace E] (hp : IsCoveringMap p)
-    (φ : Deck p) {e : p ⁻¹' {b}} (h : φ • e = e) : φ = 1 :=
-  eq_of_fiber_smul_eq_fiber_smul hp φ 1 (by simpa using h)
-
-/-- A deck transformation of a preconnected covering whose restricted fibre homeomorphism fixes
-one point is the identity. -/
-theorem eq_one_of_fiberHomeomorph_apply_eq_self [PreconnectedSpace E] (hp : IsCoveringMap p)
-    (φ : Deck p) {e : p ⁻¹' {b}} (h : fiberHomeomorph φ b e = e) : φ = 1 :=
-  eq_one_of_fiber_smul_eq_self hp φ (by simpa using h)
 
 /-- The induced deck action on a fibre of a preconnected covering is cancellative. -/
 theorem fiber_isCancelSMul [PreconnectedSpace E] (hp : IsCoveringMap p) :

--- a/TauCeti/AlgebraicTopology/UniversalCover/Deck/Connected.lean
+++ b/TauCeti/AlgebraicTopology/UniversalCover/Deck/Connected.lean
@@ -2,6 +2,7 @@
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 -/
+import Mathlib.GroupTheory.GroupAction.Basic
 import Mathlib.Topology.Covering.Basic
 import TauCeti.AlgebraicTopology.UniversalCover.Deck.Fiber
 
@@ -47,6 +48,13 @@ theorem eq_of_smul_eq_smul [PreconnectedSpace E] (hp : IsCoveringMap p) (φ ψ :
 theorem isCancelSMul [PreconnectedSpace E] (hp : IsCoveringMap p) : IsCancelSMul (Deck p) E where
   right_cancel' φ ψ _ h := eq_of_smul_eq_smul hp φ ψ h
 
+/-- The stabilizer of any point under the deck action of a preconnected covering is trivial. -/
+@[simp]
+theorem stabilizer_eq_bot [PreconnectedSpace E] (hp : IsCoveringMap p) (e : E) :
+    MulAction.stabilizer (Deck p) e = ⊥ := by
+  haveI := isCancelSMul hp
+  exact IsCancelSMul.stabilizer_eq_bot e
+
 section Fiber
 
 variable {b : B}
@@ -54,8 +62,10 @@ variable {b : B}
 /-- A deck transformation of a preconnected covering is determined by its action on one point of
 a chosen fibre. -/
 theorem eq_of_fiber_smul_eq_fiber_smul [PreconnectedSpace E] (hp : IsCoveringMap p)
-    (φ ψ : Deck p) {e : p ⁻¹' {b}} (h : φ • e = ψ • e) : φ = ψ :=
-  eq_of_apply_eq hp φ ψ (Subtype.ext_iff.mp h)
+    (φ ψ : Deck p) {e : p ⁻¹' {b}} (h : φ • e = ψ • e) : φ = ψ := by
+  have hcoe : (φ • e : E) = (ψ • e : E) := congrArg Subtype.val h
+  rw [fiber_smul_coe, fiber_smul_coe] at hcoe
+  exact eq_of_apply_eq hp φ ψ hcoe
 
 /-- A deck transformation of a preconnected covering is determined by the value of its
 restricted fibre homeomorphism at one point. -/
@@ -68,6 +78,14 @@ theorem eq_of_fiberHomeomorph_apply_eq [PreconnectedSpace E] (hp : IsCoveringMap
 theorem fiber_isCancelSMul [PreconnectedSpace E] (hp : IsCoveringMap p) :
     IsCancelSMul (Deck p) (p ⁻¹' {b}) where
   right_cancel' φ ψ _ h := eq_of_fiber_smul_eq_fiber_smul hp φ ψ h
+
+/-- The stabilizer of any fibre point under the restricted deck action of a preconnected
+covering is trivial. -/
+@[simp]
+theorem fiber_stabilizer_eq_bot [PreconnectedSpace E] (hp : IsCoveringMap p) (e : p ⁻¹' {b}) :
+    MulAction.stabilizer (Deck p) e = ⊥ := by
+  haveI := fiber_isCancelSMul (b := b) hp
+  exact IsCancelSMul.stabilizer_eq_bot e
 
 /-- For a nonempty fibre of a preconnected covering, restricting deck transformations to that
 fibre is injective. -/

--- a/TauCeti/AlgebraicTopology/UniversalCover/Deck/Connected.lean
+++ b/TauCeti/AlgebraicTopology/UniversalCover/Deck/Connected.lean
@@ -9,8 +9,8 @@ import TauCeti.AlgebraicTopology.UniversalCover.Deck.Fiber
 # Deck transformations of connected covers
 
 For a covering projection with preconnected total space, two deck transformations are equal as
-soon as they agree at one point. Equivalently, the deck action on the total space is free, and
-the induced action on every fibre has trivial stabilizers.
+soon as they agree at one point. Equivalently, the deck action on the total space is
+cancellative, and so is the induced action on every fibre.
 
 This is a small prerequisite for the universal-covers roadmap Stage 2: the pointed and
 unpointed cover correspondences need to track deck transformations through their action on a
@@ -59,31 +59,6 @@ theorem eq_one_of_smul_eq_self [PreconnectedSpace E] (hp : IsCoveringMap p) (φ 
 theorem isCancelSMul [PreconnectedSpace E] (hp : IsCoveringMap p) : IsCancelSMul (Deck p) E where
   right_cancel' φ ψ _ h := eq_of_smul_eq_smul hp φ ψ h
 
-/-- The stabilizer of a point in the total space of a preconnected covering is trivial. -/
-@[simp]
-theorem stabilizer_eq_bot [PreconnectedSpace E] (hp : IsCoveringMap p) (e : E) :
-    MulAction.stabilizer (Deck p) e = ⊥ := by
-  rw [Subgroup.eq_bot_iff_forall]
-  intro φ hφ
-  exact eq_one_of_smul_eq_self hp φ hφ
-
-/-- If a subgroup of the deck group fixes a point of the total space of a preconnected
-covering, then that subgroup is trivial. -/
-theorem le_bot_of_le_stabilizer [PreconnectedSpace E] (hp : IsCoveringMap p)
-    {H : Subgroup (Deck p)} {e : E} (hH : H ≤ MulAction.stabilizer (Deck p) e) : H ≤ ⊥ := by
-  rw [stabilizer_eq_bot hp e] at hH
-  exact hH
-
-/-- A subgroup of the deck group fixes a point of the total space of a preconnected covering
-exactly when it is trivial. -/
-theorem le_stabilizer_iff [PreconnectedSpace E] (hp : IsCoveringMap p)
-    (H : Subgroup (Deck p)) (e : E) : H ≤ MulAction.stabilizer (Deck p) e ↔ H ≤ ⊥ := by
-  constructor
-  · exact le_bot_of_le_stabilizer hp
-  · intro hH
-    rw [stabilizer_eq_bot hp e]
-    exact hH
-
 section Fiber
 
 variable {b : B}
@@ -117,33 +92,6 @@ theorem eq_one_of_fiberHomeomorph_apply_eq_self [PreconnectedSpace E] (hp : IsCo
 theorem fiber_isCancelSMul [PreconnectedSpace E] (hp : IsCoveringMap p) :
     IsCancelSMul (Deck p) (p ⁻¹' {b}) where
   right_cancel' φ ψ _ h := eq_of_fiber_smul_eq_fiber_smul hp φ ψ h
-
-/-- The stabilizer of a point in a fibre of a preconnected covering is trivial. -/
-@[simp]
-theorem fiber_stabilizer_eq_bot [PreconnectedSpace E] (hp : IsCoveringMap p) (e : p ⁻¹' {b}) :
-    MulAction.stabilizer (Deck p) e = ⊥ := by
-  rw [Subgroup.eq_bot_iff_forall]
-  intro φ hφ
-  exact eq_one_of_fiber_smul_eq_self hp φ hφ
-
-/-- If a subgroup of the deck group fixes a point of a fibre of a preconnected covering, then
-that subgroup is trivial. -/
-theorem le_bot_of_le_fiber_stabilizer [PreconnectedSpace E] (hp : IsCoveringMap p)
-    {H : Subgroup (Deck p)} {e : p ⁻¹' {b}} (hH : H ≤ MulAction.stabilizer (Deck p) e) :
-    H ≤ ⊥ := by
-  rw [fiber_stabilizer_eq_bot hp e] at hH
-  exact hH
-
-/-- A subgroup of the deck group fixes a point of a fibre of a preconnected covering exactly
-when it is trivial. -/
-theorem le_fiber_stabilizer_iff [PreconnectedSpace E] (hp : IsCoveringMap p)
-    (H : Subgroup (Deck p)) (e : p ⁻¹' {b}) :
-    H ≤ MulAction.stabilizer (Deck p) e ↔ H ≤ ⊥ := by
-  constructor
-  · exact le_bot_of_le_fiber_stabilizer hp
-  · intro hH
-    rw [fiber_stabilizer_eq_bot hp e]
-    exact hH
 
 /-- For a nonempty fibre of a preconnected covering, restricting deck transformations to that
 fibre is injective. -/

--- a/TauCeti/AlgebraicTopology/UniversalCover/Deck/Connected.lean
+++ b/TauCeti/AlgebraicTopology/UniversalCover/Deck/Connected.lean
@@ -1,0 +1,168 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+import Mathlib.Topology.Covering.Basic
+import TauCeti.AlgebraicTopology.UniversalCover.Deck.Fiber
+
+/-!
+# Deck transformations of connected covers
+
+For a covering projection with preconnected total space, two deck transformations are equal as
+soon as they agree at one point. Equivalently, the deck action on the total space is free, and
+the induced action on every fibre has trivial stabilizers.
+
+This is a small prerequisite for the universal-covers roadmap Stage 2: the pointed and
+unpointed cover correspondences need to track deck transformations through their action on a
+chosen fibre, and regular-cover statements use the fact that a deck transformation of a
+connected cover cannot fix a point unless it is the identity.
+-/
+
+namespace TauCeti
+
+namespace Deck
+
+variable {E B : Type*} [TopologicalSpace E] [TopologicalSpace B] {p : E → B}
+
+/-- Two deck transformations of a covering map with preconnected total space are equal if they
+agree at one point of the total space. -/
+theorem eq_of_apply_eq [PreconnectedSpace E] (hp : IsCoveringMap p) (φ ψ : Deck p) {e : E}
+    (h : φ.1 e = ψ.1 e) : φ = ψ := by
+  apply Subtype.ext
+  apply Homeomorph.ext
+  exact congr_fun
+    (hp.eq_of_comp_eq φ.1.continuous ψ.1.continuous
+      (by
+        ext x
+        rw [Function.comp_apply, Function.comp_apply, map_proj φ x, map_proj ψ x])
+      e h)
+
+/-- On a covering map with preconnected total space, a deck transformation fixing one point is
+the identity. -/
+theorem eq_one_of_apply_eq_self [PreconnectedSpace E] (hp : IsCoveringMap p) (φ : Deck p) {e : E}
+    (h : φ.1 e = e) : φ = 1 :=
+  eq_of_apply_eq hp φ 1 (by simpa using h)
+
+/-- On a covering map with preconnected total space, equality of the ambient deck action at one
+point determines the deck transformation. -/
+theorem eq_of_smul_eq_smul [PreconnectedSpace E] (hp : IsCoveringMap p) (φ ψ : Deck p) {e : E}
+    (h : φ • e = ψ • e) : φ = ψ :=
+  eq_of_apply_eq hp φ ψ (by simpa only [smul_eq_apply] using h)
+
+/-- On a covering map with preconnected total space, a deck transformation that fixes one point
+under the ambient action is the identity. -/
+theorem eq_one_of_smul_eq_self [PreconnectedSpace E] (hp : IsCoveringMap p) (φ : Deck p) {e : E}
+    (h : φ • e = e) : φ = 1 :=
+  eq_one_of_apply_eq_self hp φ (by simpa only [smul_eq_apply] using h)
+
+/-- The deck action on the total space of a preconnected covering is cancellative. -/
+theorem isCancelSMul [PreconnectedSpace E] (hp : IsCoveringMap p) : IsCancelSMul (Deck p) E where
+  right_cancel' φ ψ _ h := eq_of_smul_eq_smul hp φ ψ h
+
+/-- The stabilizer of a point in the total space of a preconnected covering is trivial. -/
+@[simp]
+theorem stabilizer_eq_bot [PreconnectedSpace E] (hp : IsCoveringMap p) (e : E) :
+    MulAction.stabilizer (Deck p) e = ⊥ := by
+  rw [Subgroup.eq_bot_iff_forall]
+  intro φ hφ
+  exact eq_one_of_smul_eq_self hp φ hφ
+
+/-- If a subgroup of the deck group fixes a point of the total space of a preconnected
+covering, then that subgroup is trivial. -/
+theorem le_bot_of_le_stabilizer [PreconnectedSpace E] (hp : IsCoveringMap p)
+    {H : Subgroup (Deck p)} {e : E} (hH : H ≤ MulAction.stabilizer (Deck p) e) : H ≤ ⊥ := by
+  rw [stabilizer_eq_bot hp e] at hH
+  exact hH
+
+/-- A subgroup of the deck group fixes a point of the total space of a preconnected covering
+exactly when it is trivial. -/
+theorem le_stabilizer_iff [PreconnectedSpace E] (hp : IsCoveringMap p)
+    (H : Subgroup (Deck p)) (e : E) : H ≤ MulAction.stabilizer (Deck p) e ↔ H ≤ ⊥ := by
+  constructor
+  · exact le_bot_of_le_stabilizer hp
+  · intro hH
+    rw [stabilizer_eq_bot hp e]
+    exact hH
+
+section Fiber
+
+variable {b : B}
+
+/-- A deck transformation of a preconnected covering is determined by its action on one point of
+a chosen fibre. -/
+theorem eq_of_fiber_smul_eq_fiber_smul [PreconnectedSpace E] (hp : IsCoveringMap p)
+    (φ ψ : Deck p) {e : p ⁻¹' {b}} (h : φ • e = ψ • e) : φ = ψ :=
+  eq_of_apply_eq hp φ ψ (Subtype.ext_iff.mp h)
+
+/-- A deck transformation of a preconnected covering is determined by the value of its
+restricted fibre homeomorphism at one point. -/
+theorem eq_of_fiberHomeomorph_apply_eq [PreconnectedSpace E] (hp : IsCoveringMap p)
+    (φ ψ : Deck p) {e : p ⁻¹' {b}} (h : fiberHomeomorph φ b e = fiberHomeomorph ψ b e) :
+    φ = ψ :=
+  eq_of_fiber_smul_eq_fiber_smul hp φ ψ (by simpa using h)
+
+/-- A deck transformation of a preconnected covering that fixes one point of a fibre is the
+identity. -/
+theorem eq_one_of_fiber_smul_eq_self [PreconnectedSpace E] (hp : IsCoveringMap p)
+    (φ : Deck p) {e : p ⁻¹' {b}} (h : φ • e = e) : φ = 1 :=
+  eq_of_fiber_smul_eq_fiber_smul hp φ 1 (by simpa using h)
+
+/-- A deck transformation of a preconnected covering whose restricted fibre homeomorphism fixes
+one point is the identity. -/
+theorem eq_one_of_fiberHomeomorph_apply_eq_self [PreconnectedSpace E] (hp : IsCoveringMap p)
+    (φ : Deck p) {e : p ⁻¹' {b}} (h : fiberHomeomorph φ b e = e) : φ = 1 :=
+  eq_one_of_fiber_smul_eq_self hp φ (by simpa using h)
+
+/-- The induced deck action on a fibre of a preconnected covering is cancellative. -/
+theorem fiber_isCancelSMul [PreconnectedSpace E] (hp : IsCoveringMap p) :
+    IsCancelSMul (Deck p) (p ⁻¹' {b}) where
+  right_cancel' φ ψ _ h := eq_of_fiber_smul_eq_fiber_smul hp φ ψ h
+
+/-- The stabilizer of a point in a fibre of a preconnected covering is trivial. -/
+@[simp]
+theorem fiber_stabilizer_eq_bot [PreconnectedSpace E] (hp : IsCoveringMap p) (e : p ⁻¹' {b}) :
+    MulAction.stabilizer (Deck p) e = ⊥ := by
+  rw [Subgroup.eq_bot_iff_forall]
+  intro φ hφ
+  exact eq_one_of_fiber_smul_eq_self hp φ hφ
+
+/-- If a subgroup of the deck group fixes a point of a fibre of a preconnected covering, then
+that subgroup is trivial. -/
+theorem le_bot_of_le_fiber_stabilizer [PreconnectedSpace E] (hp : IsCoveringMap p)
+    {H : Subgroup (Deck p)} {e : p ⁻¹' {b}} (hH : H ≤ MulAction.stabilizer (Deck p) e) :
+    H ≤ ⊥ := by
+  rw [fiber_stabilizer_eq_bot hp e] at hH
+  exact hH
+
+/-- A subgroup of the deck group fixes a point of a fibre of a preconnected covering exactly
+when it is trivial. -/
+theorem le_fiber_stabilizer_iff [PreconnectedSpace E] (hp : IsCoveringMap p)
+    (H : Subgroup (Deck p)) (e : p ⁻¹' {b}) :
+    H ≤ MulAction.stabilizer (Deck p) e ↔ H ≤ ⊥ := by
+  constructor
+  · exact le_bot_of_le_fiber_stabilizer hp
+  · intro hH
+    rw [fiber_stabilizer_eq_bot hp e]
+    exact hH
+
+/-- For a nonempty fibre of a preconnected covering, restricting deck transformations to that
+fibre is injective. -/
+theorem fiberHomeomorphHom_injective [PreconnectedSpace E] (hp : IsCoveringMap p)
+    [Nonempty (p ⁻¹' {b})] : Function.Injective (fiberHomeomorphHom p b) := by
+  classical
+  intro φ ψ hφψ
+  exact eq_of_fiberHomeomorph_apply_eq hp φ ψ (congr_fun (congr_arg DFunLike.coe hφψ)
+    (Classical.arbitrary (p ⁻¹' {b})))
+
+/-- For a nonempty fibre of a preconnected covering, the homomorphism restricting deck
+transformations to that fibre has trivial kernel. -/
+@[simp]
+theorem fiberHomeomorphHom_ker_eq_bot [PreconnectedSpace E] (hp : IsCoveringMap p)
+    [Nonempty (p ⁻¹' {b})] : MonoidHom.ker (fiberHomeomorphHom p b) = ⊥ :=
+  (MonoidHom.ker_eq_bot_iff (fiberHomeomorphHom p b)).mpr (fiberHomeomorphHom_injective hp)
+
+end Fiber
+
+end Deck
+
+end TauCeti


### PR DESCRIPTION
This PR adds the connected-cover deck-action API needed for the pointed and unpointed cover correspondences, advancing TauCetiRoadmap/UniversalCovers/README.md, Stage 2 target "Galois correspondence: get the bookkeeping right" and its prerequisite to add milestones for transitivity of the deck action on fibres before the regular-cover theorem.

It proves that deck transformations of a covering map with preconnected total space are determined by one point, packages the total-space and fibre actions as cancellative actions with trivial stabilizers, and shows that restriction to a nonempty fibre is injective with trivial kernel. These lemmas build directly on Mathlib `IsCoveringMap.eq_of_comp_eq`, `MulAction.stabilizer`, `IsCancelSMul`, and the existing TauCeti `Deck.fiberHomeomorphHom` API.

No Mathlib infrastructure is vendored.

Verified with `lake exe cache get`, `lake build`, and `lake exe axioms`.

🤖 Prepared with Codex