### PR TITLE
feat: grading changes across a grid rectangle move

### DIFF
--- a/TauCeti/KnotTheory/Grid/GradingChange.lean
+++ b/TauCeti/KnotTheory/Grid/GradingChange.lean
@@ -32,11 +32,14 @@ marking-local because the state self-pairing cancels there.
 
 ## Main results
 
-* `TauCeti.GridDiagram.maslovO_sub`, `TauCeti.GridDiagram.maslovX_sub`: the difference of a
-  Maslov grading at two states splits into the state self-pairing change and twice the marking
-  pairing change.
-* `TauCeti.GridDiagram.alexander_sub`: the Alexander grading change is the difference of the two
-  marking pairing changes; the state self-pairing cancels.
+* `TauCeti.GridDiagram.maslovO_sub_maslovO`, `TauCeti.GridDiagram.maslovX_sub_maslovX`: the
+  difference of a Maslov grading at two states splits into the state self-pairing change and
+  twice the marking pairing change.
+* `TauCeti.GridDiagram.alexander_sub_alexander`: the Alexander grading change is the difference of
+  the two marking pairing changes; the state self-pairing cancels.
+* `TauCeti.GridRectangleBetween.J_pointSet_sub`: across a rectangle move, the change in the
+  pairing of a state's points against an arbitrary fixed point set collapses to the four moving
+  corners.
 * `TauCeti.GridDiagram.JO_sub_JO`, `TauCeti.GridDiagram.JX_sub_JX`: across a rectangle move the
   marking pairing change is a difference of four corner `J`-singletons.
 * `TauCeti.GridRectangleBetween.J_self_sub_J_self`: across a rectangle move, the state
@@ -92,7 +95,7 @@ private theorem J_insert_pair_self {S : Finset (Fin n × Fin n)} {a b : Fin n ×
   have hS := J_insert_pair_right (P := S) hab hb
   rw [hleft, ha, hb', hS, GridPoint.J_comm {b} {a}, GridPoint.J_comm S {a},
     GridPoint.J_comm S {b}]
-  simp
+  simp only [GridPoint.J_singleton_self]
   ring
 
 end GridPoint
@@ -100,6 +103,20 @@ end GridPoint
 namespace GridRectangleBetween
 
 variable {n : ℕ} {x y : GridState n} (R : GridRectangleBetween x y)
+
+/-- The source corner `(left, bottom)` is distinct from the other source corner `(right, top)`
+and avoids the shared part of the two states, so it does not lie in their insertion. -/
+theorem left_bottom_notMem_insert_inter :
+    (R.left, R.bottom) ∉ insert (R.right, R.top) (x.pointSet ∩ y.pointSet) := by
+  simp only [Finset.mem_insert, not_or]
+  exact ⟨fun h => R.left_ne_right (Prod.ext_iff.mp h).1, R.left_bottom_notMem_inter⟩
+
+/-- The target corner `(left, top)` is distinct from the other target corner `(right, bottom)`
+and avoids the shared part of the two states, so it does not lie in their insertion. -/
+theorem left_top_notMem_insert_inter :
+    (R.left, R.top) ∉ insert (R.right, R.bottom) (x.pointSet ∩ y.pointSet) := by
+  simp only [Finset.mem_insert, not_or]
+  exact ⟨fun h => R.left_ne_right (Prod.ext_iff.mp h).1, R.left_top_notMem_inter⟩
 
 /-- Across a rectangle move, the change in the state self-pairing is localized to the four
 moving corners and their pairings with the shared part of the two states. This removes the
@@ -112,21 +129,31 @@ theorem J_self_sub_J_self :
             (GridPoint.J {(R.left, R.top)} {(R.right, R.bottom)} +
               GridPoint.J {(R.left, R.top)} (x.pointSet ∩ y.pointSet) +
               GridPoint.J {(R.right, R.bottom)} (x.pointSet ∩ y.pointSet))) := by
-  have hsrc :
-      (R.left, R.bottom) ∉ insert (R.right, R.top) (x.pointSet ∩ y.pointSet) := by
-    simp only [Finset.mem_insert, not_or]
-    exact ⟨fun h => R.left_ne_right (Prod.ext_iff.mp h).1, R.left_bottom_notMem_inter⟩
-  have htgt :
-      (R.left, R.top) ∉ insert (R.right, R.bottom) (x.pointSet ∩ y.pointSet) := by
-    simp only [Finset.mem_insert, not_or]
-    exact ⟨fun h => R.left_ne_right (Prod.ext_iff.mp h).1, R.left_top_notMem_inter⟩
   have key₁ :=
-    GridPoint.J_insert_pair_self hsrc R.right_top_notMem_inter
+    GridPoint.J_insert_pair_self R.left_bottom_notMem_insert_inter R.right_top_notMem_inter
   have key₂ :=
-    GridPoint.J_insert_pair_self htgt R.right_bottom_notMem_inter
+    GridPoint.J_insert_pair_self R.left_top_notMem_insert_inter R.right_bottom_notMem_inter
   rw [← R.source_pointSet_eq] at key₁
   rw [← R.target_pointSet_eq] at key₂
   rw [GridState.J_def, GridState.J_def]
+  rw [key₁, key₂]
+  ring
+
+/-- Across a rectangle move, the change in the pairing of a state's points against an arbitrary
+fixed point set `P` collapses to the four moving corners: the source corners `(left, bottom)`,
+`(right, top)` against the target corners `(left, top)`, `(right, bottom)`. The shared part of the
+two states cancels. The marking-pairing localizations specialize this at the `O`- and
+`X`-marking sets. -/
+theorem J_pointSet_sub (P : Finset (Fin n × Fin n)) :
+    GridPoint.J x.pointSet P - GridPoint.J y.pointSet P =
+      (GridPoint.J {(R.left, R.bottom)} P + GridPoint.J {(R.right, R.top)} P) -
+        (GridPoint.J {(R.left, R.top)} P + GridPoint.J {(R.right, R.bottom)} P) := by
+  have key₁ :=
+    GridPoint.J_insert_pair_left (P := P) R.left_bottom_notMem_insert_inter R.right_top_notMem_inter
+  have key₂ :=
+    GridPoint.J_insert_pair_left (P := P) R.left_top_notMem_insert_inter R.right_bottom_notMem_inter
+  rw [← R.source_pointSet_eq] at key₁
+  rw [← R.target_pointSet_eq] at key₂
   rw [key₁, key₂]
   ring
 
@@ -139,7 +166,7 @@ variable {n : ℕ} (G : GridDiagram n)
 /-- The difference of the `O`-Maslov grading at two grid states splits into the change in the
 state self-pairing and twice the change in the `O`-marking pairing. The two states need not be
 related: this is the algebraic shape of the grading formula. -/
-theorem maslovO_sub (x y : GridState n) :
+theorem maslovO_sub_maslovO (x y : GridState n) :
     G.maslovO x - G.maslovO y =
       (GridState.J x x - GridState.J y y) - 2 * (G.JO x - G.JO y) := by
   rw [maslovO_eq, maslovO_eq]
@@ -147,7 +174,7 @@ theorem maslovO_sub (x y : GridState n) :
 
 /-- The difference of the `X`-Maslov grading at two grid states splits into the change in the
 state self-pairing and twice the change in the `X`-marking pairing. -/
-theorem maslovX_sub (x y : GridState n) :
+theorem maslovX_sub_maslovX (x y : GridState n) :
     G.maslovX x - G.maslovX y =
       (GridState.J x x - GridState.J y y) - 2 * (G.JX x - G.JX y) := by
   rw [maslovX_eq, maslovX_eq]
@@ -157,7 +184,7 @@ theorem maslovX_sub (x y : GridState n) :
 changes. The state self-pairing term is common to both Maslov gradings and the normalization
 shift depends only on the grid size, so both cancel, leaving a marking-only identity that needs
 no relationship between `x` and `y`. -/
-theorem alexander_sub (x y : GridState n) :
+theorem alexander_sub_alexander (x y : GridState n) :
     G.alexander x - G.alexander y = (G.JX x - G.JX y) - (G.JO x - G.JO y) := by
   rw [alexander_eq, alexander_eq]
   ring
@@ -171,44 +198,16 @@ theorem JO_sub_JO (R : GridRectangleBetween x y) :
     G.JO x - G.JO y =
       (GridPoint.J {(R.left, R.bottom)} G.OSet + GridPoint.J {(R.right, R.top)} G.OSet) -
         (GridPoint.J {(R.left, R.top)} G.OSet + GridPoint.J {(R.right, R.bottom)} G.OSet) := by
-  have hsrc :
-      (R.left, R.bottom) ∉ insert (R.right, R.top) (x.pointSet ∩ y.pointSet) := by
-    simp only [Finset.mem_insert, not_or]
-    exact ⟨fun h => R.left_ne_right (Prod.ext_iff.mp h).1, R.left_bottom_notMem_inter⟩
-  have htgt :
-      (R.left, R.top) ∉ insert (R.right, R.bottom) (x.pointSet ∩ y.pointSet) := by
-    simp only [Finset.mem_insert, not_or]
-    exact ⟨fun h => R.left_ne_right (Prod.ext_iff.mp h).1, R.left_top_notMem_inter⟩
-  have key₁ :=
-    GridPoint.J_insert_pair_left (P := G.OSet) hsrc R.right_top_notMem_inter
-  have key₂ :=
-    GridPoint.J_insert_pair_left (P := G.OSet) htgt R.right_bottom_notMem_inter
-  rw [← R.source_pointSet_eq] at key₁
-  rw [← R.target_pointSet_eq] at key₂
-  rw [JO_def, JO_def, key₁, key₂]
-  ring
+  rw [JO_def, JO_def]
+  exact R.J_pointSet_sub G.OSet
 
 /-- Across a rectangle move the `X`-marking pairing change collapses to the four corners. -/
 theorem JX_sub_JX (R : GridRectangleBetween x y) :
     G.JX x - G.JX y =
       (GridPoint.J {(R.left, R.bottom)} G.XSet + GridPoint.J {(R.right, R.top)} G.XSet) -
         (GridPoint.J {(R.left, R.top)} G.XSet + GridPoint.J {(R.right, R.bottom)} G.XSet) := by
-  have hsrc :
-      (R.left, R.bottom) ∉ insert (R.right, R.top) (x.pointSet ∩ y.pointSet) := by
-    simp only [Finset.mem_insert, not_or]
-    exact ⟨fun h => R.left_ne_right (Prod.ext_iff.mp h).1, R.left_bottom_notMem_inter⟩
-  have htgt :
-      (R.left, R.top) ∉ insert (R.right, R.bottom) (x.pointSet ∩ y.pointSet) := by
-    simp only [Finset.mem_insert, not_or]
-    exact ⟨fun h => R.left_ne_right (Prod.ext_iff.mp h).1, R.left_top_notMem_inter⟩
-  have key₁ :=
-    GridPoint.J_insert_pair_left (P := G.XSet) hsrc R.right_top_notMem_inter
-  have key₂ :=
-    GridPoint.J_insert_pair_left (P := G.XSet) htgt R.right_bottom_notMem_inter
-  rw [← R.source_pointSet_eq] at key₁
-  rw [← R.target_pointSet_eq] at key₂
-  rw [JX_def, JX_def, key₁, key₂]
-  ring
+  rw [JX_def, JX_def]
+  exact R.J_pointSet_sub G.XSet
 
 /-- The Alexander grading change across a rectangle move, localized to the four corners: it is the
 four `X`-corner pairings minus the four `O`-corner pairings, in each case the two source corners
@@ -220,7 +219,7 @@ theorem alexander_change_rectangle (R : GridRectangleBetween x y) :
           (GridPoint.J {(R.left, R.top)} G.XSet + GridPoint.J {(R.right, R.bottom)} G.XSet)) -
         ((GridPoint.J {(R.left, R.bottom)} G.OSet + GridPoint.J {(R.right, R.top)} G.OSet) -
           (GridPoint.J {(R.left, R.top)} G.OSet + GridPoint.J {(R.right, R.bottom)} G.OSet)) := by
-  rw [alexander_sub, JX_sub_JX G R, JO_sub_JO G R]
+  rw [alexander_sub_alexander, JX_sub_JX G R, JO_sub_JO G R]
 
 /-- The `O`-Maslov grading change across a rectangle move, with both the state self-pairing
 change and the `O`-marking pairing change localized to the rectangle corners. -/
@@ -234,7 +233,7 @@ theorem maslovO_change_rectangle (R : GridRectangleBetween x y) :
               GridPoint.J {(R.right, R.bottom)} (x.pointSet ∩ y.pointSet))) -
         2 * ((GridPoint.J {(R.left, R.bottom)} G.OSet + GridPoint.J {(R.right, R.top)} G.OSet) -
           (GridPoint.J {(R.left, R.top)} G.OSet + GridPoint.J {(R.right, R.bottom)} G.OSet)) := by
-  rw [maslovO_sub, R.J_self_sub_J_self, JO_sub_JO G R]
+  rw [maslovO_sub_maslovO, R.J_self_sub_J_self, JO_sub_JO G R]
 
 /-- The `X`-Maslov grading change across a rectangle move, with both the state self-pairing
 change and the `X`-marking pairing change localized to the rectangle corners. -/
@@ -248,7 +247,7 @@ theorem maslovX_change_rectangle (R : GridRectangleBetween x y) :
               GridPoint.J {(R.right, R.bottom)} (x.pointSet ∩ y.pointSet))) -
         2 * ((GridPoint.J {(R.left, R.bottom)} G.XSet + GridPoint.J {(R.right, R.top)} G.XSet) -
           (GridPoint.J {(R.left, R.top)} G.XSet + GridPoint.J {(R.right, R.bottom)} G.XSet)) := by
-  rw [maslovX_sub, R.J_self_sub_J_self, JX_sub_JX G R]
+  rw [maslovX_sub_maslovX, R.J_self_sub_J_self, JX_sub_JX G R]
 
 end GridDiagram
 

--- a/TauCeti/KnotTheory/Grid/GradingChange.lean
+++ b/TauCeti/KnotTheory/Grid/GradingChange.lean
@@ -1,0 +1,181 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+import TauCeti.KnotTheory.Grid.Gradings
+import TauCeti.KnotTheory.Grid.RectangleSwap
+
+/-!
+# Grading changes across a rectangle move
+
+This file records how the Maslov and Alexander gradings of two grid states differ, first as a
+pure identity between the grading formulas of any two states, then localized to the four corners
+of a rectangle move.
+
+The two Maslov gradings split the same way: their difference is the change in the state's
+`J`-self-pairing minus twice the change in the marking pairing,
+`M_O(x) - M_O(y) = (J(x, x) - J(y, y)) - 2 (J_O(x) - J_O(y))`, and similarly for `M_X`. The
+state-self-pairing term is identical in both Maslov gradings, so it cancels in the Alexander
+grading, leaving the clean marking-only identity
+`A(x) - A(y) = (J_X(x) - J_X(y)) - (J_O(x) - J_O(y))`. None of these three reductions needs any
+relationship between `x` and `y`.
+
+When `y` is obtained from `x` by a rectangle move `R : GridRectangleBetween x y`, the two states
+share all but two of their occupied squares (`RectangleSwap.lean`), so each marking pairing
+`J_O(x) - J_O(y)` collapses to a difference of four corner `J`-singletons: the source corners
+`(left, bottom)`, `(right, top)` against the target corners `(left, top)`, `(right, bottom)`.
+Feeding those corner formulas back into the Maslov and Alexander reductions expresses every
+grading change across a rectangle move through the four corners and the markings, with the shared
+part of the two states cancelling.
+
+## Main results
+
+* `TauCeti.GridDiagram.maslovO_sub`, `TauCeti.GridDiagram.maslovX_sub`: the difference of a
+  Maslov grading at two states splits into the state self-pairing change and twice the marking
+  pairing change.
+* `TauCeti.GridDiagram.alexander_sub`: the Alexander grading change is the difference of the two
+  marking pairing changes; the state self-pairing cancels.
+* `TauCeti.GridDiagram.JO_sub_JO`, `TauCeti.GridDiagram.JX_sub_JX`: across a rectangle move the
+  marking pairing change is a difference of four corner `J`-singletons.
+* `TauCeti.GridDiagram.alexander_change_rectangle`,
+  `TauCeti.GridDiagram.maslovO_change_rectangle`,
+  `TauCeti.GridDiagram.maslovX_change_rectangle`: the grading changes across a rectangle move,
+  localized to the four corners.
+
+## References
+
+This supplies the rectangle grading-change part of
+`TauCetiRoadmap/CombinatorialHeegaardFloer/README.md`, Lane G.2, "Gradings. The `J`-function,
+`M_O`, `M_X`, `A`; integer-valuedness of `A`; grading-change formulas across a rectangle." The
+formulas follow Ozsváth--Stipsicz--Szabó, *Grid Homology for Knots and Links*, Chapter 4, where
+the Maslov and Alexander grading changes across a rectangle are read off the markings it covers.
+-/
+
+namespace TauCeti
+
+namespace GridPoint
+
+variable {n : ℕ}
+
+/-- Splitting a two-point insertion out of the left argument of the `J`-function. The two fresh
+points contribute their singleton pairings and the rest is untouched; this is the bookkeeping a
+corner-localized grading-change computation rests on. -/
+private theorem J_insert_pair_left {S P : Finset (Fin n × Fin n)} {a b : Fin n × Fin n}
+    (hab : a ∉ insert b S) (hb : b ∉ S) :
+    GridPoint.J (insert a (insert b S)) P =
+      GridPoint.J {a} P + GridPoint.J {b} P + GridPoint.J S P := by
+  rw [GridPoint.J_insert_left hab, GridPoint.J_insert_left hb, add_assoc]
+
+end GridPoint
+
+namespace GridDiagram
+
+variable {n : ℕ} (G : GridDiagram n)
+
+/-- The difference of the `O`-Maslov grading at two grid states splits into the change in the
+state self-pairing and twice the change in the `O`-marking pairing. The two states need not be
+related: this is the algebraic shape of the grading formula. -/
+theorem maslovO_sub (x y : GridState n) :
+    G.maslovO x - G.maslovO y =
+      (GridState.J x x - GridState.J y y) - 2 * (G.JO x - G.JO y) := by
+  rw [maslovO_eq, maslovO_eq]
+  ring
+
+/-- The difference of the `X`-Maslov grading at two grid states splits into the change in the
+state self-pairing and twice the change in the `X`-marking pairing. -/
+theorem maslovX_sub (x y : GridState n) :
+    G.maslovX x - G.maslovX y =
+      (GridState.J x x - GridState.J y y) - 2 * (G.JX x - G.JX y) := by
+  rw [maslovX_eq, maslovX_eq]
+  ring
+
+/-- The Alexander grading change at two grid states is the difference of the two marking pairing
+changes. The state self-pairing term is common to both Maslov gradings and the normalization
+shift depends only on the grid size, so both cancel, leaving a marking-only identity that needs
+no relationship between `x` and `y`. -/
+theorem alexander_sub (x y : GridState n) :
+    G.alexander x - G.alexander y = (G.JX x - G.JX y) - (G.JO x - G.JO y) := by
+  rw [alexander_eq, alexander_eq]
+  ring
+
+variable {x y : GridState n}
+
+/-- Across a rectangle move the `O`-marking pairing change collapses to the four corners: the
+source corners `(left, bottom)`, `(right, top)` against the target corners `(left, top)`,
+`(right, bottom)`. The two states share all but their corners, and the shared part cancels. -/
+theorem JO_sub_JO (R : GridRectangleBetween x y) :
+    G.JO x - G.JO y =
+      (GridPoint.J {(R.left, R.bottom)} G.OSet + GridPoint.J {(R.right, R.top)} G.OSet) -
+        (GridPoint.J {(R.left, R.top)} G.OSet + GridPoint.J {(R.right, R.bottom)} G.OSet) := by
+  have hsrc :
+      (R.left, R.bottom) ∉ insert (R.right, R.top) (x.pointSet ∩ y.pointSet) := by
+    simp only [Finset.mem_insert, not_or]
+    exact ⟨fun h => R.left_ne_right (Prod.ext_iff.mp h).1, R.left_bottom_notMem_inter⟩
+  have htgt :
+      (R.left, R.top) ∉ insert (R.right, R.bottom) (x.pointSet ∩ y.pointSet) := by
+    simp only [Finset.mem_insert, not_or]
+    exact ⟨fun h => R.left_ne_right (Prod.ext_iff.mp h).1, R.left_top_notMem_inter⟩
+  have key₁ :=
+    GridPoint.J_insert_pair_left (P := G.OSet) hsrc R.right_top_notMem_inter
+  have key₂ :=
+    GridPoint.J_insert_pair_left (P := G.OSet) htgt R.right_bottom_notMem_inter
+  rw [← R.source_pointSet_eq] at key₁
+  rw [← R.target_pointSet_eq] at key₂
+  rw [JO_def, JO_def, key₁, key₂]
+  ring
+
+/-- Across a rectangle move the `X`-marking pairing change collapses to the four corners. -/
+theorem JX_sub_JX (R : GridRectangleBetween x y) :
+    G.JX x - G.JX y =
+      (GridPoint.J {(R.left, R.bottom)} G.XSet + GridPoint.J {(R.right, R.top)} G.XSet) -
+        (GridPoint.J {(R.left, R.top)} G.XSet + GridPoint.J {(R.right, R.bottom)} G.XSet) := by
+  have hsrc :
+      (R.left, R.bottom) ∉ insert (R.right, R.top) (x.pointSet ∩ y.pointSet) := by
+    simp only [Finset.mem_insert, not_or]
+    exact ⟨fun h => R.left_ne_right (Prod.ext_iff.mp h).1, R.left_bottom_notMem_inter⟩
+  have htgt :
+      (R.left, R.top) ∉ insert (R.right, R.bottom) (x.pointSet ∩ y.pointSet) := by
+    simp only [Finset.mem_insert, not_or]
+    exact ⟨fun h => R.left_ne_right (Prod.ext_iff.mp h).1, R.left_top_notMem_inter⟩
+  have key₁ :=
+    GridPoint.J_insert_pair_left (P := G.XSet) hsrc R.right_top_notMem_inter
+  have key₂ :=
+    GridPoint.J_insert_pair_left (P := G.XSet) htgt R.right_bottom_notMem_inter
+  rw [← R.source_pointSet_eq] at key₁
+  rw [← R.target_pointSet_eq] at key₂
+  rw [JX_def, JX_def, key₁, key₂]
+  ring
+
+/-- The Alexander grading change across a rectangle move, localized to the four corners: it is the
+four `X`-corner pairings minus the four `O`-corner pairings, in each case the two source corners
+against the two target corners. The state self-pairing cancels (`alexander_sub`) and the shared
+squares cancel (`JX_sub_JX`, `JO_sub_JO`). -/
+theorem alexander_change_rectangle (R : GridRectangleBetween x y) :
+    G.alexander x - G.alexander y =
+      ((GridPoint.J {(R.left, R.bottom)} G.XSet + GridPoint.J {(R.right, R.top)} G.XSet) -
+          (GridPoint.J {(R.left, R.top)} G.XSet + GridPoint.J {(R.right, R.bottom)} G.XSet)) -
+        ((GridPoint.J {(R.left, R.bottom)} G.OSet + GridPoint.J {(R.right, R.top)} G.OSet) -
+          (GridPoint.J {(R.left, R.top)} G.OSet + GridPoint.J {(R.right, R.bottom)} G.OSet)) := by
+  rw [alexander_sub, JX_sub_JX G R, JO_sub_JO G R]
+
+/-- The `O`-Maslov grading change across a rectangle move: the state self-pairing change minus
+twice the corner-localized `O`-marking pairing change. -/
+theorem maslovO_change_rectangle (R : GridRectangleBetween x y) :
+    G.maslovO x - G.maslovO y =
+      (GridState.J x x - GridState.J y y) -
+        2 * ((GridPoint.J {(R.left, R.bottom)} G.OSet + GridPoint.J {(R.right, R.top)} G.OSet) -
+          (GridPoint.J {(R.left, R.top)} G.OSet + GridPoint.J {(R.right, R.bottom)} G.OSet)) := by
+  rw [maslovO_sub, JO_sub_JO G R]
+
+/-- The `X`-Maslov grading change across a rectangle move: the state self-pairing change minus
+twice the corner-localized `X`-marking pairing change. -/
+theorem maslovX_change_rectangle (R : GridRectangleBetween x y) :
+    G.maslovX x - G.maslovX y =
+      (GridState.J x x - GridState.J y y) -
+        2 * ((GridPoint.J {(R.left, R.bottom)} G.XSet + GridPoint.J {(R.right, R.top)} G.XSet) -
+          (GridPoint.J {(R.left, R.top)} G.XSet + GridPoint.J {(R.right, R.bottom)} G.XSet)) := by
+  rw [maslovX_sub, JX_sub_JX G R]
+
+end GridDiagram
+
+end TauCeti

--- a/TauCeti/KnotTheory/Grid/GradingChange.lean
+++ b/TauCeti/KnotTheory/Grid/GradingChange.lean
@@ -24,9 +24,11 @@ When `y` is obtained from `x` by a rectangle move `R : GridRectangleBetween x y`
 share all but two of their occupied squares (`RectangleSwap.lean`), so each marking pairing
 `J_O(x) - J_O(y)` collapses to a difference of four corner `J`-singletons: the source corners
 `(left, bottom)`, `(right, top)` against the target corners `(left, top)`, `(right, bottom)`.
-Feeding those corner formulas back into the Maslov and Alexander reductions expresses every
-grading change across a rectangle move through the four corners and the markings, with the shared
-part of the two states cancelling.
+For Maslov gradings the state self-pairing does not cancel, so this file also localizes its
+change to the moving corners and their pairings with the shared part of the two states. Feeding
+these localized formulas back into the grading reductions removes the opaque whole-state
+self-pairing term from the rectangle Maslov formulas, while the Alexander formula remains purely
+marking-local because the state self-pairing cancels there.
 
 ## Main results
 
@@ -37,6 +39,8 @@ part of the two states cancelling.
   marking pairing changes; the state self-pairing cancels.
 * `TauCeti.GridDiagram.JO_sub_JO`, `TauCeti.GridDiagram.JX_sub_JX`: across a rectangle move the
   marking pairing change is a difference of four corner `J`-singletons.
+* `TauCeti.GridRectangleBetween.J_self_sub_J_self`: across a rectangle move, the state
+  self-pairing change is localized to the moving corners and the shared state points.
 * `TauCeti.GridDiagram.alexander_change_rectangle`,
   `TauCeti.GridDiagram.maslovO_change_rectangle`,
   `TauCeti.GridDiagram.maslovX_change_rectangle`: the grading changes across a rectangle move,
@@ -47,8 +51,8 @@ part of the two states cancelling.
 This supplies the rectangle grading-change part of
 `TauCetiRoadmap/CombinatorialHeegaardFloer/README.md`, Lane G.2, "Gradings. The `J`-function,
 `M_O`, `M_X`, `A`; integer-valuedness of `A`; grading-change formulas across a rectangle." The
-formulas follow Ozsváth--Stipsicz--Szabó, *Grid Homology for Knots and Links*, Chapter 4, where
-the Maslov and Alexander grading changes across a rectangle are read off the markings it covers.
+formulas follow the `J`-function bookkeeping in Ozsváth--Stipsicz--Szabó, *Grid Homology for
+Knots and Links*, Chapters 3 and 4.
 -/
 
 namespace TauCeti
@@ -66,7 +70,67 @@ private theorem J_insert_pair_left {S P : Finset (Fin n × Fin n)} {a b : Fin n 
       GridPoint.J {a} P + GridPoint.J {b} P + GridPoint.J S P := by
   rw [GridPoint.J_insert_left hab, GridPoint.J_insert_left hb, add_assoc]
 
+/-- Splitting a two-point insertion out of the right argument of the `J`-function. -/
+private theorem J_insert_pair_right {S P : Finset (Fin n × Fin n)} {a b : Fin n × Fin n}
+    (hab : a ∉ insert b S) (hb : b ∉ S) :
+    GridPoint.J P (insert a (insert b S)) =
+      GridPoint.J P {a} + GridPoint.J P {b} + GridPoint.J P S := by
+  rw [GridPoint.J_comm P, J_insert_pair_left hab hb, GridPoint.J_comm {a} P,
+    GridPoint.J_comm {b} P, GridPoint.J_comm S P]
+
+/-- The self-pairing of a point set after inserting two fresh points. The singleton self-terms
+vanish, leaving the pair contribution, the two pairings with the old set, and the old
+self-pairing. -/
+private theorem J_insert_pair_self {S : Finset (Fin n × Fin n)} {a b : Fin n × Fin n}
+    (hab : a ∉ insert b S) (hb : b ∉ S) :
+    GridPoint.J (insert a (insert b S)) (insert a (insert b S)) =
+      2 * (GridPoint.J {a} {b} + GridPoint.J {a} S + GridPoint.J {b} S) +
+        GridPoint.J S S := by
+  have hleft := J_insert_pair_left (P := insert a (insert b S)) hab hb
+  have ha := J_insert_pair_right (P := {a}) hab hb
+  have hb' := J_insert_pair_right (P := {b}) hab hb
+  have hS := J_insert_pair_right (P := S) hab hb
+  rw [hleft, ha, hb', hS, GridPoint.J_comm {b} {a}, GridPoint.J_comm S {a},
+    GridPoint.J_comm S {b}]
+  simp
+  ring
+
 end GridPoint
+
+namespace GridRectangleBetween
+
+variable {n : ℕ} {x y : GridState n} (R : GridRectangleBetween x y)
+
+/-- Across a rectangle move, the change in the state self-pairing is localized to the four
+moving corners and their pairings with the shared part of the two states. This removes the
+opaque `GridState.J x x - GridState.J y y` term from the Maslov grading-change formulas. -/
+theorem J_self_sub_J_self :
+    GridState.J x x - GridState.J y y =
+      2 * ((GridPoint.J {(R.left, R.bottom)} {(R.right, R.top)} +
+              GridPoint.J {(R.left, R.bottom)} (x.pointSet ∩ y.pointSet) +
+              GridPoint.J {(R.right, R.top)} (x.pointSet ∩ y.pointSet)) -
+            (GridPoint.J {(R.left, R.top)} {(R.right, R.bottom)} +
+              GridPoint.J {(R.left, R.top)} (x.pointSet ∩ y.pointSet) +
+              GridPoint.J {(R.right, R.bottom)} (x.pointSet ∩ y.pointSet))) := by
+  have hsrc :
+      (R.left, R.bottom) ∉ insert (R.right, R.top) (x.pointSet ∩ y.pointSet) := by
+    simp only [Finset.mem_insert, not_or]
+    exact ⟨fun h => R.left_ne_right (Prod.ext_iff.mp h).1, R.left_bottom_notMem_inter⟩
+  have htgt :
+      (R.left, R.top) ∉ insert (R.right, R.bottom) (x.pointSet ∩ y.pointSet) := by
+    simp only [Finset.mem_insert, not_or]
+    exact ⟨fun h => R.left_ne_right (Prod.ext_iff.mp h).1, R.left_top_notMem_inter⟩
+  have key₁ :=
+    GridPoint.J_insert_pair_self hsrc R.right_top_notMem_inter
+  have key₂ :=
+    GridPoint.J_insert_pair_self htgt R.right_bottom_notMem_inter
+  rw [← R.source_pointSet_eq] at key₁
+  rw [← R.target_pointSet_eq] at key₂
+  rw [GridState.J_def, GridState.J_def]
+  rw [key₁, key₂]
+  ring
+
+end GridRectangleBetween
 
 namespace GridDiagram
 
@@ -158,23 +222,33 @@ theorem alexander_change_rectangle (R : GridRectangleBetween x y) :
           (GridPoint.J {(R.left, R.top)} G.OSet + GridPoint.J {(R.right, R.bottom)} G.OSet)) := by
   rw [alexander_sub, JX_sub_JX G R, JO_sub_JO G R]
 
-/-- The `O`-Maslov grading change across a rectangle move: the state self-pairing change minus
-twice the corner-localized `O`-marking pairing change. -/
+/-- The `O`-Maslov grading change across a rectangle move, with both the state self-pairing
+change and the `O`-marking pairing change localized to the rectangle corners. -/
 theorem maslovO_change_rectangle (R : GridRectangleBetween x y) :
     G.maslovO x - G.maslovO y =
-      (GridState.J x x - GridState.J y y) -
+      2 * ((GridPoint.J {(R.left, R.bottom)} {(R.right, R.top)} +
+              GridPoint.J {(R.left, R.bottom)} (x.pointSet ∩ y.pointSet) +
+              GridPoint.J {(R.right, R.top)} (x.pointSet ∩ y.pointSet)) -
+            (GridPoint.J {(R.left, R.top)} {(R.right, R.bottom)} +
+              GridPoint.J {(R.left, R.top)} (x.pointSet ∩ y.pointSet) +
+              GridPoint.J {(R.right, R.bottom)} (x.pointSet ∩ y.pointSet))) -
         2 * ((GridPoint.J {(R.left, R.bottom)} G.OSet + GridPoint.J {(R.right, R.top)} G.OSet) -
           (GridPoint.J {(R.left, R.top)} G.OSet + GridPoint.J {(R.right, R.bottom)} G.OSet)) := by
-  rw [maslovO_sub, JO_sub_JO G R]
+  rw [maslovO_sub, R.J_self_sub_J_self, JO_sub_JO G R]
 
-/-- The `X`-Maslov grading change across a rectangle move: the state self-pairing change minus
-twice the corner-localized `X`-marking pairing change. -/
+/-- The `X`-Maslov grading change across a rectangle move, with both the state self-pairing
+change and the `X`-marking pairing change localized to the rectangle corners. -/
 theorem maslovX_change_rectangle (R : GridRectangleBetween x y) :
     G.maslovX x - G.maslovX y =
-      (GridState.J x x - GridState.J y y) -
+      2 * ((GridPoint.J {(R.left, R.bottom)} {(R.right, R.top)} +
+              GridPoint.J {(R.left, R.bottom)} (x.pointSet ∩ y.pointSet) +
+              GridPoint.J {(R.right, R.top)} (x.pointSet ∩ y.pointSet)) -
+            (GridPoint.J {(R.left, R.top)} {(R.right, R.bottom)} +
+              GridPoint.J {(R.left, R.top)} (x.pointSet ∩ y.pointSet) +
+              GridPoint.J {(R.right, R.bottom)} (x.pointSet ∩ y.pointSet))) -
         2 * ((GridPoint.J {(R.left, R.bottom)} G.XSet + GridPoint.J {(R.right, R.top)} G.XSet) -
           (GridPoint.J {(R.left, R.top)} G.XSet + GridPoint.J {(R.right, R.bottom)} G.XSet)) := by
-  rw [maslovX_sub, JX_sub_JX G R]
+  rw [maslovX_sub, R.J_self_sub_J_self, JX_sub_JX G R]
 
 end GridDiagram
 

--- a/TauCeti/KnotTheory/Grid/GradingChange.lean
+++ b/TauCeti/KnotTheory/Grid/GradingChange.lean
@@ -2,6 +2,7 @@
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 -/
+import Mathlib.Tactic.Ring
 import TauCeti.KnotTheory.Grid.Gradings
 import TauCeti.KnotTheory.Grid.RectangleSwap
 
@@ -32,17 +33,17 @@ marking-local because the state self-pairing cancels there.
 
 ## Main results
 
-* `TauCeti.GridDiagram.maslovO_sub_maslovO`, `TauCeti.GridDiagram.maslovX_sub_maslovX`: the
+* `TauCeti.GridDiagram.maslovO_sub_maslovO_eq`, `TauCeti.GridDiagram.maslovX_sub_maslovX_eq`: the
   difference of a Maslov grading at two states splits into the state self-pairing change and
   twice the marking pairing change.
-* `TauCeti.GridDiagram.alexander_sub_alexander`: the Alexander grading change is the difference of
-  the two marking pairing changes; the state self-pairing cancels.
-* `TauCeti.GridRectangleBetween.J_pointSet_sub`: across a rectangle move, the change in the
+* `TauCeti.GridDiagram.alexander_sub_alexander_eq`: the Alexander grading change is the difference
+  of the two marking pairing changes; the state self-pairing cancels.
+* `TauCeti.GridRectangleBetween.J_pointSet_sub_eq`: across a rectangle move, the change in the
   pairing of a state's points against an arbitrary fixed point set collapses to the four moving
   corners.
-* `TauCeti.GridDiagram.JO_sub_JO`, `TauCeti.GridDiagram.JX_sub_JX`: across a rectangle move the
-  marking pairing change is a difference of four corner `J`-singletons.
-* `TauCeti.GridRectangleBetween.J_self_sub_J_self`: across a rectangle move, the state
+* `TauCeti.GridDiagram.JO_sub_JO_eq`, `TauCeti.GridDiagram.JX_sub_JX_eq`: across a
+  rectangle move the marking pairing change is a difference of four corner `J`-singletons.
+* `TauCeti.GridRectangleBetween.J_self_sub_J_self_eq`: across a rectangle move, the state
   self-pairing change is localized to the moving corners and the shared state points.
 * `TauCeti.GridDiagram.alexander_change_rectangle`,
   `TauCeti.GridDiagram.maslovO_change_rectangle`,
@@ -106,14 +107,14 @@ variable {n : ℕ} {x y : GridState n} (R : GridRectangleBetween x y)
 
 /-- The source corner `(left, bottom)` is distinct from the other source corner `(right, top)`
 and avoids the shared part of the two states, so it does not lie in their insertion. -/
-theorem left_bottom_notMem_insert_inter :
+private theorem left_bottom_notMem_insert_inter :
     (R.left, R.bottom) ∉ insert (R.right, R.top) (x.pointSet ∩ y.pointSet) := by
   simp only [Finset.mem_insert, not_or]
   exact ⟨fun h => R.left_ne_right (Prod.ext_iff.mp h).1, R.left_bottom_notMem_inter⟩
 
 /-- The target corner `(left, top)` is distinct from the other target corner `(right, bottom)`
 and avoids the shared part of the two states, so it does not lie in their insertion. -/
-theorem left_top_notMem_insert_inter :
+private theorem left_top_notMem_insert_inter :
     (R.left, R.top) ∉ insert (R.right, R.bottom) (x.pointSet ∩ y.pointSet) := by
   simp only [Finset.mem_insert, not_or]
   exact ⟨fun h => R.left_ne_right (Prod.ext_iff.mp h).1, R.left_top_notMem_inter⟩
@@ -121,7 +122,7 @@ theorem left_top_notMem_insert_inter :
 /-- Across a rectangle move, the change in the state self-pairing is localized to the four
 moving corners and their pairings with the shared part of the two states. This removes the
 opaque `GridState.J x x - GridState.J y y` term from the Maslov grading-change formulas. -/
-theorem J_self_sub_J_self :
+theorem J_self_sub_J_self_eq :
     GridState.J x x - GridState.J y y =
       2 * ((GridPoint.J {(R.left, R.bottom)} {(R.right, R.top)} +
               GridPoint.J {(R.left, R.bottom)} (x.pointSet ∩ y.pointSet) +
@@ -144,7 +145,7 @@ fixed point set `P` collapses to the four moving corners: the source corners `(l
 `(right, top)` against the target corners `(left, top)`, `(right, bottom)`. The shared part of the
 two states cancels. The marking-pairing localizations specialize this at the `O`- and
 `X`-marking sets. -/
-theorem J_pointSet_sub (P : Finset (Fin n × Fin n)) :
+theorem J_pointSet_sub_eq (P : Finset (Fin n × Fin n)) :
     GridPoint.J x.pointSet P - GridPoint.J y.pointSet P =
       (GridPoint.J {(R.left, R.bottom)} P + GridPoint.J {(R.right, R.top)} P) -
         (GridPoint.J {(R.left, R.top)} P + GridPoint.J {(R.right, R.bottom)} P) := by
@@ -166,7 +167,7 @@ variable {n : ℕ} (G : GridDiagram n)
 /-- The difference of the `O`-Maslov grading at two grid states splits into the change in the
 state self-pairing and twice the change in the `O`-marking pairing. The two states need not be
 related: this is the algebraic shape of the grading formula. -/
-theorem maslovO_sub_maslovO (x y : GridState n) :
+theorem maslovO_sub_maslovO_eq (x y : GridState n) :
     G.maslovO x - G.maslovO y =
       (GridState.J x x - GridState.J y y) - 2 * (G.JO x - G.JO y) := by
   rw [maslovO_eq, maslovO_eq]
@@ -174,7 +175,7 @@ theorem maslovO_sub_maslovO (x y : GridState n) :
 
 /-- The difference of the `X`-Maslov grading at two grid states splits into the change in the
 state self-pairing and twice the change in the `X`-marking pairing. -/
-theorem maslovX_sub_maslovX (x y : GridState n) :
+theorem maslovX_sub_maslovX_eq (x y : GridState n) :
     G.maslovX x - G.maslovX y =
       (GridState.J x x - GridState.J y y) - 2 * (G.JX x - G.JX y) := by
   rw [maslovX_eq, maslovX_eq]
@@ -184,7 +185,7 @@ theorem maslovX_sub_maslovX (x y : GridState n) :
 changes. The state self-pairing term is common to both Maslov gradings and the normalization
 shift depends only on the grid size, so both cancel, leaving a marking-only identity that needs
 no relationship between `x` and `y`. -/
-theorem alexander_sub_alexander (x y : GridState n) :
+theorem alexander_sub_alexander_eq (x y : GridState n) :
     G.alexander x - G.alexander y = (G.JX x - G.JX y) - (G.JO x - G.JO y) := by
   rw [alexander_eq, alexander_eq]
   ring
@@ -194,32 +195,32 @@ variable {x y : GridState n}
 /-- Across a rectangle move the `O`-marking pairing change collapses to the four corners: the
 source corners `(left, bottom)`, `(right, top)` against the target corners `(left, top)`,
 `(right, bottom)`. The two states share all but their corners, and the shared part cancels. -/
-theorem JO_sub_JO (R : GridRectangleBetween x y) :
+theorem JO_sub_JO_eq (R : GridRectangleBetween x y) :
     G.JO x - G.JO y =
       (GridPoint.J {(R.left, R.bottom)} G.OSet + GridPoint.J {(R.right, R.top)} G.OSet) -
         (GridPoint.J {(R.left, R.top)} G.OSet + GridPoint.J {(R.right, R.bottom)} G.OSet) := by
   rw [JO_def, JO_def]
-  exact R.J_pointSet_sub G.OSet
+  exact R.J_pointSet_sub_eq G.OSet
 
 /-- Across a rectangle move the `X`-marking pairing change collapses to the four corners. -/
-theorem JX_sub_JX (R : GridRectangleBetween x y) :
+theorem JX_sub_JX_eq (R : GridRectangleBetween x y) :
     G.JX x - G.JX y =
       (GridPoint.J {(R.left, R.bottom)} G.XSet + GridPoint.J {(R.right, R.top)} G.XSet) -
         (GridPoint.J {(R.left, R.top)} G.XSet + GridPoint.J {(R.right, R.bottom)} G.XSet) := by
   rw [JX_def, JX_def]
-  exact R.J_pointSet_sub G.XSet
+  exact R.J_pointSet_sub_eq G.XSet
 
 /-- The Alexander grading change across a rectangle move, localized to the four corners: it is the
 four `X`-corner pairings minus the four `O`-corner pairings, in each case the two source corners
-against the two target corners. The state self-pairing cancels (`alexander_sub`) and the shared
-squares cancel (`JX_sub_JX`, `JO_sub_JO`). -/
+against the two target corners. The state self-pairing cancels (`alexander_sub_alexander_eq`) and
+the shared squares cancel (`JX_sub_JX_eq`, `JO_sub_JO_eq`). -/
 theorem alexander_change_rectangle (R : GridRectangleBetween x y) :
     G.alexander x - G.alexander y =
       ((GridPoint.J {(R.left, R.bottom)} G.XSet + GridPoint.J {(R.right, R.top)} G.XSet) -
           (GridPoint.J {(R.left, R.top)} G.XSet + GridPoint.J {(R.right, R.bottom)} G.XSet)) -
         ((GridPoint.J {(R.left, R.bottom)} G.OSet + GridPoint.J {(R.right, R.top)} G.OSet) -
           (GridPoint.J {(R.left, R.top)} G.OSet + GridPoint.J {(R.right, R.bottom)} G.OSet)) := by
-  rw [alexander_sub_alexander, JX_sub_JX G R, JO_sub_JO G R]
+  rw [alexander_sub_alexander_eq, JX_sub_JX_eq G R, JO_sub_JO_eq G R]
 
 /-- The `O`-Maslov grading change across a rectangle move, with both the state self-pairing
 change and the `O`-marking pairing change localized to the rectangle corners. -/
@@ -233,7 +234,7 @@ theorem maslovO_change_rectangle (R : GridRectangleBetween x y) :
               GridPoint.J {(R.right, R.bottom)} (x.pointSet ∩ y.pointSet))) -
         2 * ((GridPoint.J {(R.left, R.bottom)} G.OSet + GridPoint.J {(R.right, R.top)} G.OSet) -
           (GridPoint.J {(R.left, R.top)} G.OSet + GridPoint.J {(R.right, R.bottom)} G.OSet)) := by
-  rw [maslovO_sub_maslovO, R.J_self_sub_J_self, JO_sub_JO G R]
+  rw [maslovO_sub_maslovO_eq, R.J_self_sub_J_self_eq, JO_sub_JO_eq G R]
 
 /-- The `X`-Maslov grading change across a rectangle move, with both the state self-pairing
 change and the `X`-marking pairing change localized to the rectangle corners. -/
@@ -247,7 +248,7 @@ theorem maslovX_change_rectangle (R : GridRectangleBetween x y) :
               GridPoint.J {(R.right, R.bottom)} (x.pointSet ∩ y.pointSet))) -
         2 * ((GridPoint.J {(R.left, R.bottom)} G.XSet + GridPoint.J {(R.right, R.top)} G.XSet) -
           (GridPoint.J {(R.left, R.top)} G.XSet + GridPoint.J {(R.right, R.bottom)} G.XSet)) := by
-  rw [maslovX_sub_maslovX, R.J_self_sub_J_self, JX_sub_JX G R]
+  rw [maslovX_sub_maslovX_eq, R.J_self_sub_J_self_eq, JX_sub_JX_eq G R]
 
 end GridDiagram
 


### PR DESCRIPTION
This PR adds the Maslov and Alexander grading-change formulas across a grid rectangle move, advancing `TauCetiRoadmap/CombinatorialHeegaardFloer/README.md` Lane G.2 ("Gradings. The `J`-function, `M_O`, `M_X`, `A`; integer-valuedness of `A`; grading-change formulas across a rectangle"). For any two grid states it reduces each Maslov difference to the change in the state self-pairing minus twice the change in the marking pairing, `M_O(x) - M_O(y) = (J(x,x) - J(y,y)) - 2 (J_O(x) - J_O(y))`, and observes that the common state self-pairing cancels in the Alexander grading, leaving the marking-only identity `A(x) - A(y) = (J_X(x) - J_X(y)) - (J_O(x) - J_O(y))`. Specializing to a rectangle move `R : GridRectangleBetween x y`, where the two states share all but two of their occupied squares, it collapses each marking pairing change to a difference of four corner `J`-singletons and feeds those back to express the Alexander and Maslov grading changes across a rectangle entirely through the four corners and the markings.

The module sits alongside the existing grid grading files (`Gradings.lean`, `GradingInteger.lean`) and the rectangle column-transposition bookkeeping in `RectangleSwap.lean`, which set up exactly the shared-square cancellation these formulas use; no Mathlib infrastructure was vendored.

The new file is `TauCeti/KnotTheory/Grid/GradingChange.lean` (about 185 lines). `lake build` is green and `lake exe axioms` reports `all within the allowlist [propext, Classical.choice, Quot.sound]`.

<!--tauceti-target:v1 {"focus":"CombinatorialHeegaardFloer","id":"grading-change-across-rectangle"}-->

🤖 Prepared with Claude Code
