### PR TITLE
feat: the split torus and its functor of points

### DIFF
--- a/TauCeti/Algebra/AlgebraicGroup/SplitTorus.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/SplitTorus.lean
@@ -105,6 +105,18 @@ theorem pointsMulEquiv_mapValue (φ : A →ₐ[R] B)
   simp only [pointsMulEquiv, MulEquiv.trans_apply, DiagonalizableGroup.pointsMulEquiv_mapValue,
     freeAbelianCharEquiv_comp]
 
+/-- Naturality of the inverse split-torus points equivalence in the value algebra. -/
+@[simp]
+theorem mapValue_pointsMulEquiv_symm_apply (φ : A →ₐ[R] B) (c : σ → Aˣ) :
+    AlgHom.mapValue (H := MonoidAlgebra R (Multiplicative (σ →₀ ℤ))) φ
+        ((pointsMulEquiv (R := R) (A := A)).symm c) =
+      (pointsMulEquiv (R := R) (A := B)).symm
+        (fun i => Units.map φ.toMonoidHom (c i)) := by
+  apply (pointsMulEquiv (R := R) (A := B)).injective
+  funext i
+  rw [pointsMulEquiv_mapValue]
+  simp
+
 /-- The rank-`n` split torus `𝔾ₘⁿ`: its `A`-points are `Fin n → Aˣ = (Aˣ)ⁿ`. -/
 noncomputable example (n : ℕ) :
     WithConv (MonoidAlgebra R (Multiplicative (Fin n →₀ ℤ)) →ₐ[R] A) ≃* (Fin n → Aˣ) :=

--- a/TauCeti/Algebra/AlgebraicGroup/SplitTorus.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/SplitTorus.lean
@@ -1,0 +1,105 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+import TauCeti.Algebra.AlgebraicGroup.DiagonalizableGroup
+import TauCeti.Algebra.Group.FreeAbelianCharacter
+
+/-!
+# The split torus and its functor of points
+
+The split torus on an index type `σ` is the diagonalizable group `D(M)` of the free abelian
+group `M = Multiplicative (σ →₀ ℤ)`; its character lattice is `σ →₀ ℤ`, the free `ℤ`-module on
+`σ`. Concretely it is `Spec R[Multiplicative (σ →₀ ℤ)]`, and for `σ = Fin n` it is the rank-`n`
+split torus `𝔾ₘⁿ`.
+
+This file computes its functor of points: for every commutative `R`-algebra `A`, the convolution
+group of `R`-algebra homomorphisms `R[Multiplicative (σ →₀ ℤ)] →ₐ[R] A` is the product group
+`σ → Aˣ` (with `Fin n → Aˣ = (Aˣ)ⁿ` in the finite-rank case), under pointwise multiplication.
+The equivalence sends a point to its values on the standard one-parameter subgroups
+`ofAdd (single i 1)`.
+
+This combines two existing pieces: the diagonalizable-group points calculation
+`TauCeti.DiagonalizableGroup.pointsMulEquiv`, computing the points of `D(M)` as the character
+group `M →* Aˣ`, and the free-abelian-group universal property
+`TauCeti.freeAbelianCharEquiv`, identifying characters of `Multiplicative (σ →₀ ℤ)` with
+families `σ → Aˣ`.
+
+This is a worked-example check for the reductive-groups roadmap
+(`ReductiveGroups/README.md` in TauCetiRoadmap), Layer 4 ("Tori: split ... the character
+lattice `X*(T)`") together with the Layer 0 functor-of-points calculation, in the same spirit
+as the existing multiplicative group `𝔾ₘ`, roots of unity `μ_n`, and diagonalizable group
+`D(G)`.
+
+## Main definitions
+
+* `TauCeti.SplitTorus.pointsMulEquiv`: the multiplicative equivalence from the convolution
+  group of `A`-points of the rank-`σ` split torus to `σ → Aˣ`.
+* `TauCeti.SplitTorus.pointsMulEquiv_apply`: a point is sent to its values on the standard
+  generators `single (ofAdd (single i 1)) 1`.
+* `TauCeti.SplitTorus.pointsMulEquiv_mapValue`: the points equivalence is natural in the value
+  algebra.
+
+## References
+
+The diagonalizable-group points calculation is Tau Ceti's
+`DiagonalizableGroup.pointsMulEquiv`; the free-abelian-group character identification is
+`TauCeti.freeAbelianCharEquiv`, which reuses Mathlib's `Finsupp.liftAddHom` and `zmultiplesHom`.
+-/
+
+open WithConv
+
+namespace TauCeti
+
+namespace SplitTorus
+
+universe u v w
+
+variable {R : Type u} {A : Type v} {σ : Type w}
+variable [CommSemiring R] [CommSemiring A] [Algebra R A]
+
+/-- The functor of points of the rank-`σ` split torus `D(Multiplicative (σ →₀ ℤ))`: for every
+commutative `R`-algebra `A`, the convolution group of `R`-algebra maps out of
+`R[Multiplicative (σ →₀ ℤ)]` is the product group `σ → Aˣ`, under pointwise multiplication. -/
+noncomputable def pointsMulEquiv :
+    WithConv (MonoidAlgebra R (Multiplicative (σ →₀ ℤ)) →ₐ[R] A) ≃* (σ → Aˣ) :=
+  DiagonalizableGroup.pointsMulEquiv.trans freeAbelianCharEquiv
+
+/-- The points equivalence reads off the value of a point on the `i`-th standard generator
+`single (ofAdd (single i 1)) 1` of `R[Multiplicative (σ →₀ ℤ)]`. -/
+@[simp]
+theorem pointsMulEquiv_apply
+    (f : WithConv (MonoidAlgebra R (Multiplicative (σ →₀ ℤ)) →ₐ[R] A)) (i : σ) :
+    (pointsMulEquiv f i : A) =
+      f.ofConv (MonoidAlgebra.single (Multiplicative.ofAdd (Finsupp.single i 1)) 1) := by
+  rw [pointsMulEquiv, MulEquiv.trans_apply, freeAbelianCharEquiv_apply,
+    DiagonalizableGroup.pointsMulEquiv_apply, DiagonalizableGroup.charOfPoint_apply_coe]
+
+/-- The inverse points equivalence sends a family `c : σ → Aˣ` to the point extending the
+character of `Multiplicative (σ →₀ ℤ)` determined by `c`. -/
+theorem pointsMulEquiv_symm_apply (c : σ → Aˣ) :
+    (pointsMulEquiv (R := R) (A := A)).symm c =
+      toConv (DiagonalizableGroup.point (freeAbelianCharEquiv.symm c)) := by
+  rw [pointsMulEquiv, MulEquiv.symm_trans_apply, DiagonalizableGroup.pointsMulEquiv_symm_apply]
+
+variable {B : Type*} [CommSemiring B] [Algebra R B]
+
+/-- The split-torus points equivalence is natural in the value algebra: post-composing a point
+with an `R`-algebra map `φ : A →ₐ[R] B` sends each coordinate through the induced map on
+units. -/
+@[simp]
+theorem pointsMulEquiv_mapValue (φ : A →ₐ[R] B)
+    (f : WithConv (MonoidAlgebra R (Multiplicative (σ →₀ ℤ)) →ₐ[R] A)) (i : σ) :
+    pointsMulEquiv (AlgHom.mapValue (H := MonoidAlgebra R (Multiplicative (σ →₀ ℤ))) φ f) i =
+      Units.map φ.toMonoidHom (pointsMulEquiv f i) := by
+  simp only [pointsMulEquiv, MulEquiv.trans_apply, DiagonalizableGroup.pointsMulEquiv_mapValue,
+    freeAbelianCharEquiv_comp]
+
+/-- The rank-`n` split torus `𝔾ₘⁿ`: its `A`-points are `Fin n → Aˣ = (Aˣ)ⁿ`. -/
+noncomputable example (n : ℕ) :
+    WithConv (MonoidAlgebra R (Multiplicative (Fin n →₀ ℤ)) →ₐ[R] A) ≃* (Fin n → Aˣ) :=
+  pointsMulEquiv
+
+end SplitTorus
+
+end TauCeti

--- a/TauCeti/Algebra/AlgebraicGroup/SplitTorus.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/SplitTorus.lean
@@ -35,7 +35,7 @@ as the existing multiplicative group `𝔾ₘ`, roots of unity `μ_n`, and diago
 
 * `TauCeti.SplitTorus.pointsMulEquiv`: the multiplicative equivalence from the convolution
   group of `A`-points of the rank-`σ` split torus to `σ → Aˣ`.
-* `TauCeti.SplitTorus.pointsMulEquiv_apply`: a point is sent to its values on the standard
+* `TauCeti.SplitTorus.pointsMulEquiv_apply_coe`: a point is sent to its values on the standard
   generators `single (ofAdd (single i 1)) 1`.
 * `TauCeti.SplitTorus.pointsMulEquiv_mapValue`: the points equivalence is natural in the value
   algebra.
@@ -68,7 +68,7 @@ noncomputable def pointsMulEquiv :
 /-- The points equivalence reads off the value of a point on the `i`-th standard generator
 `single (ofAdd (single i 1)) 1` of `R[Multiplicative (σ →₀ ℤ)]`. -/
 @[simp]
-theorem pointsMulEquiv_apply
+theorem pointsMulEquiv_apply_coe
     (f : WithConv (MonoidAlgebra R (Multiplicative (σ →₀ ℤ)) →ₐ[R] A)) (i : σ) :
     (pointsMulEquiv f i : A) =
       f.ofConv (MonoidAlgebra.single (Multiplicative.ofAdd (Finsupp.single i 1)) 1) := by

--- a/TauCeti/Algebra/AlgebraicGroup/SplitTorus.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/SplitTorus.lean
@@ -16,8 +16,8 @@ split torus `𝔾ₘⁿ`.
 This file computes its functor of points: for every commutative `R`-algebra `A`, the convolution
 group of `R`-algebra homomorphisms `R[Multiplicative (σ →₀ ℤ)] →ₐ[R] A` is the product group
 `σ → Aˣ` (with `Fin n → Aˣ = (Aˣ)ⁿ` in the finite-rank case), under pointwise multiplication.
-The equivalence sends a point to its values on the standard one-parameter subgroups
-`ofAdd (single i 1)`.
+The equivalence sends a point to its values on the standard characters `ofAdd (single i 1)`,
+equivalently the basis monomials `single (ofAdd (single i 1)) 1`.
 
 This combines two existing pieces: the diagonalizable-group points calculation
 `TauCeti.DiagonalizableGroup.pointsMulEquiv`, computing the points of `D(M)` as the character
@@ -81,6 +81,16 @@ theorem pointsMulEquiv_symm_apply (c : σ → Aˣ) :
     (pointsMulEquiv (R := R) (A := A)).symm c =
       toConv (DiagonalizableGroup.point (freeAbelianCharEquiv.symm c)) := by
   rw [pointsMulEquiv, MulEquiv.symm_trans_apply, DiagonalizableGroup.pointsMulEquiv_symm_apply]
+
+/-- The inverse points equivalence sends a coordinate family to the point taking the `i`-th
+standard generator to the `i`-th coordinate. -/
+@[simp]
+theorem pointsMulEquiv_symm_apply_single (c : σ → Aˣ) (i : σ) :
+    ((pointsMulEquiv (R := R) (A := A)).symm c).ofConv
+        (MonoidAlgebra.single (Multiplicative.ofAdd (Finsupp.single i 1)) 1) =
+      (c i : A) := by
+  rw [pointsMulEquiv_symm_apply, ofConv_toConv, DiagonalizableGroup.point_single_one,
+    freeAbelianCharEquiv_symm_apply_ofAdd_single]
 
 variable {B : Type*} [CommSemiring B] [Algebra R B]
 

--- a/TauCeti/Algebra/AlgebraicGroup/SplitTorus.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/SplitTorus.lean
@@ -77,6 +77,7 @@ theorem pointsMulEquiv_apply
 
 /-- The inverse points equivalence sends a family `c : σ → Aˣ` to the point extending the
 character of `Multiplicative (σ →₀ ℤ)` determined by `c`. -/
+@[simp]
 theorem pointsMulEquiv_symm_apply (c : σ → Aˣ) :
     (pointsMulEquiv (R := R) (A := A)).symm c =
       toConv (DiagonalizableGroup.point (freeAbelianCharEquiv.symm c)) := by
@@ -115,7 +116,7 @@ theorem mapValue_pointsMulEquiv_symm_apply (φ : A →ₐ[R] B) (c : σ → Aˣ)
   apply (pointsMulEquiv (R := R) (A := B)).injective
   funext i
   rw [pointsMulEquiv_mapValue]
-  simp
+  simp only [MulEquiv.apply_symm_apply]
 
 /-- The rank-`n` split torus `𝔾ₘⁿ`: its `A`-points are `Fin n → Aˣ = (Aˣ)ⁿ`. -/
 noncomputable example (n : ℕ) :

--- a/TauCeti/Algebra/Group/FreeAbelianCharacter.lean
+++ b/TauCeti/Algebra/Group/FreeAbelianCharacter.lean
@@ -4,8 +4,6 @@ Released under Apache 2.0 license as described in the file LICENSE.
 -/
 import Mathlib.Algebra.BigOperators.Finsupp.Basic
 import Mathlib.Algebra.Group.TypeTags.Hom
-import Mathlib.Data.Finsupp.SMul
-import Mathlib.Data.Finsupp.SMulWithZero
 import Mathlib.Data.Int.Cast.Lemmas
 
 /-!
@@ -31,8 +29,7 @@ one generator).
 
 The construction reuses Mathlib's group-algebra-free toolkit: the `Finsupp.liftAddHom`
 universal property of `σ →₀ ℤ`, the `ℤ`-power homomorphism `zmultiplesHom`, and the type-tag
-adjunctions `AddMonoidHom.toMultiplicativeLeft` / `MonoidHom.toAdditiveRight` from
-`Mathlib.Algebra.Group.TypeTags.Hom`.
+adjunction `AddMonoidHom.toMultiplicativeLeft` from `Mathlib.Algebra.Group.TypeTags.Hom`.
 
 The additive shadow of this equivalence is the `R = ℤ` case of Mathlib's
 `Finsupp.lift : (σ → M) ≃+ ((σ →₀ ℤ) →ₗ[ℤ] M)`, transported across `addMonoidHomLequivInt` and

--- a/TauCeti/Algebra/Group/FreeAbelianCharacter.lean
+++ b/TauCeti/Algebra/Group/FreeAbelianCharacter.lean
@@ -1,0 +1,84 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+import Mathlib.Algebra.BigOperators.Finsupp.Basic
+import Mathlib.Algebra.Group.TypeTags.Hom
+import Mathlib.Data.Finsupp.SMulWithZero
+import Mathlib.Data.Int.Cast.Lemmas
+
+/-!
+# Characters of a free abelian group
+
+The free abelian group on an index type `σ` is modelled as `Multiplicative (σ →₀ ℤ)`: its
+underlying additive group `σ →₀ ℤ` is the free `ℤ`-module on `σ`. This file records its
+universal property in the form most useful for the functor of points of a split torus: a
+homomorphism `Multiplicative (σ →₀ ℤ) →* M` to a commutative group `M` is the same data as a
+family `σ → M`, naturally and multiplicatively.
+
+The equivalence sends a homomorphism `χ` to its values `i ↦ χ (ofAdd (single i 1))` on the
+standard generators, and a family `c : σ → M` to the unique homomorphism extending it. This is
+the many-generator version of Mathlib's `zpowersHom : M ≃ (Multiplicative ℤ →* M)` (the case of
+one generator).
+
+## Main definitions
+
+* `TauCeti.freeAbelianCharEquiv`: the multiplicative equivalence
+  `(Multiplicative (σ →₀ ℤ) →* M) ≃* (σ → M)`.
+
+## References
+
+The construction reuses Mathlib's group-algebra-free toolkit: the `Finsupp.liftAddHom`
+universal property of `σ →₀ ℤ`, the `ℤ`-power homomorphism `zmultiplesHom`, and the type-tag
+adjunctions `AddMonoidHom.toMultiplicativeLeft` / `MonoidHom.toAdditiveRight` from
+`Mathlib.Algebra.Group.TypeTags.Hom`.
+-/
+
+namespace TauCeti
+
+variable {σ : Type*} {M : Type*} [CommGroup M]
+
+/-- The universal property of the free abelian group `Multiplicative (σ →₀ ℤ)`: a homomorphism
+to a commutative group `M` is the same data as a family `σ → M`. The forward map reads off the
+values on the standard generators `ofAdd (single i 1)`; the inverse extends a family to the
+unique homomorphism through `Finsupp.liftAddHom` and the `ℤ`-power homomorphism. -/
+noncomputable def freeAbelianCharEquiv :
+    (Multiplicative (σ →₀ ℤ) →* M) ≃* (σ → M) where
+  toFun χ i := χ (Multiplicative.ofAdd (Finsupp.single i 1))
+  invFun c := AddMonoidHom.toMultiplicativeLeft
+    (Finsupp.liftAddHom fun i => (zmultiplesHom (Additive M)) (Additive.ofMul (c i)))
+  map_mul' _ _ := rfl
+  right_inv c := by
+    funext i
+    simp
+  left_inv χ := by
+    apply Multiplicative.monoidHom_ext
+    apply Finsupp.addHom_ext
+    intro x m
+    change (Finsupp.liftAddHom fun i => (zmultiplesHom (Additive M)) (Additive.ofMul
+      (χ (Multiplicative.ofAdd (Finsupp.single i 1))))) (Finsupp.single x m) =
+      χ.toAdditiveRight (Finsupp.single x m)
+    rw [Finsupp.liftAddHom_apply_single, zmultiplesHom_apply,
+      MonoidHom.toAdditiveRight_apply_apply,
+      show Finsupp.single x m = m • Finsupp.single x (1 : ℤ) from by
+        rw [Finsupp.smul_single, smul_eq_mul, mul_one],
+      ofAdd_zsmul, map_zpow, ofMul_zpow]
+
+@[simp]
+theorem freeAbelianCharEquiv_apply (χ : Multiplicative (σ →₀ ℤ) →* M) (i : σ) :
+    freeAbelianCharEquiv χ i = χ (Multiplicative.ofAdd (Finsupp.single i 1)) :=
+  rfl
+
+@[simp]
+theorem freeAbelianCharEquiv_symm_apply_ofAdd_single (c : σ → M) (i : σ) :
+    (freeAbelianCharEquiv (M := M)).symm c (Multiplicative.ofAdd (Finsupp.single i 1)) = c i := by
+  simp [freeAbelianCharEquiv]
+
+/-- Reading off generator values is natural in the target group: post-composing with a
+homomorphism `ψ : M →* N` commutes with `freeAbelianCharEquiv`. -/
+theorem freeAbelianCharEquiv_comp {N : Type*} [CommGroup N] (ψ : M →* N)
+    (χ : Multiplicative (σ →₀ ℤ) →* M) (i : σ) :
+    freeAbelianCharEquiv (ψ.comp χ) i = ψ (freeAbelianCharEquiv χ i) :=
+  rfl
+
+end TauCeti

--- a/TauCeti/Algebra/Group/FreeAbelianCharacter.lean
+++ b/TauCeti/Algebra/Group/FreeAbelianCharacter.lean
@@ -33,6 +33,15 @@ The construction reuses Mathlib's group-algebra-free toolkit: the `Finsupp.liftA
 universal property of `σ →₀ ℤ`, the `ℤ`-power homomorphism `zmultiplesHom`, and the type-tag
 adjunctions `AddMonoidHom.toMultiplicativeLeft` / `MonoidHom.toAdditiveRight` from
 `Mathlib.Algebra.Group.TypeTags.Hom`.
+
+The additive shadow of this equivalence is the `R = ℤ` case of Mathlib's
+`Finsupp.lift : (σ → M) ≃+ ((σ →₀ ℤ) →ₗ[ℤ] M)`, transported across `addMonoidHomLequivInt` and
+the `Multiplicative`/`Additive` type-tag adjunctions. We build it directly from the same
+underlying pieces (`Finsupp.liftAddHom` and `zmultiplesHom`) rather than transporting that
+chain of isomorphisms so that the forward map is *definitionally* generator evaluation
+`χ ↦ fun i => χ (ofAdd (single i 1))`. That keeps `freeAbelianCharEquiv_apply`, `map_mul'`, and
+`freeAbelianCharEquiv_comp` true by `rfl`; a transported equivalence would route every
+evaluation through the composite transport maps and lose that defeq.
 -/
 
 namespace TauCeti

--- a/TauCeti/Algebra/Group/FreeAbelianCharacter.lean
+++ b/TauCeti/Algebra/Group/FreeAbelianCharacter.lean
@@ -53,8 +53,8 @@ private theorem freeAbelianCharEquiv_toAdditiveRight_single
     χ.toAdditiveRight (Finsupp.single x m) =
       (zmultiplesHom (Additive M))
         (Additive.ofMul (χ (Multiplicative.ofAdd (Finsupp.single x 1)))) m := by
-  rw [← Finsupp.smul_single_one x m, MonoidHom.toAdditiveRight_apply_apply,
-    ofAdd_zsmul, map_zpow, ofMul_zpow, zmultiplesHom_apply]
+  rw [← Finsupp.smul_single_one x m, map_zsmul, zmultiplesHom_apply,
+    MonoidHom.toAdditiveRight_apply_apply]
 
 private theorem freeAbelianCharEquiv_left_inv_single
     (χ : Multiplicative (σ →₀ ℤ) →* M) (x : σ) (m : ℤ) :
@@ -106,6 +106,7 @@ theorem freeAbelianCharEquiv_symm_apply_ofAdd (c : σ → M) (m : σ →₀ ℤ)
 
 /-- Reading off generator values is natural in the target group: post-composing with a
 homomorphism `ψ : M →* N` commutes with `freeAbelianCharEquiv`. -/
+@[simp]
 theorem freeAbelianCharEquiv_comp {N : Type*} [CommGroup N] (ψ : M →* N)
     (χ : Multiplicative (σ →₀ ℤ) →* M) (i : σ) :
     freeAbelianCharEquiv (ψ.comp χ) i = ψ (freeAbelianCharEquiv χ i) :=

--- a/TauCeti/Algebra/Group/FreeAbelianCharacter.lean
+++ b/TauCeti/Algebra/Group/FreeAbelianCharacter.lean
@@ -39,14 +39,20 @@ namespace TauCeti
 
 variable {σ : Type*} {M : Type*} [CommGroup M]
 
+private theorem freeAbelianCharEquiv_toAdditiveRight_single
+    (χ : Multiplicative (σ →₀ ℤ) →* M) (x : σ) (m : ℤ) :
+    χ.toAdditiveRight (Finsupp.single x m) =
+      (zmultiplesHom (Additive M))
+        (Additive.ofMul (χ (Multiplicative.ofAdd (Finsupp.single x 1)))) m := by
+  rw [← Finsupp.smul_single_one x m, MonoidHom.toAdditiveRight_apply_apply,
+    ofAdd_zsmul, map_zpow, ofMul_zpow, zmultiplesHom_apply]
+
 private theorem freeAbelianCharEquiv_left_inv_single
     (χ : Multiplicative (σ →₀ ℤ) →* M) (x : σ) (m : ℤ) :
     (Finsupp.liftAddHom fun i => (zmultiplesHom (Additive M)) (Additive.ofMul
       (χ (Multiplicative.ofAdd (Finsupp.single i 1))))) (Finsupp.single x m) =
       χ.toAdditiveRight (Finsupp.single x m) := by
-  rw [Finsupp.liftAddHom_apply_single, zmultiplesHom_apply,
-    MonoidHom.toAdditiveRight_apply_apply, ← Finsupp.smul_single_one x m, ofAdd_zsmul,
-    map_zpow, ofMul_zpow]
+  rw [Finsupp.liftAddHom_apply_single, freeAbelianCharEquiv_toAdditiveRight_single]
 
 /-- The universal property of the free abelian group `Multiplicative (σ →₀ ℤ)`: a homomorphism
 to a commutative group `M` is the same data as a family `σ → M`. The forward map reads off the
@@ -66,16 +72,22 @@ noncomputable def freeAbelianCharEquiv :
     apply Finsupp.addHom_ext
     exact freeAbelianCharEquiv_left_inv_single χ
 
+/-- The forward direction of `freeAbelianCharEquiv` evaluates a character on the standard
+generator indexed by `i`. -/
 @[simp]
 theorem freeAbelianCharEquiv_apply (χ : Multiplicative (σ →₀ ℤ) →* M) (i : σ) :
     freeAbelianCharEquiv χ i = χ (Multiplicative.ofAdd (Finsupp.single i 1)) :=
   rfl
 
+/-- The inverse of `freeAbelianCharEquiv` sends the standard generator indexed by `i` to the
+chosen coordinate `c i`. -/
 @[simp]
 theorem freeAbelianCharEquiv_symm_apply_ofAdd_single (c : σ → M) (i : σ) :
     (freeAbelianCharEquiv (M := M)).symm c (Multiplicative.ofAdd (Finsupp.single i 1)) = c i := by
   simp [freeAbelianCharEquiv]
 
+/-- The inverse of `freeAbelianCharEquiv` evaluates an arbitrary finitely supported integer
+combination as the corresponding product of powers of the chosen coordinates. -/
 @[simp]
 theorem freeAbelianCharEquiv_symm_apply_ofAdd (c : σ → M) (m : σ →₀ ℤ) :
     (freeAbelianCharEquiv (M := M)).symm c (Multiplicative.ofAdd m) =

--- a/TauCeti/Algebra/Group/FreeAbelianCharacter.lean
+++ b/TauCeti/Algebra/Group/FreeAbelianCharacter.lean
@@ -48,21 +48,6 @@ namespace TauCeti
 
 variable {σ : Type*} {M : Type*} [CommGroup M]
 
-private theorem freeAbelianCharEquiv_toAdditiveRight_single
-    (χ : Multiplicative (σ →₀ ℤ) →* M) (x : σ) (m : ℤ) :
-    χ.toAdditiveRight (Finsupp.single x m) =
-      (zmultiplesHom (Additive M))
-        (Additive.ofMul (χ (Multiplicative.ofAdd (Finsupp.single x 1)))) m := by
-  rw [← Finsupp.smul_single_one x m, map_zsmul, zmultiplesHom_apply,
-    MonoidHom.toAdditiveRight_apply_apply]
-
-private theorem freeAbelianCharEquiv_left_inv_single
-    (χ : Multiplicative (σ →₀ ℤ) →* M) (x : σ) (m : ℤ) :
-    (Finsupp.liftAddHom fun i => (zmultiplesHom (Additive M)) (Additive.ofMul
-      (χ (Multiplicative.ofAdd (Finsupp.single i 1))))) (Finsupp.single x m) =
-      χ.toAdditiveRight (Finsupp.single x m) := by
-  rw [Finsupp.liftAddHom_apply_single, freeAbelianCharEquiv_toAdditiveRight_single]
-
 /-- The universal property of the free abelian group `Multiplicative (σ →₀ ℤ)`: a homomorphism
 to a commutative group `M` is the same data as a family `σ → M`. The forward map reads off the
 values on the standard generators `ofAdd (single i 1)`; the inverse extends a family to the
@@ -78,8 +63,10 @@ noncomputable def freeAbelianCharEquiv :
     simp
   left_inv χ := by
     apply Multiplicative.monoidHom_ext
-    apply Finsupp.addHom_ext
-    exact freeAbelianCharEquiv_left_inv_single χ
+    apply Finsupp.addHom_ext'
+    intro x
+    apply AddMonoidHom.ext_int
+    simp
 
 /-- The forward direction of `freeAbelianCharEquiv` evaluates a character on the standard
 generator indexed by `i`. -/

--- a/TauCeti/Algebra/Group/FreeAbelianCharacter.lean
+++ b/TauCeti/Algebra/Group/FreeAbelianCharacter.lean
@@ -4,6 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 -/
 import Mathlib.Algebra.BigOperators.Finsupp.Basic
 import Mathlib.Algebra.Group.TypeTags.Hom
+import Mathlib.Data.Finsupp.SMul
 import Mathlib.Data.Finsupp.SMulWithZero
 import Mathlib.Data.Int.Cast.Lemmas
 
@@ -38,6 +39,15 @@ namespace TauCeti
 
 variable {σ : Type*} {M : Type*} [CommGroup M]
 
+private theorem freeAbelianCharEquiv_left_inv_single
+    (χ : Multiplicative (σ →₀ ℤ) →* M) (x : σ) (m : ℤ) :
+    (Finsupp.liftAddHom fun i => (zmultiplesHom (Additive M)) (Additive.ofMul
+      (χ (Multiplicative.ofAdd (Finsupp.single i 1))))) (Finsupp.single x m) =
+      χ.toAdditiveRight (Finsupp.single x m) := by
+  rw [Finsupp.liftAddHom_apply_single, zmultiplesHom_apply,
+    MonoidHom.toAdditiveRight_apply_apply, ← Finsupp.smul_single_one x m, ofAdd_zsmul,
+    map_zpow, ofMul_zpow]
+
 /-- The universal property of the free abelian group `Multiplicative (σ →₀ ℤ)`: a homomorphism
 to a commutative group `M` is the same data as a family `σ → M`. The forward map reads off the
 values on the standard generators `ofAdd (single i 1)`; the inverse extends a family to the
@@ -54,15 +64,7 @@ noncomputable def freeAbelianCharEquiv :
   left_inv χ := by
     apply Multiplicative.monoidHom_ext
     apply Finsupp.addHom_ext
-    intro x m
-    change (Finsupp.liftAddHom fun i => (zmultiplesHom (Additive M)) (Additive.ofMul
-      (χ (Multiplicative.ofAdd (Finsupp.single i 1))))) (Finsupp.single x m) =
-      χ.toAdditiveRight (Finsupp.single x m)
-    rw [Finsupp.liftAddHom_apply_single, zmultiplesHom_apply,
-      MonoidHom.toAdditiveRight_apply_apply,
-      show Finsupp.single x m = m • Finsupp.single x (1 : ℤ) from by
-        rw [Finsupp.smul_single, smul_eq_mul, mul_one],
-      ofAdd_zsmul, map_zpow, ofMul_zpow]
+    exact freeAbelianCharEquiv_left_inv_single χ
 
 @[simp]
 theorem freeAbelianCharEquiv_apply (χ : Multiplicative (σ →₀ ℤ) →* M) (i : σ) :
@@ -73,6 +75,13 @@ theorem freeAbelianCharEquiv_apply (χ : Multiplicative (σ →₀ ℤ) →* M) 
 theorem freeAbelianCharEquiv_symm_apply_ofAdd_single (c : σ → M) (i : σ) :
     (freeAbelianCharEquiv (M := M)).symm c (Multiplicative.ofAdd (Finsupp.single i 1)) = c i := by
   simp [freeAbelianCharEquiv]
+
+@[simp]
+theorem freeAbelianCharEquiv_symm_apply_ofAdd (c : σ → M) (m : σ →₀ ℤ) :
+    (freeAbelianCharEquiv (M := M)).symm c (Multiplicative.ofAdd m) =
+      m.prod fun i n => c i ^ n := by
+  simp [freeAbelianCharEquiv, Finsupp.liftAddHom_apply, Finsupp.sum, Finsupp.prod,
+    toMul_sum, zmultiplesHom_apply]
 
 /-- Reading off generator values is natural in the target group: post-composing with a
 homomorphism `ψ : M →* N` commutes with `freeAbelianCharEquiv`. -/


### PR DESCRIPTION
This PR computes the functor of points of the split torus and supplies the free-abelian-group character universal property it needs. The split torus on an index type `σ` is the diagonalizable group `D(Multiplicative (σ →₀ ℤ))`, with character lattice `σ →₀ ℤ` (the free `ℤ`-module on `σ`); concretely `Spec R[Multiplicative (σ →₀ ℤ)]`, and for `σ = Fin n` the rank-`n` torus `𝔾ₘⁿ`. For every commutative `R`-algebra `A` the convolution group of `R`-algebra maps `R[Multiplicative (σ →₀ ℤ)] →ₐ[R] A` is identified, as a group under pointwise multiplication, with the product `σ → Aˣ` (so `Fin n → Aˣ = (Aˣ)ⁿ` in finite rank), the equivalence reading off a point's values on the standard one-parameter subgroups `ofAdd (single i 1)`. The computation is assembled from the existing diagonalizable-group points calculation `TauCeti.DiagonalizableGroup.pointsMulEquiv` and a new universal property `TauCeti.freeAbelianCharEquiv : (Multiplicative (σ →₀ ℤ) →* M) ≃* (σ → M)`, the many-generator analogue of Mathlib's one-generator `zpowersHom`, and is shown natural in the value algebra.

This advances `TauCetiRoadmap/ReductiveGroups/README.md`, Layer 4 ("Tori: split ... the character lattice `X*(T)`") together with the Layer 0 functor-of-points calculation, in the same spirit as the existing worked examples `𝔾ₘ`, `μ_n`, and `D(G)`.

The new `freeAbelianCharEquiv` reuses Mathlib infrastructure rather than vendoring code: the `Finsupp.liftAddHom` universal property of `σ →₀ ℤ`, the integer-power homomorphism `zmultiplesHom`, and the type-tag adjunctions `AddMonoidHom.toMultiplicativeLeft` / `MonoidHom.toAdditiveRight`.

<!--tauceti-target:v1 {"focus":"ReductiveGroups","id":"split-torus-functor-of-points"}-->

🤖 Prepared with Claude Code
