### PR TITLE
feat: opt 5 more grid modules into the Lean module system

### DIFF
--- a/TauCeti/KnotTheory/Grid/BlockedRectangle.lean
+++ b/TauCeti/KnotTheory/Grid/BlockedRectangle.lean
@@ -2,9 +2,11 @@
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 -/
-import Mathlib.Data.Finset.Card
-import Mathlib.Data.ZMod.Basic
-import TauCeti.KnotTheory.Grid.Rectangle
+module
+
+public import Mathlib.Data.Finset.Card
+public import Mathlib.Data.ZMod.Basic
+public import TauCeti.KnotTheory.Grid.Rectangle
 
 /-!
 # Fully blocked empty rectangles in grid diagrams
@@ -41,6 +43,8 @@ objects and terminology follow Ozsváth--Stipsicz--Szabó, *Grid Homology for Kn
 Links*, Chapter 3.
 -/
 
+public section
+
 namespace TauCeti
 
 namespace GridDiagram
@@ -52,7 +56,7 @@ variable {n : ℕ} (G : GridDiagram n) (x y : GridState n)
 "Fully blocked" means that the rectangle is empty for the source grid state and its interior
 avoids every `O` and `X` marking. This is the rectangle set whose parity gives the coefficient
 of `y` in the fully blocked grid differential applied to `x`. -/
-noncomputable def fullyBlockedRectangles : Finset (GridRectangleBetween x y) := by
+@[expose] noncomputable def fullyBlockedRectangles : Finset (GridRectangleBetween x y) := by
   classical
   exact (GridRectangleBetween.emptyRectangles x y).filter fun R => R.AvoidsMarkings G
 
@@ -89,7 +93,7 @@ theorem fullyBlockedRectangles_subset_all :
     (GridRectangleBetween.emptyRectangles_subset_all x y)
 
 /-- The number of fully blocked empty rectangles from `x` to `y`, reduced modulo `2`. -/
-noncomputable def fullyBlockedRectangleCount : ZMod 2 :=
+@[expose] noncomputable def fullyBlockedRectangleCount : ZMod 2 :=
   (G.fullyBlockedRectangles x y).card
 
 /-- The fully blocked rectangle count is the cardinality of `fullyBlockedRectangles`, coerced

--- a/TauCeti/KnotTheory/Grid/GradingChange.lean
+++ b/TauCeti/KnotTheory/Grid/GradingChange.lean
@@ -2,9 +2,11 @@
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 -/
+module
+
 import Mathlib.Tactic.Ring
-import TauCeti.KnotTheory.Grid.Gradings
-import TauCeti.KnotTheory.Grid.RectangleSwap
+public import TauCeti.KnotTheory.Grid.Gradings
+public import TauCeti.KnotTheory.Grid.RectangleSwap
 
 /-!
 # Grading changes across a rectangle move
@@ -58,6 +60,8 @@ This supplies the rectangle grading-change part of
 formulas follow the `J`-function bookkeeping in Ozsváth--Stipsicz--Szabó, *Grid Homology for
 Knots and Links*, Chapters 3 and 4.
 -/
+
+public section
 
 namespace TauCeti
 

--- a/TauCeti/KnotTheory/Grid/GradingInteger.lean
+++ b/TauCeti/KnotTheory/Grid/GradingInteger.lean
@@ -2,8 +2,10 @@
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 -/
+module
+
 import Mathlib.Tactic.Ring
-import TauCeti.KnotTheory.Grid.Gradings
+public import TauCeti.KnotTheory.Grid.Gradings
 
 /-!
 # Integer-valuedness of the Maslov gradings
@@ -56,6 +58,8 @@ rectangle." The integrality of the Maslov gradings is the prerequisite that the 
 integrality of the Alexander grading itself builds on; see Ozsváth--Stipsicz--Szabó, *Grid Homology
 for Knots and Links*, Chapter 4.
 -/
+
+@[expose] public section
 
 namespace TauCeti
 

--- a/TauCeti/KnotTheory/Grid/Rectangle.lean
+++ b/TauCeti/KnotTheory/Grid/Rectangle.lean
@@ -2,14 +2,16 @@
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 -/
-import Mathlib.Data.Fin.Rev
-import Mathlib.Data.Finset.Image
-import Mathlib.Data.Finset.Prod
-import Mathlib.Data.Fintype.Card
-import Mathlib.Data.Fintype.Prod
-import TauCeti.KnotTheory.Grid.CyclicInterval
-import TauCeti.KnotTheory.Grid.Diagram
-import TauCeti.KnotTheory.Grid.Rotation
+module
+
+public import Mathlib.Data.Fin.Rev
+public import Mathlib.Data.Finset.Image
+public import Mathlib.Data.Finset.Prod
+public import Mathlib.Data.Fintype.Card
+public import Mathlib.Data.Fintype.Prod
+public import TauCeti.KnotTheory.Grid.CyclicInterval
+public import TauCeti.KnotTheory.Grid.Diagram
+public import TauCeti.KnotTheory.Grid.Rotation
 
 /-!
 # Rectangles in grid diagrams
@@ -55,6 +57,8 @@ asks for rectangles and empty rectangles `Rect°(x, y)`, and Lane G.3, "The comp
 encoding follows the toroidal grid-diagram convention from Ozsváth--Stipsicz--Szabó, *Grid
 Homology for Knots and Links*, Chapter 3.
 -/
+
+@[expose] public section
 
 namespace TauCeti
 
@@ -364,7 +368,7 @@ namespace GridRectangleBetween
 variable {n : ℕ} {x y : GridState n}
 
 /-- A rectangle between two grid states is determined by its two side columns. -/
-private theorem sidePair_injective :
+theorem sidePair_injective :
     Function.Injective fun R : GridRectangleBetween x y => (R.left, R.right) := by
   intro R S h
   cases R
@@ -738,7 +742,7 @@ theorem transpose_toGridRectangle (R : GridRectangleBetween x y) :
   rw [transpose_bottom, transpose_top, transpose_left, transpose_right]
 
 /-- Two oriented rectangles between the same states with equal side columns are equal. -/
-private theorem eq_of_sides {R S : GridRectangleBetween x y} (hleft : R.left = S.left)
+theorem eq_of_sides {R S : GridRectangleBetween x y} (hleft : R.left = S.left)
     (hright : R.right = S.right) : R = S := by
   obtain ⟨_, _, _, _, _, _⟩ := R
   obtain ⟨_, _, _, _, _, _⟩ := S

--- a/TauCeti/KnotTheory/Grid/RectangleSwap.lean
+++ b/TauCeti/KnotTheory/Grid/RectangleSwap.lean
@@ -2,7 +2,9 @@
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 -/
-import TauCeti.KnotTheory.Grid.Rectangle
+module
+
+public import TauCeti.KnotTheory.Grid.Rectangle
 
 /-!
 # A grid rectangle move is a column transposition
@@ -42,6 +44,8 @@ Lane G.2, "grading-change formulas across a rectangle", and Lane G.3, "The compl
 `∂² = 0`". The column-transposition picture of a rectangle move follows Ozsváth--Stipsicz--Szabó,
 *Grid Homology for Knots and Links*, Chapter 4.
 -/
+
+public section
 
 namespace TauCeti
 


### PR DESCRIPTION
Migrate the rectangle and grading grid files. The grid lane's computational content is its public API, so the dense files use `@[expose] public section`; the rest use selective `@[expose]`. Part of the ongoing bottom-up module-system migration (now 121 of 178).

🤖 Prepared with Claude Code