### PR TITLE
feat: the prime-splitting law for a quadratic field

### DIFF
--- a/TauCeti.lean
+++ b/TauCeti.lean
@@ -52,3 +52,4 @@ import TauCeti.NumberTheory.EffectiveBounds.UnitSquares
 import TauCeti.NumberTheory.Multiquadratic.Degree
 import TauCeti.NumberTheory.Multiquadratic.Galois
 import TauCeti.NumberTheory.Multiquadratic.SquareClass
+import TauCeti.NumberTheory.NumberField.QuadraticSplitting

--- a/TauCeti/NumberTheory/NumberField/QuadraticSplitting.lean
+++ b/TauCeti/NumberTheory/NumberField/QuadraticSplitting.lean
@@ -2,7 +2,7 @@
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 -/
-import Mathlib.FieldTheory.KummerExtension
+import Mathlib.FieldTheory.KummerPolynomial
 import Mathlib.NumberTheory.LegendreSymbol.Basic
 import Mathlib.NumberTheory.NumberField.Ideal.KummerDedekind
 import Mathlib.RingTheory.Discriminant
@@ -66,8 +66,10 @@ private theorem not_dvd_exponent_of_minpoly_quadratic {θ : 𝓞 K} {d : ℤ}
     have hfinrank : Module.finrank ℚ K = 2 := pb.finrank.trans hdim
     have haeval : (aeval pb.gen) ((X : ℚ[X]) ^ 2 - C ((d : ℤ) : ℚ)).derivative
         = algebraMap ℚ K 2 * pb.gen := by
+      -- `derivative_X_pow` leaves the exponent as `2 - 1`; reduce it to `1` so `pow_one` applies.
+      have hsub : (2 : ℕ) - 1 = 1 := by norm_num
       rw [derivative_sub, derivative_C, sub_zero, derivative_X_pow, map_mul, aeval_C, map_pow,
-        aeval_X, show (2 : ℕ) - 1 = 1 from rfl, pow_one]
+        aeval_X, hsub, pow_one]
       norm_num
     have hdiscr : Algebra.discr ℚ pb.basis = ((4 * d : ℤ) : ℚ) := by
       rw [Algebra.discr_powerBasis_eq_norm, hmin', haeval, map_mul,

--- a/TauCeti/NumberTheory/NumberField/QuadraticSplitting.lean
+++ b/TauCeti/NumberTheory/NumberField/QuadraticSplitting.lean
@@ -2,7 +2,10 @@
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 -/
-import Mathlib
+import Mathlib.FieldTheory.KummerExtension
+import Mathlib.NumberTheory.LegendreSymbol.Basic
+import Mathlib.NumberTheory.NumberField.Ideal.KummerDedekind
+import Mathlib.RingTheory.Discriminant
 
 /-!
 # The prime-splitting law for a quadratic field
@@ -39,7 +42,7 @@ variable {K : Type*} [Field K] [NumberField K]
 
 /-- **Conductor bound.** If `θ` generates `K` and has minimal polynomial `X² - d`, then an odd
 prime not dividing `d` does not divide the conductor exponent of `θ`. -/
-theorem not_dvd_exponent_of_minpoly_quadratic {θ : 𝓞 K} {d : ℤ}
+private theorem not_dvd_exponent_of_minpoly_quadratic {θ : 𝓞 K} {d : ℤ}
     (hmin : minpoly ℤ θ = X ^ 2 - C d)
     (hgen : Algebra.adjoin ℚ {(θ : K)} = ⊤) {p : ℕ} [Fact p.Prime] (hodd : p ≠ 2)
     (hcop : ¬ (p : ℤ) ∣ d) : ¬ p ∣ exponent θ := by
@@ -76,7 +79,7 @@ theorem not_dvd_exponent_of_minpoly_quadratic {θ : 𝓞 K} {d : ℤ}
     rw [hdiscr, hgenθ] at key
     -- `key : ((4d:ℤ):ℚ) • (b:K) ∈ adjoin ℤ {(θ:K)}`; bridge back into `𝓞 K`.
     let f : (𝓞 K) →ₐ[ℤ] K := IsScalarTower.toAlgHom ℤ (𝓞 K) K
-    have hfθ : f θ = (θ : K) := rfl
+    have hfθ : f θ = (θ : K) := by rw [IsScalarTower.coe_toAlgHom']
     have hAmap : (Algebra.adjoin ℤ {θ}).map f = Algebra.adjoin ℤ {(θ : K)} := by
       rw [← Algebra.adjoin_image, Set.image_singleton, hfθ]
     have himg : ((4 * d : ℤ) : ℚ) • (b : K) = f (algebraMap ℤ (𝓞 K) (4 * d) * b) := by
@@ -108,7 +111,7 @@ theorem not_dvd_exponent_of_minpoly_quadratic {θ : 𝓞 K} {d : ℤ}
 omit [NumberField K] in
 /-- **Factor count mod p.** `X² - d` has two monic irreducible factors mod `p` (for `p` odd,
 `p ∤ d`) iff `d` is a square mod `p`. -/
-theorem card_monicFactorsMod_quadratic {θ : 𝓞 K} {d : ℤ}
+private theorem card_monicFactorsMod_quadratic_iff {θ : 𝓞 K} {d : ℤ}
     (hmin : minpoly ℤ θ = X ^ 2 - C d) {p : ℕ} [Fact p.Prime] (hodd : p ≠ 2)
     (hcop : ¬ (p : ℤ) ∣ d) :
     (monicFactorsMod θ p).card = 2 ↔ legendreSym p d = 1 := by
@@ -153,7 +156,7 @@ residue mod `p`. This is the `n = 1` case of the multiquadratic prime-splitting 
 theorem quadratic_ncard_primesOver_iff {θ : 𝓞 K} {d : ℤ}
     (hmin : minpoly ℤ θ = X ^ 2 - C d) (hgen : Algebra.adjoin ℚ {(θ : K)} = ⊤)
     {p : ℕ} [Fact p.Prime] (hodd : p ≠ 2) (hcop : ¬ (p : ℤ) ∣ d) :
-    Nat.card (primesOver (span {(p : ℤ)}) (𝓞 K)) = finrank ℚ K ↔ legendreSym p d = 1 := by
+    (primesOver (span {(p : ℤ)}) (𝓞 K)).ncard = finrank ℚ K ↔ legendreSym p d = 1 := by
   have hp := not_dvd_exponent_of_minpoly_quadratic hmin hgen hodd hcop
   have hintθℚ : IsIntegral ℚ (θ : K) := θ.isIntegral_coe.tower_top
   have hfr : finrank ℚ K = 2 := by
@@ -163,10 +166,10 @@ theorem quadratic_ncard_primesOver_iff {θ : 𝓞 K} {d : ℤ}
       minpoly.isIntegrallyClosed_eq_field_fractions ℚ K (IsIntegralClosure.isIntegral ℤ K θ),
       hmin, Polynomial.map_sub, Polynomial.map_pow, map_X, Polynomial.map_C,
       natDegree_X_pow_sub_C]
-  have hcard : Nat.card (primesOver (span {(p : ℤ)}) (𝓞 K)) = (monicFactorsMod θ p).card := by
-    rw [Nat.card_congr (primesOverSpanEquivMonicFactorsMod hp)]
+  have hcard : (primesOver (span {(p : ℤ)}) (𝓞 K)).ncard = (monicFactorsMod θ p).card := by
+    rw [← Nat.card_coe_set_eq, Nat.card_congr (primesOverSpanEquivMonicFactorsMod hp)]
     exact Nat.card_eq_finsetCard _
   rw [hcard, hfr]
-  exact card_monicFactorsMod_quadratic hmin hodd hcop
+  exact card_monicFactorsMod_quadratic_iff hmin hodd hcop
 
 end TauCeti.NumberField

--- a/TauCeti/NumberTheory/NumberField/QuadraticSplitting.lean
+++ b/TauCeti/NumberTheory/NumberField/QuadraticSplitting.lean
@@ -26,7 +26,7 @@ multiquadratic roadmap).
 
 ## Main results
 
-* `TauCeti.NumberField.quadratic_ncard_primesOver_iff`: the quadratic splitting law.
+* `TauCeti.NumberField.ncard_primesOver_quadratic_iff`: the quadratic splitting law.
 
 ## Provenance
 
@@ -155,7 +155,7 @@ private theorem card_monicFactorsMod_quadratic_iff {θ : 𝓞 K} {d : ℤ}
 /-- **The quadratic splitting law.** For `K = ℚ(√d)` (`θ` a square root of the integer `d`
 generating `K`) and an odd prime `p ∤ d`, `p` splits completely in `K` iff `d` is a quadratic
 residue mod `p`. This is the `n = 1` case of the multiquadratic prime-splitting law. -/
-theorem quadratic_ncard_primesOver_iff {θ : 𝓞 K} {d : ℤ}
+theorem ncard_primesOver_quadratic_iff {θ : 𝓞 K} {d : ℤ}
     (hmin : minpoly ℤ θ = X ^ 2 - C d) (hgen : Algebra.adjoin ℚ {(θ : K)} = ⊤)
     {p : ℕ} [Fact p.Prime] (hodd : p ≠ 2) (hcop : ¬ (p : ℤ) ∣ d) :
     (primesOver (span {(p : ℤ)}) (𝓞 K)).ncard = finrank ℚ K ↔ legendreSym p d = 1 := by

--- a/TauCeti/NumberTheory/NumberField/QuadraticSplitting.lean
+++ b/TauCeti/NumberTheory/NumberField/QuadraticSplitting.lean
@@ -40,6 +40,13 @@ namespace TauCeti.NumberField
 
 variable {K : Type*} [Field K] [NumberField K]
 
+/-- The minimal polynomial of `θ` over `ℚ` is `X² - d`, obtained from its minimal polynomial
+over `ℤ` by base change along `ℤ → ℚ`. -/
+private theorem minpoly_rat_quadratic {θ : 𝓞 K} {d : ℤ} (hmin : minpoly ℤ θ = X ^ 2 - C d) :
+    minpoly ℚ (θ : K) = X ^ 2 - C ((d : ℤ) : ℚ) := by
+  rw [minpoly.isIntegrallyClosed_eq_field_fractions ℚ K (IsIntegralClosure.isIntegral ℤ K θ), hmin]
+  simp [Polynomial.map_sub, Polynomial.map_pow]
+
 /-- **Conductor bound.** If `θ` generates `K` and has minimal polynomial `X² - d`, then an odd
 prime not dividing `d` does not divide the conductor exponent of `θ`. -/
 private theorem not_dvd_exponent_of_minpoly_quadratic {θ : 𝓞 K} {d : ℤ}
@@ -54,10 +61,8 @@ private theorem not_dvd_exponent_of_minpoly_quadratic {θ : 𝓞 K} {d : ℤ}
     have hintθℚ : IsIntegral ℚ (θ : K) := hintθℤ.tower_top
     let pb : PowerBasis ℚ K := PowerBasis.ofAdjoinEqTop' hintθℚ hgen
     have hgenθ : pb.gen = (θ : K) := PowerBasis.ofAdjoinEqTop'_gen hintθℚ hgen
-    have hminθℤ : IsIntegral ℤ θ := IsIntegralClosure.isIntegral ℤ K θ
     have hmin' : minpoly ℚ pb.gen = X ^ 2 - C ((d : ℤ) : ℚ) := by
-      rw [hgenθ, minpoly.isIntegrallyClosed_eq_field_fractions ℚ K hminθℤ, hmin]
-      simp [Polynomial.map_sub, Polynomial.map_pow]
+      rw [hgenθ]; exact minpoly_rat_quadratic hmin
     have hdim : pb.dim = 2 := by
       rw [← pb.natDegree_minpoly, hmin', natDegree_X_pow_sub_C]
     have hnormθ : Algebra.norm ℚ pb.gen = -((d : ℤ) : ℚ) := by
@@ -164,10 +169,7 @@ theorem ncard_primesOver_quadratic_iff {θ : 𝓞 K} {d : ℤ}
   have hfr : finrank ℚ K = 2 := by
     rw [(PowerBasis.ofAdjoinEqTop' hintθℚ hgen).finrank,
       ← (PowerBasis.ofAdjoinEqTop' hintθℚ hgen).natDegree_minpoly,
-      PowerBasis.ofAdjoinEqTop'_gen,
-      minpoly.isIntegrallyClosed_eq_field_fractions ℚ K (IsIntegralClosure.isIntegral ℤ K θ),
-      hmin, Polynomial.map_sub, Polynomial.map_pow, map_X, Polynomial.map_C,
-      natDegree_X_pow_sub_C]
+      PowerBasis.ofAdjoinEqTop'_gen, minpoly_rat_quadratic hmin, natDegree_X_pow_sub_C]
   have hcard : (primesOver (span {(p : ℤ)}) (𝓞 K)).ncard = (monicFactorsMod θ p).card := by
     rw [← Nat.card_coe_set_eq, Nat.card_congr (primesOverSpanEquivMonicFactorsMod hp)]
     exact Nat.card_eq_finsetCard _

--- a/TauCeti/NumberTheory/NumberField/QuadraticSplitting.lean
+++ b/TauCeti/NumberTheory/NumberField/QuadraticSplitting.lean
@@ -1,0 +1,172 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+import Mathlib
+
+/-!
+# The prime-splitting law for a quadratic field
+
+For a quadratic number field `K = ℚ(√d)` — given as `K` generated over `ℚ` by an algebraic
+integer `θ` whose minimal polynomial over `ℤ` is `X² - d` — and an odd prime `p` not dividing
+`d`, the prime `p` splits completely in `K` (there are `[K:ℚ] = 2` primes of `𝓞 K` above it) if
+and only if `d` is a quadratic residue mod `p`, i.e. `legendreSym p d = 1`.
+
+The proof routes through Mathlib's number-field Kummer–Dedekind theorem
+(`primesOverSpanEquivMonicFactorsMod`): the primes above `p` biject with the monic irreducible
+factors of `X² - d` mod `p`, of which there are two exactly when `d` is a square mod `p`. The
+required conductor hypothesis `p ∤ exponent θ` follows because the conductor exponent divides the
+power-basis discriminant `4d`, which is coprime to the odd prime `p ∤ d`.
+
+This is the base case (`n = 1`) of the multiquadratic prime-splitting law (Layer 1 of the
+multiquadratic roadmap).
+
+## Main results
+
+* `TauCeti.NumberField.quadratic_ncard_primesOver_iff`: the quadratic splitting law.
+
+## Provenance
+
+The conductor/discriminant and Kummer–Dedekind toolchain is from Mathlib; this assembly is new,
+prepared for the multiquadratic roadmap of the Tau Ceti library.
+-/
+
+open Polynomial NumberField Ideal Module RingOfIntegers UniqueFactorizationMonoid
+
+namespace TauCeti.NumberField
+
+variable {K : Type*} [Field K] [NumberField K]
+
+/-- **Conductor bound.** If `θ` generates `K` and has minimal polynomial `X² - d`, then an odd
+prime not dividing `d` does not divide the conductor exponent of `θ`. -/
+theorem not_dvd_exponent_of_minpoly_quadratic {θ : 𝓞 K} {d : ℤ}
+    (hmin : minpoly ℤ θ = X ^ 2 - C d)
+    (hgen : Algebra.adjoin ℚ {(θ : K)} = ⊤) {p : ℕ} [Fact p.Prime] (hodd : p ≠ 2)
+    (hcop : ¬ (p : ℤ) ∣ d) : ¬ p ∣ exponent θ := by
+  -- Key bound: the conductor exponent divides `4d`.
+  have hmem : (algebraMap ℤ (𝓞 K)) (4 * d) ∈ conductor ℤ θ := by
+    rw [mem_conductor_iff]
+    intro b
+    have hintθℤ : IsIntegral ℤ (θ : K) := θ.isIntegral_coe
+    have hintθℚ : IsIntegral ℚ (θ : K) := hintθℤ.tower_top
+    let pb : PowerBasis ℚ K := PowerBasis.ofAdjoinEqTop' hintθℚ hgen
+    have hgenθ : pb.gen = (θ : K) := PowerBasis.ofAdjoinEqTop'_gen hintθℚ hgen
+    have hminθℤ : IsIntegral ℤ θ := IsIntegralClosure.isIntegral ℤ K θ
+    have hmin' : minpoly ℚ pb.gen = X ^ 2 - C ((d : ℤ) : ℚ) := by
+      rw [hgenθ, minpoly.isIntegrallyClosed_eq_field_fractions ℚ K hminθℤ, hmin]
+      simp [Polynomial.map_sub, Polynomial.map_pow]
+    have hdim : pb.dim = 2 := by
+      rw [← pb.natDegree_minpoly, hmin', natDegree_X_pow_sub_C]
+    have hnormθ : Algebra.norm ℚ pb.gen = -((d : ℤ) : ℚ) := by
+      rw [Algebra.PowerBasis.norm_gen_eq_coeff_zero_minpoly, hmin', hdim]
+      simp [coeff_sub, coeff_X_pow]
+    have hfinrank : Module.finrank ℚ K = 2 := pb.finrank.trans hdim
+    have haeval : (aeval pb.gen) ((X : ℚ[X]) ^ 2 - C ((d : ℤ) : ℚ)).derivative
+        = algebraMap ℚ K 2 * pb.gen := by
+      rw [derivative_sub, derivative_C, sub_zero, derivative_X_pow, map_mul, aeval_C, map_pow,
+        aeval_X, show (2 : ℕ) - 1 = 1 from rfl, pow_one]
+      norm_num
+    have hdiscr : Algebra.discr ℚ pb.basis = ((4 * d : ℤ) : ℚ) := by
+      rw [Algebra.discr_powerBasis_eq_norm, hmin', haeval, map_mul,
+        Algebra.norm_algebraMap, hnormθ, hfinrank]
+      norm_num
+    have hgenint : IsIntegral ℤ pb.gen := hgenθ ▸ hintθℤ
+    have key := Algebra.discr_mul_isIntegral_mem_adjoin (R := ℤ) (K := ℚ) (L := K) (B := pb)
+      hgenint (z := (b : K)) (b.isIntegral_coe)
+    rw [hdiscr, hgenθ] at key
+    -- `key : ((4d:ℤ):ℚ) • (b:K) ∈ adjoin ℤ {(θ:K)}`; bridge back into `𝓞 K`.
+    let f : (𝓞 K) →ₐ[ℤ] K := IsScalarTower.toAlgHom ℤ (𝓞 K) K
+    have hfθ : f θ = (θ : K) := rfl
+    have hAmap : (Algebra.adjoin ℤ {θ}).map f = Algebra.adjoin ℤ {(θ : K)} := by
+      rw [← Algebra.adjoin_image, Set.image_singleton, hfθ]
+    have himg : ((4 * d : ℤ) : ℚ) • (b : K) = f (algebraMap ℤ (𝓞 K) (4 * d) * b) := by
+      have key1 : f (algebraMap ℤ (𝓞 K) (4 * d) * b) = algebraMap ℤ K (4 * d) * (b : K) := by
+        rw [map_mul, IsScalarTower.coe_toAlgHom', ← IsScalarTower.algebraMap_apply ℤ (𝓞 K) K]
+      rw [key1, Algebra.smul_def]
+      simp
+    rw [himg, ← hAmap] at key
+    obtain ⟨y, hyA, hyeq⟩ := key
+    rwa [(FaithfulSMul.algebraMap_injective (𝓞 K) K) hyeq] at hyA
+  have hdvd : exponent θ ∣ (4 * d).natAbs := by
+    have hmem' : (4 * d : ℤ) ∈ under ℤ (conductor ℤ θ) := Ideal.mem_comap.mpr hmem
+    rw [← Int.ideal_span_absNorm_eq_self (under ℤ (conductor ℤ θ)),
+      Ideal.mem_span_singleton] at hmem'
+    have h : absNorm (under ℤ (conductor ℤ θ)) ∣ (4 * d).natAbs := by
+      simpa using Int.natAbs_dvd_natAbs.mpr hmem'
+    exact h
+  -- `p` odd and `p ∤ d` ⟹ `p ∤ 4d` ⟹ `p ∤ exponent`.
+  intro hp
+  have hp4d : (p : ℤ) ∣ 4 * d := by
+    have h := Int.natCast_dvd_natCast.mpr (hp.trans hdvd)
+    rwa [Int.dvd_natAbs] at h
+  rcases (Nat.prime_iff_prime_int.mp (Fact.out : p.Prime)).dvd_mul.mp hp4d with h4 | hd
+  · have hp4 : p ∣ 4 := by exact_mod_cast h4
+    have hp2 : p ∣ 2 := (Fact.out : p.Prime).dvd_of_dvd_pow (by simpa using hp4 : p ∣ 2 ^ 2)
+    exact hodd ((Nat.prime_dvd_prime_iff_eq Fact.out Nat.prime_two).mp hp2)
+  · exact hcop hd
+
+omit [NumberField K] in
+/-- **Factor count mod p.** `X² - d` has two monic irreducible factors mod `p` (for `p` odd,
+`p ∤ d`) iff `d` is a square mod `p`. -/
+theorem card_monicFactorsMod_quadratic {θ : 𝓞 K} {d : ℤ}
+    (hmin : minpoly ℤ θ = X ^ 2 - C d) {p : ℕ} [Fact p.Prime] (hodd : p ≠ 2)
+    (hcop : ¬ (p : ℤ) ∣ d) :
+    (monicFactorsMod θ p).card = 2 ↔ legendreSym p d = 1 := by
+  classical
+  have hc0 : (d : ZMod p) ≠ 0 := by rw [Ne, ZMod.intCast_zmod_eq_zero_iff_dvd]; exact hcop
+  have h2 : (2 : ZMod p) ≠ 0 := by
+    have hnd : ¬ (p ∣ 2) := fun h => hodd ((Nat.prime_dvd_prime_iff_eq Fact.out Nat.prime_two).mp h)
+    intro h0
+    exact hnd ((CharP.cast_eq_zero_iff (ZMod p) p 2).mp (by exact_mod_cast h0))
+  have hmap : (minpoly ℤ θ).map (Int.castRingHom (ZMod p)) = X ^ 2 - C (d : ZMod p) := by
+    rw [hmin]; simp [Polynomial.map_sub, Polynomial.map_pow]
+  rw [legendreSym.eq_one_iff p hc0]
+  simp only [monicFactorsMod, hmap]
+  constructor
+  · intro hcard
+    by_contra hns
+    have hirr : Irreducible (X ^ 2 - C (d : ZMod p)) :=
+      (X_pow_sub_C_irreducible_iff_of_prime Nat.prime_two).mpr
+        (fun b hb => hns ⟨b, by rw [← hb]; ring⟩)
+    rw [normalizedFactors_irreducible hirr] at hcard
+    simp at hcard
+  · rintro ⟨a, ha⟩
+    have ha0 : a ≠ 0 := fun h => hc0 (by rw [ha, h]; ring)
+    have hane : a ≠ -a := by
+      intro h
+      have h2a : (2 : ZMod p) * a = 0 := by linear_combination h
+      exact ha0 ((mul_eq_zero.mp h2a).resolve_left h2)
+    have hfac : X ^ 2 - C (d : ZMod p) = (X - C a) * (X - C (-a)) := by
+      rw [ha]; simp only [map_mul, map_neg]; ring
+    rw [hfac, normalizedFactors_mul (X_sub_C_ne_zero a) (X_sub_C_ne_zero (-a)),
+      normalizedFactors_irreducible (irreducible_X_sub_C a),
+      normalizedFactors_irreducible (irreducible_X_sub_C (-a)),
+      (monic_X_sub_C a).normalize_eq_self, (monic_X_sub_C (-a)).normalize_eq_self,
+      Multiset.toFinset_add, Multiset.toFinset_singleton, Multiset.toFinset_singleton,
+      Finset.card_union_of_disjoint (Finset.disjoint_singleton.mpr (by
+        rw [Ne, sub_right_inj, C_inj]; exact hane))]
+    simp
+
+/-- **The quadratic splitting law.** For `K = ℚ(√d)` (`θ` a square root of the integer `d`
+generating `K`) and an odd prime `p ∤ d`, `p` splits completely in `K` iff `d` is a quadratic
+residue mod `p`. This is the `n = 1` case of the multiquadratic prime-splitting law. -/
+theorem quadratic_ncard_primesOver_iff {θ : 𝓞 K} {d : ℤ}
+    (hmin : minpoly ℤ θ = X ^ 2 - C d) (hgen : Algebra.adjoin ℚ {(θ : K)} = ⊤)
+    {p : ℕ} [Fact p.Prime] (hodd : p ≠ 2) (hcop : ¬ (p : ℤ) ∣ d) :
+    Nat.card (primesOver (span {(p : ℤ)}) (𝓞 K)) = finrank ℚ K ↔ legendreSym p d = 1 := by
+  have hp := not_dvd_exponent_of_minpoly_quadratic hmin hgen hodd hcop
+  have hintθℚ : IsIntegral ℚ (θ : K) := θ.isIntegral_coe.tower_top
+  have hfr : finrank ℚ K = 2 := by
+    rw [(PowerBasis.ofAdjoinEqTop' hintθℚ hgen).finrank,
+      ← (PowerBasis.ofAdjoinEqTop' hintθℚ hgen).natDegree_minpoly,
+      PowerBasis.ofAdjoinEqTop'_gen,
+      minpoly.isIntegrallyClosed_eq_field_fractions ℚ K (IsIntegralClosure.isIntegral ℤ K θ),
+      hmin, Polynomial.map_sub, Polynomial.map_pow, map_X, Polynomial.map_C,
+      natDegree_X_pow_sub_C]
+  have hcard : Nat.card (primesOver (span {(p : ℤ)}) (𝓞 K)) = (monicFactorsMod θ p).card := by
+    rw [Nat.card_congr (primesOverSpanEquivMonicFactorsMod hp)]
+    exact Nat.card_eq_finsetCard _
+  rw [hcard, hfr]
+  exact card_monicFactorsMod_quadratic hmin hodd hcop
+
+end TauCeti.NumberField


### PR DESCRIPTION
This PR proves the prime-splitting law for a quadratic field, the base case (`n = 1`) of the multiquadratic prime-splitting law that is Layer 1 of the multiquadratic roadmap. For `K = ℚ(√d)` — presented as a number field generated over `ℚ` by an algebraic integer `θ` with `minpoly ℤ θ = X² - d` — and an odd prime `p ∤ d`, `TauCeti.NumberField.quadratic_ncard_primesOver_iff` shows `p` splits completely in `K` (there are `[K:ℚ]` primes of `𝓞 K` above `p`) if and only if `legendreSym p d = 1`.

The argument routes through Mathlib's number-field Kummer–Dedekind theorem (`primesOverSpanEquivMonicFactorsMod`): the primes above `p` biject with the monic irreducible factors of `X² - d` mod `p`, of which there are two exactly when `d` is a square mod `p`. The conductor hypothesis `p ∤ exponent θ` is discharged by `not_dvd_exponent_of_minpoly_quadratic`, which bounds the conductor exponent by the power-basis discriminant `4d` (via `Algebra.discr_mul_isIntegral_mem_adjoin`) and uses `p` odd, `p ∤ d`.

This discharges the `n = 1` case of the Layer-1 prime-splitting target of the multiquadratic roadmap; the general multiquadratic compositum case follows in a later PR.

🤖 Prepared with Claude Code