### PR TITLE
refactor: resolve the cofree comodule via a local instance instead of per-statement letI

### DIFF
--- a/TauCeti/Algebra/Coalgebra/Comodule/Cofree.lean
+++ b/TauCeti/Algebra/Coalgebra/Comodule/Cofree.lean
@@ -135,24 +135,27 @@ noncomputable def cofree : Comodule R C (M ⊗[R] C) where
     refine TensorProduct.ext' fun m c => ?_
     simp
 
+-- Register `cofree` as a local instance for the rest of this file, so the cofree comodule on a
+-- tensor product `· ⊗[R] C` resolves automatically and need not be threaded through every
+-- statement with `letI`. It is deliberately *not* a global instance: an `R`-module can carry many
+-- coactions, so a global cofree instance would make `Comodule` resolution non-confluent.
+attribute [local instance] cofree
+
 /-- The coaction of the cofree comodule is `id ⊗ Δ` followed by reassociation. -/
 @[simp]
 theorem cofree_coact :
-    letI := cofree R C M
     coact (R := R) (C := C) (M := M ⊗[R] C)
       = (TensorProduct.assoc R M C C).symm.toLinearMap ∘ₗ Coalgebra.comul.lTensor M :=
   rfl
 
 /-- The coaction of the cofree comodule unfolds to its implementation `cofreeCoact`. -/
 private theorem cofree_coact_eq_cofreeCoact :
-    letI := cofree R C M
     coact (R := R) (C := C) (M := M ⊗[R] C) = cofreeCoact R C M :=
   rfl
 
 /-- The coaction of the cofree comodule on a simple tensor: `m ⊗ c ↦ ∑ (m ⊗ c₁) ⊗ c₂`. -/
 @[simp]
 theorem cofree_coact_tmul (m : M) (c : C) :
-    letI := cofree R C M
     coact (R := R) (C := C) (M := M ⊗[R] C) (m ⊗ₜ c)
       = (TensorProduct.assoc R M C C).symm (m ⊗ₜ Coalgebra.comul c) :=
   cofreeCoact_tmul m c
@@ -162,11 +165,7 @@ namespace Hom
 /-- Functoriality of the cofree comodule in the coefficient module: an `R`-linear map
 `f : M → N` induces the comodule morphism `f ⊗ id : M ⊗[R] C → N ⊗[R] C`. -/
 noncomputable def cofreeMap (f : M →ₗ[R] N) :
-    letI := cofree R C M
-    letI := cofree R C N
     Hom R C (M ⊗[R] C) (N ⊗[R] C) := by
-  letI := cofree R C M
-  letI := cofree R C N
   exact
     { toLinearMap := f.rTensor C
       map_coact := by
@@ -181,25 +180,19 @@ noncomputable def cofreeMap (f : M →ₗ[R] N) :
 /-- The underlying linear map of `cofreeMap f` is `f ⊗ id`. -/
 @[simp]
 theorem cofreeMap_toLinearMap (f : M →ₗ[R] N) :
-    letI := cofree R C M
-    letI := cofree R C N
     (cofreeMap (C := C) f).toLinearMap = f.rTensor C :=
   rfl
 
 /-- `cofreeMap f` acts as `f ⊗ id`. -/
 @[simp]
 theorem cofreeMap_apply (f : M →ₗ[R] N) (x : M ⊗[R] C) :
-    letI := cofree R C M
-    letI := cofree R C N
     cofreeMap (C := C) f x = f.rTensor C x :=
   rfl
 
 /-- The cofree functor preserves identities. -/
 @[simp]
 theorem cofreeMap_id :
-    letI := cofree R C M
     cofreeMap (C := C) (LinearMap.id : M →ₗ[R] M) = Comodule.Hom.id R C (M ⊗[R] C) := by
-  letI := cofree R C M
   refine Comodule.Hom.ext fun x => ?_
   rw [cofreeMap_apply, LinearMap.rTensor_id_apply]
   rfl
@@ -207,13 +200,7 @@ theorem cofreeMap_id :
 /-- The cofree functor preserves composition. -/
 @[simp]
 theorem cofreeMap_comp (g : N →ₗ[R] P) (f : M →ₗ[R] N) :
-    letI := cofree R C M
-    letI := cofree R C N
-    letI := cofree R C P
     cofreeMap (C := C) (g.comp f) = comp (cofreeMap (C := C) g) (cofreeMap (C := C) f) := by
-  letI := cofree R C M
-  letI := cofree R C N
-  letI := cofree R C P
   refine Comodule.Hom.ext fun x => ?_
   simp [LinearMap.rTensor_comp]
 
@@ -221,9 +208,7 @@ variable (P) in
 /-- The coaction of a comodule `P`, viewed as a comodule morphism `P → P ⊗[R] C` into its cofree
 comodule. This is the unit of the cofree adjunction. -/
 noncomputable def cofreeUnit [Comodule R C P] :
-    letI := cofree R C P
     Hom R C P (P ⊗[R] C) := by
-  letI := cofree R C P
   exact
     { toLinearMap := coact (R := R) (C := C) (M := P)
       map_coact := by
@@ -236,37 +221,30 @@ noncomputable def cofreeUnit [Comodule R C P] :
 /-- The underlying linear map of `cofreeUnit P` is the coaction of `P`. -/
 @[simp]
 theorem cofreeUnit_toLinearMap [Comodule R C P] :
-    letI := cofree R C P
     (cofreeUnit (R := R) (C := C) P).toLinearMap = coact (R := R) (C := C) (M := P) :=
   rfl
 
 /-- `cofreeUnit P` acts as the coaction of `P`. -/
 @[simp]
 theorem cofreeUnit_apply [Comodule R C P] (p : P) :
-    letI := cofree R C P
     cofreeUnit (R := R) (C := C) P p = coact (R := R) (C := C) (M := P) p :=
   rfl
 
 /-- The comodule morphism `P → M ⊗[R] C` lifting an `R`-linear map `g : P → M`, namely
 `(g ⊗ id) ∘ ρ_P`. -/
 noncomputable def cofreeLift [Comodule R C P] (g : P →ₗ[R] M) :
-    letI := cofree R C M
     Hom R C P (M ⊗[R] C) := by
-  letI := cofree R C P
-  letI := cofree R C M
   exact comp (cofreeMap (C := C) g) (cofreeUnit (R := R) (C := C) P)
 
 /-- The underlying linear map of `cofreeLift g` is `(g ⊗ id) ∘ ρ_P`. -/
 @[simp]
 theorem cofreeLift_toLinearMap [Comodule R C P] (g : P →ₗ[R] M) :
-    letI := cofree R C M
     (cofreeLift (C := C) g).toLinearMap = g.rTensor C ∘ₗ coact (R := R) (C := C) (M := P) :=
   rfl
 
 /-- `cofreeLift g` acts as `(g ⊗ id) ∘ ρ_P`. -/
 @[simp]
 theorem cofreeLift_apply [Comodule R C P] (g : P →ₗ[R] M) (p : P) :
-    letI := cofree R C M
     cofreeLift (C := C) g p = g.rTensor C (coact (R := R) (C := C) (M := P) p) :=
   rfl
 
@@ -308,9 +286,7 @@ private theorem cofree_retract (z : M ⊗[R] C) :
 maps `P → M`: this is the universal property of the cofree comodule (the cofree functor is right
 adjoint to the forgetful functor). -/
 noncomputable def cofreeEquiv [Comodule R C P] :
-    letI := cofree R C M
     Hom R C P (M ⊗[R] C) ≃ (P →ₗ[R] M) := by
-  letI := cofree R C M
   exact
     { toFun φ := (TensorProduct.rid R M).toLinearMap ∘ₗ
         (Coalgebra.counit (R := R) (A := C)).lTensor M ∘ₗ φ.toLinearMap
@@ -332,19 +308,16 @@ noncomputable def cofreeEquiv [Comodule R C P] :
 `R`-linear map obtained by applying the counit to the `C` factor. -/
 @[simp]
 theorem cofreeEquiv_apply [Comodule R C P] :
-    letI := cofree R C M
     ∀ φ : Hom R C P (M ⊗[R] C),
       cofreeEquiv (R := R) (C := C) (M := M) (P := P) φ
         = (TensorProduct.rid R M).toLinearMap ∘ₗ
             (Coalgebra.counit (R := R) (A := C)).lTensor M ∘ₗ φ.toLinearMap := by
-  letI := cofree R C M
   intro φ
   rfl
 
 /-- The inverse direction of the cofree adjunction is `cofreeLift`. -/
 @[simp]
 theorem cofreeEquiv_symm_apply [Comodule R C P] (g : P →ₗ[R] M) :
-    letI := cofree R C M
     (cofreeEquiv (R := R) (C := C) (M := M) (P := P)).symm g = cofreeLift (C := C) g :=
   rfl
 

--- a/TauCeti/Algebra/Coalgebra/Comodule/FiniteCofree.lean
+++ b/TauCeti/Algebra/Coalgebra/Comodule/FiniteCofree.lean
@@ -46,13 +46,18 @@ variable [CommSemiring R] [AddCommMonoid C] [Module R C] [Coalgebra R C]
 variable {M : Type w} [AddCommMonoid M] [Module R M] [Module.Finite R (M ⊗[R] C)]
 variable {N : Type w} [AddCommMonoid N] [Module R N] [Module.Finite R (N ⊗[R] C)]
 
+-- Resolve the cofree comodule structure on `· ⊗[R] C` automatically, rather than threading it
+-- through every statement with `letI`. As in `Comodule.Cofree`, this is a local (not global)
+-- instance because an `R`-module can carry many coactions. The bundled `FGComoduleCat` objects
+-- carry their own comodule instance, so this does not clash with their coactions.
+attribute [local instance] Comodule.cofree
+
 /-- The cofree right `C`-comodule with finitely generated tensor-product carrier, bundled as an
 object of `FGComoduleCat`.
 
 The underlying module is `M ⊗[R] C`, with coaction `id ⊗ Δ` followed by reassociation. -/
 noncomputable abbrev cofree (M : Type w) [AddCommMonoid M] [Module R M]
     [Module.Finite R (M ⊗[R] C)] : FGComoduleCat.{u, v, max w v} R C :=
-  letI := Comodule.cofree R C M
   of (R := R) (C := C) (M ⊗[R] C)
 
 /-- Forgetting the finitely generated cofree comodule to all comodules gives the ambient
@@ -71,7 +76,6 @@ theorem cofree_coe : (cofree (R := R) (C := C) M : Type (max w v)) = M ⊗[R] C 
 reassociation. -/
 @[simp]
 theorem cofree_coact :
-    letI := Comodule.cofree R C M
     Comodule.coact (R := R) (C := C) (M := cofree (R := R) (C := C) M)
       = (TensorProduct.assoc R M C C).symm.toLinearMap ∘ₗ Coalgebra.comul.lTensor M :=
   rfl
@@ -80,7 +84,6 @@ theorem cofree_coact :
 `m ⊗ c` to `∑ (m ⊗ c₁) ⊗ c₂`. -/
 @[simp]
 theorem cofree_coact_tmul (m : M) (c : C) :
-    letI := Comodule.cofree R C M
     Comodule.coact (R := R) (C := C) (M := cofree (R := R) (C := C) M) (m ⊗ₜ[R] c)
       = (TensorProduct.assoc R M C C).symm (m ⊗ₜ Coalgebra.comul c) :=
   Comodule.cofree_coact_tmul m c
@@ -106,24 +109,18 @@ theorem forget₂_semimoduleCat_cofree_obj :
 An `R`-linear map `f : M → N` induces the comodule morphism `f ⊗ id`. -/
 noncomputable abbrev cofreeMap (f : M →ₗ[R] N) :
     cofree (R := R) (C := C) M ⟶ cofree (R := R) (C := C) N :=
-  letI := Comodule.cofree R C M
-  letI := Comodule.cofree R C N
   ofHom (R := R) (C := C) (Comodule.Hom.cofreeMap (C := C) f)
 
 /-- `cofreeMap f` acts as `f ⊗ id`. -/
 @[simp]
 theorem cofreeMap_apply (f : M →ₗ[R] N) (x : M ⊗[R] C) :
     cofreeMap (R := R) (C := C) f x = f.rTensor C x :=
-  letI := Comodule.cofree R C M
-  letI := Comodule.cofree R C N
   rfl
 
 /-- On simple tensors, `cofreeMap f` applies `f` to the coefficient factor. -/
 @[simp]
 theorem cofreeMap_tmul (f : M →ₗ[R] N) (m : M) (c : C) :
     cofreeMap (R := R) (C := C) f (m ⊗ₜ[R] c) = f m ⊗ₜ[R] c :=
-  letI := Comodule.cofree R C M
-  letI := Comodule.cofree R C N
   rfl
 
 /-- The finite cofree construction sends the identity linear map to the identity morphism. -/
@@ -150,7 +147,6 @@ variable {P : FGComoduleCat.{u, v, max w v} R C}
 coefficient module. -/
 noncomputable abbrev cofreeLift (P : FGComoduleCat.{u, v, max w v} R C) (g : P →ₗ[R] M) :
     P ⟶ cofree (R := R) (C := C) M :=
-  letI := Comodule.cofree R C M
   ObjectProperty.homMk
     (ComoduleCat.ofHom (R := R) (C := C) (Comodule.Hom.cofreeLift (C := C) g))
 
@@ -159,13 +155,11 @@ noncomputable abbrev cofreeLift (P : FGComoduleCat.{u, v, max w v} R C) (g : P �
 theorem cofreeLift_apply (g : P →ₗ[R] M) (p : P) :
     cofreeLift (R := R) (C := C) P g p =
       g.rTensor C (Comodule.coact (R := R) (C := C) (M := P) p) :=
-  letI := Comodule.cofree R C M
   rfl
 
 /-- The finite-category cofree universal property. -/
 noncomputable def cofreeEquiv (P : FGComoduleCat.{u, v, max w v} R C) :
     (P ⟶ cofree (R := R) (C := C) M) ≃ (P →ₗ[R] M) := by
-  letI := Comodule.cofree R C M
   exact
     { toFun φ := Comodule.Hom.cofreeEquiv (R := R) (C := C) (M := M) (P := P) φ.hom
       invFun g := cofreeLift (R := R) (C := C) P g
@@ -180,9 +174,7 @@ noncomputable def cofreeEquiv (P : FGComoduleCat.{u, v, max w v} R C) :
 @[simp]
 theorem cofreeEquiv_apply (φ : P ⟶ cofree (R := R) (C := C) M) :
     cofreeEquiv (R := R) (C := C) (M := M) P φ =
-      letI := Comodule.cofree R C M
       Comodule.Hom.cofreeEquiv (R := R) (C := C) (M := M) (P := P) φ.hom := by
-  letI := Comodule.cofree R C M
   rfl
 
 /-- The inverse direction of the finite cofree adjunction is `cofreeLift`. -/


### PR DESCRIPTION
This PR applies the product-comodule local-instance cleanup to `Comodule.cofree`, the cofree comodule on `M ⊗[R] C`. As a non-instance def it was carried into roughly fifty statements and proofs across `Cofree.lean` and `FiniteCofree.lean` with `letI := cofree R C M` (and the `N`/`P` carriers); this replaces those with a single `attribute [local instance] cofree` per file and removes the `letI` injections, so the cofree comodule resolves automatically.

`cofree` is kept a local instance rather than a global one because an `R`-module can carry many coactions, so a global cofree instance would make `Comodule` resolution non-confluent. The instance does not leak to importers, and bundled `FGComoduleCat` objects keep their own coaction since their carrier is not syntactically `· ⊗[R] C`. The full library builds with `warningAsError` on.

🤖 Prepared with Claude Code