### PR TITLE
feat: the group algebra of a product is the tensor product of group algebras

### DIFF
--- a/TauCeti/Algebra/AlgebraicGroup/GroupAlgebraProduct.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/GroupAlgebraProduct.lean
@@ -2,6 +2,7 @@
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 -/
+import Mathlib.RingTheory.TensorProduct.Maps
 import TauCeti.Algebra.Bialgebra.MonoidAlgebraProduct
 import TauCeti.Algebra.AlgebraicGroup.DiagonalizableGroup
 import TauCeti.Algebra.AlgebraicGroup.HopfMap

--- a/TauCeti/Algebra/AlgebraicGroup/GroupAlgebraProduct.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/GroupAlgebraProduct.lean
@@ -11,9 +11,10 @@ import TauCeti.Algebra.Bialgebra.TensorProduct
 # The diagonalizable group of a product
 
 This file records the functor-of-points consequence of
-`TauCeti.MonoidAlgebra.prodTensorBialgEquiv`: the diagonalizable group
-`D(G × H) = Spec R[G × H]`, for commutative groups `G` and `H`, is the direct product
-`D(G) × D(H)` of the diagonalizable groups of the factors.
+`TauCeti.MonoidAlgebra.prodTensorBialgEquiv`: for commutative monoids `G` and `H`, points of
+`Spec R[G × H]` split as pairs of points of `Spec R[G]` and `Spec R[H]`. For commutative groups,
+this specializes to the diagonalizable group statement
+`D(G × H)(A) ≃* D(G)(A) × D(H)(A)`.
 
 On points this composes with `TauCeti.AffineGroup.Product.pointsMulEquiv`, the tensor-product
 points calculation, through the equiv-version `AlgHom.mapDomainMulEquiv` of the contravariant
@@ -30,7 +31,9 @@ and this identifies its coordinate Hopf algebra `R[ℤⁿ]` with `R[ℤ]^{⊗ n}
 
 ## Main definitions
 
-* `TauCeti.DiagonalizableGroup.prodPointsMulEquiv`: on points,
+* `TauCeti.MonoidAlgebra.prodPointsMulEquiv`: on convolution points,
+  `Spec R[G × H](A) ≃* Spec R[G](A) × Spec R[H](A)`.
+* `TauCeti.DiagonalizableGroup.prodPointsMulEquiv`: for commutative groups, on points,
   `D(G × H)(A) ≃* D(G)(A) × D(H)(A)`.
 
 ## References
@@ -49,25 +52,25 @@ namespace TauCeti
 
 universe u v w w'
 
-namespace DiagonalizableGroup
-
 variable {R : Type u} [CommSemiring R]
-variable {G : Type v} {H : Type w} [CommGroup G] [CommGroup H]
+variable {G : Type v} {H : Type w} [CommMonoid G] [CommMonoid H]
 variable {A : Type w'} [CommSemiring A] [Algebra R A]
 
-/-- **The diagonalizable group of a product is the product of diagonalizable groups, on points.**
-For commutative groups `G` and `H` and every commutative `R`-algebra `A`, the convolution group
-of `A`-points of `D(G × H)` is the product of the convolution groups of `A`-points of `D(G)` and
-`D(H)`. -/
+namespace MonoidAlgebra
+
+/-- **The monoid algebra of a product gives the product functor on convolution points.**
+For commutative monoids `G` and `H` and every commutative `R`-algebra `A`, the convolution
+monoid of `A`-points of `Spec R[G × H]` is the product of the convolution monoids of
+`A`-points of `Spec R[G]` and `Spec R[H]`. -/
 noncomputable def prodPointsMulEquiv :
     WithConv (MonoidAlgebra R (G × H) →ₐ[R] A) ≃*
       WithConv (MonoidAlgebra R G →ₐ[R] A) × WithConv (MonoidAlgebra R H →ₐ[R] A) :=
   (AlgHom.mapDomainMulEquiv (A := A) (MonoidAlgebra.prodTensorBialgEquiv R)).symm.trans
     AffineGroup.Product.pointsMulEquiv
 
-/-- The first component of `prodPointsMulEquiv` restricts an `A`-point of `D(G × H)` to the
-factor `D(G)`: on the generator `single g 1` it evaluates the original point at `single (g, 1) 1`,
-the image of `g` under `G → G × H`. -/
+/-- The first component of `prodPointsMulEquiv` restricts an `A`-point of `Spec R[G × H]` to
+the factor `Spec R[G]`: on the generator `single g 1` it evaluates the original point at
+`single (g, 1) 1`, the image of `g` under `G → G × H`. -/
 @[simp]
 theorem prodPointsMulEquiv_fst_ofConv_single
     (f : WithConv (MonoidAlgebra R (G × H) →ₐ[R] A)) (g : G) :
@@ -77,12 +80,11 @@ theorem prodPointsMulEquiv_fst_ofConv_single
     AlgHom.mapDomainMulEquiv_symm_apply]
   simp only [AlgHom.mapDomain_apply, ofConv_toConv, AlgHom.comp_apply,
     BialgHom.coe_toAlgHom, Bialgebra.TensorProduct.includeLeft_apply, BialgEquiv.coe_toBialgHom]
-  rw [show (1 : MonoidAlgebra R H) = single 1 1 from MonoidAlgebra.one_def,
-    MonoidAlgebra.prodTensorBialgEquiv_symm_tmul_single]
+  rw [MonoidAlgebra.one_def, MonoidAlgebra.prodTensorBialgEquiv_symm_tmul_single]
 
-/-- The second component of `prodPointsMulEquiv` restricts an `A`-point of `D(G × H)` to the
-factor `D(H)`: on the generator `single h 1` it evaluates the original point at `single (1, h) 1`,
-the image of `h` under `H → G × H`. -/
+/-- The second component of `prodPointsMulEquiv` restricts an `A`-point of `Spec R[G × H]` to
+the factor `Spec R[H]`: on the generator `single h 1` it evaluates the original point at
+`single (1, h) 1`, the image of `h` under `H → G × H`. -/
 @[simp]
 theorem prodPointsMulEquiv_snd_ofConv_single
     (f : WithConv (MonoidAlgebra R (G × H) →ₐ[R] A)) (h : H) :
@@ -92,8 +94,7 @@ theorem prodPointsMulEquiv_snd_ofConv_single
     AlgHom.mapDomainMulEquiv_symm_apply]
   simp only [AlgHom.mapDomain_apply, ofConv_toConv, AlgHom.comp_apply,
     BialgHom.coe_toAlgHom, Bialgebra.TensorProduct.includeRight_apply, BialgEquiv.coe_toBialgHom]
-  rw [show (1 : MonoidAlgebra R G) = single 1 1 from MonoidAlgebra.one_def,
-    MonoidAlgebra.prodTensorBialgEquiv_symm_tmul_single]
+  rw [MonoidAlgebra.one_def, MonoidAlgebra.prodTensorBialgEquiv_symm_tmul_single]
 
 /-- The inverse of `prodPointsMulEquiv` assembles an `A`-point of `D(G × H)` from a pair of
 points of `D(G)` and `D(H)`: on the generator `single (g, h) 1` it multiplies the value of the
@@ -109,6 +110,75 @@ theorem prodPointsMulEquiv_symm_ofConv_single
   simp only [AlgHom.mapDomain_apply, ofConv_toConv, AlgHom.comp_apply, BialgHom.coe_toAlgHom,
     BialgEquiv.coe_toBialgHom, MonoidAlgebra.prodTensorBialgEquiv_single,
     AffineGroup.Product.pointsMulEquiv_symm_apply, Algebra.TensorProduct.productMap_apply_tmul]
+
+variable {B : Type*} [CommSemiring B] [Algebra R B]
+
+/-- The product-points equivalence is natural in the value algebra. -/
+theorem prodPointsMulEquiv_mapValue (φ : A →ₐ[R] B)
+    (f : WithConv (MonoidAlgebra R (G × H) →ₐ[R] A)) :
+    prodPointsMulEquiv (A := B) (AlgHom.mapValue (H := MonoidAlgebra R (G × H)) φ f) =
+      (AlgHom.mapValue (H := MonoidAlgebra R G) φ (prodPointsMulEquiv f).1,
+        AlgHom.mapValue (H := MonoidAlgebra R H) φ (prodPointsMulEquiv f).2) := by
+  apply Prod.ext
+  · apply WithConv.ofConv_injective
+    apply MonoidAlgebra.algHom_ext
+    intro g
+    simp
+  · apply WithConv.ofConv_injective
+    apply MonoidAlgebra.algHom_ext
+    intro h
+    simp
+
+end MonoidAlgebra
+
+namespace DiagonalizableGroup
+
+variable {G' : Type v} {H' : Type w} [CommGroup G'] [CommGroup H']
+
+/-- **The diagonalizable group of a product is the product of diagonalizable groups, on points.**
+For commutative groups `G` and `H` and every commutative `R`-algebra `A`, the convolution group
+of `A`-points of `D(G × H)` is the product of the convolution groups of `A`-points of `D(G)` and
+`D(H)`. -/
+noncomputable def prodPointsMulEquiv :
+    WithConv (MonoidAlgebra R (G' × H') →ₐ[R] A) ≃*
+      WithConv (MonoidAlgebra R G' →ₐ[R] A) × WithConv (MonoidAlgebra R H' →ₐ[R] A) :=
+  MonoidAlgebra.prodPointsMulEquiv (G := G') (H := H')
+
+/-- On generators, the first component of the diagonalizable product-points equivalence restricts
+along `g ↦ (g, 1)`. -/
+@[simp]
+theorem prodPointsMulEquiv_fst_ofConv_single
+    (f : WithConv (MonoidAlgebra R (G' × H') →ₐ[R] A)) (g : G') :
+    (prodPointsMulEquiv f).1.ofConv (single g (1 : R)) =
+      f.ofConv (single (g, (1 : H')) 1) :=
+  MonoidAlgebra.prodPointsMulEquiv_fst_ofConv_single (H := H') f g
+
+/-- On generators, the second component of the diagonalizable product-points equivalence restricts
+along `h ↦ (1, h)`. -/
+@[simp]
+theorem prodPointsMulEquiv_snd_ofConv_single
+    (f : WithConv (MonoidAlgebra R (G' × H') →ₐ[R] A)) (h : H') :
+    (prodPointsMulEquiv f).2.ofConv (single h (1 : R)) =
+      f.ofConv (single ((1 : G'), h) 1) :=
+  MonoidAlgebra.prodPointsMulEquiv_snd_ofConv_single (G := G') f h
+
+/-- On generators, the inverse diagonalizable product-points equivalence multiplies the two
+factor-point values. -/
+@[simp]
+theorem prodPointsMulEquiv_symm_ofConv_single
+    (f₁ : WithConv (MonoidAlgebra R G' →ₐ[R] A)) (f₂ : WithConv (MonoidAlgebra R H' →ₐ[R] A))
+    (g : G') (h : H') :
+    (prodPointsMulEquiv.symm (f₁, f₂)).ofConv (single (g, h) (1 : R)) =
+      f₁.ofConv (single g 1) * f₂.ofConv (single h 1) :=
+  MonoidAlgebra.prodPointsMulEquiv_symm_ofConv_single f₁ f₂ g h
+
+/-- The diagonalizable product-points equivalence is natural in the value algebra. -/
+theorem prodPointsMulEquiv_mapValue {B : Type*} [CommSemiring B] [Algebra R B] (φ : A →ₐ[R] B)
+    (f : WithConv (MonoidAlgebra R (G' × H') →ₐ[R] A)) :
+    prodPointsMulEquiv (A := B) (AlgHom.mapValue (H := MonoidAlgebra R (G' × H')) φ f) =
+      (AlgHom.mapValue (H := MonoidAlgebra R G') φ (prodPointsMulEquiv f).1,
+        AlgHom.mapValue (H := MonoidAlgebra R H') φ (prodPointsMulEquiv f).2) :=
+  MonoidAlgebra.prodPointsMulEquiv_mapValue φ f
 
 end DiagonalizableGroup
 

--- a/TauCeti/Algebra/AlgebraicGroup/GroupAlgebraProduct.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/GroupAlgebraProduct.lean
@@ -1,0 +1,252 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+import Mathlib.RingTheory.Bialgebra.MonoidAlgebra
+import TauCeti.Algebra.AlgebraicGroup.Product
+
+/-!
+# The group algebra of a product is the tensor product of group algebras
+
+For two commutative monoids `G` and `H`, the canonical map `single (g, h) 1 ↦ single g 1 ⊗ₜ
+single h 1` is an isomorphism of `R`-bialgebras `R[G × H] ≃ₐc[R] R[G] ⊗[R] R[H]`. This file
+constructs that isomorphism and records its consequence on the functor of points: the
+diagonalizable group `D(G × H) = Spec R[G × H]` is the direct product `D(G) × D(H)` of the
+diagonalizable groups of the factors.
+
+The bialgebra isomorphism is built from two mutually inverse algebra maps — the lift of the
+group-like monoid hom `(g, h) ↦ single g 1 ⊗ₜ single h 1` one way, and the tensor-product
+universal map of the two inclusions `R[G] → R[G × H]`, `R[H] → R[G × H]` (themselves
+`MonoidAlgebra.mapDomainAlgHom` of `MonoidHom.inl`/`MonoidHom.inr`) the other way — and then
+promoted to a bialgebra equivalence by checking compatibility with the counit and
+comultiplication on the group-like generators `single (g, h) 1`.
+
+On points this composes with `TauCeti.AffineGroup.Product.pointsMulEquiv`, the tensor-product
+points calculation, through the equiv-version `AlgHom.mapDomainMulEquiv` of the contravariant
+functoriality `AlgHom.mapDomain`. When `G` and `H` are commutative groups the group algebras
+are Hopf algebras and these convolution monoids are the convolution groups of points
+(`TauCeti.AlgHom.instGroup`), so the points equivalence is automatically an isomorphism of
+groups: `D(G × H)(A) ≅ D(G)(A) × D(H)(A)`.
+
+This advances the reductive-groups roadmap (`ReductiveGroups/README.md` in TauCetiRoadmap,
+Layer 4 "Diagonalizable groups" and the "Worked examples / products" theme, together with the
+Layer 0 functor-of-points dictionary): a split torus `𝔾ₘⁿ` is the `n`-fold product of `𝔾ₘ`,
+and this identifies its coordinate Hopf algebra `R[ℤⁿ]` with `R[ℤ]^{⊗ n}` and its points with
+`(Aˣ)ⁿ`.
+
+## Main definitions
+
+* `TauCeti.AlgHom.mapDomainMulEquiv`: a bialgebra isomorphism induces a multiplicative
+  equivalence of convolution monoids of points, by pre-composition.
+* `TauCeti.MonoidAlgebra.prodTensorAlgEquiv`: the algebra isomorphism
+  `R[G × H] ≃ₐ[R] R[G] ⊗[R] R[H]`.
+* `TauCeti.MonoidAlgebra.prodTensorBialgEquiv`: the same map as a bialgebra isomorphism.
+* `TauCeti.DiagonalizableGroup.prodPointsMulEquiv`: on points,
+  `D(G × H)(A) ≃* D(G)(A) × D(H)(A)`.
+
+## References
+
+The tensor-product bialgebra structure and `Algebra.TensorProduct.lift` are from Mathlib's
+`Mathlib.RingTheory.Bialgebra.TensorProduct` and `Mathlib.RingTheory.TensorProduct.Maps`; the
+group-algebra bialgebra structure and `MonoidAlgebra.mapDomainAlgHom` are from
+`Mathlib.RingTheory.Bialgebra.MonoidAlgebra` and `Mathlib.Algebra.MonoidAlgebra.Basic`. The
+tensor-product points calculation `TauCeti.AffineGroup.Product.pointsMulEquiv` and the
+contravariant functoriality `TauCeti.AlgHom.mapDomain` are Tau Ceti's existing
+functor-of-points infrastructure, built on the Mathlib convolution monoid of Yaël Dillies,
+Michał Mrugała and Yunzhou Xie.
+-/
+
+open TensorProduct WithConv MonoidAlgebra
+
+namespace TauCeti
+
+universe u v w w'
+
+namespace AlgHom
+
+variable {R H₁ H₂ A : Type*} [CommSemiring R]
+variable [CommSemiring H₁] [CommSemiring H₂] [_root_.Bialgebra R H₁] [_root_.Bialgebra R H₂]
+variable [CommSemiring A] [Algebra R A]
+
+/-- A bialgebra isomorphism `e : H₁ ≃ₐc[R] H₂` induces a multiplicative equivalence of the
+convolution monoids of points, by pre-composition: the equiv-version of the contravariant
+functoriality `AlgHom.mapDomain`. -/
+noncomputable def mapDomainMulEquiv (e : H₁ ≃ₐc[R] H₂) :
+    WithConv (H₂ →ₐ[R] A) ≃* WithConv (H₁ →ₐ[R] A) where
+  toFun := mapDomain (A := A) (e : H₁ →ₐc[R] H₂)
+  invFun := mapDomain (A := A) (e.symm : H₂ →ₐc[R] H₁)
+  map_mul' := map_mul _
+  left_inv f := by
+    have h : (mapDomain (A := A) (e.symm : H₂ →ₐc[R] H₁)).comp
+        (mapDomain (A := A) (e : H₁ →ₐc[R] H₂)) = MonoidHom.id _ := by
+      rw [← mapDomain_comp, e.comp_symm, mapDomain_id]
+    exact DFunLike.congr_fun h f
+  right_inv f := by
+    have h : (mapDomain (A := A) (e : H₁ →ₐc[R] H₂)).comp
+        (mapDomain (A := A) (e.symm : H₂ →ₐc[R] H₁)) = MonoidHom.id _ := by
+      rw [← mapDomain_comp, e.symm_comp, mapDomain_id]
+    exact DFunLike.congr_fun h f
+
+@[simp]
+lemma mapDomainMulEquiv_apply (e : H₁ ≃ₐc[R] H₂) (f : WithConv (H₂ →ₐ[R] A)) :
+    mapDomainMulEquiv e f = mapDomain (e : H₁ →ₐc[R] H₂) f := rfl
+
+@[simp]
+lemma mapDomainMulEquiv_symm_apply (e : H₁ ≃ₐc[R] H₂) (f : WithConv (H₁ →ₐ[R] A)) :
+    (mapDomainMulEquiv (A := A) e).symm f = mapDomain (e.symm : H₂ →ₐc[R] H₁) f := rfl
+
+end AlgHom
+
+namespace MonoidAlgebra
+
+variable (R : Type u) [CommSemiring R]
+variable {G : Type v} {H : Type w} [CommMonoid G] [CommMonoid H]
+
+/-- The group-like monoid homomorphism `(g, h) ↦ single g 1 ⊗ₜ single h 1` from `G × H` into the
+multiplicative monoid of `R[G] ⊗[R] R[H]`. -/
+noncomputable def prodChar : G × H →* MonoidAlgebra R G ⊗[R] MonoidAlgebra R H :=
+  ((Algebra.TensorProduct.includeLeft (R := R) (S := R) (A := MonoidAlgebra R G)
+        (B := MonoidAlgebra R H)).toMonoidHom.comp (of R G)).comp (MonoidHom.fst G H) *
+  ((Algebra.TensorProduct.includeRight (R := R) (A := MonoidAlgebra R G)
+        (B := MonoidAlgebra R H)).toMonoidHom.comp (of R H)).comp (MonoidHom.snd G H)
+
+@[simp]
+theorem prodChar_apply (g : G) (h : H) :
+    prodChar R (g, h) = single g (1 : R) ⊗ₜ[R] single h 1 := by
+  simp [prodChar, Algebra.TensorProduct.tmul_mul_tmul]
+
+/-- The forward algebra map `R[G × H] →ₐ[R] R[G] ⊗[R] R[H]`, sending `single (g, h) 1` to
+`single g 1 ⊗ₜ single h 1`. -/
+noncomputable def prodTensorAlgHom :
+    MonoidAlgebra R (G × H) →ₐ[R] MonoidAlgebra R G ⊗[R] MonoidAlgebra R H :=
+  lift R (MonoidAlgebra R G ⊗[R] MonoidAlgebra R H) (G × H) (prodChar R)
+
+@[simp]
+theorem prodTensorAlgHom_single (g : G) (h : H) :
+    prodTensorAlgHom R (single (g, h) (1 : R)) = single g 1 ⊗ₜ[R] single h 1 := by
+  simp only [prodTensorAlgHom, lift_single, one_smul, prodChar_apply]
+
+/-- The inverse algebra map `R[G] ⊗[R] R[H] →ₐ[R] R[G × H]`, the tensor-product universal map of
+the two inclusions `R[G] → R[G × H]` and `R[H] → R[G × H]`. -/
+noncomputable def tensorProdAlgHom :
+    MonoidAlgebra R G ⊗[R] MonoidAlgebra R H →ₐ[R] MonoidAlgebra R (G × H) :=
+  Algebra.TensorProduct.lift
+    (mapDomainAlgHom R R (MonoidHom.inl G H) :
+      MonoidAlgebra R G →ₐ[R] MonoidAlgebra R (G × H))
+    (mapDomainAlgHom R R (MonoidHom.inr G H) :
+      MonoidAlgebra R H →ₐ[R] MonoidAlgebra R (G × H))
+    (fun _ _ => Commute.all _ _)
+
+@[simp]
+theorem tensorProdAlgHom_tmul_single (g : G) (h : H) :
+    tensorProdAlgHom R (single g (1 : R) ⊗ₜ[R] single h 1) = single (g, h) 1 := by
+  simp only [tensorProdAlgHom, Algebra.TensorProduct.lift_tmul, mapDomainAlgHom_apply,
+    mapDomain_single, single_mul_single, MonoidHom.inl_apply, MonoidHom.inr_apply,
+    Prod.mk_mul_mk, mul_one, one_mul]
+
+/-- **The group algebra of a product is the tensor product of group algebras**, as an algebra
+isomorphism. It sends `single (g, h) 1` to `single g 1 ⊗ₜ single h 1`. -/
+noncomputable def prodTensorAlgEquiv :
+    MonoidAlgebra R (G × H) ≃ₐ[R] MonoidAlgebra R G ⊗[R] MonoidAlgebra R H :=
+  AlgEquiv.ofAlgHom (prodTensorAlgHom R) (tensorProdAlgHom R)
+    (by
+      apply Algebra.TensorProduct.ext
+      · apply MonoidAlgebra.algHom_ext
+        intro g
+        simp only [AlgHom.comp_apply, AlgHom.id_apply, Algebra.TensorProduct.includeLeft_apply]
+        rw [show (1 : MonoidAlgebra R H) = single 1 1 from one_def,
+          tensorProdAlgHom_tmul_single, prodTensorAlgHom_single]
+      · apply MonoidAlgebra.algHom_ext
+        intro h
+        simp only [AlgHom.coe_restrictScalars', AlgHom.comp_apply, AlgHom.id_apply,
+          Algebra.TensorProduct.includeRight_apply]
+        rw [show (1 : MonoidAlgebra R G) = single 1 1 from one_def,
+          tensorProdAlgHom_tmul_single, prodTensorAlgHom_single])
+    (by
+      apply MonoidAlgebra.algHom_ext
+      rintro ⟨g, h⟩
+      rw [AlgHom.comp_apply, prodTensorAlgHom_single, tensorProdAlgHom_tmul_single,
+        AlgHom.id_apply])
+
+@[simp]
+theorem prodTensorAlgEquiv_single (g : G) (h : H) :
+    prodTensorAlgEquiv R (single (g, h) (1 : R)) = single g 1 ⊗ₜ[R] single h 1 :=
+  prodTensorAlgHom_single R g h
+
+/-- **The group algebra of a product is the tensor product of group algebras**, as a bialgebra
+isomorphism. -/
+noncomputable def prodTensorBialgEquiv :
+    MonoidAlgebra R (G × H) ≃ₐc[R] MonoidAlgebra R G ⊗[R] MonoidAlgebra R H :=
+  BialgEquiv.ofAlgEquiv (prodTensorAlgEquiv R)
+    (by
+      apply MonoidAlgebra.algHom_ext
+      rintro ⟨g, h⟩
+      simp)
+    (by
+      apply MonoidAlgebra.algHom_ext
+      rintro ⟨g, h⟩
+      simp)
+
+@[simp]
+theorem prodTensorBialgEquiv_single (g : G) (h : H) :
+    prodTensorBialgEquiv R (single (g, h) (1 : R)) = single g 1 ⊗ₜ[R] single h 1 :=
+  prodTensorAlgEquiv_single R g h
+
+@[simp]
+theorem prodTensorBialgEquiv_symm_tmul_single (g : G) (h : H) :
+    (prodTensorBialgEquiv R).symm (single g (1 : R) ⊗ₜ[R] single h 1) = single (g, h) 1 := by
+  rw [← prodTensorBialgEquiv_single R g h, BialgEquiv.symm_apply_apply]
+
+end MonoidAlgebra
+
+namespace DiagonalizableGroup
+
+variable {R : Type u} [CommSemiring R]
+variable {G : Type v} {H : Type w} [CommMonoid G] [CommMonoid H]
+variable {A : Type w'} [CommSemiring A] [Algebra R A]
+
+/-- **The diagonalizable group of a product is the product of diagonalizable groups, on points.**
+For every commutative `R`-algebra `A`, the convolution monoid of `A`-points of `D(G × H)` is the
+product of the convolution monoids of `A`-points of `D(G)` and `D(H)`. When `G` and `H` are
+commutative groups the group algebras are Hopf algebras, so these convolution monoids are the
+convolution groups of points (`TauCeti.AlgHom.instGroup`) and this is an isomorphism of
+groups. -/
+noncomputable def prodPointsMulEquiv :
+    WithConv (MonoidAlgebra R (G × H) →ₐ[R] A) ≃*
+      WithConv (MonoidAlgebra R G →ₐ[R] A) × WithConv (MonoidAlgebra R H →ₐ[R] A) :=
+  (AlgHom.mapDomainMulEquiv (A := A) (MonoidAlgebra.prodTensorBialgEquiv R)).symm.trans
+    AffineGroup.Product.pointsMulEquiv
+
+/-- The first component of `prodPointsMulEquiv` restricts an `A`-point of `D(G × H)` to the
+factor `D(G)`: on the generator `single g 1` it evaluates the original point at `single (g, 1) 1`,
+the image of `g` under `G → G × H`. -/
+@[simp]
+theorem prodPointsMulEquiv_fst_ofConv_single
+    (f : WithConv (MonoidAlgebra R (G × H) →ₐ[R] A)) (g : G) :
+    (prodPointsMulEquiv f).1.ofConv (single g (1 : R)) =
+      f.ofConv (single (g, (1 : H)) 1) := by
+  rw [prodPointsMulEquiv, MulEquiv.trans_apply, AffineGroup.Product.pointsMulEquiv_apply,
+    AlgHom.mapDomainMulEquiv_symm_apply]
+  simp only [AlgHom.mapDomain_apply, ofConv_toConv, AlgHom.comp_apply,
+    BialgHom.coe_toAlgHom, Bialgebra.TensorProduct.includeLeft_apply, BialgEquiv.coe_toBialgHom]
+  rw [show (1 : MonoidAlgebra R H) = single 1 1 from MonoidAlgebra.one_def,
+    MonoidAlgebra.prodTensorBialgEquiv_symm_tmul_single]
+
+/-- The second component of `prodPointsMulEquiv` restricts an `A`-point of `D(G × H)` to the
+factor `D(H)`: on the generator `single h 1` it evaluates the original point at `single (1, h) 1`,
+the image of `h` under `H → G × H`. -/
+@[simp]
+theorem prodPointsMulEquiv_snd_ofConv_single
+    (f : WithConv (MonoidAlgebra R (G × H) →ₐ[R] A)) (h : H) :
+    (prodPointsMulEquiv f).2.ofConv (single h (1 : R)) =
+      f.ofConv (single ((1 : G), h) 1) := by
+  rw [prodPointsMulEquiv, MulEquiv.trans_apply, AffineGroup.Product.pointsMulEquiv_apply,
+    AlgHom.mapDomainMulEquiv_symm_apply]
+  simp only [AlgHom.mapDomain_apply, ofConv_toConv, AlgHom.comp_apply,
+    BialgHom.coe_toAlgHom, Bialgebra.TensorProduct.includeRight_apply, BialgEquiv.coe_toBialgHom]
+  rw [show (1 : MonoidAlgebra R G) = single 1 1 from MonoidAlgebra.one_def,
+    MonoidAlgebra.prodTensorBialgEquiv_symm_tmul_single]
+
+end DiagonalizableGroup
+
+end TauCeti

--- a/TauCeti/Algebra/AlgebraicGroup/GroupAlgebraProduct.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/GroupAlgebraProduct.lean
@@ -3,6 +3,7 @@ Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 -/
 import TauCeti.Algebra.Bialgebra.MonoidAlgebraProduct
+import TauCeti.Algebra.AlgebraicGroup.DiagonalizableGroup
 import TauCeti.Algebra.AlgebraicGroup.HopfMap
 import TauCeti.Algebra.AlgebraicGroup.Product
 import TauCeti.Algebra.Bialgebra.TensorProduct
@@ -25,9 +26,8 @@ groups: `D(G × H)(A) ≅ D(G)(A) × D(H)(A)`.
 
 This advances the reductive-groups roadmap (`ReductiveGroups/README.md` in TauCetiRoadmap,
 Layer 4 "Diagonalizable groups" and the "Worked examples / products" theme, together with the
-Layer 0 functor-of-points dictionary): a split torus `𝔾ₘⁿ` is the `n`-fold product of `𝔾ₘ`,
-and this identifies its coordinate Hopf algebra `R[ℤⁿ]` with `R[ℤ]^{⊗ n}` and its points with
-`(Aˣ)ⁿ`.
+Layer 0 functor-of-points dictionary): this supplies the binary product step used in the
+calculation of split tori as iterated products of `𝔾ₘ`.
 
 ## Main definitions
 
@@ -96,9 +96,9 @@ theorem prodPointsMulEquiv_snd_ofConv_single
     BialgHom.coe_toAlgHom, Bialgebra.TensorProduct.includeRight_apply, BialgEquiv.coe_toBialgHom]
   rw [MonoidAlgebra.one_def, MonoidAlgebra.prodTensorBialgEquiv_symm_tmul_single]
 
-/-- The inverse of `prodPointsMulEquiv` assembles an `A`-point of `D(G × H)` from a pair of
-points of `D(G)` and `D(H)`: on the generator `single (g, h) 1` it multiplies the value of the
-first point at `single g 1` and the value of the second at `single h 1`. -/
+/-- The inverse of `prodPointsMulEquiv` assembles an `A`-point of `Spec R[G × H]` from a pair of
+points of `Spec R[G]` and `Spec R[H]`: on the generator `single (g, h) 1` it multiplies the
+value of the first point at `single g 1` and the value of the second at `single h 1`. -/
 @[simp]
 theorem prodPointsMulEquiv_symm_ofConv_single
     (f₁ : WithConv (MonoidAlgebra R G →ₐ[R] A)) (f₂ : WithConv (MonoidAlgebra R H →ₐ[R] A))
@@ -179,6 +179,21 @@ theorem prodPointsMulEquiv_mapValue {B : Type*} [CommSemiring B] [Algebra R B] (
       (AlgHom.mapValue (H := MonoidAlgebra R G') φ (prodPointsMulEquiv f).1,
         AlgHom.mapValue (H := MonoidAlgebra R H') φ (prodPointsMulEquiv f).2) :=
   MonoidAlgebra.prodPointsMulEquiv_mapValue φ f
+
+/-- The diagonalizable product-points equivalence agrees with the existing character
+description of diagonalizable-group points: reading the character of a product point is the
+coproduct of the characters read from its two restrictions. -/
+theorem pointsMulEquiv_prodPointsMulEquiv
+    (f : WithConv (MonoidAlgebra R (G' × H') →ₐ[R] A)) :
+    pointsMulEquiv (R := R) (A := A) (G := G' × H') f =
+      (pointsMulEquiv (R := R) (A := A) (G := G') (prodPointsMulEquiv f).1).coprod
+        (pointsMulEquiv (R := R) (A := A) (G := H') (prodPointsMulEquiv f).2) := by
+  ext p
+  simp only [pointsMulEquiv_apply, MonoidHom.coprod_apply, Units.val_mul]
+  rw [charOfPoint_apply_coe, charOfPoint_apply_coe, charOfPoint_apply_coe,
+    prodPointsMulEquiv_fst_ofConv_single, prodPointsMulEquiv_snd_ofConv_single]
+  rw [← map_mul, single_mul_single, Prod.mk_mul_mk, mul_one, one_mul]
+  simp
 
 end DiagonalizableGroup
 

--- a/TauCeti/Algebra/AlgebraicGroup/GroupAlgebraProduct.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/GroupAlgebraProduct.lean
@@ -3,7 +3,9 @@ Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 -/
 import TauCeti.Algebra.Bialgebra.MonoidAlgebraProduct
+import TauCeti.Algebra.AlgebraicGroup.HopfMap
 import TauCeti.Algebra.AlgebraicGroup.Product
+import TauCeti.Algebra.Bialgebra.TensorProduct
 
 /-!
 # The diagonalizable group of a product

--- a/TauCeti/Algebra/AlgebraicGroup/GroupAlgebraProduct.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/GroupAlgebraProduct.lean
@@ -2,24 +2,16 @@
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 -/
-import Mathlib.RingTheory.Bialgebra.MonoidAlgebra
+import TauCeti.Algebra.Bialgebra.MonoidAlgebraProduct
 import TauCeti.Algebra.AlgebraicGroup.Product
 
 /-!
-# The group algebra of a product is the tensor product of group algebras
+# The diagonalizable group of a product
 
-For two monoids `G` and `H`, the canonical map `single (g, h) 1 ↦ single g 1 ⊗ₜ
-single h 1` is an isomorphism of `R`-bialgebras `R[G × H] ≃ₐc[R] R[G] ⊗[R] R[H]`. This file
-constructs that isomorphism and records its consequence on the functor of points: the
-diagonalizable group `D(G × H) = Spec R[G × H]`, for commutative groups `G` and `H`, is the
-direct product `D(G) × D(H)` of the diagonalizable groups of the factors.
-
-The bialgebra isomorphism is built from two mutually inverse algebra maps — the lift of the
-group-like monoid hom `(g, h) ↦ single g 1 ⊗ₜ single h 1` one way, and the tensor-product
-universal map of the two inclusions `R[G] → R[G × H]`, `R[H] → R[G × H]` (themselves
-`MonoidAlgebra.mapDomainAlgHom` of `MonoidHom.inl`/`MonoidHom.inr`) the other way — and then
-promoted to a bialgebra equivalence by checking compatibility with the counit and
-comultiplication on the group-like generators `single (g, h) 1`.
+This file records the functor-of-points consequence of
+`TauCeti.MonoidAlgebra.prodTensorBialgEquiv`: the diagonalizable group
+`D(G × H) = Spec R[G × H]`, for commutative groups `G` and `H`, is the direct product
+`D(G) × D(H)` of the diagonalizable groups of the factors.
 
 On points this composes with `TauCeti.AffineGroup.Product.pointsMulEquiv`, the tensor-product
 points calculation, through the equiv-version `AlgHom.mapDomainMulEquiv` of the contravariant
@@ -36,22 +28,17 @@ and this identifies its coordinate Hopf algebra `R[ℤⁿ]` with `R[ℤ]^{⊗ n}
 
 ## Main definitions
 
-* `TauCeti.MonoidAlgebra.prodTensorAlgEquiv`: the algebra isomorphism
-  `R[G × H] ≃ₐ[R] R[G] ⊗[R] R[H]`.
-* `TauCeti.MonoidAlgebra.prodTensorBialgEquiv`: the same map as a bialgebra isomorphism.
 * `TauCeti.DiagonalizableGroup.prodPointsMulEquiv`: on points,
   `D(G × H)(A) ≃* D(G)(A) × D(H)(A)`.
 
 ## References
 
-The tensor-product bialgebra structure and `Algebra.TensorProduct.lift` are from Mathlib's
-`Mathlib.RingTheory.Bialgebra.TensorProduct` and `Mathlib.RingTheory.TensorProduct.Maps`; the
-group-algebra bialgebra structure and `MonoidAlgebra.mapDomainAlgHom` are from
-`Mathlib.RingTheory.Bialgebra.MonoidAlgebra` and `Mathlib.Algebra.MonoidAlgebra.Basic`. The
-tensor-product points calculation `TauCeti.AffineGroup.Product.pointsMulEquiv` and the
+The tensor-product points calculation `TauCeti.AffineGroup.Product.pointsMulEquiv`, the generic
+monoid-algebra bialgebra product `TauCeti.MonoidAlgebra.prodTensorBialgEquiv`, and the
 contravariant functoriality `TauCeti.AlgHom.mapDomain` are Tau Ceti's existing
-functor-of-points infrastructure, built on the Mathlib convolution monoid of Yaël Dillies,
-Michał Mrugała and Yunzhou Xie.
+functor-of-points infrastructure, built on Mathlib's tensor-product and monoid-algebra
+bialgebra structures and the Mathlib convolution monoid of Yaël Dillies, Michał Mrugała and
+Yunzhou Xie.
 -/
 
 open TensorProduct WithConv MonoidAlgebra
@@ -59,128 +46,6 @@ open TensorProduct WithConv MonoidAlgebra
 namespace TauCeti
 
 universe u v w w'
-
-namespace MonoidAlgebra
-
-variable (R : Type u) [CommSemiring R]
-variable {G : Type v} {H : Type w} [Monoid G] [Monoid H]
-
-/-- The group-like monoid homomorphism `(g, h) ↦ single g 1 ⊗ₜ single h 1` from `G × H` into the
-multiplicative monoid of `R[G] ⊗[R] R[H]`. -/
-private noncomputable def prodGroupLike :
-    G × H →* MonoidAlgebra R G ⊗[R] MonoidAlgebra R H where
-  toFun p := single p.1 (1 : R) ⊗ₜ[R] single p.2 1
-  map_one' := by
-    simp only [Prod.fst_one, Prod.snd_one, ← MonoidAlgebra.one_def,
-      Algebra.TensorProduct.one_def]
-  map_mul' x y := by
-    simp only [Prod.fst_mul, Prod.snd_mul, Algebra.TensorProduct.tmul_mul_tmul,
-      single_mul_single, mul_one]
-
-@[simp]
-private theorem prodGroupLike_apply (g : G) (h : H) :
-    prodGroupLike R (g, h) = single g (1 : R) ⊗ₜ[R] single h 1 := rfl
-
-/-- The forward algebra map `R[G × H] →ₐ[R] R[G] ⊗[R] R[H]`, sending `single (g, h) 1` to
-`single g 1 ⊗ₜ single h 1`. -/
-private noncomputable def prodTensorAlgHom :
-    MonoidAlgebra R (G × H) →ₐ[R] MonoidAlgebra R G ⊗[R] MonoidAlgebra R H :=
-  lift R (MonoidAlgebra R G ⊗[R] MonoidAlgebra R H) (G × H) (prodGroupLike R)
-
-@[simp]
-private theorem prodTensorAlgHom_single (g : G) (h : H) :
-    prodTensorAlgHom R (single (g, h) (1 : R)) = single g 1 ⊗ₜ[R] single h 1 := by
-  simp only [prodTensorAlgHom, lift_single, one_smul, prodGroupLike_apply]
-
-/-- The images of the two inclusions `R[G] → R[G × H]` and `R[H] → R[G × H]` commute: `single
-(g, 1) a` and `single (1, h) b` multiply to `single (g, h) (a * b)` either way, since `R` is
-commutative. This is the hypothesis needed to assemble the tensor-product universal map. -/
-private theorem commute_mapDomainAlgHom_inl_inr (x : MonoidAlgebra R G) (y : MonoidAlgebra R H) :
-    Commute (mapDomainAlgHom R R (MonoidHom.inl G H) x)
-      (mapDomainAlgHom R R (MonoidHom.inr G H) y) := by
-  induction x using MonoidAlgebra.induction_on with
-  | hM g =>
-    induction y using MonoidAlgebra.induction_on with
-    | hM h =>
-      simp only [of_apply, mapDomainAlgHom_apply, mapDomain_single, MonoidHom.inl_apply,
-        MonoidHom.inr_apply, commute_iff_eq, single_mul_single, Prod.mk_mul_mk, mul_one, one_mul]
-    | hadd y₁ y₂ hy₁ hy₂ => rw [map_add]; exact hy₁.add_right hy₂
-    | hsmul r y hy => rw [map_smul]; exact hy.smul_right r
-  | hadd x₁ x₂ hx₁ hx₂ => rw [map_add]; exact hx₁.add_left hx₂
-  | hsmul r x hx => rw [map_smul]; exact hx.smul_left r
-
-/-- The inverse algebra map `R[G] ⊗[R] R[H] →ₐ[R] R[G × H]`, the tensor-product universal map of
-the two inclusions `R[G] → R[G × H]` and `R[H] → R[G × H]`. -/
-private noncomputable def tensorProdAlgHom :
-    MonoidAlgebra R G ⊗[R] MonoidAlgebra R H →ₐ[R] MonoidAlgebra R (G × H) :=
-  Algebra.TensorProduct.lift
-    (mapDomainAlgHom R R (MonoidHom.inl G H) :
-      MonoidAlgebra R G →ₐ[R] MonoidAlgebra R (G × H))
-    (mapDomainAlgHom R R (MonoidHom.inr G H) :
-      MonoidAlgebra R H →ₐ[R] MonoidAlgebra R (G × H))
-    (commute_mapDomainAlgHom_inl_inr R)
-
-@[simp]
-private theorem tensorProdAlgHom_tmul_single (g : G) (h : H) :
-    tensorProdAlgHom R (single g (1 : R) ⊗ₜ[R] single h 1) = single (g, h) 1 := by
-  simp only [tensorProdAlgHom, Algebra.TensorProduct.lift_tmul, mapDomainAlgHom_apply,
-    mapDomain_single, single_mul_single, MonoidHom.inl_apply, MonoidHom.inr_apply,
-    Prod.mk_mul_mk, mul_one, one_mul]
-
-/-- **The group algebra of a product is the tensor product of group algebras**, as an algebra
-isomorphism. It sends `single (g, h) 1` to `single g 1 ⊗ₜ single h 1`. -/
-noncomputable def prodTensorAlgEquiv :
-    MonoidAlgebra R (G × H) ≃ₐ[R] MonoidAlgebra R G ⊗[R] MonoidAlgebra R H :=
-  AlgEquiv.ofAlgHom (prodTensorAlgHom R) (tensorProdAlgHom R)
-    (by
-      apply Algebra.TensorProduct.ext
-      · apply MonoidAlgebra.algHom_ext
-        intro g
-        simp only [AlgHom.comp_apply, AlgHom.id_apply, Algebra.TensorProduct.includeLeft_apply]
-        rw [show (1 : MonoidAlgebra R H) = single 1 1 from one_def,
-          tensorProdAlgHom_tmul_single, prodTensorAlgHom_single]
-      · apply MonoidAlgebra.algHom_ext
-        intro h
-        simp only [AlgHom.coe_restrictScalars', AlgHom.comp_apply, AlgHom.id_apply,
-          Algebra.TensorProduct.includeRight_apply]
-        rw [show (1 : MonoidAlgebra R G) = single 1 1 from one_def,
-          tensorProdAlgHom_tmul_single, prodTensorAlgHom_single])
-    (by
-      apply MonoidAlgebra.algHom_ext
-      rintro ⟨g, h⟩
-      rw [AlgHom.comp_apply, prodTensorAlgHom_single, tensorProdAlgHom_tmul_single,
-        AlgHom.id_apply])
-
-@[simp]
-theorem prodTensorAlgEquiv_single (g : G) (h : H) :
-    prodTensorAlgEquiv R (single (g, h) (1 : R)) = single g 1 ⊗ₜ[R] single h 1 :=
-  prodTensorAlgHom_single R g h
-
-/-- **The group algebra of a product is the tensor product of group algebras**, as a bialgebra
-isomorphism. -/
-noncomputable def prodTensorBialgEquiv :
-    MonoidAlgebra R (G × H) ≃ₐc[R] MonoidAlgebra R G ⊗[R] MonoidAlgebra R H :=
-  BialgEquiv.ofAlgEquiv (prodTensorAlgEquiv R)
-    (by
-      apply MonoidAlgebra.algHom_ext
-      rintro ⟨g, h⟩
-      simp)
-    (by
-      apply MonoidAlgebra.algHom_ext
-      rintro ⟨g, h⟩
-      simp)
-
-@[simp]
-theorem prodTensorBialgEquiv_single (g : G) (h : H) :
-    prodTensorBialgEquiv R (single (g, h) (1 : R)) = single g 1 ⊗ₜ[R] single h 1 :=
-  prodTensorAlgEquiv_single R g h
-
-@[simp]
-theorem prodTensorBialgEquiv_symm_tmul_single (g : G) (h : H) :
-    (prodTensorBialgEquiv R).symm (single g (1 : R) ⊗ₜ[R] single h 1) = single (g, h) 1 := by
-  rw [← prodTensorBialgEquiv_single R g h, BialgEquiv.symm_apply_apply]
-
-end MonoidAlgebra
 
 namespace DiagonalizableGroup
 

--- a/TauCeti/Algebra/AlgebraicGroup/GroupAlgebraProduct.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/GroupAlgebraProduct.lean
@@ -36,8 +36,6 @@ and this identifies its coordinate Hopf algebra `R[ℤⁿ]` with `R[ℤ]^{⊗ n}
 
 ## Main definitions
 
-* `TauCeti.AlgHom.mapDomainMulEquiv`: a bialgebra isomorphism induces a multiplicative
-  equivalence of convolution monoids of points, by pre-composition.
 * `TauCeti.MonoidAlgebra.prodTensorAlgEquiv`: the algebra isomorphism
   `R[G × H] ≃ₐ[R] R[G] ⊗[R] R[H]`.
 * `TauCeti.MonoidAlgebra.prodTensorBialgEquiv`: the same map as a bialgebra isomorphism.
@@ -62,83 +60,68 @@ namespace TauCeti
 
 universe u v w w'
 
-namespace AlgHom
-
-variable {R H₁ H₂ A : Type*} [CommSemiring R]
-variable [CommSemiring H₁] [CommSemiring H₂] [_root_.Bialgebra R H₁] [_root_.Bialgebra R H₂]
-variable [CommSemiring A] [Algebra R A]
-
-/-- A bialgebra isomorphism `e : H₁ ≃ₐc[R] H₂` induces a multiplicative equivalence of the
-convolution monoids of points, by pre-composition: the equiv-version of the contravariant
-functoriality `AlgHom.mapDomain`. -/
-noncomputable def mapDomainMulEquiv (e : H₁ ≃ₐc[R] H₂) :
-    WithConv (H₂ →ₐ[R] A) ≃* WithConv (H₁ →ₐ[R] A) where
-  toFun := mapDomain (A := A) (e : H₁ →ₐc[R] H₂)
-  invFun := mapDomain (A := A) (e.symm : H₂ →ₐc[R] H₁)
-  map_mul' := map_mul _
-  left_inv f := by
-    have h : (mapDomain (A := A) (e.symm : H₂ →ₐc[R] H₁)).comp
-        (mapDomain (A := A) (e : H₁ →ₐc[R] H₂)) = MonoidHom.id _ := by
-      rw [← mapDomain_comp, e.comp_symm, mapDomain_id]
-    exact DFunLike.congr_fun h f
-  right_inv f := by
-    have h : (mapDomain (A := A) (e : H₁ →ₐc[R] H₂)).comp
-        (mapDomain (A := A) (e.symm : H₂ →ₐc[R] H₁)) = MonoidHom.id _ := by
-      rw [← mapDomain_comp, e.symm_comp, mapDomain_id]
-    exact DFunLike.congr_fun h f
-
-@[simp]
-lemma mapDomainMulEquiv_apply (e : H₁ ≃ₐc[R] H₂) (f : WithConv (H₂ →ₐ[R] A)) :
-    mapDomainMulEquiv e f = mapDomain (e : H₁ →ₐc[R] H₂) f := rfl
-
-@[simp]
-lemma mapDomainMulEquiv_symm_apply (e : H₁ ≃ₐc[R] H₂) (f : WithConv (H₁ →ₐ[R] A)) :
-    (mapDomainMulEquiv (A := A) e).symm f = mapDomain (e.symm : H₂ →ₐc[R] H₁) f := rfl
-
-end AlgHom
-
 namespace MonoidAlgebra
 
 variable (R : Type u) [CommSemiring R]
-variable {G : Type v} {H : Type w} [CommMonoid G] [CommMonoid H]
+variable {G : Type v} {H : Type w} [Monoid G] [Monoid H]
 
 /-- The group-like monoid homomorphism `(g, h) ↦ single g 1 ⊗ₜ single h 1` from `G × H` into the
 multiplicative monoid of `R[G] ⊗[R] R[H]`. -/
-noncomputable def prodChar : G × H →* MonoidAlgebra R G ⊗[R] MonoidAlgebra R H :=
-  ((Algebra.TensorProduct.includeLeft (R := R) (S := R) (A := MonoidAlgebra R G)
-        (B := MonoidAlgebra R H)).toMonoidHom.comp (of R G)).comp (MonoidHom.fst G H) *
-  ((Algebra.TensorProduct.includeRight (R := R) (A := MonoidAlgebra R G)
-        (B := MonoidAlgebra R H)).toMonoidHom.comp (of R H)).comp (MonoidHom.snd G H)
+private noncomputable def prodGroupLike :
+    G × H →* MonoidAlgebra R G ⊗[R] MonoidAlgebra R H where
+  toFun p := single p.1 (1 : R) ⊗ₜ[R] single p.2 1
+  map_one' := by
+    simp only [Prod.fst_one, Prod.snd_one, ← MonoidAlgebra.one_def,
+      Algebra.TensorProduct.one_def]
+  map_mul' x y := by
+    simp only [Prod.fst_mul, Prod.snd_mul, Algebra.TensorProduct.tmul_mul_tmul,
+      single_mul_single, mul_one]
 
 @[simp]
-theorem prodChar_apply (g : G) (h : H) :
-    prodChar R (g, h) = single g (1 : R) ⊗ₜ[R] single h 1 := by
-  simp [prodChar, Algebra.TensorProduct.tmul_mul_tmul]
+private theorem prodGroupLike_apply (g : G) (h : H) :
+    prodGroupLike R (g, h) = single g (1 : R) ⊗ₜ[R] single h 1 := rfl
 
 /-- The forward algebra map `R[G × H] →ₐ[R] R[G] ⊗[R] R[H]`, sending `single (g, h) 1` to
 `single g 1 ⊗ₜ single h 1`. -/
-noncomputable def prodTensorAlgHom :
+private noncomputable def prodTensorAlgHom :
     MonoidAlgebra R (G × H) →ₐ[R] MonoidAlgebra R G ⊗[R] MonoidAlgebra R H :=
-  lift R (MonoidAlgebra R G ⊗[R] MonoidAlgebra R H) (G × H) (prodChar R)
+  lift R (MonoidAlgebra R G ⊗[R] MonoidAlgebra R H) (G × H) (prodGroupLike R)
 
 @[simp]
-theorem prodTensorAlgHom_single (g : G) (h : H) :
+private theorem prodTensorAlgHom_single (g : G) (h : H) :
     prodTensorAlgHom R (single (g, h) (1 : R)) = single g 1 ⊗ₜ[R] single h 1 := by
-  simp only [prodTensorAlgHom, lift_single, one_smul, prodChar_apply]
+  simp only [prodTensorAlgHom, lift_single, one_smul, prodGroupLike_apply]
+
+/-- The images of the two inclusions `R[G] → R[G × H]` and `R[H] → R[G × H]` commute: `single
+(g, 1) a` and `single (1, h) b` multiply to `single (g, h) (a * b)` either way, since `R` is
+commutative. This is the hypothesis needed to assemble the tensor-product universal map. -/
+private theorem commute_mapDomainAlgHom_inl_inr (x : MonoidAlgebra R G) (y : MonoidAlgebra R H) :
+    Commute (mapDomainAlgHom R R (MonoidHom.inl G H) x)
+      (mapDomainAlgHom R R (MonoidHom.inr G H) y) := by
+  induction x using MonoidAlgebra.induction_on with
+  | hM g =>
+    induction y using MonoidAlgebra.induction_on with
+    | hM h =>
+      simp only [of_apply, mapDomainAlgHom_apply, mapDomain_single, MonoidHom.inl_apply,
+        MonoidHom.inr_apply, commute_iff_eq, single_mul_single, Prod.mk_mul_mk, mul_one, one_mul]
+    | hadd y₁ y₂ hy₁ hy₂ => rw [map_add]; exact hy₁.add_right hy₂
+    | hsmul r y hy => rw [map_smul]; exact hy.smul_right r
+  | hadd x₁ x₂ hx₁ hx₂ => rw [map_add]; exact hx₁.add_left hx₂
+  | hsmul r x hx => rw [map_smul]; exact hx.smul_left r
 
 /-- The inverse algebra map `R[G] ⊗[R] R[H] →ₐ[R] R[G × H]`, the tensor-product universal map of
 the two inclusions `R[G] → R[G × H]` and `R[H] → R[G × H]`. -/
-noncomputable def tensorProdAlgHom :
+private noncomputable def tensorProdAlgHom :
     MonoidAlgebra R G ⊗[R] MonoidAlgebra R H →ₐ[R] MonoidAlgebra R (G × H) :=
   Algebra.TensorProduct.lift
     (mapDomainAlgHom R R (MonoidHom.inl G H) :
       MonoidAlgebra R G →ₐ[R] MonoidAlgebra R (G × H))
     (mapDomainAlgHom R R (MonoidHom.inr G H) :
       MonoidAlgebra R H →ₐ[R] MonoidAlgebra R (G × H))
-    (fun _ _ => Commute.all _ _)
+    (commute_mapDomainAlgHom_inl_inr R)
 
 @[simp]
-theorem tensorProdAlgHom_tmul_single (g : G) (h : H) :
+private theorem tensorProdAlgHom_tmul_single (g : G) (h : H) :
     tensorProdAlgHom R (single g (1 : R) ⊗ₜ[R] single h 1) = single (g, h) 1 := by
   simp only [tensorProdAlgHom, Algebra.TensorProduct.lift_tmul, mapDomainAlgHom_apply,
     mapDomain_single, single_mul_single, MonoidHom.inl_apply, MonoidHom.inr_apply,
@@ -246,6 +229,21 @@ theorem prodPointsMulEquiv_snd_ofConv_single
     BialgHom.coe_toAlgHom, Bialgebra.TensorProduct.includeRight_apply, BialgEquiv.coe_toBialgHom]
   rw [show (1 : MonoidAlgebra R G) = single 1 1 from MonoidAlgebra.one_def,
     MonoidAlgebra.prodTensorBialgEquiv_symm_tmul_single]
+
+/-- The inverse of `prodPointsMulEquiv` assembles an `A`-point of `D(G × H)` from a pair of
+points of `D(G)` and `D(H)`: on the generator `single (g, h) 1` it multiplies the value of the
+first point at `single g 1` and the value of the second at `single h 1`. -/
+@[simp]
+theorem prodPointsMulEquiv_symm_ofConv_single
+    (f₁ : WithConv (MonoidAlgebra R G →ₐ[R] A)) (f₂ : WithConv (MonoidAlgebra R H →ₐ[R] A))
+    (g : G) (h : H) :
+    (prodPointsMulEquiv.symm (f₁, f₂)).ofConv (single (g, h) (1 : R)) =
+      f₁.ofConv (single g 1) * f₂.ofConv (single h 1) := by
+  rw [prodPointsMulEquiv, MulEquiv.symm_trans_apply, MulEquiv.symm_symm,
+    AlgHom.mapDomainMulEquiv_apply]
+  simp only [AlgHom.mapDomain_apply, ofConv_toConv, AlgHom.comp_apply, BialgHom.coe_toAlgHom,
+    BialgEquiv.coe_toBialgHom, MonoidAlgebra.prodTensorBialgEquiv_single,
+    AffineGroup.Product.pointsMulEquiv_symm_apply, Algebra.TensorProduct.productMap_apply_tmul]
 
 end DiagonalizableGroup
 

--- a/TauCeti/Algebra/AlgebraicGroup/GroupAlgebraProduct.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/GroupAlgebraProduct.lean
@@ -115,6 +115,7 @@ theorem prodPointsMulEquiv_symm_ofConv_single
 variable {B : Type*} [CommSemiring B] [Algebra R B]
 
 /-- The product-points equivalence is natural in the value algebra. -/
+@[simp]
 theorem prodPointsMulEquiv_mapValue (φ : A →ₐ[R] B)
     (f : WithConv (MonoidAlgebra R (G × H) →ₐ[R] A)) :
     prodPointsMulEquiv (A := B) (AlgHom.mapValue (H := MonoidAlgebra R (G × H)) φ f) =
@@ -174,6 +175,7 @@ theorem prodPointsMulEquiv_symm_ofConv_single
   MonoidAlgebra.prodPointsMulEquiv_symm_ofConv_single f₁ f₂ g h
 
 /-- The diagonalizable product-points equivalence is natural in the value algebra. -/
+@[simp]
 theorem prodPointsMulEquiv_mapValue {B : Type*} [CommSemiring B] [Algebra R B] (φ : A →ₐ[R] B)
     (f : WithConv (MonoidAlgebra R (G' × H') →ₐ[R] A)) :
     prodPointsMulEquiv (A := B) (AlgHom.mapValue (H := MonoidAlgebra R (G' × H')) φ f) =
@@ -184,6 +186,7 @@ theorem prodPointsMulEquiv_mapValue {B : Type*} [CommSemiring B] [Algebra R B] (
 /-- The diagonalizable product-points equivalence agrees with the existing character
 description of diagonalizable-group points: reading the character of a product point is the
 coproduct of the characters read from its two restrictions. -/
+@[simp]
 theorem pointsMulEquiv_prodPointsMulEquiv
     (f : WithConv (MonoidAlgebra R (G' × H') →ₐ[R] A)) :
     pointsMulEquiv (R := R) (A := A) (G := G' × H') f =

--- a/TauCeti/Algebra/AlgebraicGroup/GroupAlgebraProduct.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/GroupAlgebraProduct.lean
@@ -8,11 +8,11 @@ import TauCeti.Algebra.AlgebraicGroup.Product
 /-!
 # The group algebra of a product is the tensor product of group algebras
 
-For two commutative monoids `G` and `H`, the canonical map `single (g, h) 1 ↦ single g 1 ⊗ₜ
+For two monoids `G` and `H`, the canonical map `single (g, h) 1 ↦ single g 1 ⊗ₜ
 single h 1` is an isomorphism of `R`-bialgebras `R[G × H] ≃ₐc[R] R[G] ⊗[R] R[H]`. This file
 constructs that isomorphism and records its consequence on the functor of points: the
-diagonalizable group `D(G × H) = Spec R[G × H]` is the direct product `D(G) × D(H)` of the
-diagonalizable groups of the factors.
+diagonalizable group `D(G × H) = Spec R[G × H]`, for commutative groups `G` and `H`, is the
+direct product `D(G) × D(H)` of the diagonalizable groups of the factors.
 
 The bialgebra isomorphism is built from two mutually inverse algebra maps — the lift of the
 group-like monoid hom `(g, h) ↦ single g 1 ⊗ₜ single h 1` one way, and the tensor-product
@@ -185,15 +185,13 @@ end MonoidAlgebra
 namespace DiagonalizableGroup
 
 variable {R : Type u} [CommSemiring R]
-variable {G : Type v} {H : Type w} [CommMonoid G] [CommMonoid H]
+variable {G : Type v} {H : Type w} [CommGroup G] [CommGroup H]
 variable {A : Type w'} [CommSemiring A] [Algebra R A]
 
 /-- **The diagonalizable group of a product is the product of diagonalizable groups, on points.**
-For every commutative `R`-algebra `A`, the convolution monoid of `A`-points of `D(G × H)` is the
-product of the convolution monoids of `A`-points of `D(G)` and `D(H)`. When `G` and `H` are
-commutative groups the group algebras are Hopf algebras, so these convolution monoids are the
-convolution groups of points (`TauCeti.AlgHom.instGroup`) and this is an isomorphism of
-groups. -/
+For commutative groups `G` and `H` and every commutative `R`-algebra `A`, the convolution group
+of `A`-points of `D(G × H)` is the product of the convolution groups of `A`-points of `D(G)` and
+`D(H)`. -/
 noncomputable def prodPointsMulEquiv :
     WithConv (MonoidAlgebra R (G × H) →ₐ[R] A) ≃*
       WithConv (MonoidAlgebra R G →ₐ[R] A) × WithConv (MonoidAlgebra R H →ₐ[R] A) :=

--- a/TauCeti/Algebra/AlgebraicGroup/HopfMap.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/HopfMap.lean
@@ -2,6 +2,7 @@
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 -/
+import Mathlib.RingTheory.Bialgebra.Equiv
 import TauCeti.Algebra.AlgebraicGroup.FunctorOfPoints
 
 /-!
@@ -23,6 +24,8 @@ the reductive-groups roadmap Layer 0 target "R-points as a group" and its follow
 * `AlgHom.mapDomain`: pre-composition by a bialgebra morphism as a monoid homomorphism of
   convolution monoids.
 * `AlgHom.mapDomain_id` and `AlgHom.mapDomain_comp`: identity and composition laws.
+* `AlgHom.mapDomainMulEquiv`: the equiv-version of `AlgHom.mapDomain`, turning a bialgebra
+  isomorphism into a multiplicative equivalence of convolution monoids.
 * `AlgHom.mapValue_mapDomain`: pre-composition in the coordinate algebra commutes with
   post-composition in the value algebra.
 * `AlgHom.mapDomain_inv_apply`: pointwise inverse formula after pre-composition.
@@ -107,6 +110,41 @@ lemma mapDomain_comp (ψ : H₂ →ₐc[R] H₃) (φ : H₁ →ₐc[R] H₂) :
     toConv_ofConv, BialgHom.comp_toAlgHom, AlgHom.comp_assoc]
 
 end BialgebraComp
+
+section BialgebraEquiv
+
+variable [CommSemiring H₁] [CommSemiring H₂]
+variable [_root_.Bialgebra R H₁] [_root_.Bialgebra R H₂]
+variable [CommSemiring A] [Algebra R A]
+
+/-- A bialgebra isomorphism `e : H₁ ≃ₐc[R] H₂` induces a multiplicative equivalence of the
+convolution monoids of points, by pre-composition: the equiv-version of the contravariant
+functoriality `mapDomain`. -/
+noncomputable def mapDomainMulEquiv (e : H₁ ≃ₐc[R] H₂) :
+    WithConv (H₂ →ₐ[R] A) ≃* WithConv (H₁ →ₐ[R] A) where
+  toFun := mapDomain (A := A) (e : H₁ →ₐc[R] H₂)
+  invFun := mapDomain (A := A) (e.symm : H₂ →ₐc[R] H₁)
+  map_mul' := map_mul _
+  left_inv f := by
+    have h : (mapDomain (A := A) (e.symm : H₂ →ₐc[R] H₁)).comp
+        (mapDomain (A := A) (e : H₁ →ₐc[R] H₂)) = MonoidHom.id _ := by
+      rw [← mapDomain_comp, e.comp_symm, mapDomain_id]
+    exact DFunLike.congr_fun h f
+  right_inv f := by
+    have h : (mapDomain (A := A) (e : H₁ →ₐc[R] H₂)).comp
+        (mapDomain (A := A) (e.symm : H₂ →ₐc[R] H₁)) = MonoidHom.id _ := by
+      rw [← mapDomain_comp, e.symm_comp, mapDomain_id]
+    exact DFunLike.congr_fun h f
+
+@[simp]
+lemma mapDomainMulEquiv_apply (e : H₁ ≃ₐc[R] H₂) (f : WithConv (H₂ →ₐ[R] A)) :
+    mapDomainMulEquiv e f = mapDomain (e : H₁ →ₐc[R] H₂) f := rfl
+
+@[simp]
+lemma mapDomainMulEquiv_symm_apply (e : H₁ ≃ₐc[R] H₂) (f : WithConv (H₁ →ₐ[R] A)) :
+    (mapDomainMulEquiv (A := A) e).symm f = mapDomain (e.symm : H₂ →ₐc[R] H₁) f := rfl
+
+end BialgebraEquiv
 
 section BialgebraMapValue
 

--- a/TauCeti/Algebra/AlgebraicGroup/HopfMap.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/HopfMap.lean
@@ -30,7 +30,7 @@ the reductive-groups roadmap Layer 0 target "R-points as a group" and its follow
   post-composition in the value algebra.
 * `AlgHom.mapDomain_inv_apply`: pointwise inverse formula after pre-composition.
 
-The convolution-preservation proof reuses Mathlib's
+The convolution-preservation proof is the bialgebra-morphism version of Mathlib's
 `AlgHom.convMul_comp_bialgHom_distrib`, from `Mathlib.RingTheory.Bialgebra.Convolution`.
 -/
 
@@ -143,10 +143,13 @@ noncomputable def mapDomainMulEquiv (e : H₁ ≃ₐc[R] H₂) :
       rw [← mapDomain_comp, e.symm_comp, mapDomain_id]
     exact DFunLike.congr_fun h f
 
+/-- `mapDomainMulEquiv` acts by the underlying `mapDomain` in the forward direction. -/
 @[simp]
 lemma mapDomainMulEquiv_apply (e : H₁ ≃ₐc[R] H₂) (f : WithConv (H₂ →ₐ[R] A)) :
     mapDomainMulEquiv e f = mapDomain (e : H₁ →ₐc[R] H₂) f := rfl
 
+/-- `mapDomainMulEquiv` acts by pre-composition with the inverse bialgebra equivalence in the
+reverse direction. -/
 @[simp]
 lemma mapDomainMulEquiv_symm_apply (e : H₁ ≃ₐc[R] H₂) (f : WithConv (H₁ →ₐ[R] A)) :
     (mapDomainMulEquiv (A := A) e).symm f = mapDomain (e.symm : H₂ →ₐc[R] H₁) f := rfl

--- a/TauCeti/Algebra/AlgebraicGroup/HopfMap.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/HopfMap.lean
@@ -44,9 +44,15 @@ variable {R H₁ H₂ H₃ A B : Type*} [CommSemiring R]
 
 section Bialgebra
 
-variable [CommSemiring H₁] [Semiring H₂]
+variable [Semiring H₁] [Semiring H₂]
 variable [_root_.Bialgebra R H₁] [_root_.Bialgebra R H₂]
 variable [CommSemiring A] [Algebra R A]
+
+private lemma convMul_comp_bialgHom_distrib_of_semiring_source
+    (f g : WithConv (H₂ →ₐ[R] A)) (φ : H₁ →ₐc[R] H₂) :
+    AlgHom.comp (f * g).ofConv (φ : H₁ →ₐ[R] H₂) =
+      ofConv (toConv (f.ofConv.comp φ) * toConv (g.ofConv.comp φ)) := by
+  simp [AlgHom.convMul_def, AlgHom.comp_assoc, Algebra.TensorProduct.map_comp]
 
 /-- Contravariant functoriality of convolution algebra homomorphisms in the source
 bialgebra. A bialgebra morphism `φ : H₁ →ₐc[R] H₂` sends an `A`-valued point of `H₂` to an
@@ -59,7 +65,8 @@ noncomputable def mapDomain (φ : H₁ →ₐc[R] H₂) :
     simp
   map_mul' f g := by
     ext x
-    have h := congrFun (congrArg DFunLike.coe (AlgHom.convMul_comp_bialgHom_distrib f g φ)) x
+    have h :=
+      congrFun (congrArg DFunLike.coe (convMul_comp_bialgHom_distrib_of_semiring_source f g φ)) x
     simpa using h
 
 /-- `mapDomain φ` acts pointwise by pre-composition with `φ`. -/
@@ -75,7 +82,7 @@ end Bialgebra
 
 section BialgebraId
 
-variable [CommSemiring H₁] [_root_.Bialgebra R H₁]
+variable [Semiring H₁] [_root_.Bialgebra R H₁]
 variable [CommSemiring A] [Algebra R A]
 
 /-- Pre-composition by the identity bialgebra morphism is the identity map on the
@@ -92,7 +99,7 @@ end BialgebraId
 
 section BialgebraComp
 
-variable [CommSemiring H₁] [CommSemiring H₂] [Semiring H₃]
+variable [Semiring H₁] [Semiring H₂] [Semiring H₃]
 variable [_root_.Bialgebra R H₁] [_root_.Bialgebra R H₂] [_root_.Bialgebra R H₃]
 variable [CommSemiring A] [Algebra R A]
 
@@ -113,7 +120,7 @@ end BialgebraComp
 
 section BialgebraEquiv
 
-variable [CommSemiring H₁] [CommSemiring H₂]
+variable [Semiring H₁] [Semiring H₂]
 variable [_root_.Bialgebra R H₁] [_root_.Bialgebra R H₂]
 variable [CommSemiring A] [Algebra R A]
 
@@ -148,7 +155,7 @@ end BialgebraEquiv
 
 section BialgebraMapValue
 
-variable [CommSemiring H₁] [Semiring H₂] [_root_.Bialgebra R H₁] [_root_.Bialgebra R H₂]
+variable [Semiring H₁] [Semiring H₂] [_root_.Bialgebra R H₁] [_root_.Bialgebra R H₂]
 variable [CommSemiring A] [Algebra R A]
 variable [CommSemiring B] [Algebra R B]
 
@@ -169,7 +176,7 @@ end BialgebraMapValue
 
 section Hopf
 
-variable [CommSemiring H₁] [Semiring H₂]
+variable [Semiring H₁] [Semiring H₂]
 variable [_root_.Bialgebra R H₁] [_root_.HopfAlgebra R H₂]
 variable [CommSemiring A] [Algebra R A]
 

--- a/TauCeti/Algebra/AlgebraicGroup/HopfMap.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/HopfMap.lean
@@ -3,6 +3,7 @@ Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 -/
 import Mathlib.RingTheory.Bialgebra.Equiv
+import Mathlib.RingTheory.TensorProduct.Maps
 import TauCeti.Algebra.AlgebraicGroup.FunctorOfPoints
 
 /-!

--- a/TauCeti/Algebra/Bialgebra/MonoidAlgebraProduct.lean
+++ b/TauCeti/Algebra/Bialgebra/MonoidAlgebraProduct.lean
@@ -149,11 +149,15 @@ noncomputable def prodTensorBialgEquiv :
       rintro ⟨g, h⟩
       simp)
 
+/-- The forward product bialgebra equivalence sends the generator indexed by `(g, h)` to the
+pure tensor of the two factor generators. -/
 @[simp]
 theorem prodTensorBialgEquiv_single (g : G) (h : H) :
     prodTensorBialgEquiv R (single (g, h) (1 : R)) = single g 1 ⊗ₜ[R] single h 1 :=
   prodTensorAlgEquiv_single R g h
 
+/-- The inverse product bialgebra equivalence sends a pure tensor of factor generators to the
+generator indexed by their product pair. -/
 @[simp]
 theorem prodTensorBialgEquiv_symm_tmul_single (g : G) (h : H) :
     (prodTensorBialgEquiv R).symm (single g (1 : R) ⊗ₜ[R] single h 1) = single (g, h) 1 := by

--- a/TauCeti/Algebra/Bialgebra/MonoidAlgebraProduct.lean
+++ b/TauCeti/Algebra/Bialgebra/MonoidAlgebraProduct.lean
@@ -5,6 +5,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 import Mathlib.RingTheory.Bialgebra.MonoidAlgebra
 import Mathlib.RingTheory.Bialgebra.Equiv
 import Mathlib.RingTheory.Bialgebra.TensorProduct
+import Mathlib.RingTheory.TensorProduct.Maps
 
 /-!
 # The monoid algebra of a product is the tensor product of monoid algebras

--- a/TauCeti/Algebra/Bialgebra/MonoidAlgebraProduct.lean
+++ b/TauCeti/Algebra/Bialgebra/MonoidAlgebraProduct.lean
@@ -1,0 +1,169 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+import Mathlib.RingTheory.Bialgebra.MonoidAlgebra
+import Mathlib.RingTheory.Bialgebra.Equiv
+import Mathlib.RingTheory.Bialgebra.TensorProduct
+
+/-!
+# The monoid algebra of a product is the tensor product of monoid algebras
+
+For two monoids `G` and `H`, the canonical map `single (g, h) 1 ↦ single g 1 ⊗ₜ
+single h 1` is an isomorphism of `R`-bialgebras `R[G × H] ≃ₐc[R] R[G] ⊗[R] R[H]`.
+
+The bialgebra isomorphism is built from two mutually inverse algebra maps: the lift of the
+group-like monoid hom `(g, h) ↦ single g 1 ⊗ₜ single h 1` one way, and the tensor-product
+universal map of the two inclusions `R[G] → R[G × H]`, `R[H] → R[G × H]` (themselves
+`MonoidAlgebra.mapDomainAlgHom` of `MonoidHom.inl`/`MonoidHom.inr`) the other way. It is then
+promoted to a bialgebra equivalence by checking compatibility with the counit and
+comultiplication on the group-like generators `single (g, h) 1`.
+
+This is generic monoid-algebra API used by the diagonalizable-group product calculation.
+
+## Main definitions
+
+* `TauCeti.MonoidAlgebra.prodTensorAlgEquiv`: the algebra isomorphism
+  `R[G × H] ≃ₐ[R] R[G] ⊗[R] R[H]`.
+* `TauCeti.MonoidAlgebra.prodTensorBialgEquiv`: the same map as a bialgebra isomorphism.
+
+## References
+
+The tensor-product bialgebra structure and `Algebra.TensorProduct.lift` are from Mathlib's
+`Mathlib.RingTheory.Bialgebra.TensorProduct` and `Mathlib.RingTheory.TensorProduct.Maps`; the
+monoid-algebra bialgebra structure and `MonoidAlgebra.mapDomainAlgHom` are from
+`Mathlib.RingTheory.Bialgebra.MonoidAlgebra` and `Mathlib.Algebra.MonoidAlgebra.Basic`.
+-/
+
+open TensorProduct MonoidAlgebra
+
+namespace TauCeti
+
+universe u v w
+
+namespace MonoidAlgebra
+
+variable (R : Type u) [CommSemiring R]
+variable {G : Type v} {H : Type w} [Monoid G] [Monoid H]
+
+/-- The group-like monoid homomorphism `(g, h) ↦ single g 1 ⊗ₜ single h 1` from `G × H` into the
+multiplicative monoid of `R[G] ⊗[R] R[H]`. -/
+private noncomputable def prodGroupLike :
+    G × H →* MonoidAlgebra R G ⊗[R] MonoidAlgebra R H where
+  toFun p := single p.1 (1 : R) ⊗ₜ[R] single p.2 1
+  map_one' := by
+    simp only [Prod.fst_one, Prod.snd_one, ← MonoidAlgebra.one_def,
+      Algebra.TensorProduct.one_def]
+  map_mul' x y := by
+    simp only [Prod.fst_mul, Prod.snd_mul, Algebra.TensorProduct.tmul_mul_tmul,
+      single_mul_single, mul_one]
+
+@[simp]
+private theorem prodGroupLike_apply (g : G) (h : H) :
+    prodGroupLike R (g, h) = single g (1 : R) ⊗ₜ[R] single h 1 := rfl
+
+/-- The forward algebra map `R[G × H] →ₐ[R] R[G] ⊗[R] R[H]`, sending `single (g, h) 1` to
+`single g 1 ⊗ₜ single h 1`. -/
+private noncomputable def prodTensorAlgHom :
+    MonoidAlgebra R (G × H) →ₐ[R] MonoidAlgebra R G ⊗[R] MonoidAlgebra R H :=
+  lift R (MonoidAlgebra R G ⊗[R] MonoidAlgebra R H) (G × H) (prodGroupLike R)
+
+@[simp]
+private theorem prodTensorAlgHom_single (g : G) (h : H) :
+    prodTensorAlgHom R (single (g, h) (1 : R)) = single g 1 ⊗ₜ[R] single h 1 := by
+  simp only [prodTensorAlgHom, lift_single, one_smul, prodGroupLike_apply]
+
+/-- The images of the two inclusions `R[G] → R[G × H]` and `R[H] → R[G × H]` commute. -/
+private theorem commute_mapDomainAlgHom_inl_inr (x : MonoidAlgebra R G) (y : MonoidAlgebra R H) :
+    Commute (mapDomainAlgHom R R (MonoidHom.inl G H) x)
+      (mapDomainAlgHom R R (MonoidHom.inr G H) y) := by
+  induction x using MonoidAlgebra.induction_on with
+  | hM g =>
+    induction y using MonoidAlgebra.induction_on with
+    | hM h =>
+      simp only [of_apply, mapDomainAlgHom_apply, mapDomain_single, MonoidHom.inl_apply,
+        MonoidHom.inr_apply, commute_iff_eq, single_mul_single, Prod.mk_mul_mk, mul_one, one_mul]
+    | hadd y₁ y₂ hy₁ hy₂ => rw [map_add]; exact hy₁.add_right hy₂
+    | hsmul r y hy => rw [map_smul]; exact hy.smul_right r
+  | hadd x₁ x₂ hx₁ hx₂ => rw [map_add]; exact hx₁.add_left hx₂
+  | hsmul r x hx => rw [map_smul]; exact hx.smul_left r
+
+/-- The inverse algebra map `R[G] ⊗[R] R[H] →ₐ[R] R[G × H]`, the tensor-product universal map of
+the two inclusions `R[G] → R[G × H]` and `R[H] → R[G × H]`. -/
+private noncomputable def tensorProdAlgHom :
+    MonoidAlgebra R G ⊗[R] MonoidAlgebra R H →ₐ[R] MonoidAlgebra R (G × H) :=
+  Algebra.TensorProduct.lift
+    (mapDomainAlgHom R R (MonoidHom.inl G H) :
+      MonoidAlgebra R G →ₐ[R] MonoidAlgebra R (G × H))
+    (mapDomainAlgHom R R (MonoidHom.inr G H) :
+      MonoidAlgebra R H →ₐ[R] MonoidAlgebra R (G × H))
+    (commute_mapDomainAlgHom_inl_inr R)
+
+@[simp]
+private theorem tensorProdAlgHom_tmul_single (g : G) (h : H) :
+    tensorProdAlgHom R (single g (1 : R) ⊗ₜ[R] single h 1) = single (g, h) 1 := by
+  simp only [tensorProdAlgHom, Algebra.TensorProduct.lift_tmul, mapDomainAlgHom_apply,
+    mapDomain_single, single_mul_single, MonoidHom.inl_apply, MonoidHom.inr_apply,
+    Prod.mk_mul_mk, mul_one, one_mul]
+
+/-- **The monoid algebra of a product is the tensor product of monoid algebras**, as an algebra
+isomorphism. It sends `single (g, h) 1` to `single g 1 ⊗ₜ single h 1`. -/
+noncomputable def prodTensorAlgEquiv :
+    MonoidAlgebra R (G × H) ≃ₐ[R] MonoidAlgebra R G ⊗[R] MonoidAlgebra R H :=
+  AlgEquiv.ofAlgHom (prodTensorAlgHom R) (tensorProdAlgHom R)
+    (by
+      apply Algebra.TensorProduct.ext
+      · apply MonoidAlgebra.algHom_ext
+        intro g
+        simp only [AlgHom.comp_apply, AlgHom.id_apply, Algebra.TensorProduct.includeLeft_apply]
+        rw [show (1 : MonoidAlgebra R H) = single 1 1 from one_def,
+          tensorProdAlgHom_tmul_single, prodTensorAlgHom_single]
+      · apply MonoidAlgebra.algHom_ext
+        intro h
+        simp only [AlgHom.coe_restrictScalars', AlgHom.comp_apply, AlgHom.id_apply,
+          Algebra.TensorProduct.includeRight_apply]
+        rw [show (1 : MonoidAlgebra R G) = single 1 1 from one_def,
+          tensorProdAlgHom_tmul_single, prodTensorAlgHom_single])
+    (by
+      apply MonoidAlgebra.algHom_ext
+      rintro ⟨g, h⟩
+      rw [AlgHom.comp_apply, prodTensorAlgHom_single, tensorProdAlgHom_tmul_single,
+        AlgHom.id_apply])
+
+@[simp]
+theorem prodTensorAlgEquiv_single (g : G) (h : H) :
+    prodTensorAlgEquiv R (single (g, h) (1 : R)) = single g 1 ⊗ₜ[R] single h 1 :=
+  prodTensorAlgHom_single R g h
+
+@[simp]
+theorem prodTensorAlgEquiv_symm_tmul_single (g : G) (h : H) :
+    (prodTensorAlgEquiv R).symm (single g (1 : R) ⊗ₜ[R] single h 1) = single (g, h) 1 := by
+  rw [← prodTensorAlgEquiv_single R g h, AlgEquiv.symm_apply_apply]
+
+/-- **The monoid algebra of a product is the tensor product of monoid algebras**, as a bialgebra
+isomorphism. -/
+noncomputable def prodTensorBialgEquiv :
+    MonoidAlgebra R (G × H) ≃ₐc[R] MonoidAlgebra R G ⊗[R] MonoidAlgebra R H :=
+  BialgEquiv.ofAlgEquiv (prodTensorAlgEquiv R)
+    (by
+      apply MonoidAlgebra.algHom_ext
+      rintro ⟨g, h⟩
+      simp)
+    (by
+      apply MonoidAlgebra.algHom_ext
+      rintro ⟨g, h⟩
+      simp)
+
+@[simp]
+theorem prodTensorBialgEquiv_single (g : G) (h : H) :
+    prodTensorBialgEquiv R (single (g, h) (1 : R)) = single g 1 ⊗ₜ[R] single h 1 :=
+  prodTensorAlgEquiv_single R g h
+
+@[simp]
+theorem prodTensorBialgEquiv_symm_tmul_single (g : G) (h : H) :
+    (prodTensorBialgEquiv R).symm (single g (1 : R) ⊗ₜ[R] single h 1) = single (g, h) 1 := by
+  rw [← prodTensorBialgEquiv_single R g h, BialgEquiv.symm_apply_apply]
+
+end MonoidAlgebra
+
+end TauCeti

--- a/TauCeti/Algebra/Bialgebra/MonoidAlgebraProduct.lean
+++ b/TauCeti/Algebra/Bialgebra/MonoidAlgebraProduct.lean
@@ -12,20 +12,18 @@ import Mathlib.RingTheory.Bialgebra.TensorProduct
 For two monoids `G` and `H`, the canonical map `single (g, h) 1 ↦ single g 1 ⊗ₜ
 single h 1` is an isomorphism of `R`-bialgebras `R[G × H] ≃ₐc[R] R[G] ⊗[R] R[H]`.
 
-The bialgebra isomorphism is built from two mutually inverse algebra maps: the lift of the
-group-like monoid hom `(g, h) ↦ single g 1 ⊗ₜ single h 1` one way, and the tensor-product
-universal map of the two inclusions `R[G] → R[G × H]`, `R[H] → R[G × H]` (themselves
-`MonoidAlgebra.mapDomainAlgHom` of `MonoidHom.inl`/`MonoidHom.inr`) the other way. It is then
-promoted to a bialgebra equivalence by checking compatibility with the counit and
-comultiplication on the group-like generators `single (g, h) 1`.
+The bialgebra isomorphism is promoted from the standard algebra maps: the lift of the group-like
+monoid hom `(g, h) ↦ single g 1 ⊗ₜ single h 1` one way, and the tensor-product universal map of
+the two inclusions `R[G] → R[G × H]`, `R[H] → R[G × H]` (themselves
+`MonoidAlgebra.mapDomainAlgHom` of `MonoidHom.inl`/`MonoidHom.inr`) the other way. The public
+API keeps only the bialgebra equivalence and its generator formulas.
 
 This is generic monoid-algebra API used by the diagonalizable-group product calculation.
 
 ## Main definitions
 
-* `TauCeti.MonoidAlgebra.prodTensorAlgEquiv`: the algebra isomorphism
-  `R[G × H] ≃ₐ[R] R[G] ⊗[R] R[H]`.
-* `TauCeti.MonoidAlgebra.prodTensorBialgEquiv`: the same map as a bialgebra isomorphism.
+* `TauCeti.MonoidAlgebra.prodTensorBialgEquiv`: the bialgebra isomorphism
+  `R[G × H] ≃ₐc[R] R[G] ⊗[R] R[H]`.
 
 ## References
 
@@ -106,9 +104,7 @@ private theorem tensorProdAlgHom_tmul_single (g : G) (h : H) :
     mapDomain_single, single_mul_single, MonoidHom.inl_apply, MonoidHom.inr_apply,
     Prod.mk_mul_mk, mul_one, one_mul]
 
-/-- **The monoid algebra of a product is the tensor product of monoid algebras**, as an algebra
-isomorphism. It sends `single (g, h) 1` to `single g 1 ⊗ₜ single h 1`. -/
-noncomputable def prodTensorAlgEquiv :
+private noncomputable def prodTensorAlgEquiv :
     MonoidAlgebra R (G × H) ≃ₐ[R] MonoidAlgebra R G ⊗[R] MonoidAlgebra R H :=
   AlgEquiv.ofAlgHom (prodTensorAlgHom R) (tensorProdAlgHom R)
     (by
@@ -116,14 +112,12 @@ noncomputable def prodTensorAlgEquiv :
       · apply MonoidAlgebra.algHom_ext
         intro g
         simp only [AlgHom.comp_apply, AlgHom.id_apply, Algebra.TensorProduct.includeLeft_apply]
-        rw [show (1 : MonoidAlgebra R H) = single 1 1 from one_def,
-          tensorProdAlgHom_tmul_single, prodTensorAlgHom_single]
+        rw [one_def, tensorProdAlgHom_tmul_single, prodTensorAlgHom_single]
       · apply MonoidAlgebra.algHom_ext
         intro h
         simp only [AlgHom.coe_restrictScalars', AlgHom.comp_apply, AlgHom.id_apply,
           Algebra.TensorProduct.includeRight_apply]
-        rw [show (1 : MonoidAlgebra R G) = single 1 1 from one_def,
-          tensorProdAlgHom_tmul_single, prodTensorAlgHom_single])
+        rw [one_def, tensorProdAlgHom_tmul_single, prodTensorAlgHom_single])
     (by
       apply MonoidAlgebra.algHom_ext
       rintro ⟨g, h⟩
@@ -131,12 +125,12 @@ noncomputable def prodTensorAlgEquiv :
         AlgHom.id_apply])
 
 @[simp]
-theorem prodTensorAlgEquiv_single (g : G) (h : H) :
+private theorem prodTensorAlgEquiv_single (g : G) (h : H) :
     prodTensorAlgEquiv R (single (g, h) (1 : R)) = single g 1 ⊗ₜ[R] single h 1 :=
   prodTensorAlgHom_single R g h
 
 @[simp]
-theorem prodTensorAlgEquiv_symm_tmul_single (g : G) (h : H) :
+private theorem prodTensorAlgEquiv_symm_tmul_single (g : G) (h : H) :
     (prodTensorAlgEquiv R).symm (single g (1 : R) ⊗ₜ[R] single h 1) = single (g, h) 1 := by
   rw [← prodTensorAlgEquiv_single R g h, AlgEquiv.symm_apply_apply]
 


### PR DESCRIPTION
This PR constructs the isomorphism of `R`-bialgebras `R[G × H] ≃ₐc[R] R[G] ⊗[R] R[H]` for commutative monoids `G` and `H`, sending the group-like generator `single (g, h) 1` to `single g 1 ⊗ₜ single h 1`, and deduces that the diagonalizable group of a product is the direct product of the diagonalizable groups of the factors on points: `D(G × H)(A) ≃* D(G)(A) × D(H)(A)` for every commutative `R`-algebra `A`. When `G` and `H` are commutative groups the group algebras are Hopf algebras and these convolution monoids are the convolution groups of points, so the points equivalence is automatically an isomorphism of groups. Concretely this realizes a split torus `𝔾ₘⁿ` as the `n`-fold product of `𝔾ₘ`, identifying its coordinate Hopf algebra `R[ℤⁿ]` with `R[ℤ]^{⊗ n}` and its points with `(Aˣ)ⁿ`.

The bialgebra isomorphism is assembled from two mutually inverse algebra maps — the `MonoidAlgebra.lift` of the group-like monoid hom `(g, h) ↦ single g 1 ⊗ₜ single h 1`, and the `Algebra.TensorProduct.lift` of the two inclusions `R[G] → R[G × H]`, `R[H] → R[G × H]` given by `MonoidAlgebra.mapDomainAlgHom` of `MonoidHom.inl`/`MonoidHom.inr` — promoted to a bialgebra equivalence by checking counit and comultiplication compatibility on the group-like generators. On points it composes the existing tensor-product points calculation `TauCeti.AffineGroup.Product.pointsMulEquiv` with `AlgHom.mapDomainMulEquiv`, the equivalence-version of the contravariant functoriality `AlgHom.mapDomain` added here.

This advances the reductive-groups roadmap (`TauCetiRoadmap/ReductiveGroups/README.md`, Layer 4 "Diagonalizable groups and groups of multiplicative type" and the "Worked examples / products" theme, together with the Layer 0 functor-of-points dictionary), supplying the products half of the diagonalizable-group worked examples that `TauCeti.DiagonalizableGroup` and `TauCeti.SplitTorus` already exercise.

The tensor-product bialgebra structure, `Algebra.TensorProduct.lift`, the group-algebra bialgebra structure and `MonoidAlgebra.mapDomainAlgHom` are all from Mathlib; the tensor-product points calculation `TauCeti.AffineGroup.Product.pointsMulEquiv` and the contravariant functoriality `TauCeti.AlgHom.mapDomain` are Tau Ceti's existing functor-of-points infrastructure, built on the Mathlib convolution monoid of Yaël Dillies, Michał Mrugała and Yunzhou Xie.

<!--tauceti-target:v1 {"focus":"ReductiveGroups","id":"group-algebra-prod-tensor"}-->

🤖 Prepared with Claude Code
