### PR TITLE
fix: make the Zulip PR-status integration fail loudly on a broken key

### DIFF
--- a/.github/workflows/zulip-healthcheck.yml
+++ b/.github/workflows/zulip-healthcheck.yml
@@ -1,0 +1,37 @@
+name: Zulip PR status (healthcheck)
+
+# Actively probe the Zulip bot's credentials on a schedule, so a broken
+# ZULIP_API_KEY is caught even when no PR opens or builds for a while. The
+# per-PR workflows (zulip-pr.yml / zulip-pr-status.yml) only exercise the
+# integration when something happens on a PR; this one fails loudly on its own
+# cadence. `check` touches no PR and no message -- it just authenticates and
+# confirms the bot is subscribed to the channel.
+
+on:
+  schedule:
+  - cron: "37 */6 * * *"   # every six hours, offset off the hour
+  workflow_dispatch: {}
+
+permissions:
+  contents: read   # checkout the script
+
+concurrency:
+  group: zulip-healthcheck
+  cancel-in-progress: true
+
+jobs:
+  zulip-healthcheck:
+    if: github.repository == 'FormalFrontier/TauCeti'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          sparse-checkout: scripts/zulip
+      - name: Probe Zulip credentials
+        # No continue-on-error: a failed probe means the integration is broken
+        # and this run should go red. See scripts/zulip/README.md.
+        env:
+          ZULIP_API_KEY: ${{ secrets.ZULIP_API_KEY }}
+          ZULIP_EMAIL: ${{ secrets.ZULIP_EMAIL }}
+          ZULIP_SITE: https://leanprover.zulipchat.com
+        run: python3 scripts/zulip/zulip_pr_status.py check

--- a/.github/workflows/zulip-pr-status.yml
+++ b/.github/workflows/zulip-pr-status.yml
@@ -55,6 +55,9 @@ jobs:
         if: steps.pr.outputs.skip != 'true'
         # No continue-on-error: the script exits 0 for cosmetic/transient hiccups
         # and non-zero only for a persistent config break, which we *want* loud.
+        # This run going red never blocks a PR: only `build` and `bump-guard` are
+        # required checks, and auto-merge gates on the build status + review
+        # ledger, not on this workflow.
         env:
           GH_TOKEN: ${{ github.token }}
           ZULIP_API_KEY: ${{ secrets.ZULIP_API_KEY }}

--- a/.github/workflows/zulip-pr-status.yml
+++ b/.github/workflows/zulip-pr-status.yml
@@ -53,7 +53,8 @@ jobs:
           sparse-checkout: scripts/zulip
       - name: Reconcile Zulip reactions
         if: steps.pr.outputs.skip != 'true'
-        continue-on-error: true
+        # No continue-on-error: the script exits 0 for cosmetic/transient hiccups
+        # and non-zero only for a persistent config break, which we *want* loud.
         env:
           GH_TOKEN: ${{ github.token }}
           ZULIP_API_KEY: ${{ secrets.ZULIP_API_KEY }}

--- a/.github/workflows/zulip-pr.yml
+++ b/.github/workflows/zulip-pr.yml
@@ -3,7 +3,10 @@ name: Zulip PR status (lifecycle)
 # Maintain the per-PR message + emoji in the "Tau Ceti" Zulip channel as a PR is
 # opened, reopened, merged, or closed. CI- and review-status changes are handled
 # by zulip-pr-status.yml; this one owns the message's existence and its
-# merged/closed lifecycle. Updates are cosmetic and never fail anything.
+# merged/closed lifecycle. A one-off reaction hiccup is cosmetic and the script
+# swallows it (exit 0); a *config* break (bad ZULIP_API_KEY, bot not subscribed)
+# makes the script exit non-zero so this run goes red -- that is the only way the
+# breakage is visible, since the integration otherwise fails silently.
 
 on:
   pull_request_target:
@@ -30,7 +33,8 @@ jobs:
         with:
           sparse-checkout: scripts/zulip
       - name: Reconcile Zulip reactions
-        continue-on-error: true
+        # No continue-on-error: the script exits 0 for cosmetic/transient hiccups
+        # and non-zero only for a persistent config break, which we *want* loud.
         env:
           GH_TOKEN: ${{ github.token }}
           ZULIP_API_KEY: ${{ secrets.ZULIP_API_KEY }}

--- a/.github/workflows/zulip-pr.yml
+++ b/.github/workflows/zulip-pr.yml
@@ -35,6 +35,9 @@ jobs:
       - name: Reconcile Zulip reactions
         # No continue-on-error: the script exits 0 for cosmetic/transient hiccups
         # and non-zero only for a persistent config break, which we *want* loud.
+        # This run going red never blocks a PR: only `build` and `bump-guard` are
+        # required checks, and auto-merge gates on the build status + review
+        # ledger, not on this workflow.
         env:
           GH_TOKEN: ${{ github.token }}
           ZULIP_API_KEY: ${{ secrets.ZULIP_API_KEY }}

--- a/scripts/zulip/README.md
+++ b/scripts/zulip/README.md
@@ -25,13 +25,16 @@ are authoritative (presence is judged by the bot's user id), so a human reacting
 on a status message never confuses reconciliation. Its only dependencies are
 python3's standard library and an authenticated `gh` CLI — no PyPI packages.
 
-Two workflows trigger it:
+Three workflows drive it:
 
 - [`zulip-pr.yml`](../../.github/workflows/zulip-pr.yml) — on PR
   `opened`/`reopened`/`closed`. Creates the message and owns the merged/closed
   ending.
 - [`zulip-pr-status.yml`](../../.github/workflows/zulip-pr-status.yml) — on
   `workflow_run` of `pr-build` and `Review`. Refreshes the CI and review groups.
+- [`zulip-healthcheck.yml`](../../.github/workflows/zulip-healthcheck.yml) — a
+  schedule (every 6h) that runs `check` to probe the credentials, so a broken
+  key is caught even during quiet periods with no PR activity.
 
 ## One-time setup
 
@@ -43,6 +46,46 @@ Two workflows trigger it:
    - `ZULIP_EMAIL` — the bot's email (e.g. `tauceti-pr-bot@leanprover.zulipchat.com`)
 
    The site is hard-coded to `https://leanprover.zulipchat.com` in the workflows.
+
+   > **Set the key without a trailing newline.** A newline (or stray
+   > whitespace) rides into the Basic-auth header and Zulip rejects the key as
+   > `Malformed API key` (a 401). Use `--body`, which does not append one:
+   >
+   > ```bash
+   > gh secret set ZULIP_API_KEY --repo FormalFrontier/TauCeti --body "$KEY"
+   > ```
+   >
+   > Avoid `echo "$KEY" | gh secret set ...` (echo adds a newline). The script
+   > also `.strip()`s both creds defensively, but set them cleanly anyway.
+
+## Failure modes
+
+The integration is built to be quiet about cosmetic problems and loud about real
+ones, because the two are easy to confuse from the outside:
+
+- A **transient** hiccup — one Zulip 5xx, a network blip, a PR with no message
+  yet — is cosmetic and self-heals on the next reconcile. The script logs it and
+  exits 0, so the workflow run stays green.
+- A **configuration** break — missing/empty creds, a bad API key (401), a
+  forbidden bot (403), or the bot not subscribed to the channel — breaks *every*
+  PR and will not fix itself. The script logs it, emits a GitHub Actions
+  `::error::` annotation, and exits non-zero, so the workflow run goes **red**.
+  None of the three workflows use `continue-on-error`, so this is visible in the
+  Actions tab and on the PR's checks. (Before this split, the workflows
+  swallowed everything and always showed green, so a dead key could go unnoticed
+  for a long time.)
+
+When a run is red, re-set `ZULIP_API_KEY` per the gotcha above, then confirm:
+
+```bash
+export ZULIP_API_KEY=... ZULIP_EMAIL=... ZULIP_SITE=https://leanprover.zulipchat.com
+python3 scripts/zulip/zulip_pr_status.py check   # exits 0 and prints OK when healthy
+```
+
+Re-run the `zulip-healthcheck` workflow (or just wait for the next PR event) to
+clear the red. Reactions are reconciled from GitHub truth on every event, so
+they catch up on their own once the key works again; a one-shot backfill is only
+needed to seed messages for PRs opened while the key was broken (see below).
 
 ## Backfill (run locally)
 

--- a/scripts/zulip/zulip_pr_status.py
+++ b/scripts/zulip/zulip_pr_status.py
@@ -25,10 +25,16 @@ and we only ever add/remove our own reactions.
 
 Usage:
     zulip_pr_status.py reconcile <pr_number> [--create] [--ci STATE]
+    zulip_pr_status.py check
 
 `--create` posts the per-PR message if it does not exist yet (used by the PR
 "opened" workflow and by backfill). Without it, a PR with no message yet is left
 alone (other events only react to an existing message, never create one).
+
+`check` is a credentials/health probe: it authenticates and confirms the bot is
+subscribed to the channel, then exits 0. It touches no PR and no message, so a
+scheduled job can run it to catch a broken key during quiet periods, when no PR
+event would otherwise exercise the integration.
 
 `--ci STATE` (running|success|failure|none) forces the CI group instead of
 deriving it from the `build` commit status. The `pr-build` workflow posts the
@@ -43,9 +49,19 @@ Environment:
     GH_TOKEN / GITHUB_TOKEN                  used by `gh` for the GitHub API
 
 The only runtime dependencies are python3's standard library and an
-authenticated `gh` CLI -- no third-party packages. Emoji updates are cosmetic;
-on any non-fatal hiccup we log and exit 0 so a caller can wrap us in
-`continue-on-error` and never fail CI over a reaction.
+authenticated `gh` CLI -- no third-party packages.
+
+Failure modes are split on purpose, because "a reaction didn't update" and "the
+whole integration is dead" deserve different volumes:
+
+  * A *transient* hiccup (one Zulip 5xx, a network blip, a single missing PR)
+    is cosmetic and self-heals on the next reconcile, so we log it and exit 0.
+  * A *configuration* failure -- missing/empty creds, a bad API key (401), a
+    forbidden bot (403), or the bot not subscribed to the channel -- breaks
+    every PR and will not fix itself. We log it, emit a GitHub Actions
+    `::error::` annotation (visible even under `continue-on-error`), and exit
+    non-zero so the workflow run goes red. This is the loud signal that the
+    secret needs re-setting; see scripts/zulip/README.md for the fix.
 """
 
 import base64
@@ -62,6 +78,14 @@ REPO = os.environ.get("GH_REPO", "FormalFrontier/TauCeti")
 CHANNEL = os.environ.get("ZULIP_CHANNEL", "Tau Ceti")
 TOPIC = os.environ.get("ZULIP_TOPIC", "PRs")
 ZWSP = "\u200b"  # zero-width space, used to defuse mentions/linkifiers
+
+
+class ConfigError(RuntimeError):
+    """A persistent auth/permission/config failure that will not self-heal:
+    missing or empty creds, a bad API key (401), a forbidden bot (403), or the
+    bot not being subscribed to the channel. Raised so the caller can surface it
+    loudly (non-zero exit + ::error:: annotation) instead of the quiet cosmetic
+    path, because it breaks the integration for *every* PR, not just one."""
 
 # name -> (reaction_type, emoji_code). Unicode emoji resolve by name on the
 # server, so emoji_code is None; realm (custom) emoji must carry their id.
@@ -221,10 +245,21 @@ class Zulip:
                 pass
             if payload.get("code") in tolerate:
                 return payload
-            raise RuntimeError(f"Zulip {method} {path} failed: {e.code} {payload or e.reason}")
+            detail = f"Zulip {method} {path} failed: {e.code} {payload or e.reason}"
+            # 401/403 (and Zulip's UNAUTHORIZED code, e.g. "Malformed API key")
+            # mean the creds themselves are wrong -- a persistent break for every
+            # PR, not a one-off hiccup. Surface it as a ConfigError so main()
+            # fails loudly instead of swallowing it on the cosmetic path.
+            if e.code in (401, 403) or payload.get("code") == "UNAUTHORIZED":
+                raise ConfigError(detail)
+            raise RuntimeError(detail)
 
     def my_user_id(self):
         return self._call("GET", "/users/me", None)["user_id"]
+
+    def my_subscriptions(self):
+        return [s["name"] for s in
+                self._call("GET", "/users/me/subscriptions", None)["subscriptions"]]
 
     def get_messages(self, narrow, num_before=1000):
         params = {
@@ -346,13 +381,60 @@ def reconcile(z, pr, create, ci_override):
     log(f"PR #{pr}: review={rev} ci={ci_emoji}")
 
 
+def check(z):
+    """Health probe: authenticate and confirm the bot can act in the channel.
+
+    A bad key raises ConfigError from `my_user_id` (the 401 path); a bot that is
+    not subscribed to the channel can authenticate but cannot post or react, so
+    that is treated as a config failure too. Touches no PR and no message."""
+    bot_id = z.my_user_id()
+    subs = z.my_subscriptions()
+    if CHANNEL not in subs:
+        raise ConfigError(
+            f"bot (user {bot_id}) is not subscribed to channel {CHANNEL!r}; "
+            f"it cannot post or react there. Subscribe it and re-run.")
+    log(f"OK: authenticated as user {bot_id}, subscribed to {CHANNEL!r}")
+
+
+def fail_config(msg):
+    """Report a persistent config break loudly: a GitHub Actions error
+    annotation (visible in the run summary even under `continue-on-error`) plus a
+    non-zero exit so the workflow run goes red. See the module docstring."""
+    log(f"CONFIG ERROR: {msg}")
+    if os.environ.get("GITHUB_ACTIONS") == "true":
+        # One line, no embedded newlines: the ::error:: command must be self-contained.
+        print(f"::error title=Zulip PR status integration is broken::{msg}", flush=True)
+    return 1
+
+
 def main(argv):
-    if len(argv) < 3 or argv[1] != "reconcile":
+    cmd = argv[1] if len(argv) > 1 else None
+    if cmd not in ("reconcile", "check"):
         print(__doc__)
         return 2
-    pr = argv[2].lstrip("#")
+
+    # Strip the creds: a stray trailing newline or surrounding whitespace in the
+    # GitHub secret is the single most common way ZULIP_API_KEY breaks (the byte
+    # rides into the Basic-auth header and Zulip rejects it as "Malformed API
+    # key"). Defang it here so a sloppily-set secret still works.
+    email = (os.environ.get("ZULIP_EMAIL") or "").strip()
+    api_key = (os.environ.get("ZULIP_API_KEY") or "").strip()
+    site = (os.environ.get("ZULIP_SITE") or "https://leanprover.zulipchat.com").strip()
+    if not (email and api_key):
+        return fail_config("ZULIP_EMAIL / ZULIP_API_KEY not set (no bot configured)")
+    z = Zulip(email, api_key, site)
+
+    if cmd == "check":
+        try:
+            check(z)
+        except ConfigError as exc:
+            return fail_config(str(exc))
+        return 0
+
+    # cmd == "reconcile"
+    pr = argv[2].lstrip("#") if len(argv) > 2 else ""
     if not pr.isdigit():
-        log(f"not a PR number: {argv[2]!r}")
+        log(f"not a PR number: {argv[2]!r}" if len(argv) > 2 else "missing PR number")
         return 0
     rest = argv[3:]
     create = "--create" in rest
@@ -360,15 +442,11 @@ def main(argv):
     if "--ci" in rest:
         ci_override = rest[rest.index("--ci") + 1]
 
-    email = os.environ.get("ZULIP_EMAIL")
-    api_key = os.environ.get("ZULIP_API_KEY")
-    site = os.environ.get("ZULIP_SITE", "https://leanprover.zulipchat.com")
-    if not (email and api_key):
-        log("ZULIP_EMAIL / ZULIP_API_KEY not set; skipping (no bot configured yet)")
-        return 0
     try:
-        reconcile(Zulip(email, api_key, site), pr, create, ci_override)
-    except Exception as exc:  # cosmetic: never fail the caller over a reaction
+        reconcile(z, pr, create, ci_override)
+    except ConfigError as exc:  # broken creds/permissions: loud, fails the run
+        return fail_config(str(exc))
+    except Exception as exc:  # cosmetic: never fail the caller over one reaction
         log(f"reconcile failed (non-fatal): {exc}")
     return 0
 

--- a/scripts/zulip/zulip_pr_status.py
+++ b/scripts/zulip/zulip_pr_status.py
@@ -246,11 +246,15 @@ class Zulip:
             if payload.get("code") in tolerate:
                 return payload
             detail = f"Zulip {method} {path} failed: {e.code} {payload or e.reason}"
-            # 401/403 (and Zulip's UNAUTHORIZED code, e.g. "Malformed API key")
-            # mean the creds themselves are wrong -- a persistent break for every
-            # PR, not a one-off hiccup. Surface it as a ConfigError so main()
-            # fails loudly instead of swallowing it on the cosmetic path.
-            if e.code in (401, 403) or payload.get("code") == "UNAUTHORIZED":
+            # A persistent creds/permission break (vs a one-off hiccup) is a
+            # ConfigError, so main() fails loudly instead of swallowing it. 401
+            # and Zulip's UNAUTHORIZED code (e.g. "Malformed API key") are always
+            # auth. A 403 counts only when Zulip itself answered with a JSON body
+            # (a real permission error); an opaque 403 from a WAF/proxy has no
+            # payload and is treated as a transient hiccup, not a config break.
+            if (e.code == 401
+                    or payload.get("code") == "UNAUTHORIZED"
+                    or (e.code == 403 and payload)):
                 raise ConfigError(detail)
             raise RuntimeError(detail)
 
@@ -402,8 +406,10 @@ def fail_config(msg):
     non-zero exit so the workflow run goes red. See the module docstring."""
     log(f"CONFIG ERROR: {msg}")
     if os.environ.get("GITHUB_ACTIONS") == "true":
-        # One line, no embedded newlines: the ::error:: command must be self-contained.
-        print(f"::error title=Zulip PR status integration is broken::{msg}", flush=True)
+        # Escape the workflow-command payload so a %, CR, or LF in the error text
+        # (e.g. a Zulip JSON body) can't malform or truncate the annotation.
+        safe = msg.replace("%", "%25").replace("\r", "%0D").replace("\n", "%0A")
+        print(f"::error title=Zulip PR status integration is broken::{safe}", flush=True)
     return 1
 
 
@@ -427,8 +433,10 @@ def main(argv):
     if cmd == "check":
         try:
             check(z)
-        except ConfigError as exc:
+        except ConfigError as exc:  # broken creds/permissions: loud, fails the run
             return fail_config(str(exc))
+        except Exception as exc:  # a transient probe failure is not a config break
+            log(f"check failed (non-fatal): {exc}")
         return 0
 
     # cmd == "reconcile"


### PR DESCRIPTION
This PR makes the Zulip PR-status integration fail loudly when its credentials are broken, instead of silently reporting green while nothing posts. A bad or empty API key (401), a forbidden bot (403), missing credentials, or a bot that is not subscribed to the channel now raises a `ConfigError` that prints a GitHub Actions `::error::` annotation and exits non-zero, turning the workflow run red; a transient hiccup (one Zulip 5xx, a PR with no message yet) still exits 0 and stays green. Both per-PR workflows drop `continue-on-error` so the loud path is visible -- until now every run reported success even while a malformed key meant nothing was written, which hid a total outage for five days. The script also strips the credentials so a stray trailing newline in the secret (the usual "Malformed API key" cause) no longer breaks authentication. A new `check` subcommand and a scheduled `zulip-healthcheck` workflow probe the credentials every six hours so a broken key surfaces even with no PR activity, and the README documents the quiet-versus-loud failure modes and how to set the secret without a trailing newline.

🤖 Prepared with Claude Code