### PR TITLE
feat: add adjoint ellipticity API

### DIFF
--- a/TauCeti.lean
+++ b/TauCeti.lean
@@ -14,4 +14,5 @@ import TauCeti.AlgebraicTopology.UniversalCover.Deck.FiberTransport
 import TauCeti.AlgebraicTopology.UniversalCover.Deck.Regular
 import TauCeti.Analysis.PDE.UniformEllipticity
 import TauCeti.Basic
+import TauCeti.LinearAlgebra.Matrix.QuadraticForm
 import TauCeti.LinearAlgebra.Matrix.SymmetricPart

--- a/TauCeti.lean
+++ b/TauCeti.lean
@@ -14,3 +14,4 @@ import TauCeti.AlgebraicTopology.UniversalCover.Deck.FiberTransport
 import TauCeti.AlgebraicTopology.UniversalCover.Deck.Regular
 import TauCeti.Analysis.PDE.UniformEllipticity
 import TauCeti.Basic
+import TauCeti.LinearAlgebra.Matrix.SymmetricPart

--- a/TauCeti/Analysis/PDE/UniformEllipticity.lean
+++ b/TauCeti/Analysis/PDE/UniformEllipticity.lean
@@ -369,8 +369,9 @@ lemma transpose (h : UniformlyEllipticOn Ω a lam Lam) :
 lemma symmetricPart (h : UniformlyEllipticOn Ω a lam Lam) :
     UniformlyEllipticOn Ω (fun x => TauCeti.Matrix.symmetricPart (a x)) lam Lam := by
   refine of_bounds h.pos h.le (fun {x} hx ξ => ?_) (fun {x} hx η ξ => ?_)
-  · simpa using h.lower_bound hx ξ
-  · rw [TauCeti.Matrix.symmetricPart, smul_mulVec, add_mulVec, dotProduct_smul, dotProduct_add]
+  · rw [TauCeti.Matrix.toQuadraticForm'_symmetricPart]
+    exact h.lower_bound hx ξ
+  · rw [TauCeti.Matrix.symmetricPart_def, smul_mulVec, add_mulVec, dotProduct_smul, dotProduct_add]
     simp only [smul_eq_mul, dotProduct_transpose_mulVec]
     set N : ℝ := ‖η‖ * ‖ξ‖
     have hηξ : |η ⬝ᵥ (a x *ᵥ ξ)| ≤ Lam * N := by

--- a/TauCeti/Analysis/PDE/UniformEllipticity.lean
+++ b/TauCeti/Analysis/PDE/UniformEllipticity.lean
@@ -8,6 +8,7 @@ import Mathlib.Analysis.Normed.Operator.NormedSpace
 import Mathlib.LinearAlgebra.Matrix.BilinearForm
 import Mathlib.LinearAlgebra.QuadraticForm.Basic
 import Mathlib.Topology.Algebra.Module.FiniteDimensionBilinear
+import TauCeti.LinearAlgebra.Matrix.QuadraticForm
 import TauCeti.LinearAlgebra.Matrix.SymmetricPart
 
 /-!

--- a/TauCeti/Analysis/PDE/UniformEllipticity.lean
+++ b/TauCeti/Analysis/PDE/UniformEllipticity.lean
@@ -64,6 +64,12 @@ open _root_.Matrix
 
 variable {X n : Type*} [Fintype n] [DecidableEq n]
 
+@[deprecated TauCeti.Matrix.toQuadraticForm'_eq_dotProduct (since := "2026-06-09")]
+alias toQuadraticForm'_eq_dotProduct := TauCeti.Matrix.toQuadraticForm'_eq_dotProduct
+
+@[deprecated TauCeti.Matrix.toQuadraticForm'_smul (since := "2026-06-09")]
+alias toQuadraticForm'_smul := TauCeti.Matrix.toQuadraticForm'_smul
+
 /-- The identity matrix has quadratic form `‖ξ‖²`. -/
 @[simp]
 lemma toQuadraticForm'_one (ξ : EuclideanSpace ℝ n) :

--- a/TauCeti/Analysis/PDE/UniformEllipticity.lean
+++ b/TauCeti/Analysis/PDE/UniformEllipticity.lean
@@ -6,6 +6,7 @@ import Mathlib.Analysis.InnerProductSpace.PiL2
 import Mathlib.Analysis.Normed.Operator.Bilinear
 import Mathlib.Analysis.Normed.Operator.NormedSpace
 import Mathlib.LinearAlgebra.Matrix.BilinearForm
+import Mathlib.LinearAlgebra.Matrix.Symmetric
 import Mathlib.LinearAlgebra.QuadraticForm.Basic
 import Mathlib.Topology.Algebra.Module.FiniteDimensionBilinear
 
@@ -42,6 +43,10 @@ and Lax--Milgram arguments: constants are parameters, not hidden existential dat
   the bilinear form attached to a uniformly elliptic coefficient field.
 * `TauCeti.PDE.UniformlyEllipticOn.opNorm_matrixBilinearForm_le`: pointwise operator-norm
   boundedness of the bilinear form attached to a uniformly elliptic coefficient field.
+* `TauCeti.PDE.UniformlyEllipticOn.transpose`: the adjoint coefficient field is uniformly
+  elliptic with the same constants.
+* `TauCeti.PDE.UniformlyEllipticOn.symmetricPart`: the symmetric part of a coefficient field
+  is uniformly elliptic with the same constants.
 * `TauCeti.PDE.uniformlyEllipticOn_smul_one`: scalar, isotropic coefficient fields are
   uniformly elliptic when their scalar coefficient lies between the ellipticity constants.
 
@@ -71,6 +76,13 @@ lemma toQuadraticForm'_one (ξ : EuclideanSpace ℝ n) :
   rw [toQuadraticForm'_eq_dotProduct, one_mulVec]
   simpa [dotProduct, sq] using (EuclideanSpace.real_norm_sq_eq ξ).symm
 
+/-- Transposition does not change the quadratic form associated to a real matrix. -/
+@[simp]
+lemma toQuadraticForm'_transpose (A : Matrix n n ℝ) (ξ : EuclideanSpace ℝ n) :
+    Aᵀ.toQuadraticForm' ξ = A.toQuadraticForm' ξ := by
+  rw [toQuadraticForm'_eq_dotProduct, toQuadraticForm'_eq_dotProduct,
+    dotProduct_transpose_mulVec]
+
 omit [DecidableEq n] in
 /-- The continuous bilinear form attached to a real matrix on Euclidean space.
 
@@ -96,6 +108,13 @@ lemma matrixBilinearForm_apply (A : Matrix n n ℝ) (η ξ : EuclideanSpace ℝ 
 lemma matrixBilinearForm_one_apply (η ξ : EuclideanSpace ℝ n) :
     matrixBilinearForm (1 : Matrix n n ℝ) η ξ = η ⬝ᵥ ξ := by
   rw [matrixBilinearForm_apply, one_mulVec]
+
+/-- Transposing the coefficient matrix swaps the two arguments of the matrix bilinear form. -/
+@[simp]
+lemma matrixBilinearForm_transpose_apply (A : Matrix n n ℝ)
+    (η ξ : EuclideanSpace ℝ n) :
+    matrixBilinearForm Aᵀ η ξ = matrixBilinearForm A ξ η := by
+  rw [matrixBilinearForm_apply, matrixBilinearForm_apply, dotProduct_transpose_mulVec]
 
 /-- Matrix quadratic forms are linear in scalar multiplication of the coefficient matrix. -/
 @[simp]
@@ -130,6 +149,42 @@ lemma matrixBilinearForm_smul_one_apply (c : ℝ) (η ξ : EuclideanSpace ℝ n)
 lemma matrixBilinearForm_self (A : Matrix n n ℝ) (ξ : EuclideanSpace ℝ n) :
     matrixBilinearForm A ξ ξ = A.toQuadraticForm' ξ := by
   rw [matrixBilinearForm_apply, toQuadraticForm'_eq_dotProduct]
+
+/-- The symmetric part `(A + Aᵀ) / 2` of a real square matrix. -/
+noncomputable def symmetricPart (A : Matrix n n ℝ) : Matrix n n ℝ :=
+  (2⁻¹ : ℝ) • (A + Aᵀ)
+
+omit [Fintype n] [DecidableEq n] in
+/-- The symmetric part of a matrix is symmetric. -/
+lemma symmetricPart_isSymm (A : Matrix n n ℝ) : (symmetricPart A).IsSymm :=
+  (isSymm_add_transpose_self A).smul _
+
+omit [Fintype n] [DecidableEq n] in
+/-- A symmetric matrix is equal to its symmetric part. -/
+lemma symmetricPart_of_isSymm {A : Matrix n n ℝ} (hA : A.IsSymm) :
+    symmetricPart A = A := by
+  ext i j
+  simp [symmetricPart, hA.eq]
+  ring
+
+/-- The symmetric part has the same quadratic form as the original matrix. -/
+@[simp]
+lemma toQuadraticForm'_symmetricPart (A : Matrix n n ℝ) (ξ : EuclideanSpace ℝ n) :
+    (symmetricPart A).toQuadraticForm' ξ = A.toQuadraticForm' ξ := by
+  rw [toQuadraticForm'_eq_dotProduct, toQuadraticForm'_eq_dotProduct]
+  simp only [symmetricPart, smul_mulVec, add_mulVec, dotProduct_smul, dotProduct_add,
+    smul_eq_mul, dotProduct_transpose_mulVec]
+  ring
+
+/-- The bilinear form of the symmetric part is the average of the two swapped coefficient
+bilinear forms. -/
+lemma matrixBilinearForm_symmetricPart_apply (A : Matrix n n ℝ)
+    (η ξ : EuclideanSpace ℝ n) :
+    matrixBilinearForm (symmetricPart A) η ξ =
+      (2⁻¹ : ℝ) * (matrixBilinearForm A η ξ + matrixBilinearForm A ξ η) := by
+  rw [matrixBilinearForm_apply, matrixBilinearForm_apply, matrixBilinearForm_apply]
+  simp only [symmetricPart, smul_mulVec, add_mulVec, dotProduct_smul, dotProduct_add,
+    smul_eq_mul, dotProduct_transpose_mulVec]
 
 /-- A pointwise bilinear upper bound gives the corresponding norm estimate for the bundled
 continuous bilinear form. -/
@@ -339,6 +394,47 @@ lemma isCoercive_matrixBilinearForm (h : UniformlyEllipticOn Ω a lam Lam) {x : 
     (hx : x ∈ Ω) :
     IsCoercive (matrixBilinearForm (a x)) :=
   isCoercive_matrixBilinearForm_of_lower_bound (a x) h.pos (h.lower_bound hx)
+
+/-- The adjoint coefficient field has the same uniform ellipticity constants. -/
+lemma transpose (h : UniformlyEllipticOn Ω a lam Lam) :
+    UniformlyEllipticOn Ω (fun x => (a x)ᵀ) lam Lam := by
+  refine of_bounds h.pos h.le (fun {x} hx ξ => ?_) (fun {x} hx η ξ => ?_)
+  · simpa using h.lower_bound hx ξ
+  · have hupper := h.upper_bound hx ξ η
+    rw [dotProduct_transpose_mulVec]
+    simpa [mul_comm, mul_left_comm, mul_assoc] using hupper
+
+/-- The symmetric part of the coefficient field has the same uniform ellipticity constants. -/
+lemma symmetricPart (h : UniformlyEllipticOn Ω a lam Lam) :
+    UniformlyEllipticOn Ω (fun x => PDE.symmetricPart (a x)) lam Lam := by
+  refine of_bounds h.pos h.le (fun {x} hx ξ => ?_) (fun {x} hx η ξ => ?_)
+  · simpa using h.lower_bound hx ξ
+  · rw [PDE.symmetricPart, smul_mulVec, add_mulVec, dotProduct_smul, dotProduct_add]
+    simp only [smul_eq_mul, dotProduct_transpose_mulVec]
+    set N : ℝ := ‖η‖ * ‖ξ‖
+    have hηξ : |η ⬝ᵥ (a x *ᵥ ξ)| ≤ Lam * N := by
+      simpa [N, mul_assoc] using h.upper_bound hx η ξ
+    have hξη : |ξ ⬝ᵥ (a x *ᵥ η)| ≤ Lam * N := by
+      simpa [N, mul_comm, mul_left_comm, mul_assoc] using h.upper_bound hx ξ η
+    have hsum :
+        |η ⬝ᵥ (a x *ᵥ ξ) + ξ ⬝ᵥ (a x *ᵥ η)| ≤ Lam * N + Lam * N :=
+      (abs_add_le _ _).trans (add_le_add hηξ hξη)
+    calc
+      |(2⁻¹ : ℝ) * (η ⬝ᵥ (a x *ᵥ ξ) + ξ ⬝ᵥ (a x *ᵥ η))|
+          = (2⁻¹ : ℝ) * |η ⬝ᵥ (a x *ᵥ ξ) + ξ ⬝ᵥ (a x *ᵥ η)| := by
+            rw [abs_mul, abs_of_nonneg]
+            positivity
+      _ ≤ (2⁻¹ : ℝ) * (Lam * N + Lam * N) := by
+            exact mul_le_mul_of_nonneg_left hsum (by positivity)
+      _ = Lam * ‖η‖ * ‖ξ‖ := by
+            simp [N]
+            ring
+
+omit [Fintype n] [DecidableEq n] in
+/-- The symmetric part of each coefficient matrix is symmetric. -/
+lemma symmetricPart_isSymm (a : X → Matrix n n ℝ) (x : X) :
+    (PDE.symmetricPart (a x)).IsSymm :=
+  PDE.symmetricPart_isSymm (a x)
 
 end UniformlyEllipticOn
 

--- a/TauCeti/Analysis/PDE/UniformEllipticity.lean
+++ b/TauCeti/Analysis/PDE/UniformEllipticity.lean
@@ -6,7 +6,6 @@ import Mathlib.Analysis.InnerProductSpace.PiL2
 import Mathlib.Analysis.Normed.Operator.Bilinear
 import Mathlib.Analysis.Normed.Operator.NormedSpace
 import Mathlib.LinearAlgebra.Matrix.BilinearForm
-import Mathlib.LinearAlgebra.Matrix.Symmetric
 import Mathlib.LinearAlgebra.QuadraticForm.Basic
 import Mathlib.Topology.Algebra.Module.FiniteDimensionBilinear
 import TauCeti.LinearAlgebra.Matrix.SymmetricPart

--- a/TauCeti/Analysis/PDE/UniformEllipticity.lean
+++ b/TauCeti/Analysis/PDE/UniformEllipticity.lean
@@ -9,6 +9,7 @@ import Mathlib.LinearAlgebra.Matrix.BilinearForm
 import Mathlib.LinearAlgebra.Matrix.Symmetric
 import Mathlib.LinearAlgebra.QuadraticForm.Basic
 import Mathlib.Topology.Algebra.Module.FiniteDimensionBilinear
+import TauCeti.LinearAlgebra.Matrix.SymmetricPart
 
 /-!
 # Uniform ellipticity for divergence-form PDE coefficients
@@ -59,29 +60,16 @@ namespace TauCeti
 
 namespace PDE
 
-open Matrix
+open _root_.Matrix
 
 variable {X n : Type*} [Fintype n] [DecidableEq n]
-
-/-- Mathlib's matrix quadratic form is the dot-product expression `ξᵀ A ξ`. -/
-lemma toQuadraticForm'_eq_dotProduct (A : Matrix n n ℝ) (ξ : EuclideanSpace ℝ n) :
-    A.toQuadraticForm' ξ = ξ ⬝ᵥ (A *ᵥ ξ) := by
-  rw [Matrix.toQuadraticForm',
-    LinearMap.BilinMap.toQuadraticMap_apply, Matrix.toLinearMap₂'_apply']
 
 /-- The identity matrix has quadratic form `‖ξ‖²`. -/
 @[simp]
 lemma toQuadraticForm'_one (ξ : EuclideanSpace ℝ n) :
     (1 : Matrix n n ℝ).toQuadraticForm' ξ = ‖ξ‖ ^ 2 := by
-  rw [toQuadraticForm'_eq_dotProduct, one_mulVec]
+  rw [TauCeti.Matrix.toQuadraticForm'_eq_dotProduct, one_mulVec]
   simpa [dotProduct, sq] using (EuclideanSpace.real_norm_sq_eq ξ).symm
-
-/-- Transposition does not change the quadratic form associated to a real matrix. -/
-@[simp]
-lemma toQuadraticForm'_transpose (A : Matrix n n ℝ) (ξ : EuclideanSpace ℝ n) :
-    Aᵀ.toQuadraticForm' ξ = A.toQuadraticForm' ξ := by
-  rw [toQuadraticForm'_eq_dotProduct, toQuadraticForm'_eq_dotProduct,
-    dotProduct_transpose_mulVec]
 
 omit [DecidableEq n] in
 /-- The continuous bilinear form attached to a real matrix on Euclidean space.
@@ -116,19 +104,11 @@ lemma matrixBilinearForm_transpose_apply (A : Matrix n n ℝ)
     matrixBilinearForm Aᵀ η ξ = matrixBilinearForm A ξ η := by
   rw [matrixBilinearForm_apply, matrixBilinearForm_apply, dotProduct_transpose_mulVec]
 
-/-- Matrix quadratic forms are linear in scalar multiplication of the coefficient matrix. -/
-@[simp]
-lemma toQuadraticForm'_smul (c : ℝ) (A : Matrix n n ℝ) (ξ : EuclideanSpace ℝ n) :
-    (c • A).toQuadraticForm' ξ = c * A.toQuadraticForm' ξ := by
-  rw [toQuadraticForm'_eq_dotProduct, toQuadraticForm'_eq_dotProduct, smul_mulVec,
-    dotProduct_smul]
-  simp [smul_eq_mul]
-
 /-- The scalar identity matrix has quadratic form `c ‖ξ‖²`. -/
 @[simp]
 lemma toQuadraticForm'_smul_one (c : ℝ) (ξ : EuclideanSpace ℝ n) :
     (c • (1 : Matrix n n ℝ)).toQuadraticForm' ξ = c * ‖ξ‖ ^ 2 := by
-  rw [toQuadraticForm'_smul, toQuadraticForm'_one]
+  rw [TauCeti.Matrix.toQuadraticForm'_smul, toQuadraticForm'_one]
 
 /-- Matrix bilinear forms are linear in scalar multiplication of the coefficient matrix. -/
 @[simp]
@@ -148,43 +128,18 @@ lemma matrixBilinearForm_smul_one_apply (c : ℝ) (η ξ : EuclideanSpace ℝ n)
 @[simp]
 lemma matrixBilinearForm_self (A : Matrix n n ℝ) (ξ : EuclideanSpace ℝ n) :
     matrixBilinearForm A ξ ξ = A.toQuadraticForm' ξ := by
-  rw [matrixBilinearForm_apply, toQuadraticForm'_eq_dotProduct]
-
-/-- The symmetric part `(A + Aᵀ) / 2` of a real square matrix. -/
-noncomputable def symmetricPart (A : Matrix n n ℝ) : Matrix n n ℝ :=
-  (2⁻¹ : ℝ) • (A + Aᵀ)
-
-omit [Fintype n] [DecidableEq n] in
-/-- The symmetric part of a matrix is symmetric. -/
-lemma symmetricPart_isSymm (A : Matrix n n ℝ) : (symmetricPart A).IsSymm :=
-  (isSymm_add_transpose_self A).smul _
-
-omit [Fintype n] [DecidableEq n] in
-/-- A symmetric matrix is equal to its symmetric part. -/
-lemma symmetricPart_of_isSymm {A : Matrix n n ℝ} (hA : A.IsSymm) :
-    symmetricPart A = A := by
-  ext i j
-  simp [symmetricPart, hA.eq]
-  ring
-
-/-- The symmetric part has the same quadratic form as the original matrix. -/
-@[simp]
-lemma toQuadraticForm'_symmetricPart (A : Matrix n n ℝ) (ξ : EuclideanSpace ℝ n) :
-    (symmetricPart A).toQuadraticForm' ξ = A.toQuadraticForm' ξ := by
-  rw [toQuadraticForm'_eq_dotProduct, toQuadraticForm'_eq_dotProduct]
-  simp only [symmetricPart, smul_mulVec, add_mulVec, dotProduct_smul, dotProduct_add,
-    smul_eq_mul, dotProduct_transpose_mulVec]
-  ring
+  rw [matrixBilinearForm_apply, TauCeti.Matrix.toQuadraticForm'_eq_dotProduct]
 
 /-- The bilinear form of the symmetric part is the average of the two swapped coefficient
 bilinear forms. -/
+@[simp]
 lemma matrixBilinearForm_symmetricPart_apply (A : Matrix n n ℝ)
     (η ξ : EuclideanSpace ℝ n) :
-    matrixBilinearForm (symmetricPart A) η ξ =
+    matrixBilinearForm (TauCeti.Matrix.symmetricPart A) η ξ =
       (2⁻¹ : ℝ) * (matrixBilinearForm A η ξ + matrixBilinearForm A ξ η) := by
   rw [matrixBilinearForm_apply, matrixBilinearForm_apply, matrixBilinearForm_apply]
-  simp only [symmetricPart, smul_mulVec, add_mulVec, dotProduct_smul, dotProduct_add,
-    smul_eq_mul, dotProduct_transpose_mulVec]
+  simp only [TauCeti.Matrix.symmetricPart, smul_mulVec, add_mulVec, dotProduct_smul,
+    dotProduct_add, smul_eq_mul, dotProduct_transpose_mulVec]
 
 /-- A pointwise bilinear upper bound gives the corresponding norm estimate for the bundled
 continuous bilinear form. -/
@@ -406,10 +361,10 @@ lemma transpose (h : UniformlyEllipticOn Ω a lam Lam) :
 
 /-- The symmetric part of the coefficient field has the same uniform ellipticity constants. -/
 lemma symmetricPart (h : UniformlyEllipticOn Ω a lam Lam) :
-    UniformlyEllipticOn Ω (fun x => PDE.symmetricPart (a x)) lam Lam := by
+    UniformlyEllipticOn Ω (fun x => TauCeti.Matrix.symmetricPart (a x)) lam Lam := by
   refine of_bounds h.pos h.le (fun {x} hx ξ => ?_) (fun {x} hx η ξ => ?_)
   · simpa using h.lower_bound hx ξ
-  · rw [PDE.symmetricPart, smul_mulVec, add_mulVec, dotProduct_smul, dotProduct_add]
+  · rw [TauCeti.Matrix.symmetricPart, smul_mulVec, add_mulVec, dotProduct_smul, dotProduct_add]
     simp only [smul_eq_mul, dotProduct_transpose_mulVec]
     set N : ℝ := ‖η‖ * ‖ξ‖
     have hηξ : |η ⬝ᵥ (a x *ᵥ ξ)| ≤ Lam * N := by
@@ -429,12 +384,6 @@ lemma symmetricPart (h : UniformlyEllipticOn Ω a lam Lam) :
       _ = Lam * ‖η‖ * ‖ξ‖ := by
             simp [N]
             ring
-
-omit [Fintype n] [DecidableEq n] in
-/-- The symmetric part of each coefficient matrix is symmetric. -/
-lemma symmetricPart_isSymm (a : X → Matrix n n ℝ) (x : X) :
-    (PDE.symmetricPart (a x)).IsSymm :=
-  PDE.symmetricPart_isSymm (a x)
 
 end UniformlyEllipticOn
 

--- a/TauCeti/Analysis/PDE/UniformEllipticity.lean
+++ b/TauCeti/Analysis/PDE/UniformEllipticity.lean
@@ -144,7 +144,7 @@ lemma matrixBilinearForm_symmetricPart_apply (A : Matrix n n ℝ)
     matrixBilinearForm (TauCeti.Matrix.symmetricPart A) η ξ =
       (2⁻¹ : ℝ) * (matrixBilinearForm A η ξ + matrixBilinearForm A ξ η) := by
   rw [matrixBilinearForm_apply, matrixBilinearForm_apply, matrixBilinearForm_apply]
-  simp only [TauCeti.Matrix.symmetricPart, smul_mulVec, add_mulVec, dotProduct_smul,
+  simp only [TauCeti.Matrix.symmetricPart, invOf_eq_inv, smul_mulVec, add_mulVec, dotProduct_smul,
     dotProduct_add, smul_eq_mul, dotProduct_transpose_mulVec]
 
 /-- A pointwise bilinear upper bound gives the corresponding norm estimate for the bundled

--- a/TauCeti/LinearAlgebra/Matrix/QuadraticForm.lean
+++ b/TauCeti/LinearAlgebra/Matrix/QuadraticForm.lean
@@ -1,0 +1,56 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+import Mathlib.Analysis.InnerProductSpace.PiL2
+import Mathlib.LinearAlgebra.Matrix.BilinearForm
+import Mathlib.LinearAlgebra.QuadraticForm.Basic
+
+/-!
+# Quadratic forms associated to real matrices
+
+This file records elementary API for Mathlib's quadratic form attached to a real square
+matrix.
+
+## Main declarations
+
+* `TauCeti.Matrix.toQuadraticForm'_eq_dotProduct`: the matrix quadratic form is the
+  dot-product expression `ξᵀ A ξ`.
+* `TauCeti.Matrix.toQuadraticForm'_transpose`: transposition preserves the associated
+  quadratic form.
+* `TauCeti.Matrix.toQuadraticForm'_smul`: scalar multiplication of coefficient matrices
+  scales the associated quadratic form.
+-/
+
+namespace TauCeti
+
+namespace Matrix
+
+open scoped Matrix
+
+variable {n : Type*} [Fintype n] [DecidableEq n]
+
+/-- Mathlib's matrix quadratic form is the dot-product expression `ξᵀ A ξ`. -/
+lemma toQuadraticForm'_eq_dotProduct (A : _root_.Matrix n n ℝ) (ξ : EuclideanSpace ℝ n) :
+    A.toQuadraticForm' ξ = ξ ⬝ᵥ A.mulVec ξ := by
+  rw [_root_.Matrix.toQuadraticForm',
+    LinearMap.BilinMap.toQuadraticMap_apply, _root_.Matrix.toLinearMap₂'_apply']
+
+/-- Transposition does not change the quadratic form associated to a real matrix. -/
+@[simp]
+lemma toQuadraticForm'_transpose (A : _root_.Matrix n n ℝ) (ξ : EuclideanSpace ℝ n) :
+    A.transpose.toQuadraticForm' ξ = A.toQuadraticForm' ξ := by
+  rw [toQuadraticForm'_eq_dotProduct, toQuadraticForm'_eq_dotProduct,
+    _root_.Matrix.dotProduct_transpose_mulVec]
+
+/-- Matrix quadratic forms are linear in scalar multiplication of the coefficient matrix. -/
+@[simp]
+lemma toQuadraticForm'_smul (c : ℝ) (A : _root_.Matrix n n ℝ) (ξ : EuclideanSpace ℝ n) :
+    (c • A).toQuadraticForm' ξ = c * A.toQuadraticForm' ξ := by
+  rw [toQuadraticForm'_eq_dotProduct, toQuadraticForm'_eq_dotProduct,
+    _root_.Matrix.smul_mulVec, _root_.dotProduct_smul]
+  simp [smul_eq_mul]
+
+end Matrix
+
+end TauCeti

--- a/TauCeti/LinearAlgebra/Matrix/QuadraticForm.lean
+++ b/TauCeti/LinearAlgebra/Matrix/QuadraticForm.lean
@@ -7,10 +7,10 @@ import Mathlib.LinearAlgebra.Matrix.BilinearForm
 import Mathlib.LinearAlgebra.QuadraticForm.Basic
 
 /-!
-# Quadratic forms associated to real matrices
+# Quadratic forms associated to matrices
 
-This file records elementary API for Mathlib's quadratic form attached to a real square
-matrix.
+This file records elementary API for Mathlib's quadratic form attached to a square matrix
+in standard coordinates.
 
 ## Main declarations
 
@@ -28,24 +28,24 @@ namespace Matrix
 
 open scoped Matrix
 
-variable {n : Type*} [Fintype n] [DecidableEq n]
+variable {n R : Type*} [Fintype n] [DecidableEq n] [CommRing R]
 
 /-- Mathlib's matrix quadratic form is the dot-product expression `ξᵀ A ξ`. -/
-lemma toQuadraticForm'_eq_dotProduct (A : _root_.Matrix n n ℝ) (ξ : EuclideanSpace ℝ n) :
+lemma toQuadraticForm'_eq_dotProduct (A : _root_.Matrix n n R) (ξ : n → R) :
     A.toQuadraticForm' ξ = ξ ⬝ᵥ A.mulVec ξ := by
   rw [_root_.Matrix.toQuadraticForm',
     LinearMap.BilinMap.toQuadraticMap_apply, _root_.Matrix.toLinearMap₂'_apply']
 
-/-- Transposition does not change the quadratic form associated to a real matrix. -/
+/-- Transposition does not change the quadratic form associated to a matrix. -/
 @[simp]
-lemma toQuadraticForm'_transpose (A : _root_.Matrix n n ℝ) (ξ : EuclideanSpace ℝ n) :
+lemma toQuadraticForm'_transpose (A : _root_.Matrix n n R) (ξ : n → R) :
     A.transpose.toQuadraticForm' ξ = A.toQuadraticForm' ξ := by
   rw [toQuadraticForm'_eq_dotProduct, toQuadraticForm'_eq_dotProduct,
     _root_.Matrix.dotProduct_transpose_mulVec]
 
 /-- Matrix quadratic forms are linear in scalar multiplication of the coefficient matrix. -/
 @[simp]
-lemma toQuadraticForm'_smul (c : ℝ) (A : _root_.Matrix n n ℝ) (ξ : EuclideanSpace ℝ n) :
+lemma toQuadraticForm'_smul (c : R) (A : _root_.Matrix n n R) (ξ : n → R) :
     (c • A).toQuadraticForm' ξ = c * A.toQuadraticForm' ξ := by
   rw [toQuadraticForm'_eq_dotProduct, toQuadraticForm'_eq_dotProduct,
     _root_.Matrix.smul_mulVec, _root_.dotProduct_smul]

--- a/TauCeti/LinearAlgebra/Matrix/SymmetricPart.lean
+++ b/TauCeti/LinearAlgebra/Matrix/SymmetricPart.lean
@@ -56,6 +56,7 @@ omit [Fintype n] [DecidableEq n] in
 lemma symmetricPart_of_isSymm {A : _root_.Matrix n n R} (hA : A.IsSymm) :
     symmetricPart A = A := by
   ext i j
+  -- Matrix scalar multiplication and addition reduce to this entrywise scalar identity.
   change ⅟(2 : R) * (A i j + A j i) = A i j
   rw [hA.apply]
   rw [← two_mul, ← mul_assoc, invOf_mul_self, one_mul]
@@ -68,6 +69,8 @@ lemma toBilin'_symmetricPart (A : _root_.Matrix n n R) :
   intro v
   apply LinearMap.ext
   intro w
+  -- `toQuadraticForm'` is defined from `toLinearMap₂'`, and `associated` symmetrizes the
+  -- underlying bilinear map; the proof isolates that wrapper unfolding at one point.
   rw [symmetricPart_def, _root_.Matrix.toQuadraticForm',
     _root_.QuadraticMap.associated_toQuadraticMap]
   rw [_root_.Matrix.toBilin'_apply', _root_.Matrix.smul_mulVec, _root_.Matrix.add_mulVec,

--- a/TauCeti/LinearAlgebra/Matrix/SymmetricPart.lean
+++ b/TauCeti/LinearAlgebra/Matrix/SymmetricPart.lean
@@ -2,10 +2,8 @@
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 -/
-import Mathlib.Analysis.InnerProductSpace.PiL2
-import Mathlib.LinearAlgebra.Matrix.BilinearForm
 import Mathlib.LinearAlgebra.Matrix.Symmetric
-import Mathlib.LinearAlgebra.QuadraticForm.Basic
+import TauCeti.LinearAlgebra.Matrix.QuadraticForm
 
 /-!
 # Symmetric parts of real square matrices
@@ -31,27 +29,6 @@ open scoped Matrix
 
 variable {n : Type*} [Fintype n] [DecidableEq n]
 
-/-- Mathlib's matrix quadratic form is the dot-product expression `ξᵀ A ξ`. -/
-lemma toQuadraticForm'_eq_dotProduct (A : _root_.Matrix n n ℝ) (ξ : EuclideanSpace ℝ n) :
-    A.toQuadraticForm' ξ = ξ ⬝ᵥ A.mulVec ξ := by
-  rw [_root_.Matrix.toQuadraticForm',
-    LinearMap.BilinMap.toQuadraticMap_apply, _root_.Matrix.toLinearMap₂'_apply']
-
-/-- Transposition does not change the quadratic form associated to a real matrix. -/
-@[simp]
-lemma toQuadraticForm'_transpose (A : _root_.Matrix n n ℝ) (ξ : EuclideanSpace ℝ n) :
-    A.transpose.toQuadraticForm' ξ = A.toQuadraticForm' ξ := by
-  rw [toQuadraticForm'_eq_dotProduct, toQuadraticForm'_eq_dotProduct,
-    _root_.Matrix.dotProduct_transpose_mulVec]
-
-/-- Matrix quadratic forms are linear in scalar multiplication of the coefficient matrix. -/
-@[simp]
-lemma toQuadraticForm'_smul (c : ℝ) (A : _root_.Matrix n n ℝ) (ξ : EuclideanSpace ℝ n) :
-    (c • A).toQuadraticForm' ξ = c * A.toQuadraticForm' ξ := by
-  rw [toQuadraticForm'_eq_dotProduct, toQuadraticForm'_eq_dotProduct,
-    _root_.Matrix.smul_mulVec, _root_.dotProduct_smul]
-  simp [smul_eq_mul]
-
 /-- The symmetric part `(A + Aᵀ) / 2` of a real square matrix. -/
 noncomputable def symmetricPart (A : _root_.Matrix n n ℝ) : _root_.Matrix n n ℝ :=
   (2⁻¹ : ℝ) • (A + A.transpose)
@@ -64,6 +41,7 @@ lemma isSymm_symmetricPart (A : _root_.Matrix n n ℝ) : (symmetricPart A).IsSym
 
 omit [Fintype n] [DecidableEq n] in
 /-- A symmetric matrix is equal to its symmetric part. -/
+@[simp]
 lemma symmetricPart_of_isSymm {A : _root_.Matrix n n ℝ} (hA : A.IsSymm) :
     symmetricPart A = A := by
   ext i j

--- a/TauCeti/LinearAlgebra/Matrix/SymmetricPart.lean
+++ b/TauCeti/LinearAlgebra/Matrix/SymmetricPart.lean
@@ -13,10 +13,13 @@ This file records the elementary real matrix API for the symmetric part `(A + A�
 ## Main declarations
 
 * `TauCeti.Matrix.symmetricPart`: the symmetric part `(A + Aᵀ) / 2` of a real square matrix.
+* `TauCeti.Matrix.symmetricPart_def`: the defining formula for the symmetric part.
 * `TauCeti.Matrix.isSymm_symmetricPart`: the symmetric part of any real square matrix is
   symmetric.
 * `TauCeti.Matrix.symmetricPart_of_isSymm`: a symmetric real square matrix equals its
   symmetric part.
+* `TauCeti.Matrix.symmetricPart_eq_toMatrix'_toQuadraticForm'`: the symmetric part is
+  Mathlib's associated matrix of the quadratic form attached to `A`.
 * `TauCeti.Matrix.toQuadraticForm'_symmetricPart`: taking symmetric parts preserves the
   real quadratic form.
 -/
@@ -34,6 +37,13 @@ noncomputable def symmetricPart (A : _root_.Matrix n n ℝ) : _root_.Matrix n n 
   (2⁻¹ : ℝ) • (A + A.transpose)
 
 omit [Fintype n] [DecidableEq n] in
+/-- Characteristic formula for the symmetric part of a matrix. -/
+@[simp]
+lemma symmetricPart_def (A : _root_.Matrix n n ℝ) :
+    symmetricPart A = (2⁻¹ : ℝ) • (A + A.transpose) :=
+  rfl
+
+omit [Fintype n] [DecidableEq n] in
 /-- The symmetric part of a matrix is symmetric. -/
 @[simp]
 lemma isSymm_symmetricPart (A : _root_.Matrix n n ℝ) : (symmetricPart A).IsSymm :=
@@ -45,15 +55,37 @@ omit [Fintype n] [DecidableEq n] in
 lemma symmetricPart_of_isSymm {A : _root_.Matrix n n ℝ} (hA : A.IsSymm) :
     symmetricPart A = A := by
   ext i j
-  simp [symmetricPart, hA.eq]
+  simp [hA.eq]
   ring
+
+/-- The symmetric part is Mathlib's associated matrix of the quadratic form attached to `A`. -/
+lemma symmetricPart_eq_toMatrix'_toQuadraticForm' (A : _root_.Matrix n n ℝ) :
+    symmetricPart A = A.toQuadraticForm'.toMatrix' := by
+  apply (_root_.Matrix.toBilin' : _root_.Matrix n n ℝ ≃ₗ[ℝ] _).injective
+  rw [_root_.QuadraticForm.toMatrix']
+  change _root_.Matrix.toBilin' (symmetricPart A) =
+    _root_.Matrix.toBilin' (_root_.LinearMap.BilinForm.toMatrix' A.toQuadraticForm'.associated)
+  rw [_root_.Matrix.toBilin'_toMatrix']
+  apply LinearMap.ext
+  intro v
+  apply LinearMap.ext
+  intro w
+  change _root_.Matrix.toBilin' (symmetricPart A) v w = A.toQuadraticForm'.associated v w
+  rw [symmetricPart_def, _root_.Matrix.toQuadraticForm',
+    _root_.QuadraticMap.associated_toQuadraticMap]
+  rw [_root_.Matrix.toBilin'_apply', _root_.Matrix.smul_mulVec, _root_.Matrix.add_mulVec,
+    _root_.dotProduct_smul, _root_.dotProduct_add,
+    _root_.Matrix.dotProduct_transpose_mulVec, _root_.Matrix.toLinearMap₂'_apply',
+    _root_.Matrix.toLinearMap₂'_apply']
+  simp [smul_eq_mul, invOf_eq_inv]
+  ring_nf
 
 /-- The symmetric part has the same quadratic form as the original matrix. -/
 @[simp]
 lemma toQuadraticForm'_symmetricPart (A : _root_.Matrix n n ℝ) (ξ : EuclideanSpace ℝ n) :
     (symmetricPart A).toQuadraticForm' ξ = A.toQuadraticForm' ξ := by
   rw [toQuadraticForm'_eq_dotProduct, toQuadraticForm'_eq_dotProduct]
-  simp only [symmetricPart, _root_.Matrix.smul_mulVec, _root_.Matrix.add_mulVec,
+  simp only [symmetricPart_def, _root_.Matrix.smul_mulVec, _root_.Matrix.add_mulVec,
     _root_.dotProduct_smul, _root_.dotProduct_add, smul_eq_mul,
     _root_.Matrix.dotProduct_transpose_mulVec]
   ring

--- a/TauCeti/LinearAlgebra/Matrix/SymmetricPart.lean
+++ b/TauCeti/LinearAlgebra/Matrix/SymmetricPart.lean
@@ -1,0 +1,84 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+import Mathlib.Analysis.InnerProductSpace.PiL2
+import Mathlib.LinearAlgebra.Matrix.BilinearForm
+import Mathlib.LinearAlgebra.Matrix.Symmetric
+import Mathlib.LinearAlgebra.QuadraticForm.Basic
+
+/-!
+# Symmetric parts of real square matrices
+
+This file records the elementary real matrix API for the symmetric part `(A + Aᵀ) / 2`.
+
+## Main declarations
+
+* `TauCeti.Matrix.symmetricPart`: the symmetric part `(A + Aᵀ) / 2` of a real square matrix.
+* `TauCeti.Matrix.symmetricPart_isSymm`: the symmetric part of any real square matrix is
+  symmetric.
+* `TauCeti.Matrix.symmetricPart_of_isSymm`: a symmetric real square matrix equals its
+  symmetric part.
+* `TauCeti.Matrix.toQuadraticForm'_symmetricPart`: taking symmetric parts preserves the
+  real quadratic form.
+-/
+
+namespace TauCeti
+
+namespace Matrix
+
+open scoped Matrix
+
+variable {n : Type*} [Fintype n] [DecidableEq n]
+
+/-- Mathlib's matrix quadratic form is the dot-product expression `ξᵀ A ξ`. -/
+lemma toQuadraticForm'_eq_dotProduct (A : _root_.Matrix n n ℝ) (ξ : EuclideanSpace ℝ n) :
+    A.toQuadraticForm' ξ = ξ ⬝ᵥ A.mulVec ξ := by
+  rw [_root_.Matrix.toQuadraticForm',
+    LinearMap.BilinMap.toQuadraticMap_apply, _root_.Matrix.toLinearMap₂'_apply']
+
+/-- Transposition does not change the quadratic form associated to a real matrix. -/
+@[simp]
+lemma toQuadraticForm'_transpose (A : _root_.Matrix n n ℝ) (ξ : EuclideanSpace ℝ n) :
+    A.transpose.toQuadraticForm' ξ = A.toQuadraticForm' ξ := by
+  rw [toQuadraticForm'_eq_dotProduct, toQuadraticForm'_eq_dotProduct,
+    _root_.Matrix.dotProduct_transpose_mulVec]
+
+/-- Matrix quadratic forms are linear in scalar multiplication of the coefficient matrix. -/
+@[simp]
+lemma toQuadraticForm'_smul (c : ℝ) (A : _root_.Matrix n n ℝ) (ξ : EuclideanSpace ℝ n) :
+    (c • A).toQuadraticForm' ξ = c * A.toQuadraticForm' ξ := by
+  rw [toQuadraticForm'_eq_dotProduct, toQuadraticForm'_eq_dotProduct,
+    _root_.Matrix.smul_mulVec, _root_.dotProduct_smul]
+  simp [smul_eq_mul]
+
+/-- The symmetric part `(A + Aᵀ) / 2` of a real square matrix. -/
+noncomputable def symmetricPart (A : _root_.Matrix n n ℝ) : _root_.Matrix n n ℝ :=
+  (2⁻¹ : ℝ) • (A + A.transpose)
+
+omit [Fintype n] [DecidableEq n] in
+/-- The symmetric part of a matrix is symmetric. -/
+lemma symmetricPart_isSymm (A : _root_.Matrix n n ℝ) : (symmetricPart A).IsSymm :=
+  (_root_.Matrix.isSymm_add_transpose_self A).smul _
+
+omit [Fintype n] [DecidableEq n] in
+/-- A symmetric matrix is equal to its symmetric part. -/
+lemma symmetricPart_of_isSymm {A : _root_.Matrix n n ℝ} (hA : A.IsSymm) :
+    symmetricPart A = A := by
+  ext i j
+  simp [symmetricPart, hA.eq]
+  ring
+
+/-- The symmetric part has the same quadratic form as the original matrix. -/
+@[simp]
+lemma toQuadraticForm'_symmetricPart (A : _root_.Matrix n n ℝ) (ξ : EuclideanSpace ℝ n) :
+    (symmetricPart A).toQuadraticForm' ξ = A.toQuadraticForm' ξ := by
+  rw [toQuadraticForm'_eq_dotProduct, toQuadraticForm'_eq_dotProduct]
+  simp only [symmetricPart, _root_.Matrix.smul_mulVec, _root_.Matrix.add_mulVec,
+    _root_.dotProduct_smul, _root_.dotProduct_add, smul_eq_mul,
+    _root_.Matrix.dotProduct_transpose_mulVec]
+  ring
+
+end Matrix
+
+end TauCeti

--- a/TauCeti/LinearAlgebra/Matrix/SymmetricPart.lean
+++ b/TauCeti/LinearAlgebra/Matrix/SymmetricPart.lean
@@ -15,7 +15,7 @@ This file records the elementary real matrix API for the symmetric part `(A + A�
 ## Main declarations
 
 * `TauCeti.Matrix.symmetricPart`: the symmetric part `(A + Aᵀ) / 2` of a real square matrix.
-* `TauCeti.Matrix.symmetricPart_isSymm`: the symmetric part of any real square matrix is
+* `TauCeti.Matrix.isSymm_symmetricPart`: the symmetric part of any real square matrix is
   symmetric.
 * `TauCeti.Matrix.symmetricPart_of_isSymm`: a symmetric real square matrix equals its
   symmetric part.
@@ -58,7 +58,8 @@ noncomputable def symmetricPart (A : _root_.Matrix n n ℝ) : _root_.Matrix n n 
 
 omit [Fintype n] [DecidableEq n] in
 /-- The symmetric part of a matrix is symmetric. -/
-lemma symmetricPart_isSymm (A : _root_.Matrix n n ℝ) : (symmetricPart A).IsSymm :=
+@[simp]
+lemma isSymm_symmetricPart (A : _root_.Matrix n n ℝ) : (symmetricPart A).IsSymm :=
   (_root_.Matrix.isSymm_add_transpose_self A).smul _
 
 omit [Fintype n] [DecidableEq n] in

--- a/TauCeti/LinearAlgebra/Matrix/SymmetricPart.lean
+++ b/TauCeti/LinearAlgebra/Matrix/SymmetricPart.lean
@@ -6,18 +6,19 @@ import Mathlib.LinearAlgebra.Matrix.Symmetric
 import TauCeti.LinearAlgebra.Matrix.QuadraticForm
 
 /-!
-# Symmetric parts of real square matrices
+# Symmetric parts of square matrices
 
-This file records the elementary real matrix API for the symmetric part `(A + Aᵀ) / 2`.
+This file records elementary matrix API for the symmetric part `(A + Aᵀ) / 2` over a
+commutative ring where `2` is invertible.
 
 ## Main declarations
 
-* `TauCeti.Matrix.symmetricPart`: the symmetric part `(A + Aᵀ) / 2` of a real square matrix.
+* `TauCeti.Matrix.symmetricPart`: the symmetric part `(A + Aᵀ) / 2` of a square matrix.
 * `TauCeti.Matrix.symmetricPart_def`: the defining formula for the symmetric part.
-* `TauCeti.Matrix.isSymm_symmetricPart`: the symmetric part of any real square matrix is
-  symmetric.
-* `TauCeti.Matrix.symmetricPart_of_isSymm`: a symmetric real square matrix equals its
-  symmetric part.
+* `TauCeti.Matrix.isSymm_symmetricPart`: the symmetric part of any square matrix is symmetric.
+* `TauCeti.Matrix.symmetricPart_of_isSymm`: a symmetric square matrix equals its symmetric part.
+* `TauCeti.Matrix.toBilin'_symmetricPart`: the bilinear form of the symmetric part is the
+  bilinear form associated to the original matrix's quadratic form.
 * `TauCeti.Matrix.symmetricPart_eq_toMatrix'_toQuadraticForm'`: the symmetric part is
   Mathlib's associated matrix of the quadratic form attached to `A`.
 * `TauCeti.Matrix.toQuadraticForm'_symmetricPart`: taking symmetric parts preserves the
@@ -30,62 +31,64 @@ namespace Matrix
 
 open scoped Matrix
 
-variable {n : Type*} [Fintype n] [DecidableEq n]
+variable {n R : Type*} [Fintype n] [DecidableEq n] [CommRing R] [Invertible (2 : R)]
 
-/-- The symmetric part `(A + Aᵀ) / 2` of a real square matrix. -/
-noncomputable def symmetricPart (A : _root_.Matrix n n ℝ) : _root_.Matrix n n ℝ :=
-  (2⁻¹ : ℝ) • (A + A.transpose)
+/-- The symmetric part `(A + Aᵀ) / 2` of a square matrix. -/
+noncomputable def symmetricPart (A : _root_.Matrix n n R) : _root_.Matrix n n R :=
+  ⅟(2 : R) • (A + A.transpose)
 
 omit [Fintype n] [DecidableEq n] in
 /-- Characteristic formula for the symmetric part of a matrix. -/
 @[simp]
-lemma symmetricPart_def (A : _root_.Matrix n n ℝ) :
-    symmetricPart A = (2⁻¹ : ℝ) • (A + A.transpose) :=
+lemma symmetricPart_def (A : _root_.Matrix n n R) :
+    symmetricPart A = ⅟(2 : R) • (A + A.transpose) :=
   rfl
 
 omit [Fintype n] [DecidableEq n] in
 /-- The symmetric part of a matrix is symmetric. -/
 @[simp]
-lemma isSymm_symmetricPart (A : _root_.Matrix n n ℝ) : (symmetricPart A).IsSymm :=
+lemma isSymm_symmetricPart (A : _root_.Matrix n n R) : (symmetricPart A).IsSymm :=
   (_root_.Matrix.isSymm_add_transpose_self A).smul _
 
 omit [Fintype n] [DecidableEq n] in
 /-- A symmetric matrix is equal to its symmetric part. -/
 @[simp]
-lemma symmetricPart_of_isSymm {A : _root_.Matrix n n ℝ} (hA : A.IsSymm) :
+lemma symmetricPart_of_isSymm {A : _root_.Matrix n n R} (hA : A.IsSymm) :
     symmetricPart A = A := by
   ext i j
-  simp [hA.eq]
-  ring
+  change ⅟(2 : R) * (A i j + A j i) = A i j
+  rw [hA.apply]
+  rw [← two_mul, ← mul_assoc, invOf_mul_self, one_mul]
 
-/-- The symmetric part is Mathlib's associated matrix of the quadratic form attached to `A`. -/
-lemma symmetricPart_eq_toMatrix'_toQuadraticForm' (A : _root_.Matrix n n ℝ) :
-    symmetricPart A = A.toQuadraticForm'.toMatrix' := by
-  apply (_root_.Matrix.toBilin' : _root_.Matrix n n ℝ ≃ₗ[ℝ] _).injective
-  rw [_root_.QuadraticForm.toMatrix']
-  change _root_.Matrix.toBilin' (symmetricPart A) =
-    _root_.Matrix.toBilin' (_root_.LinearMap.BilinForm.toMatrix' A.toQuadraticForm'.associated)
-  rw [_root_.Matrix.toBilin'_toMatrix']
+/-- The bilinear form of the symmetric part is the associated bilinear form of the quadratic
+form attached to the original matrix. -/
+lemma toBilin'_symmetricPart (A : _root_.Matrix n n R) :
+    _root_.Matrix.toBilin' (symmetricPart A) = A.toQuadraticForm'.associated := by
   apply LinearMap.ext
   intro v
   apply LinearMap.ext
   intro w
-  change _root_.Matrix.toBilin' (symmetricPart A) v w = A.toQuadraticForm'.associated v w
   rw [symmetricPart_def, _root_.Matrix.toQuadraticForm',
     _root_.QuadraticMap.associated_toQuadraticMap]
   rw [_root_.Matrix.toBilin'_apply', _root_.Matrix.smul_mulVec, _root_.Matrix.add_mulVec,
     _root_.dotProduct_smul, _root_.dotProduct_add,
     _root_.Matrix.dotProduct_transpose_mulVec, _root_.Matrix.toLinearMap₂'_apply',
     _root_.Matrix.toLinearMap₂'_apply']
-  simp [smul_eq_mul, invOf_eq_inv]
-  ring_nf
+  rfl
+
+/-- The symmetric part is Mathlib's associated matrix of the quadratic form attached to `A`. -/
+lemma symmetricPart_eq_toMatrix'_toQuadraticForm' (A : _root_.Matrix n n R) :
+    symmetricPart A = A.toQuadraticForm'.toMatrix' := by
+  apply (_root_.Matrix.toBilin' : _root_.Matrix n n R ≃ₗ[R] _).injective
+  rw [toBilin'_symmetricPart]
+  exact (_root_.Matrix.toLinearMap₂'_toMatrix' A.toQuadraticForm'.associated).symm
 
 /-- The symmetric part has the same quadratic form as the original matrix. -/
 @[simp]
 lemma toQuadraticForm'_symmetricPart (A : _root_.Matrix n n ℝ) (ξ : EuclideanSpace ℝ n) :
     (symmetricPart A).toQuadraticForm' ξ = A.toQuadraticForm' ξ := by
   rw [toQuadraticForm'_eq_dotProduct, toQuadraticForm'_eq_dotProduct]
-  simp only [symmetricPart_def, _root_.Matrix.smul_mulVec, _root_.Matrix.add_mulVec,
+  simp only [symmetricPart_def, invOf_eq_inv, _root_.Matrix.smul_mulVec, _root_.Matrix.add_mulVec,
     _root_.dotProduct_smul, _root_.dotProduct_add, smul_eq_mul,
     _root_.Matrix.dotProduct_transpose_mulVec]
   ring


### PR DESCRIPTION
This PR adds transpose and symmetric-part stability API for uniformly elliptic divergence-form coefficient fields, advancing the PDE roadmap target in `TauCetiRoadmap/PDE/README.md` Lane D.16-D.17: Gårding/energy-form estimates and coercive weak-solution existence via Lax-Milgram. The new lemmas keep the roadmap's explicit constants `0 < λ ≤ Λ` visible for adjoint coefficients and for the symmetric part `(A + Aᵀ) / 2`, which are prerequisites for weak-form boundedness, coercivity, and later Fredholm/adjoint arguments.

No Mathlib infrastructure is vendored. This reuses Mathlib's matrix transpose dot-product identities, `Matrix.IsSymm`, continuous bilinear maps, and `IsCoercive`/operator-norm infrastructure already consumed by `TauCeti.Analysis.PDE.UniformEllipticity`.

Verified with `lake exe cache get`, `lake build`, and `lake exe axioms`.

🤖 Prepared with Codex