### PR TITLE
feat: opt the symplectic and Weil-divisor lanes into the module system (completes the migration)

### DIFF
--- a/TauCeti/AlgebraicGeometry/WeilDivisor.lean
+++ b/TauCeti/AlgebraicGeometry/WeilDivisor.lean
@@ -2,9 +2,14 @@
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 -/
-import Mathlib.Data.Finsupp.Weight
-import Mathlib.Data.Finsupp.Order
-import Mathlib.LinearAlgebra.Finsupp.LinearCombination
+module
+
+public import Mathlib.Data.Finsupp.Weight
+public import Mathlib.Data.Finsupp.Order
+public import Mathlib.LinearAlgebra.Finsupp.LinearCombination
+public import Mathlib.Algebra.Order.Ring.Int
+import Mathlib.Tactic.NormNum.Basic
+import Mathlib.Tactic.Ring
 
 /-!
 # Weil divisors as finite integer combinations of points
@@ -29,6 +34,8 @@ This advances the Tau Ceti Jacobian roadmap, Layer A, "Divisors on a curve: Weil
 `⊕_x ℤ`", "Degree", and "`Pic⁰ X = ker deg` (as an abstract group)".
 -/
 
+public section
+
 namespace TauCeti
 
 namespace AlgebraicGeometry
@@ -44,7 +51,7 @@ variable {X Y Z : Type*}
 noncomputable section
 
 /-- The coefficient of a point in a Weil divisor. -/
-def coeff (D : WeilDivisor X) (x : X) : ℤ :=
+@[expose] def coeff (D : WeilDivisor X) (x : X) : ℤ :=
   D x
 
 @[simp]
@@ -141,7 +148,7 @@ lemma mem_effectiveSubmonoid (D : WeilDivisor X) :
 /-- Push forward a formal divisor along a map of point sets by summing coefficients over
 fibres.  Geometric pushforward of Weil divisors will specialize this once the relevant point
 maps and residue-degree factors are available. -/
-noncomputable def pushforward (f : X → Y) : WeilDivisor X →+ WeilDivisor Y :=
+@[expose] noncomputable def pushforward (f : X → Y) : WeilDivisor X →+ WeilDivisor Y :=
   (Finsupp.lmapDomain ℤ ℤ f).toAddMonoidHom
 
 @[simp]
@@ -196,7 +203,7 @@ lemma pushforward_mem_effectiveSubmonoid {D : WeilDivisor X} (hD : D ∈ effecti
 
 /-- The unweighted degree of a Weil divisor, summing its coefficients.  On a curve over a
 non-algebraically-closed field, use `weightedDegree` with residue-field degrees instead. -/
-noncomputable def degree : WeilDivisor X →+ ℤ :=
+@[expose] noncomputable def degree : WeilDivisor X →+ ℤ :=
   Finsupp.degree
 
 lemma degree_apply (D : WeilDivisor X) : degree D = ∑ x ∈ D.support, D x :=
@@ -334,7 +341,7 @@ lemma IsEffective.degree_pos {D : WeilDivisor X} (hD : IsEffective D) (hD0 : D �
 For a smooth proper curve over an algebraically closed field this is the formal divisor group
 whose quotient by principal divisors gives the abstract degree-zero Picard group. Over a
 general field, use `weightedDegreeZeroSubgroup` with residue-field degrees as weights. -/
-noncomputable def degreeZeroSubgroup (X : Type*) : AddSubgroup (WeilDivisor X) :=
+@[expose] noncomputable def degreeZeroSubgroup (X : Type*) : AddSubgroup (WeilDivisor X) :=
   (degree : WeilDivisor X →+ ℤ).ker
 
 @[simp]
@@ -353,7 +360,7 @@ lemma coe_degreeZeroSubgroup_eq_zero_of_isEffective {D : degreeZeroSubgroup X}
   hD.eq_zero_of_degree_eq_zero (degree_coe_degreeZeroSubgroup D)
 
 /-- The formal divisor `[x] - [y]`, a basic source of degree-zero divisors. -/
-noncomputable def pointDifference (x y : X) : WeilDivisor X :=
+@[expose] noncomputable def pointDifference (x y : X) : WeilDivisor X :=
   ofPoint x - ofPoint y
 
 @[simp]
@@ -418,7 +425,7 @@ lemma pushforward_pointDifference (f : X → Y) (x y : X) :
   rfl
 
 /-- Pushforward as a homomorphism on unweighted degree-zero divisors. -/
-noncomputable def pushforwardDegreeZero (f : X → Y) :
+@[expose] noncomputable def pushforwardDegreeZero (f : X → Y) :
     degreeZeroSubgroup X →+ degreeZeroSubgroup Y where
   toFun D :=
     ⟨pushforward f D, by
@@ -451,7 +458,7 @@ lemma pushforwardDegreeZero_comp (g : Y → Z) (f : X → Y) :
 
 For a curve over a field `k`, the intended weight is `x ↦ [κ(x) : k]`, giving the formal
 degree-zero divisor group before principal divisors are introduced. -/
-noncomputable def weightedDegreeZeroSubgroup (w : X → ℤ) : AddSubgroup (WeilDivisor X) :=
+@[expose] noncomputable def weightedDegreeZeroSubgroup (w : X → ℤ) : AddSubgroup (WeilDivisor X) :=
   (weightedDegree w).ker
 
 @[simp]
@@ -541,7 +548,7 @@ lemma weightedPointBaseDifference_mem_weightedDegreeZeroSubgroup {w : X → ℤ}
 
 /-- Pushforward as a homomorphism on weighted degree-zero divisors, when the target weight
 pulls back to the source weight. -/
-noncomputable def pushforwardWeightedDegreeZero (wX : X → ℤ) (wY : Y → ℤ) (f : X → Y)
+@[expose] noncomputable def pushforwardWeightedDegreeZero (wX : X → ℤ) (wY : Y → ℤ) (f : X → Y)
     (hw : ∀ x, wY (f x) = wX x) :
     weightedDegreeZeroSubgroup wX →+ weightedDegreeZeroSubgroup wY where
   toFun D :=

--- a/TauCeti/AlgebraicGeometry/WeilDivisor/AbelJacobi.lean
+++ b/TauCeti/AlgebraicGeometry/WeilDivisor/AbelJacobi.lean
@@ -2,7 +2,9 @@
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 -/
-import TauCeti.AlgebraicGeometry.WeilDivisor.Principal
+module
+
+public import TauCeti.AlgebraicGeometry.WeilDivisor.Principal
 
 /-!
 # The abstract Abel-Jacobi divisor class map
@@ -26,6 +28,8 @@ formal divisor-class level available before line bundles, the Picard scheme, or 
 variety exist.  No external mathematics is vendored; this reuses Tau Ceti's `WeilDivisor`,
 `OrderSystem.divisorClass`, and `OrderSystem.picZero` API.
 -/
+
+@[expose] public section
 
 namespace TauCeti
 

--- a/TauCeti/AlgebraicGeometry/WeilDivisor/DegreeSplitting.lean
+++ b/TauCeti/AlgebraicGeometry/WeilDivisor/DegreeSplitting.lean
@@ -2,7 +2,9 @@
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 -/
-import TauCeti.AlgebraicGeometry.WeilDivisor.Principal
+module
+
+public import TauCeti.AlgebraicGeometry.WeilDivisor.Principal
 
 /-!
 # Splitting the divisor class group along the degree at a rational point
@@ -34,6 +36,8 @@ splits, the form in which the degree-zero part is used downstream. It reuses Tau
 `WeilDivisor` and `OrderSystem` API and Mathlib's `zmultiplesHom` and `AddMonoidHom`/`AddEquiv`
 machinery; no external mathematics is vendored.
 -/
+
+@[expose] public section
 
 namespace TauCeti
 
@@ -125,7 +129,7 @@ lemma degreeCorrection_mem_picZero (w : X → ℤ) (h : S.IsWeightedDegreeZero w
   rw [mem_picZero, degreeCorrection_apply, map_sub, map_zsmul,
     weightedDegreeClass_divisorClass_ofPoint, hx₀, smul_eq_mul, mul_one, sub_self]
 
-private noncomputable def degreeSplitForward (w : X → ℤ) (h : S.IsWeightedDegreeZero w)
+noncomputable def degreeSplitForward (w : X → ℤ) (h : S.IsWeightedDegreeZero w)
     {x₀ : X} (hx₀ : w x₀ = 1) : S.ClassGroup →+ picZero w h × ℤ :=
   ((S.degreeCorrection w h x₀).codRestrict (picZero w h)
       (S.degreeCorrection_mem_picZero w h hx₀)).prod (weightedDegreeClass w h)
@@ -138,7 +142,7 @@ private lemma degreeSplitForward_apply (w : X → ℤ) (h : S.IsWeightedDegreeZe
         weightedDegreeClass w h c) :=
   rfl
 
-private noncomputable def degreeSplitInverse (w : X → ℤ) (h : S.IsWeightedDegreeZero w) (x₀ : X) :
+noncomputable def degreeSplitInverse (w : X → ℤ) (h : S.IsWeightedDegreeZero w) (x₀ : X) :
     picZero w h × ℤ →+ S.ClassGroup :=
   (picZero w h).subtype.comp (AddMonoidHom.fst (picZero w h) ℤ) +
     (S.degreeSection x₀).comp (AddMonoidHom.snd (picZero w h) ℤ)
@@ -150,7 +154,7 @@ private lemma degreeSplitInverse_apply (w : X → ℤ) (h : S.IsWeightedDegreeZe
       (p : S.ClassGroup) + n • S.divisorClass (ofPoint x₀) := by
   simp [degreeSplitInverse]
 
-private lemma degreeSplitInverse_degreeSplitForward (w : X → ℤ) (h : S.IsWeightedDegreeZero w)
+lemma degreeSplitInverse_degreeSplitForward (w : X → ℤ) (h : S.IsWeightedDegreeZero w)
     {x₀ : X} (hx₀ : w x₀ = 1) (c : S.ClassGroup) :
     S.degreeSplitInverse w h x₀ (S.degreeSplitForward w h hx₀ c) = c := by
   rw [degreeSplitForward_apply, degreeSplitInverse_apply]

--- a/TauCeti/AlgebraicGeometry/WeilDivisor/LinearSystem.lean
+++ b/TauCeti/AlgebraicGeometry/WeilDivisor/LinearSystem.lean
@@ -2,7 +2,9 @@
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 -/
-import TauCeti.AlgebraicGeometry.WeilDivisor.Principal
+module
+
+public import TauCeti.AlgebraicGeometry.WeilDivisor.Principal
 
 /-!
 # Complete linear systems of Weil divisors
@@ -32,6 +34,8 @@ This advances the Tau Ceti Jacobian roadmap, Layer A, "Divisors on a curve" and 
 `OrderSystem` API and Mathlib's `Set` and quotient-group machinery; no external mathematics is
 vendored.
 -/
+
+public section
 
 namespace TauCeti
 

--- a/TauCeti/AlgebraicGeometry/WeilDivisor/Order.lean
+++ b/TauCeti/AlgebraicGeometry/WeilDivisor/Order.lean
@@ -2,9 +2,11 @@
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 -/
-import TauCeti.AlgebraicGeometry.WeilDivisor
-import Mathlib.Algebra.Order.Group.PosPart
-import Mathlib.Order.Preorder.Finsupp
+module
+
+public import TauCeti.AlgebraicGeometry.WeilDivisor
+public import Mathlib.Algebra.Order.Group.PosPart
+public import Mathlib.Order.Preorder.Finsupp
 
 /-!
 # The order on Weil divisors and the positive/negative part decomposition
@@ -31,6 +33,8 @@ external mathematics is vendored.
 This advances the Tau Ceti Jacobian roadmap, Layer A, "Divisors on a curve: Weil divisors
 `⊕_x ℤ`", "principal divisors", and "Degree".
 -/
+
+public section
 
 namespace TauCeti
 

--- a/TauCeti/AlgebraicGeometry/WeilDivisor/Principal.lean
+++ b/TauCeti/AlgebraicGeometry/WeilDivisor/Principal.lean
@@ -2,8 +2,10 @@
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 -/
-import TauCeti.AlgebraicGeometry.WeilDivisor
-import Mathlib.GroupTheory.QuotientGroup.Basic
+module
+
+public import TauCeti.AlgebraicGeometry.WeilDivisor
+public import Mathlib.GroupTheory.QuotientGroup.Basic
 
 /-!
 # Principal divisors and the divisor class group of an order system
@@ -49,6 +51,8 @@ Mathlib's `Finsupp.onFinset` (to assemble a finitely supported function from coo
 data) and `QuotientAddGroup` quotient machinery.
 -/
 
+public section
+
 namespace TauCeti
 
 namespace AlgebraicGeometry
@@ -74,7 +78,7 @@ namespace OrderSystem
 variable {X G : Type*} [AddCommGroup G] (S : OrderSystem X G)
 
 /-- The principal divisor `Σ_x ord_x(g) · [x]` attached to `g : G`. -/
-noncomputable def principalDivisor (g : G) : WeilDivisor X :=
+@[expose] noncomputable def principalDivisor (g : G) : WeilDivisor X :=
   Finsupp.onFinset (S.finite_support g).toFinset (fun x => S.ord x g) fun _ hx =>
     (S.finite_support g).mem_toFinset.mpr (Function.mem_support.mpr hx)
 
@@ -84,7 +88,7 @@ lemma coeff_principalDivisor (g : G) (x : X) :
   Finsupp.onFinset_apply
 
 /-- Principal divisors as a homomorphism `G →+ WeilDivisor X`. -/
-noncomputable def principalHom : G →+ WeilDivisor X where
+@[expose] noncomputable def principalHom : G →+ WeilDivisor X where
   toFun := S.principalDivisor
   map_zero' := by ext x; simp
   map_add' g₁ g₂ := by ext x; simp
@@ -207,7 +211,7 @@ every principal divisor has weighted degree zero.
 For a smooth proper curve over a field `k`, the intended weight is the residue-field degree
 `x ↦ [κ(x) : k]`; this is the geometric fact that a rational function has as many zeros as
 poles, counted with residue-field degrees. -/
-def IsWeightedDegreeZero (w : X → ℤ) : Prop :=
+@[expose] def IsWeightedDegreeZero (w : X → ℤ) : Prop :=
   ∀ g, weightedDegree w (S.principalDivisor g) = 0
 
 variable {S}
@@ -234,7 +238,7 @@ lemma weightedDegreeClass_divisorClass (w : X → ℤ) (h : S.IsWeightedDegreeZe
 
 /-- The weighted-degree-zero part of the divisor class group, the abstract `Pic⁰` of the
 Jacobian roadmap: the kernel of the weighted degree map on divisor classes. -/
-noncomputable def picZero (w : X → ℤ) (h : S.IsWeightedDegreeZero w) :
+@[expose] noncomputable def picZero (w : X → ℤ) (h : S.IsWeightedDegreeZero w) :
     AddSubgroup S.ClassGroup :=
   (weightedDegreeClass w h).ker
 
@@ -253,7 +257,7 @@ lemma divisorClass_mem_picZero (w : X → ℤ) (h : S.IsWeightedDegreeZero w)
 /-- An order system has *unweighted-degree-zero principal divisors* when every principal
 divisor has unweighted degree zero. This is the specialization of `IsWeightedDegreeZero` to the
 constant weight `1`, appropriate for the algebraically closed/unweighted formal setting. -/
-def IsUnweightedDegreeZero : Prop :=
+@[expose] def IsUnweightedDegreeZero : Prop :=
   S.IsWeightedDegreeZero fun _ => (1 : ℤ)
 
 lemma IsUnweightedDegreeZero.principalSubgroup_le_ker (h : S.IsUnweightedDegreeZero) :
@@ -265,6 +269,7 @@ lemma IsUnweightedDegreeZero.principalSubgroup_le_ker (h : S.IsUnweightedDegreeZ
 /-- The unweighted degree map on divisor classes, for the algebraically closed/unweighted
 specialization: the descended degree `weightedDegreeClass` at the constant weight `1`. For
 curves over a general field, use `weightedDegreeClass`. -/
+@[expose]
 noncomputable def unweightedDegreeClass (h : S.IsUnweightedDegreeZero) : S.ClassGroup →+ ℤ :=
   weightedDegreeClass (fun _ => (1 : ℤ)) h
 
@@ -276,6 +281,7 @@ lemma unweightedDegreeClass_divisorClass (h : S.IsUnweightedDegreeZero) (D : Wei
 /-- The unweighted-degree-zero part of the divisor class group, for the algebraically
 closed/unweighted specialization: `picZero` at the constant weight `1`. For curves over a
 general field, use `picZero` with residue-field-degree weights. -/
+@[expose]
 noncomputable def unweightedPicZero (h : S.IsUnweightedDegreeZero) : AddSubgroup S.ClassGroup :=
   picZero (fun _ => (1 : ℤ)) h
 

--- a/TauCeti/Geometry/Symplectic/ComplexModule.lean
+++ b/TauCeti/Geometry/Symplectic/ComplexModule.lean
@@ -2,9 +2,11 @@
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 -/
-import Mathlib.LinearAlgebra.BilinearMap
-import Mathlib.LinearAlgebra.Complex.Module
-import TauCeti.Geometry.Symplectic.AlmostComplex
+module
+
+public import Mathlib.LinearAlgebra.BilinearMap
+public import Mathlib.LinearAlgebra.Complex.Module
+public import TauCeti.Geometry.Symplectic.AlmostComplex
 
 /-!
 # Almost complex structures as complex module structures
@@ -37,6 +39,8 @@ structure induced from `ofComplexModule` recovers the original complex scalar ac
 * `TauCeti.AlmostComplexStructure.complexModule_ofComplexModule_smul`: the opposite round trip
   recovers the original complex scalar action.
 -/
+
+public section
 
 namespace TauCeti
 
@@ -119,6 +123,7 @@ variable [AddCommGroup V] [Module ℝ V] [Module ℂ V] [IsScalarTower ℝ ℂ V
 
 /-- The almost complex structure `v ↦ i • v` on a complex module whose real scalars are compatible
 with the ambient real structure. This is the inverse construction to `complexModule`. -/
+@[expose]
 def ofComplexModule (V : Type*) [AddCommGroup V] [Module ℝ V] [Module ℂ V] [IsScalarTower ℝ ℂ V] :
     AlmostComplexStructure V where
   toLinearMap := (LinearMap.lsmul ℂ V Complex.I).restrictScalars ℝ

--- a/TauCeti/Geometry/Symplectic/Finrank.lean
+++ b/TauCeti/Geometry/Symplectic/Finrank.lean
@@ -2,9 +2,11 @@
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 -/
-import Mathlib.Algebra.Ring.Parity
-import TauCeti.Geometry.Symplectic.ComplexModule
-import TauCeti.LinearAlgebra.ComplexFinrank
+module
+
+public import Mathlib.Algebra.Ring.Parity
+public import TauCeti.Geometry.Symplectic.ComplexModule
+public import TauCeti.LinearAlgebra.ComplexFinrank
 
 /-!
 # An almost complex structure forces even real dimension
@@ -38,6 +40,8 @@ The conventions follow McDuff--Salamon, *J-holomorphic Curves and Symplectic Top
 Section 2.1.
 -/
 
+public section
+
 namespace TauCeti
 
 variable {V : Type*} [AddCommGroup V] [Module ℝ V]
@@ -47,7 +51,7 @@ namespace AlmostComplexStructure
 /-- The complex dimension of `V` with respect to an almost complex structure `J`: the
 `ℂ`-dimension of `V` under the complex module structure induced by `J`
 (`AlmostComplexStructure.complexModule`). -/
-noncomputable def complexFinrank (J : AlmostComplexStructure V) : ℕ :=
+@[expose] noncomputable def complexFinrank (J : AlmostComplexStructure V) : ℕ :=
   letI := J.complexModule
   Module.finrank ℂ V
 

--- a/TauCeti/Geometry/Symplectic/JHolomorphic.lean
+++ b/TauCeti/Geometry/Symplectic/JHolomorphic.lean
@@ -2,11 +2,13 @@
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 -/
-import Mathlib.Analysis.Calculus.FDeriv.Add
-import Mathlib.Analysis.Calculus.FDeriv.Comp
-import Mathlib.Analysis.Calculus.FDeriv.Const
-import Mathlib.Analysis.Calculus.FDeriv.Linear
-import TauCeti.Geometry.Symplectic.AlmostComplex
+module
+
+public import Mathlib.Analysis.Calculus.FDeriv.Add
+public import Mathlib.Analysis.Calculus.FDeriv.Comp
+public import Mathlib.Analysis.Calculus.FDeriv.Const
+public import Mathlib.Analysis.Calculus.FDeriv.Linear
+public import TauCeti.Geometry.Symplectic.AlmostComplex
 
 /-!
 # `J`-holomorphic maps between real normed spaces
@@ -38,6 +40,8 @@ are closed under pointwise sums, differences, and real scalar multiples:
 The convention follows McDuff--Salamon, *J-holomorphic Curves and Symplectic Topology*,
 Section 2.1: the Cauchy--Riemann equation is `df ∘ J = J' ∘ df`.
 -/
+
+@[expose] public section
 
 namespace TauCeti
 

--- a/TauCeti/Geometry/Symplectic/JHolomorphicProd.lean
+++ b/TauCeti/Geometry/Symplectic/JHolomorphicProd.lean
@@ -2,9 +2,11 @@
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 -/
-import Mathlib.Analysis.Calculus.FDeriv.Prod
-import TauCeti.Geometry.Symplectic.JHolomorphic
-import TauCeti.Geometry.Symplectic.Prod
+module
+
+public import Mathlib.Analysis.Calculus.FDeriv.Prod
+public import TauCeti.Geometry.Symplectic.JHolomorphic
+public import TauCeti.Geometry.Symplectic.Prod
 
 /-!
 # Product operations for `J`-holomorphic maps
@@ -31,6 +33,8 @@ symmetric-product targets can use these lemmas without unfolding the Cauchy--Rie
 The convention follows McDuff--Salamon, *J-holomorphic Curves and Symplectic Topology*,
 Section 2.1: product almost complex structures act componentwise.
 -/
+
+public section
 
 namespace TauCeti
 

--- a/TauCeti/Geometry/Symplectic/Lagrangian.lean
+++ b/TauCeti/Geometry/Symplectic/Lagrangian.lean
@@ -2,8 +2,10 @@
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 -/
-import Mathlib.LinearAlgebra.BilinearForm.Orthogonal
-import TauCeti.Geometry.Symplectic.StandardCompatible
+module
+
+public import Mathlib.LinearAlgebra.BilinearForm.Orthogonal
+public import TauCeti.Geometry.Symplectic.StandardCompatible
 
 /-!
 # Isotropic, coisotropic, and Lagrangian subspaces of a symplectic form
@@ -45,6 +47,8 @@ The conventions follow McDuff--Salamon, *J-holomorphic Curves and Symplectic Top
 Section 2.3.
 -/
 
+public section
+
 namespace TauCeti
 
 namespace SymplecticForm
@@ -56,7 +60,7 @@ variable {ω : SymplecticForm V} {L L' : Submodule ℝ V}
 
 /-- The symplectic complement `L^ω = {x | ∀ y ∈ L, ω(y, x) = 0}` of a submodule `L`, namely the
 orthogonal complement of `L` for the bilinear form `ω`. -/
-def orthogonal (ω : SymplecticForm V) (L : Submodule ℝ V) : Submodule ℝ V :=
+@[expose] def orthogonal (ω : SymplecticForm V) (L : Submodule ℝ V) : Submodule ℝ V :=
   ω.toBilinForm.orthogonal L
 
 lemma orthogonal_def (ω : SymplecticForm V) (L : Submodule ℝ V) :

--- a/TauCeti/Geometry/Symplectic/LagrangianTotallyReal.lean
+++ b/TauCeti/Geometry/Symplectic/LagrangianTotallyReal.lean
@@ -2,11 +2,13 @@
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 -/
-import Mathlib.LinearAlgebra.Dimension.Finrank
-import Mathlib.LinearAlgebra.FiniteDimensional.Lemmas
-import TauCeti.Geometry.Symplectic.AlmostComplex
-import TauCeti.Geometry.Symplectic.Lagrangian
-import TauCeti.LinearAlgebra.TotallyReal
+module
+
+public import Mathlib.LinearAlgebra.Dimension.Finrank
+public import Mathlib.LinearAlgebra.FiniteDimensional.Lemmas
+public import TauCeti.Geometry.Symplectic.AlmostComplex
+public import TauCeti.Geometry.Symplectic.Lagrangian
+public import TauCeti.LinearAlgebra.TotallyReal
 
 /-!
 # Lagrangian subspaces of a tame pair are maximal totally real
@@ -50,6 +52,8 @@ totally real one.
 The conventions follow McDuff--Salamon, *J-holomorphic Curves and Symplectic Topology*,
 Sections 2.3 and 2.6.
 -/
+
+@[expose] public section
 
 namespace TauCeti
 

--- a/TauCeti/Geometry/Symplectic/Prod.lean
+++ b/TauCeti/Geometry/Symplectic/Prod.lean
@@ -2,9 +2,11 @@
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 -/
-import Mathlib.LinearAlgebra.Prod
-import TauCeti.Geometry.Symplectic.AlmostComplex
-import TauCeti.Geometry.Symplectic.Transport
+module
+
+public import Mathlib.LinearAlgebra.Prod
+public import TauCeti.Geometry.Symplectic.AlmostComplex
+public import TauCeti.Geometry.Symplectic.Transport
 
 /-!
 # Direct sums of almost complex structures and symplectic forms
@@ -40,6 +42,8 @@ following Mathlib's `LinearMap.prodMap` naming convention.
 The conventions follow McDuff--Salamon, *J-holomorphic Curves and Symplectic Topology*,
 Section 2.1, where products of compatible triples model split symplectic vector spaces.
 -/
+
+@[expose] public section
 
 namespace TauCeti
 
@@ -161,7 +165,7 @@ section Prod
 variable [AddCommGroup V] [Module ℝ V] [AddCommGroup W] [Module ℝ W]
 
 /-- The underlying bilinear form of the direct-sum symplectic form. -/
-private def prodBilin (ω₁ : SymplecticForm V) (ω₂ : SymplecticForm W) :
+def prodBilin (ω₁ : SymplecticForm V) (ω₂ : SymplecticForm W) :
     LinearMap.BilinForm ℝ (V × W) :=
   ω₁.toBilinForm.comp (LinearMap.fst ℝ V W) (LinearMap.fst ℝ V W) +
     ω₂.toBilinForm.comp (LinearMap.snd ℝ V W) (LinearMap.snd ℝ V W)
@@ -170,12 +174,12 @@ private def prodBilin (ω₁ : SymplecticForm V) (ω₂ : SymplecticForm W) :
 private lemma prodBilin_apply (ω₁ : SymplecticForm V) (ω₂ : SymplecticForm W) (p q : V × W) :
     prodBilin ω₁ ω₂ p q = ω₁ p.1 q.1 + ω₂ p.2 q.2 := rfl
 
-private lemma prodBilin_isAlt (ω₁ : SymplecticForm V) (ω₂ : SymplecticForm W) :
+lemma prodBilin_isAlt (ω₁ : SymplecticForm V) (ω₂ : SymplecticForm W) :
     (prodBilin ω₁ ω₂).IsAlt := by
   intro p
   simp
 
-private lemma prodBilin_nondegenerate (ω₁ : SymplecticForm V) (ω₂ : SymplecticForm W) :
+lemma prodBilin_nondegenerate (ω₁ : SymplecticForm V) (ω₂ : SymplecticForm W) :
     (prodBilin ω₁ ω₂).Nondegenerate := by
   refine ⟨fun p hp => ?_, fun q hq => ?_⟩
   · have h1 : p.1 = 0 := ω₁.separatingLeft p.1 fun x => by

--- a/TauCeti/Geometry/Symplectic/Rescale.lean
+++ b/TauCeti/Geometry/Symplectic/Rescale.lean
@@ -2,7 +2,9 @@
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 -/
-import TauCeti.Geometry.Symplectic.AlmostComplex
+module
+
+public import TauCeti.Geometry.Symplectic.AlmostComplex
 
 /-!
 # Rescaling symplectic forms
@@ -31,6 +33,8 @@ The convention is the standard one from symplectic geometry: changing the overal
 of `ω` changes the metric scale but not the compatible almost complex structure.
 -/
 
+public section
+
 namespace TauCeti
 
 namespace SymplecticForm
@@ -41,6 +45,7 @@ variable {V : Type*} [AddCommGroup V] [Module ℝ V]
 
 The hypothesis `c ≠ 0` is needed for nondegeneracy. The construction is not an instance because
 there is no closed scalar action at `c = 0`. -/
+@[expose]
 noncomputable def rescale (ω : SymplecticForm V) (c : ℝ) (hc : c ≠ 0) : SymplecticForm V where
   toBilinForm := c • ω.toBilinForm
   isAlt := by

--- a/TauCeti/Geometry/Symplectic/SymplecticTransport.lean
+++ b/TauCeti/Geometry/Symplectic/SymplecticTransport.lean
@@ -2,8 +2,10 @@
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 -/
-import TauCeti.Geometry.Symplectic.AlmostComplex
-import TauCeti.Geometry.Symplectic.Transport
+module
+
+public import TauCeti.Geometry.Symplectic.AlmostComplex
+public import TauCeti.Geometry.Symplectic.Transport
 
 /-!
 # Transporting symplectic forms along linear equivalences
@@ -37,6 +39,8 @@ asks. The underlying form transport reuses Mathlib's `LinearMap.BilinForm.congr`
 The conventions follow McDuff--Salamon, *J-holomorphic Curves and Symplectic Topology*,
 Section 2.1, where a symplectomorphism carries a compatible triple to a compatible triple.
 -/
+
+@[expose] public section
 
 namespace TauCeti
 

--- a/TauCeti/Geometry/Symplectic/Transport.lean
+++ b/TauCeti/Geometry/Symplectic/Transport.lean
@@ -2,9 +2,11 @@
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 -/
-import Mathlib.Algebra.Module.Equiv.Basic
-import TauCeti.Geometry.Symplectic.AlmostComplex
-import TauCeti.LinearAlgebra.ComplexLinearPart
+module
+
+public import Mathlib.Algebra.Module.Equiv.Basic
+public import TauCeti.Geometry.Symplectic.AlmostComplex
+public import TauCeti.LinearAlgebra.ComplexLinearPart
 
 /-!
 # Transporting almost complex structures along linear equivalences
@@ -36,6 +38,8 @@ The conjugation `LinearEquiv.conj` and `LinearEquiv.arrowCongr` are reused from 
 almost complex structure layer is `TauCeti.AlmostComplexStructure`.
 -/
 
+public section
+
 namespace TauCeti
 
 variable {V W X : Type*}
@@ -50,6 +54,7 @@ variable [AddCommGroup X] [Module ℝ X]
 
 The transported endomorphism is `LinearEquiv.conj e` applied to `J`, equivalently
 `w ↦ e (J (e.symm w))`, and it satisfies the almost-complex square condition. -/
+@[expose]
 def transport (J : AlmostComplexStructure V) (e : V ≃ₗ[ℝ] W) : AlmostComplexStructure W where
   toLinearMap := e.conj J.toLinearMap
   square_neg := by

--- a/TauCeti/LinearAlgebra/TotallyReal.lean
+++ b/TauCeti/LinearAlgebra/TotallyReal.lean
@@ -32,7 +32,7 @@ variable [AddCommMonoid F] [Module R F]
 
 /-- A submodule is maximal totally real with respect to `J` if it is complementary to its
 `J`-image. -/
-def IsMaximalTotallyReal (J : E →ₗ[R] E) (L : Submodule R E) : Prop :=
+@[expose] def IsMaximalTotallyReal (J : E →ₗ[R] E) (L : Submodule R E) : Prop :=
   IsCompl L (L.map J)
 
 /-- The maximal totally real predicate unfolds to complementarity of `L` and its `J`-image. -/


### PR DESCRIPTION
Migrate the final 16 files — the J-holomorphic / Lagrangian symplectic lane and the Weil-divisor / class-group extensions — **completing the module-system migration: every file in `TauCeti` now opts in** (178/178), and the library builds green.

The fixes are exposure-driven: the predicate definitions whose bodies downstream `rfl`/`⟨...⟩`/`.choose` steps reduce (`IsJHolomorphicAt`, `IsMaximalTotallyReal`, `IsWeightedDegreeZero`, `picZero`, `pointDifference`, ...) are `@[expose]`d in their home files; the dense definitional files use `@[expose] public section`; and the private construction witnesses behind public class-group equivalences are de-privatized. As with the other Weil-divisor files, the lost transitive tactic imports (`norm_num`, `ring`) and the `ℤ` order instances are now imported explicitly.

Once this lands, the `module-system` audit (#351) goes green and can be merged to enforce the invariant going forward.

🤖 Prepared with Claude Code