### PR TITLE
feat: identify regular deck orbit quotient

### DIFF
--- a/TauCeti.lean
+++ b/TauCeti.lean
@@ -10,6 +10,7 @@ import TauCeti.AlgebraicGeometry.WeilDivisor
 import TauCeti.AlgebraicTopology.UniversalCover.Deck.Connected
 import TauCeti.AlgebraicTopology.UniversalCover.Deck.Fiber
 import TauCeti.AlgebraicTopology.UniversalCover.Deck.FiberTransport
+import TauCeti.AlgebraicTopology.UniversalCover.Deck.Quotient
 import TauCeti.AlgebraicTopology.UniversalCover.Deck.Regular
 import TauCeti.Analysis.PDE.UniformEllipticity
 import TauCeti.Basic

--- a/TauCeti/AlgebraicTopology/UniversalCover/Deck.lean
+++ b/TauCeti/AlgebraicTopology/UniversalCover/Deck.lean
@@ -94,6 +94,7 @@ lemma smul_eq_apply (φ : Deck p) (e : E) : φ • e = φ.1 e :=
   rfl
 
 /-- Applying the inverse deck transformation is evaluation of the inverse homeomorphism. -/
+@[simp]
 lemma inv_smul_eq_symm_apply (φ : Deck p) (e : E) : (φ⁻¹ : Deck p) • e = φ.1.symm e :=
   rfl
 

--- a/TauCeti/AlgebraicTopology/UniversalCover/Deck.lean
+++ b/TauCeti/AlgebraicTopology/UniversalCover/Deck.lean
@@ -93,6 +93,10 @@ action of `E ≃ₜ E` on `E`. -/
 lemma smul_eq_apply (φ : Deck p) (e : E) : φ • e = φ.1 e :=
   rfl
 
+/-- Applying the inverse deck transformation is evaluation of the inverse homeomorphism. -/
+lemma inv_smul_eq_symm_apply (φ : Deck p) (e : E) : (φ⁻¹ : Deck p) • e = φ.1.symm e :=
+  rfl
+
 -- `FaithfulSMul (Deck p) E` and `ContinuousConstSMul (Deck p) E` are inherited from the generic
 -- subgroup instances in `TauCeti.Topology.Algebra.HomeomorphAction`; `Deck p` is a `Subgroup`.
 

--- a/TauCeti/AlgebraicTopology/UniversalCover/Deck/Quotient.lean
+++ b/TauCeti/AlgebraicTopology/UniversalCover/Deck/Quotient.lean
@@ -55,23 +55,30 @@ lemma orbitQuotientToBase_mk (e : E) :
       p e :=
   rfl
 
+/-- If deck orbits are exactly fibres of `p`, the deck-orbit relation is the kernel relation
+of `p`. -/
+private lemma orbitRel_eq_ker_of_exists_apply_eq
+    (hpoint : ∀ {e e' : E}, p e = p e' → ∃ φ : Deck p, φ.1 e = e') :
+    MulAction.orbitRel (Deck p) E = Setoid.ker p := by
+  ext e e'
+  constructor
+  · exact eq_proj_of_orbitRel
+  · intro heq
+    rcases hpoint heq with ⟨φ, hφ⟩
+    exact ⟨φ⁻¹, by
+      have hinv : φ.1.symm e' = e := by
+        rw [← hφ, Homeomorph.symm_apply_apply]
+      simpa [smul_eq_apply] using hinv⟩
+
 /-- If deck orbits are exactly fibres of `p`, the orbit quotient map to the base is
 injective. -/
 lemma orbitQuotientToBase_injective_of_exists_apply_eq
     (hpoint : ∀ {e e' : E}, p e = p e' → ∃ φ : Deck p, φ.1 e = e') :
     Function.Injective (orbitQuotientToBase p) := by
-  intro x y hxy
-  induction x using Quotient.inductionOn' with
-  | h e =>
-      induction y using Quotient.inductionOn' with
-      | h e' =>
-          simp only [orbitQuotientToBase_mk] at hxy
-          rcases hpoint hxy with ⟨φ, hφ⟩
-          exact Quotient.sound
-            ⟨φ⁻¹, by
-              have hinv : φ.1.symm e' = e := by
-                rw [← hφ, Homeomorph.symm_apply_apply]
-              simpa [smul_eq_apply] using hinv⟩
+  exact (Setoid.lift_injective_iff_ker_eq_of_le
+    (r := MulAction.orbitRel (Deck p) E) (f := p)
+    (fun _ _ h => eq_proj_of_orbitRel h)).mpr
+      (orbitRel_eq_ker_of_exists_apply_eq hpoint).symm
 
 /-- An over-base homeomorphism preserves the corresponding deck-orbit relations. -/
 private lemma orbitRel_homeomorph_iff (h : E ≃ₜ F) (hpq : ∀ e, q (h e) = p e) (e e' : E) :

--- a/TauCeti/AlgebraicTopology/UniversalCover/Deck/Quotient.lean
+++ b/TauCeti/AlgebraicTopology/UniversalCover/Deck/Quotient.lean
@@ -19,8 +19,8 @@ of the deck action on each fibre.
 ## Main declarations
 
 * `TauCeti.Deck.orbitQuotientToBase`: the map `E / Deck p → B` induced by `p`.
-* `TauCeti.Deck.orbitQuotientEquivBase`: for a regular deck action, `E / Deck p` is
-  equivalent to the base.
+* `TauCeti.Deck.IsRegular.orbitQuotientEquivBase`: for a regular deck action,
+  `E / Deck p` is equivalent to the base.
 
 ## References
 
@@ -55,21 +55,6 @@ lemma orbitQuotientToBase_mk (e : E) :
       p e :=
   rfl
 
-/-- The orbit quotient map is surjective exactly when the original projection map is
-surjective. -/
-lemma orbitQuotientToBase_surjective_iff :
-    Function.Surjective (orbitQuotientToBase p) ↔ Function.Surjective p := by
-  constructor
-  · intro h b
-    rcases h b with ⟨x, hx⟩
-    revert hx
-    refine Quotient.inductionOn' x ?_
-    intro e hx
-    exact ⟨e, by simpa [orbitQuotientToBase_mk] using hx⟩
-  · intro hp b
-    rcases hp b with ⟨e, he⟩
-    exact ⟨Quotient.mk'' e, by simpa [orbitQuotientToBase_mk] using he⟩
-
 /-- If deck orbits are exactly fibres of `p`, the orbit quotient map to the base is
 injective. -/
 lemma orbitQuotientToBase_injective_of_exists_apply_eq
@@ -86,14 +71,60 @@ lemma orbitQuotientToBase_injective_of_exists_apply_eq
             ⟨φ⁻¹, by
               have hinv : φ.1.symm e' = e := by
                 rw [← hφ, Homeomorph.symm_apply_apply]
-              simpa [smul_eq_apply] using hinv⟩
+              have hsmul : (φ⁻¹ : Deck p) • e' = φ.1.symm e' := rfl
+              change (φ⁻¹ : Deck p) • e' = e
+              exact hsmul.trans hinv⟩
+
+/-- An over-base homeomorphism identifies the corresponding deck-orbit quotients. -/
+def orbitQuotientEquiv (h : E ≃ₜ F) (hpq : ∀ e, q (h e) = p e) :
+    MulAction.orbitRel.Quotient (Deck p) E ≃ MulAction.orbitRel.Quotient (Deck q) F where
+  toFun := Quotient.map' h fun e e' hee' => by
+    rw [MulAction.orbitRel_apply] at hee' ⊢
+    rcases hee' with ⟨φ, hφ⟩
+    refine ⟨conjMulEquiv h hpq φ, ?_⟩
+    have hφ' : φ • e' = e := hφ
+    rw [smul_eq_apply] at hφ'
+    change (conjMulEquiv h hpq φ) • h e' = h e
+    rw [smul_eq_apply, conjMulEquiv_apply_coe, h.symm_apply_apply, ← hφ']
+  invFun := Quotient.map' h.symm fun f f' hff' => by
+    rw [MulAction.orbitRel_apply] at hff' ⊢
+    rcases hff' with ⟨ψ, hψ⟩
+    refine ⟨(conjMulEquiv h hpq).symm ψ, ?_⟩
+    have hψ' : ψ • f' = f := hψ
+    rw [smul_eq_apply] at hψ'
+    change ((conjMulEquiv h hpq).symm ψ) • h.symm f' = h.symm f
+    rw [smul_eq_apply, conjMulEquiv_symm_apply_coe, h.apply_symm_apply, ← hψ']
+  left_inv x := by
+    induction x using Quotient.inductionOn' with
+    | h e => simp [Quotient.map'_mk'']
+  right_inv x := by
+    induction x using Quotient.inductionOn' with
+    | h f => simp [Quotient.map'_mk'']
+
+/-- The over-base equivalence on orbit quotients evaluates on representatives by the
+homeomorphism. -/
+@[simp]
+lemma orbitQuotientEquiv_mk (h : E ≃ₜ F) (hpq : ∀ e, q (h e) = p e) (e : E) :
+    orbitQuotientEquiv h hpq
+      (Quotient.mk'' e : MulAction.orbitRel.Quotient (Deck p) E) =
+        (Quotient.mk'' (h e) : MulAction.orbitRel.Quotient (Deck q) F) :=
+  rfl
+
+/-- The inverse over-base equivalence on orbit quotients evaluates on representatives by the
+inverse homeomorphism. -/
+@[simp]
+lemma orbitQuotientEquiv_symm_mk (h : E ≃ₜ F) (hpq : ∀ e, q (h e) = p e) (f : F) :
+    (orbitQuotientEquiv h hpq).symm
+      (Quotient.mk'' f : MulAction.orbitRel.Quotient (Deck q) F) =
+        (Quotient.mk'' (h.symm f) : MulAction.orbitRel.Quotient (Deck p) E) :=
+  rfl
 
 namespace IsRegular
 
 /-- For a regular deck action, the map from deck-orbit quotient to the base is surjective. -/
 lemma orbitQuotientToBase_surjective (hreg : IsRegular p) :
     Function.Surjective (orbitQuotientToBase p) :=
-  orbitQuotientToBase_surjective_iff.mpr hreg.1
+  Quotient.lift_surjective p _ hreg.1
 
 /-- For a regular deck action, the map from deck-orbit quotient to the base is injective. -/
 lemma orbitQuotientToBase_injective (hreg : IsRegular p) :
@@ -116,30 +147,30 @@ lemma orbitQuotientEquivBase_mk (hreg : IsRegular p) (e : E) :
       (Quotient.mk'' e : MulAction.orbitRel.Quotient (Deck p) E) = p e :=
   rfl
 
-/-- The inverse of the orbit-quotient equivalence chooses a deck orbit over the requested
-base point. -/
-@[simp]
-lemma orbitQuotientEquivBase_apply_symm (hreg : IsRegular p)
-    (x : MulAction.orbitRel.Quotient (Deck p) E) :
-    hreg.orbitQuotientEquivBase.symm (hreg.orbitQuotientEquivBase x) = x :=
-  hreg.orbitQuotientEquivBase.left_inv x
-
-/-- Applying the orbit-quotient equivalence after its inverse gives back the base point. -/
-@[simp]
-lemma orbitQuotientEquivBase_symm_apply (hreg : IsRegular p) (b : B) :
-    hreg.orbitQuotientEquivBase (hreg.orbitQuotientEquivBase.symm b) = b :=
-  hreg.orbitQuotientEquivBase.right_inv b
-
 /-- Transporting a regular deck action along an over-base homeomorphism is compatible with
 the corresponding orbit-quotient equivalences. -/
 lemma orbitQuotientEquivBase_conj (hreg : IsRegular p) (h : E ≃ₜ F)
+    (hpq : ∀ e, q (h e) = p e) (x : MulAction.orbitRel.Quotient (Deck p) E) :
+    (hreg.conj h hpq).orbitQuotientEquivBase
+      (orbitQuotientEquiv h hpq x) = hreg.orbitQuotientEquivBase x := by
+  induction x using Quotient.inductionOn' with
+  | h e =>
+      rw [orbitQuotientEquiv_mk, orbitQuotientEquivBase_mk, orbitQuotientEquivBase_mk]
+      exact hpq e
+
+/-- Representative form of compatibility between over-base homeomorphisms and the regular
+orbit-quotient equivalences. -/
+@[simp]
+lemma orbitQuotientEquivBase_conj_mk (hreg : IsRegular p) (h : E ≃ₜ F)
     (hpq : ∀ e, q (h e) = p e) (f : F) :
     (hreg.conj h hpq).orbitQuotientEquivBase
       (Quotient.mk'' f : MulAction.orbitRel.Quotient (Deck q) F) =
         hreg.orbitQuotientEquivBase
           (Quotient.mk'' (h.symm f) : MulAction.orbitRel.Quotient (Deck p) E) := by
-  rw [orbitQuotientEquivBase_mk, orbitQuotientEquivBase_mk]
-  exact (map_symm_eq_of_map_eq h hpq f).symm
+  rw [← orbitQuotientEquiv_symm_mk h hpq f,
+    ← hreg.orbitQuotientEquivBase_conj h hpq ((orbitQuotientEquiv h hpq).symm
+      (Quotient.mk'' f : MulAction.orbitRel.Quotient (Deck q) F)),
+    (orbitQuotientEquiv h hpq).apply_symm_apply]
 
 end IsRegular
 

--- a/TauCeti/AlgebraicTopology/UniversalCover/Deck/Quotient.lean
+++ b/TauCeti/AlgebraicTopology/UniversalCover/Deck/Quotient.lean
@@ -70,16 +70,6 @@ private lemma orbitRel_eq_ker_of_exists_apply_eq
         rw [← hφ, Homeomorph.symm_apply_apply]
       simpa [smul_eq_apply] using hinv⟩
 
-/-- If deck orbits are exactly fibres of `p`, the orbit quotient map to the base is
-injective. -/
-lemma orbitQuotientToBase_injective_of_exists_apply_eq
-    (hpoint : ∀ {e e' : E}, p e = p e' → ∃ φ : Deck p, φ.1 e = e') :
-    Function.Injective (orbitQuotientToBase p) := by
-  exact (Setoid.lift_injective_iff_ker_eq_of_le
-    (r := MulAction.orbitRel (Deck p) E) (f := p)
-    (fun _ _ h => eq_proj_of_orbitRel h)).mpr
-      (orbitRel_eq_ker_of_exists_apply_eq hpoint).symm
-
 /-- An over-base homeomorphism preserves the corresponding deck-orbit relations. -/
 private lemma orbitRel_homeomorph_iff (h : E ≃ₜ F) (hpq : ∀ e, q (h e) = p e) (e e' : E) :
     MulAction.orbitRel (Deck p) E e e' ↔
@@ -135,9 +125,11 @@ namespace IsRegular
 
 /-- For a regular deck action, the map from deck-orbit quotient to the base is injective. -/
 lemma orbitQuotientToBase_injective (hreg : IsRegular p) :
-    Function.Injective (orbitQuotientToBase p) :=
-  orbitQuotientToBase_injective_of_exists_apply_eq
-    (isRegular_iff_exists_apply_eq.mp hreg).2
+    Function.Injective (orbitQuotientToBase p) := by
+  exact (Setoid.lift_injective_iff_ker_eq_of_le
+    (r := MulAction.orbitRel (Deck p) E) (f := p)
+    (fun _ _ h => eq_proj_of_orbitRel h)).mpr
+      (orbitRel_eq_ker_of_exists_apply_eq (isRegular_iff_exists_apply_eq.mp hreg).2).symm
 
 /-- A regular deck action identifies the quotient of the total space by deck orbits with the
 base. -/

--- a/TauCeti/AlgebraicTopology/UniversalCover/Deck/Quotient.lean
+++ b/TauCeti/AlgebraicTopology/UniversalCover/Deck/Quotient.lean
@@ -1,0 +1,148 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+import TauCeti.AlgebraicTopology.UniversalCover.Deck.Regular
+
+/-!
+# The orbit quotient of a regular deck action
+
+For any map `p : E → B`, deck transformations preserve the value of `p`, so `p` factors
+through the quotient of `E` by the orbit relation for the deck action. If the deck action is
+regular, the induced map from the orbit quotient to the base is an equivalence.
+
+This is algebraic bookkeeping for the universal-covers roadmap. Later quotient-cover and
+regular-cover statements need to compare the base with the orbit space of the deck action,
+but the basic equivalence only uses `Deck.IsRegular p`: surjectivity of `p` and transitivity
+of the deck action on each fibre.
+
+## Main declarations
+
+* `TauCeti.Deck.orbitQuotientToBase`: the map `E / Deck p → B` induced by `p`.
+* `TauCeti.Deck.orbitQuotientEquivBase`: for a regular deck action, `E / Deck p` is
+  equivalent to the base.
+
+## References
+
+This supplies a prerequisite for the Tau Ceti universal-covers roadmap, Stage 2, especially
+the regular-cover milestones where fibres are deck orbits and quotient covers are compared
+with the original base.
+-/
+
+namespace TauCeti
+
+namespace Deck
+
+variable {E F B : Type*} [TopologicalSpace E] [TopologicalSpace F]
+  {p : E → B} {q : F → B}
+
+/-- Points in the same deck orbit have the same projection under `p`. -/
+lemma eq_proj_of_orbitRel {e e' : E} (h : MulAction.orbitRel (Deck p) E e e') :
+    p e = p e' := by
+  rw [MulAction.orbitRel_apply] at h
+  rcases h with ⟨φ, hφ⟩
+  rw [← hφ]
+  simpa [smul_eq_apply] using map_proj φ e'
+
+/-- The projection map factors through the quotient of `E` by deck orbits. -/
+def orbitQuotientToBase (p : E → B) : MulAction.orbitRel.Quotient (Deck p) E → B :=
+  Quotient.lift p fun _ _ h => eq_proj_of_orbitRel h
+
+/-- The map from the deck-orbit quotient to the base evaluates on representatives by `p`. -/
+@[simp]
+lemma orbitQuotientToBase_mk (e : E) :
+    orbitQuotientToBase p (Quotient.mk'' e : MulAction.orbitRel.Quotient (Deck p) E) =
+      p e :=
+  rfl
+
+/-- The orbit quotient map is surjective exactly when the original projection map is
+surjective. -/
+lemma orbitQuotientToBase_surjective_iff :
+    Function.Surjective (orbitQuotientToBase p) ↔ Function.Surjective p := by
+  constructor
+  · intro h b
+    rcases h b with ⟨x, hx⟩
+    revert hx
+    refine Quotient.inductionOn' x ?_
+    intro e hx
+    exact ⟨e, by simpa [orbitQuotientToBase_mk] using hx⟩
+  · intro hp b
+    rcases hp b with ⟨e, he⟩
+    exact ⟨Quotient.mk'' e, by simpa [orbitQuotientToBase_mk] using he⟩
+
+/-- If deck orbits are exactly fibres of `p`, the orbit quotient map to the base is
+injective. -/
+lemma orbitQuotientToBase_injective_of_exists_apply_eq
+    (hpoint : ∀ {e e' : E}, p e = p e' → ∃ φ : Deck p, φ.1 e = e') :
+    Function.Injective (orbitQuotientToBase p) := by
+  intro x y hxy
+  induction x using Quotient.inductionOn' with
+  | h e =>
+      induction y using Quotient.inductionOn' with
+      | h e' =>
+          simp only [orbitQuotientToBase_mk] at hxy
+          rcases hpoint hxy with ⟨φ, hφ⟩
+          exact Quotient.sound
+            ⟨φ⁻¹, by
+              have hinv : φ.1.symm e' = e := by
+                rw [← hφ, Homeomorph.symm_apply_apply]
+              simpa [smul_eq_apply] using hinv⟩
+
+namespace IsRegular
+
+/-- For a regular deck action, the map from deck-orbit quotient to the base is surjective. -/
+lemma orbitQuotientToBase_surjective (hreg : IsRegular p) :
+    Function.Surjective (orbitQuotientToBase p) :=
+  orbitQuotientToBase_surjective_iff.mpr hreg.1
+
+/-- For a regular deck action, the map from deck-orbit quotient to the base is injective. -/
+lemma orbitQuotientToBase_injective (hreg : IsRegular p) :
+    Function.Injective (orbitQuotientToBase p) :=
+  orbitQuotientToBase_injective_of_exists_apply_eq
+    (isRegular_iff_exists_apply_eq.mp hreg).2
+
+/-- A regular deck action identifies the quotient of the total space by deck orbits with the
+base. -/
+noncomputable def orbitQuotientEquivBase (hreg : IsRegular p) :
+    MulAction.orbitRel.Quotient (Deck p) E ≃ B :=
+  Equiv.ofBijective (orbitQuotientToBase p)
+    ⟨hreg.orbitQuotientToBase_injective, hreg.orbitQuotientToBase_surjective⟩
+
+/-- The equivalence from the deck-orbit quotient to the base evaluates on representatives by
+the projection map. -/
+@[simp]
+lemma orbitQuotientEquivBase_mk (hreg : IsRegular p) (e : E) :
+    hreg.orbitQuotientEquivBase
+      (Quotient.mk'' e : MulAction.orbitRel.Quotient (Deck p) E) = p e :=
+  rfl
+
+/-- The inverse of the orbit-quotient equivalence chooses a deck orbit over the requested
+base point. -/
+@[simp]
+lemma orbitQuotientEquivBase_apply_symm (hreg : IsRegular p)
+    (x : MulAction.orbitRel.Quotient (Deck p) E) :
+    hreg.orbitQuotientEquivBase.symm (hreg.orbitQuotientEquivBase x) = x :=
+  hreg.orbitQuotientEquivBase.left_inv x
+
+/-- Applying the orbit-quotient equivalence after its inverse gives back the base point. -/
+@[simp]
+lemma orbitQuotientEquivBase_symm_apply (hreg : IsRegular p) (b : B) :
+    hreg.orbitQuotientEquivBase (hreg.orbitQuotientEquivBase.symm b) = b :=
+  hreg.orbitQuotientEquivBase.right_inv b
+
+/-- Transporting a regular deck action along an over-base homeomorphism is compatible with
+the corresponding orbit-quotient equivalences. -/
+lemma orbitQuotientEquivBase_conj (hreg : IsRegular p) (h : E ≃ₜ F)
+    (hpq : ∀ e, q (h e) = p e) (f : F) :
+    (hreg.conj h hpq).orbitQuotientEquivBase
+      (Quotient.mk'' f : MulAction.orbitRel.Quotient (Deck q) F) =
+        hreg.orbitQuotientEquivBase
+          (Quotient.mk'' (h.symm f) : MulAction.orbitRel.Quotient (Deck p) E) := by
+  rw [orbitQuotientEquivBase_mk, orbitQuotientEquivBase_mk]
+  exact (map_symm_eq_of_map_eq h hpq f).symm
+
+end IsRegular
+
+end Deck
+
+end TauCeti

--- a/TauCeti/AlgebraicTopology/UniversalCover/Deck/Quotient.lean
+++ b/TauCeti/AlgebraicTopology/UniversalCover/Deck/Quotient.lean
@@ -57,7 +57,7 @@ lemma orbitQuotientToBase_mk (e : E) :
 
 /-- If deck orbits are exactly fibres of `p`, the orbit quotient map to the base is
 injective. -/
-lemma orbitQuotientToBase_injective_of_exists_apply_eq
+private lemma orbitQuotientToBase_injective_of_exists_apply_eq
     (hpoint : ∀ {e e' : E}, p e = p e' → ∃ φ : Deck p, φ.1 e = e') :
     Function.Injective (orbitQuotientToBase p) := by
   intro x y hxy
@@ -71,35 +71,41 @@ lemma orbitQuotientToBase_injective_of_exists_apply_eq
             ⟨φ⁻¹, by
               have hinv : φ.1.symm e' = e := by
                 rw [← hφ, Homeomorph.symm_apply_apply]
-              have hsmul : (φ⁻¹ : Deck p) • e' = φ.1.symm e' := rfl
-              change (φ⁻¹ : Deck p) • e' = e
+              have hsmul := inv_smul_eq_symm_apply φ e'
               exact hsmul.trans hinv⟩
 
-/-- An over-base homeomorphism identifies the corresponding deck-orbit quotients. -/
-def orbitQuotientEquiv (h : E ≃ₜ F) (hpq : ∀ e, q (h e) = p e) :
-    MulAction.orbitRel.Quotient (Deck p) E ≃ MulAction.orbitRel.Quotient (Deck q) F where
-  toFun := Quotient.map' h fun e e' hee' => by
+/-- An over-base homeomorphism preserves the corresponding deck-orbit relations. -/
+private lemma orbitRel_homeomorph_iff (h : E ≃ₜ F) (hpq : ∀ e, q (h e) = p e) (e e' : E) :
+    MulAction.orbitRel (Deck p) E e e' ↔
+      MulAction.orbitRel (Deck q) F (h e) (h e') := by
+  constructor
+  · intro hee'
     rw [MulAction.orbitRel_apply] at hee' ⊢
     rcases hee' with ⟨φ, hφ⟩
     refine ⟨conjMulEquiv h hpq φ, ?_⟩
-    have hφ' : φ • e' = e := hφ
-    rw [smul_eq_apply] at hφ'
-    change (conjMulEquiv h hpq φ) • h e' = h e
-    rw [smul_eq_apply, conjMulEquiv_apply_coe, h.symm_apply_apply, ← hφ']
-  invFun := Quotient.map' h.symm fun f f' hff' => by
+    have hφ_apply : φ.1 e' = e := by
+      simpa only [smul_eq_apply] using hφ
+    calc
+      (conjMulEquiv h hpq φ) • h e' = (conjMulEquiv h hpq φ).1 (h e') :=
+        smul_eq_apply _ _
+      _ = h (φ.1 e') := by rw [conjMulEquiv_apply_coe, h.symm_apply_apply]
+      _ = h e := by rw [hφ_apply]
+  · intro hff'
     rw [MulAction.orbitRel_apply] at hff' ⊢
     rcases hff' with ⟨ψ, hψ⟩
     refine ⟨(conjMulEquiv h hpq).symm ψ, ?_⟩
-    have hψ' : ψ • f' = f := hψ
-    rw [smul_eq_apply] at hψ'
-    change ((conjMulEquiv h hpq).symm ψ) • h.symm f' = h.symm f
-    rw [smul_eq_apply, conjMulEquiv_symm_apply_coe, h.apply_symm_apply, ← hψ']
-  left_inv x := by
-    induction x using Quotient.inductionOn' with
-    | h e => simp [Quotient.map'_mk'']
-  right_inv x := by
-    induction x using Quotient.inductionOn' with
-    | h f => simp [Quotient.map'_mk'']
+    have hψ_apply : ψ.1 (h e') = h e := by
+      simpa only [smul_eq_apply] using hψ
+    calc
+      ((conjMulEquiv h hpq).symm ψ) • e' =
+          ((conjMulEquiv h hpq).symm ψ).1 e' := smul_eq_apply _ _
+      _ = h.symm (ψ.1 (h e')) := conjMulEquiv_symm_apply_coe h hpq ψ e'
+      _ = e := by rw [hψ_apply, h.symm_apply_apply]
+
+/-- An over-base homeomorphism identifies the corresponding deck-orbit quotients. -/
+def orbitQuotientEquiv (h : E ≃ₜ F) (hpq : ∀ e, q (h e) = p e) :
+    MulAction.orbitRel.Quotient (Deck p) E ≃ MulAction.orbitRel.Quotient (Deck q) F :=
+  Quotient.congr h.toEquiv (orbitRel_homeomorph_iff h hpq)
 
 /-- The over-base equivalence on orbit quotients evaluates on representatives by the
 homeomorphism. -/
@@ -119,12 +125,13 @@ lemma orbitQuotientEquiv_symm_mk (h : E ≃ₜ F) (hpq : ∀ e, q (h e) = p e) (
         (Quotient.mk'' (h.symm f) : MulAction.orbitRel.Quotient (Deck p) E) :=
   rfl
 
-namespace IsRegular
-
-/-- For a regular deck action, the map from deck-orbit quotient to the base is surjective. -/
-lemma orbitQuotientToBase_surjective (hreg : IsRegular p) :
+/-- If `p` is surjective, then the map from the deck-orbit quotient to the base is
+surjective. -/
+lemma orbitQuotientToBase_surjective (hp : Function.Surjective p) :
     Function.Surjective (orbitQuotientToBase p) :=
-  Quotient.lift_surjective p _ hreg.1
+  Quotient.lift_surjective p _ hp
+
+namespace IsRegular
 
 /-- For a regular deck action, the map from deck-orbit quotient to the base is injective. -/
 lemma orbitQuotientToBase_injective (hreg : IsRegular p) :
@@ -137,7 +144,7 @@ base. -/
 noncomputable def orbitQuotientEquivBase (hreg : IsRegular p) :
     MulAction.orbitRel.Quotient (Deck p) E ≃ B :=
   Equiv.ofBijective (orbitQuotientToBase p)
-    ⟨hreg.orbitQuotientToBase_injective, hreg.orbitQuotientToBase_surjective⟩
+    ⟨hreg.orbitQuotientToBase_injective, orbitQuotientToBase_surjective hreg.1⟩
 
 /-- The equivalence from the deck-orbit quotient to the base evaluates on representatives by
 the projection map. -/
@@ -146,6 +153,14 @@ lemma orbitQuotientEquivBase_mk (hreg : IsRegular p) (e : E) :
     hreg.orbitQuotientEquivBase
       (Quotient.mk'' e : MulAction.orbitRel.Quotient (Deck p) E) = p e :=
   rfl
+
+/-- The inverse quotient-base equivalence sends a projected point to the class of any lift. -/
+@[simp]
+lemma orbitQuotientEquivBase_symm_apply_proj (hreg : IsRegular p) (e : E) :
+    hreg.orbitQuotientEquivBase.symm (p e) =
+      (Quotient.mk'' e : MulAction.orbitRel.Quotient (Deck p) E) := by
+  apply hreg.orbitQuotientEquivBase.injective
+  rw [Equiv.apply_symm_apply, orbitQuotientEquivBase_mk]
 
 /-- Transporting a regular deck action along an over-base homeomorphism is compatible with
 the corresponding orbit-quotient equivalences. -/

--- a/TauCeti/AlgebraicTopology/UniversalCover/Deck/Quotient.lean
+++ b/TauCeti/AlgebraicTopology/UniversalCover/Deck/Quotient.lean
@@ -57,7 +57,7 @@ lemma orbitQuotientToBase_mk (e : E) :
 
 /-- If deck orbits are exactly fibres of `p`, the orbit quotient map to the base is
 injective. -/
-private lemma orbitQuotientToBase_injective_of_exists_apply_eq
+lemma orbitQuotientToBase_injective_of_exists_apply_eq
     (hpoint : ∀ {e e' : E}, p e = p e' → ∃ φ : Deck p, φ.1 e = e') :
     Function.Injective (orbitQuotientToBase p) := by
   intro x y hxy
@@ -71,8 +71,7 @@ private lemma orbitQuotientToBase_injective_of_exists_apply_eq
             ⟨φ⁻¹, by
               have hinv : φ.1.symm e' = e := by
                 rw [← hφ, Homeomorph.symm_apply_apply]
-              have hsmul := inv_smul_eq_symm_apply φ e'
-              exact hsmul.trans hinv⟩
+              simpa [smul_eq_apply] using hinv⟩
 
 /-- An over-base homeomorphism preserves the corresponding deck-orbit relations. -/
 private lemma orbitRel_homeomorph_iff (h : E ≃ₜ F) (hpq : ∀ e, q (h e) = p e) (e e' : E) :
@@ -125,12 +124,6 @@ lemma orbitQuotientEquiv_symm_mk (h : E ≃ₜ F) (hpq : ∀ e, q (h e) = p e) (
         (Quotient.mk'' (h.symm f) : MulAction.orbitRel.Quotient (Deck p) E) :=
   rfl
 
-/-- If `p` is surjective, then the map from the deck-orbit quotient to the base is
-surjective. -/
-lemma orbitQuotientToBase_surjective (hp : Function.Surjective p) :
-    Function.Surjective (orbitQuotientToBase p) :=
-  Quotient.lift_surjective p _ hp
-
 namespace IsRegular
 
 /-- For a regular deck action, the map from deck-orbit quotient to the base is injective. -/
@@ -144,7 +137,7 @@ base. -/
 noncomputable def orbitQuotientEquivBase (hreg : IsRegular p) :
     MulAction.orbitRel.Quotient (Deck p) E ≃ B :=
   Equiv.ofBijective (orbitQuotientToBase p)
-    ⟨hreg.orbitQuotientToBase_injective, orbitQuotientToBase_surjective hreg.1⟩
+    ⟨hreg.orbitQuotientToBase_injective, Quotient.lift_surjective p _ hreg.1⟩
 
 /-- The equivalence from the deck-orbit quotient to the base evaluates on representatives by
 the projection map. -/
@@ -161,6 +154,19 @@ lemma orbitQuotientEquivBase_symm_apply_proj (hreg : IsRegular p) (e : E) :
       (Quotient.mk'' e : MulAction.orbitRel.Quotient (Deck p) E) := by
   apply hreg.orbitQuotientEquivBase.injective
   rw [Equiv.apply_symm_apply, orbitQuotientEquivBase_mk]
+
+/-- For a regular deck action, two points have the same deck-orbit quotient class exactly when
+they have the same projection. -/
+@[simp]
+lemma orbitQuotient_mk_eq_mk_iff (hreg : IsRegular p) (e e' : E) :
+    (Quotient.mk'' e : MulAction.orbitRel.Quotient (Deck p) E) = Quotient.mk'' e' ↔
+      p e = p e' := by
+  constructor
+  · intro h
+    simpa only [orbitQuotientToBase_mk] using congr_arg (orbitQuotientToBase p) h
+  · intro h
+    apply hreg.orbitQuotientToBase_injective
+    simpa only [orbitQuotientToBase_mk] using h
 
 /-- Transporting a regular deck action along an over-base homeomorphism is compatible with
 the corresponding orbit-quotient equivalences. -/

--- a/TauCeti/AlgebraicTopology/UniversalCover/Deck/Quotient.lean
+++ b/TauCeti/AlgebraicTopology/UniversalCover/Deck/Quotient.lean
@@ -121,15 +121,35 @@ lemma orbitQuotientEquiv_symm_mk (h : E ≃ₜ F) (hpq : ∀ e, q (h e) = p e) (
         (Quotient.mk'' (h.symm f) : MulAction.orbitRel.Quotient (Deck p) E) :=
   rfl
 
+/-- If deck transformations act transitively on each fibre of `p`, the map from the
+deck-orbit quotient to the base is injective. -/
+lemma orbitQuotientToBase_injective_of_exists_apply_eq
+    (hpoint : ∀ {e e' : E}, p e = p e' → ∃ φ : Deck p, φ.1 e = e') :
+    Function.Injective (orbitQuotientToBase p) := by
+  exact (Setoid.lift_injective_iff_ker_eq_of_le
+    (r := MulAction.orbitRel (Deck p) E) (f := p)
+    (fun _ _ h => eq_proj_of_orbitRel h)).mpr
+      (orbitRel_eq_ker_of_exists_apply_eq hpoint).symm
+
+/-- If deck transformations act transitively on each fibre of `p`, two points have the same
+deck-orbit quotient class exactly when they have the same projection. -/
+lemma orbitQuotient_mk_eq_mk_iff_of_exists_apply_eq
+    (hpoint : ∀ {e e' : E}, p e = p e' → ∃ φ : Deck p, φ.1 e = e') (e e' : E) :
+    (Quotient.mk'' e : MulAction.orbitRel.Quotient (Deck p) E) = Quotient.mk'' e' ↔
+      p e = p e' := by
+  constructor
+  · intro h
+    simpa only [orbitQuotientToBase_mk] using congr_arg (orbitQuotientToBase p) h
+  · intro h
+    apply orbitQuotientToBase_injective_of_exists_apply_eq hpoint
+    simpa only [orbitQuotientToBase_mk] using h
+
 namespace IsRegular
 
 /-- For a regular deck action, the map from deck-orbit quotient to the base is injective. -/
 lemma orbitQuotientToBase_injective (hreg : IsRegular p) :
     Function.Injective (orbitQuotientToBase p) := by
-  exact (Setoid.lift_injective_iff_ker_eq_of_le
-    (r := MulAction.orbitRel (Deck p) E) (f := p)
-    (fun _ _ h => eq_proj_of_orbitRel h)).mpr
-      (orbitRel_eq_ker_of_exists_apply_eq (isRegular_iff_exists_apply_eq.mp hreg).2).symm
+  exact orbitQuotientToBase_injective_of_exists_apply_eq (isRegular_iff_exists_apply_eq.mp hreg).2
 
 /-- A regular deck action identifies the quotient of the total space by deck orbits with the
 base. -/
@@ -160,12 +180,8 @@ they have the same projection. -/
 lemma orbitQuotient_mk_eq_mk_iff (hreg : IsRegular p) (e e' : E) :
     (Quotient.mk'' e : MulAction.orbitRel.Quotient (Deck p) E) = Quotient.mk'' e' ↔
       p e = p e' := by
-  constructor
-  · intro h
-    simpa only [orbitQuotientToBase_mk] using congr_arg (orbitQuotientToBase p) h
-  · intro h
-    apply hreg.orbitQuotientToBase_injective
-    simpa only [orbitQuotientToBase_mk] using h
+  exact orbitQuotient_mk_eq_mk_iff_of_exists_apply_eq
+    (isRegular_iff_exists_apply_eq.mp hreg).2 e e'
 
 /-- Transporting a regular deck action along an over-base homeomorphism is compatible with
 the corresponding orbit-quotient equivalences. -/


### PR DESCRIPTION
This PR identifies the deck-orbit quotient of a regular deck action with the base, advancing the exact roadmap target `TauCetiRoadmap/UniversalCovers/README.md`, Stage 2, item 8, where regular covers are organized by transitivity of the deck action on fibres and quotient-cover bookkeeping is needed for the normalizer quotient and regular-cover theorems.

It adds `TauCeti.AlgebraicTopology.UniversalCover.Deck.Quotient`, with the induced map `E / Deck p → B`, its representative and bijectivity API, and the equivalence `Deck.IsRegular.orbitQuotientEquivBase`. It also imports the module from the Tau Ceti root so the API is reachable.

It vendors no external formalization. The proofs reuse Mathlib infrastructure directly, especially `MulAction.orbitRel.Quotient`, `Quotient.lift`, quotient induction, and the existing Tau Ceti `Deck.IsRegular` and fibre-transitivity API.

Verified with `lake exe cache get`, `lake build`, and `lake exe axioms`.

🤖 Prepared with Codex
