### PR TITLE
feat: add roots-of-unity base change

### DIFF
--- a/TauCeti/Algebra/AlgebraicGroup/RootsOfUnity.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/RootsOfUnity.lean
@@ -153,6 +153,8 @@ lemma pointsMulEquiv_symm_apply_single_generator_smul (n : ℕ) (ζ : rootsOfUni
     ((pointsMulEquiv (R := R) (A := A) n).symm ζ).ofConv
         (MonoidAlgebra.single (generator n) r) =
       r • ((ζ : Aˣ) : A) := by
+  -- The scalar-action rewrite fixes the coefficient from `r` to `1`, so the existing generator
+  -- evaluation lemma applies directly.
   rw [show MonoidAlgebra.single (generator n) r =
       r • MonoidAlgebra.single (generator n) (1 : R) by simp]
   rw [map_smul]

--- a/TauCeti/Algebra/AlgebraicGroup/RootsOfUnity.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/RootsOfUnity.lean
@@ -22,6 +22,8 @@ coordinate ring `R[X]/(X^n - 1)` is separate quotient-polynomial infrastructure.
 
 ## Main definitions
 
+* `TauCeti.RootsOfUnityGroup.characterMulEquivRootsOfUnity`: the multiplicative equivalence
+  from characters of `Multiplicative (ZMod n)` to `rootsOfUnity n A`.
 * `TauCeti.RootsOfUnityGroup.pointsMulEquiv`: the multiplicative equivalence from
   convolution points of `R[Multiplicative (ZMod n)]` to `rootsOfUnity n A`.
 * `TauCeti.RootsOfUnityGroup.pointsMulEquiv_apply`: the equivalence sends a point to its
@@ -59,7 +61,7 @@ abbrev generator (n : ℕ) : Multiplicative (ZMod n) :=
   Multiplicative.ofAdd 1
 
 /-- Every element of `Multiplicative (ZMod n)` is a power of the standard generator. -/
-private lemma mem_zpowers_generator (n : ℕ) (x : Multiplicative (ZMod n)) :
+lemma mem_zpowers_generator (n : ℕ) (x : Multiplicative (ZMod n)) :
     x ∈ Subgroup.zpowers (generator n) := by
   refine ⟨(Multiplicative.toAdd x).cast, ?_⟩
   simp only [generator]
@@ -72,14 +74,14 @@ private lemma mem_zpowers_generator (n : ℕ) (x : Multiplicative (ZMod n)) :
     _ = x := ofAdd_toAdd x
 
 /-- The cardinality of the standard cyclic character group is `n`. -/
-private lemma card_multiplicative_zmod (n : ℕ) :
+lemma card_multiplicative_zmod (n : ℕ) :
     Nat.card (Multiplicative (ZMod n)) = n := by
   exact (Nat.card_congr (Multiplicative.ofAdd : ZMod n ≃ Multiplicative (ZMod n))).trans
     (Nat.card_zmod n)
 
 /-- Characters of `Multiplicative (ZMod n)` are canonically `n`th roots of unity, by evaluation
 on the standard generator. -/
-private noncomputable def characterMulEquivRootsOfUnity (n : ℕ) :
+@[expose] noncomputable def characterMulEquivRootsOfUnity (n : ℕ) :
     (Multiplicative (ZMod n) →* Aˣ) ≃* rootsOfUnity n A :=
   ((IsCyclic.monoidHomMulEquivRootsOfUnityOfGenerator (mem_zpowers_generator n) Aˣ).trans
       (MulEquiv.subgroupCongr (by rw [card_multiplicative_zmod n]))).trans
@@ -88,13 +90,15 @@ private noncomputable def characterMulEquivRootsOfUnity (n : ℕ) :
 /-- A character is sent to its value on the standard generator. -/
 -- The proof is `rfl`: each composed equivalence acts on the underlying unit by projection.
 @[simp]
-private lemma characterMulEquivRootsOfUnity_apply (n : ℕ)
+lemma characterMulEquivRootsOfUnity_apply (n : ℕ)
     (χ : Multiplicative (ZMod n) →* Aˣ) :
     ((characterMulEquivRootsOfUnity (A := A) n χ : Aˣ) : A) =
       (χ (generator n) : A) :=
   rfl
 
-private lemma characterMulEquivRootsOfUnity_symm_apply_generator
+/-- The inverse character-roots equivalence sends the standard generator to the chosen root
+of unity. -/
+lemma characterMulEquivRootsOfUnity_symm_apply_generator
     (n : ℕ) (ζ : rootsOfUnity n A) :
     (((characterMulEquivRootsOfUnity (A := A) n).symm ζ (generator n) : Aˣ) : A) =
       ((ζ : Aˣ) : A) := by

--- a/TauCeti/Algebra/AlgebraicGroup/RootsOfUnity.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/RootsOfUnity.lean
@@ -53,38 +53,34 @@ namespace RootsOfUnityGroup
 
 universe u v
 
-variable {R : Type u} {A : Type v} [CommSemiring R] [CommSemiring A] [Algebra R A]
-variable {B : Type*} [CommSemiring B] [Algebra R B]
-
 /-- The standard generator of the character group defining `μ_n = D(ℤ/n)`. -/
 abbrev generator (n : ℕ) : Multiplicative (ZMod n) :=
   Multiplicative.ofAdd 1
 
-/-- Every element of `Multiplicative (ZMod n)` is a power of the standard generator. -/
-lemma mem_zpowers_generator (n : ℕ) (x : Multiplicative (ZMod n)) :
-    x ∈ Subgroup.zpowers (generator n) := by
-  refine ⟨(Multiplicative.toAdd x).cast, ?_⟩
-  simp only [generator]
-  rw [← ofAdd_zsmul]
-  calc
-    Multiplicative.ofAdd ((Multiplicative.toAdd x).cast • (1 : ZMod n)) =
-        Multiplicative.ofAdd (((Multiplicative.toAdd x).cast : ℤ) : ZMod n) := by simp
-    _ =
-        Multiplicative.ofAdd (Multiplicative.toAdd x) := by rw [ZMod.intCast_zmod_cast]
-    _ = x := ofAdd_toAdd x
+section Characters
 
-/-- The cardinality of the standard cyclic character group is `n`. -/
-lemma card_multiplicative_zmod (n : ℕ) :
-    Nat.card (Multiplicative (ZMod n)) = n := by
-  exact (Nat.card_congr (Multiplicative.ofAdd : ZMod n ≃ Multiplicative (ZMod n))).trans
-    (Nat.card_zmod n)
+variable {A : Type v} [CommMonoid A]
 
 /-- Characters of `Multiplicative (ZMod n)` are canonically `n`th roots of unity, by evaluation
 on the standard generator. -/
 @[expose] noncomputable def characterMulEquivRootsOfUnity (n : ℕ) :
     (Multiplicative (ZMod n) →* Aˣ) ≃* rootsOfUnity n A :=
-  ((IsCyclic.monoidHomMulEquivRootsOfUnityOfGenerator (mem_zpowers_generator n) Aˣ).trans
-      (MulEquiv.subgroupCongr (by rw [card_multiplicative_zmod n]))).trans
+  let hg : ∀ x : Multiplicative (ZMod n), x ∈ Subgroup.zpowers (generator n) := by
+    intro x
+    refine ⟨(Multiplicative.toAdd x).cast, ?_⟩
+    simp only [generator]
+    rw [← ofAdd_zsmul]
+    calc
+      Multiplicative.ofAdd ((Multiplicative.toAdd x).cast • (1 : ZMod n)) =
+          Multiplicative.ofAdd (((Multiplicative.toAdd x).cast : ℤ) : ZMod n) := by simp
+      _ =
+          Multiplicative.ofAdd (Multiplicative.toAdd x) := by rw [ZMod.intCast_zmod_cast]
+      _ = x := ofAdd_toAdd x
+  let hcard : Nat.card (Multiplicative (ZMod n)) = n :=
+    (Nat.card_congr (Multiplicative.ofAdd : ZMod n ≃ Multiplicative (ZMod n))).trans
+      (Nat.card_zmod n)
+  ((IsCyclic.monoidHomMulEquivRootsOfUnityOfGenerator (g := generator n) hg Aˣ).trans
+      (MulEquiv.subgroupCongr (by rw [hcard]))).trans
     (rootsOfUnityUnitsMulEquiv A n)
 
 /-- A character is sent to its value on the standard generator. -/
@@ -98,6 +94,7 @@ lemma characterMulEquivRootsOfUnity_apply (n : ℕ)
 
 /-- The inverse character-roots equivalence sends the standard generator to the chosen root
 of unity. -/
+@[simp]
 lemma characterMulEquivRootsOfUnity_symm_apply_generator
     (n : ℕ) (ζ : rootsOfUnity n A) :
     (((characterMulEquivRootsOfUnity (A := A) n).symm ζ (generator n) : Aˣ) : A) =
@@ -105,6 +102,11 @@ lemma characterMulEquivRootsOfUnity_symm_apply_generator
   rw [← characterMulEquivRootsOfUnity_apply n
     ((characterMulEquivRootsOfUnity (A := A) n).symm ζ)]
   simp
+
+end Characters
+
+variable {R : Type u} {A : Type v} [CommSemiring R] [CommSemiring A] [Algebra R A]
+variable {B : Type*} [CommSemiring B] [Algebra R B]
 
 /-- The functor of points of `μ_n = D(ℤ/n)` is the group of `n`th roots of unity.
 

--- a/TauCeti/Algebra/AlgebraicGroup/RootsOfUnity.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/RootsOfUnity.lean
@@ -22,12 +22,12 @@ coordinate ring `R[X]/(X^n - 1)` is separate quotient-polynomial infrastructure.
 
 ## Main definitions
 
-* `TauCeti.RootsOfUnityGroup.characterMulEquivRootsOfUnity`: the multiplicative equivalence
-  from characters of `Multiplicative (ZMod n)` to `rootsOfUnity n A`.
 * `TauCeti.RootsOfUnityGroup.pointsMulEquiv`: the multiplicative equivalence from
   convolution points of `R[Multiplicative (ZMod n)]` to `rootsOfUnity n A`.
 * `TauCeti.RootsOfUnityGroup.pointsMulEquiv_apply`: the equivalence sends a point to its
   value on the standard generator `single (ofAdd 1) 1`.
+* `TauCeti.RootsOfUnityGroup.pointsMulEquiv_symm_apply_single_generator_smul`: the inverse
+  equivalence evaluates scalar multiples of the standard generator.
 * `TauCeti.RootsOfUnityGroup.pointsMulEquiv_symm_apply_single_generator`: the inverse
   equivalence sends a root of unity to the point taking the standard generator to it.
 
@@ -38,7 +38,7 @@ calculation.
 ## References
 
 The diagonalizable-group points calculation is Tau Ceti's
-`DiagonalizableGroup.pointsMulEquiv`. The cyclic character group calculation is Mathlib's
+`DiagonalizableGroup.pointsMulEquiv`. The internal cyclic character group calculation uses Mathlib's
 `IsCyclic.monoidHomMulEquivRootsOfUnityOfGenerator`, from
 `Mathlib.RingTheory.RootsOfUnity.Basic`.
 -/
@@ -61,9 +61,7 @@ section Characters
 
 variable {A : Type v} [CommMonoid A]
 
-/-- Characters of `Multiplicative (ZMod n)` are canonically `n`th roots of unity, by evaluation
-on the standard generator. -/
-@[expose] noncomputable def characterMulEquivRootsOfUnity (n : ℕ) :
+private noncomputable def characterMulEquivRootsOfUnity (n : ℕ) :
     (Multiplicative (ZMod n) →* Aˣ) ≃* rootsOfUnity n A :=
   let hg : ∀ x : Multiplicative (ZMod n), x ∈ Subgroup.zpowers (generator n) := by
     intro x
@@ -83,19 +81,16 @@ on the standard generator. -/
       (MulEquiv.subgroupCongr (by rw [hcard]))).trans
     (rootsOfUnityUnitsMulEquiv A n)
 
-/-- A character is sent to its value on the standard generator. -/
 -- The proof is `rfl`: each composed equivalence acts on the underlying unit by projection.
 @[simp]
-lemma characterMulEquivRootsOfUnity_apply (n : ℕ)
+private lemma characterMulEquivRootsOfUnity_apply (n : ℕ)
     (χ : Multiplicative (ZMod n) →* Aˣ) :
     ((characterMulEquivRootsOfUnity (A := A) n χ : Aˣ) : A) =
       (χ (generator n) : A) :=
   rfl
 
-/-- The inverse character-roots equivalence sends the standard generator to the chosen root
-of unity. -/
 @[simp]
-lemma characterMulEquivRootsOfUnity_symm_apply_generator
+private lemma characterMulEquivRootsOfUnity_symm_apply_generator
     (n : ℕ) (ζ : rootsOfUnity n A) :
     (((characterMulEquivRootsOfUnity (A := A) n).symm ζ (generator n) : Aˣ) : A) =
       ((ζ : Aˣ) : A) := by
@@ -150,6 +145,18 @@ lemma pointsMulEquiv_symm_apply_single_generator (n : ℕ) (ζ : rootsOfUnity n 
     DiagonalizableGroup.pointsMulEquiv_symm_apply, ofConv_toConv,
     DiagonalizableGroup.point_single_one,
     characterMulEquivRootsOfUnity_symm_apply_generator]
+
+/-- The inverse points equivalence evaluates scalar multiples of the standard generator by
+scalar multiplication of the chosen root of unity. -/
+@[simp]
+lemma pointsMulEquiv_symm_apply_single_generator_smul (n : ℕ) (ζ : rootsOfUnity n A) (r : R) :
+    ((pointsMulEquiv (R := R) (A := A) n).symm ζ).ofConv
+        (MonoidAlgebra.single (generator n) r) =
+      r • ((ζ : Aˣ) : A) := by
+  rw [show MonoidAlgebra.single (generator n) r =
+      r • MonoidAlgebra.single (generator n) (1 : R) by simp]
+  rw [map_smul]
+  rw [pointsMulEquiv_symm_apply_single_generator]
 
 end RootsOfUnityGroup
 

--- a/TauCeti/Algebra/AlgebraicGroup/RootsOfUnityBaseChange.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/RootsOfUnityBaseChange.lean
@@ -4,7 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 -/
 module
 
-public import TauCeti.Algebra.AlgebraicGroup.BaseChange
+public import TauCeti.Algebra.AlgebraicGroup.DiagonalizableGroupBaseChange
 public import TauCeti.Algebra.AlgebraicGroup.RootsOfUnity
 
 /-!
@@ -15,11 +15,11 @@ This file records the base-changed functor-of-points calculation for the diagona
 `K`-algebra, then the `A`-points of the base-changed Hopf algebra
 `K ⊗[k] k[Multiplicative (ZMod n)]` are the usual subgroup `rootsOfUnity n A`.
 
-The construction first restricts base-changed points along `a ↦ 1 ⊗ a` using the generic
-base-change equivalence for convolution points, then applies the existing
-`RootsOfUnityGroup.pointsMulEquiv`. The characteristic lemmas spell out that the equivalence
-reads a point on the base-changed standard generator `1 ⊗ single (ofAdd 1) 1`, how the inverse
-point evaluates there, and how the equivalence is natural in the value algebra.
+The construction specializes `DiagonalizableGroup.baseChangePointsMulEquiv` to
+`Multiplicative (ZMod n)`, then applies `RootsOfUnityGroup.characterMulEquivRootsOfUnity`.
+The characteristic lemmas spell out that the equivalence reads a point on the base-changed
+standard generator `1 ⊗ single (ofAdd 1) 1`, how the inverse point evaluates on scalar
+multiples of that generator, and how the equivalence is natural in the value algebra.
 
 This is part of the ReductiveGroups roadmap worked examples: `μ_n = D(ℤ/n)` in the
 diagonalizable-groups lane, together with the Layer 0 base-change target for Hopf algebras and
@@ -31,6 +31,8 @@ their functors of points.
   base-changed `μ_n` points to `rootsOfUnity n A`.
 * `TauCeti.RootsOfUnityGroup.baseChangePointsMulEquiv_apply`: the equivalence reads a point
   by evaluating it on `1 ⊗ single (generator n) 1`.
+* `TauCeti.RootsOfUnityGroup.baseChangePointsMulEquiv_symm_apply_tmul_single_generator`: the
+  inverse equivalence evaluates scalar multiples of the base-changed generator.
 * `TauCeti.RootsOfUnityGroup.baseChangePointsMulEquiv_symm_apply_single_generator`: the
   inverse equivalence sends a root of unity to the base-changed point taking the standard
   generator to it.
@@ -39,9 +41,10 @@ their functors of points.
 
 ## References
 
-The generic base-change calculation is Tau Ceti's `AlgHom.baseChangePointsMulEquiv`, and the
-cyclic character identification with `rootsOfUnity n A` is `RootsOfUnityGroup.pointsMulEquiv`,
-itself built from Mathlib's `IsCyclic.monoidHomMulEquivRootsOfUnityOfGenerator`.
+The generic diagonalizable base-change calculation is Tau Ceti's
+`DiagonalizableGroup.baseChangePointsMulEquiv`, and the cyclic character identification with
+`rootsOfUnity n A` is `RootsOfUnityGroup.characterMulEquivRootsOfUnity`, itself built from
+Mathlib's `IsCyclic.monoidHomMulEquivRootsOfUnityOfGenerator`.
 -/
 
 public section
@@ -67,9 +70,9 @@ The target is Mathlib's subgroup of units whose `n`th power is one. -/
 noncomputable def baseChangePointsMulEquiv (n : ℕ) :
     WithConv (K ⊗[k] MonoidAlgebra k (Multiplicative (ZMod n)) →ₐ[K] A) ≃*
       rootsOfUnity n A :=
-  (AlgHom.baseChangePointsMulEquiv (k := k) (K := K)
-      (A := MonoidAlgebra k (Multiplicative (ZMod n))) (R := A)).symm.trans
-    (RootsOfUnityGroup.pointsMulEquiv (R := k) (A := A) n)
+  (DiagonalizableGroup.baseChangePointsMulEquiv (k := k) (K := K) (A := A)
+    (G := Multiplicative (ZMod n))).trans
+      (RootsOfUnityGroup.characterMulEquivRootsOfUnity n)
 
 /-- The base-changed roots-of-unity points equivalence reads a point by evaluating it on the
 base-changed standard generator `1 ⊗ single (ofAdd 1) 1`. -/
@@ -78,8 +81,20 @@ lemma baseChangePointsMulEquiv_apply (n : ℕ)
     (f : WithConv (K ⊗[k] MonoidAlgebra k (Multiplicative (ZMod n)) →ₐ[K] A)) :
     ((baseChangePointsMulEquiv (k := k) (K := K) (A := A) n f : Aˣ) : A) =
       f.ofConv (1 ⊗ₜ[k] MonoidAlgebra.single (generator n) (1 : k)) := by
-  rw [baseChangePointsMulEquiv, MulEquiv.trans_apply, RootsOfUnityGroup.pointsMulEquiv_apply,
-    AlgHom.baseChangePointsMulEquiv_symm_apply]
+  rw [baseChangePointsMulEquiv, MulEquiv.trans_apply, characterMulEquivRootsOfUnity_apply,
+    DiagonalizableGroup.baseChangePointsMulEquiv_apply_coe]
+
+/-- The inverse base-changed roots-of-unity points equivalence evaluates scalar multiples of
+the standard generator by scalar multiplication of the chosen root of unity. -/
+@[simp]
+lemma baseChangePointsMulEquiv_symm_apply_tmul_single_generator (n : ℕ)
+    (ζ : rootsOfUnity n A) (s : K) (r : k) :
+    ((baseChangePointsMulEquiv (k := k) (K := K) (A := A) n).symm ζ).ofConv
+        (s ⊗ₜ[k] MonoidAlgebra.single (generator n) r) =
+      s • (r • ((ζ : Aˣ) : A)) := by
+  rw [baseChangePointsMulEquiv, MulEquiv.symm_trans_apply,
+    DiagonalizableGroup.baseChangePointsMulEquiv_symm_apply_tmul_single,
+    characterMulEquivRootsOfUnity_symm_apply_generator]
 
 /-- The inverse base-changed roots-of-unity points equivalence takes the standard generator to
 the chosen root of unity. -/
@@ -88,7 +103,7 @@ lemma baseChangePointsMulEquiv_symm_apply_single_generator (n : ℕ) (ζ : roots
     ((baseChangePointsMulEquiv (k := k) (K := K) (A := A) n).symm ζ).ofConv
         (1 ⊗ₜ[k] MonoidAlgebra.single (generator n) (1 : k)) =
       ((ζ : Aˣ) : A) := by
-  rw [← baseChangePointsMulEquiv_apply n]
+  rw [baseChangePointsMulEquiv_symm_apply_tmul_single_generator]
   simp
 
 variable {B : Type*} [CommSemiring B] [Algebra K B] [Algebra k B] [IsScalarTower k K B]

--- a/TauCeti/Algebra/AlgebraicGroup/RootsOfUnityBaseChange.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/RootsOfUnityBaseChange.lean
@@ -4,7 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 -/
 module
 
-public import TauCeti.Algebra.AlgebraicGroup.DiagonalizableGroupBaseChange
+public import TauCeti.Algebra.AlgebraicGroup.BaseChange
 public import TauCeti.Algebra.AlgebraicGroup.RootsOfUnity
 
 /-!
@@ -15,8 +15,9 @@ This file records the base-changed functor-of-points calculation for the diagona
 `K`-algebra, then the `A`-points of the base-changed Hopf algebra
 `K ⊗[k] k[Multiplicative (ZMod n)]` are the usual subgroup `rootsOfUnity n A`.
 
-The construction specializes `DiagonalizableGroup.baseChangePointsMulEquiv` to
-`Multiplicative (ZMod n)`, then applies `RootsOfUnityGroup.characterMulEquivRootsOfUnity`.
+The construction first restricts a base-changed point along
+`1 ⊗ _ : k[Multiplicative (ZMod n)] → K ⊗[k] k[Multiplicative (ZMod n)]`, then applies
+`RootsOfUnityGroup.pointsMulEquiv`.
 The characteristic lemmas spell out that the equivalence reads a point on the base-changed
 standard generator `1 ⊗ single (ofAdd 1) 1`, how the inverse point evaluates on scalar
 multiples of that generator, and how the equivalence is natural in the value algebra.
@@ -41,10 +42,9 @@ their functors of points.
 
 ## References
 
-The generic diagonalizable base-change calculation is Tau Ceti's
-`DiagonalizableGroup.baseChangePointsMulEquiv`, and the cyclic character identification with
-`rootsOfUnity n A` is `RootsOfUnityGroup.characterMulEquivRootsOfUnity`, itself built from
-Mathlib's `IsCyclic.monoidHomMulEquivRootsOfUnityOfGenerator`.
+The generic algebra base-change calculation is Tau Ceti's
+`AlgHom.baseChangePointsMulEquiv`, and the roots-of-unity points calculation is
+`RootsOfUnityGroup.pointsMulEquiv`.
 -/
 
 public section
@@ -70,9 +70,9 @@ The target is Mathlib's subgroup of units whose `n`th power is one. -/
 noncomputable def baseChangePointsMulEquiv (n : ℕ) :
     WithConv (K ⊗[k] MonoidAlgebra k (Multiplicative (ZMod n)) →ₐ[K] A) ≃*
       rootsOfUnity n A :=
-  (DiagonalizableGroup.baseChangePointsMulEquiv (k := k) (K := K) (A := A)
-    (G := Multiplicative (ZMod n))).trans
-      (RootsOfUnityGroup.characterMulEquivRootsOfUnity n)
+  (AlgHom.baseChangePointsMulEquiv (k := k) (K := K)
+      (A := MonoidAlgebra k (Multiplicative (ZMod n))) (R := A)).symm.trans
+    (RootsOfUnityGroup.pointsMulEquiv (R := k) (A := A) n)
 
 /-- The base-changed roots-of-unity points equivalence reads a point by evaluating it on the
 base-changed standard generator `1 ⊗ single (ofAdd 1) 1`. -/
@@ -81,8 +81,8 @@ lemma baseChangePointsMulEquiv_apply (n : ℕ)
     (f : WithConv (K ⊗[k] MonoidAlgebra k (Multiplicative (ZMod n)) →ₐ[K] A)) :
     ((baseChangePointsMulEquiv (k := k) (K := K) (A := A) n f : Aˣ) : A) =
       f.ofConv (1 ⊗ₜ[k] MonoidAlgebra.single (generator n) (1 : k)) := by
-  rw [baseChangePointsMulEquiv, MulEquiv.trans_apply, characterMulEquivRootsOfUnity_apply,
-    DiagonalizableGroup.baseChangePointsMulEquiv_apply_coe]
+  rw [baseChangePointsMulEquiv, MulEquiv.trans_apply, pointsMulEquiv_apply,
+    AlgHom.baseChangePointsMulEquiv_symm_apply]
 
 /-- The inverse base-changed roots-of-unity points equivalence evaluates scalar multiples of
 the standard generator by scalar multiplication of the chosen root of unity. -/
@@ -92,9 +92,14 @@ lemma baseChangePointsMulEquiv_symm_apply_tmul_single_generator (n : ℕ)
     ((baseChangePointsMulEquiv (k := k) (K := K) (A := A) n).symm ζ).ofConv
         (s ⊗ₜ[k] MonoidAlgebra.single (generator n) r) =
       s • (r • ((ζ : Aˣ) : A)) := by
-  rw [baseChangePointsMulEquiv, MulEquiv.symm_trans_apply,
-    DiagonalizableGroup.baseChangePointsMulEquiv_symm_apply_tmul_single,
-    characterMulEquivRootsOfUnity_symm_apply_generator]
+  rw [baseChangePointsMulEquiv, MulEquiv.symm_trans_apply]
+  change (AlgHom.baseChangePointsMulEquiv (k := k) (K := K)
+      (A := MonoidAlgebra k (Multiplicative (ZMod n))) (R := A)
+        ((pointsMulEquiv (R := k) (A := A) n).symm ζ)).ofConv
+      (s ⊗ₜ[k] MonoidAlgebra.single (generator n) r) =
+    s • (r • ((ζ : Aˣ) : A))
+  rw [AlgHom.baseChangePointsMulEquiv_apply_tmul]
+  rw [pointsMulEquiv_symm_apply_single_generator_smul]
 
 /-- The inverse base-changed roots-of-unity points equivalence takes the standard generator to
 the chosen root of unity. -/

--- a/TauCeti/Algebra/AlgebraicGroup/RootsOfUnityBaseChange.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/RootsOfUnityBaseChange.lean
@@ -44,7 +44,9 @@ their functors of points.
 
 The generic algebra base-change calculation is Tau Ceti's
 `AlgHom.baseChangePointsMulEquiv`, and the roots-of-unity points calculation is
-`RootsOfUnityGroup.pointsMulEquiv`.
+`RootsOfUnityGroup.pointsMulEquiv`. This specialization follows the API pattern of
+`DiagonalizableGroup.baseChangePointsMulEquiv` in
+`TauCeti.Algebra.AlgebraicGroup.DiagonalizableGroupBaseChange`.
 -/
 
 public section
@@ -93,6 +95,8 @@ lemma baseChangePointsMulEquiv_symm_apply_tmul_single_generator (n : ℕ)
         (s ⊗ₜ[k] MonoidAlgebra.single (generator n) r) =
       s • (r • ((ζ : Aˣ) : A)) := by
   rw [baseChangePointsMulEquiv, MulEquiv.symm_trans_apply]
+  -- After unfolding the transposed equivalence, Lean still sees the inverse result through the
+  -- `WithConv` coercion; this `change` exposes exactly the generic base-change point to rewrite.
   change (AlgHom.baseChangePointsMulEquiv (k := k) (K := K)
       (A := MonoidAlgebra k (Multiplicative (ZMod n))) (R := A)
         ((pointsMulEquiv (R := k) (A := A) n).symm ζ)).ofConv

--- a/TauCeti/Algebra/AlgebraicGroup/RootsOfUnityBaseChange.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/RootsOfUnityBaseChange.lean
@@ -1,0 +1,123 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+module
+
+public import TauCeti.Algebra.AlgebraicGroup.BaseChange
+public import TauCeti.Algebra.AlgebraicGroup.RootsOfUnity
+
+/-!
+# Base change of the roots-of-unity group scheme
+
+This file records the base-changed functor-of-points calculation for the diagonalizable group
+`μ_n = D(Multiplicative (ZMod n))`. If `K` is a `k`-algebra and `A` is a commutative
+`K`-algebra, then the `A`-points of the base-changed Hopf algebra
+`K ⊗[k] k[Multiplicative (ZMod n)]` are the usual subgroup `rootsOfUnity n A`.
+
+The construction first restricts base-changed points along `a ↦ 1 ⊗ a` using the generic
+base-change equivalence for convolution points, then applies the existing
+`RootsOfUnityGroup.pointsMulEquiv`. The characteristic lemmas spell out that the equivalence
+reads a point on the base-changed standard generator `1 ⊗ single (ofAdd 1) 1`, how the inverse
+point evaluates there, and how the equivalence is natural in the value algebra.
+
+This is part of the ReductiveGroups roadmap worked examples: `μ_n = D(ℤ/n)` in the
+diagonalizable-groups lane, together with the Layer 0 base-change target for Hopf algebras and
+their functors of points.
+
+## Main declarations
+
+* `TauCeti.RootsOfUnityGroup.baseChangePointsMulEquiv`: the multiplicative equivalence from
+  base-changed `μ_n` points to `rootsOfUnity n A`.
+* `TauCeti.RootsOfUnityGroup.baseChangePointsMulEquiv_apply`: the equivalence reads a point
+  by evaluating it on `1 ⊗ single (generator n) 1`.
+* `TauCeti.RootsOfUnityGroup.baseChangePointsMulEquiv_symm_apply_single_generator`: the
+  inverse equivalence sends a root of unity to the base-changed point taking the standard
+  generator to it.
+* `TauCeti.RootsOfUnityGroup.baseChangePointsMulEquiv_mapValue`: naturality in the value
+  algebra.
+
+## References
+
+The generic base-change calculation is Tau Ceti's `AlgHom.baseChangePointsMulEquiv`, and the
+cyclic character identification with `rootsOfUnity n A` is `RootsOfUnityGroup.pointsMulEquiv`,
+itself built from Mathlib's `IsCyclic.monoidHomMulEquivRootsOfUnityOfGenerator`.
+-/
+
+public section
+
+open WithConv
+open scoped TensorProduct
+
+namespace TauCeti
+
+namespace RootsOfUnityGroup
+
+universe u v w
+
+variable {k : Type u} {K : Type v} {A : Type w}
+variable [CommSemiring k] [CommSemiring K] [CommSemiring A]
+variable [Algebra k K] [Algebra K A] [Algebra k A] [IsScalarTower k K A]
+
+/-- The `A`-points of the base change `K ⊗[k] k[Multiplicative (ZMod n)]` of `μ_n` are
+the subgroup of `n`th roots of unity in `A`.
+
+The source is the convolution group of `K`-algebra maps out of the base-changed Hopf algebra.
+The target is Mathlib's subgroup of units whose `n`th power is one. -/
+noncomputable def baseChangePointsMulEquiv (n : ℕ) :
+    WithConv (K ⊗[k] MonoidAlgebra k (Multiplicative (ZMod n)) →ₐ[K] A) ≃*
+      rootsOfUnity n A :=
+  (AlgHom.baseChangePointsMulEquiv (k := k) (K := K)
+      (A := MonoidAlgebra k (Multiplicative (ZMod n))) (R := A)).symm.trans
+    (RootsOfUnityGroup.pointsMulEquiv (R := k) (A := A) n)
+
+/-- The base-changed roots-of-unity points equivalence reads a point by evaluating it on the
+base-changed standard generator `1 ⊗ single (ofAdd 1) 1`. -/
+@[simp]
+lemma baseChangePointsMulEquiv_apply (n : ℕ)
+    (f : WithConv (K ⊗[k] MonoidAlgebra k (Multiplicative (ZMod n)) →ₐ[K] A)) :
+    ((baseChangePointsMulEquiv (k := k) (K := K) (A := A) n f : Aˣ) : A) =
+      f.ofConv (1 ⊗ₜ[k] MonoidAlgebra.single (generator n) (1 : k)) := by
+  rw [baseChangePointsMulEquiv, MulEquiv.trans_apply, RootsOfUnityGroup.pointsMulEquiv_apply,
+    AlgHom.baseChangePointsMulEquiv_symm_apply]
+
+/-- The inverse base-changed roots-of-unity points equivalence takes the standard generator to
+the chosen root of unity. -/
+@[simp]
+lemma baseChangePointsMulEquiv_symm_apply_single_generator (n : ℕ) (ζ : rootsOfUnity n A) :
+    ((baseChangePointsMulEquiv (k := k) (K := K) (A := A) n).symm ζ).ofConv
+        (1 ⊗ₜ[k] MonoidAlgebra.single (generator n) (1 : k)) =
+      ((ζ : Aˣ) : A) := by
+  rw [← baseChangePointsMulEquiv_apply n]
+  simp
+
+variable {B : Type*} [CommSemiring B] [Algebra K B] [Algebra k B] [IsScalarTower k K B]
+
+/-- The base-changed roots-of-unity points equivalence is natural in the value algebra:
+post-composing a point with a `K`-algebra map applies the induced map on roots of unity. -/
+@[simp]
+lemma baseChangePointsMulEquiv_mapValue (n : ℕ) (φ : A →ₐ[K] B)
+    (f : WithConv (K ⊗[k] MonoidAlgebra k (Multiplicative (ZMod n)) →ₐ[K] A)) :
+    baseChangePointsMulEquiv (k := k) (K := K) (A := B) n
+        (AlgHom.mapValue (H := K ⊗[k] MonoidAlgebra k (Multiplicative (ZMod n))) φ f) =
+      restrictRootsOfUnity φ.toMonoidHom n
+        (baseChangePointsMulEquiv (k := k) (K := K) (A := A) n f) := by
+  ext
+  simp [baseChangePointsMulEquiv_apply]
+
+/-- Naturality of the inverse base-changed roots-of-unity points equivalence in the value
+algebra. -/
+@[simp]
+lemma mapValue_baseChangePointsMulEquiv_symm_apply (n : ℕ) (φ : A →ₐ[K] B)
+    (ζ : rootsOfUnity n A) :
+    AlgHom.mapValue (H := K ⊗[k] MonoidAlgebra k (Multiplicative (ZMod n))) φ
+        ((baseChangePointsMulEquiv (k := k) (K := K) (A := A) n).symm ζ) =
+      (baseChangePointsMulEquiv (k := k) (K := K) (A := B) n).symm
+        (restrictRootsOfUnity φ.toMonoidHom n ζ) := by
+  apply (baseChangePointsMulEquiv (k := k) (K := K) (A := B) n).injective
+  rw [baseChangePointsMulEquiv_mapValue]
+  simp
+
+end RootsOfUnityGroup
+
+end TauCeti


### PR DESCRIPTION
This PR adds the base-changed functor-of-points calculation for the roots-of-unity group scheme `μ_n = D(Multiplicative (ZMod n))`: for a `k`-algebra `K` and a commutative `K`-algebra `A`, convolution points of `K ⊗[k] k[Multiplicative (ZMod n)]` are multiplicatively equivalent to `rootsOfUnity n A`. It exposes the characteristic API reading a point on the base-changed standard generator `1 ⊗ single (generator n) 1`, the inverse generator evaluation, and naturality in the value algebra.

This advances `TauCetiRoadmap/ReductiveGroups/README.md`, the worked-example item “`μ_n`/`μ_p`” and Layer 4 item “`μ_n = D(ℤ/n)`” in the diagonalizable-groups lane, together with Layer 0 “Base change. `K ⊗[k] A` as a Hopf algebra over `K`”. I chose it as the lowest-hanging distinct ReductiveGroups target after checking open and recently merged PRs: open #383 covers Hopf-ideal comaps, while the existing `μ_n`, diagonalizable-group, and base-change APIs already made this specialization a small missing compatibility lemma rather than new theory.

No Mathlib infrastructure is vendored. The construction reuses Tau Ceti’s `AlgHom.baseChangePointsMulEquiv` and `RootsOfUnityGroup.pointsMulEquiv`; the latter builds on Mathlib’s `IsCyclic.monoidHomMulEquivRootsOfUnityOfGenerator`.

Local verification: `lake exe cache get` completed with `No files to download` and `Already decompressed 8585 file(s)`; `lake build` completed with `Build completed successfully (4187 jobs).`; `lake exe axioms` completed with `axioms: audited 4553 TauCeti declaration(s); all within the allowlist [propext, Classical.choice, Quot.sound].`

<!--tauceti-target:v1 {"focus":"ReductiveGroups","id":"roots-of-unity-base-change"}-->

🤖 Prepared with Codex
