### PR TITLE
doc: copy-edit the README introduction

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,20 +10,20 @@ implemented and maintained by AI contributors, subject to adversarial review.
 Tau Ceti is being incubated jointly by the [Lean FRO](https://lean-lang.org/fro/) and the [Mathlib Initiative](https://mathlib-initiative.org/),
 in partnership with academic and industry groups.
 
-Our goal is to build as much mathematics as we can in a collaborative, coherent library,
+Our goal is to formalize as much mathematics as we can in a collaborative, coherent library,
 at the highest quality we can, subject to the constraint that everything is written by AIs. It's an experiment, and could use your help!
 
 We hope that by building Tau Ceti we can ensure that a significant part of AI formalization work is performed in an open-source, human curated library. Tau Ceti will be built for reuse and generality. Tau Ceti is a community resource, licensed under the Apache licence, that everyone can build on top of.
 
 We've long dreamt about formalizing all the "basic material" in mathematics.
-While we're explicitly **not** aiming here at curating and digesting mathematical knowledge in the way that a human authored library can,
-we hope that we can efficiently build a reusable library at significant scale. With Tau Ceti built, we'll be closer to the point where computers can genuinely help us explore the mathematical universe (the Lean kernel verifying, the Lean langauge providing automation in proof construction, AIs assisting with proof exploration, and Tau Ceti providing the knowledge necessary to reach the research frontier).
+While we're explicitly **not** aiming here at curating and digesting mathematical knowledge in the way that a human authored library like [Mathlib](https://leanprover-community.github.io/) can,
+we hope that we can efficiently build a reusable library at significant scale. With Tau Ceti built, we'll be closer to the point where computers can genuinely help us explore the mathematical universe (the Lean kernel verifying, the Lean language providing automation in proof construction, AIs assisting with proof exploration, and Tau Ceti providing the knowledge necessary to reach the research frontier).
 
 Humans own the roadmap for Tau Ceti, which lives in the
-[TauCetiRoadmap](https://github.com/FormalFrontier/TauCetiRoadmap) repo (mostly markdown, a
+[TauCetiRoadmap](https://github.com/FormalFrontier/TauCetiRoadmap) repository (mostly in the form of markdown files, together with a
 small amount of Lean); changes are made via human-reviewed pull requests there.
 
-AIs own the code in this repo, initiating pull requests and shepherding them through an
+AIs own the code in this repository, initiating pull requests and shepherding them through an
 AI-driven review process.
 
 Humans can raise issues against the code, and leave implementation (and review) to AIs.
@@ -32,7 +32,7 @@ Humans can raise issues against the code, and leave implementation (and review) 
 
 ## The three repositories
 
-- **TauCeti** (this repo) — the AI-authored Lean mathematics.
+- **TauCeti** (this repository) — the AI-authored Lean mathematics.
 - **[TauCetiRoadmap](https://github.com/FormalFrontier/TauCetiRoadmap)** — the human-controlled
   roadmaps that direct the work.
 - **[TauCetiReview](https://github.com/FormalFrontier/TauCetiReview)** — the review rubrics and


### PR DESCRIPTION
This PR applies the uncontroversial copy-edits from https://github.com/FormalFrontier/TauCeti/pull/366 to the README introduction: fix the `langauge` typo, spell out `repo` as `repository`, reword "build" as "formalize", link the first mention of Mathlib, and reword the roadmap description. It incorporates the inline suggestion left on that PR, and leaves the synergy paragraph and the new "Financial model" section for separate discussion.

🤖 Prepared with Claude Code