### PR TITLE
chore: golf and de-clutter the multiquadratic files

### DIFF
--- a/TauCeti/FieldTheory/IntermediateField/Quadratic.lean
+++ b/TauCeti/FieldTheory/IntermediateField/Quadratic.lean
@@ -154,6 +154,15 @@ theorem finrank_adjoin_simple_eq_two_of_sq_mem_notMem (F : IntermediateField K L
     exact hxF (hy ▸ y.2)
   omega
 
+-- `restrictScalars` keeps the same carrier and inherited `K`-module structure, so a `K`-finrank is
+-- unchanged by it. Mathlib's `Submodule.restrictScalarsEquiv` proves the analogue for submodules,
+-- but only as an `F`-linear equivalence, and restricting it to `K` needs `IsScalarTower`/
+-- `CompatibleSMul` instances that the tower `K → F → F⟮x⟯` does not provide for
+-- `Submodule.restrictScalars K`; so we name the definitional equality here instead.
+private theorem finrank_restrictScalars_eq (F : IntermediateField K L)
+    (E : IntermediateField F L) :
+    Module.finrank K (E.restrictScalars K) = Module.finrank K E := rfl
+
 /-- If `x² ∈ F` but `x ∉ F`, then adjoining `x` doubles the degree:
 `[F ⊔ K⟮x⟯ : K] = 2 · [F : K]`. -/
 theorem finrank_sup_adjoin_simple_eq_mul_two (F : IntermediateField K L) {x : L}
@@ -167,8 +176,8 @@ theorem finrank_sup_adjoin_simple_eq_mul_two (F : IntermediateField K L) {x : L}
     finrank_adjoin_simple_eq_two_of_sq_mem_notMem F hx2 hxF
   calc Module.finrank K ((F ⊔ IntermediateField.adjoin K {x}) : IntermediateField K L)
       = Module.finrank K ((IntermediateField.adjoin F {x}).restrictScalars K) := by rw [hL]
-    -- `restrictScalars` preserves the inherited `K`-module structure, so this step is definitional.
-    _ = Module.finrank K (IntermediateField.adjoin F {x}) := rfl
+    _ = Module.finrank K (IntermediateField.adjoin F {x}) := by
+        rw [finrank_restrictScalars_eq]
     _ = Module.finrank K F * Module.finrank F (IntermediateField.adjoin F {x}) := by
         rw [Module.finrank_mul_finrank]
     _ = Module.finrank K F * 2 := by rw [hfinL]

--- a/TauCeti/FieldTheory/IntermediateField/Quadratic.lean
+++ b/TauCeti/FieldTheory/IntermediateField/Quadratic.lean
@@ -154,12 +154,6 @@ theorem finrank_adjoin_simple_eq_two_of_sq_mem_notMem (F : IntermediateField K L
     exact hxF (hy ▸ y.2)
   omega
 
--- `restrictScalars` keeps the same carrier and inherited `K`-module structure; naming that
--- definitional equality keeps later degree computations from relying on an unexplained `rfl`.
-private theorem finrank_restrictScalars_eq (F : IntermediateField K L)
-    (E : IntermediateField F L) :
-    Module.finrank K (E.restrictScalars K) = Module.finrank K E := rfl
-
 /-- If `x² ∈ F` but `x ∉ F`, then adjoining `x` doubles the degree:
 `[F ⊔ K⟮x⟯ : K] = 2 · [F : K]`. -/
 theorem finrank_sup_adjoin_simple_eq_mul_two (F : IntermediateField K L) {x : L}
@@ -173,8 +167,8 @@ theorem finrank_sup_adjoin_simple_eq_mul_two (F : IntermediateField K L) {x : L}
     finrank_adjoin_simple_eq_two_of_sq_mem_notMem F hx2 hxF
   calc Module.finrank K ((F ⊔ IntermediateField.adjoin K {x}) : IntermediateField K L)
       = Module.finrank K ((IntermediateField.adjoin F {x}).restrictScalars K) := by rw [hL]
-    _ = Module.finrank K (IntermediateField.adjoin F {x}) := by
-        rw [finrank_restrictScalars_eq]
+    -- `restrictScalars` preserves the inherited `K`-module structure, so this step is definitional.
+    _ = Module.finrank K (IntermediateField.adjoin F {x}) := rfl
     _ = Module.finrank K F * Module.finrank F (IntermediateField.adjoin F {x}) := by
         rw [Module.finrank_mul_finrank]
     _ = Module.finrank K F * 2 := by rw [hfinL]

--- a/TauCeti/FieldTheory/IntermediateField/Quadratic.lean
+++ b/TauCeti/FieldTheory/IntermediateField/Quadratic.lean
@@ -154,12 +154,6 @@ theorem finrank_adjoin_simple_eq_two_of_sq_mem_notMem (F : IntermediateField K L
     exact hxF (hy ▸ y.2)
   omega
 
--- `restrictScalars` keeps the same carrier and inherited `K`-module structure; naming that
--- definitional equality keeps later degree computations from relying on an unexplained `change`.
-private theorem finrank_restrictScalars_eq (F : IntermediateField K L)
-    (E : IntermediateField F L) :
-    Module.finrank K (E.restrictScalars K) = Module.finrank K E := rfl
-
 /-- If `x² ∈ F` but `x ∉ F`, then adjoining `x` doubles the degree:
 `[F ⊔ K⟮x⟯ : K] = 2 · [F : K]`. -/
 theorem finrank_sup_adjoin_simple_eq_mul_two (F : IntermediateField K L) {x : L}
@@ -173,8 +167,7 @@ theorem finrank_sup_adjoin_simple_eq_mul_two (F : IntermediateField K L) {x : L}
     finrank_adjoin_simple_eq_two_of_sq_mem_notMem F hx2 hxF
   calc Module.finrank K ((F ⊔ IntermediateField.adjoin K {x}) : IntermediateField K L)
       = Module.finrank K ((IntermediateField.adjoin F {x}).restrictScalars K) := by rw [hL]
-    _ = Module.finrank K (IntermediateField.adjoin F {x}) := by
-        rw [finrank_restrictScalars_eq]
+    _ = Module.finrank K (IntermediateField.adjoin F {x}) := rfl
     _ = Module.finrank K F * Module.finrank F (IntermediateField.adjoin F {x}) := by
         rw [Module.finrank_mul_finrank]
     _ = Module.finrank K F * 2 := by rw [hfinL]

--- a/TauCeti/FieldTheory/IntermediateField/Quadratic.lean
+++ b/TauCeti/FieldTheory/IntermediateField/Quadratic.lean
@@ -154,6 +154,12 @@ theorem finrank_adjoin_simple_eq_two_of_sq_mem_notMem (F : IntermediateField K L
     exact hxF (hy ▸ y.2)
   omega
 
+-- `restrictScalars` keeps the same carrier and inherited `K`-module structure; naming that
+-- definitional equality keeps later degree computations from relying on an unexplained `rfl`.
+private theorem finrank_restrictScalars_eq (F : IntermediateField K L)
+    (E : IntermediateField F L) :
+    Module.finrank K (E.restrictScalars K) = Module.finrank K E := rfl
+
 /-- If `x² ∈ F` but `x ∉ F`, then adjoining `x` doubles the degree:
 `[F ⊔ K⟮x⟯ : K] = 2 · [F : K]`. -/
 theorem finrank_sup_adjoin_simple_eq_mul_two (F : IntermediateField K L) {x : L}
@@ -167,7 +173,8 @@ theorem finrank_sup_adjoin_simple_eq_mul_two (F : IntermediateField K L) {x : L}
     finrank_adjoin_simple_eq_two_of_sq_mem_notMem F hx2 hxF
   calc Module.finrank K ((F ⊔ IntermediateField.adjoin K {x}) : IntermediateField K L)
       = Module.finrank K ((IntermediateField.adjoin F {x}).restrictScalars K) := by rw [hL]
-    _ = Module.finrank K (IntermediateField.adjoin F {x}) := rfl
+    _ = Module.finrank K (IntermediateField.adjoin F {x}) := by
+        rw [finrank_restrictScalars_eq]
     _ = Module.finrank K F * Module.finrank F (IntermediateField.adjoin F {x}) := by
         rw [Module.finrank_mul_finrank]
     _ = Module.finrank K F * 2 := by rw [hfinL]

--- a/TauCeti/NumberTheory/Multiquadratic/Galois.lean
+++ b/TauCeti/NumberTheory/Multiquadratic/Galois.lean
@@ -203,16 +203,9 @@ theorem aut_mul_self_eq_one (hroot : ∀ i, root i ^ 2 = algebraMap K L (d i))
   refine IntermediateField.algHom_ext_of_eq_adjoin (F := K)
     (S := IntermediateField.adjoin K (Set.range root)) (s := Set.range root) rfl ?_
   rintro x ⟨i, rfl⟩
-  have hmem : root i ∈ IntermediateField.adjoin K (Set.range root) := subset_adjoin _ _ ⟨i, rfl⟩
-  set y : IntermediateField.adjoin K (Set.range root) := ⟨root i, hmem⟩ with hy
-  have hsq : y ^ 2 = algebraMap K _ (d i) := by
-    apply Subtype.ext
-    have hcoe : ((y : L)) ^ 2 = algebraMap K L (d i) := by rw [hy]; exact hroot i
-    simpa using hcoe
-  have h1 : (σ y) ^ 2 = y ^ 2 := by rw [← map_pow, hsq, AlgEquiv.commutes, ← hsq]
-  -- `σ` sends the generator to `± y`, so applying it twice returns `y`.
-  rcases sq_eq_sq_iff_eq_or_eq_neg.mp h1 with h | h <;>
-    simp [AlgEquiv.mul_apply, h, map_neg]
+  change σ (σ (gen root i)) = gen root i
+  -- `σ` sends the generator to `± gen root i`, so applying it twice returns the generator.
+  rcases aut_gen_eq_self_or_eq_neg hroot σ i with h | h <;> simp [h, map_neg]
 
 /-- The automorphism group of a multiquadratic field is commutative: every element has order
 dividing two, so any two commute. -/

--- a/TauCeti/NumberTheory/Multiquadratic/Galois.lean
+++ b/TauCeti/NumberTheory/Multiquadratic/Galois.lean
@@ -203,8 +203,10 @@ theorem aut_mul_self_eq_one (hroot : ∀ i, root i ^ 2 = algebraMap K L (d i))
   refine IntermediateField.algHom_ext_of_eq_adjoin (F := K)
     (S := IntermediateField.adjoin K (Set.range root)) (s := Set.range root) rfl ?_
   rintro x ⟨i, rfl⟩
+  -- The extensionality goal `↑(σ * σ) ⟨root i, _⟩ = ⟨root i, _⟩` is definitionally the generator
+  -- equation below: `gen root i := ⟨root i, _⟩`, and `↑(σ * σ) ·` reduces to `σ (σ ·)`. We convert
+  -- to that readable form so the `aut_gen_eq_self_or_eq_neg` case split can fire on `gen root i`.
   change σ (σ (gen root i)) = gen root i
-  -- `σ` sends the generator to `± gen root i`, so applying it twice returns the generator.
   rcases aut_gen_eq_self_or_eq_neg hroot σ i with h | h <;> simp [h, map_neg]
 
 /-- The automorphism group of a multiquadratic field is commutative: every element has order

--- a/TauCeti/NumberTheory/Multiquadratic/GaloisGroup.lean
+++ b/TauCeti/NumberTheory/Multiquadratic/GaloisGroup.lean
@@ -38,7 +38,7 @@ attribute [local instance] Classical.propDecidable
 
 namespace TauCeti.Multiquadratic
 
-variable {K L : Type*} [Field K] [Field L] [Algebra K L] {ι : Type*} [Finite ι]
+variable {K L : Type*} [Field K] [Field L] [Algebra K L] {ι : Type*}
   {d : ι → K} {root : ι → L}
 
 variable (root) in
@@ -48,7 +48,6 @@ noncomputable def signPattern
     (σ : adjoin K (Set.range root) ≃ₐ[K] adjoin K (Set.range root)) (i : ι) : ZMod 2 :=
   if σ (gen root i) = gen root i then 0 else 1
 
-omit [Finite ι] in
 /-- An automorphism acts on each generator by the corresponding sign. -/
 theorem aut_gen_eq_signPattern (hroot : ∀ i, root i ^ 2 = algebraMap K L (d i))
     (σ : adjoin K (Set.range root) ≃ₐ[K] adjoin K (Set.range root)) (i : ι) :
@@ -62,7 +61,6 @@ theorem aut_gen_eq_signPattern (hroot : ∀ i, root i ^ 2 = algebraMap K L (d i)
       have hval : (1 : ZMod 2).val = 1 := rfl
       simp [h', hval]
 
-omit [Finite ι] in
 /-- Two automorphisms with the same sign pattern are equal. -/
 theorem signPattern_injective (hroot : ∀ i, root i ^ 2 = algebraMap K L (d i)) :
     Function.Injective (signPattern (K := K) root) := by
@@ -75,14 +73,12 @@ theorem signPattern_injective (hroot : ∀ i, root i ^ 2 = algebraMap K L (d i))
     rw [aut_gen_eq_signPattern hroot, aut_gen_eq_signPattern hroot, h]
   exact hgen
 
-omit [Finite ι] in
 /-- The sign is `0` exactly where the automorphism fixes the generator. -/
 theorem signPattern_eq_zero
     (σ : adjoin K (Set.range root) ≃ₐ[K] adjoin K (Set.range root)) (i : ι)
     (h : σ (gen root i) = gen root i) : signPattern root σ i = 0 := by
   simp [signPattern, h]
 
-omit [Finite ι] in
 /-- The sign is `0` iff the automorphism fixes the generator. -/
 @[simp] theorem signPattern_eq_zero_iff
     (σ : adjoin K (Set.range root) ≃ₐ[K] adjoin K (Set.range root)) (i : ι) :
@@ -90,7 +86,6 @@ omit [Finite ι] in
   rw [signPattern]
   by_cases h : σ (gen root i) = gen root i <;> simp [h]
 
-omit [Finite ι] in
 /-- The sign is `1` where the automorphism negates a generator that differs from its negation. -/
 theorem signPattern_eq_one
     (σ : adjoin K (Set.range root) ≃ₐ[K] adjoin K (Set.range root)) (i : ι)
@@ -99,7 +94,6 @@ theorem signPattern_eq_one
   have hni : σ (gen root i) ≠ gen root i := fun hh => hne (h ▸ hh.symm)
   simp [signPattern, hni]
 
-omit [Finite ι] in
 /-- The sign is `1` iff the automorphism negates a generator that differs from its negation. -/
 @[simp]
 theorem signPattern_eq_one_iff (hroot : ∀ i, root i ^ 2 = algebraMap K L (d i))
@@ -116,13 +110,11 @@ theorem signPattern_eq_one_iff (hroot : ∀ i, root i ^ 2 = algebraMap K L (d i)
       · exact h
   · exact signPattern_eq_one σ i hne
 
-omit [Finite ι] in
 /-- The identity automorphism has the zero sign pattern. -/
 @[simp] theorem signPattern_one : signPattern (K := K) root (1 : adjoin K (Set.range root) ≃ₐ[K]
     adjoin K (Set.range root)) = 0 := by
   funext i; exact signPattern_eq_zero _ _ rfl
 
-omit [Finite ι] in
 private theorem signed_pow_add_mul (x : adjoin K (Set.range root)) (a b : ZMod 2) :
     (-1 : adjoin K (Set.range root)) ^ b.val * ((-1) ^ a.val * x)
       = (-1) ^ (a + b).val * x := by
@@ -130,12 +122,8 @@ private theorem signed_pow_add_mul (x : adjoin K (Set.range root)) (a b : ZMod 2
   rw [← mul_assoc, ← pow_add, ZMod.val_add, neg_one_pow_eq_pow_mod_two (b.val + a.val),
     add_comm b.val a.val]
 
-private theorem zmod_two_eq_zero_or_one (t : ZMod 2) : t = 0 ∨ t = 1 := by
-  fin_cases t
-  · exact Or.inl rfl
-  · exact Or.inr rfl
+private theorem zmod_two_eq_zero_or_one (t : ZMod 2) : t = 0 ∨ t = 1 := by revert t; decide
 
-omit [Finite ι] in
 private theorem aut_mul_gen_eq_signPattern_add
     (hroot : ∀ i, root i ^ 2 = algebraMap K L (d i))
     (σ τ : adjoin K (Set.range root) ≃ₐ[K] adjoin K (Set.range root)) (i : ι) :
@@ -145,7 +133,6 @@ private theorem aut_mul_gen_eq_signPattern_add
     map_one, aut_gen_eq_signPattern hroot σ i]
   exact signed_pow_add_mul (gen root i) (signPattern root σ i) (signPattern root τ i)
 
-omit [Finite ι] in
 /-- Pointwise composition rule for sign patterns. -/
 theorem signPattern_mul_apply (hroot : ∀ i, root i ^ 2 = algebraMap K L (d i))
     (σ τ : adjoin K (Set.range root) ≃ₐ[K] adjoin K (Set.range root)) (i : ι) :
@@ -166,9 +153,8 @@ theorem signPattern_mul_apply (hroot : ∀ i, root i ^ 2 = algebraMap K L (d i))
       · exact signPattern_eq_zero _ _ h
       · exact signPattern_eq_zero _ _ (h.trans hself.symm)
     rw [hsign (σ * τ), hsign σ, hsign τ]
-    decide
+    rfl
 
-omit [Finite ι] in
 /-- The sign pattern is additive: it is a group homomorphism to `ι → ℤ/2`. -/
 @[simp]
 theorem signPattern_mul (hroot : ∀ i, root i ^ 2 = algebraMap K L (d i))
@@ -186,20 +172,18 @@ noncomputable def signHom (hroot : ∀ i, root i ^ 2 = algebraMap K L (d i))
   map_one' := by simp
   map_mul' σ τ := by simp [signPattern_mul hroot, ofAdd_add]
 
-omit [Finite ι] in
 /-- Evaluation rule for `signHom`: it is the multiplicative form of `signPattern`. -/
 @[simp] theorem signHom_apply (hroot : ∀ i, root i ^ 2 = algebraMap K L (d i))
     (σ : adjoin K (Set.range root) ≃ₐ[K] adjoin K (Set.range root)) :
     signHom root hroot σ = Multiplicative.ofAdd (signPattern root σ) := rfl
 
-omit [Finite ι] in
 /-- The sign-pattern homomorphism is injective. -/
 theorem signHom_injective (hroot : ∀ i, root i ^ 2 = algebraMap K L (d i)) :
     Function.Injective (signHom (K := K) root hroot) := by
   intro σ τ h
   exact signPattern_injective hroot (Multiplicative.ofAdd.injective (by simpa using h))
 
-private theorem signHom_bijective [NeZero (2 : K)]
+private theorem signHom_bijective [Finite ι] [NeZero (2 : K)]
     (hroot : ∀ i, root i ^ 2 = algebraMap K L (d i))
     (hindep : ∀ S : Finset ι, S.Nonempty → ¬ IsSquare (∏ i ∈ S, d i)) :
     Function.Bijective (signHom (K := K) root hroot) := by
@@ -217,15 +201,15 @@ private theorem signHom_bijective [NeZero (2 : K)]
 
 /-- **For square-class independent radicands, the Galois group of a multiquadratic field is
 `(ℤ/2)ⁿ`.** -/
-noncomputable def galoisGroupEquiv [NeZero (2 : K)]
+noncomputable def galoisGroupEquiv [Finite ι] [NeZero (2 : K)]
     (hroot : ∀ i, root i ^ 2 = algebraMap K L (d i))
     (hindep : ∀ S : Finset ι, S.Nonempty → ¬ IsSquare (∏ i ∈ S, d i)) :
     (adjoin K (Set.range root) ≃ₐ[K] adjoin K (Set.range root)) ≃*
-      Multiplicative (ι → ZMod 2) := by
-  exact MulEquiv.ofBijective (signHom root hroot) (signHom_bijective hroot hindep)
+      Multiplicative (ι → ZMod 2) :=
+  MulEquiv.ofBijective (signHom root hroot) (signHom_bijective hroot hindep)
 
 /-- The Galois-group equivalence sends an automorphism to its multiplicative sign pattern. -/
-@[simp] theorem galoisGroupEquiv_apply [NeZero (2 : K)]
+@[simp] theorem galoisGroupEquiv_apply [Finite ι] [NeZero (2 : K)]
     (hroot : ∀ i, root i ^ 2 = algebraMap K L (d i))
     (hindep : ∀ S : Finset ι, S.Nonempty → ¬ IsSquare (∏ i ∈ S, d i))
     (σ : adjoin K (Set.range root) ≃ₐ[K] adjoin K (Set.range root)) :
@@ -234,7 +218,7 @@ noncomputable def galoisGroupEquiv [NeZero (2 : K)]
 
 /-- The inverse of `galoisGroupEquiv` realizes a sign pattern `ε` as the automorphism sending each
 generator `rootᵢ` to `(-1)^(εᵢ) · rootᵢ`. -/
-@[simp] theorem galoisGroupEquiv_symm_apply_gen [NeZero (2 : K)]
+@[simp] theorem galoisGroupEquiv_symm_apply_gen [Finite ι] [NeZero (2 : K)]
     (hroot : ∀ i, root i ^ 2 = algebraMap K L (d i))
     (hindep : ∀ S : Finset ι, S.Nonempty → ¬ IsSquare (∏ i ∈ S, d i))
     (ε : ι → ZMod 2) (i : ι) :

--- a/TauCeti/NumberTheory/Multiquadratic/GaloisGroup.lean
+++ b/TauCeti/NumberTheory/Multiquadratic/GaloisGroup.lean
@@ -153,6 +153,7 @@ theorem signPattern_mul_apply (hroot : ∀ i, root i ^ 2 = algebraMap K L (d i))
       · exact signPattern_eq_zero _ _ h
       · exact signPattern_eq_zero _ _ (h.trans hself.symm)
     rw [hsign (σ * τ), hsign σ, hsign τ]
+    -- All three signs are `0`, so the goal is `(0 : ZMod 2) = 0 + 0`.
     rfl
 
 /-- The sign pattern is additive: it is a group homomorphism to `ι → ℤ/2`. -/
@@ -175,6 +176,7 @@ noncomputable def signHom (hroot : ∀ i, root i ^ 2 = algebraMap K L (d i))
 /-- Evaluation rule for `signHom`: it is the multiplicative form of `signPattern`. -/
 @[simp] theorem signHom_apply (hroot : ∀ i, root i ^ 2 = algebraMap K L (d i))
     (σ : adjoin K (Set.range root) ≃ₐ[K] adjoin K (Set.range root)) :
+    -- Applying the bundled `MonoidHom` unfolds to its `toFun`, which is `ofAdd ∘ signPattern`.
     signHom root hroot σ = Multiplicative.ofAdd (signPattern root σ) := rfl
 
 /-- The sign-pattern homomorphism is injective. -/

--- a/TauCeti/NumberTheory/Multiquadratic/SquareClass.lean
+++ b/TauCeti/NumberTheory/Multiquadratic/SquareClass.lean
@@ -137,10 +137,6 @@ private theorem sqrtTower_sup_adjoin_eq_of_mem (root : ℕ → L) {n : ℕ}
   rw [sup_eq_left]
   exact IntermediateField.adjoin_le_iff.mpr (by simpa using hroot)
 
-private theorem algebraMap_eq_iff {a b : K} (h : algebraMap K L a = algebraMap K L b) :
-    a = b :=
-  RingHom.injective (algebraMap K L) h
-
 /-- **Square-class descent.** In characteristic not two, if `y² = r` over `K` and
 `y ∈ K(root₀, …, rootₙ₋₁)`, where `root j` is a chosen square root of `d j`, then `r` is a
 square times a subset product of the `d j` with `j < n`. -/
@@ -158,9 +154,7 @@ theorem squareClass_of_sq_mem (d : ℕ → K) (root : ℕ → L)
       intro r y hy hmem
       rw [sqrtTower_zero, IntermediateField.mem_bot] at hmem
       obtain ⟨s, rfl⟩ := hmem
-      have h2 : s ^ 2 = r := by
-        apply algebraMap_eq_iff (K := K) (L := L)
-        simpa using hy
+      have h2 : s ^ 2 = r := (algebraMap K L).injective (by simpa using hy)
       exact ⟨∅, s, by simp, by rw [Finset.prod_empty, mul_one, h2]⟩
   | succ n ih =>
       intro r y hy hmem
@@ -207,9 +201,7 @@ theorem squareClass_of_sq_mem (d : ℕ → K) (root : ℕ → L)
               rw [map_mul, ← hy, ← hroot n]
               ring
             obtain ⟨T, s, hT, hmul⟩ := ih (r * d n) (y * root n) hy_mul_sq hy_mul_mem
-            have hnT : n ∉ T := by
-              intro hn
-              exact (Nat.lt_irrefl n) (hT hn)
+            have hnT : n ∉ T := fun hn => Nat.lt_irrefl n (hT hn)
             refine ⟨insert n T, s / d n, ?_, ?_⟩
             · intro j hj
               rw [Finset.mem_coe, Finset.mem_insert] at hj


### PR DESCRIPTION
## What this PR does

A **cleanup-only** pass over the `NumberTheory/Multiquadratic` development and its
`FieldTheory/IntermediateField/Quadratic` dependency. No theorem statements, signatures, or
public names change — only `private` helpers and proof bodies. Net **−53 / +15** lines.

- **SquareClass.lean** — delete the thin `algebraMap_eq_iff` wrapper (inline
  `(algebraMap K L).injective`); one-line the `n ∉ T` proof.
- **Quadratic.lean** — delete `finrank_restrictScalars_eq` (it was literally `:= rfl`, with a
  comment conceding it only named a defeq); close the calc step with `rfl` directly.
- **Galois.lean** — reprove `aut_mul_self_eq_one` by reusing the existing
  `aut_gen_eq_self_or_eq_neg` instead of re-deriving the generator's square inline.
- **GaloisGroup.lean** — drop `[Finite ι]` from the file-level `variable` (it was unused by ~13
  lemmas, each carrying an `omit [Finite ι] in`); attach it only to the four finite-degree
  results. Golf `zmod_two_eq_zero_or_one` to `revert t; decide`, make `galoisGroupEquiv`
  term-mode (drop `by exact`), and replace a `decide` with `rfl`.

**Verification:** `lake build` of all six affected modules is green (2526 jobs);
`lake exe axioms` clean (1902 declarations, allowlist only).

---

> **Scope note.** This PR is the *golf* slice only. Everything below is the **post-merge quality
> review** that motivated it — context for reviewers and a menu of proposed follow-up work. It is
> deliberately **not** part of this PR (one topic per PR). The larger items are flagged as
> candidate issues / roadmap additions so agents can be run against them separately.

# Post-merge review — `Multiquadratic` (+ `MultiquadraticSplitting`, `IntermediateField/Quadratic`)

Method: full read of all six files; `/mathlibable` on the headline declarations (5 clustered
worker passes, each doing literature + five-method mathlib search); `/cleanup` style+golf audit
(2 passes). Files in scope land: square-class descent (PR #146), the `2ⁿ` degree (#147),
`IsSplittingField`/`IsGalois` + involution/abelian (#149), `Gal ≅ (ℤ/2)ⁿ` (#150), the
prime-splitting law (#173), and the migrated one-step quadratic API.

## Headline verdict

**The material is good.** The core mathematics is genuinely novel and absent from mathlib in
any form (confirmed by five-method search): square-class descent, the `2ⁿ` degree,
`IsSplittingField`/`IsGalois` for `∏(X²−dᵢ)`, the explicit `Gal ≅ (ℤ/2)ⁿ`, and the multiquadratic
prime-splitting law. It is correctly stated at good generality, well-documented, and
**exemplarily attributed** (every file carries a `## Provenance` block citing the
kim-em/erdos-unit-distance origin). Adversarial checks found **no** vacuity, mis-formalization,
or over-determined hypotheses, and characteristic-correct handling throughout. Nothing is
"terrible". What the review surfaces is a consistent layer of **altitude / idiom / API-shape**
issues plus mechanical debt — the band the hard CI gates (sorry/axiom/linter) can't see, which
lives in the soft rubrics (reuse, naming, API, placement, generality).

## 1. What is terrible?

Nothing mathematically. Weakest spots, descending:

1. **`signHom` collides with `Mathlib.Data.Sign.signHom`.** Different namespace, so it compiles,
   but a genuine naming defect a naming rubric should block.
2. **A 70-line hand-rolled `IntermediateField` that reinvents mathlib.**
   `exists_add_mul_of_mem_sup_adjoin_sq` (Quadratic.lean) builds the `a + b·x` field structure
   by hand, incl. a from-scratch `inv_mem'`. Mathlib's `IntermediateField.adjoin.powerBasis`
   already gives the `{1, x}` basis, and `Algebra.IsQuadraticExtension` packages "free of rank 2"
   (with `finrank_eq_two`, `normal`, `isGalois`, `isCyclic`, `isMulCommutative_galoisGroup`). The
   statement is novel; the proof re-derives known structure.
3. **A 150-line monolithic proof** — `ncard_primesOver_multiquadratic_iff`, two large branches,
   a ~55-line nested `hfix`, no decomposition.
4. **Over-provisioning** — the descent theorem ships in **four** forms (ℕ / `Fin n` / `Fintype`
   / `ℚ`-`ℝ`), three of them mechanical transports of the first; and ℕ-indexed scaffolding
   (`finrank_sqrtTower`, the `sqrtTower_*` family) is billed as a co-equal "Main result" when it
   is really the internal induction carrier.

## 2. What could be addressed by better reviewing?

All in the soft rubrics — the highest-leverage place to improve the review bots:

- **Reuse** — the `IsQuadraticExtension`/power-basis reinvention (above); thin wrappers that
  should be inlined/deleted (`algebraMap_eq_iff` = `RingHom.injective`; `finrank_restrictScalars_eq`
  = `rfl`; `zmod_two_eq_zero_or_one` = one-line `decide`) — *this PR removes/golfs those three*;
  `aut_commute` is a one-line wrapper of `Commute.of_orderOf_dvd_two`.
- **Naming** — the `signHom` collision; over-generic public names `gen`, `definingPolynomial`,
  `signPattern`, `galoisGroupEquiv`; `finrank_adjoin_range` doesn't encode the multiquadratic
  content.
- **API / altitude / placement** — the four-forms redundancy; the "Main results" mis-billing of
  internal scaffolding; `ncard_primesOver_multiquadratic_iff` taking raw `(d, r, hr, htop)`
  generator data instead of an intrinsic predicate (`htop` is load-bearing, not redundant — the
  shape is just un-idiomatic vs `IsCyclotomicExtension`).
- **Style** — file-scope `attribute [local instance] Classical.propDecidable` (only `signPattern`
  needs it); the `[Finite ι]`/`omit` repetition (*this PR fixes the GaloisGroup case*);
  `letI := Fintype.ofFinite ι` inside a def body; `by exact` wrappers (*fixed here*).
- **Structure** — the 150-line monolith.

**Caveat for the review harness:** a naive *byte*-length scan flags ~11 lines as ">100 cols", but
these are Unicode-dense (`√ ℚ ℤ ₐ ᵢ →* ≃ₐ`); counted in *characters* (what mathlib's `TextBased`
linter uses) all lines are ≤100 and CI is green. Any tool reporting line-length here is wrong —
worth hardcoding so it doesn't emit false positives.

## 3. What could be addressed by better prompting of the contributing AIs?

The defects are systematic, hence prompt-fixable. Suggested standing additions:

- **"Search mathlib for existing *structure* before building one."** The contributor reused
  `Commute.of_orderOf_dvd_two`, `restrictScalars_adjoin_eq_sup`, `IsGalois.card_aut_eq_finrank` —
  but missed `IsQuadraticExtension` and `adjoin.powerBasis` (the biggest reuse miss).
- **"Don't ship N forms of one theorem"** — keep the induction lemma `private`, export one form.
- **"No file-scope classical/decidability instances"** — `open Classical in` per-decl.
- **"Scope typeclass variables to the declarations that use them"** (kills the `omit` spam).
- **"Check the global mathlib namespace for collisions; name for content, not `gen`/`signHom`."**
- **"Decompose any proof longer than ~60 lines into named lemmas."**

These are mechanical enough to also encode as lints / a pre-submit checklist.

## 4. What could be addressed by better roadmaps?

The target produced solid building blocks but left the organising abstraction to be
(re)discovered per-PR. A stronger roadmap would sequence the **Kummer-theoretic substrate first**:

- **Build the missing `Kˣ/(Kˣ)²`-as-𝔽₂-vector-space + Kummer-rank API as an explicit
  prerequisite.** The degree and Galois-group results are the *free/independent* special case of
  the Kummer pairing `Gal(M/K) ≃* Hom(Δ, μ₂)`, `Δ ≤ Kˣ/(Kˣ)²`. Stated that way the degree theorem
  generalises from "`= 2ⁿ` when independent" to the full **genus formula `2ⁿ/γ`** — the
  literature-standard statement. Mathlib has no squares-quotient 𝔽₂ structure today, so naming
  this as a prerequisite turns several "generalise-first" verdicts into "add-as-is".
- **Mandate an intrinsic `IsMultiquadratic`/Kummer predicate** (à la `IsCyclotomicExtension`) so
  downstream results (the splitting law) consume an abstraction, not raw generator tuples.
- **Provide the missing combinator** "Galois group of a compositum of linearly-disjoint
  extensions ≅ product" — `galoisGroupEquiv` builds the `(ℤ/2)ⁿ` product by hand because this
  doesn't exist.

## 5. What should be addressed post-hoc, by opening issues?

Self-contained revision tickets — good tests of agents-running-against-issues. Sized S/M/L.
(The S-tier mechanical ones partly overlap this PR; the rest are deliberately out of scope here.)

| # | Issue | Size | Rubric |
|---|---|---|---|
| I1 | Rename `signHom` (collides with `Mathlib.Data.Sign.signHom`). | S | naming |
| I2 | Delete thin wrappers `algebraMap_eq_iff`, `finrank_restrictScalars_eq`, `zmod_two_eq_zero_or_one`. | S | reuse/golf — **done in this PR** |
| I3 | GaloisGroup: remove file-level `[Finite ι]` (kill `omit`s); narrow `Classical.propDecidable` to `signPattern`; drop `by exact`/`decide`. | S | style/golf — **`omit`/`by exact`/`decide` done here; `Classical.propDecidable` narrowing deferred** |
| I4 | De-duplicate the descent API: make `squareClass_of_sq_mem` (ℕ) the `private` engine, export one finite form, drop/inline `_fin`; demote `finrank_sqrtTower` + `sqrtTower_*` from "Main results". | M | API/altitude |
| I5 | Refactor `exists_add_mul_of_mem_sup_adjoin_sq` to derive the normal form from `adjoin.powerBasis`; have `finrank_adjoin_simple_eq_two_of_sq_mem_notMem` emit an `Algebra.IsQuadraticExtension` instance. Reconsider the aggressive `@[simp]` on `mem_sup_adjoin_sq`. | M | reuse |
| I6 | Decompose `ncard_primesOver_multiquadratic_iff` into ~5 named lemmas; add a `## Main results` section. | M | structure |
| I7 | Reconsider `aut_commute` — drop it or restate as `Monoid.exponent (… ≃ₐ[K] …) ∣ 2`. | S | reuse |
| I8 | Generalise degree + Galois group to the Kummer pairing over `Kˣ/(Kˣ)²` (𝔽₂-rank), recovering the full `2ⁿ/γ` genus formula. (Likely a roadmap addition.) | L | generality |
| I9 | Introduce an intrinsic `IsMultiquadratic`/Kummer predicate; restate the splitting law against it. | L | API |

## Appendix A — `/mathlibable` verdicts (per declaration)

Five-method search returned **nothing** for multiquadratic / square-class / families of square
roots; mathlib's `KummerExtension` covers only a *single* `Xⁿ − C a` (`autEquivZmod` etc.), so the
compositum results are genuinely new.

| Declaration | Verdict | Note |
|---|---|---|
| `sqrtTower` | YES-but-generalise / BORDERLINE | name overpromises (just `adjoin K (root '' Iio n)`); engine legitimately needed |
| `squareClass_of_sq_mem` | **YES-but-generalise-first** | the keystone; novel & minimal; consider `ringChar K ≠ 2` |
| `squareClass_of_sq_mem_fin` | NO-composable | redundant interlayer |
| `squareClass_of_sq_mem_fintype` | YES (keep as the public finite form) | transport of the ℕ engine |
| `squareClass_of_sqrt_mem` | NO-composable | 6-line `Real.sq_sqrt` specialisation |
| `exists_add_mul_of_mem_sup_adjoin_sq` / `mem_sup_adjoin_sq` | **BORDERLINE** | statement novel; proof reinvents `IsQuadraticExtension`/power-basis; char-2 correctly preserved |
| `finrank_adjoin_simple_eq_two_of_sq_mem_notMem` | NO-composable | ~3 lines from `adjoin.finrank`; could yield `IsQuadraticExtension` |
| `finrank_sup_adjoin_simple_eq_mul_two` | NO-composable | tower-law glue |
| `finrank_sqrtTower` | BORDERLINE / internal | should be `private`, not a "Main result" |
| `finrank_adjoin_range` | **YES-but-generalise-first** | the degree target; ideal form is `Kˣ/(Kˣ)²` 𝔽₂-rank → genus formula |
| `definingPolynomial`, `gen` | YES-but-generalise (with `isSplittingField`) | generic names; `letI` in def body |
| `isSplittingField`, `isGalois` | **YES-add-as-is** | flagship; bespoke per-generator separability handling is correct & necessary |
| `aut_mul_self_eq_one` | YES (real content: involution) | now reuses `aut_gen_eq_self_or_eq_neg` (this PR) |
| `aut_commute` | NO-composable | one-line wrapper of `Commute.of_orderOf_dvd_two` |
| `signPattern` / `signHom` (+ glue) | YES-but-generalise-first | name collision; idiomatic route is a Kummer pairing into `μ₂` |
| `galoisGroupEquiv` | **YES-add-as-is** | flagship; `Gal ≅ (ℤ/2)ⁿ` not in mathlib |
| `ncard_primesOver_multiquadratic_iff` | NO-composable / BORDERLINE | novel, not present; `htop` shape; monolith |

## Appendix B — golf applied here vs deferred

**Applied in this PR** (Appendix C of the full audit, safe subset): delete `algebraMap_eq_iff` /
`finrank_restrictScalars_eq`; golf `zmod_two_eq_zero_or_one`; one-line `n ∉ T`; reuse-based
`aut_mul_self_eq_one`; term-mode `galoisGroupEquiv`; `decide → rfl`; the GaloisGroup
`[Finite ι]`/`omit` scoping.

**Deferred** (would touch statements/structure or were not cleanly green): the `mem_sup_adjoin_sq_of_exists`
inline (SetLike coercion fought back); the Galois.lean section reorg (entangled with the
`[Finite ι]`-needing splitting-field results); the `gen_ne_neg` / `inv_mem'` `field_simp` golfs;
narrowing `Classical.propDecidable`. These belong with the structural follow-ups (I3/I5).
