### PR TITLE
feat: add plumbing characteristic weights

### DIFF
--- a/TauCeti/LowDimTopology/Plumbing/Characteristic.lean
+++ b/TauCeti/LowDimTopology/Plumbing/Characteristic.lean
@@ -102,7 +102,8 @@ variable [DecidableEq V] [Fintype V]
 private theorem zmod_two_sq (a : ZMod 2) : a ^ 2 = a := by
   fin_cases a <;> decide
 
-private theorem covector_eval_single (k : V → ℤ) (v : V) :
+/-- Evaluating a covector on a plumbing basis vector picks out the corresponding coordinate. -/
+theorem covector_eval_single (k : V → ℤ) (v : V) :
     (∑ w, k w * (Pi.single v (1 : ℤ) : V → ℤ) w) = k v := by
   rw [Finset.sum_eq_single v]
   · simp

--- a/TauCeti/LowDimTopology/Plumbing/Characteristic.lean
+++ b/TauCeti/LowDimTopology/Plumbing/Characteristic.lean
@@ -61,7 +61,7 @@ def IsCharacteristicVector (k : V → ℤ) : Prop :=
   ∀ v : V, k v ≡ P.weight v [ZMOD 2]
 
 /-- The subtype of characteristic covectors of the plumbing lattice. -/
-def characteristicVectors :=
+abbrev characteristicVectors :=
   { k : V → ℤ // P.IsCharacteristicVector k }
 
 /-- Characteristic covectors are exactly the covectors satisfying the vertex-wise parity
@@ -103,7 +103,7 @@ private theorem zmod_two_sq (a : ZMod 2) : a ^ 2 = a := by
   fin_cases a <;> decide
 
 /-- Evaluating a covector on a plumbing basis vector picks out the corresponding coordinate. -/
-private theorem covector_eval_single (k : V → ℤ) (v : V) :
+theorem covector_eval_single (k : V → ℤ) (v : V) :
     (∑ w, k w * (Pi.single v (1 : ℤ) : V → ℤ) w) = k v := by
   rw [Finset.sum_eq_single v]
   · simp

--- a/TauCeti/LowDimTopology/Plumbing/Characteristic.lean
+++ b/TauCeti/LowDimTopology/Plumbing/Characteristic.lean
@@ -103,7 +103,7 @@ private theorem zmod_two_sq (a : ZMod 2) : a ^ 2 = a := by
   fin_cases a <;> decide
 
 /-- Evaluating a covector on a plumbing basis vector picks out the corresponding coordinate. -/
-theorem covector_eval_single (k : V → ℤ) (v : V) :
+private theorem covector_eval_single (k : V → ℤ) (v : V) :
     (∑ w, k w * (Pi.single v (1 : ℤ) : V → ℤ) w) = k v := by
   rw [Finset.sum_eq_single v]
   · simp

--- a/TauCeti/LowDimTopology/Plumbing/Characteristic.lean
+++ b/TauCeti/LowDimTopology/Plumbing/Characteristic.lean
@@ -102,16 +102,6 @@ variable [DecidableEq V] [Fintype V]
 private theorem zmod_two_sq (a : ZMod 2) : a ^ 2 = a := by
   fin_cases a <;> decide
 
-/-- Evaluating a covector on a plumbing basis vector picks out the corresponding coordinate. -/
-private theorem covector_eval_single (k : V → ℤ) (v : V) :
-    (∑ w, k w * (Pi.single v (1 : ℤ) : V → ℤ) w) = k v := by
-  rw [Finset.sum_eq_single v]
-  · simp
-  · intro w _ hw
-    simp [Pi.single_eq_of_ne hw]
-  · intro hv
-    exact absurd (Finset.mem_univ v) hv
-
 omit [DecidableEq V] in
 private theorem adjacency_sum_cast_zmod_two_eq_zero (x : V → ℤ) :
     (∑ i, ∑ j, ((if P.toSimpleGraph.Adj i j then x i * x j else 0 : ℤ) : ZMod 2)) = 0 := by
@@ -177,7 +167,7 @@ theorem isCharacteristicVector_iff_forall_modEq_intersectionForm (k : V → ℤ)
     rw [hkz, zmod_two_sq]
   · intro h v
     have hv := h (Pi.single v (1 : ℤ) : V → ℤ)
-    rw [covector_eval_single] at hv
+    simp only [Pi.single_apply] at hv
     simpa using hv
 
 /-- The canonical characteristic covector satisfies the adjunction coordinate equation

--- a/TauCeti/LowDimTopology/Plumbing/Weight.lean
+++ b/TauCeti/LowDimTopology/Plumbing/Weight.lean
@@ -26,7 +26,8 @@ cube weights and `ℤ[U]` complexes are introduced.
 
 * `TauCeti.PlumbingGraph.characteristicWeightNumerator`: the even numerator
   `⟨k, x⟩ + x · x`.
-* `TauCeti.PlumbingGraph.characteristicWeight`: the integer weight `χ_k(x)`.
+* `TauCeti.PlumbingGraph.characteristicWeight`: the integer weight `χ_k(x)` for characteristic
+  covectors.
 
 ## Main results
 
@@ -89,31 +90,30 @@ theorem even_characteristicWeightNumerator {k : V → ℤ} (hk : P.IsCharacteris
 
 /-- The characteristic-weight expression obtained by integer-dividing
 `-(⟨k, x⟩ + x · x)` by `2`. For a characteristic covector, the numerator is even by
-`even_characteristicWeightNumerator`, and `two_mul_characteristicWeight` states the exact
-characteristic-weight equation. -/
-@[expose] noncomputable def characteristicWeight (k x : V → ℤ) : ℤ :=
-  -(P.characteristicWeightNumerator k x / 2)
+`even_characteristicWeightNumerator`, and `two_mul_characteristicWeight` states its exact
+doubling equation. -/
+@[expose] noncomputable def characteristicWeight (k : P.characteristicVectors) (x : V → ℤ) : ℤ :=
+  -(P.characteristicWeightNumerator k.val x / 2)
 
 /-- The characteristic weight as the negative half of its numerator. -/
-theorem characteristicWeight_def (k x : V → ℤ) :
-    P.characteristicWeight k x = -(P.characteristicWeightNumerator k x / 2) :=
+theorem characteristicWeight_def (k : P.characteristicVectors) (x : V → ℤ) :
+    P.characteristicWeight k x = -(P.characteristicWeightNumerator k.val x / 2) :=
   rfl
 
 /-- The defining equation for the integer-valued characteristic weight. -/
-theorem two_mul_characteristicWeight {k : V → ℤ} (hk : P.IsCharacteristicVector k)
-    (x : V → ℤ) :
-    2 * P.characteristicWeight k x = -P.characteristicWeightNumerator k x := by
-  have hdvd : (2 : ℤ) ∣ P.characteristicWeightNumerator k x :=
-    even_iff_two_dvd.mp (P.even_characteristicWeightNumerator hk x)
-  have hcancel : P.characteristicWeightNumerator k x / 2 * 2 =
-      P.characteristicWeightNumerator k x :=
+theorem two_mul_characteristicWeight (k : P.characteristicVectors) (x : V → ℤ) :
+    2 * P.characteristicWeight k x = -P.characteristicWeightNumerator k.val x := by
+  have hdvd : (2 : ℤ) ∣ P.characteristicWeightNumerator k.val x :=
+    even_iff_two_dvd.mp (P.even_characteristicWeightNumerator k.property x)
+  have hcancel : P.characteristicWeightNumerator k.val x / 2 * 2 =
+      P.characteristicWeightNumerator k.val x :=
     Int.ediv_mul_cancel hdvd
   rw [characteristicWeight_def]
   linarith
 
 /-- The characteristic weight at the zero lattice point is zero. -/
 @[simp]
-theorem characteristicWeight_zero (k : V → ℤ) :
+theorem characteristicWeight_zero (k : P.characteristicVectors) :
     P.characteristicWeight k 0 = 0 := by
   rw [characteristicWeight_def, characteristicWeightNumerator_def]
   rw [map_zero]
@@ -134,9 +134,9 @@ theorem characteristicWeightNumerator_add_two_mul (k l x : V → ℤ) :
   ring
 
 /-- Shifting a covector by `2l` subtracts the linear pairing `⟨l, x⟩` from the
-characteristic-weight expression. -/
-theorem characteristicWeight_add_two_mul (k l x : V → ℤ) :
-    P.characteristicWeight (fun v => k v + 2 * l v) x =
+characteristic weight. -/
+theorem characteristicWeight_add_two_mul (k : P.characteristicVectors) (l x : V → ℤ) :
+    P.characteristicWeight ⟨fun v => k.val v + 2 * l v, k.property.add_two_mul⟩ x =
       P.characteristicWeight k x - ∑ v, l v * x v := by
   rw [characteristicWeight_def, characteristicWeight_def,
     characteristicWeightNumerator_add_two_mul]
@@ -145,17 +145,11 @@ theorem characteristicWeight_add_two_mul (k l x : V → ℤ) :
 
 /-- The numerator of any covector on a plumbing basis sphere is the covector coordinate plus the
 sphere weight. -/
+@[simp]
 theorem characteristicWeightNumerator_single (k : V → ℤ) (v : V) :
     P.characteristicWeightNumerator k (Pi.single v 1) = k v + P.weight v := by
   rw [characteristicWeightNumerator_def, intersectionForm_single, intersectionMatrix_diag]
-  have hsum : (∑ w, k w * (Pi.single v (1 : ℤ) : V → ℤ) w) = k v := by
-    rw [Finset.sum_eq_single v]
-    · simp
-    · intro w _ hw
-      simp [Pi.single_eq_of_ne hw]
-    · intro hv
-      exact absurd (Finset.mem_univ v) hv
-  rw [hsum]
+  rw [covector_eval_single]
 
 /-- The numerator of the canonical characteristic covector on a basis sphere is `-2`. -/
 theorem characteristicWeightNumerator_canonical_single (v : V) :
@@ -165,15 +159,20 @@ theorem characteristicWeightNumerator_canonical_single (v : V) :
     P.canonicalCharacteristic_apply_add_intersection_single v
 
 /-- The characteristic weight of any covector on a plumbing basis sphere. -/
-theorem characteristicWeight_single (k : V → ℤ) (v : V) :
-    P.characteristicWeight k (Pi.single v 1) = -((k v + P.weight v) / 2) := by
+@[simp]
+theorem characteristicWeight_single (k : P.characteristicVectors) (v : V) :
+    P.characteristicWeight k (Pi.single v 1) = -((k.val v + P.weight v) / 2) := by
   rw [characteristicWeight_def, characteristicWeightNumerator_single]
 
 /-- The canonical characteristic covector has characteristic weight `1` on each basis sphere. -/
 @[simp]
 theorem characteristicWeight_canonical_single (v : V) :
-    P.characteristicWeight P.canonicalCharacteristic (Pi.single v 1) = 1 := by
-  rw [characteristicWeight_single, canonicalCharacteristic_apply]
+    P.characteristicWeight
+      ⟨P.canonicalCharacteristic, P.isCharacteristicVector_canonicalCharacteristic⟩
+      (Pi.single v 1) = 1 := by
+  rw [characteristicWeight_single]
+  change -((P.canonicalCharacteristic v + P.weight v) / 2) = 1
+  rw [canonicalCharacteristic_apply]
   have h : -P.weight v - 2 + P.weight v = -2 := by ring
   rw [h]
   norm_num

--- a/TauCeti/LowDimTopology/Plumbing/Weight.lean
+++ b/TauCeti/LowDimTopology/Plumbing/Weight.lean
@@ -129,18 +129,23 @@ theorem characteristicWeight_zero (k : P.characteristicVectors) :
   rw [map_zero]
   simp
 
+/-- The numerator is additive in its covector argument: shifting `k` by `l` adds the linear
+pairing `⟨l, x⟩`. -/
+theorem characteristicWeightNumerator_add (k l x : V → ℤ) :
+    P.characteristicWeightNumerator (fun v => k v + l v) x =
+      P.characteristicWeightNumerator k x + ∑ v, l v * x v := by
+  rw [characteristicWeightNumerator_def, characteristicWeightNumerator_def]
+  simp_rw [add_mul]
+  rw [Finset.sum_add_distrib]
+  ring
+
 /-- The numerator for a covector shifted by twice another covector. -/
 theorem characteristicWeightNumerator_add_two_mul (k l x : V → ℤ) :
     P.characteristicWeightNumerator (fun v => k v + 2 * l v) x =
       P.characteristicWeightNumerator k x + 2 * ∑ v, l v * x v := by
-  rw [characteristicWeightNumerator_def, characteristicWeightNumerator_def]
-  simp_rw [add_mul]
-  rw [Finset.sum_add_distrib]
-  have htwo : (∑ v, 2 * l v * x v) = 2 * ∑ v, l v * x v := by
-    rw [Finset.mul_sum]
-    refine Finset.sum_congr rfl fun v _ => ?_
-    ring
-  rw [htwo]
+  rw [P.characteristicWeightNumerator_add k (fun v => 2 * l v) x, Finset.mul_sum]
+  congr 1
+  refine Finset.sum_congr rfl fun v _ => ?_
   ring
 
 /-- Shifting a covector by `2l` subtracts the linear pairing `⟨l, x⟩` from the

--- a/TauCeti/LowDimTopology/Plumbing/Weight.lean
+++ b/TauCeti/LowDimTopology/Plumbing/Weight.lean
@@ -60,13 +60,18 @@ variable {V : Type*} [DecidableEq V] [Fintype V] (P : PlumbingGraph V)
 /-- The numerator of the characteristic weight function:
 `⟨k, x⟩ + x · x`, where `x · x` is the plumbing intersection form. For a characteristic covector
 `k`, this numerator is even; see `even_characteristicWeightNumerator`. -/
-@[expose] noncomputable def characteristicWeightNumerator (k x : V → ℤ) : ℤ :=
+noncomputable def characteristicWeightNumerator (k x : V → ℤ) : ℤ :=
   (∑ v, k v * x v) + P.intersectionForm x x
+
+/-- The numerator of the characteristic weight function, expanded as the defining sum. -/
+private theorem characteristicWeightNumerator_def_aux (k x : V → ℤ) :
+    P.characteristicWeightNumerator k x = (∑ v, k v * x v) + P.intersectionForm x x :=
+  rfl
 
 /-- The numerator of the characteristic weight function, expanded as the defining sum. -/
 theorem characteristicWeightNumerator_def (k x : V → ℤ) :
     P.characteristicWeightNumerator k x = (∑ v, k v * x v) + P.intersectionForm x x :=
-  rfl
+  characteristicWeightNumerator_def_aux P k x
 
 /-- The characteristic-weight numerator is even when `k` is characteristic. This is the
 integer-valuedness input for the lattice-homology weight function. -/
@@ -92,13 +97,18 @@ theorem even_characteristicWeightNumerator {k : V → ℤ} (hk : P.IsCharacteris
 `-(⟨k, x⟩ + x · x)` by `2`. For a characteristic covector, the numerator is even by
 `even_characteristicWeightNumerator`, and `two_mul_characteristicWeight` states its exact
 doubling equation. -/
-@[expose] noncomputable def characteristicWeight (k : P.characteristicVectors) (x : V → ℤ) : ℤ :=
+noncomputable def characteristicWeight (k : P.characteristicVectors) (x : V → ℤ) : ℤ :=
   -(P.characteristicWeightNumerator k.val x / 2)
+
+/-- The characteristic weight as the negative half of its numerator. -/
+private theorem characteristicWeight_def_aux (k : P.characteristicVectors) (x : V → ℤ) :
+    P.characteristicWeight k x = -(P.characteristicWeightNumerator k.val x / 2) :=
+  rfl
 
 /-- The characteristic weight as the negative half of its numerator. -/
 theorem characteristicWeight_def (k : P.characteristicVectors) (x : V → ℤ) :
     P.characteristicWeight k x = -(P.characteristicWeightNumerator k.val x / 2) :=
-  rfl
+  characteristicWeight_def_aux P k x
 
 /-- The defining equation for the integer-valued characteristic weight. -/
 theorem two_mul_characteristicWeight (k : P.characteristicVectors) (x : V → ℤ) :
@@ -143,6 +153,15 @@ theorem characteristicWeight_add_two_mul (k : P.characteristicVectors) (l x : V 
   rw [Int.add_mul_ediv_left _ _ (by norm_num : (2 : ℤ) ≠ 0)]
   ring
 
+private theorem covector_eval_single (k : V → ℤ) (v : V) :
+    (∑ w, k w * (Pi.single v (1 : ℤ) : V → ℤ) w) = k v := by
+  rw [Finset.sum_eq_single v]
+  · simp
+  · intro w _ hw
+    simp [Pi.single_eq_of_ne hw]
+  · intro hv
+    exact absurd (Finset.mem_univ v) hv
+
 /-- The numerator of any covector on a plumbing basis sphere is the covector coordinate plus the
 sphere weight. -/
 @[simp]
@@ -158,7 +177,7 @@ theorem characteristicWeightNumerator_canonical_single (v : V) :
   simpa [intersectionForm_single, intersectionMatrix_diag] using
     P.canonicalCharacteristic_apply_add_intersection_single v
 
-/-- The characteristic weight of any covector on a plumbing basis sphere. -/
+/-- The characteristic weight of any characteristic covector on a plumbing basis sphere. -/
 @[simp]
 theorem characteristicWeight_single (k : P.characteristicVectors) (v : V) :
     P.characteristicWeight k (Pi.single v 1) = -((k.val v + P.weight v) / 2) := by
@@ -170,11 +189,7 @@ theorem characteristicWeight_canonical_single (v : V) :
     P.characteristicWeight
       ⟨P.canonicalCharacteristic, P.isCharacteristicVector_canonicalCharacteristic⟩
       (Pi.single v 1) = 1 := by
-  rw [characteristicWeight_single]
-  change -((P.canonicalCharacteristic v + P.weight v) / 2) = 1
-  rw [canonicalCharacteristic_apply]
-  have h : -P.weight v - 2 + P.weight v = -2 := by ring
-  rw [h]
+  rw [characteristicWeight_def, characteristicWeightNumerator_canonical_single]
   norm_num
 
 end PlumbingGraph

--- a/TauCeti/LowDimTopology/Plumbing/Weight.lean
+++ b/TauCeti/LowDimTopology/Plumbing/Weight.lean
@@ -59,11 +59,11 @@ variable {V : Type*} [DecidableEq V] [Fintype V] (P : PlumbingGraph V)
 /-- The numerator of the characteristic weight function:
 `⟨k, x⟩ + x · x`, where `x · x` is the plumbing intersection form. For a characteristic covector
 `k`, this numerator is even; see `even_characteristicWeightNumerator`. -/
-noncomputable def characteristicWeightNumerator (k x : V → ℤ) : ℤ :=
+@[expose] noncomputable def characteristicWeightNumerator (k x : V → ℤ) : ℤ :=
   (∑ v, k v * x v) + P.intersectionForm x x
 
 /-- The numerator of the characteristic weight function, expanded as the defining sum. -/
-private theorem characteristicWeightNumerator_def (k x : V → ℤ) :
+theorem characteristicWeightNumerator_def (k x : V → ℤ) :
     P.characteristicWeightNumerator k x = (∑ v, k v * x v) + P.intersectionForm x x :=
   rfl
 
@@ -91,11 +91,11 @@ theorem even_characteristicWeightNumerator {k : V → ℤ} (hk : P.IsCharacteris
 `-(⟨k, x⟩ + x · x)` by `2`. For a characteristic covector, the numerator is even by
 `even_characteristicWeightNumerator`, and `two_mul_characteristicWeight` states the exact
 characteristic-weight equation. -/
-noncomputable def characteristicWeight (k x : V → ℤ) : ℤ :=
+@[expose] noncomputable def characteristicWeight (k x : V → ℤ) : ℤ :=
   -(P.characteristicWeightNumerator k x / 2)
 
 /-- The characteristic weight as the negative half of its numerator. -/
-private theorem characteristicWeight_def (k x : V → ℤ) :
+theorem characteristicWeight_def (k x : V → ℤ) :
     P.characteristicWeight k x = -(P.characteristicWeightNumerator k x / 2) :=
   rfl
 
@@ -147,8 +147,15 @@ theorem characteristicWeight_add_two_mul (k l x : V → ℤ) :
 sphere weight. -/
 theorem characteristicWeightNumerator_single (k : V → ℤ) (v : V) :
     P.characteristicWeightNumerator k (Pi.single v 1) = k v + P.weight v := by
-  rw [characteristicWeightNumerator_def, covector_eval_single, intersectionForm_single,
-    intersectionMatrix_diag]
+  rw [characteristicWeightNumerator_def, intersectionForm_single, intersectionMatrix_diag]
+  have hsum : (∑ w, k w * (Pi.single v (1 : ℤ) : V → ℤ) w) = k v := by
+    rw [Finset.sum_eq_single v]
+    · simp
+    · intro w _ hw
+      simp [Pi.single_eq_of_ne hw]
+    · intro hv
+      exact absurd (Finset.mem_univ v) hv
+  rw [hsum]
 
 /-- The numerator of the canonical characteristic covector on a basis sphere is `-2`. -/
 theorem characteristicWeightNumerator_canonical_single (v : V) :
@@ -157,14 +164,19 @@ theorem characteristicWeightNumerator_canonical_single (v : V) :
   simpa [intersectionForm_single, intersectionMatrix_diag] using
     P.canonicalCharacteristic_apply_add_intersection_single v
 
+/-- The characteristic weight of any covector on a plumbing basis sphere. -/
+theorem characteristicWeight_single (k : V → ℤ) (v : V) :
+    P.characteristicWeight k (Pi.single v 1) = -((k v + P.weight v) / 2) := by
+  rw [characteristicWeight_def, characteristicWeightNumerator_single]
+
 /-- The canonical characteristic covector has characteristic weight `1` on each basis sphere. -/
 @[simp]
 theorem characteristicWeight_canonical_single (v : V) :
     P.characteristicWeight P.canonicalCharacteristic (Pi.single v 1) = 1 := by
-  have htwo := P.two_mul_characteristicWeight P.isCharacteristicVector_canonicalCharacteristic
-    (Pi.single v (1 : ℤ) : V → ℤ)
-  rw [characteristicWeightNumerator_canonical_single] at htwo
-  omega
+  rw [characteristicWeight_single, canonicalCharacteristic_apply]
+  have h : -P.weight v - 2 + P.weight v = -2 := by ring
+  rw [h]
+  norm_num
 
 end PlumbingGraph
 

--- a/TauCeti/LowDimTopology/Plumbing/Weight.lean
+++ b/TauCeti/LowDimTopology/Plumbing/Weight.lean
@@ -34,8 +34,8 @@ cube weights and `ℤ[U]` complexes are introduced.
   numerator even.
 * `TauCeti.PlumbingGraph.two_mul_characteristicWeight`: the defining equation
   `2 * χ_k(x) = - (⟨k, x⟩ + x · x)`.
-* `TauCeti.PlumbingGraph.characteristicWeight_add_two_mul`: shifting a characteristic covector
-  by `2l` subtracts `⟨l, x⟩` from the weight.
+* `TauCeti.PlumbingGraph.characteristicWeight_add_two_mul`: shifting a covector by `2l`
+  subtracts `⟨l, x⟩` from the weight.
 * `TauCeti.PlumbingGraph.characteristicWeight_canonical_single`: the canonical characteristic
   covector gives weight `1` on each basis sphere.
 
@@ -59,11 +59,11 @@ variable {V : Type*} [DecidableEq V] [Fintype V] (P : PlumbingGraph V)
 /-- The numerator of the characteristic weight function:
 `⟨k, x⟩ + x · x`, where `x · x` is the plumbing intersection form. For a characteristic covector
 `k`, this numerator is even; see `even_characteristicWeightNumerator`. -/
-@[expose] noncomputable def characteristicWeightNumerator (k x : V → ℤ) : ℤ :=
+noncomputable def characteristicWeightNumerator (k x : V → ℤ) : ℤ :=
   (∑ v, k v * x v) + P.intersectionForm x x
 
 /-- The numerator of the characteristic weight function, expanded as the defining sum. -/
-theorem characteristicWeightNumerator_def (k x : V → ℤ) :
+private theorem characteristicWeightNumerator_def (k x : V → ℤ) :
     P.characteristicWeightNumerator k x = (∑ v, k v * x v) + P.intersectionForm x x :=
   rfl
 
@@ -87,14 +87,15 @@ theorem even_characteristicWeightNumerator {k : V → ℤ} (hk : P.IsCharacteris
       rw [hm]
       ring
 
-/-- The characteristic weight `χ_k(x) = -(⟨k, x⟩ + x · x) / 2`. The exact halving is justified by
-`even_characteristicWeightNumerator`; the definition uses integer division, with
-`two_mul_characteristicWeight` as the characteristic equation. -/
-@[expose] noncomputable def characteristicWeight (k x : V → ℤ) : ℤ :=
+/-- The characteristic-weight expression obtained by integer-dividing
+`-(⟨k, x⟩ + x · x)` by `2`. For a characteristic covector, the numerator is even by
+`even_characteristicWeightNumerator`, and `two_mul_characteristicWeight` states the exact
+characteristic-weight equation. -/
+noncomputable def characteristicWeight (k x : V → ℤ) : ℤ :=
   -(P.characteristicWeightNumerator k x / 2)
 
 /-- The characteristic weight as the negative half of its numerator. -/
-theorem characteristicWeight_def (k x : V → ℤ) :
+private theorem characteristicWeight_def (k x : V → ℤ) :
     P.characteristicWeight k x = -(P.characteristicWeightNumerator k x / 2) :=
   rfl
 
@@ -132,32 +133,29 @@ theorem characteristicWeightNumerator_add_two_mul (k l x : V → ℤ) :
   rw [htwo]
   ring
 
-/-- Shifting a characteristic covector by `2l` subtracts the linear pairing `⟨l, x⟩` from the
-characteristic weight. -/
-theorem characteristicWeight_add_two_mul {k l : V → ℤ} (hk : P.IsCharacteristicVector k)
-    (x : V → ℤ) :
+/-- Shifting a covector by `2l` subtracts the linear pairing `⟨l, x⟩` from the
+characteristic-weight expression. -/
+theorem characteristicWeight_add_two_mul (k l x : V → ℤ) :
     P.characteristicWeight (fun v => k v + 2 * l v) x =
       P.characteristicWeight k x - ∑ v, l v * x v := by
-  have hshift : P.IsCharacteristicVector fun v => k v + 2 * l v := hk.add_two_mul
-  have hleft := P.two_mul_characteristicWeight hshift x
-  have hright := P.two_mul_characteristicWeight hk x
-  rw [characteristicWeightNumerator_add_two_mul] at hleft
-  linarith
+  rw [characteristicWeight_def, characteristicWeight_def,
+    characteristicWeightNumerator_add_two_mul]
+  rw [Int.add_mul_ediv_left _ _ (by norm_num : (2 : ℤ) ≠ 0)]
+  ring
+
+/-- The numerator of any covector on a plumbing basis sphere is the covector coordinate plus the
+sphere weight. -/
+theorem characteristicWeightNumerator_single (k : V → ℤ) (v : V) :
+    P.characteristicWeightNumerator k (Pi.single v 1) = k v + P.weight v := by
+  rw [characteristicWeightNumerator_def, covector_eval_single, intersectionForm_single,
+    intersectionMatrix_diag]
 
 /-- The numerator of the canonical characteristic covector on a basis sphere is `-2`. -/
 theorem characteristicWeightNumerator_canonical_single (v : V) :
     P.characteristicWeightNumerator P.canonicalCharacteristic (Pi.single v 1) = -2 := by
-  rw [characteristicWeightNumerator_def]
-  have hsum : (∑ w, P.canonicalCharacteristic w * (Pi.single v (1 : ℤ) : V → ℤ) w) =
-      P.canonicalCharacteristic v := by
-    rw [Finset.sum_eq_single v]
-    · simp
-    · intro w _ hw
-      simp [Pi.single_eq_of_ne hw]
-    · intro hv
-      exact absurd (Finset.mem_univ v) hv
-  rw [hsum]
-  exact P.canonicalCharacteristic_apply_add_intersection_single v
+  rw [characteristicWeightNumerator_single]
+  simpa [intersectionForm_single, intersectionMatrix_diag] using
+    P.canonicalCharacteristic_apply_add_intersection_single v
 
 /-- The canonical characteristic covector has characteristic weight `1` on each basis sphere. -/
 @[simp]

--- a/TauCeti/LowDimTopology/Plumbing/Weight.lean
+++ b/TauCeti/LowDimTopology/Plumbing/Weight.lean
@@ -1,0 +1,173 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+module
+
+public import TauCeti.LowDimTopology.Plumbing.Characteristic
+
+/-!
+# The characteristic weight function of a plumbing lattice
+
+This file adds the integer-valued quadratic weight attached to a characteristic covector on the
+integral lattice of a plumbing graph. For a characteristic covector `k` and a lattice point
+`x : V → ℤ`, the numerator
+
+`∑ v, k v * x v + P.intersectionForm x x`
+
+is even, so the lattice-homology weight
+
+`-(∑ v, k v * x v + P.intersectionForm x x) / 2`
+
+is an integer. This is the local `χ_k(x)` function used in the lattice-homology lane before the
+cube weights and `ℤ[U]` complexes are introduced.
+
+## Main definitions
+
+* `TauCeti.PlumbingGraph.characteristicWeightNumerator`: the even numerator
+  `⟨k, x⟩ + x · x`.
+* `TauCeti.PlumbingGraph.characteristicWeight`: the integer weight `χ_k(x)`.
+
+## Main results
+
+* `TauCeti.PlumbingGraph.even_characteristicWeightNumerator`: characteristicness makes the
+  numerator even.
+* `TauCeti.PlumbingGraph.two_mul_characteristicWeight`: the defining equation
+  `2 * χ_k(x) = - (⟨k, x⟩ + x · x)`.
+* `TauCeti.PlumbingGraph.characteristicWeight_add_two_mul`: shifting a characteristic covector
+  by `2l` subtracts `⟨l, x⟩` from the weight.
+* `TauCeti.PlumbingGraph.characteristicWeight_canonical_single`: the canonical characteristic
+  covector gives weight `1` on each basis sphere.
+
+## References
+
+This supplies a prerequisite for `TauCetiRoadmap/CombinatorialHeegaardFloer/README.md`, Lane L
+("lattice homology"), whose opening data asks for plumbing graphs, their lattices, characteristic
+covectors, and weight functions. The convention `χ_k(x) = -(k(x) + x · x) / 2` follows Némethi,
+[arXiv:0709.0841](https://arxiv.org/abs/0709.0841), after Ozsváth--Szabó,
+[arXiv:math/0203265](https://arxiv.org/abs/math/0203265).
+-/
+
+public section
+
+namespace TauCeti
+
+namespace PlumbingGraph
+
+variable {V : Type*} [DecidableEq V] [Fintype V] (P : PlumbingGraph V)
+
+/-- The numerator of the characteristic weight function:
+`⟨k, x⟩ + x · x`, where `x · x` is the plumbing intersection form. For a characteristic covector
+`k`, this numerator is even; see `even_characteristicWeightNumerator`. -/
+@[expose] noncomputable def characteristicWeightNumerator (k x : V → ℤ) : ℤ :=
+  (∑ v, k v * x v) + P.intersectionForm x x
+
+/-- The numerator of the characteristic weight function, expanded as the defining sum. -/
+theorem characteristicWeightNumerator_def (k x : V → ℤ) :
+    P.characteristicWeightNumerator k x = (∑ v, k v * x v) + P.intersectionForm x x :=
+  rfl
+
+/-- The characteristic-weight numerator is even when `k` is characteristic. This is the
+integer-valuedness input for the lattice-homology weight function. -/
+theorem even_characteristicWeightNumerator {k : V → ℤ} (hk : P.IsCharacteristicVector k)
+    (x : V → ℤ) : Even (P.characteristicWeightNumerator k x) := by
+  have hmod :
+      (∑ v, k v * x v) ≡ P.intersectionForm x x [ZMOD 2] :=
+    (P.isCharacteristicVector_iff_forall_modEq_intersectionForm k).mp hk x
+  have hdvd : (2 : ℤ) ∣ P.intersectionForm x x - ∑ v, k v * x v :=
+    Int.modEq_iff_dvd.mp hmod
+  obtain ⟨m, hm⟩ := hdvd
+  refine even_iff_two_dvd.mpr ⟨m + ∑ v, k v * x v, ?_⟩
+  calc
+    P.characteristicWeightNumerator k x =
+        (P.intersectionForm x x - ∑ v, k v * x v) + 2 * ∑ v, k v * x v := by
+      rw [characteristicWeightNumerator_def]
+      ring
+    _ = 2 * (m + ∑ v, k v * x v) := by
+      rw [hm]
+      ring
+
+/-- The characteristic weight `χ_k(x) = -(⟨k, x⟩ + x · x) / 2`. The exact halving is justified by
+`even_characteristicWeightNumerator`; the definition uses integer division, with
+`two_mul_characteristicWeight` as the characteristic equation. -/
+@[expose] noncomputable def characteristicWeight (k x : V → ℤ) : ℤ :=
+  -(P.characteristicWeightNumerator k x / 2)
+
+/-- The characteristic weight as the negative half of its numerator. -/
+theorem characteristicWeight_def (k x : V → ℤ) :
+    P.characteristicWeight k x = -(P.characteristicWeightNumerator k x / 2) :=
+  rfl
+
+/-- The defining equation for the integer-valued characteristic weight. -/
+theorem two_mul_characteristicWeight {k : V → ℤ} (hk : P.IsCharacteristicVector k)
+    (x : V → ℤ) :
+    2 * P.characteristicWeight k x = -P.characteristicWeightNumerator k x := by
+  have hdvd : (2 : ℤ) ∣ P.characteristicWeightNumerator k x :=
+    even_iff_two_dvd.mp (P.even_characteristicWeightNumerator hk x)
+  have hcancel : P.characteristicWeightNumerator k x / 2 * 2 =
+      P.characteristicWeightNumerator k x :=
+    Int.ediv_mul_cancel hdvd
+  rw [characteristicWeight_def]
+  linarith
+
+/-- The characteristic weight at the zero lattice point is zero. -/
+@[simp]
+theorem characteristicWeight_zero (k : V → ℤ) :
+    P.characteristicWeight k 0 = 0 := by
+  rw [characteristicWeight_def, characteristicWeightNumerator_def]
+  rw [map_zero]
+  simp
+
+/-- The numerator for a covector shifted by twice another covector. -/
+theorem characteristicWeightNumerator_add_two_mul (k l x : V → ℤ) :
+    P.characteristicWeightNumerator (fun v => k v + 2 * l v) x =
+      P.characteristicWeightNumerator k x + 2 * ∑ v, l v * x v := by
+  rw [characteristicWeightNumerator_def, characteristicWeightNumerator_def]
+  simp_rw [add_mul]
+  rw [Finset.sum_add_distrib]
+  have htwo : (∑ v, 2 * l v * x v) = 2 * ∑ v, l v * x v := by
+    rw [Finset.mul_sum]
+    refine Finset.sum_congr rfl fun v _ => ?_
+    ring
+  rw [htwo]
+  ring
+
+/-- Shifting a characteristic covector by `2l` subtracts the linear pairing `⟨l, x⟩` from the
+characteristic weight. -/
+theorem characteristicWeight_add_two_mul {k l : V → ℤ} (hk : P.IsCharacteristicVector k)
+    (x : V → ℤ) :
+    P.characteristicWeight (fun v => k v + 2 * l v) x =
+      P.characteristicWeight k x - ∑ v, l v * x v := by
+  have hshift : P.IsCharacteristicVector fun v => k v + 2 * l v := hk.add_two_mul
+  have hleft := P.two_mul_characteristicWeight hshift x
+  have hright := P.two_mul_characteristicWeight hk x
+  rw [characteristicWeightNumerator_add_two_mul] at hleft
+  linarith
+
+/-- The numerator of the canonical characteristic covector on a basis sphere is `-2`. -/
+theorem characteristicWeightNumerator_canonical_single (v : V) :
+    P.characteristicWeightNumerator P.canonicalCharacteristic (Pi.single v 1) = -2 := by
+  rw [characteristicWeightNumerator_def]
+  have hsum : (∑ w, P.canonicalCharacteristic w * (Pi.single v (1 : ℤ) : V → ℤ) w) =
+      P.canonicalCharacteristic v := by
+    rw [Finset.sum_eq_single v]
+    · simp
+    · intro w _ hw
+      simp [Pi.single_eq_of_ne hw]
+    · intro hv
+      exact absurd (Finset.mem_univ v) hv
+  rw [hsum]
+  exact P.canonicalCharacteristic_apply_add_intersection_single v
+
+/-- The canonical characteristic covector has characteristic weight `1` on each basis sphere. -/
+@[simp]
+theorem characteristicWeight_canonical_single (v : V) :
+    P.characteristicWeight P.canonicalCharacteristic (Pi.single v 1) = 1 := by
+  have htwo := P.two_mul_characteristicWeight P.isCharacteristicVector_canonicalCharacteristic
+    (Pi.single v (1 : ℤ) : V → ℤ)
+  rw [characteristicWeightNumerator_canonical_single] at htwo
+  omega
+
+end PlumbingGraph
+
+end TauCeti

--- a/TauCeti/LowDimTopology/Plumbing/Weight.lean
+++ b/TauCeti/LowDimTopology/Plumbing/Weight.lean
@@ -158,22 +158,13 @@ theorem characteristicWeight_add_two_mul (k : P.characteristicVectors) (l x : V 
   rw [Int.add_mul_ediv_left _ _ (by norm_num : (2 : ℤ) ≠ 0)]
   ring
 
-private theorem covector_eval_single (k : V → ℤ) (v : V) :
-    (∑ w, k w * (Pi.single v (1 : ℤ) : V → ℤ) w) = k v := by
-  rw [Finset.sum_eq_single v]
-  · simp
-  · intro w _ hw
-    simp [Pi.single_eq_of_ne hw]
-  · intro hv
-    exact absurd (Finset.mem_univ v) hv
-
 /-- The numerator of any covector on a plumbing basis sphere is the covector coordinate plus the
 sphere weight. -/
 @[simp]
 theorem characteristicWeightNumerator_single (k : V → ℤ) (v : V) :
     P.characteristicWeightNumerator k (Pi.single v 1) = k v + P.weight v := by
   rw [characteristicWeightNumerator_def, intersectionForm_single, intersectionMatrix_diag]
-  rw [covector_eval_single]
+  simp [Pi.single_apply, Finset.sum_ite_eq']
 
 /-- The numerator of the canonical characteristic covector on a basis sphere is `-2`. -/
 theorem characteristicWeightNumerator_canonical_single (v : V) :


### PR DESCRIPTION
This PR adds the integer-valued characteristic weight function for plumbing lattices: for a characteristic covector `k` and lattice point `x`, it names the numerator `⟨k, x⟩ + x · x`, proves that numerator is even, defines `χ_k(x) = -(⟨k, x⟩ + x · x) / 2`, and records the exact doubling equation, the zero value, the `k + 2l` shift formula, and the canonical basis value `χ_K(E_v) = 1`. Use this as the weight-function layer that lattice homology needs before cube weights and the `ℤ[U]` complex are introduced.

This advances `TauCetiRoadmap/CombinatorialHeegaardFloer/README.md`, Lane L ("lattice homology"), specifically the opening data asking for plumbing graphs and their lattices together with lattice points and weight functions. I chose it as the lowest-hanging distinct target after checking open and recently merged PRs: plumbing intersection forms and characteristic covectors are already on `main`, while the characteristic weight function was the next small prerequisite and does not overlap the open grid-rectangle-count PR.

No Mathlib infrastructure is vendored. The implementation reuses Tau Ceti's `PlumbingGraph.intersectionForm` and `IsCharacteristicVector` parity theorem `isCharacteristicVector_iff_forall_modEq_intersectionForm`; the convention `χ_k(x) = -(k(x) + x · x) / 2` follows Némethi, arXiv:0709.0841, after Ozsváth--Szabó, arXiv:math/0203265.

Local verification: `lake exe cache get` completed with `No files to download` and `Already decompressed 8585 file(s)`; `lake build` completed with `Build completed successfully (4205 jobs).`; `lake exe axioms` completed with `axioms: audited 4821 TauCeti declaration(s); all within the allowlist [propext, Classical.choice, Quot.sound].`

<!--tauceti-target:v1 {"focus":"CombinatorialHeegaardFloer","id":"plumbing-characteristic-weight-function"}-->

🤖 Prepared with Codex
