### PR TITLE
feat: an effective class-number bound

### DIFF
--- a/TauCeti.lean
+++ b/TauCeti.lean
@@ -38,6 +38,6 @@ import TauCeti.Analysis.PDE.LowerOrder
 import TauCeti.Analysis.PDE.UniformEllipticity
 import TauCeti.Basic
 import TauCeti.FieldTheory.Trace
-import TauCeti.NumberTheory.EffectiveBounds.Discriminant
 import TauCeti.NumberTheory.EffectiveBounds.ClassNumber
+import TauCeti.NumberTheory.EffectiveBounds.Discriminant
 import TauCeti.NumberTheory.EffectiveBounds.IdealCount

--- a/TauCeti.lean
+++ b/TauCeti.lean
@@ -39,4 +39,5 @@ import TauCeti.Analysis.PDE.UniformEllipticity
 import TauCeti.Basic
 import TauCeti.FieldTheory.Trace
 import TauCeti.NumberTheory.EffectiveBounds.Discriminant
+import TauCeti.NumberTheory.EffectiveBounds.ClassNumber
 import TauCeti.NumberTheory.EffectiveBounds.IdealCount

--- a/TauCeti/NumberTheory/EffectiveBounds/ClassNumber.lean
+++ b/TauCeti/NumberTheory/EffectiveBounds/ClassNumber.lean
@@ -74,10 +74,10 @@ theorem classNumber_le_bound (F : Type*) [Field F] [NumberField F] :
       convert mul_le_mul_of_nonneg_left h_simp (abs_nonneg (discr F : ℝ)) using 1; ring
     refine le_trans (mul_le_mul_of_nonneg_right (mul_le_of_le_one_right (by positivity) ?_)
       (by positivity)) ?_
-    · exact pow_le_one₀ (by positivity) (div_le_one_of_le₀ (mod_cast Nat.recOn
-        (Module.finrank ℚ F) (by norm_num) fun n ihn => by
-          rw [Nat.factorial_succ, pow_succ']
-          exact le_trans (Nat.mul_le_mul_left _ ihn) (by gcongr; linarith)) (by positivity))
+    · have h_factorial_le_pow : ((Module.finrank ℚ F).factorial : ℝ) ≤
+          (Module.finrank ℚ F : ℝ) ^ Module.finrank ℚ F := by
+        exact_mod_cast Nat.factorial_le_pow (Module.finrank ℚ F)
+      exact pow_le_one₀ (by positivity) (div_le_one_of_le₀ h_factorial_le_pow (by positivity))
     · have h_pi_le_two : (4 : ℝ) / Real.pi ≤ 2 := by
         rw [div_le_iff₀] <;> linarith [Real.pi_gt_three]
       have h_four : (4 : ℝ) = 2 ^ 2 := by norm_num

--- a/TauCeti/NumberTheory/EffectiveBounds/ClassNumber.lean
+++ b/TauCeti/NumberTheory/EffectiveBounds/ClassNumber.lean
@@ -2,7 +2,7 @@
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 -/
-import Mathlib
+import Mathlib.NumberTheory.NumberField.ClassNumber
 import TauCeti.NumberTheory.EffectiveBounds.IdealCount
 
 /-!
@@ -35,7 +35,7 @@ namespace TauCeti.NumberField
 /-- **Class number bound.** `h_F ≤ |d_F| · 4^[F:ℚ]`. By Minkowski's bound every ideal class
 contains an integral ideal of norm at most `√|d_F|`; the classes inject into ideals of norm
 `≤ √|d_F|`, of which there are at most `|d_F| · 2ⁿ` by `card_ideal_absNorm_le`. -/
-theorem classNumber_le_bound (F : Type) [Field F] [NumberField F] :
+theorem classNumber_le_bound (F : Type*) [Field F] [NumberField F] :
     (NumberField.classNumber F : ℝ) ≤
       |(NumberField.discr F : ℝ)| * 4 ^ Module.finrank ℚ F := by
   have := @NumberField.exists_ideal_in_class_of_norm_le F _ _
@@ -78,10 +78,13 @@ theorem classNumber_le_bound (F : Type) [Field F] [NumberField F] :
         (Module.finrank ℚ F) (by norm_num) fun n ihn => by
           rw [Nat.factorial_succ, pow_succ']
           exact le_trans (Nat.mul_le_mul_left _ ihn) (by gcongr; linarith)) (by positivity))
-    · refine le_trans (mul_le_mul_of_nonneg_right (pow_le_pow_left₀ (by positivity)
-        (show (4 : ℝ) / Real.pi ≤ 2 by rw [div_le_iff₀] <;> linarith [Real.pi_gt_three]) _)
+    · have h_pi_le_two : (4 : ℝ) / Real.pi ≤ 2 := by
+        rw [div_le_iff₀] <;> linarith [Real.pi_gt_three]
+      have h_four : (4 : ℝ) = 2 ^ 2 := by norm_num
+      refine le_trans (mul_le_mul_of_nonneg_right (pow_le_pow_left₀ (by positivity)
+        h_pi_le_two _)
         (by positivity)) ?_
-      rw [show (4 : ℝ) = 2 ^ 2 by norm_num, ← pow_mul, ← pow_add]
+      rw [h_four, ← pow_mul, ← pow_add]
       gcongr <;> norm_num
       have := NumberField.InfinitePlace.card_add_two_mul_card_eq_rank F; linarith
 

--- a/TauCeti/NumberTheory/EffectiveBounds/ClassNumber.lean
+++ b/TauCeti/NumberTheory/EffectiveBounds/ClassNumber.lean
@@ -32,9 +32,8 @@ open _root_.NumberField
 
 namespace TauCeti.NumberField
 
-/-- **Class number bound.** `h_F ≤ |d_F| · 4^[F:ℚ]`. By Minkowski's bound every ideal class
-contains an integral ideal of norm at most `√|d_F|`; the classes inject into ideals of norm
-`≤ √|d_F|`, of which there are at most `|d_F| · 2ⁿ` by `card_ideal_absNorm_le`. -/
+/-- **Class number bound.** The class number of a number field `F` is at most
+`|discr F| * 4 ^ [F : ℚ]`. -/
 theorem classNumber_le_bound (F : Type*) [Field F] [NumberField F] :
     (NumberField.classNumber F : ℝ) ≤
       |(NumberField.discr F : ℝ)| * 4 ^ Module.finrank ℚ F := by

--- a/TauCeti/NumberTheory/EffectiveBounds/ClassNumber.lean
+++ b/TauCeti/NumberTheory/EffectiveBounds/ClassNumber.lean
@@ -1,0 +1,88 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+import Mathlib
+import TauCeti.NumberTheory.EffectiveBounds.IdealCount
+
+/-!
+# An effective class-number bound
+
+For a number field `F` of degree `n`, the class number is bounded by
+
+`h_F ≤ |d_F| · 4ⁿ`.
+
+By Mathlib's Minkowski bound (`NumberField.exists_ideal_in_class_of_norm_le`) every ideal
+class contains an integral ideal of norm at most `(4/π)^s · (n!/nⁿ) · √|d_F| ≤ √|d_F|`, so the
+classes inject into the ideals of norm `≤ √|d_F|`, of which there are at most `|d_F| · 2ⁿ` by
+`card_ideal_absNorm_le`.
+
+## Main result
+
+* `TauCeti.NumberField.classNumber_le_bound`: `h_F ≤ |d_F| · 4^[F:ℚ]`.
+
+## Provenance
+
+Migrated from
+[kim-em/erdos-unit-distance](https://github.com/kim-em/erdos-unit-distance), the
+formalization of L. Alpöge's disproof of the uniform-constant Erdős unit-distance conjecture.
+-/
+
+open _root_.NumberField
+
+namespace TauCeti.NumberField
+
+/-- **Class number bound.** `h_F ≤ |d_F| · 4^[F:ℚ]`. By Minkowski's bound every ideal class
+contains an integral ideal of norm at most `√|d_F|`; the classes inject into ideals of norm
+`≤ √|d_F|`, of which there are at most `|d_F| · 2ⁿ` by `card_ideal_absNorm_le`. -/
+theorem classNumber_le_bound (F : Type) [Field F] [NumberField F] :
+    (NumberField.classNumber F : ℝ) ≤
+      |(NumberField.discr F : ℝ)| * 4 ^ Module.finrank ℚ F := by
+  have := @NumberField.exists_ideal_in_class_of_norm_le F _ _
+  choose f hf using this
+  have h_card : (Set.ncard (Set.image (fun C => (f C : Ideal (𝓞 F))) Set.univ)) ≤
+      (4 / Real.pi) ^ (2 * InfinitePlace.nrComplexPlaces F) *
+        ((Module.finrank ℚ F).factorial / (Module.finrank ℚ F) ^ Module.finrank ℚ F) ^ 2 *
+        |(discr F : ℝ)| * 2 ^ Module.finrank ℚ F := by
+    have h_card : (Set.ncard {I : Ideal (𝓞 F) | I ≠ ⊥ ∧ (Ideal.absNorm I : ℝ) ≤
+        (4 / Real.pi) ^ InfinitePlace.nrComplexPlaces F *
+          ((Module.finrank ℚ F).factorial / (Module.finrank ℚ F) ^ Module.finrank ℚ F *
+            Real.sqrt |(discr F : ℝ)|)}) ≤
+        (4 / Real.pi) ^ (2 * InfinitePlace.nrComplexPlaces F) *
+          ((Module.finrank ℚ F).factorial / (Module.finrank ℚ F) ^ Module.finrank ℚ F) ^ 2 *
+          |(discr F : ℝ)| * 2 ^ Module.finrank ℚ F := by
+      convert card_ideal_absNorm_le F _ |>.2 using 1
+      · ring_nf; norm_num [Real.sq_sqrt <| abs_nonneg _]
+      · refine le_trans ?_ (hf 1 |>.2)
+        exact_mod_cast Nat.one_le_iff_ne_zero.mpr (Ideal.absNorm_ne_zero_of_nonZeroDivisors _)
+    refine le_trans ?_ h_card
+    gcongr
+    · convert card_ideal_absNorm_le F _ |>.1 using 1
+      refine le_trans ?_ (hf 1 |>.2)
+      exact_mod_cast Nat.one_le_iff_ne_zero.mpr (Ideal.absNorm_ne_zero_of_nonZeroDivisors _)
+    · simp only [Set.image_univ]
+      exact Set.range_subset_iff.mpr fun C =>
+        ⟨by intro h; simpa [h] using f C |>.2, hf C |>.2⟩
+  refine le_trans ?_ (h_card.trans ?_)
+  · rw [Set.ncard_image_of_injective _ fun x y hxy => ?_, Set.ncard_univ]
+    · norm_num [classNumber]
+    · have := hf x; have := hf y; aesop
+  · -- Simplify the right-hand side of the inequality.
+    suffices h_simp : (4 / Real.pi) ^ (2 * InfinitePlace.nrComplexPlaces F) *
+        ((Module.finrank ℚ F).factorial / (Module.finrank ℚ F) ^ Module.finrank ℚ F) ^ 2 *
+        2 ^ Module.finrank ℚ F ≤ 4 ^ Module.finrank ℚ F by
+      convert mul_le_mul_of_nonneg_left h_simp (abs_nonneg (discr F : ℝ)) using 1; ring
+    refine le_trans (mul_le_mul_of_nonneg_right (mul_le_of_le_one_right (by positivity) ?_)
+      (by positivity)) ?_
+    · exact pow_le_one₀ (by positivity) (div_le_one_of_le₀ (mod_cast Nat.recOn
+        (Module.finrank ℚ F) (by norm_num) fun n ihn => by
+          rw [Nat.factorial_succ, pow_succ']
+          exact le_trans (Nat.mul_le_mul_left _ ihn) (by gcongr; linarith)) (by positivity))
+    · refine le_trans (mul_le_mul_of_nonneg_right (pow_le_pow_left₀ (by positivity)
+        (show (4 : ℝ) / Real.pi ≤ 2 by rw [div_le_iff₀] <;> linarith [Real.pi_gt_three]) _)
+        (by positivity)) ?_
+      rw [show (4 : ℝ) = 2 ^ 2 by norm_num, ← pow_mul, ← pow_add]
+      gcongr <;> norm_num
+      have := NumberField.InfinitePlace.card_add_two_mul_card_eq_rank F; linarith
+
+end TauCeti.NumberField

--- a/TauCeti/NumberTheory/EffectiveBounds/IdealCount.lean
+++ b/TauCeti/NumberTheory/EffectiveBounds/IdealCount.lean
@@ -142,7 +142,7 @@ open _root_.NumberField Ideal IsDedekindDomain UniqueFactorizationMonoid
 
 noncomputable section
 
-variable (F : Type) [Field F] [NumberField F]
+variable (F : Type*) [Field F] [NumberField F]
 
 /-- The norm of the rational prime below a prime ideal `P` of `𝓞 F`. -/
 private def absNormUnder (P : Ideal (𝓞 F)) : ℕ := Ideal.absNorm (Ideal.under ℤ P)
@@ -373,7 +373,7 @@ open _root_.NumberField in
 one coordinate and contributes `absNorm (Ideal.under ℤ P) ^ count` there; the coordinate
 product is bounded by `Ideal.absNorm I`, and injectivity follows by recovering each count
 from a `padicValNat`. -/
-private theorem ideal_ncard_le_prodLeTuples_ncard (F : Type) [Field F] [NumberField F]
+private theorem ideal_ncard_le_prodLeTuples_ncard (F : Type*) [Field F] [NumberField F]
     {X : ℝ} :
     {I : Ideal (𝓞 F) | I ≠ ⊥ ∧ (Ideal.absNorm I : ℝ) ≤ X}.ncard ≤
       (prodLeTuples (Module.finrank ℚ F) X).ncard := by
@@ -391,7 +391,7 @@ private theorem ideal_ncard_le_prodLeTuples_ncard (F : Type) [Field F] [NumberFi
 open _root_.NumberField in
 /-- In any number field `F`, the set of nonzero integral ideals with norm at most `X` is
 finite, and for `X ≥ 1` its cardinality is at most `X² * 2^[F:ℚ]`. -/
-theorem card_ideal_absNorm_le (F : Type) [Field F] [NumberField F]
+theorem card_ideal_absNorm_le (F : Type*) [Field F] [NumberField F]
     {X : ℝ} (hX : 1 ≤ X) :
     {I : Ideal (𝓞 F) | I ≠ ⊥ ∧ (Ideal.absNorm I : ℝ) ≤ X}.Finite ∧
       (({I : Ideal (𝓞 F) | I ≠ ⊥ ∧ (Ideal.absNorm I : ℝ) ≤ X}.ncard : ℝ)) ≤


### PR DESCRIPTION
This PR adds `classNumber_le_bound`: for a number field `F` of degree `n`, the class number satisfies `h_F ≤ |d_F| · 4ⁿ`. By Mathlib's Minkowski bound (`NumberField.exists_ideal_in_class_of_norm_le`) every ideal class contains an integral ideal of norm at most `√|d_F|`, so the classes inject into the ideals of norm `≤ √|d_F|`, of which there are at most `|d_F|·2ⁿ` by the just-merged `card_ideal_absNorm_le`. This is the Layer-1 class-number target of the [effective-bounds roadmap](https://github.com/FormalFrontier/TauCetiRoadmap/blob/main/TauCetiRoadmap/EffectiveBounds/README.md) (`EffectiveBounds/Targets.lean`).

Builds on `TauCeti.NumberTheory.EffectiveBounds.IdealCount` (#143). Migrated from [kim-em/erdos-unit-distance](https://github.com/kim-em/erdos-unit-distance). Builds sorry-free, axiom audit clean.

🤖 Prepared with Claude Code