### PR TITLE
feat: count the roots of all polynomials of bounded degree and height

### DIFF
--- a/TauCeti/Algebra/Polynomial/CardRootSetUnion.lean
+++ b/TauCeti/Algebra/Polynomial/CardRootSetUnion.lean
@@ -35,9 +35,9 @@ built on.
 
 ## Main results
 
-* `TauCeti.Polynomial.ncard_iUnion_roots_natDegree_le_coeff_mem_le`: at most `#U ^ (d + 1) · d`
+* `TauCeti.Polynomial.ncard_biUnion_roots_natDegree_le_coeff_mem_le`: at most `#U ^ (d + 1) · d`
   roots in `S` among all degree-`≤ d` polynomials with every coefficient in a finite set `U`.
-* `TauCeti.Polynomial.ncard_iUnion_roots_natDegree_le_abs_intCoeff_le`: the integer
+* `TauCeti.Polynomial.ncard_biUnion_roots_natDegree_le_abs_intCoeff_le`: the integer
   specialisation, `(2 · B + 1) ^ (d + 1) · d` roots among all degree-`≤ d` integer polynomials
   with every coefficient bounded by `B` in absolute value. This is the form named by the
   Layer-2 ("effective Hermite–Minkowski") target.
@@ -54,7 +54,7 @@ finite set `U`, mapped along a ring hom `m : R →+* S`, number at most `#U ^ (d
 at most `#U ^ (d + 1)` such polynomials, and each, having degree at most `d`, has at most `d` roots
 in `S`. This is the explicit cardinality of the set whose finiteness is
 `Polynomial.bUnion_roots_finite`. -/
-theorem ncard_iUnion_roots_natDegree_le_coeff_mem_le (m : R →+* S) (d : ℕ) (U : Finset R) :
+theorem ncard_biUnion_roots_natDegree_le_coeff_mem_le (m : R →+* S) (d : ℕ) (U : Finset R) :
     (⋃ (f : R[X]) (_ : f.natDegree ≤ d ∧ ∀ i, f.coeff i ∈ U),
         ((f.map m).roots.toFinset : Set S)).ncard ≤ U.card ^ (d + 1) * d := by
   classical
@@ -82,10 +82,10 @@ most `d` with every coefficient bounded by `B` in absolute value number at most
 `(2 · B + 1) ^ (d + 1) · d`. Each of the `2 · B + 1` integers in `[-B, B]` is an allowed
 coefficient, and a degree-`≤ d` polynomial has at most `d` roots. This is the counting input named
 by the Layer-2 effective Hermite–Minkowski target. -/
-theorem ncard_iUnion_roots_natDegree_le_abs_intCoeff_le (m : ℤ →+* S) (d B : ℕ) :
+theorem ncard_biUnion_roots_natDegree_le_abs_intCoeff_le (m : ℤ →+* S) (d B : ℕ) :
     (⋃ (f : ℤ[X]) (_ : f.natDegree ≤ d ∧ ∀ i, |f.coeff i| ≤ (B : ℤ)),
         ((f.map m).roots.toFinset : Set S)).ncard ≤ (2 * B + 1) ^ (d + 1) * d := by
-  have key := ncard_iUnion_roots_natDegree_le_coeff_mem_le m d (Finset.Icc (-(B : ℤ)) B)
+  have key := ncard_biUnion_roots_natDegree_le_coeff_mem_le m d (Finset.Icc (-(B : ℤ)) B)
   have hU : (Finset.Icc (-(B : ℤ)) B).card = 2 * B + 1 := by rw [Int.card_Icc]; omega
   rw [hU] at key
   have hpred : ∀ (f : ℤ[X]) (i : ℕ),

--- a/TauCeti/Algebra/Polynomial/CardRootSetUnion.lean
+++ b/TauCeti/Algebra/Polynomial/CardRootSetUnion.lean
@@ -1,0 +1,96 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+import Mathlib.Algebra.Polynomial.Roots
+import Mathlib.Algebra.BigOperators.Finprod
+import Mathlib.Data.Set.Card.Arithmetic
+import Mathlib.Data.Int.Interval
+import TauCeti.Algebra.Polynomial.CardBoundedCoeff
+
+/-!
+# Counting the roots of all polynomials of bounded degree and bounded coefficients
+
+For a ring hom `m : R →+* S` into a domain `S` and a finite set `U` of allowed coefficient
+values, the set of all roots in `S` of the polynomials of degree at most `d` with every
+coefficient in `U`,
+
+`⋃ (f) (_ : f.natDegree ≤ d ∧ ∀ i, f.coeff i ∈ U), (f.map m).roots.toFinset`,
+
+has cardinality at most `#U ^ (d + 1) · d`: there are at most `#U ^ (d + 1)` such polynomials
+(`TauCeti.Polynomial.ncard_natDegree_le_coeff_mem_le`), and each contributes at most `d`
+roots (a degree-`≤ d` polynomial has at most `d` roots in a domain).
+
+This is precisely the explicit count of the *generating set* in Mathlib's proof of Hermite's
+finiteness theorem. There, `NumberField.finite_of_discr_bdd` shows the number fields of bounded
+discriminant inside a fixed extension are finite by realising each as `ℚ(x)` for `x` a root of an
+integer polynomial of explicitly bounded degree and coefficient height, then invoking the
+*finiteness* of this very union of root sets, `Polynomial.bUnion_roots_finite`. Mathlib exposes
+only that finiteness; the effective Hermite–Minkowski target of the effective-bounds roadmap needs
+the matching explicit cardinality, so that an injection of the fields into this generating set
+turns into an explicit count of the fields. This file supplies that cardinality, upgrading
+`Polynomial.bUnion_roots_finite` exactly as
+`TauCeti.Polynomial.ncard_natDegree_le_coeff_mem_le` upgrades the polynomial finiteness it is
+built on.
+
+## Main results
+
+* `TauCeti.Polynomial.ncard_iUnion_roots_natDegree_le_coeff_mem_le`: at most `#U ^ (d + 1) · d`
+  roots in `S` among all degree-`≤ d` polynomials with every coefficient in a finite set `U`.
+* `TauCeti.Polynomial.ncard_iUnion_roots_natDegree_le_abs_intCoeff_le`: the integer
+  specialisation, `(2 · B + 1) ^ (d + 1) · d` roots among all degree-`≤ d` integer polynomials
+  with every coefficient bounded by `B` in absolute value. This is the form named by the
+  Layer-2 ("effective Hermite–Minkowski") target.
+-/
+
+open Polynomial
+
+namespace TauCeti.Polynomial
+
+variable {R S : Type*} [Semiring R] [CommRing S] [IsDomain S] [DecidableEq S]
+
+/-- The roots in a domain `S` of all polynomials of degree at most `d` with every coefficient in a
+finite set `U`, mapped along a ring hom `m : R →+* S`, number at most `#U ^ (d + 1) · d`: there are
+at most `#U ^ (d + 1)` such polynomials, and each, having degree at most `d`, has at most `d` roots
+in `S`. This is the explicit cardinality of the set whose finiteness is
+`Polynomial.bUnion_roots_finite`. -/
+theorem ncard_iUnion_roots_natDegree_le_coeff_mem_le (m : R →+* S) (d : ℕ) (U : Finset R) :
+    (⋃ (f : R[X]) (_ : f.natDegree ≤ d ∧ ∀ i, f.coeff i ∈ U),
+        ((f.map m).roots.toFinset : Set S)).ncard ≤ U.card ^ (d + 1) * d := by
+  classical
+  set s : R[X] → Set S := fun f => ((f.map m).roots.toFinset : Set S) with hs
+  -- The index set: the relevant polynomials, finite by the bounded-coefficient count.
+  set t : Set R[X] := {f | f.natDegree ≤ d ∧ ∀ i, f.coeff i ∈ U} with ht_def
+  have ht : t.Finite := finite_setOf_natDegree_le_coeff_mem d U.finite_toSet
+  -- Each such polynomial contributes at most `d` roots in `S`.
+  have hbound : ∀ f ∈ t, (s f).ncard ≤ d := by
+    intro f hf
+    rw [hs, Set.ncard_coe_finset]
+    exact (Multiset.toFinset_card_le _).trans ((card_roots_map_le_natDegree f).trans hf.1)
+  calc (⋃ (f : R[X]) (_ : f.natDegree ≤ d ∧ ∀ i, f.coeff i ∈ U), s f).ncard
+      = (⋃ f ∈ t, s f).ncard := rfl
+    _ ≤ ∑ᶠ f ∈ t, (s f).ncard := ht.ncard_biUnion_le s
+    _ = ∑ f ∈ ht.toFinset, (s f).ncard := finsum_mem_eq_finite_toFinset_sum _ ht
+    _ ≤ ∑ _f ∈ ht.toFinset, d :=
+        Finset.sum_le_sum fun f hf => hbound f ((Set.Finite.mem_toFinset ht).mp hf)
+    _ = ht.toFinset.card * d := by rw [Finset.sum_const, smul_eq_mul]
+    _ = t.ncard * d := by rw [Set.ncard_eq_toFinset_card t ht]
+    _ ≤ U.card ^ (d + 1) * d := by gcongr; exact ncard_natDegree_le_coeff_mem_le d U
+
+/-- The integer specialisation: the roots in a domain `S` of all integer polynomials of degree at
+most `d` with every coefficient bounded by `B` in absolute value number at most
+`(2 · B + 1) ^ (d + 1) · d`. Each of the `2 · B + 1` integers in `[-B, B]` is an allowed
+coefficient, and a degree-`≤ d` polynomial has at most `d` roots. This is the counting input named
+by the Layer-2 effective Hermite–Minkowski target. -/
+theorem ncard_iUnion_roots_natDegree_le_abs_intCoeff_le (m : ℤ →+* S) (d B : ℕ) :
+    (⋃ (f : ℤ[X]) (_ : f.natDegree ≤ d ∧ ∀ i, |f.coeff i| ≤ (B : ℤ)),
+        ((f.map m).roots.toFinset : Set S)).ncard ≤ (2 * B + 1) ^ (d + 1) * d := by
+  have key := ncard_iUnion_roots_natDegree_le_coeff_mem_le m d (Finset.Icc (-(B : ℤ)) B)
+  have hU : (Finset.Icc (-(B : ℤ)) B).card = 2 * B + 1 := by rw [Int.card_Icc]; omega
+  rw [hU] at key
+  have hpred : ∀ (f : ℤ[X]) (i : ℕ),
+      |f.coeff i| ≤ (B : ℤ) ↔ f.coeff i ∈ Finset.Icc (-(B : ℤ)) B := by
+    intro f i; rw [Finset.mem_Icc, abs_le]
+  simpa only [hpred] using key
+
+end TauCeti.Polynomial


### PR DESCRIPTION
This PR adds an explicit cardinality bound for the union of root sets of all polynomials of bounded degree and bounded coefficients: for a ring hom `m : R →+* S` into a domain and a finite set `U` of allowed coefficient values, the roots in `S` of the degree-`≤ d` polynomials with every coefficient in `U` number at most `#U ^ (d + 1) · d`. There are at most `#U ^ (d + 1)` such polynomials and each, having degree `≤ d`, contributes at most `d` roots. An integer specialisation counts the roots of degree-`≤ d` integer polynomials of coefficient height `≤ B` as at most `(2·B + 1) ^ (d + 1) · d`.

This is the explicit count of the *generating set* in Mathlib's proof of Hermite's finiteness theorem: `NumberField.finite_of_discr_bdd` realises each number field of bounded discriminant as `ℚ(x)` for `x` a root of an integer polynomial of explicitly bounded degree and height, then invokes the finiteness of exactly this union of root sets, `Polynomial.bUnion_roots_finite`. Mathlib exposes only that finiteness, so the effective Hermite–Minkowski count needs the matching explicit cardinality; this upgrades `Polynomial.bUnion_roots_finite` just as the existing `TauCeti.Polynomial.ncard_natDegree_le_coeff_mem_le` (from the polynomial-counting PR it consumes) upgrades the polynomial finiteness it is built on.

It advances the `TauCetiRoadmap/EffectiveBounds` roadmap, Layer 2 ("effective Hermite–Minkowski"): `EffectiveBounds/README.md` states that "the work is extracting and counting: bound the defining polynomial's coefficients explicitly, count the polynomials", and counting the fields means counting the generating set, i.e. counting the roots of those polynomials. The per-polynomial root bound reuses Mathlib's `Polynomial.card_roots_map_le_natDegree`, the union count reuses `Set.Finite.ncard_biUnion_le`, and the polynomial count reuses the in-repo `TauCeti.Algebra.Polynomial.CardBoundedCoeff`. No Mathlib infrastructure was vendored.

<!--tauceti-target:v1 {"focus":"EffectiveBounds","id":"ncard-bunion-roots-bounded-degree"}-->

🤖 Prepared with Claude Code
