### PR TITLE
feat: an almost complex structure forces even real dimension

### DIFF
--- a/TauCeti/Geometry/Symplectic/Finrank.lean
+++ b/TauCeti/Geometry/Symplectic/Finrank.lean
@@ -2,9 +2,9 @@
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 -/
-import Mathlib.LinearAlgebra.Complex.FiniteDimensional
 import Mathlib.Algebra.Ring.Parity
 import TauCeti.Geometry.Symplectic.ComplexModule
+import TauCeti.LinearAlgebra.ComplexFinrank
 
 /-!
 # An almost complex structure forces even real dimension
@@ -27,8 +27,6 @@ assumption.
   module structure induced by `J`.
 * `TauCeti.AlmostComplexStructure.complexFinrank_def`: `complexFinrank` is `Module.finrank ℂ V`
   under the induced complex structure.
-* `TauCeti.finrank_real_eq_two_mul_finrank_complex`: a compatible complex module has real
-  dimension twice its complex dimension.
 * `TauCeti.AlmostComplexStructure.finrank_real_eq_two_mul_complexFinrank`: the real dimension is
   twice the complex dimension, `finrank ℝ V = 2 * J.complexFinrank`.
 * `TauCeti.AlmostComplexStructure.even_finrank_real`: the real dimension of a module carrying an
@@ -43,13 +41,6 @@ Section 2.1.
 namespace TauCeti
 
 variable {V : Type*} [AddCommGroup V] [Module ℝ V]
-
-/-- A compatible complex module structure forces the real dimension to be twice the complex
-dimension. This is the tower law `finrank ℝ V = finrank ℝ ℂ * finrank ℂ V` together with
-`finrank ℝ ℂ = 2`. -/
-theorem finrank_real_eq_two_mul_finrank_complex [Module ℂ V] [IsScalarTower ℝ ℂ V] :
-    Module.finrank ℝ V = 2 * Module.finrank ℂ V := by
-  rw [← Module.finrank_mul_finrank ℝ ℂ V, Complex.finrank_real_complex]
 
 namespace AlmostComplexStructure
 

--- a/TauCeti/Geometry/Symplectic/Finrank.lean
+++ b/TauCeti/Geometry/Symplectic/Finrank.lean
@@ -25,6 +25,8 @@ assumption.
 
 * `TauCeti.AlmostComplexStructure.complexFinrank`: the `ℂ`-dimension of `V` under the complex
   module structure induced by `J`.
+* `TauCeti.AlmostComplexStructure.complexFinrank_def`: `complexFinrank` is `Module.finrank ℂ V`
+  under the induced complex structure.
 * `TauCeti.AlmostComplexStructure.finrank_real_eq_two_mul_complexFinrank`: the real dimension is
   twice the complex dimension, `finrank ℝ V = 2 * J.complexFinrank`.
 * `TauCeti.AlmostComplexStructure.even_finrank_real`: the real dimension of a module carrying an
@@ -49,6 +51,12 @@ noncomputable def complexFinrank (J : AlmostComplexStructure V) : ℕ :=
   letI := J.complexModule
   Module.finrank ℂ V
 
+/-- The complex dimension of `J` is the `ℂ`-dimension of `V` under the induced complex structure. -/
+lemma complexFinrank_def (J : AlmostComplexStructure V) :
+    letI := J.complexModule
+    J.complexFinrank = Module.finrank ℂ V :=
+  rfl
+
 /-- The real dimension of a module carrying an almost complex structure `J` is twice its complex
 dimension: `finrank ℝ V = 2 * J.complexFinrank`. This is the tower law `finrank ℝ V =
 finrank ℝ ℂ * finrank ℂ V` together with `finrank ℝ ℂ = 2`. -/
@@ -56,8 +64,7 @@ theorem finrank_real_eq_two_mul_complexFinrank (J : AlmostComplexStructure V) :
     Module.finrank ℝ V = 2 * J.complexFinrank := by
   letI := J.complexModule
   letI := J.complexModule_isScalarTower
-  change Module.finrank ℝ V = 2 * Module.finrank ℂ V
-  rw [← Module.finrank_mul_finrank ℝ ℂ V, Complex.finrank_real_complex]
+  rw [J.complexFinrank_def, ← Module.finrank_mul_finrank ℝ ℂ V, Complex.finrank_real_complex]
 
 /-- The real dimension of a module carrying an almost complex structure is even. -/
 theorem even_finrank_real (J : AlmostComplexStructure V) :

--- a/TauCeti/Geometry/Symplectic/Finrank.lean
+++ b/TauCeti/Geometry/Symplectic/Finrank.lean
@@ -1,0 +1,75 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+import Mathlib.LinearAlgebra.Complex.FiniteDimensional
+import Mathlib.Algebra.Ring.Parity
+import TauCeti.Geometry.Symplectic.ComplexModule
+
+/-!
+# An almost complex structure forces even real dimension
+
+A pointwise almost complex structure `J` on a real module `V` turns `V` into a complex vector
+space (`TauCeti.AlmostComplexStructure.complexModule`), where multiplication by `i` is `J`. Since
+`ℂ` is a degree-two extension of `ℝ`, the tower law forces the real dimension of `V` to be twice
+its complex dimension, hence even. This is the classical fact that a manifold (or vector bundle)
+admitting an almost complex structure is even-dimensional (McDuff--Salamon, *J-holomorphic Curves
+and Symplectic Topology*, Section 2.1), recorded here at the pointwise linear-algebra level.
+
+Everything is stated without a finite-dimensionality hypothesis: the tower law
+`Module.finrank_mul_finrank` holds for `Module.finrank` unconditionally (an infinite-dimensional
+`V` has `Module.finrank ℝ V = 0 = 2 * 0`), so the identities below need no `FiniteDimensional`
+assumption.
+
+## Main declarations
+
+* `TauCeti.AlmostComplexStructure.complexFinrank`: the `ℂ`-dimension of `V` under the complex
+  module structure induced by `J`.
+* `TauCeti.AlmostComplexStructure.finrank_real_eq_two_mul_complexFinrank`: the real dimension is
+  twice the complex dimension, `finrank ℝ V = 2 * J.complexFinrank`.
+* `TauCeti.AlmostComplexStructure.even_finrank_real`: the real dimension of a module carrying an
+  almost complex structure is even.
+* `TauCeti.AlmostComplexStructure.isEmpty_of_odd_finrank`: an odd-dimensional real module admits no
+  almost complex structure.
+
+The conventions follow McDuff--Salamon, *J-holomorphic Curves and Symplectic Topology*,
+Section 2.1.
+-/
+
+namespace TauCeti
+
+namespace AlmostComplexStructure
+
+variable {V : Type*} [AddCommGroup V] [Module ℝ V]
+
+/-- The complex dimension of `V` with respect to an almost complex structure `J`: the
+`ℂ`-dimension of `V` under the complex module structure induced by `J`
+(`AlmostComplexStructure.complexModule`). -/
+noncomputable def complexFinrank (J : AlmostComplexStructure V) : ℕ :=
+  letI := J.complexModule
+  Module.finrank ℂ V
+
+/-- The real dimension of a module carrying an almost complex structure `J` is twice its complex
+dimension: `finrank ℝ V = 2 * J.complexFinrank`. This is the tower law `finrank ℝ V =
+finrank ℝ ℂ * finrank ℂ V` together with `finrank ℝ ℂ = 2`. -/
+theorem finrank_real_eq_two_mul_complexFinrank (J : AlmostComplexStructure V) :
+    Module.finrank ℝ V = 2 * J.complexFinrank := by
+  letI := J.complexModule
+  letI := J.complexModule_isScalarTower
+  change Module.finrank ℝ V = 2 * Module.finrank ℂ V
+  rw [← Module.finrank_mul_finrank ℝ ℂ V, Complex.finrank_real_complex]
+
+/-- The real dimension of a module carrying an almost complex structure is even. -/
+theorem even_finrank_real (J : AlmostComplexStructure V) :
+    Even (Module.finrank ℝ V) := by
+  rw [J.finrank_real_eq_two_mul_complexFinrank]
+  exact even_two_mul _
+
+/-- An odd-dimensional real module admits no almost complex structure. -/
+theorem isEmpty_of_odd_finrank (h : Odd (Module.finrank ℝ V)) :
+    IsEmpty (AlmostComplexStructure V) :=
+  ⟨fun J => (Nat.not_odd_iff_even.mpr J.even_finrank_real) h⟩
+
+end AlmostComplexStructure
+
+end TauCeti

--- a/TauCeti/Geometry/Symplectic/Finrank.lean
+++ b/TauCeti/Geometry/Symplectic/Finrank.lean
@@ -27,6 +27,8 @@ assumption.
   module structure induced by `J`.
 * `TauCeti.AlmostComplexStructure.complexFinrank_def`: `complexFinrank` is `Module.finrank ℂ V`
   under the induced complex structure.
+* `TauCeti.finrank_real_eq_two_mul_finrank_complex`: a compatible complex module has real
+  dimension twice its complex dimension.
 * `TauCeti.AlmostComplexStructure.finrank_real_eq_two_mul_complexFinrank`: the real dimension is
   twice the complex dimension, `finrank ℝ V = 2 * J.complexFinrank`.
 * `TauCeti.AlmostComplexStructure.even_finrank_real`: the real dimension of a module carrying an
@@ -40,9 +42,16 @@ Section 2.1.
 
 namespace TauCeti
 
-namespace AlmostComplexStructure
-
 variable {V : Type*} [AddCommGroup V] [Module ℝ V]
+
+/-- A compatible complex module structure forces the real dimension to be twice the complex
+dimension. This is the tower law `finrank ℝ V = finrank ℝ ℂ * finrank ℂ V` together with
+`finrank ℝ ℂ = 2`. -/
+theorem finrank_real_eq_two_mul_finrank_complex [Module ℂ V] [IsScalarTower ℝ ℂ V] :
+    Module.finrank ℝ V = 2 * Module.finrank ℂ V := by
+  rw [← Module.finrank_mul_finrank ℝ ℂ V, Complex.finrank_real_complex]
+
+namespace AlmostComplexStructure
 
 /-- The complex dimension of `V` with respect to an almost complex structure `J`: the
 `ℂ`-dimension of `V` under the complex module structure induced by `J`
@@ -52,6 +61,7 @@ noncomputable def complexFinrank (J : AlmostComplexStructure V) : ℕ :=
   Module.finrank ℂ V
 
 /-- The complex dimension of `J` is the `ℂ`-dimension of `V` under the induced complex structure. -/
+@[simp]
 lemma complexFinrank_def (J : AlmostComplexStructure V) :
     letI := J.complexModule
     J.complexFinrank = Module.finrank ℂ V :=
@@ -64,7 +74,8 @@ theorem finrank_real_eq_two_mul_complexFinrank (J : AlmostComplexStructure V) :
     Module.finrank ℝ V = 2 * J.complexFinrank := by
   letI := J.complexModule
   letI := J.complexModule_isScalarTower
-  rw [J.complexFinrank_def, ← Module.finrank_mul_finrank ℝ ℂ V, Complex.finrank_real_complex]
+  rw [J.complexFinrank_def]
+  exact finrank_real_eq_two_mul_finrank_complex
 
 /-- The real dimension of a module carrying an almost complex structure is even. -/
 theorem even_finrank_real (J : AlmostComplexStructure V) :

--- a/TauCeti/LinearAlgebra/ComplexFinrank.lean
+++ b/TauCeti/LinearAlgebra/ComplexFinrank.lean
@@ -17,10 +17,20 @@ namespace TauCeti
 variable {V : Type*} [AddCommGroup V] [Module ℝ V]
 
 /-- A compatible complex module structure forces the real dimension to be twice the complex
-dimension. This is the tower law `finrank ℝ V = finrank ℝ ℂ * finrank ℂ V` together with
-`finrank ℝ ℂ = 2`. -/
+dimension. This is the ambient-real-structure form of Mathlib's `finrank_real_of_complex`: that
+lemma fixes the real structure to be the one induced by restricting scalars
+(`Module.complexToReal`), whereas here `V` already carries an ambient `Module ℝ V` made compatible
+via `IsScalarTower ℝ ℂ V` (the situation produced by an almost complex structure). -/
 theorem finrank_real_eq_two_mul_finrank_complex [Module ℂ V] [IsScalarTower ℝ ℂ V] :
     Module.finrank ℝ V = 2 * Module.finrank ℂ V := by
-  rw [← Module.finrank_mul_finrank ℝ ℂ V, Complex.finrank_real_complex]
+  -- The ambient `Module ℝ V` agrees with the restrict-scalars structure `Module.complexToReal V`,
+  -- so the identity follows from Mathlib's `finrank_real_of_complex` for the latter.
+  have h : Module.complexToReal V = (inferInstance : Module ℝ V) := by
+    apply Module.ext
+    funext r v
+    exact IsScalarTower.algebraMap_smul ℂ r v
+  have hV := finrank_real_of_complex (E := V)
+  rw [h] at hV
+  exact hV
 
 end TauCeti

--- a/TauCeti/LinearAlgebra/ComplexFinrank.lean
+++ b/TauCeti/LinearAlgebra/ComplexFinrank.lean
@@ -1,0 +1,26 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+import Mathlib.LinearAlgebra.Complex.FiniteDimensional
+
+/-!
+# Real finrank of a compatible complex module
+
+This file records the tower-law dimension formula for a complex module whose real scalar
+structure is the ambient one. It is the linear-algebra input for almost-complex even-dimensionality
+results, but has no symplectic hypotheses.
+-/
+
+namespace TauCeti
+
+variable {V : Type*} [AddCommGroup V] [Module ℝ V]
+
+/-- A compatible complex module structure forces the real dimension to be twice the complex
+dimension. This is the tower law `finrank ℝ V = finrank ℝ ℂ * finrank ℂ V` together with
+`finrank ℝ ℂ = 2`. -/
+theorem finrank_real_eq_two_mul_finrank_complex [Module ℂ V] [IsScalarTower ℝ ℂ V] :
+    Module.finrank ℝ V = 2 * Module.finrank ℂ V := by
+  rw [← Module.finrank_mul_finrank ℝ ℂ V, Complex.finrank_real_complex]
+
+end TauCeti


### PR DESCRIPTION
This PR records that a module carrying an almost complex structure is even-dimensional. A pointwise almost complex structure `J` already turns its real module `V` into a complex vector space (`TauCeti.AlmostComplexStructure.complexModule`, where multiplication by `i` is `J`); since `ℂ` is a degree-two extension of `ℝ`, the tower law forces `finrank ℝ V = 2 * J.complexFinrank`, hence `Even (finrank ℝ V)`, and conversely an odd-dimensional real module admits no almost complex structure. This is the classical fact that an almost complex manifold (or vector bundle) is even-dimensional (McDuff–Salamon, *J-holomorphic Curves and Symplectic Topology*, Section 2.1), recorded at the pointwise linear-algebra level the analytic Heegaard Floer roadmap builds on.

It advances the analytic Heegaard Floer roadmap, `TauCetiRoadmap/HeegaardFloer/README.md`, Lane F2.1 ("Definitions land immediately: almost complex structures, tame/compatible `J`, symplectic manifolds, `J`-holomorphic maps, energy"), extending the existing pointwise almost-complex API under `TauCeti/Geometry/Symplectic/` with the foundational even-dimensionality consequence that underlies every later dimension count.

The statements carry no finite-dimensionality hypothesis: Mathlib's tower law `Module.finrank_mul_finrank` holds for `Module.finrank` unconditionally, so the identities hold for infinite-dimensional `V` too, where both sides are zero. No Mathlib infrastructure was vendored; the proofs reuse `Module.finrank_mul_finrank`, `Complex.finrank_real_complex`, and the induced complex module structure from `TauCeti/Geometry/Symplectic/ComplexModule.lean`.

<!--tauceti-target:v1 {"focus":"HeegaardFloer","id":"almost-complex-structure-even-finrank"}-->

🤖 Prepared with Claude Code
