### PR TITLE
feat: J-holomorphic maps are closed under real-linear combinations

### DIFF
--- a/TauCeti/Geometry/Symplectic/AlmostComplex.lean
+++ b/TauCeti/Geometry/Symplectic/AlmostComplex.lean
@@ -186,6 +186,38 @@ lemma IsComplexLinearMap.comp {J : AlmostComplexStructure V} {J' : AlmostComplex
     G (F (J v)) = G (J' (F v)) := by rw [hF v]
     _ = J'' (G (F v)) := hG (F v)
 
+/-- Complex-linear maps are closed under addition. -/
+lemma IsComplexLinearMap.add {J : AlmostComplexStructure V} {J' : AlmostComplexStructure W}
+    {F G : V →ₗ[ℝ] W} (hF : IsComplexLinearMap J J' F) (hG : IsComplexLinearMap J J' G) :
+    IsComplexLinearMap J J' (F + G) := by
+  rw [isComplexLinearMap_iff_apply] at hF hG ⊢
+  intro v
+  rw [LinearMap.add_apply, LinearMap.add_apply, hF v, hG v, map_add]
+
+/-- Complex-linear maps are closed under negation. -/
+lemma IsComplexLinearMap.neg {J : AlmostComplexStructure V} {J' : AlmostComplexStructure W}
+    {F : V →ₗ[ℝ] W} (hF : IsComplexLinearMap J J' F) :
+    IsComplexLinearMap J J' (-F) := by
+  rw [isComplexLinearMap_iff_apply] at hF ⊢
+  intro v
+  rw [LinearMap.neg_apply, LinearMap.neg_apply, hF v, map_neg]
+
+/-- Complex-linear maps are closed under subtraction. -/
+lemma IsComplexLinearMap.sub {J : AlmostComplexStructure V} {J' : AlmostComplexStructure W}
+    {F G : V →ₗ[ℝ] W} (hF : IsComplexLinearMap J J' F) (hG : IsComplexLinearMap J J' G) :
+    IsComplexLinearMap J J' (F - G) := by
+  rw [isComplexLinearMap_iff_apply] at hF hG ⊢
+  intro v
+  rw [LinearMap.sub_apply, LinearMap.sub_apply, hF v, hG v, map_sub]
+
+/-- Complex-linear maps are closed under multiplication by a real scalar. -/
+lemma IsComplexLinearMap.smul {J : AlmostComplexStructure V} {J' : AlmostComplexStructure W}
+    {F : V →ₗ[ℝ] W} (hF : IsComplexLinearMap J J' F) (c : ℝ) :
+    IsComplexLinearMap J J' (c • F) := by
+  rw [isComplexLinearMap_iff_apply] at hF ⊢
+  intro v
+  rw [LinearMap.smul_apply, LinearMap.smul_apply, hF v, map_smul]
+
 end ComplexLinearMap
 
 /-- A symplectic form on a real module is an alternating, nondegenerate bilinear form.

--- a/TauCeti/Geometry/Symplectic/AlmostComplex.lean
+++ b/TauCeti/Geometry/Symplectic/AlmostComplex.lean
@@ -201,34 +201,6 @@ lemma IsComplexLinearMap.comp {J : AlmostComplexStructure V} {J' : AlmostComplex
     G (F (J v)) = G (J' (F v)) := by rw [hF v]
     _ = J'' (G (F v)) := hG (F v)
 
-/-- Complex-linear maps are closed under addition. -/
-lemma IsComplexLinearMap.add {J : AlmostComplexStructure V} {J' : AlmostComplexStructure W}
-    {F G : V →ₗ[ℝ] W} (hF : IsComplexLinearMap J J' F) (hG : IsComplexLinearMap J J' G) :
-    IsComplexLinearMap J J' (F + G) := by
-  rw [isComplexLinearMap_iff_mem_complexLinearMaps] at hF hG ⊢
-  exact (complexLinearMaps J.toLinearMap J'.toLinearMap).add_mem hF hG
-
-/-- Complex-linear maps are closed under negation. -/
-lemma IsComplexLinearMap.neg {J : AlmostComplexStructure V} {J' : AlmostComplexStructure W}
-    {F : V →ₗ[ℝ] W} (hF : IsComplexLinearMap J J' F) :
-    IsComplexLinearMap J J' (-F) := by
-  rw [isComplexLinearMap_iff_mem_complexLinearMaps] at hF ⊢
-  exact (complexLinearMaps J.toLinearMap J'.toLinearMap).neg_mem hF
-
-/-- Complex-linear maps are closed under subtraction. -/
-lemma IsComplexLinearMap.sub {J : AlmostComplexStructure V} {J' : AlmostComplexStructure W}
-    {F G : V →ₗ[ℝ] W} (hF : IsComplexLinearMap J J' F) (hG : IsComplexLinearMap J J' G) :
-    IsComplexLinearMap J J' (F - G) := by
-  rw [isComplexLinearMap_iff_mem_complexLinearMaps] at hF hG ⊢
-  exact (complexLinearMaps J.toLinearMap J'.toLinearMap).sub_mem hF hG
-
-/-- Complex-linear maps are closed under multiplication by a real scalar. -/
-lemma IsComplexLinearMap.smul {J : AlmostComplexStructure V} {J' : AlmostComplexStructure W}
-    {F : V →ₗ[ℝ] W} (hF : IsComplexLinearMap J J' F) (c : ℝ) :
-    IsComplexLinearMap J J' (c • F) := by
-  rw [isComplexLinearMap_iff_mem_complexLinearMaps] at hF ⊢
-  exact (complexLinearMaps J.toLinearMap J'.toLinearMap).smul_mem c hF
-
 end ComplexLinearMap
 
 /-- A symplectic form on a real module is an alternating, nondegenerate bilinear form.

--- a/TauCeti/Geometry/Symplectic/AlmostComplex.lean
+++ b/TauCeti/Geometry/Symplectic/AlmostComplex.lean
@@ -182,6 +182,34 @@ lemma isComplexLinearMap_zero (J : AlmostComplexStructure V) (J' : AlmostComplex
   intro v
   simp
 
+/-- Complex-linear maps are closed under addition. -/
+lemma IsComplexLinearMap.add {J : AlmostComplexStructure V} {J' : AlmostComplexStructure W}
+    {F G : V →ₗ[ℝ] W} (hF : IsComplexLinearMap J J' F)
+    (hG : IsComplexLinearMap J J' G) : IsComplexLinearMap J J' (F + G) := by
+  rw [isComplexLinearMap_iff_mem_complexLinearMaps] at hF hG ⊢
+  exact (complexLinearMaps J.toLinearMap J'.toLinearMap).add_mem hF hG
+
+/-- Complex-linear maps are closed under negation. -/
+lemma IsComplexLinearMap.neg {J : AlmostComplexStructure V} {J' : AlmostComplexStructure W}
+    {F : V →ₗ[ℝ] W} (hF : IsComplexLinearMap J J' F) :
+    IsComplexLinearMap J J' (-F) := by
+  rw [isComplexLinearMap_iff_mem_complexLinearMaps] at hF ⊢
+  exact (complexLinearMaps J.toLinearMap J'.toLinearMap).neg_mem hF
+
+/-- Complex-linear maps are closed under subtraction. -/
+lemma IsComplexLinearMap.sub {J : AlmostComplexStructure V} {J' : AlmostComplexStructure W}
+    {F G : V →ₗ[ℝ] W} (hF : IsComplexLinearMap J J' F)
+    (hG : IsComplexLinearMap J J' G) : IsComplexLinearMap J J' (F - G) := by
+  rw [isComplexLinearMap_iff_mem_complexLinearMaps] at hF hG ⊢
+  exact (complexLinearMaps J.toLinearMap J'.toLinearMap).sub_mem hF hG
+
+/-- Complex-linear maps are closed under real scalar multiplication. -/
+lemma IsComplexLinearMap.smul {J : AlmostComplexStructure V} {J' : AlmostComplexStructure W}
+    {F : V →ₗ[ℝ] W} (c : ℝ) (hF : IsComplexLinearMap J J' F) :
+    IsComplexLinearMap J J' (c • F) := by
+  rw [isComplexLinearMap_iff_mem_complexLinearMaps] at hF ⊢
+  exact (complexLinearMaps J.toLinearMap J'.toLinearMap).smul_mem c hF
+
 /-- The identity map is complex-linear with respect to the same almost complex structure. -/
 @[simp]
 lemma isComplexLinearMap_id (J : AlmostComplexStructure V) :

--- a/TauCeti/Geometry/Symplectic/AlmostComplex.lean
+++ b/TauCeti/Geometry/Symplectic/AlmostComplex.lean
@@ -6,6 +6,7 @@ import Mathlib.Data.Real.Basic
 import Mathlib.LinearAlgebra.BilinearForm.Hom
 import Mathlib.LinearAlgebra.BilinearForm.Properties
 import Mathlib.LinearAlgebra.QuadraticForm.Basic
+import TauCeti.LinearAlgebra.ComplexLinearPart
 
 /-!
 # Almost complex structures and compatible symplectic forms
@@ -159,6 +160,20 @@ lemma isComplexLinearMap_iff_apply (J : AlmostComplexStructure V)
     IsComplexLinearMap J J' F ↔ ∀ v, F (J v) = J' (F v) :=
   LinearMap.ext_iff
 
+/-- The almost-complex wrapper predicate is the raw-linear complex-linearity predicate applied
+to the underlying linear maps. -/
+lemma isComplexLinearMap_iff_isComplexLinear (J : AlmostComplexStructure V)
+    (J' : AlmostComplexStructure W) (F : V →ₗ[ℝ] W) :
+    IsComplexLinearMap J J' F ↔ IsComplexLinear J.toLinearMap J'.toLinearMap F :=
+  Iff.rfl
+
+/-- Complex-linearity for almost complex structures is membership in the existing submodule of
+raw-linear complex-linear maps. -/
+lemma isComplexLinearMap_iff_mem_complexLinearMaps (J : AlmostComplexStructure V)
+    (J' : AlmostComplexStructure W) (F : V →ₗ[ℝ] W) :
+    IsComplexLinearMap J J' F ↔ F ∈ complexLinearMaps J.toLinearMap J'.toLinearMap := by
+  rw [isComplexLinearMap_iff_isComplexLinear, mem_complexLinearMaps]
+
 /-- The zero map is complex-linear for any source and target almost complex structures. -/
 @[simp]
 lemma isComplexLinearMap_zero (J : AlmostComplexStructure V) (J' : AlmostComplexStructure W) :
@@ -190,33 +205,29 @@ lemma IsComplexLinearMap.comp {J : AlmostComplexStructure V} {J' : AlmostComplex
 lemma IsComplexLinearMap.add {J : AlmostComplexStructure V} {J' : AlmostComplexStructure W}
     {F G : V →ₗ[ℝ] W} (hF : IsComplexLinearMap J J' F) (hG : IsComplexLinearMap J J' G) :
     IsComplexLinearMap J J' (F + G) := by
-  rw [isComplexLinearMap_iff_apply] at hF hG ⊢
-  intro v
-  rw [LinearMap.add_apply, LinearMap.add_apply, hF v, hG v, map_add]
+  rw [isComplexLinearMap_iff_mem_complexLinearMaps] at hF hG ⊢
+  exact (complexLinearMaps J.toLinearMap J'.toLinearMap).add_mem hF hG
 
 /-- Complex-linear maps are closed under negation. -/
 lemma IsComplexLinearMap.neg {J : AlmostComplexStructure V} {J' : AlmostComplexStructure W}
     {F : V →ₗ[ℝ] W} (hF : IsComplexLinearMap J J' F) :
     IsComplexLinearMap J J' (-F) := by
-  rw [isComplexLinearMap_iff_apply] at hF ⊢
-  intro v
-  rw [LinearMap.neg_apply, LinearMap.neg_apply, hF v, map_neg]
+  rw [isComplexLinearMap_iff_mem_complexLinearMaps] at hF ⊢
+  exact (complexLinearMaps J.toLinearMap J'.toLinearMap).neg_mem hF
 
 /-- Complex-linear maps are closed under subtraction. -/
 lemma IsComplexLinearMap.sub {J : AlmostComplexStructure V} {J' : AlmostComplexStructure W}
     {F G : V →ₗ[ℝ] W} (hF : IsComplexLinearMap J J' F) (hG : IsComplexLinearMap J J' G) :
     IsComplexLinearMap J J' (F - G) := by
-  rw [isComplexLinearMap_iff_apply] at hF hG ⊢
-  intro v
-  rw [LinearMap.sub_apply, LinearMap.sub_apply, hF v, hG v, map_sub]
+  rw [isComplexLinearMap_iff_mem_complexLinearMaps] at hF hG ⊢
+  exact (complexLinearMaps J.toLinearMap J'.toLinearMap).sub_mem hF hG
 
 /-- Complex-linear maps are closed under multiplication by a real scalar. -/
 lemma IsComplexLinearMap.smul {J : AlmostComplexStructure V} {J' : AlmostComplexStructure W}
     {F : V →ₗ[ℝ] W} (hF : IsComplexLinearMap J J' F) (c : ℝ) :
     IsComplexLinearMap J J' (c • F) := by
-  rw [isComplexLinearMap_iff_apply] at hF ⊢
-  intro v
-  rw [LinearMap.smul_apply, LinearMap.smul_apply, hF v, map_smul]
+  rw [isComplexLinearMap_iff_mem_complexLinearMaps] at hF ⊢
+  exact (complexLinearMaps J.toLinearMap J'.toLinearMap).smul_mem c hF
 
 end ComplexLinearMap
 

--- a/TauCeti/Geometry/Symplectic/JHolomorphic.lean
+++ b/TauCeti/Geometry/Symplectic/JHolomorphic.lean
@@ -2,8 +2,10 @@
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 -/
+import Mathlib.Analysis.Calculus.FDeriv.Add
 import Mathlib.Analysis.Calculus.FDeriv.Comp
 import Mathlib.Analysis.Calculus.FDeriv.Const
+import Mathlib.Analysis.Calculus.FDeriv.Linear
 import TauCeti.Geometry.Symplectic.AlmostComplex
 
 /-!
@@ -23,6 +25,15 @@ different Cauchy--Riemann convention.
 * `IsJHolomorphicAt`: a map has a complex-linear Frechet derivative at a point.
 * `IsJHolomorphicWithinAt`: a map has a complex-linear Frechet derivative within a set.
 * `IsJHolomorphicOn` and `IsJHolomorphic`: setwise and global versions.
+
+The Cauchy--Riemann equation `df ∘ J = J' ∘ df` is real-linear in `df`, so a continuous
+real-linear map is `J`-holomorphic exactly when it is complex-linear, and `J`-holomorphic maps
+are closed under pointwise sums, differences, and real scalar multiples:
+
+* `isJHolomorphicAt_continuousLinearMap_iff` and `isJHolomorphic_continuousLinearMap_iff`:
+  a continuous real-linear map is `J`-holomorphic iff it is complex-linear.
+* `IsJHolomorphicAt.add`, `IsJHolomorphicAt.neg`, `IsJHolomorphicAt.sub`,
+  `IsJHolomorphicAt.const_smul` and their within-set, setwise, and global analogues.
 
 The convention follows McDuff--Salamon, *J-holomorphic Curves and Symplectic Topology*,
 Section 2.1: the Cauchy--Riemann equation is `df ∘ J = J' ∘ df`.
@@ -293,5 +304,133 @@ lemma IsJHolomorphic.comp {J : AlmostComplexStructure V}
   fun x => (hg (f x)).comp (hf x)
 
 end JHolomorphic
+
+section LinearStructure
+
+variable {J : AlmostComplexStructure V} {J' : AlmostComplexStructure W}
+
+/-- A continuous real-linear map is `J`-holomorphic at a point iff it is complex-linear: its
+derivative is the map itself, so the Cauchy--Riemann condition becomes complex-linearity. -/
+lemma isJHolomorphicAt_continuousLinearMap_iff (F : V →L[ℝ] W) (x : V) :
+    IsJHolomorphicAt J J' (⇑F) x ↔ IsComplexLinearMap J J' F.toLinearMap := by
+  refine ⟨fun hF => ?_, fun h => ⟨F, F.hasFDerivAt, h⟩⟩
+  obtain ⟨f', hf', hcl⟩ := hF
+  rwa [hf'.unique F.hasFDerivAt] at hcl
+
+/-- A continuous real-linear map is globally `J`-holomorphic iff it is complex-linear. -/
+lemma isJHolomorphic_continuousLinearMap_iff (F : V →L[ℝ] W) :
+    IsJHolomorphic J J' (⇑F) ↔ IsComplexLinearMap J J' F.toLinearMap :=
+  ⟨fun h => (isJHolomorphicAt_continuousLinearMap_iff F 0).mp (h 0),
+    fun h x => (isJHolomorphicAt_continuousLinearMap_iff F x).mpr h⟩
+
+/-- The pointwise sum of two `J`-holomorphic maps is `J`-holomorphic. -/
+lemma IsJHolomorphicAt.add {f g : V → W} {x : V}
+    (hf : IsJHolomorphicAt J J' f x) (hg : IsJHolomorphicAt J J' g x) :
+    IsJHolomorphicAt J J' (f + g) x := by
+  refine ⟨hf.choose + hg.choose, hf.hasFDerivAt.add hg.hasFDerivAt, ?_⟩
+  have h := hf.derivative_isComplexLinear.add hg.derivative_isComplexLinear
+  rwa [← ContinuousLinearMap.toLinearMap_add] at h
+
+/-- The pointwise negation of a `J`-holomorphic map is `J`-holomorphic. -/
+lemma IsJHolomorphicAt.neg {f : V → W} {x : V} (hf : IsJHolomorphicAt J J' f x) :
+    IsJHolomorphicAt J J' (-f) x := by
+  refine ⟨-hf.choose, hf.hasFDerivAt.neg, ?_⟩
+  have h := hf.derivative_isComplexLinear.neg
+  rwa [← ContinuousLinearMap.toLinearMap_neg] at h
+
+/-- The pointwise difference of two `J`-holomorphic maps is `J`-holomorphic. -/
+lemma IsJHolomorphicAt.sub {f g : V → W} {x : V}
+    (hf : IsJHolomorphicAt J J' f x) (hg : IsJHolomorphicAt J J' g x) :
+    IsJHolomorphicAt J J' (f - g) x := by
+  refine ⟨hf.choose - hg.choose, hf.hasFDerivAt.sub hg.hasFDerivAt, ?_⟩
+  have h := hf.derivative_isComplexLinear.sub hg.derivative_isComplexLinear
+  rwa [← ContinuousLinearMap.toLinearMap_sub] at h
+
+/-- A real scalar multiple of a `J`-holomorphic map is `J`-holomorphic. -/
+lemma IsJHolomorphicAt.const_smul {f : V → W} {x : V} (hf : IsJHolomorphicAt J J' f x)
+    (c : ℝ) : IsJHolomorphicAt J J' (c • f) x := by
+  refine ⟨c • hf.choose, hf.hasFDerivAt.const_smul c, ?_⟩
+  have h := hf.derivative_isComplexLinear.smul c
+  rwa [← ContinuousLinearMap.toLinearMap_smul] at h
+
+/-- The pointwise sum of two maps `J`-holomorphic within a set is `J`-holomorphic within it. -/
+lemma IsJHolomorphicWithinAt.add {f g : V → W} {s : Set V} {x : V}
+    (hf : IsJHolomorphicWithinAt J J' f s x) (hg : IsJHolomorphicWithinAt J J' g s x) :
+    IsJHolomorphicWithinAt J J' (f + g) s x := by
+  refine ⟨hf.choose + hg.choose, hf.hasFDerivWithinAt.add hg.hasFDerivWithinAt, ?_⟩
+  have h := hf.derivative_isComplexLinear.add hg.derivative_isComplexLinear
+  rwa [← ContinuousLinearMap.toLinearMap_add] at h
+
+/-- The pointwise negation of a map `J`-holomorphic within a set is `J`-holomorphic within it. -/
+lemma IsJHolomorphicWithinAt.neg {f : V → W} {s : Set V} {x : V}
+    (hf : IsJHolomorphicWithinAt J J' f s x) :
+    IsJHolomorphicWithinAt J J' (-f) s x := by
+  refine ⟨-hf.choose, hf.hasFDerivWithinAt.neg, ?_⟩
+  have h := hf.derivative_isComplexLinear.neg
+  rwa [← ContinuousLinearMap.toLinearMap_neg] at h
+
+/-- The pointwise difference of two maps `J`-holomorphic within a set is `J`-holomorphic
+within it. -/
+lemma IsJHolomorphicWithinAt.sub {f g : V → W} {s : Set V} {x : V}
+    (hf : IsJHolomorphicWithinAt J J' f s x) (hg : IsJHolomorphicWithinAt J J' g s x) :
+    IsJHolomorphicWithinAt J J' (f - g) s x := by
+  refine ⟨hf.choose - hg.choose, hf.hasFDerivWithinAt.sub hg.hasFDerivWithinAt, ?_⟩
+  have h := hf.derivative_isComplexLinear.sub hg.derivative_isComplexLinear
+  rwa [← ContinuousLinearMap.toLinearMap_sub] at h
+
+/-- A real scalar multiple of a map `J`-holomorphic within a set is `J`-holomorphic within
+it. -/
+lemma IsJHolomorphicWithinAt.const_smul {f : V → W} {s : Set V} {x : V}
+    (hf : IsJHolomorphicWithinAt J J' f s x) (c : ℝ) :
+    IsJHolomorphicWithinAt J J' (c • f) s x := by
+  refine ⟨c • hf.choose, hf.hasFDerivWithinAt.const_smul c, ?_⟩
+  have h := hf.derivative_isComplexLinear.smul c
+  rwa [← ContinuousLinearMap.toLinearMap_smul] at h
+
+/-- The pointwise sum of two maps `J`-holomorphic on a set is `J`-holomorphic on it. -/
+lemma IsJHolomorphicOn.add {f g : V → W} {s : Set V}
+    (hf : IsJHolomorphicOn J J' f s) (hg : IsJHolomorphicOn J J' g s) :
+    IsJHolomorphicOn J J' (f + g) s :=
+  fun x hx => (hf x hx).add (hg x hx)
+
+/-- The pointwise negation of a map `J`-holomorphic on a set is `J`-holomorphic on it. -/
+lemma IsJHolomorphicOn.neg {f : V → W} {s : Set V} (hf : IsJHolomorphicOn J J' f s) :
+    IsJHolomorphicOn J J' (-f) s :=
+  fun x hx => (hf x hx).neg
+
+/-- The pointwise difference of two maps `J`-holomorphic on a set is `J`-holomorphic on it. -/
+lemma IsJHolomorphicOn.sub {f g : V → W} {s : Set V}
+    (hf : IsJHolomorphicOn J J' f s) (hg : IsJHolomorphicOn J J' g s) :
+    IsJHolomorphicOn J J' (f - g) s :=
+  fun x hx => (hf x hx).sub (hg x hx)
+
+/-- A real scalar multiple of a map `J`-holomorphic on a set is `J`-holomorphic on it. -/
+lemma IsJHolomorphicOn.const_smul {f : V → W} {s : Set V} (hf : IsJHolomorphicOn J J' f s)
+    (c : ℝ) : IsJHolomorphicOn J J' (c • f) s :=
+  fun x hx => (hf x hx).const_smul c
+
+/-- The pointwise sum of two globally `J`-holomorphic maps is `J`-holomorphic. -/
+lemma IsJHolomorphic.add {f g : V → W}
+    (hf : IsJHolomorphic J J' f) (hg : IsJHolomorphic J J' g) :
+    IsJHolomorphic J J' (f + g) :=
+  fun x => (hf x).add (hg x)
+
+/-- The pointwise negation of a globally `J`-holomorphic map is `J`-holomorphic. -/
+lemma IsJHolomorphic.neg {f : V → W} (hf : IsJHolomorphic J J' f) :
+    IsJHolomorphic J J' (-f) :=
+  fun x => (hf x).neg
+
+/-- The pointwise difference of two globally `J`-holomorphic maps is `J`-holomorphic. -/
+lemma IsJHolomorphic.sub {f g : V → W}
+    (hf : IsJHolomorphic J J' f) (hg : IsJHolomorphic J J' g) :
+    IsJHolomorphic J J' (f - g) :=
+  fun x => (hf x).sub (hg x)
+
+/-- A real scalar multiple of a globally `J`-holomorphic map is `J`-holomorphic. -/
+lemma IsJHolomorphic.const_smul {f : V → W} (hf : IsJHolomorphic J J' f) (c : ℝ) :
+    IsJHolomorphic J J' (c • f) :=
+  fun x => (hf x).const_smul c
+
+end LinearStructure
 
 end TauCeti

--- a/TauCeti/Geometry/Symplectic/JHolomorphic.lean
+++ b/TauCeti/Geometry/Symplectic/JHolomorphic.lean
@@ -330,16 +330,18 @@ lemma IsJHolomorphicAt.add {f g : V → W} {x : V}
   refine ⟨hf.choose + hg.choose, hf.hasFDerivAt.add hg.hasFDerivAt, ?_⟩
   have hF : IsComplexLinearMap J J' hf.choose.toLinearMap := hf.derivative_isComplexLinear
   have hG : IsComplexLinearMap J J' hg.choose.toLinearMap := hg.derivative_isComplexLinear
-  have h := IsComplexLinearMap.add hF hG
-  rwa [← ContinuousLinearMap.toLinearMap_add] at h
+  rw [isComplexLinearMap_iff_mem_complexLinearMaps, ContinuousLinearMap.toLinearMap_add]
+  rw [isComplexLinearMap_iff_mem_complexLinearMaps] at hF hG
+  exact (complexLinearMaps J.toLinearMap J'.toLinearMap).add_mem hF hG
 
 /-- The pointwise negation of a `J`-holomorphic map is `J`-holomorphic. -/
 lemma IsJHolomorphicAt.neg {f : V → W} {x : V} (hf : IsJHolomorphicAt J J' f x) :
     IsJHolomorphicAt J J' (-f) x := by
   refine ⟨-hf.choose, hf.hasFDerivAt.neg, ?_⟩
   have hF : IsComplexLinearMap J J' hf.choose.toLinearMap := hf.derivative_isComplexLinear
-  have h := IsComplexLinearMap.neg hF
-  rwa [← ContinuousLinearMap.toLinearMap_neg] at h
+  rw [isComplexLinearMap_iff_mem_complexLinearMaps, ContinuousLinearMap.toLinearMap_neg]
+  rw [isComplexLinearMap_iff_mem_complexLinearMaps] at hF
+  exact (complexLinearMaps J.toLinearMap J'.toLinearMap).neg_mem hF
 
 /-- The pointwise difference of two `J`-holomorphic maps is `J`-holomorphic. -/
 lemma IsJHolomorphicAt.sub {f g : V → W} {x : V}
@@ -348,16 +350,18 @@ lemma IsJHolomorphicAt.sub {f g : V → W} {x : V}
   refine ⟨hf.choose - hg.choose, hf.hasFDerivAt.sub hg.hasFDerivAt, ?_⟩
   have hF : IsComplexLinearMap J J' hf.choose.toLinearMap := hf.derivative_isComplexLinear
   have hG : IsComplexLinearMap J J' hg.choose.toLinearMap := hg.derivative_isComplexLinear
-  have h := IsComplexLinearMap.sub hF hG
-  rwa [← ContinuousLinearMap.toLinearMap_sub] at h
+  rw [isComplexLinearMap_iff_mem_complexLinearMaps, ContinuousLinearMap.toLinearMap_sub]
+  rw [isComplexLinearMap_iff_mem_complexLinearMaps] at hF hG
+  exact (complexLinearMaps J.toLinearMap J'.toLinearMap).sub_mem hF hG
 
 /-- A real scalar multiple of a `J`-holomorphic map is `J`-holomorphic. -/
 lemma IsJHolomorphicAt.const_smul {f : V → W} {x : V} (hf : IsJHolomorphicAt J J' f x)
     (c : ℝ) : IsJHolomorphicAt J J' (c • f) x := by
   refine ⟨c • hf.choose, hf.hasFDerivAt.const_smul c, ?_⟩
   have hF : IsComplexLinearMap J J' hf.choose.toLinearMap := hf.derivative_isComplexLinear
-  have h := IsComplexLinearMap.smul hF c
-  rwa [← ContinuousLinearMap.toLinearMap_smul] at h
+  rw [isComplexLinearMap_iff_mem_complexLinearMaps, ContinuousLinearMap.toLinearMap_smul]
+  rw [isComplexLinearMap_iff_mem_complexLinearMaps] at hF
+  exact (complexLinearMaps J.toLinearMap J'.toLinearMap).smul_mem c hF
 
 /-- The pointwise sum of two maps `J`-holomorphic within a set is `J`-holomorphic within it. -/
 lemma IsJHolomorphicWithinAt.add {f g : V → W} {s : Set V} {x : V}
@@ -366,8 +370,9 @@ lemma IsJHolomorphicWithinAt.add {f g : V → W} {s : Set V} {x : V}
   refine ⟨hf.choose + hg.choose, hf.hasFDerivWithinAt.add hg.hasFDerivWithinAt, ?_⟩
   have hF : IsComplexLinearMap J J' hf.choose.toLinearMap := hf.derivative_isComplexLinear
   have hG : IsComplexLinearMap J J' hg.choose.toLinearMap := hg.derivative_isComplexLinear
-  have h := IsComplexLinearMap.add hF hG
-  rwa [← ContinuousLinearMap.toLinearMap_add] at h
+  rw [isComplexLinearMap_iff_mem_complexLinearMaps, ContinuousLinearMap.toLinearMap_add]
+  rw [isComplexLinearMap_iff_mem_complexLinearMaps] at hF hG
+  exact (complexLinearMaps J.toLinearMap J'.toLinearMap).add_mem hF hG
 
 /-- The pointwise negation of a map `J`-holomorphic within a set is `J`-holomorphic within it. -/
 lemma IsJHolomorphicWithinAt.neg {f : V → W} {s : Set V} {x : V}
@@ -375,8 +380,9 @@ lemma IsJHolomorphicWithinAt.neg {f : V → W} {s : Set V} {x : V}
     IsJHolomorphicWithinAt J J' (-f) s x := by
   refine ⟨-hf.choose, hf.hasFDerivWithinAt.neg, ?_⟩
   have hF : IsComplexLinearMap J J' hf.choose.toLinearMap := hf.derivative_isComplexLinear
-  have h := IsComplexLinearMap.neg hF
-  rwa [← ContinuousLinearMap.toLinearMap_neg] at h
+  rw [isComplexLinearMap_iff_mem_complexLinearMaps, ContinuousLinearMap.toLinearMap_neg]
+  rw [isComplexLinearMap_iff_mem_complexLinearMaps] at hF
+  exact (complexLinearMaps J.toLinearMap J'.toLinearMap).neg_mem hF
 
 /-- The pointwise difference of two maps `J`-holomorphic within a set is `J`-holomorphic
 within it. -/
@@ -386,8 +392,9 @@ lemma IsJHolomorphicWithinAt.sub {f g : V → W} {s : Set V} {x : V}
   refine ⟨hf.choose - hg.choose, hf.hasFDerivWithinAt.sub hg.hasFDerivWithinAt, ?_⟩
   have hF : IsComplexLinearMap J J' hf.choose.toLinearMap := hf.derivative_isComplexLinear
   have hG : IsComplexLinearMap J J' hg.choose.toLinearMap := hg.derivative_isComplexLinear
-  have h := IsComplexLinearMap.sub hF hG
-  rwa [← ContinuousLinearMap.toLinearMap_sub] at h
+  rw [isComplexLinearMap_iff_mem_complexLinearMaps, ContinuousLinearMap.toLinearMap_sub]
+  rw [isComplexLinearMap_iff_mem_complexLinearMaps] at hF hG
+  exact (complexLinearMaps J.toLinearMap J'.toLinearMap).sub_mem hF hG
 
 /-- A real scalar multiple of a map `J`-holomorphic within a set is `J`-holomorphic within
 it. -/
@@ -396,8 +403,9 @@ lemma IsJHolomorphicWithinAt.const_smul {f : V → W} {s : Set V} {x : V}
     IsJHolomorphicWithinAt J J' (c • f) s x := by
   refine ⟨c • hf.choose, hf.hasFDerivWithinAt.const_smul c, ?_⟩
   have hF : IsComplexLinearMap J J' hf.choose.toLinearMap := hf.derivative_isComplexLinear
-  have h := IsComplexLinearMap.smul hF c
-  rwa [← ContinuousLinearMap.toLinearMap_smul] at h
+  rw [isComplexLinearMap_iff_mem_complexLinearMaps, ContinuousLinearMap.toLinearMap_smul]
+  rw [isComplexLinearMap_iff_mem_complexLinearMaps] at hF
+  exact (complexLinearMaps J.toLinearMap J'.toLinearMap).smul_mem c hF
 
 /-- The pointwise sum of two maps `J`-holomorphic on a set is `J`-holomorphic on it. -/
 lemma IsJHolomorphicOn.add {f g : V → W} {s : Set V}

--- a/TauCeti/Geometry/Symplectic/JHolomorphic.lean
+++ b/TauCeti/Geometry/Symplectic/JHolomorphic.lean
@@ -328,61 +328,46 @@ lemma IsJHolomorphicAt.add {f g : V → W} {x : V}
     (hf : IsJHolomorphicAt J J' f x) (hg : IsJHolomorphicAt J J' g x) :
     IsJHolomorphicAt J J' (f + g) x := by
   refine ⟨hf.choose + hg.choose, hf.hasFDerivAt.add hg.hasFDerivAt, ?_⟩
-  have hF : IsComplexLinearMap J J' hf.choose.toLinearMap := hf.derivative_isComplexLinear
-  have hG : IsComplexLinearMap J J' hg.choose.toLinearMap := hg.derivative_isComplexLinear
-  rw [isComplexLinearMap_iff_mem_complexLinearMaps, ContinuousLinearMap.toLinearMap_add]
-  rw [isComplexLinearMap_iff_mem_complexLinearMaps] at hF hG
-  exact (complexLinearMaps J.toLinearMap J'.toLinearMap).add_mem hF hG
+  rw [ContinuousLinearMap.toLinearMap_add]
+  exact hf.derivative_isComplexLinear.add hg.derivative_isComplexLinear
 
 /-- The pointwise negation of a `J`-holomorphic map is `J`-holomorphic. -/
 lemma IsJHolomorphicAt.neg {f : V → W} {x : V} (hf : IsJHolomorphicAt J J' f x) :
     IsJHolomorphicAt J J' (-f) x := by
   refine ⟨-hf.choose, hf.hasFDerivAt.neg, ?_⟩
-  have hF : IsComplexLinearMap J J' hf.choose.toLinearMap := hf.derivative_isComplexLinear
-  rw [isComplexLinearMap_iff_mem_complexLinearMaps, ContinuousLinearMap.toLinearMap_neg]
-  rw [isComplexLinearMap_iff_mem_complexLinearMaps] at hF
-  exact (complexLinearMaps J.toLinearMap J'.toLinearMap).neg_mem hF
+  rw [ContinuousLinearMap.toLinearMap_neg]
+  exact hf.derivative_isComplexLinear.neg
 
 /-- The pointwise difference of two `J`-holomorphic maps is `J`-holomorphic. -/
 lemma IsJHolomorphicAt.sub {f g : V → W} {x : V}
     (hf : IsJHolomorphicAt J J' f x) (hg : IsJHolomorphicAt J J' g x) :
     IsJHolomorphicAt J J' (f - g) x := by
   refine ⟨hf.choose - hg.choose, hf.hasFDerivAt.sub hg.hasFDerivAt, ?_⟩
-  have hF : IsComplexLinearMap J J' hf.choose.toLinearMap := hf.derivative_isComplexLinear
-  have hG : IsComplexLinearMap J J' hg.choose.toLinearMap := hg.derivative_isComplexLinear
-  rw [isComplexLinearMap_iff_mem_complexLinearMaps, ContinuousLinearMap.toLinearMap_sub]
-  rw [isComplexLinearMap_iff_mem_complexLinearMaps] at hF hG
-  exact (complexLinearMaps J.toLinearMap J'.toLinearMap).sub_mem hF hG
+  rw [ContinuousLinearMap.toLinearMap_sub]
+  exact hf.derivative_isComplexLinear.sub hg.derivative_isComplexLinear
 
 /-- A real scalar multiple of a `J`-holomorphic map is `J`-holomorphic. -/
 lemma IsJHolomorphicAt.const_smul {f : V → W} {x : V} (hf : IsJHolomorphicAt J J' f x)
     (c : ℝ) : IsJHolomorphicAt J J' (c • f) x := by
   refine ⟨c • hf.choose, hf.hasFDerivAt.const_smul c, ?_⟩
-  have hF : IsComplexLinearMap J J' hf.choose.toLinearMap := hf.derivative_isComplexLinear
-  rw [isComplexLinearMap_iff_mem_complexLinearMaps, ContinuousLinearMap.toLinearMap_smul]
-  rw [isComplexLinearMap_iff_mem_complexLinearMaps] at hF
-  exact (complexLinearMaps J.toLinearMap J'.toLinearMap).smul_mem c hF
+  rw [ContinuousLinearMap.toLinearMap_smul]
+  exact hf.derivative_isComplexLinear.smul c
 
 /-- The pointwise sum of two maps `J`-holomorphic within a set is `J`-holomorphic within it. -/
 lemma IsJHolomorphicWithinAt.add {f g : V → W} {s : Set V} {x : V}
     (hf : IsJHolomorphicWithinAt J J' f s x) (hg : IsJHolomorphicWithinAt J J' g s x) :
     IsJHolomorphicWithinAt J J' (f + g) s x := by
   refine ⟨hf.choose + hg.choose, hf.hasFDerivWithinAt.add hg.hasFDerivWithinAt, ?_⟩
-  have hF : IsComplexLinearMap J J' hf.choose.toLinearMap := hf.derivative_isComplexLinear
-  have hG : IsComplexLinearMap J J' hg.choose.toLinearMap := hg.derivative_isComplexLinear
-  rw [isComplexLinearMap_iff_mem_complexLinearMaps, ContinuousLinearMap.toLinearMap_add]
-  rw [isComplexLinearMap_iff_mem_complexLinearMaps] at hF hG
-  exact (complexLinearMaps J.toLinearMap J'.toLinearMap).add_mem hF hG
+  rw [ContinuousLinearMap.toLinearMap_add]
+  exact hf.derivative_isComplexLinear.add hg.derivative_isComplexLinear
 
 /-- The pointwise negation of a map `J`-holomorphic within a set is `J`-holomorphic within it. -/
 lemma IsJHolomorphicWithinAt.neg {f : V → W} {s : Set V} {x : V}
     (hf : IsJHolomorphicWithinAt J J' f s x) :
     IsJHolomorphicWithinAt J J' (-f) s x := by
   refine ⟨-hf.choose, hf.hasFDerivWithinAt.neg, ?_⟩
-  have hF : IsComplexLinearMap J J' hf.choose.toLinearMap := hf.derivative_isComplexLinear
-  rw [isComplexLinearMap_iff_mem_complexLinearMaps, ContinuousLinearMap.toLinearMap_neg]
-  rw [isComplexLinearMap_iff_mem_complexLinearMaps] at hF
-  exact (complexLinearMaps J.toLinearMap J'.toLinearMap).neg_mem hF
+  rw [ContinuousLinearMap.toLinearMap_neg]
+  exact hf.derivative_isComplexLinear.neg
 
 /-- The pointwise difference of two maps `J`-holomorphic within a set is `J`-holomorphic
 within it. -/
@@ -390,11 +375,8 @@ lemma IsJHolomorphicWithinAt.sub {f g : V → W} {s : Set V} {x : V}
     (hf : IsJHolomorphicWithinAt J J' f s x) (hg : IsJHolomorphicWithinAt J J' g s x) :
     IsJHolomorphicWithinAt J J' (f - g) s x := by
   refine ⟨hf.choose - hg.choose, hf.hasFDerivWithinAt.sub hg.hasFDerivWithinAt, ?_⟩
-  have hF : IsComplexLinearMap J J' hf.choose.toLinearMap := hf.derivative_isComplexLinear
-  have hG : IsComplexLinearMap J J' hg.choose.toLinearMap := hg.derivative_isComplexLinear
-  rw [isComplexLinearMap_iff_mem_complexLinearMaps, ContinuousLinearMap.toLinearMap_sub]
-  rw [isComplexLinearMap_iff_mem_complexLinearMaps] at hF hG
-  exact (complexLinearMaps J.toLinearMap J'.toLinearMap).sub_mem hF hG
+  rw [ContinuousLinearMap.toLinearMap_sub]
+  exact hf.derivative_isComplexLinear.sub hg.derivative_isComplexLinear
 
 /-- A real scalar multiple of a map `J`-holomorphic within a set is `J`-holomorphic within
 it. -/
@@ -402,10 +384,8 @@ lemma IsJHolomorphicWithinAt.const_smul {f : V → W} {s : Set V} {x : V}
     (hf : IsJHolomorphicWithinAt J J' f s x) (c : ℝ) :
     IsJHolomorphicWithinAt J J' (c • f) s x := by
   refine ⟨c • hf.choose, hf.hasFDerivWithinAt.const_smul c, ?_⟩
-  have hF : IsComplexLinearMap J J' hf.choose.toLinearMap := hf.derivative_isComplexLinear
-  rw [isComplexLinearMap_iff_mem_complexLinearMaps, ContinuousLinearMap.toLinearMap_smul]
-  rw [isComplexLinearMap_iff_mem_complexLinearMaps] at hF
-  exact (complexLinearMaps J.toLinearMap J'.toLinearMap).smul_mem c hF
+  rw [ContinuousLinearMap.toLinearMap_smul]
+  exact hf.derivative_isComplexLinear.smul c
 
 /-- The pointwise sum of two maps `J`-holomorphic on a set is `J`-holomorphic on it. -/
 lemma IsJHolomorphicOn.add {f g : V → W} {s : Set V}

--- a/TauCeti/Geometry/Symplectic/JHolomorphic.lean
+++ b/TauCeti/Geometry/Symplectic/JHolomorphic.lean
@@ -328,14 +328,17 @@ lemma IsJHolomorphicAt.add {f g : V → W} {x : V}
     (hf : IsJHolomorphicAt J J' f x) (hg : IsJHolomorphicAt J J' g x) :
     IsJHolomorphicAt J J' (f + g) x := by
   refine ⟨hf.choose + hg.choose, hf.hasFDerivAt.add hg.hasFDerivAt, ?_⟩
-  have h := hf.derivative_isComplexLinear.add hg.derivative_isComplexLinear
+  have hF : IsComplexLinearMap J J' hf.choose.toLinearMap := hf.derivative_isComplexLinear
+  have hG : IsComplexLinearMap J J' hg.choose.toLinearMap := hg.derivative_isComplexLinear
+  have h := IsComplexLinearMap.add hF hG
   rwa [← ContinuousLinearMap.toLinearMap_add] at h
 
 /-- The pointwise negation of a `J`-holomorphic map is `J`-holomorphic. -/
 lemma IsJHolomorphicAt.neg {f : V → W} {x : V} (hf : IsJHolomorphicAt J J' f x) :
     IsJHolomorphicAt J J' (-f) x := by
   refine ⟨-hf.choose, hf.hasFDerivAt.neg, ?_⟩
-  have h := hf.derivative_isComplexLinear.neg
+  have hF : IsComplexLinearMap J J' hf.choose.toLinearMap := hf.derivative_isComplexLinear
+  have h := IsComplexLinearMap.neg hF
   rwa [← ContinuousLinearMap.toLinearMap_neg] at h
 
 /-- The pointwise difference of two `J`-holomorphic maps is `J`-holomorphic. -/
@@ -343,14 +346,17 @@ lemma IsJHolomorphicAt.sub {f g : V → W} {x : V}
     (hf : IsJHolomorphicAt J J' f x) (hg : IsJHolomorphicAt J J' g x) :
     IsJHolomorphicAt J J' (f - g) x := by
   refine ⟨hf.choose - hg.choose, hf.hasFDerivAt.sub hg.hasFDerivAt, ?_⟩
-  have h := hf.derivative_isComplexLinear.sub hg.derivative_isComplexLinear
+  have hF : IsComplexLinearMap J J' hf.choose.toLinearMap := hf.derivative_isComplexLinear
+  have hG : IsComplexLinearMap J J' hg.choose.toLinearMap := hg.derivative_isComplexLinear
+  have h := IsComplexLinearMap.sub hF hG
   rwa [← ContinuousLinearMap.toLinearMap_sub] at h
 
 /-- A real scalar multiple of a `J`-holomorphic map is `J`-holomorphic. -/
 lemma IsJHolomorphicAt.const_smul {f : V → W} {x : V} (hf : IsJHolomorphicAt J J' f x)
     (c : ℝ) : IsJHolomorphicAt J J' (c • f) x := by
   refine ⟨c • hf.choose, hf.hasFDerivAt.const_smul c, ?_⟩
-  have h := hf.derivative_isComplexLinear.smul c
+  have hF : IsComplexLinearMap J J' hf.choose.toLinearMap := hf.derivative_isComplexLinear
+  have h := IsComplexLinearMap.smul hF c
   rwa [← ContinuousLinearMap.toLinearMap_smul] at h
 
 /-- The pointwise sum of two maps `J`-holomorphic within a set is `J`-holomorphic within it. -/
@@ -358,7 +364,9 @@ lemma IsJHolomorphicWithinAt.add {f g : V → W} {s : Set V} {x : V}
     (hf : IsJHolomorphicWithinAt J J' f s x) (hg : IsJHolomorphicWithinAt J J' g s x) :
     IsJHolomorphicWithinAt J J' (f + g) s x := by
   refine ⟨hf.choose + hg.choose, hf.hasFDerivWithinAt.add hg.hasFDerivWithinAt, ?_⟩
-  have h := hf.derivative_isComplexLinear.add hg.derivative_isComplexLinear
+  have hF : IsComplexLinearMap J J' hf.choose.toLinearMap := hf.derivative_isComplexLinear
+  have hG : IsComplexLinearMap J J' hg.choose.toLinearMap := hg.derivative_isComplexLinear
+  have h := IsComplexLinearMap.add hF hG
   rwa [← ContinuousLinearMap.toLinearMap_add] at h
 
 /-- The pointwise negation of a map `J`-holomorphic within a set is `J`-holomorphic within it. -/
@@ -366,7 +374,8 @@ lemma IsJHolomorphicWithinAt.neg {f : V → W} {s : Set V} {x : V}
     (hf : IsJHolomorphicWithinAt J J' f s x) :
     IsJHolomorphicWithinAt J J' (-f) s x := by
   refine ⟨-hf.choose, hf.hasFDerivWithinAt.neg, ?_⟩
-  have h := hf.derivative_isComplexLinear.neg
+  have hF : IsComplexLinearMap J J' hf.choose.toLinearMap := hf.derivative_isComplexLinear
+  have h := IsComplexLinearMap.neg hF
   rwa [← ContinuousLinearMap.toLinearMap_neg] at h
 
 /-- The pointwise difference of two maps `J`-holomorphic within a set is `J`-holomorphic
@@ -375,7 +384,9 @@ lemma IsJHolomorphicWithinAt.sub {f g : V → W} {s : Set V} {x : V}
     (hf : IsJHolomorphicWithinAt J J' f s x) (hg : IsJHolomorphicWithinAt J J' g s x) :
     IsJHolomorphicWithinAt J J' (f - g) s x := by
   refine ⟨hf.choose - hg.choose, hf.hasFDerivWithinAt.sub hg.hasFDerivWithinAt, ?_⟩
-  have h := hf.derivative_isComplexLinear.sub hg.derivative_isComplexLinear
+  have hF : IsComplexLinearMap J J' hf.choose.toLinearMap := hf.derivative_isComplexLinear
+  have hG : IsComplexLinearMap J J' hg.choose.toLinearMap := hg.derivative_isComplexLinear
+  have h := IsComplexLinearMap.sub hF hG
   rwa [← ContinuousLinearMap.toLinearMap_sub] at h
 
 /-- A real scalar multiple of a map `J`-holomorphic within a set is `J`-holomorphic within
@@ -384,7 +395,8 @@ lemma IsJHolomorphicWithinAt.const_smul {f : V → W} {s : Set V} {x : V}
     (hf : IsJHolomorphicWithinAt J J' f s x) (c : ℝ) :
     IsJHolomorphicWithinAt J J' (c • f) s x := by
   refine ⟨c • hf.choose, hf.hasFDerivWithinAt.const_smul c, ?_⟩
-  have h := hf.derivative_isComplexLinear.smul c
+  have hF : IsComplexLinearMap J J' hf.choose.toLinearMap := hf.derivative_isComplexLinear
+  have h := IsComplexLinearMap.smul hF c
   rwa [← ContinuousLinearMap.toLinearMap_smul] at h
 
 /-- The pointwise sum of two maps `J`-holomorphic on a set is `J`-holomorphic on it. -/


### PR DESCRIPTION
This PR develops the real-linear structure of pointwise `J`-holomorphic maps between real normed spaces. The Cauchy--Riemann condition `df ∘ J = J' ∘ df` is real-linear in the derivative, so a continuous real-linear map is `J`-holomorphic exactly when it is complex-linear (`isJHolomorphicAt_continuousLinearMap_iff` and its global form), and `J`-holomorphic maps are closed under pointwise sums, negations, differences, and real scalar multiples (`IsJHolomorphicAt.add`/`neg`/`sub`/`const_smul`, together with the within-set, setwise, and global analogues). Alongside these it records the matching closure lemmas for `IsComplexLinearMap` itself (`add`, `neg`, `sub`, `smul`), placed next to that definition in `AlmostComplex.lean`, since they are the linear backbone the map-level results consume.

This advances `TauCetiRoadmap/HeegaardFloer/README.md`, Lane F2.1 ("Definitions land immediately ... almost complex structures, tame/compatible `J`, symplectic manifolds, `J`-holomorphic maps, energy"), by completing the basic calculus of the merged `J`-holomorphic predicates (#232) with their interaction with the real-vector-space operations on maps. The complex-linear/J-holomorphic dictionary is exactly the statement that the linearized `∂̄` operator is real-linear, and the linear-map characterization gives the first non-constant `J`-holomorphic examples; both are routinely used when manipulating Floer trajectories and continuation maps later in the tower. It builds only on merged work (`AlmostComplexStructure` and `IsComplexLinearMap` from #228, the `J`-holomorphic predicates from #232) and is distinct from the open transport (#235), complex-module (#233), and totally-real (#229) work.

<!--tauceti-target:v1 {"focus":"HeegaardFloer","id":"jholomorphic-linear-maps"}-->

No Mathlib infrastructure is vendored. The proofs reuse Mathlib's `HasFDerivAt.add`/`neg`/`sub`/`const_smul` and their within-set forms, `ContinuousLinearMap.hasFDerivAt`, `HasFDerivAt.unique`, and the `ContinuousLinearMap.toLinearMap_add`/`neg`/`sub`/`smul` coercion lemmas, together with TauCeti's `AlmostComplexStructure`, `IsComplexLinearMap`, and `IsJHolomorphic*`. I checked the pinned Mathlib and TauCeti sources for any `J`-holomorphic or almost-complex calculus layer and found none in Mathlib (the whole notion is TauCeti-only), and confirmed the existing `complexLinearMaps` subspace in `ComplexLinearPart.lean` is built on the separate `IsComplexLinear` predicate, not the `IsComplexLinearMap` notion these lemmas concern.

Verification: `lake build` completed with `Build completed successfully (3853 jobs).`; `lake exe axioms` completed with `axioms: audited 2646 TauCeti declaration(s); all within the allowlist [propext, Classical.choice, Quot.sound].`

🤖 Prepared with Claude Code
