### PR TITLE
chore: cap new files at 1000 lines, let existing files grow to 1500

### DIFF
--- a/.github/workflows/pr-build.yml
+++ b/.github/workflows/pr-build.yml
@@ -162,6 +162,25 @@ jobs:
             exit 1
           fi
 
+      - name: New-file length guard — newly added .lean files must be ≤ 1000 lines
+        # A brand-new file may be at most 1000 lines; an existing file may grow up to the
+        # in-build linter ceiling of 1500 (set in lakefile.toml). The split keeps new material
+        # small and reviewable while not blocking incremental growth of established files.
+        # PR-only, like the diff-size guard: new files enter the library through a PR, and a
+        # merge_group batch is the sum of already-guarded PRs. For an *added* file the GitHub
+        # diff lists every line as an addition, so `.additions` is its line count.
+        if: ${{ github.event_name != 'merge_group' }}
+        env: { GH_TOKEN: "${{ github.token }}" }
+        run: |
+          long=$(gh api --paginate "repos/${{ github.repository }}/pulls/${{ steps.pr.outputs.num }}/files" \
+            --jq '.[] | select(.status == "added" and (.filename | endswith(".lean")) and .additions > 1000)
+                      | "\(.filename) (\(.additions) lines)"')
+          if [ -n "$long" ]; then
+            echo "NEWFILE_TOO_LONG=1" >> "$GITHUB_ENV"
+            echo "::error::New .lean files must be at most 1000 lines; these exceed it. Split them, or grow an existing file (allowed up to 1500):"
+            echo "$long"
+          fi
+
       - name: Checkout base (trusted)
         if: ${{ env.INFRA != '1' }}
         uses: actions/checkout@v4
@@ -392,6 +411,8 @@ jobs:
             state=failure; desc="diff exceeds 2000 added/removed lines or 2000 files — split into smaller PRs to keep review manageable"
           elif [ "${{ env.DIFF_UNKNOWN }}" = "1" ]; then
             state=failure; desc="could not read PR diff totals from the GitHub API — re-run pr-build"
+          elif [ "${{ env.NEWFILE_TOO_LONG }}" = "1" ]; then
+            state=failure; desc="a newly added .lean file exceeds 1000 lines — split it (existing files may grow to 1500)"
           elif [ "${{ steps.build.outcome }}" = "success" ]; then
             state=success; desc="sandboxed build + axiom audit passed (trusted config)"
           else

--- a/lakefile.toml
+++ b/lakefile.toml
@@ -17,7 +17,12 @@ rev = "master"
 [[lean_lib]]
 name = "TauCeti"
 globs = ["TauCeti.*"]
-leanOptions = { weak.linter.mathlibStandardSet = true, weak.linter.style.longFile = 1000, weak.linter.style.longFileDefValue = 1000, weak.linter.style.header = false, warningAsError = true }
+# `longFile = 1500` is the hard ceiling the in-build linter enforces for every file. A
+# *newly added* file is held to a tighter 1000-line limit by the "New-file length guard" in
+# `.github/workflows/pr-build.yml`; only files that already exist may grow up to 1500. Both
+# `longFile` and `longFileDefValue` must be set to the same value, or the linter nags to
+# remove a `set_option` on every short file (fatal under `warningAsError`).
+leanOptions = { weak.linter.mathlibStandardSet = true, weak.linter.style.longFile = 1500, weak.linter.style.longFileDefValue = 1500, weak.linter.style.header = false, warningAsError = true }
 
 
 # Human-owned governance: the axiom-allowlist audit (`lake exe axioms`). Inspects the


### PR DESCRIPTION
This PR splits the file-length policy by file age. It raises the in-build `longFile` linter ceiling to 1500 (in `lakefile.toml`) so an *existing* file may grow up to that length, and adds a "New-file length guard" to the sandboxed PR build (`.github/workflows/pr-build.yml`) that holds any newly **added** `.lean` file to 1000 lines. New material stays small and reviewable, while established files are not blocked from incremental growth.

The guard reads the trusted GitHub diff: for an added file every line is an addition, so its `.additions` count is its length. It is PR-only, mirroring the diff-size guard, and reports through the existing `build` commit status.

A later change can automatically open issues to split the files that land in the 1001-1500 range; that is out of scope here.

Because it touches `.github/` and the lakefile, it needs a human review and merge.

🤖 Prepared with Claude Code