### PR TITLE
feat: the Galois group of a multiquadratic field is (ℤ/2)ⁿ

### DIFF
--- a/TauCeti.lean
+++ b/TauCeti.lean
@@ -44,4 +44,5 @@ import TauCeti.NumberTheory.EffectiveBounds.Discriminant
 import TauCeti.NumberTheory.EffectiveBounds.IdealCount
 import TauCeti.NumberTheory.Multiquadratic.Degree
 import TauCeti.NumberTheory.Multiquadratic.Galois
+import TauCeti.NumberTheory.Multiquadratic.GaloisGroup
 import TauCeti.NumberTheory.Multiquadratic.SquareClass

--- a/TauCeti/NumberTheory/Multiquadratic/Galois.lean
+++ b/TauCeti/NumberTheory/Multiquadratic/Galois.lean
@@ -6,7 +6,6 @@ import Mathlib.FieldTheory.Galois.Basic
 import Mathlib.FieldTheory.Normal.Basic
 import Mathlib.FieldTheory.SeparableClosure
 import Mathlib.GroupTheory.Exponent
-import Mathlib.Tactic
 
 /-!
 # A multiquadratic field is Galois

--- a/TauCeti/NumberTheory/Multiquadratic/Galois.lean
+++ b/TauCeti/NumberTheory/Multiquadratic/Galois.lean
@@ -71,6 +71,7 @@ noncomputable def gen (root : ι → L) (i : ι) : adjoin K (Set.range root) :=
   ⟨root i, subset_adjoin _ _ ⟨i, rfl⟩⟩
 
 omit [Finite ι] in
+/-- Coercing the `i`-th generator of `K(rootᵢ : i)` back to `L` gives `root i`. -/
 @[simp] theorem coe_gen (i : ι) : (gen (K := K) root i : L) = root i := rfl
 
 omit [Finite ι] in
@@ -90,7 +91,7 @@ private theorem adjoin_gen_eq_top :
 
 omit [Finite ι] in
 /-- The generator squares to its radicand (in `M`). -/
-theorem gen_sq (hroot : ∀ i, root i ^ 2 = algebraMap K L (d i)) (i : ι) :
+@[simp] theorem gen_sq (hroot : ∀ i, root i ^ 2 = algebraMap K L (d i)) (i : ι) :
     gen (K := K) root i ^ 2 = algebraMap K (adjoin K (Set.range root)) (d i) := by
   apply Subtype.ext
   rw [IntermediateField.coe_pow, coe_gen, IntermediateField.coe_algebraMap_apply]

--- a/TauCeti/NumberTheory/Multiquadratic/Galois.lean
+++ b/TauCeti/NumberTheory/Multiquadratic/Galois.lean
@@ -50,6 +50,11 @@ noncomputable def definingPolynomial (d : ι → K) : K[X] :=
   letI := Fintype.ofFinite ι
   ∏ i, (X ^ 2 - C (d i))
 
+/-- The defining polynomial is the product of the quadratic factors `X² - dᵢ`. -/
+@[simp] theorem definingPolynomial_def :
+    definingPolynomial d = (letI := Fintype.ofFinite ι; ∏ i, (X ^ 2 - C (d i))) := by
+  rw [definingPolynomial]
+
 omit [Finite ι] in
 /-- Each quadratic factor splits in `M`, with roots `± rootᵢ`. -/
 private theorem splits_X_sq_sub_C (hroot : ∀ i, root i ^ 2 = algebraMap K L (d i)) (i : ι) :
@@ -96,6 +101,33 @@ omit [Finite ι] in
   apply Subtype.ext
   rw [IntermediateField.coe_pow, coe_gen, IntermediateField.coe_algebraMap_apply]
   exact hroot i
+
+omit [Finite ι] in
+/-- Every automorphism sends a generator to itself or to its negation. -/
+theorem aut_gen_eq_self_or_eq_neg (hroot : ∀ i, root i ^ 2 = algebraMap K L (d i))
+    (σ : adjoin K (Set.range root) ≃ₐ[K] adjoin K (Set.range root)) (i : ι) :
+    σ (gen root i) = gen root i ∨ σ (gen root i) = -gen root i := by
+  have h1 : (σ (gen root i)) ^ 2 = (gen root i) ^ 2 := by
+    rw [← map_pow, gen_sq hroot, AlgEquiv.commutes, ← gen_sq hroot]
+  exact sq_eq_sq_iff_eq_or_eq_neg.mp h1
+
+omit [Finite ι] in
+/-- A generator is not equal to its own negation when the radicand is nonzero. -/
+theorem gen_ne_neg [NeZero (2 : K)] (hroot : ∀ i, root i ^ 2 = algebraMap K L (d i))
+    (i : ι) (hd : d i ≠ 0) :
+    gen (K := K) root i ≠ -gen root i := by
+  intro h
+  have hcoe : root i = -root i := by simpa using congrArg Subtype.val h
+  have h2L : (2 : L) ≠ 0 := by
+    rw [← map_ofNat (algebraMap K L) 2]
+    exact (map_ne_zero_iff _ (FaithfulSMul.algebraMap_injective K L)).mpr two_ne_zero
+  have hr0 : root i = 0 := by
+    have h2 : (2 : L) * root i = 0 := by rw [two_mul]; nth_rewrite 1 [hcoe]; rw [neg_add_cancel]
+    exact (mul_eq_zero.mp h2).resolve_left h2L
+  have hd0 : d i = 0 := by
+    have hh : algebraMap K L (d i) = 0 := by rw [← hroot i, hr0]; ring
+    exact (map_eq_zero_iff _ (FaithfulSMul.algebraMap_injective K L)).mp hh
+  exact hd hd0
 
 /-- `∏ᵢ (X² - dᵢ)` is nonzero. -/
 private theorem definingPolynomial_ne_zero : definingPolynomial d ≠ 0 := by

--- a/TauCeti/NumberTheory/Multiquadratic/Galois.lean
+++ b/TauCeti/NumberTheory/Multiquadratic/Galois.lean
@@ -2,23 +2,28 @@
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 -/
-import Mathlib.Algebra.Ring.Commute
-import Mathlib.FieldTheory.IntermediateField.Adjoin.Defs
+import Mathlib.FieldTheory.Galois.Basic
+import Mathlib.FieldTheory.Normal.Basic
+import Mathlib.FieldTheory.SeparableClosure
 import Mathlib.GroupTheory.Exponent
+import Mathlib.Tactic
 
 /-!
-# The automorphism group of a multiquadratic field is elementary abelian of exponent two
+# A multiquadratic field is Galois
 
-For square roots `root i` of radicands `d i ∈ K`, every `K`-automorphism of the multiquadratic
-field `K(rootᵢ : i)` sends each generator to another element with the same square. Hence applying
-the automorphism twice fixes each generator, so it squares to the identity. Therefore the
-automorphism group has exponent two and is abelian.
+For square roots `root i` of radicands `d i ∈ K`, the multiquadratic field `M = K(rootᵢ : i)` is
+the splitting field of `∏ᵢ (X² - dᵢ)`, hence normal; when `2 ≠ 0` in `K` each generator is
+separable, so `M / K` is Galois. Along the way we record the basic structure shared by the later
+group-theoretic analysis: every `K`-automorphism sends each generator to another element with the
+same square, so it is an involution and the automorphism group is abelian.
 
-These are the "exponent-two and abelian" facts of the multiquadratic roadmap; the explicit
-identification of the group with `(ℤ/2)ⁿ` is a separate, later step.
+The explicit identification of the group with `(ℤ/2)ⁿ` is a separate, later step
+(`TauCeti.NumberTheory.Multiquadratic.GaloisGroup`).
 
 ## Main results
 
+* `TauCeti.Multiquadratic.isSplittingField`: `M` is the splitting field of `∏ᵢ (X² - dᵢ)`.
+* `TauCeti.Multiquadratic.isGalois`: `M / K` is Galois (when `2 ≠ 0` in `K`).
 * `TauCeti.Multiquadratic.aut_mul_self_eq_one`: every `σ : M ≃ₐ[K] M` satisfies `σ * σ = 1`.
 * `TauCeti.Multiquadratic.aut_commute`: the automorphism group is commutative.
 
@@ -30,12 +35,129 @@ of L. Alpöge's disproof of the uniform-constant Erdős unit-distance conjecture
 facts were established for one concrete CM field.
 -/
 
-open IntermediateField
+open Polynomial IntermediateField
 
 namespace TauCeti.Multiquadratic
 
 variable {K L : Type*} [Field K] [Field L] [Algebra K L] {ι : Type*}
   {d : ι → K} {root : ι → L}
+
+section SplittingField
+
+variable [Finite ι]
+
+/-- The defining polynomial of the multiquadratic field: `∏ᵢ (X² - dᵢ)`. -/
+noncomputable def definingPolynomial (d : ι → K) : K[X] :=
+  letI := Fintype.ofFinite ι
+  ∏ i, (X ^ 2 - C (d i))
+
+omit [Finite ι] in
+/-- Each quadratic factor splits in `M`, with roots `± rootᵢ`. -/
+private theorem splits_X_sq_sub_C (hroot : ∀ i, root i ^ 2 = algebraMap K L (d i)) (i : ι) :
+    ((X ^ 2 - C (d i)).map (algebraMap K (adjoin K (Set.range root)))).Splits := by
+  have hmem : root i ∈ adjoin K (Set.range root) := subset_adjoin _ _ ⟨i, rfl⟩
+  have hy2 : (⟨root i, hmem⟩ : adjoin K (Set.range root)) ^ 2
+      = algebraMap K (adjoin K (Set.range root)) (d i) := by
+    apply Subtype.ext
+    rw [IntermediateField.coe_pow, IntermediateField.coe_algebraMap_apply]
+    exact hroot i
+  have hfac : (X ^ 2 - C (d i)).map (algebraMap K (adjoin K (Set.range root)))
+      = (X - C ⟨root i, hmem⟩) * (X - C (-⟨root i, hmem⟩)) := by
+    rw [Polynomial.map_sub, Polynomial.map_pow, map_X, map_C, ← hy2, map_pow, map_neg]; ring
+  rw [hfac]
+  exact (Polynomial.Splits.X_sub_C _).mul (Polynomial.Splits.X_sub_C _)
+
+/-- The `i`-th generator, as an element of the multiquadratic field `M`. -/
+noncomputable def gen (root : ι → L) (i : ι) : adjoin K (Set.range root) :=
+  ⟨root i, subset_adjoin _ _ ⟨i, rfl⟩⟩
+
+omit [Finite ι] in
+@[simp] theorem coe_gen (i : ι) : (gen (K := K) root i : L) = root i := rfl
+
+omit [Finite ι] in
+/-- The generators generate `M` as its own top field. -/
+private theorem adjoin_gen_eq_top :
+    IntermediateField.adjoin K (Set.range (gen (K := K) root)) = ⊤ := by
+  refine IntermediateField.map_injective (adjoin K (Set.range root)).val ?_
+  have hmaptop : (⊤ : IntermediateField K (adjoin K (Set.range root))).map
+      (adjoin K (Set.range root)).val = adjoin K (Set.range root) := by
+    ext x
+    simp only [IntermediateField.mem_map, IntermediateField.mem_top, true_and]
+    exact ⟨fun ⟨y, hy⟩ => hy ▸ y.2, fun hx => ⟨⟨x, hx⟩, rfl⟩⟩
+  rw [IntermediateField.adjoin_map, hmaptop]
+  congr 1
+  rw [← Set.range_comp]
+  rfl
+
+omit [Finite ι] in
+/-- The generator squares to its radicand (in `M`). -/
+theorem gen_sq (hroot : ∀ i, root i ^ 2 = algebraMap K L (d i)) (i : ι) :
+    gen (K := K) root i ^ 2 = algebraMap K (adjoin K (Set.range root)) (d i) := by
+  apply Subtype.ext
+  rw [IntermediateField.coe_pow, coe_gen, IntermediateField.coe_algebraMap_apply]
+  exact hroot i
+
+/-- `∏ᵢ (X² - dᵢ)` is nonzero. -/
+private theorem definingPolynomial_ne_zero : definingPolynomial d ≠ 0 := by
+  rw [definingPolynomial, Finset.prod_ne_zero_iff]
+  exact fun i _ => Polynomial.X_pow_sub_C_ne_zero (by norm_num) (d i)
+
+/-- The defining polynomial splits over `M`. -/
+private theorem splits_definingPolynomial (hroot : ∀ i, root i ^ 2 = algebraMap K L (d i)) :
+    ((definingPolynomial d).map (algebraMap K (adjoin K (Set.range root)))).Splits := by
+  rw [definingPolynomial, Polynomial.map_prod]
+  exact Polynomial.Splits.prod fun i _ => splits_X_sq_sub_C hroot i
+
+omit [Finite ι] in
+/-- Each generator is algebraic over `K` (it satisfies `X² - dᵢ`). -/
+private theorem isAlgebraic_gen (hroot : ∀ i, root i ^ 2 = algebraMap K L (d i)) (i : ι) :
+    IsAlgebraic K (gen (K := K) root i) :=
+  ⟨X ^ 2 - C (d i), X_pow_sub_C_ne_zero (by norm_num) _, by
+    rw [map_sub, map_pow, aeval_X, aeval_C, gen_sq hroot i, sub_self]⟩
+
+/-- `M = K(rootᵢ : i)` is the splitting field of `∏ᵢ (X² - dᵢ)` over `K`. -/
+theorem isSplittingField (hroot : ∀ i, root i ^ 2 = algebraMap K L (d i)) :
+    (definingPolynomial d).IsSplittingField K (adjoin K (Set.range root)) where
+  splits' := splits_definingPolynomial hroot
+  adjoin_rootSet' := by
+    letI := Fintype.ofFinite ι
+    have hsub : Set.range (gen (K := K) root) ⊆
+        (definingPolynomial d).rootSet (adjoin K (Set.range root)) := by
+      rintro _ ⟨i, rfl⟩
+      rw [Polynomial.mem_rootSet]
+      refine ⟨definingPolynomial_ne_zero, ?_⟩
+      rw [definingPolynomial, map_prod]
+      exact Finset.prod_eq_zero (Finset.mem_univ i)
+        (by rw [map_sub, map_pow, aeval_X, aeval_C, gen_sq hroot i, sub_self])
+    have halg : ∀ x ∈ Set.range (gen (K := K) root), IsAlgebraic K x := by
+      rintro _ ⟨i, rfl⟩; exact isAlgebraic_gen hroot i
+    refine le_antisymm le_top ?_
+    rw [← Algebra.adjoin_eq_top_of_intermediateField halg (adjoin_gen_eq_top (root := root))]
+    exact Algebra.adjoin_mono hsub
+
+/-- A multiquadratic field over a field in which `2 ≠ 0` is Galois: it is the splitting field of
+`∏ᵢ (X² - dᵢ)` (hence normal), and each generator satisfies a separable quadratic. -/
+theorem isGalois [NeZero (2 : K)] (hroot : ∀ i, root i ^ 2 = algebraMap K L (d i)) :
+    IsGalois K (adjoin K (Set.range root)) := by
+  haveI := isSplittingField hroot
+  haveI : Normal K (adjoin K (Set.range root)) := Normal.of_isSplittingField (definingPolynomial d)
+  haveI : Algebra.IsSeparable K (adjoin K (Set.range root)) := by
+    rw [IntermediateField.isSeparable_adjoin_iff_isSeparable]
+    rintro _ ⟨i, rfl⟩
+    -- `root i` is a root of `X² - dᵢ`; this is separable when `dᵢ ≠ 0` (as `2 ≠ 0`), and when
+    -- `dᵢ = 0` the generator is `0`, a root of the separable polynomial `X`.
+    have haeval : aeval (root i) (X ^ 2 - C (d i)) = 0 := by
+      rw [map_sub, map_pow, aeval_X, aeval_C, hroot i, sub_self]
+    by_cases hd : d i = 0
+    · have hr0 : root i = 0 := by
+        have hz : root i ^ 2 = 0 := by rw [hroot i, hd, map_zero]
+        exact pow_eq_zero_iff (by norm_num) |>.mp hz
+      exact separable_X.of_dvd (minpoly.dvd K (root i) (by rw [aeval_X, hr0]))
+    · exact (separable_X_pow_sub_C (d i) (by exact_mod_cast two_ne_zero) hd).of_dvd
+        (minpoly.dvd K (root i) haeval)
+  constructor
+
+end SplittingField
 
 /-- Every `K`-automorphism of the multiquadratic field `K(rootᵢ : i)` is an involution: fixing
 `K` forces the image of each generator to have the same square as the generator, so applying the

--- a/TauCeti/NumberTheory/Multiquadratic/Galois.lean
+++ b/TauCeti/NumberTheory/Multiquadratic/Galois.lean
@@ -81,7 +81,7 @@ omit [Finite ι] in
 
 omit [Finite ι] in
 /-- The generators generate `M` as its own top field. -/
-private theorem adjoin_gen_eq_top :
+theorem adjoin_gen_eq_top :
     IntermediateField.adjoin K (Set.range (gen (K := K) root)) = ⊤ := by
   refine IntermediateField.map_injective (adjoin K (Set.range root)).val ?_
   have hmaptop : (⊤ : IntermediateField K (adjoin K (Set.range root))).map

--- a/TauCeti/NumberTheory/Multiquadratic/GaloisGroup.lean
+++ b/TauCeti/NumberTheory/Multiquadratic/GaloisGroup.lean
@@ -1,0 +1,267 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+import Mathlib
+import TauCeti.NumberTheory.Multiquadratic.Degree
+
+/-!
+# A multiquadratic field is Galois, with group `(ℤ/2)ⁿ`
+
+Over a field `K` of characteristic zero, a multiquadratic field `M = K(rootᵢ : i)` (with
+`rootᵢ ^ 2 = dᵢ ∈ K`) is the splitting field of the polynomial `∏ᵢ (X² - dᵢ)`, hence Galois.
+Each automorphism sends every generator to `± rootᵢ`, so it is determined by a *sign pattern*
+`ι → ℤ/2`; this assignment is an injective group homomorphism. When the radicands are
+square-class independent the degree is `2ⁿ` (`TauCeti.NumberTheory.Multiquadratic.Degree`), so
+counting forces the homomorphism to be an isomorphism: `Gal(M/K) ≃ (ℤ/2)ⁿ`.
+
+## Main results
+
+* `TauCeti.Multiquadratic.isGalois`: `M / K` is Galois.
+* `TauCeti.Multiquadratic.signHom`: the injective sign-pattern homomorphism `Gal(M/K) →* (ℤ/2)ⁿ`.
+* `TauCeti.Multiquadratic.galoisGroupEquiv`: the explicit isomorphism
+  `Gal(M/K) ≃* Multiplicative (ι → ℤ/2)`.
+
+## Provenance
+
+Generalised from
+[kim-em/erdos-unit-distance](https://github.com/kim-em/erdos-unit-distance), the formalization
+of L. Alpöge's disproof of the uniform-constant Erdős unit-distance conjecture, where the
+sign-change automorphisms of one concrete multiquadratic field were analysed; here the
+construction is carried out for an arbitrary such tower.
+-/
+
+open Polynomial IntermediateField
+
+attribute [local instance] Classical.propDecidable
+
+namespace TauCeti.Multiquadratic
+
+variable {K L : Type*} [Field K] [Field L] [Algebra K L] {ι : Type*} [Finite ι]
+  {d : ι → K} {root : ι → L}
+
+/-- The defining polynomial of the multiquadratic field: `∏ᵢ (X² - dᵢ)`. -/
+noncomputable def mqPoly (d : ι → K) : K[X] :=
+  letI := Fintype.ofFinite ι
+  ∏ i, (X ^ 2 - C (d i))
+
+omit [Finite ι] in
+/-- Each quadratic factor splits in `M`, with roots `± rootᵢ`. -/
+theorem splits_X_sq_sub_C (hroot : ∀ i, root i ^ 2 = algebraMap K L (d i)) (i : ι) :
+    ((X ^ 2 - C (d i)).map (algebraMap K (adjoin K (Set.range root)))).Splits := by
+  have hmem : root i ∈ adjoin K (Set.range root) := subset_adjoin _ _ ⟨i, rfl⟩
+  have hy2 : (⟨root i, hmem⟩ : adjoin K (Set.range root)) ^ 2
+      = algebraMap K (adjoin K (Set.range root)) (d i) := by
+    apply Subtype.ext
+    rw [IntermediateField.coe_pow, IntermediateField.coe_algebraMap_apply]
+    exact hroot i
+  have hfac : (X ^ 2 - C (d i)).map (algebraMap K (adjoin K (Set.range root)))
+      = (X - C ⟨root i, hmem⟩) * (X - C (-⟨root i, hmem⟩)) := by
+    rw [Polynomial.map_sub, Polynomial.map_pow, map_X, map_C, ← hy2, map_pow, map_neg]; ring
+  rw [hfac]
+  exact (Polynomial.Splits.X_sub_C _).mul (Polynomial.Splits.X_sub_C _)
+
+/-- The `i`-th generator, as an element of the multiquadratic field `M`. -/
+noncomputable def gen (root : ι → L) (i : ι) : adjoin K (Set.range root) :=
+  ⟨root i, subset_adjoin _ _ ⟨i, rfl⟩⟩
+
+omit [Finite ι] in
+@[simp] theorem coe_gen (i : ι) : (gen (K := K) root i : L) = root i := rfl
+
+omit [Finite ι] in
+/-- The generators generate `M` as its own top field. -/
+theorem adjoin_gen_eq_top :
+    IntermediateField.adjoin K (Set.range (gen (K := K) root)) = ⊤ := by
+  refine IntermediateField.map_injective (adjoin K (Set.range root)).val ?_
+  have hmaptop : (⊤ : IntermediateField K (adjoin K (Set.range root))).map
+      (adjoin K (Set.range root)).val = adjoin K (Set.range root) := by
+    ext x
+    simp only [IntermediateField.mem_map, IntermediateField.mem_top, true_and]
+    exact ⟨fun ⟨y, hy⟩ => hy ▸ y.2, fun hx => ⟨⟨x, hx⟩, rfl⟩⟩
+  rw [IntermediateField.adjoin_map, hmaptop]
+  congr 1
+  rw [← Set.range_comp]
+  rfl
+
+omit [Finite ι] in
+/-- The generator squares to its radicand (in `M`). -/
+theorem gen_sq (hroot : ∀ i, root i ^ 2 = algebraMap K L (d i)) (i : ι) :
+    gen (K := K) root i ^ 2 = algebraMap K (adjoin K (Set.range root)) (d i) := by
+  apply Subtype.ext
+  rw [IntermediateField.coe_pow, coe_gen, IntermediateField.coe_algebraMap_apply]
+  exact hroot i
+
+/-- `∏ᵢ (X² - dᵢ)` is nonzero. -/
+theorem mqPoly_ne_zero : mqPoly d ≠ 0 := by
+  rw [mqPoly, Finset.prod_ne_zero_iff]
+  exact fun i _ => Polynomial.X_pow_sub_C_ne_zero (by norm_num) (d i)
+
+/-- The defining polynomial splits over `M`. -/
+theorem splits_mqPoly (hroot : ∀ i, root i ^ 2 = algebraMap K L (d i)) :
+    ((mqPoly d).map (algebraMap K (adjoin K (Set.range root)))).Splits := by
+  rw [mqPoly, Polynomial.map_prod]
+  exact Polynomial.Splits.prod fun i _ => splits_X_sq_sub_C hroot i
+
+omit [Finite ι] in
+/-- Each generator is algebraic over `K` (it satisfies `X² - dᵢ`). -/
+theorem isAlgebraic_gen (hroot : ∀ i, root i ^ 2 = algebraMap K L (d i)) (i : ι) :
+    IsAlgebraic K (gen (K := K) root i) :=
+  ⟨X ^ 2 - C (d i), X_pow_sub_C_ne_zero (by norm_num) _, by
+    rw [map_sub, map_pow, aeval_X, aeval_C, gen_sq hroot i, sub_self]⟩
+
+/-- `M = K(rootᵢ : i)` is the splitting field of `∏ᵢ (X² - dᵢ)` over `K`. -/
+theorem isSplittingField (hroot : ∀ i, root i ^ 2 = algebraMap K L (d i)) :
+    (mqPoly d).IsSplittingField K (adjoin K (Set.range root)) where
+  splits' := splits_mqPoly hroot
+  adjoin_rootSet' := by
+    letI := Fintype.ofFinite ι
+    have hsub : Set.range (gen (K := K) root) ⊆
+        (mqPoly d).rootSet (adjoin K (Set.range root)) := by
+      rintro _ ⟨i, rfl⟩
+      rw [Polynomial.mem_rootSet]
+      refine ⟨mqPoly_ne_zero, ?_⟩
+      rw [mqPoly, map_prod]
+      exact Finset.prod_eq_zero (Finset.mem_univ i)
+        (by rw [map_sub, map_pow, aeval_X, aeval_C, gen_sq hroot i, sub_self])
+    have halg : ∀ x ∈ Set.range (gen (K := K) root), IsAlgebraic K x := by
+      rintro _ ⟨i, rfl⟩; exact isAlgebraic_gen hroot i
+    refine le_antisymm le_top ?_
+    rw [← Algebra.adjoin_eq_top_of_intermediateField halg (adjoin_gen_eq_top (root := root))]
+    exact Algebra.adjoin_mono hsub
+
+/-- A multiquadratic field over a field of characteristic zero is Galois. -/
+theorem isGalois [CharZero K] (hroot : ∀ i, root i ^ 2 = algebraMap K L (d i)) :
+    IsGalois K (adjoin K (Set.range root)) := by
+  haveI := isSplittingField hroot
+  haveI : Normal K (adjoin K (Set.range root)) := Normal.of_isSplittingField (mqPoly d)
+  constructor
+
+omit [Finite ι] in
+/-- Every automorphism sends a generator to `± itself`. -/
+theorem aut_gen_eq_or (hroot : ∀ i, root i ^ 2 = algebraMap K L (d i))
+    (σ : adjoin K (Set.range root) ≃ₐ[K] adjoin K (Set.range root)) (i : ι) :
+    σ (gen root i) = gen root i ∨ σ (gen root i) = -gen root i := by
+  have h1 : (σ (gen root i)) ^ 2 = (gen root i) ^ 2 := by
+    rw [← map_pow, gen_sq hroot, AlgEquiv.commutes, ← gen_sq hroot]
+  exact sq_eq_sq_iff_eq_or_eq_neg.mp h1
+
+variable (root) in
+/-- The sign pattern of an automorphism: `0` where it fixes a generator, `1` where it negates. -/
+noncomputable def signPattern
+    (σ : adjoin K (Set.range root) ≃ₐ[K] adjoin K (Set.range root)) (i : ι) : ZMod 2 :=
+  if σ (gen root i) = gen root i then 0 else 1
+
+omit [Finite ι] in
+/-- An automorphism acts on each generator by the corresponding sign. -/
+theorem aut_gen_eq_signPattern (hroot : ∀ i, root i ^ 2 = algebraMap K L (d i))
+    (σ : adjoin K (Set.range root) ≃ₐ[K] adjoin K (Set.range root)) (i : ι) :
+    σ (gen root i) = (-1) ^ (signPattern root σ i).val * gen root i := by
+  rw [signPattern]
+  split_ifs with h
+  · simp [h]
+  · rcases aut_gen_eq_or hroot σ i with h' | h'
+    · exact absurd h' h
+    · simp [h', show ((1 : ZMod 2).val) = 1 from rfl]
+
+omit [Finite ι] in
+/-- Two automorphisms with the same sign pattern are equal. -/
+theorem signPattern_injective (hroot : ∀ i, root i ^ 2 = algebraMap K L (d i)) :
+    Function.Injective (signPattern (K := K) root) := by
+  intro σ τ h
+  refine AlgEquiv.coe_algHom_injective
+    (IntermediateField.algHom_ext_of_eq_adjoin (F := K)
+      (S := adjoin K (Set.range root)) (s := Set.range root) rfl ?_)
+  rintro x ⟨i, rfl⟩
+  have hgen : σ (gen root i) = τ (gen root i) := by
+    rw [aut_gen_eq_signPattern hroot, aut_gen_eq_signPattern hroot, h]
+  exact hgen
+
+omit [Finite ι] in
+/-- A generator is not equal to its own negation (the radicand is a nonzero non-square). -/
+theorem gen_ne_neg [CharZero K] (hroot : ∀ i, root i ^ 2 = algebraMap K L (d i))
+    (hindep : ∀ S : Finset ι, S.Nonempty → ¬ IsSquare (∏ i ∈ S, d i)) (i : ι) :
+    gen (K := K) root i ≠ -gen root i := by
+  intro h
+  have hcoe : root i = -root i := by simpa using congrArg Subtype.val h
+  have h2L : (2 : L) ≠ 0 := by
+    rw [← map_ofNat (algebraMap K L) 2]
+    exact (map_ne_zero_iff _ (FaithfulSMul.algebraMap_injective K L)).mpr (by norm_num)
+  have hr0 : root i = 0 := by
+    have h2 : (2 : L) * root i = 0 := by rw [two_mul]; nth_rewrite 1 [hcoe]; rw [neg_add_cancel]
+    exact (mul_eq_zero.mp h2).resolve_left h2L
+  have hd0 : d i = 0 := by
+    have hh : algebraMap K L (d i) = 0 := by rw [← hroot i, hr0]; ring
+    exact (map_eq_zero_iff _ (FaithfulSMul.algebraMap_injective K L)).mp hh
+  refine hindep {i} ⟨i, Finset.mem_singleton_self i⟩ ?_
+  rw [Finset.prod_singleton, hd0]
+  exact ⟨0, by ring⟩
+
+omit [Finite ι] in
+/-- The sign is `0` exactly where the automorphism fixes the generator. -/
+theorem signPattern_eq_zero
+    (σ : adjoin K (Set.range root) ≃ₐ[K] adjoin K (Set.range root)) (i : ι)
+    (h : σ (gen root i) = gen root i) : signPattern root σ i = 0 := by
+  simp [signPattern, h]
+
+omit [Finite ι] in
+/-- The sign is `1` where the automorphism negates the generator (a nonzero non-square root). -/
+theorem signPattern_eq_one [CharZero K] (hroot : ∀ i, root i ^ 2 = algebraMap K L (d i))
+    (hindep : ∀ S : Finset ι, S.Nonempty → ¬ IsSquare (∏ i ∈ S, d i))
+    (σ : adjoin K (Set.range root) ≃ₐ[K] adjoin K (Set.range root)) (i : ι)
+    (h : σ (gen root i) = -gen root i) : signPattern root σ i = 1 := by
+  have hne : gen (K := K) root i ≠ -gen root i := gen_ne_neg hroot hindep i
+  have hni : σ (gen root i) ≠ gen root i := fun hh => hne (h ▸ hh.symm)
+  simp [signPattern, hni]
+
+omit [Finite ι] in
+@[simp] theorem signPattern_one : signPattern (K := K) root (1 : adjoin K (Set.range root) ≃ₐ[K]
+    adjoin K (Set.range root)) = 0 := by
+  funext i; exact signPattern_eq_zero _ _ rfl
+
+omit [Finite ι] in
+/-- The sign pattern is additive: it is a group homomorphism to `ι → ℤ/2`. -/
+theorem signPattern_mul [CharZero K] (hroot : ∀ i, root i ^ 2 = algebraMap K L (d i))
+    (hindep : ∀ S : Finset ι, S.Nonempty → ¬ IsSquare (∏ i ∈ S, d i))
+    (σ τ : adjoin K (Set.range root) ≃ₐ[K] adjoin K (Set.range root)) :
+    signPattern root (σ * τ) = signPattern root σ + signPattern root τ := by
+  funext i
+  rw [Pi.add_apply]
+  rcases aut_gen_eq_or hroot τ i with hτ | hτ <;> rcases aut_gen_eq_or hroot σ i with hσ | hσ
+  · rw [signPattern_eq_zero _ _ (by rw [AlgEquiv.mul_apply, hτ, hσ]),
+      signPattern_eq_zero _ _ hσ, signPattern_eq_zero _ _ hτ]; decide
+  · rw [signPattern_eq_one hroot hindep _ _ (by rw [AlgEquiv.mul_apply, hτ, hσ]),
+      signPattern_eq_one hroot hindep _ _ hσ, signPattern_eq_zero _ _ hτ]; decide
+  · rw [signPattern_eq_one hroot hindep _ _ (by rw [AlgEquiv.mul_apply, hτ, map_neg, hσ]),
+      signPattern_eq_zero _ _ hσ, signPattern_eq_one hroot hindep _ _ hτ]; decide
+  · rw [signPattern_eq_zero _ _ (by rw [AlgEquiv.mul_apply, hτ, map_neg, hσ, neg_neg]),
+      signPattern_eq_one hroot hindep _ _ hσ, signPattern_eq_one hroot hindep _ _ hτ]; decide
+
+variable (root) in
+/-- The Galois group of `M / K` maps to the sign patterns `(ℤ/2)ⁱ`. -/
+noncomputable def signHom [CharZero K] (hroot : ∀ i, root i ^ 2 = algebraMap K L (d i))
+    (hindep : ∀ S : Finset ι, S.Nonempty → ¬ IsSquare (∏ i ∈ S, d i)) :
+    (adjoin K (Set.range root) ≃ₐ[K] adjoin K (Set.range root)) →* Multiplicative (ι → ZMod 2) where
+  toFun σ := Multiplicative.ofAdd (signPattern root σ)
+  map_one' := by simp
+  map_mul' σ τ := by simp [signPattern_mul hroot hindep, ofAdd_add]
+
+/-- **The Galois group of a multiquadratic field is `(ℤ/2)ⁿ`.** -/
+noncomputable def galoisGroupEquiv [CharZero K]
+    (hroot : ∀ i, root i ^ 2 = algebraMap K L (d i))
+    (hindep : ∀ S : Finset ι, S.Nonempty → ¬ IsSquare (∏ i ∈ S, d i)) :
+    (adjoin K (Set.range root) ≃ₐ[K] adjoin K (Set.range root)) ≃*
+      Multiplicative (ι → ZMod 2) := by
+  haveI := isSplittingField hroot
+  haveI : FiniteDimensional K (adjoin K (Set.range root)) :=
+    IsSplittingField.finiteDimensional _ (mqPoly d)
+  haveI := isGalois hroot
+  letI := Fintype.ofFinite ι
+  refine MulEquiv.ofBijective (signHom root hroot hindep) ?_
+  rw [Fintype.bijective_iff_injective_and_card]
+  refine ⟨signPattern_injective hroot, ?_⟩
+  rw [← Nat.card_eq_fintype_card (α := adjoin K (Set.range root) ≃ₐ[K] _),
+    IsGalois.card_aut_eq_finrank K (adjoin K (Set.range root)),
+    finrank_adjoin_range hroot hindep]
+  simp [ZMod.card]
+
+end TauCeti.Multiquadratic

--- a/TauCeti/NumberTheory/Multiquadratic/GaloisGroup.lean
+++ b/TauCeti/NumberTheory/Multiquadratic/GaloisGroup.lean
@@ -127,15 +127,9 @@ omit [Finite ι] in
 private theorem signed_pow_add_mul (x : adjoin K (Set.range root)) (a b : ZMod 2) :
     (-1 : adjoin K (Set.range root)) ^ b.val * ((-1) ^ a.val * x)
       = (-1) ^ (a + b).val * x := by
-  fin_cases a <;> fin_cases b
-  · change (-1 : adjoin K (Set.range root)) ^ 0 * ((-1) ^ 0 * x) = (-1) ^ 0 * x
-    simp
-  · change (-1 : adjoin K (Set.range root)) ^ 1 * ((-1) ^ 0 * x) = (-1) ^ 1 * x
-    simp
-  · change (-1 : adjoin K (Set.range root)) ^ 0 * ((-1) ^ 1 * x) = (-1) ^ 1 * x
-    simp
-  · change (-1 : adjoin K (Set.range root)) ^ 1 * ((-1) ^ 1 * x) = (-1) ^ 0 * x
-    simp
+  -- `(-1) ^ ·` is `2`-periodic, so it factors through `ZMod.val (a + b) = (a.val + b.val) % 2`.
+  rw [← mul_assoc, ← pow_add, ZMod.val_add, neg_one_pow_eq_pow_mod_two (b.val + a.val),
+    add_comm b.val a.val]
 
 omit [Finite ι] in
 private theorem aut_mul_gen_eq_signPattern_add
@@ -155,15 +149,11 @@ theorem signPattern_mul_apply (hroot : ∀ i, root i ^ 2 = algebraMap K L (d i))
   by_cases hne : gen (K := K) root i ≠ -gen root i
   · have hmul := aut_mul_gen_eq_signPattern_add hroot σ τ i
     generalize hsum : signPattern root σ i + signPattern root τ i = s
-    fin_cases s
+    rcases (show ∀ t : ZMod 2, t = 0 ∨ t = 1 by decide) s with rfl | rfl
     · refine signPattern_eq_zero _ _ ?_
-      rw [hmul, hsum]
-      change (-1 : adjoin K (Set.range root)) ^ 0 * gen root i = gen root i
-      simp
+      rw [hmul, hsum, ZMod.val_zero, pow_zero, one_mul]
     · refine signPattern_eq_one _ _ hne ?_
-      rw [hmul, hsum]
-      change (-1 : adjoin K (Set.range root)) ^ 1 * gen root i = -gen root i
-      simp
+      rw [hmul, hsum, ZMod.val_one, pow_one, neg_one_mul]
   · have hself : gen (K := K) root i = -gen root i := of_not_not hne
     have hsign : ∀ υ : adjoin K (Set.range root) ≃ₐ[K] adjoin K (Set.range root),
         signPattern root υ i = 0 := by

--- a/TauCeti/NumberTheory/Multiquadratic/GaloisGroup.lean
+++ b/TauCeti/NumberTheory/Multiquadratic/GaloisGroup.lean
@@ -125,6 +125,7 @@ omit [Finite ι] in
 
 omit [Finite ι] in
 /-- The sign pattern is additive: it is a group homomorphism to `ι → ℤ/2`. -/
+@[simp]
 theorem signPattern_mul (hroot : ∀ i, root i ^ 2 = algebraMap K L (d i))
     (σ τ : adjoin K (Set.range root) ≃ₐ[K] adjoin K (Set.range root)) :
     signPattern root (σ * τ) = signPattern root σ + signPattern root τ := by
@@ -172,6 +173,13 @@ omit [Finite ι] in
     (σ : adjoin K (Set.range root) ≃ₐ[K] adjoin K (Set.range root)) :
     signHom root hroot σ = Multiplicative.ofAdd (signPattern root σ) := rfl
 
+omit [Finite ι] in
+/-- The sign-pattern homomorphism is injective. -/
+theorem signHom_injective (hroot : ∀ i, root i ^ 2 = algebraMap K L (d i)) :
+    Function.Injective (signHom (K := K) root hroot) := by
+  intro σ τ h
+  exact signPattern_injective hroot (Multiplicative.ofAdd.injective (by simpa using h))
+
 /-- **For square-class independent radicands, the Galois group of a multiquadratic field is
 `(ℤ/2)ⁿ`.** -/
 noncomputable def galoisGroupEquiv [NeZero (2 : K)]
@@ -186,7 +194,7 @@ noncomputable def galoisGroupEquiv [NeZero (2 : K)]
   letI := Fintype.ofFinite ι
   refine MulEquiv.ofBijective (signHom root hroot) ?_
   rw [Fintype.bijective_iff_injective_and_card]
-  refine ⟨signPattern_injective hroot, ?_⟩
+  refine ⟨signHom_injective hroot, ?_⟩
   rw [← Nat.card_eq_fintype_card (α := adjoin K (Set.range root) ≃ₐ[K] _),
     IsGalois.card_aut_eq_finrank K (adjoin K (Set.range root)),
     finrank_adjoin_range hroot hindep]

--- a/TauCeti/NumberTheory/Multiquadratic/GaloisGroup.lean
+++ b/TauCeti/NumberTheory/Multiquadratic/GaloisGroup.lean
@@ -2,25 +2,27 @@
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 -/
-import Mathlib
+import Mathlib.Data.ZMod.Basic
+import Mathlib.FieldTheory.Galois.Basic
+import Mathlib.Tactic
 import TauCeti.NumberTheory.Multiquadratic.Degree
+import TauCeti.NumberTheory.Multiquadratic.Galois
 
 /-!
-# A multiquadratic field is Galois, with group `(ℤ/2)ⁿ`
+# The Galois group of a multiquadratic field is `(ℤ/2)ⁿ`
 
-Over a field `K` of characteristic zero, a multiquadratic field `M = K(rootᵢ : i)` (with
-`rootᵢ ^ 2 = dᵢ ∈ K`) is the splitting field of the polynomial `∏ᵢ (X² - dᵢ)`, hence Galois.
-Each automorphism sends every generator to `± rootᵢ`, so it is determined by a *sign pattern*
-`ι → ℤ/2`; this assignment is an injective group homomorphism. When the radicands are
-square-class independent the degree is `2ⁿ` (`TauCeti.NumberTheory.Multiquadratic.Degree`), so
-counting forces the homomorphism to be an isomorphism: `Gal(M/K) ≃ (ℤ/2)ⁿ`.
+Over a field `K` in which `2 ≠ 0`, a multiquadratic field `M = K(rootᵢ : i)` (with
+`rootᵢ ^ 2 = dᵢ ∈ K`) is Galois (`TauCeti.NumberTheory.Multiquadratic.Galois`). Each automorphism
+sends every generator to `± rootᵢ`, so it is determined by a *sign pattern* `ι → ℤ/2`; this
+assignment is an injective group homomorphism. When the radicands are square-class independent the
+degree is `2ⁿ` (`TauCeti.NumberTheory.Multiquadratic.Degree`), so counting forces the homomorphism
+to be an isomorphism: `Gal(M/K) ≃ (ℤ/2)ⁿ`.
 
 ## Main results
 
-* `TauCeti.Multiquadratic.isGalois`: `M / K` is Galois.
 * `TauCeti.Multiquadratic.signHom`: the injective sign-pattern homomorphism `Gal(M/K) →* (ℤ/2)ⁿ`.
-* `TauCeti.Multiquadratic.galoisGroupEquiv`: the explicit isomorphism
-  `Gal(M/K) ≃* Multiplicative (ι → ℤ/2)`.
+* `TauCeti.Multiquadratic.galoisGroupEquiv`: for square-class independent radicands, the explicit
+  isomorphism `Gal(M/K) ≃* Multiplicative (ι → ℤ/2)`.
 
 ## Provenance
 
@@ -40,105 +42,9 @@ namespace TauCeti.Multiquadratic
 variable {K L : Type*} [Field K] [Field L] [Algebra K L] {ι : Type*} [Finite ι]
   {d : ι → K} {root : ι → L}
 
-/-- The defining polynomial of the multiquadratic field: `∏ᵢ (X² - dᵢ)`. -/
-noncomputable def mqPoly (d : ι → K) : K[X] :=
-  letI := Fintype.ofFinite ι
-  ∏ i, (X ^ 2 - C (d i))
-
 omit [Finite ι] in
-/-- Each quadratic factor splits in `M`, with roots `± rootᵢ`. -/
-theorem splits_X_sq_sub_C (hroot : ∀ i, root i ^ 2 = algebraMap K L (d i)) (i : ι) :
-    ((X ^ 2 - C (d i)).map (algebraMap K (adjoin K (Set.range root)))).Splits := by
-  have hmem : root i ∈ adjoin K (Set.range root) := subset_adjoin _ _ ⟨i, rfl⟩
-  have hy2 : (⟨root i, hmem⟩ : adjoin K (Set.range root)) ^ 2
-      = algebraMap K (adjoin K (Set.range root)) (d i) := by
-    apply Subtype.ext
-    rw [IntermediateField.coe_pow, IntermediateField.coe_algebraMap_apply]
-    exact hroot i
-  have hfac : (X ^ 2 - C (d i)).map (algebraMap K (adjoin K (Set.range root)))
-      = (X - C ⟨root i, hmem⟩) * (X - C (-⟨root i, hmem⟩)) := by
-    rw [Polynomial.map_sub, Polynomial.map_pow, map_X, map_C, ← hy2, map_pow, map_neg]; ring
-  rw [hfac]
-  exact (Polynomial.Splits.X_sub_C _).mul (Polynomial.Splits.X_sub_C _)
-
-/-- The `i`-th generator, as an element of the multiquadratic field `M`. -/
-noncomputable def gen (root : ι → L) (i : ι) : adjoin K (Set.range root) :=
-  ⟨root i, subset_adjoin _ _ ⟨i, rfl⟩⟩
-
-omit [Finite ι] in
-@[simp] theorem coe_gen (i : ι) : (gen (K := K) root i : L) = root i := rfl
-
-omit [Finite ι] in
-/-- The generators generate `M` as its own top field. -/
-theorem adjoin_gen_eq_top :
-    IntermediateField.adjoin K (Set.range (gen (K := K) root)) = ⊤ := by
-  refine IntermediateField.map_injective (adjoin K (Set.range root)).val ?_
-  have hmaptop : (⊤ : IntermediateField K (adjoin K (Set.range root))).map
-      (adjoin K (Set.range root)).val = adjoin K (Set.range root) := by
-    ext x
-    simp only [IntermediateField.mem_map, IntermediateField.mem_top, true_and]
-    exact ⟨fun ⟨y, hy⟩ => hy ▸ y.2, fun hx => ⟨⟨x, hx⟩, rfl⟩⟩
-  rw [IntermediateField.adjoin_map, hmaptop]
-  congr 1
-  rw [← Set.range_comp]
-  rfl
-
-omit [Finite ι] in
-/-- The generator squares to its radicand (in `M`). -/
-theorem gen_sq (hroot : ∀ i, root i ^ 2 = algebraMap K L (d i)) (i : ι) :
-    gen (K := K) root i ^ 2 = algebraMap K (adjoin K (Set.range root)) (d i) := by
-  apply Subtype.ext
-  rw [IntermediateField.coe_pow, coe_gen, IntermediateField.coe_algebraMap_apply]
-  exact hroot i
-
-/-- `∏ᵢ (X² - dᵢ)` is nonzero. -/
-theorem mqPoly_ne_zero : mqPoly d ≠ 0 := by
-  rw [mqPoly, Finset.prod_ne_zero_iff]
-  exact fun i _ => Polynomial.X_pow_sub_C_ne_zero (by norm_num) (d i)
-
-/-- The defining polynomial splits over `M`. -/
-theorem splits_mqPoly (hroot : ∀ i, root i ^ 2 = algebraMap K L (d i)) :
-    ((mqPoly d).map (algebraMap K (adjoin K (Set.range root)))).Splits := by
-  rw [mqPoly, Polynomial.map_prod]
-  exact Polynomial.Splits.prod fun i _ => splits_X_sq_sub_C hroot i
-
-omit [Finite ι] in
-/-- Each generator is algebraic over `K` (it satisfies `X² - dᵢ`). -/
-theorem isAlgebraic_gen (hroot : ∀ i, root i ^ 2 = algebraMap K L (d i)) (i : ι) :
-    IsAlgebraic K (gen (K := K) root i) :=
-  ⟨X ^ 2 - C (d i), X_pow_sub_C_ne_zero (by norm_num) _, by
-    rw [map_sub, map_pow, aeval_X, aeval_C, gen_sq hroot i, sub_self]⟩
-
-/-- `M = K(rootᵢ : i)` is the splitting field of `∏ᵢ (X² - dᵢ)` over `K`. -/
-theorem isSplittingField (hroot : ∀ i, root i ^ 2 = algebraMap K L (d i)) :
-    (mqPoly d).IsSplittingField K (adjoin K (Set.range root)) where
-  splits' := splits_mqPoly hroot
-  adjoin_rootSet' := by
-    letI := Fintype.ofFinite ι
-    have hsub : Set.range (gen (K := K) root) ⊆
-        (mqPoly d).rootSet (adjoin K (Set.range root)) := by
-      rintro _ ⟨i, rfl⟩
-      rw [Polynomial.mem_rootSet]
-      refine ⟨mqPoly_ne_zero, ?_⟩
-      rw [mqPoly, map_prod]
-      exact Finset.prod_eq_zero (Finset.mem_univ i)
-        (by rw [map_sub, map_pow, aeval_X, aeval_C, gen_sq hroot i, sub_self])
-    have halg : ∀ x ∈ Set.range (gen (K := K) root), IsAlgebraic K x := by
-      rintro _ ⟨i, rfl⟩; exact isAlgebraic_gen hroot i
-    refine le_antisymm le_top ?_
-    rw [← Algebra.adjoin_eq_top_of_intermediateField halg (adjoin_gen_eq_top (root := root))]
-    exact Algebra.adjoin_mono hsub
-
-/-- A multiquadratic field over a field of characteristic zero is Galois. -/
-theorem isGalois [CharZero K] (hroot : ∀ i, root i ^ 2 = algebraMap K L (d i)) :
-    IsGalois K (adjoin K (Set.range root)) := by
-  haveI := isSplittingField hroot
-  haveI : Normal K (adjoin K (Set.range root)) := Normal.of_isSplittingField (mqPoly d)
-  constructor
-
-omit [Finite ι] in
-/-- Every automorphism sends a generator to `± itself`. -/
-theorem aut_gen_eq_or (hroot : ∀ i, root i ^ 2 = algebraMap K L (d i))
+/-- Every automorphism sends a generator to itself or to its negation. -/
+theorem aut_gen_eq_self_or_eq_neg (hroot : ∀ i, root i ^ 2 = algebraMap K L (d i))
     (σ : adjoin K (Set.range root) ≃ₐ[K] adjoin K (Set.range root)) (i : ι) :
     σ (gen root i) = gen root i ∨ σ (gen root i) = -gen root i := by
   have h1 : (σ (gen root i)) ^ 2 = (gen root i) ^ 2 := by
@@ -159,9 +65,11 @@ theorem aut_gen_eq_signPattern (hroot : ∀ i, root i ^ 2 = algebraMap K L (d i)
   rw [signPattern]
   split_ifs with h
   · simp [h]
-  · rcases aut_gen_eq_or hroot σ i with h' | h'
+  · rcases aut_gen_eq_self_or_eq_neg hroot σ i with h' | h'
     · exact absurd h' h
-    · simp [h', show ((1 : ZMod 2).val) = 1 from rfl]
+    · -- here the sign is `1`; `(1 : ZMod 2).val = 1`, so `(-1) ^ 1 = -1` negates the generator.
+      have hval : (1 : ZMod 2).val = 1 := rfl
+      simp [h', hval]
 
 omit [Finite ι] in
 /-- Two automorphisms with the same sign pattern are equal. -/
@@ -178,14 +86,14 @@ theorem signPattern_injective (hroot : ∀ i, root i ^ 2 = algebraMap K L (d i))
 
 omit [Finite ι] in
 /-- A generator is not equal to its own negation (the radicand is a nonzero non-square). -/
-theorem gen_ne_neg [CharZero K] (hroot : ∀ i, root i ^ 2 = algebraMap K L (d i))
+theorem gen_ne_neg [NeZero (2 : K)] (hroot : ∀ i, root i ^ 2 = algebraMap K L (d i))
     (hindep : ∀ S : Finset ι, S.Nonempty → ¬ IsSquare (∏ i ∈ S, d i)) (i : ι) :
     gen (K := K) root i ≠ -gen root i := by
   intro h
   have hcoe : root i = -root i := by simpa using congrArg Subtype.val h
   have h2L : (2 : L) ≠ 0 := by
     rw [← map_ofNat (algebraMap K L) 2]
-    exact (map_ne_zero_iff _ (FaithfulSMul.algebraMap_injective K L)).mpr (by norm_num)
+    exact (map_ne_zero_iff _ (FaithfulSMul.algebraMap_injective K L)).mpr two_ne_zero
   have hr0 : root i = 0 := by
     have h2 : (2 : L) * root i = 0 := by rw [two_mul]; nth_rewrite 1 [hcoe]; rw [neg_add_cancel]
     exact (mul_eq_zero.mp h2).resolve_left h2L
@@ -204,12 +112,11 @@ theorem signPattern_eq_zero
   simp [signPattern, h]
 
 omit [Finite ι] in
-/-- The sign is `1` where the automorphism negates the generator (a nonzero non-square root). -/
-theorem signPattern_eq_one [CharZero K] (hroot : ∀ i, root i ^ 2 = algebraMap K L (d i))
-    (hindep : ∀ S : Finset ι, S.Nonempty → ¬ IsSquare (∏ i ∈ S, d i))
+/-- The sign is `1` where the automorphism negates a generator that differs from its negation. -/
+theorem signPattern_eq_one
     (σ : adjoin K (Set.range root) ≃ₐ[K] adjoin K (Set.range root)) (i : ι)
+    (hne : gen (K := K) root i ≠ -gen root i)
     (h : σ (gen root i) = -gen root i) : signPattern root σ i = 1 := by
-  have hne : gen (K := K) root i ≠ -gen root i := gen_ne_neg hroot hindep i
   have hni : σ (gen root i) ≠ gen root i := fun hh => hne (h ▸ hh.symm)
   simp [signPattern, hni]
 
@@ -220,48 +127,71 @@ omit [Finite ι] in
 
 omit [Finite ι] in
 /-- The sign pattern is additive: it is a group homomorphism to `ι → ℤ/2`. -/
-theorem signPattern_mul [CharZero K] (hroot : ∀ i, root i ^ 2 = algebraMap K L (d i))
-    (hindep : ∀ S : Finset ι, S.Nonempty → ¬ IsSquare (∏ i ∈ S, d i))
+theorem signPattern_mul (hroot : ∀ i, root i ^ 2 = algebraMap K L (d i))
+    (hne : ∀ i, gen (K := K) root i ≠ -gen root i)
     (σ τ : adjoin K (Set.range root) ≃ₐ[K] adjoin K (Set.range root)) :
     signPattern root (σ * τ) = signPattern root σ + signPattern root τ := by
   funext i
   rw [Pi.add_apply]
-  rcases aut_gen_eq_or hroot τ i with hτ | hτ <;> rcases aut_gen_eq_or hroot σ i with hσ | hσ
+  rcases aut_gen_eq_self_or_eq_neg hroot τ i with hτ | hτ <;>
+    rcases aut_gen_eq_self_or_eq_neg hroot σ i with hσ | hσ
   · rw [signPattern_eq_zero _ _ (by rw [AlgEquiv.mul_apply, hτ, hσ]),
       signPattern_eq_zero _ _ hσ, signPattern_eq_zero _ _ hτ]; decide
-  · rw [signPattern_eq_one hroot hindep _ _ (by rw [AlgEquiv.mul_apply, hτ, hσ]),
-      signPattern_eq_one hroot hindep _ _ hσ, signPattern_eq_zero _ _ hτ]; decide
-  · rw [signPattern_eq_one hroot hindep _ _ (by rw [AlgEquiv.mul_apply, hτ, map_neg, hσ]),
-      signPattern_eq_zero _ _ hσ, signPattern_eq_one hroot hindep _ _ hτ]; decide
+  · rw [signPattern_eq_one _ _ (hne i) (by rw [AlgEquiv.mul_apply, hτ, hσ]),
+      signPattern_eq_one _ _ (hne i) hσ, signPattern_eq_zero _ _ hτ]; decide
+  · rw [signPattern_eq_one _ _ (hne i) (by rw [AlgEquiv.mul_apply, hτ, map_neg, hσ]),
+      signPattern_eq_zero _ _ hσ, signPattern_eq_one _ _ (hne i) hτ]; decide
   · rw [signPattern_eq_zero _ _ (by rw [AlgEquiv.mul_apply, hτ, map_neg, hσ, neg_neg]),
-      signPattern_eq_one hroot hindep _ _ hσ, signPattern_eq_one hroot hindep _ _ hτ]; decide
+      signPattern_eq_one _ _ (hne i) hσ, signPattern_eq_one _ _ (hne i) hτ]; decide
 
 variable (root) in
 /-- The Galois group of `M / K` maps to the sign patterns `(ℤ/2)ⁱ`. -/
-noncomputable def signHom [CharZero K] (hroot : ∀ i, root i ^ 2 = algebraMap K L (d i))
-    (hindep : ∀ S : Finset ι, S.Nonempty → ¬ IsSquare (∏ i ∈ S, d i)) :
+noncomputable def signHom (hroot : ∀ i, root i ^ 2 = algebraMap K L (d i))
+    (hne : ∀ i, gen (K := K) root i ≠ -gen root i) :
     (adjoin K (Set.range root) ≃ₐ[K] adjoin K (Set.range root)) →* Multiplicative (ι → ZMod 2) where
   toFun σ := Multiplicative.ofAdd (signPattern root σ)
   map_one' := by simp
-  map_mul' σ τ := by simp [signPattern_mul hroot hindep, ofAdd_add]
+  map_mul' σ τ := by simp [signPattern_mul hroot hne, ofAdd_add]
 
-/-- **The Galois group of a multiquadratic field is `(ℤ/2)ⁿ`.** -/
-noncomputable def galoisGroupEquiv [CharZero K]
+/-- **For square-class independent radicands, the Galois group of a multiquadratic field is
+`(ℤ/2)ⁿ`.** -/
+noncomputable def galoisGroupEquiv [NeZero (2 : K)]
     (hroot : ∀ i, root i ^ 2 = algebraMap K L (d i))
     (hindep : ∀ S : Finset ι, S.Nonempty → ¬ IsSquare (∏ i ∈ S, d i)) :
     (adjoin K (Set.range root) ≃ₐ[K] adjoin K (Set.range root)) ≃*
       Multiplicative (ι → ZMod 2) := by
   haveI := isSplittingField hroot
   haveI : FiniteDimensional K (adjoin K (Set.range root)) :=
-    IsSplittingField.finiteDimensional _ (mqPoly d)
+    IsSplittingField.finiteDimensional _ (definingPolynomial d)
   haveI := isGalois hroot
   letI := Fintype.ofFinite ι
-  refine MulEquiv.ofBijective (signHom root hroot hindep) ?_
+  refine MulEquiv.ofBijective (signHom root hroot (fun i => gen_ne_neg hroot hindep i)) ?_
   rw [Fintype.bijective_iff_injective_and_card]
   refine ⟨signPattern_injective hroot, ?_⟩
   rw [← Nat.card_eq_fintype_card (α := adjoin K (Set.range root) ≃ₐ[K] _),
     IsGalois.card_aut_eq_finrank K (adjoin K (Set.range root)),
     finrank_adjoin_range hroot hindep]
   simp [ZMod.card]
+
+@[simp] theorem galoisGroupEquiv_apply [NeZero (2 : K)]
+    (hroot : ∀ i, root i ^ 2 = algebraMap K L (d i))
+    (hindep : ∀ S : Finset ι, S.Nonempty → ¬ IsSquare (∏ i ∈ S, d i))
+    (σ : adjoin K (Set.range root) ≃ₐ[K] adjoin K (Set.range root)) :
+    galoisGroupEquiv hroot hindep σ = Multiplicative.ofAdd (signPattern root σ) := rfl
+
+/-- The inverse of `galoisGroupEquiv` realizes a sign pattern `ε` as the automorphism sending each
+generator `rootᵢ` to `(-1)^(εᵢ) · rootᵢ`. -/
+theorem galoisGroupEquiv_symm_apply_gen [NeZero (2 : K)]
+    (hroot : ∀ i, root i ^ 2 = algebraMap K L (d i))
+    (hindep : ∀ S : Finset ι, S.Nonempty → ¬ IsSquare (∏ i ∈ S, d i))
+    (ε : ι → ZMod 2) (i : ι) :
+    ((galoisGroupEquiv hroot hindep).symm (Multiplicative.ofAdd ε)) (gen root i)
+      = (-1) ^ (ε i).val * gen root i := by
+  have hσ : signPattern root
+      ((galoisGroupEquiv hroot hindep).symm (Multiplicative.ofAdd ε)) = ε := by
+    have happ := (galoisGroupEquiv hroot hindep).apply_symm_apply (Multiplicative.ofAdd ε)
+    rw [galoisGroupEquiv_apply] at happ
+    exact Multiplicative.ofAdd.injective happ
+  rw [aut_gen_eq_signPattern hroot, hσ]
 
 end TauCeti.Multiquadratic

--- a/TauCeti/NumberTheory/Multiquadratic/GaloisGroup.lean
+++ b/TauCeti/NumberTheory/Multiquadratic/GaloisGroup.lean
@@ -85,9 +85,9 @@ theorem signPattern_injective (hroot : ∀ i, root i ^ 2 = algebraMap K L (d i))
   exact hgen
 
 omit [Finite ι] in
-/-- A generator is not equal to its own negation (the radicand is a nonzero non-square). -/
+/-- A generator is not equal to its own negation (the radicand is nonzero). -/
 theorem gen_ne_neg [NeZero (2 : K)] (hroot : ∀ i, root i ^ 2 = algebraMap K L (d i))
-    (hindep : ∀ S : Finset ι, S.Nonempty → ¬ IsSquare (∏ i ∈ S, d i)) (i : ι) :
+    (i : ι) (hd : d i ≠ 0) :
     gen (K := K) root i ≠ -gen root i := by
   intro h
   have hcoe : root i = -root i := by simpa using congrArg Subtype.val h
@@ -100,9 +100,7 @@ theorem gen_ne_neg [NeZero (2 : K)] (hroot : ∀ i, root i ^ 2 = algebraMap K L 
   have hd0 : d i = 0 := by
     have hh : algebraMap K L (d i) = 0 := by rw [← hroot i, hr0]; ring
     exact (map_eq_zero_iff _ (FaithfulSMul.algebraMap_injective K L)).mp hh
-  refine hindep {i} ⟨i, Finset.mem_singleton_self i⟩ ?_
-  rw [Finset.prod_singleton, hd0]
-  exact ⟨0, by ring⟩
+  exact hd hd0
 
 omit [Finite ι] in
 /-- The sign is `0` exactly where the automorphism fixes the generator. -/
@@ -165,7 +163,10 @@ noncomputable def galoisGroupEquiv [NeZero (2 : K)]
     IsSplittingField.finiteDimensional _ (definingPolynomial d)
   haveI := isGalois hroot
   letI := Fintype.ofFinite ι
-  refine MulEquiv.ofBijective (signHom root hroot (fun i => gen_ne_neg hroot hindep i)) ?_
+  have hd : ∀ i, d i ≠ 0 := fun i hd0 =>
+    hindep {i} ⟨i, Finset.mem_singleton_self i⟩
+      (by rw [Finset.prod_singleton, hd0]; exact ⟨0, by ring⟩)
+  refine MulEquiv.ofBijective (signHom root hroot (fun i => gen_ne_neg hroot i (hd i))) ?_
   rw [Fintype.bijective_iff_injective_and_card]
   refine ⟨signPattern_injective hroot, ?_⟩
   rw [← Nat.card_eq_fintype_card (α := adjoin K (Set.range root) ≃ₐ[K] _),

--- a/TauCeti/NumberTheory/Multiquadratic/GaloisGroup.lean
+++ b/TauCeti/NumberTheory/Multiquadratic/GaloisGroup.lean
@@ -100,6 +100,7 @@ theorem signPattern_eq_one
 
 omit [Finite ι] in
 /-- The sign is `1` iff the automorphism negates a generator that differs from its negation. -/
+@[simp]
 theorem signPattern_eq_one_iff (hroot : ∀ i, root i ^ 2 = algebraMap K L (d i))
     (σ : adjoin K (Set.range root) ≃ₐ[K] adjoin K (Set.range root)) (i : ι)
     (hne : gen (K := K) root i ≠ -gen root i) :

--- a/TauCeti/NumberTheory/Multiquadratic/GaloisGroup.lean
+++ b/TauCeti/NumberTheory/Multiquadratic/GaloisGroup.lean
@@ -41,15 +41,6 @@ namespace TauCeti.Multiquadratic
 variable {K L : Type*} [Field K] [Field L] [Algebra K L] {ι : Type*} [Finite ι]
   {d : ι → K} {root : ι → L}
 
-omit [Finite ι] in
-/-- Every automorphism sends a generator to itself or to its negation. -/
-theorem aut_gen_eq_self_or_eq_neg (hroot : ∀ i, root i ^ 2 = algebraMap K L (d i))
-    (σ : adjoin K (Set.range root) ≃ₐ[K] adjoin K (Set.range root)) (i : ι) :
-    σ (gen root i) = gen root i ∨ σ (gen root i) = -gen root i := by
-  have h1 : (σ (gen root i)) ^ 2 = (gen root i) ^ 2 := by
-    rw [← map_pow, gen_sq hroot, AlgEquiv.commutes, ← gen_sq hroot]
-  exact sq_eq_sq_iff_eq_or_eq_neg.mp h1
-
 variable (root) in
 /-- The sign pattern of an automorphism: `0` where it fixes a generator, `1` where it negates. -/
 noncomputable def signPattern
@@ -84,29 +75,19 @@ theorem signPattern_injective (hroot : ∀ i, root i ^ 2 = algebraMap K L (d i))
   exact hgen
 
 omit [Finite ι] in
-/-- A generator is not equal to its own negation (the radicand is nonzero). -/
-theorem gen_ne_neg [NeZero (2 : K)] (hroot : ∀ i, root i ^ 2 = algebraMap K L (d i))
-    (i : ι) (hd : d i ≠ 0) :
-    gen (K := K) root i ≠ -gen root i := by
-  intro h
-  have hcoe : root i = -root i := by simpa using congrArg Subtype.val h
-  have h2L : (2 : L) ≠ 0 := by
-    rw [← map_ofNat (algebraMap K L) 2]
-    exact (map_ne_zero_iff _ (FaithfulSMul.algebraMap_injective K L)).mpr two_ne_zero
-  have hr0 : root i = 0 := by
-    have h2 : (2 : L) * root i = 0 := by rw [two_mul]; nth_rewrite 1 [hcoe]; rw [neg_add_cancel]
-    exact (mul_eq_zero.mp h2).resolve_left h2L
-  have hd0 : d i = 0 := by
-    have hh : algebraMap K L (d i) = 0 := by rw [← hroot i, hr0]; ring
-    exact (map_eq_zero_iff _ (FaithfulSMul.algebraMap_injective K L)).mp hh
-  exact hd hd0
-
-omit [Finite ι] in
 /-- The sign is `0` exactly where the automorphism fixes the generator. -/
 theorem signPattern_eq_zero
     (σ : adjoin K (Set.range root) ≃ₐ[K] adjoin K (Set.range root)) (i : ι)
     (h : σ (gen root i) = gen root i) : signPattern root σ i = 0 := by
   simp [signPattern, h]
+
+omit [Finite ι] in
+/-- The sign is `0` iff the automorphism fixes the generator. -/
+@[simp] theorem signPattern_eq_zero_iff
+    (σ : adjoin K (Set.range root) ≃ₐ[K] adjoin K (Set.range root)) (i : ι) :
+    signPattern root σ i = 0 ↔ σ (gen root i) = gen root i := by
+  rw [signPattern]
+  by_cases h : σ (gen root i) = gen root i <;> simp [h]
 
 omit [Finite ι] in
 /-- The sign is `1` where the automorphism negates a generator that differs from its negation. -/
@@ -116,6 +97,22 @@ theorem signPattern_eq_one
     (h : σ (gen root i) = -gen root i) : signPattern root σ i = 1 := by
   have hni : σ (gen root i) ≠ gen root i := fun hh => hne (h ▸ hh.symm)
   simp [signPattern, hni]
+
+omit [Finite ι] in
+/-- The sign is `1` iff the automorphism negates a generator that differs from its negation. -/
+theorem signPattern_eq_one_iff (hroot : ∀ i, root i ^ 2 = algebraMap K L (d i))
+    (σ : adjoin K (Set.range root) ≃ₐ[K] adjoin K (Set.range root)) (i : ι)
+    (hne : gen (K := K) root i ≠ -gen root i) :
+    signPattern root σ i = 1 ↔ σ (gen root i) = -gen root i := by
+  constructor
+  · intro hsign
+    rw [signPattern] at hsign
+    split_ifs at hsign with hfix
+    · exact (zero_ne_one hsign).elim
+    · rcases aut_gen_eq_self_or_eq_neg hroot σ i with h | h
+      · exact (hfix h).elim
+      · exact h
+  · exact signPattern_eq_one σ i hne
 
 omit [Finite ι] in
 /-- The identity automorphism has the zero sign pattern. -/
@@ -130,6 +127,11 @@ private theorem signed_pow_add_mul (x : adjoin K (Set.range root)) (a b : ZMod 2
   -- `(-1) ^ ·` is `2`-periodic, so it factors through `ZMod.val (a + b) = (a.val + b.val) % 2`.
   rw [← mul_assoc, ← pow_add, ZMod.val_add, neg_one_pow_eq_pow_mod_two (b.val + a.val),
     add_comm b.val a.val]
+
+private theorem zmod_two_eq_zero_or_one (t : ZMod 2) : t = 0 ∨ t = 1 := by
+  fin_cases t
+  · exact Or.inl rfl
+  · exact Or.inr rfl
 
 omit [Finite ι] in
 private theorem aut_mul_gen_eq_signPattern_add
@@ -149,7 +151,7 @@ theorem signPattern_mul_apply (hroot : ∀ i, root i ^ 2 = algebraMap K L (d i))
   by_cases hne : gen (K := K) root i ≠ -gen root i
   · have hmul := aut_mul_gen_eq_signPattern_add hroot σ τ i
     generalize hsum : signPattern root σ i + signPattern root τ i = s
-    rcases (show ∀ t : ZMod 2, t = 0 ∨ t = 1 by decide) s with rfl | rfl
+    rcases zmod_two_eq_zero_or_one s with rfl | rfl
     · refine signPattern_eq_zero _ _ ?_
       rw [hmul, hsum, ZMod.val_zero, pow_zero, one_mul]
     · refine signPattern_eq_one _ _ hne ?_

--- a/TauCeti/NumberTheory/Multiquadratic/GaloisGroup.lean
+++ b/TauCeti/NumberTheory/Multiquadratic/GaloisGroup.lean
@@ -124,21 +124,46 @@ omit [Finite ι] in
   funext i; exact signPattern_eq_zero _ _ rfl
 
 omit [Finite ι] in
+private theorem signed_pow_add_mul (x : adjoin K (Set.range root)) (a b : ZMod 2) :
+    (-1 : adjoin K (Set.range root)) ^ b.val * ((-1) ^ a.val * x)
+      = (-1) ^ (a + b).val * x := by
+  fin_cases a <;> fin_cases b
+  · change (-1 : adjoin K (Set.range root)) ^ 0 * ((-1) ^ 0 * x) = (-1) ^ 0 * x
+    simp
+  · change (-1 : adjoin K (Set.range root)) ^ 1 * ((-1) ^ 0 * x) = (-1) ^ 1 * x
+    simp
+  · change (-1 : adjoin K (Set.range root)) ^ 0 * ((-1) ^ 1 * x) = (-1) ^ 1 * x
+    simp
+  · change (-1 : adjoin K (Set.range root)) ^ 1 * ((-1) ^ 1 * x) = (-1) ^ 0 * x
+    simp
+
+omit [Finite ι] in
+private theorem aut_mul_gen_eq_signPattern_add
+    (hroot : ∀ i, root i ^ 2 = algebraMap K L (d i))
+    (σ τ : adjoin K (Set.range root) ≃ₐ[K] adjoin K (Set.range root)) (i : ι) :
+    (σ * τ) (gen root i)
+      = (-1) ^ (signPattern root σ i + signPattern root τ i).val * gen root i := by
+  rw [AlgEquiv.mul_apply, aut_gen_eq_signPattern hroot τ i, map_mul, map_pow, map_neg,
+    map_one, aut_gen_eq_signPattern hroot σ i]
+  exact signed_pow_add_mul (gen root i) (signPattern root σ i) (signPattern root τ i)
+
+omit [Finite ι] in
 /-- Pointwise composition rule for sign patterns. -/
 theorem signPattern_mul_apply (hroot : ∀ i, root i ^ 2 = algebraMap K L (d i))
     (σ τ : adjoin K (Set.range root) ≃ₐ[K] adjoin K (Set.range root)) (i : ι) :
     signPattern root (σ * τ) i = signPattern root σ i + signPattern root τ i := by
   by_cases hne : gen (K := K) root i ≠ -gen root i
-  · rcases aut_gen_eq_self_or_eq_neg hroot τ i with hτ | hτ <;>
-      rcases aut_gen_eq_self_or_eq_neg hroot σ i with hσ | hσ
-    · rw [signPattern_eq_zero _ _ (by rw [AlgEquiv.mul_apply, hτ, hσ]),
-        signPattern_eq_zero _ _ hσ, signPattern_eq_zero _ _ hτ]; decide
-    · rw [signPattern_eq_one _ _ hne (by rw [AlgEquiv.mul_apply, hτ, hσ]),
-        signPattern_eq_one _ _ hne hσ, signPattern_eq_zero _ _ hτ]; decide
-    · rw [signPattern_eq_one _ _ hne (by rw [AlgEquiv.mul_apply, hτ, map_neg, hσ]),
-        signPattern_eq_zero _ _ hσ, signPattern_eq_one _ _ hne hτ]; decide
-    · rw [signPattern_eq_zero _ _ (by rw [AlgEquiv.mul_apply, hτ, map_neg, hσ, neg_neg]),
-        signPattern_eq_one _ _ hne hσ, signPattern_eq_one _ _ hne hτ]; decide
+  · have hmul := aut_mul_gen_eq_signPattern_add hroot σ τ i
+    generalize hsum : signPattern root σ i + signPattern root τ i = s
+    fin_cases s
+    · refine signPattern_eq_zero _ _ ?_
+      rw [hmul, hsum]
+      change (-1 : adjoin K (Set.range root)) ^ 0 * gen root i = gen root i
+      simp
+    · refine signPattern_eq_one _ _ hne ?_
+      rw [hmul, hsum]
+      change (-1 : adjoin K (Set.range root)) ^ 1 * gen root i = -gen root i
+      simp
   · have hself : gen (K := K) root i = -gen root i := of_not_not hne
     have hsign : ∀ υ : adjoin K (Set.range root) ≃ₐ[K] adjoin K (Set.range root),
         signPattern root υ i = 0 := by

--- a/TauCeti/NumberTheory/Multiquadratic/GaloisGroup.lean
+++ b/TauCeti/NumberTheory/Multiquadratic/GaloisGroup.lean
@@ -124,13 +124,10 @@ omit [Finite ι] in
   funext i; exact signPattern_eq_zero _ _ rfl
 
 omit [Finite ι] in
-/-- The sign pattern is additive: it is a group homomorphism to `ι → ℤ/2`. -/
-@[simp]
-theorem signPattern_mul (hroot : ∀ i, root i ^ 2 = algebraMap K L (d i))
-    (σ τ : adjoin K (Set.range root) ≃ₐ[K] adjoin K (Set.range root)) :
-    signPattern root (σ * τ) = signPattern root σ + signPattern root τ := by
-  funext i
-  rw [Pi.add_apply]
+/-- Pointwise composition rule for sign patterns. -/
+theorem signPattern_mul_apply (hroot : ∀ i, root i ^ 2 = algebraMap K L (d i))
+    (σ τ : adjoin K (Set.range root) ≃ₐ[K] adjoin K (Set.range root)) (i : ι) :
+    signPattern root (σ * τ) i = signPattern root σ i + signPattern root τ i := by
   by_cases hne : gen (K := K) root i ≠ -gen root i
   · rcases aut_gen_eq_self_or_eq_neg hroot τ i with hτ | hτ <;>
       rcases aut_gen_eq_self_or_eq_neg hroot σ i with hσ | hσ
@@ -142,21 +139,24 @@ theorem signPattern_mul (hroot : ∀ i, root i ^ 2 = algebraMap K L (d i))
         signPattern_eq_zero _ _ hσ, signPattern_eq_one _ _ hne hτ]; decide
     · rw [signPattern_eq_zero _ _ (by rw [AlgEquiv.mul_apply, hτ, map_neg, hσ, neg_neg]),
         signPattern_eq_one _ _ hne hσ, signPattern_eq_one _ _ hne hτ]; decide
-  · have hne : gen (K := K) root i = -gen root i := of_not_not hne
-    have hσ : signPattern root σ i = 0 := by
-      rcases aut_gen_eq_self_or_eq_neg hroot σ i with h | h
+  · have hself : gen (K := K) root i = -gen root i := of_not_not hne
+    have hsign : ∀ υ : adjoin K (Set.range root) ≃ₐ[K] adjoin K (Set.range root),
+        signPattern root υ i = 0 := by
+      intro υ
+      rcases aut_gen_eq_self_or_eq_neg hroot υ i with h | h
       · exact signPattern_eq_zero _ _ h
-      · exact signPattern_eq_zero _ _ (h.trans hne.symm)
-    have hτ : signPattern root τ i = 0 := by
-      rcases aut_gen_eq_self_or_eq_neg hroot τ i with h | h
-      · exact signPattern_eq_zero _ _ h
-      · exact signPattern_eq_zero _ _ (h.trans hne.symm)
-    have hστ : signPattern root (σ * τ) i = 0 := by
-      rcases aut_gen_eq_self_or_eq_neg hroot (σ * τ) i with h | h
-      · exact signPattern_eq_zero _ _ h
-      · exact signPattern_eq_zero _ _ (h.trans hne.symm)
-    rw [hστ, hσ, hτ]
+      · exact signPattern_eq_zero _ _ (h.trans hself.symm)
+    rw [hsign (σ * τ), hsign σ, hsign τ]
     decide
+
+omit [Finite ι] in
+/-- The sign pattern is additive: it is a group homomorphism to `ι → ℤ/2`. -/
+@[simp]
+theorem signPattern_mul (hroot : ∀ i, root i ^ 2 = algebraMap K L (d i))
+    (σ τ : adjoin K (Set.range root) ≃ₐ[K] adjoin K (Set.range root)) :
+    signPattern root (σ * τ) = signPattern root σ + signPattern root τ := by
+  funext i
+  exact signPattern_mul_apply hroot σ τ i
 
 variable (root) in
 /-- The Galois group of `M / K` maps to the sign patterns `(ℤ/2)ⁱ`. -/
@@ -180,19 +180,15 @@ theorem signHom_injective (hroot : ∀ i, root i ^ 2 = algebraMap K L (d i)) :
   intro σ τ h
   exact signPattern_injective hroot (Multiplicative.ofAdd.injective (by simpa using h))
 
-/-- **For square-class independent radicands, the Galois group of a multiquadratic field is
-`(ℤ/2)ⁿ`.** -/
-noncomputable def galoisGroupEquiv [NeZero (2 : K)]
+private theorem signHom_bijective [NeZero (2 : K)]
     (hroot : ∀ i, root i ^ 2 = algebraMap K L (d i))
     (hindep : ∀ S : Finset ι, S.Nonempty → ¬ IsSquare (∏ i ∈ S, d i)) :
-    (adjoin K (Set.range root) ≃ₐ[K] adjoin K (Set.range root)) ≃*
-      Multiplicative (ι → ZMod 2) := by
+    Function.Bijective (signHom (K := K) root hroot) := by
   haveI := isSplittingField hroot
   haveI : FiniteDimensional K (adjoin K (Set.range root)) :=
     IsSplittingField.finiteDimensional _ (definingPolynomial d)
   haveI := isGalois hroot
   letI := Fintype.ofFinite ι
-  refine MulEquiv.ofBijective (signHom root hroot) ?_
   rw [Fintype.bijective_iff_injective_and_card]
   refine ⟨signHom_injective hroot, ?_⟩
   rw [← Nat.card_eq_fintype_card (α := adjoin K (Set.range root) ≃ₐ[K] _),
@@ -200,14 +196,22 @@ noncomputable def galoisGroupEquiv [NeZero (2 : K)]
     finrank_adjoin_range hroot hindep]
   simp [ZMod.card]
 
+/-- **For square-class independent radicands, the Galois group of a multiquadratic field is
+`(ℤ/2)ⁿ`.** -/
+noncomputable def galoisGroupEquiv [NeZero (2 : K)]
+    (hroot : ∀ i, root i ^ 2 = algebraMap K L (d i))
+    (hindep : ∀ S : Finset ι, S.Nonempty → ¬ IsSquare (∏ i ∈ S, d i)) :
+    (adjoin K (Set.range root) ≃ₐ[K] adjoin K (Set.range root)) ≃*
+      Multiplicative (ι → ZMod 2) := by
+  exact MulEquiv.ofBijective (signHom root hroot) (signHom_bijective hroot hindep)
+
 /-- The Galois-group equivalence sends an automorphism to its multiplicative sign pattern. -/
 @[simp] theorem galoisGroupEquiv_apply [NeZero (2 : K)]
     (hroot : ∀ i, root i ^ 2 = algebraMap K L (d i))
     (hindep : ∀ S : Finset ι, S.Nonempty → ¬ IsSquare (∏ i ∈ S, d i))
     (σ : adjoin K (Set.range root) ≃ₐ[K] adjoin K (Set.range root)) :
     galoisGroupEquiv hroot hindep σ = Multiplicative.ofAdd (signPattern root σ) := by
-  rw [galoisGroupEquiv]
-  rfl
+  rw [galoisGroupEquiv, MulEquiv.ofBijective_apply, signHom_apply]
 
 /-- The inverse of `galoisGroupEquiv` realizes a sign pattern `ε` as the automorphism sending each
 generator `rootᵢ` to `(-1)^(εᵢ) · rootᵢ`. -/

--- a/TauCeti/NumberTheory/Multiquadratic/GaloisGroup.lean
+++ b/TauCeti/NumberTheory/Multiquadratic/GaloisGroup.lean
@@ -4,7 +4,6 @@ Released under Apache 2.0 license as described in the file LICENSE.
 -/
 import Mathlib.Data.ZMod.Basic
 import Mathlib.FieldTheory.Galois.Basic
-import Mathlib.Tactic
 import TauCeti.NumberTheory.Multiquadratic.Degree
 import TauCeti.NumberTheory.Multiquadratic.Galois
 
@@ -150,6 +149,12 @@ noncomputable def signHom (hroot : ∀ i, root i ^ 2 = algebraMap K L (d i))
   toFun σ := Multiplicative.ofAdd (signPattern root σ)
   map_one' := by simp
   map_mul' σ τ := by simp [signPattern_mul hroot hne, ofAdd_add]
+
+omit [Finite ι] in
+@[simp] theorem signHom_apply (hroot : ∀ i, root i ^ 2 = algebraMap K L (d i))
+    (hne : ∀ i, gen (K := K) root i ≠ -gen root i)
+    (σ : adjoin K (Set.range root) ≃ₐ[K] adjoin K (Set.range root)) :
+    signHom root hroot hne σ = Multiplicative.ofAdd (signPattern root σ) := rfl
 
 /-- **For square-class independent radicands, the Galois group of a multiquadratic field is
 `(ℤ/2)ⁿ`.** -/

--- a/TauCeti/NumberTheory/Multiquadratic/GaloisGroup.lean
+++ b/TauCeti/NumberTheory/Multiquadratic/GaloisGroup.lean
@@ -42,7 +42,8 @@ variable {K L : Type*} [Field K] [Field L] [Algebra K L] {ι : Type*} [Finite ι
   {d : ι → K} {root : ι → L}
 
 variable (root) in
-/-- The sign pattern of an automorphism: `0` where it fixes a generator, `1` where it negates. -/
+/-- The sign pattern of an automorphism: `0` where it fixes a generator and `1` otherwise.
+When `gen root i ≠ -gen root i`, the `1` case says that the automorphism negates the generator. -/
 noncomputable def signPattern
     (σ : adjoin K (Set.range root) ≃ₐ[K] adjoin K (Set.range root)) (i : ι) : ZMod 2 :=
   if σ (gen root i) = gen root i then 0 else 1

--- a/TauCeti/NumberTheory/Multiquadratic/GaloisGroup.lean
+++ b/TauCeti/NumberTheory/Multiquadratic/GaloisGroup.lean
@@ -118,6 +118,7 @@ theorem signPattern_eq_one
   simp [signPattern, hni]
 
 omit [Finite ι] in
+/-- The identity automorphism has the zero sign pattern. -/
 @[simp] theorem signPattern_one : signPattern (K := K) root (1 : adjoin K (Set.range root) ≃ₐ[K]
     adjoin K (Set.range root)) = 0 := by
   funext i; exact signPattern_eq_zero _ _ rfl
@@ -125,36 +126,51 @@ omit [Finite ι] in
 omit [Finite ι] in
 /-- The sign pattern is additive: it is a group homomorphism to `ι → ℤ/2`. -/
 theorem signPattern_mul (hroot : ∀ i, root i ^ 2 = algebraMap K L (d i))
-    (hne : ∀ i, gen (K := K) root i ≠ -gen root i)
     (σ τ : adjoin K (Set.range root) ≃ₐ[K] adjoin K (Set.range root)) :
     signPattern root (σ * τ) = signPattern root σ + signPattern root τ := by
   funext i
   rw [Pi.add_apply]
-  rcases aut_gen_eq_self_or_eq_neg hroot τ i with hτ | hτ <;>
-    rcases aut_gen_eq_self_or_eq_neg hroot σ i with hσ | hσ
-  · rw [signPattern_eq_zero _ _ (by rw [AlgEquiv.mul_apply, hτ, hσ]),
-      signPattern_eq_zero _ _ hσ, signPattern_eq_zero _ _ hτ]; decide
-  · rw [signPattern_eq_one _ _ (hne i) (by rw [AlgEquiv.mul_apply, hτ, hσ]),
-      signPattern_eq_one _ _ (hne i) hσ, signPattern_eq_zero _ _ hτ]; decide
-  · rw [signPattern_eq_one _ _ (hne i) (by rw [AlgEquiv.mul_apply, hτ, map_neg, hσ]),
-      signPattern_eq_zero _ _ hσ, signPattern_eq_one _ _ (hne i) hτ]; decide
-  · rw [signPattern_eq_zero _ _ (by rw [AlgEquiv.mul_apply, hτ, map_neg, hσ, neg_neg]),
-      signPattern_eq_one _ _ (hne i) hσ, signPattern_eq_one _ _ (hne i) hτ]; decide
+  by_cases hne : gen (K := K) root i ≠ -gen root i
+  · rcases aut_gen_eq_self_or_eq_neg hroot τ i with hτ | hτ <;>
+      rcases aut_gen_eq_self_or_eq_neg hroot σ i with hσ | hσ
+    · rw [signPattern_eq_zero _ _ (by rw [AlgEquiv.mul_apply, hτ, hσ]),
+        signPattern_eq_zero _ _ hσ, signPattern_eq_zero _ _ hτ]; decide
+    · rw [signPattern_eq_one _ _ hne (by rw [AlgEquiv.mul_apply, hτ, hσ]),
+        signPattern_eq_one _ _ hne hσ, signPattern_eq_zero _ _ hτ]; decide
+    · rw [signPattern_eq_one _ _ hne (by rw [AlgEquiv.mul_apply, hτ, map_neg, hσ]),
+        signPattern_eq_zero _ _ hσ, signPattern_eq_one _ _ hne hτ]; decide
+    · rw [signPattern_eq_zero _ _ (by rw [AlgEquiv.mul_apply, hτ, map_neg, hσ, neg_neg]),
+        signPattern_eq_one _ _ hne hσ, signPattern_eq_one _ _ hne hτ]; decide
+  · have hne : gen (K := K) root i = -gen root i := of_not_not hne
+    have hσ : signPattern root σ i = 0 := by
+      rcases aut_gen_eq_self_or_eq_neg hroot σ i with h | h
+      · exact signPattern_eq_zero _ _ h
+      · exact signPattern_eq_zero _ _ (h.trans hne.symm)
+    have hτ : signPattern root τ i = 0 := by
+      rcases aut_gen_eq_self_or_eq_neg hroot τ i with h | h
+      · exact signPattern_eq_zero _ _ h
+      · exact signPattern_eq_zero _ _ (h.trans hne.symm)
+    have hστ : signPattern root (σ * τ) i = 0 := by
+      rcases aut_gen_eq_self_or_eq_neg hroot (σ * τ) i with h | h
+      · exact signPattern_eq_zero _ _ h
+      · exact signPattern_eq_zero _ _ (h.trans hne.symm)
+    rw [hστ, hσ, hτ]
+    decide
 
 variable (root) in
 /-- The Galois group of `M / K` maps to the sign patterns `(ℤ/2)ⁱ`. -/
 noncomputable def signHom (hroot : ∀ i, root i ^ 2 = algebraMap K L (d i))
-    (hne : ∀ i, gen (K := K) root i ≠ -gen root i) :
-    (adjoin K (Set.range root) ≃ₐ[K] adjoin K (Set.range root)) →* Multiplicative (ι → ZMod 2) where
+    : (adjoin K (Set.range root) ≃ₐ[K] adjoin K (Set.range root)) →*
+      Multiplicative (ι → ZMod 2) where
   toFun σ := Multiplicative.ofAdd (signPattern root σ)
   map_one' := by simp
-  map_mul' σ τ := by simp [signPattern_mul hroot hne, ofAdd_add]
+  map_mul' σ τ := by simp [signPattern_mul hroot, ofAdd_add]
 
 omit [Finite ι] in
+/-- Evaluation rule for `signHom`: it is the multiplicative form of `signPattern`. -/
 @[simp] theorem signHom_apply (hroot : ∀ i, root i ^ 2 = algebraMap K L (d i))
-    (hne : ∀ i, gen (K := K) root i ≠ -gen root i)
     (σ : adjoin K (Set.range root) ≃ₐ[K] adjoin K (Set.range root)) :
-    signHom root hroot hne σ = Multiplicative.ofAdd (signPattern root σ) := rfl
+    signHom root hroot σ = Multiplicative.ofAdd (signPattern root σ) := rfl
 
 /-- **For square-class independent radicands, the Galois group of a multiquadratic field is
 `(ℤ/2)ⁿ`.** -/
@@ -168,10 +184,7 @@ noncomputable def galoisGroupEquiv [NeZero (2 : K)]
     IsSplittingField.finiteDimensional _ (definingPolynomial d)
   haveI := isGalois hroot
   letI := Fintype.ofFinite ι
-  have hd : ∀ i, d i ≠ 0 := fun i hd0 =>
-    hindep {i} ⟨i, Finset.mem_singleton_self i⟩
-      (by rw [Finset.prod_singleton, hd0]; exact ⟨0, by ring⟩)
-  refine MulEquiv.ofBijective (signHom root hroot (fun i => gen_ne_neg hroot i (hd i))) ?_
+  refine MulEquiv.ofBijective (signHom root hroot) ?_
   rw [Fintype.bijective_iff_injective_and_card]
   refine ⟨signPattern_injective hroot, ?_⟩
   rw [← Nat.card_eq_fintype_card (α := adjoin K (Set.range root) ≃ₐ[K] _),
@@ -179,15 +192,18 @@ noncomputable def galoisGroupEquiv [NeZero (2 : K)]
     finrank_adjoin_range hroot hindep]
   simp [ZMod.card]
 
+/-- The Galois-group equivalence sends an automorphism to its multiplicative sign pattern. -/
 @[simp] theorem galoisGroupEquiv_apply [NeZero (2 : K)]
     (hroot : ∀ i, root i ^ 2 = algebraMap K L (d i))
     (hindep : ∀ S : Finset ι, S.Nonempty → ¬ IsSquare (∏ i ∈ S, d i))
     (σ : adjoin K (Set.range root) ≃ₐ[K] adjoin K (Set.range root)) :
-    galoisGroupEquiv hroot hindep σ = Multiplicative.ofAdd (signPattern root σ) := rfl
+    galoisGroupEquiv hroot hindep σ = Multiplicative.ofAdd (signPattern root σ) := by
+  rw [galoisGroupEquiv]
+  rfl
 
 /-- The inverse of `galoisGroupEquiv` realizes a sign pattern `ε` as the automorphism sending each
 generator `rootᵢ` to `(-1)^(εᵢ) · rootᵢ`. -/
-theorem galoisGroupEquiv_symm_apply_gen [NeZero (2 : K)]
+@[simp] theorem galoisGroupEquiv_symm_apply_gen [NeZero (2 : K)]
     (hroot : ∀ i, root i ^ 2 = algebraMap K L (d i))
     (hindep : ∀ S : Finset ι, S.Nonempty → ¬ IsSquare (∏ i ∈ S, d i))
     (ε : ι → ZMod 2) (i : ι) :


### PR DESCRIPTION
This PR identifies the Galois group of a multiquadratic field. Over a field `K` of characteristic zero, `M = K(rootᵢ)` (with `rootᵢ ^ 2 = dᵢ ∈ K`) is the splitting field of `∏ᵢ (X² - dᵢ)`, hence Galois (`isGalois`). Every automorphism sends each generator to `± rootᵢ`, so it is determined by a sign pattern `ι → ℤ/2`; this assignment is an injective group homomorphism (`signHom`). When the radicands are square-class independent the degree is `2ⁿ`, so a cardinality count upgrades the homomorphism to an isomorphism `galoisGroupEquiv : Gal(M/K) ≃* Multiplicative (ι → ZMod 2)`.

This discharges the two Layer-0 Galois targets of the Multiquadratic roadmap (`IsGalois` and the explicit `(ℤ/2)ⁿ` isomorphism), building on the degree-`2ⁿ` result already in `TauCeti/NumberTheory/Multiquadratic/Degree.lean`.

🤖 Prepared with Claude Code