### PR TITLE
refactor: resolve the product comodule via a local instance instead of per-statement letI

### DIFF
--- a/TauCeti/Algebra/Coalgebra/Comodule/MatrixCoefficientProduct.lean
+++ b/TauCeti/Algebra/Coalgebra/Comodule/MatrixCoefficientProduct.lean
@@ -42,6 +42,11 @@ universe u v w x
 
 variable {R : Type u} {C : Type v} {M : Type w} {N : Type x}
 
+-- Resolve the product comodule structure on `M × N` automatically, rather than threading it
+-- through every statement with `letI`. As in `Comodule.Product`, `Prod` is a local (not global)
+-- instance because a global product instance would make `Comodule` resolution non-confluent.
+attribute [local instance] Prod
+
 section Submodule
 
 variable [CommSemiring R]
@@ -53,22 +58,18 @@ variable [AddCommMonoid N] [Module R N] [Comodule R C N]
 matrix coefficients. -/
 @[simp]
 theorem matrixCoefficient_prod (φ : M × N →ₗ[R] R) (x : M × N) :
-    letI : Comodule R C (M × N) := Prod (R := R) (C := C) (M := M) (N := N)
     matrixCoefficient (R := R) (C := C) φ x =
       matrixCoefficient (R := R) (C := C) (φ.comp (LinearMap.inl R M N)) x.1 +
         matrixCoefficient (R := R) (C := C) (φ.comp (LinearMap.inr R M N)) x.2 := by
-  letI : Comodule R C (M × N) := Prod (R := R) (C := C) (M := M) (N := N)
   simp [matrixCoefficient_def, TensorProduct.map_map]
 
 /-- Matrix coefficients of a left summand, viewed in the product comodule, are the original
 left matrix coefficients. -/
 @[simp]
 theorem matrixCoefficient_prod_inl (φ : M →ₗ[R] R) (m : M) :
-    letI : Comodule R C (M × N) := Prod (R := R) (C := C) (M := M) (N := N)
     matrixCoefficient (R := R) (C := C) (φ.comp (LinearMap.fst R M N))
         (LinearMap.inl R M N m) =
       matrixCoefficient (R := R) (C := C) φ m := by
-  letI : Comodule R C (M × N) := Prod (R := R) (C := C) (M := M) (N := N)
   rw [matrixCoefficient_prod]
   have hφ :
       (φ.comp (LinearMap.fst R M N)).comp (LinearMap.inl R M N) = φ := by
@@ -80,11 +81,9 @@ theorem matrixCoefficient_prod_inl (φ : M →ₗ[R] R) (m : M) :
 right matrix coefficients. -/
 @[simp]
 theorem matrixCoefficient_prod_inr (ψ : N →ₗ[R] R) (n : N) :
-    letI : Comodule R C (M × N) := Prod (R := R) (C := C) (M := M) (N := N)
     matrixCoefficient (R := R) (C := C) (ψ.comp (LinearMap.snd R M N))
         (LinearMap.inr R M N n) =
       matrixCoefficient (R := R) (C := C) ψ n := by
-  letI : Comodule R C (M × N) := Prod (R := R) (C := C) (M := M) (N := N)
   rw [matrixCoefficient_prod]
   have hψ :
       (ψ.comp (LinearMap.snd R M N)).comp (LinearMap.inr R M N) = ψ := by
@@ -96,11 +95,9 @@ theorem matrixCoefficient_prod_inr (ψ : N →ₗ[R] R) (n : N) :
 submodules of the two factors. -/
 @[simp]
 theorem matrixCoefficientSubmodule_prod :
-    letI : Comodule R C (M × N) := Prod (R := R) (C := C) (M := M) (N := N)
     matrixCoefficientSubmodule (R := R) (C := C) (M := M × N) =
       matrixCoefficientSubmodule (R := R) (C := C) (M := M) ⊔
         matrixCoefficientSubmodule (R := R) (C := C) (M := N) := by
-  letI : Comodule R C (M × N) := Prod (R := R) (C := C) (M := M) (N := N)
   apply le_antisymm
   · rw [matrixCoefficientSubmodule_le_iff]
     intro φ x
@@ -145,11 +142,9 @@ variable [AddCommMonoid N] [Module R N] [Comodule R C N]
 subalgebras of the two factors. -/
 @[simp]
 theorem matrixCoefficientSubalgebra_prod :
-    letI : Comodule R C (M × N) := Prod (R := R) (C := C) (M := M) (N := N)
     matrixCoefficientSubalgebra (R := R) (C := C) (M := M × N) =
       matrixCoefficientSubalgebra (R := R) (C := C) (M := M) ⊔
         matrixCoefficientSubalgebra (R := R) (C := C) (M := N) := by
-  letI : Comodule R C (M × N) := Prod (R := R) (C := C) (M := M) (N := N)
   apply le_antisymm
   · rw [matrixCoefficientSubalgebra_le_iff]
     intro φ x

--- a/TauCeti/Algebra/Coalgebra/Comodule/Product.lean
+++ b/TauCeti/Algebra/Coalgebra/Comodule/Product.lean
@@ -226,19 +226,24 @@ def Prod : Comodule R C (M × N) where
   coassoc := prodCoact_coassoc (R := R) (C := C) (M := M) (N := N)
   lTensor_counit_comp_coact := prodCoact_counit (R := R) (C := C) (M := M) (N := N)
 
+-- Register `Prod` as a local instance for the rest of this file, so the product comodule
+-- structure resolves automatically on `M × N` and need not be threaded through every statement
+-- with `letI`. It is deliberately *not* a global instance: several comodule structures can live
+-- on one carrier (e.g. `trivial`, `cofree`), so a global product instance would make `Comodule`
+-- resolution non-confluent. This matches how `Comodule.trivial` is used in the matrix-coefficient
+-- files.
+attribute [local instance] Prod
+
 /-- The coaction in `Comodule.Prod` is `Comodule.prodCoact`. -/
 @[simp]
 theorem Prod_coact :
-    letI : Comodule R C (M × N) := Prod (R := R) (C := C) (M := M) (N := N)
     coact (R := R) (C := C) (M := M × N) =
       prodCoact (R := R) (C := C) (M := M) (N := N) :=
   rfl
 
 /-- The first projection from the product comodule. -/
 def prodFst :
-    letI : Comodule R C (M × N) := Prod (R := R) (C := C) (M := M) (N := N)
     Hom R C (M × N) M := by
-  letI : Comodule R C (M × N) := Prod (R := R) (C := C) (M := M) (N := N)
   exact
       { toLinearMap := LinearMap.fst R M N
         map_coact := by
@@ -251,7 +256,6 @@ def prodFst :
 /-- The underlying linear map of the first projection from the product comodule. -/
 @[simp]
 theorem prodFst_toLinearMap :
-    letI : Comodule R C (M × N) := Prod (R := R) (C := C) (M := M) (N := N)
     (prodFst (R := R) (C := C) (M := M) (N := N)).toLinearMap =
       LinearMap.fst R M N :=
   rfl
@@ -259,15 +263,12 @@ theorem prodFst_toLinearMap :
 /-- Evaluating the first projection from the product comodule returns the first component. -/
 @[simp]
 theorem prodFst_apply (x : M × N) :
-    letI : Comodule R C (M × N) := Prod (R := R) (C := C) (M := M) (N := N)
     prodFst (R := R) (C := C) (M := M) (N := N) x = x.1 :=
   rfl
 
 /-- The second projection from the product comodule. -/
 def prodSnd :
-    letI : Comodule R C (M × N) := Prod (R := R) (C := C) (M := M) (N := N)
     Hom R C (M × N) N := by
-  letI : Comodule R C (M × N) := Prod (R := R) (C := C) (M := M) (N := N)
   exact
       { toLinearMap := LinearMap.snd R M N
         map_coact := by
@@ -280,7 +281,6 @@ def prodSnd :
 /-- The underlying linear map of the second projection from the product comodule. -/
 @[simp]
 theorem prodSnd_toLinearMap :
-    letI : Comodule R C (M × N) := Prod (R := R) (C := C) (M := M) (N := N)
     (prodSnd (R := R) (C := C) (M := M) (N := N)).toLinearMap =
       LinearMap.snd R M N :=
   rfl
@@ -288,15 +288,12 @@ theorem prodSnd_toLinearMap :
 /-- Evaluating the second projection from the product comodule returns the second component. -/
 @[simp]
 theorem prodSnd_apply (x : M × N) :
-    letI : Comodule R C (M × N) := Prod (R := R) (C := C) (M := M) (N := N)
     prodSnd (R := R) (C := C) (M := M) (N := N) x = x.2 :=
   rfl
 
 /-- The left inclusion into the product comodule. -/
 def prodInl :
-    letI : Comodule R C (M × N) := Prod (R := R) (C := C) (M := M) (N := N)
     Hom R C M (M × N) := by
-  letI : Comodule R C (M × N) := Prod (R := R) (C := C) (M := M) (N := N)
   exact
       { toLinearMap := LinearMap.inl R M N
         map_coact := by
@@ -306,7 +303,6 @@ def prodInl :
 /-- The underlying linear map of the left inclusion into the product comodule. -/
 @[simp]
 theorem prodInl_toLinearMap :
-    letI : Comodule R C (M × N) := Prod (R := R) (C := C) (M := M) (N := N)
     (prodInl (R := R) (C := C) (M := M) (N := N)).toLinearMap =
       LinearMap.inl R M N :=
   rfl
@@ -315,15 +311,12 @@ theorem prodInl_toLinearMap :
 component. -/
 @[simp]
 theorem prodInl_apply (m : M) :
-    letI : Comodule R C (M × N) := Prod (R := R) (C := C) (M := M) (N := N)
     prodInl (R := R) (C := C) (M := M) (N := N) m = (m, 0) :=
   rfl
 
 /-- The right inclusion into the product comodule. -/
 def prodInr :
-    letI : Comodule R C (M × N) := Prod (R := R) (C := C) (M := M) (N := N)
     Hom R C N (M × N) := by
-  letI : Comodule R C (M × N) := Prod (R := R) (C := C) (M := M) (N := N)
   exact
       { toLinearMap := LinearMap.inr R M N
         map_coact := by
@@ -333,7 +326,6 @@ def prodInr :
 /-- The underlying linear map of the right inclusion into the product comodule. -/
 @[simp]
 theorem prodInr_toLinearMap :
-    letI : Comodule R C (M × N) := Prod (R := R) (C := C) (M := M) (N := N)
     (prodInr (R := R) (C := C) (M := M) (N := N)).toLinearMap =
       LinearMap.inr R M N :=
   rfl
@@ -342,7 +334,6 @@ theorem prodInr_toLinearMap :
 component. -/
 @[simp]
 theorem prodInr_apply (n : N) :
-    letI : Comodule R C (M × N) := Prod (R := R) (C := C) (M := M) (N := N)
     prodInr (R := R) (C := C) (M := M) (N := N) n = (0, n) :=
   rfl
 
@@ -362,9 +353,7 @@ private theorem prodLeft_map_prod {P : Type*} [AddCommMonoid P] [Module R P]
 /-- The product morphism induced by two morphisms with a common source. -/
 def prodLift {P : Type*} [AddCommMonoid P] [Module R P] [Comodule R C P]
     (f : Hom R C P M) (g : Hom R C P N) :
-    letI : Comodule R C (M × N) := Prod (R := R) (C := C) (M := M) (N := N)
     Hom R C P (M × N) := by
-  letI : Comodule R C (M × N) := Prod (R := R) (C := C) (M := M) (N := N)
   exact
     { toLinearMap := f.toLinearMap.prod g.toLinearMap
       map_coact := by
@@ -377,7 +366,6 @@ def prodLift {P : Type*} [AddCommMonoid P] [Module R P] [Comodule R C P]
 @[simp]
 theorem prodLift_toLinearMap {P : Type*} [AddCommMonoid P] [Module R P] [Comodule R C P]
     (f : Hom R C P M) (g : Hom R C P N) :
-    letI : Comodule R C (M × N) := Prod (R := R) (C := C) (M := M) (N := N)
     (prodLift (R := R) (C := C) (M := M) (N := N) f g).toLinearMap =
       f.toLinearMap.prod g.toLinearMap :=
   rfl
@@ -386,16 +374,13 @@ theorem prodLift_toLinearMap {P : Type*} [AddCommMonoid P] [Module R P] [Comodul
 @[simp]
 theorem prodLift_apply {P : Type*} [AddCommMonoid P] [Module R P] [Comodule R C P]
     (f : Hom R C P M) (g : Hom R C P N) (p : P) :
-    letI : Comodule R C (M × N) := Prod (R := R) (C := C) (M := M) (N := N)
     prodLift (R := R) (C := C) (M := M) (N := N) f g p = (f p, g p) :=
   rfl
 
 /-- The product morphism induced by two morphisms with a common target. -/
 def prodDesc {P : Type*} [AddCommMonoid P] [Module R P] [Comodule R C P]
     (f : Hom R C M P) (g : Hom R C N P) :
-    letI : Comodule R C (M × N) := Prod (R := R) (C := C) (M := M) (N := N)
     Hom R C (M × N) P := by
-  letI : Comodule R C (M × N) := Prod (R := R) (C := C) (M := M) (N := N)
   exact
     { toLinearMap := LinearMap.coprod f.toLinearMap g.toLinearMap
       map_coact := by
@@ -409,7 +394,6 @@ def prodDesc {P : Type*} [AddCommMonoid P] [Module R P] [Comodule R C P]
 @[simp]
 theorem prodDesc_toLinearMap {P : Type*} [AddCommMonoid P] [Module R P] [Comodule R C P]
     (f : Hom R C M P) (g : Hom R C N P) :
-    letI : Comodule R C (M × N) := Prod (R := R) (C := C) (M := M) (N := N)
     (prodDesc (R := R) (C := C) (M := M) (N := N) f g).toLinearMap =
       LinearMap.coprod f.toLinearMap g.toLinearMap :=
   rfl
@@ -418,7 +402,6 @@ theorem prodDesc_toLinearMap {P : Type*} [AddCommMonoid P] [Module R P] [Comodul
 @[simp]
 theorem prodDesc_apply {P : Type*} [AddCommMonoid P] [Module R P] [Comodule R C P]
     (f : Hom R C M P) (g : Hom R C N P) (x : M × N) :
-    letI : Comodule R C (M × N) := Prod (R := R) (C := C) (M := M) (N := N)
     prodDesc (R := R) (C := C) (M := M) (N := N) f g x = f x.1 + g x.2 :=
   rfl
 


### PR DESCRIPTION
This PR replaces the per-statement `letI : Comodule R C (M × N) := Prod ...` injections in `Product.lean` and `MatrixCoefficientProduct.lean` with a single `attribute [local instance] Prod` per file. `Comodule.Prod` is a non-instance def, so roughly three dozen statements — including the bodies of `@[simp]` lemmas — carried the structure by hand, which obscured the statements and made the product simp lemmas awkward to apply. With `Prod` registered as a local instance the product comodule resolves automatically and the simp lemmas read cleanly.

`Prod` is kept a local instance rather than promoted to a global one on purpose: several comodule structures can live on a single carrier, so a global product instance would make `Comodule` resolution non-confluent. This mirrors the `attribute [local instance] trivial` idiom already used in the trivial-comodule matrix-coefficient file. The one remaining explicit `letI` is in the bundled `ComoduleCat` section, outside the local-instance scope. The full library builds with `warningAsError` on.

This is maintenance of existing code (always in scope per `AGENTS.md`). It refactors the product-comodule and matrix-coefficient API used for finite direct sums under `TauCetiRoadmap/ReductiveGroups/README.md`, Layer 1 (representations = comodules).

Roadmap: ReductiveGroups

🤖 Prepared with Claude Code