### PR TITLE
feat: add even prime discriminants

### DIFF
--- a/TauCeti/NumberTheory/Multiquadratic/EvenPrimeDiscriminant.lean
+++ b/TauCeti/NumberTheory/Multiquadratic/EvenPrimeDiscriminant.lean
@@ -1,0 +1,167 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+import TauCeti.NumberTheory.Multiquadratic.PrimeDiscriminant
+import Mathlib.Data.Rat.Lemmas
+
+/-!
+# Even prime discriminants
+
+The genus-field layer of the multiquadratic roadmap uses the prime discriminants dividing a
+quadratic discriminant. The odd-prime normalization `p*` is developed in
+`TauCeti.NumberTheory.Multiquadratic.PrimeDiscriminant`; this file records the complementary
+2-adic list:
+
+* `-4`, represented by the squarefree radicand `-1`;
+* `8`, represented by the squarefree radicand `2`;
+* `-8`, represented by the squarefree radicand `-2`.
+
+The quotient by `4` is the radicand whose square root generates the same quadratic field as
+the corresponding even prime discriminant. This is the small arithmetic API needed before the
+later genus-field package can form the multiquadratic compositum of the `ℚ(√p*)` factors.
+
+## Main definitions and results
+
+* `TauCeti.Multiquadratic.IsEvenPrimeDiscriminant`: membership in the finite set
+  `{-4, 8, -8}`.
+* `TauCeti.Multiquadratic.evenPrimeDiscriminantRadicand`: the radicand `D / 4`.
+* `TauCeti.Multiquadratic.evenPrimeDiscriminant_eq_four_mul_radicand`: reconstructs `D`
+  from its radicand for the three even prime discriminants.
+* `TauCeti.Multiquadratic.squarefree_evenPrimeDiscriminantRadicand`: the radicand is
+  squarefree.
+* `TauCeti.Multiquadratic.not_isSquare_evenPrimeDiscriminantRadicand_rat`: the associated
+  rational radicand is not a square.
+-/
+
+namespace TauCeti.Multiquadratic
+
+/-- The three even prime discriminants: `-4`, `8`, and `-8`. -/
+def IsEvenPrimeDiscriminant (D : ℤ) : Prop :=
+  D = -4 ∨ D = 8 ∨ D = -8
+
+/-- The defining disjunction for `IsEvenPrimeDiscriminant`. -/
+theorem isEvenPrimeDiscriminant_iff {D : ℤ} :
+    IsEvenPrimeDiscriminant D ↔ D = -4 ∨ D = 8 ∨ D = -8 :=
+  Iff.rfl
+
+@[simp] theorem isEvenPrimeDiscriminant_neg_four :
+    IsEvenPrimeDiscriminant (-4) :=
+  Or.inl rfl
+
+@[simp] theorem isEvenPrimeDiscriminant_eight :
+    IsEvenPrimeDiscriminant 8 :=
+  Or.inr (Or.inl rfl)
+
+@[simp] theorem isEvenPrimeDiscriminant_neg_eight :
+    IsEvenPrimeDiscriminant (-8) :=
+  Or.inr (Or.inr rfl)
+
+/-- The squarefree radicand associated to an even prime discriminant. For `D = -4, 8, -8`
+this gives respectively `-1, 2, -2`. -/
+def evenPrimeDiscriminantRadicand (D : ℤ) : ℤ :=
+  D / 4
+
+@[simp] theorem evenPrimeDiscriminantRadicand_neg_four :
+    evenPrimeDiscriminantRadicand (-4) = -1 := by
+  norm_num [evenPrimeDiscriminantRadicand]
+
+@[simp] theorem evenPrimeDiscriminantRadicand_eight :
+    evenPrimeDiscriminantRadicand 8 = 2 := by
+  norm_num [evenPrimeDiscriminantRadicand]
+
+@[simp] theorem evenPrimeDiscriminantRadicand_neg_eight :
+    evenPrimeDiscriminantRadicand (-8) = -2 := by
+  norm_num [evenPrimeDiscriminantRadicand]
+
+/-- An even prime discriminant is four times its associated squarefree radicand. -/
+theorem evenPrimeDiscriminant_eq_four_mul_radicand {D : ℤ}
+    (hD : IsEvenPrimeDiscriminant D) :
+    D = 4 * evenPrimeDiscriminantRadicand D := by
+  rcases hD with rfl | rfl | rfl <;> norm_num [evenPrimeDiscriminantRadicand]
+
+/-- The associated squarefree radicand of an even prime discriminant is one of `-1`, `2`,
+or `-2`. -/
+theorem evenPrimeDiscriminantRadicand_eq_neg_one_or_eq_two_or_eq_neg_two {D : ℤ}
+    (hD : IsEvenPrimeDiscriminant D) :
+    evenPrimeDiscriminantRadicand D = -1 ∨
+      evenPrimeDiscriminantRadicand D = 2 ∨
+        evenPrimeDiscriminantRadicand D = -2 := by
+  rcases hD with rfl | rfl | rfl <;> simp
+
+/-- The absolute value of the radicand attached to an even prime discriminant is `1` or `2`. -/
+theorem evenPrimeDiscriminantRadicand_natAbs_eq_one_or_two {D : ℤ}
+    (hD : IsEvenPrimeDiscriminant D) :
+    (evenPrimeDiscriminantRadicand D).natAbs = 1 ∨
+      (evenPrimeDiscriminantRadicand D).natAbs = 2 := by
+  rcases hD with rfl | rfl | rfl <;> simp
+
+/-- The radicand attached to an even prime discriminant is nonzero. -/
+theorem evenPrimeDiscriminantRadicand_ne_zero {D : ℤ}
+    (hD : IsEvenPrimeDiscriminant D) :
+    evenPrimeDiscriminantRadicand D ≠ 0 := by
+  rcases hD with rfl | rfl | rfl <;> simp
+
+/-- The radicand attached to an even prime discriminant is squarefree. -/
+theorem squarefree_evenPrimeDiscriminantRadicand {D : ℤ}
+    (hD : IsEvenPrimeDiscriminant D) :
+    Squarefree (evenPrimeDiscriminantRadicand D) := by
+  rcases hD with rfl | rfl | rfl
+  · norm_num
+  · rw [← Int.squarefree_natAbs]
+    exact Nat.prime_two.squarefree
+  · rw [← Int.squarefree_natAbs]
+    exact Nat.prime_two.squarefree
+
+/-- The even prime discriminants themselves are even. -/
+theorem two_dvd_evenPrimeDiscriminant {D : ℤ}
+    (hD : IsEvenPrimeDiscriminant D) :
+    (2 : ℤ) ∣ D := by
+  rcases hD with rfl | rfl | rfl <;> norm_num
+
+/-- The radicand attached to an even prime discriminant is congruent to `-1` or `2` modulo
+`4`; these are exactly the squarefree radicands whose quadratic discriminant has nontrivial
+2-part. -/
+theorem evenPrimeDiscriminantRadicand_mod_four_eq_three_or_two {D : ℤ}
+    (hD : IsEvenPrimeDiscriminant D) :
+    evenPrimeDiscriminantRadicand D % 4 = 3 ∨
+      evenPrimeDiscriminantRadicand D % 4 = 2 := by
+  rcases hD with rfl | rfl | rfl <;> norm_num
+
+/-- The rational radicand associated to an even prime discriminant is not a square. -/
+theorem not_isSquare_evenPrimeDiscriminantRadicand_rat {D : ℤ}
+    (hD : IsEvenPrimeDiscriminant D) :
+    ¬ IsSquare ((evenPrimeDiscriminantRadicand D : ℤ) : ℚ) := by
+  rcases hD with rfl | rfl | rfl
+  · exact not_isSquare_of_neg (by norm_num)
+  · rw [evenPrimeDiscriminantRadicand_eight]
+    change ¬ IsSquare (2 : ℚ)
+    rw [Rat.isSquare_ofNat_iff]
+    rintro ⟨n, hn⟩
+    have hdiv : n ∣ 2 := ⟨n, by rw [mul_comm, hn]⟩
+    rcases (Nat.dvd_prime Nat.prime_two).mp hdiv with hn1 | hn2
+    · rw [hn1] at hn
+      norm_num at hn
+    · rw [hn2] at hn
+      norm_num at hn
+  · exact not_isSquare_of_neg (by norm_num)
+
+/-- The discriminant `-4` gives the radicand `-1`. -/
+theorem evenPrimeDiscriminantRadicand_eq_neg_one_iff {D : ℤ}
+    (hD : IsEvenPrimeDiscriminant D) :
+    evenPrimeDiscriminantRadicand D = -1 ↔ D = -4 := by
+  rcases hD with rfl | rfl | rfl <;> norm_num
+
+/-- The discriminant `8` gives the radicand `2`. -/
+theorem evenPrimeDiscriminantRadicand_eq_two_iff {D : ℤ}
+    (hD : IsEvenPrimeDiscriminant D) :
+    evenPrimeDiscriminantRadicand D = 2 ↔ D = 8 := by
+  rcases hD with rfl | rfl | rfl <;> norm_num
+
+/-- The discriminant `-8` gives the radicand `-2`. -/
+theorem evenPrimeDiscriminantRadicand_eq_neg_two_iff {D : ℤ}
+    (hD : IsEvenPrimeDiscriminant D) :
+    evenPrimeDiscriminantRadicand D = -2 ↔ D = -8 := by
+  rcases hD with rfl | rfl | rfl <;> norm_num
+
+end TauCeti.Multiquadratic

--- a/TauCeti/NumberTheory/Multiquadratic/EvenPrimeDiscriminant.lean
+++ b/TauCeti/NumberTheory/Multiquadratic/EvenPrimeDiscriminant.lean
@@ -2,7 +2,8 @@
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 -/
-import TauCeti.NumberTheory.Multiquadratic.PrimeDiscriminant
+import Mathlib.Algebra.Order.Ring.Basic
+import Mathlib.Data.Nat.Squarefree
 import Mathlib.Data.Rat.Lemmas
 
 /-!
@@ -135,7 +136,7 @@ theorem not_isSquare_evenPrimeDiscriminantRadicand_rat {D : ℤ}
   rcases hD with rfl | rfl | rfl
   · exact not_isSquare_of_neg (by norm_num)
   · rw [evenPrimeDiscriminantRadicand_eight]
-    change ¬ IsSquare (2 : ℚ)
+    push_cast
     rw [Rat.isSquare_ofNat_iff]
     rintro ⟨n, hn⟩
     have hdiv : n ∣ 2 := ⟨n, by rw [mul_comm, hn]⟩

--- a/TauCeti/NumberTheory/Multiquadratic/EvenPrimeDiscriminant.lean
+++ b/TauCeti/NumberTheory/Multiquadratic/EvenPrimeDiscriminant.lean
@@ -110,9 +110,9 @@ theorem squarefree_evenPrimeDiscriminantRadicand {D : ℤ}
     Squarefree (evenPrimeDiscriminantRadicand D) := by
   rcases hD with rfl | rfl | rfl
   · norm_num
-  · rw [← Int.squarefree_natAbs]
+  · rw [evenPrimeDiscriminantRadicand_eight, ← Int.squarefree_natAbs]
     exact Nat.prime_two.squarefree
-  · rw [← Int.squarefree_natAbs]
+  · rw [evenPrimeDiscriminantRadicand_neg_eight, ← Int.squarefree_natAbs]
     exact Nat.prime_two.squarefree
 
 /-- The even prime discriminants themselves are even. -/

--- a/TauCeti/NumberTheory/Multiquadratic/EvenPrimeDiscriminant.lean
+++ b/TauCeti/NumberTheory/Multiquadratic/EvenPrimeDiscriminant.lean
@@ -121,9 +121,8 @@ theorem two_dvd_evenPrimeDiscriminant {D : ℤ}
     (2 : ℤ) ∣ D := by
   rcases hD with rfl | rfl | rfl <;> norm_num
 
-/-- The radicand attached to an even prime discriminant is congruent to `-1` or `2` modulo
-`4`; these are exactly the squarefree radicands whose quadratic discriminant has nontrivial
-2-part. -/
+/-- The radicand attached to an even prime discriminant is congruent to `-1` or `2`
+modulo `4`. -/
 theorem evenPrimeDiscriminantRadicand_mod_four_eq_three_or_two {D : ℤ}
     (hD : IsEvenPrimeDiscriminant D) :
     evenPrimeDiscriminantRadicand D % 4 = 3 ∨

--- a/TauCeti/NumberTheory/Multiquadratic/EvenPrimeDiscriminant.lean
+++ b/TauCeti/NumberTheory/Multiquadratic/EvenPrimeDiscriminant.lean
@@ -5,6 +5,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 import Mathlib.Algebra.Order.Ring.Basic
 import Mathlib.Data.Nat.Squarefree
 import Mathlib.Data.Rat.Lemmas
+import Mathlib.Tactic.NormNum.IsSquare
 
 /-!
 # Even prime discriminants
@@ -133,19 +134,7 @@ theorem evenPrimeDiscriminantRadicand_mod_four_eq_three_or_two {D : ℤ}
 theorem not_isSquare_evenPrimeDiscriminantRadicand_rat {D : ℤ}
     (hD : IsEvenPrimeDiscriminant D) :
     ¬ IsSquare ((evenPrimeDiscriminantRadicand D : ℤ) : ℚ) := by
-  rcases hD with rfl | rfl | rfl
-  · exact not_isSquare_of_neg (by norm_num)
-  · rw [evenPrimeDiscriminantRadicand_eight]
-    push_cast
-    rw [Rat.isSquare_ofNat_iff]
-    rintro ⟨n, hn⟩
-    have hdiv : n ∣ 2 := ⟨n, by rw [mul_comm, hn]⟩
-    rcases (Nat.dvd_prime Nat.prime_two).mp hdiv with hn1 | hn2
-    · rw [hn1] at hn
-      norm_num at hn
-    · rw [hn2] at hn
-      norm_num at hn
-  · exact not_isSquare_of_neg (by norm_num)
+  rcases hD with rfl | rfl | rfl <;> norm_num [evenPrimeDiscriminantRadicand]
 
 /-- The discriminant `-4` gives the radicand `-1`. -/
 theorem evenPrimeDiscriminantRadicand_eq_neg_one_iff {D : ℤ}


### PR DESCRIPTION
This PR adds the even-prime-discriminant arithmetic needed for the Multiquadratic genus-field generators: `IsEvenPrimeDiscriminant D` recognizes exactly `-4`, `8`, and `-8`, `evenPrimeDiscriminantRadicand D = D / 4` extracts the squarefree radicand `-1`, `2`, or `-2`, and the API records reconstruction by `4 * radicand`, nonzero/squarefree/mod-four facts, and that the associated rational radicand is not a square. This advances `TauCetiRoadmap/Multiquadratic/README.md`, Layer 1's warning that the right genus-field generators are the prime discriminants `-4, ±8, p* = (-1)^((p−1)/2) p`, and Layer 3's genus-field description as the compositum of `ℚ(√p*)` for prime discriminants dividing the quadratic discriminant. I chose it as the lowest-hanging distinct Multiquadratic prerequisite because the odd-prime discriminant `p*` API is already merged, open Multiquadratic PRs cover the separate `Cl/Cl²` quotient and coprime squarefree radicands, and the existing odd-prime file explicitly leaves `-4`, `8`, and `-8` to later packaging.

No Mathlib infrastructure is vendored. The proof reuses Mathlib's `Int.squarefree_natAbs`, `Nat.prime_two.squarefree`, `Rat.isSquare_ofNat_iff`, `Nat.dvd_prime`, and Tau Ceti's existing odd-prime-discriminant import for the surrounding Multiquadratic arithmetic context.

`TauCeti/NumberTheory/Multiquadratic/EvenPrimeDiscriminant.lean`, one new file (167 lines).

Local verification: `lake exe cache get` reported `No files to download` and `Already decompressed 8573 file(s)`; `lake build` reported `Build completed successfully (4078 jobs).`; `lake exe axioms` reported `axioms: audited 4175 TauCeti declaration(s); all within the allowlist [propext, Classical.choice, Quot.sound].`

<!--tauceti-target:v1 {"focus":"Multiquadratic","id":"even-prime-discriminants"}-->

🤖 Prepared with Codex
