### PR TITLE
feat: add lower-order PDE coefficient forms

### DIFF
--- a/TauCeti.lean
+++ b/TauCeti.lean
@@ -16,5 +16,6 @@ import TauCeti.AlgebraicTopology.UniversalCover.Deck.FiberOrbit
 import TauCeti.AlgebraicTopology.UniversalCover.Deck.FiberTransport
 import TauCeti.AlgebraicTopology.UniversalCover.Deck.Quotient
 import TauCeti.AlgebraicTopology.UniversalCover.Deck.Regular
+import TauCeti.Analysis.PDE.LowerOrder
 import TauCeti.Analysis.PDE.UniformEllipticity
 import TauCeti.Basic

--- a/TauCeti/Analysis/PDE/LowerOrder.lean
+++ b/TauCeti/Analysis/PDE/LowerOrder.lean
@@ -13,18 +13,18 @@ import Mathlib.Analysis.Normed.Operator.Mul
 The divergence-form roadmap keeps the principal elliptic coefficient, first-order drift,
 and zeroth-order mass coefficient as separate named hypotheses.  The principal matrix
 coefficient lives in `TauCeti.Analysis.PDE.UniformEllipticity`; this file records the
-pointwise bundled forms and explicit bounds for the lower-order terms
+pointwise explicit bounds for the lower-order terms
 
-* `u ↦ b(x) · ∇u`, represented here by `driftForm b`;
-* `u ↦ c(x) u`, represented in the weak form by `massForm c`.
+* `u ↦ b(x) · ∇u`, represented using
+  `ContinuousLinearMap.smulRightL ℝ (EuclideanSpace ℝ n) ℝ (innerSL ℝ (b x))`;
+* `u ↦ c(x) u`, represented in the weak form using
+  `c x • ContinuousLinearMap.mul ℝ ℝ`.
 
-These are only pointwise continuous bilinear maps.  They are the finite-dimensional
-estimates later integrated over `Ω` once the weak-derivative Sobolev spaces are available.
+These are only pointwise finite-dimensional estimates, later integrated over `Ω` once the
+weak-derivative Sobolev spaces are available.
 
 ## Main declarations
 
-* `TauCeti.PDE.driftForm`: the continuous bilinear map `(u, ξ) ↦ u * ⟪b, ξ⟫`.
-* `TauCeti.PDE.massForm`: the continuous bilinear map `(u, v) ↦ c * u * v`.
 * `TauCeti.PDE.LowerOrderBoundedOn`: explicit bounds for drift and mass coefficients on a
   domain.
 * `TauCeti.PDE.NonnegMassOn`: nonnegative bounded mass coefficients.
@@ -37,110 +37,6 @@ namespace PDE
 open scoped InnerProductSpace
 
 variable {X n : Type*} [Fintype n]
-
-/-- The pointwise first-order drift form `(u, ξ) ↦ u * ⟪b, ξ⟫`.
-
-In a weak formulation this is the integrand modelling a lower-order term such as
-`bᵢ ∂ᵢu v`, after one scalar argument represents the test function and the vector argument
-represents the gradient. -/
-noncomputable def driftForm (b : EuclideanSpace ℝ n) :
-    ℝ →L[ℝ] EuclideanSpace ℝ n →L[ℝ] ℝ :=
-  ContinuousLinearMap.smulRightL ℝ (EuclideanSpace ℝ n) ℝ (innerSL ℝ b)
-
-/-- The drift form is the expected scalar times dot-product expression. -/
-@[simp]
-lemma driftForm_apply (b : EuclideanSpace ℝ n) (u : ℝ) (ξ : EuclideanSpace ℝ n) :
-    driftForm b u ξ = u * ⟪b, ξ⟫_ℝ := by
-  simp [driftForm]
-  ring
-
-/-- The pointwise drift form is linear under scalar multiplication of the coefficient vector. -/
-@[simp]
-lemma driftForm_smul_apply (a : ℝ) (b : EuclideanSpace ℝ n) (u : ℝ)
-    (ξ : EuclideanSpace ℝ n) :
-    driftForm (a • b) u ξ = a * driftForm b u ξ := by
-  rw [driftForm_apply, driftForm_apply, real_inner_smul_left]
-  ring
-
-/-- A norm bound for the pointwise drift form in terms of the coefficient norm. -/
-lemma norm_driftForm_apply_le (b : EuclideanSpace ℝ n) (u : ℝ) (ξ : EuclideanSpace ℝ n) :
-    ‖driftForm b u ξ‖ ≤ ‖b‖ * ‖u‖ * ‖ξ‖ := by
-  rw [driftForm_apply, norm_mul]
-  calc
-    ‖u‖ * ‖⟪b, ξ⟫_ℝ‖ ≤ ‖u‖ * (‖b‖ * ‖ξ‖) := by
-      gcongr
-      exact norm_inner_le_norm b ξ
-    _ = ‖b‖ * ‖u‖ * ‖ξ‖ := by ring
-
-/-- A bound on the coefficient norm gives the corresponding pointwise drift estimate. -/
-lemma norm_driftForm_apply_le_of_norm_le {b : EuclideanSpace ℝ n} {beta : ℝ}
-    (hb : ‖b‖ ≤ beta) (u : ℝ) (ξ : EuclideanSpace ℝ n) :
-    ‖driftForm b u ξ‖ ≤ beta * ‖u‖ * ‖ξ‖ := by
-  exact (norm_driftForm_apply_le b u ξ).trans <| by
-    gcongr
-
-/-- The operator norm of the drift form is bounded by the coefficient norm. -/
-lemma opNorm_driftForm_le (b : EuclideanSpace ℝ n) :
-    ‖driftForm b‖ ≤ ‖b‖ := by
-  rw [driftForm, ContinuousLinearMap.norm_smulRightL, innerSL_apply_norm]
-
-/-- A bound on the coefficient norm bounds the operator norm of the drift form. -/
-lemma opNorm_driftForm_le_of_norm_le {b : EuclideanSpace ℝ n} {beta : ℝ}
-    (hb : ‖b‖ ≤ beta) :
-    ‖driftForm b‖ ≤ beta :=
-  (opNorm_driftForm_le b).trans hb
-
-/-- The pointwise zeroth-order mass form `(u, v) ↦ c * u * v`. -/
-noncomputable def massForm (c : ℝ) : ℝ →L[ℝ] ℝ →L[ℝ] ℝ :=
-  c • ContinuousLinearMap.mul ℝ ℝ
-
-/-- The mass form is the expected product expression. -/
-@[simp]
-lemma massForm_apply (c u v : ℝ) :
-    massForm c u v = c * u * v := by
-  simp [massForm]
-  ring
-
-/-- The zero mass coefficient gives the zero pointwise mass form. -/
-@[simp]
-lemma massForm_zero_apply (u v : ℝ) :
-    massForm 0 u v = 0 := by
-  simp [massForm_apply]
-
-/-- The mass form is additive in the coefficient. -/
-@[simp]
-lemma massForm_add_apply (c d u v : ℝ) :
-    massForm (c + d) u v = massForm c u v + massForm d u v := by
-  simp [massForm_apply]
-  ring
-
-/-- The mass form is linear under scalar multiplication of the coefficient. -/
-@[simp]
-lemma massForm_mul_apply (a c u v : ℝ) :
-    massForm (a * c) u v = a * massForm c u v := by
-  simp [massForm_apply]
-  ring
-
-/-- A norm bound for the pointwise mass form in terms of the coefficient absolute value. -/
-lemma norm_massForm_apply_le (c u v : ℝ) :
-    ‖massForm c u v‖ ≤ ‖c‖ * ‖u‖ * ‖v‖ := by
-  rw [massForm_apply, norm_mul, norm_mul, mul_assoc]
-
-/-- A bound on the coefficient absolute value gives the corresponding pointwise mass estimate. -/
-lemma norm_massForm_apply_le_of_norm_le {c gamma : ℝ} (hc : ‖c‖ ≤ gamma) (u v : ℝ) :
-    ‖massForm c u v‖ ≤ gamma * ‖u‖ * ‖v‖ := by
-  exact (norm_massForm_apply_le c u v).trans <| by
-    gcongr
-
-/-- The operator norm of the mass form is bounded by the coefficient absolute value. -/
-lemma opNorm_massForm_le (c : ℝ) :
-    ‖massForm c‖ ≤ ‖c‖ :=
-  (massForm c).opNorm_le_bound₂ (norm_nonneg c) (norm_massForm_apply_le c)
-
-/-- A bound on the coefficient absolute value bounds the operator norm of the mass form. -/
-lemma opNorm_massForm_le_of_norm_le {c gamma : ℝ} (hc : ‖c‖ ≤ gamma) :
-    ‖massForm c‖ ≤ gamma :=
-  (opNorm_massForm_le c).trans hc
 
 /-- Bounded lower-order coefficients on a domain, with explicit constants.
 
@@ -209,29 +105,53 @@ lemma of_bounds (hbeta : 0 ≤ beta) (hgamma : 0 ≤ gamma)
 @[grind =>]
 lemma norm_driftForm_le (h : LowerOrderBoundedOn Ω b c beta gamma) {x : X}
     (hx : x ∈ Ω) (u : ℝ) (ξ : EuclideanSpace ℝ n) :
-    ‖driftForm (b x) u ξ‖ ≤ beta * ‖u‖ * ‖ξ‖ :=
-  norm_driftForm_apply_le_of_norm_le (h.drift_bound hx) u ξ
+    ‖ContinuousLinearMap.smulRightL ℝ (EuclideanSpace ℝ n) ℝ (innerSL ℝ (b x)) u ξ‖ ≤
+      beta * ‖u‖ * ‖ξ‖ := by
+  rw [ContinuousLinearMap.smulRightL_apply_apply, ContinuousLinearMap.smulRight_apply,
+    innerSL_apply_apply, smul_eq_mul, norm_mul]
+  calc
+    ‖⟪b x, ξ⟫_ℝ‖ * ‖u‖ ≤ (‖b x‖ * ‖ξ‖) * ‖u‖ := by
+      gcongr
+      exact norm_inner_le_norm (b x) ξ
+    _ ≤ (beta * ‖ξ‖) * ‖u‖ := by
+      gcongr
+      exact h.drift_bound hx
+    _ = beta * ‖u‖ * ‖ξ‖ := by ring
 
 /-- Operator-norm boundedness of the drift form supplied by bounded lower-order coefficients. -/
 @[grind =>]
 lemma opNorm_driftForm_le (h : LowerOrderBoundedOn Ω b c beta gamma) {x : X}
     (hx : x ∈ Ω) :
-    ‖driftForm (b x)‖ ≤ beta :=
-  PDE.opNorm_driftForm_le_of_norm_le (h.drift_bound hx)
+    ‖ContinuousLinearMap.smulRightL ℝ (EuclideanSpace ℝ n) ℝ (innerSL ℝ (b x))‖ ≤ beta := by
+  rw [ContinuousLinearMap.norm_smulRightL, innerSL_apply_norm]
+  exact h.drift_bound hx
 
 /-- Pointwise boundedness of the mass form supplied by bounded lower-order coefficients. -/
 @[grind =>]
 lemma norm_massForm_le (h : LowerOrderBoundedOn Ω b c beta gamma) {x : X}
     (hx : x ∈ Ω) (u v : ℝ) :
-    ‖massForm (c x) u v‖ ≤ gamma * ‖u‖ * ‖v‖ :=
-  norm_massForm_apply_le_of_norm_le (h.mass_bound hx) u v
+    ‖(c x • ContinuousLinearMap.mul ℝ ℝ) u v‖ ≤ gamma * ‖u‖ * ‖v‖ := by
+  rw [ContinuousLinearMap.smul_apply, ContinuousLinearMap.smul_apply,
+    ContinuousLinearMap.mul_apply', smul_eq_mul, norm_mul, norm_mul]
+  calc
+    ‖c x‖ * (‖u‖ * ‖v‖) ≤ gamma * (‖u‖ * ‖v‖) := by
+      gcongr
+      exact h.mass_bound hx
+    _ = gamma * ‖u‖ * ‖v‖ := by ring
 
 /-- Operator-norm boundedness of the mass form supplied by bounded lower-order coefficients. -/
 @[grind =>]
 lemma opNorm_massForm_le (h : LowerOrderBoundedOn Ω b c beta gamma) {x : X}
     (hx : x ∈ Ω) :
-    ‖massForm (c x)‖ ≤ gamma :=
-  PDE.opNorm_massForm_le_of_norm_le (h.mass_bound hx)
+    ‖c x • ContinuousLinearMap.mul ℝ ℝ‖ ≤ gamma := by
+  calc
+    ‖c x • ContinuousLinearMap.mul ℝ ℝ‖ ≤ ‖c x‖ * ‖ContinuousLinearMap.mul ℝ ℝ‖ :=
+      ContinuousLinearMap.opNorm_smul_le (c x) (ContinuousLinearMap.mul ℝ ℝ)
+    _ ≤ ‖c x‖ * 1 := by
+      gcongr
+      exact ContinuousLinearMap.opNorm_mul_le ℝ ℝ
+    _ = ‖c x‖ := by ring
+    _ ≤ gamma := h.mass_bound hx
 
 end LowerOrderBoundedOn
 

--- a/TauCeti/Analysis/PDE/LowerOrder.lean
+++ b/TauCeti/Analysis/PDE/LowerOrder.lean
@@ -2,8 +2,9 @@
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 -/
-import TauCeti.Analysis.PDE.UniformEllipticity
 import Mathlib.Analysis.InnerProductSpace.LinearMap
+import Mathlib.Analysis.InnerProductSpace.PiL2
+import Mathlib.Analysis.Normed.Operator.Bilinear
 import Mathlib.Analysis.Normed.Operator.Mul
 
 /-!
@@ -26,7 +27,7 @@ estimates later integrated over `Ω` once the weak-derivative Sobolev spaces are
 * `TauCeti.PDE.massForm`: the continuous bilinear map `(u, v) ↦ c * u * v`.
 * `TauCeti.PDE.LowerOrderBoundedOn`: explicit bounds for drift and mass coefficients on a
   domain.
-* `TauCeti.PDE.NonnegativeMassOn`: nonnegative bounded mass coefficients.
+* `TauCeti.PDE.NonnegMassOn`: nonnegative bounded mass coefficients.
 -/
 
 namespace TauCeti
@@ -44,26 +45,14 @@ In a weak formulation this is the integrand modelling a lower-order term such as
 represents the gradient. -/
 noncomputable def driftForm (b : EuclideanSpace ℝ n) :
     ℝ →L[ℝ] EuclideanSpace ℝ n →L[ℝ] ℝ :=
-  LinearMap.mkContinuous₂
-    (LinearMap.mk₂ ℝ (fun u ξ => u * ⟪b, ξ⟫_ℝ)
-      (fun u v ξ => by ring)
-      (fun a u ξ => by ring)
-      (fun u ξ η => by simp [inner_add_right, mul_add])
-      (fun a u ξ => by rw [inner_smul_right]; ring))
-    ‖b‖
-    (fun u ξ => by
-      rw [LinearMap.mk₂_apply, norm_mul]
-      calc
-        ‖u‖ * ‖⟪b, ξ⟫_ℝ‖ ≤ ‖u‖ * (‖b‖ * ‖ξ‖) := by
-          gcongr
-          exact norm_inner_le_norm b ξ
-        _ = ‖b‖ * ‖u‖ * ‖ξ‖ := by ring)
+  ContinuousLinearMap.smulRightL ℝ (EuclideanSpace ℝ n) ℝ (innerSL ℝ b)
 
 /-- The drift form is the expected scalar times dot-product expression. -/
 @[simp]
 lemma driftForm_apply (b : EuclideanSpace ℝ n) (u : ℝ) (ξ : EuclideanSpace ℝ n) :
     driftForm b u ξ = u * ⟪b, ξ⟫_ℝ := by
   simp [driftForm]
+  ring
 
 /-- The pointwise drift form is linear under scalar multiplication of the coefficient vector. -/
 @[simp]
@@ -92,8 +81,8 @@ lemma norm_driftForm_apply_le_of_norm_le {b : EuclideanSpace ℝ n} {beta : ℝ}
 
 /-- The operator norm of the drift form is bounded by the coefficient norm. -/
 lemma opNorm_driftForm_le (b : EuclideanSpace ℝ n) :
-    ‖driftForm b‖ ≤ ‖b‖ :=
-  (driftForm b).opNorm_le_bound₂ (norm_nonneg b) (norm_driftForm_apply_le b)
+    ‖driftForm b‖ ≤ ‖b‖ := by
+  rw [driftForm, ContinuousLinearMap.norm_smulRightL, innerSL_apply_norm]
 
 /-- A bound on the coefficient norm bounds the operator norm of the drift form. -/
 lemma opNorm_driftForm_le_of_norm_le {b : EuclideanSpace ℝ n} {beta : ℝ}
@@ -103,21 +92,14 @@ lemma opNorm_driftForm_le_of_norm_le {b : EuclideanSpace ℝ n} {beta : ℝ}
 
 /-- The pointwise zeroth-order mass form `(u, v) ↦ c * u * v`. -/
 noncomputable def massForm (c : ℝ) : ℝ →L[ℝ] ℝ →L[ℝ] ℝ :=
-  LinearMap.mkContinuous₂
-    (LinearMap.mk₂ ℝ (fun u v => c * u * v)
-      (fun u v w => by ring)
-      (fun a u v => by ring)
-      (fun u v w => by ring)
-      (fun a u v => by ring))
-    ‖c‖
-    (fun u v => by
-      rw [LinearMap.mk₂_apply, norm_mul, norm_mul, mul_assoc])
+  c • ContinuousLinearMap.mul ℝ ℝ
 
 /-- The mass form is the expected product expression. -/
 @[simp]
 lemma massForm_apply (c u v : ℝ) :
     massForm c u v = c * u * v := by
   simp [massForm]
+  ring
 
 /-- The zero mass coefficient gives the zero pointwise mass form. -/
 @[simp]
@@ -134,7 +116,7 @@ lemma massForm_add_apply (c d u v : ℝ) :
 
 /-- The mass form is linear under scalar multiplication of the coefficient. -/
 @[simp]
-lemma massForm_smul_apply (a c u v : ℝ) :
+lemma massForm_mul_apply (a c u v : ℝ) :
     massForm (a * c) u v = a * massForm c u v := by
   simp [massForm_apply]
   ring
@@ -254,59 +236,59 @@ lemma opNorm_massForm_le (h : LowerOrderBoundedOn Ω b c beta gamma) {x : X}
 end LowerOrderBoundedOn
 
 /-- Nonnegative bounded zeroth-order coefficients on a domain. -/
-def NonnegativeMassOn (Ω : Set X) (c : X → ℝ) (gamma : ℝ) : Prop :=
+def NonnegMassOn (Ω : Set X) (c : X → ℝ) (gamma : ℝ) : Prop :=
   0 ≤ gamma ∧ ∀ ⦃x⦄, x ∈ Ω → 0 ≤ c x ∧ c x ≤ gamma
 
 /-- Characteristic restatement of nonnegative bounded mass coefficients. -/
-lemma nonnegativeMassOn_iff {Ω : Set X} {c : X → ℝ} {gamma : ℝ} :
-    NonnegativeMassOn Ω c gamma ↔
+lemma nonnegMassOn_iff {Ω : Set X} {c : X → ℝ} {gamma : ℝ} :
+    NonnegMassOn Ω c gamma ↔
       0 ≤ gamma ∧ ∀ ⦃x⦄, x ∈ Ω → 0 ≤ c x ∧ c x ≤ gamma :=
   Iff.rfl
 
-namespace NonnegativeMassOn
+namespace NonnegMassOn
 
 variable {Ω Ω' : Set X} {c : X → ℝ} {gamma gamma' : ℝ}
 
 /-- The mass bound is nonnegative. -/
 @[grind →]
-lemma gamma_nonneg (h : NonnegativeMassOn Ω c gamma) : 0 ≤ gamma :=
+lemma gamma_nonneg (h : NonnegMassOn Ω c gamma) : 0 ≤ gamma :=
   h.1
 
 /-- The mass coefficient is pointwise nonnegative. -/
 @[grind =>]
-lemma nonneg (h : NonnegativeMassOn Ω c gamma) {x : X} (hx : x ∈ Ω) : 0 ≤ c x :=
+lemma nonneg (h : NonnegMassOn Ω c gamma) {x : X} (hx : x ∈ Ω) : 0 ≤ c x :=
   (h.2 hx).1
 
 /-- The mass coefficient is pointwise bounded above. -/
 @[grind =>]
-lemma upper_bound (h : NonnegativeMassOn Ω c gamma) {x : X} (hx : x ∈ Ω) :
+lemma upper_bound (h : NonnegMassOn Ω c gamma) {x : X} (hx : x ∈ Ω) :
     c x ≤ gamma :=
   (h.2 hx).2
 
 /-- A nonnegative bounded mass coefficient is absolutely bounded. -/
 @[grind =>]
-lemma norm_bound (h : NonnegativeMassOn Ω c gamma) {x : X} (hx : x ∈ Ω) :
+lemma norm_bound (h : NonnegMassOn Ω c gamma) {x : X} (hx : x ∈ Ω) :
     ‖c x‖ ≤ gamma := by
   simpa [Real.norm_eq_abs, abs_of_nonneg (h.nonneg hx)] using h.upper_bound hx
 
 /-- Restricting the domain preserves nonnegative bounded mass coefficients. -/
-lemma mono_set (h : NonnegativeMassOn Ω c gamma) (hΩ : Ω' ⊆ Ω) :
-    NonnegativeMassOn Ω' c gamma :=
+lemma mono_set (h : NonnegMassOn Ω c gamma) (hΩ : Ω' ⊆ Ω) :
+    NonnegMassOn Ω' c gamma :=
   ⟨h.gamma_nonneg, fun {_} hx => h.2 (hΩ hx)⟩
 
 /-- Increasing the upper bound preserves nonnegative bounded mass coefficients. -/
-lemma mono_constant (h : NonnegativeMassOn Ω c gamma) (hgamma : gamma ≤ gamma') :
-    NonnegativeMassOn Ω c gamma' :=
+lemma mono_constant (h : NonnegMassOn Ω c gamma) (hgamma : gamma ≤ gamma') :
+    NonnegMassOn Ω c gamma' :=
   ⟨h.gamma_nonneg.trans hgamma,
     fun {_} hx => ⟨h.nonneg hx, (h.upper_bound hx).trans hgamma⟩⟩
 
 /-- Nonnegative bounded mass coefficients produce lower-order bounds with zero drift. -/
-lemma lowerOrderBoundedOn_zero_drift (h : NonnegativeMassOn Ω c gamma) :
+lemma lowerOrderBoundedOn_zero_drift (h : NonnegMassOn Ω c gamma) :
     LowerOrderBoundedOn Ω (fun _ => (0 : EuclideanSpace ℝ n)) c 0 gamma :=
   LowerOrderBoundedOn.of_bounds le_rfl h.gamma_nonneg
     (fun {_} _ => by simp) (fun {_} hx => h.norm_bound hx)
 
-end NonnegativeMassOn
+end NonnegMassOn
 
 /-- Zero lower-order coefficients are bounded by zero. -/
 lemma lowerOrderBoundedOn_zero (Ω : Set X) :
@@ -314,8 +296,8 @@ lemma lowerOrderBoundedOn_zero (Ω : Set X) :
   LowerOrderBoundedOn.of_bounds le_rfl le_rfl (fun {_} _ => by simp) (fun {_} _ => by simp)
 
 /-- A constant nonnegative mass coefficient is nonnegative and bounded by itself. -/
-lemma nonnegativeMassOn_const_self (Ω : Set X) {c : ℝ} (hc : 0 ≤ c) :
-    NonnegativeMassOn Ω (fun _ => c) c :=
+lemma nonnegMassOn_const_self (Ω : Set X) {c : ℝ} (hc : 0 ≤ c) :
+    NonnegMassOn Ω (fun _ => c) c :=
   ⟨hc, fun {_} _ => ⟨hc, le_rfl⟩⟩
 
 end PDE

--- a/TauCeti/Analysis/PDE/LowerOrder.lean
+++ b/TauCeti/Analysis/PDE/LowerOrder.lean
@@ -307,7 +307,8 @@ lemma nonnegMassOn_iff {Ω : Set X} {c : X → ℝ} {gamma : ℝ} :
 
 namespace NonnegMassOn
 
-variable {Ω Ω' : Set X} {c : X → ℝ} {gamma gamma' : ℝ}
+variable {Ω Ω' : Set X} {b : X → EuclideanSpace ℝ n} {c : X → ℝ}
+variable {beta gamma gamma' : ℝ}
 
 /-- The mass bound is nonnegative. -/
 @[grind →]
@@ -349,11 +350,22 @@ lemma mono_constant (h : NonnegMassOn Ω c gamma) (hgamma : gamma ≤ gamma') :
   ⟨h.gamma_nonneg.trans hgamma,
     fun {_} hx => ⟨h.nonneg hx, (h.upper_bound hx).trans hgamma⟩⟩
 
+/-- Nonnegative bounded mass coefficients are bounded mass coefficients. -/
+lemma mass_boundedOn (h : NonnegMassOn Ω c gamma) :
+    MassBoundedOn Ω c gamma :=
+  MassBoundedOn.of_bound h.gamma_nonneg fun {_} hx => h.norm_bound hx
+
+/-- A drift bound and nonnegative bounded mass coefficient produce lower-order bounds. -/
+lemma lowerOrderBoundedOn (h : NonnegMassOn Ω c gamma)
+    (hb : DriftBoundedOn (n := n) Ω b beta) :
+    LowerOrderBoundedOn Ω b c beta gamma :=
+  ⟨hb, h.mass_boundedOn⟩
+
 /-- Nonnegative bounded mass coefficients produce lower-order bounds with zero drift. -/
 lemma lowerOrderBoundedOn_zero_drift (h : NonnegMassOn Ω c gamma) :
     LowerOrderBoundedOn Ω (fun _ => (0 : EuclideanSpace ℝ n)) c 0 gamma :=
-  LowerOrderBoundedOn.of_bounds le_rfl h.gamma_nonneg
-    (fun {_} _ => by simp) (fun {_} hx => h.norm_bound hx)
+  h.lowerOrderBoundedOn
+    (DriftBoundedOn.of_bound (n := n) le_rfl fun {_} _ => by simp)
 
 end NonnegMassOn
 

--- a/TauCeti/Analysis/PDE/LowerOrder.lean
+++ b/TauCeti/Analysis/PDE/LowerOrder.lean
@@ -15,10 +15,8 @@ and zeroth-order mass coefficient as separate named hypotheses.  The principal m
 coefficient lives in `TauCeti.Analysis.PDE.UniformEllipticity`; this file records the
 pointwise explicit bounds for the lower-order terms
 
-* `u ↦ b(x) · ∇u`, represented using
-  `ContinuousLinearMap.smulRightL ℝ (EuclideanSpace ℝ n) ℝ (innerSL ℝ (b x))`;
-* `u ↦ c(x) u`, represented in the weak form using
-  `c x • ContinuousLinearMap.mul ℝ ℝ`.
+* `u ↦ b(x) · ∇u`, represented by `driftForm (b x)`;
+* `u ↦ c(x) u`, represented in the weak form by `massForm (c x)`.
 
 These are only pointwise finite-dimensional estimates, later integrated over `Ω` once the
 weak-derivative Sobolev spaces are available.
@@ -28,6 +26,7 @@ weak-derivative Sobolev spaces are available.
 * `TauCeti.PDE.LowerOrderBoundedOn`: explicit bounds for drift and mass coefficients on a
   domain.
 * `TauCeti.PDE.NonnegMassOn`: nonnegative bounded mass coefficients.
+* `TauCeti.PDE.driftForm`, `TauCeti.PDE.massForm`: named pointwise lower-order forms.
 -/
 
 namespace TauCeti
@@ -37,6 +36,30 @@ namespace PDE
 open scoped InnerProductSpace
 
 variable {X n : Type*} [Fintype n]
+
+/-- The pointwise first-order drift form `(u, ξ) ↦ ⟪b, ξ⟫ u`. -/
+noncomputable def driftForm (b : EuclideanSpace ℝ n) :
+    ℝ →L[ℝ] EuclideanSpace ℝ n →L[ℝ] ℝ :=
+  ContinuousLinearMap.smulRightL ℝ (EuclideanSpace ℝ n) ℝ (innerSL ℝ b)
+
+/-- The pointwise zeroth-order mass form `(u, v) ↦ c u v`. -/
+noncomputable def massForm (c : ℝ) : ℝ →L[ℝ] ℝ →L[ℝ] ℝ :=
+  c • ContinuousLinearMap.mul ℝ ℝ
+
+/-- Applying the drift form is the scalar product with the drift coefficient times `u`. -/
+@[simp]
+lemma driftForm_apply (b : EuclideanSpace ℝ n) (u : ℝ) (ξ : EuclideanSpace ℝ n) :
+    driftForm b u ξ = ⟪b, ξ⟫_ℝ * u := by
+  rw [driftForm, ContinuousLinearMap.smulRightL_apply_apply,
+    ContinuousLinearMap.smulRight_apply, innerSL_apply_apply, smul_eq_mul]
+
+/-- Applying the mass form is multiplication by the mass coefficient. -/
+@[simp]
+lemma massForm_apply (c u v : ℝ) :
+    massForm c u v = c * u * v := by
+  rw [massForm, ContinuousLinearMap.smul_apply, ContinuousLinearMap.smul_apply,
+    ContinuousLinearMap.mul_apply', smul_eq_mul]
+  ring
 
 /-- Bounded lower-order coefficients on a domain, with explicit constants.
 
@@ -105,10 +128,8 @@ lemma of_bounds (hbeta : 0 ≤ beta) (hgamma : 0 ≤ gamma)
 @[grind =>]
 lemma norm_driftForm_le (h : LowerOrderBoundedOn Ω b c beta gamma) {x : X}
     (hx : x ∈ Ω) (u : ℝ) (ξ : EuclideanSpace ℝ n) :
-    ‖ContinuousLinearMap.smulRightL ℝ (EuclideanSpace ℝ n) ℝ (innerSL ℝ (b x)) u ξ‖ ≤
-      beta * ‖u‖ * ‖ξ‖ := by
-  rw [ContinuousLinearMap.smulRightL_apply_apply, ContinuousLinearMap.smulRight_apply,
-    innerSL_apply_apply, smul_eq_mul, norm_mul]
+    ‖driftForm (b x) u ξ‖ ≤ beta * ‖u‖ * ‖ξ‖ := by
+  rw [driftForm_apply, norm_mul]
   calc
     ‖⟪b x, ξ⟫_ℝ‖ * ‖u‖ ≤ (‖b x‖ * ‖ξ‖) * ‖u‖ := by
       gcongr
@@ -122,31 +143,30 @@ lemma norm_driftForm_le (h : LowerOrderBoundedOn Ω b c beta gamma) {x : X}
 @[grind =>]
 lemma opNorm_driftForm_le (h : LowerOrderBoundedOn Ω b c beta gamma) {x : X}
     (hx : x ∈ Ω) :
-    ‖ContinuousLinearMap.smulRightL ℝ (EuclideanSpace ℝ n) ℝ (innerSL ℝ (b x))‖ ≤ beta := by
-  rw [ContinuousLinearMap.norm_smulRightL, innerSL_apply_norm]
+    ‖driftForm (b x)‖ ≤ beta := by
+  rw [driftForm, ContinuousLinearMap.norm_smulRightL, innerSL_apply_norm]
   exact h.drift_bound hx
 
 /-- Pointwise boundedness of the mass form supplied by bounded lower-order coefficients. -/
 @[grind =>]
 lemma norm_massForm_le (h : LowerOrderBoundedOn Ω b c beta gamma) {x : X}
     (hx : x ∈ Ω) (u v : ℝ) :
-    ‖(c x • ContinuousLinearMap.mul ℝ ℝ) u v‖ ≤ gamma * ‖u‖ * ‖v‖ := by
-  rw [ContinuousLinearMap.smul_apply, ContinuousLinearMap.smul_apply,
-    ContinuousLinearMap.mul_apply', smul_eq_mul, norm_mul, norm_mul]
+    ‖massForm (c x) u v‖ ≤ gamma * ‖u‖ * ‖v‖ := by
+  rw [massForm_apply, norm_mul, norm_mul]
   calc
-    ‖c x‖ * (‖u‖ * ‖v‖) ≤ gamma * (‖u‖ * ‖v‖) := by
+    ‖c x‖ * ‖u‖ * ‖v‖ ≤ gamma * ‖u‖ * ‖v‖ := by
       gcongr
       exact h.mass_bound hx
-    _ = gamma * ‖u‖ * ‖v‖ := by ring
 
 /-- Operator-norm boundedness of the mass form supplied by bounded lower-order coefficients. -/
 @[grind =>]
 lemma opNorm_massForm_le (h : LowerOrderBoundedOn Ω b c beta gamma) {x : X}
     (hx : x ∈ Ω) :
-    ‖c x • ContinuousLinearMap.mul ℝ ℝ‖ ≤ gamma := by
+    ‖massForm (c x)‖ ≤ gamma := by
   calc
-    ‖c x • ContinuousLinearMap.mul ℝ ℝ‖ ≤ ‖c x‖ * ‖ContinuousLinearMap.mul ℝ ℝ‖ :=
-      ContinuousLinearMap.opNorm_smul_le (c x) (ContinuousLinearMap.mul ℝ ℝ)
+    ‖massForm (c x)‖ ≤ ‖c x‖ * ‖ContinuousLinearMap.mul ℝ ℝ‖ := by
+      rw [massForm]
+      exact ContinuousLinearMap.opNorm_smul_le (c x) (ContinuousLinearMap.mul ℝ ℝ)
     _ ≤ ‖c x‖ * 1 := by
       gcongr
       exact ContinuousLinearMap.opNorm_mul_le ℝ ℝ

--- a/TauCeti/Analysis/PDE/LowerOrder.lean
+++ b/TauCeti/Analysis/PDE/LowerOrder.lean
@@ -211,6 +211,13 @@ lemma norm_bound (h : NonnegMassOn Ω c gamma) {x : X} (hx : x ∈ Ω) :
     ‖c x‖ ≤ gamma := by
   simpa [Real.norm_eq_abs, abs_of_nonneg (h.nonneg hx)] using h.upper_bound hx
 
+/-- The mass form associated to a nonnegative mass coefficient is nonnegative on the diagonal. -/
+@[grind =>]
+lemma nonneg_massForm_self (h : NonnegMassOn Ω c gamma) {x : X} (hx : x ∈ Ω) (u : ℝ) :
+    0 ≤ massForm (c x) u u := by
+  rw [massForm_apply, mul_assoc]
+  exact mul_nonneg (h.nonneg hx) (mul_self_nonneg u)
+
 /-- Restricting the domain preserves nonnegative bounded mass coefficients. -/
 lemma mono_set (h : NonnegMassOn Ω c gamma) (hΩ : Ω' ⊆ Ω) :
     NonnegMassOn Ω' c gamma :=

--- a/TauCeti/Analysis/PDE/LowerOrder.lean
+++ b/TauCeti/Analysis/PDE/LowerOrder.lean
@@ -23,8 +23,9 @@ weak-derivative Sobolev spaces are available.
 
 ## Main declarations
 
-* `TauCeti.PDE.LowerOrderBoundedOn`: explicit bounds for drift and mass coefficients on a
-  domain.
+* `TauCeti.PDE.DriftBoundedOn`, `TauCeti.PDE.MassBoundedOn`: explicit separate bounds for
+  drift and mass coefficients on a domain.
+* `TauCeti.PDE.LowerOrderBoundedOn`: the bundled lower-order bounds.
 * `TauCeti.PDE.NonnegMassOn`: nonnegative bounded mass coefficients.
 * `TauCeti.PDE.driftForm`, `TauCeti.PDE.massForm`: named pointwise lower-order forms.
 -/
@@ -61,72 +62,49 @@ lemma massForm_apply (c u v : ℝ) :
     ContinuousLinearMap.mul_apply', smul_eq_mul]
   ring
 
-/-- Bounded lower-order coefficients on a domain, with explicit constants.
+/-- Bounded drift coefficients on a domain, with an explicit constant. -/
+def DriftBoundedOn (Ω : Set X) (b : X → EuclideanSpace ℝ n) (beta : ℝ) : Prop :=
+  0 ≤ beta ∧ ∀ ⦃x⦄, x ∈ Ω → ‖b x‖ ≤ beta
 
-`LowerOrderBoundedOn Ω b c beta gamma` means that on `Ω`, the drift coefficient vector
-has norm at most `beta` and the mass coefficient has absolute value at most `gamma`. -/
-def LowerOrderBoundedOn (Ω : Set X) (b : X → EuclideanSpace ℝ n) (c : X → ℝ)
-    (beta gamma : ℝ) : Prop :=
-  0 ≤ beta ∧ 0 ≤ gamma ∧
-    ∀ ⦃x⦄, x ∈ Ω → ‖b x‖ ≤ beta ∧ ‖c x‖ ≤ gamma
-
-/-- Characteristic restatement of bounded lower-order coefficients. -/
-lemma lowerOrderBoundedOn_iff {Ω : Set X} {b : X → EuclideanSpace ℝ n} {c : X → ℝ}
-    {beta gamma : ℝ} :
-    LowerOrderBoundedOn Ω b c beta gamma ↔
-      0 ≤ beta ∧ 0 ≤ gamma ∧
-        ∀ ⦃x⦄, x ∈ Ω → ‖b x‖ ≤ beta ∧ ‖c x‖ ≤ gamma :=
+/-- Characteristic restatement of bounded drift coefficients. -/
+lemma driftBoundedOn_iff {Ω : Set X} {b : X → EuclideanSpace ℝ n} {beta : ℝ} :
+    DriftBoundedOn Ω b beta ↔
+      0 ≤ beta ∧ ∀ ⦃x⦄, x ∈ Ω → ‖b x‖ ≤ beta :=
   Iff.rfl
 
-namespace LowerOrderBoundedOn
+namespace DriftBoundedOn
 
-variable {Ω Ω' : Set X} {b : X → EuclideanSpace ℝ n} {c : X → ℝ}
-variable {beta gamma beta' gamma' : ℝ}
+variable {Ω Ω' : Set X} {b : X → EuclideanSpace ℝ n} {beta beta' : ℝ}
 
 /-- The drift bound is nonnegative. -/
 @[grind →]
-lemma beta_nonneg (h : LowerOrderBoundedOn Ω b c beta gamma) : 0 ≤ beta :=
+lemma beta_nonneg (h : DriftBoundedOn Ω b beta) : 0 ≤ beta :=
   h.1
-
-/-- The mass bound is nonnegative. -/
-@[grind →]
-lemma gamma_nonneg (h : LowerOrderBoundedOn Ω b c beta gamma) : 0 ≤ gamma :=
-  h.2.1
 
 /-- The pointwise drift coefficient bound. -/
 @[grind =>]
-lemma drift_bound (h : LowerOrderBoundedOn Ω b c beta gamma) {x : X} (hx : x ∈ Ω) :
+lemma bound (h : DriftBoundedOn Ω b beta) {x : X} (hx : x ∈ Ω) :
     ‖b x‖ ≤ beta :=
-  (h.2.2 hx).1
+  h.2 hx
 
-/-- The pointwise mass coefficient bound. -/
-@[grind =>]
-lemma mass_bound (h : LowerOrderBoundedOn Ω b c beta gamma) {x : X} (hx : x ∈ Ω) :
-    ‖c x‖ ≤ gamma :=
-  (h.2.2 hx).2
+/-- Restricting the domain preserves bounded drift coefficients. -/
+lemma mono_set (h : DriftBoundedOn Ω b beta) (hΩ : Ω' ⊆ Ω) :
+    DriftBoundedOn Ω' b beta :=
+  ⟨h.beta_nonneg, fun {_} hx => h.bound (hΩ hx)⟩
 
-/-- Restricting the domain preserves bounded lower-order coefficients. -/
-lemma mono_set (h : LowerOrderBoundedOn Ω b c beta gamma) (hΩ : Ω' ⊆ Ω) :
-    LowerOrderBoundedOn Ω' b c beta gamma :=
-  ⟨h.beta_nonneg, h.gamma_nonneg, fun {_} hx => h.2.2 (hΩ hx)⟩
-
-/-- Increasing either bound preserves bounded lower-order coefficients. -/
-lemma mono_constants (h : LowerOrderBoundedOn Ω b c beta gamma)
-    (hbeta : beta ≤ beta') (hgamma : gamma ≤ gamma') :
-    LowerOrderBoundedOn Ω b c beta' gamma' :=
-  ⟨h.beta_nonneg.trans hbeta, h.gamma_nonneg.trans hgamma,
-    fun {_} hx => ⟨(h.drift_bound hx).trans hbeta, (h.mass_bound hx).trans hgamma⟩⟩
+/-- Increasing the bound preserves bounded drift coefficients. -/
+lemma mono_constant (h : DriftBoundedOn Ω b beta) (hbeta : beta ≤ beta') :
+    DriftBoundedOn Ω b beta' :=
+  ⟨h.beta_nonneg.trans hbeta, fun {_} hx => (h.bound hx).trans hbeta⟩
 
 /-- Constructor from separate side conditions and pointwise bounds. -/
-lemma of_bounds (hbeta : 0 ≤ beta) (hgamma : 0 ≤ gamma)
-    (hb : ∀ ⦃x⦄, x ∈ Ω → ‖b x‖ ≤ beta)
-    (hc : ∀ ⦃x⦄, x ∈ Ω → ‖c x‖ ≤ gamma) :
-    LowerOrderBoundedOn Ω b c beta gamma :=
-  ⟨hbeta, hgamma, fun {_} hx => ⟨hb hx, hc hx⟩⟩
+lemma of_bound (hbeta : 0 ≤ beta) (hb : ∀ ⦃x⦄, x ∈ Ω → ‖b x‖ ≤ beta) :
+    DriftBoundedOn Ω b beta :=
+  ⟨hbeta, hb⟩
 
-/-- Pointwise boundedness of the drift form supplied by bounded lower-order coefficients. -/
+/-- Pointwise boundedness of the drift form supplied by a drift coefficient bound. -/
 @[grind =>]
-lemma norm_driftForm_le (h : LowerOrderBoundedOn Ω b c beta gamma) {x : X}
+lemma norm_driftForm_le (h : DriftBoundedOn Ω b beta) {x : X}
     (hx : x ∈ Ω) (u : ℝ) (ξ : EuclideanSpace ℝ n) :
     ‖driftForm (b x) u ξ‖ ≤ beta * ‖u‖ * ‖ξ‖ := by
   rw [driftForm_apply, norm_mul]
@@ -136,31 +114,73 @@ lemma norm_driftForm_le (h : LowerOrderBoundedOn Ω b c beta gamma) {x : X}
       exact norm_inner_le_norm (b x) ξ
     _ ≤ (beta * ‖ξ‖) * ‖u‖ := by
       gcongr
-      exact h.drift_bound hx
+      exact h.bound hx
     _ = beta * ‖u‖ * ‖ξ‖ := by ring
 
-/-- Operator-norm boundedness of the drift form supplied by bounded lower-order coefficients. -/
+/-- Operator-norm boundedness of the drift form supplied by a drift coefficient bound. -/
 @[grind =>]
-lemma opNorm_driftForm_le (h : LowerOrderBoundedOn Ω b c beta gamma) {x : X}
+lemma opNorm_driftForm_le (h : DriftBoundedOn Ω b beta) {x : X}
     (hx : x ∈ Ω) :
     ‖driftForm (b x)‖ ≤ beta := by
   rw [driftForm, ContinuousLinearMap.norm_smulRightL, innerSL_apply_norm]
-  exact h.drift_bound hx
+  exact h.bound hx
 
-/-- Pointwise boundedness of the mass form supplied by bounded lower-order coefficients. -/
+end DriftBoundedOn
+
+/-- Bounded mass coefficients on a domain, with an explicit constant. -/
+def MassBoundedOn (Ω : Set X) (c : X → ℝ) (gamma : ℝ) : Prop :=
+  0 ≤ gamma ∧ ∀ ⦃x⦄, x ∈ Ω → ‖c x‖ ≤ gamma
+
+/-- Characteristic restatement of bounded mass coefficients. -/
+lemma massBoundedOn_iff {Ω : Set X} {c : X → ℝ} {gamma : ℝ} :
+    MassBoundedOn Ω c gamma ↔
+      0 ≤ gamma ∧ ∀ ⦃x⦄, x ∈ Ω → ‖c x‖ ≤ gamma :=
+  Iff.rfl
+
+namespace MassBoundedOn
+
+variable {Ω Ω' : Set X} {c : X → ℝ} {gamma gamma' : ℝ}
+
+/-- The mass bound is nonnegative. -/
+@[grind →]
+lemma gamma_nonneg (h : MassBoundedOn Ω c gamma) : 0 ≤ gamma :=
+  h.1
+
+/-- The pointwise mass coefficient bound. -/
 @[grind =>]
-lemma norm_massForm_le (h : LowerOrderBoundedOn Ω b c beta gamma) {x : X}
+lemma bound (h : MassBoundedOn Ω c gamma) {x : X} (hx : x ∈ Ω) :
+    ‖c x‖ ≤ gamma :=
+  h.2 hx
+
+/-- Restricting the domain preserves bounded mass coefficients. -/
+lemma mono_set (h : MassBoundedOn Ω c gamma) (hΩ : Ω' ⊆ Ω) :
+    MassBoundedOn Ω' c gamma :=
+  ⟨h.gamma_nonneg, fun {_} hx => h.bound (hΩ hx)⟩
+
+/-- Increasing the bound preserves bounded mass coefficients. -/
+lemma mono_constant (h : MassBoundedOn Ω c gamma) (hgamma : gamma ≤ gamma') :
+    MassBoundedOn Ω c gamma' :=
+  ⟨h.gamma_nonneg.trans hgamma, fun {_} hx => (h.bound hx).trans hgamma⟩
+
+/-- Constructor from separate side conditions and pointwise bounds. -/
+lemma of_bound (hgamma : 0 ≤ gamma) (hc : ∀ ⦃x⦄, x ∈ Ω → ‖c x‖ ≤ gamma) :
+    MassBoundedOn Ω c gamma :=
+  ⟨hgamma, hc⟩
+
+/-- Pointwise boundedness of the mass form supplied by a mass coefficient bound. -/
+@[grind =>]
+lemma norm_massForm_le (h : MassBoundedOn Ω c gamma) {x : X}
     (hx : x ∈ Ω) (u v : ℝ) :
     ‖massForm (c x) u v‖ ≤ gamma * ‖u‖ * ‖v‖ := by
   rw [massForm_apply, norm_mul, norm_mul]
   calc
     ‖c x‖ * ‖u‖ * ‖v‖ ≤ gamma * ‖u‖ * ‖v‖ := by
       gcongr
-      exact h.mass_bound hx
+      exact h.bound hx
 
-/-- Operator-norm boundedness of the mass form supplied by bounded lower-order coefficients. -/
+/-- Operator-norm boundedness of the mass form supplied by a mass coefficient bound. -/
 @[grind =>]
-lemma opNorm_massForm_le (h : LowerOrderBoundedOn Ω b c beta gamma) {x : X}
+lemma opNorm_massForm_le (h : MassBoundedOn Ω c gamma) {x : X}
     (hx : x ∈ Ω) :
     ‖massForm (c x)‖ ≤ gamma := by
   calc
@@ -171,7 +191,107 @@ lemma opNorm_massForm_le (h : LowerOrderBoundedOn Ω b c beta gamma) {x : X}
       gcongr
       exact ContinuousLinearMap.opNorm_mul_le ℝ ℝ
     _ = ‖c x‖ := by ring
-    _ ≤ gamma := h.mass_bound hx
+    _ ≤ gamma := h.bound hx
+
+end MassBoundedOn
+
+/-- Bounded lower-order coefficients on a domain, with explicit constants.
+
+`LowerOrderBoundedOn Ω b c beta gamma` means that on `Ω`, the drift coefficient vector
+has norm at most `beta` and the mass coefficient has absolute value at most `gamma`. -/
+def LowerOrderBoundedOn (Ω : Set X) (b : X → EuclideanSpace ℝ n) (c : X → ℝ)
+    (beta gamma : ℝ) : Prop :=
+  DriftBoundedOn Ω b beta ∧ MassBoundedOn Ω c gamma
+
+/-- Characteristic restatement of bounded lower-order coefficients. -/
+lemma lowerOrderBoundedOn_iff {Ω : Set X} {b : X → EuclideanSpace ℝ n} {c : X → ℝ}
+    {beta gamma : ℝ} :
+    LowerOrderBoundedOn Ω b c beta gamma ↔
+      DriftBoundedOn Ω b beta ∧ MassBoundedOn Ω c gamma :=
+  Iff.rfl
+
+namespace LowerOrderBoundedOn
+
+variable {Ω Ω' : Set X} {b : X → EuclideanSpace ℝ n} {c : X → ℝ}
+variable {beta gamma beta' gamma' : ℝ}
+
+/-- The drift bound is nonnegative. -/
+@[grind →]
+lemma beta_nonneg (h : LowerOrderBoundedOn Ω b c beta gamma) : 0 ≤ beta :=
+  h.1.beta_nonneg
+
+/-- The mass bound is nonnegative. -/
+@[grind →]
+lemma gamma_nonneg (h : LowerOrderBoundedOn Ω b c beta gamma) : 0 ≤ gamma :=
+  h.2.gamma_nonneg
+
+/-- The bundled drift coefficient bound. -/
+lemma drift_boundedOn (h : LowerOrderBoundedOn Ω b c beta gamma) :
+    DriftBoundedOn Ω b beta :=
+  h.1
+
+/-- The bundled mass coefficient bound. -/
+lemma mass_boundedOn (h : LowerOrderBoundedOn Ω b c beta gamma) :
+    MassBoundedOn Ω c gamma :=
+  h.2
+
+/-- The pointwise drift coefficient bound. -/
+@[grind =>]
+lemma drift_bound (h : LowerOrderBoundedOn Ω b c beta gamma) {x : X} (hx : x ∈ Ω) :
+    ‖b x‖ ≤ beta :=
+  h.1.bound hx
+
+/-- The pointwise mass coefficient bound. -/
+@[grind =>]
+lemma mass_bound (h : LowerOrderBoundedOn Ω b c beta gamma) {x : X} (hx : x ∈ Ω) :
+    ‖c x‖ ≤ gamma :=
+  h.2.bound hx
+
+/-- Restricting the domain preserves bounded lower-order coefficients. -/
+lemma mono_set (h : LowerOrderBoundedOn Ω b c beta gamma) (hΩ : Ω' ⊆ Ω) :
+    LowerOrderBoundedOn Ω' b c beta gamma :=
+  ⟨h.1.mono_set hΩ, h.2.mono_set hΩ⟩
+
+/-- Increasing either bound preserves bounded lower-order coefficients. -/
+lemma mono_constants (h : LowerOrderBoundedOn Ω b c beta gamma)
+    (hbeta : beta ≤ beta') (hgamma : gamma ≤ gamma') :
+    LowerOrderBoundedOn Ω b c beta' gamma' :=
+  ⟨h.1.mono_constant hbeta, h.2.mono_constant hgamma⟩
+
+/-- Constructor from separate side conditions and pointwise bounds. -/
+lemma of_bounds (hbeta : 0 ≤ beta) (hgamma : 0 ≤ gamma)
+    (hb : ∀ ⦃x⦄, x ∈ Ω → ‖b x‖ ≤ beta)
+    (hc : ∀ ⦃x⦄, x ∈ Ω → ‖c x‖ ≤ gamma) :
+    LowerOrderBoundedOn Ω b c beta gamma :=
+  ⟨DriftBoundedOn.of_bound hbeta hb, MassBoundedOn.of_bound hgamma hc⟩
+
+/-- Convenience pointwise drift-form bound from bundled lower-order bounds. -/
+@[grind =>]
+lemma norm_driftForm_le (h : LowerOrderBoundedOn Ω b c beta gamma) {x : X}
+    (hx : x ∈ Ω) (u : ℝ) (ξ : EuclideanSpace ℝ n) :
+    ‖driftForm (b x) u ξ‖ ≤ beta * ‖u‖ * ‖ξ‖ :=
+  h.drift_boundedOn.norm_driftForm_le hx u ξ
+
+/-- Convenience operator-norm drift-form bound from bundled lower-order bounds. -/
+@[grind =>]
+lemma opNorm_driftForm_le (h : LowerOrderBoundedOn Ω b c beta gamma) {x : X}
+    (hx : x ∈ Ω) :
+    ‖driftForm (b x)‖ ≤ beta :=
+  h.drift_boundedOn.opNorm_driftForm_le hx
+
+/-- Convenience pointwise mass-form bound from bundled lower-order bounds. -/
+@[grind =>]
+lemma norm_massForm_le (h : LowerOrderBoundedOn Ω b c beta gamma) {x : X}
+    (hx : x ∈ Ω) (u v : ℝ) :
+    ‖massForm (c x) u v‖ ≤ gamma * ‖u‖ * ‖v‖ :=
+  h.mass_boundedOn.norm_massForm_le hx u v
+
+/-- Convenience operator-norm mass-form bound from bundled lower-order bounds. -/
+@[grind =>]
+lemma opNorm_massForm_le (h : LowerOrderBoundedOn Ω b c beta gamma) {x : X}
+    (hx : x ∈ Ω) :
+    ‖massForm (c x)‖ ≤ gamma :=
+  h.mass_boundedOn.opNorm_massForm_le hx
 
 end LowerOrderBoundedOn
 
@@ -213,7 +333,7 @@ lemma norm_bound (h : NonnegMassOn Ω c gamma) {x : X} (hx : x ∈ Ω) :
 
 /-- The mass form associated to a nonnegative mass coefficient is nonnegative on the diagonal. -/
 @[grind =>]
-lemma nonneg_massForm_self (h : NonnegMassOn Ω c gamma) {x : X} (hx : x ∈ Ω) (u : ℝ) :
+lemma massForm_self_nonneg (h : NonnegMassOn Ω c gamma) {x : X} (hx : x ∈ Ω) (u : ℝ) :
     0 ≤ massForm (c x) u u := by
   rw [massForm_apply, mul_assoc]
   exact mul_nonneg (h.nonneg hx) (mul_self_nonneg u)

--- a/TauCeti/Analysis/PDE/LowerOrder.lean
+++ b/TauCeti/Analysis/PDE/LowerOrder.lean
@@ -1,0 +1,323 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+import TauCeti.Analysis.PDE.UniformEllipticity
+import Mathlib.Analysis.InnerProductSpace.LinearMap
+import Mathlib.Analysis.Normed.Operator.Mul
+
+/-!
+# Lower-order pointwise forms for divergence-form PDEs
+
+The divergence-form roadmap keeps the principal elliptic coefficient, first-order drift,
+and zeroth-order mass coefficient as separate named hypotheses.  The principal matrix
+coefficient lives in `TauCeti.Analysis.PDE.UniformEllipticity`; this file records the
+pointwise bundled forms and explicit bounds for the lower-order terms
+
+* `u ↦ b(x) · ∇u`, represented here by `driftForm b`;
+* `u ↦ c(x) u`, represented in the weak form by `massForm c`.
+
+These are only pointwise continuous bilinear maps.  They are the finite-dimensional
+estimates later integrated over `Ω` once the weak-derivative Sobolev spaces are available.
+
+## Main declarations
+
+* `TauCeti.PDE.driftForm`: the continuous bilinear map `(u, ξ) ↦ u * ⟪b, ξ⟫`.
+* `TauCeti.PDE.massForm`: the continuous bilinear map `(u, v) ↦ c * u * v`.
+* `TauCeti.PDE.LowerOrderBoundedOn`: explicit bounds for drift and mass coefficients on a
+  domain.
+* `TauCeti.PDE.NonnegativeMassOn`: nonnegative bounded mass coefficients.
+-/
+
+namespace TauCeti
+
+namespace PDE
+
+open scoped InnerProductSpace
+
+variable {X n : Type*} [Fintype n]
+
+/-- The pointwise first-order drift form `(u, ξ) ↦ u * ⟪b, ξ⟫`.
+
+In a weak formulation this is the integrand modelling a lower-order term such as
+`bᵢ ∂ᵢu v`, after one scalar argument represents the test function and the vector argument
+represents the gradient. -/
+noncomputable def driftForm (b : EuclideanSpace ℝ n) :
+    ℝ →L[ℝ] EuclideanSpace ℝ n →L[ℝ] ℝ :=
+  LinearMap.mkContinuous₂
+    (LinearMap.mk₂ ℝ (fun u ξ => u * ⟪b, ξ⟫_ℝ)
+      (fun u v ξ => by ring)
+      (fun a u ξ => by ring)
+      (fun u ξ η => by simp [inner_add_right, mul_add])
+      (fun a u ξ => by rw [inner_smul_right]; ring))
+    ‖b‖
+    (fun u ξ => by
+      rw [LinearMap.mk₂_apply, norm_mul]
+      calc
+        ‖u‖ * ‖⟪b, ξ⟫_ℝ‖ ≤ ‖u‖ * (‖b‖ * ‖ξ‖) := by
+          gcongr
+          exact norm_inner_le_norm b ξ
+        _ = ‖b‖ * ‖u‖ * ‖ξ‖ := by ring)
+
+/-- The drift form is the expected scalar times dot-product expression. -/
+@[simp]
+lemma driftForm_apply (b : EuclideanSpace ℝ n) (u : ℝ) (ξ : EuclideanSpace ℝ n) :
+    driftForm b u ξ = u * ⟪b, ξ⟫_ℝ := by
+  simp [driftForm]
+
+/-- The pointwise drift form is linear under scalar multiplication of the coefficient vector. -/
+@[simp]
+lemma driftForm_smul_apply (a : ℝ) (b : EuclideanSpace ℝ n) (u : ℝ)
+    (ξ : EuclideanSpace ℝ n) :
+    driftForm (a • b) u ξ = a * driftForm b u ξ := by
+  rw [driftForm_apply, driftForm_apply, real_inner_smul_left]
+  ring
+
+/-- A norm bound for the pointwise drift form in terms of the coefficient norm. -/
+lemma norm_driftForm_apply_le (b : EuclideanSpace ℝ n) (u : ℝ) (ξ : EuclideanSpace ℝ n) :
+    ‖driftForm b u ξ‖ ≤ ‖b‖ * ‖u‖ * ‖ξ‖ := by
+  rw [driftForm_apply, norm_mul]
+  calc
+    ‖u‖ * ‖⟪b, ξ⟫_ℝ‖ ≤ ‖u‖ * (‖b‖ * ‖ξ‖) := by
+      gcongr
+      exact norm_inner_le_norm b ξ
+    _ = ‖b‖ * ‖u‖ * ‖ξ‖ := by ring
+
+/-- A bound on the coefficient norm gives the corresponding pointwise drift estimate. -/
+lemma norm_driftForm_apply_le_of_norm_le {b : EuclideanSpace ℝ n} {beta : ℝ}
+    (hb : ‖b‖ ≤ beta) (u : ℝ) (ξ : EuclideanSpace ℝ n) :
+    ‖driftForm b u ξ‖ ≤ beta * ‖u‖ * ‖ξ‖ := by
+  exact (norm_driftForm_apply_le b u ξ).trans <| by
+    gcongr
+
+/-- The operator norm of the drift form is bounded by the coefficient norm. -/
+lemma opNorm_driftForm_le (b : EuclideanSpace ℝ n) :
+    ‖driftForm b‖ ≤ ‖b‖ :=
+  (driftForm b).opNorm_le_bound₂ (norm_nonneg b) (norm_driftForm_apply_le b)
+
+/-- A bound on the coefficient norm bounds the operator norm of the drift form. -/
+lemma opNorm_driftForm_le_of_norm_le {b : EuclideanSpace ℝ n} {beta : ℝ}
+    (hb : ‖b‖ ≤ beta) :
+    ‖driftForm b‖ ≤ beta :=
+  (opNorm_driftForm_le b).trans hb
+
+/-- The pointwise zeroth-order mass form `(u, v) ↦ c * u * v`. -/
+noncomputable def massForm (c : ℝ) : ℝ →L[ℝ] ℝ →L[ℝ] ℝ :=
+  LinearMap.mkContinuous₂
+    (LinearMap.mk₂ ℝ (fun u v => c * u * v)
+      (fun u v w => by ring)
+      (fun a u v => by ring)
+      (fun u v w => by ring)
+      (fun a u v => by ring))
+    ‖c‖
+    (fun u v => by
+      rw [LinearMap.mk₂_apply, norm_mul, norm_mul, mul_assoc])
+
+/-- The mass form is the expected product expression. -/
+@[simp]
+lemma massForm_apply (c u v : ℝ) :
+    massForm c u v = c * u * v := by
+  simp [massForm]
+
+/-- The zero mass coefficient gives the zero pointwise mass form. -/
+@[simp]
+lemma massForm_zero_apply (u v : ℝ) :
+    massForm 0 u v = 0 := by
+  simp [massForm_apply]
+
+/-- The mass form is additive in the coefficient. -/
+@[simp]
+lemma massForm_add_apply (c d u v : ℝ) :
+    massForm (c + d) u v = massForm c u v + massForm d u v := by
+  simp [massForm_apply]
+  ring
+
+/-- The mass form is linear under scalar multiplication of the coefficient. -/
+@[simp]
+lemma massForm_smul_apply (a c u v : ℝ) :
+    massForm (a * c) u v = a * massForm c u v := by
+  simp [massForm_apply]
+  ring
+
+/-- A norm bound for the pointwise mass form in terms of the coefficient absolute value. -/
+lemma norm_massForm_apply_le (c u v : ℝ) :
+    ‖massForm c u v‖ ≤ ‖c‖ * ‖u‖ * ‖v‖ := by
+  rw [massForm_apply, norm_mul, norm_mul, mul_assoc]
+
+/-- A bound on the coefficient absolute value gives the corresponding pointwise mass estimate. -/
+lemma norm_massForm_apply_le_of_norm_le {c gamma : ℝ} (hc : ‖c‖ ≤ gamma) (u v : ℝ) :
+    ‖massForm c u v‖ ≤ gamma * ‖u‖ * ‖v‖ := by
+  exact (norm_massForm_apply_le c u v).trans <| by
+    gcongr
+
+/-- The operator norm of the mass form is bounded by the coefficient absolute value. -/
+lemma opNorm_massForm_le (c : ℝ) :
+    ‖massForm c‖ ≤ ‖c‖ :=
+  (massForm c).opNorm_le_bound₂ (norm_nonneg c) (norm_massForm_apply_le c)
+
+/-- A bound on the coefficient absolute value bounds the operator norm of the mass form. -/
+lemma opNorm_massForm_le_of_norm_le {c gamma : ℝ} (hc : ‖c‖ ≤ gamma) :
+    ‖massForm c‖ ≤ gamma :=
+  (opNorm_massForm_le c).trans hc
+
+/-- Bounded lower-order coefficients on a domain, with explicit constants.
+
+`LowerOrderBoundedOn Ω b c beta gamma` means that on `Ω`, the drift coefficient vector
+has norm at most `beta` and the mass coefficient has absolute value at most `gamma`. -/
+def LowerOrderBoundedOn (Ω : Set X) (b : X → EuclideanSpace ℝ n) (c : X → ℝ)
+    (beta gamma : ℝ) : Prop :=
+  0 ≤ beta ∧ 0 ≤ gamma ∧
+    ∀ ⦃x⦄, x ∈ Ω → ‖b x‖ ≤ beta ∧ ‖c x‖ ≤ gamma
+
+/-- Characteristic restatement of bounded lower-order coefficients. -/
+lemma lowerOrderBoundedOn_iff {Ω : Set X} {b : X → EuclideanSpace ℝ n} {c : X → ℝ}
+    {beta gamma : ℝ} :
+    LowerOrderBoundedOn Ω b c beta gamma ↔
+      0 ≤ beta ∧ 0 ≤ gamma ∧
+        ∀ ⦃x⦄, x ∈ Ω → ‖b x‖ ≤ beta ∧ ‖c x‖ ≤ gamma :=
+  Iff.rfl
+
+namespace LowerOrderBoundedOn
+
+variable {Ω Ω' : Set X} {b : X → EuclideanSpace ℝ n} {c : X → ℝ}
+variable {beta gamma beta' gamma' : ℝ}
+
+/-- The drift bound is nonnegative. -/
+@[grind →]
+lemma beta_nonneg (h : LowerOrderBoundedOn Ω b c beta gamma) : 0 ≤ beta :=
+  h.1
+
+/-- The mass bound is nonnegative. -/
+@[grind →]
+lemma gamma_nonneg (h : LowerOrderBoundedOn Ω b c beta gamma) : 0 ≤ gamma :=
+  h.2.1
+
+/-- The pointwise drift coefficient bound. -/
+@[grind =>]
+lemma drift_bound (h : LowerOrderBoundedOn Ω b c beta gamma) {x : X} (hx : x ∈ Ω) :
+    ‖b x‖ ≤ beta :=
+  (h.2.2 hx).1
+
+/-- The pointwise mass coefficient bound. -/
+@[grind =>]
+lemma mass_bound (h : LowerOrderBoundedOn Ω b c beta gamma) {x : X} (hx : x ∈ Ω) :
+    ‖c x‖ ≤ gamma :=
+  (h.2.2 hx).2
+
+/-- Restricting the domain preserves bounded lower-order coefficients. -/
+lemma mono_set (h : LowerOrderBoundedOn Ω b c beta gamma) (hΩ : Ω' ⊆ Ω) :
+    LowerOrderBoundedOn Ω' b c beta gamma :=
+  ⟨h.beta_nonneg, h.gamma_nonneg, fun {_} hx => h.2.2 (hΩ hx)⟩
+
+/-- Increasing either bound preserves bounded lower-order coefficients. -/
+lemma mono_constants (h : LowerOrderBoundedOn Ω b c beta gamma)
+    (hbeta : beta ≤ beta') (hgamma : gamma ≤ gamma') :
+    LowerOrderBoundedOn Ω b c beta' gamma' :=
+  ⟨h.beta_nonneg.trans hbeta, h.gamma_nonneg.trans hgamma,
+    fun {_} hx => ⟨(h.drift_bound hx).trans hbeta, (h.mass_bound hx).trans hgamma⟩⟩
+
+/-- Constructor from separate side conditions and pointwise bounds. -/
+lemma of_bounds (hbeta : 0 ≤ beta) (hgamma : 0 ≤ gamma)
+    (hb : ∀ ⦃x⦄, x ∈ Ω → ‖b x‖ ≤ beta)
+    (hc : ∀ ⦃x⦄, x ∈ Ω → ‖c x‖ ≤ gamma) :
+    LowerOrderBoundedOn Ω b c beta gamma :=
+  ⟨hbeta, hgamma, fun {_} hx => ⟨hb hx, hc hx⟩⟩
+
+/-- Pointwise boundedness of the drift form supplied by bounded lower-order coefficients. -/
+@[grind =>]
+lemma norm_driftForm_le (h : LowerOrderBoundedOn Ω b c beta gamma) {x : X}
+    (hx : x ∈ Ω) (u : ℝ) (ξ : EuclideanSpace ℝ n) :
+    ‖driftForm (b x) u ξ‖ ≤ beta * ‖u‖ * ‖ξ‖ :=
+  norm_driftForm_apply_le_of_norm_le (h.drift_bound hx) u ξ
+
+/-- Operator-norm boundedness of the drift form supplied by bounded lower-order coefficients. -/
+@[grind =>]
+lemma opNorm_driftForm_le (h : LowerOrderBoundedOn Ω b c beta gamma) {x : X}
+    (hx : x ∈ Ω) :
+    ‖driftForm (b x)‖ ≤ beta :=
+  PDE.opNorm_driftForm_le_of_norm_le (h.drift_bound hx)
+
+/-- Pointwise boundedness of the mass form supplied by bounded lower-order coefficients. -/
+@[grind =>]
+lemma norm_massForm_le (h : LowerOrderBoundedOn Ω b c beta gamma) {x : X}
+    (hx : x ∈ Ω) (u v : ℝ) :
+    ‖massForm (c x) u v‖ ≤ gamma * ‖u‖ * ‖v‖ :=
+  norm_massForm_apply_le_of_norm_le (h.mass_bound hx) u v
+
+/-- Operator-norm boundedness of the mass form supplied by bounded lower-order coefficients. -/
+@[grind =>]
+lemma opNorm_massForm_le (h : LowerOrderBoundedOn Ω b c beta gamma) {x : X}
+    (hx : x ∈ Ω) :
+    ‖massForm (c x)‖ ≤ gamma :=
+  PDE.opNorm_massForm_le_of_norm_le (h.mass_bound hx)
+
+end LowerOrderBoundedOn
+
+/-- Nonnegative bounded zeroth-order coefficients on a domain. -/
+def NonnegativeMassOn (Ω : Set X) (c : X → ℝ) (gamma : ℝ) : Prop :=
+  0 ≤ gamma ∧ ∀ ⦃x⦄, x ∈ Ω → 0 ≤ c x ∧ c x ≤ gamma
+
+/-- Characteristic restatement of nonnegative bounded mass coefficients. -/
+lemma nonnegativeMassOn_iff {Ω : Set X} {c : X → ℝ} {gamma : ℝ} :
+    NonnegativeMassOn Ω c gamma ↔
+      0 ≤ gamma ∧ ∀ ⦃x⦄, x ∈ Ω → 0 ≤ c x ∧ c x ≤ gamma :=
+  Iff.rfl
+
+namespace NonnegativeMassOn
+
+variable {Ω Ω' : Set X} {c : X → ℝ} {gamma gamma' : ℝ}
+
+/-- The mass bound is nonnegative. -/
+@[grind →]
+lemma gamma_nonneg (h : NonnegativeMassOn Ω c gamma) : 0 ≤ gamma :=
+  h.1
+
+/-- The mass coefficient is pointwise nonnegative. -/
+@[grind =>]
+lemma nonneg (h : NonnegativeMassOn Ω c gamma) {x : X} (hx : x ∈ Ω) : 0 ≤ c x :=
+  (h.2 hx).1
+
+/-- The mass coefficient is pointwise bounded above. -/
+@[grind =>]
+lemma upper_bound (h : NonnegativeMassOn Ω c gamma) {x : X} (hx : x ∈ Ω) :
+    c x ≤ gamma :=
+  (h.2 hx).2
+
+/-- A nonnegative bounded mass coefficient is absolutely bounded. -/
+@[grind =>]
+lemma norm_bound (h : NonnegativeMassOn Ω c gamma) {x : X} (hx : x ∈ Ω) :
+    ‖c x‖ ≤ gamma := by
+  simpa [Real.norm_eq_abs, abs_of_nonneg (h.nonneg hx)] using h.upper_bound hx
+
+/-- Restricting the domain preserves nonnegative bounded mass coefficients. -/
+lemma mono_set (h : NonnegativeMassOn Ω c gamma) (hΩ : Ω' ⊆ Ω) :
+    NonnegativeMassOn Ω' c gamma :=
+  ⟨h.gamma_nonneg, fun {_} hx => h.2 (hΩ hx)⟩
+
+/-- Increasing the upper bound preserves nonnegative bounded mass coefficients. -/
+lemma mono_constant (h : NonnegativeMassOn Ω c gamma) (hgamma : gamma ≤ gamma') :
+    NonnegativeMassOn Ω c gamma' :=
+  ⟨h.gamma_nonneg.trans hgamma,
+    fun {_} hx => ⟨h.nonneg hx, (h.upper_bound hx).trans hgamma⟩⟩
+
+/-- Nonnegative bounded mass coefficients produce lower-order bounds with zero drift. -/
+lemma lowerOrderBoundedOn_zero_drift (h : NonnegativeMassOn Ω c gamma) :
+    LowerOrderBoundedOn Ω (fun _ => (0 : EuclideanSpace ℝ n)) c 0 gamma :=
+  LowerOrderBoundedOn.of_bounds le_rfl h.gamma_nonneg
+    (fun {_} _ => by simp) (fun {_} hx => h.norm_bound hx)
+
+end NonnegativeMassOn
+
+/-- Zero lower-order coefficients are bounded by zero. -/
+lemma lowerOrderBoundedOn_zero (Ω : Set X) :
+    LowerOrderBoundedOn Ω (fun _ => (0 : EuclideanSpace ℝ n)) (fun _ => 0) 0 0 :=
+  LowerOrderBoundedOn.of_bounds le_rfl le_rfl (fun {_} _ => by simp) (fun {_} _ => by simp)
+
+/-- A constant nonnegative mass coefficient is nonnegative and bounded by itself. -/
+lemma nonnegativeMassOn_const_self (Ω : Set X) {c : ℝ} (hc : 0 ≤ c) :
+    NonnegativeMassOn Ω (fun _ => c) c :=
+  ⟨hc, fun {_} _ => ⟨hc, le_rfl⟩⟩
+
+end PDE
+
+end TauCeti


### PR DESCRIPTION
This PR packages the pointwise lower-order coefficient forms needed for TauCetiRoadmap/PDE/README.md, Lane D, target 16 "Weak formulation", specifically the divergence-form operator `L u = -∂ⱼ(aⁱʲ ∂ᵢ u) + bⁱ ∂ᵢ u + c u` and its weak energy integrands. It adds bundled continuous bilinear forms for the drift term `(u, ξ) ↦ u * ⟪b, ξ⟫` and the mass term `(u, v) ↦ c * u * v`, plus explicit boundedness predicates and pointwise/operator-norm estimates that later integrate over `Ω` once the Sobolev domain spaces land.

No Mathlib infrastructure is vendored. The construction reuses Mathlib's `LinearMap.mkContinuous₂`, bundled continuous multiplication, inner-product estimates, and TauCeti's existing PDE coefficient namespace and root import pattern.

Verified with `lake exe cache get`, `lake build`, and `lake exe axioms`.

🤖 Prepared with Codex