### PR TITLE
chore: retire the CI contest-reply path (re-land #214)

### DIFF
--- a/.github/workflows/review.yml
+++ b/.github/workflows/review.yml
@@ -6,8 +6,6 @@ on:
     types: [completed]
   issue_comment:
     types: [created]
-  pull_request_review_comment:
-    types: [created]
 
 permissions:
   contents: read
@@ -16,14 +14,12 @@ permissions:
 jobs:
   resolve:
     runs-on: ubuntu-latest
-    # Fire after the sandboxed pr-build succeeds, on a `/review` comment, or on an author's reply
-    # in a review thread (the reply flow re-runs only that rubric). The job-level `if` filters only
-    # by event type and excludes the bot; ALL authorization happens inside the step. We do not gate
-    # on `author_association` here because the pull_request_review_comment webhook reports it by
-    # *public* org membership, so a private member's reply arrives as NONE and the job would be
-    # silently skipped with no logs. Authorizing in-job (repository permission API, with the PR
-    # author and author_association as fallbacks) is reliable regardless of membership visibility
-    # and leaves an explicit accept/reject in the log.
+    # Fire after the sandboxed pr-build succeeds, or on a `/review` comment. The job-level `if`
+    # filters only by event type; ALL authorization happens inside the step (the repository
+    # permission API, reliable regardless of public/private org membership, with author_association
+    # as a fallback so /review never regresses). Author CONTESTS (a reply in a rubric thread) are no
+    # longer handled here: the local worker (tauceti) owns contest re-reviews so they have a single
+    # execution owner and one durable watermark, rather than racing a CI run.
     if: >
       (github.event_name == 'workflow_run'
         && github.event.workflow_run.conclusion == 'success'
@@ -31,13 +27,8 @@ jobs:
       || (github.event_name == 'issue_comment'
         && github.event.issue.pull_request != null
         && contains(github.event.comment.body, '/review'))
-      || (github.event_name == 'pull_request_review_comment'
-        && github.event.comment.user.login != 'tauceti-review-bot[bot]')
     outputs:
       pr: ${{ steps.r.outputs.pr }}
-      mode: ${{ steps.r.outputs.mode }}
-      reply_rubric: ${{ steps.r.outputs.reply_rubric }}
-      reply_comment_id: ${{ steps.r.outputs.reply_comment_id }}
     steps:
       - id: r
         env:
@@ -71,27 +62,6 @@ jobs:
             else
               echo "unauthorized /review by $actor; skipping"
             fi
-          elif [ "$EVENT" = "pull_request_review_comment" ]; then
-            # An author reply in a rubric thread re-runs only that rubric. The PR author may always
-            # contest on their own PR; anyone else needs write+ access.
-            pr_author=$(jq -r '.pull_request.user.login // ""' "$GITHUB_EVENT_PATH")
-            if [ "$actor" != "$pr_author" ] && ! authorized; then
-              echo "unauthorized review-comment reply by $actor; skipping"; exit 0
-            fi
-            # GitHub points every reply's in_reply_to_id at the thread's root comment; that root
-            # carries a hidden <!--tauceti-rubric:NAME--> marker we wrote. Outside such a thread: ignore.
-            ROOT="${{ github.event.comment.in_reply_to_id }}"
-            if [ -z "$ROOT" ]; then ROOT="${{ github.event.comment.id }}"; fi
-            BODY=$(gh api "repos/$REPO/pulls/comments/$ROOT" --jq '.body' 2>/dev/null || true)
-            RUBRIC=$(printf '%s' "$BODY" | sed -n 's/.*tauceti-rubric:\([a-z][a-z-]*\).*/\1/p' | head -1)
-            if [ -n "$RUBRIC" ]; then
-              echo "pr=${{ github.event.pull_request.number }}" >> "$GITHUB_OUTPUT"
-              echo "mode=reply" >> "$GITHUB_OUTPUT"
-              echo "reply_rubric=$RUBRIC" >> "$GITHUB_OUTPUT"
-              echo "reply_comment_id=${{ github.event.comment.id }}" >> "$GITHUB_OUTPUT"
-            else
-              echo "review comment is not in a Tau Ceti rubric thread; skipping"
-            fi
           else
             pr="${{ github.event.workflow_run.pull_requests[0].number }}"
             if [ -z "$pr" ]; then
@@ -115,7 +85,4 @@ jobs:
       trigger: ${{ github.event_name }}
       # Merging is handled by auto-merge.yml (the single merge path), so generation never merges.
       enable_automerge: false
-      mode: ${{ needs.resolve.outputs.mode }}
-      reply_rubric: ${{ needs.resolve.outputs.reply_rubric }}
-      reply_comment_id: ${{ needs.resolve.outputs.reply_comment_id }}
     secrets: inherit


### PR DESCRIPTION
This PR removes the `pull_request_review_comment` trigger and the reply-mode resolution from the Review workflow. Author contests (a reply in a rubric thread) are handled by the local worker (`tauceti`), so they have a single execution owner and one durable watermark rather than racing a CI run if `CI_REVIEW_ENABLED` is ever turned on. The build-success and `/review` triggers are unchanged.

Re-lands #214, whose PR head pointed at an empty commit so the squash merged no file changes.

🤖 Prepared with Claude Code