### PR TITLE
feat: completely monotone functions are closed under products and differentiation

### DIFF
--- a/TauCeti/Analysis/CompletelyMonotone/Closure.lean
+++ b/TauCeti/Analysis/CompletelyMonotone/Closure.lean
@@ -1,0 +1,117 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+import TauCeti.Analysis.CompletelyMonotone.Basic
+import Mathlib.Analysis.Calculus.IteratedDeriv.Lemmas
+
+/-!
+# Closure of completely monotone functions under products and differentiation
+
+This file extends the basic API of `TauCeti.IsCompletelyMonotone` (sums and nonnegative scalar
+multiples, in `TauCeti.Analysis.CompletelyMonotone.Basic`) with two further closure properties
+called for by the `OneParameterSemigroups` roadmap:
+
+* the **product** of two completely monotone functions is completely monotone, hence so is any
+  finite product and any natural power;
+* if `f` is completely monotone then so is `t ↦ -f'(t)`, the **negated derivative**.
+
+Both are elementary consequences of the sign-alternation definition. For the product, the
+Leibniz rule expands `(-1)ⁿ (fg)⁽ⁿ⁾` as a nonnegative combination
+`∑ₖ (n choose k) · [(-1)ᵏ f⁽ᵏ⁾] · [(-1)ⁿ⁻ᵏ g⁽ⁿ⁻ᵏ⁾]` of products of the (nonnegative) alternating
+derivatives of `f` and `g`. For the negated derivative, the `(n+1)`-st alternating derivative of
+`f` is the `n`-th alternating derivative of `-f'`. Mathlib has the analogous closure lemmas for
+`AbsolutelyMonotoneOn` only up to sums and scalar multiples (`AbsolutelyMonotoneOn.add`,
+`AbsolutelyMonotoneOn.smul`), so the multiplicative and differential closure built here is new.
+
+These workhorses combine with the prototypes `t ↦ e^{-x t}` to manufacture completely monotone
+functions: e.g. any finite sum `∑ⱼ cⱼ e^{-xⱼ t}` with `cⱼ, xⱼ ≥ 0`, or a product like
+`t ↦ e^{-x t} / (1 + t)`-style mixtures once their factors are known completely monotone. The
+negated-derivative closure is the first step towards the completely-monotone ↔ Bernstein-function
+correspondence (a Bernstein function is a nonnegative function whose derivative is completely
+monotone).
+
+## Main declarations
+
+* `TauCeti.IsCompletelyMonotone.mul`: completely monotone functions are closed under pointwise
+  multiplication.
+* `TauCeti.IsCompletelyMonotone.prod`: closure under finite products.
+* `TauCeti.IsCompletelyMonotone.pow`: closure under natural powers.
+* `TauCeti.IsCompletelyMonotone.neg_derivWithin`: if `f` is completely monotone then so is
+  `t ↦ -derivWithin f (Ici 0) t`.
+
+## References
+
+* R. Schilling, R. Song, Z. Vondraček, *Bernstein Functions: Theory and Applications*
+  (de Gruyter, 2nd ed. 2012).
+-/
+
+open Set
+open scoped ContDiff
+
+namespace TauCeti
+
+namespace IsCompletelyMonotone
+
+variable {f g : ℝ → ℝ}
+
+/-- Completely monotone functions are closed under pointwise multiplication. The Leibniz rule
+writes `(-1)ⁿ (fg)⁽ⁿ⁾` as the nonnegative combination
+`∑ₖ (n choose k) · [(-1)ᵏ f⁽ᵏ⁾] · [(-1)ⁿ⁻ᵏ g⁽ⁿ⁻ᵏ⁾]`. -/
+theorem mul (hf : IsCompletelyMonotone f) (hg : IsCompletelyMonotone g) :
+    IsCompletelyMonotone (f * g) := by
+  refine ⟨hf.contDiffOn.mul hg.contDiffOn, fun n t ht => ?_⟩
+  have hmem : t ∈ Ici (0 : ℝ) := mem_Ici.mpr ht
+  have hu : UniqueDiffOn ℝ (Ici (0 : ℝ)) := uniqueDiffOn_Ici 0
+  have hfn : ContDiffWithinAt ℝ n f (Ici 0) t :=
+    (hf.contDiffOn.contDiffWithinAt hmem).of_le (by exact_mod_cast le_top)
+  have hgn : ContDiffWithinAt ℝ n g (Ici 0) t :=
+    (hg.contDiffOn.contDiffWithinAt hmem).of_le (by exact_mod_cast le_top)
+  rw [iteratedDerivWithin_mul hmem hu hfn hgn, Finset.mul_sum]
+  refine Finset.sum_nonneg fun i hi => ?_
+  have hin : i ≤ n := Nat.lt_succ_iff.mp (Finset.mem_range.mp hi)
+  have e1 := hf.neg_one_pow_mul_iteratedDerivWithin_nonneg i ht
+  have e2 := hg.neg_one_pow_mul_iteratedDerivWithin_nonneg (n - i) ht
+  have hsign : ((-1 : ℝ)) ^ n = (-1) ^ i * (-1) ^ (n - i) := by
+    rw [← pow_add, Nat.add_sub_cancel' hin]
+  have key : (-1 : ℝ) ^ n * ((n.choose i : ℝ) * iteratedDerivWithin i f (Ici 0) t
+        * iteratedDerivWithin (n - i) g (Ici 0) t)
+      = (n.choose i : ℝ) * ((-1) ^ i * iteratedDerivWithin i f (Ici 0) t)
+        * ((-1) ^ (n - i) * iteratedDerivWithin (n - i) g (Ici 0) t) := by
+    rw [hsign]; ring
+  rw [key]
+  exact mul_nonneg (mul_nonneg (Nat.cast_nonneg _) e1) e2
+
+/-- Completely monotone functions are closed under finite products. -/
+theorem prod {ι : Type*} {s : Finset ι} {f : ι → ℝ → ℝ}
+    (hf : ∀ i ∈ s, IsCompletelyMonotone (f i)) :
+    IsCompletelyMonotone (fun t => ∏ i ∈ s, f i t) := by
+  have h := Finset.prod_induction f IsCompletelyMonotone
+    (fun _ _ => IsCompletelyMonotone.mul) (isCompletelyMonotone_const zero_le_one) hf
+  have heq : (∏ i ∈ s, f i) = fun t => ∏ i ∈ s, f i t := funext fun t => Finset.prod_apply t s f
+  rwa [heq] at h
+
+/-- Completely monotone functions are closed under taking natural powers. -/
+theorem pow (hf : IsCompletelyMonotone f) (k : ℕ) : IsCompletelyMonotone (f ^ k) := by
+  induction k with
+  | zero => rw [pow_zero]; exact isCompletelyMonotone_const zero_le_one
+  | succ k ih => rw [pow_succ]; exact ih.mul hf
+
+/-- If `f` is completely monotone then so is its negated derivative `t ↦ -f'(t)`. This is the
+shift `(-1)ⁿ (-f')⁽ⁿ⁾ = (-1)ⁿ⁺¹ f⁽ⁿ⁺¹⁾` of the sign-alternation condition, and is the first step
+towards the completely-monotone ↔ Bernstein correspondence. -/
+theorem neg_derivWithin (hf : IsCompletelyMonotone f) :
+    IsCompletelyMonotone (fun t => -derivWithin f (Ici 0) t) := by
+  have hu : UniqueDiffOn ℝ (Ici (0 : ℝ)) := uniqueDiffOn_Ici 0
+  refine ⟨(hf.contDiffOn.derivWithin hu (by simp)).neg, fun n t ht => ?_⟩
+  rw [iteratedDerivWithin_fun_neg, ← iteratedDerivWithin_succ' (f := f) (s := Ici 0)]
+  have hsign := hf.neg_one_pow_mul_iteratedDerivWithin_nonneg (n + 1) ht
+  have key : (-1 : ℝ) ^ n * -iteratedDerivWithin (n + 1) f (Ici 0) t
+      = (-1) ^ (n + 1) * iteratedDerivWithin (n + 1) f (Ici 0) t := by
+    rw [pow_succ]; ring
+  rw [key]
+  exact hsign
+
+end IsCompletelyMonotone
+
+end TauCeti

--- a/TauCeti/Analysis/CompletelyMonotone/Closure.lean
+++ b/TauCeti/Analysis/CompletelyMonotone/Closure.lean
@@ -37,8 +37,10 @@ monotone).
   multiplication.
 * `TauCeti.IsCompletelyMonotone.prod`: closure under finite products.
 * `TauCeti.IsCompletelyMonotone.pow`: closure under natural powers.
-* `TauCeti.IsCompletelyMonotone.neg_derivWithin`: if `f` is completely monotone then so is
-  `t ↦ -derivWithin f (Ici 0) t`.
+* `TauCeti.IsCompletelyMonotone.neg_one_pow_mul_iteratedDerivWithin`: every alternating
+  iterated derivative of a completely monotone function is completely monotone.
+* `TauCeti.IsCompletelyMonotone.neg_derivWithin`: the negated derivative within `[0, ∞)` of a
+  completely monotone function is completely monotone.
 
 ## References
 
@@ -55,9 +57,7 @@ namespace IsCompletelyMonotone
 
 variable {f g : ℝ → ℝ}
 
-/-- Completely monotone functions are closed under pointwise multiplication. The Leibniz rule
-writes `(-1)ⁿ (fg)⁽ⁿ⁾` as the nonnegative combination
-`∑ₖ (n choose k) · [(-1)ᵏ f⁽ᵏ⁾] · [(-1)ⁿ⁻ᵏ g⁽ⁿ⁻ᵏ⁾]`. -/
+/-- Completely monotone functions are closed under pointwise multiplication. -/
 theorem mul (hf : IsCompletelyMonotone f) (hg : IsCompletelyMonotone g) :
     IsCompletelyMonotone (f * g) := by
   refine ⟨hf.contDiffOn.mul hg.contDiffOn, fun n t ht => ?_⟩
@@ -97,20 +97,46 @@ theorem pow (hf : IsCompletelyMonotone f) (k : ℕ) : IsCompletelyMonotone (f ^ 
   | zero => rw [pow_zero]; exact isCompletelyMonotone_const zero_le_one
   | succ k ih => rw [pow_succ]; exact ih.mul hf
 
-/-- If `f` is completely monotone then so is its negated derivative `t ↦ -f'(t)`. This is the
-shift `(-1)ⁿ (-f')⁽ⁿ⁾ = (-1)ⁿ⁺¹ f⁽ⁿ⁺¹⁾` of the sign-alternation condition, and is the first step
-towards the completely-monotone ↔ Bernstein correspondence. -/
+/-- Every alternating iterated derivative of a completely monotone function is completely
+monotone. -/
+theorem neg_one_pow_mul_iteratedDerivWithin (hf : IsCompletelyMonotone f) (k : ℕ) :
+    IsCompletelyMonotone (fun t => (-1 : ℝ) ^ k * iteratedDerivWithin k f (Ici 0) t) := by
+  have hu : UniqueDiffOn ℝ (Ici (0 : ℝ)) := uniqueDiffOn_Ici 0
+  have hcont : ContDiffOn ℝ ∞ (iteratedDerivWithin k f (Ici 0)) (Ici 0) := by
+    induction k with
+    | zero => simpa [iteratedDerivWithin_zero] using hf.contDiffOn
+    | succ k ih =>
+        simpa [iteratedDerivWithin_succ] using ih.derivWithin (m := ∞) hu (by simp)
+  refine ⟨?_, fun n t ht => ?_⟩
+  · simpa [smul_eq_mul] using hcont.const_smul ((-1 : ℝ) ^ k)
+  have hshift :
+      iteratedDerivWithin n (iteratedDerivWithin k f (Ici 0)) (Ici 0) =
+        iteratedDerivWithin (n + k) f (Ici 0) := by
+    induction n with
+    | zero => simp [iteratedDerivWithin_zero]
+    | succ n ih =>
+        rw [iteratedDerivWithin_succ, ih, ← iteratedDerivWithin_succ]
+        congr 1
+        omega
+  have hsign := hf.neg_one_pow_mul_iteratedDerivWithin_nonneg (n + k) ht
+  have hiter :
+      iteratedDerivWithin n
+          (fun t => (-1 : ℝ) ^ k * iteratedDerivWithin k f (Ici 0) t) (Ici 0) t =
+        (-1 : ℝ) ^ k * iteratedDerivWithin (n + k) f (Ici 0) t := by
+    rw [iteratedDerivWithin_const_mul_field, hshift]
+  rw [hiter]
+  have key :
+      (-1 : ℝ) ^ n * ((-1 : ℝ) ^ k * iteratedDerivWithin (n + k) f (Ici 0) t) =
+        (-1 : ℝ) ^ (n + k) * iteratedDerivWithin (n + k) f (Ici 0) t := by
+    rw [pow_add]
+    ring
+  rwa [key]
+
+/-- The negated derivative within `[0, ∞)` of a completely monotone function is completely
+monotone. -/
 theorem neg_derivWithin (hf : IsCompletelyMonotone f) :
     IsCompletelyMonotone (fun t => -derivWithin f (Ici 0) t) := by
-  have hu : UniqueDiffOn ℝ (Ici (0 : ℝ)) := uniqueDiffOn_Ici 0
-  refine ⟨(hf.contDiffOn.derivWithin hu (by simp)).neg, fun n t ht => ?_⟩
-  rw [iteratedDerivWithin_fun_neg, ← iteratedDerivWithin_succ' (f := f) (s := Ici 0)]
-  have hsign := hf.neg_one_pow_mul_iteratedDerivWithin_nonneg (n + 1) ht
-  have key : (-1 : ℝ) ^ n * -iteratedDerivWithin (n + 1) f (Ici 0) t
-      = (-1) ^ (n + 1) * iteratedDerivWithin (n + 1) f (Ici 0) t := by
-    rw [pow_succ]; ring
-  rw [key]
-  exact hsign
+  simpa [pow_one, iteratedDerivWithin_one] using hf.neg_one_pow_mul_iteratedDerivWithin 1
 
 end IsCompletelyMonotone
 


### PR DESCRIPTION
This PR extends the `TauCeti.IsCompletelyMonotone` API with two further closure properties: the pointwise product of two completely monotone functions is completely monotone (`mul`), hence so is any finite product (`prod`) and any natural power (`pow`); and the negated derivative `t ↦ -f'(t)` of a completely monotone `f` is completely monotone (`neg_derivWithin`). The product proof expands `(-1)ⁿ (fg)⁽ⁿ⁾` through the Leibniz rule as a nonnegative combination `∑ₖ (n choose k) · [(-1)ᵏ f⁽ᵏ⁾] · [(-1)ⁿ⁻ᵏ g⁽ⁿ⁻ᵏ⁾]` of the alternating derivatives of `f` and `g`; the derivative proof is the index shift `(-1)ⁿ (-f')⁽ⁿ⁾ = (-1)ⁿ⁺¹ f⁽ⁿ⁺¹⁾`. The negated-derivative closure is the first step towards the completely-monotone ↔ Bernstein-function correspondence.

This advances the `OneParameterSemigroups` roadmap, Part B ("Completely monotone (and Bernstein) functions") in `TauCetiRoadmap/OneParameterSemigroups/README.md`, whose `API to develop` bullet asks for completely monotone functions "closed under sums, nonnegative scalar multiples, products, and pointwise limits ... derivative/integral closure". The existing `TauCeti.Analysis.CompletelyMonotone.Basic` (merged) supplies sums and nonnegative scalar multiples; this file adds the products and the derivative. Mathlib's analogous predicate `AbsolutelyMonotoneOn` carries only `add` and `smul` closure, so the multiplicative and differential closure is genuinely new; the proofs reuse Mathlib's `iteratedDerivWithin_mul` (Leibniz), `iteratedDerivWithin_fun_neg`, `iteratedDerivWithin_succ'`, and `ContDiffOn.{mul, derivWithin, neg}`. No Mathlib code is vendored.

It is distinct from the in-flight PRs in this roadmap area, which concern positive-definite functions and kernels, `charFun`, and C₀-semigroups; this is purely the completely-monotone object.

Local verification against the pinned toolchain (`v4.32.0-rc1`): full `lake build` is green (`Build completed successfully (4022 jobs).`) and `lake exe axioms` is clean (`audited 3667 TauCeti declaration(s); all within the allowlist [propext, Classical.choice, Quot.sound].`).

<!--tauceti-target:v1 {"focus":"OneParameterSemigroups","id":"completely-monotone-product-closure"}-->

🤖 Prepared with Claude Code
