### PR TITLE
feat: add normalizer quotient orbit action

### DIFF
--- a/TauCeti.lean
+++ b/TauCeti.lean
@@ -14,6 +14,7 @@ import TauCeti.AlgebraicTopology.UniversalCover.Deck.Connected
 import TauCeti.AlgebraicTopology.UniversalCover.Deck.Fiber
 import TauCeti.AlgebraicTopology.UniversalCover.Deck.FiberOrbit
 import TauCeti.AlgebraicTopology.UniversalCover.Deck.FiberTransport
+import TauCeti.AlgebraicTopology.UniversalCover.Deck.NormalizerQuotient
 import TauCeti.AlgebraicTopology.UniversalCover.Deck.Quotient
 import TauCeti.AlgebraicTopology.UniversalCover.Deck.Regular
 import TauCeti.Analysis.PDE.UniformEllipticity

--- a/TauCeti.lean
+++ b/TauCeti.lean
@@ -14,8 +14,8 @@ import TauCeti.AlgebraicTopology.UniversalCover.Deck.Connected
 import TauCeti.AlgebraicTopology.UniversalCover.Deck.Fiber
 import TauCeti.AlgebraicTopology.UniversalCover.Deck.FiberOrbit
 import TauCeti.AlgebraicTopology.UniversalCover.Deck.FiberTransport
-import TauCeti.AlgebraicTopology.UniversalCover.Deck.NormalizerQuotient
 import TauCeti.AlgebraicTopology.UniversalCover.Deck.Quotient
 import TauCeti.AlgebraicTopology.UniversalCover.Deck.Regular
 import TauCeti.Analysis.PDE.UniformEllipticity
 import TauCeti.Basic
+import TauCeti.GroupTheory.GroupAction.NormalizerQuotient

--- a/TauCeti/AlgebraicTopology/UniversalCover/Deck/NormalizerQuotient.lean
+++ b/TauCeti/AlgebraicTopology/UniversalCover/Deck/NormalizerQuotient.lean
@@ -1,0 +1,135 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+import Mathlib.GroupTheory.QuotientGroup.Basic
+
+/-!
+# Normalizer actions on subgroup-orbit quotients
+
+Let a group `G` act on a type `X`, and let `H ≤ G`. The normalizer `N_G(H)` acts on the
+orbit quotient `X / H`: a normalizing element sends each `H`-orbit to another `H`-orbit.
+Moreover, the subgroup `H`, viewed inside its normalizer, acts trivially on `X / H`, so the
+action descends to an action of the quotient group `N_G(H) / H`.
+
+This is the group-action bookkeeping needed by the universal-covers roadmap before the
+deck group of the cover attached to a subgroup `H ≤ π₁(X, x₀)` is identified with
+`N(H) / H`. The file deliberately proves only the abstract orbit-quotient descent: no
+covering-space hypotheses are involved.
+
+## Main declarations
+
+* `TauCeti.Deck.SubgroupOrbitQuotient`: the quotient of `X` by the restricted action of
+  `H`.
+* `TauCeti.Deck.normalizerOrbitEquiv`: a normalizer element acts as a permutation of
+  `X / H`.
+* `TauCeti.Deck.normalizerOrbitHom`: the corresponding homomorphism
+  `N_G(H) →* Equiv.Perm (X / H)`.
+* `TauCeti.Deck.normalizerQuotientOrbitHom`: the descended homomorphism
+  `N_G(H) / H →* Equiv.Perm (X / H)`.
+
+## References
+
+This supplies a prerequisite for the Tau Ceti universal-covers roadmap, Stage 2: the
+normalizer quotient `N(H)/H` is the algebraic object that later appears as the deck group
+of the cover associated to `H`.
+-/
+
+namespace TauCeti
+
+namespace Deck
+
+variable {G X : Type*} [Group G] [MulAction G X] (H : Subgroup G)
+
+/-- The quotient of `X` by the orbit relation of the restricted action of `H`. -/
+abbrev SubgroupOrbitQuotient : Type _ :=
+  MulAction.orbitRel.Quotient H X
+
+/-- A normalizer element preserves the orbit relation of the restricted `H`-action. -/
+lemma normalizer_smul_orbitRel_iff (n : Subgroup.normalizer (H : Set G)) (x y : X) :
+    MulAction.orbitRel H X ((n : G) • x) ((n : G) • y) ↔
+      MulAction.orbitRel H X x y := by
+  rw [MulAction.orbitRel_apply, MulAction.orbitRel_apply]
+  constructor
+  · rintro ⟨h, hh⟩
+    refine ⟨⟨(n : G)⁻¹ * (h : G) * (n : G), ?_⟩, ?_⟩
+    · exact (Subgroup.mem_normalizer_iff''.mp n.2 (h : G)).mp h.2
+    · change ((n : G)⁻¹ * (h : G) * (n : G)) • y = x
+      simpa [mul_smul, MulAction.subgroup_smul_def] using
+        congrArg (fun z => ((n : G)⁻¹) • z) hh
+  · rintro ⟨h, hh⟩
+    refine ⟨⟨(n : G) * (h : G) * (n : G)⁻¹, ?_⟩, ?_⟩
+    · exact (Subgroup.mem_normalizer_iff.mp n.2 (h : G)).mp h.2
+    · change ((n : G) * (h : G) * (n : G)⁻¹) • ((n : G) • y) = (n : G) • x
+      simpa [mul_smul, MulAction.subgroup_smul_def] using
+        congrArg (fun z => (n : G) • z) hh
+
+/-- A normalizer element acts as a permutation of the orbit quotient `X / H`. -/
+noncomputable def normalizerOrbitEquiv (n : Subgroup.normalizer (H : Set G)) :
+    SubgroupOrbitQuotient (X := X) H ≃ SubgroupOrbitQuotient (X := X) H :=
+  Quotient.congr
+    { toFun := fun x => (n : G) • x
+      invFun := fun x => ((n : G)⁻¹) • x
+      left_inv := by intro x; simp
+      right_inv := by intro x; simp }
+    fun x y => (normalizer_smul_orbitRel_iff H n x y).symm
+
+/-- On representatives, the normalizer action on the orbit quotient is the ambient action. -/
+@[simp]
+lemma normalizerOrbitEquiv_mk (n : Subgroup.normalizer (H : Set G)) (x : X) :
+    normalizerOrbitEquiv H n (Quotient.mk'' x : SubgroupOrbitQuotient (X := X) H) =
+      Quotient.mk'' ((n : G) • x) :=
+  rfl
+
+/-- The normalizer acts on the orbit quotient `X / H`. -/
+noncomputable def normalizerOrbitHom :
+    Subgroup.normalizer (H : Set G) →* Equiv.Perm (SubgroupOrbitQuotient (X := X) H) where
+  toFun := normalizerOrbitEquiv H
+  map_one' := by
+    ext q
+    induction q using Quotient.inductionOn' with
+    | h x => simp [normalizerOrbitEquiv]
+  map_mul' n m := by
+    ext q
+    induction q using Quotient.inductionOn' with
+    | h x => simp [normalizerOrbitEquiv, mul_smul]
+
+/-- On representatives, the normalizer homomorphism acts by the ambient action. -/
+@[simp]
+lemma normalizerOrbitHom_apply_mk (n : Subgroup.normalizer (H : Set G)) (x : X) :
+    normalizerOrbitHom H n (Quotient.mk'' x : SubgroupOrbitQuotient (X := X) H) =
+      Quotient.mk'' ((n : G) • x) :=
+  rfl
+
+/-- Elements of `H`, viewed as elements of its normalizer, act trivially on `X / H`. -/
+lemma subgroupOfNormalizer_le_ker_normalizerOrbitHom :
+    H.subgroupOf (Subgroup.normalizer (H : Set G)) ≤
+      MonoidHom.ker (normalizerOrbitHom (X := X) H) := by
+  intro h hh
+  ext q
+  induction q using Quotient.inductionOn' with
+  | h x =>
+      simp only [normalizerOrbitHom_apply_mk, Equiv.Perm.coe_one, id_eq]
+      refine Quotient.sound ?_
+      exact (show MulAction.orbitRel H X ((h : G) • x) x from ⟨⟨(h : G), hh⟩, rfl⟩)
+
+/-- The action of `N_G(H)` on `X / H` descends to the quotient group `N_G(H) / H`. -/
+noncomputable def normalizerQuotientOrbitHom :
+    (Subgroup.normalizer (H : Set G) ⧸ H.subgroupOf (Subgroup.normalizer (H : Set G))) →*
+      Equiv.Perm (SubgroupOrbitQuotient (X := X) H) :=
+  QuotientGroup.lift (H.subgroupOf (Subgroup.normalizer (H : Set G)))
+    (normalizerOrbitHom (X := X) H)
+    (subgroupOfNormalizer_le_ker_normalizerOrbitHom (X := X) H)
+
+/-- On representatives, the descended normalizer-quotient action is the ambient action. -/
+@[simp]
+lemma normalizerQuotientOrbitHom_mk (n : Subgroup.normalizer (H : Set G)) (x : X) :
+    normalizerQuotientOrbitHom H (QuotientGroup.mk n)
+        (Quotient.mk'' x : SubgroupOrbitQuotient (X := X) H) =
+      Quotient.mk'' ((n : G) • x) := by
+  rw [normalizerQuotientOrbitHom, QuotientGroup.lift_mk]
+  rfl
+
+end Deck
+
+end TauCeti

--- a/TauCeti/GroupTheory/GroupAction/NormalizerQuotient.lean
+++ b/TauCeti/GroupTheory/GroupAction/NormalizerQuotient.lean
@@ -166,7 +166,7 @@ noncomputable def subgroupQuotientOrbitHom (K : Subgroup G) (hHK : H ≤ K)
 
 This is a named action rather than a typeclass instance, because the containment proof
 `hHK : H ≤ K` is not inferable from the acting type `K ⧸ H.subgroupOf K`. -/
-@[reducible]
+@[implicit_reducible]
 noncomputable def subgroupQuotientMulAction (K : Subgroup G) (hHK : H ≤ K)
     [(H.subgroupOf K).Normal] :
     MulAction (K ⧸ H.subgroupOf K) (MulAction.orbitRel.Quotient H X) :=
@@ -184,6 +184,15 @@ lemma subgroupQuotientOrbitHom_mk (K : Subgroup G) (hHK : H ≤ K)
   rw [subgroupQuotientOrbitHom, QuotientGroup.lift_mk]
   rfl
 
+/-- The named subgroup-quotient action agrees with the descended permutation
+homomorphism. -/
+lemma subgroupQuotient_smul_eq_orbitHom (K : Subgroup G) (hHK : H ≤ K)
+    [(H.subgroupOf K).Normal] (q : K ⧸ H.subgroupOf K)
+    (x : MulAction.orbitRel.Quotient H X) :
+    letI := subgroupQuotientMulAction (X := X) H K hHK
+    q • x = subgroupQuotientOrbitHom H K hHK q x := by
+  rfl
+
 /-- On representatives, the descended subgroup-quotient action is the ambient action. -/
 @[simp]
 lemma subgroupQuotient_smul_mk (K : Subgroup G) (hHK : H ≤ K)
@@ -192,7 +201,7 @@ lemma subgroupQuotient_smul_mk (K : Subgroup G) (hHK : H ≤ K)
     (QuotientGroup.mk k : K ⧸ H.subgroupOf K) •
         (Quotient.mk'' x : MulAction.orbitRel.Quotient H X) =
       Quotient.mk'' ((k : G) • x) := by
-  rw [subgroupQuotientMulAction]
+  rw [subgroupQuotient_smul_eq_orbitHom]
   exact subgroupQuotientOrbitHom_mk H K hHK k x
 
 /-- The action of `N_G(H)` on `X / H` descends to the quotient group `N_G(H) / H`. -/

--- a/TauCeti/GroupTheory/GroupAction/NormalizerQuotient.lean
+++ b/TauCeti/GroupTheory/GroupAction/NormalizerQuotient.lean
@@ -184,6 +184,17 @@ lemma subgroupQuotientOrbitHom_mk (K : Subgroup G) (hHK : H ≤ K)
   rw [subgroupQuotientOrbitHom, QuotientGroup.lift_mk]
   rfl
 
+/-- On representatives, the descended subgroup-quotient action is the ambient action. -/
+@[simp]
+lemma subgroupQuotient_smul_mk (K : Subgroup G) (hHK : H ≤ K)
+    [(H.subgroupOf K).Normal] (k : K) (x : X) :
+    letI := subgroupQuotientMulAction (X := X) H K hHK
+    (QuotientGroup.mk k : K ⧸ H.subgroupOf K) •
+        (Quotient.mk'' x : MulAction.orbitRel.Quotient H X) =
+      Quotient.mk'' ((k : G) • x) := by
+  rw [subgroupQuotientMulAction]
+  exact subgroupQuotientOrbitHom_mk H K hHK k x
+
 /-- The action of `N_G(H)` on `X / H` descends to the quotient group `N_G(H) / H`. -/
 noncomputable def normalizerQuotientOrbitHom :
     (Subgroup.normalizer (H : Set G) ⧸ H.subgroupOf (Subgroup.normalizer (H : Set G))) →*
@@ -218,7 +229,6 @@ lemma normalizerQuotient_smul_mk (n : Subgroup.normalizer (H : Set G)) (x : X) :
         Subgroup.normalizer (H : Set G) ⧸ H.subgroupOf (Subgroup.normalizer (H : Set G))) •
         (Quotient.mk'' x : MulAction.orbitRel.Quotient H X) =
       Quotient.mk'' ((n : G) • x) := by
-  rw [normalizerQuotient_smul_eq_orbitHom]
-  exact normalizerQuotientOrbitHom_mk H n x
+  exact subgroupQuotient_smul_mk H (Subgroup.normalizer (H : Set G)) H.le_normalizer n x
 
 end TauCeti

--- a/TauCeti/GroupTheory/GroupAction/NormalizerQuotient.lean
+++ b/TauCeti/GroupTheory/GroupAction/NormalizerQuotient.lean
@@ -217,7 +217,9 @@ noncomputable instance normalizerQuotientMulAction :
       (MulAction.orbitRel.Quotient H X) :=
   subgroupQuotientMulAction (X := X) H (Subgroup.normalizer (H : Set G)) H.le_normalizer
 
-private lemma normalizerQuotient_smul_eq_orbitHom
+/-- The normalizer-quotient action agrees with the descended permutation homomorphism. -/
+@[simp]
+lemma normalizerQuotient_smul_eq_orbitHom
     (q : Subgroup.normalizer (H : Set G) ⧸ H.subgroupOf (Subgroup.normalizer (H : Set G)))
     (x : MulAction.orbitRel.Quotient H X) :
     q • x = normalizerQuotientOrbitHom H q x := by

--- a/TauCeti/GroupTheory/GroupAction/NormalizerQuotient.lean
+++ b/TauCeti/GroupTheory/GroupAction/NormalizerQuotient.lean
@@ -11,8 +11,9 @@ import Mathlib.GroupTheory.QuotientGroup.Defs
 
 Let a group `G` act on a type `X`, and let `H ≤ G`. The normalizer `N_G(H)` acts on the
 orbit quotient `X / H`: a normalizing element sends each `H`-orbit to another `H`-orbit.
-Moreover, the subgroup `H`, viewed inside its normalizer, acts trivially on `X / H`, so the
-action descends to an action of the quotient group `N_G(H) / H`.
+More generally, if `H ≤ K` and `H` is normal as a subgroup of `K`, then this normalizer
+action restricts to `K` and descends to an action of `K / H` on `X / H`. Specializing to
+`K = N_G(H)` gives the normalizer-quotient action.
 
 This is the group-action bookkeeping needed by the universal-covers roadmap before the
 deck group of the cover attached to a subgroup `H ≤ π₁(X, x₀)` is identified with
@@ -25,6 +26,9 @@ covering-space hypotheses are involved.
   `X / H`.
 * `TauCeti.normalizerOrbitHom`: the corresponding homomorphism
   `N_G(H) →* Equiv.Perm (X / H)`.
+* `TauCeti.subgroupQuotientOrbitHom`: for `H ≤ K` and `H ⫳ K`, the descended homomorphism
+  `K / H →* Equiv.Perm (X / H)`.
+* `TauCeti.subgroupQuotientMulAction`: the descended action of `K / H` on `X / H`.
 * `TauCeti.normalizerQuotientOrbitHom`: the descended homomorphism
   `N_G(H) / H →* Equiv.Perm (X / H)`.
 * `TauCeti.normalizerQuotientMulAction`: the descended action of `N_G(H) / H` on
@@ -113,22 +117,85 @@ lemma subgroupOfNormalizer_le_ker_normalizerOrbitHom :
       refine Quotient.sound ?_
       exact ⟨⟨(h : G), hh⟩, rfl⟩
 
+/-- If `H` is normal in `K`, then `K` acts on the orbit quotient `X / H`. -/
+noncomputable def subgroupOrbitHom (K : Subgroup G) (hHK : H ≤ K) [(H.subgroupOf K).Normal] :
+    K →* Equiv.Perm (MulAction.orbitRel.Quotient H X) where
+  toFun k :=
+    normalizerOrbitHom (X := X) H
+      ⟨(k : G), Subgroup.le_normalizer_of_normal_subgroupOf hHK k.2⟩
+  map_one' := by
+    ext q
+    induction q using Quotient.inductionOn' with
+    | h x => simp
+  map_mul' k l := by
+    ext q
+    induction q using Quotient.inductionOn' with
+    | h x => simp [mul_smul]
+
+/-- On representatives, the restricted subgroup action on the orbit quotient is the ambient
+action. -/
+@[simp]
+lemma subgroupOrbitHom_apply_mk (K : Subgroup G) (hHK : H ≤ K) [(H.subgroupOf K).Normal]
+    (k : K) (x : X) :
+    subgroupOrbitHom (X := X) H K hHK k
+        (Quotient.mk'' x : MulAction.orbitRel.Quotient H X) =
+      Quotient.mk'' ((k : G) • x) :=
+  rfl
+
+/-- Elements of `H`, viewed as elements of `K`, act trivially on `X / H`. -/
+lemma subgroupOf_le_ker_subgroupOrbitHom (K : Subgroup G) (hHK : H ≤ K)
+    [(H.subgroupOf K).Normal] :
+    H.subgroupOf K ≤ MonoidHom.ker (subgroupOrbitHom (X := X) H K hHK) := by
+  intro h hh
+  ext q
+  induction q using Quotient.inductionOn' with
+  | h x =>
+      simp only [Equiv.Perm.coe_one, id_eq]
+      refine Quotient.sound ?_
+      exact ⟨⟨(h : G), hh⟩, rfl⟩
+
+/-- The action of `K` on `X / H` descends to `K / H` when `H` is normal in `K`. -/
+noncomputable def subgroupQuotientOrbitHom (K : Subgroup G) (hHK : H ≤ K)
+    [(H.subgroupOf K).Normal] :
+    (K ⧸ H.subgroupOf K) →* Equiv.Perm (MulAction.orbitRel.Quotient H X) :=
+  QuotientGroup.lift (H.subgroupOf K)
+    (subgroupOrbitHom (X := X) H K hHK)
+    (subgroupOf_le_ker_subgroupOrbitHom (X := X) H K hHK)
+
+/-- The descended action of `K / H` on the subgroup-orbit quotient `X / H`, when `H ⫳ K`.
+
+This is a named action rather than a typeclass instance, because the containment proof
+`hHK : H ≤ K` is not inferable from the acting type `K ⧸ H.subgroupOf K`. -/
+@[reducible]
+noncomputable def subgroupQuotientMulAction (K : Subgroup G) (hHK : H ≤ K)
+    [(H.subgroupOf K).Normal] :
+    MulAction (K ⧸ H.subgroupOf K) (MulAction.orbitRel.Quotient H X) :=
+  MulAction.ofEndHom <|
+    (MulAction.toEndHom (M := Equiv.Perm (MulAction.orbitRel.Quotient H X))).comp
+      (subgroupQuotientOrbitHom (X := X) H K hHK)
+
+/-- On representatives, the descended subgroup-quotient action is the ambient action. -/
+@[simp]
+lemma subgroupQuotientOrbitHom_mk (K : Subgroup G) (hHK : H ≤ K)
+    [(H.subgroupOf K).Normal] (k : K) (x : X) :
+    subgroupQuotientOrbitHom H K hHK (QuotientGroup.mk k)
+        (Quotient.mk'' x : MulAction.orbitRel.Quotient H X) =
+      Quotient.mk'' ((k : G) • x) := by
+  rw [subgroupQuotientOrbitHom, QuotientGroup.lift_mk]
+  rfl
+
 /-- The action of `N_G(H)` on `X / H` descends to the quotient group `N_G(H) / H`. -/
 noncomputable def normalizerQuotientOrbitHom :
     (Subgroup.normalizer (H : Set G) ⧸ H.subgroupOf (Subgroup.normalizer (H : Set G))) →*
       Equiv.Perm (MulAction.orbitRel.Quotient H X) :=
-  QuotientGroup.lift (H.subgroupOf (Subgroup.normalizer (H : Set G)))
-    (normalizerOrbitHom (X := X) H)
-    (subgroupOfNormalizer_le_ker_normalizerOrbitHom (X := X) H)
+  subgroupQuotientOrbitHom (X := X) H (Subgroup.normalizer (H : Set G)) H.le_normalizer
 
 /-- The descended action of `N_G(H) / H` on the subgroup-orbit quotient `X / H`. -/
 noncomputable instance normalizerQuotientMulAction :
     MulAction
       (Subgroup.normalizer (H : Set G) ⧸ H.subgroupOf (Subgroup.normalizer (H : Set G)))
       (MulAction.orbitRel.Quotient H X) :=
-  MulAction.ofEndHom <|
-    (MulAction.toEndHom (M := Equiv.Perm (MulAction.orbitRel.Quotient H X))).comp
-      (normalizerQuotientOrbitHom (X := X) H)
+  subgroupQuotientMulAction (X := X) H (Subgroup.normalizer (H : Set G)) H.le_normalizer
 
 private lemma normalizerQuotient_smul_eq_orbitHom
     (q : Subgroup.normalizer (H : Set G) ⧸ H.subgroupOf (Subgroup.normalizer (H : Set G)))
@@ -142,8 +209,7 @@ lemma normalizerQuotientOrbitHom_mk (n : Subgroup.normalizer (H : Set G)) (x : X
     normalizerQuotientOrbitHom H (QuotientGroup.mk n)
         (Quotient.mk'' x : MulAction.orbitRel.Quotient H X) =
       Quotient.mk'' ((n : G) • x) := by
-  rw [normalizerQuotientOrbitHom, QuotientGroup.lift_mk]
-  rfl
+  exact subgroupQuotientOrbitHom_mk H (Subgroup.normalizer (H : Set G)) H.le_normalizer n x
 
 /-- On representatives, the descended normalizer-quotient action is the ambient action. -/
 @[simp]

--- a/TauCeti/GroupTheory/GroupAction/NormalizerQuotient.lean
+++ b/TauCeti/GroupTheory/GroupAction/NormalizerQuotient.lean
@@ -2,8 +2,9 @@
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 -/
+import Mathlib.Algebra.Group.Subgroup.Basic
 import Mathlib.GroupTheory.GroupAction.Basic
-import Mathlib.GroupTheory.QuotientGroup.Basic
+import Mathlib.GroupTheory.QuotientGroup.Defs
 
 /-!
 # Normalizer actions on orbit quotients
@@ -39,14 +40,6 @@ of the cover associated to `H`.
 namespace TauCeti
 
 variable {G X : Type*} [Group G] [MulAction G X] (H : Subgroup G)
-
-/-- Two quotient representatives are equal exactly when they lie in the same subgroup
-orbit. This uses the orientation of `MulAction.orbitRel_apply`: the left point is a member of
-the orbit of the right point. -/
-lemma orbitRel_quotient_mk_eq_iff (x y : X) :
-    (Quotient.mk'' x : MulAction.orbitRel.Quotient H X) = Quotient.mk'' y ↔
-      x ∈ MulAction.orbit H y := by
-  rw [Quotient.eq'', MulAction.orbitRel_apply]
 
 /-- A normalizer element preserves the orbit relation of the restricted `H`-action. -/
 lemma normalizer_smul_orbitRel_iff (n : Subgroup.normalizer (H : Set G)) (x y : X) :
@@ -137,6 +130,12 @@ noncomputable instance normalizerQuotientMulAction :
     (MulAction.toEndHom (M := Equiv.Perm (MulAction.orbitRel.Quotient H X))).comp
       (normalizerQuotientOrbitHom (X := X) H)
 
+private lemma normalizerQuotient_smul_eq_orbitHom
+    (q : Subgroup.normalizer (H : Set G) ⧸ H.subgroupOf (Subgroup.normalizer (H : Set G)))
+    (x : MulAction.orbitRel.Quotient H X) :
+    q • x = normalizerQuotientOrbitHom H q x := by
+  rfl
+
 /-- On representatives, the descended normalizer-quotient action is the ambient action. -/
 @[simp]
 lemma normalizerQuotientOrbitHom_mk (n : Subgroup.normalizer (H : Set G)) (x : X) :
@@ -153,12 +152,7 @@ lemma normalizerQuotient_smul_mk (n : Subgroup.normalizer (H : Set G)) (x : X) :
         Subgroup.normalizer (H : Set G) ⧸ H.subgroupOf (Subgroup.normalizer (H : Set G))) •
         (Quotient.mk'' x : MulAction.orbitRel.Quotient H X) =
       Quotient.mk'' ((n : G) • x) := by
-  rw [show
-    (QuotientGroup.mk n :
-        Subgroup.normalizer (H : Set G) ⧸ H.subgroupOf (Subgroup.normalizer (H : Set G))) •
-        (Quotient.mk'' x : MulAction.orbitRel.Quotient H X) =
-      normalizerQuotientOrbitHom H (QuotientGroup.mk n)
-        (Quotient.mk'' x : MulAction.orbitRel.Quotient H X) from rfl]
+  rw [normalizerQuotient_smul_eq_orbitHom]
   exact normalizerQuotientOrbitHom_mk H n x
 
 end TauCeti

--- a/TauCeti/GroupTheory/GroupAction/NormalizerQuotient.lean
+++ b/TauCeti/GroupTheory/GroupAction/NormalizerQuotient.lean
@@ -5,7 +5,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 import Mathlib.GroupTheory.QuotientGroup.Basic
 
 /-!
-# Normalizer actions on subgroup-orbit quotients
+# Normalizer actions on orbit quotients
 
 Let a group `G` act on a type `X`, and let `H ≤ G`. The normalizer `N_G(H)` acts on the
 orbit quotient `X / H`: a normalizing element sends each `H`-orbit to another `H`-orbit.
@@ -19,14 +19,15 @@ covering-space hypotheses are involved.
 
 ## Main declarations
 
-* `TauCeti.Deck.SubgroupOrbitQuotient`: the quotient of `X` by the restricted action of
-  `H`.
-* `TauCeti.Deck.normalizerOrbitEquiv`: a normalizer element acts as a permutation of
+* `TauCeti.subgroupOrbitClass`: the quotient map from `X` to its `H`-orbit quotient.
+* `TauCeti.normalizerOrbitEquiv`: a normalizer element acts as a permutation of
   `X / H`.
-* `TauCeti.Deck.normalizerOrbitHom`: the corresponding homomorphism
+* `TauCeti.normalizerOrbitHom`: the corresponding homomorphism
   `N_G(H) →* Equiv.Perm (X / H)`.
-* `TauCeti.Deck.normalizerQuotientOrbitHom`: the descended homomorphism
+* `TauCeti.normalizerQuotientOrbitHom`: the descended homomorphism
   `N_G(H) / H →* Equiv.Perm (X / H)`.
+* `TauCeti.normalizerQuotientMulAction`: the descended action of `N_G(H) / H` on
+  `X / H`.
 
 ## References
 
@@ -37,13 +38,25 @@ of the cover associated to `H`.
 
 namespace TauCeti
 
-namespace Deck
-
 variable {G X : Type*} [Group G] [MulAction G X] (H : Subgroup G)
 
-/-- The quotient of `X` by the orbit relation of the restricted action of `H`. -/
-abbrev SubgroupOrbitQuotient : Type _ :=
-  MulAction.orbitRel.Quotient H X
+/-- The orbit class of a point under the restricted action of a subgroup. -/
+def subgroupOrbitClass (x : X) : MulAction.orbitRel.Quotient H X :=
+  Quotient.mk'' x
+
+/-- The subgroup-orbit quotient map sends a point to its own class. -/
+@[simp]
+lemma subgroupOrbitClass_eq_mk (x : X) :
+    subgroupOrbitClass H x = (Quotient.mk'' x : MulAction.orbitRel.Quotient H X) :=
+  rfl
+
+/-- Two points have the same subgroup-orbit class exactly when they lie in the same subgroup
+orbit. This uses the orientation of `MulAction.orbitRel_apply`: the left point is a member of
+the orbit of the right point. -/
+lemma subgroupOrbitClass_eq_iff (x y : X) :
+    subgroupOrbitClass H x = subgroupOrbitClass H y ↔ x ∈ MulAction.orbit H y := by
+  rw [subgroupOrbitClass_eq_mk, subgroupOrbitClass_eq_mk, Quotient.eq'',
+    MulAction.orbitRel_apply]
 
 /-- A normalizer element preserves the orbit relation of the restricted `H`-action. -/
 lemma normalizer_smul_orbitRel_iff (n : Subgroup.normalizer (H : Set G)) (x y : X) :
@@ -54,19 +67,23 @@ lemma normalizer_smul_orbitRel_iff (n : Subgroup.normalizer (H : Set G)) (x y : 
   · rintro ⟨h, hh⟩
     refine ⟨⟨(n : G)⁻¹ * (h : G) * (n : G), ?_⟩, ?_⟩
     · exact (Subgroup.mem_normalizer_iff''.mp n.2 (h : G)).mp h.2
-    · change ((n : G)⁻¹ * (h : G) * (n : G)) • y = x
+    · -- The orbit witness lives in the subgroup action; expose the ambient `G` action
+      -- before conjugating the equality by `n⁻¹`.
+      change ((n : G)⁻¹ * (h : G) * (n : G)) • y = x
       simpa [mul_smul, MulAction.subgroup_smul_def] using
         congrArg (fun z => ((n : G)⁻¹) • z) hh
   · rintro ⟨h, hh⟩
     refine ⟨⟨(n : G) * (h : G) * (n : G)⁻¹, ?_⟩, ?_⟩
     · exact (Subgroup.mem_normalizer_iff.mp n.2 (h : G)).mp h.2
-    · change ((n : G) * (h : G) * (n : G)⁻¹) • ((n : G) • y) = (n : G) • x
+    · -- The orbit witness lives in the subgroup action; expose the ambient `G` action
+      -- before conjugating the equality by `n`.
+      change ((n : G) * (h : G) * (n : G)⁻¹) • ((n : G) • y) = (n : G) • x
       simpa [mul_smul, MulAction.subgroup_smul_def] using
         congrArg (fun z => (n : G) • z) hh
 
 /-- A normalizer element acts as a permutation of the orbit quotient `X / H`. -/
 noncomputable def normalizerOrbitEquiv (n : Subgroup.normalizer (H : Set G)) :
-    SubgroupOrbitQuotient (X := X) H ≃ SubgroupOrbitQuotient (X := X) H :=
+    MulAction.orbitRel.Quotient H X ≃ MulAction.orbitRel.Quotient H X :=
   Quotient.congr
     { toFun := fun x => (n : G) • x
       invFun := fun x => ((n : G)⁻¹) • x
@@ -77,13 +94,13 @@ noncomputable def normalizerOrbitEquiv (n : Subgroup.normalizer (H : Set G)) :
 /-- On representatives, the normalizer action on the orbit quotient is the ambient action. -/
 @[simp]
 lemma normalizerOrbitEquiv_mk (n : Subgroup.normalizer (H : Set G)) (x : X) :
-    normalizerOrbitEquiv H n (Quotient.mk'' x : SubgroupOrbitQuotient (X := X) H) =
+    normalizerOrbitEquiv H n (subgroupOrbitClass H x) =
       Quotient.mk'' ((n : G) • x) :=
   rfl
 
 /-- The normalizer acts on the orbit quotient `X / H`. -/
 noncomputable def normalizerOrbitHom :
-    Subgroup.normalizer (H : Set G) →* Equiv.Perm (SubgroupOrbitQuotient (X := X) H) where
+    Subgroup.normalizer (H : Set G) →* Equiv.Perm (MulAction.orbitRel.Quotient H X) where
   toFun := normalizerOrbitEquiv H
   map_one' := by
     ext q
@@ -97,7 +114,7 @@ noncomputable def normalizerOrbitHom :
 /-- On representatives, the normalizer homomorphism acts by the ambient action. -/
 @[simp]
 lemma normalizerOrbitHom_apply_mk (n : Subgroup.normalizer (H : Set G)) (x : X) :
-    normalizerOrbitHom H n (Quotient.mk'' x : SubgroupOrbitQuotient (X := X) H) =
+    normalizerOrbitHom H n (subgroupOrbitClass H x) =
       Quotient.mk'' ((n : G) • x) :=
   rfl
 
@@ -109,27 +126,43 @@ lemma subgroupOfNormalizer_le_ker_normalizerOrbitHom :
   ext q
   induction q using Quotient.inductionOn' with
   | h x =>
-      simp only [normalizerOrbitHom_apply_mk, Equiv.Perm.coe_one, id_eq]
+      simp only [Equiv.Perm.coe_one, id_eq]
       refine Quotient.sound ?_
-      exact (show MulAction.orbitRel H X ((h : G) • x) x from ⟨⟨(h : G), hh⟩, rfl⟩)
+      exact ⟨⟨(h : G), hh⟩, rfl⟩
 
 /-- The action of `N_G(H)` on `X / H` descends to the quotient group `N_G(H) / H`. -/
 noncomputable def normalizerQuotientOrbitHom :
     (Subgroup.normalizer (H : Set G) ⧸ H.subgroupOf (Subgroup.normalizer (H : Set G))) →*
-      Equiv.Perm (SubgroupOrbitQuotient (X := X) H) :=
+      Equiv.Perm (MulAction.orbitRel.Quotient H X) :=
   QuotientGroup.lift (H.subgroupOf (Subgroup.normalizer (H : Set G)))
     (normalizerOrbitHom (X := X) H)
     (subgroupOfNormalizer_le_ker_normalizerOrbitHom (X := X) H)
+
+/-- The descended action of `N_G(H) / H` on the subgroup-orbit quotient `X / H`. -/
+noncomputable instance normalizerQuotientMulAction :
+    MulAction
+      (Subgroup.normalizer (H : Set G) ⧸ H.subgroupOf (Subgroup.normalizer (H : Set G)))
+      (MulAction.orbitRel.Quotient H X) :=
+  MulAction.ofEndHom <|
+    (MulAction.toEndHom (M := Equiv.Perm (MulAction.orbitRel.Quotient H X))).comp
+      (normalizerQuotientOrbitHom (X := X) H)
 
 /-- On representatives, the descended normalizer-quotient action is the ambient action. -/
 @[simp]
 lemma normalizerQuotientOrbitHom_mk (n : Subgroup.normalizer (H : Set G)) (x : X) :
     normalizerQuotientOrbitHom H (QuotientGroup.mk n)
-        (Quotient.mk'' x : SubgroupOrbitQuotient (X := X) H) =
+        (subgroupOrbitClass H x) =
       Quotient.mk'' ((n : G) • x) := by
   rw [normalizerQuotientOrbitHom, QuotientGroup.lift_mk]
   rfl
 
-end Deck
+/-- On representatives, the descended normalizer-quotient action is the ambient action. -/
+@[simp]
+lemma normalizerQuotient_smul_mk (n : Subgroup.normalizer (H : Set G)) (x : X) :
+    (QuotientGroup.mk n :
+        Subgroup.normalizer (H : Set G) ⧸ H.subgroupOf (Subgroup.normalizer (H : Set G))) •
+        subgroupOrbitClass H x =
+      Quotient.mk'' ((n : G) • x) :=
+  rfl
 
 end TauCeti

--- a/TauCeti/GroupTheory/GroupAction/NormalizerQuotient.lean
+++ b/TauCeti/GroupTheory/GroupAction/NormalizerQuotient.lean
@@ -2,6 +2,7 @@
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 -/
+import Mathlib.GroupTheory.GroupAction.Basic
 import Mathlib.GroupTheory.QuotientGroup.Basic
 
 /-!
@@ -19,7 +20,6 @@ covering-space hypotheses are involved.
 
 ## Main declarations
 
-* `TauCeti.subgroupOrbitClass`: the quotient map from `X` to its `H`-orbit quotient.
 * `TauCeti.normalizerOrbitEquiv`: a normalizer element acts as a permutation of
   `X / H`.
 * `TauCeti.normalizerOrbitHom`: the corresponding homomorphism
@@ -40,23 +40,13 @@ namespace TauCeti
 
 variable {G X : Type*} [Group G] [MulAction G X] (H : Subgroup G)
 
-/-- The orbit class of a point under the restricted action of a subgroup. -/
-def subgroupOrbitClass (x : X) : MulAction.orbitRel.Quotient H X :=
-  Quotient.mk'' x
-
-/-- The subgroup-orbit quotient map sends a point to its own class. -/
-@[simp]
-lemma subgroupOrbitClass_eq_mk (x : X) :
-    subgroupOrbitClass H x = (Quotient.mk'' x : MulAction.orbitRel.Quotient H X) :=
-  rfl
-
-/-- Two points have the same subgroup-orbit class exactly when they lie in the same subgroup
+/-- Two quotient representatives are equal exactly when they lie in the same subgroup
 orbit. This uses the orientation of `MulAction.orbitRel_apply`: the left point is a member of
 the orbit of the right point. -/
-lemma subgroupOrbitClass_eq_iff (x y : X) :
-    subgroupOrbitClass H x = subgroupOrbitClass H y ↔ x ∈ MulAction.orbit H y := by
-  rw [subgroupOrbitClass_eq_mk, subgroupOrbitClass_eq_mk, Quotient.eq'',
-    MulAction.orbitRel_apply]
+lemma orbitRel_quotient_mk_eq_iff (x y : X) :
+    (Quotient.mk'' x : MulAction.orbitRel.Quotient H X) = Quotient.mk'' y ↔
+      x ∈ MulAction.orbit H y := by
+  rw [Quotient.eq'', MulAction.orbitRel_apply]
 
 /-- A normalizer element preserves the orbit relation of the restricted `H`-action. -/
 lemma normalizer_smul_orbitRel_iff (n : Subgroup.normalizer (H : Set G)) (x y : X) :
@@ -94,7 +84,7 @@ noncomputable def normalizerOrbitEquiv (n : Subgroup.normalizer (H : Set G)) :
 /-- On representatives, the normalizer action on the orbit quotient is the ambient action. -/
 @[simp]
 lemma normalizerOrbitEquiv_mk (n : Subgroup.normalizer (H : Set G)) (x : X) :
-    normalizerOrbitEquiv H n (subgroupOrbitClass H x) =
+    normalizerOrbitEquiv H n (Quotient.mk'' x : MulAction.orbitRel.Quotient H X) =
       Quotient.mk'' ((n : G) • x) :=
   rfl
 
@@ -114,7 +104,7 @@ noncomputable def normalizerOrbitHom :
 /-- On representatives, the normalizer homomorphism acts by the ambient action. -/
 @[simp]
 lemma normalizerOrbitHom_apply_mk (n : Subgroup.normalizer (H : Set G)) (x : X) :
-    normalizerOrbitHom H n (subgroupOrbitClass H x) =
+    normalizerOrbitHom H n (Quotient.mk'' x : MulAction.orbitRel.Quotient H X) =
       Quotient.mk'' ((n : G) • x) :=
   rfl
 
@@ -151,7 +141,7 @@ noncomputable instance normalizerQuotientMulAction :
 @[simp]
 lemma normalizerQuotientOrbitHom_mk (n : Subgroup.normalizer (H : Set G)) (x : X) :
     normalizerQuotientOrbitHom H (QuotientGroup.mk n)
-        (subgroupOrbitClass H x) =
+        (Quotient.mk'' x : MulAction.orbitRel.Quotient H X) =
       Quotient.mk'' ((n : G) • x) := by
   rw [normalizerQuotientOrbitHom, QuotientGroup.lift_mk]
   rfl
@@ -161,8 +151,14 @@ lemma normalizerQuotientOrbitHom_mk (n : Subgroup.normalizer (H : Set G)) (x : X
 lemma normalizerQuotient_smul_mk (n : Subgroup.normalizer (H : Set G)) (x : X) :
     (QuotientGroup.mk n :
         Subgroup.normalizer (H : Set G) ⧸ H.subgroupOf (Subgroup.normalizer (H : Set G))) •
-        subgroupOrbitClass H x =
-      Quotient.mk'' ((n : G) • x) :=
-  rfl
+        (Quotient.mk'' x : MulAction.orbitRel.Quotient H X) =
+      Quotient.mk'' ((n : G) • x) := by
+  rw [show
+    (QuotientGroup.mk n :
+        Subgroup.normalizer (H : Set G) ⧸ H.subgroupOf (Subgroup.normalizer (H : Set G))) •
+        (Quotient.mk'' x : MulAction.orbitRel.Quotient H X) =
+      normalizerQuotientOrbitHom H (QuotientGroup.mk n)
+        (Quotient.mk'' x : MulAction.orbitRel.Quotient H X) from rfl]
+  exact normalizerQuotientOrbitHom_mk H n x
 
 end TauCeti


### PR DESCRIPTION
This PR adds the normalizer-quotient orbit-action bookkeeping needed for TauCetiRoadmap/UniversalCovers/README.md, Stage 2, target 8 "Galois correspondence: get the bookkeeping right", specifically the milestone that the deck group of the cover attached to `H` is `N(H)/H` and the preceding normalizer-quotient API. It packages the action of `N_G(H)` on the subgroup-orbit quotient `X / H`, proves that `H` acts trivially there, and descends the action to `N_G(H) / H`.

No Mathlib infrastructure is vendored. The construction reuses Mathlib's `MulAction.orbitRel.Quotient`, subgroup normalizer API, and `QuotientGroup.lift`.

Verified with `lake exe cache get`, `lake build`, and `lake exe axioms`.

🤖 Prepared with Codex
