### PR TITLE
feat: add grid commutation relabeling

### DIFF
--- a/TauCeti/KnotTheory/Grid/Commutation.lean
+++ b/TauCeti/KnotTheory/Grid/Commutation.lean
@@ -1,0 +1,326 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+import TauCeti.KnotTheory.Grid.Diagram
+
+/-!
+# Row and column relabeling for grid diagrams
+
+This file records the elementary row and column relabeling operations on grid states and
+grid diagrams. The adjacent-row and adjacent-column swaps are the diagram-level operations
+underlying commutation moves; the later commutation maps and invariance proofs can add the
+non-interleaving hypotheses and rectangle-counting constructions on top of these total
+operations.
+
+## Main definitions
+
+* `TauCeti.GridState.relabelRows`: postcompose a grid state with a row permutation.
+* `TauCeti.GridState.relabelColumns`: precompose a grid state with the inverse of a column
+  permutation.
+* `TauCeti.GridDiagram.relabelRows`, `TauCeti.GridDiagram.relabelColumns`: the corresponding
+  relabelings of the `O` and `X` markings of a grid diagram.
+* `TauCeti.GridDiagram.swapRows`, `TauCeti.GridDiagram.swapColumns`: row and column swaps.
+
+## References
+
+This supplies a prerequisite for `TauCetiRoadmap/HeegaardFloer/README.md`, Lane G.5,
+"Invariance over `𝔽₂`. Grid moves = commutation + (de)stabilization." It isolates the
+underlying grid-diagram relabeling used by row and column commutations in the grid homology
+construction of Ozsváth--Stipsicz--Szabó, *Grid Homology for Knots and Links*, Chapter 3.
+-/
+
+namespace TauCeti
+
+namespace GridState
+
+variable {n : ℕ}
+
+/-- Relabel the rows of a grid state by a permutation of `Fin n`.
+
+If `ρ` is the row permutation, the point in column `c` moves from row `x c` to row
+`ρ (x c)`. -/
+def relabelRows (ρ : Equiv.Perm (Fin n)) (x : GridState n) : GridState n where
+  toPerm :=
+    { toFun := fun c => ρ (x c)
+      invFun := fun r => x.toPerm.symm (ρ.symm r)
+      left_inv := by
+        intro c
+        simp
+      right_inv := by
+        intro r
+        simp }
+
+/-- Relabel the columns of a grid state by a permutation of `Fin n`.
+
+The point in the old column `c` appears in the new column `κ c`, so the row in a new column
+`c` is read from the old column `κ.symm c`. -/
+def relabelColumns (κ : Equiv.Perm (Fin n)) (x : GridState n) : GridState n where
+  toPerm :=
+    { toFun := fun c => x (κ.symm c)
+      invFun := fun r => κ (x.toPerm.symm r)
+      left_inv := by
+        intro c
+        simp
+      right_inv := by
+        intro r
+        simp }
+
+/-- Row relabeling evaluates by applying the row permutation to the old row. -/
+@[simp]
+theorem relabelRows_apply (ρ : Equiv.Perm (Fin n)) (x : GridState n) (c : Fin n) :
+    x.relabelRows ρ c = ρ (x c) :=
+  rfl
+
+/-- Column relabeling evaluates by reading the old state at the inverse column. -/
+@[simp]
+theorem relabelColumns_apply (κ : Equiv.Perm (Fin n)) (x : GridState n) (c : Fin n) :
+    x.relabelColumns κ c = x (κ.symm c) :=
+  rfl
+
+/-- Relabeling rows by the identity permutation does not change a grid state. -/
+@[simp]
+theorem relabelRows_refl (x : GridState n) : x.relabelRows (Equiv.refl (Fin n)) = x := by
+  ext c
+  simp
+
+/-- Relabeling columns by the identity permutation does not change a grid state. -/
+@[simp]
+theorem relabelColumns_refl (x : GridState n) :
+    x.relabelColumns (Equiv.refl (Fin n)) = x := by
+  ext c
+  simp
+
+/-- Successive row relabelings compose. -/
+@[simp]
+theorem relabelRows_relabelRows (ρ σ : Equiv.Perm (Fin n)) (x : GridState n) :
+    (x.relabelRows ρ).relabelRows σ = x.relabelRows (ρ.trans σ) := by
+  ext c
+  simp
+
+/-- Successive column relabelings compose. -/
+@[simp]
+theorem relabelColumns_relabelColumns (κ τ : Equiv.Perm (Fin n)) (x : GridState n) :
+    (x.relabelColumns κ).relabelColumns τ = x.relabelColumns (κ.trans τ) := by
+  ext c
+  simp
+
+/-- Row and column relabeling commute on grid states. -/
+theorem relabelRows_relabelColumns (ρ κ : Equiv.Perm (Fin n)) (x : GridState n) :
+    (x.relabelRows ρ).relabelColumns κ = (x.relabelColumns κ).relabelRows ρ := by
+  ext c
+  simp
+
+/-- Membership in the point set after a row relabeling. -/
+@[simp]
+theorem mem_pointSet_relabelRows (ρ : Equiv.Perm (Fin n)) (x : GridState n)
+    (p : Fin n × Fin n) :
+    p ∈ (x.relabelRows ρ).pointSet ↔ (p.1, ρ.symm p.2) ∈ x.pointSet := by
+  simp only [mem_pointSet, relabelRows_apply]
+  constructor
+  · intro h
+    rw [← h]
+    simp
+  · intro h
+    rw [h]
+    simp
+
+/-- Membership in the point set after a column relabeling. -/
+@[simp]
+theorem mem_pointSet_relabelColumns (κ : Equiv.Perm (Fin n)) (x : GridState n)
+    (p : Fin n × Fin n) :
+    p ∈ (x.relabelColumns κ).pointSet ↔ (κ.symm p.1, p.2) ∈ x.pointSet := by
+  simp
+
+/-- Swapping two rows in a grid state. -/
+def swapRows (a b : Fin n) (x : GridState n) : GridState n :=
+  x.relabelRows (Equiv.swap a b)
+
+/-- Swapping two columns in a grid state. -/
+def swapColumns (a b : Fin n) (x : GridState n) : GridState n :=
+  x.relabelColumns (Equiv.swap a b)
+
+/-- Row swaps evaluate by swapping the row selected by the old state. -/
+@[simp]
+theorem swapRows_apply (a b : Fin n) (x : GridState n) (c : Fin n) :
+    x.swapRows a b c = Equiv.swap a b (x c) :=
+  rfl
+
+/-- Column swaps evaluate by reading the old state at the swapped column. -/
+@[simp]
+theorem swapColumns_apply (a b : Fin n) (x : GridState n) (c : Fin n) :
+    x.swapColumns a b c = x (Equiv.swap a b c) := by
+  simp [swapColumns, relabelColumns]
+
+/-- Swapping the same row twice is the identity on grid states. -/
+@[simp]
+theorem swapRows_swapRows (a b : Fin n) (x : GridState n) :
+    (x.swapRows a b).swapRows a b = x := by
+  ext c
+  simp [swapRows]
+
+/-- Swapping the same column twice is the identity on grid states. -/
+@[simp]
+theorem swapColumns_swapColumns (a b : Fin n) (x : GridState n) :
+    (x.swapColumns a b).swapColumns a b = x := by
+  ext c
+  simp [swapColumns]
+
+end GridState
+
+namespace GridDiagram
+
+variable {n : ℕ}
+
+/-- Relabel the rows of a grid diagram by relabeling both marking states. -/
+def relabelRows (ρ : Equiv.Perm (Fin n)) (G : GridDiagram n) : GridDiagram n where
+  O := G.O.relabelRows ρ
+  X := G.X.relabelRows ρ
+  disjoint := by
+    intro c h
+    exact G.disjoint c (ρ.injective h)
+
+/-- Relabel the columns of a grid diagram by relabeling both marking states. -/
+def relabelColumns (κ : Equiv.Perm (Fin n)) (G : GridDiagram n) : GridDiagram n where
+  O := G.O.relabelColumns κ
+  X := G.X.relabelColumns κ
+  disjoint := by
+    intro c h
+    exact G.disjoint (κ.symm c) h
+
+/-- The `O` marking state of a row-relabeled grid diagram. -/
+@[simp]
+theorem relabelRows_O (ρ : Equiv.Perm (Fin n)) (G : GridDiagram n) :
+    (G.relabelRows ρ).O = G.O.relabelRows ρ :=
+  rfl
+
+/-- The `X` marking state of a row-relabelled grid diagram. -/
+@[simp]
+theorem relabelRows_X (ρ : Equiv.Perm (Fin n)) (G : GridDiagram n) :
+    (G.relabelRows ρ).X = G.X.relabelRows ρ :=
+  rfl
+
+/-- The `O` marking state of a column-relabelled grid diagram. -/
+@[simp]
+theorem relabelColumns_O (κ : Equiv.Perm (Fin n)) (G : GridDiagram n) :
+    (G.relabelColumns κ).O = G.O.relabelColumns κ :=
+  rfl
+
+/-- The `X` marking state of a column-relabelled grid diagram. -/
+@[simp]
+theorem relabelColumns_X (κ : Equiv.Perm (Fin n)) (G : GridDiagram n) :
+    (G.relabelColumns κ).X = G.X.relabelColumns κ :=
+  rfl
+
+/-- Row relabeling evaluates on the `O` marking by applying the row permutation. -/
+@[simp]
+theorem relabelRows_O_apply (ρ : Equiv.Perm (Fin n)) (G : GridDiagram n) (c : Fin n) :
+    (G.relabelRows ρ).O c = ρ (G.O c) :=
+  rfl
+
+/-- Row relabeling evaluates on the `X` marking by applying the row permutation. -/
+@[simp]
+theorem relabelRows_X_apply (ρ : Equiv.Perm (Fin n)) (G : GridDiagram n) (c : Fin n) :
+    (G.relabelRows ρ).X c = ρ (G.X c) :=
+  rfl
+
+/-- Column relabeling evaluates on the `O` marking at the inverse old column. -/
+@[simp]
+theorem relabelColumns_O_apply (κ : Equiv.Perm (Fin n)) (G : GridDiagram n) (c : Fin n) :
+    (G.relabelColumns κ).O c = G.O (κ.symm c) :=
+  rfl
+
+/-- Column relabeling evaluates on the `X` marking at the inverse old column. -/
+@[simp]
+theorem relabelColumns_X_apply (κ : Equiv.Perm (Fin n)) (G : GridDiagram n) (c : Fin n) :
+    (G.relabelColumns κ).X c = G.X (κ.symm c) :=
+  rfl
+
+/-- Row relabeling transports the `O` marking set by the row permutation. -/
+@[simp]
+theorem mem_OSet_relabelRows (ρ : Equiv.Perm (Fin n)) (G : GridDiagram n)
+    (p : Fin n × Fin n) :
+    p ∈ (G.relabelRows ρ).OSet ↔ (p.1, ρ.symm p.2) ∈ G.OSet := by
+  rw [OSet, OSet]
+  exact GridState.mem_pointSet_relabelRows ρ G.O p
+
+/-- Row relabeling transports the `X` marking set by the row permutation. -/
+@[simp]
+theorem mem_XSet_relabelRows (ρ : Equiv.Perm (Fin n)) (G : GridDiagram n)
+    (p : Fin n × Fin n) :
+    p ∈ (G.relabelRows ρ).XSet ↔ (p.1, ρ.symm p.2) ∈ G.XSet := by
+  rw [XSet, XSet]
+  exact GridState.mem_pointSet_relabelRows ρ G.X p
+
+/-- Column relabeling transports the `O` marking set by the column permutation. -/
+@[simp]
+theorem mem_OSet_relabelColumns (κ : Equiv.Perm (Fin n)) (G : GridDiagram n)
+    (p : Fin n × Fin n) :
+    p ∈ (G.relabelColumns κ).OSet ↔ (κ.symm p.1, p.2) ∈ G.OSet := by
+  simp [OSet]
+
+/-- Column relabeling transports the `X` marking set by the column permutation. -/
+@[simp]
+theorem mem_XSet_relabelColumns (κ : Equiv.Perm (Fin n)) (G : GridDiagram n)
+    (p : Fin n × Fin n) :
+    p ∈ (G.relabelColumns κ).XSet ↔ (κ.symm p.1, p.2) ∈ G.XSet := by
+  simp [XSet]
+
+/-- Relabeling rows by the identity permutation does not change a grid diagram. -/
+@[simp]
+theorem relabelRows_refl (G : GridDiagram n) : G.relabelRows (Equiv.refl (Fin n)) = G := by
+  ext c <;> simp
+
+/-- Relabeling columns by the identity permutation does not change a grid diagram. -/
+@[simp]
+theorem relabelColumns_refl (G : GridDiagram n) :
+    G.relabelColumns (Equiv.refl (Fin n)) = G := by
+  ext c <;> simp
+
+/-- Swapping two rows in a grid diagram. -/
+def swapRows (a b : Fin n) (G : GridDiagram n) : GridDiagram n :=
+  G.relabelRows (Equiv.swap a b)
+
+/-- Swapping two columns in a grid diagram. -/
+def swapColumns (a b : Fin n) (G : GridDiagram n) : GridDiagram n :=
+  G.relabelColumns (Equiv.swap a b)
+
+/-- The `O` marking state of a row-swapped grid diagram. -/
+@[simp]
+theorem swapRows_O (a b : Fin n) (G : GridDiagram n) :
+    (G.swapRows a b).O = G.O.swapRows a b :=
+  rfl
+
+/-- The `X` marking state of a row-swapped grid diagram. -/
+@[simp]
+theorem swapRows_X (a b : Fin n) (G : GridDiagram n) :
+    (G.swapRows a b).X = G.X.swapRows a b :=
+  rfl
+
+/-- The `O` marking state of a column-swapped grid diagram. -/
+@[simp]
+theorem swapColumns_O (a b : Fin n) (G : GridDiagram n) :
+    (G.swapColumns a b).O = G.O.swapColumns a b :=
+  rfl
+
+/-- The `X` marking state of a column-swapped grid diagram. -/
+@[simp]
+theorem swapColumns_X (a b : Fin n) (G : GridDiagram n) :
+    (G.swapColumns a b).X = G.X.swapColumns a b :=
+  rfl
+
+/-- Swapping the same pair of rows twice is the identity on grid diagrams. -/
+@[simp]
+theorem swapRows_swapRows (a b : Fin n) (G : GridDiagram n) :
+    (G.swapRows a b).swapRows a b = G := by
+  ext c <;> simp [swapRows]
+
+/-- Swapping the same pair of columns twice is the identity on grid diagrams. -/
+@[simp]
+theorem swapColumns_swapColumns (a b : Fin n) (G : GridDiagram n) :
+    (G.swapColumns a b).swapColumns a b = G := by
+  ext c <;> simp [swapColumns]
+
+end GridDiagram
+
+end TauCeti

--- a/TauCeti/KnotTheory/Grid/Commutation.lean
+++ b/TauCeti/KnotTheory/Grid/Commutation.lean
@@ -5,18 +5,13 @@ Released under Apache 2.0 license as described in the file LICENSE.
 import TauCeti.KnotTheory.Grid.Diagram
 
 /-!
-# Row and column swaps for grid diagrams
+# Grid diagram commutation moves
 
-This file records the elementary row and column swap operations on grid states and grid
-diagrams. These swaps are the diagram-level operations underlying commutation moves; the
-later commutation maps and invariance proofs can add the non-interleaving hypotheses and
-rectangle-counting constructions on top of these total operations.
-
-## Main definitions
-
-* `TauCeti.GridState.swapRows`, `TauCeti.GridState.swapColumns`: row and column swaps of
-  grid states.
-* `TauCeti.GridDiagram.swapRows`, `TauCeti.GridDiagram.swapColumns`: row and column swaps.
+This file is reserved for commutation-specific grid diagram constructions. The total row and
+column swap operations used as the underlying relabelings live in
+`TauCeti.KnotTheory.Grid.Diagram`, next to the general row and column relabeling API. Later
+commutation maps and invariance proofs can add the non-interleaving hypotheses and
+rectangle-counting constructions here.
 
 ## References
 
@@ -27,95 +22,5 @@ construction of Ozsváth--Stipsicz--Szabó, *Grid Homology for Knots and Links*,
 -/
 
 namespace TauCeti
-
-namespace GridState
-
-variable {n : ℕ}
-
-/-- Swapping two rows in a grid state. -/
-def swapRows (a b : Fin n) (x : GridState n) : GridState n :=
-  x.relabelRows (Equiv.swap a b)
-
-/-- Swapping two columns in a grid state. -/
-def swapColumns (a b : Fin n) (x : GridState n) : GridState n :=
-  x.relabelColumns (Equiv.swap a b)
-
-/-- Row swaps evaluate by swapping the row selected by the old state. -/
-@[simp]
-theorem swapRows_apply (a b : Fin n) (x : GridState n) (c : Fin n) :
-    x.swapRows a b c = Equiv.swap a b (x c) :=
-  rfl
-
-/-- Column swaps evaluate by reading the old state at the swapped column. -/
-@[simp]
-theorem swapColumns_apply (a b : Fin n) (x : GridState n) (c : Fin n) :
-    x.swapColumns a b c = x (Equiv.swap a b c) := by
-  simp [swapColumns, relabelColumns]
-
-/-- Swapping the same pair of rows twice is the identity on grid states. -/
-@[simp]
-theorem swapRows_swapRows (a b : Fin n) (x : GridState n) :
-    (x.swapRows a b).swapRows a b = x := by
-  ext c
-  simp [swapRows]
-
-/-- Swapping the same pair of columns twice is the identity on grid states. -/
-@[simp]
-theorem swapColumns_swapColumns (a b : Fin n) (x : GridState n) :
-    (x.swapColumns a b).swapColumns a b = x := by
-  ext c
-  simp [swapColumns]
-
-end GridState
-
-namespace GridDiagram
-
-variable {n : ℕ}
-
-/-- Swapping two rows in a grid diagram. -/
-def swapRows (a b : Fin n) (G : GridDiagram n) : GridDiagram n :=
-  G.relabelRows (Equiv.swap a b)
-
-/-- Swapping two columns in a grid diagram. -/
-def swapColumns (a b : Fin n) (G : GridDiagram n) : GridDiagram n :=
-  G.relabelColumns (Equiv.swap a b)
-
-/-- The `O` marking state of a row-swapped grid diagram. -/
-@[simp]
-theorem swapRows_O (a b : Fin n) (G : GridDiagram n) :
-    (G.swapRows a b).O = G.O.swapRows a b :=
-  rfl
-
-/-- The `X` marking state of a row-swapped grid diagram. -/
-@[simp]
-theorem swapRows_X (a b : Fin n) (G : GridDiagram n) :
-    (G.swapRows a b).X = G.X.swapRows a b :=
-  rfl
-
-/-- The `O` marking state of a column-swapped grid diagram. -/
-@[simp]
-theorem swapColumns_O (a b : Fin n) (G : GridDiagram n) :
-    (G.swapColumns a b).O = G.O.swapColumns a b :=
-  rfl
-
-/-- The `X` marking state of a column-swapped grid diagram. -/
-@[simp]
-theorem swapColumns_X (a b : Fin n) (G : GridDiagram n) :
-    (G.swapColumns a b).X = G.X.swapColumns a b :=
-  rfl
-
-/-- Swapping the same pair of rows twice is the identity on grid diagrams. -/
-@[simp]
-theorem swapRows_swapRows (a b : Fin n) (G : GridDiagram n) :
-    (G.swapRows a b).swapRows a b = G := by
-  simp [swapRows]
-
-/-- Swapping the same pair of columns twice is the identity on grid diagrams. -/
-@[simp]
-theorem swapColumns_swapColumns (a b : Fin n) (G : GridDiagram n) :
-    (G.swapColumns a b).swapColumns a b = G := by
-  simp [swapColumns]
-
-end GridDiagram
 
 end TauCeti

--- a/TauCeti/KnotTheory/Grid/Commutation.lean
+++ b/TauCeti/KnotTheory/Grid/Commutation.lean
@@ -5,21 +5,17 @@ Released under Apache 2.0 license as described in the file LICENSE.
 import TauCeti.KnotTheory.Grid.Diagram
 
 /-!
-# Row and column relabeling for grid diagrams
+# Row and column swaps for grid diagrams
 
-This file records the elementary row and column relabeling operations on grid states and
-grid diagrams. The adjacent-row and adjacent-column swaps are the diagram-level operations
-underlying commutation moves; the later commutation maps and invariance proofs can add the
-non-interleaving hypotheses and rectangle-counting constructions on top of these total
-operations.
+This file records the elementary row and column swap operations on grid states and grid
+diagrams. These swaps are the diagram-level operations underlying commutation moves; the
+later commutation maps and invariance proofs can add the non-interleaving hypotheses and
+rectangle-counting constructions on top of these total operations.
 
 ## Main definitions
 
-* `TauCeti.GridState.relabelRows`: postcompose a grid state with a row permutation.
-* `TauCeti.GridState.relabelColumns`: precompose a grid state with the inverse of a column
-  permutation.
-* `TauCeti.GridDiagram.relabelRows`, `TauCeti.GridDiagram.relabelColumns`: the corresponding
-  relabelings of the `O` and `X` markings of a grid diagram.
+* `TauCeti.GridState.swapRows`, `TauCeti.GridState.swapColumns`: row and column swaps of
+  grid states.
 * `TauCeti.GridDiagram.swapRows`, `TauCeti.GridDiagram.swapColumns`: row and column swaps.
 
 ## References
@@ -35,102 +31,6 @@ namespace TauCeti
 namespace GridState
 
 variable {n : ℕ}
-
-/-- Relabel the rows of a grid state by a permutation of `Fin n`.
-
-If `ρ` is the row permutation, the point in column `c` moves from row `x c` to row
-`ρ (x c)`. -/
-def relabelRows (ρ : Equiv.Perm (Fin n)) (x : GridState n) : GridState n where
-  toPerm :=
-    { toFun := fun c => ρ (x c)
-      invFun := fun r => x.toPerm.symm (ρ.symm r)
-      left_inv := by
-        intro c
-        simp
-      right_inv := by
-        intro r
-        simp }
-
-/-- Relabel the columns of a grid state by a permutation of `Fin n`.
-
-The point in the old column `c` appears in the new column `κ c`, so the row in a new column
-`c` is read from the old column `κ.symm c`. -/
-def relabelColumns (κ : Equiv.Perm (Fin n)) (x : GridState n) : GridState n where
-  toPerm :=
-    { toFun := fun c => x (κ.symm c)
-      invFun := fun r => κ (x.toPerm.symm r)
-      left_inv := by
-        intro c
-        simp
-      right_inv := by
-        intro r
-        simp }
-
-/-- Row relabeling evaluates by applying the row permutation to the old row. -/
-@[simp]
-theorem relabelRows_apply (ρ : Equiv.Perm (Fin n)) (x : GridState n) (c : Fin n) :
-    x.relabelRows ρ c = ρ (x c) :=
-  rfl
-
-/-- Column relabeling evaluates by reading the old state at the inverse column. -/
-@[simp]
-theorem relabelColumns_apply (κ : Equiv.Perm (Fin n)) (x : GridState n) (c : Fin n) :
-    x.relabelColumns κ c = x (κ.symm c) :=
-  rfl
-
-/-- Relabeling rows by the identity permutation does not change a grid state. -/
-@[simp]
-theorem relabelRows_refl (x : GridState n) : x.relabelRows (Equiv.refl (Fin n)) = x := by
-  ext c
-  simp
-
-/-- Relabeling columns by the identity permutation does not change a grid state. -/
-@[simp]
-theorem relabelColumns_refl (x : GridState n) :
-    x.relabelColumns (Equiv.refl (Fin n)) = x := by
-  ext c
-  simp
-
-/-- Successive row relabelings compose. -/
-@[simp]
-theorem relabelRows_relabelRows (ρ σ : Equiv.Perm (Fin n)) (x : GridState n) :
-    (x.relabelRows ρ).relabelRows σ = x.relabelRows (ρ.trans σ) := by
-  ext c
-  simp
-
-/-- Successive column relabelings compose. -/
-@[simp]
-theorem relabelColumns_relabelColumns (κ τ : Equiv.Perm (Fin n)) (x : GridState n) :
-    (x.relabelColumns κ).relabelColumns τ = x.relabelColumns (κ.trans τ) := by
-  ext c
-  simp
-
-/-- Row and column relabeling commute on grid states. -/
-theorem relabelRows_relabelColumns (ρ κ : Equiv.Perm (Fin n)) (x : GridState n) :
-    (x.relabelRows ρ).relabelColumns κ = (x.relabelColumns κ).relabelRows ρ := by
-  ext c
-  simp
-
-/-- Membership in the point set after a row relabeling. -/
-@[simp]
-theorem mem_pointSet_relabelRows (ρ : Equiv.Perm (Fin n)) (x : GridState n)
-    (p : Fin n × Fin n) :
-    p ∈ (x.relabelRows ρ).pointSet ↔ (p.1, ρ.symm p.2) ∈ x.pointSet := by
-  simp only [mem_pointSet, relabelRows_apply]
-  constructor
-  · intro h
-    rw [← h]
-    simp
-  · intro h
-    rw [h]
-    simp
-
-/-- Membership in the point set after a column relabeling. -/
-@[simp]
-theorem mem_pointSet_relabelColumns (κ : Equiv.Perm (Fin n)) (x : GridState n)
-    (p : Fin n × Fin n) :
-    p ∈ (x.relabelColumns κ).pointSet ↔ (κ.symm p.1, p.2) ∈ x.pointSet := by
-  simp
 
 /-- Swapping two rows in a grid state. -/
 def swapRows (a b : Fin n) (x : GridState n) : GridState n :=
@@ -152,14 +52,14 @@ theorem swapColumns_apply (a b : Fin n) (x : GridState n) (c : Fin n) :
     x.swapColumns a b c = x (Equiv.swap a b c) := by
   simp [swapColumns, relabelColumns]
 
-/-- Swapping the same row twice is the identity on grid states. -/
+/-- Swapping the same pair of rows twice is the identity on grid states. -/
 @[simp]
 theorem swapRows_swapRows (a b : Fin n) (x : GridState n) :
     (x.swapRows a b).swapRows a b = x := by
   ext c
   simp [swapRows]
 
-/-- Swapping the same column twice is the identity on grid states. -/
+/-- Swapping the same pair of columns twice is the identity on grid states. -/
 @[simp]
 theorem swapColumns_swapColumns (a b : Fin n) (x : GridState n) :
     (x.swapColumns a b).swapColumns a b = x := by
@@ -171,111 +71,6 @@ end GridState
 namespace GridDiagram
 
 variable {n : ℕ}
-
-/-- Relabel the rows of a grid diagram by relabeling both marking states. -/
-def relabelRows (ρ : Equiv.Perm (Fin n)) (G : GridDiagram n) : GridDiagram n where
-  O := G.O.relabelRows ρ
-  X := G.X.relabelRows ρ
-  disjoint := by
-    intro c h
-    exact G.disjoint c (ρ.injective h)
-
-/-- Relabel the columns of a grid diagram by relabeling both marking states. -/
-def relabelColumns (κ : Equiv.Perm (Fin n)) (G : GridDiagram n) : GridDiagram n where
-  O := G.O.relabelColumns κ
-  X := G.X.relabelColumns κ
-  disjoint := by
-    intro c h
-    exact G.disjoint (κ.symm c) h
-
-/-- The `O` marking state of a row-relabeled grid diagram. -/
-@[simp]
-theorem relabelRows_O (ρ : Equiv.Perm (Fin n)) (G : GridDiagram n) :
-    (G.relabelRows ρ).O = G.O.relabelRows ρ :=
-  rfl
-
-/-- The `X` marking state of a row-relabelled grid diagram. -/
-@[simp]
-theorem relabelRows_X (ρ : Equiv.Perm (Fin n)) (G : GridDiagram n) :
-    (G.relabelRows ρ).X = G.X.relabelRows ρ :=
-  rfl
-
-/-- The `O` marking state of a column-relabelled grid diagram. -/
-@[simp]
-theorem relabelColumns_O (κ : Equiv.Perm (Fin n)) (G : GridDiagram n) :
-    (G.relabelColumns κ).O = G.O.relabelColumns κ :=
-  rfl
-
-/-- The `X` marking state of a column-relabelled grid diagram. -/
-@[simp]
-theorem relabelColumns_X (κ : Equiv.Perm (Fin n)) (G : GridDiagram n) :
-    (G.relabelColumns κ).X = G.X.relabelColumns κ :=
-  rfl
-
-/-- Row relabeling evaluates on the `O` marking by applying the row permutation. -/
-@[simp]
-theorem relabelRows_O_apply (ρ : Equiv.Perm (Fin n)) (G : GridDiagram n) (c : Fin n) :
-    (G.relabelRows ρ).O c = ρ (G.O c) :=
-  rfl
-
-/-- Row relabeling evaluates on the `X` marking by applying the row permutation. -/
-@[simp]
-theorem relabelRows_X_apply (ρ : Equiv.Perm (Fin n)) (G : GridDiagram n) (c : Fin n) :
-    (G.relabelRows ρ).X c = ρ (G.X c) :=
-  rfl
-
-/-- Column relabeling evaluates on the `O` marking at the inverse old column. -/
-@[simp]
-theorem relabelColumns_O_apply (κ : Equiv.Perm (Fin n)) (G : GridDiagram n) (c : Fin n) :
-    (G.relabelColumns κ).O c = G.O (κ.symm c) :=
-  rfl
-
-/-- Column relabeling evaluates on the `X` marking at the inverse old column. -/
-@[simp]
-theorem relabelColumns_X_apply (κ : Equiv.Perm (Fin n)) (G : GridDiagram n) (c : Fin n) :
-    (G.relabelColumns κ).X c = G.X (κ.symm c) :=
-  rfl
-
-/-- Row relabeling transports the `O` marking set by the row permutation. -/
-@[simp]
-theorem mem_OSet_relabelRows (ρ : Equiv.Perm (Fin n)) (G : GridDiagram n)
-    (p : Fin n × Fin n) :
-    p ∈ (G.relabelRows ρ).OSet ↔ (p.1, ρ.symm p.2) ∈ G.OSet := by
-  rw [OSet, OSet]
-  exact GridState.mem_pointSet_relabelRows ρ G.O p
-
-/-- Row relabeling transports the `X` marking set by the row permutation. -/
-@[simp]
-theorem mem_XSet_relabelRows (ρ : Equiv.Perm (Fin n)) (G : GridDiagram n)
-    (p : Fin n × Fin n) :
-    p ∈ (G.relabelRows ρ).XSet ↔ (p.1, ρ.symm p.2) ∈ G.XSet := by
-  rw [XSet, XSet]
-  exact GridState.mem_pointSet_relabelRows ρ G.X p
-
-/-- Column relabeling transports the `O` marking set by the column permutation. -/
-@[simp]
-theorem mem_OSet_relabelColumns (κ : Equiv.Perm (Fin n)) (G : GridDiagram n)
-    (p : Fin n × Fin n) :
-    p ∈ (G.relabelColumns κ).OSet ↔ (κ.symm p.1, p.2) ∈ G.OSet := by
-  simp [OSet]
-
-/-- Column relabeling transports the `X` marking set by the column permutation. -/
-@[simp]
-theorem mem_XSet_relabelColumns (κ : Equiv.Perm (Fin n)) (G : GridDiagram n)
-    (p : Fin n × Fin n) :
-    p ∈ (G.relabelColumns κ).XSet ↔ (κ.symm p.1, p.2) ∈ G.XSet := by
-  simp [XSet]
-
-/-- Relabeling rows by the identity permutation does not change a grid diagram. -/
-@[simp]
-theorem relabelRows_refl (G : GridDiagram n) : G.relabelRows (Equiv.refl (Fin n)) = G := by
-  ext c <;> simp
-
-/-- Relabeling columns by the identity permutation does not change a grid diagram. -/
-@[simp]
-theorem relabelColumns_refl (G : GridDiagram n) :
-    G.relabelColumns (Equiv.refl (Fin n)) = G := by
-  ext c <;> simp
 
 /-- Swapping two rows in a grid diagram. -/
 def swapRows (a b : Fin n) (G : GridDiagram n) : GridDiagram n :=
@@ -313,13 +108,13 @@ theorem swapColumns_X (a b : Fin n) (G : GridDiagram n) :
 @[simp]
 theorem swapRows_swapRows (a b : Fin n) (G : GridDiagram n) :
     (G.swapRows a b).swapRows a b = G := by
-  ext c <;> simp [swapRows]
+  simp [swapRows]
 
 /-- Swapping the same pair of columns twice is the identity on grid diagrams. -/
 @[simp]
 theorem swapColumns_swapColumns (a b : Fin n) (G : GridDiagram n) :
     (G.swapColumns a b).swapColumns a b = G := by
-  ext c <;> simp [swapColumns]
+  simp [swapColumns]
 
 end GridDiagram
 

--- a/TauCeti/KnotTheory/Grid/Commutation.lean
+++ b/TauCeti/KnotTheory/Grid/Commutation.lean
@@ -2,8 +2,6 @@
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 -/
-import TauCeti.KnotTheory.Grid.Diagram
-
 /-!
 # Grid diagram commutation moves
 

--- a/TauCeti/KnotTheory/Grid/Diagram.lean
+++ b/TauCeti/KnotTheory/Grid/Diagram.lean
@@ -26,10 +26,14 @@ before defining rectangles, empty rectangles, and the grid differential.
 * `TauCeti.GridState.pointSet`: the finite set of occupied squares of a grid state.
 * `TauCeti.GridState.relabelRows`, `TauCeti.GridState.relabelColumns`: row and column
   relabelings of grid states.
+* `TauCeti.GridState.swapRows`, `TauCeti.GridState.swapColumns`: row and column swaps of
+  grid states.
 * `TauCeti.GridDiagram`: an `n × n` grid diagram with `O` and `X` markings.
 * `TauCeti.GridDiagram.OSet`, `TauCeti.GridDiagram.XSet`: the marking point sets.
 * `TauCeti.GridDiagram.relabelRows`, `TauCeti.GridDiagram.relabelColumns`: row and column
   relabelings of grid diagrams.
+* `TauCeti.GridDiagram.swapRows`, `TauCeti.GridDiagram.swapColumns`: row and column swaps of
+  grid diagrams.
 
 ## References
 
@@ -240,6 +244,52 @@ theorem mem_pointSet_relabelColumns (κ : Equiv.Perm (Fin n)) (x : GridState n)
     p ∈ (x.relabelColumns κ).pointSet ↔ (κ.symm p.1, p.2) ∈ x.pointSet := by
   simp
 
+/-- Swapping two rows in a grid state. -/
+def swapRows (a b : Fin n) (x : GridState n) : GridState n :=
+  x.relabelRows (Equiv.swap a b)
+
+/-- Swapping two columns in a grid state. -/
+def swapColumns (a b : Fin n) (x : GridState n) : GridState n :=
+  x.relabelColumns (Equiv.swap a b)
+
+/-- Row swaps evaluate by swapping the row selected by the old state. -/
+@[simp]
+theorem swapRows_apply (a b : Fin n) (x : GridState n) (c : Fin n) :
+    x.swapRows a b c = Equiv.swap a b (x c) :=
+  rfl
+
+/-- Column swaps evaluate by reading the old state at the swapped column. -/
+@[simp]
+theorem swapColumns_apply (a b : Fin n) (x : GridState n) (c : Fin n) :
+    x.swapColumns a b c = x (Equiv.swap a b c) := by
+  simp [swapColumns, relabelColumns]
+
+/-- Row swaps transport the point set by the row transposition. -/
+@[simp]
+theorem mem_pointSet_swapRows (a b : Fin n) (x : GridState n) (p : Fin n × Fin n) :
+    p ∈ (x.swapRows a b).pointSet ↔ (p.1, Equiv.swap a b p.2) ∈ x.pointSet := by
+  simpa [swapRows] using GridState.mem_pointSet_relabelRows (Equiv.swap a b) x p
+
+/-- Column swaps transport the point set by the column transposition. -/
+@[simp]
+theorem mem_pointSet_swapColumns (a b : Fin n) (x : GridState n) (p : Fin n × Fin n) :
+    p ∈ (x.swapColumns a b).pointSet ↔ (Equiv.swap a b p.1, p.2) ∈ x.pointSet := by
+  simp [swapColumns]
+
+/-- Swapping the same pair of rows twice is the identity on grid states. -/
+@[simp]
+theorem swapRows_swapRows (a b : Fin n) (x : GridState n) :
+    (x.swapRows a b).swapRows a b = x := by
+  ext c
+  simp [swapRows]
+
+/-- Swapping the same pair of columns twice is the identity on grid states. -/
+@[simp]
+theorem swapColumns_swapColumns (a b : Fin n) (x : GridState n) :
+    (x.swapColumns a b).swapColumns a b = x := by
+  ext c
+  simp [swapColumns]
+
 end GridState
 
 /-- An `n × n` grid diagram, encoded by the `O`-marking and `X`-marking permutation graphs.
@@ -432,6 +482,74 @@ theorem mem_OSet_relabelColumns (κ : Equiv.Perm (Fin n)) (p : Fin n × Fin n) :
 theorem mem_XSet_relabelColumns (κ : Equiv.Perm (Fin n)) (p : Fin n × Fin n) :
     p ∈ (G.relabelColumns κ).XSet ↔ (κ.symm p.1, p.2) ∈ G.XSet := by
   simp [XSet]
+
+/-- Swapping two rows in a grid diagram. -/
+def swapRows (a b : Fin n) (G : GridDiagram n) : GridDiagram n :=
+  G.relabelRows (Equiv.swap a b)
+
+/-- Swapping two columns in a grid diagram. -/
+def swapColumns (a b : Fin n) (G : GridDiagram n) : GridDiagram n :=
+  G.relabelColumns (Equiv.swap a b)
+
+/-- The `O` marking state of a row-swapped grid diagram. -/
+@[simp]
+theorem swapRows_O (a b : Fin n) :
+    (G.swapRows a b).O = G.O.swapRows a b :=
+  rfl
+
+/-- The `X` marking state of a row-swapped grid diagram. -/
+@[simp]
+theorem swapRows_X (a b : Fin n) :
+    (G.swapRows a b).X = G.X.swapRows a b :=
+  rfl
+
+/-- The `O` marking state of a column-swapped grid diagram. -/
+@[simp]
+theorem swapColumns_O (a b : Fin n) :
+    (G.swapColumns a b).O = G.O.swapColumns a b :=
+  rfl
+
+/-- The `X` marking state of a column-swapped grid diagram. -/
+@[simp]
+theorem swapColumns_X (a b : Fin n) :
+    (G.swapColumns a b).X = G.X.swapColumns a b :=
+  rfl
+
+/-- Row swaps transport the `O` marking set by the row transposition. -/
+@[simp]
+theorem mem_OSet_swapRows (a b : Fin n) (p : Fin n × Fin n) :
+    p ∈ (G.swapRows a b).OSet ↔ (p.1, Equiv.swap a b p.2) ∈ G.OSet := by
+  simpa [swapRows] using G.mem_OSet_relabelRows (Equiv.swap a b) p
+
+/-- Row swaps transport the `X` marking set by the row transposition. -/
+@[simp]
+theorem mem_XSet_swapRows (a b : Fin n) (p : Fin n × Fin n) :
+    p ∈ (G.swapRows a b).XSet ↔ (p.1, Equiv.swap a b p.2) ∈ G.XSet := by
+  simpa [swapRows] using G.mem_XSet_relabelRows (Equiv.swap a b) p
+
+/-- Column swaps transport the `O` marking set by the column transposition. -/
+@[simp]
+theorem mem_OSet_swapColumns (a b : Fin n) (p : Fin n × Fin n) :
+    p ∈ (G.swapColumns a b).OSet ↔ (Equiv.swap a b p.1, p.2) ∈ G.OSet := by
+  simp [swapColumns]
+
+/-- Column swaps transport the `X` marking set by the column transposition. -/
+@[simp]
+theorem mem_XSet_swapColumns (a b : Fin n) (p : Fin n × Fin n) :
+    p ∈ (G.swapColumns a b).XSet ↔ (Equiv.swap a b p.1, p.2) ∈ G.XSet := by
+  simp [swapColumns]
+
+/-- Swapping the same pair of rows twice is the identity on grid diagrams. -/
+@[simp]
+theorem swapRows_swapRows (a b : Fin n) :
+    (G.swapRows a b).swapRows a b = G := by
+  ext c <;> simp [swapRows]
+
+/-- Swapping the same pair of columns twice is the identity on grid diagrams. -/
+@[simp]
+theorem swapColumns_swapColumns (a b : Fin n) :
+    (G.swapColumns a b).swapColumns a b = G := by
+  ext c <;> simp [swapColumns]
 
 /-- Relabeling rows by the identity permutation does not change a grid diagram. -/
 @[simp]

--- a/TauCeti/KnotTheory/Grid/Diagram.lean
+++ b/TauCeti/KnotTheory/Grid/Diagram.lean
@@ -24,8 +24,12 @@ before defining rectangles, empty rectangles, and the grid differential.
 
 * `TauCeti.GridState`: a grid state with a permutation graph on `Fin n`.
 * `TauCeti.GridState.pointSet`: the finite set of occupied squares of a grid state.
+* `TauCeti.GridState.relabelRows`, `TauCeti.GridState.relabelColumns`: row and column
+  relabelings of grid states.
 * `TauCeti.GridDiagram`: an `n × n` grid diagram with `O` and `X` markings.
 * `TauCeti.GridDiagram.OSet`, `TauCeti.GridDiagram.XSet`: the marking point sets.
+* `TauCeti.GridDiagram.relabelRows`, `TauCeti.GridDiagram.relabelColumns`: row and column
+  relabelings of grid diagrams.
 
 ## References
 
@@ -140,6 +144,102 @@ theorem disjoint_pointSet_iff (x y : GridState n) :
     subst hpq
     exact h p.1 ((mem_pointSet x p).mp hpX |>.trans ((mem_pointSet y p).mp hpY).symm)
 
+/-- Relabel the rows of a grid state by a permutation of `Fin n`.
+
+If `ρ` is the row permutation, the point in column `c` moves from row `x c` to row
+`ρ (x c)`. -/
+def relabelRows (ρ : Equiv.Perm (Fin n)) (x : GridState n) : GridState n where
+  toPerm :=
+    { toFun := fun c => ρ (x c)
+      invFun := fun r => x.toPerm.symm (ρ.symm r)
+      left_inv := by
+        intro c
+        simp
+      right_inv := by
+        intro r
+        simp }
+
+/-- Relabel the columns of a grid state by a permutation of `Fin n`.
+
+The point in the old column `c` appears in the new column `κ c`, so the row in a new column
+`c` is read from the old column `κ.symm c`. -/
+def relabelColumns (κ : Equiv.Perm (Fin n)) (x : GridState n) : GridState n where
+  toPerm :=
+    { toFun := fun c => x (κ.symm c)
+      invFun := fun r => κ (x.toPerm.symm r)
+      left_inv := by
+        intro c
+        simp
+      right_inv := by
+        intro r
+        simp }
+
+/-- Row relabeling evaluates by applying the row permutation to the old row. -/
+@[simp]
+theorem relabelRows_apply (ρ : Equiv.Perm (Fin n)) (x : GridState n) (c : Fin n) :
+    x.relabelRows ρ c = ρ (x c) :=
+  rfl
+
+/-- Column relabeling evaluates by reading the old state at the inverse column. -/
+@[simp]
+theorem relabelColumns_apply (κ : Equiv.Perm (Fin n)) (x : GridState n) (c : Fin n) :
+    x.relabelColumns κ c = x (κ.symm c) :=
+  rfl
+
+/-- Relabeling rows by the identity permutation does not change a grid state. -/
+@[simp]
+theorem relabelRows_refl (x : GridState n) : x.relabelRows (Equiv.refl (Fin n)) = x := by
+  ext c
+  simp
+
+/-- Relabeling columns by the identity permutation does not change a grid state. -/
+@[simp]
+theorem relabelColumns_refl (x : GridState n) :
+    x.relabelColumns (Equiv.refl (Fin n)) = x := by
+  ext c
+  simp
+
+/-- Successive row relabelings compose. -/
+@[simp]
+theorem relabelRows_relabelRows (ρ σ : Equiv.Perm (Fin n)) (x : GridState n) :
+    (x.relabelRows ρ).relabelRows σ = x.relabelRows (ρ.trans σ) := by
+  ext c
+  simp
+
+/-- Successive column relabelings compose. -/
+@[simp]
+theorem relabelColumns_relabelColumns (κ τ : Equiv.Perm (Fin n)) (x : GridState n) :
+    (x.relabelColumns κ).relabelColumns τ = x.relabelColumns (κ.trans τ) := by
+  ext c
+  simp
+
+/-- Row and column relabeling commute on grid states. -/
+theorem relabelRows_relabelColumns (ρ κ : Equiv.Perm (Fin n)) (x : GridState n) :
+    (x.relabelRows ρ).relabelColumns κ = (x.relabelColumns κ).relabelRows ρ := by
+  ext c
+  simp
+
+/-- Membership in the point set after a row relabeling. -/
+@[simp]
+theorem mem_pointSet_relabelRows (ρ : Equiv.Perm (Fin n)) (x : GridState n)
+    (p : Fin n × Fin n) :
+    p ∈ (x.relabelRows ρ).pointSet ↔ (p.1, ρ.symm p.2) ∈ x.pointSet := by
+  simp only [mem_pointSet, relabelRows_apply]
+  constructor
+  · intro h
+    rw [← h]
+    simp
+  · intro h
+    rw [h]
+    simp
+
+/-- Membership in the point set after a column relabeling. -/
+@[simp]
+theorem mem_pointSet_relabelColumns (κ : Equiv.Perm (Fin n)) (x : GridState n)
+    (p : Fin n × Fin n) :
+    p ∈ (x.relabelColumns κ).pointSet ↔ (κ.symm p.1, p.2) ∈ x.pointSet := by
+  simp
+
 end GridState
 
 /-- An `n × n` grid diagram, encoded by the `O`-marking and `X`-marking permutation graphs.
@@ -242,6 +342,123 @@ theorem not_mem_XSet_of_mem_OSet {p : Fin n × Fin n} (hp : p ∈ G.OSet) : p �
 theorem not_mem_OSet_of_mem_XSet {p : Fin n × Fin n} (hp : p ∈ G.XSet) : p ∉ G.OSet := by
   intro hpO
   exact G.not_mem_OSet_and_mem_XSet p ⟨hpO, hp⟩
+
+/-- Relabel the rows of a grid diagram by relabeling both marking states. -/
+def relabelRows (ρ : Equiv.Perm (Fin n)) (G : GridDiagram n) : GridDiagram n where
+  O := G.O.relabelRows ρ
+  X := G.X.relabelRows ρ
+  disjoint := by
+    intro c h
+    exact G.disjoint c (ρ.injective h)
+
+/-- Relabel the columns of a grid diagram by relabeling both marking states. -/
+def relabelColumns (κ : Equiv.Perm (Fin n)) (G : GridDiagram n) : GridDiagram n where
+  O := G.O.relabelColumns κ
+  X := G.X.relabelColumns κ
+  disjoint := by
+    intro c h
+    exact G.disjoint (κ.symm c) h
+
+/-- The `O` marking state of a row-relabeled grid diagram. -/
+@[simp]
+theorem relabelRows_O (ρ : Equiv.Perm (Fin n)) :
+    (G.relabelRows ρ).O = G.O.relabelRows ρ :=
+  rfl
+
+/-- The `X` marking state of a row-relabelled grid diagram. -/
+@[simp]
+theorem relabelRows_X (ρ : Equiv.Perm (Fin n)) :
+    (G.relabelRows ρ).X = G.X.relabelRows ρ :=
+  rfl
+
+/-- The `O` marking state of a column-relabelled grid diagram. -/
+@[simp]
+theorem relabelColumns_O (κ : Equiv.Perm (Fin n)) :
+    (G.relabelColumns κ).O = G.O.relabelColumns κ :=
+  rfl
+
+/-- The `X` marking state of a column-relabelled grid diagram. -/
+@[simp]
+theorem relabelColumns_X (κ : Equiv.Perm (Fin n)) :
+    (G.relabelColumns κ).X = G.X.relabelColumns κ :=
+  rfl
+
+/-- Row relabeling evaluates on the `O` marking by applying the row permutation. -/
+@[simp]
+theorem relabelRows_O_apply (ρ : Equiv.Perm (Fin n)) (c : Fin n) :
+    (G.relabelRows ρ).O c = ρ (G.O c) :=
+  rfl
+
+/-- Row relabeling evaluates on the `X` marking by applying the row permutation. -/
+@[simp]
+theorem relabelRows_X_apply (ρ : Equiv.Perm (Fin n)) (c : Fin n) :
+    (G.relabelRows ρ).X c = ρ (G.X c) :=
+  rfl
+
+/-- Column relabeling evaluates on the `O` marking at the inverse old column. -/
+@[simp]
+theorem relabelColumns_O_apply (κ : Equiv.Perm (Fin n)) (c : Fin n) :
+    (G.relabelColumns κ).O c = G.O (κ.symm c) :=
+  rfl
+
+/-- Column relabeling evaluates on the `X` marking at the inverse old column. -/
+@[simp]
+theorem relabelColumns_X_apply (κ : Equiv.Perm (Fin n)) (c : Fin n) :
+    (G.relabelColumns κ).X c = G.X (κ.symm c) :=
+  rfl
+
+/-- Row relabeling transports the `O` marking set by the row permutation. -/
+@[simp]
+theorem mem_OSet_relabelRows (ρ : Equiv.Perm (Fin n)) (p : Fin n × Fin n) :
+    p ∈ (G.relabelRows ρ).OSet ↔ (p.1, ρ.symm p.2) ∈ G.OSet := by
+  rw [OSet, OSet]
+  exact GridState.mem_pointSet_relabelRows ρ G.O p
+
+/-- Row relabeling transports the `X` marking set by the row permutation. -/
+@[simp]
+theorem mem_XSet_relabelRows (ρ : Equiv.Perm (Fin n)) (p : Fin n × Fin n) :
+    p ∈ (G.relabelRows ρ).XSet ↔ (p.1, ρ.symm p.2) ∈ G.XSet := by
+  rw [XSet, XSet]
+  exact GridState.mem_pointSet_relabelRows ρ G.X p
+
+/-- Column relabeling transports the `O` marking set by the column permutation. -/
+@[simp]
+theorem mem_OSet_relabelColumns (κ : Equiv.Perm (Fin n)) (p : Fin n × Fin n) :
+    p ∈ (G.relabelColumns κ).OSet ↔ (κ.symm p.1, p.2) ∈ G.OSet := by
+  simp [OSet]
+
+/-- Column relabeling transports the `X` marking set by the column permutation. -/
+@[simp]
+theorem mem_XSet_relabelColumns (κ : Equiv.Perm (Fin n)) (p : Fin n × Fin n) :
+    p ∈ (G.relabelColumns κ).XSet ↔ (κ.symm p.1, p.2) ∈ G.XSet := by
+  simp [XSet]
+
+/-- Relabeling rows by the identity permutation does not change a grid diagram. -/
+@[simp]
+theorem relabelRows_refl : G.relabelRows (Equiv.refl (Fin n)) = G := by
+  ext c <;> simp
+
+/-- Relabeling columns by the identity permutation does not change a grid diagram. -/
+@[simp]
+theorem relabelColumns_refl : G.relabelColumns (Equiv.refl (Fin n)) = G := by
+  ext c <;> simp
+
+/-- Successive row relabelings compose on grid diagrams. -/
+@[simp]
+theorem relabelRows_relabelRows (ρ σ : Equiv.Perm (Fin n)) :
+    (G.relabelRows ρ).relabelRows σ = G.relabelRows (ρ.trans σ) := by
+  ext c <;> simp
+
+/-- Successive column relabelings compose on grid diagrams. -/
+@[simp]
+theorem relabelColumns_relabelColumns (κ τ : Equiv.Perm (Fin n)) :
+    (G.relabelColumns κ).relabelColumns τ = G.relabelColumns (κ.trans τ) := by
+  ext c <;> simp
+
+/-- Row and column relabeling commute on grid diagrams. -/
+theorem relabelRows_relabelColumns (ρ κ : Equiv.Perm (Fin n)) :
+    (G.relabelRows ρ).relabelColumns κ = (G.relabelColumns κ).relabelRows ρ := by
+  ext c <;> simp [GridState.relabelRows_relabelColumns]
 
 end GridDiagram
 


### PR DESCRIPTION
This PR adds row and column relabeling operations for grid states and grid diagrams, with row and column swap specializations for the commutation-move lane. It advances `TauCetiRoadmap/HeegaardFloer/README.md`, Lane G.5, the specific item "Invariance over 𝔽₂. Grid moves = commutation + (de)stabilization", by isolating the total diagram-level relabeling operations that later commutation maps can refine with non-interleaving hypotheses and rectangle-counting chain maps.

<!--tauceti-target:v1 {"focus":"HeegaardFloer","id":"grid-commutation-relabeling"}-->

No Mathlib infrastructure is vendored. The implementation reuses Mathlib `Equiv.Perm` and `Equiv.swap`, together with Tau Ceti's existing `GridState`, `GridDiagram`, and point-set APIs from `TauCeti.KnotTheory.Grid.Diagram`.

Verification: `lake exe cache get` completed with `No files to download` and `Already decompressed 8555 file(s)`; `lake build` completed with `Build completed successfully (3846 jobs).`; `lake exe axioms` completed with `axioms: audited 2283 TauCeti declaration(s); all within the allowlist [propext, Classical.choice, Quot.sound].`

🤖 Prepared with Codex
