### PR TITLE
fix(Symplectic): remove duplicate isComplexLinearMap_iff_isComplexLinear

### DIFF
--- a/TauCeti/Geometry/Symplectic/AlmostComplex.lean
+++ b/TauCeti/Geometry/Symplectic/AlmostComplex.lean
@@ -175,13 +175,6 @@ lemma isComplexLinearMap_iff_apply (J : AlmostComplexStructure V)
     IsComplexLinearMap J J' F ↔ ∀ v, F (J v) = J' (F v) :=
   LinearMap.ext_iff
 
-/-- The almost-complex wrapper predicate is the raw-linear complex-linearity predicate applied
-to the underlying linear maps. -/
-lemma isComplexLinearMap_iff_isComplexLinear (J : AlmostComplexStructure V)
-    (J' : AlmostComplexStructure W) (F : V →ₗ[ℝ] W) :
-    IsComplexLinearMap J J' F ↔ IsComplexLinear J.toLinearMap J'.toLinearMap F :=
-  Iff.rfl
-
 /-- Complex-linearity for almost complex structures is membership in the existing submodule of
 raw-linear complex-linear maps. -/
 lemma isComplexLinearMap_iff_mem_complexLinearMaps (J : AlmostComplexStructure V)


### PR DESCRIPTION
## What

`AlmostComplex.lean` declared `isComplexLinearMap_iff_isComplexLinear` **twice** — byte-identical statement and proof (`:= Iff.rfl`). This is a merge artifact (around the recent symplectic merges #235/#236) that **breaks the build**:

```
'isComplexLinearMap_iff_isComplexLinear' has already been declared
```

so `main` is currently red (it also cascades to `JHolomorphic`/`Transport`/`StandardCompatible`). This removes the second copy.

## Scope

A single-topic build fix for the HeegaardFloer / symplectic roadmap material. The surviving lemma sits in its natural position immediately after `def IsComplexLinearMap`, and its consumer `isComplexLinearMap_iff_mem_complexLinearMaps` (which `rw`s it) is unaffected.

CI verified locally: `lake build` (3854 jobs) and `lake exe axioms` (2670 declarations, allowlist only) both pass with the duplicate removed.
