### PR TITLE
feat: add base-change points naturality

### DIFF
--- a/TauCeti/Algebra/AlgebraicGroup/BaseChangeNaturality.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/BaseChangeNaturality.lean
@@ -73,6 +73,8 @@ lemma baseChangePointsMulEquiv_symm_mapValue (φ : R →ₐ[K] S)
       mapValue (H := A) (φ.restrictScalars k)
         ((baseChangePointsMulEquiv (k := k) (K := K) (A := A) (R := R)).symm f) := by
   ext a
+  simp only [baseChangePointsMulEquiv_symm_apply, mapValue_apply, AlgHom.coe_comp,
+    Function.comp_apply]
   rfl
 
 end MapValue
@@ -80,7 +82,7 @@ end MapValue
 section MapDomain
 
 variable {k K A B R : Type*} [CommSemiring k] [CommSemiring K] [Algebra k K]
-variable [CommSemiring A] [CommSemiring B] [_root_.Bialgebra k A] [_root_.Bialgebra k B]
+variable [CommSemiring A] [Semiring B] [_root_.Bialgebra k A] [_root_.Bialgebra k B]
 variable [CommSemiring R] [Algebra K R] [Algebra k R] [IsScalarTower k K R]
 
 /-- Base change of points is natural in the coordinate bialgebra.
@@ -105,8 +107,8 @@ lemma baseChangePointsMulEquiv_mapDomain_apply_tmul (φ : A →ₐc[k] B)
     (f : WithConv (B →ₐ[k] R)) (s : K) (a : A) :
     baseChangePointsMulEquiv (k := k) (K := K) (A := A) (R := R)
         (mapDomain (A := R) φ f) (s ⊗ₜ[k] a) =
-      s • f.ofConv (φ a) :=
-  rfl
+      s • f.ofConv (φ a) := by
+  rw [baseChangePointsMulEquiv_apply_tmul, mapDomain_apply_apply]
 
 /-- The inverse direction of base change is natural in the coordinate bialgebra.
 
@@ -121,7 +123,8 @@ lemma baseChangePointsMulEquiv_symm_mapDomain (φ : A →ₐc[k] B)
       mapDomain (A := R) φ
         ((baseChangePointsMulEquiv (k := k) (K := K) (A := B) (R := R)).symm f) := by
   ext a
-  rfl
+  simp only [baseChangePointsMulEquiv_symm_apply, mapDomain_apply_apply,
+    _root_.Bialgebra.TensorProduct.map_tmul, _root_.BialgHom.id_apply]
 
 /-- Pointwise form of `AlgHom.baseChangePointsMulEquiv_symm_mapDomain`. -/
 @[simp]
@@ -130,8 +133,9 @@ lemma baseChangePointsMulEquiv_symm_mapDomain_apply (φ : A →ₐc[k] B)
     ((baseChangePointsMulEquiv (k := k) (K := K) (A := A) (R := R)).symm
         (mapDomain (A := R)
           (_root_.Bialgebra.TensorProduct.map (_root_.BialgHom.id K K) φ) f)).ofConv a =
-      f.ofConv (1 ⊗ₜ[k] φ a) :=
-  rfl
+      f.ofConv (1 ⊗ₜ[k] φ a) := by
+  simp only [baseChangePointsMulEquiv_symm_apply, mapDomain_apply_apply,
+    _root_.Bialgebra.TensorProduct.map_tmul, _root_.BialgHom.id_apply]
 
 end MapDomain
 

--- a/TauCeti/Algebra/AlgebraicGroup/BaseChangeNaturality.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/BaseChangeNaturality.lean
@@ -20,8 +20,6 @@ behave naturally in both the value algebra and the coordinate Hopf algebra.
 
 ## Main declarations
 
-* `TauCeti.BialgHom.baseChange`: the scalar extension of a bialgebra morphism
-  `A →ₐc[k] B` to a `K`-bialgebra morphism `K ⊗[k] A →ₐc[K] K ⊗[k] B`.
 * `TauCeti.AlgHom.mapValue_baseChangePointsMulEquiv`: base change of points commutes with
   post-composition in the value algebra.
 * `TauCeti.AlgHom.baseChangePointsMulEquiv_mapDomain`: base change of points commutes with
@@ -39,35 +37,6 @@ This builds on Mathlib's tensor-product bialgebra map
 open TensorProduct WithConv
 
 namespace TauCeti
-
-namespace BialgHom
-
-variable {k K A B : Type*} [CommSemiring k] [CommSemiring K] [Algebra k K]
-variable [CommSemiring A] [CommSemiring B] [_root_.Bialgebra k A] [_root_.Bialgebra k B]
-
-/-- Scalar extension of a bialgebra morphism.
-
-For `φ : A →ₐc[k] B`, this is the `K`-bialgebra morphism
-`K ⊗[k] A →ₐc[K] K ⊗[k] B` given on pure tensors by `s ⊗ a ↦ s ⊗ φ a`. -/
-noncomputable abbrev baseChange (K : Type*) [CommSemiring K] [Algebra k K]
-    (φ : A →ₐc[k] B) : K ⊗[k] A →ₐc[K] K ⊗[k] B :=
-  _root_.Bialgebra.TensorProduct.map (BialgHom.id K K) φ
-
-/-- The base change of a bialgebra morphism sends `s ⊗ a` to `s ⊗ φ a`. -/
-@[simp]
-lemma baseChange_tmul (φ : A →ₐc[k] B) (s : K) (a : A) :
-    baseChange K φ (s ⊗ₜ[k] a) = s ⊗ₜ[k] φ a :=
-  rfl
-
-/-- The underlying algebra homomorphism of the base-changed bialgebra morphism is the
-tensor-product algebra map. -/
-@[simp]
-lemma baseChange_toAlgHom (φ : A →ₐc[k] B) :
-    (baseChange K φ : K ⊗[k] A →ₐ[K] K ⊗[k] B) =
-      Algebra.TensorProduct.map (AlgHom.id K K) (φ : A →ₐ[k] B) :=
-  rfl
-
-end BialgHom
 
 namespace AlgHom
 
@@ -124,7 +93,8 @@ lemma baseChangePointsMulEquiv_mapDomain (φ : A →ₐc[k] B)
     (f : WithConv (B →ₐ[k] R)) :
     baseChangePointsMulEquiv (k := k) (K := K) (A := A) (R := R)
         (mapDomain (A := R) φ f) =
-      mapDomain (A := R) (BialgHom.baseChange K φ)
+      mapDomain (A := R)
+        (_root_.Bialgebra.TensorProduct.map (_root_.BialgHom.id K K) φ)
         (baseChangePointsMulEquiv (k := k) (K := K) (A := B) (R := R) f) := by
   ext a
   simp [mapDomain_apply]
@@ -146,7 +116,8 @@ with first restricting and then pre-composing by `φ`. -/
 lemma baseChangePointsMulEquiv_symm_mapDomain (φ : A →ₐc[k] B)
     (f : WithConv (K ⊗[k] B →ₐ[K] R)) :
     (baseChangePointsMulEquiv (k := k) (K := K) (A := A) (R := R)).symm
-        (mapDomain (A := R) (BialgHom.baseChange K φ) f) =
+        (mapDomain (A := R)
+          (_root_.Bialgebra.TensorProduct.map (_root_.BialgHom.id K K) φ) f) =
       mapDomain (A := R) φ
         ((baseChangePointsMulEquiv (k := k) (K := K) (A := B) (R := R)).symm f) := by
   ext a
@@ -157,7 +128,8 @@ lemma baseChangePointsMulEquiv_symm_mapDomain (φ : A →ₐc[k] B)
 lemma baseChangePointsMulEquiv_symm_mapDomain_apply (φ : A →ₐc[k] B)
     (f : WithConv (K ⊗[k] B →ₐ[K] R)) (a : A) :
     ((baseChangePointsMulEquiv (k := k) (K := K) (A := A) (R := R)).symm
-        (mapDomain (A := R) (BialgHom.baseChange K φ) f)).ofConv a =
+        (mapDomain (A := R)
+          (_root_.Bialgebra.TensorProduct.map (_root_.BialgHom.id K K) φ) f)).ofConv a =
       f.ofConv (1 ⊗ₜ[k] φ a) :=
   rfl
 

--- a/TauCeti/Algebra/AlgebraicGroup/BaseChangeNaturality.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/BaseChangeNaturality.lean
@@ -1,0 +1,168 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+import TauCeti.Algebra.AlgebraicGroup.BaseChange
+import TauCeti.Algebra.AlgebraicGroup.HopfMap
+
+/-!
+# Naturality of base-changed points
+
+This file records the two naturality properties of
+`TauCeti.AlgHom.baseChangePointsMulEquiv`. Base-changing a bialgebra from `k` to `K`
+identifies `K`-algebra maps out of `K ⊗[k] A` with `k`-algebra maps out of `A`; this
+identification is compatible with post-composition in the value algebra and with
+pre-composition by morphisms of coordinate bialgebras.
+
+These lemmas are part of the ReductiveGroups roadmap Layer 0 base-change target: after the
+convolution group structure on points, the functor-of-points dictionary needs base change to
+behave naturally in both the value algebra and the coordinate Hopf algebra.
+
+## Main declarations
+
+* `TauCeti.BialgHom.baseChange`: the scalar extension of a bialgebra morphism
+  `A →ₐc[k] B` to a `K`-bialgebra morphism `K ⊗[k] A →ₐc[K] K ⊗[k] B`.
+* `TauCeti.AlgHom.mapValue_baseChangePointsMulEquiv`: base change of points commutes with
+  post-composition in the value algebra.
+* `TauCeti.AlgHom.baseChangePointsMulEquiv_mapDomain`: base change of points commutes with
+  pre-composition in the coordinate bialgebra.
+
+## References
+
+This builds on Mathlib's tensor-product bialgebra map
+`Bialgebra.TensorProduct.map`, Mathlib's algebra base-change adjunction
+`AlgHom.liftEquiv`, and the Tau Ceti convolution-points API in
+`TauCeti.Algebra.AlgebraicGroup.BaseChange` and
+`TauCeti.Algebra.AlgebraicGroup.HopfMap`.
+-/
+
+open TensorProduct WithConv
+
+namespace TauCeti
+
+namespace BialgHom
+
+variable {k K A B : Type*} [CommSemiring k] [CommSemiring K] [Algebra k K]
+variable [CommSemiring A] [CommSemiring B] [_root_.Bialgebra k A] [_root_.Bialgebra k B]
+
+/-- Scalar extension of a bialgebra morphism.
+
+For `φ : A →ₐc[k] B`, this is the `K`-bialgebra morphism
+`K ⊗[k] A →ₐc[K] K ⊗[k] B` given on pure tensors by `s ⊗ a ↦ s ⊗ φ a`. -/
+noncomputable abbrev baseChange (K : Type*) [CommSemiring K] [Algebra k K]
+    (φ : A →ₐc[k] B) : K ⊗[k] A →ₐc[K] K ⊗[k] B :=
+  _root_.Bialgebra.TensorProduct.map (BialgHom.id K K) φ
+
+/-- The base change of a bialgebra morphism sends `s ⊗ a` to `s ⊗ φ a`. -/
+@[simp]
+lemma baseChange_tmul (φ : A →ₐc[k] B) (s : K) (a : A) :
+    baseChange K φ (s ⊗ₜ[k] a) = s ⊗ₜ[k] φ a :=
+  rfl
+
+/-- The underlying algebra homomorphism of the base-changed bialgebra morphism is the
+tensor-product algebra map. -/
+@[simp]
+lemma baseChange_toAlgHom (φ : A →ₐc[k] B) :
+    (baseChange K φ : K ⊗[k] A →ₐ[K] K ⊗[k] B) =
+      Algebra.TensorProduct.map (AlgHom.id K K) (φ : A →ₐ[k] B) :=
+  rfl
+
+end BialgHom
+
+namespace AlgHom
+
+section MapValue
+
+variable {k K A R S : Type*} [CommSemiring k] [CommSemiring K] [Semiring A]
+variable [CommSemiring R] [CommSemiring S] [Algebra k K] [_root_.Bialgebra k A]
+variable [Algebra K R] [Algebra k R] [IsScalarTower k K R]
+variable [Algebra K S] [Algebra k S] [IsScalarTower k K S]
+
+/-- Base change of points is natural in the value algebra.
+
+Post-composing an `R`-valued point by a `K`-algebra homomorphism `φ : R →ₐ[K] S` and then
+base-changing agrees with first base-changing the point and then post-composing by `φ`. -/
+@[simp]
+lemma mapValue_baseChangePointsMulEquiv (φ : R →ₐ[K] S)
+    (f : WithConv (A →ₐ[k] R)) :
+    mapValue (H := K ⊗[k] A) φ
+        (baseChangePointsMulEquiv (k := k) (K := K) (A := A) (R := R) f) =
+      baseChangePointsMulEquiv (k := k) (K := K) (A := A) (R := S)
+        (mapValue (H := A) (φ.restrictScalars k) f) := by
+  ext a
+  simp [mapValue_apply]
+
+/-- The inverse direction of base change is natural in the value algebra.
+
+Restricting a post-composed base-changed point along `a ↦ 1 ⊗ a` agrees with
+post-composing the restricted point. -/
+@[simp]
+lemma baseChangePointsMulEquiv_symm_mapValue (φ : R →ₐ[K] S)
+    (f : WithConv (K ⊗[k] A →ₐ[K] R)) :
+    (baseChangePointsMulEquiv (k := k) (K := K) (A := A) (R := S)).symm
+        (mapValue (H := K ⊗[k] A) φ f) =
+      mapValue (H := A) (φ.restrictScalars k)
+        ((baseChangePointsMulEquiv (k := k) (K := K) (A := A) (R := R)).symm f) := by
+  ext a
+  rfl
+
+end MapValue
+
+section MapDomain
+
+variable {k K A B R : Type*} [CommSemiring k] [CommSemiring K] [Algebra k K]
+variable [CommSemiring A] [CommSemiring B] [_root_.Bialgebra k A] [_root_.Bialgebra k B]
+variable [CommSemiring R] [Algebra K R] [Algebra k R] [IsScalarTower k K R]
+
+/-- Base change of points is natural in the coordinate bialgebra.
+
+Pre-composing a `B`-point by a bialgebra morphism `φ : A →ₐc[k] B` and then base-changing
+agrees with first base-changing the point and then pre-composing by the scalar extension
+`K ⊗[k] A →ₐc[K] K ⊗[k] B`. -/
+@[simp]
+lemma baseChangePointsMulEquiv_mapDomain (φ : A →ₐc[k] B)
+    (f : WithConv (B →ₐ[k] R)) :
+    baseChangePointsMulEquiv (k := k) (K := K) (A := A) (R := R)
+        (mapDomain (A := R) φ f) =
+      mapDomain (A := R) (BialgHom.baseChange K φ)
+        (baseChangePointsMulEquiv (k := k) (K := K) (A := B) (R := R) f) := by
+  ext a
+  simp [mapDomain_apply]
+
+/-- Pointwise form of `AlgHom.baseChangePointsMulEquiv_mapDomain` on pure tensors. -/
+@[simp]
+lemma baseChangePointsMulEquiv_mapDomain_apply_tmul (φ : A →ₐc[k] B)
+    (f : WithConv (B →ₐ[k] R)) (s : K) (a : A) :
+    baseChangePointsMulEquiv (k := k) (K := K) (A := A) (R := R)
+        (mapDomain (A := R) φ f) (s ⊗ₜ[k] a) =
+      s • f.ofConv (φ a) :=
+  rfl
+
+/-- The inverse direction of base change is natural in the coordinate bialgebra.
+
+Restricting along `a ↦ 1 ⊗ a` after pre-composing with the scalar extension of `φ` agrees
+with first restricting and then pre-composing by `φ`. -/
+@[simp]
+lemma baseChangePointsMulEquiv_symm_mapDomain (φ : A →ₐc[k] B)
+    (f : WithConv (K ⊗[k] B →ₐ[K] R)) :
+    (baseChangePointsMulEquiv (k := k) (K := K) (A := A) (R := R)).symm
+        (mapDomain (A := R) (BialgHom.baseChange K φ) f) =
+      mapDomain (A := R) φ
+        ((baseChangePointsMulEquiv (k := k) (K := K) (A := B) (R := R)).symm f) := by
+  ext a
+  rfl
+
+/-- Pointwise form of `AlgHom.baseChangePointsMulEquiv_symm_mapDomain`. -/
+@[simp]
+lemma baseChangePointsMulEquiv_symm_mapDomain_apply (φ : A →ₐc[k] B)
+    (f : WithConv (K ⊗[k] B →ₐ[K] R)) (a : A) :
+    ((baseChangePointsMulEquiv (k := k) (K := K) (A := A) (R := R)).symm
+        (mapDomain (A := R) (BialgHom.baseChange K φ) f)).ofConv a =
+      f.ofConv (1 ⊗ₜ[k] φ a) :=
+  rfl
+
+end MapDomain
+
+end AlgHom
+
+end TauCeti


### PR DESCRIPTION
This PR adds naturality for the base-change equivalence on convolution points. It advances `TauCetiRoadmap/ReductiveGroups/README.md`, Layer 0, the item "Base change. `K ⊗[k] A` as a Hopf algebra over `K` (use `HopfAlgebra/TensorProduct.lean`)" and supports the preceding "R-points as a group" functor-of-points target by recording that the existing base-change identification commutes with post-composition in the value algebra and pre-composition in the coordinate bialgebra.

<!--tauceti-target:v1 {"focus":"ReductiveGroups","id":"base-change-points-naturality"}-->

No Mathlib infrastructure is vendored. The construction reuses Mathlib's `Bialgebra.TensorProduct.map` for scalar extension of bialgebra morphisms, `AlgHom.liftEquiv` through TauCeti's existing `AlgHom.baseChangePointsMulEquiv`, and TauCeti's convolution functoriality APIs `AlgHom.mapValue` and `AlgHom.mapDomain`. I checked the pinned Mathlib and TauCeti sources for existing base-change points naturality, `baseChangePointsMulEquiv` naturality lemmas, and scalar-extension bialgebra morphism APIs with these statements and found no duplicate.

Verification: `lake exe cache get` completed with `No files to download` and `Already decompressed 8555 file(s)`; `lake build` completed with `Build completed successfully (3857 jobs).`; `lake exe axioms` completed with `axioms: audited 2750 TauCeti declaration(s); all within the allowlist [propext, Classical.choice, Quot.sound].`

🤖 Prepared with Codex
