### PR TITLE
feat: identify regular deck subgroup fibre orbits

### DIFF
--- a/TauCeti/AlgebraicTopology/UniversalCover/Deck/SubgroupFiberOrbitQuotientGroup.lean
+++ b/TauCeti/AlgebraicTopology/UniversalCover/Deck/SubgroupFiberOrbitQuotientGroup.lean
@@ -111,7 +111,7 @@ variable {E B : Type*} [TopologicalSpace E] {p : E → B} {b : B}
 
 /-- The subgroup-fibre orbit quotient is equivalent to the quotient of the deck group by the
 subgroup, once the deck action on the chosen fibre is free and transitive. -/
-@[expose] noncomputable def subgroupFiberOrbitQuotientEquivQuotientGroup
+noncomputable def subgroupFiberOrbitQuotientEquivQuotientGroup
     [MulAction.IsPretransitive (Deck p) (p ⁻¹' {b})] [IsCancelSMul (Deck p) (p ⁻¹' {b})]
     (H : Subgroup (Deck p)) (e : p ⁻¹' {b}) :
     SubgroupFiberOrbitQuotient H b ≃ Deck p ⧸ H :=
@@ -165,7 +165,9 @@ lemma subgroupFiberOrbitQuotientEquivQuotientGroup_symm_mk_coe
           rw [Set.mem_preimage, Set.mem_singleton_iff]
           exact (map_proj φ⁻¹ e.1).trans (Set.mem_singleton_iff.mp e.2)⟩ := by
   rw [subgroupFiberOrbitQuotientEquivQuotientGroup_symm_mk]
-  congr 1
+  apply congrArg (subgroupFiberOrbitClass H)
+  ext
+  exact fiber_smul_coe φ⁻¹ e
 
 /-- The inverse quotient equivalence sends the identity coset to the orbit class of the chosen
 fibre point. -/

--- a/TauCeti/AlgebraicTopology/UniversalCover/Deck/SubgroupFiberOrbitQuotientGroup.lean
+++ b/TauCeti/AlgebraicTopology/UniversalCover/Deck/SubgroupFiberOrbitQuotientGroup.lean
@@ -24,8 +24,12 @@ unfolding either construction.
 
 ## Main declarations
 
-* `MulAction.equivSubgroupOrbitsQuotientGroup`: applied to the deck action on one fibre, this
-  identifies `SubgroupFiberOrbitQuotient H b` with `Deck p ⧸ H`.
+* `TauCeti.Deck.subgroupFiberOrbitQuotientEquivQuotientGroup`: identifies
+  `SubgroupFiberOrbitQuotient H b` with `Deck p ⧸ H`.
+* `TauCeti.Deck.regularSubgroupFiberOrbitQuotientEquivQuotientGroup`: the regular-cover
+  specialization that installs the free-transitive deck action on the fibre.
+* `TauCeti.MulAction.equivSubgroupOrbitsQuotientGroup_mapOfLE`: generic compatibility of
+  Mathlib's subgroup-orbit quotient equivalence with maps induced by subgroup inclusions.
 * `TauCeti.Deck.subgroupFiberOrbitQuotientEquivQuotientGroup_mapOfLE`: compatibility with
   the maps induced by subgroup inclusions.
 
@@ -42,14 +46,12 @@ public section
 
 namespace TauCeti
 
-namespace Deck
-
-variable {E B : Type*} [TopologicalSpace E] {p : E → B} {b : B}
+namespace MulAction
 
 /-- Mathlib's subgroup-orbit quotient equivalence sends the coset of `g` back to the orbit
-class of `g⁻¹ • x`. This exposes that representative convention once, so deck-facing lemmas
-can rewrite through a named theorem rather than relying directly on definitional equality. -/
-private lemma mulAction_equivSubgroupOrbitsQuotientGroup_symm_mk
+class of `g⁻¹ • x`. This exposes that representative convention once, so later lemmas can
+rewrite through a named theorem rather than relying directly on definitional equality. -/
+private lemma equivSubgroupOrbitsQuotientGroup_symm_mk
     {G X : Type*} [Group G] [MulAction G X] [MulAction.IsPretransitive G X]
     [IsCancelSMul G X] (H : Subgroup G) (x : X) (g : G) :
     (MulAction.equivSubgroupOrbitsQuotientGroup x H).symm
@@ -57,31 +59,86 @@ private lemma mulAction_equivSubgroupOrbitsQuotientGroup_symm_mk
       (Quotient.mk'' (g⁻¹ • x) : MulAction.orbitRel.Quotient H X) :=
   rfl
 
+/-- The subgroup-orbit quotient equivalence sends the orbit class of `g • x` to the coset
+of `g⁻¹`. -/
+private lemma equivSubgroupOrbitsQuotientGroup_apply_smul
+    {G X : Type*} [Group G] [MulAction G X] [MulAction.IsPretransitive G X]
+    [IsCancelSMul G X] (H : Subgroup G) (x : X) (g : G) :
+    MulAction.equivSubgroupOrbitsQuotientGroup x H
+        (Quotient.mk'' (g • x) : MulAction.orbitRel.Quotient H X) =
+      QuotientGroup.mk (s := H) g⁻¹ := by
+  simpa [equivSubgroupOrbitsQuotientGroup_symm_mk, inv_inv] using
+    (MulAction.equivSubgroupOrbitsQuotientGroup x H).apply_symm_apply
+    (QuotientGroup.mk (s := H) g⁻¹)
+
+/-- The map on orbit quotients induced by an inclusion of acting subgroups. -/
+@[expose] def orbitRelQuotientMapOfLE {G X : Type*} [Group G] [MulAction G X]
+    {H K : Subgroup G} (hHK : H ≤ K) :
+    MulAction.orbitRel.Quotient H X → MulAction.orbitRel.Quotient K X :=
+  Quotient.map' id fun x y h => by
+    rw [MulAction.orbitRel_apply] at h ⊢
+    rcases h with ⟨g, hg⟩
+    exact ⟨⟨g.1, hHK g.2⟩, hg⟩
+
+/-- The map induced by `H ≤ K` sends an `H`-orbit representative to its `K`-orbit class. -/
+@[simp]
+lemma orbitRelQuotientMapOfLE_mk {G X : Type*} [Group G] [MulAction G X]
+    {H K : Subgroup G} (hHK : H ≤ K) (x : X) :
+    orbitRelQuotientMapOfLE hHK (Quotient.mk'' x : MulAction.orbitRel.Quotient H X) =
+      (Quotient.mk'' x : MulAction.orbitRel.Quotient K X) :=
+  rfl
+
+/-- The subgroup-orbit quotient equivalence is natural in subgroup inclusions. -/
+@[simp]
+lemma equivSubgroupOrbitsQuotientGroup_mapOfLE
+    {G X : Type*} [Group G] [MulAction G X] [MulAction.IsPretransitive G X]
+    [IsCancelSMul G X] {H K : Subgroup G} (hHK : H ≤ K) (x₀ : X)
+    (x : MulAction.orbitRel.Quotient H X) :
+    Subgroup.quotientMapOfLE hHK
+        (MulAction.equivSubgroupOrbitsQuotientGroup x₀ H x) =
+      MulAction.equivSubgroupOrbitsQuotientGroup x₀ K
+        (orbitRelQuotientMapOfLE hHK x) := by
+  refine Quotient.inductionOn' x ?_
+  intro x'
+  obtain ⟨g, hg⟩ := MulAction.exists_smul_eq G x₀ x'
+  rw [← hg]
+  rw [orbitRelQuotientMapOfLE_mk, equivSubgroupOrbitsQuotientGroup_apply_smul,
+    equivSubgroupOrbitsQuotientGroup_apply_smul, Subgroup.quotientMapOfLE_apply_mk]
+
+end MulAction
+
+namespace Deck
+
+variable {E B : Type*} [TopologicalSpace E] {p : E → B} {b : B}
+
+/-- The subgroup-fibre orbit quotient is equivalent to the quotient of the deck group by the
+subgroup, once the deck action on the chosen fibre is free and transitive. -/
+@[expose] noncomputable def subgroupFiberOrbitQuotientEquivQuotientGroup
+    [MulAction.IsPretransitive (Deck p) (p ⁻¹' {b})] [IsCancelSMul (Deck p) (p ⁻¹' {b})]
+    (H : Subgroup (Deck p)) (e : p ⁻¹' {b}) :
+    SubgroupFiberOrbitQuotient H b ≃ Deck p ⧸ H :=
+  MulAction.equivSubgroupOrbitsQuotientGroup e H
+
+/-- For a regular preconnected covering map, the subgroup-fibre orbit quotient is equivalent
+to the quotient of the deck group by the subgroup. -/
+@[expose] noncomputable def regularSubgroupFiberOrbitQuotientEquivQuotientGroup
+    [TopologicalSpace B] [PreconnectedSpace E] (hp : IsCoveringMap p) (hreg : IsRegular p)
+    (H : Subgroup (Deck p)) (e : p ⁻¹' {b}) :
+    SubgroupFiberOrbitQuotient H b ≃ Deck p ⧸ H :=
+  @subgroupFiberOrbitQuotientEquivQuotientGroup E B _ p b
+    (hreg.fiber_isPretransitive b) (fiber_isCancelSMul (b := b) hp) H e
+
 /-- The inverse quotient equivalence sends the coset of a deck transformation `φ` to the
 `H`-orbit class of the point `φ⁻¹ • e`. -/
 @[simp]
 lemma subgroupFiberOrbitQuotientEquivQuotientGroup_symm_mk
     [MulAction.IsPretransitive (Deck p) (p ⁻¹' {b})] [IsCancelSMul (Deck p) (p ⁻¹' {b})]
     (H : Subgroup (Deck p)) (e : p ⁻¹' {b}) (φ : Deck p) :
-    (MulAction.equivSubgroupOrbitsQuotientGroup e H).symm
+    (subgroupFiberOrbitQuotientEquivQuotientGroup H e).symm
         (QuotientGroup.mk (s := H) φ) =
       subgroupFiberOrbitClass H (φ⁻¹ • e) := by
-  simpa [subgroupFiberOrbitClass_eq_mk] using
-    mulAction_equivSubgroupOrbitsQuotientGroup_symm_mk H e φ
-
-/-- The regular-cover quotient equivalence sends the coset of a deck transformation `φ` back
-to the `H`-orbit class of `φ⁻¹ • e`. -/
-@[simp]
-lemma regularSubgroupFiberOrbitQuotientEquivQuotientGroup_symm_mk
-    [TopologicalSpace B] [PreconnectedSpace E] (hp : IsCoveringMap p) (hreg : IsRegular p)
-    (H : Subgroup (Deck p)) (e : p ⁻¹' {b}) (φ : Deck p) :
-    (@MulAction.equivSubgroupOrbitsQuotientGroup (Deck p) (p ⁻¹' {b}) _ _ e
-        (hreg.fiber_isPretransitive b) (fiber_isCancelSMul (b := b) hp) H).symm
-        (QuotientGroup.mk (s := H) φ) =
-      subgroupFiberOrbitClass H (φ⁻¹ • e) := by
-  letI := hreg.fiber_isPretransitive b
-  letI := fiber_isCancelSMul (b := b) hp
-  simp
+  simpa [subgroupFiberOrbitQuotientEquivQuotientGroup, subgroupFiberOrbitClass_eq_mk] using
+    MulAction.equivSubgroupOrbitsQuotientGroup_symm_mk H e φ
 
 /-- On underlying points, the inverse quotient equivalence sends the coset of `φ` to the
 class of the value of `φ⁻¹` on the chosen fibre point. -/
@@ -89,7 +146,7 @@ class of the value of `φ⁻¹` on the chosen fibre point. -/
 lemma subgroupFiberOrbitQuotientEquivQuotientGroup_symm_mk_coe
     [MulAction.IsPretransitive (Deck p) (p ⁻¹' {b})] [IsCancelSMul (Deck p) (p ⁻¹' {b})]
     (H : Subgroup (Deck p)) (e : p ⁻¹' {b}) (φ : Deck p) :
-    (MulAction.equivSubgroupOrbitsQuotientGroup e H).symm
+    (subgroupFiberOrbitQuotientEquivQuotientGroup H e).symm
         (QuotientGroup.mk φ) =
       subgroupFiberOrbitClass H
         ⟨φ.1.symm e.1, by
@@ -98,123 +155,50 @@ lemma subgroupFiberOrbitQuotientEquivQuotientGroup_symm_mk_coe
   rw [subgroupFiberOrbitQuotientEquivQuotientGroup_symm_mk]
   congr 1
 
-/-- On underlying points, the regular-cover inverse quotient equivalence sends the coset of
-`φ` to the class of the value of `φ⁻¹` on the chosen fibre point. -/
-@[simp]
-lemma regularSubgroupFiberOrbitQuotientEquivQuotientGroup_symm_mk_coe
-    [TopologicalSpace B] [PreconnectedSpace E] (hp : IsCoveringMap p) (hreg : IsRegular p)
-    (H : Subgroup (Deck p)) (e : p ⁻¹' {b}) (φ : Deck p) :
-    (@MulAction.equivSubgroupOrbitsQuotientGroup (Deck p) (p ⁻¹' {b}) _ _ e
-        (hreg.fiber_isPretransitive b) (fiber_isCancelSMul (b := b) hp) H).symm
-        (QuotientGroup.mk φ) =
-      subgroupFiberOrbitClass H
-        ⟨φ.1.symm e.1, by
-          rw [Set.mem_preimage, Set.mem_singleton_iff]
-          exact (map_proj φ⁻¹ e.1).trans (Set.mem_singleton_iff.mp e.2)⟩ := by
-  letI := hreg.fiber_isPretransitive b
-  letI := fiber_isCancelSMul (b := b) hp
-  simpa using subgroupFiberOrbitQuotientEquivQuotientGroup_symm_mk_coe H e φ
-
 /-- The inverse quotient equivalence sends the identity coset to the orbit class of the chosen
 fibre point. -/
 @[simp]
 lemma subgroupFiberOrbitQuotientEquivQuotientGroup_symm_one
     [MulAction.IsPretransitive (Deck p) (p ⁻¹' {b})] [IsCancelSMul (Deck p) (p ⁻¹' {b})]
     (H : Subgroup (Deck p)) (e : p ⁻¹' {b}) :
-    (MulAction.equivSubgroupOrbitsQuotientGroup e H).symm
+    (subgroupFiberOrbitQuotientEquivQuotientGroup H e).symm
         (QuotientGroup.mk (s := H) (1 : Deck p)) =
       subgroupFiberOrbitClass H e := by
   rw [subgroupFiberOrbitQuotientEquivQuotientGroup_symm_mk, inv_one, one_smul]
-
-/-- The regular-cover inverse quotient equivalence sends the identity coset to the orbit class
-of the chosen fibre point. -/
-@[simp]
-lemma regularSubgroupFiberOrbitQuotientEquivQuotientGroup_symm_one
-    [TopologicalSpace B] [PreconnectedSpace E] (hp : IsCoveringMap p) (hreg : IsRegular p)
-    (H : Subgroup (Deck p)) (e : p ⁻¹' {b}) :
-    (@MulAction.equivSubgroupOrbitsQuotientGroup (Deck p) (p ⁻¹' {b}) _ _ e
-        (hreg.fiber_isPretransitive b) (fiber_isCancelSMul (b := b) hp) H).symm
-        (QuotientGroup.mk (s := H) (1 : Deck p)) =
-      subgroupFiberOrbitClass H e := by
-  letI := hreg.fiber_isPretransitive b
-  letI := fiber_isCancelSMul (b := b) hp
-  simp
 
 /-- The quotient equivalence sends the orbit class of `φ⁻¹ • e` to the coset of `φ`. -/
 @[simp]
 lemma subgroupFiberOrbitQuotientEquivQuotientGroup_apply_inv_smul
     [MulAction.IsPretransitive (Deck p) (p ⁻¹' {b})] [IsCancelSMul (Deck p) (p ⁻¹' {b})]
     (H : Subgroup (Deck p)) (e : p ⁻¹' {b}) (φ : Deck p) :
-    MulAction.equivSubgroupOrbitsQuotientGroup e H
+    subgroupFiberOrbitQuotientEquivQuotientGroup H e
         (subgroupFiberOrbitClass H (φ⁻¹ • e)) =
       QuotientGroup.mk (s := H) φ := by
   rw [← subgroupFiberOrbitQuotientEquivQuotientGroup_symm_mk H e φ]
-  exact (MulAction.equivSubgroupOrbitsQuotientGroup e H).apply_symm_apply
+  exact (subgroupFiberOrbitQuotientEquivQuotientGroup H e).apply_symm_apply
     (QuotientGroup.mk (s := H) φ)
-
-/-- The regular-cover quotient equivalence sends the orbit class of `φ⁻¹ • e` to the coset
-of `φ`. -/
-@[simp]
-lemma regularSubgroupFiberOrbitQuotientEquivQuotientGroup_apply_inv_smul
-    [TopologicalSpace B] [PreconnectedSpace E] (hp : IsCoveringMap p) (hreg : IsRegular p)
-    (H : Subgroup (Deck p)) (e : p ⁻¹' {b}) (φ : Deck p) :
-    @MulAction.equivSubgroupOrbitsQuotientGroup (Deck p) (p ⁻¹' {b}) _ _ e
-        (hreg.fiber_isPretransitive b) (fiber_isCancelSMul (b := b) hp) H
-        (subgroupFiberOrbitClass H (φ⁻¹ • e)) =
-      QuotientGroup.mk (s := H) φ := by
-  letI := hreg.fiber_isPretransitive b
-  letI := fiber_isCancelSMul (b := b) hp
-  simpa using subgroupFiberOrbitQuotientEquivQuotientGroup_apply_inv_smul H e φ
 
 /-- The quotient equivalence sends the chosen fibre point to the identity coset. -/
 @[simp]
 lemma subgroupFiberOrbitQuotientEquivQuotientGroup_apply_base
     [MulAction.IsPretransitive (Deck p) (p ⁻¹' {b})] [IsCancelSMul (Deck p) (p ⁻¹' {b})]
     (H : Subgroup (Deck p)) (e : p ⁻¹' {b}) :
-    MulAction.equivSubgroupOrbitsQuotientGroup e H
+    subgroupFiberOrbitQuotientEquivQuotientGroup H e
         (subgroupFiberOrbitClass H e) =
       QuotientGroup.mk (s := H) (1 : Deck p) := by
   simpa using
     subgroupFiberOrbitQuotientEquivQuotientGroup_apply_inv_smul H e (1 : Deck p)
-
-/-- The regular-cover quotient equivalence sends the chosen fibre point to the identity
-coset. -/
-@[simp]
-lemma regularSubgroupFiberOrbitQuotientEquivQuotientGroup_apply_base
-    [TopologicalSpace B] [PreconnectedSpace E] (hp : IsCoveringMap p) (hreg : IsRegular p)
-    (H : Subgroup (Deck p)) (e : p ⁻¹' {b}) :
-    @MulAction.equivSubgroupOrbitsQuotientGroup (Deck p) (p ⁻¹' {b}) _ _ e
-        (hreg.fiber_isPretransitive b) (fiber_isCancelSMul (b := b) hp) H
-        (subgroupFiberOrbitClass H e) =
-      QuotientGroup.mk (s := H) (1 : Deck p) := by
-  letI := hreg.fiber_isPretransitive b
-  letI := fiber_isCancelSMul (b := b) hp
-  simpa using subgroupFiberOrbitQuotientEquivQuotientGroup_apply_base H e
 
 /-- The quotient equivalence sends the orbit class of `φ • e` to the coset of `φ⁻¹`. -/
 @[simp]
 lemma subgroupFiberOrbitQuotientEquivQuotientGroup_apply_smul
     [MulAction.IsPretransitive (Deck p) (p ⁻¹' {b})] [IsCancelSMul (Deck p) (p ⁻¹' {b})]
     (H : Subgroup (Deck p)) (e : p ⁻¹' {b}) (φ : Deck p) :
-    MulAction.equivSubgroupOrbitsQuotientGroup e H
+    subgroupFiberOrbitQuotientEquivQuotientGroup H e
         (subgroupFiberOrbitClass H (φ • e)) =
       QuotientGroup.mk (s := H) φ⁻¹ := by
   simpa using
     subgroupFiberOrbitQuotientEquivQuotientGroup_apply_inv_smul H e φ⁻¹
-
-/-- The regular-cover quotient equivalence sends the orbit class of `φ • e` to the coset of
-`φ⁻¹`. -/
-@[simp]
-lemma regularSubgroupFiberOrbitQuotientEquivQuotientGroup_apply_smul
-    [TopologicalSpace B] [PreconnectedSpace E] (hp : IsCoveringMap p) (hreg : IsRegular p)
-    (H : Subgroup (Deck p)) (e : p ⁻¹' {b}) (φ : Deck p) :
-    @MulAction.equivSubgroupOrbitsQuotientGroup (Deck p) (p ⁻¹' {b}) _ _ e
-        (hreg.fiber_isPretransitive b) (fiber_isCancelSMul (b := b) hp) H
-        (subgroupFiberOrbitClass H (φ • e)) =
-      QuotientGroup.mk (s := H) φ⁻¹ := by
-  letI := hreg.fiber_isPretransitive b
-  letI := fiber_isCancelSMul (b := b) hp
-  simpa using subgroupFiberOrbitQuotientEquivQuotientGroup_apply_smul H e φ
 
 /-- The subgroup-fibre quotient equivalence is natural in subgroup inclusions. -/
 @[simp]
@@ -223,18 +207,13 @@ lemma subgroupFiberOrbitQuotientEquivQuotientGroup_mapOfLE
     {H K : Subgroup (Deck p)} (hHK : H ≤ K) (e : p ⁻¹' {b})
     (x : SubgroupFiberOrbitQuotient H b) :
     Subgroup.quotientMapOfLE hHK
-        (MulAction.equivSubgroupOrbitsQuotientGroup e H x) =
-      MulAction.equivSubgroupOrbitsQuotientGroup e K
+        (subgroupFiberOrbitQuotientEquivQuotientGroup H e x) =
+      subgroupFiberOrbitQuotientEquivQuotientGroup K e
         (subgroupFiberOrbitMapOfLE (b := b) hHK x) := by
-  refine Quotient.inductionOn' x ?_
-  intro e'
-  obtain ⟨φ, hφ⟩ := MulAction.exists_smul_eq (Deck p) e e'
-  rw [← hφ]
-  rw [← subgroupFiberOrbitClass_eq_mk H (φ • e)]
-  rw [subgroupFiberOrbitMapOfLE_apply,
-    subgroupFiberOrbitQuotientEquivQuotientGroup_apply_smul,
-    subgroupFiberOrbitQuotientEquivQuotientGroup_apply_smul,
-    Subgroup.quotientMapOfLE_apply_mk]
+  simp [subgroupFiberOrbitQuotientEquivQuotientGroup,
+    subgroupFiberOrbitMapOfLE, MulAction.orbitRelQuotientMapOfLE,
+    MulAction.equivSubgroupOrbitsQuotientGroup_mapOfLE (G := Deck p) (X := p ⁻¹' {b})
+      hHK e x]
 
 /-- On representatives, naturality sends the class of `φ • e` through the coset map induced by
 `H ≤ K`. -/
@@ -243,44 +222,12 @@ lemma subgroupFiberOrbitQuotientEquivQuotientGroup_mapOfLE_apply_smul
     [MulAction.IsPretransitive (Deck p) (p ⁻¹' {b})] [IsCancelSMul (Deck p) (p ⁻¹' {b})]
     {H K : Subgroup (Deck p)} (hHK : H ≤ K) (e : p ⁻¹' {b}) (φ : Deck p) :
     Subgroup.quotientMapOfLE hHK
-        (MulAction.equivSubgroupOrbitsQuotientGroup e H
+        (subgroupFiberOrbitQuotientEquivQuotientGroup H e
           (subgroupFiberOrbitClass H (φ • e))) =
-      MulAction.equivSubgroupOrbitsQuotientGroup e K
+      subgroupFiberOrbitQuotientEquivQuotientGroup K e
         (subgroupFiberOrbitMapOfLE (b := b) hHK
           (subgroupFiberOrbitClass H (φ • e))) := by
   rw [subgroupFiberOrbitQuotientEquivQuotientGroup_mapOfLE]
-
-/-- The regular-cover subgroup-fibre quotient equivalence is natural in subgroup inclusions. -/
-@[simp]
-lemma regularSubgroupFiberOrbitQuotientEquivQuotientGroup_mapOfLE
-    [TopologicalSpace B] [PreconnectedSpace E] (hp : IsCoveringMap p) (hreg : IsRegular p)
-    {H K : Subgroup (Deck p)} (hHK : H ≤ K) (e : p ⁻¹' {b})
-    (x : SubgroupFiberOrbitQuotient H b) :
-    Subgroup.quotientMapOfLE hHK
-        (@MulAction.equivSubgroupOrbitsQuotientGroup (Deck p) (p ⁻¹' {b}) _ _ e
-          (hreg.fiber_isPretransitive b) (fiber_isCancelSMul (b := b) hp) H x) =
-      @MulAction.equivSubgroupOrbitsQuotientGroup (Deck p) (p ⁻¹' {b}) _ _ e
-        (hreg.fiber_isPretransitive b) (fiber_isCancelSMul (b := b) hp) K
-        (subgroupFiberOrbitMapOfLE (b := b) hHK x) := by
-  letI := hreg.fiber_isPretransitive b
-  letI := fiber_isCancelSMul (b := b) hp
-  simp
-
-/-- On representatives, the regular-cover naturality lemma sends the class of `φ • e` through
-the coset map induced by `H ≤ K`. -/
-@[simp]
-lemma regularSubgroupFiberOrbitQuotientEquivQuotientGroup_mapOfLE_apply_smul
-    [TopologicalSpace B] [PreconnectedSpace E] (hp : IsCoveringMap p) (hreg : IsRegular p)
-    {H K : Subgroup (Deck p)} (hHK : H ≤ K) (e : p ⁻¹' {b}) (φ : Deck p) :
-    Subgroup.quotientMapOfLE hHK
-        (@MulAction.equivSubgroupOrbitsQuotientGroup (Deck p) (p ⁻¹' {b}) _ _ e
-          (hreg.fiber_isPretransitive b) (fiber_isCancelSMul (b := b) hp) H
-          (subgroupFiberOrbitClass H (φ • e))) =
-      @MulAction.equivSubgroupOrbitsQuotientGroup (Deck p) (p ⁻¹' {b}) _ _ e
-        (hreg.fiber_isPretransitive b) (fiber_isCancelSMul (b := b) hp) K
-        (subgroupFiberOrbitMapOfLE (b := b) hHK
-          (subgroupFiberOrbitClass H (φ • e))) := by
-  simp
 
 /-- Equality of subgroup fibre-orbit classes is equality of the corresponding deck cosets
 under the quotient equivalence, with the inverse orientation coming from Mathlib's quotient
@@ -293,12 +240,12 @@ lemma subgroupFiberOrbitClass_eq_iff_quotientGroup_mk_inv_eq
   constructor
   · intro h
     have h' := congrArg
-      (MulAction.equivSubgroupOrbitsQuotientGroup e H) h
+      (subgroupFiberOrbitQuotientEquivQuotientGroup H e) h
     rw [subgroupFiberOrbitQuotientEquivQuotientGroup_apply_smul,
       subgroupFiberOrbitQuotientEquivQuotientGroup_apply_smul] at h'
     exact h'
   · intro h
-    apply (MulAction.equivSubgroupOrbitsQuotientGroup e H).injective
+    apply (subgroupFiberOrbitQuotientEquivQuotientGroup H e).injective
     rw [subgroupFiberOrbitQuotientEquivQuotientGroup_apply_smul,
       subgroupFiberOrbitQuotientEquivQuotientGroup_apply_smul]
     exact h

--- a/TauCeti/AlgebraicTopology/UniversalCover/Deck/SubgroupFiberOrbitQuotientGroup.lean
+++ b/TauCeti/AlgebraicTopology/UniversalCover/Deck/SubgroupFiberOrbitQuotientGroup.lean
@@ -51,7 +51,7 @@ variable {E B : Type*} [TopologicalSpace E] {p : E → B} {b : B}
 /-- Mathlib's subgroup-orbit quotient equivalence sends the coset of `g` back to the orbit
 class of `g⁻¹ • x`. This exposes that representative convention once, so deck-facing lemmas
 can rewrite through a named theorem rather than relying directly on definitional equality. -/
-lemma mulAction_equivSubgroupOrbitsQuotientGroup_symm_mk
+private lemma mulAction_equivSubgroupOrbitsQuotientGroup_symm_mk
     {G X : Type*} [Group G] [MulAction G X] [MulAction.IsPretransitive G X]
     [IsCancelSMul G X] (H : Subgroup G) (x : X) (g : G) :
     (MulAction.equivSubgroupOrbitsQuotientGroup x H).symm
@@ -105,10 +105,7 @@ lemma regularSubgroupFiberOrbitQuotientEquivQuotientGroup_symm_mk
       subgroupFiberOrbitClass H (φ⁻¹ • e) := by
   letI := hreg.fiber_isPretransitive b
   letI := fiber_isCancelSMul (b := b) hp
-  change (subgroupFiberOrbitQuotientEquivQuotientGroup H e).symm
-      (QuotientGroup.mk (s := H) φ) =
-    subgroupFiberOrbitClass H (φ⁻¹ • e)
-  exact subgroupFiberOrbitQuotientEquivQuotientGroup_symm_mk H e φ
+  simp [regularSubgroupFiberOrbitQuotientEquivQuotientGroup]
 
 /-- On underlying points, the inverse quotient equivalence sends the coset of `φ` to the
 class of the value of `φ⁻¹` on the chosen fibre point. -/
@@ -164,10 +161,7 @@ lemma regularSubgroupFiberOrbitQuotientEquivQuotientGroup_symm_one
       subgroupFiberOrbitClass H e := by
   letI := hreg.fiber_isPretransitive b
   letI := fiber_isCancelSMul (b := b) hp
-  change (subgroupFiberOrbitQuotientEquivQuotientGroup H e).symm
-      (QuotientGroup.mk (s := H) (1 : Deck p)) =
-    subgroupFiberOrbitClass H e
-  exact subgroupFiberOrbitQuotientEquivQuotientGroup_symm_one H e
+  simp [regularSubgroupFiberOrbitQuotientEquivQuotientGroup]
 
 /-- The quotient equivalence sends the orbit class of `φ⁻¹ • e` to the coset of `φ`. -/
 @[simp]
@@ -246,6 +240,7 @@ lemma regularSubgroupFiberOrbitQuotientEquivQuotientGroup_apply_smul
     subgroupFiberOrbitQuotientEquivQuotientGroup_apply_smul H e φ
 
 /-- The subgroup-fibre quotient equivalence is natural in subgroup inclusions. -/
+@[simp]
 lemma subgroupFiberOrbitQuotientEquivQuotientGroup_mapOfLE
     [MulAction.IsPretransitive (Deck p) (p ⁻¹' {b})] [IsCancelSMul (Deck p) (p ⁻¹' {b})]
     {H K : Subgroup (Deck p)} (hHK : H ≤ K) (e : p ⁻¹' {b})
@@ -258,11 +253,7 @@ lemma subgroupFiberOrbitQuotientEquivQuotientGroup_mapOfLE
   intro e'
   obtain ⟨φ, hφ⟩ := MulAction.exists_smul_eq (Deck p) e e'
   rw [← hφ]
-  change Subgroup.quotientMapOfLE hHK
-      (subgroupFiberOrbitQuotientEquivQuotientGroup H e
-        (subgroupFiberOrbitClass H (φ • e))) =
-    subgroupFiberOrbitQuotientEquivQuotientGroup K e
-      (subgroupFiberOrbitMapOfLE (b := b) hHK (subgroupFiberOrbitClass H (φ • e)))
+  rw [← subgroupFiberOrbitClass_eq_mk H (φ • e)]
   rw [subgroupFiberOrbitMapOfLE_apply,
     subgroupFiberOrbitQuotientEquivQuotientGroup_apply_smul,
     subgroupFiberOrbitQuotientEquivQuotientGroup_apply_smul,
@@ -283,6 +274,7 @@ lemma subgroupFiberOrbitQuotientEquivQuotientGroup_mapOfLE_apply_smul
   rw [subgroupFiberOrbitQuotientEquivQuotientGroup_mapOfLE]
 
 /-- The regular-cover subgroup-fibre quotient equivalence is natural in subgroup inclusions. -/
+@[simp]
 lemma regularSubgroupFiberOrbitQuotientEquivQuotientGroup_mapOfLE
     [TopologicalSpace B] [PreconnectedSpace E] (hp : IsCoveringMap p) (hreg : IsRegular p)
     {H K : Subgroup (Deck p)} (hHK : H ≤ K) (e : p ⁻¹' {b})
@@ -293,8 +285,7 @@ lemma regularSubgroupFiberOrbitQuotientEquivQuotientGroup_mapOfLE
         (subgroupFiberOrbitMapOfLE (b := b) hHK x) := by
   letI := hreg.fiber_isPretransitive b
   letI := fiber_isCancelSMul (b := b) hp
-  simpa [regularSubgroupFiberOrbitQuotientEquivQuotientGroup] using
-    subgroupFiberOrbitQuotientEquivQuotientGroup_mapOfLE hHK e x
+  simp [regularSubgroupFiberOrbitQuotientEquivQuotientGroup]
 
 /-- On representatives, the regular-cover naturality lemma sends the class of `φ • e` through
 the coset map induced by `H ≤ K`. -/

--- a/TauCeti/AlgebraicTopology/UniversalCover/Deck/SubgroupFiberOrbitQuotientGroup.lean
+++ b/TauCeti/AlgebraicTopology/UniversalCover/Deck/SubgroupFiberOrbitQuotientGroup.lean
@@ -5,6 +5,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 module
 
 public import Mathlib.GroupTheory.GroupAction.Quotient
+public import Mathlib.GroupTheory.Coset.Basic
 public import TauCeti.AlgebraicTopology.UniversalCover.Deck.SubgroupFiberOrbit
 
 /-!
@@ -23,10 +24,12 @@ unfolding either construction.
 
 ## Main declarations
 
-* `TauCeti.Deck.regularSubgroupFiberOrbitQuotientEquivQuotientGroup`: for a regular
-  preconnected covering, `SubgroupFiberOrbitQuotient H b ≃ Deck p ⧸ H`.
-* `TauCeti.Deck.regularSubgroupFiberOrbitQuotientEquivQuotientGroup_symm_mk`: the inverse
-  sends the coset of `φ` to the `H`-orbit class of `φ⁻¹ • e`.
+* `TauCeti.Deck.subgroupFiberOrbitQuotientEquivQuotientGroup`: if the deck action on one
+  fibre is free and transitive, `SubgroupFiberOrbitQuotient H b ≃ Deck p ⧸ H`.
+* `TauCeti.Deck.regularSubgroupFiberOrbitQuotientEquivQuotientGroup`: the regular-cover
+  specialization of this equivalence.
+* `TauCeti.Deck.subgroupFiberOrbitQuotientEquivQuotientGroup_mapOfLE`: compatibility with
+  the maps induced by subgroup inclusions.
 
 ## References
 
@@ -43,41 +46,90 @@ namespace TauCeti
 
 namespace Deck
 
-variable {E B : Type*} [TopologicalSpace E] [TopologicalSpace B] {p : E → B} {b : B}
+variable {E B : Type*} [TopologicalSpace E] {p : E → B} {b : B}
 
-/-- For a regular preconnected covering, quotienting one fibre by the action of
-`H ≤ Deck p` is equivalent to the coset quotient `Deck p ⧸ H`.
+/-- Mathlib's subgroup-orbit quotient equivalence sends the coset of `g` back to the orbit
+class of `g⁻¹ • x`. This exposes that representative convention once, so deck-facing lemmas
+can rewrite through a named theorem rather than relying directly on definitional equality. -/
+lemma mulAction_equivSubgroupOrbitsQuotientGroup_symm_mk
+    {G X : Type*} [Group G] [MulAction G X] [MulAction.IsPretransitive G X]
+    [IsCancelSMul G X] (H : Subgroup G) (x : X) (g : G) :
+    (MulAction.equivSubgroupOrbitsQuotientGroup x H).symm
+        (QuotientGroup.mk (s := H) g) =
+      (Quotient.mk'' (g⁻¹ • x) : MulAction.orbitRel.Quotient H X) :=
+  rfl
+
+/-- If the deck action on a single fibre is free and transitive, quotienting that fibre by the
+action of `H ≤ Deck p` is equivalent to the coset quotient `Deck p ⧸ H`.
 
 The chosen point `e` fixes the identification between the deck group and the fibre. With
 Mathlib's convention for `MulAction.equivSubgroupOrbitsQuotientGroup`, the inverse sends the
 coset of `φ` to the orbit class of `φ⁻¹ • e`; see
-`regularSubgroupFiberOrbitQuotientEquivQuotientGroup_symm_mk`. -/
-@[expose] noncomputable def regularSubgroupFiberOrbitQuotientEquivQuotientGroup
-    [PreconnectedSpace E] (hp : IsCoveringMap p) (hreg : IsRegular p)
+`subgroupFiberOrbitQuotientEquivQuotientGroup_symm_mk`. -/
+noncomputable def subgroupFiberOrbitQuotientEquivQuotientGroup
+    [MulAction.IsPretransitive (Deck p) (p ⁻¹' {b})] [IsCancelSMul (Deck p) (p ⁻¹' {b})]
+    (H : Subgroup (Deck p)) (e : p ⁻¹' {b}) :
+    SubgroupFiberOrbitQuotient H b ≃ Deck p ⧸ H :=
+  MulAction.equivSubgroupOrbitsQuotientGroup e H
+
+/-- For a regular preconnected covering, quotienting one fibre by the action of
+`H ≤ Deck p` is equivalent to the coset quotient `Deck p ⧸ H`. -/
+noncomputable def regularSubgroupFiberOrbitQuotientEquivQuotientGroup
+    [TopologicalSpace B] [PreconnectedSpace E] (hp : IsCoveringMap p) (hreg : IsRegular p)
     (H : Subgroup (Deck p)) (e : p ⁻¹' {b}) :
     SubgroupFiberOrbitQuotient H b ≃ Deck p ⧸ H := by
   letI := hreg.fiber_isPretransitive b
   letI := fiber_isCancelSMul (b := b) hp
-  exact MulAction.equivSubgroupOrbitsQuotientGroup e H
+  exact subgroupFiberOrbitQuotientEquivQuotientGroup H e
 
 /-- The inverse quotient equivalence sends the coset of a deck transformation `φ` to the
 `H`-orbit class of the point `φ⁻¹ • e`. -/
 @[simp]
+lemma subgroupFiberOrbitQuotientEquivQuotientGroup_symm_mk
+    [MulAction.IsPretransitive (Deck p) (p ⁻¹' {b})] [IsCancelSMul (Deck p) (p ⁻¹' {b})]
+    (H : Subgroup (Deck p)) (e : p ⁻¹' {b}) (φ : Deck p) :
+    (subgroupFiberOrbitQuotientEquivQuotientGroup H e).symm
+        (QuotientGroup.mk (s := H) φ) =
+      subgroupFiberOrbitClass H (φ⁻¹ • e) := by
+  simpa [subgroupFiberOrbitQuotientEquivQuotientGroup, subgroupFiberOrbitClass_eq_mk] using
+    mulAction_equivSubgroupOrbitsQuotientGroup_symm_mk H e φ
+
+/-- The regular-cover quotient equivalence sends the coset of a deck transformation `φ` back
+to the `H`-orbit class of `φ⁻¹ • e`. -/
+@[simp]
 lemma regularSubgroupFiberOrbitQuotientEquivQuotientGroup_symm_mk
-    [PreconnectedSpace E] (hp : IsCoveringMap p) (hreg : IsRegular p)
+    [TopologicalSpace B] [PreconnectedSpace E] (hp : IsCoveringMap p) (hreg : IsRegular p)
     (H : Subgroup (Deck p)) (e : p ⁻¹' {b}) (φ : Deck p) :
     (regularSubgroupFiberOrbitQuotientEquivQuotientGroup hp hreg H e).symm
         (QuotientGroup.mk (s := H) φ) =
       subgroupFiberOrbitClass H (φ⁻¹ • e) := by
   letI := hreg.fiber_isPretransitive b
   letI := fiber_isCancelSMul (b := b) hp
-  rfl
+  change (subgroupFiberOrbitQuotientEquivQuotientGroup H e).symm
+      (QuotientGroup.mk (s := H) φ) =
+    subgroupFiberOrbitClass H (φ⁻¹ • e)
+  exact subgroupFiberOrbitQuotientEquivQuotientGroup_symm_mk H e φ
 
 /-- On underlying points, the inverse quotient equivalence sends the coset of `φ` to the
 class of the value of `φ⁻¹` on the chosen fibre point. -/
 @[simp]
+lemma subgroupFiberOrbitQuotientEquivQuotientGroup_symm_mk_coe
+    [MulAction.IsPretransitive (Deck p) (p ⁻¹' {b})] [IsCancelSMul (Deck p) (p ⁻¹' {b})]
+    (H : Subgroup (Deck p)) (e : p ⁻¹' {b}) (φ : Deck p) :
+    (subgroupFiberOrbitQuotientEquivQuotientGroup H e).symm
+        (QuotientGroup.mk φ) =
+      subgroupFiberOrbitClass H
+        ⟨φ.1.symm e.1, by
+          rw [Set.mem_preimage, Set.mem_singleton_iff]
+          exact (map_proj φ⁻¹ e.1).trans (Set.mem_singleton_iff.mp e.2)⟩ := by
+  rw [subgroupFiberOrbitQuotientEquivQuotientGroup_symm_mk]
+  congr 1
+
+/-- On underlying points, the regular-cover inverse quotient equivalence sends the coset of
+`φ` to the class of the value of `φ⁻¹` on the chosen fibre point. -/
+@[simp]
 lemma regularSubgroupFiberOrbitQuotientEquivQuotientGroup_symm_mk_coe
-    [PreconnectedSpace E] (hp : IsCoveringMap p) (hreg : IsRegular p)
+    [TopologicalSpace B] [PreconnectedSpace E] (hp : IsCoveringMap p) (hreg : IsRegular p)
     (H : Subgroup (Deck p)) (e : p ⁻¹' {b}) (φ : Deck p) :
     (regularSubgroupFiberOrbitQuotientEquivQuotientGroup hp hreg H e).symm
         (QuotientGroup.mk φ) =
@@ -85,75 +137,211 @@ lemma regularSubgroupFiberOrbitQuotientEquivQuotientGroup_symm_mk_coe
         ⟨φ.1.symm e.1, by
           rw [Set.mem_preimage, Set.mem_singleton_iff]
           exact (map_proj φ⁻¹ e.1).trans (Set.mem_singleton_iff.mp e.2)⟩ := by
-  rw [regularSubgroupFiberOrbitQuotientEquivQuotientGroup_symm_mk]
-  congr 1
+  letI := hreg.fiber_isPretransitive b
+  letI := fiber_isCancelSMul (b := b) hp
+  simpa [regularSubgroupFiberOrbitQuotientEquivQuotientGroup] using
+    subgroupFiberOrbitQuotientEquivQuotientGroup_symm_mk_coe H e φ
 
 /-- The inverse quotient equivalence sends the identity coset to the orbit class of the chosen
 fibre point. -/
 @[simp]
+lemma subgroupFiberOrbitQuotientEquivQuotientGroup_symm_one
+    [MulAction.IsPretransitive (Deck p) (p ⁻¹' {b})] [IsCancelSMul (Deck p) (p ⁻¹' {b})]
+    (H : Subgroup (Deck p)) (e : p ⁻¹' {b}) :
+    (subgroupFiberOrbitQuotientEquivQuotientGroup H e).symm
+        (QuotientGroup.mk (s := H) (1 : Deck p)) =
+      subgroupFiberOrbitClass H e := by
+  rw [subgroupFiberOrbitQuotientEquivQuotientGroup_symm_mk, inv_one, one_smul]
+
+/-- The regular-cover inverse quotient equivalence sends the identity coset to the orbit class
+of the chosen fibre point. -/
+@[simp]
 lemma regularSubgroupFiberOrbitQuotientEquivQuotientGroup_symm_one
-    [PreconnectedSpace E] (hp : IsCoveringMap p) (hreg : IsRegular p)
+    [TopologicalSpace B] [PreconnectedSpace E] (hp : IsCoveringMap p) (hreg : IsRegular p)
     (H : Subgroup (Deck p)) (e : p ⁻¹' {b}) :
     (regularSubgroupFiberOrbitQuotientEquivQuotientGroup hp hreg H e).symm
         (QuotientGroup.mk (s := H) (1 : Deck p)) =
       subgroupFiberOrbitClass H e := by
-  rw [regularSubgroupFiberOrbitQuotientEquivQuotientGroup_symm_mk, inv_one, one_smul]
+  letI := hreg.fiber_isPretransitive b
+  letI := fiber_isCancelSMul (b := b) hp
+  change (subgroupFiberOrbitQuotientEquivQuotientGroup H e).symm
+      (QuotientGroup.mk (s := H) (1 : Deck p)) =
+    subgroupFiberOrbitClass H e
+  exact subgroupFiberOrbitQuotientEquivQuotientGroup_symm_one H e
 
 /-- The quotient equivalence sends the orbit class of `φ⁻¹ • e` to the coset of `φ`. -/
 @[simp]
+lemma subgroupFiberOrbitQuotientEquivQuotientGroup_apply_inv_smul
+    [MulAction.IsPretransitive (Deck p) (p ⁻¹' {b})] [IsCancelSMul (Deck p) (p ⁻¹' {b})]
+    (H : Subgroup (Deck p)) (e : p ⁻¹' {b}) (φ : Deck p) :
+    subgroupFiberOrbitQuotientEquivQuotientGroup H e
+        (subgroupFiberOrbitClass H (φ⁻¹ • e)) =
+      QuotientGroup.mk (s := H) φ := by
+  rw [← subgroupFiberOrbitQuotientEquivQuotientGroup_symm_mk H e φ]
+  exact (subgroupFiberOrbitQuotientEquivQuotientGroup H e).apply_symm_apply
+    (QuotientGroup.mk (s := H) φ)
+
+/-- The regular-cover quotient equivalence sends the orbit class of `φ⁻¹ • e` to the coset
+of `φ`. -/
+@[simp]
 lemma regularSubgroupFiberOrbitQuotientEquivQuotientGroup_apply_inv_smul
-    [PreconnectedSpace E] (hp : IsCoveringMap p) (hreg : IsRegular p)
+    [TopologicalSpace B] [PreconnectedSpace E] (hp : IsCoveringMap p) (hreg : IsRegular p)
     (H : Subgroup (Deck p)) (e : p ⁻¹' {b}) (φ : Deck p) :
     regularSubgroupFiberOrbitQuotientEquivQuotientGroup hp hreg H e
         (subgroupFiberOrbitClass H (φ⁻¹ • e)) =
       QuotientGroup.mk (s := H) φ := by
-  simpa using
-    (regularSubgroupFiberOrbitQuotientEquivQuotientGroup hp hreg H e).apply_symm_apply
-      (QuotientGroup.mk (s := H) φ)
+  letI := hreg.fiber_isPretransitive b
+  letI := fiber_isCancelSMul (b := b) hp
+  simpa [regularSubgroupFiberOrbitQuotientEquivQuotientGroup] using
+    subgroupFiberOrbitQuotientEquivQuotientGroup_apply_inv_smul H e φ
 
 /-- The quotient equivalence sends the chosen fibre point to the identity coset. -/
 @[simp]
+lemma subgroupFiberOrbitQuotientEquivQuotientGroup_apply_base
+    [MulAction.IsPretransitive (Deck p) (p ⁻¹' {b})] [IsCancelSMul (Deck p) (p ⁻¹' {b})]
+    (H : Subgroup (Deck p)) (e : p ⁻¹' {b}) :
+    subgroupFiberOrbitQuotientEquivQuotientGroup H e
+        (subgroupFiberOrbitClass H e) =
+      QuotientGroup.mk (s := H) (1 : Deck p) := by
+  simpa using
+    subgroupFiberOrbitQuotientEquivQuotientGroup_apply_inv_smul H e (1 : Deck p)
+
+/-- The regular-cover quotient equivalence sends the chosen fibre point to the identity
+coset. -/
+@[simp]
 lemma regularSubgroupFiberOrbitQuotientEquivQuotientGroup_apply_base
-    [PreconnectedSpace E] (hp : IsCoveringMap p) (hreg : IsRegular p)
+    [TopologicalSpace B] [PreconnectedSpace E] (hp : IsCoveringMap p) (hreg : IsRegular p)
     (H : Subgroup (Deck p)) (e : p ⁻¹' {b}) :
     regularSubgroupFiberOrbitQuotientEquivQuotientGroup hp hreg H e
         (subgroupFiberOrbitClass H e) =
       QuotientGroup.mk (s := H) (1 : Deck p) := by
-  simpa using
-    regularSubgroupFiberOrbitQuotientEquivQuotientGroup_apply_inv_smul
-      hp hreg H e (1 : Deck p)
+  letI := hreg.fiber_isPretransitive b
+  letI := fiber_isCancelSMul (b := b) hp
+  simpa [regularSubgroupFiberOrbitQuotientEquivQuotientGroup] using
+    subgroupFiberOrbitQuotientEquivQuotientGroup_apply_base H e
 
 /-- The quotient equivalence sends the orbit class of `φ • e` to the coset of `φ⁻¹`. -/
 @[simp]
+lemma subgroupFiberOrbitQuotientEquivQuotientGroup_apply_smul
+    [MulAction.IsPretransitive (Deck p) (p ⁻¹' {b})] [IsCancelSMul (Deck p) (p ⁻¹' {b})]
+    (H : Subgroup (Deck p)) (e : p ⁻¹' {b}) (φ : Deck p) :
+    subgroupFiberOrbitQuotientEquivQuotientGroup H e
+        (subgroupFiberOrbitClass H (φ • e)) =
+      QuotientGroup.mk (s := H) φ⁻¹ := by
+  simpa using
+    subgroupFiberOrbitQuotientEquivQuotientGroup_apply_inv_smul H e φ⁻¹
+
+/-- The regular-cover quotient equivalence sends the orbit class of `φ • e` to the coset of
+`φ⁻¹`. -/
+@[simp]
 lemma regularSubgroupFiberOrbitQuotientEquivQuotientGroup_apply_smul
-    [PreconnectedSpace E] (hp : IsCoveringMap p) (hreg : IsRegular p)
+    [TopologicalSpace B] [PreconnectedSpace E] (hp : IsCoveringMap p) (hreg : IsRegular p)
     (H : Subgroup (Deck p)) (e : p ⁻¹' {b}) (φ : Deck p) :
     regularSubgroupFiberOrbitQuotientEquivQuotientGroup hp hreg H e
         (subgroupFiberOrbitClass H (φ • e)) =
       QuotientGroup.mk (s := H) φ⁻¹ := by
-  simpa using
-    regularSubgroupFiberOrbitQuotientEquivQuotientGroup_apply_inv_smul
-      hp hreg H e φ⁻¹
+  letI := hreg.fiber_isPretransitive b
+  letI := fiber_isCancelSMul (b := b) hp
+  simpa [regularSubgroupFiberOrbitQuotientEquivQuotientGroup] using
+    subgroupFiberOrbitQuotientEquivQuotientGroup_apply_smul H e φ
+
+/-- The subgroup-fibre quotient equivalence is natural in subgroup inclusions. -/
+lemma subgroupFiberOrbitQuotientEquivQuotientGroup_mapOfLE
+    [MulAction.IsPretransitive (Deck p) (p ⁻¹' {b})] [IsCancelSMul (Deck p) (p ⁻¹' {b})]
+    {H K : Subgroup (Deck p)} (hHK : H ≤ K) (e : p ⁻¹' {b})
+    (x : SubgroupFiberOrbitQuotient H b) :
+    Subgroup.quotientMapOfLE hHK
+        (subgroupFiberOrbitQuotientEquivQuotientGroup H e x) =
+      subgroupFiberOrbitQuotientEquivQuotientGroup K e
+        (subgroupFiberOrbitMapOfLE (b := b) hHK x) := by
+  refine Quotient.inductionOn' x ?_
+  intro e'
+  obtain ⟨φ, hφ⟩ := MulAction.exists_smul_eq (Deck p) e e'
+  rw [← hφ]
+  change Subgroup.quotientMapOfLE hHK
+      (subgroupFiberOrbitQuotientEquivQuotientGroup H e
+        (subgroupFiberOrbitClass H (φ • e))) =
+    subgroupFiberOrbitQuotientEquivQuotientGroup K e
+      (subgroupFiberOrbitMapOfLE (b := b) hHK (subgroupFiberOrbitClass H (φ • e)))
+  rw [subgroupFiberOrbitMapOfLE_apply,
+    subgroupFiberOrbitQuotientEquivQuotientGroup_apply_smul,
+    subgroupFiberOrbitQuotientEquivQuotientGroup_apply_smul,
+    Subgroup.quotientMapOfLE_apply_mk]
+
+/-- On representatives, naturality sends the class of `φ • e` through the coset map induced by
+`H ≤ K`. -/
+@[simp]
+lemma subgroupFiberOrbitQuotientEquivQuotientGroup_mapOfLE_apply_smul
+    [MulAction.IsPretransitive (Deck p) (p ⁻¹' {b})] [IsCancelSMul (Deck p) (p ⁻¹' {b})]
+    {H K : Subgroup (Deck p)} (hHK : H ≤ K) (e : p ⁻¹' {b}) (φ : Deck p) :
+    Subgroup.quotientMapOfLE hHK
+        (subgroupFiberOrbitQuotientEquivQuotientGroup H e
+          (subgroupFiberOrbitClass H (φ • e))) =
+      subgroupFiberOrbitQuotientEquivQuotientGroup K e
+        (subgroupFiberOrbitMapOfLE (b := b) hHK
+          (subgroupFiberOrbitClass H (φ • e))) := by
+  rw [subgroupFiberOrbitQuotientEquivQuotientGroup_mapOfLE]
+
+/-- The regular-cover subgroup-fibre quotient equivalence is natural in subgroup inclusions. -/
+lemma regularSubgroupFiberOrbitQuotientEquivQuotientGroup_mapOfLE
+    [TopologicalSpace B] [PreconnectedSpace E] (hp : IsCoveringMap p) (hreg : IsRegular p)
+    {H K : Subgroup (Deck p)} (hHK : H ≤ K) (e : p ⁻¹' {b})
+    (x : SubgroupFiberOrbitQuotient H b) :
+    Subgroup.quotientMapOfLE hHK
+        (regularSubgroupFiberOrbitQuotientEquivQuotientGroup hp hreg H e x) =
+      regularSubgroupFiberOrbitQuotientEquivQuotientGroup hp hreg K e
+        (subgroupFiberOrbitMapOfLE (b := b) hHK x) := by
+  letI := hreg.fiber_isPretransitive b
+  letI := fiber_isCancelSMul (b := b) hp
+  simpa [regularSubgroupFiberOrbitQuotientEquivQuotientGroup] using
+    subgroupFiberOrbitQuotientEquivQuotientGroup_mapOfLE hHK e x
+
+/-- On representatives, the regular-cover naturality lemma sends the class of `φ • e` through
+the coset map induced by `H ≤ K`. -/
+@[simp]
+lemma regularSubgroupFiberOrbitQuotientEquivQuotientGroup_mapOfLE_apply_smul
+    [TopologicalSpace B] [PreconnectedSpace E] (hp : IsCoveringMap p) (hreg : IsRegular p)
+    {H K : Subgroup (Deck p)} (hHK : H ≤ K) (e : p ⁻¹' {b}) (φ : Deck p) :
+    Subgroup.quotientMapOfLE hHK
+        (regularSubgroupFiberOrbitQuotientEquivQuotientGroup hp hreg H e
+          (subgroupFiberOrbitClass H (φ • e))) =
+      regularSubgroupFiberOrbitQuotientEquivQuotientGroup hp hreg K e
+        (subgroupFiberOrbitMapOfLE (b := b) hHK
+          (subgroupFiberOrbitClass H (φ • e))) := by
+  rw [regularSubgroupFiberOrbitQuotientEquivQuotientGroup_mapOfLE]
 
 /-- Equality of subgroup fibre-orbit classes is equality of the corresponding deck cosets
-under the regular-cover quotient equivalence. -/
-lemma regularSubgroupFiberOrbitClass_eq_iff_quotientGroup_mk_eq
-    [PreconnectedSpace E] (hp : IsCoveringMap p) (hreg : IsRegular p)
+under the quotient equivalence, with the inverse orientation coming from Mathlib's quotient
+convention. -/
+lemma subgroupFiberOrbitClass_eq_iff_quotientGroup_mk_inv_eq
+    [MulAction.IsPretransitive (Deck p) (p ⁻¹' {b})] [IsCancelSMul (Deck p) (p ⁻¹' {b})]
     (H : Subgroup (Deck p)) (e : p ⁻¹' {b}) (φ ψ : Deck p) :
     subgroupFiberOrbitClass H (φ • e) = subgroupFiberOrbitClass H (ψ • e) ↔
       QuotientGroup.mk (s := H) φ⁻¹ = QuotientGroup.mk (s := H) ψ⁻¹ := by
   constructor
   · intro h
     have h' := congrArg
-      (regularSubgroupFiberOrbitQuotientEquivQuotientGroup hp hreg H e) h
-    rw [regularSubgroupFiberOrbitQuotientEquivQuotientGroup_apply_smul,
-      regularSubgroupFiberOrbitQuotientEquivQuotientGroup_apply_smul] at h'
+      (subgroupFiberOrbitQuotientEquivQuotientGroup H e) h
+    rw [subgroupFiberOrbitQuotientEquivQuotientGroup_apply_smul,
+      subgroupFiberOrbitQuotientEquivQuotientGroup_apply_smul] at h'
     exact h'
   · intro h
-    apply (regularSubgroupFiberOrbitQuotientEquivQuotientGroup hp hreg H e).injective
-    rw [regularSubgroupFiberOrbitQuotientEquivQuotientGroup_apply_smul,
-      regularSubgroupFiberOrbitQuotientEquivQuotientGroup_apply_smul]
+    apply (subgroupFiberOrbitQuotientEquivQuotientGroup H e).injective
+    rw [subgroupFiberOrbitQuotientEquivQuotientGroup_apply_smul,
+      subgroupFiberOrbitQuotientEquivQuotientGroup_apply_smul]
     exact h
+
+/-- Equality of subgroup fibre-orbit classes is equality of the corresponding deck cosets
+under the regular-cover quotient equivalence, with the inverse orientation coming from
+Mathlib's quotient convention. -/
+lemma regularSubgroupFiberOrbitClass_eq_iff_quotientGroup_mk_inv_eq
+    [TopologicalSpace B] [PreconnectedSpace E] (hp : IsCoveringMap p) (hreg : IsRegular p)
+    (H : Subgroup (Deck p)) (e : p ⁻¹' {b}) (φ ψ : Deck p) :
+    subgroupFiberOrbitClass H (φ • e) = subgroupFiberOrbitClass H (ψ • e) ↔
+      QuotientGroup.mk (s := H) φ⁻¹ = QuotientGroup.mk (s := H) ψ⁻¹ := by
+  letI := hreg.fiber_isPretransitive b
+  letI := fiber_isCancelSMul (b := b) hp
+  exact subgroupFiberOrbitClass_eq_iff_quotientGroup_mk_inv_eq H e φ ψ
 
 end Deck
 

--- a/TauCeti/AlgebraicTopology/UniversalCover/Deck/SubgroupFiberOrbitQuotientGroup.lean
+++ b/TauCeti/AlgebraicTopology/UniversalCover/Deck/SubgroupFiberOrbitQuotientGroup.lean
@@ -1,0 +1,160 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+module
+
+public import Mathlib.GroupTheory.GroupAction.Quotient
+public import TauCeti.AlgebraicTopology.UniversalCover.Deck.SubgroupFiberOrbit
+
+/-!
+# Subgroup fibre orbits of a regular cover as deck-group quotients
+
+For a regular preconnected covering map, evaluation at any point of a fibre identifies the
+deck group with that fibre. This file records the corresponding quotient-level statement:
+orbits of a subgroup `H ≤ Deck p` on the fibre are equivalent to the coset quotient
+`Deck p ⧸ H`.
+
+This is bookkeeping for the universal-covers roadmap. The classification of connected covers
+uses fibre quotients by subgroups, while the regular-cover computation of the deck group of
+the cover attached to `H` is expressed algebraically as a normalizer quotient. The bridge here
+lets later arguments move between those fibre-orbit quotients and subgroup quotients without
+unfolding either construction.
+
+## Main declarations
+
+* `TauCeti.Deck.regularSubgroupFiberOrbitQuotientEquivQuotientGroup`: for a regular
+  preconnected covering, `SubgroupFiberOrbitQuotient H b ≃ Deck p ⧸ H`.
+* `TauCeti.Deck.regularSubgroupFiberOrbitQuotientEquivQuotientGroup_symm_mk`: the inverse
+  sends the coset of `φ` to the `H`-orbit class of `φ⁻¹ • e`.
+
+## References
+
+This supplies a prerequisite for `TauCetiRoadmap/UniversalCovers/README.md`, Stage 2, items
+7 and 8, especially the regular-cover milestones comparing fibre quotients with the
+normalizer quotient `N(H)/H`. It is a deck-specific specialization of Mathlib's
+`MulAction.equivSubgroupOrbitsQuotientGroup`, the orbit-quotient form of the
+orbit-stabilizer theorem for free transitive actions.
+-/
+
+public section
+
+namespace TauCeti
+
+namespace Deck
+
+variable {E B : Type*} [TopologicalSpace E] [TopologicalSpace B] {p : E → B} {b : B}
+
+/-- For a regular preconnected covering, quotienting one fibre by the action of
+`H ≤ Deck p` is equivalent to the coset quotient `Deck p ⧸ H`.
+
+The chosen point `e` fixes the identification between the deck group and the fibre. With
+Mathlib's convention for `MulAction.equivSubgroupOrbitsQuotientGroup`, the inverse sends the
+coset of `φ` to the orbit class of `φ⁻¹ • e`; see
+`regularSubgroupFiberOrbitQuotientEquivQuotientGroup_symm_mk`. -/
+@[expose] noncomputable def regularSubgroupFiberOrbitQuotientEquivQuotientGroup
+    [PreconnectedSpace E] (hp : IsCoveringMap p) (hreg : IsRegular p)
+    (H : Subgroup (Deck p)) (e : p ⁻¹' {b}) :
+    SubgroupFiberOrbitQuotient H b ≃ Deck p ⧸ H := by
+  letI := hreg.fiber_isPretransitive b
+  letI := fiber_isCancelSMul (b := b) hp
+  exact MulAction.equivSubgroupOrbitsQuotientGroup e H
+
+/-- The inverse quotient equivalence sends the coset of a deck transformation `φ` to the
+`H`-orbit class of the point `φ⁻¹ • e`. -/
+@[simp]
+lemma regularSubgroupFiberOrbitQuotientEquivQuotientGroup_symm_mk
+    [PreconnectedSpace E] (hp : IsCoveringMap p) (hreg : IsRegular p)
+    (H : Subgroup (Deck p)) (e : p ⁻¹' {b}) (φ : Deck p) :
+    (regularSubgroupFiberOrbitQuotientEquivQuotientGroup hp hreg H e).symm
+        (QuotientGroup.mk (s := H) φ) =
+      subgroupFiberOrbitClass H (φ⁻¹ • e) := by
+  letI := hreg.fiber_isPretransitive b
+  letI := fiber_isCancelSMul (b := b) hp
+  rfl
+
+/-- On underlying points, the inverse quotient equivalence sends the coset of `φ` to the
+class of the value of `φ⁻¹` on the chosen fibre point. -/
+@[simp]
+lemma regularSubgroupFiberOrbitQuotientEquivQuotientGroup_symm_mk_coe
+    [PreconnectedSpace E] (hp : IsCoveringMap p) (hreg : IsRegular p)
+    (H : Subgroup (Deck p)) (e : p ⁻¹' {b}) (φ : Deck p) :
+    (regularSubgroupFiberOrbitQuotientEquivQuotientGroup hp hreg H e).symm
+        (QuotientGroup.mk φ) =
+      subgroupFiberOrbitClass H
+        ⟨φ.1.symm e.1, by
+          rw [Set.mem_preimage, Set.mem_singleton_iff]
+          exact (map_proj φ⁻¹ e.1).trans (Set.mem_singleton_iff.mp e.2)⟩ := by
+  rw [regularSubgroupFiberOrbitQuotientEquivQuotientGroup_symm_mk]
+  congr 1
+
+/-- The inverse quotient equivalence sends the identity coset to the orbit class of the chosen
+fibre point. -/
+@[simp]
+lemma regularSubgroupFiberOrbitQuotientEquivQuotientGroup_symm_one
+    [PreconnectedSpace E] (hp : IsCoveringMap p) (hreg : IsRegular p)
+    (H : Subgroup (Deck p)) (e : p ⁻¹' {b}) :
+    (regularSubgroupFiberOrbitQuotientEquivQuotientGroup hp hreg H e).symm
+        (QuotientGroup.mk (s := H) (1 : Deck p)) =
+      subgroupFiberOrbitClass H e := by
+  rw [regularSubgroupFiberOrbitQuotientEquivQuotientGroup_symm_mk, inv_one, one_smul]
+
+/-- The quotient equivalence sends the orbit class of `φ⁻¹ • e` to the coset of `φ`. -/
+@[simp]
+lemma regularSubgroupFiberOrbitQuotientEquivQuotientGroup_apply_inv_smul
+    [PreconnectedSpace E] (hp : IsCoveringMap p) (hreg : IsRegular p)
+    (H : Subgroup (Deck p)) (e : p ⁻¹' {b}) (φ : Deck p) :
+    regularSubgroupFiberOrbitQuotientEquivQuotientGroup hp hreg H e
+        (subgroupFiberOrbitClass H (φ⁻¹ • e)) =
+      QuotientGroup.mk (s := H) φ := by
+  simpa using
+    (regularSubgroupFiberOrbitQuotientEquivQuotientGroup hp hreg H e).apply_symm_apply
+      (QuotientGroup.mk (s := H) φ)
+
+/-- The quotient equivalence sends the chosen fibre point to the identity coset. -/
+@[simp]
+lemma regularSubgroupFiberOrbitQuotientEquivQuotientGroup_apply_base
+    [PreconnectedSpace E] (hp : IsCoveringMap p) (hreg : IsRegular p)
+    (H : Subgroup (Deck p)) (e : p ⁻¹' {b}) :
+    regularSubgroupFiberOrbitQuotientEquivQuotientGroup hp hreg H e
+        (subgroupFiberOrbitClass H e) =
+      QuotientGroup.mk (s := H) (1 : Deck p) := by
+  simpa using
+    regularSubgroupFiberOrbitQuotientEquivQuotientGroup_apply_inv_smul
+      hp hreg H e (1 : Deck p)
+
+/-- The quotient equivalence sends the orbit class of `φ • e` to the coset of `φ⁻¹`. -/
+@[simp]
+lemma regularSubgroupFiberOrbitQuotientEquivQuotientGroup_apply_smul
+    [PreconnectedSpace E] (hp : IsCoveringMap p) (hreg : IsRegular p)
+    (H : Subgroup (Deck p)) (e : p ⁻¹' {b}) (φ : Deck p) :
+    regularSubgroupFiberOrbitQuotientEquivQuotientGroup hp hreg H e
+        (subgroupFiberOrbitClass H (φ • e)) =
+      QuotientGroup.mk (s := H) φ⁻¹ := by
+  simpa using
+    regularSubgroupFiberOrbitQuotientEquivQuotientGroup_apply_inv_smul
+      hp hreg H e φ⁻¹
+
+/-- Equality of subgroup fibre-orbit classes is equality of the corresponding deck cosets
+under the regular-cover quotient equivalence. -/
+lemma regularSubgroupFiberOrbitClass_eq_iff_quotientGroup_mk_eq
+    [PreconnectedSpace E] (hp : IsCoveringMap p) (hreg : IsRegular p)
+    (H : Subgroup (Deck p)) (e : p ⁻¹' {b}) (φ ψ : Deck p) :
+    subgroupFiberOrbitClass H (φ • e) = subgroupFiberOrbitClass H (ψ • e) ↔
+      QuotientGroup.mk (s := H) φ⁻¹ = QuotientGroup.mk (s := H) ψ⁻¹ := by
+  constructor
+  · intro h
+    have h' := congrArg
+      (regularSubgroupFiberOrbitQuotientEquivQuotientGroup hp hreg H e) h
+    rw [regularSubgroupFiberOrbitQuotientEquivQuotientGroup_apply_smul,
+      regularSubgroupFiberOrbitQuotientEquivQuotientGroup_apply_smul] at h'
+    exact h'
+  · intro h
+    apply (regularSubgroupFiberOrbitQuotientEquivQuotientGroup hp hreg H e).injective
+    rw [regularSubgroupFiberOrbitQuotientEquivQuotientGroup_apply_smul,
+      regularSubgroupFiberOrbitQuotientEquivQuotientGroup_apply_smul]
+    exact h
+
+end Deck
+
+end TauCeti

--- a/TauCeti/AlgebraicTopology/UniversalCover/Deck/SubgroupFiberOrbitQuotientGroup.lean
+++ b/TauCeti/AlgebraicTopology/UniversalCover/Deck/SubgroupFiberOrbitQuotientGroup.lean
@@ -26,8 +26,6 @@ unfolding either construction.
 
 * `MulAction.equivSubgroupOrbitsQuotientGroup`: applied to the deck action on one fibre, this
   identifies `SubgroupFiberOrbitQuotient H b` with `Deck p ⧸ H`.
-* `TauCeti.Deck.regularSubgroupFiberOrbitQuotientEquivQuotientGroup`: the regular-cover
-  specialization of this equivalence.
 * `TauCeti.Deck.subgroupFiberOrbitQuotientEquivQuotientGroup_mapOfLE`: compatibility with
   the maps induced by subgroup inclusions.
 
@@ -59,16 +57,6 @@ private lemma mulAction_equivSubgroupOrbitsQuotientGroup_symm_mk
       (Quotient.mk'' (g⁻¹ • x) : MulAction.orbitRel.Quotient H X) :=
   rfl
 
-/-- For a regular preconnected covering, quotienting one fibre by the action of
-`H ≤ Deck p` is equivalent to the coset quotient `Deck p ⧸ H`. -/
-noncomputable def regularSubgroupFiberOrbitQuotientEquivQuotientGroup
-    [TopologicalSpace B] [PreconnectedSpace E] (hp : IsCoveringMap p) (hreg : IsRegular p)
-    (H : Subgroup (Deck p)) (e : p ⁻¹' {b}) :
-    SubgroupFiberOrbitQuotient H b ≃ Deck p ⧸ H := by
-  letI := hreg.fiber_isPretransitive b
-  letI := fiber_isCancelSMul (b := b) hp
-  exact MulAction.equivSubgroupOrbitsQuotientGroup e H
-
 /-- The inverse quotient equivalence sends the coset of a deck transformation `φ` to the
 `H`-orbit class of the point `φ⁻¹ • e`. -/
 @[simp]
@@ -87,12 +75,13 @@ to the `H`-orbit class of `φ⁻¹ • e`. -/
 lemma regularSubgroupFiberOrbitQuotientEquivQuotientGroup_symm_mk
     [TopologicalSpace B] [PreconnectedSpace E] (hp : IsCoveringMap p) (hreg : IsRegular p)
     (H : Subgroup (Deck p)) (e : p ⁻¹' {b}) (φ : Deck p) :
-    (regularSubgroupFiberOrbitQuotientEquivQuotientGroup hp hreg H e).symm
+    (@MulAction.equivSubgroupOrbitsQuotientGroup (Deck p) (p ⁻¹' {b}) _ _ e
+        (hreg.fiber_isPretransitive b) (fiber_isCancelSMul (b := b) hp) H).symm
         (QuotientGroup.mk (s := H) φ) =
       subgroupFiberOrbitClass H (φ⁻¹ • e) := by
   letI := hreg.fiber_isPretransitive b
   letI := fiber_isCancelSMul (b := b) hp
-  simp [regularSubgroupFiberOrbitQuotientEquivQuotientGroup]
+  simp
 
 /-- On underlying points, the inverse quotient equivalence sends the coset of `φ` to the
 class of the value of `φ⁻¹` on the chosen fibre point. -/
@@ -115,7 +104,8 @@ lemma subgroupFiberOrbitQuotientEquivQuotientGroup_symm_mk_coe
 lemma regularSubgroupFiberOrbitQuotientEquivQuotientGroup_symm_mk_coe
     [TopologicalSpace B] [PreconnectedSpace E] (hp : IsCoveringMap p) (hreg : IsRegular p)
     (H : Subgroup (Deck p)) (e : p ⁻¹' {b}) (φ : Deck p) :
-    (regularSubgroupFiberOrbitQuotientEquivQuotientGroup hp hreg H e).symm
+    (@MulAction.equivSubgroupOrbitsQuotientGroup (Deck p) (p ⁻¹' {b}) _ _ e
+        (hreg.fiber_isPretransitive b) (fiber_isCancelSMul (b := b) hp) H).symm
         (QuotientGroup.mk φ) =
       subgroupFiberOrbitClass H
         ⟨φ.1.symm e.1, by
@@ -123,8 +113,7 @@ lemma regularSubgroupFiberOrbitQuotientEquivQuotientGroup_symm_mk_coe
           exact (map_proj φ⁻¹ e.1).trans (Set.mem_singleton_iff.mp e.2)⟩ := by
   letI := hreg.fiber_isPretransitive b
   letI := fiber_isCancelSMul (b := b) hp
-  simpa [regularSubgroupFiberOrbitQuotientEquivQuotientGroup] using
-    subgroupFiberOrbitQuotientEquivQuotientGroup_symm_mk_coe H e φ
+  simpa using subgroupFiberOrbitQuotientEquivQuotientGroup_symm_mk_coe H e φ
 
 /-- The inverse quotient equivalence sends the identity coset to the orbit class of the chosen
 fibre point. -/
@@ -143,12 +132,13 @@ of the chosen fibre point. -/
 lemma regularSubgroupFiberOrbitQuotientEquivQuotientGroup_symm_one
     [TopologicalSpace B] [PreconnectedSpace E] (hp : IsCoveringMap p) (hreg : IsRegular p)
     (H : Subgroup (Deck p)) (e : p ⁻¹' {b}) :
-    (regularSubgroupFiberOrbitQuotientEquivQuotientGroup hp hreg H e).symm
+    (@MulAction.equivSubgroupOrbitsQuotientGroup (Deck p) (p ⁻¹' {b}) _ _ e
+        (hreg.fiber_isPretransitive b) (fiber_isCancelSMul (b := b) hp) H).symm
         (QuotientGroup.mk (s := H) (1 : Deck p)) =
       subgroupFiberOrbitClass H e := by
   letI := hreg.fiber_isPretransitive b
   letI := fiber_isCancelSMul (b := b) hp
-  simp [regularSubgroupFiberOrbitQuotientEquivQuotientGroup]
+  simp
 
 /-- The quotient equivalence sends the orbit class of `φ⁻¹ • e` to the coset of `φ`. -/
 @[simp]
@@ -168,13 +158,13 @@ of `φ`. -/
 lemma regularSubgroupFiberOrbitQuotientEquivQuotientGroup_apply_inv_smul
     [TopologicalSpace B] [PreconnectedSpace E] (hp : IsCoveringMap p) (hreg : IsRegular p)
     (H : Subgroup (Deck p)) (e : p ⁻¹' {b}) (φ : Deck p) :
-    regularSubgroupFiberOrbitQuotientEquivQuotientGroup hp hreg H e
+    @MulAction.equivSubgroupOrbitsQuotientGroup (Deck p) (p ⁻¹' {b}) _ _ e
+        (hreg.fiber_isPretransitive b) (fiber_isCancelSMul (b := b) hp) H
         (subgroupFiberOrbitClass H (φ⁻¹ • e)) =
       QuotientGroup.mk (s := H) φ := by
   letI := hreg.fiber_isPretransitive b
   letI := fiber_isCancelSMul (b := b) hp
-  simpa [regularSubgroupFiberOrbitQuotientEquivQuotientGroup] using
-    subgroupFiberOrbitQuotientEquivQuotientGroup_apply_inv_smul H e φ
+  simpa using subgroupFiberOrbitQuotientEquivQuotientGroup_apply_inv_smul H e φ
 
 /-- The quotient equivalence sends the chosen fibre point to the identity coset. -/
 @[simp]
@@ -193,13 +183,13 @@ coset. -/
 lemma regularSubgroupFiberOrbitQuotientEquivQuotientGroup_apply_base
     [TopologicalSpace B] [PreconnectedSpace E] (hp : IsCoveringMap p) (hreg : IsRegular p)
     (H : Subgroup (Deck p)) (e : p ⁻¹' {b}) :
-    regularSubgroupFiberOrbitQuotientEquivQuotientGroup hp hreg H e
+    @MulAction.equivSubgroupOrbitsQuotientGroup (Deck p) (p ⁻¹' {b}) _ _ e
+        (hreg.fiber_isPretransitive b) (fiber_isCancelSMul (b := b) hp) H
         (subgroupFiberOrbitClass H e) =
       QuotientGroup.mk (s := H) (1 : Deck p) := by
   letI := hreg.fiber_isPretransitive b
   letI := fiber_isCancelSMul (b := b) hp
-  simpa [regularSubgroupFiberOrbitQuotientEquivQuotientGroup] using
-    subgroupFiberOrbitQuotientEquivQuotientGroup_apply_base H e
+  simpa using subgroupFiberOrbitQuotientEquivQuotientGroup_apply_base H e
 
 /-- The quotient equivalence sends the orbit class of `φ • e` to the coset of `φ⁻¹`. -/
 @[simp]
@@ -218,13 +208,13 @@ lemma subgroupFiberOrbitQuotientEquivQuotientGroup_apply_smul
 lemma regularSubgroupFiberOrbitQuotientEquivQuotientGroup_apply_smul
     [TopologicalSpace B] [PreconnectedSpace E] (hp : IsCoveringMap p) (hreg : IsRegular p)
     (H : Subgroup (Deck p)) (e : p ⁻¹' {b}) (φ : Deck p) :
-    regularSubgroupFiberOrbitQuotientEquivQuotientGroup hp hreg H e
+    @MulAction.equivSubgroupOrbitsQuotientGroup (Deck p) (p ⁻¹' {b}) _ _ e
+        (hreg.fiber_isPretransitive b) (fiber_isCancelSMul (b := b) hp) H
         (subgroupFiberOrbitClass H (φ • e)) =
       QuotientGroup.mk (s := H) φ⁻¹ := by
   letI := hreg.fiber_isPretransitive b
   letI := fiber_isCancelSMul (b := b) hp
-  simpa [regularSubgroupFiberOrbitQuotientEquivQuotientGroup] using
-    subgroupFiberOrbitQuotientEquivQuotientGroup_apply_smul H e φ
+  simpa using subgroupFiberOrbitQuotientEquivQuotientGroup_apply_smul H e φ
 
 /-- The subgroup-fibre quotient equivalence is natural in subgroup inclusions. -/
 @[simp]
@@ -267,12 +257,14 @@ lemma regularSubgroupFiberOrbitQuotientEquivQuotientGroup_mapOfLE
     {H K : Subgroup (Deck p)} (hHK : H ≤ K) (e : p ⁻¹' {b})
     (x : SubgroupFiberOrbitQuotient H b) :
     Subgroup.quotientMapOfLE hHK
-        (regularSubgroupFiberOrbitQuotientEquivQuotientGroup hp hreg H e x) =
-      regularSubgroupFiberOrbitQuotientEquivQuotientGroup hp hreg K e
+        (@MulAction.equivSubgroupOrbitsQuotientGroup (Deck p) (p ⁻¹' {b}) _ _ e
+          (hreg.fiber_isPretransitive b) (fiber_isCancelSMul (b := b) hp) H x) =
+      @MulAction.equivSubgroupOrbitsQuotientGroup (Deck p) (p ⁻¹' {b}) _ _ e
+        (hreg.fiber_isPretransitive b) (fiber_isCancelSMul (b := b) hp) K
         (subgroupFiberOrbitMapOfLE (b := b) hHK x) := by
   letI := hreg.fiber_isPretransitive b
   letI := fiber_isCancelSMul (b := b) hp
-  simp [regularSubgroupFiberOrbitQuotientEquivQuotientGroup]
+  simp
 
 /-- On representatives, the regular-cover naturality lemma sends the class of `φ • e` through
 the coset map induced by `H ≤ K`. -/
@@ -281,12 +273,14 @@ lemma regularSubgroupFiberOrbitQuotientEquivQuotientGroup_mapOfLE_apply_smul
     [TopologicalSpace B] [PreconnectedSpace E] (hp : IsCoveringMap p) (hreg : IsRegular p)
     {H K : Subgroup (Deck p)} (hHK : H ≤ K) (e : p ⁻¹' {b}) (φ : Deck p) :
     Subgroup.quotientMapOfLE hHK
-        (regularSubgroupFiberOrbitQuotientEquivQuotientGroup hp hreg H e
+        (@MulAction.equivSubgroupOrbitsQuotientGroup (Deck p) (p ⁻¹' {b}) _ _ e
+          (hreg.fiber_isPretransitive b) (fiber_isCancelSMul (b := b) hp) H
           (subgroupFiberOrbitClass H (φ • e))) =
-      regularSubgroupFiberOrbitQuotientEquivQuotientGroup hp hreg K e
+      @MulAction.equivSubgroupOrbitsQuotientGroup (Deck p) (p ⁻¹' {b}) _ _ e
+        (hreg.fiber_isPretransitive b) (fiber_isCancelSMul (b := b) hp) K
         (subgroupFiberOrbitMapOfLE (b := b) hHK
           (subgroupFiberOrbitClass H (φ • e))) := by
-  rw [regularSubgroupFiberOrbitQuotientEquivQuotientGroup_mapOfLE]
+  simp
 
 /-- Equality of subgroup fibre-orbit classes is equality of the corresponding deck cosets
 under the quotient equivalence, with the inverse orientation coming from Mathlib's quotient

--- a/TauCeti/AlgebraicTopology/UniversalCover/Deck/SubgroupFiberOrbitQuotientGroup.lean
+++ b/TauCeti/AlgebraicTopology/UniversalCover/Deck/SubgroupFiberOrbitQuotientGroup.lean
@@ -28,8 +28,6 @@ unfolding either construction.
   `SubgroupFiberOrbitQuotient H b` with `Deck p ⧸ H`.
 * `TauCeti.Deck.regularSubgroupFiberOrbitQuotientEquivQuotientGroup`: the regular-cover
   specialization that installs the free-transitive deck action on the fibre.
-* `TauCeti.MulAction.equivSubgroupOrbitsQuotientGroup_mapOfLE`: generic compatibility of
-  Mathlib's subgroup-orbit quotient equivalence with maps induced by subgroup inclusions.
 * `TauCeti.Deck.subgroupFiberOrbitQuotientEquivQuotientGroup_mapOfLE`: compatibility with
   the maps induced by subgroup inclusions.
 
@@ -72,7 +70,7 @@ private lemma equivSubgroupOrbitsQuotientGroup_apply_smul
     (QuotientGroup.mk (s := H) g⁻¹)
 
 /-- The map on orbit quotients induced by an inclusion of acting subgroups. -/
-@[expose] def orbitRelQuotientMapOfLE {G X : Type*} [Group G] [MulAction G X]
+private def orbitRelQuotientMapOfLE {G X : Type*} [Group G] [MulAction G X]
     {H K : Subgroup G} (hHK : H ≤ K) :
     MulAction.orbitRel.Quotient H X → MulAction.orbitRel.Quotient K X :=
   Quotient.map' id fun x y h => by
@@ -82,7 +80,7 @@ private lemma equivSubgroupOrbitsQuotientGroup_apply_smul
 
 /-- The map induced by `H ≤ K` sends an `H`-orbit representative to its `K`-orbit class. -/
 @[simp]
-lemma orbitRelQuotientMapOfLE_mk {G X : Type*} [Group G] [MulAction G X]
+private lemma orbitRelQuotientMapOfLE_mk {G X : Type*} [Group G] [MulAction G X]
     {H K : Subgroup G} (hHK : H ≤ K) (x : X) :
     orbitRelQuotientMapOfLE hHK (Quotient.mk'' x : MulAction.orbitRel.Quotient H X) =
       (Quotient.mk'' x : MulAction.orbitRel.Quotient K X) :=
@@ -90,7 +88,7 @@ lemma orbitRelQuotientMapOfLE_mk {G X : Type*} [Group G] [MulAction G X]
 
 /-- The subgroup-orbit quotient equivalence is natural in subgroup inclusions. -/
 @[simp]
-lemma equivSubgroupOrbitsQuotientGroup_mapOfLE
+private lemma equivSubgroupOrbitsQuotientGroup_mapOfLE
     {G X : Type*} [Group G] [MulAction G X] [MulAction.IsPretransitive G X]
     [IsCancelSMul G X] {H K : Subgroup G} (hHK : H ≤ K) (x₀ : X)
     (x : MulAction.orbitRel.Quotient H X) :
@@ -121,7 +119,7 @@ subgroup, once the deck action on the chosen fibre is free and transitive. -/
 
 /-- For a regular preconnected covering map, the subgroup-fibre orbit quotient is equivalent
 to the quotient of the deck group by the subgroup. -/
-@[expose] noncomputable def regularSubgroupFiberOrbitQuotientEquivQuotientGroup
+noncomputable def regularSubgroupFiberOrbitQuotientEquivQuotientGroup
     [TopologicalSpace B] [PreconnectedSpace E] (hp : IsCoveringMap p) (hreg : IsRegular p)
     (H : Subgroup (Deck p)) (e : p ⁻¹' {b}) :
     SubgroupFiberOrbitQuotient H b ≃ Deck p ⧸ H :=
@@ -139,6 +137,20 @@ lemma subgroupFiberOrbitQuotientEquivQuotientGroup_symm_mk
       subgroupFiberOrbitClass H (φ⁻¹ • e) := by
   simpa [subgroupFiberOrbitQuotientEquivQuotientGroup, subgroupFiberOrbitClass_eq_mk] using
     MulAction.equivSubgroupOrbitsQuotientGroup_symm_mk H e φ
+
+/-- For a regular cover, the inverse quotient equivalence sends the coset of a deck
+transformation `φ` to the `H`-orbit class of `φ⁻¹ • e`. -/
+@[simp]
+lemma regularSubgroupFiberOrbitQuotientEquivQuotientGroup_symm_mk
+    [TopologicalSpace B] [PreconnectedSpace E] (hp : IsCoveringMap p) (hreg : IsRegular p)
+    (H : Subgroup (Deck p)) (e : p ⁻¹' {b}) (φ : Deck p) :
+    (regularSubgroupFiberOrbitQuotientEquivQuotientGroup hp hreg H e).symm
+        (QuotientGroup.mk (s := H) φ) =
+      subgroupFiberOrbitClass H (φ⁻¹ • e) := by
+  letI := hreg.fiber_isPretransitive b
+  letI := fiber_isCancelSMul (b := b) hp
+  simp [regularSubgroupFiberOrbitQuotientEquivQuotientGroup,
+    subgroupFiberOrbitQuotientEquivQuotientGroup_symm_mk H e φ]
 
 /-- On underlying points, the inverse quotient equivalence sends the coset of `φ` to the
 class of the value of `φ⁻¹` on the chosen fibre point. -/
@@ -178,6 +190,20 @@ lemma subgroupFiberOrbitQuotientEquivQuotientGroup_apply_inv_smul
   exact (subgroupFiberOrbitQuotientEquivQuotientGroup H e).apply_symm_apply
     (QuotientGroup.mk (s := H) φ)
 
+/-- For a regular cover, the quotient equivalence sends the orbit class of `φ⁻¹ • e` to the
+coset of `φ`. -/
+@[simp]
+lemma regularSubgroupFiberOrbitQuotientEquivQuotientGroup_apply_inv_smul
+    [TopologicalSpace B] [PreconnectedSpace E] (hp : IsCoveringMap p) (hreg : IsRegular p)
+    (H : Subgroup (Deck p)) (e : p ⁻¹' {b}) (φ : Deck p) :
+    regularSubgroupFiberOrbitQuotientEquivQuotientGroup hp hreg H e
+        (subgroupFiberOrbitClass H (φ⁻¹ • e)) =
+      QuotientGroup.mk (s := H) φ := by
+  letI := hreg.fiber_isPretransitive b
+  letI := fiber_isCancelSMul (b := b) hp
+  simpa [regularSubgroupFiberOrbitQuotientEquivQuotientGroup] using
+    subgroupFiberOrbitQuotientEquivQuotientGroup_apply_inv_smul H e φ
+
 /-- The quotient equivalence sends the chosen fibre point to the identity coset. -/
 @[simp]
 lemma subgroupFiberOrbitQuotientEquivQuotientGroup_apply_base
@@ -200,6 +226,20 @@ lemma subgroupFiberOrbitQuotientEquivQuotientGroup_apply_smul
   simpa using
     subgroupFiberOrbitQuotientEquivQuotientGroup_apply_inv_smul H e φ⁻¹
 
+/-- For a regular cover, the quotient equivalence sends the orbit class of `φ • e` to the
+coset of `φ⁻¹`. -/
+@[simp]
+lemma regularSubgroupFiberOrbitQuotientEquivQuotientGroup_apply_smul
+    [TopologicalSpace B] [PreconnectedSpace E] (hp : IsCoveringMap p) (hreg : IsRegular p)
+    (H : Subgroup (Deck p)) (e : p ⁻¹' {b}) (φ : Deck p) :
+    regularSubgroupFiberOrbitQuotientEquivQuotientGroup hp hreg H e
+        (subgroupFiberOrbitClass H (φ • e)) =
+      QuotientGroup.mk (s := H) φ⁻¹ := by
+  letI := hreg.fiber_isPretransitive b
+  letI := fiber_isCancelSMul (b := b) hp
+  simpa [regularSubgroupFiberOrbitQuotientEquivQuotientGroup] using
+    subgroupFiberOrbitQuotientEquivQuotientGroup_apply_smul H e φ
+
 /-- The subgroup-fibre quotient equivalence is natural in subgroup inclusions. -/
 @[simp]
 lemma subgroupFiberOrbitQuotientEquivQuotientGroup_mapOfLE
@@ -215,19 +255,21 @@ lemma subgroupFiberOrbitQuotientEquivQuotientGroup_mapOfLE
     MulAction.equivSubgroupOrbitsQuotientGroup_mapOfLE (G := Deck p) (X := p ⁻¹' {b})
       hHK e x]
 
-/-- On representatives, naturality sends the class of `φ • e` through the coset map induced by
-`H ≤ K`. -/
+/-- For a regular cover, the subgroup-fibre quotient equivalence is natural in subgroup
+inclusions. -/
 @[simp]
-lemma subgroupFiberOrbitQuotientEquivQuotientGroup_mapOfLE_apply_smul
-    [MulAction.IsPretransitive (Deck p) (p ⁻¹' {b})] [IsCancelSMul (Deck p) (p ⁻¹' {b})]
-    {H K : Subgroup (Deck p)} (hHK : H ≤ K) (e : p ⁻¹' {b}) (φ : Deck p) :
+lemma regularSubgroupFiberOrbitQuotientEquivQuotientGroup_mapOfLE
+    [TopologicalSpace B] [PreconnectedSpace E] (hp : IsCoveringMap p) (hreg : IsRegular p)
+    {H K : Subgroup (Deck p)} (hHK : H ≤ K) (e : p ⁻¹' {b})
+    (x : SubgroupFiberOrbitQuotient H b) :
     Subgroup.quotientMapOfLE hHK
-        (subgroupFiberOrbitQuotientEquivQuotientGroup H e
-          (subgroupFiberOrbitClass H (φ • e))) =
-      subgroupFiberOrbitQuotientEquivQuotientGroup K e
-        (subgroupFiberOrbitMapOfLE (b := b) hHK
-          (subgroupFiberOrbitClass H (φ • e))) := by
-  rw [subgroupFiberOrbitQuotientEquivQuotientGroup_mapOfLE]
+        (regularSubgroupFiberOrbitQuotientEquivQuotientGroup hp hreg H e x) =
+      regularSubgroupFiberOrbitQuotientEquivQuotientGroup hp hreg K e
+        (subgroupFiberOrbitMapOfLE (b := b) hHK x) := by
+  letI := hreg.fiber_isPretransitive b
+  letI := fiber_isCancelSMul (b := b) hp
+  simp [regularSubgroupFiberOrbitQuotientEquivQuotientGroup,
+    subgroupFiberOrbitQuotientEquivQuotientGroup_mapOfLE hHK e x]
 
 /-- Equality of subgroup fibre-orbit classes is equality of the corresponding deck cosets
 under the quotient equivalence, with the inverse orientation coming from Mathlib's quotient
@@ -249,18 +291,6 @@ lemma subgroupFiberOrbitClass_eq_iff_quotientGroup_mk_inv_eq
     rw [subgroupFiberOrbitQuotientEquivQuotientGroup_apply_smul,
       subgroupFiberOrbitQuotientEquivQuotientGroup_apply_smul]
     exact h
-
-/-- Equality of subgroup fibre-orbit classes is equality of the corresponding deck cosets
-under the regular-cover quotient equivalence, with the inverse orientation coming from
-Mathlib's quotient convention. -/
-lemma regularSubgroupFiberOrbitClass_eq_iff_quotientGroup_mk_inv_eq
-    [TopologicalSpace B] [PreconnectedSpace E] (hp : IsCoveringMap p) (hreg : IsRegular p)
-    (H : Subgroup (Deck p)) (e : p ⁻¹' {b}) (φ ψ : Deck p) :
-    subgroupFiberOrbitClass H (φ • e) = subgroupFiberOrbitClass H (ψ • e) ↔
-      QuotientGroup.mk (s := H) φ⁻¹ = QuotientGroup.mk (s := H) ψ⁻¹ := by
-  letI := hreg.fiber_isPretransitive b
-  letI := fiber_isCancelSMul (b := b) hp
-  exact subgroupFiberOrbitClass_eq_iff_quotientGroup_mk_inv_eq H e φ ψ
 
 end Deck
 

--- a/TauCeti/AlgebraicTopology/UniversalCover/Deck/SubgroupFiberOrbitQuotientGroup.lean
+++ b/TauCeti/AlgebraicTopology/UniversalCover/Deck/SubgroupFiberOrbitQuotientGroup.lean
@@ -24,8 +24,8 @@ unfolding either construction.
 
 ## Main declarations
 
-* `TauCeti.Deck.subgroupFiberOrbitQuotientEquivQuotientGroup`: if the deck action on one
-  fibre is free and transitive, `SubgroupFiberOrbitQuotient H b ≃ Deck p ⧸ H`.
+* `MulAction.equivSubgroupOrbitsQuotientGroup`: applied to the deck action on one fibre, this
+  identifies `SubgroupFiberOrbitQuotient H b` with `Deck p ⧸ H`.
 * `TauCeti.Deck.regularSubgroupFiberOrbitQuotientEquivQuotientGroup`: the regular-cover
   specialization of this equivalence.
 * `TauCeti.Deck.subgroupFiberOrbitQuotientEquivQuotientGroup_mapOfLE`: compatibility with
@@ -59,19 +59,6 @@ private lemma mulAction_equivSubgroupOrbitsQuotientGroup_symm_mk
       (Quotient.mk'' (g⁻¹ • x) : MulAction.orbitRel.Quotient H X) :=
   rfl
 
-/-- If the deck action on a single fibre is free and transitive, quotienting that fibre by the
-action of `H ≤ Deck p` is equivalent to the coset quotient `Deck p ⧸ H`.
-
-The chosen point `e` fixes the identification between the deck group and the fibre. With
-Mathlib's convention for `MulAction.equivSubgroupOrbitsQuotientGroup`, the inverse sends the
-coset of `φ` to the orbit class of `φ⁻¹ • e`; see
-`subgroupFiberOrbitQuotientEquivQuotientGroup_symm_mk`. -/
-noncomputable def subgroupFiberOrbitQuotientEquivQuotientGroup
-    [MulAction.IsPretransitive (Deck p) (p ⁻¹' {b})] [IsCancelSMul (Deck p) (p ⁻¹' {b})]
-    (H : Subgroup (Deck p)) (e : p ⁻¹' {b}) :
-    SubgroupFiberOrbitQuotient H b ≃ Deck p ⧸ H :=
-  MulAction.equivSubgroupOrbitsQuotientGroup e H
-
 /-- For a regular preconnected covering, quotienting one fibre by the action of
 `H ≤ Deck p` is equivalent to the coset quotient `Deck p ⧸ H`. -/
 noncomputable def regularSubgroupFiberOrbitQuotientEquivQuotientGroup
@@ -80,7 +67,7 @@ noncomputable def regularSubgroupFiberOrbitQuotientEquivQuotientGroup
     SubgroupFiberOrbitQuotient H b ≃ Deck p ⧸ H := by
   letI := hreg.fiber_isPretransitive b
   letI := fiber_isCancelSMul (b := b) hp
-  exact subgroupFiberOrbitQuotientEquivQuotientGroup H e
+  exact MulAction.equivSubgroupOrbitsQuotientGroup e H
 
 /-- The inverse quotient equivalence sends the coset of a deck transformation `φ` to the
 `H`-orbit class of the point `φ⁻¹ • e`. -/
@@ -88,10 +75,10 @@ noncomputable def regularSubgroupFiberOrbitQuotientEquivQuotientGroup
 lemma subgroupFiberOrbitQuotientEquivQuotientGroup_symm_mk
     [MulAction.IsPretransitive (Deck p) (p ⁻¹' {b})] [IsCancelSMul (Deck p) (p ⁻¹' {b})]
     (H : Subgroup (Deck p)) (e : p ⁻¹' {b}) (φ : Deck p) :
-    (subgroupFiberOrbitQuotientEquivQuotientGroup H e).symm
+    (MulAction.equivSubgroupOrbitsQuotientGroup e H).symm
         (QuotientGroup.mk (s := H) φ) =
       subgroupFiberOrbitClass H (φ⁻¹ • e) := by
-  simpa [subgroupFiberOrbitQuotientEquivQuotientGroup, subgroupFiberOrbitClass_eq_mk] using
+  simpa [subgroupFiberOrbitClass_eq_mk] using
     mulAction_equivSubgroupOrbitsQuotientGroup_symm_mk H e φ
 
 /-- The regular-cover quotient equivalence sends the coset of a deck transformation `φ` back
@@ -113,7 +100,7 @@ class of the value of `φ⁻¹` on the chosen fibre point. -/
 lemma subgroupFiberOrbitQuotientEquivQuotientGroup_symm_mk_coe
     [MulAction.IsPretransitive (Deck p) (p ⁻¹' {b})] [IsCancelSMul (Deck p) (p ⁻¹' {b})]
     (H : Subgroup (Deck p)) (e : p ⁻¹' {b}) (φ : Deck p) :
-    (subgroupFiberOrbitQuotientEquivQuotientGroup H e).symm
+    (MulAction.equivSubgroupOrbitsQuotientGroup e H).symm
         (QuotientGroup.mk φ) =
       subgroupFiberOrbitClass H
         ⟨φ.1.symm e.1, by
@@ -145,7 +132,7 @@ fibre point. -/
 lemma subgroupFiberOrbitQuotientEquivQuotientGroup_symm_one
     [MulAction.IsPretransitive (Deck p) (p ⁻¹' {b})] [IsCancelSMul (Deck p) (p ⁻¹' {b})]
     (H : Subgroup (Deck p)) (e : p ⁻¹' {b}) :
-    (subgroupFiberOrbitQuotientEquivQuotientGroup H e).symm
+    (MulAction.equivSubgroupOrbitsQuotientGroup e H).symm
         (QuotientGroup.mk (s := H) (1 : Deck p)) =
       subgroupFiberOrbitClass H e := by
   rw [subgroupFiberOrbitQuotientEquivQuotientGroup_symm_mk, inv_one, one_smul]
@@ -168,11 +155,11 @@ lemma regularSubgroupFiberOrbitQuotientEquivQuotientGroup_symm_one
 lemma subgroupFiberOrbitQuotientEquivQuotientGroup_apply_inv_smul
     [MulAction.IsPretransitive (Deck p) (p ⁻¹' {b})] [IsCancelSMul (Deck p) (p ⁻¹' {b})]
     (H : Subgroup (Deck p)) (e : p ⁻¹' {b}) (φ : Deck p) :
-    subgroupFiberOrbitQuotientEquivQuotientGroup H e
+    MulAction.equivSubgroupOrbitsQuotientGroup e H
         (subgroupFiberOrbitClass H (φ⁻¹ • e)) =
       QuotientGroup.mk (s := H) φ := by
   rw [← subgroupFiberOrbitQuotientEquivQuotientGroup_symm_mk H e φ]
-  exact (subgroupFiberOrbitQuotientEquivQuotientGroup H e).apply_symm_apply
+  exact (MulAction.equivSubgroupOrbitsQuotientGroup e H).apply_symm_apply
     (QuotientGroup.mk (s := H) φ)
 
 /-- The regular-cover quotient equivalence sends the orbit class of `φ⁻¹ • e` to the coset
@@ -194,7 +181,7 @@ lemma regularSubgroupFiberOrbitQuotientEquivQuotientGroup_apply_inv_smul
 lemma subgroupFiberOrbitQuotientEquivQuotientGroup_apply_base
     [MulAction.IsPretransitive (Deck p) (p ⁻¹' {b})] [IsCancelSMul (Deck p) (p ⁻¹' {b})]
     (H : Subgroup (Deck p)) (e : p ⁻¹' {b}) :
-    subgroupFiberOrbitQuotientEquivQuotientGroup H e
+    MulAction.equivSubgroupOrbitsQuotientGroup e H
         (subgroupFiberOrbitClass H e) =
       QuotientGroup.mk (s := H) (1 : Deck p) := by
   simpa using
@@ -219,7 +206,7 @@ lemma regularSubgroupFiberOrbitQuotientEquivQuotientGroup_apply_base
 lemma subgroupFiberOrbitQuotientEquivQuotientGroup_apply_smul
     [MulAction.IsPretransitive (Deck p) (p ⁻¹' {b})] [IsCancelSMul (Deck p) (p ⁻¹' {b})]
     (H : Subgroup (Deck p)) (e : p ⁻¹' {b}) (φ : Deck p) :
-    subgroupFiberOrbitQuotientEquivQuotientGroup H e
+    MulAction.equivSubgroupOrbitsQuotientGroup e H
         (subgroupFiberOrbitClass H (φ • e)) =
       QuotientGroup.mk (s := H) φ⁻¹ := by
   simpa using
@@ -246,8 +233,8 @@ lemma subgroupFiberOrbitQuotientEquivQuotientGroup_mapOfLE
     {H K : Subgroup (Deck p)} (hHK : H ≤ K) (e : p ⁻¹' {b})
     (x : SubgroupFiberOrbitQuotient H b) :
     Subgroup.quotientMapOfLE hHK
-        (subgroupFiberOrbitQuotientEquivQuotientGroup H e x) =
-      subgroupFiberOrbitQuotientEquivQuotientGroup K e
+        (MulAction.equivSubgroupOrbitsQuotientGroup e H x) =
+      MulAction.equivSubgroupOrbitsQuotientGroup e K
         (subgroupFiberOrbitMapOfLE (b := b) hHK x) := by
   refine Quotient.inductionOn' x ?_
   intro e'
@@ -266,9 +253,9 @@ lemma subgroupFiberOrbitQuotientEquivQuotientGroup_mapOfLE_apply_smul
     [MulAction.IsPretransitive (Deck p) (p ⁻¹' {b})] [IsCancelSMul (Deck p) (p ⁻¹' {b})]
     {H K : Subgroup (Deck p)} (hHK : H ≤ K) (e : p ⁻¹' {b}) (φ : Deck p) :
     Subgroup.quotientMapOfLE hHK
-        (subgroupFiberOrbitQuotientEquivQuotientGroup H e
+        (MulAction.equivSubgroupOrbitsQuotientGroup e H
           (subgroupFiberOrbitClass H (φ • e))) =
-      subgroupFiberOrbitQuotientEquivQuotientGroup K e
+      MulAction.equivSubgroupOrbitsQuotientGroup e K
         (subgroupFiberOrbitMapOfLE (b := b) hHK
           (subgroupFiberOrbitClass H (φ • e))) := by
   rw [subgroupFiberOrbitQuotientEquivQuotientGroup_mapOfLE]
@@ -312,12 +299,12 @@ lemma subgroupFiberOrbitClass_eq_iff_quotientGroup_mk_inv_eq
   constructor
   · intro h
     have h' := congrArg
-      (subgroupFiberOrbitQuotientEquivQuotientGroup H e) h
+      (MulAction.equivSubgroupOrbitsQuotientGroup e H) h
     rw [subgroupFiberOrbitQuotientEquivQuotientGroup_apply_smul,
       subgroupFiberOrbitQuotientEquivQuotientGroup_apply_smul] at h'
     exact h'
   · intro h
-    apply (subgroupFiberOrbitQuotientEquivQuotientGroup H e).injective
+    apply (MulAction.equivSubgroupOrbitsQuotientGroup e H).injective
     rw [subgroupFiberOrbitQuotientEquivQuotientGroup_apply_smul,
       subgroupFiberOrbitQuotientEquivQuotientGroup_apply_smul]
     exact h


### PR DESCRIPTION
This PR identifies subgroup fibre-orbit quotients of a regular preconnected covering with deck-group coset quotients. It adds the deck-specific equivalence `SubgroupFiberOrbitQuotient H b ≃ Deck p ⧸ H`, together with representative lemmas saying that the inverse sends the coset of `φ` to the `H`-orbit class of `φ⁻¹ • e` and that the forward map sends `φ • e` to the coset of `φ⁻¹`.

It advances `TauCetiRoadmap/UniversalCovers/README.md`, Stage 2, items 7 and 8, specifically the subgroup-cover and regular-cover bookkeeping where covers attached to `H ≤ π₁(X, x₀)` are compared through fibre quotients and the deck group is later computed as `N(H)/H`. I chose this as the lowest-hanging distinct UniversalCovers prerequisite after checking open and recently merged PRs: #455 covers fundamental-group subgroup basepoint change, while recent merged work covers subgroup fibre-orbit quotients, stabilizers, torsors, normalizer quotients, and the circle fundamental group. The missing small bridge was the quotient-level identification between the already-defined subgroup fibre-orbit quotient and the deck-group coset quotient under the regular connected-cover hypotheses.

No Mathlib infrastructure is vendored. The implementation reuses Mathlib's `MulAction.equivSubgroupOrbitsQuotientGroup`, the orbit-quotient form of orbit-stabilizer for free transitive actions, plus Tau Ceti's existing `Deck.fiber_isCancelSMul`, `Deck.IsRegular.fiber_isPretransitive`, and `SubgroupFiberOrbitQuotient` API.

`lake exe cache get` completed with `No files to download` and `Already decompressed 8586 file(s)`. `lake build` completed with `Build completed successfully (4261 jobs).` `lake exe axioms` completed with `axioms: audited 5349 TauCeti declaration(s); all within the allowlist [propext, Classical.choice, Quot.sound].`

<!--tauceti-target:v1 {"focus":"UniversalCovers","id":"regular-deck-subgroup-fiber-orbits-quotient-group"}-->

🤖 Prepared with Codex
