### PR TITLE
feat: functoriality of the diagonalizable group in the abelian group

### DIFF
--- a/TauCeti/Algebra/AlgebraicGroup/DiagonalizableGroupFunctoriality.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/DiagonalizableGroupFunctoriality.lean
@@ -1,0 +1,141 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+import Mathlib.RingTheory.Bialgebra.MonoidAlgebra
+import TauCeti.Algebra.AlgebraicGroup.DiagonalizableGroup
+import TauCeti.Algebra.AlgebraicGroup.HopfMap
+
+/-!
+# Functoriality of the diagonalizable group in the abelian group
+
+`TauCeti.Algebra.AlgebraicGroup.DiagonalizableGroup` computes the functor of points of the
+diagonalizable group `D(G) = Spec R[G]`: for every commutative `R`-algebra `A`, the
+convolution group of `R`-algebra maps `R[G] →ₐ[R] A` is the character group `G →* Aˣ`. This
+file records the remaining variance, making `D` into a **contravariant functor** on commutative
+groups: a group homomorphism `φ : G →* G'` induces a homomorphism of group functors
+`D(φ) : D(G') → D(G)`, and under the character identification this is just **precomposition**
+`χ ↦ χ ∘ φ` of characters.
+
+Concretely `φ` induces, by `MonoidAlgebra.mapDomainBialgHom`, the bialgebra map
+`R[G] →ₐc[R] R[G']`, which `TauCeti.AlgHom.mapDomain` turns into a monoid homomorphism
+`WithConv (R[G'] →ₐ[R] A) →* WithConv (R[G] →ₐ[R] A)` of convolution groups. The headline
+calculation `pointsMulEquiv_pointsMap` says this monoid homomorphism is intertwined by
+`pointsMulEquiv` with precomposition by `φ` on character groups, so the contravariant functor
+`G ↦ D(G)` agrees on points with the contravariant functor `G ↦ (G →* Aˣ)`. This is the
+on-points half of the roadmap's anti-equivalence `M ↦ D(M)`.
+
+This advances the reductive-groups roadmap (Layer 4, "diagonalizable groups and groups of
+multiplicative type: the anti-equivalence `M ↦ D(M)`"), building on the diagonalizable-group
+worked example and the coordinate-Hopf-algebra functoriality `AlgHom.mapDomain`.
+
+## Main declarations
+
+* `TauCeti.DiagonalizableGroup.pointsMap`: the homomorphism of convolution groups of points
+  induced by a group homomorphism `φ : G →* G'`, contravariantly.
+* `TauCeti.DiagonalizableGroup.pointsMap_id`, `TauCeti.DiagonalizableGroup.pointsMap_comp`:
+  the contravariant functoriality of `pointsMap`.
+* `TauCeti.DiagonalizableGroup.charOfPoint_comp`: reading off the character of a precomposed
+  point is precomposition of the character by `φ`.
+* `TauCeti.DiagonalizableGroup.pointsMulEquiv_pointsMap`: the points homomorphism is
+  intertwined by `pointsMulEquiv` with precomposition of characters by `φ`.
+* `TauCeti.DiagonalizableGroup.pointsMap_mapValue`: `pointsMap` is natural in the value
+  algebra.
+
+## References
+
+The group-algebra bialgebra functoriality `MonoidAlgebra.mapDomainBialgHom` is Mathlib's
+(`Mathlib.RingTheory.Bialgebra.MonoidAlgebra`). The convolution-group functoriality in the
+coordinate Hopf algebra is Tau Ceti's `TauCeti.AlgHom.mapDomain`
+(`TauCeti.Algebra.AlgebraicGroup.HopfMap`). This realizes the diagonalizable-group
+functoriality of the Tau Ceti reductive-groups roadmap (Layer 4).
+-/
+
+open WithConv
+
+namespace TauCeti
+
+universe u v w w' w''
+
+namespace DiagonalizableGroup
+
+variable {R : Type u} {A : Type v} {G : Type w} {G' : Type w'} {G'' : Type w''}
+variable [CommSemiring R] [CommSemiring A] [Algebra R A]
+variable [CommGroup G] [CommGroup G'] [CommGroup G'']
+
+/-- The bialgebra map `R[G] →ₐc[R] R[G']` induced by `φ` sends the group-like `single g 1` to
+the group-like `single (φ g) 1`. -/
+@[simp]
+theorem mapDomainBialgHom_single_one (φ : G →* G') (g : G) :
+    MonoidAlgebra.mapDomainBialgHom R φ (MonoidAlgebra.single g (1 : R)) =
+      MonoidAlgebra.single (φ g) 1 := by
+  rw [MonoidAlgebra.mapDomainBialgHom_apply, MonoidAlgebra.mapDomain_single]
+
+/-- **The diagonalizable group is contravariant in the abelian group.** A group homomorphism
+`φ : G →* G'` induces, by pre-composition with the bialgebra map `R[G] →ₐc[R] R[G']`, a
+homomorphism of convolution groups of points `D(G')(A) → D(G)(A)`. -/
+noncomputable def pointsMap (φ : G →* G') :
+    WithConv (MonoidAlgebra R G' →ₐ[R] A) →* WithConv (MonoidAlgebra R G →ₐ[R] A) :=
+  AlgHom.mapDomain (MonoidAlgebra.mapDomainBialgHom R φ)
+
+/-- `pointsMap φ` acts by pre-composition with the induced bialgebra map. -/
+@[simp]
+theorem pointsMap_apply (φ : G →* G') (f : WithConv (MonoidAlgebra R G' →ₐ[R] A)) :
+    pointsMap (A := A) φ f =
+      toConv (f.ofConv.comp
+        (MonoidAlgebra.mapDomainBialgHom R φ : MonoidAlgebra R G →ₐ[R] MonoidAlgebra R G')) :=
+  rfl
+
+/-- Pre-composition by the identity homomorphism is the identity on points. -/
+@[simp]
+theorem pointsMap_id :
+    (pointsMap (MonoidHom.id G) :
+        WithConv (MonoidAlgebra R G →ₐ[R] A) →* WithConv (MonoidAlgebra R G →ₐ[R] A)) =
+      MonoidHom.id _ := by
+  rw [pointsMap, MonoidAlgebra.mapDomainBialgHom_id, AlgHom.mapDomain_id]
+
+/-- **Contravariant functoriality.** Pre-composition by a composite homomorphism is the
+composite of the induced points homomorphisms, in the opposite order. -/
+theorem pointsMap_comp (φ : G →* G') (ψ : G' →* G'') :
+    (pointsMap (A := A) (ψ.comp φ) :
+        WithConv (MonoidAlgebra R G'' →ₐ[R] A) →* WithConv (MonoidAlgebra R G →ₐ[R] A)) =
+      (pointsMap (R := R) (A := A) φ).comp (pointsMap (R := R) (A := A) ψ) := by
+  rw [pointsMap, pointsMap, pointsMap, MonoidAlgebra.mapDomainBialgHom_comp,
+    AlgHom.mapDomain_comp]
+
+/-- Reading off the character of a point pre-composed by the induced bialgebra map is the
+character of the original point pre-composed by `φ`. -/
+@[simp]
+theorem charOfPoint_comp (φ : G →* G') (f : MonoidAlgebra R G' →ₐ[R] A) :
+    charOfPoint (f.comp
+        (MonoidAlgebra.mapDomainBialgHom R φ : MonoidAlgebra R G →ₐ[R] MonoidAlgebra R G')) =
+      (charOfPoint f).comp φ := by
+  ext g
+  rw [charOfPoint_apply_coe, AlgHom.comp_apply, MonoidHom.comp_apply, charOfPoint_apply_coe,
+    BialgHom.coe_toAlgHom (MonoidAlgebra.mapDomainBialgHom R φ), mapDomainBialgHom_single_one]
+
+/-- **The points homomorphism is precomposition of characters.** Under the identification of
+points of `D(G)` with characters of `G`, the homomorphism `pointsMap φ` induced by
+`φ : G →* G'` is intertwined with precomposition `χ ↦ χ ∘ φ` of characters. -/
+theorem pointsMulEquiv_pointsMap (φ : G →* G') (f : WithConv (MonoidAlgebra R G' →ₐ[R] A)) :
+    pointsMulEquiv (pointsMap (A := A) φ f) = (pointsMulEquiv f).comp φ := by
+  rw [pointsMap_apply, pointsMulEquiv_apply, ofConv_toConv, pointsMulEquiv_apply, charOfPoint_comp]
+
+section MapValue
+
+variable {B : Type*} [CommSemiring B] [Algebra R B]
+
+/-- `pointsMap` is natural in the value algebra: post-composing a point with an `R`-algebra map
+of value algebras commutes with the pre-composition in the coordinate group. -/
+theorem pointsMap_mapValue (φ : G →* G') (χ : A →ₐ[R] B) :
+    (pointsMap (R := R) (A := B) φ).comp (AlgHom.mapValue (H := MonoidAlgebra R G') χ) =
+      (AlgHom.mapValue (H := MonoidAlgebra R G) χ).comp (pointsMap (R := R) (A := A) φ) := by
+  ext f
+  simp only [MonoidHom.comp_apply, pointsMap_apply, AlgHom.mapValue_apply, ofConv_toConv,
+    AlgHom.comp_assoc]
+
+end MapValue
+
+end DiagonalizableGroup
+
+end TauCeti

--- a/TauCeti/Algebra/AlgebraicGroup/DiagonalizableGroupFunctoriality.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/DiagonalizableGroupFunctoriality.lean
@@ -63,10 +63,8 @@ variable {R : Type u} {A : Type v} {G : Type w} {G' : Type w'} {G'' : Type w''}
 variable [CommSemiring R] [CommSemiring A] [Algebra R A]
 variable [CommGroup G] [CommGroup G'] [CommGroup G'']
 
-/-- The bialgebra map `R[G] →ₐc[R] R[G']` induced by `φ` sends the group-like `single g 1` to
-the group-like `single (φ g) 1`. -/
 @[simp]
-theorem mapDomainBialgHom_single_one (φ : G →* G') (g : G) :
+private theorem mapDomainBialgHom_single_one (φ : G →* G') (g : G) :
     MonoidAlgebra.mapDomainBialgHom R φ (MonoidAlgebra.single g (1 : R)) =
       MonoidAlgebra.single (φ g) 1 := by
   rw [MonoidAlgebra.mapDomainBialgHom_apply, MonoidAlgebra.mapDomain_single]
@@ -117,9 +115,20 @@ theorem charOfPoint_comp (φ : G →* G') (f : MonoidAlgebra R G' →ₐ[R] A) :
 /-- **The points homomorphism is precomposition of characters.** Under the identification of
 points of `D(G)` with characters of `G`, the homomorphism `pointsMap φ` induced by
 `φ : G →* G'` is intertwined with precomposition `χ ↦ χ ∘ φ` of characters. -/
+@[simp]
 theorem pointsMulEquiv_pointsMap (φ : G →* G') (f : WithConv (MonoidAlgebra R G' →ₐ[R] A)) :
     pointsMulEquiv (pointsMap (A := A) φ f) = (pointsMulEquiv f).comp φ := by
   rw [pointsMap_apply, pointsMulEquiv_apply, ofConv_toConv, pointsMulEquiv_apply, charOfPoint_comp]
+
+/-- Mapping the point attached to a character is precomposition of that character by `φ`. -/
+@[simp]
+theorem pointsMap_pointsMulEquiv_symm (φ : G →* G') (χ : G' →* Aˣ) :
+    pointsMap (R := R) (A := A) φ ((pointsMulEquiv (R := R) (A := A) (G := G')).symm χ) =
+      (pointsMulEquiv (R := R) (A := A) (G := G)).symm (χ.comp φ) := by
+  apply (pointsMulEquiv (R := R) (A := A) (G := G)).injective
+  rw [pointsMulEquiv_pointsMap]
+  rw [(pointsMulEquiv (R := R) (A := A) (G := G')).apply_symm_apply χ]
+  exact ((pointsMulEquiv (R := R) (A := A) (G := G)).apply_symm_apply (χ.comp φ)).symm
 
 section MapValue
 
@@ -130,9 +139,7 @@ of value algebras commutes with the pre-composition in the coordinate group. -/
 theorem pointsMap_mapValue (φ : G →* G') (χ : A →ₐ[R] B) :
     (pointsMap (R := R) (A := B) φ).comp (AlgHom.mapValue (H := MonoidAlgebra R G') χ) =
       (AlgHom.mapValue (H := MonoidAlgebra R G) χ).comp (pointsMap (R := R) (A := A) φ) := by
-  ext f
-  simp only [MonoidHom.comp_apply, pointsMap_apply, AlgHom.mapValue_apply, ofConv_toConv,
-    AlgHom.comp_assoc]
+  exact AlgHom.mapValue_mapDomain (MonoidAlgebra.mapDomainBialgHom R φ) χ
 
 end MapValue
 

--- a/TauCeti/Algebra/AlgebraicGroup/DiagonalizableGroupFunctoriality.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/DiagonalizableGroupFunctoriality.lean
@@ -39,8 +39,6 @@ worked example and the coordinate-Hopf-algebra functoriality `AlgHom.mapDomain`.
   point is precomposition of the character by `φ`.
 * `TauCeti.DiagonalizableGroup.pointsMulEquiv_pointsMap`: the points homomorphism is
   intertwined by `pointsMulEquiv` with precomposition of characters by `φ`.
-* `TauCeti.DiagonalizableGroup.pointsMap_mapValue`: `pointsMap` is natural in the value
-  algebra.
 
 ## References
 
@@ -129,19 +127,6 @@ theorem pointsMap_pointsMulEquiv_symm (φ : G →* G') (χ : G' →* Aˣ) :
   rw [pointsMulEquiv_pointsMap]
   rw [(pointsMulEquiv (R := R) (A := A) (G := G')).apply_symm_apply χ]
   exact ((pointsMulEquiv (R := R) (A := A) (G := G)).apply_symm_apply (χ.comp φ)).symm
-
-section MapValue
-
-variable {B : Type*} [CommSemiring B] [Algebra R B]
-
-/-- `pointsMap` is natural in the value algebra: post-composing a point with an `R`-algebra map
-of value algebras commutes with the pre-composition in the coordinate group. -/
-theorem pointsMap_mapValue (φ : G →* G') (χ : A →ₐ[R] B) :
-    (pointsMap (R := R) (A := B) φ).comp (AlgHom.mapValue (H := MonoidAlgebra R G') χ) =
-      (AlgHom.mapValue (H := MonoidAlgebra R G) χ).comp (pointsMap (R := R) (A := A) φ) := by
-  exact AlgHom.mapValue_mapDomain (MonoidAlgebra.mapDomainBialgHom R φ) χ
-
-end MapValue
 
 end DiagonalizableGroup
 

--- a/TauCeti/Algebra/AlgebraicGroup/DiagonalizableGroupFunctoriality.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/DiagonalizableGroupFunctoriality.lean
@@ -35,6 +35,8 @@ worked example and the coordinate-Hopf-algebra functoriality `AlgHom.mapDomain`.
   induced by a group homomorphism `φ : G →* G'`, contravariantly.
 * `TauCeti.DiagonalizableGroup.pointsMap_id`, `TauCeti.DiagonalizableGroup.pointsMap_comp`:
   the contravariant functoriality of `pointsMap`.
+* `TauCeti.DiagonalizableGroup.mapValue_pointsMap`: `pointsMap` is natural in the value
+  algebra, commuting with `AlgHom.mapValue`.
 * `TauCeti.DiagonalizableGroup.charOfPoint_comp`: reading off the character of a precomposed
   point is precomposition of the character by `φ`.
 * `TauCeti.DiagonalizableGroup.pointsMulEquiv_pointsMap`: the points homomorphism is
@@ -99,6 +101,17 @@ theorem pointsMap_comp (φ : G →* G') (ψ : G' →* G'') :
   rw [pointsMap, pointsMap, pointsMap, MonoidAlgebra.mapDomainBialgHom_comp,
     AlgHom.mapDomain_comp]
 
+/-- **Naturality in the value algebra.** The contravariant points homomorphism `pointsMap φ`
+commutes with the value-algebra functoriality `AlgHom.mapValue χ`: pre-composition by the
+induced bialgebra map and post-composition by `χ : A →ₐ[R] B` may be applied in either order.
+This makes `pointsMap φ` a natural transformation of functors of points. -/
+theorem mapValue_pointsMap {B : Type*} [CommSemiring B] [Algebra R B] (φ : G →* G')
+    (χ : A →ₐ[R] B) :
+    (pointsMap (A := B) φ).comp (AlgHom.mapValue (H := MonoidAlgebra R G') χ) =
+      (AlgHom.mapValue (H := MonoidAlgebra R G) χ).comp (pointsMap (A := A) φ) := by
+  rw [pointsMap, pointsMap]
+  exact AlgHom.mapValue_mapDomain (MonoidAlgebra.mapDomainBialgHom R φ) χ
+
 /-- Reading off the character of a point pre-composed by the induced bialgebra map is the
 character of the original point pre-composed by `φ`. -/
 @[simp]
@@ -120,7 +133,7 @@ theorem pointsMulEquiv_pointsMap (φ : G →* G') (f : WithConv (MonoidAlgebra R
 
 /-- Mapping the point attached to a character is precomposition of that character by `φ`. -/
 @[simp]
-theorem pointsMap_pointsMulEquiv_symm (φ : G →* G') (χ : G' →* Aˣ) :
+theorem pointsMap_pointsMulEquiv_symm_apply (φ : G →* G') (χ : G' →* Aˣ) :
     pointsMap (R := R) (A := A) φ ((pointsMulEquiv (R := R) (A := A) (G := G')).symm χ) =
       (pointsMulEquiv (R := R) (A := A) (G := G)).symm (χ.comp φ) := by
   apply (pointsMulEquiv (R := R) (A := A) (G := G)).injective


### PR DESCRIPTION
This PR makes the diagonalizable group `D(G) = Spec R[G]` into a contravariant functor in the abelian group `G` on its functor of points, and identifies that functoriality, under the character description of points, with precomposition of characters. A group homomorphism `φ : G →* G'` induces, via Mathlib's group-algebra bialgebra map `MonoidAlgebra.mapDomainBialgHom` and the coordinate-Hopf-algebra functoriality `TauCeti.AlgHom.mapDomain`, a homomorphism of convolution groups of points `pointsMap φ : WithConv (R[G'] →ₐ[R] A) →* WithConv (R[G] →ₐ[R] A)`; this is contravariantly functorial (`pointsMap_id`, `pointsMap_comp`) and natural in the value algebra (`pointsMap_mapValue`). The headline calculation `pointsMulEquiv_pointsMap` shows that under the existing identification `pointsMulEquiv` of points of `D(G)` with characters `G →* Aˣ`, this map is precomposition `χ ↦ χ ∘ φ`, so the contravariant functor `G ↦ D(G)` agrees on points with `G ↦ (G →* Aˣ)`. This is the on-points half of the roadmap's anti-equivalence `M ↦ D(M)`.

This advances `TauCetiRoadmap/ReductiveGroups/README.md`, Layer 4 ("Diagonalizable groups and groups of multiplicative type: the anti-equivalence `M ↦ D(M) = Spec k[M]` between finitely generated abelian groups and diagonalizable groups"), building on the existing diagonalizable-group worked example `TauCeti.DiagonalizableGroup.pointsMulEquiv` and the convolution-group functoriality `TauCeti.AlgHom.mapDomain`.

The group-algebra bialgebra functoriality `MonoidAlgebra.mapDomainBialgHom` (and `mapDomain_single`) reused here is Mathlib's, from `Mathlib.RingTheory.Bialgebra.MonoidAlgebra` and `Mathlib.Algebra.MonoidAlgebra.MapDomain`.

<!--tauceti-target:v1 {"focus":"ReductiveGroups","id":"diagonalizable-group-functoriality"}-->

🤖 Prepared with Claude Code
