### PR TITLE
feat: add conditionally i.i.d. directing-measure API

### DIFF
--- a/TauCeti/Probability/Exchangeability/ConditionallyIID.lean
+++ b/TauCeti/Probability/Exchangeability/ConditionallyIID.lean
@@ -74,7 +74,8 @@ theorem ConditionallyIID.of_directing {μ : Measure Ω} {X : ℕ → Ω → α}
     {ν : Ω → ProbabilityMeasure α} (h : ConditionallyIIDWith μ X ν) : ConditionallyIID μ X :=
   ⟨ν, h⟩
 
-/-- Characteristic restatement of `ConditionallyIID`. -/
+/-- Simp normal form for the existential wrapper `ConditionallyIID`. -/
+@[simp]
 theorem conditionallyIID_iff {μ : Measure Ω} {X : ℕ → Ω → α} :
     ConditionallyIID μ X ↔ ∃ ν : Ω → ProbabilityMeasure α, ConditionallyIIDWith μ X ν :=
   Iff.rfl

--- a/TauCeti/Probability/Exchangeability/ConditionallyIID.lean
+++ b/TauCeti/Probability/Exchangeability/ConditionallyIID.lean
@@ -2,6 +2,7 @@ module
 
 public import TauCeti.Probability.Exchangeability.Basic
 public import Mathlib.MeasureTheory.Measure.FiniteMeasurePi
+public import Mathlib.MeasureTheory.Measure.GiryMonad
 
 /-!
 # Conditionally i.i.d. sequences
@@ -42,25 +43,51 @@ measure `ν` is measurable, and along every finite selection `k` of **distinct**
 the block law is the `ν`-mixture of the product measure
 `ProbabilityMeasure.pi (fun _ => ν ω)`. Distinctness (`Function.Injective k`) is what product
 laws need, in contrast with the order condition `StrictMono` of `Contractable`. -/
-@[expose]
 def ConditionallyIIDWith (μ : Measure Ω) (X : ℕ → Ω → α) (ν : Ω → ProbabilityMeasure α) :
     Prop :=
   Measurable ν ∧
     ∀ (m : ℕ) (k : Fin m → ℕ), Function.Injective k →
       blockLaw μ X k = μ.bind fun ω => (ProbabilityMeasure.pi fun _ : Fin m => ν ω).toMeasure
 
+/-- Constructor: a measurable directing measure together with the finite-block mixture identity. -/
+theorem ConditionallyIIDWith.intro {μ : Measure Ω} {X : ℕ → Ω → α} {ν : Ω → ProbabilityMeasure α}
+    (hν : Measurable ν)
+    (h : ∀ (m : ℕ) (k : Fin m → ℕ), Function.Injective k →
+      blockLaw μ X k = μ.bind fun ω => (ProbabilityMeasure.pi fun _ : Fin m => ν ω).toMeasure) :
+    ConditionallyIIDWith μ X ν :=
+  ⟨hν, h⟩
+
+/-- Characteristic restatement of `ConditionallyIIDWith`. -/
+theorem conditionallyIIDWith_iff {μ : Measure Ω} {X : ℕ → Ω → α} {ν : Ω → ProbabilityMeasure α} :
+    ConditionallyIIDWith μ X ν ↔
+      Measurable ν ∧
+        ∀ (m : ℕ) (k : Fin m → ℕ), Function.Injective k →
+          blockLaw μ X k = μ.bind fun ω => (ProbabilityMeasure.pi fun _ : Fin m => ν ω).toMeasure :=
+  Iff.rfl
+
 /-- Conditional i.i.d.-ness: existence of a directing probability measure. -/
-@[expose]
 def ConditionallyIID (μ : Measure Ω) (X : ℕ → Ω → α) : Prop :=
   ∃ ν : Ω → ProbabilityMeasure α, ConditionallyIIDWith μ X ν
 
+/-- Constructor from a directing measure together with its witness. -/
+theorem ConditionallyIID.of_directing {μ : Measure Ω} {X : ℕ → Ω → α}
+    {ν : Ω → ProbabilityMeasure α} (h : ConditionallyIIDWith μ X ν) : ConditionallyIID μ X :=
+  ⟨ν, h⟩
+
+/-- Characteristic restatement of `ConditionallyIID`. -/
+theorem conditionallyIID_iff {μ : Measure Ω} {X : ℕ → Ω → α} :
+    ConditionallyIID μ X ↔ ∃ ν : Ω → ProbabilityMeasure α, ConditionallyIIDWith μ X ν :=
+  Iff.rfl
+
 /-- The directing measure of a `ConditionallyIIDWith` witness is measurable. -/
+@[grind →]
 theorem ConditionallyIIDWith.measurable_directing {μ : Measure Ω} {X : ℕ → Ω → α}
     {ν : Ω → ProbabilityMeasure α} (h : ConditionallyIIDWith μ X ν) : Measurable ν :=
   h.1
 
 /-- The defining finite-block mixture identity of a `ConditionallyIIDWith` witness. Named
 `finite_map_eq` rather than `map_eq` to avoid colliding with `Measure.map` lemmas. -/
+@[grind =>]
 theorem ConditionallyIIDWith.finite_map_eq {μ : Measure Ω} {X : ℕ → Ω → α}
     {ν : Ω → ProbabilityMeasure α} (h : ConditionallyIIDWith μ X ν)
     {m : ℕ} (k : Fin m → ℕ) (hk : Function.Injective k) :

--- a/TauCeti/Probability/Exchangeability/ConditionallyIID.lean
+++ b/TauCeti/Probability/Exchangeability/ConditionallyIID.lean
@@ -57,7 +57,8 @@ theorem ConditionallyIIDWith.intro {μ : Measure Ω} {X : ℕ → Ω → α} {ν
     ConditionallyIIDWith μ X ν :=
   ⟨hν, h⟩
 
-/-- Characteristic restatement of `ConditionallyIIDWith`. -/
+/-- Simp normal form for `ConditionallyIIDWith`. -/
+@[simp]
 theorem conditionallyIIDWith_iff {μ : Measure Ω} {X : ℕ → Ω → α} {ν : Ω → ProbabilityMeasure α} :
     ConditionallyIIDWith μ X ν ↔
       Measurable ν ∧

--- a/TauCeti/Probability/Exchangeability/ConditionallyIID.lean
+++ b/TauCeti/Probability/Exchangeability/ConditionallyIID.lean
@@ -85,10 +85,9 @@ theorem ConditionallyIIDWith.measurable_directing {μ : Measure Ω} {X : ℕ →
     {ν : Ω → ProbabilityMeasure α} (h : ConditionallyIIDWith μ X ν) : Measurable ν :=
   h.1
 
-/-- The defining finite-block mixture identity of a `ConditionallyIIDWith` witness. Named
-`finite_map_eq` rather than `map_eq` to avoid colliding with `Measure.map` lemmas. -/
+/-- The defining finite-block mixture identity of a `ConditionallyIIDWith` witness. -/
 @[grind =>]
-theorem ConditionallyIIDWith.finite_map_eq {μ : Measure Ω} {X : ℕ → Ω → α}
+theorem ConditionallyIIDWith.map {μ : Measure Ω} {X : ℕ → Ω → α}
     {ν : Ω → ProbabilityMeasure α} (h : ConditionallyIIDWith μ X ν)
     {m : ℕ} (k : Fin m → ℕ) (hk : Function.Injective k) :
     blockLaw μ X k = μ.bind fun ω => (ProbabilityMeasure.pi fun _ : Fin m => ν ω).toMeasure :=

--- a/TauCeti/Probability/Exchangeability/ConditionallyIID.lean
+++ b/TauCeti/Probability/Exchangeability/ConditionallyIID.lean
@@ -1,0 +1,78 @@
+module
+
+public import TauCeti.Probability.Exchangeability.Basic
+public import Mathlib.MeasureTheory.Measure.FiniteMeasurePi
+
+/-!
+# Conditionally i.i.d. sequences
+
+The directing-measure API for de Finetti's theorem. A process is *conditionally i.i.d.* when
+there is a measurable random probability measure `ν : Ω → ProbabilityMeasure α` such that
+every finite block of **distinct** coordinates has, as its law, the `ν`-mixture of the
+corresponding product measure. `ConditionallyIIDWith μ X ν` names the directing measure;
+`ConditionallyIID` is the existential wrapper.
+
+This file adds the Layer 0 directing-measure definitions and their destructors only. The
+bridge `ConditionallyIID → Exchangeable` (permutation invariance of the finite product
+measures) is a later milestone.
+
+These declarations follow the roadmap signatures in
+`TauCetiRoadmap/Exchangeability/README.md` and
+`TauCetiRoadmap/Exchangeability/Targets.lean`, Layer 0, refining the existential
+`ConditionallyIID` of the roadmap into a named-directing-measure relation
+(`ConditionallyIIDWith`) plus its existential wrapper. They are adapted from the
+`cameronfreer/exchangeability` Layer 0 sources pinned at
+`e0532e59ceff23edab44dda9ab0655debbc9cc22`, with Tau Ceti API names and hypotheses.
+-/
+
+public section
+
+noncomputable section
+
+open MeasureTheory
+
+namespace TauCeti
+
+namespace Probability
+
+variable {Ω α : Type*} [MeasurableSpace Ω] [MeasurableSpace α]
+
+/-- Conditional i.i.d.-ness with a specified directing probability measure `ν`: the random
+measure `ν` is measurable, and along every finite selection `k` of **distinct** coordinates
+the block law is the `ν`-mixture of the product measure
+`ProbabilityMeasure.pi (fun _ => ν ω)`. Distinctness (`Function.Injective k`) is what product
+laws need, in contrast with the order condition `StrictMono` of `Contractable`. -/
+@[expose]
+def ConditionallyIIDWith (μ : Measure Ω) (X : ℕ → Ω → α) (ν : Ω → ProbabilityMeasure α) :
+    Prop :=
+  Measurable ν ∧
+    ∀ (m : ℕ) (k : Fin m → ℕ), Function.Injective k →
+      blockLaw μ X k = μ.bind fun ω => (ProbabilityMeasure.pi fun _ : Fin m => ν ω).toMeasure
+
+/-- Conditional i.i.d.-ness: existence of a directing probability measure. -/
+@[expose]
+def ConditionallyIID (μ : Measure Ω) (X : ℕ → Ω → α) : Prop :=
+  ∃ ν : Ω → ProbabilityMeasure α, ConditionallyIIDWith μ X ν
+
+/-- The directing measure of a `ConditionallyIIDWith` witness is measurable. -/
+theorem ConditionallyIIDWith.measurable_directing {μ : Measure Ω} {X : ℕ → Ω → α}
+    {ν : Ω → ProbabilityMeasure α} (h : ConditionallyIIDWith μ X ν) : Measurable ν :=
+  h.1
+
+/-- The defining finite-block mixture identity of a `ConditionallyIIDWith` witness. Named
+`finite_map_eq` rather than `map_eq` to avoid colliding with `Measure.map` lemmas. -/
+theorem ConditionallyIIDWith.finite_map_eq {μ : Measure Ω} {X : ℕ → Ω → α}
+    {ν : Ω → ProbabilityMeasure α} (h : ConditionallyIIDWith μ X ν)
+    {m : ℕ} (k : Fin m → ℕ) (hk : Function.Injective k) :
+    blockLaw μ X k = μ.bind fun ω => (ProbabilityMeasure.pi fun _ : Fin m => ν ω).toMeasure :=
+  h.2 m k hk
+
+/-- A `ConditionallyIID` process has a directing probability measure. -/
+theorem ConditionallyIID.exists_directing {μ : Measure Ω} {X : ℕ → Ω → α}
+    (h : ConditionallyIID μ X) :
+    ∃ ν : Ω → ProbabilityMeasure α, ConditionallyIIDWith μ X ν :=
+  h
+
+end Probability
+
+end TauCeti


### PR DESCRIPTION
## Summary

Adds `TauCeti/Probability/Exchangeability/ConditionallyIID.lean`, the Layer 0 **directing-measure
API** for de Finetti: a measurable random probability measure under which finite blocks of distinct
coordinates have, as their law, the mixture of the corresponding product measures.

- `ConditionallyIIDWith μ X ν` — `ν : Ω → ProbabilityMeasure α` is measurable, and along every finite
  selection `k : Fin m → ℕ` of **distinct** coordinates (`Function.Injective k`) the block law
  `blockLaw μ X k` equals the `ν`-mixture
  `μ.bind (fun ω => (ProbabilityMeasure.pi (fun _ => ν ω)).toMeasure)`;
- `ConditionallyIID μ X` — the existential wrapper;
- destructors `ConditionallyIIDWith.measurable_directing`, `ConditionallyIIDWith.map`, and
  `ConditionallyIID.exists_directing`.

It advances `TauCetiRoadmap/Exchangeability/README.md` and `Targets.lean`, Layer 0 — the
directing-measure item — refining the roadmap's existential `ConditionallyIID` into a
named-directing-measure relation (`ConditionallyIIDWith`) plus its existential wrapper. `Measurable ν`
matches the roadmap's "measurable random probability measure"; the injective-selection condition (vs
`StrictMono` for `Contractable`) is the distinctness that product laws need.

Definitions and destructors only; the `ConditionallyIID → Exchangeable` bridge (permutation invariance
of the finite product measures) is a later milestone. No Mathlib infrastructure is vendored: the
implementation reuses `ProbabilityMeasure.pi`, `Measure.bind`, and #451's `blockLaw`. Adapted from
`cameronfreer/exchangeability` pinned at `e0532e59ceff23edab44dda9ab0655debbc9cc22`, with Tau Ceti API
names and hypotheses.

## Coordination

I chose this as the next distinct Exchangeability target after checking open and recently merged PRs:
#451 landed the Layer 0 basics (block/prefix/path laws, the symmetry classes, contractability) but did
not include the directing-measure API, and no open or recent PR covers conditional-i.i.d. This builds
directly on #451, reusing its `blockLaw` (which already supports arbitrary distinct selections, not
just prefixes) and following its conventions (nested `TauCeti.Probability` namespace, `@[expose]`
definitions).

<!--tauceti-target:v1 {"focus":"Exchangeability","id":"exchangeability-conditionally-iid"}-->

## Test plan

`lake build` completed with `Build completed successfully (4257 jobs).` `lake exe axioms` completed
with `axioms: audited 5215 TauCeti declaration(s); all within the allowlist [propext, Classical.choice,
Quot.sound].` `lake exe module-system` reported all 230 TauCeti modules opt into the module system.
