### PR TITLE
feat: base change split torus points

### DIFF
--- a/TauCeti/Algebra/AlgebraicGroup/SplitTorusBaseChange.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/SplitTorusBaseChange.lean
@@ -1,0 +1,143 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+module
+
+public import TauCeti.Algebra.AlgebraicGroup.DiagonalizableGroupBaseChange
+public import TauCeti.Algebra.AlgebraicGroup.SplitTorus
+
+/-!
+# Base change of split-torus points
+
+The rank-`σ` split torus over `k` is the diagonalizable group
+`D(Multiplicative (σ →₀ ℤ))`, represented by the group algebra
+`k[Multiplicative (σ →₀ ℤ)]`. This file records the base-changed functor-of-points
+calculation: if `K` is a `k`-algebra and `A` is a commutative `K`-algebra, then the
+convolution group of `K`-algebra maps out of
+`K ⊗[k] k[Multiplicative (σ →₀ ℤ)]` is the product group `σ → Aˣ`.
+
+The equivalence is the specialization of
+`DiagonalizableGroup.baseChangePointsMulEquiv` to the free abelian character group, followed
+by `freeAbelianCharEquiv`. The pointwise API reads a base-changed point on the standard
+coordinate characters `1 ⊗ single (ofAdd (single i 1)) 1`, records the inverse evaluation,
+and proves naturality in the value algebra.
+
+This advances the ReductiveGroups roadmap, Layer 0 ("Base change. `K ⊗[k] A` as a Hopf
+algebra over `K`") and Layer 4 ("Tori: split ... the character lattice `X*(T)`").
+
+## Main declarations
+
+* `TauCeti.SplitTorus.baseChangePointsMulEquiv`: the multiplicative equivalence from
+  base-changed points of the rank-`σ` split torus to coordinate families `σ → Aˣ`.
+* `TauCeti.SplitTorus.baseChangePointsMulEquiv_apply_coe`: the equivalence reads a point on
+  the base-changed standard coordinate generator.
+* `TauCeti.SplitTorus.baseChangePointsMulEquiv_symm_apply_single`: the inverse equivalence
+  takes each standard coordinate generator to the chosen coordinate.
+* `TauCeti.SplitTorus.baseChangePointsMulEquiv_mapValue`: the equivalence is natural in the
+  value algebra.
+
+## References
+
+The base-change step is Tau Ceti's `DiagonalizableGroup.baseChangePointsMulEquiv`, and the
+free-abelian character calculation is Tau Ceti's `freeAbelianCharEquiv`, built from Mathlib's
+`Finsupp.liftAddHom` and `zmultiplesHom`.
+-/
+
+public section
+
+open WithConv
+open scoped TensorProduct
+
+namespace TauCeti
+
+namespace SplitTorus
+
+universe u v w w'
+
+variable {k : Type u} {K : Type v} {A : Type w} {σ : Type w'}
+variable [CommSemiring k] [CommSemiring K] [CommSemiring A]
+variable [Algebra k K] [Algebra K A] [Algebra k A] [IsScalarTower k K A]
+
+/-- The `A`-points of the base change of the rank-`σ` split torus are coordinate families
+`σ → Aˣ`.
+
+The source is the convolution group of `K`-algebra maps out of the base-changed Hopf algebra
+`K ⊗[k] k[Multiplicative (σ →₀ ℤ)]`; the target is the product group of units of the value
+algebra. -/
+@[expose] noncomputable def baseChangePointsMulEquiv :
+    WithConv (K ⊗[k] MonoidAlgebra k (Multiplicative (σ →₀ ℤ)) →ₐ[K] A) ≃* (σ → Aˣ) :=
+  (DiagonalizableGroup.baseChangePointsMulEquiv (k := k) (K := K) (A := A)
+      (G := Multiplicative (σ →₀ ℤ))).trans freeAbelianCharEquiv
+
+/-- The base-changed split-torus points equivalence reads a point by evaluating it on the
+base-changed standard coordinate generator indexed by `i`. -/
+@[simp]
+theorem baseChangePointsMulEquiv_apply_coe
+    (f : WithConv (K ⊗[k] MonoidAlgebra k (Multiplicative (σ →₀ ℤ)) →ₐ[K] A))
+    (i : σ) :
+    (baseChangePointsMulEquiv f i : A) =
+      f.ofConv (1 ⊗ₜ[k]
+        MonoidAlgebra.single (Multiplicative.ofAdd (Finsupp.single i 1)) (1 : k)) := by
+  rw [baseChangePointsMulEquiv, MulEquiv.trans_apply, freeAbelianCharEquiv_apply,
+    DiagonalizableGroup.baseChangePointsMulEquiv_apply_coe]
+
+/-- The inverse base-changed split-torus points equivalence sends a pure tensor
+`s ⊗ single (ofAdd m) r` to the scalar multiple of the monomial in the chosen coordinates
+with exponent vector `m`. -/
+@[simp]
+theorem baseChangePointsMulEquiv_symm_apply_tmul_single (c : σ → Aˣ) (s : K)
+    (m : σ →₀ ℤ) (r : k) :
+    ((baseChangePointsMulEquiv (k := k) (K := K) (A := A) (σ := σ)).symm c).ofConv
+        (s ⊗ₜ[k] MonoidAlgebra.single (Multiplicative.ofAdd m) r) =
+      s • (r • ((m.prod fun i n => c i ^ n : Aˣ) : A)) := by
+  rw [baseChangePointsMulEquiv, MulEquiv.symm_trans_apply,
+    DiagonalizableGroup.baseChangePointsMulEquiv_symm_apply_tmul_single]
+  simp only [freeAbelianCharEquiv_symm_apply_ofAdd]
+
+/-- The inverse base-changed split-torus points equivalence takes the standard coordinate
+generator indexed by `i` to the chosen coordinate `c i`. -/
+@[simp]
+theorem baseChangePointsMulEquiv_symm_apply_single (c : σ → Aˣ) (i : σ) :
+    ((baseChangePointsMulEquiv (k := k) (K := K) (A := A) (σ := σ)).symm c).ofConv
+        (1 ⊗ₜ[k] MonoidAlgebra.single (Multiplicative.ofAdd (Finsupp.single i 1)) (1 : k)) =
+      (c i : A) := by
+  rw [baseChangePointsMulEquiv_symm_apply_tmul_single]
+  simp
+
+variable {B : Type*} [CommSemiring B] [Algebra K B] [Algebra k B] [IsScalarTower k K B]
+
+/-- The base-changed split-torus points equivalence is natural in the value algebra:
+post-composing a point with a `K`-algebra map sends each coordinate through the induced map on
+unit groups. -/
+@[simp]
+theorem baseChangePointsMulEquiv_mapValue (φ : A →ₐ[K] B)
+    (f : WithConv (K ⊗[k] MonoidAlgebra k (Multiplicative (σ →₀ ℤ)) →ₐ[K] A)) (i : σ) :
+    baseChangePointsMulEquiv
+        (AlgHom.mapValue (H := K ⊗[k] MonoidAlgebra k (Multiplicative (σ →₀ ℤ))) φ f) i =
+      Units.map φ.toMonoidHom (baseChangePointsMulEquiv f i) := by
+  simp only [baseChangePointsMulEquiv, MulEquiv.trans_apply,
+    DiagonalizableGroup.baseChangePointsMulEquiv_mapValue, freeAbelianCharEquiv_comp]
+
+/-- Naturality of the inverse base-changed split-torus points equivalence in the value
+algebra. -/
+@[simp]
+theorem mapValue_baseChangePointsMulEquiv_symm_apply (φ : A →ₐ[K] B) (c : σ → Aˣ) :
+    AlgHom.mapValue (H := K ⊗[k] MonoidAlgebra k (Multiplicative (σ →₀ ℤ))) φ
+        ((baseChangePointsMulEquiv (k := k) (K := K) (A := A) (σ := σ)).symm c) =
+      (baseChangePointsMulEquiv (k := k) (K := K) (A := B) (σ := σ)).symm
+        (fun i => Units.map φ.toMonoidHom (c i)) := by
+  apply (baseChangePointsMulEquiv (k := k) (K := K) (A := B) (σ := σ)).injective
+  funext i
+  rw [baseChangePointsMulEquiv_mapValue]
+  simp
+
+/-- The base-changed rank-`n` split torus has `A`-points `Fin n → Aˣ = (Aˣ)ⁿ`. -/
+noncomputable example (n : ℕ) :
+    WithConv (K ⊗[k] MonoidAlgebra k (Multiplicative (Fin n →₀ ℤ)) →ₐ[K] A) ≃*
+      (Fin n → Aˣ) :=
+  baseChangePointsMulEquiv
+
+end SplitTorus
+
+end TauCeti

--- a/TauCeti/Algebra/AlgebraicGroup/SplitTorusBaseChange.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/SplitTorusBaseChange.lean
@@ -5,7 +5,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 module
 
 public import TauCeti.Algebra.AlgebraicGroup.DiagonalizableGroupBaseChange
-public import TauCeti.Algebra.AlgebraicGroup.SplitTorus
+public import TauCeti.Algebra.Group.FreeAbelianCharacter
 
 /-!
 # Base change of split-torus points
@@ -65,7 +65,7 @@ variable [Algebra k K] [Algebra K A] [Algebra k A] [IsScalarTower k K A]
 The source is the convolution group of `K`-algebra maps out of the base-changed Hopf algebra
 `K ⊗[k] k[Multiplicative (σ →₀ ℤ)]`; the target is the product group of units of the value
 algebra. -/
-@[expose] noncomputable def baseChangePointsMulEquiv :
+noncomputable def baseChangePointsMulEquiv :
     WithConv (K ⊗[k] MonoidAlgebra k (Multiplicative (σ →₀ ℤ)) →ₐ[K] A) ≃* (σ → Aˣ) :=
   (DiagonalizableGroup.baseChangePointsMulEquiv (k := k) (K := K) (A := A)
       (G := Multiplicative (σ →₀ ℤ))).trans freeAbelianCharEquiv

--- a/TauCeti/Algebra/AlgebraicGroup/SplitTorusBaseChange.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/SplitTorusBaseChange.lean
@@ -32,7 +32,7 @@ algebra over `K`") and Layer 4 ("Tori: split ... the character lattice `X*(T)`")
   base-changed points of the rank-`σ` split torus to coordinate families `σ → Aˣ`.
 * `TauCeti.SplitTorus.baseChangePointsMulEquiv_apply_coe`: the equivalence reads a point on
   the base-changed standard coordinate generator.
-* `TauCeti.SplitTorus.baseChangePointsMulEquiv_symm_apply_single`: the inverse equivalence
+* `TauCeti.SplitTorus.baseChangePointsMulEquiv_symm_apply_single_one`: the inverse equivalence
   takes each standard coordinate generator to the chosen coordinate.
 * `TauCeti.SplitTorus.baseChangePointsMulEquiv_mapValue`: the equivalence is natural in the
   value algebra.
@@ -98,7 +98,7 @@ theorem baseChangePointsMulEquiv_symm_apply_tmul_single (c : σ → Aˣ) (s : K)
 /-- The inverse base-changed split-torus points equivalence takes the standard coordinate
 generator indexed by `i` to the chosen coordinate `c i`. -/
 @[simp]
-theorem baseChangePointsMulEquiv_symm_apply_single (c : σ → Aˣ) (i : σ) :
+theorem baseChangePointsMulEquiv_symm_apply_single_one (c : σ → Aˣ) (i : σ) :
     ((baseChangePointsMulEquiv (k := k) (K := K) (A := A) (σ := σ)).symm c).ofConv
         (1 ⊗ₜ[k] MonoidAlgebra.single (Multiplicative.ofAdd (Finsupp.single i 1)) (1 : k)) =
       (c i : A) := by


### PR DESCRIPTION
This PR computes the base-changed functor of points of the rank-`σ` split torus. It specializes the existing diagonalizable-group base-change equivalence to `D(Multiplicative (σ →₀ ℤ))`, then composes with the free-abelian character equivalence to identify convolution points of `K ⊗[k] k[Multiplicative (σ →₀ ℤ)]` with coordinate families `σ → Aˣ`. The API records evaluation on the base-changed standard coordinate generators, inverse evaluation on arbitrary group-algebra basis elements, naturality in the value algebra, and the finite-rank `Fin n` example.

It advances `TauCetiRoadmap/ReductiveGroups/README.md`, Layer 0 item “Base change. `K ⊗[k] A` as a Hopf algebra over `K`” and Layer 4 item “Tori: split and non-split; the character lattice `X*(T)` and cocharacter lattice `X_*(T)` with their perfect pairing”. I chose this as the lowest-hanging distinct ReductiveGroups target after checking open and recently merged PRs: open #383 covers Hopf-ideal comaps, and merged #386 covers roots-of-unity base change, while split-torus base change is the analogous missing worked-example prerequisite for the torus lane.

No Mathlib infrastructure is vendored. The proof reuses Tau Ceti's `DiagonalizableGroup.baseChangePointsMulEquiv`, `SplitTorus.pointsMulEquiv`, and `freeAbelianCharEquiv`; the latter is built from Mathlib's `Finsupp.liftAddHom` and `zmultiplesHom`.

Local verification: `lake exe cache get` completed with `No files to download` and `Already decompressed 8585 file(s)`; `lake build` completed with `Build completed successfully (4194 jobs).`; `lake exe axioms` completed with `axioms: audited 4682 TauCeti declaration(s); all within the allowlist [propext, Classical.choice, Quot.sound].`

<!--tauceti-target:v1 {"focus":"ReductiveGroups","id":"split-torus-base-change"}-->

🤖 Prepared with Codex
