### PR TITLE
doc: forbid stripping human-owned changes and admin-merging AI PRs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -31,6 +31,18 @@ what new mathematics gets *added*, not whether already-merged code may be made b
   them (Mathlib moving forward on the branch the lakefile nominates, with the toolchain moving
   monotonically forward) is machine-validated by the `bump-guard` check and is welcome, but
   never edit the lakefile or move a pin backward.
+- **Never delete a PR's human-owned changes to get it past the build gate.** When a PR
+  *intentionally* touches `scripts/`, `.github/`, or the lakefile (for example, a PR that adds
+  a new CI check), those changes are the deliverable, not an obstacle. The gate routes such a
+  PR to a human on purpose; the correct response is to wait for that human review and merge,
+  never to strip the human-owned files so the PR looks auto-mergeable — that throws away the
+  work the PR exists to do. This binds automated fix/review agents too: if a PR carries
+  human-owned changes, leave it alone (skip it) rather than "fixing" it toward auto-merge.
+- **Do not `--admin`-merge AI-authored PRs.** Landing a PR is the review pipeline's job: it
+  merges only once every rubric is green (and, for `TauCeti/`-only diffs, CI is green). Using an
+  admin override to bypass that gate — even when the reviews have not been run — defeats the
+  project's quality control. If the pipeline is not producing verdicts, run the review
+  (`tauceti-review`) or leave the PR for a human; never force it through.
 
 ## How review works
 


### PR DESCRIPTION
Two rules added to `AGENTS.md`, prompted by what happened to the module-system audit PR (#351) and the migration merges:

1. **Never delete a PR's human-owned changes to get it past the build gate.** When a PR intentionally touches `scripts/`/`.github/`/the lakefile (e.g. a new CI check), those changes *are* the deliverable. An automated agent removed exactly those from #351 ("the build gate rejects non-TauCeti diffs for auto-mergeable AI work") and gutted it. The gate routes such PRs to a human on purpose — wait for that human, do not strip the files. Binds auto-fix/review agents too: skip such PRs.

2. **Do not `--admin`-merge AI-authored PRs.** The nine module-system PRs were admin-merged with zero rubric reviews. Landing is the review pipeline's job; if it is not producing verdicts, run `tauceti-review` or leave the PR for a human — never force it through.

This touches a root governance file, so it is human-owned and waits for your review and merge — which is the behaviour rule 1 is encoding.

🤖 Prepared with Claude Code