### PR TITLE
feat: add trivial group points

### DIFF
--- a/TauCeti/Algebra/AlgebraicGroup/Trivial.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/Trivial.lean
@@ -49,15 +49,6 @@ variable [CommSemiring R] [CommSemiring A] [Algebra R A]
 abbrev point : R →ₐ[R] A :=
   Algebra.ofId R A
 
-/-- The unique point evaluates by the algebra map. -/
-@[simp]
-theorem point_apply (r : R) : point (R := R) (A := A) r = algebraMap R A r :=
-  rfl
-
-/-- Every point evaluates as the algebra map. -/
-theorem apply_eq_algebraMap (f : R →ₐ[R] A) (r : R) : f r = algebraMap R A r := by
-  rw [Algebra.ext_id A f (point (R := R) (A := A)), point_apply]
-
 /-- Algebra maps out of the coordinate Hopf algebra `R` are equivalent to the one-point type. -/
 @[expose] noncomputable def pointEquiv : (R →ₐ[R] A) ≃ PUnit.{1} where
   toFun _ := PUnit.unit

--- a/TauCeti/Algebra/AlgebraicGroup/Trivial.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/Trivial.lean
@@ -49,7 +49,7 @@ variable [CommSemiring R] [CommSemiring A] [Algebra R A]
 The source is the convolution group of `R`-algebra maps out of the Hopf algebra `R`; since
 there is only one such algebra map, the convolution group is multiplicatively equivalent to
 `PUnit`. -/
-@[expose] noncomputable def pointsMulEquiv : WithConv (R →ₐ[R] A) ≃* PUnit.{1} where
+noncomputable def pointsMulEquiv : WithConv (R →ₐ[R] A) ≃* PUnit.{1} where
   toFun _ := PUnit.unit
   invFun _ := toConv (Algebra.ofId R A)
   left_inv f := by
@@ -58,15 +58,19 @@ there is only one such algebra map, the convolution group is multiplicatively eq
   right_inv _ := rfl
   map_mul' _ _ := rfl
 
+/-- The equivalence sends every convolution point to the unique element of `PUnit`. -/
 @[simp]
 theorem pointsMulEquiv_apply (f : WithConv (R →ₐ[R] A)) :
     pointsMulEquiv (R := R) (A := A) f = PUnit.unit :=
-  rfl
+  Subsingleton.elim _ _
 
+/-- The inverse equivalence sends the unique element of `PUnit` to `Algebra.ofId R A`. -/
 @[simp]
 theorem pointsMulEquiv_symm_apply (u : PUnit.{1}) :
     (pointsMulEquiv (R := R) (A := A)).symm u = toConv (Algebra.ofId R A) :=
-  rfl
+  by
+    apply WithConv.ofConv_injective
+    exact Subsingleton.elim _ _
 
 /-- The unique convolution point is the identity point. -/
 theorem convPoint_eq_one (f : WithConv (R →ₐ[R] A)) : f = 1 := by
@@ -74,11 +78,21 @@ theorem convPoint_eq_one (f : WithConv (R →ₐ[R] A)) : f = 1 := by
   rw [AlgHom.convOne_def]
   exact Subsingleton.elim _ _
 
+/-- The underlying algebra map of any trivial-group convolution point is `Algebra.ofId`. -/
 @[simp]
-theorem convPoint_ofConv (f : WithConv (R →ₐ[R] A)) :
+theorem ofConv_eq_ofId (f : WithConv (R →ₐ[R] A)) :
     f.ofConv = Algebra.ofId R A :=
   Subsingleton.elim _ _
 
+/-- Evaluating any trivial-group convolution point gives the algebra map. -/
+@[simp]
+theorem convPoint_apply (f : WithConv (R →ₐ[R] A)) (r : R) :
+    f r = algebraMap R A r := by
+  rw [convPoint_eq_one f]
+  rw [AlgHom.convOne_def]
+  rfl
+
+/-- Every `R`-algebra map `R →ₐ[R] A` becomes the convolution identity. -/
 @[simp]
 theorem toConv_eq_one (f : R →ₐ[R] A) : toConv f = (1 : WithConv (R →ₐ[R] A)) :=
   convPoint_eq_one (toConv f)

--- a/TauCeti/Algebra/AlgebraicGroup/Trivial.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/Trivial.lean
@@ -21,7 +21,6 @@ group scheme dictionary: `Spec R` over `Spec R` represents the trivial group-val
 
 ## Main declarations
 
-* `TauCeti.TrivialGroup.point`: the unique `A`-point, `Algebra.ofId R A`.
 * `TauCeti.TrivialGroup.pointsMulEquiv`: the convolution group of points is `PUnit`.
 * `TauCeti.TrivialGroup.pointsMulEquiv_mapValue`: the equivalence is natural in the value
   algebra.
@@ -45,31 +44,6 @@ universe u v w
 variable {R : Type u} {A : Type v}
 variable [CommSemiring R] [CommSemiring A] [Algebra R A]
 
-/-- The unique `A`-point of the trivial affine group represented by the Hopf algebra `R`. -/
-def point : R →ₐ[R] A :=
-  Algebra.ofId R A
-
-@[simp]
-theorem point_apply (r : R) : point (R := R) (A := A) r = algebraMap R A r :=
-  Algebra.ofId_apply (R := R) (A := A) r
-
-/-- Algebra maps out of the coordinate Hopf algebra `R` are equivalent to the one-point type. -/
-@[expose] noncomputable def pointEquiv : (R →ₐ[R] A) ≃ PUnit.{1} where
-  toFun _ := PUnit.unit
-  invFun _ := point (R := R) (A := A)
-  left_inv := fun f => Algebra.ext_id A (point (R := R) (A := A)) f
-  right_inv _ := rfl
-
-@[simp]
-theorem pointEquiv_apply (f : R →ₐ[R] A) :
-    pointEquiv (R := R) (A := A) f = PUnit.unit :=
-  rfl
-
-@[simp]
-theorem pointEquiv_symm_apply (u : PUnit.{1}) :
-    (pointEquiv (R := R) (A := A)).symm u = point (R := R) (A := A) :=
-  rfl
-
 /-- The functor of points of the trivial affine group is the one-element group.
 
 The source is the convolution group of `R`-algebra maps out of the Hopf algebra `R`; since
@@ -77,7 +51,7 @@ there is only one such algebra map, the convolution group is multiplicatively eq
 `PUnit`. -/
 @[expose] noncomputable def pointsMulEquiv : WithConv (R →ₐ[R] A) ≃* PUnit.{1} where
   toFun _ := PUnit.unit
-  invFun _ := toConv (point (R := R) (A := A))
+  invFun _ := toConv (Algebra.ofId R A)
   left_inv f := by
     apply WithConv.ofConv_injective
     exact Subsingleton.elim _ _
@@ -91,7 +65,7 @@ theorem pointsMulEquiv_apply (f : WithConv (R →ₐ[R] A)) :
 
 @[simp]
 theorem pointsMulEquiv_symm_apply (u : PUnit.{1}) :
-    (pointsMulEquiv (R := R) (A := A)).symm u = toConv (point (R := R) (A := A)) :=
+    (pointsMulEquiv (R := R) (A := A)).symm u = toConv (Algebra.ofId R A) :=
   rfl
 
 /-- The unique convolution point is the identity point. -/
@@ -102,7 +76,7 @@ theorem convPoint_eq_one (f : WithConv (R →ₐ[R] A)) : f = 1 := by
 
 @[simp]
 theorem convPoint_ofConv (f : WithConv (R →ₐ[R] A)) :
-    f.ofConv = point (R := R) (A := A) :=
+    f.ofConv = Algebra.ofId R A :=
   Subsingleton.elim _ _
 
 @[simp]
@@ -120,19 +94,6 @@ theorem convInv_apply (f : WithConv (R →ₐ[R] A)) (r : R) :
 section Naturality
 
 variable {B : Type w} [CommSemiring B] [Algebra R B]
-
-/-- The plain points equivalence is natural in the value algebra. -/
-@[simp]
-theorem pointEquiv_comp (φ : A →ₐ[R] B) (f : R →ₐ[R] A) :
-    pointEquiv (R := R) (A := B) (φ.comp f) =
-      pointEquiv (R := R) (A := A) f :=
-  rfl
-
-/-- The unique trivial-group point is natural in the value algebra. -/
-@[simp]
-theorem comp_point (φ : A →ₐ[R] B) :
-    φ.comp (point (R := R) (A := A)) = point (R := R) (A := B) := by
-  rw [point, point, Algebra.comp_ofId]
 
 /-- The trivial-group points equivalence is natural in the value algebra. -/
 @[simp]

--- a/TauCeti/Algebra/AlgebraicGroup/Trivial.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/Trivial.lean
@@ -46,8 +46,12 @@ variable {R : Type u} {A : Type v}
 variable [CommSemiring R] [CommSemiring A] [Algebra R A]
 
 /-- The unique `A`-point of the trivial affine group represented by the Hopf algebra `R`. -/
-abbrev point : R →ₐ[R] A :=
+def point : R →ₐ[R] A :=
   Algebra.ofId R A
+
+@[simp]
+theorem point_apply (r : R) : point (R := R) (A := A) r = algebraMap R A r :=
+  Algebra.ofId_apply (R := R) (A := A) r
 
 /-- Algebra maps out of the coordinate Hopf algebra `R` are equivalent to the one-point type. -/
 @[expose] noncomputable def pointEquiv : (R →ₐ[R] A) ≃ PUnit.{1} where
@@ -96,6 +100,15 @@ theorem convPoint_eq_one (f : WithConv (R →ₐ[R] A)) : f = 1 := by
   rw [AlgHom.convOne_def]
   exact Subsingleton.elim _ _
 
+@[simp]
+theorem convPoint_ofConv (f : WithConv (R →ₐ[R] A)) :
+    f.ofConv = point (R := R) (A := A) :=
+  Subsingleton.elim _ _
+
+@[simp]
+theorem toConv_eq_one (f : R →ₐ[R] A) : toConv f = (1 : WithConv (R →ₐ[R] A)) :=
+  convPoint_eq_one (toConv f)
+
 /-- Evaluating the inverse of a trivial-group point gives the algebra map. -/
 @[simp]
 theorem convInv_apply (f : WithConv (R →ₐ[R] A)) (r : R) :
@@ -114,6 +127,12 @@ theorem pointEquiv_comp (φ : A →ₐ[R] B) (f : R →ₐ[R] A) :
     pointEquiv (R := R) (A := B) (φ.comp f) =
       pointEquiv (R := R) (A := A) f :=
   rfl
+
+/-- The unique trivial-group point is natural in the value algebra. -/
+@[simp]
+theorem comp_point (φ : A →ₐ[R] B) :
+    φ.comp (point (R := R) (A := A)) = point (R := R) (A := B) := by
+  rw [point, point, Algebra.comp_ofId]
 
 /-- The trivial-group points equivalence is natural in the value algebra. -/
 @[simp]

--- a/TauCeti/Algebra/AlgebraicGroup/Trivial.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/Trivial.lean
@@ -54,19 +54,15 @@ abbrev point : R →ₐ[R] A :=
 theorem point_apply (r : R) : point (R := R) (A := A) r = algebraMap R A r :=
   rfl
 
-/-- Every `A`-point of the trivial affine group is the canonical algebra map. -/
-theorem point_eq (f : R →ₐ[R] A) : f = point (R := R) (A := A) :=
-  Subsingleton.elim f (point (R := R) (A := A))
-
-/-- Pointwise form of `point_eq`: every point evaluates as the algebra map. -/
+/-- Every point evaluates as the algebra map. -/
 theorem apply_eq_algebraMap (f : R →ₐ[R] A) (r : R) : f r = algebraMap R A r := by
-  rw [point_eq f, point_apply]
+  rw [Algebra.ext_id A f (point (R := R) (A := A)), point_apply]
 
 /-- Algebra maps out of the coordinate Hopf algebra `R` are equivalent to the one-point type. -/
 @[expose] noncomputable def pointEquiv : (R →ₐ[R] A) ≃ PUnit.{1} where
   toFun _ := PUnit.unit
   invFun _ := point (R := R) (A := A)
-  left_inv := fun f => (point_eq f).symm
+  left_inv := fun f => Algebra.ext_id A (point (R := R) (A := A)) f
   right_inv _ := rfl
 
 @[simp]
@@ -120,12 +116,6 @@ theorem convInv_apply (f : WithConv (R →ₐ[R] A)) (r : R) :
 section Naturality
 
 variable {B : Type w} [CommSemiring B] [Algebra R B]
-
-/-- The unique point is natural in the value algebra. -/
-@[simp]
-theorem comp_point (φ : A →ₐ[R] B) :
-    φ.comp (point (R := R) (A := A)) = point (R := R) (A := B) :=
-  point_eq _
 
 /-- The plain points equivalence is natural in the value algebra. -/
 @[simp]

--- a/TauCeti/Algebra/AlgebraicGroup/Trivial.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/Trivial.lean
@@ -78,6 +78,11 @@ theorem convPoint_eq_one (f : WithConv (R →ₐ[R] A)) : f = 1 := by
   rw [AlgHom.convOne_def]
   exact Subsingleton.elim _ _
 
+/-- The identity normal form for trivial-group convolution points, as a simp proposition. -/
+@[simp]
+theorem convPoint_eq_one_iff (f : WithConv (R →ₐ[R] A)) : f = 1 ↔ True :=
+  ⟨fun _ => trivial, fun _ => convPoint_eq_one f⟩
+
 /-- The underlying algebra map of any trivial-group convolution point is `Algebra.ofId`. -/
 @[simp]
 theorem ofConv_eq_ofId (f : WithConv (R →ₐ[R] A)) :

--- a/TauCeti/Algebra/AlgebraicGroup/Trivial.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/Trivial.lean
@@ -1,0 +1,157 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+module
+
+public import TauCeti.Algebra.AlgebraicGroup.FunctorOfPoints
+
+/-!
+# The trivial affine group
+
+This file records the functor-of-points calculation for the trivial affine group scheme. Its
+coordinate Hopf algebra is the base ring `R`, with Mathlib's canonical Hopf algebra structure
+on `R` over itself. For every commutative `R`-algebra `A`, there is exactly one `R`-algebra
+homomorphism `R →ₐ[R] A`, namely `Algebra.ofId R A`; consequently the convolution group of
+`A`-points is the one-element group `PUnit`.
+
+This is the terminal-object example in the Hopf-algebra/functor-of-points side of the
+ReductiveGroups roadmap, Layer 0. It is the identity object needed by the product and affine
+group scheme dictionary: `Spec R` over `Spec R` represents the trivial group-valued functor.
+
+## Main declarations
+
+* `TauCeti.TrivialGroup.point`: the unique `A`-point, `Algebra.ofId R A`.
+* `TauCeti.TrivialGroup.pointsMulEquiv`: the convolution group of points is `PUnit`.
+* `TauCeti.TrivialGroup.pointsMulEquiv_mapValue`: the equivalence is natural in the value
+  algebra.
+
+## References
+
+This uses Mathlib's `Algebra.ofId`, its `Subsingleton (R →ₐ[R] A)` instance, and the
+canonical Hopf algebra structure on `R` over itself from `Mathlib.RingTheory.HopfAlgebra.Basic`.
+-/
+
+public section
+
+open WithConv
+
+namespace TauCeti
+
+namespace TrivialGroup
+
+universe u v w
+
+variable {R : Type u} {A : Type v}
+variable [CommSemiring R] [CommSemiring A] [Algebra R A]
+
+/-- The unique `A`-point of the trivial affine group represented by the Hopf algebra `R`. -/
+abbrev point : R →ₐ[R] A :=
+  Algebra.ofId R A
+
+/-- The unique point evaluates by the algebra map. -/
+@[simp]
+theorem point_apply (r : R) : point (R := R) (A := A) r = algebraMap R A r :=
+  rfl
+
+/-- Every `A`-point of the trivial affine group is the canonical algebra map. -/
+theorem point_eq (f : R →ₐ[R] A) : f = point (R := R) (A := A) :=
+  Subsingleton.elim f (point (R := R) (A := A))
+
+/-- Pointwise form of `point_eq`: every point evaluates as the algebra map. -/
+theorem apply_eq_algebraMap (f : R →ₐ[R] A) (r : R) : f r = algebraMap R A r := by
+  rw [point_eq f, point_apply]
+
+/-- Algebra maps out of the coordinate Hopf algebra `R` are equivalent to the one-point type. -/
+@[expose] noncomputable def pointEquiv : (R →ₐ[R] A) ≃ PUnit.{1} where
+  toFun _ := PUnit.unit
+  invFun _ := point (R := R) (A := A)
+  left_inv := fun f => (point_eq f).symm
+  right_inv _ := rfl
+
+@[simp]
+theorem pointEquiv_apply (f : R →ₐ[R] A) :
+    pointEquiv (R := R) (A := A) f = PUnit.unit :=
+  rfl
+
+@[simp]
+theorem pointEquiv_symm_apply (u : PUnit.{1}) :
+    (pointEquiv (R := R) (A := A)).symm u = point (R := R) (A := A) :=
+  rfl
+
+/-- The functor of points of the trivial affine group is the one-element group.
+
+The source is the convolution group of `R`-algebra maps out of the Hopf algebra `R`; since
+there is only one such algebra map, the convolution group is multiplicatively equivalent to
+`PUnit`. -/
+@[expose] noncomputable def pointsMulEquiv : WithConv (R →ₐ[R] A) ≃* PUnit.{1} where
+  toFun _ := PUnit.unit
+  invFun _ := toConv (point (R := R) (A := A))
+  left_inv f := by
+    apply WithConv.ofConv_injective
+    exact Subsingleton.elim _ _
+  right_inv _ := rfl
+  map_mul' _ _ := rfl
+
+@[simp]
+theorem pointsMulEquiv_apply (f : WithConv (R →ₐ[R] A)) :
+    pointsMulEquiv (R := R) (A := A) f = PUnit.unit :=
+  rfl
+
+@[simp]
+theorem pointsMulEquiv_symm_apply (u : PUnit.{1}) :
+    (pointsMulEquiv (R := R) (A := A)).symm u = toConv (point (R := R) (A := A)) :=
+  rfl
+
+/-- The unique convolution point is the identity point. -/
+theorem convPoint_eq_one (f : WithConv (R →ₐ[R] A)) : f = 1 := by
+  apply WithConv.ofConv_injective
+  rw [AlgHom.convOne_def]
+  exact Subsingleton.elim _ _
+
+/-- Evaluating the inverse of a trivial-group point gives the algebra map. -/
+@[simp]
+theorem convInv_apply (f : WithConv (R →ₐ[R] A)) (r : R) :
+    f⁻¹ r = algebraMap R A r := by
+  rw [convPoint_eq_one f]
+  rw [AlgHom.convOne_def]
+  rfl
+
+section Naturality
+
+variable {B : Type w} [CommSemiring B] [Algebra R B]
+
+/-- The unique point is natural in the value algebra. -/
+@[simp]
+theorem comp_point (φ : A →ₐ[R] B) :
+    φ.comp (point (R := R) (A := A)) = point (R := R) (A := B) :=
+  point_eq _
+
+/-- The plain points equivalence is natural in the value algebra. -/
+@[simp]
+theorem pointEquiv_comp (φ : A →ₐ[R] B) (f : R →ₐ[R] A) :
+    pointEquiv (R := R) (A := B) (φ.comp f) =
+      pointEquiv (R := R) (A := A) f :=
+  rfl
+
+/-- The trivial-group points equivalence is natural in the value algebra. -/
+@[simp]
+theorem pointsMulEquiv_mapValue (φ : A →ₐ[R] B) (f : WithConv (R →ₐ[R] A)) :
+    pointsMulEquiv (R := R) (A := B)
+        (AlgHom.mapValue (H := R) φ f) =
+      pointsMulEquiv (R := R) (A := A) f :=
+  rfl
+
+/-- Naturality of the inverse trivial-group points equivalence in the value algebra. -/
+@[simp]
+theorem mapValue_pointsMulEquiv_symm_apply (φ : A →ₐ[R] B) (u : PUnit.{1}) :
+    AlgHom.mapValue (H := R) φ ((pointsMulEquiv (R := R) (A := A)).symm u) =
+      (pointsMulEquiv (R := R) (A := B)).symm u := by
+  apply (pointsMulEquiv (R := R) (A := B)).injective
+  rw [pointsMulEquiv_mapValue]
+
+end Naturality
+
+end TrivialGroup
+
+end TauCeti


### PR DESCRIPTION
This PR adds the trivial affine group points calculation: for the coordinate Hopf algebra `R` over itself, every `A`-point `R →ₐ[R] A` is the canonical algebra map, so the convolution group of points is multiplicatively equivalent to the one-element group `PUnit`. It also records the pointwise evaluation, the identity-point consequence, and naturality under post-composition in the value algebra.

This advances `TauCetiRoadmap/ReductiveGroups/README.md`, Layer 0, as a clean prerequisite for the affine group scheme dictionary item that needs the terminal object over `Spec R` and for the Layer 0 target “R-points as a group.” I chose it as the lowest-hanging distinct ReductiveGroups target after checking open and recently merged PRs: the generic convolution group, product points, diagonalizable examples, `𝔾ₘ`, `𝔾ₐ`, roots of unity, split tori, and additive base-change work already exist or are in flight, while the terminal/trivial group example was still missing.

No Mathlib infrastructure is vendored. The implementation reuses Mathlib’s `Algebra.ofId`, its `Subsingleton (R →ₐ[R] A)` instance, and Mathlib’s canonical Hopf algebra structure on `R` over itself, together with Tau Ceti’s existing convolution-points API `AlgHom.mapValue`.

`lake exe cache get` completed with `No files to download` and `Already decompressed 8586 file(s)`. `lake build` completed with `Build completed successfully (4214 jobs).` `lake exe axioms` completed with `axioms: audited 4965 TauCeti declaration(s); all within the allowlist [propext, Classical.choice, Quot.sound].`

<!--tauceti-target:v1 {"focus":"ReductiveGroups","id":"trivial-group-points"}-->

🤖 Prepared with Codex
