### PR TITLE
feat: add lattice cube face weights

### DIFF
--- a/TauCeti/LowDimTopology/Plumbing/CubeFace.lean
+++ b/TauCeti/LowDimTopology/Plumbing/CubeFace.lean
@@ -80,15 +80,15 @@ theorem characteristicUpperFaceWeight_le {x : V → ℤ} {S : Finset V} {v : V} 
 
 /-- The nonnegative `U`-exponent contributed by the lower face in a cube direction. -/
 noncomputable def characteristicLowerFaceExponent
-    (x : V → ℤ) (S : Finset V) {v : V} (_hv : v ∈ S) : ℕ :=
+    (x : V → ℤ) (S : Finset V) (v : V) : ℕ :=
   Int.toNat (P.characteristicCubeWeight k x S -
     P.characteristicCubeWeight k x (S.erase v))
 
 /-- The lower-face exponent, cast back to `ℤ`, is the difference between the ambient cube weight
 and the lower face weight. -/
 theorem characteristicLowerFaceExponent_natCast
-    {x : V → ℤ} {S : Finset V} {v : V} (hv : v ∈ S) :
-    (P.characteristicLowerFaceExponent k x S hv : ℤ) =
+    {x : V → ℤ} {S : Finset V} (v : V) :
+    (P.characteristicLowerFaceExponent k x S v : ℤ) =
       P.characteristicCubeWeight k x S - P.characteristicCubeWeight k x (S.erase v) := by
   rw [characteristicLowerFaceExponent]
   exact Int.toNat_of_nonneg
@@ -97,13 +97,13 @@ theorem characteristicLowerFaceExponent_natCast
 /-- The lower-face exponent is zero exactly when the lower face has the same weight as the
 ambient cube. -/
 theorem characteristicLowerFaceExponent_eq_zero_iff
-    {x : V → ℤ} {S : Finset V} {v : V} (hv : v ∈ S) :
-    P.characteristicLowerFaceExponent k x S hv = 0 ↔
+    {x : V → ℤ} {S : Finset V} (v : V) :
+    P.characteristicLowerFaceExponent k x S v = 0 ↔
       P.characteristicCubeWeight k x S = P.characteristicCubeWeight k x (S.erase v) := by
   constructor
   · intro h
     have hcast := congrArg (fun n : ℕ => (n : ℤ)) h
-    rw [characteristicLowerFaceExponent_natCast (P := P) (k := k) hv] at hcast
+    rw [characteristicLowerFaceExponent_natCast (P := P) (k := k) v] at hcast
     omega
   · intro h
     rw [characteristicLowerFaceExponent, h, sub_self, Int.toNat_zero]

--- a/TauCeti/LowDimTopology/Plumbing/CubeFace.lean
+++ b/TauCeti/LowDimTopology/Plumbing/CubeFace.lean
@@ -115,7 +115,7 @@ theorem characteristicLowerFaceExponent_eq_zero_iff
 
 /-- The nonnegative `U`-exponent contributed by the upper face in a direction. -/
 noncomputable def characteristicUpperFaceExponent
-    (x : V → ℤ) (S : Finset V) (v : V) : ℕ :=
+    (x : V → ℤ) (S : Finset V) {v : V} (_hv : v ∈ S) : ℕ :=
   Int.toNat (P.characteristicCubeWeight k x S -
     P.characteristicCubeWeight k (x + Pi.single v (1 : ℤ)) (S.erase v))
 
@@ -123,7 +123,7 @@ noncomputable def characteristicUpperFaceExponent
 and the upper face weight. -/
 theorem characteristicUpperFaceExponent_intCast
     {x : V → ℤ} {S : Finset V} {v : V} (hv : v ∈ S) :
-    (P.characteristicUpperFaceExponent k x S v : ℤ) =
+    (P.characteristicUpperFaceExponent k x S hv : ℤ) =
       P.characteristicCubeWeight k x S -
         P.characteristicCubeWeight k (x + Pi.single v (1 : ℤ)) (S.erase v) := by
   rw [characteristicUpperFaceExponent]
@@ -133,7 +133,7 @@ theorem characteristicUpperFaceExponent_intCast
 ambient cube. -/
 theorem characteristicUpperFaceExponent_eq_zero_iff
     {x : V → ℤ} {S : Finset V} {v : V} (hv : v ∈ S) :
-    P.characteristicUpperFaceExponent k x S v = 0 ↔
+    P.characteristicUpperFaceExponent k x S hv = 0 ↔
       P.characteristicCubeWeight k x S =
         P.characteristicCubeWeight k (x + Pi.single v (1 : ℤ)) (S.erase v) := by
   constructor

--- a/TauCeti/LowDimTopology/Plumbing/CubeFace.lean
+++ b/TauCeti/LowDimTopology/Plumbing/CubeFace.lean
@@ -1,0 +1,165 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+module
+
+public import TauCeti.LowDimTopology.Plumbing.CubeWeight
+
+/-!
+# Face weights for plumbing-lattice cubes
+
+This file adds the codimension-one face bookkeeping needed for the cubical boundary in
+Némethi's lattice homology. A cube with base point `x` and directions `S` has two faces in a
+direction `v`: the lower face with the same base point and directions `S.erase v`, and the
+upper face with base point `x + E_v` and directions `S.erase v`.
+
+The cube weight is the maximum of the point weights over all vertices, so each face weight is
+bounded above by the ambient cube weight. The resulting nonnegative differences are the
+exponents of the `U`-powers in the later lattice-homology differential.
+
+## Main results
+
+* `TauCeti.PlumbingGraph.cubeVertices_lowerFace_subset`: the lower face's vertices are
+  vertices of the ambient cube.
+* `TauCeti.PlumbingGraph.cubeVertices_upperFace_subset`: the upper face's vertices are
+  vertices of the ambient cube, when `v ∈ S`.
+* `TauCeti.PlumbingGraph.characteristicLowerFaceWeight_le` and
+  `TauCeti.PlumbingGraph.characteristicUpperFaceWeight_le`: face weights are bounded by the
+  ambient cube weight.
+* `TauCeti.PlumbingGraph.characteristicLowerFaceExponent` and
+  `TauCeti.PlumbingGraph.characteristicUpperFaceExponent`: the corresponding natural-number
+  weight differences.
+
+## References
+
+This supplies a prerequisite for `TauCetiRoadmap/CombinatorialHeegaardFloer/README.md`, Lane L
+("lattice homology"), whose opening item asks for Némethi's lattice (co)homology from lattice
+points and weight functions. The face-weight exponents are the standard cubical-boundary
+weights in Némethi, [arXiv:0709.0841](https://arxiv.org/abs/0709.0841).
+-/
+
+public section
+
+namespace TauCeti
+
+namespace PlumbingGraph
+
+variable {V : Type*} [DecidableEq V]
+
+/-- Translating the base point by `E_v` and then taking the vertex indexed by `T` is the same
+as taking the ambient vertex indexed by `insert v T`, provided `v` was not already a direction
+of `T`. -/
+theorem cubeVertex_add_single_eq_insert {T : Finset V} {v : V} (hv : v ∉ T) (x : V → ℤ) :
+    cubeVertex (x + Pi.single v (1 : ℤ)) T = cubeVertex x (insert v T) := by
+  ext w
+  by_cases hw : w = v
+  · subst hw
+    simp [cubeVertex_apply, hv]
+  · simp [cubeVertex_apply, hw]
+
+variable [DecidableEq (V → ℤ)]
+
+/-- The lower face in a direction has its vertices among the vertices of the ambient cube. -/
+theorem cubeVertices_lowerFace_subset (x : V → ℤ) (S : Finset V) (v : V) :
+    cubeVertices x (S.erase v) ⊆ cubeVertices x S :=
+  cubeVertices_subset (Finset.erase_subset v S) x
+
+/-- The upper face in a direction has its vertices among the vertices of the ambient cube. -/
+theorem cubeVertices_upperFace_subset {x : V → ℤ} {S : Finset V} {v : V} (hv : v ∈ S) :
+    cubeVertices (x + Pi.single v (1 : ℤ)) (S.erase v) ⊆ cubeVertices x S := by
+  intro y hy
+  rw [mem_cubeVertices] at hy ⊢
+  obtain ⟨T, hTS, hTy⟩ := hy
+  refine ⟨insert v T, ?_, ?_⟩
+  · exact Finset.insert_subset hv (hTS.trans (Finset.erase_subset v S))
+  · rw [← hTy]
+    have hvT : v ∉ T := fun h => Finset.notMem_erase v S (hTS h)
+    exact (cubeVertex_add_single_eq_insert hvT x).symm
+
+variable [Fintype V] (P : PlumbingGraph V) (k : P.characteristicVectors)
+
+/-- The lower face's characteristic cube weight is bounded by the ambient cube weight. -/
+theorem characteristicLowerFaceWeight_le (x : V → ℤ) (S : Finset V) (v : V) :
+    P.characteristicCubeWeight k x (S.erase v) ≤ P.characteristicCubeWeight k x S :=
+  P.characteristicCubeWeight_mono k (Finset.erase_subset v S) x
+
+/-- The upper face's characteristic cube weight is bounded by the ambient cube weight. -/
+theorem characteristicUpperFaceWeight_le {x : V → ℤ} {S : Finset V} {v : V} (hv : v ∈ S) :
+    P.characteristicCubeWeight k (x + Pi.single v (1 : ℤ)) (S.erase v) ≤
+      P.characteristicCubeWeight k x S := by
+  apply P.characteristicCubeWeight_le k
+  intro y hy
+  exact P.characteristicWeight_le_characteristicCubeWeight k
+    (cubeVertices_upperFace_subset hv hy)
+
+/-- The nonnegative `U`-exponent contributed by the lower face of a cube. -/
+noncomputable def characteristicLowerFaceExponent
+    (x : V → ℤ) (S : Finset V) (v : V) : ℕ :=
+  Int.toNat (P.characteristicCubeWeight k x S -
+    P.characteristicCubeWeight k x (S.erase v))
+
+/-- The lower-face exponent, cast back to `ℤ`, is the difference between the ambient cube weight
+and the lower face weight. -/
+theorem characteristicLowerFaceExponent_intCast (x : V → ℤ) (S : Finset V) (v : V) :
+    (P.characteristicLowerFaceExponent k x S v : ℤ) =
+      P.characteristicCubeWeight k x S - P.characteristicCubeWeight k x (S.erase v) := by
+  rw [characteristicLowerFaceExponent]
+  exact Int.toNat_of_nonneg (sub_nonneg.mpr (P.characteristicLowerFaceWeight_le k x S v))
+
+/-- The lower-face exponent is zero exactly when the lower face has the same weight as the
+ambient cube. -/
+theorem characteristicLowerFaceExponent_eq_zero_iff (x : V → ℤ) (S : Finset V) (v : V) :
+    P.characteristicLowerFaceExponent k x S v = 0 ↔
+      P.characteristicCubeWeight k x S = P.characteristicCubeWeight k x (S.erase v) := by
+  constructor
+  · intro h
+    have hcast := congrArg (fun n : ℕ => (n : ℤ)) h
+    rw [characteristicLowerFaceExponent_intCast] at hcast
+    omega
+  · intro h
+    rw [characteristicLowerFaceExponent, h, sub_self, Int.toNat_zero]
+
+/-- The nonnegative `U`-exponent contributed by the upper face of a cube in a direction `v`.
+When `v ∉ S`, this still returns the formal difference for the erased-direction expression; the
+cast-back theorem below records the intended boundary-face case `v ∈ S`. -/
+noncomputable def characteristicUpperFaceExponent
+    (x : V → ℤ) (S : Finset V) (v : V) : ℕ :=
+  Int.toNat (P.characteristicCubeWeight k x S -
+    P.characteristicCubeWeight k (x + Pi.single v (1 : ℤ)) (S.erase v))
+
+/-- The upper-face exponent, cast back to `ℤ`, is the difference between the ambient cube weight
+and the upper face weight. -/
+theorem characteristicUpperFaceExponent_intCast
+    {x : V → ℤ} {S : Finset V} {v : V} (hv : v ∈ S) :
+    (P.characteristicUpperFaceExponent k x S v : ℤ) =
+      P.characteristicCubeWeight k x S -
+        P.characteristicCubeWeight k (x + Pi.single v (1 : ℤ)) (S.erase v) := by
+  rw [characteristicUpperFaceExponent]
+  exact Int.toNat_of_nonneg (sub_nonneg.mpr (P.characteristicUpperFaceWeight_le k hv))
+
+/-- The upper-face exponent is zero exactly when the upper face has the same weight as the
+ambient cube. -/
+theorem characteristicUpperFaceExponent_eq_zero_iff
+    {x : V → ℤ} {S : Finset V} {v : V} (hv : v ∈ S) :
+    P.characteristicUpperFaceExponent k x S v = 0 ↔
+      P.characteristicCubeWeight k x S =
+        P.characteristicCubeWeight k (x + Pi.single v (1 : ℤ)) (S.erase v) := by
+  constructor
+  · intro h
+    have hcast := congrArg (fun n : ℕ => (n : ℤ)) h
+    rw [characteristicUpperFaceExponent_intCast (P := P) (k := k) hv] at hcast
+    omega
+  · intro h
+    rw [characteristicUpperFaceExponent, h, sub_self, Int.toNat_zero]
+
+/-- For a zero-dimensional cube, the lower-face exponent is zero. -/
+@[simp]
+theorem characteristicLowerFaceExponent_empty (x : V → ℤ) (v : V) :
+    P.characteristicLowerFaceExponent k x ∅ v = 0 := by
+  rw [characteristicLowerFaceExponent_eq_zero_iff]
+  simp
+
+end PlumbingGraph
+
+end TauCeti

--- a/TauCeti/LowDimTopology/Plumbing/CubeFace.lean
+++ b/TauCeti/LowDimTopology/Plumbing/CubeFace.lean
@@ -20,13 +20,10 @@ exponents of the `U`-powers in the later lattice-homology differential.
 
 ## Main results
 
-* `TauCeti.PlumbingGraph.cubeVertices_lowerFace_subset`: the lower face's vertices are
-  vertices of the ambient cube.
 * `TauCeti.PlumbingGraph.cubeVertices_upperFace_subset`: the upper face's vertices are
   vertices of the ambient cube, when `v ∈ S`.
-* `TauCeti.PlumbingGraph.characteristicLowerFaceWeight_le` and
-  `TauCeti.PlumbingGraph.characteristicUpperFaceWeight_le`: face weights are bounded by the
-  ambient cube weight.
+* `TauCeti.PlumbingGraph.characteristicUpperFaceWeight_le`: upper face weights are bounded by
+  the ambient cube weight.
 * `TauCeti.PlumbingGraph.characteristicLowerFaceExponent` and
   `TauCeti.PlumbingGraph.characteristicUpperFaceExponent`: the corresponding natural-number
   weight differences for directions in the cube.
@@ -60,11 +57,6 @@ theorem cubeVertex_add_single_eq_insert {T : Finset V} {v : V} (hv : v ∉ T) (x
 
 variable [DecidableEq (V → ℤ)]
 
-/-- The lower face in a direction has its vertices among the vertices of the ambient cube. -/
-theorem cubeVertices_lowerFace_subset (x : V → ℤ) (S : Finset V) (v : V) :
-    cubeVertices x (S.erase v) ⊆ cubeVertices x S :=
-  cubeVertices_subset (Finset.erase_subset v S) x
-
 /-- The upper face in a direction has its vertices among the vertices of the ambient cube. -/
 theorem cubeVertices_upperFace_subset {x : V → ℤ} {S : Finset V} {v : V} (hv : v ∈ S) :
     cubeVertices (x + Pi.single v (1 : ℤ)) (S.erase v) ⊆ cubeVertices x S := by
@@ -78,11 +70,6 @@ theorem cubeVertices_upperFace_subset {x : V → ℤ} {S : Finset V} {v : V} (hv
     exact (cubeVertex_add_single_eq_insert hvT x).symm
 
 variable [Fintype V] (P : PlumbingGraph V) (k : P.characteristicVectors)
-
-/-- The lower face's characteristic cube weight is bounded by the ambient cube weight. -/
-theorem characteristicLowerFaceWeight_le (x : V → ℤ) (S : Finset V) (v : V) :
-    P.characteristicCubeWeight k x (S.erase v) ≤ P.characteristicCubeWeight k x S :=
-  P.characteristicCubeWeight_mono k (Finset.erase_subset v S) x
 
 /-- The upper face's characteristic cube weight is bounded by the ambient cube weight. -/
 theorem characteristicUpperFaceWeight_le {x : V → ℤ} {S : Finset V} {v : V} (hv : v ∈ S) :
@@ -107,7 +94,8 @@ theorem characteristicLowerFaceExponent_intCast
     (P.characteristicLowerFaceExponent k x S v hv : ℤ) =
       P.characteristicCubeWeight k x S - P.characteristicCubeWeight k x (S.erase v) := by
   rw [characteristicLowerFaceExponent]
-  exact Int.toNat_of_nonneg (sub_nonneg.mpr (P.characteristicLowerFaceWeight_le k x S v))
+  exact Int.toNat_of_nonneg
+    (sub_nonneg.mpr (P.characteristicCubeWeight_mono k (Finset.erase_subset v S) x))
 
 /-- The lower-face exponent is zero exactly when the lower face has the same weight as the
 ambient cube. -/

--- a/TauCeti/LowDimTopology/Plumbing/CubeFace.lean
+++ b/TauCeti/LowDimTopology/Plumbing/CubeFace.lean
@@ -78,17 +78,18 @@ theorem characteristicUpperFaceWeight_le {x : V → ℤ} {S : Finset V} {v : V} 
   exact P.characteristicWeight_le_characteristicCubeWeight k
     (cubeVertices_upperFace_subset hv hy)
 
-/-- The nonnegative `U`-exponent contributed by the lower face in a cube direction. -/
+/-- The nonnegative `U`-exponent contributed by the lower face in a direction. -/
 noncomputable def characteristicLowerFaceExponent
-    (x : V → ℤ) (S : Finset V) {v : V} (_hv : v ∈ S) : ℕ :=
+    (x : V → ℤ) (S : Finset V) (v : V) : ℕ :=
   Int.toNat (P.characteristicCubeWeight k x S -
     P.characteristicCubeWeight k x (S.erase v))
 
 /-- The lower-face exponent, cast back to `ℤ`, is the difference between the ambient cube weight
 and the lower face weight. -/
+@[simp]
 theorem characteristicLowerFaceExponent_natCast
-    {x : V → ℤ} {S : Finset V} {v : V} (hv : v ∈ S) :
-    (P.characteristicLowerFaceExponent k x S hv : ℤ) =
+    {x : V → ℤ} {S : Finset V} {v : V} :
+    (P.characteristicLowerFaceExponent k x S v : ℤ) =
       P.characteristicCubeWeight k x S - P.characteristicCubeWeight k x (S.erase v) := by
   rw [characteristicLowerFaceExponent]
   exact Int.toNat_of_nonneg
@@ -97,13 +98,13 @@ theorem characteristicLowerFaceExponent_natCast
 /-- The lower-face exponent is zero exactly when the lower face has the same weight as the
 ambient cube. -/
 theorem characteristicLowerFaceExponent_eq_zero_iff
-    {x : V → ℤ} {S : Finset V} {v : V} (hv : v ∈ S) :
-    P.characteristicLowerFaceExponent k x S hv = 0 ↔
+    {x : V → ℤ} {S : Finset V} {v : V} :
+    P.characteristicLowerFaceExponent k x S v = 0 ↔
       P.characteristicCubeWeight k x S = P.characteristicCubeWeight k x (S.erase v) := by
   constructor
   · intro h
     have hcast := congrArg (fun n : ℕ => (n : ℤ)) h
-    rw [characteristicLowerFaceExponent_natCast (P := P) (k := k) hv] at hcast
+    rw [characteristicLowerFaceExponent_natCast (P := P) (k := k)] at hcast
     omega
   · intro h
     rw [characteristicLowerFaceExponent, h, sub_self, Int.toNat_zero]
@@ -116,6 +117,7 @@ noncomputable def characteristicUpperFaceExponent
 
 /-- The upper-face exponent, cast back to `ℤ`, is the difference between the ambient cube weight
 and the upper face weight. -/
+@[simp]
 theorem characteristicUpperFaceExponent_natCast
     {x : V → ℤ} {S : Finset V} {v : V} (hv : v ∈ S) :
     (P.characteristicUpperFaceExponent k x S hv : ℤ) =

--- a/TauCeti/LowDimTopology/Plumbing/CubeFace.lean
+++ b/TauCeti/LowDimTopology/Plumbing/CubeFace.lean
@@ -22,8 +22,9 @@ exponents of the `U`-powers in the later lattice-homology differential.
 
 * `TauCeti.PlumbingGraph.cubeVertices_upperFace_subset`: the upper face's vertices are
   vertices of the ambient cube, when `v ∈ S`.
-* `TauCeti.PlumbingGraph.characteristicUpperFaceWeight_le`: upper face weights are bounded by
-  the ambient cube weight.
+* `TauCeti.PlumbingGraph.characteristicLowerFaceWeight_le` and
+  `TauCeti.PlumbingGraph.characteristicUpperFaceWeight_le`: face weights are bounded by the
+  ambient cube weight.
 * `TauCeti.PlumbingGraph.characteristicLowerFaceExponent` and
   `TauCeti.PlumbingGraph.characteristicUpperFaceExponent`: the corresponding natural-number
   weight differences for directions in the cube.
@@ -44,10 +45,8 @@ namespace PlumbingGraph
 
 variable {V : Type*} [DecidableEq V]
 
-/-- Translating the base point by `E_v` and then taking the vertex indexed by `T` is the same
-as taking the ambient vertex indexed by `insert v T`, provided `v` was not already a direction
-of `T`. -/
-theorem cubeVertex_add_single_eq_insert {T : Finset V} {v : V} (hv : v ∉ T) (x : V → ℤ) :
+private theorem cubeVertex_add_single_eq_insert {T : Finset V} {v : V} (hv : v ∉ T)
+    (x : V → ℤ) :
     cubeVertex (x + Pi.single v (1 : ℤ)) T = cubeVertex x (insert v T) := by
   ext w
   by_cases hw : w = v
@@ -71,6 +70,11 @@ theorem cubeVertices_upperFace_subset {x : V → ℤ} {S : Finset V} {v : V} (hv
 
 variable [Fintype V] (P : PlumbingGraph V) (k : P.characteristicVectors)
 
+/-- The lower face's characteristic cube weight is bounded by the ambient cube weight. -/
+theorem characteristicLowerFaceWeight_le {x : V → ℤ} {S : Finset V} {v : V} :
+    P.characteristicCubeWeight k x (S.erase v) ≤ P.characteristicCubeWeight k x S :=
+  P.characteristicCubeWeight_mono k (Finset.erase_subset v S) x
+
 /-- The upper face's characteristic cube weight is bounded by the ambient cube weight. -/
 theorem characteristicUpperFaceWeight_le {x : V → ℤ} {S : Finset V} {v : V} (hv : v ∈ S) :
     P.characteristicCubeWeight k (x + Pi.single v (1 : ℤ)) (S.erase v) ≤
@@ -80,41 +84,38 @@ theorem characteristicUpperFaceWeight_le {x : V → ℤ} {S : Finset V} {v : V} 
   exact P.characteristicWeight_le_characteristicCubeWeight k
     (cubeVertices_upperFace_subset hv hy)
 
-/-- The nonnegative `U`-exponent contributed by the lower face of a cube in a direction of the
-cube. -/
+/-- The nonnegative `U`-exponent contributed by the lower face in a direction. -/
 noncomputable def characteristicLowerFaceExponent
-    (x : V → ℤ) (S : Finset V) (v : V) (_hv : v ∈ S) : ℕ :=
+    (x : V → ℤ) (S : Finset V) (v : V) : ℕ :=
   Int.toNat (P.characteristicCubeWeight k x S -
     P.characteristicCubeWeight k x (S.erase v))
 
 /-- The lower-face exponent, cast back to `ℤ`, is the difference between the ambient cube weight
 and the lower face weight. -/
 theorem characteristicLowerFaceExponent_intCast
-    {x : V → ℤ} {S : Finset V} {v : V} (hv : v ∈ S) :
-    (P.characteristicLowerFaceExponent k x S v hv : ℤ) =
+    {x : V → ℤ} {S : Finset V} {v : V} :
+    (P.characteristicLowerFaceExponent k x S v : ℤ) =
       P.characteristicCubeWeight k x S - P.characteristicCubeWeight k x (S.erase v) := by
   rw [characteristicLowerFaceExponent]
-  exact Int.toNat_of_nonneg
-    (sub_nonneg.mpr (P.characteristicCubeWeight_mono k (Finset.erase_subset v S) x))
+  exact Int.toNat_of_nonneg (sub_nonneg.mpr (P.characteristicLowerFaceWeight_le k))
 
 /-- The lower-face exponent is zero exactly when the lower face has the same weight as the
 ambient cube. -/
 theorem characteristicLowerFaceExponent_eq_zero_iff
-    {x : V → ℤ} {S : Finset V} {v : V} (hv : v ∈ S) :
-    P.characteristicLowerFaceExponent k x S v hv = 0 ↔
+    {x : V → ℤ} {S : Finset V} {v : V} :
+    P.characteristicLowerFaceExponent k x S v = 0 ↔
       P.characteristicCubeWeight k x S = P.characteristicCubeWeight k x (S.erase v) := by
   constructor
   · intro h
     have hcast := congrArg (fun n : ℕ => (n : ℤ)) h
-    rw [characteristicLowerFaceExponent_intCast (P := P) (k := k) hv] at hcast
+    rw [characteristicLowerFaceExponent_intCast (P := P) (k := k)] at hcast
     omega
   · intro h
     rw [characteristicLowerFaceExponent, h, sub_self, Int.toNat_zero]
 
-/-- The nonnegative `U`-exponent contributed by the upper face of a cube in a direction `v`.
-The membership hypothesis records that the upper face is a genuine face of the cube. -/
+/-- The nonnegative `U`-exponent contributed by the upper face in a direction. -/
 noncomputable def characteristicUpperFaceExponent
-    (x : V → ℤ) (S : Finset V) (v : V) (_hv : v ∈ S) : ℕ :=
+    (x : V → ℤ) (S : Finset V) (v : V) : ℕ :=
   Int.toNat (P.characteristicCubeWeight k x S -
     P.characteristicCubeWeight k (x + Pi.single v (1 : ℤ)) (S.erase v))
 
@@ -122,7 +123,7 @@ noncomputable def characteristicUpperFaceExponent
 and the upper face weight. -/
 theorem characteristicUpperFaceExponent_intCast
     {x : V → ℤ} {S : Finset V} {v : V} (hv : v ∈ S) :
-    (P.characteristicUpperFaceExponent k x S v hv : ℤ) =
+    (P.characteristicUpperFaceExponent k x S v : ℤ) =
       P.characteristicCubeWeight k x S -
         P.characteristicCubeWeight k (x + Pi.single v (1 : ℤ)) (S.erase v) := by
   rw [characteristicUpperFaceExponent]
@@ -132,7 +133,7 @@ theorem characteristicUpperFaceExponent_intCast
 ambient cube. -/
 theorem characteristicUpperFaceExponent_eq_zero_iff
     {x : V → ℤ} {S : Finset V} {v : V} (hv : v ∈ S) :
-    P.characteristicUpperFaceExponent k x S v hv = 0 ↔
+    P.characteristicUpperFaceExponent k x S v = 0 ↔
       P.characteristicCubeWeight k x S =
         P.characteristicCubeWeight k (x + Pi.single v (1 : ℤ)) (S.erase v) := by
   constructor

--- a/TauCeti/LowDimTopology/Plumbing/CubeFace.lean
+++ b/TauCeti/LowDimTopology/Plumbing/CubeFace.lean
@@ -78,9 +78,9 @@ theorem characteristicUpperFaceWeight_le {x : V → ℤ} {S : Finset V} {v : V} 
   exact P.characteristicWeight_le_characteristicCubeWeight k
     (cubeVertices_upperFace_subset hv hy)
 
-/-- The nonnegative `U`-exponent contributed by the lower face in a direction. -/
+/-- The nonnegative `U`-exponent contributed by the lower face in a cube direction. -/
 noncomputable def characteristicLowerFaceExponent
-    (x : V → ℤ) (S : Finset V) (v : V) : ℕ :=
+    (x : V → ℤ) (S : Finset V) {v : V} (_hv : v ∈ S) : ℕ :=
   Int.toNat (P.characteristicCubeWeight k x S -
     P.characteristicCubeWeight k x (S.erase v))
 
@@ -88,8 +88,8 @@ noncomputable def characteristicLowerFaceExponent
 and the lower face weight. -/
 @[simp]
 theorem characteristicLowerFaceExponent_natCast
-    {x : V → ℤ} {S : Finset V} {v : V} :
-    (P.characteristicLowerFaceExponent k x S v : ℤ) =
+    {x : V → ℤ} {S : Finset V} {v : V} (hv : v ∈ S) :
+    (P.characteristicLowerFaceExponent k x S hv : ℤ) =
       P.characteristicCubeWeight k x S - P.characteristicCubeWeight k x (S.erase v) := by
   rw [characteristicLowerFaceExponent]
   exact Int.toNat_of_nonneg
@@ -98,13 +98,13 @@ theorem characteristicLowerFaceExponent_natCast
 /-- The lower-face exponent is zero exactly when the lower face has the same weight as the
 ambient cube. -/
 theorem characteristicLowerFaceExponent_eq_zero_iff
-    {x : V → ℤ} {S : Finset V} {v : V} :
-    P.characteristicLowerFaceExponent k x S v = 0 ↔
+    {x : V → ℤ} {S : Finset V} {v : V} (hv : v ∈ S) :
+    P.characteristicLowerFaceExponent k x S hv = 0 ↔
       P.characteristicCubeWeight k x S = P.characteristicCubeWeight k x (S.erase v) := by
   constructor
   · intro h
     have hcast := congrArg (fun n : ℕ => (n : ℤ)) h
-    rw [characteristicLowerFaceExponent_natCast (P := P) (k := k)] at hcast
+    rw [characteristicLowerFaceExponent_natCast (P := P) (k := k) hv] at hcast
     omega
   · intro h
     rw [characteristicLowerFaceExponent, h, sub_self, Int.toNat_zero]

--- a/TauCeti/LowDimTopology/Plumbing/CubeFace.lean
+++ b/TauCeti/LowDimTopology/Plumbing/CubeFace.lean
@@ -80,15 +80,15 @@ theorem characteristicUpperFaceWeight_le {x : V → ℤ} {S : Finset V} {v : V} 
 
 /-- The nonnegative `U`-exponent contributed by the lower face in a cube direction. -/
 noncomputable def characteristicLowerFaceExponent
-    (x : V → ℤ) (S : Finset V) (v : V) : ℕ :=
+    (x : V → ℤ) (S : Finset V) {v : V} (_hv : v ∈ S) : ℕ :=
   Int.toNat (P.characteristicCubeWeight k x S -
     P.characteristicCubeWeight k x (S.erase v))
 
 /-- The lower-face exponent, cast back to `ℤ`, is the difference between the ambient cube weight
 and the lower face weight. -/
 theorem characteristicLowerFaceExponent_natCast
-    {x : V → ℤ} {S : Finset V} (v : V) :
-    (P.characteristicLowerFaceExponent k x S v : ℤ) =
+    {x : V → ℤ} {S : Finset V} {v : V} (hv : v ∈ S) :
+    (P.characteristicLowerFaceExponent k x S hv : ℤ) =
       P.characteristicCubeWeight k x S - P.characteristicCubeWeight k x (S.erase v) := by
   rw [characteristicLowerFaceExponent]
   exact Int.toNat_of_nonneg
@@ -97,13 +97,13 @@ theorem characteristicLowerFaceExponent_natCast
 /-- The lower-face exponent is zero exactly when the lower face has the same weight as the
 ambient cube. -/
 theorem characteristicLowerFaceExponent_eq_zero_iff
-    {x : V → ℤ} {S : Finset V} (v : V) :
-    P.characteristicLowerFaceExponent k x S v = 0 ↔
+    {x : V → ℤ} {S : Finset V} {v : V} (hv : v ∈ S) :
+    P.characteristicLowerFaceExponent k x S hv = 0 ↔
       P.characteristicCubeWeight k x S = P.characteristicCubeWeight k x (S.erase v) := by
   constructor
   · intro h
     have hcast := congrArg (fun n : ℕ => (n : ℤ)) h
-    rw [characteristicLowerFaceExponent_natCast (P := P) (k := k) v] at hcast
+    rw [characteristicLowerFaceExponent_natCast (P := P) (k := k) hv] at hcast
     omega
   · intro h
     rw [characteristicLowerFaceExponent, h, sub_self, Int.toNat_zero]

--- a/TauCeti/LowDimTopology/Plumbing/CubeFace.lean
+++ b/TauCeti/LowDimTopology/Plumbing/CubeFace.lean
@@ -80,7 +80,7 @@ theorem characteristicUpperFaceWeight_le {x : V → ℤ} {S : Finset V} {v : V} 
 
 /-- The nonnegative `U`-exponent contributed by the lower face in a cube direction. -/
 noncomputable def characteristicLowerFaceExponent
-    (x : V → ℤ) (S : Finset V) {v : V} (_hv : v ∈ S) : ℕ :=
+    (x : V → ℤ) (S : Finset V) (v : V) : ℕ :=
   Int.toNat (P.characteristicCubeWeight k x S -
     P.characteristicCubeWeight k x (S.erase v))
 
@@ -88,8 +88,8 @@ noncomputable def characteristicLowerFaceExponent
 and the lower face weight. -/
 @[simp]
 theorem characteristicLowerFaceExponent_natCast
-    {x : V → ℤ} {S : Finset V} {v : V} (hv : v ∈ S) :
-    (P.characteristicLowerFaceExponent k x S hv : ℤ) =
+    {x : V → ℤ} {S : Finset V} {v : V} :
+    (P.characteristicLowerFaceExponent k x S v : ℤ) =
       P.characteristicCubeWeight k x S - P.characteristicCubeWeight k x (S.erase v) := by
   rw [characteristicLowerFaceExponent]
   exact Int.toNat_of_nonneg
@@ -98,13 +98,13 @@ theorem characteristicLowerFaceExponent_natCast
 /-- The lower-face exponent is zero exactly when the lower face has the same weight as the
 ambient cube. -/
 theorem characteristicLowerFaceExponent_eq_zero_iff
-    {x : V → ℤ} {S : Finset V} {v : V} (hv : v ∈ S) :
-    P.characteristicLowerFaceExponent k x S hv = 0 ↔
+    {x : V → ℤ} {S : Finset V} {v : V} :
+    P.characteristicLowerFaceExponent k x S v = 0 ↔
       P.characteristicCubeWeight k x S = P.characteristicCubeWeight k x (S.erase v) := by
   constructor
   · intro h
     have hcast := congrArg (fun n : ℕ => (n : ℤ)) h
-    rw [characteristicLowerFaceExponent_natCast (P := P) (k := k) hv] at hcast
+    rw [characteristicLowerFaceExponent_natCast (P := P) (k := k)] at hcast
     omega
   · intro h
     rw [characteristicLowerFaceExponent, h, sub_self, Int.toNat_zero]

--- a/TauCeti/LowDimTopology/Plumbing/CubeFace.lean
+++ b/TauCeti/LowDimTopology/Plumbing/CubeFace.lean
@@ -71,7 +71,7 @@ theorem cubeVertices_upperFace_subset {x : V → ℤ} {S : Finset V} {v : V} (hv
 variable [Fintype V] (P : PlumbingGraph V) (k : P.characteristicVectors)
 
 /-- The lower face's characteristic cube weight is bounded by the ambient cube weight. -/
-theorem characteristicLowerFaceWeight_le {x : V → ℤ} {S : Finset V} {v : V} :
+theorem characteristicLowerFaceWeight_le {x : V → ℤ} {S : Finset V} {v : V} (_hv : v ∈ S) :
     P.characteristicCubeWeight k x (S.erase v) ≤ P.characteristicCubeWeight k x S :=
   P.characteristicCubeWeight_mono k (Finset.erase_subset v S) x
 
@@ -86,29 +86,29 @@ theorem characteristicUpperFaceWeight_le {x : V → ℤ} {S : Finset V} {v : V} 
 
 /-- The nonnegative `U`-exponent contributed by the lower face in a direction. -/
 noncomputable def characteristicLowerFaceExponent
-    (x : V → ℤ) (S : Finset V) (v : V) : ℕ :=
+    (x : V → ℤ) (S : Finset V) {v : V} (_hv : v ∈ S) : ℕ :=
   Int.toNat (P.characteristicCubeWeight k x S -
     P.characteristicCubeWeight k x (S.erase v))
 
 /-- The lower-face exponent, cast back to `ℤ`, is the difference between the ambient cube weight
 and the lower face weight. -/
 theorem characteristicLowerFaceExponent_intCast
-    {x : V → ℤ} {S : Finset V} {v : V} :
-    (P.characteristicLowerFaceExponent k x S v : ℤ) =
+    {x : V → ℤ} {S : Finset V} {v : V} (hv : v ∈ S) :
+    (P.characteristicLowerFaceExponent k x S hv : ℤ) =
       P.characteristicCubeWeight k x S - P.characteristicCubeWeight k x (S.erase v) := by
   rw [characteristicLowerFaceExponent]
-  exact Int.toNat_of_nonneg (sub_nonneg.mpr (P.characteristicLowerFaceWeight_le k))
+  exact Int.toNat_of_nonneg (sub_nonneg.mpr (P.characteristicLowerFaceWeight_le k hv))
 
 /-- The lower-face exponent is zero exactly when the lower face has the same weight as the
 ambient cube. -/
 theorem characteristicLowerFaceExponent_eq_zero_iff
-    {x : V → ℤ} {S : Finset V} {v : V} :
-    P.characteristicLowerFaceExponent k x S v = 0 ↔
+    {x : V → ℤ} {S : Finset V} {v : V} (hv : v ∈ S) :
+    P.characteristicLowerFaceExponent k x S hv = 0 ↔
       P.characteristicCubeWeight k x S = P.characteristicCubeWeight k x (S.erase v) := by
   constructor
   · intro h
     have hcast := congrArg (fun n : ℕ => (n : ℤ)) h
-    rw [characteristicLowerFaceExponent_intCast (P := P) (k := k)] at hcast
+    rw [characteristicLowerFaceExponent_intCast (P := P) (k := k) hv] at hcast
     omega
   · intro h
     rw [characteristicLowerFaceExponent, h, sub_self, Int.toNat_zero]

--- a/TauCeti/LowDimTopology/Plumbing/CubeFace.lean
+++ b/TauCeti/LowDimTopology/Plumbing/CubeFace.lean
@@ -29,7 +29,7 @@ exponents of the `U`-powers in the later lattice-homology differential.
   ambient cube weight.
 * `TauCeti.PlumbingGraph.characteristicLowerFaceExponent` and
   `TauCeti.PlumbingGraph.characteristicUpperFaceExponent`: the corresponding natural-number
-  weight differences.
+  weight differences for directions in the cube.
 
 ## References
 
@@ -93,38 +93,40 @@ theorem characteristicUpperFaceWeight_le {x : V → ℤ} {S : Finset V} {v : V} 
   exact P.characteristicWeight_le_characteristicCubeWeight k
     (cubeVertices_upperFace_subset hv hy)
 
-/-- The nonnegative `U`-exponent contributed by the lower face of a cube. -/
+/-- The nonnegative `U`-exponent contributed by the lower face of a cube in a direction of the
+cube. -/
 noncomputable def characteristicLowerFaceExponent
-    (x : V → ℤ) (S : Finset V) (v : V) : ℕ :=
+    (x : V → ℤ) (S : Finset V) (v : V) (_hv : v ∈ S) : ℕ :=
   Int.toNat (P.characteristicCubeWeight k x S -
     P.characteristicCubeWeight k x (S.erase v))
 
 /-- The lower-face exponent, cast back to `ℤ`, is the difference between the ambient cube weight
 and the lower face weight. -/
-theorem characteristicLowerFaceExponent_intCast (x : V → ℤ) (S : Finset V) (v : V) :
-    (P.characteristicLowerFaceExponent k x S v : ℤ) =
+theorem characteristicLowerFaceExponent_intCast
+    {x : V → ℤ} {S : Finset V} {v : V} (hv : v ∈ S) :
+    (P.characteristicLowerFaceExponent k x S v hv : ℤ) =
       P.characteristicCubeWeight k x S - P.characteristicCubeWeight k x (S.erase v) := by
   rw [characteristicLowerFaceExponent]
   exact Int.toNat_of_nonneg (sub_nonneg.mpr (P.characteristicLowerFaceWeight_le k x S v))
 
 /-- The lower-face exponent is zero exactly when the lower face has the same weight as the
 ambient cube. -/
-theorem characteristicLowerFaceExponent_eq_zero_iff (x : V → ℤ) (S : Finset V) (v : V) :
-    P.characteristicLowerFaceExponent k x S v = 0 ↔
+theorem characteristicLowerFaceExponent_eq_zero_iff
+    {x : V → ℤ} {S : Finset V} {v : V} (hv : v ∈ S) :
+    P.characteristicLowerFaceExponent k x S v hv = 0 ↔
       P.characteristicCubeWeight k x S = P.characteristicCubeWeight k x (S.erase v) := by
   constructor
   · intro h
     have hcast := congrArg (fun n : ℕ => (n : ℤ)) h
-    rw [characteristicLowerFaceExponent_intCast] at hcast
+    rw [characteristicLowerFaceExponent_intCast (P := P) (k := k) hv] at hcast
     omega
   · intro h
     rw [characteristicLowerFaceExponent, h, sub_self, Int.toNat_zero]
 
 /-- The nonnegative `U`-exponent contributed by the upper face of a cube in a direction `v`.
-When `v ∉ S`, this still returns the formal difference for the erased-direction expression; the
-cast-back theorem below records the intended boundary-face case `v ∈ S`. -/
+The membership hypothesis records that the upper face is a genuine face of the cube. -/
 noncomputable def characteristicUpperFaceExponent
-    (x : V → ℤ) (S : Finset V) (v : V) : ℕ :=
+    (x : V → ℤ) (S : Finset V) (v : V) (_hv : v ∈ S) : ℕ :=
   Int.toNat (P.characteristicCubeWeight k x S -
     P.characteristicCubeWeight k (x + Pi.single v (1 : ℤ)) (S.erase v))
 
@@ -132,7 +134,7 @@ noncomputable def characteristicUpperFaceExponent
 and the upper face weight. -/
 theorem characteristicUpperFaceExponent_intCast
     {x : V → ℤ} {S : Finset V} {v : V} (hv : v ∈ S) :
-    (P.characteristicUpperFaceExponent k x S v : ℤ) =
+    (P.characteristicUpperFaceExponent k x S v hv : ℤ) =
       P.characteristicCubeWeight k x S -
         P.characteristicCubeWeight k (x + Pi.single v (1 : ℤ)) (S.erase v) := by
   rw [characteristicUpperFaceExponent]
@@ -142,7 +144,7 @@ theorem characteristicUpperFaceExponent_intCast
 ambient cube. -/
 theorem characteristicUpperFaceExponent_eq_zero_iff
     {x : V → ℤ} {S : Finset V} {v : V} (hv : v ∈ S) :
-    P.characteristicUpperFaceExponent k x S v = 0 ↔
+    P.characteristicUpperFaceExponent k x S v hv = 0 ↔
       P.characteristicCubeWeight k x S =
         P.characteristicCubeWeight k (x + Pi.single v (1 : ℤ)) (S.erase v) := by
   constructor
@@ -152,13 +154,6 @@ theorem characteristicUpperFaceExponent_eq_zero_iff
     omega
   · intro h
     rw [characteristicUpperFaceExponent, h, sub_self, Int.toNat_zero]
-
-/-- For a zero-dimensional cube, the lower-face exponent is zero. -/
-@[simp]
-theorem characteristicLowerFaceExponent_empty (x : V → ℤ) (v : V) :
-    P.characteristicLowerFaceExponent k x ∅ v = 0 := by
-  rw [characteristicLowerFaceExponent_eq_zero_iff]
-  simp
 
 end PlumbingGraph
 

--- a/TauCeti/LowDimTopology/Plumbing/CubeFace.lean
+++ b/TauCeti/LowDimTopology/Plumbing/CubeFace.lean
@@ -22,12 +22,11 @@ exponents of the `U`-powers in the later lattice-homology differential.
 
 * `TauCeti.PlumbingGraph.cubeVertices_upperFace_subset`: the upper face's vertices are
   vertices of the ambient cube, when `v ∈ S`.
-* `TauCeti.PlumbingGraph.characteristicLowerFaceWeight_le` and
-  `TauCeti.PlumbingGraph.characteristicUpperFaceWeight_le`: face weights are bounded by the
-  ambient cube weight.
+* `TauCeti.PlumbingGraph.characteristicUpperFaceWeight_le`: the upper face weight is bounded by
+  the ambient cube weight.
 * `TauCeti.PlumbingGraph.characteristicLowerFaceExponent` and
   `TauCeti.PlumbingGraph.characteristicUpperFaceExponent`: the corresponding natural-number
-  weight differences for directions in the cube.
+  weight differences.
 
 ## References
 
@@ -70,11 +69,6 @@ theorem cubeVertices_upperFace_subset {x : V → ℤ} {S : Finset V} {v : V} (hv
 
 variable [Fintype V] (P : PlumbingGraph V) (k : P.characteristicVectors)
 
-/-- The lower face's characteristic cube weight is bounded by the ambient cube weight. -/
-theorem characteristicLowerFaceWeight_le {x : V → ℤ} {S : Finset V} {v : V} (_hv : v ∈ S) :
-    P.characteristicCubeWeight k x (S.erase v) ≤ P.characteristicCubeWeight k x S :=
-  P.characteristicCubeWeight_mono k (Finset.erase_subset v S) x
-
 /-- The upper face's characteristic cube weight is bounded by the ambient cube weight. -/
 theorem characteristicUpperFaceWeight_le {x : V → ℤ} {S : Finset V} {v : V} (hv : v ∈ S) :
     P.characteristicCubeWeight k (x + Pi.single v (1 : ℤ)) (S.erase v) ≤
@@ -86,29 +80,30 @@ theorem characteristicUpperFaceWeight_le {x : V → ℤ} {S : Finset V} {v : V} 
 
 /-- The nonnegative `U`-exponent contributed by the lower face in a direction. -/
 noncomputable def characteristicLowerFaceExponent
-    (x : V → ℤ) (S : Finset V) {v : V} (_hv : v ∈ S) : ℕ :=
+    (x : V → ℤ) (S : Finset V) (v : V) : ℕ :=
   Int.toNat (P.characteristicCubeWeight k x S -
     P.characteristicCubeWeight k x (S.erase v))
 
 /-- The lower-face exponent, cast back to `ℤ`, is the difference between the ambient cube weight
 and the lower face weight. -/
-theorem characteristicLowerFaceExponent_intCast
-    {x : V → ℤ} {S : Finset V} {v : V} (hv : v ∈ S) :
-    (P.characteristicLowerFaceExponent k x S hv : ℤ) =
+theorem characteristicLowerFaceExponent_natCast
+    {x : V → ℤ} {S : Finset V} {v : V} :
+    (P.characteristicLowerFaceExponent k x S v : ℤ) =
       P.characteristicCubeWeight k x S - P.characteristicCubeWeight k x (S.erase v) := by
   rw [characteristicLowerFaceExponent]
-  exact Int.toNat_of_nonneg (sub_nonneg.mpr (P.characteristicLowerFaceWeight_le k hv))
+  exact Int.toNat_of_nonneg
+    (sub_nonneg.mpr (P.characteristicCubeWeight_mono k (Finset.erase_subset v S) x))
 
 /-- The lower-face exponent is zero exactly when the lower face has the same weight as the
 ambient cube. -/
 theorem characteristicLowerFaceExponent_eq_zero_iff
-    {x : V → ℤ} {S : Finset V} {v : V} (hv : v ∈ S) :
-    P.characteristicLowerFaceExponent k x S hv = 0 ↔
+    {x : V → ℤ} {S : Finset V} {v : V} :
+    P.characteristicLowerFaceExponent k x S v = 0 ↔
       P.characteristicCubeWeight k x S = P.characteristicCubeWeight k x (S.erase v) := by
   constructor
   · intro h
     have hcast := congrArg (fun n : ℕ => (n : ℤ)) h
-    rw [characteristicLowerFaceExponent_intCast (P := P) (k := k) hv] at hcast
+    rw [characteristicLowerFaceExponent_natCast (P := P) (k := k)] at hcast
     omega
   · intro h
     rw [characteristicLowerFaceExponent, h, sub_self, Int.toNat_zero]
@@ -121,7 +116,7 @@ noncomputable def characteristicUpperFaceExponent
 
 /-- The upper-face exponent, cast back to `ℤ`, is the difference between the ambient cube weight
 and the upper face weight. -/
-theorem characteristicUpperFaceExponent_intCast
+theorem characteristicUpperFaceExponent_natCast
     {x : V → ℤ} {S : Finset V} {v : V} (hv : v ∈ S) :
     (P.characteristicUpperFaceExponent k x S hv : ℤ) =
       P.characteristicCubeWeight k x S -
@@ -139,7 +134,7 @@ theorem characteristicUpperFaceExponent_eq_zero_iff
   constructor
   · intro h
     have hcast := congrArg (fun n : ℕ => (n : ℤ)) h
-    rw [characteristicUpperFaceExponent_intCast (P := P) (k := k) hv] at hcast
+    rw [characteristicUpperFaceExponent_natCast (P := P) (k := k) hv] at hcast
     omega
   · intro h
     rw [characteristicUpperFaceExponent, h, sub_self, Int.toNat_zero]

--- a/TauCeti/LowDimTopology/Plumbing/CubeFace.lean
+++ b/TauCeti/LowDimTopology/Plumbing/CubeFace.lean
@@ -78,17 +78,17 @@ theorem characteristicUpperFaceWeight_le {x : V → ℤ} {S : Finset V} {v : V} 
   exact P.characteristicWeight_le_characteristicCubeWeight k
     (cubeVertices_upperFace_subset hv hy)
 
-/-- The nonnegative `U`-exponent contributed by the lower face in a direction. -/
+/-- The nonnegative `U`-exponent contributed by the lower face in a cube direction. -/
 noncomputable def characteristicLowerFaceExponent
-    (x : V → ℤ) (S : Finset V) (v : V) : ℕ :=
+    (x : V → ℤ) (S : Finset V) {v : V} (_hv : v ∈ S) : ℕ :=
   Int.toNat (P.characteristicCubeWeight k x S -
     P.characteristicCubeWeight k x (S.erase v))
 
 /-- The lower-face exponent, cast back to `ℤ`, is the difference between the ambient cube weight
 and the lower face weight. -/
 theorem characteristicLowerFaceExponent_natCast
-    {x : V → ℤ} {S : Finset V} {v : V} :
-    (P.characteristicLowerFaceExponent k x S v : ℤ) =
+    {x : V → ℤ} {S : Finset V} {v : V} (hv : v ∈ S) :
+    (P.characteristicLowerFaceExponent k x S hv : ℤ) =
       P.characteristicCubeWeight k x S - P.characteristicCubeWeight k x (S.erase v) := by
   rw [characteristicLowerFaceExponent]
   exact Int.toNat_of_nonneg
@@ -97,13 +97,13 @@ theorem characteristicLowerFaceExponent_natCast
 /-- The lower-face exponent is zero exactly when the lower face has the same weight as the
 ambient cube. -/
 theorem characteristicLowerFaceExponent_eq_zero_iff
-    {x : V → ℤ} {S : Finset V} {v : V} :
-    P.characteristicLowerFaceExponent k x S v = 0 ↔
+    {x : V → ℤ} {S : Finset V} {v : V} (hv : v ∈ S) :
+    P.characteristicLowerFaceExponent k x S hv = 0 ↔
       P.characteristicCubeWeight k x S = P.characteristicCubeWeight k x (S.erase v) := by
   constructor
   · intro h
     have hcast := congrArg (fun n : ℕ => (n : ℤ)) h
-    rw [characteristicLowerFaceExponent_natCast (P := P) (k := k)] at hcast
+    rw [characteristicLowerFaceExponent_natCast (P := P) (k := k) hv] at hcast
     omega
   · intro h
     rw [characteristicLowerFaceExponent, h, sub_self, Int.toNat_zero]


### PR DESCRIPTION
This PR adds codimension-one face bookkeeping for plumbing-lattice cubes: the lower and upper face vertex inclusions, the corresponding characteristic cube-weight inequalities, and the natural-number weight-difference exponents used by the later `U`-weighted cubical boundary.

It advances `TauCetiRoadmap/CombinatorialHeegaardFloer/README.md`, Lane L ("lattice homology"), specifically the opening item "Plumbing trees/graphs and their lattices; Némethi's lattice (co)homology `ℍ⁻`/`ℍ⁰` as a `ℤ[U]`-module from lattice points and weight functions." I chose it as the lowest-hanging distinct CombinatorialHeegaardFloer prerequisite after checking open and recently merged PRs: the plumbing graph, characteristic covectors, point weights, cube weights, and conjugation symmetry already exist, while the boundary-face weight differences needed for the cubical differential were still missing. The open CombinatorialHeegaardFloer PR covers grid rectangle counts, so this lattice-homology prerequisite is non-overlapping.

No Mathlib infrastructure is vendored. The implementation reuses Tau Ceti's existing `cubeVertex`, `cubeVertices`, `characteristicCubeWeight`, `characteristicCubeWeight_mono`, and vertex-weight maximum API, together with Mathlib's `Finset.erase` API and integer `toNat` facts. The face-weight convention follows Némethi, arXiv:0709.0841.

`lake exe cache get` completed with `No files to download` and `Already decompressed 8586 file(s)`. `lake build` completed with `Build completed successfully (4223 jobs).` `lake exe axioms` completed with `axioms: audited 5115 TauCeti declaration(s); all within the allowlist [propext, Classical.choice, Quot.sound].`

<!--tauceti-target:v1 {"focus":"CombinatorialHeegaardFloer","id":"lattice-cube-face-weights"}-->

🤖 Prepared with Codex
