### PR TITLE
feat: require every TauCeti file to opt into the module system (restored audit)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,6 +48,13 @@ jobs:
       - name: Axiom audit (TauCeti/ uses only allowlisted axioms)
         run: lake exe axioms
 
+      # Module-system audit. Inspects the built TauCeti `.olean`s and rejects any module that
+      # did not opt into the Lean module system (a leading `module`). It reads each module's
+      # `ModuleData.isModule` flag from the compiled artifact, so it cannot be fooled by a
+      # `module` appearing in a comment or string the way a textual grep could.
+      - name: Module-system audit (every TauCeti/ file opts into `module`)
+        run: lake exe module-system
+
       # --- Lake artifact-cache publish (dormant until configured) ---------------------
       # Publish TauCeti's OWN oleans (root-package only) to the Lake cache, so pr-build can
       # fetch them and recompile only a PR's changed modules instead of the whole library.

--- a/.github/workflows/pr-build.yml
+++ b/.github/workflows/pr-build.yml
@@ -381,6 +381,7 @@ jobs:
               export TMPDIR="$PWD/.lake/tmp"
               lake build
               lake exe axioms
+              lake exe module-system
             '
 
       - name: Report build and bump-guard statuses to the PR head commit

--- a/TauCeti/Analysis/InnerProductSpace/HarmonicIsometry.lean
+++ b/TauCeti/Analysis/InnerProductSpace/HarmonicIsometry.lean
@@ -2,9 +2,11 @@
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 -/
-import Mathlib.Analysis.InnerProductSpace.Harmonic.Basic
-import Mathlib.Analysis.Normed.Affine.Isometry
-import TauCeti.Analysis.InnerProductSpace.Laplacian
+module
+
+public import Mathlib.Analysis.InnerProductSpace.Harmonic.Basic
+public import Mathlib.Analysis.Normed.Affine.Isometry
+public import TauCeti.Analysis.InnerProductSpace.Laplacian
 
 /-!
 # Geometric invariance of harmonic functions
@@ -30,6 +32,8 @@ symmetry that underlies the mean-value property and the construction of radial h
 * `TauCeti.harmonicAt_comp_add_right_iff`, `TauCeti.harmonicOnNhd_comp_add_right_iff`:
   harmonicity is invariant under translation.
 -/
+
+public section
 
 namespace TauCeti
 

--- a/TauCeti/Analysis/InnerProductSpace/Laplacian.lean
+++ b/TauCeti/Analysis/InnerProductSpace/Laplacian.lean
@@ -2,8 +2,10 @@
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 -/
-import Mathlib.Analysis.InnerProductSpace.Laplacian
-import Mathlib.Analysis.Normed.Affine.Isometry
+module
+
+public import Mathlib.Analysis.InnerProductSpace.Laplacian
+public import Mathlib.Analysis.Normed.Affine.Isometry
 
 /-!
 # Geometric invariance of the Laplacian
@@ -42,6 +44,8 @@ corollaries, where smoothness re-enters, live in
   isometry `l`.
 * `TauCeti.laplacian_comp_add_right`: translation invariance of `Δ`.
 -/
+
+public section
 
 namespace TauCeti
 

--- a/TauCeti/Geometry/Symplectic/Hermitian.lean
+++ b/TauCeti/Geometry/Symplectic/Hermitian.lean
@@ -2,10 +2,12 @@
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 -/
-import Mathlib.Analysis.Complex.Basic
-import Mathlib.Analysis.InnerProductSpace.Defs
-import TauCeti.Geometry.Symplectic.CompatibleMetric
-import TauCeti.Geometry.Symplectic.ComplexModule
+module
+
+public import Mathlib.Analysis.Complex.Basic
+public import Mathlib.Analysis.InnerProductSpace.Defs
+public import TauCeti.Geometry.Symplectic.CompatibleMetric
+public import TauCeti.Geometry.Symplectic.ComplexModule
 
 /-!
 # The Hermitian inner product of a compatible pair
@@ -53,6 +55,8 @@ The conventions follow McDuff--Salamon, *J-holomorphic Curves and Symplectic Top
 Section 2.1: a compatible pair `(ω, J)` gives the Hermitian form `⟨v, w⟩ = g(v, w) + i ω(v, w)`.
 -/
 
+public section
+
 namespace TauCeti
 
 namespace SymplecticForm
@@ -69,6 +73,7 @@ argument from `ω.Invariant J` (`Invariant.complexAssociatedForm_conj_symm`,
 `Invariant.complexAssociatedForm_smul_left`), and positive definiteness from `ω.Tames J`
 (`Tames.complexAssociatedForm_self_re_pos`). Full compatibility is needed only to assemble
 `Compatible.hermitianCore`. -/
+@[expose]
 noncomputable def complexAssociatedForm (ω : SymplecticForm V) (J : AlmostComplexStructure V)
     (v w : V) : ℂ :=
   (ω v (J w) : ℂ) + Complex.I * (ω v w : ℂ)

--- a/lakefile.toml
+++ b/lakefile.toml
@@ -31,3 +31,12 @@ leanOptions = { weak.linter.mathlibStandardSet = true, weak.linter.style.longFil
 [[lean_exe]]
 name = "axioms"
 root = "scripts.Axioms"
+
+# Human-owned governance: the module-system audit (`lake exe module-system`). Inspects the
+# built `TauCeti` `.olean`s and rejects any module whose `ModuleData.isModule` flag is false,
+# i.e. any file that did not opt into the Lean module system with a leading `module`. Reads the
+# compiled artifact, not the source text, so a stray comment cannot fool it. Run in CI after
+# the build, alongside the axiom audit.
+[[lean_exe]]
+name = "module-system"
+root = "scripts.ModuleSystem"

--- a/scripts/ModuleSystem.lean
+++ b/scripts/ModuleSystem.lean
@@ -1,0 +1,89 @@
+import Lean
+
+/-!
+# `module-system`: enforce that every `TauCeti` file opts into the module system
+
+Human-owned governance machinery. This executable inspects the built `.olean`s of the
+`TauCeti` library and fails unless **every** module in `TauCeti` was elaborated with the
+`module` keyword, i.e. opts into the Lean module system.
+
+The signal is read from the compiled artifact, not the source text: each module's
+`ModuleData.isModule` flag is set by the frontend exactly when the file began with
+`module`. Reading it back from the `.olean` therefore certifies the real compilation, not a
+textual `grep` that a stray `module` in a comment or string could fool. Run via
+`lake exe module-system` (after `lake build`).
+
+It reads each module's main `.olean` directly with `readModuleData` rather than importing
+the whole environment: we only need one `Bool` per module, so there is no reason to load
+the transitive Mathlib closure. This is the same way Lean's own `readModuleDataPartsOfMod`
+and Lake's builtin linter obtain `isModule`. A module-system `.olean` is split into parts
+(`.olean`, `.olean.private`, `.olean.server`), but `isModule` lives in the main `.olean`
+part, which `readModuleData` loads on its own; we copy the `Bool` out and free the region.
+-/
+
+open Lean
+
+/-- The library whose modules must opt into the module system (the AI-owned mathematics). -/
+def auditedRoot : Name := `TauCeti
+
+/-- The module name for a `.lean` source path, e.g. `TauCeti/Foo/Bar.lean ↦ TauCeti.Foo.Bar`. -/
+def pathToModule (p : System.FilePath) : Name :=
+  (p.withExtension "").components.foldl (fun n s => Name.mkStr n s) Name.anonymous
+
+/-- Every `.lean` module under `dir`, recursively. -/
+partial def collectLeanModules (dir : System.FilePath) : IO (Array Name) := do
+  let mut acc := #[]
+  for entry in (← dir.readDir) do
+    if (← entry.path.isDir) then
+      acc := acc ++ (← collectLeanModules entry.path)
+    else if entry.path.extension == some "lean" then
+      acc := acc.push (pathToModule entry.path)
+  return acc
+
+/-- Every module in the `TauCeti` library: the root `TauCeti` plus all `TauCeti/**/*.lean`.
+Enumerating the source tree (rather than only importing the root) means every module is
+audited regardless of the root, which is intentionally empty and imports nothing. -/
+def auditedModules : IO (Array Name) :=
+  return #[auditedRoot] ++ (← collectLeanModules (auditedRoot.toString : System.FilePath))
+
+/-- Read `isModule` out of `modData` in its own frame. The `@[noinline]` (mirroring Lake's
+builtin linter) ends `modData`'s lifetime here, so the runtime drops its reference into the
+mmap'd region *before* the caller frees that region — reading the `Bool` afterwards, or
+letting `modData`'s reference outlive the `free`, is a use-after-free that segfaults. -/
+@[noinline] def getIsModule (modData : Lean.ModuleData) : BaseIO Bool :=
+  return modData.isModule
+
+/-- Did module `m` opt into the module system? Reads `isModule` from its main `.olean`.
+Returns `none` if the `.olean` is missing (a build/wiring fault, reported as a violation). -/
+def moduleIsOptedIn (m : Name) : IO (Option Bool) := do
+  let olean ← findOLean m
+  if !(← olean.pathExists) then return none
+  let (data, region) ← readModuleData olean
+  let isModule ← getIsModule data
+  unsafe region.free
+  return some isModule
+
+-- Return the exit code rather than calling `IO.Process.exit`, matching `scripts/Axioms.lean`.
+def main : IO UInt32 := do
+  initSearchPath (← findSysroot)
+  let modules ← auditedModules
+  let mut bad : Array Name := #[]
+  for m in modules do
+    match ← moduleIsOptedIn m with
+    | some true => pure ()
+    | some false => bad := bad.push m
+    | none => IO.eprintln s!"module-system: no `.olean` for {m} (did `lake build` run?)"
+              bad := bad.push m
+  if modules.isEmpty then
+    IO.eprintln s!"module-system: found 0 modules under {auditedRoot}: the audit is miswired."
+    return 1
+  if bad.isEmpty then
+    IO.println s!"module-system: all {modules.size} {auditedRoot} module(s) opt into the module system."
+    return 0
+  else
+    IO.eprintln s!"module-system: {bad.size} of {modules.size} {auditedRoot} module(s) do not opt \
+      into the module system (their compiled `.olean` has isModule = false):"
+    for m in bad do IO.eprintln s!"  {m}"
+    IO.eprintln "Add `module` as the first line of each (after the copyright header), and make \
+      imports `public import` where the import's contents appear in this file's public API."
+    return 1


### PR DESCRIPTION
Restores the module-system audit that was inadvertently stripped from #351. It adds `lake exe module-system` (the olean-based check: `findOLean` + `readModuleData` on `ModuleData.isModule`, sub-second, immune to a `module` in a comment) wired alongside the axiom audit in the post-merge health check and the sandboxed per-PR build, plus the `lakefile.toml` exe stanza.

The audit immediately earned its keep: three files added after the migration completed (`HarmonicIsometry`, `Laplacian`, `Hermitian`) were still non-module — exactly what it catches — so they are migrated here and the check passes (`all 182 modules opt in`).

Because it touches `scripts/`, `.github/`, and the lakefile, it is human-owned: it needs your review and a manual merge, and (per the rule in #370) must not be admin-merged or stripped to look auto-mergeable. Supersedes #351, which can be closed.

🤖 Prepared with Claude Code