### PR TITLE
perf: skip the Review "requested" event in the Zulip status workflow

### DIFF
--- a/.github/workflows/zulip-pr-status.yml
+++ b/.github/workflows/zulip-pr-status.yml
@@ -24,7 +24,12 @@ concurrency:
 
 jobs:
   zulip-pr-status:
-    if: github.repository == 'FormalFrontier/TauCeti'
+    # Skip Review's "requested" event: the scoreboard isn't updated until Review
+    # completes, so reconciling at its start re-derives the same state and does
+    # no useful work. (pr-build's "requested" is kept -- it paints 🟡 running.)
+    if: >
+      github.repository == 'FormalFrontier/TauCeti' &&
+      !(github.event.workflow_run.name == 'Review' && github.event.action == 'requested')
     runs-on: ubuntu-latest
     steps:
       - name: Resolve PR number


### PR DESCRIPTION
This PR skips the `Review` workflow's `requested` event in the Zulip status workflow. The scoreboard isn't updated until Review completes, so reconciling when it starts re-derives identical state and does no useful work — dropping it removes one Actions job per review round at no cost. `pr-build`'s `requested` event is kept, since that one paints the 🟡 running emoji.

🤖 Prepared with Claude Code