### PR TITLE
feat: a regular preconnected covering is a quotient covering map for its deck group

### DIFF
--- a/TauCeti/AlgebraicTopology/UniversalCover/Deck/Quotient.lean
+++ b/TauCeti/AlgebraicTopology/UniversalCover/Deck/Quotient.lean
@@ -57,7 +57,7 @@ lemma orbitQuotientToBase_mk (e : E) :
 
 /-- If deck orbits are exactly fibres of `p`, the deck-orbit relation is the kernel relation
 of `p`. -/
-lemma orbitRel_eq_ker_of_exists_apply_eq
+private lemma orbitRel_eq_ker_of_exists_apply_eq
     (hpoint : ∀ {e e' : E}, p e = p e' → ∃ φ : Deck p, φ.1 e = e') :
     MulAction.orbitRel (Deck p) E = Setoid.ker p := by
   ext e e'
@@ -69,6 +69,15 @@ lemma orbitRel_eq_ker_of_exists_apply_eq
       have hinv : φ.1.symm e' = e := by
         rw [← hφ, Homeomorph.symm_apply_apply]
       simpa [smul_eq_apply] using hinv⟩
+
+/-- If every pair of points with the same projection is connected by a deck transformation,
+then two points of the total space have the same projection exactly when they lie in a common
+orbit of the deck transformation group. The reverse direction holds because deck
+transformations preserve the projection. -/
+lemma apply_eq_iff_mem_orbit_of_exists_apply_eq
+    (hpoint : ∀ {e e' : E}, p e = p e' → ∃ φ : Deck p, φ.1 e = e') {e₁ e₂ : E} :
+    p e₁ = p e₂ ↔ e₁ ∈ MulAction.orbit (Deck p) e₂ := by
+  rw [← MulAction.orbitRel_apply, orbitRel_eq_ker_of_exists_apply_eq hpoint, Setoid.ker_def]
 
 /-- An over-base homeomorphism preserves the corresponding deck-orbit relations. -/
 private lemma orbitRel_homeomorph_iff (h : E ≃ₜ F) (hpq : ∀ e, q (h e) = p e) (e e' : E) :
@@ -150,6 +159,12 @@ namespace IsRegular
 lemma orbitQuotientToBase_injective (hreg : IsRegular p) :
     Function.Injective (orbitQuotientToBase p) := by
   exact orbitQuotientToBase_injective_of_exists_apply_eq (isRegular_iff_exists_apply_eq.mp hreg).2
+
+/-- For a regular deck action, two points have the same projection exactly when they lie in a
+common deck orbit. -/
+lemma apply_eq_iff_mem_orbit (hreg : IsRegular p) {e₁ e₂ : E} :
+    p e₁ = p e₂ ↔ e₁ ∈ MulAction.orbit (Deck p) e₂ :=
+  Deck.apply_eq_iff_mem_orbit_of_exists_apply_eq (isRegular_iff_exists_apply_eq.mp hreg).2
 
 /-- A regular deck action identifies the quotient of the total space by deck orbits with the
 base. -/

--- a/TauCeti/AlgebraicTopology/UniversalCover/Deck/Quotient.lean
+++ b/TauCeti/AlgebraicTopology/UniversalCover/Deck/Quotient.lean
@@ -57,7 +57,7 @@ lemma orbitQuotientToBase_mk (e : E) :
 
 /-- If deck orbits are exactly fibres of `p`, the deck-orbit relation is the kernel relation
 of `p`. -/
-private lemma orbitRel_eq_ker_of_exists_apply_eq
+lemma orbitRel_eq_ker_of_exists_apply_eq
     (hpoint : ∀ {e e' : E}, p e = p e' → ∃ φ : Deck p, φ.1 e = e') :
     MulAction.orbitRel (Deck p) E = Setoid.ker p := by
   ext e e'

--- a/TauCeti/AlgebraicTopology/UniversalCover/Deck/QuotientCovering.lean
+++ b/TauCeti/AlgebraicTopology/UniversalCover/Deck/QuotientCovering.lean
@@ -24,8 +24,8 @@ deck group is *equivalent* to the deck action being regular.
 
 ## Main declarations
 
-* `TauCeti.Deck.apply_eq_iff_mem_orbit`: for a regular map, two points share a projection
-  exactly when they lie in a common deck orbit.
+* `TauCeti.Deck.apply_eq_iff_mem_orbit`: when every fibre-pair is connected by a deck
+  transformation, two points share a projection exactly when they lie in a common deck orbit.
 * `TauCeti.Deck.IsRegular.isQuotientCoveringMap`: a regular, preconnected covering map is a
   quotient covering map for its deck group.
 * `TauCeti.Deck.isQuotientCoveringMap_iff_isRegular`: for a preconnected covering map, being a
@@ -46,14 +46,14 @@ namespace Deck
 variable {E B : Type*} [TopologicalSpace E] [TopologicalSpace B] {p : E → B}
 
 omit [TopologicalSpace B] in
-/-- For a map with regular deck action, two points of the total space have the same
-projection exactly when they lie in a common orbit of the deck transformation group. The
-forward direction is regularity; the converse holds because deck transformations preserve
-the projection. -/
-lemma apply_eq_iff_mem_orbit (hreg : IsRegular p) {e₁ e₂ : E} :
+/-- If every pair of points with the same projection is connected by a deck transformation,
+then two points of the total space have the same projection exactly when they lie in a common
+orbit of the deck transformation group. The reverse direction holds because deck
+transformations preserve the projection. -/
+lemma apply_eq_iff_mem_orbit
+    (hpoint : ∀ {e e' : E}, p e = p e' → ∃ φ : Deck p, φ.1 e = e') {e₁ e₂ : E} :
     p e₁ = p e₂ ↔ e₁ ∈ MulAction.orbit (Deck p) e₂ := by
-  change Setoid.ker p e₁ e₂ ↔ MulAction.orbitRel (Deck p) E e₁ e₂
-  rw [orbitRel_eq_ker_of_exists_apply_eq (isRegular_iff_exists_apply_eq.mp hreg).2]
+  rw [← MulAction.orbitRel_apply, orbitRel_eq_ker_of_exists_apply_eq hpoint, Setoid.ker_def]
 
 /-- A regular covering map with preconnected total space is a quotient covering map for its
 deck transformation group: it presents the base as the quotient `E / Deck p`. -/
@@ -61,7 +61,7 @@ theorem IsRegular.isQuotientCoveringMap [PreconnectedSpace E] (hreg : IsRegular 
     (hp : IsCoveringMap p) : IsQuotientCoveringMap p (Deck p) := by
   rw [isQuotientCoveringMap_iff_isCoveringMap_and]
   exact ⟨hp, hreg.1, inferInstance, isCancelSMul hp,
-    fun {e₁ e₂} => apply_eq_iff_mem_orbit hreg⟩
+    fun {e₁ e₂} => apply_eq_iff_mem_orbit (isRegular_iff_exists_apply_eq.mp hreg).2⟩
 
 /-- For a covering map with preconnected total space, being a quotient covering map for the
 deck transformation group is equivalent to regularity of the deck action. -/

--- a/TauCeti/AlgebraicTopology/UniversalCover/Deck/QuotientCovering.lean
+++ b/TauCeti/AlgebraicTopology/UniversalCover/Deck/QuotientCovering.lean
@@ -27,6 +27,7 @@ group and regularity of the deck action.
   have regular deck action.
 * `TauCeti.Deck.isQuotientCoveringMap_iff_isRegular`: for a preconnected covering map, being a
   quotient covering map for the deck group is equivalent to regularity of the deck action.
+* `TauCeti.IsCoveringMap.isOpenQuotientMap`: a surjective covering map is an open quotient map.
 * `TauCeti.Deck.IsRegular.isOpenQuotientMap`: a regular covering map is an open quotient map.
 
 ## References
@@ -38,9 +39,14 @@ where the quotient of the cover by the deck group is identified with the base vi
 
 namespace TauCeti
 
-namespace Deck
-
 variable {E B : Type*} [TopologicalSpace E] [TopologicalSpace B] {p : E → B}
+
+/-- A surjective covering map is an open quotient map. -/
+theorem IsCoveringMap.isOpenQuotientMap (hp : IsCoveringMap p)
+    (hsurj : Function.Surjective p) : IsOpenQuotientMap p :=
+  ⟨hsurj, hp.continuous, hp.isOpenMap⟩
+
+namespace Deck
 
 /-- A regular covering map with preconnected total space is a quotient covering map for its
 deck transformation group: it presents the base as the quotient `E / Deck p`. -/
@@ -48,7 +54,7 @@ theorem IsRegular.isQuotientCoveringMap [PreconnectedSpace E] (hreg : IsRegular 
     (hp : IsCoveringMap p) : IsQuotientCoveringMap p (Deck p) := by
   rw [isQuotientCoveringMap_iff_isCoveringMap_and]
   exact ⟨hp, hreg.1, inferInstance, isCancelSMul hp,
-    fun {e₁ e₂} => IsRegular.apply_eq_iff_mem_orbit hreg⟩
+    fun {e₁ e₂} => Deck.IsRegular.apply_eq_iff_mem_orbit hreg⟩
 
 /-- A quotient covering map for the deck transformation group has regular deck action. -/
 theorem IsQuotientCoveringMap.isRegular (h : IsQuotientCoveringMap p (Deck p)) :
@@ -67,7 +73,7 @@ theorem isQuotientCoveringMap_iff_isRegular [PreconnectedSpace E] (hp : IsCoveri
 /-- A regular covering map is an open quotient map. -/
 theorem IsRegular.isOpenQuotientMap (hreg : IsRegular p) (hp : IsCoveringMap p) :
     IsOpenQuotientMap p :=
-  ⟨hreg.1, hp.continuous, hp.isOpenMap⟩
+  TauCeti.IsCoveringMap.isOpenQuotientMap hp hreg.1
 
 end Deck
 

--- a/TauCeti/AlgebraicTopology/UniversalCover/Deck/QuotientCovering.lean
+++ b/TauCeti/AlgebraicTopology/UniversalCover/Deck/QuotientCovering.lean
@@ -15,22 +15,20 @@ quotient of `E` by the deck transformation group: `p` is a `IsQuotientCoveringMa
 `UniversalCover x₀ / π₁(X, x₀) ≃ X`, packaged so that it consumes Mathlib's quotient
 covering map theory rather than re-deriving it.
 
-The proof feeds the existing Tau Ceti deck-action API into Mathlib's
-`isQuotientCoveringMap_iff_isCoveringMap_and`: the action is free on a preconnected covering
-(`TauCeti.Deck.isCancelSMul`) and continuous (the generic subgroup instance), regularity
-gives surjectivity and the orbit characterization of fibres, and `p` is the covering map by
-hypothesis. Conversely, for a preconnected covering, being a quotient covering map for the
-deck group is *equivalent* to the deck action being regular.
+Conversely, quotient covering maps for the deck group are regular. For a preconnected
+covering map, this gives an equivalence between being a quotient covering map for the deck
+group and regularity of the deck action.
 
 ## Main declarations
 
-* `TauCeti.Deck.apply_eq_iff_mem_orbit`: when every fibre-pair is connected by a deck
-  transformation, two points share a projection exactly when they lie in a common deck orbit.
 * `TauCeti.Deck.IsRegular.isQuotientCoveringMap`: a regular, preconnected covering map is a
   quotient covering map for its deck group.
+* `TauCeti.Deck.IsQuotientCoveringMap.isRegular`: quotient covering maps for the deck group
+  have regular deck action.
 * `TauCeti.Deck.isQuotientCoveringMap_iff_isRegular`: for a preconnected covering map, being a
   quotient covering map for the deck group is equivalent to regularity of the deck action.
-* `TauCeti.Deck.IsRegular.isOpenQuotientMap`: such a covering map is an open quotient map.
+* `TauCeti.Deck.IsCoveringMap.isOpenQuotientMap`: a surjective covering map is an open quotient
+  map.
 
 ## References
 
@@ -45,38 +43,41 @@ namespace Deck
 
 variable {E B : Type*} [TopologicalSpace E] [TopologicalSpace B] {p : E → B}
 
-omit [TopologicalSpace B] in
-/-- If every pair of points with the same projection is connected by a deck transformation,
-then two points of the total space have the same projection exactly when they lie in a common
-orbit of the deck transformation group. The reverse direction holds because deck
-transformations preserve the projection. -/
-lemma apply_eq_iff_mem_orbit
-    (hpoint : ∀ {e e' : E}, p e = p e' → ∃ φ : Deck p, φ.1 e = e') {e₁ e₂ : E} :
-    p e₁ = p e₂ ↔ e₁ ∈ MulAction.orbit (Deck p) e₂ := by
-  rw [← MulAction.orbitRel_apply, orbitRel_eq_ker_of_exists_apply_eq hpoint, Setoid.ker_def]
-
 /-- A regular covering map with preconnected total space is a quotient covering map for its
 deck transformation group: it presents the base as the quotient `E / Deck p`. -/
 theorem IsRegular.isQuotientCoveringMap [PreconnectedSpace E] (hreg : IsRegular p)
     (hp : IsCoveringMap p) : IsQuotientCoveringMap p (Deck p) := by
   rw [isQuotientCoveringMap_iff_isCoveringMap_and]
   exact ⟨hp, hreg.1, inferInstance, isCancelSMul hp,
-    fun {e₁ e₂} => apply_eq_iff_mem_orbit (isRegular_iff_exists_apply_eq.mp hreg).2⟩
+    fun {e₁ e₂} => IsRegular.apply_eq_iff_mem_orbit hreg⟩
+
+/-- A quotient covering map for the deck transformation group has regular deck action. -/
+theorem IsQuotientCoveringMap.isRegular (h : IsQuotientCoveringMap p (Deck p)) :
+    IsRegular p := by
+  refine ⟨h.surjective, fun b => ⟨fun e e' => ?_⟩⟩
+  have hee : p e'.1 = p e.1 := (e'.2 : p e'.1 = b).trans (e.2 : p e.1 = b).symm
+  obtain ⟨φ, hφ⟩ := h.apply_eq_iff_mem_orbit.mp hee
+  exact ⟨φ, Subtype.ext ((fiber_smul_coe_eq_smul φ e).trans hφ)⟩
 
 /-- For a covering map with preconnected total space, being a quotient covering map for the
 deck transformation group is equivalent to regularity of the deck action. -/
 theorem isQuotientCoveringMap_iff_isRegular [PreconnectedSpace E] (hp : IsCoveringMap p) :
     IsQuotientCoveringMap p (Deck p) ↔ IsRegular p := by
-  refine ⟨fun h => ⟨h.surjective, fun b => ⟨fun e e' => ?_⟩⟩,
-    fun hreg => hreg.isQuotientCoveringMap hp⟩
-  have hee : p e'.1 = p e.1 := (e'.2 : p e'.1 = b).trans (e.2 : p e.1 = b).symm
-  obtain ⟨φ, hφ⟩ := h.apply_eq_iff_mem_orbit.mp hee
-  exact ⟨φ, Subtype.ext ((fiber_smul_coe_eq_smul φ e).trans hφ)⟩
+  exact ⟨fun h => IsQuotientCoveringMap.isRegular h, fun hreg => hreg.isQuotientCoveringMap hp⟩
+
+namespace IsCoveringMap
+
+/-- A surjective covering map is an open quotient map. -/
+theorem isOpenQuotientMap (hp : IsCoveringMap p) (hsurj : Function.Surjective p) :
+    IsOpenQuotientMap p :=
+  ⟨hsurj, hp.continuous, hp.isOpenMap⟩
+
+end IsCoveringMap
 
 /-- A regular covering map with preconnected total space is an open quotient map. -/
-theorem IsRegular.isOpenQuotientMap [PreconnectedSpace E] (hreg : IsRegular p)
-    (hp : IsCoveringMap p) : IsOpenQuotientMap p :=
-  (hreg.isQuotientCoveringMap hp).isOpenQuotientMap
+theorem IsRegular.isOpenQuotientMap (hreg : IsRegular p) (hp : IsCoveringMap p) :
+    IsOpenQuotientMap p :=
+  IsCoveringMap.isOpenQuotientMap hp hreg.1
 
 end Deck
 

--- a/TauCeti/AlgebraicTopology/UniversalCover/Deck/QuotientCovering.lean
+++ b/TauCeti/AlgebraicTopology/UniversalCover/Deck/QuotientCovering.lean
@@ -3,7 +3,7 @@ Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 -/
 import Mathlib.Topology.Covering.Quotient
-import TauCeti.AlgebraicTopology.UniversalCover.Deck.Regular
+import TauCeti.AlgebraicTopology.UniversalCover.Deck.Quotient
 
 /-!
 # A regular covering is a quotient covering map for its deck group
@@ -28,7 +28,7 @@ deck group is *equivalent* to the deck action being regular.
   exactly when they lie in a common deck orbit.
 * `TauCeti.Deck.IsRegular.isQuotientCoveringMap`: a regular, preconnected covering map is a
   quotient covering map for its deck group.
-* `TauCeti.Deck.isQuotientCoveringMap_iff`: for a preconnected covering map, being a
+* `TauCeti.Deck.isQuotientCoveringMap_iff_isRegular`: for a preconnected covering map, being a
   quotient covering map for the deck group is equivalent to regularity of the deck action.
 * `TauCeti.Deck.IsRegular.isOpenQuotientMap`: such a covering map is an open quotient map.
 
@@ -52,20 +52,11 @@ forward direction is regularity; the converse holds because deck transformations
 the projection. -/
 lemma apply_eq_iff_mem_orbit (hreg : IsRegular p) {e₁ e₂ : E} :
     p e₁ = p e₂ ↔ e₁ ∈ MulAction.orbit (Deck p) e₂ := by
-  constructor
-  · intro h
-    obtain ⟨φ, hφ⟩ := hreg.exists_apply_eq h.symm
-    exact ⟨φ, (smul_eq_apply φ e₂).trans hφ⟩
-  · rintro ⟨φ, rfl⟩
-    exact (congrArg p (smul_eq_apply φ e₂)).trans (map_proj φ e₂)
+  change Setoid.ker p e₁ e₂ ↔ MulAction.orbitRel (Deck p) E e₁ e₂
+  rw [orbitRel_eq_ker_of_exists_apply_eq (isRegular_iff_exists_apply_eq.mp hreg).2]
 
 /-- A regular covering map with preconnected total space is a quotient covering map for its
-deck transformation group: it presents the base as the quotient `E / Deck p`.
-
-This consumes Mathlib's `isQuotientCoveringMap_iff_isCoveringMap_and`. The five ingredients
-are: `p` is a covering map (hypothesis), `p` is surjective and the deck orbits are exactly
-the fibres (regularity, via `apply_eq_iff_mem_orbit`), the deck action is continuous (the
-generic subgroup instance) and free (`isCancelSMul`, using preconnectedness). -/
+deck transformation group: it presents the base as the quotient `E / Deck p`. -/
 theorem IsRegular.isQuotientCoveringMap [PreconnectedSpace E] (hreg : IsRegular p)
     (hp : IsCoveringMap p) : IsQuotientCoveringMap p (Deck p) := by
   rw [isQuotientCoveringMap_iff_isCoveringMap_and]
@@ -74,7 +65,7 @@ theorem IsRegular.isQuotientCoveringMap [PreconnectedSpace E] (hreg : IsRegular 
 
 /-- For a covering map with preconnected total space, being a quotient covering map for the
 deck transformation group is equivalent to regularity of the deck action. -/
-theorem isQuotientCoveringMap_iff [PreconnectedSpace E] (hp : IsCoveringMap p) :
+theorem isQuotientCoveringMap_iff_isRegular [PreconnectedSpace E] (hp : IsCoveringMap p) :
     IsQuotientCoveringMap p (Deck p) ↔ IsRegular p := by
   refine ⟨fun h => ⟨h.surjective, fun b => ⟨fun e e' => ?_⟩⟩,
     fun hreg => hreg.isQuotientCoveringMap hp⟩

--- a/TauCeti/AlgebraicTopology/UniversalCover/Deck/QuotientCovering.lean
+++ b/TauCeti/AlgebraicTopology/UniversalCover/Deck/QuotientCovering.lean
@@ -27,8 +27,7 @@ group and regularity of the deck action.
   have regular deck action.
 * `TauCeti.Deck.isQuotientCoveringMap_iff_isRegular`: for a preconnected covering map, being a
   quotient covering map for the deck group is equivalent to regularity of the deck action.
-* `TauCeti.Deck.IsCoveringMap.isOpenQuotientMap`: a surjective covering map is an open quotient
-  map.
+* `TauCeti.Deck.IsRegular.isOpenQuotientMap`: a regular covering map is an open quotient map.
 
 ## References
 
@@ -65,19 +64,10 @@ theorem isQuotientCoveringMap_iff_isRegular [PreconnectedSpace E] (hp : IsCoveri
     IsQuotientCoveringMap p (Deck p) ↔ IsRegular p := by
   exact ⟨fun h => IsQuotientCoveringMap.isRegular h, fun hreg => hreg.isQuotientCoveringMap hp⟩
 
-namespace IsCoveringMap
-
-/-- A surjective covering map is an open quotient map. -/
-theorem isOpenQuotientMap (hp : IsCoveringMap p) (hsurj : Function.Surjective p) :
-    IsOpenQuotientMap p :=
-  ⟨hsurj, hp.continuous, hp.isOpenMap⟩
-
-end IsCoveringMap
-
-/-- A regular covering map with preconnected total space is an open quotient map. -/
+/-- A regular covering map is an open quotient map. -/
 theorem IsRegular.isOpenQuotientMap (hreg : IsRegular p) (hp : IsCoveringMap p) :
     IsOpenQuotientMap p :=
-  IsCoveringMap.isOpenQuotientMap hp hreg.1
+  ⟨hreg.1, hp.continuous, hp.isOpenMap⟩
 
 end Deck
 

--- a/TauCeti/AlgebraicTopology/UniversalCover/Deck/QuotientCovering.lean
+++ b/TauCeti/AlgebraicTopology/UniversalCover/Deck/QuotientCovering.lean
@@ -1,0 +1,92 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+import Mathlib.Topology.Covering.Quotient
+import TauCeti.AlgebraicTopology.UniversalCover.Deck.Regular
+
+/-!
+# A regular covering is a quotient covering map for its deck group
+
+For a covering map `p : E → B` with preconnected total space whose deck action is regular
+(surjective, with `Deck p` acting transitively on every fibre), `p` exhibits `B` as the
+quotient of `E` by the deck transformation group: `p` is a `IsQuotientCoveringMap` for
+`Deck p`. This is the deck-side formulation of the universal-covers roadmap statement that
+`UniversalCover x₀ / π₁(X, x₀) ≃ X`, packaged so that it consumes Mathlib's quotient
+covering map theory rather than re-deriving it.
+
+The proof feeds the existing Tau Ceti deck-action API into Mathlib's
+`isQuotientCoveringMap_iff_isCoveringMap_and`: the action is free on a preconnected covering
+(`TauCeti.Deck.isCancelSMul`) and continuous (the generic subgroup instance), regularity
+gives surjectivity and the orbit characterization of fibres, and `p` is the covering map by
+hypothesis. Conversely, for a preconnected covering, being a quotient covering map for the
+deck group is *equivalent* to the deck action being regular.
+
+## Main declarations
+
+* `TauCeti.Deck.apply_eq_iff_mem_orbit`: for a regular map, two points share a projection
+  exactly when they lie in a common deck orbit.
+* `TauCeti.Deck.IsRegular.isQuotientCoveringMap`: a regular, preconnected covering map is a
+  quotient covering map for its deck group.
+* `TauCeti.Deck.isQuotientCoveringMap_iff`: for a preconnected covering map, being a
+  quotient covering map for the deck group is equivalent to regularity of the deck action.
+* `TauCeti.Deck.IsRegular.isOpenQuotientMap`: such a covering map is an open quotient map.
+
+## References
+
+This supplies a prerequisite for the Tau Ceti universal-covers roadmap, Stages 0.3 and 1,
+where the quotient of the cover by the deck group is identified with the base via Mathlib's
+`IsQuotientCoveringMap` (`Mathlib/Topology/Covering/Quotient.lean`).
+-/
+
+namespace TauCeti
+
+namespace Deck
+
+variable {E B : Type*} [TopologicalSpace E] [TopologicalSpace B] {p : E → B}
+
+omit [TopologicalSpace B] in
+/-- For a map with regular deck action, two points of the total space have the same
+projection exactly when they lie in a common orbit of the deck transformation group. The
+forward direction is regularity; the converse holds because deck transformations preserve
+the projection. -/
+lemma apply_eq_iff_mem_orbit (hreg : IsRegular p) {e₁ e₂ : E} :
+    p e₁ = p e₂ ↔ e₁ ∈ MulAction.orbit (Deck p) e₂ := by
+  constructor
+  · intro h
+    obtain ⟨φ, hφ⟩ := hreg.exists_apply_eq h.symm
+    exact ⟨φ, (smul_eq_apply φ e₂).trans hφ⟩
+  · rintro ⟨φ, rfl⟩
+    exact (congrArg p (smul_eq_apply φ e₂)).trans (map_proj φ e₂)
+
+/-- A regular covering map with preconnected total space is a quotient covering map for its
+deck transformation group: it presents the base as the quotient `E / Deck p`.
+
+This consumes Mathlib's `isQuotientCoveringMap_iff_isCoveringMap_and`. The five ingredients
+are: `p` is a covering map (hypothesis), `p` is surjective and the deck orbits are exactly
+the fibres (regularity, via `apply_eq_iff_mem_orbit`), the deck action is continuous (the
+generic subgroup instance) and free (`isCancelSMul`, using preconnectedness). -/
+theorem IsRegular.isQuotientCoveringMap [PreconnectedSpace E] (hreg : IsRegular p)
+    (hp : IsCoveringMap p) : IsQuotientCoveringMap p (Deck p) := by
+  rw [isQuotientCoveringMap_iff_isCoveringMap_and]
+  exact ⟨hp, hreg.1, inferInstance, isCancelSMul hp,
+    fun {e₁ e₂} => apply_eq_iff_mem_orbit hreg⟩
+
+/-- For a covering map with preconnected total space, being a quotient covering map for the
+deck transformation group is equivalent to regularity of the deck action. -/
+theorem isQuotientCoveringMap_iff [PreconnectedSpace E] (hp : IsCoveringMap p) :
+    IsQuotientCoveringMap p (Deck p) ↔ IsRegular p := by
+  refine ⟨fun h => ⟨h.surjective, fun b => ⟨fun e e' => ?_⟩⟩,
+    fun hreg => hreg.isQuotientCoveringMap hp⟩
+  have hee : p e'.1 = p e.1 := (e'.2 : p e'.1 = b).trans (e.2 : p e.1 = b).symm
+  obtain ⟨φ, hφ⟩ := h.apply_eq_iff_mem_orbit.mp hee
+  exact ⟨φ, Subtype.ext ((fiber_smul_coe_eq_smul φ e).trans hφ)⟩
+
+/-- A regular covering map with preconnected total space is an open quotient map. -/
+theorem IsRegular.isOpenQuotientMap [PreconnectedSpace E] (hreg : IsRegular p)
+    (hp : IsCoveringMap p) : IsOpenQuotientMap p :=
+  (hreg.isQuotientCoveringMap hp).isOpenQuotientMap
+
+end Deck
+
+end TauCeti


### PR DESCRIPTION
This PR identifies a regular, preconnected covering map with the quotient of its total space by the deck transformation group. For `p : E → B` a covering map with `[PreconnectedSpace E]` whose deck action is regular (surjective, with `Deck p` acting transitively on every fibre), it proves `IsQuotientCoveringMap p (Deck p)`, the deck-side form of the universal-covers statement that `UniversalCover x₀ / π₁(X, x₀) ≃ X`. It adds the orbit characterization of fibres `apply_eq_iff_mem_orbit`, the construction `IsRegular.isQuotientCoveringMap`, the full equivalence `isQuotientCoveringMap_iff` (for a preconnected covering, being a quotient covering map for the deck group is equivalent to regularity), and the corollary `IsRegular.isOpenQuotientMap`.

This advances `TauCetiRoadmap/UniversalCovers/README.md`, Stage 0.3 (the deck action packaged via Mathlib's `IsQuotientCoveringMap`) and Stage 1 (`UniversalCover x₀ / π₁(X, x₀) ≃ X` follows via that machinery). The proof consumes Mathlib's `isQuotientCoveringMap_iff_isCoveringMap_and` (`Mathlib/Topology/Covering/Quotient.lean`, by Junyan Xu) and builds on the existing Tau Ceti deck-action API (`Deck.isCancelSMul`, `Deck.IsRegular`, `Deck.fiber_smul_coe_eq_smul`) rather than re-deriving quotient-cover facts.

<!--tauceti-target:v1 {"focus":"UniversalCovers","id":"deck-isquotientcoveringmap"}-->

🤖 Prepared with Claude Code
