### PR TITLE
ci: pin the TauCetiReview review workflow to a commit

### DIFF
--- a/.github/workflows/review.yml
+++ b/.github/workflows/review.yml
@@ -103,7 +103,8 @@ jobs:
   review:
     needs: resolve
     if: ${{ needs.resolve.outputs.pr != '' }}
-    uses: FormalFrontier/TauCetiReview/.github/workflows/review.yml@main
+    # Pinned to a TauCetiReview commit; bump deliberately. Unpinned @main would let an upstream change break every contributor's review at once.
+    uses: FormalFrontier/TauCetiReview/.github/workflows/review.yml@688aea57fce6afee14e51707c987048924ecdf56
     with:
       pr: ${{ needs.resolve.outputs.pr }}
       trigger: ${{ github.event_name }}


### PR DESCRIPTION
This PR pins the reusable review workflow reference in `.github/workflows/review.yml` from the moving `@main` to the current TauCetiReview main commit `688aea57fce6afee14e51707c987048924ecdf56`, and adds a comment noting that bumps should be deliberate. An unpinned `@main` would let any upstream change break every contributor's review at once; pinning makes upgrades an explicit, reviewable step.

This addresses the unpinned-`@main` half of the risk. The `secrets: inherit` exposure to a reusable workflow this repo can't see is inherent to the reusable-workflow pattern and is left as a follow-up.

🤖 Prepared with Claude Code