### PR TITLE
feat: opt 41 more modules into the Lean module system

### DIFF
--- a/TauCeti/Algebra/AlgebraicGroup/AdditiveGroup.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/AdditiveGroup.lean
@@ -2,8 +2,10 @@
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 -/
-import TauCeti.Algebra.AlgebraicGroup.FunctorOfPoints
-import TauCeti.Algebra.HopfAlgebra.SymmetricAlgebra
+module
+
+public import TauCeti.Algebra.AlgebraicGroup.FunctorOfPoints
+public import TauCeti.Algebra.HopfAlgebra.SymmetricAlgebra
 
 /-!
 # The additive group
@@ -35,6 +37,8 @@ The symmetric-algebra Hopf structure is supplied by
 bialgebra and convolution monoid APIs.
 -/
 
+public section
+
 open Coalgebra HopfAlgebra SymmetricAlgebra WithConv
 open scoped TensorProduct
 
@@ -54,7 +58,7 @@ variable {B : Type*} [CommSemiring B] [Algebra R B]
 the convolution monoid of `R`-algebra maps out of `SymmetricAlgebra R M` is the additive monoid
 of `R`-linear maps `M →ₗ[R] A`: a point `F` corresponds to the linear map `x ↦ F (ι x)`, and
 convolution of points corresponds to addition of linear maps. -/
-noncomputable def pointsMulEquiv :
+@[expose] noncomputable def pointsMulEquiv :
     WithConv (SymmetricAlgebra R M →ₐ[R] A) ≃* Multiplicative (M →ₗ[R] A) where
   toFun F := Multiplicative.ofAdd (SymmetricAlgebra.lift.symm F.ofConv)
   invFun φ := toConv (SymmetricAlgebra.lift (Multiplicative.toAdd φ))

--- a/TauCeti/Algebra/AlgebraicGroup/BaseChange.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/BaseChange.lean
@@ -2,9 +2,11 @@
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 -/
-import TauCeti.Algebra.AlgebraicGroup.FunctorOfPoints
-import TauCeti.Algebra.HopfAlgebra
-import Mathlib.RingTheory.Bialgebra.TensorProduct
+module
+
+public import TauCeti.Algebra.AlgebraicGroup.FunctorOfPoints
+public import TauCeti.Algebra.HopfAlgebra
+public import Mathlib.RingTheory.Bialgebra.TensorProduct
 
 /-!
 # Base change of bialgebra points
@@ -35,6 +37,8 @@ The tensor-product bialgebra and Hopf-algebra structures and algebra base-change
 used here are from Mathlib, respectively `Mathlib.RingTheory.Bialgebra.TensorProduct`,
 `Mathlib.RingTheory.HopfAlgebra.TensorProduct`, and `AlgHom.liftEquiv`.
 -/
+
+public section
 
 open Coalgebra HopfAlgebra TensorProduct WithConv
 
@@ -77,7 +81,7 @@ private lemma liftEquiv_map_mul
 
 The forward direction sends `f : A →ₐ[k] R` to `s ⊗ a ↦ s • f a`; the inverse restricts a
 `K`-algebra map `K ⊗[k] A →ₐ[K] R` along `a ↦ 1 ⊗ a`. -/
-noncomputable def baseChangePointsMulEquiv :
+@[expose] noncomputable def baseChangePointsMulEquiv :
     WithConv (A →ₐ[k] R) ≃* WithConv (K ⊗[k] A →ₐ[K] R) :=
   { WithConv.congr (AlgHom.liftEquiv k K A R) with
   map_mul' f g := by

--- a/TauCeti/Algebra/AlgebraicGroup/BaseChangeNaturality.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/BaseChangeNaturality.lean
@@ -2,8 +2,10 @@
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 -/
-import TauCeti.Algebra.AlgebraicGroup.BaseChange
-import TauCeti.Algebra.AlgebraicGroup.HopfMap
+module
+
+public import TauCeti.Algebra.AlgebraicGroup.BaseChange
+public import TauCeti.Algebra.AlgebraicGroup.HopfMap
 
 /-!
 # Naturality of base-changed points
@@ -33,6 +35,8 @@ This builds on Mathlib's tensor-product bialgebra map
 `TauCeti.Algebra.AlgebraicGroup.BaseChange` and
 `TauCeti.Algebra.AlgebraicGroup.HopfMap`.
 -/
+
+public section
 
 open TensorProduct WithConv
 

--- a/TauCeti/Algebra/AlgebraicGroup/DiagonalizableGroup.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/DiagonalizableGroup.lean
@@ -2,9 +2,11 @@
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 -/
-import Mathlib.RingTheory.HopfAlgebra.MonoidAlgebra
-import TauCeti.Algebra.AlgebraicGroup.FunctorOfPoints
-import TauCeti.Algebra.AlgebraicGroup.MultiplicativeGroup
+module
+
+public import Mathlib.RingTheory.HopfAlgebra.MonoidAlgebra
+public import TauCeti.Algebra.AlgebraicGroup.FunctorOfPoints
+public import TauCeti.Algebra.AlgebraicGroup.MultiplicativeGroup
 
 /-!
 # The diagonalizable group and its character functor of points
@@ -55,6 +57,8 @@ Yaël Dillies, Michał Mrugała and Yunzhou Xie. This realizes the diagonalizabl
 example of the Tau Ceti reductive-groups roadmap (Layer 4 and Layer 0).
 -/
 
+public section
+
 open WithConv
 open scoped TensorProduct
 
@@ -70,7 +74,7 @@ variable [CommSemiring R] [CommSemiring A] [Algebra R A] [CommGroup G]
 /-- The `R[G]`-point of the diagonalizable group `D(G)` corresponding to a character of `G`.
 It is the algebra map extending `χ` via the universal property of the group algebra; it sends
 `single g r` to `r • χ g`. -/
-noncomputable def point (χ : G →* Aˣ) : MonoidAlgebra R G →ₐ[R] A :=
+@[expose] noncomputable def point (χ : G →* Aˣ) : MonoidAlgebra R G →ₐ[R] A :=
   MonoidAlgebra.lift R A G ((Units.coeHom A).comp χ)
 
 /-- The point associated to a character sends `single g r` to `r • χ g`. -/
@@ -90,7 +94,7 @@ theorem point_single_one (χ : G →* Aˣ) (g : G) :
 `f (single g 1)` of `A`, whose inverse is `f (single g⁻¹ 1)`. It is the monoid hom
 `(MonoidAlgebra.lift R A G).symm f : G →* A` made unit-valued through `MonoidHom.toHomUnits`,
 using that `G` is a group. -/
-noncomputable def charOfPoint (f : MonoidAlgebra R G →ₐ[R] A) : G →* Aˣ :=
+@[expose] noncomputable def charOfPoint (f : MonoidAlgebra R G →ₐ[R] A) : G →* Aˣ :=
   ((MonoidAlgebra.lift R A G).symm f).toHomUnits
 
 /-- The character read off from a point sends `g` to the value of the point on `single g 1`. -/
@@ -122,7 +126,7 @@ theorem point_charOfPoint (f : MonoidAlgebra R G →ₐ[R] A) :
   rw [point_single_one, charOfPoint_apply_coe]
 
 /-- Algebra maps out of `R[G]` are the same as characters `G →* Aˣ` of `G`. -/
-noncomputable def pointEquiv : (MonoidAlgebra R G →ₐ[R] A) ≃ (G →* Aˣ) :=
+@[expose] noncomputable def pointEquiv : (MonoidAlgebra R G →ₐ[R] A) ≃ (G →* Aˣ) :=
   (MonoidAlgebra.lift R A G).symm.trans MonoidHom.toHomUnitsMulEquiv.toEquiv
 
 /-- The equivalence sends a point to the character read off from it. -/
@@ -179,7 +183,7 @@ theorem charOfPoint_mapValue (φ : A →ₐ[R] B)
 
 The source is the convolution group of `R`-algebra maps out of `R[G]`; the target is the
 group of characters of `G` valued in the units of `A`, under pointwise multiplication. -/
-noncomputable def pointsMulEquiv : WithConv (MonoidAlgebra R G →ₐ[R] A) ≃* (G →* Aˣ) where
+@[expose] noncomputable def pointsMulEquiv : WithConv (MonoidAlgebra R G →ₐ[R] A) ≃* (G →* Aˣ) where
   toFun f := charOfPoint f.ofConv
   invFun χ := toConv (point (R := R) χ)
   left_inv f := congrArg toConv (point_charOfPoint f.ofConv)

--- a/TauCeti/Algebra/AlgebraicGroup/DiagonalizableGroupBaseChange.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/DiagonalizableGroupBaseChange.lean
@@ -2,8 +2,10 @@
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 -/
-import TauCeti.Algebra.AlgebraicGroup.BaseChangeNaturality
-import TauCeti.Algebra.AlgebraicGroup.DiagonalizableGroupFunctoriality
+module
+
+public import TauCeti.Algebra.AlgebraicGroup.BaseChangeNaturality
+public import TauCeti.Algebra.AlgebraicGroup.DiagonalizableGroupFunctoriality
 
 /-!
 # Base change of diagonalizable-group points
@@ -46,6 +48,8 @@ diagonalizable-group points calculation are Tau Ceti's
 `TauCeti.DiagonalizableGroup.pointsMulEquiv`.
 -/
 
+public section
+
 open WithConv
 open scoped TensorProduct
 
@@ -65,7 +69,7 @@ the character group `G →* Aˣ`.
 
 The source is the convolution group of `K`-algebra maps out of the base-changed Hopf algebra.
 The target is the ordinary pointwise-multiplication group of characters. -/
-noncomputable def baseChangePointsMulEquiv :
+@[expose] noncomputable def baseChangePointsMulEquiv :
     WithConv (K ⊗[k] MonoidAlgebra k G →ₐ[K] A) ≃* (G →* Aˣ) :=
   (AlgHom.baseChangePointsMulEquiv (k := k) (K := K)
       (A := MonoidAlgebra k G) (R := A)).symm.trans

--- a/TauCeti/Algebra/AlgebraicGroup/DiagonalizableGroupFunctoriality.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/DiagonalizableGroupFunctoriality.lean
@@ -2,9 +2,11 @@
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 -/
-import Mathlib.RingTheory.Bialgebra.MonoidAlgebra
-import TauCeti.Algebra.AlgebraicGroup.DiagonalizableGroup
-import TauCeti.Algebra.AlgebraicGroup.HopfMap
+module
+
+public import Mathlib.RingTheory.Bialgebra.MonoidAlgebra
+public import TauCeti.Algebra.AlgebraicGroup.DiagonalizableGroup
+public import TauCeti.Algebra.AlgebraicGroup.HopfMap
 
 /-!
 # Functoriality of the diagonalizable group in the abelian group
@@ -51,6 +53,8 @@ coordinate Hopf algebra is Tau Ceti's `TauCeti.AlgHom.mapDomain`
 functoriality of the Tau Ceti reductive-groups roadmap (Layer 4).
 -/
 
+public section
+
 open WithConv
 
 namespace TauCeti
@@ -72,7 +76,7 @@ private theorem mapDomainBialgHom_single_one (φ : G →* G') (g : G) :
 /-- **The diagonalizable group is contravariant in the abelian group.** A group homomorphism
 `φ : G →* G'` induces, by pre-composition with the bialgebra map `R[G] →ₐc[R] R[G']`, a
 homomorphism of convolution groups of points `D(G')(A) → D(G)(A)`. -/
-noncomputable def pointsMap (φ : G →* G') :
+@[expose] noncomputable def pointsMap (φ : G →* G') :
     WithConv (MonoidAlgebra R G' →ₐ[R] A) →* WithConv (MonoidAlgebra R G →ₐ[R] A) :=
   AlgHom.mapDomain (MonoidAlgebra.mapDomainBialgHom R φ)
 

--- a/TauCeti/Algebra/AlgebraicGroup/GroupAlgebraNotReduced.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/GroupAlgebraNotReduced.lean
@@ -2,11 +2,13 @@
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 -/
-import Mathlib.Algebra.CharP.Algebra
-import Mathlib.Algebra.CharP.Lemmas
-import Mathlib.Algebra.MonoidAlgebra.Module
-import Mathlib.RingTheory.Nilpotent.Basic
-import TauCeti.Algebra.AlgebraicGroup.RootsOfUnity
+module
+
+public import Mathlib.Algebra.CharP.Algebra
+public import Mathlib.Algebra.CharP.Lemmas
+public import Mathlib.Algebra.MonoidAlgebra.Module
+public import Mathlib.RingTheory.Nilpotent.Basic
+public import TauCeti.Algebra.AlgebraicGroup.RootsOfUnity
 
 /-!
 # The coordinate ring of a diagonalizable group is non-reduced in the presence of `p`-torsion
@@ -56,6 +58,8 @@ The characteristic of the group algebra is transported from that of `R` along th
 roots-of-unity group `μ_n = D(ℤ/n)` and its standard generator are Tau Ceti's
 `TauCeti.RootsOfUnityGroup`.
 -/
+
+public section
 
 namespace TauCeti
 

--- a/TauCeti/Algebra/AlgebraicGroup/HopfMap.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/HopfMap.lean
@@ -2,9 +2,11 @@
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 -/
-import Mathlib.RingTheory.Bialgebra.Equiv
-import Mathlib.RingTheory.TensorProduct.Maps
-import TauCeti.Algebra.AlgebraicGroup.FunctorOfPoints
+module
+
+public import Mathlib.RingTheory.Bialgebra.Equiv
+public import Mathlib.RingTheory.TensorProduct.Maps
+public import TauCeti.Algebra.AlgebraicGroup.FunctorOfPoints
 
 /-!
 # Functoriality in the coordinate Hopf algebra
@@ -35,6 +37,8 @@ The convolution-preservation proof is the bialgebra-morphism version of Mathlib'
 `AlgHom.convMul_comp_bialgHom_distrib`, from `Mathlib.RingTheory.Bialgebra.Convolution`.
 -/
 
+public section
+
 open WithConv
 
 namespace TauCeti
@@ -58,7 +62,7 @@ private lemma convMul_comp_bialgHom_distrib_of_semiring_source
 /-- Contravariant functoriality of convolution algebra homomorphisms in the source
 bialgebra. A bialgebra morphism `φ : H₁ →ₐc[R] H₂` sends an `A`-valued point of `H₂` to an
 `A`-valued point of `H₁` by pre-composition. -/
-noncomputable def mapDomain (φ : H₁ →ₐc[R] H₂) :
+@[expose] noncomputable def mapDomain (φ : H₁ →ₐc[R] H₂) :
     WithConv (H₂ →ₐ[R] A) →* WithConv (H₁ →ₐ[R] A) where
   toFun f := toConv (f.ofConv.comp (φ : H₁ →ₐ[R] H₂))
   map_one' := by
@@ -128,7 +132,7 @@ variable [CommSemiring A] [Algebra R A]
 /-- A bialgebra isomorphism `e : H₁ ≃ₐc[R] H₂` induces a multiplicative equivalence of the
 convolution monoids of points, by pre-composition: the equiv-version of the contravariant
 functoriality `mapDomain`. -/
-noncomputable def mapDomainMulEquiv (e : H₁ ≃ₐc[R] H₂) :
+@[expose] noncomputable def mapDomainMulEquiv (e : H₁ ≃ₐc[R] H₂) :
     WithConv (H₂ →ₐ[R] A) ≃* WithConv (H₁ →ₐ[R] A) where
   toFun := mapDomain (A := A) (e : H₁ →ₐc[R] H₂)
   invFun := mapDomain (A := A) (e.symm : H₂ →ₐc[R] H₁)

--- a/TauCeti/Algebra/AlgebraicGroup/MultiplicativeGroup.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/MultiplicativeGroup.lean
@@ -2,8 +2,10 @@
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 -/
-import Mathlib.RingTheory.HopfAlgebra.MonoidAlgebra
-import TauCeti.Algebra.AlgebraicGroup.FunctorOfPoints
+module
+
+public import Mathlib.RingTheory.HopfAlgebra.MonoidAlgebra
+public import TauCeti.Algebra.AlgebraicGroup.FunctorOfPoints
 
 /-!
 # The multiplicative group example
@@ -34,6 +36,8 @@ The Hopf algebra structure and Laurent polynomial evaluation API are from Mathli
 building on Amelia Livingston's monoid-algebra Hopf algebra formalization.
 -/
 
+public section
+
 open WithConv
 open scoped LaurentPolynomial
 
@@ -48,7 +52,7 @@ variable [CommSemiring R] [CommSemiring A] [Algebra R A]
 
 /-- The `R[T;T⁻¹]`-point of the multiplicative group corresponding to a unit of the value
 algebra. It sends `T n` to `u ^ n`. -/
-noncomputable def point (u : Aˣ) : R[T;T⁻¹] →ₐ[R] A :=
+@[expose] noncomputable def point (u : Aˣ) : R[T;T⁻¹] →ₐ[R] A :=
   { LaurentPolynomial.eval₂ (algebraMap R A) u with
     commutes' := LaurentPolynomial.eval₂_C (algebraMap R A) u }
 
@@ -65,7 +69,7 @@ theorem point_C (u : Aˣ) (r : R) :
   LaurentPolynomial.eval₂_C (algebraMap R A) u r
 
 /-- The unit of `A` obtained by evaluating an `R[T;T⁻¹]`-point at `T`. -/
-noncomputable def unitOfPoint (f : R[T;T⁻¹] →ₐ[R] A) : Aˣ where
+@[expose] noncomputable def unitOfPoint (f : R[T;T⁻¹] →ₐ[R] A) : Aˣ where
   val := f (LaurentPolynomial.T 1)
   inv := f (LaurentPolynomial.T (-1))
   val_inv := by
@@ -120,7 +124,7 @@ theorem point_unitOfPoint (f : R[T;T⁻¹] →ₐ[R] A) :
   exact point_unitOfPoint_single (R := R) (A := A) f n
 
 /-- Algebra maps out of `R[T;T⁻¹]` are the same as units of the value algebra. -/
-noncomputable def pointEquiv : (R[T;T⁻¹] →ₐ[R] A) ≃ Aˣ where
+@[expose] noncomputable def pointEquiv : (R[T;T⁻¹] →ₐ[R] A) ≃ Aˣ where
   toFun := unitOfPoint
   invFun := point (R := R) (A := A)
   left_inv := point_unitOfPoint
@@ -139,7 +143,7 @@ theorem pointEquiv_symm_apply (u : Aˣ) :
   rfl
 
 /-- Evaluating a product of convolution points at `T` multiplies their values at `T`. -/
-private theorem unitOfPoint_mul (f g : WithConv (R[T;T⁻¹] →ₐ[R] A)) :
+theorem unitOfPoint_mul (f g : WithConv (R[T;T⁻¹] →ₐ[R] A)) :
     unitOfPoint ((f * g).ofConv) = unitOfPoint f.ofConv * unitOfPoint g.ofConv := by
   ext
   rw [unitOfPoint_val, Units.val_mul]
@@ -151,7 +155,7 @@ private theorem unitOfPoint_mul (f g : WithConv (R[T;T⁻¹] →ₐ[R] A)) :
 
 The source is the convolution group of `R`-algebra maps out of `R[T;T⁻¹]`; the target is the
 ordinary unit group of `A`. -/
-noncomputable def pointsMulEquiv : WithConv (R[T;T⁻¹] →ₐ[R] A) ≃* Aˣ where
+@[expose] noncomputable def pointsMulEquiv : WithConv (R[T;T⁻¹] →ₐ[R] A) ≃* Aˣ where
   toFun f := unitOfPoint f.ofConv
   invFun u := toConv (point (R := R) (A := A) u)
   left_inv f := by

--- a/TauCeti/Algebra/AlgebraicGroup/RootsOfUnity.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/RootsOfUnity.lean
@@ -2,9 +2,11 @@
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 -/
-import Mathlib.RingTheory.RootsOfUnity.Basic
-import Mathlib.SetTheory.Cardinal.Finite
-import TauCeti.Algebra.AlgebraicGroup.DiagonalizableGroup
+module
+
+public import Mathlib.RingTheory.RootsOfUnity.Basic
+public import Mathlib.SetTheory.Cardinal.Finite
+public import TauCeti.Algebra.AlgebraicGroup.DiagonalizableGroup
 
 /-!
 # The roots-of-unity group scheme
@@ -38,6 +40,8 @@ The diagonalizable-group points calculation is Tau Ceti's
 `IsCyclic.monoidHomMulEquivRootsOfUnityOfGenerator`, from
 `Mathlib.RingTheory.RootsOfUnity.Basic`.
 -/
+
+public section
 
 open WithConv
 

--- a/TauCeti/Algebra/AlgebraicGroup/SplitTorus.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/SplitTorus.lean
@@ -2,8 +2,10 @@
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 -/
-import TauCeti.Algebra.AlgebraicGroup.DiagonalizableGroup
-import TauCeti.Algebra.Group.FreeAbelianCharacter
+module
+
+public import TauCeti.Algebra.AlgebraicGroup.DiagonalizableGroup
+public import TauCeti.Algebra.Group.FreeAbelianCharacter
 
 /-!
 # The split torus and its functor of points
@@ -46,6 +48,8 @@ The diagonalizable-group points calculation is Tau Ceti's
 `DiagonalizableGroup.pointsMulEquiv`; the free-abelian-group character identification is
 `TauCeti.freeAbelianCharEquiv`, which reuses Mathlib's `Finsupp.liftAddHom` and `zmultiplesHom`.
 -/
+
+public section
 
 open WithConv
 

--- a/TauCeti/Algebra/Coalgebra/Subcoalgebra/GroupLike.lean
+++ b/TauCeti/Algebra/Coalgebra/Subcoalgebra/GroupLike.lean
@@ -2,9 +2,11 @@
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 -/
-import Mathlib.RingTheory.Coalgebra.GroupLike
-import Mathlib.RingTheory.Finiteness.Basic
-import TauCeti.Algebra.Coalgebra.Subcoalgebra
+module
+
+public import Mathlib.RingTheory.Coalgebra.GroupLike
+public import Mathlib.RingTheory.Finiteness.Basic
+public import TauCeti.Algebra.Coalgebra.Subcoalgebra
 
 /-!
 # Subcoalgebras spanned by group-like elements
@@ -18,6 +20,8 @@ singleton span, a finite-generation theorem for finite sets of group-like elemen
 This file uses the `GroupLike` and `IsGroupLikeElem` API from
 `Mathlib.RingTheory.Coalgebra.GroupLike`, by Yaël Dillies and Michał Mrugała.
 -/
+
+public section
 
 open scoped TensorProduct
 
@@ -33,7 +37,7 @@ namespace Subcoalgebra
 variable {R C}
 
 /-- The subcoalgebra spanned by a set of group-like elements. -/
-def groupLikeSetSpan (s : Set (GroupLike R C)) : Subcoalgebra R C :=
+@[expose] def groupLikeSetSpan (s : Set (GroupLike R C)) : Subcoalgebra R C :=
   let D := Submodule.span R ((↑) '' s : Set C)
   { carrier := D
     comul_mem' := by

--- a/TauCeti/Algebra/Coalgebra/Subcoalgebra/Map.lean
+++ b/TauCeti/Algebra/Coalgebra/Subcoalgebra/Map.lean
@@ -2,9 +2,11 @@
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 -/
-import Mathlib.RingTheory.Coalgebra.Hom
-import Mathlib.RingTheory.Finiteness.Basic
-import TauCeti.Algebra.Coalgebra.Subcoalgebra.Lattice
+module
+
+public import Mathlib.RingTheory.Coalgebra.Hom
+public import Mathlib.RingTheory.Finiteness.Basic
+public import TauCeti.Algebra.Coalgebra.Subcoalgebra.Lattice
 
 /-!
 # Images of subcoalgebras
@@ -27,6 +29,8 @@ subcoalgebras need to be movable along maps of coordinate coalgebras.
 This uses the standard fact that a coalgebra morphism preserves comultiplication, so the
 image of a subcoalgebra is again a subcoalgebra. See Sweedler, *Hopf Algebras*, Chapter 2.
 -/
+
+public section
 
 open scoped TensorProduct
 
@@ -61,7 +65,7 @@ private theorem image_tensorSquare_apply (f : C →ₗc[R] D) (A : Subcoalgebra 
   | add x y hx hy => simp only [map_add, hx, hy]
 
 /-- The image of a subcoalgebra under a coalgebra morphism. -/
-def map (f : C →ₗc[R] D) (A : Subcoalgebra R C) : Subcoalgebra R D where
+@[expose] def map (f : C →ₗc[R] D) (A : Subcoalgebra R C) : Subcoalgebra R D where
   carrier := A.carrier.map f.toLinearMap
   comul_mem' := by
     rintro d hd

--- a/TauCeti/Algebra/Group/FreeAbelianCharacter.lean
+++ b/TauCeti/Algebra/Group/FreeAbelianCharacter.lean
@@ -2,9 +2,11 @@
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 -/
-import Mathlib.Algebra.BigOperators.Finsupp.Basic
-import Mathlib.Algebra.Group.TypeTags.Hom
-import Mathlib.Data.Int.Cast.Lemmas
+module
+
+public import Mathlib.Algebra.BigOperators.Finsupp.Basic
+public import Mathlib.Algebra.Group.TypeTags.Hom
+public import Mathlib.Data.Int.Cast.Lemmas
 
 /-!
 # Characters of a free abelian group
@@ -41,6 +43,8 @@ chain of isomorphisms so that the forward map is *definitionally* generator eval
 evaluation through the composite transport maps and lose that defeq.
 -/
 
+public section
+
 namespace TauCeti
 
 variable {σ : Type*} {M : Type*} [CommGroup M]
@@ -49,7 +53,7 @@ variable {σ : Type*} {M : Type*} [CommGroup M]
 to a commutative group `M` is the same data as a family `σ → M`. The forward map reads off the
 values on the standard generators `ofAdd (single i 1)`; the inverse extends a family to the
 unique homomorphism through `Finsupp.liftAddHom` and the `ℤ`-power homomorphism. -/
-noncomputable def freeAbelianCharEquiv :
+@[expose] noncomputable def freeAbelianCharEquiv :
     (Multiplicative (σ →₀ ℤ) →* M) ≃* (σ → M) where
   toFun χ i := χ (Multiplicative.ofAdd (Finsupp.single i 1))
   invFun c := AddMonoidHom.toMultiplicativeLeft

--- a/TauCeti/Algebra/HopfAlgebra/Kernel.lean
+++ b/TauCeti/Algebra/HopfAlgebra/Kernel.lean
@@ -2,10 +2,12 @@
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 -/
-import Mathlib.LinearAlgebra.TensorProduct.RightExactness
-import TauCeti.Algebra.HopfAlgebra
-import TauCeti.Algebra.HopfAlgebra.HopfIdeal
-import TauCeti.Algebra.HopfAlgebra.Quotient
+module
+
+public import Mathlib.LinearAlgebra.TensorProduct.RightExactness
+public import TauCeti.Algebra.HopfAlgebra
+public import TauCeti.Algebra.HopfAlgebra.HopfIdeal
+public import TauCeti.Algebra.HopfAlgebra.Quotient
 
 /-!
 # Kernels of Hopf algebra morphisms
@@ -34,6 +36,8 @@ dictionary.
 The construction is the standard kernel Hopf ideal. The tensor-kernel exactness step uses
 Mathlib's `Algebra.TensorProduct.map_ker`.
 -/
+
+public section
 
 open scoped TensorProduct
 
@@ -77,7 +81,7 @@ private theorem tensor_map_ker_eq_left_sup_right (f : H →ₐc[R] K)
   apply congr_arg₂ (· ⊔ ·) <;> rfl
 
 /-- The kernel of a surjective bialgebra morphism, as a Hopf ideal. -/
-def ker (f : H →ₐc[R] K) (hf : Function.Surjective f) : HopfIdeal R H :=
+@[expose] def ker (f : H →ₐc[R] K) (hf : Function.Surjective f) : HopfIdeal R H :=
   ofIdeal (RingHom.ker (f : H →ₐ[R] K))
     (by
       intro x hx
@@ -128,7 +132,7 @@ theorem ker_eq_bot_iff (f : H →ₐc[R] K) (hf : Function.Surjective f) :
 
 /-- The bialgebra morphism induced from a surjective morphism on the quotient by its
 Hopf-ideal kernel. -/
-noncomputable def kerLiftBialgHom (f : H →ₐc[R] K) (hf : Function.Surjective f) :
+@[expose] noncomputable def kerLiftBialgHom (f : H →ₐc[R] K) (hf : Function.Surjective f) :
     H ⧸ (ker f hf).toIdeal →ₐc[R] K :=
   liftBialgHom (ker f hf) f (by
     intro x hx
@@ -152,7 +156,7 @@ theorem kerLiftBialgHom_comp_mkBialgHom (f : H →ₐc[R] K) (hf : Function.Surj
 
 /-- The quotient by the Hopf-ideal kernel of a surjective morphism maps bijectively to the
 codomain. -/
-private theorem kerLiftBialgHom_bijective (f : H →ₐc[R] K) (hf : Function.Surjective f) :
+theorem kerLiftBialgHom_bijective (f : H →ₐc[R] K) (hf : Function.Surjective f) :
     Function.Bijective (kerLiftBialgHom f hf) := by
   have hfun : (kerLiftBialgHom f hf : H ⧸ (ker f hf).toIdeal → K) =
       (Ideal.quotientKerAlgEquivOfSurjective (f := (f : H →ₐ[R] K)) hf :
@@ -166,7 +170,7 @@ private theorem kerLiftBialgHom_bijective (f : H →ₐc[R] K) (hf : Function.Su
 
 /-- The quotient by the Hopf-ideal kernel of a surjective morphism is bialgebra-equivalent to
 the codomain. -/
-noncomputable def kerLiftBialgEquiv (f : H →ₐc[R] K) (hf : Function.Surjective f) :
+@[expose] noncomputable def kerLiftBialgEquiv (f : H →ₐc[R] K) (hf : Function.Surjective f) :
     (H ⧸ (ker f hf).toIdeal) ≃ₐc[R] K :=
   BialgEquiv.ofBijective (kerLiftBialgHom f hf) (kerLiftBialgHom_bijective f hf)
 

--- a/TauCeti/AlgebraicTopology/UniversalCover/Deck.lean
+++ b/TauCeti/AlgebraicTopology/UniversalCover/Deck.lean
@@ -2,8 +2,10 @@
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 -/
-import Mathlib.Topology.Homeomorph.Lemmas
-import TauCeti.Topology.Algebra.HomeomorphAction
+module
+
+public import Mathlib.Topology.Homeomorph.Lemmas
+public import TauCeti.Topology.Algebra.HomeomorphAction
 
 /-!
 # Deck transformations of a map
@@ -24,6 +26,8 @@ This file follows the deck-transformation target in the Tau Ceti universal-cover
 Stage 0.4, and the shape of the construction in Kim Morrison's mathlib4#40135.
 -/
 
+public section
+
 namespace TauCeti
 
 variable {E B : Type*} [TopologicalSpace E] (p : E → B)
@@ -31,7 +35,7 @@ variable {E B : Type*} [TopologicalSpace E] (p : E → B)
 /-- The deck transformations of a map `p : E → B`, as the subgroup of homeomorphisms of `E`
 which commute with `p`. For a covering projection, this is the usual deck transformation
 group. -/
-def Deck : Subgroup (E ≃ₜ E) where
+@[expose] def Deck : Subgroup (E ≃ₜ E) where
   carrier := {φ | ∀ e, p (φ e) = p e}
   one_mem' e := rfl
   mul_mem' hφ hψ e := by
@@ -69,7 +73,7 @@ lemma mapsTo_fiber_symm (φ : Deck p) (b : B) :
 
 /-- A deck transformation restricts to a homeomorphism of every fibre of the projection,
 the restriction of its underlying homeomorphism along `Homeomorph.subtype`. -/
-def fiberHomeomorph (φ : Deck p) (b : B) : p ⁻¹' {b} ≃ₜ p ⁻¹' {b} :=
+@[expose] def fiberHomeomorph (φ : Deck p) (b : B) : p ⁻¹' {b} ≃ₜ p ⁻¹' {b} :=
   φ.1.subtype fun e => by simp [Set.mem_preimage, eq_comm, map_proj]
 
 /-- On points, the fibre homeomorphism induced by a deck transformation is just evaluation

--- a/TauCeti/AlgebraicTopology/UniversalCover/Deck/Conjugation.lean
+++ b/TauCeti/AlgebraicTopology/UniversalCover/Deck/Conjugation.lean
@@ -2,7 +2,9 @@
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 -/
-import TauCeti.AlgebraicTopology.UniversalCover.Deck
+module
+
+public import TauCeti.AlgebraicTopology.UniversalCover.Deck
 
 /-!
 # Conjugating deck transformations
@@ -28,6 +30,8 @@ This file supplies a prerequisite for the Tau Ceti universal-covers roadmap, Sta
 (`Deck p` as the deck transformation group), and the later cover-isomorphism bookkeeping in
 Stage 2.
 -/
+
+public section
 
 namespace TauCeti
 

--- a/TauCeti/AlgebraicTopology/UniversalCover/Deck/Connected.lean
+++ b/TauCeti/AlgebraicTopology/UniversalCover/Deck/Connected.lean
@@ -2,9 +2,11 @@
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 -/
-import Mathlib.GroupTheory.GroupAction.Basic
-import Mathlib.Topology.Covering.Basic
-import TauCeti.AlgebraicTopology.UniversalCover.Deck.Fiber
+module
+
+public import Mathlib.GroupTheory.GroupAction.Basic
+public import Mathlib.Topology.Covering.Basic
+public import TauCeti.AlgebraicTopology.UniversalCover.Deck.Fiber
 
 /-!
 # Deck transformations of connected covers
@@ -25,6 +27,8 @@ connected cover cannot fix a point unless it is the identity.
 * `TauCeti.Deck.deckEquivFiberOfSurjective`: if that evaluation map is also surjective, it
   identifies the deck group with the chosen fibre.
 -/
+
+public section
 
 namespace TauCeti
 
@@ -121,7 +125,7 @@ evaluation at that point identifies the deck group with that fibre.
 
 This is the simply-transitive fibre action package used later when regular covers are
 compared with normal subgroups and normalizer quotients. -/
-noncomputable def deckEquivFiberOfSurjective [PreconnectedSpace E] (hp : IsCoveringMap p)
+@[expose] noncomputable def deckEquivFiberOfSurjective [PreconnectedSpace E] (hp : IsCoveringMap p)
     (e : p ⁻¹' {b}) (hsurj : Function.Surjective fun φ : Deck p => φ • e) :
     Deck p ≃ p ⁻¹' {b} :=
   Equiv.ofBijective (fun φ : Deck p => φ • e)

--- a/TauCeti/AlgebraicTopology/UniversalCover/Deck/Fiber.lean
+++ b/TauCeti/AlgebraicTopology/UniversalCover/Deck/Fiber.lean
@@ -2,7 +2,9 @@
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 -/
-import TauCeti.AlgebraicTopology.UniversalCover.Deck
+module
+
+public import TauCeti.AlgebraicTopology.UniversalCover.Deck
 
 /-!
 # The action of deck transformations on a fibre
@@ -28,6 +30,8 @@ This supplies a prerequisite for the Tau Ceti universal-covers roadmap, Stage 0.
 Stages 1 and 2.
 -/
 
+public section
+
 namespace TauCeti
 
 namespace Deck
@@ -37,7 +41,7 @@ variable {E B : Type*} [TopologicalSpace E] {p : E → B} {b : B}
 /-- The homomorphism from deck transformations to homeomorphisms of the fibre over `b`.
 
 It sends a deck transformation to its restriction to the subtype `p ⁻¹' {b}`. -/
-def fiberHomeomorphHom (p : E → B) (b : B) : Deck p →* (p ⁻¹' {b} ≃ₜ p ⁻¹' {b}) where
+@[expose] def fiberHomeomorphHom (p : E → B) (b : B) : Deck p →* (p ⁻¹' {b} ≃ₜ p ⁻¹' {b}) where
   toFun φ := fiberHomeomorph φ b
   map_one' := by
     ext e

--- a/TauCeti/AlgebraicTopology/UniversalCover/Deck/FiberOrbit.lean
+++ b/TauCeti/AlgebraicTopology/UniversalCover/Deck/FiberOrbit.lean
@@ -2,9 +2,11 @@
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 -/
-import Mathlib.GroupTheory.GroupAction.Basic
-import TauCeti.AlgebraicTopology.UniversalCover.Deck.FiberTransport
-import TauCeti.AlgebraicTopology.UniversalCover.Deck.Regular
+module
+
+public import Mathlib.GroupTheory.GroupAction.Basic
+public import TauCeti.AlgebraicTopology.UniversalCover.Deck.FiberTransport
+public import TauCeti.AlgebraicTopology.UniversalCover.Deck.Regular
 
 /-!
 # Deck orbits on fibres
@@ -38,6 +40,8 @@ the pointed/unpointed connected-cover correspondence records how chosen lifts va
 deck action, and regular covers are exactly those whose deck action is transitive on fibres.
 -/
 
+public section
+
 namespace TauCeti
 
 namespace Deck
@@ -50,7 +54,7 @@ abbrev FiberOrbitQuotient (p : E → B) (b : B) : Type _ :=
   MulAction.orbitRel.Quotient (Deck p) (p ⁻¹' {b})
 
 /-- The deck orbit class of a point in one fibre. -/
-def fiberOrbitClass (e : p ⁻¹' {b}) : FiberOrbitQuotient p b :=
+@[expose] def fiberOrbitClass (e : p ⁻¹' {b}) : FiberOrbitQuotient p b :=
   Quotient.mk'' e
 
 /-- The deck-orbit quotient map sends a fibre point to its own class. -/
@@ -67,7 +71,7 @@ lemma fiberOrbitClass_eq_iff (e e' : p ⁻¹' {b}) :
   rw [fiberOrbitClass_eq_mk, fiberOrbitClass_eq_mk, Quotient.eq'', MulAction.orbitRel_apply]
 
 /-- An over-base homeomorphism identifies deck-orbit quotients of corresponding fibres. -/
-def fiberOrbitQuotientEquiv (h : E ≃ₜ F) (hpq : ∀ e, q (h e) = p e) (b : B) :
+@[expose] def fiberOrbitQuotientEquiv (h : E ≃ₜ F) (hpq : ∀ e, q (h e) = p e) (b : B) :
     FiberOrbitQuotient p b ≃ FiberOrbitQuotient q b :=
   Quotient.congr (fiberMap h hpq b).toEquiv fun e e' => by
     rw [MulAction.orbitRel_apply, MulAction.orbitRel_apply]

--- a/TauCeti/AlgebraicTopology/UniversalCover/Deck/FiberTransport.lean
+++ b/TauCeti/AlgebraicTopology/UniversalCover/Deck/FiberTransport.lean
@@ -2,8 +2,10 @@
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 -/
-import TauCeti.AlgebraicTopology.UniversalCover.Deck.Conjugation
-import TauCeti.AlgebraicTopology.UniversalCover.Deck.Fiber
+module
+
+public import TauCeti.AlgebraicTopology.UniversalCover.Deck.Conjugation
+public import TauCeti.AlgebraicTopology.UniversalCover.Deck.Fiber
 
 /-!
 # Transporting deck actions on fibres
@@ -28,6 +30,8 @@ This supplies a prerequisite for the Tau Ceti universal-covers roadmap, Stage 2
 deck-transformation group.
 -/
 
+public section
+
 namespace TauCeti
 
 namespace Deck
@@ -37,7 +41,7 @@ variable {E F G B : Type*} [TopologicalSpace E] [TopologicalSpace F] [Topologica
 
 /-- An over-base homeomorphism identifies the fibre over `b` for `p` with the fibre over
 `b` for `q`. -/
-def fiberMap (h : E ≃ₜ F) (hpq : ∀ e, q (h e) = p e) (b : B) :
+@[expose] def fiberMap (h : E ≃ₜ F) (hpq : ∀ e, q (h e) = p e) (b : B) :
     p ⁻¹' {b} ≃ₜ q ⁻¹' {b} :=
   h.subtype fun e => by
     simp only [Set.mem_preimage, Set.mem_singleton_iff]

--- a/TauCeti/AlgebraicTopology/UniversalCover/Deck/FundamentalGroup.lean
+++ b/TauCeti/AlgebraicTopology/UniversalCover/Deck/FundamentalGroup.lean
@@ -2,8 +2,10 @@
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 -/
-import TauCeti.AlgebraicTopology.UniversalCover.Deck.QuotientCovering
-import Mathlib.Topology.Homotopy.Lifting
+module
+
+public import TauCeti.AlgebraicTopology.UniversalCover.Deck.QuotientCovering
+public import Mathlib.Topology.Homotopy.Lifting
 
 /-!
 # The fundamental group of the base of a regular cover and its deck group
@@ -54,6 +56,8 @@ The comparison map is Mathlib's `IsQuotientCoveringMap.fundamentalGroupEquiv` (J
 `Mathlib/Topology/Homotopy/Lifting.lean`); the quotient-covering presentation of a regular
 deck action is `TauCeti.Deck.IsRegular.isQuotientCoveringMap`.
 -/
+
+public section
 
 namespace TauCeti
 

--- a/TauCeti/AlgebraicTopology/UniversalCover/Deck/Quotient.lean
+++ b/TauCeti/AlgebraicTopology/UniversalCover/Deck/Quotient.lean
@@ -2,7 +2,9 @@
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 -/
-import TauCeti.AlgebraicTopology.UniversalCover.Deck.Regular
+module
+
+public import TauCeti.AlgebraicTopology.UniversalCover.Deck.Regular
 
 /-!
 # The orbit quotient of a regular deck action
@@ -29,6 +31,8 @@ the regular-cover milestones where fibres are deck orbits and quotient covers ar
 with the original base.
 -/
 
+public section
+
 namespace TauCeti
 
 namespace Deck
@@ -45,7 +49,7 @@ lemma eq_proj_of_orbitRel {e e' : E} (h : MulAction.orbitRel (Deck p) E e e') :
   simpa [smul_eq_apply] using map_proj φ e'
 
 /-- The projection map factors through the quotient of `E` by deck orbits. -/
-def orbitQuotientToBase (p : E → B) : MulAction.orbitRel.Quotient (Deck p) E → B :=
+@[expose] def orbitQuotientToBase (p : E → B) : MulAction.orbitRel.Quotient (Deck p) E → B :=
   Quotient.lift p fun _ _ h => eq_proj_of_orbitRel h
 
 /-- The map from the deck-orbit quotient to the base evaluates on representatives by `p`. -/
@@ -80,7 +84,7 @@ lemma apply_eq_iff_mem_orbit_of_exists_apply_eq
   rw [← MulAction.orbitRel_apply, orbitRel_eq_ker_of_exists_apply_eq hpoint, Setoid.ker_def]
 
 /-- An over-base homeomorphism preserves the corresponding deck-orbit relations. -/
-private lemma orbitRel_homeomorph_iff (h : E ≃ₜ F) (hpq : ∀ e, q (h e) = p e) (e e' : E) :
+lemma orbitRel_homeomorph_iff (h : E ≃ₜ F) (hpq : ∀ e, q (h e) = p e) (e e' : E) :
     MulAction.orbitRel (Deck p) E e e' ↔
       MulAction.orbitRel (Deck q) F (h e) (h e') := by
   constructor
@@ -108,7 +112,7 @@ private lemma orbitRel_homeomorph_iff (h : E ≃ₜ F) (hpq : ∀ e, q (h e) = p
       _ = e := by rw [hψ_apply, h.symm_apply_apply]
 
 /-- An over-base homeomorphism identifies the corresponding deck-orbit quotients. -/
-def orbitQuotientEquiv (h : E ≃ₜ F) (hpq : ∀ e, q (h e) = p e) :
+@[expose] def orbitQuotientEquiv (h : E ≃ₜ F) (hpq : ∀ e, q (h e) = p e) :
     MulAction.orbitRel.Quotient (Deck p) E ≃ MulAction.orbitRel.Quotient (Deck q) F :=
   Quotient.congr h.toEquiv (orbitRel_homeomorph_iff h hpq)
 
@@ -168,7 +172,7 @@ lemma apply_eq_iff_mem_orbit (hreg : IsRegular p) {e₁ e₂ : E} :
 
 /-- A regular deck action identifies the quotient of the total space by deck orbits with the
 base. -/
-noncomputable def orbitQuotientEquivBase (hreg : IsRegular p) :
+@[expose] noncomputable def orbitQuotientEquivBase (hreg : IsRegular p) :
     MulAction.orbitRel.Quotient (Deck p) E ≃ B :=
   Equiv.ofBijective (orbitQuotientToBase p)
     ⟨hreg.orbitQuotientToBase_injective, Quotient.lift_surjective p _ hreg.1⟩

--- a/TauCeti/AlgebraicTopology/UniversalCover/Deck/QuotientCovering.lean
+++ b/TauCeti/AlgebraicTopology/UniversalCover/Deck/QuotientCovering.lean
@@ -2,8 +2,10 @@
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 -/
-import Mathlib.Topology.Covering.Quotient
-import TauCeti.AlgebraicTopology.UniversalCover.Deck.Quotient
+module
+
+public import Mathlib.Topology.Covering.Quotient
+public import TauCeti.AlgebraicTopology.UniversalCover.Deck.Quotient
 
 /-!
 # A regular covering is a quotient covering map for its deck group
@@ -36,6 +38,8 @@ This supplies a prerequisite for the Tau Ceti universal-covers roadmap, Stages 0
 where the quotient of the cover by the deck group is identified with the base via Mathlib's
 `IsQuotientCoveringMap` (`Mathlib/Topology/Covering/Quotient.lean`).
 -/
+
+public section
 
 namespace TauCeti
 

--- a/TauCeti/AlgebraicTopology/UniversalCover/Deck/QuotientHomeomorph.lean
+++ b/TauCeti/AlgebraicTopology/UniversalCover/Deck/QuotientHomeomorph.lean
@@ -2,8 +2,10 @@
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 -/
-import Mathlib.Topology.Homeomorph.Defs
-import TauCeti.AlgebraicTopology.UniversalCover.Deck.Quotient
+module
+
+public import Mathlib.Topology.Homeomorph.Defs
+public import TauCeti.AlgebraicTopology.UniversalCover.Deck.Quotient
 
 /-!
 # The orbit quotient of a regular open map is homeomorphic to the base
@@ -32,6 +34,8 @@ This supplies a prerequisite for the Tau Ceti universal-covers roadmap, Stage 1,
 `UniversalCover x₀ / π₁(X, x₀) ≃ X` follows from the deck-group identification via Mathlib's
 `IsQuotientCoveringMap`; the present statement is its base-independent regular-cover form.
 -/
+
+public section
 
 namespace TauCeti
 
@@ -70,7 +74,7 @@ namespace IsRegular
 
 /-- For a regular continuous open map, the deck-orbit quotient `E / Deck p` is homeomorphic to
 the base. -/
-noncomputable def orbitQuotientHomeomorphBase (hreg : IsRegular p) (hcont : Continuous p)
+@[expose] noncomputable def orbitQuotientHomeomorphBase (hreg : IsRegular p) (hcont : Continuous p)
     (hopen : IsOpenMap p) :
     MulAction.orbitRel.Quotient (Deck p) E ≃ₜ B :=
   hreg.orbitQuotientEquivBase.toHomeomorphOfContinuousOpen

--- a/TauCeti/AlgebraicTopology/UniversalCover/Deck/Regular.lean
+++ b/TauCeti/AlgebraicTopology/UniversalCover/Deck/Regular.lean
@@ -2,9 +2,11 @@
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 -/
-import Mathlib.GroupTheory.GroupAction.Transitive
-import TauCeti.AlgebraicTopology.UniversalCover.Deck.Connected
-import TauCeti.AlgebraicTopology.UniversalCover.Deck.FiberTransport
+module
+
+public import Mathlib.GroupTheory.GroupAction.Transitive
+public import TauCeti.AlgebraicTopology.UniversalCover.Deck.Connected
+public import TauCeti.AlgebraicTopology.UniversalCover.Deck.FiberTransport
 
 /-!
 # Regular deck actions on fibres
@@ -39,6 +41,8 @@ regular covers are characterized by transitivity of the deck action on fibres an
 group of the cover associated to a subgroup is computed as a normalizer quotient.
 -/
 
+public section
+
 namespace TauCeti
 
 namespace Deck
@@ -52,7 +56,7 @@ For covering maps between connected, locally path-connected spaces this is the u
 deck-action formulation of a regular covering. The definition is kept independent of
 `IsCoveringMap` so it can also be transported along isomorphisms of maps without carrying
 unused topological hypotheses. -/
-def IsRegular (p : E → B) : Prop :=
+@[expose] def IsRegular (p : E → B) : Prop :=
   Function.Surjective p ∧ ∀ b : B, MulAction.IsPretransitive (Deck p) (p ⁻¹' {b})
 
 /-- Characteristic restatement of regularity of the deck action. -/
@@ -143,7 +147,7 @@ variable [TopologicalSpace B] {b : B}
 
 /-- For a preconnected covering with regular deck action, evaluation at a chosen fibre point
 identifies the deck group with that fibre. -/
-noncomputable def deckEquivFiber [PreconnectedSpace E] (hp : IsCoveringMap p)
+@[expose] noncomputable def deckEquivFiber [PreconnectedSpace E] (hp : IsCoveringMap p)
     (hreg : IsRegular p) (e : p ⁻¹' {b}) : Deck p ≃ p ⁻¹' {b} := by
   letI := hreg.fiber_isPretransitive b
   exact deckEquivFiberOfSurjective hp e (MulAction.surjective_smul (Deck p) e)

--- a/TauCeti/NumberTheory/Multiquadratic/CMField.lean
+++ b/TauCeti/NumberTheory/Multiquadratic/CMField.lean
@@ -2,9 +2,11 @@
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 -/
-import TauCeti.NumberTheory.Multiquadratic.PrimeRadicands
-import Mathlib.Data.Complex.Basic
-import Mathlib.Data.Finset.Option
+module
+
+public import TauCeti.NumberTheory.Multiquadratic.PrimeRadicands
+public import Mathlib.Data.Complex.Basic
+public import Mathlib.Data.Finset.Option
 
 /-!
 # Multiquadratic CM fields
@@ -45,6 +47,8 @@ step over the real subfield (the route taken there), it treats `i = √(-1)` as 
 proves the square-class combinator `not_isSquare_prod_optionNeg` over an arbitrary ordered field,
 then feeds the already-migrated `finrank_adjoin_range`.
 -/
+
+public section
 
 open scoped Function
 

--- a/TauCeti/NumberTheory/Multiquadratic/CoprimeSquarefree.lean
+++ b/TauCeti/NumberTheory/Multiquadratic/CoprimeSquarefree.lean
@@ -2,12 +2,14 @@
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 -/
-import TauCeti.NumberTheory.Multiquadratic.Degree
-import TauCeti.NumberTheory.Multiquadratic.Squarefree
-import Mathlib.Analysis.Real.Sqrt
-import Mathlib.Data.Rat.Lemmas
-import Mathlib.Algebra.Squarefree.Basic
-import Mathlib.RingTheory.Int.Basic
+module
+
+public import TauCeti.NumberTheory.Multiquadratic.Degree
+public import TauCeti.NumberTheory.Multiquadratic.Squarefree
+public import Mathlib.Analysis.Real.Sqrt
+public import Mathlib.Data.Rat.Lemmas
+public import Mathlib.Algebra.Squarefree.Basic
+public import Mathlib.RingTheory.Int.Basic
 
 /-!
 # Multiquadratic fields with pairwise-coprime squarefree integer radicands
@@ -40,6 +42,8 @@ special case where each radicand is prime.
 * `TauCeti.Multiquadratic.finrank_adjoin_sqrt_six_thirtyfive`: `[ℚ(√6, √35) : ℚ] = 4`, a worked
   example with composite radicands, beyond the reach of the distinct-primes corollary.
 -/
+
+public section
 
 open scoped Function
 

--- a/TauCeti/NumberTheory/Multiquadratic/Degree.lean
+++ b/TauCeti/NumberTheory/Multiquadratic/Degree.lean
@@ -2,7 +2,9 @@
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 -/
-import TauCeti.NumberTheory.Multiquadratic.SquareClass
+module
+
+public import TauCeti.NumberTheory.Multiquadratic.SquareClass
 
 /-!
 # The degree of a multiquadratic field
@@ -26,6 +28,8 @@ The tower-degree induction is migrated and generalised from the declaration
 [kim-em/erdos-unit-distance](https://github.com/kim-em/erdos-unit-distance), the formalization
 of L. Alpöge's disproof of the uniform-constant Erdős unit-distance conjecture.
 -/
+
+public section
 
 open TauCeti.IntermediateField
 

--- a/TauCeti/NumberTheory/Multiquadratic/Galois.lean
+++ b/TauCeti/NumberTheory/Multiquadratic/Galois.lean
@@ -2,10 +2,12 @@
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 -/
-import Mathlib.FieldTheory.Galois.Basic
-import Mathlib.FieldTheory.Normal.Basic
-import Mathlib.FieldTheory.SeparableClosure
-import Mathlib.GroupTheory.Exponent
+module
+
+public import Mathlib.FieldTheory.Galois.Basic
+public import Mathlib.FieldTheory.Normal.Basic
+public import Mathlib.FieldTheory.SeparableClosure
+public import Mathlib.GroupTheory.Exponent
 
 /-!
 # A multiquadratic field is Galois
@@ -33,6 +35,8 @@ Generalised from
 of L. Alpöge's disproof of the uniform-constant Erdős unit-distance conjecture, where these
 facts were established for one concrete CM field.
 -/
+
+public section
 
 open Polynomial IntermediateField
 
@@ -72,7 +76,7 @@ private theorem splits_X_sq_sub_C (hroot : ∀ i, root i ^ 2 = algebraMap K L (d
   exact (Polynomial.Splits.X_sub_C _).mul (Polynomial.Splits.X_sub_C _)
 
 /-- The `i`-th generator, as an element of the multiquadratic field `M`. -/
-noncomputable def gen (root : ι → L) (i : ι) : adjoin K (Set.range root) :=
+@[expose] noncomputable def gen (root : ι → L) (i : ι) : adjoin K (Set.range root) :=
   ⟨root i, subset_adjoin _ _ ⟨i, rfl⟩⟩
 
 omit [Finite ι] in

--- a/TauCeti/NumberTheory/Multiquadratic/GaloisGroup.lean
+++ b/TauCeti/NumberTheory/Multiquadratic/GaloisGroup.lean
@@ -2,10 +2,12 @@
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 -/
-import Mathlib.Data.ZMod.Basic
-import Mathlib.FieldTheory.Galois.Basic
-import TauCeti.NumberTheory.Multiquadratic.Degree
-import TauCeti.NumberTheory.Multiquadratic.Galois
+module
+
+public import Mathlib.Data.ZMod.Basic
+public import Mathlib.FieldTheory.Galois.Basic
+public import TauCeti.NumberTheory.Multiquadratic.Degree
+public import TauCeti.NumberTheory.Multiquadratic.Galois
 
 /-!
 # The Galois group of a multiquadratic field is `(ℤ/2)ⁿ`
@@ -34,6 +36,8 @@ sign-change automorphisms of one concrete multiquadratic field were analysed; he
 construction is carried out for an arbitrary such tower.
 -/
 
+public section
+
 open Polynomial IntermediateField
 
 attribute [local instance] Classical.propDecidable
@@ -46,7 +50,7 @@ variable {K L : Type*} [Field K] [Field L] [Algebra K L] {ι : Type*}
 variable (root) in
 /-- The sign pattern of an automorphism: `0` where it fixes a generator and `1` otherwise.
 When `gen root i ≠ -gen root i`, the `1` case says that the automorphism negates the generator. -/
-noncomputable def signPattern
+@[expose] noncomputable def signPattern
     (σ : adjoin K (Set.range root) ≃ₐ[K] adjoin K (Set.range root)) (i : ι) : ZMod 2 :=
   if σ (gen root i) = gen root i then 0 else 1
 
@@ -168,7 +172,7 @@ theorem signPattern_mul (hroot : ∀ i, root i ^ 2 = algebraMap K L (d i))
 
 variable (root) in
 /-- The Galois group of `M / K` maps to the sign patterns `(ℤ/2)ⁱ`. -/
-noncomputable def signHom (hroot : ∀ i, root i ^ 2 = algebraMap K L (d i))
+@[expose] noncomputable def signHom (hroot : ∀ i, root i ^ 2 = algebraMap K L (d i))
     : (adjoin K (Set.range root) ≃ₐ[K] adjoin K (Set.range root)) →*
       Multiplicative (ι → ZMod 2) where
   toFun σ := Multiplicative.ofAdd (signPattern root σ)

--- a/TauCeti/NumberTheory/Multiquadratic/LegendrePrimeDiscriminant.lean
+++ b/TauCeti/NumberTheory/Multiquadratic/LegendrePrimeDiscriminant.lean
@@ -2,8 +2,10 @@
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 -/
-import TauCeti.NumberTheory.Multiquadratic.PrimeDiscriminant
-import Mathlib.NumberTheory.LegendreSymbol.QuadraticReciprocity
+module
+
+public import TauCeti.NumberTheory.Multiquadratic.PrimeDiscriminant
+public import Mathlib.NumberTheory.LegendreSymbol.QuadraticReciprocity
 
 /-!
 # Legendre symbols of odd prime discriminants
@@ -27,6 +29,8 @@ in the shape downstream multiquadratic splitting statements need.
 * `TauCeti.Multiquadratic.forall_legendreSym_oddPrimeDiscriminant_eq_one_iff` is the
   indexed-family form used by the multiquadratic splitting law.
 -/
+
+public section
 
 namespace TauCeti.Multiquadratic
 

--- a/TauCeti/NumberTheory/Multiquadratic/PrimeDiscriminant.lean
+++ b/TauCeti/NumberTheory/Multiquadratic/PrimeDiscriminant.lean
@@ -2,9 +2,11 @@
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 -/
-import Mathlib.Algebra.Squarefree.Basic
-import Mathlib.NumberTheory.LegendreSymbol.ZModChar
-import Mathlib.RingTheory.Int.Basic
+module
+
+public import Mathlib.Algebra.Squarefree.Basic
+public import Mathlib.NumberTheory.LegendreSymbol.ZModChar
+public import Mathlib.RingTheory.Int.Basic
 
 /-!
 # Odd prime discriminants
@@ -35,6 +37,8 @@ primes into radicands `p*` satisfying `p* ≡ 1 (mod 4)`.
   formula `p* = (-1)^(p/2) p`.
 -/
 
+public section
+
 namespace TauCeti.Multiquadratic
 
 /-- The odd prime discriminant `p*`: `p` when `p % 4 = 1` and `-p` otherwise (so the value is
@@ -42,7 +46,7 @@ namespace TauCeti.Multiquadratic
 second case is the intended one for odd primes. The primality hypothesis is not part of the
 definition so that the expression rewrites by computation; the API below supplies the
 prime-specific facts. -/
-def oddPrimeDiscriminant (p : ℕ) : ℤ :=
+@[expose] def oddPrimeDiscriminant (p : ℕ) : ℤ :=
   if p % 4 = 1 then p else -(p : ℤ)
 
 /-- The defining `if` expression for the odd prime discriminant. -/

--- a/TauCeti/NumberTheory/Multiquadratic/PrimeGaloisGroup.lean
+++ b/TauCeti/NumberTheory/Multiquadratic/PrimeGaloisGroup.lean
@@ -2,8 +2,10 @@
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 -/
-import TauCeti.NumberTheory.Multiquadratic.GaloisGroup
-import TauCeti.NumberTheory.Multiquadratic.PrimeRadicands
+module
+
+public import TauCeti.NumberTheory.Multiquadratic.GaloisGroup
+public import TauCeti.NumberTheory.Multiquadratic.PrimeRadicands
 
 /-!
 # The Galois group of a prime-radicand multiquadratic field
@@ -26,6 +28,8 @@ product of distinct primes is squarefree and not a unit, hence not a square.
 * `TauCeti.Multiquadratic.card_aut_adjoin_sqrt_primes`: `|Gal(ℚ(√p₁, …, √pₙ)/ℚ)| = 2^|ι|`.
 * `TauCeti.Multiquadratic.card_aut_adjoin_sqrt_two_three`: `|Gal(ℚ(√2, √3)/ℚ)| = 4`.
 -/
+
+public section
 
 open IntermediateField
 

--- a/TauCeti/NumberTheory/Multiquadratic/PrimeRadicands.lean
+++ b/TauCeti/NumberTheory/Multiquadratic/PrimeRadicands.lean
@@ -2,11 +2,13 @@
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 -/
-import TauCeti.NumberTheory.Multiquadratic.Degree
-import TauCeti.NumberTheory.Multiquadratic.Squarefree
-import Mathlib.Analysis.Real.Sqrt
-import Mathlib.Data.Rat.Lemmas
-import Mathlib.Data.Nat.Squarefree
+module
+
+public import TauCeti.NumberTheory.Multiquadratic.Degree
+public import TauCeti.NumberTheory.Multiquadratic.Squarefree
+public import Mathlib.Analysis.Real.Sqrt
+public import Mathlib.Data.Rat.Lemmas
+public import Mathlib.Data.Nat.Squarefree
 
 /-!
 # Multiquadratic fields with prime radicands
@@ -34,6 +36,8 @@ factor), so it is not a square.
   family of distinct primes.
 * `TauCeti.Multiquadratic.finrank_adjoin_sqrt_two_three`: `[ℚ(√2, √3) : ℚ] = 4`.
 -/
+
+public section
 
 open scoped Function
 

--- a/TauCeti/NumberTheory/Multiquadratic/SquareClass.lean
+++ b/TauCeti/NumberTheory/Multiquadratic/SquareClass.lean
@@ -2,9 +2,11 @@
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 -/
-import TauCeti.FieldTheory.IntermediateField.Quadratic
-import Mathlib.Analysis.Real.Sqrt
-import Mathlib.Data.Finset.Fin
+module
+
+public import TauCeti.FieldTheory.IntermediateField.Quadratic
+public import Mathlib.Analysis.Real.Sqrt
+public import Mathlib.Data.Finset.Fin
 
 /-!
 # Square-class descent in multiquadratic towers
@@ -43,6 +45,8 @@ conjecture, where it was developed for one specific CM field. Here it is the fie
 square-class engine of the multiquadratic-fields roadmap.
 -/
 
+public section
+
 open IntermediateField
 
 namespace TauCeti.Multiquadratic
@@ -50,7 +54,7 @@ namespace TauCeti.Multiquadratic
 variable {K L : Type*} [Field K] [Field L] [Algebra K L]
 
 /-- Iterated multiquadratic tower `K(root₀, …, rootₙ₋₁) ⊆ L`. -/
-noncomputable def sqrtTower (root : ℕ → L) (n : ℕ) : IntermediateField K L :=
+@[expose] noncomputable def sqrtTower (root : ℕ → L) (n : ℕ) : IntermediateField K L :=
   IntermediateField.adjoin K (root '' Set.Iio n)
 
 /-- The defining adjoin presentation of `sqrtTower`. -/

--- a/TauCeti/NumberTheory/Multiquadratic/SquareClassIndependence.lean
+++ b/TauCeti/NumberTheory/Multiquadratic/SquareClassIndependence.lean
@@ -2,8 +2,10 @@
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 -/
-import TauCeti.NumberTheory.Multiquadratic.Degree
-import TauCeti.FieldTheory.SquareClassGroup
+module
+
+public import TauCeti.NumberTheory.Multiquadratic.Degree
+public import TauCeti.FieldTheory.SquareClassGroup
 
 /-!
 # Square-class independence as `ZMod 2`-linear independence
@@ -24,6 +26,8 @@ This file consumes that equivalence to restate the degree theorem against the st
 * `TauCeti.Multiquadratic.finrank_adjoin_range_of_linearIndependent`: the degree theorem
   `[K(rootᵢ : i) : K] = 2^|ι|` restated against linear independence of the unit classes.
 -/
+
+public section
 
 namespace TauCeti.Multiquadratic
 

--- a/TauCeti/NumberTheory/Multiquadratic/Squarefree.lean
+++ b/TauCeti/NumberTheory/Multiquadratic/Squarefree.lean
@@ -2,7 +2,9 @@
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 -/
-import Mathlib.Algebra.Squarefree.Basic
+module
+
+public import Mathlib.Algebra.Squarefree.Basic
 
 /-!
 # Squarefree helpers for multiquadratic radicands
@@ -10,6 +12,8 @@ import Mathlib.Algebra.Squarefree.Basic
 This file records small squarefree arithmetic facts used by the multiquadratic degree and
 prime-discriminant APIs.
 -/
+
+public section
 
 namespace TauCeti.Multiquadratic
 

--- a/TauCeti/NumberTheory/NumberField/MultiquadraticSplitting.lean
+++ b/TauCeti/NumberTheory/NumberField/MultiquadraticSplitting.lean
@@ -2,12 +2,14 @@
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 -/
-import Mathlib.NumberTheory.LegendreSymbol.Basic
-import Mathlib.LinearAlgebra.Dimension.FreeAndStrongRankCondition
-import Mathlib.LinearAlgebra.Dimension.DivisionRing
-import Mathlib.RingTheory.IntegralClosure.IntegralRestrict
-import TauCeti.NumberTheory.Multiquadratic.Galois
-import TauCeti.NumberTheory.NumberField.SplitsCompletely
+module
+
+public import Mathlib.NumberTheory.LegendreSymbol.Basic
+public import Mathlib.LinearAlgebra.Dimension.FreeAndStrongRankCondition
+public import Mathlib.LinearAlgebra.Dimension.DivisionRing
+public import Mathlib.RingTheory.IntegralClosure.IntegralRestrict
+public import TauCeti.NumberTheory.Multiquadratic.Galois
+public import TauCeti.NumberTheory.NumberField.SplitsCompletely
 
 /-!
 # The prime-splitting law for a multiquadratic field
@@ -23,6 +25,8 @@ This is the general (compositum) case; the base case `n = 1` is `ncard_primesOve
   law — `p` splits completely in `K = ℚ(√d₁, …, √dₙ)` iff every `dᵢ` is a quadratic residue
   mod `p`.
 -/
+
+public section
 
 open Polynomial NumberField Ideal Module MulAction
 open scoped Pointwise

--- a/TauCeti/Topology/Homotopy/AmbientIsotopyConj.lean
+++ b/TauCeti/Topology/Homotopy/AmbientIsotopyConj.lean
@@ -2,7 +2,9 @@
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 -/
-import TauCeti.Topology.Homotopy.Isotopy
+module
+
+public import TauCeti.Topology.Homotopy.Isotopy
 
 /-!
 # Transporting ambient isotopies across changes of ambient coordinates
@@ -42,6 +44,8 @@ transport formulas specialise to genuine group conjugates `h * - * h⁻¹`.
   specialisations, with the conjugates written as group products `h * - * h⁻¹` in `Y ≃ₜ Y`.
 -/
 
+public section
+
 namespace TauCeti
 
 open unitInterval ContinuousMap Topology
@@ -56,7 +60,7 @@ variable (Φ : AmbientIsotopy Y)
 at each time `t` run the homeomorphism `Φ t` in the coordinates supplied by `h`, giving
 `z ↦ h (Φ (t, h⁻¹ z))`. The total map is a homeomorphism because it is `Φ`'s total homeomorphism
 pre- and post-composed with the product homeomorphisms `id ×ₜ h⁻¹` and `id ×ₜ h`. -/
-noncomputable def transport (h : Y ≃ₜ Z) : AmbientIsotopy Z where
+@[expose] noncomputable def transport (h : Y ≃ₜ Z) : AmbientIsotopy Z where
   toContinuousMap := ⟨fun p => h (Φ.toContinuousMap (p.1, h.symm p.2)), by fun_prop⟩
   isHomeomorph_total' := by
     have heq : (fun p : I × Z => (p.1, h (Φ.toContinuousMap (p.1, h.symm p.2))))
@@ -100,7 +104,7 @@ theorem finalHomeomorph_transport (h : Y ≃ₜ Z) :
 `AmbientIsotopy.transport` in which the change of coordinates fixes the ambient space, so the
 endpoint slices conjugate inside the group `Y ≃ₜ Y`. The total map is
 `(t, y) ↦ (t, h (Φ (t, h⁻¹ y)))`. -/
-noncomputable def conj (h : Y ≃ₜ Y) : AmbientIsotopy Y := Φ.transport h
+@[expose] noncomputable def conj (h : Y ≃ₜ Y) : AmbientIsotopy Y := Φ.transport h
 
 @[simp]
 theorem conj_apply (h : Y ≃ₜ Y) (p : I × Y) :

--- a/TauCeti/Topology/Homotopy/Covering.lean
+++ b/TauCeti/Topology/Homotopy/Covering.lean
@@ -2,7 +2,9 @@
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 -/
-import Mathlib.Topology.Homotopy.Lifting
+module
+
+public import Mathlib.Topology.Homotopy.Lifting
 
 /-!
 # Covering maps and fundamental-group monodromy
@@ -23,13 +25,15 @@ This builds directly on Junyan Xu's covering-space lifting and monodromy API in
 `Mathlib.Topology.Homotopy.Lifting`.
 -/
 
+public section
+
 namespace TauCeti
 
 variable {E X : Type*} [TopologicalSpace E] [TopologicalSpace X] {p : E → X} {x : X}
 
 /-- Choosing a basepoint lift `e` in the fibre over `x` identifies the fundamental group of
 the base with that fibre, via `γ ↦ monodromy γ e`. -/
-noncomputable def IsCoveringMap.fundamentalGroupEquivFiber [SimplyConnectedSpace E]
+@[expose] noncomputable def IsCoveringMap.fundamentalGroupEquivFiber [SimplyConnectedSpace E]
     (hp : IsCoveringMap p) (e : p ⁻¹' {x}) :
     FundamentalGroup X x ≃ p ⁻¹' {x} :=
   { toFun γ := hp.monodromy γ e


### PR DESCRIPTION
This PR continues the bottom-up migration of the TauCeti library to the Lean module system, opting in 41 further files on top of the 56 already migrated (#352). Each gains a leading `module`, `public import`s for its statement-level dependencies (tactic-only imports such as `Mathlib.Tactic` stay private), and selective `@[expose]` on the definitions whose bodies downstream rfl-lemmas reduce — instances are exposed by default, so they carry no annotation.

These 41 form the next downward-closed layer (a `module` file may not import a non-`module` file). The remaining files are blocked behind a core of ~15 modules whose proofs break under the module system — mostly instance-resolution changes that exposing definitions perturbs, which need case-by-case repair — plus the grid `Diagram` file, which exceeds the current 1000-line cap and is unblocked by the file-length policy PR (#353). Those follow in later PRs.

🤖 Prepared with Claude Code