### PR TITLE
feat: add additive comodule morphisms

### DIFF
--- a/TauCeti.lean
+++ b/TauCeti.lean
@@ -4,6 +4,7 @@
 -- `TauCetiRoadmap` or `TauCetiReview` (both enforced in CI). As the library
 -- grows, import the submodules of `TauCeti/` here.
 import TauCeti.Algebra.AlgebraicGroup.CommHopfAlgCat
+import TauCeti.Algebra.Coalgebra.Comodule.Hom
 import TauCeti.Algebra.Coalgebra.ComoduleCat
 import TauCeti.AlgebraicGeometry.WeilDivisor
 import TauCeti.AlgebraicTopology.UniversalCover.Deck.Connected

--- a/TauCeti/Algebra/Coalgebra/Comodule/Hom.lean
+++ b/TauCeti/Algebra/Coalgebra/Comodule/Hom.lean
@@ -50,6 +50,14 @@ instance instAdd : Add (Hom R C M N) where
         ext m
         simp [TensorProduct.map_add_left, map_coact_apply] }
 
+/-- Scalar multiplication of right-comodule morphisms, defined pointwise. -/
+instance instSMul : SMul R (Hom R C M N) where
+  smul r f :=
+    { toLinearMap := r • f.toLinearMap
+      map_coact := by
+        ext m
+        simp [TensorProduct.map_smul_left, map_coact_apply] }
+
 @[simp]
 theorem zero_toLinearMap : (0 : Hom R C M N).toLinearMap = 0 :=
   rfl
@@ -57,6 +65,11 @@ theorem zero_toLinearMap : (0 : Hom R C M N).toLinearMap = 0 :=
 @[simp]
 theorem add_toLinearMap (f g : Hom R C M N) :
     (f + g).toLinearMap = f.toLinearMap + g.toLinearMap :=
+  rfl
+
+@[simp]
+theorem smul_toLinearMap (r : R) (f : Hom R C M N) :
+    (r • f).toLinearMap = r • f.toLinearMap :=
   rfl
 
 /-- The zero comodule morphism evaluates to zero. -/
@@ -69,11 +82,18 @@ theorem zero_apply (m : M) : (0 : Hom R C M N) m = 0 :=
 theorem add_apply (f g : Hom R C M N) (m : M) : (f + g) m = f m + g m :=
   rfl
 
+/-- Scalar multiplication of comodule morphisms is pointwise scalar multiplication. -/
+@[simp]
+theorem smul_apply (r : R) (f : Hom R C M N) (m : M) : (r • f) m = r • f m :=
+  rfl
+
 /-- Natural-number scalar multiplication of comodule morphisms, defined by repeated
 pointwise addition. -/
 instance instNSMul : SMul ℕ (Hom R C M N) where
   smul n f := n.rec 0 fun _ g => f + g
 
+/-- Comodule morphisms form an additive commutative monoid under pointwise zero, addition,
+and natural-number scalar multiplication. -/
 instance instAddCommMonoid : AddCommMonoid (Hom R C M N) where
   zero := 0
   add := (· + ·)
@@ -92,12 +112,23 @@ instance instAddCommMonoid : AddCommMonoid (Hom R C M N) where
     simp [add_comm]
   nsmul_zero f := by
     ext m
-    change (0 : Hom R C M N) m = 0
-    rfl
+    rw [show ((0 : ℕ) • f : Hom R C M N) = 0 from rfl]
   nsmul_succ n f := by
     ext m
-    change (f + n • f) m = (n • f + f) m
+    rw [show (Nat.succ n • f : Hom R C M N) = f + n • f from rfl]
     rw [add_apply, add_apply, add_comm]
+
+private def toLinearMapAddMonoidHom : Hom R C M N →+ M →ₗ[R] N where
+  toFun f := f.toLinearMap
+  map_zero' := zero_toLinearMap
+  map_add' := add_toLinearMap
+
+/-- Comodule morphisms form an `R`-module under pointwise scalar multiplication. -/
+instance instModule : Module R (Hom R C M N) :=
+  fast_instance%
+  Function.Injective.module R toLinearMapAddMonoidHom (fun f g h => by
+    ext m
+    exact LinearMap.congr_fun h m) fun _ _ => smul_toLinearMap _ _
 
 /-- Natural-number scalar multiplication of comodule morphisms is pointwise. -/
 @[simp]
@@ -110,6 +141,12 @@ theorem nsmul_apply (n : ℕ) (f : Hom R C M N) (m : M) :
   | succ n ih =>
       rw [succ_nsmul, add_apply, ih, succ_nsmul]
 
+@[simp]
+theorem nsmul_toLinearMap (n : ℕ) (f : Hom R C M N) :
+    (n • f).toLinearMap = n • f.toLinearMap := by
+  ext m
+  simp
+
 /-- Finite sums of comodule morphisms are evaluated pointwise. -/
 @[simp]
 theorem sum_apply {ι : Type*} (s : Finset ι) (f : ι → Hom R C M N) (m : M) :
@@ -119,20 +156,26 @@ theorem sum_apply {ι : Type*} (s : Finset ι) (f : ι → Hom R C M N) (m : M) 
   | empty => simp
   | insert i s hi ih => simp [hi, ih]
 
+@[simp]
+theorem sum_toLinearMap {ι : Type*} (s : Finset ι) (f : ι → Hom R C M N) :
+    (∑ i ∈ s, f i).toLinearMap = ∑ i ∈ s, (f i).toLinearMap := by
+  ext m
+  simp
+
 section Comp
 
 variable {P : Type*} [AddCommMonoid P] [Module R P] [Comodule R C P]
 
 /-- Composition of comodule morphisms is additive in the left argument. -/
 @[simp]
-theorem comp_add (g h : Hom R C N P) (f : Hom R C M N) :
+theorem add_comp (g h : Hom R C N P) (f : Hom R C M N) :
     comp (g + h) f = comp g f + comp h f := by
   ext m
   rfl
 
 /-- Composition of comodule morphisms is additive in the right argument. -/
 @[simp]
-theorem add_comp (g : Hom R C N P) (f h : Hom R C M N) :
+theorem comp_add (g : Hom R C N P) (f h : Hom R C M N) :
     comp g (f + h) = comp g f + comp g h := by
   ext m
   exact map_add g.toLinearMap (f m) (h m)

--- a/TauCeti/Algebra/Coalgebra/Comodule/Hom.lean
+++ b/TauCeti/Algebra/Coalgebra/Comodule/Hom.lean
@@ -1,0 +1,158 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+import TauCeti.Algebra.Coalgebra.Comodule
+
+/-!
+# Additive structure on comodule morphisms
+
+This file records the pointwise additive-monoid structure on morphisms of right comodules.
+The underlying linear maps already have zero, addition, natural-number scalar
+multiplication, and finite sums; the only point to check is that these operations still
+commute with the coactions.
+
+This is basic infrastructure for the reductive-groups roadmap Layer 1 target
+"Comodules over a coalgebra/Hopf algebra": the representation category of an affine group
+scheme should have additive hom-sets before finite-dimensional, tensor, and dual structures
+are built on top.
+-/
+
+open scoped TensorProduct
+
+namespace TauCeti
+
+namespace Comodule
+
+universe u v w x
+
+variable {R : Type u} {C : Type v} {M : Type w} {N : Type x}
+variable [CommSemiring R]
+variable [AddCommMonoid C] [Module R C] [Coalgebra R C]
+variable [AddCommMonoid M] [Module R M] [Comodule R C M]
+variable [AddCommMonoid N] [Module R N] [Comodule R C N]
+
+namespace Hom
+
+/-- The zero morphism of right comodules. -/
+instance instZero : Zero (Hom R C M N) where
+  zero :=
+    { toLinearMap := 0
+      map_coact := by
+        ext m
+        simp }
+
+/-- Addition of right-comodule morphisms, defined pointwise. -/
+instance instAdd : Add (Hom R C M N) where
+  add f g :=
+    { toLinearMap := f.toLinearMap + g.toLinearMap
+      map_coact := by
+        ext m
+        simp [TensorProduct.map_add_left, map_coact_apply] }
+
+@[simp]
+theorem zero_toLinearMap : (0 : Hom R C M N).toLinearMap = 0 :=
+  rfl
+
+@[simp]
+theorem add_toLinearMap (f g : Hom R C M N) :
+    (f + g).toLinearMap = f.toLinearMap + g.toLinearMap :=
+  rfl
+
+/-- The zero comodule morphism evaluates to zero. -/
+@[simp]
+theorem zero_apply (m : M) : (0 : Hom R C M N) m = 0 :=
+  rfl
+
+/-- Addition of comodule morphisms is pointwise addition. -/
+@[simp]
+theorem add_apply (f g : Hom R C M N) (m : M) : (f + g) m = f m + g m :=
+  rfl
+
+/-- Natural-number scalar multiplication of comodule morphisms, defined by repeated
+pointwise addition. -/
+instance instNSMul : SMul ℕ (Hom R C M N) where
+  smul n f := n.rec 0 fun _ g => f + g
+
+instance instAddCommMonoid : AddCommMonoid (Hom R C M N) where
+  zero := 0
+  add := (· + ·)
+  nsmul := (· • ·)
+  zero_add f := by
+    ext m
+    simp
+  add_zero f := by
+    ext m
+    simp
+  add_assoc f g h := by
+    ext m
+    simp [add_assoc]
+  add_comm f g := by
+    ext m
+    simp [add_comm]
+  nsmul_zero f := by
+    ext m
+    change (0 : Hom R C M N) m = 0
+    rfl
+  nsmul_succ n f := by
+    ext m
+    change (f + n • f) m = (n • f + f) m
+    rw [add_apply, add_apply, add_comm]
+
+/-- Natural-number scalar multiplication of comodule morphisms is pointwise. -/
+@[simp]
+theorem nsmul_apply (n : ℕ) (f : Hom R C M N) (m : M) :
+    (n • f) m = n • f m := by
+  induction n with
+  | zero =>
+      rw [zero_nsmul, zero_nsmul]
+      rfl
+  | succ n ih =>
+      rw [succ_nsmul, add_apply, ih, succ_nsmul]
+
+/-- Finite sums of comodule morphisms are evaluated pointwise. -/
+@[simp]
+theorem sum_apply {ι : Type*} (s : Finset ι) (f : ι → Hom R C M N) (m : M) :
+    (∑ i ∈ s, f i) m = ∑ i ∈ s, f i m := by
+  classical
+  induction s using Finset.induction_on with
+  | empty => simp
+  | insert i s hi ih => simp [hi, ih]
+
+section Comp
+
+variable {P : Type*} [AddCommMonoid P] [Module R P] [Comodule R C P]
+
+/-- Composition of comodule morphisms is additive in the left argument. -/
+@[simp]
+theorem comp_add (g h : Hom R C N P) (f : Hom R C M N) :
+    comp (g + h) f = comp g f + comp h f := by
+  ext m
+  rfl
+
+/-- Composition of comodule morphisms is additive in the right argument. -/
+@[simp]
+theorem add_comp (g : Hom R C N P) (f h : Hom R C M N) :
+    comp g (f + h) = comp g f + comp g h := by
+  ext m
+  exact map_add g.toLinearMap (f m) (h m)
+
+/-- Composing the zero morphism on the left gives the zero morphism. -/
+@[simp]
+theorem zero_comp (f : Hom R C M N) : comp (0 : Hom R C N P) f = 0 := by
+  ext m
+  rfl
+
+/-- Composing the zero morphism on the right gives the zero morphism. -/
+@[simp]
+theorem comp_zero (g : Hom R C N P) : comp g (0 : Hom R C M N) = 0 := by
+  ext m
+  exact map_zero g.toLinearMap
+
+end Comp
+
+end Hom
+
+end Comodule
+
+end TauCeti

--- a/TauCeti/Algebra/Coalgebra/Comodule/Hom.lean
+++ b/TauCeti/Algebra/Coalgebra/Comodule/Hom.lean
@@ -190,6 +190,22 @@ theorem comp_add (g : Hom R C N P) (f h : Hom R C M N) :
   ext m
   exact map_add g.toLinearMap (f m) (h m)
 
+/-- Composition of comodule morphisms is compatible with scalar multiplication in the left
+argument. -/
+@[simp]
+theorem smul_comp (r : R) (g : Hom R C N P) (f : Hom R C M N) :
+    comp (r • g) f = r • comp g f := by
+  ext m
+  rfl
+
+/-- Composition of comodule morphisms is compatible with scalar multiplication in the right
+argument. -/
+@[simp]
+theorem comp_smul (r : R) (g : Hom R C N P) (f : Hom R C M N) :
+    comp g (r • f) = r • comp g f := by
+  ext m
+  exact map_smul g.toLinearMap r (f m)
+
 /-- Composing the zero morphism on the left gives the zero morphism. -/
 @[simp]
 theorem zero_comp (f : Hom R C M N) : comp (0 : Hom R C N P) f = 0 := by

--- a/TauCeti/Algebra/Coalgebra/Comodule/Hom.lean
+++ b/TauCeti/Algebra/Coalgebra/Comodule/Hom.lean
@@ -58,15 +58,19 @@ instance instSMul : SMul R (Hom R C M N) where
         ext m
         simp [TensorProduct.map_smul_left, map_coact_apply] }
 
+/-- The zero comodule morphism has the zero linear map underneath. -/
 @[simp]
 theorem zero_toLinearMap : (0 : Hom R C M N).toLinearMap = 0 :=
   rfl
 
+/-- Addition of comodule morphisms is addition of the underlying linear maps. -/
 @[simp]
 theorem add_toLinearMap (f g : Hom R C M N) :
     (f + g).toLinearMap = f.toLinearMap + g.toLinearMap :=
   rfl
 
+/-- Scalar multiplication of comodule morphisms is scalar multiplication of the underlying
+linear maps. -/
 @[simp]
 theorem smul_toLinearMap (r : R) (f : Hom R C M N) :
     (r • f).toLinearMap = r • f.toLinearMap :=
@@ -110,6 +114,9 @@ instance instAddCommMonoid : AddCommMonoid (Hom R C M N) where
   add_comm f g := by
     ext m
     simp [add_comm]
+  -- These fields verify that the custom primitive `SMul ℕ` instance agrees with the
+  -- `AddCommMonoid` nsmul convention. Unfolding it exposes definitional equalities, after
+  -- which the successor case only differs by commutativity of pointwise addition.
   nsmul_zero f := by
     ext m
     rw [show ((0 : ℕ) • f : Hom R C M N) = 0 from rfl]
@@ -141,6 +148,8 @@ theorem nsmul_apply (n : ℕ) (f : Hom R C M N) (m : M) :
   | succ n ih =>
       rw [succ_nsmul, add_apply, ih, succ_nsmul]
 
+/-- Natural-number scalar multiplication of comodule morphisms is natural-number scalar
+multiplication of the underlying linear maps. -/
 @[simp]
 theorem nsmul_toLinearMap (n : ℕ) (f : Hom R C M N) :
     (n • f).toLinearMap = n • f.toLinearMap := by
@@ -156,6 +165,7 @@ theorem sum_apply {ι : Type*} (s : Finset ι) (f : ι → Hom R C M N) (m : M) 
   | empty => simp
   | insert i s hi ih => simp [hi, ih]
 
+/-- Finite sums of comodule morphisms are finite sums of the underlying linear maps. -/
 @[simp]
 theorem sum_toLinearMap {ι : Type*} (s : Finset ι) (f : ι → Hom R C M N) :
     (∑ i ∈ s, f i).toLinearMap = ∑ i ∈ s, (f i).toLinearMap := by

--- a/TauCeti/Algebra/Coalgebra/ComoduleCat.lean
+++ b/TauCeti/Algebra/Coalgebra/ComoduleCat.lean
@@ -3,7 +3,7 @@ Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 -/
 import Mathlib.Algebra.Category.ModuleCat.Semi
-import TauCeti.Algebra.Coalgebra.Comodule
+import TauCeti.Algebra.Coalgebra.Comodule.Hom
 
 /-!
 # The category of comodules over a coalgebra

--- a/TauCeti/Algebra/Coalgebra/ComoduleCat.lean
+++ b/TauCeti/Algebra/Coalgebra/ComoduleCat.lean
@@ -270,6 +270,22 @@ theorem comp_add {M N P : ComoduleCat.{u, v, w} R C} (f : M ⟶ N) (g h : N ⟶ 
   ext m
   rfl
 
+/-- Composition in `ComoduleCat` is compatible with scalar multiplication in the left
+morphism. -/
+@[simp]
+theorem smul_comp {M N P : ComoduleCat.{u, v, w} R C} (r : R) (f : M ⟶ N) (g : N ⟶ P) :
+    (r • f) ≫ g = r • (f ≫ g) := by
+  ext m
+  exact map_smul g.toLinearMap r (f m)
+
+/-- Composition in `ComoduleCat` is compatible with scalar multiplication in the right
+morphism. -/
+@[simp]
+theorem comp_smul {M N P : ComoduleCat.{u, v, w} R C} (r : R) (f : M ⟶ N) (g : N ⟶ P) :
+    f ≫ (r • g) = r • (f ≫ g) := by
+  ext m
+  rfl
+
 /-- Composing the zero morphism on the left gives the zero morphism. -/
 @[simp]
 theorem zero_comp {M N P : ComoduleCat.{u, v, w} R C} (f : N ⟶ P) :

--- a/TauCeti/Algebra/Coalgebra/ComoduleCat.lean
+++ b/TauCeti/Algebra/Coalgebra/ComoduleCat.lean
@@ -82,14 +82,26 @@ instance category : Category (ComoduleCat.{u, v, w} R C) where
   id M := Comodule.Hom.id R C M
   comp f g := Comodule.Hom.comp g f
 
+/-- The zero structure on categorical morphisms is the zero comodule morphism. -/
 instance homZero (M N : ComoduleCat.{u, v, w} R C) : Zero (M ⟶ N) :=
   inferInstanceAs (Zero (Comodule.Hom R C M N))
 
+/-- Addition of categorical morphisms is pointwise addition of comodule morphisms. -/
 instance homAdd (M N : ComoduleCat.{u, v, w} R C) : Add (M ⟶ N) :=
   inferInstanceAs (Add (Comodule.Hom R C M N))
 
+/-- Categorical morphisms form an additive commutative monoid under pointwise operations. -/
 instance homAddCommMonoid (M N : ComoduleCat.{u, v, w} R C) : AddCommMonoid (M ⟶ N) :=
   inferInstanceAs (AddCommMonoid (Comodule.Hom R C M N))
+
+/-- Scalar multiplication of categorical morphisms is pointwise scalar multiplication of
+comodule morphisms. -/
+instance homSMul (M N : ComoduleCat.{u, v, w} R C) : SMul R (M ⟶ N) :=
+  inferInstanceAs (SMul R (Comodule.Hom R C M N))
+
+/-- Categorical morphisms form an `R`-module under pointwise operations. -/
+instance homModule (M N : ComoduleCat.{u, v, w} R C) : Module R (M ⟶ N) :=
+  inferInstanceAs (Module R (Comodule.Hom R C M N))
 
 /-- `ComoduleCat` is concrete, with concrete morphisms the bundled comodule morphisms. -/
 instance concreteCategory :
@@ -192,6 +204,26 @@ theorem toLinearMap_add {M N : ComoduleCat.{u, v, w} R C} (f g : M ⟶ N) :
     (f + g).toLinearMap = f.toLinearMap + g.toLinearMap :=
   rfl
 
+/-- Natural-number scalar multiplication of morphisms is natural-number scalar multiplication
+of the underlying linear maps. -/
+@[simp]
+theorem toLinearMap_nsmul {M N : ComoduleCat.{u, v, w} R C} (n : ℕ) (f : M ⟶ N) :
+    (n • f).toLinearMap = n • f.toLinearMap :=
+  Comodule.Hom.nsmul_toLinearMap n f
+
+/-- Scalar multiplication of morphisms is scalar multiplication of the underlying linear maps. -/
+@[simp]
+theorem toLinearMap_smul {M N : ComoduleCat.{u, v, w} R C} (r : R) (f : M ⟶ N) :
+    (r • f).toLinearMap = r • f.toLinearMap :=
+  rfl
+
+/-- Finite sums of morphisms are finite sums of the underlying linear maps. -/
+@[simp]
+theorem toLinearMap_sum {ι : Type*} {M N : ComoduleCat.{u, v, w} R C} (s : Finset ι)
+    (f : ι → (M ⟶ N)) :
+    (∑ i ∈ s, f i).toLinearMap = ∑ i ∈ s, (f i).toLinearMap :=
+  Comodule.Hom.sum_toLinearMap s f
+
 /-- The zero morphism acts as the zero function. -/
 @[simp]
 theorem zero_apply {M N : ComoduleCat.{u, v, w} R C} (m : M) :
@@ -203,6 +235,26 @@ theorem zero_apply {M N : ComoduleCat.{u, v, w} R C} (m : M) :
 theorem add_apply {M N : ComoduleCat.{u, v, w} R C} (f g : M ⟶ N) (m : M) :
     (f + g) m = f m + g m :=
   rfl
+
+/-- Natural-number scalar multiplication of morphisms acts by pointwise natural-number scalar
+multiplication. -/
+@[simp]
+theorem nsmul_apply {M N : ComoduleCat.{u, v, w} R C} (n : ℕ) (f : M ⟶ N) (m : M) :
+    (n • f) m = n • f m :=
+  Comodule.Hom.nsmul_apply n f m
+
+/-- Scalar multiplication of morphisms acts by pointwise scalar multiplication. -/
+@[simp]
+theorem smul_apply {M N : ComoduleCat.{u, v, w} R C} (r : R) (f : M ⟶ N) (m : M) :
+    (r • f) m = r • f m :=
+  rfl
+
+/-- Finite sums of morphisms act by pointwise finite sums. -/
+@[simp]
+theorem sum_apply {ι : Type*} {M N : ComoduleCat.{u, v, w} R C} (s : Finset ι)
+    (f : ι → (M ⟶ N)) (m : M) :
+    (∑ i ∈ s, f i) m = ∑ i ∈ s, f i m :=
+  Comodule.Hom.sum_apply s f m
 
 /-- Composition in `ComoduleCat` is additive in the left morphism. -/
 @[simp]

--- a/TauCeti/Algebra/Coalgebra/ComoduleCat.lean
+++ b/TauCeti/Algebra/Coalgebra/ComoduleCat.lean
@@ -82,6 +82,15 @@ instance category : Category (ComoduleCat.{u, v, w} R C) where
   id M := Comodule.Hom.id R C M
   comp f g := Comodule.Hom.comp g f
 
+instance homZero (M N : ComoduleCat.{u, v, w} R C) : Zero (M ⟶ N) :=
+  inferInstanceAs (Zero (Comodule.Hom R C M N))
+
+instance homAdd (M N : ComoduleCat.{u, v, w} R C) : Add (M ⟶ N) :=
+  inferInstanceAs (Add (Comodule.Hom R C M N))
+
+instance homAddCommMonoid (M N : ComoduleCat.{u, v, w} R C) : AddCommMonoid (M ⟶ N) :=
+  inferInstanceAs (AddCommMonoid (Comodule.Hom R C M N))
+
 /-- `ComoduleCat` is concrete, with concrete morphisms the bundled comodule morphisms. -/
 instance concreteCategory :
     ConcreteCategory (ComoduleCat.{u, v, w} R C)
@@ -169,6 +178,58 @@ theorem id_apply (M : ComoduleCat.{u, v, w} R C) (m : M) :
 theorem comp_apply {M N P : ComoduleCat.{u, v, w} R C} (f : M ⟶ N) (g : N ⟶ P)
     (m : M) :
     (f ≫ g) m = g (f m) :=
+  rfl
+
+/-- The zero morphism has the zero linear map underneath. -/
+@[simp]
+theorem toLinearMap_zero (M N : ComoduleCat.{u, v, w} R C) :
+    (0 : M ⟶ N).toLinearMap = 0 :=
+  rfl
+
+/-- Addition of morphisms is addition of the underlying linear maps. -/
+@[simp]
+theorem toLinearMap_add {M N : ComoduleCat.{u, v, w} R C} (f g : M ⟶ N) :
+    (f + g).toLinearMap = f.toLinearMap + g.toLinearMap :=
+  rfl
+
+/-- The zero morphism acts as the zero function. -/
+@[simp]
+theorem zero_apply {M N : ComoduleCat.{u, v, w} R C} (m : M) :
+    (0 : M ⟶ N) m = 0 :=
+  rfl
+
+/-- Addition of morphisms acts by pointwise addition. -/
+@[simp]
+theorem add_apply {M N : ComoduleCat.{u, v, w} R C} (f g : M ⟶ N) (m : M) :
+    (f + g) m = f m + g m :=
+  rfl
+
+/-- Composition in `ComoduleCat` is additive in the left morphism. -/
+@[simp]
+theorem add_comp {M N P : ComoduleCat.{u, v, w} R C} (f g : M ⟶ N) (h : N ⟶ P) :
+    (f + g) ≫ h = f ≫ h + g ≫ h := by
+  ext m
+  exact map_add h.toLinearMap (f m) (g m)
+
+/-- Composition in `ComoduleCat` is additive in the right morphism. -/
+@[simp]
+theorem comp_add {M N P : ComoduleCat.{u, v, w} R C} (f : M ⟶ N) (g h : N ⟶ P) :
+    f ≫ (g + h) = f ≫ g + f ≫ h := by
+  ext m
+  rfl
+
+/-- Composing the zero morphism on the left gives the zero morphism. -/
+@[simp]
+theorem zero_comp {M N P : ComoduleCat.{u, v, w} R C} (f : N ⟶ P) :
+    (0 : M ⟶ N) ≫ f = 0 := by
+  ext m
+  exact map_zero f.toLinearMap
+
+/-- Composing the zero morphism on the right gives the zero morphism. -/
+@[simp]
+theorem comp_zero {M N P : ComoduleCat.{u, v, w} R C} (f : M ⟶ N) :
+    f ≫ (0 : N ⟶ P) = 0 := by
+  ext m
   rfl
 
 /-- The forgetful functor from comodules to their underlying semimodules. -/

--- a/TauCeti/Algebra/Coalgebra/ComoduleCat.lean
+++ b/TauCeti/Algebra/Coalgebra/ComoduleCat.lean
@@ -3,6 +3,7 @@ Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 -/
 import Mathlib.Algebra.Category.ModuleCat.Semi
+import Mathlib.CategoryTheory.Limits.Shapes.ZeroMorphisms
 import TauCeti.Algebra.Coalgebra.Comodule.Hom
 
 /-!
@@ -299,6 +300,14 @@ theorem comp_zero {M N P : ComoduleCat.{u, v, w} R C} (f : M ⟶ N) :
     f ≫ (0 : N ⟶ P) = 0 := by
   ext m
   rfl
+
+/-- `ComoduleCat` has the standard categorical zero morphisms. -/
+instance hasZeroMorphisms :
+    CategoryTheory.Limits.HasZeroMorphisms (ComoduleCat.{u, v, w} R C) where
+  zero := inferInstance
+  comp_zero := fun f P => ComoduleCat.comp_zero (R := R) (C := C) (P := P) f
+  zero_comp := fun M {N P} f => ComoduleCat.zero_comp (R := R) (C := C) (M := M) (N := N)
+    (P := P) f
 
 /-- The forgetful functor from comodules to their underlying semimodules. -/
 instance hasForgetToSemimodule : HasForget₂ (ComoduleCat.{u, v, w} R C) (SemimoduleCat.{w} R) where


### PR DESCRIPTION
This PR adds pointwise additive hom-set infrastructure for right comodules, advancing `TauCetiRoadmap/ReductiveGroups/README.md`, Layer 1 target "Comodules over a coalgebra/Hopf algebra `A`: a coaction `ρ : V → V ⊗ A` with coassociativity and counit; comodule morphisms; the (rigid monoidal) category of finite-dimensional comodules; tensor products, duals, the regular representation." It packages zero, addition, natural-number scalar multiplication, finite sums, and additivity of composition for `Comodule.Hom`, so the existing bundled comodule category has the expected additive hom-sets before finite-dimensional and tensor-structure work is added.

No Mathlib infrastructure is vendored; the implementation uses the existing Tau Ceti `Comodule.Hom` definition and standard Mathlib linear-map/tensor-product API.

Verified with `lake exe cache get`, `lake build`, and `lake exe axioms`.

🤖 Prepared with Codex
