### PR TITLE
feat: add lines-of-code-by-date charts to the website

### DIFF
--- a/.github/workflows/loc-graph.yml
+++ b/.github/workflows/loc-graph.yml
@@ -18,6 +18,10 @@ on:
     - cron: "0 6 * * 1"   # Mondays 06:00 UTC
   workflow_dispatch:
 
+concurrency:
+  group: loc-graph
+  cancel-in-progress: false
+
 jobs:
   graphs:
     runs-on: ubuntu-latest
@@ -62,5 +66,8 @@ jobs:
           else
             git add web/static_files/loc-tauceti.svg web/static_files/loc-roadmap.svg
             git commit -m "chore: refresh lines-of-code charts"
+            # Replay onto any commits that landed since checkout, so the push
+            # is a fast-forward even if main moved during this run.
+            git pull --rebase origin main
             git push
           fi

--- a/.github/workflows/loc-graph.yml
+++ b/.github/workflows/loc-graph.yml
@@ -1,0 +1,66 @@
+name: LoC graphs
+
+# Weekly: regenerate the "lines of code by date" charts shown on the website's
+# Statistics page, and commit them if they changed. The commit touches web/**,
+# which triggers pages.yml to redeploy the site.
+#
+# Both charts are rebuilt from scratch from git history each run (see
+# Scripts/loc_graph.py), so there is no state file to keep in sync. The TauCeti
+# chart comes from this repository's own history; the roadmap chart from a fresh
+# clone of the human-owned TauCetiRoadmap repository.
+#
+# The push uses the tauceti-review-bot App token (as update.yml does) so that the
+# pages.yml workflow fires on the resulting commit — a GITHUB_TOKEN push would not
+# trigger it.
+
+on:
+  schedule:
+    - cron: "0 6 * * 1"   # Mondays 06:00 UTC
+  workflow_dispatch:
+
+jobs:
+  graphs:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/create-github-app-token@v1
+        id: app-token
+        with:
+          app-id: ${{ secrets.APP_ID }}
+          private-key: ${{ secrets.APP_PRIVATE_KEY }}
+          owner: FormalFrontier
+
+      - name: Check out TauCeti (full history)
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          token: ${{ steps.app-token.outputs.token }}
+
+      - name: Clone the roadmap repository (full history)
+        run: git clone --quiet https://github.com/FormalFrontier/TauCetiRoadmap.git /tmp/roadmap
+
+      - name: Regenerate the charts
+        run: |
+          python3 Scripts/loc_graph.py \
+            --repo . --ref HEAD \
+            --title "Tau Ceti — lines of Lean" --accent "#ff9d4d" \
+            --out web/static_files/loc-tauceti.svg \
+            'TauCeti/**' 'TauCeti.lean'
+          python3 Scripts/loc_graph.py \
+            --repo /tmp/roadmap --ref HEAD \
+            --title "Tau Ceti Roadmap — lines written" --accent "#5eead4" \
+            --out web/static_files/loc-roadmap.svg \
+            'TauCetiRoadmap/**' 'TauCetiRoadmap.lean'
+
+      - name: Commit if the charts changed
+        run: |
+          git config user.name  "tauceti-review-bot[bot]"
+          git config user.email "290224625+tauceti-review-bot[bot]@users.noreply.github.com"
+          if git diff --quiet -- web/static_files/loc-tauceti.svg web/static_files/loc-roadmap.svg; then
+            echo "Charts unchanged; nothing to commit."
+          else
+            git add web/static_files/loc-tauceti.svg web/static_files/loc-roadmap.svg
+            git commit -m "chore: refresh lines-of-code charts"
+            git push
+          fi

--- a/Scripts/loc_graph.py
+++ b/Scripts/loc_graph.py
@@ -1,0 +1,147 @@
+#!/usr/bin/env python3
+"""Generate a self-contained "lines of code by date" SVG from git history.
+
+Pure stdlib: no third-party dependencies, so CI needs no `pip install`.
+
+Counts net lines (additions - deletions, from `git log --numstat`) of the files
+matching the given pathspecs, accumulated chronologically, one data point per
+day on which any matching commit landed. The whole series is reconstructed from
+git each run, so there is no state file to keep up to date.
+
+Styled to sit on the dark navy Tau Ceti site (see web/static_files/style.css).
+"""
+
+import subprocess, sys, argparse, datetime as dt, html, math
+
+# Palette mirrors style.css so the chart matches the site.
+BG      = "#101936"   # panel over the navy gradient
+PANEL   = "#1b2547"
+GRID    = "rgba(255,255,255,0.08)"
+AXIS    = "rgba(255,255,255,0.18)"
+TEXT    = "#eef2fb"
+MUTED   = "#9aa6c9"
+
+
+def series(repo, pathspecs, ref):
+    out = subprocess.run(
+        ["git", "-C", repo, "log", "--reverse", "--no-merges", "--numstat",
+         "--date=short", "--format=COMMIT %ad", ref, "--", *pathspecs],
+        capture_output=True, text=True, check=True).stdout
+    net, by_day, order = 0, {}, []
+    date = None
+    for line in out.splitlines():
+        if line.startswith("COMMIT "):
+            date = line[7:].strip()
+        elif line and date:
+            add, _, rest = line.partition("\t")
+            if add == "-":            # binary file
+                continue
+            dele = rest.split("\t", 1)[0]
+            net += int(add) - int(dele)
+            if date not in by_day:
+                order.append(date)
+            by_day[date] = net
+    return [(d, by_day[d]) for d in order]
+
+
+def nice_ceil(x):
+    """Round up to a 1/2/2.5/5 * 10^k value for a tidy axis top."""
+    if x <= 0:
+        return 1
+    mag = 10 ** math.floor(math.log10(x))
+    for m in (1, 2, 2.5, 5, 10):
+        if x <= m * mag:
+            return int(m * mag)
+    return int(10 * mag)
+
+
+def render(data, title, accent, out):
+    W, H = 900, 460
+    L, R, T, B = 72, 28, 60, 52      # margins
+    pw, ph = W - L - R, H - T - B
+
+    d0 = dt.date.fromisoformat(data[0][0])
+    d1 = dt.date.fromisoformat(data[-1][0])
+    span = max((d1 - d0).days, 1)
+    ymax = nice_ceil(max(v for _, v in data))
+
+    def X(d): return L + (dt.date.fromisoformat(d) - d0).days / span * pw
+    def Y(v): return T + ph - v / ymax * ph
+
+    pts = [(X(d), Y(v)) for d, v in data]
+    line = " ".join(f"{x:.1f},{y:.1f}" for x, y in pts)
+    area = f"{L},{T+ph} " + line + f" {L+pw},{T+ph}"
+
+    yticks = []
+    for i in range(6):
+        v = ymax * i // 5
+        y = Y(v)
+        yticks.append(f'<line class="grid" x1="{L}" y1="{y:.1f}" x2="{L+pw}" y2="{y:.1f}"/>')
+        yticks.append(f'<text class="ytick" x="{L-12}" y="{y+4:.1f}">{v:,}</text>')
+
+    # x ticks: walk left to right, label only when >= 78px past the last label
+    # (so runs of consecutive days don't collide); always keep first and last.
+    xticks, last_x = [], -1e9
+    for i, (d, _) in enumerate(data):
+        x = X(d)
+        forced = i == 0 or i == len(data) - 1
+        if forced or x - last_x >= 78:
+            if i == len(data) - 1 and xticks and x - last_x < 78:
+                xticks.pop()        # drop a label that would crowd the final one
+            lab = dt.date.fromisoformat(d).strftime("%b %-d")
+            xticks.append(f'<text class="xtick" x="{x:.1f}" y="{T+ph+24}">{lab}</text>')
+            last_x = x
+
+    dots = "".join(f'<circle cx="{x:.1f}" cy="{y:.1f}" r="3"/>' for x, y in pts)
+    latest = data[-1][1]
+    grad = "g" + accent.lstrip("#")
+
+    svg = f'''<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 {W} {H}"
+     font-family="ui-sans-serif,system-ui,-apple-system,'Segoe UI',Roboto,sans-serif" role="img"
+     aria-label="{html.escape(title)}: {latest:,} lines as of {data[-1][0]}">
+  <defs>
+    <linearGradient id="{grad}" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0" stop-color="{accent}" stop-opacity="0.28"/>
+      <stop offset="1" stop-color="{accent}" stop-opacity="0"/>
+    </linearGradient>
+  </defs>
+  <style>
+    .grid{{stroke:{GRID};stroke-width:1}}
+    .axis{{stroke:{AXIS};stroke-width:1}}
+    .ytick{{fill:{MUTED};font-size:13px;text-anchor:end}}
+    .xtick{{fill:{MUTED};font-size:13px;text-anchor:middle}}
+    .title{{fill:{TEXT};font-size:19px;font-weight:600}}
+    .sub{{fill:{MUTED};font-size:13px}}
+    .line{{fill:none;stroke:{accent};stroke-width:2.5;stroke-linejoin:round;stroke-linecap:round}}
+    circle{{fill:{accent}}}
+  </style>
+  <rect x="0.5" y="0.5" width="{W-1}" height="{H-1}" rx="12" fill="{BG}" stroke="{PANEL}"/>
+  <text class="title" x="{L}" y="30">{html.escape(title)}</text>
+  <text class="sub" x="{L}" y="48">{latest:,} lines as of {data[-1][0]}</text>
+  {''.join(yticks)}
+  <line class="axis" x1="{L}" y1="{T}" x2="{L}" y2="{T+ph}"/>
+  <line class="axis" x1="{L}" y1="{T+ph}" x2="{L+pw}" y2="{T+ph}"/>
+  <polygon points="{area}" fill="url(#{grad})"/>
+  <polyline class="line" points="{line}"/>
+  {dots}
+  {''.join(xticks)}
+</svg>
+'''
+    with open(out, "w") as f:
+        f.write(svg)
+
+
+if __name__ == "__main__":
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--repo", default=".")
+    ap.add_argument("--ref", default="HEAD")
+    ap.add_argument("--title", required=True)
+    ap.add_argument("--accent", default="#ff9d4d")
+    ap.add_argument("--out", required=True)
+    ap.add_argument("pathspecs", nargs="+")
+    a = ap.parse_args()
+    data = series(a.repo, a.pathspecs, a.ref)
+    if not data:
+        sys.exit("no commits matched pathspecs")
+    render(data, a.title, a.accent, a.out)
+    print(f"wrote {a.out}: {len(data)} points, latest {data[-1][1]:,}")

--- a/Scripts/loc_graph.py
+++ b/Scripts/loc_graph.py
@@ -88,7 +88,8 @@ def render(data, title, accent, out):
         if forced or x - last_x >= 78:
             if i == len(data) - 1 and xticks and x - last_x < 78:
                 xticks.pop()        # drop a label that would crowd the final one
-            lab = dt.date.fromisoformat(d).strftime("%b %-d")
+            dd = dt.date.fromisoformat(d)
+            lab = f"{dd:%b} {dd.day}"   # avoid the GNU-only %-d
             xticks.append(f'<text class="xtick" x="{x:.1f}" y="{T+ph+24}">{lab}</text>')
             last_x = x
 

--- a/web/Main.lean
+++ b/web/Main.lean
@@ -7,5 +7,6 @@ open Verso Genre Blog Site Syntax
 def taucetiSite : Site := site Site.Front /
   static "static" ← "static_files"
   "about" Site.About
+  "statistics" Site.Stats
 
 def main := blogMain theme taucetiSite

--- a/web/Site.lean
+++ b/web/Site.lean
@@ -1,2 +1,3 @@
 import Site.Front
 import Site.About
+import Site.Stats

--- a/web/Site/Stats.lean
+++ b/web/Site/Stats.lean
@@ -1,0 +1,36 @@
+import VersoBlog
+open Verso Genre Blog
+open Verso.Output Verso.Output.Html
+
+/-- The two "lines of code by date" charts. The SVGs are regenerated weekly into
+`static_files/` by the `loc-graph` workflow, so this page never needs touching as
+the project grows. They are embedded as a raw HTML blob: each `<img>` simply points
+at the static asset. -/
+def locGraphs : Html := {{
+  <div class="loc-graphs">
+    <figure class="loc-figure">
+      <img class="loc-graph" src="static/loc-tauceti.svg"
+           alt="Tau Ceti: lines of Lean by date"/>
+      <figcaption>"The Lean library under " <code>"TauCeti/"</code> ", net lines by date."</figcaption>
+    </figure>
+    <figure class="loc-figure">
+      <img class="loc-graph" src="static/loc-roadmap.svg"
+           alt="Tau Ceti Roadmap: lines written by date"/>
+      <figcaption>"The human-owned roadmap repository, net lines by date."</figcaption>
+    </figure>
+  </div>
+}}
+
+#doc (Page) "Statistics" =>
+
+How much mathematics has Tau Ceti formalized, and how fast is the roadmap that
+directs it growing? Both charts count net lines — additions minus deletions, taken
+from the git history and reconstructed from scratch each week, so they cannot drift.
+
+:::blob locGraphs
+:::
+
+The vertical scales differ by an order of magnitude and on purpose: the library is
+measured in tens of thousands of lines of Lean, the roadmap in thousands of lines of
+prose and target statements. The library figure counts only the mathematics — the
+files under `TauCeti/` — not the website or tooling.

--- a/web/Site/Theme.lean
+++ b/web/Site/Theme.lean
@@ -23,6 +23,7 @@ def theme : Theme := { Theme.default with
               <a class="brand" href="."><img src="static/header.png" alt="Tau Ceti"/></a>
               <nav class="nav-links">
                 <a href=".">"Home"</a>
+                <a href="statistics">"Statistics"</a>
                 <a href="about">"About"</a>
                 <a href="https://github.com/FormalFrontier/TauCeti">"GitHub"</a>
               </nav>
@@ -83,6 +84,15 @@ def theme : Theme := { Theme.default with
             <div class="card"><h3>"Reductive algebraic groups"</h3></div>
             <div class="card"><h3>"Partial differential equations"</h3></div>
           </div>
+        </section>
+
+        <section class="band growth">
+          <h2 class="section-title">"Growing fast"</h2>
+          <a class="growth-link" href="statistics">
+            <img class="growth-img" src="static/loc-tauceti.svg"
+                 alt="Tau Ceti: lines of Lean by date"/>
+            <span class="growth-cta">"See the statistics →"</span>
+          </a>
         </section>
 
         <section class="band repos">

--- a/web/static_files/loc-roadmap.svg
+++ b/web/static_files/loc-roadmap.svg
@@ -1,0 +1,30 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 900 460"
+     font-family="ui-sans-serif,system-ui,-apple-system,'Segoe UI',Roboto,sans-serif" role="img"
+     aria-label="Tau Ceti Roadmap — lines written: 5,963 lines as of 2026-06-20">
+  <defs>
+    <linearGradient id="g5eead4" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0" stop-color="#5eead4" stop-opacity="0.28"/>
+      <stop offset="1" stop-color="#5eead4" stop-opacity="0"/>
+    </linearGradient>
+  </defs>
+  <style>
+    .grid{stroke:rgba(255,255,255,0.08);stroke-width:1}
+    .axis{stroke:rgba(255,255,255,0.18);stroke-width:1}
+    .ytick{fill:#9aa6c9;font-size:13px;text-anchor:end}
+    .xtick{fill:#9aa6c9;font-size:13px;text-anchor:middle}
+    .title{fill:#eef2fb;font-size:19px;font-weight:600}
+    .sub{fill:#9aa6c9;font-size:13px}
+    .line{fill:none;stroke:#5eead4;stroke-width:2.5;stroke-linejoin:round;stroke-linecap:round}
+    circle{fill:#5eead4}
+  </style>
+  <rect x="0.5" y="0.5" width="899" height="459" rx="12" fill="#101936" stroke="#1b2547"/>
+  <text class="title" x="72" y="30">Tau Ceti Roadmap — lines written</text>
+  <text class="sub" x="72" y="48">5,963 lines as of 2026-06-20</text>
+  <line class="grid" x1="72" y1="408.0" x2="872" y2="408.0"/><text class="ytick" x="60" y="412.0">0</text><line class="grid" x1="72" y1="338.4" x2="872" y2="338.4"/><text class="ytick" x="60" y="342.4">2,000</text><line class="grid" x1="72" y1="268.8" x2="872" y2="268.8"/><text class="ytick" x="60" y="272.8">4,000</text><line class="grid" x1="72" y1="199.2" x2="872" y2="199.2"/><text class="ytick" x="60" y="203.2">6,000</text><line class="grid" x1="72" y1="129.6" x2="872" y2="129.6"/><text class="ytick" x="60" y="133.6">8,000</text><line class="grid" x1="72" y1="60.0" x2="872" y2="60.0"/><text class="ytick" x="60" y="64.0">10,000</text>
+  <line class="axis" x1="72" y1="60" x2="72" y2="408"/>
+  <line class="axis" x1="72" y1="408" x2="872" y2="408"/>
+  <polygon points="72,408 72.0,366.6 448.5,346.1 495.5,329.6 542.6,329.1 683.8,330.2 777.9,330.2 824.9,210.3 872.0,200.5 872,408" fill="url(#g5eead4)"/>
+  <polyline class="line" points="72.0,366.6 448.5,346.1 495.5,329.6 542.6,329.1 683.8,330.2 777.9,330.2 824.9,210.3 872.0,200.5"/>
+  <circle cx="72.0" cy="366.6" r="3"/><circle cx="448.5" cy="346.1" r="3"/><circle cx="495.5" cy="329.6" r="3"/><circle cx="542.6" cy="329.1" r="3"/><circle cx="683.8" cy="330.2" r="3"/><circle cx="777.9" cy="330.2" r="3"/><circle cx="824.9" cy="210.3" r="3"/><circle cx="872.0" cy="200.5" r="3"/>
+  <text class="xtick" x="72.0" y="432">Jun 3</text><text class="xtick" x="448.5" y="432">Jun 11</text><text class="xtick" x="542.6" y="432">Jun 13</text><text class="xtick" x="683.8" y="432">Jun 16</text><text class="xtick" x="777.9" y="432">Jun 18</text><text class="xtick" x="872.0" y="432">Jun 20</text>
+</svg>

--- a/web/static_files/loc-tauceti.svg
+++ b/web/static_files/loc-tauceti.svg
@@ -1,0 +1,30 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 900 460"
+     font-family="ui-sans-serif,system-ui,-apple-system,'Segoe UI',Roboto,sans-serif" role="img"
+     aria-label="Tau Ceti — lines of Lean: 27,962 lines as of 2026-06-21">
+  <defs>
+    <linearGradient id="gff9d4d" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0" stop-color="#ff9d4d" stop-opacity="0.28"/>
+      <stop offset="1" stop-color="#ff9d4d" stop-opacity="0"/>
+    </linearGradient>
+  </defs>
+  <style>
+    .grid{stroke:rgba(255,255,255,0.08);stroke-width:1}
+    .axis{stroke:rgba(255,255,255,0.18);stroke-width:1}
+    .ytick{fill:#9aa6c9;font-size:13px;text-anchor:end}
+    .xtick{fill:#9aa6c9;font-size:13px;text-anchor:middle}
+    .title{fill:#eef2fb;font-size:19px;font-weight:600}
+    .sub{fill:#9aa6c9;font-size:13px}
+    .line{fill:none;stroke:#ff9d4d;stroke-width:2.5;stroke-linejoin:round;stroke-linecap:round}
+    circle{fill:#ff9d4d}
+  </style>
+  <rect x="0.5" y="0.5" width="899" height="459" rx="12" fill="#101936" stroke="#1b2547"/>
+  <text class="title" x="72" y="30">Tau Ceti — lines of Lean</text>
+  <text class="sub" x="72" y="48">27,962 lines as of 2026-06-21</text>
+  <line class="grid" x1="72" y1="408.0" x2="872" y2="408.0"/><text class="ytick" x="60" y="412.0">0</text><line class="grid" x1="72" y1="338.4" x2="872" y2="338.4"/><text class="ytick" x="60" y="342.4">10,000</text><line class="grid" x1="72" y1="268.8" x2="872" y2="268.8"/><text class="ytick" x="60" y="272.8">20,000</text><line class="grid" x1="72" y1="199.2" x2="872" y2="199.2"/><text class="ytick" x="60" y="203.2">30,000</text><line class="grid" x1="72" y1="129.6" x2="872" y2="129.6"/><text class="ytick" x="60" y="133.6">40,000</text><line class="grid" x1="72" y1="60.0" x2="872" y2="60.0"/><text class="ytick" x="60" y="64.0">50,000</text>
+  <line class="axis" x1="72" y1="60" x2="72" y2="408"/>
+  <line class="axis" x1="72" y1="408" x2="872" y2="408"/>
+  <polygon points="72,408 72.0,407.8 116.4,405.3 338.7,384.3 383.1,364.2 427.6,348.1 472.0,340.8 516.4,327.3 605.3,316.5 649.8,306.0 694.2,303.0 738.7,289.6 783.1,271.8 827.6,248.6 872.0,213.4 872,408" fill="url(#gff9d4d)"/>
+  <polyline class="line" points="72.0,407.8 116.4,405.3 338.7,384.3 383.1,364.2 427.6,348.1 472.0,340.8 516.4,327.3 605.3,316.5 649.8,306.0 694.2,303.0 738.7,289.6 783.1,271.8 827.6,248.6 872.0,213.4"/>
+  <circle cx="72.0" cy="407.8" r="3"/><circle cx="116.4" cy="405.3" r="3"/><circle cx="338.7" cy="384.3" r="3"/><circle cx="383.1" cy="364.2" r="3"/><circle cx="427.6" cy="348.1" r="3"/><circle cx="472.0" cy="340.8" r="3"/><circle cx="516.4" cy="327.3" r="3"/><circle cx="605.3" cy="316.5" r="3"/><circle cx="649.8" cy="306.0" r="3"/><circle cx="694.2" cy="303.0" r="3"/><circle cx="738.7" cy="289.6" r="3"/><circle cx="783.1" cy="271.8" r="3"/><circle cx="827.6" cy="248.6" r="3"/><circle cx="872.0" cy="213.4" r="3"/>
+  <text class="xtick" x="72.0" y="432">Jun 3</text><text class="xtick" x="338.7" y="432">Jun 9</text><text class="xtick" x="427.6" y="432">Jun 11</text><text class="xtick" x="516.4" y="432">Jun 13</text><text class="xtick" x="605.3" y="432">Jun 15</text><text class="xtick" x="694.2" y="432">Jun 17</text><text class="xtick" x="783.1" y="432">Jun 19</text><text class="xtick" x="872.0" y="432">Jun 21</text>
+</svg>

--- a/web/static_files/style.css
+++ b/web/static_files/style.css
@@ -183,6 +183,46 @@ a.card:hover { transform: translateY(-3px); border-color: var(--teal); text-deco
 /* About / interior prose pages */
 .frontpage { padding-bottom: 1rem; }
 
+/* ---- lines-of-code charts ---- */
+/* Statistics page: the two figures stack, each chart fills its width. */
+.loc-graphs { display: flex; flex-direction: column; gap: 2rem; margin: 2rem 0; }
+.loc-figure { margin: 0; }
+.loc-graph { display: block; width: 100%; height: auto; }
+.loc-figure figcaption {
+  color: var(--muted);
+  font-size: 0.92rem;
+  text-align: center;
+  margin-top: 0.6rem;
+}
+.loc-figure figcaption code {
+  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+  color: var(--text);
+}
+
+/* Front-page teaser: the library chart linking through to the statistics page. */
+.growth-link {
+  display: block;
+  max-width: 760px;
+  margin: 0 auto;
+  text-align: center;
+}
+.growth-img {
+  display: block;
+  width: 100%;
+  height: auto;
+  border-radius: 12px;
+  transition: transform 0.15s;
+}
+.growth-link:hover { text-decoration: none; }
+.growth-link:hover .growth-img { transform: translateY(-2px); }
+.growth-cta {
+  display: inline-block;
+  margin-top: 0.9rem;
+  color: var(--teal);
+  font-family: var(--display);
+  font-weight: 500;
+}
+
 /* ---- responsive ---- */
 @media (max-width: 820px) {
   .hero { grid-template-columns: 1fr; padding: 2.75rem 0; }


### PR DESCRIPTION
This PR adds a Statistics page to the website that charts lines of code by date, one chart for the TauCeti Lean library and a separate one (different vertical scale) for the human-owned roadmap repository. A zero-dependency Python stdlib script (`Scripts/loc_graph.py`) reconstructs each series from `git log --numstat` — net lines accumulated by date — and emits a self-contained SVG styled for the site's dark theme, so there is no state file to keep in sync. A weekly workflow regenerates both charts (cloning the roadmap repository for the second), commits them under `web/static_files/` if they changed, and the resulting push redeploys the page through the existing `pages.yml`. The push uses the `tauceti-review-bot` App token, as `update.yml` does, so that the deploy actually fires. The front page gains a "Growing fast" teaser showing the library chart and linking through to the new page.

The charts are embedded with a Verso `:::blob` directive pointing at the static SVGs, and the page is registered alongside About. Initial SVGs are committed so the page works on first deploy.

This touches `web/`, `Scripts/`, and `.github/` (human-owned paths), so it needs a human review and does not auto-merge.

🤖 Prepared with Claude Code