### PR TITLE
doc: name Tau Ceti explicitly in the Mathlib dependency note

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ Eventually, these review agents' token costs will be covered by some combination
 
 ## Mathlib dependency
 
-For now we depend on Mathlib's `master` branch. AIs are encouraged to make PRs that bump the pin to new commits on the `master` branch, and fix any resulting problems in the library.
+For now we depend on Mathlib's `master` branch. AIs are encouraged to make PRs to Tau Ceti that bump the pin to new commits on Mathlib's `master` branch, and fix any resulting problems in Tau Ceti.
 
 From Tau Ceti's point of view, Mathlib is a long way away, so we don't plan around close coordination: if you're missing something in Mathlib that you need, just build it here. (This includes needing material from Mathlib PRs; it's fine to just vendor it here with appropriate attribution, there's no need to wait.)
 


### PR DESCRIPTION
This PR disambiguates the "Mathlib dependency" section of the README, which ended "fix any resulting problems in the library". With both Mathlib and Tau Ceti in play, "the library" could be misread as Mathlib. Following Filippo Nuccio's suggestion on [Zulip](https://leanprover.zulipchat.com/#narrow/channel/610393-Tau-Ceti/topic/Welcome.20to.20Tau.20Ceti.21/near/604499925), this names Tau Ceti explicitly in both spots and clarifies that the pin tracks Mathlib's master.

🤖 Prepared with Claude Code