### PR TITLE
feat: bridge characteristic functions to positive-definite predicates

### DIFF
--- a/TauCeti/Analysis/Bochner/CharFunPositiveDefinite.lean
+++ b/TauCeti/Analysis/Bochner/CharFunPositiveDefinite.lean
@@ -1,0 +1,93 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+import TauCeti.Analysis.Bochner.CharFunPosDef
+import TauCeti.Analysis.PositiveDefinite.Basic
+import TauCeti.Analysis.PositiveDefinite.Kernel
+import Mathlib.MeasureTheory.Measure.CharacteristicFunction.TaylorExpansion
+
+/-!
+# Characteristic functions as positive-definite functions
+
+This file connects the quadratic-form positivity calculation for characteristic functions to
+Tau Ceti's generic positive-definite-function predicate. If the involution on an additive group is
+negation, then Mathlib's characteristic function `MeasureTheory.charFun μ` of a finite measure is
+`TauCeti.IsPositiveDefinite`.
+
+Together with Mathlib's continuity theorem for characteristic functions, this gives the "finite
+measure's Fourier transform is continuous positive-definite" bridge lemma requested in Part C of
+the `OneParameterSemigroups` roadmap, before the harder converse direction of Bochner's theorem.
+
+## Main declarations
+
+* `TauCeti.charFun_isPositiveDefiniteKernel`: the translation-invariant kernel
+  `K(a, b) = charFun μ (a - b)` is positive definite.
+* `TauCeti.charFun_star_kernel_isPositiveDefiniteKernel_of_star_eq_neg`: with an explicit
+  `star = -` involution, the kernel `K(a, b) = charFun μ (a + star b)` is positive definite.
+* `TauCeti.charFun_isPositiveDefinite_of_star_eq_neg`: `charFun μ` is positive definite for any
+  explicit `star = -` involution.
+* `TauCeti.continuous_charFun_and_isPositiveDefinite_of_star_eq_neg`: the paired continuity and
+  positive-definiteness package.
+-/
+
+open MeasureTheory
+
+namespace TauCeti
+
+open scoped ComplexOrder
+
+variable {E : Type*} [NormedAddCommGroup E] [InnerProductSpace ℝ E]
+  [MeasurableSpace E] [OpensMeasurableSpace E] {μ : Measure E} [IsFiniteMeasure μ]
+
+/-- The translation-invariant characteristic-function kernel
+`(a, b) ↦ charFun μ (a - b)` is positive definite. This repackages the existing Gram-matrix
+statement `charFun_posSemidef` as a `TauCeti.IsPositiveDefiniteKernel`. -/
+theorem charFun_isPositiveDefiniteKernel :
+    IsPositiveDefiniteKernel (fun a b : E => MeasureTheory.charFun μ (a - b)) := by
+  rw [isPositiveDefiniteKernel_def]
+  simpa using charFun_posSemidef (μ := μ) (fun x : E => x)
+
+/-- With an explicit `star = -` involution, the kernel associated to `charFun μ` by the generic
+positive-definite-function construction, `(a, b) ↦ charFun μ (a + star b)`, is positive
+definite. -/
+theorem charFun_star_kernel_isPositiveDefiniteKernel_of_star_eq_neg [StarAddMonoid E]
+    (hstar : ∀ x : E, star x = -x) :
+    IsPositiveDefiniteKernel (fun a b : E => MeasureTheory.charFun μ (a + star b)) := by
+  rw [isPositiveDefiniteKernel_def]
+  simpa [hstar, sub_eq_add_neg] using charFun_posSemidef (μ := μ) (fun x : E => x)
+
+/-- The characteristic function of a finite measure is positive definite for any additive-group
+involution that is explicitly negation. This is the generic-predicate form of
+`charFun_fintype_sum_mul_conj_nonneg`, using
+`F (vᵢ + star vⱼ) = charFun μ (vᵢ - vⱼ)`. -/
+theorem charFun_isPositiveDefinite_of_star_eq_neg [StarAddMonoid E]
+    (hstar : ∀ x : E, star x = -x) :
+    IsPositiveDefinite (MeasureTheory.charFun μ) := by
+  intro n c v
+  have h := charFun_fintype_sum_mul_conj_nonneg (μ := μ) c v
+  refine le_of_le_of_eq h ?_
+  refine Finset.sum_congr rfl fun i _ => Finset.sum_congr rfl fun j _ => ?_
+  simp [hstar, sub_eq_add_neg]
+
+/-- The characteristic function of a finite measure on a second-countable real inner product space
+is continuous and positive definite, provided the chosen involution is negation. This is the
+forward bridge toward Bochner's theorem in the language of `TauCeti.IsPositiveDefinite`. -/
+theorem continuous_charFun_and_isPositiveDefinite_of_star_eq_neg
+    [BorelSpace E] [SecondCountableTopology E] [StarAddMonoid E]
+    (hstar : ∀ x : E, star x = -x) :
+    Continuous (MeasureTheory.charFun μ) ∧ IsPositiveDefinite (MeasureTheory.charFun μ) :=
+  ⟨MeasureTheory.continuous_charFun, charFun_isPositiveDefinite_of_star_eq_neg hstar⟩
+
+/-- The continuous positive-definite characteristic function, together with its associated
+positive-definite kernel. This is a convenient bundled form for downstream Bochner arguments that
+need both the one-variable predicate and the two-variable Gram-kernel predicate. -/
+theorem continuous_charFun_and_isPositiveDefinite_and_kernel_of_star_eq_neg
+    [BorelSpace E] [SecondCountableTopology E] [StarAddMonoid E]
+    (hstar : ∀ x : E, star x = -x) :
+    Continuous (MeasureTheory.charFun μ) ∧ IsPositiveDefinite (MeasureTheory.charFun μ) ∧
+      IsPositiveDefiniteKernel (fun a b : E => MeasureTheory.charFun μ (a + star b)) :=
+  ⟨MeasureTheory.continuous_charFun, charFun_isPositiveDefinite_of_star_eq_neg hstar,
+    charFun_star_kernel_isPositiveDefiniteKernel_of_star_eq_neg hstar⟩
+
+end TauCeti

--- a/TauCeti/Analysis/Bochner/CharFunPositiveDefinite.lean
+++ b/TauCeti/Analysis/Bochner/CharFunPositiveDefinite.lean
@@ -37,7 +37,9 @@ namespace TauCeti
 
 open scoped ComplexOrder
 
-variable {E : Type*} [NormedAddCommGroup E] [InnerProductSpace ℝ E]
+section Seminormed
+
+variable {E : Type*} [SeminormedAddCommGroup E] [InnerProductSpace ℝ E]
   [MeasurableSpace E] [OpensMeasurableSpace E] {μ : Measure E} [IsFiniteMeasure μ]
 
 /-- The translation-invariant characteristic-function kernel
@@ -50,12 +52,16 @@ theorem charFun_isPositiveDefiniteKernel :
 
 /-- With an explicit `star = -` involution, the kernel associated to `charFun μ` by the generic
 positive-definite-function construction, `(a, b) ↦ charFun μ (a + star b)`, is positive
-definite. -/
+definite. Under `hstar` this kernel coincides with the translation-invariant kernel of
+`charFun_isPositiveDefiniteKernel`. -/
 theorem charFun_star_kernel_isPositiveDefiniteKernel_of_star_eq_neg [StarAddMonoid E]
     (hstar : ∀ x : E, star x = -x) :
     IsPositiveDefiniteKernel (fun a b : E => MeasureTheory.charFun μ (a + star b)) := by
-  rw [isPositiveDefiniteKernel_def]
-  simpa [hstar, sub_eq_add_neg] using charFun_posSemidef (μ := μ) (fun x : E => x)
+  have h : (fun a b : E => MeasureTheory.charFun μ (a + star b))
+      = fun a b : E => MeasureTheory.charFun μ (a - b) := by
+    simp only [hstar, sub_eq_add_neg]
+  rw [h]
+  exact charFun_isPositiveDefiniteKernel
 
 /-- The characteristic function of a finite measure is positive definite for any additive-group
 involution that is explicitly negation. This is the generic-predicate form of
@@ -70,24 +76,22 @@ theorem charFun_isPositiveDefinite_of_star_eq_neg [StarAddMonoid E]
   refine Finset.sum_congr rfl fun i _ => Finset.sum_congr rfl fun j _ => ?_
   simp [hstar, sub_eq_add_neg]
 
+end Seminormed
+
+section Normed
+
+variable {E : Type*} [NormedAddCommGroup E] [InnerProductSpace ℝ E]
+  [MeasurableSpace E] [BorelSpace E] [SecondCountableTopology E]
+  {μ : Measure E} [IsFiniteMeasure μ]
+
 /-- The characteristic function of a finite measure on a second-countable real inner product space
 is continuous and positive definite, provided the chosen involution is negation. This is the
 forward bridge toward Bochner's theorem in the language of `TauCeti.IsPositiveDefinite`. -/
-theorem continuous_charFun_and_isPositiveDefinite_of_star_eq_neg
-    [BorelSpace E] [SecondCountableTopology E] [StarAddMonoid E]
+theorem continuous_charFun_and_isPositiveDefinite_of_star_eq_neg [StarAddMonoid E]
     (hstar : ∀ x : E, star x = -x) :
     Continuous (MeasureTheory.charFun μ) ∧ IsPositiveDefinite (MeasureTheory.charFun μ) :=
   ⟨MeasureTheory.continuous_charFun, charFun_isPositiveDefinite_of_star_eq_neg hstar⟩
 
-/-- The continuous positive-definite characteristic function, together with its associated
-positive-definite kernel. This is a convenient bundled form for downstream Bochner arguments that
-need both the one-variable predicate and the two-variable Gram-kernel predicate. -/
-theorem continuous_charFun_and_isPositiveDefinite_and_kernel_of_star_eq_neg
-    [BorelSpace E] [SecondCountableTopology E] [StarAddMonoid E]
-    (hstar : ∀ x : E, star x = -x) :
-    Continuous (MeasureTheory.charFun μ) ∧ IsPositiveDefinite (MeasureTheory.charFun μ) ∧
-      IsPositiveDefiniteKernel (fun a b : E => MeasureTheory.charFun μ (a + star b)) :=
-  ⟨MeasureTheory.continuous_charFun, charFun_isPositiveDefinite_of_star_eq_neg hstar,
-    charFun_star_kernel_isPositiveDefiniteKernel_of_star_eq_neg hstar⟩
+end Normed
 
 end TauCeti


### PR DESCRIPTION
This PR records the forward Bochner bridge from Mathlib's characteristic function to Tau Ceti's generic positive-definite predicates. It repackages the existing quadratic-form calculation for `MeasureTheory.charFun μ` as `TauCeti.charFun_isPositiveDefinite_of_star_eq_neg`, under the explicit hypothesis that the chosen involution on the additive group is negation, and as the associated positive-definite kernel statements for `K(a, b) = charFun μ (a - b)` and `K(a, b) = charFun μ (a + star b)`. It also packages Mathlib's `MeasureTheory.continuous_charFun` with the new predicate-level statement for downstream Bochner arguments.

This advances `TauCetiRoadmap/OneParameterSemigroups/README.md`, Part C ("Positive-definite functions and Bochner's theorem"), specifically the `API to develop` bullet calling for "the bridge lemma: a finite measure's Fourier transform is continuous positive-definite (`pd_quadratic_form_of_measure`)". The existing Tau Ceti file `TauCeti/Analysis/Bochner/CharFunPosDef.lean` proves the finite-family and matrix positivity directly for `charFun`; this PR supplies the missing connection to `TauCeti.IsPositiveDefinite` and `TauCeti.IsPositiveDefiniteKernel` without changing that existing API.

No Mathlib infrastructure is vendored. The proofs reuse Mathlib's `MeasureTheory.continuous_charFun` and Tau Ceti's existing `charFun_fintype_sum_mul_conj_nonneg`, `charFun_posSemidef`, `IsPositiveDefinite`, and `IsPositiveDefiniteKernel`.

`TauCeti/Analysis/Bochner/CharFunPositiveDefinite.lean`, one new file (93 lines).

Local verification: `lake exe cache get` reported `No files to download` and `Already decompressed 8573 file(s)`; `lake build` reported `Build completed successfully (4113 jobs).`; `lake exe axioms` reported `axioms: audited 4157 TauCeti declaration(s); all within the allowlist [propext, Classical.choice, Quot.sound].`

<!--tauceti-target:v1 {"focus":"OneParameterSemigroups","id":"charfun-ispositivedefinite"}-->

🤖 Prepared with Codex
