### PR TITLE
feat: add semigroup-group positive definiteness

### DIFF
--- a/TauCeti/Analysis/PositiveDefinite/SemigroupGroup.lean
+++ b/TauCeti/Analysis/PositiveDefinite/SemigroupGroup.lean
@@ -1,0 +1,179 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+module
+
+public import TauCeti.Analysis.PositiveDefinite.Basic
+public import Mathlib.Data.NNReal.Basic
+
+/-!
+# Positive-definite functions on `[0, ∞) × V`
+
+This file records the Berg--Christensen--Ressel semigroup-group positive-definiteness predicate
+for functions on `ℝ≥0 × V`. For an additive group `V`, the intended involution is
+`(t, v) ↦ (t, -v)`, so the finite quadratic forms use the entries
+`F (tᵢ + tⱼ, vᵢ - vⱼ)`.
+
+The generic predicate `TauCeti.IsPositiveDefinite` already handles involutive additive monoids.
+Here we spell out the BCR specialization directly, rather than installing a global negation
+`StarAddMonoid` instance on every additive group `V`, which would conflict with Mathlib's ordinary
+star conventions. The result is the named hypothesis needed for the BCR Laplace--Fourier
+representation target in the `OneParameterSemigroups` roadmap.
+
+This advances `TauCetiRoadmap/OneParameterSemigroups/README.md`, Part C, Objects: the roadmap asks
+for `IsSemigroupGroupPD` as the positive-definite predicate on `ℝ≥0 × V` with involution
+`(t, a)⋆ = (t, -a)`.
+
+## Main declarations
+
+* `TauCeti.IsSemigroupGroupPD`: the BCR positive-definiteness predicate on `ℝ≥0 × V`.
+* `TauCeti.IsSemigroupGroupPD.sum_nonneg`: the defining inequality over any finite index type.
+* `TauCeti.IsSemigroupGroupPD.map_zero_nonneg`: the value at `(0, 0)` is nonnegative.
+* `TauCeti.IsSemigroupGroupPD.conj_symm`: conjugate symmetry for the BCR involution.
+* `TauCeti.IsSemigroupGroupPD.add`, `TauCeti.IsSemigroupGroupPD.const_mul`, and
+  `TauCeti.IsSemigroupGroupPD.sum`: closure under the basic finite linear operations needed by
+  the later semigroup representation theory.
+
+## References
+
+* C. Berg, J. P. R. Christensen, P. Ressel, *Harmonic Analysis on Semigroups* (GTM 100, 1984),
+  Chapter 4.
+-/
+
+public section
+
+open ComplexConjugate
+open scoped ComplexOrder
+open scoped NNReal
+
+namespace TauCeti
+
+variable {V : Type*} [AddCommGroup V] {F G : ℝ≥0 × V → ℂ}
+
+/-- A function on `ℝ≥0 × V` is semigroup-group positive definite, in the
+Berg--Christensen--Ressel sense, if all finite quadratic forms formed using the involution
+`(t, v) ↦ (t, -v)` are nonnegative:
+`∑ᵢⱼ cᵢ conj(cⱼ) F(tᵢ + tⱼ, vᵢ - vⱼ) ≥ 0`. -/
+@[expose] def IsSemigroupGroupPD (F : ℝ≥0 × V → ℂ) : Prop :=
+  ∀ (n : ℕ) (c : Fin n → ℂ) (p : Fin n → ℝ≥0 × V),
+    0 ≤ ∑ i, ∑ j, c i * conj (c j) * F ((p i).1 + (p j).1, (p i).2 - (p j).2)
+
+namespace IsSemigroupGroupPD
+
+/-- Semigroup-group positive-definiteness over an arbitrary finite index type. -/
+theorem sum_nonneg (hF : IsSemigroupGroupPD F) {ι : Type*} [Fintype ι]
+    (c : ι → ℂ) (p : ι → ℝ≥0 × V) :
+    0 ≤ ∑ i, ∑ j, c i * conj (c j) * F ((p i).1 + (p j).1, (p i).2 - (p j).2) := by
+  classical
+  let e : Fin (Fintype.card ι) ≃ ι := (Fintype.equivFin ι).symm
+  have h := hF (Fintype.card ι) (fun i => c (e i)) (fun i => p (e i))
+  refine le_of_le_of_eq h ?_
+  exact Fintype.sum_equiv e _ _ fun i =>
+    Fintype.sum_equiv e _ _ fun j => rfl
+
+/-- The value of a semigroup-group positive-definite function at the identity is nonnegative. -/
+theorem map_zero_nonneg (hF : IsSemigroupGroupPD F) : 0 ≤ F (0, 0) := by
+  have h := hF 1 ![1] ![(0, 0)]
+  simpa [Fin.sum_univ_one] using h
+
+/-- The value at the identity of a semigroup-group positive-definite function has zero imaginary
+part. -/
+@[simp]
+theorem map_zero_im (hF : IsSemigroupGroupPD F) : (F (0, 0)).im = 0 :=
+  ((Complex.nonneg_iff.mp hF.map_zero_nonneg).2).symm
+
+/-- The real part of the value at the identity of a semigroup-group positive-definite function is
+nonnegative. -/
+theorem map_zero_re_nonneg (hF : IsSemigroupGroupPD F) : 0 ≤ (F (0, 0)).re :=
+  (Complex.nonneg_iff.mp hF.map_zero_nonneg).1
+
+/-- The `2 × 2` BCR Hermitian sub-form at two points. -/
+theorem quadForm_two_nonneg (hF : IsSemigroupGroupPD F) (p q : ℝ≥0 × V) (c₀ c₁ : ℂ) :
+    0 ≤ c₀ * conj c₀ * F (p.1 + p.1, p.2 - p.2)
+      + c₀ * conj c₁ * F (p.1 + q.1, p.2 - q.2)
+      + c₁ * conj c₀ * F (q.1 + p.1, q.2 - p.2)
+      + c₁ * conj c₁ * F (q.1 + q.1, q.2 - q.2) := by
+  have h := hF 2 ![c₀, c₁] ![p, q]
+  simp only [Fin.sum_univ_two, Matrix.cons_val_zero, Matrix.cons_val_one] at h
+  exact le_of_le_of_eq h (by ring)
+
+/-- A semigroup-group positive-definite function is conjugate symmetric for the
+BCR involution: `conj (F (s + t, w - v)) = F (t + s, v - w)`. -/
+@[simp]
+theorem conj_symm (hF : IsSemigroupGroupPD F) (p q : ℝ≥0 × V) :
+    conj (F (q.1 + p.1, q.2 - p.2)) = F (p.1 + q.1, p.2 - q.2) := by
+  have hp : (F (p.1 + p.1, p.2 - p.2)).im = 0 := by
+    have h := hF.quadForm_two_nonneg p p 1 0
+    simpa using (Complex.nonneg_iff.mp h).2.symm
+  have hq : (F (q.1 + q.1, q.2 - q.2)).im = 0 := by
+    have h := hF.quadForm_two_nonneg q q 1 0
+    simpa using (Complex.nonneg_iff.mp h).2.symm
+  have hp0 : (F (p.1 + p.1, 0)).im = 0 := by simpa [sub_self] using hp
+  have hq0 : (F (q.1 + q.1, 0)).im = 0 := by simpa [sub_self] using hq
+  have him :
+      (F (q.1 + p.1, q.2 - p.2)).im + (F (p.1 + q.1, p.2 - q.2)).im = 0 := by
+    have h := (Complex.nonneg_iff.mp (hF.quadForm_two_nonneg p q 1 1)).2
+    simp [Complex.add_im, hp0, hq0] at h
+    linarith
+  have hre :
+      (F (q.1 + p.1, q.2 - p.2)).re = (F (p.1 + q.1, p.2 - q.2)).re := by
+    have h := (Complex.nonneg_iff.mp (hF.quadForm_two_nonneg p q 1 Complex.I)).2
+    simp [Complex.add_im, Complex.mul_im, hp0, hq0] at h
+    linarith
+  apply Complex.ext
+  · rw [Complex.conj_re]
+    exact hre
+  · rw [Complex.conj_im]
+    linarith
+
+/-- Semigroup-group positive-definite functions are closed under addition. -/
+theorem add (hF : IsSemigroupGroupPD F) (hG : IsSemigroupGroupPD G) :
+    IsSemigroupGroupPD (fun x => F x + G x) := by
+  intro n c p
+  have hsplit :
+      ∑ i, ∑ j, c i * conj (c j) *
+          (F ((p i).1 + (p j).1, (p i).2 - (p j).2) +
+            G ((p i).1 + (p j).1, (p i).2 - (p j).2))
+        = (∑ i, ∑ j, c i * conj (c j) *
+            F ((p i).1 + (p j).1, (p i).2 - (p j).2))
+          + ∑ i, ∑ j, c i * conj (c j) *
+            G ((p i).1 + (p j).1, (p i).2 - (p j).2) := by
+    simp only [mul_add, Finset.sum_add_distrib]
+  simpa only [hsplit] using add_nonneg (hF n c p) (hG n c p)
+
+/-- Semigroup-group positive-definite functions are closed under multiplication by a nonnegative
+complex scalar. -/
+theorem const_mul {k : ℂ} (hk : 0 ≤ k) (hF : IsSemigroupGroupPD F) :
+    IsSemigroupGroupPD (fun x => k * F x) := by
+  intro n c p
+  have hpull :
+      ∑ i, ∑ j, c i * conj (c j) *
+          (k * F ((p i).1 + (p j).1, (p i).2 - (p j).2))
+        = k * ∑ i, ∑ j, c i * conj (c j) *
+          F ((p i).1 + (p j).1, (p i).2 - (p j).2) := by
+    rw [Finset.mul_sum]
+    refine Finset.sum_congr rfl fun i _ => ?_
+    rw [Finset.mul_sum]
+    refine Finset.sum_congr rfl fun j _ => ?_
+    ring
+  rw [hpull]
+  exact mul_nonneg hk (hF n c p)
+
+/-- Semigroup-group positive-definite functions are closed under finite sums. -/
+theorem sum {ι : Type*} {s : Finset ι} {H : ι → ℝ≥0 × V → ℂ}
+    (hH : ∀ i ∈ s, IsSemigroupGroupPD (H i)) :
+    IsSemigroupGroupPD (fun x => ∑ i ∈ s, H i x) := by
+  classical
+  have heq : (∑ i ∈ s, H i) = fun x => ∑ i ∈ s, H i x :=
+    funext fun x => Finset.sum_apply x s H
+  rw [← heq]
+  exact Finset.sum_induction H IsSemigroupGroupPD (fun _ _ => add)
+      (by
+        intro n c p
+        simp)
+      hH
+
+end IsSemigroupGroupPD
+
+end TauCeti

--- a/TauCeti/Analysis/PositiveDefinite/SemigroupGroup.lean
+++ b/TauCeti/Analysis/PositiveDefinite/SemigroupGroup.lean
@@ -4,7 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 -/
 module
 
-public import TauCeti.Analysis.PositiveDefinite.Basic
+public import TauCeti.Analysis.PositiveDefinite.KernelClosure
 public import Mathlib.Data.NNReal.Basic
 
 /-!
@@ -15,10 +15,11 @@ for functions on `ℝ≥0 × V`. For an additive group `V`, the intended involut
 `(t, v) ↦ (t, -v)`, so the finite quadratic forms use the entries
 `F (tᵢ + tⱼ, vᵢ - vⱼ)`.
 
-The generic predicate `TauCeti.IsPositiveDefinite` already handles involutive additive monoids.
-Here we spell out the BCR specialization directly, rather than installing a global negation
-`StarAddMonoid` instance on every additive group `V`, which would conflict with Mathlib's ordinary
-star conventions. The result is the named hypothesis needed for the BCR Laplace--Fourier
+The generic positive-definite-kernel predicate already captures the finite Gram-matrix condition.
+Here we name its BCR specialization for the kernel
+`K p q = F (p.1 + q.1, p.2 - q.2)`, rather than installing a global negation `StarAddMonoid`
+instance on every additive group `V`, which would conflict with Mathlib's ordinary star
+conventions. The result is the named hypothesis needed for the BCR Laplace--Fourier
 representation target in the `OneParameterSemigroups` roadmap.
 
 This advances `TauCetiRoadmap/OneParameterSemigroups/README.md`, Part C, Objects: the roadmap asks
@@ -56,8 +57,7 @@ Berg--Christensen--Ressel sense, if all finite quadratic forms formed using the 
 `(t, v) ↦ (t, -v)` are nonnegative:
 `∑ᵢⱼ cᵢ conj(cⱼ) F(tᵢ + tⱼ, vᵢ - vⱼ) ≥ 0`. -/
 @[expose] def IsSemigroupGroupPD (F : ℝ≥0 × V → ℂ) : Prop :=
-  ∀ (n : ℕ) (c : Fin n → ℂ) (p : Fin n → ℝ≥0 × V),
-    0 ≤ ∑ i, ∑ j, c i * conj (c j) * F ((p i).1 + (p j).1, (p i).2 - (p j).2)
+  IsPositiveDefiniteKernel fun p q : ℝ≥0 × V => F (p.1 + q.1, p.2 - q.2)
 
 namespace IsSemigroupGroupPD
 
@@ -66,16 +66,12 @@ theorem sum_nonneg (hF : IsSemigroupGroupPD F) {ι : Type*} [Fintype ι]
     (c : ι → ℂ) (p : ι → ℝ≥0 × V) :
     0 ≤ ∑ i, ∑ j, c i * conj (c j) * F ((p i).1 + (p j).1, (p i).2 - (p j).2) := by
   classical
-  let e : Fin (Fintype.card ι) ≃ ι := (Fintype.equivFin ι).symm
-  have h := hF (Fintype.card ι) (fun i => c (e i)) (fun i => p (e i))
-  refine le_of_le_of_eq h ?_
-  exact Fintype.sum_equiv e _ _ fun i =>
-    Fintype.sum_equiv e _ _ fun j => rfl
+  have hpos := (isPositiveDefiniteKernel_iff.mp hF).2 p (fun i => conj (c i))
+  simpa only [Complex.conj_conj] using hpos
 
 /-- The value of a semigroup-group positive-definite function at the identity is nonnegative. -/
 theorem map_zero_nonneg (hF : IsSemigroupGroupPD F) : 0 ≤ F (0, 0) := by
-  have h := hF 1 ![1] ![(0, 0)]
-  simpa [Fin.sum_univ_one] using h
+  simpa using isPositiveDefiniteKernel_apply_self_nonneg hF ((0, 0) : ℝ≥0 × V)
 
 /-- The value at the identity of a semigroup-group positive-definite function has zero imaginary
 part. -/
@@ -94,7 +90,7 @@ theorem quadForm_two_nonneg (hF : IsSemigroupGroupPD F) (p q : ℝ≥0 × V) (c�
       + c₀ * conj c₁ * F (p.1 + q.1, p.2 - q.2)
       + c₁ * conj c₀ * F (q.1 + p.1, q.2 - p.2)
       + c₁ * conj c₁ * F (q.1 + q.1, q.2 - q.2) := by
-  have h := hF 2 ![c₀, c₁] ![p, q]
+  have h := hF.sum_nonneg ![c₀, c₁] ![p, q]
   simp only [Fin.sum_univ_two, Matrix.cons_val_zero, Matrix.cons_val_one] at h
   exact le_of_le_of_eq h (by ring)
 
@@ -103,76 +99,32 @@ BCR involution: `conj (F (s + t, w - v)) = F (t + s, v - w)`. -/
 @[simp]
 theorem conj_symm (hF : IsSemigroupGroupPD F) (p q : ℝ≥0 × V) :
     conj (F (q.1 + p.1, q.2 - p.2)) = F (p.1 + q.1, p.2 - q.2) := by
-  have hp : (F (p.1 + p.1, p.2 - p.2)).im = 0 := by
-    have h := hF.quadForm_two_nonneg p p 1 0
-    simpa using (Complex.nonneg_iff.mp h).2.symm
-  have hq : (F (q.1 + q.1, q.2 - q.2)).im = 0 := by
-    have h := hF.quadForm_two_nonneg q q 1 0
-    simpa using (Complex.nonneg_iff.mp h).2.symm
-  have hp0 : (F (p.1 + p.1, 0)).im = 0 := by simpa [sub_self] using hp
-  have hq0 : (F (q.1 + q.1, 0)).im = 0 := by simpa [sub_self] using hq
-  have him :
-      (F (q.1 + p.1, q.2 - p.2)).im + (F (p.1 + q.1, p.2 - q.2)).im = 0 := by
-    have h := (Complex.nonneg_iff.mp (hF.quadForm_two_nonneg p q 1 1)).2
-    simp [Complex.add_im, hp0, hq0] at h
-    linarith
-  have hre :
-      (F (q.1 + p.1, q.2 - p.2)).re = (F (p.1 + q.1, p.2 - q.2)).re := by
-    have h := (Complex.nonneg_iff.mp (hF.quadForm_two_nonneg p q 1 Complex.I)).2
-    simp [Complex.add_im, Complex.mul_im, hp0, hq0] at h
-    linarith
-  apply Complex.ext
-  · rw [Complex.conj_re]
-    exact hre
-  · rw [Complex.conj_im]
-    linarith
+  simpa using isPositiveDefiniteKernel_conj_symm hF q p
 
 /-- Semigroup-group positive-definite functions are closed under addition. -/
 theorem add (hF : IsSemigroupGroupPD F) (hG : IsSemigroupGroupPD G) :
     IsSemigroupGroupPD (fun x => F x + G x) := by
-  intro n c p
-  have hsplit :
-      ∑ i, ∑ j, c i * conj (c j) *
-          (F ((p i).1 + (p j).1, (p i).2 - (p j).2) +
-            G ((p i).1 + (p j).1, (p i).2 - (p j).2))
-        = (∑ i, ∑ j, c i * conj (c j) *
-            F ((p i).1 + (p j).1, (p i).2 - (p j).2))
-          + ∑ i, ∑ j, c i * conj (c j) *
-            G ((p i).1 + (p j).1, (p i).2 - (p j).2) := by
-    simp only [mul_add, Finset.sum_add_distrib]
-  simpa only [hsplit] using add_nonneg (hF n c p) (hG n c p)
+  exact isPositiveDefiniteKernel_add hF hG
 
 /-- Semigroup-group positive-definite functions are closed under multiplication by a nonnegative
 complex scalar. -/
 theorem const_mul {k : ℂ} (hk : 0 ≤ k) (hF : IsSemigroupGroupPD F) :
     IsSemigroupGroupPD (fun x => k * F x) := by
-  intro n c p
-  have hpull :
-      ∑ i, ∑ j, c i * conj (c j) *
-          (k * F ((p i).1 + (p j).1, (p i).2 - (p j).2))
-        = k * ∑ i, ∑ j, c i * conj (c j) *
-          F ((p i).1 + (p j).1, (p i).2 - (p j).2) := by
-    rw [Finset.mul_sum]
-    refine Finset.sum_congr rfl fun i _ => ?_
-    rw [Finset.mul_sum]
-    refine Finset.sum_congr rfl fun j _ => ?_
-    ring
-  rw [hpull]
-  exact mul_nonneg hk (hF n c p)
+  change IsPositiveDefiniteKernel fun p q : ℝ≥0 × V =>
+    k * F (p.1 + q.1, p.2 - q.2)
+  simpa [Algebra.smul_def] using
+    isPositiveDefiniteKernel_smul_of_nonneg (α := ℝ≥0 × V) (K := fun p q : ℝ≥0 × V =>
+      F (p.1 + q.1, p.2 - q.2)) hk hF
 
 /-- Semigroup-group positive-definite functions are closed under finite sums. -/
 theorem sum {ι : Type*} {s : Finset ι} {H : ι → ℝ≥0 × V → ℂ}
     (hH : ∀ i ∈ s, IsSemigroupGroupPD (H i)) :
     IsSemigroupGroupPD (fun x => ∑ i ∈ s, H i x) := by
   classical
-  have heq : (∑ i ∈ s, H i) = fun x => ∑ i ∈ s, H i x :=
-    funext fun x => Finset.sum_apply x s H
-  rw [← heq]
-  exact Finset.sum_induction H IsSemigroupGroupPD (fun _ _ => add)
-      (by
-        intro n c p
-        simp)
-      hH
+  change IsPositiveDefiniteKernel fun p q : ℝ≥0 × V =>
+    ∑ i ∈ s, H i (p.1 + q.1, p.2 - q.2)
+  simpa using isPositiveDefiniteKernel_sum (α := ℝ≥0 × V)
+    (K := fun (i : ι) (p q : ℝ≥0 × V) => H i (p.1 + q.1, p.2 - q.2)) hH
 
 end IsSemigroupGroupPD
 

--- a/TauCeti/Analysis/PositiveDefinite/SemigroupGroup.lean
+++ b/TauCeti/Analysis/PositiveDefinite/SemigroupGroup.lean
@@ -31,13 +31,13 @@ for `IsSemigroupGroupPD` as the positive-definite predicate on `ℝ≥0 × V` wi
 ## Main declarations
 
 * `TauCeti.IsSemigroupGroupPD`: the BCR positive-definiteness predicate on `ℝ≥0 × V`.
-* `TauCeti.isSemigroupGroupPD_iff_isPositiveDefinite`: the bridge to the generic
-  positive-definite-function predicate.
 * `TauCeti.isSemigroupGroupPD_iff_isPositiveDefiniteKernel`: the bridge to the associated
   positive-definite kernel.
 * `TauCeti.isSemigroupGroupPD_iff`: the finite quadratic-form characterization.
 * `TauCeti.IsSemigroupGroupPD.conj_symm`, diagonal, and origin lemmas: basic consequences of the
   semigroup-group positive-definiteness condition.
+* `TauCeti.isSemigroupGroupPD_const_of_nonneg`, `TauCeti.isSemigroupGroupPD_zero`, and
+  `TauCeti.isSemigroupGroupPD_one`: basic constant examples.
 * `TauCeti.IsSemigroupGroupPD.add`, `TauCeti.IsSemigroupGroupPD.mul`, and finite
   `sum`/`prod`: closure properties inherited from positive-definite kernels.
 * `TauCeti.IsSemigroupGroupPD.quadForm_two_nonneg`: the `2 × 2` BCR Hermitian sub-form is
@@ -63,7 +63,7 @@ variable {V : Type*} [AddCommGroup V] {F G : ℝ≥0 × V → ℂ}
 
 This wrapper avoids installing a global negation `StarAddMonoid` instance on an arbitrary
 additive group `V`. -/
-structure BCRPoint (V : Type*) where
+private structure BCRPoint (V : Type*) where
   /-- The nonnegative time coordinate. -/
   time : ℝ≥0
   /-- The group coordinate. -/
@@ -84,47 +84,48 @@ private def toProd (p : BCRPoint V) : ℝ≥0 × V :=
   (p.time, p.point)
 
 @[ext]
-theorem ext {p q : BCRPoint V} (ht : p.time = q.time) (hv : p.point = q.point) : p = q := by
+private theorem ext {p q : BCRPoint V} (ht : p.time = q.time) (hv : p.point = q.point) :
+    p = q := by
   cases p
   cases q
   simp_all
 
-instance [AddCommGroup V] : Zero (BCRPoint V) where
+private instance [AddCommGroup V] : Zero (BCRPoint V) where
   zero := ⟨0, 0⟩
 
-instance [AddCommGroup V] : Add (BCRPoint V) where
+private instance [AddCommGroup V] : Add (BCRPoint V) where
   add p q := ⟨p.time + q.time, p.point + q.point⟩
 
-instance [AddCommGroup V] : Star (BCRPoint V) where
+private instance [AddCommGroup V] : Star (BCRPoint V) where
   star p := ⟨p.time, -p.point⟩
 
 @[simp]
-theorem zero_time [AddCommGroup V] : (0 : BCRPoint V).time = 0 :=
+private theorem zero_time [AddCommGroup V] : (0 : BCRPoint V).time = 0 :=
   rfl
 
 @[simp]
-theorem zero_point [AddCommGroup V] : (0 : BCRPoint V).point = 0 :=
+private theorem zero_point [AddCommGroup V] : (0 : BCRPoint V).point = 0 :=
   rfl
 
 @[simp]
-theorem add_time [AddCommGroup V] (p q : BCRPoint V) :
+private theorem add_time [AddCommGroup V] (p q : BCRPoint V) :
     (p + q).time = p.time + q.time :=
   rfl
 
 @[simp]
-theorem add_point [AddCommGroup V] (p q : BCRPoint V) :
+private theorem add_point [AddCommGroup V] (p q : BCRPoint V) :
     (p + q).point = p.point + q.point :=
   rfl
 
 @[simp]
-theorem star_time [AddCommGroup V] (p : BCRPoint V) : (star p).time = p.time :=
+private theorem star_time [AddCommGroup V] (p : BCRPoint V) : (star p).time = p.time :=
   rfl
 
 @[simp]
-theorem star_point [AddCommGroup V] (p : BCRPoint V) : (star p).point = -p.point :=
+private theorem star_point [AddCommGroup V] (p : BCRPoint V) : (star p).point = -p.point :=
   rfl
 
-instance [AddCommGroup V] : AddCommMonoid (BCRPoint V) where
+private instance [AddCommGroup V] : AddCommMonoid (BCRPoint V) where
   add := (· + ·)
   zero := 0
   add_assoc := by
@@ -141,7 +142,7 @@ instance [AddCommGroup V] : AddCommMonoid (BCRPoint V) where
     ext <;> simp [add_comm]
   nsmul := nsmulRec
 
-instance [AddCommGroup V] : StarAddMonoid (BCRPoint V) where
+private instance [AddCommGroup V] : StarAddMonoid (BCRPoint V) where
   star_add := by
     intro p q
     ext <;> simp [add_comm]
@@ -160,7 +161,7 @@ def IsSemigroupGroupPD (F : ℝ≥0 × V → ℂ) : Prop :=
 
 /-- The BCR predicate is the generic positive-definite-function predicate on the local
 `BCRPoint` wrapper carrying the involution `(t, v) ↦ (t, -v)`. -/
-theorem isSemigroupGroupPD_iff_isPositiveDefinite :
+private theorem isSemigroupGroupPD_iff_isPositiveDefinite :
     IsSemigroupGroupPD F ↔ IsPositiveDefinite (fun p : BCRPoint V => F (p.time, p.point)) :=
   Iff.rfl
 
@@ -190,6 +191,22 @@ theorem IsSemigroupGroupPD.of_isPositiveDefiniteKernel
     (hF : IsPositiveDefiniteKernel fun p q : ℝ≥0 × V => F (p.1 + q.1, p.2 - q.2)) :
     IsSemigroupGroupPD F :=
   isSemigroupGroupPD_iff_isPositiveDefiniteKernel.mpr hF
+
+/-- A nonnegative complex constant is semigroup-group positive definite. -/
+theorem isSemigroupGroupPD_const_of_nonneg {k : ℂ} (hk : 0 ≤ k) :
+    IsSemigroupGroupPD (fun _ : ℝ≥0 × V => k) :=
+  IsSemigroupGroupPD.of_isPositiveDefiniteKernel <| by
+    simpa using isPositiveDefiniteKernel_const_of_nonneg (α := ℝ≥0 × V) hk
+
+/-- The zero function is semigroup-group positive definite. -/
+theorem isSemigroupGroupPD_zero :
+    IsSemigroupGroupPD (fun _ : ℝ≥0 × V => (0 : ℂ)) :=
+  isSemigroupGroupPD_const_of_nonneg le_rfl
+
+/-- The constant-one function is semigroup-group positive definite. -/
+theorem isSemigroupGroupPD_one :
+    IsSemigroupGroupPD (fun _ : ℝ≥0 × V => (1 : ℂ)) :=
+  isSemigroupGroupPD_const_of_nonneg zero_le_one
 
 /-- The finite quadratic-form characterization of semigroup-group positive definiteness. -/
 theorem isSemigroupGroupPD_iff :

--- a/TauCeti/Analysis/PositiveDefinite/SemigroupGroup.lean
+++ b/TauCeti/Analysis/PositiveDefinite/SemigroupGroup.lean
@@ -4,6 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 -/
 module
 
+public import TauCeti.Analysis.PositiveDefinite.Kernel
 public import TauCeti.Analysis.PositiveDefinite.KernelClosure
 public import Mathlib.Data.NNReal.Basic
 
@@ -29,12 +30,13 @@ for `IsSemigroupGroupPD` as the positive-definite predicate on `ℝ≥0 × V` wi
 ## Main declarations
 
 * `TauCeti.IsSemigroupGroupPD`: the BCR positive-definiteness predicate on `ℝ≥0 × V`.
-* `TauCeti.IsSemigroupGroupPD.sum_nonneg`: the defining inequality over any finite index type.
-* `TauCeti.IsSemigroupGroupPD.map_zero_nonneg`: the value at `(0, 0)` is nonnegative.
+* `TauCeti.isSemigroupGroupPD_iff`: the finite quadratic-form characterization.
+* `TauCeti.IsSemigroupGroupPD.add_star_self_nonneg`: diagonal values are nonnegative.
 * `TauCeti.IsSemigroupGroupPD.conj_symm`: conjugate symmetry for the BCR involution.
-* `TauCeti.IsSemigroupGroupPD.add`, `TauCeti.IsSemigroupGroupPD.const_mul`, and
-  `TauCeti.IsSemigroupGroupPD.sum`: closure under the basic finite linear operations needed by
-  the later semigroup representation theory.
+* `TauCeti.IsSemigroupGroupPD.add`, `TauCeti.IsSemigroupGroupPD.const_mul`,
+  `TauCeti.IsSemigroupGroupPD.mul`, `TauCeti.IsSemigroupGroupPD.sum`, and
+  `TauCeti.IsSemigroupGroupPD.prod`: closure under the basic finite operations needed by the
+  later semigroup representation theory.
 
 ## References
 
@@ -56,8 +58,42 @@ variable {V : Type*} [AddCommGroup V] {F G : ℝ≥0 × V → ℂ}
 Berg--Christensen--Ressel sense, if all finite quadratic forms formed using the involution
 `(t, v) ↦ (t, -v)` are nonnegative:
 `∑ᵢⱼ cᵢ conj(cⱼ) F(tᵢ + tⱼ, vᵢ - vⱼ) ≥ 0`. -/
-@[expose] def IsSemigroupGroupPD (F : ℝ≥0 × V → ℂ) : Prop :=
+def IsSemigroupGroupPD (F : ℝ≥0 × V → ℂ) : Prop :=
   IsPositiveDefiniteKernel fun p q : ℝ≥0 × V => F (p.1 + q.1, p.2 - q.2)
+
+/-- The kernel associated to a semigroup-group positive-definite function is positive definite. -/
+theorem IsSemigroupGroupPD.isPositiveDefiniteKernel (hF : IsSemigroupGroupPD F) :
+    IsPositiveDefiniteKernel fun p q : ℝ≥0 × V => F (p.1 + q.1, p.2 - q.2) :=
+  hF
+
+/-- Build a semigroup-group positive-definite function from the associated positive-definite
+kernel. -/
+theorem IsSemigroupGroupPD.of_isPositiveDefiniteKernel
+    (hF : IsPositiveDefiniteKernel fun p q : ℝ≥0 × V => F (p.1 + q.1, p.2 - q.2)) :
+    IsSemigroupGroupPD F :=
+  hF
+
+/-- The finite quadratic-form characterization of semigroup-group positive definiteness. -/
+theorem isSemigroupGroupPD_iff :
+    IsSemigroupGroupPD F ↔
+      (∀ p q : ℝ≥0 × V, conj (F (p.1 + q.1, p.2 - q.2))
+        = F (q.1 + p.1, q.2 - p.2)) ∧
+        ∀ {ι : Type*} [Fintype ι] (c : ι → ℂ) (p : ι → ℝ≥0 × V),
+          0 ≤ ∑ i, ∑ j, c i * conj (c j) *
+            F ((p i).1 + (p j).1, (p i).2 - (p j).2) := by
+  classical
+  constructor
+  · intro hF
+    refine ⟨fun p q => isPositiveDefiniteKernel_conj_symm hF p q, ?_⟩
+    intro ι _ c p
+    have hpos := (isPositiveDefiniteKernel_iff.mp hF.isPositiveDefiniteKernel).2 p
+      (fun i => conj (c i))
+    simpa only [Complex.conj_conj] using hpos
+  · rintro ⟨hsymm, hpos⟩
+    exact IsSemigroupGroupPD.of_isPositiveDefiniteKernel <| isPositiveDefiniteKernel_iff.mpr
+      ⟨hsymm, fun p x => by
+        have h := hpos (fun i => conj (x i)) p
+        simpa only [Complex.conj_conj] using h⟩
 
 namespace IsSemigroupGroupPD
 
@@ -65,13 +101,28 @@ namespace IsSemigroupGroupPD
 theorem sum_nonneg (hF : IsSemigroupGroupPD F) {ι : Type*} [Fintype ι]
     (c : ι → ℂ) (p : ι → ℝ≥0 × V) :
     0 ≤ ∑ i, ∑ j, c i * conj (c j) * F ((p i).1 + (p j).1, (p i).2 - (p j).2) := by
-  classical
-  have hpos := (isPositiveDefiniteKernel_iff.mp hF).2 p (fun i => conj (c i))
-  simpa only [Complex.conj_conj] using hpos
+  exact (isSemigroupGroupPD_iff.mp hF).2 c p
+
+/-- Diagonal values of a semigroup-group positive-definite function are nonnegative. -/
+theorem add_star_self_nonneg (hF : IsSemigroupGroupPD F) (p : ℝ≥0 × V) :
+    0 ≤ F (p.1 + p.1, p.2 - p.2) := by
+  simpa using isPositiveDefiniteKernel_apply_self_nonneg hF.isPositiveDefiniteKernel p
+
+/-- Diagonal values of a semigroup-group positive-definite function have zero imaginary part. -/
+@[simp]
+theorem add_star_self_im (hF : IsSemigroupGroupPD F) (p : ℝ≥0 × V) :
+    (F (p.1 + p.1, p.2 - p.2)).im = 0 :=
+  ((Complex.nonneg_iff.mp (hF.add_star_self_nonneg p)).2).symm
+
+/-- The real parts of diagonal values of a semigroup-group positive-definite function are
+nonnegative. -/
+theorem add_star_self_re_nonneg (hF : IsSemigroupGroupPD F) (p : ℝ≥0 × V) :
+    0 ≤ (F (p.1 + p.1, p.2 - p.2)).re :=
+  (Complex.nonneg_iff.mp (hF.add_star_self_nonneg p)).1
 
 /-- The value of a semigroup-group positive-definite function at the identity is nonnegative. -/
 theorem map_zero_nonneg (hF : IsSemigroupGroupPD F) : 0 ≤ F (0, 0) := by
-  simpa using isPositiveDefiniteKernel_apply_self_nonneg hF ((0, 0) : ℝ≥0 × V)
+  simpa using hF.add_star_self_nonneg ((0, 0) : ℝ≥0 × V)
 
 /-- The value at the identity of a semigroup-group positive-definite function has zero imaginary
 part. -/
@@ -99,32 +150,53 @@ BCR involution: `conj (F (s + t, w - v)) = F (t + s, v - w)`. -/
 @[simp]
 theorem conj_symm (hF : IsSemigroupGroupPD F) (p q : ℝ≥0 × V) :
     conj (F (q.1 + p.1, q.2 - p.2)) = F (p.1 + q.1, p.2 - q.2) := by
-  simpa using isPositiveDefiniteKernel_conj_symm hF q p
+  exact isPositiveDefiniteKernel_conj_symm hF.isPositiveDefiniteKernel q p
 
 /-- Semigroup-group positive-definite functions are closed under addition. -/
 theorem add (hF : IsSemigroupGroupPD F) (hG : IsSemigroupGroupPD G) :
     IsSemigroupGroupPD (fun x => F x + G x) := by
-  exact isPositiveDefiniteKernel_add hF hG
+  exact IsSemigroupGroupPD.of_isPositiveDefiniteKernel <|
+    isPositiveDefiniteKernel_add hF.isPositiveDefiniteKernel hG.isPositiveDefiniteKernel
 
 /-- Semigroup-group positive-definite functions are closed under multiplication by a nonnegative
 complex scalar. -/
 theorem const_mul {k : ℂ} (hk : 0 ≤ k) (hF : IsSemigroupGroupPD F) :
     IsSemigroupGroupPD (fun x => k * F x) := by
-  change IsPositiveDefiniteKernel fun p q : ℝ≥0 × V =>
-    k * F (p.1 + q.1, p.2 - q.2)
+  refine IsSemigroupGroupPD.of_isPositiveDefiniteKernel ?_
   simpa [Algebra.smul_def] using
     isPositiveDefiniteKernel_smul_of_nonneg (α := ℝ≥0 × V) (K := fun p q : ℝ≥0 × V =>
-      F (p.1 + q.1, p.2 - q.2)) hk hF
+      F (p.1 + q.1, p.2 - q.2)) hk hF.isPositiveDefiniteKernel
+
+/-- Semigroup-group positive-definite functions are closed under pointwise multiplication. -/
+theorem mul (hF : IsSemigroupGroupPD F) (hG : IsSemigroupGroupPD G) :
+    IsSemigroupGroupPD (fun x => F x * G x) := by
+  exact IsSemigroupGroupPD.of_isPositiveDefiniteKernel <|
+    isPositiveDefiniteKernel_mul hF.isPositiveDefiniteKernel hG.isPositiveDefiniteKernel
 
 /-- Semigroup-group positive-definite functions are closed under finite sums. -/
 theorem sum {ι : Type*} {s : Finset ι} {H : ι → ℝ≥0 × V → ℂ}
     (hH : ∀ i ∈ s, IsSemigroupGroupPD (H i)) :
     IsSemigroupGroupPD (fun x => ∑ i ∈ s, H i x) := by
   classical
-  change IsPositiveDefiniteKernel fun p q : ℝ≥0 × V =>
-    ∑ i ∈ s, H i (p.1 + q.1, p.2 - q.2)
+  refine IsSemigroupGroupPD.of_isPositiveDefiniteKernel ?_
   simpa using isPositiveDefiniteKernel_sum (α := ℝ≥0 × V)
     (K := fun (i : ι) (p q : ℝ≥0 × V) => H i (p.1 + q.1, p.2 - q.2)) hH
+
+/-- Semigroup-group positive-definite functions are closed under finite products. -/
+theorem prod {ι : Type*} {s : Finset ι} {H : ι → ℝ≥0 × V → ℂ}
+    (hH : ∀ i ∈ s, IsSemigroupGroupPD (H i)) :
+    IsSemigroupGroupPD (fun x => ∏ i ∈ s, H i x) := by
+  classical
+  refine IsSemigroupGroupPD.of_isPositiveDefiniteKernel ?_
+  simpa using isPositiveDefiniteKernel_prod (α := ℝ≥0 × V)
+    (K := fun (i : ι) (p q : ℝ≥0 × V) => H i (p.1 + q.1, p.2 - q.2)) hH
+
+/-- Schur powers of a semigroup-group positive-definite function are positive definite. -/
+theorem pow (hF : IsSemigroupGroupPD F) (n : ℕ) :
+    IsSemigroupGroupPD (fun x => F x ^ n) := by
+  refine IsSemigroupGroupPD.of_isPositiveDefiniteKernel ?_
+  simpa using isPositiveDefiniteKernel_pow (α := ℝ≥0 × V)
+    (K := fun p q : ℝ≥0 × V => F (p.1 + q.1, p.2 - q.2)) hF.isPositiveDefiniteKernel n
 
 end IsSemigroupGroupPD
 

--- a/TauCeti/Analysis/PositiveDefinite/SemigroupGroup.lean
+++ b/TauCeti/Analysis/PositiveDefinite/SemigroupGroup.lean
@@ -30,13 +30,11 @@ for `IsSemigroupGroupPD` as the positive-definite predicate on `ℝ≥0 × V` wi
 ## Main declarations
 
 * `TauCeti.IsSemigroupGroupPD`: the BCR positive-definiteness predicate on `ℝ≥0 × V`.
+* `TauCeti.isSemigroupGroupPD_def`: the definitional bridge to the associated
+  positive-definite kernel.
 * `TauCeti.isSemigroupGroupPD_iff`: the finite quadratic-form characterization.
-* `TauCeti.IsSemigroupGroupPD.add_star_self_nonneg`: diagonal values are nonnegative.
-* `TauCeti.IsSemigroupGroupPD.conj_symm`: conjugate symmetry for the BCR involution.
-* `TauCeti.IsSemigroupGroupPD.add`, `TauCeti.IsSemigroupGroupPD.const_mul`,
-  `TauCeti.IsSemigroupGroupPD.mul`, `TauCeti.IsSemigroupGroupPD.sum`, and
-  `TauCeti.IsSemigroupGroupPD.prod`: closure under the basic finite operations needed by the
-  later semigroup representation theory.
+* `TauCeti.IsSemigroupGroupPD.quadForm_two_nonneg`: the `2 × 2` BCR Hermitian sub-form is
+  nonnegative.
 
 ## References
 
@@ -61,17 +59,24 @@ Berg--Christensen--Ressel sense, if all finite quadratic forms formed using the 
 def IsSemigroupGroupPD (F : ℝ≥0 × V → ℂ) : Prop :=
   IsPositiveDefiniteKernel fun p q : ℝ≥0 × V => F (p.1 + q.1, p.2 - q.2)
 
+/-- The definitional bridge from semigroup-group positive definiteness to the associated
+positive-definite kernel. -/
+theorem isSemigroupGroupPD_def :
+    IsSemigroupGroupPD F ↔
+      IsPositiveDefiniteKernel fun p q : ℝ≥0 × V => F (p.1 + q.1, p.2 - q.2) :=
+  Iff.rfl
+
 /-- The kernel associated to a semigroup-group positive-definite function is positive definite. -/
 theorem IsSemigroupGroupPD.isPositiveDefiniteKernel (hF : IsSemigroupGroupPD F) :
     IsPositiveDefiniteKernel fun p q : ℝ≥0 × V => F (p.1 + q.1, p.2 - q.2) :=
-  hF
+  isSemigroupGroupPD_def.mp hF
 
 /-- Build a semigroup-group positive-definite function from the associated positive-definite
 kernel. -/
 theorem IsSemigroupGroupPD.of_isPositiveDefiniteKernel
     (hF : IsPositiveDefiniteKernel fun p q : ℝ≥0 × V => F (p.1 + q.1, p.2 - q.2)) :
     IsSemigroupGroupPD F :=
-  hF
+  isSemigroupGroupPD_def.mpr hF
 
 /-- The finite quadratic-form characterization of semigroup-group positive definiteness. -/
 theorem isSemigroupGroupPD_iff :
@@ -97,106 +102,15 @@ theorem isSemigroupGroupPD_iff :
 
 namespace IsSemigroupGroupPD
 
-/-- Semigroup-group positive-definiteness over an arbitrary finite index type. -/
-theorem sum_nonneg (hF : IsSemigroupGroupPD F) {ι : Type*} [Fintype ι]
-    (c : ι → ℂ) (p : ι → ℝ≥0 × V) :
-    0 ≤ ∑ i, ∑ j, c i * conj (c j) * F ((p i).1 + (p j).1, (p i).2 - (p j).2) := by
-  exact (isSemigroupGroupPD_iff.mp hF).2 c p
-
-/-- Diagonal values of a semigroup-group positive-definite function are nonnegative. -/
-theorem add_star_self_nonneg (hF : IsSemigroupGroupPD F) (p : ℝ≥0 × V) :
-    0 ≤ F (p.1 + p.1, p.2 - p.2) := by
-  simpa using isPositiveDefiniteKernel_apply_self_nonneg hF.isPositiveDefiniteKernel p
-
-/-- Diagonal values of a semigroup-group positive-definite function have zero imaginary part. -/
-@[simp]
-theorem add_star_self_im (hF : IsSemigroupGroupPD F) (p : ℝ≥0 × V) :
-    (F (p.1 + p.1, p.2 - p.2)).im = 0 :=
-  ((Complex.nonneg_iff.mp (hF.add_star_self_nonneg p)).2).symm
-
-/-- The real parts of diagonal values of a semigroup-group positive-definite function are
-nonnegative. -/
-theorem add_star_self_re_nonneg (hF : IsSemigroupGroupPD F) (p : ℝ≥0 × V) :
-    0 ≤ (F (p.1 + p.1, p.2 - p.2)).re :=
-  (Complex.nonneg_iff.mp (hF.add_star_self_nonneg p)).1
-
-/-- The value of a semigroup-group positive-definite function at the identity is nonnegative. -/
-theorem map_zero_nonneg (hF : IsSemigroupGroupPD F) : 0 ≤ F (0, 0) := by
-  simpa using hF.add_star_self_nonneg ((0, 0) : ℝ≥0 × V)
-
-/-- The value at the identity of a semigroup-group positive-definite function has zero imaginary
-part. -/
-@[simp]
-theorem map_zero_im (hF : IsSemigroupGroupPD F) : (F (0, 0)).im = 0 :=
-  ((Complex.nonneg_iff.mp hF.map_zero_nonneg).2).symm
-
-/-- The real part of the value at the identity of a semigroup-group positive-definite function is
-nonnegative. -/
-theorem map_zero_re_nonneg (hF : IsSemigroupGroupPD F) : 0 ≤ (F (0, 0)).re :=
-  (Complex.nonneg_iff.mp hF.map_zero_nonneg).1
-
 /-- The `2 × 2` BCR Hermitian sub-form at two points. -/
 theorem quadForm_two_nonneg (hF : IsSemigroupGroupPD F) (p q : ℝ≥0 × V) (c₀ c₁ : ℂ) :
     0 ≤ c₀ * conj c₀ * F (p.1 + p.1, p.2 - p.2)
       + c₀ * conj c₁ * F (p.1 + q.1, p.2 - q.2)
       + c₁ * conj c₀ * F (q.1 + p.1, q.2 - p.2)
       + c₁ * conj c₁ * F (q.1 + q.1, q.2 - q.2) := by
-  have h := hF.sum_nonneg ![c₀, c₁] ![p, q]
+  have h := (isSemigroupGroupPD_iff.mp hF).2 ![c₀, c₁] ![p, q]
   simp only [Fin.sum_univ_two, Matrix.cons_val_zero, Matrix.cons_val_one] at h
   exact le_of_le_of_eq h (by ring)
-
-/-- A semigroup-group positive-definite function is conjugate symmetric for the
-BCR involution: `conj (F (s + t, w - v)) = F (t + s, v - w)`. -/
-@[simp]
-theorem conj_symm (hF : IsSemigroupGroupPD F) (p q : ℝ≥0 × V) :
-    conj (F (q.1 + p.1, q.2 - p.2)) = F (p.1 + q.1, p.2 - q.2) := by
-  exact isPositiveDefiniteKernel_conj_symm hF.isPositiveDefiniteKernel q p
-
-/-- Semigroup-group positive-definite functions are closed under addition. -/
-theorem add (hF : IsSemigroupGroupPD F) (hG : IsSemigroupGroupPD G) :
-    IsSemigroupGroupPD (fun x => F x + G x) := by
-  exact IsSemigroupGroupPD.of_isPositiveDefiniteKernel <|
-    isPositiveDefiniteKernel_add hF.isPositiveDefiniteKernel hG.isPositiveDefiniteKernel
-
-/-- Semigroup-group positive-definite functions are closed under multiplication by a nonnegative
-complex scalar. -/
-theorem const_mul {k : ℂ} (hk : 0 ≤ k) (hF : IsSemigroupGroupPD F) :
-    IsSemigroupGroupPD (fun x => k * F x) := by
-  refine IsSemigroupGroupPD.of_isPositiveDefiniteKernel ?_
-  simpa [Algebra.smul_def] using
-    isPositiveDefiniteKernel_smul_of_nonneg (α := ℝ≥0 × V) (K := fun p q : ℝ≥0 × V =>
-      F (p.1 + q.1, p.2 - q.2)) hk hF.isPositiveDefiniteKernel
-
-/-- Semigroup-group positive-definite functions are closed under pointwise multiplication. -/
-theorem mul (hF : IsSemigroupGroupPD F) (hG : IsSemigroupGroupPD G) :
-    IsSemigroupGroupPD (fun x => F x * G x) := by
-  exact IsSemigroupGroupPD.of_isPositiveDefiniteKernel <|
-    isPositiveDefiniteKernel_mul hF.isPositiveDefiniteKernel hG.isPositiveDefiniteKernel
-
-/-- Semigroup-group positive-definite functions are closed under finite sums. -/
-theorem sum {ι : Type*} {s : Finset ι} {H : ι → ℝ≥0 × V → ℂ}
-    (hH : ∀ i ∈ s, IsSemigroupGroupPD (H i)) :
-    IsSemigroupGroupPD (fun x => ∑ i ∈ s, H i x) := by
-  classical
-  refine IsSemigroupGroupPD.of_isPositiveDefiniteKernel ?_
-  simpa using isPositiveDefiniteKernel_sum (α := ℝ≥0 × V)
-    (K := fun (i : ι) (p q : ℝ≥0 × V) => H i (p.1 + q.1, p.2 - q.2)) hH
-
-/-- Semigroup-group positive-definite functions are closed under finite products. -/
-theorem prod {ι : Type*} {s : Finset ι} {H : ι → ℝ≥0 × V → ℂ}
-    (hH : ∀ i ∈ s, IsSemigroupGroupPD (H i)) :
-    IsSemigroupGroupPD (fun x => ∏ i ∈ s, H i x) := by
-  classical
-  refine IsSemigroupGroupPD.of_isPositiveDefiniteKernel ?_
-  simpa using isPositiveDefiniteKernel_prod (α := ℝ≥0 × V)
-    (K := fun (i : ι) (p q : ℝ≥0 × V) => H i (p.1 + q.1, p.2 - q.2)) hH
-
-/-- Schur powers of a semigroup-group positive-definite function are positive definite. -/
-theorem pow (hF : IsSemigroupGroupPD F) (n : ℕ) :
-    IsSemigroupGroupPD (fun x => F x ^ n) := by
-  refine IsSemigroupGroupPD.of_isPositiveDefiniteKernel ?_
-  simpa using isPositiveDefiniteKernel_pow (α := ℝ≥0 × V)
-    (K := fun p q : ℝ≥0 × V => F (p.1 + q.1, p.2 - q.2)) hF.isPositiveDefiniteKernel n
 
 end IsSemigroupGroupPD
 

--- a/TauCeti/Analysis/PositiveDefinite/SemigroupGroup.lean
+++ b/TauCeti/Analysis/PositiveDefinite/SemigroupGroup.lean
@@ -33,6 +33,10 @@ for `IsSemigroupGroupPD` as the positive-definite predicate on `ℝ≥0 × V` wi
 * `TauCeti.isSemigroupGroupPD_def`: the definitional bridge to the associated
   positive-definite kernel.
 * `TauCeti.isSemigroupGroupPD_iff`: the finite quadratic-form characterization.
+* `TauCeti.IsSemigroupGroupPD.conj_symm` and origin lemmas: basic consequences of the
+  semigroup-group positive-definiteness condition.
+* `TauCeti.IsSemigroupGroupPD.add`, `TauCeti.IsSemigroupGroupPD.mul`, and finite
+  `sum`/`prod`: closure properties inherited from positive-definite kernels.
 * `TauCeti.IsSemigroupGroupPD.quadForm_two_nonneg`: the `2 × 2` BCR Hermitian sub-form is
   nonnegative.
 
@@ -89,7 +93,7 @@ theorem isSemigroupGroupPD_iff :
   classical
   constructor
   · intro hF
-    refine ⟨fun p q => isPositiveDefiniteKernel_conj_symm hF p q, ?_⟩
+    refine ⟨fun p q => isPositiveDefiniteKernel_conj_symm hF.isPositiveDefiniteKernel p q, ?_⟩
     intro ι _ c p
     have hpos := (isPositiveDefiniteKernel_iff.mp hF.isPositiveDefiniteKernel).2 p
       (fun i => conj (c i))
@@ -102,6 +106,15 @@ theorem isSemigroupGroupPD_iff :
 
 namespace IsSemigroupGroupPD
 
+/-- Positive-definiteness holds for arbitrary finite BCR families: for every finite family of
+scalars `c` and points `p`, the quadratic form
+`∑ i, ∑ j, c i * conj (c j) * F ((p i).1 + (p j).1, (p i).2 - (p j).2)` is nonnegative. -/
+theorem sum_nonneg (hF : IsSemigroupGroupPD F) {ι : Type*} [Fintype ι]
+    (c : ι → ℂ) (p : ι → ℝ≥0 × V) :
+    0 ≤ ∑ i, ∑ j, c i * conj (c j) *
+      F ((p i).1 + (p j).1, (p i).2 - (p j).2) :=
+  (isSemigroupGroupPD_iff.mp hF).2 c p
+
 /-- The `2 × 2` BCR Hermitian sub-form at two points. -/
 theorem quadForm_two_nonneg (hF : IsSemigroupGroupPD F) (p q : ℝ≥0 × V) (c₀ c₁ : ℂ) :
     0 ≤ c₀ * conj c₀ * F (p.1 + p.1, p.2 - p.2)
@@ -111,6 +124,81 @@ theorem quadForm_two_nonneg (hF : IsSemigroupGroupPD F) (p q : ℝ≥0 × V) (c�
   have h := (isSemigroupGroupPD_iff.mp hF).2 ![c₀, c₁] ![p, q]
   simp only [Fin.sum_univ_two, Matrix.cons_val_zero, Matrix.cons_val_one] at h
   exact le_of_le_of_eq h (by ring)
+
+/-- A semigroup-group positive-definite function is conjugate symmetric for the BCR kernel:
+`conj (F (t + u, v - w)) = F (u + t, w - v)`. -/
+@[simp]
+theorem conj_symm (hF : IsSemigroupGroupPD F) (p q : ℝ≥0 × V) :
+    conj (F (p.1 + q.1, p.2 - q.2)) = F (q.1 + p.1, q.2 - p.2) :=
+  isPositiveDefiniteKernel_conj_symm hF.isPositiveDefiniteKernel p q
+
+/-- The value of a semigroup-group positive-definite function at `(0, 0)` is real and
+nonnegative. -/
+theorem map_zero_nonneg (hF : IsSemigroupGroupPD F) : 0 ≤ F (0, 0) := by
+  simpa using isPositiveDefiniteKernel_apply_self_nonneg hF.isPositiveDefiniteKernel
+    ((0, 0) : ℝ≥0 × V)
+
+/-- The value of a semigroup-group positive-definite function at `(0, 0)` has zero imaginary
+part. -/
+@[simp]
+theorem map_zero_im (hF : IsSemigroupGroupPD F) : (F (0, 0)).im = 0 :=
+  ((Complex.nonneg_iff.mp hF.map_zero_nonneg).2).symm
+
+/-- The real part of the value of a semigroup-group positive-definite function at `(0, 0)` is
+nonnegative. -/
+theorem map_zero_re_nonneg (hF : IsSemigroupGroupPD F) : 0 ≤ (F (0, 0)).re :=
+  (Complex.nonneg_iff.mp hF.map_zero_nonneg).1
+
+/-- The value at `(0, 0)` of a semigroup-group positive-definite function is equal to its real
+part, viewed as a complex number. -/
+theorem map_zero_eq_ofReal_re (hF : IsSemigroupGroupPD F) : F (0, 0) = ((F (0, 0)).re : ℂ) := by
+  apply Complex.ext
+  · simp
+  · simpa using hF.map_zero_im
+
+/-- Semigroup-group positive-definite functions are closed under addition. -/
+theorem add (hF : IsSemigroupGroupPD F) (hG : IsSemigroupGroupPD G) :
+    IsSemigroupGroupPD fun x => F x + G x :=
+  IsSemigroupGroupPD.of_isPositiveDefiniteKernel <| by
+    simpa only [Pi.add_apply] using
+      isPositiveDefiniteKernel_add hF.isPositiveDefiniteKernel hG.isPositiveDefiniteKernel
+
+/-- Semigroup-group positive-definite functions are closed under multiplication by a
+nonnegative complex scalar. -/
+theorem const_mul {k : ℂ} (hk : 0 ≤ k) (hF : IsSemigroupGroupPD F) :
+    IsSemigroupGroupPD fun x => k * F x :=
+  IsSemigroupGroupPD.of_isPositiveDefiniteKernel <| by
+    simpa only [Pi.smul_apply, smul_eq_mul] using
+      isPositiveDefiniteKernel_smul_of_nonneg hk hF.isPositiveDefiniteKernel
+
+/-- Semigroup-group positive-definite functions are closed under multiplication by a
+nonnegative real scalar. -/
+theorem smul_of_nonneg {r : ℝ} (hr : 0 ≤ r) (hF : IsSemigroupGroupPD F) :
+    IsSemigroupGroupPD fun x => r • F x :=
+  IsSemigroupGroupPD.of_isPositiveDefiniteKernel <|
+    isPositiveDefiniteKernel_smul hr hF.isPositiveDefiniteKernel
+
+/-- Semigroup-group positive-definite functions are closed under pointwise multiplication
+(Schur product). -/
+theorem mul (hF : IsSemigroupGroupPD F) (hG : IsSemigroupGroupPD G) :
+    IsSemigroupGroupPD fun x => F x * G x :=
+  IsSemigroupGroupPD.of_isPositiveDefiniteKernel <|
+    isPositiveDefiniteKernel_mul hF.isPositiveDefiniteKernel hG.isPositiveDefiniteKernel
+
+/-- Semigroup-group positive-definite functions are closed under finite sums. -/
+theorem sum {ι : Type*} {s : Finset ι} {F : ι → ℝ≥0 × V → ℂ}
+    (hF : ∀ i ∈ s, IsSemigroupGroupPD (F i)) :
+    IsSemigroupGroupPD fun x => ∑ i ∈ s, F i x :=
+  IsSemigroupGroupPD.of_isPositiveDefiniteKernel <|
+    isPositiveDefiniteKernel_sum fun i hi => (hF i hi).isPositiveDefiniteKernel
+
+/-- Semigroup-group positive-definite functions are closed under finite products
+(Schur products). -/
+theorem prod {ι : Type*} {s : Finset ι} {F : ι → ℝ≥0 × V → ℂ}
+    (hF : ∀ i ∈ s, IsSemigroupGroupPD (F i)) :
+    IsSemigroupGroupPD fun x => ∏ i ∈ s, F i x :=
+  IsSemigroupGroupPD.of_isPositiveDefiniteKernel <|
+    isPositiveDefiniteKernel_prod fun i hi => (hF i hi).isPositiveDefiniteKernel
 
 end IsSemigroupGroupPD
 

--- a/TauCeti/Analysis/PositiveDefinite/SemigroupGroup.lean
+++ b/TauCeti/Analysis/PositiveDefinite/SemigroupGroup.lean
@@ -72,29 +72,15 @@ namespace BCRPoint
 
 variable {V : Type*}
 
-/-- Convert a product point to the local BCR wrapper. -/
-@[expose] def ofProd (p : ℝ≥0 × V) : BCRPoint V :=
+/-- Convert a product point to the local BCR wrapper. Internal helper, not part of the public
+API. -/
+private def ofProd (p : ℝ≥0 × V) : BCRPoint V :=
   ⟨p.1, p.2⟩
 
-/-- Convert a local BCR wrapper back to the product type. -/
-@[expose] def toProd (p : BCRPoint V) : ℝ≥0 × V :=
+/-- Convert a local BCR wrapper back to the product type. Internal helper, not part of the public
+API. -/
+private def toProd (p : BCRPoint V) : ℝ≥0 × V :=
   (p.time, p.point)
-
-@[simp]
-theorem ofProd_time (p : ℝ≥0 × V) : (ofProd p).time = p.1 :=
-  rfl
-
-@[simp]
-theorem ofProd_point (p : ℝ≥0 × V) : (ofProd p).point = p.2 :=
-  rfl
-
-@[simp]
-theorem toProd_fst (p : BCRPoint V) : (toProd p).1 = p.time :=
-  rfl
-
-@[simp]
-theorem toProd_snd (p : BCRPoint V) : (toProd p).2 = p.point :=
-  rfl
 
 @[ext]
 theorem ext {p q : BCRPoint V} (ht : p.time = q.time) (hv : p.point = q.point) : p = q := by

--- a/TauCeti/Analysis/PositiveDefinite/SemigroupGroup.lean
+++ b/TauCeti/Analysis/PositiveDefinite/SemigroupGroup.lean
@@ -33,7 +33,8 @@ for `IsSemigroupGroupPD` as the positive-definite predicate on `ℝ≥0 × V` wi
 * `TauCeti.IsSemigroupGroupPD`: the BCR positive-definiteness predicate on `ℝ≥0 × V`.
 * `TauCeti.isSemigroupGroupPD_iff_isPositiveDefinite`: the bridge to the generic
   positive-definite-function predicate.
-* `TauCeti.isSemigroupGroupPD_def`: the bridge to the associated positive-definite kernel.
+* `TauCeti.isSemigroupGroupPD_iff_isPositiveDefiniteKernel`: the bridge to the associated
+  positive-definite kernel.
 * `TauCeti.isSemigroupGroupPD_iff`: the finite quadratic-form characterization.
 * `TauCeti.IsSemigroupGroupPD.conj_symm`, diagonal, and origin lemmas: basic consequences of the
   semigroup-group positive-definiteness condition.
@@ -165,7 +166,7 @@ theorem isSemigroupGroupPD_iff_isPositiveDefinite :
 
 /-- The bridge from semigroup-group positive definiteness to the associated positive-definite
 kernel. -/
-theorem isSemigroupGroupPD_def :
+theorem isSemigroupGroupPD_iff_isPositiveDefiniteKernel :
     IsSemigroupGroupPD F ↔
       IsPositiveDefiniteKernel fun p q : ℝ≥0 × V => F (p.1 + q.1, p.2 - q.2) := by
   constructor
@@ -181,14 +182,14 @@ theorem isSemigroupGroupPD_def :
 /-- The kernel associated to a semigroup-group positive-definite function is positive definite. -/
 theorem IsSemigroupGroupPD.isPositiveDefiniteKernel (hF : IsSemigroupGroupPD F) :
     IsPositiveDefiniteKernel fun p q : ℝ≥0 × V => F (p.1 + q.1, p.2 - q.2) :=
-  isSemigroupGroupPD_def.mp hF
+  isSemigroupGroupPD_iff_isPositiveDefiniteKernel.mp hF
 
 /-- Build a semigroup-group positive-definite function from the associated positive-definite
 kernel. -/
 theorem IsSemigroupGroupPD.of_isPositiveDefiniteKernel
     (hF : IsPositiveDefiniteKernel fun p q : ℝ≥0 × V => F (p.1 + q.1, p.2 - q.2)) :
     IsSemigroupGroupPD F :=
-  isSemigroupGroupPD_def.mpr hF
+  isSemigroupGroupPD_iff_isPositiveDefiniteKernel.mpr hF
 
 /-- The finite quadratic-form characterization of semigroup-group positive definiteness. -/
 theorem isSemigroupGroupPD_iff :

--- a/TauCeti/Analysis/PositiveDefinite/SemigroupGroup.lean
+++ b/TauCeti/Analysis/PositiveDefinite/SemigroupGroup.lean
@@ -4,6 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 -/
 module
 
+public import TauCeti.Analysis.PositiveDefinite.FunctionKernel
 public import TauCeti.Analysis.PositiveDefinite.Kernel
 public import TauCeti.Analysis.PositiveDefinite.KernelClosure
 public import Mathlib.Data.NNReal.Basic
@@ -16,9 +17,9 @@ for functions on `ℝ≥0 × V`. For an additive group `V`, the intended involut
 `(t, v) ↦ (t, -v)`, so the finite quadratic forms use the entries
 `F (tᵢ + tⱼ, vᵢ - vⱼ)`.
 
-The generic positive-definite-kernel predicate already captures the finite Gram-matrix condition.
-Here we name its BCR specialization for the kernel
-`K p q = F (p.1 + q.1, p.2 - q.2)`, rather than installing a global negation `StarAddMonoid`
+The generic positive-definite-function predicate already captures the finite quadratic-form
+condition. Here we name its BCR specialization by using the local wrapper `BCRPoint V`, whose
+involution is `(t, v) ↦ (t, -v)`, rather than installing a global negation `StarAddMonoid`
 instance on every additive group `V`, which would conflict with Mathlib's ordinary star
 conventions. The result is the named hypothesis needed for the BCR Laplace--Fourier
 representation target in the `OneParameterSemigroups` roadmap.
@@ -30,8 +31,9 @@ for `IsSemigroupGroupPD` as the positive-definite predicate on `ℝ≥0 × V` wi
 ## Main declarations
 
 * `TauCeti.IsSemigroupGroupPD`: the BCR positive-definiteness predicate on `ℝ≥0 × V`.
-* `TauCeti.isSemigroupGroupPD_def`: the definitional bridge to the associated
-  positive-definite kernel.
+* `TauCeti.isSemigroupGroupPD_iff_isPositiveDefinite`: the bridge to the generic
+  positive-definite-function predicate.
+* `TauCeti.isSemigroupGroupPD_def`: the bridge to the associated positive-definite kernel.
 * `TauCeti.isSemigroupGroupPD_iff`: the finite quadratic-form characterization.
 * `TauCeti.IsSemigroupGroupPD.conj_symm`, diagonal, and origin lemmas: basic consequences of the
   semigroup-group positive-definiteness condition.
@@ -56,19 +58,139 @@ namespace TauCeti
 
 variable {V : Type*} [AddCommGroup V] {F G : ℝ≥0 × V → ℂ}
 
+/-- The additive monoid `ℝ≥0 × V` equipped with the BCR involution `(t, v) ↦ (t, -v)`.
+
+This wrapper avoids installing a global negation `StarAddMonoid` instance on an arbitrary
+additive group `V`. -/
+structure BCRPoint (V : Type*) where
+  /-- The nonnegative time coordinate. -/
+  time : ℝ≥0
+  /-- The group coordinate. -/
+  point : V
+
+namespace BCRPoint
+
+variable {V : Type*}
+
+/-- Convert a product point to the local BCR wrapper. -/
+@[expose] def ofProd (p : ℝ≥0 × V) : BCRPoint V :=
+  ⟨p.1, p.2⟩
+
+/-- Convert a local BCR wrapper back to the product type. -/
+@[expose] def toProd (p : BCRPoint V) : ℝ≥0 × V :=
+  (p.time, p.point)
+
+@[simp]
+theorem ofProd_time (p : ℝ≥0 × V) : (ofProd p).time = p.1 :=
+  rfl
+
+@[simp]
+theorem ofProd_point (p : ℝ≥0 × V) : (ofProd p).point = p.2 :=
+  rfl
+
+@[simp]
+theorem toProd_fst (p : BCRPoint V) : (toProd p).1 = p.time :=
+  rfl
+
+@[simp]
+theorem toProd_snd (p : BCRPoint V) : (toProd p).2 = p.point :=
+  rfl
+
+@[ext]
+theorem ext {p q : BCRPoint V} (ht : p.time = q.time) (hv : p.point = q.point) : p = q := by
+  cases p
+  cases q
+  simp_all
+
+instance [AddCommGroup V] : Zero (BCRPoint V) where
+  zero := ⟨0, 0⟩
+
+instance [AddCommGroup V] : Add (BCRPoint V) where
+  add p q := ⟨p.time + q.time, p.point + q.point⟩
+
+instance [AddCommGroup V] : Star (BCRPoint V) where
+  star p := ⟨p.time, -p.point⟩
+
+@[simp]
+theorem zero_time [AddCommGroup V] : (0 : BCRPoint V).time = 0 :=
+  rfl
+
+@[simp]
+theorem zero_point [AddCommGroup V] : (0 : BCRPoint V).point = 0 :=
+  rfl
+
+@[simp]
+theorem add_time [AddCommGroup V] (p q : BCRPoint V) :
+    (p + q).time = p.time + q.time :=
+  rfl
+
+@[simp]
+theorem add_point [AddCommGroup V] (p q : BCRPoint V) :
+    (p + q).point = p.point + q.point :=
+  rfl
+
+@[simp]
+theorem star_time [AddCommGroup V] (p : BCRPoint V) : (star p).time = p.time :=
+  rfl
+
+@[simp]
+theorem star_point [AddCommGroup V] (p : BCRPoint V) : (star p).point = -p.point :=
+  rfl
+
+instance [AddCommGroup V] : AddCommMonoid (BCRPoint V) where
+  add := (· + ·)
+  zero := 0
+  add_assoc := by
+    intro a b c
+    ext <;> simp [add_assoc]
+  zero_add := by
+    intro a
+    ext <;> simp
+  add_zero := by
+    intro a
+    ext <;> simp
+  add_comm := by
+    intro a b
+    ext <;> simp [add_comm]
+  nsmul := nsmulRec
+
+instance [AddCommGroup V] : StarAddMonoid (BCRPoint V) where
+  star_add := by
+    intro p q
+    ext <;> simp [add_comm]
+  star_involutive := by
+    intro p
+    ext <;> simp
+
+end BCRPoint
+
 /-- A function on `ℝ≥0 × V` is semigroup-group positive definite, in the
 Berg--Christensen--Ressel sense, if all finite quadratic forms formed using the involution
 `(t, v) ↦ (t, -v)` are nonnegative:
 `∑ᵢⱼ cᵢ conj(cⱼ) F(tᵢ + tⱼ, vᵢ - vⱼ) ≥ 0`. -/
 def IsSemigroupGroupPD (F : ℝ≥0 × V → ℂ) : Prop :=
-  IsPositiveDefiniteKernel fun p q : ℝ≥0 × V => F (p.1 + q.1, p.2 - q.2)
+  IsPositiveDefinite fun p : BCRPoint V => F (p.time, p.point)
 
-/-- The definitional bridge from semigroup-group positive definiteness to the associated
-positive-definite kernel. -/
+/-- The BCR predicate is the generic positive-definite-function predicate on the local
+`BCRPoint` wrapper carrying the involution `(t, v) ↦ (t, -v)`. -/
+theorem isSemigroupGroupPD_iff_isPositiveDefinite :
+    IsSemigroupGroupPD F ↔ IsPositiveDefinite (fun p : BCRPoint V => F (p.time, p.point)) :=
+  Iff.rfl
+
+/-- The bridge from semigroup-group positive definiteness to the associated positive-definite
+kernel. -/
 theorem isSemigroupGroupPD_def :
     IsSemigroupGroupPD F ↔
-      IsPositiveDefiniteKernel fun p q : ℝ≥0 × V => F (p.1 + q.1, p.2 - q.2) :=
-  Iff.rfl
+      IsPositiveDefiniteKernel fun p q : ℝ≥0 × V => F (p.1 + q.1, p.2 - q.2) := by
+  constructor
+  · intro hF
+    have hK := IsPositiveDefinite.isPositiveDefiniteKernel hF
+    have hK' := isPositiveDefiniteKernel_comp hK (fun p : ℝ≥0 × V => BCRPoint.ofProd p)
+    simpa [BCRPoint.ofProd, sub_eq_add_neg] using hK'
+  · intro hK
+    refine IsPositiveDefinite.of_isPositiveDefiniteKernel ?_
+    have hK' := isPositiveDefiniteKernel_comp hK (fun p : BCRPoint V => BCRPoint.toProd p)
+    simpa [BCRPoint.toProd, sub_eq_add_neg] using hK'
 
 /-- The kernel associated to a semigroup-group positive-definite function is positive definite. -/
 theorem IsSemigroupGroupPD.isPositiveDefiniteKernel (hF : IsSemigroupGroupPD F) :
@@ -121,9 +243,8 @@ theorem quadForm_two_nonneg (hF : IsSemigroupGroupPD F) (p q : ℝ≥0 × V) (c�
       + c₀ * conj c₁ * F (p.1 + q.1, p.2 - q.2)
       + c₁ * conj c₀ * F (q.1 + p.1, q.2 - p.2)
       + c₁ * conj c₁ * F (q.1 + q.1, q.2 - q.2) := by
-  have h := (isSemigroupGroupPD_iff.mp hF).2 ![c₀, c₁] ![p, q]
-  simp only [Fin.sum_univ_two, Matrix.cons_val_zero, Matrix.cons_val_one] at h
-  exact le_of_le_of_eq h (by ring)
+  simpa [BCRPoint.ofProd, sub_eq_add_neg] using
+    IsPositiveDefinite.quadForm_two_nonneg hF (BCRPoint.ofProd p) (BCRPoint.ofProd q) c₀ c₁
 
 /-- A semigroup-group positive-definite function is conjugate symmetric for the BCR kernel:
 `conj (F (t + u, v - w)) = F (u + t, w - v)`. -/

--- a/TauCeti/Analysis/PositiveDefinite/SemigroupGroup.lean
+++ b/TauCeti/Analysis/PositiveDefinite/SemigroupGroup.lean
@@ -33,7 +33,7 @@ for `IsSemigroupGroupPD` as the positive-definite predicate on `ℝ≥0 × V` wi
 * `TauCeti.isSemigroupGroupPD_def`: the definitional bridge to the associated
   positive-definite kernel.
 * `TauCeti.isSemigroupGroupPD_iff`: the finite quadratic-form characterization.
-* `TauCeti.IsSemigroupGroupPD.conj_symm` and origin lemmas: basic consequences of the
+* `TauCeti.IsSemigroupGroupPD.conj_symm`, diagonal, and origin lemmas: basic consequences of the
   semigroup-group positive-definiteness condition.
 * `TauCeti.IsSemigroupGroupPD.add`, `TauCeti.IsSemigroupGroupPD.mul`, and finite
   `sum`/`prod`: closure properties inherited from positive-definite kernels.
@@ -132,29 +132,51 @@ theorem conj_symm (hF : IsSemigroupGroupPD F) (p q : ℝ≥0 × V) :
     conj (F (p.1 + q.1, p.2 - q.2)) = F (q.1 + p.1, q.2 - p.2) :=
   isPositiveDefiniteKernel_conj_symm hF.isPositiveDefiniteKernel p q
 
+/-- Values of a semigroup-group positive-definite function on the time diagonal `(t + t, 0)` are
+real and nonnegative. -/
+theorem diagonal_nonneg (hF : IsSemigroupGroupPD F) (t : ℝ≥0) : 0 ≤ F (t + t, 0) := by
+  simpa using isPositiveDefiniteKernel_apply_self_nonneg hF.isPositiveDefiniteKernel (t, 0)
+
+/-- Values of a semigroup-group positive-definite function on the time diagonal `(t + t, 0)` have
+zero imaginary part. -/
+@[simp]
+theorem diagonal_im (hF : IsSemigroupGroupPD F) (t : ℝ≥0) : (F (t + t, 0)).im = 0 :=
+  ((Complex.nonneg_iff.mp (hF.diagonal_nonneg t)).2).symm
+
+/-- The real part of a semigroup-group positive-definite function on the time diagonal
+`(t + t, 0)` is nonnegative. -/
+theorem diagonal_re_nonneg (hF : IsSemigroupGroupPD F) (t : ℝ≥0) :
+    0 ≤ (F (t + t, 0)).re :=
+  (Complex.nonneg_iff.mp (hF.diagonal_nonneg t)).1
+
+/-- A semigroup-group positive-definite function on the time diagonal `(t + t, 0)` is equal to
+its real part, viewed as a complex number. -/
+theorem diagonal_eq_ofReal_re (hF : IsSemigroupGroupPD F) (t : ℝ≥0) :
+    F (t + t, 0) = ((F (t + t, 0)).re : ℂ) := by
+  apply Complex.ext
+  · simp
+  · simpa using hF.diagonal_im t
+
 /-- The value of a semigroup-group positive-definite function at `(0, 0)` is real and
 nonnegative. -/
 theorem map_zero_nonneg (hF : IsSemigroupGroupPD F) : 0 ≤ F (0, 0) := by
-  simpa using isPositiveDefiniteKernel_apply_self_nonneg hF.isPositiveDefiniteKernel
-    ((0, 0) : ℝ≥0 × V)
+  simpa using hF.diagonal_nonneg 0
 
 /-- The value of a semigroup-group positive-definite function at `(0, 0)` has zero imaginary
 part. -/
 @[simp]
 theorem map_zero_im (hF : IsSemigroupGroupPD F) : (F (0, 0)).im = 0 :=
-  ((Complex.nonneg_iff.mp hF.map_zero_nonneg).2).symm
+  by simpa using hF.diagonal_im 0
 
 /-- The real part of the value of a semigroup-group positive-definite function at `(0, 0)` is
 nonnegative. -/
 theorem map_zero_re_nonneg (hF : IsSemigroupGroupPD F) : 0 ≤ (F (0, 0)).re :=
-  (Complex.nonneg_iff.mp hF.map_zero_nonneg).1
+  by simpa using hF.diagonal_re_nonneg 0
 
 /-- The value at `(0, 0)` of a semigroup-group positive-definite function is equal to its real
 part, viewed as a complex number. -/
 theorem map_zero_eq_ofReal_re (hF : IsSemigroupGroupPD F) : F (0, 0) = ((F (0, 0)).re : ℂ) := by
-  apply Complex.ext
-  · simp
-  · simpa using hF.map_zero_im
+  simpa using hF.diagonal_eq_ofReal_re 0
 
 /-- Semigroup-group positive-definite functions are closed under addition. -/
 theorem add (hF : IsSemigroupGroupPD F) (hG : IsSemigroupGroupPD G) :


### PR DESCRIPTION
This PR adds the Berg--Christensen--Ressel semigroup-group positive-definiteness predicate on `ℝ≥0 × V`, spelling the intended involution `(t, v) ↦ (t, -v)` directly in the finite quadratic form `F (tᵢ + tⱼ, vᵢ - vⱼ)`, and provide the first small API: arbitrary finite-index restatement, nonnegativity and reality at `(0, 0)`, conjugate symmetry, and closure under addition, nonnegative complex scalar multiplication, and finite sums.

It advances `TauCetiRoadmap/OneParameterSemigroups/README.md`, Part C, Objects, specifically the item defining `IsSemigroupGroupPD` as the positive-definite predicate on `ℝ≥0 × V` with BCR involution `(t, a)⋆ = (t, -a)`. I chose this as the lowest-hanging distinct OneParameterSemigroups target after checking open and recently merged PRs: the Bernstein representation infrastructure is already claimed in #33/#426, and the generic positive-definite predicate, kernel bridge, limits, continuity, pullbacks, and normalization have already landed, while the named BCR object-level predicate was still missing.

No Mathlib infrastructure is vendored. The implementation reuses Tau Ceti's existing `IsPositiveDefinite` conventions and Mathlib's `NNReal`, finite sums, and complex order API. The BCR convention follows Berg--Christensen--Ressel, *Harmonic Analysis on Semigroups*, Chapter 4.

`lake exe cache get` completed with `No files to download` and `Already decompressed 8586 file(s)`. `lake build` completed with `Build completed successfully (4244 jobs).` `lake exe axioms` completed with `axioms: audited 5183 TauCeti declaration(s); all within the allowlist [propext, Classical.choice, Quot.sound].`

<!--tauceti-target:v1 {"focus":"OneParameterSemigroups","id":"semigroup-group-positive-definite"}-->

🤖 Prepared with Codex
