### PR TITLE
feat: opt 15 more modules into the Lean module system

### DIFF
--- a/TauCeti/Algebra/AlgebraicGroup/GroupAlgebraProduct.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/GroupAlgebraProduct.lean
@@ -2,12 +2,14 @@
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 -/
-import Mathlib.RingTheory.TensorProduct.Maps
-import TauCeti.Algebra.Bialgebra.MonoidAlgebraProduct
-import TauCeti.Algebra.AlgebraicGroup.DiagonalizableGroup
-import TauCeti.Algebra.AlgebraicGroup.HopfMap
-import TauCeti.Algebra.AlgebraicGroup.Product
-import TauCeti.Algebra.Bialgebra.TensorProduct
+module
+
+public import Mathlib.RingTheory.TensorProduct.Maps
+public import TauCeti.Algebra.Bialgebra.MonoidAlgebraProduct
+public import TauCeti.Algebra.AlgebraicGroup.DiagonalizableGroup
+public import TauCeti.Algebra.AlgebraicGroup.HopfMap
+public import TauCeti.Algebra.AlgebraicGroup.Product
+public import TauCeti.Algebra.Bialgebra.TensorProduct
 
 /-!
 # The diagonalizable group of a product
@@ -46,6 +48,8 @@ functor-of-points infrastructure, built on Mathlib's tensor-product and monoid-a
 bialgebra structures and the Mathlib convolution monoid of Yaël Dillies, Michał Mrugała and
 Yunzhou Xie.
 -/
+
+public section
 
 open TensorProduct WithConv MonoidAlgebra
 

--- a/TauCeti/Algebra/AlgebraicGroup/Product.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/Product.lean
@@ -2,8 +2,10 @@
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 -/
-import TauCeti.Algebra.AlgebraicGroup.HopfMap
-import TauCeti.Algebra.Bialgebra.TensorProduct
+module
+
+public import TauCeti.Algebra.AlgebraicGroup.HopfMap
+public import TauCeti.Algebra.Bialgebra.TensorProduct
 
 /-!
 # The direct product of affine group schemes on points
@@ -48,6 +50,8 @@ infrastructure, built on the Mathlib convolution monoid of Yaël Dillies, Micha�
 Yunzhou Xie.
 -/
 
+public section
+
 open TensorProduct WithConv
 
 namespace TauCeti
@@ -77,13 +81,13 @@ theorem productMap_restrict (g : (H₁ ⊗[R] H₂) →ₐ[R] A) :
 of convolution monoids: it pre-composes with the two inclusions `includeLeft` and
 `includeRight`. Each component is `TauCeti.AlgHom.mapDomain` of a bialgebra morphism, hence a
 monoid homomorphism, so their pairing is too. -/
-private noncomputable def restrictHom :
+@[expose] noncomputable def restrictHom :
     WithConv ((H₁ ⊗[R] H₂) →ₐ[R] A) →*
       WithConv (H₁ →ₐ[R] A) × WithConv (H₂ →ₐ[R] A) :=
   (AlgHom.mapDomain includeLeft).prod (AlgHom.mapDomain includeRight)
 
 @[simp]
-private theorem restrictHom_apply (f : WithConv ((H₁ ⊗[R] H₂) →ₐ[R] A)) :
+theorem restrictHom_apply (f : WithConv ((H₁ ⊗[R] H₂) →ₐ[R] A)) :
     restrictHom f = (AlgHom.mapDomain includeLeft f, AlgHom.mapDomain includeRight f) := rfl
 
 /-- The convolution monoid of `R`-algebra homomorphisms out of a tensor product of commutative
@@ -93,7 +97,7 @@ On the functor of points this is the direct product of the affine group schemes 
 `Spec H₂`: Mathlib's product map sends `x ⊗ₜ y` to `f₁ x * f₂ y`, and convolution is computed
 componentwise. When `H₁` and `H₂` are Hopf algebras these convolution monoids are groups
 (`TauCeti.AlgHom.instGroup`), so this is automatically an isomorphism of groups. -/
-noncomputable def pointsMulEquiv :
+@[expose] noncomputable def pointsMulEquiv :
     WithConv ((H₁ ⊗[R] H₂) →ₐ[R] A) ≃* WithConv (H₁ →ₐ[R] A) × WithConv (H₂ →ₐ[R] A) where
   toFun := restrictHom
   invFun p := toConv (Algebra.TensorProduct.productMap p.1.ofConv p.2.ofConv)

--- a/TauCeti/AlgebraicTopology/UniversalCover/AddCircle.lean
+++ b/TauCeti/AlgebraicTopology/UniversalCover/AddCircle.lean
@@ -2,9 +2,11 @@
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 -/
-import Mathlib.Topology.Instances.AddCircle.Defs
-import TauCeti.Algebra.Group.ZMultiples
-import TauCeti.AlgebraicTopology.UniversalCover.Deck
+module
+
+public import Mathlib.Topology.Instances.AddCircle.Defs
+public import TauCeti.Algebra.Group.ZMultiples
+public import TauCeti.AlgebraicTopology.UniversalCover.Deck
 
 /-!
 # The deck transformation group of the quotient map `𝕜 → AddCircle p`
@@ -41,6 +43,8 @@ This advances the Tau Ceti universal-covers roadmap, Stage 4 (`π₁(S¹) ≅ �
 `AddCircle` covering and the deck-transformation group of Stage 0.4.
 -/
 
+public section
+
 namespace TauCeti
 
 open AddSubgroup
@@ -62,7 +66,7 @@ theorem mem_addCircleCoe {φ : 𝕜 ≃ₜ 𝕜} :
 
 /-- Right translation by an element of `zmultiples p`, as a deck transformation of
 `(↑) : 𝕜 → AddCircle p`. -/
-def addRightZMultiples (a : zmultiples p) : Deck ((↑) : 𝕜 → AddCircle p) :=
+@[expose] def addRightZMultiples (a : zmultiples p) : Deck ((↑) : 𝕜 → AddCircle p) :=
   ⟨Homeomorph.addRight (a : 𝕜), mem_addCircleCoe.2 fun e => by
     simpa only [Homeomorph.coe_addRight, add_sub_cancel_left] using a.2⟩
 
@@ -106,19 +110,19 @@ theorem addCircleCoe_eq_add_apply_zero [PreconnectedSpace 𝕜]
   rw [sub_zero, sub_eq_iff_eq_add] at h
   rw [h, add_comm]
 
-private def addRightZMultiplesHom :
+@[expose] def addRightZMultiplesHom :
     Multiplicative (zmultiples p) →* Deck ((↑) : 𝕜 → AddCircle p) where
   toFun a := addRightZMultiples a.toAdd
   map_one' := addRightZMultiples_zero
   map_mul' _ _ := addRightZMultiples_add _ _
 
-private theorem addRightZMultiplesHom_apply (a : Multiplicative (zmultiples p)) :
+theorem addRightZMultiplesHom_apply (a : Multiplicative (zmultiples p)) :
     addRightZMultiplesHom a = addRightZMultiples a.toAdd :=
   rfl
 
 /-- The deck transformation group of `(↑) : 𝕜 → AddCircle p` on a preconnected domain with
 totally disconnected period subgroup is the group of translations by the period subgroup. -/
-noncomputable def addCircleMulEquiv [PreconnectedSpace 𝕜]
+@[expose] noncomputable def addCircleMulEquiv [PreconnectedSpace 𝕜]
     [TotallyDisconnectedSpace (zmultiples p)] :
     Multiplicative (zmultiples p) ≃* Deck ((↑) : 𝕜 → AddCircle p) :=
   MulEquiv.ofBijective addRightZMultiplesHom <| by

--- a/TauCeti/Analysis/Bochner/CharFunPositiveDefinite.lean
+++ b/TauCeti/Analysis/Bochner/CharFunPositiveDefinite.lean
@@ -2,10 +2,12 @@
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 -/
-import TauCeti.Analysis.Bochner.CharFunPosDef
-import TauCeti.Analysis.PositiveDefinite.Basic
-import TauCeti.Analysis.PositiveDefinite.Kernel
-import Mathlib.MeasureTheory.Measure.CharacteristicFunction.TaylorExpansion
+module
+
+public import TauCeti.Analysis.Bochner.CharFunPosDef
+public import TauCeti.Analysis.PositiveDefinite.Basic
+public import TauCeti.Analysis.PositiveDefinite.Kernel
+public import Mathlib.MeasureTheory.Measure.CharacteristicFunction.TaylorExpansion
 
 /-!
 # Characteristic functions as positive-definite functions
@@ -30,6 +32,8 @@ the `OneParameterSemigroups` roadmap, before the harder converse direction of Bo
 * `TauCeti.continuous_charFun_and_isPositiveDefinite_of_star_eq_neg`: the paired continuity and
   positive-definiteness package.
 -/
+
+public section
 
 open MeasureTheory
 

--- a/TauCeti/Analysis/CompletelyMonotone/Basic.lean
+++ b/TauCeti/Analysis/CompletelyMonotone/Basic.lean
@@ -66,7 +66,7 @@ namespace TauCeti
 `[0, ∞)` and its iterated derivatives within `[0, ∞)` alternate in sign:
 `0 ≤ (-1)ⁿ f⁽ⁿ⁾(t)` for every `n` and every `t ≥ 0`. The smoothness clause prevents the sign
 condition from being satisfied vacuously by a junk iterated derivative. -/
-def IsCompletelyMonotone (f : ℝ → ℝ) : Prop :=
+@[expose] def IsCompletelyMonotone (f : ℝ → ℝ) : Prop :=
   ContDiffOn ℝ ∞ f (Ici 0) ∧
     ∀ n : ℕ, ∀ t : ℝ, 0 ≤ t → 0 ≤ (-1) ^ n * iteratedDerivWithin n f (Ici 0) t
 
@@ -222,7 +222,7 @@ lemma isCompletelyMonotone_exp_neg_mul {x : ℝ} (hx : 0 ≤ x) :
 /-- Complete monotonicity on the open half-line `(0, ∞)`: the function is `C^∞` there and its
 ordinary iterated derivatives alternate in sign. This is the version used for derivatives of
 Bernstein functions, whose right derivatives need not be finite at `0`. -/
-def IsCompletelyMonotoneOnIoi (f : ℝ → ℝ) : Prop :=
+@[expose] def IsCompletelyMonotoneOnIoi (f : ℝ → ℝ) : Prop :=
   ContDiffOn ℝ ∞ f (Ioi 0) ∧
     ∀ n : ℕ, ∀ t : ℝ, 0 < t → 0 ≤ (-1) ^ n * iteratedDeriv n f t
 

--- a/TauCeti/Analysis/CompletelyMonotone/Bernstein.lean
+++ b/TauCeti/Analysis/CompletelyMonotone/Bernstein.lean
@@ -2,8 +2,10 @@
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 -/
-import TauCeti.Analysis.CompletelyMonotone.Basic
-import Mathlib.Analysis.Convex.Deriv
+module
+
+public import TauCeti.Analysis.CompletelyMonotone.Basic
+public import Mathlib.Analysis.Convex.Deriv
 
 /-!
 # Bernstein functions
@@ -49,6 +51,8 @@ nonnegative scalar multiples, and the basic catalogue — constants, the identit
 * R. Schilling, R. Song, Z. Vondraček, *Bernstein Functions: Theory and Applications*
   (de Gruyter, 2nd ed. 2012).
 -/
+
+public section
 
 open Set Filter
 open scoped ContDiff Topology

--- a/TauCeti/Analysis/CompletelyMonotone/Closure.lean
+++ b/TauCeti/Analysis/CompletelyMonotone/Closure.lean
@@ -2,8 +2,10 @@
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 -/
-import TauCeti.Analysis.CompletelyMonotone.Basic
-import Mathlib.Analysis.Calculus.IteratedDeriv.Lemmas
+module
+
+public import TauCeti.Analysis.CompletelyMonotone.Basic
+public import Mathlib.Analysis.Calculus.IteratedDeriv.Lemmas
 
 /-!
 # Closure of completely monotone functions under products and differentiation
@@ -47,6 +49,8 @@ monotone).
 * R. Schilling, R. Song, Z. Vondraček, *Bernstein Functions: Theory and Applications*
   (de Gruyter, 2nd ed. 2012).
 -/
+
+public section
 
 open Set
 open scoped ContDiff

--- a/TauCeti/Analysis/PositiveDefinite/Basic.lean
+++ b/TauCeti/Analysis/PositiveDefinite/Basic.lean
@@ -73,7 +73,7 @@ variable {M : Type*} [AddMonoid M] [StarAddMonoid M] {F G : M → ℂ}
 every finite family of scalars `c : Fin n → ℂ` and points `v : Fin n → M`, the Hermitian form
 `∑_{i,j} c i · conj (c j) · F (v i + star (v j))` is a nonnegative real number (using the order on
 `ℂ` for which `0 ≤ z` means `z` is real and nonnegative). -/
-def IsPositiveDefinite (F : M → ℂ) : Prop :=
+@[expose] def IsPositiveDefinite (F : M → ℂ) : Prop :=
   ∀ (n : ℕ) (c : Fin n → ℂ) (v : Fin n → M),
     0 ≤ ∑ i, ∑ j, c i * conj (c j) * F (v i + star (v j))
 

--- a/TauCeti/Analysis/PositiveDefinite/FunctionKernel.lean
+++ b/TauCeti/Analysis/PositiveDefinite/FunctionKernel.lean
@@ -2,8 +2,10 @@
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 -/
-import TauCeti.Analysis.PositiveDefinite.Basic
-import TauCeti.Analysis.PositiveDefinite.Kernel
+module
+
+public import TauCeti.Analysis.PositiveDefinite.Basic
+public import TauCeti.Analysis.PositiveDefinite.Kernel
 
 /-!
 # The positive-definite function ↔ positive-definite kernel correspondence
@@ -48,6 +50,8 @@ group form. No Mathlib code is vendored.
 * C. Berg, J. P. R. Christensen, P. Ressel, *Harmonic Analysis on Semigroups* (GTM 100, 1984),
   Chapter 3.
 -/
+
+public section
 
 open ComplexConjugate
 open scoped ComplexOrder

--- a/TauCeti/Analysis/PositiveDefinite/Kernel.lean
+++ b/TauCeti/Analysis/PositiveDefinite/Kernel.lean
@@ -68,7 +68,7 @@ variable {α : Type v}
 
 /-- A kernel `K : α → α → 𝕜` is *positive definite* when the matrix indexed by all points of `α`
 is positive semidefinite. -/
-def IsPositiveDefiniteKernel (K : α → α → 𝕜) : Prop :=
+@[expose] def IsPositiveDefiniteKernel (K : α → α → 𝕜) : Prop :=
   (Matrix.of fun a b => K a b).PosSemidef
 
 /-- The named kernel predicate is definitionally Mathlib's positive semidefinite predicate on the

--- a/TauCeti/Analysis/PositiveDefinite/Pullback.lean
+++ b/TauCeti/Analysis/PositiveDefinite/Pullback.lean
@@ -2,7 +2,9 @@
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 -/
-import TauCeti.Analysis.PositiveDefinite.Basic
+module
+
+public import TauCeti.Analysis.PositiveDefinite.Basic
 
 /-!
 # Pullbacks of positive-definite functions
@@ -39,6 +41,8 @@ identify the Gram entries.
 * C. Berg, J. P. R. Christensen, P. Ressel, *Harmonic Analysis on Semigroups* (GTM 100,
   1984), Chapter 3.
 -/
+
+public section
 
 namespace TauCeti
 

--- a/TauCeti/KnotTheory/Grid/Diagram.lean
+++ b/TauCeti/KnotTheory/Grid/Diagram.lean
@@ -2,12 +2,14 @@
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 -/
-import Mathlib.Data.Fin.Basic
-import Mathlib.Data.Finset.Card
-import Mathlib.Data.Fintype.Basic
-import Mathlib.Data.Fintype.Card
-import Mathlib.Data.Fintype.Perm
-import Mathlib.GroupTheory.Perm.Basic
+module
+
+public import Mathlib.Data.Fin.Basic
+public import Mathlib.Data.Finset.Card
+public import Mathlib.Data.Fintype.Basic
+public import Mathlib.Data.Fintype.Card
+public import Mathlib.Data.Fintype.Perm
+public import Mathlib.GroupTheory.Perm.Basic
 
 /-!
 # Grid diagrams and grid states
@@ -35,6 +37,8 @@ encoding follows the standard grid-diagram convention from Ozsváth--Stipsicz--S
 Homology for Knots and Links*, Chapter 3: one `O` and one `X` marking in each row and column,
 and a grid state is one point in each row and column.
 -/
+
+@[expose] public section
 
 namespace TauCeti
 

--- a/TauCeti/KnotTheory/Grid/DiagramRelabeling.lean
+++ b/TauCeti/KnotTheory/Grid/DiagramRelabeling.lean
@@ -2,7 +2,9 @@
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 -/
-import TauCeti.KnotTheory.Grid.Diagram
+module
+
+public import TauCeti.KnotTheory.Grid.Diagram
 
 /-!
 # Relabeling and column-of-row lookups
@@ -23,6 +25,8 @@ This supplies a prerequisite for `TauCetiRoadmap/CombinatorialHeegaardFloer/READ
 G.5, "Invariance over 𝔽₂. Grid moves = commutation + (de)stabilization". The conventions follow
 Ozsváth--Stipsicz--Szabó, *Grid Homology for Knots and Links*, Chapter 3.
 -/
+
+public section
 
 namespace TauCeti
 

--- a/TauCeti/KnotTheory/Grid/Rotation.lean
+++ b/TauCeti/KnotTheory/Grid/Rotation.lean
@@ -2,8 +2,10 @@
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 -/
-import Mathlib.Data.Fin.Rev
-import TauCeti.KnotTheory.Grid.Diagram
+module
+
+public import Mathlib.Data.Fin.Rev
+public import TauCeti.KnotTheory.Grid.Diagram
 
 /-!
 # The half-turn rotation of grid states and diagrams
@@ -44,6 +46,8 @@ This advances `TauCetiRoadmap/CombinatorialHeegaardFloer/README.md`, Lane G item
 standard grid symmetries of Ozsváth--Stipsicz--Szabó, *Grid Homology for Knots and Links*,
 Chapter 3.
 -/
+
+@[expose] public section
 
 namespace TauCeti
 

--- a/TauCeti/KnotTheory/Grid/StateCardinality.lean
+++ b/TauCeti/KnotTheory/Grid/StateCardinality.lean
@@ -2,10 +2,12 @@
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 -/
-import Mathlib.Data.Fintype.Perm
-import Mathlib.SetTheory.Cardinal.Finite
+module
+
+public import Mathlib.Data.Fintype.Perm
+public import Mathlib.SetTheory.Cardinal.Finite
 import Mathlib.Tactic.FinCases
-import TauCeti.KnotTheory.Grid.Diagram
+public import TauCeti.KnotTheory.Grid.Diagram
 
 /-!
 # Cardinality of grid states
@@ -33,6 +35,8 @@ and grid states", and the standing convention that the grid complexes should com
 small grids. The encoding follows Ozsváth--Stipsicz--Szabó, *Grid Homology for Knots and Links*,
 Chapter 3: a grid state is one occupied square in every row and every column.
 -/
+
+public section
 
 namespace TauCeti
 

--- a/TauCeti/NumberTheory/Multiquadratic/EvenPrimeDiscriminant.lean
+++ b/TauCeti/NumberTheory/Multiquadratic/EvenPrimeDiscriminant.lean
@@ -43,7 +43,7 @@ public section
 namespace TauCeti.Multiquadratic
 
 /-- The three even prime discriminants: `-4`, `8`, and `-8`. -/
-def IsEvenPrimeDiscriminant (D : ℤ) : Prop :=
+@[expose] def IsEvenPrimeDiscriminant (D : ℤ) : Prop :=
   D = -4 ∨ D = 8 ∨ D = -8
 
 /-- The defining disjunction for `IsEvenPrimeDiscriminant`. -/

--- a/TauCeti/NumberTheory/Multiquadratic/PrimeDiscriminants.lean
+++ b/TauCeti/NumberTheory/Multiquadratic/PrimeDiscriminants.lean
@@ -2,10 +2,12 @@
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 -/
-import TauCeti.NumberTheory.Multiquadratic.EvenPrimeDiscriminant
-import TauCeti.NumberTheory.Multiquadratic.PrimeDiscriminant
-import TauCeti.NumberTheory.Multiquadratic.Squarefree
-import Mathlib.Data.Rat.Lemmas
+module
+
+public import TauCeti.NumberTheory.Multiquadratic.EvenPrimeDiscriminant
+public import TauCeti.NumberTheory.Multiquadratic.PrimeDiscriminant
+public import TauCeti.NumberTheory.Multiquadratic.Squarefree
+public import Mathlib.Data.Rat.Lemmas
 
 /-!
 # Prime discriminants
@@ -31,6 +33,8 @@ discriminant `D ∈ {-4, 8, -8}`, the radicand is `D / 4`, so the three even cas
 * `TauCeti.Multiquadratic.not_isSquare_primeDiscriminantRadicand_rat`: the associated rational
   radicand is not a square.
 -/
+
+public section
 
 namespace TauCeti.Multiquadratic
 
@@ -99,7 +103,7 @@ theorem not_isEvenPrimeDiscriminant_oddPrimeDiscriminant {p : ℕ}
 
 /-- The squarefree radicand attached to a prime discriminant. In the even cases this divides by
 `4`; in the odd cases the discriminant is already squarefree and is used as its own radicand. -/
-def primeDiscriminantRadicand (D : ℤ) : ℤ :=
+@[expose] def primeDiscriminantRadicand (D : ℤ) : ℤ :=
   if D = -4 ∨ D = 8 ∨ D = -8 then evenPrimeDiscriminantRadicand D else D
 
 /-- The defining equation for the prime-discriminant radicand. -/

--- a/TauCeti/Topology/Homotopy/AmbientIsotopic.lean
+++ b/TauCeti/Topology/Homotopy/AmbientIsotopic.lean
@@ -55,7 +55,7 @@ carries `f` to `g`, that is, its final homeomorphism postcomposes `f` to `g`. Th
 continuous topological ambient-isotopy relation intended to underlie later knot-equivalence
 specialisations (ambient isotopy of smooth embeddings `S¹ ↪ M`); it does not itself encode the
 smooth or PL structure those specialisations add. -/
-def AmbientIsotopic (f g : C(X, Y)) : Prop :=
+@[expose] def AmbientIsotopic (f g : C(X, Y)) : Prop :=
   ∃ Φ : AmbientIsotopy Y, Φ.final.comp f = g
 
 /-- `f` and `g` are ambient isotopic exactly when some ambient isotopy's final homeomorphism

--- a/TauCeti/Topology/Homotopy/Isotopy.lean
+++ b/TauCeti/Topology/Homotopy/Isotopy.lean
@@ -349,7 +349,7 @@ instance instHomotopyLike : HomotopyLike (Isotopy f₀ f₁) f₀ f₁ where
 end Isotopy
 
 /-- Two maps `f₀ f₁ : C(X, Y)` are **isotopic** if there is an isotopy between them. -/
-def Isotopic (f₀ f₁ : C(X, Y)) : Prop :=
+@[expose] def Isotopic (f₀ f₁ : C(X, Y)) : Prop :=
   Nonempty (Isotopy f₀ f₁)
 
 namespace Isotopic

--- a/TauCeti/Topology/Homotopy/IsotopyComp.lean
+++ b/TauCeti/Topology/Homotopy/IsotopyComp.lean
@@ -2,7 +2,9 @@
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 -/
-import TauCeti.Topology.Homotopy.Isotopy
+module
+
+public import TauCeti.Topology.Homotopy.Isotopy
 
 /-!
 # Naturality of isotopy under composition with embeddings
@@ -40,6 +42,8 @@ survives both.
   codomain, or a change of source coordinates).
 -/
 
+public section
+
 namespace TauCeti
 
 open unitInterval ContinuousMap Topology
@@ -53,7 +57,7 @@ variable {f₀ f₁ : C(X, Y)}
 
 /-- Postcompose an isotopy `f₀ ≈ f₁` with a topological embedding `g : Y ↪ Z` to get an
 isotopy `g ∘ f₀ ≈ g ∘ f₁`. -/
-def postcomp (F : Isotopy f₀ f₁) (g : C(Y, Z)) (hg : IsEmbedding g) :
+@[expose] def postcomp (F : Isotopy f₀ f₁) (g : C(Y, Z)) (hg : IsEmbedding g) :
     Isotopy (g.comp f₀) (g.comp f₁) where
   toHomotopy := (Homotopy.refl g).comp F.toHomotopy
   isEmbedding_total' :=
@@ -65,7 +69,7 @@ theorem postcomp_apply (F : Isotopy f₀ f₁) (g : C(Y, Z)) (hg : IsEmbedding g
 
 /-- Precompose an isotopy `f₀ ≈ f₁` with a topological embedding `e : W ↪ X` to get an
 isotopy `f₀ ∘ e ≈ f₁ ∘ e`. -/
-def precomp (F : Isotopy f₀ f₁) (e : C(W, X)) (he : IsEmbedding e) :
+@[expose] def precomp (F : Isotopy f₀ f₁) (e : C(W, X)) (he : IsEmbedding e) :
     Isotopy (f₀.comp e) (f₁.comp e) where
   toHomotopy := F.toHomotopy.compContinuousMap e
   isEmbedding_total' :=

--- a/TauCeti/Topology/Homotopy/IsotopyProd.lean
+++ b/TauCeti/Topology/Homotopy/IsotopyProd.lean
@@ -2,7 +2,9 @@
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 -/
-import TauCeti.Topology.Homotopy.AmbientIsotopic
+module
+
+public import TauCeti.Topology.Homotopy.AmbientIsotopic
 
 /-!
 # Products of isotopies and ambient isotopies
@@ -40,6 +42,8 @@ recovered through the time-duplicating embedding `(t, x, x') ↦ ((t, x), (t, x'
 * `TauCeti.AmbientIsotopic.prodMap`: the product closure on the ambient-isotopy relation.
 -/
 
+public section
+
 namespace TauCeti
 
 open unitInterval ContinuousMap Topology
@@ -63,7 +67,7 @@ embeddings of `I × X → I × Y` and `I × X' → I × Y'` that preserve the ti
 *merged* total map `(t, (x, x')) ↦ (t, ((u (t, x)).2, (v (t, x')).2))` reading both at the same
 time `t` is an embedding. It factors as the time-duplicating embedding, then `u × v`, then the
 projection identifying the two (equal) time coordinates. -/
-private theorem isEmbedding_mergeTotal {u : C(I × X, I × Y)} {v : C(I × X', I × Y')}
+theorem isEmbedding_mergeTotal {u : C(I × X, I × Y)} {v : C(I × X', I × Y')}
     (hu : IsEmbedding u) (hv : IsEmbedding v) (hu1 : ∀ p, (u p).1 = p.1)
     (hv1 : ∀ p, (v p).1 = p.1) :
     IsEmbedding fun p : I × (X × X') => (p.1, ((u (p.1, p.2.1)).2, (v (p.1, p.2.2)).2)) := by
@@ -90,7 +94,7 @@ variable {f₀ f₁ : C(X, Y)} {g₀ g₁ : C(X', Y')}
 isotopy `g₀ ≈ g₁` build an isotopy `f₀.prodMap g₀ ≈ f₁.prodMap g₁` whose value at `(t, (x, x'))` is
 `(F (t, x), G (t, x'))`. The underlying homotopy is Mathlib's `ContinuousMap.Homotopy.prodMap`; the
 total map is an embedding by `isEmbedding_mergeTotal`. -/
-def prodMap (F : Isotopy f₀ f₁) (G : Isotopy g₀ g₁) :
+@[expose] def prodMap (F : Isotopy f₀ f₁) (G : Isotopy g₀ g₁) :
     Isotopy (f₀.prodMap g₀) (f₁.prodMap g₁) where
   toHomotopy := F.toHomotopy.prodMap G.toHomotopy
   isEmbedding_total' :=
@@ -121,6 +125,7 @@ namespace AmbientIsotopy
 is `(Φ (t, y), Ψ (t, y'))`. Its total map is a homeomorphism, being an embedding (by
 `isEmbedding_mergeTotal`) and surjective (each factor is surjective at every time, by
 `AmbientIsotopy.isHomeomorph_apply`). -/
+@[expose]
 def prodCongr (Φ : AmbientIsotopy Y) (Ψ : AmbientIsotopy Y') : AmbientIsotopy (Y × Y') where
   toContinuousMap :=
     ⟨fun p => (Φ.toContinuousMap (p.1, p.2.1), Ψ.toContinuousMap (p.1, p.2.2)), by fun_prop⟩


### PR DESCRIPTION
This PR continues the bottom-up migration, opting in 15 further files (now 112 of ~180). It includes the grid-diagram core (`Diagram`, `Rotation`), whose definitional content is its public API, so those use `@[expose] public section`; the rest use selective `@[expose]` on the definitions and predicates whose bodies downstream `intro`/`rcases`/`⟨...⟩`/`rfl` steps reduce. Tactic-only imports stay private.

It also adds `@[expose]` to a handful of predicate definitions in already-migrated files (`IsPositiveDefinite`, `IsCompletelyMonotone`, `IsEvenPrimeDiscriminant`, `AmbientIsotopic`, `Isotopic`, ...): those were merged before any `module` file consumed them, and a module consumer needs the predicate body exposed to case-split or reduce it. This is the expected producer-side follow-on as consumers come online.

A core of five modules whose proofs break under exposure (instance-resolution and type-mismatch changes that need case-by-case repair) still blocks the remainder; those follow in later PRs.

🤖 Prepared with Claude Code