### PR TITLE
doc: reference the Tau Ceti roadmap by name, not as an in-repo path

### DIFF
--- a/TauCeti/Algebra/AlgebraicGroup/AdditiveGroup.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/AdditiveGroup.lean
@@ -16,7 +16,7 @@ recovers the one-dimensional additive group `𝔾ₐ = Spec R[X]`, whose `A`-val
 `(A, +)`; the `R`-points are this construction specialized to `A = R`.
 
 This is the worked example `𝔾ₐ` from the Tau Ceti reductive-groups roadmap
-(`TauCetiRoadmap/ReductiveGroups/README.md`, "Worked examples" and Layer 0, "R-points as a
+(`ReductiveGroups/README.md` in TauCetiRoadmap, "Worked examples" and Layer 0, "R-points as a
 group"), in the same spirit as the multiplicative group `𝔾ₘ`.
 
 ## Main declarations

--- a/TauCeti/Algebra/AlgebraicGroup/FiniteTypeCommHopfAlgCat.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/FiniteTypeCommHopfAlgCat.lean
@@ -29,7 +29,7 @@ reductive-groups roadmap: the Hopf algebra structure carries the group law, whil
 ## References
 
 This is the finite-type coordinate-Hopf-algebra wrapper requested by
-`TauCetiRoadmap/ReductiveGroups/README.md`, in the standing hypotheses and Layer 0
+`ReductiveGroups/README.md` in TauCetiRoadmap, in the standing hypotheses and Layer 0
 three-way dictionary: an affine group scheme of finite type over `k` is modeled by a
 commutative Hopf `k`-algebra finitely generated as a `k`-algebra. The finite-type algebra
 infrastructure is Mathlib's `FGAlgCat` and `Algebra.FiniteType`; the Hopf algebra category

--- a/TauCeti/Algebra/AlgebraicGroup/Product.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/Product.lean
@@ -38,7 +38,7 @@ instances of pre-composition with the bialgebra morphisms from
 
 This realizes the "products of affine group schemes" computation on the functor of points, in
 the spirit of the worked examples of the Tau Ceti ReductiveGroups roadmap
-(`TauCetiRoadmap/ReductiveGroups/README.md`, Layer 0 "R-points as a group" and the three
+(`ReductiveGroups/README.md` in TauCetiRoadmap, Layer 0 "R-points as a group" and the three
 synchronized models). The tensor-product bialgebra structure and its unit and identity
 isomorphisms are from Mathlib's `Mathlib.RingTheory.Bialgebra.TensorProduct`; the universal
 property `Algebra.TensorProduct.lift` is from Mathlib's

--- a/TauCeti/Algebra/Coalgebra/Comodule/Cofree.lean
+++ b/TauCeti/Algebra/Coalgebra/Comodule/Cofree.lean
@@ -41,7 +41,7 @@ explicitly. This follows the convention already used for `Comodule.trivial` and
 This is the cofree (coinduced) comodule of a coalgebra; see for example Sweedler, *Hopf
 Algebras*, Chapter 2. It is added for the Layer 1 target "Comodules over a coalgebra/Hopf
 algebra" of the Tau Ceti reductive-groups roadmap,
-`TauCetiRoadmap/ReductiveGroups/README.md`, specifically the regular/cofree representations and
+`ReductiveGroups/README.md` in TauCetiRoadmap, specifically the regular/cofree representations and
 the adjunction underlying the embedding theorem.
 -/
 

--- a/TauCeti/Algebra/Coalgebra/Comodule/Finite.lean
+++ b/TauCeti/Algebra/Coalgebra/Comodule/Finite.lean
@@ -33,7 +33,7 @@ reconstruction should be built on this full subcategory rather than on all comod
 ## References
 
 This supplies the finite-dimensional-category part of
-`TauCetiRoadmap/ReductiveGroups/README.md`, Layer 1 target "Comodules over a coalgebra/Hopf
+`ReductiveGroups/README.md` in TauCetiRoadmap, Layer 1 target "Comodules over a coalgebra/Hopf
 algebra". The construction follows Mathlib's `FGModuleCat` pattern: finite objects are a full
 subcategory defined by the object property `Module.Finite`.
 -/

--- a/TauCeti/Algebra/Coalgebra/Comodule/FinitePreadditive.lean
+++ b/TauCeti/Algebra/Coalgebra/Comodule/FinitePreadditive.lean
@@ -32,7 +32,7 @@ Tannakian reconstruction can be built on finitely generated comodules.
 ## References
 
 This supplies additive-category bookkeeping for
-`TauCetiRoadmap/ReductiveGroups/README.md`, Layer 1 target "Comodules over a coalgebra/Hopf
+`ReductiveGroups/README.md` in TauCetiRoadmap, Layer 1 target "Comodules over a coalgebra/Hopf
 algebra": the finite-dimensional comodule category should have additive hom-sets before the
 rigid monoidal representation category is developed. The transfer mechanism is Mathlib's
 `ObjectProperty.FullSubcategory` preadditive instance.

--- a/TauCeti/Algebra/Coalgebra/Comodule/MatrixCoefficient.lean
+++ b/TauCeti/Algebra/Coalgebra/Comodule/MatrixCoefficient.lean
@@ -30,7 +30,7 @@ coefficients.
 
 This is standard coalgebra/comodule terminology; see Sweedler, *Hopf Algebras*, Chapter 2.
 It supplies the "matrix coefficients" prerequisite in
-`TauCetiRoadmap/ReductiveGroups/README.md`, Layer 1, "The dictionary: representation of
+`ReductiveGroups/README.md` in TauCetiRoadmap, Layer 1, "The dictionary: representation of
 `G` ⇆ `A`-comodule; matrix coefficients."
 -/
 

--- a/TauCeti/Algebra/Coalgebra/Comodule/MatrixCoefficientAdjoin.lean
+++ b/TauCeti/Algebra/Coalgebra/Comodule/MatrixCoefficientAdjoin.lean
@@ -31,7 +31,7 @@ representation is faithful exactly when its matrix coefficients generate `A`.
 ## References
 
 This is standard coalgebra/comodule terminology; see Sweedler, *Hopf Algebras*, Chapter 2.
-It supplies a prerequisite for `TauCetiRoadmap/ReductiveGroups/README.md`, Layer 1,
+It supplies a prerequisite for `ReductiveGroups/README.md` in TauCetiRoadmap, Layer 1,
 "Faithfulness done right", where faithful representations are characterized by their matrix
 coefficients generating the coordinate Hopf algebra.
 -/

--- a/TauCeti/Algebra/Coalgebra/Comodule/MatrixCoefficientFunctorial.lean
+++ b/TauCeti/Algebra/Coalgebra/Comodule/MatrixCoefficientFunctorial.lean
@@ -30,7 +30,7 @@ generate the coordinate Hopf algebra.
 
 This is standard matrix-coefficient functoriality for comodules; see Sweedler, *Hopf
 Algebras*, Chapter 2. It supplies a prerequisite for
-`TauCetiRoadmap/ReductiveGroups/README.md`, Layer 1, "Faithfulness done right", where
+`ReductiveGroups/README.md` in TauCetiRoadmap, Layer 1, "Faithfulness done right", where
 faithful representations are characterized by their matrix coefficients generating the
 coordinate Hopf algebra.
 -/

--- a/TauCeti/Algebra/Coalgebra/Comodule/Preadditive.lean
+++ b/TauCeti/Algebra/Coalgebra/Comodule/Preadditive.lean
@@ -31,7 +31,7 @@ representation category can be developed.
 ## References
 
 This supplies a prerequisite for
-`TauCetiRoadmap/ReductiveGroups/README.md`, Layer 1 target "Comodules over a coalgebra/Hopf
+`ReductiveGroups/README.md` in TauCetiRoadmap, Layer 1 target "Comodules over a coalgebra/Hopf
 algebra": the finite-dimensional comodule representation category should be an additive
 category before tensor products, duals, and Tannakian structure are built on top.
 -/

--- a/TauCeti/Algebra/Coalgebra/Comodule/Transport.lean
+++ b/TauCeti/Algebra/Coalgebra/Comodule/Transport.lean
@@ -25,7 +25,7 @@ unfolding the definition of a comodule.
 
 ## References
 
-This supplies infrastructure for `TauCetiRoadmap/ReductiveGroups/README.md`, Layer 1 target
+This supplies infrastructure for `ReductiveGroups/README.md` in TauCetiRoadmap, Layer 1 target
 "Comodules over a coalgebra/Hopf algebra", specifically the categorical API needed before
 tensor products and duals of comodules.
 -/

--- a/TauCeti/Algebra/Coalgebra/Comodule/Trivial.lean
+++ b/TauCeti/Algebra/Coalgebra/Comodule/Trivial.lean
@@ -36,7 +36,7 @@ choose the trivial one.
 ## References
 
 This supplies a small prerequisite for the Tau Ceti reductive-groups roadmap,
-`TauCetiRoadmap/ReductiveGroups/README.md`, Layer 1 target "Comodules over a coalgebra/Hopf
+`ReductiveGroups/README.md` in TauCetiRoadmap, Layer 1 target "Comodules over a coalgebra/Hopf
 algebra", specifically the tensor-unit side of the requested tensor-product and rigid
 monoidal comodule category. It uses Mathlib's bialgebra API from
 `Mathlib.RingTheory.Bialgebra.GroupLike`.

--- a/TauCeti/Algebra/Coalgebra/Comodule/Zero.lean
+++ b/TauCeti/Algebra/Coalgebra/Comodule/Zero.lean
@@ -27,7 +27,7 @@ concrete carrier.
 
 The construction is the standard zero object in the category of comodules; see Sweedler,
 *Hopf Algebras*, Chapter 2. It supplies an additive-category prerequisite for
-`TauCetiRoadmap/ReductiveGroups/README.md`, Layer 1, "Comodules over a coalgebra/Hopf
+`ReductiveGroups/README.md` in TauCetiRoadmap, Layer 1, "Comodules over a coalgebra/Hopf
 algebra". The proof that a subsingleton bundled comodule is zero follows Mathlib's
 `SemimoduleCat.isZero_of_subsingleton` / `ModuleCat.isZero_of_subsingleton` pattern.
 -/


### PR DESCRIPTION
This PR rewords module docstrings under `TauCeti/` that cited `TauCetiRoadmap/ReductiveGroups/README.md` as if it were a path in this repository. TauCetiRoadmap is a separate repository, so a TauCeti-only clone hits dead filesystem references. Each citation now reads ``ReductiveGroups/README.md` in the TauCetiRoadmap repository`, keeping the specific roadmap area, layer, and target identifiers intact. Only comment prose changes; no Lean code is touched.

🤖 Prepared with Claude Code