### PR TITLE
feat: count grid states

### DIFF
--- a/TauCeti/KnotTheory/Grid/Diagram.lean
+++ b/TauCeti/KnotTheory/Grid/Diagram.lean
@@ -66,8 +66,8 @@ namespace GridState
 
 variable {n : ℕ}
 
-/-- Grid states are equivalent to permutations of the columns. -/
-private def equivPerm : GridState n ≃ Equiv.Perm (Fin n) where
+/-- Grid states on an `n × n` grid are equivalent to permutations of the columns. -/
+def equivPerm (n : ℕ) : GridState n ≃ Equiv.Perm (Fin n) where
   toFun x := x.toPerm
   invFun σ := ⟨σ⟩
   left_inv x := by cases x; rfl
@@ -75,7 +75,7 @@ private def equivPerm : GridState n ≃ Equiv.Perm (Fin n) where
 
 /-- There are finitely many grid states of a fixed grid size. -/
 instance : Fintype (GridState n) :=
-  Fintype.ofEquiv (Equiv.Perm (Fin n)) equivPerm.symm
+  Fintype.ofEquiv (Equiv.Perm (Fin n)) (equivPerm n).symm
 
 /-- Apply a grid state to a column to get its occupied row. -/
 instance : CoeFun (GridState n) fun _ => Fin n → Fin n where

--- a/TauCeti/KnotTheory/Grid/Diagram.lean
+++ b/TauCeti/KnotTheory/Grid/Diagram.lean
@@ -21,26 +21,11 @@ that no square contains both markings.
 The point-set API records the basic row, column, cardinality, and disjointness facts used
 before defining rectangles, empty rectangles, and the grid differential.
 
-## Main definitions
-
 * `TauCeti.GridState`: a grid state with a permutation graph on `Fin n`.
 * `TauCeti.GridState.pointSet`: the finite set of occupied squares of a grid state.
-* `TauCeti.GridState.relabelRows`, `TauCeti.GridState.relabelColumns`: row and column
-  relabelings of grid states.
-* `TauCeti.GridState.swapRows`, `TauCeti.GridState.swapColumns`: row and column swaps of
-  grid states.
-* `TauCeti.GridState.transpose`: the diagonal reflection of a grid state, with the inverse
-  permutation graph.
 * `TauCeti.GridDiagram`: an `n × n` grid diagram with `O` and `X` markings.
 * `TauCeti.GridDiagram.OSet`, `TauCeti.GridDiagram.XSet`: the marking point sets.
-* `TauCeti.GridDiagram.relabelRows`, `TauCeti.GridDiagram.relabelColumns`: row and column
-  relabelings of grid diagrams.
-* `TauCeti.GridDiagram.swapRows`, `TauCeti.GridDiagram.swapColumns`: row and column swaps of
-  grid diagrams.
-* `TauCeti.GridDiagram.transpose`: the diagonal reflection of a grid diagram, reflecting both
-  marking states.
-* `TauCeti.GridDiagram.swapMarkings`: the grid diagram obtained by exchanging the `O`- and
-  `X`-marking states.
+* Relabeling, swapping, transposition, and marking-swap operations for grid states and diagrams.
 
 ## References
 
@@ -81,6 +66,16 @@ instance : Fintype (GridState n) :=
 instance : CoeFun (GridState n) fun _ => Fin n → Fin n where
   coe x := x.toPerm
 
+/-- The permutation associated to a grid state by `GridState.equivPerm`. -/
+@[simp] theorem equivPerm_apply (x : GridState n) : equivPerm n x = x.toPerm := rfl
+
+/-- The grid state associated to a permutation by the inverse of `GridState.equivPerm`. -/
+@[simp] theorem equivPerm_symm_apply (σ : Equiv.Perm (Fin n)) : (equivPerm n).symm σ = ⟨σ⟩ := rfl
+
+/-- Evaluating a grid state obtained from a permutation gives the permutation value. -/
+@[simp] theorem equivPerm_symm_apply_apply (σ : Equiv.Perm (Fin n)) (c : Fin n) :
+    ((equivPerm n).symm σ : GridState n) c = σ c := rfl
+
 /-- Grid states are extensional in their column-to-row functions. -/
 @[ext]
 theorem ext {x y : GridState n} (h : ∀ c : Fin n, x c = y c) : x = y := by
@@ -94,6 +89,10 @@ theorem ext {x y : GridState n} (h : ∀ c : Fin n, x c = y c) : x = y := by
 the second coordinate is the row. -/
 def pointSet (x : GridState n) : Finset (Fin n × Fin n) :=
   Finset.univ.image fun c => (c, x c)
+
+/-- The point set of the grid state obtained from `σ` is the graph `{(c, σ c)}`. -/
+@[simp] theorem equivPerm_symm_pointSet (σ : Equiv.Perm (Fin n)) :
+    ((equivPerm n).symm σ : GridState n).pointSet = Finset.univ.image fun c => (c, σ c) := rfl
 
 /-- Membership in the point set of a grid state is the graph condition for its permutation. -/
 @[simp]

--- a/TauCeti/KnotTheory/Grid/Diagram.lean
+++ b/TauCeti/KnotTheory/Grid/Diagram.lean
@@ -70,7 +70,7 @@ instance : CoeFun (GridState n) fun _ => Fin n → Fin n where
 @[simp] theorem equivPerm_apply (x : GridState n) : equivPerm n x = x.toPerm := rfl
 
 /-- The grid state associated to a permutation by the inverse of `GridState.equivPerm`. -/
-@[simp] theorem equivPerm_symm_apply (σ : Equiv.Perm (Fin n)) : (equivPerm n).symm σ = ⟨σ⟩ := rfl
+theorem equivPerm_symm_apply (σ : Equiv.Perm (Fin n)) : (equivPerm n).symm σ = ⟨σ⟩ := rfl
 
 /-- Evaluating a grid state obtained from a permutation gives the permutation value. -/
 @[simp] theorem equivPerm_symm_apply_apply (σ : Equiv.Perm (Fin n)) (c : Fin n) :

--- a/TauCeti/KnotTheory/Grid/StateCardinality.lean
+++ b/TauCeti/KnotTheory/Grid/StateCardinality.lean
@@ -2,8 +2,8 @@
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 -/
-import Mathlib.Data.Finite.Perm
 import Mathlib.Data.Fintype.Perm
+import Mathlib.SetTheory.Cardinal.Finite
 import Mathlib.Tactic.FinCases
 import TauCeti.KnotTheory.Grid.Diagram
 
@@ -18,15 +18,11 @@ The statements here are deliberately about the generator set only. They are the 
 needed before explicit computations of small fully blocked grid complexes, whose chain module is
 the free `ZMod 2`-module on `GridState n`.
 
-## Main definitions
-
-* `TauCeti.GridState.equivPerm`: grid states are equivalent to permutations of `Fin n`.
-
 ## Main results
 
 * `TauCeti.GridState.card`: there are `n!` grid states on an `n × n` grid.
 * `TauCeti.GridState.card_univ`: the finite generator set has cardinality `n!`.
-* `TauCeti.GridState.uniqueOfCardLeOne`: for `n ≤ 1`, there is a unique grid state.
+* `TauCeti.GridState.uniqueOfLeOne`: for `n ≤ 1`, there is a unique grid state.
 * `TauCeti.GridState.card_zero`, `TauCeti.GridState.card_one`, `TauCeti.GridState.card_two`:
   small-grid cardinalities used as sanity checks for later computations.
 
@@ -44,15 +40,6 @@ namespace GridState
 
 variable {n : ℕ}
 
-/-- Grid states on an `n × n` grid are equivalent to permutations of the columns. -/
-def equivPerm (n : ℕ) : GridState n ≃ Equiv.Perm (Fin n) where
-  toFun x := x.toPerm
-  invFun σ := ⟨σ⟩
-  left_inv x := by
-    cases x
-    rfl
-  right_inv σ := rfl
-
 /-- The permutation associated to a grid state by `GridState.equivPerm`. -/
 @[simp]
 theorem equivPerm_apply (x : GridState n) : equivPerm n x = x.toPerm :=
@@ -69,7 +56,7 @@ theorem equivPerm_symm_apply_apply (σ : Equiv.Perm (Fin n)) (c : Fin n) :
     ((equivPerm n).symm σ : GridState n) c = σ c :=
   rfl
 
-/-- The permutation equivalence preserves the point-set graph. -/
+/-- The point set of the grid state obtained from a permutation `σ` is the graph `{(c, σ c)}`. -/
 @[simp]
 theorem equivPerm_symm_pointSet (σ : Equiv.Perm (Fin n)) :
     ((equivPerm n).symm σ : GridState n).pointSet =
@@ -92,30 +79,27 @@ theorem natCard (n : ℕ) : Nat.card (GridState n) = n.factorial := by
   rw [Nat.card_eq_fintype_card, card]
 
 /-- There is one grid state on the empty grid. -/
-@[simp]
 theorem card_zero : Fintype.card (GridState 0) = 1 := by
   simp
 
 /-- There is one grid state on a `1 × 1` grid. -/
-@[simp]
 theorem card_one : Fintype.card (GridState 1) = 1 := by
   simp
 
 /-- There are two grid states on a `2 × 2` grid. -/
-@[simp]
 theorem card_two : Fintype.card (GridState 2) = 2 := by
   simp
 
 /-- There is a unique grid state whenever the grid has at most one row and column. -/
 @[reducible]
-def uniqueOfCardLeOne (hn : n ≤ 1) : Unique (GridState n) := by
+def uniqueOfLeOne (hn : n ≤ 1) : Unique (GridState n) := by
   have hcard : Fintype.card (GridState n) ≤ 1 := by
     rw [card]
     rcases n with _ | n
     · simp
     · rcases n with _ | n
       · simp
-      · exact False.elim ((Nat.not_succ_le_zero n) (Nat.succ_le_succ_iff.mp hn))
+      · omega
   letI : Subsingleton (GridState n) := Fintype.card_le_one_iff_subsingleton.mp hcard
   exact
     { default := (equivPerm n).symm 1
@@ -123,55 +107,40 @@ def uniqueOfCardLeOne (hn : n ≤ 1) : Unique (GridState n) := by
 
 /-- There is a unique grid state on the empty grid. -/
 instance instUniqueZero : Unique (GridState 0) :=
-  uniqueOfCardLeOne (n := 0) (Nat.zero_le 1)
-
-/-- Grid states on the empty grid are subsingletons. -/
-instance instSubsingletonZero : Subsingleton (GridState 0) :=
-  inferInstance
+  uniqueOfLeOne (n := 0) (Nat.zero_le 1)
 
 /-- The unique empty-grid state is the state associated to the identity permutation. -/
-@[simp]
 theorem default_zero_eq : (default : GridState 0) = (equivPerm 0).symm 1 :=
   Subsingleton.elim _ _
 
 /-- There is a unique grid state on a `1 × 1` grid. -/
 instance instUniqueOne : Unique (GridState 1) :=
-  uniqueOfCardLeOne (n := 1) (Nat.le_refl 1)
-
-/-- Grid states on a `1 × 1` grid are subsingletons. -/
-instance instSubsingletonOne : Subsingleton (GridState 1) :=
-  inferInstance
+  uniqueOfLeOne (n := 1) (Nat.le_refl 1)
 
 /-- The unique `1 × 1` grid state sends the only column to the only row. -/
 @[simp]
-theorem one_apply (x : GridState 1) (c : Fin 1) : x c = 0 := by
+theorem apply_eq_zero (x : GridState 1) (c : Fin 1) : x c = 0 := by
   fin_cases c
   exact Subsingleton.elim _ _
 
 /-- The two grid states on a `2 × 2` grid are exactly the identity and the transposition. -/
-theorem exists_eq_id_or_swap (x : GridState 2) :
+theorem eq_one_or_swap (x : GridState 2) :
     x = (equivPerm 2).symm 1 ∨ x = (equivPerm 2).symm (Equiv.swap 0 1) := by
+  have hne : x 1 ≠ x 0 := fun h => Fin.zero_ne_one (x.toPerm.injective h.symm)
   rcases eq_or_ne (x 0) 0 with h0 | h0
   · left
     ext c
     fin_cases c
     · simpa using h0
-    · have hne : x 1 ≠ x 0 := by
-        intro h
-        exact Fin.zero_ne_one (x.toPerm.injective h.symm)
-      have h1 : x 1 = 1 := by
-        exact Fin.eq_one_of_ne_zero (x 1) fun hx1 => hne (hx1.trans h0.symm)
+    · have h1 : x 1 = 1 :=
+        Fin.eq_one_of_ne_zero (x 1) fun hx1 => hne (hx1.trans h0.symm)
       exact congrArg Fin.val h1
   · right
-    have hx0 : x 0 = 1 := by
-      exact Fin.eq_one_of_ne_zero (x 0) h0
+    have hx0 : x 0 = 1 := Fin.eq_one_of_ne_zero (x 0) h0
     ext c
     fin_cases c
     · exact congrArg Fin.val hx0
-    · have hne : x 1 ≠ x 0 := by
-        intro h
-        exact Fin.zero_ne_one (x.toPerm.injective h.symm)
-      have hx1 : x 1 = 0 := by
+    · have hx1 : x 1 = 0 := by
         by_contra hx1
         exact hne ((Fin.eq_one_of_ne_zero (x 1) hx1).trans hx0.symm)
       exact congrArg Fin.val hx1

--- a/TauCeti/KnotTheory/Grid/StateCardinality.lean
+++ b/TauCeti/KnotTheory/Grid/StateCardinality.lean
@@ -124,7 +124,7 @@ theorem apply_eq_zero (x : GridState 1) (c : Fin 1) : x c = 0 := by
   exact Subsingleton.elim _ _
 
 /-- The two grid states on a `2 × 2` grid are exactly the identity and the transposition. -/
-theorem eq_one_or_swap (x : GridState 2) :
+theorem eq_equivPerm_symm_one_or_eq_equivPerm_symm_swap (x : GridState 2) :
     x = (equivPerm 2).symm 1 ∨ x = (equivPerm 2).symm (Equiv.swap 0 1) := by
   have hne : x 1 ≠ x 0 := fun h => Fin.zero_ne_one (x.toPerm.injective h.symm)
   rcases eq_or_ne (x 0) 0 with h0 | h0

--- a/TauCeti/KnotTheory/Grid/StateCardinality.lean
+++ b/TauCeti/KnotTheory/Grid/StateCardinality.lean
@@ -1,0 +1,181 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+import Mathlib.Data.Finite.Perm
+import Mathlib.Data.Fintype.Perm
+import Mathlib.Tactic.FinCases
+import TauCeti.KnotTheory.Grid.Diagram
+
+/-!
+# Cardinality of grid states
+
+This file records the finite size of the generator set for an `n × n` grid complex. A grid state
+is encoded in `TauCeti.KnotTheory.Grid.Diagram` as a permutation graph on the columns, so the
+set of grid states is equivalent to `Equiv.Perm (Fin n)` and has cardinality `n!`.
+
+The statements here are deliberately about the generator set only. They are the counting API
+needed before explicit computations of small fully blocked grid complexes, whose chain module is
+the free `ZMod 2`-module on `GridState n`.
+
+## Main definitions
+
+* `TauCeti.GridState.equivPerm`: grid states are equivalent to permutations of `Fin n`.
+
+## Main results
+
+* `TauCeti.GridState.card`: there are `n!` grid states on an `n × n` grid.
+* `TauCeti.GridState.card_univ`: the finite generator set has cardinality `n!`.
+* `TauCeti.GridState.uniqueOfCardLeOne`: for `n ≤ 1`, there is a unique grid state.
+* `TauCeti.GridState.card_zero`, `TauCeti.GridState.card_one`, `TauCeti.GridState.card_two`:
+  small-grid cardinalities used as sanity checks for later computations.
+
+## References
+
+This advances `TauCetiRoadmap/CombinatorialHeegaardFloer/README.md`, Lane G.1, "Grid diagrams
+and grid states", and the standing convention that the grid complexes should compute on explicit
+small grids. The encoding follows Ozsváth--Stipsicz--Szabó, *Grid Homology for Knots and Links*,
+Chapter 3: a grid state is one occupied square in every row and every column.
+-/
+
+namespace TauCeti
+
+namespace GridState
+
+variable {n : ℕ}
+
+/-- Grid states on an `n × n` grid are equivalent to permutations of the columns. -/
+def equivPerm (n : ℕ) : GridState n ≃ Equiv.Perm (Fin n) where
+  toFun x := x.toPerm
+  invFun σ := ⟨σ⟩
+  left_inv x := by
+    cases x
+    rfl
+  right_inv σ := rfl
+
+/-- The permutation associated to a grid state by `GridState.equivPerm`. -/
+@[simp]
+theorem equivPerm_apply (x : GridState n) : equivPerm n x = x.toPerm :=
+  rfl
+
+/-- The grid state associated to a permutation by the inverse of `GridState.equivPerm`. -/
+@[simp]
+theorem equivPerm_symm_apply (σ : Equiv.Perm (Fin n)) : (equivPerm n).symm σ = ⟨σ⟩ :=
+  rfl
+
+/-- Converting a permutation to a grid state and evaluating it gives the permutation value. -/
+@[simp]
+theorem equivPerm_symm_apply_apply (σ : Equiv.Perm (Fin n)) (c : Fin n) :
+    ((equivPerm n).symm σ : GridState n) c = σ c :=
+  rfl
+
+/-- The permutation equivalence preserves the point-set graph. -/
+@[simp]
+theorem equivPerm_symm_pointSet (σ : Equiv.Perm (Fin n)) :
+    ((equivPerm n).symm σ : GridState n).pointSet =
+      Finset.univ.image fun c => (c, σ c) :=
+  rfl
+
+/-- The number of grid states on an `n × n` grid is `n!`. -/
+@[simp]
+theorem card (n : ℕ) : Fintype.card (GridState n) = n.factorial := by
+  rw [Fintype.card_congr (equivPerm n), Fintype.card_perm, Fintype.card_fin]
+
+/-- The universe finite set of grid states has cardinality `n!`. -/
+@[simp]
+theorem card_univ (n : ℕ) : (Finset.univ : Finset (GridState n)).card = n.factorial := by
+  rw [Finset.card_univ, card]
+
+/-- The natural cardinality of grid states is `n!`. -/
+@[simp]
+theorem natCard (n : ℕ) : Nat.card (GridState n) = n.factorial := by
+  rw [Nat.card_eq_fintype_card, card]
+
+/-- There is one grid state on the empty grid. -/
+@[simp]
+theorem card_zero : Fintype.card (GridState 0) = 1 := by
+  simp
+
+/-- There is one grid state on a `1 × 1` grid. -/
+@[simp]
+theorem card_one : Fintype.card (GridState 1) = 1 := by
+  simp
+
+/-- There are two grid states on a `2 × 2` grid. -/
+@[simp]
+theorem card_two : Fintype.card (GridState 2) = 2 := by
+  simp
+
+/-- There is a unique grid state whenever the grid has at most one row and column. -/
+@[reducible]
+def uniqueOfCardLeOne (hn : n ≤ 1) : Unique (GridState n) := by
+  have hcard : Fintype.card (GridState n) ≤ 1 := by
+    rw [card]
+    rcases n with _ | n
+    · simp
+    · rcases n with _ | n
+      · simp
+      · exact False.elim ((Nat.not_succ_le_zero n) (Nat.succ_le_succ_iff.mp hn))
+  letI : Subsingleton (GridState n) := Fintype.card_le_one_iff_subsingleton.mp hcard
+  exact
+    { default := (equivPerm n).symm 1
+      uniq := fun _ => Subsingleton.elim _ _ }
+
+/-- There is a unique grid state on the empty grid. -/
+instance instUniqueZero : Unique (GridState 0) :=
+  uniqueOfCardLeOne (n := 0) (Nat.zero_le 1)
+
+/-- Grid states on the empty grid are subsingletons. -/
+instance instSubsingletonZero : Subsingleton (GridState 0) :=
+  inferInstance
+
+/-- The unique empty-grid state is the state associated to the identity permutation. -/
+@[simp]
+theorem default_zero_eq : (default : GridState 0) = (equivPerm 0).symm 1 :=
+  Subsingleton.elim _ _
+
+/-- There is a unique grid state on a `1 × 1` grid. -/
+instance instUniqueOne : Unique (GridState 1) :=
+  uniqueOfCardLeOne (n := 1) (Nat.le_refl 1)
+
+/-- Grid states on a `1 × 1` grid are subsingletons. -/
+instance instSubsingletonOne : Subsingleton (GridState 1) :=
+  inferInstance
+
+/-- The unique `1 × 1` grid state sends the only column to the only row. -/
+@[simp]
+theorem one_apply (x : GridState 1) (c : Fin 1) : x c = 0 := by
+  fin_cases c
+  exact Subsingleton.elim _ _
+
+/-- The two grid states on a `2 × 2` grid are exactly the identity and the transposition. -/
+theorem exists_eq_id_or_swap (x : GridState 2) :
+    x = (equivPerm 2).symm 1 ∨ x = (equivPerm 2).symm (Equiv.swap 0 1) := by
+  rcases eq_or_ne (x 0) 0 with h0 | h0
+  · left
+    ext c
+    fin_cases c
+    · simpa using h0
+    · have hne : x 1 ≠ x 0 := by
+        intro h
+        exact Fin.zero_ne_one (x.toPerm.injective h.symm)
+      have h1 : x 1 = 1 := by
+        exact Fin.eq_one_of_ne_zero (x 1) fun hx1 => hne (hx1.trans h0.symm)
+      exact congrArg Fin.val h1
+  · right
+    have hx0 : x 0 = 1 := by
+      exact Fin.eq_one_of_ne_zero (x 0) h0
+    ext c
+    fin_cases c
+    · exact congrArg Fin.val hx0
+    · have hne : x 1 ≠ x 0 := by
+        intro h
+        exact Fin.zero_ne_one (x.toPerm.injective h.symm)
+      have hx1 : x 1 = 0 := by
+        by_contra hx1
+        exact hne ((Fin.eq_one_of_ne_zero (x 1) hx1).trans hx0.symm)
+      exact congrArg Fin.val hx1
+
+end GridState
+
+end TauCeti

--- a/TauCeti/KnotTheory/Grid/StateCardinality.lean
+++ b/TauCeti/KnotTheory/Grid/StateCardinality.lean
@@ -104,23 +104,28 @@ theorem apply_eq_zero (x : GridState 1) (c : Fin 1) : x c = 0 := by
 theorem eq_equivPerm_symm_one_or_eq_equivPerm_symm_swap (x : GridState 2) :
     x = (equivPerm 2).symm 1 ∨ x = (equivPerm 2).symm (Equiv.swap 0 1) := by
   have hne : x 1 ≠ x 0 := fun h => Fin.zero_ne_one (x.toPerm.injective h.symm)
-  rcases eq_or_ne (x 0) 0 with h0 | h0
-  · left
-    ext c
-    fin_cases c
-    · simpa using h0
-    · have h1 : x 1 = 1 :=
-        Fin.eq_one_of_ne_zero (x 1) fun hx1 => hne (hx1.trans h0.symm)
-      exact congrArg Fin.val h1
-  · right
-    have hx0 : x 0 = 1 := Fin.eq_one_of_ne_zero (x 0) h0
-    ext c
-    fin_cases c
-    · exact congrArg Fin.val hx0
-    · have hx1 : x 1 = 0 := by
+  have hx : x.toPerm = 1 ∨ x.toPerm = Equiv.swap 0 1 := by
+    rcases eq_or_ne (x 0) 0 with h0 | h0
+    · left
+      have h1 : x 1 = 1 := Fin.eq_one_of_ne_zero (x 1) fun hx1 => hne (hx1.trans h0.symm)
+      apply Equiv.ext
+      intro c
+      fin_cases c
+      · simpa using h0
+      · simpa using h1
+    · right
+      have hx0 : x 0 = 1 := Fin.eq_one_of_ne_zero (x 0) h0
+      have hx1 : x 1 = 0 := by
         by_contra hx1
         exact hne ((Fin.eq_one_of_ne_zero (x 1) hx1).trans hx0.symm)
-      exact congrArg Fin.val hx1
+      apply Equiv.ext
+      intro c
+      fin_cases c
+      · simpa [Equiv.swap_apply_left] using hx0
+      · simpa [Equiv.swap_apply_right] using hx1
+  rcases hx with h | h
+  · exact Or.inl (by rw [Equiv.eq_symm_apply, equivPerm_apply, h])
+  · exact Or.inr (by rw [Equiv.eq_symm_apply, equivPerm_apply, h])
 
 end GridState
 

--- a/TauCeti/KnotTheory/Grid/StateCardinality.lean
+++ b/TauCeti/KnotTheory/Grid/StateCardinality.lean
@@ -22,7 +22,7 @@ the free `ZMod 2`-module on `GridState n`.
 
 * `TauCeti.GridState.card`: there are `n!` grid states on an `n × n` grid.
 * `TauCeti.GridState.card_univ`: the finite generator set has cardinality `n!`.
-* `TauCeti.GridState.uniqueOfLeOne`: for `n ≤ 1`, there is a unique grid state.
+* `TauCeti.GridState.subsingletonOfLeOne`: for `n ≤ 1`, grid states are unique.
 * `TauCeti.GridState.card_zero`, `TauCeti.GridState.card_one`, `TauCeti.GridState.card_two`:
   small-grid cardinalities used as sanity checks for later computations.
 
@@ -39,29 +39,6 @@ namespace TauCeti
 namespace GridState
 
 variable {n : ℕ}
-
-/-- The permutation associated to a grid state by `GridState.equivPerm`. -/
-@[simp]
-theorem equivPerm_apply (x : GridState n) : equivPerm n x = x.toPerm :=
-  rfl
-
-/-- The grid state associated to a permutation by the inverse of `GridState.equivPerm`. -/
-@[simp]
-theorem equivPerm_symm_apply (σ : Equiv.Perm (Fin n)) : (equivPerm n).symm σ = ⟨σ⟩ :=
-  rfl
-
-/-- Converting a permutation to a grid state and evaluating it gives the permutation value. -/
-@[simp]
-theorem equivPerm_symm_apply_apply (σ : Equiv.Perm (Fin n)) (c : Fin n) :
-    ((equivPerm n).symm σ : GridState n) c = σ c :=
-  rfl
-
-/-- The point set of the grid state obtained from a permutation `σ` is the graph `{(c, σ c)}`. -/
-@[simp]
-theorem equivPerm_symm_pointSet (σ : Equiv.Perm (Fin n)) :
-    ((equivPerm n).symm σ : GridState n).pointSet =
-      Finset.univ.image fun c => (c, σ c) :=
-  rfl
 
 /-- The number of grid states on an `n × n` grid is `n!`. -/
 @[simp]
@@ -90,9 +67,8 @@ theorem card_one : Fintype.card (GridState 1) = 1 := by
 theorem card_two : Fintype.card (GridState 2) = 2 := by
   simp
 
-/-- There is a unique grid state whenever the grid has at most one row and column. -/
-@[reducible]
-def uniqueOfLeOne (hn : n ≤ 1) : Unique (GridState n) := by
+/-- Any two grid states are equal whenever the grid has at most one row and column. -/
+theorem subsingletonOfLeOne (hn : n ≤ 1) : Subsingleton (GridState n) := by
   have hcard : Fintype.card (GridState n) ≤ 1 := by
     rw [card]
     rcases n with _ | n
@@ -100,14 +76,13 @@ def uniqueOfLeOne (hn : n ≤ 1) : Unique (GridState n) := by
     · rcases n with _ | n
       · simp
       · omega
-  letI : Subsingleton (GridState n) := Fintype.card_le_one_iff_subsingleton.mp hcard
-  exact
-    { default := (equivPerm n).symm 1
-      uniq := fun _ => Subsingleton.elim _ _ }
+  exact Fintype.card_le_one_iff_subsingleton.mp hcard
 
 /-- There is a unique grid state on the empty grid. -/
 instance instUniqueZero : Unique (GridState 0) :=
-  uniqueOfLeOne (n := 0) (Nat.zero_le 1)
+  letI : Subsingleton (GridState 0) := subsingletonOfLeOne (Nat.zero_le 1)
+  { default := (equivPerm 0).symm 1
+    uniq := fun _ => Subsingleton.elim _ _ }
 
 /-- The unique empty-grid state is the state associated to the identity permutation. -/
 theorem default_zero_eq : (default : GridState 0) = (equivPerm 0).symm 1 :=
@@ -115,7 +90,9 @@ theorem default_zero_eq : (default : GridState 0) = (equivPerm 0).symm 1 :=
 
 /-- There is a unique grid state on a `1 × 1` grid. -/
 instance instUniqueOne : Unique (GridState 1) :=
-  uniqueOfLeOne (n := 1) (Nat.le_refl 1)
+  letI : Subsingleton (GridState 1) := subsingletonOfLeOne (Nat.le_refl 1)
+  { default := (equivPerm 1).symm 1
+    uniq := fun _ => Subsingleton.elim _ _ }
 
 /-- The unique `1 × 1` grid state sends the only column to the only row. -/
 @[simp]


### PR DESCRIPTION
This PR exposes the finite generator count for the grid-combinatorial lane by adding `GridState.equivPerm`, the equivalence between grid states on an `n × n` grid and `Equiv.Perm (Fin n)`, and deriving `GridState.card : Fintype.card (GridState n) = n.factorial`. It also records the corresponding `Finset.univ` and `Nat.card` forms, the unique-state cases for grid sizes `0` and `1`, and the explicit two-state classification for grid size `2`, giving later computable grid-complex examples a small concrete cardinality API.

This advances `TauCetiRoadmap/CombinatorialHeegaardFloer/README.md`, Lane G.1, “Grid diagrams and grid states. Toroidal `n × n` grids with `O`/`X`-markings (one per row and column); grid states as bijections columns → rows”, together with the standing convention that grid definitions should compute on explicit small grids. I chose it as the lowest-hanging distinct CombinatorialHeegaardFloer prerequisite because the current grid stack already has grid states, rectangles, gradings, rectangle counts, the fully blocked differential, and open PRs covering grading changes and commutation-arc rotation, while no open or merged PR exposes the factorial size of the grid-state generator set.

No Mathlib infrastructure is vendored. The proof reuses Mathlib’s `Fintype.card_perm`, `Nat.card_perm`-level finite permutation API via `Fintype.card`, and the existing Tau Ceti `GridState` permutation encoding from `TauCeti.KnotTheory.Grid.Diagram`.

Local verification: `lake exe cache get` completed successfully with `No files to download` and `Decompressed 8229 already-cached file(s)`; `lake build` completed with `Build completed successfully (4079 jobs).`; `lake exe axioms` reported `axioms: audited 4176 TauCeti declaration(s); all within the allowlist [propext, Classical.choice, Quot.sound].`

<!--tauceti-target:v1 {"focus":"CombinatorialHeegaardFloer","id":"grid-state-cardinality"}-->

🤖 Prepared with Codex
