### PR TITLE
test: fix-ci fixture (deliberately broken proof)

### DIFF
--- a/TauCeti.lean
+++ b/TauCeti.lean
@@ -76,4 +76,5 @@ import TauCeti.NumberTheory.Multiquadratic.SquareClass
 import TauCeti.NumberTheory.NumberField.MultiquadraticSplitting
 import TauCeti.NumberTheory.NumberField.QuadraticSplitting
 import TauCeti.NumberTheory.NumberField.SplitsCompletely
+import TauCeti.ScratchFixCI
 import TauCeti.Topology.Algebra.HomeomorphAction

--- a/TauCeti/ScratchFixCI.lean
+++ b/TauCeti/ScratchFixCI.lean
@@ -1,0 +1,11 @@
+import Mathlib.Tactic
+
+namespace TauCeti
+
+/-- Fix-ci fixture: the proof below is deliberately broken (references a non-existent lemma) so the
+`build` check is red. The worker's fix-ci round should repair it to a correct proof and push green.
+Safe to delete. -/
+theorem fixci_probe (n : Nat) : n + 0 = n := by
+  exact Nat.this_lemma_does_not_exist n
+
+end TauCeti

--- a/TauCeti/ScratchFixCI.lean
+++ b/TauCeti/ScratchFixCI.lean
@@ -6,6 +6,6 @@ namespace TauCeti
 `build` check is red. The worker's fix-ci round should repair it to a correct proof and push green.
 Safe to delete. -/
 theorem fixci_probe (n : Nat) : n + 0 = n := by
-  exact Nat.this_lemma_does_not_exist n
+  exact Nat.add_zero n
 
 end TauCeti


### PR DESCRIPTION
This PR adds a theorem with a deliberately broken proof so the build is red, to exercise the worker's fix-ci workflow end to end (codex should repair the proof in a bubble and push green). Safe to close.

🤖 Prepared with Claude Code