### PR TITLE
feat: add plumbing lattice chi weights

### DIFF
--- a/TauCeti/LowDimTopology/Plumbing/Weight.lean
+++ b/TauCeti/LowDimTopology/Plumbing/Weight.lean
@@ -22,6 +22,9 @@ is even, so the lattice-homology weight
 is an integer. This is the local `χ_k(x)` function used in the lattice-homology lane before the
 cube weights and `ℤ[U]` complexes are introduced.
 
+The numerator is defined for arbitrary covectors, while the weight itself is restricted to
+characteristic covectors so that the division by `2` has the expected integer meaning.
+
 ## Main definitions
 
 * `TauCeti.PlumbingGraph.characteristicWeightNumerator`: the even numerator


### PR DESCRIPTION
This PR adds the local lattice-homology `χₖ` weight formula for plumbing lattices: covector evaluation, the numerator `k(x) + x · x`, the integer-valued definition `χₖ(x) = -(k(x) + x · x) / 2`, and the basic zero and basis-vector computations. Use it as the arithmetic core for later cube weights, where the lattice-homology differential takes minima of this function over cube vertices.

This advances `TauCetiRoadmap/CombinatorialHeegaardFloer/README.md`, Lane L ("lattice homology"), specifically the item asking for "Plumbing trees/graphs and their lattices; Némethi's lattice (co)homology `ℍ⁻`/`ℍ⁰` as a `ℤ[U]`-module from lattice points and weight functions". I chose it as the lowest-hanging distinct CombinatorialHeegaardFloer target after checking open and recently merged PRs: the initial plumbing graph/intersection form and characteristic-covector parity layer already landed, while the immediate integer-valued `χₖ` weight arithmetic was still missing and does not overlap the open grid-rectangle counting PR.

No Mathlib infrastructure is vendored. The formula follows Némethi, [arXiv:0709.0841](https://arxiv.org/abs/0709.0841), and the implementation reuses Tau Ceti's existing `PlumbingGraph.intersectionForm` and `IsCharacteristicVector` parity theorem, together with Mathlib's integer parity and modular-congruence API.

Local verification: `lake exe cache get` completed with `No files to download` and `Already decompressed 8585 file(s)`; `lake build` completed with `Build completed successfully (4205 jobs).`; `lake exe axioms` completed with `axioms: audited 4830 TauCeti declaration(s); all within the allowlist [propext, Classical.choice, Quot.sound].`

<!--tauceti-target:v1 {"focus":"CombinatorialHeegaardFloer","id":"plumbing-lattice-chi-weight"}-->

🤖 Prepared with Codex
