### PR TITLE
feat: add massive energy integrand coercivity

### DIFF
--- a/TauCeti/Analysis/PDE/CoerciveEnergy.lean
+++ b/TauCeti/Analysis/PDE/CoerciveEnergy.lean
@@ -21,17 +21,12 @@ monolithic PDE class.
 
 ## Main declarations
 
-* `TauCeti.PDE.energyIntegrand_self_lower_bound_of_bounds`: pointwise lower bound for the
-  energy density with bounded drift and a mass lower bound.
-* `TauCeti.PDE.isCoercive_energyIntegrand_of_bounds`: coercivity of the jet bilinear form when
-  the mass lower bound dominates the drift defect.
+* `TauCeti.PDE.min_mul_prod_norm_sq_le_add`: product sup-norm lower-bound bridge for
+  coercivity estimates.
 * `TauCeti.PDE.isCoercive_energyIntegrand_zero_drift_of_lower_bounds`: the zero-drift
   specialization, needing only a positive mass lower bound.
-* `TauCeti.PDE.isCoercive_energyIntegrand_of_bounds_on`: the domain version from raw lower
-  bounds, with no upper ellipticity bound or bundled coefficient predicate.
-* `TauCeti.PDE.UniformlyEllipticOn.isCoercive_energyIntegrand` and
-  `TauCeti.PDE.UniformlyEllipticOn.isCoercive_energyIntegrand_zero_drift`: the same results
-  using the bundled uniform-ellipticity and coefficient predicates.
+* `TauCeti.PDE.UniformlyEllipticOn.isCoercive_energyIntegrand_zero_drift`: the same result
+  using the bundled uniform-ellipticity and mass lower-bound predicates.
 -/
 
 namespace TauCeti
@@ -48,7 +43,7 @@ variable {lam mu beta : ℝ}
 omit [DecidableEq n] in
 /-- The square of the product sup norm is controlled by the two squared coordinate norms
 with the smaller coefficient. -/
-private lemma min_mul_prod_norm_sq_le_add (hlam : 0 ≤ lam) (hmu : 0 ≤ mu)
+lemma min_mul_prod_norm_sq_le_add (hlam : 0 ≤ lam) (hmu : 0 ≤ mu)
     (U : ℝ × EuclideanSpace ℝ n) :
     min lam mu * ‖U‖ ^ 2 ≤ lam * ‖U.2‖ ^ 2 + mu * ‖U.1‖ ^ 2 := by
   have hmin_lam : min lam mu ≤ lam := min_le_left _ _
@@ -73,7 +68,7 @@ private lemma min_mul_prod_norm_sq_le_add (hlam : 0 ≤ lam) (hmu : 0 ≤ mu)
 If the principal part has quadratic lower bound `λ‖ξ‖²`, the drift satisfies `‖b₀‖ ≤ β`, and
 the mass coefficient satisfies `μ ≤ c₀`, then the diagonal of the jet form is bounded below by
 `(λ/2)‖∇u‖² + (μ − β²/2λ)|u|²`. -/
-lemma energyIntegrand_self_lower_bound_of_bounds (hlam : 0 < lam)
+private lemma energyIntegrand_self_lower_bound_of_bounds (hlam : 0 < lam)
     {A : Matrix n n ℝ} {b₀ : EuclideanSpace ℝ n} {c₀ : ℝ}
     (hA : ∀ ξ : EuclideanSpace ℝ n, lam * ‖ξ‖ ^ 2 ≤ A.toQuadraticForm' ξ)
     (hb : ‖b₀‖ ≤ beta) (hc : mu ≤ c₀) (U : ℝ × EuclideanSpace ℝ n) :
@@ -96,7 +91,7 @@ lemma energyIntegrand_self_lower_bound_of_bounds (hlam : 0 < lam)
 
 With ellipticity floor `λ`, drift bound `β`, and mass lower bound `μ` satisfying `β²/2λ < μ`,
 the jet form is coercive with constant `min (λ/2) (μ − β²/2λ)`. -/
-lemma isCoercive_energyIntegrand_of_bounds (hlam : 0 < lam)
+private lemma isCoercive_energyIntegrand_of_bounds (hlam : 0 < lam)
     {A : Matrix n n ℝ} {b₀ : EuclideanSpace ℝ n} {c₀ : ℝ}
     (hA : ∀ ξ : EuclideanSpace ℝ n, lam * ‖ξ‖ ^ 2 ≤ A.toQuadraticForm' ξ)
     (hb : ‖b₀‖ ≤ beta) (hc : mu ≤ c₀) (hmu : beta ^ 2 / (2 * lam) < mu) :
@@ -125,7 +120,7 @@ lemma isCoercive_energyIntegrand_zero_drift_of_lower_bounds (hlam : 0 < lam) (hm
 At each point of `Ω`, an ellipticity floor `λ`, a drift bound `β`, and a mass lower bound `μ`
 with `β²/2λ < μ` make the jet form coercive.  Only the lower assumptions are needed: there is
 no upper ellipticity bound and no bundled coefficient predicate. -/
-lemma isCoercive_energyIntegrand_of_bounds_on {Ω : Set X}
+private lemma isCoercive_energyIntegrand_of_bounds_on {Ω : Set X}
     {a : X → Matrix n n ℝ} {b : X → EuclideanSpace ℝ n} {c : X → ℝ} (hlam : 0 < lam)
     (hA : ∀ ⦃x⦄, x ∈ Ω → ∀ ξ : EuclideanSpace ℝ n, lam * ‖ξ‖ ^ 2 ≤ (a x).toQuadraticForm' ξ)
     (hb : ∀ ⦃x⦄, x ∈ Ω → ‖b x‖ ≤ beta) (hc : ∀ ⦃x⦄, x ∈ Ω → mu ≤ c x)
@@ -142,7 +137,7 @@ variable {lam Lam beta mu : ℝ}
 dominates the drift defect make the pointwise jet integrand coercive at every point of the
 domain. -/
 @[grind =>]
-lemma isCoercive_energyIntegrand (he : UniformlyEllipticOn Ω a lam Lam)
+private lemma isCoercive_energyIntegrand (he : UniformlyEllipticOn Ω a lam Lam)
     (hb : DriftBoundedOn Ω b beta) (hc : MassLowerBoundOn Ω c mu)
     (hmu : beta ^ 2 / (2 * lam) < mu) {x : X} (hx : x ∈ Ω) :
     IsCoercive (energyIntegrand (a x) (b x) (c x)) :=

--- a/TauCeti/Analysis/PDE/CoerciveEnergy.lean
+++ b/TauCeti/Analysis/PDE/CoerciveEnergy.lean
@@ -23,10 +23,12 @@ monolithic PDE class.
 
 * `TauCeti.PDE.energyIntegrand_self_lower_bound_of_bounds`: pointwise lower bound for the
   energy density with bounded drift and a mass lower bound.
-* `TauCeti.PDE.isCoercive_energyIntegrand_of_lower_bounds`: coercivity of the bundled jet
-  bilinear form when the mass lower bound dominates the drift defect.
+* `TauCeti.PDE.isCoercive_energyIntegrand_of_bounds`: coercivity of the jet bilinear form when
+  the mass lower bound dominates the drift defect.
 * `TauCeti.PDE.isCoercive_energyIntegrand_zero_drift_of_lower_bounds`: the zero-drift
   specialization, needing only a positive mass lower bound.
+* `TauCeti.PDE.isCoercive_energyIntegrand_of_bounds_on`: the domain version from raw lower
+  bounds, with no upper ellipticity bound or bundled coefficient predicate.
 * `TauCeti.PDE.UniformlyEllipticOn.isCoercive_energyIntegrand` and
   `TauCeti.PDE.UniformlyEllipticOn.isCoercive_energyIntegrand_zero_drift`: the same results
   using the bundled uniform-ellipticity and coefficient predicates.
@@ -94,7 +96,7 @@ lemma energyIntegrand_self_lower_bound_of_bounds (hlam : 0 < lam)
 
 With ellipticity floor `λ`, drift bound `β`, and mass lower bound `μ` satisfying `β²/2λ < μ`,
 the jet form is coercive with constant `min (λ/2) (μ − β²/2λ)`. -/
-lemma isCoercive_energyIntegrand_of_lower_bounds (hlam : 0 < lam)
+lemma isCoercive_energyIntegrand_of_bounds (hlam : 0 < lam)
     {A : Matrix n n ℝ} {b₀ : EuclideanSpace ℝ n} {c₀ : ℝ}
     (hA : ∀ ξ : EuclideanSpace ℝ n, lam * ‖ξ‖ ^ 2 ≤ A.toQuadraticForm' ξ)
     (hb : ‖b₀‖ ≤ beta) (hc : mu ≤ c₀) (hmu : beta ^ 2 / (2 * lam) < mu) :
@@ -109,14 +111,27 @@ lemma isCoercive_energyIntegrand_of_lower_bounds (hlam : 0 < lam)
 
 /-- Coercivity of the zero-drift jet bilinear form from a positive mass lower bound.
 
-This is the `β = 0` specialization of `isCoercive_energyIntegrand_of_lower_bounds`, where the
+This is the `β = 0` specialization of `isCoercive_energyIntegrand_of_bounds`, where the
 coercivity constant is `min (λ/2) μ`. -/
 lemma isCoercive_energyIntegrand_zero_drift_of_lower_bounds (hlam : 0 < lam) (hmu : 0 < mu)
     {A : Matrix n n ℝ} {c₀ : ℝ}
     (hA : ∀ ξ : EuclideanSpace ℝ n, lam * ‖ξ‖ ^ 2 ≤ A.toQuadraticForm' ξ)
     (hc : mu ≤ c₀) :
     IsCoercive (energyIntegrand A 0 c₀) :=
-  isCoercive_energyIntegrand_of_lower_bounds (beta := 0) hlam hA (by simp) hc (by simpa using hmu)
+  isCoercive_energyIntegrand_of_bounds (beta := 0) hlam hA (by simp) hc (by simpa using hmu)
+
+/-- Coercivity of the pointwise jet bilinear form on a domain from raw lower bounds.
+
+At each point of `Ω`, an ellipticity floor `λ`, a drift bound `β`, and a mass lower bound `μ`
+with `β²/2λ < μ` make the jet form coercive.  Only the lower assumptions are needed: there is
+no upper ellipticity bound and no bundled coefficient predicate. -/
+lemma isCoercive_energyIntegrand_of_bounds_on {Ω : Set X}
+    {a : X → Matrix n n ℝ} {b : X → EuclideanSpace ℝ n} {c : X → ℝ} (hlam : 0 < lam)
+    (hA : ∀ ⦃x⦄, x ∈ Ω → ∀ ξ : EuclideanSpace ℝ n, lam * ‖ξ‖ ^ 2 ≤ (a x).toQuadraticForm' ξ)
+    (hb : ∀ ⦃x⦄, x ∈ Ω → ‖b x‖ ≤ beta) (hc : ∀ ⦃x⦄, x ∈ Ω → mu ≤ c x)
+    (hmu : beta ^ 2 / (2 * lam) < mu) {x : X} (hx : x ∈ Ω) :
+    IsCoercive (energyIntegrand (a x) (b x) (c x)) :=
+  isCoercive_energyIntegrand_of_bounds hlam (hA hx) (hb hx) (hc hx) hmu
 
 namespace UniformlyEllipticOn
 
@@ -131,8 +146,8 @@ lemma isCoercive_energyIntegrand (he : UniformlyEllipticOn Ω a lam Lam)
     (hb : DriftBoundedOn Ω b beta) (hc : MassLowerBoundOn Ω c mu)
     (hmu : beta ^ 2 / (2 * lam) < mu) {x : X} (hx : x ∈ Ω) :
     IsCoercive (energyIntegrand (a x) (b x) (c x)) :=
-  isCoercive_energyIntegrand_of_lower_bounds he.pos (he.lower_bound hx)
-    (hb.bound hx) (hc.lower_bound hx) hmu
+  isCoercive_energyIntegrand_of_bounds_on he.pos (fun {_} hy => he.lower_bound hy)
+    (fun {_} hy => hb.bound hy) (fun {_} hy => hc.lower_bound hy) hmu hx
 
 /-- A uniformly elliptic principal coefficient and a positive mass lower bound make the
 zero-drift pointwise jet integrand coercive at every point of the domain. -/

--- a/TauCeti/Analysis/PDE/CoerciveEnergy.lean
+++ b/TauCeti/Analysis/PDE/CoerciveEnergy.lean
@@ -114,14 +114,6 @@ lemma isCoercive_energyIntegrand_zero_drift (hlam : 0 < lam) {A : Matrix n n ℝ
   isCoercive_energyIntegrand_of_bounds (beta := 0) (mu := c₀) hlam hA (by simp) le_rfl
     (by simpa using hc₀)
 
-/-- Coercivity of the zero-drift jet bilinear form from a positive mass lower bound. -/
-lemma isCoercive_energyIntegrand_zero_drift_of_lower_bounds (hlam : 0 < lam) (hmu : 0 < mu)
-    {A : Matrix n n ℝ} {c₀ : ℝ}
-    (hA : ∀ ξ : EuclideanSpace ℝ n, lam * ‖ξ‖ ^ 2 ≤ A.toQuadraticForm' ξ)
-    (hc : mu ≤ c₀) :
-    IsCoercive (energyIntegrand A 0 c₀) :=
-  isCoercive_energyIntegrand_zero_drift hlam (hmu.trans_le hc) hA
-
 /-- Coercivity of the pointwise jet bilinear form on a domain from raw lower bounds.
 
 At each point of `Ω`, an ellipticity floor `λ`, a drift bound `β`, and a mass lower bound `μ`

--- a/TauCeti/Analysis/PDE/CoerciveEnergy.lean
+++ b/TauCeti/Analysis/PDE/CoerciveEnergy.lean
@@ -23,8 +23,8 @@ monolithic PDE class.
 
 * `TauCeti.PDE.min_mul_prod_norm_sq_le_add`: product sup-norm lower-bound bridge for
   coercivity estimates.
-* `TauCeti.PDE.isCoercive_energyIntegrand_zero_drift_of_lower_bounds`: the zero-drift
-  specialization, needing only a positive mass lower bound.
+* `TauCeti.PDE.isCoercive_energyIntegrand_zero_drift`: the zero-drift specialization,
+  needing only a positive zeroth-order coefficient.
 * `TauCeti.PDE.UniformlyEllipticOn.isCoercive_energyIntegrand_zero_drift`: the same result
   using the bundled uniform-ellipticity and mass lower-bound predicates.
 -/
@@ -40,11 +40,10 @@ variable {X n : Type*} [Fintype n] [DecidableEq n]
 
 variable {lam mu beta : ℝ}
 
-omit [DecidableEq n] in
 /-- The square of the product sup norm is controlled by the two squared coordinate norms
 with the smaller coefficient. -/
 lemma min_mul_prod_norm_sq_le_add (hlam : 0 ≤ lam) (hmu : 0 ≤ mu)
-    (U : ℝ × EuclideanSpace ℝ n) :
+    {E F : Type*} [SeminormedAddCommGroup E] [SeminormedAddCommGroup F] (U : E × F) :
     min lam mu * ‖U‖ ^ 2 ≤ lam * ‖U.2‖ ^ 2 + mu * ‖U.1‖ ^ 2 := by
   have hmin_lam : min lam mu ≤ lam := min_le_left _ _
   have hmin_mu : min lam mu ≤ mu := min_le_right _ _
@@ -104,16 +103,24 @@ private lemma isCoercive_energyIntegrand_of_bounds (hlam : 0 < lam)
   rw [Real.norm_eq_abs, sq_abs] at hmin
   simpa [pow_two, mul_assoc] using hmin.trans hlb
 
-/-- Coercivity of the zero-drift jet bilinear form from a positive mass lower bound.
+/-- Coercivity of the zero-drift jet bilinear form from a positive zeroth-order coefficient.
 
-This is the `β = 0` specialization of `isCoercive_energyIntegrand_of_bounds`, where the
-coercivity constant is `min (λ/2) μ`. -/
+This is the `β = 0` specialization of `isCoercive_energyIntegrand_of_bounds`, with the
+coercivity constant `min (λ/2) c₀`. -/
+lemma isCoercive_energyIntegrand_zero_drift (hlam : 0 < lam) {A : Matrix n n ℝ} {c₀ : ℝ}
+    (hc₀ : 0 < c₀)
+    (hA : ∀ ξ : EuclideanSpace ℝ n, lam * ‖ξ‖ ^ 2 ≤ A.toQuadraticForm' ξ) :
+    IsCoercive (energyIntegrand A 0 c₀) :=
+  isCoercive_energyIntegrand_of_bounds (beta := 0) (mu := c₀) hlam hA (by simp) le_rfl
+    (by simpa using hc₀)
+
+/-- Coercivity of the zero-drift jet bilinear form from a positive mass lower bound. -/
 lemma isCoercive_energyIntegrand_zero_drift_of_lower_bounds (hlam : 0 < lam) (hmu : 0 < mu)
     {A : Matrix n n ℝ} {c₀ : ℝ}
     (hA : ∀ ξ : EuclideanSpace ℝ n, lam * ‖ξ‖ ^ 2 ≤ A.toQuadraticForm' ξ)
     (hc : mu ≤ c₀) :
     IsCoercive (energyIntegrand A 0 c₀) :=
-  isCoercive_energyIntegrand_of_bounds (beta := 0) hlam hA (by simp) hc (by simpa using hmu)
+  isCoercive_energyIntegrand_zero_drift hlam (hmu.trans_le hc) hA
 
 /-- Coercivity of the pointwise jet bilinear form on a domain from raw lower bounds.
 
@@ -150,8 +157,8 @@ zero-drift pointwise jet integrand coercive at every point of the domain. -/
 lemma isCoercive_energyIntegrand_zero_drift (he : UniformlyEllipticOn Ω a lam Lam)
     (hc : MassLowerBoundOn Ω c mu) {x : X} (hx : x ∈ Ω) :
     IsCoercive (energyIntegrand (a x) 0 (c x)) :=
-  isCoercive_energyIntegrand_zero_drift_of_lower_bounds he.pos hc.mu_pos
-    (he.lower_bound hx) (hc.lower_bound hx)
+  PDE.isCoercive_energyIntegrand_zero_drift he.pos (hc.mu_pos.trans_le (hc.lower_bound hx))
+    (he.lower_bound hx)
 
 end UniformlyEllipticOn
 

--- a/TauCeti/Analysis/PDE/CoerciveEnergy.lean
+++ b/TauCeti/Analysis/PDE/CoerciveEnergy.lean
@@ -1,0 +1,160 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+import TauCeti.Analysis.PDE.EnergyForm
+
+/-!
+# Pointwise coercivity for massive divergence-form energy integrands
+
+The PDE roadmap's Lax--Milgram lane needs coercive bilinear forms.  The file
+`TauCeti.Analysis.PDE.EnergyForm` gives the pointwise energy integrand for a
+divergence-form operator.  This file records the elementary coercive case where the
+principal coefficient is uniformly elliptic and the zeroth-order mass coefficient has a
+strict positive lower bound.
+
+This is still a pointwise finite-dimensional statement: the weak Sobolev space and the
+integrated energy form are later Lane A/D work.  The lower-mass hypothesis is kept as a
+separate predicate, in the roadmap's style of spelling out coefficient assumptions rather
+than hiding them in a monolithic PDE class.
+
+## Main declarations
+
+* `TauCeti.PDE.MassLowerBoundOn`: a positive lower bound for a mass coefficient.
+* `TauCeti.PDE.massiveEnergyIntegrand_self_lower_bound`: pointwise lower bound for the
+  zero-drift energy density.
+* `TauCeti.PDE.isCoercive_energyIntegrand_zero_drift_of_lower_bounds`: coercivity of the
+  bundled jet bilinear form from ellipticity and a positive mass lower bound.
+* `TauCeti.PDE.UniformlyEllipticOn.isCoercive_energyIntegrand_zero_drift`: the same result
+  using the bundled uniform-ellipticity predicate.
+-/
+
+namespace TauCeti
+
+namespace PDE
+
+open Matrix
+
+variable {X n : Type*} [Fintype n] [DecidableEq n]
+
+/-- A strictly positive lower bound for a zeroth-order mass coefficient on a domain. -/
+def MassLowerBoundOn (Ω : Set X) (c : X → ℝ) (mu : ℝ) : Prop :=
+  0 < mu ∧ ∀ ⦃x⦄, x ∈ Ω → mu ≤ c x
+
+/-- Characteristic restatement of a positive mass lower bound. -/
+lemma massLowerBoundOn_iff {Ω : Set X} {c : X → ℝ} {mu : ℝ} :
+    MassLowerBoundOn Ω c mu ↔ 0 < mu ∧ ∀ ⦃x⦄, x ∈ Ω → mu ≤ c x :=
+  Iff.rfl
+
+namespace MassLowerBoundOn
+
+variable {Ω Ω' : Set X} {c : X → ℝ} {mu mu' : ℝ}
+
+/-- The mass lower-bound constant is positive. -/
+@[grind →]
+lemma pos (h : MassLowerBoundOn Ω c mu) : 0 < mu :=
+  h.1
+
+/-- The mass lower-bound constant is nonnegative. -/
+lemma nonneg (h : MassLowerBoundOn Ω c mu) : 0 ≤ mu :=
+  h.pos.le
+
+/-- The pointwise lower bound supplied by a mass lower-bound hypothesis. -/
+@[grind =>]
+lemma lower_bound (h : MassLowerBoundOn Ω c mu) {x : X} (hx : x ∈ Ω) : mu ≤ c x :=
+  h.2 hx
+
+/-- A positive mass lower bound gives pointwise nonnegativity of the mass coefficient. -/
+lemma nonnegMassPointwiseOn (h : MassLowerBoundOn Ω c mu) :
+    NonnegMassPointwiseOn Ω c :=
+  fun {_} hx => h.nonneg.trans (h.lower_bound hx)
+
+/-- Restricting the domain preserves a mass lower bound. -/
+lemma mono_set (h : MassLowerBoundOn Ω c mu) (hΩ : Ω' ⊆ Ω) :
+    MassLowerBoundOn Ω' c mu :=
+  ⟨h.pos, fun {_} hx => h.lower_bound (hΩ hx)⟩
+
+/-- Decreasing the positive lower-bound constant preserves a mass lower bound. -/
+lemma mono_constant (h : MassLowerBoundOn Ω c mu) (hmu' : 0 < mu') (hmu'_le : mu' ≤ mu) :
+    MassLowerBoundOn Ω c mu' :=
+  ⟨hmu', fun {_} hx => hmu'_le.trans (h.lower_bound hx)⟩
+
+end MassLowerBoundOn
+
+variable {Ω : Set X} {a : X → Matrix n n ℝ} {c : X → ℝ} {lam mu : ℝ}
+
+omit [DecidableEq n] in
+/-- The square of the product sup norm is controlled by the two squared coordinate norms
+with the smaller coefficient. -/
+private lemma min_mul_prod_norm_sq_le_add (hlam : 0 ≤ lam) (hmu : 0 ≤ mu)
+    (U : ℝ × EuclideanSpace ℝ n) :
+    min lam mu * ‖U‖ ^ 2 ≤ lam * ‖U.2‖ ^ 2 + mu * ‖U.1‖ ^ 2 := by
+  have hmin_lam : min lam mu ≤ lam := min_le_left _ _
+  have hmin_mu : min lam mu ≤ mu := min_le_right _ _
+  rw [Prod.norm_def]
+  rcases le_total ‖U.1‖ ‖U.2‖ with hle | hle
+  · rw [max_eq_right hle]
+    calc
+      min lam mu * ‖U.2‖ ^ 2 ≤ lam * ‖U.2‖ ^ 2 := by
+        exact mul_le_mul_of_nonneg_right hmin_lam (sq_nonneg ‖U.2‖)
+      _ ≤ lam * ‖U.2‖ ^ 2 + mu * ‖U.1‖ ^ 2 := by
+        exact le_add_of_nonneg_right (mul_nonneg hmu (sq_nonneg ‖U.1‖))
+  · rw [max_eq_left hle]
+    calc
+      min lam mu * ‖U.1‖ ^ 2 ≤ mu * ‖U.1‖ ^ 2 := by
+        exact mul_le_mul_of_nonneg_right hmin_mu (sq_nonneg ‖U.1‖)
+      _ ≤ lam * ‖U.2‖ ^ 2 + mu * ‖U.1‖ ^ 2 := by
+        exact le_add_of_nonneg_left (mul_nonneg hlam (sq_nonneg ‖U.2‖))
+
+/-- Pointwise lower bound for the zero-drift energy integrand with a positive mass floor.
+
+If the principal part has quadratic lower bound `λ‖ξ‖²` and the mass coefficient satisfies
+`μ ≤ c`, then the jet energy controls the full product norm with constant `min λ μ`. -/
+lemma massiveEnergyIntegrand_self_lower_bound (hlam : 0 ≤ lam) (hmu : 0 ≤ mu)
+    {A : Matrix n n ℝ} {c₀ : ℝ}
+    (hA : ∀ ξ : EuclideanSpace ℝ n, lam * ‖ξ‖ ^ 2 ≤ A.toQuadraticForm' ξ)
+    (hc : mu ≤ c₀) (U : ℝ × EuclideanSpace ℝ n) :
+    min lam mu * ‖U‖ ^ 2 ≤ energyIntegrand A 0 c₀ U U := by
+  have hmass : mu * ‖U.1‖ ^ 2 ≤ c₀ * U.1 ^ 2 := by
+    rw [Real.norm_eq_abs, sq_abs]
+    exact mul_le_mul_of_nonneg_right hc (sq_nonneg U.1)
+  have hprincipal : lam * ‖U.2‖ ^ 2 ≤ A.toQuadraticForm' U.2 := hA U.2
+  calc
+    min lam mu * ‖U‖ ^ 2 ≤ lam * ‖U.2‖ ^ 2 + mu * ‖U.1‖ ^ 2 :=
+      min_mul_prod_norm_sq_le_add hlam hmu U
+    _ ≤ energyIntegrand A 0 c₀ U U := by
+      have henergy : A.toQuadraticForm' U.2 + c₀ * U.1 ^ 2 = energyIntegrand A 0 c₀ U U := by
+        rw [energyIntegrand_self]
+        simp
+      exact (add_le_add hprincipal hmass).trans_eq henergy
+
+/-- Coercivity of the zero-drift jet bilinear form from separate pointwise lower bounds.
+
+The coercivity constant is `min λ μ`, where `λ` is the ellipticity floor and `μ` is the
+positive mass floor. -/
+lemma isCoercive_energyIntegrand_zero_drift_of_lower_bounds (hlam : 0 < lam) (hmu : 0 < mu)
+    {A : Matrix n n ℝ} {c₀ : ℝ}
+    (hA : ∀ ξ : EuclideanSpace ℝ n, lam * ‖ξ‖ ^ 2 ≤ A.toQuadraticForm' ξ)
+    (hc : mu ≤ c₀) :
+    IsCoercive (energyIntegrand A 0 c₀) := by
+  refine ⟨min lam mu, lt_min hlam hmu, fun U => ?_⟩
+  simpa [pow_two, mul_assoc] using massiveEnergyIntegrand_self_lower_bound hlam.le hmu.le hA hc U
+
+namespace UniformlyEllipticOn
+
+variable {Ω : Set X} {a : X → Matrix n n ℝ} {c : X → ℝ} {lam Lam mu : ℝ}
+
+/-- A uniformly elliptic principal coefficient and a positive mass lower bound make the
+zero-drift pointwise jet integrand coercive at every point of the domain. -/
+@[grind =>]
+lemma isCoercive_energyIntegrand_zero_drift (he : UniformlyEllipticOn Ω a lam Lam)
+    (hc : MassLowerBoundOn Ω c mu) {x : X} (hx : x ∈ Ω) :
+    IsCoercive (energyIntegrand (a x) 0 (c x)) :=
+  isCoercive_energyIntegrand_zero_drift_of_lower_bounds he.pos hc.pos
+    (he.lower_bound hx) (hc.lower_bound hx)
+
+end UniformlyEllipticOn
+
+end PDE
+
+end TauCeti

--- a/TauCeti/Analysis/PDE/CoerciveEnergy.lean
+++ b/TauCeti/Analysis/PDE/CoerciveEnergy.lean
@@ -5,28 +5,31 @@ Released under Apache 2.0 license as described in the file LICENSE.
 import TauCeti.Analysis.PDE.EnergyForm
 
 /-!
-# Pointwise coercivity for massive divergence-form energy integrands
+# Pointwise coercivity for divergence-form energy integrands
 
 The PDE roadmap's Lax--Milgram lane needs coercive bilinear forms.  The file
-`TauCeti.Analysis.PDE.EnergyForm` gives the pointwise energy integrand for a
-divergence-form operator.  This file records the elementary coercive case where the
-principal coefficient is uniformly elliptic and the zeroth-order mass coefficient has a
-strict positive lower bound.
+`TauCeti.Analysis.PDE.EnergyForm` gives the pointwise energy integrand for a divergence-form
+operator together with its pointwise Gårding lower bound.  This file turns that Gårding
+estimate into pointwise coercivity once the zeroth-order mass coefficient has a lower bound
+that dominates the drift defect `β²/2λ`.
 
 This is still a pointwise finite-dimensional statement: the weak Sobolev space and the
-integrated energy form are later Lane A/D work.  The lower-mass hypothesis is kept as a
-separate predicate, in the roadmap's style of spelling out coefficient assumptions rather
-than hiding them in a monolithic PDE class.
+integrated energy form are later Lane A/D work.  The coefficient assumptions (uniform
+ellipticity, a drift bound, and a mass lower bound) are kept as separate named predicates,
+in the roadmap's style of spelling out coefficient assumptions rather than hiding them in a
+monolithic PDE class.
 
 ## Main declarations
 
-* `TauCeti.PDE.MassLowerBoundOn`: a positive lower bound for a mass coefficient.
-* `TauCeti.PDE.massiveEnergyIntegrand_self_lower_bound`: pointwise lower bound for the
-  zero-drift energy density.
-* `TauCeti.PDE.isCoercive_energyIntegrand_zero_drift_of_lower_bounds`: coercivity of the
-  bundled jet bilinear form from ellipticity and a positive mass lower bound.
-* `TauCeti.PDE.UniformlyEllipticOn.isCoercive_energyIntegrand_zero_drift`: the same result
-  using the bundled uniform-ellipticity predicate.
+* `TauCeti.PDE.energyIntegrand_self_lower_bound_of_bounds`: pointwise lower bound for the
+  energy density with bounded drift and a mass lower bound.
+* `TauCeti.PDE.isCoercive_energyIntegrand_of_lower_bounds`: coercivity of the bundled jet
+  bilinear form when the mass lower bound dominates the drift defect.
+* `TauCeti.PDE.isCoercive_energyIntegrand_zero_drift_of_lower_bounds`: the zero-drift
+  specialization, needing only a positive mass lower bound.
+* `TauCeti.PDE.UniformlyEllipticOn.isCoercive_energyIntegrand` and
+  `TauCeti.PDE.UniformlyEllipticOn.isCoercive_energyIntegrand_zero_drift`: the same results
+  using the bundled uniform-ellipticity and coefficient predicates.
 -/
 
 namespace TauCeti
@@ -34,54 +37,11 @@ namespace TauCeti
 namespace PDE
 
 open Matrix
+open scoped InnerProductSpace
 
 variable {X n : Type*} [Fintype n] [DecidableEq n]
 
-/-- A strictly positive lower bound for a zeroth-order mass coefficient on a domain. -/
-def MassLowerBoundOn (Ω : Set X) (c : X → ℝ) (mu : ℝ) : Prop :=
-  0 < mu ∧ ∀ ⦃x⦄, x ∈ Ω → mu ≤ c x
-
-/-- Characteristic restatement of a positive mass lower bound. -/
-lemma massLowerBoundOn_iff {Ω : Set X} {c : X → ℝ} {mu : ℝ} :
-    MassLowerBoundOn Ω c mu ↔ 0 < mu ∧ ∀ ⦃x⦄, x ∈ Ω → mu ≤ c x :=
-  Iff.rfl
-
-namespace MassLowerBoundOn
-
-variable {Ω Ω' : Set X} {c : X → ℝ} {mu mu' : ℝ}
-
-/-- The mass lower-bound constant is positive. -/
-@[grind →]
-lemma pos (h : MassLowerBoundOn Ω c mu) : 0 < mu :=
-  h.1
-
-/-- The mass lower-bound constant is nonnegative. -/
-lemma nonneg (h : MassLowerBoundOn Ω c mu) : 0 ≤ mu :=
-  h.pos.le
-
-/-- The pointwise lower bound supplied by a mass lower-bound hypothesis. -/
-@[grind =>]
-lemma lower_bound (h : MassLowerBoundOn Ω c mu) {x : X} (hx : x ∈ Ω) : mu ≤ c x :=
-  h.2 hx
-
-/-- A positive mass lower bound gives pointwise nonnegativity of the mass coefficient. -/
-lemma nonnegMassPointwiseOn (h : MassLowerBoundOn Ω c mu) :
-    NonnegMassPointwiseOn Ω c :=
-  fun {_} hx => h.nonneg.trans (h.lower_bound hx)
-
-/-- Restricting the domain preserves a mass lower bound. -/
-lemma mono_set (h : MassLowerBoundOn Ω c mu) (hΩ : Ω' ⊆ Ω) :
-    MassLowerBoundOn Ω' c mu :=
-  ⟨h.pos, fun {_} hx => h.lower_bound (hΩ hx)⟩
-
-/-- Decreasing the positive lower-bound constant preserves a mass lower bound. -/
-lemma mono_constant (h : MassLowerBoundOn Ω c mu) (hmu' : 0 < mu') (hmu'_le : mu' ≤ mu) :
-    MassLowerBoundOn Ω c mu' :=
-  ⟨hmu', fun {_} hx => hmu'_le.trans (h.lower_bound hx)⟩
-
-end MassLowerBoundOn
-
-variable {Ω : Set X} {a : X → Matrix n n ℝ} {c : X → ℝ} {lam mu : ℝ}
+variable {lam mu beta : ℝ}
 
 omit [DecidableEq n] in
 /-- The square of the product sup norm is controlled by the two squared coordinate norms
@@ -106,43 +66,76 @@ private lemma min_mul_prod_norm_sq_le_add (hlam : 0 ≤ lam) (hmu : 0 ≤ mu)
       _ ≤ lam * ‖U.2‖ ^ 2 + mu * ‖U.1‖ ^ 2 := by
         exact le_add_of_nonneg_left (mul_nonneg hlam (sq_nonneg ‖U.2‖))
 
-/-- Pointwise lower bound for the zero-drift energy integrand with a positive mass floor.
+/-- Pointwise lower bound for the energy integrand with bounded drift and a mass lower bound.
 
-If the principal part has quadratic lower bound `λ‖ξ‖²` and the mass coefficient satisfies
-`μ ≤ c`, then the jet energy controls the full product norm with constant `min λ μ`. -/
-lemma massiveEnergyIntegrand_self_lower_bound (hlam : 0 ≤ lam) (hmu : 0 ≤ mu)
-    {A : Matrix n n ℝ} {c₀ : ℝ}
+If the principal part has quadratic lower bound `λ‖ξ‖²`, the drift satisfies `‖b₀‖ ≤ β`, and
+the mass coefficient satisfies `μ ≤ c₀`, then the diagonal of the jet form is bounded below by
+`(λ/2)‖∇u‖² + (μ − β²/2λ)|u|²`.  The drift is absorbed into half of the ellipticity floor by
+Young's inequality, with the resulting mass defect `β²/2λ` paid for out of the mass floor `μ`.
+This reuses the pointwise Gårding bound `garding_energyIntegrand_self_of_bounds`, restoring the
+mass term split off from the nonnegative coefficient `c₀ − μ`. -/
+lemma energyIntegrand_self_lower_bound_of_bounds (hlam : 0 < lam)
+    {A : Matrix n n ℝ} {b₀ : EuclideanSpace ℝ n} {c₀ : ℝ}
     (hA : ∀ ξ : EuclideanSpace ℝ n, lam * ‖ξ‖ ^ 2 ≤ A.toQuadraticForm' ξ)
-    (hc : mu ≤ c₀) (U : ℝ × EuclideanSpace ℝ n) :
-    min lam mu * ‖U‖ ^ 2 ≤ energyIntegrand A 0 c₀ U U := by
-  have hmass : mu * ‖U.1‖ ^ 2 ≤ c₀ * U.1 ^ 2 := by
-    rw [Real.norm_eq_abs, sq_abs]
-    exact mul_le_mul_of_nonneg_right hc (sq_nonneg U.1)
-  have hprincipal : lam * ‖U.2‖ ^ 2 ≤ A.toQuadraticForm' U.2 := hA U.2
-  calc
-    min lam mu * ‖U‖ ^ 2 ≤ lam * ‖U.2‖ ^ 2 + mu * ‖U.1‖ ^ 2 :=
-      min_mul_prod_norm_sq_le_add hlam hmu U
-    _ ≤ energyIntegrand A 0 c₀ U U := by
-      have henergy : A.toQuadraticForm' U.2 + c₀ * U.1 ^ 2 = energyIntegrand A 0 c₀ U U := by
-        rw [energyIntegrand_self]
-        simp
-      exact (add_le_add hprincipal hmass).trans_eq henergy
+    (hb : ‖b₀‖ ≤ beta) (hc : mu ≤ c₀) (U : ℝ × EuclideanSpace ℝ n) :
+    lam / 2 * ‖U.2‖ ^ 2 + (mu - beta ^ 2 / (2 * lam)) * U.1 ^ 2
+      ≤ energyIntegrand A b₀ c₀ U U := by
+  have hdecomp : energyIntegrand A b₀ c₀ U U
+      = energyIntegrand A b₀ (c₀ - mu) U U + mu * U.1 ^ 2 := by
+    rw [energyIntegrand_self, energyIntegrand_self]; ring
+  have hgard := garding_energyIntegrand_self_of_bounds (Ω := (Set.univ : Set Unit))
+    (a := fun _ => A) (b := fun _ => b₀) (c := fun _ => c₀ - mu) hlam
+    (fun {_} _ ξ => hA ξ) (fun {_} _ => hb) (fun {_} _ => sub_nonneg.mpr hc)
+    (Set.mem_univ ()) U
+  rw [hdecomp]
+  have hrw : lam / 2 * ‖U.2‖ ^ 2 + (mu - beta ^ 2 / (2 * lam)) * U.1 ^ 2
+      = lam / 2 * ‖U.2‖ ^ 2 - beta ^ 2 / (2 * lam) * U.1 ^ 2 + mu * U.1 ^ 2 := by ring
+  rw [hrw]
+  linarith [hgard]
 
-/-- Coercivity of the zero-drift jet bilinear form from separate pointwise lower bounds.
+/-- Coercivity of the jet bilinear form when the mass lower bound dominates the drift defect.
 
-The coercivity constant is `min λ μ`, where `λ` is the ellipticity floor and `μ` is the
-positive mass floor. -/
+With ellipticity floor `λ`, drift bound `β`, and mass lower bound `μ` satisfying `β²/2λ < μ`,
+the jet form is coercive with constant `min (λ/2) (μ − β²/2λ)`. -/
+lemma isCoercive_energyIntegrand_of_lower_bounds (hlam : 0 < lam)
+    {A : Matrix n n ℝ} {b₀ : EuclideanSpace ℝ n} {c₀ : ℝ}
+    (hA : ∀ ξ : EuclideanSpace ℝ n, lam * ‖ξ‖ ^ 2 ≤ A.toQuadraticForm' ξ)
+    (hb : ‖b₀‖ ≤ beta) (hc : mu ≤ c₀) (hmu : beta ^ 2 / (2 * lam) < mu) :
+    IsCoercive (energyIntegrand A b₀ c₀) := by
+  have hhalf : (0 : ℝ) < lam / 2 := by positivity
+  have hdef : 0 < mu - beta ^ 2 / (2 * lam) := sub_pos.mpr hmu
+  refine ⟨min (lam / 2) (mu - beta ^ 2 / (2 * lam)), lt_min hhalf hdef, fun U => ?_⟩
+  have hlb := energyIntegrand_self_lower_bound_of_bounds hlam hA hb hc U
+  have hmin := min_mul_prod_norm_sq_le_add hhalf.le hdef.le U
+  rw [Real.norm_eq_abs, sq_abs] at hmin
+  simpa [pow_two, mul_assoc] using hmin.trans hlb
+
+/-- Coercivity of the zero-drift jet bilinear form from a positive mass lower bound.
+
+This is the `β = 0` specialization of `isCoercive_energyIntegrand_of_lower_bounds`, where the
+coercivity constant is `min (λ/2) μ`. -/
 lemma isCoercive_energyIntegrand_zero_drift_of_lower_bounds (hlam : 0 < lam) (hmu : 0 < mu)
     {A : Matrix n n ℝ} {c₀ : ℝ}
     (hA : ∀ ξ : EuclideanSpace ℝ n, lam * ‖ξ‖ ^ 2 ≤ A.toQuadraticForm' ξ)
     (hc : mu ≤ c₀) :
-    IsCoercive (energyIntegrand A 0 c₀) := by
-  refine ⟨min lam mu, lt_min hlam hmu, fun U => ?_⟩
-  simpa [pow_two, mul_assoc] using massiveEnergyIntegrand_self_lower_bound hlam.le hmu.le hA hc U
+    IsCoercive (energyIntegrand A 0 c₀) :=
+  isCoercive_energyIntegrand_of_lower_bounds (beta := 0) hlam hA (by simp) hc (by simpa using hmu)
 
 namespace UniformlyEllipticOn
 
-variable {Ω : Set X} {a : X → Matrix n n ℝ} {c : X → ℝ} {lam Lam mu : ℝ}
+variable {Ω : Set X} {a : X → Matrix n n ℝ} {b : X → EuclideanSpace ℝ n} {c : X → ℝ}
+variable {lam Lam beta mu : ℝ}
+
+/-- A uniformly elliptic principal coefficient, a bounded drift, and a mass lower bound that
+dominates the drift defect make the pointwise jet integrand coercive at every point of the
+domain. -/
+@[grind =>]
+lemma isCoercive_energyIntegrand (he : UniformlyEllipticOn Ω a lam Lam)
+    (hb : DriftBoundedOn Ω b beta) (hc : MassLowerBoundOn Ω c mu)
+    (hmu : beta ^ 2 / (2 * lam) < mu) {x : X} (hx : x ∈ Ω) :
+    IsCoercive (energyIntegrand (a x) (b x) (c x)) :=
+  isCoercive_energyIntegrand_of_lower_bounds he.pos (he.lower_bound hx)
+    (hb.bound hx) (hc.lower_bound hx) hmu
 
 /-- A uniformly elliptic principal coefficient and a positive mass lower bound make the
 zero-drift pointwise jet integrand coercive at every point of the domain. -/

--- a/TauCeti/Analysis/PDE/CoerciveEnergy.lean
+++ b/TauCeti/Analysis/PDE/CoerciveEnergy.lean
@@ -70,10 +70,7 @@ private lemma min_mul_prod_norm_sq_le_add (hlam : 0 ≤ lam) (hmu : 0 ≤ mu)
 
 If the principal part has quadratic lower bound `λ‖ξ‖²`, the drift satisfies `‖b₀‖ ≤ β`, and
 the mass coefficient satisfies `μ ≤ c₀`, then the diagonal of the jet form is bounded below by
-`(λ/2)‖∇u‖² + (μ − β²/2λ)|u|²`.  The drift is absorbed into half of the ellipticity floor by
-Young's inequality, with the resulting mass defect `β²/2λ` paid for out of the mass floor `μ`.
-This reuses the pointwise Gårding bound `garding_energyIntegrand_self_of_bounds`, restoring the
-mass term split off from the nonnegative coefficient `c₀ − μ`. -/
+`(λ/2)‖∇u‖² + (μ − β²/2λ)|u|²`. -/
 lemma energyIntegrand_self_lower_bound_of_bounds (hlam : 0 < lam)
     {A : Matrix n n ℝ} {b₀ : EuclideanSpace ℝ n} {c₀ : ℝ}
     (hA : ∀ ξ : EuclideanSpace ℝ n, lam * ‖ξ‖ ^ 2 ≤ A.toQuadraticForm' ξ)
@@ -143,7 +140,7 @@ zero-drift pointwise jet integrand coercive at every point of the domain. -/
 lemma isCoercive_energyIntegrand_zero_drift (he : UniformlyEllipticOn Ω a lam Lam)
     (hc : MassLowerBoundOn Ω c mu) {x : X} (hx : x ∈ Ω) :
     IsCoercive (energyIntegrand (a x) 0 (c x)) :=
-  isCoercive_energyIntegrand_zero_drift_of_lower_bounds he.pos hc.pos
+  isCoercive_energyIntegrand_zero_drift_of_lower_bounds he.pos hc.mu_pos
     (he.lower_bound hx) (hc.lower_bound hx)
 
 end UniformlyEllipticOn

--- a/TauCeti/Analysis/PDE/LowerOrder.lean
+++ b/TauCeti/Analysis/PDE/LowerOrder.lean
@@ -27,6 +27,7 @@ weak-derivative Sobolev spaces are available.
   drift and mass coefficients on a domain.
 * `TauCeti.PDE.LowerOrderBoundedOn`: the bundled lower-order bounds.
 * `TauCeti.PDE.NonnegMassOn`: nonnegative bounded mass coefficients.
+* `TauCeti.PDE.MassLowerBoundOn`: a strictly positive lower bound for a mass coefficient.
 * `TauCeti.PDE.driftForm`, `TauCeti.PDE.massForm`: named pointwise lower-order forms.
 -/
 
@@ -326,6 +327,50 @@ lemma mono_set (h : NonnegMassPointwiseOn Ω c) (hΩ : Ω' ⊆ Ω) :
   fun {_} hx => h (hΩ hx)
 
 end NonnegMassPointwiseOn
+
+/-- A strictly positive lower bound for a zeroth-order mass coefficient on a domain. -/
+def MassLowerBoundOn (Ω : Set X) (c : X → ℝ) (mu : ℝ) : Prop :=
+  0 < mu ∧ ∀ ⦃x⦄, x ∈ Ω → mu ≤ c x
+
+/-- Characteristic restatement of a positive mass lower bound. -/
+lemma massLowerBoundOn_iff {Ω : Set X} {c : X → ℝ} {mu : ℝ} :
+    MassLowerBoundOn Ω c mu ↔ 0 < mu ∧ ∀ ⦃x⦄, x ∈ Ω → mu ≤ c x :=
+  Iff.rfl
+
+namespace MassLowerBoundOn
+
+variable {Ω Ω' : Set X} {c : X → ℝ} {mu mu' : ℝ}
+
+/-- The mass lower-bound constant is positive. -/
+@[grind →]
+lemma pos (h : MassLowerBoundOn Ω c mu) : 0 < mu :=
+  h.1
+
+/-- The mass lower-bound constant is nonnegative. -/
+lemma nonneg (h : MassLowerBoundOn Ω c mu) : 0 ≤ mu :=
+  h.pos.le
+
+/-- The pointwise lower bound supplied by a mass lower-bound hypothesis. -/
+@[grind =>]
+lemma lower_bound (h : MassLowerBoundOn Ω c mu) {x : X} (hx : x ∈ Ω) : mu ≤ c x :=
+  h.2 hx
+
+/-- A positive mass lower bound gives pointwise nonnegativity of the mass coefficient. -/
+lemma nonnegMassPointwiseOn (h : MassLowerBoundOn Ω c mu) :
+    NonnegMassPointwiseOn Ω c :=
+  fun {_} hx => h.nonneg.trans (h.lower_bound hx)
+
+/-- Restricting the domain preserves a mass lower bound. -/
+lemma mono_set (h : MassLowerBoundOn Ω c mu) (hΩ : Ω' ⊆ Ω) :
+    MassLowerBoundOn Ω' c mu :=
+  ⟨h.pos, fun {_} hx => h.lower_bound (hΩ hx)⟩
+
+/-- Decreasing the positive lower-bound constant preserves a mass lower bound. -/
+lemma mono_constant (h : MassLowerBoundOn Ω c mu) (hmu' : 0 < mu') (hmu'_le : mu' ≤ mu) :
+    MassLowerBoundOn Ω c mu' :=
+  ⟨hmu', fun {_} hx => hmu'_le.trans (h.lower_bound hx)⟩
+
+end MassLowerBoundOn
 
 /-- Nonnegative bounded zeroth-order coefficients on a domain. -/
 def NonnegMassOn (Ω : Set X) (c : X → ℝ) (gamma : ℝ) : Prop :=

--- a/TauCeti/Analysis/PDE/LowerOrder.lean
+++ b/TauCeti/Analysis/PDE/LowerOrder.lean
@@ -343,12 +343,12 @@ variable {Ω Ω' : Set X} {c : X → ℝ} {mu mu' : ℝ}
 
 /-- The mass lower-bound constant is positive. -/
 @[grind →]
-lemma pos (h : MassLowerBoundOn Ω c mu) : 0 < mu :=
+lemma mu_pos (h : MassLowerBoundOn Ω c mu) : 0 < mu :=
   h.1
 
 /-- The mass lower-bound constant is nonnegative. -/
-lemma nonneg (h : MassLowerBoundOn Ω c mu) : 0 ≤ mu :=
-  h.pos.le
+lemma mu_nonneg (h : MassLowerBoundOn Ω c mu) : 0 ≤ mu :=
+  h.mu_pos.le
 
 /-- The pointwise lower bound supplied by a mass lower-bound hypothesis. -/
 @[grind =>]
@@ -358,12 +358,12 @@ lemma lower_bound (h : MassLowerBoundOn Ω c mu) {x : X} (hx : x ∈ Ω) : mu �
 /-- A positive mass lower bound gives pointwise nonnegativity of the mass coefficient. -/
 lemma nonnegMassPointwiseOn (h : MassLowerBoundOn Ω c mu) :
     NonnegMassPointwiseOn Ω c :=
-  fun {_} hx => h.nonneg.trans (h.lower_bound hx)
+  fun {_} hx => h.mu_nonneg.trans (h.lower_bound hx)
 
 /-- Restricting the domain preserves a mass lower bound. -/
 lemma mono_set (h : MassLowerBoundOn Ω c mu) (hΩ : Ω' ⊆ Ω) :
     MassLowerBoundOn Ω' c mu :=
-  ⟨h.pos, fun {_} hx => h.lower_bound (hΩ hx)⟩
+  ⟨h.mu_pos, fun {_} hx => h.lower_bound (hΩ hx)⟩
 
 /-- Decreasing the positive lower-bound constant preserves a mass lower bound. -/
 lemma mono_constant (h : MassLowerBoundOn Ω c mu) (hmu' : 0 < mu') (hmu'_le : mu' ≤ mu) :

--- a/TauCeti/Analysis/PDE/LowerOrder.lean
+++ b/TauCeti/Analysis/PDE/LowerOrder.lean
@@ -360,6 +360,14 @@ lemma mu_nonneg (h : MassLowerBoundOn Ω c mu) : 0 ≤ mu :=
 lemma lower_bound (h : MassLowerBoundOn Ω c mu) {x : X} (hx : x ∈ Ω) : mu ≤ c x :=
   h.2 hx
 
+/-- The mass form associated to a mass lower bound is bounded below on the diagonal. -/
+@[grind =>]
+lemma massForm_self_lower_bound (h : MassLowerBoundOn Ω c mu) {x : X} (hx : x ∈ Ω)
+    (u : ℝ) :
+    mu * u ^ 2 ≤ massForm (c x) u u := by
+  rw [massForm_apply, mul_assoc]
+  simpa [pow_two] using mul_le_mul_of_nonneg_right (h.lower_bound hx) (mul_self_nonneg u)
+
 /-- A positive mass lower bound gives pointwise nonnegativity of the mass coefficient. -/
 lemma nonnegMassPointwiseOn (h : MassLowerBoundOn Ω c mu) :
     NonnegMassPointwiseOn Ω c :=

--- a/TauCeti/Analysis/PDE/LowerOrder.lean
+++ b/TauCeti/Analysis/PDE/LowerOrder.lean
@@ -341,6 +341,11 @@ namespace MassLowerBoundOn
 
 variable {Ω Ω' : Set X} {c : X → ℝ} {mu mu' : ℝ}
 
+/-- Constructor from the positivity side condition and the pointwise lower bound. -/
+lemma of_lower_bound (hmu : 0 < mu) (hc : ∀ ⦃x⦄, x ∈ Ω → mu ≤ c x) :
+    MassLowerBoundOn Ω c mu :=
+  ⟨hmu, hc⟩
+
 /-- The mass lower-bound constant is positive. -/
 @[grind →]
 lemma mu_pos (h : MassLowerBoundOn Ω c mu) : 0 < mu :=
@@ -460,6 +465,11 @@ lemma lowerOrderBoundedOn_zero (Ω : Set X) :
 lemma nonnegMassOn_const_self (Ω : Set X) {c : ℝ} (hc : 0 ≤ c) :
     NonnegMassOn Ω (fun _ => c) c :=
   ⟨hc, fun {_} _ => ⟨hc, le_rfl⟩⟩
+
+/-- A constant positive mass coefficient has itself as a mass lower bound. -/
+lemma massLowerBoundOn_const_self (Ω : Set X) {mu : ℝ} (hmu : 0 < mu) :
+    MassLowerBoundOn Ω (fun _ => mu) mu :=
+  ⟨hmu, fun {_} _ => le_rfl⟩
 
 end PDE
 


### PR DESCRIPTION
This PR adds a pointwise coercivity prerequisite for the PDE energy-method lane: a new `MassLowerBoundOn Ω c μ` predicate records a strict positive lower bound for the zeroth-order coefficient, and ellipticity plus that mass floor imply `IsCoercive (energyIntegrand (a x) 0 (c x))` at each point of the domain. This advances `TauCetiRoadmap/PDE/README.md`, Lane D, the target “existence and uniqueness of the weak solution of `−Δu = f`, `u|∂Ω = 0`, on a bounded domain, via `IsCoercive` + `continuousLinearEquivOfBilin` (Lax–Milgram)” from `Targets.lean`, by supplying the finite-dimensional pointwise coercivity input for a massive zero-drift energy integrand before the integrated Sobolev energy form lands.

It is the lowest-hanging distinct PDE target I found because `main` already has the pointwise uniform-ellipticity, lower-order, and energy-integrand stack, while the full weak-derivative Sobolev space `Wkp` is a much larger Lane A construction. This PR stays on the existing pointwise stack and proves the non-vacuous coercive case with explicit constant `min λ μ`.

No Mathlib infrastructure is vendored. The proof reuses Tau Ceti’s `UniformlyEllipticOn`, `energyIntegrand`, and Mathlib’s `IsCoercive` convention for bounded bilinear forms, together with the existing product sup-norm API.

Local verification: `lake exe cache get` completed with `No files to download` and `Already decompressed 8573 file(s)`; `lake build` completed with `Build completed successfully (4063 jobs).`; `lake exe axioms` completed with `axioms: audited 4011 TauCeti declaration(s); all within the allowlist [propext, Classical.choice, Quot.sound].`

<!--tauceti-target:v1 {"focus":"PDE","id":"massive-energy-integrand-coercivity"}-->

🤖 Prepared with Codex
