### PR TITLE
feat: product calculus for J-holomorphic maps

### DIFF
--- a/TauCeti/Geometry/Symplectic/JHolomorphicProd.lean
+++ b/TauCeti/Geometry/Symplectic/JHolomorphicProd.lean
@@ -20,8 +20,6 @@ symmetric-product targets can use these lemmas without unfolding the Cauchy--Rie
 
 ## Main declarations
 
-* `TauCeti.IsComplexLinearMap.prod`: a pair of complex-linear maps with the same source is
-  complex-linear into a direct-sum target.
 * `TauCeti.IsJHolomorphicAt.prod`, `IsJHolomorphicWithinAt.prod`, `IsJHolomorphicOn.prod`,
   and `IsJHolomorphic.prod`: product maps of `J`-holomorphic maps.
 * `TauCeti.isJHolomorphicAt_fst` and `isJHolomorphicAt_snd`, with within-set, setwise, and
@@ -41,22 +39,6 @@ variable {V W X : Type*}
 variable [NormedAddCommGroup V] [NormedSpace ℝ V]
 variable [NormedAddCommGroup W] [NormedSpace ℝ W]
 variable [NormedAddCommGroup X] [NormedSpace ℝ X]
-
-section ComplexLinearMapProd
-
-variable {J : AlmostComplexStructure V} {J₁ : AlmostComplexStructure W}
-variable {J₂ : AlmostComplexStructure X}
-
-/-- A pair of complex-linear maps with the same source is complex-linear into the direct-sum
-almost complex structure. -/
-lemma IsComplexLinearMap.prod {F : V →ₗ[ℝ] W} {G : V →ₗ[ℝ] X}
-    (hF : IsComplexLinearMap J J₁ F) (hG : IsComplexLinearMap J J₂ G) :
-    IsComplexLinearMap J (J₁.prod J₂) (F.prod G) := by
-  rw [isComplexLinearMap_iff_apply] at hF hG ⊢
-  intro v
-  simp [hF v, hG v]
-
-end ComplexLinearMapProd
 
 section Projections
 
@@ -151,6 +133,7 @@ lemma IsJHolomorphic.prod {f : V → W} {g : V → X}
   fun x => (hf x).prod (hg x)
 
 /-- A map into a direct-sum target is pointwise `J`-holomorphic iff both coordinate maps are. -/
+@[simp]
 lemma isJHolomorphicAt_prod_iff (f : V → W × X) (x : V) :
     IsJHolomorphicAt J (J₁.prod J₂) f x ↔
       IsJHolomorphicAt J J₁ (fun y => (f y).1) x ∧
@@ -163,6 +146,7 @@ lemma isJHolomorphicAt_prod_iff (f : V → W × X) (x : V) :
     simpa using h.1.prod h.2
 
 /-- A map into a direct-sum target is `J`-holomorphic within a set iff both coordinate maps are. -/
+@[simp]
 lemma isJHolomorphicWithinAt_prod_iff (f : V → W × X) (s : Set V) (x : V) :
     IsJHolomorphicWithinAt J (J₁.prod J₂) f s x ↔
       IsJHolomorphicWithinAt J J₁ (fun y => (f y).1) s x ∧
@@ -175,6 +159,7 @@ lemma isJHolomorphicWithinAt_prod_iff (f : V → W × X) (s : Set V) (x : V) :
     simpa using h.1.prod h.2
 
 /-- A map into a direct-sum target is `J`-holomorphic on a set iff both coordinate maps are. -/
+@[simp]
 lemma isJHolomorphicOn_prod_iff (f : V → W × X) (s : Set V) :
     IsJHolomorphicOn J (J₁.prod J₂) f s ↔
       IsJHolomorphicOn J J₁ (fun y => (f y).1) s ∧
@@ -188,6 +173,7 @@ lemma isJHolomorphicOn_prod_iff (f : V → W × X) (s : Set V) :
     exact h.1.prod h.2
 
 /-- A map into a direct-sum target is globally `J`-holomorphic iff both coordinate maps are. -/
+@[simp]
 lemma isJHolomorphic_prod_iff (f : V → W × X) :
     IsJHolomorphic J (J₁.prod J₂) f ↔
       IsJHolomorphic J J₁ (fun y => (f y).1) ∧

--- a/TauCeti/Geometry/Symplectic/JHolomorphicProd.lean
+++ b/TauCeti/Geometry/Symplectic/JHolomorphicProd.lean
@@ -20,8 +20,8 @@ symmetric-product targets can use these lemmas without unfolding the Cauchy--Rie
 
 ## Main declarations
 
-* `TauCeti.IsJHolomorphicAt.prod`, `IsJHolomorphicWithinAt.prod`, `IsJHolomorphicOn.prod`,
-  and `IsJHolomorphic.prod`: product maps of `J`-holomorphic maps.
+* `TauCeti.IsJHolomorphicAt.prodMk`, `IsJHolomorphicWithinAt.prodMk`,
+  `IsJHolomorphicOn.prodMk`, and `IsJHolomorphic.prodMk`: product maps of `J`-holomorphic maps.
 * `TauCeti.isJHolomorphicAt_fst` and `isJHolomorphicAt_snd`, with within-set, setwise, and
   global variants: the coordinate projections are `J`-holomorphic.
 * `TauCeti.isJHolomorphicAt_prod_iff`, `isJHolomorphicWithinAt_prod_iff`,
@@ -103,7 +103,7 @@ variable {J₂ : AlmostComplexStructure X}
 
 /-- Pairing two pointwise `J`-holomorphic maps gives a `J`-holomorphic map into the direct-sum
 almost complex structure. -/
-lemma IsJHolomorphicAt.prod {f : V → W} {g : V → X} {x : V}
+lemma IsJHolomorphicAt.prodMk {f : V → W} {g : V → X} {x : V}
     (hf : IsJHolomorphicAt J J₁ f x) (hg : IsJHolomorphicAt J J₂ g x) :
     IsJHolomorphicAt J (J₁.prod J₂) (fun y => (f y, g y)) x := by
   refine ⟨hf.choose.prod hg.choose, hf.hasFDerivAt.prodMk hg.hasFDerivAt, ?_⟩
@@ -111,7 +111,7 @@ lemma IsJHolomorphicAt.prod {f : V → W} {g : V → X} {x : V}
 
 /-- Pairing two maps `J`-holomorphic within a set gives a `J`-holomorphic map into the direct-sum
 almost complex structure. -/
-lemma IsJHolomorphicWithinAt.prod {f : V → W} {g : V → X} {s : Set V} {x : V}
+lemma IsJHolomorphicWithinAt.prodMk {f : V → W} {g : V → X} {s : Set V} {x : V}
     (hf : IsJHolomorphicWithinAt J J₁ f s x)
     (hg : IsJHolomorphicWithinAt J J₂ g s x) :
     IsJHolomorphicWithinAt J (J₁.prod J₂) (fun y => (f y, g y)) s x := by
@@ -120,17 +120,17 @@ lemma IsJHolomorphicWithinAt.prod {f : V → W} {g : V → X} {s : Set V} {x : V
 
 /-- Pairing two maps `J`-holomorphic on a set gives a `J`-holomorphic map into the direct-sum
 almost complex structure. -/
-lemma IsJHolomorphicOn.prod {f : V → W} {g : V → X} {s : Set V}
+lemma IsJHolomorphicOn.prodMk {f : V → W} {g : V → X} {s : Set V}
     (hf : IsJHolomorphicOn J J₁ f s) (hg : IsJHolomorphicOn J J₂ g s) :
     IsJHolomorphicOn J (J₁.prod J₂) (fun y => (f y, g y)) s :=
-  fun x hx => (hf x hx).prod (hg x hx)
+  fun x hx => (hf x hx).prodMk (hg x hx)
 
 /-- Pairing two globally `J`-holomorphic maps gives a `J`-holomorphic map into the direct-sum
 almost complex structure. -/
-lemma IsJHolomorphic.prod {f : V → W} {g : V → X}
+lemma IsJHolomorphic.prodMk {f : V → W} {g : V → X}
     (hf : IsJHolomorphic J J₁ f) (hg : IsJHolomorphic J J₂ g) :
     IsJHolomorphic J (J₁.prod J₂) (fun y => (f y, g y)) :=
-  fun x => (hf x).prod (hg x)
+  fun x => (hf x).prodMk (hg x)
 
 /-- A map into a direct-sum target is pointwise `J`-holomorphic iff both coordinate maps are. -/
 @[simp]
@@ -143,7 +143,7 @@ lemma isJHolomorphicAt_prod_iff (f : V → W × X) (x : V) :
     exact ⟨(isJHolomorphicAt_fst J₁ J₂ (f x)).comp hf,
       (isJHolomorphicAt_snd J₁ J₂ (f x)).comp hf⟩
   · intro h
-    simpa using h.1.prod h.2
+    simpa using h.1.prodMk h.2
 
 /-- A map into a direct-sum target is `J`-holomorphic within a set iff both coordinate maps are. -/
 @[simp]
@@ -156,7 +156,7 @@ lemma isJHolomorphicWithinAt_prod_iff (f : V → W × X) (s : Set V) (x : V) :
     exact ⟨(isJHolomorphicWithinAt_fst J₁ J₂ Set.univ (f x)).comp hf (by simp),
       (isJHolomorphicWithinAt_snd J₁ J₂ Set.univ (f x)).comp hf (by simp)⟩
   · intro h
-    simpa using h.1.prod h.2
+    simpa using h.1.prodMk h.2
 
 /-- A map into a direct-sum target is `J`-holomorphic on a set iff both coordinate maps are. -/
 @[simp]
@@ -170,7 +170,7 @@ lemma isJHolomorphicOn_prod_iff (f : V → W × X) (s : Set V) :
     · exact ((isJHolomorphicWithinAt_prod_iff f s x).mp (hf x hx)).1
     · exact ((isJHolomorphicWithinAt_prod_iff f s x).mp (hf x hx)).2
   · intro h
-    exact h.1.prod h.2
+    exact h.1.prodMk h.2
 
 /-- A map into a direct-sum target is globally `J`-holomorphic iff both coordinate maps are. -/
 @[simp]
@@ -184,7 +184,7 @@ lemma isJHolomorphic_prod_iff (f : V → W × X) :
     · exact ((isJHolomorphicAt_prod_iff f x).mp (hf x)).1
     · exact ((isJHolomorphicAt_prod_iff f x).mp (hf x)).2
   · intro h
-    exact h.1.prod h.2
+    exact h.1.prodMk h.2
 
 end ProductMaps
 

--- a/TauCeti/Geometry/Symplectic/JHolomorphicProd.lean
+++ b/TauCeti/Geometry/Symplectic/JHolomorphicProd.lean
@@ -1,0 +1,205 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+import Mathlib.Analysis.Calculus.FDeriv.Prod
+import TauCeti.Geometry.Symplectic.JHolomorphic
+import TauCeti.Geometry.Symplectic.Prod
+
+/-!
+# Product operations for `J`-holomorphic maps
+
+This file adds the product calculus for the map-level `J`-holomorphic predicate used by the
+analytic Heegaard Floer roadmap. The target product carries the direct-sum almost complex
+structure from `TauCeti.Geometry.Symplectic.Prod`, and a map into that product is
+`J`-holomorphic exactly when its two coordinate maps are.
+
+The API is deliberately local and linear: it packages Mathlib's Frechet-derivative product
+rules with the existing linear direct-sum almost-complex API. Later strip, disk, product, and
+symmetric-product targets can use these lemmas without unfolding the Cauchy--Riemann equation.
+
+## Main declarations
+
+* `TauCeti.IsComplexLinearMap.prod`: a pair of complex-linear maps with the same source is
+  complex-linear into a direct-sum target.
+* `TauCeti.IsJHolomorphicAt.prod`, `IsJHolomorphicWithinAt.prod`, `IsJHolomorphicOn.prod`,
+  and `IsJHolomorphic.prod`: product maps of `J`-holomorphic maps.
+* `TauCeti.isJHolomorphicAt_fst` and `isJHolomorphicAt_snd`, with within-set, setwise, and
+  global variants: the coordinate projections are `J`-holomorphic.
+* `TauCeti.isJHolomorphicAt_prod_iff`, `isJHolomorphicWithinAt_prod_iff`,
+  `isJHolomorphicOn_prod_iff`, and `isJHolomorphic_prod_iff`: coordinatewise
+  characterizations of `J`-holomorphic maps into a product.
+
+The convention follows McDuff--Salamon, *J-holomorphic Curves and Symplectic Topology*,
+Section 2.1: product almost complex structures act componentwise.
+-/
+
+namespace TauCeti
+
+variable {V W X : Type*}
+
+variable [NormedAddCommGroup V] [NormedSpace ℝ V]
+variable [NormedAddCommGroup W] [NormedSpace ℝ W]
+variable [NormedAddCommGroup X] [NormedSpace ℝ X]
+
+section ComplexLinearMapProd
+
+variable {J : AlmostComplexStructure V} {J₁ : AlmostComplexStructure W}
+variable {J₂ : AlmostComplexStructure X}
+
+/-- A pair of complex-linear maps with the same source is complex-linear into the direct-sum
+almost complex structure. -/
+lemma IsComplexLinearMap.prod {F : V →ₗ[ℝ] W} {G : V →ₗ[ℝ] X}
+    (hF : IsComplexLinearMap J J₁ F) (hG : IsComplexLinearMap J J₂ G) :
+    IsComplexLinearMap J (J₁.prod J₂) (F.prod G) := by
+  rw [isComplexLinearMap_iff_apply] at hF hG ⊢
+  intro v
+  simp [hF v, hG v]
+
+end ComplexLinearMapProd
+
+section Projections
+
+variable (J₁ : AlmostComplexStructure V) (J₂ : AlmostComplexStructure W)
+
+/-- The first coordinate projection is `J`-holomorphic at every point. -/
+@[simp]
+lemma isJHolomorphicAt_fst (p : V × W) :
+    IsJHolomorphicAt (J₁.prod J₂) J₁ Prod.fst p :=
+  (isJHolomorphicAt_continuousLinearMap_iff (ContinuousLinearMap.fst ℝ V W) p).mpr
+    (AlmostComplexStructure.isComplexLinearMap_fst J₁ J₂)
+
+/-- The second coordinate projection is `J`-holomorphic at every point. -/
+@[simp]
+lemma isJHolomorphicAt_snd (p : V × W) :
+    IsJHolomorphicAt (J₁.prod J₂) J₂ Prod.snd p :=
+  (isJHolomorphicAt_continuousLinearMap_iff (ContinuousLinearMap.snd ℝ V W) p).mpr
+    (AlmostComplexStructure.isComplexLinearMap_snd J₁ J₂)
+
+/-- The first coordinate projection is `J`-holomorphic within every set. -/
+@[simp]
+lemma isJHolomorphicWithinAt_fst (s : Set (V × W)) (p : V × W) :
+    IsJHolomorphicWithinAt (J₁.prod J₂) J₁ Prod.fst s p :=
+  (isJHolomorphicAt_fst J₁ J₂ p).isJHolomorphicWithinAt
+
+/-- The second coordinate projection is `J`-holomorphic within every set. -/
+@[simp]
+lemma isJHolomorphicWithinAt_snd (s : Set (V × W)) (p : V × W) :
+    IsJHolomorphicWithinAt (J₁.prod J₂) J₂ Prod.snd s p :=
+  (isJHolomorphicAt_snd J₁ J₂ p).isJHolomorphicWithinAt
+
+/-- The first coordinate projection is `J`-holomorphic on every set. -/
+@[simp]
+lemma isJHolomorphicOn_fst (s : Set (V × W)) :
+    IsJHolomorphicOn (J₁.prod J₂) J₁ Prod.fst s :=
+  fun p _ => isJHolomorphicWithinAt_fst J₁ J₂ s p
+
+/-- The second coordinate projection is `J`-holomorphic on every set. -/
+@[simp]
+lemma isJHolomorphicOn_snd (s : Set (V × W)) :
+    IsJHolomorphicOn (J₁.prod J₂) J₂ Prod.snd s :=
+  fun p _ => isJHolomorphicWithinAt_snd J₁ J₂ s p
+
+/-- The first coordinate projection is globally `J`-holomorphic. -/
+@[simp]
+lemma isJHolomorphic_fst :
+    IsJHolomorphic (J₁.prod J₂) J₁ Prod.fst :=
+  fun p => isJHolomorphicAt_fst J₁ J₂ p
+
+/-- The second coordinate projection is globally `J`-holomorphic. -/
+@[simp]
+lemma isJHolomorphic_snd :
+    IsJHolomorphic (J₁.prod J₂) J₂ Prod.snd :=
+  fun p => isJHolomorphicAt_snd J₁ J₂ p
+
+end Projections
+
+section ProductMaps
+
+variable {J : AlmostComplexStructure V} {J₁ : AlmostComplexStructure W}
+variable {J₂ : AlmostComplexStructure X}
+
+/-- Pairing two pointwise `J`-holomorphic maps gives a `J`-holomorphic map into the direct-sum
+almost complex structure. -/
+lemma IsJHolomorphicAt.prod {f : V → W} {g : V → X} {x : V}
+    (hf : IsJHolomorphicAt J J₁ f x) (hg : IsJHolomorphicAt J J₂ g x) :
+    IsJHolomorphicAt J (J₁.prod J₂) (fun y => (f y, g y)) x := by
+  refine ⟨hf.choose.prod hg.choose, hf.hasFDerivAt.prodMk hg.hasFDerivAt, ?_⟩
+  exact hf.derivative_isComplexLinear.prod hg.derivative_isComplexLinear
+
+/-- Pairing two maps `J`-holomorphic within a set gives a `J`-holomorphic map into the direct-sum
+almost complex structure. -/
+lemma IsJHolomorphicWithinAt.prod {f : V → W} {g : V → X} {s : Set V} {x : V}
+    (hf : IsJHolomorphicWithinAt J J₁ f s x)
+    (hg : IsJHolomorphicWithinAt J J₂ g s x) :
+    IsJHolomorphicWithinAt J (J₁.prod J₂) (fun y => (f y, g y)) s x := by
+  refine ⟨hf.choose.prod hg.choose, hf.hasFDerivWithinAt.prodMk hg.hasFDerivWithinAt, ?_⟩
+  exact hf.derivative_isComplexLinear.prod hg.derivative_isComplexLinear
+
+/-- Pairing two maps `J`-holomorphic on a set gives a `J`-holomorphic map into the direct-sum
+almost complex structure. -/
+lemma IsJHolomorphicOn.prod {f : V → W} {g : V → X} {s : Set V}
+    (hf : IsJHolomorphicOn J J₁ f s) (hg : IsJHolomorphicOn J J₂ g s) :
+    IsJHolomorphicOn J (J₁.prod J₂) (fun y => (f y, g y)) s :=
+  fun x hx => (hf x hx).prod (hg x hx)
+
+/-- Pairing two globally `J`-holomorphic maps gives a `J`-holomorphic map into the direct-sum
+almost complex structure. -/
+lemma IsJHolomorphic.prod {f : V → W} {g : V → X}
+    (hf : IsJHolomorphic J J₁ f) (hg : IsJHolomorphic J J₂ g) :
+    IsJHolomorphic J (J₁.prod J₂) (fun y => (f y, g y)) :=
+  fun x => (hf x).prod (hg x)
+
+/-- A map into a direct-sum target is pointwise `J`-holomorphic iff both coordinate maps are. -/
+lemma isJHolomorphicAt_prod_iff (f : V → W × X) (x : V) :
+    IsJHolomorphicAt J (J₁.prod J₂) f x ↔
+      IsJHolomorphicAt J J₁ (fun y => (f y).1) x ∧
+        IsJHolomorphicAt J J₂ (fun y => (f y).2) x := by
+  constructor
+  · intro hf
+    exact ⟨(isJHolomorphicAt_fst J₁ J₂ (f x)).comp hf,
+      (isJHolomorphicAt_snd J₁ J₂ (f x)).comp hf⟩
+  · intro h
+    simpa using h.1.prod h.2
+
+/-- A map into a direct-sum target is `J`-holomorphic within a set iff both coordinate maps are. -/
+lemma isJHolomorphicWithinAt_prod_iff (f : V → W × X) (s : Set V) (x : V) :
+    IsJHolomorphicWithinAt J (J₁.prod J₂) f s x ↔
+      IsJHolomorphicWithinAt J J₁ (fun y => (f y).1) s x ∧
+        IsJHolomorphicWithinAt J J₂ (fun y => (f y).2) s x := by
+  constructor
+  · intro hf
+    exact ⟨(isJHolomorphicWithinAt_fst J₁ J₂ Set.univ (f x)).comp hf (by simp),
+      (isJHolomorphicWithinAt_snd J₁ J₂ Set.univ (f x)).comp hf (by simp)⟩
+  · intro h
+    simpa using h.1.prod h.2
+
+/-- A map into a direct-sum target is `J`-holomorphic on a set iff both coordinate maps are. -/
+lemma isJHolomorphicOn_prod_iff (f : V → W × X) (s : Set V) :
+    IsJHolomorphicOn J (J₁.prod J₂) f s ↔
+      IsJHolomorphicOn J J₁ (fun y => (f y).1) s ∧
+        IsJHolomorphicOn J J₂ (fun y => (f y).2) s := by
+  constructor
+  · intro hf
+    refine ⟨fun x hx => ?_, fun x hx => ?_⟩
+    · exact ((isJHolomorphicWithinAt_prod_iff f s x).mp (hf x hx)).1
+    · exact ((isJHolomorphicWithinAt_prod_iff f s x).mp (hf x hx)).2
+  · intro h
+    exact h.1.prod h.2
+
+/-- A map into a direct-sum target is globally `J`-holomorphic iff both coordinate maps are. -/
+lemma isJHolomorphic_prod_iff (f : V → W × X) :
+    IsJHolomorphic J (J₁.prod J₂) f ↔
+      IsJHolomorphic J J₁ (fun y => (f y).1) ∧
+        IsJHolomorphic J J₂ (fun y => (f y).2) := by
+  constructor
+  · intro hf
+    refine ⟨fun x => ?_, fun x => ?_⟩
+    · exact ((isJHolomorphicAt_prod_iff f x).mp (hf x)).1
+    · exact ((isJHolomorphicAt_prod_iff f x).mp (hf x)).2
+  · intro h
+    exact h.1.prod h.2
+
+end ProductMaps
+
+end TauCeti

--- a/TauCeti/Geometry/Symplectic/Prod.lean
+++ b/TauCeti/Geometry/Symplectic/Prod.lean
@@ -31,6 +31,8 @@ following Mathlib's `LinearMap.prodMap` naming convention.
   `isComplexLinearMap_fst` / `isComplexLinearMap_snd`: the structural maps of the product are
   complex-linear for the direct-sum structure.
 * `TauCeti.AlmostComplexStructure.transport_prod`: transport distributes over the direct sum.
+* `TauCeti.IsComplexLinearMap.prod` and `TauCeti.IsComplexLinearMap.prodMap`: complex-linearity is
+  preserved by pairing maps with a common source and by product maps into the direct sum.
 * `TauCeti.SymplecticForm.prod`: the direct-sum symplectic form on `V × W`.
 * `TauCeti.SymplecticForm.prod_invariant`, `prod_tames`, `prod_compatible`: a direct sum of
   invariant / tame / compatible pairs is invariant / tame / compatible.
@@ -128,6 +130,16 @@ section ComplexLinearMap
 
 variable [AddCommGroup V] [Module ℝ V] [AddCommGroup W] [Module ℝ W]
 variable [AddCommGroup V'] [Module ℝ V'] [AddCommGroup W'] [Module ℝ W']
+
+/-- A pair of complex-linear maps with the same source is complex-linear into the direct-sum
+almost complex structure. -/
+lemma IsComplexLinearMap.prod {J : AlmostComplexStructure V} {J₁ : AlmostComplexStructure W}
+    {J₂ : AlmostComplexStructure V'} {F : V →ₗ[ℝ] W} {G : V →ₗ[ℝ] V'}
+    (hF : IsComplexLinearMap J J₁ F) (hG : IsComplexLinearMap J J₂ G) :
+    IsComplexLinearMap J (J₁.prod J₂) (F.prod G) := by
+  rw [isComplexLinearMap_iff_apply] at hF hG ⊢
+  intro v
+  simp [hF v, hG v]
 
 /-- A product map of complex-linear maps is complex-linear for the direct-sum almost complex
 structures. -/


### PR DESCRIPTION
This PR adds product calculus for Tau Ceti's pointwise `J`-holomorphic maps: coordinate projections from a direct-sum almost complex target are `J`-holomorphic, products of two `J`-holomorphic maps are `J`-holomorphic into the direct sum, and maps into a product are characterized coordinatewise by `isJHolomorphicAt_prod_iff`, `isJHolomorphicWithinAt_prod_iff`, `isJHolomorphicOn_prod_iff`, and `isJHolomorphic_prod_iff`. Use these lemmas as the product-target API for the local Cauchy--Riemann equation, so later strip, disk, product, and symmetric-product constructions do not unfold `IsJHolomorphicAt`.

This advances `TauCetiRoadmap/HeegaardFloer/README.md`, Lane F2.1 ("Definitions land immediately ... almost complex structures ... `J`-holomorphic maps") and supplies a clean prerequisite for Lane F2.2/F3/F4 where holomorphic strips/disks are composed with product charts and projected to factors. The existing files already define linear almost complex structures, the direct-sum almost complex structure, and the core `J`-holomorphic predicate; this PR fills the lowest-hanging missing API between them without introducing manifold-level or Fredholm machinery.

The reused formal infrastructure is Mathlib's Frechet-derivative product API in `Mathlib/Analysis/Calculus/FDeriv/Prod.lean`, especially `HasFDerivAt.prodMk` and `HasFDerivWithinAt.prodMk`, together with Tau Ceti's existing `TauCeti.AlmostComplexStructure.prod`, `TauCeti.IsComplexLinearMap.prodMap`, and projection complex-linearity lemmas. No Mathlib code or external formalization is vendored. The conventions follow McDuff--Salamon, *J-holomorphic Curves and Symplectic Topology*, Section 2.1, where product almost complex structures act componentwise.

Local verification against the pinned toolchain: `lake exe cache get` completed successfully; full `lake build` is green (`Build completed successfully (4049 jobs).`); and `lake exe axioms` is clean (`axioms: audited 3769 TauCeti declaration(s); all within the allowlist [propext, Classical.choice, Quot.sound].`).

<!--tauceti-target:v1 {"focus":"HeegaardFloer","id":"j-holomorphic-product-maps"}-->

🤖 Prepared with Codex
