### PR TITLE
feat: add smooth embedding ambient isotopy

### DIFF
--- a/TauCeti/Geometry/Manifold/SmoothEmbedding.lean
+++ b/TauCeti/Geometry/Manifold/SmoothEmbedding.lean
@@ -24,6 +24,8 @@ later tubular-neighbourhood and surgery interfaces.
 ## Main definitions
 
 * `TauCeti.SmoothEmbedding I J n M N`: bundled `C^n` smooth embeddings `M → N`.
+* `TauCeti.SmoothEmbedding.toContinuousMap`: the underlying continuous map, implemented through
+  Mathlib's generic `ContinuousMapClass` coercion.
 * `TauCeti.SmoothEmbedding.ofIsSmoothEmbedding`: bundle a map satisfying Mathlib's
   `Manifold.IsSmoothEmbedding` predicate.
 * `TauCeti.SmoothEmbedding.id`: the identity smooth embedding.
@@ -83,10 +85,37 @@ instance instFunLike : FunLike (SmoothEmbedding I J n M N) M N where
     cases hfg
     rfl
 
+instance instContinuousMapClass : ContinuousMapClass (SmoothEmbedding I J n M N) M N where
+  map_continuous f := f.toContMDiffMap.contMDiff.continuous
+
 /-- The bundled `C^n` map underlying a smooth embedding. -/
 @[simp]
 theorem toContMDiffMap_coe (f : SmoothEmbedding I J n M N) :
     ⇑f.toContMDiffMap = f := rfl
+
+/-- The continuous map underlying a bundled smooth embedding. -/
+abbrev toContinuousMap (f : SmoothEmbedding I J n M N) : C(M, N) :=
+  _root_.toContinuousMap f
+
+@[simp]
+theorem toContinuousMap_apply (f : SmoothEmbedding I J n M N) (x : M) :
+    f.toContinuousMap x = f x :=
+  rfl
+
+@[simp]
+theorem coe_toContinuousMap (f : SmoothEmbedding I J n M N) :
+    ⇑f.toContinuousMap = f :=
+  rfl
+
+/-- The underlying continuous map determines a bundled smooth embedding. -/
+theorem toContinuousMap_injective :
+    Function.Injective (toContinuousMap : SmoothEmbedding I J n M N → C(M, N)) :=
+  ContinuousMap.coe_injective'
+
+@[simp]
+theorem toContinuousMap_inj {f g : SmoothEmbedding I J n M N} :
+    (toContinuousMap f : C(M, N)) = toContinuousMap g ↔ f = g :=
+  toContinuousMap_injective.eq_iff
 
 /-- A bundled smooth embedding is a `C^n` map. -/
 theorem contMDiff (f : SmoothEmbedding I J n M N) : ContMDiff I J n f :=

--- a/TauCeti/Geometry/Manifold/SmoothEmbedding/AmbientIsotopy.lean
+++ b/TauCeti/Geometry/Manifold/SmoothEmbedding/AmbientIsotopy.lean
@@ -23,8 +23,6 @@ specialise further when they need differentiable isotopies.
 
 ## Main definitions
 
-* `TauCeti.SmoothEmbedding.toContinuousMap`: the continuous map underlying a bundled smooth
-  embedding.
 * `TauCeti.SmoothEmbedding.AmbientIsotopic`: two bundled smooth embeddings are ambient isotopic
   when their underlying continuous maps are ambient isotopic.
 * `TauCeti.SmoothEmbedding.AmbientIsotopic.setoid`: ambient isotopy as a setoid on bundled smooth
@@ -53,46 +51,19 @@ variable {𝕜 : Type*} [NontriviallyNormedField 𝕜]
   {N : Type*} [TopologicalSpace N] [ChartedSpace H' N]
   {n : ℕ∞ω}
 
-/-- The continuous map underlying a bundled smooth embedding. -/
-@[expose]
-def toContinuousMap (f : SmoothEmbedding I J n M N) : C(M, N) where
-  toFun := f
-  continuous_toFun := f.contMDiff.continuous
-
-@[simp]
-theorem toContinuousMap_apply (f : SmoothEmbedding I J n M N) (x : M) :
-    f.toContinuousMap x = f x :=
-  rfl
-
-@[simp]
-theorem coe_toContinuousMap (f : SmoothEmbedding I J n M N) :
-    ⇑f.toContinuousMap = f :=
-  rfl
-
-/-- The underlying continuous map determines a bundled smooth embedding. -/
-theorem toContinuousMap_injective :
-    Function.Injective (toContinuousMap : SmoothEmbedding I J n M N → C(M, N)) := by
-  intro f g h
-  ext x
-  exact congr_fun (congrArg DFunLike.coe h) x
-
-@[simp]
-theorem toContinuousMap_inj {f g : SmoothEmbedding I J n M N} :
-    f.toContinuousMap = g.toContinuousMap ↔ f = g :=
-  toContinuousMap_injective.eq_iff
-
 variable {f g h : SmoothEmbedding I J n M N}
 
 /-- Two bundled smooth embeddings are ambient isotopic when their underlying continuous maps are
 ambient isotopic. This is the continuous topological relation, not a smooth ambient isotopy. -/
-@[expose] def AmbientIsotopic (f g : SmoothEmbedding I J n M N) : Prop :=
+def AmbientIsotopic (f g : SmoothEmbedding I J n M N) : Prop :=
   TauCeti.AmbientIsotopic f.toContinuousMap g.toContinuousMap
 
-/-- Ambient isotopy of bundled smooth embeddings is ambient isotopy of their underlying
-continuous maps. -/
+/-- Ambient isotopy of bundled smooth embeddings is witnessed by an ambient isotopy whose final
+homeomorphism postcomposes the first underlying continuous map to the second. -/
 theorem ambientIsotopic_def :
-    AmbientIsotopic f g ↔ TauCeti.AmbientIsotopic f.toContinuousMap g.toContinuousMap :=
-  Iff.rfl
+    AmbientIsotopic f g ↔
+      ∃ Φ : TauCeti.AmbientIsotopy N, Φ.final.comp f.toContinuousMap = g.toContinuousMap :=
+  TauCeti.ambientIsotopic_def
 
 namespace AmbientIsotopic
 
@@ -104,7 +75,7 @@ theorem of_ambientIsotopy (Φ : TauCeti.AmbientIsotopy N)
 
 /-- A symmetric form of `SmoothEmbedding.AmbientIsotopic.of_ambientIsotopy`, useful when the
 endpoint equation is oriented as `g = Φ.final ∘ f`. -/
-theorem of_eq_final (Φ : TauCeti.AmbientIsotopy N)
+theorem of_eq_final_comp (Φ : TauCeti.AmbientIsotopy N)
     (hΦ : g.toContinuousMap = Φ.final.comp f.toContinuousMap) : AmbientIsotopic f g :=
   of_ambientIsotopy Φ hΦ.symm
 

--- a/TauCeti/Geometry/Manifold/SmoothEmbedding/AmbientIsotopy.lean
+++ b/TauCeti/Geometry/Manifold/SmoothEmbedding/AmbientIsotopy.lean
@@ -1,0 +1,153 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+module
+
+public import TauCeti.Geometry.Manifold.SmoothEmbedding
+public import TauCeti.Topology.Homotopy.AmbientIsotopic
+
+/-!
+# Ambient isotopy of bundled smooth embeddings
+
+The geometric-topology roadmap treats geometric knot presentations as smooth embeddings,
+and asks that isotopy and ambient isotopy be defined generally before being specialised.
+`TauCeti.AmbientIsotopic` already gives the point-set ambient-isotopy relation for continuous
+maps. This file connects that relation to the bundled smooth embeddings of
+`TauCeti.Geometry.Manifold.SmoothEmbedding`.
+
+The relation here does not assert that the ambient isotopy is smooth in time or in the ambient
+variable. It is the continuous ambient-isotopy relation on the underlying maps of two bundled
+smooth embeddings, which is the topological relation later smooth-knot and concordance files can
+specialise further when they need differentiable isotopies.
+
+## Main definitions
+
+* `TauCeti.SmoothEmbedding.toContinuousMap`: the continuous map underlying a bundled smooth
+  embedding.
+* `TauCeti.SmoothEmbedding.AmbientIsotopic`: two bundled smooth embeddings are ambient isotopic
+  when their underlying continuous maps are ambient isotopic.
+* `TauCeti.SmoothEmbedding.AmbientIsotopic.setoid`: ambient isotopy as a setoid on bundled smooth
+  embeddings.
+
+The source for the topological notion is Burde--Zieschang, *Knots*, Chapter 1, Definitions 1.1
+and 1.2, via the existing `TauCeti.Topology.Homotopy.Isotopy` and
+`TauCeti.Topology.Homotopy.AmbientIsotopic` files.
+-/
+
+public section
+
+namespace TauCeti
+
+open scoped Manifold ContDiff
+open ContinuousMap
+
+namespace SmoothEmbedding
+
+variable {𝕜 : Type*} [NontriviallyNormedField 𝕜]
+  {E : Type*} [NormedAddCommGroup E] [NormedSpace 𝕜 E]
+  {E' : Type*} [NormedAddCommGroup E'] [NormedSpace 𝕜 E']
+  {H : Type*} [TopologicalSpace H] {H' : Type*} [TopologicalSpace H']
+  {I : ModelWithCorners 𝕜 E H} {J : ModelWithCorners 𝕜 E' H'}
+  {M : Type*} [TopologicalSpace M] [ChartedSpace H M]
+  {N : Type*} [TopologicalSpace N] [ChartedSpace H' N]
+  {n : ℕ∞ω}
+
+/-- The continuous map underlying a bundled smooth embedding. -/
+@[expose]
+def toContinuousMap (f : SmoothEmbedding I J n M N) : C(M, N) where
+  toFun := f
+  continuous_toFun := f.contMDiff.continuous
+
+@[simp]
+theorem toContinuousMap_apply (f : SmoothEmbedding I J n M N) (x : M) :
+    f.toContinuousMap x = f x :=
+  rfl
+
+@[simp]
+theorem coe_toContinuousMap (f : SmoothEmbedding I J n M N) :
+    ⇑f.toContinuousMap = f :=
+  rfl
+
+/-- The underlying continuous map determines a bundled smooth embedding. -/
+theorem toContinuousMap_injective :
+    Function.Injective (toContinuousMap : SmoothEmbedding I J n M N → C(M, N)) := by
+  intro f g h
+  ext x
+  exact congr_fun (congrArg DFunLike.coe h) x
+
+@[simp]
+theorem toContinuousMap_inj {f g : SmoothEmbedding I J n M N} :
+    f.toContinuousMap = g.toContinuousMap ↔ f = g :=
+  toContinuousMap_injective.eq_iff
+
+variable {f g h : SmoothEmbedding I J n M N}
+
+/-- Two bundled smooth embeddings are ambient isotopic when their underlying continuous maps are
+ambient isotopic. This is the continuous topological relation, not a smooth ambient isotopy. -/
+@[expose] def AmbientIsotopic (f g : SmoothEmbedding I J n M N) : Prop :=
+  TauCeti.AmbientIsotopic f.toContinuousMap g.toContinuousMap
+
+/-- Ambient isotopy of bundled smooth embeddings is ambient isotopy of their underlying
+continuous maps. -/
+theorem ambientIsotopic_def :
+    AmbientIsotopic f g ↔ TauCeti.AmbientIsotopic f.toContinuousMap g.toContinuousMap :=
+  Iff.rfl
+
+namespace AmbientIsotopic
+
+/-- An ambient isotopy whose final map carries `f` to `g` witnesses ambient isotopy of the two
+bundled smooth embeddings. -/
+theorem of_ambientIsotopy (Φ : TauCeti.AmbientIsotopy N)
+    (hΦ : Φ.final.comp f.toContinuousMap = g.toContinuousMap) : AmbientIsotopic f g :=
+  ⟨Φ, hΦ⟩
+
+/-- A symmetric form of `SmoothEmbedding.AmbientIsotopic.of_ambientIsotopy`, useful when the
+endpoint equation is oriented as `g = Φ.final ∘ f`. -/
+theorem of_eq_final (Φ : TauCeti.AmbientIsotopy N)
+    (hΦ : g.toContinuousMap = Φ.final.comp f.toContinuousMap) : AmbientIsotopic f g :=
+  of_ambientIsotopy Φ hΦ.symm
+
+/-- Ambient isotopy of bundled smooth embeddings is reflexive. -/
+@[refl]
+theorem refl (f : SmoothEmbedding I J n M N) : AmbientIsotopic f f :=
+  TauCeti.AmbientIsotopic.refl f.toContinuousMap
+
+/-- Ambient isotopy of bundled smooth embeddings is symmetric. -/
+@[symm]
+theorem symm (hfg : AmbientIsotopic f g) : AmbientIsotopic g f :=
+  TauCeti.AmbientIsotopic.symm hfg
+
+/-- Ambient isotopy of bundled smooth embeddings is transitive. -/
+@[trans]
+theorem trans (hfg : AmbientIsotopic f g) (hgh : AmbientIsotopic g h) : AmbientIsotopic f h :=
+  TauCeti.AmbientIsotopic.trans hfg hgh
+
+/-- Ambient isotopic bundled smooth embeddings have isotopic underlying continuous maps. -/
+theorem isotopic (hfg : AmbientIsotopic f g) : Isotopic f.toContinuousMap g.toContinuousMap :=
+  TauCeti.AmbientIsotopic.isotopic hfg f.isEmbedding
+
+/-- Ambient isotopy is an equivalence relation on bundled smooth embeddings. -/
+theorem equivalence :
+    Equivalence (AmbientIsotopic (I := I) (J := J) (n := n) (M := M) (N := N)) :=
+  ⟨refl, fun hfg => hfg.symm, fun hfg hgh => hfg.trans hgh⟩
+
+/-- The ambient-isotopy equivalence relation on bundled smooth embeddings, packaged as a
+`Setoid`. -/
+def setoid (I : ModelWithCorners 𝕜 E H) (J : ModelWithCorners 𝕜 E' H') (n : ℕ∞ω)
+    (M : Type*) [TopologicalSpace M] [ChartedSpace H M]
+    (N : Type*) [TopologicalSpace N] [ChartedSpace H' N] :
+    Setoid (SmoothEmbedding I J n M N) where
+  r := AmbientIsotopic
+  iseqv := equivalence
+
+@[simp]
+theorem setoid_r_iff {f g : SmoothEmbedding I J n M N} :
+    (setoid I J n M N).r f g ↔ AmbientIsotopic f g :=
+  Iff.rfl
+
+end AmbientIsotopic
+
+end SmoothEmbedding
+
+end TauCeti


### PR DESCRIPTION
This PR adds the continuous map underlying a bundled smooth embedding and specializes the existing continuous ambient-isotopy relation to bundled smooth embeddings. It defines `SmoothEmbedding.toContinuousMap`, the relation `SmoothEmbedding.AmbientIsotopic f g`, constructor lemmas from an ambient isotopy endpoint equation, the equivalence-relation API, the setoid, and the implication that ambient-isotopic bundled smooth embeddings have isotopic underlying continuous maps.

This advances `TauCetiRoadmap/GeometricTopology/README.md`, specifically the Encoding conventions item “Isotopy is defined generally, then specialised” and Layer 4’s convention that geometric knot presentations are smooth embeddings `S¹ ↪ M`. I chose it as the lowest-hanging distinct GeometricTopology prerequisite after checking open and recently merged PRs: Tau Ceti already has general continuous isotopy/ambient isotopy and a bundled `SmoothEmbedding` type, but the small bridge letting later knot-presentation files use the general ambient-isotopy relation on bundled smooth embeddings was still missing.

No Mathlib infrastructure is vendored. The implementation reuses Tau Ceti’s `SmoothEmbedding`, `AmbientIsotopic`, and `Isotopic` APIs, and Mathlib’s `ContMDiff.continuous` to obtain the underlying continuous map. The topological ambient-isotopy convention follows Burde--Zieschang, *Knots*, Chapter 1, Definitions 1.1 and 1.2, via the existing Tau Ceti isotopy files.

`lake exe cache get` completed with `No files to download` and `Already decompressed 8586 file(s)`. `lake build` completed with `Build completed successfully (4218 jobs).` `lake exe axioms` completed with `axioms: audited 5018 TauCeti declaration(s); all within the allowlist [propext, Classical.choice, Quot.sound].`

<!--tauceti-target:v1 {"focus":"GeometricTopology","id":"smooth-embedding-ambient-isotopy"}-->

🤖 Prepared with Codex
