### PR TITLE
chore: regenerate the lines-of-code charts daily

### DIFF
--- a/.github/workflows/loc-graph.yml
+++ b/.github/workflows/loc-graph.yml
@@ -1,6 +1,6 @@
 name: LoC graphs
 
-# Weekly: regenerate the "lines of code by date" charts shown on the website's
+# Daily: regenerate the "lines of code by date" charts shown on the website's
 # Statistics page, and commit them if they changed. The commit touches web/**,
 # which triggers pages.yml to redeploy the site.
 #
@@ -15,7 +15,7 @@ name: LoC graphs
 
 on:
   schedule:
-    - cron: "0 6 * * 1"   # Mondays 06:00 UTC
+    - cron: "0 6 * * *"   # Daily 06:00 UTC
   workflow_dispatch:
 
 concurrency:


### PR DESCRIPTION
This PR changes the LoC graphs workflow from a weekly schedule (Mondays 06:00 UTC) to a daily one (06:00 UTC), so the Statistics page charts stay current without waiting up to a week. The charts are rebuilt from scratch from git history each run, so daily regeneration carries no extra state.

🤖 Prepared with Claude Code