### PR TITLE
chore: bump merge-only pin to the scoreboard-comment gate

### DIFF
--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -64,7 +64,7 @@ jobs:
     if: ${{ needs.resolve.outputs.pr != '' }}
     # Pinned to a TauCetiReview commit; bump deliberately. The reusable workflow receives the App
     # secrets, so a floating @main would be a supply-chain risk.
-    uses: FormalFrontier/TauCetiReview/.github/workflows/merge-only.yml@ce4b95f196094d59cdd657b666afdc9c6353d74a
+    uses: FormalFrontier/TauCetiReview/.github/workflows/merge-only.yml@77288bf5718c55d9975d150ffb27456cd94c8237
     with:
       pr: ${{ needs.resolve.outputs.pr }}
     # Pass only the App credentials merge-only needs, not all of TauCeti's secrets.


### PR DESCRIPTION
This PR bumps the pinned merge-only workflow to the TauCetiReview commit whose gate reads each PR's scoreboard COMMENT (head-pinned, full per-rubric `states`, with a table fallback for older comments) instead of the TauCetiData round records, so a contributor with no store write still has their review count via the comment they post. The hard boundary a forged scoreboard cannot bypass (CI build + scope + axiom audit + bump-guard) is unchanged.

🤖 Prepared with Claude Code