### PR TITLE
feat: identify roots-of-unity group points

### DIFF
--- a/TauCeti.lean
+++ b/TauCeti.lean
@@ -15,6 +15,7 @@ import TauCeti.Algebra.AlgebraicGroup.HopfMap
 import TauCeti.Algebra.AlgebraicGroup.MultiplicativeGroup
 import TauCeti.Algebra.AlgebraicGroup.PointsFunctor
 import TauCeti.Algebra.AlgebraicGroup.Product
+import TauCeti.Algebra.AlgebraicGroup.RootsOfUnity
 import TauCeti.Algebra.Bialgebra.TensorProduct
 import TauCeti.Algebra.Coalgebra.Comodule
 import TauCeti.Algebra.Coalgebra.Comodule.Cofree

--- a/TauCeti/Algebra/AlgebraicGroup/RootsOfUnity.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/RootsOfUnity.lean
@@ -1,0 +1,120 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+import Mathlib.RingTheory.RootsOfUnity.Basic
+import Mathlib.SetTheory.Cardinal.Finite
+import TauCeti.Algebra.AlgebraicGroup.DiagonalizableGroup
+
+/-!
+# The roots-of-unity group scheme
+
+This file records the functor-of-points calculation for the diagonalizable group
+`D(Multiplicative (ZMod n))`. For positive `n`, this is the usual finite diagonalizable group
+scheme `μ_n`: for every commutative `R`-algebra `A`, its convolution group of `A`-points is the
+group of `n`th roots of unity in `A`.
+
+The result is deliberately just the points calculation. The represented Hopf algebra is the
+group algebra `R[Multiplicative (ZMod n)]`; identifying it with the more classical
+coordinate ring `R[X]/(X^n - 1)` is separate quotient-polynomial infrastructure.
+
+## Main definitions
+
+* `TauCeti.RootsOfUnityGroup.pointsMulEquiv`: the multiplicative equivalence from
+  convolution points of `R[Multiplicative (ZMod n)]` to `rootsOfUnity n A`.
+* `TauCeti.RootsOfUnityGroup.pointsMulEquiv_apply`: the equivalence sends a point to its
+  value on the standard generator `single (ofAdd 1) 1`.
+
+This is a worked-example check for the reductive-groups roadmap, Layer 4:
+"`μ_n = D(ℤ/n)`" in the diagonalizable-groups lane, together with the Layer 0 functor-of-points
+calculation.
+
+## References
+
+The diagonalizable-group points calculation is Tau Ceti's
+`DiagonalizableGroup.pointsMulEquiv`. The cyclic character group calculation is Mathlib's
+`IsCyclic.monoidHomMulEquivRootsOfUnityOfGenerator`, from
+`Mathlib.RingTheory.RootsOfUnity.Basic`.
+-/
+
+open WithConv
+
+namespace TauCeti
+
+namespace RootsOfUnityGroup
+
+universe u v
+
+variable {R : Type u} {A : Type v} [CommSemiring R] [CommSemiring A] [Algebra R A]
+
+/-- The standard generator of the character group defining `μ_n = D(ℤ/n)`. -/
+abbrev generator (n : ℕ) : Multiplicative (ZMod n) :=
+  Multiplicative.ofAdd 1
+
+/-- Every element of `Multiplicative (ZMod n)` is a power of the standard generator. -/
+lemma mem_zpowers_generator (n : ℕ) (x : Multiplicative (ZMod n)) :
+    x ∈ Subgroup.zpowers (generator n) := by
+  refine ⟨(Multiplicative.toAdd x).cast, ?_⟩
+  change (Multiplicative.ofAdd (1 : ZMod n)) ^ (Multiplicative.toAdd x).cast = x
+  rw [← ofAdd_zsmul]
+  calc
+    Multiplicative.ofAdd ((Multiplicative.toAdd x).cast • (1 : ZMod n)) =
+        Multiplicative.ofAdd (((Multiplicative.toAdd x).cast : ℤ) : ZMod n) := by simp
+    _ =
+        Multiplicative.ofAdd (Multiplicative.toAdd x) := by rw [ZMod.intCast_zmod_cast]
+    _ = x := ofAdd_toAdd x
+
+/-- The cardinality of the standard cyclic character group is `n`. -/
+@[simp]
+lemma natCard_multiplicative_zmod (n : ℕ) :
+    Nat.card (Multiplicative (ZMod n)) = n := by
+  exact (Nat.card_congr (Multiplicative.ofAdd : ZMod n ≃ Multiplicative (ZMod n))).trans
+    (Nat.card_zmod n)
+
+/-- Characters of `Multiplicative (ZMod n)` are canonically `n`th roots of unity, by evaluation
+on the standard generator. -/
+noncomputable def characterMulEquivRootsOfUnity (n : ℕ) :
+    (Multiplicative (ZMod n) →* Aˣ) ≃* rootsOfUnity n A :=
+  ((IsCyclic.monoidHomMulEquivRootsOfUnityOfGenerator (mem_zpowers_generator n) Aˣ).trans
+      (MulEquiv.subgroupCongr (by rw [natCard_multiplicative_zmod n]))).trans
+    (rootsOfUnityUnitsMulEquiv A n)
+
+/-- A character is sent to its value on the standard generator. -/
+@[simp]
+lemma characterMulEquivRootsOfUnity_apply (n : ℕ) (χ : Multiplicative (ZMod n) →* Aˣ) :
+    ((characterMulEquivRootsOfUnity (A := A) n χ : Aˣ) : A) =
+      (χ (generator n) : A) :=
+  rfl
+
+/-- The functor of points of `μ_n = D(ℤ/n)` is the group of `n`th roots of unity.
+
+The source is the convolution group of `R`-algebra maps out of the group algebra
+`R[Multiplicative (ZMod n)]`, and the target is Mathlib's subgroup of units whose `n`th power
+is one. -/
+noncomputable def pointsMulEquiv (n : ℕ) :
+    WithConv (MonoidAlgebra R (Multiplicative (ZMod n)) →ₐ[R] A) ≃*
+      rootsOfUnity n A :=
+  (DiagonalizableGroup.pointsMulEquiv (R := R) (A := A)
+    (G := Multiplicative (ZMod n))).trans (characterMulEquivRootsOfUnity n)
+
+/-- The points equivalence sends a point to its value on the standard generator. -/
+@[simp]
+lemma pointsMulEquiv_apply (n : ℕ)
+    (f : WithConv (MonoidAlgebra R (Multiplicative (ZMod n)) →ₐ[R] A)) :
+    ((pointsMulEquiv (R := R) (A := A) n f : Aˣ) : A) =
+      f.ofConv (MonoidAlgebra.single (generator n) 1) := by
+  rw [pointsMulEquiv, MulEquiv.trans_apply, DiagonalizableGroup.pointsMulEquiv_apply,
+    characterMulEquivRootsOfUnity_apply]
+  rfl
+
+/-- Under the points equivalence, convolution multiplication is multiplication of roots of
+unity. -/
+lemma pointsMulEquiv_mul (n : ℕ)
+    (f g : WithConv (MonoidAlgebra R (Multiplicative (ZMod n)) →ₐ[R] A)) :
+    pointsMulEquiv (R := R) (A := A) n (f * g) =
+      pointsMulEquiv (R := R) (A := A) n f * pointsMulEquiv (R := R) (A := A) n g := by
+  exact (pointsMulEquiv (R := R) (A := A) n).map_mul f g
+
+end RootsOfUnityGroup
+
+end TauCeti

--- a/TauCeti/Algebra/AlgebraicGroup/RootsOfUnity.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/RootsOfUnity.lean
@@ -80,13 +80,8 @@ private noncomputable def characterMulEquivRootsOfUnity (n : ℕ) :
       (MulEquiv.subgroupCongr (by rw [card_multiplicative_zmod n]))).trans
     (rootsOfUnityUnitsMulEquiv A n)
 
-/-- A character is sent to its value on the standard generator.
-
-The proof is `rfl`: each of the three composed equivalences acts on the underlying unit by a
-projection. `monoidHomMulEquivRootsOfUnityOfGenerator` carries `χ` to
-`(IsUnit.map χ (Group.isUnit (generator n))).unit`, whose value is `χ (generator n)` by
-`IsUnit.unit_spec`; `subgroupCongr` and `rootsOfUnityUnitsMulEquiv` are both identity on the
-underlying value. The composite value in `A` is therefore definitionally `χ (generator n)`. -/
+/-- A character is sent to its value on the standard generator. -/
+-- The proof is `rfl`: each composed equivalence acts on the underlying unit by projection.
 @[simp]
 private lemma characterMulEquivRootsOfUnity_apply (n : ℕ)
     (χ : Multiplicative (ZMod n) →* Aˣ) :

--- a/TauCeti/Algebra/AlgebraicGroup/RootsOfUnity.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/RootsOfUnity.lean
@@ -24,6 +24,8 @@ coordinate ring `R[X]/(X^n - 1)` is separate quotient-polynomial infrastructure.
   convolution points of `R[Multiplicative (ZMod n)]` to `rootsOfUnity n A`.
 * `TauCeti.RootsOfUnityGroup.pointsMulEquiv_apply`: the equivalence sends a point to its
   value on the standard generator `single (ofAdd 1) 1`.
+* `TauCeti.RootsOfUnityGroup.pointsMulEquiv_symm_apply_single_generator`: the inverse
+  equivalence sends a root of unity to the point taking the standard generator to it.
 
 This is a worked-example check for the reductive-groups roadmap, Layer 4:
 "`μ_n = D(ℤ/n)`" in the diagonalizable-groups lane, together with the Layer 0 functor-of-points
@@ -72,7 +74,7 @@ private lemma card_multiplicative_zmod (n : ℕ) :
 
 /-- Characters of `Multiplicative (ZMod n)` are canonically `n`th roots of unity, by evaluation
 on the standard generator. -/
-noncomputable def characterMulEquivRootsOfUnity (n : ℕ) :
+private noncomputable def characterMulEquivRootsOfUnity (n : ℕ) :
     (Multiplicative (ZMod n) →* Aˣ) ≃* rootsOfUnity n A :=
   ((IsCyclic.monoidHomMulEquivRootsOfUnityOfGenerator (mem_zpowers_generator n) Aˣ).trans
       (MulEquiv.subgroupCongr (by rw [card_multiplicative_zmod n]))).trans
@@ -86,10 +88,19 @@ projection. `monoidHomMulEquivRootsOfUnityOfGenerator` carries `χ` to
 `IsUnit.unit_spec`; `subgroupCongr` and `rootsOfUnityUnitsMulEquiv` are both identity on the
 underlying value. The composite value in `A` is therefore definitionally `χ (generator n)`. -/
 @[simp]
-lemma characterMulEquivRootsOfUnity_apply (n : ℕ) (χ : Multiplicative (ZMod n) →* Aˣ) :
+private lemma characterMulEquivRootsOfUnity_apply (n : ℕ)
+    (χ : Multiplicative (ZMod n) →* Aˣ) :
     ((characterMulEquivRootsOfUnity (A := A) n χ : Aˣ) : A) =
       (χ (generator n) : A) :=
   rfl
+
+private lemma characterMulEquivRootsOfUnity_symm_apply_generator
+    (n : ℕ) (ζ : rootsOfUnity n A) :
+    (((characterMulEquivRootsOfUnity (A := A) n).symm ζ (generator n) : Aˣ) : A) =
+      ((ζ : Aˣ) : A) := by
+  rw [← characterMulEquivRootsOfUnity_apply n
+    ((characterMulEquivRootsOfUnity (A := A) n).symm ζ)]
+  simp
 
 /-- The functor of points of `μ_n = D(ℤ/n)` is the group of `n`th roots of unity.
 
@@ -111,6 +122,18 @@ lemma pointsMulEquiv_apply (n : ℕ)
   rw [pointsMulEquiv, MulEquiv.trans_apply, DiagonalizableGroup.pointsMulEquiv_apply,
     characterMulEquivRootsOfUnity_apply]
   exact DiagonalizableGroup.charOfPoint_apply_coe f.ofConv (generator n)
+
+/-- The inverse points equivalence sends a root of unity to the point taking the standard
+generator to that root. -/
+@[simp]
+lemma pointsMulEquiv_symm_apply_single_generator (n : ℕ) (ζ : rootsOfUnity n A) :
+    ((pointsMulEquiv (R := R) (A := A) n).symm ζ).ofConv
+        (MonoidAlgebra.single (generator n) 1) =
+      ((ζ : Aˣ) : A) := by
+  rw [pointsMulEquiv, MulEquiv.symm_trans_apply,
+    DiagonalizableGroup.pointsMulEquiv_symm_apply, ofConv_toConv,
+    DiagonalizableGroup.point_single_one,
+    characterMulEquivRootsOfUnity_symm_apply_generator]
 
 end RootsOfUnityGroup
 

--- a/TauCeti/Algebra/AlgebraicGroup/RootsOfUnity.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/RootsOfUnity.lean
@@ -52,10 +52,10 @@ abbrev generator (n : ℕ) : Multiplicative (ZMod n) :=
   Multiplicative.ofAdd 1
 
 /-- Every element of `Multiplicative (ZMod n)` is a power of the standard generator. -/
-lemma mem_zpowers_generator (n : ℕ) (x : Multiplicative (ZMod n)) :
+private lemma mem_zpowers_generator (n : ℕ) (x : Multiplicative (ZMod n)) :
     x ∈ Subgroup.zpowers (generator n) := by
   refine ⟨(Multiplicative.toAdd x).cast, ?_⟩
-  change (Multiplicative.ofAdd (1 : ZMod n)) ^ (Multiplicative.toAdd x).cast = x
+  simp only [generator]
   rw [← ofAdd_zsmul]
   calc
     Multiplicative.ofAdd ((Multiplicative.toAdd x).cast • (1 : ZMod n)) =
@@ -66,7 +66,7 @@ lemma mem_zpowers_generator (n : ℕ) (x : Multiplicative (ZMod n)) :
 
 /-- The cardinality of the standard cyclic character group is `n`. -/
 @[simp]
-lemma natCard_multiplicative_zmod (n : ℕ) :
+private lemma card_multiplicative_zmod (n : ℕ) :
     Nat.card (Multiplicative (ZMod n)) = n := by
   exact (Nat.card_congr (Multiplicative.ofAdd : ZMod n ≃ Multiplicative (ZMod n))).trans
     (Nat.card_zmod n)
@@ -76,10 +76,16 @@ on the standard generator. -/
 noncomputable def characterMulEquivRootsOfUnity (n : ℕ) :
     (Multiplicative (ZMod n) →* Aˣ) ≃* rootsOfUnity n A :=
   ((IsCyclic.monoidHomMulEquivRootsOfUnityOfGenerator (mem_zpowers_generator n) Aˣ).trans
-      (MulEquiv.subgroupCongr (by rw [natCard_multiplicative_zmod n]))).trans
+      (MulEquiv.subgroupCongr (by rw [card_multiplicative_zmod n]))).trans
     (rootsOfUnityUnitsMulEquiv A n)
 
-/-- A character is sent to its value on the standard generator. -/
+/-- A character is sent to its value on the standard generator.
+
+The proof is `rfl`: each of the three composed equivalences acts on the underlying unit by a
+projection. `monoidHomMulEquivRootsOfUnityOfGenerator` carries `χ` to
+`(IsUnit.map χ (Group.isUnit (generator n))).unit`, whose value is `χ (generator n)` by
+`IsUnit.unit_spec`; `subgroupCongr` and `rootsOfUnityUnitsMulEquiv` are both identity on the
+underlying value. The composite value in `A` is therefore definitionally `χ (generator n)`. -/
 @[simp]
 lemma characterMulEquivRootsOfUnity_apply (n : ℕ) (χ : Multiplicative (ZMod n) →* Aˣ) :
     ((characterMulEquivRootsOfUnity (A := A) n χ : Aˣ) : A) =
@@ -105,7 +111,7 @@ lemma pointsMulEquiv_apply (n : ℕ)
       f.ofConv (MonoidAlgebra.single (generator n) 1) := by
   rw [pointsMulEquiv, MulEquiv.trans_apply, DiagonalizableGroup.pointsMulEquiv_apply,
     characterMulEquivRootsOfUnity_apply]
-  rfl
+  exact DiagonalizableGroup.charOfPoint_apply_coe f.ofConv (generator n)
 
 end RootsOfUnityGroup
 

--- a/TauCeti/Algebra/AlgebraicGroup/RootsOfUnity.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/RootsOfUnity.lean
@@ -48,6 +48,7 @@ namespace RootsOfUnityGroup
 universe u v
 
 variable {R : Type u} {A : Type v} [CommSemiring R] [CommSemiring A] [Algebra R A]
+variable {B : Type*} [CommSemiring B] [Algebra R B]
 
 /-- The standard generator of the character group defining `μ_n = D(ℤ/n)`. -/
 abbrev generator (n : ℕ) : Multiplicative (ZMod n) :=
@@ -117,6 +118,16 @@ lemma pointsMulEquiv_apply (n : ℕ)
   rw [pointsMulEquiv, MulEquiv.trans_apply, DiagonalizableGroup.pointsMulEquiv_apply,
     characterMulEquivRootsOfUnity_apply]
   exact DiagonalizableGroup.charOfPoint_apply_coe f.ofConv (generator n)
+
+/-- The points equivalence is natural in the value algebra. -/
+@[simp]
+lemma pointsMulEquiv_mapValue (n : ℕ) (φ : A →ₐ[R] B)
+    (f : WithConv (MonoidAlgebra R (Multiplicative (ZMod n)) →ₐ[R] A)) :
+    pointsMulEquiv (R := R) (A := B) n
+        (AlgHom.mapValue (H := MonoidAlgebra R (Multiplicative (ZMod n))) φ f) =
+      restrictRootsOfUnity φ.toMonoidHom n (pointsMulEquiv (R := R) (A := A) n f) := by
+  ext
+  simp [pointsMulEquiv_apply]
 
 /-- The inverse points equivalence sends a root of unity to the point taking the standard
 generator to that root. -/

--- a/TauCeti/Algebra/AlgebraicGroup/RootsOfUnity.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/RootsOfUnity.lean
@@ -65,7 +65,6 @@ private lemma mem_zpowers_generator (n : ℕ) (x : Multiplicative (ZMod n)) :
     _ = x := ofAdd_toAdd x
 
 /-- The cardinality of the standard cyclic character group is `n`. -/
-@[simp]
 private lemma card_multiplicative_zmod (n : ℕ) :
     Nat.card (Multiplicative (ZMod n)) = n := by
   exact (Nat.card_congr (Multiplicative.ofAdd : ZMod n ≃ Multiplicative (ZMod n))).trans

--- a/TauCeti/Algebra/AlgebraicGroup/RootsOfUnity.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/RootsOfUnity.lean
@@ -107,14 +107,6 @@ lemma pointsMulEquiv_apply (n : ℕ)
     characterMulEquivRootsOfUnity_apply]
   rfl
 
-/-- Under the points equivalence, convolution multiplication is multiplication of roots of
-unity. -/
-lemma pointsMulEquiv_mul (n : ℕ)
-    (f g : WithConv (MonoidAlgebra R (Multiplicative (ZMod n)) →ₐ[R] A)) :
-    pointsMulEquiv (R := R) (A := A) n (f * g) =
-      pointsMulEquiv (R := R) (A := A) n f * pointsMulEquiv (R := R) (A := A) n g := by
-  exact (pointsMulEquiv (R := R) (A := A) n).map_mul f g
-
 end RootsOfUnityGroup
 
 end TauCeti


### PR DESCRIPTION
This PR identifies the functor of points of the roots-of-unity group scheme `μ_n = D(ℤ/n)`: for every commutative `R`-algebra `A`, the convolution group of `R`-algebra maps out of `R[Multiplicative (ZMod n)]` is multiplicatively equivalent to Mathlib's subgroup `rootsOfUnity n A`. It advances `TauCetiRoadmap/ReductiveGroups/README.md`, Worked examples, the item "`μ_n`/`μ_p`", and Layer 4, the item "Diagonalizable groups and groups of multiplicative type: ... `μ_n = D(ℤ/n)`", by adding the concrete `μ_n` points calculation on top of the merged diagonalizable-group API.

<!--tauceti-target:v1 {"focus":"ReductiveGroups","id":"mu-n-roots-of-unity-points"}-->

No Mathlib infrastructure is vendored. The construction reuses Tau Ceti's `DiagonalizableGroup.pointsMulEquiv` and Mathlib's `IsCyclic.monoidHomMulEquivRootsOfUnityOfGenerator`, `rootsOfUnityUnitsMulEquiv`, and `Nat.card_zmod` roots-of-unity and cyclic-group API.

Verification: `lake exe cache get` completed with `No files to download` and `Already decompressed 8542 file(s).`; `lake build` completed with `Build completed successfully (3834 jobs).`; `lake exe axioms` completed with `axioms: audited 1833 TauCeti declaration(s); all within the allowlist [propext, Classical.choice, Quot.sound].`

🤖 Prepared with Codex
