### PR TITLE
feat: degree of a prime-radicand multiquadratic field

### DIFF
--- a/TauCeti/NumberTheory/Multiquadratic/PrimeRadicands.lean
+++ b/TauCeti/NumberTheory/Multiquadratic/PrimeRadicands.lean
@@ -23,7 +23,6 @@ factor), so it is not a square.
 
 ## Main results
 
-* `TauCeti.Multiquadratic.not_isSquare_of_squarefree`: a squarefree non-unit is not a square.
 * `TauCeti.Multiquadratic.not_isSquare_prod_primes`: for distinct primes `p i`, no nonempty subset
   product `∏_{i ∈ S} (p i : ℚ)` is a square — square-class independence in the form the degree
   theorem consumes.
@@ -36,26 +35,25 @@ open scoped Function
 
 namespace TauCeti.Multiquadratic
 
-/-- A squarefree non-unit is not a square: if `a = r * r` then `r * r ∣ a` forces `r` to be a unit,
-hence `a` a unit. -/
-theorem not_isSquare_of_squarefree {R : Type*} [CommMonoid R] {a : R}
+private theorem not_isSquare_of_squarefree_of_not_isUnit {R : Type*} [CommMonoid R] {a : R}
     (ha : Squarefree a) (hu : ¬ IsUnit a) : ¬ IsSquare a := by
   rintro ⟨r, rfl⟩
   exact hu ((ha r dvd_rfl).mul (ha r dvd_rfl))
 
-/-- **Square-class independence of distinct primes.** If the `p i` are prime and pairwise distinct,
-then no nonempty subset product `∏_{i ∈ S} (p i : ℚ)` is a square in `ℚ`. This is the hypothesis the
-multiquadratic degree theorem `finrank_adjoin_range` consumes. -/
+/-- **Square-class independence of distinct primes.** If the selected `p i` are prime and pairwise
+distinct, then no nonempty subset product `∏_{i ∈ S} (p i : ℚ)` is a square in `ℚ`. This is the
+hypothesis the multiquadratic degree theorem `finrank_adjoin_range` consumes. -/
 theorem not_isSquare_prod_primes {ι : Type*} (p : ι → ℕ)
-    (hp : ∀ i, (p i).Prime) (hinj : Function.Injective p)
-    {S : Finset ι} (hS : S.Nonempty) :
+    (hp : ∀ i, (p i).Prime) {S : Finset ι}
+    (hdist : Set.Pairwise (S : Set ι) (fun i j => p i ≠ p j))
+    (hS : S.Nonempty) :
     ¬ IsSquare (∏ i ∈ S, (p i : ℚ)) := by
   rw [← Nat.cast_prod, Rat.isSquare_natCast_iff]
-  refine not_isSquare_of_squarefree ?_ ?_
+  refine not_isSquare_of_squarefree_of_not_isUnit ?_ ?_
   · refine Finset.squarefree_prod_of_pairwise_isCoprime (fun i _ j _ hij => ?_)
       (fun i _ => (hp i).prime.squarefree)
     exact Nat.coprime_iff_isRelPrime.mp
-      ((Nat.coprime_primes (hp i) (hp j)).mpr fun h => hij (hinj h))
+      ((Nat.coprime_primes (hp i) (hp j)).mpr fun h => hdist ‹i ∈ S› ‹j ∈ S› hij h)
   · rw [Nat.isUnit_iff]
     obtain ⟨i, hi⟩ := hS
     intro hprod
@@ -72,7 +70,9 @@ theorem finrank_adjoin_sqrt_primes {ι : Type*} [Finite ι] (p : ι → ℕ)
   refine finrank_adjoin_range (d := fun i => (p i : ℚ))
     (root := fun i => Real.sqrt (p i)) (fun i => ?_) (fun S hS => ?_)
   · rw [Real.sq_sqrt (Nat.cast_nonneg _), map_natCast]
-  · exact not_isSquare_prod_primes p hp hinj hS
+  · refine not_isSquare_prod_primes p hp ?_ hS
+    intro i _ j _ hij h
+    exact hij (hinj h)
 
 /-- **Worked example: `[ℚ(√2, √3) : ℚ] = 4`.** The smallest nontrivial multiquadratic degree,
 obtained from `finrank_adjoin_sqrt_primes` with the primes `2` and `3`. -/

--- a/TauCeti/NumberTheory/Multiquadratic/PrimeRadicands.lean
+++ b/TauCeti/NumberTheory/Multiquadratic/PrimeRadicands.lean
@@ -43,21 +43,21 @@ private theorem not_isSquare_of_squarefree_of_not_isUnit {R : Type*} [CommMonoid
 /-- **Square-class independence of distinct primes.** If the selected `p i` are prime and pairwise
 distinct, then no nonempty subset product `∏_{i ∈ S} (p i : ℚ)` is a square in `ℚ`. This is the
 hypothesis the multiquadratic degree theorem `finrank_adjoin_range` consumes. -/
-theorem not_isSquare_prod_primes {ι : Type*} (p : ι → ℕ)
-    (hp : ∀ i, (p i).Prime) {S : Finset ι}
+theorem not_isSquare_prod_primes {ι : Type*} (p : ι → ℕ) {S : Finset ι}
+    (hp : ∀ i ∈ S, (p i).Prime)
     (hdist : Set.Pairwise (S : Set ι) (fun i j => p i ≠ p j))
     (hS : S.Nonempty) :
     ¬ IsSquare (∏ i ∈ S, (p i : ℚ)) := by
   rw [← Nat.cast_prod, Rat.isSquare_natCast_iff]
   refine not_isSquare_of_squarefree_of_not_isUnit ?_ ?_
-  · refine Finset.squarefree_prod_of_pairwise_isCoprime (fun i _ j _ hij => ?_)
-      (fun i _ => (hp i).prime.squarefree)
+  · refine Finset.squarefree_prod_of_pairwise_isCoprime (fun i hi j hj hij => ?_)
+      (fun i hi => (hp i hi).prime.squarefree)
     exact Nat.coprime_iff_isRelPrime.mp
-      ((Nat.coprime_primes (hp i) (hp j)).mpr fun h => hdist ‹i ∈ S› ‹j ∈ S› hij h)
+      ((Nat.coprime_primes (hp i hi) (hp j hj)).mpr fun h => hdist hi hj hij h)
   · rw [Nat.isUnit_iff]
     obtain ⟨i, hi⟩ := hS
     intro hprod
-    exact (hp i).ne_one (Nat.dvd_one.mp (hprod ▸ Finset.dvd_prod_of_mem p hi))
+    exact (hp i hi).ne_one (Nat.dvd_one.mp (hprod ▸ Finset.dvd_prod_of_mem p hi))
 
 /-- **Degree of a prime-radicand multiquadratic field.** For a finite family of distinct primes
 `p : ι → ℕ`, the field generated over `ℚ` by their real square roots has degree `2^|ι|`. This is the
@@ -70,7 +70,7 @@ theorem finrank_adjoin_sqrt_primes {ι : Type*} [Finite ι] (p : ι → ℕ)
   refine finrank_adjoin_range (d := fun i => (p i : ℚ))
     (root := fun i => Real.sqrt (p i)) (fun i => ?_) (fun S hS => ?_)
   · rw [Real.sq_sqrt (Nat.cast_nonneg _), map_natCast]
-  · refine not_isSquare_prod_primes p hp ?_ hS
+  · refine not_isSquare_prod_primes p (fun i _ => hp i) ?_ hS
     intro i _ j _ hij h
     exact hij (hinj h)
 

--- a/TauCeti/NumberTheory/Multiquadratic/PrimeRadicands.lean
+++ b/TauCeti/NumberTheory/Multiquadratic/PrimeRadicands.lean
@@ -1,0 +1,91 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+import TauCeti.NumberTheory.Multiquadratic.Degree
+import Mathlib.Analysis.Real.Sqrt
+import Mathlib.Data.Rat.Lemmas
+import Mathlib.Data.Nat.Squarefree
+
+/-!
+# Multiquadratic fields with prime radicands
+
+The field-generic degree theorem `TauCeti.Multiquadratic.finrank_adjoin_range` says that a
+multiquadratic field has degree `2ⁿ` once the radicands are **square-class independent**: no
+nonempty subset product of them is a square. This file supplies that hypothesis for the most
+common concrete source of square-class independent radicands — a family of **distinct primes** —
+and so derives the prime-indexed degree corollary `[ℚ(√p₁, …, √pₙ) : ℚ] = 2ⁿ` (a genus-theory
+input) and the smallest non-vacuity example `[ℚ(√2, √3) : ℚ] = 4`.
+
+The square-class independence of distinct primes is elementary: a nonempty subset product of
+distinct primes is squarefree (the primes are pairwise coprime) and is not a unit (it has a prime
+factor), so it is not a square.
+
+## Main results
+
+* `TauCeti.Multiquadratic.not_isSquare_of_squarefree`: a squarefree non-unit is not a square.
+* `TauCeti.Multiquadratic.not_isSquare_prod_primes`: for distinct primes `p i`, no nonempty subset
+  product `∏_{i ∈ S} (p i : ℚ)` is a square — square-class independence in the form the degree
+  theorem consumes.
+* `TauCeti.Multiquadratic.finrank_adjoin_sqrt_primes`: `[ℚ(√p₁, …, √pₙ) : ℚ] = 2^|ι|` for a finite
+  family of distinct primes.
+* `TauCeti.Multiquadratic.finrank_adjoin_sqrt_two_three`: `[ℚ(√2, √3) : ℚ] = 4`.
+-/
+
+open scoped Function
+
+namespace TauCeti.Multiquadratic
+
+/-- A squarefree non-unit is not a square: if `a = r * r` then `r * r ∣ a` forces `r` to be a unit,
+hence `a` a unit. -/
+theorem not_isSquare_of_squarefree {R : Type*} [CommMonoid R] {a : R}
+    (ha : Squarefree a) (hu : ¬ IsUnit a) : ¬ IsSquare a := by
+  rintro ⟨r, rfl⟩
+  exact hu ((ha r dvd_rfl).mul (ha r dvd_rfl))
+
+/-- **Square-class independence of distinct primes.** If the `p i` are prime and pairwise distinct,
+then no nonempty subset product `∏_{i ∈ S} (p i : ℚ)` is a square in `ℚ`. This is the hypothesis the
+multiquadratic degree theorem `finrank_adjoin_range` consumes. -/
+theorem not_isSquare_prod_primes {ι : Type*} (p : ι → ℕ)
+    (hp : ∀ i, (p i).Prime) (hinj : Function.Injective p)
+    {S : Finset ι} (hS : S.Nonempty) :
+    ¬ IsSquare (∏ i ∈ S, (p i : ℚ)) := by
+  rw [← Nat.cast_prod, Rat.isSquare_natCast_iff]
+  refine not_isSquare_of_squarefree ?_ ?_
+  · refine Finset.squarefree_prod_of_pairwise_isCoprime (fun i _ j _ hij => ?_)
+      (fun i _ => (hp i).prime.squarefree)
+    exact Nat.coprime_iff_isRelPrime.mp
+      ((Nat.coprime_primes (hp i) (hp j)).mpr fun h => hij (hinj h))
+  · rw [Nat.isUnit_iff]
+    obtain ⟨i, hi⟩ := hS
+    intro hprod
+    exact (hp i).ne_one (Nat.dvd_one.mp (hprod ▸ Finset.dvd_prod_of_mem p hi))
+
+/-- **Degree of a prime-radicand multiquadratic field.** For a finite family of distinct primes
+`p : ι → ℕ`, the field generated over `ℚ` by their real square roots has degree `2^|ι|`. This is the
+prime-indexed corollary of the field-generic degree theorem `finrank_adjoin_range`. -/
+theorem finrank_adjoin_sqrt_primes {ι : Type*} [Finite ι] (p : ι → ℕ)
+    (hp : ∀ i, (p i).Prime) (hinj : Function.Injective p) :
+    Module.finrank ℚ
+        (IntermediateField.adjoin ℚ (Set.range fun i => (Real.sqrt (p i) : ℝ)))
+      = 2 ^ Nat.card ι := by
+  refine finrank_adjoin_range (d := fun i => (p i : ℚ))
+    (root := fun i => Real.sqrt (p i)) (fun i => ?_) (fun S hS => ?_)
+  · rw [Real.sq_sqrt (Nat.cast_nonneg _), map_natCast]
+  · exact not_isSquare_prod_primes p hp hinj hS
+
+/-- **Worked example: `[ℚ(√2, √3) : ℚ] = 4`.** The smallest nontrivial multiquadratic degree,
+obtained from `finrank_adjoin_sqrt_primes` with the primes `2` and `3`. -/
+theorem finrank_adjoin_sqrt_two_three :
+    Module.finrank ℚ
+      (IntermediateField.adjoin ℚ {Real.sqrt 2, Real.sqrt 3} : IntermediateField ℚ ℝ) = 4 := by
+  have h := finrank_adjoin_sqrt_primes ![2, 3] (by decide) (by decide)
+  have hset : (Set.range fun i : Fin 2 => Real.sqrt ((![2, 3] : Fin 2 → ℕ) i))
+      = {Real.sqrt 2, Real.sqrt 3} := by
+    ext x
+    simp [Fin.exists_fin_two, eq_comm]
+  rw [hset] at h
+  rw [h]
+  simp
+
+end TauCeti.Multiquadratic


### PR DESCRIPTION
This PR derives the prime-indexed corollary of the multiquadratic degree theorem and discharges the roadmap's smallest non-vacuity worked example, `[ℚ(√2, √3) : ℚ] = 4`. The field-generic theorem `TauCeti.Multiquadratic.finrank_adjoin_range` gives degree `2ⁿ` once the radicands are square-class independent (no nonempty subset product is a square); this PR supplies that hypothesis for the most common concrete source of such radicands, a family of distinct primes, and reads off `[ℚ(√p₁, …, √pₙ) : ℚ] = 2^|ι|`. The square-class independence is elementary: a nonempty subset product of distinct primes is squarefree (the primes are pairwise coprime) and is not a unit (it has a prime factor), hence not a square. This advances the prime-indexed degree corollary called for in `TauCetiRoadmap/Multiquadratic/README.md` ("prove the field-generic theorem, then derive the rational and prime-indexed versions (the genus-theory inputs) as corollaries") and the Layer 0 acceptance criterion `[ℚ(√2, √3) : ℚ] = 4` from its "Worked examples" list, the non-vacuity example mirrored in `TauCetiRoadmap/Multiquadratic/Targets.lean`.

The new file `TauCeti/NumberTheory/Multiquadratic/PrimeRadicands.lean` (about 80 lines) adds `not_isSquare_of_squarefree` (a squarefree non-unit is not a square, building on `Finset.squarefree_prod_of_pairwise_isCoprime` and `Rat.isSquare_natCast_iff` from Mathlib), `not_isSquare_prod_primes` (square-class independence of distinct primes), `finrank_adjoin_sqrt_primes` (the prime-indexed degree corollary), and `finrank_adjoin_sqrt_two_three` (the worked example). It consumes the migrated degree theorem in `TauCeti/NumberTheory/Multiquadratic/Degree.lean` without re-deriving any of it.

<!--tauceti-target:v1 {"focus":"Multiquadratic","id":"finrank-adjoin-sqrt-primes"}-->

🤖 Prepared with Claude Code
