### PR TITLE
feat: add Abel-Jacobi degree splitting

### DIFF
--- a/TauCeti/AlgebraicGeometry/WeilDivisor.lean
+++ b/TauCeti/AlgebraicGeometry/WeilDivisor.lean
@@ -507,8 +507,14 @@ lemma pointDifference_mem_weightedDegreeZeroSubgroup {w : X → ℤ} {x y : X}
 For the geometric weight `w x = [κ(x) : k]` and a rational base point `x₀` with `w x₀ = 1`,
 this is the degree-zero divisor underlying the Abel-Jacobi class of the closed point `x`.
 In the algebraically closed/unweighted specialization, this recovers `pointDifference x x₀`. -/
-noncomputable def weightedPointBaseDifference (w : X → ℤ) (x₀ x : X) : WeilDivisor X :=
+@[expose] noncomputable def weightedPointBaseDifference (w : X → ℤ) (x₀ x : X) : WeilDivisor X :=
   ofPoint x - w x • ofPoint x₀
+
+/-- The degree-corrected point divisor is `[x]` minus `w x` copies of the base point `[x₀]`.
+This exposes the definition as a public equation for use across modules. -/
+lemma weightedPointBaseDifference_eq_ofPoint_sub_zsmul (w : X → ℤ) (x₀ x : X) :
+    weightedPointBaseDifference w x₀ x = ofPoint x - w x • ofPoint x₀ :=
+  rfl
 
 /-- At the constant weight `1`, the degree-corrected point divisor is the usual point
 difference. This simp lemma lets unweighted API reuse the weighted construction. -/

--- a/TauCeti/AlgebraicGeometry/WeilDivisor/AbelJacobiDegreeSplitting.lean
+++ b/TauCeti/AlgebraicGeometry/WeilDivisor/AbelJacobiDegreeSplitting.lean
@@ -52,41 +52,8 @@ lemma degreeCorrection_divisorClass_ofPoint (w : X → ℤ) (h : S.IsWeightedDeg
     {x₀ : X} (hx₀ : w x₀ = 1) (x : X) :
     S.degreeCorrection w h x₀ (S.divisorClass (ofPoint x)) =
       (S.weightedAbelJacobiClass w h hx₀ x : S.ClassGroup) := by
-  classical
-  rw [degreeCorrection_apply, weightedDegreeClass_divisorClass_ofPoint,
-    coe_weightedAbelJacobiClass]
-  rw [← map_zsmul, ← map_sub]
-  congr 1
-  ext y
-  rw [coeff_sub, coeff_weightedPointBaseDifference]
-  change (ofPoint x) y - (w x • ofPoint x₀) y =
-    (if y = x then 1 else 0) - if y = x₀ then w x else 0
-  rw [show (ofPoint x) y = coeff (ofPoint x) y by rfl,
-    show (w x • ofPoint x₀) y = w x * coeff (ofPoint x₀) y by rfl]
-  by_cases hyx : y = x
-  · subst y
-    by_cases hx₀ : x = x₀
-    · simp [hx₀]
-    · simp [hx₀]
-  · by_cases hy₀ : y = x₀
-    · subst y
-      have hx₀ : x₀ ≠ x := hyx
-      simp [hx₀]
-    · simp [hyx, hy₀]
-
-/-- A class already in `Pic⁰` is unchanged by degree correction. -/
-lemma degreeCorrection_eq_self_of_mem_picZero (w : X → ℤ) (h : S.IsWeightedDegreeZero w)
-    (x₀ : X) {c : S.ClassGroup} (hc : c ∈ picZero w h) :
-    S.degreeCorrection w h x₀ c = c := by
-  rw [degreeCorrection_apply, (mem_picZero w h).mp hc, zero_zsmul, sub_zero]
-
-/-- The degree correction of a coerced `Pic⁰` class is the same class in the ambient class
-group. -/
-@[simp]
-lemma degreeCorrection_coe_picZero (w : X → ℤ) (h : S.IsWeightedDegreeZero w)
-    (x₀ : X) (p : picZero w h) :
-    S.degreeCorrection w h x₀ (p : S.ClassGroup) = p :=
-  S.degreeCorrection_eq_self_of_mem_picZero w h x₀ p.property
+  rw [degreeCorrection_divisorClass, coe_weightedAbelJacobiClass,
+    weightedPointBaseDifference_eq_ofPoint_sub_zsmul, weightedDegree_ofPoint]
 
 /-! ### Weighted splitting formulas -/
 
@@ -110,12 +77,8 @@ lemma classGroupAddEquivPicZeroProdInt_coe_weightedAbelJacobiClass (w : X → �
     (h : S.IsWeightedDegreeZero w) {x₀ : X} (hx₀ : w x₀ = 1) (x : X) :
     S.classGroupAddEquivPicZeroProdInt w h hx₀
         (S.weightedAbelJacobiClass w h hx₀ x : S.ClassGroup) =
-      (S.weightedAbelJacobiClass w h hx₀ x, 0) := by
-  rw [classGroupAddEquivPicZeroProdInt_apply]
-  apply Prod.ext
-  · apply Subtype.ext
-    exact S.degreeCorrection_coe_picZero w h x₀ (S.weightedAbelJacobiClass w h hx₀ x)
-  · exact (mem_picZero w h).mp (S.weightedAbelJacobiClass w h hx₀ x).property
+      (S.weightedAbelJacobiClass w h hx₀ x, 0) :=
+  S.classGroupAddEquivPicZeroProdInt_coe_picZero w h hx₀ (S.weightedAbelJacobiClass w h hx₀ x)
 
 /-- The degree-corrected point divisor `[x] - w(x)[x₀]` maps to the weighted Abel-Jacobi class
 and degree `0` under the splitting `Cl(X) ≃+ Pic⁰ × ℤ`. -/
@@ -157,12 +120,10 @@ lemma classGroupAddEquivUnweightedPicZeroProdInt_divisorClass_ofPoint
     (h : S.IsUnweightedDegreeZero) (x₀ x : X) :
     S.classGroupAddEquivUnweightedPicZeroProdInt h x₀ (S.divisorClass (ofPoint x)) =
       (S.unweightedAbelJacobiClass h x₀ x, 1) := by
-  rw [classGroupAddEquivUnweightedPicZeroProdInt]
-  change S.classGroupAddEquivPicZeroProdInt (fun _ : X => (1 : ℤ)) h rfl
-      (S.divisorClass (ofPoint x)) =
-    (S.weightedAbelJacobiClass (fun _ : X => (1 : ℤ)) h rfl x, 1)
-  exact S.classGroupAddEquivPicZeroProdInt_divisorClass_ofPoint
-    (fun _ : X => (1 : ℤ)) h (x₀ := x₀) rfl x
+  rw [classGroupAddEquivUnweightedPicZeroProdInt_apply]
+  refine Prod.ext (Subtype.ext ?_) ?_
+  · exact S.degreeCorrection_divisorClass_ofPoint_unweighted h x₀ x
+  · rw [unweightedDegreeClass_divisorClass, degree_ofPoint]
 
 /-- Under the unweighted splitting, a coerced unweighted Abel-Jacobi class has degree zero and
 `Pic⁰` component itself. -/
@@ -171,13 +132,19 @@ lemma classGroupAddEquivUnweightedPicZeroProdInt_coe_unweightedAbelJacobiClass
     (h : S.IsUnweightedDegreeZero) (x₀ x : X) :
     S.classGroupAddEquivUnweightedPicZeroProdInt h x₀
         (S.unweightedAbelJacobiClass h x₀ x : S.ClassGroup) =
+      (S.unweightedAbelJacobiClass h x₀ x, 0) :=
+  S.classGroupAddEquivUnweightedPicZeroProdInt_coe_unweightedPicZero h x₀
+    (S.unweightedAbelJacobiClass h x₀ x)
+
+/-- The point difference `[x] - [x₀]` maps to the unweighted Abel-Jacobi class and degree `0`
+under the unweighted splitting `Cl(X) ≃+ Pic⁰ × ℤ`. -/
+@[simp]
+lemma classGroupAddEquivUnweightedPicZeroProdInt_divisorClass_pointDifference
+    (h : S.IsUnweightedDegreeZero) (x₀ x : X) :
+    S.classGroupAddEquivUnweightedPicZeroProdInt h x₀ (S.divisorClass (pointDifference x x₀)) =
       (S.unweightedAbelJacobiClass h x₀ x, 0) := by
-  rw [classGroupAddEquivUnweightedPicZeroProdInt]
-  change S.classGroupAddEquivPicZeroProdInt (fun _ : X => (1 : ℤ)) h rfl
-      (S.weightedAbelJacobiClass (fun _ : X => (1 : ℤ)) h rfl x : S.ClassGroup) =
-    (S.weightedAbelJacobiClass (fun _ : X => (1 : ℤ)) h rfl x, 0)
-  exact S.classGroupAddEquivPicZeroProdInt_coe_weightedAbelJacobiClass
-    (fun _ : X => (1 : ℤ)) h (x₀ := x₀) rfl x
+  rw [← S.coe_unweightedAbelJacobiClass h x₀ x,
+    S.classGroupAddEquivUnweightedPicZeroProdInt_coe_unweightedAbelJacobiClass h x₀ x]
 
 /-- The inverse unweighted splitting reconstructs the point class `[x]` from its Abel-Jacobi
 component and degree `1`. -/

--- a/TauCeti/AlgebraicGeometry/WeilDivisor/AbelJacobiDegreeSplitting.lean
+++ b/TauCeti/AlgebraicGeometry/WeilDivisor/AbelJacobiDegreeSplitting.lean
@@ -1,0 +1,199 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+module
+
+public import TauCeti.AlgebraicGeometry.WeilDivisor.AbelJacobi
+public import TauCeti.AlgebraicGeometry.WeilDivisor.DegreeSplitting
+
+/-!
+# Abel-Jacobi classes and the degree splitting
+
+This file records how the abstract Abel-Jacobi divisor class from
+`TauCeti.AlgebraicGeometry.WeilDivisor.AbelJacobi` interacts with the class-group splitting
+from `TauCeti.AlgebraicGeometry.WeilDivisor.DegreeSplitting`.
+
+For an order system whose principal divisors have weighted degree zero, a weight-one base point
+`x₀` splits the divisor class group as
+
+`Cl(X) ≃+ Pic⁰(X) × ℤ`.
+
+Under this splitting, the class of a point divisor `[x]` has `Pic⁰` component equal to the
+weighted Abel-Jacobi class of `x`, and degree component `w x`. Equivalently, the degree-corrected
+class `[x] - w(x)[x₀]` maps to the Abel-Jacobi class together with degree `0`.
+
+This advances `TauCetiRoadmap/JacobianChallenge/README.md`, Layer A, the "`Pic⁰ X = ker deg`
+(as an abstract group)" item and the rational-point degree splitting used by the later
+normalized Abel-Jacobi morphism. No external mathematics is vendored; the proofs combine Tau
+Ceti's existing `OrderSystem.picZero`, `weightedAbelJacobiClass`, and
+`classGroupAddEquivPicZeroProdInt` APIs.
+-/
+
+@[expose] public section
+
+namespace TauCeti
+
+namespace AlgebraicGeometry
+
+namespace WeilDivisor
+
+variable {X G : Type*} [AddCommGroup G]
+
+namespace OrderSystem
+
+variable (S : OrderSystem X G)
+
+/-! ### Degree correction of point classes -/
+
+/-- Correcting the degree of the point class `[x]` by the base point `x₀` gives exactly the
+class-group representative of the weighted Abel-Jacobi class of `x`. -/
+lemma degreeCorrection_divisorClass_ofPoint (w : X → ℤ) (h : S.IsWeightedDegreeZero w)
+    {x₀ : X} (hx₀ : w x₀ = 1) (x : X) :
+    S.degreeCorrection w h x₀ (S.divisorClass (ofPoint x)) =
+      (S.weightedAbelJacobiClass w h hx₀ x : S.ClassGroup) := by
+  classical
+  rw [degreeCorrection_apply, weightedDegreeClass_divisorClass_ofPoint,
+    coe_weightedAbelJacobiClass]
+  rw [← map_zsmul, ← map_sub]
+  congr 1
+  ext y
+  rw [coeff_sub, coeff_weightedPointBaseDifference]
+  change (ofPoint x) y - (w x • ofPoint x₀) y =
+    (if y = x then 1 else 0) - if y = x₀ then w x else 0
+  rw [show (ofPoint x) y = coeff (ofPoint x) y by rfl,
+    show (w x • ofPoint x₀) y = w x * coeff (ofPoint x₀) y by rfl]
+  by_cases hyx : y = x
+  · subst y
+    by_cases hx₀ : x = x₀
+    · simp [hx₀]
+    · simp [hx₀]
+  · by_cases hy₀ : y = x₀
+    · subst y
+      have hx₀ : x₀ ≠ x := hyx
+      simp [hx₀]
+    · simp [hyx, hy₀]
+
+/-- A class already in `Pic⁰` is unchanged by degree correction. -/
+lemma degreeCorrection_eq_self_of_mem_picZero (w : X → ℤ) (h : S.IsWeightedDegreeZero w)
+    (x₀ : X) {c : S.ClassGroup} (hc : c ∈ picZero w h) :
+    S.degreeCorrection w h x₀ c = c := by
+  rw [degreeCorrection_apply, (mem_picZero w h).mp hc, zero_zsmul, sub_zero]
+
+/-- The degree correction of a coerced `Pic⁰` class is the same class in the ambient class
+group. -/
+@[simp]
+lemma degreeCorrection_coe_picZero (w : X → ℤ) (h : S.IsWeightedDegreeZero w)
+    (x₀ : X) (p : picZero w h) :
+    S.degreeCorrection w h x₀ (p : S.ClassGroup) = p :=
+  S.degreeCorrection_eq_self_of_mem_picZero w h x₀ p.property
+
+/-! ### Weighted splitting formulas -/
+
+/-- Under the splitting `Cl(X) ≃+ Pic⁰ × ℤ`, the class of the point divisor `[x]` has
+`Pic⁰` component the weighted Abel-Jacobi class of `x`, and degree component `w x`. -/
+@[simp]
+lemma classGroupAddEquivPicZeroProdInt_divisorClass_ofPoint (w : X → ℤ)
+    (h : S.IsWeightedDegreeZero w) {x₀ : X} (hx₀ : w x₀ = 1) (x : X) :
+    S.classGroupAddEquivPicZeroProdInt w h hx₀ (S.divisorClass (ofPoint x)) =
+      (S.weightedAbelJacobiClass w h hx₀ x, w x) := by
+  rw [classGroupAddEquivPicZeroProdInt_apply, weightedDegreeClass_divisorClass_ofPoint]
+  apply Prod.ext
+  · apply Subtype.ext
+    exact S.degreeCorrection_divisorClass_ofPoint w h hx₀ x
+  · rfl
+
+/-- Under the splitting `Cl(X) ≃+ Pic⁰ × ℤ`, a coerced weighted Abel-Jacobi class has degree
+zero and `Pic⁰` component itself. -/
+@[simp]
+lemma classGroupAddEquivPicZeroProdInt_coe_weightedAbelJacobiClass (w : X → ℤ)
+    (h : S.IsWeightedDegreeZero w) {x₀ : X} (hx₀ : w x₀ = 1) (x : X) :
+    S.classGroupAddEquivPicZeroProdInt w h hx₀
+        (S.weightedAbelJacobiClass w h hx₀ x : S.ClassGroup) =
+      (S.weightedAbelJacobiClass w h hx₀ x, 0) := by
+  rw [classGroupAddEquivPicZeroProdInt_apply]
+  apply Prod.ext
+  · apply Subtype.ext
+    exact S.degreeCorrection_coe_picZero w h x₀ (S.weightedAbelJacobiClass w h hx₀ x)
+  · exact (mem_picZero w h).mp (S.weightedAbelJacobiClass w h hx₀ x).property
+
+/-- The degree-corrected point divisor `[x] - w(x)[x₀]` maps to the weighted Abel-Jacobi class
+and degree `0` under the splitting `Cl(X) ≃+ Pic⁰ × ℤ`. -/
+@[simp]
+lemma classGroupAddEquivPicZeroProdInt_divisorClass_weightedPointBaseDifference
+    (w : X → ℤ) (h : S.IsWeightedDegreeZero w) {x₀ : X} (hx₀ : w x₀ = 1) (x : X) :
+    S.classGroupAddEquivPicZeroProdInt w h hx₀
+        (S.divisorClass (weightedPointBaseDifference w x₀ x)) =
+      (S.weightedAbelJacobiClass w h hx₀ x, 0) := by
+  rw [← S.coe_weightedAbelJacobiClass w h hx₀ x,
+    S.classGroupAddEquivPicZeroProdInt_coe_weightedAbelJacobiClass w h hx₀ x]
+
+/-- The inverse splitting reconstructs the point class `[x]` from its weighted Abel-Jacobi
+component and its degree `w x`. -/
+@[simp]
+lemma classGroupAddEquivPicZeroProdInt_symm_weightedAbelJacobiClass (w : X → ℤ)
+    (h : S.IsWeightedDegreeZero w) {x₀ : X} (hx₀ : w x₀ = 1) (x : X) :
+    (S.classGroupAddEquivPicZeroProdInt w h hx₀).symm
+        (S.weightedAbelJacobiClass w h hx₀ x, w x) =
+      S.divisorClass (ofPoint x) := by
+  rw [← S.classGroupAddEquivPicZeroProdInt_divisorClass_ofPoint w h hx₀ x]
+  simp
+
+/-! ### Unweighted specialization -/
+
+/-- In the unweighted specialization, correcting the degree of `[x]` by `x₀` gives the ambient
+class of the unweighted Abel-Jacobi class. -/
+lemma degreeCorrection_divisorClass_ofPoint_unweighted (h : S.IsUnweightedDegreeZero)
+    (x₀ x : X) :
+    S.degreeCorrection (fun _ : X => (1 : ℤ)) h x₀ (S.divisorClass (ofPoint x)) =
+      (S.unweightedAbelJacobiClass h x₀ x : S.ClassGroup) := by
+  simpa [unweightedAbelJacobiClass] using
+    S.degreeCorrection_divisorClass_ofPoint (fun _ : X => (1 : ℤ)) h (x₀ := x₀) rfl x
+
+/-- Under the unweighted splitting `Cl(X) ≃+ Pic⁰ × ℤ`, the class of `[x]` has `Pic⁰`
+component the unweighted Abel-Jacobi class of `x`, and degree component `1`. -/
+@[simp]
+lemma classGroupAddEquivUnweightedPicZeroProdInt_divisorClass_ofPoint
+    (h : S.IsUnweightedDegreeZero) (x₀ x : X) :
+    S.classGroupAddEquivUnweightedPicZeroProdInt h x₀ (S.divisorClass (ofPoint x)) =
+      (S.unweightedAbelJacobiClass h x₀ x, 1) := by
+  rw [classGroupAddEquivUnweightedPicZeroProdInt]
+  change S.classGroupAddEquivPicZeroProdInt (fun _ : X => (1 : ℤ)) h rfl
+      (S.divisorClass (ofPoint x)) =
+    (S.weightedAbelJacobiClass (fun _ : X => (1 : ℤ)) h rfl x, 1)
+  exact S.classGroupAddEquivPicZeroProdInt_divisorClass_ofPoint
+    (fun _ : X => (1 : ℤ)) h (x₀ := x₀) rfl x
+
+/-- Under the unweighted splitting, a coerced unweighted Abel-Jacobi class has degree zero and
+`Pic⁰` component itself. -/
+@[simp]
+lemma classGroupAddEquivUnweightedPicZeroProdInt_coe_unweightedAbelJacobiClass
+    (h : S.IsUnweightedDegreeZero) (x₀ x : X) :
+    S.classGroupAddEquivUnweightedPicZeroProdInt h x₀
+        (S.unweightedAbelJacobiClass h x₀ x : S.ClassGroup) =
+      (S.unweightedAbelJacobiClass h x₀ x, 0) := by
+  rw [classGroupAddEquivUnweightedPicZeroProdInt]
+  change S.classGroupAddEquivPicZeroProdInt (fun _ : X => (1 : ℤ)) h rfl
+      (S.weightedAbelJacobiClass (fun _ : X => (1 : ℤ)) h rfl x : S.ClassGroup) =
+    (S.weightedAbelJacobiClass (fun _ : X => (1 : ℤ)) h rfl x, 0)
+  exact S.classGroupAddEquivPicZeroProdInt_coe_weightedAbelJacobiClass
+    (fun _ : X => (1 : ℤ)) h (x₀ := x₀) rfl x
+
+/-- The inverse unweighted splitting reconstructs the point class `[x]` from its Abel-Jacobi
+component and degree `1`. -/
+@[simp]
+lemma classGroupAddEquivUnweightedPicZeroProdInt_symm_unweightedAbelJacobiClass
+    (h : S.IsUnweightedDegreeZero) (x₀ x : X) :
+    (S.classGroupAddEquivUnweightedPicZeroProdInt h x₀).symm
+        (S.unweightedAbelJacobiClass h x₀ x, 1) =
+      S.divisorClass (ofPoint x) := by
+  rw [← S.classGroupAddEquivUnweightedPicZeroProdInt_divisorClass_ofPoint h x₀ x]
+  simp
+
+end OrderSystem
+
+end WeilDivisor
+
+end AlgebraicGeometry
+
+end TauCeti

--- a/TauCeti/AlgebraicGeometry/WeilDivisor/DegreeSplitting.lean
+++ b/TauCeti/AlgebraicGeometry/WeilDivisor/DegreeSplitting.lean
@@ -129,6 +129,28 @@ lemma degreeCorrection_mem_picZero (w : X → ℤ) (h : S.IsWeightedDegreeZero w
   rw [mem_picZero, degreeCorrection_apply, map_sub, map_zsmul,
     weightedDegreeClass_divisorClass_ofPoint, hx₀, smul_eq_mul, mul_one, sub_self]
 
+/-- Degree correction acts on a divisor class by subtracting the base-point divisor scaled by the
+weighted degree of any representative. -/
+lemma degreeCorrection_divisorClass (w : X → ℤ) (h : S.IsWeightedDegreeZero w) (x₀ : X)
+    (D : WeilDivisor X) :
+    S.degreeCorrection w h x₀ (S.divisorClass D) =
+      S.divisorClass (D - weightedDegree w D • ofPoint x₀) := by
+  rw [degreeCorrection_apply, weightedDegreeClass_divisorClass, map_sub, map_zsmul]
+
+/-- A class already in `picZero` is unchanged by degree correction. -/
+lemma degreeCorrection_eq_self_of_mem_picZero (w : X → ℤ) (h : S.IsWeightedDegreeZero w)
+    (x₀ : X) {c : S.ClassGroup} (hc : c ∈ picZero w h) :
+    S.degreeCorrection w h x₀ c = c := by
+  rw [degreeCorrection_apply, (mem_picZero w h).mp hc, zero_zsmul, sub_zero]
+
+/-- The degree correction of a coerced `picZero` class is the same class in the ambient class
+group. -/
+@[simp]
+lemma degreeCorrection_coe_picZero (w : X → ℤ) (h : S.IsWeightedDegreeZero w)
+    (x₀ : X) (p : picZero w h) :
+    S.degreeCorrection w h x₀ (p : S.ClassGroup) = p :=
+  S.degreeCorrection_eq_self_of_mem_picZero w h x₀ p.property
+
 noncomputable def degreeSplitForward (w : X → ℤ) (h : S.IsWeightedDegreeZero w)
     {x₀ : X} (hx₀ : w x₀ = 1) : S.ClassGroup →+ picZero w h × ℤ :=
   ((S.degreeCorrection w h x₀).codRestrict (picZero w h)
@@ -209,6 +231,17 @@ lemma classGroupAddEquivPicZeroProdInt_symm_apply (w : X → ℤ) (h : S.IsWeigh
       (p : S.ClassGroup) + n • S.divisorClass (ofPoint x₀) :=
   S.degreeSplitInverse_apply w h x₀ p n
 
+/-- Under the splitting `Cl(X) ≃+ picZero × ℤ`, a coerced `picZero` class has `Pic⁰` component
+itself and degree component `0`. -/
+@[simp]
+lemma classGroupAddEquivPicZeroProdInt_coe_picZero (w : X → ℤ) (h : S.IsWeightedDegreeZero w)
+    {x₀ : X} (hx₀ : w x₀ = 1) (p : picZero w h) :
+    S.classGroupAddEquivPicZeroProdInt w h hx₀ (p : S.ClassGroup) = (p, 0) := by
+  rw [classGroupAddEquivPicZeroProdInt_apply]
+  refine Prod.ext (Subtype.ext ?_) ?_
+  · exact S.degreeCorrection_coe_picZero w h x₀ p
+  · exact (mem_picZero w h).mp p.property
+
 /-! ### The unweighted specialization -/
 
 /-- The unweighted/algebraically closed specialization of the splitting: with unweighted-degree
@@ -233,6 +266,14 @@ lemma classGroupAddEquivUnweightedPicZeroProdInt_symm_apply (h : S.IsUnweightedD
     (S.classGroupAddEquivUnweightedPicZeroProdInt h x₀).symm (p, n) =
       (p : S.ClassGroup) + n • S.divisorClass (ofPoint x₀) :=
   S.classGroupAddEquivPicZeroProdInt_symm_apply (fun _ => (1 : ℤ)) h rfl p n
+
+/-- Under the unweighted splitting, a coerced `unweightedPicZero` class has `Pic⁰` component
+itself and degree component `0`. -/
+@[simp]
+lemma classGroupAddEquivUnweightedPicZeroProdInt_coe_unweightedPicZero
+    (h : S.IsUnweightedDegreeZero) (x₀ : X) (p : unweightedPicZero h) :
+    S.classGroupAddEquivUnweightedPicZeroProdInt h x₀ (p : S.ClassGroup) = (p, 0) :=
+  S.classGroupAddEquivPicZeroProdInt_coe_picZero (fun _ => (1 : ℤ)) h rfl p
 
 /-- With unweighted-degree-zero principal divisors and a base point, the unweighted degree is
 surjective onto `ℤ`. -/


### PR DESCRIPTION
This PR records how the abstract Abel-Jacobi divisor class appears under the existing class-group splitting `Cl(X) ≃ Pic⁰ × ℤ`: the point class `[x]` maps to `(AJ(x), w x)`, the degree-corrected class `[x] - w(x)[x₀]` maps to `(AJ(x), 0)`, and the inverse splitting reconstructs `[x]` from its Abel-Jacobi component and degree. Use these lemmas as the compatibility API between the current Layer A divisor-class model and the later normalized Abel-Jacobi morphism.

This advances `TauCetiRoadmap/JacobianChallenge/README.md`, Layer A, specifically the "`Pic⁰ X = ker deg` (as an abstract group)" item and the rational-point degree splitting needed before Layer F's basepoint-normalized Abel-Jacobi map `aj : X ⟶ Jac X`. I chose it as the lowest-hanging distinct JacobianChallenge prerequisite after checking open and recently merged PRs: open #311 covers the quotient model of `Pic⁰`, merged #404 covers basepoint changes, open #412 covers degree-zero complete linear systems, and `DegreeSplitting.lean` already exists on `main`; this PR only supplies the missing compatibility between that splitting and the existing abstract Abel-Jacobi point class.

No Mathlib infrastructure is vendored. The implementation reuses Tau Ceti's `OrderSystem.picZero`, `weightedAbelJacobiClass`, and `classGroupAddEquivPicZeroProdInt` APIs, with only routine quotient-group and subtype extensionality from Mathlib.

Local verification: `lake exe cache get` completed with `No files to download` and `Already decompressed 8586 file(s)`; `lake build` completed with `Build completed successfully (4208 jobs).`; `lake exe axioms` completed with `axioms: audited 4858 TauCeti declaration(s); all within the allowlist [propext, Classical.choice, Quot.sound].`

<!--tauceti-target:v1 {"focus":"JacobianChallenge","id":"abel-jacobi-degree-splitting"}-->

🤖 Prepared with Codex
