### PR TITLE
feat: opt the grid commutation lane into the module system

### DIFF
--- a/TauCeti/KnotTheory/Grid/Commutation.lean
+++ b/TauCeti/KnotTheory/Grid/Commutation.lean
@@ -2,8 +2,10 @@
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 -/
-import TauCeti.KnotTheory.Grid.CyclicInterval
-import TauCeti.KnotTheory.Grid.Diagram
+module
+
+public import TauCeti.KnotTheory.Grid.CyclicInterval
+public import TauCeti.KnotTheory.Grid.Diagram
 
 /-!
 # Grid diagram commutation moves
@@ -44,6 +46,8 @@ This supplies a prerequisite for `TauCetiRoadmap/CombinatorialHeegaardFloer/READ
 non-interleaving condition for row and column commutations in the grid homology construction of
 Ozsváth--Stipsicz--Szabó, *Grid Homology for Knots and Links*, Chapter 3.
 -/
+
+@[expose] public section
 
 namespace TauCeti
 

--- a/TauCeti/KnotTheory/Grid/CommutationRelabeling.lean
+++ b/TauCeti/KnotTheory/Grid/CommutationRelabeling.lean
@@ -2,8 +2,10 @@
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 -/
-import TauCeti.KnotTheory.Grid.Commutation
-import TauCeti.KnotTheory.Grid.DiagramRelabeling
+module
+
+public import TauCeti.KnotTheory.Grid.Commutation
+public import TauCeti.KnotTheory.Grid.DiagramRelabeling
 
 /-!
 # Relabeling and grid commutation arcs
@@ -39,6 +41,8 @@ G.5, "Invariance over 𝔽₂. Grid moves = commutation + (de)stabilization", wh
 are attached to elementary row and column commutations. The conventions follow
 Ozsváth--Stipsicz--Szabó, *Grid Homology for Knots and Links*, Chapter 3.
 -/
+
+public section
 
 namespace TauCeti
 

--- a/TauCeti/KnotTheory/Grid/CommutationRotation.lean
+++ b/TauCeti/KnotTheory/Grid/CommutationRotation.lean
@@ -2,9 +2,11 @@
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 -/
-import TauCeti.KnotTheory.Grid.CyclicInterval
-import TauCeti.KnotTheory.Grid.Commutation
-import TauCeti.KnotTheory.Grid.Rotation
+module
+
+public import TauCeti.KnotTheory.Grid.CyclicInterval
+public import TauCeti.KnotTheory.Grid.Commutation
+public import TauCeti.KnotTheory.Grid.Rotation
 
 /-!
 # Rotation and grid commutation arcs
@@ -33,6 +35,8 @@ G.5, "Invariance over 𝔽₂. Grid moves = commutation + (de)stabilization", wh
 are built from the row and column marking arcs. The orientation convention follows
 Ozsváth--Stipsicz--Szabó, *Grid Homology for Knots and Links*, Chapter 3.
 -/
+
+public section
 
 namespace TauCeti
 

--- a/TauCeti/KnotTheory/Grid/Complex.lean
+++ b/TauCeti/KnotTheory/Grid/Complex.lean
@@ -2,9 +2,11 @@
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 -/
-import Mathlib.Data.ZMod.Basic
-import Mathlib.LinearAlgebra.Finsupp.LSum
-import TauCeti.KnotTheory.Grid.BlockedRectangle
+module
+
+public import Mathlib.Data.ZMod.Basic
+public import Mathlib.LinearAlgebra.Finsupp.LSum
+public import TauCeti.KnotTheory.Grid.BlockedRectangle
 
 /-!
 # The fully blocked grid chain module
@@ -35,6 +37,8 @@ This supplies a prerequisite for `TauCetiRoadmap/CombinatorialHeegaardFloer/READ
 markings)". The coefficient formula follows Ozsváth--Stipsicz--Szabó, *Grid Homology for
 Knots and Links*, Chapter 3.
 -/
+
+public section
 
 namespace TauCeti
 
@@ -132,6 +136,7 @@ variable {n : ℕ} (G : GridDiagram n)
 /-- The value of the fully blocked differential on a single grid-state generator.
 
 Its `y`-coefficient is the parity of fully blocked empty rectangles from `x` to `y`. -/
+@[expose]
 noncomputable def fullyBlockedDifferentialOnGenerator (x : GridState n) : GridChain (ZMod 2) n :=
   Finset.univ.sum fun y : GridState n =>
     Finsupp.single y (G.fullyBlockedRectangleCount x y)

--- a/TauCeti/KnotTheory/Grid/CyclicInterval.lean
+++ b/TauCeti/KnotTheory/Grid/CyclicInterval.lean
@@ -123,7 +123,7 @@ theorem right_notMem_cIoo (a b : Fin n) : b ∉ cIoo a b := by
 
 The endpoints `a₀`, `a₁` lie on the same side of the pair `b₀`, `b₁`, and conversely. This
 two-sided formulation handles shared-endpoint cases uniformly. -/
-def Noninterleaving (a₀ a₁ b₀ b₁ : Fin n) : Prop :=
+@[expose] def Noninterleaving (a₀ a₁ b₀ b₁ : Fin n) : Prop :=
   (a₀ ∈ cIoo b₀ b₁ ↔ a₁ ∈ cIoo b₀ b₁) ∧
     (b₀ ∈ cIoo a₀ a₁ ↔ b₁ ∈ cIoo a₀ a₁)
 

--- a/TauCeti/KnotTheory/Grid/DifferentialSymmetry.lean
+++ b/TauCeti/KnotTheory/Grid/DifferentialSymmetry.lean
@@ -2,8 +2,10 @@
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 -/
-import Mathlib.LinearAlgebra.Finsupp.LSum
-import TauCeti.KnotTheory.Grid.Complex
+module
+
+public import Mathlib.LinearAlgebra.Finsupp.LSum
+public import TauCeti.KnotTheory.Grid.Complex
 
 /-!
 # Symmetries of the fully blocked grid differential
@@ -44,6 +46,8 @@ invariance naturality-ready": these are the chain-level symmetries of the fully 
 complex on which an invariance statement is later built. The diagonal and marking symmetries
 follow Ozsváth--Stipsicz--Szabó, *Grid Homology for Knots and Links*, Chapter 3.
 -/
+
+public section
 
 namespace TauCeti
 


### PR DESCRIPTION
Migrate the column/row commutation grid files. The key fix was exposing `Grid.Noninterleaving` in the already-merged `CyclicInterval`: the commutation predicates unfold to it, so the `*_iff` rfl-lemmas need its body visible to module consumers — a producer-side exposure as consumers come online. Part of the ongoing migration (now 127 of 178).

🤖 Prepared with Claude Code