### PR TITLE
feat: the pointwise integrand of a divergence-form energy bilinear form

### DIFF
--- a/TauCeti/Analysis/PDE/EnergyForm.lean
+++ b/TauCeti/Analysis/PDE/EnergyForm.lean
@@ -46,17 +46,22 @@ explicit (never hidden in a `∃ C`):
 * `TauCeti.PDE.energyIntegrand_one_zero_zero_apply`,
   `TauCeti.PDE.energyIntegrand_one_zero_zero_self`: the Laplacian model `−Δ`, whose jet form
   is the Dirichlet integrand `⟨∇u, ∇v⟩`, with diagonal `‖∇u‖²`.
+* `TauCeti.PDE.norm_energyIntegrand_apply_le_of_bounds`,
+  `TauCeti.PDE.opNorm_energyIntegrand_le_of_bounds`: boundedness with explicit constant
+  `Λ + β + γ`.
+* `TauCeti.PDE.garding_energyIntegrand_self_of_bounds`: the pointwise Gårding lower bound
+  on the diagonal.
 * `TauCeti.PDE.UniformlyEllipticOn.norm_energyIntegrand_apply_le`,
-  `TauCeti.PDE.UniformlyEllipticOn.opNorm_energyIntegrand_le`: boundedness with explicit
-  constant `Λ + β + γ`.
-* `TauCeti.PDE.UniformlyEllipticOn.garding_energyIntegrand_self`: the pointwise Gårding
-  lower bound on the diagonal.
+  `TauCeti.PDE.UniformlyEllipticOn.opNorm_energyIntegrand_le`, and
+  `TauCeti.PDE.UniformlyEllipticOn.garding_energyIntegrand_self`: bundled-hypothesis
+  corollaries of the pointwise estimates.
 -/
 
 namespace TauCeti
 
 namespace PDE
 
+open Matrix
 open scoped InnerProductSpace
 
 variable {X n : Type*} [Fintype n] [DecidableEq n]
@@ -90,6 +95,7 @@ lemma energyIntegrand_apply (A : Matrix n n ℝ) (b : EuclideanSpace ℝ n) (c :
   simp [energyIntegrand]
 
 /-- The diagonal of the jet form, the energy density `⟨a ∇u, ∇u⟩ + ⟪b, ∇u⟫ u + c u²`. -/
+@[simp]
 lemma energyIntegrand_self (A : Matrix n n ℝ) (b : EuclideanSpace ℝ n) (c : ℝ)
     (U : ℝ × EuclideanSpace ℝ n) :
     energyIntegrand A b c U U
@@ -105,21 +111,40 @@ lemma energyIntegrand_one_zero_zero_apply (U V : ℝ × EuclideanSpace ℝ n) :
   simp [energyIntegrand_apply]
 
 /-- The diagonal of the Laplacian model's jet form is the Dirichlet energy density `‖∇u‖²`. -/
+@[simp]
 lemma energyIntegrand_one_zero_zero_self (U : ℝ × EuclideanSpace ℝ n) :
     energyIntegrand (1 : Matrix n n ℝ) 0 0 U U = ‖U.2‖ ^ 2 := by
   rw [energyIntegrand_self, toQuadraticForm'_one]
   simp
 
-namespace UniformlyEllipticOn
-
 variable {Ω : Set X} {a : X → Matrix n n ℝ} {b : X → EuclideanSpace ℝ n} {c : X → ℝ}
 variable {lam Lam beta gamma : ℝ}
+
+/-- Weighted Young inequality in the form used to absorb the first-order drift term into
+half of the ellipticity floor. -/
+lemma mul_norm_abs_le_half_mul_sq_add (hlam : 0 < lam) (beta u : ℝ) (r : ℝ) :
+    beta * r * |u| ≤ lam / 2 * r ^ 2 + beta ^ 2 / (2 * lam) * u ^ 2 := by
+  have hkey := two_mul_le_add_sq (lam * r) (beta * |u|)
+  rw [mul_pow, mul_pow, sq_abs] at hkey
+  have h2lam : (0 : ℝ) < 2 * lam := mul_pos two_pos hlam
+  rw [← sub_nonneg]
+  have expand : lam / 2 * r ^ 2 + beta ^ 2 / (2 * lam) * u ^ 2 - beta * r * |u|
+      = (lam ^ 2 * r ^ 2 + beta ^ 2 * u ^ 2 - 2 * lam * beta * r * |u|)
+          / (2 * lam) := by
+    field_simp
+  rw [expand]
+  apply div_nonneg _ h2lam.le
+  nlinarith [hkey]
 
 /-- Pointwise boundedness of the jet form with explicit constant `Λ + β + γ`: at every
 point of the domain, the principal, drift, and mass contributions are each controlled by
 the corresponding constant times the jet norms. -/
-lemma norm_energyIntegrand_apply_le (he : UniformlyEllipticOn Ω a lam Lam)
-    (hbc : LowerOrderBoundedOn Ω b c beta gamma) {x : X} (hx : x ∈ Ω)
+lemma norm_energyIntegrand_apply_le_of_bounds (hLam : 0 ≤ Lam) (hbeta : 0 ≤ beta)
+    (hgamma : 0 ≤ gamma)
+    (ha : ∀ ⦃x⦄, x ∈ Ω → ∀ η ξ : EuclideanSpace ℝ n,
+      |η ⬝ᵥ (a x *ᵥ ξ)| ≤ Lam * ‖η‖ * ‖ξ‖)
+    (hb : ∀ ⦃x⦄, x ∈ Ω → ‖b x‖ ≤ beta)
+    (hc : ∀ ⦃x⦄, x ∈ Ω → ‖c x‖ ≤ gamma) {x : X} (hx : x ∈ Ω)
     (U V : ℝ × EuclideanSpace ℝ n) :
     ‖energyIntegrand (a x) (b x) (c x) U V‖ ≤ (Lam + beta + gamma) * ‖U‖ * ‖V‖ := by
   have step : ∀ {K p q : ℝ}, 0 ≤ K → 0 ≤ p → 0 ≤ q → p ≤ ‖U‖ → q ≤ ‖V‖ →
@@ -130,18 +155,20 @@ lemma norm_energyIntegrand_apply_le (he : UniformlyEllipticOn Ω a lam Lam)
           mul_le_mul_of_nonneg_left (mul_le_mul hpU hqV hq (hp.trans hpU)) hK
       _ = K * ‖U‖ * ‖V‖ := by ring
   have hmat : ‖matrixBilinearForm (a x) V.2 U.2‖ ≤ Lam * ‖U‖ * ‖V‖ := by
-    have h := he.norm_point_matrixBilinearForm_le hx V.2 U.2
+    have h := norm_matrixBilinearForm_le_of_upper_bound (a x) (ha hx) V.2 U.2
     rw [mul_right_comm] at h
-    exact h.trans (step he.upper_nonneg (norm_nonneg _) (norm_nonneg _)
+    exact h.trans (step hLam (norm_nonneg _) (norm_nonneg _)
       (norm_snd_le U) (norm_snd_le V))
   have hdrift : ‖driftForm (b x) V.1 U.2‖ ≤ beta * ‖U‖ * ‖V‖ := by
-    have h := hbc.norm_driftForm_le hx V.1 U.2
+    have hb' : DriftBoundedOn Ω b beta := DriftBoundedOn.of_bound hbeta hb
+    have h := hb'.norm_driftForm_le hx V.1 U.2
     rw [mul_right_comm] at h
-    exact h.trans (step hbc.beta_nonneg (norm_nonneg _) (norm_nonneg _)
+    exact h.trans (step hbeta (norm_nonneg _) (norm_nonneg _)
       (norm_snd_le U) (norm_fst_le V))
   have hmass : ‖massForm (c x) U.1 V.1‖ ≤ gamma * ‖U‖ * ‖V‖ := by
-    have h := hbc.norm_massForm_le hx U.1 V.1
-    exact h.trans (step hbc.gamma_nonneg (norm_nonneg _) (norm_nonneg _)
+    have hc' : MassBoundedOn Ω c gamma := MassBoundedOn.of_bound hgamma hc
+    have h := hc'.norm_massForm_le hx U.1 V.1
+    exact h.trans (step hgamma (norm_nonneg _) (norm_nonneg _)
       (norm_fst_le U) (norm_fst_le V))
   rw [energyIntegrand_apply]
   calc ‖matrixBilinearForm (a x) V.2 U.2 + driftForm (b x) V.1 U.2 + massForm (c x) U.1 V.1‖
@@ -156,31 +183,37 @@ lemma norm_energyIntegrand_apply_le (he : UniformlyEllipticOn Ω a lam Lam)
 /-- The operator norm of the jet form is at most `Λ + β + γ`. This is the boundedness
 hypothesis of Lax--Milgram, with the constant explicit in the ellipticity, drift, and mass
 bounds. -/
-lemma opNorm_energyIntegrand_le (he : UniformlyEllipticOn Ω a lam Lam)
-    (hbc : LowerOrderBoundedOn Ω b c beta gamma) {x : X} (hx : x ∈ Ω) :
+lemma opNorm_energyIntegrand_le_of_bounds (hLam : 0 ≤ Lam) (hbeta : 0 ≤ beta)
+    (hgamma : 0 ≤ gamma)
+    (ha : ∀ ⦃x⦄, x ∈ Ω → ∀ η ξ : EuclideanSpace ℝ n,
+      |η ⬝ᵥ (a x *ᵥ ξ)| ≤ Lam * ‖η‖ * ‖ξ‖)
+    (hb : ∀ ⦃x⦄, x ∈ Ω → ‖b x‖ ≤ beta)
+    (hc : ∀ ⦃x⦄, x ∈ Ω → ‖c x‖ ≤ gamma) {x : X} (hx : x ∈ Ω) :
     ‖energyIntegrand (a x) (b x) (c x)‖ ≤ Lam + beta + gamma := by
   refine (energyIntegrand (a x) (b x) (c x)).opNorm_le_bound₂
-    (_root_.add_nonneg (_root_.add_nonneg he.upper_nonneg hbc.beta_nonneg) hbc.gamma_nonneg) ?_
+    (_root_.add_nonneg (_root_.add_nonneg hLam hbeta) hgamma) ?_
   intro U V
-  exact he.norm_energyIntegrand_apply_le hbc hx U V
+  exact norm_energyIntegrand_apply_le_of_bounds hLam hbeta hgamma ha hb hc hx U V
 
 /-- **Pointwise Gårding inequality.** With a nonnegative mass coefficient (`c ≥ 0`), the
 diagonal of the jet form is bounded below by `(λ/2)‖∇u‖² − (β²/2λ)|u|²`. The ellipticity
 floor `λ‖∇u‖²` pays for the drift term via Young's inequality, leaving half the floor and a
 mass defect proportional to `β²/λ`. Integrating over `Ω` this is Gårding's inequality
 `a(u, u) ≥ (λ/2)‖∇u‖²_{L²} − (β²/2λ)‖u‖²_{L²}`. -/
-lemma garding_energyIntegrand_self (he : UniformlyEllipticOn Ω a lam Lam)
-    (hb : DriftBoundedOn Ω b beta) (hc : NonnegMassOn Ω c gamma) {x : X} (hx : x ∈ Ω)
+lemma garding_energyIntegrand_self_of_bounds (hlam : 0 < lam)
+    (hQ : ∀ ⦃x⦄, x ∈ Ω → ∀ ξ : EuclideanSpace ℝ n,
+      lam * ‖ξ‖ ^ 2 ≤ (a x).toQuadraticForm' ξ)
+    (hb : ∀ ⦃x⦄, x ∈ Ω → ‖b x‖ ≤ beta)
+    (hc : ∀ ⦃x⦄, x ∈ Ω → 0 ≤ c x) {x : X} (hx : x ∈ Ω)
     (U : ℝ × EuclideanSpace ℝ n) :
     lam / 2 * ‖U.2‖ ^ 2 - beta ^ 2 / (2 * lam) * U.1 ^ 2
       ≤ energyIntegrand (a x) (b x) (c x) U U := by
   rw [energyIntegrand_self]
-  have hlam := he.pos
-  have hQ : lam * ‖U.2‖ ^ 2 ≤ (a x).toQuadraticForm' U.2 := he.lower_bound hx U.2
-  have hM : 0 ≤ c x * U.1 ^ 2 := mul_nonneg (hc.nonneg hx) (sq_nonneg _)
+  have hQ' : lam * ‖U.2‖ ^ 2 ≤ (a x).toQuadraticForm' U.2 := hQ hx U.2
+  have hM : 0 ≤ c x * U.1 ^ 2 := mul_nonneg (hc hx) (sq_nonneg _)
   have hbip : |⟪b x, U.2⟫_ℝ| ≤ beta * ‖U.2‖ :=
     (abs_real_inner_le_norm (b x) U.2).trans
-      (mul_le_mul_of_nonneg_right (hb.bound hx) (norm_nonneg _))
+      (mul_le_mul_of_nonneg_right (hb hx) (norm_nonneg _))
   have hD : -(beta * ‖U.2‖ * |U.1|) ≤ ⟪b x, U.2⟫_ℝ * U.1 := by
     have habs : |⟪b x, U.2⟫_ℝ * U.1| ≤ beta * ‖U.2‖ * |U.1| := by
       rw [abs_mul]
@@ -188,20 +221,43 @@ lemma garding_energyIntegrand_self (he : UniformlyEllipticOn Ω a lam Lam)
     have := neg_abs_le (⟪b x, U.2⟫_ℝ * U.1)
     linarith
   have hYoung : beta * ‖U.2‖ * |U.1| ≤
-      lam / 2 * ‖U.2‖ ^ 2 + beta ^ 2 / (2 * lam) * U.1 ^ 2 := by
-    have hkey := two_mul_le_add_sq (lam * ‖U.2‖) (beta * |U.1|)
-    rw [mul_pow, mul_pow, sq_abs] at hkey
-    have h2lam : (0 : ℝ) < 2 * lam := mul_pos two_pos hlam
-    rw [← sub_nonneg]
-    have expand : lam / 2 * ‖U.2‖ ^ 2 + beta ^ 2 / (2 * lam) * U.1 ^ 2
-        - beta * ‖U.2‖ * |U.1|
-        = (lam ^ 2 * ‖U.2‖ ^ 2 + beta ^ 2 * U.1 ^ 2
-            - 2 * lam * beta * ‖U.2‖ * |U.1|) / (2 * lam) := by
-      field_simp
-    rw [expand]
-    apply div_nonneg _ h2lam.le
-    nlinarith [hkey]
-  nlinarith [hQ, hM, hD, hYoung]
+      lam / 2 * ‖U.2‖ ^ 2 + beta ^ 2 / (2 * lam) * U.1 ^ 2 :=
+    mul_norm_abs_le_half_mul_sq_add hlam beta U.1 ‖U.2‖
+  nlinarith [hQ', hM, hD, hYoung]
+
+namespace UniformlyEllipticOn
+
+variable {Ω : Set X} {a : X → Matrix n n ℝ} {b : X → EuclideanSpace ℝ n} {c : X → ℝ}
+variable {lam Lam beta gamma : ℝ}
+
+/-- Bundled-hypothesis corollary of pointwise boundedness of the jet form. -/
+@[grind =>]
+lemma norm_energyIntegrand_apply_le (he : UniformlyEllipticOn Ω a lam Lam)
+    (hbc : LowerOrderBoundedOn Ω b c beta gamma) {x : X} (hx : x ∈ Ω)
+    (U V : ℝ × EuclideanSpace ℝ n) :
+    ‖energyIntegrand (a x) (b x) (c x) U V‖ ≤ (Lam + beta + gamma) * ‖U‖ * ‖V‖ :=
+  norm_energyIntegrand_apply_le_of_bounds he.upper_nonneg hbc.beta_nonneg hbc.gamma_nonneg
+    (fun {_} hx => he.upper_bound hx) (fun {_} hx => hbc.drift_bound hx)
+    (fun {_} hx => hbc.mass_bound hx) hx U V
+
+/-- Bundled-hypothesis corollary of the operator-norm bound for the jet form. -/
+@[grind =>]
+lemma opNorm_energyIntegrand_le (he : UniformlyEllipticOn Ω a lam Lam)
+    (hbc : LowerOrderBoundedOn Ω b c beta gamma) {x : X} (hx : x ∈ Ω) :
+    ‖energyIntegrand (a x) (b x) (c x)‖ ≤ Lam + beta + gamma :=
+  opNorm_energyIntegrand_le_of_bounds he.upper_nonneg hbc.beta_nonneg hbc.gamma_nonneg
+    (fun {_} hx => he.upper_bound hx) (fun {_} hx => hbc.drift_bound hx)
+    (fun {_} hx => hbc.mass_bound hx) hx
+
+/-- Bundled-hypothesis corollary of the pointwise Gårding lower bound on the diagonal. -/
+@[grind =>]
+lemma garding_energyIntegrand_self (he : UniformlyEllipticOn Ω a lam Lam)
+    (hb : DriftBoundedOn Ω b beta) (hc : NonnegMassOn Ω c gamma) {x : X} (hx : x ∈ Ω)
+    (U : ℝ × EuclideanSpace ℝ n) :
+    lam / 2 * ‖U.2‖ ^ 2 - beta ^ 2 / (2 * lam) * U.1 ^ 2
+      ≤ energyIntegrand (a x) (b x) (c x) U U :=
+  garding_energyIntegrand_self_of_bounds he.pos (fun {_} hx => he.lower_bound hx)
+    (fun {_} hx => hb.bound hx) (fun {_} hx => hc.nonneg hx) hx U
 
 end UniformlyEllipticOn
 

--- a/TauCeti/Analysis/PDE/EnergyForm.lean
+++ b/TauCeti/Analysis/PDE/EnergyForm.lean
@@ -253,7 +253,7 @@ lemma opNorm_energyIntegrand_le (he : UniformlyEllipticOn Ω a lam Lam)
 bounded drift, and a pointwise nonnegative mass coefficient. -/
 @[grind =>]
 lemma garding_energyIntegrand_self (he : UniformlyEllipticOn Ω a lam Lam)
-    (hb : DriftBoundedOn Ω b beta) (hc : MassNonnegativeOn Ω c) {x : X} (hx : x ∈ Ω)
+    (hb : DriftBoundedOn Ω b beta) (hc : NonnegMassPointwiseOn Ω c) {x : X} (hx : x ∈ Ω)
     (U : ℝ × EuclideanSpace ℝ n) :
     lam / 2 * ‖U.2‖ ^ 2 - beta ^ 2 / (2 * lam) * U.1 ^ 2
       ≤ energyIntegrand (a x) (b x) (c x) U U :=

--- a/TauCeti/Analysis/PDE/EnergyForm.lean
+++ b/TauCeti/Analysis/PDE/EnergyForm.lean
@@ -1,0 +1,210 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+import TauCeti.Analysis.PDE.UniformEllipticity
+import TauCeti.Analysis.PDE.LowerOrder
+
+/-!
+# The pointwise integrand of a divergence-form energy bilinear form
+
+For a divergence-form operator `L u = -∂ⱼ(aⁱʲ ∂ᵢ u) + bⁱ ∂ᵢ u + c u`, the weak (energy)
+bilinear form is
+
+`a(u, v) = ∫_Ω (aⁱʲ ∂ᵢu ∂ⱼv + bⁱ ∂ᵢu v + c u v)`,
+
+whose integrand at a point `x` depends only on the *jets* `(u(x), ∇u(x))` and
+`(v(x), ∇v(x))`, that is, on pairs in `ℝ × EuclideanSpace ℝ n`. This file assembles the
+three pointwise coefficient forms already available
+
+* the principal matrix form `matrixBilinearForm (a x)` (in
+  `TauCeti.Analysis.PDE.UniformEllipticity`),
+* the drift form `driftForm (b x)` and the mass form `massForm (c x)` (in
+  `TauCeti.Analysis.PDE.LowerOrder`),
+
+into a single bundled continuous bilinear form on jets, `energyIntegrand (a x) (b x) (c x)`,
+matching `(U, V) ↦ ⟨a(x) U.2, V.2⟩ + ⟪b(x), U.2⟫ V.1 + c(x) U.1 V.1`, where `U.2 = ∇u`,
+`U.1 = u`. Integrating this jet form over `Ω` against the jets of `u` and `v` recovers the
+energy bilinear form, so this is the pointwise seed of Lane D's weak formulation.
+
+The two estimates the energy method needs are proved pointwise, with their constants left
+explicit (never hidden in a `∃ C`):
+
+* **boundedness**: the operator norm of the jet form is at most `Λ + β + γ`, the sum of the
+  ellipticity, drift, and mass constants;
+* **Gårding's inequality (pointwise)**: with a sign condition `c ≥ 0` on the mass
+  coefficient, the diagonal of the jet form is bounded below by
+  `(λ/2)‖∇u‖² − (β²/2λ)|u|²`, the integrand-level version of Gårding's
+  `a(u, u) ≥ α‖u‖²_{H¹} − K‖u‖²_{L²}`. The drift is absorbed by Young's inequality, paid
+  for out of half of the ellipticity floor.
+
+## Main declarations
+
+* `TauCeti.PDE.energyIntegrand`: the bundled jet bilinear form of a divergence-form operator.
+* `TauCeti.PDE.energyIntegrand_apply`, `TauCeti.PDE.energyIntegrand_self`: its value and its
+  diagonal value.
+* `TauCeti.PDE.energyIntegrand_one_zero_zero_apply`,
+  `TauCeti.PDE.energyIntegrand_one_zero_zero_self`: the Laplacian model `−Δ`, whose jet form
+  is the Dirichlet integrand `⟨∇u, ∇v⟩`, with diagonal `‖∇u‖²`.
+* `TauCeti.PDE.UniformlyEllipticOn.norm_energyIntegrand_apply_le`,
+  `TauCeti.PDE.UniformlyEllipticOn.opNorm_energyIntegrand_le`: boundedness with explicit
+  constant `Λ + β + γ`.
+* `TauCeti.PDE.UniformlyEllipticOn.garding_energyIntegrand_self`: the pointwise Gårding
+  lower bound on the diagonal.
+-/
+
+namespace TauCeti
+
+namespace PDE
+
+open scoped InnerProductSpace
+
+variable {X n : Type*} [Fintype n] [DecidableEq n]
+
+/-- The pointwise weak-form (energy) integrand of a divergence-form operator
+`L u = -∂ⱼ(aⁱʲ ∂ᵢu) + bⁱ ∂ᵢu + c u`, as a bundled continuous bilinear form on jets
+`(value, gradient) ∈ ℝ × EuclideanSpace ℝ n`.
+
+On jets `U = (u, ∇u)` and `V = (v, ∇v)` it evaluates to
+`⟨a ∇u, ∇v⟩ + ⟪b, ∇u⟫ v + c u v`, the integrand of `a(u, v)`. Bundling it as a
+`ContinuousLinearMap` lets it feed Mathlib's bounded-bilinear-form and Lax--Milgram APIs
+once the energy form is integrated over the Sobolev space. -/
+noncomputable def energyIntegrand (A : Matrix n n ℝ) (b : EuclideanSpace ℝ n) (c : ℝ) :
+    (ℝ × EuclideanSpace ℝ n) →L[ℝ] (ℝ × EuclideanSpace ℝ n) →L[ℝ] ℝ :=
+  (matrixBilinearForm A).flip.bilinearComp
+      (ContinuousLinearMap.snd ℝ ℝ (EuclideanSpace ℝ n))
+      (ContinuousLinearMap.snd ℝ ℝ (EuclideanSpace ℝ n))
+    + (driftForm b).flip.bilinearComp
+        (ContinuousLinearMap.snd ℝ ℝ (EuclideanSpace ℝ n))
+        (ContinuousLinearMap.fst ℝ ℝ (EuclideanSpace ℝ n))
+    + (massForm c).bilinearComp
+        (ContinuousLinearMap.fst ℝ ℝ (EuclideanSpace ℝ n))
+        (ContinuousLinearMap.fst ℝ ℝ (EuclideanSpace ℝ n))
+
+/-- The jet form evaluates to `⟨a ∇u, ∇v⟩ + ⟪b, ∇u⟫ v + c u v` on jets `U`, `V`. -/
+@[simp]
+lemma energyIntegrand_apply (A : Matrix n n ℝ) (b : EuclideanSpace ℝ n) (c : ℝ)
+    (U V : ℝ × EuclideanSpace ℝ n) :
+    energyIntegrand A b c U V
+      = matrixBilinearForm A V.2 U.2 + driftForm b V.1 U.2 + massForm c U.1 V.1 := by
+  simp [energyIntegrand]
+
+/-- The diagonal of the jet form, the energy density `⟨a ∇u, ∇u⟩ + ⟪b, ∇u⟫ u + c u²`. -/
+lemma energyIntegrand_self (A : Matrix n n ℝ) (b : EuclideanSpace ℝ n) (c : ℝ)
+    (U : ℝ × EuclideanSpace ℝ n) :
+    energyIntegrand A b c U U
+      = A.toQuadraticForm' U.2 + ⟪b, U.2⟫_ℝ * U.1 + c * U.1 ^ 2 := by
+  rw [energyIntegrand_apply, matrixBilinearForm_self, driftForm_apply, massForm_apply]
+  ring
+
+/-- The Laplacian model `−Δ` (`a = 1`, no drift, no mass) has jet form the Dirichlet
+integrand `⟨∇u, ∇v⟩`. -/
+@[simp]
+lemma energyIntegrand_one_zero_zero_apply (U V : ℝ × EuclideanSpace ℝ n) :
+    energyIntegrand (1 : Matrix n n ℝ) 0 0 U V = V.2 ⬝ᵥ U.2 := by
+  simp [energyIntegrand_apply]
+
+/-- The diagonal of the Laplacian model's jet form is the Dirichlet energy density `‖∇u‖²`. -/
+lemma energyIntegrand_one_zero_zero_self (U : ℝ × EuclideanSpace ℝ n) :
+    energyIntegrand (1 : Matrix n n ℝ) 0 0 U U = ‖U.2‖ ^ 2 := by
+  rw [energyIntegrand_self, toQuadraticForm'_one]
+  simp
+
+namespace UniformlyEllipticOn
+
+variable {Ω : Set X} {a : X → Matrix n n ℝ} {b : X → EuclideanSpace ℝ n} {c : X → ℝ}
+variable {lam Lam beta gamma : ℝ}
+
+/-- Pointwise boundedness of the jet form with explicit constant `Λ + β + γ`: at every
+point of the domain, the principal, drift, and mass contributions are each controlled by
+the corresponding constant times the jet norms. -/
+lemma norm_energyIntegrand_apply_le (he : UniformlyEllipticOn Ω a lam Lam)
+    (hbc : LowerOrderBoundedOn Ω b c beta gamma) {x : X} (hx : x ∈ Ω)
+    (U V : ℝ × EuclideanSpace ℝ n) :
+    ‖energyIntegrand (a x) (b x) (c x) U V‖ ≤ (Lam + beta + gamma) * ‖U‖ * ‖V‖ := by
+  have step : ∀ {K p q : ℝ}, 0 ≤ K → 0 ≤ p → 0 ≤ q → p ≤ ‖U‖ → q ≤ ‖V‖ →
+      K * p * q ≤ K * ‖U‖ * ‖V‖ := by
+    intro K p q hK hp hq hpU hqV
+    calc K * p * q = K * (p * q) := by ring
+      _ ≤ K * (‖U‖ * ‖V‖) :=
+          mul_le_mul_of_nonneg_left (mul_le_mul hpU hqV hq (hp.trans hpU)) hK
+      _ = K * ‖U‖ * ‖V‖ := by ring
+  have hmat : ‖matrixBilinearForm (a x) V.2 U.2‖ ≤ Lam * ‖U‖ * ‖V‖ := by
+    have h := he.norm_point_matrixBilinearForm_le hx V.2 U.2
+    rw [mul_right_comm] at h
+    exact h.trans (step he.upper_nonneg (norm_nonneg _) (norm_nonneg _)
+      (norm_snd_le U) (norm_snd_le V))
+  have hdrift : ‖driftForm (b x) V.1 U.2‖ ≤ beta * ‖U‖ * ‖V‖ := by
+    have h := hbc.norm_driftForm_le hx V.1 U.2
+    rw [mul_right_comm] at h
+    exact h.trans (step hbc.beta_nonneg (norm_nonneg _) (norm_nonneg _)
+      (norm_snd_le U) (norm_fst_le V))
+  have hmass : ‖massForm (c x) U.1 V.1‖ ≤ gamma * ‖U‖ * ‖V‖ := by
+    have h := hbc.norm_massForm_le hx U.1 V.1
+    exact h.trans (step hbc.gamma_nonneg (norm_nonneg _) (norm_nonneg _)
+      (norm_fst_le U) (norm_fst_le V))
+  rw [energyIntegrand_apply]
+  calc ‖matrixBilinearForm (a x) V.2 U.2 + driftForm (b x) V.1 U.2 + massForm (c x) U.1 V.1‖
+      ≤ ‖matrixBilinearForm (a x) V.2 U.2 + driftForm (b x) V.1 U.2‖
+          + ‖massForm (c x) U.1 V.1‖ := norm_add_le _ _
+    _ ≤ ‖matrixBilinearForm (a x) V.2 U.2‖ + ‖driftForm (b x) V.1 U.2‖
+          + ‖massForm (c x) U.1 V.1‖ := by gcongr; exact norm_add_le _ _
+    _ ≤ Lam * ‖U‖ * ‖V‖ + beta * ‖U‖ * ‖V‖ + gamma * ‖U‖ * ‖V‖ :=
+        add_le_add (add_le_add hmat hdrift) hmass
+    _ = (Lam + beta + gamma) * ‖U‖ * ‖V‖ := by ring
+
+/-- The operator norm of the jet form is at most `Λ + β + γ`. This is the boundedness
+hypothesis of Lax--Milgram, with the constant explicit in the ellipticity, drift, and mass
+bounds. -/
+lemma opNorm_energyIntegrand_le (he : UniformlyEllipticOn Ω a lam Lam)
+    (hbc : LowerOrderBoundedOn Ω b c beta gamma) {x : X} (hx : x ∈ Ω) :
+    ‖energyIntegrand (a x) (b x) (c x)‖ ≤ Lam + beta + gamma := by
+  refine (energyIntegrand (a x) (b x) (c x)).opNorm_le_bound₂
+    (_root_.add_nonneg (_root_.add_nonneg he.upper_nonneg hbc.beta_nonneg) hbc.gamma_nonneg) ?_
+  intro U V
+  exact he.norm_energyIntegrand_apply_le hbc hx U V
+
+/-- **Pointwise Gårding inequality.** With a nonnegative mass coefficient (`c ≥ 0`), the
+diagonal of the jet form is bounded below by `(λ/2)‖∇u‖² − (β²/2λ)|u|²`. The ellipticity
+floor `λ‖∇u‖²` pays for the drift term via Young's inequality, leaving half the floor and a
+mass defect proportional to `β²/λ`. Integrating over `Ω` this is Gårding's inequality
+`a(u, u) ≥ (λ/2)‖∇u‖²_{L²} − (β²/2λ)‖u‖²_{L²}`. -/
+lemma garding_energyIntegrand_self (he : UniformlyEllipticOn Ω a lam Lam)
+    (hb : DriftBoundedOn Ω b beta) (hc : NonnegMassOn Ω c gamma) {x : X} (hx : x ∈ Ω)
+    (U : ℝ × EuclideanSpace ℝ n) :
+    lam / 2 * ‖U.2‖ ^ 2 - beta ^ 2 / (2 * lam) * U.1 ^ 2
+      ≤ energyIntegrand (a x) (b x) (c x) U U := by
+  rw [energyIntegrand_self]
+  have hlam := he.pos
+  have hQ : lam * ‖U.2‖ ^ 2 ≤ (a x).toQuadraticForm' U.2 := he.lower_bound hx U.2
+  have hM : 0 ≤ c x * U.1 ^ 2 := mul_nonneg (hc.nonneg hx) (sq_nonneg _)
+  have hbip : |⟪b x, U.2⟫_ℝ| ≤ beta * ‖U.2‖ :=
+    (abs_real_inner_le_norm (b x) U.2).trans
+      (mul_le_mul_of_nonneg_right (hb.bound hx) (norm_nonneg _))
+  have hD : -(beta * ‖U.2‖ * |U.1|) ≤ ⟪b x, U.2⟫_ℝ * U.1 := by
+    have habs : |⟪b x, U.2⟫_ℝ * U.1| ≤ beta * ‖U.2‖ * |U.1| := by
+      rw [abs_mul]
+      exact mul_le_mul_of_nonneg_right hbip (abs_nonneg _)
+    have := neg_abs_le (⟪b x, U.2⟫_ℝ * U.1)
+    linarith
+  have hYoung : beta * ‖U.2‖ * |U.1| ≤
+      lam / 2 * ‖U.2‖ ^ 2 + beta ^ 2 / (2 * lam) * U.1 ^ 2 := by
+    have hkey := two_mul_le_add_sq (lam * ‖U.2‖) (beta * |U.1|)
+    rw [mul_pow, mul_pow, sq_abs] at hkey
+    have h2lam : (0 : ℝ) < 2 * lam := mul_pos two_pos hlam
+    rw [← sub_nonneg]
+    have expand : lam / 2 * ‖U.2‖ ^ 2 + beta ^ 2 / (2 * lam) * U.1 ^ 2
+        - beta * ‖U.2‖ * |U.1|
+        = (lam ^ 2 * ‖U.2‖ ^ 2 + beta ^ 2 * U.1 ^ 2
+            - 2 * lam * beta * ‖U.2‖ * |U.1|) / (2 * lam) := by
+      field_simp
+    rw [expand]
+    apply div_nonneg _ h2lam.le
+    nlinarith [hkey]
+  nlinarith [hQ, hM, hD, hYoung]
+
+end UniformlyEllipticOn
+
+end PDE
+
+end TauCeti

--- a/TauCeti/Analysis/PDE/EnergyForm.lean
+++ b/TauCeti/Analysis/PDE/EnergyForm.lean
@@ -139,8 +139,7 @@ private lemma mul_norm_abs_le_half_mul_sq_add (hlam : 0 < lam) (beta u : ℝ) (r
 /-- Pointwise boundedness of the jet form with explicit constant `Λ + β + γ`: at every
 point of the domain, the principal, drift, and mass contributions are each controlled by
 the corresponding constant times the jet norms. -/
-lemma norm_energyIntegrand_apply_le_of_bounds (hLam : 0 ≤ Lam) (hbeta : 0 ≤ beta)
-    (hgamma : 0 ≤ gamma)
+lemma norm_energyIntegrand_apply_le_of_bounds (hLam : 0 ≤ Lam)
     (ha : ∀ ⦃x⦄, x ∈ Ω → ∀ η ξ : EuclideanSpace ℝ n,
       |η ⬝ᵥ (a x *ᵥ ξ)| ≤ Lam * ‖η‖ * ‖ξ‖)
     (hb : ∀ ⦃x⦄, x ∈ Ω → ‖b x‖ ≤ beta)
@@ -154,22 +153,33 @@ lemma norm_energyIntegrand_apply_le_of_bounds (hLam : 0 ≤ Lam) (hbeta : 0 ≤ 
       _ ≤ K * (‖U‖ * ‖V‖) :=
           mul_le_mul_of_nonneg_left (mul_le_mul hpU hqV hq (hp.trans hpU)) hK
       _ = K * ‖U‖ * ‖V‖ := by ring
+  have hbeta : 0 ≤ beta := (norm_nonneg (b x)).trans (hb hx)
+  have hgamma : 0 ≤ gamma := (norm_nonneg (c x)).trans (hc hx)
   have hmat : ‖matrixBilinearForm (a x) V.2 U.2‖ ≤ Lam * ‖U‖ * ‖V‖ := by
     have h := norm_matrixBilinearForm_le_of_upper_bound (a x) (ha hx) V.2 U.2
     rw [mul_right_comm] at h
     exact h.trans (step hLam (norm_nonneg _) (norm_nonneg _)
       (norm_snd_le U) (norm_snd_le V))
   have hdrift : ‖driftForm (b x) V.1 U.2‖ ≤ beta * ‖U‖ * ‖V‖ := by
-    have hb' : DriftBoundedOn Ω b beta := DriftBoundedOn.of_bound hbeta hb
-    have h := hb'.norm_driftForm_le hx V.1 U.2
-    rw [mul_right_comm] at h
-    exact h.trans (step hbeta (norm_nonneg _) (norm_nonneg _)
-      (norm_snd_le U) (norm_fst_le V))
+    rw [driftForm_apply, norm_mul]
+    calc
+      ‖⟪b x, U.2⟫_ℝ‖ * ‖V.1‖ ≤ (‖b x‖ * ‖U.2‖) * ‖V.1‖ := by
+        gcongr
+        exact norm_inner_le_norm (b x) U.2
+      _ ≤ (beta * ‖U.2‖) * ‖V.1‖ := by
+        gcongr
+        exact hb hx
+      _ = beta * ‖U.2‖ * ‖V.1‖ := by ring
+      _ ≤ beta * ‖U‖ * ‖V‖ :=
+        step hbeta (norm_nonneg _) (norm_nonneg _) (norm_snd_le U) (norm_fst_le V)
   have hmass : ‖massForm (c x) U.1 V.1‖ ≤ gamma * ‖U‖ * ‖V‖ := by
-    have hc' : MassBoundedOn Ω c gamma := MassBoundedOn.of_bound hgamma hc
-    have h := hc'.norm_massForm_le hx U.1 V.1
-    exact h.trans (step hgamma (norm_nonneg _) (norm_nonneg _)
-      (norm_fst_le U) (norm_fst_le V))
+    rw [massForm_apply, norm_mul, norm_mul]
+    calc
+      ‖c x‖ * ‖U.1‖ * ‖V.1‖ ≤ gamma * ‖U.1‖ * ‖V.1‖ := by
+        gcongr
+        exact hc hx
+      _ ≤ gamma * ‖U‖ * ‖V‖ :=
+        step hgamma (norm_nonneg _) (norm_nonneg _) (norm_fst_le U) (norm_fst_le V)
   rw [energyIntegrand_apply]
   calc ‖matrixBilinearForm (a x) V.2 U.2 + driftForm (b x) V.1 U.2 + massForm (c x) U.1 V.1‖
       ≤ ‖matrixBilinearForm (a x) V.2 U.2 + driftForm (b x) V.1 U.2‖
@@ -183,17 +193,18 @@ lemma norm_energyIntegrand_apply_le_of_bounds (hLam : 0 ≤ Lam) (hbeta : 0 ≤ 
 /-- The operator norm of the jet form is at most `Λ + β + γ`. This is the boundedness
 hypothesis of Lax--Milgram, with the constant explicit in the ellipticity, drift, and mass
 bounds. -/
-lemma opNorm_energyIntegrand_le_of_bounds (hLam : 0 ≤ Lam) (hbeta : 0 ≤ beta)
-    (hgamma : 0 ≤ gamma)
+lemma opNorm_energyIntegrand_le_of_bounds (hLam : 0 ≤ Lam)
     (ha : ∀ ⦃x⦄, x ∈ Ω → ∀ η ξ : EuclideanSpace ℝ n,
       |η ⬝ᵥ (a x *ᵥ ξ)| ≤ Lam * ‖η‖ * ‖ξ‖)
     (hb : ∀ ⦃x⦄, x ∈ Ω → ‖b x‖ ≤ beta)
     (hc : ∀ ⦃x⦄, x ∈ Ω → ‖c x‖ ≤ gamma) {x : X} (hx : x ∈ Ω) :
     ‖energyIntegrand (a x) (b x) (c x)‖ ≤ Lam + beta + gamma := by
+  have hbeta : 0 ≤ beta := (norm_nonneg (b x)).trans (hb hx)
+  have hgamma : 0 ≤ gamma := (norm_nonneg (c x)).trans (hc hx)
   refine (energyIntegrand (a x) (b x) (c x)).opNorm_le_bound₂
     (_root_.add_nonneg (_root_.add_nonneg hLam hbeta) hgamma) ?_
   intro U V
-  exact norm_energyIntegrand_apply_le_of_bounds hLam hbeta hgamma ha hb hc hx U V
+  exact norm_energyIntegrand_apply_le_of_bounds hLam ha hb hc hx U V
 
 /-- **Pointwise Gårding inequality.** With a nonnegative mass coefficient (`c ≥ 0`), the
 diagonal of the jet form is bounded below by `(λ/2)‖∇u‖² − (β²/2λ)|u|²`. The ellipticity
@@ -236,18 +247,16 @@ lemma norm_energyIntegrand_apply_le (he : UniformlyEllipticOn Ω a lam Lam)
     (hbc : LowerOrderBoundedOn Ω b c beta gamma) {x : X} (hx : x ∈ Ω)
     (U V : ℝ × EuclideanSpace ℝ n) :
     ‖energyIntegrand (a x) (b x) (c x) U V‖ ≤ (Lam + beta + gamma) * ‖U‖ * ‖V‖ :=
-  norm_energyIntegrand_apply_le_of_bounds he.upper_nonneg hbc.beta_nonneg hbc.gamma_nonneg
-    (fun {_} hx => he.upper_bound hx) (fun {_} hx => hbc.drift_bound hx)
-    (fun {_} hx => hbc.mass_bound hx) hx U V
+  norm_energyIntegrand_apply_le_of_bounds he.upper_nonneg (fun {_} hx => he.upper_bound hx)
+    (fun {_} hx => hbc.drift_bound hx) (fun {_} hx => hbc.mass_bound hx) hx U V
 
 /-- Bundled-hypothesis corollary of the operator-norm bound for the jet form. -/
 @[grind =>]
 lemma opNorm_energyIntegrand_le (he : UniformlyEllipticOn Ω a lam Lam)
     (hbc : LowerOrderBoundedOn Ω b c beta gamma) {x : X} (hx : x ∈ Ω) :
     ‖energyIntegrand (a x) (b x) (c x)‖ ≤ Lam + beta + gamma :=
-  opNorm_energyIntegrand_le_of_bounds he.upper_nonneg hbc.beta_nonneg hbc.gamma_nonneg
-    (fun {_} hx => he.upper_bound hx) (fun {_} hx => hbc.drift_bound hx)
-    (fun {_} hx => hbc.mass_bound hx) hx
+  opNorm_energyIntegrand_le_of_bounds he.upper_nonneg (fun {_} hx => he.upper_bound hx)
+    (fun {_} hx => hbc.drift_bound hx) (fun {_} hx => hbc.mass_bound hx) hx
 
 /-- Corollary of the pointwise Gårding lower bound on the diagonal from bundled ellipticity,
 bounded drift, and a pointwise nonnegative mass coefficient. -/

--- a/TauCeti/Analysis/PDE/EnergyForm.lean
+++ b/TauCeti/Analysis/PDE/EnergyForm.lean
@@ -122,7 +122,7 @@ variable {lam Lam beta gamma : ℝ}
 
 /-- Weighted Young inequality in the form used to absorb the first-order drift term into
 half of the ellipticity floor. -/
-lemma mul_norm_abs_le_half_mul_sq_add (hlam : 0 < lam) (beta u : ℝ) (r : ℝ) :
+private lemma mul_norm_abs_le_half_mul_sq_add (hlam : 0 < lam) (beta u : ℝ) (r : ℝ) :
     beta * r * |u| ≤ lam / 2 * r ^ 2 + beta ^ 2 / (2 * lam) * u ^ 2 := by
   have hkey := two_mul_le_add_sq (lam * r) (beta * |u|)
   rw [mul_pow, mul_pow, sq_abs] at hkey

--- a/TauCeti/Analysis/PDE/EnergyForm.lean
+++ b/TauCeti/Analysis/PDE/EnergyForm.lean
@@ -53,8 +53,8 @@ explicit (never hidden in a `∃ C`):
   on the diagonal.
 * `TauCeti.PDE.UniformlyEllipticOn.norm_energyIntegrand_apply_le`,
   `TauCeti.PDE.UniformlyEllipticOn.opNorm_energyIntegrand_le`, and
-  `TauCeti.PDE.UniformlyEllipticOn.garding_energyIntegrand_self`: bundled-hypothesis
-  corollaries of the pointwise estimates.
+  `TauCeti.PDE.UniformlyEllipticOn.garding_energyIntegrand_self`: convenient corollaries
+  of the pointwise estimates.
 -/
 
 namespace TauCeti
@@ -249,10 +249,11 @@ lemma opNorm_energyIntegrand_le (he : UniformlyEllipticOn Ω a lam Lam)
     (fun {_} hx => he.upper_bound hx) (fun {_} hx => hbc.drift_bound hx)
     (fun {_} hx => hbc.mass_bound hx) hx
 
-/-- Bundled-hypothesis corollary of the pointwise Gårding lower bound on the diagonal. -/
+/-- Corollary of the pointwise Gårding lower bound on the diagonal from bundled ellipticity,
+bounded drift, and a pointwise nonnegative mass coefficient. -/
 @[grind =>]
 lemma garding_energyIntegrand_self (he : UniformlyEllipticOn Ω a lam Lam)
-    (hb : DriftBoundedOn Ω b beta) (hc : NonnegMassOn Ω c gamma) {x : X} (hx : x ∈ Ω)
+    (hb : DriftBoundedOn Ω b beta) (hc : MassNonnegativeOn Ω c) {x : X} (hx : x ∈ Ω)
     (U : ℝ × EuclideanSpace ℝ n) :
     lam / 2 * ‖U.2‖ ^ 2 - beta ^ 2 / (2 * lam) * U.1 ^ 2
       ≤ energyIntegrand (a x) (b x) (c x) U U :=

--- a/TauCeti/Analysis/PDE/LowerOrder.lean
+++ b/TauCeti/Analysis/PDE/LowerOrder.lean
@@ -296,36 +296,36 @@ lemma opNorm_massForm_le (h : LowerOrderBoundedOn Ω b c beta gamma) {x : X}
 end LowerOrderBoundedOn
 
 /-- Pointwise nonnegative zeroth-order coefficients on a domain. -/
-def MassNonnegativeOn (Ω : Set X) (c : X → ℝ) : Prop :=
+def NonnegMassPointwiseOn (Ω : Set X) (c : X → ℝ) : Prop :=
   ∀ ⦃x⦄, x ∈ Ω → 0 ≤ c x
 
 /-- Characteristic restatement of pointwise nonnegative mass coefficients. -/
-lemma massNonnegativeOn_iff {Ω : Set X} {c : X → ℝ} :
-    MassNonnegativeOn Ω c ↔ ∀ ⦃x⦄, x ∈ Ω → 0 ≤ c x :=
+lemma nonnegMassPointwiseOn_iff {Ω : Set X} {c : X → ℝ} :
+    NonnegMassPointwiseOn Ω c ↔ ∀ ⦃x⦄, x ∈ Ω → 0 ≤ c x :=
   Iff.rfl
 
-namespace MassNonnegativeOn
+namespace NonnegMassPointwiseOn
 
 variable {Ω Ω' : Set X} {c : X → ℝ}
 
 /-- The mass coefficient is pointwise nonnegative. -/
 @[grind =>]
-lemma nonneg (h : MassNonnegativeOn Ω c) {x : X} (hx : x ∈ Ω) : 0 ≤ c x :=
+lemma nonneg (h : NonnegMassPointwiseOn Ω c) {x : X} (hx : x ∈ Ω) : 0 ≤ c x :=
   h hx
 
 /-- The mass form associated to a nonnegative mass coefficient is nonnegative on the diagonal. -/
 @[grind =>]
-lemma massForm_self_nonneg (h : MassNonnegativeOn Ω c) {x : X} (hx : x ∈ Ω) (u : ℝ) :
+lemma massForm_self_nonneg (h : NonnegMassPointwiseOn Ω c) {x : X} (hx : x ∈ Ω) (u : ℝ) :
     0 ≤ massForm (c x) u u := by
   rw [massForm_apply, mul_assoc]
   exact mul_nonneg (h.nonneg hx) (mul_self_nonneg u)
 
 /-- Restricting the domain preserves pointwise nonnegative mass coefficients. -/
-lemma mono_set (h : MassNonnegativeOn Ω c) (hΩ : Ω' ⊆ Ω) :
-    MassNonnegativeOn Ω' c :=
+lemma mono_set (h : NonnegMassPointwiseOn Ω c) (hΩ : Ω' ⊆ Ω) :
+    NonnegMassPointwiseOn Ω' c :=
   fun {_} hx => h (hΩ hx)
 
-end MassNonnegativeOn
+end NonnegMassPointwiseOn
 
 /-- Nonnegative bounded zeroth-order coefficients on a domain. -/
 def NonnegMassOn (Ω : Set X) (c : X → ℝ) (gamma : ℝ) : Prop :=
@@ -353,8 +353,8 @@ lemma nonneg (h : NonnegMassOn Ω c gamma) {x : X} (hx : x ∈ Ω) : 0 ≤ c x :
   (h.2 hx).1
 
 /-- A nonnegative bounded mass coefficient is pointwise nonnegative. -/
-lemma mass_nonnegativeOn (h : NonnegMassOn Ω c gamma) :
-    MassNonnegativeOn Ω c :=
+lemma nonnegMassPointwiseOn (h : NonnegMassOn Ω c gamma) :
+    NonnegMassPointwiseOn Ω c :=
   fun {_} hx => h.nonneg hx
 
 /-- The mass coefficient is pointwise bounded above. -/

--- a/TauCeti/Analysis/PDE/LowerOrder.lean
+++ b/TauCeti/Analysis/PDE/LowerOrder.lean
@@ -295,6 +295,38 @@ lemma opNorm_massForm_le (h : LowerOrderBoundedOn Ω b c beta gamma) {x : X}
 
 end LowerOrderBoundedOn
 
+/-- Pointwise nonnegative zeroth-order coefficients on a domain. -/
+def MassNonnegativeOn (Ω : Set X) (c : X → ℝ) : Prop :=
+  ∀ ⦃x⦄, x ∈ Ω → 0 ≤ c x
+
+/-- Characteristic restatement of pointwise nonnegative mass coefficients. -/
+lemma massNonnegativeOn_iff {Ω : Set X} {c : X → ℝ} :
+    MassNonnegativeOn Ω c ↔ ∀ ⦃x⦄, x ∈ Ω → 0 ≤ c x :=
+  Iff.rfl
+
+namespace MassNonnegativeOn
+
+variable {Ω Ω' : Set X} {c : X → ℝ}
+
+/-- The mass coefficient is pointwise nonnegative. -/
+@[grind =>]
+lemma nonneg (h : MassNonnegativeOn Ω c) {x : X} (hx : x ∈ Ω) : 0 ≤ c x :=
+  h hx
+
+/-- The mass form associated to a nonnegative mass coefficient is nonnegative on the diagonal. -/
+@[grind =>]
+lemma massForm_self_nonneg (h : MassNonnegativeOn Ω c) {x : X} (hx : x ∈ Ω) (u : ℝ) :
+    0 ≤ massForm (c x) u u := by
+  rw [massForm_apply, mul_assoc]
+  exact mul_nonneg (h.nonneg hx) (mul_self_nonneg u)
+
+/-- Restricting the domain preserves pointwise nonnegative mass coefficients. -/
+lemma mono_set (h : MassNonnegativeOn Ω c) (hΩ : Ω' ⊆ Ω) :
+    MassNonnegativeOn Ω' c :=
+  fun {_} hx => h (hΩ hx)
+
+end MassNonnegativeOn
+
 /-- Nonnegative bounded zeroth-order coefficients on a domain. -/
 def NonnegMassOn (Ω : Set X) (c : X → ℝ) (gamma : ℝ) : Prop :=
   0 ≤ gamma ∧ ∀ ⦃x⦄, x ∈ Ω → 0 ≤ c x ∧ c x ≤ gamma
@@ -319,6 +351,11 @@ lemma gamma_nonneg (h : NonnegMassOn Ω c gamma) : 0 ≤ gamma :=
 @[grind =>]
 lemma nonneg (h : NonnegMassOn Ω c gamma) {x : X} (hx : x ∈ Ω) : 0 ≤ c x :=
   (h.2 hx).1
+
+/-- A nonnegative bounded mass coefficient is pointwise nonnegative. -/
+lemma mass_nonnegativeOn (h : NonnegMassOn Ω c gamma) :
+    MassNonnegativeOn Ω c :=
+  fun {_} hx => h.nonneg hx
 
 /-- The mass coefficient is pointwise bounded above. -/
 @[grind =>]


### PR DESCRIPTION
This PR assembles the pointwise coefficient forms of a divergence-form operator `L u = -∂ⱼ(aⁱʲ ∂ᵢu) + bⁱ ∂ᵢu + c u` into the bundled jet bilinear form `TauCeti.PDE.energyIntegrand (a x) (b x) (c x)`, the integrand of the energy form `a(u, v) = ∫_Ω (aⁱʲ ∂ᵢu ∂ⱼv + bⁱ ∂ᵢu v + c u v)` evaluated on the jets `(u(x), ∇u(x))` and `(v(x), ∇v(x))` in `ℝ × EuclideanSpace ℝ n`. It then proves the two estimates the energy method needs, both with explicit constants: the jet form's operator norm is at most `Λ + β + γ`, and (under the sign condition `c ≥ 0`) its diagonal satisfies the pointwise Gårding lower bound `(λ/2)‖∇u‖² − (β²/2λ)|u|²`, with the drift absorbed by Young's inequality out of half the ellipticity floor.

This advances the partial differential equations roadmap `TauCetiRoadmap/PDE/README.md`, Lane D.16 ("Weak formulation. The energy bilinear form ... boundedness; Gårding's inequality `a(u,u) ≥ α‖u‖²_{H¹} − β‖u‖²_{L²}` from uniform ellipticity"), supplying its pointwise integrand-level seed. It builds directly on the principal matrix form `matrixBilinearForm` (`TauCeti/Analysis/PDE/UniformEllipticity.lean`) and the lower-order forms `driftForm`, `massForm` with their bound predicates `UniformlyEllipticOn`, `LowerOrderBoundedOn`, `DriftBoundedOn`, `NonnegMassOn` (`TauCeti/Analysis/PDE/LowerOrder.lean`), and honours the roadmap's standing instruction to keep ellipticity, drift, and mass constants explicit rather than hidden in an existential. The bundling consumes Mathlib's `ContinuousLinearMap.bilinearComp` and `opNorm_le_bound₂`; the Laplacian model `−Δ` (`energyIntegrand 1 0 0`) is recorded as the Dirichlet integrand `⟨∇u, ∇v⟩` with diagonal `‖∇u‖²`, a non-vacuity check.

`lake build` and `lake exe axioms` are green (axioms within `[propext, Classical.choice, Quot.sound]`).

<!--tauceti-target:v1 {"focus":"PDE","id":"energy-integrand-garding"}-->

🤖 Prepared with Claude Code
