### PR TITLE
feat: add J-holomorphic product-map calculus

### DIFF
--- a/TauCeti/Geometry/Symplectic/JHolomorphicProdMap.lean
+++ b/TauCeti/Geometry/Symplectic/JHolomorphicProdMap.lean
@@ -14,7 +14,7 @@ predicate used in the analytic Heegaard Floer roadmap. The existing product file
 with a common source and product target. Here the source is also a product: if
 `f : V → V'` and `g : W → W'` are `J`-holomorphic, then
 `Prod.map f g : V × W → V' × W'` is `J`-holomorphic for the direct-sum almost complex
-structures.
+structures, both on arbitrary product-source subsets and on rectangular product sets.
 
 The same API records the affine coordinate inclusions `v ↦ (v, w₀)` and `w ↦ (v₀, w)`,
 and restriction of a product-source `J`-holomorphic map along either inclusion. These are the
@@ -161,9 +161,19 @@ lemma IsJHolomorphicAt.prodMap {f : V → V'} {g : W → W'} {p : V × W}
     ((hf.comp (isJHolomorphicAt_fst J₁ J₂ p)).prodMk
       (hg.comp (isJHolomorphicAt_snd J₁ J₂ p)))
 
+/-- The product map of two maps `J`-holomorphic within the coordinate images of a product-source
+set is `J`-holomorphic within that set. -/
+lemma IsJHolomorphicWithinAt.prodMap {f : V → V'} {g : W → W'} {u : Set (V × W)}
+    {p : V × W} (hf : IsJHolomorphicWithinAt J₁ K₁ f (Prod.fst '' u) p.1)
+    (hg : IsJHolomorphicWithinAt J₂ K₂ g (Prod.snd '' u) p.2) :
+    IsJHolomorphicWithinAt (J₁.prod J₂) (K₁.prod K₂) (Prod.map f g) u p := by
+  simpa [Prod.map] using
+    ((hf.comp (isJHolomorphicWithinAt_fst J₁ J₂ u p) (fun q hq => ⟨q, hq, rfl⟩)).prodMk
+      (hg.comp (isJHolomorphicWithinAt_snd J₁ J₂ u p) (fun q hq => ⟨q, hq, rfl⟩)))
+
 /-- The product map of two maps `J`-holomorphic within sets is `J`-holomorphic within the
 product set. -/
-lemma IsJHolomorphicWithinAt.prodMap {f : V → V'} {g : W → W'} {s : Set V} {t : Set W}
+lemma IsJHolomorphicWithinAt.prodMap_prod {f : V → V'} {g : W → W'} {s : Set V} {t : Set W}
     {p : V × W} (hf : IsJHolomorphicWithinAt J₁ K₁ f s p.1)
     (hg : IsJHolomorphicWithinAt J₂ K₂ g t p.2) :
     IsJHolomorphicWithinAt (J₁.prod J₂) (K₁.prod K₂) (Prod.map f g) (s ×ˢ t) p := by
@@ -176,7 +186,7 @@ lemma IsJHolomorphicOn.prodMap {f : V → V'} {g : W → W'} {s : Set V} {t : Se
     (hf : IsJHolomorphicOn J₁ K₁ f s) (hg : IsJHolomorphicOn J₂ K₂ g t) :
     IsJHolomorphicOn (J₁.prod J₂) (K₁.prod K₂) (Prod.map f g) (s ×ˢ t) := by
   intro p hp
-  simpa [Prod.map] using (hf p.1 hp.1).prodMap (hg p.2 hp.2)
+  simpa [Prod.map] using (hf p.1 hp.1).prodMap_prod (hg p.2 hp.2)
 
 /-- The product map of two globally `J`-holomorphic maps is globally `J`-holomorphic. -/
 lemma IsJHolomorphic.prodMap {f : V → V'} {g : W → W'}

--- a/TauCeti/Geometry/Symplectic/JHolomorphicProdMap.lean
+++ b/TauCeti/Geometry/Symplectic/JHolomorphicProdMap.lean
@@ -44,57 +44,57 @@ variable (J₁ : AlmostComplexStructure V) (J₂ : AlmostComplexStructure W)
 
 /-- The affine inclusion of the first coordinate into a product is `J`-holomorphic. -/
 @[simp]
-lemma isJHolomorphicAt_prod_mk_left (w₀ : W) (v : V) :
+lemma isJHolomorphicAt_prodMk_left (w₀ : W) (v : V) :
     IsJHolomorphicAt J₁ (J₁.prod J₂) (fun v' : V => (v', w₀)) v :=
   (isJHolomorphicAt_id J₁ v).prodMk (isJHolomorphicAt_const J₁ J₂ w₀ v)
 
 /-- The affine inclusion of the second coordinate into a product is `J`-holomorphic. -/
 @[simp]
-lemma isJHolomorphicAt_prod_mk_right (v₀ : V) (w : W) :
+lemma isJHolomorphicAt_prodMk_right (v₀ : V) (w : W) :
     IsJHolomorphicAt J₂ (J₁.prod J₂) (fun w' : W => (v₀, w')) w :=
   (isJHolomorphicAt_const J₂ J₁ v₀ w).prodMk (isJHolomorphicAt_id J₂ w)
 
 /-- The affine inclusion of the first coordinate into a product is `J`-holomorphic within
 every set. -/
 @[simp]
-lemma isJHolomorphicWithinAt_prod_mk_left (w₀ : W) (s : Set V) (v : V) :
+lemma isJHolomorphicWithinAt_prodMk_left (w₀ : W) (s : Set V) (v : V) :
     IsJHolomorphicWithinAt J₁ (J₁.prod J₂) (fun v' : V => (v', w₀)) s v :=
-  (isJHolomorphicAt_prod_mk_left J₁ J₂ w₀ v).isJHolomorphicWithinAt
+  (isJHolomorphicAt_prodMk_left J₁ J₂ w₀ v).isJHolomorphicWithinAt
 
 /-- The affine inclusion of the second coordinate into a product is `J`-holomorphic within
 every set. -/
 @[simp]
-lemma isJHolomorphicWithinAt_prod_mk_right (v₀ : V) (s : Set W) (w : W) :
+lemma isJHolomorphicWithinAt_prodMk_right (v₀ : V) (s : Set W) (w : W) :
     IsJHolomorphicWithinAt J₂ (J₁.prod J₂) (fun w' : W => (v₀, w')) s w :=
-  (isJHolomorphicAt_prod_mk_right J₁ J₂ v₀ w).isJHolomorphicWithinAt
+  (isJHolomorphicAt_prodMk_right J₁ J₂ v₀ w).isJHolomorphicWithinAt
 
 /-- The affine inclusion of the first coordinate into a product is `J`-holomorphic on every
 set. -/
 @[simp]
-lemma isJHolomorphicOn_prod_mk_left (w₀ : W) (s : Set V) :
+lemma isJHolomorphicOn_prodMk_left (w₀ : W) (s : Set V) :
     IsJHolomorphicOn J₁ (J₁.prod J₂) (fun v' : V => (v', w₀)) s :=
-  fun v _ => isJHolomorphicWithinAt_prod_mk_left J₁ J₂ w₀ s v
+  fun v _ => isJHolomorphicWithinAt_prodMk_left J₁ J₂ w₀ s v
 
 /-- The affine inclusion of the second coordinate into a product is `J`-holomorphic on every
 set. -/
 @[simp]
-lemma isJHolomorphicOn_prod_mk_right (v₀ : V) (s : Set W) :
+lemma isJHolomorphicOn_prodMk_right (v₀ : V) (s : Set W) :
     IsJHolomorphicOn J₂ (J₁.prod J₂) (fun w' : W => (v₀, w')) s :=
-  fun w _ => isJHolomorphicWithinAt_prod_mk_right J₁ J₂ v₀ s w
+  fun w _ => isJHolomorphicWithinAt_prodMk_right J₁ J₂ v₀ s w
 
 /-- The affine inclusion of the first coordinate into a product is globally
 `J`-holomorphic. -/
 @[simp]
-lemma isJHolomorphic_prod_mk_left (w₀ : W) :
+lemma isJHolomorphic_prodMk_left (w₀ : W) :
     IsJHolomorphic J₁ (J₁.prod J₂) (fun v' : V => (v', w₀)) :=
-  fun v => isJHolomorphicAt_prod_mk_left J₁ J₂ w₀ v
+  fun v => isJHolomorphicAt_prodMk_left J₁ J₂ w₀ v
 
 /-- The affine inclusion of the second coordinate into a product is globally
 `J`-holomorphic. -/
 @[simp]
-lemma isJHolomorphic_prod_mk_right (v₀ : V) :
+lemma isJHolomorphic_prodMk_right (v₀ : V) :
     IsJHolomorphic J₂ (J₁.prod J₂) (fun w' : W => (v₀, w')) :=
-  fun w => isJHolomorphicAt_prod_mk_right J₁ J₂ v₀ w
+  fun w => isJHolomorphicAt_prodMk_right J₁ J₂ v₀ w
 
 end CoordinateInclusions
 
@@ -105,47 +105,45 @@ variable {K : AlmostComplexStructure X}
 
 /-- Restricting a product-source `J`-holomorphic map to a fixed second coordinate preserves
 `J`-holomorphicity. -/
-lemma IsJHolomorphicAt.comp_prod_mk_left {f : V × W → X} {v : V} {w : W}
+lemma IsJHolomorphicAt.comp_prodMk_left {f : V × W → X} {v : V} {w : W}
     (hf : IsJHolomorphicAt (J₁.prod J₂) K f (v, w)) :
     IsJHolomorphicAt J₁ K (fun v' : V => f (v', w)) v := by
   simpa [Function.comp_def] using
     IsJHolomorphicAt.comp (J := J₁) (J' := J₁.prod J₂) (J'' := K)
       (f := fun v' : V => (v', w)) (g := f) (x := v) hf
-      (isJHolomorphicAt_prod_mk_left J₁ J₂ w v)
+      (isJHolomorphicAt_prodMk_left J₁ J₂ w v)
 
 /-- Restricting a product-source `J`-holomorphic map to a fixed first coordinate preserves
 `J`-holomorphicity. -/
-lemma IsJHolomorphicAt.comp_prod_mk_right {f : V × W → X} {v : V} {w : W}
+lemma IsJHolomorphicAt.comp_prodMk_right {f : V × W → X} {v : V} {w : W}
     (hf : IsJHolomorphicAt (J₁.prod J₂) K f (v, w)) :
     IsJHolomorphicAt J₂ K (fun w' : W => f (v, w')) w := by
   simpa [Function.comp_def] using
     IsJHolomorphicAt.comp (J := J₂) (J' := J₁.prod J₂) (J'' := K)
       (f := fun w' : W => (v, w')) (g := f) (x := w) hf
-      (isJHolomorphicAt_prod_mk_right J₁ J₂ v w)
+      (isJHolomorphicAt_prodMk_right J₁ J₂ v w)
 
-/-- Restricting a product-source map on a product set to a fixed second coordinate preserves
+/-- Restricting a product-source map along a fixed second-coordinate inclusion preserves
 within-set `J`-holomorphicity. -/
-lemma IsJHolomorphicWithinAt.comp_prod_mk_left {f : V × W → X} {s : Set V} {t : Set W}
-    {v : V} {w : W} (hf : IsJHolomorphicWithinAt (J₁.prod J₂) K f (s ×ˢ t) (v, w))
-    (hw : w ∈ t) :
+lemma IsJHolomorphicWithinAt.comp_prodMk_left {f : V × W → X} {u : Set (V × W)}
+    {s : Set V} {v : V} {w : W} (hf : IsJHolomorphicWithinAt (J₁.prod J₂) K f u (v, w))
+    (hsu : Set.MapsTo (fun v' : V => (v', w)) s u) :
     IsJHolomorphicWithinAt J₁ K (fun v' : V => f (v', w)) s v := by
   simpa [Function.comp_def] using
     IsJHolomorphicWithinAt.comp (J := J₁) (J' := J₁.prod J₂) (J'' := K)
-      (f := fun v' : V => (v', w)) (g := f) (s := s) (t := s ×ˢ t) (x := v) hf
-      (isJHolomorphicWithinAt_prod_mk_left J₁ J₂ w s v)
-      (fun _ hv' => ⟨hv', hw⟩)
+      (f := fun v' : V => (v', w)) (g := f) (s := s) (t := u) (x := v) hf
+      (isJHolomorphicWithinAt_prodMk_left J₁ J₂ w s v) hsu
 
-/-- Restricting a product-source map on a product set to a fixed first coordinate preserves
+/-- Restricting a product-source map along a fixed first-coordinate inclusion preserves
 within-set `J`-holomorphicity. -/
-lemma IsJHolomorphicWithinAt.comp_prod_mk_right {f : V × W → X} {s : Set V} {t : Set W}
-    {v : V} {w : W} (hf : IsJHolomorphicWithinAt (J₁.prod J₂) K f (s ×ˢ t) (v, w))
-    (hv : v ∈ s) :
+lemma IsJHolomorphicWithinAt.comp_prodMk_right {f : V × W → X} {u : Set (V × W)}
+    {t : Set W} {v : V} {w : W} (hf : IsJHolomorphicWithinAt (J₁.prod J₂) K f u (v, w))
+    (htu : Set.MapsTo (fun w' : W => (v, w')) t u) :
     IsJHolomorphicWithinAt J₂ K (fun w' : W => f (v, w')) t w := by
   simpa [Function.comp_def] using
     IsJHolomorphicWithinAt.comp (J := J₂) (J' := J₁.prod J₂) (J'' := K)
-      (f := fun w' : W => (v, w')) (g := f) (s := t) (t := s ×ˢ t) (x := w) hf
-      (isJHolomorphicWithinAt_prod_mk_right J₁ J₂ v t w)
-      (fun _ hw' => ⟨hv, hw'⟩)
+      (f := fun w' : W => (v, w')) (g := f) (s := t) (t := u) (x := w) hf
+      (isJHolomorphicWithinAt_prodMk_right J₁ J₂ v t w) htu
 
 end CoordinateRestrictions
 
@@ -163,14 +161,22 @@ lemma IsJHolomorphicAt.prodMap {f : V → V'} {g : W → W'} {p : V × W}
     ((hf.comp (isJHolomorphicAt_fst J₁ J₂ p)).prodMk
       (hg.comp (isJHolomorphicAt_snd J₁ J₂ p)))
 
+/-- The product map of two maps `J`-holomorphic within sets is `J`-holomorphic within the
+product set. -/
+lemma IsJHolomorphicWithinAt.prodMap {f : V → V'} {g : W → W'} {s : Set V} {t : Set W}
+    {p : V × W} (hf : IsJHolomorphicWithinAt J₁ K₁ f s p.1)
+    (hg : IsJHolomorphicWithinAt J₂ K₂ g t p.2) :
+    IsJHolomorphicWithinAt (J₁.prod J₂) (K₁.prod K₂) (Prod.map f g) (s ×ˢ t) p := by
+  simpa [Prod.map] using
+    ((hf.comp (isJHolomorphicWithinAt_fst J₁ J₂ (s ×ˢ t) p) (fun q hq => hq.1)).prodMk
+      (hg.comp (isJHolomorphicWithinAt_snd J₁ J₂ (s ×ˢ t) p) (fun q hq => hq.2)))
+
 /-- The product map of two maps `J`-holomorphic on sets is `J`-holomorphic on the product set. -/
 lemma IsJHolomorphicOn.prodMap {f : V → V'} {g : W → W'} {s : Set V} {t : Set W}
     (hf : IsJHolomorphicOn J₁ K₁ f s) (hg : IsJHolomorphicOn J₂ K₂ g t) :
     IsJHolomorphicOn (J₁.prod J₂) (K₁.prod K₂) (Prod.map f g) (s ×ˢ t) := by
   intro p hp
-  exact (hf p.1 hp.1).comp (isJHolomorphicWithinAt_fst J₁ J₂ (s ×ˢ t) p)
-      (fun q hq => hq.1) |>.prodMk
-    ((hg p.2 hp.2).comp (isJHolomorphicWithinAt_snd J₁ J₂ (s ×ˢ t) p) (fun q hq => hq.2))
+  simpa [Prod.map] using (hf p.1 hp.1).prodMap (hg p.2 hp.2)
 
 /-- The product map of two globally `J`-holomorphic maps is globally `J`-holomorphic. -/
 lemma IsJHolomorphic.prodMap {f : V → V'} {g : W → W'}

--- a/TauCeti/Geometry/Symplectic/JHolomorphicProdMap.lean
+++ b/TauCeti/Geometry/Symplectic/JHolomorphicProdMap.lean
@@ -1,0 +1,183 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+module
+
+public import TauCeti.Geometry.Symplectic.JHolomorphicProd
+
+/-!
+# Product maps of `J`-holomorphic maps
+
+This file adds the source-and-target product calculus for the pointwise `J`-holomorphic
+predicate used in the analytic Heegaard Floer roadmap. The existing product file handles maps
+with a common source and product target. Here the source is also a product: if
+`f : V → V'` and `g : W → W'` are `J`-holomorphic, then
+`Prod.map f g : V × W → V' × W'` is `J`-holomorphic for the direct-sum almost complex
+structures.
+
+The same API records the affine coordinate inclusions `v ↦ (v, w₀)` and `w ↦ (v₀, w)`,
+and restriction of a product-source `J`-holomorphic map along either inclusion. These are the
+local product-chart facts needed before strip, disk, product, and symmetric-product
+constructions can use the Cauchy--Riemann equation without unfolding it.
+
+The convention follows McDuff--Salamon, *J-holomorphic Curves and Symplectic Topology*,
+Section 2.1: product almost complex structures act componentwise and the Cauchy--Riemann
+equation is preserved by products and coordinate inclusions.
+-/
+
+public section
+
+namespace TauCeti
+
+variable {V W V' W' X : Type*}
+
+variable [NormedAddCommGroup V] [NormedSpace ℝ V]
+variable [NormedAddCommGroup W] [NormedSpace ℝ W]
+variable [NormedAddCommGroup V'] [NormedSpace ℝ V']
+variable [NormedAddCommGroup W'] [NormedSpace ℝ W']
+variable [NormedAddCommGroup X] [NormedSpace ℝ X]
+
+section CoordinateInclusions
+
+variable (J₁ : AlmostComplexStructure V) (J₂ : AlmostComplexStructure W)
+
+/-- The affine inclusion of the first coordinate into a product is `J`-holomorphic. -/
+@[simp]
+lemma isJHolomorphicAt_prod_mk_left (w₀ : W) (v : V) :
+    IsJHolomorphicAt J₁ (J₁.prod J₂) (fun v' : V => (v', w₀)) v :=
+  (isJHolomorphicAt_id J₁ v).prodMk (isJHolomorphicAt_const J₁ J₂ w₀ v)
+
+/-- The affine inclusion of the second coordinate into a product is `J`-holomorphic. -/
+@[simp]
+lemma isJHolomorphicAt_prod_mk_right (v₀ : V) (w : W) :
+    IsJHolomorphicAt J₂ (J₁.prod J₂) (fun w' : W => (v₀, w')) w :=
+  (isJHolomorphicAt_const J₂ J₁ v₀ w).prodMk (isJHolomorphicAt_id J₂ w)
+
+/-- The affine inclusion of the first coordinate into a product is `J`-holomorphic within
+every set. -/
+@[simp]
+lemma isJHolomorphicWithinAt_prod_mk_left (w₀ : W) (s : Set V) (v : V) :
+    IsJHolomorphicWithinAt J₁ (J₁.prod J₂) (fun v' : V => (v', w₀)) s v :=
+  (isJHolomorphicAt_prod_mk_left J₁ J₂ w₀ v).isJHolomorphicWithinAt
+
+/-- The affine inclusion of the second coordinate into a product is `J`-holomorphic within
+every set. -/
+@[simp]
+lemma isJHolomorphicWithinAt_prod_mk_right (v₀ : V) (s : Set W) (w : W) :
+    IsJHolomorphicWithinAt J₂ (J₁.prod J₂) (fun w' : W => (v₀, w')) s w :=
+  (isJHolomorphicAt_prod_mk_right J₁ J₂ v₀ w).isJHolomorphicWithinAt
+
+/-- The affine inclusion of the first coordinate into a product is `J`-holomorphic on every
+set. -/
+@[simp]
+lemma isJHolomorphicOn_prod_mk_left (w₀ : W) (s : Set V) :
+    IsJHolomorphicOn J₁ (J₁.prod J₂) (fun v' : V => (v', w₀)) s :=
+  fun v _ => isJHolomorphicWithinAt_prod_mk_left J₁ J₂ w₀ s v
+
+/-- The affine inclusion of the second coordinate into a product is `J`-holomorphic on every
+set. -/
+@[simp]
+lemma isJHolomorphicOn_prod_mk_right (v₀ : V) (s : Set W) :
+    IsJHolomorphicOn J₂ (J₁.prod J₂) (fun w' : W => (v₀, w')) s :=
+  fun w _ => isJHolomorphicWithinAt_prod_mk_right J₁ J₂ v₀ s w
+
+/-- The affine inclusion of the first coordinate into a product is globally
+`J`-holomorphic. -/
+@[simp]
+lemma isJHolomorphic_prod_mk_left (w₀ : W) :
+    IsJHolomorphic J₁ (J₁.prod J₂) (fun v' : V => (v', w₀)) :=
+  fun v => isJHolomorphicAt_prod_mk_left J₁ J₂ w₀ v
+
+/-- The affine inclusion of the second coordinate into a product is globally
+`J`-holomorphic. -/
+@[simp]
+lemma isJHolomorphic_prod_mk_right (v₀ : V) :
+    IsJHolomorphic J₂ (J₁.prod J₂) (fun w' : W => (v₀, w')) :=
+  fun w => isJHolomorphicAt_prod_mk_right J₁ J₂ v₀ w
+
+end CoordinateInclusions
+
+section CoordinateRestrictions
+
+variable {J₁ : AlmostComplexStructure V} {J₂ : AlmostComplexStructure W}
+variable {K : AlmostComplexStructure X}
+
+/-- Restricting a product-source `J`-holomorphic map to a fixed second coordinate preserves
+`J`-holomorphicity. -/
+lemma IsJHolomorphicAt.comp_prod_mk_left {f : V × W → X} {v : V} {w : W}
+    (hf : IsJHolomorphicAt (J₁.prod J₂) K f (v, w)) :
+    IsJHolomorphicAt J₁ K (fun v' : V => f (v', w)) v := by
+  simpa [Function.comp_def] using
+    IsJHolomorphicAt.comp (J := J₁) (J' := J₁.prod J₂) (J'' := K)
+      (f := fun v' : V => (v', w)) (g := f) (x := v) hf
+      (isJHolomorphicAt_prod_mk_left J₁ J₂ w v)
+
+/-- Restricting a product-source `J`-holomorphic map to a fixed first coordinate preserves
+`J`-holomorphicity. -/
+lemma IsJHolomorphicAt.comp_prod_mk_right {f : V × W → X} {v : V} {w : W}
+    (hf : IsJHolomorphicAt (J₁.prod J₂) K f (v, w)) :
+    IsJHolomorphicAt J₂ K (fun w' : W => f (v, w')) w := by
+  simpa [Function.comp_def] using
+    IsJHolomorphicAt.comp (J := J₂) (J' := J₁.prod J₂) (J'' := K)
+      (f := fun w' : W => (v, w')) (g := f) (x := w) hf
+      (isJHolomorphicAt_prod_mk_right J₁ J₂ v w)
+
+/-- Restricting a product-source map on a product set to a fixed second coordinate preserves
+within-set `J`-holomorphicity. -/
+lemma IsJHolomorphicWithinAt.comp_prod_mk_left {f : V × W → X} {s : Set V} {t : Set W}
+    {v : V} {w : W} (hf : IsJHolomorphicWithinAt (J₁.prod J₂) K f (s ×ˢ t) (v, w))
+    (hw : w ∈ t) :
+    IsJHolomorphicWithinAt J₁ K (fun v' : V => f (v', w)) s v := by
+  simpa [Function.comp_def] using
+    IsJHolomorphicWithinAt.comp (J := J₁) (J' := J₁.prod J₂) (J'' := K)
+      (f := fun v' : V => (v', w)) (g := f) (s := s) (t := s ×ˢ t) (x := v) hf
+      (isJHolomorphicWithinAt_prod_mk_left J₁ J₂ w s v)
+      (fun _ hv' => ⟨hv', hw⟩)
+
+/-- Restricting a product-source map on a product set to a fixed first coordinate preserves
+within-set `J`-holomorphicity. -/
+lemma IsJHolomorphicWithinAt.comp_prod_mk_right {f : V × W → X} {s : Set V} {t : Set W}
+    {v : V} {w : W} (hf : IsJHolomorphicWithinAt (J₁.prod J₂) K f (s ×ˢ t) (v, w))
+    (hv : v ∈ s) :
+    IsJHolomorphicWithinAt J₂ K (fun w' : W => f (v, w')) t w := by
+  simpa [Function.comp_def] using
+    IsJHolomorphicWithinAt.comp (J := J₂) (J' := J₁.prod J₂) (J'' := K)
+      (f := fun w' : W => (v, w')) (g := f) (s := t) (t := s ×ˢ t) (x := w) hf
+      (isJHolomorphicWithinAt_prod_mk_right J₁ J₂ v t w)
+      (fun _ hw' => ⟨hv, hw'⟩)
+
+end CoordinateRestrictions
+
+section ProductMaps
+
+variable {J₁ : AlmostComplexStructure V} {J₂ : AlmostComplexStructure W}
+variable {K₁ : AlmostComplexStructure V'} {K₂ : AlmostComplexStructure W'}
+
+/-- The product map of two pointwise `J`-holomorphic maps is `J`-holomorphic for the
+direct-sum almost complex structures. -/
+lemma IsJHolomorphicAt.prodMap {f : V → V'} {g : W → W'} {p : V × W}
+    (hf : IsJHolomorphicAt J₁ K₁ f p.1) (hg : IsJHolomorphicAt J₂ K₂ g p.2) :
+    IsJHolomorphicAt (J₁.prod J₂) (K₁.prod K₂) (Prod.map f g) p := by
+  simpa [Prod.map] using
+    ((hf.comp (isJHolomorphicAt_fst J₁ J₂ p)).prodMk
+      (hg.comp (isJHolomorphicAt_snd J₁ J₂ p)))
+
+/-- The product map of two maps `J`-holomorphic on sets is `J`-holomorphic on the product set. -/
+lemma IsJHolomorphicOn.prodMap {f : V → V'} {g : W → W'} {s : Set V} {t : Set W}
+    (hf : IsJHolomorphicOn J₁ K₁ f s) (hg : IsJHolomorphicOn J₂ K₂ g t) :
+    IsJHolomorphicOn (J₁.prod J₂) (K₁.prod K₂) (Prod.map f g) (s ×ˢ t) := by
+  intro p hp
+  exact (hf p.1 hp.1).comp (isJHolomorphicWithinAt_fst J₁ J₂ (s ×ˢ t) p)
+      (fun q hq => hq.1) |>.prodMk
+    ((hg p.2 hp.2).comp (isJHolomorphicWithinAt_snd J₁ J₂ (s ×ˢ t) p) (fun q hq => hq.2))
+
+/-- The product map of two globally `J`-holomorphic maps is globally `J`-holomorphic. -/
+lemma IsJHolomorphic.prodMap {f : V → V'} {g : W → W'}
+    (hf : IsJHolomorphic J₁ K₁ f) (hg : IsJHolomorphic J₂ K₂ g) :
+    IsJHolomorphic (J₁.prod J₂) (K₁.prod K₂) (Prod.map f g) :=
+  fun p => (hf p.1).prodMap (hg p.2)
+
+end ProductMaps
+
+end TauCeti


### PR DESCRIPTION
This PR adds the source-and-target product-map calculus for pointwise `J`-holomorphic maps. It proves that the affine coordinate inclusions `v ↦ (v, w0)` and `w ↦ (v0, w)` are `J`-holomorphic, records that a product-source `J`-holomorphic map remains `J`-holomorphic after fixing either coordinate, and packages the product rule: if `f : V -> V2` and `g : W -> W2` are `J`-holomorphic, then `Prod.map f g : V × W -> V2 × W2` is `J`-holomorphic for the direct-sum almost complex structures.

This advances `TauCetiRoadmap/HeegaardFloer/README.md`, Lane F2 item 1 (“Definitions land immediately ... almost complex structures ... `J`-holomorphic maps”), as a clean product-chart prerequisite for the later strip, disk, product, and symmetric-product constructions in Lanes F2-F4. I chose it as the lowest-hanging distinct HeegaardFloer target because the existing pointwise `J`-holomorphic API and target-product calculus had already landed, while the matching source-and-target product-map wrapper was still absent and follows directly from that infrastructure.

No Mathlib infrastructure is vendored. The proofs reuse Tau Ceti’s existing `IsJHolomorphicAt.prodMk`, coordinate projection lemmas, direct-sum `AlmostComplexStructure.prod`, and Mathlib’s Frechet derivative product/projection API through those existing wrappers.

Local verification: `lake exe cache get` completed with `No files to download` and `Already decompressed 8585 file(s)`; `lake build` completed with `Build completed successfully (4188 jobs).`; `lake exe axioms` completed with `axioms: audited 4578 TauCeti declaration(s); all within the allowlist [propext, Classical.choice, Quot.sound].`

<!--tauceti-target:v1 {"focus":"HeegaardFloer","id":"j-holomorphic-product-map-calculus"}-->

🤖 Prepared with Codex
