### PR TITLE
feat: the Hermitian inner product of a compatible pair

### DIFF
--- a/TauCeti/Geometry/Symplectic/AlmostComplex.lean
+++ b/TauCeti/Geometry/Symplectic/AlmostComplex.lean
@@ -362,13 +362,20 @@ lemma Compatible.invariant_apply {ω : SymplecticForm V} {J : AlmostComplexStruc
     (h : ω.Compatible J) (v w : V) : ω (J v) (J w) = ω v w :=
   (ω.invariant_iff J).mp h.invariant v w
 
+/-- For a `J`-invariant form, the associated bilinear form is symmetric pointwise. Only invariance
+is needed. -/
+lemma Invariant.associatedBilinForm_apply_swap
+    {ω : SymplecticForm V} {J : AlmostComplexStructure V}
+    (hinv : ω.Invariant J) (v w : V) : ω v (J w) = ω w (J v) := by
+  calc
+    ω v (J w) = -ω (J w) v := by rw [ω.neg_eq]
+    _ = ω w (J v) := by simpa using (ω.invariant_iff J).mp hinv w (J v)
+
 /-- For a compatible pair, the associated bilinear form is symmetric pointwise. -/
 lemma Compatible.associatedBilinForm_apply_swap
     {ω : SymplecticForm V} {J : AlmostComplexStructure V}
-    (h : ω.Compatible J) (v w : V) : ω v (J w) = ω w (J v) := by
-  calc
-    ω v (J w) = -ω (J w) v := by rw [ω.neg_eq]
-    _ = ω w (J v) := by simpa using h.invariant_apply w (J v)
+    (h : ω.Compatible J) (v w : V) : ω v (J w) = ω w (J v) :=
+  h.invariant.associatedBilinForm_apply_swap v w
 
 /-- For a compatible pair, the associated bilinear form `ω(·, J ·)` is symmetric. -/
 lemma Compatible.associatedBilinForm_isSymm

--- a/TauCeti/Geometry/Symplectic/AlmostComplex.lean
+++ b/TauCeti/Geometry/Symplectic/AlmostComplex.lean
@@ -377,11 +377,18 @@ lemma Compatible.associatedBilinForm_apply_swap
     (h : ω.Compatible J) (v w : V) : ω v (J w) = ω w (J v) :=
   h.invariant.associatedBilinForm_apply_swap v w
 
+/-- For a `J`-invariant form, the associated bilinear form `ω(·, J ·)` is symmetric. Only
+invariance is needed. -/
+lemma Invariant.associatedBilinForm_isSymm
+    {ω : SymplecticForm V} {J : AlmostComplexStructure V}
+    (hinv : ω.Invariant J) : (ω.associatedBilinForm J).IsSymm :=
+  ⟨fun v w => hinv.associatedBilinForm_apply_swap v w⟩
+
 /-- For a compatible pair, the associated bilinear form `ω(·, J ·)` is symmetric. -/
 lemma Compatible.associatedBilinForm_isSymm
     {ω : SymplecticForm V} {J : AlmostComplexStructure V}
     (h : ω.Compatible J) : (ω.associatedBilinForm J).IsSymm :=
-  ⟨fun v w => h.associatedBilinForm_apply_swap v w⟩
+  h.invariant.associatedBilinForm_isSymm
 
 lemma Compatible.associated_pos {ω : SymplecticForm V} {J : AlmostComplexStructure V}
     (h : ω.Compatible J) {v : V} (hv : v ≠ 0) : 0 < ω v (J v) :=

--- a/TauCeti/Geometry/Symplectic/Hermitian.lean
+++ b/TauCeti/Geometry/Symplectic/Hermitian.lean
@@ -24,22 +24,25 @@ argument over the `J`-induced complex structure, and it is positive definite.
 
 This is the complex companion of `TauCeti.SymplecticForm.Compatible.innerProductCore`, which
 records the real metric `g` of the same pair as an `InnerProductSpace.Core ℝ V`. Here the form is
-built once, as `SymplecticForm.hermitianForm`, with the compatibility hypotheses entering only in
-the Hermitian-structure facts, and the capstone `Compatible.hermitianCore` exhibits it as an
-`InnerProductSpace.Core ℂ V` for the complex structure `J.complexModule`.
+built once, as `SymplecticForm.hermitianForm`, and the Hermitian-structure facts are proved under
+the weakest hypothesis each one needs: conjugate symmetry and conjugate-linearity in the first
+argument need only `ω.Invariant J`, while positive definiteness needs only `ω.Tames J`.
+Compatibility (`Invariant` plus `Tames`) is what assembles all of them into the capstone
+`Compatible.hermitianCore`, exhibiting `h` as an `InnerProductSpace.Core ℂ V` for the complex
+structure `J.complexModule`.
 
 ## Main declarations
 
 * `TauCeti.SymplecticForm.hermitianForm`: the complex form `h(v, w) = ω(v, J w) + i ω(v, w)`.
 * `TauCeti.SymplecticForm.hermitianForm_re` / `hermitianForm_im`: the real and imaginary parts of
   `h` are the metric `g(v, w) = ω(v, J w)` and the symplectic form `ω(v, w)`.
-* `TauCeti.SymplecticForm.Compatible.hermitianForm_conj_symm`: `h` is conjugate-symmetric,
-  `conj (h(w, v)) = h(v, w)`.
+* `TauCeti.SymplecticForm.Invariant.hermitianForm_conj_symm`: `h` is conjugate-symmetric,
+  `conj (h(w, v)) = h(v, w)`, needing only `J`-invariance.
 * `TauCeti.SymplecticForm.hermitianForm_smul_right`: `h` is complex linear in its second argument,
   `h(v, z • w) = z · h(v, w)`, for the complex structure `J.complexModule` (no compatibility
   needed).
-* `TauCeti.SymplecticForm.Compatible.hermitianForm_self`: `h(v, v) = ω(v, J v)` is real and
-  positive on nonzero vectors.
+* `TauCeti.SymplecticForm.hermitianForm_self`: `h(v, v) = ω(v, J v)`, with
+  `TauCeti.SymplecticForm.Tames.hermitianForm_self_re_pos` adding positivity on nonzero vectors.
 * `TauCeti.SymplecticForm.Compatible.hermitianCore`: the Hermitian inner product of a compatible
   pair as an `InnerProductSpace.Core ℂ V`.
 
@@ -62,17 +65,16 @@ noncomputable def hermitianForm (ω : SymplecticForm V) (J : AlmostComplexStruct
     (v w : V) : ℂ :=
   (ω v (J w) : ℂ) + Complex.I * (ω v w : ℂ)
 
+@[simp]
 lemma hermitianForm_apply (ω : SymplecticForm V) (J : AlmostComplexStructure V) (v w : V) :
     ω.hermitianForm J v w = (ω v (J w) : ℂ) + Complex.I * (ω v w : ℂ) := rfl
 
 /-- The real part of the Hermitian form is the metric `g(v, w) = ω(v, J w)`. -/
-@[simp]
 lemma hermitianForm_re (ω : SymplecticForm V) (J : AlmostComplexStructure V) (v w : V) :
     (ω.hermitianForm J v w).re = ω v (J w) := by
   simp [hermitianForm]
 
 /-- The imaginary part of the Hermitian form is the symplectic form `ω(v, w)`. -/
-@[simp]
 lemma hermitianForm_im (ω : SymplecticForm V) (J : AlmostComplexStructure V) (v w : V) :
     (ω.hermitianForm J v w).im = ω v w := by
   simp [hermitianForm]
@@ -96,7 +98,7 @@ lemma hermitianForm_add_right (ω : SymplecticForm V) (J : AlmostComplexStructur
 /-- Auxiliary real-scalar form of complex linearity in the second argument: feeding the real
 decomposition `r.re • w + r.im • J w` of `r • w` to the second slot multiplies by `r`. This needs
 only `J² = -1`, not compatibility. -/
-lemma hermitianForm_smul_right_aux (ω : SymplecticForm V) (J : AlmostComplexStructure V)
+private lemma hermitianForm_smul_right_aux (ω : SymplecticForm V) (J : AlmostComplexStructure V)
     (r : ℂ) (v w : V) :
     ω.hermitianForm J v (r.re • w + r.im • J w) = r * ω.hermitianForm J v w := by
   have key1 : ω v (J (r.re • w + r.im • J w)) = r.re * ω v (J w) + r.im * -(ω v w) := by
@@ -104,11 +106,8 @@ lemma hermitianForm_smul_right_aux (ω : SymplecticForm V) (J : AlmostComplexStr
   have key2 : ω v (r.re • w + r.im • J w) = r.re * ω v w + r.im * ω v (J w) := by
     simp only [map_add, map_smul, smul_eq_mul]
   simp only [hermitianForm, key1, key2]
-  apply Complex.ext <;>
-    simp only [Complex.add_re, Complex.add_im, Complex.mul_re, Complex.mul_im, Complex.ofReal_re,
-      Complex.ofReal_im, Complex.I_re, Complex.I_im, Complex.neg_re, Complex.neg_im,
-      Complex.ofReal_add, Complex.ofReal_mul, Complex.ofReal_neg] <;>
-    ring
+  apply Complex.ext <;> simp
+  ring
 
 /-- The Hermitian form is complex linear in its second argument over the complex structure
 `J.complexModule`: `h(v, z • w) = z · h(v, w)`. This is the defining property of a Hermitian inner
@@ -122,10 +121,84 @@ lemma hermitianForm_smul_right (ω : SymplecticForm V) (J : AlmostComplexStructu
   exact ω.hermitianForm_smul_right_aux J z v w
 
 /-- The diagonal of the Hermitian form is real and equals the metric diagonal `ω(v, J v)`. -/
-@[simp]
 lemma hermitianForm_self (ω : SymplecticForm V) (J : AlmostComplexStructure V) (v : V) :
     ω.hermitianForm J v v = (ω v (J v) : ℂ) := by
   simp [hermitianForm]
+
+namespace Tames
+
+variable {ω : SymplecticForm V} {J : AlmostComplexStructure V}
+
+/-- The diagonal of the Hermitian form is positive on nonzero vectors. Only tameness is needed. -/
+lemma hermitianForm_self_re_pos (htames : ω.Tames J) {v : V} (hv : v ≠ 0) :
+    0 < (ω.hermitianForm J v v).re := by
+  rw [hermitianForm_re]
+  exact htames v hv
+
+/-- The real part of the diagonal of the Hermitian form is nonnegative, in the `RCLike.re` form
+the inner-product-space core expects. Only tameness is needed. -/
+lemma hermitianForm_re_self_nonneg (htames : ω.Tames J) (v : V) :
+    0 ≤ RCLike.re (ω.hermitianForm J v v) := by
+  rw [ω.hermitianForm_self]
+  simpa using SymplecticForm.symplecticForm_apply_apply_self_nonneg
+    ((ω.tames_iff_associated_pos J).mp htames) v
+
+/-- The diagonal of the Hermitian form vanishes exactly at zero. Only tameness is needed. -/
+lemma hermitianForm_self_eq_zero (htames : ω.Tames J) {v : V} :
+    ω.hermitianForm J v v = 0 ↔ v = 0 := by
+  rw [ω.hermitianForm_self, Complex.ofReal_eq_zero, ← associatedBilinForm_apply]
+  exact SymplecticForm.associatedBilinForm_self_eq_zero ((ω.tames_iff_associated_pos J).mp htames)
+
+end Tames
+
+namespace Invariant
+
+variable {ω : SymplecticForm V} {J : AlmostComplexStructure V}
+
+/-- The Hermitian form is conjugate-symmetric: `conj (h(w, v)) = h(v, w)`. Only `J`-invariance is
+needed. -/
+lemma hermitianForm_conj_symm (hinv : ω.Invariant J) (v w : V) :
+    (starRingEnd ℂ) (ω.hermitianForm J w v) = ω.hermitianForm J v w := by
+  have hg : ω w (J v) = ω v (J w) := by
+    have h2 : ω v (J w) = ω w (J v) :=
+      calc ω v (J w) = -ω (J w) v := by rw [ω.neg_eq]
+        _ = ω w (J v) := by simpa using hinv.apply w (J v)
+    exact h2.symm
+  have hω : ω w v = -(ω v w) := (ω.neg_eq v w).symm
+  simp only [hermitianForm, map_add, map_mul, Complex.conj_ofReal, Complex.conj_I, hg, hω]
+  push_cast
+  ring
+
+/-- Auxiliary real-scalar form of conjugate linearity in the first argument: feeding the real
+decomposition `r.re • v + r.im • J v` of `r • v` to the first slot multiplies by `conj r`. Only
+`J`-invariance is needed. -/
+private lemma hermitianForm_smul_left_aux (hinv : ω.Invariant J) (r : ℂ) (v w : V) :
+    ω.hermitianForm J (r.re • v + r.im • J v) w
+      = (starRingEnd ℂ) r * ω.hermitianForm J v w := by
+  have hJvw : ω (J v) (J w) = ω v w := hinv.apply v w
+  have hJv : ω (J v) w = -(ω v (J w)) := by
+    have h1 : -ω (J v) w = ω w (J v) := ω.neg_eq (J v) w
+    have h2 : ω v (J w) = ω w (J v) :=
+      calc ω v (J w) = -ω (J w) v := by rw [ω.neg_eq]
+        _ = ω w (J v) := by simpa using hinv.apply w (J v)
+    linarith
+  have key1 : ω (r.re • v + r.im • J v) (J w) = r.re * ω v (J w) + r.im * ω v w := by
+    simp only [map_add, map_smul, LinearMap.add_apply, LinearMap.smul_apply, smul_eq_mul, hJvw]
+  have key2 : ω (r.re • v + r.im • J v) w = r.re * ω v w + r.im * -(ω v (J w)) := by
+    simp only [map_add, map_smul, LinearMap.add_apply, LinearMap.smul_apply, smul_eq_mul, hJv]
+  simp only [hermitianForm, key1, key2]
+  apply Complex.ext <;> simp
+
+/-- The Hermitian form is conjugate linear in its first argument over the complex structure
+`J.complexModule`: `h(z • v, w) = conj z · h(v, w)`. Only `J`-invariance is needed. -/
+lemma hermitianForm_smul_left (hinv : ω.Invariant J) (z : ℂ) (v w : V) :
+    letI := J.complexModule
+    ω.hermitianForm J (z • v) w = (starRingEnd ℂ) z * ω.hermitianForm J v w := by
+  letI := J.complexModule
+  rw [J.complexModule_smul_def]
+  exact hinv.hermitianForm_smul_left_aux z v w
+
+end Invariant
 
 namespace Compatible
 
@@ -133,64 +206,31 @@ variable {ω : SymplecticForm V} {J : AlmostComplexStructure V}
 
 /-- The diagonal of the Hermitian form is positive on nonzero vectors. -/
 lemma hermitianForm_self_re_pos (h : ω.Compatible J) {v : V} (hv : v ≠ 0) :
-    0 < (ω.hermitianForm J v v).re := by
-  rw [hermitianForm_re]
-  exact h.associated_pos hv
+    0 < (ω.hermitianForm J v v).re :=
+  h.tames.hermitianForm_self_re_pos hv
 
 /-- The real part of the diagonal of the Hermitian form is nonnegative, in the `RCLike.re` form
 the inner-product-space core expects. -/
 lemma hermitianForm_re_self_nonneg (h : ω.Compatible J) (v : V) :
-    0 ≤ RCLike.re (ω.hermitianForm J v v) := by
-  rw [ω.hermitianForm_self]
-  simpa using h.symplecticForm_apply_apply_self_nonneg v
+    0 ≤ RCLike.re (ω.hermitianForm J v v) :=
+  h.tames.hermitianForm_re_self_nonneg v
 
-/-- The diagonal of the Hermitian form vanishes only at zero. -/
-lemma hermitianForm_self_eq_zero (h : ω.Compatible J) {v : V}
-    (hv : ω.hermitianForm J v v = 0) : v = 0 := by
-  rw [ω.hermitianForm_self] at hv
-  have hz : ω v (J v) = 0 := by exact_mod_cast hv
-  rw [← associatedBilinForm_apply] at hz
-  exact h.associatedBilinForm_self_eq_zero.mp hz
+/-- The diagonal of the Hermitian form vanishes exactly at zero. -/
+lemma hermitianForm_self_eq_zero (h : ω.Compatible J) {v : V} :
+    ω.hermitianForm J v v = 0 ↔ v = 0 :=
+  h.tames.hermitianForm_self_eq_zero
 
 /-- The Hermitian form is conjugate-symmetric: `conj (h(w, v)) = h(v, w)`. -/
 lemma hermitianForm_conj_symm (h : ω.Compatible J) (v w : V) :
-    (starRingEnd ℂ) (ω.hermitianForm J w v) = ω.hermitianForm J v w := by
-  have hg : ω w (J v) = ω v (J w) := (h.associatedBilinForm_apply_swap v w).symm
-  have hω : ω w v = -(ω v w) := (ω.neg_eq v w).symm
-  simp only [hermitianForm, map_add, map_mul, Complex.conj_ofReal, Complex.conj_I, hg, hω]
-  push_cast
-  ring
-
-/-- Auxiliary real-scalar form of conjugate linearity in the first argument: feeding the real
-decomposition `r.re • v + r.im • J v` of `r • v` to the first slot multiplies by `conj r`. -/
-lemma hermitianForm_smul_left_aux (h : ω.Compatible J) (r : ℂ) (v w : V) :
-    ω.hermitianForm J (r.re • v + r.im • J v) w
-      = (starRingEnd ℂ) r * ω.hermitianForm J v w := by
-  have hJvw : ω (J v) (J w) = ω v w := h.invariant_apply v w
-  have hJv : ω (J v) w = -(ω v (J w)) := by
-    have h1 : -ω (J v) w = ω w (J v) := ω.neg_eq (J v) w
-    have h2 : ω v (J w) = ω w (J v) := h.associatedBilinForm_apply_swap v w
-    linarith
-  have key1 : ω (r.re • v + r.im • J v) (J w) = r.re * ω v (J w) + r.im * ω v w := by
-    simp only [map_add, map_smul, LinearMap.add_apply, LinearMap.smul_apply, smul_eq_mul, hJvw]
-  have key2 : ω (r.re • v + r.im • J v) w = r.re * ω v w + r.im * -(ω v (J w)) := by
-    simp only [map_add, map_smul, LinearMap.add_apply, LinearMap.smul_apply, smul_eq_mul, hJv]
-  simp only [hermitianForm, key1, key2]
-  apply Complex.ext <;>
-    simp only [Complex.add_re, Complex.add_im, Complex.mul_re, Complex.mul_im, Complex.ofReal_re,
-      Complex.ofReal_im, Complex.I_re, Complex.I_im, Complex.conj_re, Complex.conj_im,
-      Complex.neg_re, Complex.neg_im, Complex.ofReal_add, Complex.ofReal_mul,
-      Complex.ofReal_neg] <;>
-    ring
+    (starRingEnd ℂ) (ω.hermitianForm J w v) = ω.hermitianForm J v w :=
+  h.invariant.hermitianForm_conj_symm v w
 
 /-- The Hermitian form is conjugate linear in its first argument over the complex structure
 `J.complexModule`: `h(z • v, w) = conj z · h(v, w)`. -/
 lemma hermitianForm_smul_left (h : ω.Compatible J) (z : ℂ) (v w : V) :
     letI := J.complexModule
-    ω.hermitianForm J (z • v) w = (starRingEnd ℂ) z * ω.hermitianForm J v w := by
-  letI := J.complexModule
-  rw [J.complexModule_smul_def]
-  exact h.hermitianForm_smul_left_aux z v w
+    ω.hermitianForm J (z • v) w = (starRingEnd ℂ) z * ω.hermitianForm J v w :=
+  h.invariant.hermitianForm_smul_left z v w
 
 /-- The Hermitian inner product of a compatible pair, packaged as an `InnerProductSpace.Core ℂ V`
 for the complex structure `J.complexModule`.
@@ -207,14 +247,15 @@ noncomputable def hermitianCore (h : ω.Compatible J) :
     re_inner_nonneg := h.hermitianForm_re_self_nonneg
     add_left := ω.hermitianForm_add_left J
     smul_left := fun v w z => h.hermitianForm_smul_left z v w
-    definite := fun _ hv => h.hermitianForm_self_eq_zero hv }
+    definite := fun _ hv => h.hermitianForm_self_eq_zero.mp hv }
 
 /-- The inner product from `hermitianCore` is the Hermitian form `ω(v, J w) + i ω(v, w)`. -/
 @[simp]
 lemma hermitianCore_inner (h : ω.Compatible J) (v w : V) :
     letI := J.complexModule
-    @inner ℂ V h.hermitianCore.toInner v w = (ω v (J w) : ℂ) + Complex.I * (ω v w : ℂ) :=
-  rfl
+    @inner ℂ V h.hermitianCore.toInner v w = (ω v (J w) : ℂ) + Complex.I * (ω v w : ℂ) := by
+  change ω.hermitianForm J v w = _
+  rw [hermitianForm_apply]
 
 end Compatible
 

--- a/TauCeti/Geometry/Symplectic/Hermitian.lean
+++ b/TauCeti/Geometry/Symplectic/Hermitian.lean
@@ -23,8 +23,9 @@ metric and the symplectic form, `h` is conjugate-symmetric, it is complex linear
 argument over the `J`-induced complex structure, and it is positive definite.
 
 This is the complex companion of `TauCeti.SymplecticForm.Compatible.innerProductCore`, which
-records the real metric `g` of the same pair as an `InnerProductSpace.Core ℝ V`. Here the form is
-built once, as `SymplecticForm.hermitianForm`, and the Hermitian-structure facts are proved under
+records the real metric `g` of the same pair as an `InnerProductSpace.Core ℝ V`. Here the complex
+form is built once, as `SymplecticForm.complexAssociatedForm`, and the Hermitian-structure facts
+are proved under
 the weakest hypothesis each one needs: conjugate symmetry and conjugate-linearity in the first
 argument need only `ω.Invariant J`, while positive definiteness needs only `ω.Tames J`.
 Compatibility (`Invariant` plus `Tames`) is what assembles all of them into the capstone
@@ -33,15 +34,16 @@ structure `J.complexModule`.
 
 ## Main declarations
 
-* `TauCeti.SymplecticForm.hermitianForm`: the complex form `h(v, w) = ω(v, J w) + i ω(v, w)`.
-* `TauCeti.SymplecticForm.hermitianForm_re` / `hermitianForm_im`: the real and imaginary parts of
-  `h` are the metric `g(v, w) = ω(v, J w)` and the symplectic form `ω(v, w)`.
+* `TauCeti.SymplecticForm.complexAssociatedForm`: the complex form
+  `h(v, w) = ω(v, J w) + i ω(v, w)`.
+* `TauCeti.SymplecticForm.complexAssociatedForm_re` / `complexAssociatedForm_im`: the real and
+  imaginary parts of `h` are the metric `g(v, w) = ω(v, J w)` and the symplectic form `ω(v, w)`.
 * `TauCeti.SymplecticForm.Invariant.hermitianForm_conj_symm`: `h` is conjugate-symmetric,
   `conj (h(w, v)) = h(v, w)`, needing only `J`-invariance.
-* `TauCeti.SymplecticForm.hermitianForm_smul_right`: `h` is complex linear in its second argument,
-  `h(v, z • w) = z · h(v, w)`, for the complex structure `J.complexModule` (no compatibility
-  needed).
-* `TauCeti.SymplecticForm.hermitianForm_self`: `h(v, v) = ω(v, J v)`, with
+* `TauCeti.SymplecticForm.complexAssociatedForm_smul_right`: `h` is complex linear in its second
+  argument, `h(v, z • w) = z · h(v, w)`, for the complex structure `J.complexModule` (no
+  compatibility needed).
+* `TauCeti.SymplecticForm.complexAssociatedForm_self`: `h(v, v) = ω(v, J v)`, with
   `TauCeti.SymplecticForm.Tames.hermitianForm_self_re_pos` adding positivity on nonzero vectors.
 * `TauCeti.SymplecticForm.Compatible.hermitianCore`: the Hermitian inner product of a compatible
   pair as an `InnerProductSpace.Core ℂ V`.
@@ -56,74 +58,83 @@ namespace SymplecticForm
 
 variable {V : Type*} [AddCommGroup V] [Module ℝ V]
 
-/-- The Hermitian form of a pair `(ω, J)`: `h(v, w) = ω(v, J w) + i ω(v, w)`.
+/-- The complex form associated to a pair `(ω, J)`: `h(v, w) = ω(v, J w) + i ω(v, w)`.
 
 Its real part is the metric `ω(·, J ·)` and its imaginary part is the symplectic form `ω`. The
 Hermitian-structure facts (conjugate symmetry, complex linearity in the second argument, positive
 definiteness) need `J² = -1` and compatibility; the bare definition does not. -/
-noncomputable def hermitianForm (ω : SymplecticForm V) (J : AlmostComplexStructure V)
+noncomputable def complexAssociatedForm (ω : SymplecticForm V) (J : AlmostComplexStructure V)
     (v w : V) : ℂ :=
   (ω v (J w) : ℂ) + Complex.I * (ω v w : ℂ)
 
 @[simp]
-lemma hermitianForm_apply (ω : SymplecticForm V) (J : AlmostComplexStructure V) (v w : V) :
-    ω.hermitianForm J v w = (ω v (J w) : ℂ) + Complex.I * (ω v w : ℂ) := rfl
+lemma complexAssociatedForm_apply (ω : SymplecticForm V) (J : AlmostComplexStructure V)
+    (v w : V) :
+    ω.complexAssociatedForm J v w = (ω v (J w) : ℂ) + Complex.I * (ω v w : ℂ) := rfl
 
-/-- The real part of the Hermitian form is the metric `g(v, w) = ω(v, J w)`. -/
-lemma hermitianForm_re (ω : SymplecticForm V) (J : AlmostComplexStructure V) (v w : V) :
-    (ω.hermitianForm J v w).re = ω v (J w) := by
-  simp [hermitianForm]
+/-- The real part of the complex associated form is the metric `g(v, w) = ω(v, J w)`. -/
+lemma complexAssociatedForm_re (ω : SymplecticForm V) (J : AlmostComplexStructure V)
+    (v w : V) :
+    (ω.complexAssociatedForm J v w).re = ω v (J w) := by
+  simp [complexAssociatedForm]
 
-/-- The imaginary part of the Hermitian form is the symplectic form `ω(v, w)`. -/
-lemma hermitianForm_im (ω : SymplecticForm V) (J : AlmostComplexStructure V) (v w : V) :
-    (ω.hermitianForm J v w).im = ω v w := by
-  simp [hermitianForm]
+/-- The imaginary part of the complex associated form is the symplectic form `ω(v, w)`. -/
+lemma complexAssociatedForm_im (ω : SymplecticForm V) (J : AlmostComplexStructure V)
+    (v w : V) :
+    (ω.complexAssociatedForm J v w).im = ω v w := by
+  simp [complexAssociatedForm]
 
-/-- The Hermitian form is additive in its first argument. -/
-lemma hermitianForm_add_left (ω : SymplecticForm V) (J : AlmostComplexStructure V)
+/-- The complex associated form is additive in its first argument. -/
+lemma complexAssociatedForm_add_left (ω : SymplecticForm V) (J : AlmostComplexStructure V)
     (v₁ v₂ w : V) :
-    ω.hermitianForm J (v₁ + v₂) w = ω.hermitianForm J v₁ w + ω.hermitianForm J v₂ w := by
-  simp only [hermitianForm, map_add, LinearMap.add_apply]
+    ω.complexAssociatedForm J (v₁ + v₂) w =
+      ω.complexAssociatedForm J v₁ w + ω.complexAssociatedForm J v₂ w := by
+  simp only [complexAssociatedForm, map_add, LinearMap.add_apply]
   push_cast
   ring
 
-/-- The Hermitian form is additive in its second argument. -/
-lemma hermitianForm_add_right (ω : SymplecticForm V) (J : AlmostComplexStructure V)
+/-- The complex associated form is additive in its second argument. -/
+lemma complexAssociatedForm_add_right (ω : SymplecticForm V) (J : AlmostComplexStructure V)
     (v w₁ w₂ : V) :
-    ω.hermitianForm J v (w₁ + w₂) = ω.hermitianForm J v w₁ + ω.hermitianForm J v w₂ := by
-  simp only [hermitianForm, map_add]
+    ω.complexAssociatedForm J v (w₁ + w₂) =
+      ω.complexAssociatedForm J v w₁ + ω.complexAssociatedForm J v w₂ := by
+  simp only [complexAssociatedForm, map_add]
   push_cast
   ring
 
 /-- Auxiliary real-scalar form of complex linearity in the second argument: feeding the real
 decomposition `r.re • w + r.im • J w` of `r • w` to the second slot multiplies by `r`. This needs
 only `J² = -1`, not compatibility. -/
-private lemma hermitianForm_smul_right_aux (ω : SymplecticForm V) (J : AlmostComplexStructure V)
+private lemma complexAssociatedForm_smul_right_aux
+    (ω : SymplecticForm V) (J : AlmostComplexStructure V)
     (r : ℂ) (v w : V) :
-    ω.hermitianForm J v (r.re • w + r.im • J w) = r * ω.hermitianForm J v w := by
+    ω.complexAssociatedForm J v (r.re • w + r.im • J w) =
+      r * ω.complexAssociatedForm J v w := by
   have key1 : ω v (J (r.re • w + r.im • J w)) = r.re * ω v (J w) + r.im * -(ω v w) := by
     simp only [map_add, map_smul, smul_eq_mul, AlmostComplexStructure.apply_apply, map_neg]
   have key2 : ω v (r.re • w + r.im • J w) = r.re * ω v w + r.im * ω v (J w) := by
     simp only [map_add, map_smul, smul_eq_mul]
-  simp only [hermitianForm, key1, key2]
+  simp only [complexAssociatedForm, key1, key2]
   apply Complex.ext <;> simp
   ring
 
-/-- The Hermitian form is complex linear in its second argument over the complex structure
-`J.complexModule`: `h(v, z • w) = z · h(v, w)`. This is the defining property of a Hermitian inner
-product on the complex vector space `(V, J)`, and needs only `J² = -1`, not compatibility. -/
-lemma hermitianForm_smul_right (ω : SymplecticForm V) (J : AlmostComplexStructure V)
+/-- The complex associated form is complex linear in its second argument over the complex structure
+`J.complexModule`: `h(v, z • w) = z · h(v, w)`. This is one of the defining properties of a
+Hermitian inner product on the complex vector space `(V, J)`, and needs only `J² = -1`, not
+compatibility. -/
+lemma complexAssociatedForm_smul_right (ω : SymplecticForm V) (J : AlmostComplexStructure V)
     (z : ℂ) (v w : V) :
     letI := J.complexModule
-    ω.hermitianForm J v (z • w) = z * ω.hermitianForm J v w := by
+    ω.complexAssociatedForm J v (z • w) = z * ω.complexAssociatedForm J v w := by
   letI := J.complexModule
   rw [J.complexModule_smul_def]
-  exact ω.hermitianForm_smul_right_aux J z v w
+  exact ω.complexAssociatedForm_smul_right_aux J z v w
 
-/-- The diagonal of the Hermitian form is real and equals the metric diagonal `ω(v, J v)`. -/
-lemma hermitianForm_self (ω : SymplecticForm V) (J : AlmostComplexStructure V) (v : V) :
-    ω.hermitianForm J v v = (ω v (J v) : ℂ) := by
-  simp [hermitianForm]
+/-- The diagonal of the complex associated form is real and equals the metric diagonal
+`ω(v, J v)`. -/
+lemma complexAssociatedForm_self (ω : SymplecticForm V) (J : AlmostComplexStructure V) (v : V) :
+    ω.complexAssociatedForm J v v = (ω v (J v) : ℂ) := by
+  simp [complexAssociatedForm]
 
 namespace Tames
 
@@ -131,22 +142,22 @@ variable {ω : SymplecticForm V} {J : AlmostComplexStructure V}
 
 /-- The diagonal of the Hermitian form is positive on nonzero vectors. Only tameness is needed. -/
 lemma hermitianForm_self_re_pos (htames : ω.Tames J) {v : V} (hv : v ≠ 0) :
-    0 < (ω.hermitianForm J v v).re := by
-  rw [hermitianForm_re]
+    0 < (ω.complexAssociatedForm J v v).re := by
+  rw [complexAssociatedForm_re]
   exact htames v hv
 
 /-- The real part of the diagonal of the Hermitian form is nonnegative, in the `RCLike.re` form
 the inner-product-space core expects. Only tameness is needed. -/
 lemma hermitianForm_re_self_nonneg (htames : ω.Tames J) (v : V) :
-    0 ≤ RCLike.re (ω.hermitianForm J v v) := by
-  rw [ω.hermitianForm_self]
+    0 ≤ RCLike.re (ω.complexAssociatedForm J v v) := by
+  rw [ω.complexAssociatedForm_self]
   simpa using SymplecticForm.symplecticForm_apply_apply_self_nonneg
     ((ω.tames_iff_associated_pos J).mp htames) v
 
 /-- The diagonal of the Hermitian form vanishes exactly at zero. Only tameness is needed. -/
 lemma hermitianForm_self_eq_zero (htames : ω.Tames J) {v : V} :
-    ω.hermitianForm J v v = 0 ↔ v = 0 := by
-  rw [ω.hermitianForm_self, Complex.ofReal_eq_zero, ← associatedBilinForm_apply]
+    ω.complexAssociatedForm J v v = 0 ↔ v = 0 := by
+  rw [ω.complexAssociatedForm_self, Complex.ofReal_eq_zero, ← associatedBilinForm_apply]
   exact SymplecticForm.associatedBilinForm_self_eq_zero ((ω.tames_iff_associated_pos J).mp htames)
 
 end Tames
@@ -158,14 +169,14 @@ variable {ω : SymplecticForm V} {J : AlmostComplexStructure V}
 /-- The Hermitian form is conjugate-symmetric: `conj (h(w, v)) = h(v, w)`. Only `J`-invariance is
 needed. -/
 lemma hermitianForm_conj_symm (hinv : ω.Invariant J) (v w : V) :
-    (starRingEnd ℂ) (ω.hermitianForm J w v) = ω.hermitianForm J v w := by
+    (starRingEnd ℂ) (ω.complexAssociatedForm J w v) = ω.complexAssociatedForm J v w := by
   have hg : ω w (J v) = ω v (J w) := by
     have h2 : ω v (J w) = ω w (J v) :=
       calc ω v (J w) = -ω (J w) v := by rw [ω.neg_eq]
         _ = ω w (J v) := by simpa using hinv.apply w (J v)
     exact h2.symm
   have hω : ω w v = -(ω v w) := (ω.neg_eq v w).symm
-  simp only [hermitianForm, map_add, map_mul, Complex.conj_ofReal, Complex.conj_I, hg, hω]
+  simp only [complexAssociatedForm, map_add, map_mul, Complex.conj_ofReal, Complex.conj_I, hg, hω]
   push_cast
   ring
 
@@ -173,27 +184,26 @@ lemma hermitianForm_conj_symm (hinv : ω.Invariant J) (v w : V) :
 decomposition `r.re • v + r.im • J v` of `r • v` to the first slot multiplies by `conj r`. Only
 `J`-invariance is needed. -/
 private lemma hermitianForm_smul_left_aux (hinv : ω.Invariant J) (r : ℂ) (v w : V) :
-    ω.hermitianForm J (r.re • v + r.im • J v) w
-      = (starRingEnd ℂ) r * ω.hermitianForm J v w := by
+    ω.complexAssociatedForm J (r.re • v + r.im • J v) w
+      = (starRingEnd ℂ) r * ω.complexAssociatedForm J v w := by
   have hJvw : ω (J v) (J w) = ω v w := hinv.apply v w
   have hJv : ω (J v) w = -(ω v (J w)) := by
-    have h1 : -ω (J v) w = ω w (J v) := ω.neg_eq (J v) w
-    have h2 : ω v (J w) = ω w (J v) :=
-      calc ω v (J w) = -ω (J w) v := by rw [ω.neg_eq]
-        _ = ω w (J v) := by simpa using hinv.apply w (J v)
+    have hskew := hinv.associatedBilinForm_skewAdjoint v (J w)
+    simp [associatedBilinForm_apply, AlmostComplexStructure.apply_apply] at hskew
     linarith
   have key1 : ω (r.re • v + r.im • J v) (J w) = r.re * ω v (J w) + r.im * ω v w := by
     simp only [map_add, map_smul, LinearMap.add_apply, LinearMap.smul_apply, smul_eq_mul, hJvw]
   have key2 : ω (r.re • v + r.im • J v) w = r.re * ω v w + r.im * -(ω v (J w)) := by
     simp only [map_add, map_smul, LinearMap.add_apply, LinearMap.smul_apply, smul_eq_mul, hJv]
-  simp only [hermitianForm, key1, key2]
+  simp only [complexAssociatedForm, key1, key2]
   apply Complex.ext <;> simp
 
 /-- The Hermitian form is conjugate linear in its first argument over the complex structure
 `J.complexModule`: `h(z • v, w) = conj z · h(v, w)`. Only `J`-invariance is needed. -/
 lemma hermitianForm_smul_left (hinv : ω.Invariant J) (z : ℂ) (v w : V) :
     letI := J.complexModule
-    ω.hermitianForm J (z • v) w = (starRingEnd ℂ) z * ω.hermitianForm J v w := by
+    ω.complexAssociatedForm J (z • v) w =
+      (starRingEnd ℂ) z * ω.complexAssociatedForm J v w := by
   letI := J.complexModule
   rw [J.complexModule_smul_def]
   exact hinv.hermitianForm_smul_left_aux z v w
@@ -206,30 +216,31 @@ variable {ω : SymplecticForm V} {J : AlmostComplexStructure V}
 
 /-- The diagonal of the Hermitian form is positive on nonzero vectors. -/
 lemma hermitianForm_self_re_pos (h : ω.Compatible J) {v : V} (hv : v ≠ 0) :
-    0 < (ω.hermitianForm J v v).re :=
+    0 < (ω.complexAssociatedForm J v v).re :=
   h.tames.hermitianForm_self_re_pos hv
 
 /-- The real part of the diagonal of the Hermitian form is nonnegative, in the `RCLike.re` form
 the inner-product-space core expects. -/
 lemma hermitianForm_re_self_nonneg (h : ω.Compatible J) (v : V) :
-    0 ≤ RCLike.re (ω.hermitianForm J v v) :=
+    0 ≤ RCLike.re (ω.complexAssociatedForm J v v) :=
   h.tames.hermitianForm_re_self_nonneg v
 
 /-- The diagonal of the Hermitian form vanishes exactly at zero. -/
 lemma hermitianForm_self_eq_zero (h : ω.Compatible J) {v : V} :
-    ω.hermitianForm J v v = 0 ↔ v = 0 :=
+    ω.complexAssociatedForm J v v = 0 ↔ v = 0 :=
   h.tames.hermitianForm_self_eq_zero
 
 /-- The Hermitian form is conjugate-symmetric: `conj (h(w, v)) = h(v, w)`. -/
 lemma hermitianForm_conj_symm (h : ω.Compatible J) (v w : V) :
-    (starRingEnd ℂ) (ω.hermitianForm J w v) = ω.hermitianForm J v w :=
+    (starRingEnd ℂ) (ω.complexAssociatedForm J w v) = ω.complexAssociatedForm J v w :=
   h.invariant.hermitianForm_conj_symm v w
 
 /-- The Hermitian form is conjugate linear in its first argument over the complex structure
 `J.complexModule`: `h(z • v, w) = conj z · h(v, w)`. -/
 lemma hermitianForm_smul_left (h : ω.Compatible J) (z : ℂ) (v w : V) :
     letI := J.complexModule
-    ω.hermitianForm J (z • v) w = (starRingEnd ℂ) z * ω.hermitianForm J v w :=
+    ω.complexAssociatedForm J (z • v) w =
+      (starRingEnd ℂ) z * ω.complexAssociatedForm J v w :=
   h.invariant.hermitianForm_smul_left z v w
 
 /-- The Hermitian inner product of a compatible pair, packaged as an `InnerProductSpace.Core ℂ V`
@@ -242,10 +253,10 @@ noncomputable def hermitianCore (h : ω.Compatible J) :
     letI := J.complexModule
     InnerProductSpace.Core ℂ V :=
   letI := J.complexModule
-  { inner := ω.hermitianForm J
+  { inner := ω.complexAssociatedForm J
     conj_inner_symm := h.hermitianForm_conj_symm
     re_inner_nonneg := h.hermitianForm_re_self_nonneg
-    add_left := ω.hermitianForm_add_left J
+    add_left := ω.complexAssociatedForm_add_left J
     smul_left := fun v w z => h.hermitianForm_smul_left z v w
     definite := fun _ hv => h.hermitianForm_self_eq_zero.mp hv }
 
@@ -254,8 +265,10 @@ noncomputable def hermitianCore (h : ω.Compatible J) :
 lemma hermitianCore_inner (h : ω.Compatible J) (v w : V) :
     letI := J.complexModule
     @inner ℂ V h.hermitianCore.toInner v w = (ω v (J w) : ℂ) + Complex.I * (ω v w : ℂ) := by
-  change ω.hermitianForm J v w = _
-  rw [hermitianForm_apply]
+  -- `hermitianCore` sets `inner := ω.complexAssociatedForm J`; `toInner` projects that field
+  -- through the reducible wrapper installed by `InnerProductSpace.Core`.
+  change ω.complexAssociatedForm J v w = _
+  rw [complexAssociatedForm_apply]
 
 end Compatible
 

--- a/TauCeti/Geometry/Symplectic/Hermitian.lean
+++ b/TauCeti/Geometry/Symplectic/Hermitian.lean
@@ -1,0 +1,223 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+import Mathlib.Analysis.Complex.Basic
+import Mathlib.Analysis.InnerProductSpace.Defs
+import TauCeti.Geometry.Symplectic.CompatibleMetric
+import TauCeti.Geometry.Symplectic.ComplexModule
+
+/-!
+# The Hermitian inner product of a compatible pair
+
+A symplectic form `ω` compatible with an almost complex structure `J` packages the real metric
+`g(v, w) = ω(v, J w)` and the symplectic form into a single complex Hermitian inner product
+```
+h(v, w) = g(v, w) + i ω(v, w) = ω(v, J w) + i ω(v, w)
+```
+on the complex vector space `(V, J)` (the complex structure of `ComplexModule.lean`, where
+multiplication by `i` is `J`). This is the classical statement that a compatible triple
+`(ω, J, g)` is the same data as a Hermitian structure (McDuff--Salamon, *J-holomorphic Curves and
+Symplectic Topology*, Section 2.1, Remark 2.6.4): the real and imaginary parts of `h` recover the
+metric and the symplectic form, `h` is conjugate-symmetric, it is complex linear in the second
+argument over the `J`-induced complex structure, and it is positive definite.
+
+This is the complex companion of `TauCeti.SymplecticForm.Compatible.innerProductCore`, which
+records the real metric `g` of the same pair as an `InnerProductSpace.Core ℝ V`. Here the form is
+built once, as `SymplecticForm.hermitianForm`, with the compatibility hypotheses entering only in
+the Hermitian-structure facts, and the capstone `Compatible.hermitianCore` exhibits it as an
+`InnerProductSpace.Core ℂ V` for the complex structure `J.complexModule`.
+
+## Main declarations
+
+* `TauCeti.SymplecticForm.hermitianForm`: the complex form `h(v, w) = ω(v, J w) + i ω(v, w)`.
+* `TauCeti.SymplecticForm.hermitianForm_re` / `hermitianForm_im`: the real and imaginary parts of
+  `h` are the metric `g(v, w) = ω(v, J w)` and the symplectic form `ω(v, w)`.
+* `TauCeti.SymplecticForm.Compatible.hermitianForm_conj_symm`: `h` is conjugate-symmetric,
+  `conj (h(w, v)) = h(v, w)`.
+* `TauCeti.SymplecticForm.hermitianForm_smul_right`: `h` is complex linear in its second argument,
+  `h(v, z • w) = z · h(v, w)`, for the complex structure `J.complexModule` (no compatibility
+  needed).
+* `TauCeti.SymplecticForm.Compatible.hermitianForm_self`: `h(v, v) = ω(v, J v)` is real and
+  positive on nonzero vectors.
+* `TauCeti.SymplecticForm.Compatible.hermitianCore`: the Hermitian inner product of a compatible
+  pair as an `InnerProductSpace.Core ℂ V`.
+
+The conventions follow McDuff--Salamon, *J-holomorphic Curves and Symplectic Topology*,
+Section 2.1: a compatible pair `(ω, J)` gives the Hermitian form `⟨v, w⟩ = g(v, w) + i ω(v, w)`.
+-/
+
+namespace TauCeti
+
+namespace SymplecticForm
+
+variable {V : Type*} [AddCommGroup V] [Module ℝ V]
+
+/-- The Hermitian form of a pair `(ω, J)`: `h(v, w) = ω(v, J w) + i ω(v, w)`.
+
+Its real part is the metric `ω(·, J ·)` and its imaginary part is the symplectic form `ω`. The
+Hermitian-structure facts (conjugate symmetry, complex linearity in the second argument, positive
+definiteness) need `J² = -1` and compatibility; the bare definition does not. -/
+noncomputable def hermitianForm (ω : SymplecticForm V) (J : AlmostComplexStructure V)
+    (v w : V) : ℂ :=
+  (ω v (J w) : ℂ) + Complex.I * (ω v w : ℂ)
+
+lemma hermitianForm_apply (ω : SymplecticForm V) (J : AlmostComplexStructure V) (v w : V) :
+    ω.hermitianForm J v w = (ω v (J w) : ℂ) + Complex.I * (ω v w : ℂ) := rfl
+
+/-- The real part of the Hermitian form is the metric `g(v, w) = ω(v, J w)`. -/
+@[simp]
+lemma hermitianForm_re (ω : SymplecticForm V) (J : AlmostComplexStructure V) (v w : V) :
+    (ω.hermitianForm J v w).re = ω v (J w) := by
+  simp [hermitianForm]
+
+/-- The imaginary part of the Hermitian form is the symplectic form `ω(v, w)`. -/
+@[simp]
+lemma hermitianForm_im (ω : SymplecticForm V) (J : AlmostComplexStructure V) (v w : V) :
+    (ω.hermitianForm J v w).im = ω v w := by
+  simp [hermitianForm]
+
+/-- The Hermitian form is additive in its first argument. -/
+lemma hermitianForm_add_left (ω : SymplecticForm V) (J : AlmostComplexStructure V)
+    (v₁ v₂ w : V) :
+    ω.hermitianForm J (v₁ + v₂) w = ω.hermitianForm J v₁ w + ω.hermitianForm J v₂ w := by
+  simp only [hermitianForm, map_add, LinearMap.add_apply]
+  push_cast
+  ring
+
+/-- The Hermitian form is additive in its second argument. -/
+lemma hermitianForm_add_right (ω : SymplecticForm V) (J : AlmostComplexStructure V)
+    (v w₁ w₂ : V) :
+    ω.hermitianForm J v (w₁ + w₂) = ω.hermitianForm J v w₁ + ω.hermitianForm J v w₂ := by
+  simp only [hermitianForm, map_add]
+  push_cast
+  ring
+
+/-- Auxiliary real-scalar form of complex linearity in the second argument: feeding the real
+decomposition `r.re • w + r.im • J w` of `r • w` to the second slot multiplies by `r`. This needs
+only `J² = -1`, not compatibility. -/
+lemma hermitianForm_smul_right_aux (ω : SymplecticForm V) (J : AlmostComplexStructure V)
+    (r : ℂ) (v w : V) :
+    ω.hermitianForm J v (r.re • w + r.im • J w) = r * ω.hermitianForm J v w := by
+  have key1 : ω v (J (r.re • w + r.im • J w)) = r.re * ω v (J w) + r.im * -(ω v w) := by
+    simp only [map_add, map_smul, smul_eq_mul, AlmostComplexStructure.apply_apply, map_neg]
+  have key2 : ω v (r.re • w + r.im • J w) = r.re * ω v w + r.im * ω v (J w) := by
+    simp only [map_add, map_smul, smul_eq_mul]
+  simp only [hermitianForm, key1, key2]
+  apply Complex.ext <;>
+    simp only [Complex.add_re, Complex.add_im, Complex.mul_re, Complex.mul_im, Complex.ofReal_re,
+      Complex.ofReal_im, Complex.I_re, Complex.I_im, Complex.neg_re, Complex.neg_im,
+      Complex.ofReal_add, Complex.ofReal_mul, Complex.ofReal_neg] <;>
+    ring
+
+/-- The Hermitian form is complex linear in its second argument over the complex structure
+`J.complexModule`: `h(v, z • w) = z · h(v, w)`. This is the defining property of a Hermitian inner
+product on the complex vector space `(V, J)`, and needs only `J² = -1`, not compatibility. -/
+lemma hermitianForm_smul_right (ω : SymplecticForm V) (J : AlmostComplexStructure V)
+    (z : ℂ) (v w : V) :
+    letI := J.complexModule
+    ω.hermitianForm J v (z • w) = z * ω.hermitianForm J v w := by
+  letI := J.complexModule
+  rw [J.complexModule_smul_def]
+  exact ω.hermitianForm_smul_right_aux J z v w
+
+/-- The diagonal of the Hermitian form is real and equals the metric diagonal `ω(v, J v)`. -/
+@[simp]
+lemma hermitianForm_self (ω : SymplecticForm V) (J : AlmostComplexStructure V) (v : V) :
+    ω.hermitianForm J v v = (ω v (J v) : ℂ) := by
+  simp [hermitianForm]
+
+namespace Compatible
+
+variable {ω : SymplecticForm V} {J : AlmostComplexStructure V}
+
+/-- The diagonal of the Hermitian form is positive on nonzero vectors. -/
+lemma hermitianForm_self_re_pos (h : ω.Compatible J) {v : V} (hv : v ≠ 0) :
+    0 < (ω.hermitianForm J v v).re := by
+  rw [hermitianForm_re]
+  exact h.associated_pos hv
+
+/-- The real part of the diagonal of the Hermitian form is nonnegative, in the `RCLike.re` form
+the inner-product-space core expects. -/
+lemma hermitianForm_re_self_nonneg (h : ω.Compatible J) (v : V) :
+    0 ≤ RCLike.re (ω.hermitianForm J v v) := by
+  rw [ω.hermitianForm_self]
+  simpa using h.symplecticForm_apply_apply_self_nonneg v
+
+/-- The diagonal of the Hermitian form vanishes only at zero. -/
+lemma hermitianForm_self_eq_zero (h : ω.Compatible J) {v : V}
+    (hv : ω.hermitianForm J v v = 0) : v = 0 := by
+  rw [ω.hermitianForm_self] at hv
+  have hz : ω v (J v) = 0 := by exact_mod_cast hv
+  rw [← associatedBilinForm_apply] at hz
+  exact h.associatedBilinForm_self_eq_zero.mp hz
+
+/-- The Hermitian form is conjugate-symmetric: `conj (h(w, v)) = h(v, w)`. -/
+lemma hermitianForm_conj_symm (h : ω.Compatible J) (v w : V) :
+    (starRingEnd ℂ) (ω.hermitianForm J w v) = ω.hermitianForm J v w := by
+  have hg : ω w (J v) = ω v (J w) := (h.associatedBilinForm_apply_swap v w).symm
+  have hω : ω w v = -(ω v w) := (ω.neg_eq v w).symm
+  simp only [hermitianForm, map_add, map_mul, Complex.conj_ofReal, Complex.conj_I, hg, hω]
+  push_cast
+  ring
+
+/-- Auxiliary real-scalar form of conjugate linearity in the first argument: feeding the real
+decomposition `r.re • v + r.im • J v` of `r • v` to the first slot multiplies by `conj r`. -/
+lemma hermitianForm_smul_left_aux (h : ω.Compatible J) (r : ℂ) (v w : V) :
+    ω.hermitianForm J (r.re • v + r.im • J v) w
+      = (starRingEnd ℂ) r * ω.hermitianForm J v w := by
+  have hJvw : ω (J v) (J w) = ω v w := h.invariant_apply v w
+  have hJv : ω (J v) w = -(ω v (J w)) := by
+    have h1 : -ω (J v) w = ω w (J v) := ω.neg_eq (J v) w
+    have h2 : ω v (J w) = ω w (J v) := h.associatedBilinForm_apply_swap v w
+    linarith
+  have key1 : ω (r.re • v + r.im • J v) (J w) = r.re * ω v (J w) + r.im * ω v w := by
+    simp only [map_add, map_smul, LinearMap.add_apply, LinearMap.smul_apply, smul_eq_mul, hJvw]
+  have key2 : ω (r.re • v + r.im • J v) w = r.re * ω v w + r.im * -(ω v (J w)) := by
+    simp only [map_add, map_smul, LinearMap.add_apply, LinearMap.smul_apply, smul_eq_mul, hJv]
+  simp only [hermitianForm, key1, key2]
+  apply Complex.ext <;>
+    simp only [Complex.add_re, Complex.add_im, Complex.mul_re, Complex.mul_im, Complex.ofReal_re,
+      Complex.ofReal_im, Complex.I_re, Complex.I_im, Complex.conj_re, Complex.conj_im,
+      Complex.neg_re, Complex.neg_im, Complex.ofReal_add, Complex.ofReal_mul,
+      Complex.ofReal_neg] <;>
+    ring
+
+/-- The Hermitian form is conjugate linear in its first argument over the complex structure
+`J.complexModule`: `h(z • v, w) = conj z · h(v, w)`. -/
+lemma hermitianForm_smul_left (h : ω.Compatible J) (z : ℂ) (v w : V) :
+    letI := J.complexModule
+    ω.hermitianForm J (z • v) w = (starRingEnd ℂ) z * ω.hermitianForm J v w := by
+  letI := J.complexModule
+  rw [J.complexModule_smul_def]
+  exact h.hermitianForm_smul_left_aux z v w
+
+/-- The Hermitian inner product of a compatible pair, packaged as an `InnerProductSpace.Core ℂ V`
+for the complex structure `J.complexModule`.
+
+The inner product is `⟨v, w⟩ = ω(v, J w) + i ω(v, w)`, conjugate linear in the first argument and
+complex linear in the second, with `⟨v, v⟩ = ω(v, J v) > 0` for `v ≠ 0`. -/
+@[implicit_reducible]
+noncomputable def hermitianCore (h : ω.Compatible J) :
+    letI := J.complexModule
+    InnerProductSpace.Core ℂ V :=
+  letI := J.complexModule
+  { inner := ω.hermitianForm J
+    conj_inner_symm := h.hermitianForm_conj_symm
+    re_inner_nonneg := h.hermitianForm_re_self_nonneg
+    add_left := ω.hermitianForm_add_left J
+    smul_left := fun v w z => h.hermitianForm_smul_left z v w
+    definite := fun _ hv => h.hermitianForm_self_eq_zero hv }
+
+/-- The inner product from `hermitianCore` is the Hermitian form `ω(v, J w) + i ω(v, w)`. -/
+@[simp]
+lemma hermitianCore_inner (h : ω.Compatible J) (v w : V) :
+    letI := J.complexModule
+    @inner ℂ V h.hermitianCore.toInner v w = (ω v (J w) : ℂ) + Complex.I * (ω v w : ℂ) :=
+  rfl
+
+end Compatible
+
+end SymplecticForm
+
+end TauCeti

--- a/TauCeti/Geometry/Symplectic/Hermitian.lean
+++ b/TauCeti/Geometry/Symplectic/Hermitian.lean
@@ -18,7 +18,7 @@ h(v, w) = g(v, w) + i ω(v, w) = ω(v, J w) + i ω(v, w)
 on the complex vector space `(V, J)` (the complex structure of `ComplexModule.lean`, where
 multiplication by `i` is `J`). This is the classical statement that a compatible triple
 `(ω, J, g)` is the same data as a Hermitian structure (McDuff--Salamon, *J-holomorphic Curves and
-Symplectic Topology*, Section 2.1, Remark 2.6.4): the real and imaginary parts of `h` recover the
+Symplectic Topology*, Section 2.1): the real and imaginary parts of `h` recover the
 metric and the symplectic form, `h` is conjugate-symmetric, it is complex linear in the second
 argument over the `J`-induced complex structure, and it is positive definite.
 
@@ -38,13 +38,14 @@ structure `J.complexModule`.
   `h(v, w) = ω(v, J w) + i ω(v, w)`.
 * `TauCeti.SymplecticForm.complexAssociatedForm_re` / `complexAssociatedForm_im`: the real and
   imaginary parts of `h` are the metric `g(v, w) = ω(v, J w)` and the symplectic form `ω(v, w)`.
-* `TauCeti.SymplecticForm.Invariant.hermitianForm_conj_symm`: `h` is conjugate-symmetric,
+* `TauCeti.SymplecticForm.Invariant.complexAssociatedForm_conj_symm`: `h` is conjugate-symmetric,
   `conj (h(w, v)) = h(v, w)`, needing only `J`-invariance.
 * `TauCeti.SymplecticForm.complexAssociatedForm_smul_right`: `h` is complex linear in its second
   argument, `h(v, z • w) = z · h(v, w)`, for the complex structure `J.complexModule` (no
   compatibility needed).
 * `TauCeti.SymplecticForm.complexAssociatedForm_self`: `h(v, v) = ω(v, J v)`, with
-  `TauCeti.SymplecticForm.Tames.hermitianForm_self_re_pos` adding positivity on nonzero vectors.
+  `TauCeti.SymplecticForm.Tames.complexAssociatedForm_self_re_pos` adding positivity on nonzero
+  vectors.
 * `TauCeti.SymplecticForm.Compatible.hermitianCore`: the Hermitian inner product of a compatible
   pair as an `InnerProductSpace.Core ℂ V`.
 
@@ -64,9 +65,9 @@ Its real part is the metric `ω(·, J ·)` and its imaginary part is the symplec
 bare definition needs no hypotheses on `(ω, J)`; the Hermitian-structure facts are each proved
 under the weakest hypothesis they need: complex linearity in the second argument from `J² = -1`
 alone (`complexAssociatedForm_smul_right`), conjugate symmetry and conjugate-linearity in the first
-argument from `ω.Invariant J` (`Invariant.hermitianForm_conj_symm`,
-`Invariant.hermitianForm_smul_left`), and positive definiteness from `ω.Tames J`
-(`Tames.hermitianForm_self_re_pos`). Full compatibility is needed only to assemble
+argument from `ω.Invariant J` (`Invariant.complexAssociatedForm_conj_symm`,
+`Invariant.complexAssociatedForm_smul_left`), and positive definiteness from `ω.Tames J`
+(`Tames.complexAssociatedForm_self_re_pos`). Full compatibility is needed only to assemble
 `Compatible.hermitianCore`. -/
 noncomputable def complexAssociatedForm (ω : SymplecticForm V) (J : AlmostComplexStructure V)
     (v w : V) : ℂ :=
@@ -148,21 +149,21 @@ namespace Tames
 variable {ω : SymplecticForm V} {J : AlmostComplexStructure V}
 
 /-- The diagonal of the Hermitian form is positive on nonzero vectors. Only tameness is needed. -/
-lemma hermitianForm_self_re_pos (htames : ω.Tames J) {v : V} (hv : v ≠ 0) :
+lemma complexAssociatedForm_self_re_pos (htames : ω.Tames J) {v : V} (hv : v ≠ 0) :
     0 < (ω.complexAssociatedForm J v v).re := by
   rw [complexAssociatedForm_re]
   exact htames v hv
 
 /-- The real part of the diagonal of the Hermitian form is nonnegative, in the `RCLike.re` form
 the inner-product-space core expects. Only tameness is needed. -/
-lemma hermitianForm_re_self_nonneg (htames : ω.Tames J) (v : V) :
+lemma complexAssociatedForm_self_re_nonneg (htames : ω.Tames J) (v : V) :
     0 ≤ RCLike.re (ω.complexAssociatedForm J v v) := by
   rw [ω.complexAssociatedForm_self]
   simpa using SymplecticForm.symplecticForm_apply_apply_self_nonneg
     ((ω.tames_iff_associated_pos J).mp htames) v
 
 /-- The diagonal of the Hermitian form vanishes exactly at zero. Only tameness is needed. -/
-lemma hermitianForm_self_eq_zero (htames : ω.Tames J) {v : V} :
+lemma complexAssociatedForm_self_eq_zero (htames : ω.Tames J) {v : V} :
     ω.complexAssociatedForm J v v = 0 ↔ v = 0 := by
   rw [ω.complexAssociatedForm_self, Complex.ofReal_eq_zero, ← associatedBilinForm_apply]
   exact SymplecticForm.associatedBilinForm_self_eq_zero ((ω.tames_iff_associated_pos J).mp htames)
@@ -175,7 +176,7 @@ variable {ω : SymplecticForm V} {J : AlmostComplexStructure V}
 
 /-- The Hermitian form is conjugate-symmetric: `conj (h(w, v)) = h(v, w)`. Only `J`-invariance is
 needed. -/
-lemma hermitianForm_conj_symm (hinv : ω.Invariant J) (v w : V) :
+lemma complexAssociatedForm_conj_symm (hinv : ω.Invariant J) (v w : V) :
     (starRingEnd ℂ) (ω.complexAssociatedForm J w v) = ω.complexAssociatedForm J v w := by
   have hg : ω w (J v) = ω v (J w) := hinv.associatedBilinForm_apply_swap w v
   have hω : ω w v = -(ω v w) := (ω.neg_eq v w).symm
@@ -186,7 +187,7 @@ lemma hermitianForm_conj_symm (hinv : ω.Invariant J) (v w : V) :
 /-- Auxiliary real-scalar form of conjugate linearity in the first argument: feeding the real
 decomposition `r.re • v + r.im • J v` of `r • v` to the first slot multiplies by `conj r`. Only
 `J`-invariance is needed. -/
-private lemma hermitianForm_smul_left_aux (hinv : ω.Invariant J) (r : ℂ) (v w : V) :
+private lemma complexAssociatedForm_smul_left_aux (hinv : ω.Invariant J) (r : ℂ) (v w : V) :
     ω.complexAssociatedForm J (r.re • v + r.im • J v) w
       = (starRingEnd ℂ) r * ω.complexAssociatedForm J v w := by
   have hJvw : ω (J v) (J w) = ω v w := hinv.apply v w
@@ -203,13 +204,13 @@ private lemma hermitianForm_smul_left_aux (hinv : ω.Invariant J) (r : ℂ) (v w
 
 /-- The Hermitian form is conjugate linear in its first argument over the complex structure
 `J.complexModule`: `h(z • v, w) = conj z · h(v, w)`. Only `J`-invariance is needed. -/
-lemma hermitianForm_smul_left (hinv : ω.Invariant J) (z : ℂ) (v w : V) :
+lemma complexAssociatedForm_smul_left (hinv : ω.Invariant J) (z : ℂ) (v w : V) :
     letI := J.complexModule
     ω.complexAssociatedForm J (z • v) w =
       (starRingEnd ℂ) z * ω.complexAssociatedForm J v w := by
   letI := J.complexModule
   rw [J.complexModule_smul_def]
-  exact hinv.hermitianForm_smul_left_aux z v w
+  exact hinv.complexAssociatedForm_smul_left_aux z v w
 
 end Invariant
 
@@ -218,33 +219,33 @@ namespace Compatible
 variable {ω : SymplecticForm V} {J : AlmostComplexStructure V}
 
 /-- The diagonal of the Hermitian form is positive on nonzero vectors. -/
-lemma hermitianForm_self_re_pos (h : ω.Compatible J) {v : V} (hv : v ≠ 0) :
+lemma complexAssociatedForm_self_re_pos (h : ω.Compatible J) {v : V} (hv : v ≠ 0) :
     0 < (ω.complexAssociatedForm J v v).re :=
-  h.tames.hermitianForm_self_re_pos hv
+  h.tames.complexAssociatedForm_self_re_pos hv
 
 /-- The real part of the diagonal of the Hermitian form is nonnegative, in the `RCLike.re` form
 the inner-product-space core expects. -/
-lemma hermitianForm_re_self_nonneg (h : ω.Compatible J) (v : V) :
+lemma complexAssociatedForm_self_re_nonneg (h : ω.Compatible J) (v : V) :
     0 ≤ RCLike.re (ω.complexAssociatedForm J v v) :=
-  h.tames.hermitianForm_re_self_nonneg v
+  h.tames.complexAssociatedForm_self_re_nonneg v
 
 /-- The diagonal of the Hermitian form vanishes exactly at zero. -/
-lemma hermitianForm_self_eq_zero (h : ω.Compatible J) {v : V} :
+lemma complexAssociatedForm_self_eq_zero (h : ω.Compatible J) {v : V} :
     ω.complexAssociatedForm J v v = 0 ↔ v = 0 :=
-  h.tames.hermitianForm_self_eq_zero
+  h.tames.complexAssociatedForm_self_eq_zero
 
 /-- The Hermitian form is conjugate-symmetric: `conj (h(w, v)) = h(v, w)`. -/
-lemma hermitianForm_conj_symm (h : ω.Compatible J) (v w : V) :
+lemma complexAssociatedForm_conj_symm (h : ω.Compatible J) (v w : V) :
     (starRingEnd ℂ) (ω.complexAssociatedForm J w v) = ω.complexAssociatedForm J v w :=
-  h.invariant.hermitianForm_conj_symm v w
+  h.invariant.complexAssociatedForm_conj_symm v w
 
 /-- The Hermitian form is conjugate linear in its first argument over the complex structure
 `J.complexModule`: `h(z • v, w) = conj z · h(v, w)`. -/
-lemma hermitianForm_smul_left (h : ω.Compatible J) (z : ℂ) (v w : V) :
+lemma complexAssociatedForm_smul_left (h : ω.Compatible J) (z : ℂ) (v w : V) :
     letI := J.complexModule
     ω.complexAssociatedForm J (z • v) w =
       (starRingEnd ℂ) z * ω.complexAssociatedForm J v w :=
-  h.invariant.hermitianForm_smul_left z v w
+  h.invariant.complexAssociatedForm_smul_left z v w
 
 /-- The Hermitian inner product of a compatible pair, packaged as an `InnerProductSpace.Core ℂ V`
 for the complex structure `J.complexModule`.
@@ -257,11 +258,11 @@ noncomputable def hermitianCore (h : ω.Compatible J) :
     InnerProductSpace.Core ℂ V :=
   letI := J.complexModule
   { inner := ω.complexAssociatedForm J
-    conj_inner_symm := h.hermitianForm_conj_symm
-    re_inner_nonneg := h.hermitianForm_re_self_nonneg
+    conj_inner_symm := h.complexAssociatedForm_conj_symm
+    re_inner_nonneg := h.complexAssociatedForm_self_re_nonneg
     add_left := ω.complexAssociatedForm_add_left J
-    smul_left := fun v w z => h.hermitianForm_smul_left z v w
-    definite := fun _ hv => h.hermitianForm_self_eq_zero.mp hv }
+    smul_left := fun v w z => h.complexAssociatedForm_smul_left z v w
+    definite := fun _ hv => h.complexAssociatedForm_self_eq_zero.mp hv }
 
 /-- The inner product from `hermitianCore` is the Hermitian form `ω(v, J w) + i ω(v, w)`. -/
 @[simp]

--- a/TauCeti/Geometry/Symplectic/Hermitian.lean
+++ b/TauCeti/Geometry/Symplectic/Hermitian.lean
@@ -61,24 +61,30 @@ variable {V : Type*} [AddCommGroup V] [Module ℝ V]
 /-- The complex form associated to a pair `(ω, J)`: `h(v, w) = ω(v, J w) + i ω(v, w)`.
 
 Its real part is the metric `ω(·, J ·)` and its imaginary part is the symplectic form `ω`. The
-Hermitian-structure facts (conjugate symmetry, complex linearity in the second argument, positive
-definiteness) need `J² = -1` and compatibility; the bare definition does not. -/
+bare definition needs no hypotheses on `(ω, J)`; the Hermitian-structure facts are each proved
+under the weakest hypothesis they need: complex linearity in the second argument from `J² = -1`
+alone (`complexAssociatedForm_smul_right`), conjugate symmetry and conjugate-linearity in the first
+argument from `ω.Invariant J` (`Invariant.hermitianForm_conj_symm`,
+`Invariant.hermitianForm_smul_left`), and positive definiteness from `ω.Tames J`
+(`Tames.hermitianForm_self_re_pos`). Full compatibility is needed only to assemble
+`Compatible.hermitianCore`. -/
 noncomputable def complexAssociatedForm (ω : SymplecticForm V) (J : AlmostComplexStructure V)
     (v w : V) : ℂ :=
   (ω v (J w) : ℂ) + Complex.I * (ω v w : ℂ)
 
-@[simp]
 lemma complexAssociatedForm_apply (ω : SymplecticForm V) (J : AlmostComplexStructure V)
     (v w : V) :
     ω.complexAssociatedForm J v w = (ω v (J w) : ℂ) + Complex.I * (ω v w : ℂ) := rfl
 
 /-- The real part of the complex associated form is the metric `g(v, w) = ω(v, J w)`. -/
+@[simp]
 lemma complexAssociatedForm_re (ω : SymplecticForm V) (J : AlmostComplexStructure V)
     (v w : V) :
     (ω.complexAssociatedForm J v w).re = ω v (J w) := by
   simp [complexAssociatedForm]
 
 /-- The imaginary part of the complex associated form is the symplectic form `ω(v, w)`. -/
+@[simp]
 lemma complexAssociatedForm_im (ω : SymplecticForm V) (J : AlmostComplexStructure V)
     (v w : V) :
     (ω.complexAssociatedForm J v w).im = ω v w := by
@@ -132,6 +138,7 @@ lemma complexAssociatedForm_smul_right (ω : SymplecticForm V) (J : AlmostComple
 
 /-- The diagonal of the complex associated form is real and equals the metric diagonal
 `ω(v, J v)`. -/
+@[simp]
 lemma complexAssociatedForm_self (ω : SymplecticForm V) (J : AlmostComplexStructure V) (v : V) :
     ω.complexAssociatedForm J v v = (ω v (J v) : ℂ) := by
   simp [complexAssociatedForm]
@@ -170,11 +177,7 @@ variable {ω : SymplecticForm V} {J : AlmostComplexStructure V}
 needed. -/
 lemma hermitianForm_conj_symm (hinv : ω.Invariant J) (v w : V) :
     (starRingEnd ℂ) (ω.complexAssociatedForm J w v) = ω.complexAssociatedForm J v w := by
-  have hg : ω w (J v) = ω v (J w) := by
-    have h2 : ω v (J w) = ω w (J v) :=
-      calc ω v (J w) = -ω (J w) v := by rw [ω.neg_eq]
-        _ = ω w (J v) := by simpa using hinv.apply w (J v)
-    exact h2.symm
+  have hg : ω w (J v) = ω v (J w) := hinv.associatedBilinForm_apply_swap w v
   have hω : ω w v = -(ω v w) := (ω.neg_eq v w).symm
   simp only [complexAssociatedForm, map_add, map_mul, Complex.conj_ofReal, Complex.conj_I, hg, hω]
   push_cast

--- a/TauCeti/Geometry/Symplectic/Hermitian.lean
+++ b/TauCeti/Geometry/Symplectic/Hermitian.lean
@@ -73,6 +73,7 @@ noncomputable def complexAssociatedForm (ω : SymplecticForm V) (J : AlmostCompl
     (v w : V) : ℂ :=
   (ω v (J w) : ℂ) + Complex.I * (ω v w : ℂ)
 
+@[simp]
 lemma complexAssociatedForm_apply (ω : SymplecticForm V) (J : AlmostComplexStructure V)
     (v w : V) :
     ω.complexAssociatedForm J v w = (ω v (J w) : ℂ) + Complex.I * (ω v w : ℂ) := rfl


### PR DESCRIPTION
This PR packages the real metric `g(v, w) = ω(v, J w)` and the symplectic form of a compatible pair `(ω, J)` into a single complex Hermitian inner product `h(v, w) = g(v, w) + i ω(v, w) = ω(v, J w) + i ω(v, w)` on the complex vector space `(V, J)`, and exhibits it as an `InnerProductSpace.Core ℂ V` for the `J`-induced complex structure. It adds `TauCeti.SymplecticForm.hermitianForm` together with the facts that its real and imaginary parts recover the metric and the symplectic form (`hermitianForm_re`, `hermitianForm_im`), that it is conjugate-symmetric (`Compatible.hermitianForm_conj_symm`), complex linear in its second argument over `J.complexModule` (`hermitianForm_smul_right`, which needs only `J² = -1`), conjugate linear in its first argument (`Compatible.hermitianForm_smul_left`), and positive definite (`Compatible.hermitianForm_self`, `hermitianForm_self_re_pos`, `hermitianForm_self_eq_zero`), with the capstone `Compatible.hermitianCore`. This is the classical statement that a compatible triple `(ω, J, g)` is the same data as a Hermitian structure.

This advances `TauCetiRoadmap/HeegaardFloer/README.md`, Lane F2.1 ("Definitions land immediately ... almost complex structures, tame/compatible `J`, symplectic manifolds, `J`-holomorphic maps, energy"), as the complex companion of the real metric core `TauCeti.SymplecticForm.Compatible.innerProductCore` already in `CompatibleMetric.lean`: where that records the metric `g` as an `InnerProductSpace.Core ℝ V`, this records the full Hermitian form `g + i ω` as an `InnerProductSpace.Core ℂ V`. It builds on the existing pointwise layer under `TauCeti/Geometry/Symplectic/`: the compatible-pair API of `AlmostComplex.lean` and `CompatibleMetric.lean` (`Invariant`, `Compatible`, `associatedBilinForm`, `associatedBilinForm_apply_swap`, `symplecticForm_apply_apply_self_nonneg`, `associatedBilinForm_self_eq_zero`) and the `J`-induced complex structure `AlmostComplexStructure.complexModule` of `ComplexModule.lean`. The conventions follow McDuff--Salamon, *J-holomorphic Curves and Symplectic Topology*, Section 2.1, where a compatible pair `(ω, J)` gives the Hermitian form `⟨v, w⟩ = g(v, w) + i ω(v, w)`. The only Mathlib infrastructure reused is `InnerProductSpace.Core` and the `Complex` real/imaginary-part calculus; no code is vendored.

Local verification against the pinned toolchain (`v4.32.0-rc1`): `lake exe cache get` succeeded, full `lake build` is green (`Build completed successfully (4121 jobs).`), and `lake exe axioms` is clean (`axioms: audited 4239 TauCeti declaration(s); all within the allowlist [propext, Classical.choice, Quot.sound].`).

<!--tauceti-target:v1 {"focus":"HeegaardFloer","id":"compatible-hermitian-inner-product"}-->

🤖 Prepared with Claude Code
