### PR TITLE
refactor: tidy two module-system exposure choices from the migration

### DIFF
--- a/TauCeti/Algebra/AlgebraicGroup/MultiplicativeGroup.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/MultiplicativeGroup.lean
@@ -142,15 +142,6 @@ theorem pointEquiv_symm_apply (u : Aˣ) :
     (pointEquiv (R := R) (A := A)).symm u = point (R := R) (A := A) u :=
   rfl
 
-/-- Evaluating a product of convolution points at `T` multiplies their values at `T`. -/
-theorem unitOfPoint_mul (f g : WithConv (R[T;T⁻¹] →ₐ[R] A)) :
-    unitOfPoint ((f * g).ofConv) = unitOfPoint f.ofConv * unitOfPoint g.ofConv := by
-  ext
-  rw [unitOfPoint_val, Units.val_mul]
-  simp only [unitOfPoint_val]
-  rw [AlgHom.convMul_apply]
-  simp
-
 /-- The functor of points of the multiplicative group is the unit group of the value algebra.
 
 The source is the convolution group of `R`-algebra maps out of `R[T;T⁻¹]`; the target is the
@@ -161,7 +152,12 @@ ordinary unit group of `A`. -/
   left_inv f := by
     exact congrArg toConv (point_unitOfPoint (R := R) (A := A) f.ofConv)
   right_inv := unitOfPoint_point
-  map_mul' := unitOfPoint_mul
+  map_mul' f g := by
+    ext
+    rw [unitOfPoint_val, Units.val_mul]
+    simp only [unitOfPoint_val]
+    rw [AlgHom.convMul_apply]
+    simp
 
 /-- The multiplicative equivalence sends a convolution point to its value on `T`. -/
 @[simp]

--- a/TauCeti/Geometry/Symplectic/LagrangianTotallyReal.lean
+++ b/TauCeti/Geometry/Symplectic/LagrangianTotallyReal.lean
@@ -53,7 +53,7 @@ The conventions follow McDuff--Salamon, *J-holomorphic Curves and Symplectic Top
 Sections 2.3 and 2.6.
 -/
 
-@[expose] public section
+public section
 
 namespace TauCeti
 


### PR DESCRIPTION
Follow-up to the retroactive review of the module-system migration. Two genuine cleanups — the actionable subset of the review:

- `LagrangianTotallyReal.lean`: the file has no `def`s, so its `@[expose] public section` was a no-op → demoted to plain `public section`.
- `MultiplicativeGroup.lean`: inline the single-use witness `unitOfPoint_mul` into `pointsMulEquiv.map_mul'` rather than keeping it as public API.

The review found **no correctness issues** — all three hand-written proof fixes (the scaling step in ComplexLinearPart, the `Complex.norm_def` rewrite in Doubling, the WeilDivisor imports) verified sound. Its other over-exposure / de-privatization flags turned out to be load-bearing under the module system: a public `foo_apply := rfl` lemma forces `@[expose]` on `foo`, and the remaining witnesses either cascade (their sub-proofs reference private helpers) or live in genuinely definitionally-dense files. So the migration's exposure was largely necessary, not gratuitous.

TauCeti/-only, so it can go through the normal review-and-merge path.

🤖 Prepared with Claude Code
