### PR TITLE
feat: run pr-build and bump-guard on merge_group for the merge queue

### DIFF
--- a/.github/workflows/bump-guard.yml
+++ b/.github/workflows/bump-guard.yml
@@ -16,6 +16,11 @@ name: bump-guard
 on:
   pull_request_target:
     types: [opened, synchronize, reopened]
+  # Re-validate each merge-queue entry and post `bump-guard` on the merge-group commit, so the
+  # queue's required check is satisfied. The PR's own pin delta is unchanged by queueing, so a
+  # content PR still passes trivially and a real bump is still judged against the current tip.
+  merge_group:
+    types: [checks_requested]
   workflow_dispatch:
     inputs:
       pr: { description: "PR number to validate", required: true, type: string }
@@ -25,7 +30,7 @@ permissions:
   statuses: write
 
 concurrency:
-  group: bump-guard-${{ github.event.pull_request.number || inputs.pr }}
+  group: bump-guard-${{ github.event.pull_request.number || inputs.pr || github.event.merge_group.head_sha }}
   cancel-in-progress: true
 
 jobs:
@@ -36,16 +41,26 @@ jobs:
         id: pr
         env: { GH_TOKEN: "${{ github.token }}" }
         run: |
-          if [ "${{ github.event_name }}" = "pull_request_target" ]; then
+          if [ "${{ github.event_name }}" = "merge_group" ]; then
+            HEAD_REF='${{ github.event.merge_group.head_ref }}'
+            NUM=$(printf '%s' "$HEAD_REF" | sed -n 's#.*/pr-\([0-9]\{1,\}\)-.*#\1#p')
+            [ -n "$NUM" ] || { echo "::error::could not parse PR number from $HEAD_REF"; exit 1; }
+            SHA=$(gh api "repos/${{ github.repository }}/pulls/$NUM"  --jq .head.sha)
+            REPO=$(gh api "repos/${{ github.repository }}/pulls/$NUM" --jq .head.repo.full_name)
+            BASE_REF='${{ github.event.merge_group.base_ref }}'; BASE_REF="${BASE_REF#refs/heads/}"
+            STATUS_SHA='${{ github.event.merge_group.head_sha }}'
+          elif [ "${{ github.event_name }}" = "pull_request_target" ]; then
             NUM='${{ github.event.pull_request.number }}'
             SHA='${{ github.event.pull_request.head.sha }}'
             REPO='${{ github.event.pull_request.head.repo.full_name }}'
             BASE_REF='${{ github.event.pull_request.base.ref }}'
+            STATUS_SHA="$SHA"
           else
             NUM='${{ inputs.pr }}'
             SHA=$(gh api "repos/${{ github.repository }}/pulls/$NUM"  --jq .head.sha)
             REPO=$(gh api "repos/${{ github.repository }}/pulls/$NUM" --jq .head.repo.full_name)
             BASE_REF=$(gh api "repos/${{ github.repository }}/pulls/$NUM" --jq .base.ref)
+            STATUS_SHA="$SHA"
           fi
           # Merge-base with the target branch: check-bump.sh uses it to tell the PR's own
           # lakefile/pin delta apart from the target branch simply moving ahead. owner:sha
@@ -56,11 +71,12 @@ jobs:
           MB=$(gh api "repos/${{ github.repository }}/compare/${BASE_REF}...${OWNER}:${SHA}" \
                  --jq '.merge_base_commit.sha' 2>/dev/null || true)
           [ -n "$MB" ] || { MB="$BASE_REF"; echo "::warning::merge-base unresolved; falling back to $BASE_REF tip"; }
-          echo "num=$NUM"      >> "$GITHUB_OUTPUT"
-          echo "sha=$SHA"      >> "$GITHUB_OUTPUT"
-          echo "repo=$REPO"    >> "$GITHUB_OUTPUT"
-          echo "mergebase=$MB" >> "$GITHUB_OUTPUT"
-          echo "Validating PR #$NUM @ $SHA from $REPO (delta vs merge-base $MB)"
+          echo "num=$NUM"             >> "$GITHUB_OUTPUT"
+          echo "sha=$SHA"             >> "$GITHUB_OUTPUT"
+          echo "repo=$REPO"           >> "$GITHUB_OUTPUT"
+          echo "mergebase=$MB"        >> "$GITHUB_OUTPUT"
+          echo "status_sha=$STATUS_SHA" >> "$GITHUB_OUTPUT"
+          echo "Validating PR #$NUM @ $SHA from $REPO (status -> $STATUS_SHA, delta vs merge-base $MB)"
 
       - name: Checkout base (trusted — the validator and the current target-tip config)
         uses: actions/checkout@v4
@@ -99,8 +115,8 @@ jobs:
           else
             state=failure; desc="manifest/toolchain change is not a validated forward bump — needs human review"
           fi
-          gh api -X POST "repos/${{ github.repository }}/statuses/${{ steps.pr.outputs.sha }}" \
+          gh api -X POST "repos/${{ github.repository }}/statuses/${{ steps.pr.outputs.status_sha }}" \
             -f state="$state" -f context="bump-guard" -f description="$desc" \
             -f target_url="${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
-          echo "posted bump-guard=$state ($desc) to ${{ steps.pr.outputs.sha }}"
+          echo "posted bump-guard=$state ($desc) to ${{ steps.pr.outputs.status_sha }}"
           [ "$state" = "success" ]

--- a/.github/workflows/pr-build.yml
+++ b/.github/workflows/pr-build.yml
@@ -14,6 +14,12 @@ name: pr-build
 on:
   pull_request_target:
     types: [opened, synchronize, reopened]
+  # The merge queue tests each entry (PR + current main) before it lands: build the same way and
+  # post the `build` status on the merge-group commit so the queue's required check is satisfied.
+  # The queue is configured group-size 1, so "this PR overlaid on current main" — exactly what the
+  # job already builds — is the merge-group content.
+  merge_group:
+    types: [checks_requested]
   workflow_dispatch:
     inputs:
       pr: { description: "PR number to build", required: true, type: string }
@@ -23,7 +29,7 @@ permissions:
   statuses: write
 
 concurrency:
-  group: pr-build-${{ github.event.pull_request.number || inputs.pr }}
+  group: pr-build-${{ github.event.pull_request.number || inputs.pr || github.event.merge_group.head_sha }}
   cancel-in-progress: true
 
 jobs:
@@ -38,16 +44,28 @@ jobs:
         id: pr
         env: { GH_TOKEN: "${{ github.token }}" }
         run: |
-          if [ "${{ github.event_name }}" = "pull_request_target" ]; then
+          if [ "${{ github.event_name }}" = "merge_group" ]; then
+            # The queue's temp ref encodes the PR: refs/heads/gh-readonly-queue/main/pr-183-<sha>.
+            HEAD_REF='${{ github.event.merge_group.head_ref }}'
+            NUM=$(printf '%s' "$HEAD_REF" | sed -n 's#.*/pr-\([0-9]\{1,\}\)-.*#\1#p')
+            [ -n "$NUM" ] || { echo "::error::could not parse PR number from $HEAD_REF"; exit 1; }
+            SHA=$(gh api "repos/${{ github.repository }}/pulls/$NUM"  --jq .head.sha)
+            REPO=$(gh api "repos/${{ github.repository }}/pulls/$NUM" --jq .head.repo.full_name)
+            BASE_REF='${{ github.event.merge_group.base_ref }}'; BASE_REF="${BASE_REF#refs/heads/}"
+            # The queue's required check must land on the merge-group commit, not the PR head.
+            STATUS_SHA='${{ github.event.merge_group.head_sha }}'
+          elif [ "${{ github.event_name }}" = "pull_request_target" ]; then
             NUM='${{ github.event.pull_request.number }}'
             SHA='${{ github.event.pull_request.head.sha }}'
             REPO='${{ github.event.pull_request.head.repo.full_name }}'
             BASE_REF='${{ github.event.pull_request.base.ref }}'
+            STATUS_SHA="$SHA"
           else
             NUM='${{ inputs.pr }}'
             SHA=$(gh api "repos/${{ github.repository }}/pulls/$NUM"  --jq .head.sha)
             REPO=$(gh api "repos/${{ github.repository }}/pulls/$NUM" --jq .head.repo.full_name)
             BASE_REF=$(gh api "repos/${{ github.repository }}/pulls/$NUM" --jq .base.ref)
+            STATUS_SHA="$SHA"
           fi
           # Merge-base with the target branch, for the Lake-pin bump validation below:
           # check-bump.sh uses it to scope the PR's own pin delta. owner:sha for forks;
@@ -57,11 +75,12 @@ jobs:
           MB=$(gh api "repos/${{ github.repository }}/compare/${BASE_REF}...${OWNER}:${SHA}" \
                  --jq '.merge_base_commit.sha' 2>/dev/null || true)
           [ -n "$MB" ] || { MB="$BASE_REF"; echo "::warning::merge-base unresolved; falling back to $BASE_REF tip"; }
-          echo "num=$NUM"      >> "$GITHUB_OUTPUT"
-          echo "sha=$SHA"      >> "$GITHUB_OUTPUT"
-          echo "repo=$REPO"    >> "$GITHUB_OUTPUT"
-          echo "mergebase=$MB" >> "$GITHUB_OUTPUT"
-          echo "Building PR #$NUM @ $SHA from $REPO (bump delta vs merge-base $MB)"
+          echo "num=$NUM"             >> "$GITHUB_OUTPUT"
+          echo "sha=$SHA"             >> "$GITHUB_OUTPUT"
+          echo "repo=$REPO"           >> "$GITHUB_OUTPUT"
+          echo "mergebase=$MB"        >> "$GITHUB_OUTPUT"
+          echo "status_sha=$STATUS_SHA" >> "$GITHUB_OUTPUT"
+          echo "Building PR #$NUM @ $SHA from $REPO (status -> $STATUS_SHA, bump delta vs merge-base $MB)"
 
       - name: Scope guard — PR must touch only TauCeti/ or the root TauCeti.lean (from the trusted GitHub file list)
         env: { GH_TOKEN: "${{ github.token }}" }
@@ -257,8 +276,8 @@ jobs:
           else
             state=failure; desc="sandboxed build or axiom audit failed"
           fi
-          gh api -X POST "repos/${{ github.repository }}/statuses/${{ steps.pr.outputs.sha }}" \
+          gh api -X POST "repos/${{ github.repository }}/statuses/${{ steps.pr.outputs.status_sha }}" \
             -f state="$state" -f context="build" -f description="$desc" \
             -f target_url="${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
-          echo "posted build=$state ($desc) to ${{ steps.pr.outputs.sha }}"
+          echo "posted build=$state ($desc) to ${{ steps.pr.outputs.status_sha }}"
           [ "$state" = "success" ]


### PR DESCRIPTION
This PR makes the `pr-build` and `bump-guard` gating workflows also run on `merge_group` events, so a GitHub merge queue can be enabled on `main`. A merge queue tests each entry — the PR merged onto the current `main` — before it lands, and requires the same status checks (`build`, `bump-guard`) to report on the merge-group commit rather than the PR head. Both workflows now resolve the PR number from the queue's `gh-readonly-queue/main/pr-<n>-<sha>` ref, run their existing validation unchanged, and post their status on the merge-group commit via a new `status_sha` output.

The build path is reused as-is rather than duplicated: `pr-build` already overlays the PR's `TauCeti/` onto the current-`main` config and builds that, which — with the queue configured at group size 1 — is exactly the merge-group content. `bump-guard` likewise judges the PR's own pin delta against the current tip, so a content PR still passes trivially inside the queue and a real bump is still validated against current `main`. The change is inert until a merge queue is actually enabled on `main`.

This is the first half of moving merges onto a queue, so an approved PR that has simply fallen behind `main` is retested against current `main` and merged without a re-review, instead of being stranded `BEHIND` as today.

🤖 Prepared with Claude Code