### PR TITLE
refactor(IntermediateField): derive the quadratic normal form from mathlib's power basis

### DIFF
--- a/TauCeti/FieldTheory/IntermediateField/Quadratic.lean
+++ b/TauCeti/FieldTheory/IntermediateField/Quadratic.lean
@@ -45,76 +45,35 @@ theorem exists_add_mul_of_mem_sup_adjoin_sq {F : IntermediateField K L} {x : L}
     (hx2 : x ^ 2 ∈ F) {y : L}
     (hy : y ∈ F ⊔ IntermediateField.adjoin K {x}) :
     ∃ a b : L, a ∈ F ∧ b ∈ F ∧ y = a + b * x := by
-  let S : IntermediateField K L :=
-    { carrier := {y | ∃ a b : L, a ∈ F ∧ b ∈ F ∧ y = a + b * x}
-      zero_mem' := ⟨0, 0, zero_mem F, zero_mem F, by simp⟩
-      add_mem' := by
-        rintro y z ⟨a, b, ha, hb, rfl⟩ ⟨c, d, hc, hd, rfl⟩
-        exact ⟨a + c, b + d, add_mem ha hc, add_mem hb hd, by ring⟩
-      one_mem' := ⟨1, 0, one_mem F, zero_mem F, by simp⟩
-      mul_mem' := by
-        rintro y z ⟨a, b, ha, hb, rfl⟩ ⟨c, d, hc, hd, rfl⟩
-        refine ⟨a * c + (b * d) * x ^ 2, a * d + b * c, ?_, ?_, by ring⟩
-        · exact add_mem (mul_mem ha hc) (mul_mem (mul_mem hb hd) hx2)
-        · exact add_mem (mul_mem ha hd) (mul_mem hb hc)
-      algebraMap_mem' := fun k => ⟨algebraMap K L k, 0, F.algebraMap_mem k, zero_mem F, by simp⟩
-      inv_mem' := by
-        classical
-        rintro y ⟨a, b, ha, hb, rfl⟩
-        by_cases hy0 : a + b * x = 0
-        · exact ⟨0, 0, zero_mem F, zero_mem F, by simp [hy0]⟩
-        · by_cases hD : a ^ 2 - b ^ 2 * x ^ 2 = 0
-          · have hprod : (a - b * x) * (a + b * x) = 0 := by
-              calc
-                (a - b * x) * (a + b * x) = a ^ 2 - b ^ 2 * x ^ 2 := by ring
-                _ = 0 := hD
-            have hamul : a - b * x = 0 := (mul_eq_zero.mp hprod).resolve_right hy0
-            have haeq : a = b * x := sub_eq_zero.mp hamul
-            have hbx : b * x ≠ 0 := by
-              intro h
-              apply hy0
-              rw [haeq, h]
-              ring
-            have hx0 : x ≠ 0 := by
-              intro hx
-              apply hbx
-              rw [hx, mul_zero]
-            have htwo : (2 : L) ≠ 0 := by
-              intro htwo
-              apply hy0
-              rw [haeq, ← two_mul]
-              simp [htwo]
-            have hden : (2 : L) * b * x ^ 2 ≠ 0 := by
-              have hb0 : b ≠ 0 := left_ne_zero_of_mul hbx
-              exact mul_ne_zero (mul_ne_zero htwo hb0) (pow_ne_zero 2 hx0)
-            have hb0 : b ≠ 0 := left_ne_zero_of_mul hbx
-            refine ⟨0, ((2 : L) * b * x ^ 2)⁻¹, zero_mem F, ?_, ?_⟩
-            · exact inv_mem (mul_mem (mul_mem (F.natCast_mem 2) hb) hx2)
-            · rw [haeq]
-              field_simp [hden, hbx, hb0, hx0, htwo]
-              rw [mul_zero, zero_mul, zero_add]
-              -- `field_simp` leaves the numerator as `1 + 1`; rewrite it to `2` so the
-              -- denominator `2 * b * x²` cancels via `div_self`.
-              rw [show (1 + 1 : L) = 2 by norm_num]
-              exact div_self htwo
-          · have hDmem : a ^ 2 - b ^ 2 * x ^ 2 ∈ F :=
-              sub_mem (pow_mem ha 2) (mul_mem (pow_mem hb 2) hx2)
-            refine ⟨a * (a ^ 2 - b ^ 2 * x ^ 2)⁻¹,
-              -b * (a ^ 2 - b ^ 2 * x ^ 2)⁻¹, ?_, ?_, ?_⟩
-            · exact mul_mem ha (inv_mem hDmem)
-            · exact mul_mem (neg_mem hb) (inv_mem hDmem)
-            · field_simp [hD, hy0]
-              ring }
-  have hle : F ⊔ IntermediateField.adjoin K {x} ≤ S := by
-    refine sup_le ?_ ?_
-    · intro z hz
-      exact ⟨z, 0, hz, zero_mem F, by simp⟩
-    · rw [IntermediateField.adjoin_le_iff]
-      intro z hz
-      rw [Set.mem_singleton_iff] at hz
-      subst hz
-      exact ⟨0, 1, zero_mem F, one_mem F, by simp⟩
-  exact hle hy
+  -- Since `x² ∈ F`, the element `x` is integral over `F` and the minimal polynomial of `x`
+  -- over `F` divides `X² - x²`, so `F⟮x⟯` carries a power basis `1, x` of dimension `≤ 2`.
+  have hx2_int : IsIntegral F (x ^ 2) := by
+    simpa using isIntegral_algebraMap (R := F) (A := L) (x := (⟨x ^ 2, hx2⟩ : F))
+  have hx_int : IsIntegral F x := IsIntegral.of_pow (by norm_num : 0 < 2) hx2_int
+  have hdvd : minpoly F x ∣ ((Polynomial.X : Polynomial F) ^ 2 - Polynomial.C ⟨x ^ 2, hx2⟩) :=
+    minpoly.dvd F x (by simp)
+  have hpoly_ne : ((Polynomial.X : Polynomial F) ^ 2 - Polynomial.C ⟨x ^ 2, hx2⟩) ≠ 0 := by
+    intro hzero; have hdeg := congrArg Polynomial.natDegree hzero; norm_num at hdeg
+  have hle2 : (minpoly F x).natDegree ≤ 2 :=
+    (Polynomial.natDegree_le_of_dvd hdvd hpoly_ne).trans_eq (by simp)
+  -- View `y` as an element of `F⟮x⟯` and write it on the power basis: `y = c₁ * x + c₀`
+  -- with `c₀ c₁ ∈ F`, the coefficients of a polynomial of degree `< dim ≤ 2`.
+  rw [← IntermediateField.restrictScalars_adjoin_eq_sup K F ({x} : Set L),
+    mem_restrictScalars] at hy
+  obtain ⟨f, hfdeg, hf⟩ :=
+    (IntermediateField.adjoin.powerBasis hx_int).exists_eq_aeval ⟨y, hy⟩
+  have hfle : f.natDegree ≤ 1 := by
+    have := hfdeg.trans_le (by simpa using hle2)
+    omega
+  rw [Polynomial.eq_X_add_C_of_natDegree_le_one hfle,
+    IntermediateField.adjoin.powerBasis_gen] at hf
+  refine ⟨algebraMap F L (f.coeff 0), algebraMap F L (f.coeff 1),
+    (f.coeff 0).2, (f.coeff 1).2, ?_⟩
+  have hfeq := congrArg (Subtype.val (p := (· ∈ adjoin F {x}))) hf
+  rw [AdjoinSimple.coe_aeval_gen_apply] at hfeq
+  simp only [Polynomial.aeval_add, Polynomial.aeval_mul, Polynomial.aeval_C,
+    Polynomial.aeval_X] at hfeq
+  linear_combination hfeq
 
 /-- Membership in `F ⊔ K⟮x⟯`, for `x² ∈ F`, is equivalent to having the form `a + b * x`
 with `a, b ∈ F`. -/

--- a/TauCeti/FieldTheory/IntermediateField/Quadratic.lean
+++ b/TauCeti/FieldTheory/IntermediateField/Quadratic.lean
@@ -39,6 +39,23 @@ theorem mem_sup_adjoin_sq_of_exists {F : IntermediateField K L} {x y : L}
   exact add_mem (hF ha)
     (mul_mem (hF hb) (hx (IntermediateField.mem_adjoin_of_mem K (Set.mem_singleton x))))
 
+/-- If `x² ∈ F`, then `x` is integral over `F` (it is a root of `X² - x²`). -/
+private theorem isIntegral_of_sq_mem {F : IntermediateField K L} {x : L} (hx2 : x ^ 2 ∈ F) :
+    IsIntegral F x := by
+  have hx2_int : IsIntegral F (x ^ 2) := by
+    simpa using isIntegral_algebraMap (R := F) (A := L) (x := (⟨x ^ 2, hx2⟩ : F))
+  exact IsIntegral.of_pow (by norm_num : 0 < 2) hx2_int
+
+/-- If `x² ∈ F`, then the minimal polynomial of `x` over `F` has degree at most `2`, since it
+divides the nonzero polynomial `X² - x²`. -/
+private theorem minpoly_natDegree_le_two_of_sq_mem {F : IntermediateField K L} {x : L}
+    (hx2 : x ^ 2 ∈ F) : (minpoly F x).natDegree ≤ 2 := by
+  have hdvd : minpoly F x ∣ ((Polynomial.X : Polynomial F) ^ 2 - Polynomial.C ⟨x ^ 2, hx2⟩) :=
+    minpoly.dvd F x (by simp)
+  have hpoly_ne : ((Polynomial.X : Polynomial F) ^ 2 - Polynomial.C ⟨x ^ 2, hx2⟩) ≠ 0 := by
+    intro hzero; have hdeg := congrArg Polynomial.natDegree hzero; norm_num at hdeg
+  exact (Polynomial.natDegree_le_of_dvd hdvd hpoly_ne).trans_eq (by simp)
+
 /-- If `x² ∈ F`, every element of `F ⊔ K⟮x⟯` has the form `a + b * x` with
 `a, b ∈ F`. -/
 theorem exists_add_mul_of_mem_sup_adjoin_sq {F : IntermediateField K L} {x : L}
@@ -47,25 +64,20 @@ theorem exists_add_mul_of_mem_sup_adjoin_sq {F : IntermediateField K L} {x : L}
     ∃ a b : L, a ∈ F ∧ b ∈ F ∧ y = a + b * x := by
   -- Since `x² ∈ F`, the element `x` is integral over `F` and the minimal polynomial of `x`
   -- over `F` divides `X² - x²`, so `F⟮x⟯` carries a power basis `1, x` of dimension `≤ 2`.
-  have hx2_int : IsIntegral F (x ^ 2) := by
-    simpa using isIntegral_algebraMap (R := F) (A := L) (x := (⟨x ^ 2, hx2⟩ : F))
-  have hx_int : IsIntegral F x := IsIntegral.of_pow (by norm_num : 0 < 2) hx2_int
-  have hdvd : minpoly F x ∣ ((Polynomial.X : Polynomial F) ^ 2 - Polynomial.C ⟨x ^ 2, hx2⟩) :=
-    minpoly.dvd F x (by simp)
-  have hpoly_ne : ((Polynomial.X : Polynomial F) ^ 2 - Polynomial.C ⟨x ^ 2, hx2⟩) ≠ 0 := by
-    intro hzero; have hdeg := congrArg Polynomial.natDegree hzero; norm_num at hdeg
-  have hle2 : (minpoly F x).natDegree ≤ 2 :=
-    (Polynomial.natDegree_le_of_dvd hdvd hpoly_ne).trans_eq (by simp)
+  have hx_int : IsIntegral F x := isIntegral_of_sq_mem hx2
   -- View `y` as an element of `F⟮x⟯` and write it on the power basis: `y = c₁ * x + c₀`
   -- with `c₀ c₁ ∈ F`, the coefficients of a polynomial of degree `< dim ≤ 2`.
   rw [← IntermediateField.restrictScalars_adjoin_eq_sup K F ({x} : Set L),
     mem_restrictScalars] at hy
-  obtain ⟨f, hfdeg, hf⟩ :=
-    (IntermediateField.adjoin.powerBasis hx_int).exists_eq_aeval ⟨y, hy⟩
+  set pb := IntermediateField.adjoin.powerBasis hx_int with hpb
+  obtain ⟨f, hfdeg, hf⟩ := pb.exists_eq_aeval ⟨y, hy⟩
+  have hdim : pb.dim ≤ 2 := by
+    rw [hpb, IntermediateField.adjoin.powerBasis_dim]
+    exact minpoly_natDegree_le_two_of_sq_mem hx2
   have hfle : f.natDegree ≤ 1 := by
-    have := hfdeg.trans_le (by simpa using hle2)
+    have := hfdeg.trans_le hdim
     omega
-  rw [Polynomial.eq_X_add_C_of_natDegree_le_one hfle,
+  rw [hpb, Polynomial.eq_X_add_C_of_natDegree_le_one hfle,
     IntermediateField.adjoin.powerBasis_gen] at hf
   refine ⟨algebraMap F L (f.coeff 0), algebraMap F L (f.coeff 1),
     (f.coeff 0).2, (f.coeff 1).2, ?_⟩
@@ -88,19 +100,9 @@ theorem mem_sup_adjoin_sq {F : IntermediateField K L} {x : L}
 theorem finrank_adjoin_simple_eq_two_of_sq_mem_notMem (F : IntermediateField K L) {x : L}
     (hx2 : x ^ 2 ∈ F) (hxF : x ∉ F) :
     Module.finrank F (IntermediateField.adjoin F {x}) = 2 := by
-  have hx2_int : IsIntegral F (x ^ 2) := by
-    simpa using isIntegral_algebraMap (R := F) (A := L) (x := (⟨x ^ 2, hx2⟩ : F))
-  have hx_int : IsIntegral F x := IsIntegral.of_pow (by norm_num : 0 < 2) hx2_int
+  have hx_int : IsIntegral F x := isIntegral_of_sq_mem hx2
   have hfin := IntermediateField.adjoin.finrank hx_int
-  have hle : (minpoly F x).natDegree ≤ 2 := by
-    have hroot : Polynomial.aeval x
-        ((Polynomial.X : Polynomial F) ^ 2 - Polynomial.C ⟨x ^ 2, hx2⟩) = 0 := by simp
-    have hdvd : minpoly F x ∣ ((Polynomial.X : Polynomial F) ^ 2 - Polynomial.C ⟨x ^ 2, hx2⟩) :=
-      minpoly.dvd F x hroot
-    have hpoly_ne :
-        ((Polynomial.X : Polynomial F) ^ 2 - Polynomial.C ⟨x ^ 2, hx2⟩) ≠ 0 := by
-      intro hzero; have hdeg := congrArg Polynomial.natDegree hzero; norm_num at hdeg
-    exact (Polynomial.natDegree_le_of_dvd hdvd hpoly_ne).trans_eq (by simp)
+  have hle : (minpoly F x).natDegree ≤ 2 := minpoly_natDegree_le_two_of_sq_mem hx2
   have hpos : 0 < (minpoly F x).natDegree := minpoly.natDegree_pos hx_int
   have hne1 : (minpoly F x).natDegree ≠ 1 := by
     intro hdeg1


### PR DESCRIPTION
## What

`exists_add_mul_of_mem_sup_adjoin_sq` (the lemma: for `x² ∈ F`, every element of `F ⊔ K⟮x⟯` has the form `a + b·x` with `a, b ∈ F`) hand-rolled a 70-line `IntermediateField` — including a ~45-line `inv_mem'` that re-proves closure under inverse — purely to characterise the elements. This re-derives it from mathlib's `IntermediateField.adjoin.powerBasis`:

- `restrictScalars_adjoin_eq_sup` turns `y ∈ F ⊔ adjoin K {x}` into `y ∈ adjoin F {x}` (= `F⟮x⟯` over `F`);
- `adjoin.powerBasis` + `PowerBasis.exists_eq_aeval` give the `{1, x}` expansion, with `minpoly F x ∣ X² − x²` bounding the degree to ≤ 2;
- the existence form absorbs the `x ∈ F` (degree-1) case automatically.

**The public statement is unchanged.** Proof body 70 → 26 lines. The shared "`x²∈F` ⇒ integral + minpoly degree ≤ 2" reasoning is factored into the `private` helpers `isIntegral_of_sq_mem` / `minpoly_natDegree_le_two_of_sq_mem`, used by both this lemma and `finrank_adjoin_simple_eq_two_of_sq_mem_notMem`.

## Scope / roadmap

Advances `TauCetiRoadmap/Multiquadratic/README.md`, **Layer 0: the multiquadratic field** — specifically **Square-class descent**, whose one-step quadratic engine names `mem_sup_adjoin_sq` / `exists_add_mul_of_mem_sup_adjoin_sq`. A single-topic, single-file proof-quality/reuse refactor of that existing prerequisite (also item **I5** from PR #206's post-merge review).

## Notes for reviewers

- **Reuse:** replaces a from-scratch reinvention of `IntermediateField`/inverse-closure with mathlib's power-basis API.
- **Deprecation:** none — no public declaration is renamed, removed, or restated; `exists_add_mul_of_mem_sup_adjoin_sq` and `mem_sup_adjoin_sq` keep byte-identical statements, so the consumer (`Multiquadratic/SquareClass.lean`) is unaffected.

CI verified locally on green `main`: `lake build` (3935 jobs, zero warnings) and `lake exe axioms` (2841 declarations, allowlist only) both pass.

Roadmap: Multiquadratic