### PR TITLE
feat: transport almost complex structures along linear equivalences

### DIFF
--- a/TauCeti/Geometry/Symplectic/AlmostComplex.lean
+++ b/TauCeti/Geometry/Symplectic/AlmostComplex.lean
@@ -6,6 +6,7 @@ import Mathlib.Data.Real.Basic
 import Mathlib.LinearAlgebra.BilinearForm.Hom
 import Mathlib.LinearAlgebra.BilinearForm.Properties
 import Mathlib.LinearAlgebra.QuadraticForm.Basic
+import TauCeti.LinearAlgebra.ComplexLinearPart
 
 /-!
 # Almost complex structures and compatible symplectic forms
@@ -53,6 +54,14 @@ structure AlmostComplexStructure (V : Type*) [AddCommGroup V] [Module ℝ V] whe
 namespace AlmostComplexStructure
 
 variable [AddCommGroup V] [Module ℝ V]
+
+/-- The underlying linear map determines an almost complex structure: the only data is the
+endomorphism, the defining identity being a proposition. -/
+theorem toLinearMap_injective :
+    Function.Injective (toLinearMap : AlmostComplexStructure V → (V →ₗ[ℝ] V)) := by
+  rintro ⟨L, hL⟩ ⟨L', hL'⟩ h
+  subst h
+  rfl
 
 instance : CoeFun (AlmostComplexStructure V) fun _ => V → V :=
   ⟨fun J => J.toLinearMap⟩
@@ -151,6 +160,13 @@ almost complex structures if it intertwines them. -/
 def IsComplexLinearMap (J : AlmostComplexStructure V) (J' : AlmostComplexStructure W)
     (F : V →ₗ[ℝ] W) : Prop :=
   F.comp J.toLinearMap = J'.toLinearMap.comp F
+
+/-- The bundled almost-complex predicate is the raw complex-linearity predicate applied to the
+underlying endomorphisms. -/
+lemma isComplexLinearMap_iff_isComplexLinear (J : AlmostComplexStructure V)
+    (J' : AlmostComplexStructure W) (F : V →ₗ[ℝ] W) :
+    IsComplexLinearMap J J' F ↔ IsComplexLinear J.toLinearMap J'.toLinearMap F :=
+  Iff.rfl
 
 /-- Rewrite complex-linearity of a real-linear map as the pointwise equation
 `F (J v) = J' (F v)`. -/

--- a/TauCeti/Geometry/Symplectic/Transport.lean
+++ b/TauCeti/Geometry/Symplectic/Transport.lean
@@ -1,0 +1,143 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+import Mathlib.Algebra.Module.Equiv.Basic
+import TauCeti.Geometry.Symplectic.AlmostComplex
+
+/-!
+# Transporting almost complex structures along linear equivalences
+
+A real-linear isomorphism `e : V ≃ₗ[ℝ] W` carries an almost complex structure `J` on `V` to
+one on `W` by conjugation, `w ↦ e (J (e.symm w))`. This file records that transport and its
+functoriality, and packages the statement that `e` itself is then a complex-linear isomorphism
+between `(V, J)` and `(W, J.transport e)`.
+
+This is the pointwise naturality that the smooth layer of the analytic Heegaard Floer roadmap
+needs: an almost complex structure on a vector bundle is given fiberwise, and a change of
+trivialization acts on each fiber by exactly this conjugation. The capstone
+`IsComplexLinearMap.arrowCongr` says that complex-linearity of a map is preserved when both
+source and target are transported, so the whole `J`-holomorphic dictionary moves along
+isomorphisms without being restated.
+
+## Main declarations
+
+* `TauCeti.AlmostComplexStructure.transport`: the almost complex structure `e.conj J` on `W`,
+  obtained by conjugating `J` with `e : V ≃ₗ[ℝ] W`.
+* `TauCeti.AlmostComplexStructure.transport_refl` / `transport_trans`: functoriality of
+  transport in the linear equivalence.
+* `TauCeti.AlmostComplexStructure.isComplexLinearMap_transport`: the equivalence `e` is
+  complex-linear from `J` to `J.transport e`.
+* `TauCeti.IsComplexLinearMap.arrowCongr`: complex-linearity transports along a pair of linear
+  equivalences applied to the source and target.
+
+The conjugation `LinearEquiv.conj` and `LinearEquiv.arrowCongr` are reused from Mathlib; the
+almost complex structure layer is `TauCeti.AlmostComplexStructure`.
+-/
+
+namespace TauCeti
+
+variable {V W X : Type*}
+
+namespace AlmostComplexStructure
+
+variable [AddCommGroup V] [Module ℝ V]
+variable [AddCommGroup W] [Module ℝ W]
+variable [AddCommGroup X] [Module ℝ X]
+
+/-- The underlying linear map determines an almost complex structure: the only data is the
+endomorphism, the defining identity being a proposition. -/
+theorem toLinearMap_injective :
+    Function.Injective (toLinearMap : AlmostComplexStructure V → (V →ₗ[ℝ] V)) := by
+  rintro ⟨L, hL⟩ ⟨L', hL'⟩ h
+  subst h
+  rfl
+
+/-- Transport an almost complex structure along a real-linear equivalence by conjugation.
+
+The endomorphism is `LinearEquiv.conj e` applied to `J`, that is `w ↦ e (J (e.symm w))`; it
+again squares to `-1` because conjugation is multiplicative and fixes `±id`. -/
+def transport (J : AlmostComplexStructure V) (e : V ≃ₗ[ℝ] W) : AlmostComplexStructure W where
+  toLinearMap := e.conj J.toLinearMap
+  square_neg := by
+    rw [← LinearEquiv.conj_comp, J.square_neg, map_neg, LinearEquiv.conj_id]
+
+@[simp]
+lemma transport_toLinearMap (J : AlmostComplexStructure V) (e : V ≃ₗ[ℝ] W) :
+    (J.transport e).toLinearMap = e.conj J.toLinearMap := rfl
+
+@[simp]
+lemma transport_apply (J : AlmostComplexStructure V) (e : V ≃ₗ[ℝ] W) (w : W) :
+    J.transport e w = e (J (e.symm w)) := rfl
+
+/-- Transporting along the identity equivalence does nothing. -/
+@[simp]
+lemma transport_refl (J : AlmostComplexStructure V) :
+    J.transport (LinearEquiv.refl ℝ V) = J :=
+  toLinearMap_injective (by ext v; simp)
+
+/-- Transport is functorial: transporting along `e₁` then `e₂` is transporting along their
+composite. -/
+lemma transport_trans (J : AlmostComplexStructure V) (e₁ : V ≃ₗ[ℝ] W) (e₂ : W ≃ₗ[ℝ] X) :
+    (J.transport e₁).transport e₂ = J.transport (e₁ ≪≫ₗ e₂) := by
+  apply toLinearMap_injective
+  simp only [transport_toLinearMap]
+  rw [← LinearEquiv.trans_apply, LinearEquiv.conj_trans]
+
+/-- Transporting forward along `e` and back along `e.symm` returns the original structure. -/
+@[simp]
+lemma transport_symm_transport (J : AlmostComplexStructure V) (e : V ≃ₗ[ℝ] W) :
+    (J.transport e).transport e.symm = J := by
+  rw [transport_trans, e.self_trans_symm, transport_refl]
+
+/-- Transporting back along `e.symm` and forward along `e` returns the original structure. -/
+@[simp]
+lemma transport_transport_symm (J : AlmostComplexStructure W) (e : V ≃ₗ[ℝ] W) :
+    (J.transport e.symm).transport e = J := by
+  rw [transport_trans, e.symm_trans_self, transport_refl]
+
+/-- Transport commutes with negation of the almost complex structure. -/
+@[simp]
+lemma transport_neg (J : AlmostComplexStructure V) (e : V ≃ₗ[ℝ] W) :
+    (-J).transport e = -(J.transport e) := by
+  apply toLinearMap_injective
+  simp only [transport_toLinearMap, neg_toLinearMap, map_neg]
+
+/-- A linear equivalence is complex-linear from `J` to its transport `J.transport e`. -/
+lemma isComplexLinearMap_transport (J : AlmostComplexStructure V) (e : V ≃ₗ[ℝ] W) :
+    IsComplexLinearMap J (J.transport e) e.toLinearMap := by
+  rw [isComplexLinearMap_iff_apply]
+  intro v
+  simp
+
+/-- The inverse equivalence is complex-linear from `J.transport e` back to `J`. -/
+lemma isComplexLinearMap_symm_transport (J : AlmostComplexStructure V) (e : V ≃ₗ[ℝ] W) :
+    IsComplexLinearMap (J.transport e) J e.symm.toLinearMap := by
+  rw [isComplexLinearMap_iff_apply]
+  intro w
+  simp
+
+end AlmostComplexStructure
+
+section Naturality
+
+variable {V₁ V₂ W₁ W₂ : Type*}
+variable [AddCommGroup V₁] [Module ℝ V₁] [AddCommGroup V₂] [Module ℝ V₂]
+variable [AddCommGroup W₁] [Module ℝ W₁] [AddCommGroup W₂] [Module ℝ W₂]
+
+/-- Complex-linearity transports along a pair of linear equivalences: if `F` intertwines `J`
+and `J'`, then conjugating `F` by `eV` on the source and `eW` on the target intertwines the
+transported structures. -/
+lemma IsComplexLinearMap.arrowCongr {J : AlmostComplexStructure V₁}
+    {J' : AlmostComplexStructure W₁} {F : V₁ →ₗ[ℝ] W₁} (hF : IsComplexLinearMap J J' F)
+    (eV : V₁ ≃ₗ[ℝ] V₂) (eW : W₁ ≃ₗ[ℝ] W₂) :
+    IsComplexLinearMap (J.transport eV) (J'.transport eW) (eV.arrowCongr eW F) := by
+  rw [isComplexLinearMap_iff_apply] at hF ⊢
+  intro v
+  simp only [LinearEquiv.arrowCongr_apply, AlmostComplexStructure.transport_apply,
+    LinearEquiv.symm_apply_apply]
+  rw [hF]
+
+end Naturality
+
+end TauCeti

--- a/TauCeti/Geometry/Symplectic/Transport.lean
+++ b/TauCeti/Geometry/Symplectic/Transport.lean
@@ -2,7 +2,6 @@
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 -/
-import Mathlib.Algebra.Module.Equiv.Basic
 import TauCeti.Geometry.Symplectic.AlmostComplex
 
 /-!
@@ -119,23 +118,9 @@ variable {V₁ V₂ W₁ W₂ : Type*}
 variable [AddCommGroup V₁] [Module ℝ V₁] [AddCommGroup V₂] [Module ℝ V₂]
 variable [AddCommGroup W₁] [Module ℝ W₁] [AddCommGroup W₂] [Module ℝ W₂]
 
-/-- Raw complex-linearity is preserved and reflected by conjugating source and target along
-linear equivalences. -/
-lemma isComplexLinear_arrowCongr_iff {J : V₁ →ₗ[ℝ] V₁} {J' : W₁ →ₗ[ℝ] W₁}
-    {F : V₁ →ₗ[ℝ] W₁} (eV : V₁ ≃ₗ[ℝ] V₂) (eW : W₁ ≃ₗ[ℝ] W₂) :
-    IsComplexLinear (eV.conj J) (eW.conj J') (eV.arrowCongr eW F) ↔
-      IsComplexLinear J J' F := by
-  constructor
-  · intro hF
-    refine isComplexLinear_of_apply fun v => ?_
-    have h := hF.apply (eV v)
-    simpa [LinearEquiv.arrowCongr_apply] using congrArg eW.symm h
-  · intro hF
-    refine isComplexLinear_of_apply fun v => ?_
-    simp [LinearEquiv.arrowCongr_apply, hF.apply]
-
 /-- Complex-linearity is preserved and reflected when source, target, and map are transported
 along linear equivalences. -/
+@[simp]
 lemma isComplexLinearMap_arrowCongr_iff {J : AlmostComplexStructure V₁}
     {J' : AlmostComplexStructure W₁} {F : V₁ →ₗ[ℝ] W₁}
     (eV : V₁ ≃ₗ[ℝ] V₂) (eW : W₁ ≃ₗ[ℝ] W₂) :

--- a/TauCeti/Geometry/Symplectic/Transport.lean
+++ b/TauCeti/Geometry/Symplectic/Transport.lean
@@ -2,6 +2,7 @@
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 -/
+import Mathlib.Algebra.Module.Equiv.Basic
 import TauCeti.Geometry.Symplectic.AlmostComplex
 
 /-!
@@ -69,6 +70,7 @@ lemma transport_refl (J : AlmostComplexStructure V) :
 
 /-- Transport is functorial: transporting along `e₁` then `e₂` is transporting along their
 composite. -/
+@[simp]
 lemma transport_trans (J : AlmostComplexStructure V) (e₁ : V ≃ₗ[ℝ] W) (e₂ : W ≃ₗ[ℝ] X) :
     (J.transport e₁).transport e₂ = J.transport (e₁ ≪≫ₗ e₂) := by
   apply toLinearMap_injective

--- a/TauCeti/Geometry/Symplectic/Transport.lean
+++ b/TauCeti/Geometry/Symplectic/Transport.lean
@@ -4,6 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 -/
 import Mathlib.Algebra.Module.Equiv.Basic
 import TauCeti.Geometry.Symplectic.AlmostComplex
+import TauCeti.LinearAlgebra.ComplexLinearPart
 
 /-!
 # Transporting almost complex structures along linear equivalences

--- a/TauCeti/Geometry/Symplectic/Transport.lean
+++ b/TauCeti/Geometry/Symplectic/Transport.lean
@@ -13,12 +13,12 @@ one on `W` by conjugation, `w ↦ e (J (e.symm w))`. This file records that tran
 functoriality, and packages the statement that `e` itself is then a complex-linear isomorphism
 between `(V, J)` and `(W, J.transport e)`.
 
-This is the pointwise naturality that the smooth layer of the analytic Heegaard Floer roadmap
-needs: an almost complex structure on a vector bundle is given fiberwise, and a change of
+This is the pointwise linear algebra that the smooth layer of the analytic Heegaard Floer
+roadmap needs before stating the corresponding bundle-level and `J`-holomorphic naturality:
+an almost complex structure on a vector bundle is given fiberwise, and a change of
 trivialization acts on each fiber by exactly this conjugation. The capstone
-`IsComplexLinearMap.arrowCongr` says that complex-linearity of a map is preserved when both
-source and target are transported, so the whole `J`-holomorphic dictionary moves along
-isomorphisms without being restated.
+`isComplexLinearMap_arrowCongr_iff` says that complex-linearity of a linear map is preserved
+and reflected when both source and target are transported.
 
 ## Main declarations
 
@@ -45,18 +45,10 @@ variable [AddCommGroup V] [Module ℝ V]
 variable [AddCommGroup W] [Module ℝ W]
 variable [AddCommGroup X] [Module ℝ X]
 
-/-- The underlying linear map determines an almost complex structure: the only data is the
-endomorphism, the defining identity being a proposition. -/
-theorem toLinearMap_injective :
-    Function.Injective (toLinearMap : AlmostComplexStructure V → (V →ₗ[ℝ] V)) := by
-  rintro ⟨L, hL⟩ ⟨L', hL'⟩ h
-  subst h
-  rfl
-
 /-- Transport an almost complex structure along a real-linear equivalence by conjugation.
 
-The endomorphism is `LinearEquiv.conj e` applied to `J`, that is `w ↦ e (J (e.symm w))`; it
-again squares to `-1` because conjugation is multiplicative and fixes `±id`. -/
+The transported endomorphism is `LinearEquiv.conj e` applied to `J`, equivalently
+`w ↦ e (J (e.symm w))`, and it satisfies the almost-complex square condition. -/
 def transport (J : AlmostComplexStructure V) (e : V ≃ₗ[ℝ] W) : AlmostComplexStructure W where
   toLinearMap := e.conj J.toLinearMap
   square_neg := by
@@ -104,6 +96,7 @@ lemma transport_neg (J : AlmostComplexStructure V) (e : V ≃ₗ[ℝ] W) :
   simp only [transport_toLinearMap, neg_toLinearMap, map_neg]
 
 /-- A linear equivalence is complex-linear from `J` to its transport `J.transport e`. -/
+@[simp]
 lemma isComplexLinearMap_transport (J : AlmostComplexStructure V) (e : V ≃ₗ[ℝ] W) :
     IsComplexLinearMap J (J.transport e) e.toLinearMap := by
   rw [isComplexLinearMap_iff_apply]
@@ -111,6 +104,7 @@ lemma isComplexLinearMap_transport (J : AlmostComplexStructure V) (e : V ≃ₗ[
   simp
 
 /-- The inverse equivalence is complex-linear from `J.transport e` back to `J`. -/
+@[simp]
 lemma isComplexLinearMap_symm_transport (J : AlmostComplexStructure V) (e : V ≃ₗ[ℝ] W) :
     IsComplexLinearMap (J.transport e) J e.symm.toLinearMap := by
   rw [isComplexLinearMap_iff_apply]
@@ -125,18 +119,40 @@ variable {V₁ V₂ W₁ W₂ : Type*}
 variable [AddCommGroup V₁] [Module ℝ V₁] [AddCommGroup V₂] [Module ℝ V₂]
 variable [AddCommGroup W₁] [Module ℝ W₁] [AddCommGroup W₂] [Module ℝ W₂]
 
+/-- Raw complex-linearity is preserved and reflected by conjugating source and target along
+linear equivalences. -/
+lemma isComplexLinear_arrowCongr_iff {J : V₁ →ₗ[ℝ] V₁} {J' : W₁ →ₗ[ℝ] W₁}
+    {F : V₁ →ₗ[ℝ] W₁} (eV : V₁ ≃ₗ[ℝ] V₂) (eW : W₁ ≃ₗ[ℝ] W₂) :
+    IsComplexLinear (eV.conj J) (eW.conj J') (eV.arrowCongr eW F) ↔
+      IsComplexLinear J J' F := by
+  constructor
+  · intro hF
+    refine isComplexLinear_of_apply fun v => ?_
+    have h := hF.apply (eV v)
+    simpa [LinearEquiv.arrowCongr_apply] using congrArg eW.symm h
+  · intro hF
+    refine isComplexLinear_of_apply fun v => ?_
+    simp [LinearEquiv.arrowCongr_apply, hF.apply]
+
+/-- Complex-linearity is preserved and reflected when source, target, and map are transported
+along linear equivalences. -/
+lemma isComplexLinearMap_arrowCongr_iff {J : AlmostComplexStructure V₁}
+    {J' : AlmostComplexStructure W₁} {F : V₁ →ₗ[ℝ] W₁}
+    (eV : V₁ ≃ₗ[ℝ] V₂) (eW : W₁ ≃ₗ[ℝ] W₂) :
+    IsComplexLinearMap (J.transport eV) (J'.transport eW) (eV.arrowCongr eW F) ↔
+      IsComplexLinearMap J J' F := by
+  rw [isComplexLinearMap_iff_isComplexLinear, isComplexLinearMap_iff_isComplexLinear,
+    AlmostComplexStructure.transport_toLinearMap, AlmostComplexStructure.transport_toLinearMap,
+    isComplexLinear_arrowCongr_iff]
+
 /-- Complex-linearity transports along a pair of linear equivalences: if `F` intertwines `J`
 and `J'`, then conjugating `F` by `eV` on the source and `eW` on the target intertwines the
 transported structures. -/
 lemma IsComplexLinearMap.arrowCongr {J : AlmostComplexStructure V₁}
     {J' : AlmostComplexStructure W₁} {F : V₁ →ₗ[ℝ] W₁} (hF : IsComplexLinearMap J J' F)
     (eV : V₁ ≃ₗ[ℝ] V₂) (eW : W₁ ≃ₗ[ℝ] W₂) :
-    IsComplexLinearMap (J.transport eV) (J'.transport eW) (eV.arrowCongr eW F) := by
-  rw [isComplexLinearMap_iff_apply] at hF ⊢
-  intro v
-  simp only [LinearEquiv.arrowCongr_apply, AlmostComplexStructure.transport_apply,
-    LinearEquiv.symm_apply_apply]
-  rw [hF]
+    IsComplexLinearMap (J.transport eV) (J'.transport eW) (eV.arrowCongr eW F) :=
+  (isComplexLinearMap_arrowCongr_iff eV eW).mpr hF
 
 end Naturality
 

--- a/TauCeti/LinearAlgebra/ComplexLinearPart.lean
+++ b/TauCeti/LinearAlgebra/ComplexLinearPart.lean
@@ -3,6 +3,7 @@ Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 -/
 import Mathlib.Data.Real.Basic
+import Mathlib.Algebra.Module.Equiv.Basic
 import Mathlib.LinearAlgebra.Span.Defs
 import Mathlib.Tactic.Module
 import Mathlib.Tactic.Abel
@@ -51,6 +52,8 @@ statement, before any smoothness or bundle structure is introduced.
   complex-antilinear part vanishes (the `∂̄ F = 0` characterization).
 * `TauCeti.isCompl_complexLinearMaps`: the complex-linear and complex-antilinear maps are
   complementary subspaces of all real-linear maps.
+* `TauCeti.isComplexLinear_arrowCongr_iff`: complex-linearity is preserved and reflected by
+  conjugating source, target, and map along real-linear equivalences.
 
 The sign conventions follow McDuff--Salamon, *J-holomorphic Curves and Symplectic Topology*,
 2nd ed., Section 2.2, specialized to the pointwise real-linear setting.
@@ -97,6 +100,23 @@ theorem IsComplexLinear.apply {F : V →ₗ[ℝ] W} (h : IsComplexLinear J J' F)
 theorem isComplexLinear_of_apply {F : V →ₗ[ℝ] W} (h : ∀ v, F (J v) = J' (F v)) :
     IsComplexLinear J J' F :=
   LinearMap.ext fun v => by simpa using h v
+
+/-- Raw complex-linearity is preserved and reflected by conjugating source and target along
+linear equivalences. -/
+@[simp]
+theorem isComplexLinear_arrowCongr_iff {V₂ W₂ : Type*}
+    [AddCommGroup V₂] [Module ℝ V₂] [AddCommGroup W₂] [Module ℝ W₂]
+    {F : V →ₗ[ℝ] W} (eV : V ≃ₗ[ℝ] V₂) (eW : W ≃ₗ[ℝ] W₂) :
+    IsComplexLinear (eV.conj J) (eW.conj J') (eV.arrowCongr eW F) ↔
+      IsComplexLinear J J' F := by
+  constructor
+  · intro hF
+    refine isComplexLinear_of_apply fun v => ?_
+    have h := hF.apply (eV v)
+    simpa [LinearEquiv.arrowCongr_apply] using congrArg eW.symm h
+  · intro hF
+    refine isComplexLinear_of_apply fun v => ?_
+    simp [LinearEquiv.arrowCongr_apply, hF.apply]
 
 /-- The pointwise form of complex antilinearity: `F (J v) = -(J' (F v))`. -/
 theorem IsComplexAntilinear.apply {F : V →ₗ[ℝ] W} (h : IsComplexAntilinear J J' F) (v : V) :


### PR DESCRIPTION
This PR adds `TauCeti.AlmostComplexStructure.transport`, which carries an almost complex structure `J` on a real module `V` to one on `W` along a real-linear equivalence `e : V ≃ₗ[ℝ] W` by conjugation, `w ↦ e (J (e.symm w))`. It records functoriality (`transport_refl`, `transport_trans`, the two round-trip simp lemmas, and `transport_neg`), proves that `e` is then a complex-linear isomorphism from `(V, J)` to `(W, J.transport e)` in both directions (`isComplexLinearMap_transport`, `isComplexLinearMap_symm_transport`), and closes with the naturality capstone `IsComplexLinearMap.arrowCongr`: complex-linearity of a map is preserved when source and target structures are both transported.

This advances `TauCetiRoadmap/HeegaardFloer/README.md`, Lane F2.1 ("almost complex structures, tame/compatible `J`, symplectic manifolds, `J`-holomorphic maps, energy"), by supplying the pointwise naturality the smooth layer needs: an almost complex structure on a vector bundle is given fiberwise, a change of trivialization acts on each fiber by exactly this conjugation, and the `J`-holomorphic dictionary then moves along isomorphisms without being restated. It builds directly on the merged `TauCeti.AlmostComplexStructure` (#228) and `IsComplexLinearMap` (#228), and is distinct from the open totally-real (#229) and complex-module (#233) work.

<!--tauceti-target:v1 {"focus":"HeegaardFloer","id":"almostcomplexstructure-transport"}-->

No Mathlib infrastructure is vendored. The construction reuses Mathlib's `LinearEquiv.conj` (with `conj_comp`, `conj_id`, `conj_trans`) and `LinearEquiv.arrowCongr` from `Mathlib.Algebra.Module.Equiv.Basic`, together with TauCeti's `AlmostComplexStructure` and `IsComplexLinearMap`. I checked the pinned Mathlib and TauCeti sources for an existing transport/conjugation of almost complex structures and found none (Mathlib has no almost complex structure layer).

Verification: `lake build` completed with `Build completed successfully (3854 jobs).`; `lake exe axioms` completed with `axioms: audited 2639 TauCeti declaration(s); all within the allowlist [propext, Classical.choice, Quot.sound].`

🤖 Prepared with Claude Code
