### PR TITLE
feat: add comodule zero object

### DIFF
--- a/TauCeti.lean
+++ b/TauCeti.lean
@@ -12,6 +12,7 @@ import TauCeti.Algebra.Coalgebra.Comodule.MatrixCoefficient
 import TauCeti.Algebra.Coalgebra.Comodule.Preadditive
 import TauCeti.Algebra.Coalgebra.Comodule.Transport
 import TauCeti.Algebra.Coalgebra.Comodule.Trivial
+import TauCeti.Algebra.Coalgebra.Comodule.Zero
 import TauCeti.Algebra.Coalgebra.ComoduleCat
 import TauCeti.AlgebraicGeometry.WeilDivisor
 import TauCeti.AlgebraicTopology.UniversalCover.Deck.Connected

--- a/TauCeti/Algebra/Coalgebra/Comodule/Finite.lean
+++ b/TauCeti/Algebra/Coalgebra/Comodule/Finite.lean
@@ -2,8 +2,8 @@
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 -/
-import Mathlib.CategoryTheory.ObjectProperty.FullSubcategory
-import TauCeti.Algebra.Coalgebra.ComoduleCat
+import Mathlib.CategoryTheory.ObjectProperty.ContainsZero
+import TauCeti.Algebra.Coalgebra.Comodule.Zero
 
 /-!
 # Finitely generated comodules
@@ -24,6 +24,8 @@ reconstruction should be built on this full subcategory rather than on all comod
 * `TauCeti.FGComoduleCat.of`: build a finitely generated bundled comodule from unbundled data.
 * `TauCeti.FGComoduleCat.ofHom`: lift an unbundled comodule morphism between finitely generated
   comodules.
+* `TauCeti.FGComoduleCat.isZero_zero`: `FGComoduleCat.zero` is a zero object.
+* `HasZeroObject (FGComoduleCat R C)`.
 
 ## References
 
@@ -33,7 +35,7 @@ algebra". The construction follows Mathlib's `FGModuleCat` pattern: finite objec
 subcategory defined by the object property `Module.Finite`.
 -/
 
-open CategoryTheory
+open CategoryTheory CategoryTheory.Limits
 
 namespace TauCeti
 
@@ -55,6 +57,15 @@ module. -/
 theorem isFG_iff (M : ComoduleCat.{u, v, w} R C) :
     isFG (R := R) (C := C) M ↔ Module.Finite R M :=
   Iff.rfl
+
+/-- The zero comodule is finitely generated. -/
+theorem finite_zero : Module.Finite R (zero R C : ComoduleCat.{u, v, w} R C) := by
+  rw [zero]
+  infer_instance
+
+/-- The finite-generation property contains the zero comodule. -/
+instance isFG_containsZero : (isFG (R := R) (C := C)).ContainsZero where
+  exists_zero := ⟨zero R C, isZero_zero R C, finite_zero R C⟩
 
 end ComoduleCat
 
@@ -154,6 +165,54 @@ theorem ofHom_apply {M N : Type w} [AddCommMonoid M] [Module R M] [Comodule R C 
     [Module.Finite R N] (f : Comodule.Hom R C M N) (m : M) :
     ofHom (R := R) (C := C) f m = f m :=
   rfl
+
+variable (R C)
+
+/-- The bundled finitely generated zero right comodule. -/
+def zero : FGComoduleCat.{u, v, w} R C :=
+  ⟨ComoduleCat.zero R C, ComoduleCat.finite_zero R C⟩
+
+/-- The ambient comodule underlying the finitely generated zero comodule is the zero comodule. -/
+@[simp]
+theorem zero_obj :
+    (zero R C : FGComoduleCat.{u, v, w} R C).obj = ComoduleCat.zero R C :=
+  rfl
+
+/-- The named finitely generated zero comodule is a zero object. -/
+theorem isZero_zero : IsZero (zero R C : FGComoduleCat.{u, v, w} R C) :=
+  IsZero.of_full_of_faithful_of_isZero (ComoduleCat.isFG (R := R) (C := C)).ι (zero R C)
+    (ComoduleCat.isZero_zero R C)
+
+/-- Any morphism from the named finitely generated zero comodule is zero. -/
+theorem zero_hom_eq_zero (M : FGComoduleCat.{u, v, w} R C) (f : zero R C ⟶ M) : f = 0 :=
+  (isZero_zero (R := R) (C := C)).eq_of_src f 0
+
+/-- Any morphism to the named finitely generated zero comodule is zero. -/
+theorem hom_zero_eq_zero (M : FGComoduleCat.{u, v, w} R C) (f : M ⟶ zero R C) : f = 0 :=
+  (isZero_zero (R := R) (C := C)).eq_of_tgt f 0
+
+/-- The canonical morphism out of the named finitely generated zero comodule is the zero
+morphism. -/
+@[simp]
+theorem isZero_zero_to (M : FGComoduleCat.{u, v, w} R C) :
+    (isZero_zero (R := R) (C := C)).to_ M = 0 :=
+  zero_hom_eq_zero (R := R) (C := C) M _
+
+/-- The canonical morphism into the named finitely generated zero comodule is the zero morphism. -/
+@[simp]
+theorem isZero_zero_from (M : FGComoduleCat.{u, v, w} R C) :
+    (isZero_zero (R := R) (C := C)).from_ M = 0 :=
+  hom_zero_eq_zero (R := R) (C := C) M _
+
+/-- Morphisms from the named finitely generated zero comodule are unique. -/
+@[ext]
+theorem zero_hom_ext {M : FGComoduleCat.{u, v, w} R C} (f g : zero R C ⟶ M) : f = g :=
+  (isZero_zero (R := R) (C := C)).eq_of_src f g
+
+/-- Morphisms to the named finitely generated zero comodule are unique. -/
+@[ext]
+theorem hom_zero_ext {M : FGComoduleCat.{u, v, w} R C} (f g : M ⟶ zero R C) : f = g :=
+  (isZero_zero (R := R) (C := C)).eq_of_tgt f g
 
 end FGComoduleCat
 

--- a/TauCeti/Algebra/Coalgebra/Comodule/Zero.lean
+++ b/TauCeti/Algebra/Coalgebra/Comodule/Zero.lean
@@ -1,0 +1,117 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+import Mathlib.CategoryTheory.Limits.Shapes.ZeroObjects
+import TauCeti.Algebra.Coalgebra.ComoduleCat
+
+/-!
+# The zero comodule
+
+This file adds the zero object for right comodules over a coalgebra. This is Layer 1
+infrastructure for the reductive-groups roadmap target "Comodules over a coalgebra/Hopf
+algebra": before the finite-dimensional comodule category can be used as the additive
+representation category, it needs the standard zero object compatible with the existing zero
+morphisms.
+
+The zero comodule is the unique coaction on `PUnit`. We expose it both unbundled and bundled,
+and register a zero-object instance for `ComoduleCat`.
+
+## Main declarations
+
+* `TauCeti.Comodule.instPUnit`: the zero right comodule on `PUnit`.
+* `TauCeti.ComoduleCat.zero`: the bundled zero comodule.
+* `HasZeroObject (ComoduleCat R C)`.
+
+## References
+
+The construction is the standard zero object in the category of comodules; see Sweedler,
+*Hopf Algebras*, Chapter 2. It supplies an additive-category prerequisite for
+`TauCetiRoadmap/ReductiveGroups/README.md`, Layer 1, "Comodules over a coalgebra/Hopf
+algebra".
+-/
+
+open CategoryTheory CategoryTheory.Limits
+open scoped TensorProduct
+
+namespace TauCeti
+
+universe u v w
+
+namespace Comodule
+
+variable (R : Type u) (C : Type v)
+variable [CommSemiring R]
+variable [AddCommMonoid C] [Module R C] [Coalgebra R C]
+
+/-- The unique right-comodule structure on the zero module `PUnit`. -/
+instance instPUnit : Comodule R C PUnit where
+  coact := 0
+  coassoc := by
+    ext x
+    exact Subsingleton.elim _ _
+  lTensor_counit_comp_coact := by
+    ext x
+    exact Subsingleton.elim _ _
+
+/-- The coaction on the zero comodule is the zero linear map. -/
+@[simp]
+theorem punit_coact : coact (R := R) (C := C) (M := PUnit) = 0 :=
+  rfl
+
+end Comodule
+
+namespace ComoduleCat
+
+variable (R : Type u) (C : Type v)
+variable [CommSemiring R]
+variable [AddCommMonoid C] [Module R C] [Coalgebra R C]
+
+/-- The bundled zero right comodule. -/
+abbrev zero : ComoduleCat.{u, v, w} R C :=
+  of R C PUnit.{w + 1}
+
+/-- The bundled zero comodule has carrier `PUnit`. -/
+@[simp]
+theorem zero_carrier : (zero R C : Type) = PUnit :=
+  rfl
+
+/-- The coaction on the bundled zero comodule is zero. -/
+@[simp]
+theorem zero_coact :
+    Comodule.coact (R := R) (C := C) (M := zero R C) = 0 :=
+  rfl
+
+/-- A comodule whose underlying type is subsingleton is a zero object. -/
+theorem isZero_of_subsingleton (M : ComoduleCat.{u, v, w} R C) [Subsingleton M] : IsZero M where
+  unique_to N :=
+    ⟨{ default := (0 : M ⟶ N)
+       uniq := by
+        intro f
+        ext m
+        rw [Subsingleton.elim m (0 : M)]
+        exact map_zero f.toLinearMap }⟩
+  unique_from N :=
+    ⟨{ default := (0 : N ⟶ M)
+       uniq := by
+        intro f
+        ext m
+        subsingleton }⟩
+
+/-- The category of right comodules has a zero object. -/
+instance hasZeroObject : HasZeroObject (ComoduleCat.{u, v, w} R C) :=
+  ⟨⟨zero R C, isZero_of_subsingleton (R := R) (C := C) (zero R C)⟩⟩
+
+/-- Every morphism out of the zero comodule is the zero morphism. -/
+theorem zero_hom_ext (M : ComoduleCat.{u, v, w} R C) (f : zero R C ⟶ M) : f = 0 := by
+  ext x
+  rw [Subsingleton.elim x (0 : zero R C)]
+  exact map_zero f.toLinearMap
+
+/-- Every morphism into the zero comodule is the zero morphism. -/
+theorem hom_zero_ext (M : ComoduleCat.{u, v, w} R C) (f : M ⟶ zero R C) : f = 0 := by
+  ext x
+
+end ComoduleCat
+
+end TauCeti

--- a/TauCeti/Algebra/Coalgebra/Comodule/Zero.lean
+++ b/TauCeti/Algebra/Coalgebra/Comodule/Zero.lean
@@ -20,7 +20,6 @@ concrete carrier.
 
 ## Main declarations
 
-* `TauCeti.Comodule.instPUnit`: the zero right comodule on `PUnit`.
 * `TauCeti.ComoduleCat.zero`: the bundled zero comodule.
 * `TauCeti.ComoduleCat.isZero_zero`: `ComoduleCat.zero` is a zero object.
 * `TauCeti.FGComoduleCat.isZero_zero`: `FGComoduleCat.zero` is a zero object.
@@ -50,7 +49,7 @@ variable [CommSemiring R]
 variable [AddCommMonoid C] [Module R C] [Coalgebra R C]
 
 /-- The unique right-comodule structure on the zero module `PUnit`. -/
-instance instPUnit : Comodule R C PUnit where
+private instance instPUnit : Comodule R C PUnit where
   coact := 0
   coassoc := by
     ext x
@@ -58,11 +57,6 @@ instance instPUnit : Comodule R C PUnit where
   lTensor_counit_comp_coact := by
     ext x
     exact Subsingleton.elim _ _
-
-/-- The coaction on the zero comodule is the zero linear map. -/
-@[simp]
-theorem punit_coact : coact (R := R) (C := C) (M := PUnit) = 0 :=
-  rfl
 
 end Comodule
 

--- a/TauCeti/Algebra/Coalgebra/Comodule/Zero.lean
+++ b/TauCeti/Algebra/Coalgebra/Comodule/Zero.lean
@@ -2,8 +2,8 @@
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 -/
-import Mathlib.CategoryTheory.Limits.Shapes.ZeroObjects
-import TauCeti.Algebra.Coalgebra.ComoduleCat
+import Mathlib.CategoryTheory.ObjectProperty.ContainsZero
+import TauCeti.Algebra.Coalgebra.Comodule.Finite
 
 /-!
 # The zero comodule
@@ -15,20 +15,22 @@ representation category, it needs the standard zero object compatible with the e
 morphisms.
 
 The zero comodule is the unique coaction on `PUnit`. We expose it both unbundled and bundled,
-and register a zero-object instance for `ComoduleCat`.
+and register zero-object instances for `ComoduleCat` and `FGComoduleCat`.
 
 ## Main declarations
 
 * `TauCeti.Comodule.instPUnit`: the zero right comodule on `PUnit`.
 * `TauCeti.ComoduleCat.zero`: the bundled zero comodule.
 * `HasZeroObject (ComoduleCat R C)`.
+* `HasZeroObject (FGComoduleCat R C)`.
 
 ## References
 
 The construction is the standard zero object in the category of comodules; see Sweedler,
 *Hopf Algebras*, Chapter 2. It supplies an additive-category prerequisite for
 `TauCetiRoadmap/ReductiveGroups/README.md`, Layer 1, "Comodules over a coalgebra/Hopf
-algebra".
+algebra". The proof that a subsingleton bundled comodule is zero follows Mathlib's
+`SemimoduleCat.isZero_of_subsingleton` / `ModuleCat.isZero_of_subsingleton` pattern.
 -/
 
 open CategoryTheory CategoryTheory.Limits
@@ -102,16 +104,34 @@ theorem isZero_of_subsingleton (M : ComoduleCat.{u, v, w} R C) [Subsingleton M] 
 instance hasZeroObject : HasZeroObject (ComoduleCat.{u, v, w} R C) :=
   ⟨⟨zero R C, isZero_of_subsingleton (R := R) (C := C) (zero R C)⟩⟩
 
-/-- Every morphism out of the zero comodule is the zero morphism. -/
-theorem zero_hom_ext (M : ComoduleCat.{u, v, w} R C) (f : zero R C ⟶ M) : f = 0 := by
-  ext x
-  rw [Subsingleton.elim x (0 : zero R C)]
-  exact map_zero f.toLinearMap
-
-/-- Every morphism into the zero comodule is the zero morphism. -/
-theorem hom_zero_ext (M : ComoduleCat.{u, v, w} R C) (f : M ⟶ zero R C) : f = 0 := by
-  ext x
+/-- The finite-generation property contains the zero comodule. -/
+instance isFG_containsZero : (isFG (R := R) (C := C)).ContainsZero where
+  exists_zero :=
+    ⟨zero R C, isZero_of_subsingleton (R := R) (C := C) (zero R C),
+      show Module.Finite R (zero R C) from inferInstance⟩
 
 end ComoduleCat
+
+namespace FGComoduleCat
+
+variable (R : Type u) (C : Type v)
+variable [CommSemiring R]
+variable [AddCommMonoid C] [Module R C] [Coalgebra R C]
+
+/-- The bundled finitely generated zero right comodule. -/
+abbrev zero : FGComoduleCat.{u, v, w} R C :=
+  ⟨ComoduleCat.zero R C, show Module.Finite R (ComoduleCat.zero R C) from inferInstance⟩
+
+/-- The ambient comodule underlying the finitely generated zero comodule is the zero comodule. -/
+@[simp]
+theorem zero_obj :
+    (zero R C : FGComoduleCat.{u, v, w} R C).obj = ComoduleCat.zero R C :=
+  rfl
+
+/-- The category of finitely generated right comodules has a zero object. -/
+instance hasZeroObject : HasZeroObject (FGComoduleCat.{u, v, w} R C) :=
+  inferInstance
+
+end FGComoduleCat
 
 end TauCeti

--- a/TauCeti/Algebra/Coalgebra/Comodule/Zero.lean
+++ b/TauCeti/Algebra/Coalgebra/Comodule/Zero.lean
@@ -14,13 +14,16 @@ algebra": before the finite-dimensional comodule category can be used as the add
 representation category, it needs the standard zero object compatible with the existing zero
 morphisms.
 
-The zero comodule is the unique coaction on `PUnit`. We expose it both unbundled and bundled,
-and register zero-object instances for `ComoduleCat` and `FGComoduleCat`.
+The zero comodule is implemented by the unique coaction on `PUnit`. The bundled API exposes
+the named zero objects through their `IsZero` characterizations, rather than through the
+concrete carrier.
 
 ## Main declarations
 
 * `TauCeti.Comodule.instPUnit`: the zero right comodule on `PUnit`.
 * `TauCeti.ComoduleCat.zero`: the bundled zero comodule.
+* `TauCeti.ComoduleCat.isZero_zero`: `ComoduleCat.zero` is a zero object.
+* `TauCeti.FGComoduleCat.isZero_zero`: `FGComoduleCat.zero` is a zero object.
 * `HasZeroObject (ComoduleCat R C)`.
 * `HasZeroObject (FGComoduleCat R C)`.
 
@@ -70,19 +73,8 @@ variable [CommSemiring R]
 variable [AddCommMonoid C] [Module R C] [Coalgebra R C]
 
 /-- The bundled zero right comodule. -/
-abbrev zero : ComoduleCat.{u, v, w} R C :=
+def zero : ComoduleCat.{u, v, w} R C :=
   of R C PUnit.{w + 1}
-
-/-- The bundled zero comodule has carrier `PUnit`. -/
-@[simp]
-theorem zero_carrier : (zero R C : Type) = PUnit :=
-  rfl
-
-/-- The coaction on the bundled zero comodule is zero. -/
-@[simp]
-theorem zero_coact :
-    Comodule.coact (R := R) (C := C) (M := zero R C) = 0 :=
-  rfl
 
 /-- A comodule whose underlying type is subsingleton is a zero object. -/
 theorem isZero_of_subsingleton (M : ComoduleCat.{u, v, w} R C) [Subsingleton M] : IsZero M where
@@ -100,15 +92,52 @@ theorem isZero_of_subsingleton (M : ComoduleCat.{u, v, w} R C) [Subsingleton M] 
         ext m
         subsingleton }⟩
 
+/-- The named zero comodule is a zero object. -/
+theorem isZero_zero : IsZero (zero R C : ComoduleCat.{u, v, w} R C) := by
+  rw [zero]
+  exact isZero_of_subsingleton (R := R) (C := C) (of R C PUnit.{w + 1})
+
+/-- Any morphism from the named zero comodule is zero. -/
+theorem zero_hom_eq_zero (M : ComoduleCat.{u, v, w} R C) (f : zero R C ⟶ M) : f = 0 :=
+  (isZero_zero (R := R) (C := C)).eq_of_src f 0
+
+/-- Any morphism to the named zero comodule is zero. -/
+theorem hom_zero_eq_zero (M : ComoduleCat.{u, v, w} R C) (f : M ⟶ zero R C) : f = 0 :=
+  (isZero_zero (R := R) (C := C)).eq_of_tgt f 0
+
+/-- The canonical morphism out of the named zero comodule is the zero morphism. -/
+@[simp]
+theorem isZero_zero_to (M : ComoduleCat.{u, v, w} R C) :
+    (isZero_zero (R := R) (C := C)).to_ M = 0 :=
+  zero_hom_eq_zero (R := R) (C := C) M _
+
+/-- The canonical morphism into the named zero comodule is the zero morphism. -/
+@[simp]
+theorem isZero_zero_from (M : ComoduleCat.{u, v, w} R C) :
+    (isZero_zero (R := R) (C := C)).from_ M = 0 :=
+  hom_zero_eq_zero (R := R) (C := C) M _
+
+/-- Morphisms from the named zero comodule are unique. -/
+@[ext]
+theorem zero_hom_ext {M : ComoduleCat.{u, v, w} R C} (f g : zero R C ⟶ M) : f = g :=
+  (isZero_zero (R := R) (C := C)).eq_of_src f g
+
+/-- Morphisms to the named zero comodule are unique. -/
+@[ext]
+theorem hom_zero_ext {M : ComoduleCat.{u, v, w} R C} (f g : M ⟶ zero R C) : f = g :=
+  (isZero_zero (R := R) (C := C)).eq_of_tgt f g
+
 /-- The category of right comodules has a zero object. -/
 instance hasZeroObject : HasZeroObject (ComoduleCat.{u, v, w} R C) :=
-  ⟨⟨zero R C, isZero_of_subsingleton (R := R) (C := C) (zero R C)⟩⟩
+  ⟨⟨zero R C, isZero_zero R C⟩⟩
 
 /-- The finite-generation property contains the zero comodule. -/
 instance isFG_containsZero : (isFG (R := R) (C := C)).ContainsZero where
   exists_zero :=
-    ⟨zero R C, isZero_of_subsingleton (R := R) (C := C) (zero R C),
-      show Module.Finite R (zero R C) from inferInstance⟩
+    ⟨zero R C, isZero_zero R C,
+      show Module.Finite R (zero R C) from by
+        rw [zero]
+        infer_instance⟩
 
 end ComoduleCat
 
@@ -119,8 +148,10 @@ variable [CommSemiring R]
 variable [AddCommMonoid C] [Module R C] [Coalgebra R C]
 
 /-- The bundled finitely generated zero right comodule. -/
-abbrev zero : FGComoduleCat.{u, v, w} R C :=
-  ⟨ComoduleCat.zero R C, show Module.Finite R (ComoduleCat.zero R C) from inferInstance⟩
+def zero : FGComoduleCat.{u, v, w} R C :=
+  ⟨ComoduleCat.zero R C, by
+    rw [ComoduleCat.zero]
+    exact show Module.Finite R (ComoduleCat.of R C PUnit.{w + 1}) from inferInstance⟩
 
 /-- The ambient comodule underlying the finitely generated zero comodule is the zero comodule. -/
 @[simp]
@@ -128,9 +159,45 @@ theorem zero_obj :
     (zero R C : FGComoduleCat.{u, v, w} R C).obj = ComoduleCat.zero R C :=
   rfl
 
+/-- The named finitely generated zero comodule is a zero object. -/
+theorem isZero_zero : IsZero (zero R C : FGComoduleCat.{u, v, w} R C) :=
+  IsZero.of_full_of_faithful_of_isZero (ComoduleCat.isFG (R := R) (C := C)).ι (zero R C)
+    (ComoduleCat.isZero_zero R C)
+
+/-- Any morphism from the named finitely generated zero comodule is zero. -/
+theorem zero_hom_eq_zero (M : FGComoduleCat.{u, v, w} R C) (f : zero R C ⟶ M) : f = 0 :=
+  (isZero_zero (R := R) (C := C)).eq_of_src f 0
+
+/-- Any morphism to the named finitely generated zero comodule is zero. -/
+theorem hom_zero_eq_zero (M : FGComoduleCat.{u, v, w} R C) (f : M ⟶ zero R C) : f = 0 :=
+  (isZero_zero (R := R) (C := C)).eq_of_tgt f 0
+
+/-- The canonical morphism out of the named finitely generated zero comodule is the zero
+morphism. -/
+@[simp]
+theorem isZero_zero_to (M : FGComoduleCat.{u, v, w} R C) :
+    (isZero_zero (R := R) (C := C)).to_ M = 0 :=
+  zero_hom_eq_zero (R := R) (C := C) M _
+
+/-- The canonical morphism into the named finitely generated zero comodule is the zero morphism. -/
+@[simp]
+theorem isZero_zero_from (M : FGComoduleCat.{u, v, w} R C) :
+    (isZero_zero (R := R) (C := C)).from_ M = 0 :=
+  hom_zero_eq_zero (R := R) (C := C) M _
+
+/-- Morphisms from the named finitely generated zero comodule are unique. -/
+@[ext]
+theorem zero_hom_ext {M : FGComoduleCat.{u, v, w} R C} (f g : zero R C ⟶ M) : f = g :=
+  (isZero_zero (R := R) (C := C)).eq_of_src f g
+
+/-- Morphisms to the named finitely generated zero comodule are unique. -/
+@[ext]
+theorem hom_zero_ext {M : FGComoduleCat.{u, v, w} R C} (f g : M ⟶ zero R C) : f = g :=
+  (isZero_zero (R := R) (C := C)).eq_of_tgt f g
+
 /-- The category of finitely generated right comodules has a zero object. -/
 instance hasZeroObject : HasZeroObject (FGComoduleCat.{u, v, w} R C) :=
-  inferInstance
+  ⟨⟨zero R C, isZero_zero R C⟩⟩
 
 end FGComoduleCat
 

--- a/TauCeti/Algebra/Coalgebra/Comodule/Zero.lean
+++ b/TauCeti/Algebra/Coalgebra/Comodule/Zero.lean
@@ -2,8 +2,7 @@
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 -/
-import Mathlib.CategoryTheory.ObjectProperty.ContainsZero
-import TauCeti.Algebra.Coalgebra.Comodule.Finite
+import TauCeti.Algebra.Coalgebra.ComoduleCat
 
 /-!
 # The zero comodule
@@ -22,9 +21,7 @@ concrete carrier.
 
 * `TauCeti.ComoduleCat.zero`: the bundled zero comodule.
 * `TauCeti.ComoduleCat.isZero_zero`: `ComoduleCat.zero` is a zero object.
-* `TauCeti.FGComoduleCat.isZero_zero`: `FGComoduleCat.zero` is a zero object.
 * `HasZeroObject (ComoduleCat R C)`.
-* `HasZeroObject (FGComoduleCat R C)`.
 
 ## References
 
@@ -125,74 +122,6 @@ theorem hom_zero_ext {M : ComoduleCat.{u, v, w} R C} (f g : M ⟶ zero R C) : f 
 instance hasZeroObject : HasZeroObject (ComoduleCat.{u, v, w} R C) :=
   ⟨⟨zero R C, isZero_zero R C⟩⟩
 
-/-- The finite-generation property contains the zero comodule. -/
-instance isFG_containsZero : (isFG (R := R) (C := C)).ContainsZero where
-  exists_zero :=
-    ⟨zero R C, isZero_zero R C,
-      show Module.Finite R (zero R C) from by
-        rw [zero]
-        infer_instance⟩
-
 end ComoduleCat
-
-namespace FGComoduleCat
-
-variable (R : Type u) (C : Type v)
-variable [CommSemiring R]
-variable [AddCommMonoid C] [Module R C] [Coalgebra R C]
-
-/-- The bundled finitely generated zero right comodule. -/
-def zero : FGComoduleCat.{u, v, w} R C :=
-  ⟨ComoduleCat.zero R C, by
-    rw [ComoduleCat.zero]
-    exact show Module.Finite R (ComoduleCat.of R C PUnit.{w + 1}) from inferInstance⟩
-
-/-- The ambient comodule underlying the finitely generated zero comodule is the zero comodule. -/
-@[simp]
-theorem zero_obj :
-    (zero R C : FGComoduleCat.{u, v, w} R C).obj = ComoduleCat.zero R C :=
-  rfl
-
-/-- The named finitely generated zero comodule is a zero object. -/
-theorem isZero_zero : IsZero (zero R C : FGComoduleCat.{u, v, w} R C) :=
-  IsZero.of_full_of_faithful_of_isZero (ComoduleCat.isFG (R := R) (C := C)).ι (zero R C)
-    (ComoduleCat.isZero_zero R C)
-
-/-- Any morphism from the named finitely generated zero comodule is zero. -/
-theorem zero_hom_eq_zero (M : FGComoduleCat.{u, v, w} R C) (f : zero R C ⟶ M) : f = 0 :=
-  (isZero_zero (R := R) (C := C)).eq_of_src f 0
-
-/-- Any morphism to the named finitely generated zero comodule is zero. -/
-theorem hom_zero_eq_zero (M : FGComoduleCat.{u, v, w} R C) (f : M ⟶ zero R C) : f = 0 :=
-  (isZero_zero (R := R) (C := C)).eq_of_tgt f 0
-
-/-- The canonical morphism out of the named finitely generated zero comodule is the zero
-morphism. -/
-@[simp]
-theorem isZero_zero_to (M : FGComoduleCat.{u, v, w} R C) :
-    (isZero_zero (R := R) (C := C)).to_ M = 0 :=
-  zero_hom_eq_zero (R := R) (C := C) M _
-
-/-- The canonical morphism into the named finitely generated zero comodule is the zero morphism. -/
-@[simp]
-theorem isZero_zero_from (M : FGComoduleCat.{u, v, w} R C) :
-    (isZero_zero (R := R) (C := C)).from_ M = 0 :=
-  hom_zero_eq_zero (R := R) (C := C) M _
-
-/-- Morphisms from the named finitely generated zero comodule are unique. -/
-@[ext]
-theorem zero_hom_ext {M : FGComoduleCat.{u, v, w} R C} (f g : zero R C ⟶ M) : f = g :=
-  (isZero_zero (R := R) (C := C)).eq_of_src f g
-
-/-- Morphisms to the named finitely generated zero comodule are unique. -/
-@[ext]
-theorem hom_zero_ext {M : FGComoduleCat.{u, v, w} R C} (f g : M ⟶ zero R C) : f = g :=
-  (isZero_zero (R := R) (C := C)).eq_of_tgt f g
-
-/-- The category of finitely generated right comodules has a zero object. -/
-instance hasZeroObject : HasZeroObject (FGComoduleCat.{u, v, w} R C) :=
-  ⟨⟨zero R C, isZero_zero R C⟩⟩
-
-end FGComoduleCat
 
 end TauCeti


### PR DESCRIPTION
This PR adds the zero right comodule and zero-object instance for `ComoduleCat`, advancing `TauCetiRoadmap/ReductiveGroups/README.md`, Layer 1 target "Comodules over a coalgebra/Hopf algebra", specifically the additive-category prerequisite for the finite-dimensional comodule representation category before tensor products, duals, and Tannakian structure. It defines the unique `PUnit` coaction, bundles it as `ComoduleCat.zero`, registers `HasZeroObject (ComoduleCat R C)`, and adds uniqueness lemmas for maps to and from the zero comodule. No Mathlib infrastructure is vendored; this reuses Mathlib `CategoryTheory.Limits.IsZero` / `HasZeroObject` and TauCeti existing `ComoduleCat` and zero-morphism API. Validated with `lake exe cache get`, `lake build`, and `lake exe axioms`. `lake build` ended with `Build completed successfully (3140 jobs).` `lake exe axioms` ended with `axioms: audited 938 TauCeti declaration(s); all within the allowlist [propext, Classical.choice, Quot.sound].`

🤖 Prepared with Codex
