### PR TITLE
feat: add plumbing cube weights

### DIFF
--- a/TauCeti/LowDimTopology/Plumbing/CubeWeight.lean
+++ b/TauCeti/LowDimTopology/Plumbing/CubeWeight.lean
@@ -86,18 +86,27 @@ private theorem cubeVertex_sum_mem_subsetSum {T S : Finset V} (hTS : T ⊆ S) :
 noncomputable def cubeVertices (x : V → ℤ) (S : Finset V) : Finset (V → ℤ) :=
   ((S.image fun v => Pi.single v (1 : ℤ)).subsetSum).image fun z => x + z
 
-/-- Membership in the vertex set of a plumbing cube. -/
+/-- A point is a vertex of the cube based at `x` with directions `S` exactly when it is
+`cubeVertex x T` for some subset `T ⊆ S` of the directions. -/
 theorem mem_cubeVertices (x : V → ℤ) (S : Finset V) (y : V → ℤ) :
-    y ∈ cubeVertices x S ↔
-      ∃ z ∈ (S.image fun v => Pi.single v (1 : ℤ)).subsetSum, x + z = y := by
+    y ∈ cubeVertices x S ↔ ∃ T ⊆ S, cubeVertex x T = y := by
   rw [cubeVertices, Finset.mem_image]
+  constructor
+  · rintro ⟨z, hz, rfl⟩
+    rw [Finset.mem_subsetSum_iff] at hz
+    obtain ⟨U, hU, rfl⟩ := hz
+    rw [Finset.subset_image_iff] at hU
+    obtain ⟨T, hTS, rfl⟩ := hU
+    exact ⟨T, hTS, by rw [cubeVertex, Finset.sum_image single_one_injective.injOn]⟩
+  · rintro ⟨T, hTS, rfl⟩
+    exact ⟨∑ v ∈ T, Pi.single v (1 : ℤ), cubeVertex_sum_mem_subsetSum hTS, rfl⟩
 
 /-- The base point is a vertex of every cube. -/
 @[simp]
 theorem base_mem_cubeVertices (x : V → ℤ) (S : Finset V) :
     x ∈ cubeVertices x S := by
   rw [mem_cubeVertices]
-  exact ⟨0, by simp, by simp⟩
+  exact ⟨∅, Finset.empty_subset S, cubeVertex_empty x⟩
 
 /-- The vertex set of a cube is nonempty. -/
 theorem cubeVertices_nonempty (x : V → ℤ) (S : Finset V) :
@@ -108,15 +117,27 @@ theorem cubeVertices_nonempty (x : V → ℤ) (S : Finset V) :
 theorem cubeVertex_subset_mem_cubeVertices {T S : Finset V} (hTS : T ⊆ S) (x : V → ℤ) :
     cubeVertex x T ∈ cubeVertices x S := by
   rw [mem_cubeVertices]
-  exact ⟨∑ v ∈ T, Pi.single v (1 : ℤ), cubeVertex_sum_mem_subsetSum hTS, by rw [cubeVertex]⟩
+  exact ⟨T, hTS, rfl⟩
 
 /-- The vertices of a subcube are vertices of the larger cube. -/
 theorem cubeVertices_subset {S T : Finset V} (hST : S ⊆ T) (x : V → ℤ) :
     cubeVertices x S ⊆ cubeVertices x T := by
   intro y hy
   rw [mem_cubeVertices] at hy ⊢
-  obtain ⟨z, hz, hzy⟩ := hy
-  exact ⟨z, Finset.subsetSum_mono (Finset.image_subset_image hST) hz, hzy⟩
+  obtain ⟨U, hUS, rfl⟩ := hy
+  exact ⟨U, hUS.trans hST, rfl⟩
+
+/-- The zero-dimensional cube has its base point as its only vertex. -/
+@[simp]
+theorem cubeVertices_empty (x : V → ℤ) : cubeVertices x ∅ = {x} := by
+  ext y
+  rw [mem_cubeVertices, Finset.mem_singleton]
+  constructor
+  · rintro ⟨T, hT, rfl⟩
+    rw [Finset.subset_empty.mp hT]
+    exact cubeVertex_empty x
+  · rintro rfl
+    exact ⟨∅, Finset.empty_subset _, cubeVertex_empty _⟩
 
 variable [Fintype V]
 
@@ -226,18 +247,8 @@ theorem characteristicCubeWeight_empty (P : PlumbingGraph V) (k : P.characterist
   apply le_antisymm
   · apply P.characteristicCubeWeight_le k
     intro z hz
-    rw [mem_cubeVertices] at hz
-    obtain ⟨u, hu, huz⟩ := hz
-    rw [Finset.mem_subsetSum_iff] at hu
-    obtain ⟨U, hU, hsum⟩ := hu
-    have hUeq : U = ∅ := by
-      rw [Finset.eq_empty_iff_forall_notMem]
-      intro a ha
-      exact (by simpa using hU ha)
-    have hu0 : u = 0 := by
-      rw [← hsum, hUeq]
-      simp
-    rw [← huz, hu0, add_zero]
+    rw [cubeVertices_empty, Finset.mem_singleton] at hz
+    rw [hz]
   · exact P.characteristicWeight_le_characteristicCubeWeight_base k x ∅
 
 end PlumbingGraph

--- a/TauCeti/LowDimTopology/Plumbing/CubeWeight.lean
+++ b/TauCeti/LowDimTopology/Plumbing/CubeWeight.lean
@@ -5,6 +5,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 module
 
 public import TauCeti.LowDimTopology.Plumbing.Weight
+public import Mathlib.Combinatorics.Additive.SubsetSum
 
 /-!
 # Cube weights in a plumbing lattice
@@ -42,14 +43,8 @@ variable {V : Type*} [DecidableEq V]
 
 /-- The lattice point obtained from a base point `x` by adding the plumbing basis vectors in
 `T`. This is the vertex of a lattice cube indexed by the subset `T` of its directions. -/
-@[expose]
 noncomputable def cubeVertex (x : V → ℤ) (T : Finset V) : V → ℤ :=
   x + ∑ v ∈ T, Pi.single v (1 : ℤ)
-
-/-- The cube vertex, expanded as the defining finite sum of basis vectors. -/
-theorem cubeVertex_def (x : V → ℤ) (T : Finset V) :
-    cubeVertex x T = x + ∑ v ∈ T, Pi.single v (1 : ℤ) :=
-  rfl
 
 /-- The vertex indexed by the empty subset is the base point. -/
 @[simp]
@@ -71,70 +66,86 @@ theorem cubeVertex_apply (x : V → ℤ) (T : Finset V) (v : V) :
   classical
   simp [cubeVertex, Finset.sum_apply, Pi.single_apply]
 
-variable [Fintype V]
+variable [DecidableEq (V → ℤ)]
+
+omit [DecidableEq (V → ℤ)] in
+private theorem single_one_injective : Function.Injective fun v : V => Pi.single v (1 : ℤ) := by
+  intro v w hvw
+  by_contra hne
+  have hcoord := congr_fun hvw v
+  simp [Pi.single, hne] at hcoord
+
+private theorem cubeVertex_sum_mem_subsetSum {T S : Finset V} (hTS : T ⊆ S) :
+    (∑ v ∈ T, Pi.single v (1 : ℤ)) ∈
+      (S.image fun v => Pi.single v (1 : ℤ)).subsetSum := by
+  rw [Finset.mem_subsetSum_iff]
+  refine ⟨T.image fun v => Pi.single v (1 : ℤ), Finset.image_subset_image hTS, ?_⟩
+  rw [Finset.sum_image single_one_injective.injOn]
 
 /-- The finite set of all vertices of the cube with base point `x` and directions `S`. -/
-@[expose]
 noncomputable def cubeVertices (x : V → ℤ) (S : Finset V) : Finset (V → ℤ) :=
-  S.powerset.image fun T => cubeVertex x T
+  ((S.image fun v => Pi.single v (1 : ℤ)).subsetSum).image fun z => x + z
 
 /-- Membership in the vertex set of a plumbing cube. -/
 theorem mem_cubeVertices (x : V → ℤ) (S : Finset V) (y : V → ℤ) :
-    y ∈ cubeVertices x S ↔ ∃ T : Finset V, T ⊆ S ∧ cubeVertex x T = y := by
-  simp [cubeVertices]
+    y ∈ cubeVertices x S ↔
+      ∃ z ∈ (S.image fun v => Pi.single v (1 : ℤ)).subsetSum, x + z = y := by
+  rw [cubeVertices, Finset.mem_image]
 
 /-- The base point is a vertex of every cube. -/
 @[simp]
-theorem cubeVertex_mem_cubeVertices (x : V → ℤ) (S : Finset V) :
+theorem base_mem_cubeVertices (x : V → ℤ) (S : Finset V) :
     x ∈ cubeVertices x S := by
   rw [mem_cubeVertices]
-  exact ⟨∅, by simp, by simp⟩
+  exact ⟨0, by simp, by simp⟩
 
 /-- The vertex set of a cube is nonempty. -/
 theorem cubeVertices_nonempty (x : V → ℤ) (S : Finset V) :
     (cubeVertices x S).Nonempty :=
-  ⟨x, cubeVertex_mem_cubeVertices x S⟩
+  ⟨x, base_mem_cubeVertices x S⟩
 
 /-- A direction subset determines a vertex of any cube containing those directions. -/
 theorem cubeVertex_subset_mem_cubeVertices {T S : Finset V} (hTS : T ⊆ S) (x : V → ℤ) :
     cubeVertex x T ∈ cubeVertices x S := by
   rw [mem_cubeVertices]
-  exact ⟨T, hTS, rfl⟩
+  exact ⟨∑ v ∈ T, Pi.single v (1 : ℤ), cubeVertex_sum_mem_subsetSum hTS, by rw [cubeVertex]⟩
 
 /-- The vertices of a subcube are vertices of the larger cube. -/
 theorem cubeVertices_subset {S T : Finset V} (hST : S ⊆ T) (x : V → ℤ) :
     cubeVertices x S ⊆ cubeVertices x T := by
   intro y hy
   rw [mem_cubeVertices] at hy ⊢
-  obtain ⟨U, hUS, rfl⟩ := hy
-  exact ⟨U, hUS.trans hST, rfl⟩
+  obtain ⟨z, hz, hzy⟩ := hy
+  exact ⟨z, Finset.subsetSum_mono (Finset.image_subset_image hST) hz, hzy⟩
+
+variable [Fintype V]
 
 /-- The characteristic weight values attained on the vertices of a plumbing cube. -/
-noncomputable def characteristicCubeWeightValues
+private noncomputable def characteristicCubeWeightValues
     (P : PlumbingGraph V)
     (k : P.characteristicVectors) (x : V → ℤ) (S : Finset V) : Finset ℤ :=
   (cubeVertices x S).image fun y => P.characteristicWeight k y
 
 /-- The value set for a plumbing cube is nonempty. -/
-theorem characteristicCubeWeightValues_nonempty
+private theorem characteristicCubeWeightValues_nonempty
     (P : PlumbingGraph V)
     (k : P.characteristicVectors) (x : V → ℤ) (S : Finset V) :
-    (P.characteristicCubeWeightValues k x S).Nonempty :=
+    (characteristicCubeWeightValues P k x S).Nonempty :=
   Finset.image_nonempty.mpr (cubeVertices_nonempty x S)
 
 /-- The characteristic cube weight is the maximum of the point weights over the cube's vertices. -/
 noncomputable def characteristicCubeWeight
-    (P : PlumbingGraph V)
-    (k : P.characteristicVectors) (x : V → ℤ) (S : Finset V) : ℤ :=
-  (P.characteristicCubeWeightValues k x S).max'
-    (P.characteristicCubeWeightValues_nonempty k x S)
+  (P : PlumbingGraph V)
+  (k : P.characteristicVectors) (x : V → ℤ) (S : Finset V) : ℤ :=
+  (characteristicCubeWeightValues P k x S).max'
+    (characteristicCubeWeightValues_nonempty P k x S)
 
 /-- A vertex weight is one of the values used to form the characteristic cube weight. -/
-theorem characteristicWeight_mem_characteristicCubeWeightValues
+private theorem characteristicWeight_mem_characteristicCubeWeightValues
     (P : PlumbingGraph V)
     (k : P.characteristicVectors) {x : V → ℤ} {S : Finset V} {y : V → ℤ}
     (hy : y ∈ cubeVertices x S) :
-    P.characteristicWeight k y ∈ P.characteristicCubeWeightValues k x S := by
+    P.characteristicWeight k y ∈ characteristicCubeWeightValues P k x S := by
   exact Finset.mem_image.mpr ⟨y, hy, rfl⟩
 
 /-- The point weight at any vertex is bounded above by the characteristic cube weight. -/
@@ -144,9 +155,42 @@ theorem characteristicWeight_le_characteristicCubeWeight
     (hy : y ∈ cubeVertices x S) :
     P.characteristicWeight k y ≤ P.characteristicCubeWeight k x S := by
   exact Finset.le_max'
-    (P.characteristicCubeWeightValues k x S)
+    (characteristicCubeWeightValues P k x S)
     (P.characteristicWeight k y)
-    (P.characteristicWeight_mem_characteristicCubeWeightValues k hy)
+    (characteristicWeight_mem_characteristicCubeWeightValues P k hy)
+
+/-- To bound a characteristic cube weight above, bound the weight at every vertex. -/
+theorem characteristicCubeWeight_le
+    (P : PlumbingGraph V)
+    (k : P.characteristicVectors) {x : V → ℤ} {S : Finset V} {n : ℤ}
+    (h : ∀ y ∈ cubeVertices x S, P.characteristicWeight k y ≤ n) :
+    P.characteristicCubeWeight k x S ≤ n := by
+  unfold characteristicCubeWeight
+  exact Finset.max'_le _ _ _ fun m hm => by
+    obtain ⟨y, hy, rfl⟩ := Finset.mem_image.mp hm
+    exact h y hy
+
+/-- A characteristic cube weight is bounded above by `n` iff every vertex weight is. -/
+theorem characteristicCubeWeight_le_iff
+    (P : PlumbingGraph V)
+    (k : P.characteristicVectors) {x : V → ℤ} {S : Finset V} {n : ℤ} :
+    P.characteristicCubeWeight k x S ≤ n ↔
+      ∀ y ∈ cubeVertices x S, P.characteristicWeight k y ≤ n :=
+  ⟨fun h _ hy => (P.characteristicWeight_le_characteristicCubeWeight k hy).trans h,
+    P.characteristicCubeWeight_le k⟩
+
+/-- The characteristic cube weight is attained at some vertex of the cube. -/
+theorem exists_characteristicWeight_eq_characteristicCubeWeight
+    (P : PlumbingGraph V)
+    (k : P.characteristicVectors) (x : V → ℤ) (S : Finset V) :
+    ∃ y ∈ cubeVertices x S, P.characteristicWeight k y = P.characteristicCubeWeight k x S := by
+  unfold characteristicCubeWeight
+  have hmax : (characteristicCubeWeightValues P k x S).max'
+      (characteristicCubeWeightValues_nonempty P k x S) ∈
+        characteristicCubeWeightValues P k x S :=
+    Finset.max'_mem _ _
+  obtain ⟨y, hy, hweight⟩ := Finset.mem_image.mp hmax
+  exact ⟨y, hy, hweight⟩
 
 /-- The point weight at a direction subset is bounded above by the characteristic cube weight. -/
 theorem characteristicWeight_cubeVertex_le_characteristicCubeWeight
@@ -169,14 +213,9 @@ theorem characteristicCubeWeight_mono
     (P : PlumbingGraph V)
     (k : P.characteristicVectors) {S T : Finset V} (hST : S ⊆ T) (x : V → ℤ) :
     P.characteristicCubeWeight k x S ≤ P.characteristicCubeWeight k x T := by
-  let y := (P.characteristicCubeWeightValues k x S).max'
-    (P.characteristicCubeWeightValues_nonempty k x S)
-  have hy : y ∈ P.characteristicCubeWeightValues k x S :=
-    Finset.max'_mem _ _
-  obtain ⟨z, hz, hzy⟩ := Finset.mem_image.mp hy
-  change y ≤ P.characteristicCubeWeight k x T
-  rw [← hzy]
-  exact P.characteristicWeight_le_characteristicCubeWeight k (cubeVertices_subset hST x hz)
+  apply P.characteristicCubeWeight_le k
+  intro y hy
+  exact P.characteristicWeight_le_characteristicCubeWeight k (cubeVertices_subset hST x hy)
 
 /-- The characteristic cube weight of the zero-dimensional cube is the point weight of its base
 point. -/
@@ -185,17 +224,20 @@ theorem characteristicCubeWeight_empty (P : PlumbingGraph V) (k : P.characterist
     (x : V → ℤ) :
     P.characteristicCubeWeight k x ∅ = P.characteristicWeight k x := by
   apply le_antisymm
-  · let y := (P.characteristicCubeWeightValues k x ∅).max'
-      (P.characteristicCubeWeightValues_nonempty k x ∅)
-    have hy : y ∈ P.characteristicCubeWeightValues k x ∅ :=
-      Finset.max'_mem _ _
-    obtain ⟨z, hz, hzy⟩ := Finset.mem_image.mp hy
-    change y ≤ P.characteristicWeight k x
-    rw [← hzy]
+  · apply P.characteristicCubeWeight_le k
+    intro z hz
     rw [mem_cubeVertices] at hz
-    obtain ⟨T, hT, rfl⟩ := hz
-    simp at hT
-    simp [hT]
+    obtain ⟨u, hu, huz⟩ := hz
+    rw [Finset.mem_subsetSum_iff] at hu
+    obtain ⟨U, hU, hsum⟩ := hu
+    have hUeq : U = ∅ := by
+      rw [Finset.eq_empty_iff_forall_notMem]
+      intro a ha
+      exact (by simpa using hU ha)
+    have hu0 : u = 0 := by
+      rw [← hsum, hUeq]
+      simp
+    rw [← huz, hu0, add_zero]
   · exact P.characteristicWeight_le_characteristicCubeWeight_base k x ∅
 
 end PlumbingGraph

--- a/TauCeti/LowDimTopology/Plumbing/CubeWeight.lean
+++ b/TauCeti/LowDimTopology/Plumbing/CubeWeight.lean
@@ -1,0 +1,203 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+module
+
+public import TauCeti.LowDimTopology.Plumbing.Weight
+
+/-!
+# Cube weights in a plumbing lattice
+
+This file packages the finite cube weights used in Némethi's lattice homology. A cube is
+specified by a base lattice point `x : V → ℤ` and a finite set `S : Finset V` of basis
+directions. Its vertices are the points
+
+`x + ∑ v ∈ T, E_v`
+
+for subsets `T ⊆ S`. For a characteristic covector `k`, the cube weight is the maximum of the
+already-defined point weights `χ_k` over these vertices.
+
+## Main definitions
+
+* `TauCeti.PlumbingGraph.cubeVertex`: the vertex indexed by a subset of directions.
+* `TauCeti.PlumbingGraph.cubeVertices`: the finite set of all vertices of a cube.
+* `TauCeti.PlumbingGraph.characteristicCubeWeight`: the maximum `χ_k` over those vertices.
+
+## References
+
+This supplies a prerequisite for `TauCetiRoadmap/CombinatorialHeegaardFloer/README.md`, Lane L
+("lattice homology"), whose opening item asks for Némethi's lattice (co)homology from lattice
+points and weight functions. The cube weight is the standard maximum over vertices used in the
+lattice-homology cubical complex; see Némethi, [arXiv:0709.0841](https://arxiv.org/abs/0709.0841).
+-/
+
+public section
+
+namespace TauCeti
+
+namespace PlumbingGraph
+
+variable {V : Type*} [DecidableEq V]
+
+/-- The lattice point obtained from a base point `x` by adding the plumbing basis vectors in
+`T`. This is the vertex of a lattice cube indexed by the subset `T` of its directions. -/
+@[expose]
+noncomputable def cubeVertex (x : V → ℤ) (T : Finset V) : V → ℤ :=
+  x + ∑ v ∈ T, Pi.single v (1 : ℤ)
+
+/-- The cube vertex, expanded as the defining finite sum of basis vectors. -/
+theorem cubeVertex_def (x : V → ℤ) (T : Finset V) :
+    cubeVertex x T = x + ∑ v ∈ T, Pi.single v (1 : ℤ) :=
+  rfl
+
+/-- The vertex indexed by the empty subset is the base point. -/
+@[simp]
+theorem cubeVertex_empty (x : V → ℤ) : cubeVertex x ∅ = x := by
+  simp [cubeVertex]
+
+/-- Adding a direction not already present adds the corresponding basis vector to the cube
+vertex. -/
+theorem cubeVertex_insert {T : Finset V} {v : V} (hv : v ∉ T) (x : V → ℤ) :
+    cubeVertex x (insert v T) = cubeVertex x T + Pi.single v (1 : ℤ) := by
+  ext w
+  simp [cubeVertex, hv, add_assoc, add_comm]
+
+/-- The coordinate value of a cube vertex. It is `x v + 1` in directions selected by `T`, and
+`x v` otherwise. -/
+@[simp]
+theorem cubeVertex_apply (x : V → ℤ) (T : Finset V) (v : V) :
+    cubeVertex x T v = x v + if v ∈ T then 1 else 0 := by
+  classical
+  simp [cubeVertex, Finset.sum_apply, Pi.single_apply]
+
+variable [Fintype V]
+
+/-- The finite set of all vertices of the cube with base point `x` and directions `S`. -/
+@[expose]
+noncomputable def cubeVertices (x : V → ℤ) (S : Finset V) : Finset (V → ℤ) :=
+  S.powerset.image fun T => cubeVertex x T
+
+/-- Membership in the vertex set of a plumbing cube. -/
+theorem mem_cubeVertices (x : V → ℤ) (S : Finset V) (y : V → ℤ) :
+    y ∈ cubeVertices x S ↔ ∃ T : Finset V, T ⊆ S ∧ cubeVertex x T = y := by
+  simp [cubeVertices]
+
+/-- The base point is a vertex of every cube. -/
+@[simp]
+theorem cubeVertex_mem_cubeVertices (x : V → ℤ) (S : Finset V) :
+    x ∈ cubeVertices x S := by
+  rw [mem_cubeVertices]
+  exact ⟨∅, by simp, by simp⟩
+
+/-- The vertex set of a cube is nonempty. -/
+theorem cubeVertices_nonempty (x : V → ℤ) (S : Finset V) :
+    (cubeVertices x S).Nonempty :=
+  ⟨x, cubeVertex_mem_cubeVertices x S⟩
+
+/-- A direction subset determines a vertex of any cube containing those directions. -/
+theorem cubeVertex_subset_mem_cubeVertices {T S : Finset V} (hTS : T ⊆ S) (x : V → ℤ) :
+    cubeVertex x T ∈ cubeVertices x S := by
+  rw [mem_cubeVertices]
+  exact ⟨T, hTS, rfl⟩
+
+/-- The vertices of a subcube are vertices of the larger cube. -/
+theorem cubeVertices_subset {S T : Finset V} (hST : S ⊆ T) (x : V → ℤ) :
+    cubeVertices x S ⊆ cubeVertices x T := by
+  intro y hy
+  rw [mem_cubeVertices] at hy ⊢
+  obtain ⟨U, hUS, rfl⟩ := hy
+  exact ⟨U, hUS.trans hST, rfl⟩
+
+/-- The characteristic weight values attained on the vertices of a plumbing cube. -/
+noncomputable def characteristicCubeWeightValues
+    (P : PlumbingGraph V)
+    (k : P.characteristicVectors) (x : V → ℤ) (S : Finset V) : Finset ℤ :=
+  (cubeVertices x S).image fun y => P.characteristicWeight k y
+
+/-- The value set for a plumbing cube is nonempty. -/
+theorem characteristicCubeWeightValues_nonempty
+    (P : PlumbingGraph V)
+    (k : P.characteristicVectors) (x : V → ℤ) (S : Finset V) :
+    (P.characteristicCubeWeightValues k x S).Nonempty :=
+  Finset.image_nonempty.mpr (cubeVertices_nonempty x S)
+
+/-- The characteristic cube weight is the maximum of the point weights over the cube's vertices. -/
+noncomputable def characteristicCubeWeight
+    (P : PlumbingGraph V)
+    (k : P.characteristicVectors) (x : V → ℤ) (S : Finset V) : ℤ :=
+  (P.characteristicCubeWeightValues k x S).max'
+    (P.characteristicCubeWeightValues_nonempty k x S)
+
+/-- A vertex weight is one of the values used to form the characteristic cube weight. -/
+theorem characteristicWeight_mem_characteristicCubeWeightValues
+    (P : PlumbingGraph V)
+    (k : P.characteristicVectors) {x : V → ℤ} {S : Finset V} {y : V → ℤ}
+    (hy : y ∈ cubeVertices x S) :
+    P.characteristicWeight k y ∈ P.characteristicCubeWeightValues k x S := by
+  exact Finset.mem_image.mpr ⟨y, hy, rfl⟩
+
+/-- The point weight at any vertex is bounded above by the characteristic cube weight. -/
+theorem characteristicWeight_le_characteristicCubeWeight
+    (P : PlumbingGraph V)
+    (k : P.characteristicVectors) {x : V → ℤ} {S : Finset V} {y : V → ℤ}
+    (hy : y ∈ cubeVertices x S) :
+    P.characteristicWeight k y ≤ P.characteristicCubeWeight k x S := by
+  exact Finset.le_max'
+    (P.characteristicCubeWeightValues k x S)
+    (P.characteristicWeight k y)
+    (P.characteristicWeight_mem_characteristicCubeWeightValues k hy)
+
+/-- The point weight at a direction subset is bounded above by the characteristic cube weight. -/
+theorem characteristicWeight_cubeVertex_le_characteristicCubeWeight
+    (P : PlumbingGraph V)
+    (k : P.characteristicVectors) {T S : Finset V} (hTS : T ⊆ S) (x : V → ℤ) :
+    P.characteristicWeight k (cubeVertex x T) ≤ P.characteristicCubeWeight k x S :=
+  P.characteristicWeight_le_characteristicCubeWeight k
+    (cubeVertex_subset_mem_cubeVertices hTS x)
+
+/-- The base point's weight is bounded above by every cube weight based at that point. -/
+theorem characteristicWeight_le_characteristicCubeWeight_base
+    (P : PlumbingGraph V)
+    (k : P.characteristicVectors) (x : V → ℤ) (S : Finset V) :
+    P.characteristicWeight k x ≤ P.characteristicCubeWeight k x S := by
+  simpa using
+    P.characteristicWeight_cubeVertex_le_characteristicCubeWeight k (Finset.empty_subset S) x
+
+/-- Characteristic cube weight is monotone under enlarging the set of cube directions. -/
+theorem characteristicCubeWeight_mono
+    (P : PlumbingGraph V)
+    (k : P.characteristicVectors) {S T : Finset V} (hST : S ⊆ T) (x : V → ℤ) :
+    P.characteristicCubeWeight k x S ≤ P.characteristicCubeWeight k x T := by
+  let y := (P.characteristicCubeWeightValues k x S).max'
+    (P.characteristicCubeWeightValues_nonempty k x S)
+  have hy : y ∈ P.characteristicCubeWeightValues k x S :=
+    Finset.max'_mem _ _
+  obtain ⟨z, hz, hzy⟩ := Finset.mem_image.mp hy
+  change y ≤ P.characteristicCubeWeight k x T
+  rw [← hzy]
+  exact P.characteristicWeight_le_characteristicCubeWeight k (cubeVertices_subset hST x hz)
+
+/-- The characteristic cube weight of the zero-dimensional cube is the point weight of its base
+point. -/
+@[simp]
+theorem characteristicCubeWeight_empty (P : PlumbingGraph V) (k : P.characteristicVectors)
+    (x : V → ℤ) :
+    P.characteristicCubeWeight k x ∅ = P.characteristicWeight k x := by
+  apply le_antisymm
+  · let y := (P.characteristicCubeWeightValues k x ∅).max'
+      (P.characteristicCubeWeightValues_nonempty k x ∅)
+    have hy : y ∈ P.characteristicCubeWeightValues k x ∅ :=
+      Finset.max'_mem _ _
+    obtain ⟨z, hz, hzy⟩ := Finset.mem_image.mp hy
+    change y ≤ P.characteristicWeight k x
+    rw [← hzy]
+    rw [mem_cubeVertices] at hz
+    obtain ⟨T, hT, rfl⟩ := hz
+    simp at hT
+    simp [hT]
+  · exact P.characteristicWeight_le_characteristicCubeWeight_base k x ∅
+
+end PlumbingGraph
+
+end TauCeti


### PR DESCRIPTION
This PR adds the finite cube-weight layer for plumbing lattice homology: `cubeVertex` builds the lattice point `x + ∑ v ∈ T, E_v`, `cubeVertices` collects the vertices indexed by all subsets of a finite direction set, and `characteristicCubeWeight` takes the maximum of the existing characteristic point weight `χ_k` over those vertices. Use it as the cubical weight function needed before defining Némethi's lattice-homology differential over `ℤ[U]`.

This advances `TauCetiRoadmap/CombinatorialHeegaardFloer/README.md`, Lane L ("lattice homology"), specifically the item asking for "Némethi's lattice (co)homology `ℍ⁻`/`ℍ⁰` as a `ℤ[U]`-module from lattice points and weight functions". I chose it as the lowest-hanging distinct target after checking open and recently merged PRs: point weights for plumbing lattices already exist on `main`, while the open CombinatorialHeegaardFloer PRs cover another point-weight formulation and grid rectangle counts, not the finite cube maximum needed for the cubical complex.

No Mathlib infrastructure is vendored. The implementation reuses Tau Ceti's `PlumbingGraph.characteristicWeight` and Mathlib's finite-set `powerset`, `image`, and `max'` APIs. The convention that a cube weight is the maximum of `χ_k` over subset vertices follows Némethi, arXiv:0709.0841.

Local verification: `lake exe cache get` completed with `Decompressed 8586 file(s)` and `Already decompressed 8586 file(s)`; `lake build` completed with `Build completed successfully (4208 jobs).`; `lake exe axioms` completed with `axioms: audited 4868 TauCeti declaration(s); all within the allowlist [propext, Classical.choice, Quot.sound].`

<!--tauceti-target:v1 {"focus":"CombinatorialHeegaardFloer","id":"plumbing-cube-weight"}-->

🤖 Prepared with Codex
