### PR TITLE
feat: prove the grid Maslov gradings are integer-valued

### DIFF
--- a/TauCeti/KnotTheory/Grid/GradingInteger.lean
+++ b/TauCeti/KnotTheory/Grid/GradingInteger.lean
@@ -33,37 +33,18 @@ so `M_O(x)` is an integer. The same computation handles `M_X`.
 * `TauCeti.GridDiagram.maslovO_exists_int`, `TauCeti.GridDiagram.maslovX_exists_int`: the Maslov
   gradings are integers.
 * `TauCeti.GridDiagram.two_mul_alexander_eq_intCast`,
-  `TauCeti.GridDiagram.alexander_two_mul_exists_int`: twice the Alexander grading is an integer.
+  `TauCeti.GridDiagram.two_mul_alexander_exists_int`: twice the Alexander grading is an integer.
 
 ## References
 
-This advances `TauCetiRoadmap/HeegaardFloer/README.md`, Lane G.2, "Gradings. The `J`-function,
-`M_O`, `M_X`, `A`; integer-valuedness of `A`; grading-change formulas across a rectangle." The
-integrality of the Maslov gradings is the prerequisite that the (parity-sensitive) integrality of
-the Alexander grading itself builds on; see Ozsváth--Stipsicz--Szabó, *Grid Homology for Knots and
-Links*, Chapter 4.
+This advances `TauCetiRoadmap/CombinatorialHeegaardFloer/README.md`, Lane G item 2, "Gradings.
+The `J`-function, `M_O`, `M_X`, `A`; integer-valuedness of `A`; grading-change formulas across a
+rectangle." The integrality of the Maslov gradings is the prerequisite that the (parity-sensitive)
+integrality of the Alexander grading itself builds on; see Ozsváth--Stipsicz--Szabó, *Grid Homology
+for Knots and Links*, Chapter 4.
 -/
 
 namespace TauCeti
-
-namespace GridPoint
-
-variable {n : ℕ}
-
-/-- The symmetrized numerator of the `J`-function on a point set with itself is even: it is twice
-the ordered southwest count. -/
-theorem JNum_self (s : Finset (Fin n × Fin n)) : JNum s s = 2 * I s s := by
-  rw [JNum_def, two_mul]
-
-/-- The `J`-function on a point set with itself is an integer, namely the ordered southwest
-count. The two southwest comparisons of a pair contribute symmetrically, so the division by two
-is exact. -/
-theorem J_self (s : Finset (Fin n × Fin n)) : GridPoint.J s s = (I s s : ℚ) := by
-  rw [J_def, JNum_self]
-  push_cast
-  ring
-
-end GridPoint
 
 namespace GridDiagram
 
@@ -77,36 +58,40 @@ def maslovOℤ (x : GridState n) : ℤ :=
   (GridPoint.I x.pointSet x.pointSet : ℤ) - GridPoint.JNum x.pointSet G.OSet
     + GridPoint.I G.OSet G.OSet + 1
 
+/-- The integer `O`-Maslov grading restated as its defining formula. -/
+@[simp]
+theorem maslovOℤ_def (x : GridState n) :
+    G.maslovOℤ x =
+      (GridPoint.I x.pointSet x.pointSet : ℤ) - GridPoint.JNum x.pointSet G.OSet
+        + GridPoint.I G.OSet G.OSet + 1 :=
+  rfl
+
 /-- The integer-valued `X`-Maslov grading of a grid state. -/
 def maslovXℤ (x : GridState n) : ℤ :=
   (GridPoint.I x.pointSet x.pointSet : ℤ) - GridPoint.JNum x.pointSet G.XSet
     + GridPoint.I G.XSet G.XSet + 1
 
+/-- The integer `X`-Maslov grading restated as its defining formula. -/
+@[simp]
+theorem maslovXℤ_def (x : GridState n) :
+    G.maslovXℤ x =
+      (GridPoint.I x.pointSet x.pointSet : ℤ) - GridPoint.JNum x.pointSet G.XSet
+        + GridPoint.I G.XSet G.XSet + 1 :=
+  rfl
+
 /-- The rational `O`-Maslov grading is the cast of its integer counterpart: `M_O` is an
-integer. -/
+integer. This specializes the general self-pairing integrality `GridPoint.JDiff_self_eq_intCast`
+to the `O`-markings. -/
 theorem maslovO_eq_intCast (x : GridState n) : G.maslovO x = (G.maslovOℤ x : ℚ) := by
-  have hxx : GridState.J x x = (GridPoint.I x.pointSet x.pointSet : ℚ) := by
-    rw [GridState.J_def, GridPoint.J_self]
-  have hOO : GridState.J G.O G.O = (GridPoint.I G.OSet G.OSet : ℚ) := by
-    rw [GridState.J_def, GridPoint.J_self, OSet]
-  have hJO : 2 * G.JO x = (GridPoint.JNum x.pointSet G.OSet : ℚ) := by
-    rw [JO_def, GridPoint.J_def]
-    ring
-  rw [maslovO_eq, hxx, hJO, hOO, maslovOℤ]
+  rw [maslovO_def, GridPoint.JDiff_self_eq_intCast, maslovOℤ]
   push_cast
   ring
 
 /-- The rational `X`-Maslov grading is the cast of its integer counterpart: `M_X` is an
-integer. -/
+integer. This specializes the general self-pairing integrality `GridPoint.JDiff_self_eq_intCast`
+to the `X`-markings. -/
 theorem maslovX_eq_intCast (x : GridState n) : G.maslovX x = (G.maslovXℤ x : ℚ) := by
-  have hxx : GridState.J x x = (GridPoint.I x.pointSet x.pointSet : ℚ) := by
-    rw [GridState.J_def, GridPoint.J_self]
-  have hXX : GridState.J G.X G.X = (GridPoint.I G.XSet G.XSet : ℚ) := by
-    rw [GridState.J_def, GridPoint.J_self, XSet]
-  have hJX : 2 * G.JX x = (GridPoint.JNum x.pointSet G.XSet : ℚ) := by
-    rw [JX_def, GridPoint.J_def]
-    ring
-  rw [maslovX_eq, hxx, hJX, hXX, maslovXℤ]
+  rw [maslovX_def, GridPoint.JDiff_self_eq_intCast, maslovXℤ]
   push_cast
   ring
 
@@ -123,6 +108,12 @@ The normalization shift `(n - 1)` is taken over `ℤ`, so the formula is literal
 def alexanderTwoℤ (x : GridState n) : ℤ :=
   G.maslovOℤ x - G.maslovXℤ x - ((n : ℤ) - 1)
 
+/-- The integer numerator of twice the Alexander grading restated as its defining formula. -/
+@[simp]
+theorem alexanderTwoℤ_def (x : GridState n) :
+    G.alexanderTwoℤ x = G.maslovOℤ x - G.maslovXℤ x - ((n : ℤ) - 1) :=
+  rfl
+
 /-- Twice the Alexander grading is an integer: it is the difference of the integer Maslov
 gradings, corrected by the normalization shift. This stops short of integrality of `A` itself,
 which is the genuinely parity-sensitive statement. -/
@@ -134,7 +125,7 @@ theorem two_mul_alexander_eq_intCast (x : GridState n) :
 
 /-- Twice the Alexander grading is an integer; equivalently, the Alexander grading is a
 half-integer. -/
-theorem alexander_two_mul_exists_int (x : GridState n) :
+theorem two_mul_alexander_exists_int (x : GridState n) :
     ∃ m : ℤ, 2 * G.alexander x = (m : ℚ) :=
   ⟨G.alexanderTwoℤ x, G.two_mul_alexander_eq_intCast x⟩
 

--- a/TauCeti/KnotTheory/Grid/GradingInteger.lean
+++ b/TauCeti/KnotTheory/Grid/GradingInteger.lean
@@ -2,6 +2,7 @@
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 -/
+import Mathlib.Tactic.Ring
 import TauCeti.KnotTheory.Grid.Gradings
 
 /-!

--- a/TauCeti/KnotTheory/Grid/GradingInteger.lean
+++ b/TauCeti/KnotTheory/Grid/GradingInteger.lean
@@ -1,0 +1,143 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+import TauCeti.KnotTheory.Grid.Gradings
+
+/-!
+# Integer-valuedness of the Maslov gradings
+
+The Maslov gradings `M_O` and `M_X` of a grid state are defined in
+`TauCeti.KnotTheory.Grid.Gradings` as rational-valued formulas through the `J`-function, which is
+itself a half-integer (the symmetrization of a point-pair count divided by two). This file proves
+that the two Maslov gradings are in fact integers, by exhibiting explicit integer formulas and
+the corresponding rational casts. As an immediate consequence the Alexander grading is a
+half-integer: its double is an integer.
+
+The key elementary fact is that the `J`-function on a point set with *itself* is already an
+integer, `J(s, s) = I(s, s)`, because the symmetrized numerator `JNum(s, s) = 2 · I(s, s)` is
+even. Feeding this into the formula `M_O(x) = J(x, x) - 2 · J(x, O) + J(O, O) + 1` cancels every
+remaining half: `2 · J(x, O) = JNum(x, O)` is an integer, and the two self-pairings are integers,
+so `M_O(x)` is an integer. The same computation handles `M_X`.
+
+## Main definitions
+
+* `TauCeti.GridDiagram.maslovOℤ`, `TauCeti.GridDiagram.maslovXℤ`: the integer-valued Maslov
+  gradings.
+* `TauCeti.GridDiagram.alexanderTwoℤ`: the integer numerator of twice the Alexander grading.
+
+## Main results
+
+* `TauCeti.GridDiagram.maslovO_eq_intCast`, `TauCeti.GridDiagram.maslovX_eq_intCast`: the
+  rational Maslov gradings are the casts of their integer counterparts.
+* `TauCeti.GridDiagram.maslovO_exists_int`, `TauCeti.GridDiagram.maslovX_exists_int`: the Maslov
+  gradings are integers.
+* `TauCeti.GridDiagram.two_mul_alexander_eq_intCast`,
+  `TauCeti.GridDiagram.alexander_two_mul_exists_int`: twice the Alexander grading is an integer.
+
+## References
+
+This advances `TauCetiRoadmap/HeegaardFloer/README.md`, Lane G.2, "Gradings. The `J`-function,
+`M_O`, `M_X`, `A`; integer-valuedness of `A`; grading-change formulas across a rectangle." The
+integrality of the Maslov gradings is the prerequisite that the (parity-sensitive) integrality of
+the Alexander grading itself builds on; see Ozsváth--Stipsicz--Szabó, *Grid Homology for Knots and
+Links*, Chapter 4.
+-/
+
+namespace TauCeti
+
+namespace GridPoint
+
+variable {n : ℕ}
+
+/-- The symmetrized numerator of the `J`-function on a point set with itself is even: it is twice
+the ordered southwest count. -/
+theorem JNum_self (s : Finset (Fin n × Fin n)) : JNum s s = 2 * I s s := by
+  rw [JNum_def, two_mul]
+
+/-- The `J`-function on a point set with itself is an integer, namely the ordered southwest
+count. The two southwest comparisons of a pair contribute symmetrically, so the division by two
+is exact. -/
+theorem J_self (s : Finset (Fin n × Fin n)) : GridPoint.J s s = (I s s : ℚ) := by
+  rw [J_def, JNum_self]
+  push_cast
+  ring
+
+end GridPoint
+
+namespace GridDiagram
+
+variable {n : ℕ} (G : GridDiagram n)
+
+/-- The integer-valued `O`-Maslov grading of a grid state.
+
+This is the integer formula `M_O(x) = I(x, x) - JNum(x, O) + I(O, O) + 1` obtained from the
+rational definition once the two halves coming from the `J`-function cancel. -/
+def maslovOℤ (x : GridState n) : ℤ :=
+  (GridPoint.I x.pointSet x.pointSet : ℤ) - GridPoint.JNum x.pointSet G.OSet
+    + GridPoint.I G.OSet G.OSet + 1
+
+/-- The integer-valued `X`-Maslov grading of a grid state. -/
+def maslovXℤ (x : GridState n) : ℤ :=
+  (GridPoint.I x.pointSet x.pointSet : ℤ) - GridPoint.JNum x.pointSet G.XSet
+    + GridPoint.I G.XSet G.XSet + 1
+
+/-- The rational `O`-Maslov grading is the cast of its integer counterpart: `M_O` is an
+integer. -/
+theorem maslovO_eq_intCast (x : GridState n) : G.maslovO x = (G.maslovOℤ x : ℚ) := by
+  have hxx : GridState.J x x = (GridPoint.I x.pointSet x.pointSet : ℚ) := by
+    rw [GridState.J_def, GridPoint.J_self]
+  have hOO : GridState.J G.O G.O = (GridPoint.I G.OSet G.OSet : ℚ) := by
+    rw [GridState.J_def, GridPoint.J_self, OSet]
+  have hJO : 2 * G.JO x = (GridPoint.JNum x.pointSet G.OSet : ℚ) := by
+    rw [JO_def, GridPoint.J_def]
+    ring
+  rw [maslovO_eq, hxx, hJO, hOO, maslovOℤ]
+  push_cast
+  ring
+
+/-- The rational `X`-Maslov grading is the cast of its integer counterpart: `M_X` is an
+integer. -/
+theorem maslovX_eq_intCast (x : GridState n) : G.maslovX x = (G.maslovXℤ x : ℚ) := by
+  have hxx : GridState.J x x = (GridPoint.I x.pointSet x.pointSet : ℚ) := by
+    rw [GridState.J_def, GridPoint.J_self]
+  have hXX : GridState.J G.X G.X = (GridPoint.I G.XSet G.XSet : ℚ) := by
+    rw [GridState.J_def, GridPoint.J_self, XSet]
+  have hJX : 2 * G.JX x = (GridPoint.JNum x.pointSet G.XSet : ℚ) := by
+    rw [JX_def, GridPoint.J_def]
+    ring
+  rw [maslovX_eq, hxx, hJX, hXX, maslovXℤ]
+  push_cast
+  ring
+
+/-- The `O`-Maslov grading is an integer. -/
+theorem maslovO_exists_int (x : GridState n) : ∃ m : ℤ, G.maslovO x = (m : ℚ) :=
+  ⟨G.maslovOℤ x, G.maslovO_eq_intCast x⟩
+
+/-- The `X`-Maslov grading is an integer. -/
+theorem maslovX_exists_int (x : GridState n) : ∃ m : ℤ, G.maslovX x = (m : ℚ) :=
+  ⟨G.maslovXℤ x, G.maslovX_eq_intCast x⟩
+
+/-- The integer numerator of twice the Alexander grading, `2 · A(x) = M_O(x) - M_X(x) - (n - 1)`.
+The normalization shift `(n - 1)` is taken over `ℤ`, so the formula is literal at every `n`. -/
+def alexanderTwoℤ (x : GridState n) : ℤ :=
+  G.maslovOℤ x - G.maslovXℤ x - ((n : ℤ) - 1)
+
+/-- Twice the Alexander grading is an integer: it is the difference of the integer Maslov
+gradings, corrected by the normalization shift. This stops short of integrality of `A` itself,
+which is the genuinely parity-sensitive statement. -/
+theorem two_mul_alexander_eq_intCast (x : GridState n) :
+    2 * G.alexander x = (G.alexanderTwoℤ x : ℚ) := by
+  rw [alexander_def, G.maslovO_eq_intCast, G.maslovX_eq_intCast, alexanderTwoℤ]
+  push_cast
+  ring
+
+/-- Twice the Alexander grading is an integer; equivalently, the Alexander grading is a
+half-integer. -/
+theorem alexander_two_mul_exists_int (x : GridState n) :
+    ∃ m : ℤ, 2 * G.alexander x = (m : ℚ) :=
+  ⟨G.alexanderTwoℤ x, G.two_mul_alexander_eq_intCast x⟩
+
+end GridDiagram
+
+end TauCeti

--- a/TauCeti/KnotTheory/Grid/JFunction.lean
+++ b/TauCeti/KnotTheory/Grid/JFunction.lean
@@ -160,6 +160,12 @@ def JNum (s t : Finset (Fin n × Fin n)) : ℕ :=
 theorem JNum_def (s t : Finset (Fin n × Fin n)) : JNum s t = I s t + I t s :=
   rfl
 
+/-- The symmetrized numerator of the `J`-function on a point set with itself is even: it is twice
+the ordered southwest count. -/
+@[simp]
+theorem JNum_self (s : Finset (Fin n × Fin n)) : JNum s s = 2 * I s s := by
+  rw [JNum_def, two_mul]
+
 /-- The rational-valued symmetrized grid `J`-function. -/
 def J (s t : Finset (Fin n × Fin n)) : ℚ :=
   ((JNum s t : ℕ) : ℚ) / 2
@@ -167,6 +173,15 @@ def J (s t : Finset (Fin n × Fin n)) : ℚ :=
 /-- The rational-valued `J`-function is half of its symmetrized numerator. -/
 theorem J_def (s t : Finset (Fin n × Fin n)) : GridPoint.J s t = ((JNum s t : ℕ) : ℚ) / 2 :=
   rfl
+
+/-- The `J`-function on a point set with itself is an integer, namely the ordered southwest
+count. The two southwest comparisons of a pair contribute symmetrically, so the division by two
+is exact. -/
+@[simp]
+theorem J_self (s : Finset (Fin n × Fin n)) : GridPoint.J s s = (I s s : ℚ) := by
+  rw [J_def, JNum_self]
+  push_cast
+  ring
 
 /-- The numerator of `J` is symmetric. -/
 theorem JNum_comm (s t : Finset (Fin n × Fin n)) : JNum s t = JNum t s := by
@@ -290,6 +305,16 @@ theorem JDiff_right_sub_empty (s a t : Finset (Fin n × Fin n)) :
 theorem JDiff_self_eq (s a : Finset (Fin n × Fin n)) :
     JDiff s a s a = GridPoint.J s s - 2 * GridPoint.J s a + GridPoint.J a a := by
   rw [JDiff, GridPoint.J_comm a s]
+  ring
+
+/-- The self-pairing `JDiff s a s a` is integer-valued: it is the cast of
+`I(s, s) - JNum(s, a) + I(a, a)`. The two `J`-self-pairings are integers by `J_self`, and the
+cross term `2 · J(s, a)` is the integer numerator `JNum(s, a)`, so every half cancels. This is the
+general fact underlying the integer-valuedness of the Maslov gradings. -/
+theorem JDiff_self_eq_intCast (s a : Finset (Fin n × Fin n)) :
+    JDiff s a s a = ((I s s : ℤ) - JNum s a + I a a : ℚ) := by
+  rw [JDiff_self_eq, J_self s, J_self a, J_def]
+  push_cast
   ring
 
 /-- `JDiff` is additive in the left positive point set over disjoint unions. -/


### PR DESCRIPTION
This PR proves that the `O`- and `X`-Maslov gradings of a grid state are integer-valued, even though they are defined as rational formulas through the half-integer `J`-function. It exhibits explicit integer-valued gradings `maslovOℤ` and `maslovXℤ` together with the rational casts `maslovO_eq_intCast` and `maslovX_eq_intCast`, and packages the integrality as `maslovO_exists_int` / `maslovX_exists_int`. The key elementary fact is that the `J`-function on a point set with itself is already an integer, `J(s, s) = I(s, s)`, because its symmetrized numerator `JNum(s, s) = 2·I(s, s)` is even; it is packaged as the general self-pairing lemma `GridPoint.JDiff_self_eq_intCast`, and the two Maslov casts are specializations of it. As a corollary the Alexander grading is shown to be a half-integer: `alexanderTwoℤ` is the integer numerator of `2·A(x)`, with `two_mul_alexander_eq_intCast` and `two_mul_alexander_exists_int`. This is the integrality prerequisite that the genuinely parity-sensitive integrality of `A` itself builds on.

It advances `TauCetiRoadmap/CombinatorialHeegaardFloer/README.md`, Lane G item 2, "Gradings. The `J`-function, `M_O`, `M_X`, `A`; integer-valuedness of `A`; grading-change formulas across a rectangle", following Ozsváth--Stipsicz--Szabó, *Grid Homology for Knots and Links*, Chapter 4. No open or merged PR covers Maslov integrality; it reuses the existing Tau Ceti grid `J`-function and grading API and vendors no Mathlib infrastructure.

<!--tauceti-target:v1 {"focus":"HeegaardFloer","id":"grid-maslov-gradings-integer-valued"}-->

🤖 Prepared with Claude Code
