### PR TITLE
feat: add Hopf ideal comaps

### DIFF
--- a/TauCeti/Algebra/HopfAlgebra/HopfIdeal/Comap.lean
+++ b/TauCeti/Algebra/HopfAlgebra/HopfIdeal/Comap.lean
@@ -123,30 +123,6 @@ theorem comap_bot (f : H →ₐc[R] K) (hf : Function.Surjective f) :
   ext h
   rw [mem_comap, mem_ker, mem_bot]
 
-/-- Surjective inverse image of Hopf ideals preserves joins. -/
-@[simp]
-theorem comap_sup_of_surjective (I J : HopfIdeal R K) (f : H →ₐc[R] K)
-    (hf : Function.Surjective f) :
-    (I ⊔ J).comap f hf = I.comap f hf ⊔ J.comap f hf := by
-  ext h
-  constructor
-  · intro hh
-    rw [mem_comap, mem_sup] at hh
-    rcases hh with ⟨y, hy, z, hz, hyz⟩
-    obtain ⟨hy', rfl⟩ := hf y
-    obtain ⟨hz', rfl⟩ := hf z
-    rw [← map_add] at hyz
-    refine mem_sup.mpr ⟨hy' + (h - (hy' + hz')), ?_, hz', mem_comap.mpr hz, ?_⟩
-    · rw [mem_comap, map_add, map_sub, hyz, sub_self, add_zero]
-      exact hy
-    · abel
-  · intro hh
-    rw [mem_sup] at hh
-    rcases hh with ⟨y, hy, z, hz, rfl⟩
-    rw [mem_comap] at hy hz ⊢
-    rw [map_add]
-    exact mem_sup.mpr ⟨f y, hy, f z, hz, rfl⟩
-
 /-- Surjective inverse image of Hopf ideals preserves nonempty suprema of families. -/
 @[simp]
 theorem comap_iSup_of_surjective {ι : Type*} [Nonempty ι] (I : ι → HopfIdeal R K)
@@ -200,6 +176,37 @@ theorem comap_iSup_of_surjective {ι : Type*} [Nonempty ι] (I : ι → HopfIdea
       -- Expose the bounded `Finset.sum` shape produced by `Finsupp.sum` so `map_sum` applies.
       change (∑ a ∈ s.support, f (s a)) = f (∑ a ∈ s.support, s a)
       rw [map_sum]⟩
+
+/-- Surjective inverse image of Hopf ideals preserves joins. -/
+@[simp]
+theorem comap_sup_of_surjective (I J : HopfIdeal R K) (f : H →ₐc[R] K)
+    (hf : Function.Surjective f) :
+    (I ⊔ J).comap f hf = I.comap f hf ⊔ J.comap f hf := by
+  have hsup : I ⊔ J = ⨆ b : Bool, cond b I J := by
+    apply le_antisymm
+    · refine sup_le ?_ ?_
+      · exact le_sSup ⟨true, rfl⟩
+      · exact le_sSup ⟨false, rfl⟩
+    · rw [iSup]
+      refine sSup_le ?_
+      rintro _ ⟨b, rfl⟩
+      cases b <;> simp
+  have hsup_comap :
+      I.comap f hf ⊔ J.comap f hf = ⨆ b : Bool, (cond b I J).comap f hf := by
+    apply le_antisymm
+    · refine sup_le ?_ ?_
+      · exact le_sSup ⟨true, rfl⟩
+      · exact le_sSup ⟨false, rfl⟩
+    · rw [iSup]
+      refine sSup_le ?_
+      rintro _ ⟨b, rfl⟩
+      cases b <;> simp
+  calc
+    (I ⊔ J).comap f hf = (⨆ b : Bool, cond b I J).comap f hf := by
+      exact congrArg (fun A : HopfIdeal R K => A.comap f hf) hsup
+    _ = ⨆ b : Bool, (cond b I J).comap f hf :=
+      comap_iSup_of_surjective (fun b : Bool => cond b I J) f hf
+    _ = I.comap f hf ⊔ J.comap f hf := hsup_comap.symm
 
 /-- Surjective inverse image of Hopf ideals preserves nonempty suprema of sets. -/
 @[simp]

--- a/TauCeti/Algebra/HopfAlgebra/HopfIdeal/Comap.lean
+++ b/TauCeti/Algebra/HopfAlgebra/HopfIdeal/Comap.lean
@@ -118,16 +118,16 @@ theorem comap_eq_comap_iff_of_surjective (f : H →ₐc[R] K)
 
 /-- The inverse image of the zero Hopf ideal is the kernel Hopf ideal. -/
 @[simp]
-theorem comap_bot (f : H →ₐc[R] K) (hf : Function.Surjective f) :
-    (⊥ : HopfIdeal R K).comap f hf = ker f hf := by
+theorem comap_bot (f : H →ₐc[R] K) (hf hfker : Function.Surjective f) :
+    (⊥ : HopfIdeal R K).comap f hf = ker f hfker := by
   ext h
   rw [mem_comap, mem_ker, mem_bot]
 
 /-- Surjective inverse image of Hopf ideals preserves joins. -/
 @[simp]
 theorem comap_sup_of_surjective (I J : HopfIdeal R K) (f : H →ₐc[R] K)
-    (hf : Function.Surjective f) :
-    (I ⊔ J).comap f hf = I.comap f hf ⊔ J.comap f hf := by
+    (hf hfI hfJ : Function.Surjective f) :
+    (I ⊔ J).comap f hf = I.comap f hfI ⊔ J.comap f hfJ := by
   ext h
   constructor
   · intro hh
@@ -150,8 +150,9 @@ theorem comap_sup_of_surjective (I J : HopfIdeal R K) (f : H →ₐc[R] K)
 /-- Surjective inverse image of Hopf ideals preserves nonempty suprema of families. -/
 @[simp]
 theorem comap_iSup_of_surjective {ι : Type*} [Nonempty ι] (I : ι → HopfIdeal R K)
-    (f : H →ₐc[R] K) (hf : Function.Surjective f) :
-    (⨆ i, I i).comap f hf = ⨆ i, (I i).comap f hf := by
+    (f : H →ₐc[R] K) (hf : Function.Surjective f)
+    (hfI : ∀ _, Function.Surjective f) :
+    (⨆ i, I i).comap f hf = ⨆ i, (I i).comap f (hfI i) := by
   classical
   ext h
   constructor
@@ -195,7 +196,7 @@ theorem comap_iSup_of_surjective {ι : Type*} [Nonempty ι] (I : ι → HopfIdea
     rcases hh with ⟨s, hs, rfl⟩
     rw [mem_comap, mem_iSup]
     exact ⟨s.mapRange f (map_zero f),
-      fun i => (mem_comap (I := I i) (f := f) (hf := hf)).mp (hs i), by
+      fun i => (mem_comap (I := I i) (f := f) (hf := hfI i)).mp (hs i), by
       rw [Finsupp.sum_mapRange_index (fun _ => rfl)]
       change (∑ a ∈ s.support, f (s a)) = f (∑ a ∈ s.support, s a)
       rw [map_sum]⟩
@@ -203,8 +204,9 @@ theorem comap_iSup_of_surjective {ι : Type*} [Nonempty ι] (I : ι → HopfIdea
 /-- Surjective inverse image of Hopf ideals preserves nonempty suprema of sets. -/
 @[simp]
 theorem comap_sSup_of_surjective (S : Set (HopfIdeal R K)) (hS : S.Nonempty)
-    (f : H →ₐc[R] K) (hf : Function.Surjective f) :
-    (sSup S).comap f hf = sSup ((fun I => I.comap f hf) '' S) := by
+    (f : H →ₐc[R] K) (hf : Function.Surjective f)
+    (hfS : ∀ _, Function.Surjective f) :
+    (sSup S).comap f hf = sSup ((fun I => I.comap f (hfS I)) '' S) := by
   classical
   haveI : Nonempty S := hS.to_subtype
   rw [sSup_eq_iSup', comap_iSup_of_surjective, sSup_image']

--- a/TauCeti/Algebra/HopfAlgebra/HopfIdeal/Comap.lean
+++ b/TauCeti/Algebra/HopfAlgebra/HopfIdeal/Comap.lean
@@ -83,51 +83,51 @@ theorem mem_comap {I : HopfIdeal R K} {f : H →ₐc[R] K} {hf : Function.Surjec
   exact mem_toIdeal
 
 /-- Inverse image of Hopf ideals is monotone. -/
-theorem comap_mono (f : H →ₐc[R] K) (hfI hfJ : Function.Surjective f)
-    {I J : HopfIdeal R K} (hIJ : I ≤ J) : I.comap f hfI ≤ J.comap f hfJ := by
+theorem comap_mono (f : H →ₐc[R] K) (hf : Function.Surjective f)
+    {I J : HopfIdeal R K} (hIJ : I ≤ J) : I.comap f hf ≤ J.comap f hf := by
   intro h hh
   exact mem_comap.mpr (hIJ (mem_comap.mp hh))
 
 /-- For a surjective morphism, inverse image of Hopf ideals reflects containment. -/
 theorem le_of_comap_le_comap_of_surjective (f : H →ₐc[R] K)
-    (hfI hfJ : Function.Surjective f) {I J : HopfIdeal R K}
-    (hIJ : I.comap f hfI ≤ J.comap f hfJ) : I ≤ J := by
+    (hf : Function.Surjective f) {I J : HopfIdeal R K}
+    (hIJ : I.comap f hf ≤ J.comap f hf) : I ≤ J := by
   intro k hk
-  obtain ⟨h, rfl⟩ := hfI k
+  obtain ⟨h, rfl⟩ := hf k
   exact mem_comap.mp (hIJ (mem_comap.mpr hk))
 
 /-- For a surjective morphism, containment after inverse image is equivalent to containment
 before inverse image. -/
 theorem comap_le_comap_iff_of_surjective (f : H →ₐc[R] K)
-    (hfI hfJ : Function.Surjective f) {I J : HopfIdeal R K} :
-    I.comap f hfI ≤ J.comap f hfJ ↔ I ≤ J :=
-  ⟨le_of_comap_le_comap_of_surjective f hfI hfJ, comap_mono f hfI hfJ⟩
+    (hf : Function.Surjective f) {I J : HopfIdeal R K} :
+    I.comap f hf ≤ J.comap f hf ↔ I ≤ J :=
+  ⟨le_of_comap_le_comap_of_surjective f hf, comap_mono f hf⟩
 
 /-- For a surjective morphism, inverse image of Hopf ideals reflects equality. -/
 @[simp]
 theorem comap_eq_comap_iff_of_surjective (f : H →ₐc[R] K)
-    (hfI hfJ : Function.Surjective f) {I J : HopfIdeal R K} :
-    I.comap f hfI = J.comap f hfJ ↔ I = J := by
+    (hf : Function.Surjective f) {I J : HopfIdeal R K} :
+    I.comap f hf = J.comap f hf ↔ I = J := by
   constructor
   · intro h
     apply le_antisymm
-    · rw [← comap_le_comap_iff_of_surjective f hfI hfJ, h]
-    · rw [← comap_le_comap_iff_of_surjective f hfJ hfI, h]
+    · rw [← comap_le_comap_iff_of_surjective f hf, h]
+    · rw [← comap_le_comap_iff_of_surjective f hf, h]
   · intro h
     rw [h]
 
 /-- The inverse image of the zero Hopf ideal is the kernel Hopf ideal. -/
 @[simp]
-theorem comap_bot (f : H →ₐc[R] K) (hf hfker : Function.Surjective f) :
-    (⊥ : HopfIdeal R K).comap f hf = ker f hfker := by
+theorem comap_bot (f : H →ₐc[R] K) (hf : Function.Surjective f) :
+    (⊥ : HopfIdeal R K).comap f hf = ker f hf := by
   ext h
   rw [mem_comap, mem_ker, mem_bot]
 
 /-- Surjective inverse image of Hopf ideals preserves joins. -/
 @[simp]
 theorem comap_sup_of_surjective (I J : HopfIdeal R K) (f : H →ₐc[R] K)
-    (hf hfI hfJ : Function.Surjective f) :
-    (I ⊔ J).comap f hf = I.comap f hfI ⊔ J.comap f hfJ := by
+    (hf : Function.Surjective f) :
+    (I ⊔ J).comap f hf = I.comap f hf ⊔ J.comap f hf := by
   ext h
   constructor
   · intro hh
@@ -150,9 +150,8 @@ theorem comap_sup_of_surjective (I J : HopfIdeal R K) (f : H →ₐc[R] K)
 /-- Surjective inverse image of Hopf ideals preserves nonempty suprema of families. -/
 @[simp]
 theorem comap_iSup_of_surjective {ι : Type*} [Nonempty ι] (I : ι → HopfIdeal R K)
-    (f : H →ₐc[R] K) (hf : Function.Surjective f)
-    (hfI : ∀ _, Function.Surjective f) :
-    (⨆ i, I i).comap f hf = ⨆ i, (I i).comap f (hfI i) := by
+    (f : H →ₐc[R] K) (hf : Function.Surjective f) :
+    (⨆ i, I i).comap f hf = ⨆ i, (I i).comap f hf := by
   classical
   ext h
   constructor
@@ -196,7 +195,7 @@ theorem comap_iSup_of_surjective {ι : Type*} [Nonempty ι] (I : ι → HopfIdea
     rcases hh with ⟨s, hs, rfl⟩
     rw [mem_comap, mem_iSup]
     exact ⟨s.mapRange f (map_zero f),
-      fun i => (mem_comap (I := I i) (f := f) (hf := hfI i)).mp (hs i), by
+      fun i => (mem_comap (I := I i) (f := f) (hf := hf)).mp (hs i), by
       rw [Finsupp.sum_mapRange_index (fun _ => rfl)]
       -- Expose the bounded `Finset.sum` shape produced by `Finsupp.sum` so `map_sum` applies.
       change (∑ a ∈ s.support, f (s a)) = f (∑ a ∈ s.support, s a)
@@ -205,18 +204,16 @@ theorem comap_iSup_of_surjective {ι : Type*} [Nonempty ι] (I : ι → HopfIdea
 /-- Surjective inverse image of Hopf ideals preserves nonempty suprema of sets. -/
 @[simp]
 theorem comap_sSup_of_surjective (S : Set (HopfIdeal R K)) (hS : S.Nonempty)
-    (f : H →ₐc[R] K) (hf : Function.Surjective f)
-    (hfS : ∀ _, Function.Surjective f) :
-    (sSup S).comap f hf = sSup ((fun I => I.comap f (hfS I)) '' S) := by
+    (f : H →ₐc[R] K) (hf : Function.Surjective f) :
+    (sSup S).comap f hf = sSup ((fun I => I.comap f hf) '' S) := by
   classical
   haveI : Nonempty S := hS.to_subtype
   rw [sSup_eq_iSup', comap_iSup_of_surjective, sSup_image']
 
 /-- Pulling a Hopf ideal back along the identity morphism leaves it unchanged. -/
 @[simp]
-theorem comap_id (I : HopfIdeal R H)
-    (hf : Function.Surjective (BialgHom.id R H)) :
-    I.comap (BialgHom.id R H) hf = I := by
+theorem comap_id (I : HopfIdeal R H) :
+    I.comap (BialgHom.id R H) (fun h => ⟨h, rfl⟩) = I := by
   ext h
   rw [mem_comap, BialgHom.coe_id]
   rfl
@@ -224,9 +221,8 @@ theorem comap_id (I : HopfIdeal R H)
 /-- Inverse image of Hopf ideals is compatible with composition of surjective morphisms. -/
 @[simp]
 theorem comap_comap (I : HopfIdeal R L) (g : K →ₐc[R] L) (hg : Function.Surjective g)
-    (f : H →ₐc[R] K) (hf : Function.Surjective f)
-    (hgf : Function.Surjective (g.comp f)) :
-    (I.comap g hg).comap f hf = I.comap (g.comp f) hgf := by
+    (f : H →ₐc[R] K) (hf : Function.Surjective f) :
+    (I.comap g hg).comap f hf = I.comap (g.comp f) (hg.comp hf) := by
   ext h
   rw [mem_comap, mem_comap, mem_comap, BialgHom.coe_comp]
   rfl

--- a/TauCeti/Algebra/HopfAlgebra/HopfIdeal/Comap.lean
+++ b/TauCeti/Algebra/HopfAlgebra/HopfIdeal/Comap.lean
@@ -25,9 +25,11 @@ schemes in the affine Hopf-algebra dictionary.
 
 * `TauCeti.HopfIdeal.comap`: the inverse image of a Hopf ideal under a surjective morphism.
 * `TauCeti.HopfIdeal.comap_toIdeal` and `TauCeti.HopfIdeal.mem_comap`: characteristic API.
-* `TauCeti.HopfIdeal.comap_le_comap_iff`: surjective inverse image reflects containment.
+* `TauCeti.HopfIdeal.comap_le_comap_iff_of_surjective`: surjective inverse image reflects
+  containment.
 * `TauCeti.HopfIdeal.comap_bot`: the kernel of a surjective morphism is the inverse image of
   the zero Hopf ideal.
+* `TauCeti.HopfIdeal.comap_sup`: surjective inverse image preserves joins.
 * `TauCeti.HopfIdeal.comap_id` and `TauCeti.HopfIdeal.comap_comap`: identity and composition
   laws.
 
@@ -84,7 +86,7 @@ theorem comap_mono (f : H →ₐc[R] K) (hf : Function.Surjective f) {I J : Hopf
   exact mem_comap.mpr (hIJ (mem_comap.mp hh))
 
 /-- For a surjective morphism, inverse image of Hopf ideals reflects containment. -/
-theorem le_of_comap_le_comap (f : H →ₐc[R] K) (hf : Function.Surjective f)
+theorem le_of_comap_le_comap_of_surjective (f : H →ₐc[R] K) (hf : Function.Surjective f)
     {I J : HopfIdeal R K} (hIJ : I.comap f hf ≤ J.comap f hf) : I ≤ J := by
   intro k hk
   obtain ⟨h, rfl⟩ := hf k
@@ -92,19 +94,19 @@ theorem le_of_comap_le_comap (f : H →ₐc[R] K) (hf : Function.Surjective f)
 
 /-- For a surjective morphism, containment after inverse image is equivalent to containment
 before inverse image. -/
-theorem comap_le_comap_iff (f : H →ₐc[R] K) (hf : Function.Surjective f)
+theorem comap_le_comap_iff_of_surjective (f : H →ₐc[R] K) (hf : Function.Surjective f)
     {I J : HopfIdeal R K} : I.comap f hf ≤ J.comap f hf ↔ I ≤ J :=
-  ⟨le_of_comap_le_comap f hf, comap_mono f hf⟩
+  ⟨le_of_comap_le_comap_of_surjective f hf, comap_mono f hf⟩
 
 /-- For a surjective morphism, inverse image of Hopf ideals reflects equality. -/
 @[simp]
-theorem comap_eq_comap_iff (f : H →ₐc[R] K) (hf : Function.Surjective f)
+theorem comap_eq_comap_iff_of_surjective (f : H →ₐc[R] K) (hf : Function.Surjective f)
     {I J : HopfIdeal R K} : I.comap f hf = J.comap f hf ↔ I = J := by
   constructor
   · intro h
     apply le_antisymm
-    · rw [← comap_le_comap_iff f hf, h]
-    · rw [← comap_le_comap_iff f hf, h]
+    · rw [← comap_le_comap_iff_of_surjective f hf, h]
+    · rw [← comap_le_comap_iff_of_surjective f hf, h]
   · intro h
     rw [h]
 
@@ -115,10 +117,35 @@ theorem comap_bot (f : H →ₐc[R] K) (hf : Function.Surjective f) :
   ext h
   rw [mem_comap, mem_ker, mem_bot]
 
+/-- Surjective inverse image of Hopf ideals preserves joins. -/
+@[simp]
+theorem comap_sup (I J : HopfIdeal R K) (f : H →ₐc[R] K)
+    (hf : Function.Surjective f) :
+    (I ⊔ J).comap f hf = I.comap f hf ⊔ J.comap f hf := by
+  ext h
+  constructor
+  · intro hh
+    rw [mem_comap, mem_sup] at hh
+    rcases hh with ⟨y, hy, z, hz, hyz⟩
+    obtain ⟨hy', rfl⟩ := hf y
+    obtain ⟨hz', rfl⟩ := hf z
+    rw [← map_add] at hyz
+    refine mem_sup.mpr ⟨hy' + (h - (hy' + hz')), ?_, hz', mem_comap.mpr hz, ?_⟩
+    · rw [mem_comap, map_add, map_sub, hyz, sub_self, add_zero]
+      exact hy
+    · abel
+  · intro hh
+    rw [mem_sup] at hh
+    rcases hh with ⟨y, hy, z, hz, rfl⟩
+    rw [mem_comap] at hy hz ⊢
+    rw [map_add]
+    exact mem_sup.mpr ⟨f y, hy, f z, hz, rfl⟩
+
 /-- Pulling a Hopf ideal back along the identity morphism leaves it unchanged. -/
 @[simp]
-theorem comap_id (I : HopfIdeal R H) :
-    I.comap (BialgHom.id R H) (fun h => ⟨h, rfl⟩) = I := by
+theorem comap_id (I : HopfIdeal R H)
+    (hf : Function.Surjective (BialgHom.id R H)) :
+    I.comap (BialgHom.id R H) hf = I := by
   ext h
   rw [mem_comap, BialgHom.coe_id]
   rfl
@@ -126,8 +153,9 @@ theorem comap_id (I : HopfIdeal R H) :
 /-- Inverse image of Hopf ideals is compatible with composition of surjective morphisms. -/
 @[simp]
 theorem comap_comap (I : HopfIdeal R L) (g : K →ₐc[R] L) (hg : Function.Surjective g)
-    (f : H →ₐc[R] K) (hf : Function.Surjective f) :
-    (I.comap g hg).comap f hf = I.comap (g.comp f) (hg.comp hf) := by
+    (f : H →ₐc[R] K) (hf : Function.Surjective f)
+    (hgf : Function.Surjective (g.comp f)) :
+    (I.comap g hg).comap f hf = I.comap (g.comp f) hgf := by
   ext h
   rw [mem_comap, mem_comap, mem_comap, BialgHom.coe_comp]
   rfl

--- a/TauCeti/Algebra/HopfAlgebra/HopfIdeal/Comap.lean
+++ b/TauCeti/Algebra/HopfAlgebra/HopfIdeal/Comap.lean
@@ -29,7 +29,10 @@ schemes in the affine Hopf-algebra dictionary.
   containment.
 * `TauCeti.HopfIdeal.comap_bot`: the kernel of a surjective morphism is the inverse image of
   the zero Hopf ideal.
-* `TauCeti.HopfIdeal.comap_sup`: surjective inverse image preserves joins.
+* `TauCeti.HopfIdeal.comap_sup_of_surjective`: surjective inverse image preserves binary joins.
+* `TauCeti.HopfIdeal.comap_iSup_of_surjective` and
+  `TauCeti.HopfIdeal.comap_sSup_of_surjective`: surjective inverse image preserves nonempty
+  suprema.
 * `TauCeti.HopfIdeal.comap_id` and `TauCeti.HopfIdeal.comap_comap`: identity and composition
   laws.
 
@@ -80,33 +83,36 @@ theorem mem_comap {I : HopfIdeal R K} {f : H →ₐc[R] K} {hf : Function.Surjec
   exact mem_toIdeal
 
 /-- Inverse image of Hopf ideals is monotone. -/
-theorem comap_mono (f : H →ₐc[R] K) (hf : Function.Surjective f) {I J : HopfIdeal R K}
-    (hIJ : I ≤ J) : I.comap f hf ≤ J.comap f hf := by
+theorem comap_mono (f : H →ₐc[R] K) (hfI hfJ : Function.Surjective f)
+    {I J : HopfIdeal R K} (hIJ : I ≤ J) : I.comap f hfI ≤ J.comap f hfJ := by
   intro h hh
   exact mem_comap.mpr (hIJ (mem_comap.mp hh))
 
 /-- For a surjective morphism, inverse image of Hopf ideals reflects containment. -/
-theorem le_of_comap_le_comap_of_surjective (f : H →ₐc[R] K) (hf : Function.Surjective f)
-    {I J : HopfIdeal R K} (hIJ : I.comap f hf ≤ J.comap f hf) : I ≤ J := by
+theorem le_of_comap_le_comap_of_surjective (f : H →ₐc[R] K)
+    (hfI hfJ : Function.Surjective f) {I J : HopfIdeal R K}
+    (hIJ : I.comap f hfI ≤ J.comap f hfJ) : I ≤ J := by
   intro k hk
-  obtain ⟨h, rfl⟩ := hf k
+  obtain ⟨h, rfl⟩ := hfI k
   exact mem_comap.mp (hIJ (mem_comap.mpr hk))
 
 /-- For a surjective morphism, containment after inverse image is equivalent to containment
 before inverse image. -/
-theorem comap_le_comap_iff_of_surjective (f : H →ₐc[R] K) (hf : Function.Surjective f)
-    {I J : HopfIdeal R K} : I.comap f hf ≤ J.comap f hf ↔ I ≤ J :=
-  ⟨le_of_comap_le_comap_of_surjective f hf, comap_mono f hf⟩
+theorem comap_le_comap_iff_of_surjective (f : H →ₐc[R] K)
+    (hfI hfJ : Function.Surjective f) {I J : HopfIdeal R K} :
+    I.comap f hfI ≤ J.comap f hfJ ↔ I ≤ J :=
+  ⟨le_of_comap_le_comap_of_surjective f hfI hfJ, comap_mono f hfI hfJ⟩
 
 /-- For a surjective morphism, inverse image of Hopf ideals reflects equality. -/
 @[simp]
-theorem comap_eq_comap_iff_of_surjective (f : H →ₐc[R] K) (hf : Function.Surjective f)
-    {I J : HopfIdeal R K} : I.comap f hf = J.comap f hf ↔ I = J := by
+theorem comap_eq_comap_iff_of_surjective (f : H →ₐc[R] K)
+    (hfI hfJ : Function.Surjective f) {I J : HopfIdeal R K} :
+    I.comap f hfI = J.comap f hfJ ↔ I = J := by
   constructor
   · intro h
     apply le_antisymm
-    · rw [← comap_le_comap_iff_of_surjective f hf, h]
-    · rw [← comap_le_comap_iff_of_surjective f hf, h]
+    · rw [← comap_le_comap_iff_of_surjective f hfI hfJ, h]
+    · rw [← comap_le_comap_iff_of_surjective f hfJ hfI, h]
   · intro h
     rw [h]
 
@@ -119,7 +125,7 @@ theorem comap_bot (f : H →ₐc[R] K) (hf : Function.Surjective f) :
 
 /-- Surjective inverse image of Hopf ideals preserves joins. -/
 @[simp]
-theorem comap_sup (I J : HopfIdeal R K) (f : H →ₐc[R] K)
+theorem comap_sup_of_surjective (I J : HopfIdeal R K) (f : H →ₐc[R] K)
     (hf : Function.Surjective f) :
     (I ⊔ J).comap f hf = I.comap f hf ⊔ J.comap f hf := by
   ext h
@@ -140,6 +146,68 @@ theorem comap_sup (I J : HopfIdeal R K) (f : H →ₐc[R] K)
     rw [mem_comap] at hy hz ⊢
     rw [map_add]
     exact mem_sup.mpr ⟨f y, hy, f z, hz, rfl⟩
+
+/-- Surjective inverse image of Hopf ideals preserves nonempty suprema of families. -/
+@[simp]
+theorem comap_iSup_of_surjective {ι : Type*} [Nonempty ι] (I : ι → HopfIdeal R K)
+    (f : H →ₐc[R] K) (hf : Function.Surjective f) :
+    (⨆ i, I i).comap f hf = ⨆ i, (I i).comap f hf := by
+  classical
+  ext h
+  constructor
+  · intro hh
+    rw [mem_comap, mem_iSup] at hh
+    rcases hh with ⟨s, hs, hsum⟩
+    let pre : K → H := fun k => if hk : k = 0 then 0 else Classical.choose (hf k)
+    have hpre : ∀ k, f (pre k) = k := by
+      intro k
+      by_cases hk : k = 0
+      · simp [pre, hk]
+      · simpa [pre, hk] using Classical.choose_spec (hf k)
+    have hpre_zero : pre 0 = 0 := by simp [pre]
+    let t : ι →₀ H := s.mapRange pre hpre_zero
+    let i0 : ι := Classical.choice ‹Nonempty ι›
+    let u : ι →₀ H := t + Finsupp.single i0 (h - t.sum fun _ y => y)
+    rw [mem_iSup]
+    refine ⟨u, ?_, ?_⟩
+    · intro i
+      by_cases hi : i = i0
+      · subst hi
+        dsimp [u]
+        rw [Finsupp.single_eq_same]
+        exact add_mem (by simpa [t, hpre] using hs i0) (by
+          rw [mem_comap, map_sub]
+          have ht_sum : f (t.sum fun _ y => y) = s.sum fun _ y => y := by
+            dsimp [t]
+            rw [Finsupp.sum_mapRange_index (fun _ => rfl), Finsupp.sum, map_sum]
+            exact Finset.sum_congr rfl fun i _ => by simp [hpre]
+          rw [ht_sum, hsum, sub_self]
+          exact zero_mem (I i0))
+      · dsimp [u]
+        rw [Finsupp.single_eq_of_ne hi]
+        simpa [t, hpre] using hs i
+    · dsimp [u]
+      rw [Finsupp.sum_add_index (fun _ _ => rfl) (fun _ _ _ _ => rfl),
+        Finsupp.sum_single_index rfl]
+      abel
+  · intro hh
+    rw [mem_iSup] at hh
+    rcases hh with ⟨s, hs, rfl⟩
+    rw [mem_comap, mem_iSup]
+    exact ⟨s.mapRange f (map_zero f),
+      fun i => (mem_comap (I := I i) (f := f) (hf := hf)).mp (hs i), by
+      rw [Finsupp.sum_mapRange_index (fun _ => rfl)]
+      change (∑ a ∈ s.support, f (s a)) = f (∑ a ∈ s.support, s a)
+      rw [map_sum]⟩
+
+/-- Surjective inverse image of Hopf ideals preserves nonempty suprema of sets. -/
+@[simp]
+theorem comap_sSup_of_surjective (S : Set (HopfIdeal R K)) (hS : S.Nonempty)
+    (f : H →ₐc[R] K) (hf : Function.Surjective f) :
+    (sSup S).comap f hf = sSup ((fun I => I.comap f hf) '' S) := by
+  classical
+  haveI : Nonempty S := hS.to_subtype
+  rw [sSup_eq_iSup', comap_iSup_of_surjective, sSup_image']
 
 /-- Pulling a Hopf ideal back along the identity morphism leaves it unchanged. -/
 @[simp]

--- a/TauCeti/Algebra/HopfAlgebra/HopfIdeal/Comap.lean
+++ b/TauCeti/Algebra/HopfAlgebra/HopfIdeal/Comap.lean
@@ -1,0 +1,154 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+module
+
+public import TauCeti.Algebra.HopfAlgebra.Kernel
+
+/-!
+# Inverse images of Hopf ideals along surjective Hopf algebra morphisms
+
+This file records the inverse image of a Hopf ideal along a surjective bialgebra morphism.
+For a surjective morphism `f : H →ₐc[R] K` and a Hopf ideal `I` of `K`, the preimage
+`f ⁻¹ I` is a Hopf ideal of `H`. The construction is made by applying the existing
+kernel-of-a-surjective-Hopf-map theorem to the composite `H → K → K/I`.
+
+The surjectivity hypothesis is intentional: over a general commutative base, the tensor
+exactness needed for the coideal condition is not automatic without an exactness hypothesis.
+
+This is a Layer 3 prerequisite for the reductive-groups roadmap target "Hopf ideals ↔ closed
+subgroup schemes", including kernels and pullback-style operations on closed subgroup
+schemes in the affine Hopf-algebra dictionary.
+
+## Main declarations
+
+* `TauCeti.HopfIdeal.comap`: the inverse image of a Hopf ideal under a surjective morphism.
+* `TauCeti.HopfIdeal.comap_toIdeal` and `TauCeti.HopfIdeal.mem_comap`: characteristic API.
+* `TauCeti.HopfIdeal.comap_le_comap_iff`: surjective inverse image reflects containment.
+* `TauCeti.HopfIdeal.comap_bot`: the kernel of a surjective morphism is the inverse image of
+  the zero Hopf ideal.
+* `TauCeti.HopfIdeal.comap_id` and `TauCeti.HopfIdeal.comap_comap`: identity and composition
+  laws.
+
+## References
+
+The construction is the standard inverse image of a Hopf ideal along a surjective Hopf algebra
+morphism, reduced here to the quotient-kernel construction already in
+`TauCeti.Algebra.HopfAlgebra.Kernel`.
+-/
+
+public section
+
+namespace TauCeti
+
+universe u v w x
+
+namespace HopfIdeal
+
+variable {R : Type u} [CommRing R]
+variable {H : Type v} {K : Type w} {L : Type x}
+variable [Ring H] [Ring K] [Ring L]
+variable [HopfAlgebra R H] [HopfAlgebra R K] [HopfAlgebra R L]
+
+/-- If `f : H →ₐc[R] K` is surjective, then the composite with the quotient map
+`K → K/I` is surjective. -/
+theorem quotient_comp_surjective (f : H →ₐc[R] K) (hf : Function.Surjective f)
+    (I : HopfIdeal R K) :
+    Function.Surjective ((Bialgebra.Quotient.mkBialgHom I.toIdeal).comp f) := by
+  intro q
+  obtain ⟨k, rfl⟩ := Ideal.Quotient.mkₐ_surjective R I.toIdeal q
+  obtain ⟨h, rfl⟩ := hf k
+  exact ⟨h, rfl⟩
+
+/-- The inverse image of a Hopf ideal along a surjective bialgebra morphism.
+
+It is defined as the kernel of the composite `H → K → K/I`; its underlying ideal is the
+ordinary ideal comap of `I.toIdeal`. -/
+@[expose] noncomputable def comap (I : HopfIdeal R K) (f : H →ₐc[R] K)
+    (hf : Function.Surjective f) : HopfIdeal R H :=
+  ker ((Bialgebra.Quotient.mkBialgHom I.toIdeal).comp f) (quotient_comp_surjective f hf I)
+
+/-- The underlying ideal of `I.comap f hf` is the ordinary ideal-theoretic inverse image. -/
+@[simp]
+theorem comap_toIdeal (I : HopfIdeal R K) (f : H →ₐc[R] K)
+    (hf : Function.Surjective f) :
+    (I.comap f hf).toIdeal = Ideal.comap (f : H →+* K) I.toIdeal := by
+  ext h
+  rw [mem_toIdeal, comap, mem_ker, Ideal.mem_comap, BialgHom.coe_comp,
+    Function.comp_apply, Bialgebra.Quotient.mkBialgHom_apply, Ideal.Quotient.eq_zero_iff_mem]
+  exact mem_toIdeal.symm
+
+/-- Membership in the inverse-image Hopf ideal is membership after applying the morphism. -/
+@[simp]
+theorem mem_comap {I : HopfIdeal R K} {f : H →ₐc[R] K} {hf : Function.Surjective f}
+    {h : H} : h ∈ I.comap f hf ↔ f h ∈ I := by
+  rw [← mem_toIdeal, comap_toIdeal, Ideal.mem_comap]
+  exact mem_toIdeal
+
+/-- Inverse image of Hopf ideals is monotone. -/
+theorem comap_mono (f : H →ₐc[R] K) (hf : Function.Surjective f) {I J : HopfIdeal R K}
+    (hIJ : I ≤ J) : I.comap f hf ≤ J.comap f hf := by
+  intro h hh
+  exact mem_comap.mpr (hIJ (mem_comap.mp hh))
+
+/-- For a surjective morphism, inverse image of Hopf ideals reflects containment. -/
+theorem le_of_comap_le_comap (f : H →ₐc[R] K) (hf : Function.Surjective f)
+    {I J : HopfIdeal R K} (hIJ : I.comap f hf ≤ J.comap f hf) : I ≤ J := by
+  intro k hk
+  obtain ⟨h, rfl⟩ := hf k
+  exact mem_comap.mp (hIJ (mem_comap.mpr hk))
+
+/-- For a surjective morphism, containment after inverse image is equivalent to containment
+before inverse image. -/
+theorem comap_le_comap_iff (f : H →ₐc[R] K) (hf : Function.Surjective f)
+    {I J : HopfIdeal R K} : I.comap f hf ≤ J.comap f hf ↔ I ≤ J :=
+  ⟨le_of_comap_le_comap f hf, comap_mono f hf⟩
+
+/-- For a surjective morphism, inverse image of Hopf ideals reflects equality. -/
+@[simp]
+theorem comap_eq_comap_iff (f : H →ₐc[R] K) (hf : Function.Surjective f)
+    {I J : HopfIdeal R K} : I.comap f hf = J.comap f hf ↔ I = J := by
+  constructor
+  · intro h
+    apply le_antisymm
+    · rw [← comap_le_comap_iff f hf, h]
+    · rw [← comap_le_comap_iff f hf, h]
+  · intro h
+    rw [h]
+
+/-- The inverse image of the zero Hopf ideal is the kernel Hopf ideal. -/
+@[simp]
+theorem comap_bot (f : H →ₐc[R] K) (hf : Function.Surjective f) :
+    (⊥ : HopfIdeal R K).comap f hf = ker f hf := by
+  ext h
+  rw [mem_comap, mem_ker, mem_bot]
+
+/-- Pulling a Hopf ideal back along the identity morphism leaves it unchanged. -/
+@[simp]
+theorem comap_id (I : HopfIdeal R H) :
+    I.comap (BialgHom.id R H) (fun h => ⟨h, rfl⟩) = I := by
+  ext h
+  rw [mem_comap, BialgHom.coe_id]
+  rfl
+
+/-- The composite of surjective bialgebra morphisms is surjective. -/
+theorem comp_surjective (g : K →ₐc[R] L) (hg : Function.Surjective g)
+    (f : H →ₐc[R] K) (hf : Function.Surjective f) : Function.Surjective (g.comp f) := by
+  intro l
+  obtain ⟨k, rfl⟩ := hg l
+  obtain ⟨h, rfl⟩ := hf k
+  exact ⟨h, rfl⟩
+
+/-- Inverse image of Hopf ideals is compatible with composition of surjective morphisms. -/
+@[simp]
+theorem comap_comap (I : HopfIdeal R L) (g : K →ₐc[R] L) (hg : Function.Surjective g)
+    (f : H →ₐc[R] K) (hf : Function.Surjective f) :
+    (I.comap g hg).comap f hf = I.comap (g.comp f) (comp_surjective g hg f hf) := by
+  ext h
+  rw [mem_comap, mem_comap, mem_comap, BialgHom.coe_comp]
+  rfl
+
+end HopfIdeal
+
+end TauCeti

--- a/TauCeti/Algebra/HopfAlgebra/HopfIdeal/Comap.lean
+++ b/TauCeti/Algebra/HopfAlgebra/HopfIdeal/Comap.lean
@@ -51,23 +51,14 @@ variable {H : Type v} {K : Type w} {L : Type x}
 variable [Ring H] [Ring K] [Ring L]
 variable [HopfAlgebra R H] [HopfAlgebra R K] [HopfAlgebra R L]
 
-/-- If `f : H →ₐc[R] K` is surjective, then the composite with the quotient map
-`K → K/I` is surjective. -/
-theorem quotient_comp_surjective (f : H →ₐc[R] K) (hf : Function.Surjective f)
-    (I : HopfIdeal R K) :
-    Function.Surjective ((Bialgebra.Quotient.mkBialgHom I.toIdeal).comp f) := by
-  intro q
-  obtain ⟨k, rfl⟩ := Ideal.Quotient.mkₐ_surjective R I.toIdeal q
-  obtain ⟨h, rfl⟩ := hf k
-  exact ⟨h, rfl⟩
-
 /-- The inverse image of a Hopf ideal along a surjective bialgebra morphism.
 
 It is defined as the kernel of the composite `H → K → K/I`; its underlying ideal is the
 ordinary ideal comap of `I.toIdeal`. -/
-@[expose] noncomputable def comap (I : HopfIdeal R K) (f : H →ₐc[R] K)
+noncomputable def comap (I : HopfIdeal R K) (f : H →ₐc[R] K)
     (hf : Function.Surjective f) : HopfIdeal R H :=
-  ker ((Bialgebra.Quotient.mkBialgHom I.toIdeal).comp f) (quotient_comp_surjective f hf I)
+  ker ((Bialgebra.Quotient.mkBialgHom I.toIdeal).comp f)
+    ((Ideal.Quotient.mkₐ_surjective R I.toIdeal).comp hf)
 
 /-- The underlying ideal of `I.comap f hf` is the ordinary ideal-theoretic inverse image. -/
 @[simp]
@@ -132,19 +123,11 @@ theorem comap_id (I : HopfIdeal R H) :
   rw [mem_comap, BialgHom.coe_id]
   rfl
 
-/-- The composite of surjective bialgebra morphisms is surjective. -/
-theorem comp_surjective (g : K →ₐc[R] L) (hg : Function.Surjective g)
-    (f : H →ₐc[R] K) (hf : Function.Surjective f) : Function.Surjective (g.comp f) := by
-  intro l
-  obtain ⟨k, rfl⟩ := hg l
-  obtain ⟨h, rfl⟩ := hf k
-  exact ⟨h, rfl⟩
-
 /-- Inverse image of Hopf ideals is compatible with composition of surjective morphisms. -/
 @[simp]
 theorem comap_comap (I : HopfIdeal R L) (g : K →ₐc[R] L) (hg : Function.Surjective g)
     (f : H →ₐc[R] K) (hf : Function.Surjective f) :
-    (I.comap g hg).comap f hf = I.comap (g.comp f) (comp_surjective g hg f hf) := by
+    (I.comap g hg).comap f hf = I.comap (g.comp f) (hg.comp hf) := by
   ext h
   rw [mem_comap, mem_comap, mem_comap, BialgHom.coe_comp]
   rfl

--- a/TauCeti/Algebra/HopfAlgebra/HopfIdeal/Comap.lean
+++ b/TauCeti/Algebra/HopfAlgebra/HopfIdeal/Comap.lean
@@ -198,6 +198,7 @@ theorem comap_iSup_of_surjective {ι : Type*} [Nonempty ι] (I : ι → HopfIdea
     exact ⟨s.mapRange f (map_zero f),
       fun i => (mem_comap (I := I i) (f := f) (hf := hfI i)).mp (hs i), by
       rw [Finsupp.sum_mapRange_index (fun _ => rfl)]
+      -- Expose the bounded `Finset.sum` shape produced by `Finsupp.sum` so `map_sum` applies.
       change (∑ a ∈ s.support, f (s a)) = f (∑ a ∈ s.support, s a)
       rw [map_sum]⟩
 


### PR DESCRIPTION
This PR adds the inverse image of a Hopf ideal along a surjective bialgebra morphism, implemented as the kernel of the composite `H → K → K/I`. It advances `TauCetiRoadmap/ReductiveGroups/README.md`, Layer 3, the item "Hopf ideals ↔ closed subgroup schemes", specifically its Hopf-ideal quotient and "kernels" infrastructure, as a clean prerequisite for pullback-style operations on closed subgroup schemes in the affine Hopf-algebra dictionary. The surjectivity hypothesis is deliberate: over a general commutative base the tensor exactness needed for the coideal condition is not automatic without an exactness hypothesis, while the surjective case follows honestly from the existing kernel-of-surjection theorem.

It adds `TauCeti.HopfIdeal.comap` together with the characteristic API: underlying ideal as ordinary `Ideal.comap`, membership, monotonicity, order reflection for surjective maps, equality reflection, identity, composition, and `comap_bot`, which identifies the kernel of a surjective morphism as the inverse image of the zero Hopf ideal.

No Mathlib infrastructure is vendored. The construction reuses Tau Ceti's existing `HopfIdeal.ker` and Mathlib's quotient bialgebra morphism `Bialgebra.Quotient.mkBialgHom`.

Local verification: `lake exe cache get` completed with `No files to download` and `Already decompressed 8579 file(s)`; `lake build` completed with `Build completed successfully (4173 jobs).`; `lake exe axioms` completed with `axioms: audited 4501 TauCeti declaration(s); all within the allowlist [propext, Classical.choice, Quot.sound].`

<!--tauceti-target:v1 {"focus":"ReductiveGroups","id":"hopf-ideal-comap"}-->

🤖 Prepared with Codex
