### PR TITLE
chore: bump merge-only pin to the enqueue version

### DIFF
--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -64,7 +64,7 @@ jobs:
     if: ${{ needs.resolve.outputs.pr != '' }}
     # Pinned to a TauCetiReview commit; bump deliberately. The reusable workflow receives the App
     # secrets, so a floating @main would be a supply-chain risk.
-    uses: FormalFrontier/TauCetiReview/.github/workflows/merge-only.yml@8141201d620b0ae986222bea6ee25d7c0d3d1e72
+    uses: FormalFrontier/TauCetiReview/.github/workflows/merge-only.yml@c2b62aa0b8a43602d1adc1b762fd41452fcd687d
     with:
       pr: ${{ needs.resolve.outputs.pr }}
     # Pass only the App credentials merge-only needs, not all of TauCeti's secrets.


### PR DESCRIPTION
This PR points TauCeti's auto-merge at `TauCetiReview/.github/workflows/merge-only.yml@c2b62aa` (https://github.com/FormalFrontier/TauCetiReview/pull/65 — "feat: enqueue approved PRs into the merge queue instead of direct-merging"), the version that adds an approved, `TauCeti/`-only PR to the merge queue rather than squash-merging it directly. With the merge queue now enabled on `main` and `merge_group` support in `pr-build` / `bump-guard` (#201), an approved PR that has fallen behind `main` is retested against current `main` by the queue and merged without any re-review, instead of being stranded `BEHIND` as before.

🤖 Prepared with Claude Code