### PR TITLE
feat: add J-holomorphic map predicates

### DIFF
--- a/TauCeti/Geometry/Symplectic/AlmostComplex.lean
+++ b/TauCeti/Geometry/Symplectic/AlmostComplex.lean
@@ -21,6 +21,7 @@ on tangent fibers rather than restating the linear algebra.
 ## Main declarations
 
 * `TauCeti.AlmostComplexStructure`: a real-linear endomorphism `J` with `J^2 = -1`.
+* `TauCeti.IsComplexLinearMap`: a real-linear map intertwining two almost complex structures.
 * `TauCeti.SymplecticForm`: an alternating, nondegenerate real bilinear form.
 * `TauCeti.SymplecticForm.Tames`: the positivity condition `0 < ω v (J v)` for `v ≠ 0`.
 * `TauCeti.SymplecticForm.Compatible`: `J`-invariance plus positivity of `ω(·, J ·)`.
@@ -36,7 +37,7 @@ namespace TauCeti
 
 open LinearMap
 
-variable {V W : Type*}
+variable {V W X : Type*}
 
 /-- A pointwise almost complex structure is a real-linear endomorphism whose square is `-1`.
 
@@ -138,6 +139,54 @@ lemma product_apply (v : V × V) :
     product V v = (-v.2, v.1) := rfl
 
 end AlmostComplexStructure
+
+section ComplexLinearMap
+
+variable [AddCommGroup V] [Module ℝ V]
+variable [AddCommGroup W] [Module ℝ W]
+variable [AddCommGroup X] [Module ℝ X]
+
+/-- A real-linear map is complex-linear with respect to two fixed pointwise
+almost complex structures if it intertwines them. -/
+def IsComplexLinearMap (J : AlmostComplexStructure V) (J' : AlmostComplexStructure W)
+    (F : V →ₗ[ℝ] W) : Prop :=
+  F.comp J.toLinearMap = J'.toLinearMap.comp F
+
+/-- Rewrite complex-linearity of a real-linear map as the pointwise equation
+`F (J v) = J' (F v)`. -/
+lemma isComplexLinearMap_iff_apply (J : AlmostComplexStructure V)
+    (J' : AlmostComplexStructure W) (F : V →ₗ[ℝ] W) :
+    IsComplexLinearMap J J' F ↔ ∀ v, F (J v) = J' (F v) :=
+  LinearMap.ext_iff
+
+/-- The zero map is complex-linear for any source and target almost complex structures. -/
+@[simp]
+lemma isComplexLinearMap_zero (J : AlmostComplexStructure V) (J' : AlmostComplexStructure W) :
+    IsComplexLinearMap J J' (0 : V →ₗ[ℝ] W) := by
+  rw [isComplexLinearMap_iff_apply]
+  intro v
+  simp
+
+/-- The identity map is complex-linear with respect to the same almost complex structure. -/
+@[simp]
+lemma isComplexLinearMap_id (J : AlmostComplexStructure V) :
+    IsComplexLinearMap J J (LinearMap.id : V →ₗ[ℝ] V) := by
+  rw [isComplexLinearMap_iff_apply]
+  intro v
+  simp [LinearMap.id_apply]
+
+/-- Complex-linear maps are closed under composition. -/
+lemma IsComplexLinearMap.comp {J : AlmostComplexStructure V} {J' : AlmostComplexStructure W}
+    {J'' : AlmostComplexStructure X} {F : V →ₗ[ℝ] W} {G : W →ₗ[ℝ] X}
+    (hG : IsComplexLinearMap J' J'' G) (hF : IsComplexLinearMap J J' F) :
+    IsComplexLinearMap J J'' (G.comp F) := by
+  rw [isComplexLinearMap_iff_apply] at hF hG ⊢
+  intro v
+  calc
+    G (F (J v)) = G (J' (F v)) := by rw [hF v]
+    _ = J'' (G (F v)) := hG (F v)
+
+end ComplexLinearMap
 
 /-- A symplectic form on a real module is an alternating, nondegenerate bilinear form.
 

--- a/TauCeti/Geometry/Symplectic/JHolomorphic.lean
+++ b/TauCeti/Geometry/Symplectic/JHolomorphic.lean
@@ -23,6 +23,7 @@ different Cauchy--Riemann convention.
 * `IsComplexLinearMap`: a continuous real-linear map intertwines two almost complex
   structures.
 * `IsJHolomorphicAt`: a map has a complex-linear Frechet derivative at a point.
+* `IsJHolomorphicWithinAt`: a map has a complex-linear Frechet derivative within a set.
 * `IsJHolomorphicOn` and `IsJHolomorphic`: setwise and global versions.
 
 The convention follows McDuff--Salamon, *J-holomorphic Curves and Symplectic Topology*,
@@ -81,10 +82,17 @@ def IsJHolomorphicAt (J : AlmostComplexStructure V) (J' : AlmostComplexStructure
     (f : V → W) (x : V) : Prop :=
   ∃ f' : V →L[ℝ] W, HasFDerivAt f f' x ∧ IsComplexLinearMap J J' f'
 
-/-- A map is `J`-holomorphic on a set if it is `J`-holomorphic at every point of the set. -/
+/-- A map is `J`-holomorphic within a set at a point if its Frechet derivative within the
+set exists there and intertwines the source and target almost complex structures. -/
+def IsJHolomorphicWithinAt (J : AlmostComplexStructure V) (J' : AlmostComplexStructure W)
+    (f : V → W) (s : Set V) (x : V) : Prop :=
+  ∃ f' : V →L[ℝ] W, HasFDerivWithinAt f f' s x ∧ IsComplexLinearMap J J' f'
+
+/-- A map is `J`-holomorphic on a set if it is `J`-holomorphic within that set at every
+point of the set. -/
 def IsJHolomorphicOn (J : AlmostComplexStructure V) (J' : AlmostComplexStructure W)
     (f : V → W) (s : Set V) : Prop :=
-  ∀ x ∈ s, IsJHolomorphicAt J J' f x
+  ∀ x ∈ s, IsJHolomorphicWithinAt J J' f s x
 
 /-- A globally `J`-holomorphic map is `J`-holomorphic at every point. -/
 def IsJHolomorphic (J : AlmostComplexStructure V) (J' : AlmostComplexStructure W)
@@ -94,7 +102,8 @@ def IsJHolomorphic (J : AlmostComplexStructure V) (J' : AlmostComplexStructure W
 lemma isJHolomorphicOn_univ (J : AlmostComplexStructure V) (J' : AlmostComplexStructure W)
     (f : V → W) :
     IsJHolomorphicOn J J' f Set.univ ↔ IsJHolomorphic J J' f := by
-  simp [IsJHolomorphicOn, IsJHolomorphic]
+  simp [IsJHolomorphicOn, IsJHolomorphicWithinAt, IsJHolomorphic, IsJHolomorphicAt,
+    hasFDerivWithinAt_univ]
 
 lemma IsJHolomorphicAt.hasFDerivAt {J : AlmostComplexStructure V}
     {J' : AlmostComplexStructure W} {f : V → W} {x : V}
@@ -126,6 +135,50 @@ lemma IsJHolomorphicAt.fderiv_apply_commute {J : AlmostComplexStructure V}
     fderiv ℝ f x (J v) = J' (fderiv ℝ f x v) :=
   (isComplexLinear_iff_apply J J' (fderiv ℝ f x)).mp hf.fderiv_isComplexLinear v
 
+lemma IsJHolomorphicAt.isJHolomorphicWithinAt {J : AlmostComplexStructure V}
+    {J' : AlmostComplexStructure W} {f : V → W} {s : Set V} {x : V}
+    (hf : IsJHolomorphicAt J J' f x) :
+    IsJHolomorphicWithinAt J J' f s x :=
+  ⟨hf.choose, hf.hasFDerivAt.hasFDerivWithinAt, hf.derivative_isComplexLinear⟩
+
+lemma IsJHolomorphicWithinAt.hasFDerivWithinAt {J : AlmostComplexStructure V}
+    {J' : AlmostComplexStructure W} {f : V → W} {s : Set V} {x : V}
+    (hf : IsJHolomorphicWithinAt J J' f s x) :
+    HasFDerivWithinAt f hf.choose s x :=
+  hf.choose_spec.1
+
+lemma IsJHolomorphicWithinAt.derivative_isComplexLinear {J : AlmostComplexStructure V}
+    {J' : AlmostComplexStructure W} {f : V → W} {s : Set V} {x : V}
+    (hf : IsJHolomorphicWithinAt J J' f s x) :
+    IsComplexLinearMap J J' hf.choose :=
+  hf.choose_spec.2
+
+lemma IsJHolomorphicWithinAt.differentiableWithinAt {J : AlmostComplexStructure V}
+    {J' : AlmostComplexStructure W} {f : V → W} {s : Set V} {x : V}
+    (hf : IsJHolomorphicWithinAt J J' f s x) :
+    DifferentiableWithinAt ℝ f s x :=
+  hf.hasFDerivWithinAt.differentiableWithinAt
+
+lemma IsJHolomorphicWithinAt.fderivWithin_isComplexLinear {J : AlmostComplexStructure V}
+    {J' : AlmostComplexStructure W} {f : V → W} {s : Set V} {x : V}
+    (hf : IsJHolomorphicWithinAt J J' f s x) (hs : UniqueDiffWithinAt ℝ s x) :
+    IsComplexLinearMap J J' (fderivWithin ℝ f s x) := by
+  simpa [hf.hasFDerivWithinAt.fderivWithin hs] using hf.derivative_isComplexLinear
+
+lemma IsJHolomorphicWithinAt.fderivWithin_apply_commute {J : AlmostComplexStructure V}
+    {J' : AlmostComplexStructure W} {f : V → W} {s : Set V} {x v : V}
+    (hf : IsJHolomorphicWithinAt J J' f s x) (hs : UniqueDiffWithinAt ℝ s x) :
+    fderivWithin ℝ f s x (J v) = J' (fderivWithin ℝ f s x v) :=
+  (isComplexLinear_iff_apply J J' (fderivWithin ℝ f s x)).mp
+    (hf.fderivWithin_isComplexLinear hs) v
+
+lemma IsJHolomorphicWithinAt.isJHolomorphicAt_of_mem_nhds {J : AlmostComplexStructure V}
+    {J' : AlmostComplexStructure W} {f : V → W} {s : Set V} {x : V}
+    (hf : IsJHolomorphicWithinAt J J' f s x) (hs : s ∈ nhds x) :
+    IsJHolomorphicAt J J' f x :=
+  ⟨hf.choose, (hasFDerivWithinAt_of_mem_nhds hs).mp hf.hasFDerivWithinAt,
+    hf.derivative_isComplexLinear⟩
+
 /-- A constant map is `J`-holomorphic at every point. -/
 lemma isJHolomorphicAt_const (J : AlmostComplexStructure V) (J' : AlmostComplexStructure W)
     (c : W) (x : V) : IsJHolomorphicAt J J' (fun _ : V => c) x :=
@@ -147,13 +200,15 @@ lemma IsJHolomorphicAt.comp {J : AlmostComplexStructure V}
 lemma IsJHolomorphicOn.mono {J : AlmostComplexStructure V} {J' : AlmostComplexStructure W}
     {f : V → W} {s t : Set V} (hf : IsJHolomorphicOn J J' f t) (hst : s ⊆ t) :
     IsJHolomorphicOn J J' f s :=
-  fun x hx => hf x (hst hx)
+  fun x hx =>
+    let hfx := hf x (hst hx)
+    ⟨hfx.choose, hfx.hasFDerivWithinAt.mono hst, hfx.derivative_isComplexLinear⟩
 
 lemma IsJHolomorphic.isJHolomorphicOn {J : AlmostComplexStructure V}
     {J' : AlmostComplexStructure W} {f : V → W}
     (hf : IsJHolomorphic J J' f) (s : Set V) :
     IsJHolomorphicOn J J' f s :=
-  fun x _ => hf x
+  fun x _ => (hf x).isJHolomorphicWithinAt
 
 lemma isJHolomorphic_const (J : AlmostComplexStructure V) (J' : AlmostComplexStructure W)
     (c : W) : IsJHolomorphic J J' (fun _ : V => c) :=

--- a/TauCeti/Geometry/Symplectic/JHolomorphic.lean
+++ b/TauCeti/Geometry/Symplectic/JHolomorphic.lean
@@ -61,6 +61,40 @@ def IsJHolomorphic (J : AlmostComplexStructure V) (J' : AlmostComplexStructure W
     (f : V → W) : Prop :=
   ∀ x, IsJHolomorphicAt J J' f x
 
+/-- Restate pointwise `J`-holomorphicity as existence of a complex-linear Frechet
+derivative. -/
+lemma isJHolomorphicAt_iff (J : AlmostComplexStructure V) (J' : AlmostComplexStructure W)
+    (f : V → W) (x : V) :
+    IsJHolomorphicAt J J' f x ↔
+      ∃ f' : V →L[ℝ] W, HasFDerivAt f f' x ∧ IsComplexLinearMap J J' f'.toLinearMap :=
+  Iff.rfl
+
+/-- Restate within-set `J`-holomorphicity as existence of a complex-linear Frechet
+derivative within the set. -/
+lemma isJHolomorphicWithinAt_iff (J : AlmostComplexStructure V)
+    (J' : AlmostComplexStructure W) (f : V → W) (s : Set V) (x : V) :
+    IsJHolomorphicWithinAt J J' f s x ↔
+      ∃ f' : V →L[ℝ] W,
+        HasFDerivWithinAt f f' s x ∧ IsComplexLinearMap J J' f'.toLinearMap :=
+  Iff.rfl
+
+/-- Restate setwise `J`-holomorphicity as the within-set derivative condition at each
+point of the set. -/
+lemma isJHolomorphicOn_iff (J : AlmostComplexStructure V) (J' : AlmostComplexStructure W)
+    (f : V → W) (s : Set V) :
+    IsJHolomorphicOn J J' f s ↔
+      ∀ x ∈ s, ∃ f' : V →L[ℝ] W,
+        HasFDerivWithinAt f f' s x ∧ IsComplexLinearMap J J' f'.toLinearMap :=
+  Iff.rfl
+
+/-- Restate global `J`-holomorphicity as the pointwise derivative condition at every point. -/
+lemma isJHolomorphic_iff (J : AlmostComplexStructure V) (J' : AlmostComplexStructure W)
+    (f : V → W) :
+    IsJHolomorphic J J' f ↔
+      ∀ x, ∃ f' : V →L[ℝ] W, HasFDerivAt f f' x ∧
+        IsComplexLinearMap J J' f'.toLinearMap :=
+  Iff.rfl
+
 /-- On the whole space, setwise `J`-holomorphicity is the same as global
 `J`-holomorphicity. -/
 @[simp]

--- a/TauCeti/Geometry/Symplectic/JHolomorphic.lean
+++ b/TauCeti/Geometry/Symplectic/JHolomorphic.lean
@@ -20,7 +20,6 @@ different Cauchy--Riemann convention.
 
 ## Main declarations
 
-* `IsComplexLinearMap`: a real-linear map intertwines two almost complex structures.
 * `IsJHolomorphicAt`: a map has a complex-linear Frechet derivative at a point.
 * `IsJHolomorphicWithinAt`: a map has a complex-linear Frechet derivative within a set.
 * `IsJHolomorphicOn` and `IsJHolomorphic`: setwise and global versions.
@@ -36,42 +35,6 @@ variable {V W X : Type*}
 variable [NormedAddCommGroup V] [NormedSpace ℝ V]
 variable [NormedAddCommGroup W] [NormedSpace ℝ W]
 variable [NormedAddCommGroup X] [NormedSpace ℝ X]
-
-/-- A real-linear map is complex-linear with respect to two fixed pointwise
-almost complex structures if it intertwines them. -/
-def IsComplexLinearMap (J : AlmostComplexStructure V) (J' : AlmostComplexStructure W)
-    (F : V →ₗ[ℝ] W) : Prop :=
-  F.comp J.toLinearMap = J'.toLinearMap.comp F
-
-lemma isComplexLinearMap_iff_apply (J : AlmostComplexStructure V)
-    (J' : AlmostComplexStructure W) (F : V →ₗ[ℝ] W) :
-    IsComplexLinearMap J J' F ↔ ∀ v, F (J v) = J' (F v) :=
-  LinearMap.ext_iff
-
-/-- The zero map is complex-linear for any source and target almost complex structures. -/
-lemma isComplexLinearMap_zero (J : AlmostComplexStructure V) (J' : AlmostComplexStructure W) :
-    IsComplexLinearMap J J' (0 : V →ₗ[ℝ] W) := by
-  rw [isComplexLinearMap_iff_apply]
-  intro v
-  simp
-
-/-- The identity map is complex-linear with respect to the same almost complex structure. -/
-lemma isComplexLinearMap_id (J : AlmostComplexStructure V) :
-    IsComplexLinearMap J J (LinearMap.id : V →ₗ[ℝ] V) := by
-  rw [isComplexLinearMap_iff_apply]
-  intro v
-  simp [LinearMap.id_apply]
-
-/-- Complex-linear maps are closed under composition. -/
-lemma IsComplexLinearMap.comp {J : AlmostComplexStructure V} {J' : AlmostComplexStructure W}
-    {J'' : AlmostComplexStructure X} {F : V →ₗ[ℝ] W} {G : W →ₗ[ℝ] X}
-    (hG : IsComplexLinearMap J' J'' G) (hF : IsComplexLinearMap J J' F) :
-    IsComplexLinearMap J J'' (G.comp F) := by
-  rw [isComplexLinearMap_iff_apply] at hF hG ⊢
-  intro v
-  calc
-    G (F (J v)) = G (J' (F v)) := by rw [hF v]
-    _ = J'' (G (F v)) := hG (F v)
 
 section JHolomorphic
 
@@ -98,6 +61,8 @@ def IsJHolomorphic (J : AlmostComplexStructure V) (J' : AlmostComplexStructure W
     (f : V → W) : Prop :=
   ∀ x, IsJHolomorphicAt J J' f x
 
+/-- On the whole space, setwise `J`-holomorphicity is the same as global
+`J`-holomorphicity. -/
 @[simp]
 lemma isJHolomorphicOn_univ (J : AlmostComplexStructure V) (J' : AlmostComplexStructure W)
     (f : V → W) :
@@ -105,30 +70,36 @@ lemma isJHolomorphicOn_univ (J : AlmostComplexStructure V) (J' : AlmostComplexSt
   simp [IsJHolomorphicOn, IsJHolomorphicWithinAt, IsJHolomorphic, IsJHolomorphicAt,
     hasFDerivWithinAt_univ]
 
+/-- The continuous-linear derivative witnessing `J`-holomorphicity at a point. -/
 lemma IsJHolomorphicAt.hasFDerivAt {J : AlmostComplexStructure V}
     {J' : AlmostComplexStructure W} {f : V → W} {x : V}
     (hf : IsJHolomorphicAt J J' f x) :
     HasFDerivAt f hf.choose x :=
   hf.choose_spec.1
 
+/-- The chosen derivative at a `J`-holomorphic point is complex-linear. -/
 lemma IsJHolomorphicAt.derivative_isComplexLinear {J : AlmostComplexStructure V}
     {J' : AlmostComplexStructure W} {f : V → W} {x : V}
     (hf : IsJHolomorphicAt J J' f x) :
     IsComplexLinearMap J J' hf.choose.toLinearMap :=
   hf.choose_spec.2
 
+/-- A `J`-holomorphic map is differentiable at the point. -/
 lemma IsJHolomorphicAt.differentiableAt {J : AlmostComplexStructure V}
     {J' : AlmostComplexStructure W} {f : V → W} {x : V}
     (hf : IsJHolomorphicAt J J' f x) :
     DifferentiableAt ℝ f x :=
   hf.hasFDerivAt.differentiableAt
 
+/-- The Frechet derivative of a `J`-holomorphic map is complex-linear. -/
 lemma IsJHolomorphicAt.fderiv_isComplexLinear {J : AlmostComplexStructure V}
     {J' : AlmostComplexStructure W} {f : V → W} {x : V}
     (hf : IsJHolomorphicAt J J' f x) :
     IsComplexLinearMap J J' (fderiv ℝ f x).toLinearMap := by
   simpa [hf.hasFDerivAt.fderiv] using hf.derivative_isComplexLinear
 
+/-- The Frechet derivative of a `J`-holomorphic map commutes with the almost complex
+structures pointwise. -/
 lemma IsJHolomorphicAt.fderiv_apply_commute {J : AlmostComplexStructure V}
     {J' : AlmostComplexStructure W} {f : V → W} {x v : V}
     (hf : IsJHolomorphicAt J J' f x) :
@@ -136,36 +107,42 @@ lemma IsJHolomorphicAt.fderiv_apply_commute {J : AlmostComplexStructure V}
   (isComplexLinearMap_iff_apply J J' (fderiv ℝ f x).toLinearMap).mp
     hf.fderiv_isComplexLinear v
 
+/-- A pointwise `J`-holomorphic map is `J`-holomorphic within any set. -/
 lemma IsJHolomorphicAt.isJHolomorphicWithinAt {J : AlmostComplexStructure V}
     {J' : AlmostComplexStructure W} {f : V → W} {s : Set V} {x : V}
     (hf : IsJHolomorphicAt J J' f x) :
     IsJHolomorphicWithinAt J J' f s x :=
   ⟨hf.choose, hf.hasFDerivAt.hasFDerivWithinAt, hf.derivative_isComplexLinear⟩
 
+/-- The continuous-linear derivative witnessing `J`-holomorphicity within a set. -/
 lemma IsJHolomorphicWithinAt.hasFDerivWithinAt {J : AlmostComplexStructure V}
     {J' : AlmostComplexStructure W} {f : V → W} {s : Set V} {x : V}
     (hf : IsJHolomorphicWithinAt J J' f s x) :
     HasFDerivWithinAt f hf.choose s x :=
   hf.choose_spec.1
 
+/-- The chosen within-set derivative is complex-linear. -/
 lemma IsJHolomorphicWithinAt.derivative_isComplexLinear {J : AlmostComplexStructure V}
     {J' : AlmostComplexStructure W} {f : V → W} {s : Set V} {x : V}
     (hf : IsJHolomorphicWithinAt J J' f s x) :
     IsComplexLinearMap J J' hf.choose.toLinearMap :=
   hf.choose_spec.2
 
+/-- A map that is `J`-holomorphic within a set is differentiable within that set. -/
 lemma IsJHolomorphicWithinAt.differentiableWithinAt {J : AlmostComplexStructure V}
     {J' : AlmostComplexStructure W} {f : V → W} {s : Set V} {x : V}
     (hf : IsJHolomorphicWithinAt J J' f s x) :
     DifferentiableWithinAt ℝ f s x :=
   hf.hasFDerivWithinAt.differentiableWithinAt
 
+/-- The within-set Frechet derivative is complex-linear when the set has unique derivatives. -/
 lemma IsJHolomorphicWithinAt.fderivWithin_isComplexLinear {J : AlmostComplexStructure V}
     {J' : AlmostComplexStructure W} {f : V → W} {s : Set V} {x : V}
     (hf : IsJHolomorphicWithinAt J J' f s x) (hs : UniqueDiffWithinAt ℝ s x) :
     IsComplexLinearMap J J' (fderivWithin ℝ f s x).toLinearMap := by
   simpa [hf.hasFDerivWithinAt.fderivWithin hs] using hf.derivative_isComplexLinear
 
+/-- The within-set Frechet derivative commutes with the almost complex structures pointwise. -/
 lemma IsJHolomorphicWithinAt.fderivWithin_apply_commute {J : AlmostComplexStructure V}
     {J' : AlmostComplexStructure W} {f : V → W} {s : Set V} {x v : V}
     (hf : IsJHolomorphicWithinAt J J' f s x) (hs : UniqueDiffWithinAt ℝ s x) :
@@ -173,6 +150,8 @@ lemma IsJHolomorphicWithinAt.fderivWithin_apply_commute {J : AlmostComplexStruct
   (isComplexLinearMap_iff_apply J J' (fderivWithin ℝ f s x).toLinearMap).mp
     (hf.fderivWithin_isComplexLinear hs) v
 
+/-- A within-set `J`-holomorphic map is pointwise `J`-holomorphic when the set is a
+neighborhood of the point. -/
 lemma IsJHolomorphicWithinAt.isJHolomorphicAt_of_mem_nhds {J : AlmostComplexStructure V}
     {J' : AlmostComplexStructure W} {f : V → W} {s : Set V} {x : V}
     (hf : IsJHolomorphicWithinAt J J' f s x) (hs : s ∈ nhds x) :
@@ -181,15 +160,18 @@ lemma IsJHolomorphicWithinAt.isJHolomorphicAt_of_mem_nhds {J : AlmostComplexStru
     hf.derivative_isComplexLinear⟩
 
 /-- A constant map is `J`-holomorphic at every point. -/
+@[simp]
 lemma isJHolomorphicAt_const (J : AlmostComplexStructure V) (J' : AlmostComplexStructure W)
     (c : W) (x : V) : IsJHolomorphicAt J J' (fun _ : V => c) x :=
-  ⟨0, hasFDerivAt_const c x, by simpa using isComplexLinearMap_zero J J'⟩
+  ⟨0, hasFDerivAt_const c x, by simp⟩
 
 /-- The identity map is `J`-holomorphic for any fixed almost complex structure `J`. -/
+@[simp]
 lemma isJHolomorphicAt_id (J : AlmostComplexStructure V) (x : V) :
     IsJHolomorphicAt J J id x :=
-  ⟨ContinuousLinearMap.id ℝ V, hasFDerivAt_id x, by simpa using isComplexLinearMap_id J⟩
+  ⟨ContinuousLinearMap.id ℝ V, hasFDerivAt_id x, by simp⟩
 
+/-- Chain rule for pointwise `J`-holomorphic maps. -/
 lemma IsJHolomorphicAt.comp {J : AlmostComplexStructure V}
     {J' : AlmostComplexStructure W} {J'' : AlmostComplexStructure X}
     {f : V → W} {g : W → X} {x : V}
@@ -198,6 +180,39 @@ lemma IsJHolomorphicAt.comp {J : AlmostComplexStructure V}
   refine ⟨hg.choose.comp hf.choose, hg.hasFDerivAt.comp x hf.hasFDerivAt, ?_⟩
   exact IsComplexLinearMap.comp hg.derivative_isComplexLinear hf.derivative_isComplexLinear
 
+/-- A constant map is `J`-holomorphic within every set at every point. -/
+@[simp]
+lemma isJHolomorphicWithinAt_const (J : AlmostComplexStructure V)
+    (J' : AlmostComplexStructure W) (c : W) (s : Set V) (x : V) :
+    IsJHolomorphicWithinAt J J' (fun _ : V => c) s x :=
+  (isJHolomorphicAt_const J J' c x).isJHolomorphicWithinAt
+
+/-- The identity map is `J`-holomorphic within every set at every point. -/
+@[simp]
+lemma isJHolomorphicWithinAt_id (J : AlmostComplexStructure V) (s : Set V) (x : V) :
+    IsJHolomorphicWithinAt J J id s x :=
+  (isJHolomorphicAt_id J x).isJHolomorphicWithinAt
+
+/-- Chain rule for within-set `J`-holomorphic maps. -/
+lemma IsJHolomorphicWithinAt.comp {J : AlmostComplexStructure V}
+    {J' : AlmostComplexStructure W} {J'' : AlmostComplexStructure X}
+    {f : V → W} {g : W → X} {s : Set V} {t : Set W} {x : V}
+    (hg : IsJHolomorphicWithinAt J' J'' g t (f x))
+    (hf : IsJHolomorphicWithinAt J J' f s x) (hst : Set.MapsTo f s t) :
+    IsJHolomorphicWithinAt J J'' (g ∘ f) s x := by
+  refine ⟨hg.choose.comp hf.choose, hg.hasFDerivWithinAt.comp x hf.hasFDerivWithinAt hst, ?_⟩
+  exact IsComplexLinearMap.comp hg.derivative_isComplexLinear hf.derivative_isComplexLinear
+
+/-- Chain rule for setwise `J`-holomorphic maps. -/
+lemma IsJHolomorphicOn.comp {J : AlmostComplexStructure V}
+    {J' : AlmostComplexStructure W} {J'' : AlmostComplexStructure X}
+    {f : V → W} {g : W → X} {s : Set V} {t : Set W}
+    (hg : IsJHolomorphicOn J' J'' g t) (hf : IsJHolomorphicOn J J' f s)
+    (hst : Set.MapsTo f s t) :
+    IsJHolomorphicOn J J'' (g ∘ f) s :=
+  fun x hx => (hg (f x) (hst hx)).comp (hf x hx) hst
+
+/-- Restrict the domain set of a setwise `J`-holomorphic map. -/
 lemma IsJHolomorphicOn.mono {J : AlmostComplexStructure V} {J' : AlmostComplexStructure W}
     {f : V → W} {s t : Set V} (hf : IsJHolomorphicOn J J' f t) (hst : s ⊆ t) :
     IsJHolomorphicOn J J' f s :=
@@ -205,19 +220,25 @@ lemma IsJHolomorphicOn.mono {J : AlmostComplexStructure V} {J' : AlmostComplexSt
     let hfx := hf x (hst hx)
     ⟨hfx.choose, hfx.hasFDerivWithinAt.mono hst, hfx.derivative_isComplexLinear⟩
 
+/-- A globally `J`-holomorphic map is `J`-holomorphic on every set. -/
 lemma IsJHolomorphic.isJHolomorphicOn {J : AlmostComplexStructure V}
     {J' : AlmostComplexStructure W} {f : V → W}
     (hf : IsJHolomorphic J J' f) (s : Set V) :
     IsJHolomorphicOn J J' f s :=
   fun x _ => (hf x).isJHolomorphicWithinAt
 
+/-- A constant map is globally `J`-holomorphic. -/
+@[simp]
 lemma isJHolomorphic_const (J : AlmostComplexStructure V) (J' : AlmostComplexStructure W)
     (c : W) : IsJHolomorphic J J' (fun _ : V => c) :=
   fun x => isJHolomorphicAt_const J J' c x
 
+/-- The identity map is globally `J`-holomorphic. -/
+@[simp]
 lemma isJHolomorphic_id (J : AlmostComplexStructure V) : IsJHolomorphic J J id :=
   fun x => isJHolomorphicAt_id J x
 
+/-- Chain rule for global `J`-holomorphic maps. -/
 lemma IsJHolomorphic.comp {J : AlmostComplexStructure V}
     {J' : AlmostComplexStructure W} {J'' : AlmostComplexStructure X}
     {f : V → W} {g : W → X}

--- a/TauCeti/Geometry/Symplectic/JHolomorphic.lean
+++ b/TauCeti/Geometry/Symplectic/JHolomorphic.lean
@@ -1,0 +1,174 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+import Mathlib.Analysis.Calculus.FDeriv.Comp
+import Mathlib.Analysis.Calculus.FDeriv.Const
+import TauCeti.Geometry.Symplectic.AlmostComplex
+
+/-!
+# `J`-holomorphic maps between real normed spaces
+
+This file adds the first map-level definition for the analytic Heegaard Floer roadmap:
+a map between real normed spaces with fixed pointwise almost complex structures is
+`J`-holomorphic at a point when it has a Frechet derivative there and that derivative
+commutes with the two almost complex structures.
+
+The definitions are deliberately linear and local. Later manifold and bundle versions should
+use this as the model on coordinate charts and tangent fibers, rather than introducing a
+different Cauchy--Riemann convention.
+
+## Main declarations
+
+* `IsComplexLinearMap`: a continuous real-linear map intertwines two almost complex
+  structures.
+* `IsJHolomorphicAt`: a map has a complex-linear Frechet derivative at a point.
+* `IsJHolomorphicOn` and `IsJHolomorphic`: setwise and global versions.
+
+The convention follows McDuff--Salamon, *J-holomorphic Curves and Symplectic Topology*,
+Section 2.1: the Cauchy--Riemann equation is `df ∘ J = J' ∘ df`.
+-/
+
+namespace TauCeti
+
+variable {V W X : Type*}
+
+variable [NormedAddCommGroup V] [NormedSpace ℝ V]
+variable [NormedAddCommGroup W] [NormedSpace ℝ W]
+variable [NormedAddCommGroup X] [NormedSpace ℝ X]
+
+/-- A continuous real-linear map is complex-linear with respect to two fixed pointwise
+almost complex structures if it intertwines them. -/
+def IsComplexLinearMap (J : AlmostComplexStructure V) (J' : AlmostComplexStructure W)
+    (F : V →L[ℝ] W) : Prop :=
+  F.toLinearMap.comp J.toLinearMap = J'.toLinearMap.comp F.toLinearMap
+
+lemma isComplexLinear_iff_apply (J : AlmostComplexStructure V)
+    (J' : AlmostComplexStructure W) (F : V →L[ℝ] W) :
+    IsComplexLinearMap J J' F ↔ ∀ v, F (J v) = J' (F v) :=
+  LinearMap.ext_iff
+
+/-- The zero map is complex-linear for any source and target almost complex structures. -/
+lemma isComplexLinear_zero (J : AlmostComplexStructure V) (J' : AlmostComplexStructure W) :
+    IsComplexLinearMap J J' (0 : V →L[ℝ] W) := by
+  rw [isComplexLinear_iff_apply]
+  intro v
+  simp
+
+/-- The identity map is complex-linear with respect to the same almost complex structure. -/
+lemma isComplexLinear_id (J : AlmostComplexStructure V) :
+    IsComplexLinearMap J J (ContinuousLinearMap.id ℝ V) := by
+  rw [isComplexLinear_iff_apply]
+  intro v
+  rfl
+
+/-- Complex-linear continuous maps are closed under composition. -/
+lemma IsComplexLinearMap.comp {J : AlmostComplexStructure V} {J' : AlmostComplexStructure W}
+    {J'' : AlmostComplexStructure X} {F : V →L[ℝ] W} {G : W →L[ℝ] X}
+    (hG : IsComplexLinearMap J' J'' G) (hF : IsComplexLinearMap J J' F) :
+    IsComplexLinearMap J J'' (G.comp F) := by
+  rw [isComplexLinear_iff_apply] at hF hG ⊢
+  intro v
+  calc
+    G (F (J v)) = G (J' (F v)) := by rw [hF v]
+    _ = J'' (G (F v)) := hG (F v)
+
+section JHolomorphic
+
+/-- A map is `J`-holomorphic at a point if its Frechet derivative exists there and
+intertwines the source and target almost complex structures. -/
+def IsJHolomorphicAt (J : AlmostComplexStructure V) (J' : AlmostComplexStructure W)
+    (f : V → W) (x : V) : Prop :=
+  ∃ f' : V →L[ℝ] W, HasFDerivAt f f' x ∧ IsComplexLinearMap J J' f'
+
+/-- A map is `J`-holomorphic on a set if it is `J`-holomorphic at every point of the set. -/
+def IsJHolomorphicOn (J : AlmostComplexStructure V) (J' : AlmostComplexStructure W)
+    (f : V → W) (s : Set V) : Prop :=
+  ∀ x ∈ s, IsJHolomorphicAt J J' f x
+
+/-- A globally `J`-holomorphic map is `J`-holomorphic at every point. -/
+def IsJHolomorphic (J : AlmostComplexStructure V) (J' : AlmostComplexStructure W)
+    (f : V → W) : Prop :=
+  ∀ x, IsJHolomorphicAt J J' f x
+
+lemma isJHolomorphicOn_univ (J : AlmostComplexStructure V) (J' : AlmostComplexStructure W)
+    (f : V → W) :
+    IsJHolomorphicOn J J' f Set.univ ↔ IsJHolomorphic J J' f := by
+  simp [IsJHolomorphicOn, IsJHolomorphic]
+
+lemma IsJHolomorphicAt.hasFDerivAt {J : AlmostComplexStructure V}
+    {J' : AlmostComplexStructure W} {f : V → W} {x : V}
+    (hf : IsJHolomorphicAt J J' f x) :
+    HasFDerivAt f hf.choose x :=
+  hf.choose_spec.1
+
+lemma IsJHolomorphicAt.derivative_isComplexLinear {J : AlmostComplexStructure V}
+    {J' : AlmostComplexStructure W} {f : V → W} {x : V}
+    (hf : IsJHolomorphicAt J J' f x) :
+    IsComplexLinearMap J J' hf.choose :=
+  hf.choose_spec.2
+
+lemma IsJHolomorphicAt.differentiableAt {J : AlmostComplexStructure V}
+    {J' : AlmostComplexStructure W} {f : V → W} {x : V}
+    (hf : IsJHolomorphicAt J J' f x) :
+    DifferentiableAt ℝ f x :=
+  hf.hasFDerivAt.differentiableAt
+
+lemma IsJHolomorphicAt.fderiv_isComplexLinear {J : AlmostComplexStructure V}
+    {J' : AlmostComplexStructure W} {f : V → W} {x : V}
+    (hf : IsJHolomorphicAt J J' f x) :
+    IsComplexLinearMap J J' (fderiv ℝ f x) := by
+  simpa [hf.hasFDerivAt.fderiv] using hf.derivative_isComplexLinear
+
+lemma IsJHolomorphicAt.fderiv_apply_commute {J : AlmostComplexStructure V}
+    {J' : AlmostComplexStructure W} {f : V → W} {x v : V}
+    (hf : IsJHolomorphicAt J J' f x) :
+    fderiv ℝ f x (J v) = J' (fderiv ℝ f x v) :=
+  (isComplexLinear_iff_apply J J' (fderiv ℝ f x)).mp hf.fderiv_isComplexLinear v
+
+/-- A constant map is `J`-holomorphic at every point. -/
+lemma isJHolomorphicAt_const (J : AlmostComplexStructure V) (J' : AlmostComplexStructure W)
+    (c : W) (x : V) : IsJHolomorphicAt J J' (fun _ : V => c) x :=
+  ⟨0, hasFDerivAt_const c x, isComplexLinear_zero J J'⟩
+
+/-- The identity map is `J`-holomorphic for any fixed almost complex structure `J`. -/
+lemma isJHolomorphicAt_id (J : AlmostComplexStructure V) (x : V) :
+    IsJHolomorphicAt J J id x :=
+  ⟨ContinuousLinearMap.id ℝ V, hasFDerivAt_id x, isComplexLinear_id J⟩
+
+lemma IsJHolomorphicAt.comp {J : AlmostComplexStructure V}
+    {J' : AlmostComplexStructure W} {J'' : AlmostComplexStructure X}
+    {f : V → W} {g : W → X} {x : V}
+    (hg : IsJHolomorphicAt J' J'' g (f x)) (hf : IsJHolomorphicAt J J' f x) :
+    IsJHolomorphicAt J J'' (g ∘ f) x := by
+  refine ⟨hg.choose.comp hf.choose, hg.hasFDerivAt.comp x hf.hasFDerivAt, ?_⟩
+  exact IsComplexLinearMap.comp hg.derivative_isComplexLinear hf.derivative_isComplexLinear
+
+lemma IsJHolomorphicOn.mono {J : AlmostComplexStructure V} {J' : AlmostComplexStructure W}
+    {f : V → W} {s t : Set V} (hf : IsJHolomorphicOn J J' f t) (hst : s ⊆ t) :
+    IsJHolomorphicOn J J' f s :=
+  fun x hx => hf x (hst hx)
+
+lemma IsJHolomorphic.isJHolomorphicOn {J : AlmostComplexStructure V}
+    {J' : AlmostComplexStructure W} {f : V → W}
+    (hf : IsJHolomorphic J J' f) (s : Set V) :
+    IsJHolomorphicOn J J' f s :=
+  fun x _ => hf x
+
+lemma isJHolomorphic_const (J : AlmostComplexStructure V) (J' : AlmostComplexStructure W)
+    (c : W) : IsJHolomorphic J J' (fun _ : V => c) :=
+  fun x => isJHolomorphicAt_const J J' c x
+
+lemma isJHolomorphic_id (J : AlmostComplexStructure V) : IsJHolomorphic J J id :=
+  fun x => isJHolomorphicAt_id J x
+
+lemma IsJHolomorphic.comp {J : AlmostComplexStructure V}
+    {J' : AlmostComplexStructure W} {J'' : AlmostComplexStructure X}
+    {f : V → W} {g : W → X}
+    (hg : IsJHolomorphic J' J'' g) (hf : IsJHolomorphic J J' f) :
+    IsJHolomorphic J J'' (g ∘ f) :=
+  fun x => (hg (f x)).comp (hf x)
+
+end JHolomorphic
+
+end TauCeti

--- a/TauCeti/Geometry/Symplectic/JHolomorphic.lean
+++ b/TauCeti/Geometry/Symplectic/JHolomorphic.lean
@@ -20,8 +20,7 @@ different Cauchy--Riemann convention.
 
 ## Main declarations
 
-* `IsComplexLinearMap`: a continuous real-linear map intertwines two almost complex
-  structures.
+* `IsComplexLinearMap`: a real-linear map intertwines two almost complex structures.
 * `IsJHolomorphicAt`: a map has a complex-linear Frechet derivative at a point.
 * `IsJHolomorphicWithinAt`: a map has a complex-linear Frechet derivative within a set.
 * `IsJHolomorphicOn` and `IsJHolomorphic`: setwise and global versions.
@@ -38,37 +37,37 @@ variable [NormedAddCommGroup V] [NormedSpace ℝ V]
 variable [NormedAddCommGroup W] [NormedSpace ℝ W]
 variable [NormedAddCommGroup X] [NormedSpace ℝ X]
 
-/-- A continuous real-linear map is complex-linear with respect to two fixed pointwise
+/-- A real-linear map is complex-linear with respect to two fixed pointwise
 almost complex structures if it intertwines them. -/
 def IsComplexLinearMap (J : AlmostComplexStructure V) (J' : AlmostComplexStructure W)
-    (F : V →L[ℝ] W) : Prop :=
-  F.toLinearMap.comp J.toLinearMap = J'.toLinearMap.comp F.toLinearMap
+    (F : V →ₗ[ℝ] W) : Prop :=
+  F.comp J.toLinearMap = J'.toLinearMap.comp F
 
-lemma isComplexLinear_iff_apply (J : AlmostComplexStructure V)
-    (J' : AlmostComplexStructure W) (F : V →L[ℝ] W) :
+lemma isComplexLinearMap_iff_apply (J : AlmostComplexStructure V)
+    (J' : AlmostComplexStructure W) (F : V →ₗ[ℝ] W) :
     IsComplexLinearMap J J' F ↔ ∀ v, F (J v) = J' (F v) :=
   LinearMap.ext_iff
 
 /-- The zero map is complex-linear for any source and target almost complex structures. -/
-lemma isComplexLinear_zero (J : AlmostComplexStructure V) (J' : AlmostComplexStructure W) :
-    IsComplexLinearMap J J' (0 : V →L[ℝ] W) := by
-  rw [isComplexLinear_iff_apply]
+lemma isComplexLinearMap_zero (J : AlmostComplexStructure V) (J' : AlmostComplexStructure W) :
+    IsComplexLinearMap J J' (0 : V →ₗ[ℝ] W) := by
+  rw [isComplexLinearMap_iff_apply]
   intro v
   simp
 
 /-- The identity map is complex-linear with respect to the same almost complex structure. -/
-lemma isComplexLinear_id (J : AlmostComplexStructure V) :
-    IsComplexLinearMap J J (ContinuousLinearMap.id ℝ V) := by
-  rw [isComplexLinear_iff_apply]
+lemma isComplexLinearMap_id (J : AlmostComplexStructure V) :
+    IsComplexLinearMap J J (LinearMap.id : V →ₗ[ℝ] V) := by
+  rw [isComplexLinearMap_iff_apply]
   intro v
-  rfl
+  simp [LinearMap.id_apply]
 
-/-- Complex-linear continuous maps are closed under composition. -/
+/-- Complex-linear maps are closed under composition. -/
 lemma IsComplexLinearMap.comp {J : AlmostComplexStructure V} {J' : AlmostComplexStructure W}
-    {J'' : AlmostComplexStructure X} {F : V →L[ℝ] W} {G : W →L[ℝ] X}
+    {J'' : AlmostComplexStructure X} {F : V →ₗ[ℝ] W} {G : W →ₗ[ℝ] X}
     (hG : IsComplexLinearMap J' J'' G) (hF : IsComplexLinearMap J J' F) :
     IsComplexLinearMap J J'' (G.comp F) := by
-  rw [isComplexLinear_iff_apply] at hF hG ⊢
+  rw [isComplexLinearMap_iff_apply] at hF hG ⊢
   intro v
   calc
     G (F (J v)) = G (J' (F v)) := by rw [hF v]
@@ -80,13 +79,13 @@ section JHolomorphic
 intertwines the source and target almost complex structures. -/
 def IsJHolomorphicAt (J : AlmostComplexStructure V) (J' : AlmostComplexStructure W)
     (f : V → W) (x : V) : Prop :=
-  ∃ f' : V →L[ℝ] W, HasFDerivAt f f' x ∧ IsComplexLinearMap J J' f'
+  ∃ f' : V →L[ℝ] W, HasFDerivAt f f' x ∧ IsComplexLinearMap J J' f'.toLinearMap
 
 /-- A map is `J`-holomorphic within a set at a point if its Frechet derivative within the
 set exists there and intertwines the source and target almost complex structures. -/
 def IsJHolomorphicWithinAt (J : AlmostComplexStructure V) (J' : AlmostComplexStructure W)
     (f : V → W) (s : Set V) (x : V) : Prop :=
-  ∃ f' : V →L[ℝ] W, HasFDerivWithinAt f f' s x ∧ IsComplexLinearMap J J' f'
+  ∃ f' : V →L[ℝ] W, HasFDerivWithinAt f f' s x ∧ IsComplexLinearMap J J' f'.toLinearMap
 
 /-- A map is `J`-holomorphic on a set if it is `J`-holomorphic within that set at every
 point of the set. -/
@@ -99,6 +98,7 @@ def IsJHolomorphic (J : AlmostComplexStructure V) (J' : AlmostComplexStructure W
     (f : V → W) : Prop :=
   ∀ x, IsJHolomorphicAt J J' f x
 
+@[simp]
 lemma isJHolomorphicOn_univ (J : AlmostComplexStructure V) (J' : AlmostComplexStructure W)
     (f : V → W) :
     IsJHolomorphicOn J J' f Set.univ ↔ IsJHolomorphic J J' f := by
@@ -114,7 +114,7 @@ lemma IsJHolomorphicAt.hasFDerivAt {J : AlmostComplexStructure V}
 lemma IsJHolomorphicAt.derivative_isComplexLinear {J : AlmostComplexStructure V}
     {J' : AlmostComplexStructure W} {f : V → W} {x : V}
     (hf : IsJHolomorphicAt J J' f x) :
-    IsComplexLinearMap J J' hf.choose :=
+    IsComplexLinearMap J J' hf.choose.toLinearMap :=
   hf.choose_spec.2
 
 lemma IsJHolomorphicAt.differentiableAt {J : AlmostComplexStructure V}
@@ -126,14 +126,15 @@ lemma IsJHolomorphicAt.differentiableAt {J : AlmostComplexStructure V}
 lemma IsJHolomorphicAt.fderiv_isComplexLinear {J : AlmostComplexStructure V}
     {J' : AlmostComplexStructure W} {f : V → W} {x : V}
     (hf : IsJHolomorphicAt J J' f x) :
-    IsComplexLinearMap J J' (fderiv ℝ f x) := by
+    IsComplexLinearMap J J' (fderiv ℝ f x).toLinearMap := by
   simpa [hf.hasFDerivAt.fderiv] using hf.derivative_isComplexLinear
 
 lemma IsJHolomorphicAt.fderiv_apply_commute {J : AlmostComplexStructure V}
     {J' : AlmostComplexStructure W} {f : V → W} {x v : V}
     (hf : IsJHolomorphicAt J J' f x) :
     fderiv ℝ f x (J v) = J' (fderiv ℝ f x v) :=
-  (isComplexLinear_iff_apply J J' (fderiv ℝ f x)).mp hf.fderiv_isComplexLinear v
+  (isComplexLinearMap_iff_apply J J' (fderiv ℝ f x).toLinearMap).mp
+    hf.fderiv_isComplexLinear v
 
 lemma IsJHolomorphicAt.isJHolomorphicWithinAt {J : AlmostComplexStructure V}
     {J' : AlmostComplexStructure W} {f : V → W} {s : Set V} {x : V}
@@ -150,7 +151,7 @@ lemma IsJHolomorphicWithinAt.hasFDerivWithinAt {J : AlmostComplexStructure V}
 lemma IsJHolomorphicWithinAt.derivative_isComplexLinear {J : AlmostComplexStructure V}
     {J' : AlmostComplexStructure W} {f : V → W} {s : Set V} {x : V}
     (hf : IsJHolomorphicWithinAt J J' f s x) :
-    IsComplexLinearMap J J' hf.choose :=
+    IsComplexLinearMap J J' hf.choose.toLinearMap :=
   hf.choose_spec.2
 
 lemma IsJHolomorphicWithinAt.differentiableWithinAt {J : AlmostComplexStructure V}
@@ -162,14 +163,14 @@ lemma IsJHolomorphicWithinAt.differentiableWithinAt {J : AlmostComplexStructure 
 lemma IsJHolomorphicWithinAt.fderivWithin_isComplexLinear {J : AlmostComplexStructure V}
     {J' : AlmostComplexStructure W} {f : V → W} {s : Set V} {x : V}
     (hf : IsJHolomorphicWithinAt J J' f s x) (hs : UniqueDiffWithinAt ℝ s x) :
-    IsComplexLinearMap J J' (fderivWithin ℝ f s x) := by
+    IsComplexLinearMap J J' (fderivWithin ℝ f s x).toLinearMap := by
   simpa [hf.hasFDerivWithinAt.fderivWithin hs] using hf.derivative_isComplexLinear
 
 lemma IsJHolomorphicWithinAt.fderivWithin_apply_commute {J : AlmostComplexStructure V}
     {J' : AlmostComplexStructure W} {f : V → W} {s : Set V} {x v : V}
     (hf : IsJHolomorphicWithinAt J J' f s x) (hs : UniqueDiffWithinAt ℝ s x) :
     fderivWithin ℝ f s x (J v) = J' (fderivWithin ℝ f s x v) :=
-  (isComplexLinear_iff_apply J J' (fderivWithin ℝ f s x)).mp
+  (isComplexLinearMap_iff_apply J J' (fderivWithin ℝ f s x).toLinearMap).mp
     (hf.fderivWithin_isComplexLinear hs) v
 
 lemma IsJHolomorphicWithinAt.isJHolomorphicAt_of_mem_nhds {J : AlmostComplexStructure V}
@@ -182,12 +183,12 @@ lemma IsJHolomorphicWithinAt.isJHolomorphicAt_of_mem_nhds {J : AlmostComplexStru
 /-- A constant map is `J`-holomorphic at every point. -/
 lemma isJHolomorphicAt_const (J : AlmostComplexStructure V) (J' : AlmostComplexStructure W)
     (c : W) (x : V) : IsJHolomorphicAt J J' (fun _ : V => c) x :=
-  ⟨0, hasFDerivAt_const c x, isComplexLinear_zero J J'⟩
+  ⟨0, hasFDerivAt_const c x, by simpa using isComplexLinearMap_zero J J'⟩
 
 /-- The identity map is `J`-holomorphic for any fixed almost complex structure `J`. -/
 lemma isJHolomorphicAt_id (J : AlmostComplexStructure V) (x : V) :
     IsJHolomorphicAt J J id x :=
-  ⟨ContinuousLinearMap.id ℝ V, hasFDerivAt_id x, isComplexLinear_id J⟩
+  ⟨ContinuousLinearMap.id ℝ V, hasFDerivAt_id x, by simpa using isComplexLinearMap_id J⟩
 
 lemma IsJHolomorphicAt.comp {J : AlmostComplexStructure V}
     {J' : AlmostComplexStructure W} {J'' : AlmostComplexStructure X}

--- a/TauCeti/Geometry/Symplectic/JHolomorphic.lean
+++ b/TauCeti/Geometry/Symplectic/JHolomorphic.lean
@@ -227,6 +227,18 @@ lemma isJHolomorphicWithinAt_id (J : AlmostComplexStructure V) (s : Set V) (x : 
     IsJHolomorphicWithinAt J J id s x :=
   (isJHolomorphicAt_id J x).isJHolomorphicWithinAt
 
+/-- A constant map is `J`-holomorphic on every set. -/
+@[simp]
+lemma isJHolomorphicOn_const (J : AlmostComplexStructure V) (J' : AlmostComplexStructure W)
+    (c : W) (s : Set V) : IsJHolomorphicOn J J' (fun _ : V => c) s :=
+  fun x _ => isJHolomorphicWithinAt_const J J' c s x
+
+/-- The identity map is `J`-holomorphic on every set. -/
+@[simp]
+lemma isJHolomorphicOn_id (J : AlmostComplexStructure V) (s : Set V) :
+    IsJHolomorphicOn J J id s :=
+  fun x _ => isJHolomorphicWithinAt_id J s x
+
 /-- Chain rule for within-set `J`-holomorphic maps. -/
 lemma IsJHolomorphicWithinAt.comp {J : AlmostComplexStructure V}
     {J' : AlmostComplexStructure W} {J'' : AlmostComplexStructure X}


### PR DESCRIPTION
This PR adds the derivative-level definition of `J`-holomorphic maps between real normed spaces with fixed pointwise almost complex structures: a map is `J`-holomorphic at a point when it has a Frechet derivative there and that derivative satisfies `df ∘ J = J' ∘ df`. It also adds setwise and global predicates, extracts differentiability and the `fderiv` commutation equation, and proves the constant, identity, and composition APIs.

This advances `TauCetiRoadmap/HeegaardFloer/README.md`, Lane F2.1, the item "Definitions land immediately (almost nothing to wait for): almost complex structures, tame/compatible `J`, symplectic manifolds, `J`-holomorphic maps, energy", by supplying the first map-level Cauchy--Riemann predicate over the already-merged pointwise almost-complex definitions.

<!--tauceti-target:v1 {"focus":"HeegaardFloer","id":"j-holomorphic-maps"}-->

No Mathlib infrastructure is vendored. The definition follows McDuff--Salamon, *J-holomorphic Curves and Symplectic Topology*, Section 2.1, and reuses Mathlib's `HasFDerivAt`, `fderiv`, continuous-linear-map composition, and derivative composition API together with TauCeti's `AlmostComplexStructure`. I checked the pinned Mathlib and TauCeti sources for an existing general fixed-`J` holomorphic-map predicate, `IsJHolomorphic`, `JHolomorphic`, `IsComplexLinearMap`, and related Cauchy--Riemann APIs; Mathlib has complex-analysis specializations but no duplicate of this fixed almost-complex-structure predicate.

Verification: `lake exe cache get` completed with `No files to download` and `Already decompressed 8555 file(s)`; `lake build` completed with `Build completed successfully (3851 jobs).`; `lake exe axioms` completed with `axioms: audited 2505 TauCeti declaration(s); all within the allowlist [propext, Classical.choice, Quot.sound].`

🤖 Prepared with Codex
