### PR TITLE
feat: add finite cofree comodules

### DIFF
--- a/TauCeti.lean
+++ b/TauCeti.lean
@@ -9,6 +9,7 @@ import TauCeti.Algebra.Coalgebra.Comodule.Cofree
 import TauCeti.Algebra.Coalgebra.Comodule.Corestrict
 import TauCeti.Algebra.Coalgebra.Comodule.Finite
 import TauCeti.Algebra.Coalgebra.Comodule.FiniteCorestrict
+import TauCeti.Algebra.Coalgebra.Comodule.FiniteCofree
 import TauCeti.Algebra.Coalgebra.Comodule.FinitePreadditive
 import TauCeti.Algebra.Coalgebra.Comodule.FiniteTrivial
 import TauCeti.Algebra.Coalgebra.Comodule.Hom

--- a/TauCeti/Algebra/Coalgebra/Comodule/FiniteCofree.lean
+++ b/TauCeti/Algebra/Coalgebra/Comodule/FiniteCofree.lean
@@ -10,8 +10,8 @@ import TauCeti.Algebra.Coalgebra.Comodule.Finite
 # Finitely generated cofree comodules
 
 This file lifts the cofree right comodule `M ⊗[R] C` to the finitely generated comodule
-category when both the coefficient module `M` and the coalgebra `C` are finitely generated
-over `R`. It is the finite-category version of `ComoduleCat.cofree`.
+category when the tensor-product carrier is finitely generated over `R`. It is the
+finite-category version of `ComoduleCat.cofree`.
 
 This is Layer 1 infrastructure for the Tau Ceti reductive-groups roadmap target
 "Comodules over a coalgebra/Hopf algebra": the finite-dimensional representation category
@@ -21,15 +21,17 @@ the embedding theorem can be developed.
 ## Main definitions
 
 * `TauCeti.FGComoduleCat.cofree`: the cofree comodule as a finitely generated object.
-* `TauCeti.FGComoduleCat.cofreeMap`: functoriality in the finite coefficient module.
+* `TauCeti.FGComoduleCat.cofreeMap`: functoriality between finite cofree objects.
+* `TauCeti.FGComoduleCat.cofreeLift`: the finite-category form of the cofree lifting map.
+* `TauCeti.FGComoduleCat.cofreeEquiv`: the cofree universal property in `FGComoduleCat`.
 * `TauCeti.FGComoduleCat.incl_cofree`: forgetting the finite cofree comodule gives the
   ambient cofree comodule.
 
 ## References
 
 The cofree-comodule construction follows Sweedler, *Hopf Algebras*, Chapter 2, as in
-`TauCeti.Algebra.Coalgebra.Comodule.Cofree`. The finite-generation proof reuses Mathlib's
-`Module.Finite.tensorProduct`.
+`TauCeti.Algebra.Coalgebra.Comodule.Cofree`. When the coefficient module and coalgebra are
+finitely generated, the finite-generation proof reuses Mathlib's `Module.Finite.tensorProduct`.
 -/
 
 open CategoryTheory
@@ -43,16 +45,15 @@ namespace FGComoduleCat
 
 variable (R : Type u) (C : Type v)
 variable [CommSemiring R] [AddCommMonoid C] [Module R C] [Coalgebra R C]
-variable [Module.Finite R C]
-variable {M : Type w} [AddCommMonoid M] [Module R M] [Module.Finite R M]
-variable {N : Type w} [AddCommMonoid N] [Module R N] [Module.Finite R N]
+variable {M : Type w} [AddCommMonoid M] [Module R M] [Module.Finite R (M ⊗[R] C)]
+variable {N : Type w} [AddCommMonoid N] [Module R N] [Module.Finite R (N ⊗[R] C)]
 
-/-- The cofree right `C`-comodule on a finitely generated module, bundled as an object of
-`FGComoduleCat`.
+/-- The cofree right `C`-comodule with finitely generated tensor-product carrier, bundled as an
+object of `FGComoduleCat`.
 
 The underlying module is `M ⊗[R] C`, with coaction `id ⊗ Δ` followed by reassociation. -/
 noncomputable abbrev cofree (M : Type w) [AddCommMonoid M] [Module R M]
-    [Module.Finite R M] : FGComoduleCat.{u, v, max w v} R C :=
+    [Module.Finite R (M ⊗[R] C)] : FGComoduleCat.{u, v, max w v} R C :=
   letI := Comodule.cofree R C M
   of (R := R) (C := C) (M ⊗[R] C)
 
@@ -102,7 +103,7 @@ theorem forget₂_semimoduleCat_cofree_obj :
       SemimoduleCat.of R (M ⊗[R] C) :=
   rfl
 
-/-- Functoriality of finite cofree comodules in the finite coefficient module.
+/-- Functoriality of finite cofree comodules in the coefficient module.
 
 An `R`-linear map `f : M → N` induces the comodule morphism `f ⊗ id`. -/
 noncomputable abbrev cofreeMap (f : M →ₗ[R] N) :
@@ -138,12 +139,60 @@ theorem cofreeMap_id :
 
 /-- The finite cofree construction preserves composition of coefficient-module maps. -/
 @[simp]
-theorem cofreeMap_comp {P : Type w} [AddCommMonoid P] [Module R P] [Module.Finite R P]
-    (g : N →ₗ[R] P) (f : M →ₗ[R] N) :
+theorem cofreeMap_comp {P : Type w} [AddCommMonoid P] [Module R P]
+    [Module.Finite R (P ⊗[R] C)] (g : N →ₗ[R] P) (f : M →ₗ[R] N) :
     cofreeMap (R := R) (C := C) (g.comp f) =
       cofreeMap (R := R) (C := C) f ≫ cofreeMap (R := R) (C := C) g := by
   ext x
   simp
+
+variable {P : FGComoduleCat.{u, v, max w v} R C}
+
+/-- The finite-category cofree lift of an `R`-linear map from a finite comodule to the
+coefficient module. -/
+noncomputable abbrev cofreeLift (P : FGComoduleCat.{u, v, max w v} R C) (g : P →ₗ[R] M) :
+    P ⟶ cofree (R := R) (C := C) M :=
+  letI := Comodule.cofree R C M
+  ObjectProperty.homMk
+    (ComoduleCat.ofHom (R := R) (C := C) (Comodule.Hom.cofreeLift (C := C) g))
+
+/-- `cofreeLift g` acts as `(g ⊗ id) ∘ ρ_P`. -/
+@[simp]
+theorem cofreeLift_apply (g : P →ₗ[R] M) (p : P) :
+    cofreeLift (R := R) (C := C) P g p =
+      g.rTensor C (Comodule.coact (R := R) (C := C) (M := P) p) :=
+  letI := Comodule.cofree R C M
+  rfl
+
+/-- The finite-category cofree universal property. -/
+noncomputable def cofreeEquiv (P : FGComoduleCat.{u, v, max w v} R C) :
+    (P ⟶ cofree (R := R) (C := C) M) ≃ (P →ₗ[R] M) := by
+  letI := Comodule.cofree R C M
+  exact
+    { toFun φ := Comodule.Hom.cofreeEquiv (R := R) (C := C) (M := M) (P := P) φ.hom
+      invFun g := cofreeLift (R := R) (C := C) P g
+      left_inv φ := by
+        apply ObjectProperty.hom_ext
+        exact (Comodule.Hom.cofreeEquiv (R := R) (C := C) (M := M) (P := P)).left_inv φ.hom
+      right_inv g :=
+        (Comodule.Hom.cofreeEquiv (R := R) (C := C) (M := M) (P := P)).right_inv g }
+
+/-- The forward direction of the finite cofree adjunction sends a comodule morphism to the
+`R`-linear map obtained by applying the counit to the `C` factor. -/
+@[simp]
+theorem cofreeEquiv_apply (φ : P ⟶ cofree (R := R) (C := C) M) :
+    cofreeEquiv (R := R) (C := C) (M := M) P φ =
+      letI := Comodule.cofree R C M
+      Comodule.Hom.cofreeEquiv (R := R) (C := C) (M := M) (P := P) φ.hom := by
+  letI := Comodule.cofree R C M
+  rfl
+
+/-- The inverse direction of the finite cofree adjunction is `cofreeLift`. -/
+@[simp]
+theorem cofreeEquiv_symm_apply (g : P →ₗ[R] M) :
+    (cofreeEquiv (R := R) (C := C) (M := M) P).symm g =
+      cofreeLift (R := R) (C := C) P g :=
+  rfl
 
 end FGComoduleCat
 

--- a/TauCeti/Algebra/Coalgebra/Comodule/FiniteCofree.lean
+++ b/TauCeti/Algebra/Coalgebra/Comodule/FiniteCofree.lean
@@ -47,11 +47,6 @@ variable [Module.Finite R C]
 variable {M : Type w} [AddCommMonoid M] [Module R M] [Module.Finite R M]
 variable {N : Type w} [AddCommMonoid N] [Module R N] [Module.Finite R N]
 
-/-- The tensor product underlying a cofree comodule is finitely generated when both tensor
-factors are finitely generated. -/
-instance cofree_tensorProduct_finite : Module.Finite R (M ⊗[R] C) :=
-  Module.Finite.tensorProduct R M C
-
 /-- The cofree right `C`-comodule on a finitely generated module, bundled as an object of
 `FGComoduleCat`.
 

--- a/TauCeti/Algebra/Coalgebra/Comodule/FiniteCofree.lean
+++ b/TauCeti/Algebra/Coalgebra/Comodule/FiniteCofree.lean
@@ -1,0 +1,155 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+import Mathlib.RingTheory.TensorProduct.Finite
+import TauCeti.Algebra.Coalgebra.Comodule.Cofree
+import TauCeti.Algebra.Coalgebra.Comodule.Finite
+
+/-!
+# Finitely generated cofree comodules
+
+This file lifts the cofree right comodule `M ⊗[R] C` to the finitely generated comodule
+category when both the coefficient module `M` and the coalgebra `C` are finitely generated
+over `R`. It is the finite-category version of `ComoduleCat.cofree`.
+
+This is Layer 1 infrastructure for the Tau Ceti reductive-groups roadmap target
+"Comodules over a coalgebra/Hopf algebra": the finite-dimensional representation category
+needs finite versions of the regular and cofree comodules before tensor products, duals, and
+the embedding theorem can be developed.
+
+## Main definitions
+
+* `TauCeti.FGComoduleCat.cofree`: the cofree comodule as a finitely generated object.
+* `TauCeti.FGComoduleCat.cofreeMap`: functoriality in the finite coefficient module.
+* `TauCeti.FGComoduleCat.incl_cofree`: forgetting the finite cofree comodule gives the
+  ambient cofree comodule.
+
+## References
+
+The cofree-comodule construction follows Sweedler, *Hopf Algebras*, Chapter 2, as in
+`TauCeti.Algebra.Coalgebra.Comodule.Cofree`. The finite-generation proof reuses Mathlib's
+`Module.Finite.tensorProduct`.
+-/
+
+open CategoryTheory
+open scoped TensorProduct
+
+namespace TauCeti
+
+universe u v w
+
+namespace FGComoduleCat
+
+variable (R : Type u) (C : Type v)
+variable [CommSemiring R] [AddCommMonoid C] [Module R C] [Coalgebra R C]
+variable [Module.Finite R C]
+variable {M : Type w} [AddCommMonoid M] [Module R M] [Module.Finite R M]
+variable {N : Type w} [AddCommMonoid N] [Module R N] [Module.Finite R N]
+
+/-- The tensor product underlying a cofree comodule is finitely generated when both tensor
+factors are finitely generated. -/
+instance cofree_tensorProduct_finite : Module.Finite R (M ⊗[R] C) :=
+  Module.Finite.tensorProduct R M C
+
+/-- The cofree right `C`-comodule on a finitely generated module, bundled as an object of
+`FGComoduleCat`.
+
+The underlying module is `M ⊗[R] C`, with coaction `id ⊗ Δ` followed by reassociation. -/
+noncomputable abbrev cofree (M : Type w) [AddCommMonoid M] [Module R M]
+    [Module.Finite R M] : FGComoduleCat.{u, v, max w v} R C :=
+  letI := Comodule.cofree R C M
+  of (R := R) (C := C) (M ⊗[R] C)
+
+/-- Forgetting the finitely generated cofree comodule to all comodules gives the ambient
+cofree comodule. -/
+@[simp]
+theorem cofree_obj :
+    (cofree (R := R) (C := C) M).obj = ComoduleCat.cofree R C M :=
+  rfl
+
+/-- The underlying type of the finitely generated cofree comodule is `M ⊗[R] C`. -/
+@[simp]
+theorem cofree_coe : (cofree (R := R) (C := C) M : Type (max w v)) = M ⊗[R] C :=
+  rfl
+
+/-- The coaction on the finitely generated cofree comodule is `id ⊗ Δ` followed by
+reassociation. -/
+@[simp]
+theorem cofree_coact :
+    letI := Comodule.cofree R C M
+    Comodule.coact (R := R) (C := C) (M := cofree (R := R) (C := C) M)
+      = (TensorProduct.assoc R M C C).symm.toLinearMap ∘ₗ Coalgebra.comul.lTensor M :=
+  rfl
+
+/-- The coaction on the finitely generated cofree comodule sends a simple tensor
+`m ⊗ c` to `∑ (m ⊗ c₁) ⊗ c₂`. -/
+@[simp]
+theorem cofree_coact_tmul (m : M) (c : C) :
+    letI := Comodule.cofree R C M
+    Comodule.coact (R := R) (C := C) (M := cofree (R := R) (C := C) M) (m ⊗ₜ[R] c)
+      = (TensorProduct.assoc R M C C).symm (m ⊗ₜ Coalgebra.comul c) :=
+  Comodule.cofree_coact_tmul m c
+
+/-- The inclusion of finitely generated comodules sends `FGComoduleCat.cofree` to
+`ComoduleCat.cofree`. -/
+@[simp]
+theorem incl_cofree :
+    (incl (R := R) (C := C)).obj (cofree (R := R) (C := C) M) =
+      ComoduleCat.cofree R C M :=
+  rfl
+
+/-- The finite cofree comodule forgets to the tensor product module `M ⊗[R] C`. -/
+@[simp]
+theorem forget₂_semimoduleCat_cofree_obj :
+    (forget₂ (FGComoduleCat.{u, v, max w v} R C) (SemimoduleCat.{max w v} R)).obj
+        (cofree (R := R) (C := C) M) =
+      SemimoduleCat.of R (M ⊗[R] C) :=
+  rfl
+
+/-- Functoriality of finite cofree comodules in the finite coefficient module.
+
+An `R`-linear map `f : M → N` induces the comodule morphism `f ⊗ id`. -/
+noncomputable abbrev cofreeMap (f : M →ₗ[R] N) :
+    cofree (R := R) (C := C) M ⟶ cofree (R := R) (C := C) N :=
+  letI := Comodule.cofree R C M
+  letI := Comodule.cofree R C N
+  ofHom (R := R) (C := C) (Comodule.Hom.cofreeMap (C := C) f)
+
+/-- `cofreeMap f` acts as `f ⊗ id`. -/
+@[simp]
+theorem cofreeMap_apply (f : M →ₗ[R] N) (x : M ⊗[R] C) :
+    cofreeMap (R := R) (C := C) f x = f.rTensor C x :=
+  letI := Comodule.cofree R C M
+  letI := Comodule.cofree R C N
+  rfl
+
+/-- On simple tensors, `cofreeMap f` applies `f` to the coefficient factor. -/
+@[simp]
+theorem cofreeMap_tmul (f : M →ₗ[R] N) (m : M) (c : C) :
+    cofreeMap (R := R) (C := C) f (m ⊗ₜ[R] c) = f m ⊗ₜ[R] c :=
+  letI := Comodule.cofree R C M
+  letI := Comodule.cofree R C N
+  rfl
+
+/-- The finite cofree construction sends the identity linear map to the identity morphism. -/
+@[simp]
+theorem cofreeMap_id :
+    cofreeMap (R := R) (C := C) (LinearMap.id : M →ₗ[R] M) =
+      𝟙 (cofree (R := R) (C := C) M) :=
+  by
+    ext x
+    simp
+
+/-- The finite cofree construction preserves composition of coefficient-module maps. -/
+@[simp]
+theorem cofreeMap_comp {P : Type w} [AddCommMonoid P] [Module R P] [Module.Finite R P]
+    (g : N →ₗ[R] P) (f : M →ₗ[R] N) :
+    cofreeMap (R := R) (C := C) (g.comp f) =
+      cofreeMap (R := R) (C := C) f ≫ cofreeMap (R := R) (C := C) g := by
+  ext x
+  simp
+
+end FGComoduleCat
+
+end TauCeti

--- a/TauCeti/Algebra/Coalgebra/Comodule/FiniteCofree.lean
+++ b/TauCeti/Algebra/Coalgebra/Comodule/FiniteCofree.lean
@@ -2,7 +2,6 @@
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 -/
-import Mathlib.RingTheory.TensorProduct.Finite
 import TauCeti.Algebra.Coalgebra.Comodule.Cofree
 import TauCeti.Algebra.Coalgebra.Comodule.Finite
 
@@ -30,8 +29,7 @@ the embedding theorem can be developed.
 ## References
 
 The cofree-comodule construction follows Sweedler, *Hopf Algebras*, Chapter 2, as in
-`TauCeti.Algebra.Coalgebra.Comodule.Cofree`. When the coefficient module and coalgebra are
-finitely generated, the finite-generation proof reuses Mathlib's `Module.Finite.tensorProduct`.
+`TauCeti.Algebra.Coalgebra.Comodule.Cofree`.
 -/
 
 open CategoryTheory


### PR DESCRIPTION
This PR adds finitely generated cofree comodules, advancing `TauCetiRoadmap/ReductiveGroups/README.md`, Layer 1 target "Comodules over a coalgebra/Hopf algebra `A`: a coaction `ρ : V → V ⊗ A` with coassociativity and counit; comodule morphisms; the (rigid monoidal) category of finite-dimensional comodules; tensor products, duals, the regular representation." It packages the existing cofree comodule `M ⊗[R] C` as an object of `FGComoduleCat` when both `M` and `C` are finitely generated, records the coaction and forgetful compatibility lemmas, and provides functoriality in the finite coefficient module. This was the lowest-hanging distinct ReductiveGroups prerequisite I found because open and merged PRs already cover the points functor, base change, `𝔾_m`, finite regular comodules, subcomodules, and matrix coefficients, while no open or merged PR provides finite cofree comodules.

No Mathlib infrastructure is vendored. The finite-generation proof reuses Mathlib `Module.Finite.tensorProduct`, and the construction reuses Tau Ceti's existing `Comodule.cofree`, `Comodule.Hom.cofreeMap`, `ComoduleCat.cofree`, and `FGComoduleCat` full-subcategory API.

Validated with `lake exe cache get`, `lake build`, and `lake exe axioms`. `lake exe cache get` ended with `No files to download` and `Already decompressed 8480 file(s).` The final `lake build` ended with `Build completed successfully (3709 jobs).` The final `lake exe axioms` ended with `axioms: audited 1517 TauCeti declaration(s); all within the allowlist [propext, Classical.choice, Quot.sound].`

🤖 Prepared with Codex
