### PR TITLE
feat: add the tautological diffeomorphism action

### DIFF
--- a/TauCeti/Geometry/Diffeomorphism/Action.lean
+++ b/TauCeti/Geometry/Diffeomorphism/Action.lean
@@ -1,0 +1,96 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+module
+
+public import TauCeti.Geometry.Diffeomorphism.Group
+public import Mathlib.Topology.Algebra.ConstMulAction
+public import Mathlib.Algebra.Group.Subgroup.Actions
+
+/-!
+# The tautological action of the diffeomorphism group
+
+The self-diffeomorphism group `M ≃ₘ^n⟮I, I⟯ M` acts on the underlying manifold by evaluation:
+`φ • x = φ x`. This file records that action, its faithfulness, continuity in the point, and
+the forgetful homomorphism to the homeomorphism group.
+
+This is a small prerequisite for the geometric-topology roadmap
+(`TauCetiRoadmap/GeometricTopology/README.md`, layer 3, "diffeomorphism groups with the C^∞
+topology"). The layer builds `Diff(M)` as a group first and then equips it with the `C^∞`
+topology; the evaluation action and the map `Diff(M) → Homeomorph(M)` are basic API for relating
+that future topological group to the underlying space.
+
+## Main definitions
+
+* `TauCeti.Diffeomorph.toHomeomorphHom`: the forgetful group homomorphism from
+  self-diffeomorphisms to self-homeomorphisms.
+* `TauCeti.Diffeomorph.applyMulAction`: the `MulAction (M ≃ₘ^n⟮I, I⟯ M) M` with
+  `φ • x = φ x`.
+* `TauCeti.Diffeomorph.applyFaithfulSMul`: the action is faithful.
+* `TauCeti.Diffeomorph.applyContinuousConstSMul`: each diffeomorphism acts continuously.
+* `TauCeti.Diffeomorph.applySubgroupContinuousConstSMul`: subgroups inherit continuity in the
+  point.
+-/
+
+public section
+
+namespace TauCeti
+
+open scoped Manifold ContDiff
+
+namespace Diffeomorph
+
+variable {𝕜 : Type*} [NontriviallyNormedField 𝕜]
+  {E : Type*} [NormedAddCommGroup E] [NormedSpace 𝕜 E]
+  {H : Type*} [TopologicalSpace H] {I : ModelWithCorners 𝕜 E H}
+  {M : Type*} [TopologicalSpace M] [ChartedSpace H M] {n : ℕ∞ω}
+
+/-- The forgetful group homomorphism from self-diffeomorphisms to self-homeomorphisms. -/
+@[expose, simps]
+def toHomeomorphHom : (M ≃ₘ^n⟮I, I⟯ M) →* (M ≃ₜ M) where
+  toFun f := f.toHomeomorph
+  map_one' := rfl
+  map_mul' _ _ := rfl
+
+/-- The forgetful homomorphism to self-homeomorphisms is injective. -/
+theorem toHomeomorphHom_injective :
+    Function.Injective (toHomeomorphHom : (M ≃ₘ^n⟮I, I⟯ M) → (M ≃ₜ M)) := by
+  intro f g h
+  apply _root_.Diffeomorph.ext
+  intro x
+  exact congr_fun (congrArg DFunLike.coe h) x
+
+/-- The tautological action of the self-diffeomorphism group on the manifold by evaluation. -/
+instance applyMulAction : MulAction (M ≃ₘ^n⟮I, I⟯ M) M where
+  smul f x := f x
+  one_smul _ := rfl
+  mul_smul _ _ _ := rfl
+
+/-- The tautological action of `M ≃ₘ^n⟮I, I⟯ M` on `M` is given by evaluation. -/
+@[simp]
+theorem smul_def (f : M ≃ₘ^n⟮I, I⟯ M) (x : M) : f • x = f x := rfl
+
+/-- The action homomorphism of the tautological diffeomorphism action is the forgetful homomorphism
+to permutations. -/
+theorem toPermHom_eq_toPerm :
+    MulAction.toPermHom (M ≃ₘ^n⟮I, I⟯ M) M = toPerm := rfl
+
+/-- The tautological action of `M ≃ₘ^n⟮I, I⟯ M` on `M` is faithful. -/
+instance applyFaithfulSMul : FaithfulSMul (M ≃ₘ^n⟮I, I⟯ M) M :=
+  ⟨fun h => _root_.Diffeomorph.ext h⟩
+
+/-- The action of each self-diffeomorphism on `M` is continuous. -/
+instance applyContinuousConstSMul : ContinuousConstSMul (M ≃ₘ^n⟮I, I⟯ M) M :=
+  ⟨fun f => f.continuous⟩
+
+/-- A subgroup of the self-diffeomorphism group acts continuously on `M` in the point, reusing
+continuity of the ambient action. Mathlib transfers `MulAction` and `FaithfulSMul` to a subgroup
+but not `ContinuousConstSMul`, so we record it here. -/
+instance applySubgroupContinuousConstSMul (G : Subgroup (M ≃ₘ^n⟮I, I⟯ M)) :
+    ContinuousConstSMul G M :=
+  ⟨fun f => continuous_const_smul (f : M ≃ₘ^n⟮I, I⟯ M)⟩
+
+end Diffeomorph
+
+end TauCeti

--- a/TauCeti/Geometry/Diffeomorphism/Action.lean
+++ b/TauCeti/Geometry/Diffeomorphism/Action.lean
@@ -5,9 +5,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 module
 
 public import TauCeti.Geometry.Diffeomorphism.Group
-public import TauCeti.Topology.Algebra.HomeomorphAction
-public import Mathlib.Topology.Algebra.ConstMulAction
-public import Mathlib.Algebra.Group.Subgroup.Actions
+public import TauCeti.Topology.Algebra.ConstMulAction
 
 /-!
 # The tautological action of the diffeomorphism group
@@ -15,8 +13,8 @@ public import Mathlib.Algebra.Group.Subgroup.Actions
 The self-diffeomorphism group `M ≃ₘ^n⟮I, I⟯ M` acts on the underlying manifold by evaluation:
 `φ • x = φ x`. This file records that action, its faithfulness, and continuity in the point.
 
-The action formalization mirrors `TauCeti.Homeomorph.applyMulAction` and
-`TauCeti.Homeomorph.applyContinuousConstSMul` in `TauCeti.Topology.Algebra.HomeomorphAction`,
+The action formalization mirrors `TauCeti.Homeomorph.applyMulAction` in
+`TauCeti.Topology.Algebra.HomeomorphAction`,
 which in turn follows `Equiv.Perm.applyMulAction` and the construction in Kim Morrison's
 mathlib4#40135.
 
@@ -61,6 +59,7 @@ theorem smul_def (f : M ≃ₘ^n⟮I, I⟯ M) (x : M) : f • x = f x := rfl
 
 /-- The action homomorphism of the tautological diffeomorphism action is the forgetful homomorphism
 to permutations. -/
+@[simp]
 theorem toPermHom_eq_toPerm :
     MulAction.toPermHom (M ≃ₘ^n⟮I, I⟯ M) M = toPerm := by
   ext f x

--- a/TauCeti/Geometry/Diffeomorphism/Action.lean
+++ b/TauCeti/Geometry/Diffeomorphism/Action.lean
@@ -5,6 +5,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 module
 
 public import TauCeti.Geometry.Diffeomorphism.Group
+public import TauCeti.Topology.Algebra.HomeomorphAction
 public import Mathlib.Topology.Algebra.ConstMulAction
 public import Mathlib.Algebra.Group.Subgroup.Actions
 
@@ -12,8 +13,12 @@ public import Mathlib.Algebra.Group.Subgroup.Actions
 # The tautological action of the diffeomorphism group
 
 The self-diffeomorphism group `M ≃ₘ^n⟮I, I⟯ M` acts on the underlying manifold by evaluation:
-`φ • x = φ x`. This file records that action, its faithfulness, continuity in the point, and
-the forgetful homomorphism to the homeomorphism group.
+`φ • x = φ x`. This file records that action, its faithfulness, and continuity in the point.
+
+The action formalization mirrors `TauCeti.Homeomorph.applyMulAction` and
+`TauCeti.Homeomorph.applyContinuousConstSMul` in `TauCeti.Topology.Algebra.HomeomorphAction`,
+which in turn follows `Equiv.Perm.applyMulAction` and the construction in Kim Morrison's
+mathlib4#40135.
 
 This is a small prerequisite for the geometric-topology roadmap
 (`TauCetiRoadmap/GeometricTopology/README.md`, layer 3, "diffeomorphism groups with the C^∞
@@ -23,8 +28,6 @@ that future topological group to the underlying space.
 
 ## Main definitions
 
-* `TauCeti.Diffeomorph.toHomeomorphHom`: the forgetful group homomorphism from
-  self-diffeomorphisms to self-homeomorphisms.
 * `TauCeti.Diffeomorph.applyMulAction`: the `MulAction (M ≃ₘ^n⟮I, I⟯ M) M` with
   `φ • x = φ x`.
 * `TauCeti.Diffeomorph.applyFaithfulSMul`: the action is faithful.
@@ -46,21 +49,6 @@ variable {𝕜 : Type*} [NontriviallyNormedField 𝕜]
   {H : Type*} [TopologicalSpace H] {I : ModelWithCorners 𝕜 E H}
   {M : Type*} [TopologicalSpace M] [ChartedSpace H M] {n : ℕ∞ω}
 
-/-- The forgetful group homomorphism from self-diffeomorphisms to self-homeomorphisms. -/
-@[expose, simps]
-def toHomeomorphHom : (M ≃ₘ^n⟮I, I⟯ M) →* (M ≃ₜ M) where
-  toFun f := f.toHomeomorph
-  map_one' := rfl
-  map_mul' _ _ := rfl
-
-/-- The forgetful homomorphism to self-homeomorphisms is injective. -/
-theorem toHomeomorphHom_injective :
-    Function.Injective (toHomeomorphHom : (M ≃ₘ^n⟮I, I⟯ M) → (M ≃ₜ M)) := by
-  intro f g h
-  apply _root_.Diffeomorph.ext
-  intro x
-  exact congr_fun (congrArg DFunLike.coe h) x
-
 /-- The tautological action of the self-diffeomorphism group on the manifold by evaluation. -/
 instance applyMulAction : MulAction (M ≃ₘ^n⟮I, I⟯ M) M where
   smul f x := f x
@@ -74,7 +62,9 @@ theorem smul_def (f : M ≃ₘ^n⟮I, I⟯ M) (x : M) : f • x = f x := rfl
 /-- The action homomorphism of the tautological diffeomorphism action is the forgetful homomorphism
 to permutations. -/
 theorem toPermHom_eq_toPerm :
-    MulAction.toPermHom (M ≃ₘ^n⟮I, I⟯ M) M = toPerm := rfl
+    MulAction.toPermHom (M ≃ₘ^n⟮I, I⟯ M) M = toPerm := by
+  ext f x
+  rfl
 
 /-- The tautological action of `M ≃ₘ^n⟮I, I⟯ M` on `M` is faithful. -/
 instance applyFaithfulSMul : FaithfulSMul (M ≃ₘ^n⟮I, I⟯ M) M :=
@@ -84,12 +74,11 @@ instance applyFaithfulSMul : FaithfulSMul (M ≃ₘ^n⟮I, I⟯ M) M :=
 instance applyContinuousConstSMul : ContinuousConstSMul (M ≃ₘ^n⟮I, I⟯ M) M :=
   ⟨fun f => f.continuous⟩
 
-/-- A subgroup of the self-diffeomorphism group acts continuously on `M` in the point, reusing
-continuity of the ambient action. Mathlib transfers `MulAction` and `FaithfulSMul` to a subgroup
-but not `ContinuousConstSMul`, so we record it here. -/
-instance applySubgroupContinuousConstSMul (G : Subgroup (M ≃ₘ^n⟮I, I⟯ M)) :
+/-- A subgroup of the self-diffeomorphism group acts continuously on `M` in the point, by the
+generic subgroup transfer for `ContinuousConstSMul`. -/
+abbrev applySubgroupContinuousConstSMul (G : Subgroup (M ≃ₘ^n⟮I, I⟯ M)) :
     ContinuousConstSMul G M :=
-  ⟨fun f => continuous_const_smul (f : M ≃ₘ^n⟮I, I⟯ M)⟩
+  inferInstance
 
 end Diffeomorph
 

--- a/TauCeti/Geometry/Diffeomorphism/Group.lean
+++ b/TauCeti/Geometry/Diffeomorphism/Group.lean
@@ -33,6 +33,8 @@ construction works for every smoothness exponent `n`, with `n = ∞` the case na
 * the `One`, `Mul`, `Inv`, and `Group` instances on `M ≃ₘ^n⟮I, I⟯ M`.
 * `TauCeti.Diffeomorph.toPerm`: the forgetful group homomorphism to the underlying permutation
   group `Equiv.Perm M`, which is injective.
+* `TauCeti.Diffeomorph.toHomeomorphHom`: the forgetful group homomorphism to the underlying
+  homeomorphism group, which is injective.
 
 ## Main results
 
@@ -141,6 +143,20 @@ def toPerm : (M ≃ₘ^n⟮I, I⟯ M) →* Equiv.Perm M where
 /-- The forgetful homomorphism to permutations is injective. -/
 theorem toPerm_injective : Function.Injective (toPerm : (M ≃ₘ^n⟮I, I⟯ M) → Equiv.Perm M) :=
   _root_.Diffeomorph.toEquiv_injective
+
+/-- The forgetful group homomorphism from self-diffeomorphisms to self-homeomorphisms. -/
+def toHomeomorphHom : (M ≃ₘ^n⟮I, I⟯ M) →* (M ≃ₜ M) where
+  toFun f := f.toHomeomorph
+  map_one' := rfl
+  map_mul' _ _ := rfl
+
+/-- The forgetful homomorphism to self-homeomorphisms is injective. -/
+theorem toHomeomorphHom_injective :
+    Function.Injective (toHomeomorphHom : (M ≃ₘ^n⟮I, I⟯ M) → (M ≃ₜ M)) := by
+  intro f g h
+  apply _root_.Diffeomorph.ext
+  intro x
+  exact congr_fun (congrArg DFunLike.coe h) x
 
 end Diffeomorph
 

--- a/TauCeti/Geometry/Diffeomorphism/Group.lean
+++ b/TauCeti/Geometry/Diffeomorphism/Group.lean
@@ -112,12 +112,15 @@ theorem coe_mul (f g : M ≃ₘ^n⟮I, I⟯ M) : ⇑(f * g) = f ∘ g := rfl
 theorem coe_inv (f : M ≃ₘ^n⟮I, I⟯ M) : ⇑(f⁻¹) = f.symm := rfl
 
 /-- Multiplication of self-diffeomorphisms acts by applying the right factor, then the left. -/
+@[simp]
 theorem mul_apply (f g : M ≃ₘ^n⟮I, I⟯ M) (x : M) : (f * g) x = f (g x) := rfl
 
 /-- The unit self-diffeomorphism fixes every point. -/
+@[simp]
 theorem one_apply (x : M) : (1 : M ≃ₘ^n⟮I, I⟯ M) x = x := rfl
 
 /-- The inverse in the self-diffeomorphism group acts as the inverse diffeomorphism. -/
+@[simp]
 theorem inv_apply (f : M ≃ₘ^n⟮I, I⟯ M) (x : M) : f⁻¹ x = f.symm x := rfl
 
 /-- The underlying equivalence of the unit self-diffeomorphism is the unit permutation. -/
@@ -145,7 +148,6 @@ theorem toPerm_injective : Function.Injective (toPerm : (M ≃ₘ^n⟮I, I⟯ M)
   _root_.Diffeomorph.toEquiv_injective
 
 /-- The forgetful group homomorphism from self-diffeomorphisms to self-homeomorphisms. -/
-@[expose]
 def toHomeomorphHom : (M ≃ₘ^n⟮I, I⟯ M) →* (M ≃ₜ M) where
   toFun f := f.toHomeomorph
   map_one' := rfl
@@ -155,7 +157,8 @@ def toHomeomorphHom : (M ≃ₘ^n⟮I, I⟯ M) →* (M ≃ₜ M) where
 homeomorphism. -/
 @[simp]
 theorem toHomeomorphHom_apply (f : M ≃ₘ^n⟮I, I⟯ M) :
-    toHomeomorphHom f = f.toHomeomorph :=
+    toHomeomorphHom f = f.toHomeomorph := by
+  ext x
   rfl
 
 /-- The forgetful homomorphism to self-homeomorphisms is injective. -/

--- a/TauCeti/Geometry/Diffeomorphism/Group.lean
+++ b/TauCeti/Geometry/Diffeomorphism/Group.lean
@@ -145,10 +145,18 @@ theorem toPerm_injective : Function.Injective (toPerm : (M ≃ₘ^n⟮I, I⟯ M)
   _root_.Diffeomorph.toEquiv_injective
 
 /-- The forgetful group homomorphism from self-diffeomorphisms to self-homeomorphisms. -/
+@[expose]
 def toHomeomorphHom : (M ≃ₘ^n⟮I, I⟯ M) →* (M ≃ₜ M) where
   toFun f := f.toHomeomorph
   map_one' := rfl
   map_mul' _ _ := rfl
+
+/-- The forgetful homomorphism to self-homeomorphisms sends a diffeomorphism to its underlying
+homeomorphism. -/
+@[simp]
+theorem toHomeomorphHom_apply (f : M ≃ₘ^n⟮I, I⟯ M) :
+    toHomeomorphHom f = f.toHomeomorph :=
+  rfl
 
 /-- The forgetful homomorphism to self-homeomorphisms is injective. -/
 theorem toHomeomorphHom_injective :

--- a/TauCeti/Topology/Algebra/ConstMulAction.lean
+++ b/TauCeti/Topology/Algebra/ConstMulAction.lean
@@ -11,35 +11,25 @@ public import Mathlib.Topology.Algebra.ConstMulAction
 /-!
 # Continuity for restricted actions
 
-This file records generic transfer instances for actions whose pointwise orbit maps are
-continuous. A submonoid, and hence a subgroup, inherits `ContinuousConstSMul` from an ambient
-scalar action; the additive counterparts transfer `ContinuousConstVAdd`.
+This file records a generic transfer instance for actions whose pointwise orbit maps are
+continuous. A subgroup inherits `ContinuousConstSMul` from an ambient scalar action.
 -/
 
 public section
 
 namespace TauCeti
 
-namespace Submonoid
-
-/-- A submonoid inherits continuity in the point from an ambient continuous action. -/
-@[to_additive
-  /-- An additive submonoid inherits continuity in the point from an ambient continuous action. -/]
-instance continuousConstSMul {M X : Type*} [MulOneClass M] [TopologicalSpace X] [SMul M X]
-    [ContinuousConstSMul M X] (S : Submonoid M) : ContinuousConstSMul S X :=
+private instance submonoidContinuousConstSMul {M X : Type*} [MulOneClass M] [TopologicalSpace X]
+    [SMul M X] [ContinuousConstSMul M X] (S : Submonoid M) : ContinuousConstSMul S X :=
   ⟨fun g => by
     simpa only [Submonoid.smul_def] using continuous_const_smul (g : M)⟩
-
-end Submonoid
 
 namespace Subgroup
 
 /-- A subgroup inherits continuity in the point from an ambient continuous action. -/
-@[to_additive
-  /-- An additive subgroup inherits continuity in the point from an ambient continuous action. -/]
 instance continuousConstSMul {G X : Type*} [Group G] [TopologicalSpace X] [SMul G X]
     [ContinuousConstSMul G X] (S : Subgroup G) : ContinuousConstSMul S X :=
-  Submonoid.continuousConstSMul S.toSubmonoid
+  submonoidContinuousConstSMul S.toSubmonoid
 
 end Subgroup
 

--- a/TauCeti/Topology/Algebra/ConstMulAction.lean
+++ b/TauCeti/Topology/Algebra/ConstMulAction.lean
@@ -13,7 +13,7 @@ public import Mathlib.Topology.Algebra.ConstMulAction
 
 This file records generic transfer instances for actions whose pointwise orbit maps are
 continuous. A submonoid, and hence a subgroup, inherits `ContinuousConstSMul` from an ambient
-monoid action.
+scalar action; the additive counterparts transfer `ContinuousConstVAdd`.
 -/
 
 public section
@@ -23,7 +23,9 @@ namespace TauCeti
 namespace Submonoid
 
 /-- A submonoid inherits continuity in the point from an ambient continuous action. -/
-instance continuousConstSMul {M X : Type*} [Monoid M] [TopologicalSpace X] [MulAction M X]
+@[to_additive
+  /-- An additive submonoid inherits continuity in the point from an ambient continuous action. -/]
+instance continuousConstSMul {M X : Type*} [MulOneClass M] [TopologicalSpace X] [SMul M X]
     [ContinuousConstSMul M X] (S : Submonoid M) : ContinuousConstSMul S X :=
   ⟨fun g => by
     simpa only [Submonoid.smul_def] using continuous_const_smul (g : M)⟩
@@ -33,7 +35,9 @@ end Submonoid
 namespace Subgroup
 
 /-- A subgroup inherits continuity in the point from an ambient continuous action. -/
-instance continuousConstSMul {G X : Type*} [Group G] [TopologicalSpace X] [MulAction G X]
+@[to_additive
+  /-- An additive subgroup inherits continuity in the point from an ambient continuous action. -/]
+instance continuousConstSMul {G X : Type*} [Group G] [TopologicalSpace X] [SMul G X]
     [ContinuousConstSMul G X] (S : Subgroup G) : ContinuousConstSMul S X :=
   Submonoid.continuousConstSMul S.toSubmonoid
 

--- a/TauCeti/Topology/Algebra/ConstMulAction.lean
+++ b/TauCeti/Topology/Algebra/ConstMulAction.lean
@@ -1,0 +1,42 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+module
+
+public import Mathlib.Algebra.Group.Subgroup.Actions
+public import Mathlib.Algebra.Group.Submonoid.MulAction
+public import Mathlib.Topology.Algebra.ConstMulAction
+
+/-!
+# Continuity for restricted actions
+
+This file records generic transfer instances for actions whose pointwise orbit maps are
+continuous. A submonoid, and hence a subgroup, inherits `ContinuousConstSMul` from an ambient
+monoid action.
+-/
+
+public section
+
+namespace TauCeti
+
+namespace Submonoid
+
+/-- A submonoid inherits continuity in the point from an ambient continuous action. -/
+instance continuousConstSMul {M X : Type*} [Monoid M] [TopologicalSpace X] [MulAction M X]
+    [ContinuousConstSMul M X] (S : Submonoid M) : ContinuousConstSMul S X :=
+  ⟨fun g => by
+    simpa only [Submonoid.smul_def] using continuous_const_smul (g : M)⟩
+
+end Submonoid
+
+namespace Subgroup
+
+/-- A subgroup inherits continuity in the point from an ambient continuous action. -/
+instance continuousConstSMul {G X : Type*} [Group G] [TopologicalSpace X] [MulAction G X]
+    [ContinuousConstSMul G X] (S : Subgroup G) : ContinuousConstSMul S X :=
+  Submonoid.continuousConstSMul S.toSubmonoid
+
+end Subgroup
+
+end TauCeti

--- a/TauCeti/Topology/Algebra/ConstMulAction.lean
+++ b/TauCeti/Topology/Algebra/ConstMulAction.lean
@@ -11,25 +11,34 @@ public import Mathlib.Topology.Algebra.ConstMulAction
 /-!
 # Continuity for restricted actions
 
-This file records a generic transfer instance for actions whose pointwise orbit maps are
-continuous. A subgroup inherits `ContinuousConstSMul` from an ambient scalar action.
+This file records generic transfer instances for actions whose pointwise orbit maps are
+continuous. A submonoid, and hence a subgroup, inherits `ContinuousConstSMul` from an ambient
+scalar action.
 -/
 
 public section
 
 namespace TauCeti
 
-private instance submonoidContinuousConstSMul {M X : Type*} [MulOneClass M] [TopologicalSpace X]
-    [SMul M X] [ContinuousConstSMul M X] (S : Submonoid M) : ContinuousConstSMul S X :=
+namespace Submonoid
+
+/-- A submonoid inherits continuity in the point from an ambient continuous action. -/
+@[to_additive AddSubmonoid.continuousConstVAdd
+/-- An additive submonoid inherits continuity in the point from an ambient continuous additive
+action. -/]
+instance continuousConstSMul {M X : Type*} [MulOneClass M] [TopologicalSpace X] [SMul M X]
+    [ContinuousConstSMul M X] (S : Submonoid M) : ContinuousConstSMul S X :=
   ⟨fun g => by
     simpa only [Submonoid.smul_def] using continuous_const_smul (g : M)⟩
+
+end Submonoid
 
 namespace Subgroup
 
 /-- A subgroup inherits continuity in the point from an ambient continuous action. -/
 instance continuousConstSMul {G X : Type*} [Group G] [TopologicalSpace X] [SMul G X]
     [ContinuousConstSMul G X] (S : Subgroup G) : ContinuousConstSMul S X :=
-  submonoidContinuousConstSMul S.toSubmonoid
+  TauCeti.Submonoid.continuousConstSMul S.toSubmonoid
 
 end Subgroup
 

--- a/TauCeti/Topology/Algebra/HomeomorphAction.lean
+++ b/TauCeti/Topology/Algebra/HomeomorphAction.lean
@@ -4,9 +4,8 @@ Released under Apache 2.0 license as described in the file LICENSE.
 -/
 module
 
-public import Mathlib.Topology.Algebra.ConstMulAction
+public import TauCeti.Topology.Algebra.ConstMulAction
 public import Mathlib.Topology.Homeomorph.Defs
-public import Mathlib.Algebra.Group.Subgroup.Actions
 
 /-!
 # The tautological action of the homeomorphism group
@@ -22,24 +21,11 @@ mathlib4#40135.
 * `TauCeti.Homeomorph.smul_def`: the defining simp lemma `φ • e = φ e`.
 * `TauCeti.Homeomorph.applyFaithfulSMul`: the action is faithful.
 * `TauCeti.Homeomorph.applyContinuousConstSMul`: each homeomorphism acts continuously.
-* `TauCeti.Subgroup.continuousConstSMul`: subgroups inherit continuity in the point from an
-  ambient continuous action.
 -/
 
 public section
 
 namespace TauCeti
-
-namespace Subgroup
-
-/-- A subgroup inherits continuity in the point from an ambient continuous action. -/
-instance continuousConstSMul {G X : Type*} [Group G] [TopologicalSpace X] [MulAction G X]
-    [ContinuousConstSMul G X] (S : Subgroup G) : ContinuousConstSMul S X :=
-  ⟨fun g => by
-    change Continuous fun x => (g : G) • x
-    exact continuous_const_smul (g : G)⟩
-
-end Subgroup
 
 namespace Homeomorph
 

--- a/TauCeti/Topology/Algebra/HomeomorphAction.lean
+++ b/TauCeti/Topology/Algebra/HomeomorphAction.lean
@@ -22,11 +22,24 @@ mathlib4#40135.
 * `TauCeti.Homeomorph.smul_def`: the defining simp lemma `φ • e = φ e`.
 * `TauCeti.Homeomorph.applyFaithfulSMul`: the action is faithful.
 * `TauCeti.Homeomorph.applyContinuousConstSMul`: each homeomorphism acts continuously.
+* `TauCeti.Subgroup.continuousConstSMul`: subgroups inherit continuity in the point from an
+  ambient continuous action.
 -/
 
 public section
 
 namespace TauCeti
+
+namespace Subgroup
+
+/-- A subgroup inherits continuity in the point from an ambient continuous action. -/
+instance continuousConstSMul {G X : Type*} [Group G] [TopologicalSpace X] [MulAction G X]
+    [ContinuousConstSMul G X] (S : Subgroup G) : ContinuousConstSMul S X :=
+  ⟨fun g => by
+    change Continuous fun x => (g : G) • x
+    exact continuous_const_smul (g : G)⟩
+
+end Subgroup
 
 namespace Homeomorph
 
@@ -50,15 +63,10 @@ instance applyFaithfulSMul : FaithfulSMul (E ≃ₜ E) E :=
 instance applyContinuousConstSMul : ContinuousConstSMul (E ≃ₜ E) E :=
   ⟨fun φ => φ.continuous⟩
 
--- Faithfulness for a `Subgroup (E ≃ₜ E)` is already supplied by Mathlib's generic subgroup
--- action transfer (`Mathlib.Algebra.Group.Subgroup.Actions`) from the ambient `applyFaithfulSMul`,
--- so we do not restate it. Continuity in the point, however, has no such subgroup transfer:
-
-/-- A subgroup of the homeomorphism group acts continuously on `E` in the point, reusing
-continuity of the ambient action. Mathlib transfers `MulAction` and `FaithfulSMul` to a
-subgroup but not `ContinuousConstSMul`, so we record it here. -/
-instance applySubgroupContinuousConstSMul (H : Subgroup (E ≃ₜ E)) : ContinuousConstSMul H E :=
-  ⟨fun φ => continuous_const_smul (φ : E ≃ₜ E)⟩
+/-- A subgroup of the homeomorphism group acts continuously on `E` in the point, by the generic
+subgroup transfer for `ContinuousConstSMul`. -/
+abbrev applySubgroupContinuousConstSMul (H : Subgroup (E ≃ₜ E)) : ContinuousConstSMul H E :=
+  inferInstance
 
 end Homeomorph
 


### PR DESCRIPTION
This PR adds the tautological evaluation action of the self-diffeomorphism group on its manifold: `φ • x = φ x` for `φ : M ≃ₘ^n⟮I, I⟯ M`. It also records the forgetful group homomorphism `Diffeomorph.toHomeomorphHom : (M ≃ₘ^n⟮I, I⟯ M) →* (M ≃ₜ M)`, its injectivity, the agreement of `MulAction.toPermHom` with the existing `Diffeomorph.toPerm`, and the `FaithfulSMul` / `ContinuousConstSMul` instances for the full group and continuity for subgroups.

This advances `TauCetiRoadmap/GeometricTopology/README.md`, layer 3, "diffeomorphism groups with the C^∞ topology", specifically the buildout around the group `Diff(M) := M ≃ₘ^∞⟮I, I⟯ M` and the later `Diff(M, ∂M)` subgroup/topological-group API. The bare group instance already exists in `TauCeti.Geometry.Diffeomorphism.Group`; this PR supplies the next lowest-hanging characteristic API for that group, needed before the future `C^∞` topology and smooth-family-to-`Diff(M)` constructions can talk about evaluation and subgroup actions.

No Mathlib infrastructure is vendored. The construction reuses Mathlib's `Diffeomorph.toHomeomorph`, `ContinuousConstSMul`, and subgroup action transfer, together with Tau Ceti's existing `Diffeomorph` group and `toPerm` API.

Local verification: `lake exe cache get` completed with `No files to download` and `Already decompressed 8579 file(s)`; `lake build` completed with `Build completed successfully (4154 jobs).`; `lake exe axioms` completed with `axioms: audited 4516 TauCeti declaration(s); all within the allowlist [propext, Classical.choice, Quot.sound].`

<!--tauceti-target:v1 {"focus":"GeometricTopology","id":"diffeomorphism-tautological-action"}-->

🤖 Prepared with Codex
