### PR TITLE
feat: add the abstract Abel-Jacobi divisor class

### DIFF
--- a/TauCeti/AlgebraicGeometry/WeilDivisor.lean
+++ b/TauCeti/AlgebraicGeometry/WeilDivisor.lean
@@ -477,6 +477,68 @@ lemma pointDifference_mem_weightedDegreeZeroSubgroup {w : X → ℤ} {x y : X}
     (h : w x = w y) : pointDifference x y ∈ weightedDegreeZeroSubgroup w := by
   simp [h]
 
+/-! ### Degree-corrected point divisors -/
+
+/-- The divisor `[x] - w(x)[x₀]`.
+
+For the geometric weight `w x = [κ(x) : k]` and a rational base point `x₀` with `w x₀ = 1`,
+this is the degree-zero divisor underlying the Abel-Jacobi class of the closed point `x`.
+In the algebraically closed/unweighted specialization, this recovers `pointDifference x x₀`. -/
+noncomputable def weightedPointBaseDifference (w : X → ℤ) (x₀ x : X) : WeilDivisor X :=
+  ofPoint x - w x • ofPoint x₀
+
+/-- At the constant weight `1`, the degree-corrected point divisor is the usual point
+difference. This simp lemma lets unweighted API reuse the weighted construction. -/
+@[simp]
+lemma weightedPointBaseDifference_eq_pointDifference (x₀ x : X) :
+    weightedPointBaseDifference (fun _ : X => (1 : ℤ)) x₀ x = pointDifference x x₀ := by
+  simp [weightedPointBaseDifference, pointDifference]
+
+/-- Coefficients of the degree-corrected point divisor, used as the pointwise simp form of
+`weightedPointBaseDifference`. -/
+@[simp]
+lemma coeff_weightedPointBaseDifference [DecidableEq X] (w : X → ℤ) (x₀ x y : X) :
+    coeff (weightedPointBaseDifference w x₀ x) y =
+      (if y = x then 1 else 0) - if y = x₀ then w x else 0 := by
+  by_cases hyx : y = x
+  · subst y
+    by_cases hx₀ : x = x₀ <;> simp [weightedPointBaseDifference, ofPoint, coeff, hx₀]
+  · by_cases hy₀ : y = x₀
+    · subst y
+      have hx₀ : x₀ ≠ x := by simpa using hyx
+      simp [weightedPointBaseDifference, ofPoint, coeff, hx₀]
+    · simp [weightedPointBaseDifference, ofPoint, coeff, hyx, hy₀]
+
+/-- The support of `[x] - w(x)[x₀]` is contained in `{x, x₀}`. -/
+lemma support_weightedPointBaseDifference_subset [DecidableEq X] (w : X → ℤ) (x₀ x : X) :
+    (weightedPointBaseDifference w x₀ x).support ⊆ {x, x₀} := by
+  intro y hy
+  rw [Finset.mem_insert, Finset.mem_singleton]
+  by_contra hyx
+  push Not at hyx
+  exact Finsupp.mem_support_iff.mp hy (by
+    simp [weightedPointBaseDifference, ofPoint, hyx.1, hyx.2])
+
+/-- If the base point has weight `1`, the divisor `[x₀] - w(x₀)[x₀]` is zero. -/
+@[simp]
+lemma weightedPointBaseDifference_self {w : X → ℤ} {x₀ : X} (hx₀ : w x₀ = 1) :
+    weightedPointBaseDifference w x₀ x₀ = 0 := by
+  simp [weightedPointBaseDifference, hx₀]
+
+/-- The weighted degree of `[x] - w(x)[x₀]` is `w(x) * (1 - w(x₀))`. -/
+@[simp]
+lemma weightedDegree_weightedPointBaseDifference (w : X → ℤ) (x₀ x : X) :
+    weightedDegree w (weightedPointBaseDifference w x₀ x) = w x * (1 - w x₀) := by
+  simp [weightedPointBaseDifference]
+  ring
+
+/-- If the base point has weight `1`, then `[x] - w(x)[x₀]` has weighted degree zero. -/
+@[simp]
+lemma weightedPointBaseDifference_mem_weightedDegreeZeroSubgroup {w : X → ℤ} {x₀ : X}
+    (hx₀ : w x₀ = 1) (x : X) :
+    weightedPointBaseDifference w x₀ x ∈ weightedDegreeZeroSubgroup w := by
+  simp [hx₀]
+
 /-- Pushforward as a homomorphism on weighted degree-zero divisors, when the target weight
 pulls back to the source weight. -/
 noncomputable def pushforwardWeightedDegreeZero (wX : X → ℤ) (wY : Y → ℤ) (f : X → Y)

--- a/TauCeti/AlgebraicGeometry/WeilDivisor/AbelJacobi.lean
+++ b/TauCeti/AlgebraicGeometry/WeilDivisor/AbelJacobi.lean
@@ -1,0 +1,215 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+import TauCeti.AlgebraicGeometry.WeilDivisor.Principal
+
+/-!
+# The abstract Abel-Jacobi divisor class map
+
+This file adds the point-level divisor-class shadow of the Abel-Jacobi map to the formal
+Layer A divisor API.  Once the Jacobian is constructed as `Pic⁰(X)`, the Abel-Jacobi morphism
+attached to a base point `x₀` sends a point `x` to the degree-zero line bundle
+`𝒪_X(x - x₀)` over an algebraically closed field.  For closed points over a non-algebraically
+closed field, the degree-corrected divisor is `x - deg(x) x₀`, when `x₀` has residue degree
+`1`.
+
+Here the geometry is still abstracted to an `OrderSystem` and an integer-valued weight
+`w : X → ℤ`.  We define the formal divisor `[x] - w(x)[x₀]`, prove it has weighted degree zero
+when `w x₀ = 1`, and take its divisor class as an element of the abstract `Pic⁰` subgroup
+already built in `WeilDivisor.Principal`.  The unweighted specialization recovers
+`x ↦ [x] - [x₀]`.
+
+This advances `TauCetiRoadmap/JacobianChallenge/README.md`, Layer A (`Pic⁰ X = ker deg`) as a
+direct prerequisite for Layer F's Abel-Jacobi morphism `aj : X ⟶ Jac X`, while staying at the
+formal divisor-class level available before line bundles, the Picard scheme, or the Jacobian
+variety exist.  No external mathematics is vendored; this reuses Tau Ceti's `WeilDivisor`,
+`OrderSystem.divisorClass`, and `OrderSystem.picZero` API.
+-/
+
+namespace TauCeti
+
+namespace AlgebraicGeometry
+
+namespace WeilDivisor
+
+variable {X G : Type*} [AddCommGroup G]
+
+/-! ### Degree-corrected point divisors -/
+
+/-- The divisor `[x] - w(x)[x₀]`.
+
+For the geometric weight `w x = [κ(x) : k]` and a rational base point `x₀` with `w x₀ = 1`,
+this is the degree-zero divisor underlying the Abel-Jacobi class of the closed point `x`.
+In the algebraically closed/unweighted specialization, use
+`unweightedPointBaseDifference`, which is definitionally `[x] - [x₀]`. -/
+noncomputable def weightedPointBaseDifference (w : X → ℤ) (x₀ x : X) : WeilDivisor X :=
+  ofPoint x - w x • ofPoint x₀
+
+@[simp]
+lemma weightedPointBaseDifference_eq_pointDifference (x₀ x : X) :
+    weightedPointBaseDifference (fun _ : X => (1 : ℤ)) x₀ x = pointDifference x x₀ := by
+  simp [weightedPointBaseDifference, pointDifference]
+
+@[simp]
+lemma coeff_weightedPointBaseDifference [DecidableEq X] (w : X → ℤ) (x₀ x y : X) :
+    coeff (weightedPointBaseDifference w x₀ x) y =
+      (if y = x then 1 else 0) - if y = x₀ then w x else 0 := by
+  by_cases hyx : y = x
+  · subst y
+    by_cases hx₀ : x = x₀ <;> simp [weightedPointBaseDifference, ofPoint, coeff, hx₀]
+  · by_cases hy₀ : y = x₀
+    · subst y
+      have hx₀ : x₀ ≠ x := by simpa using hyx
+      simp [weightedPointBaseDifference, ofPoint, coeff, hx₀]
+    · simp [weightedPointBaseDifference, ofPoint, coeff, hyx, hy₀]
+
+/-- The support of `[x] - w(x)[x₀]` is contained in `{x, x₀}`. -/
+lemma support_weightedPointBaseDifference_subset [DecidableEq X] (w : X → ℤ) (x₀ x : X) :
+    (weightedPointBaseDifference w x₀ x).support ⊆ {x, x₀} := by
+  intro y hy
+  rw [Finset.mem_insert, Finset.mem_singleton]
+  by_contra hyx
+  push Not at hyx
+  exact Finsupp.mem_support_iff.mp hy (by
+    simp [weightedPointBaseDifference, ofPoint, hyx.1, hyx.2])
+
+/-- If the base point has weight `1`, the divisor `[x₀] - w(x₀)[x₀]` is zero. -/
+@[simp]
+lemma weightedPointBaseDifference_self {w : X → ℤ} {x₀ : X} (hx₀ : w x₀ = 1) :
+    weightedPointBaseDifference w x₀ x₀ = 0 := by
+  simp [weightedPointBaseDifference, hx₀]
+
+/-- The weighted degree of `[x] - w(x)[x₀]` is `w(x) * (1 - w(x₀))`. -/
+@[simp]
+lemma weightedDegree_weightedPointBaseDifference (w : X → ℤ) (x₀ x : X) :
+    weightedDegree w (weightedPointBaseDifference w x₀ x) = w x * (1 - w x₀) := by
+  simp [weightedPointBaseDifference]
+  ring
+
+/-- If the base point has weight `1`, then `[x] - w(x)[x₀]` has weighted degree zero. -/
+@[simp]
+lemma weightedPointBaseDifference_mem_weightedDegreeZeroSubgroup {w : X → ℤ} {x₀ : X}
+    (hx₀ : w x₀ = 1) (x : X) :
+    weightedPointBaseDifference w x₀ x ∈ weightedDegreeZeroSubgroup w := by
+  simp [hx₀]
+
+/-- The unweighted divisor `[x] - [x₀]`, the algebraically closed form of the Abel-Jacobi
+point divisor. -/
+noncomputable abbrev unweightedPointBaseDifference (x₀ x : X) : WeilDivisor X :=
+  weightedPointBaseDifference (fun _ : X => (1 : ℤ)) x₀ x
+
+@[simp]
+lemma unweightedPointBaseDifference_eq_pointDifference (x₀ x : X) :
+    unweightedPointBaseDifference x₀ x = pointDifference x x₀ :=
+  weightedPointBaseDifference_eq_pointDifference x₀ x
+
+@[simp]
+lemma degree_unweightedPointBaseDifference (x₀ x : X) :
+    degree (unweightedPointBaseDifference x₀ x) = 0 := by
+  simp
+
+/-- The unweighted point divisor `[x] - [x₀]` lies in the degree-zero divisor subgroup. -/
+@[simp]
+lemma unweightedPointBaseDifference_mem_degreeZeroSubgroup (x₀ x : X) :
+    unweightedPointBaseDifference x₀ x ∈ degreeZeroSubgroup X := by
+  simp
+
+/-! ### Abel-Jacobi classes in the abstract Picard group -/
+
+namespace OrderSystem
+
+variable (S : OrderSystem X G)
+
+/-- The weighted abstract Abel-Jacobi class of a point.
+
+For a geometric weight `w x = [κ(x) : k]` and a rational base point `x₀` (`w x₀ = 1`), this is
+the class of `[x] - w(x)[x₀]` in the abstract weighted-degree-zero Picard group. -/
+noncomputable def weightedAbelJacobiClass (w : X → ℤ) (hdeg : S.IsWeightedDegreeZero w)
+    {x₀ : X} (hx₀ : w x₀ = 1) (x : X) : picZero w hdeg :=
+  ⟨S.divisorClass (weightedPointBaseDifference w x₀ x), by
+    rw [divisorClass_mem_picZero]
+    exact weightedPointBaseDifference_mem_weightedDegreeZeroSubgroup hx₀ x⟩
+
+@[simp]
+lemma coe_weightedAbelJacobiClass (w : X → ℤ) (hdeg : S.IsWeightedDegreeZero w)
+    {x₀ : X} (hx₀ : w x₀ = 1) (x : X) :
+    (S.weightedAbelJacobiClass w hdeg hx₀ x : S.ClassGroup) =
+      S.divisorClass (weightedPointBaseDifference w x₀ x) :=
+  rfl
+
+/-- The weighted abstract Abel-Jacobi class of the base point is zero. -/
+@[simp]
+lemma weightedAbelJacobiClass_base (w : X → ℤ) (hdeg : S.IsWeightedDegreeZero w)
+    {x₀ : X} (hx₀ : w x₀ = 1) :
+    S.weightedAbelJacobiClass w hdeg hx₀ x₀ = 0 := by
+  apply Subtype.ext
+  simp [weightedAbelJacobiClass, hx₀]
+
+/-- Equality of weighted Abel-Jacobi classes is equality of the corresponding divisor classes. -/
+lemma weightedAbelJacobiClass_eq_iff_divisorClass (w : X → ℤ)
+    (hdeg : S.IsWeightedDegreeZero w) {x₀ : X} (hx₀ : w x₀ = 1) {x y : X} :
+    S.weightedAbelJacobiClass w hdeg hx₀ x = S.weightedAbelJacobiClass w hdeg hx₀ y ↔
+      S.divisorClass (weightedPointBaseDifference w x₀ x) =
+        S.divisorClass (weightedPointBaseDifference w x₀ y) := by
+  constructor
+  · intro h
+    exact congr_arg Subtype.val h
+  · intro h
+    exact Subtype.ext h
+
+/-- Equality of weighted Abel-Jacobi classes is linear equivalence of the corresponding
+degree-corrected point divisors. -/
+lemma weightedAbelJacobiClass_eq_iff_linearlyEquivalent (w : X → ℤ)
+    (hdeg : S.IsWeightedDegreeZero w) {x₀ : X} (hx₀ : w x₀ = 1) {x y : X} :
+    S.weightedAbelJacobiClass w hdeg hx₀ x = S.weightedAbelJacobiClass w hdeg hx₀ y ↔
+      S.LinearlyEquivalent (weightedPointBaseDifference w x₀ x)
+        (weightedPointBaseDifference w x₀ y) := by
+  rw [S.weightedAbelJacobiClass_eq_iff_divisorClass w hdeg hx₀, S.divisorClass_eq_iff]
+
+/-- The unweighted abstract Abel-Jacobi class `x ↦ [[x] - [x₀]]` in the abstract `Pic⁰`
+subgroup. -/
+noncomputable def unweightedAbelJacobiClass (hdeg : S.IsUnweightedDegreeZero) (x₀ x : X) :
+    unweightedPicZero hdeg :=
+  ⟨S.divisorClass (pointDifference x x₀), by simp⟩
+
+@[simp]
+lemma coe_unweightedAbelJacobiClass (hdeg : S.IsUnweightedDegreeZero) (x₀ x : X) :
+    (S.unweightedAbelJacobiClass hdeg x₀ x : S.ClassGroup) =
+      S.divisorClass (pointDifference x x₀) :=
+  rfl
+
+/-- The unweighted abstract Abel-Jacobi class sends the base point to zero. -/
+@[simp]
+lemma unweightedAbelJacobiClass_base (hdeg : S.IsUnweightedDegreeZero) (x₀ : X) :
+    S.unweightedAbelJacobiClass hdeg x₀ x₀ = 0 := by
+  apply Subtype.ext
+  simp [unweightedAbelJacobiClass]
+
+/-- Equality of unweighted Abel-Jacobi classes is equality of the corresponding divisor
+classes. -/
+lemma unweightedAbelJacobiClass_eq_iff_divisorClass (hdeg : S.IsUnweightedDegreeZero)
+    (x₀ : X) {x y : X} :
+    S.unweightedAbelJacobiClass hdeg x₀ x = S.unweightedAbelJacobiClass hdeg x₀ y ↔
+      S.divisorClass (pointDifference x x₀) = S.divisorClass (pointDifference y x₀) := by
+  constructor
+  · intro h
+    exact congr_arg Subtype.val h
+  · intro h
+    exact Subtype.ext h
+
+/-- Equality of unweighted Abel-Jacobi classes is linear equivalence of the point-difference
+divisors. -/
+lemma unweightedAbelJacobiClass_eq_iff_linearlyEquivalent (hdeg : S.IsUnweightedDegreeZero)
+    (x₀ : X) {x y : X} :
+    S.unweightedAbelJacobiClass hdeg x₀ x = S.unweightedAbelJacobiClass hdeg x₀ y ↔
+      S.LinearlyEquivalent (pointDifference x x₀) (pointDifference y x₀) := by
+  rw [S.unweightedAbelJacobiClass_eq_iff_divisorClass hdeg x₀, S.divisorClass_eq_iff]
+
+end OrderSystem
+
+end WeilDivisor
+
+end AlgebraicGeometry
+
+end TauCeti

--- a/TauCeti/AlgebraicGeometry/WeilDivisor/AbelJacobi.lean
+++ b/TauCeti/AlgebraicGeometry/WeilDivisor/AbelJacobi.lean
@@ -41,8 +41,7 @@ variable {X G : Type*} [AddCommGroup G]
 
 For the geometric weight `w x = [κ(x) : k]` and a rational base point `x₀` with `w x₀ = 1`,
 this is the degree-zero divisor underlying the Abel-Jacobi class of the closed point `x`.
-In the algebraically closed/unweighted specialization, use
-`unweightedPointBaseDifference`, which is definitionally `[x] - [x₀]`. -/
+In the algebraically closed/unweighted specialization, this recovers `pointDifference x x₀`. -/
 noncomputable def weightedPointBaseDifference (w : X → ℤ) (x₀ x : X) : WeilDivisor X :=
   ofPoint x - w x • ofPoint x₀
 
@@ -93,27 +92,6 @@ lemma weightedPointBaseDifference_mem_weightedDegreeZeroSubgroup {w : X → ℤ}
     (hx₀ : w x₀ = 1) (x : X) :
     weightedPointBaseDifference w x₀ x ∈ weightedDegreeZeroSubgroup w := by
   simp [hx₀]
-
-/-- The unweighted divisor `[x] - [x₀]`, the algebraically closed form of the Abel-Jacobi
-point divisor. -/
-noncomputable abbrev unweightedPointBaseDifference (x₀ x : X) : WeilDivisor X :=
-  weightedPointBaseDifference (fun _ : X => (1 : ℤ)) x₀ x
-
-@[simp]
-lemma unweightedPointBaseDifference_eq_pointDifference (x₀ x : X) :
-    unweightedPointBaseDifference x₀ x = pointDifference x x₀ :=
-  weightedPointBaseDifference_eq_pointDifference x₀ x
-
-@[simp]
-lemma degree_unweightedPointBaseDifference (x₀ x : X) :
-    degree (unweightedPointBaseDifference x₀ x) = 0 := by
-  simp
-
-/-- The unweighted point divisor `[x] - [x₀]` lies in the degree-zero divisor subgroup. -/
-@[simp]
-lemma unweightedPointBaseDifference_mem_degreeZeroSubgroup (x₀ x : X) :
-    unweightedPointBaseDifference x₀ x ∈ degreeZeroSubgroup X := by
-  simp
 
 /-! ### Abel-Jacobi classes in the abstract Picard group -/
 

--- a/TauCeti/AlgebraicGeometry/WeilDivisor/AbelJacobi.lean
+++ b/TauCeti/AlgebraicGeometry/WeilDivisor/AbelJacobi.lean
@@ -35,64 +35,6 @@ namespace WeilDivisor
 
 variable {X G : Type*} [AddCommGroup G]
 
-/-! ### Degree-corrected point divisors -/
-
-/-- The divisor `[x] - w(x)[x₀]`.
-
-For the geometric weight `w x = [κ(x) : k]` and a rational base point `x₀` with `w x₀ = 1`,
-this is the degree-zero divisor underlying the Abel-Jacobi class of the closed point `x`.
-In the algebraically closed/unweighted specialization, this recovers `pointDifference x x₀`. -/
-noncomputable def weightedPointBaseDifference (w : X → ℤ) (x₀ x : X) : WeilDivisor X :=
-  ofPoint x - w x • ofPoint x₀
-
-@[simp]
-lemma weightedPointBaseDifference_eq_pointDifference (x₀ x : X) :
-    weightedPointBaseDifference (fun _ : X => (1 : ℤ)) x₀ x = pointDifference x x₀ := by
-  simp [weightedPointBaseDifference, pointDifference]
-
-@[simp]
-lemma coeff_weightedPointBaseDifference [DecidableEq X] (w : X → ℤ) (x₀ x y : X) :
-    coeff (weightedPointBaseDifference w x₀ x) y =
-      (if y = x then 1 else 0) - if y = x₀ then w x else 0 := by
-  by_cases hyx : y = x
-  · subst y
-    by_cases hx₀ : x = x₀ <;> simp [weightedPointBaseDifference, ofPoint, coeff, hx₀]
-  · by_cases hy₀ : y = x₀
-    · subst y
-      have hx₀ : x₀ ≠ x := by simpa using hyx
-      simp [weightedPointBaseDifference, ofPoint, coeff, hx₀]
-    · simp [weightedPointBaseDifference, ofPoint, coeff, hyx, hy₀]
-
-/-- The support of `[x] - w(x)[x₀]` is contained in `{x, x₀}`. -/
-lemma support_weightedPointBaseDifference_subset [DecidableEq X] (w : X → ℤ) (x₀ x : X) :
-    (weightedPointBaseDifference w x₀ x).support ⊆ {x, x₀} := by
-  intro y hy
-  rw [Finset.mem_insert, Finset.mem_singleton]
-  by_contra hyx
-  push Not at hyx
-  exact Finsupp.mem_support_iff.mp hy (by
-    simp [weightedPointBaseDifference, ofPoint, hyx.1, hyx.2])
-
-/-- If the base point has weight `1`, the divisor `[x₀] - w(x₀)[x₀]` is zero. -/
-@[simp]
-lemma weightedPointBaseDifference_self {w : X → ℤ} {x₀ : X} (hx₀ : w x₀ = 1) :
-    weightedPointBaseDifference w x₀ x₀ = 0 := by
-  simp [weightedPointBaseDifference, hx₀]
-
-/-- The weighted degree of `[x] - w(x)[x₀]` is `w(x) * (1 - w(x₀))`. -/
-@[simp]
-lemma weightedDegree_weightedPointBaseDifference (w : X → ℤ) (x₀ x : X) :
-    weightedDegree w (weightedPointBaseDifference w x₀ x) = w x * (1 - w x₀) := by
-  simp [weightedPointBaseDifference]
-  ring
-
-/-- If the base point has weight `1`, then `[x] - w(x)[x₀]` has weighted degree zero. -/
-@[simp]
-lemma weightedPointBaseDifference_mem_weightedDegreeZeroSubgroup {w : X → ℤ} {x₀ : X}
-    (hx₀ : w x₀ = 1) (x : X) :
-    weightedPointBaseDifference w x₀ x ∈ weightedDegreeZeroSubgroup w := by
-  simp [hx₀]
-
 /-! ### Abel-Jacobi classes in the abstract Picard group -/
 
 namespace OrderSystem
@@ -109,6 +51,8 @@ noncomputable def weightedAbelJacobiClass (w : X → ℤ) (hdeg : S.IsWeightedDe
     rw [divisorClass_mem_picZero]
     exact weightedPointBaseDifference_mem_weightedDegreeZeroSubgroup hx₀ x⟩
 
+/-- Coercing the weighted Abel-Jacobi class to the class group gives the divisor class of the
+degree-corrected point divisor. This is the canonical simp form for the subtype coercion. -/
 @[simp]
 lemma coe_weightedAbelJacobiClass (w : X → ℤ) (hdeg : S.IsWeightedDegreeZero w)
     {x₀ : X} (hx₀ : w x₀ = 1) (x : X) :
@@ -132,9 +76,10 @@ lemma weightedAbelJacobiClass_eq_iff_divisorClass (w : X → ℤ)
         S.divisorClass (weightedPointBaseDifference w x₀ y) := by
   constructor
   · intro h
-    exact congr_arg Subtype.val h
+    simpa using congr_arg Subtype.val h
   · intro h
-    exact Subtype.ext h
+    apply Subtype.ext
+    simpa using h
 
 /-- Equality of weighted Abel-Jacobi classes is linear equivalence of the corresponding
 degree-corrected point divisors. -/
@@ -149,13 +94,15 @@ lemma weightedAbelJacobiClass_eq_iff_linearlyEquivalent (w : X → ℤ)
 subgroup. -/
 noncomputable def unweightedAbelJacobiClass (hdeg : S.IsUnweightedDegreeZero) (x₀ x : X) :
     unweightedPicZero hdeg :=
-  ⟨S.divisorClass (pointDifference x x₀), by simp⟩
+  S.weightedAbelJacobiClass (fun _ => (1 : ℤ)) hdeg (x₀ := x₀) rfl x
 
+/-- Coercing the unweighted Abel-Jacobi class to the class group gives the divisor class of
+`[x] - [x₀]`. This exposes the unweighted specialization in the expected class-group form. -/
 @[simp]
 lemma coe_unweightedAbelJacobiClass (hdeg : S.IsUnweightedDegreeZero) (x₀ x : X) :
     (S.unweightedAbelJacobiClass hdeg x₀ x : S.ClassGroup) =
-      S.divisorClass (pointDifference x x₀) :=
-  rfl
+      S.divisorClass (pointDifference x x₀) := by
+  simp [unweightedAbelJacobiClass]
 
 /-- The unweighted abstract Abel-Jacobi class sends the base point to zero. -/
 @[simp]
@@ -172,9 +119,13 @@ lemma unweightedAbelJacobiClass_eq_iff_divisorClass (hdeg : S.IsUnweightedDegree
       S.divisorClass (pointDifference x x₀) = S.divisorClass (pointDifference y x₀) := by
   constructor
   · intro h
+    rw [← S.coe_unweightedAbelJacobiClass hdeg x₀ x,
+      ← S.coe_unweightedAbelJacobiClass hdeg x₀ y]
     exact congr_arg Subtype.val h
   · intro h
-    exact Subtype.ext h
+    apply Subtype.ext
+    rwa [S.coe_unweightedAbelJacobiClass hdeg x₀ x,
+      S.coe_unweightedAbelJacobiClass hdeg x₀ y]
 
 /-- Equality of unweighted Abel-Jacobi classes is linear equivalence of the point-difference
 divisors. -/


### PR DESCRIPTION
This PR adds the abstract Abel-Jacobi divisor-class map available at the current formal-divisor layer: for an order system with weighted-degree-zero principal divisors and a base point `x₀` of weight `1`, it sends a point `x` to the class of the degree-corrected divisor `[x] - w(x)[x₀]` in the abstract weighted `Pic⁰`; in the unweighted specialization this is the familiar class of `[x] - [x₀]`. It records the coefficient, support, degree-zero, basepoint, coercion, divisor-class equality, and linear-equivalence characterizations needed to use the construction without unfolding it.

This advances `TauCetiRoadmap/JacobianChallenge/README.md`, Layer A (`Pic⁰ X = ker deg`, as an abstract group) as a direct prerequisite for Layer F (`The Abel-Jacobi morphism aj : X ⟶ Jac X, x₀ ↦ 0`). The scheme-level Abel-Jacobi morphism, line bundles, Picard scheme, and Jacobian variety do not exist yet, so this PR deliberately stops at the honest divisor-class shadow supported by the existing `WeilDivisor` and `OrderSystem` API.

No Mathlib infrastructure is vendored. The construction reuses Tau Ceti `WeilDivisor.ofPoint`, `pointDifference`, `weightedDegreeZeroSubgroup`, `OrderSystem.divisorClass`, and `OrderSystem.picZero`, together with Mathlib existing `Finsupp` support and quotient subgroup machinery already used by the surrounding divisor files.

`lake build`: `Build completed successfully (4049 jobs).`
`lake exe axioms`: `axioms: audited 3774 TauCeti declaration(s); all within the allowlist [propext, Classical.choice, Quot.sound].`

<!--tauceti-target:v1 {"focus":"JacobianChallenge","id":"abel-jacobi-divisor-class"}-->

🤖 Prepared with Codex
