### PR TITLE
chore: bump merge-only pin past the dead roadmap-checkout removal

### DIFF
--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -64,7 +64,7 @@ jobs:
     if: ${{ needs.resolve.outputs.pr != '' }}
     # Pinned to a TauCetiReview commit; bump deliberately. The reusable workflow receives the App
     # secrets, so a floating @main would be a supply-chain risk.
-    uses: FormalFrontier/TauCetiReview/.github/workflows/merge-only.yml@77288bf5718c55d9975d150ffb27456cd94c8237
+    uses: FormalFrontier/TauCetiReview/.github/workflows/merge-only.yml@7bfab94c2d6d4e59f756775fb52e6eb58f7ca724
     with:
       pr: ${{ needs.resolve.outputs.pr }}
     # Pass only the App credentials merge-only needs, not all of TauCeti's secrets.


### PR DESCRIPTION
This PR bumps the pinned merge-only workflow past the removal of its dead `TauCetiRoadmap` checkout step (FormalFrontier/TauCetiReview#69), so the merge check no longer clones the roadmap it never reads.

🤖 Prepared with Claude Code