### PR TITLE
feat: normalize positive-definite functions

### DIFF
--- a/TauCeti/Analysis/PositiveDefinite/Basic.lean
+++ b/TauCeti/Analysis/PositiveDefinite/Basic.lean
@@ -41,6 +41,9 @@ here. The continuity theory and Bochner's representation theorem are later miles
 * `TauCeti.IsPositiveDefinite.map_zero_nonneg`: `0 ≤ F 0`.
 * `TauCeti.IsPositiveDefinite.map_zero_im`: `(F 0).im = 0`.
 * `TauCeti.IsPositiveDefinite.map_zero_re_nonneg`: `0 ≤ (F 0).re`.
+* `TauCeti.IsPositiveDefinite.map_zero_eq_ofReal_re`: `F 0 = ((F 0).re : ℂ)`.
+* `TauCeti.IsPositiveDefinite.map_zero_re_pos_of_ne_zero`: if `F 0 ≠ 0`, then
+  `0 < (F 0).re`.
 * `TauCeti.IsPositiveDefinite.conj_symm`: `conj (F (b + a⋆)) = F (a + b⋆)`.
 * `TauCeti.IsPositiveDefinite.normSq_le`: the Cauchy–Schwarz inequality
   `‖F (a + b⋆)‖² ≤ (F (a + a⋆)).re * (F (b + b⋆)).re`.
@@ -129,6 +132,24 @@ theorem map_zero_im (hF : IsPositiveDefinite F) : (F 0).im = 0 :=
 /-- The real part of the value of a positive-definite function at `0` is nonnegative. -/
 theorem map_zero_re_nonneg (hF : IsPositiveDefinite F) : 0 ≤ (F 0).re :=
   (Complex.nonneg_iff.mp hF.map_zero_nonneg).1
+
+/-- The value at the origin of a positive-definite function is equal to the real number
+`(F 0).re`, viewed as a complex number. -/
+theorem map_zero_eq_ofReal_re (hF : IsPositiveDefinite F) : F 0 = ((F 0).re : ℂ) := by
+  apply Complex.ext
+  · simp
+  · simpa using hF.map_zero_im
+
+/-- If a positive-definite function is nonzero at the origin, then the real part of that value is
+strictly positive. -/
+theorem map_zero_re_pos_of_ne_zero (hF : IsPositiveDefinite F) (h0 : F 0 ≠ 0) :
+    0 < (F 0).re := by
+  refine lt_of_le_of_ne hF.map_zero_re_nonneg ?_
+  intro hre
+  apply h0
+  apply Complex.ext
+  · exact hre.symm
+  · simpa using hF.map_zero_im
 
 /-- A positive-definite function is conjugate symmetric in the involution:
 `conj (F (b + star a)) = F (a + star b)`. -/

--- a/TauCeti/Analysis/PositiveDefinite/Normalize.lean
+++ b/TauCeti/Analysis/PositiveDefinite/Normalize.lean
@@ -25,8 +25,6 @@ normalized function rather than introducing a new bundled predicate.
 
 ## Main declarations
 
-* `TauCeti.IsPositiveDefinite.map_zero_re_pos_of_ne_zero`: a nonzero positive-definite function
-  has strictly positive real value at the origin.
 * `TauCeti.IsPositiveDefinite.normalize`: multiplying by `((F 0).re)⁻¹` preserves
   positive-definiteness.
 * `TauCeti.IsPositiveDefinite.normalize_apply_zero`: the normalized function has value `1` at
@@ -50,24 +48,6 @@ namespace TauCeti
 namespace IsPositiveDefinite
 
 variable {M : Type*} [AddMonoid M] [StarAddMonoid M] {F : M → ℂ}
-
-/-- The value at the origin of a positive-definite function is equal to the real number
-`(F 0).re`, viewed as a complex number. -/
-theorem map_zero_eq_ofReal_re (hF : IsPositiveDefinite F) : F 0 = ((F 0).re : ℂ) := by
-  apply Complex.ext
-  · simp
-  · simpa using hF.map_zero_im
-
-/-- If a positive-definite function is nonzero at the origin, then the real part of that value is
-strictly positive. -/
-theorem map_zero_re_pos_of_ne_zero (hF : IsPositiveDefinite F) (h0 : F 0 ≠ 0) :
-    0 < (F 0).re := by
-  refine lt_of_le_of_ne hF.map_zero_re_nonneg ?_
-  intro hre
-  apply h0
-  apply Complex.ext
-  · exact hre.symm
-  · simpa using hF.map_zero_im
 
 /-- The normalizing scalar `((F 0).re)⁻¹`, viewed as a complex number, is nonnegative. -/
 private theorem normalizeScalar_nonneg (hF : IsPositiveDefinite F) :

--- a/TauCeti/Analysis/PositiveDefinite/Normalize.lean
+++ b/TauCeti/Analysis/PositiveDefinite/Normalize.lean
@@ -1,0 +1,143 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+module
+
+public import TauCeti.Analysis.PositiveDefinite.Basic
+
+/-!
+# Normalizing positive-definite functions
+
+This file records the standard normalization step for positive-definite functions: if
+`F : M → ℂ` is positive definite and `F 0 ≠ 0`, then multiplying by the reciprocal of the
+nonnegative real number `(F 0).re` gives a positive-definite function whose value at the origin
+is `1`.
+
+This is part of the normalization API requested in Part C of the `OneParameterSemigroups`
+roadmap ("Positive-definite functions and Bochner's theorem"). Normalized positive-definite
+functions are the convenient form for characteristic functions and for the later Bochner and
+GNS/Kolmogorov constructions: after normalization, the general bound `‖F a‖ ≤ (F 0).re` becomes
+the familiar `‖F a‖ ≤ 1`.
+
+The file deliberately keeps the hypotheses unbundled. It proves lemmas about the explicit
+normalized function rather than introducing a new bundled predicate.
+
+## Main declarations
+
+* `TauCeti.IsPositiveDefinite.map_zero_re_pos_of_ne_zero`: a nonzero positive-definite function
+  has strictly positive real value at the origin.
+* `TauCeti.IsPositiveDefinite.normalize`: multiplying by `((F 0).re)⁻¹` preserves
+  positive-definiteness.
+* `TauCeti.IsPositiveDefinite.normalize_apply_zero`: the normalized function has value `1` at
+  the origin.
+* `TauCeti.IsPositiveDefinite.norm_normalize_apply_le_one_of_add_star_eq_zero` and
+  `TauCeti.IsPositiveDefinite.norm_normalize_apply_le_one_of_star_eq_neg`: normalized functions
+  are bounded by `1` on the usual group-like points.
+
+## References
+
+* C. Berg, J. P. R. Christensen, P. Ressel, *Harmonic Analysis on Semigroups* (GTM 100, 1984),
+  Chapter 3.
+-/
+
+public section
+
+open scoped ComplexOrder
+
+namespace TauCeti
+
+namespace IsPositiveDefinite
+
+variable {M : Type*} [AddMonoid M] [StarAddMonoid M] {F : M → ℂ}
+
+/-- The value at the origin of a positive-definite function is equal to the real number
+`(F 0).re`, viewed as a complex number. -/
+theorem map_zero_eq_ofReal_re (hF : IsPositiveDefinite F) : F 0 = ((F 0).re : ℂ) := by
+  apply Complex.ext
+  · simp
+  · simpa using hF.map_zero_im
+
+/-- If a positive-definite function is nonzero at the origin, then the real part of that value is
+strictly positive. -/
+theorem map_zero_re_pos_of_ne_zero (hF : IsPositiveDefinite F) (h0 : F 0 ≠ 0) :
+    0 < (F 0).re := by
+  refine lt_of_le_of_ne hF.map_zero_re_nonneg ?_
+  intro hre
+  apply h0
+  apply Complex.ext
+  · exact hre.symm
+  · simpa using hF.map_zero_im
+
+/-- The normalizing scalar `((F 0).re)⁻¹`, viewed as a complex number, is nonnegative. -/
+theorem normalizeScalar_nonneg (hF : IsPositiveDefinite F) :
+    0 ≤ (((F 0).re)⁻¹ : ℂ) := by
+  exact inv_nonneg.mpr ((RCLike.ofReal_nonneg (K := ℂ)).mpr hF.map_zero_re_nonneg)
+
+/-- Multiplying a positive-definite function by the reciprocal of its real value at the origin
+preserves positive-definiteness. If `F 0 = 0` this gives the zero scaling; the separate
+`normalize_apply_zero` lemma below records the useful nonzero case. -/
+theorem normalize (hF : IsPositiveDefinite F) :
+    IsPositiveDefinite (fun x => (((F 0).re)⁻¹ : ℂ) * F x) :=
+  hF.const_mul hF.normalizeScalar_nonneg
+
+/-- The normalized positive-definite function has value `1` at the origin. -/
+@[simp]
+theorem normalize_apply_zero (hF : IsPositiveDefinite F) (h0 : F 0 ≠ 0) :
+    (((F 0).re)⁻¹ : ℂ) * F 0 = 1 := by
+  have hpos := hF.map_zero_re_pos_of_ne_zero h0
+  rw [hF.map_zero_eq_ofReal_re]
+  norm_cast
+  exact inv_mul_cancel₀ hpos.ne'
+
+/-- The normalized positive-definite function has real value `1` at the origin. -/
+@[simp]
+theorem normalize_apply_zero_re (hF : IsPositiveDefinite F) (h0 : F 0 ≠ 0) :
+    ((((F 0).re)⁻¹ : ℂ) * F 0).re = 1 := by
+  rw [hF.normalize_apply_zero h0]
+  simp
+
+/-- The normalized positive-definite function has zero imaginary value at the origin. -/
+@[simp]
+theorem normalize_apply_zero_im (hF : IsPositiveDefinite F) (h0 : F 0 ≠ 0) :
+    ((((F 0).re)⁻¹ : ℂ) * F 0).im = 0 := by
+  rw [hF.normalize_apply_zero h0]
+  simp
+
+/-- At points satisfying `a + star a = 0`, the normalized positive-definite function is bounded
+by `1`. -/
+theorem norm_normalize_apply_le_one_of_add_star_eq_zero (hF : IsPositiveDefinite F)
+    (h0 : F 0 ≠ 0) (a : M) (ha : a + star a = 0) :
+    ‖(((F 0).re)⁻¹ : ℂ) * F a‖ ≤ 1 := by
+  have hpos := hF.map_zero_re_pos_of_ne_zero h0
+  have hbound := hF.norm_apply_le_map_zero_re_of_add_star_eq_zero a ha
+  have hnorm : ‖(((F 0).re)⁻¹ : ℂ)‖ = ((F 0).re)⁻¹ := by
+    rw [norm_inv, Complex.norm_of_nonneg hpos.le]
+  rw [norm_mul, hnorm]
+  have hscale := mul_le_mul_of_nonneg_left hbound (inv_nonneg.mpr hpos.le)
+  rw [inv_mul_cancel₀ hpos.ne'] at hscale
+  simpa [mul_comm] using hscale
+
+section Group
+
+variable {G : Type*} [AddGroup G] [StarAddMonoid G] {H : G → ℂ}
+
+/-- Under the negation involution, the normalized positive-definite function is bounded by `1` at
+every point. -/
+theorem norm_normalize_apply_le_one_of_star_eq_neg (hH : IsPositiveDefinite H)
+    (h0 : H 0 ≠ 0) (a : G) (hstar_a : star a = -a) :
+    ‖(((H 0).re)⁻¹ : ℂ) * H a‖ ≤ 1 :=
+  hH.norm_normalize_apply_le_one_of_add_star_eq_zero h0 a (by rw [hstar_a, add_neg_cancel])
+
+/-- If the involution is negation everywhere, the normalized positive-definite function is
+uniformly bounded by `1`. -/
+theorem norm_normalize_apply_le_one_of_forall_star_eq_neg (hH : IsPositiveDefinite H)
+    (h0 : H 0 ≠ 0) (hstar : ∀ a : G, star a = -a) (a : G) :
+    ‖(((H 0).re)⁻¹ : ℂ) * H a‖ ≤ 1 :=
+  hH.norm_normalize_apply_le_one_of_star_eq_neg h0 a (hstar a)
+
+end Group
+
+end IsPositiveDefinite
+
+end TauCeti

--- a/TauCeti/Analysis/PositiveDefinite/Normalize.lean
+++ b/TauCeti/Analysis/PositiveDefinite/Normalize.lean
@@ -70,7 +70,7 @@ theorem map_zero_re_pos_of_ne_zero (hF : IsPositiveDefinite F) (h0 : F 0 ≠ 0) 
   · simpa using hF.map_zero_im
 
 /-- The normalizing scalar `((F 0).re)⁻¹`, viewed as a complex number, is nonnegative. -/
-theorem normalizeScalar_nonneg (hF : IsPositiveDefinite F) :
+private theorem normalizeScalar_nonneg (hF : IsPositiveDefinite F) :
     0 ≤ (((F 0).re)⁻¹ : ℂ) := by
   exact inv_nonneg.mpr ((RCLike.ofReal_nonneg (K := ℂ)).mpr hF.map_zero_re_nonneg)
 
@@ -90,33 +90,21 @@ theorem normalize_apply_zero (hF : IsPositiveDefinite F) (h0 : F 0 ≠ 0) :
   norm_cast
   exact inv_mul_cancel₀ hpos.ne'
 
-/-- The normalized positive-definite function has real value `1` at the origin. -/
-@[simp]
-theorem normalize_apply_zero_re (hF : IsPositiveDefinite F) (h0 : F 0 ≠ 0) :
-    ((((F 0).re)⁻¹ : ℂ) * F 0).re = 1 := by
-  rw [hF.normalize_apply_zero h0]
-  simp
-
-/-- The normalized positive-definite function has zero imaginary value at the origin. -/
-@[simp]
-theorem normalize_apply_zero_im (hF : IsPositiveDefinite F) (h0 : F 0 ≠ 0) :
-    ((((F 0).re)⁻¹ : ℂ) * F 0).im = 0 := by
-  rw [hF.normalize_apply_zero h0]
-  simp
-
 /-- At points satisfying `a + star a = 0`, the normalized positive-definite function is bounded
-by `1`. -/
+by `1`. When `F 0 = 0` the normalizing scalar is `0`, so the bound holds trivially. -/
 theorem norm_normalize_apply_le_one_of_add_star_eq_zero (hF : IsPositiveDefinite F)
-    (h0 : F 0 ≠ 0) (a : M) (ha : a + star a = 0) :
+    (a : M) (ha : a + star a = 0) :
     ‖(((F 0).re)⁻¹ : ℂ) * F a‖ ≤ 1 := by
-  have hpos := hF.map_zero_re_pos_of_ne_zero h0
-  have hbound := hF.norm_apply_le_map_zero_re_of_add_star_eq_zero a ha
-  have hnorm : ‖(((F 0).re)⁻¹ : ℂ)‖ = ((F 0).re)⁻¹ := by
-    rw [norm_inv, Complex.norm_of_nonneg hpos.le]
-  rw [norm_mul, hnorm]
-  have hscale := mul_le_mul_of_nonneg_left hbound (inv_nonneg.mpr hpos.le)
-  rw [inv_mul_cancel₀ hpos.ne'] at hscale
-  simpa [mul_comm] using hscale
+  rcases hF.map_zero_re_nonneg.lt_or_eq with hpos | hre
+  · have hbound := hF.norm_apply_le_map_zero_re_of_add_star_eq_zero a ha
+    have hnorm : ‖(((F 0).re)⁻¹ : ℂ)‖ = ((F 0).re)⁻¹ := by
+      rw [norm_inv, Complex.norm_of_nonneg hpos.le]
+    rw [norm_mul, hnorm]
+    have hscale := mul_le_mul_of_nonneg_left hbound (inv_nonneg.mpr hpos.le)
+    rw [inv_mul_cancel₀ hpos.ne'] at hscale
+    simpa [mul_comm] using hscale
+  · rw [← hre]
+    simp
 
 section Group
 
@@ -125,16 +113,16 @@ variable {G : Type*} [AddGroup G] [StarAddMonoid G] {H : G → ℂ}
 /-- Under the negation involution, the normalized positive-definite function is bounded by `1` at
 every point. -/
 theorem norm_normalize_apply_le_one_of_star_eq_neg (hH : IsPositiveDefinite H)
-    (h0 : H 0 ≠ 0) (a : G) (hstar_a : star a = -a) :
+    (a : G) (hstar_a : star a = -a) :
     ‖(((H 0).re)⁻¹ : ℂ) * H a‖ ≤ 1 :=
-  hH.norm_normalize_apply_le_one_of_add_star_eq_zero h0 a (by rw [hstar_a, add_neg_cancel])
+  hH.norm_normalize_apply_le_one_of_add_star_eq_zero a (by rw [hstar_a, add_neg_cancel])
 
 /-- If the involution is negation everywhere, the normalized positive-definite function is
 uniformly bounded by `1`. -/
 theorem norm_normalize_apply_le_one_of_forall_star_eq_neg (hH : IsPositiveDefinite H)
-    (h0 : H 0 ≠ 0) (hstar : ∀ a : G, star a = -a) (a : G) :
+    (hstar : ∀ a : G, star a = -a) (a : G) :
     ‖(((H 0).re)⁻¹ : ℂ) * H a‖ ≤ 1 :=
-  hH.norm_normalize_apply_le_one_of_star_eq_neg h0 a (hstar a)
+  hH.norm_normalize_apply_le_one_of_star_eq_neg a (hstar a)
 
 end Group
 


### PR DESCRIPTION
This PR normalizes nonzero positive-definite functions. It adds the small API showing that a positive-definite function with `F 0 ≠ 0` has strictly positive real value at the origin, that scaling by `((F 0).re)⁻¹` preserves positive-definiteness, that the normalized function has value `1` at `0`, and that the usual positive-definite bound becomes `‖F a‖ ≤ 1` after normalization on points satisfying `a + star a = 0` (with the additive-group `star a = -a` corollaries).

This advances `TauCetiRoadmap/OneParameterSemigroups/README.md`, Part C, the `API to develop` item naming "normalization `F(0) = 1`" for positive-definite functions. I chose it as the lowest-hanging distinct OneParameterSemigroups target after checking open and recently merged PRs: the general `IsPositiveDefinite` predicate, the PD-function/PD-kernel bridge, pullbacks, and characteristic-function positive-definiteness have already landed, while the normalization step was still missing and is a direct prerequisite for the normalized characteristic-function, Bochner, and GNS/Kolmogorov API.

No Mathlib infrastructure is vendored. The proofs reuse Tau Ceti's existing `IsPositiveDefinite` facts (`map_zero_im`, `map_zero_re_nonneg`, `const_mul`, and `norm_apply_le_map_zero_re_of_add_star_eq_zero`) together with Mathlib's complex order and norm API (`RCLike.ofReal_nonneg`, `Complex.norm_of_nonneg`, and `norm_inv`).

Local verification: `lake exe cache get` completed with `No files to download` and `Already decompressed 8585 file(s)`; `lake build` completed with `Build completed successfully (4191 jobs).`; `lake exe axioms` completed with `axioms: audited 4635 TauCeti declaration(s); all within the allowlist [propext, Classical.choice, Quot.sound].`

<!--tauceti-target:v1 {"focus":"OneParameterSemigroups","id":"positive-definite-normalization"}-->

🤖 Prepared with Codex
