### PR TITLE
feat: add exchangeability pushforward closure

### DIFF
--- a/TauCeti/Probability/Exchangeability/Basic.lean
+++ b/TauCeti/Probability/Exchangeability/Basic.lean
@@ -146,6 +146,19 @@ theorem map_prefixLaw (μ : Measure Ω) {X : ℕ → Ω → α}
       prefixLaw μ (fun n ω => f (X n ω)) n :=
   map_blockLaw μ (fun i : Fin n => i.val) hf hX
 
+/-- A coordinatewise measurable map sends path laws to path laws. -/
+theorem map_pathLaw (μ : Measure Ω) {X : ℕ → Ω → α}
+    {f : α → β} [MeasurableSpace β] (hf : Measurable f)
+    (hX : ∀ i, AEMeasurable (X i) μ) :
+    (pathLaw μ X).map (fun x : ℕ → α => fun i => f (x i)) =
+      pathLaw μ (fun n ω => f (X n ω)) := by
+  rw [pathLaw_apply, pathLaw_apply]
+  rw [AEMeasurable.map_map_of_aemeasurable]
+  · rfl
+  · exact (measurable_pi_lambda (fun x : ℕ → α => fun i => f (x i)) fun i =>
+      hf.comp (measurable_pi_apply i)).aemeasurable
+  · exact aemeasurable_pi_lambda (fun ω => fun i => X i ω) hX
+
 theorem Exchangeable.exchangeableAt {μ : Measure Ω} {X : ℕ → Ω → α}
     (h : Exchangeable μ X) (n : ℕ) : ExchangeableAt μ X n :=
   h n

--- a/TauCeti/Probability/Exchangeability/Map.lean
+++ b/TauCeti/Probability/Exchangeability/Map.lean
@@ -1,0 +1,101 @@
+module
+
+public import TauCeti.Probability.Exchangeability.Contractability
+
+/-!
+# Coordinatewise maps of exchangeable processes
+
+This file records that the Layer 0 symmetry notions for sequence laws are preserved by
+applying a measurable map to every coordinate of the process. It supplies the process-level
+closure API promised by the Exchangeability roadmap from the law-level lemmas
+`map_blockLaw` and `map_prefixLaw` in `Basic.lean`.
+
+These statements follow `TauCetiRoadmap/Exchangeability/README.md`, Layer 0, the item
+asking for closure of the symmetry classes under coordinatewise pushforward. The proofs use
+only Tau Ceti's existing finite-dimensional law API and Mathlib's `Measure.map`
+composition lemmas.
+-/
+
+public section
+
+noncomputable section
+
+open MeasureTheory
+
+namespace TauCeti
+
+namespace Probability
+
+variable {Ω α β : Type*} [MeasurableSpace Ω] [MeasurableSpace α] [MeasurableSpace β]
+
+/-- A coordinatewise measurable map sends path laws to path laws. -/
+theorem map_pathLaw (μ : Measure Ω) {X : ℕ → Ω → α} {f : α → β} (hf : Measurable f)
+    (hX : ∀ i, AEMeasurable (X i) μ) :
+    (pathLaw μ X).map (fun x : ℕ → α => fun i => f (x i)) =
+      pathLaw μ (fun n ω => f (X n ω)) := by
+  rw [pathLaw_apply, pathLaw_apply]
+  rw [AEMeasurable.map_map_of_aemeasurable]
+  · rfl
+  · exact (measurable_pi_lambda (fun x : ℕ → α => fun i => f (x i)) fun i =>
+      hf.comp (measurable_pi_apply i)).aemeasurable
+  · exact aemeasurable_pi_lambda (fun ω => fun i => X i ω) hX
+
+/-- Finite exchangeability at a fixed length is preserved by a coordinatewise measurable
+map of the value space. -/
+theorem ExchangeableAt.map_values {μ : Measure Ω} {X : ℕ → Ω → α} {n : ℕ}
+    (h : ExchangeableAt μ X n) {f : α → β} (hf : Measurable f)
+    (hX : ∀ i : Fin n, AEMeasurable (X i.val) μ) :
+    ExchangeableAt μ (fun n ω => f (X n ω)) n := by
+  intro σ
+  calc
+    blockLaw μ (fun n ω => f (X n ω)) (fun i : Fin n => (σ i).val) =
+        (blockLaw μ X (fun i : Fin n => (σ i).val)).map
+          (fun x : Fin n → α => fun i => f (x i)) := by
+      exact (map_blockLaw μ (fun i : Fin n => (σ i).val) hf (fun i => hX (σ i))).symm
+    _ = (prefixLaw μ X n).map (fun x : Fin n → α => fun i => f (x i)) := by
+      rw [h.permute σ]
+    _ = prefixLaw μ (fun n ω => f (X n ω)) n := by
+      exact map_prefixLaw μ hf n hX
+
+/-- Finite exchangeability is preserved by a coordinatewise measurable map of the value
+space. -/
+theorem Exchangeable.map_values {μ : Measure Ω} {X : ℕ → Ω → α} (h : Exchangeable μ X)
+    {f : α → β} (hf : Measurable f) (hX : ∀ i, AEMeasurable (X i) μ) :
+    Exchangeable μ (fun n ω => f (X n ω)) := by
+  intro n
+  exact (h.exchangeableAt n).map_values hf (fun i => hX i.val)
+
+/-- Full exchangeability is preserved by a coordinatewise measurable map of the value
+space. -/
+theorem FullyExchangeable.map_values {μ : Measure Ω} {X : ℕ → Ω → α}
+    (h : FullyExchangeable μ X) {f : α → β} (hf : Measurable f)
+    (hX : ∀ i, AEMeasurable (X i) μ) :
+    FullyExchangeable μ (fun n ω => f (X n ω)) := by
+  intro π
+  calc
+    μ.map (fun ω i => f (X (π i) ω)) =
+        (pathLaw μ (fun n ω => X (π n) ω)).map
+          (fun x : ℕ → α => fun i => f (x i)) := by
+      exact (map_pathLaw μ hf (fun i => hX (π i))).symm
+    _ = (pathLaw μ X).map (fun x : ℕ → α => fun i => f (x i)) := by
+      rw [pathLaw_apply, h.permute π]
+    _ = pathLaw μ (fun n ω => f (X n ω)) := by
+      exact map_pathLaw μ hf hX
+
+/-- Contractability is preserved by a coordinatewise measurable map of the value space. -/
+theorem Contractable.map_values {μ : Measure Ω} {X : ℕ → Ω → α} (h : Contractable μ X)
+    {f : α → β} (hf : Measurable f) (hX : ∀ i, AEMeasurable (X i) μ) :
+    Contractable μ (fun n ω => f (X n ω)) := by
+  intro m k hk
+  calc
+    blockLaw μ (fun n ω => f (X n ω)) k =
+        (blockLaw μ X k).map (fun x : Fin m → α => fun i => f (x i)) := by
+      exact (map_blockLaw μ k hf (fun i => hX (k i))).symm
+    _ = (prefixLaw μ X m).map (fun x : Fin m → α => fun i => f (x i)) := by
+      rw [h.map hk]
+    _ = prefixLaw μ (fun n ω => f (X n ω)) m := by
+      exact map_prefixLaw μ hf m (fun i => hX i.val)
+
+end Probability
+
+end TauCeti

--- a/TauCeti/Probability/Exchangeability/Map.lean
+++ b/TauCeti/Probability/Exchangeability/Map.lean
@@ -8,7 +8,7 @@ public import TauCeti.Probability.Exchangeability.Contractability
 This file records that the Layer 0 symmetry notions for sequence laws are preserved by
 applying a measurable map to every coordinate of the process. It supplies the process-level
 closure API promised by the Exchangeability roadmap from the law-level lemmas
-`map_blockLaw` and `map_prefixLaw` in `Basic.lean`.
+`map_blockLaw`, `map_prefixLaw`, and `map_pathLaw` in `Basic.lean`.
 
 These statements follow `TauCetiRoadmap/Exchangeability/README.md`, Layer 0, the item
 asking for closure of the symmetry classes under coordinatewise pushforward. The proofs use
@@ -27,18 +27,6 @@ namespace TauCeti
 namespace Probability
 
 variable {Ω α β : Type*} [MeasurableSpace Ω] [MeasurableSpace α] [MeasurableSpace β]
-
-/-- A coordinatewise measurable map sends path laws to path laws. -/
-theorem map_pathLaw (μ : Measure Ω) {X : ℕ → Ω → α} {f : α → β} (hf : Measurable f)
-    (hX : ∀ i, AEMeasurable (X i) μ) :
-    (pathLaw μ X).map (fun x : ℕ → α => fun i => f (x i)) =
-      pathLaw μ (fun n ω => f (X n ω)) := by
-  rw [pathLaw_apply, pathLaw_apply]
-  rw [AEMeasurable.map_map_of_aemeasurable]
-  · rfl
-  · exact (measurable_pi_lambda (fun x : ℕ → α => fun i => f (x i)) fun i =>
-      hf.comp (measurable_pi_apply i)).aemeasurable
-  · exact aemeasurable_pi_lambda (fun ω => fun i => X i ω) hX
 
 /-- Finite exchangeability at a fixed length is preserved by a coordinatewise measurable
 map of the value space. -/


### PR DESCRIPTION
This PR adds process-level coordinatewise measurable pushforward closure for the Layer 0 exchangeability symmetry notions: finite exchangeability at a fixed length, finite exchangeability at every length, full exchangeability, and contractability. It also records the path-law pushforward lemma needed by the full-exchangeability case.

It advances `TauCetiRoadmap/Exchangeability/README.md`, Layer 0, the implication-lattice/API item asking for “closure of each symmetry class under coordinatewise pushforward `X ↦ (f ∘ Xᵢ)`.” I chose this as the lowest-hanging distinct Exchangeability target after checking open and recently merged PRs: #451 added the basic definitions and law-level map lemmas, #456 added the conditional-i.i.d. directing-measure API, and open #459 covers `Exchangeable → Contractable`, while the process-level coordinatewise pushforward closure for the already-defined symmetry notions was still absent. This PR intentionally does not add the conditional-i.i.d. pushforward case, since that needs a separate probability-measure pushforward measurability adapter for random directing measures.

No Mathlib infrastructure is vendored. The implementation reuses Tau Ceti's existing `map_blockLaw`, `map_prefixLaw`, `Contractable.map`, and `FullyExchangeable.permute`, plus Mathlib's `AEMeasurable.map_map_of_aemeasurable` and product-function measurability API.

`lake exe cache get` completed with `No files to download` and `Already decompressed 8586 file(s)`. `lake build` completed with `Build completed successfully (4263 jobs).` `lake exe axioms` completed with `axioms: audited 5392 TauCeti declaration(s); all within the allowlist [propext, Classical.choice, Quot.sound].`

<!--tauceti-target:v1 {"focus":"Exchangeability","id":"coordinatewise-pushforward-symmetry"}-->

🤖 Prepared with Codex
