### PR TITLE
feat: showcase four checked theorems in a readable carousel

### DIFF
--- a/web/Site/Front.lean
+++ b/web/Site/Front.lean
@@ -5,8 +5,10 @@ open Verso Genre Blog
 
 {leanExampleProject frontExamples "examples"}
 
-Deck-transformation rigidity, from the universal-covers development: two deck
-transformations of a connected covering space that agree at a single point of the
-total space are equal.
-
 {leanCommand frontExamples deck_rigidity}
+
+{leanCommand frontExamples ellipticity_coercive}
+
+{leanCommand frontExamples effective_divisor}
+
+{leanCommand frontExamples hopf_antipode}

--- a/web/Site/Theme.lean
+++ b/web/Site/Theme.lean
@@ -15,6 +15,7 @@ def theme : Theme := { Theme.default with
           <title>{{ (← param (α := String) "title") }} " — Tau Ceti"</title>
           {{← builtinHeader }}
           <link rel="stylesheet" href="static/style.css"/>
+          <script src="static/site.js" defer="defer"></script>
         </head>
         <body>
           <header class="site-nav">
@@ -104,8 +105,14 @@ def theme : Theme := { Theme.default with
 
         <section class="band taste">
           <h2 class="section-title">"A taste of the maths"</h2>
-          <p class="taste-note">"A real theorem from the universal-covers development — extracted from the library and type-checked when this page is built, so it cannot drift out of date."</p>
-          {{← param "content" }}
+          <p class="taste-note">"Four real theorems — one for each roadmap theme — extracted from the library and type-checked when this page is built, so they cannot drift out of date."</p>
+          <div class="carousel">
+            <button class="carousel-arrow prev" type="button" aria-label="Previous example">"‹"</button>
+            <div class="carousel-track">
+              {{← param "content" }}
+            </div>
+            <button class="carousel-arrow next" type="button" aria-label="Next example">"›"</button>
+          </div>
         </section>
       </div>
     }}, id⟩

--- a/web/examples/Examples.lean
+++ b/web/examples/Examples.lean
@@ -1,12 +1,14 @@
 import TauCeti.AlgebraicTopology.UniversalCover.Deck.Connected
 import TauCeti.Analysis.PDE.UniformEllipticity
+import TauCeti.AlgebraicGeometry.WeilDivisor
+import TauCeti.Algebra.HopfAlgebra
 import SubVerso.Examples
 open SubVerso.Examples
-open TauCeti TauCeti.PDE Matrix
 
 %example deck_rigidity
-/-- Two deck transformations of a connected covering space that agree at a single
-point of the total space are equal — the rigidity that pins down the deck group. -/
+open TauCeti in
+/-- Universal covers — two deck transformations of a connected covering space that
+agree at a single point of the total space are equal. -/
 theorem deck_rigidity {E B : Type*} [TopologicalSpace E] [TopologicalSpace B]
     {p : E → B} [PreconnectedSpace E] (hp : IsCoveringMap p)
     (φ ψ : Deck p) {e : E} (h : φ.1 e = ψ.1 e) : φ = ψ :=
@@ -14,12 +16,31 @@ theorem deck_rigidity {E B : Type*} [TopologicalSpace E] [TopologicalSpace B]
 %end
 
 %example ellipticity_coercive
-/-- On a uniformly elliptic region, the coefficient matrix induces a coercive
-bilinear form at each interior point — the Lax–Milgram hypothesis, with explicit
-ellipticity constants. -/
+open TauCeti.PDE Matrix in
+/-- Partial differential equations — on a uniformly elliptic region the coefficient
+matrix induces a coercive bilinear form, the hypothesis that powers Lax–Milgram. -/
 theorem ellipticity_coercive {X n : Type*} [Fintype n] [DecidableEq n]
     {Ω : Set X} {a : X → Matrix n n ℝ} {lam Lam : ℝ}
     (h : UniformlyEllipticOn Ω a lam Lam) {x : X} (hx : x ∈ Ω) :
     IsCoercive (matrixBilinearForm (a x)) :=
   h.isCoercive_matrixBilinearForm hx
+%end
+
+%example effective_divisor
+open TauCeti.AlgebraicGeometry TauCeti.AlgebraicGeometry.WeilDivisor in
+/-- The Jacobian challenge — a nonzero effective Weil divisor has a point with
+strictly positive coefficient. -/
+theorem effective_divisor {X : Type*} {D : WeilDivisor X}
+    (hD : IsEffective D) (hD0 : D ≠ 0) : ∃ x, 0 < D.coeff x :=
+  hD.exists_pos_coeff_of_ne_zero hD0
+%end
+
+%example hopf_antipode
+open HopfAlgebra in
+/-- Reductive algebraic groups — a bialgebra homomorphism between Hopf algebras
+commutes with the antipodes. -/
+theorem hopf_antipode {R A B : Type*} [CommSemiring R] [Semiring A] [Semiring B]
+    [HopfAlgebra R A] [HopfAlgebra R B] (φ : A →ₐc[R] B) :
+    φ.toLinearMap.comp (antipode R (A := A)) = (antipode R (A := B)).comp φ.toLinearMap :=
+  TauCeti.BialgHom.toLinearMap_comp_antipode φ
 %end

--- a/web/static_files/site.js
+++ b/web/static_files/site.js
@@ -1,0 +1,14 @@
+// Wire the horizontal "taste of the maths" carousels: arrows scroll one card.
+document.querySelectorAll(".carousel").forEach(function (carousel) {
+  var track = carousel.querySelector(".carousel-track");
+  if (!track) return;
+  function step() { return Math.min(track.clientWidth * 0.85, 720); }
+  var prev = carousel.querySelector(".carousel-arrow.prev");
+  var next = carousel.querySelector(".carousel-arrow.next");
+  if (prev) prev.addEventListener("click", function () {
+    track.scrollBy({ left: -step(), behavior: "smooth" });
+  });
+  if (next) next.addEventListener("click", function () {
+    track.scrollBy({ left: step(), behavior: "smooth" });
+  });
+});

--- a/web/static_files/style.css
+++ b/web/static_files/style.css
@@ -11,6 +11,12 @@
   --panel: rgba(255, 255, 255, 0.03);
   --display: "Chakra Petch", system-ui, sans-serif;
   --max: 1100px;
+
+  /* Verso highlights default to black text; recolour for the dark theme. */
+  --verso-code-color: #d6def5;
+  --verso-code-keyword-color: #c4b5fd;
+  --verso-code-const-color: #7dd3fc;
+  --verso-code-var-color: #fcd9a8;
 }
 
 html { scroll-behavior: smooth; }
@@ -186,4 +192,55 @@ a.card:hover { transform: translateY(-3px); border-color: var(--teal); text-deco
 }
 @media (max-width: 520px) {
   .cards.four, .cards.three { grid-template-columns: 1fr; }
+}
+
+/* ---- Verso code blocks: readable on the dark theme ---- */
+.hl.lean .sort { color: var(--teal); }
+.hl.lean .doc-comment, .hl.lean .comment { color: var(--muted); font-style: italic; }
+.hl.lean.block {
+  background: #0a0f20;
+  color: var(--verso-code-color);
+  border: 1px solid var(--line);
+  border-radius: 12px;
+  padding: 1.1rem 1.25rem;
+  font-size: 0.9rem;
+  line-height: 1.55;
+  overflow-x: auto;
+}
+
+/* ---- horizontal carousel for the code samples ---- */
+.carousel { position: relative; display: flex; align-items: center; gap: 0.5rem; }
+.carousel-track {
+  flex: 1 1 auto;
+  display: flex;
+  gap: 1.25rem;
+  overflow-x: auto;
+  scroll-snap-type: x mandatory;
+  scroll-padding: 0 0.5rem;
+  padding: 0.4rem 0.25rem 1.1rem;
+  scrollbar-color: var(--teal) rgba(255, 255, 255, 0.08);
+}
+.carousel-track > .hl.lean.block {
+  flex: 0 0 min(86%, 680px);
+  scroll-snap-align: center;
+  margin: 0;
+}
+.carousel-arrow {
+  flex: 0 0 auto;
+  width: 2.5rem;
+  height: 2.5rem;
+  border-radius: 999px;
+  border: 1px solid var(--line);
+  background: rgba(255, 255, 255, 0.04);
+  color: var(--text);
+  font-family: var(--display);
+  font-size: 1.5rem;
+  line-height: 1;
+  cursor: pointer;
+  transition: background 0.15s, border-color 0.15s;
+}
+.carousel-arrow:hover { background: rgba(94, 234, 212, 0.12); border-color: var(--teal); }
+@media (max-width: 640px) {
+  .carousel-arrow { display: none; }
+  .carousel-track > .hl.lean.block { flex-basis: 88%; }
 }


### PR DESCRIPTION
This PR fixes the unreadable code samples (Verso's default highlight colours are black, invisible on the dark theme) by recolouring the token variables and giving code blocks a dark panel. It adds two more type-checked theorems to the examples project — a nonzero effective Weil divisor has a point of positive coefficient (the Jacobian challenge) and a bialgebra homomorphism commutes with the antipode (reductive algebraic groups) — so the landing page now showcases one real, build-time-checked theorem per roadmap theme. The four samples sit in a horizontal scroll-snap carousel with previous/next arrows.

🤖 Prepared with Claude Code