### PR TITLE
feat: add additive group base-change points

### DIFF
--- a/TauCeti/Algebra/AlgebraicGroup/AdditiveGroupBaseChange.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/AdditiveGroupBaseChange.lean
@@ -1,0 +1,184 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+module
+
+public import TauCeti.Algebra.AlgebraicGroup.AdditiveGroup
+public import TauCeti.Algebra.AlgebraicGroup.BaseChange
+
+/-!
+# Base change of additive-group points
+
+The vector group attached to a `k`-module `M` is represented by the symmetric Hopf algebra
+`SymmetricAlgebra k M`. This file records the base-changed functor-of-points calculation:
+if `K` is a `k`-algebra and `A` is a commutative `K`-algebra, then the convolution monoid of
+`K`-algebra maps out of `K ⊗[k] SymmetricAlgebra k M` is the additive monoid of `k`-linear
+maps `M →ₗ[k] A`.
+
+The equivalence first restricts a base-changed point along
+`m ↦ 1 ⊗ ι(m)` using `AlgHom.baseChangePointsMulEquiv`, then applies
+`AdditiveGroup.pointsMulEquiv`. The characteristic lemmas spell out the generator values,
+the inverse map on scalar multiples of generators, naturality in the value algebra, and the
+one-dimensional additive group `𝔾ₐ`.
+
+This is the additive-group worked example from the ReductiveGroups roadmap, combined with
+the Layer 0 base-change target for Hopf algebras and their functors of points.
+
+## Main declarations
+
+* `TauCeti.AdditiveGroup.baseChangePointsMulEquiv`: base-changed vector-group points are
+  `k`-linear maps `M →ₗ[k] A`.
+* `TauCeti.AdditiveGroup.baseChangePointsMulEquiv_apply_apply`: the equivalence reads a
+  point on `1 ⊗ ι(m)`.
+* `TauCeti.AdditiveGroup.baseChangePointsMulEquiv_symm_apply_tmul_ι`: the inverse
+  equivalence evaluates scalar multiples of base-changed generators.
+* `TauCeti.AdditiveGroup.gaBaseChangePointsMulEquiv`: the base-changed `𝔾ₐ` points are the
+  additive monoid of `A`.
+
+## References
+
+The generic base-change step is Tau Ceti's `AlgHom.baseChangePointsMulEquiv`; the vector-group
+points calculation is Tau Ceti's `AdditiveGroup.pointsMulEquiv`.
+-/
+
+public section
+
+open SymmetricAlgebra WithConv
+open scoped TensorProduct
+
+namespace TauCeti
+
+namespace AdditiveGroup
+
+universe u v w w'
+
+variable {k : Type u} {K : Type v} {A : Type w} {M : Type w'}
+variable [CommSemiring k] [CommSemiring K] [CommSemiring A]
+variable [Algebra k K] [Algebra K A] [Algebra k A] [IsScalarTower k K A]
+variable [AddCommMonoid M] [Module k M]
+
+/-- The `A`-points of the base change `K ⊗[k] SymmetricAlgebra k M` of the vector group on
+`M` are the additive monoid of `k`-linear maps `M →ₗ[k] A`.
+
+The source is the convolution monoid of `K`-algebra maps out of the base-changed Hopf algebra;
+the target is written multiplicatively as `Multiplicative (M →ₗ[k] A)` to match `≃*`. -/
+noncomputable def baseChangePointsMulEquiv :
+    WithConv (K ⊗[k] SymmetricAlgebra k M →ₐ[K] A) ≃* Multiplicative (M →ₗ[k] A) :=
+  (AlgHom.baseChangePointsMulEquiv (k := k) (K := K)
+      (A := SymmetricAlgebra k M) (R := A)).symm.trans
+    (pointsMulEquiv (R := k) (M := M) (A := A))
+
+/-- The base-changed vector-group points equivalence reads a point by evaluating it on the
+base-changed generator `1 ⊗ ι(m)`. -/
+@[simp]
+theorem baseChangePointsMulEquiv_apply_apply
+    (F : WithConv (K ⊗[k] SymmetricAlgebra k M →ₐ[K] A)) (m : M) :
+    Multiplicative.toAdd (baseChangePointsMulEquiv F) m =
+      F.ofConv (1 ⊗ₜ[k] ι k M m) := by
+  rw [baseChangePointsMulEquiv, MulEquiv.trans_apply, toAdd_pointsMulEquiv_apply,
+    AlgHom.baseChangePointsMulEquiv_symm_apply]
+
+/-- The inverse base-changed vector-group points equivalence evaluates scalar multiples of
+base-changed generators by scalar multiplication of the corresponding linear-map value. -/
+@[simp]
+theorem baseChangePointsMulEquiv_symm_apply_tmul_ι
+    (φ : Multiplicative (M →ₗ[k] A)) (s : K) (m : M) :
+    ((baseChangePointsMulEquiv (k := k) (K := K) (A := A) (M := M)).symm φ).ofConv
+        (s ⊗ₜ[k] ι k M m) =
+      s • (Multiplicative.toAdd φ m) := by
+  simp [baseChangePointsMulEquiv, pointsMulEquiv_symm_apply]
+
+/-- The inverse base-changed vector-group points equivalence takes the generator indexed by
+`m` to the value of the chosen linear map at `m`. -/
+@[simp]
+theorem baseChangePointsMulEquiv_symm_apply_ι
+    (φ : Multiplicative (M →ₗ[k] A)) (m : M) :
+    ((baseChangePointsMulEquiv (k := k) (K := K) (A := A) (M := M)).symm φ).ofConv
+        (1 ⊗ₜ[k] ι k M m) =
+      Multiplicative.toAdd φ m := by
+  rw [baseChangePointsMulEquiv_symm_apply_tmul_ι]
+  simp
+
+variable {B : Type*} [CommSemiring B] [Algebra K B] [Algebra k B] [IsScalarTower k K B]
+
+/-- The base-changed vector-group points equivalence is natural in the value algebra:
+post-composing a point with a `K`-algebra map post-composes the corresponding `k`-linear map. -/
+@[simp]
+theorem toAdd_baseChangePointsMulEquiv_mapValue (ψ : A →ₐ[K] B)
+    (F : WithConv (K ⊗[k] SymmetricAlgebra k M →ₐ[K] A)) :
+    Multiplicative.toAdd
+        (baseChangePointsMulEquiv
+          (AlgHom.mapValue (H := K ⊗[k] SymmetricAlgebra k M) ψ F)) =
+      (ψ.toLinearMap.restrictScalars k).comp
+        (Multiplicative.toAdd
+          (baseChangePointsMulEquiv (k := k) (K := K) (A := A) (M := M) F)) := by
+  ext m
+  rw [baseChangePointsMulEquiv_apply_apply, LinearMap.comp_apply,
+    baseChangePointsMulEquiv_apply_apply]
+  rfl
+
+/-- Naturality of the base-changed vector-group points equivalence in the value algebra. -/
+@[simp]
+theorem baseChangePointsMulEquiv_mapValue (ψ : A →ₐ[K] B)
+    (F : WithConv (K ⊗[k] SymmetricAlgebra k M →ₐ[K] A)) :
+    baseChangePointsMulEquiv
+        (AlgHom.mapValue (H := K ⊗[k] SymmetricAlgebra k M) ψ F) =
+      Multiplicative.ofAdd
+        ((ψ.toLinearMap.restrictScalars k).comp
+          (Multiplicative.toAdd
+            (baseChangePointsMulEquiv (k := k) (K := K) (A := A) (M := M) F))) := by
+  exact congrArg Multiplicative.ofAdd (toAdd_baseChangePointsMulEquiv_mapValue ψ F)
+
+/-- Naturality of the inverse base-changed vector-group points equivalence in the value
+algebra. -/
+@[simp]
+theorem mapValue_baseChangePointsMulEquiv_symm_apply (ψ : A →ₐ[K] B)
+    (φ : Multiplicative (M →ₗ[k] A)) :
+    AlgHom.mapValue (H := K ⊗[k] SymmetricAlgebra k M) ψ
+        ((baseChangePointsMulEquiv (k := k) (K := K) (A := A) (M := M)).symm φ) =
+      (baseChangePointsMulEquiv (k := k) (K := K) (A := B) (M := M)).symm
+        (Multiplicative.ofAdd ((ψ.toLinearMap.restrictScalars k).comp
+          (Multiplicative.toAdd φ))) := by
+  apply (baseChangePointsMulEquiv (k := k) (K := K) (A := B) (M := M)).injective
+  rw [baseChangePointsMulEquiv_mapValue]
+  simp
+
+section Ga
+
+variable {A : Type w} [CommSemiring A]
+variable [Algebra K A] [Algebra k A] [IsScalarTower k K A]
+
+/-- The base-changed one-dimensional additive group `𝔾ₐ` has `A`-points the additive monoid
+of the value algebra `A`. -/
+noncomputable def gaBaseChangePointsMulEquiv :
+    WithConv (K ⊗[k] SymmetricAlgebra k k →ₐ[K] A) ≃* Multiplicative A :=
+  (baseChangePointsMulEquiv (k := k) (K := K) (A := A) (M := k)).trans
+    (AddEquiv.toMultiplicative (LinearMap.ringLmapEquivSelf k k A).toAddEquiv)
+
+/-- The base-changed `𝔾ₐ` points equivalence reads a point by evaluating it on
+`1 ⊗ ι(1)`. -/
+@[simp]
+theorem toAdd_gaBaseChangePointsMulEquiv
+    (F : WithConv (K ⊗[k] SymmetricAlgebra k k →ₐ[K] A)) :
+    Multiplicative.toAdd (gaBaseChangePointsMulEquiv F) =
+      F.ofConv (1 ⊗ₜ[k] ι k k 1) := by
+  rw [gaBaseChangePointsMulEquiv]
+  simp
+
+/-- The inverse base-changed `𝔾ₐ` points equivalence takes the generator `1 ⊗ ι(1)` to the
+chosen value. -/
+@[simp]
+theorem gaBaseChangePointsMulEquiv_symm_apply_ι (a : Multiplicative A) :
+    ((gaBaseChangePointsMulEquiv (k := k) (K := K) (A := A)).symm a).ofConv
+        (1 ⊗ₜ[k] ι k k 1) =
+      Multiplicative.toAdd a := by
+  rw [gaBaseChangePointsMulEquiv, MulEquiv.symm_trans_apply,
+    baseChangePointsMulEquiv_symm_apply_ι]
+  simp
+
+end Ga
+
+end AdditiveGroup
+
+end TauCeti

--- a/TauCeti/Algebra/AlgebraicGroup/AdditiveGroupBaseChange.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/AdditiveGroupBaseChange.lean
@@ -10,7 +10,7 @@ public import TauCeti.Algebra.AlgebraicGroup.BaseChange
 /-!
 # Base change of additive-group points
 
-The vector group attached to a `k`-module `M` is represented by the symmetric Hopf algebra
+The vector group attached to a `k`-module `M` is represented by the symmetric bialgebra
 `SymmetricAlgebra k M`. This file records the base-changed functor-of-points calculation:
 if `K` is a `k`-algebra and `A` is a commutative `K`-algebra, then the convolution monoid of
 `K`-algebra maps out of `K ⊗[k] SymmetricAlgebra k M` is the additive monoid of `k`-linear
@@ -23,13 +23,13 @@ the inverse map on scalar multiples of generators, naturality in the value algeb
 one-dimensional additive group `𝔾ₐ`.
 
 This is the additive-group worked example from the ReductiveGroups roadmap, combined with
-the Layer 0 base-change target for Hopf algebras and their functors of points.
+the Layer 0 base-change target for coordinate bialgebras and their functors of points.
 
 ## Main declarations
 
 * `TauCeti.AdditiveGroup.baseChangePointsMulEquiv`: base-changed vector-group points are
   `k`-linear maps `M →ₗ[k] A`.
-* `TauCeti.AdditiveGroup.baseChangePointsMulEquiv_apply_apply`: the equivalence reads a
+* `TauCeti.AdditiveGroup.toAdd_baseChangePointsMulEquiv_apply`: the equivalence reads a
   point on `1 ⊗ ι(m)`.
 * `TauCeti.AdditiveGroup.baseChangePointsMulEquiv_symm_apply_tmul_ι`: the inverse
   equivalence evaluates scalar multiples of base-changed generators.
@@ -39,7 +39,9 @@ the Layer 0 base-change target for Hopf algebras and their functors of points.
 ## References
 
 The generic base-change step is Tau Ceti's `AlgHom.baseChangePointsMulEquiv`; the vector-group
-points calculation is Tau Ceti's `AdditiveGroup.pointsMulEquiv`.
+points calculation is Tau Ceti's `AdditiveGroup.pointsMulEquiv`. This specialization follows
+the API pattern of `RootsOfUnityGroup.baseChangePointsMulEquiv`,
+`SplitTorus.baseChangePointsMulEquiv`, and `DiagonalizableGroup.baseChangePointsMulEquiv`.
 -/
 
 public section
@@ -61,7 +63,7 @@ variable [AddCommMonoid M] [Module k M]
 /-- The `A`-points of the base change `K ⊗[k] SymmetricAlgebra k M` of the vector group on
 `M` are the additive monoid of `k`-linear maps `M →ₗ[k] A`.
 
-The source is the convolution monoid of `K`-algebra maps out of the base-changed Hopf algebra;
+The source is the convolution monoid of `K`-algebra maps out of the base-changed bialgebra;
 the target is written multiplicatively as `Multiplicative (M →ₗ[k] A)` to match `≃*`. -/
 noncomputable def baseChangePointsMulEquiv :
     WithConv (K ⊗[k] SymmetricAlgebra k M →ₐ[K] A) ≃* Multiplicative (M →ₗ[k] A) :=
@@ -72,7 +74,7 @@ noncomputable def baseChangePointsMulEquiv :
 /-- The base-changed vector-group points equivalence reads a point by evaluating it on the
 base-changed generator `1 ⊗ ι(m)`. -/
 @[simp]
-theorem baseChangePointsMulEquiv_apply_apply
+theorem toAdd_baseChangePointsMulEquiv_apply
     (F : WithConv (K ⊗[k] SymmetricAlgebra k M →ₐ[K] A)) (m : M) :
     Multiplicative.toAdd (baseChangePointsMulEquiv F) m =
       F.ofConv (1 ⊗ₜ[k] ι k M m) := by
@@ -114,9 +116,10 @@ theorem toAdd_baseChangePointsMulEquiv_mapValue (ψ : A →ₐ[K] B)
         (Multiplicative.toAdd
           (baseChangePointsMulEquiv (k := k) (K := K) (A := A) (M := M) F)) := by
   ext m
-  rw [baseChangePointsMulEquiv_apply_apply, LinearMap.comp_apply,
-    baseChangePointsMulEquiv_apply_apply]
-  rfl
+  rw [toAdd_baseChangePointsMulEquiv_apply, LinearMap.comp_apply,
+    toAdd_baseChangePointsMulEquiv_apply, AlgHom.mapValue_apply, ofConv_toConv,
+    AlgHom.comp_apply]
+  rw [LinearMap.restrictScalars_apply, AlgHom.toLinearMap_apply]
 
 /-- Naturality of the base-changed vector-group points equivalence in the value algebra. -/
 @[simp]
@@ -176,6 +179,45 @@ theorem gaBaseChangePointsMulEquiv_symm_apply_ι (a : Multiplicative A) :
   rw [gaBaseChangePointsMulEquiv, MulEquiv.symm_trans_apply,
     baseChangePointsMulEquiv_symm_apply_ι]
   simp
+
+/-- Reading a base-changed `𝔾ₐ`-point as an element of the value algebra is natural in the
+value algebra: post-composing the point with a `K`-algebra map applies that map to the
+corresponding element. -/
+@[simp]
+theorem toAdd_gaBaseChangePointsMulEquiv_mapValue (ψ : A →ₐ[K] B)
+    (F : WithConv (K ⊗[k] SymmetricAlgebra k k →ₐ[K] A)) :
+    Multiplicative.toAdd
+        (gaBaseChangePointsMulEquiv
+          (AlgHom.mapValue (H := K ⊗[k] SymmetricAlgebra k k) ψ F)) =
+      ψ (Multiplicative.toAdd
+        (gaBaseChangePointsMulEquiv (k := k) (K := K) (A := A) F)) := by
+  rw [toAdd_gaBaseChangePointsMulEquiv, toAdd_gaBaseChangePointsMulEquiv,
+    AlgHom.mapValue_apply, ofConv_toConv, AlgHom.comp_apply]
+
+/-- The base-changed `𝔾ₐ` points equivalence is natural in the value algebra. -/
+@[simp]
+theorem gaBaseChangePointsMulEquiv_mapValue (ψ : A →ₐ[K] B)
+    (F : WithConv (K ⊗[k] SymmetricAlgebra k k →ₐ[K] A)) :
+    gaBaseChangePointsMulEquiv
+        (AlgHom.mapValue (H := K ⊗[k] SymmetricAlgebra k k) ψ F) =
+      Multiplicative.ofAdd
+        (ψ (Multiplicative.toAdd
+          (gaBaseChangePointsMulEquiv (k := k) (K := K) (A := A) F))) := by
+  exact congrArg Multiplicative.ofAdd (toAdd_gaBaseChangePointsMulEquiv_mapValue ψ F)
+
+/-- Naturality of the inverse base-changed `𝔾ₐ` points equivalence in the value algebra. -/
+@[simp]
+theorem mapValue_gaBaseChangePointsMulEquiv_symm_apply (ψ : A →ₐ[K] B)
+    (a : Multiplicative A) :
+    AlgHom.mapValue (H := K ⊗[k] SymmetricAlgebra k k) ψ
+        ((gaBaseChangePointsMulEquiv (k := k) (K := K) (A := A)).symm a) =
+      (gaBaseChangePointsMulEquiv (k := k) (K := K) (A := B)).symm
+        (Multiplicative.ofAdd (ψ (Multiplicative.toAdd a))) := by
+  apply (gaBaseChangePointsMulEquiv (k := k) (K := K) (A := B)).injective
+  rw [gaBaseChangePointsMulEquiv_mapValue]
+  rw [(gaBaseChangePointsMulEquiv (k := k) (K := K) (A := A)).apply_symm_apply a]
+  exact ((gaBaseChangePointsMulEquiv (k := k) (K := K) (A := B)).apply_symm_apply
+    (Multiplicative.ofAdd (ψ (Multiplicative.toAdd a)))).symm
 
 end Ga
 


### PR DESCRIPTION
This PR adds the base-changed functor-of-points calculation for the additive/vector group represented by `SymmetricAlgebra k M`: for a `k`-algebra `K` and a commutative `K`-algebra `A`, convolution points of `K ⊗[k] SymmetricAlgebra k M` identify with the additive monoid of `k`-linear maps `M →ₗ[k] A`. It records the generator-value formula on `1 ⊗ ι(m)`, the inverse evaluation on scalar multiples of base-changed generators, naturality in the value algebra, and the one-dimensional `𝔾ₐ` specialization.

This advances `TauCetiRoadmap/ReductiveGroups/README.md`, Layer 0, specifically the target “Base change. `K ⊗[k] A` as a Hopf algebra over `K`”, together with the worked example list item `𝔾ₐ`. I chose it as the lowest-hanging distinct ReductiveGroups target after checking open and recently merged PRs: the generic base-change equivalence and the unbased additive-group points calculation already exist, and diagonalizable/roots-of-unity/split-torus base-change specializations already landed, but the additive-group base-change specialization was missing.

No Mathlib infrastructure is vendored. The implementation reuses Tau Ceti’s `AlgHom.baseChangePointsMulEquiv` and `AdditiveGroup.pointsMulEquiv`, plus Mathlib’s `SymmetricAlgebra` universal property through the existing Tau Ceti additive-group API.

`lake exe cache get` completed with `No files to download` and `Already decompressed 8586 file(s)`. `lake build` completed with `Build completed successfully (4214 jobs).` `lake exe axioms` completed with `axioms: audited 4963 TauCeti declaration(s); all within the allowlist [propext, Classical.choice, Quot.sound].`

<!--tauceti-target:v1 {"focus":"ReductiveGroups","id":"additive-group-base-change-points"}-->

🤖 Prepared with Codex
