### PR TITLE
doc: explain that the coalgebra C is a phantom argument of matrixCoefficient

### DIFF
--- a/TauCeti/Algebra/Coalgebra/Comodule/MatrixCoefficient.lean
+++ b/TauCeti/Algebra/Coalgebra/Comodule/MatrixCoefficient.lean
@@ -26,6 +26,17 @@ coefficients.
 * `TauCeti.Comodule.matrixCoefficient`: the coefficient element attached to `φ` and `m`.
 * `TauCeti.Comodule.matrixCoefficientBilinear`: bilinearity in the functional and vector.
 
+## Implementation notes
+
+The coalgebra `C` is a *phantom* parameter of `matrixCoefficient` and its relatives throughout
+this family of files: it occurs in the return type and in the `[Comodule R C M]` instance, but not
+in the types of the explicit arguments `φ : M →ₗ[R] R` and `m : M`. A module `M` can be a comodule
+over more than one coalgebra, so `C` is genuinely not inferable from `φ` and `m`. Unless the
+expected result type already pins `C` down, call sites must pass it explicitly, as in
+`matrixCoefficient (C := C) φ m` (and likewise `(R := R)` when `R` is not otherwise determined) —
+and statements, `simp` lemmas, and `Set.range`-style expressions usually have no such expected
+type. These named arguments are required for elaboration there, not removable noise.
+
 ## References
 
 This is standard coalgebra/comodule terminology; see Sweedler, *Hopf Algebras*, Chapter 2.


### PR DESCRIPTION
This PR documents, in the `MatrixCoefficient` module docstring, why the matrix-coefficient API is invoked with explicit `(R := R) (C := C)` arguments. The coalgebra `C` occurs only in the return type and the `[Comodule R C M]` instance, never in the types of the explicit arguments `φ : M →ₗ[R] R` and `m : M`; since a module can be a comodule over several coalgebras, `C` is not inferable from `φ` and `m` unless an expected result type already pins it down, which statements and `simp` lemmas generally do not. The note records that these named arguments are required for elaboration rather than removable stylistic noise, so the pattern is not mistaken for clutter.

This is maintenance of existing code (always in scope per `AGENTS.md`). It documents the matrix-coefficient API under `TauCetiRoadmap/ReductiveGroups/README.md`, Layer 1 (representation ⇆ comodule; matrix coefficients).

🤖 Prepared with Claude Code