### PR TITLE
feat: bound the support of the fully blocked grid differential

### DIFF
--- a/TauCeti/KnotTheory/Grid/Diagram.lean
+++ b/TauCeti/KnotTheory/Grid/Diagram.lean
@@ -9,6 +9,7 @@ public import Mathlib.Data.Finset.Card
 public import Mathlib.Data.Fintype.Basic
 public import Mathlib.Data.Fintype.Card
 public import Mathlib.Data.Fintype.Perm
+public import Mathlib.Data.Fintype.Prod
 public import Mathlib.GroupTheory.Perm.Basic
 
 /-!
@@ -65,6 +66,12 @@ def equivPerm (n : ℕ) : GridState n ≃ Equiv.Perm (Fin n) where
 /-- There are finitely many grid states of a fixed grid size. -/
 instance : Fintype (GridState n) :=
   Fintype.ofEquiv (Equiv.Perm (Fin n)) (equivPerm n).symm
+
+/-- Equality of grid states is decidable: a grid state is determined by its underlying
+permutation, whose equality is decidable. This makes finite sets of grid states computable. -/
+instance : DecidableEq (GridState n) := fun x y =>
+  decidable_of_iff (x.toPerm = y.toPerm)
+    ⟨fun h => by cases x; cases y; cases h; rfl, fun h => by rw [h]⟩
 
 /-- Apply a grid state to a column to get its occupied row. -/
 instance : CoeFun (GridState n) fun _ => Fin n → Fin n where
@@ -298,6 +305,37 @@ theorem swapRows_apply (a b : Fin n) (x : GridState n) (c : Fin n) :
 theorem swapColumns_apply (a b : Fin n) (x : GridState n) (c : Fin n) :
     x.swapColumns a b c = x (Equiv.swap a b c) := by
   simp [swapColumns, relabelColumns]
+
+/-- The grid states obtained from `x` by transposing a pair of distinct columns.
+
+These are exactly the states a single grid rectangle can reach from `x`: the fully blocked
+differential of the generator `x` is supported here. -/
+def columnSwapNeighbors (x : GridState n) : Finset (GridState n) :=
+  (Finset.univ.filter fun p : Fin n × Fin n => p.1 ≠ p.2).image
+    fun p => x.swapColumns p.1 p.2
+
+/-- A state is a column-swap neighbour of `x` exactly when it is `x` with a pair of distinct
+columns transposed. -/
+@[simp]
+theorem mem_columnSwapNeighbors {x y : GridState n} :
+    y ∈ x.columnSwapNeighbors ↔ ∃ c d : Fin n, c ≠ d ∧ y = x.swapColumns c d := by
+  simp only [columnSwapNeighbors, Finset.mem_image, Finset.mem_filter, Finset.mem_univ, true_and,
+    Prod.exists]
+  constructor
+  · rintro ⟨c, d, hcd, rfl⟩
+    exact ⟨c, d, hcd, rfl⟩
+  · rintro ⟨c, d, hcd, rfl⟩
+    exact ⟨c, d, hcd, rfl⟩
+
+/-- A grid state is not a column-swap neighbour of itself: swapping two distinct columns moves the
+occupied row of either column, so the result differs from the original. -/
+@[simp]
+theorem self_notMem_columnSwapNeighbors (x : GridState n) : x ∉ x.columnSwapNeighbors := by
+  rw [mem_columnSwapNeighbors]
+  rintro ⟨c, d, hcd, hx⟩
+  have hval := congrArg (fun z : GridState n => z c) hx
+  simp only [swapColumns_apply, Equiv.swap_apply_left] at hval
+  exact hcd (x.toPerm.injective hval)
 
 /-- Row swaps transport the point set by the row transposition. -/
 @[simp]

--- a/TauCeti/KnotTheory/Grid/DifferentialSupport.lean
+++ b/TauCeti/KnotTheory/Grid/DifferentialSupport.lean
@@ -1,0 +1,165 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+module
+
+public import TauCeti.KnotTheory.Grid.Complex
+public import TauCeti.KnotTheory.Grid.RectangleSwap
+
+/-!
+# Support of the fully blocked grid differential
+
+A grid rectangle from `x` to `y` exists only when the two states differ at exactly two columns,
+where they exchange their rows: `RectangleSwap.lean` records that the target of any oriented
+rectangle is `y = x.swapColumns R.left R.right` for the two distinct side columns. Reading this
+backwards bounds the *support* of the fully blocked grid differential: the coefficient of `y` in
+`∂ x` can only be nonzero when `y` is one of the finitely many column transpositions of `x`.
+
+This is the structural fact that makes the fully blocked complex computable. Although there are
+`n!` grid states, the differential of a generator only ever reaches the `O(n²)` states obtained
+by swapping a pair of columns, so an evaluation of `∂` never has to range over all of `GridState
+n`. It is also a step the rectangle-pairing `∂² = 0` argument relies on: a length-two sequence of
+rectangles `x → y → z` passes through a column transposition `y` of `x`, not an arbitrary state.
+
+## Main definitions
+
+* `TauCeti.GridState.columnSwapNeighbors`: the grid states obtained from `x` by transposing a
+  pair of distinct columns -- the states a rectangle from `x` can reach.
+
+## Main results
+
+* `TauCeti.GridDiagram.exists_swapColumns_of_fullyBlockedRectangleCount_ne_zero`: a nonzero
+  differential coefficient forces the target to be a column transposition of the source.
+* `TauCeti.GridDiagram.fullyBlockedRectangleCount_eq_zero_of_forall_ne`: the coefficient vanishes
+  whenever the target is not any column transposition of the source.
+* `TauCeti.GridDiagram.fullyBlockedDifferentialOnGenerator_support_subset` and
+  `TauCeti.GridDiagram.fullyBlockedDifferential_single_support_subset`: the differential of a
+  generator is supported on the column-swap neighbours of the state.
+
+## References
+
+This supplies a prerequisite for `TauCetiRoadmap/CombinatorialHeegaardFloer/README.md`, Lane G.3,
+"The complexes and `∂² = 0`", and the "grid homology computes" acceptance criterion. The
+column-transposition picture of a rectangle move follows Ozsváth--Stipsicz--Szabó, *Grid Homology
+for Knots and Links*, Chapters 3 and 4.
+-/
+
+public section
+
+namespace TauCeti
+
+namespace GridState
+
+variable {n : ℕ}
+
+/-- Equality of grid states is decidable: a grid state is determined by its underlying
+permutation, whose equality is decidable. This makes the finite set of column-swap neighbours a
+computable `Finset`. -/
+instance : DecidableEq (GridState n) := fun x y =>
+  decidable_of_iff (x.toPerm = y.toPerm)
+    ⟨fun h => by cases x; cases y; cases h; rfl, fun h => by rw [h]⟩
+
+/-- The grid states obtained from `x` by transposing a pair of distinct columns.
+
+These are exactly the states a single grid rectangle can reach from `x`: the differential of the
+generator `x` is supported here (`fullyBlockedDifferentialOnGenerator_support_subset`). -/
+def columnSwapNeighbors (x : GridState n) : Finset (GridState n) :=
+  (Finset.univ.filter fun p : Fin n × Fin n => p.1 ≠ p.2).image
+    fun p => x.swapColumns p.1 p.2
+
+/-- A state is a column-swap neighbour of `x` exactly when it is `x` with a pair of distinct
+columns transposed. -/
+theorem mem_columnSwapNeighbors {x y : GridState n} :
+    y ∈ x.columnSwapNeighbors ↔ ∃ c d : Fin n, c ≠ d ∧ y = x.swapColumns c d := by
+  simp only [columnSwapNeighbors, Finset.mem_image, Finset.mem_filter, Finset.mem_univ, true_and,
+    Prod.exists]
+  constructor
+  · rintro ⟨c, d, hcd, rfl⟩
+    exact ⟨c, d, hcd, rfl⟩
+  · rintro ⟨c, d, hcd, rfl⟩
+    exact ⟨c, d, hcd, rfl⟩
+
+/-- A grid state is not a column-swap neighbour of itself: swapping two distinct columns moves the
+occupied row of either column, so the result differs from the original. -/
+@[simp]
+theorem self_notMem_columnSwapNeighbors (x : GridState n) : x ∉ x.columnSwapNeighbors := by
+  rw [mem_columnSwapNeighbors]
+  rintro ⟨c, d, hcd, hx⟩
+  have hval := congrArg (fun z : GridState n => z c) hx
+  simp only [swapColumns_apply, Equiv.swap_apply_left] at hval
+  exact hcd (x.toPerm.injective hval)
+
+end GridState
+
+namespace GridDiagram
+
+variable {n : ℕ} (G : GridDiagram n) {x y : GridState n}
+
+/-- A nonzero fully blocked rectangle count produces an oriented rectangle, hence at least one
+fully blocked rectangle exists between the two states. -/
+theorem fullyBlockedRectangles_nonempty_of_count_ne_zero
+    (h : G.fullyBlockedRectangleCount x y ≠ 0) : (G.fullyBlockedRectangles x y).Nonempty := by
+  refine Finset.nonempty_of_ne_empty fun he => h ?_
+  rw [fullyBlockedRectangleCount_def, he, Finset.card_empty, Nat.cast_zero]
+
+/-- A nonzero coefficient of the fully blocked differential forces the target state to be a column
+transposition of the source: the two distinct side columns of any rectangle from `x` to `y`
+exhibit `y` as `x.swapColumns`. -/
+theorem exists_swapColumns_of_fullyBlockedRectangleCount_ne_zero
+    (h : G.fullyBlockedRectangleCount x y ≠ 0) :
+    ∃ c d : Fin n, c ≠ d ∧ y = x.swapColumns c d := by
+  obtain ⟨R, -⟩ := G.fullyBlockedRectangles_nonempty_of_count_ne_zero h
+  exact ⟨R.left, R.right, R.left_ne_right, R.target_eq_swapColumns⟩
+
+/-- The fully blocked rectangle count vanishes whenever the target is not any column transposition
+of the source. This is the contrapositive of
+`exists_swapColumns_of_fullyBlockedRectangleCount_ne_zero`. -/
+theorem fullyBlockedRectangleCount_eq_zero_of_forall_ne
+    (h : ∀ c d : Fin n, c ≠ d → y ≠ x.swapColumns c d) :
+    G.fullyBlockedRectangleCount x y = 0 := by
+  by_contra hne
+  obtain ⟨c, d, hcd, hy⟩ := G.exists_swapColumns_of_fullyBlockedRectangleCount_ne_zero hne
+  exact h c d hcd hy
+
+/-- The fully blocked rectangle count is supported on column transpositions: if `y` is not a
+column-swap neighbour of `x`, the coefficient is zero. -/
+theorem fullyBlockedRectangleCount_eq_zero_of_notMem_columnSwapNeighbors
+    (h : y ∉ x.columnSwapNeighbors) : G.fullyBlockedRectangleCount x y = 0 :=
+  G.fullyBlockedRectangleCount_eq_zero_of_forall_ne fun c d hcd hy =>
+    h (GridState.mem_columnSwapNeighbors.mpr ⟨c, d, hcd, hy⟩)
+
+/-- The coefficient of the fully blocked differential on a generator vanishes off the column-swap
+neighbours of the state. -/
+theorem fullyBlockedDifferentialOnGenerator_apply_eq_zero_of_notMem_columnSwapNeighbors
+    (x : GridState n) {y : GridState n} (h : y ∉ x.columnSwapNeighbors) :
+    G.fullyBlockedDifferentialOnGenerator x y = 0 := by
+  rw [fullyBlockedDifferentialOnGenerator_apply]
+  exact G.fullyBlockedRectangleCount_eq_zero_of_notMem_columnSwapNeighbors h
+
+/-- The fully blocked differential of a generator `x` is supported on the column-swap neighbours
+of `x`: although there are `n!` grid states, `∂ x` only reaches the states obtained by
+transposing a pair of columns. -/
+theorem fullyBlockedDifferentialOnGenerator_support_subset (x : GridState n) :
+    (G.fullyBlockedDifferentialOnGenerator x).support ⊆ x.columnSwapNeighbors := by
+  intro y hy
+  by_contra hmem
+  exact (Finsupp.mem_support_iff.mp hy)
+    (G.fullyBlockedDifferentialOnGenerator_apply_eq_zero_of_notMem_columnSwapNeighbors x hmem)
+
+/-- The number of states reached by the fully blocked differential of a generator is at most the
+number of column-swap neighbours of the state. -/
+theorem fullyBlockedDifferentialOnGenerator_support_card_le (x : GridState n) :
+    (G.fullyBlockedDifferentialOnGenerator x).support.card ≤ x.columnSwapNeighbors.card :=
+  Finset.card_le_card (G.fullyBlockedDifferentialOnGenerator_support_subset x)
+
+/-- The fully blocked differential of a single generator, taken through the linear map, is
+supported on the column-swap neighbours of the state. -/
+theorem fullyBlockedDifferential_single_support_subset (x : GridState n) :
+    (G.fullyBlockedDifferential (Finsupp.single x 1)).support ⊆ x.columnSwapNeighbors := by
+  rw [fullyBlockedDifferential_single]
+  exact G.fullyBlockedDifferentialOnGenerator_support_subset x
+
+end GridDiagram
+
+end TauCeti

--- a/TauCeti/KnotTheory/Grid/DifferentialSupport.lean
+++ b/TauCeti/KnotTheory/Grid/DifferentialSupport.lean
@@ -22,7 +22,7 @@ by swapping a pair of columns, so an evaluation of `∂` never has to range over
 n`. It is also a step the rectangle-pairing `∂² = 0` argument relies on: a length-two sequence of
 rectangles `x → y → z` passes through a column transposition `y` of `x`, not an arbitrary state.
 
-## Main definitions
+## Key API
 
 * `TauCeti.GridState.columnSwapNeighbors`: the grid states obtained from `x` by transposing a
   pair of distinct columns -- the states a rectangle from `x` can reach.
@@ -48,49 +48,6 @@ for Knots and Links*, Chapters 3 and 4.
 public section
 
 namespace TauCeti
-
-namespace GridState
-
-variable {n : ℕ}
-
-/-- Equality of grid states is decidable: a grid state is determined by its underlying
-permutation, whose equality is decidable. This makes the finite set of column-swap neighbours a
-computable `Finset`. -/
-instance : DecidableEq (GridState n) := fun x y =>
-  decidable_of_iff (x.toPerm = y.toPerm)
-    ⟨fun h => by cases x; cases y; cases h; rfl, fun h => by rw [h]⟩
-
-/-- The grid states obtained from `x` by transposing a pair of distinct columns.
-
-These are exactly the states a single grid rectangle can reach from `x`: the differential of the
-generator `x` is supported here (`fullyBlockedDifferentialOnGenerator_support_subset`). -/
-def columnSwapNeighbors (x : GridState n) : Finset (GridState n) :=
-  (Finset.univ.filter fun p : Fin n × Fin n => p.1 ≠ p.2).image
-    fun p => x.swapColumns p.1 p.2
-
-/-- A state is a column-swap neighbour of `x` exactly when it is `x` with a pair of distinct
-columns transposed. -/
-theorem mem_columnSwapNeighbors {x y : GridState n} :
-    y ∈ x.columnSwapNeighbors ↔ ∃ c d : Fin n, c ≠ d ∧ y = x.swapColumns c d := by
-  simp only [columnSwapNeighbors, Finset.mem_image, Finset.mem_filter, Finset.mem_univ, true_and,
-    Prod.exists]
-  constructor
-  · rintro ⟨c, d, hcd, rfl⟩
-    exact ⟨c, d, hcd, rfl⟩
-  · rintro ⟨c, d, hcd, rfl⟩
-    exact ⟨c, d, hcd, rfl⟩
-
-/-- A grid state is not a column-swap neighbour of itself: swapping two distinct columns moves the
-occupied row of either column, so the result differs from the original. -/
-@[simp]
-theorem self_notMem_columnSwapNeighbors (x : GridState n) : x ∉ x.columnSwapNeighbors := by
-  rw [mem_columnSwapNeighbors]
-  rintro ⟨c, d, hcd, hx⟩
-  have hval := congrArg (fun z : GridState n => z c) hx
-  simp only [swapColumns_apply, Equiv.swap_apply_left] at hval
-  exact hcd (x.toPerm.injective hval)
-
-end GridState
 
 namespace GridDiagram
 


### PR DESCRIPTION
This PR bounds the support of the fully blocked grid differential. A grid rectangle from a state `x` to a state `y` exists only when the two states differ at exactly two columns, where they exchange their occupied rows, so `y` is necessarily `x` with a pair of distinct columns transposed (`RectangleSwap.lean`'s `target_eq_swapColumns`). Reading this backwards, the coefficient of `y` in `∂ x` can be nonzero only when `y` is one of the finitely many column transpositions of `x`. The PR defines `GridState.columnSwapNeighbors x`, the states reachable from `x` by a column transposition, and proves the differential of a generator is supported there: `fullyBlockedDifferentialOnGenerator_support_subset` and its linear-map form `fullyBlockedDifferential_single_support_subset`, together with the underlying vanishing lemmas `exists_swapColumns_of_fullyBlockedRectangleCount_ne_zero` and `fullyBlockedRectangleCount_eq_zero_of_forall_ne`. It also adds the basic `DecidableEq (GridState n)` instance needed to form the neighbour set as a computable `Finset`.

This advances `TauCetiRoadmap/CombinatorialHeegaardFloer/README.md`, Lane G.3, "The complexes and `∂² = 0`", and the "grid homology computes" acceptance criterion: although there are `n!` grid states, the differential of a generator only ever reaches the `O(n²)` column-swap neighbours, so an evaluation of `∂` never has to range over all of `GridState n`. The support bound is also the step the rectangle-pairing `∂² = 0` argument relies on, since a length-two sequence of rectangles `x → y → z` passes through a column transposition `y` of `x`. I chose it as a small, self-contained increment after checking open and merged PRs: the fully blocked differential (#223) and the rectangle-as-column-transposition identification (#249) already landed, and this packages their immediate consequence for the differential's support; it does not overlap the open plumbing-lattice work (#387).

No Mathlib infrastructure is vendored. The file reuses Tau Ceti's existing grid rectangle, differential, and `swapColumns` API together with Mathlib's `Finsupp` support and `Finset.image` lemmas.

Local verification: `lake build` completed with `Build completed successfully (4190 jobs).` and `lake exe axioms` reported `axioms: audited 4626 TauCeti declaration(s); all within the allowlist [propext, Classical.choice, Quot.sound].`

<!--tauceti-target:v1 {"focus":"CombinatorialHeegaardFloer","id":"fully-blocked-grid-differential-support"}-->

🤖 Prepared with Claude Code
