### PR TITLE
feat: add finite comodule preadditive API

### DIFF
--- a/TauCeti.lean
+++ b/TauCeti.lean
@@ -9,6 +9,7 @@ import TauCeti.Algebra.Coalgebra.Comodule.Cofree
 import TauCeti.Algebra.Coalgebra.Comodule.Corestrict
 import TauCeti.Algebra.Coalgebra.Comodule.Finite
 import TauCeti.Algebra.Coalgebra.Comodule.FiniteCorestrict
+import TauCeti.Algebra.Coalgebra.Comodule.FinitePreadditive
 import TauCeti.Algebra.Coalgebra.Comodule.FiniteTrivial
 import TauCeti.Algebra.Coalgebra.Comodule.Hom
 import TauCeti.Algebra.Coalgebra.Comodule.MatrixCoefficient

--- a/TauCeti/Algebra/Coalgebra/Comodule/FinitePreadditive.lean
+++ b/TauCeti/Algebra/Coalgebra/Comodule/FinitePreadditive.lean
@@ -9,21 +9,15 @@ import TauCeti.Algebra.Coalgebra.Comodule.Preadditive
 /-!
 # Preadditive structure on finitely generated comodules
 
-This file records the preadditive structure on the category of finitely generated right
-comodules over a coalgebra over a commutative ring. The category is a full subcategory of all
-comodules, so Mathlib transfers the preadditive structure from `ComoduleCat`; the declarations
-here expose concrete simp API needed to use finite-dimensional comodules without unfolding the
-full-subcategory construction.
+This file makes the preadditive structure on the category of finitely generated right
+comodules over a coalgebra over a commutative ring available from a finite-comodule import.
+The category is a full subcategory of all comodules, so Mathlib transfers the preadditive
+structure from `ComoduleCat`.
 
 This is a small Layer 1 prerequisite for the reductive-groups roadmap's finite-dimensional
 representation category: additive hom-sets and an additive inclusion functor are needed before
 tensor products, duals, and Tannakian reconstruction can be built on finitely generated
 comodules.
-
-## Main declarations
-
-* Simp lemmas identifying zero, addition, negation, and subtraction with the corresponding
-  ambient comodule morphisms.
 
 ## References
 
@@ -44,75 +38,12 @@ namespace FGComoduleCat
 
 variable {R : Type u} [CommRing R]
 variable {C : Type v} [AddCommMonoid C] [Module R C] [Coalgebra R C]
-variable {M N P : FGComoduleCat.{u, v, w} R C}
 
-/-- Addition of finitely generated comodule morphisms is addition of the ambient comodule
-morphisms. -/
-@[simp]
-theorem hom_add_hom (f g : M ⟶ N) : (f + g).hom = f.hom + g.hom :=
-  rfl
+example : Preadditive (FGComoduleCat.{u, v, w} R C) :=
+  inferInstance
 
-/-- Negation of finitely generated comodule morphisms is negation of the ambient comodule
-morphisms. -/
-@[simp]
-theorem hom_neg_hom (f : M ⟶ N) : (-f).hom = -f.hom :=
-  rfl
-
-/-- Subtraction of finitely generated comodule morphisms is subtraction of the ambient
-comodule morphisms. -/
-@[simp]
-theorem hom_sub_hom (f g : M ⟶ N) : (f - g).hom = f.hom - g.hom :=
-  rfl
-
-/-- The underlying linear map of the zero morphism is zero. -/
-@[simp]
-theorem hom_toLinearMap_zero : (0 : M ⟶ N).hom.toLinearMap = 0 :=
-  rfl
-
-/-- The underlying linear map of a sum is the sum of the underlying linear maps. -/
-@[simp]
-theorem hom_toLinearMap_add (f g : M ⟶ N) :
-    (f + g).hom.toLinearMap = f.hom.toLinearMap + g.hom.toLinearMap := by
-  simp
-
-/-- The underlying linear map of a negation is the negation of the underlying linear map. -/
-@[simp]
-theorem hom_toLinearMap_neg (f : M ⟶ N) :
-    (-(f)).hom.toLinearMap = -f.hom.toLinearMap := by
-  simp
-
-/-- The underlying linear map of a subtraction is the subtraction of the underlying linear
-maps. -/
-@[simp]
-theorem hom_toLinearMap_sub (f g : M ⟶ N) :
-    (f - g).hom.toLinearMap = f.hom.toLinearMap - g.hom.toLinearMap := by
-  simp
-
-/-- The zero finitely generated comodule morphism evaluates to zero. -/
-@[simp]
-theorem zero_apply (m : M) : (0 : M ⟶ N) m = 0 :=
-  rfl
-
-/-- Addition of finitely generated comodule morphisms is pointwise. -/
-@[simp]
-theorem add_apply (f g : M ⟶ N) (m : M) : (f + g) m = f m + g m := by
-  rfl
-
-/-- Negation of finitely generated comodule morphisms is pointwise. -/
-@[simp]
-theorem neg_apply (f : M ⟶ N) (m : M) : (-f) m = -f m := by
-  -- Pass through the ambient comodule morphism, where pointwise negation is already API.
-  change (-f).hom m = -f.hom m
-  rw [hom_neg_hom]
-  exact ComoduleCat.neg_apply (R := R) (C := C) f.hom m
-
-/-- Subtraction of finitely generated comodule morphisms is pointwise. -/
-@[simp]
-theorem sub_apply (f g : M ⟶ N) (m : M) : (f - g) m = f m - g m := by
-  -- Pass through the ambient comodule morphism, where pointwise subtraction is already API.
-  change (f - g).hom m = f.hom m - g.hom m
-  rw [hom_sub_hom]
-  exact ComoduleCat.sub_apply (R := R) (C := C) f.hom g.hom m
+example : (FGComoduleCat.incl (R := R) (C := C)).Additive :=
+  inferInstance
 
 end FGComoduleCat
 

--- a/TauCeti/Algebra/Coalgebra/Comodule/FinitePreadditive.lean
+++ b/TauCeti/Algebra/Coalgebra/Comodule/FinitePreadditive.lean
@@ -1,0 +1,166 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+import Mathlib.CategoryTheory.Preadditive.AdditiveFunctor
+import TauCeti.Algebra.Coalgebra.Comodule.Finite
+import TauCeti.Algebra.Coalgebra.Comodule.Preadditive
+
+/-!
+# Preadditive structure on finitely generated comodules
+
+This file records the preadditive structure on the category of finitely generated right
+comodules over a coalgebra over a commutative ring. The category is a full subcategory of all
+comodules, so Mathlib transfers the preadditive structure from `ComoduleCat`; the declarations
+here expose the concrete API needed to use finite-dimensional comodules without unfolding the
+full-subcategory construction.
+
+This is a small Layer 1 prerequisite for the reductive-groups roadmap's finite-dimensional
+representation category: additive hom-sets and an additive inclusion functor are needed before
+tensor products, duals, and Tannakian reconstruction can be built on finitely generated
+comodules.
+
+## Main declarations
+
+* `TauCeti.FGComoduleCat.preadditive`: `FGComoduleCat R C` is preadditive over a commutative
+  ring.
+* `TauCeti.FGComoduleCat.incl_additive`: the inclusion into all comodules is additive.
+* Simp lemmas identifying zero, addition, negation, and subtraction with the corresponding
+  ambient comodule morphisms.
+
+## References
+
+This supplies additive-category bookkeeping for
+`TauCetiRoadmap/ReductiveGroups/README.md`, Layer 1 target "Comodules over a coalgebra/Hopf
+algebra": the finite-dimensional comodule category should have additive hom-sets before the
+rigid monoidal representation category is developed. The transfer mechanism is Mathlib's
+`ObjectProperty.FullSubcategory` preadditive instance.
+-/
+
+open CategoryTheory
+
+namespace TauCeti
+
+universe u v w
+
+namespace FGComoduleCat
+
+variable (R : Type u) [CommRing R]
+variable (C : Type v) [AddCommMonoid C] [Module R C] [Coalgebra R C]
+
+/-- The category of finitely generated right comodules over a coalgebra over a commutative ring
+is preadditive. -/
+instance preadditive : Preadditive (FGComoduleCat.{u, v, w} R C) :=
+  inferInstanceAs (Preadditive (ComoduleCat.isFG.{u, v, w} (R := R) (C := C)).FullSubcategory)
+
+/-- The inclusion from finitely generated comodules into all comodules is additive. -/
+instance incl_additive : Functor.Additive
+    (incl (R := R) (C := C) : FGComoduleCat.{u, v, w} R C ⥤
+      ComoduleCat.{u, v, w} R C) :=
+  inferInstanceAs (Functor.Additive
+    (ComoduleCat.isFG.{u, v, w} (R := R) (C := C)).ι)
+
+variable {R C}
+variable {M N P : FGComoduleCat.{u, v, w} R C}
+
+/-- The zero morphism of finitely generated comodules has the zero ambient comodule morphism
+underneath. -/
+@[simp]
+theorem hom_zero_hom : (0 : M ⟶ N).hom = 0 :=
+  rfl
+
+/-- Addition of finitely generated comodule morphisms is addition of the ambient comodule
+morphisms. -/
+@[simp]
+theorem hom_add_hom (f g : M ⟶ N) : (f + g).hom = f.hom + g.hom :=
+  rfl
+
+/-- Negation of finitely generated comodule morphisms is negation of the ambient comodule
+morphisms. -/
+@[simp]
+theorem hom_neg_hom (f : M ⟶ N) : (-f).hom = -f.hom :=
+  rfl
+
+/-- Subtraction of finitely generated comodule morphisms is subtraction of the ambient
+comodule morphisms. -/
+@[simp]
+theorem hom_sub_hom (f g : M ⟶ N) : (f - g).hom = f.hom - g.hom :=
+  rfl
+
+/-- The underlying linear map of the zero morphism is zero. -/
+@[simp]
+theorem hom_toLinearMap_zero : (0 : M ⟶ N).hom.toLinearMap = 0 :=
+  rfl
+
+/-- The underlying linear map of a sum is the sum of the underlying linear maps. -/
+@[simp]
+theorem hom_toLinearMap_add (f g : M ⟶ N) :
+    (f + g).hom.toLinearMap = f.hom.toLinearMap + g.hom.toLinearMap := by
+  simp
+
+/-- The underlying linear map of a negation is the negation of the underlying linear map. -/
+@[simp]
+theorem hom_toLinearMap_neg (f : M ⟶ N) :
+    (-(f)).hom.toLinearMap = -f.hom.toLinearMap := by
+  simp
+
+/-- The underlying linear map of a subtraction is the subtraction of the underlying linear
+maps. -/
+@[simp]
+theorem hom_toLinearMap_sub (f g : M ⟶ N) :
+    (f - g).hom.toLinearMap = f.hom.toLinearMap - g.hom.toLinearMap := by
+  simp
+
+/-- The zero finitely generated comodule morphism evaluates to zero. -/
+@[simp]
+theorem zero_apply (m : M) : (0 : M ⟶ N) m = 0 :=
+  rfl
+
+/-- Addition of finitely generated comodule morphisms is pointwise. -/
+@[simp]
+theorem add_apply (f g : M ⟶ N) (m : M) : (f + g) m = f m + g m := by
+  rfl
+
+/-- Negation of finitely generated comodule morphisms is pointwise. -/
+@[simp]
+theorem neg_apply (f : M ⟶ N) (m : M) : (-f) m = -f m := by
+  -- Pass through the ambient comodule morphism, where pointwise negation is already API.
+  change (-f).hom m = -f.hom m
+  rw [hom_neg_hom]
+  exact ComoduleCat.neg_apply (R := R) (C := C) f.hom m
+
+/-- Subtraction of finitely generated comodule morphisms is pointwise. -/
+@[simp]
+theorem sub_apply (f g : M ⟶ N) (m : M) : (f - g) m = f m - g m := by
+  -- Pass through the ambient comodule morphism, where pointwise subtraction is already API.
+  change (f - g).hom m = f.hom m - g.hom m
+  rw [hom_sub_hom]
+  exact ComoduleCat.sub_apply (R := R) (C := C) f.hom g.hom m
+
+/-- Composition in the finite-comodule category is additive in the left argument. -/
+@[simp]
+theorem comp_add (f : M ⟶ N) (g h : N ⟶ P) : f ≫ (g + h) = f ≫ g + f ≫ h :=
+  CategoryTheory.Preadditive.comp_add M N P f g h
+
+/-- Composition in the finite-comodule category is additive in the right argument. -/
+@[simp]
+theorem add_comp (f g : M ⟶ N) (h : N ⟶ P) : (f + g) ≫ h = f ≫ h + g ≫ h :=
+  CategoryTheory.Preadditive.add_comp M N P f g h
+
+/-- The inclusion into all comodules sends zero morphisms to zero morphisms. -/
+@[simp]
+theorem incl_map_zero : (incl (R := R) (C := C)).map (0 : M ⟶ N) = 0 :=
+  rfl
+
+/-- The inclusion into all comodules sends sums of morphisms to sums of morphisms. -/
+@[simp]
+theorem incl_map_add (f g : M ⟶ N) :
+    (incl (R := R) (C := C)).map (f + g) =
+      (incl (R := R) (C := C)).map f + (incl (R := R) (C := C)).map g :=
+  CategoryTheory.Functor.map_add
+    (incl (R := R) (C := C) : FGComoduleCat.{u, v, w} R C ⥤
+    ComoduleCat.{u, v, w} R C)
+
+end FGComoduleCat
+
+end TauCeti

--- a/TauCeti/Algebra/Coalgebra/Comodule/FinitePreadditive.lean
+++ b/TauCeti/Algebra/Coalgebra/Comodule/FinitePreadditive.lean
@@ -120,29 +120,10 @@ theorem sub_apply (f g : M ⟶ N) (m : M) : (f - g) m = f m - g m := by
   rw [hom_sub_hom]
   exact ComoduleCat.sub_apply (R := R) (C := C) f.hom g.hom m
 
-/-- Composition in the finite-comodule category is additive in the left argument. -/
-@[simp]
-theorem comp_add (f : M ⟶ N) (g h : N ⟶ P) : f ≫ (g + h) = f ≫ g + f ≫ h :=
-  CategoryTheory.Preadditive.comp_add M N P f g h
-
-/-- Composition in the finite-comodule category is additive in the right argument. -/
-@[simp]
-theorem add_comp (f g : M ⟶ N) (h : N ⟶ P) : (f + g) ≫ h = f ≫ h + g ≫ h :=
-  CategoryTheory.Preadditive.add_comp M N P f g h
-
 /-- The inclusion into all comodules sends zero morphisms to zero morphisms. -/
 @[simp]
 theorem incl_map_zero : (incl (R := R) (C := C)).map (0 : M ⟶ N) = 0 :=
   rfl
-
-/-- The inclusion into all comodules sends sums of morphisms to sums of morphisms. -/
-@[simp]
-theorem incl_map_add (f g : M ⟶ N) :
-    (incl (R := R) (C := C)).map (f + g) =
-      (incl (R := R) (C := C)).map f + (incl (R := R) (C := C)).map g :=
-  CategoryTheory.Functor.map_add
-    (incl (R := R) (C := C) : FGComoduleCat.{u, v, w} R C ⥤
-    ComoduleCat.{u, v, w} R C)
 
 end FGComoduleCat
 

--- a/TauCeti/Algebra/Coalgebra/Comodule/FinitePreadditive.lean
+++ b/TauCeti/Algebra/Coalgebra/Comodule/FinitePreadditive.lean
@@ -2,7 +2,6 @@
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 -/
-import Mathlib.CategoryTheory.Preadditive.AdditiveFunctor
 import TauCeti.Algebra.Coalgebra.Comodule.Finite
 import TauCeti.Algebra.Coalgebra.Comodule.Preadditive
 
@@ -12,16 +11,15 @@ import TauCeti.Algebra.Coalgebra.Comodule.Preadditive
 This file makes the preadditive structure on the category of finitely generated right
 comodules over a coalgebra over a commutative ring available from a finite-comodule import.
 The category is a full subcategory of all comodules, so Mathlib transfers the preadditive
-structure from `ComoduleCat`, and the inclusion into all comodules is additive.
+structure from `ComoduleCat`.
 
 It also records concrete simp lemmas computing the zero, addition, negation, and subtraction of
 finitely generated comodule morphisms through the underlying ambient comodule morphism `.hom`,
 and pointwise on elements, so downstream code never has to unfold the full-subcategory transfer.
 
 This is a small Layer 1 prerequisite for the reductive-groups roadmap's finite-dimensional
-representation category: additive hom-sets and an additive inclusion functor are needed before
-tensor products, duals, and Tannakian reconstruction can be built on finitely generated
-comodules.
+representation category: additive hom-sets are needed before tensor products, duals, and
+Tannakian reconstruction can be built on finitely generated comodules.
 
 ## Main declarations
 
@@ -37,8 +35,7 @@ This supplies additive-category bookkeeping for
 `TauCetiRoadmap/ReductiveGroups/README.md`, Layer 1 target "Comodules over a coalgebra/Hopf
 algebra": the finite-dimensional comodule category should have additive hom-sets before the
 rigid monoidal representation category is developed. The transfer mechanism is Mathlib's
-`ObjectProperty.FullSubcategory` preadditive instance, and the additive inclusion is Mathlib's
-`CategoryTheory.fullSubcategoryInclusion_additive`.
+`ObjectProperty.FullSubcategory` preadditive instance.
 -/
 
 open CategoryTheory

--- a/TauCeti/Algebra/Coalgebra/Comodule/FinitePreadditive.lean
+++ b/TauCeti/Algebra/Coalgebra/Comodule/FinitePreadditive.lean
@@ -12,7 +12,7 @@ import TauCeti.Algebra.Coalgebra.Comodule.Preadditive
 This file records the preadditive structure on the category of finitely generated right
 comodules over a coalgebra over a commutative ring. The category is a full subcategory of all
 comodules, so Mathlib transfers the preadditive structure from `ComoduleCat`; the declarations
-here expose the concrete API needed to use finite-dimensional comodules without unfolding the
+here expose concrete simp API needed to use finite-dimensional comodules without unfolding the
 full-subcategory construction.
 
 This is a small Layer 1 prerequisite for the reductive-groups roadmap's finite-dimensional
@@ -22,9 +22,6 @@ comodules.
 
 ## Main declarations
 
-* `TauCeti.FGComoduleCat.preadditive`: `FGComoduleCat R C` is preadditive over a commutative
-  ring.
-* `TauCeti.FGComoduleCat.incl_additive`: the inclusion into all comodules is additive.
 * Simp lemmas identifying zero, addition, negation, and subtraction with the corresponding
   ambient comodule morphisms.
 
@@ -45,22 +42,8 @@ universe u v w
 
 namespace FGComoduleCat
 
-variable (R : Type u) [CommRing R]
-variable (C : Type v) [AddCommMonoid C] [Module R C] [Coalgebra R C]
-
-/-- The category of finitely generated right comodules over a coalgebra over a commutative ring
-is preadditive. -/
-instance preadditive : Preadditive (FGComoduleCat.{u, v, w} R C) :=
-  inferInstanceAs (Preadditive (ComoduleCat.isFG.{u, v, w} (R := R) (C := C)).FullSubcategory)
-
-/-- The inclusion from finitely generated comodules into all comodules is additive. -/
-instance incl_additive : Functor.Additive
-    (incl (R := R) (C := C) : FGComoduleCat.{u, v, w} R C ⥤
-      ComoduleCat.{u, v, w} R C) :=
-  inferInstanceAs (Functor.Additive
-    (ComoduleCat.isFG.{u, v, w} (R := R) (C := C)).ι)
-
-variable {R C}
+variable {R : Type u} [CommRing R]
+variable {C : Type v} [AddCommMonoid C] [Module R C] [Coalgebra R C]
 variable {M N P : FGComoduleCat.{u, v, w} R C}
 
 /-- The zero morphism of finitely generated comodules has the zero ambient comodule morphism

--- a/TauCeti/Algebra/Coalgebra/Comodule/FinitePreadditive.lean
+++ b/TauCeti/Algebra/Coalgebra/Comodule/FinitePreadditive.lean
@@ -46,12 +46,6 @@ variable {R : Type u} [CommRing R]
 variable {C : Type v} [AddCommMonoid C] [Module R C] [Coalgebra R C]
 variable {M N P : FGComoduleCat.{u, v, w} R C}
 
-/-- The zero morphism of finitely generated comodules has the zero ambient comodule morphism
-underneath. -/
-@[simp]
-theorem hom_zero_hom : (0 : M ⟶ N).hom = 0 :=
-  rfl
-
 /-- Addition of finitely generated comodule morphisms is addition of the ambient comodule
 morphisms. -/
 @[simp]
@@ -119,11 +113,6 @@ theorem sub_apply (f g : M ⟶ N) (m : M) : (f - g) m = f m - g m := by
   change (f - g).hom m = f.hom m - g.hom m
   rw [hom_sub_hom]
   exact ComoduleCat.sub_apply (R := R) (C := C) f.hom g.hom m
-
-/-- The inclusion into all comodules sends zero morphisms to zero morphisms. -/
-@[simp]
-theorem incl_map_zero : (incl (R := R) (C := C)).map (0 : M ⟶ N) = 0 :=
-  rfl
 
 end FGComoduleCat
 

--- a/TauCeti/Algebra/Coalgebra/Comodule/FinitePreadditive.lean
+++ b/TauCeti/Algebra/Coalgebra/Comodule/FinitePreadditive.lean
@@ -12,12 +12,24 @@ import TauCeti.Algebra.Coalgebra.Comodule.Preadditive
 This file makes the preadditive structure on the category of finitely generated right
 comodules over a coalgebra over a commutative ring available from a finite-comodule import.
 The category is a full subcategory of all comodules, so Mathlib transfers the preadditive
-structure from `ComoduleCat`.
+structure from `ComoduleCat`, and the inclusion into all comodules is additive.
+
+It also records concrete simp lemmas computing the zero, addition, negation, and subtraction of
+finitely generated comodule morphisms through the underlying ambient comodule morphism `.hom`,
+and pointwise on elements, so downstream code never has to unfold the full-subcategory transfer.
 
 This is a small Layer 1 prerequisite for the reductive-groups roadmap's finite-dimensional
 representation category: additive hom-sets and an additive inclusion functor are needed before
 tensor products, duals, and Tannakian reconstruction can be built on finitely generated
 comodules.
+
+## Main declarations
+
+* `TauCeti.FGComoduleCat.hom_zero`, `hom_add`, `hom_neg`, `hom_sub`: the additive-group
+  operations on finitely generated comodule morphisms agree with those of the ambient
+  `ComoduleCat` morphism underneath.
+* `TauCeti.FGComoduleCat.zero_apply`, `add_apply`, `neg_apply`, `sub_apply`: the same
+  operations computed pointwise on elements.
 
 ## References
 
@@ -25,7 +37,8 @@ This supplies additive-category bookkeeping for
 `TauCetiRoadmap/ReductiveGroups/README.md`, Layer 1 target "Comodules over a coalgebra/Hopf
 algebra": the finite-dimensional comodule category should have additive hom-sets before the
 rigid monoidal representation category is developed. The transfer mechanism is Mathlib's
-`ObjectProperty.FullSubcategory` preadditive instance.
+`ObjectProperty.FullSubcategory` preadditive instance, and the additive inclusion is Mathlib's
+`CategoryTheory.fullSubcategoryInclusion_additive`.
 -/
 
 open CategoryTheory
@@ -38,12 +51,49 @@ namespace FGComoduleCat
 
 variable {R : Type u} [CommRing R]
 variable {C : Type v} [AddCommMonoid C] [Module R C] [Coalgebra R C]
+variable {M N : FGComoduleCat.{u, v, w} R C}
 
-example : Preadditive (FGComoduleCat.{u, v, w} R C) :=
-  inferInstance
+/-- The ambient comodule morphism underlying the zero morphism is the zero morphism. -/
+@[simp]
+theorem hom_zero : (0 : M ⟶ N).hom = 0 :=
+  rfl
 
-example : (FGComoduleCat.incl (R := R) (C := C)).Additive :=
-  inferInstance
+/-- The ambient comodule morphism underlying a sum is the sum of the underlying morphisms. -/
+@[simp]
+theorem hom_add (f g : M ⟶ N) : (f + g).hom = f.hom + g.hom :=
+  rfl
+
+/-- The ambient comodule morphism underlying a negation is the negation of the underlying
+morphism. -/
+@[simp]
+theorem hom_neg (f : M ⟶ N) : (-f).hom = -f.hom :=
+  rfl
+
+/-- The ambient comodule morphism underlying a difference is the difference of the underlying
+morphisms. -/
+@[simp]
+theorem hom_sub (f g : M ⟶ N) : (f - g).hom = f.hom - g.hom :=
+  rfl
+
+/-- The zero morphism acts as the zero function. -/
+@[simp]
+theorem zero_apply (m : M) : (0 : M ⟶ N) m = 0 :=
+  rfl
+
+/-- Addition of morphisms acts by pointwise addition. -/
+@[simp]
+theorem add_apply (f g : M ⟶ N) (m : M) : (f + g) m = f m + g m :=
+  rfl
+
+/-- Negation of morphisms acts by pointwise negation. -/
+@[simp]
+theorem neg_apply (f : M ⟶ N) (m : M) : (-f) m = -f m :=
+  rfl
+
+/-- Subtraction of morphisms acts by pointwise subtraction. -/
+@[simp]
+theorem sub_apply (f g : M ⟶ N) (m : M) : (f - g) m = f m - g m :=
+  rfl
 
 end FGComoduleCat
 


### PR DESCRIPTION
This PR adds preadditive-category bookkeeping for finitely generated right comodules: `FGComoduleCat R C` inherits the preadditive structure from all comodules over a commutative ring, the inclusion into `ComoduleCat R C` is additive, and the zero/add/neg/sub morphism operations are exposed through concrete simp lemmas. This advances `TauCetiRoadmap/ReductiveGroups/README.md`, Layer 1 target "Comodules over a coalgebra/Hopf algebra `A`: a coaction `ρ : V → V ⊗ A` with coassociativity and counit; comodule morphisms; the (rigid monoidal) category of finite-dimensional comodules; tensor products, duals, the regular representation," by supplying additive hom-set API for the finite-dimensional representation category before tensor products and duals are added.

No Mathlib infrastructure is vendored. The construction reuses Mathlib's `ObjectProperty.FullSubcategory` preadditive instance and `fullSubcategoryInclusion_additive`, together with Tau Ceti's existing `ComoduleCat.preadditive` and `FGComoduleCat` full-subcategory definition.

Validated with `lake exe cache get`, `lake build`, and `lake exe axioms`. `lake exe cache get` ended with `No files to download` and `Already decompressed 8480 file(s).` `lake build` ended with `Build completed successfully (3696 jobs).` `lake exe axioms` ended with `axioms: audited 1444 TauCeti declaration(s); all within the allowlist [propext, Classical.choice, Quot.sound].`

🤖 Prepared with Codex
