### PR TITLE
feat: add symmetric energy integrands

### DIFF
--- a/TauCeti/Analysis/PDE/SymmetricEnergy.lean
+++ b/TauCeti/Analysis/PDE/SymmetricEnergy.lean
@@ -9,10 +9,10 @@ public import TauCeti.Analysis.PDE.EnergyForm
 /-!
 # Symmetric pointwise energy integrands
 
-For a divergence-form operator with no drift term, symmetry of the principal coefficient
-matrix is exactly symmetry of the pointwise jet bilinear form
-`energyIntegrand A 0 c`.  This file records that finite-dimensional bookkeeping before the
-energy form is integrated over a Sobolev space.
+For a divergence-form operator with no drift term, a symmetric principal coefficient
+matrix gives a symmetric pointwise jet bilinear form `energyIntegrand A 0 c`.  This file
+records that finite-dimensional bookkeeping before the energy form is integrated over a
+Sobolev space.
 
 The main use is Lane D of the PDE roadmap: the weak formulation and the Dirichlet spectrum
 need the integrated form coming from symmetric coefficients to be a symmetric coercive
@@ -114,10 +114,10 @@ lemma energyIntegrand_coefficientSymmetricPart_zero_drift_flip_eq (A : Matrix n 
 /-- A pointwise symmetric coefficient field gives symmetric zero-drift jet forms at every
 point of the domain. -/
 lemma energyIntegrand_zero_drift_comm_on {Ω : Set X} {a : X → Matrix n n ℝ}
-    (ha : ∀ ⦃x⦄, x ∈ Ω → (a x).IsSymm) {x : X} (hx : x ∈ Ω) (c₀ : ℝ)
+    (ha : ∀ ⦃x⦄, x ∈ Ω → (a x).IsSymm) {x : X} (hx : x ∈ Ω) (c : X → ℝ)
     (U V : ℝ × EuclideanSpace ℝ n) :
-    energyIntegrand (a x) 0 c₀ U V = energyIntegrand (a x) 0 c₀ V U :=
-  energyIntegrand_zero_drift_comm_of_isSymm (ha hx) c₀ U V
+    energyIntegrand (a x) 0 (c x) U V = energyIntegrand (a x) 0 (c x) V U :=
+  energyIntegrand_zero_drift_comm_of_isSymm (ha hx) (c x) U V
 
 end PDE
 

--- a/TauCeti/Analysis/PDE/SymmetricEnergy.lean
+++ b/TauCeti/Analysis/PDE/SymmetricEnergy.lean
@@ -1,0 +1,124 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+module
+
+public import TauCeti.Analysis.PDE.EnergyForm
+
+/-!
+# Symmetric pointwise energy integrands
+
+For a divergence-form operator with no drift term, symmetry of the principal coefficient
+matrix is exactly symmetry of the pointwise jet bilinear form
+`energyIntegrand A 0 c`.  This file records that finite-dimensional bookkeeping before the
+energy form is integrated over a Sobolev space.
+
+The main use is Lane D of the PDE roadmap: the weak formulation and the Dirichlet spectrum
+need the integrated form coming from symmetric coefficients to be a symmetric coercive
+bilinear form.  The already-existing `coefficientSymmetricPart` replaces a possibly
+nonsymmetric coefficient matrix by `(A + Aᵀ) / 2`; here we prove the corresponding facts for
+the full zero-drift jet integrand.
+
+## Main declarations
+
+* `TauCeti.PDE.energyIntegrand_zero_drift_transpose_apply`: transposing the principal
+  coefficient swaps the two jet arguments.
+* `TauCeti.PDE.energyIntegrand_zero_drift_comm_of_isSymm`: a symmetric principal
+  coefficient gives a symmetric zero-drift jet form.
+* `TauCeti.PDE.energyIntegrand_coefficientSymmetricPart_zero_drift_apply`: the symmetric
+  part has zero-drift jet form equal to the average of the original form and its transpose.
+* `TauCeti.PDE.energyIntegrand_coefficientSymmetricPart_zero_drift_self`: the diagonal
+  energy density is unchanged by replacing the principal coefficient by its symmetric part.
+* `TauCeti.PDE.energyIntegrand_zero_drift_comm_on`: a pointwise symmetric coefficient field
+  gives symmetric zero-drift jet forms at every point of the domain.
+-/
+
+public section
+
+namespace TauCeti
+
+namespace PDE
+
+open Matrix
+
+variable {X n : Type*} [Fintype n] [DecidableEq n]
+
+/-- With zero drift, transposing the principal coefficient swaps the two jet arguments. -/
+@[simp]
+lemma energyIntegrand_zero_drift_transpose_apply (A : Matrix n n ℝ) (c : ℝ)
+    (U V : ℝ × EuclideanSpace ℝ n) :
+    energyIntegrand Aᵀ 0 c U V = energyIntegrand A 0 c V U := by
+  rw [energyIntegrand_apply, energyIntegrand_apply, matrixBilinearForm_transpose_apply]
+  simp [driftForm_apply, massForm_apply, mul_comm, mul_left_comm]
+
+/-- A symmetric principal coefficient gives a symmetric zero-drift jet form. -/
+lemma energyIntegrand_zero_drift_comm_of_isSymm {A : Matrix n n ℝ} (hA : A.IsSymm)
+    (c : ℝ) (U V : ℝ × EuclideanSpace ℝ n) :
+    energyIntegrand A 0 c U V = energyIntegrand A 0 c V U := by
+  calc
+    energyIntegrand A 0 c U V = energyIntegrand Aᵀ 0 c U V := by rw [hA.eq]
+    _ = energyIntegrand A 0 c V U := energyIntegrand_zero_drift_transpose_apply A c U V
+
+/-- Bundled-map form of symmetry for the zero-drift jet integrand. -/
+lemma energyIntegrand_zero_drift_flip_eq_of_isSymm {A : Matrix n n ℝ} (hA : A.IsSymm)
+    (c : ℝ) :
+    (energyIntegrand A 0 c).flip = energyIntegrand A 0 c := by
+  apply ContinuousLinearMap.ext
+  intro U
+  apply ContinuousLinearMap.ext
+  intro V
+  exact energyIntegrand_zero_drift_comm_of_isSymm hA c V U
+
+/-- The identity principal coefficient gives a symmetric zero-drift jet form. -/
+lemma energyIntegrand_one_zero_drift_comm (c : ℝ) (U V : ℝ × EuclideanSpace ℝ n) :
+    energyIntegrand (1 : Matrix n n ℝ) 0 c U V =
+      energyIntegrand (1 : Matrix n n ℝ) 0 c V U :=
+  energyIntegrand_zero_drift_comm_of_isSymm isSymm_one c U V
+
+/-- The symmetric part's zero-drift jet form is the average of the original form and its
+transpose. -/
+@[simp]
+lemma energyIntegrand_coefficientSymmetricPart_zero_drift_apply (A : Matrix n n ℝ)
+    (c : ℝ) (U V : ℝ × EuclideanSpace ℝ n) :
+    energyIntegrand (coefficientSymmetricPart A) 0 c U V =
+      (energyIntegrand A 0 c U V + energyIntegrand A 0 c V U) / 2 := by
+  rw [energyIntegrand_apply, matrixBilinearForm_coefficientSymmetricPart_apply,
+    energyIntegrand_apply, energyIntegrand_apply]
+  simp [driftForm_apply, massForm_apply, mul_comm, mul_left_comm]
+  ring
+
+/-- Replacing the principal coefficient by its symmetric part does not change the
+zero-drift diagonal energy density. -/
+@[simp]
+lemma energyIntegrand_coefficientSymmetricPart_zero_drift_self (A : Matrix n n ℝ)
+    (c : ℝ) (U : ℝ × EuclideanSpace ℝ n) :
+    energyIntegrand (coefficientSymmetricPart A) 0 c U U =
+      energyIntegrand A 0 c U U := by
+  rw [energyIntegrand_self, energyIntegrand_self, toQuadraticForm'_coefficientSymmetricPart]
+
+/-- The symmetric part always gives a symmetric zero-drift jet form. -/
+lemma energyIntegrand_coefficientSymmetricPart_zero_drift_comm (A : Matrix n n ℝ)
+    (c : ℝ) (U V : ℝ × EuclideanSpace ℝ n) :
+    energyIntegrand (coefficientSymmetricPart A) 0 c U V =
+      energyIntegrand (coefficientSymmetricPart A) 0 c V U :=
+  energyIntegrand_zero_drift_comm_of_isSymm (coefficientSymmetricPart_isSymm A) c U V
+
+/-- Bundled-map form of symmetry for the symmetric-part zero-drift jet integrand. -/
+lemma energyIntegrand_coefficientSymmetricPart_zero_drift_flip_eq (A : Matrix n n ℝ)
+    (c : ℝ) :
+    (energyIntegrand (coefficientSymmetricPart A) 0 c).flip =
+      energyIntegrand (coefficientSymmetricPart A) 0 c :=
+  energyIntegrand_zero_drift_flip_eq_of_isSymm (coefficientSymmetricPart_isSymm A) c
+
+/-- A pointwise symmetric coefficient field gives symmetric zero-drift jet forms at every
+point of the domain. -/
+lemma energyIntegrand_zero_drift_comm_on {Ω : Set X} {a : X → Matrix n n ℝ}
+    (ha : ∀ ⦃x⦄, x ∈ Ω → (a x).IsSymm) {x : X} (hx : x ∈ Ω) (c₀ : ℝ)
+    (U V : ℝ × EuclideanSpace ℝ n) :
+    energyIntegrand (a x) 0 c₀ U V = energyIntegrand (a x) 0 c₀ V U :=
+  energyIntegrand_zero_drift_comm_of_isSymm (ha hx) c₀ U V
+
+end PDE
+
+end TauCeti

--- a/TauCeti/Analysis/PDE/SymmetricEnergy.lean
+++ b/TauCeti/Analysis/PDE/SymmetricEnergy.lean
@@ -61,6 +61,7 @@ lemma energyIntegrand_zero_drift_comm_of_isSymm {A : Matrix n n ℝ} (hA : A.IsS
     _ = energyIntegrand A 0 c V U := energyIntegrand_zero_drift_transpose_apply A c U V
 
 /-- Bundled-map form of symmetry for the zero-drift jet integrand. -/
+@[simp]
 lemma energyIntegrand_zero_drift_flip_eq_of_isSymm {A : Matrix n n ℝ} (hA : A.IsSymm)
     (c : ℝ) :
     (energyIntegrand A 0 c).flip = energyIntegrand A 0 c := by
@@ -105,6 +106,7 @@ lemma energyIntegrand_coefficientSymmetricPart_zero_drift_comm (A : Matrix n n �
   energyIntegrand_zero_drift_comm_of_isSymm (coefficientSymmetricPart_isSymm A) c U V
 
 /-- Bundled-map form of symmetry for the symmetric-part zero-drift jet integrand. -/
+@[simp]
 lemma energyIntegrand_coefficientSymmetricPart_zero_drift_flip_eq (A : Matrix n n ℝ)
     (c : ℝ) :
     (energyIntegrand (coefficientSymmetricPart A) 0 c).flip =

--- a/TauCeti/Analysis/PDE/SymmetricEnergy.lean
+++ b/TauCeti/Analysis/PDE/SymmetricEnergy.lean
@@ -28,8 +28,8 @@ the full zero-drift jet integrand.
   coefficient gives a symmetric zero-drift jet form.
 * `TauCeti.PDE.energyIntegrand_coefficientSymmetricPart_zero_drift_apply`: the symmetric
   part has zero-drift jet form equal to the average of the original form and its transpose.
-* `TauCeti.PDE.energyIntegrand_coefficientSymmetricPart_zero_drift_self`: the diagonal
-  energy density is unchanged by replacing the principal coefficient by its symmetric part.
+* `TauCeti.PDE.energyIntegrand_coefficientSymmetricPart_self`: the diagonal energy density
+  is unchanged by replacing the principal coefficient by its symmetric part.
 * `TauCeti.PDE.energyIntegrand_zero_drift_comm_on`: a pointwise symmetric coefficient field
   gives symmetric zero-drift jet forms at every point of the domain.
 -/
@@ -89,13 +89,13 @@ lemma energyIntegrand_coefficientSymmetricPart_zero_drift_apply (A : Matrix n n 
   simp [driftForm_apply, massForm_apply, mul_comm, mul_left_comm]
   ring
 
-/-- Replacing the principal coefficient by its symmetric part does not change the
-zero-drift diagonal energy density. -/
+/-- Replacing the principal coefficient by its symmetric part does not change the diagonal
+energy density. -/
 @[simp]
-lemma energyIntegrand_coefficientSymmetricPart_zero_drift_self (A : Matrix n n ℝ)
-    (c : ℝ) (U : ℝ × EuclideanSpace ℝ n) :
-    energyIntegrand (coefficientSymmetricPart A) 0 c U U =
-      energyIntegrand A 0 c U U := by
+lemma energyIntegrand_coefficientSymmetricPart_self (A : Matrix n n ℝ)
+    (b : EuclideanSpace ℝ n) (c : ℝ) (U : ℝ × EuclideanSpace ℝ n) :
+    energyIntegrand (coefficientSymmetricPart A) b c U U =
+      energyIntegrand A b c U U := by
   rw [energyIntegrand_self, energyIntegrand_self, toQuadraticForm'_coefficientSymmetricPart]
 
 /-- The symmetric part always gives a symmetric zero-drift jet form. -/


### PR DESCRIPTION
This PR adds pointwise symmetry bookkeeping for zero-drift divergence-form energy integrands: transposing the principal coefficient swaps jet arguments, a symmetric coefficient matrix gives a symmetric bundled jet bilinear form, and replacing a coefficient matrix by its symmetric part gives the averaged zero-drift form without changing the diagonal energy density.

It advances `TauCetiRoadmap/PDE/README.md`, Lane D, item 16 ("Weak formulation. The energy bilinear form ... boundedness; Gårding's inequality") as a clean prerequisite, and supports Lane D, item 19 ("Spectrum of `−Δ` ... compact self-adjoint inverse") by making the finite-dimensional symmetry of the zero-drift energy integrand explicit before the integrated weak form is built. I chose it as the lowest-hanging distinct PDE target after checking open and recently merged PRs: the recently merged symmetric-part PR covers matrix coefficients, while the existing energy-integrand files cover boundedness and coercivity but not symmetry of the full jet form.

No Mathlib infrastructure is vendored. The implementation reuses Tau Ceti's existing `energyIntegrand`, `matrixBilinearForm_transpose_apply`, `coefficientSymmetricPart`, and `coefficientSymmetricPart_isSymm` APIs, together with Mathlib's `Matrix.IsSymm` and `ContinuousLinearMap.flip`.

`lake exe cache get` completed with `No files to download` and `Already decompressed 8586 file(s)`. `lake build` completed with `Build completed successfully (4222 jobs).` `lake exe axioms` completed with `axioms: audited 5087 TauCeti declaration(s); all within the allowlist [propext, Classical.choice, Quot.sound].`

<!--tauceti-target:v1 {"focus":"PDE","id":"energy-integrand-symmetric"}-->

🤖 Prepared with Codex
