### PR TITLE
refactor: dedupe the prime-radicand Galois corollaries via section variables

### DIFF
--- a/TauCeti/NumberTheory/Multiquadratic/PrimeGaloisGroup.lean
+++ b/TauCeti/NumberTheory/Multiquadratic/PrimeGaloisGroup.lean
@@ -37,49 +37,59 @@ namespace TauCeti.Multiquadratic
 
 variable {ι : Type*}
 
+-- A finite family of distinct primes, the source of square-class-independent radicands at which
+-- these corollaries instantiate the field-generic multiquadratic results.
+section PrimeFamily
+
+variable [Finite ι] (p : ι → ℕ) (hp : ∀ i, (p i).Prime) (hinj : Function.Injective p)
+
+omit [Finite ι] in
+/-- The square roots `√(p i)` of a prime family satisfy the radicand equation `√(p i)² = p i`,
+the `hroot` hypothesis the field-generic multiquadratic results consume. This also pins the
+radicand data `d i = p i` and the generators `root i = √(p i)` for those results. -/
+private theorem sqrtPrime_sq (i : ι) : Real.sqrt (p i) ^ 2 = algebraMap ℚ ℝ (p i : ℚ) :=
+  sq_sqrt_natCast (p i)
+
+include hp hinj
+
 /-- **The Galois group of a prime-radicand multiquadratic field is `(ℤ/2)ⁿ`.** For a finite family
 of distinct primes `p : ι → ℕ`, the field generated over `ℚ` by their real square roots has Galois
 group isomorphic to `Multiplicative (ι → ℤ/2)`. This is the prime-indexed corollary of the
 field-generic isomorphism `galoisGroupEquiv`. -/
-noncomputable def galoisGroupEquivSqrtPrimes [Finite ι] (p : ι → ℕ)
-    (hp : ∀ i, (p i).Prime) (hinj : Function.Injective p) :
+noncomputable def galoisGroupEquivSqrtPrimes :
     (adjoin ℚ (Set.range fun i => (Real.sqrt (p i) : ℝ)) ≃ₐ[ℚ]
         adjoin ℚ (Set.range fun i => (Real.sqrt (p i) : ℝ))) ≃*
       Multiplicative (ι → ZMod 2) :=
-  galoisGroupEquiv (d := fun i => (p i : ℚ)) (root := fun i => Real.sqrt (p i))
-    (fun i => sq_sqrt_natCast (p i)) (not_isSquare_prod_primes_of_injective p hp hinj)
+  galoisGroupEquiv (sqrtPrime_sq p) (not_isSquare_prod_primes_of_injective p hp hinj)
 
 /-- The prime-radicand Galois equivalence sends an automorphism to its sign pattern on the
 generators `√(p i)`. -/
-@[simp] theorem galoisGroupEquivSqrtPrimes_apply [Finite ι] (p : ι → ℕ)
-    (hp : ∀ i, (p i).Prime) (hinj : Function.Injective p)
+@[simp] theorem galoisGroupEquivSqrtPrimes_apply
     (σ : adjoin ℚ (Set.range fun i => (Real.sqrt (p i) : ℝ)) ≃ₐ[ℚ]
         adjoin ℚ (Set.range fun i => (Real.sqrt (p i) : ℝ))) :
     galoisGroupEquivSqrtPrimes p hp hinj σ =
-      Multiplicative.ofAdd (signPattern (fun i => (Real.sqrt (p i) : ℝ)) σ) := by
-  exact galoisGroupEquiv_apply (d := fun i => (p i : ℚ)) (root := fun i => Real.sqrt (p i))
-    (fun i => sq_sqrt_natCast (p i)) (not_isSquare_prod_primes_of_injective p hp hinj) σ
+      Multiplicative.ofAdd (signPattern (fun i => (Real.sqrt (p i) : ℝ)) σ) :=
+  galoisGroupEquiv_apply (sqrtPrime_sq p)
+    (not_isSquare_prod_primes_of_injective p hp hinj) σ
 
 /-- The inverse prime-radicand Galois equivalence realizes a sign pattern by sending each
 generator `√(p i)` to `(-1)^(ε i) · √(p i)`. -/
-@[simp] theorem galoisGroupEquivSqrtPrimes_symm_apply_gen [Finite ι] (p : ι → ℕ)
-    (hp : ∀ i, (p i).Prime) (hinj : Function.Injective p)
-    (ε : ι → ZMod 2) (i : ι) :
+@[simp] theorem galoisGroupEquivSqrtPrimes_symm_apply_gen (ε : ι → ZMod 2) (i : ι) :
     ((galoisGroupEquivSqrtPrimes p hp hinj).symm (Multiplicative.ofAdd ε))
         (gen (fun i => (Real.sqrt (p i) : ℝ)) i)
-      = (-1) ^ (ε i).val * gen (fun i => (Real.sqrt (p i) : ℝ)) i := by
-  exact galoisGroupEquiv_symm_apply_gen (d := fun i => (p i : ℚ))
-    (root := fun i => Real.sqrt (p i)) (fun i => sq_sqrt_natCast (p i))
+      = (-1) ^ (ε i).val * gen (fun i => (Real.sqrt (p i) : ℝ)) i :=
+  galoisGroupEquiv_symm_apply_gen (sqrtPrime_sq p)
     (not_isSquare_prod_primes_of_injective p hp hinj) ε i
 
 /-- **Cardinality of the Galois group of a prime-radicand multiquadratic field.** For a finite
 family of distinct primes `p : ι → ℕ`, `|Gal(ℚ(√p₁, …, √pₙ)/ℚ)| = 2^|ι|`. -/
-theorem card_aut_adjoin_sqrt_primes [Finite ι] (p : ι → ℕ)
-    (hp : ∀ i, (p i).Prime) (hinj : Function.Injective p) :
+theorem card_aut_adjoin_sqrt_primes :
     Nat.card (adjoin ℚ (Set.range fun i => (Real.sqrt (p i) : ℝ)) ≃ₐ[ℚ]
         adjoin ℚ (Set.range fun i => (Real.sqrt (p i) : ℝ))) = 2 ^ Nat.card ι :=
-  card_aut_adjoin_range (d := fun i => (p i : ℚ)) (root := fun i => Real.sqrt (p i))
-    (fun i => sq_sqrt_natCast (p i)) (not_isSquare_prod_primes_of_injective p hp hinj)
+  card_aut_adjoin_range (sqrtPrime_sq p)
+    (not_isSquare_prod_primes_of_injective p hp hinj)
+
+end PrimeFamily
 
 /-- **Worked example: `|Gal(ℚ(√2, √3)/ℚ)| = 4`.** The two-prime field obtained from
 `card_aut_adjoin_sqrt_primes` with the primes `2` and `3`. -/


### PR DESCRIPTION
This PR removes the repeated instantiation boilerplate in `PrimeGaloisGroup.lean`. Each of the four prime-radicand corollaries re-spelled the same four-argument instantiation of the field-generic multiquadratic Galois lemmas — `(d := fun i => (p i : ℚ)) (root := fun i => Real.sqrt (p i)) (fun i => sq_sqrt_natCast (p i)) (not_isSquare_prod_primes_of_injective p hp hinj)`. It moves `p`, `hp`, `hinj` into section variables, introduces a private `sqrtPrime_sq` lemma whose type already pins the radicand data `d` and the generators `root` so the explicit `(d := …) (root := …)` arguments are inferred and dropped, and switches the two `@[simp]` apply-lemmas from `by exact` to term mode. The public statement forms, lemma names, and exported argument lists are unchanged, and the full library builds with `warningAsError` on.

This is maintenance of existing code (always in scope per `AGENTS.md`); the file's corollaries serve the prime-radicand multiquadratic Galois-group target under `TauCetiRoadmap/Multiquadratic`, Layer 0 (multiquadratic field degree / Galois group).

Roadmap: Multiquadratic

🤖 Prepared with Claude Code