### PR TITLE
feat: add Abel-Jacobi basepoint changes

### DIFF
--- a/TauCeti/AlgebraicGeometry/WeilDivisor.lean
+++ b/TauCeti/AlgebraicGeometry/WeilDivisor.lean
@@ -373,6 +373,16 @@ lemma coe_degreeZeroSubgroup_eq_zero_of_isEffective {D : degreeZeroSubgroup X}
 lemma pointDifference_self (x : X) : pointDifference x x = 0 := by
   simp [pointDifference]
 
+/-- Point differences telescope additively: `[x] - [y] + ([y] - [z]) = [x] - [z]`. -/
+@[simp]
+lemma pointDifference_add_pointDifference_cancel (x y z : X) :
+    pointDifference x y + pointDifference y z = pointDifference x z := by
+  simp [pointDifference, sub_eq_add_neg, add_assoc, add_left_comm]
+
+/-- Reversing a point difference negates it. -/
+lemma pointDifference_swap (x y : X) : pointDifference y x = -pointDifference x y := by
+  simp [pointDifference, sub_eq_add_neg, add_comm]
+
 @[simp]
 lemma coeff_pointDifference_left (x y : X) :
     coeff (pointDifference x y) x = 1 - coeff (ofPoint y) x := by
@@ -497,8 +507,7 @@ lemma pointDifference_mem_weightedDegreeZeroSubgroup {w : X → ℤ} {x y : X}
 For the geometric weight `w x = [κ(x) : k]` and a rational base point `x₀` with `w x₀ = 1`,
 this is the degree-zero divisor underlying the Abel-Jacobi class of the closed point `x`.
 In the algebraically closed/unweighted specialization, this recovers `pointDifference x x₀`. -/
-@[expose] noncomputable def weightedPointBaseDifference (w : X → ℤ) (x₀ x : X) :
-    WeilDivisor X :=
+noncomputable def weightedPointBaseDifference (w : X → ℤ) (x₀ x : X) : WeilDivisor X :=
   ofPoint x - w x • ofPoint x₀
 
 /-- At the constant weight `1`, the degree-corrected point divisor is the usual point
@@ -507,6 +516,12 @@ difference. This simp lemma lets unweighted API reuse the weighted construction.
 lemma weightedPointBaseDifference_eq_pointDifference (x₀ x : X) :
     weightedPointBaseDifference (fun _ : X => (1 : ℤ)) x₀ x = pointDifference x x₀ := by
   simp [weightedPointBaseDifference, pointDifference]
+
+/-- If the point has weight `1`, the degree-corrected point divisor is the usual point
+difference. -/
+lemma weightedPointBaseDifference_eq_pointDifference_of_weight_eq_one {w : X → ℤ} {x₀ x : X}
+    (hx : w x = 1) : weightedPointBaseDifference w x₀ x = pointDifference x x₀ := by
+  simp [weightedPointBaseDifference, pointDifference, hx]
 
 /-- Coefficients of the degree-corrected point divisor, used as the pointwise simp form of
 `weightedPointBaseDifference`. -/
@@ -552,6 +567,21 @@ lemma weightedPointBaseDifference_mem_weightedDegreeZeroSubgroup {w : X → ℤ}
     (hx₀ : w x₀ = 1) (x : X) :
     weightedPointBaseDifference w x₀ x ∈ weightedDegreeZeroSubgroup w := by
   simp [hx₀]
+
+/-- Changing the base point in the weighted point-base divisor translates it by
+`w(x) • ([x₀] - [y₀])`. -/
+lemma weightedPointBaseDifference_change_base (w : X → ℤ) (x₀ y₀ x : X) :
+    weightedPointBaseDifference w y₀ x =
+      weightedPointBaseDifference w x₀ x + w x • pointDifference x₀ y₀ := by
+  simp [weightedPointBaseDifference, pointDifference, sub_eq_add_neg, add_assoc,
+    add_left_comm, add_comm]
+
+/-- The difference between the weighted point-base divisors for two base points is
+`w(x) • ([x₀] - [y₀])`. -/
+lemma weightedPointBaseDifference_sub_change_base (w : X → ℤ) (x₀ y₀ x : X) :
+    weightedPointBaseDifference w y₀ x - weightedPointBaseDifference w x₀ x =
+      w x • pointDifference x₀ y₀ := by
+  rw [weightedPointBaseDifference_change_base, add_sub_cancel_left]
 
 /-- Pushforward as a homomorphism on weighted degree-zero divisors, when the target weight
 pulls back to the source weight. -/

--- a/TauCeti/AlgebraicGeometry/WeilDivisor.lean
+++ b/TauCeti/AlgebraicGeometry/WeilDivisor.lean
@@ -584,6 +584,14 @@ lemma weightedPointBaseDifference_sub_change_base (w : X → ℤ) (x₀ y₀ x :
       w x • pointDifference x₀ y₀ := by
   rw [weightedPointBaseDifference_change_base, add_sub_cancel_left]
 
+/-- Subtracting two degree-corrected point divisors with the same base point cancels the base
+term when the two points have equal weight. -/
+lemma weightedPointBaseDifference_sub_same_base (w : X → ℤ) {x₀ x y : X} (hxy : w x = w y) :
+    weightedPointBaseDifference w x₀ x - weightedPointBaseDifference w x₀ y =
+      pointDifference x y := by
+  simp [weightedPointBaseDifference, pointDifference, hxy, sub_eq_add_neg, add_assoc,
+    add_left_comm, add_comm]
+
 /-- Pushforward as a homomorphism on weighted degree-zero divisors, when the target weight
 pulls back to the source weight. -/
 @[expose] noncomputable def pushforwardWeightedDegreeZero (wX : X → ℤ) (wY : Y → ℤ) (f : X → Y)

--- a/TauCeti/AlgebraicGeometry/WeilDivisor.lean
+++ b/TauCeti/AlgebraicGeometry/WeilDivisor.lean
@@ -519,6 +519,7 @@ lemma weightedPointBaseDifference_eq_pointDifference (x₀ x : X) :
 
 /-- If the point has weight `1`, the degree-corrected point divisor is the usual point
 difference. -/
+@[simp]
 lemma weightedPointBaseDifference_eq_pointDifference_of_weight_eq_one {w : X → ℤ} {x₀ x : X}
     (hx : w x = 1) : weightedPointBaseDifference w x₀ x = pointDifference x x₀ := by
   simp [weightedPointBaseDifference, pointDifference, hx]

--- a/TauCeti/AlgebraicGeometry/WeilDivisor.lean
+++ b/TauCeti/AlgebraicGeometry/WeilDivisor.lean
@@ -497,7 +497,8 @@ lemma pointDifference_mem_weightedDegreeZeroSubgroup {w : X → ℤ} {x y : X}
 For the geometric weight `w x = [κ(x) : k]` and a rational base point `x₀` with `w x₀ = 1`,
 this is the degree-zero divisor underlying the Abel-Jacobi class of the closed point `x`.
 In the algebraically closed/unweighted specialization, this recovers `pointDifference x x₀`. -/
-noncomputable def weightedPointBaseDifference (w : X → ℤ) (x₀ x : X) : WeilDivisor X :=
+@[expose] noncomputable def weightedPointBaseDifference (w : X → ℤ) (x₀ x : X) :
+    WeilDivisor X :=
   ofPoint x - w x • ofPoint x₀
 
 /-- At the constant weight `1`, the degree-corrected point divisor is the usual point

--- a/TauCeti/AlgebraicGeometry/WeilDivisor/BasepointChange.lean
+++ b/TauCeti/AlgebraicGeometry/WeilDivisor/BasepointChange.lean
@@ -47,32 +47,33 @@ namespace OrderSystem
 
 variable (S : OrderSystem X G)
 
-/-- The degree-zero class `[x₀] - [y₀]` measuring the translation between Abel-Jacobi maps
-normalized at two weight-one base points. -/
+/-- The degree-zero class `[x₀] - [y₀]` measuring the translation between two equal-weight
+base points. -/
 noncomputable def weightedBasepointChangeClass (w : X → ℤ) (hdeg : S.IsWeightedDegreeZero w)
-    {x₀ y₀ : X} (_hx₀ : w x₀ = 1) (hy₀ : w y₀ = 1) : picZero w hdeg :=
-  S.weightedAbelJacobiClass w hdeg hy₀ x₀
+    {x₀ y₀ : X} (hxy : w x₀ = w y₀) : picZero w hdeg :=
+  ⟨S.divisorClass (pointDifference x₀ y₀), by
+    rw [divisorClass_mem_picZero]
+    simpa using pointDifference_mem_weightedDegreeZeroSubgroup (w := w) (x := x₀) (y := y₀) hxy⟩
 
 @[simp]
 lemma coe_weightedBasepointChangeClass (w : X → ℤ) (hdeg : S.IsWeightedDegreeZero w)
-    {x₀ y₀ : X} (hx₀ : w x₀ = 1) (hy₀ : w y₀ = 1) :
-    (S.weightedBasepointChangeClass w hdeg hx₀ hy₀ : S.ClassGroup) =
+    {x₀ y₀ : X} (hxy : w x₀ = w y₀) :
+    (S.weightedBasepointChangeClass w hdeg hxy : S.ClassGroup) =
       S.divisorClass (pointDifference x₀ y₀) :=
-  by
-    simp [weightedBasepointChangeClass,
-      weightedPointBaseDifference_eq_pointDifference_of_weight_eq_one hx₀]
+  rfl
 
 @[simp]
 lemma weightedBasepointChangeClass_self (w : X → ℤ) (hdeg : S.IsWeightedDegreeZero w)
-    {x₀ : X} (hx₀ : w x₀ = 1) :
-    S.weightedBasepointChangeClass w hdeg hx₀ hx₀ = 0 := by
-  exact S.weightedAbelJacobiClass_base w hdeg hx₀
+    {x₀ : X} :
+    S.weightedBasepointChangeClass w hdeg (x₀ := x₀) rfl = 0 := by
+  apply Subtype.ext
+  simp
 
 /-- Reversing the two base points negates the base-point-change class. -/
 lemma weightedBasepointChangeClass_swap (w : X → ℤ) (hdeg : S.IsWeightedDegreeZero w)
-    {x₀ y₀ : X} (hx₀ : w x₀ = 1) (hy₀ : w y₀ = 1) :
-    S.weightedBasepointChangeClass w hdeg hy₀ hx₀ =
-      -S.weightedBasepointChangeClass w hdeg hx₀ hy₀ := by
+    {x₀ y₀ : X} (hxy : w x₀ = w y₀) :
+    S.weightedBasepointChangeClass w hdeg hxy.symm =
+      -S.weightedBasepointChangeClass w hdeg hxy := by
   apply Subtype.ext
   simp only [coe_weightedBasepointChangeClass, NegMemClass.coe_neg]
   rw [← map_neg, ← pointDifference_swap]
@@ -80,10 +81,10 @@ lemma weightedBasepointChangeClass_swap (w : X → ℤ) (hdeg : S.IsWeightedDegr
 /-- Base-point-change classes compose: the translation from `x₀` to `z₀` is the sum of the
 translations from `x₀` to `y₀` and from `y₀` to `z₀`. -/
 lemma weightedBasepointChangeClass_add (w : X → ℤ) (hdeg : S.IsWeightedDegreeZero w)
-    {x₀ y₀ z₀ : X} (hx₀ : w x₀ = 1) (hy₀ : w y₀ = 1) (hz₀ : w z₀ = 1) :
-    S.weightedBasepointChangeClass w hdeg hx₀ hy₀ +
-        S.weightedBasepointChangeClass w hdeg hy₀ hz₀ =
-      S.weightedBasepointChangeClass w hdeg hx₀ hz₀ := by
+    {x₀ y₀ z₀ : X} (hxy : w x₀ = w y₀) (hyz : w y₀ = w z₀) :
+    S.weightedBasepointChangeClass w hdeg hxy +
+        S.weightedBasepointChangeClass w hdeg hyz =
+      S.weightedBasepointChangeClass w hdeg (hxy.trans hyz) := by
   apply Subtype.ext
   simp only [coe_weightedBasepointChangeClass, AddMemClass.coe_add]
   rw [← map_add, pointDifference_add_pointDifference_cancel]
@@ -94,7 +95,7 @@ lemma weightedAbelJacobiClass_change_base (w : X → ℤ) (hdeg : S.IsWeightedDe
     {x₀ y₀ : X} (hx₀ : w x₀ = 1) (hy₀ : w y₀ = 1) (x : X) :
     S.weightedAbelJacobiClass w hdeg hy₀ x =
       S.weightedAbelJacobiClass w hdeg hx₀ x +
-      w x • S.weightedBasepointChangeClass w hdeg hx₀ hy₀ := by
+      w x • S.weightedBasepointChangeClass w hdeg (hx₀.trans hy₀.symm) := by
   apply Subtype.ext
   simp only [coe_weightedAbelJacobiClass, coe_weightedBasepointChangeClass,
     AddMemClass.coe_add, AddSubgroupClass.coe_zsmul]
@@ -105,16 +106,17 @@ the new base point. -/
 lemma weightedAbelJacobiClass_base_eq_basepointChangeClass (w : X → ℤ)
     (hdeg : S.IsWeightedDegreeZero w) {x₀ y₀ : X} (hx₀ : w x₀ = 1) (hy₀ : w y₀ = 1) :
     S.weightedAbelJacobiClass w hdeg hy₀ x₀ =
-      S.weightedBasepointChangeClass w hdeg hx₀ hy₀ := by
-  rfl
+      S.weightedBasepointChangeClass w hdeg (hx₀.trans hy₀.symm) := by
+  apply Subtype.ext
+  simp [hx₀]
 
 /-- The base-point-change class equals the Abel-Jacobi class of the old base point with respect
 to the new base point. -/
 lemma weightedBasepointChangeClass_eq_abelJacobiClass (w : X → ℤ)
     (hdeg : S.IsWeightedDegreeZero w) {x₀ y₀ : X} (hx₀ : w x₀ = 1) (hy₀ : w y₀ = 1) :
-    S.weightedBasepointChangeClass w hdeg hx₀ hy₀ =
+    S.weightedBasepointChangeClass w hdeg (hx₀.trans hy₀.symm) =
       S.weightedAbelJacobiClass w hdeg hy₀ x₀ := by
-  rfl
+  rw [S.weightedAbelJacobiClass_base_eq_basepointChangeClass w hdeg hx₀ hy₀]
 
 /-- In the class group, the difference between two weighted Abel-Jacobi classes with different
 base points is `w(x)` times the class `[x₀] - [y₀]`. -/
@@ -132,7 +134,7 @@ lemma weightedAbelJacobiClass_sub_change_base_coe (w : X → ℤ)
 /-- The unweighted base-point-change class `[x₀] - [y₀]` in the abstract unweighted `Pic⁰`. -/
 noncomputable def unweightedBasepointChangeClass (hdeg : S.IsUnweightedDegreeZero) (x₀ y₀ : X) :
     unweightedPicZero hdeg :=
-  S.weightedBasepointChangeClass (fun _ => (1 : ℤ)) hdeg (x₀ := x₀) (y₀ := y₀) rfl rfl
+  S.weightedBasepointChangeClass (fun _ => (1 : ℤ)) hdeg (x₀ := x₀) (y₀ := y₀) rfl
 
 @[simp]
 lemma coe_unweightedBasepointChangeClass (hdeg : S.IsUnweightedDegreeZero) (x₀ y₀ : X) :
@@ -144,8 +146,9 @@ lemma coe_unweightedBasepointChangeClass (hdeg : S.IsUnweightedDegreeZero) (x₀
 @[simp]
 lemma unweightedBasepointChangeClass_self (hdeg : S.IsUnweightedDegreeZero) (x₀ : X) :
     S.unweightedBasepointChangeClass hdeg x₀ x₀ = 0 := by
-  exact S.weightedBasepointChangeClass_self (fun _ : X => (1 : ℤ)) hdeg rfl
+  exact S.weightedBasepointChangeClass_self (fun _ : X => (1 : ℤ)) hdeg
 
+/-- Reversing the two unweighted base points negates the base-point-change class. -/
 lemma unweightedBasepointChangeClass_swap (hdeg : S.IsUnweightedDegreeZero) (x₀ y₀ : X) :
     S.unweightedBasepointChangeClass hdeg y₀ x₀ =
       -S.unweightedBasepointChangeClass hdeg x₀ y₀ := by
@@ -188,7 +191,8 @@ lemma unweightedAbelJacobiClass_eq_basepointChangeClass (hdeg : S.IsUnweightedDe
     (x y : X) :
     S.unweightedAbelJacobiClass hdeg y x =
       S.unweightedBasepointChangeClass hdeg x y := by
-  rfl
+  apply Subtype.ext
+  simp
 
 end OrderSystem
 

--- a/TauCeti/AlgebraicGeometry/WeilDivisor/BasepointChange.lean
+++ b/TauCeti/AlgebraicGeometry/WeilDivisor/BasepointChange.lean
@@ -105,7 +105,7 @@ lemma weightedAbelJacobiClass_change_base (w : X → ℤ) (hdeg : S.IsWeightedDe
 
 /-- The base-point-change class is the Abel-Jacobi class of the old base point with respect to
 the new base point. -/
-lemma weightedAbelJacobiClass_base_eq_basepointChangeClass (w : X → ℤ)
+lemma weightedAbelJacobiClass_oldBase_eq_basepointChangeClass (w : X → ℤ)
     (hdeg : S.IsWeightedDegreeZero w) {x₀ y₀ : X} (hx₀ : w x₀ = 1) (hy₀ : w y₀ = 1) :
     S.weightedAbelJacobiClass w hdeg hy₀ x₀ =
       S.weightedBasepointChangeClass w hdeg (hx₀.trans hy₀.symm) := by
@@ -118,7 +118,7 @@ lemma weightedBasepointChangeClass_eq_abelJacobiClass (w : X → ℤ)
     (hdeg : S.IsWeightedDegreeZero w) {x₀ y₀ : X} (hx₀ : w x₀ = 1) (hy₀ : w y₀ = 1) :
     S.weightedBasepointChangeClass w hdeg (hx₀.trans hy₀.symm) =
       S.weightedAbelJacobiClass w hdeg hy₀ x₀ := by
-  rw [S.weightedAbelJacobiClass_base_eq_basepointChangeClass w hdeg hx₀ hy₀]
+  rw [S.weightedAbelJacobiClass_oldBase_eq_basepointChangeClass w hdeg hx₀ hy₀]
 
 /-- In the class group, the difference between two weighted Abel-Jacobi classes with different
 base points is `w(x)` times the class `[x₀] - [y₀]`. -/
@@ -130,6 +130,16 @@ lemma weightedAbelJacobiClass_sub_change_base_coe (w : X → ℤ)
       w x • S.divisorClass (pointDifference x₀ y₀) := by
   rw [coe_weightedAbelJacobiClass, coe_weightedAbelJacobiClass, ← map_zsmul, ← map_sub,
     weightedPointBaseDifference_sub_change_base]
+
+/-- The difference between two weighted Abel-Jacobi classes with the same base point is the
+class `[x] - [y]` when the two points have equal weight. -/
+lemma weightedAbelJacobiClass_sub_coe (w : X → ℤ) (hdeg : S.IsWeightedDegreeZero w)
+    {x₀ x y : X} (hx₀ : w x₀ = 1) (hxy : w x = w y) :
+    (S.weightedAbelJacobiClass w hdeg hx₀ x : S.ClassGroup) -
+        (S.weightedAbelJacobiClass w hdeg hx₀ y : S.ClassGroup) =
+      S.divisorClass (pointDifference x y) := by
+  rw [coe_weightedAbelJacobiClass, coe_weightedAbelJacobiClass, ← map_sub,
+    weightedPointBaseDifference_sub_same_base w hxy]
 
 /-! ### Unweighted specialization -/
 
@@ -154,8 +164,9 @@ lemma unweightedAbelJacobiClass_sub_coe (hdeg : S.IsUnweightedDegreeZero) (x₀ 
     (S.unweightedAbelJacobiClass hdeg x₀ x : S.ClassGroup) -
         (S.unweightedAbelJacobiClass hdeg x₀ y : S.ClassGroup) =
       S.divisorClass (pointDifference x y) := by
-  rw [coe_unweightedAbelJacobiClass, coe_unweightedAbelJacobiClass, ← map_sub]
-  simp [pointDifference, sub_eq_add_neg, add_assoc, add_left_comm, add_comm]
+  simpa only [unweightedAbelJacobiClass] using
+    S.weightedAbelJacobiClass_sub_coe (fun _ : X => (1 : ℤ)) hdeg (x₀ := x₀)
+      (x := x) (y := y) rfl rfl
 
 end OrderSystem
 

--- a/TauCeti/AlgebraicGeometry/WeilDivisor/BasepointChange.lean
+++ b/TauCeti/AlgebraicGeometry/WeilDivisor/BasepointChange.lean
@@ -41,41 +41,6 @@ namespace WeilDivisor
 
 variable {X G : Type*} [AddCommGroup G]
 
-/-! ### Divisor-level base-point identities -/
-
-/-- Point differences compose additively: `[x] - [y] + ([y] - [z]) = [x] - [z]`. -/
-@[simp]
-lemma pointDifference_add_pointDifference (x y z : X) :
-    pointDifference x y + pointDifference y z = pointDifference x z := by
-  simp [pointDifference, sub_eq_add_neg, add_assoc, add_left_comm]
-
-/-- Reversing a point difference negates it. -/
-lemma pointDifference_swap (x y : X) : pointDifference y x = -pointDifference x y := by
-  simp [pointDifference, sub_eq_add_neg, add_comm]
-
-/-- Changing the base point in the weighted point-base divisor translates it by
-`w(x) • ([x₀] - [y₀])`. -/
-lemma weightedPointBaseDifference_change_base (w : X → ℤ) (x₀ y₀ x : X) :
-    weightedPointBaseDifference w y₀ x =
-      weightedPointBaseDifference w x₀ x + w x • pointDifference x₀ y₀ := by
-  classical
-  ext z
-  simp [weightedPointBaseDifference, pointDifference, sub_eq_add_neg, add_assoc,
-    add_left_comm, add_comm]
-
-/-- The difference between the weighted point-base divisors for two base points is
-`w(x) • ([x₀] - [y₀])`. -/
-lemma weightedPointBaseDifference_sub_change_base (w : X → ℤ) (x₀ y₀ x : X) :
-    weightedPointBaseDifference w y₀ x - weightedPointBaseDifference w x₀ x =
-      w x • pointDifference x₀ y₀ := by
-  rw [weightedPointBaseDifference_change_base, add_sub_cancel_left]
-
-/-- If two base points have the same weight, their point difference has weighted degree zero. -/
-@[simp]
-lemma basepointDifference_mem_weightedDegreeZeroSubgroup {w : X → ℤ} {x₀ y₀ : X}
-    (h : w x₀ = w y₀) : pointDifference x₀ y₀ ∈ weightedDegreeZeroSubgroup w := by
-  simpa using pointDifference_mem_weightedDegreeZeroSubgroup (w := w) (x := x₀) (y := y₀) h
-
 /-! ### Class-level base-point changes -/
 
 namespace OrderSystem
@@ -85,24 +50,23 @@ variable (S : OrderSystem X G)
 /-- The degree-zero class `[x₀] - [y₀]` measuring the translation between Abel-Jacobi maps
 normalized at two weight-one base points. -/
 noncomputable def weightedBasepointChangeClass (w : X → ℤ) (hdeg : S.IsWeightedDegreeZero w)
-    {x₀ y₀ : X} (hx₀ : w x₀ = 1) (hy₀ : w y₀ = 1) : picZero w hdeg :=
-  ⟨S.divisorClass (pointDifference x₀ y₀), by
-    rw [divisorClass_mem_picZero]
-    exact basepointDifference_mem_weightedDegreeZeroSubgroup (hx₀.trans hy₀.symm)⟩
+    {x₀ y₀ : X} (_hx₀ : w x₀ = 1) (hy₀ : w y₀ = 1) : picZero w hdeg :=
+  S.weightedAbelJacobiClass w hdeg hy₀ x₀
 
 @[simp]
 lemma coe_weightedBasepointChangeClass (w : X → ℤ) (hdeg : S.IsWeightedDegreeZero w)
     {x₀ y₀ : X} (hx₀ : w x₀ = 1) (hy₀ : w y₀ = 1) :
     (S.weightedBasepointChangeClass w hdeg hx₀ hy₀ : S.ClassGroup) =
       S.divisorClass (pointDifference x₀ y₀) :=
-  rfl
+  by
+    simp [weightedBasepointChangeClass,
+      weightedPointBaseDifference_eq_pointDifference_of_weight_eq_one hx₀]
 
 @[simp]
 lemma weightedBasepointChangeClass_self (w : X → ℤ) (hdeg : S.IsWeightedDegreeZero w)
     {x₀ : X} (hx₀ : w x₀ = 1) :
     S.weightedBasepointChangeClass w hdeg hx₀ hx₀ = 0 := by
-  apply Subtype.ext
-  simp [weightedBasepointChangeClass]
+  exact S.weightedAbelJacobiClass_base w hdeg hx₀
 
 /-- Reversing the two base points negates the base-point-change class. -/
 lemma weightedBasepointChangeClass_swap (w : X → ℤ) (hdeg : S.IsWeightedDegreeZero w)
@@ -110,7 +74,7 @@ lemma weightedBasepointChangeClass_swap (w : X → ℤ) (hdeg : S.IsWeightedDegr
     S.weightedBasepointChangeClass w hdeg hy₀ hx₀ =
       -S.weightedBasepointChangeClass w hdeg hx₀ hy₀ := by
   apply Subtype.ext
-  change S.divisorClass (pointDifference y₀ x₀) = -S.divisorClass (pointDifference x₀ y₀)
+  simp only [coe_weightedBasepointChangeClass, NegMemClass.coe_neg]
   rw [← map_neg, ← pointDifference_swap]
 
 /-- Base-point-change classes compose: the translation from `x₀` to `z₀` is the sum of the
@@ -121,9 +85,8 @@ lemma weightedBasepointChangeClass_add (w : X → ℤ) (hdeg : S.IsWeightedDegre
         S.weightedBasepointChangeClass w hdeg hy₀ hz₀ =
       S.weightedBasepointChangeClass w hdeg hx₀ hz₀ := by
   apply Subtype.ext
-  change S.divisorClass (pointDifference x₀ y₀) + S.divisorClass (pointDifference y₀ z₀) =
-    S.divisorClass (pointDifference x₀ z₀)
-  rw [← map_add, pointDifference_add_pointDifference]
+  simp only [coe_weightedBasepointChangeClass, AddMemClass.coe_add]
+  rw [← map_add, pointDifference_add_pointDifference_cancel]
 
 /-- Changing the Abel-Jacobi base point from `x₀` to `y₀` adds `w(x)` times the class
 `[x₀] - [y₀]`. This is the weighted closed-point form, where `w(x)` is the residue degree. -/
@@ -133,11 +96,25 @@ lemma weightedAbelJacobiClass_change_base (w : X → ℤ) (hdeg : S.IsWeightedDe
       S.weightedAbelJacobiClass w hdeg hx₀ x +
       w x • S.weightedBasepointChangeClass w hdeg hx₀ hy₀ := by
   apply Subtype.ext
-  change S.divisorClass (weightedPointBaseDifference w y₀ x) =
-    (S.weightedAbelJacobiClass w hdeg hx₀ x : S.ClassGroup) +
-      w x • (S.weightedBasepointChangeClass w hdeg hx₀ hy₀ : S.ClassGroup)
-  rw [coe_weightedAbelJacobiClass, coe_weightedBasepointChangeClass]
+  simp only [coe_weightedAbelJacobiClass, coe_weightedBasepointChangeClass,
+    AddMemClass.coe_add, AddSubgroupClass.coe_zsmul]
   rw [← map_zsmul, ← map_add, ← weightedPointBaseDifference_change_base]
+
+/-- The base-point-change class is the Abel-Jacobi class of the old base point with respect to
+the new base point. -/
+lemma weightedAbelJacobiClass_base_eq_basepointChangeClass (w : X → ℤ)
+    (hdeg : S.IsWeightedDegreeZero w) {x₀ y₀ : X} (hx₀ : w x₀ = 1) (hy₀ : w y₀ = 1) :
+    S.weightedAbelJacobiClass w hdeg hy₀ x₀ =
+      S.weightedBasepointChangeClass w hdeg hx₀ hy₀ := by
+  rfl
+
+/-- The base-point-change class equals the Abel-Jacobi class of the old base point with respect
+to the new base point. -/
+lemma weightedBasepointChangeClass_eq_abelJacobiClass (w : X → ℤ)
+    (hdeg : S.IsWeightedDegreeZero w) {x₀ y₀ : X} (hx₀ : w x₀ = 1) (hy₀ : w y₀ = 1) :
+    S.weightedBasepointChangeClass w hdeg hx₀ hy₀ =
+      S.weightedAbelJacobiClass w hdeg hy₀ x₀ := by
+  rfl
 
 /-- In the class group, the difference between two weighted Abel-Jacobi classes with different
 base points is `w(x)` times the class `[x₀] - [y₀]`. -/
@@ -161,19 +138,19 @@ noncomputable def unweightedBasepointChangeClass (hdeg : S.IsUnweightedDegreeZer
 lemma coe_unweightedBasepointChangeClass (hdeg : S.IsUnweightedDegreeZero) (x₀ y₀ : X) :
     (S.unweightedBasepointChangeClass hdeg x₀ y₀ : S.ClassGroup) =
       S.divisorClass (pointDifference x₀ y₀) :=
-  rfl
+  by
+    simp [unweightedBasepointChangeClass]
 
 @[simp]
 lemma unweightedBasepointChangeClass_self (hdeg : S.IsUnweightedDegreeZero) (x₀ : X) :
     S.unweightedBasepointChangeClass hdeg x₀ x₀ = 0 := by
-  apply Subtype.ext
-  simp [unweightedBasepointChangeClass]
+  exact S.weightedBasepointChangeClass_self (fun _ : X => (1 : ℤ)) hdeg rfl
 
 lemma unweightedBasepointChangeClass_swap (hdeg : S.IsUnweightedDegreeZero) (x₀ y₀ : X) :
     S.unweightedBasepointChangeClass hdeg y₀ x₀ =
       -S.unweightedBasepointChangeClass hdeg x₀ y₀ := by
   apply Subtype.ext
-  change S.divisorClass (pointDifference y₀ x₀) = -S.divisorClass (pointDifference x₀ y₀)
+  simp only [coe_unweightedBasepointChangeClass, NegMemClass.coe_neg]
   rw [← map_neg, ← pointDifference_swap]
 
 /-- Unweighted base-point-change classes compose additively. -/
@@ -182,9 +159,8 @@ lemma unweightedBasepointChangeClass_add (hdeg : S.IsUnweightedDegreeZero) (x₀
         S.unweightedBasepointChangeClass hdeg y₀ z₀ =
       S.unweightedBasepointChangeClass hdeg x₀ z₀ := by
   apply Subtype.ext
-  change S.divisorClass (pointDifference x₀ y₀) + S.divisorClass (pointDifference y₀ z₀) =
-    S.divisorClass (pointDifference x₀ z₀)
-  rw [← map_add, pointDifference_add_pointDifference]
+  simp only [coe_unweightedBasepointChangeClass, AddMemClass.coe_add]
+  rw [← map_add, pointDifference_add_pointDifference_cancel]
 
 /-- Changing the base point in the unweighted abstract Abel-Jacobi class is translation by
 `[x₀] - [y₀]`. -/
@@ -193,11 +169,9 @@ lemma unweightedAbelJacobiClass_change_base (hdeg : S.IsUnweightedDegreeZero) (x
       S.unweightedAbelJacobiClass hdeg x₀ x +
         S.unweightedBasepointChangeClass hdeg x₀ y₀ := by
   apply Subtype.ext
-  rw [coe_unweightedAbelJacobiClass]
-  change S.divisorClass (pointDifference x y₀) =
-    (S.unweightedAbelJacobiClass hdeg x₀ x : S.ClassGroup) +
-      (S.unweightedBasepointChangeClass hdeg x₀ y₀ : S.ClassGroup)
-  rw [coe_unweightedAbelJacobiClass, coe_unweightedBasepointChangeClass, ← map_add]
+  simp only [coe_unweightedAbelJacobiClass, coe_unweightedBasepointChangeClass,
+    AddMemClass.coe_add]
+  rw [← map_add]
   simp [pointDifference, sub_eq_add_neg, add_assoc, add_left_comm, add_comm]
 
 /-- The class `[x] - [y]` is the difference of two Abel-Jacobi classes with the same base point. -/
@@ -214,8 +188,7 @@ lemma unweightedAbelJacobiClass_eq_basepointChangeClass (hdeg : S.IsUnweightedDe
     (x y : X) :
     S.unweightedAbelJacobiClass hdeg y x =
       S.unweightedBasepointChangeClass hdeg x y := by
-  apply Subtype.ext
-  simp [unweightedAbelJacobiClass, unweightedBasepointChangeClass]
+  rfl
 
 end OrderSystem
 

--- a/TauCeti/AlgebraicGeometry/WeilDivisor/BasepointChange.lean
+++ b/TauCeti/AlgebraicGeometry/WeilDivisor/BasepointChange.lean
@@ -18,8 +18,10 @@ the degree-corrected point divisors satisfy
 `[x] - w(x)[y₀] = ([x] - w(x)[x₀]) + w(x)([x₀] - [y₀])`.
 
 Passing to divisor classes gives the corresponding formula in the abstract `Pic⁰` subgroup:
-changing the Abel-Jacobi base point translates the class by the degree of the point times the
-degree-zero class `[x₀] - [y₀]`.  In the unweighted/algebraically closed specialization, this is
+changing the Abel-Jacobi base point translates the class by the weight `w x` times the
+degree-zero class `[x₀] - [y₀]`.  For the geometric weight by residue-field degree, this is
+translation by the degree of the point.  In the unweighted/algebraically closed specialization,
+this is
 the familiar identity
 
 `AJ_{y₀}(x) = AJ_{x₀}(x) + AJ_{y₀}(x₀)`.
@@ -89,8 +91,8 @@ lemma weightedBasepointChangeClass_add (w : X → ℤ) (hdeg : S.IsWeightedDegre
   simp only [coe_weightedBasepointChangeClass, AddMemClass.coe_add]
   rw [← map_add, pointDifference_add_pointDifference_cancel]
 
-/-- Changing the Abel-Jacobi base point from `x₀` to `y₀` adds `w(x)` times the class
-`[x₀] - [y₀]`. This is the weighted closed-point form, where `w(x)` is the residue degree. -/
+/-- Changing the Abel-Jacobi base point from `x₀` to `y₀` adds `w x` times the class
+`[x₀] - [y₀]`. For the geometric specialization, `w x` is the residue-field degree. -/
 lemma weightedAbelJacobiClass_change_base (w : X → ℤ) (hdeg : S.IsWeightedDegreeZero w)
     {x₀ y₀ : X} (hx₀ : w x₀ = 1) (hy₀ : w y₀ = 1) (x : X) :
     S.weightedAbelJacobiClass w hdeg hy₀ x =
@@ -131,51 +133,21 @@ lemma weightedAbelJacobiClass_sub_change_base_coe (w : X → ℤ)
 
 /-! ### Unweighted specialization -/
 
-/-- The unweighted base-point-change class `[x₀] - [y₀]` in the abstract unweighted `Pic⁰`. -/
-noncomputable def unweightedBasepointChangeClass (hdeg : S.IsUnweightedDegreeZero) (x₀ y₀ : X) :
-    unweightedPicZero hdeg :=
-  S.weightedBasepointChangeClass (fun _ => (1 : ℤ)) hdeg (x₀ := x₀) (y₀ := y₀) rfl
-
-@[simp]
-lemma coe_unweightedBasepointChangeClass (hdeg : S.IsUnweightedDegreeZero) (x₀ y₀ : X) :
-    (S.unweightedBasepointChangeClass hdeg x₀ y₀ : S.ClassGroup) =
-      S.divisorClass (pointDifference x₀ y₀) :=
-  by
-    simp [unweightedBasepointChangeClass]
-
-@[simp]
-lemma unweightedBasepointChangeClass_self (hdeg : S.IsUnweightedDegreeZero) (x₀ : X) :
-    S.unweightedBasepointChangeClass hdeg x₀ x₀ = 0 := by
-  exact S.weightedBasepointChangeClass_self (fun _ : X => (1 : ℤ)) hdeg
-
-/-- Reversing the two unweighted base points negates the base-point-change class. -/
-lemma unweightedBasepointChangeClass_swap (hdeg : S.IsUnweightedDegreeZero) (x₀ y₀ : X) :
-    S.unweightedBasepointChangeClass hdeg y₀ x₀ =
-      -S.unweightedBasepointChangeClass hdeg x₀ y₀ := by
-  apply Subtype.ext
-  simp only [coe_unweightedBasepointChangeClass, NegMemClass.coe_neg]
-  rw [← map_neg, ← pointDifference_swap]
-
-/-- Unweighted base-point-change classes compose additively. -/
-lemma unweightedBasepointChangeClass_add (hdeg : S.IsUnweightedDegreeZero) (x₀ y₀ z₀ : X) :
-    S.unweightedBasepointChangeClass hdeg x₀ y₀ +
-        S.unweightedBasepointChangeClass hdeg y₀ z₀ =
-      S.unweightedBasepointChangeClass hdeg x₀ z₀ := by
-  apply Subtype.ext
-  simp only [coe_unweightedBasepointChangeClass, AddMemClass.coe_add]
-  rw [← map_add, pointDifference_add_pointDifference_cancel]
-
 /-- Changing the base point in the unweighted abstract Abel-Jacobi class is translation by
-`[x₀] - [y₀]`. -/
+the existing Abel-Jacobi class of `x₀` based at `y₀`. -/
 lemma unweightedAbelJacobiClass_change_base (hdeg : S.IsUnweightedDegreeZero) (x₀ y₀ x : X) :
     S.unweightedAbelJacobiClass hdeg y₀ x =
       S.unweightedAbelJacobiClass hdeg x₀ x +
-        S.unweightedBasepointChangeClass hdeg x₀ y₀ := by
+        S.unweightedAbelJacobiClass hdeg y₀ x₀ := by
+  have h := S.weightedAbelJacobiClass_change_base (fun _ : X => (1 : ℤ)) hdeg (x₀ := x₀)
+    (y₀ := y₀) rfl rfl x
+  rw [S.weightedBasepointChangeClass_eq_abelJacobiClass (fun _ : X => (1 : ℤ)) hdeg
+    (x₀ := x₀) (y₀ := y₀) rfl rfl] at h
   apply Subtype.ext
-  simp only [coe_unweightedAbelJacobiClass, coe_unweightedBasepointChangeClass,
-    AddMemClass.coe_add]
-  rw [← map_add]
-  simp [pointDifference, sub_eq_add_neg, add_assoc, add_left_comm, add_comm]
+  have h' := congr_arg Subtype.val h
+  simpa only [coe_unweightedAbelJacobiClass, coe_weightedAbelJacobiClass,
+    weightedPointBaseDifference_eq_pointDifference, AddMemClass.coe_add,
+    AddSubgroupClass.coe_zsmul, one_zsmul] using h'
 
 /-- The class `[x] - [y]` is the difference of two Abel-Jacobi classes with the same base point. -/
 lemma unweightedAbelJacobiClass_sub_coe (hdeg : S.IsUnweightedDegreeZero) (x₀ x y : X) :
@@ -184,15 +156,6 @@ lemma unweightedAbelJacobiClass_sub_coe (hdeg : S.IsUnweightedDegreeZero) (x₀ 
       S.divisorClass (pointDifference x y) := by
   rw [coe_unweightedAbelJacobiClass, coe_unweightedAbelJacobiClass, ← map_sub]
   simp [pointDifference, sub_eq_add_neg, add_assoc, add_left_comm, add_comm]
-
-/-- The unweighted Abel-Jacobi class based at `y` sends `x` to the base-point-change class
-from `x` to `y`. -/
-lemma unweightedAbelJacobiClass_eq_basepointChangeClass (hdeg : S.IsUnweightedDegreeZero)
-    (x y : X) :
-    S.unweightedAbelJacobiClass hdeg y x =
-      S.unweightedBasepointChangeClass hdeg x y := by
-  apply Subtype.ext
-  simp
 
 end OrderSystem
 

--- a/TauCeti/AlgebraicGeometry/WeilDivisor/BasepointChange.lean
+++ b/TauCeti/AlgebraicGeometry/WeilDivisor/BasepointChange.lean
@@ -1,0 +1,226 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+module
+
+public import TauCeti.AlgebraicGeometry.WeilDivisor.AbelJacobi
+
+/-!
+# Changing the base point in the abstract Abel-Jacobi class
+
+This file adds the base-point-change calculus for the formal divisor-class shadow of the
+Abel-Jacobi map from `TauCeti.AlgebraicGeometry.WeilDivisor.AbelJacobi`.
+
+For a weight `w : X → ℤ`, a weight-one base point `x₀`, and another weight-one base point `y₀`,
+the degree-corrected point divisors satisfy
+
+`[x] - w(x)[y₀] = ([x] - w(x)[x₀]) + w(x)([x₀] - [y₀])`.
+
+Passing to divisor classes gives the corresponding formula in the abstract `Pic⁰` subgroup:
+changing the Abel-Jacobi base point translates the class by the degree of the point times the
+degree-zero class `[x₀] - [y₀]`.  In the unweighted/algebraically closed specialization, this is
+the familiar identity
+
+`AJ_{y₀}(x) = AJ_{x₀}(x) + AJ_{y₀}(x₀)`.
+
+This advances `TauCetiRoadmap/JacobianChallenge/README.md`, Layer A (`Pic⁰ X = ker deg`) and is
+a direct formal prerequisite for Layer F's normalized Abel-Jacobi morphism `aj : X ⟶ Jac X`,
+where choosing a rational base point forces `x₀ ↦ 0` and changing that choice should be a
+translation.  No external mathematics is vendored; the proofs use only the existing
+`WeilDivisor`, `OrderSystem.divisorClass`, and abstract Abel-Jacobi API.
+-/
+
+@[expose] public section
+
+namespace TauCeti
+
+namespace AlgebraicGeometry
+
+namespace WeilDivisor
+
+variable {X G : Type*} [AddCommGroup G]
+
+/-! ### Divisor-level base-point identities -/
+
+/-- Point differences compose additively: `[x] - [y] + ([y] - [z]) = [x] - [z]`. -/
+@[simp]
+lemma pointDifference_add_pointDifference (x y z : X) :
+    pointDifference x y + pointDifference y z = pointDifference x z := by
+  simp [pointDifference, sub_eq_add_neg, add_assoc, add_left_comm]
+
+/-- Reversing a point difference negates it. -/
+lemma pointDifference_swap (x y : X) : pointDifference y x = -pointDifference x y := by
+  simp [pointDifference, sub_eq_add_neg, add_comm]
+
+/-- Changing the base point in the weighted point-base divisor translates it by
+`w(x) • ([x₀] - [y₀])`. -/
+lemma weightedPointBaseDifference_change_base (w : X → ℤ) (x₀ y₀ x : X) :
+    weightedPointBaseDifference w y₀ x =
+      weightedPointBaseDifference w x₀ x + w x • pointDifference x₀ y₀ := by
+  classical
+  ext z
+  simp [weightedPointBaseDifference, pointDifference, sub_eq_add_neg, add_assoc,
+    add_left_comm, add_comm]
+
+/-- The difference between the weighted point-base divisors for two base points is
+`w(x) • ([x₀] - [y₀])`. -/
+lemma weightedPointBaseDifference_sub_change_base (w : X → ℤ) (x₀ y₀ x : X) :
+    weightedPointBaseDifference w y₀ x - weightedPointBaseDifference w x₀ x =
+      w x • pointDifference x₀ y₀ := by
+  rw [weightedPointBaseDifference_change_base, add_sub_cancel_left]
+
+/-- If two base points have the same weight, their point difference has weighted degree zero. -/
+@[simp]
+lemma basepointDifference_mem_weightedDegreeZeroSubgroup {w : X → ℤ} {x₀ y₀ : X}
+    (h : w x₀ = w y₀) : pointDifference x₀ y₀ ∈ weightedDegreeZeroSubgroup w := by
+  simpa using pointDifference_mem_weightedDegreeZeroSubgroup (w := w) (x := x₀) (y := y₀) h
+
+/-! ### Class-level base-point changes -/
+
+namespace OrderSystem
+
+variable (S : OrderSystem X G)
+
+/-- The degree-zero class `[x₀] - [y₀]` measuring the translation between Abel-Jacobi maps
+normalized at two weight-one base points. -/
+noncomputable def weightedBasepointChangeClass (w : X → ℤ) (hdeg : S.IsWeightedDegreeZero w)
+    {x₀ y₀ : X} (hx₀ : w x₀ = 1) (hy₀ : w y₀ = 1) : picZero w hdeg :=
+  ⟨S.divisorClass (pointDifference x₀ y₀), by
+    rw [divisorClass_mem_picZero]
+    exact basepointDifference_mem_weightedDegreeZeroSubgroup (hx₀.trans hy₀.symm)⟩
+
+@[simp]
+lemma coe_weightedBasepointChangeClass (w : X → ℤ) (hdeg : S.IsWeightedDegreeZero w)
+    {x₀ y₀ : X} (hx₀ : w x₀ = 1) (hy₀ : w y₀ = 1) :
+    (S.weightedBasepointChangeClass w hdeg hx₀ hy₀ : S.ClassGroup) =
+      S.divisorClass (pointDifference x₀ y₀) :=
+  rfl
+
+@[simp]
+lemma weightedBasepointChangeClass_self (w : X → ℤ) (hdeg : S.IsWeightedDegreeZero w)
+    {x₀ : X} (hx₀ : w x₀ = 1) :
+    S.weightedBasepointChangeClass w hdeg hx₀ hx₀ = 0 := by
+  apply Subtype.ext
+  simp [weightedBasepointChangeClass]
+
+/-- Reversing the two base points negates the base-point-change class. -/
+lemma weightedBasepointChangeClass_swap (w : X → ℤ) (hdeg : S.IsWeightedDegreeZero w)
+    {x₀ y₀ : X} (hx₀ : w x₀ = 1) (hy₀ : w y₀ = 1) :
+    S.weightedBasepointChangeClass w hdeg hy₀ hx₀ =
+      -S.weightedBasepointChangeClass w hdeg hx₀ hy₀ := by
+  apply Subtype.ext
+  change S.divisorClass (pointDifference y₀ x₀) = -S.divisorClass (pointDifference x₀ y₀)
+  rw [← map_neg, ← pointDifference_swap]
+
+/-- Base-point-change classes compose: the translation from `x₀` to `z₀` is the sum of the
+translations from `x₀` to `y₀` and from `y₀` to `z₀`. -/
+lemma weightedBasepointChangeClass_add (w : X → ℤ) (hdeg : S.IsWeightedDegreeZero w)
+    {x₀ y₀ z₀ : X} (hx₀ : w x₀ = 1) (hy₀ : w y₀ = 1) (hz₀ : w z₀ = 1) :
+    S.weightedBasepointChangeClass w hdeg hx₀ hy₀ +
+        S.weightedBasepointChangeClass w hdeg hy₀ hz₀ =
+      S.weightedBasepointChangeClass w hdeg hx₀ hz₀ := by
+  apply Subtype.ext
+  change S.divisorClass (pointDifference x₀ y₀) + S.divisorClass (pointDifference y₀ z₀) =
+    S.divisorClass (pointDifference x₀ z₀)
+  rw [← map_add, pointDifference_add_pointDifference]
+
+/-- Changing the Abel-Jacobi base point from `x₀` to `y₀` adds `w(x)` times the class
+`[x₀] - [y₀]`. This is the weighted closed-point form, where `w(x)` is the residue degree. -/
+lemma weightedAbelJacobiClass_change_base (w : X → ℤ) (hdeg : S.IsWeightedDegreeZero w)
+    {x₀ y₀ : X} (hx₀ : w x₀ = 1) (hy₀ : w y₀ = 1) (x : X) :
+    S.weightedAbelJacobiClass w hdeg hy₀ x =
+      S.weightedAbelJacobiClass w hdeg hx₀ x +
+      w x • S.weightedBasepointChangeClass w hdeg hx₀ hy₀ := by
+  apply Subtype.ext
+  change S.divisorClass (weightedPointBaseDifference w y₀ x) =
+    (S.weightedAbelJacobiClass w hdeg hx₀ x : S.ClassGroup) +
+      w x • (S.weightedBasepointChangeClass w hdeg hx₀ hy₀ : S.ClassGroup)
+  rw [coe_weightedAbelJacobiClass, coe_weightedBasepointChangeClass]
+  rw [← map_zsmul, ← map_add, ← weightedPointBaseDifference_change_base]
+
+/-- In the class group, the difference between two weighted Abel-Jacobi classes with different
+base points is `w(x)` times the class `[x₀] - [y₀]`. -/
+lemma weightedAbelJacobiClass_sub_change_base_coe (w : X → ℤ)
+    (hdeg : S.IsWeightedDegreeZero w) {x₀ y₀ : X} (hx₀ : w x₀ = 1) (hy₀ : w y₀ = 1)
+    (x : X) :
+    (S.weightedAbelJacobiClass w hdeg hy₀ x : S.ClassGroup) -
+        (S.weightedAbelJacobiClass w hdeg hx₀ x : S.ClassGroup) =
+      w x • S.divisorClass (pointDifference x₀ y₀) := by
+  rw [coe_weightedAbelJacobiClass, coe_weightedAbelJacobiClass, ← map_zsmul, ← map_sub,
+    weightedPointBaseDifference_sub_change_base]
+
+/-! ### Unweighted specialization -/
+
+/-- The unweighted base-point-change class `[x₀] - [y₀]` in the abstract unweighted `Pic⁰`. -/
+noncomputable def unweightedBasepointChangeClass (hdeg : S.IsUnweightedDegreeZero) (x₀ y₀ : X) :
+    unweightedPicZero hdeg :=
+  S.weightedBasepointChangeClass (fun _ => (1 : ℤ)) hdeg (x₀ := x₀) (y₀ := y₀) rfl rfl
+
+@[simp]
+lemma coe_unweightedBasepointChangeClass (hdeg : S.IsUnweightedDegreeZero) (x₀ y₀ : X) :
+    (S.unweightedBasepointChangeClass hdeg x₀ y₀ : S.ClassGroup) =
+      S.divisorClass (pointDifference x₀ y₀) :=
+  rfl
+
+@[simp]
+lemma unweightedBasepointChangeClass_self (hdeg : S.IsUnweightedDegreeZero) (x₀ : X) :
+    S.unweightedBasepointChangeClass hdeg x₀ x₀ = 0 := by
+  apply Subtype.ext
+  simp [unweightedBasepointChangeClass]
+
+lemma unweightedBasepointChangeClass_swap (hdeg : S.IsUnweightedDegreeZero) (x₀ y₀ : X) :
+    S.unweightedBasepointChangeClass hdeg y₀ x₀ =
+      -S.unweightedBasepointChangeClass hdeg x₀ y₀ := by
+  apply Subtype.ext
+  change S.divisorClass (pointDifference y₀ x₀) = -S.divisorClass (pointDifference x₀ y₀)
+  rw [← map_neg, ← pointDifference_swap]
+
+/-- Unweighted base-point-change classes compose additively. -/
+lemma unweightedBasepointChangeClass_add (hdeg : S.IsUnweightedDegreeZero) (x₀ y₀ z₀ : X) :
+    S.unweightedBasepointChangeClass hdeg x₀ y₀ +
+        S.unweightedBasepointChangeClass hdeg y₀ z₀ =
+      S.unweightedBasepointChangeClass hdeg x₀ z₀ := by
+  apply Subtype.ext
+  change S.divisorClass (pointDifference x₀ y₀) + S.divisorClass (pointDifference y₀ z₀) =
+    S.divisorClass (pointDifference x₀ z₀)
+  rw [← map_add, pointDifference_add_pointDifference]
+
+/-- Changing the base point in the unweighted abstract Abel-Jacobi class is translation by
+`[x₀] - [y₀]`. -/
+lemma unweightedAbelJacobiClass_change_base (hdeg : S.IsUnweightedDegreeZero) (x₀ y₀ x : X) :
+    S.unweightedAbelJacobiClass hdeg y₀ x =
+      S.unweightedAbelJacobiClass hdeg x₀ x +
+        S.unweightedBasepointChangeClass hdeg x₀ y₀ := by
+  apply Subtype.ext
+  rw [coe_unweightedAbelJacobiClass]
+  change S.divisorClass (pointDifference x y₀) =
+    (S.unweightedAbelJacobiClass hdeg x₀ x : S.ClassGroup) +
+      (S.unweightedBasepointChangeClass hdeg x₀ y₀ : S.ClassGroup)
+  rw [coe_unweightedAbelJacobiClass, coe_unweightedBasepointChangeClass, ← map_add]
+  simp [pointDifference, sub_eq_add_neg, add_assoc, add_left_comm, add_comm]
+
+/-- The class `[x] - [y]` is the difference of two Abel-Jacobi classes with the same base point. -/
+lemma unweightedAbelJacobiClass_sub_coe (hdeg : S.IsUnweightedDegreeZero) (x₀ x y : X) :
+    (S.unweightedAbelJacobiClass hdeg x₀ x : S.ClassGroup) -
+        (S.unweightedAbelJacobiClass hdeg x₀ y : S.ClassGroup) =
+      S.divisorClass (pointDifference x y) := by
+  rw [coe_unweightedAbelJacobiClass, coe_unweightedAbelJacobiClass, ← map_sub]
+  simp [pointDifference, sub_eq_add_neg, add_assoc, add_left_comm, add_comm]
+
+/-- The unweighted Abel-Jacobi class based at `y` sends `x` to the base-point-change class
+from `x` to `y`. -/
+lemma unweightedAbelJacobiClass_eq_basepointChangeClass (hdeg : S.IsUnweightedDegreeZero)
+    (x y : X) :
+    S.unweightedAbelJacobiClass hdeg y x =
+      S.unweightedBasepointChangeClass hdeg x y := by
+  apply Subtype.ext
+  simp [unweightedAbelJacobiClass, unweightedBasepointChangeClass]
+
+end OrderSystem
+
+end WeilDivisor
+
+end AlgebraicGeometry
+
+end TauCeti


### PR DESCRIPTION
This PR adds the basepoint-change calculus for the abstract Abel-Jacobi divisor class in the JacobianChallenge Layer A Weil-divisor API. It proves the divisor identity `[x] - w(x)[y₀] = ([x] - w(x)[x₀]) + w(x)([x₀] - [y₀])`, packages the degree-zero class `[x₀] - [y₀]` measuring the translation between two weight-one base points, and records the corresponding weighted and unweighted formulas inside the abstract `Pic⁰` subgroup. It also exposes the existing `weightedPointBaseDifference` definition so this immediate downstream API can calculate with it.

This advances `TauCetiRoadmap/JacobianChallenge/README.md`, Layer A, the specific `Pic⁰ X = ker deg` item, as a formal prerequisite for Layer F's normalized Abel-Jacobi morphism `aj : X ⟶ Jac X`: once the Abel-Jacobi map is normalized by a rational base point with `x₀ ↦ 0`, changing that base point should translate the resulting `Pic⁰` class by `[x₀] - [y₀]`. I chose it as the lowest-hanging distinct JacobianChallenge target after checking open and recently merged PRs: the existing Weil-divisor, divisor-class, degree-zero, complete-linear-system, rational-point splitting, and initial Abel-Jacobi class API had landed, but the basepoint-change formulas for that class were still missing.

No Mathlib infrastructure is vendored. The proofs reuse Tau Ceti's `WeilDivisor`, `OrderSystem.divisorClass`, `picZero`, and abstract Abel-Jacobi API, together with Mathlib's standard additive-group homomorphism rewrites.

Local verification: `lake exe cache get` completed with `No files to download` and `Already decompressed 8585 file(s)`; `lake build` completed with `Build completed successfully (4197 jobs).`; `lake exe axioms` completed with `axioms: audited 4752 TauCeti declaration(s); all within the allowlist [propext, Classical.choice, Quot.sound].`

<!--tauceti-target:v1 {"focus":"JacobianChallenge","id":"abel-jacobi-basepoint-change"}-->

🤖 Prepared with Codex
