### PR TITLE
feat: the intersection form of a plumbing graph

### DIFF
--- a/TauCeti/LowDimTopology/Plumbing/IntersectionForm.lean
+++ b/TauCeti/LowDimTopology/Plumbing/IntersectionForm.lean
@@ -1,0 +1,206 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+import Mathlib.Combinatorics.SimpleGraph.AdjMatrix
+import Mathlib.LinearAlgebra.Matrix.Notation
+import Mathlib.LinearAlgebra.Matrix.BilinearForm
+import Mathlib.LinearAlgebra.Matrix.PosDef
+import Mathlib.LinearAlgebra.Matrix.Symmetric
+
+/-!
+# Plumbing graphs and their intersection forms
+
+This file opens the lattice-homology lane of the combinatorial Heegaard Floer roadmap. A
+plumbing graph records the combinatorial data of a plumbing of disk bundles over spheres: a
+finite graph whose vertices are the spheres, whose edges record which spheres are plumbed, and
+an integer weight on each vertex giving its self-intersection (the framing / Euler number).
+
+The fundamental algebraic object attached to this data is the **intersection form**, the
+symmetric `ℤ`-bilinear form on `V → ℤ` whose matrix is the framing on the diagonal and the
+adjacency indicator off the diagonal. This is the lattice on which Némethi's lattice homology
+of a (negative-definite) plumbed three-manifold is built. Here we set up the matrix, its
+entry formulas and symmetry, the bilinear form and its self-pairing expansion as a quadratic
+form, and the negative-definiteness predicate, recording that a negative-definite plumbing has
+every framing negative.
+
+We model the underlying combinatorics with a finite `SimpleGraph`: one edge between two
+distinct spheres, no edge multiplicities or signs. This is the standard starting point (the
+plumbing trees of Seifert-fibred examples), with edge multiplicities a later refinement.
+
+## Main definitions
+
+* `TauCeti.PlumbingGraph`: a finite simple graph with an integer weight on each vertex.
+* `TauCeti.PlumbingGraph.intersectionMatrix`: the framing-diagonal adjacency matrix.
+* `TauCeti.PlumbingGraph.intersectionForm`: the associated symmetric `ℤ`-bilinear form.
+* `TauCeti.PlumbingGraph.IsNegativeDefinite`: negative-definiteness of the intersection form.
+
+## Main results
+
+* `TauCeti.PlumbingGraph.intersectionMatrix_diag` and
+  `TauCeti.PlumbingGraph.intersectionMatrix_apply_of_ne`: the diagonal entry is the framing and
+  an off-diagonal entry is the adjacency indicator.
+* `TauCeti.PlumbingGraph.intersectionMatrix_isSymm`,
+  `TauCeti.PlumbingGraph.intersectionForm_isSymm`: the intersection form is symmetric.
+* `TauCeti.PlumbingGraph.intersectionForm_self`: the self-pairing as a quadratic form, the
+  framing-weighted sum of squares plus the adjacency cross terms.
+* `TauCeti.PlumbingGraph.IsNegativeDefinite.weight_neg`: a negative-definite plumbing has every
+  framing negative.
+
+## References
+
+This supplies the first prerequisite for `TauCetiRoadmap/CombinatorialHeegaardFloer/README.md`,
+Lane L ("lattice homology"), whose opening data is "plumbing trees/graphs and their lattices …
+from lattice points and weight functions … finite combinatorics plus bilinear forms". The
+intersection form of a plumbing graph follows Némethi,
+[arXiv:0709.0841](https://arxiv.org/abs/0709.0841), after Ozsváth--Szabó,
+[arXiv:math/0203265](https://arxiv.org/abs/math/0203265).
+-/
+
+namespace TauCeti
+
+/-- A plumbing graph: a finite simple graph together with an integer weight on each vertex.
+
+The vertices are the plumbed spheres, the edges record which pairs of spheres are plumbed
+together, and `weight v` is the self-intersection number (the framing / Euler number) of the
+sphere `v`. The combinatorics is modelled by a `SimpleGraph`: at most one edge between two
+distinct vertices, and no self-loops. -/
+structure PlumbingGraph (V : Type*) where
+  /-- The underlying simple graph: an edge for each pair of plumbed spheres. -/
+  toSimpleGraph : SimpleGraph V
+  /-- Adjacency in the underlying graph is decidable, so the adjacency matrix is available. -/
+  decidableAdj : DecidableRel toSimpleGraph.Adj
+  /-- The framing (self-intersection / Euler number) of each sphere. -/
+  weight : V → ℤ
+
+attribute [instance] PlumbingGraph.decidableAdj
+
+namespace PlumbingGraph
+
+variable {V : Type*} [DecidableEq V] (P : PlumbingGraph V)
+
+/-- The intersection matrix of a plumbing graph: the framing on the diagonal and the adjacency
+indicator off the diagonal.
+
+This is the matrix of the intersection form of the plumbed four-manifold in the basis of
+spheres: a sphere meets itself in its framing and meets a plumbed neighbour once. -/
+def intersectionMatrix : Matrix V V ℤ :=
+  Matrix.diagonal P.weight + P.toSimpleGraph.adjMatrix ℤ
+
+/-- The entry of the intersection matrix: the framing when on the diagonal plus one for each
+adjacency. -/
+theorem intersectionMatrix_apply (i j : V) :
+    P.intersectionMatrix i j =
+      (if i = j then P.weight i else 0) + (if P.toSimpleGraph.Adj i j then 1 else 0) := by
+  simp only [intersectionMatrix, Matrix.add_apply, Matrix.diagonal_apply,
+    SimpleGraph.adjMatrix_apply]
+
+/-- The diagonal entry of the intersection matrix is the framing: a sphere has no self-loop, so
+the adjacency term vanishes. -/
+@[simp]
+theorem intersectionMatrix_diag (i : V) : P.intersectionMatrix i i = P.weight i := by
+  rw [intersectionMatrix_apply, if_pos rfl, if_neg (P.toSimpleGraph.irrefl), add_zero]
+
+/-- Off the diagonal the intersection matrix is the adjacency indicator. -/
+theorem intersectionMatrix_apply_of_ne {i j : V} (h : i ≠ j) :
+    P.intersectionMatrix i j = if P.toSimpleGraph.Adj i j then 1 else 0 := by
+  rw [intersectionMatrix_apply, if_neg h, zero_add]
+
+/-- Two plumbed spheres meet once: an adjacency contributes the entry one. -/
+theorem intersectionMatrix_of_adj {i j : V} (h : P.toSimpleGraph.Adj i j) :
+    P.intersectionMatrix i j = 1 := by
+  rw [P.intersectionMatrix_apply_of_ne h.ne, if_pos h]
+
+/-- Distinct non-adjacent spheres are disjoint: the entry is zero. -/
+theorem intersectionMatrix_of_not_adj {i j : V} (hij : i ≠ j) (h : ¬ P.toSimpleGraph.Adj i j) :
+    P.intersectionMatrix i j = 0 := by
+  rw [P.intersectionMatrix_apply_of_ne hij, if_neg h]
+
+/-- The intersection matrix is symmetric: the diagonal framing matrix and the adjacency matrix
+are each symmetric. -/
+theorem intersectionMatrix_isSymm : P.intersectionMatrix.IsSymm :=
+  (Matrix.isSymm_diagonal P.weight).add
+    (SimpleGraph.isSymm_adjMatrix (α := ℤ) P.toSimpleGraph)
+
+/-- A plumbing graph is **negative definite** when its intersection form is negative definite,
+equivalently when the negated intersection matrix is positive definite. For plumbed
+three-manifolds this is the standing hypothesis under which lattice homology computes the
+Heegaard Floer invariant. -/
+def IsNegativeDefinite : Prop :=
+  (-P.intersectionMatrix).PosDef
+
+/-- A negative-definite plumbing graph has every framing negative: a diagonal entry of the
+positive-definite negated intersection matrix is the negated framing. -/
+theorem IsNegativeDefinite.weight_neg (h : P.IsNegativeDefinite) (i : V) : P.weight i < 0 := by
+  have key : 0 < (-P.intersectionMatrix) i i := h.diag_pos
+  rw [Matrix.neg_apply, intersectionMatrix_diag] at key
+  linarith
+
+section Form
+
+variable [Fintype V]
+
+/-- The intersection form of a plumbing graph: the symmetric `ℤ`-bilinear form on `V → ℤ` with
+matrix `intersectionMatrix`. -/
+noncomputable def intersectionForm : LinearMap.BilinForm ℤ (V → ℤ) :=
+  Matrix.toBilin' P.intersectionMatrix
+
+/-- The intersection form expanded as a double sum over the intersection matrix entries. -/
+theorem intersectionForm_apply (x y : V → ℤ) :
+    P.intersectionForm x y = ∑ i, ∑ j, x i * P.intersectionMatrix i j * y j :=
+  Matrix.toBilin'_apply _ x y
+
+/-- The intersection form pairs the basis sphere classes by the intersection matrix entries. -/
+@[simp]
+theorem intersectionForm_single (i j : V) :
+    P.intersectionForm (Pi.single i 1) (Pi.single j 1) = P.intersectionMatrix i j :=
+  Matrix.toBilin'_single _ i j
+
+/-- The intersection form is symmetric. -/
+theorem intersectionForm_isSymm : P.intersectionForm.IsSymm :=
+  Matrix.isSymm_toBilin'_iff_isSymm.mpr P.intersectionMatrix_isSymm
+
+/-- The intersection form as a quadratic form: its value on a single class is the
+framing-weighted sum of squares together with the adjacency cross terms. -/
+theorem intersectionForm_self (x : V → ℤ) :
+    P.intersectionForm x x =
+      (∑ i, P.weight i * x i ^ 2) +
+        ∑ i, ∑ j, if P.toSimpleGraph.Adj i j then x i * x j else 0 := by
+  rw [intersectionForm_apply]
+  have hsplit : ∀ i j : V, x i * P.intersectionMatrix i j * x j =
+      x i * Matrix.diagonal P.weight i j * x j +
+        x i * (P.toSimpleGraph.adjMatrix ℤ) i j * x j := by
+    intro i j
+    rw [intersectionMatrix, Matrix.add_apply]; ring
+  simp_rw [hsplit, Finset.sum_add_distrib]
+  congr 1
+  · refine Finset.sum_congr rfl fun i _ => ?_
+    rw [Finset.sum_eq_single i]
+    · rw [Matrix.diagonal_apply_eq]; ring
+    · intro j _ hj
+      rw [Matrix.diagonal_apply_ne _ (Ne.symm hj)]; ring
+    · intro hi; exact absurd (Finset.mem_univ i) hi
+  · refine Finset.sum_congr rfl fun i _ => Finset.sum_congr rfl fun j _ => ?_
+    rw [SimpleGraph.adjMatrix_apply]
+    split_ifs <;> ring
+
+end Form
+
+end PlumbingGraph
+
+/-- The two-vertex plumbing with a single edge and both framings `-2`: the `A₂` plumbing, whose
+intersection form is the negative of the `A₂` Cartan matrix. A self-validating example for the
+entry formulas. -/
+def a2Plumbing : PlumbingGraph (Fin 2) where
+  toSimpleGraph := ⊤
+  decidableAdj := inferInstance
+  weight := fun _ => -2
+
+@[simp]
+theorem a2Plumbing_intersectionMatrix :
+    a2Plumbing.intersectionMatrix = !![(-2 : ℤ), 1; 1, -2] := by
+  ext i j
+  fin_cases i <;> fin_cases j <;>
+    simp [a2Plumbing, PlumbingGraph.intersectionMatrix_apply, SimpleGraph.top_adj]
+
+end TauCeti

--- a/TauCeti/LowDimTopology/Plumbing/IntersectionForm.lean
+++ b/TauCeti/LowDimTopology/Plumbing/IntersectionForm.lean
@@ -13,7 +13,7 @@ import Mathlib.LinearAlgebra.Matrix.Symmetric
 
 This file opens the lattice-homology lane of the combinatorial Heegaard Floer roadmap. A
 plumbing graph records the combinatorial data of a plumbing of disk bundles over spheres: a
-finite graph whose vertices are the spheres, whose edges record which spheres are plumbed, and
+simple graph whose vertices are the spheres, whose edges record which spheres are plumbed, and
 an integer weight on each vertex giving its self-intersection (the framing / Euler number).
 
 The fundamental algebraic object attached to this data is the **intersection form**, the
@@ -24,16 +24,18 @@ entry formulas and symmetry, the bilinear form and its self-pairing expansion as
 form, and the negative-definiteness predicate, recording that a negative-definite plumbing has
 every framing negative.
 
-We model the underlying combinatorics with a finite `SimpleGraph`: one edge between two
-distinct spheres, no edge multiplicities or signs. This is the standard starting point (the
-plumbing trees of Seifert-fibred examples), with edge multiplicities a later refinement.
+We model the underlying combinatorics with a `SimpleGraph`: one edge between two distinct
+spheres, no edge multiplicities or signs. The matrix-level definitions make sense for any
+vertex type; the lattice form used for Lane L is introduced under `[Fintype V]`, matching the
+finite plumbing graphs in the roadmap. This is the standard starting point (the plumbing trees
+of Seifert-fibred examples), with edge multiplicities a later refinement.
 
 ## Main definitions
 
-* `TauCeti.PlumbingGraph`: a finite simple graph with an integer weight on each vertex.
+* `TauCeti.PlumbingGraph`: a simple graph with an integer weight on each vertex.
 * `TauCeti.PlumbingGraph.intersectionMatrix`: the framing-diagonal adjacency matrix.
 * `TauCeti.PlumbingGraph.intersectionForm`: the associated symmetric `ℤ`-bilinear form.
-* `TauCeti.PlumbingGraph.IsNegativeDefinite`: negative-definiteness of the intersection form.
+* `TauCeti.PlumbingGraph.IsNegativeDefinite`: negative-definiteness of the intersection matrix.
 
 ## Main results
 
@@ -42,6 +44,8 @@ plumbing trees of Seifert-fibred examples), with edge multiplicities a later ref
   an off-diagonal entry is the adjacency indicator.
 * `TauCeti.PlumbingGraph.intersectionMatrix_isSymm`,
   `TauCeti.PlumbingGraph.intersectionForm_isSymm`: the intersection form is symmetric.
+* `TauCeti.PlumbingGraph.intersectionForm_apply_weight_add_adj`: the bilinear form expanded
+  as framing terms plus adjacency terms.
 * `TauCeti.PlumbingGraph.intersectionForm_self`: the self-pairing as a quadratic form, the
   framing-weighted sum of squares plus the adjacency cross terms.
 * `TauCeti.PlumbingGraph.IsNegativeDefinite.weight_neg`: a negative-definite plumbing has every
@@ -59,12 +63,13 @@ intersection form of a plumbing graph follows Némethi,
 
 namespace TauCeti
 
-/-- A plumbing graph: a finite simple graph together with an integer weight on each vertex.
+/-- A plumbing graph: a simple graph together with an integer weight on each vertex.
 
 The vertices are the plumbed spheres, the edges record which pairs of spheres are plumbed
 together, and `weight v` is the self-intersection number (the framing / Euler number) of the
 sphere `v`. The combinatorics is modelled by a `SimpleGraph`: at most one edge between two
-distinct vertices, and no self-loops. -/
+distinct vertices, and no self-loops. The finite lattice API is provided by declarations that
+assume `[Fintype V]`. -/
 structure PlumbingGraph (V : Type*) where
   /-- The underlying simple graph: an edge for each pair of plumbed spheres. -/
   toSimpleGraph : SimpleGraph V
@@ -122,10 +127,10 @@ theorem intersectionMatrix_isSymm : P.intersectionMatrix.IsSymm :=
   (Matrix.isSymm_diagonal P.weight).add
     (SimpleGraph.isSymm_adjMatrix (α := ℤ) P.toSimpleGraph)
 
-/-- A plumbing graph is **negative definite** when its intersection form is negative definite,
-equivalently when the negated intersection matrix is positive definite. For plumbed
-three-manifolds this is the standing hypothesis under which lattice homology computes the
-Heegaard Floer invariant. -/
+/-- A plumbing graph is **negative definite** when its intersection matrix is negative
+definite, equivalently when the negated intersection matrix is positive definite. For finite
+plumbed three-manifolds this is the standing hypothesis under which lattice homology computes
+the Heegaard Floer invariant. -/
 def IsNegativeDefinite : Prop :=
   (-P.intersectionMatrix).PosDef
 
@@ -160,16 +165,15 @@ theorem intersectionForm_single (i j : V) :
 theorem intersectionForm_isSymm : P.intersectionForm.IsSymm :=
   Matrix.isSymm_toBilin'_iff_isSymm.mpr P.intersectionMatrix_isSymm
 
-/-- The intersection form as a quadratic form: its value on a single class is the
-framing-weighted sum of squares together with the adjacency cross terms. -/
-theorem intersectionForm_self (x : V → ℤ) :
-    P.intersectionForm x x =
-      (∑ i, P.weight i * x i ^ 2) +
-        ∑ i, ∑ j, if P.toSimpleGraph.Adj i j then x i * x j else 0 := by
+/-- The intersection form expanded into its framing contribution and adjacency contribution. -/
+theorem intersectionForm_apply_weight_add_adj (x y : V → ℤ) :
+    P.intersectionForm x y =
+      (∑ i, P.weight i * x i * y i) +
+        ∑ i, ∑ j, if P.toSimpleGraph.Adj i j then x i * y j else 0 := by
   rw [intersectionForm_apply]
-  have hsplit : ∀ i j : V, x i * P.intersectionMatrix i j * x j =
-      x i * Matrix.diagonal P.weight i j * x j +
-        x i * (P.toSimpleGraph.adjMatrix ℤ) i j * x j := by
+  have hsplit : ∀ i j : V, x i * P.intersectionMatrix i j * y j =
+      x i * Matrix.diagonal P.weight i j * y j +
+        x i * (P.toSimpleGraph.adjMatrix ℤ) i j * y j := by
     intro i j
     rw [intersectionMatrix, Matrix.add_apply]; ring
   simp_rw [hsplit, Finset.sum_add_distrib]
@@ -184,6 +188,16 @@ theorem intersectionForm_self (x : V → ℤ) :
     rw [SimpleGraph.adjMatrix_apply]
     split_ifs <;> ring
 
+/-- The intersection form as a quadratic form: its value on a single class is the
+framing-weighted sum of squares together with the adjacency cross terms. -/
+theorem intersectionForm_self (x : V → ℤ) :
+    P.intersectionForm x x =
+      (∑ i, P.weight i * x i ^ 2) +
+        ∑ i, ∑ j, if P.toSimpleGraph.Adj i j then x i * x j else 0 := by
+  rw [intersectionForm_apply_weight_add_adj]
+  congr 1
+  refine Finset.sum_congr rfl fun i _ => by ring
+
 end Form
 
 end PlumbingGraph
@@ -196,6 +210,7 @@ def a2Plumbing : PlumbingGraph (Fin 2) where
   decidableAdj := inferInstance
   weight := fun _ => -2
 
+/-- The intersection matrix of the `A₂` plumbing is the standard `[-2, 1; 1, -2]` matrix. -/
 @[simp]
 theorem a2Plumbing_intersectionMatrix :
     a2Plumbing.intersectionMatrix = !![(-2 : ℤ), 1; 1, -2] := by


### PR DESCRIPTION
This PR opens the lattice-homology lane (Lane L) of the combinatorial Heegaard Floer roadmap by introducing plumbing graphs and their intersection forms. A `PlumbingGraph` bundles a finite `SimpleGraph` of plumbed spheres with an integer framing (Euler number) on each vertex; its `intersectionMatrix` carries the framing on the diagonal and the adjacency indicator off it, realised as `Matrix.diagonal weight + adjMatrix`. On top of this we record the entry formulas, the symmetry of the matrix and of the associated `ℤ`-bilinear `intersectionForm`, the self-pairing of the form expanded as a quadratic form (framing-weighted sum of squares plus adjacency cross terms), and the `IsNegativeDefinite` predicate together with the fact that a negative-definite plumbing has every framing negative. A two-vertex example computes the `A₂` plumbing intersection matrix, the negative of the `A₂` Cartan matrix, as a self-validating check.

This advances `TauCetiRoadmap/CombinatorialHeegaardFloer/README.md`, Lane L ("lattice homology"), whose opening data is "plumbing trees/graphs and their lattices ... from lattice points and weight functions ... finite combinatorics plus bilinear forms", and which the roadmap names "the cheapest lane to start in parallel". The mathematics follows Némethi (arXiv:0709.0841), after Ozsváth--Szabó (arXiv:math/0203265).

It reuses Mathlib infrastructure throughout: `SimpleGraph.adjMatrix` and `isSymm_adjMatrix`, `Matrix.diagonal`/`isSymm_diagonal`, `Matrix.toBilin'` with `isSymm_toBilin'_iff_isSymm`, and `Matrix.PosDef` with `PosDef.diag_pos`.

<!--tauceti-target:v1 {"focus":"CombinatorialHeegaardFloer","id":"intersection-form-plumbing-graph"}-->

🤖 Prepared with Claude Code
