### PR TITLE
feat: add normalizer quotient API

### DIFF
--- a/TauCeti/Algebra/Group/NormalizerQuotient.lean
+++ b/TauCeti/Algebra/Group/NormalizerQuotient.lean
@@ -24,6 +24,8 @@ in the normal case.
 
 * `TauCeti.Subgroup.normalizerQuotient`: the quotient `N(H) / H`.
 * `TauCeti.Subgroup.normalizerQuotientMk`: the canonical map `N(H) →* N(H) / H`.
+* `TauCeti.Subgroup.normalizerQuotientLift`: the universal property for maps out of
+  `N(H) / H`.
 * `TauCeti.Subgroup.normalizerQuotientToQuotientOfNormal`: when `H` is normal in `G`,
   the natural map `N(H) / H →* G / H`.
 * `TauCeti.Subgroup.normalizerQuotientEquivQuotientOfNormal`: when `H` is normal in `G`,
@@ -93,6 +95,54 @@ lemma normalizerQuotientMk_range (H : Subgroup G) :
     (normalizerQuotientMk H).range = ⊤ :=
   QuotientGroup.range_mk'
     (N := H.subgroupOf (_root_.Subgroup.normalizer (H : Set G)))
+
+variable {M : Type*} [Group M]
+
+/-- The universal property of `N(H) / H`: a homomorphism from the normalizer that kills the
+copy of `H` descends to a homomorphism from the normalizer quotient. -/
+abbrev normalizerQuotientLift (H : Subgroup G)
+    (φ : _root_.Subgroup.normalizer (H : Set G) →* M)
+    (hφ : H.subgroupOf (_root_.Subgroup.normalizer (H : Set G)) ≤ φ.ker) :
+    normalizerQuotient H →* M :=
+  QuotientGroup.lift (H.subgroupOf (_root_.Subgroup.normalizer (H : Set G))) φ hφ
+
+/-- The lift from `N(H) / H` evaluates on representatives as the original homomorphism. -/
+@[simp]
+lemma normalizerQuotientLift_mk (H : Subgroup G)
+    (φ : _root_.Subgroup.normalizer (H : Set G) →* M)
+    (hφ : H.subgroupOf (_root_.Subgroup.normalizer (H : Set G)) ≤ φ.ker)
+    (g : _root_.Subgroup.normalizer (H : Set G)) :
+    normalizerQuotientLift H φ hφ (normalizerQuotientMk H g) = φ g :=
+  rfl
+
+/-- The lift from `N(H) / H`, composed with the quotient map, is the original homomorphism
+from the normalizer. -/
+@[simp]
+lemma normalizerQuotientLift_comp_mk (H : Subgroup G)
+    (φ : _root_.Subgroup.normalizer (H : Set G) →* M)
+    (hφ : H.subgroupOf (_root_.Subgroup.normalizer (H : Set G)) ≤ φ.ker) :
+    (normalizerQuotientLift H φ hφ).comp (normalizerQuotientMk H) = φ :=
+  rfl
+
+/-- A lift from `N(H) / H` is surjective when the original homomorphism from the normalizer is
+surjective. -/
+lemma normalizerQuotientLift_surjective_of_surjective (H : Subgroup G)
+    (φ : _root_.Subgroup.normalizer (H : Set G) →* M)
+    (hφ : H.subgroupOf (_root_.Subgroup.normalizer (H : Set G)) ≤ φ.ker)
+    (hφsurj : Function.Surjective φ) :
+    Function.Surjective (normalizerQuotientLift H φ hφ) :=
+  QuotientGroup.lift_surjective_of_surjective
+    (H.subgroupOf (_root_.Subgroup.normalizer (H : Set G))) φ hφsurj hφ
+
+/-- A lift from `N(H) / H` is injective exactly when the only normalizer elements killed by
+the original homomorphism are the elements of `H`. -/
+lemma normalizerQuotientLift_injective_iff (H : Subgroup G)
+    (φ : _root_.Subgroup.normalizer (H : Set G) →* M)
+    (hφ : H.subgroupOf (_root_.Subgroup.normalizer (H : Set G)) ≤ φ.ker) :
+    Function.Injective (normalizerQuotientLift H φ hφ) ↔
+      H.subgroupOf (_root_.Subgroup.normalizer (H : Set G)) = φ.ker :=
+  QuotientGroup.injective_lift_iff
+    (H.subgroupOf (_root_.Subgroup.normalizer (H : Set G))) φ hφ
 
 /-- The quotient equality criterion for representatives in the normalizer, stated in the
 ambient group `G`. -/

--- a/TauCeti/Algebra/Group/NormalizerQuotient.lean
+++ b/TauCeti/Algebra/Group/NormalizerQuotient.lean
@@ -98,21 +98,13 @@ lemma normalizerQuotientMk_range (H : Subgroup G) :
 
 variable {M : Type*} [Group M]
 
-/-- The subgroup-form universal property of `N(H) / H`: a homomorphism from the normalizer
-whose kernel contains the copy of `H` descends to a homomorphism from the normalizer quotient. -/
-abbrev normalizerQuotientLiftOfSubgroupOf (H : Subgroup G)
-    (φ : _root_.Subgroup.normalizer (H : Set G) →* M)
-    (hφ : H.subgroupOf (_root_.Subgroup.normalizer (H : Set G)) ≤ φ.ker) :
-    normalizerQuotient H →* M :=
-  QuotientGroup.lift (H.subgroupOf (_root_.Subgroup.normalizer (H : Set G))) φ hφ
-
 /-- The universal property of `N(H) / H`: a homomorphism from the normalizer that sends every
 ambient element of `H` to `1` descends to a homomorphism from the normalizer quotient. -/
 abbrev normalizerQuotientLift (H : Subgroup G)
     (φ : _root_.Subgroup.normalizer (H : Set G) →* M)
     (hφ : ∀ g : _root_.Subgroup.normalizer (H : Set G), (g : G) ∈ H → φ g = 1) :
     normalizerQuotient H →* M :=
-  normalizerQuotientLiftOfSubgroupOf H φ (by
+  QuotientGroup.lift (H.subgroupOf (_root_.Subgroup.normalizer (H : Set G))) φ (by
     intro g hg
     exact hφ g hg)
 

--- a/TauCeti/Algebra/Group/NormalizerQuotient.lean
+++ b/TauCeti/Algebra/Group/NormalizerQuotient.lean
@@ -52,7 +52,7 @@ abbrev normalizerQuotient (H : Subgroup G) : Type _ :=
     H.subgroupOf (_root_.Subgroup.normalizer (H : Set G))
 
 /-- The canonical quotient map from the normalizer of `H` to `N(H) / H`. -/
-@[expose] def normalizerQuotientMk (H : Subgroup G) :
+abbrev normalizerQuotientMk (H : Subgroup G) :
     _root_.Subgroup.normalizer (H : Set G) →* normalizerQuotient H :=
   QuotientGroup.mk' (H.subgroupOf (_root_.Subgroup.normalizer (H : Set G)))
 
@@ -72,16 +72,30 @@ lemma normalizerQuotientMk_eq_one_iff (H : Subgroup G)
   simp [normalizerQuotientMk, normalizerQuotient, _root_.Subgroup.mem_subgroupOf,
     QuotientGroup.eq_one_iff]
 
+/-- The kernel of the quotient map `N(H) →* N(H) / H` is the copy of `H` inside its
+normalizer. -/
+@[simp]
+lemma normalizerQuotientMk_ker (H : Subgroup G) :
+    (normalizerQuotientMk H).ker =
+      H.subgroupOf (_root_.Subgroup.normalizer (H : Set G)) := by
+  exact QuotientGroup.ker_mk'
+    (N := H.subgroupOf (_root_.Subgroup.normalizer (H : Set G)))
+
+/-- The quotient equality criterion for representatives in the normalizer, stated in the
+ambient group `G`. -/
+lemma normalizerQuotientMk_eq_iff_div_mem (H : Subgroup G)
+    (g k : _root_.Subgroup.normalizer (H : Set G)) :
+    normalizerQuotientMk H g = normalizerQuotientMk H k ↔ (g : G) / (k : G) ∈ H := by
+  simpa [normalizerQuotientMk, normalizerQuotient, _root_.Subgroup.mem_subgroupOf]
+    using QuotientGroup.eq_iff_div_mem
+      (N := H.subgroupOf (_root_.Subgroup.normalizer (H : Set G))) (x := g) (y := k)
+
 /-- A version of the equality criterion using multiplication by an element of `H`. -/
 lemma normalizerQuotientMk_eq_iff_exists_mul (H : Subgroup G)
     (g k : _root_.Subgroup.normalizer (H : Set G)) :
     normalizerQuotientMk H g = normalizerQuotientMk H k ↔
       ∃ h ∈ H, h * (k : G) = g := by
-  rw [show normalizerQuotientMk H g = normalizerQuotientMk H k ↔
-      (g : G) / (k : G) ∈ H by
-    simpa [normalizerQuotientMk, normalizerQuotient, _root_.Subgroup.mem_subgroupOf]
-      using QuotientGroup.eq_iff_div_mem
-        (N := H.subgroupOf (_root_.Subgroup.normalizer (H : Set G))) (x := g) (y := k)]
+  rw [normalizerQuotientMk_eq_iff_div_mem]
   constructor
   · intro hgk
     exact ⟨(g : G) / k, hgk, by simp [div_eq_mul_inv, mul_assoc]⟩
@@ -94,7 +108,7 @@ section Normal
 variable (H : Subgroup G) [H.Normal]
 
 /-- When `H` is normal in `G`, every element of `G` lies in the normalizer of `H`. -/
-@[expose] def toNormalizerOfNormal : G →* _root_.Subgroup.normalizer (H : Set G) where
+abbrev toNormalizerOfNormal : G →* _root_.Subgroup.normalizer (H : Set G) where
   toFun g := ⟨g, by simp [_root_.Subgroup.normalizer_eq_top (H := H)]⟩
   map_one' := rfl
   map_mul' _ _ := rfl
@@ -114,7 +128,7 @@ lemma toNormalizerOfNormal_surjective :
 
 /-- When `H` is normal in `G`, the normalizer quotient maps naturally to the ordinary quotient
 `G / H` by forgetting that representatives lie in the normalizer. -/
-@[expose] def normalizerQuotientToQuotientOfNormal :
+abbrev normalizerQuotientToQuotientOfNormal :
     normalizerQuotient H →* G ⧸ H :=
   QuotientGroup.map (H.subgroupOf (_root_.Subgroup.normalizer (H : Set G))) H
     (_root_.Subgroup.normalizer (H : Set G)).subtype
@@ -139,42 +153,30 @@ lemma normalizerQuotientToQuotientOfNormal_comp_mk :
       (QuotientGroup.mk' H).comp (_root_.Subgroup.normalizer (H : Set G)).subtype :=
   rfl
 
-/-- The comparison map `N(H) / H →* G / H` is surjective when `H` is normal in `G`. -/
-lemma normalizerQuotientToQuotientOfNormal_surjective :
-    Function.Surjective (normalizerQuotientToQuotientOfNormal H) := by
-  intro q
-  induction q using Quotient.inductionOn' with
-  | h g =>
-      refine ⟨normalizerQuotientMk H (toNormalizerOfNormal H g), ?_⟩
-      rw [normalizerQuotientToQuotientOfNormal_mk]
-      rfl
+/-- Under normality, the normalizer is isomorphic to the ambient group. -/
+abbrev normalizerEquivOfNormal :
+    _root_.Subgroup.normalizer (H : Set G) ≃* G :=
+  (MulEquiv.subgroupCongr (_root_.Subgroup.normalizer_eq_top (H := H))).trans Subgroup.topEquiv
 
-/-- The comparison map `N(H) / H →* G / H` is injective when `H` is normal in `G`. -/
-lemma normalizerQuotientToQuotientOfNormal_injective :
-    Function.Injective (normalizerQuotientToQuotientOfNormal H) := by
-  intro q r hqr
-  induction q using Quotient.inductionOn' with
-  | h g =>
-      induction r using Quotient.inductionOn' with
-      | h k =>
-          change normalizerQuotientMk H g = normalizerQuotientMk H k
-          apply (QuotientGroup.eq_iff_div_mem
-            (N := H.subgroupOf (_root_.Subgroup.normalizer (H : Set G))) (x := g)
-            (y := k)).mpr
-          change (normalizerQuotientToQuotientOfNormal H) (normalizerQuotientMk H g) =
-              (normalizerQuotientToQuotientOfNormal H) (normalizerQuotientMk H k) at hqr
-          rw [normalizerQuotientToQuotientOfNormal_mk,
-            normalizerQuotientToQuotientOfNormal_mk] at hqr
-          simpa [_root_.Subgroup.mem_subgroupOf] using
-            (QuotientGroup.eq_iff_div_mem (N := H) (x := (g : G)) (y := (k : G))).mp hqr
+/-- Under the normalizer-to-ambient-group equivalence, the copy of `H` in the normalizer maps
+to `H`. -/
+lemma normalizerEquivOfNormal_map_subgroupOf :
+    (H.subgroupOf (_root_.Subgroup.normalizer (H : Set G))).map
+        (normalizerEquivOfNormal H) = H := by
+  ext g
+  constructor
+  · rintro ⟨k, hk, rfl⟩
+    exact hk
+  · intro hg
+    exact ⟨⟨g, by simp [_root_.Subgroup.normalizer_eq_top (H := H)]⟩, hg, rfl⟩
 
 /-- If `H` is normal in `G`, then `N(H) / H` is canonically isomorphic to `G / H`. This is
 the algebraic form of the regular-cover specialization from `N(H) / H` to `π₁(X, x₀) / H`. -/
-@[expose] noncomputable def normalizerQuotientEquivQuotientOfNormal :
+noncomputable abbrev normalizerQuotientEquivQuotientOfNormal :
     normalizerQuotient H ≃* G ⧸ H :=
-  MulEquiv.ofBijective (normalizerQuotientToQuotientOfNormal H)
-    ⟨normalizerQuotientToQuotientOfNormal_injective H,
-      normalizerQuotientToQuotientOfNormal_surjective H⟩
+  QuotientGroup.congr
+    (H.subgroupOf (_root_.Subgroup.normalizer (H : Set G))) H
+    (normalizerEquivOfNormal H) (normalizerEquivOfNormal_map_subgroupOf H)
 
 /-- The normal-case equivalence sends a normalizer representative to its ordinary quotient
 class in `G / H`. -/
@@ -183,6 +185,14 @@ lemma normalizerQuotientEquivQuotientOfNormal_mk
     (g : _root_.Subgroup.normalizer (H : Set G)) :
     normalizerQuotientEquivQuotientOfNormal H (normalizerQuotientMk H g) =
       QuotientGroup.mk' H (g : G) :=
+  rfl
+
+/-- The inverse normal-case equivalence sends an ordinary quotient representative to the
+corresponding representative in the normalizer quotient. -/
+@[simp]
+lemma normalizerQuotientEquivQuotientOfNormal_symm_mk (g : G) :
+    (normalizerQuotientEquivQuotientOfNormal H).symm (QuotientGroup.mk' H g) =
+      normalizerQuotientMk H (toNormalizerOfNormal H g) :=
   rfl
 
 end Normal

--- a/TauCeti/Algebra/Group/NormalizerQuotient.lean
+++ b/TauCeti/Algebra/Group/NormalizerQuotient.lean
@@ -153,30 +153,21 @@ lemma normalizerQuotientToQuotientOfNormal_comp_mk :
       (QuotientGroup.mk' H).comp (_root_.Subgroup.normalizer (H : Set G)).subtype :=
   rfl
 
-/-- Under normality, the normalizer is isomorphic to the ambient group. -/
-abbrev normalizerEquivOfNormal :
-    _root_.Subgroup.normalizer (H : Set G) ≃* G :=
-  (MulEquiv.subgroupCongr (_root_.Subgroup.normalizer_eq_top (H := H))).trans Subgroup.topEquiv
-
-/-- Under the normalizer-to-ambient-group equivalence, the copy of `H` in the normalizer maps
-to `H`. -/
-lemma normalizerEquivOfNormal_map_subgroupOf :
-    (H.subgroupOf (_root_.Subgroup.normalizer (H : Set G))).map
-        (normalizerEquivOfNormal H) = H := by
-  ext g
-  constructor
-  · rintro ⟨k, hk, rfl⟩
-    exact hk
-  · intro hg
-    exact ⟨⟨g, by simp [_root_.Subgroup.normalizer_eq_top (H := H)]⟩, hg, rfl⟩
-
 /-- If `H` is normal in `G`, then `N(H) / H` is canonically isomorphic to `G / H`. This is
 the algebraic form of the regular-cover specialization from `N(H) / H` to `π₁(X, x₀) / H`. -/
 noncomputable abbrev normalizerQuotientEquivQuotientOfNormal :
     normalizerQuotient H ≃* G ⧸ H :=
   QuotientGroup.congr
     (H.subgroupOf (_root_.Subgroup.normalizer (H : Set G))) H
-    (normalizerEquivOfNormal H) (normalizerEquivOfNormal_map_subgroupOf H)
+    ((MulEquiv.subgroupCongr (_root_.Subgroup.normalizer_eq_top (H := H))).trans
+      Subgroup.topEquiv)
+    (by
+      ext g
+      constructor
+      · rintro ⟨k, hk, rfl⟩
+        exact hk
+      · intro hg
+        exact ⟨⟨g, by simp [_root_.Subgroup.normalizer_eq_top (H := H)]⟩, hg, rfl⟩)
 
 /-- The normal-case equivalence sends a normalizer representative to its ordinary quotient
 class in `G / H`. -/

--- a/TauCeti/Algebra/Group/NormalizerQuotient.lean
+++ b/TauCeti/Algebra/Group/NormalizerQuotient.lean
@@ -98,19 +98,29 @@ lemma normalizerQuotientMk_range (H : Subgroup G) :
 
 variable {M : Type*} [Group M]
 
-/-- The universal property of `N(H) / H`: a homomorphism from the normalizer that kills the
-copy of `H` descends to a homomorphism from the normalizer quotient. -/
-abbrev normalizerQuotientLift (H : Subgroup G)
+/-- The subgroup-form universal property of `N(H) / H`: a homomorphism from the normalizer
+whose kernel contains the copy of `H` descends to a homomorphism from the normalizer quotient. -/
+abbrev normalizerQuotientLiftOfSubgroupOf (H : Subgroup G)
     (φ : _root_.Subgroup.normalizer (H : Set G) →* M)
     (hφ : H.subgroupOf (_root_.Subgroup.normalizer (H : Set G)) ≤ φ.ker) :
     normalizerQuotient H →* M :=
   QuotientGroup.lift (H.subgroupOf (_root_.Subgroup.normalizer (H : Set G))) φ hφ
 
+/-- The universal property of `N(H) / H`: a homomorphism from the normalizer that sends every
+ambient element of `H` to `1` descends to a homomorphism from the normalizer quotient. -/
+abbrev normalizerQuotientLift (H : Subgroup G)
+    (φ : _root_.Subgroup.normalizer (H : Set G) →* M)
+    (hφ : ∀ g : _root_.Subgroup.normalizer (H : Set G), (g : G) ∈ H → φ g = 1) :
+    normalizerQuotient H →* M :=
+  normalizerQuotientLiftOfSubgroupOf H φ (by
+    intro g hg
+    exact hφ g hg)
+
 /-- The lift from `N(H) / H` evaluates on representatives as the original homomorphism. -/
 @[simp]
 lemma normalizerQuotientLift_mk (H : Subgroup G)
     (φ : _root_.Subgroup.normalizer (H : Set G) →* M)
-    (hφ : H.subgroupOf (_root_.Subgroup.normalizer (H : Set G)) ≤ φ.ker)
+    (hφ : ∀ g : _root_.Subgroup.normalizer (H : Set G), (g : G) ∈ H → φ g = 1)
     (g : _root_.Subgroup.normalizer (H : Set G)) :
     normalizerQuotientLift H φ hφ (normalizerQuotientMk H g) = φ g :=
   rfl
@@ -120,7 +130,7 @@ from the normalizer. -/
 @[simp]
 lemma normalizerQuotientLift_comp_mk (H : Subgroup G)
     (φ : _root_.Subgroup.normalizer (H : Set G) →* M)
-    (hφ : H.subgroupOf (_root_.Subgroup.normalizer (H : Set G)) ≤ φ.ker) :
+    (hφ : ∀ g : _root_.Subgroup.normalizer (H : Set G), (g : G) ∈ H → φ g = 1) :
     (normalizerQuotientLift H φ hφ).comp (normalizerQuotientMk H) = φ :=
   rfl
 
@@ -128,21 +138,34 @@ lemma normalizerQuotientLift_comp_mk (H : Subgroup G)
 surjective. -/
 lemma normalizerQuotientLift_surjective_of_surjective (H : Subgroup G)
     (φ : _root_.Subgroup.normalizer (H : Set G) →* M)
-    (hφ : H.subgroupOf (_root_.Subgroup.normalizer (H : Set G)) ≤ φ.ker)
+    (hφ : ∀ g : _root_.Subgroup.normalizer (H : Set G), (g : G) ∈ H → φ g = 1)
     (hφsurj : Function.Surjective φ) :
     Function.Surjective (normalizerQuotientLift H φ hφ) :=
   QuotientGroup.lift_surjective_of_surjective
-    (H.subgroupOf (_root_.Subgroup.normalizer (H : Set G))) φ hφsurj hφ
+    (H.subgroupOf (_root_.Subgroup.normalizer (H : Set G))) φ hφsurj (by
+      intro g hg
+      exact hφ g hg)
 
 /-- A lift from `N(H) / H` is injective exactly when the only normalizer elements killed by
 the original homomorphism are the elements of `H`. -/
 lemma normalizerQuotientLift_injective_iff (H : Subgroup G)
     (φ : _root_.Subgroup.normalizer (H : Set G) →* M)
-    (hφ : H.subgroupOf (_root_.Subgroup.normalizer (H : Set G)) ≤ φ.ker) :
+    (hφ : ∀ g : _root_.Subgroup.normalizer (H : Set G), (g : G) ∈ H → φ g = 1) :
     Function.Injective (normalizerQuotientLift H φ hφ) ↔
-      H.subgroupOf (_root_.Subgroup.normalizer (H : Set G)) = φ.ker :=
-  QuotientGroup.injective_lift_iff
-    (H.subgroupOf (_root_.Subgroup.normalizer (H : Set G))) φ hφ
+      ∀ g : _root_.Subgroup.normalizer (H : Set G), φ g = 1 ↔ (g : G) ∈ H := by
+  rw [QuotientGroup.injective_lift_iff]
+  · constructor
+    · intro hker g
+      constructor
+      · intro hg
+        have : g ∈ H.subgroupOf (_root_.Subgroup.normalizer (H : Set G)) := by
+          rw [hker]
+          exact hg
+        exact this
+      · exact hφ g
+    · intro hker
+      ext g
+      exact (hker g).symm
 
 /-- The quotient equality criterion for representatives in the normalizer, stated in the
 ambient group `G`. -/

--- a/TauCeti/Algebra/Group/NormalizerQuotient.lean
+++ b/TauCeti/Algebra/Group/NormalizerQuotient.lean
@@ -81,6 +81,19 @@ lemma normalizerQuotientMk_ker (H : Subgroup G) :
   exact QuotientGroup.ker_mk'
     (N := H.subgroupOf (_root_.Subgroup.normalizer (H : Set G)))
 
+/-- Every element of `N(H) / H` is represented by an element of the normalizer. -/
+lemma normalizerQuotientMk_surjective (H : Subgroup G) :
+    Function.Surjective (normalizerQuotientMk H) :=
+  QuotientGroup.mk'_surjective
+    (H.subgroupOf (_root_.Subgroup.normalizer (H : Set G)))
+
+/-- The canonical map `N(H) →* N(H) / H` has full range. -/
+@[simp]
+lemma normalizerQuotientMk_range (H : Subgroup G) :
+    (normalizerQuotientMk H).range = ⊤ :=
+  QuotientGroup.range_mk'
+    (N := H.subgroupOf (_root_.Subgroup.normalizer (H : Set G)))
+
 /-- The quotient equality criterion for representatives in the normalizer, stated in the
 ambient group `G`. -/
 lemma normalizerQuotientMk_eq_iff_div_mem (H : Subgroup G)
@@ -106,25 +119,6 @@ lemma normalizerQuotientMk_eq_iff_exists_mul (H : Subgroup G)
 section Normal
 
 variable (H : Subgroup G) [H.Normal]
-
-/-- When `H` is normal in `G`, every element of `G` lies in the normalizer of `H`. -/
-abbrev toNormalizerOfNormal : G →* _root_.Subgroup.normalizer (H : Set G) where
-  toFun g := ⟨g, by simp [_root_.Subgroup.normalizer_eq_top (H := H)]⟩
-  map_one' := rfl
-  map_mul' _ _ := rfl
-
-/-- The coercion of `toNormalizerOfNormal` is the identity on points. -/
-@[simp]
-lemma toNormalizerOfNormal_apply_coe (g : G) :
-    (toNormalizerOfNormal H g : G) = g :=
-  rfl
-
-/-- Under normality, `toNormalizerOfNormal` is surjective because the normalizer is all of
-`G`. -/
-lemma toNormalizerOfNormal_surjective :
-    Function.Surjective (toNormalizerOfNormal H) := by
-  intro g
-  exact ⟨g, Subtype.ext rfl⟩
 
 /-- When `H` is normal in `G`, the normalizer quotient maps naturally to the ordinary quotient
 `G / H` by forgetting that representatives lie in the normalizer. -/
@@ -183,7 +177,7 @@ corresponding representative in the normalizer quotient. -/
 @[simp]
 lemma normalizerQuotientEquivQuotientOfNormal_symm_mk (g : G) :
     (normalizerQuotientEquivQuotientOfNormal H).symm (QuotientGroup.mk' H g) =
-      normalizerQuotientMk H (toNormalizerOfNormal H g) :=
+      normalizerQuotientMk H ⟨g, by simp [_root_.Subgroup.normalizer_eq_top (H := H)]⟩ :=
   rfl
 
 end Normal

--- a/TauCeti/AlgebraicTopology/UniversalCover/Deck/NormalizerQuotient.lean
+++ b/TauCeti/AlgebraicTopology/UniversalCover/Deck/NormalizerQuotient.lean
@@ -1,0 +1,206 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+module
+
+public import Mathlib.GroupTheory.QuotientGroup.Basic
+
+/-!
+# The normalizer quotient of a subgroup
+
+This file packages the algebraic quotient `N(H) / H`, where `N(H)` is the normalizer of a
+subgroup `H ≤ G`. This is the group that occurs in the universal-covers roadmap when the
+deck group of the connected cover associated to `H ≤ π₁(X, x₀)` is identified with
+`N(H) / H`.
+
+The construction is deliberately only a thin local API around Mathlib's `Subgroup.normalizer`,
+`Subgroup.subgroupOf`, and quotient groups. Mathlib already proves that `H` is normal in its
+normalizer; this file gives the quotient a stable name and records its canonical quotient map,
+kernel, equality criterion, and the comparison with `G / H` in the normal case.
+
+## Main declarations
+
+* `TauCeti.Subgroup.normalizerQuotient`: the quotient `N(H) / H`.
+* `TauCeti.Subgroup.normalizerQuotientMk`: the canonical map `N(H) →* N(H) / H`.
+* `TauCeti.Subgroup.normalizerQuotientToQuotientOfNormal`: when `H` is normal in `G`,
+  the natural map `N(H) / H →* G / H`.
+* `TauCeti.Subgroup.normalizerQuotientEquivQuotientOfNormal`: when `H` is normal in `G`,
+  the normalizer quotient is canonically isomorphic to `G / H`.
+
+## References
+
+This supplies the algebraic normalizer-quotient prerequisite named in
+`TauCetiRoadmap/UniversalCovers/README.md`, Stage 2: for the cover associated to
+`H ≤ π₁(X, x₀)`, the deck group is `N(H) / H`, and in the regular case `H ◁ π₁(X, x₀)`
+this becomes `π₁(X, x₀) / H`.
+-/
+
+public section
+
+namespace TauCeti
+
+namespace Subgroup
+
+variable {G : Type*} [Group G]
+
+/-- The normalizer of a subgroup, as a subgroup of the ambient group. Mathlib's
+`Subgroup.normalizer` is stated for a set, so this abbreviation fixes the coercion for the
+normalizer quotient API below. -/
+abbrev subgroupNormalizer (H : Subgroup G) : Subgroup G :=
+  _root_.Subgroup.normalizer (H : Set G)
+
+/-- The normalizer quotient `N(H) / H` of a subgroup `H ≤ G`. Here `H` is viewed as a normal
+subgroup of its normalizer, using Mathlib's `Subgroup.normal_in_normalizer` instance. -/
+abbrev normalizerQuotient (H : Subgroup G) : Type _ :=
+  subgroupNormalizer H ⧸ H.subgroupOf (subgroupNormalizer H)
+
+/-- The canonical quotient map from the normalizer of `H` to `N(H) / H`. -/
+@[expose] def normalizerQuotientMk (H : Subgroup G) :
+    subgroupNormalizer H →* normalizerQuotient H :=
+  QuotientGroup.mk' (H.subgroupOf (subgroupNormalizer H))
+
+/-- The canonical quotient map evaluates as the quotient-group constructor. -/
+@[simp]
+lemma normalizerQuotientMk_apply (H : Subgroup G) (g : subgroupNormalizer H) :
+    normalizerQuotientMk H g = (g : normalizerQuotient H) :=
+  rfl
+
+/-- The canonical quotient map to `N(H) / H` is surjective. -/
+lemma normalizerQuotientMk_surjective (H : Subgroup G) :
+    Function.Surjective (normalizerQuotientMk H) :=
+  QuotientGroup.mk'_surjective (H.subgroupOf (subgroupNormalizer H))
+
+/-- The kernel of the canonical quotient map `N(H) →* N(H) / H` is `H`, viewed as a
+subgroup of its normalizer. -/
+@[simp]
+lemma normalizerQuotientMk_ker (H : Subgroup G) :
+    MonoidHom.ker (normalizerQuotientMk H) = H.subgroupOf (subgroupNormalizer H) :=
+  QuotientGroup.ker_mk' (H.subgroupOf (subgroupNormalizer H))
+
+/-- A normalizer element maps to the identity in `N(H) / H` exactly when its underlying
+element of `G` lies in `H`. -/
+@[simp]
+lemma normalizerQuotientMk_eq_one_iff (H : Subgroup G) (g : subgroupNormalizer H) :
+    normalizerQuotientMk H g = 1 ↔ (g : G) ∈ H := by
+  rw [← MonoidHom.mem_ker, normalizerQuotientMk_ker]
+  rfl
+
+/-- Two elements of the normalizer have the same image in `N(H) / H` exactly when their
+quotient lies in `H`. -/
+lemma normalizerQuotientMk_eq_iff (H : Subgroup G) (g k : subgroupNormalizer H) :
+    normalizerQuotientMk H g = normalizerQuotientMk H k ↔ (g : G) / (k : G) ∈ H := by
+  simpa [normalizerQuotientMk, normalizerQuotient, _root_.Subgroup.mem_subgroupOf]
+    using QuotientGroup.eq_iff_div_mem (N := H.subgroupOf (subgroupNormalizer H))
+      (x := g) (y := k)
+
+/-- A version of the equality criterion using multiplication by an element of `H`. -/
+lemma normalizerQuotientMk_eq_iff_exists_mul (H : Subgroup G) (g k : subgroupNormalizer H) :
+    normalizerQuotientMk H g = normalizerQuotientMk H k ↔
+      ∃ h ∈ H, h * (k : G) = g := by
+  rw [normalizerQuotientMk_eq_iff]
+  constructor
+  · intro hgk
+    exact ⟨(g : G) / k, hgk, by simp [div_eq_mul_inv, mul_assoc]⟩
+  · rintro ⟨h, hh, hg⟩
+    rw [← hg]
+    simpa [div_eq_mul_inv, mul_assoc] using hh
+
+section Normal
+
+variable (H : Subgroup G) [H.Normal]
+
+/-- When `H` is normal in `G`, every element of `G` lies in the normalizer of `H`. -/
+@[expose] def toNormalizerOfNormal : G →* subgroupNormalizer H where
+  toFun g := ⟨g, by simp [subgroupNormalizer, _root_.Subgroup.normalizer_eq_top (H := H)]⟩
+  map_one' := rfl
+  map_mul' _ _ := rfl
+
+/-- The coercion of `toNormalizerOfNormal` is the identity on points. -/
+@[simp]
+lemma toNormalizerOfNormal_apply_coe (g : G) :
+    (toNormalizerOfNormal H g : G) = g :=
+  rfl
+
+/-- Under normality, `toNormalizerOfNormal` is surjective because the normalizer is all of
+`G`. -/
+lemma toNormalizerOfNormal_surjective :
+    Function.Surjective (toNormalizerOfNormal H) := by
+  intro g
+  exact ⟨g, Subtype.ext rfl⟩
+
+/-- When `H` is normal in `G`, the normalizer quotient maps naturally to the ordinary quotient
+`G / H` by forgetting that representatives lie in the normalizer. -/
+@[expose] def normalizerQuotientToQuotientOfNormal :
+    normalizerQuotient H →* G ⧸ H :=
+  QuotientGroup.lift (H.subgroupOf (subgroupNormalizer H))
+    ((QuotientGroup.mk' H).comp (subgroupNormalizer H).subtype)
+    (by
+      intro g hg
+      rw [MonoidHom.mem_ker]
+      exact (QuotientGroup.eq_one_iff (N := H) (x := (g : G))).mpr hg)
+
+/-- The comparison map from `N(H) / H` to `G / H` sends a normalizer representative to its
+ordinary quotient class. -/
+@[simp]
+lemma normalizerQuotientToQuotientOfNormal_mk (g : subgroupNormalizer H) :
+    normalizerQuotientToQuotientOfNormal H (normalizerQuotientMk H g) =
+      QuotientGroup.mk' H (g : G) :=
+  rfl
+
+/-- The ordinary quotient map `G →* G / H`, factored through the normalizer under normality,
+agrees with the comparison map from `N(H) / H`. -/
+@[simp]
+lemma normalizerQuotientToQuotientOfNormal_comp_mk :
+    (normalizerQuotientToQuotientOfNormal H).comp (normalizerQuotientMk H) =
+      (QuotientGroup.mk' H).comp (subgroupNormalizer H).subtype :=
+  rfl
+
+/-- The comparison map `N(H) / H →* G / H` is surjective when `H` is normal in `G`. -/
+lemma normalizerQuotientToQuotientOfNormal_surjective :
+    Function.Surjective (normalizerQuotientToQuotientOfNormal H) := by
+  intro q
+  induction q using Quotient.inductionOn' with
+  | h g =>
+      refine ⟨normalizerQuotientMk H (toNormalizerOfNormal H g), ?_⟩
+      rw [normalizerQuotientToQuotientOfNormal_mk]
+      rfl
+
+/-- The comparison map `N(H) / H →* G / H` is injective when `H` is normal in `G`. -/
+lemma normalizerQuotientToQuotientOfNormal_injective :
+    Function.Injective (normalizerQuotientToQuotientOfNormal H) := by
+  intro q r hqr
+  induction q using Quotient.inductionOn' with
+  | h g =>
+      induction r using Quotient.inductionOn' with
+      | h k =>
+          change normalizerQuotientMk H g = normalizerQuotientMk H k
+          apply (normalizerQuotientMk_eq_iff H g k).mpr
+          change (normalizerQuotientToQuotientOfNormal H) (normalizerQuotientMk H g) =
+              (normalizerQuotientToQuotientOfNormal H) (normalizerQuotientMk H k) at hqr
+          rw [normalizerQuotientToQuotientOfNormal_mk,
+            normalizerQuotientToQuotientOfNormal_mk] at hqr
+          exact (QuotientGroup.eq_iff_div_mem (N := H) (x := (g : G)) (y := (k : G))).mp
+            hqr
+
+/-- If `H` is normal in `G`, then `N(H) / H` is canonically isomorphic to `G / H`. This is
+the algebraic form of the regular-cover specialization from `N(H) / H` to `π₁(X, x₀) / H`. -/
+@[expose] noncomputable def normalizerQuotientEquivQuotientOfNormal :
+    normalizerQuotient H ≃* G ⧸ H :=
+  MulEquiv.ofBijective (normalizerQuotientToQuotientOfNormal H)
+    ⟨normalizerQuotientToQuotientOfNormal_injective H,
+      normalizerQuotientToQuotientOfNormal_surjective H⟩
+
+/-- The normal-case equivalence sends a normalizer representative to its ordinary quotient
+class in `G / H`. -/
+@[simp]
+lemma normalizerQuotientEquivQuotientOfNormal_mk (g : subgroupNormalizer H) :
+    normalizerQuotientEquivQuotientOfNormal H (normalizerQuotientMk H g) =
+      QuotientGroup.mk' H (g : G) :=
+  rfl
+
+end Normal
+
+end Subgroup
+
+end TauCeti

--- a/TauCeti/AlgebraicTopology/UniversalCover/Deck/NormalizerQuotient.lean
+++ b/TauCeti/AlgebraicTopology/UniversalCover/Deck/NormalizerQuotient.lean
@@ -17,7 +17,8 @@ deck group of the connected cover associated to `H ≤ π₁(X, x₀)` is identi
 The construction is deliberately only a thin local API around Mathlib's `Subgroup.normalizer`,
 `Subgroup.subgroupOf`, and quotient groups. Mathlib already proves that `H` is normal in its
 normalizer; this file gives the quotient a stable name and records its canonical quotient map,
-kernel, equality criterion, and the comparison with `G / H` in the normal case.
+an equality criterion by multiplication by an element of `H`, and the comparison with `G / H`
+in the normal case.
 
 ## Main declarations
 
@@ -44,61 +45,43 @@ namespace Subgroup
 
 variable {G : Type*} [Group G]
 
-/-- The normalizer of a subgroup, as a subgroup of the ambient group. Mathlib's
-`Subgroup.normalizer` is stated for a set, so this abbreviation fixes the coercion for the
-normalizer quotient API below. -/
-abbrev subgroupNormalizer (H : Subgroup G) : Subgroup G :=
-  _root_.Subgroup.normalizer (H : Set G)
-
 /-- The normalizer quotient `N(H) / H` of a subgroup `H ≤ G`. Here `H` is viewed as a normal
 subgroup of its normalizer, using Mathlib's `Subgroup.normal_in_normalizer` instance. -/
 abbrev normalizerQuotient (H : Subgroup G) : Type _ :=
-  subgroupNormalizer H ⧸ H.subgroupOf (subgroupNormalizer H)
+  _root_.Subgroup.normalizer (H : Set G) ⧸
+    H.subgroupOf (_root_.Subgroup.normalizer (H : Set G))
 
 /-- The canonical quotient map from the normalizer of `H` to `N(H) / H`. -/
 @[expose] def normalizerQuotientMk (H : Subgroup G) :
-    subgroupNormalizer H →* normalizerQuotient H :=
-  QuotientGroup.mk' (H.subgroupOf (subgroupNormalizer H))
+    _root_.Subgroup.normalizer (H : Set G) →* normalizerQuotient H :=
+  QuotientGroup.mk' (H.subgroupOf (_root_.Subgroup.normalizer (H : Set G)))
 
 /-- The canonical quotient map evaluates as the quotient-group constructor. -/
 @[simp]
-lemma normalizerQuotientMk_apply (H : Subgroup G) (g : subgroupNormalizer H) :
+lemma normalizerQuotientMk_apply (H : Subgroup G)
+    (g : _root_.Subgroup.normalizer (H : Set G)) :
     normalizerQuotientMk H g = (g : normalizerQuotient H) :=
   rfl
-
-/-- The canonical quotient map to `N(H) / H` is surjective. -/
-lemma normalizerQuotientMk_surjective (H : Subgroup G) :
-    Function.Surjective (normalizerQuotientMk H) :=
-  QuotientGroup.mk'_surjective (H.subgroupOf (subgroupNormalizer H))
-
-/-- The kernel of the canonical quotient map `N(H) →* N(H) / H` is `H`, viewed as a
-subgroup of its normalizer. -/
-@[simp]
-lemma normalizerQuotientMk_ker (H : Subgroup G) :
-    MonoidHom.ker (normalizerQuotientMk H) = H.subgroupOf (subgroupNormalizer H) :=
-  QuotientGroup.ker_mk' (H.subgroupOf (subgroupNormalizer H))
 
 /-- A normalizer element maps to the identity in `N(H) / H` exactly when its underlying
 element of `G` lies in `H`. -/
 @[simp]
-lemma normalizerQuotientMk_eq_one_iff (H : Subgroup G) (g : subgroupNormalizer H) :
+lemma normalizerQuotientMk_eq_one_iff (H : Subgroup G)
+    (g : _root_.Subgroup.normalizer (H : Set G)) :
     normalizerQuotientMk H g = 1 ↔ (g : G) ∈ H := by
-  rw [← MonoidHom.mem_ker, normalizerQuotientMk_ker]
-  rfl
-
-/-- Two elements of the normalizer have the same image in `N(H) / H` exactly when their
-quotient lies in `H`. -/
-lemma normalizerQuotientMk_eq_iff (H : Subgroup G) (g k : subgroupNormalizer H) :
-    normalizerQuotientMk H g = normalizerQuotientMk H k ↔ (g : G) / (k : G) ∈ H := by
-  simpa [normalizerQuotientMk, normalizerQuotient, _root_.Subgroup.mem_subgroupOf]
-    using QuotientGroup.eq_iff_div_mem (N := H.subgroupOf (subgroupNormalizer H))
-      (x := g) (y := k)
+  simp [normalizerQuotientMk, normalizerQuotient, _root_.Subgroup.mem_subgroupOf,
+    QuotientGroup.eq_one_iff]
 
 /-- A version of the equality criterion using multiplication by an element of `H`. -/
-lemma normalizerQuotientMk_eq_iff_exists_mul (H : Subgroup G) (g k : subgroupNormalizer H) :
+lemma normalizerQuotientMk_eq_iff_exists_mul (H : Subgroup G)
+    (g k : _root_.Subgroup.normalizer (H : Set G)) :
     normalizerQuotientMk H g = normalizerQuotientMk H k ↔
       ∃ h ∈ H, h * (k : G) = g := by
-  rw [normalizerQuotientMk_eq_iff]
+  rw [show normalizerQuotientMk H g = normalizerQuotientMk H k ↔
+      (g : G) / (k : G) ∈ H by
+    simpa [normalizerQuotientMk, normalizerQuotient, _root_.Subgroup.mem_subgroupOf]
+      using QuotientGroup.eq_iff_div_mem
+        (N := H.subgroupOf (_root_.Subgroup.normalizer (H : Set G))) (x := g) (y := k)]
   constructor
   · intro hgk
     exact ⟨(g : G) / k, hgk, by simp [div_eq_mul_inv, mul_assoc]⟩
@@ -111,8 +94,8 @@ section Normal
 variable (H : Subgroup G) [H.Normal]
 
 /-- When `H` is normal in `G`, every element of `G` lies in the normalizer of `H`. -/
-@[expose] def toNormalizerOfNormal : G →* subgroupNormalizer H where
-  toFun g := ⟨g, by simp [subgroupNormalizer, _root_.Subgroup.normalizer_eq_top (H := H)]⟩
+@[expose] def toNormalizerOfNormal : G →* _root_.Subgroup.normalizer (H : Set G) where
+  toFun g := ⟨g, by simp [_root_.Subgroup.normalizer_eq_top (H := H)]⟩
   map_one' := rfl
   map_mul' _ _ := rfl
 
@@ -133,17 +116,17 @@ lemma toNormalizerOfNormal_surjective :
 `G / H` by forgetting that representatives lie in the normalizer. -/
 @[expose] def normalizerQuotientToQuotientOfNormal :
     normalizerQuotient H →* G ⧸ H :=
-  QuotientGroup.lift (H.subgroupOf (subgroupNormalizer H))
-    ((QuotientGroup.mk' H).comp (subgroupNormalizer H).subtype)
+  QuotientGroup.map (H.subgroupOf (_root_.Subgroup.normalizer (H : Set G))) H
+    (_root_.Subgroup.normalizer (H : Set G)).subtype
     (by
       intro g hg
-      rw [MonoidHom.mem_ker]
-      exact (QuotientGroup.eq_one_iff (N := H) (x := (g : G))).mpr hg)
+      exact hg)
 
 /-- The comparison map from `N(H) / H` to `G / H` sends a normalizer representative to its
 ordinary quotient class. -/
 @[simp]
-lemma normalizerQuotientToQuotientOfNormal_mk (g : subgroupNormalizer H) :
+lemma normalizerQuotientToQuotientOfNormal_mk
+    (g : _root_.Subgroup.normalizer (H : Set G)) :
     normalizerQuotientToQuotientOfNormal H (normalizerQuotientMk H g) =
       QuotientGroup.mk' H (g : G) :=
   rfl
@@ -153,7 +136,7 @@ agrees with the comparison map from `N(H) / H`. -/
 @[simp]
 lemma normalizerQuotientToQuotientOfNormal_comp_mk :
     (normalizerQuotientToQuotientOfNormal H).comp (normalizerQuotientMk H) =
-      (QuotientGroup.mk' H).comp (subgroupNormalizer H).subtype :=
+      (QuotientGroup.mk' H).comp (_root_.Subgroup.normalizer (H : Set G)).subtype :=
   rfl
 
 /-- The comparison map `N(H) / H →* G / H` is surjective when `H` is normal in `G`. -/
@@ -175,13 +158,15 @@ lemma normalizerQuotientToQuotientOfNormal_injective :
       induction r using Quotient.inductionOn' with
       | h k =>
           change normalizerQuotientMk H g = normalizerQuotientMk H k
-          apply (normalizerQuotientMk_eq_iff H g k).mpr
+          apply (QuotientGroup.eq_iff_div_mem
+            (N := H.subgroupOf (_root_.Subgroup.normalizer (H : Set G))) (x := g)
+            (y := k)).mpr
           change (normalizerQuotientToQuotientOfNormal H) (normalizerQuotientMk H g) =
               (normalizerQuotientToQuotientOfNormal H) (normalizerQuotientMk H k) at hqr
           rw [normalizerQuotientToQuotientOfNormal_mk,
             normalizerQuotientToQuotientOfNormal_mk] at hqr
-          exact (QuotientGroup.eq_iff_div_mem (N := H) (x := (g : G)) (y := (k : G))).mp
-            hqr
+          simpa [_root_.Subgroup.mem_subgroupOf] using
+            (QuotientGroup.eq_iff_div_mem (N := H) (x := (g : G)) (y := (k : G))).mp hqr
 
 /-- If `H` is normal in `G`, then `N(H) / H` is canonically isomorphic to `G / H`. This is
 the algebraic form of the regular-cover specialization from `N(H) / H` to `π₁(X, x₀) / H`. -/
@@ -194,7 +179,8 @@ the algebraic form of the regular-cover specialization from `N(H) / H` to `π₁
 /-- The normal-case equivalence sends a normalizer representative to its ordinary quotient
 class in `G / H`. -/
 @[simp]
-lemma normalizerQuotientEquivQuotientOfNormal_mk (g : subgroupNormalizer H) :
+lemma normalizerQuotientEquivQuotientOfNormal_mk
+    (g : _root_.Subgroup.normalizer (H : Set G)) :
     normalizerQuotientEquivQuotientOfNormal H (normalizerQuotientMk H g) =
       QuotientGroup.mk' H (g : G) :=
   rfl


### PR DESCRIPTION
This PR packages the algebraic normalizer quotient `N(H) / H` used by the UniversalCovers regular-cover bookkeeping. It adds a local `TauCeti.Subgroup.normalizerQuotient` API, the canonical quotient map from the normalizer, kernel and equality criteria, and the normal-subgroup comparison identifying `N(H) / H` with `G / H` when `H` is normal.

It advances `TauCetiRoadmap/UniversalCovers/README.md`, Stage 2, item 8, specifically the milestone that for the cover attached to `H` the deck group is `N(H)/H`, and that in the regular case `H ◁ π₁(X, x₀)` the deck group is `π₁(X, x₀)/H`. I chose it as the lowest-hanging distinct UniversalCovers prerequisite after checking open and recently merged PRs: the Mathlib lifting criterion wrapper has already landed, and Tau Ceti already has deck actions, fibre transitivity, quotient-covering, and regular-cover/fundamental-group comparison APIs, while the named normalizer-quotient algebra package was still missing.

No Mathlib infrastructure is vendored. The implementation reuses Mathlib's `Subgroup.normalizer`, `Subgroup.normal_in_normalizer`, `Subgroup.subgroupOf`, and `QuotientGroup` API.

`lake exe cache get` completed with `No files to download` and `Already decompressed 8586 file(s)`. `lake build` completed with `Build completed successfully (4223 jobs).` `lake exe axioms` completed with `axioms: audited 5129 TauCeti declaration(s); all within the allowlist [propext, Classical.choice, Quot.sound].`

<!--tauceti-target:v1 {"focus":"UniversalCovers","id":"normalizer-quotient-deck-group"}-->

🤖 Prepared with Codex
