### PR TITLE
feat: transport deck fibre actions

### DIFF
--- a/TauCeti.lean
+++ b/TauCeti.lean
@@ -8,5 +8,6 @@ import TauCeti.Algebra.Coalgebra.ComoduleCat
 import TauCeti.AlgebraicGeometry.WeilDivisor
 import TauCeti.AlgebraicTopology.UniversalCover.Deck.Connected
 import TauCeti.AlgebraicTopology.UniversalCover.Deck.Fiber
+import TauCeti.AlgebraicTopology.UniversalCover.Deck.FiberTransport
 import TauCeti.Analysis.PDE.UniformEllipticity
 import TauCeti.Basic

--- a/TauCeti/AlgebraicTopology/UniversalCover/Deck/FiberTransport.lean
+++ b/TauCeti/AlgebraicTopology/UniversalCover/Deck/FiberTransport.lean
@@ -171,6 +171,7 @@ theorem fiberMap_symm_image_orbit (h : E ≃ₜ F) (hpq : ∀ e, q (h e) = p e)
     simpa using fiberMap_symm_smul h hpq (conjMulEquiv h hpq φ) f
 
 /-- Transporting both fibre points preserves membership in deck orbits. -/
+@[simp]
 theorem mem_orbit_fiberMap_iff (h : E ≃ₜ F) (hpq : ∀ e, q (h e) = p e)
     (e e' : p ⁻¹' {b}) :
     fiberMap h hpq b e' ∈ MulAction.orbit (Deck q) (fiberMap h hpq b e) ↔
@@ -188,6 +189,7 @@ theorem mem_orbit_fiberMap_iff (h : E ≃ₜ F) (hpq : ∀ e, q (h e) = p e)
     simpa using hcoe
 
 /-- Transporting both target-fibre points back preserves membership in deck orbits. -/
+@[simp]
 theorem mem_orbit_fiberMap_symm_iff (h : E ≃ₜ F) (hpq : ∀ e, q (h e) = p e)
     (f f' : q ⁻¹' {b}) :
     (fiberMap h hpq b).symm f' ∈

--- a/TauCeti/AlgebraicTopology/UniversalCover/Deck/FiberTransport.lean
+++ b/TauCeti/AlgebraicTopology/UniversalCover/Deck/FiberTransport.lean
@@ -133,6 +133,7 @@ lemma fiberMap_mem_orbit (h : E ≃ₜ F) (hpq : ∀ e, q (h e) = p e) (φ : Dec
 
 /-- The fibre map carries the deck orbit of a point onto the deck orbit of the transported
 point. -/
+@[simp]
 theorem fiberMap_image_orbit (h : E ≃ₜ F) (hpq : ∀ e, q (h e) = p e) (e : p ⁻¹' {b}) :
     fiberMap h hpq b '' MulAction.orbit (Deck p) e =
       MulAction.orbit (Deck q) (fiberMap h hpq b e) := by
@@ -155,6 +156,7 @@ lemma fiberMap_symm_mem_orbit (h : E ≃ₜ F) (hpq : ∀ e, q (h e) = p e) (ψ 
 
 /-- The inverse fibre map carries the deck orbit of a point onto the deck orbit of the
 transported point. -/
+@[simp]
 theorem fiberMap_symm_image_orbit (h : E ≃ₜ F) (hpq : ∀ e, q (h e) = p e)
     (f : q ⁻¹' {b}) :
     (fiberMap h hpq b).symm '' MulAction.orbit (Deck q) f =
@@ -167,6 +169,41 @@ theorem fiberMap_symm_image_orbit (h : E ≃ₜ F) (hpq : ∀ e, q (h e) = p e)
   · rintro ⟨φ, rfl⟩
     refine ⟨conjMulEquiv h hpq φ • f, ⟨conjMulEquiv h hpq φ, rfl⟩, ?_⟩
     simpa using fiberMap_symm_smul h hpq (conjMulEquiv h hpq φ) f
+
+/-- Transporting both fibre points preserves membership in deck orbits. -/
+theorem mem_orbit_fiberMap_iff (h : E ≃ₜ F) (hpq : ∀ e, q (h e) = p e)
+    (e e' : p ⁻¹' {b}) :
+    fiberMap h hpq b e' ∈ MulAction.orbit (Deck q) (fiberMap h hpq b e) ↔
+      e' ∈ MulAction.orbit (Deck p) e := by
+  constructor
+  · rintro ⟨ψ, hψ⟩
+    refine ⟨(conjMulEquiv h hpq).symm ψ, ?_⟩
+    ext
+    have hcoe := congrArg h.symm (congrArg Subtype.val hψ)
+    simpa using hcoe
+  · rintro ⟨φ, hφ⟩
+    refine ⟨conjMulEquiv h hpq φ, ?_⟩
+    ext
+    have hcoe := congrArg h (congrArg Subtype.val hφ)
+    simpa using hcoe
+
+/-- Transporting both target-fibre points back preserves membership in deck orbits. -/
+theorem mem_orbit_fiberMap_symm_iff (h : E ≃ₜ F) (hpq : ∀ e, q (h e) = p e)
+    (f f' : q ⁻¹' {b}) :
+    (fiberMap h hpq b).symm f' ∈
+        MulAction.orbit (Deck p) ((fiberMap h hpq b).symm f) ↔
+      f' ∈ MulAction.orbit (Deck q) f := by
+  constructor
+  · rintro ⟨φ, hφ⟩
+    refine ⟨conjMulEquiv h hpq φ, ?_⟩
+    ext
+    have hcoe := congrArg h (congrArg Subtype.val hφ)
+    simpa using hcoe
+  · rintro ⟨ψ, hψ⟩
+    refine ⟨(conjMulEquiv h hpq).symm ψ, ?_⟩
+    ext
+    have hcoe := congrArg h.symm (congrArg Subtype.val hψ)
+    simpa using hcoe
 
 end Deck
 

--- a/TauCeti/AlgebraicTopology/UniversalCover/Deck/FiberTransport.lean
+++ b/TauCeti/AlgebraicTopology/UniversalCover/Deck/FiberTransport.lean
@@ -1,0 +1,173 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+import TauCeti.AlgebraicTopology.UniversalCover.Deck.Conjugation
+import TauCeti.AlgebraicTopology.UniversalCover.Deck.Fiber
+
+/-!
+# Transporting deck actions on fibres
+
+An isomorphism of maps over a common base identifies corresponding fibres. This file packages
+that fibre identification and records that it intertwines the restricted deck actions with
+conjugation of deck transformations.
+
+This is bookkeeping for the universal-covers roadmap: pointed cover isomorphisms carry chosen
+lifts of the basepoint between fibres, and the pointed/unpointed cover correspondences need the
+deck action on those fibres to be compatible with conjugating the deck group.
+
+## Main definitions
+
+* `TauCeti.Deck.fiberMap`: the homeomorphism between fibres induced by an over-base
+  homeomorphism.
+
+## References
+
+This supplies a prerequisite for the Tau Ceti universal-covers roadmap, Stage 2
+(`pointed` and `unpointed` connected cover correspondences), building on Stage 0.4's
+deck-transformation group.
+-/
+
+namespace TauCeti
+
+namespace Deck
+
+variable {E F G B : Type*} [TopologicalSpace E] [TopologicalSpace F] [TopologicalSpace G]
+  {p : E → B} {q : F → B} {r : G → B} {b : B}
+
+/-- An over-base homeomorphism identifies the fibre over `b` for `p` with the fibre over
+`b` for `q`. -/
+def fiberMap (h : E ≃ₜ F) (hpq : ∀ e, q (h e) = p e) (b : B) :
+    p ⁻¹' {b} ≃ₜ q ⁻¹' {b} :=
+  h.subtype fun e => by
+    simp only [Set.mem_preimage, Set.mem_singleton_iff]
+    rw [hpq]
+
+/-- On underlying points, the fibre map induced by an over-base homeomorphism is just that
+homeomorphism. -/
+@[simp]
+lemma fiberMap_apply_coe (h : E ≃ₜ F) (hpq : ∀ e, q (h e) = p e) (e : p ⁻¹' {b}) :
+    (fiberMap h hpq b e : F) = h e.1 :=
+  rfl
+
+/-- On underlying points, the inverse fibre map is the inverse of the over-base
+homeomorphism. -/
+@[simp]
+lemma fiberMap_symm_apply_coe (h : E ≃ₜ F) (hpq : ∀ e, q (h e) = p e)
+    (f : q ⁻¹' {b}) :
+    ((fiberMap h hpq b).symm f : E) = h.symm f.1 :=
+  rfl
+
+/-- The fibre map induced by the identity over-base homeomorphism is the identity. -/
+@[simp]
+lemma fiberMap_refl :
+    fiberMap (Homeomorph.refl E) (p := p) (q := p) (fun _ => rfl) b =
+      Homeomorph.refl (p ⁻¹' {b}) := by
+  ext e
+  rfl
+
+/-- The inverse of the fibre map induced by an over-base homeomorphism is the fibre map induced
+by the inverse over-base homeomorphism. -/
+@[simp]
+lemma fiberMap_symm (h : E ≃ₜ F) (hpq : ∀ e, q (h e) = p e) :
+    (fiberMap h hpq b).symm =
+      fiberMap h.symm (map_symm_eq_of_map_eq h hpq) b := by
+  ext f
+  rfl
+
+/-- Fibre maps compose as the underlying over-base homeomorphisms compose. -/
+@[simp]
+lemma fiberMap_trans (h : E ≃ₜ F) (k : F ≃ₜ G)
+    (hpq : ∀ e, q (h e) = p e) (hqr : ∀ f, r (k f) = q f) :
+    (fiberMap h hpq b).trans (fiberMap k hqr b) =
+      fiberMap (h.trans k) (fun e => by rw [Homeomorph.trans_apply, hqr, hpq]) b := by
+  ext e
+  rfl
+
+/-- Fibre transport intertwines the restricted deck action with conjugation of deck
+transformations. -/
+@[simp]
+lemma fiberMap_smul (h : E ≃ₜ F) (hpq : ∀ e, q (h e) = p e) (φ : Deck p)
+    (e : p ⁻¹' {b}) :
+    fiberMap h hpq b (φ • e) = conjMulEquiv h hpq φ • fiberMap h hpq b e := by
+  ext
+  simp
+
+/-- The inverse fibre transport intertwines the restricted deck action with inverse
+conjugation of deck transformations. -/
+@[simp]
+lemma fiberMap_symm_smul (h : E ≃ₜ F) (hpq : ∀ e, q (h e) = p e) (ψ : Deck q)
+    (f : q ⁻¹' {b}) :
+    (fiberMap h hpq b).symm (ψ • f) =
+      (conjMulEquiv h hpq).symm ψ • (fiberMap h hpq b).symm f := by
+  ext
+  simp
+
+/-- Transporting a deck transformation to the target cover and then restricting it to a fibre
+is the same as restricting first and conjugating the resulting fibre homeomorphism by the fibre
+transport map. -/
+@[simp]
+lemma fiberMap_trans_fiberHomeomorph (h : E ≃ₜ F) (hpq : ∀ e, q (h e) = p e)
+    (φ : Deck p) :
+    (fiberMap h hpq b).trans (fiberHomeomorph (conjMulEquiv h hpq φ) b) =
+      (fiberHomeomorph φ b).trans (fiberMap h hpq b) := by
+  ext e
+  simp
+
+/-- Restricting conjugated deck transformations to a fibre is compatible with the fibre
+restriction homomorphism. -/
+@[simp]
+lemma fiberHomeomorphHom_conjMulEquiv (h : E ≃ₜ F) (hpq : ∀ e, q (h e) = p e)
+    (φ : Deck p) :
+    fiberHomeomorphHom q b (conjMulEquiv h hpq φ) =
+      (fiberMap h hpq b).symm.trans ((fiberHomeomorphHom p b φ).trans (fiberMap h hpq b)) := by
+  ext f
+  simp
+
+/-- Applying a deck transformation and then transporting to the target fibre gives a point in
+the target deck orbit. -/
+lemma fiberMap_mem_orbit (h : E ≃ₜ F) (hpq : ∀ e, q (h e) = p e) (φ : Deck p)
+    (e : p ⁻¹' {b}) :
+    fiberMap h hpq b (φ • e) ∈ MulAction.orbit (Deck q) (fiberMap h hpq b e) := by
+  exact ⟨conjMulEquiv h hpq φ, fiberMap_smul h hpq φ e |>.symm⟩
+
+/-- The fibre map carries the deck orbit of a point onto the deck orbit of the transported
+point. -/
+theorem fiberMap_image_orbit (h : E ≃ₜ F) (hpq : ∀ e, q (h e) = p e) (e : p ⁻¹' {b}) :
+    fiberMap h hpq b '' MulAction.orbit (Deck p) e =
+      MulAction.orbit (Deck q) (fiberMap h hpq b e) := by
+  ext f
+  constructor
+  · rintro ⟨e', ⟨φ, hφ⟩, rfl⟩
+    rw [← hφ]
+    exact fiberMap_mem_orbit h hpq φ e
+  · rintro ⟨ψ, rfl⟩
+    refine ⟨(conjMulEquiv h hpq).symm ψ • e, ⟨(conjMulEquiv h hpq).symm ψ, rfl⟩, ?_⟩
+    simpa using fiberMap_smul h hpq ((conjMulEquiv h hpq).symm ψ) e
+
+/-- Applying a deck transformation and then transporting back to the source fibre gives a
+point in the source deck orbit. -/
+lemma fiberMap_symm_mem_orbit (h : E ≃ₜ F) (hpq : ∀ e, q (h e) = p e) (ψ : Deck q)
+    (f : q ⁻¹' {b}) :
+    (fiberMap h hpq b).symm (ψ • f) ∈
+      MulAction.orbit (Deck p) ((fiberMap h hpq b).symm f) := by
+  exact ⟨(conjMulEquiv h hpq).symm ψ, fiberMap_symm_smul h hpq ψ f |>.symm⟩
+
+/-- The inverse fibre map carries the deck orbit of a point onto the deck orbit of the
+transported point. -/
+theorem fiberMap_symm_image_orbit (h : E ≃ₜ F) (hpq : ∀ e, q (h e) = p e)
+    (f : q ⁻¹' {b}) :
+    (fiberMap h hpq b).symm '' MulAction.orbit (Deck q) f =
+      MulAction.orbit (Deck p) ((fiberMap h hpq b).symm f) := by
+  ext e
+  constructor
+  · rintro ⟨f', ⟨ψ, hψ⟩, rfl⟩
+    rw [← hψ]
+    exact fiberMap_symm_mem_orbit h hpq ψ f
+  · rintro ⟨φ, rfl⟩
+    refine ⟨conjMulEquiv h hpq φ • f, ⟨conjMulEquiv h hpq φ, rfl⟩, ?_⟩
+    simpa using fiberMap_symm_smul h hpq (conjMulEquiv h hpq φ) f
+
+end Deck
+
+end TauCeti


### PR DESCRIPTION
This PR adds fibre transport for over-base homeomorphisms and proves that it intertwines restricted deck actions with deck-group conjugation, advancing `TauCetiRoadmap/UniversalCovers/README.md`, Stage 2 target "Galois correspondence: get the bookkeeping right", specifically the pointed/unpointed cover-isomorphism bookkeeping for chosen lifts and fibre actions. It builds directly on the existing `Deck.conjMulEquiv` and `Deck.fiberHomeomorphHom` API, supplying `Deck.fiberMap`, composition/inverse simp lemmas, action compatibility, fibre-homeomorphism compatibility, and orbit-image lemmas.

No Mathlib infrastructure is vendored; this uses Mathlib `Homeomorph.subtype` and the existing TauCeti deck-transformation API.

Verified with `lake exe cache get`, `lake build`, and `lake exe axioms`.

🤖 Prepared with Codex