### PR TITLE
refactor: delegate the bundled complex-linear closure lemmas to the raw predicate

### DIFF
--- a/TauCeti/Geometry/Symplectic/AlmostComplex.lean
+++ b/TauCeti/Geometry/Symplectic/AlmostComplex.lean
@@ -193,10 +193,8 @@ lemma isComplexLinearMap_iff_mem_complexLinearMaps (J : AlmostComplexStructure V
 /-- The zero map is complex-linear for any source and target almost complex structures. -/
 @[simp]
 lemma isComplexLinearMap_zero (J : AlmostComplexStructure V) (J' : AlmostComplexStructure W) :
-    IsComplexLinearMap J J' (0 : V →ₗ[ℝ] W) := by
-  rw [isComplexLinearMap_iff_apply]
-  intro v
-  simp
+    IsComplexLinearMap J J' (0 : V →ₗ[ℝ] W) :=
+  isComplexLinear_zero
 
 /-- Complex-linear maps are closed under addition. -/
 lemma IsComplexLinearMap.add {J : AlmostComplexStructure V} {J' : AlmostComplexStructure W}
@@ -208,9 +206,8 @@ lemma IsComplexLinearMap.add {J : AlmostComplexStructure V} {J' : AlmostComplexS
 /-- Complex-linear maps are closed under negation. -/
 lemma IsComplexLinearMap.neg {J : AlmostComplexStructure V} {J' : AlmostComplexStructure W}
     {F : V →ₗ[ℝ] W} (hF : IsComplexLinearMap J J' F) :
-    IsComplexLinearMap J J' (-F) := by
-  rw [isComplexLinearMap_iff_mem_complexLinearMaps] at hF ⊢
-  exact (complexLinearMaps J.toLinearMap J'.toLinearMap).neg_mem hF
+    IsComplexLinearMap J J' (-F) :=
+  IsComplexLinear.neg hF
 
 /-- Complex-linear maps are closed under subtraction. -/
 lemma IsComplexLinearMap.sub {J : AlmostComplexStructure V} {J' : AlmostComplexStructure W}
@@ -229,21 +226,15 @@ lemma IsComplexLinearMap.smul {J : AlmostComplexStructure V} {J' : AlmostComplex
 /-- The identity map is complex-linear with respect to the same almost complex structure. -/
 @[simp]
 lemma isComplexLinearMap_id (J : AlmostComplexStructure V) :
-    IsComplexLinearMap J J (LinearMap.id : V →ₗ[ℝ] V) := by
-  rw [isComplexLinearMap_iff_apply]
-  intro v
-  simp [LinearMap.id_apply]
+    IsComplexLinearMap J J (LinearMap.id : V →ₗ[ℝ] V) :=
+  isComplexLinear_id
 
 /-- Complex-linear maps are closed under composition. -/
 lemma IsComplexLinearMap.comp {J : AlmostComplexStructure V} {J' : AlmostComplexStructure W}
     {J'' : AlmostComplexStructure X} {F : V →ₗ[ℝ] W} {G : W →ₗ[ℝ] X}
     (hG : IsComplexLinearMap J' J'' G) (hF : IsComplexLinearMap J J' F) :
-    IsComplexLinearMap J J'' (G.comp F) := by
-  rw [isComplexLinearMap_iff_apply] at hF hG ⊢
-  intro v
-  calc
-    G (F (J v)) = G (J' (F v)) := by rw [hF v]
-    _ = J'' (G (F v)) := hG (F v)
+    IsComplexLinearMap J J'' (G.comp F) :=
+  IsComplexLinear.comp hG hF
 
 end ComplexLinearMap
 


### PR DESCRIPTION
This PR removes duplicated proofs in `AlmostComplex.lean`. `IsComplexLinearMap J J' F` is definitionally `IsComplexLinear J.toLinearMap J'.toLinearMap F` — a contract the file already states as `isComplexLinearMap_iff_isComplexLinear := Iff.rfl` — yet the bundled `.neg`, `.comp`, `isComplexLinearMap_zero`, and `isComplexLinearMap_id` re-derived closure facts that `ComplexLinearPart` already proves for the raw predicate. Replace those four tactic proofs with one-line term-mode delegations to the upstream `IsComplexLinear.neg`/`.comp`/`isComplexLinear_zero`/`isComplexLinear_id`. `.add`/`.sub`/`.smul` are left routing through the `complexLinearMaps` submodule, which has no standalone upstream counterpart. The bundled API and every lemma name are unchanged, so the ten downstream files (including `JHolomorphic`) build unchanged with `warningAsError` on.

This is maintenance of existing code (always in scope per `AGENTS.md`). The `IsComplexLinearMap` closure lemmas support the almost-complex / `J`-holomorphic definitions under `TauCetiRoadmap/HeegaardFloer/README.md`, Lane F2, item 1.

Roadmap: HeegaardFloer

🤖 Prepared with Claude Code