### PR TITLE
feat: bump-guard — machine-validate forward-only Lake-pin / toolchain bumps

### DIFF
--- a/.github/workflows/bump-guard.yml
+++ b/.github/workflows/bump-guard.yml
@@ -1,0 +1,86 @@
+name: bump-guard
+
+# Validates that a PR's change to lake-manifest.json / lean-toolchain is a safe,
+# machine-checkable *forward* bump (mathlib moved forward on the branch nominated
+# in lakefile.toml; transitive pins derived from mathlib; toolchain monotonic and
+# consistent), and posts a `bump-guard` commit status. This status is what lets
+# pr-build build, and the review auto-merge accept, a manifest/toolchain-only PR
+# without a human — see Scripts/check-bump.sh for the full contract.
+#
+# Runs in a TRUSTED, base-defined workflow (pull_request_target): the validator is
+# always the base's Scripts/check-bump.sh, run against the base config and the PR's
+# (text-only) lean-toolchain/lake-manifest.json/lakefile. It executes NONE of the
+# PR's code — only reads two files and queries the trusted mathlib repo via gh api.
+# A PR that changes neither file passes trivially, so the check is uniformly present.
+
+on:
+  pull_request_target:
+    types: [opened, synchronize, reopened]
+  workflow_dispatch:
+    inputs:
+      pr: { description: "PR number to validate", required: true, type: string }
+
+permissions:
+  contents: read
+  statuses: write
+
+concurrency:
+  group: bump-guard-${{ github.event.pull_request.number || inputs.pr }}
+  cancel-in-progress: true
+
+jobs:
+  guard:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Resolve PR head
+        id: pr
+        env: { GH_TOKEN: "${{ github.token }}" }
+        run: |
+          if [ "${{ github.event_name }}" = "pull_request_target" ]; then
+            NUM='${{ github.event.pull_request.number }}'
+            SHA='${{ github.event.pull_request.head.sha }}'
+            REPO='${{ github.event.pull_request.head.repo.full_name }}'
+          else
+            NUM='${{ inputs.pr }}'
+            SHA=$(gh api "repos/${{ github.repository }}/pulls/$NUM" --jq .head.sha)
+            REPO=$(gh api "repos/${{ github.repository }}/pulls/$NUM" --jq .head.repo.full_name)
+          fi
+          echo "num=$NUM"   >> "$GITHUB_OUTPUT"
+          echo "sha=$SHA"   >> "$GITHUB_OUTPUT"
+          echo "repo=$REPO" >> "$GITHUB_OUTPUT"
+          echo "Validating PR #$NUM @ $SHA from $REPO"
+
+      - name: Checkout base (trusted — the validator and base config)
+        uses: actions/checkout@v4
+        with: { path: base, persist-credentials: false }
+
+      - name: Checkout PR head (untrusted, no credentials — read as text only)
+        uses: actions/checkout@v4
+        with:
+          repository: ${{ steps.pr.outputs.repo }}
+          ref: ${{ steps.pr.outputs.sha }}
+          path: pr
+          persist-credentials: false
+
+      - name: Validate forward-only bump (trusted base validator)
+        id: guard
+        env: { GH_TOKEN: "${{ github.token }}" }
+        run: |
+          # The base copy of the script and base config are trusted; only the
+          # PR's lean-toolchain/lake-manifest.json/lakefile.* are read from pr/.
+          bash base/Scripts/check-bump.sh base pr
+
+      - name: Report bump-guard status to the PR head commit
+        if: always()
+        env: { GH_TOKEN: "${{ github.token }}" }
+        run: |
+          if [ "${{ steps.guard.outcome }}" = "success" ]; then
+            state=success; desc="forward-only Lake-pin / toolchain bump (or no pin change)"
+          else
+            state=failure; desc="manifest/toolchain change is not a validated forward bump — needs human review"
+          fi
+          gh api -X POST "repos/${{ github.repository }}/statuses/${{ steps.pr.outputs.sha }}" \
+            -f state="$state" -f context="bump-guard" -f description="$desc" \
+            -f target_url="${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+          echo "posted bump-guard=$state ($desc) to ${{ steps.pr.outputs.sha }}"
+          [ "$state" = "success" ]

--- a/.github/workflows/pr-build.yml
+++ b/.github/workflows/pr-build.yml
@@ -195,7 +195,13 @@ jobs:
             echo "::error::landrun not enforcing (run=$ok write=$wr shm=$shm net=$net); refusing to run PR code"; exit 1
           fi
 
-      - name: Fetch Mathlib with the trusted base config (network; no PR code)
+      # `lake exe cache get` runs the `cache` exe built from the pinned Mathlib, unsandboxed,
+      # with network (to download oleans) but deliberately NO token in env. For a normal PR that
+      # is the trusted base Mathlib. For a validated bump it is the PR's Mathlib pin — which
+      # bump-guard proved is a *forward commit on Mathlib's own master* (same repo, never a fork),
+      # so the code run here is still trusted Mathlib master under the project's "track master"
+      # policy; only the PR's TauCeti/ code stays untrusted and runs solely under landrun below.
+      - name: Fetch Mathlib with the (bump-validated) config (network, no token; no PR code)
         if: ${{ env.INFRA != '1' }}
         run: ( cd base && lake exe cache get ) && mkdir -p base/.lake/tmp
 

--- a/.github/workflows/pr-build.yml
+++ b/.github/workflows/pr-build.yml
@@ -62,11 +62,20 @@ jobs:
           # the root), it is overlaid into the sandbox below, and the import-boundary
           # guard covers it. Everything else outside TauCeti/ (lakefile, Scripts/,
           # .github/) stays trusted-base-only and routes to a human.
+          # lake-manifest.json and lean-toolchain are also permitted, but ONLY as a
+          # machine-validated forward bump: the "Validate the Lake-pin bump" step below
+          # runs the trusted base Scripts/check-bump.sh and routes to a human if it is
+          # anything other than a forward move (mathlib forward on its nominated branch,
+          # transitive pins derived from mathlib, toolchain monotonic). lakefile.* stays
+          # human-owned (and check-bump fails if it changed).
           if [ -z "$files" ]; then
             echo "INFRA=1" >> "$GITHUB_ENV"; echo "::warning::no files / unable to list — routing to human"
-          elif echo "$files" | grep -vqE '^TauCeti/|^TauCeti\.lean$'; then
+          elif echo "$files" | grep -vqE '^TauCeti/|^TauCeti\.lean$|^lake-manifest\.json$|^lean-toolchain$'; then
             echo "INFRA=1" >> "$GITHUB_ENV"
-            echo "::warning::PR changes paths outside TauCeti/ (infra) — not sandbox-built; needs human review"
+            echo "::warning::PR changes paths outside TauCeti/ + Lake pins (infra) — not sandbox-built; needs human review"
+          elif echo "$files" | grep -qE '^lake-manifest\.json$|^lean-toolchain$'; then
+            echo "BUMP=1" >> "$GITHUB_ENV"
+            echo "::notice::PR changes Lake pins — validating as a forward bump before building"
           fi
 
       - name: Diff size guard — additions, deletions, and changed files each ≤ 2000 (trusted GitHub PR totals)
@@ -105,6 +114,24 @@ jobs:
           path: pr
           persist-credentials: false
 
+      # For a Lake-pin PR, validate it is a safe forward bump BEFORE overlaying its
+      # pins or building. The validator is always the TRUSTED base copy of the script,
+      # run against the base config and the PR's (text-only) pin files; it executes no
+      # PR code. An invalid/backward/forked bump sets INFRA=1 → not built, routed to a
+      # human. (Run inline, not by reading the separate bump-guard status, to avoid a
+      # race with that concurrently-running workflow.)
+      - name: Validate the Lake-pin bump (trusted base validator) before building
+        if: ${{ env.INFRA != '1' && env.BUMP == '1' }}
+        env: { GH_TOKEN: "${{ github.token }}" }
+        run: |
+          if bash base/Scripts/check-bump.sh base pr; then
+            echo "Lake-pin bump validated — building with the PR's pins."
+          else
+            echo "BUMP_BAD=1" >> "$GITHUB_ENV"
+            echo "INFRA=1" >> "$GITHUB_ENV"
+            echo "::warning::Lake-pin change is not a validated forward bump — routing to human"
+          fi
+
       - name: Overlay PR TauCeti/ and root TauCeti.lean onto the trusted base (reject symlinks)
         if: ${{ env.INFRA != '1' }}
         run: |
@@ -120,6 +147,15 @@ jobs:
           if [ -e pr/TauCeti.lean ]; then
             test ! -L pr/TauCeti.lean || { echo "::error::TauCeti.lean must not be a symlink"; exit 1; }
             cp -a pr/TauCeti.lean base/TauCeti.lean
+          fi
+          # For a validated forward bump, overlay the PR's Lake pins too, so the build
+          # below actually exercises the new mathlib/toolchain (check-bump already
+          # verified these are a safe forward move; lakefile.* is unchanged).
+          if [ "${BUMP:-}" = "1" ]; then
+            for f in lake-manifest.json lean-toolchain; do
+              if [ -L "pr/$f" ]; then echo "::error::$f must not be a symlink"; exit 1; fi
+              [ -e "pr/$f" ] && cp -a "pr/$f" "base/$f"
+            done
           fi
 
       - name: Import-boundary guard (TauCeti/ and TauCeti.lean ⊬ roadmap/review)
@@ -183,7 +219,9 @@ jobs:
         if: always()
         env: { GH_TOKEN: "${{ github.token }}" }
         run: |
-          if [ "${{ env.INFRA }}" = "1" ]; then
+          if [ "${{ env.BUMP_BAD }}" = "1" ]; then
+            state=failure; desc="Lake-pin change is not a validated forward bump — human review + merge required"
+          elif [ "${{ env.INFRA }}" = "1" ]; then
             state=failure; desc="changes outside TauCeti/ — human review + merge required"
           elif [ "${{ env.TOO_LARGE }}" = "1" ]; then
             state=failure; desc="diff exceeds 2000 added/removed lines or 2000 files — split into smaller PRs to keep review manageable"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -18,8 +18,12 @@ roadmap first, rather than building it here.
   Mathlib linter set (style, file length, no `maxHeartbeats` overrides). Do not try to disable
   these.
 - One topic per PR. Ship a prerequisite refactor as its own PR.
-- `TauCeti/` is the only place code goes; everything else (`Scripts/`, `.github/`, the Lake
-  config) is human-owned.
+- `TauCeti/` is the only place code goes. `Scripts/`, `.github/`, and the lakefile
+  (`lakefile.toml`/`lakefile.lean`) are human-owned. The two Lake *pins* —
+  `lake-manifest.json` and `lean-toolchain` — are an exception: a **forward-only** bump of
+  them (Mathlib moving forward on the branch the lakefile nominates, with the toolchain moving
+  monotonically forward) is machine-validated by the `bump-guard` check and is welcome, but
+  never edit the lakefile or move a pin backward.
 
 ## How review works
 
@@ -30,8 +34,10 @@ verdicts. Address their findings and push; re-review runs automatically on new c
 human can comment `/review` to re-trigger.
 
 When every rubric approves on the current commit and the PR changes only `TauCeti/` (with CI
-green), it **merges automatically**. A PR that touches human-owned paths (`Scripts/`,
-`.github/`, the Lake config) always needs a human review. The review pipeline is sandboxed so
-it can run on untrusted PRs; see
+green), it **merges automatically**. A PR that *also* changes `lake-manifest.json` and/or
+`lean-toolchain` can auto-merge too, but only once the `bump-guard` check confirms it is a
+forward-only bump and the sandboxed build passes against the new pins. A PR that touches any
+other human-owned path (`Scripts/`, `.github/`, the lakefile) always needs a human review. The
+review pipeline is sandboxed so it can run on untrusted PRs; see
 [`SECURITY.md`](https://github.com/FormalFrontier/TauCetiReview/blob/main/SECURITY.md) in
 TauCetiReview.

--- a/Scripts/check-bump.sh
+++ b/Scripts/check-bump.sh
@@ -12,11 +12,16 @@
 #
 #   1. lakefile.toml / lakefile.lean are byte-identical to base (lakefile edits
 #      stay human-owned; they change which branch/dep is even nominated).
-#   2. The nominated require (mathlib) keeps its url + inputRev (master), and its
-#      new rev is a *descendant of the old rev* AND *on inputRev's history* — a
-#      genuine forward move on the nominated branch (via the GitHub compare API).
-#   3. Every other git pin equals mathlib's OWN lake-manifest at the new rev, so
-#      transitive deps can't be re-pointed independently of the trusted mathlib.
+#   2. The nominated require (mathlib) is the ONLY package named "mathlib", is a
+#      `git` package pinned to a 40-hex commit SHA, keeps its url + inputRev
+#      (master), and its new rev is a *descendant of the old rev* AND *on
+#      inputRev's history* — a genuine forward move on the nominated branch (via
+#      the GitHub compare API; the SHA requirement makes the compared revs
+#      immutable, so what we validate is exactly what Lake will resolve and build).
+#   3. The PR manifest's package set, MINUS mathlib, is EXACTLY mathlib's own
+#      lake-manifest at the new rev, field-for-field (type/url/rev/inputRev) — no
+#      package added, removed, renamed, retyped (e.g. a `path` dep), duplicated, or
+#      re-pointed independently of the trusted mathlib.
 #   4. lean-toolchain moves monotonically forward on the leanprover/lean4 channel
 #      AND equals mathlib's lean-toolchain at the new rev.
 #
@@ -48,31 +53,39 @@ for f in lakefile.toml lakefile.lean; do
 done
 
 # --- helpers ------------------------------------------------------------------
-# Emit "name<TAB>url<TAB>rev<TAB>inputRev" for every git package in a manifest.
-manifest_git() {
-  python3 - "$1" <<'PY'
-import json,sys
-m=json.load(open(sys.argv[1]))
-for p in m.get("packages",[]):
-    if p.get("type")=="git":
-        print("\t".join([p.get("name",""),
-                         (p.get("url") or "").rstrip("/").removesuffix(".git"),
-                         p.get("rev",""), p.get("inputRev") or ""]))
-PY
-}
 # owner/repo slug from a github url
 slug() { sed -E 's#^https?://github.com/##; s#/$##; s#\.git$##' <<<"$1"; }
 
-BASE_GIT="$(manifest_git "$BASE/lake-manifest.json")" || fail "cannot parse base lake-manifest.json"
-PR_GIT="$(manifest_git "$PR/lake-manifest.json")"     || fail "cannot parse PR lake-manifest.json"
+# Print "url<TAB>rev<TAB>inputRev" for THE mathlib package in <file>, after asserting:
+# exactly one package named mathlib, of type git, with a 40-hex commit-SHA rev. Any
+# violation prints "ERROR: ..." and exits 1 (so the caller can `|| fail`).
+mathlib_of() {
+  python3 - "$1" <<'PY'
+import json,sys,re
+try:
+    m=json.load(open(sys.argv[1]))
+except Exception as e:
+    print(f"ERROR: cannot parse manifest: {e}"); sys.exit(1)
+pkgs=m.get("packages",[])
+names=[p.get("name") for p in pkgs]
+dups=sorted({n for n in names if names.count(n)>1})
+if dups: print(f"ERROR: duplicate package names in manifest: {dups}"); sys.exit(1)
+ml=[p for p in pkgs if p.get("name")=="mathlib"]
+if len(ml)!=1: print(f"ERROR: expected exactly one 'mathlib' package, found {len(ml)}"); sys.exit(1)
+p=ml[0]
+if p.get("type")!="git": print(f"ERROR: mathlib package is not type git (got {p.get('type')!r})"); sys.exit(1)
+rev=p.get("rev") or ""
+if not re.fullmatch(r"[0-9a-f]{40}", rev): print(f"ERROR: mathlib rev {rev!r} is not a 40-hex commit SHA"); sys.exit(1)
+url=(p.get("url") or "").rstrip("/")
+if url.endswith(".git"): url=url[:-4]
+print("\t".join([url, rev, p.get("inputRev") or ""]))
+PY
+}
 
-# --- locate mathlib in both manifests -----------------------------------------
-ml_base="$(awk -F'\t' '$1=="mathlib"{print; exit}' <<<"$BASE_GIT")"
-ml_pr="$(awk   -F'\t' '$1=="mathlib"{print; exit}' <<<"$PR_GIT")"
-[ -n "$ml_base" ] || fail "no mathlib git package in base manifest"
-[ -n "$ml_pr" ]   || fail "no mathlib git package in PR manifest"
-IFS=$'\t' read -r _ ML_URL_B ML_REV_B ML_IR_B <<<"$ml_base"
-IFS=$'\t' read -r _ ML_URL_P ML_REV_P ML_IR_P <<<"$ml_pr"
+ml_base="$(mathlib_of "$BASE/lake-manifest.json")" || fail "base manifest: ${ml_base#ERROR: }"
+ml_pr="$(mathlib_of   "$PR/lake-manifest.json")"   || fail "PR manifest: ${ml_pr#ERROR: }"
+IFS=$'\t' read -r ML_URL_B ML_REV_B ML_IR_B <<<"$ml_base"
+IFS=$'\t' read -r ML_URL_P ML_REV_P ML_IR_P <<<"$ml_pr"
 
 [ "$ML_URL_B" = "$ML_URL_P" ] || fail "mathlib url changed ($ML_URL_B -> $ML_URL_P) — repo swap is human-owned"
 [ "$ML_IR_B"  = "$ML_IR_P"  ] || fail "mathlib inputRev (nominated branch) changed ($ML_IR_B -> $ML_IR_P) — human-owned"
@@ -81,8 +94,8 @@ ML_SLUG="$(slug "$ML_URL_P")"
 # --- 2. mathlib moved forward on the nominated branch -------------------------
 if [ "$ML_REV_B" = "$ML_REV_P" ]; then
   # mathlib pin unchanged: then NOTHING in the manifest may change (the rest is derived from it).
-  if [ "$BASE_GIT" != "$PR_GIT" ]; then
-    fail "mathlib rev unchanged but other manifest pins changed — not a derived bump"
+  if ! diff -q "$BASE/lake-manifest.json" "$PR/lake-manifest.json" >/dev/null 2>&1; then
+    fail "mathlib rev unchanged but the manifest changed — not a derived bump"
   fi
   echo "bump-guard: mathlib pin unchanged."
 else
@@ -101,21 +114,48 @@ else
   echo "bump-guard: mathlib $ML_REV_B -> $ML_REV_P is a forward move on '$ML_IR_P'."
 fi
 
-# --- 3. every other pin equals mathlib's own manifest at the new rev ----------
+# --- 3. the rest of the manifest is EXACTLY mathlib's own manifest at the new rev
 ML_MANIFEST="$(gh api "repos/$ML_SLUG/contents/lake-manifest.json?ref=$ML_REV_P" --jq '.content' 2>/dev/null | base64 -d)" \
   || fail "cannot fetch mathlib lake-manifest.json at $ML_REV_P"
-ML_GIT="$(manifest_git <(printf '%s' "$ML_MANIFEST"))" || fail "cannot parse mathlib manifest at $ML_REV_P"
+ML_TMP="$(mktemp)"; trap 'rm -f "$ML_TMP"' EXIT
+printf '%s' "$ML_MANIFEST" > "$ML_TMP"
 
-while IFS=$'\t' read -r name url rev inputrev; do
-  [ -z "$name" ] && continue
-  [ "$name" = "mathlib" ] && continue
-  ml_line="$(awk -F'\t' -v n="$name" '$1==n{print; exit}' <<<"$ML_GIT")"
-  [ -n "$ml_line" ] || fail "PR pins git dep '$name' that mathlib@$ML_REV_P does not depend on"
-  IFS=$'\t' read -r _ m_url m_rev _ <<<"$ml_line"
-  [ "$url" = "$m_url" ] || fail "dep '$name' url ($url) != mathlib's ($m_url) — not a derived pin"
-  [ "$rev" = "$m_rev" ] || fail "dep '$name' rev ($rev) != mathlib@$ML_REV_P's ($m_rev) — not a derived pin"
-done <<<"$PR_GIT"
-echo "bump-guard: all transitive pins match mathlib@$ML_REV_P."
+derived_msg="$(python3 - "$PR/lake-manifest.json" "$ML_TMP" <<'PY'
+import json,sys,re
+def norm_url(u):
+    u=(u or "").rstrip("/")
+    return u[:-4] if u.endswith(".git") else u
+def load(p):
+    return json.load(open(p)).get("packages",[])
+pr, ml = load(sys.argv[1]), load(sys.argv[2])
+
+def tup(p):  # the identity we require to match, field-for-field
+    return (p.get("type"), norm_url(p.get("url")), p.get("rev"), p.get("inputRev"))
+
+# PR manifest: no dup names, every package is git pinned to a 40-hex SHA.
+prnames=[p.get("name") for p in pr]
+dups=sorted({n for n in prnames if prnames.count(n)>1})
+if dups: print(f"duplicate package names in PR manifest: {dups}"); sys.exit(1)
+for p in pr:
+    if p.get("type")!="git":
+        print(f"PR pins non-git package '{p.get('name')}' (type {p.get('type')!r}); only git deps derived from mathlib are allowed"); sys.exit(1)
+    if not re.fullmatch(r"[0-9a-f]{40}", p.get("rev") or ""):
+        print(f"PR dep '{p.get('name')}' rev is not a 40-hex commit SHA"); sys.exit(1)
+
+# The PR's deps, minus mathlib, must be EXACTLY mathlib's own deps — same names, same fields.
+pr_by  = {p.get("name"): p for p in pr if p.get("name")!="mathlib"}
+ml_by  = {p.get("name"): p for p in ml}
+only_pr = sorted(set(pr_by) - set(ml_by))
+only_ml = sorted(set(ml_by) - set(pr_by))
+if only_pr: print(f"PR pins deps mathlib@new does not depend on: {only_pr}"); sys.exit(1)
+if only_ml: print(f"PR is missing deps mathlib@new depends on: {only_ml}"); sys.exit(1)
+for n in pr_by:
+    if tup(pr_by[n]) != tup(ml_by[n]):
+        print(f"dep '{n}' does not match mathlib@new (PR {tup(pr_by[n])} vs mathlib {tup(ml_by[n])})"); sys.exit(1)
+print("OK")
+PY
+)" || fail "${derived_msg:-transitive pins do not match mathlib@$ML_REV_P}"
+echo "bump-guard: all transitive pins match mathlib@$ML_REV_P exactly."
 
 # --- 4. toolchain: monotonic forward AND consistent with mathlib --------------
 TC_B="$(tr -d '[:space:]' <"$BASE/lean-toolchain" 2>/dev/null)"
@@ -124,17 +164,17 @@ TC_P="$(tr -d '[:space:]' <"$PR/lean-toolchain" 2>/dev/null)"
 [ -n "$TC_P" ] || fail "cannot read PR lean-toolchain"
 
 if [ "$TC_B" != "$TC_P" ]; then
-  python3 - "$TC_B" "$TC_P" <<'PY' || exit 1
+  tc_msg="$(python3 - "$TC_B" "$TC_P" <<'PY'
 import re,sys
 def parse(t):
     m=re.fullmatch(r"leanprover/lean4:v(\d+)\.(\d+)\.(\d+)(?:-rc(\d+))?", t)
-    if not m: sys.exit(f"BUMP-GUARD: FAIL — toolchain '{t}' is not a leanprover/lean4 vX.Y.Z[-rcN] release")
+    if not m: print(f"toolchain '{t}' is not a leanprover/lean4 vX.Y.Z[-rcN] release"); sys.exit(1)
     x,y,z,rc=m.groups()
-    # a final release outranks any rc of the same X.Y.Z
-    return (int(x),int(y),int(z), int(rc) if rc is not None else float("inf"))
+    return (int(x),int(y),int(z), int(rc) if rc is not None else float("inf"))  # release > any rc of same X.Y.Z
 b,p=parse(sys.argv[1]),parse(sys.argv[2])
-if p < b: sys.exit(f"BUMP-GUARD: FAIL — toolchain moved backward ({sys.argv[1]} -> {sys.argv[2]})")
+if p < b: print(f"toolchain moved backward ({sys.argv[1]} -> {sys.argv[2]})"); sys.exit(1)
 PY
+  )" || fail "${tc_msg:-toolchain is not a monotonic forward release}"
 fi
 
 ML_TC="$(gh api "repos/$ML_SLUG/contents/lean-toolchain?ref=$ML_REV_P" --jq '.content' 2>/dev/null | base64 -d | tr -d '[:space:]')" \

--- a/Scripts/check-bump.sh
+++ b/Scripts/check-bump.sh
@@ -1,0 +1,145 @@
+#!/usr/bin/env bash
+# check-bump.sh — validate that a PR's proposed Lake-pin / toolchain change is a
+# safe, machine-checkable *forward* bump, and nothing else.
+#
+# This is the trust anchor that lets a PR touching `lake-manifest.json` and/or
+# `lean-toolchain` (but NOT the lakefile) be built and auto-merged without a human:
+# the worry is a PR that re-points a dependency at a malicious fork/commit or a
+# malicious toolchain and then gets auto-built. We reduce the whole manifest to a
+# deterministic function of one validated fact — "mathlib moved forward on the
+# branch nominated in lakefile.toml" — and require the toolchain to move forward
+# and match mathlib's:
+#
+#   1. lakefile.toml / lakefile.lean are byte-identical to base (lakefile edits
+#      stay human-owned; they change which branch/dep is even nominated).
+#   2. The nominated require (mathlib) keeps its url + inputRev (master), and its
+#      new rev is a *descendant of the old rev* AND *on inputRev's history* — a
+#      genuine forward move on the nominated branch (via the GitHub compare API).
+#   3. Every other git pin equals mathlib's OWN lake-manifest at the new rev, so
+#      transitive deps can't be re-pointed independently of the trusted mathlib.
+#   4. lean-toolchain moves monotonically forward on the leanprover/lean4 channel
+#      AND equals mathlib's lean-toolchain at the new rev.
+#
+# It does NO build and runs NONE of the PR's code — only reads/parses two text
+# files and queries the trusted upstream via `gh api`. Usage:
+#
+#   check-bump.sh <base_dir> <pr_dir>
+#
+# where each dir holds the repo's lean-toolchain, lake-manifest.json, lakefile.toml
+# (and optionally lakefile.lean). Exit 0 = safe forward bump (or no pin change);
+# exit 1 = not auto-mergeable (route to a human). Reasons are printed.
+set -uo pipefail
+
+BASE="${1:?usage: check-bump.sh <base_dir> <pr_dir>}"
+PR="${2:?usage: check-bump.sh <base_dir> <pr_dir>}"
+
+fail() { echo "::error::bump-guard: $*"; echo "BUMP-GUARD: FAIL — $*"; exit 1; }
+ok()   { echo "BUMP-GUARD: PASS — $*"; exit 0; }
+
+# --- 1. lakefile is human-owned: it must not change ---------------------------
+for f in lakefile.toml lakefile.lean; do
+  b="$BASE/$f"; p="$PR/$f"
+  # Treat an absent file the same on both sides; a file appearing/vanishing is a change.
+  [ -f "$b" ] || b=/dev/null
+  [ -f "$p" ] || p=/dev/null
+  if ! diff -q "$b" "$p" >/dev/null 2>&1; then
+    fail "$f differs from base — lakefile edits are human-owned and never auto-merge"
+  fi
+done
+
+# --- helpers ------------------------------------------------------------------
+# Emit "name<TAB>url<TAB>rev<TAB>inputRev" for every git package in a manifest.
+manifest_git() {
+  python3 - "$1" <<'PY'
+import json,sys
+m=json.load(open(sys.argv[1]))
+for p in m.get("packages",[]):
+    if p.get("type")=="git":
+        print("\t".join([p.get("name",""),
+                         (p.get("url") or "").rstrip("/").removesuffix(".git"),
+                         p.get("rev",""), p.get("inputRev") or ""]))
+PY
+}
+# owner/repo slug from a github url
+slug() { sed -E 's#^https?://github.com/##; s#/$##; s#\.git$##' <<<"$1"; }
+
+BASE_GIT="$(manifest_git "$BASE/lake-manifest.json")" || fail "cannot parse base lake-manifest.json"
+PR_GIT="$(manifest_git "$PR/lake-manifest.json")"     || fail "cannot parse PR lake-manifest.json"
+
+# --- locate mathlib in both manifests -----------------------------------------
+ml_base="$(awk -F'\t' '$1=="mathlib"{print; exit}' <<<"$BASE_GIT")"
+ml_pr="$(awk   -F'\t' '$1=="mathlib"{print; exit}' <<<"$PR_GIT")"
+[ -n "$ml_base" ] || fail "no mathlib git package in base manifest"
+[ -n "$ml_pr" ]   || fail "no mathlib git package in PR manifest"
+IFS=$'\t' read -r _ ML_URL_B ML_REV_B ML_IR_B <<<"$ml_base"
+IFS=$'\t' read -r _ ML_URL_P ML_REV_P ML_IR_P <<<"$ml_pr"
+
+[ "$ML_URL_B" = "$ML_URL_P" ] || fail "mathlib url changed ($ML_URL_B -> $ML_URL_P) — repo swap is human-owned"
+[ "$ML_IR_B"  = "$ML_IR_P"  ] || fail "mathlib inputRev (nominated branch) changed ($ML_IR_B -> $ML_IR_P) — human-owned"
+ML_SLUG="$(slug "$ML_URL_P")"
+
+# --- 2. mathlib moved forward on the nominated branch -------------------------
+if [ "$ML_REV_B" = "$ML_REV_P" ]; then
+  # mathlib pin unchanged: then NOTHING in the manifest may change (the rest is derived from it).
+  if [ "$BASE_GIT" != "$PR_GIT" ]; then
+    fail "mathlib rev unchanged but other manifest pins changed — not a derived bump"
+  fi
+  echo "bump-guard: mathlib pin unchanged."
+else
+  st_fwd="$(gh api "repos/$ML_SLUG/compare/$ML_REV_B...$ML_REV_P" --jq '.status' 2>/dev/null)" \
+    || fail "compare API failed for $ML_SLUG $ML_REV_B...$ML_REV_P"
+  case "$st_fwd" in
+    ahead) : ;;  # new strictly descends from old — forward
+    *) fail "mathlib rev is not a forward move from base (compare status: ${st_fwd:-unknown}); old=$ML_REV_B new=$ML_REV_P" ;;
+  esac
+  st_branch="$(gh api "repos/$ML_SLUG/compare/$ML_REV_P...$ML_IR_P" --jq '.status' 2>/dev/null)" \
+    || fail "compare API failed for $ML_SLUG $ML_REV_P...$ML_IR_P"
+  case "$st_branch" in
+    ahead|identical) : ;;  # the nominated branch tip is at-or-ahead of new — new is on its history
+    *) fail "mathlib new rev $ML_REV_P is not on branch '$ML_IR_P' (compare status: ${st_branch:-unknown})" ;;
+  esac
+  echo "bump-guard: mathlib $ML_REV_B -> $ML_REV_P is a forward move on '$ML_IR_P'."
+fi
+
+# --- 3. every other pin equals mathlib's own manifest at the new rev ----------
+ML_MANIFEST="$(gh api "repos/$ML_SLUG/contents/lake-manifest.json?ref=$ML_REV_P" --jq '.content' 2>/dev/null | base64 -d)" \
+  || fail "cannot fetch mathlib lake-manifest.json at $ML_REV_P"
+ML_GIT="$(manifest_git <(printf '%s' "$ML_MANIFEST"))" || fail "cannot parse mathlib manifest at $ML_REV_P"
+
+while IFS=$'\t' read -r name url rev inputrev; do
+  [ -z "$name" ] && continue
+  [ "$name" = "mathlib" ] && continue
+  ml_line="$(awk -F'\t' -v n="$name" '$1==n{print; exit}' <<<"$ML_GIT")"
+  [ -n "$ml_line" ] || fail "PR pins git dep '$name' that mathlib@$ML_REV_P does not depend on"
+  IFS=$'\t' read -r _ m_url m_rev _ <<<"$ml_line"
+  [ "$url" = "$m_url" ] || fail "dep '$name' url ($url) != mathlib's ($m_url) — not a derived pin"
+  [ "$rev" = "$m_rev" ] || fail "dep '$name' rev ($rev) != mathlib@$ML_REV_P's ($m_rev) — not a derived pin"
+done <<<"$PR_GIT"
+echo "bump-guard: all transitive pins match mathlib@$ML_REV_P."
+
+# --- 4. toolchain: monotonic forward AND consistent with mathlib --------------
+TC_B="$(tr -d '[:space:]' <"$BASE/lean-toolchain" 2>/dev/null)"
+TC_P="$(tr -d '[:space:]' <"$PR/lean-toolchain" 2>/dev/null)"
+[ -n "$TC_B" ] || fail "cannot read base lean-toolchain"
+[ -n "$TC_P" ] || fail "cannot read PR lean-toolchain"
+
+if [ "$TC_B" != "$TC_P" ]; then
+  python3 - "$TC_B" "$TC_P" <<'PY' || exit 1
+import re,sys
+def parse(t):
+    m=re.fullmatch(r"leanprover/lean4:v(\d+)\.(\d+)\.(\d+)(?:-rc(\d+))?", t)
+    if not m: sys.exit(f"BUMP-GUARD: FAIL — toolchain '{t}' is not a leanprover/lean4 vX.Y.Z[-rcN] release")
+    x,y,z,rc=m.groups()
+    # a final release outranks any rc of the same X.Y.Z
+    return (int(x),int(y),int(z), int(rc) if rc is not None else float("inf"))
+b,p=parse(sys.argv[1]),parse(sys.argv[2])
+if p < b: sys.exit(f"BUMP-GUARD: FAIL — toolchain moved backward ({sys.argv[1]} -> {sys.argv[2]})")
+PY
+fi
+
+ML_TC="$(gh api "repos/$ML_SLUG/contents/lean-toolchain?ref=$ML_REV_P" --jq '.content' 2>/dev/null | base64 -d | tr -d '[:space:]')" \
+  || fail "cannot fetch mathlib lean-toolchain at $ML_REV_P"
+[ "$TC_P" = "$ML_TC" ] || fail "PR lean-toolchain ($TC_P) != mathlib@$ML_REV_P's ($ML_TC)"
+echo "bump-guard: toolchain $TC_B -> $TC_P is forward and matches mathlib@$ML_REV_P."
+
+ok "forward-only bump validated (mathlib on '$ML_IR_P', derived transitive pins, toolchain consistent)"


### PR DESCRIPTION
This PR adds a trusted CI guard, `bump-guard`, so that a PR which changes only `TauCeti/` plus the two Lake *pins* (`lake-manifest.json` and `lean-toolchain`) can be sandbox-built and — once review approves — auto-merged without a human, while the lakefile itself stays human-owned. Today every Lake-config change is routed to a human; this makes routine forward Mathlib/toolchain bumps machine-validated instead.

`Scripts/check-bump.sh` reduces the whole manifest to one machine-checkable fact: Mathlib moved *forward* on the branch nominated in `lakefile.toml` (checked via the GitHub compare API — the new rev descends from the old one and is on the nominated branch). It then ties every transitive pin to Mathlib's own `lake-manifest.json` at that rev, so a dependency cannot be re-pointed independently of the trusted Mathlib, and requires `lean-toolchain` to move monotonically forward on the `leanprover/lean4` channel and to match Mathlib's toolchain. It executes none of the PR's code — it only reads two text files and queries the trusted Mathlib repo — and it fails outright if `lakefile.toml`/`lakefile.lean` changed.

`.github/workflows/bump-guard.yml` runs that validator in a trusted, base-defined `pull_request_target` workflow and posts a `bump-guard` commit status (a PR touching neither pin file passes trivially, so the check is uniformly present). `pr-build.yml` now permits the two pin files, validates them inline with the same trusted validator — run inline rather than by reading bump-guard's status, to avoid a race with that concurrently-running workflow — overlays the validated pins onto the trusted base, and builds against them under landrun. An invalid or backward bump still sets `INFRA=1` and is routed to a human. `AGENTS.md` documents the forward-only exception.

This is the foundational piece of a three-repo change; the matching TauCetiReview change (let the auto-merge arbiter accept PRs touching only `TauCeti/` + these two pins) and the TauCetiWorker change (a proactive bump task) follow in their own PRs. [FormalFrontier/TauCeti#162](https://github.com/FormalFrontier/TauCeti/pull/162) is a real forward bump that validates green under `check-bump.sh` locally and is the natural first end-to-end test.

🤖 Prepared with Claude Code