### PR TITLE
feat: base change diagonalizable group points

### DIFF
--- a/TauCeti/Algebra/AlgebraicGroup/DiagonalizableGroupBaseChange.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/DiagonalizableGroupBaseChange.lean
@@ -1,0 +1,178 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+import TauCeti.Algebra.AlgebraicGroup.BaseChangeNaturality
+import TauCeti.Algebra.AlgebraicGroup.DiagonalizableGroupFunctoriality
+
+/-!
+# Base change of diagonalizable-group points
+
+For a commutative group `G`, the diagonalizable group `D(G)` over `k` is represented by the
+Hopf algebra `k[G]`. This file records the corresponding base-change calculation on functors
+of points: if `K` is a `k`-algebra and `A` is a commutative `K`-algebra, then the
+`A`-valued points of the base-changed Hopf algebra `K ⊗[k] k[G]` are still the character group
+`G →* Aˣ`.
+
+The construction is the composition of two existing Tau Ceti equivalences:
+`AlgHom.baseChangePointsMulEquiv`, which identifies points of `K ⊗[k] k[G]` with
+`k`-algebra maps out of `k[G]`, and `DiagonalizableGroup.pointsMulEquiv`, which identifies
+those maps with characters. The lemmas here spell out the values on the group-like generators
+`1 ⊗ single g 1`, the inverse map, naturality in the value algebra, and compatibility with
+the contravariant functoriality in `G`.
+
+This advances the ReductiveGroups roadmap, Layer 0 ("Base change. `K ⊗[k] A` as a Hopf
+algebra over `K`") and Layer 4 ("Diagonalizable groups and groups of multiplicative type:
+`M ↦ D(M) = Spec k[M]`").
+
+## Main declarations
+
+* `TauCeti.DiagonalizableGroup.baseChangePointsMulEquiv`: the multiplicative equivalence
+  from base-changed points of `D(G)` to the character group `G →* Aˣ`.
+* `TauCeti.DiagonalizableGroup.baseChangePointsMulEquiv_apply_coe`: the equivalence reads a
+  point by evaluating it on `1 ⊗ single g 1`.
+* `TauCeti.DiagonalizableGroup.baseChangePointsMulEquiv_mapValue`: the equivalence is
+  natural in the value algebra.
+* `TauCeti.DiagonalizableGroup.baseChangePointsMulEquiv_mapDomain`: under a homomorphism
+  `G →* G'`, the base-changed points map is precomposition of characters.
+
+## References
+
+The group-algebra Hopf structure and `MonoidAlgebra.mapDomainBialgHom` are Mathlib's
+`Mathlib.RingTheory.HopfAlgebra.MonoidAlgebra` and
+`Mathlib.RingTheory.Bialgebra.MonoidAlgebra`. The base-change equivalence and the
+diagonalizable-group points calculation are Tau Ceti's
+`TauCeti.AlgHom.baseChangePointsMulEquiv` and
+`TauCeti.DiagonalizableGroup.pointsMulEquiv`.
+-/
+
+open WithConv
+open scoped TensorProduct
+
+namespace TauCeti
+
+universe u v w w'
+
+namespace DiagonalizableGroup
+
+variable {k : Type u} {K : Type v} {A : Type w} {G : Type w'}
+variable [CommSemiring k] [CommSemiring K] [CommSemiring A]
+variable [Algebra k K] [Algebra K A] [Algebra k A] [IsScalarTower k K A]
+variable [CommGroup G]
+
+/-- The `A`-points of the base change `K ⊗[k] k[G]` of the diagonalizable group `D(G)` are
+the character group `G →* Aˣ`.
+
+The source is the convolution group of `K`-algebra maps out of the base-changed Hopf algebra.
+The target is the ordinary pointwise-multiplication group of characters. -/
+noncomputable def baseChangePointsMulEquiv :
+    WithConv (K ⊗[k] MonoidAlgebra k G →ₐ[K] A) ≃* (G →* Aˣ) :=
+  (AlgHom.baseChangePointsMulEquiv (k := k) (K := K)
+      (A := MonoidAlgebra k G) (R := A)).symm.trans
+    (pointsMulEquiv (R := k) (A := A) (G := G))
+
+/-- Applying `baseChangePointsMulEquiv` first restricts a base-changed point along
+`g ↦ 1 ⊗ single g 1`, then reads off its character. -/
+@[simp]
+theorem baseChangePointsMulEquiv_apply
+    (f : WithConv (K ⊗[k] MonoidAlgebra k G →ₐ[K] A)) :
+    baseChangePointsMulEquiv f =
+      charOfPoint
+        (((AlgHom.baseChangePointsMulEquiv (k := k) (K := K)
+          (A := MonoidAlgebra k G) (R := A)).symm f).ofConv) :=
+  rfl
+
+/-- The base-changed diagonalizable-points equivalence reads a point by evaluating it on the
+base-changed group-like element `1 ⊗ single g 1`. -/
+@[simp]
+theorem baseChangePointsMulEquiv_apply_coe
+    (f : WithConv (K ⊗[k] MonoidAlgebra k G →ₐ[K] A)) (g : G) :
+    (baseChangePointsMulEquiv f g : A) =
+      f.ofConv (1 ⊗ₜ[k] MonoidAlgebra.single g (1 : k)) := by
+  rw [baseChangePointsMulEquiv_apply, charOfPoint_apply_coe,
+    AlgHom.baseChangePointsMulEquiv_symm_apply]
+
+/-- The inverse base-changed diagonalizable-points equivalence extends a character after
+base change. On a pure tensor it sends `s ⊗ single g r` to `s • (r • χ g)`. -/
+@[simp]
+theorem baseChangePointsMulEquiv_symm_apply_tmul_single (χ : G →* Aˣ) (s : K)
+    (g : G) (r : k) :
+    ((baseChangePointsMulEquiv (k := k) (K := K) (A := A) (G := G)).symm χ).ofConv
+        (s ⊗ₜ[k] MonoidAlgebra.single g r) =
+      s • (r • (χ g : A)) := by
+  simp [baseChangePointsMulEquiv, DiagonalizableGroup.pointsMulEquiv_symm_apply,
+    DiagonalizableGroup.point_single]
+
+/-- The inverse base-changed diagonalizable-points equivalence takes `1 ⊗ single g 1` to the
+value of the character at `g`. -/
+@[simp]
+theorem baseChangePointsMulEquiv_symm_apply_single_one (χ : G →* Aˣ) (g : G) :
+    ((baseChangePointsMulEquiv (k := k) (K := K) (A := A) (G := G)).symm χ).ofConv
+        (1 ⊗ₜ[k] MonoidAlgebra.single g (1 : k)) =
+      (χ g : A) := by
+  rw [baseChangePointsMulEquiv_symm_apply_tmul_single]
+  simp
+
+variable {B : Type*} [CommSemiring B] [Algebra K B] [Algebra k B] [IsScalarTower k K B]
+
+/-- The base-changed diagonalizable-points equivalence is natural in the value algebra. -/
+@[simp]
+theorem baseChangePointsMulEquiv_mapValue (φ : A →ₐ[K] B)
+    (f : WithConv (K ⊗[k] MonoidAlgebra k G →ₐ[K] A)) :
+    baseChangePointsMulEquiv
+        (AlgHom.mapValue (H := K ⊗[k] MonoidAlgebra k G) φ f) =
+      (Units.map φ.toMonoidHom).comp
+        (baseChangePointsMulEquiv (k := k) (K := K) (A := A) (G := G) f) := by
+  ext g
+  simp [Units.coe_map]
+
+/-- Naturality of the inverse base-changed diagonalizable-points equivalence in the value
+algebra. -/
+@[simp]
+theorem mapValue_baseChangePointsMulEquiv_symm_apply (φ : A →ₐ[K] B) (χ : G →* Aˣ) :
+    AlgHom.mapValue (H := K ⊗[k] MonoidAlgebra k G) φ
+        ((baseChangePointsMulEquiv (k := k) (K := K) (A := A) (G := G)).symm χ) =
+      (baseChangePointsMulEquiv (k := k) (K := K) (A := B) (G := G)).symm
+        ((Units.map φ.toMonoidHom).comp χ) := by
+  apply (baseChangePointsMulEquiv (k := k) (K := K) (A := B) (G := G)).injective
+  rw [baseChangePointsMulEquiv_mapValue]
+  simp
+
+section MapDomain
+
+variable {G' : Type*} [CommGroup G']
+
+/-- Under base change, the points map induced contravariantly by `φ : G →* G'` is
+precomposition of characters by `φ`. -/
+@[simp]
+theorem baseChangePointsMulEquiv_mapDomain (φ : G →* G')
+    (f : WithConv (K ⊗[k] MonoidAlgebra k G' →ₐ[K] A)) :
+    baseChangePointsMulEquiv
+        (AlgHom.mapDomain (A := A)
+          (_root_.Bialgebra.TensorProduct.map (_root_.BialgHom.id K K)
+            (MonoidAlgebra.mapDomainBialgHom k φ)) f) =
+      (baseChangePointsMulEquiv (k := k) (K := K) (A := A) (G := G') f).comp φ := by
+  ext g
+  simp only [baseChangePointsMulEquiv_apply_coe, MonoidHom.comp_apply,
+    AlgHom.mapDomain_apply_apply, _root_.Bialgebra.TensorProduct.map_tmul,
+    _root_.BialgHom.id_apply, MonoidAlgebra.mapDomainBialgHom_apply,
+    MonoidAlgebra.mapDomain_single]
+
+/-- Mapping the base-changed point attached to a character is precomposition of that character
+by the homomorphism of character groups. -/
+@[simp]
+theorem mapDomain_baseChangePointsMulEquiv_symm_apply (φ : G →* G') (χ : G' →* Aˣ) :
+    AlgHom.mapDomain (A := A)
+        (_root_.Bialgebra.TensorProduct.map (_root_.BialgHom.id K K)
+          (MonoidAlgebra.mapDomainBialgHom k φ))
+        ((baseChangePointsMulEquiv (k := k) (K := K) (A := A) (G := G')).symm χ) =
+      (baseChangePointsMulEquiv (k := k) (K := K) (A := A) (G := G)).symm (χ.comp φ) := by
+  apply (baseChangePointsMulEquiv (k := k) (K := K) (A := A) (G := G)).injective
+  rw [baseChangePointsMulEquiv_mapDomain]
+  simp
+
+end MapDomain
+
+end DiagonalizableGroup
+
+end TauCeti


### PR DESCRIPTION
This PR adds the base-change points calculation for diagonalizable groups: for a commutative group `G`, a `k`-algebra `K`, and a commutative `K`-algebra `A`, it identifies the convolution group of `K`-algebra maps out of the base-changed Hopf algebra `K ⊗[k] k[G]` with the character group `G →* Aˣ`. It records the pointwise formula on `1 ⊗ single g 1`, the inverse formula on pure tensors `s ⊗ single g r`, naturality in the value algebra, and compatibility with the contravariant functoriality in `G`, so downstream diagonalizable-group arguments can use base change without unfolding the generic `AlgHom.baseChangePointsMulEquiv` composition.

This advances `TauCetiRoadmap/ReductiveGroups/README.md`, Layer 0, the specific item "Base change. `K ⊗[k] A` as a Hopf algebra over `K`", together with Layer 4, "Diagonalizable groups and groups of multiplicative type: the anti-equivalence `M ↦ D(M) = Spec k[M]`". It is the lowest-hanging remaining ReductiveGroups target I found because the convolution points group, base-change equivalence, diagonalizable points calculation, and diagonalizable functoriality already exist in Tau Ceti; this PR only supplies the missing characteristic API for their intersection and does not overlap the open/merged product, quotient, or category-refactor work.

No Mathlib infrastructure is vendored. The construction reuses Tau Ceti's `TauCeti.AlgHom.baseChangePointsMulEquiv`, `TauCeti.DiagonalizableGroup.pointsMulEquiv`, and `TauCeti.AlgHom.mapDomain`, plus Mathlib's group-algebra Hopf structure and `MonoidAlgebra.mapDomainBialgHom`.

Local verification: `lake exe cache get` completed with `Already decompressed 8573 file(s)`; `lake build` completed with `Build completed successfully (4056 jobs).`; `lake exe axioms` completed with `axioms: audited 3866 TauCeti declaration(s); all within the allowlist [propext, Classical.choice, Quot.sound].`

<!--tauceti-target:v1 {"focus":"ReductiveGroups","id":"diagonalizable-base-change-points"}-->

🤖 Prepared with Codex
