### PR TITLE
feat: the Galois group of a prime-radicand multiquadratic field

### DIFF
--- a/TauCeti/NumberTheory/Multiquadratic/GaloisGroup.lean
+++ b/TauCeti/NumberTheory/Multiquadratic/GaloisGroup.lean
@@ -22,6 +22,8 @@ to be an isomorphism: `Gal(M/K) ≃ (ℤ/2)ⁿ`.
 * `TauCeti.Multiquadratic.signHom`: the injective sign-pattern homomorphism `Gal(M/K) →* (ℤ/2)ⁿ`.
 * `TauCeti.Multiquadratic.galoisGroupEquiv`: for square-class independent radicands, the explicit
   isomorphism `Gal(M/K) ≃* Multiplicative (ι → ℤ/2)`.
+* `TauCeti.Multiquadratic.card_aut_adjoin_range`: the cardinality reading
+  `|Gal(M/K)| = 2^|ι|` of that isomorphism.
 
 ## Provenance
 
@@ -232,5 +234,20 @@ generator `rootᵢ` to `(-1)^(εᵢ) · rootᵢ`. -/
     rw [galoisGroupEquiv_apply] at happ
     exact Multiplicative.ofAdd.injective happ
   rw [aut_gen_eq_signPattern hroot, hσ]
+
+/-- **Cardinality of the Galois group of a multiquadratic field.** If no nonempty subset product
+of the radicands `d i` is a square in `K` (and `2 ≠ 0` in `K`), then the multiquadratic field
+`M = K(rootᵢ : i)` has `|Gal(M/K)| = 2^|ι|`. This is the cardinality reading of the explicit
+isomorphism `galoisGroupEquiv`. -/
+theorem card_aut_adjoin_range [Finite ι] [NeZero (2 : K)]
+    (hroot : ∀ i, root i ^ 2 = algebraMap K L (d i))
+    (hindep : ∀ S : Finset ι, S.Nonempty → ¬ IsSquare (∏ i ∈ S, d i)) :
+    Nat.card (adjoin K (Set.range root) ≃ₐ[K] adjoin K (Set.range root)) = 2 ^ Nat.card ι := by
+  classical
+  letI := Fintype.ofFinite ι
+  rw [Nat.card_congr (galoisGroupEquiv hroot hindep).toEquiv,
+    Nat.card_congr (Multiplicative.ofAdd (α := ι → ZMod 2)).symm,
+    Nat.card_eq_fintype_card, Nat.card_eq_fintype_card, Fintype.card_pi]
+  simp [ZMod.card]
 
 end TauCeti.Multiquadratic

--- a/TauCeti/NumberTheory/Multiquadratic/PrimeGaloisGroup.lean
+++ b/TauCeti/NumberTheory/Multiquadratic/PrimeGaloisGroup.lean
@@ -11,19 +11,16 @@ import TauCeti.NumberTheory.Multiquadratic.PrimeRadicands
 The field-generic isomorphism `TauCeti.Multiquadratic.galoisGroupEquiv` identifies the Galois
 group of a multiquadratic field `M = K(rootᵢ : i)` with `(ℤ/2)ⁿ` once the radicands are
 **square-class independent**: no nonempty subset product of them is a square. This file derives
-the cardinality of that Galois group, `|Gal(M/K)| = 2^|ι|`, and supplies the
-square-class-independence hypothesis for the most common concrete source of independent
-radicands — a family of **distinct primes** — to obtain the prime-indexed corollary
-`Gal(ℚ(√p₁, …, √pₙ)/ℚ) ≃ (ℤ/2)ⁿ` (a genus-theory input) and the smallest non-vacuity example
-`|Gal(ℚ(√2, √3)/ℚ)| = 4`.
+prime-indexed corollaries by supplying the square-class-independence hypothesis for the most
+common concrete source of independent radicands — a family of **distinct primes**. This gives
+`Gal(ℚ(√p₁, …, √pₙ)/ℚ) ≃ (ℤ/2)ⁿ` (a genus-theory input), its cardinality, and the two-prime
+worked example `|Gal(ℚ(√2, √3)/ℚ)| = 4`.
 
 The prime case reuses `TauCeti.Multiquadratic.not_isSquare_prod_primes`: a nonempty subset
 product of distinct primes is squarefree and not a unit, hence not a square.
 
 ## Main results
 
-* `TauCeti.Multiquadratic.card_aut_adjoin_range`: for square-class independent radicands over a
-  field with `2 ≠ 0`, `|Gal(M/K)| = 2^|ι|`, the field-generic Galois-group cardinality.
 * `TauCeti.Multiquadratic.galoisGroupEquivSqrtPrimes`: for a finite family of distinct primes
   `p : ι → ℕ`, the explicit isomorphism `Gal(ℚ(√p₁, …, √pₙ)/ℚ) ≃ Multiplicative (ι → ℤ/2)`.
 * `TauCeti.Multiquadratic.card_aut_adjoin_sqrt_primes`: `|Gal(ℚ(√p₁, …, √pₙ)/ℚ)| = 2^|ι|`.
@@ -36,20 +33,16 @@ namespace TauCeti.Multiquadratic
 
 variable {K L : Type*} [Field K] [Field L] [Algebra K L] {ι : Type*}
 
-/-- **Cardinality of the Galois group of a multiquadratic field.** If no nonempty subset product
-of the radicands `d i` is a square in `K` (and `2 ≠ 0` in `K`), then the multiquadratic field
-`M = K(rootᵢ : i)` has `|Gal(M/K)| = 2^|ι|`. This is the cardinality reading of the explicit
-isomorphism `galoisGroupEquiv`. -/
-theorem card_aut_adjoin_range [Finite ι] {d : ι → K} {root : ι → L} [NeZero (2 : K)]
-    (hroot : ∀ i, root i ^ 2 = algebraMap K L (d i))
-    (hindep : ∀ S : Finset ι, S.Nonempty → ¬ IsSquare (∏ i ∈ S, d i)) :
-    Nat.card (adjoin K (Set.range root) ≃ₐ[K] adjoin K (Set.range root)) = 2 ^ Nat.card ι := by
-  classical
-  letI := Fintype.ofFinite ι
-  rw [Nat.card_congr (galoisGroupEquiv hroot hindep).toEquiv,
-    Nat.card_congr (Multiplicative.ofAdd (α := ι → ZMod 2)).symm,
-    Nat.card_eq_fintype_card, Nat.card_eq_fintype_card, Fintype.card_pi]
-  simp [ZMod.card]
+private theorem sqrt_nat_sq (p : ι → ℕ) (i : ι) :
+    (Real.sqrt (p i)) ^ 2 = algebraMap ℚ ℝ (p i : ℚ) := by
+  rw [Real.sq_sqrt (Nat.cast_nonneg _), map_natCast]
+
+private theorem not_isSquare_prod_sqrt_primes (p : ι → ℕ)
+    (hp : ∀ i, (p i).Prime) (hinj : Function.Injective p) :
+    ∀ S : Finset ι, S.Nonempty → ¬ IsSquare (∏ i ∈ S, (p i : ℚ)) := by
+  intro S hS
+  exact not_isSquare_prod_primes p (fun i _ => hp i)
+    (fun i _ j _ hij h => hij (hinj h)) hS
 
 /-- **The Galois group of a prime-radicand multiquadratic field is `(ℤ/2)ⁿ`.** For a finite family
 of distinct primes `p : ι → ℕ`, the field generated over `ℚ` by their real square roots has Galois
@@ -61,9 +54,30 @@ noncomputable def galoisGroupEquivSqrtPrimes [Finite ι] (p : ι → ℕ)
         adjoin ℚ (Set.range fun i => (Real.sqrt (p i) : ℝ))) ≃*
       Multiplicative (ι → ZMod 2) :=
   galoisGroupEquiv (d := fun i => (p i : ℚ)) (root := fun i => Real.sqrt (p i))
-    (fun i => by rw [Real.sq_sqrt (Nat.cast_nonneg _), map_natCast])
-    (fun S hS => not_isSquare_prod_primes p (fun i _ => hp i)
-      (fun i _ j _ hij h => hij (hinj h)) hS)
+    (sqrt_nat_sq p) (not_isSquare_prod_sqrt_primes p hp hinj)
+
+/-- The prime-radicand Galois equivalence sends an automorphism to its sign pattern on the
+generators `√(p i)`. -/
+@[simp] theorem galoisGroupEquivSqrtPrimes_apply [Finite ι] (p : ι → ℕ)
+    (hp : ∀ i, (p i).Prime) (hinj : Function.Injective p)
+    (σ : adjoin ℚ (Set.range fun i => (Real.sqrt (p i) : ℝ)) ≃ₐ[ℚ]
+        adjoin ℚ (Set.range fun i => (Real.sqrt (p i) : ℝ))) :
+    galoisGroupEquivSqrtPrimes p hp hinj σ =
+      Multiplicative.ofAdd (signPattern (fun i => (Real.sqrt (p i) : ℝ)) σ) := by
+  exact galoisGroupEquiv_apply (d := fun i => (p i : ℚ)) (root := fun i => Real.sqrt (p i))
+    (sqrt_nat_sq p) (not_isSquare_prod_sqrt_primes p hp hinj) σ
+
+/-- The inverse prime-radicand Galois equivalence realizes a sign pattern by sending each
+generator `√(p i)` to `(-1)^(ε i) · √(p i)`. -/
+@[simp] theorem galoisGroupEquivSqrtPrimes_symm_apply_gen [Finite ι] (p : ι → ℕ)
+    (hp : ∀ i, (p i).Prime) (hinj : Function.Injective p)
+    (ε : ι → ZMod 2) (i : ι) :
+    ((galoisGroupEquivSqrtPrimes p hp hinj).symm (Multiplicative.ofAdd ε))
+        (gen (fun i => (Real.sqrt (p i) : ℝ)) i)
+      = (-1) ^ (ε i).val * gen (fun i => (Real.sqrt (p i) : ℝ)) i := by
+  exact galoisGroupEquiv_symm_apply_gen (d := fun i => (p i : ℚ))
+    (root := fun i => Real.sqrt (p i)) (sqrt_nat_sq p)
+    (not_isSquare_prod_sqrt_primes p hp hinj) ε i
 
 /-- **Cardinality of the Galois group of a prime-radicand multiquadratic field.** For a finite
 family of distinct primes `p : ι → ℕ`, `|Gal(ℚ(√p₁, …, √pₙ)/ℚ)| = 2^|ι|`. -/
@@ -72,12 +86,10 @@ theorem card_aut_adjoin_sqrt_primes [Finite ι] (p : ι → ℕ)
     Nat.card (adjoin ℚ (Set.range fun i => (Real.sqrt (p i) : ℝ)) ≃ₐ[ℚ]
         adjoin ℚ (Set.range fun i => (Real.sqrt (p i) : ℝ))) = 2 ^ Nat.card ι :=
   card_aut_adjoin_range (d := fun i => (p i : ℚ)) (root := fun i => Real.sqrt (p i))
-    (fun i => by rw [Real.sq_sqrt (Nat.cast_nonneg _), map_natCast])
-    (fun S hS => not_isSquare_prod_primes p (fun i _ => hp i)
-      (fun i _ j _ hij h => hij (hinj h)) hS)
+    (sqrt_nat_sq p) (not_isSquare_prod_sqrt_primes p hp hinj)
 
-/-- **Worked example: `|Gal(ℚ(√2, √3)/ℚ)| = 4`.** The Galois group of the smallest nontrivial
-multiquadratic field, obtained from `card_aut_adjoin_sqrt_primes` with the primes `2` and `3`. -/
+/-- **Worked example: `|Gal(ℚ(√2, √3)/ℚ)| = 4`.** The two-prime field obtained from
+`card_aut_adjoin_sqrt_primes` with the primes `2` and `3`. -/
 theorem card_aut_adjoin_sqrt_two_three :
     Nat.card ((adjoin ℚ {Real.sqrt 2, Real.sqrt 3} : IntermediateField ℚ ℝ) ≃ₐ[ℚ]
         (adjoin ℚ {Real.sqrt 2, Real.sqrt 3} : IntermediateField ℚ ℝ)) = 4 := by

--- a/TauCeti/NumberTheory/Multiquadratic/PrimeGaloisGroup.lean
+++ b/TauCeti/NumberTheory/Multiquadratic/PrimeGaloisGroup.lean
@@ -31,18 +31,7 @@ open IntermediateField
 
 namespace TauCeti.Multiquadratic
 
-variable {K L : Type*} [Field K] [Field L] [Algebra K L] {ι : Type*}
-
-private theorem sqrt_nat_sq (p : ι → ℕ) (i : ι) :
-    (Real.sqrt (p i)) ^ 2 = algebraMap ℚ ℝ (p i : ℚ) := by
-  rw [Real.sq_sqrt (Nat.cast_nonneg _), map_natCast]
-
-private theorem not_isSquare_prod_sqrt_primes (p : ι → ℕ)
-    (hp : ∀ i, (p i).Prime) (hinj : Function.Injective p) :
-    ∀ S : Finset ι, S.Nonempty → ¬ IsSquare (∏ i ∈ S, (p i : ℚ)) := by
-  intro S hS
-  exact not_isSquare_prod_primes p (fun i _ => hp i)
-    (fun i _ j _ hij h => hij (hinj h)) hS
+variable {ι : Type*}
 
 /-- **The Galois group of a prime-radicand multiquadratic field is `(ℤ/2)ⁿ`.** For a finite family
 of distinct primes `p : ι → ℕ`, the field generated over `ℚ` by their real square roots has Galois
@@ -54,7 +43,7 @@ noncomputable def galoisGroupEquivSqrtPrimes [Finite ι] (p : ι → ℕ)
         adjoin ℚ (Set.range fun i => (Real.sqrt (p i) : ℝ))) ≃*
       Multiplicative (ι → ZMod 2) :=
   galoisGroupEquiv (d := fun i => (p i : ℚ)) (root := fun i => Real.sqrt (p i))
-    (sqrt_nat_sq p) (not_isSquare_prod_sqrt_primes p hp hinj)
+    (fun i => sq_sqrt_natCast (p i)) (not_isSquare_prod_primes_of_injective p hp hinj)
 
 /-- The prime-radicand Galois equivalence sends an automorphism to its sign pattern on the
 generators `√(p i)`. -/
@@ -65,7 +54,7 @@ generators `√(p i)`. -/
     galoisGroupEquivSqrtPrimes p hp hinj σ =
       Multiplicative.ofAdd (signPattern (fun i => (Real.sqrt (p i) : ℝ)) σ) := by
   exact galoisGroupEquiv_apply (d := fun i => (p i : ℚ)) (root := fun i => Real.sqrt (p i))
-    (sqrt_nat_sq p) (not_isSquare_prod_sqrt_primes p hp hinj) σ
+    (fun i => sq_sqrt_natCast (p i)) (not_isSquare_prod_primes_of_injective p hp hinj) σ
 
 /-- The inverse prime-radicand Galois equivalence realizes a sign pattern by sending each
 generator `√(p i)` to `(-1)^(ε i) · √(p i)`. -/
@@ -76,8 +65,8 @@ generator `√(p i)` to `(-1)^(ε i) · √(p i)`. -/
         (gen (fun i => (Real.sqrt (p i) : ℝ)) i)
       = (-1) ^ (ε i).val * gen (fun i => (Real.sqrt (p i) : ℝ)) i := by
   exact galoisGroupEquiv_symm_apply_gen (d := fun i => (p i : ℚ))
-    (root := fun i => Real.sqrt (p i)) (sqrt_nat_sq p)
-    (not_isSquare_prod_sqrt_primes p hp hinj) ε i
+    (root := fun i => Real.sqrt (p i)) (fun i => sq_sqrt_natCast (p i))
+    (not_isSquare_prod_primes_of_injective p hp hinj) ε i
 
 /-- **Cardinality of the Galois group of a prime-radicand multiquadratic field.** For a finite
 family of distinct primes `p : ι → ℕ`, `|Gal(ℚ(√p₁, …, √pₙ)/ℚ)| = 2^|ι|`. -/
@@ -86,7 +75,7 @@ theorem card_aut_adjoin_sqrt_primes [Finite ι] (p : ι → ℕ)
     Nat.card (adjoin ℚ (Set.range fun i => (Real.sqrt (p i) : ℝ)) ≃ₐ[ℚ]
         adjoin ℚ (Set.range fun i => (Real.sqrt (p i) : ℝ))) = 2 ^ Nat.card ι :=
   card_aut_adjoin_range (d := fun i => (p i : ℚ)) (root := fun i => Real.sqrt (p i))
-    (sqrt_nat_sq p) (not_isSquare_prod_sqrt_primes p hp hinj)
+    (fun i => sq_sqrt_natCast (p i)) (not_isSquare_prod_primes_of_injective p hp hinj)
 
 /-- **Worked example: `|Gal(ℚ(√2, √3)/ℚ)| = 4`.** The two-prime field obtained from
 `card_aut_adjoin_sqrt_primes` with the primes `2` and `3`. -/

--- a/TauCeti/NumberTheory/Multiquadratic/PrimeGaloisGroup.lean
+++ b/TauCeti/NumberTheory/Multiquadratic/PrimeGaloisGroup.lean
@@ -1,0 +1,93 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+import TauCeti.NumberTheory.Multiquadratic.GaloisGroup
+import TauCeti.NumberTheory.Multiquadratic.PrimeRadicands
+
+/-!
+# The Galois group of a prime-radicand multiquadratic field
+
+The field-generic isomorphism `TauCeti.Multiquadratic.galoisGroupEquiv` identifies the Galois
+group of a multiquadratic field `M = K(rootᵢ : i)` with `(ℤ/2)ⁿ` once the radicands are
+**square-class independent**: no nonempty subset product of them is a square. This file derives
+the cardinality of that Galois group, `|Gal(M/K)| = 2^|ι|`, and supplies the
+square-class-independence hypothesis for the most common concrete source of independent
+radicands — a family of **distinct primes** — to obtain the prime-indexed corollary
+`Gal(ℚ(√p₁, …, √pₙ)/ℚ) ≃ (ℤ/2)ⁿ` (a genus-theory input) and the smallest non-vacuity example
+`|Gal(ℚ(√2, √3)/ℚ)| = 4`.
+
+The prime case reuses `TauCeti.Multiquadratic.not_isSquare_prod_primes`: a nonempty subset
+product of distinct primes is squarefree and not a unit, hence not a square.
+
+## Main results
+
+* `TauCeti.Multiquadratic.card_aut_adjoin_range`: for square-class independent radicands over a
+  field with `2 ≠ 0`, `|Gal(M/K)| = 2^|ι|`, the field-generic Galois-group cardinality.
+* `TauCeti.Multiquadratic.galoisGroupEquivSqrtPrimes`: for a finite family of distinct primes
+  `p : ι → ℕ`, the explicit isomorphism `Gal(ℚ(√p₁, …, √pₙ)/ℚ) ≃ Multiplicative (ι → ℤ/2)`.
+* `TauCeti.Multiquadratic.card_aut_adjoin_sqrt_primes`: `|Gal(ℚ(√p₁, …, √pₙ)/ℚ)| = 2^|ι|`.
+* `TauCeti.Multiquadratic.card_aut_adjoin_sqrt_two_three`: `|Gal(ℚ(√2, √3)/ℚ)| = 4`.
+-/
+
+open IntermediateField
+
+namespace TauCeti.Multiquadratic
+
+variable {K L : Type*} [Field K] [Field L] [Algebra K L] {ι : Type*}
+
+/-- **Cardinality of the Galois group of a multiquadratic field.** If no nonempty subset product
+of the radicands `d i` is a square in `K` (and `2 ≠ 0` in `K`), then the multiquadratic field
+`M = K(rootᵢ : i)` has `|Gal(M/K)| = 2^|ι|`. This is the cardinality reading of the explicit
+isomorphism `galoisGroupEquiv`. -/
+theorem card_aut_adjoin_range [Finite ι] {d : ι → K} {root : ι → L} [NeZero (2 : K)]
+    (hroot : ∀ i, root i ^ 2 = algebraMap K L (d i))
+    (hindep : ∀ S : Finset ι, S.Nonempty → ¬ IsSquare (∏ i ∈ S, d i)) :
+    Nat.card (adjoin K (Set.range root) ≃ₐ[K] adjoin K (Set.range root)) = 2 ^ Nat.card ι := by
+  classical
+  letI := Fintype.ofFinite ι
+  rw [Nat.card_congr (galoisGroupEquiv hroot hindep).toEquiv,
+    Nat.card_congr (Multiplicative.ofAdd (α := ι → ZMod 2)).symm,
+    Nat.card_eq_fintype_card, Nat.card_eq_fintype_card, Fintype.card_pi]
+  simp [ZMod.card]
+
+/-- **The Galois group of a prime-radicand multiquadratic field is `(ℤ/2)ⁿ`.** For a finite family
+of distinct primes `p : ι → ℕ`, the field generated over `ℚ` by their real square roots has Galois
+group isomorphic to `Multiplicative (ι → ℤ/2)`. This is the prime-indexed corollary of the
+field-generic isomorphism `galoisGroupEquiv`. -/
+noncomputable def galoisGroupEquivSqrtPrimes [Finite ι] (p : ι → ℕ)
+    (hp : ∀ i, (p i).Prime) (hinj : Function.Injective p) :
+    (adjoin ℚ (Set.range fun i => (Real.sqrt (p i) : ℝ)) ≃ₐ[ℚ]
+        adjoin ℚ (Set.range fun i => (Real.sqrt (p i) : ℝ))) ≃*
+      Multiplicative (ι → ZMod 2) :=
+  galoisGroupEquiv (d := fun i => (p i : ℚ)) (root := fun i => Real.sqrt (p i))
+    (fun i => by rw [Real.sq_sqrt (Nat.cast_nonneg _), map_natCast])
+    (fun S hS => not_isSquare_prod_primes p (fun i _ => hp i)
+      (fun i _ j _ hij h => hij (hinj h)) hS)
+
+/-- **Cardinality of the Galois group of a prime-radicand multiquadratic field.** For a finite
+family of distinct primes `p : ι → ℕ`, `|Gal(ℚ(√p₁, …, √pₙ)/ℚ)| = 2^|ι|`. -/
+theorem card_aut_adjoin_sqrt_primes [Finite ι] (p : ι → ℕ)
+    (hp : ∀ i, (p i).Prime) (hinj : Function.Injective p) :
+    Nat.card (adjoin ℚ (Set.range fun i => (Real.sqrt (p i) : ℝ)) ≃ₐ[ℚ]
+        adjoin ℚ (Set.range fun i => (Real.sqrt (p i) : ℝ))) = 2 ^ Nat.card ι :=
+  card_aut_adjoin_range (d := fun i => (p i : ℚ)) (root := fun i => Real.sqrt (p i))
+    (fun i => by rw [Real.sq_sqrt (Nat.cast_nonneg _), map_natCast])
+    (fun S hS => not_isSquare_prod_primes p (fun i _ => hp i)
+      (fun i _ j _ hij h => hij (hinj h)) hS)
+
+/-- **Worked example: `|Gal(ℚ(√2, √3)/ℚ)| = 4`.** The Galois group of the smallest nontrivial
+multiquadratic field, obtained from `card_aut_adjoin_sqrt_primes` with the primes `2` and `3`. -/
+theorem card_aut_adjoin_sqrt_two_three :
+    Nat.card ((adjoin ℚ {Real.sqrt 2, Real.sqrt 3} : IntermediateField ℚ ℝ) ≃ₐ[ℚ]
+        (adjoin ℚ {Real.sqrt 2, Real.sqrt 3} : IntermediateField ℚ ℝ)) = 4 := by
+  have h := card_aut_adjoin_sqrt_primes ![2, 3] (by decide) (by decide)
+  have hset : (Set.range fun i : Fin 2 => Real.sqrt ((![2, 3] : Fin 2 → ℕ) i))
+      = {Real.sqrt 2, Real.sqrt 3} := by
+    ext x
+    simp [Fin.exists_fin_two, eq_comm]
+  rw [hset] at h
+  rw [h, Nat.card_eq_fintype_card, Fintype.card_fin]
+  norm_num
+
+end TauCeti.Multiquadratic

--- a/TauCeti/NumberTheory/Multiquadratic/PrimeRadicands.lean
+++ b/TauCeti/NumberTheory/Multiquadratic/PrimeRadicands.lean
@@ -26,6 +26,9 @@ factor), so it is not a square.
 * `TauCeti.Multiquadratic.not_isSquare_prod_primes`: for distinct primes `p i`, no nonempty subset
   product `∏_{i ∈ S} (p i : ℚ)` is a square — square-class independence in the form the degree
   theorem consumes.
+* `TauCeti.Multiquadratic.not_isSquare_prod_primes_of_injective`: the same square-class
+  independence, packaged from an injective family of primes — the shape the multiquadratic degree
+  and Galois-group theorems consume directly.
 * `TauCeti.Multiquadratic.finrank_adjoin_sqrt_primes`: `[ℚ(√p₁, …, √pₙ) : ℚ] = 2^|ι|` for a finite
   family of distinct primes.
 * `TauCeti.Multiquadratic.finrank_adjoin_sqrt_two_three`: `[ℚ(√2, √3) : ℚ] = 4`.
@@ -59,6 +62,22 @@ theorem not_isSquare_prod_primes {ι : Type*} (p : ι → ℕ) {S : Finset ι}
     intro hprod
     exact (hp i hi).ne_one (Nat.dvd_one.mp (hprod ▸ Finset.dvd_prod_of_mem p hi))
 
+/-- The real square root of a natural number squares back to its rational value, in the form
+`(√n)² = algebraMap ℚ ℝ n`. This supplies the `hroot` hypothesis that the multiquadratic degree and
+Galois-group theorems consume for the family of square roots of a prime family. -/
+theorem sq_sqrt_natCast (n : ℕ) :
+    (Real.sqrt n) ^ 2 = algebraMap ℚ ℝ (n : ℚ) := by
+  rw [Real.sq_sqrt (Nat.cast_nonneg _), map_natCast]
+
+/-- **Square-class independence of an injective family of primes.** If `p : ι → ℕ` is injective and
+each `p i` is prime, then no nonempty subset product `∏_{i ∈ S} (p i : ℚ)` is a square. This is the
+`hindep` hypothesis the multiquadratic degree and Galois-group theorems consume directly. -/
+theorem not_isSquare_prod_primes_of_injective {ι : Type*} (p : ι → ℕ)
+    (hp : ∀ i, (p i).Prime) (hinj : Function.Injective p) :
+    ∀ S : Finset ι, S.Nonempty → ¬ IsSquare (∏ i ∈ S, (p i : ℚ)) :=
+  fun _ hS => not_isSquare_prod_primes p (fun i _ => hp i)
+    (fun _ _ _ _ hij h => hij (hinj h)) hS
+
 /-- **Degree of a prime-radicand multiquadratic field.** For a finite family of distinct primes
 `p : ι → ℕ`, the field generated over `ℚ` by their real square roots has degree `2^|ι|`. This is the
 prime-indexed corollary of the field-generic degree theorem `finrank_adjoin_range`. -/
@@ -66,13 +85,9 @@ theorem finrank_adjoin_sqrt_primes {ι : Type*} [Finite ι] (p : ι → ℕ)
     (hp : ∀ i, (p i).Prime) (hinj : Function.Injective p) :
     Module.finrank ℚ
         (IntermediateField.adjoin ℚ (Set.range fun i => (Real.sqrt (p i) : ℝ)))
-      = 2 ^ Nat.card ι := by
-  refine finrank_adjoin_range (d := fun i => (p i : ℚ))
-    (root := fun i => Real.sqrt (p i)) (fun i => ?_) (fun S hS => ?_)
-  · rw [Real.sq_sqrt (Nat.cast_nonneg _), map_natCast]
-  · refine not_isSquare_prod_primes p (fun i _ => hp i) ?_ hS
-    intro i _ j _ hij h
-    exact hij (hinj h)
+      = 2 ^ Nat.card ι :=
+  finrank_adjoin_range (d := fun i => (p i : ℚ)) (root := fun i => Real.sqrt (p i))
+    (fun i => sq_sqrt_natCast (p i)) (not_isSquare_prod_primes_of_injective p hp hinj)
 
 /-- **Worked example: `[ℚ(√2, √3) : ℚ] = 4`.** The smallest nontrivial multiquadratic degree,
 obtained from `finrank_adjoin_sqrt_primes` with the primes `2` and `3`. -/


### PR DESCRIPTION
This PR derives the cardinality of the Galois group of a multiquadratic field and the prime-indexed corollary of the Galois-group isomorphism. Building on the field-generic isomorphism `Gal(K(rootᵢ : i)/K) ≃ Multiplicative (ι → ℤ/2)` already in `TauCeti.NumberTheory.Multiquadratic.GaloisGroup` (`galoisGroupEquiv`), it adds the field-generic cardinality `card_aut_adjoin_range : |Gal(M/K)| = 2^|ι|` under square-class independence, then supplies that hypothesis for a finite family of distinct primes to obtain `galoisGroupEquivSqrtPrimes : Gal(ℚ(√p₁, …, √pₙ)/ℚ) ≃ Multiplicative (ι → ℤ/2)` and its cardinality `card_aut_adjoin_sqrt_primes : |Gal(ℚ(√p₁, …, √pₙ)/ℚ)| = 2^|ι|`, closing with the smallest non-vacuity worked example `card_aut_adjoin_sqrt_two_three : |Gal(ℚ(√2, √3)/ℚ)| = 4`.

This advances Layer 0 of `TauCetiRoadmap/Multiquadratic/README.md` ("the Galois group `(ℤ/2)ⁿ`") and its worked example `[ℚ(√2, √3) : ℚ] = 4`, following the roadmap's instruction to prove the field-generic theorem and then derive the prime-indexed version (a genus-theory input) as a corollary. It parallels the existing degree corollaries in `TauCeti.NumberTheory.Multiquadratic.PrimeRadicands` (`finrank_adjoin_sqrt_primes`, `finrank_adjoin_sqrt_two_three`), reusing `not_isSquare_prod_primes` for the square-class independence of distinct primes and `galoisGroupEquiv` for the isomorphism; the cardinality computation goes through Mathlib's `Nat.card_congr`, `Fintype.card_pi`, and `ZMod.card`.

`lake build` is green and `lake exe axioms` reports `audited 3450 TauCeti declaration(s); all within the allowlist [propext, Classical.choice, Quot.sound]`.

<!--tauceti-target:v1 {"focus":"Multiquadratic","id":"galois-group-prime-radicand-multiquadratic-field"}-->

🤖 Prepared with Claude Code
