### PR TITLE
feat: add the half-turn rotation symmetry of grid states and diagrams

### DIFF
--- a/TauCeti/KnotTheory/Grid/GradingInteger.lean
+++ b/TauCeti/KnotTheory/Grid/GradingInteger.lean
@@ -38,6 +38,9 @@ so `M_O(x)` is an integer. The same computation handles `M_X`.
 * `TauCeti.GridDiagram.maslovOℤ_transpose`, `TauCeti.GridDiagram.maslovXℤ_transpose`,
   `TauCeti.GridDiagram.alexanderTwoℤ_transpose`: the integer-valued gradings are invariant
   under the diagonal reflection of a grid state and diagram.
+* `TauCeti.GridDiagram.maslovOℤ_rotate`, `TauCeti.GridDiagram.maslovXℤ_rotate`,
+  `TauCeti.GridDiagram.alexanderTwoℤ_rotate`: the integer-valued gradings are invariant
+  under the half-turn rotation of a grid state and diagram.
 * `TauCeti.GridDiagram.maslovOℤ_swapMarkings`, `TauCeti.GridDiagram.maslovXℤ_swapMarkings`,
   `TauCeti.GridDiagram.alexanderTwoℤ_swapMarkings`: the integer-valued gradings transform
   under the marking swap.
@@ -153,6 +156,24 @@ reflection. -/
 theorem alexanderTwoℤ_transpose (x : GridState n) :
     G.transpose.alexanderTwoℤ x.transpose = G.alexanderTwoℤ x := by
   rw [alexanderTwoℤ_def, alexanderTwoℤ_def, maslovOℤ_transpose, maslovXℤ_transpose]
+
+/-- The integer-valued `O`-Maslov grading is invariant under the half-turn rotation. -/
+theorem maslovOℤ_rotate (x : GridState n) :
+    G.rotate.maslovOℤ x.rotate = G.maslovOℤ x := by
+  rw [maslovOℤ_def, maslovOℤ_def, GridState.rotate_pointSet, rotate_OSet,
+    GridPoint.I_image_rev, GridPoint.JNum_image_rev, GridPoint.I_image_rev]
+
+/-- The integer-valued `X`-Maslov grading is invariant under the half-turn rotation. -/
+theorem maslovXℤ_rotate (x : GridState n) :
+    G.rotate.maslovXℤ x.rotate = G.maslovXℤ x := by
+  rw [maslovXℤ_def, maslovXℤ_def, GridState.rotate_pointSet, rotate_XSet,
+    GridPoint.I_image_rev, GridPoint.JNum_image_rev, GridPoint.I_image_rev]
+
+/-- The integer numerator of twice the Alexander grading is invariant under the half-turn
+rotation. -/
+theorem alexanderTwoℤ_rotate (x : GridState n) :
+    G.rotate.alexanderTwoℤ x.rotate = G.alexanderTwoℤ x := by
+  rw [alexanderTwoℤ_def, alexanderTwoℤ_def, maslovOℤ_rotate, maslovXℤ_rotate]
 
 /-- The marking swap exchanges the integer-valued Maslov gradings. -/
 @[simp]

--- a/TauCeti/KnotTheory/Grid/Gradings.lean
+++ b/TauCeti/KnotTheory/Grid/Gradings.lean
@@ -27,6 +27,9 @@ rectangle-change theorems can refer to these names without unfolding the point-p
 * `TauCeti.GridDiagram.maslovO_transpose`, `TauCeti.GridDiagram.maslovX_transpose`,
   `TauCeti.GridDiagram.alexander_transpose`: the Maslov and Alexander gradings are invariant
   under the diagonal reflection of a grid state and diagram.
+* `TauCeti.GridDiagram.maslovO_rotate`, `TauCeti.GridDiagram.maslovX_rotate`,
+  `TauCeti.GridDiagram.alexander_rotate`: the Maslov and Alexander gradings are invariant
+  under the half-turn rotation of a grid state and diagram.
 * `TauCeti.GridDiagram.maslovO_swapMarkings`, `TauCeti.GridDiagram.maslovX_swapMarkings`: the
   two Maslov gradings are exchanged by the marking swap.
 * `TauCeti.GridDiagram.alexander_swapMarkings`: the Alexander grading is negated up to the
@@ -138,6 +141,24 @@ depends only on the common grid size, so it cancels between the two diagrams. -/
 theorem alexander_transpose (x : GridState n) :
     G.transpose.alexander x.transpose = G.alexander x := by
   rw [alexander_def, alexander_def, maslovO_transpose, maslovX_transpose]
+
+/-- The `O`-Maslov grading is invariant under the half-turn rotation. -/
+theorem maslovO_rotate (x : GridState n) :
+    G.rotate.maslovO x.rotate = G.maslovO x := by
+  rw [maslovO_def, maslovO_def, GridState.rotate_pointSet, rotate_OSet,
+    GridPoint.JDiff_image_rev]
+
+/-- The `X`-Maslov grading is invariant under the half-turn rotation. -/
+theorem maslovX_rotate (x : GridState n) :
+    G.rotate.maslovX x.rotate = G.maslovX x := by
+  rw [maslovX_def, maslovX_def, GridState.rotate_pointSet, rotate_XSet,
+    GridPoint.JDiff_image_rev]
+
+/-- The Alexander grading is invariant under the half-turn rotation. The normalization shift
+depends only on the common grid size, so it cancels between the two diagrams. -/
+theorem alexander_rotate (x : GridState n) :
+    G.rotate.alexander x.rotate = G.alexander x := by
+  rw [alexander_def, alexander_def, maslovO_rotate, maslovX_rotate]
 
 /-- The marking swap exchanges the two Maslov gradings: `M_O` of the swap is `M_X`. -/
 @[simp]

--- a/TauCeti/KnotTheory/Grid/JFunction.lean
+++ b/TauCeti/KnotTheory/Grid/JFunction.lean
@@ -7,7 +7,7 @@ import Mathlib.Algebra.Field.Rat
 import Mathlib.Data.Finset.Prod
 import Mathlib.Data.Rat.Lemmas
 import Mathlib.Tactic.Ring
-import TauCeti.KnotTheory.Grid.Diagram
+import TauCeti.KnotTheory.Grid.Rotation
 
 /-!
 # The grid `J`-function
@@ -36,6 +36,11 @@ and `A`.
 * `TauCeti.GridPoint.I_image_swap`, `TauCeti.GridPoint.J_image_swap`,
   `TauCeti.GridPoint.JDiff_image_swap`, `TauCeti.GridState.J_transpose`: the southwest counts
   and the `J`-function are invariant under reflecting the point sets across the diagonal.
+* `TauCeti.GridPoint.I_image_rev`, `TauCeti.GridPoint.JNum_image_rev`,
+  `TauCeti.GridPoint.J_image_rev`, `TauCeti.GridPoint.JDiff_image_rev`,
+  `TauCeti.GridState.J_rotate`: reversing both coordinates of the point sets exchanges the two
+  arguments of the ordered count `I`, while the symmetrized `JNum`, `J`, and `JDiff` are
+  invariant.
 
 ## References
 
@@ -453,6 +458,67 @@ theorem JDiff_image_swap (s a t b : Finset (Fin n × Fin n)) :
   rw [JDiff_def, JDiff_def, J_image_swap, J_image_swap, J_image_swap,
     J_image_swap]
 
+/-- Reversing both coordinates of both points of a pair exchanges the two endpoints of the strict
+southwest relation: it sends the column and row comparisons to their reverses. -/
+@[simp]
+theorem isSouthWest_rev (p q : Fin n × Fin n) :
+    IsSouthWest (Prod.map Fin.rev Fin.rev p) (Prod.map Fin.rev Fin.rev q) ↔ IsSouthWest q p := by
+  simp only [IsSouthWest, Prod.map_fst, Prod.map_snd]
+  have h1 := p.1.isLt
+  have h2 := q.1.isLt
+  have h3 := p.2.isLt
+  have h4 := q.2.isLt
+  rw [Fin.val_rev, Fin.val_rev, Fin.val_rev, Fin.val_rev]
+  omega
+
+/-- The coordinate-reversal map on grid squares is injective. -/
+private theorem prodMap_rev_injective :
+    Function.Injective (Prod.map (Fin.rev (n := n)) (Fin.rev (n := n))) :=
+  Fin.rev_injective.prodMap Fin.rev_injective
+
+/-- The coordinate-reversal map on pairs of grid squares is injective. -/
+private theorem prodMap_prodMap_rev_injective :
+    Function.Injective
+      (Prod.map (Prod.map (Fin.rev (n := n)) (Fin.rev (n := n)))
+        (Prod.map (Fin.rev (n := n)) (Fin.rev (n := n)))) :=
+  prodMap_rev_injective.prodMap prodMap_rev_injective
+
+/-- The ordered southwest count is invariant, up to exchanging the two point sets, under reversing
+both coordinates of both point sets. The reversal turns each southwest comparison into the
+opposite comparison, so the count of southwest pairs from `s` to `t` becomes the count from `t`
+to `s`. -/
+theorem I_image_rev (s t : Finset (Fin n × Fin n)) :
+    I (s.image (Prod.map Fin.rev Fin.rev)) (t.image (Prod.map Fin.rev Fin.rev)) = I t s := by
+  classical
+  rw [I_def, ← Finset.prodMap_image_product (Prod.map Fin.rev Fin.rev)
+      (Prod.map Fin.rev Fin.rev) s t, Finset.filter_image,
+    Finset.card_image_of_injective _ prodMap_prodMap_rev_injective]
+  rw [I_def, ← Finset.image_swap_product t s, Finset.filter_image,
+    Finset.card_image_of_injective _ Prod.swap_injective]
+  refine congrArg Finset.card (Finset.filter_congr fun pq _ => ?_)
+  simpa using isSouthWest_rev pq.1 pq.2
+
+/-- The numerator of the `J`-function is invariant under reversing both coordinates of both point
+sets. The two ordered counts are exchanged by the reversal, and their sum is symmetric. -/
+theorem JNum_image_rev (s t : Finset (Fin n × Fin n)) :
+    JNum (s.image (Prod.map Fin.rev Fin.rev)) (t.image (Prod.map Fin.rev Fin.rev)) = JNum s t := by
+  rw [JNum_def, JNum_def, I_image_rev, I_image_rev, Nat.add_comm]
+
+/-- The symmetrized grid `J`-function is invariant under reversing both coordinates of both point
+sets. -/
+theorem J_image_rev (s t : Finset (Fin n × Fin n)) :
+    GridPoint.J (s.image (Prod.map Fin.rev Fin.rev)) (t.image (Prod.map Fin.rev Fin.rev))
+      = GridPoint.J s t := by
+  rw [J_def, J_def, JNum_image_rev]
+
+/-- The bilinear `J`-function on formal differences is invariant under reversing both coordinates
+of all four point sets. -/
+theorem JDiff_image_rev (s a t b : Finset (Fin n × Fin n)) :
+    JDiff (s.image (Prod.map Fin.rev Fin.rev)) (a.image (Prod.map Fin.rev Fin.rev))
+        (t.image (Prod.map Fin.rev Fin.rev)) (b.image (Prod.map Fin.rev Fin.rev))
+      = JDiff s a t b := by
+  rw [JDiff_def, JDiff_def, J_image_rev, J_image_rev, J_image_rev, J_image_rev]
+
 end GridPoint
 
 namespace GridState
@@ -477,6 +543,11 @@ diagonal. -/
 theorem J_transpose (x y : GridState n) :
     GridState.J x.transpose y.transpose = GridState.J x y := by
   rw [J_def, J_def, transpose_pointSet, transpose_pointSet, GridPoint.J_image_swap]
+
+/-- The state-level grid `J`-function is invariant under the half-turn rotation of both states. -/
+theorem J_rotate (x y : GridState n) :
+    GridState.J x.rotate y.rotate = GridState.J x y := by
+  rw [J_def, J_def, rotate_pointSet, rotate_pointSet, GridPoint.J_image_rev]
 
 end GridState
 
@@ -511,6 +582,16 @@ theorem JO_transpose (x : GridState n) :
 theorem JX_transpose (x : GridState n) :
     GridDiagram.JX G.transpose x.transpose = GridDiagram.JX G x := by
   rw [JX_def, JX_def, GridState.transpose_pointSet, transpose_XSet, GridPoint.J_image_swap]
+
+/-- `JO` is invariant under the half-turn rotation of the diagram and state. -/
+theorem JO_rotate (x : GridState n) :
+    GridDiagram.JO G.rotate x.rotate = GridDiagram.JO G x := by
+  rw [JO_def, JO_def, GridState.rotate_pointSet, rotate_OSet, GridPoint.J_image_rev]
+
+/-- `JX` is invariant under the half-turn rotation of the diagram and state. -/
+theorem JX_rotate (x : GridState n) :
+    GridDiagram.JX G.rotate x.rotate = GridDiagram.JX G x := by
+  rw [JX_def, JX_def, GridState.rotate_pointSet, rotate_XSet, GridPoint.J_image_rev]
 
 /-- The marking swap exchanges the `O`-marking `J`-pairing with the `X`-marking `J`-pairing. -/
 @[simp]

--- a/TauCeti/KnotTheory/Grid/JFunction.lean
+++ b/TauCeti/KnotTheory/Grid/JFunction.lean
@@ -460,7 +460,7 @@ theorem JDiff_image_swap (s a t b : Finset (Fin n × Fin n)) :
 
 /-- Reversing both coordinates of both points of a pair exchanges the two endpoints of the strict
 southwest relation: it sends the column and row comparisons to their reverses. -/
-@[simp]
+@[simp, grind =]
 theorem isSouthWest_rev (p q : Fin n × Fin n) :
     IsSouthWest (Prod.map Fin.rev Fin.rev p) (Prod.map Fin.rev Fin.rev q) ↔ IsSouthWest q p := by
   simp only [IsSouthWest, Prod.map_fst, Prod.map_snd]

--- a/TauCeti/KnotTheory/Grid/Rotation.lean
+++ b/TauCeti/KnotTheory/Grid/Rotation.lean
@@ -33,6 +33,9 @@ Only the basic state/diagram operation and its point-set lemmas live here, paral
 * `TauCeti.GridState.rotate_pointSet`, `TauCeti.GridDiagram.rotate_OSet`,
   `TauCeti.GridDiagram.rotate_XSet`: the point sets of a rotated state or diagram are the
   half-turn rotation of the original point sets.
+* `TauCeti.GridState.relabelRows_rotate`, `TauCeti.GridState.relabelColumns_rotate`,
+  `TauCeti.GridDiagram.swapMarkings_rotate`: rotation interacts predictably with the existing
+  relabeling, swap, and marking-swap operations.
 
 ## References
 
@@ -44,8 +47,6 @@ Chapter 3.
 
 namespace TauCeti
 
-namespace GridState
-
 variable {n : ℕ}
 
 /-- Reversing both coordinates of a grid square twice returns the original square. -/
@@ -53,6 +54,27 @@ private theorem rev2_rev2 (p : Fin n × Fin n) :
     Prod.map Fin.rev Fin.rev (Prod.map Fin.rev Fin.rev p) = p := by
   obtain ⟨a, b⟩ := p
   simp [Fin.rev_rev]
+
+/-- Conjugating a row or column swap by coordinate reversal swaps the reversed indices. -/
+private theorem revPerm_trans_swap_trans_revPerm (a b : Fin n) :
+    Fin.revPerm.trans ((Equiv.swap a b).trans Fin.revPerm) = Equiv.swap a.rev b.rev := by
+  ext c
+  by_cases hca : c = a.rev
+  · subst hca
+    simp
+  · by_cases hcb : c = b.rev
+    · subst hcb
+      simp
+    · have hca' : c.rev ≠ a := by
+        intro h
+        exact hca (Fin.rev_eq_iff.mp h)
+      have hcb' : c.rev ≠ b := by
+        intro h
+        exact hcb (Fin.rev_eq_iff.mp h)
+      simp [Equiv.swap_apply_of_ne_of_ne hca hcb, Equiv.swap_apply_of_ne_of_ne hca' hcb',
+        Fin.rev_rev]
+
+namespace GridState
 
 /-- The half-turn rotation of a grid state.
 
@@ -91,6 +113,38 @@ theorem rotate_pointSet (x : GridState n) :
 theorem rotate_rotate (x : GridState n) : x.rotate.rotate = x := by
   ext c
   simp [Fin.rev_rev]
+
+/-- Row relabeling before rotation becomes row relabeling by the conjugate permutation after
+rotation. -/
+@[simp]
+theorem relabelRows_rotate (ρ : Equiv.Perm (Fin n)) (x : GridState n) :
+    (x.relabelRows ρ).rotate = x.rotate.relabelRows (Fin.revPerm.trans (ρ.trans Fin.revPerm)) := by
+  ext c
+  simp [rotate, Fin.rev_rev]
+
+/-- Column relabeling before rotation becomes column relabeling by the conjugate permutation
+after rotation. -/
+@[simp]
+theorem relabelColumns_rotate (κ : Equiv.Perm (Fin n)) (x : GridState n) :
+    (x.relabelColumns κ).rotate =
+      x.rotate.relabelColumns (Fin.revPerm.trans (κ.trans Fin.revPerm)) := by
+  ext c
+  simp [rotate, Fin.rev_rev]
+
+/-- Swapping rows before rotation is the same as swapping the reversed rows after rotation. -/
+@[simp]
+theorem swapRows_rotate (a b : Fin n) (x : GridState n) :
+    (x.swapRows a b).rotate = x.rotate.swapRows a.rev b.rev := by
+  rw [swapRows, relabelRows_rotate, revPerm_trans_swap_trans_revPerm]
+  rfl
+
+/-- Swapping columns before rotation is the same as swapping the reversed columns after
+rotation. -/
+@[simp]
+theorem swapColumns_rotate (a b : Fin n) (x : GridState n) :
+    (x.swapColumns a b).rotate = x.rotate.swapColumns a.rev b.rev := by
+  rw [swapColumns, relabelColumns_rotate, revPerm_trans_swap_trans_revPerm]
+  rfl
 
 end GridState
 
@@ -146,6 +200,41 @@ theorem mem_XSet_rotate (p : Fin n × Fin n) :
 @[simp]
 theorem rotate_rotate : G.rotate.rotate = G := by
   ext c <;> simp
+
+/-- Row relabeling before rotation becomes row relabeling by the conjugate permutation after
+rotation. -/
+@[simp]
+theorem relabelRows_rotate (ρ : Equiv.Perm (Fin n)) :
+    (G.relabelRows ρ).rotate = G.rotate.relabelRows (Fin.revPerm.trans (ρ.trans Fin.revPerm)) := by
+  ext c <;> simp
+
+/-- Column relabeling before rotation becomes column relabeling by the conjugate permutation
+after rotation. -/
+@[simp]
+theorem relabelColumns_rotate (κ : Equiv.Perm (Fin n)) :
+    (G.relabelColumns κ).rotate =
+      G.rotate.relabelColumns (Fin.revPerm.trans (κ.trans Fin.revPerm)) := by
+  ext c <;> simp
+
+/-- Swapping rows before rotation is the same as swapping the reversed rows after rotation. -/
+@[simp]
+theorem swapRows_rotate (a b : Fin n) :
+    (G.swapRows a b).rotate = G.rotate.swapRows a.rev b.rev := by
+  rw [swapRows, relabelRows_rotate, revPerm_trans_swap_trans_revPerm]
+  rfl
+
+/-- Swapping columns before rotation is the same as swapping the reversed columns after
+rotation. -/
+@[simp]
+theorem swapColumns_rotate (a b : Fin n) :
+    (G.swapColumns a b).rotate = G.rotate.swapColumns a.rev b.rev := by
+  rw [swapColumns, relabelColumns_rotate, revPerm_trans_swap_trans_revPerm]
+  rfl
+
+/-- Exchanging the two marking states commutes with the half-turn rotation. -/
+@[simp]
+theorem swapMarkings_rotate : G.swapMarkings.rotate = G.rotate.swapMarkings := by
+  ext c <;> simp [GridDiagram.rotate]
 
 end GridDiagram
 

--- a/TauCeti/KnotTheory/Grid/Rotation.lean
+++ b/TauCeti/KnotTheory/Grid/Rotation.lean
@@ -114,6 +114,11 @@ theorem rotate_rotate (x : GridState n) : x.rotate.rotate = x := by
   ext c
   simp [Fin.rev_rev]
 
+/-- Diagonal reflection commutes with the half-turn rotation of a grid state. -/
+@[simp]
+theorem transpose_rotate (x : GridState n) : x.transpose.rotate = x.rotate.transpose := by
+  simp [rotate, GridState.relabelRows_relabelColumns]
+
 /-- Row relabeling before rotation becomes row relabeling by the conjugate permutation after
 rotation. -/
 @[simp]
@@ -200,6 +205,11 @@ theorem mem_XSet_rotate (p : Fin n × Fin n) :
 @[simp]
 theorem rotate_rotate : G.rotate.rotate = G := by
   ext c <;> simp
+
+/-- Diagonal reflection commutes with the half-turn rotation of a grid diagram. -/
+@[simp]
+theorem transpose_rotate : G.transpose.rotate = G.rotate.transpose := by
+  ext c <;> simp [GridState.transpose_rotate]
 
 /-- Row relabeling before rotation becomes row relabeling by the conjugate permutation after
 rotation. -/

--- a/TauCeti/KnotTheory/Grid/Rotation.lean
+++ b/TauCeti/KnotTheory/Grid/Rotation.lean
@@ -2,25 +2,24 @@
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 -/
-import Mathlib.Tactic.Ring
-import TauCeti.KnotTheory.Grid.GradingInteger
+import Mathlib.Data.Fin.Rev
+import TauCeti.KnotTheory.Grid.Diagram
 
 /-!
-# The half-turn rotation symmetry of grid states and diagrams
+# The half-turn rotation of grid states and diagrams
 
 This file adds the `180°` rotation of the toroidal grid to the grid-combinatorial lane of the
 Heegaard Floer roadmap, alongside the already-developed diagonal reflection (`transpose`) and
 marking swap (`swapMarkings`). Rotation reverses both the column and the row coordinate, so on
-grid squares it is the map `(c, r) ↦ (cᵒ, rᵒ)` with `·ᵒ = Fin.rev`. It carries a grid state to a
-grid state, a grid diagram to a grid diagram, and -- crucially -- it preserves all of the Maslov
-and Alexander gradings.
+grid squares it is the map `(c, r) ↦ (cᵒ, rᵒ)` with `·ᵒ = Fin.rev`. It is the composition of the
+column and row relabelings by the coordinate reversal `Fin.revPerm`, so it reuses the existing
+relabeling API rather than introducing a new primitive. It carries a grid state to a grid state
+and a grid diagram to a grid diagram.
 
-The reason rotation preserves the gradings while a single-axis reflection does not is exactly
-that it reverses *both* coordinates at once: the strict southwest relation underlying the
-`J`-function is sent to itself with its two endpoints exchanged, so the symmetrized point-pair
-counts `I`, `JNum`, `J`, and their formal-difference extension `JDiff` are all unchanged. This is
-the structural analogue of `GridPoint.I_image_swap` for the diagonal reflection, where reflection
-across the main diagonal exchanges the two coordinates instead of reversing them.
+Only the basic state/diagram operation and its point-set lemmas live here, parallel to where
+`transpose` is developed; the invariance of the `J`-function under coordinate reversal is in
+`TauCeti.KnotTheory.Grid.JFunction`, and the resulting grading invariance is in
+`TauCeti.KnotTheory.Grid.Gradings` and `TauCeti.KnotTheory.Grid.GradingInteger`.
 
 ## Main definitions
 
@@ -29,95 +28,21 @@ across the main diagonal exchanges the two coordinates instead of reversing them
 
 ## Main results
 
-* `TauCeti.GridPoint.I_image_rev`, `TauCeti.GridPoint.J_image_rev`,
-  `TauCeti.GridPoint.JDiff_image_rev`: the southwest counts and the `J`-function are invariant
-  under reversing both coordinates of the point sets.
 * `TauCeti.GridState.rotate_rotate`, `TauCeti.GridDiagram.rotate_rotate`: rotation is an
   involution on grid states and grid diagrams.
-* `TauCeti.GridDiagram.maslovO_rotate`, `TauCeti.GridDiagram.maslovX_rotate`,
-  `TauCeti.GridDiagram.alexander_rotate`: the Maslov and Alexander gradings are invariant under
-  the half-turn rotation.
-* `TauCeti.GridDiagram.maslovOℤ_rotate`, `TauCeti.GridDiagram.maslovXℤ_rotate`,
-  `TauCeti.GridDiagram.alexanderTwoℤ_rotate`: the integer-valued gradings are likewise invariant.
+* `TauCeti.GridState.rotate_pointSet`, `TauCeti.GridDiagram.rotate_OSet`,
+  `TauCeti.GridDiagram.rotate_XSet`: the point sets of a rotated state or diagram are the
+  half-turn rotation of the original point sets.
 
 ## References
 
-This advances `TauCetiRoadmap/CombinatorialHeegaardFloer/README.md`, Lane G item 2, "Gradings.
-The `J`-function, `M_O`, `M_X`, `A`; integer-valuedness of `A`; grading-change formulas across a
-rectangle", supplying a grading-preserving symmetry of the kind anticipated by the "Symmetries
-and the genus bound" milestone (Lane G item 8). The half-turn rotation of a grid diagram is one
-of the standard grid symmetries of Ozsváth--Stipsicz--Szabó, *Grid Homology for Knots and
-Links*, Chapter 3.
+This advances `TauCetiRoadmap/CombinatorialHeegaardFloer/README.md`, Lane G item 8,
+"Symmetries and the genus bound": the half-turn rotation of a grid diagram is one of the
+standard grid symmetries of Ozsváth--Stipsicz--Szabó, *Grid Homology for Knots and Links*,
+Chapter 3.
 -/
 
 namespace TauCeti
-
-namespace GridPoint
-
-variable {n : ℕ}
-
-/-- Reversing both coordinates of both points of a pair exchanges the two endpoints of the strict
-southwest relation: it sends the column and row comparisons to their reverses. -/
-@[simp]
-theorem isSouthWest_rev (p q : Fin n × Fin n) :
-    IsSouthWest (Prod.map Fin.rev Fin.rev p) (Prod.map Fin.rev Fin.rev q) ↔ IsSouthWest q p := by
-  simp only [IsSouthWest, Prod.map_fst, Prod.map_snd]
-  have h1 := p.1.isLt
-  have h2 := q.1.isLt
-  have h3 := p.2.isLt
-  have h4 := q.2.isLt
-  rw [Fin.val_rev, Fin.val_rev, Fin.val_rev, Fin.val_rev]
-  omega
-
-/-- The coordinate-reversal map on grid squares is injective. -/
-private theorem prodMap_rev_injective :
-    Function.Injective (Prod.map (Fin.rev (n := n)) (Fin.rev (n := n))) :=
-  Fin.rev_injective.prodMap Fin.rev_injective
-
-/-- The coordinate-reversal map on pairs of grid squares is injective. -/
-private theorem prodMap_prodMap_rev_injective :
-    Function.Injective
-      (Prod.map (Prod.map (Fin.rev (n := n)) (Fin.rev (n := n)))
-        (Prod.map (Fin.rev (n := n)) (Fin.rev (n := n)))) :=
-  prodMap_rev_injective.prodMap prodMap_rev_injective
-
-/-- The ordered southwest count is invariant, up to exchanging the two point sets, under reversing
-both coordinates of both point sets. The reversal turns each southwest comparison into the
-opposite comparison, so the count of southwest pairs from `s` to `t` becomes the count from `t`
-to `s`. -/
-theorem I_image_rev (s t : Finset (Fin n × Fin n)) :
-    I (s.image (Prod.map Fin.rev Fin.rev)) (t.image (Prod.map Fin.rev Fin.rev)) = I t s := by
-  classical
-  rw [I_def, ← Finset.prodMap_image_product (Prod.map Fin.rev Fin.rev)
-      (Prod.map Fin.rev Fin.rev) s t, Finset.filter_image,
-    Finset.card_image_of_injective _ prodMap_prodMap_rev_injective]
-  rw [I_def, ← Finset.image_swap_product t s, Finset.filter_image,
-    Finset.card_image_of_injective _ Prod.swap_injective]
-  refine congrArg Finset.card (Finset.filter_congr fun pq _ => ?_)
-  simpa using isSouthWest_rev pq.1 pq.2
-
-/-- The numerator of the `J`-function is invariant under reversing both coordinates of both point
-sets. The two ordered counts are exchanged by the reversal, and their sum is symmetric. -/
-theorem JNum_image_rev (s t : Finset (Fin n × Fin n)) :
-    JNum (s.image (Prod.map Fin.rev Fin.rev)) (t.image (Prod.map Fin.rev Fin.rev)) = JNum s t := by
-  rw [JNum_def, JNum_def, I_image_rev, I_image_rev, Nat.add_comm]
-
-/-- The symmetrized grid `J`-function is invariant under reversing both coordinates of both point
-sets. -/
-theorem J_image_rev (s t : Finset (Fin n × Fin n)) :
-    GridPoint.J (s.image (Prod.map Fin.rev Fin.rev)) (t.image (Prod.map Fin.rev Fin.rev))
-      = GridPoint.J s t := by
-  rw [J_def, J_def, JNum_image_rev]
-
-/-- The bilinear `J`-function on formal differences is invariant under reversing both coordinates
-of all four point sets. -/
-theorem JDiff_image_rev (s a t b : Finset (Fin n × Fin n)) :
-    JDiff (s.image (Prod.map Fin.rev Fin.rev)) (a.image (Prod.map Fin.rev Fin.rev))
-        (t.image (Prod.map Fin.rev Fin.rev)) (b.image (Prod.map Fin.rev Fin.rev))
-      = JDiff s a t b := by
-  rw [JDiff_def, JDiff_def, J_image_rev, J_image_rev, J_image_rev, J_image_rev]
-
-end GridPoint
 
 namespace GridState
 
@@ -127,22 +52,21 @@ variable {n : ℕ}
 private theorem rev2_rev2 (p : Fin n × Fin n) :
     Prod.map Fin.rev Fin.rev (Prod.map Fin.rev Fin.rev p) = p := by
   obtain ⟨a, b⟩ := p
-  change (Fin.rev (Fin.rev a), Fin.rev (Fin.rev b)) = (a, b)
-  rw [Fin.rev_rev, Fin.rev_rev]
+  simp [Fin.rev_rev]
 
 /-- The half-turn rotation of a grid state.
 
-Rotating the occupied squares by `180°` reverses both the column and the row coordinate, so the
-new permutation graph conjugates the old one by the coordinate reversal `Fin.revPerm`. -/
-def rotate (x : GridState n) : GridState n where
-  toPerm := Fin.revPerm.trans (x.toPerm.trans Fin.revPerm)
+Rotating the occupied squares by `180°` reverses both the column and the row coordinate. It is
+the composition of the column and row relabelings by the coordinate reversal `Fin.revPerm`. -/
+def rotate (x : GridState n) : GridState n :=
+  (x.relabelColumns Fin.revPerm).relabelRows Fin.revPerm
 
 /-- The rotated state reads off a column by reversing it, applying the original state, and
 reversing the resulting row. -/
 @[simp]
 theorem rotate_apply (x : GridState n) (c : Fin n) :
     x.rotate c = (x (Fin.rev c)).rev := by
-  simp [rotate, Equiv.trans_apply]
+  simp [rotate]
 
 /-- A square lies in the rotated state exactly when its half-turn rotation lies in the original
 state. -/
@@ -176,14 +100,11 @@ variable {n : ℕ} (G : GridDiagram n)
 
 /-- The half-turn rotation of a grid diagram, rotating both marking states.
 
-The rotation is injective on squares, so it preserves the condition that no square carries both an
-`O` and an `X` marking. -/
-def rotate (G : GridDiagram n) : GridDiagram n where
-  O := G.O.rotate
-  X := G.X.rotate
-  disjoint c := by
-    simp only [GridState.rotate_apply]
-    exact fun h => G.disjoint (Fin.rev c) (Fin.rev_injective h)
+It is the composition of the column and row relabelings by the coordinate reversal `Fin.revPerm`,
+applied to both marking states at once. Each relabeling is again a grid diagram, so rotation
+preserves the condition that no square carries both an `O` and an `X` marking. -/
+def rotate (G : GridDiagram n) : GridDiagram n :=
+  (G.relabelColumns Fin.revPerm).relabelRows Fin.revPerm
 
 /-- The `O`-marking state of the rotated diagram is the rotation of the original `O`-state. -/
 @[simp]
@@ -205,51 +126,26 @@ theorem rotate_OSet : G.rotate.OSet = G.OSet.image (Prod.map Fin.rev Fin.rev) :=
 theorem rotate_XSet : G.rotate.XSet = G.XSet.image (Prod.map Fin.rev Fin.rev) :=
   GridState.rotate_pointSet G.X
 
+/-- A square lies in the rotated diagram's `O`-marking set exactly when its half-turn rotation
+lies in the original `O`-marking set. -/
+@[simp]
+theorem mem_OSet_rotate (p : Fin n × Fin n) :
+    p ∈ G.rotate.OSet ↔ Prod.map Fin.rev Fin.rev p ∈ G.OSet := by
+  rw [OSet, OSet, rotate_O]
+  exact GridState.mem_pointSet_rotate G.O p
+
+/-- A square lies in the rotated diagram's `X`-marking set exactly when its half-turn rotation
+lies in the original `X`-marking set. -/
+@[simp]
+theorem mem_XSet_rotate (p : Fin n × Fin n) :
+    p ∈ G.rotate.XSet ↔ Prod.map Fin.rev Fin.rev p ∈ G.XSet := by
+  rw [XSet, XSet, rotate_X]
+  exact GridState.mem_pointSet_rotate G.X p
+
 /-- The half-turn rotation is an involution on grid diagrams. -/
 @[simp]
 theorem rotate_rotate : G.rotate.rotate = G := by
-  cases G
-  simp only [rotate, GridState.rotate_rotate]
-
-/-- The `O`-Maslov grading is invariant under the half-turn rotation. -/
-@[simp]
-theorem maslovO_rotate (x : GridState n) :
-    G.rotate.maslovO x.rotate = G.maslovO x := by
-  rw [maslovO_def, maslovO_def, GridState.rotate_pointSet, rotate_OSet, GridPoint.JDiff_image_rev]
-
-/-- The `X`-Maslov grading is invariant under the half-turn rotation. -/
-@[simp]
-theorem maslovX_rotate (x : GridState n) :
-    G.rotate.maslovX x.rotate = G.maslovX x := by
-  rw [maslovX_def, maslovX_def, GridState.rotate_pointSet, rotate_XSet, GridPoint.JDiff_image_rev]
-
-/-- The Alexander grading is invariant under the half-turn rotation. The normalization shift
-depends only on the common grid size, so it is untouched. -/
-@[simp]
-theorem alexander_rotate (x : GridState n) :
-    G.rotate.alexander x.rotate = G.alexander x := by
-  rw [alexander_def, alexander_def, maslovO_rotate, maslovX_rotate]
-
-/-- The integer-valued `O`-Maslov grading is invariant under the half-turn rotation. -/
-@[simp]
-theorem maslovOℤ_rotate (x : GridState n) :
-    G.rotate.maslovOℤ x.rotate = G.maslovOℤ x := by
-  rw [maslovOℤ_def, maslovOℤ_def, GridState.rotate_pointSet, rotate_OSet,
-    GridPoint.I_image_rev, GridPoint.JNum_image_rev, GridPoint.I_image_rev]
-
-/-- The integer-valued `X`-Maslov grading is invariant under the half-turn rotation. -/
-@[simp]
-theorem maslovXℤ_rotate (x : GridState n) :
-    G.rotate.maslovXℤ x.rotate = G.maslovXℤ x := by
-  rw [maslovXℤ_def, maslovXℤ_def, GridState.rotate_pointSet, rotate_XSet,
-    GridPoint.I_image_rev, GridPoint.JNum_image_rev, GridPoint.I_image_rev]
-
-/-- The integer numerator of twice the Alexander grading is invariant under the half-turn
-rotation. -/
-@[simp]
-theorem alexanderTwoℤ_rotate (x : GridState n) :
-    G.rotate.alexanderTwoℤ x.rotate = G.alexanderTwoℤ x := by
-  rw [alexanderTwoℤ_def, alexanderTwoℤ_def, maslovOℤ_rotate, maslovXℤ_rotate]
+  ext c <;> simp
 
 end GridDiagram
 

--- a/TauCeti/KnotTheory/Grid/Rotation.lean
+++ b/TauCeti/KnotTheory/Grid/Rotation.lean
@@ -1,0 +1,256 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+import Mathlib.Tactic.Ring
+import TauCeti.KnotTheory.Grid.GradingInteger
+
+/-!
+# The half-turn rotation symmetry of grid states and diagrams
+
+This file adds the `180°` rotation of the toroidal grid to the grid-combinatorial lane of the
+Heegaard Floer roadmap, alongside the already-developed diagonal reflection (`transpose`) and
+marking swap (`swapMarkings`). Rotation reverses both the column and the row coordinate, so on
+grid squares it is the map `(c, r) ↦ (cᵒ, rᵒ)` with `·ᵒ = Fin.rev`. It carries a grid state to a
+grid state, a grid diagram to a grid diagram, and -- crucially -- it preserves all of the Maslov
+and Alexander gradings.
+
+The reason rotation preserves the gradings while a single-axis reflection does not is exactly
+that it reverses *both* coordinates at once: the strict southwest relation underlying the
+`J`-function is sent to itself with its two endpoints exchanged, so the symmetrized point-pair
+counts `I`, `JNum`, `J`, and their formal-difference extension `JDiff` are all unchanged. This is
+the structural analogue of `GridPoint.I_image_swap` for the diagonal reflection, where reflection
+across the main diagonal exchanges the two coordinates instead of reversing them.
+
+## Main definitions
+
+* `TauCeti.GridState.rotate`: the half-turn rotation of a grid state.
+* `TauCeti.GridDiagram.rotate`: the half-turn rotation of a grid diagram.
+
+## Main results
+
+* `TauCeti.GridPoint.I_image_rev`, `TauCeti.GridPoint.J_image_rev`,
+  `TauCeti.GridPoint.JDiff_image_rev`: the southwest counts and the `J`-function are invariant
+  under reversing both coordinates of the point sets.
+* `TauCeti.GridState.rotate_rotate`, `TauCeti.GridDiagram.rotate_rotate`: rotation is an
+  involution on grid states and grid diagrams.
+* `TauCeti.GridDiagram.maslovO_rotate`, `TauCeti.GridDiagram.maslovX_rotate`,
+  `TauCeti.GridDiagram.alexander_rotate`: the Maslov and Alexander gradings are invariant under
+  the half-turn rotation.
+* `TauCeti.GridDiagram.maslovOℤ_rotate`, `TauCeti.GridDiagram.maslovXℤ_rotate`,
+  `TauCeti.GridDiagram.alexanderTwoℤ_rotate`: the integer-valued gradings are likewise invariant.
+
+## References
+
+This advances `TauCetiRoadmap/CombinatorialHeegaardFloer/README.md`, Lane G item 2, "Gradings.
+The `J`-function, `M_O`, `M_X`, `A`; integer-valuedness of `A`; grading-change formulas across a
+rectangle", supplying a grading-preserving symmetry of the kind anticipated by the "Symmetries
+and the genus bound" milestone (Lane G item 8). The half-turn rotation of a grid diagram is one
+of the standard grid symmetries of Ozsváth--Stipsicz--Szabó, *Grid Homology for Knots and
+Links*, Chapter 3.
+-/
+
+namespace TauCeti
+
+namespace GridPoint
+
+variable {n : ℕ}
+
+/-- Reversing both coordinates of both points of a pair exchanges the two endpoints of the strict
+southwest relation: it sends the column and row comparisons to their reverses. -/
+@[simp]
+theorem isSouthWest_rev (p q : Fin n × Fin n) :
+    IsSouthWest (Prod.map Fin.rev Fin.rev p) (Prod.map Fin.rev Fin.rev q) ↔ IsSouthWest q p := by
+  simp only [IsSouthWest, Prod.map_fst, Prod.map_snd]
+  have h1 := p.1.isLt
+  have h2 := q.1.isLt
+  have h3 := p.2.isLt
+  have h4 := q.2.isLt
+  rw [Fin.val_rev, Fin.val_rev, Fin.val_rev, Fin.val_rev]
+  omega
+
+/-- The coordinate-reversal map on grid squares is injective. -/
+private theorem prodMap_rev_injective :
+    Function.Injective (Prod.map (Fin.rev (n := n)) (Fin.rev (n := n))) :=
+  Fin.rev_injective.prodMap Fin.rev_injective
+
+/-- The coordinate-reversal map on pairs of grid squares is injective. -/
+private theorem prodMap_prodMap_rev_injective :
+    Function.Injective
+      (Prod.map (Prod.map (Fin.rev (n := n)) (Fin.rev (n := n)))
+        (Prod.map (Fin.rev (n := n)) (Fin.rev (n := n)))) :=
+  prodMap_rev_injective.prodMap prodMap_rev_injective
+
+/-- The ordered southwest count is invariant, up to exchanging the two point sets, under reversing
+both coordinates of both point sets. The reversal turns each southwest comparison into the
+opposite comparison, so the count of southwest pairs from `s` to `t` becomes the count from `t`
+to `s`. -/
+theorem I_image_rev (s t : Finset (Fin n × Fin n)) :
+    I (s.image (Prod.map Fin.rev Fin.rev)) (t.image (Prod.map Fin.rev Fin.rev)) = I t s := by
+  classical
+  rw [I_def, ← Finset.prodMap_image_product (Prod.map Fin.rev Fin.rev)
+      (Prod.map Fin.rev Fin.rev) s t, Finset.filter_image,
+    Finset.card_image_of_injective _ prodMap_prodMap_rev_injective]
+  rw [I_def, ← Finset.image_swap_product t s, Finset.filter_image,
+    Finset.card_image_of_injective _ Prod.swap_injective]
+  refine congrArg Finset.card (Finset.filter_congr fun pq _ => ?_)
+  simpa using isSouthWest_rev pq.1 pq.2
+
+/-- The numerator of the `J`-function is invariant under reversing both coordinates of both point
+sets. The two ordered counts are exchanged by the reversal, and their sum is symmetric. -/
+theorem JNum_image_rev (s t : Finset (Fin n × Fin n)) :
+    JNum (s.image (Prod.map Fin.rev Fin.rev)) (t.image (Prod.map Fin.rev Fin.rev)) = JNum s t := by
+  rw [JNum_def, JNum_def, I_image_rev, I_image_rev, Nat.add_comm]
+
+/-- The symmetrized grid `J`-function is invariant under reversing both coordinates of both point
+sets. -/
+theorem J_image_rev (s t : Finset (Fin n × Fin n)) :
+    GridPoint.J (s.image (Prod.map Fin.rev Fin.rev)) (t.image (Prod.map Fin.rev Fin.rev))
+      = GridPoint.J s t := by
+  rw [J_def, J_def, JNum_image_rev]
+
+/-- The bilinear `J`-function on formal differences is invariant under reversing both coordinates
+of all four point sets. -/
+theorem JDiff_image_rev (s a t b : Finset (Fin n × Fin n)) :
+    JDiff (s.image (Prod.map Fin.rev Fin.rev)) (a.image (Prod.map Fin.rev Fin.rev))
+        (t.image (Prod.map Fin.rev Fin.rev)) (b.image (Prod.map Fin.rev Fin.rev))
+      = JDiff s a t b := by
+  rw [JDiff_def, JDiff_def, J_image_rev, J_image_rev, J_image_rev, J_image_rev]
+
+end GridPoint
+
+namespace GridState
+
+variable {n : ℕ}
+
+/-- Reversing both coordinates of a grid square twice returns the original square. -/
+private theorem rev2_rev2 (p : Fin n × Fin n) :
+    Prod.map Fin.rev Fin.rev (Prod.map Fin.rev Fin.rev p) = p := by
+  obtain ⟨a, b⟩ := p
+  change (Fin.rev (Fin.rev a), Fin.rev (Fin.rev b)) = (a, b)
+  rw [Fin.rev_rev, Fin.rev_rev]
+
+/-- The half-turn rotation of a grid state.
+
+Rotating the occupied squares by `180°` reverses both the column and the row coordinate, so the
+new permutation graph conjugates the old one by the coordinate reversal `Fin.revPerm`. -/
+def rotate (x : GridState n) : GridState n where
+  toPerm := Fin.revPerm.trans (x.toPerm.trans Fin.revPerm)
+
+/-- The rotated state reads off a column by reversing it, applying the original state, and
+reversing the resulting row. -/
+@[simp]
+theorem rotate_apply (x : GridState n) (c : Fin n) :
+    x.rotate c = (x (Fin.rev c)).rev := by
+  simp [rotate, Equiv.trans_apply]
+
+/-- A square lies in the rotated state exactly when its half-turn rotation lies in the original
+state. -/
+@[simp]
+theorem mem_pointSet_rotate (x : GridState n) (p : Fin n × Fin n) :
+    p ∈ x.rotate.pointSet ↔ Prod.map Fin.rev Fin.rev p ∈ x.pointSet := by
+  simp only [mem_pointSet, rotate_apply, Prod.map_fst, Prod.map_snd, Fin.rev_eq_iff]
+
+/-- The point set of the rotated state is the half-turn rotation of the original point set. -/
+theorem rotate_pointSet (x : GridState n) :
+    x.rotate.pointSet = x.pointSet.image (Prod.map Fin.rev Fin.rev) := by
+  ext p
+  rw [mem_pointSet_rotate, Finset.mem_image]
+  constructor
+  · intro hp
+    exact ⟨Prod.map Fin.rev Fin.rev p, hp, rev2_rev2 p⟩
+  · rintro ⟨q, hq, rfl⟩
+    rwa [rev2_rev2 q]
+
+/-- The half-turn rotation is an involution on grid states. -/
+@[simp]
+theorem rotate_rotate (x : GridState n) : x.rotate.rotate = x := by
+  ext c
+  simp [Fin.rev_rev]
+
+end GridState
+
+namespace GridDiagram
+
+variable {n : ℕ} (G : GridDiagram n)
+
+/-- The half-turn rotation of a grid diagram, rotating both marking states.
+
+The rotation is injective on squares, so it preserves the condition that no square carries both an
+`O` and an `X` marking. -/
+def rotate (G : GridDiagram n) : GridDiagram n where
+  O := G.O.rotate
+  X := G.X.rotate
+  disjoint c := by
+    simp only [GridState.rotate_apply]
+    exact fun h => G.disjoint (Fin.rev c) (Fin.rev_injective h)
+
+/-- The `O`-marking state of the rotated diagram is the rotation of the original `O`-state. -/
+@[simp]
+theorem rotate_O : G.rotate.O = G.O.rotate :=
+  rfl
+
+/-- The `X`-marking state of the rotated diagram is the rotation of the original `X`-state. -/
+@[simp]
+theorem rotate_X : G.rotate.X = G.X.rotate :=
+  rfl
+
+/-- The `O`-markings of the rotated diagram are the half-turn rotation of the original
+`O`-markings. -/
+theorem rotate_OSet : G.rotate.OSet = G.OSet.image (Prod.map Fin.rev Fin.rev) :=
+  GridState.rotate_pointSet G.O
+
+/-- The `X`-markings of the rotated diagram are the half-turn rotation of the original
+`X`-markings. -/
+theorem rotate_XSet : G.rotate.XSet = G.XSet.image (Prod.map Fin.rev Fin.rev) :=
+  GridState.rotate_pointSet G.X
+
+/-- The half-turn rotation is an involution on grid diagrams. -/
+@[simp]
+theorem rotate_rotate : G.rotate.rotate = G := by
+  cases G
+  simp only [rotate, GridState.rotate_rotate]
+
+/-- The `O`-Maslov grading is invariant under the half-turn rotation. -/
+@[simp]
+theorem maslovO_rotate (x : GridState n) :
+    G.rotate.maslovO x.rotate = G.maslovO x := by
+  rw [maslovO_def, maslovO_def, GridState.rotate_pointSet, rotate_OSet, GridPoint.JDiff_image_rev]
+
+/-- The `X`-Maslov grading is invariant under the half-turn rotation. -/
+@[simp]
+theorem maslovX_rotate (x : GridState n) :
+    G.rotate.maslovX x.rotate = G.maslovX x := by
+  rw [maslovX_def, maslovX_def, GridState.rotate_pointSet, rotate_XSet, GridPoint.JDiff_image_rev]
+
+/-- The Alexander grading is invariant under the half-turn rotation. The normalization shift
+depends only on the common grid size, so it is untouched. -/
+@[simp]
+theorem alexander_rotate (x : GridState n) :
+    G.rotate.alexander x.rotate = G.alexander x := by
+  rw [alexander_def, alexander_def, maslovO_rotate, maslovX_rotate]
+
+/-- The integer-valued `O`-Maslov grading is invariant under the half-turn rotation. -/
+@[simp]
+theorem maslovOℤ_rotate (x : GridState n) :
+    G.rotate.maslovOℤ x.rotate = G.maslovOℤ x := by
+  rw [maslovOℤ_def, maslovOℤ_def, GridState.rotate_pointSet, rotate_OSet,
+    GridPoint.I_image_rev, GridPoint.JNum_image_rev, GridPoint.I_image_rev]
+
+/-- The integer-valued `X`-Maslov grading is invariant under the half-turn rotation. -/
+@[simp]
+theorem maslovXℤ_rotate (x : GridState n) :
+    G.rotate.maslovXℤ x.rotate = G.maslovXℤ x := by
+  rw [maslovXℤ_def, maslovXℤ_def, GridState.rotate_pointSet, rotate_XSet,
+    GridPoint.I_image_rev, GridPoint.JNum_image_rev, GridPoint.I_image_rev]
+
+/-- The integer numerator of twice the Alexander grading is invariant under the half-turn
+rotation. -/
+@[simp]
+theorem alexanderTwoℤ_rotate (x : GridState n) :
+    G.rotate.alexanderTwoℤ x.rotate = G.alexanderTwoℤ x := by
+  rw [alexanderTwoℤ_def, alexanderTwoℤ_def, maslovOℤ_rotate, maslovXℤ_rotate]
+
+end GridDiagram
+
+end TauCeti


### PR DESCRIPTION
This PR adds the half-turn (`180°`) rotation symmetry of grid states and grid diagrams to the grid-combinatorial lane, alongside the existing diagonal reflection (`transpose`) and marking swap (`swapMarkings`), and proves that it preserves every Maslov and Alexander grading. Rotation reverses both the column and the row coordinate of each grid square, `(c, r) ↦ (cᵒ, rᵒ)` with `·ᵒ = Fin.rev`, which is exactly the move that sends the strict southwest relation underlying the `J`-function to itself with its two endpoints exchanged. As a result the symmetrized point-pair counts `I`, `JNum`, `J`, and their formal-difference extension `JDiff` are all unchanged, so `M_O`, `M_X`, and `A` (and their integer-valued counterparts) are invariant. This is the rotational analogue of the existing `GridPoint.I_image_swap` machinery for the diagonal reflection, and a single-axis reflection is deliberately not added because only reversing both coordinates at once is grading-preserving.

This advances `TauCetiRoadmap/CombinatorialHeegaardFloer/README.md`, Lane G item 2 ("Gradings. The `J`-function, `M_O`, `M_X`, `A`; integer-valuedness of `A`; grading-change formulas across a rectangle"), supplying a grading-preserving symmetry of the kind the "Symmetries and the genus bound" milestone (Lane G item 8) will use, following the standard grid symmetries of Ozsváth–Stipsicz–Szabó, *Grid Homology for Knots and Links*, Chapter 3.

Everything is over the pinned Mathlib; no Mathlib infrastructure was vendored.

<!--tauceti-target:v1 {"focus":"CombinatorialHeegaardFloer","id":"grid-rotation-symmetry"}-->

🤖 Prepared with Claude Code
