### PR TITLE
feat: add comodule products

### DIFF
--- a/TauCeti.lean
+++ b/TauCeti.lean
@@ -13,6 +13,7 @@ import TauCeti.Algebra.Coalgebra.Comodule.Hom
 import TauCeti.Algebra.Coalgebra.Comodule.MatrixCoefficient
 import TauCeti.Algebra.Coalgebra.Comodule.MatrixCoefficientAdjoin
 import TauCeti.Algebra.Coalgebra.Comodule.Preadditive
+import TauCeti.Algebra.Coalgebra.Comodule.Prod
 import TauCeti.Algebra.Coalgebra.Comodule.Regular
 import TauCeti.Algebra.Coalgebra.Comodule.Transport
 import TauCeti.Algebra.Coalgebra.Comodule.Trivial

--- a/TauCeti/Algebra/Coalgebra/Comodule/Hom.lean
+++ b/TauCeti/Algebra/Coalgebra/Comodule/Hom.lean
@@ -81,6 +81,11 @@ theorem smul_toLinearMap (r : R) (f : Hom R C M N) :
 theorem zero_apply (m : M) : (0 : Hom R C M N) m = 0 :=
   rfl
 
+/-- Every comodule morphism sends zero to zero. -/
+@[simp]
+theorem apply_zero (f : Hom R C M N) : f (0 : M) = 0 :=
+  map_zero f.toLinearMap
+
 /-- Addition of comodule morphisms is pointwise addition. -/
 @[simp]
 theorem add_apply (f g : Hom R C M N) (m : M) : (f + g) m = f m + g m :=

--- a/TauCeti/Algebra/Coalgebra/Comodule/Prod.lean
+++ b/TauCeti/Algebra/Coalgebra/Comodule/Prod.lean
@@ -59,17 +59,6 @@ variable [AddCommMonoid P] [Module R P] [Comodule R C P]
 local notation "ρM" => coact (R := R) (C := C) (M := M)
 local notation "ρN" => coact (R := R) (C := C) (M := N)
 
-omit [Coalgebra R C] [Comodule R C M] in
-/-- The `g = h = id` special case of `TensorProduct.map_map_assoc`, phrased so it can rewrite
-the comodule coassociativity calculation below. This is only a local proof helper; the general
-associator naturality lives in Mathlib's `TensorProduct.map_map_assoc`. -/
-private theorem assoc_rTensor_rTensor_apply {Q : Type*} [AddCommMonoid Q] [Module R Q]
-    (f : M →ₗ[R] Q) (x : (M ⊗[R] C) ⊗[R] C) :
-    TensorProduct.assoc R Q C C ((f.rTensor C).rTensor C x)
-      = f.rTensor (C ⊗[R] C) (TensorProduct.assoc R M C C x) := by
-  simpa [LinearMap.rTensor] using
-    (TensorProduct.map_map_assoc f LinearMap.id LinearMap.id x).symm
-
 /-- The coaction of the product comodule `M × N`: coact on each factor, then include into the
 corresponding summand. This is the implementation of the `Comodule R C (M × N)` instance; the
 public characterizing equations are `prod_coact_apply`, `prod_coact_inl`, and `prod_coact_inr`. -/
@@ -108,7 +97,18 @@ private theorem prodCoassoc_inl (m : M) :
   rw [prodCoact_inl_apply]
   rw [← LinearMap.comp_apply (prodCoact.rTensor C), ← LinearMap.rTensor_comp,
     prodCoact_comp_inl, LinearMap.rTensor_comp]
-  simp only [LinearMap.comp_apply, assoc_rTensor_rTensor_apply, coassoc_apply]
+  have h :
+      TensorProduct.assoc R (M × N) C C
+        ((LinearMap.rTensor C (LinearMap.rTensor C (LinearMap.inl R M N)) ∘ₗ
+          LinearMap.rTensor C (coact (R := R) (C := C) (M := M))) (ρM m))
+        = (LinearMap.inl R M N).rTensor (C ⊗[R] C)
+          (TensorProduct.assoc R M C C
+            ((coact (R := R) (C := C) (M := M)).rTensor C (ρM m))) := by
+    simp only [LinearMap.comp_apply]
+    simpa [LinearMap.rTensor] using
+      (TensorProduct.map_map_assoc (LinearMap.inl R M N) LinearMap.id LinearMap.id
+        ((coact (R := R) (C := C) (M := M)).rTensor C (ρM m))).symm
+  rw [h, coassoc_apply]
   rw [← LinearMap.comp_apply (Coalgebra.comul.lTensor (M × N)),
     LinearMap.lTensor_comp_rTensor, ← LinearMap.comp_apply (LinearMap.rTensor (C ⊗[R] C) _),
     LinearMap.rTensor_comp_lTensor]
@@ -119,7 +119,18 @@ private theorem prodCoassoc_inr (n : N) :
   rw [prodCoact_inr_apply]
   rw [← LinearMap.comp_apply (prodCoact.rTensor C), ← LinearMap.rTensor_comp,
     prodCoact_comp_inr, LinearMap.rTensor_comp]
-  simp only [LinearMap.comp_apply, assoc_rTensor_rTensor_apply, coassoc_apply]
+  have h :
+      TensorProduct.assoc R (M × N) C C
+        ((LinearMap.rTensor C (LinearMap.rTensor C (LinearMap.inr R M N)) ∘ₗ
+          LinearMap.rTensor C (coact (R := R) (C := C) (M := N))) (ρN n))
+        = (LinearMap.inr R M N).rTensor (C ⊗[R] C)
+          (TensorProduct.assoc R N C C
+            ((coact (R := R) (C := C) (M := N)).rTensor C (ρN n))) := by
+    simp only [LinearMap.comp_apply]
+    simpa [LinearMap.rTensor] using
+      (TensorProduct.map_map_assoc (LinearMap.inr R M N) LinearMap.id LinearMap.id
+        ((coact (R := R) (C := C) (M := N)).rTensor C (ρN n))).symm
+  rw [h, coassoc_apply]
   rw [← LinearMap.comp_apply (Coalgebra.comul.lTensor (M × N)),
     LinearMap.lTensor_comp_rTensor, ← LinearMap.comp_apply (LinearMap.rTensor (C ⊗[R] C) _),
     LinearMap.rTensor_comp_lTensor]
@@ -285,11 +296,19 @@ def coprod (f : Hom R C M P) (g : Hom R C N P) : Hom R C (M × N) P where
 
 /-- The first inclusion recovers the first component of a morphism out of the coproduct. -/
 @[simp] theorem coprod_comp_inl (f : Hom R C M P) (g : Hom R C N P) :
-    comp (coprod f g) inl = f := by ext m; simp
+    comp (coprod f g) inl = f := by
+  ext m
+  simp only [comp_apply, coprod_apply, inl_apply]
+  change f m + g.toLinearMap 0 = f m
+  rw [map_zero g.toLinearMap, add_zero]
 
 /-- The second inclusion recovers the second component of a morphism out of the coproduct. -/
 @[simp] theorem coprod_comp_inr (f : Hom R C M P) (g : Hom R C N P) :
-    comp (coprod f g) inr = g := by ext n; simp
+    comp (coprod f g) inr = g := by
+  ext n
+  simp only [comp_apply, coprod_apply, inr_apply]
+  change f.toLinearMap 0 + g n = g n
+  rw [map_zero f.toLinearMap, zero_add]
 
 /-- A morphism into the product is determined by its two projections: two morphisms into
 `M × N` that agree after `fst` and after `snd` are equal. This is the uniqueness half of the

--- a/TauCeti/Algebra/Coalgebra/Comodule/Prod.lean
+++ b/TauCeti/Algebra/Coalgebra/Comodule/Prod.lean
@@ -239,6 +239,26 @@ def inr : Hom R C N (M × N) where
 /-- The inclusion `inr` sends `n` to `(0, n)`. -/
 @[simp] theorem inr_apply (n : N) : (inr : Hom R C N (M × N)) n = (0, n) := rfl
 
+/-- The projection `fst` has the underlying first projection linear map. -/
+@[simp]
+theorem fst_toLinearMap : (fst : Hom R C (M × N) M).toLinearMap = LinearMap.fst R M N :=
+  rfl
+
+/-- The projection `snd` has the underlying second projection linear map. -/
+@[simp]
+theorem snd_toLinearMap : (snd : Hom R C (M × N) N).toLinearMap = LinearMap.snd R M N :=
+  rfl
+
+/-- The inclusion `inl` has the underlying first inclusion linear map. -/
+@[simp]
+theorem inl_toLinearMap : (inl : Hom R C M (M × N)).toLinearMap = LinearMap.inl R M N :=
+  rfl
+
+/-- The inclusion `inr` has the underlying second inclusion linear map. -/
+@[simp]
+theorem inr_toLinearMap : (inr : Hom R C N (M × N)).toLinearMap = LinearMap.inr R M N :=
+  rfl
+
 /-- The morphism into a product induced by a pair of morphisms. -/
 def prod (f : Hom R C P M) (g : Hom R C P N) : Hom R C P (M × N) where
   toLinearMap := f.toLinearMap.prod g.toLinearMap
@@ -285,6 +305,18 @@ def coprod (f : Hom R C M P) (g : Hom R C N P) : Hom R C (M × N) P where
 /-- The morphism out of the coproduct applies as the sum of its component morphisms. -/
 @[simp] theorem coprod_apply (f : Hom R C M P) (g : Hom R C N P) (x : M × N) :
     (coprod f g) x = f x.1 + g x.2 := rfl
+
+/-- The morphism into a product has the product of the underlying linear maps. -/
+@[simp]
+theorem prod_toLinearMap (f : Hom R C P M) (g : Hom R C P N) :
+    (prod f g).toLinearMap = f.toLinearMap.prod g.toLinearMap :=
+  rfl
+
+/-- The morphism out of a coproduct has the coproduct of the underlying linear maps. -/
+@[simp]
+theorem coprod_toLinearMap (f : Hom R C M P) (g : Hom R C N P) :
+    (coprod f g).toLinearMap = f.toLinearMap.coprod g.toLinearMap :=
+  rfl
 
 /-- The first projection recovers the first component of a morphism into the product. -/
 @[simp] theorem fst_comp_prod (f : Hom R C P M) (g : Hom R C P N) :

--- a/TauCeti/Algebra/Coalgebra/Comodule/Prod.lean
+++ b/TauCeti/Algebra/Coalgebra/Comodule/Prod.lean
@@ -1,0 +1,289 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+import Mathlib.LinearAlgebra.Prod
+import TauCeti.Algebra.Coalgebra.Comodule.Hom
+
+/-!
+# Products of comodules
+
+For two right `C`-comodules `M` and `N` over an `R`-coalgebra `C`, this file equips the
+product module `M × N` with the canonical right `C`-coaction
+`(m, n) ↦ ι_M(ρ_M m) + ι_N(ρ_N n)`, where `ι_M`, `ι_N` are the inclusions into the first and
+second summand. With this structure the projections `M × N → M`, `M × N → N` and the
+inclusions `M → M × N`, `N → M × N` are comodule morphisms, and the universal properties of
+the product and the coproduct hold, so `M × N` is simultaneously the product and the coproduct
+of `M` and `N`: a direct sum of comodules.
+
+Together with the zero object (`TauCeti.Algebra.Coalgebra.Comodule.Zero`) and the preadditive
+structure (`TauCeti.Algebra.Coalgebra.Comodule.Preadditive`) this supplies the binary-biproduct
+ingredient of the (finite-dimensional) comodule representation category called for in Layer 1
+of the reductive-groups roadmap.
+
+## Main definitions
+
+* `TauCeti.Comodule.instProd`: the right `C`-comodule structure on `M × N`.
+* `TauCeti.Comodule.Hom.fst`, `TauCeti.Comodule.Hom.snd`: the projection comodule morphisms.
+* `TauCeti.Comodule.Hom.inl`, `TauCeti.Comodule.Hom.inr`: the inclusion comodule morphisms.
+* `TauCeti.Comodule.Hom.prod`, `TauCeti.Comodule.Hom.coprod`: the morphisms induced by the
+  universal properties of the product and the coproduct, characterized by
+  `fst_comp_prod`/`snd_comp_prod` and `coprod_comp_inl`/`coprod_comp_inr`, with the
+  biproduct relations `fst_comp_inl`, `snd_comp_inl`, `fst_comp_inr`, `snd_comp_inr`.
+
+## References
+
+This is the standard direct sum of comodules; see for example Sweedler, *Hopf Algebras*,
+Chapter 2. It supplies a binary-biproduct prerequisite for
+`TauCetiRoadmap/ReductiveGroups/README.md`, Layer 1, "Comodules over a coalgebra/Hopf
+algebra". It reuses Mathlib's `TensorProduct.assoc` associativity coherence and the
+`rTensor`/`lTensor` calculus from `Mathlib.LinearAlgebra.TensorProduct.Map`.
+-/
+
+open scoped TensorProduct
+
+namespace TauCeti
+
+universe u v w x y
+
+namespace Comodule
+
+variable {R : Type u} {C : Type v} {M : Type w} {N : Type x} {P : Type y}
+variable [CommSemiring R]
+variable [AddCommMonoid C] [Module R C] [Coalgebra R C]
+variable [AddCommMonoid M] [Module R M] [Comodule R C M]
+variable [AddCommMonoid N] [Module R N] [Comodule R C N]
+variable [AddCommMonoid P] [Module R P] [Comodule R C P]
+
+local notation "ρM" => coact (R := R) (C := C) (M := M)
+local notation "ρN" => coact (R := R) (C := C) (M := N)
+
+omit [Coalgebra R C] [Comodule R C M] in
+/-- A naturality lemma for the tensor associator against `rTensor` in the first factor,
+phrased so it can rewrite the comodule coassociativity calculation below. -/
+theorem assoc_rTensor_rTensor_apply {Q : Type*} [AddCommMonoid Q] [Module R Q] (f : M →ₗ[R] Q)
+    (x : (M ⊗[R] C) ⊗[R] C) :
+    TensorProduct.assoc R Q C C ((f.rTensor C).rTensor C x)
+      = f.rTensor (C ⊗[R] C) (TensorProduct.assoc R M C C x) := by
+  induction x with
+  | zero => simp
+  | tmul a c =>
+    induction a with
+    | zero => simp
+    | tmul m c' => simp
+    | add a b ha hb => simp only [TensorProduct.add_tmul, map_add, ha, hb]
+  | add a b ha hb => simp only [map_add, ha, hb]
+
+/-- The coaction of the product comodule `M × N`: coact on each factor, then include into the
+corresponding summand. -/
+noncomputable def prodCoact : (M × N) →ₗ[R] (M × N) ⊗[R] C :=
+  (LinearMap.inl R M N).rTensor C ∘ₗ ρM ∘ₗ LinearMap.fst R M N
+    + (LinearMap.inr R M N).rTensor C ∘ₗ ρN ∘ₗ LinearMap.snd R M N
+
+@[simp]
+theorem prodCoact_comp_inl :
+    prodCoact ∘ₗ LinearMap.inl R M N = (LinearMap.inl R M N).rTensor C ∘ₗ ρM := by
+  ext m; simp [prodCoact]
+
+@[simp]
+theorem prodCoact_comp_inr :
+    prodCoact ∘ₗ LinearMap.inr R M N = (LinearMap.inr R M N).rTensor C ∘ₗ ρN := by
+  ext n; simp [prodCoact]
+
+theorem prodCoact_apply (m : M) (n : N) :
+    prodCoact (m, n) = (LinearMap.inl R M N).rTensor C (ρM m)
+      + (LinearMap.inr R M N).rTensor C (ρN n) := by
+  simp [prodCoact]
+
+private theorem prodCoassoc_inl (m : M) :
+    TensorProduct.assoc R (M × N) C C (prodCoact.rTensor C (prodCoact (LinearMap.inl R M N m)))
+      = Coalgebra.comul.lTensor (M × N) (prodCoact (LinearMap.inl R M N m)) := by
+  rw [show prodCoact (LinearMap.inl R M N m) = (LinearMap.inl R M N).rTensor C (ρM m) from
+      congr($prodCoact_comp_inl m)]
+  rw [← LinearMap.comp_apply (prodCoact.rTensor C), ← LinearMap.rTensor_comp,
+    prodCoact_comp_inl, LinearMap.rTensor_comp]
+  simp only [LinearMap.comp_apply, assoc_rTensor_rTensor_apply, coassoc_apply]
+  rw [← LinearMap.comp_apply (Coalgebra.comul.lTensor (M × N)),
+    LinearMap.lTensor_comp_rTensor, ← LinearMap.comp_apply (LinearMap.rTensor (C ⊗[R] C) _),
+    LinearMap.rTensor_comp_lTensor]
+
+private theorem prodCoassoc_inr (n : N) :
+    TensorProduct.assoc R (M × N) C C (prodCoact.rTensor C (prodCoact (LinearMap.inr R M N n)))
+      = Coalgebra.comul.lTensor (M × N) (prodCoact (LinearMap.inr R M N n)) := by
+  rw [show prodCoact (LinearMap.inr R M N n) = (LinearMap.inr R M N).rTensor C (ρN n) from
+      congr($prodCoact_comp_inr n)]
+  rw [← LinearMap.comp_apply (prodCoact.rTensor C), ← LinearMap.rTensor_comp,
+    prodCoact_comp_inr, LinearMap.rTensor_comp]
+  simp only [LinearMap.comp_apply, assoc_rTensor_rTensor_apply, coassoc_apply]
+  rw [← LinearMap.comp_apply (Coalgebra.comul.lTensor (M × N)),
+    LinearMap.lTensor_comp_rTensor, ← LinearMap.comp_apply (LinearMap.rTensor (C ⊗[R] C) _),
+    LinearMap.rTensor_comp_lTensor]
+
+private theorem prodCounit_inl (m : M) :
+    (Coalgebra.counit : C →ₗ[R] R).lTensor (M × N) (prodCoact (LinearMap.inl R M N m))
+      = (LinearMap.inl R M N m) ⊗ₜ[R] (1 : R) := by
+  rw [show prodCoact (LinearMap.inl R M N m) = (LinearMap.inl R M N).rTensor C (ρM m) from
+      congr($prodCoact_comp_inl m)]
+  rw [← LinearMap.comp_apply, LinearMap.lTensor_comp_rTensor, ← LinearMap.rTensor_comp_lTensor,
+    LinearMap.comp_apply, lTensor_counit_coact]
+  simp
+
+private theorem prodCounit_inr (n : N) :
+    (Coalgebra.counit : C →ₗ[R] R).lTensor (M × N) (prodCoact (LinearMap.inr R M N n))
+      = (LinearMap.inr R M N n) ⊗ₜ[R] (1 : R) := by
+  rw [show prodCoact (LinearMap.inr R M N n) = (LinearMap.inr R M N).rTensor C (ρN n) from
+      congr($prodCoact_comp_inr n)]
+  rw [← LinearMap.comp_apply, LinearMap.lTensor_comp_rTensor, ← LinearMap.rTensor_comp_lTensor,
+    LinearMap.comp_apply, lTensor_counit_coact]
+  simp
+
+/-- The product `M × N` of two right `C`-comodules, with the summandwise coaction. -/
+noncomputable instance instProd : Comodule R C (M × N) where
+  coact := prodCoact
+  coassoc := by
+    refine LinearMap.ext fun x => ?_
+    obtain ⟨m, n⟩ := x
+    rw [show (m, n) = LinearMap.inl R M N m + LinearMap.inr R M N n by simp]
+    simp only [map_add, LinearMap.comp_apply, LinearEquiv.coe_toLinearMap]
+    rw [prodCoassoc_inl, prodCoassoc_inr]
+  lTensor_counit_comp_coact := by
+    apply LinearMap.prod_ext
+    · ext m
+      simp only [LinearMap.comp_apply]
+      rw [prodCounit_inl]
+      rfl
+    · ext n
+      simp only [LinearMap.comp_apply]
+      rw [prodCounit_inr]
+      rfl
+
+@[simp]
+theorem prod_coact_apply (m : M) (n : N) :
+    coact (R := R) (C := C) (M := M × N) (m, n) = (LinearMap.inl R M N).rTensor C (ρM m)
+      + (LinearMap.inr R M N).rTensor C (ρN n) :=
+  prodCoact_apply m n
+
+@[simp]
+theorem prod_coact_inl (m : M) :
+    coact (R := R) (C := C) (M := M × N) (LinearMap.inl R M N m)
+      = (LinearMap.inl R M N).rTensor C (ρM m) :=
+  congr($prodCoact_comp_inl m)
+
+@[simp]
+theorem prod_coact_inr (n : N) :
+    coact (R := R) (C := C) (M := M × N) (LinearMap.inr R M N n)
+      = (LinearMap.inr R M N).rTensor C (ρN n) :=
+  congr($prodCoact_comp_inr n)
+
+namespace Hom
+
+@[simp] theorem apply_zero (f : Hom R C M N) : f (0 : M) = 0 :=
+  map_zero f.toLinearMap
+
+/-- The first projection `M × N → M` as a comodule morphism. -/
+def fst : Hom R C (M × N) M where
+  toLinearMap := LinearMap.fst R M N
+  map_coact := by
+    apply LinearMap.prod_ext
+    · ext m
+      simp
+    · ext n
+      simp
+
+/-- The second projection `M × N → N` as a comodule morphism. -/
+def snd : Hom R C (M × N) N where
+  toLinearMap := LinearMap.snd R M N
+  map_coact := by
+    apply LinearMap.prod_ext
+    · ext m
+      simp
+    · ext n
+      simp
+
+/-- The first inclusion `M → M × N` as a comodule morphism. -/
+def inl : Hom R C M (M × N) where
+  toLinearMap := LinearMap.inl R M N
+  map_coact := (prodCoact_comp_inl).symm
+
+/-- The second inclusion `N → M × N` as a comodule morphism. -/
+def inr : Hom R C N (M × N) where
+  toLinearMap := LinearMap.inr R M N
+  map_coact := (prodCoact_comp_inr).symm
+
+@[simp] theorem fst_apply (x : M × N) : (fst : Hom R C (M × N) M) x = x.1 := rfl
+@[simp] theorem snd_apply (x : M × N) : (snd : Hom R C (M × N) N) x = x.2 := rfl
+@[simp] theorem inl_apply (m : M) : (inl : Hom R C M (M × N)) m = (m, 0) := rfl
+@[simp] theorem inr_apply (n : N) : (inr : Hom R C N (M × N)) n = (0, n) := rfl
+
+/-- The morphism into a product induced by a pair of morphisms. -/
+def prod (f : Hom R C P M) (g : Hom R C P N) : Hom R C P (M × N) where
+  toLinearMap := f.toLinearMap.prod g.toLinearMap
+  map_coact := by
+    have hdecomp : f.toLinearMap.prod g.toLinearMap
+        = (LinearMap.inl R M N).comp f.toLinearMap
+          + (LinearMap.inr R M N).comp g.toLinearMap := by ext q <;> simp
+    refine LinearMap.ext fun p => ?_
+    have hf := LinearMap.congr_fun f.map_coact p
+    have hg := LinearMap.congr_fun g.map_coact p
+    simp only [LinearMap.comp_apply] at hf hg
+    change TensorProduct.map (f.toLinearMap.prod g.toLinearMap) LinearMap.id (coact p)
+      = coact (R := R) (C := C) (M := M × N) ((f.toLinearMap.prod g.toLinearMap) p)
+    rw [hdecomp, TensorProduct.map_add_left, LinearMap.add_apply,
+      ← LinearMap.rTensor_map, ← LinearMap.rTensor_map, hf, hg]
+    simp only [LinearMap.add_apply, LinearMap.comp_apply, LinearMap.coe_inl, LinearMap.coe_inr,
+      Prod.mk_add_mk, add_zero, zero_add, prod_coact_apply]
+
+/-- The morphism out of a coproduct induced by a pair of morphisms. -/
+def coprod (f : Hom R C M P) (g : Hom R C N P) : Hom R C (M × N) P where
+  toLinearMap := f.toLinearMap.coprod g.toLinearMap
+  map_coact := by
+    apply LinearMap.prod_ext
+    · ext m
+      have hf := LinearMap.congr_fun f.map_coact m
+      simp only [LinearMap.comp_apply] at hf ⊢
+      rw [prod_coact_inl, LinearMap.map_rTensor, LinearMap.coprod_inl, hf]
+      congr 1
+      simp only [LinearMap.coprod_apply, LinearMap.inl_apply, map_zero, add_zero]
+    · ext n
+      have hg := LinearMap.congr_fun g.map_coact n
+      simp only [LinearMap.comp_apply] at hg ⊢
+      rw [prod_coact_inr, LinearMap.map_rTensor, LinearMap.coprod_inr, hg]
+      congr 1
+      simp only [LinearMap.coprod_apply, LinearMap.inr_apply, map_zero, zero_add]
+
+@[simp] theorem prod_apply (f : Hom R C P M) (g : Hom R C P N) (p : P) :
+    (prod f g) p = (f p, g p) := rfl
+
+@[simp] theorem coprod_apply (f : Hom R C M P) (g : Hom R C N P) (x : M × N) :
+    (coprod f g) x = f x.1 + g x.2 := rfl
+
+@[simp] theorem fst_comp_prod (f : Hom R C P M) (g : Hom R C P N) :
+    comp fst (prod f g) = f := by ext p; simp
+
+@[simp] theorem snd_comp_prod (f : Hom R C P M) (g : Hom R C P N) :
+    comp snd (prod f g) = g := by ext p; simp
+
+@[simp] theorem coprod_comp_inl (f : Hom R C M P) (g : Hom R C N P) :
+    comp (coprod f g) inl = f := by ext m; simp
+
+@[simp] theorem coprod_comp_inr (f : Hom R C M P) (g : Hom R C N P) :
+    comp (coprod f g) inr = g := by ext n; simp
+
+@[simp] theorem fst_comp_inl : comp (fst : Hom R C (M × N) M) inl = id R C M := by
+  ext m; simp
+
+@[simp] theorem snd_comp_inl : comp (snd : Hom R C (M × N) N) inl = 0 := by
+  ext m; simp
+
+@[simp] theorem fst_comp_inr : comp (fst : Hom R C (M × N) M) inr = 0 := by
+  ext n; simp
+
+@[simp] theorem snd_comp_inr : comp (snd : Hom R C (M × N) N) inr = id R C N := by
+  ext n; simp
+
+end Hom
+
+end Comodule
+
+
+end TauCeti

--- a/TauCeti/Algebra/Coalgebra/Comodule/Prod.lean
+++ b/TauCeti/Algebra/Coalgebra/Comodule/Prod.lean
@@ -16,10 +16,10 @@ inclusions `M → M × N`, `N → M × N` are comodule morphisms, and the univer
 the product and the coproduct hold, so `M × N` is simultaneously the product and the coproduct
 of `M` and `N`: a direct sum of comodules.
 
-Together with the zero object (`TauCeti.Algebra.Coalgebra.Comodule.Zero`) and the preadditive
-structure (`TauCeti.Algebra.Coalgebra.Comodule.Preadditive`) this supplies the binary-biproduct
-ingredient of the (finite-dimensional) comodule representation category called for in Layer 1
-of the reductive-groups roadmap.
+This file stays at the unbundled `Comodule.Hom` level. The bundled `ComoduleCat`
+product/coproduct/biproduct instances for the finite-dimensional representation category are a
+separate categorical layer; the maps and uniqueness lemmas here are the prerequisite
+unbundled product/coproduct API.
 
 ## Main definitions
 
@@ -35,7 +35,7 @@ of the reductive-groups roadmap.
 ## References
 
 This is the standard direct sum of comodules; see for example Sweedler, *Hopf Algebras*,
-Chapter 2. It supplies a binary-biproduct prerequisite for
+Chapter 2. It supplies an unbundled product/coproduct prerequisite for
 `TauCetiRoadmap/ReductiveGroups/README.md`, Layer 1, "Comodules over a coalgebra/Hopf
 algebra". It reuses Mathlib's `TensorProduct.assoc` associativity coherence and the
 `rTensor`/`lTensor` calculus from `Mathlib.LinearAlgebra.TensorProduct.Map`.

--- a/TauCeti/Algebra/Coalgebra/Comodule/Prod.lean
+++ b/TauCeti/Algebra/Coalgebra/Comodule/Prod.lean
@@ -28,8 +28,9 @@ of the reductive-groups roadmap.
 * `TauCeti.Comodule.Hom.inl`, `TauCeti.Comodule.Hom.inr`: the inclusion comodule morphisms.
 * `TauCeti.Comodule.Hom.prod`, `TauCeti.Comodule.Hom.coprod`: the morphisms induced by the
   universal properties of the product and the coproduct, characterized by
-  `fst_comp_prod`/`snd_comp_prod` and `coprod_comp_inl`/`coprod_comp_inr`, with the
-  biproduct relations `fst_comp_inl`, `snd_comp_inl`, `fst_comp_inr`, `snd_comp_inr`.
+  `fst_comp_prod`/`snd_comp_prod` and `coprod_comp_inl`/`coprod_comp_inr` together with the
+  uniqueness lemmas `prod_ext`/`coprod_ext`, with the biproduct relations `fst_comp_inl`,
+  `snd_comp_inl`, `fst_comp_inr`, `snd_comp_inr`.
 
 ## References
 
@@ -59,47 +60,52 @@ local notation "ρM" => coact (R := R) (C := C) (M := M)
 local notation "ρN" => coact (R := R) (C := C) (M := N)
 
 omit [Coalgebra R C] [Comodule R C M] in
-/-- A naturality lemma for the tensor associator against `rTensor` in the first factor,
-phrased so it can rewrite the comodule coassociativity calculation below. -/
-theorem assoc_rTensor_rTensor_apply {Q : Type*} [AddCommMonoid Q] [Module R Q] (f : M →ₗ[R] Q)
-    (x : (M ⊗[R] C) ⊗[R] C) :
+/-- The `g = h = id` special case of `TensorProduct.map_map_assoc`, phrased so it can rewrite
+the comodule coassociativity calculation below. This is only a local proof helper; the general
+associator naturality lives in Mathlib's `TensorProduct.map_map_assoc`. -/
+private theorem assoc_rTensor_rTensor_apply {Q : Type*} [AddCommMonoid Q] [Module R Q]
+    (f : M →ₗ[R] Q) (x : (M ⊗[R] C) ⊗[R] C) :
     TensorProduct.assoc R Q C C ((f.rTensor C).rTensor C x)
       = f.rTensor (C ⊗[R] C) (TensorProduct.assoc R M C C x) := by
-  induction x with
-  | zero => simp
-  | tmul a c =>
-    induction a with
-    | zero => simp
-    | tmul m c' => simp
-    | add a b ha hb => simp only [TensorProduct.add_tmul, map_add, ha, hb]
-  | add a b ha hb => simp only [map_add, ha, hb]
+  simpa [LinearMap.rTensor] using
+    (TensorProduct.map_map_assoc f LinearMap.id LinearMap.id x).symm
 
 /-- The coaction of the product comodule `M × N`: coact on each factor, then include into the
-corresponding summand. -/
-noncomputable def prodCoact : (M × N) →ₗ[R] (M × N) ⊗[R] C :=
+corresponding summand. This is the implementation of the `Comodule R C (M × N)` instance; the
+public characterizing equations are `prod_coact_apply`, `prod_coact_inl`, and `prod_coact_inr`. -/
+private noncomputable def prodCoact : (M × N) →ₗ[R] (M × N) ⊗[R] C :=
   (LinearMap.inl R M N).rTensor C ∘ₗ ρM ∘ₗ LinearMap.fst R M N
     + (LinearMap.inr R M N).rTensor C ∘ₗ ρN ∘ₗ LinearMap.snd R M N
 
 @[simp]
-theorem prodCoact_comp_inl :
+private theorem prodCoact_comp_inl :
     prodCoact ∘ₗ LinearMap.inl R M N = (LinearMap.inl R M N).rTensor C ∘ₗ ρM := by
   ext m; simp [prodCoact]
 
 @[simp]
-theorem prodCoact_comp_inr :
+private theorem prodCoact_comp_inr :
     prodCoact ∘ₗ LinearMap.inr R M N = (LinearMap.inr R M N).rTensor C ∘ₗ ρN := by
   ext n; simp [prodCoact]
 
-theorem prodCoact_apply (m : M) (n : N) :
+private theorem prodCoact_apply (m : M) (n : N) :
     prodCoact (m, n) = (LinearMap.inl R M N).rTensor C (ρM m)
       + (LinearMap.inr R M N).rTensor C (ρN n) := by
   simp [prodCoact]
 
+/-- `prodCoact` on a first-summand inclusion is the included coaction. -/
+private theorem prodCoact_inl_apply (m : M) :
+    prodCoact (LinearMap.inl R M N m) = (LinearMap.inl R M N).rTensor C (ρM m) :=
+  LinearMap.congr_fun prodCoact_comp_inl m
+
+/-- `prodCoact` on a second-summand inclusion is the included coaction. -/
+private theorem prodCoact_inr_apply (n : N) :
+    prodCoact (LinearMap.inr R M N n) = (LinearMap.inr R M N).rTensor C (ρN n) :=
+  LinearMap.congr_fun prodCoact_comp_inr n
+
 private theorem prodCoassoc_inl (m : M) :
     TensorProduct.assoc R (M × N) C C (prodCoact.rTensor C (prodCoact (LinearMap.inl R M N m)))
       = Coalgebra.comul.lTensor (M × N) (prodCoact (LinearMap.inl R M N m)) := by
-  rw [show prodCoact (LinearMap.inl R M N m) = (LinearMap.inl R M N).rTensor C (ρM m) from
-      congr($prodCoact_comp_inl m)]
+  rw [prodCoact_inl_apply]
   rw [← LinearMap.comp_apply (prodCoact.rTensor C), ← LinearMap.rTensor_comp,
     prodCoact_comp_inl, LinearMap.rTensor_comp]
   simp only [LinearMap.comp_apply, assoc_rTensor_rTensor_apply, coassoc_apply]
@@ -110,8 +116,7 @@ private theorem prodCoassoc_inl (m : M) :
 private theorem prodCoassoc_inr (n : N) :
     TensorProduct.assoc R (M × N) C C (prodCoact.rTensor C (prodCoact (LinearMap.inr R M N n)))
       = Coalgebra.comul.lTensor (M × N) (prodCoact (LinearMap.inr R M N n)) := by
-  rw [show prodCoact (LinearMap.inr R M N n) = (LinearMap.inr R M N).rTensor C (ρN n) from
-      congr($prodCoact_comp_inr n)]
+  rw [prodCoact_inr_apply]
   rw [← LinearMap.comp_apply (prodCoact.rTensor C), ← LinearMap.rTensor_comp,
     prodCoact_comp_inr, LinearMap.rTensor_comp]
   simp only [LinearMap.comp_apply, assoc_rTensor_rTensor_apply, coassoc_apply]
@@ -122,8 +127,7 @@ private theorem prodCoassoc_inr (n : N) :
 private theorem prodCounit_inl (m : M) :
     (Coalgebra.counit : C →ₗ[R] R).lTensor (M × N) (prodCoact (LinearMap.inl R M N m))
       = (LinearMap.inl R M N m) ⊗ₜ[R] (1 : R) := by
-  rw [show prodCoact (LinearMap.inl R M N m) = (LinearMap.inl R M N).rTensor C (ρM m) from
-      congr($prodCoact_comp_inl m)]
+  rw [prodCoact_inl_apply]
   rw [← LinearMap.comp_apply, LinearMap.lTensor_comp_rTensor, ← LinearMap.rTensor_comp_lTensor,
     LinearMap.comp_apply, lTensor_counit_coact]
   simp
@@ -131,10 +135,15 @@ private theorem prodCounit_inl (m : M) :
 private theorem prodCounit_inr (n : N) :
     (Coalgebra.counit : C →ₗ[R] R).lTensor (M × N) (prodCoact (LinearMap.inr R M N n))
       = (LinearMap.inr R M N n) ⊗ₜ[R] (1 : R) := by
-  rw [show prodCoact (LinearMap.inr R M N n) = (LinearMap.inr R M N).rTensor C (ρN n) from
-      congr($prodCoact_comp_inr n)]
+  rw [prodCoact_inr_apply]
   rw [← LinearMap.comp_apply, LinearMap.lTensor_comp_rTensor, ← LinearMap.rTensor_comp_lTensor,
     LinearMap.comp_apply, lTensor_counit_coact]
+  simp
+
+omit [Coalgebra R C] [Comodule R C M] [Comodule R C N] in
+/-- An element of `M × N` is the sum of its two summand inclusions. -/
+private theorem prod_eq_inl_add_inr (m : M) (n : N) :
+    (m, n) = LinearMap.inl R M N m + LinearMap.inr R M N n := by
   simp
 
 /-- The product `M × N` of two right `C`-comodules, with the summandwise coaction. -/
@@ -143,7 +152,7 @@ noncomputable instance instProd : Comodule R C (M × N) where
   coassoc := by
     refine LinearMap.ext fun x => ?_
     obtain ⟨m, n⟩ := x
-    rw [show (m, n) = LinearMap.inl R M N m + LinearMap.inr R M N n by simp]
+    rw [prod_eq_inl_add_inr (R := R) m n]
     simp only [map_add, LinearMap.comp_apply, LinearEquiv.coe_toLinearMap]
     rw [prodCoassoc_inl, prodCoassoc_inr]
   lTensor_counit_comp_coact := by
@@ -157,28 +166,28 @@ noncomputable instance instProd : Comodule R C (M × N) where
       rw [prodCounit_inr]
       rfl
 
+/-- The product coaction on a pair is the sum of the coactions included into each summand. -/
 @[simp]
 theorem prod_coact_apply (m : M) (n : N) :
     coact (R := R) (C := C) (M := M × N) (m, n) = (LinearMap.inl R M N).rTensor C (ρM m)
       + (LinearMap.inr R M N).rTensor C (ρN n) :=
   prodCoact_apply m n
 
+/-- The product coaction on a first-summand inclusion is the included coaction of `M`. -/
 @[simp]
 theorem prod_coact_inl (m : M) :
     coact (R := R) (C := C) (M := M × N) (LinearMap.inl R M N m)
       = (LinearMap.inl R M N).rTensor C (ρM m) :=
-  congr($prodCoact_comp_inl m)
+  prodCoact_inl_apply m
 
+/-- The product coaction on a second-summand inclusion is the included coaction of `N`. -/
 @[simp]
 theorem prod_coact_inr (n : N) :
     coact (R := R) (C := C) (M := M × N) (LinearMap.inr R M N n)
       = (LinearMap.inr R M N).rTensor C (ρN n) :=
-  congr($prodCoact_comp_inr n)
+  prodCoact_inr_apply n
 
 namespace Hom
-
-@[simp] theorem apply_zero (f : Hom R C M N) : f (0 : M) = 0 :=
-  map_zero f.toLinearMap
 
 /-- The first projection `M × N → M` as a comodule morphism. -/
 def fst : Hom R C (M × N) M where
@@ -210,9 +219,13 @@ def inr : Hom R C N (M × N) where
   toLinearMap := LinearMap.inr R M N
   map_coact := (prodCoact_comp_inr).symm
 
+/-- The projection `fst` acts as the underlying first projection. -/
 @[simp] theorem fst_apply (x : M × N) : (fst : Hom R C (M × N) M) x = x.1 := rfl
+/-- The projection `snd` acts as the underlying second projection. -/
 @[simp] theorem snd_apply (x : M × N) : (snd : Hom R C (M × N) N) x = x.2 := rfl
+/-- The inclusion `inl` sends `m` to `(m, 0)`. -/
 @[simp] theorem inl_apply (m : M) : (inl : Hom R C M (M × N)) m = (m, 0) := rfl
+/-- The inclusion `inr` sends `n` to `(0, n)`. -/
 @[simp] theorem inr_apply (n : N) : (inr : Hom R C N (M × N)) n = (0, n) := rfl
 
 /-- The morphism into a product induced by a pair of morphisms. -/
@@ -226,6 +239,9 @@ def prod (f : Hom R C P M) (g : Hom R C P N) : Hom R C P (M × N) where
     have hf := LinearMap.congr_fun f.map_coact p
     have hg := LinearMap.congr_fun g.map_coact p
     simp only [LinearMap.comp_apply] at hf hg
+    -- Unfold the two compositions in `map_coact` to their pointwise form so the explicit
+    -- `rTensor`/`TensorProduct.map` rewriting below applies; both sides are definitionally
+    -- this application.
     change TensorProduct.map (f.toLinearMap.prod g.toLinearMap) LinearMap.id (coact p)
       = coact (R := R) (C := C) (M := M × N) ((f.toLinearMap.prod g.toLinearMap) p)
     rw [hdecomp, TensorProduct.map_add_left, LinearMap.add_apply,
@@ -251,33 +267,66 @@ def coprod (f : Hom R C M P) (g : Hom R C N P) : Hom R C (M × N) P where
       congr 1
       simp only [LinearMap.coprod_apply, LinearMap.inr_apply, map_zero, zero_add]
 
+/-- The morphism into the product applies as the pair of its component morphisms. -/
 @[simp] theorem prod_apply (f : Hom R C P M) (g : Hom R C P N) (p : P) :
     (prod f g) p = (f p, g p) := rfl
 
+/-- The morphism out of the coproduct applies as the sum of its component morphisms. -/
 @[simp] theorem coprod_apply (f : Hom R C M P) (g : Hom R C N P) (x : M × N) :
     (coprod f g) x = f x.1 + g x.2 := rfl
 
+/-- The first projection recovers the first component of a morphism into the product. -/
 @[simp] theorem fst_comp_prod (f : Hom R C P M) (g : Hom R C P N) :
     comp fst (prod f g) = f := by ext p; simp
 
+/-- The second projection recovers the second component of a morphism into the product. -/
 @[simp] theorem snd_comp_prod (f : Hom R C P M) (g : Hom R C P N) :
     comp snd (prod f g) = g := by ext p; simp
 
+/-- The first inclusion recovers the first component of a morphism out of the coproduct. -/
 @[simp] theorem coprod_comp_inl (f : Hom R C M P) (g : Hom R C N P) :
     comp (coprod f g) inl = f := by ext m; simp
 
+/-- The second inclusion recovers the second component of a morphism out of the coproduct. -/
 @[simp] theorem coprod_comp_inr (f : Hom R C M P) (g : Hom R C N P) :
     comp (coprod f g) inr = g := by ext n; simp
 
+/-- A morphism into the product is determined by its two projections: two morphisms into
+`M × N` that agree after `fst` and after `snd` are equal. This is the uniqueness half of the
+product's universal property. -/
+theorem prod_ext {h k : Hom R C P (M × N)} (hfst : comp fst h = comp fst k)
+    (hsnd : comp snd h = comp snd k) : h = k :=
+  Hom.ext fun p => Prod.ext (by simpa using congr($hfst p)) (by simpa using congr($hsnd p))
+
+/-- A morphism out of the coproduct is determined by its two inclusions: two morphisms out of
+`M × N` that agree after `inl` and after `inr` are equal. This is the uniqueness half of the
+coproduct's universal property. -/
+theorem coprod_ext {h k : Hom R C (M × N) P} (hinl : comp h inl = comp k inl)
+    (hinr : comp h inr = comp k inr) : h = k := by
+  ext x
+  obtain ⟨m, n⟩ := x
+  have hm := congr($hinl m)
+  have hn := congr($hinr n)
+  simp only [comp_apply, inl_apply, inr_apply] at hm hn
+  have e1 : h (m, n) = h (m, 0) + h (0, n) := by
+    simpa using map_add h.toLinearMap (m, 0) (0, n)
+  have e2 : k (m, n) = k (m, 0) + k (0, n) := by
+    simpa using map_add k.toLinearMap (m, 0) (0, n)
+  rw [e1, e2, hm, hn]
+
+/-- The first projection of the first inclusion is the identity. -/
 @[simp] theorem fst_comp_inl : comp (fst : Hom R C (M × N) M) inl = id R C M := by
   ext m; simp
 
+/-- The first projection kills the second inclusion. -/
 @[simp] theorem snd_comp_inl : comp (snd : Hom R C (M × N) N) inl = 0 := by
   ext m; simp
 
+/-- The second projection kills the first inclusion. -/
 @[simp] theorem fst_comp_inr : comp (fst : Hom R C (M × N) M) inr = 0 := by
   ext n; simp
 
+/-- The second projection of the second inclusion is the identity. -/
 @[simp] theorem snd_comp_inr : comp (snd : Hom R C (M × N) N) inr = id R C N := by
   ext n; simp
 

--- a/TauCeti/Algebra/Coalgebra/Comodule/Prod.lean
+++ b/TauCeti/Algebra/Coalgebra/Comodule/Prod.lean
@@ -299,16 +299,14 @@ def coprod (f : Hom R C M P) (g : Hom R C N P) : Hom R C (M × N) P where
     comp (coprod f g) inl = f := by
   ext m
   simp only [comp_apply, coprod_apply, inl_apply]
-  change f m + g.toLinearMap 0 = f m
-  rw [map_zero g.toLinearMap, add_zero]
+  simp [Hom.apply_zero]
 
 /-- The second inclusion recovers the second component of a morphism out of the coproduct. -/
 @[simp] theorem coprod_comp_inr (f : Hom R C M P) (g : Hom R C N P) :
     comp (coprod f g) inr = g := by
   ext n
   simp only [comp_apply, coprod_apply, inr_apply]
-  change f.toLinearMap 0 + g n = g n
-  rw [map_zero f.toLinearMap, zero_add]
+  simp [Hom.apply_zero]
 
 /-- A morphism into the product is determined by its two projections: two morphisms into
 `M × N` that agree after `fst` and after `snd` are equal. This is the uniqueness half of the
@@ -337,11 +335,11 @@ theorem coprod_ext {h k : Hom R C (M × N) P} (hinl : comp h inl = comp k inl)
 @[simp] theorem fst_comp_inl : comp (fst : Hom R C (M × N) M) inl = id R C M := by
   ext m; simp
 
-/-- The first projection kills the second inclusion. -/
+/-- The second projection kills the first inclusion. -/
 @[simp] theorem snd_comp_inl : comp (snd : Hom R C (M × N) N) inl = 0 := by
   ext m; simp
 
-/-- The second projection kills the first inclusion. -/
+/-- The first projection kills the second inclusion. -/
 @[simp] theorem fst_comp_inr : comp (fst : Hom R C (M × N) M) inr = 0 := by
   ext n; simp
 

--- a/TauCeti/Algebra/Coalgebra/Comodule/Prod.lean
+++ b/TauCeti/Algebra/Coalgebra/Comodule/Prod.lean
@@ -30,7 +30,7 @@ of the reductive-groups roadmap.
   universal properties of the product and the coproduct, characterized by
   `fst_comp_prod`/`snd_comp_prod` and `coprod_comp_inl`/`coprod_comp_inr` together with the
   uniqueness lemmas `prod_ext`/`coprod_ext`, with the biproduct relations `fst_comp_inl`,
-  `snd_comp_inl`, `fst_comp_inr`, `snd_comp_inr`.
+  `snd_comp_inl`, `fst_comp_inr`, `snd_comp_inr`, and `coprod_inl_inr`.
 
 ## References
 
@@ -378,6 +378,13 @@ theorem coprod_ext {h k : Hom R C (M × N) P} (hinl : comp h inl = comp k inl)
 /-- The second projection of the second inclusion is the identity. -/
 @[simp] theorem snd_comp_inr : comp (snd : Hom R C (M × N) N) inr = id R C N := by
   ext n; simp
+
+/-- The two coproduct inclusions decompose the identity on the product comodule. -/
+@[simp] theorem coprod_inl_inr : coprod (inl : Hom R C M (M × N)) inr = id R C (M × N) := by
+  apply Hom.ext
+  intro x
+  obtain ⟨m, n⟩ := x
+  simp
 
 end Hom
 


### PR DESCRIPTION
This PR equips the product `M × N` of two right `C`-comodules over an `R`-coalgebra `C` with its canonical direct-sum coaction `(m, n) ↦ ι_M(ρ_M m) + ι_N(ρ_N n)`, and builds the morphism API exhibiting it as both a product and a coproduct of comodules. The projections `fst`, `snd` and inclusions `inl`, `inr` are comodule morphisms; the universal-property maps `prod` and `coprod` come with their defining relations (`fst_comp_prod`, `snd_comp_prod`, `coprod_comp_inl`, `coprod_comp_inr`) and the biproduct relations (`fst_comp_inl`, `snd_comp_inl`, `fst_comp_inr`, `snd_comp_inr`). Together with the existing zero object and preadditive structure on the comodule category, this supplies the binary-biproduct (finite direct sum) ingredient of the additive representation category.

This advances the `ReductiveGroups` roadmap, `TauCetiRoadmap/ReductiveGroups/README.md`, Layer 1 ("representations = comodules"): the comodule category called for there, "tensor products, duals, the regular representation", needs its additive structure, of which finite direct sums are the missing binary-biproduct piece (the zero object and preadditivity already landed). It builds on the merged comodule and comodule-morphism API and reuses Mathlib's tensor-product associativity coherence (`TensorProduct.assoc`, `map_map_assoc`) and the `rTensor`/`lTensor` calculus from `Mathlib.LinearAlgebra.TensorProduct.Map`, together with the product/coproduct linear-map API (`LinearMap.prod_ext`, `LinearMap.coprod`) from `Mathlib.LinearAlgebra.Prod`; no Mathlib code was vendored.

🤖 Prepared with Claude Code