### PR TITLE
feat: trace-form diagonalisation for square-root bases

### DIFF
--- a/TauCeti/FieldTheory/Trace.lean
+++ b/TauCeti/FieldTheory/Trace.lean
@@ -3,6 +3,7 @@ Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 -/
 import Mathlib.NumberTheory.NumberField.Basic
+import Mathlib.RingTheory.Discriminant
 import Mathlib.RingTheory.Trace.Basic
 
 /-!
@@ -12,8 +13,12 @@ This file collects reusable trace facts for finite field extensions.
 
 ## Main results
 
+* `TauCeti.trace_eq_zero_of_sq_algebraMap_of_not_mem_range`: in a finite extension,
+  `x² ∈ F` and `x ∉ F` imply `Tr x = 0`.
 * `TauCeti.NumberField.trace_eq_zero_of_sq_ratCast_of_not_mem_range`: the number-field
-  helper saying that `x² ∈ ℚ`, `x ∉ ℚ` implies `Tr x = 0`.
+  specialization saying that `x² ∈ ℚ`, `x ∉ ℚ` implies `Tr x = 0`.
+* `TauCeti.Algebra.discr_one_self_eq_of_sq`: in a quadratic extension, the trace-form
+  discriminant of the square-root basis `{1, x}` is `4a` when `x² = a`.
 
 ## Provenance
 
@@ -23,13 +28,13 @@ formalization of L. Alpöge's disproof of the uniform-constant Erdős unit-dista
 conjecture, where these trace facts supported square-root basis computations over number fields.
 -/
 
-open Polynomial
+open Module Polynomial
 
 namespace TauCeti
 
 /-- In a finite field extension, an element outside the base field whose square lies in the
 base field has trace zero. -/
-private theorem trace_eq_zero_of_sq_algebraMap_of_not_mem_range {F L : Type*} [Field F] [Field L]
+theorem trace_eq_zero_of_sq_algebraMap_of_not_mem_range {F L : Type*} [Field F] [Field L]
     [Algebra F L] [FiniteDimensional F L] {x : L} {r : F}
     (hx2 : x ^ 2 = algebraMap F L r) (hx : x ∉ (algebraMap F L).range) :
     Algebra.trace F L x = 0 := by
@@ -58,6 +63,44 @@ private theorem trace_eq_zero_of_sq_algebraMap_of_not_mem_range {F L : Type*} [F
       (by rw [Polynomial.natDegree_X_pow_sub_C]; norm_num)]
     simp [Polynomial.coeff_X_pow]
   rw [hnc]; simp
+
+namespace Algebra
+
+variable {F L : Type*} [Field F] [Field L] [Algebra F L] [FiniteDimensional F L]
+
+/-- For a quadratic extension `L / F` and an element `x ∉ F` whose square is `a ∈ F`, the
+trace-form discriminant of the square-root basis `{1, x}` equals `4 a`. -/
+theorem discr_one_self_eq_of_sq {x : L} {a : F} (hfin : finrank F L = 2)
+    (hx2 : x ^ 2 = algebraMap F L a) (hx : x ∉ (algebraMap F L).range) :
+    Algebra.discr F ![1, x] = 4 * a := by
+  have htr0 : Algebra.trace F L x = 0 :=
+    TauCeti.trace_eq_zero_of_sq_algebraMap_of_not_mem_range hx2 hx
+  have hone : (1 : L) = algebraMap F L 1 := (map_one _).symm
+  have hxmul : x * x = algebraMap F L a := by
+    rw [← pow_two]
+    exact hx2
+  have e00 : Algebra.traceMatrix F ![1, x] 0 0 = 2 := by
+    rw [Algebra.traceMatrix_apply, Algebra.traceForm_apply]
+    simp only [Matrix.cons_val_zero, mul_one]
+    rw [hone, Algebra.trace_algebraMap, hfin]
+    simp
+  have e11 : Algebra.traceMatrix F ![1, x] 1 1 = 2 * a := by
+    rw [Algebra.traceMatrix_apply, Algebra.traceForm_apply]
+    simp only [Matrix.cons_val_one, Matrix.cons_val_zero]
+    rw [hxmul, Algebra.trace_algebraMap, hfin]
+    simp [nsmul_eq_mul]
+  have e01 : Algebra.traceMatrix F ![1, x] 0 1 = 0 := by
+    rw [Algebra.traceMatrix_apply, Algebra.traceForm_apply]
+    simp only [Matrix.cons_val_zero, Matrix.cons_val_one, one_mul]
+    exact htr0
+  have e10 : Algebra.traceMatrix F ![1, x] 1 0 = 0 := by
+    rw [Algebra.traceMatrix_apply, Algebra.traceForm_apply]
+    simp only [Matrix.cons_val_zero, Matrix.cons_val_one, mul_one]
+    exact htr0
+  rw [Algebra.discr_def, Matrix.det_fin_two, e00, e11, e01, e10]
+  ring
+
+end Algebra
 
 namespace NumberField
 

--- a/TauCeti/FieldTheory/Trace.lean
+++ b/TauCeti/FieldTheory/Trace.lean
@@ -13,12 +13,10 @@ This file collects reusable trace facts for finite field extensions.
 
 ## Main results
 
-* `TauCeti.trace_eq_zero_of_sq_algebraMap_of_not_mem_range`: in a finite extension,
-  `x² ∈ F` and `x ∉ F` imply `Tr x = 0`.
 * `TauCeti.NumberField.trace_eq_zero_of_sq_ratCast_of_not_mem_range`: the number-field
   specialization saying that `x² ∈ ℚ`, `x ∉ ℚ` implies `Tr x = 0`.
 * `TauCeti.Algebra.discr_one_self_eq_of_sq`: in a quadratic extension, the trace-form
-  discriminant of the square-root basis `{1, x}` is `4a` when `x² = a`.
+  discriminant of the square-root basis `{1, x}` is `4a` when `x² = a` and `x ∉ F`.
 
 ## Provenance
 
@@ -34,7 +32,7 @@ namespace TauCeti
 
 /-- In a finite field extension, an element outside the base field whose square lies in the
 base field has trace zero. -/
-theorem trace_eq_zero_of_sq_algebraMap_of_not_mem_range {F L : Type*} [Field F] [Field L]
+private theorem trace_eq_zero_of_sq_algebraMap_of_not_mem_range {F L : Type*} [Field F] [Field L]
     [Algebra F L] [FiniteDimensional F L] {x : L} {r : F}
     (hx2 : x ^ 2 = algebraMap F L r) (hx : x ∉ (algebraMap F L).range) :
     Algebra.trace F L x = 0 := by
@@ -74,7 +72,7 @@ theorem discr_one_self_eq_of_sq {x : L} {a : F} (hfin : finrank F L = 2)
     (hx2 : x ^ 2 = algebraMap F L a) (hx : x ∉ (algebraMap F L).range) :
     Algebra.discr F ![1, x] = 4 * a := by
   have htr0 : Algebra.trace F L x = 0 :=
-    TauCeti.trace_eq_zero_of_sq_algebraMap_of_not_mem_range hx2 hx
+    trace_eq_zero_of_sq_algebraMap_of_not_mem_range hx2 hx
   have hone : (1 : L) = algebraMap F L 1 := (map_one _).symm
   have hxmul : x * x = algebraMap F L a := by
     rw [← pow_two]
@@ -109,6 +107,6 @@ theorem trace_eq_zero_of_sq_ratCast_of_not_mem_range {K : Type*} [Field K] [Numb
     {x : K} {r : ℚ} (hx2 : x ^ 2 = algebraMap ℚ K r)
     (hx : x ∉ (algebraMap ℚ K).range) :
     Algebra.trace ℚ K x = 0 :=
-  TauCeti.trace_eq_zero_of_sq_algebraMap_of_not_mem_range hx2 hx
+  trace_eq_zero_of_sq_algebraMap_of_not_mem_range hx2 hx
 
 end TauCeti.NumberField

--- a/TauCeti/FieldTheory/Trace.lean
+++ b/TauCeti/FieldTheory/Trace.lean
@@ -112,8 +112,4 @@ theorem trace_eq_zero_of_sq_ratCast {K : Type*} [Field K] [NumberField K]
     Algebra.trace ℚ K x = 0 :=
   TauCeti.Algebra.trace_eq_zero_of_sq_algebraMap_of_not_mem_range hx2 hx
 
-/-- Deprecated compatibility alias for the old NumberField helper name. -/
-@[deprecated TauCeti.NumberField.trace_eq_zero_of_sq_ratCast (since := "2026-06-20")]
-alias trace_eq_zero_of_sq_ratCast_of_not_mem_range := trace_eq_zero_of_sq_ratCast
-
 end TauCeti.NumberField

--- a/TauCeti/FieldTheory/Trace.lean
+++ b/TauCeti/FieldTheory/Trace.lean
@@ -112,4 +112,8 @@ theorem trace_eq_zero_of_sq_ratCast {K : Type*} [Field K] [NumberField K]
     Algebra.trace ℚ K x = 0 :=
   TauCeti.Algebra.trace_eq_zero_of_sq_algebraMap_of_not_mem_range hx2 hx
 
+/-- Deprecated compatibility alias for the old NumberField helper name. -/
+@[deprecated TauCeti.NumberField.trace_eq_zero_of_sq_ratCast (since := "2026-06-20")]
+alias trace_eq_zero_of_sq_ratCast_of_not_mem_range := trace_eq_zero_of_sq_ratCast
+
 end TauCeti.NumberField

--- a/TauCeti/FieldTheory/Trace.lean
+++ b/TauCeti/FieldTheory/Trace.lean
@@ -17,8 +17,9 @@ This file collects reusable trace facts for finite field extensions.
   specialization saying that `x² ∈ ℚ`, `x ∉ ℚ` implies `Tr x = 0`.
 * `TauCeti.Algebra.trace_eq_zero_of_sq_algebraMap_of_not_mem_range`: the corresponding
   trace-vanishing statement for any finite field extension.
-* `TauCeti.Algebra.discr_one_sqrt_eq_of_sq`: in a quadratic extension, the trace-form
-  discriminant of the square-root basis `{1, x}` is `4a` when `x² = a` and `x ∉ F`.
+* `TauCeti.Algebra.discr_one_elem_eq_of_sq_algebraMap`: in a quadratic extension, the
+  trace-form discriminant of the square-root basis `{1, x}` is `4a` when `x² = a` and
+  `x ∉ F`.
 
 ## Provenance
 
@@ -70,7 +71,7 @@ variable {F L : Type*} [Field F] [Field L] [Algebra F L] [FiniteDimensional F L]
 
 /-- For a quadratic extension `L / F` and an element `x ∉ F` whose square is `a ∈ F`, the
 trace-form discriminant of the square-root basis `{1, x}` equals `4 a`. -/
-theorem discr_one_sqrt_eq_of_sq {x : L} {a : F} (hfin : finrank F L = 2)
+theorem discr_one_elem_eq_of_sq_algebraMap {x : L} {a : F} (hfin : finrank F L = 2)
     (hx2 : x ^ 2 = algebraMap F L a) (hx : x ∉ (algebraMap F L).range) :
     Algebra.discr F ![1, x] = 4 * a := by
   have htr0 : Algebra.trace F L x = 0 :=
@@ -110,5 +111,9 @@ theorem trace_eq_zero_of_sq_ratCast {K : Type*} [Field K] [NumberField K]
     (hx : x ∉ (algebraMap ℚ K).range) :
     Algebra.trace ℚ K x = 0 :=
   TauCeti.Algebra.trace_eq_zero_of_sq_algebraMap_of_not_mem_range hx2 hx
+
+/-- Deprecated compatibility alias for the old NumberField helper name. -/
+@[deprecated TauCeti.NumberField.trace_eq_zero_of_sq_ratCast (since := "2026-06-20")]
+alias trace_eq_zero_of_sq_ratCast_of_not_mem_range := trace_eq_zero_of_sq_ratCast
 
 end TauCeti.NumberField

--- a/TauCeti/FieldTheory/Trace.lean
+++ b/TauCeti/FieldTheory/Trace.lean
@@ -15,6 +15,8 @@ This file collects reusable trace facts for finite field extensions.
 
 * `TauCeti.NumberField.trace_eq_zero_of_sq_ratCast`: the number-field
   specialization saying that `x² ∈ ℚ`, `x ∉ ℚ` implies `Tr x = 0`.
+* `TauCeti.Algebra.trace_eq_zero_of_sq_algebraMap_of_not_mem_range`: the corresponding
+  trace-vanishing statement for any finite field extension.
 * `TauCeti.Algebra.discr_one_self_eq_of_sq`: in a quadratic extension, the trace-form
   discriminant of the square-root basis `{1, x}` is `4a` when `x² = a` and `x ∉ F`.
 
@@ -30,9 +32,11 @@ open Module Polynomial
 
 namespace TauCeti
 
+namespace Algebra
+
 /-- In a finite field extension, an element outside the base field whose square lies in the
 base field has trace zero. -/
-private theorem trace_eq_zero_of_sq_algebraMap_of_not_mem_range {F L : Type*} [Field F] [Field L]
+theorem trace_eq_zero_of_sq_algebraMap_of_not_mem_range {F L : Type*} [Field F] [Field L]
     [Algebra F L] [FiniteDimensional F L] {x : L} {r : F}
     (hx2 : x ^ 2 = algebraMap F L r) (hx : x ∉ (algebraMap F L).range) :
     Algebra.trace F L x = 0 := by
@@ -61,8 +65,6 @@ private theorem trace_eq_zero_of_sq_algebraMap_of_not_mem_range {F L : Type*} [F
       (by rw [Polynomial.natDegree_X_pow_sub_C]; norm_num)]
     simp [Polynomial.coeff_X_pow]
   rw [hnc]; simp
-
-namespace Algebra
 
 variable {F L : Type*} [Field F] [Field L] [Algebra F L] [FiniteDimensional F L]
 
@@ -107,6 +109,14 @@ theorem trace_eq_zero_of_sq_ratCast {K : Type*} [Field K] [NumberField K]
     {x : K} {r : ℚ} (hx2 : x ^ 2 = algebraMap ℚ K r)
     (hx : x ∉ (algebraMap ℚ K).range) :
     Algebra.trace ℚ K x = 0 :=
-  trace_eq_zero_of_sq_algebraMap_of_not_mem_range hx2 hx
+  TauCeti.Algebra.trace_eq_zero_of_sq_algebraMap_of_not_mem_range hx2 hx
+
+/-- Deprecated compatibility alias for the original trace-vanishing helper name. -/
+@[deprecated TauCeti.NumberField.trace_eq_zero_of_sq_ratCast (since := "2026-06-20")]
+theorem trace_eq_zero_of_sq_ratCast_of_not_mem_range {K : Type*} [Field K] [NumberField K]
+    {x : K} {r : ℚ} (hx2 : x ^ 2 = algebraMap ℚ K r)
+    (hx : x ∉ (algebraMap ℚ K).range) :
+    Algebra.trace ℚ K x = 0 :=
+  trace_eq_zero_of_sq_ratCast hx2 hx
 
 end TauCeti.NumberField

--- a/TauCeti/FieldTheory/Trace.lean
+++ b/TauCeti/FieldTheory/Trace.lean
@@ -17,7 +17,7 @@ This file collects reusable trace facts for finite field extensions.
   specialization saying that `x² ∈ ℚ`, `x ∉ ℚ` implies `Tr x = 0`.
 * `TauCeti.Algebra.trace_eq_zero_of_sq_algebraMap_of_not_mem_range`: the corresponding
   trace-vanishing statement for any finite field extension.
-* `TauCeti.Algebra.discr_one_self_eq_of_sq`: in a quadratic extension, the trace-form
+* `TauCeti.Algebra.discr_one_sqrt_eq_of_sq`: in a quadratic extension, the trace-form
   discriminant of the square-root basis `{1, x}` is `4a` when `x² = a` and `x ∉ F`.
 
 ## Provenance
@@ -70,7 +70,7 @@ variable {F L : Type*} [Field F] [Field L] [Algebra F L] [FiniteDimensional F L]
 
 /-- For a quadratic extension `L / F` and an element `x ∉ F` whose square is `a ∈ F`, the
 trace-form discriminant of the square-root basis `{1, x}` equals `4 a`. -/
-theorem discr_one_self_eq_of_sq {x : L} {a : F} (hfin : finrank F L = 2)
+theorem discr_one_sqrt_eq_of_sq {x : L} {a : F} (hfin : finrank F L = 2)
     (hx2 : x ^ 2 = algebraMap F L a) (hx : x ∉ (algebraMap F L).range) :
     Algebra.discr F ![1, x] = 4 * a := by
   have htr0 : Algebra.trace F L x = 0 :=
@@ -110,13 +110,5 @@ theorem trace_eq_zero_of_sq_ratCast {K : Type*} [Field K] [NumberField K]
     (hx : x ∉ (algebraMap ℚ K).range) :
     Algebra.trace ℚ K x = 0 :=
   TauCeti.Algebra.trace_eq_zero_of_sq_algebraMap_of_not_mem_range hx2 hx
-
-/-- Deprecated compatibility alias for the original trace-vanishing helper name. -/
-@[deprecated TauCeti.NumberField.trace_eq_zero_of_sq_ratCast (since := "2026-06-20")]
-theorem trace_eq_zero_of_sq_ratCast_of_not_mem_range {K : Type*} [Field K] [NumberField K]
-    {x : K} {r : ℚ} (hx2 : x ^ 2 = algebraMap ℚ K r)
-    (hx : x ∉ (algebraMap ℚ K).range) :
-    Algebra.trace ℚ K x = 0 :=
-  trace_eq_zero_of_sq_ratCast hx2 hx
 
 end TauCeti.NumberField

--- a/TauCeti/FieldTheory/Trace.lean
+++ b/TauCeti/FieldTheory/Trace.lean
@@ -13,7 +13,7 @@ This file collects reusable trace facts for finite field extensions.
 
 ## Main results
 
-* `TauCeti.NumberField.trace_eq_zero_of_sq_ratCast_of_not_mem_range`: the number-field
+* `TauCeti.NumberField.trace_eq_zero_of_sq_ratCast`: the number-field
   specialization saying that `x² ∈ ℚ`, `x ∉ ℚ` implies `Tr x = 0`.
 * `TauCeti.Algebra.discr_one_self_eq_of_sq`: in a quadratic extension, the trace-form
   discriminant of the square-root basis `{1, x}` is `4a` when `x² = a` and `x ∉ F`.
@@ -103,7 +103,7 @@ end Algebra
 namespace NumberField
 
 /-- In a number field, an irrational element whose square is rational has trace zero. -/
-theorem trace_eq_zero_of_sq_ratCast_of_not_mem_range {K : Type*} [Field K] [NumberField K]
+theorem trace_eq_zero_of_sq_ratCast {K : Type*} [Field K] [NumberField K]
     {x : K} {r : ℚ} (hx2 : x ^ 2 = algebraMap ℚ K r)
     (hx : x ∉ (algebraMap ℚ K).range) :
     Algebra.trace ℚ K x = 0 :=

--- a/TauCeti/NumberTheory/EffectiveBounds/TraceForm.lean
+++ b/TauCeti/NumberTheory/EffectiveBounds/TraceForm.lean
@@ -2,8 +2,7 @@
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 -/
-import Mathlib.RingTheory.Discriminant
-import Mathlib.NumberTheory.NumberField.Basic
+import TauCeti.FieldTheory.Trace
 import Mathlib.LinearAlgebra.Complex.FiniteDimensional
 
 /-!
@@ -12,18 +11,19 @@ import Mathlib.LinearAlgebra.Complex.FiniteDimensional
 The effective discriminant bound `|d_K| ≤ |disc b|` (already in
 `TauCeti/NumberTheory/EffectiveBounds/Discriminant.lean`) is only useful once one can
 *evaluate* `disc b` on a concrete basis. The cheapest bases of a quadratic field are the
-square-root bases `{1, x}` with `x² ∈ K`, and on those the trace form is diagonal: the
-off-diagonal entry `Tr(1 · x) = Tr x` vanishes because an element whose square lies in the
-base field has trace zero.
+square-root bases `{1, x}` with `x² ∈ K`, and on those the trace form is diagonal when
+`x ∉ K`: the off-diagonal entry `Tr(1 · x) = Tr x` vanishes because a non-base-field
+element whose square lies in the base field has trace zero.
 
-This file supplies that trace-vanishing criterion and the resulting discriminant formula.
+This file records the EffectiveBounds square-root examples using the reusable trace and
+discriminant API from `TauCeti.FieldTheory.Trace`.
 
 ## Main results
 
-* `TauCeti.Algebra.trace_eq_zero_of_sq_mem_range`: if `x² ∈ K` (as an element of a finite
-  field extension `L / K`) but `x ∉ K`, then `Tr_{L/K} x = 0`.
-* `TauCeti.NumberField.trace_eq_zero_of_sq_ratCast`: the number-field specialisation, for
-  `x` in a number field `K` with `x² = (q : K)` rational and `x` irrational.
+* `TauCeti.trace_eq_zero_of_sq_algebraMap_of_not_mem_range`: if `x² ∈ K` (as an element
+  of a finite field extension `L / K`) but `x ∉ K`, then `Tr_{L/K} x = 0`.
+* `TauCeti.NumberField.trace_eq_zero_of_sq_ratCast_of_not_mem_range`: the number-field
+  specialization, for `x` in a number field `K` with `x² ∈ ℚ` and `x ∉ ℚ`.
 * `TauCeti.Algebra.discr_one_self_eq_of_sq`: for a quadratic extension `L / K` and
   `x ∉ K` with `x² = a ∈ K`, the trace-form discriminant of the basis `{1, x}` is `4 a`.
 
@@ -35,94 +35,20 @@ and `disc ℝ {1, I} = -4`, mirroring the roadmap's `ℚ(i)` worked example.
 The trace-vanishing criterion migrates `trace_eq_zero_of_sq_ratCast` from
 [kim-em/erdos-unit-distance](https://github.com/kim-em/erdos-unit-distance), the
 formalization of L. Alpöge's disproof of the uniform-constant Erdős unit-distance
-conjecture, where it diagonalises the trace form on square-root bases; the criterion is
-restated here over an arbitrary finite field extension, with the rational version kept as a
-direct corollary.
+conjecture, where it diagonalises the trace form on square-root bases. The reusable
+criterion and discriminant formula live in `TauCeti.FieldTheory.Trace`; this file keeps
+the EffectiveBounds worked examples near the roadmap target.
 -/
 
-open Module Polynomial
+open Polynomial
 
 namespace TauCeti
 
 namespace Algebra
 
-variable {K L : Type*} [Field K] [Field L] [Algebra K L] [FiniteDimensional K L]
-
-/-- If `x` lies in a finite extension `L / K`, its square lies in `K`, but `x` itself does
-not, then the trace `Tr_{L/K} x` vanishes. Indeed the minimal polynomial of such an `x` is
-`X² - a`, whose subleading coefficient is zero, and the trace is `[L : K(x)]` times that
-coefficient. -/
-theorem trace_eq_zero_of_sq_mem_range {x : L} {a : K} (hx2 : x ^ 2 = algebraMap K L a)
-    (hx : x ∉ (algebraMap K L).range) : Algebra.trace K L x = 0 := by
-  have hint : IsIntegral K x := IsIntegral.of_finite K x
-  -- `x` is a root of the monic quadratic `X² - C a`.
-  have haeval : (Polynomial.aeval x) (X ^ 2 - C a) = 0 := by
-    rw [map_sub, map_pow, aeval_X, aeval_C, hx2, sub_self]
-  have hmonic : (X ^ 2 - C a : K[X]).Monic := monic_X_pow_sub_C a (by norm_num)
-  have hdvd : minpoly K x ∣ (X ^ 2 - C a) := minpoly.dvd K x haeval
-  -- `x ∉ K` forces the minimal polynomial to have degree at least two, hence to *be* it.
-  have hge : 2 ≤ (minpoly K x).natDegree := (minpoly.two_le_natDegree_iff hint).mpr hx
-  have hmin : (X ^ 2 - C a : K[X]) = minpoly K x :=
-    eq_of_monic_of_dvd_of_natDegree_le (minpoly.monic hint) hmonic hdvd
-      (by rw [natDegree_X_pow_sub_C]; exact hge)
-  -- The subleading coefficient of `X² - C a` is zero.
-  have hnext : (X ^ 2 - C a : K[X]).nextCoeff = 0 := by
-    rw [nextCoeff_of_natDegree_pos (by rw [natDegree_X_pow_sub_C]; norm_num),
-      natDegree_X_pow_sub_C]
-    simp [coeff_X_pow]
-  rw [trace_eq_finrank_mul_minpoly_nextCoeff K x, ← hmin, hnext, neg_zero, mul_zero]
-
-/-- For a quadratic extension `L / K` and an element `x ∉ K` whose square is `a ∈ K`, the
-trace-form discriminant of the square-root basis `{1, x}` equals `4 a`: the trace form is
-diagonal with entries `Tr 1 = 2` and `Tr x² = 2 a`. -/
-theorem discr_one_self_eq_of_sq {x : L} {a : K} (hfin : finrank K L = 2)
-    (hx2 : x ^ 2 = algebraMap K L a) (hx : x ∉ (algebraMap K L).range) :
-    Algebra.discr K ![1, x] = 4 * a := by
-  have htr0 : Algebra.trace K L x = 0 := trace_eq_zero_of_sq_mem_range hx2 hx
-  have e00 : Algebra.traceMatrix K ![1, x] 0 0 = 2 := by
-    rw [Algebra.traceMatrix_apply, Algebra.traceForm_apply]
-    simp only [Matrix.cons_val_zero, mul_one]
-    rw [show (1 : L) = algebraMap K L 1 from (map_one _).symm, Algebra.trace_algebraMap, hfin]
-    simp
-  have e11 : Algebra.traceMatrix K ![1, x] 1 1 = 2 * a := by
-    rw [Algebra.traceMatrix_apply, Algebra.traceForm_apply]
-    simp only [Matrix.cons_val_one, Matrix.cons_val_zero]
-    rw [show x * x = algebraMap K L a from by rw [← pow_two]; exact hx2,
-      Algebra.trace_algebraMap, hfin]
-    simp [nsmul_eq_mul]
-  have e01 : Algebra.traceMatrix K ![1, x] 0 1 = 0 := by
-    rw [Algebra.traceMatrix_apply, Algebra.traceForm_apply]
-    simp only [Matrix.cons_val_zero, Matrix.cons_val_one, one_mul]
-    exact htr0
-  have e10 : Algebra.traceMatrix K ![1, x] 1 0 = 0 := by
-    rw [Algebra.traceMatrix_apply, Algebra.traceForm_apply]
-    simp only [Matrix.cons_val_zero, Matrix.cons_val_one, mul_one]
-    exact htr0
-  rw [Algebra.discr_def, Matrix.det_fin_two, e00, e11, e01, e10]
-  ring
-
-end Algebra
-
-namespace NumberField
-
-/-- **Trace-zero criterion for square-root generators.** In a number field `K`, an element
-`x` whose square is a rational `q` but which is itself irrational has trace zero. This is
-the form that diagonalises the trace form on a square-root basis of a quadratic field. -/
-theorem trace_eq_zero_of_sq_ratCast {K : Type*} [Field K] [NumberField K] {x : K} {q : ℚ}
-    (hx2 : x ^ 2 = (q : K)) (hx : ∀ r : ℚ, (r : K) ≠ x) : Algebra.trace ℚ K x = 0 := by
-  refine TauCeti.Algebra.trace_eq_zero_of_sq_mem_range (a := q) ?_ ?_
-  · rw [hx2, eq_ratCast]
-  · rintro ⟨r, hr⟩
-    rw [eq_ratCast] at hr
-    exact hx r hr
-
-end NumberField
-
-namespace Algebra
-
 /-- `Complex.I` squares to the real number `-1`, so its trace over `ℝ` vanishes. -/
 example : Algebra.trace ℝ ℂ Complex.I = 0 := by
-  refine trace_eq_zero_of_sq_mem_range (a := -1) ?_ ?_
+  refine TauCeti.trace_eq_zero_of_sq_algebraMap_of_not_mem_range (r := -1) ?_ ?_
   · rw [Complex.I_sq]; simp
   · rintro ⟨r, hr⟩
     simpa [Complex.ext_iff, Complex.I_im] using congrArg Complex.im hr

--- a/TauCeti/NumberTheory/EffectiveBounds/TraceForm.lean
+++ b/TauCeti/NumberTheory/EffectiveBounds/TraceForm.lean
@@ -17,9 +17,10 @@ square-root bases `{1, x}` with `x² ∈ K`, and on those the trace form is diag
 element whose square lies in the base field has trace zero.
 
 This file declares no new results: it records the EffectiveBounds square-root worked
-examples by reusing the trace and discriminant API from `TauCeti.FieldTheory.Trace`
-(`TauCeti.NumberField.trace_eq_zero_of_sq_ratCast` and
-`TauCeti.Algebra.discr_one_elem_eq_of_sq_algebraMap`).
+examples. The discriminant example reuses `TauCeti.Algebra.discr_one_elem_eq_of_sq_algebraMap`
+from `TauCeti.FieldTheory.Trace` (which in turn evaluates the off-diagonal trace via the
+trace-vanishing criterion); the trace example computes `Tr_{ℂ/ℝ} I` directly via
+`Algebra.trace_complex_apply`.
 
 ## Worked examples
 

--- a/TauCeti/NumberTheory/EffectiveBounds/TraceForm.lean
+++ b/TauCeti/NumberTheory/EffectiveBounds/TraceForm.lean
@@ -1,0 +1,141 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+import Mathlib.RingTheory.Discriminant
+import Mathlib.NumberTheory.NumberField.Basic
+import Mathlib.LinearAlgebra.Complex.FiniteDimensional
+
+/-!
+# Trace-form diagonalisation for square-root bases
+
+The effective discriminant bound `|d_K| ≤ |disc b|` (already in
+`TauCeti/NumberTheory/EffectiveBounds/Discriminant.lean`) is only useful once one can
+*evaluate* `disc b` on a concrete basis. The cheapest bases of a quadratic field are the
+square-root bases `{1, x}` with `x² ∈ K`, and on those the trace form is diagonal: the
+off-diagonal entry `Tr(1 · x) = Tr x` vanishes because an element whose square lies in the
+base field has trace zero.
+
+This file supplies that trace-vanishing criterion and the resulting discriminant formula.
+
+## Main results
+
+* `TauCeti.Algebra.trace_eq_zero_of_sq_mem_range`: if `x² ∈ K` (as an element of a finite
+  field extension `L / K`) but `x ∉ K`, then `Tr_{L/K} x = 0`.
+* `TauCeti.NumberField.trace_eq_zero_of_sq_ratCast`: the number-field specialisation, for
+  `x` in a number field `K` with `x² = (q : K)` rational and `x` irrational.
+* `TauCeti.Algebra.discr_one_self_eq_of_sq`: for a quadratic extension `L / K` and
+  `x ∉ K` with `x² = a ∈ K`, the trace-form discriminant of the basis `{1, x}` is `4 a`.
+
+The two `example`s at the end exercise the API on `ℂ / ℝ` (degree two): `Tr_{ℂ/ℝ} I = 0`
+and `disc ℝ {1, I} = -4`, mirroring the roadmap's `ℚ(i)` worked example.
+
+## Provenance
+
+The trace-vanishing criterion migrates `trace_eq_zero_of_sq_ratCast` from
+[kim-em/erdos-unit-distance](https://github.com/kim-em/erdos-unit-distance), the
+formalization of L. Alpöge's disproof of the uniform-constant Erdős unit-distance
+conjecture, where it diagonalises the trace form on square-root bases; the criterion is
+restated here over an arbitrary finite field extension, with the rational version kept as a
+direct corollary.
+-/
+
+open Module Polynomial
+
+namespace TauCeti
+
+namespace Algebra
+
+variable {K L : Type*} [Field K] [Field L] [Algebra K L] [FiniteDimensional K L]
+
+/-- If `x` lies in a finite extension `L / K`, its square lies in `K`, but `x` itself does
+not, then the trace `Tr_{L/K} x` vanishes. Indeed the minimal polynomial of such an `x` is
+`X² - a`, whose subleading coefficient is zero, and the trace is `[L : K(x)]` times that
+coefficient. -/
+theorem trace_eq_zero_of_sq_mem_range {x : L} {a : K} (hx2 : x ^ 2 = algebraMap K L a)
+    (hx : x ∉ (algebraMap K L).range) : Algebra.trace K L x = 0 := by
+  have hint : IsIntegral K x := IsIntegral.of_finite K x
+  -- `x` is a root of the monic quadratic `X² - C a`.
+  have haeval : (Polynomial.aeval x) (X ^ 2 - C a) = 0 := by
+    rw [map_sub, map_pow, aeval_X, aeval_C, hx2, sub_self]
+  have hmonic : (X ^ 2 - C a : K[X]).Monic := monic_X_pow_sub_C a (by norm_num)
+  have hdvd : minpoly K x ∣ (X ^ 2 - C a) := minpoly.dvd K x haeval
+  -- `x ∉ K` forces the minimal polynomial to have degree at least two, hence to *be* it.
+  have hge : 2 ≤ (minpoly K x).natDegree := (minpoly.two_le_natDegree_iff hint).mpr hx
+  have hmin : (X ^ 2 - C a : K[X]) = minpoly K x :=
+    eq_of_monic_of_dvd_of_natDegree_le (minpoly.monic hint) hmonic hdvd
+      (by rw [natDegree_X_pow_sub_C]; exact hge)
+  -- The subleading coefficient of `X² - C a` is zero.
+  have hnext : (X ^ 2 - C a : K[X]).nextCoeff = 0 := by
+    rw [nextCoeff_of_natDegree_pos (by rw [natDegree_X_pow_sub_C]; norm_num),
+      natDegree_X_pow_sub_C]
+    simp [coeff_X_pow]
+  rw [trace_eq_finrank_mul_minpoly_nextCoeff K x, ← hmin, hnext, neg_zero, mul_zero]
+
+/-- For a quadratic extension `L / K` and an element `x ∉ K` whose square is `a ∈ K`, the
+trace-form discriminant of the square-root basis `{1, x}` equals `4 a`: the trace form is
+diagonal with entries `Tr 1 = 2` and `Tr x² = 2 a`. -/
+theorem discr_one_self_eq_of_sq {x : L} {a : K} (hfin : finrank K L = 2)
+    (hx2 : x ^ 2 = algebraMap K L a) (hx : x ∉ (algebraMap K L).range) :
+    Algebra.discr K ![1, x] = 4 * a := by
+  have htr0 : Algebra.trace K L x = 0 := trace_eq_zero_of_sq_mem_range hx2 hx
+  have e00 : Algebra.traceMatrix K ![1, x] 0 0 = 2 := by
+    rw [Algebra.traceMatrix_apply, Algebra.traceForm_apply]
+    simp only [Matrix.cons_val_zero, mul_one]
+    rw [show (1 : L) = algebraMap K L 1 from (map_one _).symm, Algebra.trace_algebraMap, hfin]
+    simp
+  have e11 : Algebra.traceMatrix K ![1, x] 1 1 = 2 * a := by
+    rw [Algebra.traceMatrix_apply, Algebra.traceForm_apply]
+    simp only [Matrix.cons_val_one, Matrix.cons_val_zero]
+    rw [show x * x = algebraMap K L a from by rw [← pow_two]; exact hx2,
+      Algebra.trace_algebraMap, hfin]
+    simp [nsmul_eq_mul]
+  have e01 : Algebra.traceMatrix K ![1, x] 0 1 = 0 := by
+    rw [Algebra.traceMatrix_apply, Algebra.traceForm_apply]
+    simp only [Matrix.cons_val_zero, Matrix.cons_val_one, one_mul]
+    exact htr0
+  have e10 : Algebra.traceMatrix K ![1, x] 1 0 = 0 := by
+    rw [Algebra.traceMatrix_apply, Algebra.traceForm_apply]
+    simp only [Matrix.cons_val_zero, Matrix.cons_val_one, mul_one]
+    exact htr0
+  rw [Algebra.discr_def, Matrix.det_fin_two, e00, e11, e01, e10]
+  ring
+
+end Algebra
+
+namespace NumberField
+
+/-- **Trace-zero criterion for square-root generators.** In a number field `K`, an element
+`x` whose square is a rational `q` but which is itself irrational has trace zero. This is
+the form that diagonalises the trace form on a square-root basis of a quadratic field. -/
+theorem trace_eq_zero_of_sq_ratCast {K : Type*} [Field K] [NumberField K] {x : K} {q : ℚ}
+    (hx2 : x ^ 2 = (q : K)) (hx : ∀ r : ℚ, (r : K) ≠ x) : Algebra.trace ℚ K x = 0 := by
+  refine TauCeti.Algebra.trace_eq_zero_of_sq_mem_range (a := q) ?_ ?_
+  · rw [hx2, eq_ratCast]
+  · rintro ⟨r, hr⟩
+    rw [eq_ratCast] at hr
+    exact hx r hr
+
+end NumberField
+
+namespace Algebra
+
+/-- `Complex.I` squares to the real number `-1`, so its trace over `ℝ` vanishes. -/
+example : Algebra.trace ℝ ℂ Complex.I = 0 := by
+  refine trace_eq_zero_of_sq_mem_range (a := -1) ?_ ?_
+  · rw [Complex.I_sq]; simp
+  · rintro ⟨r, hr⟩
+    simpa [Complex.ext_iff, Complex.I_im] using congrArg Complex.im hr
+
+/-- The trace-form discriminant of the basis `{1, I}` of `ℂ` over `ℝ` is `-4`, recovering
+`|disc {1, i}| = 4` of the roadmap's `ℚ(i)` worked example. -/
+example : Algebra.discr ℝ ![1, Complex.I] = -4 := by
+  rw [discr_one_self_eq_of_sq (a := -1) Complex.finrank_real_complex]
+  · norm_num
+  · rw [Complex.I_sq]; simp
+  · rintro ⟨r, hr⟩
+    simpa [Complex.ext_iff, Complex.I_im] using congrArg Complex.im hr
+
+end Algebra
+
+end TauCeti

--- a/TauCeti/NumberTheory/EffectiveBounds/TraceForm.lean
+++ b/TauCeti/NumberTheory/EffectiveBounds/TraceForm.lean
@@ -4,6 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 -/
 import TauCeti.FieldTheory.Trace
 import Mathlib.LinearAlgebra.Complex.FiniteDimensional
+import Mathlib.RingTheory.Complex
 
 /-!
 # Trace-form diagonalisation for square-root bases
@@ -20,8 +21,6 @@ discriminant API from `TauCeti.FieldTheory.Trace`.
 
 ## Main results
 
-* `TauCeti.trace_eq_zero_of_sq_algebraMap_of_not_mem_range`: if `x² ∈ K` (as an element
-  of a finite field extension `L / K`) but `x ∉ K`, then `Tr_{L/K} x = 0`.
 * `TauCeti.NumberField.trace_eq_zero_of_sq_ratCast_of_not_mem_range`: the number-field
   specialization, for `x` in a number field `K` with `x² ∈ ℚ` and `x ∉ ℚ`.
 * `TauCeti.Algebra.discr_one_self_eq_of_sq`: for a quadratic extension `L / K` and
@@ -48,10 +47,8 @@ namespace Algebra
 
 /-- `Complex.I` squares to the real number `-1`, so its trace over `ℝ` vanishes. -/
 example : Algebra.trace ℝ ℂ Complex.I = 0 := by
-  refine TauCeti.trace_eq_zero_of_sq_algebraMap_of_not_mem_range (r := -1) ?_ ?_
-  · rw [Complex.I_sq]; simp
-  · rintro ⟨r, hr⟩
-    simpa [Complex.ext_iff, Complex.I_im] using congrArg Complex.im hr
+  rw [Algebra.trace_complex_apply, Complex.I_re]
+  norm_num
 
 /-- The trace-form discriminant of the basis `{1, I}` of `ℂ` over `ℝ` is `-4`, recovering
 `|disc {1, i}| = 4` of the roadmap's `ℚ(i)` worked example. -/

--- a/TauCeti/NumberTheory/EffectiveBounds/TraceForm.lean
+++ b/TauCeti/NumberTheory/EffectiveBounds/TraceForm.lean
@@ -19,7 +19,7 @@ element whose square lies in the base field has trace zero.
 This file declares no new results: it records the EffectiveBounds square-root worked
 examples by reusing the trace and discriminant API from `TauCeti.FieldTheory.Trace`
 (`TauCeti.NumberField.trace_eq_zero_of_sq_ratCast` and
-`TauCeti.Algebra.discr_one_sqrt_eq_of_sq`).
+`TauCeti.Algebra.discr_one_elem_eq_of_sq_algebraMap`).
 
 ## Worked examples
 
@@ -50,7 +50,7 @@ example : Algebra.trace ℝ ℂ Complex.I = 0 := by
 /-- The trace-form discriminant of the basis `{1, I}` of `ℂ` over `ℝ` is `-4`, recovering
 `|disc {1, i}| = 4` of the roadmap's `ℚ(i)` worked example. -/
 example : Algebra.discr ℝ ![1, Complex.I] = -4 := by
-  rw [discr_one_sqrt_eq_of_sq (a := -1) Complex.finrank_real_complex]
+  rw [discr_one_elem_eq_of_sq_algebraMap (a := -1) Complex.finrank_real_complex]
   · norm_num
   · rw [Complex.I_sq]; simp
   · rintro ⟨r, hr⟩

--- a/TauCeti/NumberTheory/EffectiveBounds/TraceForm.lean
+++ b/TauCeti/NumberTheory/EffectiveBounds/TraceForm.lean
@@ -16,17 +16,14 @@ square-root bases `{1, x}` with `x² ∈ K`, and on those the trace form is diag
 `x ∉ K`: the off-diagonal entry `Tr(1 · x) = Tr x` vanishes because a non-base-field
 element whose square lies in the base field has trace zero.
 
-This file records the EffectiveBounds square-root examples using the reusable trace and
-discriminant API from `TauCeti.FieldTheory.Trace`.
+This file declares no new results: it records the EffectiveBounds square-root worked
+examples by reusing the trace and discriminant API from `TauCeti.FieldTheory.Trace`
+(`TauCeti.NumberField.trace_eq_zero_of_sq_ratCast` and
+`TauCeti.Algebra.discr_one_sqrt_eq_of_sq`).
 
-## Main results
+## Worked examples
 
-* `TauCeti.NumberField.trace_eq_zero_of_sq_ratCast`: the number-field
-  specialization, for `x` in a number field `K` with `x² ∈ ℚ` and `x ∉ ℚ`.
-* `TauCeti.Algebra.discr_one_self_eq_of_sq`: for a quadratic extension `L / K` and
-  `x ∉ K` with `x² = a ∈ K`, the trace-form discriminant of the basis `{1, x}` is `4 a`.
-
-The two `example`s at the end exercise the API on `ℂ / ℝ` (degree two): `Tr_{ℂ/ℝ} I = 0`
+The two `example`s below exercise that API on `ℂ / ℝ` (degree two): `Tr_{ℂ/ℝ} I = 0`
 and `disc ℝ {1, I} = -4`, mirroring the roadmap's `ℚ(i)` worked example.
 
 ## Provenance
@@ -53,7 +50,7 @@ example : Algebra.trace ℝ ℂ Complex.I = 0 := by
 /-- The trace-form discriminant of the basis `{1, I}` of `ℂ` over `ℝ` is `-4`, recovering
 `|disc {1, i}| = 4` of the roadmap's `ℚ(i)` worked example. -/
 example : Algebra.discr ℝ ![1, Complex.I] = -4 := by
-  rw [discr_one_self_eq_of_sq (a := -1) Complex.finrank_real_complex]
+  rw [discr_one_sqrt_eq_of_sq (a := -1) Complex.finrank_real_complex]
   · norm_num
   · rw [Complex.I_sq]; simp
   · rintro ⟨r, hr⟩

--- a/TauCeti/NumberTheory/EffectiveBounds/TraceForm.lean
+++ b/TauCeti/NumberTheory/EffectiveBounds/TraceForm.lean
@@ -21,7 +21,7 @@ discriminant API from `TauCeti.FieldTheory.Trace`.
 
 ## Main results
 
-* `TauCeti.NumberField.trace_eq_zero_of_sq_ratCast_of_not_mem_range`: the number-field
+* `TauCeti.NumberField.trace_eq_zero_of_sq_ratCast`: the number-field
   specialization, for `x` in a number field `K` with `x² ∈ ℚ` and `x ∉ ℚ`.
 * `TauCeti.Algebra.discr_one_self_eq_of_sq`: for a quadratic extension `L / K` and
   `x ∉ K` with `x² = a ∈ K`, the trace-form discriminant of the basis `{1, x}` is `4 a`.


### PR DESCRIPTION
This PR adds the trace-form diagonalisation that evaluates a square-root basis discriminant, the tool the effective discriminant bound needs to be usable on concrete quadratic fields. It proves that an element `x` of a finite field extension `L / K` with `x² ∈ K` but `x ∉ K` has vanishing trace (`Algebra.trace_eq_zero_of_sq_mem_range`), specialises it to a number field with a rational square (`NumberField.trace_eq_zero_of_sq_ratCast`, the `trace_eq_zero_of_sq_ratCast` helper named in the roadmap), and uses it to compute the trace-form discriminant of the basis `{1, x}` of a quadratic extension as `4 a` when `x² = a` (`Algebra.discr_one_self_eq_of_sq`). Two `example`s exercise the API on `ℂ / ℝ`: `Tr_{ℂ/ℝ} I = 0` and `disc ℝ {1, I} = -4`, mirroring the roadmap's `ℚ(i)` worked example `|disc {1, i}| = 4`.

This advances the EffectiveBounds roadmap (`TauCetiRoadmap/EffectiveBounds/README.md`, Layer 1): the discriminant-from-an-integral-basis target lists the helper `trace_eq_zero_of_sq_ratCast` ("an element with `x² ∈ ℚ`, `x ∉ ℚ` has trace zero") as the piece that "diagonalises the trace form on square-root bases: it is how the `ℚ(i)` worked example below evaluates `|disc b|`." The already-merged discriminant bound (`abs_discr_le_of_basis_isIntegral`) did not need this helper, so it was left unported; this PR supplies it, in the more general finite-extension form, together with the trace-form discriminant computation it enables.

The trace-vanishing criterion migrates `trace_eq_zero_of_sq_ratCast` from [kim-em/erdos-unit-distance](https://github.com/kim-em/erdos-unit-distance) (the formalization of L. Alpöge's disproof of the uniform-constant Erdős unit-distance conjecture), restated over an arbitrary finite field extension with the rational version kept as a direct corollary; thanks to its authors.

<!--tauceti-target:v1 {"focus":"EffectiveBounds","id":"trace-eq-zero-of-sq-ratcast"}-->

🤖 Prepared with Claude Code
