### PR TITLE
feat: add exchangeability basics

### DIFF
--- a/TauCeti/Probability/Exchangeability/Basic.lean
+++ b/TauCeti/Probability/Exchangeability/Basic.lean
@@ -1,21 +1,26 @@
 module
 
-public import Mathlib.Probability.Process.FiniteDimensionalLaws
+public import Mathlib.MeasureTheory.Measure.Map
+public import Mathlib.MeasureTheory.MeasurableSpace.Constructions
+public import Mathlib.Order.Fin.Basic
+public import Mathlib.Tactic.Measurability
 
 /-!
 # Basic exchangeability definitions
 
-This file starts the Layer 0 exchangeability API: finite-dimensional block laws of a
-process, prefix laws, path laws, finite exchangeability, full exchangeability, and
-contractability.  The definitions are intentionally hypothesis-light; measurability
+This file starts the Layer 0 exchangeability API: indexed block laws of a process,
+prefix laws, path laws, finite exchangeability, full exchangeability, and
+contractability. The definitions are intentionally hypothesis-light; measurability
 hypotheses enter only in lemmas that compose `Measure.map`s.
 
 These declarations follow the roadmap signatures in
 `TauCetiRoadmap/Exchangeability/README.md` and
-`TauCetiRoadmap/Exchangeability/Targets.lean`, Layer 0.
+`TauCetiRoadmap/Exchangeability/Targets.lean`, Layer 0. They are adapted from the
+`cameronfreer/exchangeability` Layer 0 sources pinned at
+`e0532e59ceff23edab44dda9ab0655debbc9cc22`, with Tau Ceti API names and hypotheses.
 -/
 
-@[expose] public section
+public section
 
 noncomputable section
 
@@ -27,57 +32,69 @@ namespace Probability
 
 variable {Ω α β ι : Type*} [MeasurableSpace Ω] [MeasurableSpace α]
 
-/-- The finite-dimensional law of a process along an index selection `k`. -/
-def finiteBlockLaw (μ : Measure Ω) (X : ℕ → Ω → α) (k : ι → ℕ) : Measure (ι → α) :=
+/-- The law of a process along an indexed coordinate selection `k`.
+
+This is finite-dimensional when the index type `ι` is finite; `pathLaw` is the special case
+`ι = ℕ` and `k = id`. -/
+@[expose]
+def blockLaw (μ : Measure Ω) (X : ℕ → Ω → α) (k : ι → ℕ) : Measure (ι → α) :=
   μ.map fun ω i => X (k i) ω
 
 /-- The law of the first `n` coordinates of a process. -/
+@[expose]
 def prefixLaw (μ : Measure Ω) (X : ℕ → Ω → α) (n : ℕ) : Measure (Fin n → α) :=
-  finiteBlockLaw μ X fun i : Fin n => i.val
+  blockLaw μ X fun i : Fin n => i.val
 
 /-- The law of the whole process as a measure on path space. -/
+@[expose]
 def pathLaw (μ : Measure Ω) (X : ℕ → Ω → α) : Measure (ℕ → α) :=
-  finiteBlockLaw μ X id
+  blockLaw μ X id
 
 /-- Projection from path space to the first `n` coordinates. -/
+@[expose]
 def prefixProj (α : Type*) (n : ℕ) (x : ℕ → α) : Fin n → α :=
   fun i => x i.val
 
 /-- The left shift on one-sided path space. -/
+@[expose]
 def shift (α : Type*) (x : ℕ → α) : ℕ → α :=
   fun n => x (n + 1)
 
 /-- Finite exchangeability at `n`: the first `n` coordinates have permutation-invariant law. -/
+@[expose]
 def ExchangeableAt (μ : Measure Ω) (X : ℕ → Ω → α) (n : ℕ) : Prop :=
   ∀ σ : Equiv.Perm (Fin n),
-    finiteBlockLaw μ X (fun i : Fin n => (σ i).val) = prefixLaw μ X n
+    blockLaw μ X (fun i : Fin n => (σ i).val) = prefixLaw μ X n
 
 /-- Finite exchangeability at every length. -/
+@[expose]
 def Exchangeable (μ : Measure Ω) (X : ℕ → Ω → α) : Prop :=
   ∀ n, ExchangeableAt μ X n
 
 /-- Full exchangeability: the path law is invariant under every permutation of `ℕ`. -/
+@[expose]
 def FullyExchangeable (μ : Measure Ω) (X : ℕ → Ω → α) : Prop :=
-  ∀ π : Equiv.Perm ℕ, finiteBlockLaw μ X π = pathLaw μ X
+  ∀ π : Equiv.Perm ℕ, blockLaw μ X π = pathLaw μ X
 
 /-- Contractability, or spreadability: finite-dimensional laws are invariant under strictly
 increasing finite subsequences. -/
+@[expose]
 def Contractable (μ : Measure Ω) (X : ℕ → Ω → α) : Prop :=
-  ∀ (m : ℕ) (k : Fin m → ℕ), StrictMono k → finiteBlockLaw μ X k = prefixLaw μ X m
+  ∀ (m : ℕ) (k : Fin m → ℕ), StrictMono k → blockLaw μ X k = prefixLaw μ X m
 
 @[simp]
-theorem finiteBlockLaw_apply (μ : Measure Ω) (X : ℕ → Ω → α) (k : ι → ℕ) :
-    finiteBlockLaw μ X k = μ.map (fun ω i => X (k i) ω) :=
+theorem blockLaw_apply (μ : Measure Ω) (X : ℕ → Ω → α) (k : ι → ℕ) :
+    blockLaw μ X k = μ.map (fun ω i => X (k i) ω) :=
   rfl
 
 @[simp]
 theorem prefixLaw_apply (μ : Measure Ω) (X : ℕ → Ω → α) (n : ℕ) :
-    prefixLaw μ X n = finiteBlockLaw μ X (fun i : Fin n => i.val) :=
+    prefixLaw μ X n = blockLaw μ X (fun i : Fin n => i.val) :=
   rfl
 
 @[simp]
 theorem pathLaw_apply (μ : Measure Ω) (X : ℕ → Ω → α) :
-    pathLaw μ X = finiteBlockLaw μ X id :=
+    pathLaw μ X = blockLaw μ X id :=
   rfl
 
 omit [MeasurableSpace α] in
@@ -105,23 +122,24 @@ theorem measurable_shift : Measurable (shift α) := by
 theorem map_prefixProj_pathLaw (μ : Measure Ω) {X : ℕ → Ω → α}
     (hX : ∀ i, Measurable (X i)) (n : ℕ) :
     (pathLaw μ X).map (prefixProj α n) = prefixLaw μ X n := by
-  rw [pathLaw, prefixLaw, finiteBlockLaw, finiteBlockLaw]
+  rw [pathLaw, prefixLaw, blockLaw, blockLaw]
   rw [Measure.map_map]
   · rfl
   · exact measurable_prefixProj n
   · exact measurable_pi_lambda (fun ω => fun i => X i ω) fun i => hX i
 
 /-- A coordinatewise measurable map sends block laws to block laws. -/
-theorem map_finiteBlockLaw (μ : Measure Ω) {X : ℕ → Ω → α} (k : ι → ℕ)
-    {f : α → β} [MeasurableSpace β] (hf : Measurable f) (hX : ∀ i, Measurable (X i)) :
-    (finiteBlockLaw μ X k).map (fun x : ι → α => fun i => f (x i)) =
-      finiteBlockLaw μ (fun n ω => f (X n ω)) k := by
-  rw [finiteBlockLaw, finiteBlockLaw]
+theorem map_blockLaw (μ : Measure Ω) {X : ℕ → Ω → α} (k : ι → ℕ)
+    {f : α → β} [MeasurableSpace β] (hf : Measurable f)
+    (hXk : ∀ i : ι, Measurable (X (k i))) :
+    (blockLaw μ X k).map (fun x : ι → α => fun i => f (x i)) =
+      blockLaw μ (fun n ω => f (X n ω)) k := by
+  rw [blockLaw, blockLaw]
   rw [Measure.map_map]
   · rfl
   · exact measurable_pi_lambda (fun x : ι → α => fun i => f (x i)) fun i =>
       hf.comp (measurable_pi_apply i)
-  · exact measurable_pi_lambda (fun ω => fun i => X (k i) ω) fun i => hX (k i)
+  · exact measurable_pi_lambda (fun ω => fun i => X (k i) ω) hXk
 
 /-- A coordinatewise measurable map sends prefix laws to prefix laws. -/
 theorem map_prefixLaw (μ : Measure Ω) {X : ℕ → Ω → α}
@@ -129,7 +147,7 @@ theorem map_prefixLaw (μ : Measure Ω) {X : ℕ → Ω → α}
     (n : ℕ) :
     (prefixLaw μ X n).map (fun x : Fin n → α => fun i => f (x i)) =
       prefixLaw μ (fun n ω => f (X n ω)) n :=
-  map_finiteBlockLaw μ (fun i : Fin n => i.val) hf hX
+  map_blockLaw μ (fun i : Fin n => i.val) hf fun i => hX i.val
 
 theorem Exchangeable.exchangeableAt {μ : Measure Ω} {X : ℕ → Ω → α}
     (h : Exchangeable μ X) (n : ℕ) : ExchangeableAt μ X n :=
@@ -137,44 +155,13 @@ theorem Exchangeable.exchangeableAt {μ : Measure Ω} {X : ℕ → Ω → α}
 
 theorem ExchangeableAt.permute {μ : Measure Ω} {X : ℕ → Ω → α} {n : ℕ}
     (h : ExchangeableAt μ X n) (σ : Equiv.Perm (Fin n)) :
-    finiteBlockLaw μ X (fun i : Fin n => (σ i).val) = prefixLaw μ X n :=
+    blockLaw μ X (fun i : Fin n => (σ i).val) = prefixLaw μ X n :=
   h σ
 
-theorem Contractable.map {μ : Measure Ω} {X : ℕ → Ω → α} (h : Contractable μ X)
-    {m : ℕ} {k : Fin m → ℕ} (hk : StrictMono k) :
-    finiteBlockLaw μ X k = prefixLaw μ X m :=
-  h m k hk
-
-/-- The one-coordinate specialization of contractability. -/
-theorem Contractable.map_single {μ : Measure Ω} {X : ℕ → Ω → α} (h : Contractable μ X)
-    (k : Fin 1 → ℕ) :
-    finiteBlockLaw μ X k = prefixLaw μ X 1 := by
-  exact h.map (by
-    intro i j hij
-    fin_cases i
-    fin_cases j
-    omega)
-
-/-- The two-coordinate specialization of contractability. -/
-theorem Contractable.map_pair {μ : Measure Ω} {X : ℕ → Ω → α} (h : Contractable μ X)
-    {i j : ℕ} (hij : i < j) :
-    finiteBlockLaw μ X (fun r : Fin 2 => if r = 0 then i else j) = prefixLaw μ X 2 := by
-  refine h.map ?_
-  intro r s hrs
-  fin_cases r <;> fin_cases s <;> simp_all
-
-/-- Contractability is preserved by passing to a strictly increasing subsequence. -/
-theorem Contractable.comp {μ : Measure Ω} {X : ℕ → Ω → α} (h : Contractable μ X)
-    {φ : ℕ → ℕ} (hφ : StrictMono φ) :
-    Contractable μ (fun n ω => X (φ n) ω) := by
-  intro m k hk
-  calc
-    finiteBlockLaw μ (fun n ω => X (φ n) ω) k =
-        finiteBlockLaw μ X (φ ∘ k) := rfl
-    _ = prefixLaw μ X m := h.map (hφ.comp hk)
-    _ = finiteBlockLaw μ (fun n ω => X (φ n) ω) (fun i : Fin m => i.val) := by
-      exact (h.map (hφ.comp (Fin.val_strictMono : StrictMono (fun i : Fin m => i.val)))).symm
-    _ = prefixLaw μ (fun n ω => X (φ n) ω) m := rfl
+theorem FullyExchangeable.permute {μ : Measure Ω} {X : ℕ → Ω → α}
+    (h : FullyExchangeable μ X) (π : Equiv.Perm ℕ) :
+    blockLaw μ X π = pathLaw μ X :=
+  h π
 
 end Probability
 

--- a/TauCeti/Probability/Exchangeability/Basic.lean
+++ b/TauCeti/Probability/Exchangeability/Basic.lean
@@ -2,7 +2,6 @@ module
 
 public import Mathlib.MeasureTheory.Measure.Map
 public import Mathlib.MeasureTheory.MeasurableSpace.Constructions
-public import Mathlib.Order.Fin.Basic
 public import Mathlib.Tactic.Measurability
 
 /-!
@@ -30,14 +29,12 @@ namespace TauCeti
 
 namespace Probability
 
-variable {Ω α β ι : Type*} [MeasurableSpace Ω] [MeasurableSpace α]
+variable {Ω α β : Type*} [MeasurableSpace Ω] [MeasurableSpace α]
 
-/-- The law of a process along an indexed coordinate selection `k`.
-
-This is finite-dimensional when the index type `ι` is finite; `pathLaw` is the special case
-`ι = ℕ` and `k = id`. -/
+/-- The finite-dimensional law of a process along a coordinate selection `k`. -/
 @[expose]
-def blockLaw (μ : Measure Ω) (X : ℕ → Ω → α) (k : ι → ℕ) : Measure (ι → α) :=
+def blockLaw (μ : Measure Ω) (X : ℕ → Ω → α) {m : ℕ} (k : Fin m → ℕ) :
+    Measure (Fin m → α) :=
   μ.map fun ω i => X (k i) ω
 
 /-- The law of the first `n` coordinates of a process. -/
@@ -48,7 +45,7 @@ def prefixLaw (μ : Measure Ω) (X : ℕ → Ω → α) (n : ℕ) : Measure (Fin
 /-- The law of the whole process as a measure on path space. -/
 @[expose]
 def pathLaw (μ : Measure Ω) (X : ℕ → Ω → α) : Measure (ℕ → α) :=
-  blockLaw μ X id
+  μ.map fun ω i => X i ω
 
 /-- Projection from path space to the first `n` coordinates. -/
 @[expose]
@@ -74,7 +71,7 @@ def Exchangeable (μ : Measure Ω) (X : ℕ → Ω → α) : Prop :=
 /-- Full exchangeability: the path law is invariant under every permutation of `ℕ`. -/
 @[expose]
 def FullyExchangeable (μ : Measure Ω) (X : ℕ → Ω → α) : Prop :=
-  ∀ π : Equiv.Perm ℕ, blockLaw μ X π = pathLaw μ X
+  ∀ π : Equiv.Perm ℕ, μ.map (fun ω i => X (π i) ω) = pathLaw μ X
 
 /-- Contractability, or spreadability: finite-dimensional laws are invariant under strictly
 increasing finite subsequences. -/
@@ -83,7 +80,7 @@ def Contractable (μ : Measure Ω) (X : ℕ → Ω → α) : Prop :=
   ∀ (m : ℕ) (k : Fin m → ℕ), StrictMono k → blockLaw μ X k = prefixLaw μ X m
 
 @[simp]
-theorem blockLaw_apply (μ : Measure Ω) (X : ℕ → Ω → α) (k : ι → ℕ) :
+theorem blockLaw_apply (μ : Measure Ω) (X : ℕ → Ω → α) {m : ℕ} (k : Fin m → ℕ) :
     blockLaw μ X k = μ.map (fun ω i => X (k i) ω) :=
   rfl
 
@@ -94,7 +91,7 @@ theorem prefixLaw_apply (μ : Measure Ω) (X : ℕ → Ω → α) (n : ℕ) :
 
 @[simp]
 theorem pathLaw_apply (μ : Measure Ω) (X : ℕ → Ω → α) :
-    pathLaw μ X = blockLaw μ X id :=
+    pathLaw μ X = μ.map (fun ω i => X i ω) :=
   rfl
 
 omit [MeasurableSpace α] in
@@ -122,32 +119,32 @@ theorem measurable_shift : Measurable (shift α) := by
 theorem map_prefixProj_pathLaw (μ : Measure Ω) {X : ℕ → Ω → α}
     (hX : ∀ i, Measurable (X i)) (n : ℕ) :
     (pathLaw μ X).map (prefixProj α n) = prefixLaw μ X n := by
-  rw [pathLaw, prefixLaw, blockLaw, blockLaw]
+  rw [pathLaw_apply, prefixLaw_apply, blockLaw_apply]
   rw [Measure.map_map]
   · rfl
   · exact measurable_prefixProj n
   · exact measurable_pi_lambda (fun ω => fun i => X i ω) fun i => hX i
 
 /-- A coordinatewise measurable map sends block laws to block laws. -/
-theorem map_blockLaw (μ : Measure Ω) {X : ℕ → Ω → α} (k : ι → ℕ)
+theorem map_blockLaw (μ : Measure Ω) {X : ℕ → Ω → α} {m : ℕ} (k : Fin m → ℕ)
     {f : α → β} [MeasurableSpace β] (hf : Measurable f)
-    (hXk : ∀ i : ι, Measurable (X (k i))) :
-    (blockLaw μ X k).map (fun x : ι → α => fun i => f (x i)) =
+    (hXk : ∀ i : Fin m, Measurable (X (k i))) :
+    (blockLaw μ X k).map (fun x : Fin m → α => fun i => f (x i)) =
       blockLaw μ (fun n ω => f (X n ω)) k := by
-  rw [blockLaw, blockLaw]
+  rw [blockLaw_apply, blockLaw_apply]
   rw [Measure.map_map]
   · rfl
-  · exact measurable_pi_lambda (fun x : ι → α => fun i => f (x i)) fun i =>
+  · exact measurable_pi_lambda (fun x : Fin m → α => fun i => f (x i)) fun i =>
       hf.comp (measurable_pi_apply i)
   · exact measurable_pi_lambda (fun ω => fun i => X (k i) ω) hXk
 
 /-- A coordinatewise measurable map sends prefix laws to prefix laws. -/
 theorem map_prefixLaw (μ : Measure Ω) {X : ℕ → Ω → α}
-    {f : α → β} [MeasurableSpace β] (hf : Measurable f) (hX : ∀ i, Measurable (X i))
-    (n : ℕ) :
+    {f : α → β} [MeasurableSpace β] (hf : Measurable f)
+    (n : ℕ) (hX : ∀ i : Fin n, Measurable (X i.val)) :
     (prefixLaw μ X n).map (fun x : Fin n → α => fun i => f (x i)) =
       prefixLaw μ (fun n ω => f (X n ω)) n :=
-  map_blockLaw μ (fun i : Fin n => i.val) hf fun i => hX i.val
+  map_blockLaw μ (fun i : Fin n => i.val) hf hX
 
 theorem Exchangeable.exchangeableAt {μ : Measure Ω} {X : ℕ → Ω → α}
     (h : Exchangeable μ X) (n : ℕ) : ExchangeableAt μ X n :=
@@ -160,7 +157,7 @@ theorem ExchangeableAt.permute {μ : Measure Ω} {X : ℕ → Ω → α} {n : �
 
 theorem FullyExchangeable.permute {μ : Measure Ω} {X : ℕ → Ω → α}
     (h : FullyExchangeable μ X) (π : Equiv.Perm ℕ) :
-    blockLaw μ X π = pathLaw μ X :=
+    μ.map (fun ω i => X (π i) ω) = pathLaw μ X :=
   h π
 
 end Probability

--- a/TauCeti/Probability/Exchangeability/Basic.lean
+++ b/TauCeti/Probability/Exchangeability/Basic.lean
@@ -1,4 +1,6 @@
-import Mathlib.Probability.Process.FiniteDimensionalLaws
+module
+
+public import Mathlib.Probability.Process.FiniteDimensionalLaws
 
 /-!
 # Basic exchangeability definitions
@@ -12,6 +14,8 @@ These declarations follow the roadmap signatures in
 `TauCetiRoadmap/Exchangeability/README.md` and
 `TauCetiRoadmap/Exchangeability/Targets.lean`, Layer 0.
 -/
+
+@[expose] public section
 
 noncomputable section
 

--- a/TauCeti/Probability/Exchangeability/Basic.lean
+++ b/TauCeti/Probability/Exchangeability/Basic.lean
@@ -1,0 +1,177 @@
+import Mathlib.Probability.Process.FiniteDimensionalLaws
+
+/-!
+# Basic exchangeability definitions
+
+This file starts the Layer 0 exchangeability API: finite-dimensional block laws of a
+process, prefix laws, path laws, finite exchangeability, full exchangeability, and
+contractability.  The definitions are intentionally hypothesis-light; measurability
+hypotheses enter only in lemmas that compose `Measure.map`s.
+
+These declarations follow the roadmap signatures in
+`TauCetiRoadmap/Exchangeability/README.md` and
+`TauCetiRoadmap/Exchangeability/Targets.lean`, Layer 0.
+-/
+
+noncomputable section
+
+open MeasureTheory
+
+namespace TauCeti
+
+namespace Probability
+
+variable {Ω α β ι : Type*} [MeasurableSpace Ω] [MeasurableSpace α]
+
+/-- The finite-dimensional law of a process along an index selection `k`. -/
+def finiteBlockLaw (μ : Measure Ω) (X : ℕ → Ω → α) (k : ι → ℕ) : Measure (ι → α) :=
+  μ.map fun ω i => X (k i) ω
+
+/-- The law of the first `n` coordinates of a process. -/
+def prefixLaw (μ : Measure Ω) (X : ℕ → Ω → α) (n : ℕ) : Measure (Fin n → α) :=
+  finiteBlockLaw μ X fun i : Fin n => i.val
+
+/-- The law of the whole process as a measure on path space. -/
+def pathLaw (μ : Measure Ω) (X : ℕ → Ω → α) : Measure (ℕ → α) :=
+  finiteBlockLaw μ X id
+
+/-- Projection from path space to the first `n` coordinates. -/
+def prefixProj (α : Type*) (n : ℕ) (x : ℕ → α) : Fin n → α :=
+  fun i => x i.val
+
+/-- The left shift on one-sided path space. -/
+def shift (α : Type*) (x : ℕ → α) : ℕ → α :=
+  fun n => x (n + 1)
+
+/-- Finite exchangeability at `n`: the first `n` coordinates have permutation-invariant law. -/
+def ExchangeableAt (μ : Measure Ω) (X : ℕ → Ω → α) (n : ℕ) : Prop :=
+  ∀ σ : Equiv.Perm (Fin n),
+    finiteBlockLaw μ X (fun i : Fin n => (σ i).val) = prefixLaw μ X n
+
+/-- Finite exchangeability at every length. -/
+def Exchangeable (μ : Measure Ω) (X : ℕ → Ω → α) : Prop :=
+  ∀ n, ExchangeableAt μ X n
+
+/-- Full exchangeability: the path law is invariant under every permutation of `ℕ`. -/
+def FullyExchangeable (μ : Measure Ω) (X : ℕ → Ω → α) : Prop :=
+  ∀ π : Equiv.Perm ℕ, finiteBlockLaw μ X π = pathLaw μ X
+
+/-- Contractability, or spreadability: finite-dimensional laws are invariant under strictly
+increasing finite subsequences. -/
+def Contractable (μ : Measure Ω) (X : ℕ → Ω → α) : Prop :=
+  ∀ (m : ℕ) (k : Fin m → ℕ), StrictMono k → finiteBlockLaw μ X k = prefixLaw μ X m
+
+@[simp]
+theorem finiteBlockLaw_apply (μ : Measure Ω) (X : ℕ → Ω → α) (k : ι → ℕ) :
+    finiteBlockLaw μ X k = μ.map (fun ω i => X (k i) ω) :=
+  rfl
+
+@[simp]
+theorem prefixLaw_apply (μ : Measure Ω) (X : ℕ → Ω → α) (n : ℕ) :
+    prefixLaw μ X n = finiteBlockLaw μ X (fun i : Fin n => i.val) :=
+  rfl
+
+@[simp]
+theorem pathLaw_apply (μ : Measure Ω) (X : ℕ → Ω → α) :
+    pathLaw μ X = finiteBlockLaw μ X id :=
+  rfl
+
+omit [MeasurableSpace α] in
+@[simp]
+theorem prefixProj_apply (n : ℕ) (x : ℕ → α) (i : Fin n) :
+    prefixProj α n x i = x i.val :=
+  rfl
+
+omit [MeasurableSpace α] in
+@[simp]
+theorem shift_apply (x : ℕ → α) (n : ℕ) : shift α x n = x (n + 1) :=
+  rfl
+
+/-- The prefix projection is measurable. -/
+theorem measurable_prefixProj (n : ℕ) : Measurable (prefixProj α n) := by
+  unfold prefixProj
+  measurability
+
+/-- The one-sided path-space shift is measurable. -/
+theorem measurable_shift : Measurable (shift α) := by
+  unfold shift
+  measurability
+
+/-- The prefix law is the pushforward of the path law by `prefixProj`. -/
+theorem map_prefixProj_pathLaw (μ : Measure Ω) {X : ℕ → Ω → α}
+    (hX : ∀ i, Measurable (X i)) (n : ℕ) :
+    (pathLaw μ X).map (prefixProj α n) = prefixLaw μ X n := by
+  rw [pathLaw, prefixLaw, finiteBlockLaw, finiteBlockLaw]
+  rw [Measure.map_map]
+  · rfl
+  · exact measurable_prefixProj n
+  · exact measurable_pi_lambda (fun ω => fun i => X i ω) fun i => hX i
+
+/-- A coordinatewise measurable map sends block laws to block laws. -/
+theorem map_finiteBlockLaw (μ : Measure Ω) {X : ℕ → Ω → α} (k : ι → ℕ)
+    {f : α → β} [MeasurableSpace β] (hf : Measurable f) (hX : ∀ i, Measurable (X i)) :
+    (finiteBlockLaw μ X k).map (fun x : ι → α => fun i => f (x i)) =
+      finiteBlockLaw μ (fun n ω => f (X n ω)) k := by
+  rw [finiteBlockLaw, finiteBlockLaw]
+  rw [Measure.map_map]
+  · rfl
+  · exact measurable_pi_lambda (fun x : ι → α => fun i => f (x i)) fun i =>
+      hf.comp (measurable_pi_apply i)
+  · exact measurable_pi_lambda (fun ω => fun i => X (k i) ω) fun i => hX (k i)
+
+/-- A coordinatewise measurable map sends prefix laws to prefix laws. -/
+theorem map_prefixLaw (μ : Measure Ω) {X : ℕ → Ω → α}
+    {f : α → β} [MeasurableSpace β] (hf : Measurable f) (hX : ∀ i, Measurable (X i))
+    (n : ℕ) :
+    (prefixLaw μ X n).map (fun x : Fin n → α => fun i => f (x i)) =
+      prefixLaw μ (fun n ω => f (X n ω)) n :=
+  map_finiteBlockLaw μ (fun i : Fin n => i.val) hf hX
+
+theorem Exchangeable.exchangeableAt {μ : Measure Ω} {X : ℕ → Ω → α}
+    (h : Exchangeable μ X) (n : ℕ) : ExchangeableAt μ X n :=
+  h n
+
+theorem ExchangeableAt.permute {μ : Measure Ω} {X : ℕ → Ω → α} {n : ℕ}
+    (h : ExchangeableAt μ X n) (σ : Equiv.Perm (Fin n)) :
+    finiteBlockLaw μ X (fun i : Fin n => (σ i).val) = prefixLaw μ X n :=
+  h σ
+
+theorem Contractable.map {μ : Measure Ω} {X : ℕ → Ω → α} (h : Contractable μ X)
+    {m : ℕ} {k : Fin m → ℕ} (hk : StrictMono k) :
+    finiteBlockLaw μ X k = prefixLaw μ X m :=
+  h m k hk
+
+/-- The one-coordinate specialization of contractability. -/
+theorem Contractable.map_single {μ : Measure Ω} {X : ℕ → Ω → α} (h : Contractable μ X)
+    (k : Fin 1 → ℕ) :
+    finiteBlockLaw μ X k = prefixLaw μ X 1 := by
+  exact h.map (by
+    intro i j hij
+    fin_cases i
+    fin_cases j
+    omega)
+
+/-- The two-coordinate specialization of contractability. -/
+theorem Contractable.map_pair {μ : Measure Ω} {X : ℕ → Ω → α} (h : Contractable μ X)
+    {i j : ℕ} (hij : i < j) :
+    finiteBlockLaw μ X (fun r : Fin 2 => if r = 0 then i else j) = prefixLaw μ X 2 := by
+  refine h.map ?_
+  intro r s hrs
+  fin_cases r <;> fin_cases s <;> simp_all
+
+/-- Contractability is preserved by passing to a strictly increasing subsequence. -/
+theorem Contractable.comp {μ : Measure Ω} {X : ℕ → Ω → α} (h : Contractable μ X)
+    {φ : ℕ → ℕ} (hφ : StrictMono φ) :
+    Contractable μ (fun n ω => X (φ n) ω) := by
+  intro m k hk
+  calc
+    finiteBlockLaw μ (fun n ω => X (φ n) ω) k =
+        finiteBlockLaw μ X (φ ∘ k) := rfl
+    _ = prefixLaw μ X m := h.map (hφ.comp hk)
+    _ = finiteBlockLaw μ (fun n ω => X (φ n) ω) (fun i : Fin m => i.val) := by
+      exact (h.map (hφ.comp (Fin.val_strictMono : StrictMono (fun i : Fin m => i.val)))).symm
+    _ = prefixLaw μ (fun n ω => X (φ n) ω) m := rfl
+
+end Probability
+
+end TauCeti

--- a/TauCeti/Probability/Exchangeability/Basic.lean
+++ b/TauCeti/Probability/Exchangeability/Basic.lean
@@ -1,6 +1,7 @@
 module
 
 public import Mathlib.MeasureTheory.Measure.Map
+public import Mathlib.MeasureTheory.Measure.AEMeasurable
 public import Mathlib.MeasureTheory.MeasurableSpace.Constructions
 public import Mathlib.Tactic.Measurability
 
@@ -117,31 +118,30 @@ theorem measurable_shift : Measurable (shift α) := by
 
 /-- The prefix law is the pushforward of the path law by `prefixProj`. -/
 theorem map_prefixProj_pathLaw (μ : Measure Ω) {X : ℕ → Ω → α}
-    (hX : ∀ i, Measurable (X i)) (n : ℕ) :
+    (hX : AEMeasurable (fun ω => fun i => X i ω) μ) (n : ℕ) :
     (pathLaw μ X).map (prefixProj α n) = prefixLaw μ X n := by
   rw [pathLaw_apply, prefixLaw_apply, blockLaw_apply]
-  rw [Measure.map_map]
-  · rfl
-  · exact measurable_prefixProj n
-  · exact measurable_pi_lambda (fun ω => fun i => X i ω) fun i => hX i
+  rw [AEMeasurable.map_map_of_aemeasurable (measurable_prefixProj n).aemeasurable hX,
+    Function.comp_def]
+  rfl
 
 /-- A coordinatewise measurable map sends block laws to block laws. -/
 theorem map_blockLaw (μ : Measure Ω) {X : ℕ → Ω → α} {m : ℕ} (k : Fin m → ℕ)
     {f : α → β} [MeasurableSpace β] (hf : Measurable f)
-    (hXk : ∀ i : Fin m, Measurable (X (k i))) :
+    (hXk : ∀ i : Fin m, AEMeasurable (X (k i)) μ) :
     (blockLaw μ X k).map (fun x : Fin m → α => fun i => f (x i)) =
       blockLaw μ (fun n ω => f (X n ω)) k := by
   rw [blockLaw_apply, blockLaw_apply]
-  rw [Measure.map_map]
+  rw [AEMeasurable.map_map_of_aemeasurable]
   · rfl
-  · exact measurable_pi_lambda (fun x : Fin m → α => fun i => f (x i)) fun i =>
-      hf.comp (measurable_pi_apply i)
-  · exact measurable_pi_lambda (fun ω => fun i => X (k i) ω) hXk
+  · exact (measurable_pi_lambda (fun x : Fin m → α => fun i => f (x i)) fun i =>
+      hf.comp (measurable_pi_apply i)).aemeasurable
+  · exact aemeasurable_pi_lambda (fun ω => fun i => X (k i) ω) hXk
 
 /-- A coordinatewise measurable map sends prefix laws to prefix laws. -/
 theorem map_prefixLaw (μ : Measure Ω) {X : ℕ → Ω → α}
     {f : α → β} [MeasurableSpace β] (hf : Measurable f)
-    (n : ℕ) (hX : ∀ i : Fin n, Measurable (X i.val)) :
+    (n : ℕ) (hX : ∀ i : Fin n, AEMeasurable (X i.val) μ) :
     (prefixLaw μ X n).map (fun x : Fin n → α => fun i => f (x i)) =
       prefixLaw μ (fun n ω => f (X n ω)) n :=
   map_blockLaw μ (fun i : Fin n => i.val) hf hX

--- a/TauCeti/Probability/Exchangeability/Contractability.lean
+++ b/TauCeti/Probability/Exchangeability/Contractability.lean
@@ -1,0 +1,66 @@
+module
+
+public import TauCeti.Probability.Exchangeability.Basic
+
+/-!
+# Contractability API
+
+This file records basic lemmas for `Contractable` processes. The definitions live in
+`TauCeti.Probability.Exchangeability.Basic`; this file is the Layer 0 home for
+contractability-specific API.
+
+These declarations are adapted from the `cameronfreer/exchangeability` Layer 0 sources pinned
+at `e0532e59ceff23edab44dda9ab0655debbc9cc22`, with Tau Ceti API names and hypotheses.
+-/
+
+public section
+
+noncomputable section
+
+open MeasureTheory
+
+namespace TauCeti
+
+namespace Probability
+
+variable {Ω α : Type*} [MeasurableSpace Ω] [MeasurableSpace α]
+
+theorem Contractable.map {μ : Measure Ω} {X : ℕ → Ω → α} (h : Contractable μ X)
+    {m : ℕ} {k : Fin m → ℕ} (hk : StrictMono k) :
+    blockLaw μ X k = prefixLaw μ X m :=
+  h m k hk
+
+/-- The one-coordinate specialization of contractability. -/
+theorem Contractable.map_single {μ : Measure Ω} {X : ℕ → Ω → α} (h : Contractable μ X)
+    (k : Fin 1 → ℕ) :
+    blockLaw μ X k = prefixLaw μ X 1 := by
+  exact h.map (by
+    intro i j hij
+    fin_cases i
+    fin_cases j
+    omega)
+
+/-- The two-coordinate specialization of contractability. -/
+theorem Contractable.map_pair {μ : Measure Ω} {X : ℕ → Ω → α} (h : Contractable μ X)
+    {i j : ℕ} (hij : i < j) :
+    blockLaw μ X (fun r : Fin 2 => if r = 0 then i else j) = prefixLaw μ X 2 := by
+  refine h.map ?_
+  intro r s hrs
+  fin_cases r <;> fin_cases s <;> simp_all
+
+/-- Contractability is preserved by passing to a strictly increasing subsequence. -/
+theorem Contractable.comp {μ : Measure Ω} {X : ℕ → Ω → α} (h : Contractable μ X)
+    {φ : ℕ → ℕ} (hφ : StrictMono φ) :
+    Contractable μ (fun n ω => X (φ n) ω) := by
+  intro m k hk
+  calc
+    blockLaw μ (fun n ω => X (φ n) ω) k =
+        blockLaw μ X (φ ∘ k) := rfl
+    _ = prefixLaw μ X m := h.map (hφ.comp hk)
+    _ = blockLaw μ (fun n ω => X (φ n) ω) (fun i : Fin m => i.val) := by
+      exact (h.map (hφ.comp (Fin.val_strictMono : StrictMono (fun i : Fin m => i.val)))).symm
+    _ = prefixLaw μ (fun n ω => X (φ n) ω) m := rfl
+
+end Probability
+
+end TauCeti

--- a/TauCeti/Probability/Exchangeability/Contractability.lean
+++ b/TauCeti/Probability/Exchangeability/Contractability.lean
@@ -1,6 +1,7 @@
 module
 
 public import TauCeti.Probability.Exchangeability.Basic
+public import Mathlib.Order.Fin.Basic
 
 /-!
 # Contractability API
@@ -25,6 +26,8 @@ namespace Probability
 
 variable {Ω α : Type*} [MeasurableSpace Ω] [MeasurableSpace α]
 
+/-- A contractable process has the same finite-dimensional block law as the corresponding
+prefix law along any strictly increasing finite index map. -/
 theorem Contractable.map {μ : Measure Ω} {X : ℕ → Ω → α} (h : Contractable μ X)
     {m : ℕ} {k : Fin m → ℕ} (hk : StrictMono k) :
     blockLaw μ X k = prefixLaw μ X m :=


### PR DESCRIPTION
This PR adds the Layer 0 Exchangeability basics: finite block laws, prefix laws, path laws, prefix projections, the one-sided path-space shift, finite and full exchangeability, and contractability, together with small measurability and contractability API for later finite-marginal and implication-lattice work.

It advances `TauCetiRoadmap/Exchangeability/README.md`, Layer 0, specifically the build items `Exchangeable μ X`, `FullyExchangeable μ X`, `ExchangeableAt μ X n`, `Contractable μ X`, `pathLaw μ X`, and prefix projections, plus the key milestones `Contractable.map_single`, `Contractable.map_pair`, and `Contractable.comp`. I chose this as the lowest-hanging distinct Exchangeability target after checking open and recently merged PRs: there was no in-flight Exchangeability PR, and Mathlib has the finite-dimensional-law uniqueness theorem that this layer will later wrap but not these process-level exchangeability definitions.

No Mathlib infrastructure is vendored. The implementation reuses Mathlib's `Measure.map`, product-function measurability API, `Fin.val_strictMono`, and the existing finite-dimensional-law import for the layer this file prepares.

`lake exe cache get` completed with `No files to download` and `Completed successfully in 2235 ms!`. `lake build` completed with `Build completed successfully (4272 jobs).` `lake exe axioms` completed with `axioms: audited 5202 TauCeti declaration(s); all within the allowlist [propext, Classical.choice, Quot.sound].`

<!--tauceti-target:v1 {"focus":"Exchangeability","id":"exchangeability-basic-definitions"}-->

🤖 Prepared with Codex
