### PR TITLE
feat: add Hopf ideal kernels

### DIFF
--- a/TauCeti.lean
+++ b/TauCeti.lean
@@ -47,6 +47,7 @@ import TauCeti.Algebra.Coalgebra.Subcomodule.Lattice
 import TauCeti.Algebra.Group.PowMonoidHom
 import TauCeti.Algebra.HopfAlgebra
 import TauCeti.Algebra.HopfAlgebra.HopfIdeal
+import TauCeti.Algebra.HopfAlgebra.Kernel
 import TauCeti.Algebra.HopfAlgebra.Quotient
 import TauCeti.Algebra.HopfAlgebra.SymmetricAlgebra
 import TauCeti.AlgebraicGeometry.WeilDivisor

--- a/TauCeti/Algebra/HopfAlgebra/Kernel.lean
+++ b/TauCeti/Algebra/HopfAlgebra/Kernel.lean
@@ -72,10 +72,7 @@ def ker (f : H →ₐc[R] K) (hf : Function.Surjective f) : HopfIdeal R H :=
       rw [Algebra.TensorProduct.map_ker (f := (f : H →ₐ[R] K)) (g := (f : H →ₐ[R] K))
         hf hf] at hker'
       rw [leftTensorIdeal_def, rightTensorIdeal_def]
-      change Coalgebra.comul (R := R) x ∈
-        Ideal.map Algebra.TensorProduct.includeLeft (RingHom.ker (f : H →ₐ[R] K)) ⊔
-          Ideal.map Algebra.TensorProduct.includeRight (RingHom.ker (f : H →ₐ[R] K))
-      exact hker')
+      convert hker' <;> rfl)
     (by
       intro x hx
       have h := CoalgHomClass.counit_comp_apply f x
@@ -150,10 +147,8 @@ theorem kerLiftBialgHom_bijective (f : H →ₐc[R] K) (hf : Function.Surjective
     obtain ⟨y, rfl⟩ := Ideal.Quotient.mkₐ_surjective R (ker f hf).toIdeal q₂
     rw [kerLiftBialgHom_mk, kerLiftBialgHom_mk] at hq
     have hsub : x - y ∈ (ker f hf).toIdeal := by
-      rw [ker_toIdeal, RingHom.mem_ker, map_sub]
-      change f x - f y = 0
-      rw [hq, sub_self]
-    change Ideal.Quotient.mk (ker f hf).toIdeal x = Ideal.Quotient.mk (ker f hf).toIdeal y
+      rw [ker_toIdeal, RingHom.mem_ker]
+      simp [map_sub, hq]
     exact (Ideal.Quotient.mk_eq_mk_iff_sub_mem (I := (ker f hf).toIdeal) x y).mpr hsub
   · intro y
     obtain ⟨x, rfl⟩ := hf y

--- a/TauCeti/Algebra/HopfAlgebra/Kernel.lean
+++ b/TauCeti/Algebra/HopfAlgebra/Kernel.lean
@@ -5,12 +5,13 @@ Released under Apache 2.0 license as described in the file LICENSE.
 import Mathlib.LinearAlgebra.TensorProduct.RightExactness
 import TauCeti.Algebra.HopfAlgebra
 import TauCeti.Algebra.HopfAlgebra.HopfIdeal
+import TauCeti.Algebra.HopfAlgebra.Quotient
 
 /-!
 # Kernels of Hopf algebra morphisms
 
-This file records that the kernel of a surjective morphism of commutative Hopf algebras is a
-Hopf ideal. The surjectivity hypothesis is the exactness input needed to identify the kernel
+This file records that the kernel of a surjective morphism of Hopf algebras is a Hopf ideal.
+The surjectivity hypothesis is the exactness input needed to identify the kernel
 of the tensor-square map with `ker f ⊗ H + H ⊗ ker f`.
 
 This is a Layer 3 prerequisite for the reductive-groups roadmap target "Hopf ideals ↔ closed
@@ -20,8 +21,9 @@ dictionary.
 ## Main declarations
 
 * `TauCeti.HopfIdeal.ker`: the Hopf ideal given by the kernel of a surjective bialgebra
-  morphism between commutative Hopf algebras.
+  morphism.
 * `TauCeti.HopfIdeal.ker_toIdeal` and `TauCeti.HopfIdeal.mem_ker`: its characteristic API.
+* `TauCeti.HopfIdeal.ker_mkBialgHom`: the kernel of the quotient morphism by `I` is `I`.
 
 ## References
 
@@ -38,7 +40,7 @@ universe u v w
 namespace HopfIdeal
 
 variable {R : Type u} {H : Type v} {K : Type w}
-variable [CommRing R] [CommRing H] [CommRing K]
+variable [CommRing R] [Ring H] [Ring K]
 variable [HopfAlgebra R H] [HopfAlgebra R K]
 
 /-- The tensor-square map sends the comultiplication of an element in the kernel of a
@@ -56,17 +58,20 @@ private theorem comul_mem_tensor_map_ker (f : H →ₐc[R] K) {x : H}
       have hfx : f x = 0 := RingHom.mem_ker.mp hx
       simpa using congrArg (Coalgebra.comul (R := R) (A := K)) hfx
 
-/-- The kernel of a surjective bialgebra morphism of commutative Hopf algebras, as a
-Hopf ideal. -/
+/-- The kernel of a surjective bialgebra morphism, as a Hopf ideal. -/
 def ker (f : H →ₐc[R] K) (hf : Function.Surjective f) : HopfIdeal R H :=
   ofIdeal (RingHom.ker (f : H →ₐ[R] K))
     (by
       intro x hx
       have hker := comul_mem_tensor_map_ker (R := R) f hx
+      -- `map_ker` is stated for the raw tensor-product algebra map, while
+      -- `comul_mem_tensor_map_ker` naturally packages the same map as a `RingHom` kernel.
       change Coalgebra.comul (R := R) x ∈
         RingHom.ker (Algebra.TensorProduct.map (f : H →ₐ[R] K) (f : H →ₐ[R] K)) at hker
       rw [Algebra.TensorProduct.map_ker (f := (f : H →ₐ[R] K)) (g := (f : H →ₐ[R] K))
         hf hf] at hker
+      -- Unfold the local tensor-ideal wrappers to match the exact image ideals produced by
+      -- `Algebra.TensorProduct.map_ker`.
       change Coalgebra.comul (R := R) x ∈
         Ideal.map Algebra.TensorProduct.includeLeft (RingHom.ker (f : H →ₐ[R] K)) ⊔
           Ideal.map Algebra.TensorProduct.includeRight (RingHom.ker (f : H →ₐ[R] K))
@@ -74,12 +79,16 @@ def ker (f : H →ₐc[R] K) (hf : Function.Surjective f) : HopfIdeal R H :=
     (by
       intro x hx
       have h := LinearMap.congr_fun (CoalgHomClass.counit_comp f) x
+      -- `CoalgHomClass.counit_comp` is a linear-map equality; this exposes its pointwise
+      -- counit statement for the bialgebra-hom coercion.
       change Coalgebra.counit (R := R) (f x) = Coalgebra.counit (R := R) x at h
       have hfx : f x = 0 := RingHom.mem_ker.mp hx
       simpa [hfx] using h.symm)
     (by
       intro x hx
       rw [RingHom.mem_ker]
+      -- Normalize the algebra-hom coercion in the kernel goal so `BialgHom.map_antipode`
+      -- rewrites the displayed expression directly.
       change f (HopfAlgebra.antipode R x) = 0
       have hfx : f x = 0 := RingHom.mem_ker.mp hx
       rw [BialgHom.map_antipode, hfx]
@@ -113,6 +122,14 @@ theorem ker_eq_bot_iff (f : H →ₐc[R] K) (hf : Function.Surjective f) :
     ext x
     rw [mem_ker, mem_bot]
     exact ⟨fun hx => hinj (by simpa using hx), fun hx => by rw [hx, map_zero]⟩
+
+/-- The Hopf-ideal kernel of the quotient morphism by `I` is `I`. -/
+@[simp]
+theorem ker_mkBialgHom (I : HopfIdeal R H) :
+    ker (mkBialgHom I) (Ideal.Quotient.mkₐ_surjective R I.toIdeal) = I := by
+  ext x
+  rw [mem_ker, mkBialgHom_apply, Ideal.Quotient.mkₐ_eq_mk,
+    Ideal.Quotient.eq_zero_iff_mem, mem_toIdeal]
 
 end HopfIdeal
 

--- a/TauCeti/Algebra/HopfAlgebra/Kernel.lean
+++ b/TauCeti/Algebra/HopfAlgebra/Kernel.lean
@@ -60,6 +60,20 @@ private theorem comul_mem_tensor_map_ker (f : H →ₐc[R] K) {x : H}
       have hfx : f x = 0 := RingHom.mem_ker.mp hx
       simpa using congrArg (Coalgebra.comul (R := R) (A := K)) hfx
 
+/-- The tensor-kernel exactness theorem in the tensor-ideal notation used by `HopfIdeal`. -/
+private theorem tensor_map_ker_eq_left_sup_right (f : H →ₐc[R] K)
+    (hf : Function.Surjective f) :
+    RingHom.ker (Algebra.TensorProduct.map (f : H →ₐ[R] K) (f : H →ₐ[R] K)) =
+      leftTensorIdeal (R := R) (H := H) (RingHom.ker (f : H →ₐ[R] K)) ⊔
+        rightTensorIdeal (R := R) (H := H) (RingHom.ker (f : H →ₐ[R] K)) := by
+  rw [Algebra.TensorProduct.map_ker (f := (f : H →ₐ[R] K)) (g := (f : H →ₐ[R] K)) hf hf,
+    leftTensorIdeal_def, rightTensorIdeal_def]
+  simp only [AlgHom.toRingHom_eq_coe]
+  -- `map_ker` states the two maps via algebra-hom coercions, while `leftTensorIdeal_def`
+  -- and `rightTensorIdeal_def` use their `toRingHom`; after the named coercion rewrite
+  -- these are the same ideal maps definitionally.
+  apply congr_arg₂ (· ⊔ ·) <;> rfl
+
 /-- The kernel of a surjective bialgebra morphism, as a Hopf ideal. -/
 def ker (f : H →ₐc[R] K) (hf : Function.Surjective f) : HopfIdeal R H :=
   ofIdeal (RingHom.ker (f : H →ₐ[R] K))
@@ -69,10 +83,7 @@ def ker (f : H →ₐc[R] K) (hf : Function.Surjective f) : HopfIdeal R H :=
       have hker' : Coalgebra.comul (R := R) x ∈
           RingHom.ker (Algebra.TensorProduct.map (f : H →ₐ[R] K) (f : H →ₐ[R] K)) := by
         simpa using hker
-      rw [Algebra.TensorProduct.map_ker (f := (f : H →ₐ[R] K)) (g := (f : H →ₐ[R] K))
-        hf hf] at hker'
-      rw [leftTensorIdeal_def, rightTensorIdeal_def]
-      convert hker' <;> rfl)
+      rwa [tensor_map_ker_eq_left_sup_right (R := R) f hf] at hker')
     (by
       intro x hx
       have h := CoalgHomClass.counit_comp_apply f x

--- a/TauCeti/Algebra/HopfAlgebra/Kernel.lean
+++ b/TauCeti/Algebra/HopfAlgebra/Kernel.lean
@@ -25,6 +25,8 @@ dictionary.
 * `TauCeti.HopfIdeal.ker_toIdeal` and `TauCeti.HopfIdeal.mem_ker`: its characteristic API.
 * `TauCeti.HopfIdeal.kerLiftBialgHom`: the induced bialgebra morphism from the quotient by
   the kernel of a surjective morphism.
+* `TauCeti.HopfIdeal.kerLiftBialgEquiv`: the resulting bialgebra equivalence from the quotient
+  by the kernel to the codomain.
 * `TauCeti.HopfIdeal.ker_mkBialgHom`: the kernel of the quotient morphism by `I` is `I`.
 
 ## References
@@ -150,20 +152,37 @@ theorem kerLiftBialgHom_comp_mkBialgHom (f : H →ₐc[R] K) (hf : Function.Surj
 
 /-- The quotient by the Hopf-ideal kernel of a surjective morphism maps bijectively to the
 codomain. -/
-theorem kerLiftBialgHom_bijective (f : H →ₐc[R] K) (hf : Function.Surjective f) :
+private theorem kerLiftBialgHom_bijective (f : H →ₐc[R] K) (hf : Function.Surjective f) :
     Function.Bijective (kerLiftBialgHom f hf) := by
-  constructor
-  · intro q₁ q₂ hq
-    obtain ⟨x, rfl⟩ := Ideal.Quotient.mkₐ_surjective R (ker f hf).toIdeal q₁
-    obtain ⟨y, rfl⟩ := Ideal.Quotient.mkₐ_surjective R (ker f hf).toIdeal q₂
-    rw [kerLiftBialgHom_mk, kerLiftBialgHom_mk] at hq
-    have hsub : x - y ∈ (ker f hf).toIdeal := by
-      rw [ker_toIdeal, RingHom.mem_ker]
-      simp [map_sub, hq]
-    exact (Ideal.Quotient.mk_eq_mk_iff_sub_mem (I := (ker f hf).toIdeal) x y).mpr hsub
-  · intro y
-    obtain ⟨x, rfl⟩ := hf y
-    exact ⟨Ideal.Quotient.mkₐ R (ker f hf).toIdeal x, kerLiftBialgHom_mk f hf x⟩
+  have hfun : (kerLiftBialgHom f hf : H ⧸ (ker f hf).toIdeal → K) =
+      (Ideal.quotientKerAlgEquivOfSurjective (f := (f : H →ₐ[R] K)) hf :
+        H ⧸ RingHom.ker (f : H →ₐ[R] K) → K) := by
+    ext q
+    obtain ⟨h, rfl⟩ := Ideal.Quotient.mkₐ_surjective R (ker f hf).toIdeal q
+    rw [kerLiftBialgHom_mk, Ideal.Quotient.mkₐ_eq_mk]
+    exact (Ideal.quotientKerAlgEquivOfSurjective_mk (f := (f : H →ₐ[R] K)) hf h).symm
+  rw [hfun]
+  exact (Ideal.quotientKerAlgEquivOfSurjective (f := (f : H →ₐ[R] K)) hf).bijective
+
+/-- The quotient by the Hopf-ideal kernel of a surjective morphism is bialgebra-equivalent to
+the codomain. -/
+noncomputable def kerLiftBialgEquiv (f : H →ₐc[R] K) (hf : Function.Surjective f) :
+    (H ⧸ (ker f hf).toIdeal) ≃ₐc[R] K :=
+  BialgEquiv.ofBijective (kerLiftBialgHom f hf) (kerLiftBialgHom_bijective f hf)
+
+/-- The kernel quotient equivalence applies as the kernel quotient lift. -/
+@[simp]
+theorem kerLiftBialgEquiv_apply (f : H →ₐc[R] K) (hf : Function.Surjective f)
+    (q : H ⧸ (ker f hf).toIdeal) :
+    kerLiftBialgEquiv f hf q = kerLiftBialgHom f hf q :=
+  rfl
+
+/-- The bialgebra morphism underlying the kernel quotient equivalence is the kernel quotient
+lift. -/
+@[simp]
+theorem kerLiftBialgEquiv_toBialgHom (f : H →ₐc[R] K) (hf : Function.Surjective f) :
+    (kerLiftBialgEquiv f hf : H ⧸ (ker f hf).toIdeal →ₐc[R] K) = kerLiftBialgHom f hf :=
+  rfl
 
 /-- The Hopf-ideal kernel of the quotient morphism by `I` is `I`. -/
 @[simp]

--- a/TauCeti/Algebra/HopfAlgebra/Kernel.lean
+++ b/TauCeti/Algebra/HopfAlgebra/Kernel.lean
@@ -1,0 +1,119 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+import Mathlib.LinearAlgebra.TensorProduct.RightExactness
+import TauCeti.Algebra.HopfAlgebra
+import TauCeti.Algebra.HopfAlgebra.HopfIdeal
+
+/-!
+# Kernels of Hopf algebra morphisms
+
+This file records that the kernel of a surjective morphism of commutative Hopf algebras is a
+Hopf ideal. The surjectivity hypothesis is the exactness input needed to identify the kernel
+of the tensor-square map with `ker f ⊗ H + H ⊗ ker f`.
+
+This is a Layer 3 prerequisite for the reductive-groups roadmap target "Hopf ideals ↔ closed
+subgroup schemes", specifically the "kernels" part of the Hopf-ideal/closed-subgroup
+dictionary.
+
+## Main declarations
+
+* `TauCeti.HopfIdeal.ker`: the Hopf ideal given by the kernel of a surjective bialgebra
+  morphism between commutative Hopf algebras.
+* `TauCeti.HopfIdeal.ker_toIdeal` and `TauCeti.HopfIdeal.mem_ker`: its characteristic API.
+
+## References
+
+The construction is the standard kernel Hopf ideal. The tensor-kernel exactness step uses
+Mathlib's `Algebra.TensorProduct.map_ker`.
+-/
+
+open scoped TensorProduct
+
+namespace TauCeti
+
+universe u v w
+
+namespace HopfIdeal
+
+variable {R : Type u} {H : Type v} {K : Type w}
+variable [CommRing R] [CommRing H] [CommRing K]
+variable [HopfAlgebra R H] [HopfAlgebra R K]
+
+/-- The tensor-square map sends the comultiplication of an element in the kernel of a
+bialgebra morphism to zero. -/
+private theorem comul_mem_tensor_map_ker (f : H →ₐc[R] K) {x : H}
+    (hx : x ∈ RingHom.ker (f : H →ₐ[R] K)) :
+    Coalgebra.comul (R := R) x ∈
+      RingHom.ker
+        (Algebra.TensorProduct.map (f : H →ₐ[R] K) (f : H →ₐ[R] K)).toRingHom := by
+  rw [RingHom.mem_ker]
+  calc
+    Algebra.TensorProduct.map (f : H →ₐ[R] K) (f : H →ₐ[R] K) (Coalgebra.comul (R := R) x)
+        = Coalgebra.comul (R := R) (f x) := CoalgHomClass.map_comp_comul_apply f x
+    _ = 0 := by
+      have hfx : f x = 0 := RingHom.mem_ker.mp hx
+      simpa using congrArg (Coalgebra.comul (R := R) (A := K)) hfx
+
+/-- The kernel of a surjective bialgebra morphism of commutative Hopf algebras, as a
+Hopf ideal. -/
+def ker (f : H →ₐc[R] K) (hf : Function.Surjective f) : HopfIdeal R H :=
+  ofIdeal (RingHom.ker (f : H →ₐ[R] K))
+    (by
+      intro x hx
+      have hker := comul_mem_tensor_map_ker (R := R) f hx
+      change Coalgebra.comul (R := R) x ∈
+        RingHom.ker (Algebra.TensorProduct.map (f : H →ₐ[R] K) (f : H →ₐ[R] K)) at hker
+      rw [Algebra.TensorProduct.map_ker (f := (f : H →ₐ[R] K)) (g := (f : H →ₐ[R] K))
+        hf hf] at hker
+      change Coalgebra.comul (R := R) x ∈
+        Ideal.map Algebra.TensorProduct.includeLeft (RingHom.ker (f : H →ₐ[R] K)) ⊔
+          Ideal.map Algebra.TensorProduct.includeRight (RingHom.ker (f : H →ₐ[R] K))
+      exact hker)
+    (by
+      intro x hx
+      have h := LinearMap.congr_fun (CoalgHomClass.counit_comp f) x
+      change Coalgebra.counit (R := R) (f x) = Coalgebra.counit (R := R) x at h
+      have hfx : f x = 0 := RingHom.mem_ker.mp hx
+      simpa [hfx] using h.symm)
+    (by
+      intro x hx
+      rw [RingHom.mem_ker]
+      change f (HopfAlgebra.antipode R x) = 0
+      have hfx : f x = 0 := RingHom.mem_ker.mp hx
+      rw [BialgHom.map_antipode, hfx]
+      simp)
+
+/-- The underlying ideal of the kernel Hopf ideal is the ring-hom kernel. -/
+@[simp]
+theorem ker_toIdeal (f : H →ₐc[R] K) (hf : Function.Surjective f) :
+    (ker f hf).toIdeal = RingHom.ker (f : H →ₐ[R] K) :=
+  rfl
+
+/-- Membership in the kernel Hopf ideal is vanishing under the bialgebra morphism. -/
+@[simp]
+theorem mem_ker (f : H →ₐc[R] K) (hf : Function.Surjective f) {x : H} :
+    x ∈ ker f hf ↔ f x = 0 := by
+  rw [← mem_toIdeal, ker_toIdeal, RingHom.mem_ker]
+  rfl
+
+/-- The kernel Hopf ideal is bottom exactly when the morphism is injective. -/
+theorem ker_eq_bot_iff (f : H →ₐc[R] K) (hf : Function.Surjective f) :
+    ker f hf = ⊥ ↔ Function.Injective f := by
+  constructor
+  · intro h x y hxy
+    have hmem : x - y ∈ ker f hf := by
+      rw [mem_ker, map_sub, hxy, sub_self]
+    have hzero : x - y = 0 := by
+      rw [h] at hmem
+      exact (HopfIdeal.mem_bot (R := R) (H := H)).mp hmem
+    exact sub_eq_zero.mp hzero
+  · intro hinj
+    ext x
+    rw [mem_ker, mem_bot]
+    exact ⟨fun hx => hinj (by simpa using hx), fun hx => by rw [hx, map_zero]⟩
+
+end HopfIdeal
+
+end TauCeti

--- a/TauCeti/Algebra/HopfAlgebra/Kernel.lean
+++ b/TauCeti/Algebra/HopfAlgebra/Kernel.lean
@@ -23,6 +23,8 @@ dictionary.
 * `TauCeti.HopfIdeal.ker`: the Hopf ideal given by the kernel of a surjective bialgebra
   morphism.
 * `TauCeti.HopfIdeal.ker_toIdeal` and `TauCeti.HopfIdeal.mem_ker`: its characteristic API.
+* `TauCeti.HopfIdeal.kerLiftBialgHom`: the induced bialgebra morphism from the quotient by
+  the kernel of a surjective morphism.
 * `TauCeti.HopfIdeal.ker_mkBialgHom`: the kernel of the quotient morphism by `I` is `I`.
 
 ## References
@@ -64,35 +66,26 @@ def ker (f : H →ₐc[R] K) (hf : Function.Surjective f) : HopfIdeal R H :=
     (by
       intro x hx
       have hker := comul_mem_tensor_map_ker (R := R) f hx
-      -- `map_ker` is stated for the raw tensor-product algebra map, while
-      -- `comul_mem_tensor_map_ker` naturally packages the same map as a `RingHom` kernel.
-      change Coalgebra.comul (R := R) x ∈
-        RingHom.ker (Algebra.TensorProduct.map (f : H →ₐ[R] K) (f : H →ₐ[R] K)) at hker
+      have hker' : Coalgebra.comul (R := R) x ∈
+          RingHom.ker (Algebra.TensorProduct.map (f : H →ₐ[R] K) (f : H →ₐ[R] K)) := by
+        simpa using hker
       rw [Algebra.TensorProduct.map_ker (f := (f : H →ₐ[R] K)) (g := (f : H →ₐ[R] K))
-        hf hf] at hker
-      -- Unfold the local tensor-ideal wrappers to match the exact image ideals produced by
-      -- `Algebra.TensorProduct.map_ker`.
+        hf hf] at hker'
+      rw [leftTensorIdeal_def, rightTensorIdeal_def]
       change Coalgebra.comul (R := R) x ∈
         Ideal.map Algebra.TensorProduct.includeLeft (RingHom.ker (f : H →ₐ[R] K)) ⊔
           Ideal.map Algebra.TensorProduct.includeRight (RingHom.ker (f : H →ₐ[R] K))
-      exact hker)
+      exact hker')
     (by
       intro x hx
-      have h := LinearMap.congr_fun (CoalgHomClass.counit_comp f) x
-      -- `CoalgHomClass.counit_comp` is a linear-map equality; this exposes its pointwise
-      -- counit statement for the bialgebra-hom coercion.
-      change Coalgebra.counit (R := R) (f x) = Coalgebra.counit (R := R) x at h
+      have h := CoalgHomClass.counit_comp_apply f x
       have hfx : f x = 0 := RingHom.mem_ker.mp hx
       simpa [hfx] using h.symm)
     (by
       intro x hx
       rw [RingHom.mem_ker]
-      -- Normalize the algebra-hom coercion in the kernel goal so `BialgHom.map_antipode`
-      -- rewrites the displayed expression directly.
-      change f (HopfAlgebra.antipode R x) = 0
       have hfx : f x = 0 := RingHom.mem_ker.mp hx
-      rw [BialgHom.map_antipode, hfx]
-      simp)
+      simp [hfx, BialgHom.map_antipode f x])
 
 /-- The underlying ideal of the kernel Hopf ideal is the ring-hom kernel. -/
 @[simp]
@@ -122,6 +115,49 @@ theorem ker_eq_bot_iff (f : H →ₐc[R] K) (hf : Function.Surjective f) :
     ext x
     rw [mem_ker, mem_bot]
     exact ⟨fun hx => hinj (by simpa using hx), fun hx => by rw [hx, map_zero]⟩
+
+/-- The bialgebra morphism induced from a surjective morphism on the quotient by its
+Hopf-ideal kernel. -/
+noncomputable def kerLiftBialgHom (f : H →ₐc[R] K) (hf : Function.Surjective f) :
+    H ⧸ (ker f hf).toIdeal →ₐc[R] K :=
+  liftBialgHom (ker f hf) f (by
+    intro x hx
+    simpa [ker_toIdeal] using hx)
+
+/-- The kernel quotient lift evaluates on quotient classes as the original morphism. -/
+@[simp]
+theorem kerLiftBialgHom_mk (f : H →ₐc[R] K) (hf : Function.Surjective f) (h : H) :
+    kerLiftBialgHom f hf (Ideal.Quotient.mkₐ R (ker f hf).toIdeal h) = f h :=
+  liftBialgHom_mk (ker f hf) f (by
+    intro x hx
+    simpa [ker_toIdeal] using hx) h
+
+/-- The kernel quotient lift composed with the quotient map is the original morphism. -/
+@[simp]
+theorem kerLiftBialgHom_comp_mkBialgHom (f : H →ₐc[R] K) (hf : Function.Surjective f) :
+    (kerLiftBialgHom f hf).comp (mkBialgHom (ker f hf)) = f :=
+  liftBialgHom_comp_mkBialgHom (ker f hf) f (by
+    intro x hx
+    simpa [ker_toIdeal] using hx)
+
+/-- The quotient by the Hopf-ideal kernel of a surjective morphism maps bijectively to the
+codomain. -/
+theorem kerLiftBialgHom_bijective (f : H →ₐc[R] K) (hf : Function.Surjective f) :
+    Function.Bijective (kerLiftBialgHom f hf) := by
+  constructor
+  · intro q₁ q₂ hq
+    obtain ⟨x, rfl⟩ := Ideal.Quotient.mkₐ_surjective R (ker f hf).toIdeal q₁
+    obtain ⟨y, rfl⟩ := Ideal.Quotient.mkₐ_surjective R (ker f hf).toIdeal q₂
+    rw [kerLiftBialgHom_mk, kerLiftBialgHom_mk] at hq
+    have hsub : x - y ∈ (ker f hf).toIdeal := by
+      rw [ker_toIdeal, RingHom.mem_ker, map_sub]
+      change f x - f y = 0
+      rw [hq, sub_self]
+    change Ideal.Quotient.mk (ker f hf).toIdeal x = Ideal.Quotient.mk (ker f hf).toIdeal y
+    exact (Ideal.Quotient.mk_eq_mk_iff_sub_mem (I := (ker f hf).toIdeal) x y).mpr hsub
+  · intro y
+    obtain ⟨x, rfl⟩ := hf y
+    exact ⟨Ideal.Quotient.mkₐ R (ker f hf).toIdeal x, kerLiftBialgHom_mk f hf x⟩
 
 /-- The Hopf-ideal kernel of the quotient morphism by `I` is `I`. -/
 @[simp]


### PR DESCRIPTION
This PR adds the Hopf ideal associated to the kernel of a surjective bialgebra morphism between commutative Hopf algebras. It advances `TauCetiRoadmap/ReductiveGroups/README.md`, Layer 3, the item "Hopf ideals ↔ closed subgroup schemes: an ideal `I` with `Δ(I) ⊆ I⊗A + A⊗I`, `ε(I)=0`, `S(I) ⊆ I`; the quotient Hopf algebra `A/I`; the anti-equivalence; kernels" by supplying the kernel half needed alongside the existing Hopf-ideal quotient API.

<!--tauceti-target:v1 {"focus":"ReductiveGroups","id":"hopf-ideal-kernel"}-->

No Mathlib infrastructure is vendored. The proof reuses Mathlib's `Algebra.TensorProduct.map_ker` for the tensor-square kernel exactness of a surjective algebra map, together with Mathlib bialgebra morphism compatibility for counit/comultiplication and Tau Ceti's `BialgHom.map_antipode` API.

Verification: `lake exe cache get` completed with `No files to download` and `Already decompressed 8542 file(s).`; `lake build` completed with `Build completed successfully (3836 jobs).`; `lake exe axioms` completed with `axioms: audited 1872 TauCeti declaration(s); all within the allowlist [propext, Classical.choice, Quot.sound].`

🤖 Prepared with Codex
