### PR TITLE
chore: upload lakeprof reports from the radar benchmark

### DIFF
--- a/scripts/bench/build/README.md
+++ b/scripts/bench/build/README.md
@@ -22,3 +22,9 @@ The following metrics are collected individually for each module:
 
 - `build/module/<name>//lines`
 - `build/module/<name>//instructions`
+
+When the benchmark runs under radar (signalled by the `IN_RADAR` environment
+variable, which radar's harness sets), the lakeprof report is uploaded to
+`https://speed.lean-lang.org/tauceti-out/<commit>/`. The upload is best effort:
+if it fails, the benchmark still succeeds. Local runs leave `IN_RADAR` unset and
+never upload.

--- a/scripts/bench/build/lakeprof_report_template.html
+++ b/scripts/bench/build/lakeprof_report_template.html
@@ -1,0 +1,74 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="UTF-8" />
+    <title>Lakeprof Report</title>
+  </head>
+  <body>
+    <h1>Lakeprof Report</h1>
+    <button type="button" id="btn_fetch">View build trace in Perfetto</button>
+    <pre><code>__LAKEPROF_REPORT__</code></pre>
+
+    <script type="text/javascript">
+      // https://perfetto.dev/docs/visualization/deep-linking-to-perfetto-ui
+      // https://gist.github.com/chromy/170c11ce30d9084957d7f3aa065e89f8
+
+      const BASE_URL = __BASE_URL__;
+      const ORIGIN = "https://ui.perfetto.dev";
+
+      const btnFetch = document.getElementById("btn_fetch");
+
+      async function fetchAndOpen(traceUrl) {
+        const resp = await fetch(traceUrl);
+        // Error checking is left as an exercise to the reader.
+        const blob = await resp.blob();
+        const arrayBuffer = await blob.arrayBuffer();
+        openTrace(arrayBuffer, traceUrl);
+      }
+
+      function openTrace(arrayBuffer, traceUrl) {
+        const win = window.open(ORIGIN);
+        if (!win) {
+          btnFetch.style.background = "#f3ca63";
+          btnFetch.onclick = () => openTrace(arrayBuffer);
+          btnFetch.innerText =
+            "Popups blocked, click here to open the trace file";
+          return;
+        }
+
+        const timer = setInterval(() => win.postMessage("PING", ORIGIN), 50);
+
+        const onMessageHandler = (evt) => {
+          if (evt.data !== "PONG") return;
+
+          // We got a PONG, the UI is ready.
+          window.clearInterval(timer);
+          window.removeEventListener("message", onMessageHandler);
+
+          const reopenUrl = new URL(location.href);
+          reopenUrl.hash = `#reopen=${traceUrl}`;
+          win.postMessage(
+            {
+              perfetto: {
+                buffer: arrayBuffer,
+                title: "Lake Build Trace",
+                url: reopenUrl.toString(),
+              },
+            },
+            ORIGIN
+          );
+        };
+
+        window.addEventListener("message", onMessageHandler);
+      }
+
+      // This is triggered when following the link from the Perfetto UI's sidebar.
+      if (location.hash.startsWith("#reopen=")) {
+        const traceUrl = location.hash.substr(8);
+        fetchAndOpen(traceUrl);
+      }
+
+      btnFetch.onclick = () => fetchAndOpen(`${BASE_URL}/lakeprof.trace_event`);
+    </script>
+  </body>
+</html>

--- a/scripts/bench/build/lakeprof_report_upload.py
+++ b/scripts/bench/build/lakeprof_report_upload.py
@@ -1,0 +1,44 @@
+#!/usr/bin/env python3
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+
+def run(*args: str) -> None:
+    subprocess.run(args, check=True)
+
+
+def run_stdout(*command: str, cwd: str | None = None) -> str:
+    result = subprocess.run(command, capture_output=True, encoding="utf-8", cwd=cwd)
+    if result.returncode != 0:
+        print(result.stdout, end="", file=sys.stdout)
+        print(result.stderr, end="", file=sys.stderr)
+        sys.exit(result.returncode)
+    return result.stdout
+
+
+def main() -> None:
+    script_file = Path(__file__)
+    template_file = script_file.parent / "lakeprof_report_template.html"
+
+    sha = run_stdout("git", "rev-parse", "@").strip()
+    base_url = f"https://speed.lean-lang.org/tauceti-out/{sha}"
+    report = run_stdout("lakeprof", "report", "-prc")
+    with open(template_file) as f:
+        template = f.read()
+
+    template = template.replace("__BASE_URL__", json.dumps(base_url))
+    template = template.replace("__LAKEPROF_REPORT__", report)
+
+    with open("index.html", "w") as f:
+        f.write(template)
+
+    run("curl", "-T", "index.html", f"{base_url}/index.html")
+    run("curl", "-T", "lakeprof.log", f"{base_url}/lakeprof.log")
+    run("curl", "-T", "lakeprof.trace_event", f"{base_url}/lakeprof.trace_event")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/bench/build/run
+++ b/scripts/bench/build/run
@@ -15,3 +15,11 @@ LAKE_OVERRIDE_LEAN=true LEAN=$(realpath "$BENCH/build/fake-root/bin/lean") \
 # Analyze lakeprof data
 lakeprof report -pj | jq -c '{metric: "build/lakeprof/longest build path//wall-clock", value: .[-1][2], unit: "s"}' >> measurements.jsonl
 lakeprof report -rj | jq -c '{metric: "build/lakeprof/longest rebuild path//wall-clock", value: .[-1][2], unit: "s"}' >> measurements.jsonl
+
+# Upload the lakeprof report when running under radar (radar's harness exports
+# IN_RADAR=1; local runs leave it unset, so this never fires off-radar). Best
+# effort: a failed upload must not fail the benchmark.
+if [ -n "${IN_RADAR:-}" ]; then
+  python3 "$BENCH/build/lakeprof_report_upload.py" \
+    || echo "lakeprof report upload failed; continuing"
+fi


### PR DESCRIPTION
This PR restores cslib's lakeprof-report upload to the benchmark suite, repointed at the `tauceti-out` path, so radar can surface the interactive per-commit build trace alongside the numeric metrics. The upload runs only under radar (guarded on the `IN_RADAR` environment variable that radar's harness exports, so local runs never upload) and is best effort: a failed upload prints a warning and the benchmark still succeeds.

The destination `https://speed.lean-lang.org/tauceti-out/<commit>/` still needs provisioning server-side; until it exists the `curl -T` PUTs are harmlessly redirected and the benchmark is unaffected. Verified locally end to end with `IN_RADAR=1`: the suite ran green (exit 0), the upload was attempted and failed gracefully, the report artifacts (`index.html`, `lakeprof.trace_event`) were produced, and all measurements were still emitted.

This lives under `scripts/`, so it is human-owned and merged by hand rather than auto-merged.

🤖 Prepared with Claude Code