### PR TITLE
chore: bump merge-only pin to the TauCetiData-backed gate

### DIFF
--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -64,7 +64,7 @@ jobs:
     if: ${{ needs.resolve.outputs.pr != '' }}
     # Pinned to a TauCetiReview commit; bump deliberately. The reusable workflow receives the App
     # secrets, so a floating @main would be a supply-chain risk.
-    uses: FormalFrontier/TauCetiReview/.github/workflows/merge-only.yml@c2b62aa0b8a43602d1adc1b762fd41452fcd687d
+    uses: FormalFrontier/TauCetiReview/.github/workflows/merge-only.yml@ce4b95f196094d59cdd657b666afdc9c6353d74a
     with:
       pr: ${{ needs.resolve.outputs.pr }}
     # Pass only the App credentials merge-only needs, not all of TauCeti's secrets.


### PR DESCRIPTION
This PR points auto-merge at `TauCetiReview/.github/workflows/merge-only.yml@ce4b95f` (https://github.com/FormalFrontier/TauCetiReview/pull/66), the version that reads the live verdict store — TauCetiData round records — instead of the `reviews` branch that has been dead since June 4. The gate had been seeing zero current reviews and refusing every approved PR; with this, approved PRs (like #183 and #185) merge again through the gate and the merge queue.

🤖 Prepared with Claude Code