### PR TITLE
feat: opt 4 more modules into the Lean module system

### DIFF
--- a/TauCeti/Algebra/AlgebraicGroup/CommHopfAlgCat.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/CommHopfAlgCat.lean
@@ -2,9 +2,11 @@
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 -/
-import Mathlib.Algebra.Category.CommHopfAlgCat
-import TauCeti.Algebra.AlgebraicGroup.HopfMap
-import TauCeti.Algebra.AlgebraicGroup.PointsFunctor
+module
+
+public import Mathlib.Algebra.Category.CommHopfAlgCat
+public import TauCeti.Algebra.AlgebraicGroup.HopfMap
+public import TauCeti.Algebra.AlgebraicGroup.PointsFunctor
 
 /-!
 # Commutative Hopf algebras and their functor of points
@@ -38,6 +40,8 @@ functoriality uses Mathlib's convolution monoid and bialgebra morphism API, in p
 `AlgHom.mapDomain`.
 -/
 
+public section
+
 open CategoryTheory WithConv
 
 namespace TauCeti
@@ -53,7 +57,7 @@ between their group-valued points functors, contravariantly in the coordinate al
 
 At a commutative `R`-algebra `A`, this sends an `A`-valued point `f : K →ₐ[R] A` to
 `f ∘ φ : H →ₐ[R] A`. -/
-noncomputable def mapPointsFunctor {H K : CommHopfAlgCat.{v} R} (φ : H ⟶ K) :
+@[expose] noncomputable def mapPointsFunctor {H K : CommHopfAlgCat.{v} R} (φ : H ⟶ K) :
     HopfAlgebra.pointsFunctor (R := R) (H := K) ⟶
       HopfAlgebra.pointsFunctor (R := R) (H := H) where
   app A := GrpCat.ofHom
@@ -101,7 +105,7 @@ functor of points.
 A coordinate Hopf algebra `H` is sent to the functor `A ↦ WithConv (H →ₐ[R] A)`. A morphism
 `φ : H ⟶ K` is sent contravariantly to the natural transformation that pre-composes
 `K`-points by `φ`. -/
-noncomputable def pointsFunctor :
+@[expose] noncomputable def pointsFunctor :
     (CommHopfAlgCat.{v} R)ᵒᵖ ⥤ CommAlgCat.{w} R ⥤ GrpCat.{max v w} where
   obj H := HopfAlgebra.pointsFunctor (R := R) (H := H.unop)
   map φ := mapPointsFunctor φ.unop

--- a/TauCeti/Algebra/AlgebraicGroup/PointsFunctor.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/PointsFunctor.lean
@@ -2,9 +2,11 @@
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 -/
-import Mathlib.Algebra.Category.CommAlgCat.Basic
-import Mathlib.Algebra.Category.Grp.Basic
-import TauCeti.Algebra.AlgebraicGroup.FunctorOfPoints
+module
+
+public import Mathlib.Algebra.Category.CommAlgCat.Basic
+public import Mathlib.Algebra.Category.Grp.Basic
+public import TauCeti.Algebra.AlgebraicGroup.FunctorOfPoints
 
 /-!
 # The functor of points of a Hopf algebra
@@ -33,6 +35,8 @@ homomorphisms and the convolution-group inverse already developed in
 `TauCeti.Algebra.AlgebraicGroup.FunctorOfPoints`.
 -/
 
+public section
+
 open CategoryTheory _root_.HopfAlgebra TensorProduct WithConv
 
 namespace TauCeti
@@ -53,7 +57,7 @@ noncomputable abbrev points (A : CommAlgCat.{w} R) : GrpCat.{max v w} :=
 /-- The group homomorphism on points induced by a morphism of value algebras.
 
 It sends an `A`-point `f : H →ₐ[R] A` to the `B`-point `φ ∘ f`. -/
-noncomputable def mapPoints {A B : CommAlgCat.{w} R} (φ : A ⟶ B) :
+@[expose] noncomputable def mapPoints {A B : CommAlgCat.{w} R} (φ : A ⟶ B) :
     points (H := H) A ⟶ points (H := H) B :=
   GrpCat.ofHom (AlgHom.mapValue (H := H) φ.hom)
 
@@ -94,7 +98,7 @@ lemma mapPoints_comp {A B C : CommAlgCat.{w} R} (φ : A ⟶ B) (ψ : B ⟶ C) :
 
 It maps a commutative `R`-algebra `A` to the convolution group on algebra homomorphisms
 `H →ₐ[R] A`, and maps `φ : A ⟶ B` to post-composition with `φ`. -/
-noncomputable def pointsFunctor : CommAlgCat.{w} R ⥤ GrpCat.{max v w} where
+@[expose] noncomputable def pointsFunctor : CommAlgCat.{w} R ⥤ GrpCat.{max v w} where
   obj A := points (H := H) A
   map φ := mapPoints (H := H) φ
   map_id A := mapPoints_id (H := H) A

--- a/TauCeti/KnotTheory/Grid/Gradings.lean
+++ b/TauCeti/KnotTheory/Grid/Gradings.lean
@@ -2,8 +2,10 @@
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 -/
+module
+
 import Mathlib.Tactic.Ring
-import TauCeti.KnotTheory.Grid.JFunction
+public import TauCeti.KnotTheory.Grid.JFunction
 
 /-!
 # Maslov and Alexander gradings for grid states
@@ -45,6 +47,8 @@ Ozsváth--Stipsicz--Szabó, *Grid Homology for Knots and Links*, Chapter 3.2:
 `A(x) = (M_O(x) - M_X(x)) / 2 - (n - 1) / 2`.
 -/
 
+public section
+
 namespace TauCeti
 
 namespace GridDiagram
@@ -54,7 +58,7 @@ variable {n : ℕ} (G : GridDiagram n)
 /-- The `O`-Maslov grading of a grid state.
 
 This is the formula `M_O(x) = J(x - O, x - O) + 1`. -/
-def maslovO (x : GridState n) : ℚ :=
+@[expose] def maslovO (x : GridState n) : ℚ :=
   GridPoint.JDiff x.pointSet G.OSet x.pointSet G.OSet + 1
 
 /-- The `O`-Maslov grading as a `JDiff` self-pairing plus one. -/
@@ -71,7 +75,7 @@ theorem maslovO_eq (x : GridState n) :
 /-- The `X`-Maslov grading of a grid state.
 
 This is the formula `M_X(x) = J(x - X, x - X) + 1`. -/
-def maslovX (x : GridState n) : ℚ :=
+@[expose] def maslovX (x : GridState n) : ℚ :=
   GridPoint.JDiff x.pointSet G.XSet x.pointSet G.XSet + 1
 
 /-- The `X`-Maslov grading as a `JDiff` self-pairing plus one. -/
@@ -90,7 +94,7 @@ theorem maslovX_eq (x : GridState n) :
 This is the formula `A(x) = (M_O(x) - M_X(x)) / 2 - (n - 1) / 2`. The shift is cast
 through `ℤ`, so the formula remains literal at `n = 0`; integer-valuedness is a later grading
 theorem. -/
-def alexander (x : GridState n) : ℚ :=
+@[expose] def alexander (x : GridState n) : ℚ :=
   (G.maslovO x - G.maslovX x) / 2 - (((n : ℤ) - 1 : ℤ) : ℚ) / 2
 
 /-- The Alexander grading as the difference of the two Maslov gradings with the standard

--- a/TauCeti/KnotTheory/Grid/JFunction.lean
+++ b/TauCeti/KnotTheory/Grid/JFunction.lean
@@ -2,13 +2,15 @@
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 -/
-import Mathlib.Algebra.Field.Basic
-import Mathlib.Algebra.Field.Rat
-import Mathlib.Data.Fintype.Prod
-import Mathlib.Data.Finset.Prod
-import Mathlib.Data.Rat.Lemmas
+module
+
+public import Mathlib.Algebra.Field.Basic
+public import Mathlib.Algebra.Field.Rat
+public import Mathlib.Data.Fintype.Prod
+public import Mathlib.Data.Finset.Prod
+public import Mathlib.Data.Rat.Lemmas
 import Mathlib.Tactic.Ring
-import TauCeti.KnotTheory.Grid.Rotation
+public import TauCeti.KnotTheory.Grid.Rotation
 
 /-!
 # The grid `J`-function
@@ -55,6 +57,8 @@ for Knots and Links*, Chapter 3.2, where `J` is the symmetrization of the northe
 point-pair count.
 -/
 
+public section
+
 namespace TauCeti
 
 namespace GridPoint
@@ -64,7 +68,7 @@ variable {n : ℕ}
 /-- A grid point is strictly southwest of another when both its column and row coordinates are
 strictly smaller. This is the affine point-pair relation used in the grid `J`-function; it is
 not the toroidal cyclic order used for rectangles. -/
-def IsSouthWest (p q : Fin n × Fin n) : Prop :=
+@[expose] def IsSouthWest (p q : Fin n × Fin n) : Prop :=
   p.1.val < q.1.val ∧ p.2.val < q.2.val
 
 /-- The strict southwest relation has a decidable instance. -/
@@ -96,7 +100,7 @@ theorem not_isSouthWest_swap {p q : Fin n × Fin n} (h : IsSouthWest p q) :
   exact (not_lt_of_gt h.1) hqp.1
 
 /-- The ordered count of pairs `(p, q) ∈ s × t` with `p` strictly southwest of `q`. -/
-def I (s t : Finset (Fin n × Fin n)) : ℕ :=
+@[expose] def I (s t : Finset (Fin n × Fin n)) : ℕ :=
   ((s ×ˢ t).filter fun pq : (Fin n × Fin n) × (Fin n × Fin n) =>
     IsSouthWest pq.1 pq.2).card
 
@@ -168,7 +172,7 @@ theorem I_insert_right {p : Fin n × Fin n} {s t : Finset (Fin n × Fin n)} (h :
 
 /-- The numerator of the symmetrized `J`-function. Keeping the numerator as a natural number is
 convenient for parity and integrality lemmas before passing to rational values. -/
-def JNum (s t : Finset (Fin n × Fin n)) : ℕ :=
+@[expose] def JNum (s t : Finset (Fin n × Fin n)) : ℕ :=
   I s t + I t s
 
 /-- The numerator of `J` is the sum of the two ordered southwest counts. -/
@@ -182,7 +186,7 @@ theorem JNum_self (s : Finset (Fin n × Fin n)) : JNum s s = 2 * I s s := by
   rw [JNum_def, two_mul]
 
 /-- The rational-valued symmetrized grid `J`-function. -/
-def J (s t : Finset (Fin n × Fin n)) : ℚ :=
+@[expose] def J (s t : Finset (Fin n × Fin n)) : ℚ :=
   ((JNum s t : ℕ) : ℚ) / 2
 
 /-- The rational-valued `J`-function is half of its symmetrized numerator. -/
@@ -276,7 +280,7 @@ theorem J_insert_right {p : Fin n × Fin n} {s t : Finset (Fin n × Fin n)} (h :
 
 `JDiff s a t b` means `J(s - a, t - b)`, expanded as
 `J s t - J s b - J a t + J a b`. -/
-def JDiff (s a t b : Finset (Fin n × Fin n)) : ℚ :=
+@[expose] def JDiff (s a t b : Finset (Fin n × Fin n)) : ℚ :=
   GridPoint.J s t - GridPoint.J s b - GridPoint.J a t + GridPoint.J a b
 
 /-- The definition of `JDiff` as the expanded four-term formula. -/
@@ -549,7 +553,7 @@ namespace GridState
 variable {n : ℕ}
 
 /-- The grid `J`-function applied to the point sets of two grid states. -/
-def J (x y : GridState n) : ℚ :=
+@[expose] def J (x y : GridState n) : ℚ :=
   GridPoint.J x.pointSet y.pointSet
 
 /-- The state-level grid `J`-function is the point-set `J`-function on state point sets. -/
@@ -640,7 +644,7 @@ namespace GridDiagram
 variable {n : ℕ} (G : GridDiagram n)
 
 /-- The grid `J`-function against the `O`-markings of a grid diagram. -/
-def JO (x : GridState n) : ℚ :=
+@[expose] def JO (x : GridState n) : ℚ :=
   GridPoint.J x.pointSet G.OSet
 
 /-- `JO` is the point-set `J`-function of a state against the `O`-markings. -/
@@ -649,7 +653,7 @@ theorem JO_def (x : GridState n) : GridDiagram.JO G x = GridPoint.J x.pointSet G
   rfl
 
 /-- The grid `J`-function against the `X`-markings of a grid diagram. -/
-def JX (x : GridState n) : ℚ :=
+@[expose] def JX (x : GridState n) : ℚ :=
   GridPoint.J x.pointSet G.XSet
 
 /-- `JX` is the point-set `J`-function of a state against the `X`-markings. -/


### PR DESCRIPTION
Migrate the functor-of-points core (`PointsFunctor`, `CommHopfAlgCat`) and two grid files. `PointsFunctor` needed only its two definitions (`mapPoints`, `pointsFunctor`) exposed — the category-theory "type mismatch" errors were cascades from those being opaque, not real proof breakage, so it unblocks the affine-group-scheme cluster for later batches.

🤖 Prepared with Claude Code