### PR TITLE
feat: upgrade positive-definite continuity

### DIFF
--- a/TauCeti/Analysis/PositiveDefinite/Continuity.lean
+++ b/TauCeti/Analysis/PositiveDefinite/Continuity.lean
@@ -13,9 +13,11 @@ public import Mathlib.Topology.Algebra.Group.Basic
 
 This file records the standard continuity upgrade for positive-definite functions on a seminormed
 additive group with the negation involution. A positive-definite function that is continuous at
-the origin is uniformly continuous. The proof uses the usual reproducing-kernel estimate
-`‖F x - F y‖² ≤ 2 F(0).re ‖F (x - y) - F 0‖`, obtained from the `3 × 3` Gram matrix of the
-points `x`, `y`, and `0`.
+the origin is uniformly continuous. The file also records the local estimates
+`‖F x - F y‖² ≤ 2 F(0).re ((F 0).re - (F (x + star y)).re)` and
+`‖F x - F y‖² ≤ 2 F(0).re ‖F (x + star y) - F 0‖` at points satisfying
+`x + star x = 0` and `y + star y = 0`, together with their specializations to additive groups
+whose involution is negation.
 
 This advances Part C of the `OneParameterSemigroups` roadmap, whose positive-definite-function
 API asks for the basic fact "continuity at `0` ⇒ uniform continuity" before Bochner's theorem.
@@ -26,8 +28,12 @@ In the namespace `TauCeti.IsPositiveDefinite`:
 
 * `norm_sub_sq_le_two_mul_map_zero_re_mul_re_sub_of_star_eq_neg`:
   the local real-part continuity estimate.
+* `norm_sub_sq_le_two_mul_map_zero_re_mul_re_sub_of_add_star_eq_zero`:
+  the monoid-level local real-part continuity estimate.
 * `norm_sub_sq_le_two_mul_map_zero_re_mul_norm_sub_of_star_eq_neg`:
   the local norm-valued continuity estimate.
+* `norm_sub_sq_le_two_mul_map_zero_re_mul_norm_sub_of_add_star_eq_zero`:
+  the monoid-level local norm-valued continuity estimate.
 * `norm_sub_sq_le_two_mul_map_zero_re_mul_re_sub_of_forall_star_eq_neg` and
   `norm_sub_sq_le_two_mul_map_zero_re_mul_norm_sub_of_forall_star_eq_neg`:
   specializations to a globally negating involution.
@@ -51,27 +57,17 @@ namespace IsPositiveDefinite
 
 section Algebra
 
-variable {E : Type*} [AddGroup E] [StarAddMonoid E] {F : E → ℂ}
+variable {E : Type*} [AddMonoid E] [StarAddMonoid E] {F : E → ℂ}
 
-private theorem apply_neg_eq_conj (hF : IsPositiveDefinite F)
-    {x : E} (hx : star x = -x) : F (-x) = conj (F x) := by
-  have h := hF.conj_symm x 0
-  simpa [hx] using congrArg conj h
-
-private theorem eq_zero_of_map_zero_re_eq_zero (hF : IsPositiveDefinite F)
-    (hstar : ∀ x : E, star x = -x) (h0 : (F 0).re = 0) (x : E) : F x = 0 := by
-  have hnorm : ‖F x‖ ≤ 0 := by
-    simpa [h0] using hF.norm_apply_le_map_zero_re_of_star_eq_neg x (hstar x)
-  exact norm_eq_zero.mp (le_antisymm hnorm (norm_nonneg _))
-
-private theorem gram_three_sub_expand
-    {x y : E} (hx : star x = -x) (hy : star y = -y)
-    (hyx : F (y - x) = conj (F (x - y)))
-    (hnx : F (-x) = conj (F x)) (hny : F (0 + -y) = conj (F y)) {lam : ℂ} :
+private theorem gram_three_add_star_expand
+    {x y : E} (hx : x + star x = 0) (hy : y + star y = 0)
+    (hyx : F (y + star x) = conj (F (x + star y)))
+    (hnx : F (star x) = conj (F x)) (hny : F (0 + star y) = conj (F y))
+    {lam : ℂ} :
     (∑ i : Fin 3, ∑ j : Fin 3,
       ![1, -1, lam] i * conj (![1, -1, lam] j) *
         F (![x, y, 0] i + star (![x, y, 0] j)))
-      = F 0 - F (x - y) + conj lam * F x - conj (F (x - y)) + F 0
+      = F 0 - F (x + star y) + conj lam * F x - conj (F (x + star y)) + F 0
         - conj lam * F y + lam * conj (F x) - lam * conj (F y)
         + lam * conj lam * F 0 := by
   simp only [Fin.sum_univ_three, Matrix.cons_val_zero, Matrix.cons_val_one,
@@ -79,10 +75,7 @@ private theorem gram_three_sub_expand
   simp only [Matrix.vecHead, Matrix.vecTail]
   simp only [Function.comp_apply, Fin.succ_zero_eq_one, Matrix.cons_val_zero,
     Matrix.cons_val_one]
-  rw [hx, hy, star_zero, zero_add, add_zero, sub_eq_add_neg,
-    ← sub_eq_add_neg y x, hyx, hnx, hny]
-  simp only [add_zero, add_neg_cancel]
-  rw [← sub_eq_add_neg x y]
+  rw [hx, hy, star_zero, zero_add, add_zero, hyx, hnx, hny]
   simp
   ring_nf
 
@@ -99,23 +92,24 @@ private theorem gram_three_sub_re_complex_algebra {r : ℝ} {z d lam : ℂ}
   field_simp [hr.ne']
   ring_nf
 
-private theorem gram_three_sub_re_algebra (hF : IsPositiveDefinite F)
-    {x y : E} (hx : star x = -x) (hy : star y = -y)
-    (hyx : F (y - x) = conj (F (x - y)))
-    (hnx : F (-x) = conj (F x)) (hny : F (0 + -y) = conj (F y)) {C d lam : ℂ}
+private theorem gram_three_add_star_re_algebra (hF : IsPositiveDefinite F)
+    {x y : E} (hx : x + star x = 0) (hy : y + star y = 0)
+    (hyx : F (y + star x) = conj (F (x + star y)))
+    (hnx : F (star x) = conj (F x)) (hny : F (0 + star y) = conj (F y))
+    {C d lam : ℂ}
     (hC : C = F 0) (hd : d = F x - F y) (hlam : lam = -d / C)
     (hCpos : 0 < (F 0).re) :
     (∑ i : Fin 3, ∑ j : Fin 3,
       ![1, -1, lam] i * conj (![1, -1, lam] j) *
         F (![x, y, 0] i + star (![x, y, 0] j))).re
-      = 2 * (F 0).re - 2 * (F (x - y)).re - Complex.normSq d / (F 0).re := by
-  rw [gram_three_sub_expand hx hy hyx hnx hny]
+      = 2 * (F 0).re - 2 * (F (x + star y)).re - Complex.normSq d / (F 0).re := by
+  rw [gram_three_add_star_expand hx hy hyx hnx hny]
   have hCreal : F 0 = ((F 0).re : ℂ) := hF.map_zero_eq_ofReal_re
   have hstructured :
-      (F 0 - F (x - y) + conj lam * F x - conj (F (x - y)) + F 0
+      (F 0 - F (x + star y) + conj lam * F x - conj (F (x + star y)) + F 0
           - conj lam * F y + lam * conj (F x) - lam * conj (F y)
           + lam * conj lam * F 0).re
-        = (((F 0).re : ℂ) - F (x - y) + conj lam * d - conj (F (x - y))
+        = (((F 0).re : ℂ) - F (x + star y) + conj lam * d - conj (F (x + star y))
           + ((F 0).re : ℂ) + lam * conj d
           + lam * conj lam * ((F 0).re : ℂ)).re := by
     rw [hCreal, hd]
@@ -127,36 +121,39 @@ private theorem gram_three_sub_re_algebra (hF : IsPositiveDefinite F)
     exact hlam
   exact gram_three_sub_re_complex_algebra hlam' hCpos
 
-private theorem gram_three_sub_re_eq (hF : IsPositiveDefinite F)
-    {x y : E} (hx : star x = -x) (hy : star y = -y) {C d lam : ℂ}
+private theorem gram_three_add_star_re_eq (hF : IsPositiveDefinite F)
+    {x y : E} (hx : x + star x = 0) (hy : y + star y = 0) {C d lam : ℂ}
     (hC : C = F 0) (hd : d = F x - F y) (hlam : lam = -d / C)
     (hCpos : 0 < (F 0).re) :
     (∑ i : Fin 3, ∑ j : Fin 3,
       ![1, -1, lam] i * conj (![1, -1, lam] j) *
         F (![x, y, 0] i + star (![x, y, 0] j))).re
-      = 2 * (F 0).re - 2 * (F (x - y)).re - Complex.normSq d / (F 0).re := by
-  have hyx : F (y - x) = conj (F (x - y)) := by
+      = 2 * (F 0).re - 2 * (F (x + star y)).re - Complex.normSq d / (F 0).re := by
+  have hyx : F (y + star x) = conj (F (x + star y)) := by
     have h := hF.conj_symm x y
-    simpa [hx, hy, sub_eq_add_neg] using congrArg conj h
-  have hnx : F (-x) = conj (F x) := hF.apply_neg_eq_conj hx
-  have hny : F (0 + -y) = conj (F y) := by
-    simpa using hF.apply_neg_eq_conj hy
-  exact hF.gram_three_sub_re_algebra hx hy hyx hnx hny hC hd hlam hCpos
+    simpa using congrArg conj h
+  have hnx : F (star x) = conj (F x) := by
+    have h := hF.conj_symm x 0
+    simpa using congrArg conj h
+  have hny : F (0 + star y) = conj (F y) := by
+    have h := hF.conj_symm y 0
+    simpa using congrArg conj h
+  exact hF.gram_three_add_star_re_algebra hx hy hyx hnx hny hC hd hlam hCpos
 
-/-- The local real-part form of the standard positive-definite continuity estimate. -/
-theorem norm_sub_sq_le_two_mul_map_zero_re_mul_re_sub_of_star_eq_neg
+/-- The local monoid-level real-part form of the standard positive-definite continuity estimate. -/
+theorem norm_sub_sq_le_two_mul_map_zero_re_mul_re_sub_of_add_star_eq_zero
     (hF : IsPositiveDefinite F)
-    {x y : E} (hx : star x = -x) (hy : star y = -y) :
+    {x y : E} (hx : x + star x = 0) (hy : y + star y = 0) :
     ‖F x - F y‖ ^ 2
-      ≤ 2 * (F 0).re * ((F 0).re - (F (x - y)).re) := by
+      ≤ 2 * (F 0).re * ((F 0).re - (F (x + star y)).re) := by
   by_cases hC0 : (F 0).re = 0
   · have hFx : F x = 0 := by
       have hnorm : ‖F x‖ ≤ 0 := by
-        simpa [hC0] using hF.norm_apply_le_map_zero_re_of_star_eq_neg x hx
+        simpa [hC0] using hF.norm_apply_le_map_zero_re_of_add_star_eq_zero x hx
       exact norm_eq_zero.mp (le_antisymm hnorm (norm_nonneg _))
     have hFy : F y = 0 := by
       have hnorm : ‖F y‖ ≤ 0 := by
-        simpa [hC0] using hF.norm_apply_le_map_zero_re_of_star_eq_neg y hy
+        simpa [hC0] using hF.norm_apply_le_map_zero_re_of_add_star_eq_zero y hy
       exact norm_eq_zero.mp (le_antisymm hnorm (norm_nonneg _))
     simp [hFx, hFy, hC0]
   have hCpos : 0 < (F 0).re := lt_of_le_of_ne hF.map_zero_re_nonneg (Ne.symm hC0)
@@ -172,23 +169,62 @@ theorem norm_sub_sq_le_two_mul_map_zero_re_mul_re_sub_of_star_eq_neg
       (∑ i : Fin 3, ∑ j : Fin 3,
         ![1, -1, lam] i * conj (![1, -1, lam] j) *
           F (![x, y, 0] i + star (![x, y, 0] j))).re
-        = 2 * (F 0).re - 2 * (F (x - y)).re - Complex.normSq d / (F 0).re := by
-    exact hF.gram_three_sub_re_eq hx hy rfl rfl rfl hCpos
+        = 2 * (F 0).re - 2 * (F (x + star y)).re - Complex.normSq d / (F 0).re := by
+    exact hF.gram_three_add_star_re_eq hx hy rfl rfl rfl hCpos
   have hmain : Complex.normSq d ≤ (F 0).re *
-      (2 * (F 0).re - 2 * (F (x - y)).re) := by
-    have hnonneg : 0 ≤ 2 * (F 0).re - 2 * (F (x - y)).re
+      (2 * (F 0).re - 2 * (F (x + star y)).re) := by
+    have hnonneg : 0 ≤ 2 * (F 0).re - 2 * (F (x + star y)).re
         - Complex.normSq d / (F 0).re := by
       simpa [hQcalc] using hQre
     have hdiv :
-        Complex.normSq d / (F 0).re ≤ 2 * (F 0).re - 2 * (F (x - y)).re := by
+        Complex.normSq d / (F 0).re ≤ 2 * (F 0).re - 2 * (F (x + star y)).re := by
       linarith
     have hmul := (div_le_iff₀ hCpos).mp hdiv
     nlinarith
   calc
     ‖F x - F y‖ ^ 2 = Complex.normSq d := by
       simp [d, Complex.normSq_eq_norm_sq]
-    _ ≤ (F 0).re * (2 * (F 0).re - 2 * (F (x - y)).re) := hmain
-    _ = 2 * (F 0).re * ((F 0).re - (F (x - y)).re) := by ring
+    _ ≤ (F 0).re * (2 * (F 0).re - 2 * (F (x + star y)).re) := hmain
+    _ = 2 * (F 0).re * ((F 0).re - (F (x + star y)).re) := by ring
+
+/-- The local monoid-level norm-valued form of the standard positive-definite continuity
+estimate. -/
+theorem norm_sub_sq_le_two_mul_map_zero_re_mul_norm_sub_of_add_star_eq_zero
+    (hF : IsPositiveDefinite F)
+    {x y : E} (hx : x + star x = 0) (hy : y + star y = 0) :
+    ‖F x - F y‖ ^ 2 ≤ 2 * (F 0).re * ‖F (x + star y) - F 0‖ := by
+  have hre :
+      (F 0).re - (F (x + star y)).re ≤ ‖F (x + star y) - F 0‖ := by
+    have h₁ : (F 0).re - (F (x + star y)).re
+        = -((F (x + star y) - F 0).re) := by
+      simp [Complex.sub_re]
+    rw [h₁]
+    exact (neg_le_abs _).trans (Complex.abs_re_le_norm _)
+  exact (hF.norm_sub_sq_le_two_mul_map_zero_re_mul_re_sub_of_add_star_eq_zero hx hy).trans
+    (mul_le_mul_of_nonneg_left hre (mul_nonneg zero_le_two hF.map_zero_re_nonneg))
+
+end Algebra
+
+section GroupAlgebra
+
+variable {E : Type*} [AddGroup E] [StarAddMonoid E] {F : E → ℂ}
+
+private theorem eq_zero_of_map_zero_re_eq_zero (hF : IsPositiveDefinite F)
+    (hstar : ∀ x : E, star x = -x) (h0 : (F 0).re = 0) (x : E) : F x = 0 := by
+  have hnorm : ‖F x‖ ≤ 0 := by
+    simpa [h0] using hF.norm_apply_le_map_zero_re_of_star_eq_neg x (hstar x)
+  exact norm_eq_zero.mp (le_antisymm hnorm (norm_nonneg _))
+
+/-- The local real-part form of the standard positive-definite continuity estimate. -/
+theorem norm_sub_sq_le_two_mul_map_zero_re_mul_re_sub_of_star_eq_neg
+    (hF : IsPositiveDefinite F)
+    {x y : E} (hx : star x = -x) (hy : star y = -y) :
+    ‖F x - F y‖ ^ 2
+      ≤ 2 * (F 0).re * ((F 0).re - (F (x - y)).re) := by
+  have hx0 : x + star x = 0 := by rw [hx, add_neg_cancel]
+  have hy0 : y + star y = 0 := by rw [hy, add_neg_cancel]
+  simpa [hy, sub_eq_add_neg] using
+    hF.norm_sub_sq_le_two_mul_map_zero_re_mul_re_sub_of_add_star_eq_zero hx0 hy0
 
 /-- The real-part form of the standard positive-definite continuity estimate under a globally
 negating involution. -/
@@ -204,15 +240,10 @@ theorem norm_sub_sq_le_two_mul_map_zero_re_mul_norm_sub_of_star_eq_neg
     (hF : IsPositiveDefinite F)
     {x y : E} (hx : star x = -x) (hy : star y = -y) :
     ‖F x - F y‖ ^ 2 ≤ 2 * (F 0).re * ‖F (x - y) - F 0‖ := by
-  have hre :
-      (F 0).re - (F (x - y)).re ≤ ‖F (x - y) - F 0‖ := by
-    have h₁ : (F 0).re - (F (x - y)).re
-        = -((F (x - y) - F 0).re) := by
-      simp [Complex.sub_re]
-    rw [h₁]
-    exact (neg_le_abs _).trans (Complex.abs_re_le_norm _)
-  exact (hF.norm_sub_sq_le_two_mul_map_zero_re_mul_re_sub_of_star_eq_neg hx hy).trans
-    (mul_le_mul_of_nonneg_left hre (mul_nonneg zero_le_two hF.map_zero_re_nonneg))
+  have hx0 : x + star x = 0 := by rw [hx, add_neg_cancel]
+  have hy0 : y + star y = 0 := by rw [hy, add_neg_cancel]
+  simpa [hy, sub_eq_add_neg] using
+    hF.norm_sub_sq_le_two_mul_map_zero_re_mul_norm_sub_of_add_star_eq_zero hx0 hy0
 
 /-- The norm-valued form of the standard positive-definite continuity estimate under a globally
 negating involution. -/
@@ -222,7 +253,7 @@ theorem norm_sub_sq_le_two_mul_map_zero_re_mul_norm_sub_of_forall_star_eq_neg
     ‖F x - F y‖ ^ 2 ≤ 2 * (F 0).re * ‖F (x - y) - F 0‖ :=
   hF.norm_sub_sq_le_two_mul_map_zero_re_mul_norm_sub_of_star_eq_neg (hstar x) (hstar y)
 
-end Algebra
+end GroupAlgebra
 
 section Topology
 

--- a/TauCeti/Analysis/PositiveDefinite/Continuity.lean
+++ b/TauCeti/Analysis/PositiveDefinite/Continuity.lean
@@ -59,6 +59,23 @@ section Algebra
 
 variable {E : Type*} [AddMonoid E] [StarAddMonoid E] {F : E → ℂ}
 
+private theorem gram_three_add_star_expand_of_values
+    {x y : E} {lam : ℂ} {c : Fin 3 → ℂ} {p : Fin 3 → E}
+    (hc0 : c 0 = 1) (hc1 : c 1 = -1) (hc2 : c 2 = lam)
+    (hp0 : p 0 = x) (hp1 : p 1 = y) (hp2 : p 2 = 0)
+    (hx : x + star x = 0) (hy : y + star y = 0)
+    (hyx : F (y + star x) = conj (F (x + star y)))
+    (hnx : F (star x) = conj (F x)) (hny : F (0 + star y) = conj (F y)) :
+    (∑ i : Fin 3, ∑ j : Fin 3,
+      c i * conj (c j) * F (p i + star (p j)))
+      = F 0 - F (x + star y) + conj lam * F x - conj (F (x + star y)) + F 0
+        - conj lam * F y + lam * conj (F x) - lam * conj (F y)
+        + lam * conj lam * F 0 := by
+  simp only [Fin.sum_univ_three, hc0, hc1, hc2, hp0, hp1, hp2]
+  rw [hx, hy, star_zero, zero_add, add_zero, hyx, hnx, hny]
+  simp
+  ring_nf
+
 private theorem gram_three_add_star_expand
     {x y : E} (hx : x + star x = 0) (hy : y + star y = 0)
     (hyx : F (y + star x) = conj (F (x + star y)))
@@ -70,14 +87,9 @@ private theorem gram_three_add_star_expand
       = F 0 - F (x + star y) + conj lam * F x - conj (F (x + star y)) + F 0
         - conj lam * F y + lam * conj (F x) - lam * conj (F y)
         + lam * conj lam * F 0 := by
-  simp only [Fin.sum_univ_three, Matrix.cons_val_zero, Matrix.cons_val_one,
-    Matrix.cons_val_two]
-  simp only [Matrix.vecHead, Matrix.vecTail]
-  simp only [Function.comp_apply, Fin.succ_zero_eq_one, Matrix.cons_val_zero,
-    Matrix.cons_val_one]
-  rw [hx, hy, star_zero, zero_add, add_zero, hyx, hnx, hny]
-  simp
-  ring_nf
+  exact gram_three_add_star_expand_of_values (F := F) (x := x) (y := y)
+    (c := ![1, -1, lam]) (p := ![x, y, 0]) rfl rfl rfl rfl rfl rfl
+    hx hy hyx hnx hny
 
 -- The remaining calculation is pure complex algebra after `F 0` has been normalized to a
 -- positive real scalar and `lam = -d / F 0` has been substituted.

--- a/TauCeti/Analysis/PositiveDefinite/Continuity.lean
+++ b/TauCeti/Analysis/PositiveDefinite/Continuity.lean
@@ -24,10 +24,13 @@ API asks for the basic fact "continuity at `0` ⇒ uniform continuity" before Bo
 
 In the namespace `TauCeti.IsPositiveDefinite`:
 
-* `norm_sub_sq_le_two_mul_map_zero_re_mul_re_sub_of_forall_star_eq_neg`:
-  the real-part continuity estimate.
-* `norm_sub_sq_le_two_mul_map_zero_re_mul_norm_sub_of_forall_star_eq_neg`:
-  the norm-valued continuity estimate.
+* `norm_sub_sq_le_two_mul_map_zero_re_mul_re_sub_of_star_eq_neg`:
+  the local real-part continuity estimate.
+* `norm_sub_sq_le_two_mul_map_zero_re_mul_norm_sub_of_star_eq_neg`:
+  the local norm-valued continuity estimate.
+* `norm_sub_sq_le_two_mul_map_zero_re_mul_re_sub_of_forall_star_eq_neg` and
+  `norm_sub_sq_le_two_mul_map_zero_re_mul_norm_sub_of_forall_star_eq_neg`:
+  specializations to a globally negating involution.
 * `uniformContinuous_of_continuousAt_zero_of_forall_star_eq_neg`:
   continuity at `0` implies uniform continuity.
 
@@ -48,12 +51,12 @@ namespace IsPositiveDefinite
 
 section Algebra
 
-variable {E : Type*} [AddCommGroup E] [StarAddMonoid E] {F : E → ℂ}
+variable {E : Type*} [AddGroup E] [StarAddMonoid E] {F : E → ℂ}
 
 private theorem apply_neg_eq_conj (hF : IsPositiveDefinite F)
-    (hstar : ∀ x : E, star x = -x) (x : E) : F (-x) = conj (F x) := by
+    {x : E} (hx : star x = -x) : F (-x) = conj (F x) := by
   have h := hF.conj_symm x 0
-  simpa [hstar x] using congrArg conj h
+  simpa [hx] using congrArg conj h
 
 private theorem eq_zero_of_map_zero_re_eq_zero (hF : IsPositiveDefinite F)
     (hstar : ∀ x : E, star x = -x) (h0 : (F 0).re = 0) (x : E) : F x = 0 := by
@@ -61,27 +64,23 @@ private theorem eq_zero_of_map_zero_re_eq_zero (hF : IsPositiveDefinite F)
     simpa [h0] using hF.norm_apply_le_map_zero_re_of_star_eq_neg x (hstar x)
   exact norm_eq_zero.mp (le_antisymm hnorm (norm_nonneg _))
 
-private theorem gram_three_sub_re_eq (hF : IsPositiveDefinite F)
-    (hstar : ∀ x : E, star x = -x) {x y : E} {C d lam : ℂ}
+private theorem gram_three_sub_re_algebra (hF : IsPositiveDefinite F)
+    {x y : E} (hx : star x = -x) (hy : star y = -y)
+    (hyx : F (y - x) = conj (F (x - y)))
+    (hnx : F (-x) = conj (F x)) (hny : F (0 + -y) = conj (F y)) {C d lam : ℂ}
     (hC : C = F 0) (hd : d = F x - F y) (hlam : lam = -d / C)
     (hCpos : 0 < (F 0).re) :
     (∑ i : Fin 3, ∑ j : Fin 3,
       ![1, -1, lam] i * conj (![1, -1, lam] j) *
         F (![x, y, 0] i + star (![x, y, 0] j))).re
       = 2 * (F 0).re - 2 * (F (x - y)).re - Complex.normSq d / (F 0).re := by
-  have hyx : F (y - x) = conj (F (x - y)) := by
-    have h := hF.conj_symm x y
-    simpa [hstar x, hstar y, sub_eq_add_neg, add_comm] using congrArg conj h
-  have hnx : F (-x) = conj (F x) := hF.apply_neg_eq_conj hstar x
-  have hny : F (-y) = conj (F y) := hF.apply_neg_eq_conj hstar y
-  have hny' : F (0 + -y) = conj (F y) := by simpa using hny
   simp only [Fin.sum_univ_three, Matrix.cons_val_zero, Matrix.cons_val_one,
     Matrix.cons_val_two]
   simp only [Matrix.vecHead, Matrix.vecTail]
   simp only [Function.comp_apply, Fin.succ_zero_eq_one, Matrix.cons_val_zero,
     Matrix.cons_val_one]
-  rw [hstar x, hstar y, hstar 0, neg_zero, zero_add, add_zero, sub_eq_add_neg,
-    ← sub_eq_add_neg y x, hyx, hnx, hny']
+  rw [hx, hy, star_zero, zero_add, add_zero, sub_eq_add_neg,
+    ← sub_eq_add_neg y x, hyx, hnx, hny]
   simp only [add_zero, add_neg_cancel]
   simp only [hC, hd, hlam]
   rw [hF.map_zero_eq_ofReal_re]
@@ -91,14 +90,38 @@ private theorem gram_three_sub_re_eq (hF : IsPositiveDefinite F)
   field_simp [hCpos.ne']
   ring_nf
 
-/-- The real-part form of the standard positive-definite continuity estimate. -/
-theorem norm_sub_sq_le_two_mul_map_zero_re_mul_re_sub_of_forall_star_eq_neg
+private theorem gram_three_sub_re_eq (hF : IsPositiveDefinite F)
+    {x y : E} (hx : star x = -x) (hy : star y = -y) {C d lam : ℂ}
+    (hC : C = F 0) (hd : d = F x - F y) (hlam : lam = -d / C)
+    (hCpos : 0 < (F 0).re) :
+    (∑ i : Fin 3, ∑ j : Fin 3,
+      ![1, -1, lam] i * conj (![1, -1, lam] j) *
+        F (![x, y, 0] i + star (![x, y, 0] j))).re
+      = 2 * (F 0).re - 2 * (F (x - y)).re - Complex.normSq d / (F 0).re := by
+  have hyx : F (y - x) = conj (F (x - y)) := by
+    have h := hF.conj_symm x y
+    simpa [hx, hy, sub_eq_add_neg] using congrArg conj h
+  have hnx : F (-x) = conj (F x) := hF.apply_neg_eq_conj hx
+  have hny : F (0 + -y) = conj (F y) := by
+    simpa using hF.apply_neg_eq_conj hy
+  exact hF.gram_three_sub_re_algebra hx hy hyx hnx hny hC hd hlam hCpos
+
+/-- The local real-part form of the standard positive-definite continuity estimate. -/
+theorem norm_sub_sq_le_two_mul_map_zero_re_mul_re_sub_of_star_eq_neg
     (hF : IsPositiveDefinite F)
-    (hstar : ∀ x : E, star x = -x) (x y : E) :
+    {x y : E} (hx : star x = -x) (hy : star y = -y) :
     ‖F x - F y‖ ^ 2
       ≤ 2 * (F 0).re * ((F 0).re - (F (x - y)).re) := by
   by_cases hC0 : (F 0).re = 0
-  · simp [hF.eq_zero_of_map_zero_re_eq_zero hstar hC0]
+  · have hFx : F x = 0 := by
+      have hnorm : ‖F x‖ ≤ 0 := by
+        simpa [hC0] using hF.norm_apply_le_map_zero_re_of_star_eq_neg x hx
+      exact norm_eq_zero.mp (le_antisymm hnorm (norm_nonneg _))
+    have hFy : F y = 0 := by
+      have hnorm : ‖F y‖ ≤ 0 := by
+        simpa [hC0] using hF.norm_apply_le_map_zero_re_of_star_eq_neg y hy
+      exact norm_eq_zero.mp (le_antisymm hnorm (norm_nonneg _))
+    simp [hFx, hFy, hC0]
   have hCpos : 0 < (F 0).re := lt_of_le_of_ne hF.map_zero_re_nonneg (Ne.symm hC0)
   let C : ℂ := F 0
   let d : ℂ := F x - F y
@@ -113,7 +136,7 @@ theorem norm_sub_sq_le_two_mul_map_zero_re_mul_re_sub_of_forall_star_eq_neg
         ![1, -1, lam] i * conj (![1, -1, lam] j) *
           F (![x, y, 0] i + star (![x, y, 0] j))).re
         = 2 * (F 0).re - 2 * (F (x - y)).re - Complex.normSq d / (F 0).re := by
-    exact hF.gram_three_sub_re_eq hstar rfl rfl rfl hCpos
+    exact hF.gram_three_sub_re_eq hx hy rfl rfl rfl hCpos
   have hmain : Complex.normSq d ≤ (F 0).re *
       (2 * (F 0).re - 2 * (F (x - y)).re) := by
     have hnonneg : 0 ≤ 2 * (F 0).re - 2 * (F (x - y)).re
@@ -130,10 +153,19 @@ theorem norm_sub_sq_le_two_mul_map_zero_re_mul_re_sub_of_forall_star_eq_neg
     _ ≤ (F 0).re * (2 * (F 0).re - 2 * (F (x - y)).re) := hmain
     _ = 2 * (F 0).re * ((F 0).re - (F (x - y)).re) := by ring
 
-/-- The norm-valued form of the standard positive-definite continuity estimate. -/
-theorem norm_sub_sq_le_two_mul_map_zero_re_mul_norm_sub_of_forall_star_eq_neg
+/-- The real-part form of the standard positive-definite continuity estimate under a globally
+negating involution. -/
+theorem norm_sub_sq_le_two_mul_map_zero_re_mul_re_sub_of_forall_star_eq_neg
     (hF : IsPositiveDefinite F)
     (hstar : ∀ x : E, star x = -x) (x y : E) :
+    ‖F x - F y‖ ^ 2
+      ≤ 2 * (F 0).re * ((F 0).re - (F (x - y)).re) :=
+  hF.norm_sub_sq_le_two_mul_map_zero_re_mul_re_sub_of_star_eq_neg (hstar x) (hstar y)
+
+/-- The local norm-valued form of the standard positive-definite continuity estimate. -/
+theorem norm_sub_sq_le_two_mul_map_zero_re_mul_norm_sub_of_star_eq_neg
+    (hF : IsPositiveDefinite F)
+    {x y : E} (hx : star x = -x) (hy : star y = -y) :
     ‖F x - F y‖ ^ 2 ≤ 2 * (F 0).re * ‖F (x - y) - F 0‖ := by
   have hre :
       (F 0).re - (F (x - y)).re ≤ ‖F (x - y) - F 0‖ := by
@@ -142,8 +174,16 @@ theorem norm_sub_sq_le_two_mul_map_zero_re_mul_norm_sub_of_forall_star_eq_neg
       simp [Complex.sub_re]
     rw [h₁]
     exact (neg_le_abs _).trans (Complex.abs_re_le_norm _)
-  exact (hF.norm_sub_sq_le_two_mul_map_zero_re_mul_re_sub_of_forall_star_eq_neg hstar x y).trans
+  exact (hF.norm_sub_sq_le_two_mul_map_zero_re_mul_re_sub_of_star_eq_neg hx hy).trans
     (mul_le_mul_of_nonneg_left hre (mul_nonneg zero_le_two hF.map_zero_re_nonneg))
+
+/-- The norm-valued form of the standard positive-definite continuity estimate under a globally
+negating involution. -/
+theorem norm_sub_sq_le_two_mul_map_zero_re_mul_norm_sub_of_forall_star_eq_neg
+    (hF : IsPositiveDefinite F)
+    (hstar : ∀ x : E, star x = -x) (x y : E) :
+    ‖F x - F y‖ ^ 2 ≤ 2 * (F 0).re * ‖F (x - y) - F 0‖ :=
+  hF.norm_sub_sq_le_two_mul_map_zero_re_mul_norm_sub_of_star_eq_neg (hstar x) (hstar y)
 
 end Algebra
 
@@ -177,8 +217,8 @@ theorem uniformContinuous_of_continuousAt_zero_of_forall_star_eq_neg (hF : IsPos
     calc
       ‖F x - F y‖ ^ 2 ≤ 2 * (F 0).re * ‖F (x - y) - F 0‖ := hbound
       _ < 2 * (F 0).re * η := mul_lt_mul_of_pos_left hsmall (mul_pos zero_lt_two hCpos)
+      _ = 2 * (F 0).re * (ε ^ 2 / (2 * (F 0).re)) := by rfl
       _ = ε ^ 2 := by
-        rw [show η = ε ^ 2 / (2 * (F 0).re) from rfl]
         field_simp [(mul_pos zero_lt_two hCpos).ne']
   have habs := sq_lt_sq.mp hsquare_le
   simpa [dist_eq_norm, abs_of_nonneg hε.le] using habs

--- a/TauCeti/Analysis/PositiveDefinite/Continuity.lean
+++ b/TauCeti/Analysis/PositiveDefinite/Continuity.lean
@@ -1,0 +1,165 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+module
+
+public import TauCeti.Analysis.PositiveDefinite.Basic
+public import Mathlib.Topology.MetricSpace.Basic
+public import Mathlib.Topology.Algebra.Group.Basic
+
+/-!
+# Continuity of positive-definite functions
+
+This file records the standard continuity upgrade for positive-definite functions on a normed
+additive group with the negation involution. A positive-definite function that is continuous at
+the origin is uniformly continuous. The proof uses the usual reproducing-kernel estimate
+`‖F x - F y‖² ≤ 2 F(0).re ‖F (x - y) - F 0‖`, obtained from the `3 × 3` Gram matrix of the
+points `x`, `y`, and `0`.
+
+This advances Part C of the `OneParameterSemigroups` roadmap, whose positive-definite-function
+API asks for the basic fact "continuity at `0` ⇒ uniform continuity" before Bochner's theorem.
+
+## Main declarations
+
+* `TauCeti.IsPositiveDefinite.norm_sub_sq_le_two_mul_map_zero_re_mul_re_sub`: the real-part
+  continuity estimate.
+* `TauCeti.IsPositiveDefinite.norm_sub_sq_le_two_mul_map_zero_re_mul_norm_sub`: the norm-valued
+  continuity estimate.
+* `TauCeti.IsPositiveDefinite.uniformContinuous_of_continuousAt_zero`: continuity at `0`
+  implies uniform continuity.
+
+## References
+
+* C. Berg, J. P. R. Christensen, P. Ressel, *Harmonic Analysis on Semigroups* (GTM 100, 1984),
+  Chapter 3.
+-/
+
+public section
+
+open ComplexConjugate
+open scoped ComplexOrder
+
+namespace TauCeti
+
+namespace IsPositiveDefinite
+
+variable {E : Type*} [NormedAddCommGroup E] [StarAddMonoid E] {F : E → ℂ}
+
+private theorem apply_neg_eq_conj (hF : IsPositiveDefinite F)
+    (hstar : ∀ x : E, star x = -x) (x : E) : F (-x) = conj (F x) := by
+  have h := hF.conj_symm x 0
+  simpa [hstar x] using congrArg conj h
+
+private theorem eq_zero_of_map_zero_re_eq_zero (hF : IsPositiveDefinite F)
+    (hstar : ∀ x : E, star x = -x) (h0 : (F 0).re = 0) (x : E) : F x = 0 := by
+  have hnorm : ‖F x‖ ≤ 0 := by
+    simpa [h0] using hF.norm_apply_le_map_zero_re_of_star_eq_neg x (hstar x)
+  exact norm_eq_zero.mp (le_antisymm hnorm (norm_nonneg _))
+
+/-- The real-part form of the standard positive-definite continuity estimate. -/
+theorem norm_sub_sq_le_two_mul_map_zero_re_mul_re_sub (hF : IsPositiveDefinite F)
+    (hstar : ∀ x : E, star x = -x) (x y : E) :
+    ‖F x - F y‖ ^ 2
+      ≤ 2 * (F 0).re * ((F 0).re - (F (x - y)).re) := by
+  by_cases hC0 : (F 0).re = 0
+  · simp [hF.eq_zero_of_map_zero_re_eq_zero hstar hC0]
+  have hCpos : 0 < (F 0).re := lt_of_le_of_ne hF.map_zero_re_nonneg (Ne.symm hC0)
+  let C : ℂ := F 0
+  let d : ℂ := F x - F y
+  let lam : ℂ := -d / C
+  have hyx : F (y - x) = conj (F (x - y)) := by
+    have h := hF.conj_symm x y
+    simpa [hstar x, hstar y, sub_eq_add_neg, add_comm] using congrArg conj h
+  have hnx : F (-x) = conj (F x) := hF.apply_neg_eq_conj hstar x
+  have hny : F (-y) = conj (F y) := hF.apply_neg_eq_conj hstar y
+  have hny' : F (0 + -y) = conj (F y) := by simpa using hny
+  have hQ := hF 3 ![1, -1, lam] ![x, y, 0]
+  have hQre : 0 ≤ (∑ i : Fin 3, ∑ j : Fin 3,
+      ![1, -1, lam] i * conj (![1, -1, lam] j) *
+        F (![x, y, 0] i + star (![x, y, 0] j))).re :=
+    (Complex.nonneg_iff.mp hQ).1
+  have hQcalc :
+      (∑ i : Fin 3, ∑ j : Fin 3,
+        ![1, -1, lam] i * conj (![1, -1, lam] j) *
+          F (![x, y, 0] i + star (![x, y, 0] j))).re
+        = 2 * (F 0).re - 2 * (F (x - y)).re - Complex.normSq d / (F 0).re := by
+    simp only [Fin.sum_univ_three, Matrix.cons_val_zero, Matrix.cons_val_one,
+      Matrix.cons_val_two]
+    simp only [Matrix.vecHead, Matrix.vecTail]
+    simp only [Function.comp_apply, Fin.succ_zero_eq_one, Matrix.cons_val_zero,
+      Matrix.cons_val_one]
+    rw [hstar x, hstar y, hstar 0, neg_zero, zero_add, add_zero, sub_eq_add_neg,
+      ← sub_eq_add_neg y x, hyx, hnx, hny']
+    simp only [add_zero, add_neg_cancel]
+    simp only [C, d, lam]
+    rw [hF.map_zero_eq_ofReal_re]
+    field_simp [Complex.ofReal_ne_zero.mpr hCpos.ne']
+    rw [← sub_eq_add_neg x y]
+    simp [Complex.normSq_apply]
+    field_simp [hCpos.ne']
+    ring_nf
+  have hmain : Complex.normSq d ≤ (F 0).re *
+      (2 * (F 0).re - 2 * (F (x - y)).re) := by
+    have hnonneg : 0 ≤ 2 * (F 0).re - 2 * (F (x - y)).re
+        - Complex.normSq d / (F 0).re := by
+      simpa [hQcalc] using hQre
+    have hdiv :
+        Complex.normSq d / (F 0).re ≤ 2 * (F 0).re - 2 * (F (x - y)).re := by
+      linarith
+    have hmul := (div_le_iff₀ hCpos).mp hdiv
+    nlinarith
+  calc
+    ‖F x - F y‖ ^ 2 = Complex.normSq d := by
+      simp [d, Complex.normSq_eq_norm_sq]
+    _ ≤ (F 0).re * (2 * (F 0).re - 2 * (F (x - y)).re) := hmain
+    _ = 2 * (F 0).re * ((F 0).re - (F (x - y)).re) := by ring
+
+/-- The norm-valued form of the standard positive-definite continuity estimate. -/
+theorem norm_sub_sq_le_two_mul_map_zero_re_mul_norm_sub (hF : IsPositiveDefinite F)
+    (hstar : ∀ x : E, star x = -x) (x y : E) :
+    ‖F x - F y‖ ^ 2 ≤ 2 * (F 0).re * ‖F (x - y) - F 0‖ := by
+  have hre :
+      (F 0).re - (F (x - y)).re ≤ ‖F (x - y) - F 0‖ := by
+    have h₁ : (F 0).re - (F (x - y)).re
+        = -((F (x - y) - F 0).re) := by
+      simp [Complex.sub_re]
+    rw [h₁]
+    exact (neg_le_abs _).trans (Complex.abs_re_le_norm _)
+  exact (hF.norm_sub_sq_le_two_mul_map_zero_re_mul_re_sub hstar x y).trans
+    (mul_le_mul_of_nonneg_left hre (mul_nonneg zero_le_two hF.map_zero_re_nonneg))
+
+/-- A positive-definite function on a normed additive group with the negation involution is
+uniformly continuous as soon as it is continuous at the origin. -/
+theorem uniformContinuous_of_continuousAt_zero (hF : IsPositiveDefinite F)
+    (hstar : ∀ x : E, star x = -x) (hcont : ContinuousAt F 0) :
+    UniformContinuous F := by
+  rw [Metric.uniformContinuous_iff]
+  intro ε hε
+  by_cases hC0 : (F 0).re = 0
+  · refine ⟨1, zero_lt_one, fun x y _ => ?_⟩
+    simp [hF.eq_zero_of_map_zero_re_eq_zero hstar hC0, hε]
+  have hCpos : 0 < (F 0).re := lt_of_le_of_ne hF.map_zero_re_nonneg (Ne.symm hC0)
+  let η : ℝ := ε ^ 2 / (2 * (F 0).re)
+  have hη : 0 < η := div_pos (sq_pos_of_pos hε) (mul_pos zero_lt_two hCpos)
+  have hev := (Metric.tendsto_nhds.mp hcont) η hη
+  rcases Metric.eventually_nhds_iff.mp hev with ⟨δ, hδ, hδF⟩
+  refine ⟨δ, hδ, fun x y hxy => ?_⟩
+  have hdist : dist (x - y) 0 < δ := by
+    simpa [dist_eq_norm, sub_eq_add_neg, add_comm] using hxy
+  have hsmall : ‖F (x - y) - F 0‖ < η := by
+    simpa [dist_eq_norm] using hδF hdist
+  have hsquare_le : ‖F x - F y‖ ^ 2 < ε ^ 2 := by
+    have hbound := hF.norm_sub_sq_le_two_mul_map_zero_re_mul_norm_sub hstar x y
+    calc
+      ‖F x - F y‖ ^ 2 ≤ 2 * (F 0).re * ‖F (x - y) - F 0‖ := hbound
+      _ < 2 * (F 0).re * η := mul_lt_mul_of_pos_left hsmall (mul_pos zero_lt_two hCpos)
+      _ = ε ^ 2 := by
+        change 2 * (F 0).re * (ε ^ 2 / (2 * (F 0).re)) = ε ^ 2
+        field_simp [(mul_pos zero_lt_two hCpos).ne']
+  have habs := sq_lt_sq.mp hsquare_le
+  simpa [dist_eq_norm, abs_of_nonneg hε.le] using habs
+
+end IsPositiveDefinite
+
+end TauCeti

--- a/TauCeti/Analysis/PositiveDefinite/Continuity.lean
+++ b/TauCeti/Analysis/PositiveDefinite/Continuity.lean
@@ -6,7 +6,7 @@ module
 
 public import TauCeti.Analysis.PositiveDefinite.Basic
 public import Mathlib.Topology.MetricSpace.Basic
-public import Mathlib.Topology.Algebra.Group.Basic
+public import Mathlib.Analysis.Normed.Group.Basic
 
 /-!
 # Continuity of positive-definite functions
@@ -269,7 +269,7 @@ end GroupAlgebra
 
 section Topology
 
-variable {E : Type*} [SeminormedAddCommGroup E] [StarAddMonoid E] {F : E → ℂ}
+variable {E : Type*} [SeminormedAddGroup E] [StarAddMonoid E] {F : E → ℂ}
 
 /-- A positive-definite function on a seminormed additive group with the negation involution is
 uniformly continuous as soon as it is continuous at the origin. -/
@@ -287,8 +287,20 @@ theorem uniformContinuous_of_continuousAt_zero_of_forall_star_eq_neg (hF : IsPos
   have hev := (Metric.tendsto_nhds.mp hcont) η hη
   rcases Metric.eventually_nhds_iff.mp hev with ⟨δ, hδ, hδF⟩
   refine ⟨δ, hδ, fun x y hxy => ?_⟩
+  have hadd_comm : ∀ a b : E, a + b = b + a := by
+    intro a b
+    have hneg_comm : -(-a) + -(-b) = -(-b) + -(-a) := by
+      calc
+        -(-a) + -(-b) = star (-a) + star (-b) := by rw [hstar, hstar]
+        _ = star ((-a) + (-b)) := (star_add (-a) (-b)).symm
+        _ = -((-a) + (-b)) := hstar ((-a) + (-b))
+        _ = -(-b) + -(-a) := neg_add_rev (-a) (-b)
+    simpa using hneg_comm
+  have hxy_norm : ‖x + -y‖ < δ := by
+    rw [SeminormedAddGroup.dist_eq] at hxy
+    simpa [sub_eq_add_neg, hadd_comm, ← norm_neg (x + -y)] using hxy
   have hdist : dist (x - y) 0 < δ := by
-    simpa [dist_eq_norm, sub_eq_add_neg, add_comm] using hxy
+    simpa [SeminormedAddGroup.dist_eq, sub_eq_add_neg, ← norm_neg (x + -y)] using hxy_norm
   have hsmall : ‖F (x - y) - F 0‖ < η := by
     simpa [dist_eq_norm] using hδF hdist
   have hsquare_le : ‖F x - F y‖ ^ 2 < ε ^ 2 := by

--- a/TauCeti/Analysis/PositiveDefinite/Continuity.lean
+++ b/TauCeti/Analysis/PositiveDefinite/Continuity.lean
@@ -64,6 +64,41 @@ private theorem eq_zero_of_map_zero_re_eq_zero (hF : IsPositiveDefinite F)
     simpa [h0] using hF.norm_apply_le_map_zero_re_of_star_eq_neg x (hstar x)
   exact norm_eq_zero.mp (le_antisymm hnorm (norm_nonneg _))
 
+private theorem gram_three_sub_expand
+    {x y : E} (hx : star x = -x) (hy : star y = -y)
+    (hyx : F (y - x) = conj (F (x - y)))
+    (hnx : F (-x) = conj (F x)) (hny : F (0 + -y) = conj (F y)) {lam : ℂ} :
+    (∑ i : Fin 3, ∑ j : Fin 3,
+      ![1, -1, lam] i * conj (![1, -1, lam] j) *
+        F (![x, y, 0] i + star (![x, y, 0] j)))
+      = F 0 - F (x - y) + conj lam * F x - conj (F (x - y)) + F 0
+        - conj lam * F y + lam * conj (F x) - lam * conj (F y)
+        + lam * conj lam * F 0 := by
+  simp only [Fin.sum_univ_three, Matrix.cons_val_zero, Matrix.cons_val_one,
+    Matrix.cons_val_two]
+  simp only [Matrix.vecHead, Matrix.vecTail]
+  simp only [Function.comp_apply, Fin.succ_zero_eq_one, Matrix.cons_val_zero,
+    Matrix.cons_val_one]
+  rw [hx, hy, star_zero, zero_add, add_zero, sub_eq_add_neg,
+    ← sub_eq_add_neg y x, hyx, hnx, hny]
+  simp only [add_zero, add_neg_cancel]
+  rw [← sub_eq_add_neg x y]
+  simp
+  ring_nf
+
+-- The remaining calculation is pure complex algebra after `F 0` has been normalized to a
+-- positive real scalar and `lam = -d / F 0` has been substituted.
+private theorem gram_three_sub_re_complex_algebra {r : ℝ} {z d lam : ℂ}
+    (hlam : lam = -d / (r : ℂ)) (hr : 0 < r) :
+    ((r : ℂ) - z + conj lam * d - conj z + (r : ℂ) + lam * conj d
+        + lam * conj lam * (r : ℂ)).re
+      = 2 * r - 2 * z.re - Complex.normSq d / r := by
+  rw [hlam]
+  field_simp [Complex.ofReal_ne_zero.mpr hr.ne']
+  simp [Complex.normSq_apply]
+  field_simp [hr.ne']
+  ring_nf
+
 private theorem gram_three_sub_re_algebra (hF : IsPositiveDefinite F)
     {x y : E} (hx : star x = -x) (hy : star y = -y)
     (hyx : F (y - x) = conj (F (x - y)))
@@ -74,21 +109,23 @@ private theorem gram_three_sub_re_algebra (hF : IsPositiveDefinite F)
       ![1, -1, lam] i * conj (![1, -1, lam] j) *
         F (![x, y, 0] i + star (![x, y, 0] j))).re
       = 2 * (F 0).re - 2 * (F (x - y)).re - Complex.normSq d / (F 0).re := by
-  simp only [Fin.sum_univ_three, Matrix.cons_val_zero, Matrix.cons_val_one,
-    Matrix.cons_val_two]
-  simp only [Matrix.vecHead, Matrix.vecTail]
-  simp only [Function.comp_apply, Fin.succ_zero_eq_one, Matrix.cons_val_zero,
-    Matrix.cons_val_one]
-  rw [hx, hy, star_zero, zero_add, add_zero, sub_eq_add_neg,
-    ← sub_eq_add_neg y x, hyx, hnx, hny]
-  simp only [add_zero, add_neg_cancel]
-  simp only [hC, hd, hlam]
-  rw [hF.map_zero_eq_ofReal_re]
-  field_simp [Complex.ofReal_ne_zero.mpr hCpos.ne']
-  rw [← sub_eq_add_neg x y]
-  simp [Complex.normSq_apply]
-  field_simp [hCpos.ne']
-  ring_nf
+  rw [gram_three_sub_expand hx hy hyx hnx hny]
+  have hCreal : F 0 = ((F 0).re : ℂ) := hF.map_zero_eq_ofReal_re
+  have hstructured :
+      (F 0 - F (x - y) + conj lam * F x - conj (F (x - y)) + F 0
+          - conj lam * F y + lam * conj (F x) - lam * conj (F y)
+          + lam * conj lam * F 0).re
+        = (((F 0).re : ℂ) - F (x - y) + conj lam * d - conj (F (x - y))
+          + ((F 0).re : ℂ) + lam * conj d
+          + lam * conj lam * ((F 0).re : ℂ)).re := by
+    rw [hCreal, hd]
+    simp
+    ring_nf
+  rw [hstructured]
+  have hlam' : lam = -d / ((F 0).re : ℂ) := by
+    rw [hC, hCreal] at hlam
+    exact hlam
+  exact gram_three_sub_re_complex_algebra hlam' hCpos
 
 private theorem gram_three_sub_re_eq (hF : IsPositiveDefinite F)
     {x y : E} (hx : star x = -x) (hy : star y = -y) {C d lam : ℂ}

--- a/TauCeti/Analysis/PositiveDefinite/Continuity.lean
+++ b/TauCeti/Analysis/PositiveDefinite/Continuity.lean
@@ -11,7 +11,7 @@ public import Mathlib.Topology.Algebra.Group.Basic
 /-!
 # Continuity of positive-definite functions
 
-This file records the standard continuity upgrade for positive-definite functions on a normed
+This file records the standard continuity upgrade for positive-definite functions on a seminormed
 additive group with the negation involution. A positive-definite function that is continuous at
 the origin is uniformly continuous. The proof uses the usual reproducing-kernel estimate
 `‖F x - F y‖² ≤ 2 F(0).re ‖F (x - y) - F 0‖`, obtained from the `3 × 3` Gram matrix of the
@@ -22,12 +22,14 @@ API asks for the basic fact "continuity at `0` ⇒ uniform continuity" before Bo
 
 ## Main declarations
 
-* `TauCeti.IsPositiveDefinite.norm_sub_sq_le_two_mul_map_zero_re_mul_re_sub`: the real-part
-  continuity estimate.
-* `TauCeti.IsPositiveDefinite.norm_sub_sq_le_two_mul_map_zero_re_mul_norm_sub`: the norm-valued
-  continuity estimate.
-* `TauCeti.IsPositiveDefinite.uniformContinuous_of_continuousAt_zero`: continuity at `0`
-  implies uniform continuity.
+In the namespace `TauCeti.IsPositiveDefinite`:
+
+* `norm_sub_sq_le_two_mul_map_zero_re_mul_re_sub_of_forall_star_eq_neg`:
+  the real-part continuity estimate.
+* `norm_sub_sq_le_two_mul_map_zero_re_mul_norm_sub_of_forall_star_eq_neg`:
+  the norm-valued continuity estimate.
+* `uniformContinuous_of_continuousAt_zero_of_forall_star_eq_neg`:
+  continuity at `0` implies uniform continuity.
 
 ## References
 
@@ -44,7 +46,9 @@ namespace TauCeti
 
 namespace IsPositiveDefinite
 
-variable {E : Type*} [NormedAddCommGroup E] [StarAddMonoid E] {F : E → ℂ}
+section Algebra
+
+variable {E : Type*} [AddCommGroup E] [StarAddMonoid E] {F : E → ℂ}
 
 private theorem apply_neg_eq_conj (hF : IsPositiveDefinite F)
     (hstar : ∀ x : E, star x = -x) (x : E) : F (-x) = conj (F x) := by
@@ -57,8 +61,39 @@ private theorem eq_zero_of_map_zero_re_eq_zero (hF : IsPositiveDefinite F)
     simpa [h0] using hF.norm_apply_le_map_zero_re_of_star_eq_neg x (hstar x)
   exact norm_eq_zero.mp (le_antisymm hnorm (norm_nonneg _))
 
+private theorem gram_three_sub_re_eq (hF : IsPositiveDefinite F)
+    (hstar : ∀ x : E, star x = -x) {x y : E} {C d lam : ℂ}
+    (hC : C = F 0) (hd : d = F x - F y) (hlam : lam = -d / C)
+    (hCpos : 0 < (F 0).re) :
+    (∑ i : Fin 3, ∑ j : Fin 3,
+      ![1, -1, lam] i * conj (![1, -1, lam] j) *
+        F (![x, y, 0] i + star (![x, y, 0] j))).re
+      = 2 * (F 0).re - 2 * (F (x - y)).re - Complex.normSq d / (F 0).re := by
+  have hyx : F (y - x) = conj (F (x - y)) := by
+    have h := hF.conj_symm x y
+    simpa [hstar x, hstar y, sub_eq_add_neg, add_comm] using congrArg conj h
+  have hnx : F (-x) = conj (F x) := hF.apply_neg_eq_conj hstar x
+  have hny : F (-y) = conj (F y) := hF.apply_neg_eq_conj hstar y
+  have hny' : F (0 + -y) = conj (F y) := by simpa using hny
+  simp only [Fin.sum_univ_three, Matrix.cons_val_zero, Matrix.cons_val_one,
+    Matrix.cons_val_two]
+  simp only [Matrix.vecHead, Matrix.vecTail]
+  simp only [Function.comp_apply, Fin.succ_zero_eq_one, Matrix.cons_val_zero,
+    Matrix.cons_val_one]
+  rw [hstar x, hstar y, hstar 0, neg_zero, zero_add, add_zero, sub_eq_add_neg,
+    ← sub_eq_add_neg y x, hyx, hnx, hny']
+  simp only [add_zero, add_neg_cancel]
+  simp only [hC, hd, hlam]
+  rw [hF.map_zero_eq_ofReal_re]
+  field_simp [Complex.ofReal_ne_zero.mpr hCpos.ne']
+  rw [← sub_eq_add_neg x y]
+  simp [Complex.normSq_apply]
+  field_simp [hCpos.ne']
+  ring_nf
+
 /-- The real-part form of the standard positive-definite continuity estimate. -/
-theorem norm_sub_sq_le_two_mul_map_zero_re_mul_re_sub (hF : IsPositiveDefinite F)
+theorem norm_sub_sq_le_two_mul_map_zero_re_mul_re_sub_of_forall_star_eq_neg
+    (hF : IsPositiveDefinite F)
     (hstar : ∀ x : E, star x = -x) (x y : E) :
     ‖F x - F y‖ ^ 2
       ≤ 2 * (F 0).re * ((F 0).re - (F (x - y)).re) := by
@@ -68,12 +103,6 @@ theorem norm_sub_sq_le_two_mul_map_zero_re_mul_re_sub (hF : IsPositiveDefinite F
   let C : ℂ := F 0
   let d : ℂ := F x - F y
   let lam : ℂ := -d / C
-  have hyx : F (y - x) = conj (F (x - y)) := by
-    have h := hF.conj_symm x y
-    simpa [hstar x, hstar y, sub_eq_add_neg, add_comm] using congrArg conj h
-  have hnx : F (-x) = conj (F x) := hF.apply_neg_eq_conj hstar x
-  have hny : F (-y) = conj (F y) := hF.apply_neg_eq_conj hstar y
-  have hny' : F (0 + -y) = conj (F y) := by simpa using hny
   have hQ := hF 3 ![1, -1, lam] ![x, y, 0]
   have hQre : 0 ≤ (∑ i : Fin 3, ∑ j : Fin 3,
       ![1, -1, lam] i * conj (![1, -1, lam] j) *
@@ -84,21 +113,7 @@ theorem norm_sub_sq_le_two_mul_map_zero_re_mul_re_sub (hF : IsPositiveDefinite F
         ![1, -1, lam] i * conj (![1, -1, lam] j) *
           F (![x, y, 0] i + star (![x, y, 0] j))).re
         = 2 * (F 0).re - 2 * (F (x - y)).re - Complex.normSq d / (F 0).re := by
-    simp only [Fin.sum_univ_three, Matrix.cons_val_zero, Matrix.cons_val_one,
-      Matrix.cons_val_two]
-    simp only [Matrix.vecHead, Matrix.vecTail]
-    simp only [Function.comp_apply, Fin.succ_zero_eq_one, Matrix.cons_val_zero,
-      Matrix.cons_val_one]
-    rw [hstar x, hstar y, hstar 0, neg_zero, zero_add, add_zero, sub_eq_add_neg,
-      ← sub_eq_add_neg y x, hyx, hnx, hny']
-    simp only [add_zero, add_neg_cancel]
-    simp only [C, d, lam]
-    rw [hF.map_zero_eq_ofReal_re]
-    field_simp [Complex.ofReal_ne_zero.mpr hCpos.ne']
-    rw [← sub_eq_add_neg x y]
-    simp [Complex.normSq_apply]
-    field_simp [hCpos.ne']
-    ring_nf
+    exact hF.gram_three_sub_re_eq hstar rfl rfl rfl hCpos
   have hmain : Complex.normSq d ≤ (F 0).re *
       (2 * (F 0).re - 2 * (F (x - y)).re) := by
     have hnonneg : 0 ≤ 2 * (F 0).re - 2 * (F (x - y)).re
@@ -116,7 +131,8 @@ theorem norm_sub_sq_le_two_mul_map_zero_re_mul_re_sub (hF : IsPositiveDefinite F
     _ = 2 * (F 0).re * ((F 0).re - (F (x - y)).re) := by ring
 
 /-- The norm-valued form of the standard positive-definite continuity estimate. -/
-theorem norm_sub_sq_le_two_mul_map_zero_re_mul_norm_sub (hF : IsPositiveDefinite F)
+theorem norm_sub_sq_le_two_mul_map_zero_re_mul_norm_sub_of_forall_star_eq_neg
+    (hF : IsPositiveDefinite F)
     (hstar : ∀ x : E, star x = -x) (x y : E) :
     ‖F x - F y‖ ^ 2 ≤ 2 * (F 0).re * ‖F (x - y) - F 0‖ := by
   have hre :
@@ -126,12 +142,18 @@ theorem norm_sub_sq_le_two_mul_map_zero_re_mul_norm_sub (hF : IsPositiveDefinite
       simp [Complex.sub_re]
     rw [h₁]
     exact (neg_le_abs _).trans (Complex.abs_re_le_norm _)
-  exact (hF.norm_sub_sq_le_two_mul_map_zero_re_mul_re_sub hstar x y).trans
+  exact (hF.norm_sub_sq_le_two_mul_map_zero_re_mul_re_sub_of_forall_star_eq_neg hstar x y).trans
     (mul_le_mul_of_nonneg_left hre (mul_nonneg zero_le_two hF.map_zero_re_nonneg))
 
-/-- A positive-definite function on a normed additive group with the negation involution is
+end Algebra
+
+section Topology
+
+variable {E : Type*} [SeminormedAddCommGroup E] [StarAddMonoid E] {F : E → ℂ}
+
+/-- A positive-definite function on a seminormed additive group with the negation involution is
 uniformly continuous as soon as it is continuous at the origin. -/
-theorem uniformContinuous_of_continuousAt_zero (hF : IsPositiveDefinite F)
+theorem uniformContinuous_of_continuousAt_zero_of_forall_star_eq_neg (hF : IsPositiveDefinite F)
     (hstar : ∀ x : E, star x = -x) (hcont : ContinuousAt F 0) :
     UniformContinuous F := by
   rw [Metric.uniformContinuous_iff]
@@ -150,15 +172,18 @@ theorem uniformContinuous_of_continuousAt_zero (hF : IsPositiveDefinite F)
   have hsmall : ‖F (x - y) - F 0‖ < η := by
     simpa [dist_eq_norm] using hδF hdist
   have hsquare_le : ‖F x - F y‖ ^ 2 < ε ^ 2 := by
-    have hbound := hF.norm_sub_sq_le_two_mul_map_zero_re_mul_norm_sub hstar x y
+    have hbound :=
+      hF.norm_sub_sq_le_two_mul_map_zero_re_mul_norm_sub_of_forall_star_eq_neg hstar x y
     calc
       ‖F x - F y‖ ^ 2 ≤ 2 * (F 0).re * ‖F (x - y) - F 0‖ := hbound
       _ < 2 * (F 0).re * η := mul_lt_mul_of_pos_left hsmall (mul_pos zero_lt_two hCpos)
       _ = ε ^ 2 := by
-        change 2 * (F 0).re * (ε ^ 2 / (2 * (F 0).re)) = ε ^ 2
+        rw [show η = ε ^ 2 / (2 * (F 0).re) from rfl]
         field_simp [(mul_pos zero_lt_two hCpos).ne']
   have habs := sq_lt_sq.mp hsquare_le
   simpa [dist_eq_norm, abs_of_nonneg hε.le] using habs
+
+end Topology
 
 end IsPositiveDefinite
 


### PR DESCRIPTION
This PR adds the continuity upgrade for positive-definite functions on normed additive groups with the negation involution: if `F` is positive definite and continuous at `0`, then `F` is uniformly continuous. It also records the quantitative estimates `‖F x - F y‖² ≤ 2 F(0).re * (F(0).re - Re F(x-y))` and `‖F x - F y‖² ≤ 2 F(0).re * ‖F(x-y) - F(0)‖`, which are the reusable API behind the upgrade.

This advances `TauCetiRoadmap/OneParameterSemigroups/README.md`, Part C, the positive-definite-functions API item naming the basic property “continuity at `0` ⇒ uniform continuity”. I chose it as the lowest-hanging distinct OneParameterSemigroups target after checking open and recently merged PRs: normalization, pointwise limits, characteristic-function positivity, pullbacks, and finite kernel closure are already landed or in flight, while this continuity upgrade was still missing and follows from the existing finite-family predicate plus the norm bound at the origin.

No Mathlib infrastructure is vendored. The proof reuses Tau Ceti's `IsPositiveDefinite` finite-family definition, conjugate-symmetry API, and `‖F a‖ ≤ (F 0).re` bound, together with Mathlib's metric uniform-continuity criterion and complex norm/order API. The estimate is the standard `3 × 3` Gram-matrix argument for the points `x`, `y`, and `0`, as in Berg–Christensen–Ressel, *Harmonic Analysis on Semigroups*, Chapter 3.

Local verification: `lake exe cache get` completed with `No files to download` and `Already decompressed 8585 file(s)`; `lake build` completed with `Build completed successfully (4200 jobs).`; `lake exe axioms` completed with `axioms: audited 4765 TauCeti declaration(s); all within the allowlist [propext, Classical.choice, Quot.sound].`

<!--tauceti-target:v1 {"focus":"OneParameterSemigroups","id":"positive-definite-continuity-uniform-continuity"}-->

🤖 Prepared with Codex
