### PR TITLE
fix: scope the bump-guard check to the PR's own pin delta

### DIFF
--- a/.github/workflows/bump-guard.yml
+++ b/.github/workflows/bump-guard.yml
@@ -40,19 +40,38 @@ jobs:
             NUM='${{ github.event.pull_request.number }}'
             SHA='${{ github.event.pull_request.head.sha }}'
             REPO='${{ github.event.pull_request.head.repo.full_name }}'
+            BASE_REF='${{ github.event.pull_request.base.ref }}'
           else
             NUM='${{ inputs.pr }}'
-            SHA=$(gh api "repos/${{ github.repository }}/pulls/$NUM" --jq .head.sha)
+            SHA=$(gh api "repos/${{ github.repository }}/pulls/$NUM"  --jq .head.sha)
             REPO=$(gh api "repos/${{ github.repository }}/pulls/$NUM" --jq .head.repo.full_name)
+            BASE_REF=$(gh api "repos/${{ github.repository }}/pulls/$NUM" --jq .base.ref)
           fi
-          echo "num=$NUM"   >> "$GITHUB_OUTPUT"
-          echo "sha=$SHA"   >> "$GITHUB_OUTPUT"
-          echo "repo=$REPO" >> "$GITHUB_OUTPUT"
-          echo "Validating PR #$NUM @ $SHA from $REPO"
+          # Merge-base with the target branch: check-bump.sh uses it to tell the PR's own
+          # lakefile/pin delta apart from the target branch simply moving ahead. owner:sha
+          # head form so a fork head resolves too. `|| true` keeps the command-substitution
+          # nonzero from tripping the shell's set -e before the fallback runs; on any miss
+          # we fall back to the tip (BASE_REF) — at worst the pre-fix behaviour, never a break.
+          OWNER="${REPO%%/*}"
+          MB=$(gh api "repos/${{ github.repository }}/compare/${BASE_REF}...${OWNER}:${SHA}" \
+                 --jq '.merge_base_commit.sha' 2>/dev/null || true)
+          [ -n "$MB" ] || { MB="$BASE_REF"; echo "::warning::merge-base unresolved; falling back to $BASE_REF tip"; }
+          echo "num=$NUM"      >> "$GITHUB_OUTPUT"
+          echo "sha=$SHA"      >> "$GITHUB_OUTPUT"
+          echo "repo=$REPO"    >> "$GITHUB_OUTPUT"
+          echo "mergebase=$MB" >> "$GITHUB_OUTPUT"
+          echo "Validating PR #$NUM @ $SHA from $REPO (delta vs merge-base $MB)"
 
-      - name: Checkout base (trusted — the validator and base config)
+      - name: Checkout base (trusted — the validator and the current target-tip config)
         uses: actions/checkout@v4
         with: { path: base, persist-credentials: false }
+
+      - name: Checkout merge-base config (trusted ancestor — only to scope the PR's delta)
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ steps.pr.outputs.mergebase }}
+          path: mergebase
+          persist-credentials: false
 
       - name: Checkout PR head (untrusted, no credentials — read as text only)
         uses: actions/checkout@v4
@@ -66,9 +85,10 @@ jobs:
         id: guard
         env: { GH_TOKEN: "${{ github.token }}" }
         run: |
-          # The base copy of the script and base config are trusted; only the
-          # PR's lean-toolchain/lake-manifest.json/lakefile.* are read from pr/.
-          bash base/Scripts/check-bump.sh base pr
+          # The validator script and the BASE config it judges a genuine bump against are
+          # the trusted target tip; mergebase/ only scopes the PR's own delta; pr/ is read
+          # as text. See Scripts/check-bump.sh.
+          bash base/Scripts/check-bump.sh base mergebase pr
 
       - name: Report bump-guard status to the PR head commit
         if: always()

--- a/.github/workflows/pr-build.yml
+++ b/.github/workflows/pr-build.yml
@@ -42,15 +42,26 @@ jobs:
             NUM='${{ github.event.pull_request.number }}'
             SHA='${{ github.event.pull_request.head.sha }}'
             REPO='${{ github.event.pull_request.head.repo.full_name }}'
+            BASE_REF='${{ github.event.pull_request.base.ref }}'
           else
             NUM='${{ inputs.pr }}'
-            SHA=$(gh api "repos/${{ github.repository }}/pulls/$NUM" --jq .head.sha)
+            SHA=$(gh api "repos/${{ github.repository }}/pulls/$NUM"  --jq .head.sha)
             REPO=$(gh api "repos/${{ github.repository }}/pulls/$NUM" --jq .head.repo.full_name)
+            BASE_REF=$(gh api "repos/${{ github.repository }}/pulls/$NUM" --jq .base.ref)
           fi
-          echo "num=$NUM"   >> "$GITHUB_OUTPUT"
-          echo "sha=$SHA"   >> "$GITHUB_OUTPUT"
-          echo "repo=$REPO" >> "$GITHUB_OUTPUT"
-          echo "Building PR #$NUM @ $SHA from $REPO"
+          # Merge-base with the target branch, for the Lake-pin bump validation below:
+          # check-bump.sh uses it to scope the PR's own pin delta. owner:sha for forks;
+          # `|| true` so a failed substitution does not trip set -e before the fallback;
+          # on any miss fall back to the tip (BASE_REF) — at worst the pre-fix behaviour.
+          OWNER="${REPO%%/*}"
+          MB=$(gh api "repos/${{ github.repository }}/compare/${BASE_REF}...${OWNER}:${SHA}" \
+                 --jq '.merge_base_commit.sha' 2>/dev/null || true)
+          [ -n "$MB" ] || { MB="$BASE_REF"; echo "::warning::merge-base unresolved; falling back to $BASE_REF tip"; }
+          echo "num=$NUM"      >> "$GITHUB_OUTPUT"
+          echo "sha=$SHA"      >> "$GITHUB_OUTPUT"
+          echo "repo=$REPO"    >> "$GITHUB_OUTPUT"
+          echo "mergebase=$MB" >> "$GITHUB_OUTPUT"
+          echo "Building PR #$NUM @ $SHA from $REPO (bump delta vs merge-base $MB)"
 
       - name: Scope guard — PR must touch only TauCeti/ or the root TauCeti.lean (from the trusted GitHub file list)
         env: { GH_TOKEN: "${{ github.token }}" }
@@ -105,6 +116,14 @@ jobs:
         uses: actions/checkout@v4
         with: { path: base, persist-credentials: false }
 
+      - name: Checkout merge-base config (trusted ancestor — only to scope the PR's pin delta)
+        if: ${{ env.INFRA != '1' && env.BUMP == '1' }}
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ steps.pr.outputs.mergebase }}
+          path: mergebase
+          persist-credentials: false
+
       - name: Checkout PR head (untrusted, no credentials)
         if: ${{ env.INFRA != '1' }}
         uses: actions/checkout@v4
@@ -115,16 +134,16 @@ jobs:
           persist-credentials: false
 
       # For a Lake-pin PR, validate it is a safe forward bump BEFORE overlaying its
-      # pins or building. The validator is always the TRUSTED base copy of the script,
-      # run against the base config and the PR's (text-only) pin files; it executes no
-      # PR code. An invalid/backward/forked bump sets INFRA=1 → not built, routed to a
-      # human. (Run inline, not by reading the separate bump-guard status, to avoid a
-      # race with that concurrently-running workflow.)
+      # pins or building. The validator and the BASE config it judges against are the
+      # TRUSTED current target tip; mergebase/ only scopes the PR's own pin delta; pr/
+      # is read as text — no PR code runs. An invalid/backward/forked bump sets INFRA=1
+      # → not built, routed to a human. (Run inline, not by reading the separate
+      # bump-guard status, to avoid a race with that concurrently-running workflow.)
       - name: Validate the Lake-pin bump (trusted base validator) before building
         if: ${{ env.INFRA != '1' && env.BUMP == '1' }}
         env: { GH_TOKEN: "${{ github.token }}" }
         run: |
-          if bash base/Scripts/check-bump.sh base pr; then
+          if bash base/Scripts/check-bump.sh base mergebase pr; then
             echo "Lake-pin bump validated — building with the PR's pins."
           else
             echo "BUMP_BAD=1" >> "$GITHUB_ENV"

--- a/Scripts/check-bump.sh
+++ b/Scripts/check-bump.sh
@@ -28,18 +28,39 @@
 # It does NO build and runs NONE of the PR's code — only reads/parses two text
 # files and queries the trusted upstream via `gh api`. Usage:
 #
-#   check-bump.sh <base_dir> <pr_dir>
+#   check-bump.sh <base_dir> <merge_base_dir> <pr_dir>
 #
 # where each dir holds the repo's lean-toolchain, lake-manifest.json, lakefile.toml
-# (and optionally lakefile.lean). Exit 0 = safe forward bump (or no pin change);
-# exit 1 = not auto-mergeable (route to a human). Reasons are printed.
+# (and optionally lakefile.lean). base_dir is the CURRENT target-branch tip — the
+# trusted config the PR actually builds and merges against, and what a genuine bump is
+# validated against. merge_base_dir is the PR's merge-base with the target branch, used
+# only to decide whether the PR changed these files at all (so a PR that is merely
+# behind the tip is not judged as if it had edited them). Exit 0 = safe forward bump
+# (or no pin change); exit 1 = not auto-mergeable (route to a human). Reasons printed.
 set -uo pipefail
 
-BASE="${1:?usage: check-bump.sh <base_dir> <pr_dir>}"
-PR="${2:?usage: check-bump.sh <base_dir> <pr_dir>}"
+BASE="${1:?usage: check-bump.sh <base_dir> <merge_base_dir> <pr_dir>}"
+MERGE_BASE="${2:?usage: check-bump.sh <base_dir> <merge_base_dir> <pr_dir>}"
+PR="${3:?usage: check-bump.sh <base_dir> <merge_base_dir> <pr_dir>}"
 
 fail() { echo "::error::bump-guard: $*"; echo "BUMP-GUARD: FAIL — $*"; exit 1; }
 ok()   { echo "BUMP-GUARD: PASS — $*"; exit 0; }
+
+# --- 0. is this a pin change at all? (the PR's OWN delta, vs its merge-base) ---
+# Validate only what the PR itself changes in the human-owned lakefile and the Lake
+# pins. If none of these differ from the merge-base, the PR did not touch them — it is
+# not a bump (it may merely be behind the target tip, which has moved them forward
+# underneath it), so pass trivially. Only when the PR's own delta touches one of them
+# do we judge it, strictly, against the CURRENT base config (steps 1–4 below). This is
+# the one fact that needs the merge-base; everything below is relative to BASE (tip).
+pin_changed=0
+for f in lakefile.toml lakefile.lean lake-manifest.json lean-toolchain; do
+  m="$MERGE_BASE/$f"; p="$PR/$f"
+  [ -f "$m" ] || m=/dev/null
+  [ -f "$p" ] || p=/dev/null
+  if ! diff -q "$m" "$p" >/dev/null 2>&1; then pin_changed=1; break; fi
+done
+[ "$pin_changed" = 0 ] && ok "no lakefile or Lake-pin change relative to the merge-base"
 
 # --- 1. lakefile is human-owned: it must not change ---------------------------
 for f in lakefile.toml lakefile.lean; do


### PR DESCRIPTION
This PR fixes a false positive in the `bump-guard` check (and the identical inline check in `pr-build`): a content PR that branched before an unrelated lakefile or Lake-pin bump merged to the target branch, and never touched those files itself, was failing with `lakefile.toml differs from base — lakefile edits are human-owned` and routing to a human. The cause is that `Scripts/check-bump.sh` diffed the PR head against the target branch *tip*, so a PR merely sitting behind a pin move was judged as if it had edited the pins.

The fix keeps all the decision logic in the one shared validator both workflows already call. `Scripts/check-bump.sh` now takes `<base> <merge_base> <pr>` and first asks whether the PR changes the lakefile or the Lake pins *relative to its merge-base with the target branch*. If it does not, the PR is not a bump and passes trivially. Only when the PR's own delta touches those files does it run the existing strict validation — and that validation is still against the **current** target tip (`base`), so a genuine bump is judged against the live trusted config, never a stale merge-base. The merge-base is used for exactly one thing: telling the PR's own delta apart from the branch moving ahead underneath it.

Because the strict path is unchanged and still anchored on the current tip, the trust boundary is intact: a bump that is behind a lakefile change on the target branch still fails against the current lakefile and routes to a human (verified). Both `bump-guard.yml` and `pr-build.yml` resolve the merge-base via the GitHub compare API (`owner:sha` head form, so fork heads resolve) and fall back to the tip if that call fails, so a transient API error can at worst reproduce the old behaviour and never breaks a run.

Verified by replay against live data: PR #183 (a content PR behind a lakefile bump) now passes via the trivial gate; the real mathlib bump in #184 still passes the full strict validation; and a synthetic bump sitting behind a lakefile change on the target still fails to a human.

🤖 Prepared with Claude Code