### PR TITLE
test: rebase fixture (aggregator import conflict)

### DIFF
--- a/TauCeti.lean
+++ b/TauCeti.lean
@@ -16,6 +16,7 @@ import TauCeti.Algebra.AlgebraicGroup.HopfMap
 import TauCeti.Algebra.AlgebraicGroup.MultiplicativeGroup
 import TauCeti.Algebra.AlgebraicGroup.PointsFunctor
 import TauCeti.Algebra.AlgebraicGroup.Product
+import TauCeti.Algebra.AlgebraicGroup.RebaseProbe
 import TauCeti.Algebra.Bialgebra.TensorProduct
 import TauCeti.Algebra.Coalgebra.Comodule
 import TauCeti.Algebra.Coalgebra.Comodule.Cofree

--- a/TauCeti/Algebra/AlgebraicGroup/RebaseProbe.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/RebaseProbe.lean
@@ -1,0 +1,10 @@
+import Mathlib.Tactic
+
+namespace TauCeti
+
+/-- Rebase fixture: a trivial probe so this PR adds an import line into the `TauCeti.lean`
+aggregator's `Algebra.AlgebraicGroup` block, colliding with an import main added there
+(`RootsOfUnity`). This exercises the worker's rebase (import-union) workflow. Safe to delete. -/
+theorem rebase_probe : True := trivial
+
+end TauCeti


### PR DESCRIPTION
This PR forks before #182 and adds an import into the same `TauCeti.lean` AlgebraicGroup block, so it is CONFLICTING with main — to exercise the worker's rebase (import-union) workflow in a bubble. Safe to close.

🤖 Prepared with Claude Code