### PR TITLE
feat: the fundamental group of the circle is ℤ

### DIFF
--- a/TauCeti/AlgebraicTopology/UniversalCover/AddCircle.lean
+++ b/TauCeti/AlgebraicTopology/UniversalCover/AddCircle.lean
@@ -100,9 +100,7 @@ theorem addRightZMultiples_injective :
   simpa using this
 
 /-- The projection `(↑) : 𝕜 → AddCircle p` has regular deck action: it is surjective and its
-deck transformation group acts transitively on every fibre. Transitivity is witnessed by
-translation: two points with the same image differ by an element of the period subgroup
-`zmultiples p`, and translating by that element is a deck transformation. -/
+deck transformation group acts transitively on every fibre. -/
 theorem isRegular_addCircleCoe : IsRegular ((↑) : 𝕜 → AddCircle p) := by
   rw [isRegular_iff_exists_apply_eq]
   refine ⟨QuotientAddGroup.mk_surjective, ?_⟩

--- a/TauCeti/AlgebraicTopology/UniversalCover/AddCircle.lean
+++ b/TauCeti/AlgebraicTopology/UniversalCover/AddCircle.lean
@@ -7,6 +7,7 @@ module
 public import Mathlib.Topology.Instances.AddCircle.Defs
 public import TauCeti.Algebra.Group.ZMultiples
 public import TauCeti.AlgebraicTopology.UniversalCover.Deck
+public import TauCeti.AlgebraicTopology.UniversalCover.Deck.Regular
 
 /-!
 # The deck transformation group of the quotient map `𝕜 → AddCircle p`
@@ -31,6 +32,8 @@ universal cover `ℝ → S¹` and the algebraic input to the universal-covers ro
 
 * `TauCeti.Deck.addRightZMultiples`: translation by an element of `zmultiples p` as a deck
   transformation of `(↑) : 𝕜 → AddCircle p`.
+* `TauCeti.Deck.isRegular_addCircleCoe`: the projection `(↑) : 𝕜 → AddCircle p` has regular
+  deck action.
 * `TauCeti.Deck.addCircleMulEquiv`: the deck group of `(↑) : 𝕜 → AddCircle p` is
   `Multiplicative (zmultiples p)`.
 * `TauCeti.Deck.addCircleMulEquivInt`: for a totally disconnected period subgroup and a
@@ -95,6 +98,19 @@ theorem addRightZMultiples_injective :
   intro _ _ h
   have := congrArg (fun φ : Deck ((↑) : 𝕜 → AddCircle p) => φ.1 0) h
   simpa using this
+
+/-- The projection `(↑) : 𝕜 → AddCircle p` has regular deck action: it is surjective and its
+deck transformation group acts transitively on every fibre. Transitivity is witnessed by
+translation: two points with the same image differ by an element of the period subgroup
+`zmultiples p`, and translating by that element is a deck transformation. -/
+theorem isRegular_addCircleCoe : IsRegular ((↑) : 𝕜 → AddCircle p) := by
+  rw [isRegular_iff_exists_apply_eq]
+  refine ⟨QuotientAddGroup.mk_surjective, ?_⟩
+  intro e e' he
+  have hmem : e' - e ∈ zmultiples p := by
+    have hsub : e - e' ∈ zmultiples p := (QuotientAddGroup.eq_iff_sub_mem ..).1 he
+    simpa using neg_mem hsub
+  exact ⟨addRightZMultiples ⟨e' - e, hmem⟩, by simp [addRightZMultiples_apply]⟩
 
 /-- On a preconnected domain with totally disconnected period subgroup, a deck transformation of
 `(↑) : 𝕜 → AddCircle p` is right translation by `φ 0`. -/

--- a/TauCeti/AlgebraicTopology/UniversalCover/CircleFundamentalGroup.lean
+++ b/TauCeti/AlgebraicTopology/UniversalCover/CircleFundamentalGroup.lean
@@ -64,7 +64,7 @@ open AddSubgroup
 namespace AddCircle
 
 variable {𝕜 : Type*} [AddCommGroup 𝕜] [TopologicalSpace 𝕜] [IsTopologicalAddGroup 𝕜]
-  {p : 𝕜} [SimplyConnectedSpace 𝕜] [PreconnectedSpace 𝕜]
+  {p : 𝕜} [SimplyConnectedSpace 𝕜]
   [TotallyDisconnectedSpace (zmultiples p)]
 
 /-- For a covering projection `(↑) : 𝕜 → AddCircle p` from a simply connected preconnected
@@ -79,12 +79,14 @@ noncomputable def fundamentalGroupMulEquivZMultiples
       (MulOpposite.opMulEquiv (M := Multiplicative (zmultiples p))).symm)
 
 omit [SimplyConnectedSpace 𝕜] in
+variable [PreconnectedSpace 𝕜] in
 private lemma addCircleMulEquiv_symm_addRightZMultiples (n : Multiplicative (zmultiples p)) :
     Deck.addCircleMulEquiv.symm (Deck.addRightZMultiples n.toAdd) = n := by
   rw [← Deck.addCircleMulEquiv_apply n]
   exact MulEquiv.symm_apply_apply Deck.addCircleMulEquiv n
 
 omit [SimplyConnectedSpace 𝕜] in
+variable [PreconnectedSpace 𝕜] in
 private lemma fundamentalGroupMulEquivZMultiples_toPeriod_symm_apply
     (n : Multiplicative (zmultiples p)) :
     (((MulEquiv.op Deck.addCircleMulEquiv.symm).trans

--- a/TauCeti/AlgebraicTopology/UniversalCover/CircleFundamentalGroup.lean
+++ b/TauCeti/AlgebraicTopology/UniversalCover/CircleFundamentalGroup.lean
@@ -1,0 +1,120 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+module
+
+public import Mathlib.Topology.Covering.AddCircle
+public import Mathlib.Topology.Instances.AddCircle.Real
+public import Mathlib.Analysis.Convex.Contractible
+public import Mathlib.AlgebraicTopology.FundamentalGroupoid.SimplyConnected
+public import Mathlib.Algebra.Group.Equiv.Opposite
+public import TauCeti.AlgebraicTopology.UniversalCover.AddCircle
+public import TauCeti.AlgebraicTopology.UniversalCover.Deck.FundamentalGroup
+public import TauCeti.AlgebraicTopology.UniversalCover.Deck.Regular
+
+/-!
+# The fundamental group of the circle is `ℤ`
+
+The covering `(↑) : ℝ → AddCircle p` is the universal cover of the circle: its total space
+`ℝ` is contractible, hence simply connected, and the cover is regular with deck group
+`Multiplicative ℤ` (the translations by the period subgroup, computed in
+`TauCeti.Deck.addCircleMulEquivInt`). The regular-cover comparison
+`TauCeti.Deck.IsRegular.fundamentalGroupEquiv` then identifies the fundamental group of the
+base with the opposite of the deck group, and since `Multiplicative ℤ` is commutative the
+opposite drops out, giving
+
+  `FundamentalGroup (AddCircle p) x ≃* Multiplicative ℤ`
+
+for any nonzero real period `p`. Specialising to the unit circle `UnitAddCircle = ℝ ⧸ ℤ`
+yields the classical `π₁(S¹) ≅ ℤ`.
+
+The regularity input is elementary and holds for an arbitrary topological additive group:
+two points of `𝕜` with the same image under `(↑) : 𝕜 → AddCircle p` differ by an element of
+the period subgroup `zmultiples p`, and translation by that element is a deck
+transformation, so `Deck ((↑) : 𝕜 → AddCircle p)` acts transitively on every fibre.
+
+## Main declarations
+
+* `TauCeti.Deck.isRegular_addCircleCoe`: the quotient cover `(↑) : 𝕜 → AddCircle p` has
+  regular deck action.
+* `TauCeti.AddCircle.fundamentalGroupMulEquiv`: for a nonzero real period, the fundamental
+  group of `AddCircle p` (based at any point with a chosen lift) is `Multiplicative ℤ`.
+* `TauCeti.AddCircle.zeroFundamentalGroupMulEquiv`: the basepoint-`0` specialisation, using
+  the lift `0 : ℝ`.
+* `TauCeti.UnitAddCircle.fundamentalGroupMulEquiv`: `π₁(S¹) ≅ ℤ` for the unit circle.
+
+## References
+
+This advances the Tau Ceti universal-covers roadmap, Stage 4 target 12 (`π₁(S¹) ≅ ℤ`,
+"built from `AddCircle.isCoveringMap_coe` (`ℝ → S¹`) and deck transformations";
+`TauCetiRoadmap/UniversalCovers/README.md`). It consumes Mathlib's `AddCircle` covering map
+(`AddCircle.isCoveringMap_coe`, Junyan Xu) and the contractibility of a real topological
+vector space, together with the Tau Ceti deck-transformation theory of Stages 0.4 and 1.
+-/
+
+public section
+
+namespace TauCeti
+
+open AddSubgroup
+
+namespace Deck
+
+variable {𝕜 : Type*} [AddCommGroup 𝕜] [TopologicalSpace 𝕜] [IsTopologicalAddGroup 𝕜] {p : 𝕜}
+
+/-- The quotient cover `(↑) : 𝕜 → AddCircle p` has regular deck action: it is surjective and
+its deck transformation group acts transitively on every fibre. Transitivity is witnessed by
+translation: two points with the same image differ by an element of the period subgroup
+`zmultiples p`, and translating by that element is a deck transformation. -/
+theorem isRegular_addCircleCoe : IsRegular ((↑) : 𝕜 → AddCircle p) := by
+  rw [isRegular_iff_exists_apply_eq]
+  refine ⟨QuotientAddGroup.mk_surjective, ?_⟩
+  intro e e' he
+  have hmem : e' - e ∈ zmultiples p := by
+    have hsub : e - e' ∈ zmultiples p := (QuotientAddGroup.eq_iff_sub_mem ..).1 he
+    simpa using neg_mem hsub
+  exact ⟨addRightZMultiples ⟨e' - e, hmem⟩, by simp [addRightZMultiples_apply]⟩
+
+end Deck
+
+namespace AddCircle
+
+variable (p : ℝ)
+
+/-- For a nonzero real period `p`, the fundamental group of the circle `AddCircle p`, based at
+any point `x` with a chosen lift `e : (↑) ⁻¹' {x}`, is infinite cyclic:
+`FundamentalGroup (AddCircle p) x ≃* Multiplicative ℤ`.
+
+The cover `(↑) : ℝ → AddCircle p` is regular (`TauCeti.Deck.isRegular_addCircleCoe`) with
+contractible (hence simply connected) total space `ℝ`, so the regular-cover comparison
+`TauCeti.Deck.IsRegular.fundamentalGroupEquiv` identifies `π₁` with the opposite deck group;
+the deck group is `Multiplicative ℤ` by `TauCeti.Deck.addCircleMulEquivInt`, and the opposite
+of a commutative group is itself. -/
+noncomputable def fundamentalGroupMulEquiv (hp : p ≠ 0) {x : AddCircle p}
+    (e : ((↑) : ℝ → AddCircle p) ⁻¹' {x}) :
+    FundamentalGroup (AddCircle p) x ≃* Multiplicative ℤ :=
+  (Deck.isRegular_addCircleCoe.fundamentalGroupEquiv (AddCircle.isCoveringMap_coe p) e).trans
+    ((MulEquiv.op
+      (Deck.addCircleMulEquivInt (not_isOfFinAddOrder_of_isAddTorsionFree hp)).symm).trans
+        (MulOpposite.opMulEquiv (M := Multiplicative ℤ)).symm)
+
+/-- The fundamental group of the circle `AddCircle p` based at `0`, with the lift `0 : ℝ`, is
+`Multiplicative ℤ`. -/
+noncomputable def zeroFundamentalGroupMulEquiv (hp : p ≠ 0) :
+    FundamentalGroup (AddCircle p) 0 ≃* Multiplicative ℤ :=
+  fundamentalGroupMulEquiv p hp ⟨0, by simp⟩
+
+end AddCircle
+
+namespace UnitAddCircle
+
+/-- The fundamental group of the unit circle `S¹ = ℝ ⧸ ℤ` is `ℤ`:
+`FundamentalGroup UnitAddCircle 0 ≃* Multiplicative ℤ`. This is the classical `π₁(S¹) ≅ ℤ`. -/
+noncomputable def fundamentalGroupMulEquiv :
+    FundamentalGroup UnitAddCircle 0 ≃* Multiplicative ℤ :=
+  AddCircle.zeroFundamentalGroupMulEquiv 1 one_ne_zero
+
+end UnitAddCircle
+
+end TauCeti

--- a/TauCeti/AlgebraicTopology/UniversalCover/CircleFundamentalGroup.lean
+++ b/TauCeti/AlgebraicTopology/UniversalCover/CircleFundamentalGroup.lean
@@ -11,7 +11,6 @@ public import Mathlib.AlgebraicTopology.FundamentalGroupoid.SimplyConnected
 public import Mathlib.Algebra.Group.Equiv.Opposite
 public import TauCeti.AlgebraicTopology.UniversalCover.AddCircle
 public import TauCeti.AlgebraicTopology.UniversalCover.Deck.FundamentalGroup
-public import TauCeti.AlgebraicTopology.UniversalCover.Deck.Regular
 
 /-!
 # The fundamental group of the circle is `ℤ`
@@ -36,11 +35,13 @@ transformation, so `Deck ((↑) : 𝕜 → AddCircle p)` acts transitively on ev
 
 ## Main declarations
 
-* `TauCeti.Deck.isRegular_addCircleCoe`: the quotient cover `(↑) : 𝕜 → AddCircle p` has
+* `TauCeti.Deck.isRegular_addCircleCoe`: the projection `(↑) : 𝕜 → AddCircle p` has
   regular deck action.
+* `TauCeti.AddCircle.fundamentalGroupMulEquivOfAddCircle`: the generic statement for a
+  simply connected additive quotient projection with cyclic deck group.
 * `TauCeti.AddCircle.fundamentalGroupMulEquiv`: for a nonzero real period, the fundamental
   group of `AddCircle p` (based at any point with a chosen lift) is `Multiplicative ℤ`.
-* `TauCeti.AddCircle.zeroFundamentalGroupMulEquiv`: the basepoint-`0` specialisation, using
+* `TauCeti.AddCircle.fundamentalGroupMulEquiv_zero`: the basepoint-`0` specialisation, using
   the lift `0 : ℝ`.
 * `TauCeti.UnitAddCircle.fundamentalGroupMulEquiv`: `π₁(S¹) ≅ ℤ` for the unit circle.
 
@@ -59,28 +60,89 @@ namespace TauCeti
 
 open AddSubgroup
 
-namespace Deck
-
-variable {𝕜 : Type*} [AddCommGroup 𝕜] [TopologicalSpace 𝕜] [IsTopologicalAddGroup 𝕜] {p : 𝕜}
-
-/-- The quotient cover `(↑) : 𝕜 → AddCircle p` has regular deck action: it is surjective and
-its deck transformation group acts transitively on every fibre. Transitivity is witnessed by
-translation: two points with the same image differ by an element of the period subgroup
-`zmultiples p`, and translating by that element is a deck transformation. -/
-theorem isRegular_addCircleCoe : IsRegular ((↑) : 𝕜 → AddCircle p) := by
-  rw [isRegular_iff_exists_apply_eq]
-  refine ⟨QuotientAddGroup.mk_surjective, ?_⟩
-  intro e e' he
-  have hmem : e' - e ∈ zmultiples p := by
-    have hsub : e - e' ∈ zmultiples p := (QuotientAddGroup.eq_iff_sub_mem ..).1 he
-    simpa using neg_mem hsub
-  exact ⟨addRightZMultiples ⟨e' - e, hmem⟩, by simp [addRightZMultiples_apply]⟩
-
-end Deck
-
 namespace AddCircle
 
+variable {𝕜 : Type*} [AddCommGroup 𝕜] [TopologicalSpace 𝕜] [IsTopologicalAddGroup 𝕜]
+  {p : 𝕜} [SimplyConnectedSpace 𝕜] [PreconnectedSpace 𝕜]
+  [TotallyDisconnectedSpace (zmultiples p)]
+
+/-- For an additive quotient projection `(↑) : 𝕜 → AddCircle p` whose total space is simply
+connected and whose period subgroup is infinite cyclic, the fundamental group of `AddCircle p`,
+based at any point `x` with a chosen lift `e : (↑) ⁻¹' {x}`, is `Multiplicative ℤ`.
+
+The proof uses the regular deck action of the quotient projection, the supplied covering-map
+hypothesis, and the generic computation of the deck group of an AddCircle quotient. -/
+noncomputable def fundamentalGroupMulEquivOfAddCircle
+    (hcov : IsCoveringMap ((↑) : 𝕜 → AddCircle p)) (hp : ¬ IsOfFinAddOrder p)
+    {x : AddCircle p} (e : ((↑) : 𝕜 → AddCircle p) ⁻¹' {x}) :
+    FundamentalGroup (AddCircle p) x ≃* Multiplicative ℤ :=
+  (Deck.isRegular_addCircleCoe.fundamentalGroupEquiv hcov e).trans
+    ((MulEquiv.op (Deck.addCircleMulEquivInt hp).symm).trans
+      (MulOpposite.opMulEquiv (M := Multiplicative ℤ)).symm)
+
+/-- Characterization of the integer assigned by
+`fundamentalGroupMulEquivOfAddCircle`: a loop class maps to `n` exactly when its monodromy
+translate of the chosen lift differs by `n • p`. -/
+lemma fundamentalGroupMulEquivOfAddCircle_apply_eq_iff
+    (hcov : IsCoveringMap ((↑) : 𝕜 → AddCircle p)) (hp : ¬ IsOfFinAddOrder p)
+    {x : AddCircle p} (e : ((↑) : 𝕜 → AddCircle p) ⁻¹' {x})
+    (γ : FundamentalGroup (AddCircle p) x) (n : Multiplicative ℤ) :
+    fundamentalGroupMulEquivOfAddCircle hcov hp e γ = n ↔
+      (hcov.monodromy γ e : 𝕜) = (e : 𝕜) + n.toAdd • p := by
+  let F := Deck.isRegular_addCircleCoe.fundamentalGroupEquiv hcov e
+  let T :=
+    (MulEquiv.op (Deck.addCircleMulEquivInt hp).symm).trans
+      (MulOpposite.opMulEquiv (M := Multiplicative ℤ)).symm
+  change T (F γ) = n ↔ (hcov.monodromy γ e : 𝕜) = (e : 𝕜) + n.toAdd • p
+  constructor
+  · intro h
+    have hf : F γ = MulOpposite.op (Deck.addCircleMulEquivInt hp n) := by
+      have h' := congrArg T.symm h
+      simpa [T] using h'
+    have hs :=
+      (Deck.isRegular_addCircleCoe.fundamentalGroupEquiv_apply_eq_iff hcov e γ
+        (MulOpposite.op (Deck.addCircleMulEquivInt hp n))).1 hf
+    simpa [Deck.addCircleMulEquivInt_apply] using hs.symm
+  · intro hm
+    have hs : (MulOpposite.op (Deck.addCircleMulEquivInt hp n)).unop • (e : 𝕜) =
+        (hcov.monodromy γ e : 𝕜) := by
+      simpa [Deck.addCircleMulEquivInt_apply] using hm.symm
+    have hf : F γ = MulOpposite.op (Deck.addCircleMulEquivInt hp n) :=
+      (Deck.isRegular_addCircleCoe.fundamentalGroupEquiv_apply_eq_iff hcov e γ
+        (MulOpposite.op (Deck.addCircleMulEquivInt hp n))).2 hs
+    change T (F γ) = n
+    rw [hf]
+    simp [T]
+
+/-- The inverse equivalence sends `n` to the loop class whose monodromy translates the chosen
+lift by `n • p`. -/
+@[simp]
+lemma fundamentalGroupMulEquivOfAddCircle_symm_monodromy
+    (hcov : IsCoveringMap ((↑) : 𝕜 → AddCircle p)) (hp : ¬ IsOfFinAddOrder p)
+    {x : AddCircle p} (e : ((↑) : 𝕜 → AddCircle p) ⁻¹' {x}) (n : Multiplicative ℤ) :
+    (hcov.monodromy ((fundamentalGroupMulEquivOfAddCircle hcov hp e).symm n) e : 𝕜) =
+      (e : 𝕜) + n.toAdd • p := by
+  exact (fundamentalGroupMulEquivOfAddCircle_apply_eq_iff hcov hp e
+    ((fundamentalGroupMulEquivOfAddCircle hcov hp e).symm n) n).1
+      (MulEquiv.apply_symm_apply _ _)
+
+/-- A loop class maps to `1` under `fundamentalGroupMulEquivOfAddCircle` exactly when its
+monodromy fixes the chosen lift. -/
+@[simp]
+lemma fundamentalGroupMulEquivOfAddCircle_eq_one_iff
+    (hcov : IsCoveringMap ((↑) : 𝕜 → AddCircle p)) (hp : ¬ IsOfFinAddOrder p)
+    {x : AddCircle p} (e : ((↑) : 𝕜 → AddCircle p) ⁻¹' {x})
+    (γ : FundamentalGroup (AddCircle p) x) :
+    fundamentalGroupMulEquivOfAddCircle hcov hp e γ = 1 ↔ hcov.monodromy γ e = e := by
+  rw [fundamentalGroupMulEquivOfAddCircle_apply_eq_iff]
+  simpa using (Iff.symm Subtype.ext_iff :
+    ((hcov.monodromy γ e : 𝕜) = (e : 𝕜) ↔ hcov.monodromy γ e = e))
+
 variable (p : ℝ)
+
+/-- The standard lift `0 : ℝ` of the basepoint `0 : AddCircle p`. -/
+def zeroLift : ((↑) : ℝ → AddCircle p) ⁻¹' {(0 : AddCircle p)} :=
+  ⟨0, by simp⟩
 
 /-- For a nonzero real period `p`, the fundamental group of the circle `AddCircle p`, based at
 any point `x` with a chosen lift `e : (↑) ⁻¹' {x}`, is infinite cyclic:
@@ -94,16 +156,69 @@ of a commutative group is itself. -/
 noncomputable def fundamentalGroupMulEquiv (hp : p ≠ 0) {x : AddCircle p}
     (e : ((↑) : ℝ → AddCircle p) ⁻¹' {x}) :
     FundamentalGroup (AddCircle p) x ≃* Multiplicative ℤ :=
-  (Deck.isRegular_addCircleCoe.fundamentalGroupEquiv (AddCircle.isCoveringMap_coe p) e).trans
-    ((MulEquiv.op
-      (Deck.addCircleMulEquivInt (not_isOfFinAddOrder_of_isAddTorsionFree hp)).symm).trans
-        (MulOpposite.opMulEquiv (M := Multiplicative ℤ)).symm)
+  fundamentalGroupMulEquivOfAddCircle (AddCircle.isCoveringMap_coe p)
+    (not_isOfFinAddOrder_of_isAddTorsionFree hp) e
+
+/-- Characterization of the integer assigned by `fundamentalGroupMulEquiv`: a loop class maps
+to `n` exactly when its monodromy translate of the chosen lift differs by `n • p`. -/
+lemma fundamentalGroupMulEquiv_apply_eq_iff (hp : p ≠ 0) {x : AddCircle p}
+    (e : ((↑) : ℝ → AddCircle p) ⁻¹' {x}) (γ : FundamentalGroup (AddCircle p) x)
+    (n : Multiplicative ℤ) :
+    fundamentalGroupMulEquiv p hp e γ = n ↔
+      ((AddCircle.isCoveringMap_coe p).monodromy γ e : ℝ) = (e : ℝ) + n.toAdd • p :=
+  fundamentalGroupMulEquivOfAddCircle_apply_eq_iff (AddCircle.isCoveringMap_coe p)
+    (not_isOfFinAddOrder_of_isAddTorsionFree hp) e γ n
+
+/-- The inverse equivalence sends `n` to the loop class whose monodromy translates the chosen
+lift by `n • p`. -/
+@[simp]
+lemma fundamentalGroupMulEquiv_symm_monodromy (hp : p ≠ 0) {x : AddCircle p}
+    (e : ((↑) : ℝ → AddCircle p) ⁻¹' {x}) (n : Multiplicative ℤ) :
+    ((AddCircle.isCoveringMap_coe p).monodromy ((fundamentalGroupMulEquiv p hp e).symm n) e :
+      ℝ) = (e : ℝ) + n.toAdd • p :=
+  fundamentalGroupMulEquivOfAddCircle_symm_monodromy (AddCircle.isCoveringMap_coe p)
+    (not_isOfFinAddOrder_of_isAddTorsionFree hp) e n
+
+/-- A loop class maps to `1` under `fundamentalGroupMulEquiv` exactly when its monodromy fixes
+the chosen lift. -/
+@[simp]
+lemma fundamentalGroupMulEquiv_eq_one_iff (hp : p ≠ 0) {x : AddCircle p}
+    (e : ((↑) : ℝ → AddCircle p) ⁻¹' {x}) (γ : FundamentalGroup (AddCircle p) x) :
+    fundamentalGroupMulEquiv p hp e γ = 1 ↔ (AddCircle.isCoveringMap_coe p).monodromy γ e = e :=
+  fundamentalGroupMulEquivOfAddCircle_eq_one_iff (AddCircle.isCoveringMap_coe p)
+    (not_isOfFinAddOrder_of_isAddTorsionFree hp) e γ
 
 /-- The fundamental group of the circle `AddCircle p` based at `0`, with the lift `0 : ℝ`, is
 `Multiplicative ℤ`. -/
-noncomputable def zeroFundamentalGroupMulEquiv (hp : p ≠ 0) :
+noncomputable def fundamentalGroupMulEquiv_zero (hp : p ≠ 0) :
     FundamentalGroup (AddCircle p) 0 ≃* Multiplicative ℤ :=
-  fundamentalGroupMulEquiv p hp ⟨0, by simp⟩
+  fundamentalGroupMulEquiv p hp (zeroLift p)
+
+/-- Characterization of the integer assigned by the basepoint-`0` specialization. -/
+lemma fundamentalGroupMulEquiv_zero_apply_eq_iff (hp : p ≠ 0)
+    (γ : FundamentalGroup (AddCircle p) 0) (n : Multiplicative ℤ) :
+    fundamentalGroupMulEquiv_zero p hp γ = n ↔
+      ((AddCircle.isCoveringMap_coe p).monodromy γ (zeroLift p) : ℝ) = n.toAdd • p := by
+  rw [fundamentalGroupMulEquiv_zero]
+  simpa [zeroLift] using fundamentalGroupMulEquiv_apply_eq_iff p hp (zeroLift p) γ n
+
+/-- The inverse of the basepoint-`0` specialization has monodromy translation `n • p`. -/
+@[simp]
+lemma fundamentalGroupMulEquiv_zero_symm_monodromy (hp : p ≠ 0) (n : Multiplicative ℤ) :
+    ((AddCircle.isCoveringMap_coe p).monodromy ((fundamentalGroupMulEquiv_zero p hp).symm n)
+      (zeroLift p) : ℝ) = n.toAdd • p := by
+  rw [fundamentalGroupMulEquiv_zero]
+  simp [zeroLift]
+
+/-- A loop class maps to `1` under the basepoint-`0` specialization exactly when its monodromy
+fixes the zero lift. -/
+@[simp]
+lemma fundamentalGroupMulEquiv_zero_eq_one_iff (hp : p ≠ 0)
+    (γ : FundamentalGroup (AddCircle p) 0) :
+    fundamentalGroupMulEquiv_zero p hp γ = 1 ↔
+      (AddCircle.isCoveringMap_coe p).monodromy γ (zeroLift p) = zeroLift p := by
+  rw [fundamentalGroupMulEquiv_zero]
+  exact fundamentalGroupMulEquiv_eq_one_iff p hp (zeroLift p) γ
 
 end AddCircle
 
@@ -113,7 +228,32 @@ namespace UnitAddCircle
 `FundamentalGroup UnitAddCircle 0 ≃* Multiplicative ℤ`. This is the classical `π₁(S¹) ≅ ℤ`. -/
 noncomputable def fundamentalGroupMulEquiv :
     FundamentalGroup UnitAddCircle 0 ≃* Multiplicative ℤ :=
-  AddCircle.zeroFundamentalGroupMulEquiv 1 one_ne_zero
+  AddCircle.fundamentalGroupMulEquiv_zero 1 one_ne_zero
+
+/-- Characterization of the integer assigned by the unit-circle equivalence. -/
+lemma fundamentalGroupMulEquiv_apply_eq_iff (γ : FundamentalGroup UnitAddCircle 0)
+    (n : Multiplicative ℤ) :
+    fundamentalGroupMulEquiv γ = n ↔
+      ((AddCircle.isCoveringMap_coe 1).monodromy γ (AddCircle.zeroLift 1) : ℝ) = n.toAdd := by
+  simpa [fundamentalGroupMulEquiv] using
+    AddCircle.fundamentalGroupMulEquiv_zero_apply_eq_iff 1 one_ne_zero γ n
+
+/-- The inverse of the unit-circle equivalence has monodromy translation by `n`. -/
+@[simp]
+lemma fundamentalGroupMulEquiv_symm_monodromy (n : Multiplicative ℤ) :
+    ((AddCircle.isCoveringMap_coe 1).monodromy (fundamentalGroupMulEquiv.symm n)
+      (AddCircle.zeroLift 1) : ℝ) = n.toAdd := by
+  simp [fundamentalGroupMulEquiv,
+    AddCircle.fundamentalGroupMulEquiv_zero_symm_monodromy 1 one_ne_zero n]
+
+/-- A unit-circle loop class maps to `1` exactly when its monodromy fixes the zero lift. -/
+@[simp]
+lemma fundamentalGroupMulEquiv_eq_one_iff (γ : FundamentalGroup UnitAddCircle 0) :
+    fundamentalGroupMulEquiv γ = 1 ↔
+      (AddCircle.isCoveringMap_coe 1).monodromy γ (AddCircle.zeroLift 1) =
+        AddCircle.zeroLift 1 := by
+  simpa [fundamentalGroupMulEquiv] using
+    AddCircle.fundamentalGroupMulEquiv_zero_eq_one_iff 1 one_ne_zero γ
 
 end UnitAddCircle
 

--- a/TauCeti/AlgebraicTopology/UniversalCover/CircleFundamentalGroup.lean
+++ b/TauCeti/AlgebraicTopology/UniversalCover/CircleFundamentalGroup.lean
@@ -35,11 +35,9 @@ transformation, so `Deck ((↑) : 𝕜 → AddCircle p)` acts transitively on ev
 
 ## Main declarations
 
-* `TauCeti.Deck.isRegular_addCircleCoe`: the projection `(↑) : 𝕜 → AddCircle p` has
-  regular deck action.
 * `TauCeti.AddCircle.fundamentalGroupMulEquivZMultiples`: for a covering projection from a
   simply connected additive group, the fundamental group of `AddCircle p` is the period subgroup.
-* `TauCeti.AddCircle.fundamentalGroupMulEquivOfAddCircle`: for a covering projection from a
+* `TauCeti.AddCircle.fundamentalGroupMulEquivInt`: for a covering projection from a
   simply connected additive group with non-torsion period, the fundamental group of
   `AddCircle p` is `Multiplicative ℤ`.
 * `TauCeti.AddCircle.fundamentalGroupMulEquiv`: for a nonzero real period, the fundamental
@@ -156,21 +154,21 @@ lemma fundamentalGroupMulEquivZMultiples_eq_one_iff
 topological additive commutative group with totally disconnected non-torsion period subgroup,
 the fundamental group of `AddCircle p` is infinite cyclic:
 `FundamentalGroup (AddCircle p) x ≃* Multiplicative ℤ`. -/
-noncomputable def fundamentalGroupMulEquivOfAddCircle
+noncomputable def fundamentalGroupMulEquivInt
     (hcov : IsCoveringMap ((↑) : 𝕜 → AddCircle p)) (hp : ¬ IsOfFinAddOrder p)
     {x : AddCircle p} (e : ((↑) : 𝕜 → AddCircle p) ⁻¹' {x}) :
     FundamentalGroup (AddCircle p) x ≃* Multiplicative ℤ :=
   (fundamentalGroupMulEquivZMultiples hcov e).trans (intEquivZMultiples hp).toMultiplicative.symm
 
-/-- Characterization of the integer assigned by `fundamentalGroupMulEquivOfAddCircle`: a loop
+/-- Characterization of the integer assigned by `fundamentalGroupMulEquivInt`: a loop
 class maps to `n` exactly when its monodromy translate of the chosen lift differs by `n • p`. -/
-lemma fundamentalGroupMulEquivOfAddCircle_apply_eq_iff
+lemma fundamentalGroupMulEquivInt_apply_eq_iff
     (hcov : IsCoveringMap ((↑) : 𝕜 → AddCircle p)) (hp : ¬ IsOfFinAddOrder p)
     {x : AddCircle p} (e : ((↑) : 𝕜 → AddCircle p) ⁻¹' {x})
     (γ : FundamentalGroup (AddCircle p) x) (n : Multiplicative ℤ) :
-    fundamentalGroupMulEquivOfAddCircle hcov hp e γ = n ↔
+    fundamentalGroupMulEquivInt hcov hp e γ = n ↔
       (hcov.monodromy γ e : 𝕜) = (e : 𝕜) + n.toAdd • p := by
-  dsimp [fundamentalGroupMulEquivOfAddCircle]
+  dsimp [fundamentalGroupMulEquivInt]
   rw [MulEquiv.symm_apply_eq]
   simpa using fundamentalGroupMulEquivZMultiples_apply_eq_iff hcov e γ
     ((intEquivZMultiples hp).toMultiplicative n)
@@ -178,24 +176,24 @@ lemma fundamentalGroupMulEquivOfAddCircle_apply_eq_iff
 /-- The inverse generic integer equivalence sends `n` to the loop class whose monodromy
 translates the chosen lift by `n • p`. -/
 @[simp]
-lemma fundamentalGroupMulEquivOfAddCircle_symm_monodromy
+lemma fundamentalGroupMulEquivInt_symm_monodromy
     (hcov : IsCoveringMap ((↑) : 𝕜 → AddCircle p)) (hp : ¬ IsOfFinAddOrder p)
     {x : AddCircle p} (e : ((↑) : 𝕜 → AddCircle p) ⁻¹' {x}) (n : Multiplicative ℤ) :
-    (hcov.monodromy ((fundamentalGroupMulEquivOfAddCircle hcov hp e).symm n) e : 𝕜) =
+    (hcov.monodromy ((fundamentalGroupMulEquivInt hcov hp e).symm n) e : 𝕜) =
       (e : 𝕜) + n.toAdd • p := by
-  exact (fundamentalGroupMulEquivOfAddCircle_apply_eq_iff hcov hp e
-    ((fundamentalGroupMulEquivOfAddCircle hcov hp e).symm n) n).1
+  exact (fundamentalGroupMulEquivInt_apply_eq_iff hcov hp e
+    ((fundamentalGroupMulEquivInt hcov hp e).symm n) n).1
       (MulEquiv.apply_symm_apply _ _)
 
 /-- A loop class maps to `1` under the generic integer equivalence exactly when its monodromy
 fixes the chosen lift. -/
 @[simp]
-lemma fundamentalGroupMulEquivOfAddCircle_eq_one_iff
+lemma fundamentalGroupMulEquivInt_eq_one_iff
     (hcov : IsCoveringMap ((↑) : 𝕜 → AddCircle p)) (hp : ¬ IsOfFinAddOrder p)
     {x : AddCircle p} (e : ((↑) : 𝕜 → AddCircle p) ⁻¹' {x})
     (γ : FundamentalGroup (AddCircle p) x) :
-    fundamentalGroupMulEquivOfAddCircle hcov hp e γ = 1 ↔ hcov.monodromy γ e = e := by
-  rw [fundamentalGroupMulEquivOfAddCircle_apply_eq_iff]
+    fundamentalGroupMulEquivInt hcov hp e γ = 1 ↔ hcov.monodromy γ e = e := by
+  rw [fundamentalGroupMulEquivInt_apply_eq_iff]
   simpa using (Iff.symm Subtype.ext_iff :
     ((hcov.monodromy γ e : 𝕜) = (e : 𝕜) ↔ hcov.monodromy γ e = e))
 
@@ -207,7 +205,7 @@ any point `x` with a chosen lift `e : (↑) ⁻¹' {x}`, is infinite cyclic:
 noncomputable def fundamentalGroupMulEquiv (hp : p ≠ 0) {x : AddCircle p}
     (e : ((↑) : ℝ → AddCircle p) ⁻¹' {x}) :
     FundamentalGroup (AddCircle p) x ≃* Multiplicative ℤ :=
-  fundamentalGroupMulEquivOfAddCircle (AddCircle.isCoveringMap_coe p)
+  fundamentalGroupMulEquivInt (AddCircle.isCoveringMap_coe p)
     (not_isOfFinAddOrder_of_isAddTorsionFree hp) e
 
 /-- Characterization of the integer assigned by `fundamentalGroupMulEquiv`: a loop class maps
@@ -217,7 +215,7 @@ lemma fundamentalGroupMulEquiv_apply_eq_iff (hp : p ≠ 0) {x : AddCircle p}
     (n : Multiplicative ℤ) :
     fundamentalGroupMulEquiv p hp e γ = n ↔
       ((AddCircle.isCoveringMap_coe p).monodromy γ e : ℝ) = (e : ℝ) + n.toAdd • p :=
-  fundamentalGroupMulEquivOfAddCircle_apply_eq_iff (AddCircle.isCoveringMap_coe p)
+  fundamentalGroupMulEquivInt_apply_eq_iff (AddCircle.isCoveringMap_coe p)
     (not_isOfFinAddOrder_of_isAddTorsionFree hp) e γ n
 
 /-- The inverse equivalence sends `n` to the loop class whose monodromy translates the chosen
@@ -227,7 +225,7 @@ lemma fundamentalGroupMulEquiv_symm_monodromy (hp : p ≠ 0) {x : AddCircle p}
     (e : ((↑) : ℝ → AddCircle p) ⁻¹' {x}) (n : Multiplicative ℤ) :
     ((AddCircle.isCoveringMap_coe p).monodromy ((fundamentalGroupMulEquiv p hp e).symm n) e :
       ℝ) = (e : ℝ) + n.toAdd • p :=
-  fundamentalGroupMulEquivOfAddCircle_symm_monodromy (AddCircle.isCoveringMap_coe p)
+  fundamentalGroupMulEquivInt_symm_monodromy (AddCircle.isCoveringMap_coe p)
     (not_isOfFinAddOrder_of_isAddTorsionFree hp) e n
 
 /-- A loop class maps to `1` under `fundamentalGroupMulEquiv` exactly when its monodromy fixes
@@ -236,7 +234,7 @@ the chosen lift. -/
 lemma fundamentalGroupMulEquiv_eq_one_iff (hp : p ≠ 0) {x : AddCircle p}
     (e : ((↑) : ℝ → AddCircle p) ⁻¹' {x}) (γ : FundamentalGroup (AddCircle p) x) :
     fundamentalGroupMulEquiv p hp e γ = 1 ↔ (AddCircle.isCoveringMap_coe p).monodromy γ e = e :=
-  fundamentalGroupMulEquivOfAddCircle_eq_one_iff (AddCircle.isCoveringMap_coe p)
+  fundamentalGroupMulEquivInt_eq_one_iff (AddCircle.isCoveringMap_coe p)
     (not_isOfFinAddOrder_of_isAddTorsionFree hp) e γ
 
 /-- The fundamental group of the circle `AddCircle p` based at `0`, with the lift `0 : ℝ`, is

--- a/TauCeti/AlgebraicTopology/UniversalCover/CircleFundamentalGroup.lean
+++ b/TauCeti/AlgebraicTopology/UniversalCover/CircleFundamentalGroup.lean
@@ -37,8 +37,6 @@ transformation, so `Deck ((↑) : 𝕜 → AddCircle p)` acts transitively on ev
 
 * `TauCeti.Deck.isRegular_addCircleCoe`: the projection `(↑) : 𝕜 → AddCircle p` has
   regular deck action.
-* `TauCeti.AddCircle.fundamentalGroupMulEquivOfAddCircle`: the generic statement for a
-  simply connected additive quotient projection with cyclic deck group.
 * `TauCeti.AddCircle.fundamentalGroupMulEquiv`: for a nonzero real period, the fundamental
   group of `AddCircle p` (based at any point with a chosen lift) is `Multiplicative ℤ`.
 * `TauCeti.AddCircle.fundamentalGroupMulEquiv_zero`: the basepoint-`0` specialisation, using
@@ -66,58 +64,65 @@ variable {𝕜 : Type*} [AddCommGroup 𝕜] [TopologicalSpace 𝕜] [IsTopologic
   {p : 𝕜} [SimplyConnectedSpace 𝕜] [PreconnectedSpace 𝕜]
   [TotallyDisconnectedSpace (zmultiples p)]
 
-/-- For an additive quotient projection `(↑) : 𝕜 → AddCircle p` whose total space is simply
-connected and whose period subgroup is infinite cyclic, the fundamental group of `AddCircle p`,
-based at any point `x` with a chosen lift `e : (↑) ⁻¹' {x}`, is `Multiplicative ℤ`.
+private noncomputable def fundamentalGroupMulEquivZMultiples
+    (hcov : IsCoveringMap ((↑) : 𝕜 → AddCircle p))
+    {x : AddCircle p} (e : ((↑) : 𝕜 → AddCircle p) ⁻¹' {x}) :
+    FundamentalGroup (AddCircle p) x ≃* Multiplicative (zmultiples p) :=
+  (Deck.isRegular_addCircleCoe.fundamentalGroupEquiv hcov e).trans
+    ((MulEquiv.op Deck.addCircleMulEquiv.symm).trans
+      (MulOpposite.opMulEquiv (M := Multiplicative (zmultiples p))).symm)
 
-The proof uses the regular deck action of the quotient projection, the supplied covering-map
-hypothesis, and the generic computation of the deck group of an AddCircle quotient. -/
-noncomputable def fundamentalGroupMulEquivOfAddCircle
+private lemma fundamentalGroupMulEquivZMultiples_apply_eq_iff
+    (hcov : IsCoveringMap ((↑) : 𝕜 → AddCircle p))
+    {x : AddCircle p} (e : ((↑) : 𝕜 → AddCircle p) ⁻¹' {x})
+    (γ : FundamentalGroup (AddCircle p) x) (n : Multiplicative (zmultiples p)) :
+    fundamentalGroupMulEquivZMultiples hcov e γ = n ↔
+      (hcov.monodromy γ e : 𝕜) = (e : 𝕜) + (n.toAdd : 𝕜) := by
+  let F := Deck.isRegular_addCircleCoe.fundamentalGroupEquiv hcov e
+  let T :=
+    (MulEquiv.op Deck.addCircleMulEquiv.symm).trans
+      (MulOpposite.opMulEquiv (M := Multiplicative (zmultiples p))).symm
+  dsimp [fundamentalGroupMulEquivZMultiples]
+  constructor
+  · intro h
+    have hf : F γ = MulOpposite.op (Deck.addCircleMulEquiv n) := by
+      have h' := congrArg T.symm h
+      simpa [T] using h'
+    have hs :=
+      (Deck.isRegular_addCircleCoe.fundamentalGroupEquiv_apply_eq_iff hcov e γ
+        (MulOpposite.op (Deck.addCircleMulEquiv n))).1 hf
+    simpa using hs.symm
+  · intro hm
+    have hs : (MulOpposite.op (Deck.addCircleMulEquiv n)).unop • (e : 𝕜) =
+        (hcov.monodromy γ e : 𝕜) := by
+      simpa using hm.symm
+    have hf : F γ = MulOpposite.op (Deck.addCircleMulEquiv n) :=
+      (Deck.isRegular_addCircleCoe.fundamentalGroupEquiv_apply_eq_iff hcov e γ
+        (MulOpposite.op (Deck.addCircleMulEquiv n))).2 hs
+    rw [hf]
+    change Deck.addCircleMulEquiv.symm (Deck.addRightZMultiples n.toAdd) = n
+    rw [← Deck.addCircleMulEquiv_apply n]
+    exact MulEquiv.symm_apply_apply Deck.addCircleMulEquiv n
+
+private noncomputable def fundamentalGroupMulEquivOfAddCircle
     (hcov : IsCoveringMap ((↑) : 𝕜 → AddCircle p)) (hp : ¬ IsOfFinAddOrder p)
     {x : AddCircle p} (e : ((↑) : 𝕜 → AddCircle p) ⁻¹' {x}) :
     FundamentalGroup (AddCircle p) x ≃* Multiplicative ℤ :=
-  (Deck.isRegular_addCircleCoe.fundamentalGroupEquiv hcov e).trans
-    ((MulEquiv.op (Deck.addCircleMulEquivInt hp).symm).trans
-      (MulOpposite.opMulEquiv (M := Multiplicative ℤ)).symm)
+  (fundamentalGroupMulEquivZMultiples hcov e).trans (intEquivZMultiples hp).toMultiplicative.symm
 
-/-- Characterization of the integer assigned by
-`fundamentalGroupMulEquivOfAddCircle`: a loop class maps to `n` exactly when its monodromy
-translate of the chosen lift differs by `n • p`. -/
-lemma fundamentalGroupMulEquivOfAddCircle_apply_eq_iff
+private lemma fundamentalGroupMulEquivOfAddCircle_apply_eq_iff
     (hcov : IsCoveringMap ((↑) : 𝕜 → AddCircle p)) (hp : ¬ IsOfFinAddOrder p)
     {x : AddCircle p} (e : ((↑) : 𝕜 → AddCircle p) ⁻¹' {x})
     (γ : FundamentalGroup (AddCircle p) x) (n : Multiplicative ℤ) :
     fundamentalGroupMulEquivOfAddCircle hcov hp e γ = n ↔
       (hcov.monodromy γ e : 𝕜) = (e : 𝕜) + n.toAdd • p := by
-  let F := Deck.isRegular_addCircleCoe.fundamentalGroupEquiv hcov e
-  let T :=
-    (MulEquiv.op (Deck.addCircleMulEquivInt hp).symm).trans
-      (MulOpposite.opMulEquiv (M := Multiplicative ℤ)).symm
-  change T (F γ) = n ↔ (hcov.monodromy γ e : 𝕜) = (e : 𝕜) + n.toAdd • p
-  constructor
-  · intro h
-    have hf : F γ = MulOpposite.op (Deck.addCircleMulEquivInt hp n) := by
-      have h' := congrArg T.symm h
-      simpa [T] using h'
-    have hs :=
-      (Deck.isRegular_addCircleCoe.fundamentalGroupEquiv_apply_eq_iff hcov e γ
-        (MulOpposite.op (Deck.addCircleMulEquivInt hp n))).1 hf
-    simpa [Deck.addCircleMulEquivInt_apply] using hs.symm
-  · intro hm
-    have hs : (MulOpposite.op (Deck.addCircleMulEquivInt hp n)).unop • (e : 𝕜) =
-        (hcov.monodromy γ e : 𝕜) := by
-      simpa [Deck.addCircleMulEquivInt_apply] using hm.symm
-    have hf : F γ = MulOpposite.op (Deck.addCircleMulEquivInt hp n) :=
-      (Deck.isRegular_addCircleCoe.fundamentalGroupEquiv_apply_eq_iff hcov e γ
-        (MulOpposite.op (Deck.addCircleMulEquivInt hp n))).2 hs
-    change T (F γ) = n
-    rw [hf]
-    simp [T]
+  dsimp [fundamentalGroupMulEquivOfAddCircle]
+  rw [MulEquiv.symm_apply_eq]
+  simpa using fundamentalGroupMulEquivZMultiples_apply_eq_iff hcov e γ
+    ((intEquivZMultiples hp).toMultiplicative n)
 
-/-- The inverse equivalence sends `n` to the loop class whose monodromy translates the chosen
-lift by `n • p`. -/
 @[simp]
-lemma fundamentalGroupMulEquivOfAddCircle_symm_monodromy
+private lemma fundamentalGroupMulEquivOfAddCircle_symm_monodromy
     (hcov : IsCoveringMap ((↑) : 𝕜 → AddCircle p)) (hp : ¬ IsOfFinAddOrder p)
     {x : AddCircle p} (e : ((↑) : 𝕜 → AddCircle p) ⁻¹' {x}) (n : Multiplicative ℤ) :
     (hcov.monodromy ((fundamentalGroupMulEquivOfAddCircle hcov hp e).symm n) e : 𝕜) =
@@ -126,10 +131,8 @@ lemma fundamentalGroupMulEquivOfAddCircle_symm_monodromy
     ((fundamentalGroupMulEquivOfAddCircle hcov hp e).symm n) n).1
       (MulEquiv.apply_symm_apply _ _)
 
-/-- A loop class maps to `1` under `fundamentalGroupMulEquivOfAddCircle` exactly when its
-monodromy fixes the chosen lift. -/
 @[simp]
-lemma fundamentalGroupMulEquivOfAddCircle_eq_one_iff
+private lemma fundamentalGroupMulEquivOfAddCircle_eq_one_iff
     (hcov : IsCoveringMap ((↑) : 𝕜 → AddCircle p)) (hp : ¬ IsOfFinAddOrder p)
     {x : AddCircle p} (e : ((↑) : 𝕜 → AddCircle p) ⁻¹' {x})
     (γ : FundamentalGroup (AddCircle p) x) :
@@ -141,18 +144,18 @@ lemma fundamentalGroupMulEquivOfAddCircle_eq_one_iff
 variable (p : ℝ)
 
 /-- The standard lift `0 : ℝ` of the basepoint `0 : AddCircle p`. -/
-def zeroLift : ((↑) : ℝ → AddCircle p) ⁻¹' {(0 : AddCircle p)} :=
+@[expose] def zeroLift : ((↑) : ℝ → AddCircle p) ⁻¹' {(0 : AddCircle p)} :=
   ⟨0, by simp⟩
+
+/-- The underlying real number of the standard zero lift is `0`. -/
+@[simp]
+theorem zeroLift_coe : ((zeroLift p : ((↑) : ℝ → AddCircle p) ⁻¹' {(0 : AddCircle p)}) : ℝ) =
+    0 :=
+  rfl
 
 /-- For a nonzero real period `p`, the fundamental group of the circle `AddCircle p`, based at
 any point `x` with a chosen lift `e : (↑) ⁻¹' {x}`, is infinite cyclic:
-`FundamentalGroup (AddCircle p) x ≃* Multiplicative ℤ`.
-
-The cover `(↑) : ℝ → AddCircle p` is regular (`TauCeti.Deck.isRegular_addCircleCoe`) with
-contractible (hence simply connected) total space `ℝ`, so the regular-cover comparison
-`TauCeti.Deck.IsRegular.fundamentalGroupEquiv` identifies `π₁` with the opposite deck group;
-the deck group is `Multiplicative ℤ` by `TauCeti.Deck.addCircleMulEquivInt`, and the opposite
-of a commutative group is itself. -/
+`FundamentalGroup (AddCircle p) x ≃* Multiplicative ℤ`. -/
 noncomputable def fundamentalGroupMulEquiv (hp : p ≠ 0) {x : AddCircle p}
     (e : ((↑) : ℝ → AddCircle p) ⁻¹' {x}) :
     FundamentalGroup (AddCircle p) x ≃* Multiplicative ℤ :=

--- a/TauCeti/AlgebraicTopology/UniversalCover/CircleFundamentalGroup.lean
+++ b/TauCeti/AlgebraicTopology/UniversalCover/CircleFundamentalGroup.lean
@@ -37,6 +37,8 @@ transformation, so `Deck ((↑) : 𝕜 → AddCircle p)` acts transitively on ev
 
 * `TauCeti.Deck.isRegular_addCircleCoe`: the projection `(↑) : 𝕜 → AddCircle p` has
   regular deck action.
+* `TauCeti.AddCircle.fundamentalGroupMulEquivZMultiples`: for a covering projection from a
+  simply connected additive group, the fundamental group of `AddCircle p` is the period subgroup.
 * `TauCeti.AddCircle.fundamentalGroupMulEquiv`: for a nonzero real period, the fundamental
   group of `AddCircle p` (based at any point with a chosen lift) is `Multiplicative ℤ`.
 * `TauCeti.AddCircle.fundamentalGroupMulEquiv_zero`: the basepoint-`0` specialisation, using
@@ -64,21 +66,33 @@ variable {𝕜 : Type*} [AddCommGroup 𝕜] [TopologicalSpace 𝕜] [IsTopologic
   {p : 𝕜} [SimplyConnectedSpace 𝕜] [PreconnectedSpace 𝕜]
   [TotallyDisconnectedSpace (zmultiples p)]
 
-private noncomputable def fundamentalGroupMulEquivZMultiples
+/-- For a covering projection `(↑) : 𝕜 → AddCircle p` from a simply connected preconnected
+topological additive commutative group with totally disconnected period subgroup, the
+fundamental group of `AddCircle p` is the multiplicative period subgroup. -/
+noncomputable def fundamentalGroupMulEquivZMultiples
     (hcov : IsCoveringMap ((↑) : 𝕜 → AddCircle p))
     {x : AddCircle p} (e : ((↑) : 𝕜 → AddCircle p) ⁻¹' {x}) :
     FundamentalGroup (AddCircle p) x ≃* Multiplicative (zmultiples p) :=
-  (Deck.isRegular_addCircleCoe.fundamentalGroupEquiv hcov e).trans
+  (Deck.IsRegular.fundamentalGroupEquiv Deck.isRegular_addCircleCoe hcov e).trans
     ((MulEquiv.op Deck.addCircleMulEquiv.symm).trans
       (MulOpposite.opMulEquiv (M := Multiplicative (zmultiples p))).symm)
 
-private lemma fundamentalGroupMulEquivZMultiples_apply_eq_iff
+omit [SimplyConnectedSpace 𝕜] in
+private lemma addCircleMulEquiv_symm_addRightZMultiples (n : Multiplicative (zmultiples p)) :
+    Deck.addCircleMulEquiv.symm (Deck.addRightZMultiples n.toAdd) = n := by
+  rw [← Deck.addCircleMulEquiv_apply n]
+  exact MulEquiv.symm_apply_apply Deck.addCircleMulEquiv n
+
+/-- Characterization of the period-subgroup element assigned by
+`fundamentalGroupMulEquivZMultiples`: a loop class maps to `n` exactly when its monodromy
+translate of the chosen lift differs by the element `n`. -/
+lemma fundamentalGroupMulEquivZMultiples_apply_eq_iff
     (hcov : IsCoveringMap ((↑) : 𝕜 → AddCircle p))
     {x : AddCircle p} (e : ((↑) : 𝕜 → AddCircle p) ⁻¹' {x})
     (γ : FundamentalGroup (AddCircle p) x) (n : Multiplicative (zmultiples p)) :
     fundamentalGroupMulEquivZMultiples hcov e γ = n ↔
       (hcov.monodromy γ e : 𝕜) = (e : 𝕜) + (n.toAdd : 𝕜) := by
-  let F := Deck.isRegular_addCircleCoe.fundamentalGroupEquiv hcov e
+  let F := Deck.IsRegular.fundamentalGroupEquiv Deck.isRegular_addCircleCoe hcov e
   let T :=
     (MulEquiv.op Deck.addCircleMulEquiv.symm).trans
       (MulOpposite.opMulEquiv (M := Multiplicative (zmultiples p))).symm
@@ -89,7 +103,7 @@ private lemma fundamentalGroupMulEquivZMultiples_apply_eq_iff
       have h' := congrArg T.symm h
       simpa [T] using h'
     have hs :=
-      (Deck.isRegular_addCircleCoe.fundamentalGroupEquiv_apply_eq_iff hcov e γ
+      (Deck.IsRegular.fundamentalGroupEquiv_apply_eq_iff Deck.isRegular_addCircleCoe hcov e γ
         (MulOpposite.op (Deck.addCircleMulEquiv n))).1 hf
     simpa using hs.symm
   · intro hm
@@ -97,12 +111,35 @@ private lemma fundamentalGroupMulEquivZMultiples_apply_eq_iff
         (hcov.monodromy γ e : 𝕜) := by
       simpa using hm.symm
     have hf : F γ = MulOpposite.op (Deck.addCircleMulEquiv n) :=
-      (Deck.isRegular_addCircleCoe.fundamentalGroupEquiv_apply_eq_iff hcov e γ
+      (Deck.IsRegular.fundamentalGroupEquiv_apply_eq_iff Deck.isRegular_addCircleCoe hcov e γ
         (MulOpposite.op (Deck.addCircleMulEquiv n))).2 hs
     rw [hf]
-    change Deck.addCircleMulEquiv.symm (Deck.addRightZMultiples n.toAdd) = n
-    rw [← Deck.addCircleMulEquiv_apply n]
-    exact MulEquiv.symm_apply_apply Deck.addCircleMulEquiv n
+    exact addCircleMulEquiv_symm_addRightZMultiples n
+
+/-- The inverse of the period-subgroup equivalence sends `n` to the loop class whose monodromy
+translates the chosen lift by `n`. -/
+@[simp]
+lemma fundamentalGroupMulEquivZMultiples_symm_monodromy
+    (hcov : IsCoveringMap ((↑) : 𝕜 → AddCircle p))
+    {x : AddCircle p} (e : ((↑) : 𝕜 → AddCircle p) ⁻¹' {x})
+    (n : Multiplicative (zmultiples p)) :
+    (hcov.monodromy ((fundamentalGroupMulEquivZMultiples hcov e).symm n) e : 𝕜) =
+      (e : 𝕜) + (n.toAdd : 𝕜) := by
+  exact (fundamentalGroupMulEquivZMultiples_apply_eq_iff hcov e
+    ((fundamentalGroupMulEquivZMultiples hcov e).symm n) n).1
+      (MulEquiv.apply_symm_apply _ _)
+
+/-- A loop class maps to `1` under the period-subgroup equivalence exactly when its monodromy
+fixes the chosen lift. -/
+@[simp]
+lemma fundamentalGroupMulEquivZMultiples_eq_one_iff
+    (hcov : IsCoveringMap ((↑) : 𝕜 → AddCircle p))
+    {x : AddCircle p} (e : ((↑) : 𝕜 → AddCircle p) ⁻¹' {x})
+    (γ : FundamentalGroup (AddCircle p) x) :
+    fundamentalGroupMulEquivZMultiples hcov e γ = 1 ↔ hcov.monodromy γ e = e := by
+  rw [fundamentalGroupMulEquivZMultiples_apply_eq_iff]
+  simpa using (Iff.symm Subtype.ext_iff :
+    ((hcov.monodromy γ e : 𝕜) = (e : 𝕜) ↔ hcov.monodromy γ e = e))
 
 private noncomputable def fundamentalGroupMulEquivOfAddCircle
     (hcov : IsCoveringMap ((↑) : 𝕜 → AddCircle p)) (hp : ¬ IsOfFinAddOrder p)

--- a/TauCeti/AlgebraicTopology/UniversalCover/CircleFundamentalGroup.lean
+++ b/TauCeti/AlgebraicTopology/UniversalCover/CircleFundamentalGroup.lean
@@ -39,6 +39,9 @@ transformation, so `Deck ((↑) : 𝕜 → AddCircle p)` acts transitively on ev
   regular deck action.
 * `TauCeti.AddCircle.fundamentalGroupMulEquivZMultiples`: for a covering projection from a
   simply connected additive group, the fundamental group of `AddCircle p` is the period subgroup.
+* `TauCeti.AddCircle.fundamentalGroupMulEquivOfAddCircle`: for a covering projection from a
+  simply connected additive group with non-torsion period, the fundamental group of
+  `AddCircle p` is `Multiplicative ℤ`.
 * `TauCeti.AddCircle.fundamentalGroupMulEquiv`: for a nonzero real period, the fundamental
   group of `AddCircle p` (based at any point with a chosen lift) is `Multiplicative ℤ`.
 * `TauCeti.AddCircle.fundamentalGroupMulEquiv_zero`: the basepoint-`0` specialisation, using
@@ -83,6 +86,14 @@ private lemma addCircleMulEquiv_symm_addRightZMultiples (n : Multiplicative (zmu
   rw [← Deck.addCircleMulEquiv_apply n]
   exact MulEquiv.symm_apply_apply Deck.addCircleMulEquiv n
 
+omit [SimplyConnectedSpace 𝕜] in
+private lemma fundamentalGroupMulEquivZMultiples_toPeriod_symm_apply
+    (n : Multiplicative (zmultiples p)) :
+    (((MulEquiv.op Deck.addCircleMulEquiv.symm).trans
+      (MulOpposite.opMulEquiv (M := Multiplicative (zmultiples p))).symm).symm n) =
+        MulOpposite.op (Deck.addCircleMulEquiv n) := by
+  simp
+
 /-- Characterization of the period-subgroup element assigned by
 `fundamentalGroupMulEquivZMultiples`: a loop class maps to `n` exactly when its monodromy
 translate of the chosen lift differs by the element `n`. -/
@@ -101,7 +112,7 @@ lemma fundamentalGroupMulEquivZMultiples_apply_eq_iff
   · intro h
     have hf : F γ = MulOpposite.op (Deck.addCircleMulEquiv n) := by
       have h' := congrArg T.symm h
-      simpa [T] using h'
+      simpa [T, fundamentalGroupMulEquivZMultiples_toPeriod_symm_apply n] using h'
     have hs :=
       (Deck.IsRegular.fundamentalGroupEquiv_apply_eq_iff Deck.isRegular_addCircleCoe hcov e γ
         (MulOpposite.op (Deck.addCircleMulEquiv n))).1 hf
@@ -141,13 +152,19 @@ lemma fundamentalGroupMulEquivZMultiples_eq_one_iff
   simpa using (Iff.symm Subtype.ext_iff :
     ((hcov.monodromy γ e : 𝕜) = (e : 𝕜) ↔ hcov.monodromy γ e = e))
 
-private noncomputable def fundamentalGroupMulEquivOfAddCircle
+/-- For a covering projection `(↑) : 𝕜 → AddCircle p` from a simply connected preconnected
+topological additive commutative group with totally disconnected non-torsion period subgroup,
+the fundamental group of `AddCircle p` is infinite cyclic:
+`FundamentalGroup (AddCircle p) x ≃* Multiplicative ℤ`. -/
+noncomputable def fundamentalGroupMulEquivOfAddCircle
     (hcov : IsCoveringMap ((↑) : 𝕜 → AddCircle p)) (hp : ¬ IsOfFinAddOrder p)
     {x : AddCircle p} (e : ((↑) : 𝕜 → AddCircle p) ⁻¹' {x}) :
     FundamentalGroup (AddCircle p) x ≃* Multiplicative ℤ :=
   (fundamentalGroupMulEquivZMultiples hcov e).trans (intEquivZMultiples hp).toMultiplicative.symm
 
-private lemma fundamentalGroupMulEquivOfAddCircle_apply_eq_iff
+/-- Characterization of the integer assigned by `fundamentalGroupMulEquivOfAddCircle`: a loop
+class maps to `n` exactly when its monodromy translate of the chosen lift differs by `n • p`. -/
+lemma fundamentalGroupMulEquivOfAddCircle_apply_eq_iff
     (hcov : IsCoveringMap ((↑) : 𝕜 → AddCircle p)) (hp : ¬ IsOfFinAddOrder p)
     {x : AddCircle p} (e : ((↑) : 𝕜 → AddCircle p) ⁻¹' {x})
     (γ : FundamentalGroup (AddCircle p) x) (n : Multiplicative ℤ) :
@@ -158,8 +175,10 @@ private lemma fundamentalGroupMulEquivOfAddCircle_apply_eq_iff
   simpa using fundamentalGroupMulEquivZMultiples_apply_eq_iff hcov e γ
     ((intEquivZMultiples hp).toMultiplicative n)
 
+/-- The inverse generic integer equivalence sends `n` to the loop class whose monodromy
+translates the chosen lift by `n • p`. -/
 @[simp]
-private lemma fundamentalGroupMulEquivOfAddCircle_symm_monodromy
+lemma fundamentalGroupMulEquivOfAddCircle_symm_monodromy
     (hcov : IsCoveringMap ((↑) : 𝕜 → AddCircle p)) (hp : ¬ IsOfFinAddOrder p)
     {x : AddCircle p} (e : ((↑) : 𝕜 → AddCircle p) ⁻¹' {x}) (n : Multiplicative ℤ) :
     (hcov.monodromy ((fundamentalGroupMulEquivOfAddCircle hcov hp e).symm n) e : 𝕜) =
@@ -168,8 +187,10 @@ private lemma fundamentalGroupMulEquivOfAddCircle_symm_monodromy
     ((fundamentalGroupMulEquivOfAddCircle hcov hp e).symm n) n).1
       (MulEquiv.apply_symm_apply _ _)
 
+/-- A loop class maps to `1` under the generic integer equivalence exactly when its monodromy
+fixes the chosen lift. -/
 @[simp]
-private lemma fundamentalGroupMulEquivOfAddCircle_eq_one_iff
+lemma fundamentalGroupMulEquivOfAddCircle_eq_one_iff
     (hcov : IsCoveringMap ((↑) : 𝕜 → AddCircle p)) (hp : ¬ IsOfFinAddOrder p)
     {x : AddCircle p} (e : ((↑) : 𝕜 → AddCircle p) ⁻¹' {x})
     (γ : FundamentalGroup (AddCircle p) x) :
@@ -179,16 +200,6 @@ private lemma fundamentalGroupMulEquivOfAddCircle_eq_one_iff
     ((hcov.monodromy γ e : 𝕜) = (e : 𝕜) ↔ hcov.monodromy γ e = e))
 
 variable (p : ℝ)
-
-/-- The standard lift `0 : ℝ` of the basepoint `0 : AddCircle p`. -/
-@[expose] def zeroLift : ((↑) : ℝ → AddCircle p) ⁻¹' {(0 : AddCircle p)} :=
-  ⟨0, by simp⟩
-
-/-- The underlying real number of the standard zero lift is `0`. -/
-@[simp]
-theorem zeroLift_coe : ((zeroLift p : ((↑) : ℝ → AddCircle p) ⁻¹' {(0 : AddCircle p)}) : ℝ) =
-    0 :=
-  rfl
 
 /-- For a nonzero real period `p`, the fundamental group of the circle `AddCircle p`, based at
 any point `x` with a chosen lift `e : (↑) ⁻¹' {x}`, is infinite cyclic:
@@ -232,23 +243,23 @@ lemma fundamentalGroupMulEquiv_eq_one_iff (hp : p ≠ 0) {x : AddCircle p}
 `Multiplicative ℤ`. -/
 noncomputable def fundamentalGroupMulEquiv_zero (hp : p ≠ 0) :
     FundamentalGroup (AddCircle p) 0 ≃* Multiplicative ℤ :=
-  fundamentalGroupMulEquiv p hp (zeroLift p)
+  fundamentalGroupMulEquiv p hp ⟨0, by simp⟩
 
 /-- Characterization of the integer assigned by the basepoint-`0` specialization. -/
 lemma fundamentalGroupMulEquiv_zero_apply_eq_iff (hp : p ≠ 0)
     (γ : FundamentalGroup (AddCircle p) 0) (n : Multiplicative ℤ) :
     fundamentalGroupMulEquiv_zero p hp γ = n ↔
-      ((AddCircle.isCoveringMap_coe p).monodromy γ (zeroLift p) : ℝ) = n.toAdd • p := by
+      ((AddCircle.isCoveringMap_coe p).monodromy γ ⟨0, by simp⟩ : ℝ) = n.toAdd • p := by
   rw [fundamentalGroupMulEquiv_zero]
-  simpa [zeroLift] using fundamentalGroupMulEquiv_apply_eq_iff p hp (zeroLift p) γ n
+  simpa using fundamentalGroupMulEquiv_apply_eq_iff p hp ⟨0, by simp⟩ γ n
 
 /-- The inverse of the basepoint-`0` specialization has monodromy translation `n • p`. -/
 @[simp]
 lemma fundamentalGroupMulEquiv_zero_symm_monodromy (hp : p ≠ 0) (n : Multiplicative ℤ) :
     ((AddCircle.isCoveringMap_coe p).monodromy ((fundamentalGroupMulEquiv_zero p hp).symm n)
-      (zeroLift p) : ℝ) = n.toAdd • p := by
+      ⟨0, by simp⟩ : ℝ) = n.toAdd • p := by
   rw [fundamentalGroupMulEquiv_zero]
-  simp [zeroLift]
+  simp
 
 /-- A loop class maps to `1` under the basepoint-`0` specialization exactly when its monodromy
 fixes the zero lift. -/
@@ -256,9 +267,9 @@ fixes the zero lift. -/
 lemma fundamentalGroupMulEquiv_zero_eq_one_iff (hp : p ≠ 0)
     (γ : FundamentalGroup (AddCircle p) 0) :
     fundamentalGroupMulEquiv_zero p hp γ = 1 ↔
-      (AddCircle.isCoveringMap_coe p).monodromy γ (zeroLift p) = zeroLift p := by
+      (AddCircle.isCoveringMap_coe p).monodromy γ ⟨0, by simp⟩ = ⟨0, by simp⟩ := by
   rw [fundamentalGroupMulEquiv_zero]
-  exact fundamentalGroupMulEquiv_eq_one_iff p hp (zeroLift p) γ
+  exact fundamentalGroupMulEquiv_eq_one_iff p hp ⟨0, by simp⟩ γ
 
 end AddCircle
 
@@ -274,7 +285,7 @@ noncomputable def fundamentalGroupMulEquiv :
 lemma fundamentalGroupMulEquiv_apply_eq_iff (γ : FundamentalGroup UnitAddCircle 0)
     (n : Multiplicative ℤ) :
     fundamentalGroupMulEquiv γ = n ↔
-      ((AddCircle.isCoveringMap_coe 1).monodromy γ (AddCircle.zeroLift 1) : ℝ) = n.toAdd := by
+      ((AddCircle.isCoveringMap_coe 1).monodromy γ ⟨0, by simp⟩ : ℝ) = n.toAdd := by
   simpa [fundamentalGroupMulEquiv] using
     AddCircle.fundamentalGroupMulEquiv_zero_apply_eq_iff 1 one_ne_zero γ n
 
@@ -282,7 +293,7 @@ lemma fundamentalGroupMulEquiv_apply_eq_iff (γ : FundamentalGroup UnitAddCircle
 @[simp]
 lemma fundamentalGroupMulEquiv_symm_monodromy (n : Multiplicative ℤ) :
     ((AddCircle.isCoveringMap_coe 1).monodromy (fundamentalGroupMulEquiv.symm n)
-      (AddCircle.zeroLift 1) : ℝ) = n.toAdd := by
+      ⟨0, by simp⟩ : ℝ) = n.toAdd := by
   simp [fundamentalGroupMulEquiv,
     AddCircle.fundamentalGroupMulEquiv_zero_symm_monodromy 1 one_ne_zero n]
 
@@ -290,8 +301,7 @@ lemma fundamentalGroupMulEquiv_symm_monodromy (n : Multiplicative ℤ) :
 @[simp]
 lemma fundamentalGroupMulEquiv_eq_one_iff (γ : FundamentalGroup UnitAddCircle 0) :
     fundamentalGroupMulEquiv γ = 1 ↔
-      (AddCircle.isCoveringMap_coe 1).monodromy γ (AddCircle.zeroLift 1) =
-        AddCircle.zeroLift 1 := by
+      (AddCircle.isCoveringMap_coe 1).monodromy γ ⟨0, by simp⟩ = ⟨0, by simp⟩ := by
   simpa [fundamentalGroupMulEquiv] using
     AddCircle.fundamentalGroupMulEquiv_zero_eq_one_iff 1 one_ne_zero γ
 


### PR DESCRIPTION
This PR identifies the fundamental group of the real additive circle with the infinite cyclic group, proving `FundamentalGroup (AddCircle p) x ≃* Multiplicative ℤ` for every nonzero real period `p` and, specialised to the unit circle `UnitAddCircle = ℝ ⧸ ℤ`, the classical `π₁(S¹) ≅ ℤ`. It advances the universal-covers roadmap Stage 4 target 12 (`π₁(S¹) ≅ ℤ`, "built from `AddCircle.isCoveringMap_coe` (`ℝ → S¹`) and deck transformations"; `TauCetiRoadmap/UniversalCovers/README.md`).

The argument assembles existing pieces: the cover `(↑) : ℝ → AddCircle p` is regular with contractible (hence simply connected) total space `ℝ`, so the Stage 1 regular-cover comparison `Deck.IsRegular.fundamentalGroupEquiv` identifies `π₁` of the base with the opposite of the deck group; the deck group is `Multiplicative ℤ` by the Stage 0.4 computation `Deck.addCircleMulEquivInt`, and the opposite of a commutative group is itself. The only new input is regularity of the quotient cover, `Deck.isRegular_addCircleCoe`, which holds for an arbitrary topological additive group: two points of `𝕜` with the same image differ by an element of the period subgroup, and translating by it is a deck transformation, so the deck group acts transitively on every fibre.

It consumes Mathlib's `AddCircle.isCoveringMap_coe` (Junyan Xu) for the covering hypothesis and `RealTopologicalVectorSpace.contractibleSpace` for simple connectivity of `ℝ`, together with the Tau Ceti deck-transformation theory of Stages 0.4 and 1.

<!--tauceti-target:v1 {"focus":"UniversalCovers","id":"fundamental-group-circle-equiv-int"}-->

🤖 Prepared with Claude Code
