### PR TITLE
feat: naturality of isotopy under composition with embeddings

### DIFF
--- a/TauCeti/Topology/Homotopy/IsotopyComp.lean
+++ b/TauCeti/Topology/Homotopy/IsotopyComp.lean
@@ -33,7 +33,7 @@ survives both.
 
 * `TauCeti.Isotopic.postcomp` / `TauCeti.Isotopic.precomp`: the same closure on the isotopy
   *relation*.
-* `TauCeti.Isotopic.precomp_postcomp`: the two-sided form, composing with an embedding on
+* `TauCeti.Isotopic.postcomp_precomp`: the two-sided form, composing with an embedding on
   each side.
 * `TauCeti.Isotopic.postcomp_homeomorph` / `TauCeti.Isotopic.precomp_homeomorph`: the common
   special case where the composing map is a homeomorphism (an ambient homeomorphism on the
@@ -52,8 +52,7 @@ namespace Isotopy
 variable {f₀ f₁ : C(X, Y)}
 
 /-- Postcompose an isotopy `f₀ ≈ f₁` with a topological embedding `g : Y ↪ Z` to get an
-isotopy `g ∘ f₀ ≈ g ∘ f₁`. The total map is `(id × g) ∘ F.totalMap`, an embedding because
-`id × g` and `F.totalMap` both are. -/
+isotopy `g ∘ f₀ ≈ g ∘ f₁`. -/
 def postcomp (F : Isotopy f₀ f₁) (g : C(Y, Z)) (hg : IsEmbedding g) :
     Isotopy (g.comp f₀) (g.comp f₁) where
   toHomotopy := (Homotopy.refl g).comp F.toHomotopy
@@ -65,8 +64,7 @@ theorem postcomp_apply (F : Isotopy f₀ f₁) (g : C(Y, Z)) (hg : IsEmbedding g
     F.postcomp g hg p = g (F p) := rfl
 
 /-- Precompose an isotopy `f₀ ≈ f₁` with a topological embedding `e : W ↪ X` to get an
-isotopy `f₀ ∘ e ≈ f₁ ∘ e`. The total map is `F.totalMap ∘ (id × e)`, an embedding because
-`F.totalMap` and `id × e` both are. -/
+isotopy `f₀ ∘ e ≈ f₁ ∘ e`. -/
 def precomp (F : Isotopy f₀ f₁) (e : C(W, X)) (he : IsEmbedding e) :
     Isotopy (f₀.comp e) (f₁.comp e) where
   toHomotopy := F.toHomotopy.compContinuousMap e
@@ -97,7 +95,7 @@ theorem precomp (h : Isotopic f₀ f₁) (e : C(W, X)) (he : IsEmbedding e) :
 
 /-- The two-sided form: an isotopy relation survives composing with an embedding on each
 side. -/
-theorem precomp_postcomp (h : Isotopic f₀ f₁) (g : C(Y, Z)) (hg : IsEmbedding g) (e : C(W, X))
+theorem postcomp_precomp (h : Isotopic f₀ f₁) (g : C(Y, Z)) (hg : IsEmbedding g) (e : C(W, X))
     (he : IsEmbedding e) : Isotopic (g.comp (f₀.comp e)) (g.comp (f₁.comp e)) :=
   (h.precomp e he).postcomp g hg
 

--- a/TauCeti/Topology/Homotopy/IsotopyComp.lean
+++ b/TauCeti/Topology/Homotopy/IsotopyComp.lean
@@ -33,7 +33,8 @@ survives both.
 
 * `TauCeti.Isotopic.postcomp` / `TauCeti.Isotopic.precomp`: the same closure on the isotopy
   *relation*.
-* `TauCeti.Isotopic.comp`: the two-sided form, composing with an embedding on each side.
+* `TauCeti.Isotopic.precomp_postcomp`: the two-sided form, composing with an embedding on
+  each side.
 * `TauCeti.Isotopic.postcomp_homeomorph` / `TauCeti.Isotopic.precomp_homeomorph`: the common
   special case where the composing map is a homeomorphism (an ambient homeomorphism on the
   codomain, or a change of source coordinates).
@@ -96,7 +97,7 @@ theorem precomp (h : Isotopic f₀ f₁) (e : C(W, X)) (he : IsEmbedding e) :
 
 /-- The two-sided form: an isotopy relation survives composing with an embedding on each
 side. -/
-theorem comp (h : Isotopic f₀ f₁) (g : C(Y, Z)) (hg : IsEmbedding g) (e : C(W, X))
+theorem precomp_postcomp (h : Isotopic f₀ f₁) (g : C(Y, Z)) (hg : IsEmbedding g) (e : C(W, X))
     (he : IsEmbedding e) : Isotopic (g.comp (f₀.comp e)) (g.comp (f₁.comp e)) :=
   (h.precomp e he).postcomp g hg
 

--- a/TauCeti/Topology/Homotopy/IsotopyComp.lean
+++ b/TauCeti/Topology/Homotopy/IsotopyComp.lean
@@ -1,0 +1,115 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+import TauCeti.Topology.Homotopy.Isotopy
+
+/-!
+# Naturality of isotopy under composition with embeddings
+
+An isotopy is a homotopy whose level-preserving total map is a topological embedding. This
+file records that the isotopy relation is *natural*: composing on either side with a
+topological embedding carries an isotopy to an isotopy, and so an isotopy relation to an
+isotopy relation. These are the closure properties the geometric-topology roadmap
+(`TauCetiRoadmap/GeometricTopology/README.md`) asks the general isotopy notion to carry
+before specialising to smooth embeddings `S¹ ↪ M`: they mirror, for `TauCeti.Isotopy`, the
+composition lemmas Mathlib provides for `IsEmbedding` (`Topology.IsEmbedding.comp`) and for
+homotopy (`ContinuousMap.Homotopy.comp`, `ContinuousMap.Homotopy.compContinuousMap`), which
+this file reuses for the underlying homotopies.
+
+The two-sided generality (an embedding on either side, not merely a homeomorphism) is what
+the roadmap's layer-2 closure properties for locally flat embeddings will consume: a
+submanifold inclusion postcomposes, a chart or open embedding precomposes, and the isotopy
+survives both.
+
+## Main definitions
+
+* `TauCeti.Isotopy.postcomp`: postcomposing an isotopy `f₀ ≈ f₁` with an embedding `g`
+  yields an isotopy `g ∘ f₀ ≈ g ∘ f₁`.
+* `TauCeti.Isotopy.precomp`: precomposing an isotopy `f₀ ≈ f₁` with an embedding `e` yields
+  an isotopy `f₀ ∘ e ≈ f₁ ∘ e`.
+
+## Main results
+
+* `TauCeti.Isotopic.postcomp` / `TauCeti.Isotopic.precomp`: the same closure on the isotopy
+  *relation*.
+* `TauCeti.Isotopic.comp`: the two-sided form, composing with an embedding on each side.
+* `TauCeti.Isotopic.postcomp_homeomorph` / `TauCeti.Isotopic.precomp_homeomorph`: the common
+  special case where the composing map is a homeomorphism (an ambient homeomorphism on the
+  codomain, or a change of source coordinates).
+-/
+
+namespace TauCeti
+
+open unitInterval ContinuousMap Topology
+
+variable {W X Y Z : Type*} [TopologicalSpace W] [TopologicalSpace X] [TopologicalSpace Y]
+  [TopologicalSpace Z]
+
+namespace Isotopy
+
+variable {f₀ f₁ : C(X, Y)}
+
+/-- Postcompose an isotopy `f₀ ≈ f₁` with a topological embedding `g : Y ↪ Z` to get an
+isotopy `g ∘ f₀ ≈ g ∘ f₁`. The total map is `(id × g) ∘ F.totalMap`, an embedding because
+`id × g` and `F.totalMap` both are. -/
+def postcomp (F : Isotopy f₀ f₁) (g : C(Y, Z)) (hg : IsEmbedding g) :
+    Isotopy (g.comp f₀) (g.comp f₁) where
+  toHomotopy := (Homotopy.refl g).comp F.toHomotopy
+  isEmbedding_total' :=
+    (IsEmbedding.id.prodMap hg).comp F.isEmbedding_total'
+
+@[simp]
+theorem postcomp_apply (F : Isotopy f₀ f₁) (g : C(Y, Z)) (hg : IsEmbedding g) (p : I × X) :
+    F.postcomp g hg p = g (F p) := rfl
+
+/-- Precompose an isotopy `f₀ ≈ f₁` with a topological embedding `e : W ↪ X` to get an
+isotopy `f₀ ∘ e ≈ f₁ ∘ e`. The total map is `F.totalMap ∘ (id × e)`, an embedding because
+`F.totalMap` and `id × e` both are. -/
+def precomp (F : Isotopy f₀ f₁) (e : C(W, X)) (he : IsEmbedding e) :
+    Isotopy (f₀.comp e) (f₁.comp e) where
+  toHomotopy := F.toHomotopy.compContinuousMap e
+  isEmbedding_total' :=
+    F.isEmbedding_total'.comp (IsEmbedding.id.prodMap he)
+
+@[simp]
+theorem precomp_apply (F : Isotopy f₀ f₁) (e : C(W, X)) (he : IsEmbedding e) (p : I × W) :
+    F.precomp e he p = F (p.1, e p.2) := rfl
+
+end Isotopy
+
+namespace Isotopic
+
+variable {f₀ f₁ : C(X, Y)}
+
+/-- Postcompose an isotopy relation with a topological embedding: if `f₀ ≈ f₁` and `g` is an
+embedding, then `g ∘ f₀ ≈ g ∘ f₁`. -/
+theorem postcomp (h : Isotopic f₀ f₁) (g : C(Y, Z)) (hg : IsEmbedding g) :
+    Isotopic (g.comp f₀) (g.comp f₁) :=
+  ⟨h.some.postcomp g hg⟩
+
+/-- Precompose an isotopy relation with a topological embedding: if `f₀ ≈ f₁` and `e` is an
+embedding, then `f₀ ∘ e ≈ f₁ ∘ e`. -/
+theorem precomp (h : Isotopic f₀ f₁) (e : C(W, X)) (he : IsEmbedding e) :
+    Isotopic (f₀.comp e) (f₁.comp e) :=
+  ⟨h.some.precomp e he⟩
+
+/-- The two-sided form: an isotopy relation survives composing with an embedding on each
+side. -/
+theorem comp (h : Isotopic f₀ f₁) (g : C(Y, Z)) (hg : IsEmbedding g) (e : C(W, X))
+    (he : IsEmbedding e) : Isotopic (g.comp (f₀.comp e)) (g.comp (f₁.comp e)) :=
+  (h.precomp e he).postcomp g hg
+
+/-- Postcomposing an isotopy relation with a homeomorphism of the codomain. -/
+theorem postcomp_homeomorph (h : Isotopic f₀ f₁) (e : Y ≃ₜ Z) :
+    Isotopic ((e : C(Y, Z)).comp f₀) ((e : C(Y, Z)).comp f₁) :=
+  h.postcomp _ e.isEmbedding
+
+/-- Precomposing an isotopy relation with a homeomorphism of the source. -/
+theorem precomp_homeomorph (h : Isotopic f₀ f₁) (e : W ≃ₜ X) :
+    Isotopic (f₀.comp (e : C(W, X))) (f₁.comp (e : C(W, X))) :=
+  h.precomp _ e.isEmbedding
+
+end Isotopic
+
+end TauCeti


### PR DESCRIPTION
This PR records that the isotopy relation is natural under composition with topological embeddings: postcomposing an isotopy `f₀ ≈ f₁` with an embedding `g` gives an isotopy `g ∘ f₀ ≈ g ∘ f₁`, precomposing with an embedding `e` gives `f₀ ∘ e ≈ f₁ ∘ e`, and the same closure holds for the isotopy relation `Isotopic`, including the common homeomorphism special cases on either side. These are the closure properties the geometric-topology roadmap asks the general isotopy notion to carry before it is specialised to smooth embeddings `S¹ ↪ M`.

This advances `TauCetiRoadmap/GeometricTopology/README.md`, "Encoding conventions" ("Isotopy is defined generally, then specialised, ... The same general `Isotopic` underlies locally flat isotopy (layer 2), diffeotopies (layer 3), and concordance (layer 6); none of those should re-define it"), and supplies, for `TauCeti.Isotopy`, the two-sided composition closure that layer 2's locally flat embeddings call for ("homeomorphism invariance: `h ∘ f ∘ k` ... and more generally for chart maps and open embeddings on either side"). It builds directly on the `Isotopy`/`Isotopic` API landed in https://github.com/FormalFrontier/TauCeti/pull/248 (feat: add isotopy and ambient isotopy of embeddings), and is disjoint from https://github.com/FormalFrontier/TauCeti/pull/261 (feat: the ambient-isotopy equivalence relation), which treats ambient isotopy of maps rather than composition closure of the underlying isotopy relation.

The underlying homotopies reuse Mathlib's `ContinuousMap.Homotopy.comp` (with `Homotopy.refl` for postcomposition) and `ContinuousMap.Homotopy.compContinuousMap` (for precomposition); the embedding of each total map then follows from `Topology.IsEmbedding.comp` and `Topology.IsEmbedding.prodMap`, since the new total map is the old one composed on one side with `id × g` or `id × e`.

<!--tauceti-target:v1 {"focus":"GeometricTopology","id":"isotopy-naturality-composition-embeddings"}-->

🤖 Prepared with Claude Code
