### PR TITLE
feat: square-class independence of pairwise-coprime squarefree integer radicands

### DIFF
--- a/TauCeti/NumberTheory/Multiquadratic/CoprimeSquarefree.lean
+++ b/TauCeti/NumberTheory/Multiquadratic/CoprimeSquarefree.lean
@@ -6,8 +6,8 @@ import TauCeti.NumberTheory.Multiquadratic.Degree
 import Mathlib.Analysis.Real.Sqrt
 import Mathlib.Data.Rat.Lemmas
 import Mathlib.Algebra.Squarefree.Basic
+import Mathlib.RingTheory.Int.Basic
 import Mathlib.Tactic.NormNum.Prime
-import Mathlib.Data.Nat.Prime.Int
 
 /-!
 # Multiquadratic fields with pairwise-coprime squarefree integer radicands
@@ -98,12 +98,14 @@ theorem finrank_adjoin_sqrt_six_thirtyfive :
   have h6 : Squarefree (6 : ℤ) := by
     have : Squarefree ((2 : ℤ) * 3) := squarefree_mul_iff.mpr
       ⟨(Int.isCoprime_iff_gcd_eq_one.mpr (by decide)).isRelPrime,
-        (by norm_num : Prime (2 : ℤ)).squarefree, (by norm_num : Prime (3 : ℤ)).squarefree⟩
+        (Int.prime_iff_natAbs_prime.2 (by decide)).squarefree,
+        (Int.prime_iff_natAbs_prime.2 (by decide)).squarefree⟩
     simpa using this
   have h35 : Squarefree (35 : ℤ) := by
     have : Squarefree ((5 : ℤ) * 7) := squarefree_mul_iff.mpr
       ⟨(Int.isCoprime_iff_gcd_eq_one.mpr (by decide)).isRelPrime,
-        (by norm_num : Prime (5 : ℤ)).squarefree, (by norm_num : Prime (7 : ℤ)).squarefree⟩
+        (Int.prime_iff_natAbs_prime.2 (by decide)).squarefree,
+        (Int.prime_iff_natAbs_prime.2 (by decide)).squarefree⟩
     simpa using this
   have hsf : ∀ i, Squarefree ((![6, 35] : Fin 2 → ℤ) i) := by
     intro i

--- a/TauCeti/NumberTheory/Multiquadratic/CoprimeSquarefree.lean
+++ b/TauCeti/NumberTheory/Multiquadratic/CoprimeSquarefree.lean
@@ -7,7 +7,6 @@ import Mathlib.Analysis.Real.Sqrt
 import Mathlib.Data.Rat.Lemmas
 import Mathlib.Algebra.Squarefree.Basic
 import Mathlib.RingTheory.Int.Basic
-import Mathlib.Tactic.NormNum.Prime
 
 /-!
 # Multiquadratic fields with pairwise-coprime squarefree integer radicands

--- a/TauCeti/NumberTheory/Multiquadratic/CoprimeSquarefree.lean
+++ b/TauCeti/NumberTheory/Multiquadratic/CoprimeSquarefree.lean
@@ -1,0 +1,142 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+import TauCeti.NumberTheory.Multiquadratic.Degree
+import Mathlib.Analysis.Real.Sqrt
+import Mathlib.Data.Rat.Lemmas
+import Mathlib.Algebra.Squarefree.Basic
+import Mathlib.Data.Nat.Squarefree
+import Mathlib.Tactic.NormNum.Prime
+import Mathlib.Data.Nat.Prime.Int
+
+/-!
+# Multiquadratic fields with pairwise-coprime squarefree integer radicands
+
+The field-generic degree theorem `TauCeti.Multiquadratic.finrank_adjoin_range` gives a
+multiquadratic field degree `2ⁿ` once its radicands are **square-class independent**: no nonempty
+subset product of them is a square. The genus theory the roadmap targets works with the rational
+field `ℚ(√d₁, …, √dₙ)` for **squarefree integers** `dᵢ`, where the radicands range over composite
+and negative values (`ℚ(√-3, √-7)`, `ℚ(√6, √35)`), not just the distinct primes already handled in
+`TauCeti.NumberTheory.Multiquadratic.PrimeRadicands`.
+
+This file supplies square-class independence in that setting: a family of **pairwise coprime,
+squarefree, non-unit** integers is square-class independent. The argument is the same one that
+works for distinct primes, run at the level of the integers: a nonempty subset product of pairwise
+coprime squarefree integers is again squarefree (Mathlib's
+`Finset.squarefree_prod_of_pairwise_isCoprime`) and is not a unit (it has a non-unit factor), so it
+is not a square; and an integer is a square in `ℚ` iff it is a square in `ℤ`
+(`Rat.isSquare_intCast_iff`). The distinct-primes statement `not_isSquare_prod_primes` is the
+special case where each radicand is prime.
+
+## Main results
+
+* `TauCeti.Multiquadratic.not_isSquare_prod_of_coprime_squarefree`: for pairwise coprime squarefree
+  non-unit integers `d i`, no nonempty subset product `∏_{i ∈ S} d i` is a square in `ℤ`.
+* `TauCeti.Multiquadratic.not_isSquare_prod_coprime_squarefree_rat`: the same square-class
+  independence cast to `ℚ`, in the `∀ S` shape the degree theorem consumes.
+* `TauCeti.Multiquadratic.finrank_adjoin_range_coprime_squarefree`:
+  `[ℚ(√d₁, …, √dₙ) : ℚ] = 2^|ι|` for pairwise coprime squarefree non-unit integer radicands, the
+  squarefree-integer corollary of `finrank_adjoin_range`.
+* `TauCeti.Multiquadratic.finrank_adjoin_sqrt_six_thirtyfive`: `[ℚ(√6, √35) : ℚ] = 4`, a worked
+  example with composite radicands, beyond the reach of the distinct-primes corollary.
+-/
+
+open scoped Function
+
+namespace TauCeti.Multiquadratic
+
+/-- A squarefree non-unit of a commutative monoid is not a square: a square `r * r` has `r` as a
+square factor, so squarefreeness forces `r` to be a unit, hence so is `r * r`. -/
+private theorem not_isSquare_of_squarefree_of_not_isUnit {R : Type*} [CommMonoid R] {a : R}
+    (ha : Squarefree a) (hu : ¬ IsUnit a) : ¬ IsSquare a := by
+  rintro ⟨r, rfl⟩
+  exact hu ((ha r dvd_rfl).mul (ha r dvd_rfl))
+
+/-- **Square-class independence of pairwise coprime squarefree integers.** If the radicands `d i`
+are pairwise coprime, each squarefree, and each a non-unit, then no nonempty subset product
+`∏_{i ∈ S} d i` is a square in `ℤ`. This generalises `not_isSquare_prod_primes` (the distinct-primes
+case) to the squarefree integers the genus theory uses, and supplies the square-class independence
+the multiquadratic degree theorem `finrank_adjoin_range` consumes. -/
+theorem not_isSquare_prod_of_coprime_squarefree {ι : Type*} (d : ι → ℤ) {S : Finset ι}
+    (hcop : (S : Set ι).Pairwise (IsCoprime on d)) (hsf : ∀ i ∈ S, Squarefree (d i))
+    (hnu : ∀ i ∈ S, ¬ IsUnit (d i)) (hS : S.Nonempty) :
+    ¬ IsSquare (∏ i ∈ S, d i) := by
+  refine not_isSquare_of_squarefree_of_not_isUnit ?_ ?_
+  · exact Finset.squarefree_prod_of_pairwise_isCoprime
+      (fun i hi j hj hij => (hcop hi hj hij).isRelPrime) hsf
+  · obtain ⟨i, hi⟩ := hS
+    exact fun hu => hnu i hi (isUnit_of_dvd_unit (Finset.dvd_prod_of_mem d hi) hu)
+
+/-- **Square-class independence cast to `ℚ`.** If `d : ι → ℤ` is pairwise coprime with each entry
+squarefree and a non-unit, then no nonempty subset product `∏_{i ∈ S} (d i : ℚ)` is a square in
+`ℚ`. This is the `∀ S` shape of `hindep` the degree and Galois-group theorems consume directly. -/
+theorem not_isSquare_prod_coprime_squarefree_rat {ι : Type*} (d : ι → ℤ)
+    (hcop : Pairwise (IsCoprime on d)) (hsf : ∀ i, Squarefree (d i)) (hnu : ∀ i, ¬ IsUnit (d i)) :
+    ∀ S : Finset ι, S.Nonempty → ¬ IsSquare (∏ i ∈ S, (d i : ℚ)) := by
+  intro S hS
+  rw [← Int.cast_prod, Rat.isSquare_intCast_iff]
+  exact not_isSquare_prod_of_coprime_squarefree d (hcop.set_pairwise _)
+    (fun i _ => hsf i) (fun i _ => hnu i) hS
+
+/-- **Degree of a multiquadratic field with squarefree integer radicands.** If `d : ι → ℤ` is
+pairwise coprime with each entry squarefree and a non-unit, and `root i` is a square root of `d i`
+in a field `L` over `ℚ` (so `ℚ(√d₁, …, √dₙ)` makes sense even for the negative radicands the genus
+theory needs), then `[ℚ(rootᵢ : i) : ℚ] = 2^|ι|`. This is the squarefree-integer corollary of the
+field-generic degree theorem `finrank_adjoin_range`. -/
+theorem finrank_adjoin_range_coprime_squarefree {ι : Type*} [Finite ι] {L : Type*} [Field L]
+    [Algebra ℚ L] (d : ι → ℤ) (root : ι → L) (hroot : ∀ i, root i ^ 2 = algebraMap ℚ L (d i))
+    (hcop : Pairwise (IsCoprime on d)) (hsf : ∀ i, Squarefree (d i)) (hnu : ∀ i, ¬ IsUnit (d i)) :
+    Module.finrank ℚ (IntermediateField.adjoin ℚ (Set.range root)) = 2 ^ Nat.card ι :=
+  finrank_adjoin_range (d := fun i => (d i : ℚ)) hroot
+    (not_isSquare_prod_coprime_squarefree_rat d hcop hsf hnu)
+
+/-- The real square root of a nonnegative integer squares back to its rational value, in the form
+`(√d)² = algebraMap ℚ ℝ d`. This supplies the `hroot` hypothesis of the degree theorem for the real
+square roots of nonnegative integer radicands. -/
+theorem sq_sqrt_intCast {n : ℤ} (hn : 0 ≤ n) :
+    (Real.sqrt n) ^ 2 = algebraMap ℚ ℝ (n : ℚ) := by
+  rw [Real.sq_sqrt (by exact_mod_cast hn), map_intCast]
+
+/-- **Worked example: `[ℚ(√6, √35) : ℚ] = 4`.** The radicands `6 = 2·3` and `35 = 5·7` are
+composite, so this lies beyond the distinct-primes corollary `finrank_adjoin_sqrt_primes`; it is
+covered by `finrank_adjoin_range_coprime_squarefree` because `6` and `35` are coprime, squarefree,
+and not units. -/
+theorem finrank_adjoin_sqrt_six_thirtyfive :
+    Module.finrank ℚ
+      (IntermediateField.adjoin ℚ {Real.sqrt 6, Real.sqrt 35} : IntermediateField ℚ ℝ) = 4 := by
+  have hcop : Pairwise (IsCoprime on (![6, 35] : Fin 2 → ℤ)) := by
+    have h : IsCoprime (6 : ℤ) 35 := Int.isCoprime_iff_gcd_eq_one.mpr (by decide)
+    have h' : IsCoprime (35 : ℤ) 6 := h.symm
+    intro i j hij
+    fin_cases i <;> fin_cases j <;> simp_all [Function.onFun]
+  have h6 : Squarefree (6 : ℤ) := by
+    have : Squarefree ((2 : ℤ) * 3) := squarefree_mul_iff.mpr
+      ⟨(Int.isCoprime_iff_gcd_eq_one.mpr (by decide)).isRelPrime,
+        (by norm_num : Prime (2 : ℤ)).squarefree, (by norm_num : Prime (3 : ℤ)).squarefree⟩
+    simpa using this
+  have h35 : Squarefree (35 : ℤ) := by
+    have : Squarefree ((5 : ℤ) * 7) := squarefree_mul_iff.mpr
+      ⟨(Int.isCoprime_iff_gcd_eq_one.mpr (by decide)).isRelPrime,
+        (by norm_num : Prime (5 : ℤ)).squarefree, (by norm_num : Prime (7 : ℤ)).squarefree⟩
+    simpa using this
+  have hsf : ∀ i, Squarefree ((![6, 35] : Fin 2 → ℤ) i) := by
+    intro i
+    fin_cases i
+    · exact h6
+    · exact h35
+  have hnu : ∀ i, ¬ IsUnit ((![6, 35] : Fin 2 → ℤ) i) := by
+    intro i
+    fin_cases i <;> simp [Int.isUnit_iff]
+  have h := finrank_adjoin_range_coprime_squarefree (L := ℝ) ![6, 35]
+    (fun i => Real.sqrt ((![6, 35] : Fin 2 → ℤ) i))
+    (fun i => by fin_cases i <;> exact sq_sqrt_intCast (by norm_num)) hcop hsf hnu
+  have hset : (Set.range fun i : Fin 2 => Real.sqrt ((![6, 35] : Fin 2 → ℤ) i))
+      = {Real.sqrt 6, Real.sqrt 35} := by
+    ext x
+    simp [Fin.exists_fin_two, eq_comm]
+  rw [hset] at h
+  rw [h]
+  simp
+
+end TauCeti.Multiquadratic

--- a/TauCeti/NumberTheory/Multiquadratic/CoprimeSquarefree.lean
+++ b/TauCeti/NumberTheory/Multiquadratic/CoprimeSquarefree.lean
@@ -6,7 +6,6 @@ import TauCeti.NumberTheory.Multiquadratic.Degree
 import Mathlib.Analysis.Real.Sqrt
 import Mathlib.Data.Rat.Lemmas
 import Mathlib.Algebra.Squarefree.Basic
-import Mathlib.Data.Nat.Squarefree
 import Mathlib.Tactic.NormNum.Prime
 import Mathlib.Data.Nat.Prime.Int
 
@@ -33,9 +32,9 @@ special case where each radicand is prime.
 
 * `TauCeti.Multiquadratic.not_isSquare_prod_of_coprime_squarefree`: for pairwise coprime squarefree
   non-unit integers `d i`, no nonempty subset product `∏_{i ∈ S} d i` is a square in `ℤ`.
-* `TauCeti.Multiquadratic.not_isSquare_prod_coprime_squarefree_rat`: the same square-class
+* `TauCeti.Multiquadratic.not_isSquare_prod_of_coprime_squarefree_rat`: the same square-class
   independence cast to `ℚ`, in the `∀ S` shape the degree theorem consumes.
-* `TauCeti.Multiquadratic.finrank_adjoin_range_coprime_squarefree`:
+* `TauCeti.Multiquadratic.finrank_adjoin_range_of_coprime_squarefree`:
   `[ℚ(√d₁, …, √dₙ) : ℚ] = 2^|ι|` for pairwise coprime squarefree non-unit integer radicands, the
   squarefree-integer corollary of `finrank_adjoin_range`.
 * `TauCeti.Multiquadratic.finrank_adjoin_sqrt_six_thirtyfive`: `[ℚ(√6, √35) : ℚ] = 4`, a worked
@@ -45,13 +44,6 @@ special case where each radicand is prime.
 open scoped Function
 
 namespace TauCeti.Multiquadratic
-
-/-- A squarefree non-unit of a commutative monoid is not a square: a square `r * r` has `r` as a
-square factor, so squarefreeness forces `r` to be a unit, hence so is `r * r`. -/
-private theorem not_isSquare_of_squarefree_of_not_isUnit {R : Type*} [CommMonoid R] {a : R}
-    (ha : Squarefree a) (hu : ¬ IsUnit a) : ¬ IsSquare a := by
-  rintro ⟨r, rfl⟩
-  exact hu ((ha r dvd_rfl).mul (ha r dvd_rfl))
 
 /-- **Square-class independence of pairwise coprime squarefree integers.** If the radicands `d i`
 are pairwise coprime, each squarefree, and each a non-unit, then no nonempty subset product
@@ -71,7 +63,7 @@ theorem not_isSquare_prod_of_coprime_squarefree {ι : Type*} (d : ι → ℤ) {S
 /-- **Square-class independence cast to `ℚ`.** If `d : ι → ℤ` is pairwise coprime with each entry
 squarefree and a non-unit, then no nonempty subset product `∏_{i ∈ S} (d i : ℚ)` is a square in
 `ℚ`. This is the `∀ S` shape of `hindep` the degree and Galois-group theorems consume directly. -/
-theorem not_isSquare_prod_coprime_squarefree_rat {ι : Type*} (d : ι → ℤ)
+theorem not_isSquare_prod_of_coprime_squarefree_rat {ι : Type*} (d : ι → ℤ)
     (hcop : Pairwise (IsCoprime on d)) (hsf : ∀ i, Squarefree (d i)) (hnu : ∀ i, ¬ IsUnit (d i)) :
     ∀ S : Finset ι, S.Nonempty → ¬ IsSquare (∏ i ∈ S, (d i : ℚ)) := by
   intro S hS
@@ -84,24 +76,17 @@ pairwise coprime with each entry squarefree and a non-unit, and `root i` is a sq
 in a field `L` over `ℚ` (so `ℚ(√d₁, …, √dₙ)` makes sense even for the negative radicands the genus
 theory needs), then `[ℚ(rootᵢ : i) : ℚ] = 2^|ι|`. This is the squarefree-integer corollary of the
 field-generic degree theorem `finrank_adjoin_range`. -/
-theorem finrank_adjoin_range_coprime_squarefree {ι : Type*} [Finite ι] {L : Type*} [Field L]
+theorem finrank_adjoin_range_of_coprime_squarefree {ι : Type*} [Finite ι] {L : Type*} [Field L]
     [Algebra ℚ L] (d : ι → ℤ) (root : ι → L) (hroot : ∀ i, root i ^ 2 = algebraMap ℚ L (d i))
     (hcop : Pairwise (IsCoprime on d)) (hsf : ∀ i, Squarefree (d i)) (hnu : ∀ i, ¬ IsUnit (d i)) :
     Module.finrank ℚ (IntermediateField.adjoin ℚ (Set.range root)) = 2 ^ Nat.card ι :=
   finrank_adjoin_range (d := fun i => (d i : ℚ)) hroot
-    (not_isSquare_prod_coprime_squarefree_rat d hcop hsf hnu)
-
-/-- The real square root of a nonnegative integer squares back to its rational value, in the form
-`(√d)² = algebraMap ℚ ℝ d`. This supplies the `hroot` hypothesis of the degree theorem for the real
-square roots of nonnegative integer radicands. -/
-theorem sq_sqrt_intCast {n : ℤ} (hn : 0 ≤ n) :
-    (Real.sqrt n) ^ 2 = algebraMap ℚ ℝ (n : ℚ) := by
-  rw [Real.sq_sqrt (by exact_mod_cast hn), map_intCast]
+    (not_isSquare_prod_of_coprime_squarefree_rat d hcop hsf hnu)
 
 /-- **Worked example: `[ℚ(√6, √35) : ℚ] = 4`.** The radicands `6 = 2·3` and `35 = 5·7` are
 composite, so this lies beyond the distinct-primes corollary `finrank_adjoin_sqrt_primes`; it is
-covered by `finrank_adjoin_range_coprime_squarefree` because `6` and `35` are coprime, squarefree,
-and not units. -/
+covered by `finrank_adjoin_range_of_coprime_squarefree` because `6` and `35` are coprime,
+squarefree, and not units. -/
 theorem finrank_adjoin_sqrt_six_thirtyfive :
     Module.finrank ℚ
       (IntermediateField.adjoin ℚ {Real.sqrt 6, Real.sqrt 35} : IntermediateField ℚ ℝ) = 4 := by
@@ -128,7 +113,7 @@ theorem finrank_adjoin_sqrt_six_thirtyfive :
   have hnu : ∀ i, ¬ IsUnit ((![6, 35] : Fin 2 → ℤ) i) := by
     intro i
     fin_cases i <;> simp [Int.isUnit_iff]
-  have h := finrank_adjoin_range_coprime_squarefree (L := ℝ) ![6, 35]
+  have h := finrank_adjoin_range_of_coprime_squarefree (L := ℝ) ![6, 35]
     (fun i => Real.sqrt ((![6, 35] : Fin 2 → ℤ) i))
     (fun i => by fin_cases i <;> exact sq_sqrt_intCast (by norm_num)) hcop hsf hnu
   have hset : (Set.range fun i : Fin 2 => Real.sqrt ((![6, 35] : Fin 2 → ℤ) i))

--- a/TauCeti/NumberTheory/Multiquadratic/Degree.lean
+++ b/TauCeti/NumberTheory/Multiquadratic/Degree.lean
@@ -3,6 +3,7 @@ Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 -/
 import TauCeti.NumberTheory.Multiquadratic.SquareClass
+import Mathlib.Algebra.Squarefree.Basic
 
 /-!
 # The degree of a multiquadratic field
@@ -30,6 +31,15 @@ of L. Alpöge's disproof of the uniform-constant Erdős unit-distance conjecture
 open TauCeti.IntermediateField
 
 namespace TauCeti.Multiquadratic
+
+/-- A squarefree non-unit of a commutative monoid is not a square: a square `r * r` has `r` as a
+square factor, so squarefreeness forces `r` to be a unit, hence so is `r * r`. This converts the
+arithmetic squarefreeness of a radicand product into the `¬ IsSquare` hypothesis the degree theorems
+consume. -/
+theorem not_isSquare_of_squarefree_of_not_isUnit {R : Type*} [CommMonoid R] {a : R}
+    (ha : Squarefree a) (hu : ¬ IsUnit a) : ¬ IsSquare a := by
+  rintro ⟨r, rfl⟩
+  exact hu ((ha r dvd_rfl).mul (ha r dvd_rfl))
 
 variable {K L : Type*} [Field K] [Field L] [Algebra K L]
 

--- a/TauCeti/NumberTheory/Multiquadratic/PrimeRadicands.lean
+++ b/TauCeti/NumberTheory/Multiquadratic/PrimeRadicands.lean
@@ -38,11 +38,6 @@ open scoped Function
 
 namespace TauCeti.Multiquadratic
 
-private theorem not_isSquare_of_squarefree_of_not_isUnit {R : Type*} [CommMonoid R] {a : R}
-    (ha : Squarefree a) (hu : ¬ IsUnit a) : ¬ IsSquare a := by
-  rintro ⟨r, rfl⟩
-  exact hu ((ha r dvd_rfl).mul (ha r dvd_rfl))
-
 /-- **Square-class independence of distinct primes.** If the selected `p i` are prime and pairwise
 distinct, then no nonempty subset product `∏_{i ∈ S} (p i : ℚ)` is a square in `ℚ`. This is the
 hypothesis the multiquadratic degree theorem `finrank_adjoin_range` consumes. -/
@@ -64,10 +59,12 @@ theorem not_isSquare_prod_primes {ι : Type*} (p : ι → ℕ) {S : Finset ι}
 
 /-- The real square root of a natural number squares back to its rational value, in the form
 `(√n)² = algebraMap ℚ ℝ n`. This supplies the `hroot` hypothesis that the multiquadratic degree and
-Galois-group theorems consume for the family of square roots of a prime family. -/
+Galois-group theorems consume for the family of square roots of a prime family. It is the `0 ≤ n`
+special case of `sq_sqrt_intCast`. -/
 theorem sq_sqrt_natCast (n : ℕ) :
     (Real.sqrt n) ^ 2 = algebraMap ℚ ℝ (n : ℚ) := by
-  rw [Real.sq_sqrt (Nat.cast_nonneg _), map_natCast]
+  have h := sq_sqrt_intCast (n := (n : ℤ)) (Int.natCast_nonneg n)
+  rwa [Int.cast_natCast, Int.cast_natCast] at h
 
 /-- **Square-class independence of an injective family of primes.** If `p : ι → ℕ` is injective and
 each `p i` is prime, then no nonempty subset product `∏_{i ∈ S} (p i : ℚ)` is a square. This is the

--- a/TauCeti/NumberTheory/Multiquadratic/SquareClass.lean
+++ b/TauCeti/NumberTheory/Multiquadratic/SquareClass.lean
@@ -335,4 +335,12 @@ theorem squareClass_of_sqrt_mem (c : ℕ → ℚ) (hc : ∀ j, 0 ≤ c j) :
   · have hr_nonneg : 0 ≤ (r : ℝ) := by exact_mod_cast hr
     simpa using Real.sq_sqrt hr_nonneg
 
+/-- The real square root of a nonnegative integer squares back to its rational value, in the form
+`(√n)² = algebraMap ℚ ℝ n`. This supplies the `hroot` hypothesis of the degree theorem for the real
+square roots of integer radicands. The natural-number form `sq_sqrt_natCast` is the special case
+`0 ≤ n`. -/
+theorem sq_sqrt_intCast {n : ℤ} (hn : 0 ≤ n) :
+    (Real.sqrt n) ^ 2 = algebraMap ℚ ℝ (n : ℚ) := by
+  rw [Real.sq_sqrt (by exact_mod_cast hn), map_intCast]
+
 end TauCeti.Multiquadratic


### PR DESCRIPTION
This PR adds square-class independence for **pairwise-coprime squarefree integer radicands**, the form the genus theory needs: `not_isSquare_prod_of_coprime_squarefree` shows that for integers `d i` that are pairwise coprime, squarefree, and non-units, no nonempty subset product `∏_{i ∈ S} d i` is a square in `ℤ`. It casts this to `ℚ` (`not_isSquare_prod_coprime_squarefree_rat`) and derives the degree corollary `finrank_adjoin_range_coprime_squarefree`: `[ℚ(√d₁, …, √dₙ) : ℚ] = 2^|ι|` for such radicands, stated over a generic field holding the roots so it applies to the negative radicands (`ℚ(√-3, √-7)`) the genus fields use. The worked example `finrank_adjoin_sqrt_six_thirtyfive` proves `[ℚ(√6, √35) : ℚ] = 4`, with composite radicands beyond the reach of the existing distinct-primes corollary.

This advances `TauCetiRoadmap/Multiquadratic/README.md`, Layer 0 ("Degree. Under square-class independence, `[K(√d₁,…,√dₙ) : K] = 2ⁿ`") and its standing instruction to "prove the field-generic theorem, then derive the rational and prime-indexed versions (the genus-theory inputs) as corollaries": Mathlib's quadratic-field and Kummer machinery has nothing on multiquadratic degree, and the genus theory works with squarefree integer radicands ("Rational radicands reduce to this integral squarefree case by square classes"). It generalises the merged distinct-primes statement `not_isSquare_prod_primes` (every distinct prime family is pairwise coprime, squarefree, and non-unit, so that is the special case) to the composite and negative squarefree radicands the genus fields require, which the existing prime-radicand and CM-field corollaries do not cover. I chose this because Layer 0's degree and Galois group, the prime-radicand and CM corollaries, and the Layer 1 splitting law are already merged, and the open Multiquadratic PRs cover the odd prime discriminants (#322) and the `Cl/Cl²` quotient (#294); the squarefree-integer square-class independence is the lowest-hanging distinct prerequisite none of them supply.

No Mathlib infrastructure is vendored. The proof reuses Mathlib's `Finset.squarefree_prod_of_pairwise_isCoprime`, `Rat.isSquare_intCast_iff`, `Int.squarefree_natCast`, `squarefree_mul_iff`, `IsCoprime.isRelPrime`, and `Int.isCoprime_iff_gcd_eq_one`, and consumes the field-generic degree theorem `TauCeti.Multiquadratic.finrank_adjoin_range`.

`TauCeti/NumberTheory/Multiquadratic/CoprimeSquarefree.lean`, one new file (142 lines).

Local verification: `lake exe cache get` reported `No files to download` and `Already decompressed 8573 file(s)`; `lake build` reported `Build completed successfully (4066 jobs).`; `lake exe axioms` reported `axioms: audited 4075 TauCeti declaration(s); all within the allowlist [propext, Classical.choice, Quot.sound].`

<!--tauceti-target:v1 {"focus":"Multiquadratic","id":"not-issquare-prod-of-coprime-squarefree"}-->

🤖 Prepared with Claude Code
