### PR TITLE
feat: add complementary cyclic intervals

### DIFF
--- a/TauCeti/KnotTheory/Grid/CyclicInterval.lean
+++ b/TauCeti/KnotTheory/Grid/CyclicInterval.lean
@@ -1,0 +1,199 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+import TauCeti.KnotTheory.Grid.Rectangle
+
+/-!
+# Complementary cyclic intervals in finite grids
+
+This file records finite-set bookkeeping for the clockwise open cyclic intervals used by
+toroidal grid rectangles. For distinct endpoints `a` and `b`, the two arcs `cIoo a b` and
+`cIoo b a` are disjoint and together contain exactly the points other than `a` and `b`.
+
+These lemmas are deliberately stated at the one-dimensional `Fin n` level. Rectangle-pair
+arguments for the grid differential can then apply them independently in the column and row
+directions before taking products.
+
+## Main results
+
+* `TauCeti.Grid.disjoint_cIoo_swap`: opposite open arcs are disjoint.
+* `TauCeti.Grid.mem_cIoo_or_mem_cIoo_swap_iff`: a point lies in one opposite arc exactly when
+  it is not an endpoint.
+* `TauCeti.Grid.cIoo_union_swap`: the two opposite arcs cover the endpoint complement.
+* `TauCeti.Grid.card_cIoo_add_card_cIoo_swap`: the two arc lengths add to `n - 2`.
+
+## References
+
+This supplies a prerequisite for `TauCetiRoadmap/HeegaardFloer/README.md`, Lane G.3, "The
+complexes and `∂² = 0`", where the annular cases in the juxtaposition proof use the fact that
+the two complementary cyclic intervals partition the non-endpoint columns or rows. The
+terminology follows Ozsváth--Stipsicz--Szabó, *Grid Homology for Knots and Links*, Chapter 3.
+-/
+
+namespace TauCeti
+
+namespace Grid
+
+variable {n : ℕ}
+
+/-- A point cannot lie in both open cyclic intervals with the same endpoints but opposite
+orientations. -/
+theorem not_mem_cIoo_and_mem_cIoo_swap (a b x : Fin n) :
+    ¬(x ∈ cIoo a b ∧ x ∈ cIoo b a) := by
+  rw [mem_cIoo, mem_cIoo]
+  rintro ⟨hxab, hxba⟩
+  by_cases hab : a.val < b.val
+  · have hxab' : a.val < x.val ∧ x.val < b.val := by
+      simpa [hab] using hxab.2
+    have hbxa : ¬ b.val < a.val := Nat.not_lt.mpr (Nat.le_of_lt hab)
+    have hxba' : b.val < x.val ∨ x.val < a.val := by
+      simpa [hbxa] using hxba.2
+    omega
+  · have hxab' : a.val < x.val ∨ x.val < b.val := by
+      simpa [hab] using hxab.2
+    have hba : b.val < a.val := Nat.lt_of_le_of_ne (Nat.le_of_not_gt hab) (by omega)
+    have hxba' : b.val < x.val ∧ x.val < a.val := by
+      simpa [hba] using hxba.2
+    omega
+
+/-- Opposite open cyclic intervals with the same endpoints are disjoint. -/
+theorem disjoint_cIoo_swap (a b : Fin n) : Disjoint (cIoo a b) (cIoo b a) := by
+  rw [Finset.disjoint_iff_ne]
+  intro x hx y hy hxy
+  subst hxy
+  exact not_mem_cIoo_and_mem_cIoo_swap a b x ⟨hx, hy⟩
+
+/-- Membership in one of the two opposite cyclic intervals is the same as being neither
+endpoint. -/
+theorem mem_cIoo_or_mem_cIoo_swap_iff {a b x : Fin n} (h : a ≠ b) :
+    x ∈ cIoo a b ∨ x ∈ cIoo b a ↔ x ≠ a ∧ x ≠ b := by
+  constructor
+  · rintro (hx | hx)
+    · exact ⟨fun hxa => left_notMem_cIoo a b (hxa ▸ hx),
+        fun hxb => right_notMem_cIoo a b (hxb ▸ hx)⟩
+    · exact ⟨fun hxa => right_notMem_cIoo b a (hxa ▸ hx),
+        fun hxb => left_notMem_cIoo b a (hxb ▸ hx)⟩
+  · intro hx
+    by_cases hab : a.val < b.val
+    · by_cases hax : a.val < x.val
+      · by_cases hxb : x.val < b.val
+        · exact Or.inl ((mem_cIoo a b x).mpr ⟨h, by simp [hab, hax, hxb]⟩)
+        · exact Or.inr ((mem_cIoo b a x).mpr ⟨h.symm, by
+            have hbxa : ¬ b.val < a.val := Nat.not_lt.mpr (Nat.le_of_lt hab)
+            have hbx : b.val < x.val := Nat.lt_of_le_of_ne (Nat.le_of_not_gt hxb) (by omega)
+            simp [hbxa, hbx]⟩)
+      · exact Or.inr ((mem_cIoo b a x).mpr ⟨h.symm, by
+          have hbxa : ¬ b.val < a.val := Nat.not_lt.mpr (Nat.le_of_lt hab)
+          have hxa : x.val < a.val := Nat.lt_of_le_of_ne (Nat.le_of_not_gt hax) (by omega)
+          simp [hbxa, hxa]⟩)
+    · have hba : b.val < a.val := Nat.lt_of_le_of_ne (Nat.le_of_not_gt hab) (by omega)
+      by_cases hbx : b.val < x.val
+      · by_cases hxa : x.val < a.val
+        · exact Or.inr ((mem_cIoo b a x).mpr ⟨h.symm, by simp [hba, hbx, hxa]⟩)
+        · exact Or.inl ((mem_cIoo a b x).mpr ⟨h, by
+            have hax : a.val < x.val := Nat.lt_of_le_of_ne (Nat.le_of_not_gt hxa) (by omega)
+            simp [hab, hax]⟩)
+      · exact Or.inl ((mem_cIoo a b x).mpr ⟨h, by
+          have hxb : x.val < b.val := Nat.lt_of_le_of_ne (Nat.le_of_not_gt hbx) (by omega)
+          simp [hab, hxb]⟩)
+
+/-- A point outside the clockwise interval from `a` to `b` is either an endpoint or lies in
+the opposite clockwise interval. -/
+theorem not_mem_cIoo_iff {a b x : Fin n} (h : a ≠ b) :
+    x ∉ cIoo a b ↔ x = a ∨ x = b ∨ x ∈ cIoo b a := by
+  constructor
+  · intro hx
+    by_cases hxa : x = a
+    · exact Or.inl hxa
+    by_cases hxb : x = b
+    · exact Or.inr (Or.inl hxb)
+    · exact Or.inr (Or.inr ((mem_cIoo_or_mem_cIoo_swap_iff h).mpr ⟨hxa, hxb⟩ |>.resolve_left hx))
+  · intro hx
+    rcases hx with hxa | hxb | hx
+    · rw [hxa]
+      exact left_notMem_cIoo a b
+    · rw [hxb]
+      exact right_notMem_cIoo a b
+    · intro hxab
+      exact not_mem_cIoo_and_mem_cIoo_swap a b x ⟨hxab, hx⟩
+
+/-- The two opposite cyclic intervals cover exactly the complement of their endpoints. -/
+theorem cIoo_union_swap {a b : Fin n} (h : a ≠ b) :
+    cIoo a b ∪ cIoo b a = (Finset.univ.erase a).erase b := by
+  ext x
+  rw [Finset.mem_union, mem_cIoo_or_mem_cIoo_swap_iff h]
+  simp only [Finset.mem_erase, Finset.mem_univ, and_true]
+  constructor
+  · rintro ⟨hxa, hxb⟩
+    exact ⟨hxb, hxa⟩
+  · rintro ⟨hxb, hxa⟩
+    exact ⟨hxa, hxb⟩
+
+/-- The endpoint complement can equivalently erase the two endpoints in the other order. -/
+theorem cIoo_union_swap_eq_erase_erase {a b : Fin n} (h : a ≠ b) :
+    cIoo a b ∪ cIoo b a = (Finset.univ.erase b).erase a := by
+  rw [cIoo_union_swap h]
+  ext x
+  simp only [Finset.mem_erase, Finset.mem_univ, and_true]
+  tauto
+
+/-- The opposite cyclic interval is the endpoint complement with the first interval removed. -/
+theorem cIoo_swap_eq_endpointComplement_sdiff {a b : Fin n} (h : a ≠ b) :
+    cIoo b a = (Finset.univ.erase a).erase b \ cIoo a b := by
+  ext x
+  constructor
+  · intro hx
+    refine Finset.mem_sdiff.mpr ⟨?_, ?_⟩
+    · rw [← cIoo_union_swap h]
+      exact Finset.mem_union_right _ hx
+    · intro hxab
+      exact not_mem_cIoo_and_mem_cIoo_swap a b x ⟨hxab, hx⟩
+  · intro hx
+    have hxu : x ∈ cIoo a b ∪ cIoo b a := by
+      rw [cIoo_union_swap h]
+      exact (Finset.mem_sdiff.mp hx).1
+    rcases Finset.mem_union.mp hxu with hxab | hxba
+    · exact ((Finset.mem_sdiff.mp hx).2 hxab).elim
+    · exact hxba
+
+/-- Removing the opposite cyclic interval from the endpoint complement gives the original
+cyclic interval. -/
+theorem cIoo_eq_endpointComplement_sdiff_swap {a b : Fin n} (h : a ≠ b) :
+    cIoo a b = (Finset.univ.erase a).erase b \ cIoo b a := by
+  ext x
+  constructor
+  · intro hx
+    refine Finset.mem_sdiff.mpr ⟨?_, ?_⟩
+    · rw [← cIoo_union_swap h]
+      exact Finset.mem_union_left _ hx
+    · intro hxba
+      exact not_mem_cIoo_and_mem_cIoo_swap a b x ⟨hx, hxba⟩
+  · intro hx
+    have hxu : x ∈ cIoo a b ∪ cIoo b a := by
+      rw [cIoo_union_swap h]
+      exact (Finset.mem_sdiff.mp hx).1
+    rcases Finset.mem_union.mp hxu with hxab | hxba
+    · exact hxab
+    · exact ((Finset.mem_sdiff.mp hx).2 hxba).elim
+
+/-- The two complementary cyclic intervals have total cardinality `n - 2`. -/
+theorem card_cIoo_add_card_cIoo_swap {a b : Fin n} (h : a ≠ b) :
+    (cIoo a b).card + (cIoo b a).card = n - 2 := by
+  have hcard := congrArg Finset.card (cIoo_union_swap h)
+  rw [Finset.card_union_of_disjoint (disjoint_cIoo_swap a b)] at hcard
+  have hbmem : b ∈ (Finset.univ : Finset (Fin n)).erase a := by
+    simp [h.symm]
+  rw [Finset.card_erase_of_mem hbmem, Finset.card_erase_of_mem (Finset.mem_univ a),
+    Finset.card_univ, Fintype.card_fin] at hcard
+  exact hcard
+
+/-- The cardinalities of the two opposite intervals are symmetric. -/
+theorem card_cIoo_swap_add_card_cIoo {a b : Fin n} (h : a ≠ b) :
+    (cIoo b a).card + (cIoo a b).card = n - 2 := by
+  rw [Nat.add_comm]
+  exact card_cIoo_add_card_cIoo_swap h
+
+end Grid
+
+end TauCeti

--- a/TauCeti/KnotTheory/Grid/CyclicInterval.lean
+++ b/TauCeti/KnotTheory/Grid/CyclicInterval.lean
@@ -2,7 +2,8 @@
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 -/
-import TauCeti.KnotTheory.Grid.Rectangle
+import Mathlib.Data.Set.Finite.Basic
+import Mathlib.Order.Circular.ZMod
 
 /-!
 # Complementary cyclic intervals in finite grids
@@ -37,9 +38,80 @@ namespace Grid
 
 variable {n : ℕ}
 
+/-- The clockwise open cyclic interval from `a` to `b` in `Fin n`.
+
+If `a < b` in the standard representatives, this is the ordinary open interval
+`a < x < b`. If `b ≤ a` and `a ≠ b`, it wraps around `0`, so it is the union of
+`a < x` and `x < b`. The interval from a point to itself is empty. -/
+noncomputable def cIoo (a b : Fin n) : Finset (Fin n) :=
+  ((Set.finite_univ : (Set.univ : Set (Fin n)).Finite).subset
+    (Set.subset_univ (Set.cIoo a b : Set (Fin n)))).toFinset
+
+/-- Membership in a clockwise open cyclic interval, unfolded as inequalities between the
+standard representatives. -/
+@[simp]
+theorem mem_cIoo (a b x : Fin n) :
+    x ∈ cIoo a b ↔
+      a ≠ b ∧
+        if a.val < b.val then
+          a.val < x.val ∧ x.val < b.val
+        else
+          a.val < x.val ∨ x.val < b.val := by
+  rw [cIoo]
+  simp only [Set.Finite.mem_toFinset, Set.mem_cIoo, Fin.sbtw_iff, Fin.lt_def]
+  constructor
+  · rintro (⟨hax, hxb⟩ | ⟨hxb, hba⟩ | ⟨hba, hax⟩)
+    · exact ⟨fun hab => by omega, by simp [hax, hxb]⟩
+    · exact ⟨fun hab => by omega, by simp [Nat.not_lt_of_gt hba, hxb]⟩
+    · exact ⟨fun hab => by omega, by simp [Nat.not_lt_of_gt hba, hax]⟩
+  · intro h
+    by_cases hab : a.val < b.val
+    · exact Or.inl (by simpa [hab] using h.2)
+    · have hba : b.val < a.val := by
+        exact Nat.lt_of_le_of_ne (Nat.le_of_not_gt hab) (by omega)
+      rcases (by simpa [hab] using h.2) with hax | hxb
+      · exact Or.inr (Or.inr ⟨hba, hax⟩)
+      · exact Or.inr (Or.inl ⟨hxb, hba⟩)
+
+/-- The open cyclic interval from a point to itself is empty. -/
+@[simp]
+theorem cIoo_self (a : Fin n) : cIoo a a = ∅ := by
+  ext x
+  simp
+
+/-- The initial endpoint is not in its open cyclic interval. -/
+@[simp]
+theorem left_notMem_cIoo (a b : Fin n) : a ∉ cIoo a b := by
+  intro ha
+  rw [mem_cIoo] at ha
+  by_cases hab : a.val < b.val
+  · have hinside : a.val < a.val ∧ a.val < b.val := by
+      simpa only [hab, if_true] using ha.2
+    exact Nat.lt_irrefl a.val hinside.1
+  · have hinside : a.val < a.val ∨ a.val < b.val := by
+      simpa only [hab, if_false] using ha.2
+    cases hinside with
+    | inl hlt => exact Nat.lt_irrefl a.val hlt
+    | inr hlt => exact hab hlt
+
+/-- The terminal endpoint is not in its open cyclic interval. -/
+@[simp]
+theorem right_notMem_cIoo (a b : Fin n) : b ∉ cIoo a b := by
+  intro hb
+  rw [mem_cIoo] at hb
+  by_cases hab : a.val < b.val
+  · have hinside : a.val < b.val ∧ b.val < b.val := by
+      simpa only [hab, if_true] using hb.2
+    exact Nat.lt_irrefl b.val hinside.2
+  · have hinside : a.val < b.val ∨ b.val < b.val := by
+      simpa only [hab, if_false] using hb.2
+    cases hinside with
+    | inl hlt => exact hab hlt
+    | inr hlt => exact Nat.lt_irrefl b.val hlt
+
 /-- A point cannot lie in both open cyclic intervals with the same endpoints but opposite
 orientations. -/
-theorem not_mem_cIoo_and_mem_cIoo_swap (a b x : Fin n) :
+private theorem not_mem_cIoo_and_cIoo_swap (a b x : Fin n) :
     ¬(x ∈ cIoo a b ∧ x ∈ cIoo b a) := by
   rw [mem_cIoo, mem_cIoo]
   rintro ⟨hxab, hxba⟩
@@ -62,10 +134,11 @@ theorem disjoint_cIoo_swap (a b : Fin n) : Disjoint (cIoo a b) (cIoo b a) := by
   rw [Finset.disjoint_iff_ne]
   intro x hx y hy hxy
   subst hxy
-  exact not_mem_cIoo_and_mem_cIoo_swap a b x ⟨hx, hy⟩
+  exact not_mem_cIoo_and_cIoo_swap a b x ⟨hx, hy⟩
 
 /-- Membership in one of the two opposite cyclic intervals is the same as being neither
 endpoint. -/
+@[simp]
 theorem mem_cIoo_or_mem_cIoo_swap_iff {a b x : Fin n} (h : a ≠ b) :
     x ∈ cIoo a b ∨ x ∈ cIoo b a ↔ x ≠ a ∧ x ≠ b := by
   constructor
@@ -100,6 +173,7 @@ theorem mem_cIoo_or_mem_cIoo_swap_iff {a b x : Fin n} (h : a ≠ b) :
 
 /-- A point outside the clockwise interval from `a` to `b` is either an endpoint or lies in
 the opposite clockwise interval. -/
+@[simp]
 theorem not_mem_cIoo_iff {a b x : Fin n} (h : a ≠ b) :
     x ∉ cIoo a b ↔ x = a ∨ x = b ∨ x ∈ cIoo b a := by
   constructor
@@ -116,9 +190,10 @@ theorem not_mem_cIoo_iff {a b x : Fin n} (h : a ≠ b) :
     · rw [hxb]
       exact right_notMem_cIoo a b
     · intro hxab
-      exact not_mem_cIoo_and_mem_cIoo_swap a b x ⟨hxab, hx⟩
+      exact not_mem_cIoo_and_cIoo_swap a b x ⟨hxab, hx⟩
 
 /-- The two opposite cyclic intervals cover exactly the complement of their endpoints. -/
+@[simp]
 theorem cIoo_union_swap {a b : Fin n} (h : a ≠ b) :
     cIoo a b ∪ cIoo b a = (Finset.univ.erase a).erase b := by
   ext x
@@ -130,16 +205,8 @@ theorem cIoo_union_swap {a b : Fin n} (h : a ≠ b) :
   · rintro ⟨hxb, hxa⟩
     exact ⟨hxa, hxb⟩
 
-/-- The endpoint complement can equivalently erase the two endpoints in the other order. -/
-theorem cIoo_union_swap_eq_erase_erase {a b : Fin n} (h : a ≠ b) :
-    cIoo a b ∪ cIoo b a = (Finset.univ.erase b).erase a := by
-  rw [cIoo_union_swap h]
-  ext x
-  simp only [Finset.mem_erase, Finset.mem_univ, and_true]
-  tauto
-
 /-- The opposite cyclic interval is the endpoint complement with the first interval removed. -/
-theorem cIoo_swap_eq_endpointComplement_sdiff {a b : Fin n} (h : a ≠ b) :
+theorem cIoo_swap_eq_erase_erase_sdiff {a b : Fin n} (h : a ≠ b) :
     cIoo b a = (Finset.univ.erase a).erase b \ cIoo a b := by
   ext x
   constructor
@@ -148,7 +215,7 @@ theorem cIoo_swap_eq_endpointComplement_sdiff {a b : Fin n} (h : a ≠ b) :
     · rw [← cIoo_union_swap h]
       exact Finset.mem_union_right _ hx
     · intro hxab
-      exact not_mem_cIoo_and_mem_cIoo_swap a b x ⟨hxab, hx⟩
+      exact not_mem_cIoo_and_cIoo_swap a b x ⟨hxab, hx⟩
   · intro hx
     have hxu : x ∈ cIoo a b ∪ cIoo b a := by
       rw [cIoo_union_swap h]
@@ -156,26 +223,6 @@ theorem cIoo_swap_eq_endpointComplement_sdiff {a b : Fin n} (h : a ≠ b) :
     rcases Finset.mem_union.mp hxu with hxab | hxba
     · exact ((Finset.mem_sdiff.mp hx).2 hxab).elim
     · exact hxba
-
-/-- Removing the opposite cyclic interval from the endpoint complement gives the original
-cyclic interval. -/
-theorem cIoo_eq_endpointComplement_sdiff_swap {a b : Fin n} (h : a ≠ b) :
-    cIoo a b = (Finset.univ.erase a).erase b \ cIoo b a := by
-  ext x
-  constructor
-  · intro hx
-    refine Finset.mem_sdiff.mpr ⟨?_, ?_⟩
-    · rw [← cIoo_union_swap h]
-      exact Finset.mem_union_left _ hx
-    · intro hxba
-      exact not_mem_cIoo_and_mem_cIoo_swap a b x ⟨hx, hxba⟩
-  · intro hx
-    have hxu : x ∈ cIoo a b ∪ cIoo b a := by
-      rw [cIoo_union_swap h]
-      exact (Finset.mem_sdiff.mp hx).1
-    rcases Finset.mem_union.mp hxu with hxab | hxba
-    · exact hxab
-    · exact ((Finset.mem_sdiff.mp hx).2 hxba).elim
 
 /-- The two complementary cyclic intervals have total cardinality `n - 2`. -/
 theorem card_cIoo_add_card_cIoo_swap {a b : Fin n} (h : a ≠ b) :
@@ -187,12 +234,6 @@ theorem card_cIoo_add_card_cIoo_swap {a b : Fin n} (h : a ≠ b) :
   rw [Finset.card_erase_of_mem hbmem, Finset.card_erase_of_mem (Finset.mem_univ a),
     Finset.card_univ, Fintype.card_fin] at hcard
   exact hcard
-
-/-- The cardinalities of the two opposite intervals are symmetric. -/
-theorem card_cIoo_swap_add_card_cIoo {a b : Fin n} (h : a ≠ b) :
-    (cIoo b a).card + (cIoo a b).card = n - 2 := by
-  rw [Nat.add_comm]
-  exact card_cIoo_add_card_cIoo_swap h
 
 end Grid
 

--- a/TauCeti/KnotTheory/Grid/Rectangle.lean
+++ b/TauCeti/KnotTheory/Grid/Rectangle.lean
@@ -22,7 +22,6 @@ finite-set disjointness conditions used for empty rectangles and marking-avoidin
 
 ## Main definitions
 
-* `TauCeti.Grid.cIoo`: the clockwise open-open circular interval from `a` to `b`.
 * `TauCeti.GridRectangle`: a toroidal rectangle, represented by its four cyclic sides.
 * `TauCeti.GridRectangle.interior`: the finite set of squares strictly inside the rectangle.
 * `TauCeti.GridRectangleBetween`: an oriented rectangle from one grid state to another.

--- a/TauCeti/KnotTheory/Grid/Rectangle.lean
+++ b/TauCeti/KnotTheory/Grid/Rectangle.lean
@@ -4,8 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 -/
 import Mathlib.Data.Finset.Prod
 import Mathlib.Data.Fintype.Prod
-import Mathlib.Data.Set.Finite.Basic
-import Mathlib.Order.Circular.ZMod
+import TauCeti.KnotTheory.Grid.CyclicInterval
 import TauCeti.KnotTheory.Grid.Diagram
 
 /-!
@@ -40,83 +39,6 @@ The encoding follows the toroidal grid-diagram convention from Ozsváth--Stipsic
 -/
 
 namespace TauCeti
-
-namespace Grid
-
-variable {n : ℕ}
-
-/-- The clockwise open cyclic interval from `a` to `b` in `Fin n`.
-
-If `a < b` in the standard representatives, this is the ordinary open interval
-`a < x < b`. If `b ≤ a` and `a ≠ b`, it wraps around `0`, so it is the union of
-`a < x` and `x < b`. The interval from a point to itself is empty. -/
-noncomputable def cIoo (a b : Fin n) : Finset (Fin n) :=
-  ((Set.finite_univ : (Set.univ : Set (Fin n)).Finite).subset
-    (Set.subset_univ (Set.cIoo a b : Set (Fin n)))).toFinset
-
-/-- Membership in a clockwise open cyclic interval, unfolded as inequalities between the
-standard representatives. -/
-@[simp]
-theorem mem_cIoo (a b x : Fin n) :
-    x ∈ cIoo a b ↔
-      a ≠ b ∧
-        if a.val < b.val then
-          a.val < x.val ∧ x.val < b.val
-        else
-          a.val < x.val ∨ x.val < b.val := by
-  rw [cIoo]
-  simp only [Set.Finite.mem_toFinset, Set.mem_cIoo, Fin.sbtw_iff, Fin.lt_def]
-  constructor
-  · rintro (⟨hax, hxb⟩ | ⟨hxb, hba⟩ | ⟨hba, hax⟩)
-    · exact ⟨fun hab => by omega, by simp [hax, hxb]⟩
-    · exact ⟨fun hab => by omega, by simp [Nat.not_lt_of_gt hba, hxb]⟩
-    · exact ⟨fun hab => by omega, by simp [Nat.not_lt_of_gt hba, hax]⟩
-  · intro h
-    by_cases hab : a.val < b.val
-    · exact Or.inl (by simpa [hab] using h.2)
-    · have hba : b.val < a.val := by
-        exact Nat.lt_of_le_of_ne (Nat.le_of_not_gt hab) (by omega)
-      rcases (by simpa [hab] using h.2) with hax | hxb
-      · exact Or.inr (Or.inr ⟨hba, hax⟩)
-      · exact Or.inr (Or.inl ⟨hxb, hba⟩)
-
-/-- The open cyclic interval from a point to itself is empty. -/
-@[simp]
-theorem cIoo_self (a : Fin n) : cIoo a a = ∅ := by
-  ext x
-  simp
-
-/-- The initial endpoint is not in its open cyclic interval. -/
-@[simp]
-theorem left_notMem_cIoo (a b : Fin n) : a ∉ cIoo a b := by
-  intro ha
-  rw [mem_cIoo] at ha
-  by_cases hab : a.val < b.val
-  · have hinside : a.val < a.val ∧ a.val < b.val := by
-      simpa only [hab, if_true] using ha.2
-    exact Nat.lt_irrefl a.val hinside.1
-  · have hinside : a.val < a.val ∨ a.val < b.val := by
-      simpa only [hab, if_false] using ha.2
-    cases hinside with
-    | inl hlt => exact Nat.lt_irrefl a.val hlt
-    | inr hlt => exact hab hlt
-
-/-- The terminal endpoint is not in its open cyclic interval. -/
-@[simp]
-theorem right_notMem_cIoo (a b : Fin n) : b ∉ cIoo a b := by
-  intro hb
-  rw [mem_cIoo] at hb
-  by_cases hab : a.val < b.val
-  · have hinside : a.val < b.val ∧ b.val < b.val := by
-      simpa only [hab, if_true] using hb.2
-    exact Nat.lt_irrefl b.val hinside.2
-  · have hinside : a.val < b.val ∨ b.val < b.val := by
-      simpa only [hab, if_false] using hb.2
-    cases hinside with
-    | inl hlt => exact hab hlt
-    | inr hlt => exact Nat.lt_irrefl b.val hlt
-
-end Grid
 
 /-- A toroidal grid rectangle, represented by its oriented column and row sides.
 


### PR DESCRIPTION
This PR adds finite-set bookkeeping for complementary cyclic intervals in grid diagrams: opposite open arcs on `Fin n` are disjoint, cover exactly the complement of their two endpoints, recover each other by set difference from that endpoint complement, and have total cardinality `n - 2`. It advances `TauCetiRoadmap/HeegaardFloer/README.md`, Lane G.3, the specific item "The complexes and `∂² = 0`. Fully blocked `GC̃` over 𝔽₂", by supplying the one-dimensional partition facts used in the annular cases of the later rectangle-pair juxtaposition proof.

<!--tauceti-target:v1 {"focus":"HeegaardFloer","id":"complementary-cyclic-intervals"}-->

No Mathlib infrastructure is vendored. The implementation reuses Mathlib finite-set APIs such as `Finset.disjoint_iff_ne`, `Finset.mem_union`, `Finset.mem_sdiff`, `Finset.card_union_of_disjoint`, `Finset.card_erase_of_mem`, and the existing Tau Ceti `Grid.cIoo` API from `TauCeti.KnotTheory.Grid.Rectangle`. I checked the pinned Mathlib source for circular interval infrastructure and found `Set.cIoo`, `Set.compl_cIoo`, and `Fin.sbtw_iff` in `.lake/packages/mathlib/Mathlib/Order/Circular*.lean`; the finite `Finset (Fin n)` complementary-arc API added here was not present.

Verification: `lake exe cache get` completed with `No files to download` and `Already decompressed 8555 file(s)`; `lake build` completed with `Build completed successfully (3846 jobs).`; `lake exe axioms` completed with `axioms: audited 2246 TauCeti declaration(s); all within the allowlist [propext, Classical.choice, Quot.sound].`

🤖 Prepared with Codex
