### PR TITLE
feat: opt the comodule and functor-of-points core into the module system

### DIFF
--- a/TauCeti/Algebra/AlgebraicGroup/FiniteTypeCommHopfAlgCat.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/FiniteTypeCommHopfAlgCat.lean
@@ -2,8 +2,10 @@
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 -/
-import Mathlib.Algebra.Category.CommAlgCat.FiniteType
-import TauCeti.Algebra.AlgebraicGroup.CommHopfAlgCat
+module
+
+public import Mathlib.Algebra.Category.CommAlgCat.FiniteType
+public import TauCeti.Algebra.AlgebraicGroup.CommHopfAlgCat
 
 /-!
 # Finite-type commutative Hopf algebras
@@ -36,6 +38,8 @@ infrastructure is Mathlib's `FGAlgCat` and `Algebra.FiniteType`; the Hopf algebr
 is Mathlib's bundled `CommHopfAlgCat`, on top of which Tau Ceti adds the points functor.
 -/
 
+public section
+
 open CategoryTheory
 
 namespace TauCeti
@@ -44,7 +48,7 @@ universe u v w
 
 /-- The object property on commutative Hopf algebras selecting finite-type coordinate
 algebras. -/
-def finiteTypeCommHopfAlgProperty (R : Type u) [CommRing R] :
+@[expose] def finiteTypeCommHopfAlgProperty (R : Type u) [CommRing R] :
     ObjectProperty (_root_.CommHopfAlgCat.{v} R) :=
   fun H => Algebra.FiniteType R H
 
@@ -167,7 +171,7 @@ lemma forget₂_fgAlgCat_map {H K : FiniteTypeCommHopfAlgCat.{u, v} R} (φ : H �
 
 /-- The contravariant group-valued functor of points of a finite-type commutative Hopf
 algebra. -/
-noncomputable def pointsFunctor :
+@[expose] noncomputable def pointsFunctor :
     (FiniteTypeCommHopfAlgCat.{u, v} R)ᵒᵖ ⥤ CommAlgCat.{w} R ⥤ GrpCat.{max v w} :=
   CategoryTheory.Functor.op
       (forget₂ (FiniteTypeCommHopfAlgCat.{u, v} R) (_root_.CommHopfAlgCat.{v} R)) ⋙

--- a/TauCeti/Algebra/AlgebraicGroup/HopfIdealQuotient.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/HopfIdealQuotient.lean
@@ -2,9 +2,11 @@
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 -/
-import Mathlib.RingTheory.FiniteType
-import TauCeti.Algebra.AlgebraicGroup.FiniteTypeCommHopfAlgCat
-import TauCeti.Algebra.HopfAlgebra.Quotient
+module
+
+public import Mathlib.RingTheory.FiniteType
+public import TauCeti.Algebra.AlgebraicGroup.FiniteTypeCommHopfAlgCat
+public import TauCeti.Algebra.HopfAlgebra.Quotient
 
 /-!
 # Hopf-ideal quotients of finite-type commutative Hopf algebras
@@ -35,6 +37,8 @@ which cites Sweedler, *Hopf Algebras*, Chapter 4, and Waterhouse, *Introduction 
 Group Schemes*, §16. The finite-type descent is Mathlib's
 `Algebra.FiniteType.quotient`.
 -/
+
+public section
 
 namespace TauCeti
 

--- a/TauCeti/Algebra/Coalgebra/Comodule.lean
+++ b/TauCeti/Algebra/Coalgebra/Comodule.lean
@@ -2,7 +2,9 @@
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 -/
-import Mathlib.RingTheory.Coalgebra.Basic
+module
+
+public import Mathlib.RingTheory.Coalgebra.Basic
 
 /-!
 # Comodules over a coalgebra
@@ -29,6 +31,8 @@ This follows the standard definition of a right comodule over a coalgebra; see f
 Sweedler, *Hopf Algebras*, Chapter 2. It is added for the "Comodules over a coalgebra/Hopf
 algebra" target in Layer 1 of the Tau Ceti reductive-groups roadmap.
 -/
+
+public section
 
 open scoped TensorProduct
 
@@ -164,16 +168,14 @@ theorem map_coact_apply (f : Hom R C M N) (m : M) :
 
 variable (R C M) in
 /-- The identity morphism of a right comodule. -/
-@[simps!]
-def id : Hom R C M M where
+@[expose, simps!] def id : Hom R C M M where
   toLinearMap := LinearMap.id
   map_coact := by
     ext m
     simp
 
 /-- Composition of right-comodule morphisms. -/
-@[simps!]
-def comp (g : Hom R C N P) (f : Hom R C M N) : Hom R C M P where
+@[expose, simps!] def comp (g : Hom R C N P) (f : Hom R C M N) : Hom R C M P where
   toLinearMap := g.toLinearMap ∘ₗ f.toLinearMap
   map_coact := by
     ext m

--- a/TauCeti/Algebra/Coalgebra/Comodule/Hom.lean
+++ b/TauCeti/Algebra/Coalgebra/Comodule/Hom.lean
@@ -2,7 +2,9 @@
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 -/
-import TauCeti.Algebra.Coalgebra.Comodule
+module
+
+public import TauCeti.Algebra.Coalgebra.Comodule
 
 /-!
 # Additive structure on comodule morphisms
@@ -17,6 +19,8 @@ This is basic infrastructure for the reductive-groups roadmap Layer 1 target
 scheme should have additive hom-sets before finite-dimensional, tensor, and dual structures
 are built on top.
 -/
+
+public section
 
 open scoped TensorProduct
 
@@ -125,7 +129,7 @@ instance instAddCommMonoid : AddCommMonoid (Hom R C M N) where
     rw [show (Nat.succ n • f : Hom R C M N) = f + n • f from rfl]
     rw [add_apply, add_apply, add_comm]
 
-private def toLinearMapAddMonoidHom : Hom R C M N →+ M →ₗ[R] N where
+@[expose] def toLinearMapAddMonoidHom : Hom R C M N →+ M →ₗ[R] N where
   toFun f := f.toLinearMap
   map_zero' := zero_toLinearMap
   map_add' := add_toLinearMap

--- a/TauCeti/Algebra/Coalgebra/Comodule/Preadditive.lean
+++ b/TauCeti/Algebra/Coalgebra/Comodule/Preadditive.lean
@@ -2,8 +2,10 @@
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 -/
-import Mathlib.CategoryTheory.Preadditive.Basic
-import TauCeti.Algebra.Coalgebra.ComoduleCat
+module
+
+public import Mathlib.CategoryTheory.Preadditive.Basic
+public import TauCeti.Algebra.Coalgebra.ComoduleCat
 
 /-!
 # Preadditive structure on comodule categories
@@ -35,6 +37,8 @@ This supplies a prerequisite for
 algebra": the finite-dimensional comodule representation category should be an additive
 category before tensor products, duals, and Tannakian structure are built on top.
 -/
+
+public section
 
 open CategoryTheory
 open scoped TensorProduct

--- a/TauCeti/Algebra/Coalgebra/Comodule/Zero.lean
+++ b/TauCeti/Algebra/Coalgebra/Comodule/Zero.lean
@@ -2,7 +2,9 @@
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 -/
-import TauCeti.Algebra.Coalgebra.ComoduleCat
+module
+
+public import TauCeti.Algebra.Coalgebra.ComoduleCat
 
 /-!
 # The zero comodule
@@ -31,6 +33,8 @@ The construction is the standard zero object in the category of comodules; see S
 algebra". The proof that a subsingleton bundled comodule is zero follows Mathlib's
 `SemimoduleCat.isZero_of_subsingleton` / `ModuleCat.isZero_of_subsingleton` pattern.
 -/
+
+public section
 
 open CategoryTheory CategoryTheory.Limits
 open scoped TensorProduct

--- a/TauCeti/Algebra/Coalgebra/ComoduleCat.lean
+++ b/TauCeti/Algebra/Coalgebra/ComoduleCat.lean
@@ -2,9 +2,11 @@
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 -/
-import Mathlib.Algebra.Category.ModuleCat.Semi
-import Mathlib.CategoryTheory.Limits.Shapes.ZeroMorphisms
-import TauCeti.Algebra.Coalgebra.Comodule.Hom
+module
+
+public import Mathlib.Algebra.Category.ModuleCat.Semi
+public import Mathlib.CategoryTheory.Limits.Shapes.ZeroMorphisms
+public import TauCeti.Algebra.Coalgebra.Comodule.Hom
 
 /-!
 # The category of comodules over a coalgebra
@@ -33,6 +35,8 @@ Layer 1 of the Tau Ceti reductive-groups roadmap: "Comodules over a coalgebra/Ho
 The bundled-category API follows the pattern of `Mathlib.Algebra.Category.CoalgCat.Basic` and
 `Mathlib.LinearAlgebra.QuadraticForm.QuadraticModuleCat`.
 -/
+
+public section
 
 open CategoryTheory
 
@@ -330,7 +334,7 @@ theorem forget₂_map {M N : ComoduleCat.{u, v, w} R C} (f : M ⟶ N) :
   rfl
 
 /-- A categorical isomorphism of comodules induces the underlying linear equivalence. -/
-def isoToLinearEquiv {M N : ComoduleCat.{u, v, w} R C} (i : M ≅ N) : M ≃ₗ[R] N :=
+@[expose] def isoToLinearEquiv {M N : ComoduleCat.{u, v, w} R C} (i : M ≅ N) : M ≃ₗ[R] N :=
   ((forget₂ (ComoduleCat.{u, v, w} R C) (SemimoduleCat.{w} R)).mapIso i).toLinearEquivₛ
 
 /-- The linear equivalence induced by a comodule isomorphism has the isomorphism's forward
@@ -390,7 +394,7 @@ theorem isoToLinearEquiv_trans {M N P : ComoduleCat.{u, v, w} R C} (i : M ≅ N)
 
 /-- Build a comodule isomorphism from a linear equivalence whose forward map respects the
 coactions. -/
-def isoOfLinearEquiv {M N : ComoduleCat.{u, v, w} R C} (e : M ≃ₗ[R] N)
+@[expose] def isoOfLinearEquiv {M N : ComoduleCat.{u, v, w} R C} (e : M ≃ₗ[R] N)
     (h : TensorProduct.map e.toLinearMap LinearMap.id ∘ₗ
         Comodule.coact (R := R) (C := C) (M := M) =
       Comodule.coact (R := R) (C := C) (M := N) ∘ₗ e.toLinearMap)

--- a/TauCeti/Algebra/Coalgebra/Subcoalgebra/RegularSubcomodule.lean
+++ b/TauCeti/Algebra/Coalgebra/Subcoalgebra/RegularSubcomodule.lean
@@ -2,8 +2,10 @@
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 -/
-import TauCeti.Algebra.Coalgebra.Subcoalgebra.Lattice
-import TauCeti.Algebra.Coalgebra.Subcomodule.Lattice
+module
+
+public import TauCeti.Algebra.Coalgebra.Subcoalgebra.Lattice
+public import TauCeti.Algebra.Coalgebra.Subcomodule.Lattice
 
 /-!
 # Subcoalgebras as subcomodules of the regular comodule
@@ -29,6 +31,8 @@ This follows immediately from the standard definitions: if `Δ(D) ⊆ D ⊗ D`, 
 `Δ(D) ⊆ D ⊗ C`, so `D` is a subcomodule of the regular comodule. The definitions of
 subcoalgebra and subcomodule follow Sweedler, *Hopf Algebras*, Chapter 2.
 -/
+
+public section
 
 open scoped TensorProduct
 
@@ -59,7 +63,7 @@ private theorem tensorSquare_range_le_regular_range (D : Subcoalgebra R C) :
 
 The underlying submodule is unchanged; the map `D ⊗ D → C ⊗ C` factors through
 `D ⊗ C → C ⊗ C` by including the second tensor factor. -/
-def toRegularSubcomodule (D : Subcoalgebra R C) : Subcomodule R C C where
+@[expose] def toRegularSubcomodule (D : Subcoalgebra R C) : Subcomodule R C C where
   carrier := D.toSubmodule
   coact_mem' := by
     intro c hc
@@ -86,7 +90,7 @@ theorem toRegularSubcomodule_mono {D E : Subcoalgebra R C} (hDE : D ≤ E) :
   exact mem_toRegularSubcomodule.2 (hDE (mem_toRegularSubcomodule.1 hc))
 
 /-- Viewing subcoalgebras as regular subcomodules is an order embedding. -/
-def toRegularSubcomoduleOrderEmbedding :
+@[expose] def toRegularSubcomoduleOrderEmbedding :
     Subcoalgebra R C ↪o Subcomodule R C C where
   toFun := toRegularSubcomodule
   inj' D E h := by

--- a/TauCeti/Algebra/Coalgebra/Subcomodule.lean
+++ b/TauCeti/Algebra/Coalgebra/Subcomodule.lean
@@ -2,8 +2,10 @@
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 -/
-import Mathlib.RingTheory.Finiteness.Basic
-import TauCeti.Algebra.Coalgebra.Comodule
+module
+
+public import Mathlib.RingTheory.Finiteness.Basic
+public import TauCeti.Algebra.Coalgebra.Comodule
 
 /-!
 # Subcomodules
@@ -33,6 +35,8 @@ This follows the standard definition of a subcomodule: `N ≤ M` satisfies
 
 The lightweight range-based API follows the pattern of `TauCeti.Subcoalgebra`.
 -/
+
+public section
 
 open scoped TensorProduct
 
@@ -83,7 +87,7 @@ instance : PartialOrder (Subcomodule R C M) :=
   .ofSetLike (Subcomodule R C M) M
 
 /-- The underlying submodule of a subcomodule. -/
-def toSubmodule (N : Subcomodule R C M) : Submodule R M :=
+@[expose] def toSubmodule (N : Subcomodule R C M) : Submodule R M :=
   N.carrier
 
 @[simp]
@@ -118,7 +122,7 @@ theorem coact_mem (N : Subcomodule R C M) {m : M} (hm : m ∈ N) :
   N.coact_mem' hm
 
 /-- Constructor from a submodule and the tensor-product stability condition. -/
-def ofSubmodule (N : Submodule R M)
+@[expose] def ofSubmodule (N : Submodule R M)
     (hN :
       ∀ ⦃m : M⦄, m ∈ N →
         Comodule.coact (R := R) (C := C) (M := M) m ∈
@@ -216,7 +220,7 @@ private theorem image_tensor_apply (f : Comodule.Hom R C M N) (A : Subcomodule R
   | add x y hx hy => simp only [map_add, hx, hy]
 
 /-- The image of a subcomodule under a comodule morphism. -/
-def map (A : Subcomodule R C M) (f : Comodule.Hom R C M N) : Subcomodule R C N where
+@[expose] def map (A : Subcomodule R C M) (f : Comodule.Hom R C M N) : Subcomodule R C N where
   carrier := A.carrier.map f.toLinearMap
   coact_mem' := by
     intro n hn

--- a/TauCeti/Algebra/Coalgebra/Subcomodule/Comap.lean
+++ b/TauCeti/Algebra/Coalgebra/Subcomodule/Comap.lean
@@ -2,9 +2,11 @@
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 -/
-import Mathlib.LinearAlgebra.TensorProduct.RightExactness
-import Mathlib.RingTheory.Flat.Basic
-import TauCeti.Algebra.Coalgebra.Subcomodule
+module
+
+public import Mathlib.LinearAlgebra.TensorProduct.RightExactness
+public import Mathlib.RingTheory.Flat.Basic
+public import TauCeti.Algebra.Coalgebra.Subcomodule
 
 /-!
 # Inverse images of subcomodules
@@ -34,6 +36,8 @@ The construction is the standard inverse image of a subcomodule; see Sweedler,
 *Hopf Algebras*, Chapter 2. The exactness step reuses Mathlib's
 `TensorProduct.rTensor_exact` and `LinearMap.exact_subtype_ker_map`.
 -/
+
+public section
 
 open scoped TensorProduct
 
@@ -156,7 +160,7 @@ private theorem comap_coact_mem (f : Comodule.Hom R C M N) (B : Subcomodule R C 
   coact_mem_range_comap_toLinearMap f B hm
 
 /-- The inverse image of a subcomodule under a comodule morphism. -/
-def comap (B : Subcomodule R C N) (f : Comodule.Hom R C M N) : Subcomodule R C M where
+@[expose] def comap (B : Subcomodule R C N) (f : Comodule.Hom R C M N) : Subcomodule R C M where
   carrier := B.toSubmodule.comap f.toLinearMap
   coact_mem' := by
     intro m hm

--- a/TauCeti/Algebra/Coalgebra/Subcomodule/Lattice.lean
+++ b/TauCeti/Algebra/Coalgebra/Subcomodule/Lattice.lean
@@ -2,9 +2,11 @@
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 -/
-import Mathlib.LinearAlgebra.DFinsupp
-import Mathlib.RingTheory.Finiteness.Basic
-import TauCeti.Algebra.Coalgebra.Subcomodule
+module
+
+public import Mathlib.LinearAlgebra.DFinsupp
+public import Mathlib.RingTheory.Finiteness.Basic
+public import TauCeti.Algebra.Coalgebra.Subcomodule
 
 /-!
 # Joins of subcomodules
@@ -34,6 +36,8 @@ The lattice construction is adapted from `TauCeti.Algebra.Coalgebra.Subcoalgebra
 and the image-join lemmas follow the corresponding map API in
 `TauCeti.Algebra.Coalgebra.Subcoalgebra.Map`.
 -/
+
+public section
 
 open scoped TensorProduct
 
@@ -122,28 +126,23 @@ theorem mem_sup {N P : Subcomodule R C M} {m : M} :
   rw [← mem_toSubmodule, sup_toSubmodule, Submodule.mem_sup]
   rfl
 
-private theorem le_sup_left' (N P : Subcomodule R C M) : N ≤ N ⊔ P := by
-  intro m hm
-  rw [← mem_toSubmodule, sup_toSubmodule]
-  exact Submodule.mem_sup_left ((mem_toSubmodule).2 hm)
-
-private theorem le_sup_right' (N P : Subcomodule R C M) : P ≤ N ⊔ P := by
-  intro m hm
-  rw [← mem_toSubmodule, sup_toSubmodule]
-  exact Submodule.mem_sup_right ((mem_toSubmodule).2 hm)
-
-private theorem sup_le' {N P Q : Subcomodule R C M} (hN : N ≤ Q) (hP : P ≤ Q) :
-    N ⊔ P ≤ Q := by
-  intro m hm
-  rw [mem_sup] at hm
-  rcases hm with ⟨n, hn, p, hp, rfl⟩
-  exact add_mem (hN hn) (hP hp)
-
 /-- Subcomodules form a semilattice under the join whose carrier is the supremum of the
 underlying submodules. -/
 instance instSemilatticeSup : SemilatticeSup (Subcomodule R C M) :=
-  SemilatticeSup.mk (fun N P => N ⊔ P) le_sup_left' le_sup_right'
-    (fun _ _ _ => sup_le')
+  SemilatticeSup.mk (fun N P => N ⊔ P)
+    (fun _ _ => by
+      intro m hm
+      rw [← mem_toSubmodule, sup_toSubmodule]
+      exact Submodule.mem_sup_left ((mem_toSubmodule).2 hm))
+    (fun _ _ => by
+      intro m hm
+      rw [← mem_toSubmodule, sup_toSubmodule]
+      exact Submodule.mem_sup_right ((mem_toSubmodule).2 hm))
+    (fun _ _ _ hN hP => by
+      intro m hm
+      rw [mem_sup] at hm
+      rcases hm with ⟨n, hn, p, hp, rfl⟩
+      exact add_mem (hN hn) (hP hp))
 
 /-- The underlying submodule of a supremum of a set of subcomodules is the supremum of the
 underlying submodules indexed by that set. -/


### PR DESCRIPTION
Migrate 11 more files: the finite-type Hopf-algebra category, the Hopf-ideal quotient, and the comodule/subcomodule core (`Comodule`, `ComoduleCat`, `Hom`, `Subcomodule`, ...). The fixes were exposure-driven (`finiteTypeCommHopfAlgProperty`, the local `pointsFunctor`, `toLinearMapAddMonoidHom`, and `@[expose, simps]` where simps generators are consumed); the subcomodule semilattice witnesses are inlined into the instance rather than exposed. Now 137 of 178.

🤖 Prepared with Claude Code