### PR TITLE
feat: add finite closure for positive-definite kernels

### DIFF
--- a/TauCeti/Analysis/PositiveDefinite/Kernel.lean
+++ b/TauCeti/Analysis/PositiveDefinite/Kernel.lean
@@ -47,9 +47,10 @@ forms, with no positive-definite-kernel notion, so this is new; no code is vendo
 * `TauCeti.isPositiveDefiniteKernel_comp`: positive definiteness is preserved by pullback.
 * `TauCeti.isPositiveDefiniteKernel_zero`, `TauCeti.isPositiveDefiniteKernel_one`, and
   `TauCeti.isPositiveDefiniteKernel_const_of_nonneg`: constant positive-definite kernels.
-* `TauCeti.isPositiveDefiniteKernel_add`, `TauCeti.isPositiveDefiniteKernel_smul`,
-  `TauCeti.isPositiveDefiniteKernel_mul`: closure under sums, nonnegative scalar multiples, and
-  pointwise products.
+* `TauCeti.isPositiveDefiniteKernel_add`, `TauCeti.isPositiveDefiniteKernel_smul`, and
+  `TauCeti.isPositiveDefiniteKernel_smul_of_nonneg`: closure under sums, nonnegative real scalar
+  multiples, and nonnegative scalar multiples in the codomain.
+* `TauCeti.isPositiveDefiniteKernel_mul`: closure under pointwise products.
 * `TauCeti.isPositiveDefiniteKernel_iff`: the quadratic-form characterization, whose reverse
   direction builds a positive-definite kernel from conjugate symmetry and form nonnegativity.
 * `TauCeti.isPositiveDefiniteKernel_conj_mul`: the rank-one kernels
@@ -111,14 +112,24 @@ theorem isPositiveDefiniteKernel_add {K L : α → α → 𝕜}
   ext a b
   rfl
 
-/-- Nonnegative scalar multiples of positive-definite kernels are positive definite. -/
-theorem isPositiveDefiniteKernel_smul {K : α → α → 𝕜} {c : 𝕜} (hc : 0 ≤ c)
+/-- Nonnegative scalar multiples in the codomain of positive-definite kernels are positive
+definite. -/
+theorem isPositiveDefiniteKernel_smul_of_nonneg {K : α → α → 𝕜} {c : 𝕜} (hc : 0 ≤ c)
     (hK : IsPositiveDefiniteKernel K) :
     IsPositiveDefiniteKernel (fun a b => c • K a b) := by
   rw [isPositiveDefiniteKernel_def] at hK ⊢
   convert hK.smul hc using 1
   ext a b
   rfl
+
+/-- Nonnegative real scalar multiples of positive-definite kernels are positive definite. -/
+theorem isPositiveDefiniteKernel_smul {K : α → α → 𝕜} {r : ℝ} (hr : 0 ≤ r)
+    (hK : IsPositiveDefiniteKernel K) :
+    IsPositiveDefiniteKernel (fun a b => r • K a b) := by
+  convert isPositiveDefiniteKernel_smul_of_nonneg (𝕜 := 𝕜) (α := α) (K := K)
+    (c := (r : 𝕜)) (by exact_mod_cast hr) hK using 1
+  ext a b
+  exact Algebra.smul_def r (K a b)
 
 /-- Pointwise products of positive-definite kernels are positive definite. -/
 theorem isPositiveDefiniteKernel_mul {K L : α → α → 𝕜}
@@ -186,7 +197,7 @@ theorem isPositiveDefiniteKernel_one :
 /-- A nonnegative constant gives a positive-definite constant kernel. -/
 theorem isPositiveDefiniteKernel_const_of_nonneg {c : 𝕜} (hc : 0 ≤ c) :
     IsPositiveDefiniteKernel (fun _ _ : α => c) := by
-  convert isPositiveDefiniteKernel_smul (𝕜 := 𝕜) (α := α)
+  convert isPositiveDefiniteKernel_smul_of_nonneg (𝕜 := 𝕜) (α := α)
     (K := fun _ _ : α => (1 : 𝕜)) hc isPositiveDefiniteKernel_one using 1
   ext a b
   simp

--- a/TauCeti/Analysis/PositiveDefinite/Kernel.lean
+++ b/TauCeti/Analysis/PositiveDefinite/Kernel.lean
@@ -45,6 +45,8 @@ forms, with no positive-definite-kernel notion, so this is new; no code is vendo
 * `TauCeti.isPositiveDefiniteKernel_conj_symm`: positive-definite kernels are
   conjugate-symmetric.
 * `TauCeti.isPositiveDefiniteKernel_comp`: positive definiteness is preserved by pullback.
+* `TauCeti.isPositiveDefiniteKernel_zero`, `TauCeti.isPositiveDefiniteKernel_one`, and
+  `TauCeti.isPositiveDefiniteKernel_const_of_nonneg`: constant positive-definite kernels.
 * `TauCeti.isPositiveDefiniteKernel_add`, `TauCeti.isPositiveDefiniteKernel_smul`,
   `TauCeti.isPositiveDefiniteKernel_mul`: closure under sums, nonnegative scalar multiples, and
   pointwise products.
@@ -109,12 +111,12 @@ theorem isPositiveDefiniteKernel_add {K L : α → α → 𝕜}
   ext a b
   rfl
 
-/-- Nonnegative real scalar multiples of positive-definite kernels are positive definite. -/
-theorem isPositiveDefiniteKernel_smul {K : α → α → 𝕜} {r : ℝ} (hr : 0 ≤ r)
+/-- Nonnegative scalar multiples of positive-definite kernels are positive definite. -/
+theorem isPositiveDefiniteKernel_smul {K : α → α → 𝕜} {c : 𝕜} (hc : 0 ≤ c)
     (hK : IsPositiveDefiniteKernel K) :
-    IsPositiveDefiniteKernel (fun a b => r • K a b) := by
+    IsPositiveDefiniteKernel (fun a b => c • K a b) := by
   rw [isPositiveDefiniteKernel_def] at hK ⊢
-  convert hK.smul hr using 1
+  convert hK.smul hc using 1
   ext a b
   rfl
 
@@ -170,6 +172,24 @@ theorem isPositiveDefiniteKernel_conj_mul (g : α → 𝕜) :
       simp only [Matrix.of_apply, Matrix.vecMulVec_apply, Pi.star_apply, starRingEnd_apply]
     rw [e]
     exact Matrix.posSemidef_vecMulVec_star_self _
+
+/-- The zero kernel is positive definite. -/
+theorem isPositiveDefiniteKernel_zero :
+    IsPositiveDefiniteKernel (fun _ _ : α => (0 : 𝕜)) := by
+  simpa using isPositiveDefiniteKernel_conj_mul (𝕜 := 𝕜) (α := α) (fun _ => (0 : 𝕜))
+
+/-- The constant kernel with value `1` is positive definite. -/
+theorem isPositiveDefiniteKernel_one :
+    IsPositiveDefiniteKernel (fun _ _ : α => (1 : 𝕜)) := by
+  simpa using isPositiveDefiniteKernel_conj_mul (𝕜 := 𝕜) (α := α) (fun _ => (1 : 𝕜))
+
+/-- A nonnegative constant gives a positive-definite constant kernel. -/
+theorem isPositiveDefiniteKernel_const_of_nonneg {c : 𝕜} (hc : 0 ≤ c) :
+    IsPositiveDefiniteKernel (fun _ _ : α => c) := by
+  convert isPositiveDefiniteKernel_smul (𝕜 := 𝕜) (α := α)
+    (K := fun _ _ : α => (1 : 𝕜)) hc isPositiveDefiniteKernel_one using 1
+  ext a b
+  simp
 
 /-- The quadratic-form characterization of a positive-definite kernel: `K` is positive definite if
 and only if it is conjugate-symmetric and every Hermitian form

--- a/TauCeti/Analysis/PositiveDefinite/KernelClosure.lean
+++ b/TauCeti/Analysis/PositiveDefinite/KernelClosure.lean
@@ -78,7 +78,7 @@ theorem isPositiveDefiniteKernel_sum_smul {ι : Type w} {s : Finset ι}
     (hK : ∀ i ∈ s, IsPositiveDefiniteKernel (K i)) :
     IsPositiveDefiniteKernel (fun a b => ∑ i ∈ s, r i • K i a b) :=
   isPositiveDefiniteKernel_sum fun i hi =>
-    isPositiveDefiniteKernel_smul (hr i hi) (hK i hi)
+    isPositiveDefiniteKernel_smul_of_nonneg (hr i hi) (hK i hi)
 
 /-- Schur powers of a positive-definite kernel are positive definite. -/
 theorem isPositiveDefiniteKernel_pow {K : α → α → 𝕜}

--- a/TauCeti/Analysis/PositiveDefinite/KernelClosure.lean
+++ b/TauCeti/Analysis/PositiveDefinite/KernelClosure.lean
@@ -4,6 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 -/
 module
 
+public import Mathlib.Algebra.BigOperators.Group.Finset.Defs
 public import TauCeti.Analysis.PositiveDefinite.Kernel
 
 /-!
@@ -13,24 +14,21 @@ This file adds finite closure API for `TauCeti.IsPositiveDefiniteKernel`, the tw
 positive-definite kernel predicate used in the positive-definite-function and Bochner part of the
 `OneParameterSemigroups` roadmap.
 
-The basic kernel file already proves the binary closure operations: sums, nonnegative real scalar
-multiples, pointwise products, and rank-one kernels `(a, b) ↦ conj (g a) * g b`. This module
-packages their finite consequences. These are the forms used by finite-rank kernel constructions
-and by the finite-dimensional approximations that feed the later GNS/Kolmogorov decomposition:
-finite sums of rank-one kernels are positive definite, and finite Schur products of
-positive-definite kernels are positive definite.
+The basic kernel file already proves the constant kernels and binary closure operations: sums,
+nonnegative scalar multiples, pointwise products, and rank-one kernels
+`(a, b) ↦ conj (g a) * g b`. This module packages their finite consequences. These are the forms
+used by finite-rank kernel constructions and by the finite-dimensional approximations that feed
+the later GNS/Kolmogorov decomposition: finite sums of rank-one kernels are positive definite,
+and finite Schur products of positive-definite kernels are positive definite.
 
-No external formalization is vendored. The proofs are direct inductions through the existing
-Tau Ceti binary kernel API, which itself uses Mathlib's positive-semidefinite matrix calculus.
+No external formalization is vendored.
 
 ## Main declarations
 
-* `TauCeti.isPositiveDefiniteKernel_zero`, `TauCeti.isPositiveDefiniteKernel_one`, and
-  `TauCeti.isPositiveDefiniteKernel_const_of_nonneg`: constant positive-definite kernels.
 * `TauCeti.isPositiveDefiniteKernel_sum`: finite sums of positive-definite kernels.
 * `TauCeti.isPositiveDefiniteKernel_prod`: finite pointwise products of positive-definite
   kernels.
-* `TauCeti.isPositiveDefiniteKernel_sum_smul`: finite sums with nonnegative real weights.
+* `TauCeti.isPositiveDefiniteKernel_sum_smul`: finite sums with nonnegative weights.
 * `TauCeti.isPositiveDefiniteKernel_pow`: Schur powers of a positive-definite kernel.
 * `TauCeti.isPositiveDefiniteKernel_sum_conj_mul`: finite sums of rank-one kernels.
 
@@ -42,7 +40,7 @@ Tau Ceti binary kernel API, which itself uses Mathlib's positive-semidefinite ma
 
 public section
 
-open scoped ComplexConjugate
+open scoped ComplexConjugate ComplexOrder
 
 namespace TauCeti
 
@@ -50,25 +48,6 @@ universe u v w
 
 variable {𝕜 : Type u} [RCLike 𝕜]
 variable {α : Type v}
-
-/-- The zero kernel is positive definite. -/
-theorem isPositiveDefiniteKernel_zero :
-    IsPositiveDefiniteKernel (fun _ _ : α => (0 : 𝕜)) := by
-  simpa using isPositiveDefiniteKernel_conj_mul (𝕜 := 𝕜) (α := α) (fun _ => (0 : 𝕜))
-
-/-- The constant kernel with value `1` is positive definite. -/
-theorem isPositiveDefiniteKernel_one :
-    IsPositiveDefiniteKernel (fun _ _ : α => (1 : 𝕜)) := by
-  simpa using isPositiveDefiniteKernel_conj_mul (𝕜 := 𝕜) (α := α) (fun _ => (1 : 𝕜))
-
-/-- A nonnegative real constant, viewed in an `RCLike` field, gives a positive-definite
-constant kernel. -/
-theorem isPositiveDefiniteKernel_const_of_nonneg {r : ℝ} (hr : 0 ≤ r) :
-    IsPositiveDefiniteKernel (fun _ _ : α => (r : 𝕜)) := by
-  convert isPositiveDefiniteKernel_smul (𝕜 := 𝕜) (α := α)
-    (K := fun _ _ : α => (1 : 𝕜)) hr isPositiveDefiniteKernel_one using 1
-  ext a b
-  exact @Algebra.algebraMap_eq_smul_one ℝ 𝕜 _ _ _ r
 
 /-- Finite sums of positive-definite kernels are positive definite. -/
 theorem isPositiveDefiniteKernel_sum {ι : Type w} {s : Finset ι}
@@ -92,10 +71,10 @@ theorem isPositiveDefiniteKernel_prod {ι : Type w} {s : Finset ι}
     simp
   rwa [heq] at h
 
-/-- Finite sums of positive-definite kernels with nonnegative real weights are positive
+/-- Finite sums of positive-definite kernels with nonnegative weights are positive
 definite. This is the weighted finite-mixture form most often used in examples. -/
 theorem isPositiveDefiniteKernel_sum_smul {ι : Type w} {s : Finset ι}
-    {r : ι → ℝ} {K : ι → α → α → 𝕜} (hr : ∀ i ∈ s, 0 ≤ r i)
+    {r : ι → 𝕜} {K : ι → α → α → 𝕜} (hr : ∀ i ∈ s, 0 ≤ r i)
     (hK : ∀ i ∈ s, IsPositiveDefiniteKernel (K i)) :
     IsPositiveDefiniteKernel (fun a b => ∑ i ∈ s, r i • K i a b) :=
   isPositiveDefiniteKernel_sum fun i hi =>
@@ -128,9 +107,9 @@ theorem isPositiveDefiniteKernel_prod_conj_mul {ι : Type w} (s : Finset ι)
       (fun a b => ∏ i ∈ s, conj (g i a) * g i b) :=
   isPositiveDefiniteKernel_prod fun i _ => isPositiveDefiniteKernel_conj_mul (g i)
 
-/-- Finite nonnegative real combinations of rank-one kernels are positive definite. -/
+/-- Finite nonnegative combinations of rank-one kernels are positive definite. -/
 theorem isPositiveDefiniteKernel_sum_smul_conj_mul {ι : Type w} {s : Finset ι}
-    {r : ι → ℝ} (hr : ∀ i ∈ s, 0 ≤ r i) (g : ι → α → 𝕜) :
+    {r : ι → 𝕜} (hr : ∀ i ∈ s, 0 ≤ r i) (g : ι → α → 𝕜) :
     IsPositiveDefiniteKernel
       (fun a b => ∑ i ∈ s, r i • (conj (g i a) * g i b)) :=
   isPositiveDefiniteKernel_sum_smul hr fun i _ => isPositiveDefiniteKernel_conj_mul (g i)

--- a/TauCeti/Analysis/PositiveDefinite/KernelClosure.lean
+++ b/TauCeti/Analysis/PositiveDefinite/KernelClosure.lean
@@ -1,0 +1,138 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+module
+
+public import TauCeti.Analysis.PositiveDefinite.Kernel
+
+/-!
+# Finite closure for positive-definite kernels
+
+This file adds finite closure API for `TauCeti.IsPositiveDefiniteKernel`, the two-variable
+positive-definite kernel predicate used in the positive-definite-function and Bochner part of the
+`OneParameterSemigroups` roadmap.
+
+The basic kernel file already proves the binary closure operations: sums, nonnegative real scalar
+multiples, pointwise products, and rank-one kernels `(a, b) ↦ conj (g a) * g b`. This module
+packages their finite consequences. These are the forms used by finite-rank kernel constructions
+and by the finite-dimensional approximations that feed the later GNS/Kolmogorov decomposition:
+finite sums of rank-one kernels are positive definite, and finite Schur products of
+positive-definite kernels are positive definite.
+
+No external formalization is vendored. The proofs are direct inductions through the existing
+Tau Ceti binary kernel API, which itself uses Mathlib's positive-semidefinite matrix calculus.
+
+## Main declarations
+
+* `TauCeti.isPositiveDefiniteKernel_zero`, `TauCeti.isPositiveDefiniteKernel_one`, and
+  `TauCeti.isPositiveDefiniteKernel_const_of_nonneg`: constant positive-definite kernels.
+* `TauCeti.isPositiveDefiniteKernel_sum`: finite sums of positive-definite kernels.
+* `TauCeti.isPositiveDefiniteKernel_prod`: finite pointwise products of positive-definite
+  kernels.
+* `TauCeti.isPositiveDefiniteKernel_sum_smul`: finite sums with nonnegative real weights.
+* `TauCeti.isPositiveDefiniteKernel_pow`: Schur powers of a positive-definite kernel.
+* `TauCeti.isPositiveDefiniteKernel_sum_conj_mul`: finite sums of rank-one kernels.
+
+## References
+
+* C. Berg, J. P. R. Christensen, P. Ressel, *Harmonic Analysis on Semigroups* (GTM 100, 1984),
+  Chapter 3.
+-/
+
+public section
+
+open scoped ComplexConjugate
+
+namespace TauCeti
+
+universe u v w
+
+variable {𝕜 : Type u} [RCLike 𝕜]
+variable {α : Type v}
+
+/-- The zero kernel is positive definite. -/
+theorem isPositiveDefiniteKernel_zero :
+    IsPositiveDefiniteKernel (fun _ _ : α => (0 : 𝕜)) := by
+  simpa using isPositiveDefiniteKernel_conj_mul (𝕜 := 𝕜) (α := α) (fun _ => (0 : 𝕜))
+
+/-- The constant kernel with value `1` is positive definite. -/
+theorem isPositiveDefiniteKernel_one :
+    IsPositiveDefiniteKernel (fun _ _ : α => (1 : 𝕜)) := by
+  simpa using isPositiveDefiniteKernel_conj_mul (𝕜 := 𝕜) (α := α) (fun _ => (1 : 𝕜))
+
+/-- A nonnegative real constant, viewed in an `RCLike` field, gives a positive-definite
+constant kernel. -/
+theorem isPositiveDefiniteKernel_const_of_nonneg {r : ℝ} (hr : 0 ≤ r) :
+    IsPositiveDefiniteKernel (fun _ _ : α => (r : 𝕜)) := by
+  convert isPositiveDefiniteKernel_smul (𝕜 := 𝕜) (α := α)
+    (K := fun _ _ : α => (1 : 𝕜)) hr isPositiveDefiniteKernel_one using 1
+  ext a b
+  exact @Algebra.algebraMap_eq_smul_one ℝ 𝕜 _ _ _ r
+
+/-- Finite sums of positive-definite kernels are positive definite. -/
+theorem isPositiveDefiniteKernel_sum {ι : Type w} {s : Finset ι}
+    {K : ι → α → α → 𝕜} (hK : ∀ i ∈ s, IsPositiveDefiniteKernel (K i)) :
+    IsPositiveDefiniteKernel (fun a b => ∑ i ∈ s, K i a b) := by
+  have h := Finset.sum_induction K IsPositiveDefiniteKernel
+    (fun _ _ => isPositiveDefiniteKernel_add) isPositiveDefiniteKernel_zero hK
+  have heq : (∑ i ∈ s, K i) = fun a b => ∑ i ∈ s, K i a b := by
+    ext a b
+    simp
+  rwa [heq] at h
+
+/-- Finite pointwise products of positive-definite kernels are positive definite. -/
+theorem isPositiveDefiniteKernel_prod {ι : Type w} {s : Finset ι}
+    {K : ι → α → α → 𝕜} (hK : ∀ i ∈ s, IsPositiveDefiniteKernel (K i)) :
+    IsPositiveDefiniteKernel (fun a b => ∏ i ∈ s, K i a b) := by
+  have h := Finset.prod_induction K IsPositiveDefiniteKernel
+    (fun _ _ => isPositiveDefiniteKernel_mul) isPositiveDefiniteKernel_one hK
+  have heq : (∏ i ∈ s, K i) = fun a b => ∏ i ∈ s, K i a b := by
+    ext a b
+    simp
+  rwa [heq] at h
+
+/-- Finite sums of positive-definite kernels with nonnegative real weights are positive
+definite. This is the weighted finite-mixture form most often used in examples. -/
+theorem isPositiveDefiniteKernel_sum_smul {ι : Type w} {s : Finset ι}
+    {r : ι → ℝ} {K : ι → α → α → 𝕜} (hr : ∀ i ∈ s, 0 ≤ r i)
+    (hK : ∀ i ∈ s, IsPositiveDefiniteKernel (K i)) :
+    IsPositiveDefiniteKernel (fun a b => ∑ i ∈ s, r i • K i a b) :=
+  isPositiveDefiniteKernel_sum fun i hi =>
+    isPositiveDefiniteKernel_smul (hr i hi) (hK i hi)
+
+/-- Schur powers of a positive-definite kernel are positive definite. -/
+theorem isPositiveDefiniteKernel_pow {K : α → α → 𝕜}
+    (hK : IsPositiveDefiniteKernel K) (n : ℕ) :
+    IsPositiveDefiniteKernel (fun a b => K a b ^ n) := by
+  induction n with
+  | zero =>
+      simpa using isPositiveDefiniteKernel_one (𝕜 := 𝕜) (α := α)
+  | succ n ih =>
+      simpa [pow_succ] using isPositiveDefiniteKernel_mul ih hK
+
+/-- Finite sums of rank-one kernels `(a, b) ↦ conj (gᵢ a) * gᵢ b` are positive definite.
+These are the finite-rank positive-definite kernels used as the elementary building blocks for
+the later GNS/Kolmogorov decomposition. -/
+theorem isPositiveDefiniteKernel_sum_conj_mul {ι : Type w} (s : Finset ι)
+    (g : ι → α → 𝕜) :
+    IsPositiveDefiniteKernel
+      (fun a b => ∑ i ∈ s, conj (g i a) * g i b) :=
+  isPositiveDefiniteKernel_sum fun i _ => isPositiveDefiniteKernel_conj_mul (g i)
+
+/-- Finite products of rank-one kernels are positive definite. This is the Schur-product
+companion to `TauCeti.isPositiveDefiniteKernel_sum_conj_mul`. -/
+theorem isPositiveDefiniteKernel_prod_conj_mul {ι : Type w} (s : Finset ι)
+    (g : ι → α → 𝕜) :
+    IsPositiveDefiniteKernel
+      (fun a b => ∏ i ∈ s, conj (g i a) * g i b) :=
+  isPositiveDefiniteKernel_prod fun i _ => isPositiveDefiniteKernel_conj_mul (g i)
+
+/-- Finite nonnegative real combinations of rank-one kernels are positive definite. -/
+theorem isPositiveDefiniteKernel_sum_smul_conj_mul {ι : Type w} {s : Finset ι}
+    {r : ι → ℝ} (hr : ∀ i ∈ s, 0 ≤ r i) (g : ι → α → 𝕜) :
+    IsPositiveDefiniteKernel
+      (fun a b => ∑ i ∈ s, r i • (conj (g i a) * g i b)) :=
+  isPositiveDefiniteKernel_sum_smul hr fun i _ => isPositiveDefiniteKernel_conj_mul (g i)
+
+end TauCeti


### PR DESCRIPTION
This PR adds the finite closure API for positive-definite kernels. It records the zero, one, and nonnegative real constant kernels, finite sums and finite Schur products of positive-definite kernels, nonnegative weighted finite sums, Schur powers, and the finite-rank constructors obtained from sums and products of rank-one kernels `(a, b) ↦ conj (g a) * g b`.

This advances `TauCetiRoadmap/OneParameterSemigroups/README.md`, Part C, the positive-definite-functions API item asking for closure under sums and products, Schur pointwise products, and the PD-kernel / GNS-Kolmogorov infrastructure. I chose it as the lowest-hanging distinct OneParameterSemigroups target after checking open and recently merged PRs: positive-definite normalization, pullbacks, function-kernel equivalence, characteristic-function positivity, and pointwise limits are already landed or in flight, while the existing kernel file still only had binary closure and rank-one kernels.

No Mathlib infrastructure is vendored. The proofs reuse Tau Ceti's `IsPositiveDefiniteKernel` binary closure API, which itself rests on Mathlib's `Matrix.PosSemidef` and Schur product theorem.

Local verification: `lake exe cache get` completed with `No files to download` and `Already decompressed 8585 file(s)`; `lake build` completed with `Build completed successfully (4198 jobs).`; `lake exe axioms` completed with `axioms: audited 4746 TauCeti declaration(s); all within the allowlist [propext, Classical.choice, Quot.sound].`

<!--tauceti-target:v1 {"focus":"OneParameterSemigroups","id":"positive-definite-kernel-finite-closure"}-->

🤖 Prepared with Codex
