### PR TITLE
feat: prove exchangeable implies contractable

### DIFF
--- a/TauCeti/Probability/Exchangeability/Basic.lean
+++ b/TauCeti/Probability/Exchangeability/Basic.lean
@@ -161,12 +161,12 @@ theorem map_blockLaw_reindex (μ : Measure Ω) {X : ℕ → Ω → α} {n p : �
 /-- Projecting the prefix law on `Fin n` onto its first `m ≤ n` coordinates (via `Fin.castLE`)
 gives the prefix law on `Fin m`. -/
 theorem map_prefixLaw_castLE (μ : Measure Ω) {X : ℕ → Ω → α} {m n : ℕ} (hmn : m ≤ n)
-    (hX : ∀ i, AEMeasurable (X i) μ) :
+    (hX : ∀ i : Fin n, AEMeasurable (X i.val) μ) :
     (prefixLaw μ X n).map (fun x : Fin n → α => fun i : Fin m => x (Fin.castLE hmn i)) =
       prefixLaw μ X m := by
   have hidx : (fun i : Fin n => i.val) ∘ Fin.castLE hmn = fun i : Fin m => i.val := by
     funext i; simp
-  rw [prefixLaw_apply, map_blockLaw_reindex μ _ (Fin.castLE hmn) (fun j => hX j.val), hidx]
+  rw [prefixLaw_apply, map_blockLaw_reindex μ _ (Fin.castLE hmn) hX, hidx]
   exact (prefixLaw_apply μ X m).symm
 
 theorem Exchangeable.exchangeableAt {μ : Measure Ω} {X : ℕ → Ω → α}

--- a/TauCeti/Probability/Exchangeability/Basic.lean
+++ b/TauCeti/Probability/Exchangeability/Basic.lean
@@ -146,6 +146,29 @@ theorem map_prefixLaw (μ : Measure Ω) {X : ℕ → Ω → α}
       prefixLaw μ (fun n ω => f (X n ω)) n :=
   map_blockLaw μ (fun i : Fin n => i.val) hf hX
 
+/-- Push a block law forward along a coordinate reindexing: selecting the coordinates of
+`blockLaw μ X k` through `g : Fin p → Fin n` yields the block law along `k ∘ g`. -/
+theorem map_blockLaw_reindex (μ : Measure Ω) {X : ℕ → Ω → α} {n p : ℕ}
+    (k : Fin n → ℕ) (g : Fin p → Fin n) (hXk : ∀ j : Fin n, AEMeasurable (X (k j)) μ) :
+    (blockLaw μ X k).map (fun x : Fin n → α => fun i : Fin p => x (g i)) =
+      blockLaw μ X (k ∘ g) := by
+  rw [blockLaw_apply, blockLaw_apply,
+    AEMeasurable.map_map_of_aemeasurable
+      ((measurable_pi_lambda _ fun i => measurable_pi_apply (g i)).aemeasurable)
+      (aemeasurable_pi_lambda _ hXk)]
+  rfl
+
+/-- Projecting the prefix law on `Fin n` onto its first `m ≤ n` coordinates (via `Fin.castLE`)
+gives the prefix law on `Fin m`. -/
+theorem map_prefixLaw_castLE (μ : Measure Ω) {X : ℕ → Ω → α} {m n : ℕ} (hmn : m ≤ n)
+    (hX : ∀ i, AEMeasurable (X i) μ) :
+    (prefixLaw μ X n).map (fun x : Fin n → α => fun i : Fin m => x (Fin.castLE hmn i)) =
+      prefixLaw μ X m := by
+  have hidx : (fun i : Fin n => i.val) ∘ Fin.castLE hmn = fun i : Fin m => i.val := by
+    funext i; simp
+  rw [prefixLaw_apply, map_blockLaw_reindex μ _ (Fin.castLE hmn) (fun j => hX j.val), hidx]
+  exact (prefixLaw_apply μ X m).symm
+
 theorem Exchangeable.exchangeableAt {μ : Measure Ω} {X : ℕ → Ω → α}
     (h : Exchangeable μ X) (n : ℕ) : ExchangeableAt μ X n :=
   h n

--- a/TauCeti/Probability/Exchangeability/Contractability.lean
+++ b/TauCeti/Probability/Exchangeability/Contractability.lean
@@ -86,9 +86,9 @@ private theorem exists_perm_extending_strictMono {m n : ℕ} (k : Fin m → ℕ)
     (fun i j hij => hk.injective (Fin.mk.inj hij))
   exact ⟨σ, fun i => congrArg Fin.val (hσ i)⟩
 
-/-- **Every exchangeable sequence is contractable**: along any strictly increasing finite
-selection `k : Fin m → ℕ`, the block law `blockLaw μ X k` equals the prefix law `prefixLaw μ X m`.
-One direction of the de Finetti–Ryll-Nardzewski equivalence. -/
+/-- **Every exchangeable sequence with a.e. measurable coordinates is contractable**: along any
+strictly increasing finite selection `k : Fin m → ℕ`, the block law `blockLaw μ X k` equals the
+prefix law `prefixLaw μ X m`. One direction of the de Finetti–Ryll-Nardzewski equivalence. -/
 theorem contractable_of_exchangeable {μ : Measure Ω} {X : ℕ → Ω → α}
     (hX : Exchangeable μ X) (hX_meas : ∀ i, AEMeasurable (X i) μ) : Contractable μ X := by
   intro m k hk
@@ -121,8 +121,8 @@ theorem contractable_of_exchangeable {μ : Measure Ω} {X : ℕ → Ω → α}
       (Measure.map (fun x : Fin n → α => fun i : Fin (m' + 1) => x (Fin.castLE hmn i))) hexch
     rwa [hLHS, hRHS] at key
 
-/-- Every exchangeable sequence is contractable (dot-notation form of
-`contractable_of_exchangeable`). -/
+/-- Every exchangeable sequence with a.e. measurable coordinates is contractable (dot-notation
+form of `contractable_of_exchangeable`). -/
 theorem Exchangeable.contractable {μ : Measure Ω} {X : ℕ → Ω → α}
     (hX : Exchangeable μ X) (hX_meas : ∀ i, AEMeasurable (X i) μ) : Contractable μ X :=
   contractable_of_exchangeable hX hX_meas

--- a/TauCeti/Probability/Exchangeability/Contractability.lean
+++ b/TauCeti/Probability/Exchangeability/Contractability.lean
@@ -15,8 +15,17 @@ It also provides `map_blockLaw_reindex`, the coordinate-reindexing pushforward o
 (the companion of `Basic`'s value-reindexing `map_blockLaw`), used here to project
 finite-dimensional laws onto sub-blocks.
 
+The main result is `contractable_of_exchangeable` (with dot-notation form
+`Exchangeable.contractable`): every exchangeable sequence is contractable. The proof realizes a
+strictly increasing finite selection as the first coordinates of a permutation of a large enough
+`Fin n` (`exists_perm_extending_strictMono`, a thin wrapper around Mathlib's
+`Equiv.Perm.exists_extending_pair`), applies exchangeability at that dimension, and projects back
+to the chosen sub-block.
+
 These declarations are adapted from the `cameronfreer/exchangeability` Layer 0 sources pinned
-at `e0532e59ceff23edab44dda9ab0655debbc9cc22`, with Tau Ceti API names and hypotheses.
+at `e0532e59ceff23edab44dda9ab0655debbc9cc22`, with Tau Ceti API names and hypotheses; the
+combinatorial core is Mathlib's `Equiv.Perm.exists_extending_pair` (Cameron Freer, Mathlib
+#34599).
 -/
 
 public section
@@ -82,6 +91,70 @@ theorem Contractable.comp {μ : Measure Ω} {X : ℕ → Ω → α} (h : Contrac
     _ = blockLaw μ (fun n ω => X (φ n) ω) (fun i : Fin m => i.val) := by
       exact (h.map (hφ.comp (Fin.val_strictMono : StrictMono (fun i : Fin m => i.val)))).symm
     _ = prefixLaw μ (fun n ω => X (φ n) ω) m := rfl
+
+/-- Any strictly increasing finite selection extends to a permutation of a large enough `Fin n`:
+given `k : Fin m → ℕ` strictly increasing with every value `< n` and `m ≤ n`, there is a
+permutation `σ` of `Fin n` with `(σ ⟨i, _⟩).val = k i` for every `i : Fin m`.
+
+This is a thin wrapper around Mathlib's `Equiv.Perm.exists_extending_pair` (Cameron Freer,
+Mathlib #34599), applied to the initial-segment inclusion `Fin.castLE hmn` and the strictly
+monotone embedding `i ↦ ⟨k i, _⟩`, both injective. -/
+theorem exists_perm_extending_strictMono {m n : ℕ} (k : Fin m → ℕ)
+    (hk : StrictMono k) (hk_bound : ∀ i, k i < n) (hmn : m ≤ n) :
+    ∃ σ : Equiv.Perm (Fin n), ∀ i : Fin m,
+      (σ ⟨i.val, Nat.lt_of_lt_of_le i.isLt hmn⟩).val = k i := by
+  obtain ⟨σ, hσ⟩ := Equiv.Perm.exists_extending_pair (Fin.castLE hmn)
+    (fun i => ⟨k i, hk_bound i⟩)
+    (fun i j h => by
+      apply Fin.val_injective
+      exact (congrArg Fin.val h : (Fin.castLE hmn i).val = (Fin.castLE hmn j).val))
+    (fun i j hij => hk.injective (Fin.mk.inj hij))
+  exact ⟨σ, fun i => congrArg Fin.val (hσ i)⟩
+
+/-- **Every exchangeable sequence is contractable.** Along any strictly increasing finite
+selection `k : Fin m → ℕ`, the block law equals the prefix law.
+
+The proof extends `k` to a permutation `σ` of a large enough `Fin n`
+(`exists_perm_extending_strictMono`), invokes exchangeability at dimension `n`, and projects both
+laws onto the first `m` coordinates with `map_blockLaw_reindex`. -/
+theorem contractable_of_exchangeable {μ : Measure Ω} {X : ℕ → Ω → α}
+    (hX : Exchangeable μ X) (hX_meas : ∀ i, AEMeasurable (X i) μ) : Contractable μ X := by
+  intro m k hk
+  cases m with
+  | zero =>
+    rw [blockLaw_apply, prefixLaw_apply, blockLaw_apply]
+    congr 1
+    funext ω i
+    exact i.elim0
+  | succ m' =>
+    set n := max (m' + 1) (k (Fin.last m') + 1) with hn
+    have hmn : m' + 1 ≤ n := le_max_left _ _
+    have hk_bound : ∀ i, k i < n := by
+      intro i
+      have h₁ : k i ≤ k (Fin.last m') := hk.monotone (Fin.le_last i)
+      omega
+    obtain ⟨σ, hσ⟩ := exists_perm_extending_strictMono k hk hk_bound hmn
+    have hexch : blockLaw μ X (fun i : Fin n => (σ i).val) = prefixLaw μ X n :=
+      (hX.exchangeableAt n).permute σ
+    have hLHS : (blockLaw μ X (fun i : Fin n => (σ i).val)).map
+          (fun x : Fin n → α => fun i : Fin (m' + 1) => x (Fin.castLE hmn i)) = blockLaw μ X k := by
+      have hidx : (fun i : Fin n => (σ i).val) ∘ Fin.castLE hmn = k := by
+        funext i; exact hσ i
+      rw [map_blockLaw_reindex μ _ (Fin.castLE hmn) (fun j => hX_meas (σ j).val), hidx]
+    have hRHS : (prefixLaw μ X n).map
+          (fun x : Fin n → α => fun i : Fin (m' + 1) => x (Fin.castLE hmn i)) =
+            prefixLaw μ X (m' + 1) := by
+      rw [prefixLaw_apply, map_blockLaw_reindex μ _ (Fin.castLE hmn) (fun j => hX_meas j.val)]
+      rfl
+    have key := congrArg
+      (Measure.map (fun x : Fin n → α => fun i : Fin (m' + 1) => x (Fin.castLE hmn i))) hexch
+    rwa [hLHS, hRHS] at key
+
+/-- Every exchangeable sequence is contractable (dot-notation form of
+`contractable_of_exchangeable`). -/
+theorem Exchangeable.contractable {μ : Measure Ω} {X : ℕ → Ω → α}
+    (hX : Exchangeable μ X) (hX_meas : ∀ i, AEMeasurable (X i) μ) : Contractable μ X :=
+  contractable_of_exchangeable hX hX_meas
 
 end Probability
 

--- a/TauCeti/Probability/Exchangeability/Contractability.lean
+++ b/TauCeti/Probability/Exchangeability/Contractability.lean
@@ -92,6 +92,34 @@ theorem Contractable.comp {μ : Measure Ω} {X : ℕ → Ω → α} (h : Contrac
       exact (h.map (hφ.comp (Fin.val_strictMono : StrictMono (fun i : Fin m => i.val)))).symm
     _ = prefixLaw μ (fun n ω => X (φ n) ω) m := rfl
 
+/-- For a contractable process, any two strictly increasing selections of the same length have
+the same block law. -/
+theorem Contractable.allStrictMono_eq {μ : Measure Ω} {X : ℕ → Ω → α} (h : Contractable μ X)
+    {m : ℕ} {k₁ k₂ : Fin m → ℕ} (hk₁ : StrictMono k₁) (hk₂ : StrictMono k₂) :
+    blockLaw μ X k₁ = blockLaw μ X k₂ :=
+  (h.map hk₁).trans (h.map hk₂).symm
+
+/-- For a contractable process, every length-`m` consecutive block starting at `c`, namely
+`(X c, X (c+1), …, X (c+m-1))`, has the prefix law. -/
+theorem Contractable.shift_segment_eq {μ : Measure Ω} {X : ℕ → Ω → α} (h : Contractable μ X)
+    (m c : ℕ) :
+    blockLaw μ X (fun i : Fin m => c + i.val) = prefixLaw μ X m :=
+  h.map fun _ _ hij => Nat.add_lt_add_left hij c
+
+/-- For a contractable process, a strictly increasing selection shifted by an offset `c` has the
+prefix law. -/
+theorem Contractable.shift_and_select {μ : Measure Ω} {X : ℕ → Ω → α} (h : Contractable μ X)
+    {m : ℕ} (k : Fin m → ℕ) (c : ℕ) (hk : StrictMono k) :
+    blockLaw μ X (fun i => c + k i) = prefixLaw μ X m :=
+  h.map fun _ _ hij => Nat.add_lt_add_left (hk hij) c
+
+/-- For a contractable process, a strictly increasing selection of coordinates from `Fin n` has
+the prefix law. -/
+theorem Contractable.restrict {μ : Measure Ω} {X : ℕ → Ω → α} (h : Contractable μ X)
+    {n m : ℕ} (k : Fin m → Fin n) (hk : StrictMono k) :
+    blockLaw μ X (fun i => (k i).val) = prefixLaw μ X m :=
+  h.map fun _ _ hij => hk hij
+
 /-- Any strictly increasing finite selection extends to a permutation of a large enough `Fin n`:
 given `k : Fin m → ℕ` strictly increasing with every value `< n` and `m ≤ n`, there is a
 permutation `σ` of `Fin n` with `(σ ⟨i, _⟩).val = k i` for every `i : Fin m`.

--- a/TauCeti/Probability/Exchangeability/Contractability.lean
+++ b/TauCeti/Probability/Exchangeability/Contractability.lean
@@ -116,7 +116,7 @@ theorem contractable_of_exchangeable {μ : Measure Ω} {X : ℕ → Ω → α}
     have hRHS : (prefixLaw μ X n).map
           (fun x : Fin n → α => fun i : Fin (m' + 1) => x (Fin.castLE hmn i)) =
             prefixLaw μ X (m' + 1) :=
-      map_prefixLaw_castLE μ hmn hX_meas
+      map_prefixLaw_castLE μ hmn (fun j => hX_meas j.val)
     have key := congrArg
       (Measure.map (fun x : Fin n → α => fun i : Fin (m' + 1) => x (Fin.castLE hmn i))) hexch
     rwa [hLHS, hRHS] at key

--- a/TauCeti/Probability/Exchangeability/Contractability.lean
+++ b/TauCeti/Probability/Exchangeability/Contractability.lean
@@ -12,7 +12,8 @@ This file records basic lemmas for `Contractable` processes. The definitions liv
 contractability-specific API.
 
 The main result is `contractable_of_exchangeable` (with dot-notation form
-`Exchangeable.contractable`): every exchangeable sequence is contractable.
+`Exchangeable.contractable`): every exchangeable sequence with a.e. measurable coordinates is
+contractable.
 
 These declarations are adapted from the `cameronfreer/exchangeability` Layer 0 sources pinned
 at `e0532e59ceff23edab44dda9ab0655debbc9cc22`, with Tau Ceti API names and hypotheses; the

--- a/TauCeti/Probability/Exchangeability/Contractability.lean
+++ b/TauCeti/Probability/Exchangeability/Contractability.lean
@@ -2,7 +2,7 @@ module
 
 public import TauCeti.Probability.Exchangeability.Basic
 public import Mathlib.Order.Fin.Basic
-public import Mathlib.Logic.Equiv.Fintype
+import Mathlib.Logic.Equiv.Fintype
 
 /-!
 # Contractability API

--- a/TauCeti/Probability/Exchangeability/Contractability.lean
+++ b/TauCeti/Probability/Exchangeability/Contractability.lean
@@ -2,6 +2,7 @@ module
 
 public import TauCeti.Probability.Exchangeability.Basic
 public import Mathlib.Order.Fin.Basic
+public import Mathlib.Logic.Equiv.Fintype
 
 /-!
 # Contractability API
@@ -9,6 +10,10 @@ public import Mathlib.Order.Fin.Basic
 This file records basic lemmas for `Contractable` processes. The definitions live in
 `TauCeti.Probability.Exchangeability.Basic`; this file is the Layer 0 home for
 contractability-specific API.
+
+It also provides `map_blockLaw_reindex`, the coordinate-reindexing pushforward of block laws
+(the companion of `Basic`'s value-reindexing `map_blockLaw`), used here to project
+finite-dimensional laws onto sub-blocks.
 
 These declarations are adapted from the `cameronfreer/exchangeability` Layer 0 sources pinned
 at `e0532e59ceff23edab44dda9ab0655debbc9cc22`, with Tau Ceti API names and hypotheses.
@@ -25,6 +30,20 @@ namespace TauCeti
 namespace Probability
 
 variable {Ω α : Type*} [MeasurableSpace Ω] [MeasurableSpace α]
+
+/-- Push a block law forward along a coordinate reindexing: selecting the coordinates of
+`blockLaw μ X k` through `g : Fin p → Fin n` yields the block law along `k ∘ g`. This is the
+coordinate-reindexing companion of `Basic`'s `map_blockLaw` (which reindexes the *values*),
+used to project a finite-dimensional law onto a sub-block. -/
+theorem map_blockLaw_reindex (μ : Measure Ω) {X : ℕ → Ω → α} {n p : ℕ}
+    (k : Fin n → ℕ) (g : Fin p → Fin n) (hXk : ∀ j : Fin n, AEMeasurable (X (k j)) μ) :
+    (blockLaw μ X k).map (fun x : Fin n → α => fun i : Fin p => x (g i)) =
+      blockLaw μ X (k ∘ g) := by
+  rw [blockLaw_apply, blockLaw_apply,
+    AEMeasurable.map_map_of_aemeasurable
+      ((measurable_pi_lambda _ fun i => measurable_pi_apply (g i)).aemeasurable)
+      (aemeasurable_pi_lambda _ hXk)]
+  rfl
 
 /-- A contractable process has the same finite-dimensional block law as the corresponding
 prefix law along any strictly increasing finite index map. -/

--- a/TauCeti/Probability/Exchangeability/Contractability.lean
+++ b/TauCeti/Probability/Exchangeability/Contractability.lean
@@ -40,20 +40,6 @@ namespace Probability
 
 variable {Ω α : Type*} [MeasurableSpace Ω] [MeasurableSpace α]
 
-/-- Push a block law forward along a coordinate reindexing: selecting the coordinates of
-`blockLaw μ X k` through `g : Fin p → Fin n` yields the block law along `k ∘ g`. This is the
-coordinate-reindexing companion of `Basic`'s `map_blockLaw` (which reindexes the *values*),
-used to project a finite-dimensional law onto a sub-block. -/
-theorem map_blockLaw_reindex (μ : Measure Ω) {X : ℕ → Ω → α} {n p : ℕ}
-    (k : Fin n → ℕ) (g : Fin p → Fin n) (hXk : ∀ j : Fin n, AEMeasurable (X (k j)) μ) :
-    (blockLaw μ X k).map (fun x : Fin n → α => fun i : Fin p => x (g i)) =
-      blockLaw μ X (k ∘ g) := by
-  rw [blockLaw_apply, blockLaw_apply,
-    AEMeasurable.map_map_of_aemeasurable
-      ((measurable_pi_lambda _ fun i => measurable_pi_apply (g i)).aemeasurable)
-      (aemeasurable_pi_lambda _ hXk)]
-  rfl
-
 /-- A contractable process has the same finite-dimensional block law as the corresponding
 prefix law along any strictly increasing finite index map. -/
 theorem Contractable.map {μ : Measure Ω} {X : ℕ → Ω → α} (h : Contractable μ X)
@@ -171,9 +157,8 @@ theorem contractable_of_exchangeable {μ : Measure Ω} {X : ℕ → Ω → α}
       rw [map_blockLaw_reindex μ _ (Fin.castLE hmn) (fun j => hX_meas (σ j).val), hidx]
     have hRHS : (prefixLaw μ X n).map
           (fun x : Fin n → α => fun i : Fin (m' + 1) => x (Fin.castLE hmn i)) =
-            prefixLaw μ X (m' + 1) := by
-      rw [prefixLaw_apply, map_blockLaw_reindex μ _ (Fin.castLE hmn) (fun j => hX_meas j.val)]
-      rfl
+            prefixLaw μ X (m' + 1) :=
+      map_prefixLaw_castLE μ hmn hX_meas
     have key := congrArg
       (Measure.map (fun x : Fin n → α => fun i : Fin (m' + 1) => x (Fin.castLE hmn i))) hexch
     rwa [hLHS, hRHS] at key

--- a/TauCeti/Probability/Exchangeability/Contractability.lean
+++ b/TauCeti/Probability/Exchangeability/Contractability.lean
@@ -11,16 +11,8 @@ This file records basic lemmas for `Contractable` processes. The definitions liv
 `TauCeti.Probability.Exchangeability.Basic`; this file is the Layer 0 home for
 contractability-specific API.
 
-It also provides `map_blockLaw_reindex`, the coordinate-reindexing pushforward of block laws
-(the companion of `Basic`'s value-reindexing `map_blockLaw`), used here to project
-finite-dimensional laws onto sub-blocks.
-
 The main result is `contractable_of_exchangeable` (with dot-notation form
-`Exchangeable.contractable`): every exchangeable sequence is contractable. The proof realizes a
-strictly increasing finite selection as the first coordinates of a permutation of a large enough
-`Fin n` (`exists_perm_extending_strictMono`, a thin wrapper around Mathlib's
-`Equiv.Perm.exists_extending_pair`), applies exchangeability at that dimension, and projects back
-to the chosen sub-block.
+`Exchangeable.contractable`): every exchangeable sequence is contractable.
 
 These declarations are adapted from the `cameronfreer/exchangeability` Layer 0 sources pinned
 at `e0532e59ceff23edab44dda9ab0655debbc9cc22`, with Tau Ceti API names and hypotheses; the
@@ -78,45 +70,14 @@ theorem Contractable.comp {μ : Measure Ω} {X : ℕ → Ω → α} (h : Contrac
       exact (h.map (hφ.comp (Fin.val_strictMono : StrictMono (fun i : Fin m => i.val)))).symm
     _ = prefixLaw μ (fun n ω => X (φ n) ω) m := rfl
 
-/-- For a contractable process, any two strictly increasing selections of the same length have
-the same block law. -/
-theorem Contractable.allStrictMono_eq {μ : Measure Ω} {X : ℕ → Ω → α} (h : Contractable μ X)
-    {m : ℕ} {k₁ k₂ : Fin m → ℕ} (hk₁ : StrictMono k₁) (hk₂ : StrictMono k₂) :
-    blockLaw μ X k₁ = blockLaw μ X k₂ :=
-  (h.map hk₁).trans (h.map hk₂).symm
-
-/-- For a contractable process, every length-`m` consecutive block starting at `c`, namely
-`(X c, X (c+1), …, X (c+m-1))`, has the prefix law. -/
-theorem Contractable.shift_segment_eq {μ : Measure Ω} {X : ℕ → Ω → α} (h : Contractable μ X)
-    (m c : ℕ) :
-    blockLaw μ X (fun i : Fin m => c + i.val) = prefixLaw μ X m :=
-  h.map fun _ _ hij => Nat.add_lt_add_left hij c
-
-/-- For a contractable process, a strictly increasing selection shifted by an offset `c` has the
-prefix law. -/
-theorem Contractable.shift_and_select {μ : Measure Ω} {X : ℕ → Ω → α} (h : Contractable μ X)
-    {m : ℕ} (k : Fin m → ℕ) (c : ℕ) (hk : StrictMono k) :
-    blockLaw μ X (fun i => c + k i) = prefixLaw μ X m :=
-  h.map fun _ _ hij => Nat.add_lt_add_left (hk hij) c
-
-/-- For a contractable process, a strictly increasing selection of coordinates from `Fin n` has
-the prefix law. -/
-theorem Contractable.restrict {μ : Measure Ω} {X : ℕ → Ω → α} (h : Contractable μ X)
-    {n m : ℕ} (k : Fin m → Fin n) (hk : StrictMono k) :
-    blockLaw μ X (fun i => (k i).val) = prefixLaw μ X m :=
-  h.map fun _ _ hij => hk hij
-
-/-- Any strictly increasing finite selection extends to a permutation of a large enough `Fin n`:
-given `k : Fin m → ℕ` strictly increasing with every value `< n` and `m ≤ n`, there is a
-permutation `σ` of `Fin n` with `(σ ⟨i, _⟩).val = k i` for every `i : Fin m`.
-
-This is a thin wrapper around Mathlib's `Equiv.Perm.exists_extending_pair` (Cameron Freer,
-Mathlib #34599), applied to the initial-segment inclusion `Fin.castLE hmn` and the strictly
-monotone embedding `i ↦ ⟨k i, _⟩`, both injective. -/
-theorem exists_perm_extending_strictMono {m n : ℕ} (k : Fin m → ℕ)
+/-- A strictly increasing finite selection `k : Fin m → ℕ` whose values lie below `n` (with
+`m ≤ n`) is realized by a permutation `σ` of `Fin n`: `(σ ⟨i, _⟩).val = k i` for every
+`i : Fin m`. -/
+private theorem exists_perm_extending_strictMono {m n : ℕ} (k : Fin m → ℕ)
     (hk : StrictMono k) (hk_bound : ∀ i, k i < n) (hmn : m ≤ n) :
     ∃ σ : Equiv.Perm (Fin n), ∀ i : Fin m,
       (σ ⟨i.val, Nat.lt_of_lt_of_le i.isLt hmn⟩).val = k i := by
+  -- thin wrapper over Mathlib's `Equiv.Perm.exists_extending_pair` (Cameron Freer, #34599)
   obtain ⟨σ, hσ⟩ := Equiv.Perm.exists_extending_pair (Fin.castLE hmn)
     (fun i => ⟨k i, hk_bound i⟩)
     (fun i j h => by
@@ -125,12 +86,9 @@ theorem exists_perm_extending_strictMono {m n : ℕ} (k : Fin m → ℕ)
     (fun i j hij => hk.injective (Fin.mk.inj hij))
   exact ⟨σ, fun i => congrArg Fin.val (hσ i)⟩
 
-/-- **Every exchangeable sequence is contractable.** Along any strictly increasing finite
-selection `k : Fin m → ℕ`, the block law equals the prefix law.
-
-The proof extends `k` to a permutation `σ` of a large enough `Fin n`
-(`exists_perm_extending_strictMono`), invokes exchangeability at dimension `n`, and projects both
-laws onto the first `m` coordinates with `map_blockLaw_reindex`. -/
+/-- **Every exchangeable sequence is contractable**: along any strictly increasing finite
+selection `k : Fin m → ℕ`, the block law `blockLaw μ X k` equals the prefix law `prefixLaw μ X m`.
+One direction of the de Finetti–Ryll-Nardzewski equivalence. -/
 theorem contractable_of_exchangeable {μ : Measure Ω} {X : ℕ → Ω → α}
     (hX : Exchangeable μ X) (hX_meas : ∀ i, AEMeasurable (X i) μ) : Contractable μ X := by
   intro m k hk


### PR DESCRIPTION
<!--tauceti-target:v1 {"focus":"Exchangeability","id":"exchangeability-exchangeable-implies-contractable"}-->

## Summary

Proves the first Layer 0 theorem of the Exchangeability roadmap: **every exchangeable sequence
is contractable**.

`TauCeti/Probability/Exchangeability/Basic.lean` gains two general, reusable projection lemmas,
placed next to the existing `map_blockLaw` / `map_prefixLaw`:

- `map_blockLaw_reindex` — the coordinate-reindexing pushforward of block laws (companion of the
  value-reindexing `map_blockLaw`), for projecting finite-dimensional laws onto sub-blocks;
- `map_prefixLaw_castLE` — projecting a prefix law on `Fin n` onto its first `m ≤ n` coordinates
  (via `Fin.castLE`) gives the prefix law on `Fin m`.

`TauCeti/Probability/Exchangeability/Contractability.lean` gains the theorem:

- `contractable_of_exchangeable` (and dot form `Exchangeable.contractable`) — along any strictly
  increasing finite selection, the block law equals the prefix law. The proof realizes the
  selection as the first coordinates of a permutation `σ`, applies exchangeability at dimension
  `n`, and projects both laws back with the two lemmas above. The permutation extension is a
  private helper `exists_perm_extending_strictMono`, a **thin wrapper around Mathlib's
  `Equiv.Perm.exists_extending_pair`** (Cameron Freer, Mathlib #34599), so no permutation
  combinatorics are re-derived here.

## Roadmap

Advances `TauCetiRoadmap/Exchangeability`, Layer 0 (sequence laws / symmetry notions): the
exchangeable ⇒ contractable bridge. Builds on the merged `Basic.lean` (#451) `blockLaw` /
`prefixLaw` API and reuses its accessors `Exchangeable.exchangeableAt` / `ExchangeableAt.permute`.

This intentionally does not prove `Exchangeable ↔ FullyExchangeable` or `ConditionallyIID →
Exchangeable`; those are follow-up Layer 0 PRs.

Checked open PRs: no unmerged Exchangeability PR overlaps this target. This builds on the merged
Layer 0 API PRs #451 and #456.

## Test plan

```bash
lake build
lake exe axioms
lake exe module-system
```

All pass: axiom audit reports only `propext`, `Classical.choice`, `Quot.sound`; module-system
audit passes; touched Lean lines are ≤100 chars.

## Attribution

Proofs adapted from the `cameronfreer/exchangeability` Layer 0 sources pinned at
`e0532e59ceff23edab44dda9ab0655debbc9cc22`, with Tau Ceti API names and hypotheses. The
combinatorial core is Mathlib's `Equiv.Perm.exists_extending_pair` (Cameron Freer, Mathlib
#34599). PR contents and description drafted with Claude (Opus 4.8) and human-directed.
