### PR TITLE
ci: auto-merge green PRs without generating reviews in CI

### DIFF
--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -1,0 +1,69 @@
+name: Auto-merge
+
+# Merge a PR automatically once it is genuinely ready, WITHOUT generating any reviews here (that is
+# expensive — it spends API budget — and is gated off in review.yml). Reviews are produced by people
+# running tauceti-review / tauceti locally, which push the verdict ledger to the reviews branch and
+# post the scoreboard comment. This workflow just reads that ledger and merges when ready.
+#
+# It calls the lightweight TauCetiReview merge-only workflow, which mints no provider keys, runs no
+# reviewer, and merges only when the engine's own rule says so: build green on HEAD, every blocking
+# rubric green on HEAD, every changed path under TauCeti/ (plus the allowed root files), and bump-guard
+# green for any Lake-pin change. The decision is read from the real ledger, so a forged scoreboard
+# comment can only TRIGGER a re-check, never supply a verdict — which is why the triggers below can be
+# loose: an over-trigger is a cheap no-op, never a wrong merge.
+
+on:
+  # Head is freshly green: re-check whether this PR is now mergeable.
+  workflow_run:
+    workflows: ["pr-build"]
+    types: [completed]
+  # A review scoreboard was just posted or edited (a local review may have turned the PR green).
+  issue_comment:
+    types: [created, edited]
+
+permissions:
+  contents: read
+  pull-requests: read
+
+concurrency:
+  group: auto-merge-${{ github.event.issue.number || github.event.workflow_run.head_sha }}
+  cancel-in-progress: false
+
+jobs:
+  resolve:
+    runs-on: ubuntu-latest
+    # Only react to a successful build, or to a comment carrying the scoreboard marker on a PR.
+    if: >
+      (github.event_name == 'workflow_run'
+        && github.event.workflow_run.conclusion == 'success'
+        && github.event.workflow_run.event == 'pull_request_target')
+      || (github.event_name == 'issue_comment'
+        && github.event.issue.pull_request != null
+        && contains(github.event.comment.body, 'tauceti-meta:v1'))
+    outputs:
+      pr: ${{ steps.r.outputs.pr }}
+    steps:
+      - id: r
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+          if [ "${{ github.event_name }}" = "issue_comment" ]; then
+            echo "pr=${{ github.event.issue.number }}" >> "$GITHUB_OUTPUT"
+          else
+            pr="${{ github.event.workflow_run.pull_requests[0].number }}"
+            if [ -z "$pr" ]; then
+              pr=$(gh api "repos/$REPO/commits/${{ github.event.workflow_run.head_sha }}/pulls" --jq '.[0].number // empty')
+            fi
+            echo "pr=$pr" >> "$GITHUB_OUTPUT"
+          fi
+
+  merge:
+    needs: resolve
+    if: ${{ needs.resolve.outputs.pr != '' }}
+    # Pinned to a TauCetiReview commit; bump deliberately (the same policy as review.yml).
+    uses: FormalFrontier/TauCetiReview/.github/workflows/merge-only.yml@main
+    with:
+      pr: ${{ needs.resolve.outputs.pr }}
+    secrets: inherit

--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -62,10 +62,9 @@ jobs:
   merge:
     needs: resolve
     if: ${{ needs.resolve.outputs.pr != '' }}
-    # NOTE: currently @main — pin to a TauCetiReview commit SHA once #62 is merged (same policy as
-    # review.yml). The reusable workflow receives the App secrets, so a floating ref is a supply-chain
-    # risk until pinned.
-    uses: FormalFrontier/TauCetiReview/.github/workflows/merge-only.yml@main
+    # Pinned to a TauCetiReview commit; bump deliberately. The reusable workflow receives the App
+    # secrets, so a floating @main would be a supply-chain risk.
+    uses: FormalFrontier/TauCetiReview/.github/workflows/merge-only.yml@8141201d620b0ae986222bea6ee25d7c0d3d1e72
     with:
       pr: ${{ needs.resolve.outputs.pr }}
     # Pass only the App credentials merge-only needs, not all of TauCeti's secrets.

--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -62,8 +62,13 @@ jobs:
   merge:
     needs: resolve
     if: ${{ needs.resolve.outputs.pr != '' }}
-    # Pinned to a TauCetiReview commit; bump deliberately (the same policy as review.yml).
+    # NOTE: currently @main — pin to a TauCetiReview commit SHA once #62 is merged (same policy as
+    # review.yml). The reusable workflow receives the App secrets, so a floating ref is a supply-chain
+    # risk until pinned.
     uses: FormalFrontier/TauCetiReview/.github/workflows/merge-only.yml@main
     with:
       pr: ${{ needs.resolve.outputs.pr }}
-    secrets: inherit
+    # Pass only the App credentials merge-only needs, not all of TauCeti's secrets.
+    secrets:
+      APP_ID: ${{ secrets.APP_ID }}
+      APP_PRIVATE_KEY: ${{ secrets.APP_PRIVATE_KEY }}

--- a/.github/workflows/review.yml
+++ b/.github/workflows/review.yml
@@ -102,12 +102,17 @@ jobs:
 
   review:
     needs: resolve
-    if: ${{ needs.resolve.outputs.pr != '' }}
+    # GENERATING reviews in CI spends API budget, so it is OFF unless the repo variable
+    # CI_REVIEW_ENABLED is set to 'true'. While off, reviews are run from the command line
+    # (tauceti-review in TauCetiReview, or tauceti from TauCetiWorker). Merging is independent:
+    # auto-merge.yml merges a green PR regardless of this gate. Re-enable by setting the variable.
+    if: ${{ vars.CI_REVIEW_ENABLED == 'true' && needs.resolve.outputs.pr != '' }}
     uses: FormalFrontier/TauCetiReview/.github/workflows/review.yml@main
     with:
       pr: ${{ needs.resolve.outputs.pr }}
       trigger: ${{ github.event_name }}
-      enable_automerge: true
+      # Merging is handled by auto-merge.yml (the single merge path), so generation never merges.
+      enable_automerge: false
       mode: ${{ needs.resolve.outputs.mode }}
       reply_rubric: ${{ needs.resolve.outputs.reply_rubric }}
       reply_comment_id: ${{ needs.resolve.outputs.reply_comment_id }}

--- a/.github/workflows/review.yml
+++ b/.github/workflows/review.yml
@@ -107,7 +107,9 @@ jobs:
     # (tauceti-review in TauCetiReview, or tauceti from TauCetiWorker). Merging is independent:
     # auto-merge.yml merges a green PR regardless of this gate. Re-enable by setting the variable.
     if: ${{ vars.CI_REVIEW_ENABLED == 'true' && needs.resolve.outputs.pr != '' }}
-    uses: FormalFrontier/TauCetiReview/.github/workflows/review.yml@main
+    # Pinned to a TauCetiReview commit; bump deliberately (an unpinned @main lets an upstream change
+    # break every contributor's review at once, and this workflow inherits TauCeti's secrets).
+    uses: FormalFrontier/TauCetiReview/.github/workflows/review.yml@8141201d620b0ae986222bea6ee25d7c0d3d1e72
     with:
       pr: ${{ needs.resolve.outputs.pr }}
       trigger: ${{ github.event_name }}


### PR DESCRIPTION
This PR splits review generation from merging. Generating reviews in CI spends API budget, so `review.yml`'s review job is gated behind a `CI_REVIEW_ENABLED` repository variable (off by default); for now reviews are run from the command line via `tauceti-review` or `tauceti`. Merging is now handled by a new always-on, cheap `auto-merge.yml` that calls TauCetiReview's no-dispatch merge-only workflow: it mints no provider keys, runs no reviewer, and merges only when the engine's own rule says so (build green on HEAD, every blocking rubric green on HEAD, `TauCeti/`-only paths, bump-guard green for any Lake-pin change). Reviews come from people running the engine locally; CI notices the green ledger and merges, never paying to generate.

Depends on FormalFrontier/TauCetiReview#62 (the `merge-only.yml` workflow + no-dispatch `merge` mode). Merge that first, then this references it — the `@main` pin here is bumped to the merged SHA once #62 lands. Supersedes #195 (which disabled the whole review job, taking auto-merge down with it).

🤖 Prepared with Claude Code