### PR TITLE
feat: add relative diffeomorphism fixers

### DIFF
--- a/TauCeti/Algebra/GroupAction/FixingSubgroup.lean
+++ b/TauCeti/Algebra/GroupAction/FixingSubgroup.lean
@@ -1,0 +1,29 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+module
+
+public import Mathlib.GroupTheory.GroupAction.FixingSubgroup
+
+/-!
+# Pointwise fixing subgroups
+
+This file records small generic additions to Mathlib's `fixingSubgroup` API.
+-/
+
+public section
+
+namespace TauCeti
+
+/-- For a faithful action, the subgroup fixing the whole space pointwise is trivial. -/
+@[simp]
+theorem fixingSubgroup_univ {G α : Type*} [Group G] [MulAction G α] [FaithfulSMul G α] :
+    _root_.fixingSubgroup G (Set.univ : Set α) = ⊥ := by
+  ext g
+  rw [_root_.mem_fixingSubgroup_iff, Subgroup.mem_bot]
+  refine ⟨fun hg => ?_, fun hg x _ => by rw [hg, one_smul]⟩
+  exact FaithfulSMul.eq_of_smul_eq_smul fun x =>
+    (hg x (Set.mem_univ x)).trans (one_smul G x).symm
+
+end TauCeti

--- a/TauCeti/Geometry/Diffeomorphism/FixingSubgroup.lean
+++ b/TauCeti/Geometry/Diffeomorphism/FixingSubgroup.lean
@@ -1,0 +1,166 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+module
+
+public import TauCeti.Geometry.Diffeomorphism.Action
+public import TauCeti.Topology.Algebra.HomeomorphAction
+public import Mathlib.GroupTheory.GroupAction.SubMulAction.OfFixingSubgroup
+
+/-!
+# Diffeomorphisms fixing a subset pointwise
+
+The geometric-topology roadmap's relative diffeomorphism groups, such as `Diff(M, ∂M)`, are
+subgroups of the self-diffeomorphism group whose elements fix a specified subset pointwise. Mathlib
+already provides the generic pointwise fixing subgroup `fixingSubgroup` for any group
+action; this file specializes that construction to the tautological action of the diffeomorphism
+group on its manifold.
+
+This is the algebraic substrate for the layer-3 target in
+`TauCetiRoadmap/GeometricTopology/README.md`, "diffeomorphism groups with the C^∞ topology", where
+`Diff(M, ∂M)` is the subgroup fixing the boundary pointwise. The topology and the proof that the
+relative subgroup is closed are deliberately left to the later `C^∞`-topology buildout.
+
+## Main definitions
+
+* `TauCeti.Diffeomorph.fixingSubgroup s`: self-diffeomorphisms fixing every point of `s`.
+* `TauCeti.Diffeomorph.RelativeDiff I M n s`: the corresponding relative diffeomorphism group,
+  as a type abbreviation for that subgroup.
+
+## Main results
+
+* `mem_fixingSubgroup_iff`: membership is the pointwise equation `∀ x ∈ s, f x = x`.
+* `fixingSubgroup_empty` / `fixingSubgroup_univ`: the empty-set fixer is all of `Diff(M)`, and
+  the whole-space fixer is trivial.
+* `fixingSubgroup_antitone`: fixing a larger set gives a smaller subgroup.
+* `fixingSubgroup_le_stabilizer`: pointwise fixers preserve the set setwise.
+* `toHomeomorph_mem_fixingSubgroup`: forgetting smoothness sends a relative diffeomorphism to the
+  corresponding relative homeomorphism.
+-/
+
+public section
+
+namespace TauCeti
+
+open scoped Manifold ContDiff Pointwise
+
+namespace Diffeomorph
+
+variable {𝕜 : Type*} [NontriviallyNormedField 𝕜]
+  {E : Type*} [NormedAddCommGroup E] [NormedSpace 𝕜 E]
+  {H : Type*} [TopologicalSpace H] {I : ModelWithCorners 𝕜 E H}
+  {M : Type*} [TopologicalSpace M] [ChartedSpace H M] {n : ℕ∞ω}
+
+/-- The subgroup of self-diffeomorphisms fixing every point of `s`.
+
+This is Mathlib's generic `fixingSubgroup`, specialized to the tautological action of
+`M ≃ₘ^n⟮I, I⟯ M` on `M`. For a boundary set this is the algebraic part of the relative
+diffeomorphism group `Diff(M, ∂M)`. -/
+abbrev fixingSubgroup (s : Set M) : Subgroup (M ≃ₘ^n⟮I, I⟯ M) :=
+  _root_.fixingSubgroup (M ≃ₘ^n⟮I, I⟯ M) s
+
+/-- The relative diffeomorphism group fixing the subset `s` pointwise. -/
+abbrev RelativeDiff (I : ModelWithCorners 𝕜 E H) (M : Type*) [TopologicalSpace M]
+    [ChartedSpace H M] (n : ℕ∞ω) (s : Set M) : Type _ :=
+  fixingSubgroup (I := I) (n := n) s
+
+/-- Membership in the pointwise fixing subgroup is the pointwise fixedness equation on `s`. -/
+@[simp]
+theorem mem_fixingSubgroup_iff {s : Set M} {f : M ≃ₘ^n⟮I, I⟯ M} :
+    f ∈ fixingSubgroup (I := I) (n := n) s ↔ ∀ x ∈ s, f x = x := by
+  simp [fixingSubgroup, _root_.mem_fixingSubgroup_iff]
+
+/-- A member of `fixingSubgroup s` fixes each point of `s`. -/
+theorem apply_eq_of_mem_fixingSubgroup {s : Set M} {f : M ≃ₘ^n⟮I, I⟯ M}
+    (hf : f ∈ fixingSubgroup (I := I) (n := n) s) {x : M} (hx : x ∈ s) : f x = x :=
+  (mem_fixingSubgroup_iff.mp hf) x hx
+
+/-- To prove that a diffeomorphism lies in the pointwise fixing subgroup, prove it fixes each
+point of the subset. -/
+theorem mem_fixingSubgroup_of_forall {s : Set M} {f : M ≃ₘ^n⟮I, I⟯ M}
+    (hf : ∀ x ∈ s, f x = x) : f ∈ fixingSubgroup (I := I) (n := n) s :=
+  mem_fixingSubgroup_iff.mpr hf
+
+/-- The relative diffeomorphism group fixing the empty set is the full diffeomorphism group. -/
+@[simp]
+theorem fixingSubgroup_empty :
+    fixingSubgroup (I := I) (M := M) (n := n) (∅ : Set M) = ⊤ := by
+  exact _root_.fixingSubgroup_empty (M := M ≃ₘ^n⟮I, I⟯ M) (α := M)
+
+/-- The relative diffeomorphism group fixing all points is trivial. -/
+@[simp]
+theorem fixingSubgroup_univ :
+    fixingSubgroup (I := I) (M := M) (n := n) (Set.univ : Set M) = ⊥ := by
+  ext f
+  simp only [mem_fixingSubgroup_iff, Set.mem_univ, true_imp_iff, Subgroup.mem_bot]
+  exact ⟨fun h => _root_.Diffeomorph.ext h, fun h x => by rw [h]; rfl⟩
+
+/-- Fixing a larger set pointwise gives a smaller subgroup. -/
+theorem fixingSubgroup_antitone {s t : Set M} (hst : s ⊆ t) :
+    fixingSubgroup (I := I) (n := n) t ≤ fixingSubgroup (I := I) (n := n) s := by
+  exact _root_.fixingSubgroup_antitone (M ≃ₘ^n⟮I, I⟯ M) M hst
+
+/-- Pointwise fixing is invariant under replacing the subset by an equal subset. -/
+theorem fixingSubgroup_congr {s t : Set M} (hst : s = t) :
+    fixingSubgroup (I := I) (n := n) s = fixingSubgroup (I := I) (n := n) t := by
+  subst t
+  rfl
+
+/-- Fixing `s ∪ t` pointwise is the same as fixing both `s` and `t` pointwise. -/
+@[simp]
+theorem fixingSubgroup_union (s t : Set M) :
+    fixingSubgroup (I := I) (n := n) (s ∪ t) =
+      fixingSubgroup (I := I) (n := n) s ⊓ fixingSubgroup (I := I) (n := n) t := by
+  exact _root_.fixingSubgroup_union (M := M ≃ₘ^n⟮I, I⟯ M) (α := M)
+
+/-- Pointwise fixers preserve the fixed subset setwise. -/
+theorem fixingSubgroup_le_stabilizer (s : Set M) :
+    fixingSubgroup (I := I) (n := n) s ≤
+      MulAction.stabilizer (M ≃ₘ^n⟮I, I⟯ M) s :=
+  MulAction.fixingSubgroup_le_stabilizer (M ≃ₘ^n⟮I, I⟯ M) s
+
+/-- A relative diffeomorphism fixes every point of the subset defining it. -/
+@[simp]
+theorem RelativeDiff.apply_eq {s : Set M}
+    (f : RelativeDiff (𝕜 := 𝕜) (I := I) M n s) {x : M} (hx : x ∈ s) :
+    (f : M ≃ₘ^n⟮I, I⟯ M) x = x :=
+  apply_eq_of_mem_fixingSubgroup f.property hx
+
+/-- The forgetful homomorphism to homeomorphisms sends a relative diffeomorphism to a homeomorphism
+fixing the same subset pointwise. -/
+theorem toHomeomorph_mem_fixingSubgroup {s : Set M} {f : M ≃ₘ^n⟮I, I⟯ M}
+    (hf : f ∈ fixingSubgroup (I := I) (n := n) s) :
+    f.toHomeomorph ∈ _root_.fixingSubgroup (M ≃ₜ M) s := by
+  rw [_root_.mem_fixingSubgroup_iff]
+  intro x hx
+  exact apply_eq_of_mem_fixingSubgroup hf hx
+
+/-- Forgetting smoothness maps the relative diffeomorphism group into the corresponding relative
+homeomorphism group. -/
+@[expose]
+def toRelativeHomeomorphHom (s : Set M) :
+    fixingSubgroup (I := I) (n := n) s →*
+      _root_.fixingSubgroup (M ≃ₜ M) s where
+  toFun f := ⟨(f : M ≃ₘ^n⟮I, I⟯ M).toHomeomorph, toHomeomorph_mem_fixingSubgroup f.property⟩
+  map_one' := by
+    ext x
+    rfl
+  map_mul' f g := by
+    ext x
+    rfl
+
+@[simp]
+theorem toRelativeHomeomorphHom_apply (s : Set M)
+    (f : fixingSubgroup (I := I) (n := n) s) :
+    (toRelativeHomeomorphHom (M := M) s f : M ≃ₜ M) =
+      (f : M ≃ₘ^n⟮I, I⟯ M).toHomeomorph := rfl
+
+/-- The relative diffeomorphism group inherits pointwise continuity of its action on `M`. -/
+abbrev RelativeDiff.continuousConstSMul (s : Set M) :
+    ContinuousConstSMul (RelativeDiff (𝕜 := 𝕜) (I := I) M n s) M :=
+  inferInstance
+
+end Diffeomorph
+
+end TauCeti

--- a/TauCeti/Geometry/Diffeomorphism/FixingSubgroup.lean
+++ b/TauCeti/Geometry/Diffeomorphism/FixingSubgroup.lean
@@ -133,14 +133,11 @@ theorem toHomeomorph_mem_fixingSubgroup {s : Set M} {f : M ≃ₘ^n⟮I, I⟯ M}
 homeomorphism group. -/
 def toRelativeHomeomorphHom (s : Set M) :
     fixingSubgroup (I := I) (n := n) s →*
-      _root_.fixingSubgroup (M ≃ₜ M) s where
-  toFun f := ⟨(f : M ≃ₘ^n⟮I, I⟯ M).toHomeomorph, toHomeomorph_mem_fixingSubgroup f.property⟩
-  map_one' := by
-    ext x
-    rfl
-  map_mul' f g := by
-    ext x
-    rfl
+      _root_.fixingSubgroup (M ≃ₜ M) s :=
+  (toHomeomorphHom (I := I) (n := n)).restrict (fixingSubgroup (I := I) (n := n) s)
+    |>.codRestrict (_root_.fixingSubgroup (M ≃ₜ M) s) fun f => by
+      rw [MonoidHom.restrict_apply, toHomeomorphHom_apply]
+      exact toHomeomorph_mem_fixingSubgroup f.property
 
 /-- Applying the forgetful homomorphism to a relative diffeomorphism is its underlying
 homeomorphism. -/
@@ -150,7 +147,7 @@ theorem toRelativeHomeomorphHom_apply (s : Set M)
     (toRelativeHomeomorphHom (M := M) s f : M ≃ₜ M) =
       (f : M ≃ₘ^n⟮I, I⟯ M).toHomeomorph := by
   ext x
-  rfl
+  simp [toRelativeHomeomorphHom, toHomeomorphHom_apply]
 
 /-- The relative diffeomorphism group inherits pointwise continuity of its action on `M`. -/
 abbrev RelativeDiff.continuousConstSMul (s : Set M) :

--- a/TauCeti/Geometry/Diffeomorphism/FixingSubgroup.lean
+++ b/TauCeti/Geometry/Diffeomorphism/FixingSubgroup.lean
@@ -6,7 +6,7 @@ module
 
 public import TauCeti.Geometry.Diffeomorphism.Action
 public import TauCeti.Topology.Algebra.HomeomorphAction
-public import Mathlib.GroupTheory.GroupAction.FixingSubgroup
+public import Mathlib.GroupTheory.GroupAction.SubMulAction.OfFixingSubgroup
 
 /-!
 # Diffeomorphisms fixing a subset pointwise
@@ -34,7 +34,6 @@ relative subgroup is closed are deliberately left to the later `C^∞`-topology 
 * `fixingSubgroup_empty` / `fixingSubgroup_univ`: the empty-set fixer is all of `Diff(M)`, and
   the whole-space fixer is trivial.
 * `fixingSubgroup_antitone`: fixing a larger set gives a smaller subgroup.
-* `fixingSubgroup_le_stabilizer`: pointwise fixers preserve the set setwise.
 * `toHomeomorph_mem_fixingSubgroup`: forgetting smoothness sends a relative diffeomorphism to the
   corresponding relative homeomorphism.
 -/
@@ -113,14 +112,6 @@ theorem fixingSubgroup_union (s t : Set M) :
     fixingSubgroup (I := I) (n := n) (s ∪ t) =
       fixingSubgroup (I := I) (n := n) s ⊓ fixingSubgroup (I := I) (n := n) t := by
   exact _root_.fixingSubgroup_union (M := M ≃ₘ^n⟮I, I⟯ M) (α := M)
-
-/-- Pointwise fixers preserve the fixed subset setwise. -/
-theorem fixingSubgroup_le_stabilizer (s : Set M) :
-    fixingSubgroup (I := I) (n := n) s ≤
-      MulAction.stabilizer (M ≃ₘ^n⟮I, I⟯ M) s :=
-  (MulAction.le_stabilizer_iff_smul_le s _).mpr fun f hf x hx => by
-    rcases hx with ⟨y, hy, rfl⟩
-    simpa [apply_eq_of_mem_fixingSubgroup hf hy] using hy
 
 /-- A relative diffeomorphism fixes every point of the subset defining it. -/
 @[simp]

--- a/TauCeti/Geometry/Diffeomorphism/FixingSubgroup.lean
+++ b/TauCeti/Geometry/Diffeomorphism/FixingSubgroup.lean
@@ -6,8 +6,7 @@ module
 
 public import TauCeti.Geometry.Diffeomorphism.Action
 public import TauCeti.Topology.Algebra.HomeomorphAction
-public import Mathlib.GroupTheory.GroupAction.FixingSubgroup
-public import Mathlib.GroupTheory.GroupAction.SubMulAction.OfFixingSubgroup
+public import TauCeti.Algebra.GroupAction.FixingSubgroup
 
 /-!
 # Diffeomorphisms fixing a subset pointwise
@@ -44,17 +43,6 @@ public section
 namespace TauCeti
 
 open scoped Manifold ContDiff Pointwise
-
-/-- For a faithful action, the subgroup fixing the whole space pointwise is trivial. -/
-@[simp]
-private theorem fixingSubgroup_univ_of_faithful {G α : Type*} [Group G] [MulAction G α]
-    [FaithfulSMul G α] :
-    _root_.fixingSubgroup G (Set.univ : Set α) = ⊥ := by
-  ext g
-  rw [_root_.mem_fixingSubgroup_iff, Subgroup.mem_bot]
-  refine ⟨fun hg => ?_, fun hg x _ => by rw [hg, one_smul]⟩
-  exact FaithfulSMul.eq_of_smul_eq_smul fun x =>
-    (hg x (Set.mem_univ x)).trans (one_smul G x).symm
 
 namespace Diffeomorph
 
@@ -103,17 +91,12 @@ theorem fixingSubgroup_empty :
 @[simp]
 theorem fixingSubgroup_univ :
     fixingSubgroup (I := I) (M := M) (n := n) (Set.univ : Set M) = ⊥ := by
-  exact fixingSubgroup_univ_of_faithful (G := M ≃ₘ^n⟮I, I⟯ M) (α := M)
+  exact TauCeti.fixingSubgroup_univ (G := M ≃ₘ^n⟮I, I⟯ M) (α := M)
 
 /-- Fixing a larger set pointwise gives a smaller subgroup. -/
 theorem fixingSubgroup_antitone {s t : Set M} (hst : s ⊆ t) :
     fixingSubgroup (I := I) (n := n) t ≤ fixingSubgroup (I := I) (n := n) s := by
   exact _root_.fixingSubgroup_antitone (M ≃ₘ^n⟮I, I⟯ M) M hst
-
-/-- Pointwise fixing a subset implies setwise stabilizing it. -/
-theorem fixingSubgroup_le_stabilizer (s : Set M) :
-    fixingSubgroup (I := I) (n := n) s ≤ MulAction.stabilizer (M ≃ₘ^n⟮I, I⟯ M) s := by
-  exact MulAction.fixingSubgroup_le_stabilizer (M ≃ₘ^n⟮I, I⟯ M) s
 
 /-- Pointwise fixing is invariant under replacing the subset by an equal subset. -/
 theorem fixingSubgroup_congr {s t : Set M} (hst : s = t) :

--- a/TauCeti/Geometry/Diffeomorphism/FixingSubgroup.lean
+++ b/TauCeti/Geometry/Diffeomorphism/FixingSubgroup.lean
@@ -138,7 +138,6 @@ theorem toHomeomorph_mem_fixingSubgroup {s : Set M} {f : M ≃ₘ^n⟮I, I⟯ M}
 
 /-- Forgetting smoothness maps the relative diffeomorphism group into the corresponding relative
 homeomorphism group. -/
-@[expose]
 def toRelativeHomeomorphHom (s : Set M) :
     fixingSubgroup (I := I) (n := n) s →*
       _root_.fixingSubgroup (M ≃ₜ M) s where
@@ -150,11 +149,15 @@ def toRelativeHomeomorphHom (s : Set M) :
     ext x
     rfl
 
+/-- Applying the forgetful homomorphism to a relative diffeomorphism is its underlying
+homeomorphism. -/
 @[simp]
 theorem toRelativeHomeomorphHom_apply (s : Set M)
     (f : fixingSubgroup (I := I) (n := n) s) :
     (toRelativeHomeomorphHom (M := M) s f : M ≃ₜ M) =
-      (f : M ≃ₘ^n⟮I, I⟯ M).toHomeomorph := rfl
+      (f : M ≃ₘ^n⟮I, I⟯ M).toHomeomorph := by
+  ext x
+  rfl
 
 /-- The relative diffeomorphism group inherits pointwise continuity of its action on `M`. -/
 abbrev RelativeDiff.continuousConstSMul (s : Set M) :

--- a/TauCeti/Geometry/Diffeomorphism/FixingSubgroup.lean
+++ b/TauCeti/Geometry/Diffeomorphism/FixingSubgroup.lean
@@ -4,6 +4,8 @@ Released under Apache 2.0 license as described in the file LICENSE.
 -/
 module
 
+import Mathlib.GroupTheory.GroupAction.SubMulAction.OfFixingSubgroup
+
 public import TauCeti.Geometry.Diffeomorphism.Action
 public import TauCeti.Topology.Algebra.HomeomorphAction
 public import TauCeti.Algebra.GroupAction.FixingSubgroup
@@ -34,6 +36,7 @@ relative subgroup is closed are deliberately left to the later `C^∞`-topology 
 * `fixingSubgroup_empty` / `fixingSubgroup_univ`: the empty-set fixer is all of `Diff(M)`, and
   the whole-space fixer is trivial.
 * `fixingSubgroup_antitone`: fixing a larger set gives a smaller subgroup.
+* `fixingSubgroup_le_stabilizer`: pointwise fixing a subset implies stabilizing it setwise.
 * `toHomeomorph_mem_fixingSubgroup`: forgetting smoothness sends a relative diffeomorphism to the
   corresponding relative homeomorphism.
 -/
@@ -103,6 +106,12 @@ theorem fixingSubgroup_congr {s t : Set M} (hst : s = t) :
     fixingSubgroup (I := I) (n := n) s = fixingSubgroup (I := I) (n := n) t := by
   subst t
   rfl
+
+/-- The pointwise fixer of a subset is contained in its setwise stabilizer. -/
+theorem fixingSubgroup_le_stabilizer (s : Set M) :
+    fixingSubgroup (I := I) (n := n) s ≤
+      MulAction.stabilizer (M ≃ₘ^n⟮I, I⟯ M) s := by
+  exact MulAction.fixingSubgroup_le_stabilizer (M ≃ₘ^n⟮I, I⟯ M) s
 
 /-- Fixing `s ∪ t` pointwise is the same as fixing both `s` and `t` pointwise. -/
 @[simp]

--- a/TauCeti/Geometry/Diffeomorphism/FixingSubgroup.lean
+++ b/TauCeti/Geometry/Diffeomorphism/FixingSubgroup.lean
@@ -27,7 +27,7 @@ relative subgroup is closed are deliberately left to the later `C^∞`-topology 
 ## Main definitions
 
 * `TauCeti.Diffeomorph.fixingSubgroup s`: self-diffeomorphisms fixing every point of `s`.
-* `TauCeti.Diffeomorph.RelativeDiff I M n s`: the corresponding relative diffeomorphism group,
+* `TauCeti.RelativeDiff I M n s`: the corresponding relative diffeomorphism group,
   as a type abbreviation for that subgroup.
 
 ## Main results
@@ -47,12 +47,17 @@ namespace TauCeti
 
 open scoped Manifold ContDiff Pointwise
 
-namespace Diffeomorph
-
 variable {𝕜 : Type*} [NontriviallyNormedField 𝕜]
   {E : Type*} [NormedAddCommGroup E] [NormedSpace 𝕜 E]
   {H : Type*} [TopologicalSpace H] {I : ModelWithCorners 𝕜 E H}
   {M : Type*} [TopologicalSpace M] [ChartedSpace H M] {n : ℕ∞ω}
+
+/-- The relative diffeomorphism group fixing the subset `s` pointwise. -/
+abbrev RelativeDiff (I : ModelWithCorners 𝕜 E H) (M : Type*) [TopologicalSpace M]
+    [ChartedSpace H M] (n : ℕ∞ω) (s : Set M) : Type _ :=
+  _root_.fixingSubgroup (M ≃ₘ^n⟮I, I⟯ M) s
+
+namespace Diffeomorph
 
 /-- The subgroup of self-diffeomorphisms fixing every point of `s`.
 
@@ -61,11 +66,6 @@ This is Mathlib's generic `fixingSubgroup`, specialized to the tautological acti
 diffeomorphism group `Diff(M, ∂M)`. -/
 abbrev fixingSubgroup (s : Set M) : Subgroup (M ≃ₘ^n⟮I, I⟯ M) :=
   _root_.fixingSubgroup (M ≃ₘ^n⟮I, I⟯ M) s
-
-/-- The relative diffeomorphism group fixing the subset `s` pointwise. -/
-abbrev RelativeDiff (I : ModelWithCorners 𝕜 E H) (M : Type*) [TopologicalSpace M]
-    [ChartedSpace H M] (n : ℕ∞ω) (s : Set M) : Type _ :=
-  fixingSubgroup (I := I) (n := n) s
 
 /-- Membership in the pointwise fixing subgroup is the pointwise fixedness equation on `s`. -/
 @[simp]
@@ -120,13 +120,6 @@ theorem fixingSubgroup_union (s t : Set M) :
       fixingSubgroup (I := I) (n := n) s ⊓ fixingSubgroup (I := I) (n := n) t := by
   exact _root_.fixingSubgroup_union (M := M ≃ₘ^n⟮I, I⟯ M) (α := M)
 
-/-- A relative diffeomorphism fixes every point of the subset defining it. -/
-@[simp]
-theorem RelativeDiff.apply_eq {s : Set M}
-    (f : RelativeDiff (𝕜 := 𝕜) (I := I) M n s) {x : M} (hx : x ∈ s) :
-    (f : M ≃ₘ^n⟮I, I⟯ M) x = x :=
-  apply_eq_of_mem_fixingSubgroup f.property hx
-
 /-- The forgetful homomorphism to homeomorphisms sends a relative diffeomorphism to a homeomorphism
 fixing the same subset pointwise. -/
 theorem toHomeomorph_mem_fixingSubgroup {s : Set M} {f : M ≃ₘ^n⟮I, I⟯ M}
@@ -156,11 +149,18 @@ theorem toRelativeHomeomorphHom_apply (s : Set M)
   ext x
   simp [toRelativeHomeomorphHom, toHomeomorphHom_apply]
 
+end Diffeomorph
+
+/-- A relative diffeomorphism fixes every point of the subset defining it. -/
+@[simp]
+theorem RelativeDiff.apply_eq {s : Set M}
+    (f : RelativeDiff (𝕜 := 𝕜) (I := I) M n s) {x : M} (hx : x ∈ s) :
+    (f : M ≃ₘ^n⟮I, I⟯ M) x = x :=
+  Diffeomorph.apply_eq_of_mem_fixingSubgroup f.property hx
+
 /-- The relative diffeomorphism group inherits pointwise continuity of its action on `M`. -/
 abbrev RelativeDiff.continuousConstSMul (s : Set M) :
     ContinuousConstSMul (RelativeDiff (𝕜 := 𝕜) (I := I) M n s) M :=
   inferInstance
-
-end Diffeomorph
 
 end TauCeti

--- a/TauCeti/Geometry/Diffeomorphism/FixingSubgroup.lean
+++ b/TauCeti/Geometry/Diffeomorphism/FixingSubgroup.lean
@@ -6,7 +6,7 @@ module
 
 public import TauCeti.Geometry.Diffeomorphism.Action
 public import TauCeti.Topology.Algebra.HomeomorphAction
-public import Mathlib.GroupTheory.GroupAction.SubMulAction.OfFixingSubgroup
+public import Mathlib.GroupTheory.GroupAction.FixingSubgroup
 
 /-!
 # Diffeomorphisms fixing a subset pointwise
@@ -43,6 +43,16 @@ public section
 namespace TauCeti
 
 open scoped Manifold ContDiff Pointwise
+
+/-- For a faithful action, the subgroup fixing the whole space pointwise is trivial. -/
+@[simp]
+theorem fixingSubgroup_univ {G α : Type*} [Group G] [MulAction G α] [FaithfulSMul G α] :
+    _root_.fixingSubgroup G (Set.univ : Set α) = ⊥ := by
+  ext g
+  rw [_root_.mem_fixingSubgroup_iff, Subgroup.mem_bot]
+  refine ⟨fun hg => ?_, fun hg x _ => by rw [hg, one_smul]⟩
+  exact FaithfulSMul.eq_of_smul_eq_smul fun x =>
+    (hg x (Set.mem_univ x)).trans (one_smul G x).symm
 
 namespace Diffeomorph
 
@@ -91,14 +101,26 @@ theorem fixingSubgroup_empty :
 @[simp]
 theorem fixingSubgroup_univ :
     fixingSubgroup (I := I) (M := M) (n := n) (Set.univ : Set M) = ⊥ := by
-  ext f
-  simp only [mem_fixingSubgroup_iff, Set.mem_univ, true_imp_iff, Subgroup.mem_bot]
-  exact ⟨fun h => _root_.Diffeomorph.ext h, fun h x => by rw [h]; rfl⟩
+  exact TauCeti.fixingSubgroup_univ (G := M ≃ₘ^n⟮I, I⟯ M) (α := M)
 
 /-- Fixing a larger set pointwise gives a smaller subgroup. -/
 theorem fixingSubgroup_antitone {s t : Set M} (hst : s ⊆ t) :
     fixingSubgroup (I := I) (n := n) t ≤ fixingSubgroup (I := I) (n := n) s := by
   exact _root_.fixingSubgroup_antitone (M ≃ₘ^n⟮I, I⟯ M) M hst
+
+/-- Pointwise fixing a subset implies setwise stabilizing it. -/
+theorem fixingSubgroup_le_stabilizer (s : Set M) :
+    fixingSubgroup (I := I) (n := n) s ≤ MulAction.stabilizer (M ≃ₘ^n⟮I, I⟯ M) s := by
+  intro f hf
+  rw [MulAction.mem_stabilizer_iff]
+  ext x
+  constructor
+  · rintro ⟨y, hy, hxy⟩
+    have hxy' : f y = x := by simpa [Diffeomorph.smul_def] using hxy
+    rw [apply_eq_of_mem_fixingSubgroup hf hy] at hxy'
+    simpa [← hxy'] using hy
+  · intro hx
+    exact ⟨x, hx, by simpa [Diffeomorph.smul_def] using apply_eq_of_mem_fixingSubgroup hf hx⟩
 
 /-- Pointwise fixing is invariant under replacing the subset by an equal subset. -/
 theorem fixingSubgroup_congr {s t : Set M} (hst : s = t) :

--- a/TauCeti/Geometry/Diffeomorphism/FixingSubgroup.lean
+++ b/TauCeti/Geometry/Diffeomorphism/FixingSubgroup.lean
@@ -7,6 +7,7 @@ module
 public import TauCeti.Geometry.Diffeomorphism.Action
 public import TauCeti.Topology.Algebra.HomeomorphAction
 public import Mathlib.GroupTheory.GroupAction.FixingSubgroup
+public import Mathlib.GroupTheory.GroupAction.SubMulAction.OfFixingSubgroup
 
 /-!
 # Diffeomorphisms fixing a subset pointwise
@@ -46,7 +47,8 @@ open scoped Manifold ContDiff Pointwise
 
 /-- For a faithful action, the subgroup fixing the whole space pointwise is trivial. -/
 @[simp]
-theorem fixingSubgroup_univ {G α : Type*} [Group G] [MulAction G α] [FaithfulSMul G α] :
+private theorem fixingSubgroup_univ_of_faithful {G α : Type*} [Group G] [MulAction G α]
+    [FaithfulSMul G α] :
     _root_.fixingSubgroup G (Set.univ : Set α) = ⊥ := by
   ext g
   rw [_root_.mem_fixingSubgroup_iff, Subgroup.mem_bot]
@@ -101,7 +103,7 @@ theorem fixingSubgroup_empty :
 @[simp]
 theorem fixingSubgroup_univ :
     fixingSubgroup (I := I) (M := M) (n := n) (Set.univ : Set M) = ⊥ := by
-  exact TauCeti.fixingSubgroup_univ (G := M ≃ₘ^n⟮I, I⟯ M) (α := M)
+  exact fixingSubgroup_univ_of_faithful (G := M ≃ₘ^n⟮I, I⟯ M) (α := M)
 
 /-- Fixing a larger set pointwise gives a smaller subgroup. -/
 theorem fixingSubgroup_antitone {s t : Set M} (hst : s ⊆ t) :
@@ -111,16 +113,7 @@ theorem fixingSubgroup_antitone {s t : Set M} (hst : s ⊆ t) :
 /-- Pointwise fixing a subset implies setwise stabilizing it. -/
 theorem fixingSubgroup_le_stabilizer (s : Set M) :
     fixingSubgroup (I := I) (n := n) s ≤ MulAction.stabilizer (M ≃ₘ^n⟮I, I⟯ M) s := by
-  intro f hf
-  rw [MulAction.mem_stabilizer_iff]
-  ext x
-  constructor
-  · rintro ⟨y, hy, hxy⟩
-    have hxy' : f y = x := by simpa [Diffeomorph.smul_def] using hxy
-    rw [apply_eq_of_mem_fixingSubgroup hf hy] at hxy'
-    simpa [← hxy'] using hy
-  · intro hx
-    exact ⟨x, hx, by simpa [Diffeomorph.smul_def] using apply_eq_of_mem_fixingSubgroup hf hx⟩
+  exact MulAction.fixingSubgroup_le_stabilizer (M ≃ₘ^n⟮I, I⟯ M) s
 
 /-- Pointwise fixing is invariant under replacing the subset by an equal subset. -/
 theorem fixingSubgroup_congr {s t : Set M} (hst : s = t) :

--- a/TauCeti/Geometry/Diffeomorphism/FixingSubgroup.lean
+++ b/TauCeti/Geometry/Diffeomorphism/FixingSubgroup.lean
@@ -6,7 +6,7 @@ module
 
 public import TauCeti.Geometry.Diffeomorphism.Action
 public import TauCeti.Topology.Algebra.HomeomorphAction
-public import Mathlib.GroupTheory.GroupAction.SubMulAction.OfFixingSubgroup
+public import Mathlib.GroupTheory.GroupAction.FixingSubgroup
 
 /-!
 # Diffeomorphisms fixing a subset pointwise
@@ -118,7 +118,9 @@ theorem fixingSubgroup_union (s t : Set M) :
 theorem fixingSubgroup_le_stabilizer (s : Set M) :
     fixingSubgroup (I := I) (n := n) s ≤
       MulAction.stabilizer (M ≃ₘ^n⟮I, I⟯ M) s :=
-  MulAction.fixingSubgroup_le_stabilizer (M ≃ₘ^n⟮I, I⟯ M) s
+  (MulAction.le_stabilizer_iff_smul_le s _).mpr fun f hf x hx => by
+    rcases hx with ⟨y, hy, rfl⟩
+    simpa [apply_eq_of_mem_fixingSubgroup hf hy] using hy
 
 /-- A relative diffeomorphism fixes every point of the subset defining it. -/
 @[simp]


### PR DESCRIPTION
This PR adds the relative diffeomorphism subgroup fixing a chosen subset pointwise, by specializing Mathlib's generic `fixingSubgroup` to Tau Ceti's tautological action of `M ≃ₘ^n⟮I, I⟯ M` on `M`. It exposes the relative group abbreviation `Diffeomorph.RelativeDiff`, the membership and pointwise-application API, empty/universal/union and antitonicity lemmas, the inclusion into the setwise stabilizer, and the forgetful homomorphism to the corresponding relative homeomorphism group.

It advances `TauCetiRoadmap/GeometricTopology/README.md`, Layer 3, "diffeomorphism groups with the C^∞ topology", specifically the relative setup where `Diff(M, ∂M)` is the subgroup fixing `∂M` pointwise. I chose it as the lowest-hanging distinct GeometricTopology prerequisite after checking open and recently merged PRs: the full diffeomorphism group and its tautological action already exist, and the open GeometricTopology PR covers smooth-embedding ambient isotopy, while the algebraic pointwise-fixer wrapper for future relative diffeomorphism groups was still missing.

No Mathlib infrastructure is vendored. The implementation reuses Mathlib's `fixingSubgroup`, `mem_fixingSubgroup_iff`, `fixingSubgroup_empty`, `fixingSubgroup_antitone`, `fixingSubgroup_union`, and `MulAction.fixingSubgroup_le_stabilizer`, together with Tau Ceti's existing `Diffeomorph.applyMulAction`, `Homeomorph.applyMulAction`, and forgetful `Diffeomorph.toHomeomorph` API.

`lake exe cache get` completed with `No files to download` and `Already decompressed 8586 file(s)`. `lake build` completed with `Build completed successfully (4235 jobs).` `lake exe axioms` completed with `axioms: audited 5118 TauCeti declaration(s); all within the allowlist [propext, Classical.choice, Quot.sound].`

<!--tauceti-target:v1 {"focus":"GeometricTopology","id":"diffeomorphism-pointwise-stabilizer"}-->

🤖 Prepared with Codex
