### PR TITLE
feat: the Alexander grading change across a grid rectangle

### DIFF
--- a/TauCeti/KnotTheory/Grid/GradingChange.lean
+++ b/TauCeti/KnotTheory/Grid/GradingChange.lean
@@ -19,15 +19,12 @@ plus the shared part, so the contribution of the `n - 2` shared squares is the *
 and for `y`. In the difference it cancels, leaving a formula in the four corners alone. For the
 `O`- and `X`-marking pairings this is `JO_source_sub_JO_target` and `JX_source_sub_JX_target`.
 
-Combining those rectangle-specific formulas with the general Alexander-difference identity from
-`Gradings.lean` gives the headline theorem `alexander_source_sub_alexander_target`: the
-Alexander grading change across a rectangle depends only on the four corners of `R` and the
-markings, never on the `n - 2` shared squares.
+Combining those rectangle-specific formulas with the grading definitions gives the headline
+theorem `alexander_source_sub_alexander_target`: the Alexander grading change across a rectangle
+depends only on the four corners of `R` and the markings, never on the `n - 2` shared squares.
 
 ## Main results
 
-* `TauCeti.GridState.J_pointSet_sub_J_swapColumns_pointSet`: the arbitrary column-swap
-  `J`-pairing change against a fixed point set.
 * `TauCeti.GridRectangleBetween.J_source_pointSet_eq`,
   `TauCeti.GridRectangleBetween.J_target_pointSet_eq`: the `J`-pairing of the source or target
   state against any point set splits as its two corners plus the shared part.
@@ -48,66 +45,6 @@ Ozsváth--Stipsicz--Szabó, *Grid Homology for Knots and Links*, Chapter 4.
 -/
 
 namespace TauCeti
-
-namespace GridState
-
-variable {n : ℕ} (x : GridState n) {a b : Fin n}
-
-/-- The `J`-pairing of a grid state against any point set splits as the contributions of its
-two squares in columns `a` and `b` plus the contribution of the squares it shares with the
-state obtained by swapping those columns. -/
-theorem J_pointSet_eq_of_swapColumns (h : a ≠ b) (s : Finset (Fin n × Fin n)) :
-    GridPoint.J x.pointSet s =
-      GridPoint.J {(a, x a)} s + GridPoint.J {(b, x b)} s +
-        GridPoint.J (x.pointSet ∩ (x.swapColumns a b).pointSet) s := by
-  have hb : (b, x b) ∉ x.pointSet ∩ (x.swapColumns a b).pointSet := by
-    rw [mem_pointSet_inter_swapColumns_iff x h]
-    rintro ⟨_, _, hb⟩
-    exact hb rfl
-  have ha : (a, x a) ∉
-      insert (b, x b) (x.pointSet ∩ (x.swapColumns a b).pointSet) := by
-    simp only [Finset.mem_insert, not_or]
-    exact ⟨fun hab => h (congrArg Prod.fst hab), by
-      rw [mem_pointSet_inter_swapColumns_iff x h]
-      rintro ⟨_, ha, _⟩
-      exact ha rfl⟩
-  conv_lhs => rw [pointSet_eq_insert_insert_inter_swapColumns x h]
-  rw [GridPoint.J_insert_left ha, GridPoint.J_insert_left hb]
-  ring
-
-/-- The `J`-pairing of a column-swapped grid state against any point set splits as the
-contributions of the two transported squares plus the contribution shared with the source
-state. -/
-theorem J_swapColumns_pointSet_eq (h : a ≠ b) (s : Finset (Fin n × Fin n)) :
-    GridPoint.J (x.swapColumns a b).pointSet s =
-      GridPoint.J {(a, x b)} s + GridPoint.J {(b, x a)} s +
-        GridPoint.J (x.pointSet ∩ (x.swapColumns a b).pointSet) s := by
-  have hb : (b, x a) ∉ x.pointSet ∩ (x.swapColumns a b).pointSet := by
-    rw [mem_pointSet_inter_swapColumns_iff x h]
-    rintro ⟨_, _, hb⟩
-    exact hb rfl
-  have ha : (a, x b) ∉
-      insert (b, x a) (x.pointSet ∩ (x.swapColumns a b).pointSet) := by
-    simp only [Finset.mem_insert, not_or]
-    exact ⟨fun hab => h (congrArg Prod.fst hab), by
-      rw [mem_pointSet_inter_swapColumns_iff x h]
-      rintro ⟨_, ha, _⟩
-      exact ha rfl⟩
-  conv_lhs => rw [swapColumns_pointSet_eq_insert_insert_inter x h]
-  rw [GridPoint.J_insert_left ha, GridPoint.J_insert_left hb]
-  ring
-
-/-- The change in the `J`-pairing against a fixed point set under an arbitrary swap of two
-columns. The squares shared by the two states cancel, leaving only the four affected column
-entries. -/
-theorem J_pointSet_sub_J_swapColumns_pointSet (h : a ≠ b) (s : Finset (Fin n × Fin n)) :
-    GridPoint.J x.pointSet s - GridPoint.J (x.swapColumns a b).pointSet s =
-      GridPoint.J {(a, x a)} s + GridPoint.J {(b, x b)} s -
-        GridPoint.J {(a, x b)} s - GridPoint.J {(b, x a)} s := by
-  rw [J_pointSet_eq_of_swapColumns x h s, J_swapColumns_pointSet_eq x h s]
-  ring
-
-end GridState
 
 namespace GridRectangleBetween
 
@@ -151,8 +88,8 @@ theorem J_source_sub_J_target (s : Finset (Fin n × Fin n)) :
     GridPoint.J x.pointSet s - GridPoint.J y.pointSet s =
       GridPoint.J {(R.left, R.bottom)} s + GridPoint.J {(R.right, R.top)} s -
         GridPoint.J {(R.left, R.top)} s - GridPoint.J {(R.right, R.bottom)} s := by
-  simpa [R.target_eq_swapColumns, bottom, top] using
-    GridState.J_pointSet_sub_J_swapColumns_pointSet x R.left_ne_right s
+  rw [R.J_source_pointSet_eq s, R.J_target_pointSet_eq s]
+  ring
 
 end GridRectangleBetween
 
@@ -188,7 +125,11 @@ theorem alexander_source_sub_alexander_target (R : GridRectangleBetween x y) :
           GridPoint.J {(R.left, R.top)} G.XSet - GridPoint.J {(R.right, R.bottom)} G.XSet) -
         (GridPoint.J {(R.left, R.bottom)} G.OSet + GridPoint.J {(R.right, R.top)} G.OSet -
           GridPoint.J {(R.left, R.top)} G.OSet - GridPoint.J {(R.right, R.bottom)} G.OSet) := by
-  rw [G.alexander_sub_eq_JX_sub_JO x y, G.JX_source_sub_JX_target R, G.JO_source_sub_JO_target R]
+  have hAlexander :
+      G.alexander x - G.alexander y = (G.JX x - G.JX y) - (G.JO x - G.JO y) := by
+    rw [alexander_def, alexander_def, maslovO_eq, maslovX_eq, maslovO_eq, maslovX_eq]
+    ring
+  rw [hAlexander, G.JX_source_sub_JX_target R, G.JO_source_sub_JO_target R]
 
 end GridDiagram
 

--- a/TauCeti/KnotTheory/Grid/GradingChange.lean
+++ b/TauCeti/KnotTheory/Grid/GradingChange.lean
@@ -18,10 +18,11 @@ plus the shared part, so the contribution of the `n - 2` shared squares is the *
 and for `y`. In the difference it cancels, leaving a formula in the four corners alone. For the
 `O`- and `X`-marking pairings this is `JO_source_sub_JO_target` and `JX_source_sub_JX_target`.
 
-The Alexander grading is `A = (M_O - M_X) / 2 - (n - 1) / 2`, and after expanding the two Maslov
-gradings the self-pairing `J(x, x)` and the grid-size shift cancel between `x` and `y`, so the
-grading change `A(x) - A(y)` reduces to `(JX x - JX y) - (JO x - JO y)`
-(`alexander_sub_eq_JX_sub_JO`). Combining the two pieces gives the headline four-corner formula
+The general identity `alexander_sub_eq_JX_sub_JO` from `Gradings.lean` rewrites
+`A(x) - A(y)` as `(JX x - JX y) - (JO x - JO y)`: in the expanded Maslov formulas,
+`J(z, z)` cancels inside each state's `M_O(z) - M_X(z)`, while the marking self-pairings and
+normalization shift cancel between the two Alexander gradings. Combining that with the
+rectangle-specific `J`-pairing formulas gives the headline four-corner formula
 `alexander_source_sub_alexander_target`: the Alexander grading change across a rectangle depends
 only on the four corners of `R` and the markings, never on the `n - 2` shared squares.
 
@@ -35,8 +36,6 @@ only on the four corners of `R` and the markings, never on the `n - 2` shared sq
 * `TauCeti.GridDiagram.JO_source_sub_JO_target`,
   `TauCeti.GridDiagram.JX_source_sub_JX_target`: the four-corner formula for the `O`- and
   `X`-marking pairings.
-* `TauCeti.GridDiagram.alexander_sub_eq_JX_sub_JO`: the Alexander grading change in terms of the
-  two marking pairings.
 * `TauCeti.GridDiagram.alexander_source_sub_alexander_target`: the four-corner formula for the
   Alexander grading change across a rectangle.
 
@@ -118,16 +117,6 @@ theorem JX_source_sub_JX_target (R : GridRectangleBetween x y) :
         GridPoint.J {(R.left, R.top)} G.XSet - GridPoint.J {(R.right, R.bottom)} G.XSet := by
   rw [JX_def, JX_def]
   exact R.J_source_sub_J_target G.XSet
-
-/-- The Alexander grading change between two grid states is the change in the `X`-marking pairing
-minus the change in the `O`-marking pairing. Expanding the two Maslov gradings, the common
-self-pairing `J(x, x)` and the grid-size normalization shift cancel, leaving only the two marking
-pairings. This holds for any two states; across a rectangle it combines with the four-corner
-formulas above. -/
-theorem alexander_sub_eq_JX_sub_JO (x y : GridState n) :
-    G.alexander x - G.alexander y = (G.JX x - G.JX y) - (G.JO x - G.JO y) := by
-  rw [alexander_def, alexander_def, maslovO_eq, maslovX_eq, maslovO_eq, maslovX_eq]
-  ring
 
 /-- The Alexander grading change across a rectangle, as a four-corner formula: it is the
 alternating sum over the four corners of the `X`-marking pairing minus the same alternating sum of

--- a/TauCeti/KnotTheory/Grid/GradingChange.lean
+++ b/TauCeti/KnotTheory/Grid/GradingChange.lean
@@ -1,0 +1,146 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+import TauCeti.KnotTheory.Grid.RectangleSwap
+import TauCeti.KnotTheory.Grid.Gradings
+
+/-!
+# The Alexander grading change across a grid rectangle
+
+A rectangle `R : GridRectangleBetween x y` exchanges two side columns of the source state `x`,
+so the two point sets `x` and `y` agree on `n - 2` shared squares and differ only at the four
+corners of `R`. `RectangleSwap.lean` records this decomposition; here we feed it through the
+`J`-function additivity (`JFunction.lean`) to read off how the gradings change from `x` to `y`.
+
+The `J`-pairing of a state against a fixed marking set is additive over the disjoint corners
+plus the shared part, so the contribution of the `n - 2` shared squares is the *same* for `x`
+and for `y`. In the difference it cancels, leaving a formula in the four corners alone. For the
+`O`- and `X`-marking pairings this is `JO_source_sub_JO_target` and `JX_source_sub_JX_target`.
+
+The Alexander grading is `A = (M_O - M_X) / 2 - (n - 1) / 2`, and after expanding the two Maslov
+gradings the self-pairing `J(x, x)` and the grid-size shift cancel between `x` and `y`, so the
+grading change `A(x) - A(y)` reduces to `(JX x - JX y) - (JO x - JO y)`
+(`alexander_sub_eq_JX_sub_JO`). Combining the two pieces gives the headline four-corner formula
+`alexander_source_sub_alexander_target`: the Alexander grading change across a rectangle depends
+only on the four corners of `R` and the markings, never on the `n - 2` shared squares.
+
+## Main results
+
+* `TauCeti.GridRectangleBetween.J_source_pointSet_eq`,
+  `TauCeti.GridRectangleBetween.J_target_pointSet_eq`: the `J`-pairing of the source or target
+  state against any point set splits as its two corners plus the shared part.
+* `TauCeti.GridRectangleBetween.J_source_sub_J_target`: the corresponding difference, with the
+  shared part cancelled.
+* `TauCeti.GridDiagram.JO_source_sub_JO_target`,
+  `TauCeti.GridDiagram.JX_source_sub_JX_target`: the four-corner formula for the `O`- and
+  `X`-marking pairings.
+* `TauCeti.GridDiagram.alexander_sub_eq_JX_sub_JO`: the Alexander grading change in terms of the
+  two marking pairings.
+* `TauCeti.GridDiagram.alexander_source_sub_alexander_target`: the four-corner formula for the
+  Alexander grading change across a rectangle.
+
+## References
+
+This advances `TauCetiRoadmap/CombinatorialHeegaardFloer/README.md`, Lane G item 2 ("Gradings.
+[...] grading-change formulas across a rectangle"), building on the corner/shared-square
+decomposition that `RectangleSwap.lean` was written to support. The formula follows
+Ozsváth--Stipsicz--Szabó, *Grid Homology for Knots and Links*, Chapter 4.
+-/
+
+namespace TauCeti
+
+namespace GridRectangleBetween
+
+variable {n : ℕ} {x y : GridState n} (R : GridRectangleBetween x y)
+
+/-- The `J`-pairing of the source state against any point set splits as the contributions of its
+two source corners `(R.left, R.bottom)` and `(R.right, R.top)` plus the contribution of the
+`n - 2` squares it shares with the target state. -/
+theorem J_source_pointSet_eq (s : Finset (Fin n × Fin n)) :
+    GridPoint.J x.pointSet s =
+      GridPoint.J {(R.left, R.bottom)} s + GridPoint.J {(R.right, R.top)} s +
+        GridPoint.J (x.pointSet ∩ y.pointSet) s := by
+  have hb : (R.right, R.top) ∉ x.pointSet ∩ y.pointSet := R.right_top_notMem_inter
+  have ha : (R.left, R.bottom) ∉
+      insert (R.right, R.top) (x.pointSet ∩ y.pointSet) := by
+    simp only [Finset.mem_insert, not_or]
+    exact ⟨fun h => R.left_ne_right (congrArg Prod.fst h), R.left_bottom_notMem_inter⟩
+  conv_lhs => rw [R.source_pointSet_eq]
+  rw [GridPoint.J_insert_left ha, GridPoint.J_insert_left hb]
+  ring
+
+/-- The `J`-pairing of the target state against any point set splits as the contributions of its
+two target corners `(R.left, R.top)` and `(R.right, R.bottom)` plus the contribution of the
+`n - 2` squares it shares with the source state. -/
+theorem J_target_pointSet_eq (s : Finset (Fin n × Fin n)) :
+    GridPoint.J y.pointSet s =
+      GridPoint.J {(R.left, R.top)} s + GridPoint.J {(R.right, R.bottom)} s +
+        GridPoint.J (x.pointSet ∩ y.pointSet) s := by
+  have hd : (R.right, R.bottom) ∉ x.pointSet ∩ y.pointSet := R.right_bottom_notMem_inter
+  have hc : (R.left, R.top) ∉
+      insert (R.right, R.bottom) (x.pointSet ∩ y.pointSet) := by
+    simp only [Finset.mem_insert, not_or]
+    exact ⟨fun h => R.left_ne_right (congrArg Prod.fst h), R.left_top_notMem_inter⟩
+  conv_lhs => rw [R.target_pointSet_eq]
+  rw [GridPoint.J_insert_left hc, GridPoint.J_insert_left hd]
+  ring
+
+/-- The change in the `J`-pairing against a fixed point set from the source state to the target
+state of a rectangle, with the shared `n - 2` squares cancelled: only the four corners remain. -/
+theorem J_source_sub_J_target (s : Finset (Fin n × Fin n)) :
+    GridPoint.J x.pointSet s - GridPoint.J y.pointSet s =
+      GridPoint.J {(R.left, R.bottom)} s + GridPoint.J {(R.right, R.top)} s -
+        GridPoint.J {(R.left, R.top)} s - GridPoint.J {(R.right, R.bottom)} s := by
+  rw [R.J_source_pointSet_eq s, R.J_target_pointSet_eq s]
+  ring
+
+end GridRectangleBetween
+
+namespace GridDiagram
+
+variable {n : ℕ} (G : GridDiagram n) {x y : GridState n}
+
+/-- The change in the `O`-marking `J`-pairing across a rectangle is determined by the four
+corners alone. -/
+theorem JO_source_sub_JO_target (R : GridRectangleBetween x y) :
+    G.JO x - G.JO y =
+      GridPoint.J {(R.left, R.bottom)} G.OSet + GridPoint.J {(R.right, R.top)} G.OSet -
+        GridPoint.J {(R.left, R.top)} G.OSet - GridPoint.J {(R.right, R.bottom)} G.OSet := by
+  rw [JO_def, JO_def]
+  exact R.J_source_sub_J_target G.OSet
+
+/-- The change in the `X`-marking `J`-pairing across a rectangle is determined by the four
+corners alone. -/
+theorem JX_source_sub_JX_target (R : GridRectangleBetween x y) :
+    G.JX x - G.JX y =
+      GridPoint.J {(R.left, R.bottom)} G.XSet + GridPoint.J {(R.right, R.top)} G.XSet -
+        GridPoint.J {(R.left, R.top)} G.XSet - GridPoint.J {(R.right, R.bottom)} G.XSet := by
+  rw [JX_def, JX_def]
+  exact R.J_source_sub_J_target G.XSet
+
+/-- The Alexander grading change between two grid states is the change in the `X`-marking pairing
+minus the change in the `O`-marking pairing. Expanding the two Maslov gradings, the common
+self-pairing `J(x, x)` and the grid-size normalization shift cancel, leaving only the two marking
+pairings. This holds for any two states; across a rectangle it combines with the four-corner
+formulas above. -/
+theorem alexander_sub_eq_JX_sub_JO (x y : GridState n) :
+    G.alexander x - G.alexander y = (G.JX x - G.JX y) - (G.JO x - G.JO y) := by
+  rw [alexander_def, alexander_def, maslovO_eq, maslovX_eq, maslovO_eq, maslovX_eq]
+  ring
+
+/-- The Alexander grading change across a rectangle, as a four-corner formula: it is the
+alternating sum over the four corners of the `X`-marking pairing minus the same alternating sum of
+the `O`-marking pairing. In particular it depends only on the four corners of the rectangle and
+the markings, not on the `n - 2` squares the source and target states share. -/
+theorem alexander_source_sub_alexander_target (R : GridRectangleBetween x y) :
+    G.alexander x - G.alexander y =
+      (GridPoint.J {(R.left, R.bottom)} G.XSet + GridPoint.J {(R.right, R.top)} G.XSet -
+          GridPoint.J {(R.left, R.top)} G.XSet - GridPoint.J {(R.right, R.bottom)} G.XSet) -
+        (GridPoint.J {(R.left, R.bottom)} G.OSet + GridPoint.J {(R.right, R.top)} G.OSet -
+          GridPoint.J {(R.left, R.top)} G.OSet - GridPoint.J {(R.right, R.bottom)} G.OSet) := by
+  rw [G.alexander_sub_eq_JX_sub_JO x y, G.JX_source_sub_JX_target R, G.JO_source_sub_JO_target R]
+
+end GridDiagram
+
+end TauCeti

--- a/TauCeti/KnotTheory/Grid/GradingChange.lean
+++ b/TauCeti/KnotTheory/Grid/GradingChange.lean
@@ -11,21 +11,18 @@ import TauCeti.KnotTheory.Grid.Gradings
 
 A rectangle `R : GridRectangleBetween x y` exchanges two side columns of the source state `x`,
 so the two point sets `x` and `y` agree on `n - 2` shared squares and differ only at the four
-corners of `R`. `RectangleSwap.lean` records this decomposition; here we feed it through the
-`J`-function additivity (`JFunction.lean`) to read off how the gradings change from `x` to `y`.
+corners of `R`. This file turns that corner/shared-square decomposition into four-corner
+formulas for the change in `J`-pairings and in the Alexander grading.
 
 The `J`-pairing of a state against a fixed marking set is additive over the disjoint corners
 plus the shared part, so the contribution of the `n - 2` shared squares is the *same* for `x`
 and for `y`. In the difference it cancels, leaving a formula in the four corners alone. For the
 `O`- and `X`-marking pairings this is `JO_source_sub_JO_target` and `JX_source_sub_JX_target`.
 
-The general identity `alexander_sub_eq_JX_sub_JO` from `Gradings.lean` rewrites
-`A(x) - A(y)` as `(JX x - JX y) - (JO x - JO y)`: in the expanded Maslov formulas,
-`J(z, z)` cancels inside each state's `M_O(z) - M_X(z)`, while the marking self-pairings and
-normalization shift cancel between the two Alexander gradings. Combining that with the
-rectangle-specific `J`-pairing formulas gives the headline four-corner formula
-`alexander_source_sub_alexander_target`: the Alexander grading change across a rectangle depends
-only on the four corners of `R` and the markings, never on the `n - 2` shared squares.
+Combining those rectangle-specific formulas with the general Alexander-difference identity from
+`Gradings.lean` gives the headline theorem `alexander_source_sub_alexander_target`: the
+Alexander grading change across a rectangle depends only on the four corners of `R` and the
+markings, never on the `n - 2` shared squares.
 
 ## Main results
 

--- a/TauCeti/KnotTheory/Grid/GradingChange.lean
+++ b/TauCeti/KnotTheory/Grid/GradingChange.lean
@@ -2,6 +2,7 @@
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 -/
+import Mathlib.Tactic.Ring
 import TauCeti.KnotTheory.Grid.RectangleSwap
 import TauCeti.KnotTheory.Grid.Gradings
 

--- a/TauCeti/KnotTheory/Grid/GradingChange.lean
+++ b/TauCeti/KnotTheory/Grid/GradingChange.lean
@@ -33,6 +33,8 @@ depends only on the four corners of `R` and the markings, never on the `n - 2` s
 * `TauCeti.GridDiagram.JO_source_sub_JO_target`,
   `TauCeti.GridDiagram.JX_source_sub_JX_target`: the four-corner formula for the `O`- and
   `X`-marking pairings.
+* `TauCeti.GridDiagram.alexander_sub_alexander_eq_JX_sub_JX_sub_JO_sub_JO`: the general
+  Alexander grading difference in terms of the `X`- and `O`-marking pairings.
 * `TauCeti.GridDiagram.alexander_source_sub_alexander_target`: the four-corner formula for the
   Alexander grading change across a rectangle.
 
@@ -115,6 +117,14 @@ theorem JX_source_sub_JX_target (R : GridRectangleBetween x y) :
   rw [JX_def, JX_def]
   exact R.J_source_sub_J_target G.XSet
 
+/-- The difference of Alexander gradings of two grid states is the corresponding difference of
+the `X`-marking pairings minus the corresponding difference of the `O`-marking pairings. The
+normalization shift in the Alexander grading cancels in the difference. -/
+theorem alexander_sub_alexander_eq_JX_sub_JX_sub_JO_sub_JO (x y : GridState n) :
+    G.alexander x - G.alexander y = (G.JX x - G.JX y) - (G.JO x - G.JO y) := by
+  rw [alexander_def, alexander_def, maslovO_eq, maslovX_eq, maslovO_eq, maslovX_eq]
+  ring
+
 /-- The Alexander grading change across a rectangle, as a four-corner formula: it is the
 alternating sum over the four corners of the `X`-marking pairing minus the same alternating sum of
 the `O`-marking pairing. In particular it depends only on the four corners of the rectangle and
@@ -125,11 +135,8 @@ theorem alexander_source_sub_alexander_target (R : GridRectangleBetween x y) :
           GridPoint.J {(R.left, R.top)} G.XSet - GridPoint.J {(R.right, R.bottom)} G.XSet) -
         (GridPoint.J {(R.left, R.bottom)} G.OSet + GridPoint.J {(R.right, R.top)} G.OSet -
           GridPoint.J {(R.left, R.top)} G.OSet - GridPoint.J {(R.right, R.bottom)} G.OSet) := by
-  have hAlexander :
-      G.alexander x - G.alexander y = (G.JX x - G.JX y) - (G.JO x - G.JO y) := by
-    rw [alexander_def, alexander_def, maslovO_eq, maslovX_eq, maslovO_eq, maslovX_eq]
-    ring
-  rw [hAlexander, G.JX_source_sub_JX_target R, G.JO_source_sub_JO_target R]
+  rw [G.alexander_sub_alexander_eq_JX_sub_JX_sub_JO_sub_JO x y,
+    G.JX_source_sub_JX_target R, G.JO_source_sub_JO_target R]
 
 end GridDiagram
 

--- a/TauCeti/KnotTheory/Grid/GradingChange.lean
+++ b/TauCeti/KnotTheory/Grid/GradingChange.lean
@@ -26,6 +26,8 @@ markings, never on the `n - 2` shared squares.
 
 ## Main results
 
+* `TauCeti.GridState.J_pointSet_sub_J_swapColumns_pointSet`: the arbitrary column-swap
+  `J`-pairing change against a fixed point set.
 * `TauCeti.GridRectangleBetween.J_source_pointSet_eq`,
   `TauCeti.GridRectangleBetween.J_target_pointSet_eq`: the `J`-pairing of the source or target
   state against any point set splits as its two corners plus the shared part.
@@ -46,6 +48,66 @@ Ozsváth--Stipsicz--Szabó, *Grid Homology for Knots and Links*, Chapter 4.
 -/
 
 namespace TauCeti
+
+namespace GridState
+
+variable {n : ℕ} (x : GridState n) {a b : Fin n}
+
+/-- The `J`-pairing of a grid state against any point set splits as the contributions of its
+two squares in columns `a` and `b` plus the contribution of the squares it shares with the
+state obtained by swapping those columns. -/
+theorem J_pointSet_eq_of_swapColumns (h : a ≠ b) (s : Finset (Fin n × Fin n)) :
+    GridPoint.J x.pointSet s =
+      GridPoint.J {(a, x a)} s + GridPoint.J {(b, x b)} s +
+        GridPoint.J (x.pointSet ∩ (x.swapColumns a b).pointSet) s := by
+  have hb : (b, x b) ∉ x.pointSet ∩ (x.swapColumns a b).pointSet := by
+    rw [mem_pointSet_inter_swapColumns_iff x h]
+    rintro ⟨_, _, hb⟩
+    exact hb rfl
+  have ha : (a, x a) ∉
+      insert (b, x b) (x.pointSet ∩ (x.swapColumns a b).pointSet) := by
+    simp only [Finset.mem_insert, not_or]
+    exact ⟨fun hab => h (congrArg Prod.fst hab), by
+      rw [mem_pointSet_inter_swapColumns_iff x h]
+      rintro ⟨_, ha, _⟩
+      exact ha rfl⟩
+  conv_lhs => rw [pointSet_eq_insert_insert_inter_swapColumns x h]
+  rw [GridPoint.J_insert_left ha, GridPoint.J_insert_left hb]
+  ring
+
+/-- The `J`-pairing of a column-swapped grid state against any point set splits as the
+contributions of the two transported squares plus the contribution shared with the source
+state. -/
+theorem J_swapColumns_pointSet_eq (h : a ≠ b) (s : Finset (Fin n × Fin n)) :
+    GridPoint.J (x.swapColumns a b).pointSet s =
+      GridPoint.J {(a, x b)} s + GridPoint.J {(b, x a)} s +
+        GridPoint.J (x.pointSet ∩ (x.swapColumns a b).pointSet) s := by
+  have hb : (b, x a) ∉ x.pointSet ∩ (x.swapColumns a b).pointSet := by
+    rw [mem_pointSet_inter_swapColumns_iff x h]
+    rintro ⟨_, _, hb⟩
+    exact hb rfl
+  have ha : (a, x b) ∉
+      insert (b, x a) (x.pointSet ∩ (x.swapColumns a b).pointSet) := by
+    simp only [Finset.mem_insert, not_or]
+    exact ⟨fun hab => h (congrArg Prod.fst hab), by
+      rw [mem_pointSet_inter_swapColumns_iff x h]
+      rintro ⟨_, ha, _⟩
+      exact ha rfl⟩
+  conv_lhs => rw [swapColumns_pointSet_eq_insert_insert_inter x h]
+  rw [GridPoint.J_insert_left ha, GridPoint.J_insert_left hb]
+  ring
+
+/-- The change in the `J`-pairing against a fixed point set under an arbitrary swap of two
+columns. The squares shared by the two states cancel, leaving only the four affected column
+entries. -/
+theorem J_pointSet_sub_J_swapColumns_pointSet (h : a ≠ b) (s : Finset (Fin n × Fin n)) :
+    GridPoint.J x.pointSet s - GridPoint.J (x.swapColumns a b).pointSet s =
+      GridPoint.J {(a, x a)} s + GridPoint.J {(b, x b)} s -
+        GridPoint.J {(a, x b)} s - GridPoint.J {(b, x a)} s := by
+  rw [J_pointSet_eq_of_swapColumns x h s, J_swapColumns_pointSet_eq x h s]
+  ring
+
+end GridState
 
 namespace GridRectangleBetween
 
@@ -89,8 +151,8 @@ theorem J_source_sub_J_target (s : Finset (Fin n × Fin n)) :
     GridPoint.J x.pointSet s - GridPoint.J y.pointSet s =
       GridPoint.J {(R.left, R.bottom)} s + GridPoint.J {(R.right, R.top)} s -
         GridPoint.J {(R.left, R.top)} s - GridPoint.J {(R.right, R.bottom)} s := by
-  rw [R.J_source_pointSet_eq s, R.J_target_pointSet_eq s]
-  ring
+  simpa [R.target_eq_swapColumns, bottom, top] using
+    GridState.J_pointSet_sub_J_swapColumns_pointSet x R.left_ne_right s
 
 end GridRectangleBetween
 

--- a/TauCeti/KnotTheory/Grid/Gradings.lean
+++ b/TauCeti/KnotTheory/Grid/Gradings.lean
@@ -34,6 +34,9 @@ rectangle-change theorems can refer to these names without unfolding the point-p
   two Maslov gradings are exchanged by the marking swap.
 * `TauCeti.GridDiagram.alexander_swapMarkings`: the Alexander grading is negated up to the
   normalization shift under the marking swap.
+* `TauCeti.GridDiagram.alexander_sub_eq_JX_sub_JO`: the Alexander grading difference between
+  any two states is the corresponding `X`-marking `J`-pairing difference minus the
+  `O`-marking one.
 
 ## References
 
@@ -107,6 +110,15 @@ theorem alexander_eq (x : GridState n) :
       (2 * (G.JX x - G.JO x) + (GridState.J G.O G.O - GridState.J G.X G.X) -
         (((n : ℤ) - 1 : ℤ) : ℚ)) / 2 := by
   rw [alexander, maslovO_eq, maslovX_eq]
+  ring
+
+/-- The Alexander grading change between two grid states is the change in the `X`-marking pairing
+minus the change in the `O`-marking pairing. In the expanded Maslov formulas,
+`GridState.J z z` cancels inside `M_O(z) - M_X(z)` for each state `z`, while the marking
+self-pairings and the normalization shift cancel between the two Alexander gradings. -/
+theorem alexander_sub_eq_JX_sub_JO (x y : GridState n) :
+    G.alexander x - G.alexander y = (G.JX x - G.JX y) - (G.JO x - G.JO y) := by
+  rw [alexander_def, alexander_def, maslovO_eq, maslovX_eq, maslovO_eq, maslovX_eq]
   ring
 
 /-- The difference of the two Maslov gradings is twice the Alexander grading plus the

--- a/TauCeti/KnotTheory/Grid/Gradings.lean
+++ b/TauCeti/KnotTheory/Grid/Gradings.lean
@@ -113,9 +113,7 @@ theorem alexander_eq (x : GridState n) :
   ring
 
 /-- The Alexander grading change between two grid states is the change in the `X`-marking pairing
-minus the change in the `O`-marking pairing. In the expanded Maslov formulas,
-`GridState.J z z` cancels inside `M_O(z) - M_X(z)` for each state `z`, while the marking
-self-pairings and the normalization shift cancel between the two Alexander gradings. -/
+minus the change in the `O`-marking pairing. -/
 theorem alexander_sub_eq_JX_sub_JO (x y : GridState n) :
     G.alexander x - G.alexander y = (G.JX x - G.JX y) - (G.JO x - G.JO y) := by
   rw [alexander_def, alexander_def, maslovO_eq, maslovX_eq, maslovO_eq, maslovX_eq]

--- a/TauCeti/KnotTheory/Grid/Gradings.lean
+++ b/TauCeti/KnotTheory/Grid/Gradings.lean
@@ -34,9 +34,6 @@ rectangle-change theorems can refer to these names without unfolding the point-p
   two Maslov gradings are exchanged by the marking swap.
 * `TauCeti.GridDiagram.alexander_swapMarkings`: the Alexander grading is negated up to the
   normalization shift under the marking swap.
-* `TauCeti.GridDiagram.alexander_sub_eq_JX_sub_JO`: the Alexander grading difference between
-  any two states is the corresponding `X`-marking `J`-pairing difference minus the
-  `O`-marking one.
 
 ## References
 
@@ -110,13 +107,6 @@ theorem alexander_eq (x : GridState n) :
       (2 * (G.JX x - G.JO x) + (GridState.J G.O G.O - GridState.J G.X G.X) -
         (((n : ℤ) - 1 : ℤ) : ℚ)) / 2 := by
   rw [alexander, maslovO_eq, maslovX_eq]
-  ring
-
-/-- The Alexander grading change between two grid states is the change in the `X`-marking pairing
-minus the change in the `O`-marking pairing. -/
-theorem alexander_sub_eq_JX_sub_JO (x y : GridState n) :
-    G.alexander x - G.alexander y = (G.JX x - G.JX y) - (G.JO x - G.JO y) := by
-  rw [alexander_def, alexander_def, maslovO_eq, maslovX_eq, maslovO_eq, maslovX_eq]
   ring
 
 /-- The difference of the two Maslov gradings is twice the Alexander grading plus the


### PR DESCRIPTION
This PR proves the Alexander grading change across a grid rectangle as an explicit four-corner formula, advancing Lane G item 2 of `TauCetiRoadmap/CombinatorialHeegaardFloer/README.md` ("Gradings. [...] grading-change formulas across a rectangle"). A rectangle `R : GridRectangleBetween x y` swaps two side columns of the source state, so the source and target point sets agree on `n - 2` shared squares and differ only at the four corners of `R`. The `J`-pairing of a state against a fixed marking set is additive over those corners plus the shared part, so the shared contribution is identical for `x` and `y` and cancels in the difference, and after expanding the two Maslov gradings the self-pairing `J(x, x)` and the grid-size normalization shift cancel too. The headline `GridDiagram.alexander_source_sub_alexander_target` reads off `A(x) - A(y)` as the alternating sum over the four corners of the `X`-marking pairing minus the same alternating sum of the `O`-marking pairing, manifestly independent of the shared squares; the reusable steps are `GridRectangleBetween.J_source_sub_J_target`, `GridDiagram.JO_source_sub_JO_target`, `GridDiagram.JX_source_sub_JX_target`, and `GridDiagram.alexander_sub_eq_JX_sub_JO`.

This builds directly on the corner/shared-square decomposition (`source_pointSet_eq`, `target_pointSet_eq`) that `RectangleSwap.lean` was written to support, and on the `J`-function additivity in `JFunction.lean`. It vendors no Mathlib infrastructure. The formula follows Ozsváth--Stipsicz--Szabó, *Grid Homology for Knots and Links*, Chapter 4.

`lake build` and `lake exe axioms` are green: `axioms: audited 3673 TauCeti declaration(s); all within the allowlist [propext, Classical.choice, Quot.sound].`

<!--tauceti-target:v1 {"focus":"CombinatorialHeegaardFloer","id":"alexander-grading-change-across-rectangle"}-->

🤖 Prepared with Claude Code
