### PR TITLE
feat: package finite-type Hopf ideal quotients

### DIFF
--- a/TauCeti.lean
+++ b/TauCeti.lean
@@ -11,6 +11,7 @@ import TauCeti.Algebra.AlgebraicGroup.CommHopfAlgCat
 import TauCeti.Algebra.AlgebraicGroup.DiagonalizableGroup
 import TauCeti.Algebra.AlgebraicGroup.FiniteTypeCommHopfAlgCat
 import TauCeti.Algebra.AlgebraicGroup.FunctorOfPoints
+import TauCeti.Algebra.AlgebraicGroup.HopfIdealQuotient
 import TauCeti.Algebra.AlgebraicGroup.HopfMap
 import TauCeti.Algebra.AlgebraicGroup.MultiplicativeGroup
 import TauCeti.Algebra.AlgebraicGroup.PointsFunctor

--- a/TauCeti/Algebra/AlgebraicGroup/HopfIdealQuotient.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/HopfIdealQuotient.lean
@@ -1,0 +1,210 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+import TauCeti.Algebra.AlgebraicGroup.FiniteTypeCommHopfAlgCat
+import TauCeti.Algebra.HopfAlgebra.Quotient
+
+/-!
+# Hopf-ideal quotients of finite-type commutative Hopf algebras
+
+This file packages the quotient of a finite-type commutative Hopf algebra by a Hopf ideal
+as another object of `FiniteTypeCommHopfAlgCat`. The Hopf algebra structure and quotient
+bialgebra morphism are supplied by `TauCeti.Algebra.HopfAlgebra.Quotient`; the only extra
+ingredient here is that finite type descends along the surjective quotient algebra map.
+
+This is a small Layer 3 prerequisite for the reductive-groups roadmap target
+"Hopf ideals ↔ closed subgroup schemes": once closed subgroup schemes are represented by
+Hopf ideals on coordinate rings, their quotient coordinate Hopf algebras should remain in
+the finite-type coordinate-Hopf-algebra category.
+
+## Main declarations
+
+* `TauCeti.HopfIdeal.finiteTypeQuotient`: finite type of `H ⧸ I`.
+* `TauCeti.CommHopfAlgCat.quotient`: the quotient object in `CommHopfAlgCat`.
+* `TauCeti.FiniteTypeCommHopfAlgCat.quotient`: the quotient object in
+  `FiniteTypeCommHopfAlgCat`.
+* `TauCeti.FiniteTypeCommHopfAlgCat.mkQuotient`: the quotient morphism.
+* `TauCeti.FiniteTypeCommHopfAlgCat.liftQuotient`: the induced morphism out of a quotient.
+
+## References
+
+The quotient Hopf algebra construction follows `TauCeti.Algebra.HopfAlgebra.Quotient`,
+which cites Sweedler, *Hopf Algebras*, Chapter 4, and Waterhouse, *Introduction to Affine
+Group Schemes*, §16. The finite-type descent is Mathlib's
+`Algebra.FiniteType.of_surjective`.
+-/
+
+namespace TauCeti
+
+universe u v
+
+namespace HopfIdeal
+
+variable {R : Type u} {H : Type v}
+variable [CommRing R] [CommRing H] [HopfAlgebra R H]
+variable [Algebra.FiniteType R H]
+
+/-- The quotient of a finite-type commutative Hopf algebra by a Hopf ideal is finite type. -/
+instance finiteTypeQuotient (I : HopfIdeal R H) : Algebra.FiniteType R (H ⧸ I.toIdeal) :=
+  Algebra.FiniteType.of_surjective (Ideal.Quotient.mkₐ R I.toIdeal)
+    (Ideal.Quotient.mkₐ_surjective R I.toIdeal)
+
+end HopfIdeal
+
+namespace CommHopfAlgCat
+
+open CategoryTheory
+
+variable {R : Type u} [CommRing R]
+
+/-- The quotient of a commutative Hopf algebra by a Hopf ideal, as a bundled commutative
+Hopf algebra. -/
+noncomputable abbrev quotient (H : CommHopfAlgCat.{u, v} R) (I : HopfIdeal R H) :
+    CommHopfAlgCat.{u, v} R :=
+  of R (H ⧸ I.toIdeal)
+
+/-- The quotient morphism `H ⟶ H ⧸ I` in `CommHopfAlgCat`. -/
+noncomputable abbrev mkQuotient (H : CommHopfAlgCat.{u, v} R) (I : HopfIdeal R H) :
+    H ⟶ quotient H I :=
+  ofHom (HopfIdeal.mkBialgHom I)
+
+/-- The quotient morphism has the expected underlying bialgebra morphism. -/
+@[simp]
+lemma toBialgHom_mkQuotient (H : CommHopfAlgCat.{u, v} R) (I : HopfIdeal R H) :
+    toBialgHom (mkQuotient H I) = HopfIdeal.mkBialgHom I :=
+  rfl
+
+/-- The quotient morphism sends an element to its quotient class. -/
+@[simp]
+lemma mkQuotient_apply (H : CommHopfAlgCat.{u, v} R) (I : HopfIdeal R H) (h : H) :
+    toBialgHom (mkQuotient H I) h = Ideal.Quotient.mkₐ R I.toIdeal h :=
+  rfl
+
+variable {H K : CommHopfAlgCat.{u, v} R}
+
+/-- A morphism of commutative Hopf algebras out of `H` which kills a Hopf ideal factors
+through the quotient object. -/
+noncomputable abbrev liftQuotient (I : HopfIdeal R H) (f : H ⟶ K)
+    (hf : I.toIdeal ≤ RingHom.ker (toBialgHom f).toAlgHom.toRingHom) : quotient H I ⟶ K :=
+  ofHom (HopfIdeal.liftBialgHom I (toBialgHom f) hf)
+
+/-- The quotient lift has the expected underlying bialgebra morphism. -/
+@[simp]
+lemma toBialgHom_liftQuotient (I : HopfIdeal R H) (f : H ⟶ K)
+    (hf : I.toIdeal ≤ RingHom.ker (toBialgHom f).toAlgHom.toRingHom) :
+    toBialgHom (liftQuotient I f hf) = HopfIdeal.liftBialgHom I (toBialgHom f) hf :=
+  rfl
+
+/-- The quotient lift evaluates on quotient classes as the original morphism. -/
+@[simp]
+lemma liftQuotient_mk (I : HopfIdeal R H) (f : H ⟶ K)
+    (hf : I.toIdeal ≤ RingHom.ker (toBialgHom f).toAlgHom.toRingHom) (h : H) :
+    toBialgHom (liftQuotient I f hf) (Ideal.Quotient.mkₐ R I.toIdeal h) =
+      toBialgHom f h :=
+  HopfIdeal.liftBialgHom_mk I (toBialgHom f) hf h
+
+/-- The quotient lift composed with the quotient morphism is the original morphism. -/
+@[simp]
+lemma liftQuotient_comp_mkQuotient (I : HopfIdeal R H) (f : H ⟶ K)
+    (hf : I.toIdeal ≤ RingHom.ker (toBialgHom f).toAlgHom.toRingHom) :
+    mkQuotient H I ≫ liftQuotient I f hf = f := by
+  ext h
+  exact BialgHom.congr_fun
+    (HopfIdeal.liftBialgHom_comp_mkBialgHom I (toBialgHom f) hf) h
+
+/-- A morphism out of the quotient object is determined by its precomposition with the
+quotient morphism. -/
+lemma liftQuotient_unique (I : HopfIdeal R H) (f : H ⟶ K)
+    (hf : I.toIdeal ≤ RingHom.ker (toBialgHom f).toAlgHom.toRingHom) (g : quotient H I ⟶ K)
+    (hg : mkQuotient H I ≫ g = f) : g = liftQuotient I f hf := by
+  ext q
+  obtain ⟨h, rfl⟩ := Ideal.Quotient.mkₐ_surjective R I.toIdeal q
+  calc
+    toBialgHom g (Ideal.Quotient.mkₐ R I.toIdeal h) =
+        toBialgHom (mkQuotient H I ≫ g) h := rfl
+    _ = toBialgHom f h := by rw [hg]
+    _ = toBialgHom (liftQuotient I f hf) (Ideal.Quotient.mkₐ R I.toIdeal h) :=
+      (liftQuotient_mk I f hf h).symm
+
+end CommHopfAlgCat
+
+namespace FiniteTypeCommHopfAlgCat
+
+open CategoryTheory
+
+variable {R : Type u} [CommRing R]
+
+/-- The quotient of a finite-type commutative Hopf algebra by a Hopf ideal, as a bundled
+finite-type commutative Hopf algebra. -/
+noncomputable abbrev quotient (H : FiniteTypeCommHopfAlgCat.{u, v} R) (I : HopfIdeal R H) :
+    FiniteTypeCommHopfAlgCat.{u, v} R :=
+  of R (H ⧸ I.toIdeal)
+
+/-- The quotient morphism `H ⟶ H ⧸ I` in `FiniteTypeCommHopfAlgCat`. -/
+noncomputable abbrev mkQuotient (H : FiniteTypeCommHopfAlgCat.{u, v} R)
+    (I : HopfIdeal R H) : H ⟶ quotient H I :=
+  ofHom (HopfIdeal.mkBialgHom I)
+
+/-- The quotient morphism has the expected underlying bialgebra morphism. -/
+@[simp]
+lemma toBialgHom_mkQuotient (H : FiniteTypeCommHopfAlgCat.{u, v} R)
+    (I : HopfIdeal R H) : toBialgHom (mkQuotient H I) = HopfIdeal.mkBialgHom I :=
+  rfl
+
+/-- The quotient morphism sends an element to its quotient class. -/
+@[simp]
+lemma mkQuotient_apply (H : FiniteTypeCommHopfAlgCat.{u, v} R)
+    (I : HopfIdeal R H) (h : H) :
+    toBialgHom (mkQuotient H I) h = Ideal.Quotient.mkₐ R I.toIdeal h :=
+  rfl
+
+variable {H K : FiniteTypeCommHopfAlgCat.{u, v} R}
+
+/-- A morphism of finite-type commutative Hopf algebras out of `H` which kills a Hopf ideal
+factors through the quotient object. -/
+noncomputable abbrev liftQuotient (I : HopfIdeal R H) (f : H ⟶ K)
+    (hf : I.toIdeal ≤ RingHom.ker (toBialgHom f).toAlgHom.toRingHom) : quotient H I ⟶ K :=
+  ofHom (HopfIdeal.liftBialgHom I (toBialgHom f) hf)
+
+/-- The quotient lift has the expected underlying bialgebra morphism. -/
+@[simp]
+lemma toBialgHom_liftQuotient (I : HopfIdeal R H) (f : H ⟶ K)
+    (hf : I.toIdeal ≤ RingHom.ker (toBialgHom f).toAlgHom.toRingHom) :
+    toBialgHom (liftQuotient I f hf) = HopfIdeal.liftBialgHom I (toBialgHom f) hf :=
+  rfl
+
+/-- The quotient lift evaluates on quotient classes as the original morphism. -/
+@[simp]
+lemma liftQuotient_mk (I : HopfIdeal R H) (f : H ⟶ K)
+    (hf : I.toIdeal ≤ RingHom.ker (toBialgHom f).toAlgHom.toRingHom) (h : H) :
+    toBialgHom (liftQuotient I f hf) (Ideal.Quotient.mkₐ R I.toIdeal h) =
+      toBialgHom f h :=
+  HopfIdeal.liftBialgHom_mk I (toBialgHom f) hf h
+
+/-- The quotient lift composed with the quotient morphism is the original morphism. -/
+@[simp]
+lemma liftQuotient_comp_mkQuotient (I : HopfIdeal R H) (f : H ⟶ K)
+    (hf : I.toIdeal ≤ RingHom.ker (toBialgHom f).toAlgHom.toRingHom) :
+    mkQuotient H I ≫ liftQuotient I f hf = f := by
+  ext h
+  exact BialgHom.congr_fun
+    (HopfIdeal.liftBialgHom_comp_mkBialgHom I (toBialgHom f) hf) h
+
+/-- A morphism out of the quotient object is determined by its precomposition with the
+quotient morphism. -/
+lemma liftQuotient_unique (I : HopfIdeal R H) (f : H ⟶ K)
+    (hf : I.toIdeal ≤ RingHom.ker (toBialgHom f).toAlgHom.toRingHom) (g : quotient H I ⟶ K)
+    (hg : mkQuotient H I ≫ g = f) : g = liftQuotient I f hf := by
+  ext q
+  obtain ⟨h, rfl⟩ := Ideal.Quotient.mkₐ_surjective R I.toIdeal q
+  calc
+    toBialgHom g (Ideal.Quotient.mkₐ R I.toIdeal h) =
+        toBialgHom (mkQuotient H I ≫ g) h := rfl
+    _ = toBialgHom f h := by rw [hg]
+    _ = toBialgHom (liftQuotient I f hf) (Ideal.Quotient.mkₐ R I.toIdeal h) :=
+      (liftQuotient_mk I f hf h).symm
+
+end FiniteTypeCommHopfAlgCat
+
+end TauCeti

--- a/TauCeti/Algebra/AlgebraicGroup/HopfIdealQuotient.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/HopfIdealQuotient.lean
@@ -132,17 +132,12 @@ noncomputable abbrev mkQuotient (H : FiniteTypeCommHopfAlgCat.{u, v} R)
     (I : HopfIdeal R H) : H ⟶ quotient H I :=
   ObjectProperty.homMk (CommHopfAlgCat.mkQuotient H.obj I)
 
-/-- The quotient morphism has the expected underlying bialgebra morphism. -/
+/-- The finite-type quotient morphism forgets to the `CommHopfAlgCat` quotient morphism. -/
 @[simp]
-lemma toBialgHom_mkQuotient (H : FiniteTypeCommHopfAlgCat.{u, v} R)
-    (I : HopfIdeal R H) : toBialgHom (mkQuotient H I) = HopfIdeal.mkBialgHom I :=
-  rfl
-
-/-- The quotient morphism sends an element to its quotient class. -/
-@[simp]
-lemma mkQuotient_apply (H : FiniteTypeCommHopfAlgCat.{u, v} R)
-    (I : HopfIdeal R H) (h : H) :
-    toBialgHom (mkQuotient H I) h = Ideal.Quotient.mkₐ R I.toIdeal h :=
+lemma forget₂_commHopfAlgCat_map_mkQuotient (H : FiniteTypeCommHopfAlgCat.{u, v} R)
+    (I : HopfIdeal R H) :
+    (forget₂ (FiniteTypeCommHopfAlgCat.{u, v} R) (CommHopfAlgCat.{u, v} R)).map
+      (mkQuotient H I) = CommHopfAlgCat.mkQuotient H.obj I :=
   rfl
 
 variable {H K : FiniteTypeCommHopfAlgCat.{u, v} R}
@@ -153,20 +148,13 @@ noncomputable abbrev liftQuotient (I : HopfIdeal R H) (f : H ⟶ K)
     (hf : I.toIdeal ≤ RingHom.ker (toBialgHom f).toAlgHom.toRingHom) : quotient H I ⟶ K :=
   ObjectProperty.homMk (CommHopfAlgCat.liftQuotient I f.hom hf)
 
-/-- The quotient lift has the expected underlying bialgebra morphism. -/
+/-- The finite-type quotient lift forgets to the `CommHopfAlgCat` quotient lift. -/
 @[simp]
-lemma toBialgHom_liftQuotient (I : HopfIdeal R H) (f : H ⟶ K)
+lemma forget₂_commHopfAlgCat_map_liftQuotient (I : HopfIdeal R H) (f : H ⟶ K)
     (hf : I.toIdeal ≤ RingHom.ker (toBialgHom f).toAlgHom.toRingHom) :
-    toBialgHom (liftQuotient I f hf) = HopfIdeal.liftBialgHom I (toBialgHom f) hf :=
+    (forget₂ (FiniteTypeCommHopfAlgCat.{u, v} R) (CommHopfAlgCat.{u, v} R)).map
+      (liftQuotient I f hf) = CommHopfAlgCat.liftQuotient I f.hom hf :=
   rfl
-
-/-- The quotient lift evaluates on quotient classes as the original morphism. -/
-@[simp]
-lemma liftQuotient_mk (I : HopfIdeal R H) (f : H ⟶ K)
-    (hf : I.toIdeal ≤ RingHom.ker (toBialgHom f).toAlgHom.toRingHom) (h : H) :
-    toBialgHom (liftQuotient I f hf) (Ideal.Quotient.mkₐ R I.toIdeal h) =
-      toBialgHom f h :=
-  HopfIdeal.liftBialgHom_mk I (toBialgHom f) hf h
 
 /-- The quotient lift composed with the quotient morphism is the original morphism. -/
 @[simp]

--- a/TauCeti/Algebra/AlgebraicGroup/HopfIdealQuotient.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/HopfIdealQuotient.lean
@@ -20,7 +20,6 @@ the finite-type coordinate-Hopf-algebra category.
 
 ## Main declarations
 
-* `TauCeti.HopfIdeal.finiteTypeQuotient`: finite type of `H ⧸ I`.
 * `TauCeti.CommHopfAlgCat.quotient`: the quotient object in `CommHopfAlgCat`.
 * `TauCeti.FiniteTypeCommHopfAlgCat.quotient`: the quotient object in
   `FiniteTypeCommHopfAlgCat`.
@@ -38,19 +37,6 @@ Group Schemes*, §16. The finite-type descent is Mathlib's
 namespace TauCeti
 
 universe u v
-
-namespace HopfIdeal
-
-variable {R : Type u} {H : Type v}
-variable [CommRing R] [CommRing H] [HopfAlgebra R H]
-variable [Algebra.FiniteType R H]
-
-/-- The quotient of a finite-type commutative Hopf algebra by a Hopf ideal is finite type. -/
-instance finiteTypeQuotient (I : HopfIdeal R H) : Algebra.FiniteType R (H ⧸ I.toIdeal) :=
-  Algebra.FiniteType.of_surjective (Ideal.Quotient.mkₐ R I.toIdeal)
-    (Ideal.Quotient.mkₐ_surjective R I.toIdeal)
-
-end HopfIdeal
 
 namespace CommHopfAlgCat
 
@@ -187,23 +173,23 @@ lemma liftQuotient_mk (I : HopfIdeal R H) (f : H ⟶ K)
 lemma liftQuotient_comp_mkQuotient (I : HopfIdeal R H) (f : H ⟶ K)
     (hf : I.toIdeal ≤ RingHom.ker (toBialgHom f).toAlgHom.toRingHom) :
     mkQuotient H I ≫ liftQuotient I f hf = f := by
-  ext h
-  exact BialgHom.congr_fun
-    (HopfIdeal.liftBialgHom_comp_mkBialgHom I (toBialgHom f) hf) h
+  apply (forget₂ (FiniteTypeCommHopfAlgCat.{u, v} R)
+    (CommHopfAlgCat.{u, v} R)).map_injective
+  exact CommHopfAlgCat.liftQuotient_comp_mkQuotient I f.hom hf
 
 /-- A morphism out of the quotient object is determined by its precomposition with the
 quotient morphism. -/
 lemma liftQuotient_unique (I : HopfIdeal R H) (f : H ⟶ K)
     (hf : I.toIdeal ≤ RingHom.ker (toBialgHom f).toAlgHom.toRingHom) (g : quotient H I ⟶ K)
     (hg : mkQuotient H I ≫ g = f) : g = liftQuotient I f hf := by
-  ext q
-  obtain ⟨h, rfl⟩ := Ideal.Quotient.mkₐ_surjective R I.toIdeal q
-  calc
-    toBialgHom g (Ideal.Quotient.mkₐ R I.toIdeal h) =
-        toBialgHom (mkQuotient H I ≫ g) h := rfl
-    _ = toBialgHom f h := by rw [hg]
-    _ = toBialgHom (liftQuotient I f hf) (Ideal.Quotient.mkₐ R I.toIdeal h) :=
-      (liftQuotient_mk I f hf h).symm
+  apply (forget₂ (FiniteTypeCommHopfAlgCat.{u, v} R)
+    (CommHopfAlgCat.{u, v} R)).map_injective
+  have hg' : CommHopfAlgCat.ofHom (HopfIdeal.mkBialgHom I) ≫ g.hom = f.hom :=
+    congrArg
+      (fun φ => (forget₂ (FiniteTypeCommHopfAlgCat.{u, v} R)
+        (CommHopfAlgCat.{u, v} R)).map φ) hg
+  exact CommHopfAlgCat.liftQuotient_unique (H := CommHopfAlgCat.of R H) I f.hom hf
+    g.hom hg'
 
 end FiniteTypeCommHopfAlgCat
 

--- a/TauCeti/Algebra/AlgebraicGroup/HopfIdealQuotient.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/HopfIdealQuotient.lean
@@ -2,6 +2,7 @@
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 -/
+import Mathlib.RingTheory.FiniteType
 import TauCeti.Algebra.AlgebraicGroup.FiniteTypeCommHopfAlgCat
 import TauCeti.Algebra.HopfAlgebra.Quotient
 
@@ -31,7 +32,7 @@ the finite-type coordinate-Hopf-algebra category.
 The quotient Hopf algebra construction follows `TauCeti.Algebra.HopfAlgebra.Quotient`,
 which cites Sweedler, *Hopf Algebras*, Chapter 4, and Waterhouse, *Introduction to Affine
 Group Schemes*, §16. The finite-type descent is Mathlib's
-`Algebra.FiniteType.of_surjective`.
+`Algebra.FiniteType.quotient`.
 -/
 
 namespace TauCeti
@@ -92,7 +93,7 @@ lemma liftQuotient_mk (I : HopfIdeal R H) (f : H ⟶ K)
 
 /-- The quotient lift composed with the quotient morphism is the original morphism. -/
 @[simp]
-lemma liftQuotient_comp_mkQuotient (I : HopfIdeal R H) (f : H ⟶ K)
+lemma mkQuotient_comp_liftQuotient (I : HopfIdeal R H) (f : H ⟶ K)
     (hf : I.toIdeal ≤ RingHom.ker (toBialgHom f).toAlgHom.toRingHom) :
     mkQuotient H I ≫ liftQuotient I f hf = f := by
   ext h
@@ -158,12 +159,12 @@ lemma forget₂_commHopfAlgCat_map_liftQuotient (I : HopfIdeal R H) (f : H ⟶ K
 
 /-- The quotient lift composed with the quotient morphism is the original morphism. -/
 @[simp]
-lemma liftQuotient_comp_mkQuotient (I : HopfIdeal R H) (f : H ⟶ K)
+lemma mkQuotient_comp_liftQuotient (I : HopfIdeal R H) (f : H ⟶ K)
     (hf : I.toIdeal ≤ RingHom.ker (toBialgHom f).toAlgHom.toRingHom) :
     mkQuotient H I ≫ liftQuotient I f hf = f := by
   apply (forget₂ (FiniteTypeCommHopfAlgCat.{u, v} R)
     (CommHopfAlgCat.{u, v} R)).map_injective
-  exact CommHopfAlgCat.liftQuotient_comp_mkQuotient I f.hom hf
+  exact CommHopfAlgCat.mkQuotient_comp_liftQuotient I f.hom hf
 
 /-- A morphism out of the quotient object is determined by its precomposition with the
 quotient morphism. -/

--- a/TauCeti/Algebra/AlgebraicGroup/HopfIdealQuotient.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/HopfIdealQuotient.lean
@@ -25,6 +25,7 @@ the finite-type coordinate-Hopf-algebra category.
 * `TauCeti.FiniteTypeCommHopfAlgCat.quotient`: the quotient object in
   `FiniteTypeCommHopfAlgCat`.
 * `TauCeti.FiniteTypeCommHopfAlgCat.mkQuotient`: the quotient morphism.
+* `TauCeti.FiniteTypeCommHopfAlgCat.mkQuotient_ker`: its kernel characterization.
 * `TauCeti.FiniteTypeCommHopfAlgCat.liftQuotient`: the induced morphism out of a quotient.
 
 ## References
@@ -67,6 +68,19 @@ lemma toBialgHom_mkQuotient (H : CommHopfAlgCat.{u, v} R) (I : HopfIdeal R H) :
 lemma mkQuotient_apply (H : CommHopfAlgCat.{u, v} R) (I : HopfIdeal R H) (h : H) :
     toBialgHom (mkQuotient H I) h = Ideal.Quotient.mkₐ R I.toIdeal h :=
   rfl
+
+/-- The kernel of the quotient morphism is the Hopf ideal being quotiented by. -/
+lemma mkQuotient_ker (H : CommHopfAlgCat.{u, v} R) (I : HopfIdeal R H) :
+    RingHom.ker (toBialgHom (mkQuotient H I)).toAlgHom.toRingHom = I.toIdeal := by
+  rw [toBialgHom_mkQuotient]
+  exact Ideal.Quotient.mkₐ_ker (R₁ := R) I.toIdeal
+
+/-- An element maps to zero in the quotient exactly when it belongs to the Hopf ideal. -/
+@[simp]
+lemma mkQuotient_eq_zero_iff (H : CommHopfAlgCat.{u, v} R) (I : HopfIdeal R H) (h : H) :
+    toBialgHom (mkQuotient H I) h = 0 ↔ h ∈ I.toIdeal := by
+  rw [mkQuotient_apply]
+  exact Ideal.Quotient.eq_zero_iff_mem
 
 variable {H K : CommHopfAlgCat.{u, v} R}
 
@@ -140,6 +154,18 @@ lemma forget₂_commHopfAlgCat_map_mkQuotient (H : FiniteTypeCommHopfAlgCat.{u, 
     (forget₂ (FiniteTypeCommHopfAlgCat.{u, v} R) (CommHopfAlgCat.{u, v} R)).map
       (mkQuotient H I) = CommHopfAlgCat.mkQuotient H.obj I :=
   rfl
+
+/-- The kernel of the finite-type quotient morphism is the Hopf ideal being quotiented by. -/
+lemma mkQuotient_ker (H : FiniteTypeCommHopfAlgCat.{u, v} R) (I : HopfIdeal R H) :
+    RingHom.ker (toBialgHom (mkQuotient H I)).toAlgHom.toRingHom = I.toIdeal :=
+  CommHopfAlgCat.mkQuotient_ker H.obj I
+
+/-- An element maps to zero in the finite-type quotient exactly when it belongs to the Hopf
+ideal. -/
+@[simp]
+lemma mkQuotient_eq_zero_iff (H : FiniteTypeCommHopfAlgCat.{u, v} R)
+    (I : HopfIdeal R H) (h : H) : toBialgHom (mkQuotient H I) h = 0 ↔ h ∈ I.toIdeal :=
+  CommHopfAlgCat.mkQuotient_eq_zero_iff H.obj I h
 
 variable {H K : FiniteTypeCommHopfAlgCat.{u, v} R}
 

--- a/TauCeti/Algebra/AlgebraicGroup/HopfIdealQuotient.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/HopfIdealQuotient.lean
@@ -125,12 +125,12 @@ variable {R : Type u} [CommRing R]
 finite-type commutative Hopf algebra. -/
 noncomputable abbrev quotient (H : FiniteTypeCommHopfAlgCat.{u, v} R) (I : HopfIdeal R H) :
     FiniteTypeCommHopfAlgCat.{u, v} R :=
-  of R (H ⧸ I.toIdeal)
+  ⟨CommHopfAlgCat.quotient H.obj I, inferInstanceAs (Algebra.FiniteType R (H ⧸ I.toIdeal))⟩
 
 /-- The quotient morphism `H ⟶ H ⧸ I` in `FiniteTypeCommHopfAlgCat`. -/
 noncomputable abbrev mkQuotient (H : FiniteTypeCommHopfAlgCat.{u, v} R)
     (I : HopfIdeal R H) : H ⟶ quotient H I :=
-  ofHom (HopfIdeal.mkBialgHom I)
+  ObjectProperty.homMk (CommHopfAlgCat.mkQuotient H.obj I)
 
 /-- The quotient morphism has the expected underlying bialgebra morphism. -/
 @[simp]
@@ -151,7 +151,7 @@ variable {H K : FiniteTypeCommHopfAlgCat.{u, v} R}
 factors through the quotient object. -/
 noncomputable abbrev liftQuotient (I : HopfIdeal R H) (f : H ⟶ K)
     (hf : I.toIdeal ≤ RingHom.ker (toBialgHom f).toAlgHom.toRingHom) : quotient H I ⟶ K :=
-  ofHom (HopfIdeal.liftBialgHom I (toBialgHom f) hf)
+  ObjectProperty.homMk (CommHopfAlgCat.liftQuotient I f.hom hf)
 
 /-- The quotient lift has the expected underlying bialgebra morphism. -/
 @[simp]

--- a/TauCeti/Algebra/HopfAlgebra/Quotient.lean
+++ b/TauCeti/Algebra/HopfAlgebra/Quotient.lean
@@ -3,7 +3,6 @@ Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 -/
 import Mathlib.RingTheory.HopfAlgebra.Convolution
-import Mathlib.RingTheory.FiniteType
 import Mathlib.RingTheory.Ideal.Quotient.Operations
 import TauCeti.Algebra.HopfAlgebra.HopfIdeal
 

--- a/TauCeti/Algebra/HopfAlgebra/Quotient.lean
+++ b/TauCeti/Algebra/HopfAlgebra/Quotient.lean
@@ -31,7 +31,6 @@ map kills. No exactness or flatness input is needed; that is what the Hopf-ideal
   comultiplication and counit of the quotient, as `R`-algebra homomorphisms descended from `H`.
 * `TauCeti.HopfIdeal.instCoalgebraQuotient`, `instBialgebraQuotient`,
   `instHopfAlgebraQuotient`: the coalgebra, bialgebra and Hopf algebra structures on `H ⧸ I`.
-* `TauCeti.HopfIdeal.finiteTypeQuotient`: finite type of `H ⧸ I` when `H` is finite type.
 * `TauCeti.HopfIdeal.mkBialgHom`: the quotient map `H →ₐc[R] H ⧸ I` as a bialgebra morphism.
 * `TauCeti.HopfIdeal.liftBialgHom`: the bialgebra morphism induced from a bialgebra morphism
   which kills the Hopf ideal.
@@ -417,12 +416,6 @@ section CommRing
 
 variable [CommRing H] [HopfAlgebra R H]
 variable (I : HopfIdeal R H)
-
-/-- The quotient of a finite-type commutative Hopf algebra by a Hopf ideal is finite type. -/
-instance finiteTypeQuotient [Algebra.FiniteType R H] :
-    Algebra.FiniteType R (H ⧸ I.toIdeal) :=
-  Algebra.FiniteType.of_surjective (Ideal.Quotient.mkₐ R I.toIdeal)
-    (Ideal.Quotient.mkₐ_surjective R I.toIdeal)
 
 /-- The antipode of the quotient, as an `R`-algebra homomorphism descended from `H` (valid since
 `H` is commutative, where the antipode is an algebra homomorphism). -/

--- a/TauCeti/Algebra/HopfAlgebra/Quotient.lean
+++ b/TauCeti/Algebra/HopfAlgebra/Quotient.lean
@@ -3,6 +3,7 @@ Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 -/
 import Mathlib.RingTheory.HopfAlgebra.Convolution
+import Mathlib.RingTheory.FiniteType
 import Mathlib.RingTheory.Ideal.Quotient.Operations
 import TauCeti.Algebra.HopfAlgebra.HopfIdeal
 
@@ -30,6 +31,7 @@ map kills. No exactness or flatness input is needed; that is what the Hopf-ideal
   comultiplication and counit of the quotient, as `R`-algebra homomorphisms descended from `H`.
 * `TauCeti.HopfIdeal.instCoalgebraQuotient`, `instBialgebraQuotient`,
   `instHopfAlgebraQuotient`: the coalgebra, bialgebra and Hopf algebra structures on `H ⧸ I`.
+* `TauCeti.HopfIdeal.finiteTypeQuotient`: finite type of `H ⧸ I` when `H` is finite type.
 * `TauCeti.HopfIdeal.mkBialgHom`: the quotient map `H →ₐc[R] H ⧸ I` as a bialgebra morphism.
 * `TauCeti.HopfIdeal.liftBialgHom`: the bialgebra morphism induced from a bialgebra morphism
   which kills the Hopf ideal.
@@ -415,6 +417,12 @@ section CommRing
 
 variable [CommRing H] [HopfAlgebra R H]
 variable (I : HopfIdeal R H)
+
+/-- The quotient of a finite-type commutative Hopf algebra by a Hopf ideal is finite type. -/
+instance finiteTypeQuotient [Algebra.FiniteType R H] :
+    Algebra.FiniteType R (H ⧸ I.toIdeal) :=
+  Algebra.FiniteType.of_surjective (Ideal.Quotient.mkₐ R I.toIdeal)
+    (Ideal.Quotient.mkₐ_surjective R I.toIdeal)
 
 /-- The antipode of the quotient, as an `R`-algebra homomorphism descended from `H` (valid since
 `H` is commutative, where the antipode is an algebra homomorphism). -/


### PR DESCRIPTION
This PR packages Hopf-ideal quotients inside the coordinate-Hopf-algebra categories used by the ReductiveGroups roadmap. It adds `CommHopfAlgCat.quotient` and `FiniteTypeCommHopfAlgCat.quotient`, their quotient morphisms, and the induced lift/uniqueness API, so the categorical finite-type model is closed under the Hopf-ideal quotient construction already present in Tau Ceti. This advances `TauCetiRoadmap/ReductiveGroups/README.md`, Layer 3, the item "Hopf ideals ↔ closed subgroup schemes: an ideal `I` with `Δ(I) ⊆ I⊗A + A⊗I`, `ε(I)=0`, `S(I) ⊆ I`; the quotient Hopf algebra `A/I`; the anti-equivalence; kernels" by packaging the quotient Hopf algebra in `CommHopfAlgCat` and its finite-type full subcategory.

<!--tauceti-target:v1 {"focus":"ReductiveGroups","id":"finite-type-hopf-ideal-quotient"}-->

No Mathlib infrastructure is vendored. The construction reuses Tau Ceti's `HopfIdeal.mkBialgHom` and `HopfIdeal.liftBialgHom` quotient Hopf algebra API, and Mathlib's `Algebra.FiniteType.of_surjective` with `Ideal.Quotient.mkₐ_surjective` for finite-type descent along the quotient algebra map.

Verification: `lake exe cache get` completed successfully with no files to download and 8174 cached files decompressed; `lake build` completed successfully with 3834 jobs; `lake exe axioms` audited 1846 TauCeti declarations and all axioms were within the allowlist `[propext, Classical.choice, Quot.sound]`.

🤖 Prepared with Codex
