### PR TITLE
feat: the fundamental group of the base of a regular cover is the opposite deck group

### DIFF
--- a/TauCeti/AlgebraicTopology/UniversalCover/Deck/FundamentalGroup.lean
+++ b/TauCeti/AlgebraicTopology/UniversalCover/Deck/FundamentalGroup.lean
@@ -41,8 +41,10 @@ identifies `π₁(X, x)` with that fibre via monodromy.
   `FundamentalGroup X x ≃* (Deck p)ᵐᵒᵖ`.
 * `TauCeti.Deck.IsRegular.fundamentalGroupEquiv_unop_smul`: the deck element
   attached to `γ` moves the chosen lift `e` to `monodromy γ e`.
-* `TauCeti.Deck.IsRegular.fundamentalGroupEquiv_eq_iff`: characterizes equality
+* `TauCeti.Deck.IsRegular.fundamentalGroupEquiv_apply_eq_iff`: characterizes equality
   with an arbitrary deck transformation by its value at the chosen lift.
+* `TauCeti.Deck.IsRegular.fundamentalGroupEquiv_symm_monodromy`: characterizes the
+  inverse equivalence by the monodromy translate of the chosen lift.
 * `TauCeti.Deck.IsRegular.fundamentalGroupEquiv_eq_one_iff`: `γ` maps to the
   identity exactly when its monodromy fixes `e`.
 
@@ -78,12 +80,29 @@ lemma IsRegular.fundamentalGroupEquiv_unop_smul [SimplyConnectedSpace E]
 
 /-- The fundamental group element `γ` corresponds to a deck transformation `g` exactly when
 `g.unop` moves the chosen lift `e` to the monodromy translate of `e` along `γ`. -/
-lemma IsRegular.fundamentalGroupEquiv_eq_iff [SimplyConnectedSpace E]
+lemma IsRegular.fundamentalGroupEquiv_apply_eq_iff [SimplyConnectedSpace E]
     (hreg : IsRegular p) (hp : IsCoveringMap p) (e : p ⁻¹' {x})
     (γ : FundamentalGroup X x) (g : (Deck p)ᵐᵒᵖ) :
     hreg.fundamentalGroupEquiv hp e γ = g ↔
       g.unop • (e : E) = hp.monodromy γ e :=
   (hreg.isQuotientCoveringMap hp).fundamentalGroupToMulOpposite_apply_eq_Iff
+
+/-- The fundamental group element corresponding to an opposite deck transformation is the
+unique loop class whose monodromy moves the chosen lift `e` by that deck transformation. -/
+lemma IsRegular.fundamentalGroupEquiv_symm_monodromy [SimplyConnectedSpace E]
+    (hreg : IsRegular p) (hp : IsCoveringMap p) (e : p ⁻¹' {x}) (g : (Deck p)ᵐᵒᵖ) :
+    (hp.monodromy ((hreg.fundamentalGroupEquiv hp e).symm g) e : E) = g.unop • (e : E) := by
+  simpa using
+    (IsRegular.fundamentalGroupEquiv_unop_smul hreg hp e
+      ((hreg.fundamentalGroupEquiv hp e).symm g)).symm
+
+/-- A `Deck p` spelling of `fundamentalGroupEquiv_symm_monodromy`. The loop class
+corresponding to `MulOpposite.op φ` has monodromy action equal to `φ` at the chosen lift. -/
+lemma IsRegular.fundamentalGroupEquiv_symm_op_monodromy [SimplyConnectedSpace E]
+    (hreg : IsRegular p) (hp : IsCoveringMap p) (e : p ⁻¹' {x}) (φ : Deck p) :
+    (hp.monodromy ((hreg.fundamentalGroupEquiv hp e).symm (MulOpposite.op φ)) e : E) =
+      φ • (e : E) := by
+  simpa using IsRegular.fundamentalGroupEquiv_symm_monodromy hreg hp e (MulOpposite.op φ)
 
 /-- A loop class `γ` maps to the identity deck transformation exactly when its monodromy
 fixes the chosen basepoint lift `e`. -/

--- a/TauCeti/AlgebraicTopology/UniversalCover/Deck/FundamentalGroup.lean
+++ b/TauCeti/AlgebraicTopology/UniversalCover/Deck/FundamentalGroup.lean
@@ -14,11 +14,12 @@ fundamental group of the base is anti-isomorphic to the deck transformation grou
 
   `FundamentalGroup X x ≃* (Deck p)ᵐᵒᵖ`.
 
-This is the Stage 1 target of the universal-covers roadmap
+This is the regular-cover comparison needed for the Stage 1 universal-covers roadmap target
 (`Deck (UniversalCover.proj x₀) ≃* FundamentalGroup X x₀`, "possibly up to `ᵐᵒᵖ`; pin the
-action/composition convention first"). It is stated here for an arbitrary regular cover with
-simply connected total space, of which the universal cover is the special case
-`E = UniversalCover x₀` (where simple connectivity and regularity of the deck action hold).
+action/composition convention first"). The theorem here is stated for an arbitrary regular
+cover with simply connected total space, not as the specialized `UniversalCover.proj`
+statement itself. That specialization is a later instantiation with `E = UniversalCover x₀`
+once the corresponding regularity and simple-connectivity hypotheses are in scope.
 
 The `ᵐᵒᵖ` is genuine and pins the convention noted in the roadmap. The deck group acts on
 the total space on the *left* (`Deck.smul_eq_apply : φ • e = φ.1 e`), while the monodromy of
@@ -36,21 +37,20 @@ identifies `π₁(X, x)` with that fibre via monodromy.
 
 ## Main declarations
 
-* `TauCeti.Deck.IsRegular.fundamentalGroupMulEquivDeckOp`: the anti-isomorphism
+* `TauCeti.Deck.IsRegular.fundamentalGroupEquiv`: the anti-isomorphism
   `FundamentalGroup X x ≃* (Deck p)ᵐᵒᵖ`.
-* `TauCeti.Deck.IsRegular.fundamentalGroupMulEquivDeckOp_unop_smul`: the deck element
+* `TauCeti.Deck.IsRegular.fundamentalGroupEquiv_unop_smul`: the deck element
   attached to `γ` moves the chosen lift `e` to `monodromy γ e`.
-* `TauCeti.Deck.IsRegular.fundamentalGroupMulEquivDeckOp_eq_iff`: characterizes equality
+* `TauCeti.Deck.IsRegular.fundamentalGroupEquiv_eq_iff`: characterizes equality
   with an arbitrary deck transformation by its value at the chosen lift.
-* `TauCeti.Deck.IsRegular.fundamentalGroupMulEquivDeckOp_eq_one_iff`: `γ` maps to the
+* `TauCeti.Deck.IsRegular.fundamentalGroupEquiv_eq_one_iff`: `γ` maps to the
   identity exactly when its monodromy fixes `e`.
 
 ## References
 
 The comparison map is Mathlib's `IsQuotientCoveringMap.fundamentalGroupEquiv` (Junyan Xu,
 `Mathlib/Topology/Homotopy/Lifting.lean`); the quotient-covering presentation of a regular
-deck action is `TauCeti.Deck.IsRegular.isQuotientCoveringMap`. This discharges the Stage 1
-target of the Tau Ceti universal-covers roadmap.
+deck action is `TauCeti.Deck.IsRegular.isQuotientCoveringMap`.
 -/
 
 namespace TauCeti
@@ -63,7 +63,7 @@ variable {E X : Type*} [TopologicalSpace E] [TopologicalSpace X] {p : E → X} {
 group of the base is anti-isomorphic to the deck transformation group:
 `FundamentalGroup X x ≃* (Deck p)ᵐᵒᵖ`. The `ᵐᵒᵖ` reflects that the deck group acts on the
 left while the monodromy of `π₁` acts on the right; see the module docstring. -/
-noncomputable def IsRegular.fundamentalGroupMulEquivDeckOp [SimplyConnectedSpace E]
+noncomputable def IsRegular.fundamentalGroupEquiv [SimplyConnectedSpace E]
     (hreg : IsRegular p) (hp : IsCoveringMap p) (e : p ⁻¹' {x}) :
     FundamentalGroup X x ≃* (Deck p)ᵐᵒᵖ :=
   (hreg.isQuotientCoveringMap hp).fundamentalGroupEquiv e
@@ -71,26 +71,26 @@ noncomputable def IsRegular.fundamentalGroupMulEquivDeckOp [SimplyConnectedSpace
 /-- The deck transformation attached to a loop class `γ` moves the chosen basepoint lift `e`
 along the monodromy of `γ`. -/
 @[simp]
-lemma IsRegular.fundamentalGroupMulEquivDeckOp_unop_smul [SimplyConnectedSpace E]
+lemma IsRegular.fundamentalGroupEquiv_unop_smul [SimplyConnectedSpace E]
     (hreg : IsRegular p) (hp : IsCoveringMap p) (e : p ⁻¹' {x}) (γ : FundamentalGroup X x) :
-    (hreg.fundamentalGroupMulEquivDeckOp hp e γ).unop • (e : E) = (hp.monodromy γ e : E) :=
+    (hreg.fundamentalGroupEquiv hp e γ).unop • (e : E) = (hp.monodromy γ e : E) :=
   (hreg.isQuotientCoveringMap hp).unop_fundamentalGroupToMulOpposite_smul
 
 /-- The fundamental group element `γ` corresponds to a deck transformation `g` exactly when
 `g.unop` moves the chosen lift `e` to the monodromy translate of `e` along `γ`. -/
-lemma IsRegular.fundamentalGroupMulEquivDeckOp_eq_iff [SimplyConnectedSpace E]
+lemma IsRegular.fundamentalGroupEquiv_eq_iff [SimplyConnectedSpace E]
     (hreg : IsRegular p) (hp : IsCoveringMap p) (e : p ⁻¹' {x})
     (γ : FundamentalGroup X x) (g : (Deck p)ᵐᵒᵖ) :
-    hreg.fundamentalGroupMulEquivDeckOp hp e γ = g ↔
+    hreg.fundamentalGroupEquiv hp e γ = g ↔
       g.unop • (e : E) = hp.monodromy γ e :=
   (hreg.isQuotientCoveringMap hp).fundamentalGroupToMulOpposite_apply_eq_Iff
 
 /-- A loop class `γ` maps to the identity deck transformation exactly when its monodromy
 fixes the chosen basepoint lift `e`. -/
 @[simp]
-lemma IsRegular.fundamentalGroupMulEquivDeckOp_eq_one_iff [SimplyConnectedSpace E]
+lemma IsRegular.fundamentalGroupEquiv_eq_one_iff [SimplyConnectedSpace E]
     (hreg : IsRegular p) (hp : IsCoveringMap p) (e : p ⁻¹' {x}) (γ : FundamentalGroup X x) :
-    hreg.fundamentalGroupMulEquivDeckOp hp e γ = 1 ↔ hp.monodromy γ e = e :=
+    hreg.fundamentalGroupEquiv hp e γ = 1 ↔ hp.monodromy γ e = e :=
   (hreg.isQuotientCoveringMap hp).fundamentalGroupToMulOpposite_eq_one_iff
 
 end Deck

--- a/TauCeti/AlgebraicTopology/UniversalCover/Deck/FundamentalGroup.lean
+++ b/TauCeti/AlgebraicTopology/UniversalCover/Deck/FundamentalGroup.lean
@@ -40,10 +40,14 @@ identifies `π₁(X, x)` with that fibre via monodromy.
   `FundamentalGroup X x ≃* (Deck p)ᵐᵒᵖ`.
 * `TauCeti.Deck.IsRegular.fundamentalGroupMulEquivDeckOp_unop_smul`: the deck element
   attached to `γ` moves the chosen lift `e` to `monodromy γ e`.
+* `TauCeti.Deck.IsRegular.fundamentalGroupMulEquivDeckOp_eq_iff`: characterizes equality
+  with an arbitrary deck transformation by its value at the chosen lift.
 * `TauCeti.Deck.IsRegular.fundamentalGroupMulEquivDeckOp_eq_one_iff`: `γ` maps to the
   identity exactly when its monodromy fixes `e`.
-* `TauCeti.Deck.IsRegular.fundamentalGroupEquivFiber`: the induced bijection
+* `TauCeti.IsCoveringMap.fundamentalGroupEquivFiber`: the monodromy bijection
   `FundamentalGroup X x ≃ p ⁻¹' {x}`, `γ ↦ monodromy γ e`.
+* `TauCeti.Deck.IsRegular.fundamentalGroupEquivFiber`: the same bijection, exposed from a
+  regular cover.
 
 ## References
 
@@ -76,38 +80,103 @@ lemma IsRegular.fundamentalGroupMulEquivDeckOp_unop_smul [SimplyConnectedSpace E
     (hreg.fundamentalGroupMulEquivDeckOp hp e γ).unop • (e : E) = (hp.monodromy γ e : E) :=
   (hreg.isQuotientCoveringMap hp).unop_fundamentalGroupToMulOpposite_smul
 
+/-- The fundamental group element `γ` corresponds to a deck transformation `g` exactly when
+`g.unop` moves the chosen lift `e` to the monodromy translate of `e` along `γ`. -/
+lemma IsRegular.fundamentalGroupMulEquivDeckOp_eq_iff [SimplyConnectedSpace E]
+    (hreg : IsRegular p) (hp : IsCoveringMap p) (e : p ⁻¹' {x})
+    (γ : FundamentalGroup X x) (g : (Deck p)ᵐᵒᵖ) :
+    hreg.fundamentalGroupMulEquivDeckOp hp e γ = g ↔
+      g.unop • (e : E) = hp.monodromy γ e :=
+  (hreg.isQuotientCoveringMap hp).fundamentalGroupToMulOpposite_apply_eq_Iff
+
 /-- A loop class `γ` maps to the identity deck transformation exactly when its monodromy
 fixes the chosen basepoint lift `e`. -/
+@[simp]
 lemma IsRegular.fundamentalGroupMulEquivDeckOp_eq_one_iff [SimplyConnectedSpace E]
     (hreg : IsRegular p) (hp : IsCoveringMap p) (e : p ⁻¹' {x}) (γ : FundamentalGroup X x) :
     hreg.fundamentalGroupMulEquivDeckOp hp e γ = 1 ↔ hp.monodromy γ e = e :=
   (hreg.isQuotientCoveringMap hp).fundamentalGroupToMulOpposite_eq_one_iff
 
-/-- Choosing a basepoint lift `e` in the fibre over `x` identifies the fundamental group of
-the base with that fibre, via `γ ↦ monodromy γ e`. This is the orbit-stabiliser bijection of
-the (free, transitive) `π₁`-action on the fibre of a regular simply connected cover. -/
-noncomputable def IsRegular.fundamentalGroupEquivFiber [SimplyConnectedSpace E]
-    (hreg : IsRegular p) (hp : IsCoveringMap p) (e : p ⁻¹' {x}) :
-    FundamentalGroup X x ≃ p ⁻¹' {x} :=
-  (hreg.fundamentalGroupMulEquivDeckOp hp e).toEquiv.trans <|
-    MulOpposite.opEquiv.symm.trans ((hreg.isQuotientCoveringMap hp).fiberEquivGroup e).symm
+end Deck
 
+variable {E X : Type*} [TopologicalSpace E] [TopologicalSpace X] {p : E → X} {x : X}
+
+/-- Choosing a basepoint lift `e` in the fibre over `x` identifies the fundamental group of
+the base with that fibre, via `γ ↦ monodromy γ e`. -/
+noncomputable def IsCoveringMap.fundamentalGroupEquivFiber [SimplyConnectedSpace E]
+    (hp : IsCoveringMap p) (e : p ⁻¹' {x}) :
+    FundamentalGroup X x ≃ p ⁻¹' {x} :=
+  { toFun γ := hp.monodromy γ e
+    invFun e' :=
+      FundamentalGroup.fromPath <|
+        ((Path.Homotopic.Quotient.mk (PathConnectedSpace.somePath (e : E) (e' : E))).map
+          ⟨p, hp.continuous⟩).cast e.2.symm e'.2.symm
+    left_inv γ := by
+      set Γ : Path.Homotopic.Quotient (e : E) (hp.monodromy γ e : E) :=
+        hp.liftPathQuotient γ e
+      have hpath :
+          Path.Homotopic.Quotient.mk
+              (PathConnectedSpace.somePath (e : E) (hp.monodromy γ e : E)) = Γ :=
+        Subsingleton.elim _ _
+      -- Unfold the inverse map to expose the endpoint casts from `p e` back to `x`.
+      change (((Path.Homotopic.Quotient.mk
+        (PathConnectedSpace.somePath (e : E) (hp.monodromy γ e : E))).map
+          ⟨p, hp.continuous⟩).cast e.2.symm (hp.monodromy γ e).2.symm) = γ
+      rw [hpath, hp.map_liftPathQuotient]
+      simp [Path.Homotopic.Quotient.cast_cast]
+    right_inv e' := by
+      obtain ⟨e₀, he₀⟩ := e
+      obtain ⟨e₁, he₁⟩ := e'
+      change p e₀ = x at he₀
+      change p e₁ = x at he₁
+      set Γ : Path.Homotopic.Quotient e₀ e₁ :=
+        Path.Homotopic.Quotient.mk (PathConnectedSpace.somePath e₀ e₁)
+      -- Unfold the forward map to match the casted base path used in the inverse.
+      change hp.monodromy ((Γ.map ⟨p, hp.continuous⟩).cast he₀.symm he₁.symm)
+        ⟨e₀, he₀⟩ = ⟨e₁, he₁⟩
+      exact hp.monodromy_eq_of_map_eq Γ (by simp [Path.Homotopic.Quotient.cast_cast]) }
+
+/-- The general fibre equivalence sends a loop class to the monodromy translate of the chosen
+lift, as an equality in the total space `E`. -/
+@[simp]
+lemma IsCoveringMap.fundamentalGroupEquivFiber_apply_coe [SimplyConnectedSpace E]
+    (hp : IsCoveringMap p) (e : p ⁻¹' {x}) (γ : FundamentalGroup X x) :
+    (IsCoveringMap.fundamentalGroupEquivFiber hp e γ : E) = (hp.monodromy γ e : E) :=
+  rfl
+
+/-- The general fibre equivalence sends a loop class to the monodromy translate of the chosen
+lift, as an equality in the fibre subtype. -/
+@[simp]
+lemma IsCoveringMap.fundamentalGroupEquivFiber_apply [SimplyConnectedSpace E]
+    (hp : IsCoveringMap p) (e : p ⁻¹' {x}) (γ : FundamentalGroup X x) :
+    IsCoveringMap.fundamentalGroupEquivFiber hp e γ = hp.monodromy γ e :=
+  rfl
+
+namespace Deck
+
+/-- Choosing a basepoint lift `e` in the fibre over `x` of a regular simply connected cover
+identifies the fundamental group of the base with that fibre, via `γ ↦ monodromy γ e`. This is
+the regular-cover specialization of `IsCoveringMap.fundamentalGroupEquivFiber`. -/
+noncomputable def IsRegular.fundamentalGroupEquivFiber [SimplyConnectedSpace E]
+    (_hreg : IsRegular p) (hp : IsCoveringMap p) (e : p ⁻¹' {x}) :
+    FundamentalGroup X x ≃ p ⁻¹' {x} :=
+  IsCoveringMap.fundamentalGroupEquivFiber hp e
+
+/-- The regular-cover fibre equivalence sends a loop class to the monodromy translate of the
+chosen lift, as an equality in the total space `E`. -/
+@[simp]
 lemma IsRegular.fundamentalGroupEquivFiber_apply_coe [SimplyConnectedSpace E]
     (hreg : IsRegular p) (hp : IsCoveringMap p) (e : p ⁻¹' {x}) (γ : FundamentalGroup X x) :
-    (hreg.fundamentalGroupEquivFiber hp e γ : E) = (hp.monodromy γ e : E) := by
-  set hf := hreg.isQuotientCoveringMap hp
-  set g := (hreg.fundamentalGroupMulEquivDeckOp hp e γ).unop with hg
-  change ((hf.fiberEquivGroup e).symm g : E) = (hp.monodromy γ e : E)
-  have hsmul : ((hf.fiberEquivGroup e).symm g : E) = g • (e : E) := by
-    have := hf.fiberEquivGroup_smul_self (e := e) (e' := (hf.fiberEquivGroup e).symm g)
-    rwa [Equiv.apply_symm_apply] at this
-  rw [hsmul, hg, hreg.fundamentalGroupMulEquivDeckOp_unop_smul hp e γ]
+    (hreg.fundamentalGroupEquivFiber hp e γ : E) = (hp.monodromy γ e : E) :=
+  IsCoveringMap.fundamentalGroupEquivFiber_apply_coe hp e γ
 
+/-- The regular-cover fibre equivalence sends a loop class to the monodromy translate of the
+chosen lift, as an equality in the fibre subtype. -/
 @[simp]
 lemma IsRegular.fundamentalGroupEquivFiber_apply [SimplyConnectedSpace E]
     (hreg : IsRegular p) (hp : IsCoveringMap p) (e : p ⁻¹' {x}) (γ : FundamentalGroup X x) :
     hreg.fundamentalGroupEquivFiber hp e γ = hp.monodromy γ e :=
-  Subtype.ext (hreg.fundamentalGroupEquivFiber_apply_coe hp e γ)
+  IsCoveringMap.fundamentalGroupEquivFiber_apply hp e γ
 
 end Deck
 

--- a/TauCeti/AlgebraicTopology/UniversalCover/Deck/FundamentalGroup.lean
+++ b/TauCeti/AlgebraicTopology/UniversalCover/Deck/FundamentalGroup.lean
@@ -3,7 +3,7 @@ Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 -/
 import TauCeti.AlgebraicTopology.UniversalCover.Deck.QuotientCovering
-import TauCeti.Topology.Homotopy.Covering
+import Mathlib.Topology.Homotopy.Lifting
 
 /-!
 # The fundamental group of the base of a regular cover and its deck group
@@ -44,9 +44,6 @@ identifies `π₁(X, x)` with that fibre via monodromy.
   with an arbitrary deck transformation by its value at the chosen lift.
 * `TauCeti.Deck.IsRegular.fundamentalGroupMulEquivDeckOp_eq_one_iff`: `γ` maps to the
   identity exactly when its monodromy fixes `e`.
-The imported declaration `TauCeti.IsCoveringMap.fundamentalGroupEquivFiber` gives the
-associated monodromy bijection `FundamentalGroup X x ≃ p ⁻¹' {x}`, `γ ↦ monodromy γ e`,
-for any covering map with simply connected total space.
 
 ## References
 

--- a/TauCeti/AlgebraicTopology/UniversalCover/Deck/FundamentalGroup.lean
+++ b/TauCeti/AlgebraicTopology/UniversalCover/Deck/FundamentalGroup.lean
@@ -46,8 +46,6 @@ identifies `π₁(X, x)` with that fibre via monodromy.
   identity exactly when its monodromy fixes `e`.
 * `TauCeti.IsCoveringMap.fundamentalGroupEquivFiber`: the monodromy bijection
   `FundamentalGroup X x ≃ p ⁻¹' {x}`, `γ ↦ monodromy γ e`.
-* `TauCeti.Deck.IsRegular.fundamentalGroupEquivFiber`: the same bijection, exposed from a
-  regular cover.
 
 ## References
 
@@ -118,23 +116,18 @@ noncomputable def IsCoveringMap.fundamentalGroupEquivFiber [SimplyConnectedSpace
           Path.Homotopic.Quotient.mk
               (PathConnectedSpace.somePath (e : E) (hp.monodromy γ e : E)) = Γ :=
         Subsingleton.elim _ _
-      -- Unfold the inverse map to expose the endpoint casts from `p e` back to `x`.
-      change (((Path.Homotopic.Quotient.mk
-        (PathConnectedSpace.somePath (e : E) (hp.monodromy γ e : E))).map
-          ⟨p, hp.continuous⟩).cast e.2.symm (hp.monodromy γ e).2.symm) = γ
+      dsimp only
       rw [hpath, hp.map_liftPathQuotient]
       simp [Path.Homotopic.Quotient.cast_cast]
     right_inv e' := by
       obtain ⟨e₀, he₀⟩ := e
       obtain ⟨e₁, he₁⟩ := e'
-      change p e₀ = x at he₀
-      change p e₁ = x at he₁
+      simp only [Set.mem_preimage, Set.mem_singleton_iff] at he₀ he₁
       set Γ : Path.Homotopic.Quotient e₀ e₁ :=
         Path.Homotopic.Quotient.mk (PathConnectedSpace.somePath e₀ e₁)
-      -- Unfold the forward map to match the casted base path used in the inverse.
-      change hp.monodromy ((Γ.map ⟨p, hp.continuous⟩).cast he₀.symm he₁.symm)
-        ⟨e₀, he₀⟩ = ⟨e₁, he₁⟩
-      exact hp.monodromy_eq_of_map_eq Γ (by simp [Path.Homotopic.Quotient.cast_cast]) }
+      dsimp only
+      simpa [Γ] using
+        hp.monodromy_eq_of_map_eq Γ (by simp [Γ, Path.Homotopic.Quotient.cast_cast]) }
 
 /-- The general fibre equivalence sends a loop class to the monodromy translate of the chosen
 lift, as an equality in the total space `E`. -/
@@ -152,32 +145,22 @@ lemma IsCoveringMap.fundamentalGroupEquivFiber_apply [SimplyConnectedSpace E]
     IsCoveringMap.fundamentalGroupEquivFiber hp e γ = hp.monodromy γ e :=
   rfl
 
-namespace Deck
-
-/-- Choosing a basepoint lift `e` in the fibre over `x` of a regular simply connected cover
-identifies the fundamental group of the base with that fibre, via `γ ↦ monodromy γ e`. This is
-the regular-cover specialization of `IsCoveringMap.fundamentalGroupEquivFiber`. -/
-noncomputable def IsRegular.fundamentalGroupEquivFiber [SimplyConnectedSpace E]
-    (_hreg : IsRegular p) (hp : IsCoveringMap p) (e : p ⁻¹' {x}) :
-    FundamentalGroup X x ≃ p ⁻¹' {x} :=
-  IsCoveringMap.fundamentalGroupEquivFiber hp e
-
-/-- The regular-cover fibre equivalence sends a loop class to the monodromy translate of the
-chosen lift, as an equality in the total space `E`. -/
+/-- The inverse of the general fibre equivalence is characterized by the loop class whose
+monodromy sends the chosen lift to the requested fibre point. -/
 @[simp]
-lemma IsRegular.fundamentalGroupEquivFiber_apply_coe [SimplyConnectedSpace E]
-    (hreg : IsRegular p) (hp : IsCoveringMap p) (e : p ⁻¹' {x}) (γ : FundamentalGroup X x) :
-    (hreg.fundamentalGroupEquivFiber hp e γ : E) = (hp.monodromy γ e : E) :=
-  IsCoveringMap.fundamentalGroupEquivFiber_apply_coe hp e γ
+lemma IsCoveringMap.fundamentalGroupEquivFiber_symm_apply [SimplyConnectedSpace E]
+    (hp : IsCoveringMap p) (e e' : p ⁻¹' {x}) :
+    hp.monodromy ((IsCoveringMap.fundamentalGroupEquivFiber hp e).symm e') e = e' := by
+  have h := (IsCoveringMap.fundamentalGroupEquivFiber hp e).apply_symm_apply e'
+  rw [IsCoveringMap.fundamentalGroupEquivFiber_apply] at h
+  exact h
 
-/-- The regular-cover fibre equivalence sends a loop class to the monodromy translate of the
-chosen lift, as an equality in the fibre subtype. -/
+/-- On underlying points, the inverse of the general fibre equivalence is characterized by
+the loop class whose monodromy sends the chosen lift to the requested fibre point. -/
 @[simp]
-lemma IsRegular.fundamentalGroupEquivFiber_apply [SimplyConnectedSpace E]
-    (hreg : IsRegular p) (hp : IsCoveringMap p) (e : p ⁻¹' {x}) (γ : FundamentalGroup X x) :
-    hreg.fundamentalGroupEquivFiber hp e γ = hp.monodromy γ e :=
-  IsCoveringMap.fundamentalGroupEquivFiber_apply hp e γ
-
-end Deck
+lemma IsCoveringMap.fundamentalGroupEquivFiber_symm_apply_coe [SimplyConnectedSpace E]
+    (hp : IsCoveringMap p) (e e' : p ⁻¹' {x}) :
+    (hp.monodromy ((IsCoveringMap.fundamentalGroupEquivFiber hp e).symm e') e : E) = e' := by
+  exact congrArg Subtype.val (IsCoveringMap.fundamentalGroupEquivFiber_symm_apply hp e e')
 
 end TauCeti

--- a/TauCeti/AlgebraicTopology/UniversalCover/Deck/FundamentalGroup.lean
+++ b/TauCeti/AlgebraicTopology/UniversalCover/Deck/FundamentalGroup.lean
@@ -1,0 +1,114 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+import Mathlib.Topology.Homotopy.Lifting
+import TauCeti.AlgebraicTopology.UniversalCover.Deck.QuotientCovering
+
+/-!
+# The fundamental group of the base of a regular cover and its deck group
+
+For a covering map `p : E → X` with **simply connected** total space whose deck action is
+**regular** (`p` surjective, with `Deck p` acting transitively on every fibre), the
+fundamental group of the base is anti-isomorphic to the deck transformation group:
+
+  `FundamentalGroup X x ≃* (Deck p)ᵐᵒᵖ`.
+
+This is the Stage 1 target of the universal-covers roadmap
+(`Deck (UniversalCover.proj x₀) ≃* FundamentalGroup X x₀`, "possibly up to `ᵐᵒᵖ`; pin the
+action/composition convention first"). It is stated here for an arbitrary regular cover with
+simply connected total space, of which the universal cover is the special case
+`E = UniversalCover x₀` (where simple connectivity and regularity of the deck action hold).
+
+The `ᵐᵒᵖ` is genuine and pins the convention noted in the roadmap. The deck group acts on
+the total space on the *left* (`Deck.smul_eq_apply : φ • e = φ.1 e`), while the monodromy of
+`π₁(X, x)` acts on each fibre on the *right* (`monodromy (γ.trans γ') = monodromy γ' ∘
+monodromy γ`); choosing a basepoint lift `e` in the fibre and matching the deck element that
+realises a monodromy therefore reverses multiplication, so the natural isomorphism lands in
+`(Deck p)ᵐᵒᵖ`.
+
+The isomorphism is Mathlib's `IsQuotientCoveringMap.fundamentalGroupEquiv`, instantiated at
+the group `Deck p` through `Deck.IsRegular.isQuotientCoveringMap`: a regular preconnected
+covering exhibits its base as the quotient of the total space by `Deck p`, and for a simply
+connected total space Mathlib's quotient-covering machinery identifies the deck group with
+`π₁` of the base. As a corollary, choosing a basepoint lift `e` in the fibre over `x`
+identifies `π₁(X, x)` with that fibre via monodromy.
+
+## Main declarations
+
+* `TauCeti.Deck.IsRegular.fundamentalGroupMulEquivDeckOp`: the anti-isomorphism
+  `FundamentalGroup X x ≃* (Deck p)ᵐᵒᵖ`.
+* `TauCeti.Deck.IsRegular.fundamentalGroupMulEquivDeckOp_unop_smul`: the deck element
+  attached to `γ` moves the chosen lift `e` to `monodromy γ e`.
+* `TauCeti.Deck.IsRegular.fundamentalGroupMulEquivDeckOp_eq_one_iff`: `γ` maps to the
+  identity exactly when its monodromy fixes `e`.
+* `TauCeti.Deck.IsRegular.fundamentalGroupEquivFiber`: the induced bijection
+  `FundamentalGroup X x ≃ p ⁻¹' {x}`, `γ ↦ monodromy γ e`.
+
+## References
+
+The comparison map is Mathlib's `IsQuotientCoveringMap.fundamentalGroupEquiv` (Junyan Xu,
+`Mathlib/Topology/Homotopy/Lifting.lean`); the quotient-covering presentation of a regular
+deck action is `TauCeti.Deck.IsRegular.isQuotientCoveringMap`. This discharges the Stage 1
+target of the Tau Ceti universal-covers roadmap.
+-/
+
+namespace TauCeti
+
+namespace Deck
+
+variable {E X : Type*} [TopologicalSpace E] [TopologicalSpace X] {p : E → X} {x : X}
+
+/-- For a regular covering map `p : E → X` with simply connected total space, the fundamental
+group of the base is anti-isomorphic to the deck transformation group:
+`FundamentalGroup X x ≃* (Deck p)ᵐᵒᵖ`. The `ᵐᵒᵖ` reflects that the deck group acts on the
+left while the monodromy of `π₁` acts on the right; see the module docstring. -/
+noncomputable def IsRegular.fundamentalGroupMulEquivDeckOp [SimplyConnectedSpace E]
+    (hreg : IsRegular p) (hp : IsCoveringMap p) (e : p ⁻¹' {x}) :
+    FundamentalGroup X x ≃* (Deck p)ᵐᵒᵖ :=
+  (hreg.isQuotientCoveringMap hp).fundamentalGroupEquiv e
+
+/-- The deck transformation attached to a loop class `γ` moves the chosen basepoint lift `e`
+along the monodromy of `γ`. -/
+@[simp]
+lemma IsRegular.fundamentalGroupMulEquivDeckOp_unop_smul [SimplyConnectedSpace E]
+    (hreg : IsRegular p) (hp : IsCoveringMap p) (e : p ⁻¹' {x}) (γ : FundamentalGroup X x) :
+    (hreg.fundamentalGroupMulEquivDeckOp hp e γ).unop • (e : E) = (hp.monodromy γ e : E) :=
+  (hreg.isQuotientCoveringMap hp).unop_fundamentalGroupToMulOpposite_smul
+
+/-- A loop class `γ` maps to the identity deck transformation exactly when its monodromy
+fixes the chosen basepoint lift `e`. -/
+lemma IsRegular.fundamentalGroupMulEquivDeckOp_eq_one_iff [SimplyConnectedSpace E]
+    (hreg : IsRegular p) (hp : IsCoveringMap p) (e : p ⁻¹' {x}) (γ : FundamentalGroup X x) :
+    hreg.fundamentalGroupMulEquivDeckOp hp e γ = 1 ↔ hp.monodromy γ e = e :=
+  (hreg.isQuotientCoveringMap hp).fundamentalGroupToMulOpposite_eq_one_iff
+
+/-- Choosing a basepoint lift `e` in the fibre over `x` identifies the fundamental group of
+the base with that fibre, via `γ ↦ monodromy γ e`. This is the orbit-stabiliser bijection of
+the (free, transitive) `π₁`-action on the fibre of a regular simply connected cover. -/
+noncomputable def IsRegular.fundamentalGroupEquivFiber [SimplyConnectedSpace E]
+    (hreg : IsRegular p) (hp : IsCoveringMap p) (e : p ⁻¹' {x}) :
+    FundamentalGroup X x ≃ p ⁻¹' {x} :=
+  (hreg.fundamentalGroupMulEquivDeckOp hp e).toEquiv.trans <|
+    MulOpposite.opEquiv.symm.trans ((hreg.isQuotientCoveringMap hp).fiberEquivGroup e).symm
+
+lemma IsRegular.fundamentalGroupEquivFiber_apply_coe [SimplyConnectedSpace E]
+    (hreg : IsRegular p) (hp : IsCoveringMap p) (e : p ⁻¹' {x}) (γ : FundamentalGroup X x) :
+    (hreg.fundamentalGroupEquivFiber hp e γ : E) = (hp.monodromy γ e : E) := by
+  set hf := hreg.isQuotientCoveringMap hp
+  set g := (hreg.fundamentalGroupMulEquivDeckOp hp e γ).unop with hg
+  change ((hf.fiberEquivGroup e).symm g : E) = (hp.monodromy γ e : E)
+  have hsmul : ((hf.fiberEquivGroup e).symm g : E) = g • (e : E) := by
+    have := hf.fiberEquivGroup_smul_self (e := e) (e' := (hf.fiberEquivGroup e).symm g)
+    rwa [Equiv.apply_symm_apply] at this
+  rw [hsmul, hg, hreg.fundamentalGroupMulEquivDeckOp_unop_smul hp e γ]
+
+@[simp]
+lemma IsRegular.fundamentalGroupEquivFiber_apply [SimplyConnectedSpace E]
+    (hreg : IsRegular p) (hp : IsCoveringMap p) (e : p ⁻¹' {x}) (γ : FundamentalGroup X x) :
+    hreg.fundamentalGroupEquivFiber hp e γ = hp.monodromy γ e :=
+  Subtype.ext (hreg.fundamentalGroupEquivFiber_apply_coe hp e γ)
+
+end Deck
+
+end TauCeti

--- a/TauCeti/AlgebraicTopology/UniversalCover/Deck/FundamentalGroup.lean
+++ b/TauCeti/AlgebraicTopology/UniversalCover/Deck/FundamentalGroup.lean
@@ -2,8 +2,8 @@
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 -/
-import Mathlib.Topology.Homotopy.Lifting
 import TauCeti.AlgebraicTopology.UniversalCover.Deck.QuotientCovering
+import TauCeti.Topology.Homotopy.Covering
 
 /-!
 # The fundamental group of the base of a regular cover and its deck group
@@ -44,8 +44,9 @@ identifies `π₁(X, x)` with that fibre via monodromy.
   with an arbitrary deck transformation by its value at the chosen lift.
 * `TauCeti.Deck.IsRegular.fundamentalGroupMulEquivDeckOp_eq_one_iff`: `γ` maps to the
   identity exactly when its monodromy fixes `e`.
-* `TauCeti.IsCoveringMap.fundamentalGroupEquivFiber`: the monodromy bijection
-  `FundamentalGroup X x ≃ p ⁻¹' {x}`, `γ ↦ monodromy γ e`.
+The imported declaration `TauCeti.IsCoveringMap.fundamentalGroupEquivFiber` gives the
+associated monodromy bijection `FundamentalGroup X x ≃ p ⁻¹' {x}`, `γ ↦ monodromy γ e`,
+for any covering map with simply connected total space.
 
 ## References
 
@@ -96,71 +97,5 @@ lemma IsRegular.fundamentalGroupMulEquivDeckOp_eq_one_iff [SimplyConnectedSpace 
   (hreg.isQuotientCoveringMap hp).fundamentalGroupToMulOpposite_eq_one_iff
 
 end Deck
-
-variable {E X : Type*} [TopologicalSpace E] [TopologicalSpace X] {p : E → X} {x : X}
-
-/-- Choosing a basepoint lift `e` in the fibre over `x` identifies the fundamental group of
-the base with that fibre, via `γ ↦ monodromy γ e`. -/
-noncomputable def IsCoveringMap.fundamentalGroupEquivFiber [SimplyConnectedSpace E]
-    (hp : IsCoveringMap p) (e : p ⁻¹' {x}) :
-    FundamentalGroup X x ≃ p ⁻¹' {x} :=
-  { toFun γ := hp.monodromy γ e
-    invFun e' :=
-      FundamentalGroup.fromPath <|
-        ((Path.Homotopic.Quotient.mk (PathConnectedSpace.somePath (e : E) (e' : E))).map
-          ⟨p, hp.continuous⟩).cast e.2.symm e'.2.symm
-    left_inv γ := by
-      set Γ : Path.Homotopic.Quotient (e : E) (hp.monodromy γ e : E) :=
-        hp.liftPathQuotient γ e
-      have hpath :
-          Path.Homotopic.Quotient.mk
-              (PathConnectedSpace.somePath (e : E) (hp.monodromy γ e : E)) = Γ :=
-        Subsingleton.elim _ _
-      dsimp only
-      rw [hpath, hp.map_liftPathQuotient]
-      simp [Path.Homotopic.Quotient.cast_cast]
-    right_inv e' := by
-      obtain ⟨e₀, he₀⟩ := e
-      obtain ⟨e₁, he₁⟩ := e'
-      simp only [Set.mem_preimage, Set.mem_singleton_iff] at he₀ he₁
-      set Γ : Path.Homotopic.Quotient e₀ e₁ :=
-        Path.Homotopic.Quotient.mk (PathConnectedSpace.somePath e₀ e₁)
-      dsimp only
-      simpa [Γ] using
-        hp.monodromy_eq_of_map_eq Γ (by simp [Γ, Path.Homotopic.Quotient.cast_cast]) }
-
-/-- The general fibre equivalence sends a loop class to the monodromy translate of the chosen
-lift, as an equality in the total space `E`. -/
-@[simp]
-lemma IsCoveringMap.fundamentalGroupEquivFiber_apply_coe [SimplyConnectedSpace E]
-    (hp : IsCoveringMap p) (e : p ⁻¹' {x}) (γ : FundamentalGroup X x) :
-    (IsCoveringMap.fundamentalGroupEquivFiber hp e γ : E) = (hp.monodromy γ e : E) :=
-  rfl
-
-/-- The general fibre equivalence sends a loop class to the monodromy translate of the chosen
-lift, as an equality in the fibre subtype. -/
-@[simp]
-lemma IsCoveringMap.fundamentalGroupEquivFiber_apply [SimplyConnectedSpace E]
-    (hp : IsCoveringMap p) (e : p ⁻¹' {x}) (γ : FundamentalGroup X x) :
-    IsCoveringMap.fundamentalGroupEquivFiber hp e γ = hp.monodromy γ e :=
-  rfl
-
-/-- The inverse of the general fibre equivalence is characterized by the loop class whose
-monodromy sends the chosen lift to the requested fibre point. -/
-@[simp]
-lemma IsCoveringMap.fundamentalGroupEquivFiber_symm_apply [SimplyConnectedSpace E]
-    (hp : IsCoveringMap p) (e e' : p ⁻¹' {x}) :
-    hp.monodromy ((IsCoveringMap.fundamentalGroupEquivFiber hp e).symm e') e = e' := by
-  have h := (IsCoveringMap.fundamentalGroupEquivFiber hp e).apply_symm_apply e'
-  rw [IsCoveringMap.fundamentalGroupEquivFiber_apply] at h
-  exact h
-
-/-- On underlying points, the inverse of the general fibre equivalence is characterized by
-the loop class whose monodromy sends the chosen lift to the requested fibre point. -/
-@[simp]
-lemma IsCoveringMap.fundamentalGroupEquivFiber_symm_apply_coe [SimplyConnectedSpace E]
-    (hp : IsCoveringMap p) (e e' : p ⁻¹' {x}) :
-    (hp.monodromy ((IsCoveringMap.fundamentalGroupEquivFiber hp e).symm e') e : E) = e' := by
-  exact congrArg Subtype.val (IsCoveringMap.fundamentalGroupEquivFiber_symm_apply hp e e')
 
 end TauCeti

--- a/TauCeti/Topology/Homotopy/Covering.lean
+++ b/TauCeti/Topology/Homotopy/Covering.lean
@@ -1,0 +1,94 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+import Mathlib.Topology.Homotopy.Lifting
+
+/-!
+# Covering maps and fundamental-group monodromy
+
+This file records generic covering-space consequences of Mathlib's path-lifting and
+monodromy API. For a covering map `p : E → X` whose total space is simply connected,
+choosing a lift `e` over `x` identifies `π₁(X, x)` with the fibre over `x` by sending a
+loop class to its monodromy translate of `e`.
+
+## Main declarations
+
+* `TauCeti.IsCoveringMap.fundamentalGroupEquivFiber`: the monodromy bijection
+  `FundamentalGroup X x ≃ p ⁻¹' {x}`, `γ ↦ monodromy γ e`.
+
+## References
+
+This builds directly on Junyan Xu's covering-space lifting and monodromy API in
+`Mathlib.Topology.Homotopy.Lifting`.
+-/
+
+namespace TauCeti
+
+variable {E X : Type*} [TopologicalSpace E] [TopologicalSpace X] {p : E → X} {x : X}
+
+/-- Choosing a basepoint lift `e` in the fibre over `x` identifies the fundamental group of
+the base with that fibre, via `γ ↦ monodromy γ e`. -/
+noncomputable def IsCoveringMap.fundamentalGroupEquivFiber [SimplyConnectedSpace E]
+    (hp : IsCoveringMap p) (e : p ⁻¹' {x}) :
+    FundamentalGroup X x ≃ p ⁻¹' {x} :=
+  { toFun γ := hp.monodromy γ e
+    invFun e' :=
+      FundamentalGroup.fromPath <|
+        ((Path.Homotopic.Quotient.mk (PathConnectedSpace.somePath (e : E) (e' : E))).map
+          ⟨p, hp.continuous⟩).cast e.2.symm e'.2.symm
+    left_inv γ := by
+      set Γ : Path.Homotopic.Quotient (e : E) (hp.monodromy γ e : E) :=
+        hp.liftPathQuotient γ e
+      have hpath :
+          Path.Homotopic.Quotient.mk
+              (PathConnectedSpace.somePath (e : E) (hp.monodromy γ e : E)) = Γ :=
+        Subsingleton.elim _ _
+      dsimp only
+      rw [hpath, hp.map_liftPathQuotient]
+      simp [Path.Homotopic.Quotient.cast_cast]
+    right_inv e' := by
+      obtain ⟨e₀, he₀⟩ := e
+      obtain ⟨e₁, he₁⟩ := e'
+      simp only [Set.mem_preimage, Set.mem_singleton_iff] at he₀ he₁
+      set Γ : Path.Homotopic.Quotient e₀ e₁ :=
+        Path.Homotopic.Quotient.mk (PathConnectedSpace.somePath e₀ e₁)
+      dsimp only
+      simpa [Γ] using
+        hp.monodromy_eq_of_map_eq Γ (by simp [Γ, Path.Homotopic.Quotient.cast_cast]) }
+
+/-- The general fibre equivalence sends a loop class to the monodromy translate of the chosen
+lift, as an equality in the total space `E`. -/
+@[simp]
+lemma IsCoveringMap.fundamentalGroupEquivFiber_apply_coe [SimplyConnectedSpace E]
+    (hp : IsCoveringMap p) (e : p ⁻¹' {x}) (γ : FundamentalGroup X x) :
+    (IsCoveringMap.fundamentalGroupEquivFiber hp e γ : E) = (hp.monodromy γ e : E) :=
+  rfl
+
+/-- The general fibre equivalence sends a loop class to the monodromy translate of the chosen
+lift, as an equality in the fibre subtype. -/
+@[simp]
+lemma IsCoveringMap.fundamentalGroupEquivFiber_apply [SimplyConnectedSpace E]
+    (hp : IsCoveringMap p) (e : p ⁻¹' {x}) (γ : FundamentalGroup X x) :
+    IsCoveringMap.fundamentalGroupEquivFiber hp e γ = hp.monodromy γ e :=
+  rfl
+
+/-- The inverse of the general fibre equivalence is characterized by the loop class whose
+monodromy sends the chosen lift to the requested fibre point. -/
+@[simp]
+lemma IsCoveringMap.fundamentalGroupEquivFiber_symm_apply [SimplyConnectedSpace E]
+    (hp : IsCoveringMap p) (e e' : p ⁻¹' {x}) :
+    hp.monodromy ((IsCoveringMap.fundamentalGroupEquivFiber hp e).symm e') e = e' := by
+  have h := (IsCoveringMap.fundamentalGroupEquivFiber hp e).apply_symm_apply e'
+  rw [IsCoveringMap.fundamentalGroupEquivFiber_apply] at h
+  exact h
+
+/-- On underlying points, the inverse of the general fibre equivalence is characterized by
+the loop class whose monodromy sends the chosen lift to the requested fibre point. -/
+@[simp]
+lemma IsCoveringMap.fundamentalGroupEquivFiber_symm_apply_coe [SimplyConnectedSpace E]
+    (hp : IsCoveringMap p) (e e' : p ⁻¹' {x}) :
+    (hp.monodromy ((IsCoveringMap.fundamentalGroupEquivFiber hp e).symm e') e : E) = e' := by
+  exact congrArg Subtype.val (IsCoveringMap.fundamentalGroupEquivFiber_symm_apply hp e e')
+
+end TauCeti

--- a/TauCeti/Topology/Homotopy/Covering.lean
+++ b/TauCeti/Topology/Homotopy/Covering.lean
@@ -76,7 +76,7 @@ lemma IsCoveringMap.fundamentalGroupEquivFiber_apply [SimplyConnectedSpace E]
 /-- The inverse of the general fibre equivalence is characterized by the loop class whose
 monodromy sends the chosen lift to the requested fibre point. -/
 @[simp]
-lemma IsCoveringMap.fundamentalGroupEquivFiber_symm_apply [SimplyConnectedSpace E]
+lemma IsCoveringMap.fundamentalGroupEquivFiber_apply_symm_apply [SimplyConnectedSpace E]
     (hp : IsCoveringMap p) (e e' : p ⁻¹' {x}) :
     hp.monodromy ((IsCoveringMap.fundamentalGroupEquivFiber hp e).symm e') e = e' := by
   have h := (IsCoveringMap.fundamentalGroupEquivFiber hp e).apply_symm_apply e'
@@ -86,9 +86,9 @@ lemma IsCoveringMap.fundamentalGroupEquivFiber_symm_apply [SimplyConnectedSpace 
 /-- On underlying points, the inverse of the general fibre equivalence is characterized by
 the loop class whose monodromy sends the chosen lift to the requested fibre point. -/
 @[simp]
-lemma IsCoveringMap.fundamentalGroupEquivFiber_symm_apply_coe [SimplyConnectedSpace E]
+lemma IsCoveringMap.fundamentalGroupEquivFiber_apply_symm_apply_coe [SimplyConnectedSpace E]
     (hp : IsCoveringMap p) (e e' : p ⁻¹' {x}) :
     (hp.monodromy ((IsCoveringMap.fundamentalGroupEquivFiber hp e).symm e') e : E) = e' := by
-  exact congrArg Subtype.val (IsCoveringMap.fundamentalGroupEquivFiber_symm_apply hp e e')
+  exact congrArg Subtype.val (IsCoveringMap.fundamentalGroupEquivFiber_apply_symm_apply hp e e')
 
 end TauCeti


### PR DESCRIPTION
This PR identifies the fundamental group of the base of a regular cover with the opposite of its deck transformation group: for a covering map `p : E → X` with simply connected total space whose deck action is regular (`p` surjective, with `Deck p` transitive on every fibre), it constructs `TauCeti.Deck.IsRegular.fundamentalGroupMulEquivDeckOp : FundamentalGroup X x ≃* (Deck p)ᵐᵒᵖ`. It records how the comparison acts (the deck element attached to a loop class `γ` carries the chosen basepoint lift `e` along the monodromy of `γ`, with `γ` mapping to the identity exactly when its monodromy fixes `e`), and derives the orbit-stabiliser bijection `FundamentalGroup X x ≃ p ⁻¹' {x}`, `γ ↦ monodromy γ e`, between the fundamental group and a fibre.

This advances `TauCetiRoadmap/UniversalCovers/README.md`, Stage 1, item 5 ("`Deck(proj) ≃* π₁(X, x₀)`. The isomorphism connecting Stage 0.3 and 0.4"), whose `Targets.lean` names `Deck (UniversalCover.proj x₀) ≃* FundamentalGroup X x₀` "possibly up to `ᵐᵒᵖ`; pin the action/composition convention first" as the natural first Stage 1 theorem. The statement is given for an arbitrary regular cover with simply connected total space, of which the universal cover is the special case `E = UniversalCover x₀`. The `ᵐᵒᵖ` pins the convention the roadmap flags: the deck group acts on the left (`Deck.smul_eq_apply`) while `π₁` monodromy acts on the right (`monodromy (γ.trans γ')` composes in the opposite order), so the natural isomorphism reverses multiplication and lands in `(Deck p)ᵐᵒᵖ`.

The comparison map itself is Mathlib's `IsQuotientCoveringMap.fundamentalGroupEquiv` (Junyan Xu, `Mathlib/Topology/Homotopy/Lifting.lean`); no Mathlib code is vendored. The contribution is instantiating it at the group `Deck p` through the repo's `TauCeti.Deck.IsRegular.isQuotientCoveringMap` (a regular preconnected covering presents its base as `E / Deck p`), reading off its action via the monodromy through Mathlib's `unop_fundamentalGroupToMulOpposite_smul` and `fundamentalGroupToMulOpposite_eq_one_iff`, and combining with `fiberEquivGroup` to obtain the fibre bijection. The `[SimplyConnectedSpace E]` hypothesis supplies `[PathConnectedSpace E]` and `[PreconnectedSpace E]` automatically, so it is the only connectivity assumption stated. Mathlib has no statement comparing `π₁` of the base with the deck group of a regular cover (it phrases `fundamentalGroupEquiv` for an abstract `IsQuotientCoveringMap p G`), so this is genuinely new.

Local verification against the pinned toolchain: full `lake build` is green (`Build completed successfully (4042 jobs).`) and `lake exe axioms` is clean (`axioms: audited 3684 TauCeti declaration(s); all within the allowlist [propext, Classical.choice, Quot.sound].`).

<!--tauceti-target:v1 {"focus":"UniversalCovers","id":"fundamental-group-regular-cover-deck-op"}-->

🤖 Prepared with Claude Code
