### PR TITLE
refactor(NumberTheory): reuse map_prod for the ideal-norm product in IdealCount

### DIFF
--- a/TauCeti/NumberTheory/EffectiveBounds/IdealCount.lean
+++ b/TauCeti/NumberTheory/EffectiveBounds/IdealCount.lean
@@ -278,11 +278,7 @@ private theorem prod_encodeIdeal_le_absNorm {I : Ideal (𝓞 F)} (hI : I ≠ ⊥
           (Ideal.absNorm P) ^ ((normalizedFactors I).count P)
         = Ideal.absNorm (∏ P ∈ (normalizedFactors I).toFinset,
           P ^ ((normalizedFactors I).count P)) := by
-      induction (normalizedFactors I).toFinset using Finset.induction with
-      | empty =>
-          simp
-      | insert P s hPs ih =>
-          rw [Finset.prod_insert hPs, Finset.prod_insert hPs, map_mul, ih, map_pow]
+      simp only [map_prod, map_pow]
     have hI_eq : ∏ P ∈ (normalizedFactors I).toFinset,
         P ^ ((normalizedFactors I).count P) = I := by
       rw [← Finset.prod_multiset_count, Ideal.prod_normalizedFactors_eq_self hI]


### PR DESCRIPTION
Replaces a hand-rolled `Finset.induction` with the Mathlib reuse it was re-deriving.

In `TauCeti.NumberField.IdealCount.prod_encodeIdeal_le_absNorm`, the equality

```
∏ P ∈ (normalizedFactors I).toFinset, (Ideal.absNorm P) ^ (count P)
  = Ideal.absNorm (∏ P ∈ (normalizedFactors I).toFinset, P ^ (count P))
```

was proved by inducting over the factor finset and applying `map_mul`/`map_pow` at each step. But `Ideal.absNorm` is a bundled `MonoidWithZeroHom` (`Ideal _ →*₀ ℕ`), so this is precisely `map_prod` composed with `map_pow` under the binder — `simp only [map_prod, map_pow]` closes it in one line. Net `-5/+1`; no statement changes (the only edit is the proof of one `private` helper).

## Scope

`IdealCount.lean` is the ideal-counting prerequisite behind the effective class-number bound (`TauCeti.NumberField.classNumber_le_bound`, which uses `card_ideal_absNorm_le` from this file) and the bounded-discriminant number-field count — both Layer-3 targets on the effective-bounds roadmap. This is a reuse cleanup of that existing prerequisite, not new material.

## Checks

- `lake build` clean (4075 jobs)
- `lake exe axioms` clean (4117 declarations, allowlist only)
