### PR TITLE
fix: drop the Mathlib cache step from the Pages workflow

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -44,10 +44,7 @@ jobs:
           key: web-lake-${{ runner.os }}-${{ hashFiles('web/lake-manifest.json', 'web/lean-toolchain') }}
           restore-keys: web-lake-${{ runner.os }}-
 
-      - name: Fetch Mathlib oleans
-        run: lake exe cache get
-
-      - name: Build site (compiles Verso + checks the Mathlib examples)
+      - name: Build site (compiles Verso from source)
         run: lake build
 
       - name: Generate static site


### PR DESCRIPTION
This PR removes the `lake exe cache get` step from the Pages workflow. The site no longer depends on Mathlib (theorem snippets are now static, linked to their checked source), so there is no `cache` executable and the step failed the deploy. The site builds from Verso directly.

🤖 Prepared with Claude Code