### PR TITLE
perf: source PR state from the event payload, not the API

### DIFF
--- a/.github/workflows/zulip-pr.yml
+++ b/.github/workflows/zulip-pr.yml
@@ -38,6 +38,13 @@ jobs:
           ZULIP_SITE: https://leanprover.zulipchat.com
           PR: ${{ github.event.pull_request.number }}
           ACTION: ${{ github.event.action }}
+          # Feed PR state straight from the event payload so reconcile needs no
+          # /pulls API call (a close/merge then makes zero GitHub API calls).
+          # Title goes via env, never inline, to avoid any shell injection.
+          PR_STATE: ${{ github.event.pull_request.state }}
+          PR_MERGED: ${{ github.event.pull_request.merged }}
+          PR_HEAD: ${{ github.event.pull_request.head.sha }}
+          PR_TITLE: ${{ github.event.pull_request.title }}
         run: |
           # Create the message when a PR opens/reopens; otherwise only react to it.
           CREATE=""

--- a/scripts/zulip/zulip_pr_status.py
+++ b/scripts/zulip/zulip_pr_status.py
@@ -105,7 +105,24 @@ def gh_api(path, jq=None, paginate=False):
 
 
 def pr_state(pr):
-    """{'state','merged','head','title'} for the PR, from GitHub."""
+    """{'state','merged','head','title'} for the PR.
+
+    Prefer the triggering event's payload, passed in via PR_STATE/PR_HEAD/
+    PR_MERGED/PR_TITLE (the lifecycle workflow sets these from
+    github.event.pull_request, so a close/merge needs no GitHub API call at
+    all). Fall back to the REST API when they aren't set (the workflow_run
+    status workflow and the backfill), where the payload is absent or isn't the
+    PR we're reconciling.
+    """
+    env_state = os.environ.get("PR_STATE")
+    env_head = os.environ.get("PR_HEAD")
+    if env_state and env_head:
+        return {
+            "state": env_state,
+            "merged": os.environ.get("PR_MERGED") == "true",
+            "head": env_head,
+            "title": os.environ.get("PR_TITLE") or f"PR #{pr}",
+        }
     d = json.loads(gh_api(f"/repos/{REPO}/pulls/{pr}"))
     return {
         "state": d["state"],                 # "open" | "closed"


### PR DESCRIPTION
This PR cuts the GitHub API calls the Zulip status integration makes per event. The lifecycle workflow now feeds PR state (state, merged, head, title) to reconcile straight from `github.event.pull_request`, so it no longer calls `/pulls/{pr}` on every event — a close or merge now makes zero GitHub API calls (those paths already skip the scoreboard and CI fetches). The script falls back to the REST API when the `PR_*` env vars are absent, so the `workflow_run` status workflow and the local backfill are unchanged. The title is passed via env rather than inline to keep it injection-safe.

🤖 Prepared with Claude Code