### PR TITLE
feat: the maximal elementary-2 quotient Cl/Cl² of a class group

### DIFF
--- a/TauCeti/Algebra/Group/ElementaryTwoQuotient.lean
+++ b/TauCeti/Algebra/Group/ElementaryTwoQuotient.lean
@@ -34,13 +34,17 @@ names around it. The cardinality identity is still expressed through the squarin
 ## Main definitions and results
 
 * `TauCeti.ElementaryTwoQuotient`: the quotient `G ⧸ G²`, a `ZMod 2`-module.
-* `TauCeti.elementaryTwoQuotientMk` and `TauCeti.elementaryTwoQuotientMk_eq_zero_iff`: the class of
-  an element, trivial iff the element is a square; `elementaryTwoQuotientMk_mul`,
+* `TauCeti.elementaryTwoQuotientMkAdd`, `TauCeti.elementaryTwoQuotientMk`, and
+  `TauCeti.elementaryTwoQuotientMk_eq_zero_iff`: the quotient map and the class of an element,
+  trivial iff the element is a square; `elementaryTwoQuotientMk_mul`,
   `elementaryTwoQuotientMk_one`, and `elementaryTwoQuotientMk_prod` record its additivity.
 * `TauCeti.elementaryTwoQuotientMk_surjective` and `TauCeti.elementaryTwoQuotientMk_eq_iff`: the
   class map is surjective, and two elements have the same class iff they differ by a square.
 * `TauCeti.elementaryTwoQuotientLiftEquiv` and `TauCeti.elementaryTwoQuotientLinearLiftEquiv`: the
   universal property for maps out of `G/G²`, inherited from `ModN.liftEquiv`.
+* `TauCeti.range_lsmul_two_toAddSubgroup_eq_square_toAddSubgroup` and
+  `TauCeti.card_elementaryTwoQuotient_eq_index_square`: named identifications used to compute
+  the quotient cardinality.
 * `TauCeti.card_elementaryTwoQuotient_eq_card_sq_eq_one`: `|G/G²| = |{g | g² = 1}|`.
 * `TauCeti.twoRank` and `TauCeti.card_elementaryTwoQuotient_eq_two_pow_twoRank`: the 2-rank, with
   `|G/G²| = 2 ^ twoRank`.
@@ -60,16 +64,20 @@ instance [Finite G] : Finite (ElementaryTwoQuotient G) :=
 
 variable {G}
 
+/-- The quotient homomorphism `Additive G →+ G/G²`, exposed in the `ModN` additive form. -/
+def elementaryTwoQuotientMkAdd : Additive G →+ ElementaryTwoQuotient G :=
+  ModN.mkQ 2
+
 /-- The class of an element of `G` in the maximal elementary-2 quotient `G / G²`. -/
 def elementaryTwoQuotientMk (g : G) : ElementaryTwoQuotient G :=
-  ModN.mkQ 2 (Additive.ofMul g)
+  elementaryTwoQuotientMkAdd (Additive.ofMul g)
 
 /-- An element has trivial class in `G / G²` iff it is a square. -/
 @[simp] theorem elementaryTwoQuotientMk_eq_zero_iff (g : G) :
     elementaryTwoQuotientMk g = 0 ↔ IsSquare g := by
   -- `elementaryTwoQuotientMk g = ModN.mkQ 2 (ofMul g)` is the quotient map of `ofMul g`, so it
   -- vanishes iff `ofMul g` lies in the doubling subgroup `range (lsmul ℤ _ 2)`.
-  rw [elementaryTwoQuotientMk, ModN.mkQ]
+  rw [elementaryTwoQuotientMk, elementaryTwoQuotientMkAdd, ModN.mkQ]
   simp only [AddMonoidHom.coe_coe, Submodule.mkQ_apply]
   rw [Submodule.Quotient.mk_eq_zero, LinearMap.mem_range]
   constructor
@@ -128,38 +136,43 @@ theorem elementaryTwoQuotientMk_eq_iff (g h : G) :
 
 variable (G)
 
+/-- The doubling subgroup of `Additive G` is the additive form of the subgroup of squares of `G`. -/
+theorem range_lsmul_two_toAddSubgroup_eq_square_toAddSubgroup :
+    (LinearMap.range (LinearMap.lsmul ℤ (Additive G) ↑(2 : ℕ))).toAddSubgroup =
+      (Subgroup.square G).toAddSubgroup := by
+  ext g
+  rw [Submodule.mem_toAddSubgroup, Additive.mem_toAddSubgroup, LinearMap.mem_range,
+    Subgroup.mem_square]
+  constructor
+  · rintro ⟨a, rfl⟩
+    exact ⟨Additive.toMul a, by simp [toMul_zsmul, zpow_two]⟩
+  · rintro ⟨a, ha⟩
+    refine ⟨Additive.ofMul a, ?_⟩
+    apply Additive.toMul.injective
+    simpa [toMul_zsmul, zpow_two, pow_two] using ha.symm
+
+/-- The cardinality of `G/G²` is the index of the subgroup of squares. -/
+theorem card_elementaryTwoQuotient_eq_index_square [Finite G] :
+    Nat.card (ElementaryTwoQuotient G) = (Subgroup.square G).index := by
+  rw [show Nat.card (ElementaryTwoQuotient G)
+        = (LinearMap.range (LinearMap.lsmul ℤ (Additive G) ↑(2 : ℕ))).toAddSubgroup.index from
+        (AddSubgroup.index_eq_card
+          (LinearMap.range (LinearMap.lsmul ℤ (Additive G) ↑(2 : ℕ))).toAddSubgroup).symm,
+    range_lsmul_two_toAddSubgroup_eq_square_toAddSubgroup, Subgroup.index_toAddSubgroup]
+
 /-- **The maximal elementary-2 quotient and the 2-torsion subgroup have the same cardinality.**
 `|G/G²| = |{g | g² = 1}|`. The squaring endomorphism `g ↦ g²` has range `G²` and kernel the
 2-torsion; in a finite group the index of the range equals the cardinality of the kernel. -/
 theorem card_elementaryTwoQuotient_eq_card_sq_eq_one [Finite G] :
     Nat.card (ElementaryTwoQuotient G) = Nat.card {g : G // g ^ 2 = 1} := by
-  have hsq :
-      (LinearMap.range (LinearMap.lsmul ℤ (Additive G) ↑(2 : ℕ))).toAddSubgroup =
-      (Subgroup.square G).toAddSubgroup := by
-    ext g
-    rw [Submodule.mem_toAddSubgroup, Additive.mem_toAddSubgroup, LinearMap.mem_range,
-      Subgroup.mem_square]
-    constructor
-    · rintro ⟨a, rfl⟩
-      exact ⟨Additive.toMul a, by simp [toMul_zsmul, zpow_two]⟩
-    · rintro ⟨a, ha⟩
-      refine ⟨Additive.ofMul a, ?_⟩
-      apply Additive.toMul.injective
-      simpa [toMul_zsmul, zpow_two, pow_two] using ha.symm
-  -- `ElementaryTwoQuotient G = ModN (Additive G) 2` is the additive quotient of `Additive G` by the
-  -- doubling subgroup `(range (lsmul ℤ _ 2)).toAddSubgroup`, so its cardinality is that subgroup's
-  -- index (`AddSubgroup.index_eq_card`); `hsq` identifies the subgroup with the squares `G²`, which
-  -- are the range of the squaring homomorphism (`square_eq_powMonoidHom_two_range`).
-  rw [show Nat.card (ElementaryTwoQuotient G)
-        = (LinearMap.range (LinearMap.lsmul ℤ (Additive G) ↑(2 : ℕ))).toAddSubgroup.index from
-        (AddSubgroup.index_eq_card
-          (LinearMap.range (LinearMap.lsmul ℤ (Additive G) ↑(2 : ℕ))).toAddSubgroup).symm,
-    hsq, Subgroup.index_toAddSubgroup, square_eq_powMonoidHom_two_range, Subgroup.index_range]
+  rw [card_elementaryTwoQuotient_eq_index_square, square_eq_powMonoidHom_two_range,
+    Subgroup.index_range]
   exact Nat.card_congr (Equiv.subtypeEquivRight fun g => by simp [MonoidHom.mem_ker])
 
-/-- **The 2-rank of a finite commutative group**: the `ZMod 2`-dimension of the maximal
-elementary-2 quotient `G / G²`. -/
-noncomputable def twoRank [Finite G] : ℕ := Module.finrank (ZMod 2) (ElementaryTwoQuotient G)
+/-- **The 2-rank of a commutative group with finite-dimensional elementary-2 quotient**: the
+`ZMod 2`-dimension of the maximal elementary-2 quotient `G / G²`. -/
+noncomputable def twoRank [Module.Finite (ZMod 2) (ElementaryTwoQuotient G)] : ℕ :=
+  Module.finrank (ZMod 2) (ElementaryTwoQuotient G)
 
 /-- The maximal elementary-2 quotient has cardinality `2 ^ twoRank`: it is a finite `𝔽₂`-vector
 space of dimension the 2-rank. -/

--- a/TauCeti/Algebra/Group/ElementaryTwoQuotient.lean
+++ b/TauCeti/Algebra/Group/ElementaryTwoQuotient.lean
@@ -37,7 +37,9 @@ names around it. The cardinality identity is still expressed through the squarin
 * `TauCeti.elementaryTwoQuotientMkAdd`, `TauCeti.elementaryTwoQuotientMk`, and
   `TauCeti.elementaryTwoQuotientMk_eq_zero_iff`: the quotient map and the class of an element,
   trivial iff the element is a square; `elementaryTwoQuotientMk_mul`,
-  `elementaryTwoQuotientMk_one`, and `elementaryTwoQuotientMk_prod` record its additivity.
+  `elementaryTwoQuotientMk_one`, `elementaryTwoQuotientMk_inv`,
+  `elementaryTwoQuotientMk_div`, `elementaryTwoQuotientMk_pow`, and
+  `elementaryTwoQuotientMk_prod` record its additivity.
 * `TauCeti.elementaryTwoQuotientMk_surjective` and `TauCeti.elementaryTwoQuotientMk_eq_iff`: the
   class map is surjective, and two elements have the same class iff they differ by a square.
 * `TauCeti.elementaryTwoQuotientLiftEquiv` and `TauCeti.elementaryTwoQuotientLinearLiftEquiv`: the
@@ -122,6 +124,21 @@ protected def elementaryTwoQuotientLinearLiftEquiv [AddCommGroup H] [Module (ZMo
 @[simp] theorem elementaryTwoQuotientMk_one : elementaryTwoQuotientMk (1 : G) = 0 := by
   simp only [elementaryTwoQuotientMk, ofMul_one, AddMonoidHom.map_zero]
 
+/-- The class map to `G / G²` sends inverses to negatives. -/
+@[simp] theorem elementaryTwoQuotientMk_inv (g : G) :
+    elementaryTwoQuotientMk g⁻¹ = -elementaryTwoQuotientMk g := by
+  simp only [elementaryTwoQuotientMk, ofMul_inv, map_neg]
+
+/-- The class map to `G / G²` sends quotients to differences. -/
+@[simp] theorem elementaryTwoQuotientMk_div (g h : G) :
+    elementaryTwoQuotientMk (g / h) = elementaryTwoQuotientMk g - elementaryTwoQuotientMk h := by
+  simp only [elementaryTwoQuotientMk, ofMul_div, map_sub]
+
+/-- The class map to `G / G²` sends powers to scalar multiples. -/
+@[simp] theorem elementaryTwoQuotientMk_pow (g : G) (n : ℕ) :
+    elementaryTwoQuotientMk (g ^ n) = n • elementaryTwoQuotientMk g := by
+  simp only [elementaryTwoQuotientMk, ofMul_pow, map_nsmul]
+
 /-- The class map to `G / G²` sends a finite product to the sum of the classes. -/
 theorem elementaryTwoQuotientMk_prod {ι : Type*} (S : Finset ι) (g : ι → G) :
     elementaryTwoQuotientMk (∏ i ∈ S, g i) = ∑ i ∈ S, elementaryTwoQuotientMk (g i) := by
@@ -138,10 +155,7 @@ theorem elementaryTwoQuotientMk_surjective :
 /-- Two elements have the same class in `G / G²` iff they differ by a square. -/
 theorem elementaryTwoQuotientMk_eq_iff (g h : G) :
     elementaryTwoQuotientMk g = elementaryTwoQuotientMk h ↔ IsSquare (g / h) := by
-  have hdiv : elementaryTwoQuotientMk (g / h)
-      = elementaryTwoQuotientMk g - elementaryTwoQuotientMk h := by
-    simp only [elementaryTwoQuotientMk, ofMul_div, map_sub]
-  rw [← elementaryTwoQuotientMk_eq_zero_iff, hdiv, sub_eq_zero]
+  rw [← elementaryTwoQuotientMk_eq_zero_iff, elementaryTwoQuotientMk_div, sub_eq_zero]
 
 variable (G)
 
@@ -156,7 +170,7 @@ private theorem range_lsmul_two_toAddSubgroup_eq_square_toAddSubgroup :
     Subgroup.mem_square]
 
 /-- The cardinality of `G/G²` is the index of the subgroup of squares. -/
-theorem card_elementaryTwoQuotient_eq_index_square [Finite G] :
+theorem card_elementaryTwoQuotient_eq_index_square :
     Nat.card (ElementaryTwoQuotient G) = (Subgroup.square G).index := by
   -- `ElementaryTwoQuotient G` unfolds to `Additive G ⧸ range (lsmul ℤ _ 2)`, so its cardinality is
   -- definitionally the index of the doubling subgroup; `AddSubgroup.index_eq_card` names that
@@ -169,8 +183,10 @@ theorem card_elementaryTwoQuotient_eq_index_square [Finite G] :
 
 /-- **The maximal elementary-2 quotient and the 2-torsion subgroup have the same cardinality.**
 `|G/G²| = |{g | g² = 1}|`. The squaring endomorphism `g ↦ g²` has range `G²` and kernel the
-2-torsion; in a finite group the index of the range equals the cardinality of the kernel. -/
-theorem card_elementaryTwoQuotient_eq_card_twoTorsion [Finite G] :
+2-torsion; when its kernel has finite index, the index of the range equals the cardinality of the
+kernel. -/
+theorem card_elementaryTwoQuotient_eq_card_twoTorsion
+    [(powMonoidHom 2 : G →* G).ker.FiniteIndex] :
     Nat.card (ElementaryTwoQuotient G) = Nat.card {g : G // g ^ 2 = 1} := by
   rw [card_elementaryTwoQuotient_eq_index_square, square_eq_powMonoidHom_two_range,
     Subgroup.index_range]

--- a/TauCeti/Algebra/Group/ElementaryTwoQuotient.lean
+++ b/TauCeti/Algebra/Group/ElementaryTwoQuotient.lean
@@ -33,7 +33,8 @@ cleanest through the squaring homomorphism `powMonoidHom 2` and `Subgroup.index_
 
 * `TauCeti.elementaryTwoQuotient`: the quotient `G ⧸ G²`, a `ZMod 2`-module.
 * `TauCeti.elementaryTwoQuotientMk` and `TauCeti.elementaryTwoQuotientMk_eq_zero_iff`: the class of
-  an element, trivial iff the element is a square.
+  an element, trivial iff the element is a square; `elementaryTwoQuotientMk_mul`,
+  `elementaryTwoQuotientMk_one`, and `elementaryTwoQuotientMk_prod` record its additivity.
 * `TauCeti.card_elementaryTwoQuotient_eq_card_sq_eq_one`: `|G/G²| = |{g | g² = 1}|`.
 * `TauCeti.twoRank` and `TauCeti.card_elementaryTwoQuotient_eq_two_pow_twoRank`: the 2-rank, with
   `|G/G²| = 2 ^ twoRank`.
@@ -71,6 +72,20 @@ def elementaryTwoQuotientMk (g : G) : elementaryTwoQuotient G :=
     Subgroup.mem_square]
   simp
 
+/-- The class map to `G / G²` sends a product to the sum of the classes. -/
+@[simp] theorem elementaryTwoQuotientMk_mul (g h : G) :
+    elementaryTwoQuotientMk (g * h) = elementaryTwoQuotientMk g + elementaryTwoQuotientMk h := by
+  simp only [elementaryTwoQuotientMk, ofMul_mul, ← QuotientAddGroup.mk'_apply, map_add]
+
+/-- The class map to `G / G²` sends `1` to `0`. -/
+@[simp] theorem elementaryTwoQuotientMk_one : elementaryTwoQuotientMk (1 : G) = 0 := by
+  simp only [elementaryTwoQuotientMk, ofMul_one, ← QuotientAddGroup.mk'_apply, map_zero]
+
+/-- The class map to `G / G²` sends a finite product to the sum of the classes. -/
+theorem elementaryTwoQuotientMk_prod {ι : Type*} (S : Finset ι) (g : ι → G) :
+    elementaryTwoQuotientMk (∏ i ∈ S, g i) = ∑ i ∈ S, elementaryTwoQuotientMk (g i) := by
+  simp only [elementaryTwoQuotientMk, ofMul_prod, ← QuotientAddGroup.mk'_apply, map_sum]
+
 variable (G)
 
 /-- **The maximal elementary-2 quotient and the 2-torsion subgroup have the same cardinality.**
@@ -84,9 +99,10 @@ theorem card_elementaryTwoQuotient_eq_card_sq_eq_one [Finite G] :
   rw [← AddSubgroup.index_eq_card, Subgroup.index_toAddSubgroup, hsq, Subgroup.index_range]
   exact Nat.card_congr (Equiv.subtypeEquivRight fun g => by simp [MonoidHom.mem_ker])
 
-/-- **The 2-rank of a finite commutative group**: the `ZMod 2`-dimension of the maximal
-elementary-2 quotient `G / G²`. -/
-noncomputable def twoRank [Finite G] : ℕ := Module.finrank (ZMod 2) (elementaryTwoQuotient G)
+/-- **The 2-rank of a commutative group**: the `ZMod 2`-dimension of the maximal
+elementary-2 quotient `G / G²`. For an infinite quotient this `Module.finrank` is `0` by
+convention; the genus-theory use is for a finite group, where it is the genuine 2-rank. -/
+noncomputable def twoRank : ℕ := Module.finrank (ZMod 2) (elementaryTwoQuotient G)
 
 /-- The maximal elementary-2 quotient has cardinality `2 ^ twoRank`: it is a finite `𝔽₂`-vector
 space of dimension the 2-rank. -/

--- a/TauCeti/Algebra/Group/ElementaryTwoQuotient.lean
+++ b/TauCeti/Algebra/Group/ElementaryTwoQuotient.lean
@@ -1,0 +1,97 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+import Mathlib.Algebra.Field.ZMod
+import Mathlib.Algebra.Group.Subgroup.Even
+import Mathlib.Algebra.Module.ZMod
+import Mathlib.FieldTheory.Finiteness
+import Mathlib.GroupTheory.Index
+
+/-!
+# The maximal elementary-2 quotient `G / G²` of a commutative group
+
+For a commutative group `G`, the quotient by its subgroup of squares, `G / G²`, has every element
+of order dividing `2`, so it is a vector space over `𝔽₂ = ZMod 2`. When `G` is finite its dimension
+is the **2-rank** of `G`. This file develops that construction at the level of an arbitrary
+commutative group; the genus-theory specialization to a class group lives in
+`TauCeti.NumberTheory.ClassGroup.ElementaryTwoQuotient`, and the square-class group `Kˣ ⧸ (Kˣ)²` of
+`TauCeti.FieldTheory.SquareClassGroup` is the same construction for `G = Kˣ`.
+
+⚠ This quotient is the **maximal elementary-2 quotient** of `G`, *not* its 2-torsion subgroup
+`{g | g² = 1}`. The two are different objects — a quotient and a subgroup — but for a finite group
+they have the same cardinality, because the squaring endomorphism `g ↦ g²` has `G²` as its range and
+the 2-torsion as its kernel, and a finite group has the same cardinality as the product of the range
+and kernel of any endomorphism. We keep the two distinct in names and statements and record the
+cardinality identity as `card_elementaryTwoQuotient_eq_card_sq_eq_one`.
+
+Mathlib's `ModN G n` is the analogous additive quotient `G ⧸ nG` built from `range (lsmul ℤ G n)`;
+we keep the multiplicative `Subgroup.square` framing here because the cardinality identity is
+cleanest through the squaring homomorphism `powMonoidHom 2` and `Subgroup.index_range`.
+
+## Main definitions and results
+
+* `TauCeti.elementaryTwoQuotient`: the quotient `G ⧸ G²`, a `ZMod 2`-module.
+* `TauCeti.elementaryTwoQuotientMk` and `TauCeti.elementaryTwoQuotientMk_eq_zero_iff`: the class of
+  an element, trivial iff the element is a square.
+* `TauCeti.card_elementaryTwoQuotient_eq_card_sq_eq_one`: `|G/G²| = |{g | g² = 1}|`.
+* `TauCeti.twoRank` and `TauCeti.card_elementaryTwoQuotient_eq_two_pow_twoRank`: the 2-rank, with
+  `|G/G²| = 2 ^ twoRank`.
+-/
+
+namespace TauCeti
+
+variable (G : Type*) [CommGroup G]
+
+/-- **The maximal elementary-2 quotient `G / G²`** of a commutative group, written additively on
+`Additive G`. -/
+abbrev elementaryTwoQuotient : Type _ :=
+  Additive G ⧸ (Subgroup.square G).toAddSubgroup
+
+/-- The elementary-2 quotient is a `ZMod 2`-module: every element has order dividing two, since the
+double of any element is (additively) the class of a square. -/
+noncomputable instance : Module (ZMod 2) (elementaryTwoQuotient G) :=
+  QuotientAddGroup.zmodModule fun x => by
+    rw [Additive.mem_toAddSubgroup, Subgroup.mem_square, toMul_nsmul]
+    exact ⟨Additive.toMul x, pow_two _⟩
+
+instance [Finite G] : Finite (elementaryTwoQuotient G) :=
+  Finite.of_surjective _ (QuotientAddGroup.mk'_surjective _)
+
+variable {G}
+
+/-- The class of an element of `G` in the maximal elementary-2 quotient `G / G²`. -/
+def elementaryTwoQuotientMk (g : G) : elementaryTwoQuotient G :=
+  QuotientAddGroup.mk (Additive.ofMul g)
+
+/-- An element has trivial class in `G / G²` iff it is a square. -/
+@[simp] theorem elementaryTwoQuotientMk_eq_zero_iff (g : G) :
+    elementaryTwoQuotientMk g = 0 ↔ IsSquare g := by
+  rw [elementaryTwoQuotientMk, QuotientAddGroup.eq_zero_iff, Additive.mem_toAddSubgroup,
+    Subgroup.mem_square]
+  simp
+
+variable (G)
+
+/-- **The maximal elementary-2 quotient and the 2-torsion subgroup have the same cardinality.**
+`|G/G²| = |{g | g² = 1}|`. The squaring endomorphism `g ↦ g²` has range `G²` and kernel the
+2-torsion; in a finite group the index of the range equals the cardinality of the kernel. -/
+theorem card_elementaryTwoQuotient_eq_card_sq_eq_one [Finite G] :
+    Nat.card (elementaryTwoQuotient G) = Nat.card {g : G // g ^ 2 = 1} := by
+  have hsq : Subgroup.square G = (powMonoidHom 2 : G →* G).range := by
+    ext g
+    simp [Subgroup.mem_square, MonoidHom.mem_range, isSquare_iff_exists_sq, eq_comm]
+  rw [← AddSubgroup.index_eq_card, Subgroup.index_toAddSubgroup, hsq, Subgroup.index_range]
+  exact Nat.card_congr (Equiv.subtypeEquivRight fun g => by simp [MonoidHom.mem_ker])
+
+/-- **The 2-rank of a finite commutative group**: the `ZMod 2`-dimension of the maximal
+elementary-2 quotient `G / G²`. -/
+noncomputable def twoRank [Finite G] : ℕ := Module.finrank (ZMod 2) (elementaryTwoQuotient G)
+
+/-- The maximal elementary-2 quotient has cardinality `2 ^ twoRank`: it is a finite `𝔽₂`-vector
+space of dimension the 2-rank. -/
+theorem card_elementaryTwoQuotient_eq_two_pow_twoRank [Finite G] :
+    Nat.card (elementaryTwoQuotient G) = 2 ^ twoRank G := by
+  rw [twoRank, Module.natCard_eq_pow_finrank (K := ZMod 2), Nat.card_zmod]
+
+end TauCeti

--- a/TauCeti/Algebra/Group/ElementaryTwoQuotient.lean
+++ b/TauCeti/Algebra/Group/ElementaryTwoQuotient.lean
@@ -25,7 +25,7 @@ commutative group; the genus-theory specialization to a class group lives in
 they have the same cardinality, because the squaring endomorphism `g ↦ g²` has `G²` as its range and
 the 2-torsion as its kernel, and a finite group has the same cardinality as the product of the range
 and kernel of any endomorphism. We keep the two distinct in names and statements and record the
-cardinality identity as `card_elementaryTwoQuotient_eq_card_sq_eq_one`.
+cardinality identity as `card_elementaryTwoQuotient_eq_card_twoTorsion`.
 
 This file uses Mathlib's additive quotient `ModN (Additive G) 2` and adds multiplicative-square
 names around it. The cardinality identity is still expressed through the squaring homomorphism
@@ -44,7 +44,7 @@ names around it. The cardinality identity is still expressed through the squarin
   universal property for maps out of `G/G²`, inherited from `ModN.liftEquiv`.
 * `TauCeti.card_elementaryTwoQuotient_eq_index_square`: the quotient cardinality as the index of
   the subgroup of squares.
-* `TauCeti.card_elementaryTwoQuotient_eq_card_sq_eq_one`: `|G/G²| = |{g | g² = 1}|`.
+* `TauCeti.card_elementaryTwoQuotient_eq_card_twoTorsion`: `|G/G²| = |{g | g² = 1}|`.
 * `TauCeti.twoRank` and `TauCeti.card_elementaryTwoQuotient_eq_two_pow_twoRank`: the 2-rank, with
   `|G/G²| = 2 ^ twoRank`.
 -/
@@ -71,6 +71,24 @@ def elementaryTwoQuotientMkAdd : Additive G →+ ElementaryTwoQuotient G :=
 def elementaryTwoQuotientMk (g : G) : ElementaryTwoQuotient G :=
   elementaryTwoQuotientMkAdd (Additive.ofMul g)
 
+/-- An element of `Additive G` lies in the doubling submodule `range (lsmul ℤ _ 2)` iff its
+multiplicative form is a square. This is the shared core relating the `ModN`/`lsmul` model of the
+quotient to the multiplicative subgroup of squares, used both by the zero-characterization and by
+the subgroup identification, and is kept private to the file. -/
+private theorem mem_range_lsmul_two_iff (a : Additive G) :
+    a ∈ LinearMap.range (LinearMap.lsmul ℤ (Additive G) ↑(2 : ℕ)) ↔
+      IsSquare (Additive.toMul a) := by
+  rw [LinearMap.mem_range]
+  constructor
+  · rintro ⟨b, hb⟩
+    refine ⟨Additive.toMul b, ?_⟩
+    have hmul := congr_arg Additive.toMul hb
+    simpa [toMul_zsmul, zpow_two, pow_two] using hmul.symm
+  · rintro ⟨b, hb⟩
+    refine ⟨Additive.ofMul b, ?_⟩
+    apply Additive.toMul.injective
+    simpa [toMul_zsmul, zpow_two, pow_two] using hb.symm
+
 /-- An element has trivial class in `G / G²` iff it is a square. -/
 @[simp] theorem elementaryTwoQuotientMk_eq_zero_iff (g : G) :
     elementaryTwoQuotientMk g = 0 ↔ IsSquare g := by
@@ -78,16 +96,8 @@ def elementaryTwoQuotientMk (g : G) : ElementaryTwoQuotient G :=
   -- vanishes iff `ofMul g` lies in the doubling subgroup `range (lsmul ℤ _ 2)`.
   rw [elementaryTwoQuotientMk, elementaryTwoQuotientMkAdd, ModN.mkQ]
   simp only [AddMonoidHom.coe_coe, Submodule.mkQ_apply]
-  rw [Submodule.Quotient.mk_eq_zero, LinearMap.mem_range]
-  constructor
-  · rintro ⟨a, ha⟩
-    refine ⟨Additive.toMul a, ?_⟩
-    have hmul := congr_arg Additive.toMul ha
-    simpa [toMul_zsmul, zpow_two, pow_two] using hmul.symm
-  · rintro ⟨a, ha⟩
-    refine ⟨Additive.ofMul a, ?_⟩
-    apply Additive.toMul.injective
-    simpa [toMul_zsmul, zpow_two, pow_two] using ha.symm
+  rw [Submodule.Quotient.mk_eq_zero]
+  exact mem_range_lsmul_two_iff (Additive.ofMul g)
 
 /-- The universal property of `G/G²` for additive homomorphisms: maps out of the quotient are
 additive homomorphisms from `Additive G` whose values are killed by `2`. -/
@@ -142,15 +152,8 @@ private theorem range_lsmul_two_toAddSubgroup_eq_square_toAddSubgroup :
     (LinearMap.range (LinearMap.lsmul ℤ (Additive G) ↑(2 : ℕ))).toAddSubgroup =
       (Subgroup.square G).toAddSubgroup := by
   ext g
-  rw [Submodule.mem_toAddSubgroup, Additive.mem_toAddSubgroup, LinearMap.mem_range,
+  rw [Submodule.mem_toAddSubgroup, mem_range_lsmul_two_iff, Additive.mem_toAddSubgroup,
     Subgroup.mem_square]
-  constructor
-  · rintro ⟨a, rfl⟩
-    exact ⟨Additive.toMul a, by simp [toMul_zsmul, zpow_two]⟩
-  · rintro ⟨a, ha⟩
-    refine ⟨Additive.ofMul a, ?_⟩
-    apply Additive.toMul.injective
-    simpa [toMul_zsmul, zpow_two, pow_two] using ha.symm
 
 /-- The cardinality of `G/G²` is the index of the subgroup of squares. -/
 theorem card_elementaryTwoQuotient_eq_index_square [Finite G] :
@@ -167,7 +170,7 @@ theorem card_elementaryTwoQuotient_eq_index_square [Finite G] :
 /-- **The maximal elementary-2 quotient and the 2-torsion subgroup have the same cardinality.**
 `|G/G²| = |{g | g² = 1}|`. The squaring endomorphism `g ↦ g²` has range `G²` and kernel the
 2-torsion; in a finite group the index of the range equals the cardinality of the kernel. -/
-theorem card_elementaryTwoQuotient_eq_card_sq_eq_one [Finite G] :
+theorem card_elementaryTwoQuotient_eq_card_twoTorsion [Finite G] :
     Nat.card (ElementaryTwoQuotient G) = Nat.card {g : G // g ^ 2 = 1} := by
   rw [card_elementaryTwoQuotient_eq_index_square, square_eq_powMonoidHom_two_range,
     Subgroup.index_range]

--- a/TauCeti/Algebra/Group/ElementaryTwoQuotient.lean
+++ b/TauCeti/Algebra/Group/ElementaryTwoQuotient.lean
@@ -44,6 +44,8 @@ names around it. The cardinality identity is still expressed through the squarin
   class map is surjective, and two elements have the same class iff they differ by a square.
 * `TauCeti.elementaryTwoQuotientLiftEquiv` and `TauCeti.elementaryTwoQuotientLinearLiftEquiv`: the
   universal property for maps out of `G/G²`, inherited from `ModN.liftEquiv`.
+* `TauCeti.elementaryTwoQuotientEquivSquareQuotient`: the equivalence between Mathlib's `ModN`
+  model and the quotient by the additive form of `G²`.
 * `TauCeti.card_elementaryTwoQuotient_eq_index_square`: the quotient cardinality as the index of
   the subgroup of squares.
 * `TauCeti.card_elementaryTwoQuotient_eq_card_twoTorsion`: `|G/G²| = |{g | g² = 1}|`.
@@ -169,17 +171,22 @@ private theorem range_lsmul_two_toAddSubgroup_eq_square_toAddSubgroup :
   rw [Submodule.mem_toAddSubgroup, mem_range_lsmul_two_iff, Additive.mem_toAddSubgroup,
     Subgroup.mem_square]
 
+/-- Mathlib's `ModN (Additive G) 2` model of `G/G²` agrees with the direct quotient by the
+additive form of the square subgroup. -/
+noncomputable def elementaryTwoQuotientEquivSquareQuotient :
+    ElementaryTwoQuotient G ≃+ Additive G ⧸ (Subgroup.square G).toAddSubgroup :=
+  QuotientAddGroup.congr _ _ (AddEquiv.refl (Additive G)) <| by
+    simpa using range_lsmul_two_toAddSubgroup_eq_square_toAddSubgroup G
+
 /-- The cardinality of `G/G²` is the index of the subgroup of squares. -/
 theorem card_elementaryTwoQuotient_eq_index_square :
     Nat.card (ElementaryTwoQuotient G) = (Subgroup.square G).index := by
-  -- `ElementaryTwoQuotient G` unfolds to `Additive G ⧸ range (lsmul ℤ _ 2)`, so its cardinality is
-  -- definitionally the index of the doubling subgroup; `AddSubgroup.index_eq_card` names that
-  -- defeq.
-  rw [show Nat.card (ElementaryTwoQuotient G)
-        = (LinearMap.range (LinearMap.lsmul ℤ (Additive G) ↑(2 : ℕ))).toAddSubgroup.index from
-        (AddSubgroup.index_eq_card
-          (LinearMap.range (LinearMap.lsmul ℤ (Additive G) ↑(2 : ℕ))).toAddSubgroup).symm,
-    range_lsmul_two_toAddSubgroup_eq_square_toAddSubgroup, Subgroup.index_toAddSubgroup]
+  calc
+    Nat.card (ElementaryTwoQuotient G)
+        = Nat.card (Additive G ⧸ (Subgroup.square G).toAddSubgroup) :=
+            Nat.card_congr (elementaryTwoQuotientEquivSquareQuotient (G := G)).toEquiv
+    _ = (Subgroup.square G).index := by
+          rw [← AddSubgroup.index_eq_card, Subgroup.index_toAddSubgroup]
 
 /-- **The maximal elementary-2 quotient and the 2-torsion subgroup have the same cardinality.**
 `|G/G²| = |{g | g² = 1}|`. The squaring endomorphism `g ↦ g²` has range `G²` and kernel the

--- a/TauCeti/Algebra/Group/ElementaryTwoQuotient.lean
+++ b/TauCeti/Algebra/Group/ElementaryTwoQuotient.lean
@@ -8,6 +8,7 @@ import Mathlib.Algebra.Module.ZMod
 import Mathlib.FieldTheory.Finiteness
 import Mathlib.GroupTheory.Index
 import Mathlib.LinearAlgebra.FreeModule.ModN
+import TauCeti.Algebra.Group.PowMonoidHom
 
 /-!
 # The maximal elementary-2 quotient `G / G²` of a commutative group
@@ -32,7 +33,7 @@ names around it. The cardinality identity is still expressed through the squarin
 
 ## Main definitions and results
 
-* `TauCeti.elementaryTwoQuotient`: the quotient `G ⧸ G²`, a `ZMod 2`-module.
+* `TauCeti.ElementaryTwoQuotient`: the quotient `G ⧸ G²`, a `ZMod 2`-module.
 * `TauCeti.elementaryTwoQuotientMk` and `TauCeti.elementaryTwoQuotientMk_eq_zero_iff`: the class of
   an element, trivial iff the element is a square; `elementaryTwoQuotientMk_mul`,
   `elementaryTwoQuotientMk_one`, and `elementaryTwoQuotientMk_prod` record its additivity.
@@ -51,16 +52,16 @@ variable (G : Type*) [CommGroup G]
 
 /-- **The maximal elementary-2 quotient `G / G²`** of a commutative group, written additively on
 `Additive G`. -/
-abbrev elementaryTwoQuotient : Type _ :=
+abbrev ElementaryTwoQuotient : Type _ :=
   ModN (Additive G) 2
 
-instance [Finite G] : Finite (elementaryTwoQuotient G) :=
+instance [Finite G] : Finite (ElementaryTwoQuotient G) :=
   Finite.of_surjective _ (QuotientAddGroup.mk'_surjective _)
 
 variable {G}
 
 /-- The class of an element of `G` in the maximal elementary-2 quotient `G / G²`. -/
-def elementaryTwoQuotientMk (g : G) : elementaryTwoQuotient G :=
+def elementaryTwoQuotientMk (g : G) : ElementaryTwoQuotient G :=
   ModN.mkQ 2 (Additive.ofMul g)
 
 /-- An element has trivial class in `G / G²` iff it is a square. -/
@@ -69,7 +70,7 @@ def elementaryTwoQuotientMk (g : G) : elementaryTwoQuotient G :=
   -- `elementaryTwoQuotientMk g = ModN.mkQ 2 (ofMul g)` is the quotient map of `ofMul g`, so it
   -- vanishes iff `ofMul g` lies in the doubling subgroup `range (lsmul ℤ _ 2)`.
   rw [elementaryTwoQuotientMk, ModN.mkQ]
-  change Submodule.Quotient.mk (Additive.ofMul g) = 0 ↔ IsSquare g
+  simp only [AddMonoidHom.coe_coe, Submodule.mkQ_apply]
   rw [Submodule.Quotient.mk_eq_zero, LinearMap.mem_range]
   constructor
   · rintro ⟨a, ha⟩
@@ -84,14 +85,14 @@ def elementaryTwoQuotientMk (g : G) : elementaryTwoQuotient G :=
 /-- The universal property of `G/G²` for additive homomorphisms: maps out of the quotient are
 additive homomorphisms from `Additive G` whose values are killed by `2`. -/
 protected def elementaryTwoQuotientLiftEquiv [AddMonoid M] :
-    (elementaryTwoQuotient G →+ M) ≃
+    (ElementaryTwoQuotient G →+ M) ≃
       {φ : Additive G →+ M // ∀ g, 2 • φ g = 0} :=
   ModN.liftEquiv
 
 /-- The universal property of `G/G²` for `ZMod 2`-linear maps: linear maps out of the quotient are
 additive homomorphisms from `Additive G` whose values are killed by `2`. -/
 protected def elementaryTwoQuotientLinearLiftEquiv [AddCommGroup H] [Module (ZMod 2) H] :
-    (elementaryTwoQuotient G →ₗ[ZMod 2] H) ≃
+    (ElementaryTwoQuotient G →ₗ[ZMod 2] H) ≃
       {φ : Additive G →+ H // ∀ g, 2 • φ g = 0} :=
   ModN.liftEquiv'
 
@@ -112,7 +113,7 @@ theorem elementaryTwoQuotientMk_prod {ι : Type*} (S : Finset ι) (g : ι → G)
 
 /-- Every element of `G / G²` is the class of some element of `G`. -/
 theorem elementaryTwoQuotientMk_surjective :
-    Function.Surjective (elementaryTwoQuotientMk : G → elementaryTwoQuotient G) := by
+    Function.Surjective (elementaryTwoQuotientMk : G → ElementaryTwoQuotient G) := by
   intro x
   obtain ⟨a, rfl⟩ := Submodule.Quotient.mk_surjective _ x
   exact ⟨Additive.toMul a, rfl⟩
@@ -131,7 +132,7 @@ variable (G)
 `|G/G²| = |{g | g² = 1}|`. The squaring endomorphism `g ↦ g²` has range `G²` and kernel the
 2-torsion; in a finite group the index of the range equals the cardinality of the kernel. -/
 theorem card_elementaryTwoQuotient_eq_card_sq_eq_one [Finite G] :
-    Nat.card (elementaryTwoQuotient G) = Nat.card {g : G // g ^ 2 = 1} := by
+    Nat.card (ElementaryTwoQuotient G) = Nat.card {g : G // g ^ 2 = 1} := by
   have hsq :
       (LinearMap.range (LinearMap.lsmul ℤ (Additive G) ↑(2 : ℕ))).toAddSubgroup =
       (Subgroup.square G).toAddSubgroup := by
@@ -145,27 +146,25 @@ theorem card_elementaryTwoQuotient_eq_card_sq_eq_one [Finite G] :
       refine ⟨Additive.ofMul a, ?_⟩
       apply Additive.toMul.injective
       simpa [toMul_zsmul, zpow_two, pow_two] using ha.symm
-  have hrange : Subgroup.square G = (powMonoidHom 2 : G →* G).range := by
-    ext g
-    simp [Subgroup.mem_square, MonoidHom.mem_range, isSquare_iff_exists_sq, eq_comm]
-  -- `elementaryTwoQuotient G = ModN (Additive G) 2` is, by definition, the additive quotient of
-  -- `Additive G` by the subgroup `(range (lsmul ℤ _ 2)).toAddSubgroup`, so its cardinality is that
-  -- subgroup's index; `hsq` then identifies the subgroup with the squares `G²`.
-  change Nat.card (Additive G ⧸
-    (LinearMap.range (LinearMap.lsmul ℤ (Additive G) ↑(2 : ℕ))).toAddSubgroup) =
-    Nat.card {g : G // g ^ 2 = 1}
-  rw [← AddSubgroup.index_eq_card, hsq, Subgroup.index_toAddSubgroup, hrange,
-    Subgroup.index_range]
+  -- `ElementaryTwoQuotient G = ModN (Additive G) 2` is the additive quotient of `Additive G` by the
+  -- doubling subgroup `(range (lsmul ℤ _ 2)).toAddSubgroup`, so its cardinality is that subgroup's
+  -- index (`AddSubgroup.index_eq_card`); `hsq` identifies the subgroup with the squares `G²`, which
+  -- are the range of the squaring homomorphism (`square_eq_powMonoidHom_two_range`).
+  rw [show Nat.card (ElementaryTwoQuotient G)
+        = (LinearMap.range (LinearMap.lsmul ℤ (Additive G) ↑(2 : ℕ))).toAddSubgroup.index from
+        (AddSubgroup.index_eq_card
+          (LinearMap.range (LinearMap.lsmul ℤ (Additive G) ↑(2 : ℕ))).toAddSubgroup).symm,
+    hsq, Subgroup.index_toAddSubgroup, square_eq_powMonoidHom_two_range, Subgroup.index_range]
   exact Nat.card_congr (Equiv.subtypeEquivRight fun g => by simp [MonoidHom.mem_ker])
 
 /-- **The 2-rank of a finite commutative group**: the `ZMod 2`-dimension of the maximal
 elementary-2 quotient `G / G²`. -/
-noncomputable def twoRank [Finite G] : ℕ := Module.finrank (ZMod 2) (elementaryTwoQuotient G)
+noncomputable def twoRank [Finite G] : ℕ := Module.finrank (ZMod 2) (ElementaryTwoQuotient G)
 
 /-- The maximal elementary-2 quotient has cardinality `2 ^ twoRank`: it is a finite `𝔽₂`-vector
 space of dimension the 2-rank. -/
 theorem card_elementaryTwoQuotient_eq_two_pow_twoRank [Finite G] :
-    Nat.card (elementaryTwoQuotient G) = 2 ^ twoRank G := by
+    Nat.card (ElementaryTwoQuotient G) = 2 ^ twoRank G := by
   rw [twoRank, Module.natCard_eq_pow_finrank (K := ZMod 2), Nat.card_zmod]
 
 end TauCeti

--- a/TauCeti/Algebra/Group/ElementaryTwoQuotient.lean
+++ b/TauCeti/Algebra/Group/ElementaryTwoQuotient.lean
@@ -36,6 +36,8 @@ names around it. The cardinality identity is still expressed through the squarin
 * `TauCeti.elementaryTwoQuotientMk` and `TauCeti.elementaryTwoQuotientMk_eq_zero_iff`: the class of
   an element, trivial iff the element is a square; `elementaryTwoQuotientMk_mul`,
   `elementaryTwoQuotientMk_one`, and `elementaryTwoQuotientMk_prod` record its additivity.
+* `TauCeti.elementaryTwoQuotientMk_surjective` and `TauCeti.elementaryTwoQuotientMk_eq_iff`: the
+  class map is surjective, and two elements have the same class iff they differ by a square.
 * `TauCeti.elementaryTwoQuotientLiftEquiv` and `TauCeti.elementaryTwoQuotientLinearLiftEquiv`: the
   universal property for maps out of `G/G²`, inherited from `ModN.liftEquiv`.
 * `TauCeti.card_elementaryTwoQuotient_eq_card_sq_eq_one`: `|G/G²| = |{g | g² = 1}|`.
@@ -64,12 +66,11 @@ def elementaryTwoQuotientMk (g : G) : elementaryTwoQuotient G :=
 /-- An element has trivial class in `G / G²` iff it is a square. -/
 @[simp] theorem elementaryTwoQuotientMk_eq_zero_iff (g : G) :
     elementaryTwoQuotientMk g = 0 ↔ IsSquare g := by
+  -- `elementaryTwoQuotientMk g = ModN.mkQ 2 (ofMul g)` is the quotient map of `ofMul g`, so it
+  -- vanishes iff `ofMul g` lies in the doubling subgroup `range (lsmul ℤ _ 2)`.
   rw [elementaryTwoQuotientMk, ModN.mkQ]
   change Submodule.Quotient.mk (Additive.ofMul g) = 0 ↔ IsSquare g
-  rw [Submodule.Quotient.mk_eq_zero]
-  change Additive.ofMul g ∈ LinearMap.range (LinearMap.lsmul ℤ (Additive G) ↑(2 : ℕ)) ↔
-    IsSquare g
-  rw [LinearMap.mem_range]
+  rw [Submodule.Quotient.mk_eq_zero, LinearMap.mem_range]
   constructor
   · rintro ⟨a, ha⟩
     refine ⟨Additive.toMul a, ?_⟩
@@ -109,6 +110,21 @@ theorem elementaryTwoQuotientMk_prod {ι : Type*} (S : Finset ι) (g : ι → G)
   simp only [elementaryTwoQuotientMk, ofMul_prod]
   rw [map_sum]
 
+/-- Every element of `G / G²` is the class of some element of `G`. -/
+theorem elementaryTwoQuotientMk_surjective :
+    Function.Surjective (elementaryTwoQuotientMk : G → elementaryTwoQuotient G) := by
+  intro x
+  obtain ⟨a, rfl⟩ := Submodule.Quotient.mk_surjective _ x
+  exact ⟨Additive.toMul a, rfl⟩
+
+/-- Two elements have the same class in `G / G²` iff they differ by a square. -/
+theorem elementaryTwoQuotientMk_eq_iff (g h : G) :
+    elementaryTwoQuotientMk g = elementaryTwoQuotientMk h ↔ IsSquare (g / h) := by
+  have hdiv : elementaryTwoQuotientMk (g / h)
+      = elementaryTwoQuotientMk g - elementaryTwoQuotientMk h := by
+    simp only [elementaryTwoQuotientMk, ofMul_div, map_sub]
+  rw [← elementaryTwoQuotientMk_eq_zero_iff, hdiv, sub_eq_zero]
+
 variable (G)
 
 /-- **The maximal elementary-2 quotient and the 2-torsion subgroup have the same cardinality.**
@@ -120,9 +136,8 @@ theorem card_elementaryTwoQuotient_eq_card_sq_eq_one [Finite G] :
       (LinearMap.range (LinearMap.lsmul ℤ (Additive G) ↑(2 : ℕ))).toAddSubgroup =
       (Subgroup.square G).toAddSubgroup := by
     ext g
-    change g ∈ LinearMap.range (LinearMap.lsmul ℤ (Additive G) ↑(2 : ℕ)) ↔
-      Additive.toMul g ∈ Subgroup.square G
-    rw [LinearMap.mem_range, Subgroup.mem_square]
+    rw [Submodule.mem_toAddSubgroup, Additive.mem_toAddSubgroup, LinearMap.mem_range,
+      Subgroup.mem_square]
     constructor
     · rintro ⟨a, rfl⟩
       exact ⟨Additive.toMul a, by simp [toMul_zsmul, zpow_two]⟩
@@ -133,6 +148,9 @@ theorem card_elementaryTwoQuotient_eq_card_sq_eq_one [Finite G] :
   have hrange : Subgroup.square G = (powMonoidHom 2 : G →* G).range := by
     ext g
     simp [Subgroup.mem_square, MonoidHom.mem_range, isSquare_iff_exists_sq, eq_comm]
+  -- `elementaryTwoQuotient G = ModN (Additive G) 2` is, by definition, the additive quotient of
+  -- `Additive G` by the subgroup `(range (lsmul ℤ _ 2)).toAddSubgroup`, so its cardinality is that
+  -- subgroup's index; `hsq` then identifies the subgroup with the squares `G²`.
   change Nat.card (Additive G ⧸
     (LinearMap.range (LinearMap.lsmul ℤ (Additive G) ↑(2 : ℕ))).toAddSubgroup) =
     Nat.card {g : G // g ^ 2 = 1}

--- a/TauCeti/Algebra/Group/ElementaryTwoQuotient.lean
+++ b/TauCeti/Algebra/Group/ElementaryTwoQuotient.lean
@@ -42,9 +42,8 @@ names around it. The cardinality identity is still expressed through the squarin
   class map is surjective, and two elements have the same class iff they differ by a square.
 * `TauCeti.elementaryTwoQuotientLiftEquiv` and `TauCeti.elementaryTwoQuotientLinearLiftEquiv`: the
   universal property for maps out of `G/G²`, inherited from `ModN.liftEquiv`.
-* `TauCeti.range_lsmul_two_toAddSubgroup_eq_square_toAddSubgroup` and
-  `TauCeti.card_elementaryTwoQuotient_eq_index_square`: named identifications used to compute
-  the quotient cardinality.
+* `TauCeti.card_elementaryTwoQuotient_eq_index_square`: the quotient cardinality as the index of
+  the subgroup of squares.
 * `TauCeti.card_elementaryTwoQuotient_eq_card_sq_eq_one`: `|G/G²| = |{g | g² = 1}|`.
 * `TauCeti.twoRank` and `TauCeti.card_elementaryTwoQuotient_eq_two_pow_twoRank`: the 2-rank, with
   `|G/G²| = 2 ^ twoRank`.
@@ -136,8 +135,10 @@ theorem elementaryTwoQuotientMk_eq_iff (g h : G) :
 
 variable (G)
 
-/-- The doubling subgroup of `Additive G` is the additive form of the subgroup of squares of `G`. -/
-theorem range_lsmul_two_toAddSubgroup_eq_square_toAddSubgroup :
+/-- The doubling subgroup of `Additive G` is the additive form of the subgroup of squares of `G`.
+This is the implementation detail relating the `ModN`/`lsmul` model of the quotient to the
+multiplicative subgroup of squares, and is kept private to the file. -/
+private theorem range_lsmul_two_toAddSubgroup_eq_square_toAddSubgroup :
     (LinearMap.range (LinearMap.lsmul ℤ (Additive G) ↑(2 : ℕ))).toAddSubgroup =
       (Subgroup.square G).toAddSubgroup := by
   ext g
@@ -154,6 +155,9 @@ theorem range_lsmul_two_toAddSubgroup_eq_square_toAddSubgroup :
 /-- The cardinality of `G/G²` is the index of the subgroup of squares. -/
 theorem card_elementaryTwoQuotient_eq_index_square [Finite G] :
     Nat.card (ElementaryTwoQuotient G) = (Subgroup.square G).index := by
+  -- `ElementaryTwoQuotient G` unfolds to `Additive G ⧸ range (lsmul ℤ _ 2)`, so its cardinality is
+  -- definitionally the index of the doubling subgroup; `AddSubgroup.index_eq_card` names that
+  -- defeq.
   rw [show Nat.card (ElementaryTwoQuotient G)
         = (LinearMap.range (LinearMap.lsmul ℤ (Additive G) ↑(2 : ℕ))).toAddSubgroup.index from
         (AddSubgroup.index_eq_card
@@ -176,7 +180,8 @@ noncomputable def twoRank [Module.Finite (ZMod 2) (ElementaryTwoQuotient G)] : �
 
 /-- The maximal elementary-2 quotient has cardinality `2 ^ twoRank`: it is a finite `𝔽₂`-vector
 space of dimension the 2-rank. -/
-theorem card_elementaryTwoQuotient_eq_two_pow_twoRank [Finite G] :
+theorem card_elementaryTwoQuotient_eq_two_pow_twoRank
+    [Module.Finite (ZMod 2) (ElementaryTwoQuotient G)] :
     Nat.card (ElementaryTwoQuotient G) = 2 ^ twoRank G := by
   rw [twoRank, Module.natCard_eq_pow_finrank (K := ZMod 2), Nat.card_zmod]
 

--- a/TauCeti/Algebra/Group/ElementaryTwoQuotient.lean
+++ b/TauCeti/Algebra/Group/ElementaryTwoQuotient.lean
@@ -7,6 +7,7 @@ import Mathlib.Algebra.Group.Subgroup.Even
 import Mathlib.Algebra.Module.ZMod
 import Mathlib.FieldTheory.Finiteness
 import Mathlib.GroupTheory.Index
+import Mathlib.LinearAlgebra.FreeModule.ModN
 
 /-!
 # The maximal elementary-2 quotient `G / G²` of a commutative group
@@ -25,9 +26,9 @@ the 2-torsion as its kernel, and a finite group has the same cardinality as the 
 and kernel of any endomorphism. We keep the two distinct in names and statements and record the
 cardinality identity as `card_elementaryTwoQuotient_eq_card_sq_eq_one`.
 
-Mathlib's `ModN G n` is the analogous additive quotient `G ⧸ nG` built from `range (lsmul ℤ G n)`;
-we keep the multiplicative `Subgroup.square` framing here because the cardinality identity is
-cleanest through the squaring homomorphism `powMonoidHom 2` and `Subgroup.index_range`.
+This file uses Mathlib's additive quotient `ModN (Additive G) 2` and adds multiplicative-square
+names around it. The cardinality identity is still expressed through the squaring homomorphism
+`powMonoidHom 2` and `Subgroup.index_range`.
 
 ## Main definitions and results
 
@@ -35,6 +36,8 @@ cleanest through the squaring homomorphism `powMonoidHom 2` and `Subgroup.index_
 * `TauCeti.elementaryTwoQuotientMk` and `TauCeti.elementaryTwoQuotientMk_eq_zero_iff`: the class of
   an element, trivial iff the element is a square; `elementaryTwoQuotientMk_mul`,
   `elementaryTwoQuotientMk_one`, and `elementaryTwoQuotientMk_prod` record its additivity.
+* `TauCeti.elementaryTwoQuotientLiftEquiv` and `TauCeti.elementaryTwoQuotientLinearLiftEquiv`: the
+  universal property for maps out of `G/G²`, inherited from `ModN.liftEquiv`.
 * `TauCeti.card_elementaryTwoQuotient_eq_card_sq_eq_one`: `|G/G²| = |{g | g² = 1}|`.
 * `TauCeti.twoRank` and `TauCeti.card_elementaryTwoQuotient_eq_two_pow_twoRank`: the 2-rank, with
   `|G/G²| = 2 ^ twoRank`.
@@ -47,14 +50,7 @@ variable (G : Type*) [CommGroup G]
 /-- **The maximal elementary-2 quotient `G / G²`** of a commutative group, written additively on
 `Additive G`. -/
 abbrev elementaryTwoQuotient : Type _ :=
-  Additive G ⧸ (Subgroup.square G).toAddSubgroup
-
-/-- The elementary-2 quotient is a `ZMod 2`-module: every element has order dividing two, since the
-double of any element is (additively) the class of a square. -/
-noncomputable instance : Module (ZMod 2) (elementaryTwoQuotient G) :=
-  QuotientAddGroup.zmodModule fun x => by
-    rw [Additive.mem_toAddSubgroup, Subgroup.mem_square, toMul_nsmul]
-    exact ⟨Additive.toMul x, pow_two _⟩
+  ModN (Additive G) 2
 
 instance [Finite G] : Finite (elementaryTwoQuotient G) :=
   Finite.of_surjective _ (QuotientAddGroup.mk'_surjective _)
@@ -63,28 +59,55 @@ variable {G}
 
 /-- The class of an element of `G` in the maximal elementary-2 quotient `G / G²`. -/
 def elementaryTwoQuotientMk (g : G) : elementaryTwoQuotient G :=
-  QuotientAddGroup.mk (Additive.ofMul g)
+  ModN.mkQ 2 (Additive.ofMul g)
 
 /-- An element has trivial class in `G / G²` iff it is a square. -/
 @[simp] theorem elementaryTwoQuotientMk_eq_zero_iff (g : G) :
     elementaryTwoQuotientMk g = 0 ↔ IsSquare g := by
-  rw [elementaryTwoQuotientMk, QuotientAddGroup.eq_zero_iff, Additive.mem_toAddSubgroup,
-    Subgroup.mem_square]
-  simp
+  rw [elementaryTwoQuotientMk, ModN.mkQ]
+  change Submodule.Quotient.mk (Additive.ofMul g) = 0 ↔ IsSquare g
+  rw [Submodule.Quotient.mk_eq_zero]
+  change Additive.ofMul g ∈ LinearMap.range (LinearMap.lsmul ℤ (Additive G) ↑(2 : ℕ)) ↔
+    IsSquare g
+  rw [LinearMap.mem_range]
+  constructor
+  · rintro ⟨a, ha⟩
+    refine ⟨Additive.toMul a, ?_⟩
+    have hmul := congr_arg Additive.toMul ha
+    simpa [toMul_zsmul, zpow_two, pow_two] using hmul.symm
+  · rintro ⟨a, ha⟩
+    refine ⟨Additive.ofMul a, ?_⟩
+    apply Additive.toMul.injective
+    simpa [toMul_zsmul, zpow_two, pow_two] using ha.symm
+
+/-- The universal property of `G/G²` for additive homomorphisms: maps out of the quotient are
+additive homomorphisms from `Additive G` whose values are killed by `2`. -/
+protected def elementaryTwoQuotientLiftEquiv [AddMonoid M] :
+    (elementaryTwoQuotient G →+ M) ≃
+      {φ : Additive G →+ M // ∀ g, 2 • φ g = 0} :=
+  ModN.liftEquiv
+
+/-- The universal property of `G/G²` for `ZMod 2`-linear maps: linear maps out of the quotient are
+additive homomorphisms from `Additive G` whose values are killed by `2`. -/
+protected def elementaryTwoQuotientLinearLiftEquiv [AddCommGroup H] [Module (ZMod 2) H] :
+    (elementaryTwoQuotient G →ₗ[ZMod 2] H) ≃
+      {φ : Additive G →+ H // ∀ g, 2 • φ g = 0} :=
+  ModN.liftEquiv'
 
 /-- The class map to `G / G²` sends a product to the sum of the classes. -/
 @[simp] theorem elementaryTwoQuotientMk_mul (g h : G) :
     elementaryTwoQuotientMk (g * h) = elementaryTwoQuotientMk g + elementaryTwoQuotientMk h := by
-  simp only [elementaryTwoQuotientMk, ofMul_mul, ← QuotientAddGroup.mk'_apply, map_add]
+  simp only [elementaryTwoQuotientMk, ofMul_mul, AddMonoidHom.map_add]
 
 /-- The class map to `G / G²` sends `1` to `0`. -/
 @[simp] theorem elementaryTwoQuotientMk_one : elementaryTwoQuotientMk (1 : G) = 0 := by
-  simp only [elementaryTwoQuotientMk, ofMul_one, ← QuotientAddGroup.mk'_apply, map_zero]
+  simp only [elementaryTwoQuotientMk, ofMul_one, AddMonoidHom.map_zero]
 
 /-- The class map to `G / G²` sends a finite product to the sum of the classes. -/
 theorem elementaryTwoQuotientMk_prod {ι : Type*} (S : Finset ι) (g : ι → G) :
     elementaryTwoQuotientMk (∏ i ∈ S, g i) = ∑ i ∈ S, elementaryTwoQuotientMk (g i) := by
-  simp only [elementaryTwoQuotientMk, ofMul_prod, ← QuotientAddGroup.mk'_apply, map_sum]
+  simp only [elementaryTwoQuotientMk, ofMul_prod]
+  rw [map_sum]
 
 variable (G)
 
@@ -93,16 +116,33 @@ variable (G)
 2-torsion; in a finite group the index of the range equals the cardinality of the kernel. -/
 theorem card_elementaryTwoQuotient_eq_card_sq_eq_one [Finite G] :
     Nat.card (elementaryTwoQuotient G) = Nat.card {g : G // g ^ 2 = 1} := by
-  have hsq : Subgroup.square G = (powMonoidHom 2 : G →* G).range := by
+  have hsq :
+      (LinearMap.range (LinearMap.lsmul ℤ (Additive G) ↑(2 : ℕ))).toAddSubgroup =
+      (Subgroup.square G).toAddSubgroup := by
+    ext g
+    change g ∈ LinearMap.range (LinearMap.lsmul ℤ (Additive G) ↑(2 : ℕ)) ↔
+      Additive.toMul g ∈ Subgroup.square G
+    rw [LinearMap.mem_range, Subgroup.mem_square]
+    constructor
+    · rintro ⟨a, rfl⟩
+      exact ⟨Additive.toMul a, by simp [toMul_zsmul, zpow_two]⟩
+    · rintro ⟨a, ha⟩
+      refine ⟨Additive.ofMul a, ?_⟩
+      apply Additive.toMul.injective
+      simpa [toMul_zsmul, zpow_two, pow_two] using ha.symm
+  have hrange : Subgroup.square G = (powMonoidHom 2 : G →* G).range := by
     ext g
     simp [Subgroup.mem_square, MonoidHom.mem_range, isSquare_iff_exists_sq, eq_comm]
-  rw [← AddSubgroup.index_eq_card, Subgroup.index_toAddSubgroup, hsq, Subgroup.index_range]
+  change Nat.card (Additive G ⧸
+    (LinearMap.range (LinearMap.lsmul ℤ (Additive G) ↑(2 : ℕ))).toAddSubgroup) =
+    Nat.card {g : G // g ^ 2 = 1}
+  rw [← AddSubgroup.index_eq_card, hsq, Subgroup.index_toAddSubgroup, hrange,
+    Subgroup.index_range]
   exact Nat.card_congr (Equiv.subtypeEquivRight fun g => by simp [MonoidHom.mem_ker])
 
-/-- **The 2-rank of a commutative group**: the `ZMod 2`-dimension of the maximal
-elementary-2 quotient `G / G²`. For an infinite quotient this `Module.finrank` is `0` by
-convention; the genus-theory use is for a finite group, where it is the genuine 2-rank. -/
-noncomputable def twoRank : ℕ := Module.finrank (ZMod 2) (elementaryTwoQuotient G)
+/-- **The 2-rank of a finite commutative group**: the `ZMod 2`-dimension of the maximal
+elementary-2 quotient `G / G²`. -/
+noncomputable def twoRank [Finite G] : ℕ := Module.finrank (ZMod 2) (elementaryTwoQuotient G)
 
 /-- The maximal elementary-2 quotient has cardinality `2 ^ twoRank`: it is a finite `𝔽₂`-vector
 space of dimension the 2-rank. -/

--- a/TauCeti/Algebra/Group/PowMonoidHom.lean
+++ b/TauCeti/Algebra/Group/PowMonoidHom.lean
@@ -15,6 +15,7 @@ homomorphism has index at most `2 ^ S.card`.
 
 ## Main results
 
+* `TauCeti.square_eq_powMonoidHom_two_range`: `G²` is the range of the squaring homomorphism.
 * `TauCeti.index_square_le_of_closure_eq_top`: `[G : G²] ≤ 2 ^ S.card`.
 
 ## Provenance
@@ -54,7 +55,7 @@ private theorem index_powMonoidHom_range_le_of_closure_eq_top {G : Type*} [CommG
 
 /-- In a commutative group, Mathlib's subgroup of squares agrees with the range of the
 squaring homomorphism. -/
-private theorem square_eq_powMonoidHom_two_range {G : Type*} [CommGroup G] :
+theorem square_eq_powMonoidHom_two_range {G : Type*} [CommGroup G] :
     Subgroup.square G = (powMonoidHom 2 : G →* G).range := by
   ext g
   rw [Subgroup.mem_square, MonoidHom.mem_range]

--- a/TauCeti/FieldTheory/SquareClassGroup.lean
+++ b/TauCeti/FieldTheory/SquareClassGroup.lean
@@ -2,8 +2,9 @@
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 -/
+import Mathlib.Algebra.Group.Subgroup.Even
+import Mathlib.Algebra.Module.ZMod
 import Mathlib.LinearAlgebra.LinearIndependent.Defs
-import TauCeti.Algebra.Group.ElementaryTwoQuotient
 
 /-!
 # The square-class group `Kˣ ⧸ (Kˣ)²`
@@ -32,20 +33,31 @@ variable {K : Type*} [Field K]
 
 /-- **The square-class group** `Kˣ ⧸ (Kˣ)²`, written additively on `Additive Kˣ`. -/
 abbrev SquareClassGroup (K : Type*) [Field K] : Type _ :=
-  elementaryTwoQuotient Kˣ
+  Additive Kˣ ⧸ (Subgroup.square Kˣ).toAddSubgroup
+
+/-- The square-class group is a `ZMod 2`-module: every element has order dividing two, since the
+double of any unit class is the class of a square. -/
+instance : Module (ZMod 2) (SquareClassGroup K) :=
+  QuotientAddGroup.zmodModule fun x => by
+    rw [Additive.mem_toAddSubgroup, Subgroup.mem_square, toMul_nsmul]
+    exact ⟨Additive.toMul x, pow_two _⟩
 
 /-- The square class of a unit. -/
 def squareClass (u : Kˣ) : SquareClassGroup K :=
-  elementaryTwoQuotientMk u
+  QuotientAddGroup.mk (Additive.ofMul u)
 
 /-- A unit has trivial square class iff it is a square. -/
-@[simp] theorem squareClass_eq_zero_iff (u : Kˣ) : squareClass u = 0 ↔ IsSquare u :=
-  elementaryTwoQuotientMk_eq_zero_iff u
+@[simp] theorem squareClass_eq_zero_iff (u : Kˣ) : squareClass u = 0 ↔ IsSquare u := by
+  rw [squareClass, QuotientAddGroup.eq_zero_iff, Additive.mem_toAddSubgroup,
+    Subgroup.mem_square]
+  simp
 
 /-- The square class of a product is the sum of the square classes. -/
 theorem squareClass_prod {ι : Type*} (S : Finset ι) (d : ι → Kˣ) :
-    squareClass (∏ i ∈ S, d i) = ∑ i ∈ S, squareClass (d i) :=
-  elementaryTwoQuotientMk_prod S d
+    squareClass (∏ i ∈ S, d i) = ∑ i ∈ S, squareClass (d i) := by
+  simp only [squareClass, ofMul_prod]
+  rw [← QuotientAddGroup.mk'_apply, map_sum]
+  simp only [QuotientAddGroup.mk'_apply]
 
 private theorem zmod_two_eq_zero_or_one (t : ZMod 2) : t = 0 ∨ t = 1 := by revert t; decide
 

--- a/TauCeti/FieldTheory/SquareClassGroup.lean
+++ b/TauCeti/FieldTheory/SquareClassGroup.lean
@@ -2,9 +2,8 @@
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 -/
-import Mathlib.Algebra.Group.Subgroup.Even
-import Mathlib.Algebra.Module.ZMod
 import Mathlib.LinearAlgebra.LinearIndependent.Defs
+import TauCeti.Algebra.Group.ElementaryTwoQuotient
 
 /-!
 # The square-class group `Kˣ ⧸ (Kˣ)²`
@@ -33,31 +32,20 @@ variable {K : Type*} [Field K]
 
 /-- **The square-class group** `Kˣ ⧸ (Kˣ)²`, written additively on `Additive Kˣ`. -/
 abbrev SquareClassGroup (K : Type*) [Field K] : Type _ :=
-  Additive Kˣ ⧸ (Subgroup.square Kˣ).toAddSubgroup
-
-/-- The square-class group is a `ZMod 2`-module: every element has order dividing two, since the
-double of any unit class is the class of a square. -/
-instance : Module (ZMod 2) (SquareClassGroup K) :=
-  QuotientAddGroup.zmodModule fun x => by
-    rw [Additive.mem_toAddSubgroup, Subgroup.mem_square, toMul_nsmul]
-    exact ⟨Additive.toMul x, pow_two _⟩
+  elementaryTwoQuotient Kˣ
 
 /-- The square class of a unit. -/
 def squareClass (u : Kˣ) : SquareClassGroup K :=
-  QuotientAddGroup.mk (Additive.ofMul u)
+  elementaryTwoQuotientMk u
 
 /-- A unit has trivial square class iff it is a square. -/
-@[simp] theorem squareClass_eq_zero_iff (u : Kˣ) : squareClass u = 0 ↔ IsSquare u := by
-  rw [squareClass, QuotientAddGroup.eq_zero_iff, Additive.mem_toAddSubgroup,
-    Subgroup.mem_square]
-  simp
+@[simp] theorem squareClass_eq_zero_iff (u : Kˣ) : squareClass u = 0 ↔ IsSquare u :=
+  elementaryTwoQuotientMk_eq_zero_iff u
 
 /-- The square class of a product is the sum of the square classes. -/
 theorem squareClass_prod {ι : Type*} (S : Finset ι) (d : ι → Kˣ) :
-    squareClass (∏ i ∈ S, d i) = ∑ i ∈ S, squareClass (d i) := by
-  simp only [squareClass, ofMul_prod]
-  rw [← QuotientAddGroup.mk'_apply, map_sum]
-  simp only [QuotientAddGroup.mk'_apply]
+    squareClass (∏ i ∈ S, d i) = ∑ i ∈ S, squareClass (d i) :=
+  elementaryTwoQuotientMk_prod S d
 
 private theorem zmod_two_eq_zero_or_one (t : ZMod 2) : t = 0 ∨ t = 1 := by revert t; decide
 

--- a/TauCeti/NumberTheory/ClassGroup/ElementaryTwoQuotient.lean
+++ b/TauCeti/NumberTheory/ClassGroup/ElementaryTwoQuotient.lean
@@ -82,12 +82,18 @@ theorem elementaryTwoQuotientMk_eq_iff (C D : ClassGroup R) :
     elementaryTwoQuotientMk R C = elementaryTwoQuotientMk R D ↔ IsSquare (C / D) :=
   TauCeti.elementaryTwoQuotientMk_eq_iff C D
 
+/-- **The 2-rank of the class group when `Cl(R)/Cl(R)²` is finite-dimensional**: the `ZMod 2`
+dimension of the maximal elementary-2 quotient. In genus-theory applications the `t - 1` formula
+belongs to the narrow class group; for imaginary fields the narrow and ordinary class groups
+coincide. -/
+noncomputable def twoRank [Module.Finite (ZMod 2) (ElementaryTwoQuotient R)] : ℕ :=
+  TauCeti.twoRank (ClassGroup R)
+
 variable [Finite (ClassGroup R)]
 
-/-- **The 2-rank of the finite class group**: the `ZMod 2`-dimension of the maximal elementary-2
-quotient `Cl(R)/Cl(R)²`. In genus-theory applications the `t - 1` formula belongs to the narrow
-class group; for imaginary fields the narrow and ordinary class groups coincide. -/
-noncomputable def twoRank : ℕ := TauCeti.twoRank (ClassGroup R)
+/-- A finite class group has finite-dimensional elementary-2 quotient. -/
+instance : Module.Finite (ZMod 2) (ElementaryTwoQuotient R) := by
+  infer_instance
 
 /-- **The maximal elementary-2 quotient and the 2-torsion subgroup have the same cardinality.**
 `|Cl(R)/Cl(R)²| = |Cl(R)[2]|`. -/

--- a/TauCeti/NumberTheory/ClassGroup/ElementaryTwoQuotient.lean
+++ b/TauCeti/NumberTheory/ClassGroup/ElementaryTwoQuotient.lean
@@ -106,6 +106,13 @@ coincide. -/
 noncomputable def twoRank [Module.Finite (ZMod 2) (ElementaryTwoQuotient R)] : ℕ :=
   TauCeti.twoRank (ClassGroup R)
 
+/-- The maximal elementary-2 quotient has cardinality `2 ^ twoRank`: it is a finite `𝔽₂`-vector
+space of dimension the 2-rank. -/
+theorem card_elementaryTwoQuotient_eq_two_pow_twoRank
+    [Module.Finite (ZMod 2) (ElementaryTwoQuotient R)] :
+    Nat.card (ElementaryTwoQuotient R) = 2 ^ twoRank R :=
+  TauCeti.card_elementaryTwoQuotient_eq_two_pow_twoRank (ClassGroup R)
+
 variable [Finite (ClassGroup R)]
 
 /-- A finite class group has finite-dimensional elementary-2 quotient. -/
@@ -117,11 +124,5 @@ instance : Module.Finite (ZMod 2) (ElementaryTwoQuotient R) := by
 theorem card_elementaryTwoQuotient_eq_card_twoTorsion :
     Nat.card (ElementaryTwoQuotient R) = Nat.card {C : ClassGroup R // C ^ 2 = 1} :=
   TauCeti.card_elementaryTwoQuotient_eq_card_twoTorsion (ClassGroup R)
-
-/-- The maximal elementary-2 quotient has cardinality `2 ^ twoRank`: it is a finite `𝔽₂`-vector
-space of dimension the 2-rank. -/
-theorem card_elementaryTwoQuotient_eq_two_pow_twoRank :
-    Nat.card (ElementaryTwoQuotient R) = 2 ^ twoRank R :=
-  TauCeti.card_elementaryTwoQuotient_eq_two_pow_twoRank (ClassGroup R)
 
 end TauCeti.ClassGroup

--- a/TauCeti/NumberTheory/ClassGroup/ElementaryTwoQuotient.lean
+++ b/TauCeti/NumberTheory/ClassGroup/ElementaryTwoQuotient.lean
@@ -20,14 +20,14 @@ subgroup `Cl(R)[2] = {C | C² = 1}`. The two are different objects — a quotien
 for a finite abelian group they have the same cardinality (see
 `card_elementaryTwoQuotient_eq_card_twoTorsion`); we keep them distinct in names and statements.
 
-The construction itself is the general `TauCeti.elementaryTwoQuotient` of a commutative group,
+The construction itself is the general `TauCeti.ElementaryTwoQuotient` of a commutative group,
 specialized here to `G = ClassGroup R` under the genus-theory names Layer 2 of the multiquadratic
 roadmap targets (`TauCetiRoadmap/Multiquadratic/README.md`). The same general construction is the
 square-class group `Kˣ ⧸ (Kˣ)²` of `TauCeti.FieldTheory.SquareClassGroup` for `G = Kˣ`.
 
 ## Main definitions and results
 
-* `TauCeti.ClassGroup.elementaryTwoQuotient`: the quotient `Cl(R) ⧸ Cl(R)²`, a `ZMod 2`-module.
+* `TauCeti.ClassGroup.ElementaryTwoQuotient`: the quotient `Cl(R) ⧸ Cl(R)²`, a `ZMod 2`-module.
 * `TauCeti.ClassGroup.elementaryTwoQuotientMk` and `elementaryTwoQuotientMk_eq_zero_iff`: the class
   of an ideal class, trivial iff that class is a square; `elementaryTwoQuotientMk_mul`,
   `elementaryTwoQuotientMk_one`, and `elementaryTwoQuotientMk_prod` record its additivity, while
@@ -44,11 +44,11 @@ namespace TauCeti.ClassGroup
 variable (R : Type*) [CommRing R] [IsDomain R]
 
 /-- **The maximal elementary-2 quotient `Cl(R)/Cl(R)²` of the class group**, the general
-`TauCeti.elementaryTwoQuotient` specialized to `ClassGroup R`. -/
-abbrev elementaryTwoQuotient : Type _ := TauCeti.elementaryTwoQuotient (ClassGroup R)
+`TauCeti.ElementaryTwoQuotient` specialized to `ClassGroup R`. -/
+abbrev ElementaryTwoQuotient : Type _ := TauCeti.ElementaryTwoQuotient (ClassGroup R)
 
 /-- The class of an ideal class in the maximal elementary-2 quotient `Cl(R)/Cl(R)²`. -/
-noncomputable def elementaryTwoQuotientMk (C : ClassGroup R) : elementaryTwoQuotient R :=
+noncomputable def elementaryTwoQuotientMk (C : ClassGroup R) : ElementaryTwoQuotient R :=
   TauCeti.elementaryTwoQuotientMk C
 
 /-- An ideal class has trivial class in `Cl(R)/Cl(R)²` iff it is a square. -/
@@ -92,13 +92,13 @@ noncomputable def twoRank : ℕ := TauCeti.twoRank (ClassGroup R)
 /-- **The maximal elementary-2 quotient and the 2-torsion subgroup have the same cardinality.**
 `|Cl(R)/Cl(R)²| = |Cl(R)[2]|`. -/
 theorem card_elementaryTwoQuotient_eq_card_twoTorsion :
-    Nat.card (elementaryTwoQuotient R) = Nat.card {C : ClassGroup R // C ^ 2 = 1} :=
+    Nat.card (ElementaryTwoQuotient R) = Nat.card {C : ClassGroup R // C ^ 2 = 1} :=
   TauCeti.card_elementaryTwoQuotient_eq_card_sq_eq_one (ClassGroup R)
 
 /-- The maximal elementary-2 quotient has cardinality `2 ^ twoRank`: it is a finite `𝔽₂`-vector
 space of dimension the 2-rank. -/
 theorem card_elementaryTwoQuotient_eq_two_pow_twoRank :
-    Nat.card (elementaryTwoQuotient R) = 2 ^ twoRank R :=
+    Nat.card (ElementaryTwoQuotient R) = 2 ^ twoRank R :=
   TauCeti.card_elementaryTwoQuotient_eq_two_pow_twoRank (ClassGroup R)
 
 end TauCeti.ClassGroup

--- a/TauCeti/NumberTheory/ClassGroup/ElementaryTwoQuotient.lean
+++ b/TauCeti/NumberTheory/ClassGroup/ElementaryTwoQuotient.lean
@@ -99,7 +99,7 @@ instance : Module.Finite (ZMod 2) (ElementaryTwoQuotient R) := by
 `|Cl(R)/Cl(R)²| = |Cl(R)[2]|`. -/
 theorem card_elementaryTwoQuotient_eq_card_twoTorsion :
     Nat.card (ElementaryTwoQuotient R) = Nat.card {C : ClassGroup R // C ^ 2 = 1} :=
-  TauCeti.card_elementaryTwoQuotient_eq_card_sq_eq_one (ClassGroup R)
+  TauCeti.card_elementaryTwoQuotient_eq_card_twoTorsion (ClassGroup R)
 
 /-- The maximal elementary-2 quotient has cardinality `2 ^ twoRank`: it is a finite `𝔽₂`-vector
 space of dimension the 2-rank. -/

--- a/TauCeti/NumberTheory/ClassGroup/ElementaryTwoQuotient.lean
+++ b/TauCeti/NumberTheory/ClassGroup/ElementaryTwoQuotient.lean
@@ -30,9 +30,10 @@ square-class group `Kˣ ⧸ (Kˣ)²` of `TauCeti.FieldTheory.SquareClassGroup` f
 * `TauCeti.ClassGroup.ElementaryTwoQuotient`: the quotient `Cl(R) ⧸ Cl(R)²`, a `ZMod 2`-module.
 * `TauCeti.ClassGroup.elementaryTwoQuotientMk` and `elementaryTwoQuotientMk_eq_zero_iff`: the class
   of an ideal class, trivial iff that class is a square; `elementaryTwoQuotientMk_mul`,
-  `elementaryTwoQuotientMk_one`, and `elementaryTwoQuotientMk_prod` record its additivity, while
-  `elementaryTwoQuotientMk_surjective` and `elementaryTwoQuotientMk_eq_iff` give surjectivity and
-  the equality criterion.
+  `elementaryTwoQuotientMk_one`, `elementaryTwoQuotientMk_inv`,
+  `elementaryTwoQuotientMk_div`, `elementaryTwoQuotientMk_pow`, and
+  `elementaryTwoQuotientMk_prod` record its additivity, while `elementaryTwoQuotientMk_surjective`
+  and `elementaryTwoQuotientMk_eq_iff` give surjectivity and the equality criterion.
 * `TauCeti.ClassGroup.card_elementaryTwoQuotient_eq_card_twoTorsion`: `|Cl(R)/Cl(R)²| = |Cl(R)[2]|`,
   the quotient and the 2-torsion subgroup have equal cardinality.
 * `TauCeti.ClassGroup.twoRank` and `card_elementaryTwoQuotient_eq_two_pow_twoRank`: the 2-rank, with
@@ -65,6 +66,22 @@ noncomputable def elementaryTwoQuotientMk (C : ClassGroup R) : ElementaryTwoQuot
 @[simp] theorem elementaryTwoQuotientMk_one :
     elementaryTwoQuotientMk R (1 : ClassGroup R) = 0 :=
   TauCeti.elementaryTwoQuotientMk_one
+
+/-- The class map to `Cl(R)/Cl(R)²` sends inverses to negatives. -/
+@[simp] theorem elementaryTwoQuotientMk_inv (C : ClassGroup R) :
+    elementaryTwoQuotientMk R C⁻¹ = -elementaryTwoQuotientMk R C :=
+  TauCeti.elementaryTwoQuotientMk_inv C
+
+/-- The class map to `Cl(R)/Cl(R)²` sends quotients to differences. -/
+@[simp] theorem elementaryTwoQuotientMk_div (C D : ClassGroup R) :
+    elementaryTwoQuotientMk R (C / D) =
+      elementaryTwoQuotientMk R C - elementaryTwoQuotientMk R D :=
+  TauCeti.elementaryTwoQuotientMk_div C D
+
+/-- The class map to `Cl(R)/Cl(R)²` sends powers to scalar multiples. -/
+@[simp] theorem elementaryTwoQuotientMk_pow (C : ClassGroup R) (n : ℕ) :
+    elementaryTwoQuotientMk R (C ^ n) = n • elementaryTwoQuotientMk R C :=
+  TauCeti.elementaryTwoQuotientMk_pow C n
 
 /-- The class map to `Cl(R)/Cl(R)²` sends a finite product of ideal classes to the sum of the
 classes. -/

--- a/TauCeti/NumberTheory/ClassGroup/ElementaryTwoQuotient.lean
+++ b/TauCeti/NumberTheory/ClassGroup/ElementaryTwoQuotient.lean
@@ -2,11 +2,8 @@
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 -/
-import Mathlib.Algebra.Group.Subgroup.Even
-import Mathlib.Algebra.Module.ZMod
-import Mathlib.FieldTheory.Finiteness
-import Mathlib.GroupTheory.Index
-import Mathlib.NumberTheory.NumberField.ClassNumber
+import Mathlib.RingTheory.ClassGroup.Basic
+import TauCeti.Algebra.Group.ElementaryTwoQuotient
 
 /-!
 # The maximal elementary-2 quotient `Cl(R)/Cl(R)²` of a class group
@@ -20,68 +17,59 @@ theorems compute.
 
 ⚠ This quotient is the **maximal elementary-2 quotient** of the class group, *not* the 2-torsion
 subgroup `Cl(R)[2] = {C | C² = 1}`. The two are different objects — a quotient and a subgroup — but
-for a finite abelian group they have the same cardinality, because the squaring endomorphism
-`C ↦ C²` has `Cl(R)²` as its range and `Cl(R)[2]` as its kernel, and a finite group has the same
-cardinality as the product of the range and kernel of any endomorphism. We keep the two distinct in
-names and statements and record the cardinality identity as `card_elementaryTwoQuotient`.
+for a finite abelian group they have the same cardinality (see
+`card_elementaryTwoQuotient_eq_card_twoTorsion`); we keep them distinct in names and statements.
+
+The construction itself is the general `TauCeti.elementaryTwoQuotient` of a commutative group,
+specialized here to `G = ClassGroup R` under the genus-theory names Layer 2 of the multiquadratic
+roadmap targets (`TauCetiRoadmap/Multiquadratic/README.md`). The same general construction is the
+square-class group `Kˣ ⧸ (Kˣ)²` of `TauCeti.FieldTheory.SquareClassGroup` for `G = Kˣ`.
 
 ## Main definitions and results
 
 * `TauCeti.ClassGroup.elementaryTwoQuotient`: the quotient `Cl(R) ⧸ Cl(R)²`, a `ZMod 2`-module.
-* `TauCeti.ClassGroup.card_elementaryTwoQuotient`: `|Cl(R)/Cl(R)²| = |Cl(R)[2]|`, the quotient and
-  the 2-torsion subgroup have equal cardinality.
-* `TauCeti.ClassGroup.twoRank` and
-  `TauCeti.ClassGroup.card_elementaryTwoQuotient_eq_two_pow_twoRank`: the 2-rank, with
+* `TauCeti.ClassGroup.elementaryTwoQuotientMk` and `elementaryTwoQuotientMk_eq_zero_iff`: the class
+  of an ideal class, trivial iff that class is a square.
+* `TauCeti.ClassGroup.card_elementaryTwoQuotient_eq_card_twoTorsion`: `|Cl(R)/Cl(R)²| = |Cl(R)[2]|`,
+  the quotient and the 2-torsion subgroup have equal cardinality.
+* `TauCeti.ClassGroup.twoRank` and `card_elementaryTwoQuotient_eq_two_pow_twoRank`: the 2-rank, with
   `|Cl(R)/Cl(R)²| = 2 ^ twoRank`.
-
-The `ZMod 2`-module construction mirrors the square-class group `Kˣ ⧸ (Kˣ)²` of
-`TauCeti.FieldTheory.SquareClassGroup`; here it is carried out for the class group, the object
-Layer 2 of the multiquadratic roadmap targets.
 -/
 
 namespace TauCeti.ClassGroup
 
 variable (R : Type*) [CommRing R] [IsDomain R]
 
-/-- **The maximal elementary-2 quotient `Cl(R)/Cl(R)²` of the class group**, written additively on
-`Additive (ClassGroup R)`. -/
-abbrev elementaryTwoQuotient : Type _ :=
-  Additive (ClassGroup R) ⧸ (Subgroup.square (ClassGroup R)).toAddSubgroup
+/-- **The maximal elementary-2 quotient `Cl(R)/Cl(R)²` of the class group**, the general
+`TauCeti.elementaryTwoQuotient` specialized to `ClassGroup R`. -/
+abbrev elementaryTwoQuotient : Type _ := TauCeti.elementaryTwoQuotient (ClassGroup R)
 
-/-- The elementary-2 quotient is a `ZMod 2`-module: every element has order dividing two, since the
-double of any class is (additively) the class of a square. -/
-noncomputable instance : Module (ZMod 2) (elementaryTwoQuotient R) :=
-  QuotientAddGroup.zmodModule fun x => by
-    rw [Additive.mem_toAddSubgroup, Subgroup.mem_square, toMul_nsmul]
-    exact ⟨Additive.toMul x, pow_two _⟩
+/-- The class of an ideal class in the maximal elementary-2 quotient `Cl(R)/Cl(R)²`. -/
+noncomputable def elementaryTwoQuotientMk (C : ClassGroup R) : elementaryTwoQuotient R :=
+  TauCeti.elementaryTwoQuotientMk C
 
-instance [Finite (ClassGroup R)] : Finite (elementaryTwoQuotient R) :=
-  Finite.of_surjective _ (QuotientAddGroup.mk'_surjective _)
+/-- An ideal class has trivial class in `Cl(R)/Cl(R)²` iff it is a square. -/
+@[simp] theorem elementaryTwoQuotientMk_eq_zero_iff (C : ClassGroup R) :
+    elementaryTwoQuotientMk R C = 0 ↔ IsSquare C :=
+  TauCeti.elementaryTwoQuotientMk_eq_zero_iff C
 
 variable [Finite (ClassGroup R)]
 
 /-- **The maximal elementary-2 quotient and the 2-torsion subgroup have the same cardinality.**
-`|Cl(R)/Cl(R)²| = |Cl(R)[2]|`. The squaring endomorphism `C ↦ C²` has range `Cl(R)²` and kernel
-`Cl(R)[2]`; in a finite group the index of the range equals the cardinality of the kernel. -/
-theorem card_elementaryTwoQuotient :
-    Nat.card (elementaryTwoQuotient R) = Nat.card {C : ClassGroup R // C ^ 2 = 1} := by
-  have hsq : Subgroup.square (ClassGroup R)
-      = (powMonoidHom 2 : ClassGroup R →* ClassGroup R).range := by
-    ext g
-    simp [Subgroup.mem_square, MonoidHom.mem_range, isSquare_iff_exists_sq, eq_comm]
-  change (Subgroup.square (ClassGroup R)).toAddSubgroup.index = _
-  rw [Subgroup.index_toAddSubgroup, hsq, Subgroup.index_range]
-  exact Nat.card_congr (Equiv.subtypeEquivRight fun g => by simp [MonoidHom.mem_ker])
+`|Cl(R)/Cl(R)²| = |Cl(R)[2]|`. -/
+theorem card_elementaryTwoQuotient_eq_card_twoTorsion :
+    Nat.card (elementaryTwoQuotient R) = Nat.card {C : ClassGroup R // C ^ 2 = 1} :=
+  TauCeti.card_elementaryTwoQuotient_eq_card_sq_eq_one (ClassGroup R)
 
 /-- **The 2-rank of the class group**: the `ZMod 2`-dimension of the maximal elementary-2 quotient
 `Cl(R)/Cl(R)²`. This is the quantity the genus-field theorems express as `t - 1`, with `t` the
 number of ramified primes. -/
-noncomputable def twoRank : ℕ := Module.finrank (ZMod 2) (elementaryTwoQuotient R)
+noncomputable def twoRank : ℕ := TauCeti.twoRank (ClassGroup R)
 
 /-- The maximal elementary-2 quotient has cardinality `2 ^ twoRank`: it is a finite `𝔽₂`-vector
 space of dimension the 2-rank. -/
 theorem card_elementaryTwoQuotient_eq_two_pow_twoRank :
-    Nat.card (elementaryTwoQuotient R) = 2 ^ twoRank R := by
-  rw [twoRank, Module.natCard_eq_pow_finrank (K := ZMod 2), Nat.card_zmod]
+    Nat.card (elementaryTwoQuotient R) = 2 ^ twoRank R :=
+  TauCeti.card_elementaryTwoQuotient_eq_two_pow_twoRank (ClassGroup R)
 
 end TauCeti.ClassGroup

--- a/TauCeti/NumberTheory/ClassGroup/ElementaryTwoQuotient.lean
+++ b/TauCeti/NumberTheory/ClassGroup/ElementaryTwoQuotient.lean
@@ -29,7 +29,8 @@ square-class group `Kˣ ⧸ (Kˣ)²` of `TauCeti.FieldTheory.SquareClassGroup` f
 
 * `TauCeti.ClassGroup.elementaryTwoQuotient`: the quotient `Cl(R) ⧸ Cl(R)²`, a `ZMod 2`-module.
 * `TauCeti.ClassGroup.elementaryTwoQuotientMk` and `elementaryTwoQuotientMk_eq_zero_iff`: the class
-  of an ideal class, trivial iff that class is a square.
+  of an ideal class, trivial iff that class is a square; `elementaryTwoQuotientMk_mul`,
+  `elementaryTwoQuotientMk_one`, and `elementaryTwoQuotientMk_prod` record its additivity.
 * `TauCeti.ClassGroup.card_elementaryTwoQuotient_eq_card_twoTorsion`: `|Cl(R)/Cl(R)²| = |Cl(R)[2]|`,
   the quotient and the 2-torsion subgroup have equal cardinality.
 * `TauCeti.ClassGroup.twoRank` and `card_elementaryTwoQuotient_eq_two_pow_twoRank`: the 2-rank, with
@@ -53,6 +54,27 @@ noncomputable def elementaryTwoQuotientMk (C : ClassGroup R) : elementaryTwoQuot
     elementaryTwoQuotientMk R C = 0 ↔ IsSquare C :=
   TauCeti.elementaryTwoQuotientMk_eq_zero_iff C
 
+/-- The class map to `Cl(R)/Cl(R)²` sends a product of ideal classes to the sum of the classes. -/
+@[simp] theorem elementaryTwoQuotientMk_mul (C D : ClassGroup R) :
+    elementaryTwoQuotientMk R (C * D) = elementaryTwoQuotientMk R C + elementaryTwoQuotientMk R D :=
+  TauCeti.elementaryTwoQuotientMk_mul C D
+
+/-- The class map to `Cl(R)/Cl(R)²` sends the trivial ideal class to `0`. -/
+@[simp] theorem elementaryTwoQuotientMk_one :
+    elementaryTwoQuotientMk R (1 : ClassGroup R) = 0 :=
+  TauCeti.elementaryTwoQuotientMk_one
+
+/-- The class map to `Cl(R)/Cl(R)²` sends a finite product of ideal classes to the sum of the
+classes. -/
+theorem elementaryTwoQuotientMk_prod {ι : Type*} (S : Finset ι) (C : ι → ClassGroup R) :
+    elementaryTwoQuotientMk R (∏ i ∈ S, C i) = ∑ i ∈ S, elementaryTwoQuotientMk R (C i) :=
+  TauCeti.elementaryTwoQuotientMk_prod S C
+
+/-- **The 2-rank of the class group**: the `ZMod 2`-dimension of the maximal elementary-2 quotient
+`Cl(R)/Cl(R)²`. This is the quantity the genus-field theorems express as `t - 1`, with `t` the
+number of ramified primes. -/
+noncomputable def twoRank : ℕ := TauCeti.twoRank (ClassGroup R)
+
 variable [Finite (ClassGroup R)]
 
 /-- **The maximal elementary-2 quotient and the 2-torsion subgroup have the same cardinality.**
@@ -60,11 +82,6 @@ variable [Finite (ClassGroup R)]
 theorem card_elementaryTwoQuotient_eq_card_twoTorsion :
     Nat.card (elementaryTwoQuotient R) = Nat.card {C : ClassGroup R // C ^ 2 = 1} :=
   TauCeti.card_elementaryTwoQuotient_eq_card_sq_eq_one (ClassGroup R)
-
-/-- **The 2-rank of the class group**: the `ZMod 2`-dimension of the maximal elementary-2 quotient
-`Cl(R)/Cl(R)²`. This is the quantity the genus-field theorems express as `t - 1`, with `t` the
-number of ramified primes. -/
-noncomputable def twoRank : ℕ := TauCeti.twoRank (ClassGroup R)
 
 /-- The maximal elementary-2 quotient has cardinality `2 ^ twoRank`: it is a finite `𝔽₂`-vector
 space of dimension the 2-rank. -/

--- a/TauCeti/NumberTheory/ClassGroup/ElementaryTwoQuotient.lean
+++ b/TauCeti/NumberTheory/ClassGroup/ElementaryTwoQuotient.lean
@@ -30,7 +30,9 @@ square-class group `Kˣ ⧸ (Kˣ)²` of `TauCeti.FieldTheory.SquareClassGroup` f
 * `TauCeti.ClassGroup.elementaryTwoQuotient`: the quotient `Cl(R) ⧸ Cl(R)²`, a `ZMod 2`-module.
 * `TauCeti.ClassGroup.elementaryTwoQuotientMk` and `elementaryTwoQuotientMk_eq_zero_iff`: the class
   of an ideal class, trivial iff that class is a square; `elementaryTwoQuotientMk_mul`,
-  `elementaryTwoQuotientMk_one`, and `elementaryTwoQuotientMk_prod` record its additivity.
+  `elementaryTwoQuotientMk_one`, and `elementaryTwoQuotientMk_prod` record its additivity, while
+  `elementaryTwoQuotientMk_surjective` and `elementaryTwoQuotientMk_eq_iff` give surjectivity and
+  the equality criterion.
 * `TauCeti.ClassGroup.card_elementaryTwoQuotient_eq_card_twoTorsion`: `|Cl(R)/Cl(R)²| = |Cl(R)[2]|`,
   the quotient and the 2-torsion subgroup have equal cardinality.
 * `TauCeti.ClassGroup.twoRank` and `card_elementaryTwoQuotient_eq_two_pow_twoRank`: the 2-rank, with
@@ -69,6 +71,16 @@ classes. -/
 theorem elementaryTwoQuotientMk_prod {ι : Type*} (S : Finset ι) (C : ι → ClassGroup R) :
     elementaryTwoQuotientMk R (∏ i ∈ S, C i) = ∑ i ∈ S, elementaryTwoQuotientMk R (C i) :=
   TauCeti.elementaryTwoQuotientMk_prod S C
+
+/-- Every element of `Cl(R)/Cl(R)²` is the class of some ideal class. -/
+theorem elementaryTwoQuotientMk_surjective :
+    Function.Surjective (elementaryTwoQuotientMk R) :=
+  TauCeti.elementaryTwoQuotientMk_surjective
+
+/-- Two ideal classes have the same class in `Cl(R)/Cl(R)²` iff they differ by a square. -/
+theorem elementaryTwoQuotientMk_eq_iff (C D : ClassGroup R) :
+    elementaryTwoQuotientMk R C = elementaryTwoQuotientMk R D ↔ IsSquare (C / D) :=
+  TauCeti.elementaryTwoQuotientMk_eq_iff C D
 
 variable [Finite (ClassGroup R)]
 

--- a/TauCeti/NumberTheory/ClassGroup/ElementaryTwoQuotient.lean
+++ b/TauCeti/NumberTheory/ClassGroup/ElementaryTwoQuotient.lean
@@ -70,12 +70,12 @@ theorem elementaryTwoQuotientMk_prod {ι : Type*} (S : Finset ι) (C : ι → Cl
     elementaryTwoQuotientMk R (∏ i ∈ S, C i) = ∑ i ∈ S, elementaryTwoQuotientMk R (C i) :=
   TauCeti.elementaryTwoQuotientMk_prod S C
 
-/-- **The 2-rank of the class group**: the `ZMod 2`-dimension of the maximal elementary-2 quotient
-`Cl(R)/Cl(R)²`. This is the quantity the genus-field theorems express as `t - 1`, with `t` the
-number of ramified primes. -/
-noncomputable def twoRank : ℕ := TauCeti.twoRank (ClassGroup R)
-
 variable [Finite (ClassGroup R)]
+
+/-- **The 2-rank of the finite class group**: the `ZMod 2`-dimension of the maximal elementary-2
+quotient `Cl(R)/Cl(R)²`. In genus-theory applications the `t - 1` formula belongs to the narrow
+class group; for imaginary fields the narrow and ordinary class groups coincide. -/
+noncomputable def twoRank : ℕ := TauCeti.twoRank (ClassGroup R)
 
 /-- **The maximal elementary-2 quotient and the 2-torsion subgroup have the same cardinality.**
 `|Cl(R)/Cl(R)²| = |Cl(R)[2]|`. -/

--- a/TauCeti/NumberTheory/ClassGroup/ElementaryTwoQuotient.lean
+++ b/TauCeti/NumberTheory/ClassGroup/ElementaryTwoQuotient.lean
@@ -1,0 +1,87 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+import Mathlib.Algebra.Group.Subgroup.Even
+import Mathlib.Algebra.Module.ZMod
+import Mathlib.FieldTheory.Finiteness
+import Mathlib.GroupTheory.Index
+import Mathlib.NumberTheory.NumberField.ClassNumber
+
+/-!
+# The maximal elementary-2 quotient `Cl(R)/Cl(R)²` of a class group
+
+For a domain `R` (for the genus-theory application, the ring of integers `𝓞 K` of a number field,
+whose class group is finite), the **class group** `ClassGroup R` is an abelian group, and genus
+theory studies its `2`-part through the quotient by its subgroup of squares,
+`Cl(R) / Cl(R)²`. Every element of this quotient has order dividing `2`, so it is a vector space
+over `𝔽₂ = ZMod 2`; its dimension is the **2-rank** of the class group, the quantity the genus-field
+theorems compute.
+
+⚠ This quotient is the **maximal elementary-2 quotient** of the class group, *not* the 2-torsion
+subgroup `Cl(R)[2] = {C | C² = 1}`. The two are different objects — a quotient and a subgroup — but
+for a finite abelian group they have the same cardinality, because the squaring endomorphism
+`C ↦ C²` has `Cl(R)²` as its range and `Cl(R)[2]` as its kernel, and a finite group has the same
+cardinality as the product of the range and kernel of any endomorphism. We keep the two distinct in
+names and statements and record the cardinality identity as `card_elementaryTwoQuotient`.
+
+## Main definitions and results
+
+* `TauCeti.ClassGroup.elementaryTwoQuotient`: the quotient `Cl(R) ⧸ Cl(R)²`, a `ZMod 2`-module.
+* `TauCeti.ClassGroup.card_elementaryTwoQuotient`: `|Cl(R)/Cl(R)²| = |Cl(R)[2]|`, the quotient and
+  the 2-torsion subgroup have equal cardinality.
+* `TauCeti.ClassGroup.twoRank` and
+  `TauCeti.ClassGroup.card_elementaryTwoQuotient_eq_two_pow_twoRank`: the 2-rank, with
+  `|Cl(R)/Cl(R)²| = 2 ^ twoRank`.
+
+The `ZMod 2`-module construction mirrors the square-class group `Kˣ ⧸ (Kˣ)²` of
+`TauCeti.FieldTheory.SquareClassGroup`; here it is carried out for the class group, the object
+Layer 2 of the multiquadratic roadmap targets.
+-/
+
+namespace TauCeti.ClassGroup
+
+variable (R : Type*) [CommRing R] [IsDomain R]
+
+/-- **The maximal elementary-2 quotient `Cl(R)/Cl(R)²` of the class group**, written additively on
+`Additive (ClassGroup R)`. -/
+abbrev elementaryTwoQuotient : Type _ :=
+  Additive (ClassGroup R) ⧸ (Subgroup.square (ClassGroup R)).toAddSubgroup
+
+/-- The elementary-2 quotient is a `ZMod 2`-module: every element has order dividing two, since the
+double of any class is (additively) the class of a square. -/
+noncomputable instance : Module (ZMod 2) (elementaryTwoQuotient R) :=
+  QuotientAddGroup.zmodModule fun x => by
+    rw [Additive.mem_toAddSubgroup, Subgroup.mem_square, toMul_nsmul]
+    exact ⟨Additive.toMul x, pow_two _⟩
+
+instance [Finite (ClassGroup R)] : Finite (elementaryTwoQuotient R) :=
+  Finite.of_surjective _ (QuotientAddGroup.mk'_surjective _)
+
+variable [Finite (ClassGroup R)]
+
+/-- **The maximal elementary-2 quotient and the 2-torsion subgroup have the same cardinality.**
+`|Cl(R)/Cl(R)²| = |Cl(R)[2]|`. The squaring endomorphism `C ↦ C²` has range `Cl(R)²` and kernel
+`Cl(R)[2]`; in a finite group the index of the range equals the cardinality of the kernel. -/
+theorem card_elementaryTwoQuotient :
+    Nat.card (elementaryTwoQuotient R) = Nat.card {C : ClassGroup R // C ^ 2 = 1} := by
+  have hsq : Subgroup.square (ClassGroup R)
+      = (powMonoidHom 2 : ClassGroup R →* ClassGroup R).range := by
+    ext g
+    simp [Subgroup.mem_square, MonoidHom.mem_range, isSquare_iff_exists_sq, eq_comm]
+  change (Subgroup.square (ClassGroup R)).toAddSubgroup.index = _
+  rw [Subgroup.index_toAddSubgroup, hsq, Subgroup.index_range]
+  exact Nat.card_congr (Equiv.subtypeEquivRight fun g => by simp [MonoidHom.mem_ker])
+
+/-- **The 2-rank of the class group**: the `ZMod 2`-dimension of the maximal elementary-2 quotient
+`Cl(R)/Cl(R)²`. This is the quantity the genus-field theorems express as `t - 1`, with `t` the
+number of ramified primes. -/
+noncomputable def twoRank : ℕ := Module.finrank (ZMod 2) (elementaryTwoQuotient R)
+
+/-- The maximal elementary-2 quotient has cardinality `2 ^ twoRank`: it is a finite `𝔽₂`-vector
+space of dimension the 2-rank. -/
+theorem card_elementaryTwoQuotient_eq_two_pow_twoRank :
+    Nat.card (elementaryTwoQuotient R) = 2 ^ twoRank R := by
+  rw [twoRank, Module.natCard_eq_pow_finrank (K := ZMod 2), Nat.card_zmod]
+
+end TauCeti.ClassGroup


### PR DESCRIPTION
This PR builds the **maximal elementary-2 quotient `Cl(R)/Cl(R)²`** of the class group of a domain, the entry point to Layer 2 of the multiquadratic roadmap (`TauCetiRoadmap/Multiquadratic/README.md`, "Layer 2: the 2-elementary quotient of the class group": "The squaring map on `Cl(K)` and the quotient `Cl(K)/Cl(K)²`. ⚠ Call it what it is: this is the maximal elementary-2 *quotient*, not the 2-torsion subgroup `Cl(K)[2]`; they have the same cardinality for a finite abelian group but are different objects, keep them distinct in names and statements."). It defines the quotient `Cl(R) ⧸ Cl(R)²` as a `ZMod 2`-vector space, proves the cardinality identity `|Cl(R)/Cl(R)²| = |Cl(R)[2]|` between the quotient and the 2-torsion subgroup while keeping the two objects distinct, defines the **2-rank** as the `𝔽₂`-dimension of the quotient, and records `|Cl(R)/Cl(R)²| = 2 ^ twoRank`. The class group of a number field is finite (Mathlib's `NumberField.instFintypeClassGroup`), so every statement applies to `Cl(𝓞 K)`, the genus-theory object; the results are stated field-generically over a domain with finite class group rather than baked to a number field.

The `ZMod 2`-module construction (`QuotientAddGroup.zmodModule` on `Additive (ClassGroup R)`) mirrors the existing square-class group `Kˣ ⧸ (Kˣ)²` in `TauCeti/FieldTheory/SquareClassGroup.lean`; the cardinality identity reuses Mathlib's `Subgroup.index_range` (the index of the range of an endomorphism equals the cardinality of its kernel) applied to the squaring homomorphism `powMonoidHom 2`, and `Module.natCard_eq_pow_finrank` for the 2-rank reading.

`TauCeti/NumberTheory/ClassGroup/ElementaryTwoQuotient.lean`, one new file (~90 lines).

<!--tauceti-target:v1 {"focus":"Multiquadratic","id":"class-group-elementary-two-quotient"}-->

🤖 Prepared with Claude Code
