### PR TITLE
feat: regular comodule coefficients generate

### DIFF
--- a/TauCeti.lean
+++ b/TauCeti.lean
@@ -15,6 +15,7 @@ import TauCeti.Algebra.Coalgebra.Comodule.Hom
 import TauCeti.Algebra.Coalgebra.Comodule.MatrixCoefficient
 import TauCeti.Algebra.Coalgebra.Comodule.MatrixCoefficientAdjoin
 import TauCeti.Algebra.Coalgebra.Comodule.MatrixCoefficientFunctorial
+import TauCeti.Algebra.Coalgebra.Comodule.MatrixCoefficientRegular
 import TauCeti.Algebra.Coalgebra.Comodule.Preadditive
 import TauCeti.Algebra.Coalgebra.Comodule.Regular
 import TauCeti.Algebra.Coalgebra.Comodule.Transport

--- a/TauCeti/Algebra/Coalgebra/Comodule/MatrixCoefficientRegular.lean
+++ b/TauCeti/Algebra/Coalgebra/Comodule/MatrixCoefficientRegular.lean
@@ -1,0 +1,139 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+import TauCeti.Algebra.Coalgebra.Comodule.MatrixCoefficientAdjoin
+import TauCeti.Algebra.Coalgebra.Comodule.Regular
+
+/-!
+# Matrix coefficients of the regular comodule
+
+This file records that the regular right comodule has enough matrix coefficients to recover
+the whole coalgebra. The key coefficient is the counit: for the regular comodule, the matrix
+coefficient attached to `Coalgebra.counit` and a vector `c` is exactly `c`.
+
+This is a small Layer 1 prerequisite for the reductive-groups roadmap's faithful
+representation criterion, where faithfulness is detected by whether matrix coefficients
+generate the coordinate Hopf algebra. It proves that the regular representation satisfies
+that generated-coefficient condition.
+
+## Main declarations
+
+* `TauCeti.Comodule.regular_matrixCoefficientSet_eq_univ`: every element of a coalgebra is a
+  matrix coefficient of the regular comodule.
+* `TauCeti.Comodule.regular_matrixCoefficientSubmodule_eq_top`: regular coefficients span the
+  whole coalgebra.
+* `TauCeti.Comodule.regular_matrixCoefficientSubalgebra_eq_top`: for a bialgebra or algebra
+  coalgebra, regular coefficients generate the whole algebra.
+
+## References
+
+This is the standard observation that the regular comodule's coefficient space is the whole
+coalgebra; see Sweedler, *Hopf Algebras*, Chapter 2. It uses the existing Tau Ceti matrix
+coefficient API and Mathlib's counit law for coalgebras.
+-/
+
+namespace TauCeti
+
+namespace Comodule
+
+universe u v
+
+variable {R : Type u} {C : Type v}
+variable [CommSemiring R]
+
+section Coalgebra
+
+variable [AddCommMonoid C] [Module R C] [Coalgebra R C]
+
+/-- Every element of a coalgebra is a matrix coefficient of the regular comodule.
+
+The element `c` is obtained by pairing `c` with the counit functional. -/
+theorem mem_regular_matrixCoefficientSet (c : C) :
+    c ∈ matrixCoefficientSet (R := R) (C := C) (M := C) := by
+  rw [mem_matrixCoefficientSet_iff]
+  exact ⟨Coalgebra.counit (R := R) (A := C), c, matrixCoefficient_counit_self (R := R) c⟩
+
+/-- The matrix coefficient set of the regular comodule is the whole coalgebra. -/
+@[simp]
+theorem regular_matrixCoefficientSet_eq_univ :
+    matrixCoefficientSet (R := R) (C := C) (M := C) = Set.univ := by
+  ext c
+  exact ⟨fun _ => Set.mem_univ c, fun _ => mem_regular_matrixCoefficientSet (R := R) (C := C) c⟩
+
+/-- A submodule contains all regular-comodule matrix coefficients iff it is top. -/
+theorem regular_matrixCoefficientSubmodule_le_iff {P : Submodule R C} :
+    matrixCoefficientSubmodule (R := R) (C := C) (M := C) ≤ P ↔ P = ⊤ := by
+  constructor
+  · intro hP
+    rw [eq_top_iff]
+    intro c _
+    rw [← matrixCoefficient_counit_self (R := R) c]
+    exact hP (matrixCoefficient_mem_submodule (R := R) (C := C)
+      (Coalgebra.counit (R := R) (A := C)) c)
+  · intro hP
+    rw [hP]
+    exact le_top
+
+/-- The regular comodule's matrix coefficients span the whole coalgebra. -/
+@[simp]
+theorem regular_matrixCoefficientSubmodule_eq_top :
+    matrixCoefficientSubmodule (R := R) (C := C) (M := C) = ⊤ := by
+  rw [matrixCoefficientSubmodule, regular_matrixCoefficientSet_eq_univ]
+  exact Submodule.span_univ
+
+/-- Every element of the bundled regular comodule's coalgebra is a matrix coefficient. -/
+theorem mem_regularObj_matrixCoefficientSet (c : ComoduleCat.regular R C) :
+    c ∈ matrixCoefficientSet (R := R) (C := C) (M := ComoduleCat.regular R C) :=
+  mem_regular_matrixCoefficientSet (R := R) (C := C) c
+
+/-- The bundled regular comodule's matrix coefficient set is the whole coalgebra. -/
+@[simp]
+theorem regularObj_matrixCoefficientSet_eq_univ :
+    matrixCoefficientSet (R := R) (C := C) (M := ComoduleCat.regular R C) = Set.univ :=
+  regular_matrixCoefficientSet_eq_univ (R := R) (C := C)
+
+/-- The bundled regular comodule's matrix coefficients span the whole coalgebra. -/
+@[simp]
+theorem regularObj_matrixCoefficientSubmodule_eq_top :
+    matrixCoefficientSubmodule (R := R) (C := C) (M := ComoduleCat.regular R C) = ⊤ :=
+  regular_matrixCoefficientSubmodule_eq_top (R := R) (C := C)
+
+end Coalgebra
+
+section Algebra
+
+variable [Semiring C] [Algebra R C] [Coalgebra R C]
+
+/-- A subalgebra contains all regular-comodule matrix coefficients iff it is top. -/
+theorem regular_matrixCoefficientSubalgebra_le_iff {S : Subalgebra R C} :
+    matrixCoefficientSubalgebra (R := R) (C := C) (M := C) ≤ S ↔ S = ⊤ := by
+  constructor
+  · intro hS
+    rw [eq_top_iff]
+    intro c _
+    rw [← matrixCoefficient_counit_self (R := R) c]
+    exact hS (matrixCoefficient_mem_subalgebra
+      (R := R) (C := C) (M := C) (Coalgebra.counit (R := R) (A := C)) c)
+  · intro hS
+    rw [hS]
+    exact le_top
+
+/-- The regular comodule's matrix coefficients generate the whole ambient algebra. -/
+@[simp]
+theorem regular_matrixCoefficientSubalgebra_eq_top :
+    matrixCoefficientSubalgebra (R := R) (C := C) (M := C) = ⊤ :=
+  matrixCoefficientSubalgebra_eq_top_of_submodule_eq_top
+    (regular_matrixCoefficientSubmodule_eq_top (R := R) (C := C))
+
+/-- The bundled regular comodule's matrix coefficients generate the whole ambient algebra. -/
+@[simp]
+theorem regularObj_matrixCoefficientSubalgebra_eq_top :
+    matrixCoefficientSubalgebra (R := R) (C := C) (M := ComoduleCat.regular R C) = ⊤ :=
+  regular_matrixCoefficientSubalgebra_eq_top (R := R) (C := C)
+
+end Algebra
+
+end Comodule
+
+end TauCeti

--- a/TauCeti/Algebra/Coalgebra/Comodule/MatrixCoefficientRegular.lean
+++ b/TauCeti/Algebra/Coalgebra/Comodule/MatrixCoefficientRegular.lean
@@ -62,7 +62,7 @@ theorem regular_matrixCoefficientSet_eq_univ :
   exact ⟨fun _ => Set.mem_univ c, fun _ => mem_regular_matrixCoefficientSet (R := R) (C := C) c⟩
 
 /-- A submodule contains all regular-comodule matrix coefficients iff it is top. -/
-theorem regular_matrixCoefficientSubmodule_le_iff {P : Submodule R C} :
+theorem regular_matrixCoefficientSubmodule_le_iff_eq_top {P : Submodule R C} :
     matrixCoefficientSubmodule (R := R) (C := C) (M := C) ≤ P ↔ P = ⊤ := by
   constructor
   · intro hP
@@ -106,7 +106,7 @@ section Algebra
 variable [Semiring C] [Algebra R C] [Coalgebra R C]
 
 /-- A subalgebra contains all regular-comodule matrix coefficients iff it is top. -/
-theorem regular_matrixCoefficientSubalgebra_le_iff {S : Subalgebra R C} :
+theorem regular_matrixCoefficientSubalgebra_le_iff_eq_top {S : Subalgebra R C} :
     matrixCoefficientSubalgebra (R := R) (C := C) (M := C) ≤ S ↔ S = ⊤ := by
   constructor
   · intro hS


### PR DESCRIPTION
This PR proves that the regular comodule has all coalgebra elements as matrix coefficients, advancing `TauCetiRoadmap/ReductiveGroups/README.md`, Layer 1 target "Faithfulness done right: define a representation to be faithful when `G → GL(V)` is a closed immersion, and prove this is equivalent to its matrix coefficients generating `A`," and the same layer's regular-representation prerequisite. It records that the counit coefficient of the regular comodule recovers each element, then packages the resulting universal coefficient set, top coefficient span, and top generated coefficient algebra, with bundled `ComoduleCat.regular` variants reachable from the TauCeti root.

No Mathlib infrastructure is vendored. The proof reuses Tau Ceti's existing `Comodule.matrixCoefficient_counit_self`, `matrixCoefficientSubmodule`, and `matrixCoefficientSubalgebra` API, together with Mathlib's coalgebra counit law underlying the existing regular-comodule coefficient formula.

Validated with `lake exe cache get`, `lake build`, and `lake exe axioms`. `lake exe cache get` ended with `No files to download` and `Already decompressed 8480 file(s).` `lake build` ended with `Build completed successfully (3709 jobs).` `lake exe axioms` ended with `axioms: audited 1514 TauCeti declaration(s); all within the allowlist [propext, Classical.choice, Quot.sound].`

🤖 Prepared with Codex
