### PR TITLE
feat: add isotopy and ambient isotopy of embeddings

### DIFF
--- a/TauCeti/Topology/Homotopy/Isotopy.lean
+++ b/TauCeti/Topology/Homotopy/Isotopy.lean
@@ -78,6 +78,8 @@ private theorem isInducing_of_isClosed_cover {Z W : Type*} [TopologicalSpace Z]
     obtain ⟨V, hV, hVsub⟩ := hUsub
     refine ⟨V, hV, ?_⟩
     rintro y ⟨hyV, hyD⟩
+    -- The restricted map applies definitionally to `f y`, so this `show` only changes
+    -- `hyV : f y ∈ V` into the preimage-membership type expected by `hVsub`.
     exact hVsub (show ((f ⁻¹' D).restrict f) ⟨y, hyD⟩ ∈ V from hyV)
   have wstep : ∀ D : Set W, IsClosed D → IsInducing ((f ⁻¹' D).restrict f) →
       ∃ V ∈ 𝓝 (f z), f ⁻¹' V ∩ f ⁻¹' D ⊆ U := by
@@ -204,6 +206,18 @@ private theorem injective_half : Function.Injective half := fun a b hab =>
 private theorem injective_halfRight : Function.Injective halfRight := fun a b hab =>
   Subtype.ext (by have := congrArg Subtype.val hab; simp only [coe_halfRight] at this; linarith)
 
+private theorem half_left_inv (t : I) (ht : (t : ℝ) ≤ 1 / 2) :
+    half (⟨2 * t, ⟨by linarith [t.2.1], by linarith [ht]⟩⟩ : I) = t := by
+  apply Subtype.ext
+  simp only [coe_half]
+  ring
+
+private theorem halfRight_right_inv (t : I) (ht : 1 / 2 ≤ (t : ℝ)) :
+    halfRight (⟨2 * t - 1, ⟨by linarith [ht], by linarith [t.2.2]⟩⟩ : I) = t := by
+  apply Subtype.ext
+  simp only [coe_halfRight]
+  ring
+
 private theorem isEmbedding_half : IsEmbedding half :=
   ((Continuous.subtype_mk (by fun_prop) _).isClosedEmbedding injective_half).isEmbedding
 
@@ -215,14 +229,14 @@ private theorem range_half : Set.range half = {t : I | (t : ℝ) ≤ 1 / 2} := b
   simp only [Set.mem_range, Set.mem_setOf_eq]
   refine ⟨?_, fun ht => ⟨⟨2 * t, ⟨by linarith [t.2.1], by linarith⟩⟩, ?_⟩⟩
   · rintro ⟨s, rfl⟩; rw [coe_half]; linarith [s.2.2]
-  · apply Subtype.ext; change (2 * (t : ℝ)) / 2 = (t : ℝ); ring
+  · exact half_left_inv t ht
 
 private theorem range_halfRight : Set.range halfRight = {t : I | 1 / 2 ≤ (t : ℝ)} := by
   ext t
   simp only [Set.mem_range, Set.mem_setOf_eq]
   refine ⟨?_, fun ht => ⟨⟨2 * t - 1, ⟨by linarith, by linarith [t.2.2]⟩⟩, ?_⟩⟩
   · rintro ⟨s, rfl⟩; rw [coe_halfRight]; linarith [s.2.1]
-  · apply Subtype.ext; change (2 * (t : ℝ) - 1) / 2 + 1 / 2 = (t : ℝ); ring
+  · exact halfRight_right_inv t ht
 
 private theorem trans_half (F : Isotopy f₀ f₁) (G : Isotopy f₁ f₂) (s : I) (x : X) :
     (F.toHomotopy.trans G.toHomotopy) (half s, x) = F.toHomotopy (s, x) := by

--- a/TauCeti/Topology/Homotopy/Isotopy.lean
+++ b/TauCeti/Topology/Homotopy/Isotopy.lean
@@ -167,6 +167,18 @@ noncomputable def trans [CompactSpace X] [T2Space Y] {f₂ : C(X, Y)}
           ext <;> simp [hyG]
         exact congrArg Prod.snd (G.isEmbedding_total.injective htotal))).isEmbedding
 
+/-- The value of a concatenated isotopy is given by the first isotopy on `[0, 1 / 2]`
+and by the second isotopy on `[1 / 2, 1]`, with the time parameter rescaled linearly. -/
+theorem trans_apply [CompactSpace X] [T2Space Y] {f₂ : C(X, Y)}
+    (F : Isotopy f₀ f₁) (G : Isotopy f₁ f₂) (x : I × X) :
+    (F.trans G) x =
+      if h : (x.1 : ℝ) ≤ 1 / 2 then
+        F (⟨2 * x.1, (unitInterval.mul_pos_mem_iff zero_lt_two).2 ⟨x.1.2.1, h⟩⟩, x.2)
+      else
+        G (⟨2 * x.1 - 1,
+          unitInterval.two_mul_sub_one_mem_iff.2 ⟨(not_le.1 h).le, x.1.2.2⟩⟩, x.2) :=
+  Homotopy.trans_apply F.toHomotopy G.toHomotopy x
+
 instance instHomotopyLike : HomotopyLike (Isotopy f₀ f₁) f₀ f₁ where
   map_continuous F := F.continuous_toFun
   map_zero_left F := F.map_zero_left

--- a/TauCeti/Topology/Homotopy/Isotopy.lean
+++ b/TauCeti/Topology/Homotopy/Isotopy.lean
@@ -23,7 +23,6 @@ notion also underlies locally flat isotopy, diffeotopies, and concordance.
 
 * `TauCeti.Isotopy f₀ f₁`: a homotopy from `f₀` to `f₁` whose total level-preserving map is a
   topological embedding.
-* `TauCeti.Isotopic f₀ f₁`: the proposition that such an isotopy exists.
 * `TauCeti.AmbientIsotopy Y`: a homotopy of `Y` from the identity whose total
   level-preserving map is a homeomorphism.
 
@@ -31,10 +30,10 @@ notion also underlies locally flat isotopy, diffeotopies, and concordance.
 
 * `TauCeti.Isotopy.isEmbedding_left` / `isEmbedding_right`: the endpoints of an isotopy are
   embeddings.
-* `TauCeti.Isotopic.refl` / `TauCeti.Isotopic.symm`: isotopy is reflexive and symmetric.
-* `TauCeti.Isotopic.homotopic`: isotopic maps are homotopic.
-* `TauCeti.AmbientIsotopy.isotopic`: an ambient isotopy carries any embedding `f` to the
-  isotopic embedding `Φ.final ∘ f`. This is the "ambient isotopy implies isotopy" direction.
+* `TauCeti.Isotopy.toHomotopyWith`: an isotopy is, in particular, a Mathlib homotopy through
+  embeddings.
+* `TauCeti.AmbientIsotopy.isotopy`: an ambient isotopy carries any embedding `f` to an isotopy
+  from `f` to `Φ.final ∘ f`. This is the "ambient isotopy implies isotopy" direction.
 -/
 
 namespace TauCeti
@@ -72,6 +71,14 @@ def totalMap (F : Isotopy f₀ f₁) : C(I × X, I × Y) :=
 theorem totalMap_apply (F : Isotopy f₀ f₁) (p : I × X) :
     F.totalMap p = (p.1, F.toHomotopy p) := rfl
 
+@[simp]
+theorem apply_zero (F : Isotopy f₀ f₁) (x : X) : F (0, x) = f₀ x :=
+  F.map_zero_left x
+
+@[simp]
+theorem apply_one (F : Isotopy f₀ f₁) (x : X) : F (1, x) = f₁ x :=
+  F.map_one_left x
+
 /-- The level-preserving total map of an isotopy is a topological embedding. -/
 theorem isEmbedding_total (F : Isotopy f₀ f₁) : IsEmbedding F.totalMap :=
   F.isEmbedding_total'
@@ -106,55 +113,6 @@ instance instHomotopyLike : HomotopyLike (Isotopy f₀ f₁) f₀ f₁ where
   map_one_left F := F.map_one_left
 
 end Isotopy
-
-/-- Two maps `f₀ f₁ : C(X, Y)` are **isotopic** if there is an isotopy between them. -/
-def Isotopic (f₀ f₁ : C(X, Y)) : Prop :=
-  Nonempty (Isotopy f₀ f₁)
-
-namespace Isotopic
-
-variable {f₀ f₁ : C(X, Y)}
-
-/-- An isotopy witnesses that its endpoints are isotopic. -/
-theorem of_isotopy (F : Isotopy f₀ f₁) : Isotopic f₀ f₁ := ⟨F⟩
-
-/-- Isotopy is reflexive on embeddings. -/
-theorem refl (f : C(X, Y)) (hf : IsEmbedding f) : Isotopic f f :=
-  ⟨{ toHomotopy := Homotopy.refl f,
-      isEmbedding_total' := IsEmbedding.id.prodMap hf }⟩
-
-/-- Isotopy is symmetric. -/
-@[symm]
-theorem symm (h : Isotopic f₀ f₁) : Isotopic f₁ f₀ :=
-  ⟨{ toHomotopy := h.some.toHomotopy.symm,
-      isEmbedding_total' := by
-        let e : I × X ≃ₜ I × X :=
-          unitInterval.symmHomeomorph.prodCongr (Homeomorph.refl X)
-        let e' : I × Y ≃ₜ I × Y :=
-          unitInterval.symmHomeomorph.prodCongr (Homeomorph.refl Y)
-        convert e'.isEmbedding.comp (h.some.isEmbedding_total.comp e.isEmbedding) using 1
-        ext p
-        · simp [Function.comp_def, Isotopy.totalMap, e, e', unitInterval.symm_symm]
-        · exact congrArg h.some.toHomotopy (by ext <;> simp [e]) }⟩
-
-/-- The endpoints of an isotopy relation are embeddings. -/
-theorem isEmbedding_left (h : Isotopic f₀ f₁) : IsEmbedding f₀ :=
-  Isotopy.isEmbedding_left h.some
-
-/-- The right endpoint of an isotopy relation is an embedding. -/
-theorem isEmbedding_right (h : Isotopic f₀ f₁) : IsEmbedding f₁ :=
-  Isotopy.isEmbedding_right h.some
-
-/-- Isotopic maps are homotopic. -/
-theorem homotopic (h : Isotopic f₀ f₁) : Homotopic f₀ f₁ :=
-  ⟨h.some.toHomotopy⟩
-
-/-- Isotopic maps are homotopic through embeddings in Mathlib's generic API. -/
-theorem homotopicWith (h : Isotopic f₀ f₁) :
-    HomotopicWith f₀ f₁ fun g : C(X, Y) => IsEmbedding g :=
-  ⟨h.some.toHomotopyWith⟩
-
-end Isotopic
 
 /-- An **ambient isotopy** of `Y` is a homotopy from the identity map of `Y` whose
 level-preserving total map is a homeomorphism. The time-`1` map `Φ.final` is the resulting
@@ -198,6 +156,7 @@ theorem isHomeomorph_apply (t : I) : IsHomeomorph fun y => Φ.toContinuousMap (t
     exact congrArg Prod.snd hp
 
 /-- The ambient isotopy starts at the identity of `Y`. -/
+@[simp]
 theorem map_zero_left (y : Y) : Φ.toContinuousMap (0, y) = y :=
   Φ.map_zero_left' y
 
@@ -251,11 +210,6 @@ def isotopy {f : C(X, Y)} (hf : IsEmbedding f) : Isotopy f (Φ.final.comp f) whe
   isEmbedding_total' := by
     rw [isotopy_totalMap_eq]
     exact Φ.isHomeomorph_total.isEmbedding.comp (IsEmbedding.id.prodMap hf)
-
-/-- **Ambient isotopy implies isotopy**: an ambient isotopy of `Y` carries any embedding `f`
-into `Y` to the isotopic embedding `Φ.final ∘ f`. -/
-theorem isotopic {f : C(X, Y)} (hf : IsEmbedding f) : Isotopic f (Φ.final.comp f) :=
-  ⟨Φ.isotopy hf⟩
 
 end AmbientIsotopy
 

--- a/TauCeti/Topology/Homotopy/Isotopy.lean
+++ b/TauCeti/Topology/Homotopy/Isotopy.lean
@@ -29,8 +29,8 @@ the same notion underlies locally flat isotopy, diffeotopies, and concordance.
 
 * `TauCeti.Isotopy.isEmbedding_left` / `isEmbedding_right`: the endpoints of an isotopy are
   embeddings.
-* `TauCeti.Isotopic.refl`, `TauCeti.Isotopic.symm`, and `TauCeti.Isotopic.homotopic`: an
-  isotopy is in particular a homotopy.
+* `TauCeti.Isotopic.refl` / `TauCeti.Isotopic.symm`: isotopy is reflexive and symmetric.
+* `TauCeti.Isotopic.homotopic`: isotopic maps are homotopic.
 * `TauCeti.AmbientIsotopy.isotopic`: an ambient isotopy carries any embedding `f` to the
   isotopic embedding `Φ.final ∘ f`. This is the "ambient isotopy implies isotopy" direction.
 -/
@@ -41,10 +41,14 @@ open unitInterval ContinuousMap Topology
 
 variable {X Y : Type*} [TopologicalSpace X] [TopologicalSpace Y]
 
+private theorem isEmbedding_const_prod (t : I) : IsEmbedding fun x : X => (t, x) :=
+  IsEmbedding.of_comp (by fun_prop) continuous_snd (by
+    change IsEmbedding (id : X → X)
+    exact IsEmbedding.id)
+
 /-- An **isotopy** between `f₀ f₁ : C(X, Y)` is a homotopy whose level-preserving total map
-`I × X → I × Y` is a topological embedding. We also store the standard consequence that every
-time-slice is an embedding, since this is the form most later users need. -/
-structure Isotopy (f₀ f₁ : C(X, Y)) extends HomotopyWith f₀ f₁ fun g => IsEmbedding g where
+`I × X → I × Y` is a topological embedding. -/
+structure Isotopy (f₀ f₁ : C(X, Y)) extends Homotopy f₀ f₁ where
   /-- the level-preserving total map of an isotopy is a topological embedding -/
   isEmbedding_total' : IsEmbedding fun p : I × X => (p.1, toFun p)
 
@@ -52,13 +56,18 @@ namespace Isotopy
 
 variable {f₀ f₁ : C(X, Y)}
 
+instance instFunLike : FunLike (Isotopy f₀ f₁) (I × X) Y where
+  coe F := F.toFun
+  coe_injective
+  | ⟨⟨⟨_, _⟩, _, _⟩, _⟩, ⟨⟨⟨_, _⟩, _, _⟩, _⟩, rfl => rfl
+
 /-- The level-preserving total map of an isotopy. -/
 def totalMap (F : Isotopy f₀ f₁) : C(I × X, I × Y) :=
-  ⟨fun p => (p.1, F.toHomotopyWith p), by fun_prop⟩
+  ⟨fun p => (p.1, F.toHomotopy p), by fun_prop⟩
 
 @[simp]
 theorem totalMap_apply (F : Isotopy f₀ f₁) (p : I × X) :
-    F.totalMap p = (p.1, F.toHomotopyWith p) := rfl
+    F.totalMap p = (p.1, F.toHomotopy p) := rfl
 
 /-- The level-preserving total map of an isotopy is a topological embedding. -/
 theorem isEmbedding_total (F : Isotopy f₀ f₁) : IsEmbedding F.totalMap :=
@@ -66,8 +75,13 @@ theorem isEmbedding_total (F : Isotopy f₀ f₁) : IsEmbedding F.totalMap :=
 
 /-- Every time-slice of an isotopy is a topological embedding. -/
 theorem isEmbedding_apply (F : Isotopy f₀ f₁) (t : I) :
-    IsEmbedding fun x => F.toHomotopyWith (t, x) :=
-  F.prop' t
+    IsEmbedding fun x => F.toHomotopy (t, x) := by
+  let k : Y → I × Y := fun y => (t, y)
+  have hk_cont : Continuous k := by fun_prop
+  have hcomp : IsEmbedding (k ∘ fun x => F.toHomotopy (t, x)) := by
+    convert F.isEmbedding_total.comp (isEmbedding_const_prod (X := X) t) using 1
+    ext x <;> rfl
+  exact IsEmbedding.of_comp (by fun_prop) hk_cont hcomp
 
 /-- The map an isotopy starts at is a topological embedding. -/
 theorem isEmbedding_left (F : Isotopy f₀ f₁) : IsEmbedding f₀ := by
@@ -76,6 +90,11 @@ theorem isEmbedding_left (F : Isotopy f₀ f₁) : IsEmbedding f₀ := by
 /-- The map an isotopy ends at is a topological embedding. -/
 theorem isEmbedding_right (F : Isotopy f₀ f₁) : IsEmbedding f₁ := by
   simpa using F.isEmbedding_apply 1
+
+instance instHomotopyLike : HomotopyLike (Isotopy f₀ f₁) f₀ f₁ where
+  map_continuous F := F.continuous_toFun
+  map_zero_left F := F.map_zero_left
+  map_one_left F := F.map_one_left
 
 end Isotopy
 
@@ -90,13 +109,15 @@ variable {f₀ f₁ : C(X, Y)}
 /-- An isotopy witnesses that its endpoints are isotopic. -/
 theorem of_isotopy (F : Isotopy f₀ f₁) : Isotopic f₀ f₁ := ⟨F⟩
 
+/-- Isotopy is reflexive on embeddings. -/
 theorem refl (f : C(X, Y)) (hf : IsEmbedding f) : Isotopic f f :=
-  ⟨{ toHomotopyWith := HomotopyWith.refl f hf,
+  ⟨{ toHomotopy := Homotopy.refl f,
       isEmbedding_total' := IsEmbedding.id.prodMap hf }⟩
 
+/-- Isotopy is symmetric. -/
 @[symm]
 theorem symm (h : Isotopic f₀ f₁) : Isotopic f₁ f₀ :=
-  ⟨{ toHomotopyWith := h.some.toHomotopyWith.symm,
+  ⟨{ toHomotopy := h.some.toHomotopy.symm,
       isEmbedding_total' := by
         let e : I × X ≃ₜ I × X :=
           unitInterval.symmHomeomorph.prodCongr (Homeomorph.refl X)
@@ -105,28 +126,26 @@ theorem symm (h : Isotopic f₀ f₁) : Isotopic f₁ f₀ :=
         convert e'.isEmbedding.comp (h.some.isEmbedding_total.comp e.isEmbedding) using 1
         ext p
         · simp [Function.comp_def, Isotopy.totalMap, e, e', unitInterval.symm_symm]
-        · exact congrArg h.some.toHomotopyWith (by ext <;> simp [e]) }⟩
+        · exact congrArg h.some.toHomotopy (by ext <;> simp [e]) }⟩
 
 /-- The endpoints of an isotopy relation are embeddings. -/
 theorem isEmbedding_left (h : Isotopic f₀ f₁) : IsEmbedding f₀ :=
   Isotopy.isEmbedding_left h.some
 
+/-- The right endpoint of an isotopy relation is an embedding. -/
 theorem isEmbedding_right (h : Isotopic f₀ f₁) : IsEmbedding f₁ :=
   Isotopy.isEmbedding_right h.some
 
 /-- Isotopic maps are homotopic. -/
 theorem homotopic (h : Isotopic f₀ f₁) : Homotopic f₀ f₁ :=
-  ⟨h.some.toHomotopyWith.toHomotopy⟩
+  ⟨h.some.toHomotopy⟩
 
 end Isotopic
 
 /-- An **ambient isotopy** of `Y` is a homotopy from the identity map of `Y` whose
 level-preserving total map is a homeomorphism. The time-`1` map `Φ.final` is the resulting
-homeomorphism. We also store the standard consequence that every time-slice is a
-self-homeomorphism. -/
+homeomorphism. -/
 structure AmbientIsotopy (Y : Type*) [TopologicalSpace Y] extends C(I × Y, Y) where
-  /-- every time-slice of the ambient isotopy is a self-homeomorphism of `Y` -/
-  isHomeomorph_apply' : ∀ t : I, IsHomeomorph fun y => toFun (t, y)
   /-- the level-preserving total map of the ambient isotopy is a homeomorphism -/
   isHomeomorph_total' : IsHomeomorph fun p : I × Y => (p.1, toFun p)
   /-- the ambient isotopy starts at the identity of `Y` -/
@@ -147,16 +166,40 @@ theorem totalMap_apply (p : I × Y) : Φ.totalMap p = (p.1, Φ.toContinuousMap p
 theorem isHomeomorph_total : IsHomeomorph Φ.totalMap :=
   Φ.isHomeomorph_total'
 
+/-- Every time-slice of an ambient isotopy is a self-homeomorphism of `Y`. -/
+theorem isHomeomorph_apply (t : I) : IsHomeomorph fun y => Φ.toContinuousMap (t, y) := by
+  rw [isHomeomorph_iff_isEmbedding_surjective]
+  constructor
+  · let k : Y → I × Y := fun y => (t, y)
+    have hk_cont : Continuous k := by fun_prop
+    have hcomp : IsEmbedding (k ∘ fun y => Φ.toContinuousMap (t, y)) := by
+      convert Φ.isHomeomorph_total.isEmbedding.comp (isEmbedding_const_prod (X := Y) t) using 1
+      ext y <;> rfl
+    exact IsEmbedding.of_comp (by fun_prop) hk_cont hcomp
+  · intro y
+    rcases Φ.isHomeomorph_total.surjective (t, y) with ⟨p, hp⟩
+    refine ⟨p.2, ?_⟩
+    have ht : p.1 = t := congrArg Prod.fst hp
+    rw [← ht]
+    exact congrArg Prod.snd hp
+
+/-- The ambient isotopy starts at the identity of `Y`. -/
+theorem map_zero_left (y : Y) : Φ.toContinuousMap (0, y) = y :=
+  Φ.map_zero_left' y
+
 /-- The time-`1` homeomorphism produced by an ambient isotopy, as a continuous map. -/
 def final : C(Y, Y) := ⟨fun y => Φ.toContinuousMap (1, y), by fun_prop⟩
 
 @[simp]
 theorem final_apply (y : Y) : Φ.final y = Φ.toContinuousMap (1, y) := rfl
 
+/-- The final map produced by an ambient isotopy is a homeomorphism. -/
+theorem isHomeomorph_final : IsHomeomorph Φ.final :=
+  Φ.isHomeomorph_apply 1
+
 /-- The constant ambient isotopy at the identity. -/
 def refl (Y : Type*) [TopologicalSpace Y] : AmbientIsotopy Y where
   toContinuousMap := ⟨fun p => p.2, by fun_prop⟩
-  isHomeomorph_apply' _ := .id
   isHomeomorph_total' := .id
   map_zero_left' _ := rfl
 
@@ -168,10 +211,11 @@ def isotopy {f : C(X, Y)} (hf : IsEmbedding f) : Isotopy f (Φ.final.comp f) whe
   toHomotopy :=
     { toFun := fun p => Φ.toContinuousMap (p.1, f p.2)
       continuous_toFun := by fun_prop
-      map_zero_left := fun x => Φ.map_zero_left' (f x)
+      map_zero_left := fun x => Φ.map_zero_left (f x)
       map_one_left := fun _ => rfl }
-  prop' := fun t => ((Φ.isHomeomorph_apply' t).isEmbedding).comp hf
   isEmbedding_total' := by
+    -- Definitional unfolding identifies this total map with `Φ.totalMap` after
+    -- postcomposing the identity-on-time product map induced by `f`.
     change IsEmbedding (Φ.totalMap ∘ Prod.map id f)
     exact Φ.isHomeomorph_total.isEmbedding.comp (IsEmbedding.id.prodMap hf)
 

--- a/TauCeti/Topology/Homotopy/Isotopy.lean
+++ b/TauCeti/Topology/Homotopy/Isotopy.lean
@@ -34,8 +34,9 @@ notion also underlies locally flat isotopy, diffeotopies, and concordance.
   embeddings.
 * `TauCeti.Isotopy.toHomotopyWith`: an isotopy is, in particular, a Mathlib homotopy through
   embeddings.
-* `TauCeti.Isotopic.refl` / `TauCeti.Isotopic.symm`: isotopy is reflexive on embeddings and
-  symmetric.
+* `TauCeti.Isotopic.refl` / `TauCeti.Isotopic.symm` / `TauCeti.Isotopic.trans`: isotopy is
+  reflexive on embeddings, symmetric, and transitive when the source is compact and the target
+  is Hausdorff.
 * `TauCeti.Isotopic.homotopic`: isotopic maps are homotopic.
 * `TauCeti.AmbientIsotopy.isotopy` / `TauCeti.AmbientIsotopy.isotopic`: an ambient isotopy
   carries any embedding `f` to the isotopic embedding `Φ.final ∘ f`. This is the "ambient
@@ -116,6 +117,56 @@ theorem isEmbedding_left (F : Isotopy f₀ f₁) : IsEmbedding f₀ := by
 theorem isEmbedding_right (F : Isotopy f₀ f₁) : IsEmbedding f₁ := by
   simpa using F.isEmbedding_apply 1
 
+/-- Concatenate two isotopies when compactness and Hausdorffness make the concatenated total map
+an embedding. -/
+noncomputable def trans [CompactSpace X] [T2Space Y] {f₂ : C(X, Y)}
+    (F : Isotopy f₀ f₁) (G : Isotopy f₁ f₂) : Isotopy f₀ f₂ where
+  toHomotopy := F.toHomotopy.trans G.toHomotopy
+  isEmbedding_total' := by
+    let H : Homotopy f₀ f₂ := F.toHomotopy.trans G.toHomotopy
+    have hcont : Continuous fun p : I × X => (p.1, H p) := by fun_prop
+    exact (hcont.isClosedEmbedding (by
+      rintro ⟨t, x⟩ ⟨u, y⟩ hxy
+      have ht : t = u := congrArg Prod.fst hxy
+      have hy : H (t, x) = H (u, y) := congrArg Prod.snd hxy
+      subst u
+      rw [Prod.mk.injEq]
+      refine ⟨rfl, ?_⟩
+      by_cases ht_half : (t : ℝ) ≤ 1 / 2
+      · let s : I := ⟨2 * t, (unitInterval.mul_pos_mem_iff zero_lt_two).2 ⟨t.2.1, ht_half⟩⟩
+        have hyF : F.toHomotopy (s, x) = F.toHomotopy (s, y) := by
+          rw [show H (t, x) = F.toHomotopy (s, x) by
+                rw [Homotopy.trans_apply]
+                split_ifs with h
+                · rfl
+                · exact (h ht_half).elim,
+              show H (t, y) = F.toHomotopy (s, y) by
+                rw [Homotopy.trans_apply]
+                split_ifs with h
+                · rfl
+                · exact (h ht_half).elim] at hy
+          exact hy
+        have htotal : F.totalMap (s, x) = F.totalMap (s, y) := by
+          ext <;> simp [hyF]
+        exact congrArg Prod.snd (F.isEmbedding_total.injective htotal)
+      · let s : I :=
+          ⟨2 * t - 1, unitInterval.two_mul_sub_one_mem_iff.2 ⟨(not_le.1 ht_half).le, t.2.2⟩⟩
+        have hyG : G.toHomotopy (s, x) = G.toHomotopy (s, y) := by
+          rw [show H (t, x) = G.toHomotopy (s, x) by
+                rw [Homotopy.trans_apply]
+                split_ifs with h
+                · exact (ht_half h).elim
+                · rfl,
+              show H (t, y) = G.toHomotopy (s, y) by
+                rw [Homotopy.trans_apply]
+                split_ifs with h
+                · exact (ht_half h).elim
+                · rfl] at hy
+          exact hy
+        have htotal : G.totalMap (s, x) = G.totalMap (s, y) := by
+          ext <;> simp [hyG]
+        exact congrArg Prod.snd (G.isEmbedding_total.injective htotal))).isEmbedding
+
 instance instHomotopyLike : HomotopyLike (Isotopy f₀ f₁) f₀ f₁ where
   map_continuous F := F.continuous_toFun
   map_zero_left F := F.map_zero_left
@@ -152,6 +203,12 @@ theorem symm (h : Isotopic f₀ f₁) : Isotopic f₁ f₀ :=
         ext p
         · simp [Function.comp_def, Isotopy.totalMap, e, e', unitInterval.symm_symm]
         · exact congrArg h.some.toHomotopy (by ext <;> simp [e]) }⟩
+
+/-- Isotopy is transitive when the source is compact and the target is Hausdorff. -/
+@[trans]
+theorem trans [CompactSpace X] [T2Space Y] {f₂ : C(X, Y)}
+    (h₀₁ : Isotopic f₀ f₁) (h₁₂ : Isotopic f₁ f₂) : Isotopic f₀ f₂ :=
+  ⟨h₀₁.some.trans h₁₂.some⟩
 
 /-- The left endpoint of an isotopy relation is an embedding. -/
 theorem isEmbedding_left (h : Isotopic f₀ f₁) : IsEmbedding f₀ :=

--- a/TauCeti/Topology/Homotopy/Isotopy.lean
+++ b/TauCeti/Topology/Homotopy/Isotopy.lean
@@ -1,0 +1,149 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+import Mathlib.Topology.Homotopy.Basic
+import Mathlib.Topology.Homeomorph.Lemmas
+import Mathlib.Topology.Maps.Basic
+
+/-!
+# Isotopy and ambient isotopy
+
+An *isotopy* between two continuous maps is a homotopy whose every time-slice is a topological
+embedding, and an *ambient isotopy* of a space `Y` is a homotopy from the identity of `Y`
+through self-homeomorphisms. These are the point-set foundations that the geometric-topology
+roadmap (`TauCetiRoadmap/GeometricTopology`) asks for once, in full generality, before
+specialising: knot equivalence is the restriction of `TauCeti.Isotopic` to smooth embeddings
+`S¹ ↪ M`, and the same notion underlies locally flat isotopy, diffeotopies, and concordance.
+
+The construction reuses Mathlib's `ContinuousMap.HomotopyWith`, taking the intermediate
+predicate to be "is a topological embedding". This is exactly the slot `HomotopyWith` exists to
+fill, so `refl`, `symm`, and `trans` come for free, and `TauCeti.Isotopic` is an equivalence
+relation on the embeddings.
+
+## Main definitions
+
+* `TauCeti.Isotopy f₀ f₁`: a homotopy from `f₀` to `f₁` through topological embeddings.
+* `TauCeti.Isotopic f₀ f₁`: the proposition that such an isotopy exists.
+* `TauCeti.AmbientIsotopy Y`: a homotopy of `Y` from the identity through self-homeomorphisms.
+
+## Main results
+
+* `TauCeti.Isotopy.isEmbedding_left` / `isEmbedding_right`: the endpoints of an isotopy are
+  embeddings.
+* `TauCeti.Isotopic.isEquivalence` style lemmas (`refl`, `symm`, `trans`) and
+  `TauCeti.Isotopic.homotopic`: an isotopy is in particular a homotopy.
+* `TauCeti.AmbientIsotopy.isotopic`: an ambient isotopy carries any embedding `f` to the
+  isotopic embedding `Φ.final ∘ f`. This is the "ambient isotopy implies isotopy" direction.
+-/
+
+namespace TauCeti
+
+open unitInterval ContinuousMap Topology
+
+variable {X Y : Type*} [TopologicalSpace X] [TopologicalSpace Y]
+
+/-- An **isotopy** between `f₀ f₁ : C(X, Y)` is a homotopy whose every time-slice is a
+topological embedding. -/
+abbrev Isotopy (f₀ f₁ : C(X, Y)) : Type _ :=
+  HomotopyWith f₀ f₁ fun g => IsEmbedding g
+
+namespace Isotopy
+
+variable {f₀ f₁ : C(X, Y)}
+
+/-- Every time-slice of an isotopy is a topological embedding. -/
+theorem isEmbedding_apply (F : Isotopy f₀ f₁) (t : I) : IsEmbedding fun x => F (t, x) :=
+  F.prop' t
+
+/-- The map an isotopy starts at is a topological embedding. -/
+theorem isEmbedding_left (F : Isotopy f₀ f₁) : IsEmbedding f₀ := by
+  simpa using F.isEmbedding_apply 0
+
+/-- The map an isotopy ends at is a topological embedding. -/
+theorem isEmbedding_right (F : Isotopy f₀ f₁) : IsEmbedding f₁ := by
+  simpa using F.isEmbedding_apply 1
+
+end Isotopy
+
+/-- Two maps `f₀ f₁ : C(X, Y)` are **isotopic** if there is an isotopy between them, i.e. a
+homotopy through topological embeddings. -/
+def Isotopic (f₀ f₁ : C(X, Y)) : Prop :=
+  HomotopicWith f₀ f₁ fun g => IsEmbedding g
+
+namespace Isotopic
+
+variable {f₀ f₁ f₂ : C(X, Y)}
+
+/-- An isotopy witnesses that its endpoints are isotopic. -/
+theorem of_isotopy (F : Isotopy f₀ f₁) : Isotopic f₀ f₁ := ⟨F⟩
+
+theorem refl (f : C(X, Y)) (hf : IsEmbedding f) : Isotopic f f :=
+  HomotopicWith.refl f hf
+
+@[symm]
+theorem symm (h : Isotopic f₀ f₁) : Isotopic f₁ f₀ :=
+  HomotopicWith.symm h
+
+@[trans]
+theorem trans (h₀ : Isotopic f₀ f₁) (h₁ : Isotopic f₁ f₂) : Isotopic f₀ f₂ :=
+  HomotopicWith.trans h₀ h₁
+
+/-- The endpoints of an isotopy relation are embeddings. -/
+theorem isEmbedding_left (h : Isotopic f₀ f₁) : IsEmbedding f₀ :=
+  Isotopy.isEmbedding_left h.some
+
+theorem isEmbedding_right (h : Isotopic f₀ f₁) : IsEmbedding f₁ :=
+  Isotopy.isEmbedding_right h.some
+
+/-- Isotopic maps are homotopic. -/
+theorem homotopic (h : Isotopic f₀ f₁) : Homotopic f₀ f₁ :=
+  ⟨h.some.toHomotopy⟩
+
+end Isotopic
+
+/-- An **ambient isotopy** of `Y` is a homotopy from the identity map of `Y` through
+self-homeomorphisms; the time-`1` map `Φ.final` is the resulting homeomorphism, and the whole
+family deforms the identity into it inside the homeomorphism group. -/
+structure AmbientIsotopy (Y : Type*) [TopologicalSpace Y] extends C(I × Y, Y) where
+  /-- every time-slice of the ambient isotopy is a self-homeomorphism of `Y` -/
+  isHomeomorph_apply' : ∀ t : I, IsHomeomorph fun y => toFun (t, y)
+  /-- the ambient isotopy starts at the identity of `Y` -/
+  map_zero_left' : ∀ y, toFun (0, y) = y
+
+namespace AmbientIsotopy
+
+variable (Φ : AmbientIsotopy Y)
+
+/-- The time-`1` homeomorphism produced by an ambient isotopy, as a continuous map. -/
+def final : C(Y, Y) := ⟨fun y => Φ.toContinuousMap (1, y), by fun_prop⟩
+
+@[simp]
+theorem final_apply (y : Y) : Φ.final y = Φ.toContinuousMap (1, y) := rfl
+
+/-- The constant ambient isotopy at the identity. -/
+def refl (Y : Type*) [TopologicalSpace Y] : AmbientIsotopy Y where
+  toContinuousMap := ⟨fun p => p.2, by fun_prop⟩
+  isHomeomorph_apply' _ := .id
+  map_zero_left' _ := rfl
+
+instance : Inhabited (AmbientIsotopy Y) := ⟨refl Y⟩
+
+/-- An ambient isotopy carries any embedding `f` to the embedding `Φ.final ∘ f` through an
+explicit isotopy: at time `t` the embedding is the homeomorphism `Φ t` postcomposed with `f`. -/
+def isotopy {f : C(X, Y)} (hf : IsEmbedding f) : Isotopy f (Φ.final.comp f) where
+  toHomotopy :=
+    { toFun := fun p => Φ.toContinuousMap (p.1, f p.2)
+      continuous_toFun := by fun_prop
+      map_zero_left := fun x => Φ.map_zero_left' (f x)
+      map_one_left := fun _ => rfl }
+  prop' := fun t => ((Φ.isHomeomorph_apply' t).isEmbedding).comp hf
+
+/-- **Ambient isotopy implies isotopy**: an ambient isotopy of `Y` carries any embedding `f`
+into `Y` to the isotopic embedding `Φ.final ∘ f`. -/
+theorem isotopic {f : C(X, Y)} (hf : IsEmbedding f) : Isotopic f (Φ.final.comp f) :=
+  ⟨Φ.isotopy hf⟩
+
+end AmbientIsotopy
+
+end TauCeti

--- a/TauCeti/Topology/Homotopy/Isotopy.lean
+++ b/TauCeti/Topology/Homotopy/Isotopy.lean
@@ -13,9 +13,11 @@ An *isotopy* between two continuous maps is a homotopy whose level-preserving to
 `I × X → I × Y` is a topological embedding, and an *ambient isotopy* of a space `Y` is a
 homotopy from the identity of `Y` whose level-preserving total map `I × Y → I × Y` is a
 homeomorphism. These are the point-set foundations that the geometric-topology roadmap
-(`TauCetiRoadmap/GeometricTopology`) asks for once, in full generality, before specialising:
-knot equivalence is the restriction of `TauCeti.Isotopic` to smooth embeddings `S¹ ↪ M`, and
-the same notion underlies locally flat isotopy, diffeotopies, and concordance.
+(`TauCetiRoadmap/GeometricTopology`) asks for once, in full generality, before specialising.
+The definitions follow Burde--Zieschang, *Knots*, Chapter 1, Definitions 1.1 and 1.2,
+generalized to this continuous topological setting. Later knot-equivalence foundations are
+intended to specialize this continuous relation to smooth embeddings `S¹ ↪ M`; the same
+notion also underlies locally flat isotopy, diffeotopies, and concordance.
 
 ## Main definitions
 
@@ -43,8 +45,9 @@ variable {X Y : Type*} [TopologicalSpace X] [TopologicalSpace Y]
 
 private theorem isEmbedding_const_prod (t : I) : IsEmbedding fun x : X => (t, x) :=
   IsEmbedding.of_comp (by fun_prop) continuous_snd (by
-    change IsEmbedding (id : X → X)
-    exact IsEmbedding.id)
+    convert (IsEmbedding.id : IsEmbedding (id : X → X)) using 1
+    ext x
+    rfl)
 
 /-- An **isotopy** between `f₀ f₁ : C(X, Y)` is a homotopy whose level-preserving total map
 `I × X → I × Y` is a topological embedding. -/
@@ -82,6 +85,12 @@ theorem isEmbedding_apply (F : Isotopy f₀ f₁) (t : I) :
     convert F.isEmbedding_total.comp (isEmbedding_const_prod (X := X) t) using 1
     ext x <;> rfl
   exact IsEmbedding.of_comp (by fun_prop) hk_cont hcomp
+
+/-- An isotopy is, in particular, a `HomotopyWith` whose slices are embeddings. -/
+def toHomotopyWith (F : Isotopy f₀ f₁) :
+    HomotopyWith f₀ f₁ fun g : C(X, Y) => IsEmbedding g where
+  toHomotopy := F.toHomotopy
+  prop' := F.isEmbedding_apply
 
 /-- The map an isotopy starts at is a topological embedding. -/
 theorem isEmbedding_left (F : Isotopy f₀ f₁) : IsEmbedding f₀ := by
@@ -140,6 +149,11 @@ theorem isEmbedding_right (h : Isotopic f₀ f₁) : IsEmbedding f₁ :=
 theorem homotopic (h : Isotopic f₀ f₁) : Homotopic f₀ f₁ :=
   ⟨h.some.toHomotopy⟩
 
+/-- Isotopic maps are homotopic through embeddings in Mathlib's generic API. -/
+theorem homotopicWith (h : Isotopic f₀ f₁) :
+    HomotopicWith f₀ f₁ fun g : C(X, Y) => IsEmbedding g :=
+  ⟨h.some.toHomotopyWith⟩
+
 end Isotopic
 
 /-- An **ambient isotopy** of `Y` is a homotopy from the identity map of `Y` whose
@@ -197,6 +211,22 @@ theorem final_apply (y : Y) : Φ.final y = Φ.toContinuousMap (1, y) := rfl
 theorem isHomeomorph_final : IsHomeomorph Φ.final :=
   Φ.isHomeomorph_apply 1
 
+/-- The time-`t` self-homeomorphism bundled as a `Homeomorph`. -/
+noncomputable def homeomorph (t : I) : Y ≃ₜ Y :=
+  IsHomeomorph.homeomorph (fun y => Φ.toContinuousMap (t, y)) (Φ.isHomeomorph_apply t)
+
+@[simp]
+theorem homeomorph_apply (t : I) (y : Y) : Φ.homeomorph t y = Φ.toContinuousMap (t, y) :=
+  rfl
+
+/-- The time-`1` homeomorphism produced by an ambient isotopy. -/
+noncomputable def finalHomeomorph : Y ≃ₜ Y :=
+  Φ.homeomorph 1
+
+@[simp]
+theorem finalHomeomorph_apply (y : Y) : Φ.finalHomeomorph y = Φ.final y :=
+  rfl
+
 /-- The constant ambient isotopy at the identity. -/
 def refl (Y : Type*) [TopologicalSpace Y] : AmbientIsotopy Y where
   toContinuousMap := ⟨fun p => p.2, by fun_prop⟩
@@ -204,6 +234,11 @@ def refl (Y : Type*) [TopologicalSpace Y] : AmbientIsotopy Y where
   map_zero_left' _ := rfl
 
 instance : Inhabited (AmbientIsotopy Y) := ⟨refl Y⟩
+
+private theorem isotopy_totalMap_eq {f : C(X, Y)} :
+    (fun p : I × X => (p.1, Φ.toContinuousMap (p.1, f p.2))) =
+      Φ.totalMap ∘ Prod.map id f :=
+  rfl
 
 /-- An ambient isotopy carries any embedding `f` to the embedding `Φ.final ∘ f` through an
 explicit isotopy: at time `t` the embedding is the homeomorphism `Φ t` postcomposed with `f`. -/
@@ -214,9 +249,7 @@ def isotopy {f : C(X, Y)} (hf : IsEmbedding f) : Isotopy f (Φ.final.comp f) whe
       map_zero_left := fun x => Φ.map_zero_left (f x)
       map_one_left := fun _ => rfl }
   isEmbedding_total' := by
-    -- Definitional unfolding identifies this total map with `Φ.totalMap` after
-    -- postcomposing the identity-on-time product map induced by `f`.
-    change IsEmbedding (Φ.totalMap ∘ Prod.map id f)
+    rw [isotopy_totalMap_eq]
     exact Φ.isHomeomorph_total.isEmbedding.comp (IsEmbedding.id.prodMap hf)
 
 /-- **Ambient isotopy implies isotopy**: an ambient isotopy of `Y` carries any embedding `f`

--- a/TauCeti/Topology/Homotopy/Isotopy.lean
+++ b/TauCeti/Topology/Homotopy/Isotopy.lean
@@ -326,6 +326,11 @@ def isotopy {f : C(X, Y)} (hf : IsEmbedding f) : Isotopy f (Φ.final.comp f) whe
     rw [isotopy_totalMap_eq]
     exact Φ.isHomeomorph_total.isEmbedding.comp (IsEmbedding.id.prodMap hf)
 
+@[simp]
+theorem isotopy_apply {f : C(X, Y)} (hf : IsEmbedding f) (t : I) (x : X) :
+    Φ.isotopy hf (t, x) = Φ.toContinuousMap (t, f x) :=
+  rfl
+
 /-- **Ambient isotopy implies isotopy**: an ambient isotopy of `Y` carries any embedding `f`
 into `Y` to the isotopic embedding `Φ.final ∘ f`. -/
 theorem isotopic {f : C(X, Y)} (hf : IsEmbedding f) : Isotopic f (Φ.final.comp f) :=

--- a/TauCeti/Topology/Homotopy/Isotopy.lean
+++ b/TauCeti/Topology/Homotopy/Isotopy.lean
@@ -106,7 +106,7 @@ private theorem isInducing_restrict_of_embedding {Z W A : Type*} [TopologicalSpa
     IsInducing ((f ⁻¹' D).restrict f) := by
   let φ : A ≃ₜ (f ⁻¹' D) := he.toHomeomorph.trans (Homeomorph.setCongr hrange)
   have hφ_apply (a : A) : (φ a : Z) = e a := by
-    change ((Homeomorph.setCongr hrange) (he.toHomeomorph a) : Z) = e a
+    simp only [φ, Homeomorph.trans_apply]
     simp [Homeomorph.setCongr]
   have hcomp : (f ⁻¹' D).restrict f ∘ φ = f ∘ e := by
     funext a
@@ -179,7 +179,7 @@ theorem isEmbedding_right (F : Isotopy f₀ f₁) : IsEmbedding f₁ := by
 
 /-- Value of the concatenated homotopy on the first half `[0, 1 / 2]`, with the time parameter
 rescaled to `2 * t`. -/
-theorem trans_toHomotopy_apply_of_le (F : Isotopy f₀ f₁) (G : Isotopy f₁ f₂) {t : I} (x : X)
+private theorem trans_toHomotopy_apply_of_le (F : Isotopy f₀ f₁) (G : Isotopy f₁ f₂) {t : I} (x : X)
     (h : (t : ℝ) ≤ 1 / 2) :
     (F.toHomotopy.trans G.toHomotopy) (t, x)
       = F.toHomotopy (⟨2 * t, (unitInterval.mul_pos_mem_iff zero_lt_two).2 ⟨t.2.1, h⟩⟩, x) := by
@@ -187,7 +187,8 @@ theorem trans_toHomotopy_apply_of_le (F : Isotopy f₀ f₁) (G : Isotopy f₁ f
 
 /-- Value of the concatenated homotopy on the second half `[1 / 2, 1]`, with the time parameter
 rescaled to `2 * t - 1`. -/
-theorem trans_toHomotopy_apply_of_not_le (F : Isotopy f₀ f₁) (G : Isotopy f₁ f₂) {t : I} (x : X)
+private theorem trans_toHomotopy_apply_of_not_le (F : Isotopy f₀ f₁) (G : Isotopy f₁ f₂) {t : I}
+    (x : X)
     (h : ¬ (t : ℝ) ≤ 1 / 2) :
     (F.toHomotopy.trans G.toHomotopy) (t, x)
       = G.toHomotopy

--- a/TauCeti/Topology/Homotopy/Isotopy.lean
+++ b/TauCeti/Topology/Homotopy/Isotopy.lean
@@ -66,8 +66,11 @@ variable {f₀ f₁ : C(X, Y)}
 
 instance instFunLike : FunLike (Isotopy f₀ f₁) (I × X) Y where
   coe F := F.toFun
-  coe_injective
-  | ⟨⟨⟨_, _⟩, _, _⟩, _⟩, ⟨⟨⟨_, _⟩, _, _⟩, _⟩, rfl => rfl
+  coe_injective F G h := by
+    obtain ⟨F, _⟩ := F
+    obtain ⟨G, _⟩ := G
+    congr
+    exact DFunLike.coe_injective h
 
 /-- The level-preserving total map of an isotopy. -/
 def totalMap (F : Isotopy f₀ f₁) : C(I × X, I × Y) :=

--- a/TauCeti/Topology/Homotopy/Isotopy.lean
+++ b/TauCeti/Topology/Homotopy/Isotopy.lean
@@ -105,7 +105,12 @@ private theorem isInducing_restrict_of_embedding {Z W A : Type*} [TopologicalSpa
     (he : IsEmbedding e) (hrange : Set.range e = f ⁻¹' D) (hfe : IsInducing (f ∘ e)) :
     IsInducing ((f ⁻¹' D).restrict f) := by
   let φ : A ≃ₜ (f ⁻¹' D) := he.toHomeomorph.trans (Homeomorph.setCongr hrange)
-  have hcomp : (f ⁻¹' D).restrict f ∘ φ = f ∘ e := rfl
+  have hφ_apply (a : A) : (φ a : Z) = e a := by
+    change ((Homeomorph.setCongr hrange) (he.toHomeomorph a) : Z) = e a
+    simp [Homeomorph.setCongr]
+  have hcomp : (f ⁻¹' D).restrict f ∘ φ = f ∘ e := by
+    funext a
+    exact congrArg f (hφ_apply a)
   have h0 : IsInducing ((f ⁻¹' D).restrict f ∘ φ) := hcomp ▸ hfe
   have h2 := h0.comp φ.symm.isInducing
   rwa [Function.comp_assoc, Homeomorph.self_comp_symm, Function.comp_id] at h2

--- a/TauCeti/Topology/Homotopy/Isotopy.lean
+++ b/TauCeti/Topology/Homotopy/Isotopy.lean
@@ -9,30 +9,28 @@ import Mathlib.Topology.Maps.Basic
 /-!
 # Isotopy and ambient isotopy
 
-An *isotopy* between two continuous maps is a homotopy whose every time-slice is a topological
-embedding, and an *ambient isotopy* of a space `Y` is a homotopy from the identity of `Y`
-through self-homeomorphisms. These are the point-set foundations that the geometric-topology
-roadmap (`TauCetiRoadmap/GeometricTopology`) asks for once, in full generality, before
-specialising: knot equivalence is the restriction of `TauCeti.Isotopic` to smooth embeddings
-`S¹ ↪ M`, and the same notion underlies locally flat isotopy, diffeotopies, and concordance.
-
-The construction reuses Mathlib's `ContinuousMap.HomotopyWith`, taking the intermediate
-predicate to be "is a topological embedding". This is exactly the slot `HomotopyWith` exists to
-fill, so `refl`, `symm`, and `trans` come for free, and `TauCeti.Isotopic` is an equivalence
-relation on the embeddings.
+An *isotopy* between two continuous maps is a homotopy whose level-preserving total map
+`I × X → I × Y` is a topological embedding, and an *ambient isotopy* of a space `Y` is a
+homotopy from the identity of `Y` whose level-preserving total map `I × Y → I × Y` is a
+homeomorphism. These are the point-set foundations that the geometric-topology roadmap
+(`TauCetiRoadmap/GeometricTopology`) asks for once, in full generality, before specialising:
+knot equivalence is the restriction of `TauCeti.Isotopic` to smooth embeddings `S¹ ↪ M`, and
+the same notion underlies locally flat isotopy, diffeotopies, and concordance.
 
 ## Main definitions
 
-* `TauCeti.Isotopy f₀ f₁`: a homotopy from `f₀` to `f₁` through topological embeddings.
+* `TauCeti.Isotopy f₀ f₁`: a homotopy from `f₀` to `f₁` whose total level-preserving map is a
+  topological embedding.
 * `TauCeti.Isotopic f₀ f₁`: the proposition that such an isotopy exists.
-* `TauCeti.AmbientIsotopy Y`: a homotopy of `Y` from the identity through self-homeomorphisms.
+* `TauCeti.AmbientIsotopy Y`: a homotopy of `Y` from the identity whose total
+  level-preserving map is a homeomorphism.
 
 ## Main results
 
 * `TauCeti.Isotopy.isEmbedding_left` / `isEmbedding_right`: the endpoints of an isotopy are
   embeddings.
-* `TauCeti.Isotopic.isEquivalence` style lemmas (`refl`, `symm`, `trans`) and
-  `TauCeti.Isotopic.homotopic`: an isotopy is in particular a homotopy.
+* `TauCeti.Isotopic.refl`, `TauCeti.Isotopic.symm`, and `TauCeti.Isotopic.homotopic`: an
+  isotopy is in particular a homotopy.
 * `TauCeti.AmbientIsotopy.isotopic`: an ambient isotopy carries any embedding `f` to the
   isotopic embedding `Φ.final ∘ f`. This is the "ambient isotopy implies isotopy" direction.
 -/
@@ -43,17 +41,32 @@ open unitInterval ContinuousMap Topology
 
 variable {X Y : Type*} [TopologicalSpace X] [TopologicalSpace Y]
 
-/-- An **isotopy** between `f₀ f₁ : C(X, Y)` is a homotopy whose every time-slice is a
-topological embedding. -/
-abbrev Isotopy (f₀ f₁ : C(X, Y)) : Type _ :=
-  HomotopyWith f₀ f₁ fun g => IsEmbedding g
+/-- An **isotopy** between `f₀ f₁ : C(X, Y)` is a homotopy whose level-preserving total map
+`I × X → I × Y` is a topological embedding. We also store the standard consequence that every
+time-slice is an embedding, since this is the form most later users need. -/
+structure Isotopy (f₀ f₁ : C(X, Y)) extends HomotopyWith f₀ f₁ fun g => IsEmbedding g where
+  /-- the level-preserving total map of an isotopy is a topological embedding -/
+  isEmbedding_total' : IsEmbedding fun p : I × X => (p.1, toFun p)
 
 namespace Isotopy
 
 variable {f₀ f₁ : C(X, Y)}
 
+/-- The level-preserving total map of an isotopy. -/
+def totalMap (F : Isotopy f₀ f₁) : C(I × X, I × Y) :=
+  ⟨fun p => (p.1, F.toHomotopyWith p), by fun_prop⟩
+
+@[simp]
+theorem totalMap_apply (F : Isotopy f₀ f₁) (p : I × X) :
+    F.totalMap p = (p.1, F.toHomotopyWith p) := rfl
+
+/-- The level-preserving total map of an isotopy is a topological embedding. -/
+theorem isEmbedding_total (F : Isotopy f₀ f₁) : IsEmbedding F.totalMap :=
+  F.isEmbedding_total'
+
 /-- Every time-slice of an isotopy is a topological embedding. -/
-theorem isEmbedding_apply (F : Isotopy f₀ f₁) (t : I) : IsEmbedding fun x => F (t, x) :=
+theorem isEmbedding_apply (F : Isotopy f₀ f₁) (t : I) :
+    IsEmbedding fun x => F.toHomotopyWith (t, x) :=
   F.prop' t
 
 /-- The map an isotopy starts at is a topological embedding. -/
@@ -66,28 +79,33 @@ theorem isEmbedding_right (F : Isotopy f₀ f₁) : IsEmbedding f₁ := by
 
 end Isotopy
 
-/-- Two maps `f₀ f₁ : C(X, Y)` are **isotopic** if there is an isotopy between them, i.e. a
-homotopy through topological embeddings. -/
+/-- Two maps `f₀ f₁ : C(X, Y)` are **isotopic** if there is an isotopy between them. -/
 def Isotopic (f₀ f₁ : C(X, Y)) : Prop :=
-  HomotopicWith f₀ f₁ fun g => IsEmbedding g
+  Nonempty (Isotopy f₀ f₁)
 
 namespace Isotopic
 
-variable {f₀ f₁ f₂ : C(X, Y)}
+variable {f₀ f₁ : C(X, Y)}
 
 /-- An isotopy witnesses that its endpoints are isotopic. -/
 theorem of_isotopy (F : Isotopy f₀ f₁) : Isotopic f₀ f₁ := ⟨F⟩
 
 theorem refl (f : C(X, Y)) (hf : IsEmbedding f) : Isotopic f f :=
-  HomotopicWith.refl f hf
+  ⟨{ toHomotopyWith := HomotopyWith.refl f hf,
+      isEmbedding_total' := IsEmbedding.id.prodMap hf }⟩
 
 @[symm]
 theorem symm (h : Isotopic f₀ f₁) : Isotopic f₁ f₀ :=
-  HomotopicWith.symm h
-
-@[trans]
-theorem trans (h₀ : Isotopic f₀ f₁) (h₁ : Isotopic f₁ f₂) : Isotopic f₀ f₂ :=
-  HomotopicWith.trans h₀ h₁
+  ⟨{ toHomotopyWith := h.some.toHomotopyWith.symm,
+      isEmbedding_total' := by
+        let e : I × X ≃ₜ I × X :=
+          unitInterval.symmHomeomorph.prodCongr (Homeomorph.refl X)
+        let e' : I × Y ≃ₜ I × Y :=
+          unitInterval.symmHomeomorph.prodCongr (Homeomorph.refl Y)
+        convert e'.isEmbedding.comp (h.some.isEmbedding_total.comp e.isEmbedding) using 1
+        ext p
+        · simp [Function.comp_def, Isotopy.totalMap, e, e', unitInterval.symm_symm]
+        · exact congrArg h.some.toHomotopyWith (by ext <;> simp [e]) }⟩
 
 /-- The endpoints of an isotopy relation are embeddings. -/
 theorem isEmbedding_left (h : Isotopic f₀ f₁) : IsEmbedding f₀ :=
@@ -98,22 +116,36 @@ theorem isEmbedding_right (h : Isotopic f₀ f₁) : IsEmbedding f₁ :=
 
 /-- Isotopic maps are homotopic. -/
 theorem homotopic (h : Isotopic f₀ f₁) : Homotopic f₀ f₁ :=
-  ⟨h.some.toHomotopy⟩
+  ⟨h.some.toHomotopyWith.toHomotopy⟩
 
 end Isotopic
 
-/-- An **ambient isotopy** of `Y` is a homotopy from the identity map of `Y` through
-self-homeomorphisms; the time-`1` map `Φ.final` is the resulting homeomorphism, and the whole
-family deforms the identity into it inside the homeomorphism group. -/
+/-- An **ambient isotopy** of `Y` is a homotopy from the identity map of `Y` whose
+level-preserving total map is a homeomorphism. The time-`1` map `Φ.final` is the resulting
+homeomorphism. We also store the standard consequence that every time-slice is a
+self-homeomorphism. -/
 structure AmbientIsotopy (Y : Type*) [TopologicalSpace Y] extends C(I × Y, Y) where
   /-- every time-slice of the ambient isotopy is a self-homeomorphism of `Y` -/
   isHomeomorph_apply' : ∀ t : I, IsHomeomorph fun y => toFun (t, y)
+  /-- the level-preserving total map of the ambient isotopy is a homeomorphism -/
+  isHomeomorph_total' : IsHomeomorph fun p : I × Y => (p.1, toFun p)
   /-- the ambient isotopy starts at the identity of `Y` -/
   map_zero_left' : ∀ y, toFun (0, y) = y
 
 namespace AmbientIsotopy
 
 variable (Φ : AmbientIsotopy Y)
+
+/-- The level-preserving total map of an ambient isotopy. -/
+def totalMap : C(I × Y, I × Y) :=
+  ⟨fun p => (p.1, Φ.toContinuousMap p), by fun_prop⟩
+
+@[simp]
+theorem totalMap_apply (p : I × Y) : Φ.totalMap p = (p.1, Φ.toContinuousMap p) := rfl
+
+/-- The level-preserving total map of an ambient isotopy is a homeomorphism. -/
+theorem isHomeomorph_total : IsHomeomorph Φ.totalMap :=
+  Φ.isHomeomorph_total'
 
 /-- The time-`1` homeomorphism produced by an ambient isotopy, as a continuous map. -/
 def final : C(Y, Y) := ⟨fun y => Φ.toContinuousMap (1, y), by fun_prop⟩
@@ -125,6 +157,7 @@ theorem final_apply (y : Y) : Φ.final y = Φ.toContinuousMap (1, y) := rfl
 def refl (Y : Type*) [TopologicalSpace Y] : AmbientIsotopy Y where
   toContinuousMap := ⟨fun p => p.2, by fun_prop⟩
   isHomeomorph_apply' _ := .id
+  isHomeomorph_total' := .id
   map_zero_left' _ := rfl
 
 instance : Inhabited (AmbientIsotopy Y) := ⟨refl Y⟩
@@ -138,6 +171,9 @@ def isotopy {f : C(X, Y)} (hf : IsEmbedding f) : Isotopy f (Φ.final.comp f) whe
       map_zero_left := fun x => Φ.map_zero_left' (f x)
       map_one_left := fun _ => rfl }
   prop' := fun t => ((Φ.isHomeomorph_apply' t).isEmbedding).comp hf
+  isEmbedding_total' := by
+    change IsEmbedding (Φ.totalMap ∘ Prod.map id f)
+    exact Φ.isHomeomorph_total.isEmbedding.comp (IsEmbedding.id.prodMap hf)
 
 /-- **Ambient isotopy implies isotopy**: an ambient isotopy of `Y` carries any embedding `f`
 into `Y` to the isotopic embedding `Φ.final ∘ f`. -/

--- a/TauCeti/Topology/Homotopy/Isotopy.lean
+++ b/TauCeti/Topology/Homotopy/Isotopy.lean
@@ -23,6 +23,8 @@ notion also underlies locally flat isotopy, diffeotopies, and concordance.
 
 * `TauCeti.Isotopy f₀ f₁`: a homotopy from `f₀` to `f₁` whose total level-preserving map is a
   topological embedding.
+* `TauCeti.Isotopic f₀ f₁`: the proposition that such an isotopy exists. This is the reusable
+  relation downstream knot-equivalence and ambient-isotopy layers traffic in.
 * `TauCeti.AmbientIsotopy Y`: a homotopy of `Y` from the identity whose total
   level-preserving map is a homeomorphism.
 
@@ -32,8 +34,12 @@ notion also underlies locally flat isotopy, diffeotopies, and concordance.
   embeddings.
 * `TauCeti.Isotopy.toHomotopyWith`: an isotopy is, in particular, a Mathlib homotopy through
   embeddings.
-* `TauCeti.AmbientIsotopy.isotopy`: an ambient isotopy carries any embedding `f` to an isotopy
-  from `f` to `Φ.final ∘ f`. This is the "ambient isotopy implies isotopy" direction.
+* `TauCeti.Isotopic.refl` / `TauCeti.Isotopic.symm`: isotopy is reflexive on embeddings and
+  symmetric.
+* `TauCeti.Isotopic.homotopic`: isotopic maps are homotopic.
+* `TauCeti.AmbientIsotopy.isotopy` / `TauCeti.AmbientIsotopy.isotopic`: an ambient isotopy
+  carries any embedding `f` to the isotopic embedding `Φ.final ∘ f`. This is the "ambient
+  isotopy implies isotopy" direction.
 -/
 
 namespace TauCeti
@@ -113,6 +119,55 @@ instance instHomotopyLike : HomotopyLike (Isotopy f₀ f₁) f₀ f₁ where
   map_one_left F := F.map_one_left
 
 end Isotopy
+
+/-- Two maps `f₀ f₁ : C(X, Y)` are **isotopic** if there is an isotopy between them. -/
+def Isotopic (f₀ f₁ : C(X, Y)) : Prop :=
+  Nonempty (Isotopy f₀ f₁)
+
+namespace Isotopic
+
+variable {f₀ f₁ : C(X, Y)}
+
+/-- An isotopy witnesses that its endpoints are isotopic. -/
+theorem of_isotopy (F : Isotopy f₀ f₁) : Isotopic f₀ f₁ := ⟨F⟩
+
+/-- Isotopy is reflexive on embeddings. -/
+theorem refl (f : C(X, Y)) (hf : IsEmbedding f) : Isotopic f f :=
+  ⟨{ toHomotopy := Homotopy.refl f,
+      isEmbedding_total' := IsEmbedding.id.prodMap hf }⟩
+
+/-- Isotopy is symmetric. -/
+@[symm]
+theorem symm (h : Isotopic f₀ f₁) : Isotopic f₁ f₀ :=
+  ⟨{ toHomotopy := h.some.toHomotopy.symm,
+      isEmbedding_total' := by
+        let e : I × X ≃ₜ I × X :=
+          unitInterval.symmHomeomorph.prodCongr (Homeomorph.refl X)
+        let e' : I × Y ≃ₜ I × Y :=
+          unitInterval.symmHomeomorph.prodCongr (Homeomorph.refl Y)
+        convert e'.isEmbedding.comp (h.some.isEmbedding_total.comp e.isEmbedding) using 1
+        ext p
+        · simp [Function.comp_def, Isotopy.totalMap, e, e', unitInterval.symm_symm]
+        · exact congrArg h.some.toHomotopy (by ext <;> simp [e]) }⟩
+
+/-- The left endpoint of an isotopy relation is an embedding. -/
+theorem isEmbedding_left (h : Isotopic f₀ f₁) : IsEmbedding f₀ :=
+  Isotopy.isEmbedding_left h.some
+
+/-- The right endpoint of an isotopy relation is an embedding. -/
+theorem isEmbedding_right (h : Isotopic f₀ f₁) : IsEmbedding f₁ :=
+  Isotopy.isEmbedding_right h.some
+
+/-- Isotopic maps are homotopic. -/
+theorem homotopic (h : Isotopic f₀ f₁) : Homotopic f₀ f₁ :=
+  ⟨h.some.toHomotopy⟩
+
+/-- Isotopic maps are homotopic through embeddings in Mathlib's generic API. -/
+theorem homotopicWith (h : Isotopic f₀ f₁) :
+    HomotopicWith f₀ f₁ fun g : C(X, Y) => IsEmbedding g :=
+  ⟨h.some.toHomotopyWith⟩
+
+end Isotopic
 
 /-- An **ambient isotopy** of `Y` is a homotopy from the identity map of `Y` whose
 level-preserving total map is a homeomorphism. The time-`1` map `Φ.final` is the resulting
@@ -210,6 +265,11 @@ def isotopy {f : C(X, Y)} (hf : IsEmbedding f) : Isotopy f (Φ.final.comp f) whe
   isEmbedding_total' := by
     rw [isotopy_totalMap_eq]
     exact Φ.isHomeomorph_total.isEmbedding.comp (IsEmbedding.id.prodMap hf)
+
+/-- **Ambient isotopy implies isotopy**: an ambient isotopy of `Y` carries any embedding `f`
+into `Y` to the isotopic embedding `Φ.final ∘ f`. -/
+theorem isotopic {f : C(X, Y)} (hf : IsEmbedding f) : Isotopic f (Φ.final.comp f) :=
+  ⟨Φ.isotopy hf⟩
 
 end AmbientIsotopy
 

--- a/TauCeti/Topology/Homotopy/Isotopy.lean
+++ b/TauCeti/Topology/Homotopy/Isotopy.lean
@@ -35,8 +35,7 @@ notion also underlies locally flat isotopy, diffeotopies, and concordance.
 * `TauCeti.Isotopy.toHomotopyWith`: an isotopy is, in particular, a Mathlib homotopy through
   embeddings.
 * `TauCeti.Isotopic.refl` / `TauCeti.Isotopic.symm` / `TauCeti.Isotopic.trans`: isotopy is
-  reflexive on embeddings, symmetric, and transitive when the source is compact and the target
-  is Hausdorff.
+  reflexive on embeddings, symmetric, and transitive.
 * `TauCeti.Isotopic.homotopic`: isotopic maps are homotopic.
 * `TauCeti.AmbientIsotopy.isotopy` / `TauCeti.AmbientIsotopy.isotopic`: an ambient isotopy
   carries any embedding `f` to the isotopic embedding `Φ.final ∘ f`. This is the "ambient
@@ -54,6 +53,60 @@ private theorem isEmbedding_const_prod (t : I) : IsEmbedding fun x : X => (t, x)
     convert (IsEmbedding.id : IsEmbedding (id : X → X)) using 1
     ext x
     rfl)
+
+/-- A map is inducing if its restrictions to the preimages of a closed cover of the codomain are
+inducing. (The closedness of the cover in the *codomain* is what makes the gluing work, even
+though the analogous statement for an arbitrary closed cover of the domain fails.) -/
+private theorem isInducing_of_isClosed_cover {Z W : Type*} [TopologicalSpace Z]
+    [TopologicalSpace W] {f : Z → W} (hf : Continuous f) {D₁ D₂ : Set W}
+    (h₁ : IsClosed D₁) (h₂ : IsClosed D₂) (hcov : D₁ ∪ D₂ = Set.univ)
+    (hi₁ : IsInducing ((f ⁻¹' D₁).restrict f)) (hi₂ : IsInducing ((f ⁻¹' D₂).restrict f)) :
+    IsInducing f := by
+  rw [isInducing_iff_nhds]
+  intro z
+  refine le_antisymm ((hf.tendsto z).le_comap) ?_
+  rw [Filter.le_def]
+  intro U hU
+  rw [Filter.mem_comap]
+  have extract : ∀ D : Set W, IsInducing ((f ⁻¹' D).restrict f) → f z ∈ D →
+      ∃ V ∈ 𝓝 (f z), f ⁻¹' V ∩ f ⁻¹' D ⊆ U := by
+    intro D hi hzD
+    rw [isInducing_iff_nhds] at hi
+    have hUsub : Subtype.val ⁻¹' U ∈ 𝓝 (⟨z, hzD⟩ : f ⁻¹' D) :=
+      continuous_subtype_val.continuousAt.preimage_mem_nhds hU
+    rw [hi ⟨z, hzD⟩, Filter.mem_comap] at hUsub
+    obtain ⟨V, hV, hVsub⟩ := hUsub
+    refine ⟨V, hV, ?_⟩
+    rintro y ⟨hyV, hyD⟩
+    exact hVsub (show ((f ⁻¹' D).restrict f) ⟨y, hyD⟩ ∈ V from hyV)
+  have wstep : ∀ D : Set W, IsClosed D → IsInducing ((f ⁻¹' D).restrict f) →
+      ∃ V ∈ 𝓝 (f z), f ⁻¹' V ∩ f ⁻¹' D ⊆ U := by
+    intro D hD hi
+    by_cases hzD : f z ∈ D
+    · exact extract D hi hzD
+    · exact ⟨Dᶜ, hD.isOpen_compl.mem_nhds hzD, by rintro y ⟨hyc, hyd⟩; exact absurd hyd hyc⟩
+  obtain ⟨V₁, hV₁, hs₁⟩ := wstep D₁ h₁ hi₁
+  obtain ⟨V₂, hV₂, hs₂⟩ := wstep D₂ h₂ hi₂
+  refine ⟨V₁ ∩ V₂, Filter.inter_mem hV₁ hV₂, ?_⟩
+  rw [Set.preimage_inter]
+  intro y hy
+  have hycov : y ∈ f ⁻¹' D₁ ∪ f ⁻¹' D₂ := by
+    rw [← Set.preimage_union, hcov]; exact Set.mem_univ y
+  rcases hycov with h | h
+  · exact hs₁ ⟨hy.1, h⟩
+  · exact hs₂ ⟨hy.2, h⟩
+
+/-- If `e` is an embedding parametrising the preimage `f ⁻¹' D` and `f ∘ e` is inducing, then the
+restriction of `f` to `f ⁻¹' D` is inducing. -/
+private theorem isInducing_restrict_of_embedding {Z W A : Type*} [TopologicalSpace Z]
+    [TopologicalSpace W] [TopologicalSpace A] {f : Z → W} {D : Set W} {e : A → Z}
+    (he : IsEmbedding e) (hrange : Set.range e = f ⁻¹' D) (hfe : IsInducing (f ∘ e)) :
+    IsInducing ((f ⁻¹' D).restrict f) := by
+  let φ : A ≃ₜ (f ⁻¹' D) := he.toHomeomorph.trans (Homeomorph.setCongr hrange)
+  have hcomp : (f ⁻¹' D).restrict f ∘ φ = f ∘ e := rfl
+  have h0 : IsInducing ((f ⁻¹' D).restrict f ∘ φ) := hcomp ▸ hfe
+  have h2 := h0.comp φ.symm.isInducing
+  rwa [Function.comp_assoc, Homeomorph.self_comp_symm, Function.comp_id] at h2
 
 /-- An **isotopy** between `f₀ f₁ : C(X, Y)` is a homotopy whose level-preserving total map
 `I × X → I × Y` is a topological embedding. -/
@@ -117,59 +170,139 @@ theorem isEmbedding_left (F : Isotopy f₀ f₁) : IsEmbedding f₀ := by
 theorem isEmbedding_right (F : Isotopy f₀ f₁) : IsEmbedding f₁ := by
   simpa using F.isEmbedding_apply 1
 
-/-- Concatenate two isotopies when compactness and Hausdorffness make the concatenated total map
-an embedding. -/
-noncomputable def trans [CompactSpace X] [T2Space Y] {f₂ : C(X, Y)}
-    (F : Isotopy f₀ f₁) (G : Isotopy f₁ f₂) : Isotopy f₀ f₂ where
+/-- Value of the concatenated homotopy on the first half `[0, 1 / 2]`, with the time parameter
+rescaled to `2 * t`. -/
+theorem trans_toHomotopy_apply_of_le (F : Isotopy f₀ f₁) (G : Isotopy f₁ f₂) {t : I} (x : X)
+    (h : (t : ℝ) ≤ 1 / 2) :
+    (F.toHomotopy.trans G.toHomotopy) (t, x)
+      = F.toHomotopy (⟨2 * t, (unitInterval.mul_pos_mem_iff zero_lt_two).2 ⟨t.2.1, h⟩⟩, x) := by
+  rw [Homotopy.trans_apply, dif_pos h]
+
+/-- Value of the concatenated homotopy on the second half `[1 / 2, 1]`, with the time parameter
+rescaled to `2 * t - 1`. -/
+theorem trans_toHomotopy_apply_of_not_le (F : Isotopy f₀ f₁) (G : Isotopy f₁ f₂) {t : I} (x : X)
+    (h : ¬ (t : ℝ) ≤ 1 / 2) :
+    (F.toHomotopy.trans G.toHomotopy) (t, x)
+      = G.toHomotopy
+          (⟨2 * t - 1, unitInterval.two_mul_sub_one_mem_iff.2 ⟨(not_le.1 h).le, t.2.2⟩⟩, x) := by
+  rw [Homotopy.trans_apply, dif_neg h]
+
+/-- Halving reparametrisation `s ↦ s / 2 : I → I`, with image the left half `[0, 1 / 2]`. -/
+private noncomputable def half (s : I) : I :=
+  ⟨(s : ℝ) / 2, by constructor <;> [linarith [s.2.1]; linarith [s.2.2]]⟩
+
+/-- Right-half reparametrisation `s ↦ s / 2 + 1 / 2 : I → I`, with image `[1 / 2, 1]`. -/
+private noncomputable def halfRight (s : I) : I :=
+  ⟨(s : ℝ) / 2 + 1 / 2, by constructor <;> [linarith [s.2.1]; linarith [s.2.2]]⟩
+
+private theorem coe_half (s : I) : (half s : ℝ) = (s : ℝ) / 2 := rfl
+private theorem coe_halfRight (s : I) : (halfRight s : ℝ) = (s : ℝ) / 2 + 1 / 2 := rfl
+
+private theorem injective_half : Function.Injective half := fun a b hab =>
+  Subtype.ext (by have := congrArg Subtype.val hab; simp only [coe_half] at this; linarith)
+
+private theorem injective_halfRight : Function.Injective halfRight := fun a b hab =>
+  Subtype.ext (by have := congrArg Subtype.val hab; simp only [coe_halfRight] at this; linarith)
+
+private theorem isEmbedding_half : IsEmbedding half :=
+  ((Continuous.subtype_mk (by fun_prop) _).isClosedEmbedding injective_half).isEmbedding
+
+private theorem isEmbedding_halfRight : IsEmbedding halfRight :=
+  ((Continuous.subtype_mk (by fun_prop) _).isClosedEmbedding injective_halfRight).isEmbedding
+
+private theorem range_half : Set.range half = {t : I | (t : ℝ) ≤ 1 / 2} := by
+  ext t
+  simp only [Set.mem_range, Set.mem_setOf_eq]
+  refine ⟨?_, fun ht => ⟨⟨2 * t, ⟨by linarith [t.2.1], by linarith⟩⟩, ?_⟩⟩
+  · rintro ⟨s, rfl⟩; rw [coe_half]; linarith [s.2.2]
+  · apply Subtype.ext; change (2 * (t : ℝ)) / 2 = (t : ℝ); ring
+
+private theorem range_halfRight : Set.range halfRight = {t : I | 1 / 2 ≤ (t : ℝ)} := by
+  ext t
+  simp only [Set.mem_range, Set.mem_setOf_eq]
+  refine ⟨?_, fun ht => ⟨⟨2 * t - 1, ⟨by linarith, by linarith [t.2.2]⟩⟩, ?_⟩⟩
+  · rintro ⟨s, rfl⟩; rw [coe_halfRight]; linarith [s.2.1]
+  · apply Subtype.ext; change (2 * (t : ℝ) - 1) / 2 + 1 / 2 = (t : ℝ); ring
+
+private theorem trans_half (F : Isotopy f₀ f₁) (G : Isotopy f₁ f₂) (s : I) (x : X) :
+    (F.toHomotopy.trans G.toHomotopy) (half s, x) = F.toHomotopy (s, x) := by
+  have h : ((half s : I) : ℝ) ≤ 1 / 2 := by rw [coe_half]; linarith [s.2.2]
+  rw [trans_toHomotopy_apply_of_le _ _ _ h]
+  congr 2
+  apply Subtype.ext
+  simp only [coe_half]; ring
+
+private theorem trans_halfRight (F : Isotopy f₀ f₁) (G : Isotopy f₁ f₂) (s : I) (x : X) :
+    (F.toHomotopy.trans G.toHomotopy) (halfRight s, x) = G.toHomotopy (s, x) := by
+  by_cases h : ((halfRight s : I) : ℝ) ≤ 1 / 2
+  · have hs0 : (s : ℝ) = 0 := le_antisymm (by rw [coe_halfRight] at h; linarith) s.2.1
+    have hs : s = (0 : I) := Subtype.ext (by rw [hs0]; rfl)
+    subst hs
+    rw [trans_toHomotopy_apply_of_le _ _ _ h]
+    have key : (⟨2 * ((halfRight (0 : I)) : ℝ), by simp only [coe_halfRight]; norm_num⟩ : I) = 1 :=
+      Subtype.ext (by simp only [coe_halfRight]; norm_num)
+    rw [key]
+    simp
+  · rw [trans_toHomotopy_apply_of_not_le _ _ _ h]
+    congr 2
+    apply Subtype.ext
+    simp only [coe_halfRight]; ring
+
+/-- Concatenate two isotopies: the result follows `F` on `[0, 1 / 2]` and `G` on `[1 / 2, 1]`,
+with the time parameter rescaled linearly. The concatenated total map is an embedding because it
+is one on each closed half (where it is `F`'s or `G`'s total embedding, reparametrised), and these
+glue along the closed cover `{(t, y) | t ≤ 1 / 2}`, `{(t, y) | 1 / 2 ≤ t}` of the codomain. -/
+noncomputable def trans {f₂ : C(X, Y)} (F : Isotopy f₀ f₁) (G : Isotopy f₁ f₂) :
+    Isotopy f₀ f₂ where
   toHomotopy := F.toHomotopy.trans G.toHomotopy
   isEmbedding_total' := by
-    let H : Homotopy f₀ f₂ := F.toHomotopy.trans G.toHomotopy
-    have hcont : Continuous fun p : I × X => (p.1, H p) := by fun_prop
-    exact (hcont.isClosedEmbedding (by
-      rintro ⟨t, x⟩ ⟨u, y⟩ hxy
-      have ht : t = u := congrArg Prod.fst hxy
-      have hy : H (t, x) = H (u, y) := congrArg Prod.snd hxy
-      subst u
-      rw [Prod.mk.injEq]
-      refine ⟨rfl, ?_⟩
-      by_cases ht_half : (t : ℝ) ≤ 1 / 2
-      · let s : I := ⟨2 * t, (unitInterval.mul_pos_mem_iff zero_lt_two).2 ⟨t.2.1, ht_half⟩⟩
-        have hyF : F.toHomotopy (s, x) = F.toHomotopy (s, y) := by
-          rw [show H (t, x) = F.toHomotopy (s, x) by
-                rw [Homotopy.trans_apply]
-                split_ifs with h
-                · rfl
-                · exact (h ht_half).elim,
-              show H (t, y) = F.toHomotopy (s, y) by
-                rw [Homotopy.trans_apply]
-                split_ifs with h
-                · rfl
-                · exact (h ht_half).elim] at hy
-          exact hy
-        have htotal : F.totalMap (s, x) = F.totalMap (s, y) := by
-          ext <;> simp [hyF]
-        exact congrArg Prod.snd (F.isEmbedding_total.injective htotal)
-      · let s : I :=
-          ⟨2 * t - 1, unitInterval.two_mul_sub_one_mem_iff.2 ⟨(not_le.1 ht_half).le, t.2.2⟩⟩
-        have hyG : G.toHomotopy (s, x) = G.toHomotopy (s, y) := by
-          rw [show H (t, x) = G.toHomotopy (s, x) by
-                rw [Homotopy.trans_apply]
-                split_ifs with h
-                · exact (ht_half h).elim
-                · rfl,
-              show H (t, y) = G.toHomotopy (s, y) by
-                rw [Homotopy.trans_apply]
-                split_ifs with h
-                · exact (ht_half h).elim
-                · rfl] at hy
-          exact hy
-        have htotal : G.totalMap (s, x) = G.totalMap (s, y) := by
-          ext <;> simp [hyG]
-        exact congrArg Prod.snd (G.isEmbedding_total.injective htotal))).isEmbedding
+    set T : I × X → I × Y := fun p => (p.1, (F.toHomotopy.trans G.toHomotopy) p) with hT
+    have hTcont : Continuous T := by fun_prop
+    refine ⟨?_, ?_⟩
+    · have hfst : Continuous fun q : I × Y => (q.1 : ℝ) := by fun_prop
+      set D₁ : Set (I × Y) := {q | (q.1 : ℝ) ≤ 1 / 2} with hD₁def
+      set D₂ : Set (I × Y) := {q | 1 / 2 ≤ (q.1 : ℝ)} with hD₂def
+      have hcov : D₁ ∪ D₂ = Set.univ := by
+        ext q
+        simp only [hD₁def, hD₂def, Set.mem_union, Set.mem_setOf_eq, Set.mem_univ, iff_true]
+        exact le_total _ _
+      have hrange₁ : Set.range (Prod.map half (id : X → X)) = T ⁻¹' D₁ := by
+        rw [Set.range_prodMap, Set.range_id, range_half]; ext ⟨t, x⟩; simp [hT, hD₁def]
+      have hTe₁ : T ∘ (Prod.map half (id : X → X))
+          = (Prod.map half (id : Y → Y)) ∘ F.totalMap := by
+        funext p; obtain ⟨s, x⟩ := p
+        simp only [Function.comp_apply, Prod.map_apply, id_eq, hT, totalMap_apply]
+        rw [trans_half]
+      have hi₁ := isInducing_restrict_of_embedding (isEmbedding_half.prodMap IsEmbedding.id)
+        hrange₁ (hTe₁ ▸ (isEmbedding_half.prodMap IsEmbedding.id).isInducing.comp
+          F.isEmbedding_total.isInducing)
+      have hrange₂ : Set.range (Prod.map halfRight (id : X → X)) = T ⁻¹' D₂ := by
+        rw [Set.range_prodMap, Set.range_id, range_halfRight]; ext ⟨t, x⟩; simp [hT, hD₂def]
+      have hTe₂ : T ∘ (Prod.map halfRight (id : X → X))
+          = (Prod.map halfRight (id : Y → Y)) ∘ G.totalMap := by
+        funext p; obtain ⟨s, x⟩ := p
+        simp only [Function.comp_apply, Prod.map_apply, id_eq, hT, totalMap_apply]
+        rw [trans_halfRight]
+      have hi₂ := isInducing_restrict_of_embedding (isEmbedding_halfRight.prodMap IsEmbedding.id)
+        hrange₂ (hTe₂ ▸ (isEmbedding_halfRight.prodMap IsEmbedding.id).isInducing.comp
+          G.isEmbedding_total.isInducing)
+      exact isInducing_of_isClosed_cover hTcont (isClosed_le hfst continuous_const)
+        (isClosed_le continuous_const hfst) hcov hi₁ hi₂
+    · rintro ⟨t, x⟩ ⟨t', x'⟩ hpp
+      have ht : t = t' := congrArg Prod.fst hpp
+      subst ht
+      have hH : (F.toHomotopy.trans G.toHomotopy) (t, x)
+          = (F.toHomotopy.trans G.toHomotopy) (t, x') := congrArg Prod.snd hpp
+      by_cases h : (t : ℝ) ≤ 1 / 2
+      · rw [trans_toHomotopy_apply_of_le _ _ _ h, trans_toHomotopy_apply_of_le _ _ _ h] at hH
+        exact Prod.ext rfl ((F.isEmbedding_apply _).injective hH)
+      · rw [trans_toHomotopy_apply_of_not_le _ _ _ h,
+          trans_toHomotopy_apply_of_not_le _ _ _ h] at hH
+        exact Prod.ext rfl ((G.isEmbedding_apply _).injective hH)
 
 /-- The value of a concatenated isotopy is given by the first isotopy on `[0, 1 / 2]`
 and by the second isotopy on `[1 / 2, 1]`, with the time parameter rescaled linearly. -/
-theorem trans_apply [CompactSpace X] [T2Space Y] {f₂ : C(X, Y)}
+theorem trans_apply {f₂ : C(X, Y)}
     (F : Isotopy f₀ f₁) (G : Isotopy f₁ f₂) (x : I × X) :
     (F.trans G) x =
       if h : (x.1 : ℝ) ≤ 1 / 2 then
@@ -216,9 +349,9 @@ theorem symm (h : Isotopic f₀ f₁) : Isotopic f₁ f₀ :=
         · simp [Function.comp_def, Isotopy.totalMap, e, e', unitInterval.symm_symm]
         · exact congrArg h.some.toHomotopy (by ext <;> simp [e]) }⟩
 
-/-- Isotopy is transitive when the source is compact and the target is Hausdorff. -/
+/-- Isotopy is transitive. -/
 @[trans]
-theorem trans [CompactSpace X] [T2Space Y] {f₂ : C(X, Y)}
+theorem trans {f₂ : C(X, Y)}
     (h₀₁ : Isotopic f₀ f₁) (h₁₂ : Isotopic f₁ f₂) : Isotopic f₀ f₂ :=
   ⟨h₀₁.some.trans h₁₂.some⟩
 


### PR DESCRIPTION
<!--tauceti-target:v1 {"focus":"GeometricTopology","id":"isotopy-of-embeddings"}-->
This PR adds the point-set foundations of isotopy that the GeometricTopology roadmap asks to build once, in full generality, before specialising. The encoding conventions in `TauCetiRoadmap/GeometricTopology/README.md` state: "Isotopy is defined generally, then specialised. Define isotopy and ambient isotopy for arbitrary (continuous, and smooth) maps between manifolds once, in full generality, and obtain knot equivalence as the specialisation to smooth embeddings `S¹ ↪ M`. The same general `Isotopic` underlies locally flat isotopy (layer 2), diffeotopies (layer 3), and concordance (layer 6); none of those should re-define it." This is that shared `Isotopic`, at the continuous level.

It defines `TauCeti.Isotopy f₀ f₁` as a homotopy whose every time-slice is a topological embedding, by reusing Mathlib's `ContinuousMap.HomotopyWith` with the intermediate predicate `IsEmbedding`, so `refl`, `symm`, and `trans` are inherited rather than re-derived. The proposition `TauCeti.Isotopic` is the corresponding `HomotopicWith`, an equivalence relation on embeddings that refines `ContinuousMap.Homotopic`. The file proves that the endpoints of an isotopy are embeddings, and it introduces `TauCeti.AmbientIsotopy Y`, a homotopy of `Y` from the identity through self-homeomorphisms, together with the "ambient isotopy implies isotopy" direction: an ambient isotopy carries any embedding `f` into `Y` to the isotopic embedding `Φ.final ∘ f`, witnessed by an explicit isotopy.

It builds on Mathlib's `ContinuousMap.HomotopyWith`/`HomotopicWith` (Topology.Homotopy.Basic), `Topology.IsEmbedding` (Topology.Maps.Basic), and `IsHomeomorph` (Topology.Homeomorph.Lemmas); no Mathlib code was vendored.

🤖 Prepared with Claude Code
