### PR TITLE
feat: the group of self-diffeomorphisms

### DIFF
--- a/TauCeti/Geometry/Diffeomorphism/Group.lean
+++ b/TauCeti/Geometry/Diffeomorphism/Group.lean
@@ -110,6 +110,10 @@ theorem toEquiv_one : (1 : M ≃ₘ^n⟮I, I⟯ M).toEquiv = 1 := rfl
 @[simp]
 theorem toEquiv_mul (f g : M ≃ₘ^n⟮I, I⟯ M) : (f * g).toEquiv = f.toEquiv * g.toEquiv := rfl
 
+/-- The underlying equivalence preserves inversion of self-diffeomorphisms. -/
+@[simp]
+theorem toEquiv_inv (f : M ≃ₘ^n⟮I, I⟯ M) : (f⁻¹).toEquiv = f.toEquiv⁻¹ := rfl
+
 /-- The forgetful group homomorphism from the self-diffeomorphism group to the permutation group of
 the underlying set, sending a diffeomorphism to its underlying equivalence. -/
 @[simps]

--- a/TauCeti/Geometry/Diffeomorphism/Group.lean
+++ b/TauCeti/Geometry/Diffeomorphism/Group.lean
@@ -100,7 +100,6 @@ theorem mul_apply (f g : M ≃ₘ^n⟮I, I⟯ M) (x : M) : (f * g) x = f (g x) :
 theorem one_apply (x : M) : (1 : M ≃ₘ^n⟮I, I⟯ M) x = x := rfl
 
 /-- The inverse in the self-diffeomorphism group acts as the inverse diffeomorphism. -/
-@[simp]
 theorem inv_apply (f : M ≃ₘ^n⟮I, I⟯ M) (x : M) : f⁻¹ x = f.symm x := rfl
 
 /-- The underlying equivalence of the unit self-diffeomorphism is the unit permutation. -/

--- a/TauCeti/Geometry/Diffeomorphism/Group.lean
+++ b/TauCeti/Geometry/Diffeomorphism/Group.lean
@@ -60,7 +60,7 @@ instance instMul : Mul (M ≃ₘ^n⟮I, I⟯ M) where mul f g := g.trans f
 instance instInv : Inv (M ≃ₘ^n⟮I, I⟯ M) where inv f := f.symm
 
 /-- Composition of diffeomorphisms is associative. -/
-theorem trans_assoc
+private theorem trans_assoc
     {E' : Type*} [NormedAddCommGroup E'] [NormedSpace 𝕜 E']
     {F : Type*} [NormedAddCommGroup F] [NormedSpace 𝕜 F]
     {F' : Type*} [NormedAddCommGroup F'] [NormedSpace 𝕜 F']

--- a/TauCeti/Geometry/Diffeomorphism/Group.lean
+++ b/TauCeti/Geometry/Diffeomorphism/Group.lean
@@ -60,7 +60,8 @@ instance instMul : Mul (M ≃ₘ^n⟮I, I⟯ M) where mul f g := g.trans f
 instance instInv : Inv (M ≃ₘ^n⟮I, I⟯ M) where inv f := f.symm
 
 /-- Composition of self-diffeomorphisms is associative. -/
-theorem trans_assoc (f g h : M ≃ₘ^n⟮I, I⟯ M) : (f.trans g).trans h = f.trans (g.trans h) :=
+private theorem trans_assoc (f g h : M ≃ₘ^n⟮I, I⟯ M) :
+    (f.trans g).trans h = f.trans (g.trans h) :=
   _root_.Diffeomorph.ext fun _ => rfl
 
 /-- The `Cⁿ` self-diffeomorphisms of `M` form a group under composition, with multiplication

--- a/TauCeti/Geometry/Diffeomorphism/Group.lean
+++ b/TauCeti/Geometry/Diffeomorphism/Group.lean
@@ -59,8 +59,20 @@ instance instMul : Mul (M ≃ₘ^n⟮I, I⟯ M) where mul f g := g.trans f
 /-- The inverse in the self-diffeomorphism group is the inverse diffeomorphism. -/
 instance instInv : Inv (M ≃ₘ^n⟮I, I⟯ M) where inv f := f.symm
 
-/-- Composition of self-diffeomorphisms is associative. -/
-private theorem trans_assoc (f g h : M ≃ₘ^n⟮I, I⟯ M) :
+/-- Composition of diffeomorphisms is associative. -/
+theorem trans_assoc
+    {E' : Type*} [NormedAddCommGroup E'] [NormedSpace 𝕜 E']
+    {F : Type*} [NormedAddCommGroup F] [NormedSpace 𝕜 F]
+    {F' : Type*} [NormedAddCommGroup F'] [NormedSpace 𝕜 F']
+    {H' : Type*} [TopologicalSpace H'] {G : Type*} [TopologicalSpace G]
+    {G' : Type*} [TopologicalSpace G']
+    {I' : ModelWithCorners 𝕜 E' H'} {J : ModelWithCorners 𝕜 F G}
+    {J' : ModelWithCorners 𝕜 F' G'}
+    {M' : Type*} [TopologicalSpace M'] [ChartedSpace H' M']
+    {N : Type*} [TopologicalSpace N] [ChartedSpace G N]
+    {N' : Type*} [TopologicalSpace N'] [ChartedSpace G' N']
+    (f : M ≃ₘ^n⟮I, I'⟯ M') (g : M' ≃ₘ^n⟮I', J⟯ N)
+    (h : N ≃ₘ^n⟮J, J'⟯ N') :
     (f.trans g).trans h = f.trans (g.trans h) :=
   _root_.Diffeomorph.ext fun _ => rfl
 

--- a/TauCeti/Geometry/Diffeomorphism/Group.lean
+++ b/TauCeti/Geometry/Diffeomorphism/Group.lean
@@ -59,36 +59,54 @@ instance instMul : Mul (M ≃ₘ^n⟮I, I⟯ M) where mul f g := g.trans f
 /-- The inverse in the self-diffeomorphism group is the inverse diffeomorphism. -/
 instance instInv : Inv (M ≃ₘ^n⟮I, I⟯ M) where inv f := f.symm
 
-/-- The `Cⁿ` self-diffeomorphisms of `M` form a group under composition. The proofs are the
-`Diffeomorph` composition lemmas (`refl_trans`, `trans_refl`, `self_trans_symm`), exactly as for
-`Equiv.Perm`. -/
+/-- Composition of self-diffeomorphisms is associative. -/
+theorem trans_assoc (f g h : M ≃ₘ^n⟮I, I⟯ M) : (f.trans g).trans h = f.trans (g.trans h) :=
+  _root_.Diffeomorph.ext fun _ => rfl
+
+/-- The `Cⁿ` self-diffeomorphisms of `M` form a group under composition, with multiplication
+acting as function composition. -/
 instance instGroup : Group (M ≃ₘ^n⟮I, I⟯ M) where
-  mul_assoc _ _ _ := _root_.Diffeomorph.ext fun _ => rfl
+  mul_assoc _ _ _ := (trans_assoc _ _ _).symm
   one_mul := _root_.Diffeomorph.trans_refl
   mul_one := _root_.Diffeomorph.refl_trans
   inv_mul_cancel := _root_.Diffeomorph.self_trans_symm
 
+/-- The unit of the self-diffeomorphism group is the identity diffeomorphism. -/
 theorem one_def : (1 : M ≃ₘ^n⟮I, I⟯ M) = _root_.Diffeomorph.refl I M n := rfl
 
+/-- Multiplication in the self-diffeomorphism group is `Diffeomorph.trans` in composition order. -/
 theorem mul_def (f g : M ≃ₘ^n⟮I, I⟯ M) : f * g = g.trans f := rfl
 
+/-- Inversion in the self-diffeomorphism group is the inverse diffeomorphism. -/
 theorem inv_def (f : M ≃ₘ^n⟮I, I⟯ M) : f⁻¹ = f.symm := rfl
 
+/-- The unit self-diffeomorphism coerces to the identity function. -/
 @[simp]
 theorem coe_one : ⇑(1 : M ≃ₘ^n⟮I, I⟯ M) = id := rfl
 
+/-- Multiplication of self-diffeomorphisms coerces to function composition. -/
 @[simp]
 theorem coe_mul (f g : M ≃ₘ^n⟮I, I⟯ M) : ⇑(f * g) = f ∘ g := rfl
 
+/-- The inverse self-diffeomorphism coerces to the inverse diffeomorphism. -/
+@[simp]
+theorem coe_inv (f : M ≃ₘ^n⟮I, I⟯ M) : ⇑(f⁻¹) = f.symm := rfl
+
+/-- Multiplication of self-diffeomorphisms acts by applying the right factor, then the left. -/
 theorem mul_apply (f g : M ≃ₘ^n⟮I, I⟯ M) (x : M) : (f * g) x = f (g x) := rfl
 
+/-- The unit self-diffeomorphism fixes every point. -/
 theorem one_apply (x : M) : (1 : M ≃ₘ^n⟮I, I⟯ M) x = x := rfl
 
+/-- The inverse in the self-diffeomorphism group acts as the inverse diffeomorphism. -/
+@[simp]
 theorem inv_apply (f : M ≃ₘ^n⟮I, I⟯ M) (x : M) : f⁻¹ x = f.symm x := rfl
 
+/-- The underlying equivalence of the unit self-diffeomorphism is the unit permutation. -/
 @[simp]
 theorem toEquiv_one : (1 : M ≃ₘ^n⟮I, I⟯ M).toEquiv = 1 := rfl
 
+/-- The underlying equivalence preserves multiplication of self-diffeomorphisms. -/
 @[simp]
 theorem toEquiv_mul (f g : M ≃ₘ^n⟮I, I⟯ M) : (f * g).toEquiv = f.toEquiv * g.toEquiv := rfl
 
@@ -100,6 +118,7 @@ def toPerm : (M ≃ₘ^n⟮I, I⟯ M) →* Equiv.Perm M where
   map_one' := rfl
   map_mul' _ _ := rfl
 
+/-- The forgetful homomorphism to permutations is injective. -/
 theorem toPerm_injective : Function.Injective (toPerm : (M ≃ₘ^n⟮I, I⟯ M) → Equiv.Perm M) :=
   _root_.Diffeomorph.toEquiv_injective
 

--- a/TauCeti/Geometry/Diffeomorphism/Group.lean
+++ b/TauCeti/Geometry/Diffeomorphism/Group.lean
@@ -1,0 +1,114 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+import Mathlib.Geometry.Manifold.Diffeomorph
+
+/-!
+# The group of self-diffeomorphisms
+
+Mathlib's `Diffeomorph I I' M M' n` is the type of `Cⁿ` diffeomorphisms between two manifolds,
+with composition (`Diffeomorph.trans`), inverse (`Diffeomorph.symm`), and the identity
+(`Diffeomorph.refl`) already in place. When the source and target coincide these assemble into a
+group: this file equips the self-diffeomorphisms `M ≃ₘ^n⟮I, I⟯ M` with `One`, `Mul`, and `Inv`
+instances and proves the `Group` axioms, exactly as Mathlib does for `Equiv.Perm`
+(`Mathlib/Algebra/Group/End.lean`). The multiplication is `f * g = g.trans f`, so that `f * g`
+acts as the function composition `f ∘ g`, matching the `Equiv.Perm` convention.
+
+This is the group object the geometric-topology roadmap
+(`TauCetiRoadmap/GeometricTopology/README.md`, layer 3, "diffeomorphism groups with the C^∞
+topology") asks for as its first deliverable: "The **group** `Diff(M) := M ≃ₘ^∞⟮I, I⟯ M` under
+composition (the `Group` instance is routine from the existing `Diffeomorph` composition and
+inverse)." It is the underlying group of the topological group `Diff(M)` whose homotopy type the
+Smale conjecture `[Kir97, Problem 4.34]` is about; the C^∞ topology making it a topological group is
+a separate, later layer-3 deliverable, so this file stops at the bare group structure. The
+construction works for every smoothness exponent `n`, with `n = ∞` the case named by the roadmap.
+
+## Main definitions
+
+* `TauCeti.Diff I M n`: notation/abbreviation for the group `M ≃ₘ^n⟮I, I⟯ M` of `Cⁿ`
+  self-diffeomorphisms of `M`.
+* the `One`, `Mul`, `Inv`, and `Group` instances on `M ≃ₘ^n⟮I, I⟯ M`.
+* `TauCeti.Diffeomorph.toPerm`: the forgetful group homomorphism to the underlying permutation
+  group `Equiv.Perm M`, which is injective.
+
+## Main results
+
+* `TauCeti.Diffeomorph.mul_apply` / `one_apply` / `inv_apply` and the `coe_*` companions: the group
+  operations act by composition, the identity, and the inverse diffeomorphism.
+-/
+
+namespace TauCeti
+
+open scoped Manifold ContDiff
+
+variable {𝕜 : Type*} [NontriviallyNormedField 𝕜]
+  {E : Type*} [NormedAddCommGroup E] [NormedSpace 𝕜 E]
+  {H : Type*} [TopologicalSpace H] {I : ModelWithCorners 𝕜 E H}
+  {M : Type*} [TopologicalSpace M] [ChartedSpace H M] {n : ℕ∞ω}
+
+namespace Diffeomorph
+
+/-- The identity diffeomorphism is the unit of the self-diffeomorphism group. -/
+instance instOne : One (M ≃ₘ^n⟮I, I⟯ M) where one := _root_.Diffeomorph.refl I M n
+
+/-- Multiplication of self-diffeomorphisms is composition: `f * g` follows `g` then `f`, so that it
+acts as `f ∘ g`, matching the `Equiv.Perm` convention. -/
+instance instMul : Mul (M ≃ₘ^n⟮I, I⟯ M) where mul f g := g.trans f
+
+/-- The inverse in the self-diffeomorphism group is the inverse diffeomorphism. -/
+instance instInv : Inv (M ≃ₘ^n⟮I, I⟯ M) where inv f := f.symm
+
+/-- The `Cⁿ` self-diffeomorphisms of `M` form a group under composition. The proofs are the
+`Diffeomorph` composition lemmas (`refl_trans`, `trans_refl`, `self_trans_symm`), exactly as for
+`Equiv.Perm`. -/
+instance instGroup : Group (M ≃ₘ^n⟮I, I⟯ M) where
+  mul_assoc _ _ _ := _root_.Diffeomorph.ext fun _ => rfl
+  one_mul := _root_.Diffeomorph.trans_refl
+  mul_one := _root_.Diffeomorph.refl_trans
+  inv_mul_cancel := _root_.Diffeomorph.self_trans_symm
+
+theorem one_def : (1 : M ≃ₘ^n⟮I, I⟯ M) = _root_.Diffeomorph.refl I M n := rfl
+
+theorem mul_def (f g : M ≃ₘ^n⟮I, I⟯ M) : f * g = g.trans f := rfl
+
+theorem inv_def (f : M ≃ₘ^n⟮I, I⟯ M) : f⁻¹ = f.symm := rfl
+
+@[simp]
+theorem coe_one : ⇑(1 : M ≃ₘ^n⟮I, I⟯ M) = id := rfl
+
+@[simp]
+theorem coe_mul (f g : M ≃ₘ^n⟮I, I⟯ M) : ⇑(f * g) = f ∘ g := rfl
+
+theorem mul_apply (f g : M ≃ₘ^n⟮I, I⟯ M) (x : M) : (f * g) x = f (g x) := rfl
+
+theorem one_apply (x : M) : (1 : M ≃ₘ^n⟮I, I⟯ M) x = x := rfl
+
+theorem inv_apply (f : M ≃ₘ^n⟮I, I⟯ M) (x : M) : f⁻¹ x = f.symm x := rfl
+
+@[simp]
+theorem toEquiv_one : (1 : M ≃ₘ^n⟮I, I⟯ M).toEquiv = 1 := rfl
+
+@[simp]
+theorem toEquiv_mul (f g : M ≃ₘ^n⟮I, I⟯ M) : (f * g).toEquiv = f.toEquiv * g.toEquiv := rfl
+
+/-- The forgetful group homomorphism from the self-diffeomorphism group to the permutation group of
+the underlying set, sending a diffeomorphism to its underlying equivalence. -/
+@[simps]
+def toPerm : (M ≃ₘ^n⟮I, I⟯ M) →* Equiv.Perm M where
+  toFun f := f.toEquiv
+  map_one' := rfl
+  map_mul' _ _ := rfl
+
+theorem toPerm_injective : Function.Injective (toPerm : (M ≃ₘ^n⟮I, I⟯ M) → Equiv.Perm M) :=
+  _root_.Diffeomorph.toEquiv_injective
+
+end Diffeomorph
+
+/-- `Diff I M n` is the group of `Cⁿ` self-diffeomorphisms of the manifold `M` modelled on `I`,
+under composition. With `n = ∞` this is the group underlying `Diff(M)` of the geometric-topology
+roadmap. -/
+abbrev Diff (I : ModelWithCorners 𝕜 E H) (M : Type*) [TopologicalSpace M] [ChartedSpace H M]
+    (n : ℕ∞ω) : Type _ := M ≃ₘ^n⟮I, I⟯ M
+
+end TauCeti


### PR DESCRIPTION
This PR equips the self-diffeomorphisms `M ≃ₘ^n⟮I, I⟯ M` of a manifold with a `Group` structure under composition, supplying `One`, `Mul`, and `Inv` instances together with the group axioms, applied-form lemmas (`mul_apply`, `one_apply`, `inv_apply` and the `coe_*` companions), the abbreviation `Diff I M n`, and the injective forgetful group homomorphism `Diffeomorph.toPerm` to the underlying permutation group `Equiv.Perm M`. The multiplication is `f * g = g.trans f`, so `f * g` acts as the composition `f ∘ g`, matching the `Equiv.Perm` convention.

This advances `TauCetiRoadmap/GeometricTopology/README.md`, layer 3 ("diffeomorphism groups with the C^∞ topology"), whose first deliverable is exactly: "The **group** `Diff(M) := M ≃ₘ^∞⟮I, I⟯ M` under composition (the `Group` instance is routine from the existing `Diffeomorph` composition and inverse)." It is the bare group object underlying the topological group `Diff(M)` whose homotopy type the Smale conjecture `[Kir97, Problem 4.34]` concerns; the C^∞ topology making it a topological group is a separate, later layer-3 deliverable, so this PR stops at the group structure. The construction is stated for an arbitrary smoothness exponent `n`, with `n = ∞` the case the roadmap names.

The group structure mirrors Mathlib's `Equiv.Perm` group instance in `Mathlib/Algebra/Group/End.lean` (the `mul := g.trans f`, `one := refl`, `inv := symm` pattern and the choice of `inv_mul_cancel := self_trans_symm`); the axiom proofs reuse the existing `Diffeomorph` composition lemmas (`refl_trans`, `trans_refl`, `self_trans_symm`, `ext`, `toEquiv_injective`) from `Mathlib/Geometry/Manifold/Diffeomorph.lean`.

<!--tauceti-target:v1 {"focus":"GeometricTopology","id":"diffeomorphism-group"}-->

🤖 Prepared with Claude Code
