### PR TITLE
fix: post mk-all status with GITHUB_TOKEN, not the App token

### DIFF
--- a/.github/workflows/mk-all.yml
+++ b/.github/workflows/mk-all.yml
@@ -7,6 +7,11 @@ name: mk-all
 #   - fork PR              -> fail the `mk-all` check with instructions (we can't push to a fork).
 # The push uses the GitHub App token (not GITHUB_TOKEN, whose pushes don't re-trigger CI), so
 # the corrected head gets a fresh build/review; the next mk-all run finds it in sync and stops.
+# The commit-status POST, by contrast, uses GITHUB_TOKEN: it already carries `statuses: write`
+# here, whereas the App installation does not, so posting with the App token 403s ("Resource not
+# accessible by integration") and — under the runner's `bash -e` — that 403 would fail the job
+# even when the aggregator is perfectly in sync. Posting a status never re-triggers CI, so there
+# is no reason to spend the App token on it.
 #
 # Security: this is a pull_request_target job with a write token, so it treats EVERY
 # PR-controlled value as hostile. Such values are never spliced into a `run:` script via
@@ -89,7 +94,9 @@ jobs:
       - name: Push the fix (same-repo) or fail (fork), then report status
         id: sync
         env:
-          GH_TOKEN:  ${{ steps.app-token.outputs.token }}
+          # GITHUB_TOKEN (has `statuses: write` here); the App token lacks it and 403s. The git
+          # push below uses the checkout-managed App credentials, not this token.
+          GH_TOKEN:  ${{ github.token }}
           SAME:      ${{ steps.pr.outputs.same }}
           REF:       ${{ steps.pr.outputs.ref }}
           HEAD_SHA:  ${{ steps.pr.outputs.sha }}
@@ -118,7 +125,10 @@ jobs:
           else
             state=failure; desc="aggregator out of date and PR is from a fork — run Scripts/mk_all.sh and push"
           fi
+          # A status-post hiccup must never red an otherwise-correct sync, so keep it non-fatal;
+          # the job's own conclusion (last line) is the source of truth for the check.
           gh api -X POST "repos/$BASE_REPO/statuses/$status_sha" \
-            -f state="$state" -f context="mk-all" -f description="$desc"
+            -f state="$state" -f context="mk-all" -f description="$desc" \
+            || echo "::warning::could not post mk-all commit status (job conclusion still applies)"
           echo "mk-all=$state ($desc) -> $status_sha"
           [ "$state" = "success" ]


### PR DESCRIPTION
This PR fixes the `sync` (mk-all) check failing on essentially every same-repo PR even when the `TauCeti.lean` aggregator is already in sync. The job regenerates the aggregator and then posts a commit status, but it posted that status with the GitHub App token, which lacks `statuses: write`; the POST returned `403 Resource not accessible by integration`, and because the runner executes the step under `bash -e`, that 403 failed the whole job — independently of whether the aggregator had actually drifted.

The diagnosis on a recent run: `SAME: 1` (correctly detected as same-repo), the `git diff` was empty (in sync), and the only error was the 403 on `POST /repos/.../statuses`. So contributors were seeing a red required check for a file that was correct.

The fix posts the status with `GITHUB_TOKEN`, which the workflow already grants `statuses: write`, and makes the post non-fatal so a status hiccup can never red an otherwise-correct sync. The auto-sync git push is untouched: it still uses the GitHub App token via the checkout-managed credentials (whose pushes re-trigger CI), since a status POST never triggers CI and so never needed the App token. Net effect: an in-sync same-repo PR now goes green, and a drifted one auto-commits, pushes, and reports success as originally intended — with no manual `Scripts/mk_all.sh` step required of contributors.

🤖 Prepared with Claude Code