### PR TITLE
feat: add Hopf ideals

### DIFF
--- a/TauCeti.lean
+++ b/TauCeti.lean
@@ -5,6 +5,7 @@
 -- grows, import the submodules of `TauCeti/` here.
 import TauCeti.Algebra.AlgebraicGroup.CommHopfAlgCat
 import TauCeti.Algebra.AlgebraicGroup.FiniteTypeCommHopfAlgCat
+import TauCeti.Algebra.AlgebraicGroup.HopfIdeal
 import TauCeti.Algebra.Coalgebra.Comodule.Cofree
 import TauCeti.Algebra.Coalgebra.Comodule.Corestrict
 import TauCeti.Algebra.Coalgebra.Comodule.Finite

--- a/TauCeti.lean
+++ b/TauCeti.lean
@@ -5,7 +5,6 @@
 -- grows, import the submodules of `TauCeti/` here.
 import TauCeti.Algebra.AlgebraicGroup.CommHopfAlgCat
 import TauCeti.Algebra.AlgebraicGroup.FiniteTypeCommHopfAlgCat
-import TauCeti.Algebra.AlgebraicGroup.HopfIdeal
 import TauCeti.Algebra.Coalgebra.Comodule.Cofree
 import TauCeti.Algebra.Coalgebra.Comodule.Corestrict
 import TauCeti.Algebra.Coalgebra.Comodule.Finite
@@ -28,6 +27,7 @@ import TauCeti.Algebra.Coalgebra.Subcoalgebra.Map
 import TauCeti.Algebra.Coalgebra.Subcoalgebra.RegularSubcomodule
 import TauCeti.Algebra.Coalgebra.Subcomodule
 import TauCeti.Algebra.Coalgebra.Subcomodule.Lattice
+import TauCeti.Algebra.HopfAlgebra.HopfIdeal
 import TauCeti.AlgebraicGeometry.WeilDivisor
 import TauCeti.AlgebraicTopology.UniversalCover.Deck.Connected
 import TauCeti.AlgebraicTopology.UniversalCover.Deck.Fiber

--- a/TauCeti/Algebra/AlgebraicGroup/HopfIdeal.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/HopfIdeal.lean
@@ -1,0 +1,210 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+import Mathlib.RingTheory.HopfAlgebra.Basic
+import Mathlib.RingTheory.Ideal.Maps
+
+/-!
+# Hopf ideals
+
+This file defines Hopf ideals in a commutative Hopf algebra over a commutative ring. A Hopf
+ideal is an ideal `I` whose comultiplication lands in `I ⊗ H + H ⊗ I`, whose counit vanishes
+on `I`, and which is stable under the antipode.
+
+This is a small Layer 3 prerequisite for the reductive-groups roadmap target
+"Hopf ideals ↔ closed subgroup schemes": closed subgroup schemes of an affine group scheme
+are represented on coordinate rings by quotient Hopf algebras, and the ideal being quotiented
+must satisfy exactly these Hopf-ideal closure conditions.
+
+## Main definitions
+
+* `TauCeti.HopfIdeal`: a Hopf ideal of a commutative Hopf algebra.
+* `TauCeti.HopfIdeal.leftTensorIdeal` and `TauCeti.HopfIdeal.rightTensorIdeal`: the two
+  summands `I ⊗ H` and `H ⊗ I` inside `H ⊗ H`.
+* `⊥ : HopfIdeal R H`: the zero Hopf ideal.
+
+## References
+
+This follows the standard Hopf-algebra definition of a Hopf ideal; see Sweedler,
+*Hopf Algebras*, Chapter 1. The formalization uses Mathlib's Hopf-algebra and tensor-product
+ideal API.
+-/
+
+open scoped TensorProduct
+
+namespace TauCeti
+
+universe u v
+
+variable (R : Type u) (H : Type v)
+variable [CommRing R] [CommRing H] [HopfAlgebra R H]
+
+private def hopfIdealLeftTensorIdeal (I : Ideal H) : Ideal (H ⊗[R] H) :=
+  Ideal.map (Algebra.TensorProduct.includeLeft (R := R) (S := R) (A := H) (B := H)).toRingHom I
+
+private def hopfIdealRightTensorIdeal (I : Ideal H) : Ideal (H ⊗[R] H) :=
+  Ideal.map (Algebra.TensorProduct.includeRight (R := R) (A := H) (B := H)).toRingHom I
+
+/-- A Hopf ideal in a commutative Hopf algebra.
+
+The comultiplication condition is stated in the ambient tensor product algebra as
+`Δ(I) ⊆ I ⊗ H + H ⊗ I`. The quotient Hopf algebra will be added separately once the needed
+quotient coalgebra API is available. -/
+structure HopfIdeal where
+  /-- The underlying ideal. -/
+  carrier : Ideal H
+  /-- The comultiplication of an element of the ideal lies in `I ⊗ H + H ⊗ I`. -/
+  comul_mem' :
+    ∀ ⦃x : H⦄, x ∈ carrier →
+      Coalgebra.comul (R := R) x ∈
+        hopfIdealLeftTensorIdeal (R := R) (H := H) carrier ⊔
+          hopfIdealRightTensorIdeal (R := R) (H := H) carrier
+  /-- The counit vanishes on the ideal. -/
+  counit_eq_zero' : ∀ ⦃x : H⦄, x ∈ carrier → Coalgebra.counit (R := R) x = 0
+  /-- The antipode preserves the ideal. -/
+  antipode_mem' :
+    ∀ ⦃x : H⦄, x ∈ carrier → HopfAlgebra.antipode R x ∈ carrier
+
+namespace HopfIdeal
+
+variable {R H}
+
+/-- The image of an ideal `I ≤ H` under the left inclusion `H → H ⊗[R] H`, representing
+`I ⊗ H` inside the tensor product algebra. -/
+def leftTensorIdeal (I : Ideal H) : Ideal (H ⊗[R] H) :=
+  hopfIdealLeftTensorIdeal (R := R) (H := H) I
+
+/-- The image of an ideal `I ≤ H` under the right inclusion `H → H ⊗[R] H`, representing
+`H ⊗ I` inside the tensor product algebra. -/
+def rightTensorIdeal (I : Ideal H) : Ideal (H ⊗[R] H) :=
+  hopfIdealRightTensorIdeal (R := R) (H := H) I
+
+instance : SetLike (HopfIdeal R H) H where
+  coe I := I.carrier
+  coe_injective' I J h := by
+    cases I with
+    | mk carrier hcomul hcounit hantipode =>
+    cases J with
+    | mk carrier' hcomul' hcounit' hantipode' =>
+    congr
+    exact SetLike.ext' h
+
+instance : AddSubmonoidClass (HopfIdeal R H) H where
+  add_mem {I} := I.carrier.add_mem
+  zero_mem I := I.carrier.zero_mem
+
+instance : SMulMemClass (HopfIdeal R H) H H where
+  smul_mem {I} h {_} hx := I.carrier.mul_mem_left h hx
+
+instance : PartialOrder (HopfIdeal R H) :=
+  .ofSetLike (HopfIdeal R H) H
+
+/-- The underlying ideal of a Hopf ideal. -/
+def toIdeal (I : HopfIdeal R H) : Ideal H :=
+  I.carrier
+
+@[simp]
+theorem mem_carrier {I : HopfIdeal R H} {x : H} : x ∈ I.carrier ↔ x ∈ I :=
+  Iff.rfl
+
+@[simp]
+theorem mem_toIdeal {I : HopfIdeal R H} {x : H} : x ∈ I.toIdeal ↔ x ∈ I :=
+  Iff.rfl
+
+@[simp]
+theorem toIdeal_carrier (I : HopfIdeal R H) : I.toIdeal = I.carrier :=
+  rfl
+
+theorem le_def {I J : HopfIdeal R H} : I ≤ J ↔ ∀ ⦃x : H⦄, x ∈ I → x ∈ J :=
+  Iff.rfl
+
+theorem toIdeal_le_toIdeal {I J : HopfIdeal R H} :
+    I.toIdeal ≤ J.toIdeal ↔ I ≤ J :=
+  Iff.rfl
+
+/-- Two Hopf ideals are equal when they contain the same elements. -/
+@[ext]
+theorem ext {I J : HopfIdeal R H} (h : ∀ x : H, x ∈ I ↔ x ∈ J) : I = J :=
+  SetLike.ext h
+
+/-- Constructor from an ideal and the three Hopf-ideal closure conditions. -/
+def ofIdeal (I : Ideal H)
+    (hcomul :
+      ∀ ⦃x : H⦄, x ∈ I →
+        Coalgebra.comul (R := R) x ∈
+          leftTensorIdeal (R := R) (H := H) I ⊔ rightTensorIdeal (R := R) (H := H) I)
+    (hcounit : ∀ ⦃x : H⦄, x ∈ I → Coalgebra.counit (R := R) x = 0)
+    (hantipode : ∀ ⦃x : H⦄, x ∈ I → HopfAlgebra.antipode R x ∈ I) :
+    HopfIdeal R H where
+  carrier := I
+  comul_mem' := hcomul
+  counit_eq_zero' := hcounit
+  antipode_mem' := hantipode
+
+@[simp]
+theorem ofIdeal_carrier (I : Ideal H) (hcomul hcounit hantipode) :
+    (ofIdeal (R := R) (H := H) I hcomul hcounit hantipode).carrier = I :=
+  rfl
+
+@[simp]
+theorem mem_ofIdeal {I : Ideal H} {hcomul hcounit hantipode} {x : H} :
+    x ∈ ofIdeal (R := R) (H := H) I hcomul hcounit hantipode ↔ x ∈ I :=
+  Iff.rfl
+
+/-- The comultiplication of an element of a Hopf ideal lies in `I ⊗ H + H ⊗ I`. -/
+theorem comul_mem (I : HopfIdeal R H) {x : H} (hx : x ∈ I) :
+    Coalgebra.comul (R := R) x ∈
+      leftTensorIdeal (R := R) (H := H) I.toIdeal ⊔
+        rightTensorIdeal (R := R) (H := H) I.toIdeal :=
+  I.comul_mem' hx
+
+/-- The counit vanishes on a Hopf ideal. -/
+theorem counit_eq_zero (I : HopfIdeal R H) {x : H} (hx : x ∈ I) :
+    Coalgebra.counit (R := R) x = 0 :=
+  I.counit_eq_zero' hx
+
+/-- The antipode preserves a Hopf ideal. -/
+theorem antipode_mem (I : HopfIdeal R H) {x : H} (hx : x ∈ I) :
+    HopfAlgebra.antipode R x ∈ I :=
+  I.antipode_mem' hx
+
+/-- The zero ideal as a Hopf ideal. -/
+instance instBot : Bot (HopfIdeal R H) where
+  bot :=
+    { carrier := ⊥
+      comul_mem' := by
+        intro x hx
+        rw [Ideal.mem_bot] at hx
+        subst x
+        simp
+      counit_eq_zero' := by
+        intro x hx
+        rw [Ideal.mem_bot] at hx
+        subst x
+        simp
+      antipode_mem' := by
+        intro x hx
+        rw [Ideal.mem_bot] at hx
+        subst x
+        simp }
+
+@[simp]
+theorem bot_toIdeal : (⊥ : HopfIdeal R H).toIdeal = (⊥ : Ideal H) :=
+  rfl
+
+@[simp]
+theorem mem_bot {x : H} : x ∈ (⊥ : HopfIdeal R H) ↔ x = 0 :=
+  Ideal.mem_bot
+
+/-- The zero Hopf ideal is contained in every Hopf ideal. -/
+instance : OrderBot (HopfIdeal R H) where
+  bot := ⊥
+  bot_le I x hx := by
+    rw [mem_bot] at hx
+    rw [hx]
+    exact zero_mem I
+
+end HopfIdeal
+
+end TauCeti

--- a/TauCeti/Algebra/HopfAlgebra/HopfIdeal.lean
+++ b/TauCeti/Algebra/HopfAlgebra/HopfIdeal.lean
@@ -135,6 +135,8 @@ quotient coalgebra API is available. -/
 structure HopfIdeal where
   /-- The underlying ideal. -/
   carrier : Ideal H
+  /-- The underlying ideal is two-sided. -/
+  isTwoSided' : carrier.IsTwoSided
   /-- The comultiplication of an element of the ideal lies in `I ⊗ H + H ⊗ I`. -/
   comul_mem' :
     ∀ ⦃x : H⦄, x ∈ carrier →
@@ -155,9 +157,9 @@ instance : SetLike (HopfIdeal R H) H where
   coe I := I.carrier
   coe_injective' I J h := by
     cases I with
-    | mk carrier hcomul hcounit hantipode =>
+    | mk carrier htwo hcomul hcounit hantipode =>
     cases J with
-    | mk carrier' hcomul' hcounit' hantipode' =>
+    | mk carrier' htwo' hcomul' hcounit' hantipode' =>
     congr
     exact SetLike.ext' h
 
@@ -174,6 +176,9 @@ instance : PartialOrder (HopfIdeal R H) :=
 /-- The underlying ideal of a Hopf ideal. -/
 def toIdeal (I : HopfIdeal R H) : Ideal H :=
   I.carrier
+
+instance (I : HopfIdeal R H) : I.toIdeal.IsTwoSided :=
+  I.isTwoSided'
 
 @[simp]
 theorem mem_carrier {I : HopfIdeal R H} {x : H} : x ∈ I.carrier ↔ x ∈ I :=
@@ -200,7 +205,7 @@ theorem ext {I J : HopfIdeal R H} (h : ∀ x : H, x ∈ I ↔ x ∈ J) : I = J :
   SetLike.ext h
 
 /-- Constructor from an ideal and the three Hopf-ideal closure conditions. -/
-def ofIdeal (I : Ideal H)
+def ofIdeal (I : Ideal H) [I.IsTwoSided]
     (hcomul :
       ∀ ⦃x : H⦄, x ∈ I →
         Coalgebra.comul (R := R) x ∈
@@ -209,17 +214,18 @@ def ofIdeal (I : Ideal H)
     (hantipode : ∀ ⦃x : H⦄, x ∈ I → HopfAlgebra.antipode R x ∈ I) :
     HopfIdeal R H where
   carrier := I
+  isTwoSided' := inferInstance
   comul_mem' := hcomul
   counit_eq_zero' := hcounit
   antipode_mem' := hantipode
 
 @[simp]
-theorem ofIdeal_carrier (I : Ideal H) (hcomul hcounit hantipode) :
+theorem ofIdeal_carrier (I : Ideal H) [I.IsTwoSided] (hcomul hcounit hantipode) :
     (ofIdeal (R := R) (H := H) I hcomul hcounit hantipode).carrier = I :=
   rfl
 
 @[simp]
-theorem mem_ofIdeal {I : Ideal H} {hcomul hcounit hantipode} {x : H} :
+theorem mem_ofIdeal {I : Ideal H} [I.IsTwoSided] {hcomul hcounit hantipode} {x : H} :
     x ∈ ofIdeal (R := R) (H := H) I hcomul hcounit hantipode ↔ x ∈ I :=
   Iff.rfl
 
@@ -240,10 +246,16 @@ theorem antipode_mem (I : HopfIdeal R H) {x : H} (hx : x ∈ I) :
     HopfAlgebra.antipode R x ∈ I :=
   I.antipode_mem' hx
 
+/-- A Hopf ideal absorbs multiplication on the right as well as on the left. -/
+theorem mul_mem_right (I : HopfIdeal R H) {x : H} (hx : x ∈ I) (y : H) :
+    x * y ∈ I :=
+  I.toIdeal.mul_mem_right y hx
+
 /-- The zero ideal as a Hopf ideal. -/
 instance instBot : Bot (HopfIdeal R H) where
   bot :=
     { carrier := ⊥
+      isTwoSided' := inferInstance
       comul_mem' := by
         intro x hx
         rw [Ideal.mem_bot] at hx

--- a/TauCeti/Algebra/HopfAlgebra/HopfIdeal.lean
+++ b/TauCeti/Algebra/HopfAlgebra/HopfIdeal.lean
@@ -8,9 +8,9 @@ import Mathlib.RingTheory.Ideal.Maps
 /-!
 # Hopf ideals
 
-This file defines Hopf ideals in a commutative Hopf algebra over a commutative ring. A Hopf
-ideal is an ideal `I` whose comultiplication lands in `I ⊗ H + H ⊗ I`, whose counit vanishes
-on `I`, and which is stable under the antipode.
+This file defines Hopf ideals in a Hopf algebra over a commutative semiring. A Hopf ideal is
+an ideal `I` whose comultiplication lands in `I ⊗ H + H ⊗ I`, whose counit vanishes on `I`,
+and which is stable under the antipode.
 
 This is a small Layer 3 prerequisite for the reductive-groups roadmap target
 "Hopf ideals ↔ closed subgroup schemes": closed subgroup schemes of an affine group scheme
@@ -19,7 +19,7 @@ must satisfy exactly these Hopf-ideal closure conditions.
 
 ## Main definitions
 
-* `TauCeti.HopfIdeal`: a Hopf ideal of a commutative Hopf algebra.
+* `TauCeti.HopfIdeal`: a Hopf ideal in a Hopf algebra over a commutative semiring.
 * `TauCeti.HopfIdeal.leftTensorIdeal` and `TauCeti.HopfIdeal.rightTensorIdeal`: the two
   summands `I ⊗ H` and `H ⊗ I` inside `H ⊗ H`.
 * `⊥ : HopfIdeal R H`: the zero Hopf ideal.
@@ -125,9 +125,9 @@ end HopfIdeal
 end TensorIdeals
 
 variable (R : Type u) (H : Type v)
-variable [CommRing R] [CommRing H] [HopfAlgebra R H]
+variable [CommSemiring R] [Semiring H] [HopfAlgebra R H]
 
-/-- A Hopf ideal in a commutative Hopf algebra.
+/-- A Hopf ideal in a Hopf algebra over a commutative semiring.
 
 The comultiplication condition is stated in the ambient tensor product algebra as
 `Δ(I) ⊆ I ⊗ H + H ⊗ I`. The quotient Hopf algebra will be added separately once the needed

--- a/TauCeti/Algebra/HopfAlgebra/HopfIdeal.lean
+++ b/TauCeti/Algebra/HopfAlgebra/HopfIdeal.lean
@@ -81,6 +81,28 @@ theorem includeRight_mem_rightTensorIdeal {I : Ideal H} {x : H} (hx : x ∈ I) :
       rightTensorIdeal (R := R) (H := H) I :=
   Ideal.mem_map_of_mem _ hx
 
+/-- A pure tensor `x ⊗ₜ y` with `x ∈ I` lies in `I ⊗ H`. -/
+theorem tmul_mem_leftTensorIdeal {I : Ideal H} {x : H} (hx : x ∈ I) (y : H) :
+    x ⊗ₜ[R] y ∈ leftTensorIdeal (R := R) (H := H) I := by
+  have h : x ⊗ₜ[R] y =
+      Algebra.TensorProduct.includeRight (R := R) (A := H) (B := H) y *
+        Algebra.TensorProduct.includeLeft (R := R) (S := R) (A := H) (B := H) x := by
+    rw [Algebra.TensorProduct.includeLeft_apply, Algebra.TensorProduct.includeRight_apply,
+      Algebra.TensorProduct.tmul_mul_tmul, mul_one, one_mul]
+  rw [h]
+  exact Ideal.mul_mem_left _ _ (includeLeft_mem_leftTensorIdeal (R := R) (H := H) hx)
+
+/-- A pure tensor `x ⊗ₜ y` with `y ∈ I` lies in `H ⊗ I`. -/
+theorem tmul_mem_rightTensorIdeal {I : Ideal H} (x : H) {y : H} (hy : y ∈ I) :
+    x ⊗ₜ[R] y ∈ rightTensorIdeal (R := R) (H := H) I := by
+  have h : x ⊗ₜ[R] y =
+      Algebra.TensorProduct.includeLeft (R := R) (S := R) (A := H) (B := H) x *
+        Algebra.TensorProduct.includeRight (R := R) (A := H) (B := H) y := by
+    rw [Algebra.TensorProduct.includeLeft_apply, Algebra.TensorProduct.includeRight_apply,
+      Algebra.TensorProduct.tmul_mul_tmul, mul_one, one_mul]
+  rw [h]
+  exact Ideal.mul_mem_left _ _ (includeRight_mem_rightTensorIdeal (R := R) (H := H) hy)
+
 theorem mem_leftTensorIdeal {I : Ideal H} {x : H ⊗[R] H} :
     x ∈ leftTensorIdeal (R := R) (H := H) I ↔
       x ∈ Ideal.map

--- a/TauCeti/Algebra/HopfAlgebra/HopfIdeal.lean
+++ b/TauCeti/Algebra/HopfAlgebra/HopfIdeal.lean
@@ -37,14 +37,95 @@ namespace TauCeti
 
 universe u v
 
-variable (R : Type u) (H : Type v)
-variable [CommRing R] [CommRing H] [HopfAlgebra R H]
+section TensorIdeals
 
-private def hopfIdealLeftTensorIdeal (I : Ideal H) : Ideal (H ⊗[R] H) :=
+variable (R : Type u) (H : Type v)
+variable [CommSemiring R] [Semiring H] [Algebra R H]
+
+namespace HopfIdeal
+
+/-- The image of an ideal `I ≤ H` under the left inclusion `H → H ⊗[R] H`, representing
+`I ⊗ H` inside the tensor product algebra. -/
+def leftTensorIdeal (I : Ideal H) : Ideal (H ⊗[R] H) :=
   Ideal.map (Algebra.TensorProduct.includeLeft (R := R) (S := R) (A := H) (B := H)).toRingHom I
 
-private def hopfIdealRightTensorIdeal (I : Ideal H) : Ideal (H ⊗[R] H) :=
+/-- The image of an ideal `I ≤ H` under the right inclusion `H → H ⊗[R] H`, representing
+`H ⊗ I` inside the tensor product algebra. -/
+def rightTensorIdeal (I : Ideal H) : Ideal (H ⊗[R] H) :=
   Ideal.map (Algebra.TensorProduct.includeRight (R := R) (A := H) (B := H)).toRingHom I
+
+@[simp]
+theorem leftTensorIdeal_def (I : Ideal H) :
+    leftTensorIdeal (R := R) (H := H) I =
+      Ideal.map
+        (Algebra.TensorProduct.includeLeft (R := R) (S := R) (A := H) (B := H)).toRingHom
+        I :=
+  rfl
+
+@[simp]
+theorem rightTensorIdeal_def (I : Ideal H) :
+    rightTensorIdeal (R := R) (H := H) I =
+      Ideal.map
+        (Algebra.TensorProduct.includeRight (R := R) (A := H) (B := H)).toRingHom I :=
+  rfl
+
+/-- The left tensor inclusion sends elements of `I` into `I ⊗ H`. -/
+theorem includeLeft_mem_leftTensorIdeal {I : Ideal H} {x : H} (hx : x ∈ I) :
+    Algebra.TensorProduct.includeLeft (R := R) (S := R) (A := H) (B := H) x ∈
+      leftTensorIdeal (R := R) (H := H) I :=
+  Ideal.mem_map_of_mem _ hx
+
+/-- The right tensor inclusion sends elements of `I` into `H ⊗ I`. -/
+theorem includeRight_mem_rightTensorIdeal {I : Ideal H} {x : H} (hx : x ∈ I) :
+    Algebra.TensorProduct.includeRight (R := R) (A := H) (B := H) x ∈
+      rightTensorIdeal (R := R) (H := H) I :=
+  Ideal.mem_map_of_mem _ hx
+
+theorem mem_leftTensorIdeal {I : Ideal H} {x : H ⊗[R] H} :
+    x ∈ leftTensorIdeal (R := R) (H := H) I ↔
+      x ∈ Ideal.map
+        (Algebra.TensorProduct.includeLeft (R := R) (S := R) (A := H) (B := H)).toRingHom
+        I :=
+  Iff.rfl
+
+theorem mem_rightTensorIdeal {I : Ideal H} {x : H ⊗[R] H} :
+    x ∈ rightTensorIdeal (R := R) (H := H) I ↔
+      x ∈ Ideal.map
+        (Algebra.TensorProduct.includeRight (R := R) (A := H) (B := H)).toRingHom I :=
+  Iff.rfl
+
+theorem leftTensorIdeal_le_iff {I : Ideal H} {J : Ideal (H ⊗[R] H)} :
+    leftTensorIdeal (R := R) (H := H) I ≤ J ↔
+      I ≤ Ideal.comap
+        (Algebra.TensorProduct.includeLeft (R := R) (S := R) (A := H) (B := H)).toRingHom
+        J := by
+  exact Ideal.map_le_iff_le_comap
+
+theorem rightTensorIdeal_le_iff {I : Ideal H} {J : Ideal (H ⊗[R] H)} :
+    rightTensorIdeal (R := R) (H := H) I ≤ J ↔
+      I ≤ Ideal.comap
+        (Algebra.TensorProduct.includeRight (R := R) (A := H) (B := H)).toRingHom J := by
+  exact Ideal.map_le_iff_le_comap
+
+theorem le_leftTensorIdeal_iff {I : Ideal H} {J : Ideal (H ⊗[R] H)} :
+    J ≤ leftTensorIdeal (R := R) (H := H) I ↔
+      J ≤ Ideal.map
+        (Algebra.TensorProduct.includeLeft (R := R) (S := R) (A := H) (B := H)).toRingHom
+        I :=
+  Iff.rfl
+
+theorem le_rightTensorIdeal_iff {I : Ideal H} {J : Ideal (H ⊗[R] H)} :
+    J ≤ rightTensorIdeal (R := R) (H := H) I ↔
+      J ≤ Ideal.map
+        (Algebra.TensorProduct.includeRight (R := R) (A := H) (B := H)).toRingHom I :=
+  Iff.rfl
+
+end HopfIdeal
+
+end TensorIdeals
+
+variable (R : Type u) (H : Type v)
+variable [CommRing R] [CommRing H] [HopfAlgebra R H]
 
 /-- A Hopf ideal in a commutative Hopf algebra.
 
@@ -58,8 +139,8 @@ structure HopfIdeal where
   comul_mem' :
     ∀ ⦃x : H⦄, x ∈ carrier →
       Coalgebra.comul (R := R) x ∈
-        hopfIdealLeftTensorIdeal (R := R) (H := H) carrier ⊔
-          hopfIdealRightTensorIdeal (R := R) (H := H) carrier
+        HopfIdeal.leftTensorIdeal (R := R) (H := H) carrier ⊔
+          HopfIdeal.rightTensorIdeal (R := R) (H := H) carrier
   /-- The counit vanishes on the ideal. -/
   counit_eq_zero' : ∀ ⦃x : H⦄, x ∈ carrier → Coalgebra.counit (R := R) x = 0
   /-- The antipode preserves the ideal. -/
@@ -69,16 +150,6 @@ structure HopfIdeal where
 namespace HopfIdeal
 
 variable {R H}
-
-/-- The image of an ideal `I ≤ H` under the left inclusion `H → H ⊗[R] H`, representing
-`I ⊗ H` inside the tensor product algebra. -/
-def leftTensorIdeal (I : Ideal H) : Ideal (H ⊗[R] H) :=
-  hopfIdealLeftTensorIdeal (R := R) (H := H) I
-
-/-- The image of an ideal `I ≤ H` under the right inclusion `H → H ⊗[R] H`, representing
-`H ⊗ I` inside the tensor product algebra. -/
-def rightTensorIdeal (I : Ideal H) : Ideal (H ⊗[R] H) :=
-  hopfIdealRightTensorIdeal (R := R) (H := H) I
 
 instance : SetLike (HopfIdeal R H) H where
   coe I := I.carrier


### PR DESCRIPTION
This PR adds foundational Hopf ideals for commutative Hopf algebras, advancing `TauCetiRoadmap/ReductiveGroups/README.md`, Layer 3 target "Hopf ideals ↔ closed subgroup schemes: an ideal `I` with `Δ(I) ⊆ I⊗A + A⊗I`, `ε(I)=0`, `S(I) ⊆ I`; the quotient Hopf algebra `A/I`; the anti-equivalence; kernels." It defines the Hopf-ideal structure, the two tensor-summand ideals `I ⊗ H` and `H ⊗ I`, the coideal/counit/antipode API, extensionality and order, and the zero Hopf ideal as the first quotient-ready prerequisite.

No Mathlib infrastructure is vendored. The construction reuses Mathlib Hopf algebra operations, tensor-product algebra inclusions, and `Ideal.map`; the mathematical definition follows Sweedler, *Hopf Algebras*, Chapter 1.

Validated with `lake exe cache get`, `lake build`, and `lake exe axioms`. `lake exe cache get` ended with `No files to download` and `Already decompressed 8480 file(s).` `lake build` ended with `Build completed successfully (3154 jobs).` `lake exe axioms` ended with `axioms: audited 1390 TauCeti declaration(s); all within the allowlist [propext, Classical.choice, Quot.sound].`

🤖 Prepared with Codex
