### PR TITLE
feat: add noninterleaving grid commutations

### DIFF
--- a/TauCeti/KnotTheory/Grid/Commutation.lean
+++ b/TauCeti/KnotTheory/Grid/Commutation.lean
@@ -74,34 +74,6 @@ theorem O_notMem_columnArc (c : Fin n) : G.O c ∉ columnArc G c := by
 theorem X_notMem_columnArc (c : Fin n) : G.X c ∉ columnArc G c := by
   simp [columnArc]
 
-/-- The column containing the `O` marking in a given row. -/
-def OColumnOfRow (r : Fin n) : Fin n :=
-  G.O.toPerm.symm r
-
-/-- The column containing the `X` marking in a given row. -/
-def XColumnOfRow (r : Fin n) : Fin n :=
-  G.X.toPerm.symm r
-
-/-- The `O` marking in row `r` lies in column `OColumnOfRow r`. -/
-@[simp]
-theorem OColumnOfRow_apply (r : Fin n) : G.O (OColumnOfRow G r) = r := by
-  simp [OColumnOfRow]
-
-/-- The `X` marking in row `r` lies in column `XColumnOfRow r`. -/
-@[simp]
-theorem XColumnOfRow_apply (r : Fin n) : G.X (XColumnOfRow G r) = r := by
-  simp [XColumnOfRow]
-
-/-- The row whose `O` marking is in column `c` recovers `c`. -/
-@[simp]
-theorem OColumnOfRow_O (c : Fin n) : OColumnOfRow G (G.O c) = c := by
-  simp [OColumnOfRow]
-
-/-- The row whose `X` marking is in column `c` recovers `c`. -/
-@[simp]
-theorem XColumnOfRow_X (c : Fin n) : XColumnOfRow G (G.X c) = c := by
-  simp [XColumnOfRow]
-
 /-- The open horizontal arc from the `O` marking to the `X` marking in a row of a grid diagram.
 
 This is the column-coordinate version of `columnArc`: it starts at the unique column containing
@@ -133,13 +105,26 @@ of the endpoint pair in column `b`, and conversely. This symmetric form is robus
 row-sharing cases, where one endpoint of a segment may have the same row coordinate as an endpoint
 of the other segment. -/
 def ColumnsNoninterleaving (a b : Fin n) : Prop :=
-  (G.O a ∈ columnArc G b ↔ G.X a ∈ columnArc G b) ∧
-    (G.O b ∈ columnArc G a ↔ G.X b ∈ columnArc G a)
+  Grid.Noninterleaving (G.O a) (G.X a) (G.O b) (G.X b)
 
 /-- Two rows of a grid diagram have non-interleaving marking segments. -/
 def RowsNoninterleaving (a b : Fin n) : Prop :=
-  (OColumnOfRow G a ∈ rowArc G b ↔ XColumnOfRow G a ∈ rowArc G b) ∧
-    (OColumnOfRow G b ∈ rowArc G a ↔ XColumnOfRow G b ∈ rowArc G a)
+  Grid.Noninterleaving (OColumnOfRow G a) (XColumnOfRow G a)
+    (OColumnOfRow G b) (XColumnOfRow G b)
+
+/-- The defining endpoint-side conditions for column non-interleaving. -/
+theorem columnsNoninterleaving_iff (a b : Fin n) :
+    ColumnsNoninterleaving G a b ↔
+      (G.O a ∈ columnArc G b ↔ G.X a ∈ columnArc G b) ∧
+        (G.O b ∈ columnArc G a ↔ G.X b ∈ columnArc G a) := by
+  rfl
+
+/-- The defining endpoint-side conditions for row non-interleaving. -/
+theorem rowsNoninterleaving_iff (a b : Fin n) :
+    RowsNoninterleaving G a b ↔
+      (OColumnOfRow G a ∈ rowArc G b ↔ XColumnOfRow G a ∈ rowArc G b) ∧
+        (OColumnOfRow G b ∈ rowArc G a ↔ XColumnOfRow G b ∈ rowArc G a) := by
+  rfl
 
 /-- A column is non-interleaving with itself. -/
 @[simp]
@@ -154,38 +139,48 @@ theorem rowsNoninterleaving_self (a : Fin n) : RowsNoninterleaving G a a := by
 /-- Column non-interleaving is symmetric in the two columns. -/
 theorem columnsNoninterleaving_comm {a b : Fin n} :
     ColumnsNoninterleaving G a b ↔ ColumnsNoninterleaving G b a := by
-  rw [ColumnsNoninterleaving, ColumnsNoninterleaving]
-  exact and_comm
+  exact Grid.noninterleaving_comm
 
 /-- Row non-interleaving is symmetric in the two rows. -/
 theorem rowsNoninterleaving_comm {a b : Fin n} :
     RowsNoninterleaving G a b ↔ RowsNoninterleaving G b a := by
-  rw [RowsNoninterleaving, RowsNoninterleaving]
-  exact and_comm
+  exact Grid.noninterleaving_comm
+
+/-- The row `c` in the reflected diagram has its `O` marking in the original row `G.O c`. -/
+@[simp]
+theorem OColumnOfRow_transpose (c : Fin n) : OColumnOfRow G.transpose c = G.O c := by
+  simp [OColumnOfRow]
+
+/-- The row `c` in the reflected diagram has its `X` marking in the original row `G.X c`. -/
+@[simp]
+theorem XColumnOfRow_transpose (c : Fin n) : XColumnOfRow G.transpose c = G.X c := by
+  simp [XColumnOfRow]
 
 /-- Diagonal reflection turns the row arc in the reflected diagram into the column arc in the
 original diagram. -/
 @[simp]
-theorem rowArc_transpose (c : Fin n) : rowArc G.transpose c = columnArc G c :=
-  rfl
+theorem rowArc_transpose (c : Fin n) : rowArc G.transpose c = columnArc G c := by
+  simp [rowArc, columnArc]
 
 /-- Diagonal reflection turns the column arc in the reflected diagram into the row arc in the
 original diagram. -/
 @[simp]
-theorem columnArc_transpose (r : Fin n) : columnArc G.transpose r = rowArc G r :=
-  rfl
+theorem columnArc_transpose (r : Fin n) : columnArc G.transpose r = rowArc G r := by
+  simp [rowArc, columnArc, OColumnOfRow, XColumnOfRow, GridState.columnOfRow]
 
 /-- Diagonal reflection exchanges row non-interleaving with column non-interleaving. -/
 @[simp]
 theorem rowsNoninterleaving_transpose (a b : Fin n) :
     RowsNoninterleaving G.transpose a b ↔ ColumnsNoninterleaving G a b :=
-  Iff.rfl
+  by simp [RowsNoninterleaving, ColumnsNoninterleaving]
 
 /-- Diagonal reflection exchanges column non-interleaving with row non-interleaving. -/
 @[simp]
 theorem columnsNoninterleaving_transpose (a b : Fin n) :
     ColumnsNoninterleaving G.transpose a b ↔ RowsNoninterleaving G a b :=
-  Iff.rfl
+  by
+    simp [RowsNoninterleaving, ColumnsNoninterleaving, OColumnOfRow, XColumnOfRow,
+      GridState.columnOfRow]
 
 end GridDiagram
 

--- a/TauCeti/KnotTheory/Grid/Commutation.lean
+++ b/TauCeti/KnotTheory/Grid/Commutation.lean
@@ -2,23 +2,191 @@
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 -/
+import TauCeti.KnotTheory.Grid.CyclicInterval
+import TauCeti.KnotTheory.Grid.Diagram
+
 /-!
 # Grid diagram commutation moves
 
-This file is reserved for commutation-specific grid diagram constructions. The total row and
-column swap operations used as the underlying relabelings live in
-`TauCeti.KnotTheory.Grid.Diagram`, next to the general row and column relabeling API. Later
-commutation maps and invariance proofs can add the non-interleaving hypotheses and
-rectangle-counting constructions here.
+This file starts the commutation-move API for grid diagrams. The total row and column swap
+operations used as underlying relabelings live in `TauCeti.KnotTheory.Grid.Diagram`, next to the
+general row and column relabeling API. Here we add the move-specific hypothesis: two rows or
+columns are commutable when their marking segments do not interleave around the torus.
+
+For columns, the vertical segment in column `c` has endpoints `G.O c` and `G.X c`, and two columns
+are non-interleaving when each pair of endpoints lies on one side of the other column's endpoint
+pair. The row version is the same definition after reading, in each row, the unique columns
+containing the `O` and `X` markings.
+
+The predicates are intentionally just the combinatorial hypotheses. The pentagon-counting maps
+and chain homotopies for commutation invariance are later Lane G.5 targets.
+
+## Main definitions
+
+* `TauCeti.GridDiagram.columnArc`: the open cyclic interval between the two markings in a column.
+* `TauCeti.GridDiagram.rowArc`: the open cyclic interval between the two markings in a row.
+* `TauCeti.GridDiagram.ColumnsNoninterleaving`: the hypothesis for a column commutation.
+* `TauCeti.GridDiagram.RowsNoninterleaving`: the hypothesis for a row commutation.
+
+## Main results
+
+* `TauCeti.GridDiagram.columnsNoninterleaving_comm` and
+  `TauCeti.GridDiagram.rowsNoninterleaving_comm`: non-interleaving is symmetric in the two rows or
+  columns.
+* `TauCeti.GridDiagram.rowsNoninterleaving_transpose` and
+  `TauCeti.GridDiagram.columnsNoninterleaving_transpose`: diagonal reflection exchanges row and
+  column non-interleaving.
 
 ## References
 
-This supplies a prerequisite for `TauCetiRoadmap/HeegaardFloer/README.md`, Lane G.5,
+This supplies a prerequisite for `TauCetiRoadmap/CombinatorialHeegaardFloer/README.md`, Lane G.5,
 "Invariance over `𝔽₂`. Grid moves = commutation + (de)stabilization." It isolates the
-underlying grid-diagram relabeling used by row and column commutations in the grid homology
-construction of Ozsváth--Stipsicz--Szabó, *Grid Homology for Knots and Links*, Chapter 3.
+non-interleaving condition for row and column commutations in the grid homology construction of
+Ozsváth--Stipsicz--Szabó, *Grid Homology for Knots and Links*, Chapter 3.
 -/
 
 namespace TauCeti
+
+namespace GridDiagram
+
+variable {n : ℕ} (G : GridDiagram n)
+
+/-- The open vertical arc from the `O` marking to the `X` marking in a column of a grid diagram.
+
+This is the one-dimensional cyclic interval in the row coordinate. Its opposite arc is obtained by
+swapping the two markings, not by changing the column. -/
+noncomputable def columnArc (c : Fin n) : Finset (Fin n) :=
+  Grid.cIoo (G.O c) (G.X c)
+
+/-- Membership in a column arc is membership in the open cyclic interval from that column's `O`
+row to its `X` row. -/
+@[simp]
+theorem mem_columnArc (c r : Fin n) : r ∈ columnArc G c ↔ r ∈ Grid.cIoo (G.O c) (G.X c) :=
+  Iff.rfl
+
+/-- The `O` endpoint of a column is not in its own open column arc. -/
+@[simp]
+theorem O_notMem_columnArc (c : Fin n) : G.O c ∉ columnArc G c := by
+  simp [columnArc]
+
+/-- The `X` endpoint of a column is not in its own open column arc. -/
+@[simp]
+theorem X_notMem_columnArc (c : Fin n) : G.X c ∉ columnArc G c := by
+  simp [columnArc]
+
+/-- The column containing the `O` marking in a given row. -/
+def OColumnOfRow (r : Fin n) : Fin n :=
+  G.O.toPerm.symm r
+
+/-- The column containing the `X` marking in a given row. -/
+def XColumnOfRow (r : Fin n) : Fin n :=
+  G.X.toPerm.symm r
+
+/-- The `O` marking in row `r` lies in column `OColumnOfRow r`. -/
+@[simp]
+theorem OColumnOfRow_apply (r : Fin n) : G.O (OColumnOfRow G r) = r := by
+  simp [OColumnOfRow]
+
+/-- The `X` marking in row `r` lies in column `XColumnOfRow r`. -/
+@[simp]
+theorem XColumnOfRow_apply (r : Fin n) : G.X (XColumnOfRow G r) = r := by
+  simp [XColumnOfRow]
+
+/-- The row whose `O` marking is in column `c` recovers `c`. -/
+@[simp]
+theorem OColumnOfRow_O (c : Fin n) : OColumnOfRow G (G.O c) = c := by
+  simp [OColumnOfRow]
+
+/-- The row whose `X` marking is in column `c` recovers `c`. -/
+@[simp]
+theorem XColumnOfRow_X (c : Fin n) : XColumnOfRow G (G.X c) = c := by
+  simp [XColumnOfRow]
+
+/-- The open horizontal arc from the `O` marking to the `X` marking in a row of a grid diagram.
+
+This is the column-coordinate version of `columnArc`: it starts at the unique column containing
+the row's `O` marking and ends at the unique column containing the row's `X` marking. -/
+noncomputable def rowArc (r : Fin n) : Finset (Fin n) :=
+  Grid.cIoo (OColumnOfRow G r) (XColumnOfRow G r)
+
+/-- Membership in a row arc is membership in the open cyclic interval from that row's `O` column
+to its `X` column. -/
+@[simp]
+theorem mem_rowArc (r c : Fin n) :
+    c ∈ rowArc G r ↔ c ∈ Grid.cIoo (OColumnOfRow G r) (XColumnOfRow G r) :=
+  Iff.rfl
+
+/-- The `O` endpoint of a row is not in its own open row arc. -/
+@[simp]
+theorem OColumn_notMem_rowArc (r : Fin n) : OColumnOfRow G r ∉ rowArc G r := by
+  simp [rowArc]
+
+/-- The `X` endpoint of a row is not in its own open row arc. -/
+@[simp]
+theorem XColumn_notMem_rowArc (r : Fin n) : XColumnOfRow G r ∉ rowArc G r := by
+  simp [rowArc]
+
+/-- Two columns of a grid diagram have non-interleaving marking segments.
+
+The condition is phrased in both directions: the two endpoints in column `a` lie on the same side
+of the endpoint pair in column `b`, and conversely. This symmetric form is robust in degenerate
+row-sharing cases, where one endpoint of a segment may have the same row coordinate as an endpoint
+of the other segment. -/
+def ColumnsNoninterleaving (a b : Fin n) : Prop :=
+  (G.O a ∈ columnArc G b ↔ G.X a ∈ columnArc G b) ∧
+    (G.O b ∈ columnArc G a ↔ G.X b ∈ columnArc G a)
+
+/-- Two rows of a grid diagram have non-interleaving marking segments. -/
+def RowsNoninterleaving (a b : Fin n) : Prop :=
+  (OColumnOfRow G a ∈ rowArc G b ↔ XColumnOfRow G a ∈ rowArc G b) ∧
+    (OColumnOfRow G b ∈ rowArc G a ↔ XColumnOfRow G b ∈ rowArc G a)
+
+/-- A column is non-interleaving with itself. -/
+@[simp]
+theorem columnsNoninterleaving_self (a : Fin n) : ColumnsNoninterleaving G a a := by
+  simp [ColumnsNoninterleaving]
+
+/-- A row is non-interleaving with itself. -/
+@[simp]
+theorem rowsNoninterleaving_self (a : Fin n) : RowsNoninterleaving G a a := by
+  simp [RowsNoninterleaving]
+
+/-- Column non-interleaving is symmetric in the two columns. -/
+theorem columnsNoninterleaving_comm {a b : Fin n} :
+    ColumnsNoninterleaving G a b ↔ ColumnsNoninterleaving G b a := by
+  rw [ColumnsNoninterleaving, ColumnsNoninterleaving]
+  exact and_comm
+
+/-- Row non-interleaving is symmetric in the two rows. -/
+theorem rowsNoninterleaving_comm {a b : Fin n} :
+    RowsNoninterleaving G a b ↔ RowsNoninterleaving G b a := by
+  rw [RowsNoninterleaving, RowsNoninterleaving]
+  exact and_comm
+
+/-- Diagonal reflection turns the row arc in the reflected diagram into the column arc in the
+original diagram. -/
+@[simp]
+theorem rowArc_transpose (c : Fin n) : rowArc G.transpose c = columnArc G c :=
+  rfl
+
+/-- Diagonal reflection turns the column arc in the reflected diagram into the row arc in the
+original diagram. -/
+@[simp]
+theorem columnArc_transpose (r : Fin n) : columnArc G.transpose r = rowArc G r :=
+  rfl
+
+/-- Diagonal reflection exchanges row non-interleaving with column non-interleaving. -/
+@[simp]
+theorem rowsNoninterleaving_transpose (a b : Fin n) :
+    RowsNoninterleaving G.transpose a b ↔ ColumnsNoninterleaving G a b :=
+  Iff.rfl
+
+/-- Diagonal reflection exchanges column non-interleaving with row non-interleaving. -/
+@[simp]
+theorem columnsNoninterleaving_transpose (a b : Fin n) :
+    ColumnsNoninterleaving G.transpose a b ↔ RowsNoninterleaving G a b :=
+  Iff.rfl
+
+end GridDiagram
 
 end TauCeti

--- a/TauCeti/KnotTheory/Grid/Commutation.lean
+++ b/TauCeti/KnotTheory/Grid/Commutation.lean
@@ -166,7 +166,7 @@ theorem rowArc_transpose (c : Fin n) : rowArc G.transpose c = columnArc G c := b
 original diagram. -/
 @[simp]
 theorem columnArc_transpose (r : Fin n) : columnArc G.transpose r = rowArc G r := by
-  simp [rowArc, columnArc, OColumnOfRow, XColumnOfRow, GridState.columnOfRow]
+  simp only [columnArc, rowArc, transpose_O_apply, transpose_X_apply]
 
 /-- Diagonal reflection exchanges row non-interleaving with column non-interleaving. -/
 @[simp]
@@ -179,8 +179,7 @@ theorem rowsNoninterleaving_transpose (a b : Fin n) :
 theorem columnsNoninterleaving_transpose (a b : Fin n) :
     ColumnsNoninterleaving G.transpose a b ↔ RowsNoninterleaving G a b :=
   by
-    simp [RowsNoninterleaving, ColumnsNoninterleaving, OColumnOfRow, XColumnOfRow,
-      GridState.columnOfRow]
+    simp only [RowsNoninterleaving, ColumnsNoninterleaving, transpose_O_apply, transpose_X_apply]
 
 end GridDiagram
 

--- a/TauCeti/KnotTheory/Grid/Commutation.lean
+++ b/TauCeti/KnotTheory/Grid/Commutation.lean
@@ -146,16 +146,6 @@ theorem rowsNoninterleaving_comm {a b : Fin n} :
     RowsNoninterleaving G a b ↔ RowsNoninterleaving G b a := by
   exact Grid.noninterleaving_comm
 
-/-- The row `c` in the reflected diagram has its `O` marking in the original row `G.O c`. -/
-@[simp]
-theorem OColumnOfRow_transpose (c : Fin n) : OColumnOfRow G.transpose c = G.O c := by
-  simp [OColumnOfRow]
-
-/-- The row `c` in the reflected diagram has its `X` marking in the original row `G.X c`. -/
-@[simp]
-theorem XColumnOfRow_transpose (c : Fin n) : XColumnOfRow G.transpose c = G.X c := by
-  simp [XColumnOfRow]
-
 /-- Diagonal reflection turns the row arc in the reflected diagram into the column arc in the
 original diagram. -/
 @[simp]

--- a/TauCeti/KnotTheory/Grid/CyclicInterval.lean
+++ b/TauCeti/KnotTheory/Grid/CyclicInterval.lean
@@ -23,6 +23,7 @@ directions before taking products.
   it is not an endpoint.
 * `TauCeti.Grid.cIoo_union_swap`: the two opposite arcs cover the endpoint complement.
 * `TauCeti.Grid.card_cIoo_add_card_cIoo_swap`: the two arc lengths add to `n - 2`.
+* `TauCeti.Grid.Noninterleaving`: two endpoint pairs lie on the same cyclic side of each other.
 
 ## References
 
@@ -108,6 +109,32 @@ theorem right_notMem_cIoo (a b : Fin n) : b ∉ cIoo a b := by
     cases hinside with
     | inl hlt => exact hab hlt
     | inr hlt => exact Nat.lt_irrefl b.val hlt
+
+/-- Two oriented cyclic intervals have non-interleaving endpoint pairs.
+
+The endpoints `a₀`, `a₁` lie on the same side of the pair `b₀`, `b₁`, and conversely. This
+two-sided formulation handles shared-endpoint cases uniformly. -/
+def Noninterleaving (a₀ a₁ b₀ b₁ : Fin n) : Prop :=
+  (a₀ ∈ cIoo b₀ b₁ ↔ a₁ ∈ cIoo b₀ b₁) ∧
+    (b₀ ∈ cIoo a₀ a₁ ↔ b₁ ∈ cIoo a₀ a₁)
+
+/-- The defining endpoint-side conditions for `Grid.Noninterleaving`. -/
+theorem noninterleaving_iff (a₀ a₁ b₀ b₁ : Fin n) :
+    Noninterleaving a₀ a₁ b₀ b₁ ↔
+      (a₀ ∈ cIoo b₀ b₁ ↔ a₁ ∈ cIoo b₀ b₁) ∧
+        (b₀ ∈ cIoo a₀ a₁ ↔ b₁ ∈ cIoo a₀ a₁) :=
+  Iff.rfl
+
+/-- An endpoint pair is non-interleaving with itself. -/
+@[simp]
+theorem noninterleaving_self (a₀ a₁ : Fin n) : Noninterleaving a₀ a₁ a₀ a₁ := by
+  simp [Noninterleaving]
+
+/-- Non-interleaving is symmetric in the two endpoint pairs. -/
+theorem noninterleaving_comm {a₀ a₁ b₀ b₁ : Fin n} :
+    Noninterleaving a₀ a₁ b₀ b₁ ↔ Noninterleaving b₀ b₁ a₀ a₁ := by
+  rw [Noninterleaving, Noninterleaving]
+  exact and_comm
 
 /-- A point cannot lie in both open cyclic intervals with the same endpoints but opposite
 orientations. -/

--- a/TauCeti/KnotTheory/Grid/Diagram.lean
+++ b/TauCeti/KnotTheory/Grid/Diagram.lean
@@ -453,6 +453,11 @@ def transpose (x : GridState n) : GridState n where
 theorem transpose_apply (x : GridState n) (c : Fin n) : x.transpose c = x.toPerm.symm c :=
   rfl
 
+/-- The row-to-column accessor is evaluation of the reflected grid state. -/
+@[simp]
+theorem columnOfRow_eq_transpose (x : GridState n) (r : Fin n) :
+    x.columnOfRow r = x.transpose r := rfl
+
 /-- The column in row `r` of the reflected state is the original row-coordinate value at `r`. -/
 @[simp]
 theorem columnOfRow_transpose (x : GridState n) (r : Fin n) : x.transpose.columnOfRow r = x r := by
@@ -847,17 +852,20 @@ def transpose (G : GridDiagram n) : GridDiagram n where
 @[simp]
 theorem transpose_O : G.transpose.O = G.O.transpose :=
   rfl
-
 /-- The `X` marking state of the reflected diagram is the reflected `X` marking state. -/
 @[simp]
 theorem transpose_X : G.transpose.X = G.X.transpose :=
   rfl
-
+/-- The reflected diagram's `O` row coordinate is the original `O` column in that row. -/
+@[simp]
+theorem transpose_O_apply (c : Fin n) : G.transpose.O c = OColumnOfRow G c := by simp [OColumnOfRow]
+/-- The reflected diagram's `X` row coordinate is the original `X` column in that row. -/
+@[simp]
+theorem transpose_X_apply (c : Fin n) : G.transpose.X c = XColumnOfRow G c := by simp [XColumnOfRow]
 /-- The diagonal reflection is an involution on grid diagrams. -/
 @[simp]
 theorem transpose_transpose : G.transpose.transpose = G := by
   ext c <;> simp
-
 /-- Reflecting after a row relabeling is the same as column relabeling after reflecting. -/
 @[simp]
 theorem relabelRows_transpose (ρ : Equiv.Perm (Fin n)) :
@@ -985,7 +993,6 @@ theorem swapColumns_swapMarkings (a b : Fin n) :
 @[simp]
 theorem swapMarkings_transpose : G.swapMarkings.transpose = G.transpose.swapMarkings := by
   ext c <;> simp [swapMarkings]
-
 end GridDiagram
 
 end TauCeti

--- a/TauCeti/KnotTheory/Grid/Diagram.lean
+++ b/TauCeti/KnotTheory/Grid/Diagram.lean
@@ -447,7 +447,6 @@ Reflecting the occupied squares across the main diagonal exchanges columns and r
 permutation graph is the inverse of the old one. -/
 def transpose (x : GridState n) : GridState n where
   toPerm := x.toPerm.symm
-
 /-- The diagonal reflection evaluates by the inverse permutation graph. -/
 @[simp]
 theorem transpose_apply (x : GridState n) (c : Fin n) : x.transpose c = x.toPerm.symm c :=
@@ -457,18 +456,15 @@ theorem transpose_apply (x : GridState n) (c : Fin n) : x.transpose c = x.toPerm
 @[simp]
 theorem columnOfRow_eq_transpose (x : GridState n) (r : Fin n) :
     x.columnOfRow r = x.transpose r := rfl
-
 /-- The column in row `r` of the reflected state is the original row-coordinate value at `r`. -/
 @[simp]
 theorem columnOfRow_transpose (x : GridState n) (r : Fin n) : x.transpose.columnOfRow r = x r := by
   simp [columnOfRow, transpose]
-
 /-- The diagonal reflection is an involution on grid states. -/
 @[simp]
 theorem transpose_transpose (x : GridState n) : x.transpose.transpose = x := by
   cases x
   simp [transpose]
-
 /-- Reflecting after a row relabeling is the same as column relabeling after reflecting. -/
 @[simp]
 theorem relabelRows_transpose (ρ : Equiv.Perm (Fin n)) (x : GridState n) :
@@ -477,7 +473,6 @@ theorem relabelRows_transpose (ρ : Equiv.Perm (Fin n)) (x : GridState n) :
   exact congrArg Fin.val <| by
     apply (x.relabelRows ρ).toPerm.injective
     simp
-
 /-- Reflecting after a column relabeling is the same as row relabeling after reflecting. -/
 @[simp]
 theorem relabelColumns_transpose (κ : Equiv.Perm (Fin n)) (x : GridState n) :
@@ -486,13 +481,11 @@ theorem relabelColumns_transpose (κ : Equiv.Perm (Fin n)) (x : GridState n) :
   exact congrArg Fin.val <| by
     apply (x.relabelColumns κ).toPerm.injective
     simp
-
 /-- Reflecting after a row swap is the same as the corresponding column swap after reflecting. -/
 @[simp]
 theorem swapRows_transpose (a b : Fin n) (x : GridState n) :
     (x.swapRows a b).transpose = x.transpose.swapColumns a b := by
   simp [swapRows, swapColumns]
-
 /-- Reflecting after a column swap is the same as the corresponding row swap after reflecting. -/
 @[simp]
 theorem swapColumns_transpose (a b : Fin n) (x : GridState n) :
@@ -850,22 +843,29 @@ def transpose (G : GridDiagram n) : GridDiagram n where
 
 /-- The `O` marking state of the reflected diagram is the reflected `O` marking state. -/
 @[simp]
-theorem transpose_O : G.transpose.O = G.O.transpose :=
-  rfl
+theorem transpose_O : G.transpose.O = G.O.transpose := rfl
 /-- The `X` marking state of the reflected diagram is the reflected `X` marking state. -/
 @[simp]
-theorem transpose_X : G.transpose.X = G.X.transpose :=
-  rfl
+theorem transpose_X : G.transpose.X = G.X.transpose := rfl
 /-- The reflected diagram's `O` row coordinate is the original `O` column in that row. -/
 @[simp]
 theorem transpose_O_apply (c : Fin n) : G.transpose.O c = OColumnOfRow G c := by simp [OColumnOfRow]
 /-- The reflected diagram's `X` row coordinate is the original `X` column in that row. -/
 @[simp]
 theorem transpose_X_apply (c : Fin n) : G.transpose.X c = XColumnOfRow G c := by simp [XColumnOfRow]
+/-- The `O` marking in row `c` of the reflected diagram lies in column `G.O c`. -/
+@[simp]
+theorem OColumnOfRow_transpose (c : Fin n) : OColumnOfRow G.transpose c = G.O c := by
+  rw [OColumnOfRow, transpose_O]
+  exact GridState.columnOfRow_transpose G.O c
+/-- The `X` marking in row `c` of the reflected diagram lies in column `G.X c`. -/
+@[simp]
+theorem XColumnOfRow_transpose (c : Fin n) : XColumnOfRow G.transpose c = G.X c := by
+  rw [XColumnOfRow, transpose_X]
+  exact GridState.columnOfRow_transpose G.X c
 /-- The diagonal reflection is an involution on grid diagrams. -/
 @[simp]
-theorem transpose_transpose : G.transpose.transpose = G := by
-  ext c <;> simp
+theorem transpose_transpose : G.transpose.transpose = G := by ext c <;> simp
 /-- Reflecting after a row relabeling is the same as column relabeling after reflecting. -/
 @[simp]
 theorem relabelRows_transpose (ρ : Equiv.Perm (Fin n)) :

--- a/TauCeti/KnotTheory/Grid/Diagram.lean
+++ b/TauCeti/KnotTheory/Grid/Diagram.lean
@@ -137,6 +137,20 @@ theorem existsUnique_column_of_row (x : GridState n) (r : Fin n) :
   intro c hc
   exact x.toPerm.injective (by simpa using hc)
 
+/-- The column occupied by a grid state in a given row. -/
+def columnOfRow (x : GridState n) (r : Fin n) : Fin n :=
+  x.toPerm.symm r
+
+/-- The point in row `r` lies in column `columnOfRow x r`. -/
+@[simp]
+theorem apply_columnOfRow (x : GridState n) (r : Fin n) : x (x.columnOfRow r) = r := by
+  simp [columnOfRow]
+
+/-- The column containing the point in row `x c` is `c`. -/
+@[simp]
+theorem columnOfRow_apply (x : GridState n) (c : Fin n) : x.columnOfRow (x c) = c := by
+  simp [columnOfRow]
+
 /-- Point sets of grid states are equal exactly when the underlying permutations are equal. -/
 @[simp]
 theorem pointSet_inj {x y : GridState n} : x.pointSet = y.pointSet ↔ x = y := by
@@ -439,6 +453,11 @@ def transpose (x : GridState n) : GridState n where
 theorem transpose_apply (x : GridState n) (c : Fin n) : x.transpose c = x.toPerm.symm c :=
   rfl
 
+/-- The column in row `r` of the reflected state is the original row-coordinate value at `r`. -/
+@[simp]
+theorem columnOfRow_transpose (x : GridState n) (r : Fin n) : x.transpose.columnOfRow r = x r := by
+  simp [columnOfRow, transpose]
+
 /-- The diagonal reflection is an involution on grid states. -/
 @[simp]
 theorem transpose_transpose (x : GridState n) : x.transpose.transpose = x := by
@@ -577,6 +596,34 @@ theorem existsUnique_XColumn_of_row (r : Fin n) :
     ∃! c : Fin n, (c, r) ∈ G.XSet := by
   rw [XSet]
   exact G.X.existsUnique_column_of_row r
+
+/-- The column containing the `O` marking in a given row. -/
+def OColumnOfRow (r : Fin n) : Fin n :=
+  G.O.columnOfRow r
+
+/-- The column containing the `X` marking in a given row. -/
+def XColumnOfRow (r : Fin n) : Fin n :=
+  G.X.columnOfRow r
+
+/-- The `O` marking in row `r` lies in column `OColumnOfRow r`. -/
+@[simp]
+theorem OColumnOfRow_apply (r : Fin n) : G.O (OColumnOfRow G r) = r := by
+  simp [OColumnOfRow]
+
+/-- The `X` marking in row `r` lies in column `XColumnOfRow r`. -/
+@[simp]
+theorem XColumnOfRow_apply (r : Fin n) : G.X (XColumnOfRow G r) = r := by
+  simp [XColumnOfRow]
+
+/-- The column containing the `O` marking in row `G.O c` is `c`. -/
+@[simp]
+theorem OColumnOfRow_O (c : Fin n) : OColumnOfRow G (G.O c) = c := by
+  simp [OColumnOfRow]
+
+/-- The column containing the `X` marking in row `G.X c` is `c`. -/
+@[simp]
+theorem XColumnOfRow_X (c : Fin n) : XColumnOfRow G (G.X c) = c := by
+  simp [XColumnOfRow]
 
 /-- The `O` and `X` marking sets of a grid diagram are disjoint. -/
 theorem disjoint_OSet_XSet : Disjoint G.OSet G.XSet := by


### PR DESCRIPTION
This PR adds the row and column non-interleaving predicates for grid commutation moves, advancing `TauCetiRoadmap/CombinatorialHeegaardFloer/README.md`, Lane G.5, "Invariance over 𝔽₂. Grid moves = commutation + (de)stabilization." The file `TauCeti/KnotTheory/Grid/Commutation.lean` was previously only a reserved stub; this fills the first move-specific prerequisite by defining the cyclic marking arcs in a column or row, the symmetric non-interleaving hypotheses for pairs of columns or rows, and the basic self, symmetry, and transpose-conversion lemmas that later pentagon-counting commutation maps can consume.

The definitions reuse Tau Ceti's existing grid-state/grid-diagram encoding and the finite cyclic interval API `TauCeti.Grid.cIoo`; no Mathlib infrastructure was vendored. The non-interleaving condition follows the standard commutation criterion in Ozsváth--Stipsicz--Szabó, *Grid Homology for Knots and Links*, Chapter 3, phrased as both endpoint pairs lying on the same side of the other pair to make symmetry explicit.

Local verification: `lake exe cache get` completed successfully after decompressing 8573 cached files; `lake build` completed with `Build completed successfully (4048 jobs).`; `lake exe axioms` completed with `axioms: audited 3784 TauCeti declaration(s); all within the allowlist [propext, Classical.choice, Quot.sound].`

<!--tauceti-target:v1 {"focus":"CombinatorialHeegaardFloer","id":"noninterleaving-commutation"}-->

🤖 Prepared with Codex
