### PR TITLE
feat: identify a grid rectangle move with a column transposition

### DIFF
--- a/TauCeti/KnotTheory/Grid/Diagram.lean
+++ b/TauCeti/KnotTheory/Grid/Diagram.lean
@@ -302,6 +302,107 @@ theorem swapColumns_swapColumns (a b : Fin n) (x : GridState n) :
   ext c
   simp [swapColumns]
 
+/-- A square is shared by a grid state and the state with columns `a` and `b` swapped exactly
+when it is a source-state square away from the two swapped columns. -/
+@[simp]
+theorem mem_pointSet_inter_swapColumns_iff (x : GridState n) {a b : Fin n} (h : a ≠ b)
+    (p : Fin n × Fin n) :
+    p ∈ x.pointSet ∩ (x.swapColumns a b).pointSet ↔
+      p ∈ x.pointSet ∧ p.1 ≠ a ∧ p.1 ≠ b := by
+  rw [Finset.mem_inter, mem_pointSet_swapColumns]
+  constructor
+  · rintro ⟨hx, hswap⟩
+    refine ⟨hx, ?_, ?_⟩
+    · rintro hpa
+      have hxa : x a = p.2 := by
+        simpa [hpa] using (mem_pointSet x p).mp hx
+      have hxb : x b = p.2 := by
+        simpa [hpa] using (mem_pointSet x (Equiv.swap a b p.1, p.2)).mp hswap
+      exact h (x.toPerm.injective (hxa.trans hxb.symm))
+    · rintro hpb
+      have hxb : x b = p.2 := by
+        simpa [hpb] using (mem_pointSet x p).mp hx
+      have hxa : x a = p.2 := by
+        simpa [hpb] using (mem_pointSet x (Equiv.swap a b p.1, p.2)).mp hswap
+      exact h (x.toPerm.injective (hxa.trans hxb.symm))
+  · rintro ⟨hx, ha, hb⟩
+    refine ⟨hx, ?_⟩
+    simpa [Equiv.swap_apply_of_ne_of_ne ha hb] using hx
+
+/-- The point set of a grid state is the shared part with a column swap, together with the two
+source-state squares in the swapped columns. -/
+theorem pointSet_eq_insert_insert_inter_swapColumns (x : GridState n) {a b : Fin n} (h : a ≠ b) :
+    x.pointSet =
+      insert (a, x a) (insert (b, x b) (x.pointSet ∩ (x.swapColumns a b).pointSet)) := by
+  ext p
+  simp only [Finset.mem_insert]
+  constructor
+  · intro hx
+    rcases eq_or_ne p.1 a with ha | ha
+    · refine Or.inl ?_
+      have : p.2 = x a := by
+        simpa [ha] using ((mem_pointSet x p).mp hx).symm
+      exact Prod.ext ha this
+    · rcases eq_or_ne p.1 b with hb | hb
+      · refine Or.inr (Or.inl ?_)
+        have : p.2 = x b := by
+          simpa [hb] using ((mem_pointSet x p).mp hx).symm
+        exact Prod.ext hb this
+      · exact Or.inr (Or.inr ((mem_pointSet_inter_swapColumns_iff x h p).mpr ⟨hx, ha, hb⟩))
+  · rintro (rfl | rfl | hp)
+    · simp
+    · simp
+    · exact Finset.mem_of_mem_inter_left hp
+
+/-- The point set after swapping columns `a` and `b` is the shared part with the source state,
+together with the two target-state squares in the swapped columns. -/
+theorem swapColumns_pointSet_eq_insert_insert_inter (x : GridState n) {a b : Fin n} (h : a ≠ b) :
+    (x.swapColumns a b).pointSet =
+      insert (a, x b) (insert (b, x a) (x.pointSet ∩ (x.swapColumns a b).pointSet)) := by
+  ext p
+  simp only [Finset.mem_insert]
+  constructor
+  · intro hp
+    rcases eq_or_ne p.1 a with ha | ha
+    · refine Or.inl ?_
+      have : p.2 = x b := by
+        simpa [ha] using ((mem_pointSet (x.swapColumns a b) p).mp hp).symm
+      exact Prod.ext ha this
+    · rcases eq_or_ne p.1 b with hb | hb
+      · refine Or.inr (Or.inl ?_)
+        have : p.2 = x a := by
+          simpa [hb] using ((mem_pointSet (x.swapColumns a b) p).mp hp).symm
+        exact Prod.ext hb this
+      · refine Or.inr (Or.inr ?_)
+        have hx : p ∈ x.pointSet := by
+          rw [mem_pointSet] at hp ⊢
+          rw [swapColumns_apply, Equiv.swap_apply_of_ne_of_ne ha hb] at hp
+          exact hp
+        exact (mem_pointSet_inter_swapColumns_iff x h p).mpr ⟨hx, ha, hb⟩
+  · rintro (rfl | rfl | hp)
+    · simp
+    · simp
+    · exact Finset.mem_of_mem_inter_right hp
+
+/-- A grid state and a swap of two distinct columns share exactly `n - 2` squares. -/
+theorem card_pointSet_inter_swapColumns (x : GridState n) {a b : Fin n} (h : a ≠ b) :
+    (x.pointSet ∩ (x.swapColumns a b).pointSet).card = n - 2 := by
+  have hne : (b, x b) ∉ x.pointSet ∩ (x.swapColumns a b).pointSet := by
+    rw [mem_pointSet_inter_swapColumns_iff x h]
+    rintro ⟨_, _, hb⟩
+    exact hb rfl
+  have hne' :
+      (a, x a) ∉ insert (b, x b) (x.pointSet ∩ (x.swapColumns a b).pointSet) := by
+    rw [Finset.mem_insert]
+    rintro (hab | ha)
+    · exact absurd (congrArg Prod.fst hab) h
+    · rw [mem_pointSet_inter_swapColumns_iff x h] at ha
+      exact ha.2.1 rfl
+  have hcard := congrArg Finset.card (pointSet_eq_insert_insert_inter_swapColumns x h)
+  rw [card_pointSet, Finset.card_insert_of_notMem hne',
+    Finset.card_insert_of_notMem hne] at hcard
+  omega
+
 end GridState
 
 /-- An `n × n` grid diagram, encoded by the `O`-marking and `X`-marking permutation graphs.

--- a/TauCeti/KnotTheory/Grid/Diagram.lean
+++ b/TauCeti/KnotTheory/Grid/Diagram.lean
@@ -288,6 +288,31 @@ theorem mem_pointSet_swapColumns (a b : Fin n) (x : GridState n) (p : Fin n × F
     p ∈ (x.swapColumns a b).pointSet ↔ (Equiv.swap a b p.1, p.2) ∈ x.pointSet := by
   simp [swapColumns]
 
+/-- A square is shared by a grid state and a column relabeling exactly when it is a
+source-state square whose column is fixed by the relabeling permutation. -/
+@[simp]
+theorem mem_pointSet_inter_relabelColumns_iff (x : GridState n) (κ : Equiv.Perm (Fin n))
+    (p : Fin n × Fin n) :
+    p ∈ x.pointSet ∩ (x.relabelColumns κ).pointSet ↔ p ∈ x.pointSet ∧ κ p.1 = p.1 := by
+  rw [Finset.mem_inter, mem_pointSet_relabelColumns]
+  constructor
+  · rintro ⟨hx, hκ⟩
+    refine ⟨hx, ?_⟩
+    have hx_col : x p.1 = p.2 := (mem_pointSet x p).mp hx
+    have hκ_col : x (κ.symm p.1) = p.2 :=
+      (mem_pointSet x (κ.symm p.1, p.2)).mp hκ
+    have hfixed_symm : κ.symm p.1 = p.1 :=
+      x.toPerm.injective (hκ_col.trans hx_col.symm)
+    calc
+      κ p.1 = κ (κ.symm p.1) := by rw [hfixed_symm]
+      _ = p.1 := by simp
+  · rintro ⟨hx, hfixed⟩
+    refine ⟨hx, ?_⟩
+    have hfixed_symm : κ.symm p.1 = p.1 := by
+      apply κ.injective
+      simp [hfixed]
+    simpa [hfixed_symm] using hx
+
 /-- Swapping the same pair of rows twice is the identity on grid states. -/
 @[simp]
 theorem swapRows_swapRows (a b : Fin n) (x : GridState n) :
@@ -309,25 +334,18 @@ theorem mem_pointSet_inter_swapColumns_iff (x : GridState n) {a b : Fin n} (h : 
     (p : Fin n × Fin n) :
     p ∈ x.pointSet ∩ (x.swapColumns a b).pointSet ↔
       p ∈ x.pointSet ∧ p.1 ≠ a ∧ p.1 ≠ b := by
-  rw [Finset.mem_inter, mem_pointSet_swapColumns]
+  rw [swapColumns, mem_pointSet_inter_relabelColumns_iff]
   constructor
-  · rintro ⟨hx, hswap⟩
+  · rintro ⟨hx, hfixed⟩
     refine ⟨hx, ?_, ?_⟩
-    · rintro hpa
-      have hxa : x a = p.2 := by
-        simpa [hpa] using (mem_pointSet x p).mp hx
-      have hxb : x b = p.2 := by
-        simpa [hpa] using (mem_pointSet x (Equiv.swap a b p.1, p.2)).mp hswap
-      exact h (x.toPerm.injective (hxa.trans hxb.symm))
-    · rintro hpb
-      have hxb : x b = p.2 := by
-        simpa [hpb] using (mem_pointSet x p).mp hx
-      have hxa : x a = p.2 := by
-        simpa [hpb] using (mem_pointSet x (Equiv.swap a b p.1, p.2)).mp hswap
-      exact h (x.toPerm.injective (hxa.trans hxb.symm))
+    · intro hpa
+      rw [hpa, Equiv.swap_apply_left] at hfixed
+      exact h hfixed.symm
+    · intro hpb
+      rw [hpb, Equiv.swap_apply_right] at hfixed
+      exact h hfixed
   · rintro ⟨hx, ha, hb⟩
-    refine ⟨hx, ?_⟩
-    simpa [Equiv.swap_apply_of_ne_of_ne ha hb] using hx
+    exact ⟨hx, Equiv.swap_apply_of_ne_of_ne ha hb⟩
 
 /-- The point set of a grid state is the shared part with a column swap, together with the two
 source-state squares in the swapped columns. -/

--- a/TauCeti/KnotTheory/Grid/RectangleSwap.lean
+++ b/TauCeti/KnotTheory/Grid/RectangleSwap.lean
@@ -26,10 +26,9 @@ Alexander grading-change computation across a rectangle rests on, and they let l
   source state with the two side columns swapped.
 * `TauCeti.GridRectangleBetween.source_eq_swapColumns`: the symmetric statement recovering the
   source from the target.
-* `TauCeti.GridState.mem_pointSet_inter_swapColumns_iff`: a square is shared by a state and
-  a column swap exactly when it belongs to the source and avoids the two swapped columns.
-* `TauCeti.GridRectangleBetween.mem_pointSet_inter_iff`: the rectangle specialization of the
-  preceding column-swap statement.
+* `TauCeti.GridRectangleBetween.mem_pointSet_inter_iff`: a square is shared by the two states
+  exactly when it belongs to the source and avoids the two side columns -- the rectangle
+  specialization of `GridState.mem_pointSet_inter_swapColumns_iff` from `Diagram.lean`.
 * `TauCeti.GridRectangleBetween.source_pointSet_eq`,
   `TauCeti.GridRectangleBetween.target_pointSet_eq`: each state's point set is the shared part
   together with its own two corners.
@@ -45,155 +44,6 @@ Lane G.2, "grading-change formulas across a rectangle", and Lane G.3, "The compl
 -/
 
 namespace TauCeti
-
-namespace GridState
-
-variable {n : ℕ} (x : GridState n) {a b : Fin n}
-
-/-- A square is shared by a grid state and the state with columns `a` and `b` swapped exactly
-when it is a source-state square away from the two swapped columns. -/
-@[simp]
-theorem mem_pointSet_inter_swapColumns_iff (h : a ≠ b) (p : Fin n × Fin n) :
-    p ∈ x.pointSet ∩ (x.swapColumns a b).pointSet ↔
-      p ∈ x.pointSet ∧ p.1 ≠ a ∧ p.1 ≠ b := by
-  rw [Finset.mem_inter, mem_pointSet_swapColumns]
-  constructor
-  · rintro ⟨hx, hswap⟩
-    refine ⟨hx, ?_, ?_⟩
-    · rintro hpa
-      have hxa : x a = p.2 := by
-        simpa [hpa] using (mem_pointSet x p).mp hx
-      have hxb : x b = p.2 := by
-        simpa [hpa] using (mem_pointSet x (Equiv.swap a b p.1, p.2)).mp hswap
-      exact h (x.toPerm.injective (hxa.trans hxb.symm))
-    · rintro hpb
-      have hxb : x b = p.2 := by
-        simpa [hpb] using (mem_pointSet x p).mp hx
-      have hxa : x a = p.2 := by
-        simpa [hpb] using (mem_pointSet x (Equiv.swap a b p.1, p.2)).mp hswap
-      exact h (x.toPerm.injective (hxa.trans hxb.symm))
-  · rintro ⟨hx, ha, hb⟩
-    refine ⟨hx, ?_⟩
-    simpa [Equiv.swap_apply_of_ne_of_ne ha hb] using hx
-
-/-- The point set of a grid state is the shared part with a column swap, together with the two
-source-state squares in the swapped columns. -/
-theorem pointSet_eq_insert_insert_inter_swapColumns (h : a ≠ b) :
-    x.pointSet =
-      insert (a, x a) (insert (b, x b) (x.pointSet ∩ (x.swapColumns a b).pointSet)) := by
-  ext p
-  simp only [Finset.mem_insert]
-  constructor
-  · intro hx
-    rcases eq_or_ne p.1 a with ha | ha
-    · refine Or.inl ?_
-      have : p.2 = x a := by
-        simpa [ha] using ((mem_pointSet x p).mp hx).symm
-      exact Prod.ext ha this
-    · rcases eq_or_ne p.1 b with hb | hb
-      · refine Or.inr (Or.inl ?_)
-        have : p.2 = x b := by
-          simpa [hb] using ((mem_pointSet x p).mp hx).symm
-        exact Prod.ext hb this
-      · exact Or.inr (Or.inr ((mem_pointSet_inter_swapColumns_iff x h p).mpr ⟨hx, ha, hb⟩))
-  · rintro (rfl | rfl | hp)
-    · simp
-    · simp
-    · exact Finset.mem_of_mem_inter_left hp
-
-/-- The point set after swapping columns `a` and `b` is the shared part with the source state,
-together with the two target-state squares in the swapped columns. -/
-theorem swapColumns_pointSet_eq_insert_insert_inter (h : a ≠ b) :
-    (x.swapColumns a b).pointSet =
-      insert (a, x b) (insert (b, x a) (x.pointSet ∩ (x.swapColumns a b).pointSet)) := by
-  ext p
-  simp only [Finset.mem_insert]
-  constructor
-  · intro hp
-    rcases eq_or_ne p.1 a with ha | ha
-    · refine Or.inl ?_
-      have : p.2 = x b := by
-        simpa [ha] using ((mem_pointSet (x.swapColumns a b) p).mp hp).symm
-      exact Prod.ext ha this
-    · rcases eq_or_ne p.1 b with hb | hb
-      · refine Or.inr (Or.inl ?_)
-        have : p.2 = x a := by
-          simpa [hb] using ((mem_pointSet (x.swapColumns a b) p).mp hp).symm
-        exact Prod.ext hb this
-      · refine Or.inr (Or.inr ?_)
-        have hx : p ∈ x.pointSet := by
-          rw [mem_pointSet] at hp ⊢
-          rw [swapColumns_apply, Equiv.swap_apply_of_ne_of_ne ha hb] at hp
-          exact hp
-        exact (mem_pointSet_inter_swapColumns_iff x h p).mpr ⟨hx, ha, hb⟩
-  · rintro (rfl | rfl | hp)
-    · simp
-    · simp
-    · exact Finset.mem_of_mem_inter_right hp
-
-/-- The source-state square in column `a` is not shared with the state whose columns `a` and
-`b` have been swapped. -/
-theorem left_notMem_pointSet_inter_swapColumns (h : a ≠ b) :
-    (a, x a) ∉ x.pointSet ∩ (x.swapColumns a b).pointSet := by
-  rw [mem_pointSet_inter_swapColumns_iff x h]
-  rintro ⟨_, ha, _⟩
-  exact ha rfl
-
-/-- The source-state square in column `b` is not shared with the state whose columns `a` and
-`b` have been swapped. -/
-theorem right_notMem_pointSet_inter_swapColumns (h : a ≠ b) :
-    (b, x b) ∉ x.pointSet ∩ (x.swapColumns a b).pointSet := by
-  rw [mem_pointSet_inter_swapColumns_iff x h]
-  rintro ⟨_, _, hb⟩
-  exact hb rfl
-
-/-- The target-state square in column `a` after swapping columns `a` and `b` is not shared
-with the source state. -/
-theorem swapColumns_left_notMem_pointSet_inter (h : a ≠ b) :
-    (a, x b) ∉ x.pointSet ∩ (x.swapColumns a b).pointSet := by
-  rw [mem_pointSet_inter_swapColumns_iff x h]
-  rintro ⟨_, ha, _⟩
-  exact ha rfl
-
-/-- The target-state square in column `b` after swapping columns `a` and `b` is not shared
-with the source state. -/
-theorem swapColumns_right_notMem_pointSet_inter (h : a ≠ b) :
-    (b, x a) ∉ x.pointSet ∩ (x.swapColumns a b).pointSet := by
-  rw [mem_pointSet_inter_swapColumns_iff x h]
-  rintro ⟨_, _, hb⟩
-  exact hb rfl
-
-/-- The two source-state squares in the swapped columns are distinct. -/
-theorem left_ne_right_pointSet_swapColumns (h : a ≠ b) :
-    ((a, x a) : Fin n × Fin n) ≠ (b, x b) := by
-  rw [Ne, Prod.mk.injEq, not_and]
-  intro hab
-  exact absurd hab h
-
-/-- The two target-state squares in the swapped columns are distinct. -/
-theorem swapColumns_left_ne_right_pointSet (h : a ≠ b) :
-    ((a, x b) : Fin n × Fin n) ≠ (b, x a) := by
-  rw [Ne, Prod.mk.injEq, not_and]
-  intro hab
-  exact absurd hab h
-
-/-- A grid state and a swap of two distinct columns share exactly `n - 2` squares. -/
-theorem card_pointSet_inter_swapColumns (h : a ≠ b) :
-    (x.pointSet ∩ (x.swapColumns a b).pointSet).card = n - 2 := by
-  have hne : (b, x b) ∉ x.pointSet ∩ (x.swapColumns a b).pointSet :=
-    right_notMem_pointSet_inter_swapColumns x h
-  have hne' :
-      (a, x a) ∉ insert (b, x b) (x.pointSet ∩ (x.swapColumns a b).pointSet) := by
-    rw [Finset.mem_insert]
-    rintro (hab | ha)
-    · exact left_ne_right_pointSet_swapColumns x h hab
-    · exact left_notMem_pointSet_inter_swapColumns x h ha
-  have hcard := congrArg Finset.card (pointSet_eq_insert_insert_inter_swapColumns x h)
-  rw [card_pointSet, Finset.card_insert_of_notMem hne',
-    Finset.card_insert_of_notMem hne] at hcard
-  omega
-
-end GridState
 
 namespace GridRectangleBetween
 
@@ -269,13 +119,6 @@ theorem right_top_notMem_inter :
   rintro ⟨_, _, hright⟩
   exact hright rfl
 
-/-- The two corners of the source state are distinct. -/
-theorem left_bottom_ne_right_top :
-    ((R.left, R.bottom) : Fin n × Fin n) ≠ (R.right, R.top) := by
-  rw [Ne, Prod.mk.injEq, not_and]
-  intro h
-  exact absurd h R.left_ne_right
-
 /-- The upper-left target corner is not shared with the source state: it sits on a side column. -/
 @[simp]
 theorem left_top_notMem_inter :
@@ -291,13 +134,6 @@ theorem right_bottom_notMem_inter :
   rw [mem_pointSet_inter_iff R]
   rintro ⟨_, _, hright⟩
   exact hright rfl
-
-/-- The two corners of the target state are distinct. -/
-theorem left_top_ne_right_bottom :
-    ((R.left, R.top) : Fin n × Fin n) ≠ (R.right, R.bottom) := by
-  rw [Ne, Prod.mk.injEq, not_and]
-  intro h
-  exact absurd h R.left_ne_right
 
 /-- The source state's point set is its shared intersection with the target point set together
 with the two source corners `(R.left, R.bottom)` and `(R.right, R.top)`. -/

--- a/TauCeti/KnotTheory/Grid/RectangleSwap.lean
+++ b/TauCeti/KnotTheory/Grid/RectangleSwap.lean
@@ -1,0 +1,217 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+import TauCeti.KnotTheory.Grid.Rectangle
+
+/-!
+# A grid rectangle move is a column transposition
+
+An oriented rectangle `R : GridRectangleBetween x y` records the two side columns at which the
+target state `y` differs from the source state `x`: at the initial side column `y` reads the
+row `x` uses at the terminal side, and vice versa, while the two states agree away from the two
+side columns. That is exactly the effect of swapping the two side columns of `x`, so the target
+state is the column transposition `x.swapColumns R.left R.right`.
+
+This file makes that identification precise and draws the point-set consequences: the two
+states share all but two of their occupied squares, and each occupied square they do not share
+is one of the four corners of the rectangle. The shared squares are exactly the intersection of
+the two point sets, which has `n - 2` elements. These are the bookkeeping facts a Maslov or
+Alexander grading-change computation across a rectangle rests on, and they let later
+`∂² = 0`-style arguments reason about `x` and `y` through a single transposition.
+
+## Main results
+
+* `TauCeti.GridRectangleBetween.target_eq_swapColumns`: the target state of a rectangle is the
+  source state with the two side columns swapped.
+* `TauCeti.GridRectangleBetween.source_eq_swapColumns`: the symmetric statement recovering the
+  source from the target.
+* `TauCeti.GridRectangleBetween.mem_inter_pointSet_iff`: a square is shared by both states
+  exactly when it belongs to the source and avoids the two side columns.
+* `TauCeti.GridRectangleBetween.source_pointSet_eq`,
+  `TauCeti.GridRectangleBetween.target_pointSet_eq`: each state's point set is the shared part
+  together with its own two corners.
+* `TauCeti.GridRectangleBetween.card_inter_pointSet`: the two states share exactly `n - 2`
+  squares.
+
+## References
+
+This supplies a prerequisite for `TauCetiRoadmap/CombinatorialHeegaardFloer/README.md`,
+Lane G.2, "grading-change formulas across a rectangle", and Lane G.3, "The complexes and
+`∂² = 0`". The column-transposition picture of a rectangle move follows Ozsváth--Stipsicz--Szabó,
+*Grid Homology for Knots and Links*, Chapter 4.
+-/
+
+namespace TauCeti
+
+namespace GridRectangleBetween
+
+variable {n : ℕ} {x y : GridState n} (R : GridRectangleBetween x y)
+
+/-- Pointwise form of the column-transposition identity: at each column the target state reads
+the row the source state reads at the swapped column. -/
+theorem target_apply (c : Fin n) : y c = x (Equiv.swap R.left R.right c) := by
+  rcases eq_or_ne c R.left with h | hl
+  · subst h
+    rw [Equiv.swap_apply_left]
+    exact R.map_left
+  · rcases eq_or_ne c R.right with h | hr
+    · subst h
+      rw [Equiv.swap_apply_right]
+      exact R.map_right
+    · rw [Equiv.swap_apply_of_ne_of_ne hl hr]
+      exact R.map_of_ne c hl hr
+
+/-- The target state of an oriented rectangle is the source state with its two side columns
+swapped. The rectangle's defining equations -- the two side columns exchange their rows and the
+other columns are unchanged -- are precisely the action of the column transposition. -/
+theorem target_eq_swapColumns : y = x.swapColumns R.left R.right := by
+  refine GridState.ext fun c => ?_
+  rw [GridState.swapColumns_apply]
+  exact target_apply R c
+
+/-- The source state of an oriented rectangle is the target state with its two side columns
+swapped: swapping the same pair of columns twice is the identity. -/
+theorem source_eq_swapColumns : x = y.swapColumns R.left R.right := by
+  refine GridState.ext fun c => ?_
+  rw [GridState.swapColumns_apply]
+  have h := target_apply R (Equiv.swap R.left R.right c)
+  rw [Equiv.swap_apply_self] at h
+  exact h.symm
+
+/-- The underlying permutation of the target state is the source permutation precomposed with
+the transposition of the two side columns. -/
+theorem target_toPerm_eq :
+    y.toPerm = (Equiv.swap R.left R.right).trans x.toPerm := by
+  refine Equiv.ext fun c => ?_
+  rw [Equiv.trans_apply]
+  exact target_apply R c
+
+/-- A square lies in the target state exactly when its column-transposed square lies in the
+source state. -/
+theorem mem_target_pointSet_iff (p : Fin n × Fin n) :
+    p ∈ y.pointSet ↔ (Equiv.swap R.left R.right p.1, p.2) ∈ x.pointSet := by
+  rw [GridState.mem_pointSet, GridState.mk_mem_pointSet, target_apply R p.1]
+
+/-- The two side columns carry the four corners of a rectangle, so a square that the two states
+share must avoid both side columns. Conversely, away from the side columns the two states agree,
+so every source square off the side columns is shared. -/
+theorem mem_inter_pointSet_iff (p : Fin n × Fin n) :
+    p ∈ x.pointSet ∩ y.pointSet ↔
+      p ∈ x.pointSet ∧ p.1 ≠ R.left ∧ p.1 ≠ R.right := by
+  rw [Finset.mem_inter]
+  constructor
+  · rintro ⟨hx, hy⟩
+    refine ⟨hx, ?_, ?_⟩
+    · rintro hleft
+      have hb : p.2 = R.bottom := by
+        simpa [hleft, bottom] using ((GridState.mem_pointSet x p).mp hx).symm
+      have ht : p.2 = R.top := by
+        simpa [hleft, top, R.map_left] using ((GridState.mem_pointSet y p).mp hy).symm
+      exact R.bottom_ne_top (hb.symm.trans ht)
+    · rintro hright
+      have ht : p.2 = R.top := by
+        simpa [hright, top] using ((GridState.mem_pointSet x p).mp hx).symm
+      have hb : p.2 = R.bottom := by
+        simpa [hright, bottom, R.map_right] using ((GridState.mem_pointSet y p).mp hy).symm
+      exact R.bottom_ne_top (hb.symm.trans ht)
+  · rintro ⟨hx, hleft, hright⟩
+    refine ⟨hx, ?_⟩
+    rw [GridState.mem_pointSet] at hx ⊢
+    rw [R.map_of_ne p.1 hleft hright]
+    exact hx
+
+/-- The lower-left corner is not shared with the target state: it sits on a side column. -/
+theorem left_bottom_notMem_inter :
+    (R.left, R.bottom) ∉ x.pointSet ∩ y.pointSet := by
+  rw [mem_inter_pointSet_iff R]
+  rintro ⟨_, hleft, _⟩
+  exact hleft rfl
+
+/-- The upper-right corner is not shared with the target state: it sits on a side column. -/
+theorem right_top_notMem_inter :
+    (R.right, R.top) ∉ x.pointSet ∩ y.pointSet := by
+  rw [mem_inter_pointSet_iff R]
+  rintro ⟨_, _, hright⟩
+  exact hright rfl
+
+/-- The two corners of the source state are distinct. -/
+theorem left_bottom_ne_right_top :
+    ((R.left, R.bottom) : Fin n × Fin n) ≠ (R.right, R.top) := by
+  rw [Ne, Prod.mk.injEq, not_and]
+  intro h
+  exact absurd h R.left_ne_right
+
+/-- The source state's point set is its two shared columns' worth of squares -- the intersection
+with the target -- together with its two own corners. -/
+theorem source_pointSet_eq :
+    x.pointSet =
+      insert (R.left, R.bottom) (insert (R.right, R.top) (x.pointSet ∩ y.pointSet)) := by
+  ext p
+  simp only [Finset.mem_insert]
+  constructor
+  · intro hx
+    rcases eq_or_ne p.1 R.left with hleft | hleft
+    · refine Or.inl ?_
+      have : p.2 = R.bottom := by
+        simpa [hleft, bottom] using ((GridState.mem_pointSet x p).mp hx).symm
+      exact Prod.ext hleft this
+    · rcases eq_or_ne p.1 R.right with hright | hright
+      · refine Or.inr (Or.inl ?_)
+        have : p.2 = R.top := by
+          simpa [hright, top] using ((GridState.mem_pointSet x p).mp hx).symm
+        exact Prod.ext hright this
+      · exact Or.inr (Or.inr ((mem_inter_pointSet_iff R p).mpr ⟨hx, hleft, hright⟩))
+  · rintro (rfl | rfl | hp)
+    · exact R.left_bottom_mem_source
+    · exact R.right_top_mem_source
+    · exact Finset.mem_of_mem_inter_left hp
+
+/-- The target state's point set is the shared part together with its own two corners. -/
+theorem target_pointSet_eq :
+    y.pointSet =
+      insert (R.left, R.top) (insert (R.right, R.bottom) (x.pointSet ∩ y.pointSet)) := by
+  ext p
+  simp only [Finset.mem_insert]
+  constructor
+  · intro hy
+    rcases eq_or_ne p.1 R.left with hleft | hleft
+    · refine Or.inl ?_
+      have : p.2 = R.top := by
+        simpa [hleft, top, R.map_left] using ((GridState.mem_pointSet y p).mp hy).symm
+      exact Prod.ext hleft this
+    · rcases eq_or_ne p.1 R.right with hright | hright
+      · refine Or.inr (Or.inl ?_)
+        have : p.2 = R.bottom := by
+          simpa [hright, bottom, R.map_right] using ((GridState.mem_pointSet y p).mp hy).symm
+        exact Prod.ext hright this
+      · refine Or.inr (Or.inr ?_)
+        have hx : p ∈ x.pointSet := by
+          rw [GridState.mem_pointSet] at hy ⊢
+          rw [← R.map_of_ne p.1 hleft hright]
+          exact hy
+        exact (mem_inter_pointSet_iff R p).mpr ⟨hx, hleft, hright⟩
+  · rintro (rfl | rfl | hp)
+    · exact R.left_top_mem_target
+    · exact R.right_bottom_mem_target
+    · exact Finset.mem_of_mem_inter_right hp
+
+include R in
+/-- The source and target states share exactly `n - 2` squares: all of the source's `n` squares
+except its two corners. -/
+theorem card_inter_pointSet : (x.pointSet ∩ y.pointSet).card = n - 2 := by
+  have hne : (R.right, R.top) ∉ x.pointSet ∩ y.pointSet := right_top_notMem_inter R
+  have hne' :
+      (R.left, R.bottom) ∉ insert (R.right, R.top) (x.pointSet ∩ y.pointSet) := by
+    rw [Finset.mem_insert]
+    rintro (h | h)
+    · exact R.left_bottom_ne_right_top h
+    · exact left_bottom_notMem_inter R h
+  have hcard := congrArg Finset.card (source_pointSet_eq R)
+  rw [GridState.card_pointSet, Finset.card_insert_of_notMem hne',
+    Finset.card_insert_of_notMem hne] at hcard
+  omega
+
+end GridRectangleBetween
+
+end TauCeti

--- a/TauCeti/KnotTheory/Grid/RectangleSwap.lean
+++ b/TauCeti/KnotTheory/Grid/RectangleSwap.lean
@@ -26,12 +26,14 @@ Alexander grading-change computation across a rectangle rests on, and they let l
   source state with the two side columns swapped.
 * `TauCeti.GridRectangleBetween.source_eq_swapColumns`: the symmetric statement recovering the
   source from the target.
-* `TauCeti.GridRectangleBetween.mem_inter_pointSet_iff`: a square is shared by both states
-  exactly when it belongs to the source and avoids the two side columns.
+* `TauCeti.GridState.mem_pointSet_inter_swapColumns_iff`: a square is shared by a state and
+  a column swap exactly when it belongs to the source and avoids the two swapped columns.
+* `TauCeti.GridRectangleBetween.mem_pointSet_inter_iff`: the rectangle specialization of the
+  preceding column-swap statement.
 * `TauCeti.GridRectangleBetween.source_pointSet_eq`,
   `TauCeti.GridRectangleBetween.target_pointSet_eq`: each state's point set is the shared part
   together with its own two corners.
-* `TauCeti.GridRectangleBetween.card_inter_pointSet`: the two states share exactly `n - 2`
+* `TauCeti.GridRectangleBetween.card_pointSet_inter`: the two states share exactly `n - 2`
   squares.
 
 ## References
@@ -43,6 +45,154 @@ Lane G.2, "grading-change formulas across a rectangle", and Lane G.3, "The compl
 -/
 
 namespace TauCeti
+
+namespace GridState
+
+variable {n : ℕ} (x : GridState n) {a b : Fin n}
+
+/-- A square is shared by a grid state and the state with columns `a` and `b` swapped exactly
+when it is a source-state square away from the two swapped columns. -/
+theorem mem_pointSet_inter_swapColumns_iff (h : a ≠ b) (p : Fin n × Fin n) :
+    p ∈ x.pointSet ∩ (x.swapColumns a b).pointSet ↔
+      p ∈ x.pointSet ∧ p.1 ≠ a ∧ p.1 ≠ b := by
+  rw [Finset.mem_inter, mem_pointSet_swapColumns]
+  constructor
+  · rintro ⟨hx, hswap⟩
+    refine ⟨hx, ?_, ?_⟩
+    · rintro hpa
+      have hxa : x a = p.2 := by
+        simpa [hpa] using (mem_pointSet x p).mp hx
+      have hxb : x b = p.2 := by
+        simpa [hpa] using (mem_pointSet x (Equiv.swap a b p.1, p.2)).mp hswap
+      exact h (x.toPerm.injective (hxa.trans hxb.symm))
+    · rintro hpb
+      have hxb : x b = p.2 := by
+        simpa [hpb] using (mem_pointSet x p).mp hx
+      have hxa : x a = p.2 := by
+        simpa [hpb] using (mem_pointSet x (Equiv.swap a b p.1, p.2)).mp hswap
+      exact h (x.toPerm.injective (hxa.trans hxb.symm))
+  · rintro ⟨hx, ha, hb⟩
+    refine ⟨hx, ?_⟩
+    simpa [Equiv.swap_apply_of_ne_of_ne ha hb] using hx
+
+/-- The point set of a grid state is the shared part with a column swap, together with the two
+source-state squares in the swapped columns. -/
+theorem pointSet_eq_insert_insert_inter_swapColumns (h : a ≠ b) :
+    x.pointSet =
+      insert (a, x a) (insert (b, x b) (x.pointSet ∩ (x.swapColumns a b).pointSet)) := by
+  ext p
+  simp only [Finset.mem_insert]
+  constructor
+  · intro hx
+    rcases eq_or_ne p.1 a with ha | ha
+    · refine Or.inl ?_
+      have : p.2 = x a := by
+        simpa [ha] using ((mem_pointSet x p).mp hx).symm
+      exact Prod.ext ha this
+    · rcases eq_or_ne p.1 b with hb | hb
+      · refine Or.inr (Or.inl ?_)
+        have : p.2 = x b := by
+          simpa [hb] using ((mem_pointSet x p).mp hx).symm
+        exact Prod.ext hb this
+      · exact Or.inr (Or.inr ((mem_pointSet_inter_swapColumns_iff x h p).mpr ⟨hx, ha, hb⟩))
+  · rintro (rfl | rfl | hp)
+    · simp
+    · simp
+    · exact Finset.mem_of_mem_inter_left hp
+
+/-- The point set after swapping columns `a` and `b` is the shared part with the source state,
+together with the two target-state squares in the swapped columns. -/
+theorem swapColumns_pointSet_eq_insert_insert_inter (h : a ≠ b) :
+    (x.swapColumns a b).pointSet =
+      insert (a, x b) (insert (b, x a) (x.pointSet ∩ (x.swapColumns a b).pointSet)) := by
+  ext p
+  simp only [Finset.mem_insert]
+  constructor
+  · intro hp
+    rcases eq_or_ne p.1 a with ha | ha
+    · refine Or.inl ?_
+      have : p.2 = x b := by
+        simpa [ha] using ((mem_pointSet (x.swapColumns a b) p).mp hp).symm
+      exact Prod.ext ha this
+    · rcases eq_or_ne p.1 b with hb | hb
+      · refine Or.inr (Or.inl ?_)
+        have : p.2 = x a := by
+          simpa [hb] using ((mem_pointSet (x.swapColumns a b) p).mp hp).symm
+        exact Prod.ext hb this
+      · refine Or.inr (Or.inr ?_)
+        have hx : p ∈ x.pointSet := by
+          rw [mem_pointSet] at hp ⊢
+          rw [swapColumns_apply, Equiv.swap_apply_of_ne_of_ne ha hb] at hp
+          exact hp
+        exact (mem_pointSet_inter_swapColumns_iff x h p).mpr ⟨hx, ha, hb⟩
+  · rintro (rfl | rfl | hp)
+    · simp
+    · simp
+    · exact Finset.mem_of_mem_inter_right hp
+
+/-- The source-state square in column `a` is not shared with the state whose columns `a` and
+`b` have been swapped. -/
+theorem left_notMem_pointSet_inter_swapColumns (h : a ≠ b) :
+    (a, x a) ∉ x.pointSet ∩ (x.swapColumns a b).pointSet := by
+  rw [mem_pointSet_inter_swapColumns_iff x h]
+  rintro ⟨_, ha, _⟩
+  exact ha rfl
+
+/-- The source-state square in column `b` is not shared with the state whose columns `a` and
+`b` have been swapped. -/
+theorem right_notMem_pointSet_inter_swapColumns (h : a ≠ b) :
+    (b, x b) ∉ x.pointSet ∩ (x.swapColumns a b).pointSet := by
+  rw [mem_pointSet_inter_swapColumns_iff x h]
+  rintro ⟨_, _, hb⟩
+  exact hb rfl
+
+/-- The target-state square in column `a` after swapping columns `a` and `b` is not shared
+with the source state. -/
+theorem swapColumns_left_notMem_pointSet_inter (h : a ≠ b) :
+    (a, x b) ∉ x.pointSet ∩ (x.swapColumns a b).pointSet := by
+  rw [mem_pointSet_inter_swapColumns_iff x h]
+  rintro ⟨_, ha, _⟩
+  exact ha rfl
+
+/-- The target-state square in column `b` after swapping columns `a` and `b` is not shared
+with the source state. -/
+theorem swapColumns_right_notMem_pointSet_inter (h : a ≠ b) :
+    (b, x a) ∉ x.pointSet ∩ (x.swapColumns a b).pointSet := by
+  rw [mem_pointSet_inter_swapColumns_iff x h]
+  rintro ⟨_, _, hb⟩
+  exact hb rfl
+
+/-- The two source-state squares in the swapped columns are distinct. -/
+theorem left_ne_right_pointSet_swapColumns (h : a ≠ b) :
+    ((a, x a) : Fin n × Fin n) ≠ (b, x b) := by
+  rw [Ne, Prod.mk.injEq, not_and]
+  intro hab
+  exact absurd hab h
+
+/-- The two target-state squares in the swapped columns are distinct. -/
+theorem swapColumns_left_ne_right_pointSet (h : a ≠ b) :
+    ((a, x b) : Fin n × Fin n) ≠ (b, x a) := by
+  rw [Ne, Prod.mk.injEq, not_and]
+  intro hab
+  exact absurd hab h
+
+/-- A grid state and a swap of two distinct columns share exactly `n - 2` squares. -/
+theorem card_pointSet_inter_swapColumns (h : a ≠ b) :
+    (x.pointSet ∩ (x.swapColumns a b).pointSet).card = n - 2 := by
+  have hne : (b, x b) ∉ x.pointSet ∩ (x.swapColumns a b).pointSet :=
+    right_notMem_pointSet_inter_swapColumns x h
+  have hne' :
+      (a, x a) ∉ insert (b, x b) (x.pointSet ∩ (x.swapColumns a b).pointSet) := by
+    rw [Finset.mem_insert]
+    rintro (hab | ha)
+    · exact left_ne_right_pointSet_swapColumns x h hab
+    · exact left_notMem_pointSet_inter_swapColumns x h ha
+  have hcard := congrArg Finset.card (pointSet_eq_insert_insert_inter_swapColumns x h)
+  rw [card_pointSet, Finset.card_insert_of_notMem hne',
+    Finset.card_insert_of_notMem hne] at hcard
+  omega
+
+end GridState
 
 namespace GridRectangleBetween
 
@@ -96,42 +246,23 @@ theorem mem_target_pointSet_iff (p : Fin n × Fin n) :
 /-- The two side columns carry the four corners of a rectangle, so a square that the two states
 share must avoid both side columns. Conversely, away from the side columns the two states agree,
 so every source square off the side columns is shared. -/
-theorem mem_inter_pointSet_iff (p : Fin n × Fin n) :
+theorem mem_pointSet_inter_iff (p : Fin n × Fin n) :
     p ∈ x.pointSet ∩ y.pointSet ↔
       p ∈ x.pointSet ∧ p.1 ≠ R.left ∧ p.1 ≠ R.right := by
-  rw [Finset.mem_inter]
-  constructor
-  · rintro ⟨hx, hy⟩
-    refine ⟨hx, ?_, ?_⟩
-    · rintro hleft
-      have hb : p.2 = R.bottom := by
-        simpa [hleft, bottom] using ((GridState.mem_pointSet x p).mp hx).symm
-      have ht : p.2 = R.top := by
-        simpa [hleft, top, R.map_left] using ((GridState.mem_pointSet y p).mp hy).symm
-      exact R.bottom_ne_top (hb.symm.trans ht)
-    · rintro hright
-      have ht : p.2 = R.top := by
-        simpa [hright, top] using ((GridState.mem_pointSet x p).mp hx).symm
-      have hb : p.2 = R.bottom := by
-        simpa [hright, bottom, R.map_right] using ((GridState.mem_pointSet y p).mp hy).symm
-      exact R.bottom_ne_top (hb.symm.trans ht)
-  · rintro ⟨hx, hleft, hright⟩
-    refine ⟨hx, ?_⟩
-    rw [GridState.mem_pointSet] at hx ⊢
-    rw [R.map_of_ne p.1 hleft hright]
-    exact hx
+  simpa [target_eq_swapColumns R] using
+    GridState.mem_pointSet_inter_swapColumns_iff x R.left_ne_right p
 
 /-- The lower-left corner is not shared with the target state: it sits on a side column. -/
 theorem left_bottom_notMem_inter :
     (R.left, R.bottom) ∉ x.pointSet ∩ y.pointSet := by
-  rw [mem_inter_pointSet_iff R]
+  rw [mem_pointSet_inter_iff R]
   rintro ⟨_, hleft, _⟩
   exact hleft rfl
 
 /-- The upper-right corner is not shared with the target state: it sits on a side column. -/
 theorem right_top_notMem_inter :
     (R.right, R.top) ∉ x.pointSet ∩ y.pointSet := by
-  rw [mem_inter_pointSet_iff R]
+  rw [mem_pointSet_inter_iff R]
   rintro ⟨_, _, hright⟩
   exact hright rfl
 
@@ -142,75 +273,48 @@ theorem left_bottom_ne_right_top :
   intro h
   exact absurd h R.left_ne_right
 
-/-- The source state's point set is its two shared columns' worth of squares -- the intersection
-with the target -- together with its two own corners. -/
+/-- The upper-left target corner is not shared with the source state: it sits on a side column. -/
+theorem left_top_notMem_inter :
+    (R.left, R.top) ∉ x.pointSet ∩ y.pointSet := by
+  rw [mem_pointSet_inter_iff R]
+  rintro ⟨_, hleft, _⟩
+  exact hleft rfl
+
+/-- The lower-right target corner is not shared with the source state: it sits on a side column. -/
+theorem right_bottom_notMem_inter :
+    (R.right, R.bottom) ∉ x.pointSet ∩ y.pointSet := by
+  rw [mem_pointSet_inter_iff R]
+  rintro ⟨_, _, hright⟩
+  exact hright rfl
+
+/-- The two corners of the target state are distinct. -/
+theorem left_top_ne_right_bottom :
+    ((R.left, R.top) : Fin n × Fin n) ≠ (R.right, R.bottom) := by
+  rw [Ne, Prod.mk.injEq, not_and]
+  intro h
+  exact absurd h R.left_ne_right
+
+/-- The source state's point set is its shared intersection with the target point set together
+with the two source corners `(R.left, R.bottom)` and `(R.right, R.top)`. -/
 theorem source_pointSet_eq :
     x.pointSet =
       insert (R.left, R.bottom) (insert (R.right, R.top) (x.pointSet ∩ y.pointSet)) := by
-  ext p
-  simp only [Finset.mem_insert]
-  constructor
-  · intro hx
-    rcases eq_or_ne p.1 R.left with hleft | hleft
-    · refine Or.inl ?_
-      have : p.2 = R.bottom := by
-        simpa [hleft, bottom] using ((GridState.mem_pointSet x p).mp hx).symm
-      exact Prod.ext hleft this
-    · rcases eq_or_ne p.1 R.right with hright | hright
-      · refine Or.inr (Or.inl ?_)
-        have : p.2 = R.top := by
-          simpa [hright, top] using ((GridState.mem_pointSet x p).mp hx).symm
-        exact Prod.ext hright this
-      · exact Or.inr (Or.inr ((mem_inter_pointSet_iff R p).mpr ⟨hx, hleft, hright⟩))
-  · rintro (rfl | rfl | hp)
-    · exact R.left_bottom_mem_source
-    · exact R.right_top_mem_source
-    · exact Finset.mem_of_mem_inter_left hp
+  simpa [target_eq_swapColumns R, bottom, top] using
+    GridState.pointSet_eq_insert_insert_inter_swapColumns x R.left_ne_right
 
 /-- The target state's point set is the shared part together with its own two corners. -/
 theorem target_pointSet_eq :
     y.pointSet =
       insert (R.left, R.top) (insert (R.right, R.bottom) (x.pointSet ∩ y.pointSet)) := by
-  ext p
-  simp only [Finset.mem_insert]
-  constructor
-  · intro hy
-    rcases eq_or_ne p.1 R.left with hleft | hleft
-    · refine Or.inl ?_
-      have : p.2 = R.top := by
-        simpa [hleft, top, R.map_left] using ((GridState.mem_pointSet y p).mp hy).symm
-      exact Prod.ext hleft this
-    · rcases eq_or_ne p.1 R.right with hright | hright
-      · refine Or.inr (Or.inl ?_)
-        have : p.2 = R.bottom := by
-          simpa [hright, bottom, R.map_right] using ((GridState.mem_pointSet y p).mp hy).symm
-        exact Prod.ext hright this
-      · refine Or.inr (Or.inr ?_)
-        have hx : p ∈ x.pointSet := by
-          rw [GridState.mem_pointSet] at hy ⊢
-          rw [← R.map_of_ne p.1 hleft hright]
-          exact hy
-        exact (mem_inter_pointSet_iff R p).mpr ⟨hx, hleft, hright⟩
-  · rintro (rfl | rfl | hp)
-    · exact R.left_top_mem_target
-    · exact R.right_bottom_mem_target
-    · exact Finset.mem_of_mem_inter_right hp
+  simpa [target_eq_swapColumns R, bottom, top] using
+    GridState.swapColumns_pointSet_eq_insert_insert_inter x R.left_ne_right
 
 include R in
 /-- The source and target states share exactly `n - 2` squares: all of the source's `n` squares
 except its two corners. -/
-theorem card_inter_pointSet : (x.pointSet ∩ y.pointSet).card = n - 2 := by
-  have hne : (R.right, R.top) ∉ x.pointSet ∩ y.pointSet := right_top_notMem_inter R
-  have hne' :
-      (R.left, R.bottom) ∉ insert (R.right, R.top) (x.pointSet ∩ y.pointSet) := by
-    rw [Finset.mem_insert]
-    rintro (h | h)
-    · exact R.left_bottom_ne_right_top h
-    · exact left_bottom_notMem_inter R h
-  have hcard := congrArg Finset.card (source_pointSet_eq R)
-  rw [GridState.card_pointSet, Finset.card_insert_of_notMem hne',
-    Finset.card_insert_of_notMem hne] at hcard
-  omega
+theorem card_pointSet_inter : (x.pointSet ∩ y.pointSet).card = n - 2 := by
+  simpa [target_eq_swapColumns R] using
+    GridState.card_pointSet_inter_swapColumns x R.left_ne_right
 
 end GridRectangleBetween
 

--- a/TauCeti/KnotTheory/Grid/RectangleSwap.lean
+++ b/TauCeti/KnotTheory/Grid/RectangleSwap.lean
@@ -97,6 +97,7 @@ theorem mem_target_pointSet_iff (p : Fin n × Fin n) :
 /-- The two side columns carry the four corners of a rectangle, so a square that the two states
 share must avoid both side columns. Conversely, away from the side columns the two states agree,
 so every source square off the side columns is shared. -/
+@[simp]
 theorem mem_pointSet_inter_iff (p : Fin n × Fin n) :
     p ∈ x.pointSet ∩ y.pointSet ↔
       p ∈ x.pointSet ∧ p.1 ≠ R.left ∧ p.1 ≠ R.right := by

--- a/TauCeti/KnotTheory/Grid/RectangleSwap.lean
+++ b/TauCeti/KnotTheory/Grid/RectangleSwap.lean
@@ -254,6 +254,7 @@ theorem mem_pointSet_inter_iff (p : Fin n × Fin n) :
     GridState.mem_pointSet_inter_swapColumns_iff x R.left_ne_right p
 
 /-- The lower-left corner is not shared with the target state: it sits on a side column. -/
+@[simp]
 theorem left_bottom_notMem_inter :
     (R.left, R.bottom) ∉ x.pointSet ∩ y.pointSet := by
   rw [mem_pointSet_inter_iff R]
@@ -261,6 +262,7 @@ theorem left_bottom_notMem_inter :
   exact hleft rfl
 
 /-- The upper-right corner is not shared with the target state: it sits on a side column. -/
+@[simp]
 theorem right_top_notMem_inter :
     (R.right, R.top) ∉ x.pointSet ∩ y.pointSet := by
   rw [mem_pointSet_inter_iff R]
@@ -275,6 +277,7 @@ theorem left_bottom_ne_right_top :
   exact absurd h R.left_ne_right
 
 /-- The upper-left target corner is not shared with the source state: it sits on a side column. -/
+@[simp]
 theorem left_top_notMem_inter :
     (R.left, R.top) ∉ x.pointSet ∩ y.pointSet := by
   rw [mem_pointSet_inter_iff R]
@@ -282,6 +285,7 @@ theorem left_top_notMem_inter :
   exact hleft rfl
 
 /-- The lower-right target corner is not shared with the source state: it sits on a side column. -/
+@[simp]
 theorem right_bottom_notMem_inter :
     (R.right, R.bottom) ∉ x.pointSet ∩ y.pointSet := by
   rw [mem_pointSet_inter_iff R]

--- a/TauCeti/KnotTheory/Grid/RectangleSwap.lean
+++ b/TauCeti/KnotTheory/Grid/RectangleSwap.lean
@@ -52,6 +52,7 @@ variable {n : ℕ} (x : GridState n) {a b : Fin n}
 
 /-- A square is shared by a grid state and the state with columns `a` and `b` swapped exactly
 when it is a source-state square away from the two swapped columns. -/
+@[simp]
 theorem mem_pointSet_inter_swapColumns_iff (h : a ≠ b) (p : Fin n × Fin n) :
     p ∈ x.pointSet ∩ (x.swapColumns a b).pointSet ↔
       p ∈ x.pointSet ∧ p.1 ≠ a ∧ p.1 ≠ b := by


### PR DESCRIPTION
This PR identifies an oriented grid rectangle move with a column transposition. For
`R : GridRectangleBetween x y`, it proves that the target state `y` is exactly the source state
`x` with the two side columns `R.left` and `R.right` swapped (`target_eq_swapColumns`), with the
symmetric statement recovering `x` from `y` and a description of the underlying permutation. From
that single transposition picture it draws the point-set bookkeeping that later grading and
differential arguments rest on: a square is shared by both states exactly when it lies in the
source and avoids the two side columns (`mem_inter_pointSet_iff`); each state's point set is the
shared part together with its own two corners (`source_pointSet_eq`, `target_pointSet_eq`); and
the two states share exactly `n - 2` squares (`card_inter_pointSet`).

This advances `TauCetiRoadmap/CombinatorialHeegaardFloer/README.md`, Lane G, supplying a
prerequisite for milestone G.2 ("grading-change formulas across a rectangle") and milestone G.3
("The complexes and `∂² = 0`"): both reason about how a grid state changes across an empty
rectangle, and the cleanest handle on that change is the column transposition established here.
The column-transposition reading of a rectangle move follows Ozsvath--Stipsicz--Szabo, *Grid
Homology for Knots and Links*, Chapter 4. It builds on the existing grid state and rectangle API
in `TauCeti/KnotTheory/Grid/` (`GridState.swapColumns`, `GridRectangleBetween`) and Mathlib's
`Equiv.swap`; no Mathlib infrastructure was vendored.

<!--tauceti-target:v1 {"focus":"CombinatorialHeegaardFloer","id":"rectangle-between-eq-swap-columns"}-->

🤖 Prepared with Claude Code
