### PR TITLE
doc: correct the README's review-automation status

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ When a PR is opened, we first let CI run, including the full Mathlib linter set.
 
 PR contributors can push further commits, or respond to review comments, in order to solicit updated reviews.
 
-We've built the infrastructure to fire these reviews automatically on each PR (and on a `/review` comment), but it is currently switched off. For now, reviews are run from the command line.
+These reviews fire automatically on each PR once its build is green (and on a `/review` comment), and a green PR merges automatically.
 
 You can also run the same review yourself from the command line, on your own Claude and/or Codex subscription instead of the project's metered API budget, using the `tauceti-review` tool in [TauCetiReview](https://github.com/FormalFrontier/TauCetiReview). With [uv](https://docs.astral.sh/uv/):
 


### PR DESCRIPTION
This PR corrects the README's Review section, which falsely claimed the automatic-review infrastructure was switched off and that reviews ran only from the command line. The `.github/workflows/review.yml` workflow is in fact live: it fires automatically once a PR's build is green (and on a `/review` comment), and green PRs merge automatically. The follow-up sentence about running the same review yourself from the command line now reads naturally as the supplementary "also" path.

🤖 Prepared with Claude Code