### PR TITLE
feat: add ambient isotopy naturality

### DIFF
--- a/TauCeti/Topology/Homotopy/AmbientIsotopicNaturality.lean
+++ b/TauCeti/Topology/Homotopy/AmbientIsotopicNaturality.lean
@@ -60,13 +60,6 @@ theorem postcomp_homeomorph (hfg : AmbientIsotopic f g) (h : Y ≃ₜ Z) :
   have hx : Φ.final (f x) = g x := congr_fun (congrArg DFunLike.coe hΦ) x
   simpa [AmbientIsotopy.final_apply] using hx
 
-/-- Transporting ambient-isotopic maps across a homeomorphism of ambient spaces. This is the same
-statement as `AmbientIsotopic.postcomp_homeomorph`, named from the witnessing ambient-isotopy
-construction `AmbientIsotopy.transport`. -/
-theorem transport (hfg : AmbientIsotopic f g) (h : Y ≃ₜ Z) :
-    AmbientIsotopic ((h : C(Y, Z)).comp f) ((h : C(Y, Z)).comp g) :=
-  hfg.postcomp_homeomorph h
-
 /-- The two-sided coordinate-change form: precompose the source by any continuous map and
 postcompose the ambient space by a homeomorphism. -/
 theorem postcomp_homeomorph_precomp (hfg : AmbientIsotopic f g) (h : Y ≃ₜ Z) (e : C(W, X)) :

--- a/TauCeti/Topology/Homotopy/AmbientIsotopicNaturality.lean
+++ b/TauCeti/Topology/Homotopy/AmbientIsotopicNaturality.lean
@@ -58,26 +58,13 @@ theorem postcomp_homeomorph (hfg : AmbientIsotopic f g) (h : Y ≃ₜ Z) :
   refine ⟨Φ.transport h, ?_⟩
   ext x
   have hx : Φ.final (f x) = g x := congr_fun (congrArg DFunLike.coe hΦ) x
-  simpa [AmbientIsotopy.final_apply] using hx
+  simpa [AmbientIsotopy.final_transport] using congrArg h hx
 
 /-- The two-sided coordinate-change form: precompose the source by any continuous map and
 postcompose the ambient space by a homeomorphism. -/
 theorem postcomp_homeomorph_precomp (hfg : AmbientIsotopic f g) (h : Y ≃ₜ Z) (e : C(W, X)) :
     AmbientIsotopic ((h : C(Y, Z)).comp (f.comp e)) ((h : C(Y, Z)).comp (g.comp e)) :=
   (hfg.precomp e).postcomp_homeomorph h
-
-/-- Ambient isotopy survives precomposition by a homeomorphism of source spaces. This is the
-homeomorphism special case of `AmbientIsotopic.precomp`; no embedding hypothesis is needed because
-ambient isotopy acts on the codomain. -/
-theorem precomp_homeomorph (hfg : AmbientIsotopic f g) (e : W ≃ₜ X) :
-    AmbientIsotopic (f.comp (e : C(W, X))) (g.comp (e : C(W, X))) :=
-  hfg.precomp (e : C(W, X))
-
-/-- Changing both source and ambient coordinates by homeomorphisms preserves ambient isotopy. -/
-theorem homeomorph_precomp_postcomp (hfg : AmbientIsotopic f g) (h : Y ≃ₜ Z) (e : W ≃ₜ X) :
-    AmbientIsotopic ((h : C(Y, Z)).comp (f.comp (e : C(W, X))))
-      ((h : C(Y, Z)).comp (g.comp (e : C(W, X)))) :=
-  hfg.postcomp_homeomorph_precomp h (e : C(W, X))
 
 end AmbientIsotopic
 

--- a/TauCeti/Topology/Homotopy/AmbientIsotopicNaturality.lean
+++ b/TauCeti/Topology/Homotopy/AmbientIsotopicNaturality.lean
@@ -1,0 +1,91 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+module
+
+public import TauCeti.Topology.Homotopy.AmbientIsotopic
+public import TauCeti.Topology.Homotopy.AmbientIsotopyConj
+
+/-!
+# Naturality of ambient isotopy under coordinate changes
+
+The geometric-topology roadmap asks for isotopy and ambient isotopy to be defined once, in full
+generality, before specialising to locally flat embeddings, diffeotopies, knots, and concordance.
+`TauCeti.AmbientIsotopic` is the general point-set ambient-isotopy relation on continuous maps,
+and `TauCeti.AmbientIsotopy.transport` transports a witnessing ambient isotopy across a
+homeomorphism of ambient spaces. This file records the corresponding relation-level API.
+
+Precomposition is available for any continuous map of source spaces, because an ambient isotopy
+acts only on the codomain. Postcomposition is stated for a homeomorphism of ambient spaces; the
+witness is the transported ambient isotopy.
+
+## Main results
+
+* `TauCeti.AmbientIsotopic.precomp`: ambient isotopy survives precomposition by a continuous map.
+* `TauCeti.AmbientIsotopic.postcomp_homeomorph`: ambient isotopy survives postcomposition by a
+  homeomorphism of ambient spaces.
+* `TauCeti.AmbientIsotopic.postcomp_homeomorph_precomp`: the combined change-of-coordinates form.
+-/
+
+public section
+
+namespace TauCeti
+
+open unitInterval ContinuousMap Topology
+
+variable {W X Y Z : Type*} [TopologicalSpace W] [TopologicalSpace X] [TopologicalSpace Y]
+  [TopologicalSpace Z]
+
+namespace AmbientIsotopic
+
+variable {f g : C(X, Y)}
+
+/-- Ambient isotopy survives precomposition by any continuous source map. If an ambient isotopy
+of `Y` carries `f` to `g`, the same ambient isotopy carries `f ∘ e` to `g ∘ e`. -/
+theorem precomp (hfg : AmbientIsotopic f g) (e : C(W, X)) :
+    AmbientIsotopic (f.comp e) (g.comp e) := by
+  obtain ⟨Φ, hΦ⟩ := hfg
+  refine ⟨Φ, ?_⟩
+  ext w
+  exact congr_fun (congrArg DFunLike.coe hΦ) (e w)
+
+/-- Ambient isotopy survives postcomposition by a homeomorphism of ambient spaces. The witnessing
+ambient isotopy is obtained by transporting the original one across the homeomorphism. -/
+theorem postcomp_homeomorph (hfg : AmbientIsotopic f g) (h : Y ≃ₜ Z) :
+    AmbientIsotopic ((h : C(Y, Z)).comp f) ((h : C(Y, Z)).comp g) := by
+  obtain ⟨Φ, hΦ⟩ := hfg
+  refine ⟨Φ.transport h, ?_⟩
+  ext x
+  have hx : Φ.final (f x) = g x := congr_fun (congrArg DFunLike.coe hΦ) x
+  simpa [AmbientIsotopy.final_apply] using hx
+
+/-- Transporting ambient-isotopic maps across a homeomorphism of ambient spaces. This is the same
+statement as `AmbientIsotopic.postcomp_homeomorph`, named from the witnessing ambient-isotopy
+construction `AmbientIsotopy.transport`. -/
+theorem transport (hfg : AmbientIsotopic f g) (h : Y ≃ₜ Z) :
+    AmbientIsotopic ((h : C(Y, Z)).comp f) ((h : C(Y, Z)).comp g) :=
+  hfg.postcomp_homeomorph h
+
+/-- The two-sided coordinate-change form: precompose the source by any continuous map and
+postcompose the ambient space by a homeomorphism. -/
+theorem postcomp_homeomorph_precomp (hfg : AmbientIsotopic f g) (h : Y ≃ₜ Z) (e : C(W, X)) :
+    AmbientIsotopic ((h : C(Y, Z)).comp (f.comp e)) ((h : C(Y, Z)).comp (g.comp e)) :=
+  (hfg.precomp e).postcomp_homeomorph h
+
+/-- Ambient isotopy survives precomposition by a homeomorphism of source spaces. This is the
+homeomorphism special case of `AmbientIsotopic.precomp`; no embedding hypothesis is needed because
+ambient isotopy acts on the codomain. -/
+theorem precomp_homeomorph (hfg : AmbientIsotopic f g) (e : W ≃ₜ X) :
+    AmbientIsotopic (f.comp (e : C(W, X))) (g.comp (e : C(W, X))) :=
+  hfg.precomp (e : C(W, X))
+
+/-- Changing both source and ambient coordinates by homeomorphisms preserves ambient isotopy. -/
+theorem homeomorph_precomp_postcomp (hfg : AmbientIsotopic f g) (h : Y ≃ₜ Z) (e : W ≃ₜ X) :
+    AmbientIsotopic ((h : C(Y, Z)).comp (f.comp (e : C(W, X))))
+      ((h : C(Y, Z)).comp (g.comp (e : C(W, X)))) :=
+  hfg.postcomp_homeomorph_precomp h (e : C(W, X))
+
+end AmbientIsotopic
+
+end TauCeti


### PR DESCRIPTION
This PR records relation-level naturality for the general ambient-isotopy relation: ambient isotopic maps remain ambient isotopic after precomposition by any continuous source map, after changing ambient coordinates by a homeomorphism, and after doing both at once.

It advances `TauCetiRoadmap/GeometricTopology/README.md`, the Encoding conventions item “Isotopy is defined generally, then specialised,” specifically the requirement that the same general `Isotopic`/ambient-isotopy substrate underlie locally flat isotopy, diffeotopies, and concordance rather than being redefined in each later layer. I chose this as the lowest-hanging distinct GeometricTopology prerequisite after checking open and recently merged PRs: ambient isotopies already have transport across ambient homeomorphisms, and bundled smooth embeddings already have an ambient-isotopy relation, while the relation-level coordinate-change API for the general point-set relation was still missing.

No Mathlib infrastructure is vendored. The implementation reuses Tau Ceti’s existing `AmbientIsotopic` relation and `AmbientIsotopy.transport` construction, together with Mathlib’s `ContinuousMap` and `Homeomorph` coercions.

`lake exe cache get` completed with `No files to download` and `Already decompressed 8586 file(s)`. `lake build` completed with `Build completed successfully (4239 jobs).` `lake exe axioms` completed with `axioms: audited 5171 TauCeti declaration(s); all within the allowlist [propext, Classical.choice, Quot.sound].`

<!--tauceti-target:v1 {"focus":"GeometricTopology","id":"ambient-isotopic-naturality"}-->

🤖 Prepared with Codex
