### PR TITLE
refactor(IntermediateField): use minpoly.degree_le_of_ne_zero for the degree bound

### DIFF
--- a/TauCeti/FieldTheory/IntermediateField/Quadratic.lean
+++ b/TauCeti/FieldTheory/IntermediateField/Quadratic.lean
@@ -50,11 +50,11 @@ private theorem isIntegral_of_sq_mem {F : IntermediateField K L} {x : L} (hx2 : 
 divides the nonzero polynomial `X² - x²`. -/
 private theorem minpoly_natDegree_le_two_of_sq_mem {F : IntermediateField K L} {x : L}
     (hx2 : x ^ 2 ∈ F) : (minpoly F x).natDegree ≤ 2 := by
-  have hdvd : minpoly F x ∣ ((Polynomial.X : Polynomial F) ^ 2 - Polynomial.C ⟨x ^ 2, hx2⟩) :=
-    minpoly.dvd F x (by simp)
   have hpoly_ne : ((Polynomial.X : Polynomial F) ^ 2 - Polynomial.C ⟨x ^ 2, hx2⟩) ≠ 0 := by
     intro hzero; have hdeg := congrArg Polynomial.natDegree hzero; norm_num at hdeg
-  exact (Polynomial.natDegree_le_of_dvd hdvd hpoly_ne).trans_eq (by simp)
+  have hdeg := minpoly.degree_le_of_ne_zero F x hpoly_ne (by simp)
+  rw [Polynomial.degree_X_pow_sub_C (n := 2) (by norm_num)] at hdeg
+  exact Polynomial.natDegree_le_iff_degree_le.mpr hdeg
 
 /-- If `x² ∈ F`, every element of `F ⊔ K⟮x⟯` has the form `a + b * x` with
 `a, b ∈ F`. -/


### PR DESCRIPTION
## What

Follow-up to #254. In its post-merge review, **@kim-em** flagged (reuse) that the helper `minpoly_natDegree_le_two_of_sq_mem` re-derived the general fact "a nonzero annihilating polynomial bounds the minimal-polynomial degree" by hand (via `minpoly.dvd` / `Polynomial.natDegree_le_of_dvd`). This replaces that with mathlib's `minpoly.degree_le_of_ne_zero`, using `Polynomial.degree_X_pow_sub_C` for the `degree (X² − x²) = 2` step and `Polynomial.natDegree_le_iff_degree_le` to land the `natDegree ≤ 2` bound.

#254 auto-merged ~1 minute before that review posted, so this is the follow-up.

## Scope / roadmap

Same prerequisite as #254 — `TauCetiRoadmap/Multiquadratic/README.md`, **Layer 0: the multiquadratic field**, **Square-class descent**. Single-topic, single-file, `private` helper only.

## Notes for reviewers

- **Reuse:** replaces a hand-rolled minimal-polynomial degree bound with the general mathlib lemma.
- **Deprecation:** none — `minpoly_natDegree_le_two_of_sq_mem` is `private`; no public statement changes.

CI verified locally on green `main`: `lake build` (3938 jobs, zero warnings) and `lake exe axioms` (2969 declarations, allowlist only) both pass.

Roadmap: Multiquadratic