### PR TITLE
feat: add smooth embedding ambient isotopy classes

### DIFF
--- a/TauCeti/Geometry/Manifold/SmoothEmbedding/AmbientIsotopyClass.lean
+++ b/TauCeti/Geometry/Manifold/SmoothEmbedding/AmbientIsotopyClass.lean
@@ -4,7 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 -/
 module
 
-public import TauCeti.Geometry.Manifold.SmoothEmbedding.AmbientIsotopyProd
+public import TauCeti.Geometry.Manifold.SmoothEmbedding.AmbientIsotopy
 
 /-!
 # Ambient-isotopy classes of smooth embeddings
@@ -12,7 +12,7 @@ public import TauCeti.Geometry.Manifold.SmoothEmbedding.AmbientIsotopyProd
 The geometric-topology roadmap asks for equivalence in each knot presentation, with the
 geometric presentation given by smooth embeddings and equivalence given by ambient isotopy. The
 previous files define ambient isotopy of bundled smooth embeddings and package it as a `Setoid`;
-this file adds the quotient type and its first functorial operation.
+this file adds the quotient type and its core functorial operations.
 
 This remains at the general manifold level. A geometric knot type such as smooth embeddings
 `S¹ ↪ S³` is a later specialization of `SmoothEmbedding`, and its ambient-isotopy classes are
@@ -26,8 +26,6 @@ instances of the quotient defined here.
   from embeddings to ambient-isotopy classes.
 * `TauCeti.SmoothEmbedding.AmbientIsotopyClass.map`: descend a relation-preserving operation
   between smooth-embedding types to their quotients.
-* `TauCeti.SmoothEmbedding.AmbientIsotopyClass.prodMap`: products of embeddings descend to
-  products of ambient-isotopy classes.
 
 The relation being quotiented follows Burde--Zieschang, *Knots*, Chapter 1, Definitions 1.1 and
 1.2, via `TauCeti.Topology.Homotopy.AmbientIsotopic`.
@@ -54,7 +52,7 @@ variable {𝕜 : Type*} [NontriviallyNormedField 𝕜]
   {N : Type*} [TopologicalSpace N] [ChartedSpace H' N]
   {M' : Type*} [TopologicalSpace M'] [ChartedSpace G M']
   {N' : Type*} [TopologicalSpace N'] [ChartedSpace G' N']
-  {n : ℕ∞ω}
+  {n n' : ℕ∞ω}
 
 /-- Ambient-isotopy classes of bundled smooth embeddings.
 
@@ -71,16 +69,15 @@ namespace AmbientIsotopyClass
 variable {f g : SmoothEmbedding I J n M N}
 
 /-- The ambient-isotopy class of a bundled smooth embedding. -/
-def mk (f : SmoothEmbedding I J n M N) : AmbientIsotopyClass I J n M N :=
+abbrev mk (f : SmoothEmbedding I J n M N) : AmbientIsotopyClass I J n M N :=
   Quotient.mk (AmbientIsotopic.setoid I J n M N) f
 
+/-- Equality of two quotient representatives is equivalent to ambient isotopy of the bundled
+smooth embeddings. -/
 @[simp]
 theorem mk_eq_mk_iff :
     mk f = mk g ↔ SmoothEmbedding.AmbientIsotopic f g := by
-  change Quotient.mk (AmbientIsotopic.setoid I J n M N) f =
-      Quotient.mk (AmbientIsotopic.setoid I J n M N) g ↔
-    SmoothEmbedding.AmbientIsotopic f g
-  rw [Quotient.eq]
+  rw [mk, mk, Quotient.eq]
   exact AmbientIsotopic.setoid_r_iff
 
 /-- Ambient-isotopic bundled smooth embeddings determine the same ambient-isotopy class. -/
@@ -102,6 +99,7 @@ def lift {β : Sort*} (F : SmoothEmbedding I J n M N → β)
   Quotient.lift F fun f g hfg =>
     hF (f := f) (g := g) (AmbientIsotopic.setoid_r_iff.1 hfg)
 
+/-- Computation rule for `AmbientIsotopyClass.lift` on representatives. -/
 @[simp]
 theorem lift_mk {β : Sort*} (F : SmoothEmbedding I J n M N → β)
     (hF : ∀ ⦃f g : SmoothEmbedding I J n M N⦄,
@@ -112,16 +110,17 @@ theorem lift_mk {β : Sort*} (F : SmoothEmbedding I J n M N → β)
 
 /-- Descend an ambient-isotopy-preserving map between bundled smooth-embedding types to their
 ambient-isotopy quotients. -/
-def map (F : SmoothEmbedding I J n M N → SmoothEmbedding I' J' n M' N')
+def map (F : SmoothEmbedding I J n M N → SmoothEmbedding I' J' n' M' N')
     (hF : ∀ ⦃f g : SmoothEmbedding I J n M N⦄,
       SmoothEmbedding.AmbientIsotopic f g → SmoothEmbedding.AmbientIsotopic (F f) (F g)) :
-    AmbientIsotopyClass I J n M N → AmbientIsotopyClass I' J' n M' N' :=
+    AmbientIsotopyClass I J n M N → AmbientIsotopyClass I' J' n' M' N' :=
   Quotient.map F fun {f g} hfg =>
     AmbientIsotopic.setoid_r_iff.2
       (hF (f := f) (g := g) (AmbientIsotopic.setoid_r_iff.1 hfg))
 
+/-- Computation rule for `AmbientIsotopyClass.map` on representatives. -/
 @[simp]
-theorem map_mk (F : SmoothEmbedding I J n M N → SmoothEmbedding I' J' n M' N')
+theorem map_mk (F : SmoothEmbedding I J n M N → SmoothEmbedding I' J' n' M' N')
     (hF : ∀ ⦃f g : SmoothEmbedding I J n M N⦄,
       SmoothEmbedding.AmbientIsotopic f g → SmoothEmbedding.AmbientIsotopic (F f) (F g))
     (f : SmoothEmbedding I J n M N) :
@@ -129,53 +128,6 @@ theorem map_mk (F : SmoothEmbedding I J n M N → SmoothEmbedding I' J' n M' N')
   Quotient.map_mk F (fun {f g} hfg =>
     AmbientIsotopic.setoid_r_iff.2
       (hF (f := f) (g := g) (AmbientIsotopic.setoid_r_iff.1 hfg))) f
-
-variable {E₁ : Type*} [NormedAddCommGroup E₁] [NormedSpace 𝕜 E₁]
-  {E₂ : Type*} [NormedAddCommGroup E₂] [NormedSpace 𝕜 E₂]
-  {F₁ : Type*} [NormedAddCommGroup F₁] [NormedSpace 𝕜 F₁]
-  {F₂ : Type*} [NormedAddCommGroup F₂] [NormedSpace 𝕜 F₂]
-  {H₁ : Type*} [TopologicalSpace H₁] {H₂ : Type*} [TopologicalSpace H₂]
-  {G₁ : Type*} [TopologicalSpace G₁] {G₂ : Type*} [TopologicalSpace G₂]
-  {I₁ : ModelWithCorners 𝕜 E₁ H₁} {I₂ : ModelWithCorners 𝕜 E₂ H₂}
-  {J₁ : ModelWithCorners 𝕜 F₁ G₁} {J₂ : ModelWithCorners 𝕜 F₂ G₂}
-  {M₁ : Type*} [TopologicalSpace M₁] [ChartedSpace H₁ M₁]
-  {M₂ : Type*} [TopologicalSpace M₂] [ChartedSpace H₂ M₂]
-  {N₁ : Type*} [TopologicalSpace N₁] [ChartedSpace G₁ N₁]
-  {N₂ : Type*} [TopologicalSpace N₂] [ChartedSpace G₂ N₂]
-
-/-- The product of ambient-isotopy classes of bundled smooth embeddings.
-
-This is the quotient-level operation induced by `SmoothEmbedding.prodMap`, using product closure
-of ambient isotopy of bundled smooth embeddings. -/
-def prodMap [IsManifold I₁ n M₁] [IsManifold I₂ n M₂]
-    [IsManifold J₁ n N₁] [IsManifold J₂ n N₂] :
-    AmbientIsotopyClass I₁ J₁ n M₁ N₁ →
-      AmbientIsotopyClass I₂ J₂ n M₂ N₂ →
-        AmbientIsotopyClass (I₁.prod I₂) (J₁.prod J₂) n (M₁ × M₂) (N₁ × N₂) :=
-  Quotient.map₂ (fun f g => f.prodMap g) fun {f f'} hff' {g g'} hgg' =>
-    AmbientIsotopic.prodMap_setoid (f := f) (f' := f') (g := g) (g' := g') hff' hgg'
-
-@[simp]
-theorem prodMap_mk_mk [IsManifold I₁ n M₁] [IsManifold I₂ n M₂]
-    [IsManifold J₁ n N₁] [IsManifold J₂ n N₂]
-    (f : SmoothEmbedding I₁ J₁ n M₁ N₁) (g : SmoothEmbedding I₂ J₂ n M₂ N₂) :
-    prodMap (mk f) (mk g) = mk (f.prodMap g) := by
-  change
-    Quotient.map₂
-        (fun (f : SmoothEmbedding I₁ J₁ n M₁ N₁) (g : SmoothEmbedding I₂ J₂ n M₂ N₂) =>
-          f.prodMap g)
-        (fun {f f'} hff' {g g'} hgg' =>
-          AmbientIsotopic.prodMap_setoid (f := f) (f' := f') (g := g) (g' := g') hff' hgg')
-        (Quotient.mk (AmbientIsotopic.setoid I₁ J₁ n M₁ N₁) f)
-        (Quotient.mk (AmbientIsotopic.setoid I₂ J₂ n M₂ N₂) g) =
-      Quotient.mk
-        (AmbientIsotopic.setoid (I₁.prod I₂) (J₁.prod J₂) n (M₁ × M₂) (N₁ × N₂))
-        (f.prodMap g)
-  exact Quotient.map₂_mk
-    (fun (f : SmoothEmbedding I₁ J₁ n M₁ N₁) (g : SmoothEmbedding I₂ J₂ n M₂ N₂) =>
-      f.prodMap g)
-    (fun {f f'} hff' {g g'} hgg' =>
-      AmbientIsotopic.prodMap_setoid (f := f) (f' := f') (g := g) (g' := g') hff' hgg') f g
 
 end AmbientIsotopyClass
 

--- a/TauCeti/Geometry/Manifold/SmoothEmbedding/AmbientIsotopyClass.lean
+++ b/TauCeti/Geometry/Manifold/SmoothEmbedding/AmbientIsotopyClass.lean
@@ -22,10 +22,15 @@ instances of the quotient defined here.
 
 * `TauCeti.SmoothEmbedding.AmbientIsotopyClass`: bundled smooth embeddings modulo ambient
   isotopy.
+* `TauCeti.SmoothEmbedding.AmbientIsotopyClass.induction_on`: prove facts about classes by
+  checking representatives.
 * `TauCeti.SmoothEmbedding.AmbientIsotopyClass.lift`: descend a relation-invariant function
   from embeddings to ambient-isotopy classes.
 * `TauCeti.SmoothEmbedding.AmbientIsotopyClass.map`: descend a relation-preserving operation
   between smooth-embedding types to their quotients.
+* `TauCeti.SmoothEmbedding.AmbientIsotopyClass.lift₂` and
+  `TauCeti.SmoothEmbedding.AmbientIsotopyClass.map₂`: descend binary invariant or
+  relation-preserving operations.
 
 The relation being quotiented follows Burde--Zieschang, *Knots*, Chapter 1, Definitions 1.1 and
 1.2, via `TauCeti.Topology.Homotopy.AmbientIsotopic`.
@@ -42,17 +47,24 @@ namespace SmoothEmbedding
 variable {𝕜 : Type*} [NontriviallyNormedField 𝕜]
   {E : Type*} [NormedAddCommGroup E] [NormedSpace 𝕜 E]
   {E' : Type*} [NormedAddCommGroup E'] [NormedSpace 𝕜 E']
+  {E'' : Type*} [NormedAddCommGroup E''] [NormedSpace 𝕜 E'']
   {F : Type*} [NormedAddCommGroup F] [NormedSpace 𝕜 F]
   {F' : Type*} [NormedAddCommGroup F'] [NormedSpace 𝕜 F']
+  {F'' : Type*} [NormedAddCommGroup F''] [NormedSpace 𝕜 F'']
   {H : Type*} [TopologicalSpace H] {H' : Type*} [TopologicalSpace H']
+  {H'' : Type*} [TopologicalSpace H'']
   {G : Type*} [TopologicalSpace G] {G' : Type*} [TopologicalSpace G']
+  {G'' : Type*} [TopologicalSpace G'']
   {I : ModelWithCorners 𝕜 E H} {J : ModelWithCorners 𝕜 E' H'}
+  {I'' : ModelWithCorners 𝕜 E'' H''} {J'' : ModelWithCorners 𝕜 F'' G''}
   {I' : ModelWithCorners 𝕜 F G} {J' : ModelWithCorners 𝕜 F' G'}
   {M : Type*} [TopologicalSpace M] [ChartedSpace H M]
   {N : Type*} [TopologicalSpace N] [ChartedSpace H' N]
+  {M'' : Type*} [TopologicalSpace M''] [ChartedSpace H'' M'']
+  {N'' : Type*} [TopologicalSpace N''] [ChartedSpace G'' N'']
   {M' : Type*} [TopologicalSpace M'] [ChartedSpace G M']
   {N' : Type*} [TopologicalSpace N'] [ChartedSpace G' N']
-  {n n' : ℕ∞ω}
+  {n n' n'' : ℕ∞ω}
 
 /-- Ambient-isotopy classes of bundled smooth embeddings.
 
@@ -89,6 +101,18 @@ theorem ambientIsotopic_of_mk_eq (hfg : mk f = mk g) :
     SmoothEmbedding.AmbientIsotopic f g :=
   mk_eq_mk_iff.1 hfg
 
+/-- Prove a proposition about ambient-isotopy classes by checking representatives. -/
+@[elab_as_elim]
+theorem induction_on {motive : AmbientIsotopyClass I J n M N → Prop}
+    (x : AmbientIsotopyClass I J n M N)
+    (h : ∀ f : SmoothEmbedding I J n M N, motive (mk f)) : motive x :=
+  Quotient.inductionOn x h
+
+/-- Two functions out of ambient-isotopy classes are equal if they agree on representatives. -/
+theorem funext {β : Sort*} {F G : AmbientIsotopyClass I J n M N → β}
+    (h : ∀ f : SmoothEmbedding I J n M N, F (mk f) = G (mk f)) : F = G :=
+  _root_.funext fun x => induction_on x h
+
 /-- Descend a function on bundled smooth embeddings to ambient-isotopy classes.
 
 The hypothesis says exactly that the function is invariant under ambient isotopy. -/
@@ -107,6 +131,16 @@ theorem lift_mk {β : Sort*} (F : SmoothEmbedding I J n M N → β)
     lift F hF (mk f) = F f :=
   Quotient.lift_mk F (fun f g hfg =>
     hF (f := f) (g := g) (AmbientIsotopic.setoid_r_iff.1 hfg)) f
+
+/-- A function on ambient-isotopy classes agreeing with a descended function on representatives is
+equal to that descended function. -/
+theorem lift_unique {β : Sort*} (F : SmoothEmbedding I J n M N → β)
+    (hF : ∀ ⦃f g : SmoothEmbedding I J n M N⦄,
+      SmoothEmbedding.AmbientIsotopic f g → F f = F g)
+    (G : AmbientIsotopyClass I J n M N → β)
+    (hG : ∀ f : SmoothEmbedding I J n M N, G (mk f) = F f) :
+    G = lift F hF :=
+  funext fun f => by simp [hG f]
 
 /-- Descend an ambient-isotopy-preserving map between bundled smooth-embedding types to their
 ambient-isotopy quotients. -/
@@ -128,6 +162,68 @@ theorem map_mk (F : SmoothEmbedding I J n M N → SmoothEmbedding I' J' n' M' N'
   Quotient.map_mk F (fun {f g} hfg =>
     AmbientIsotopic.setoid_r_iff.2
       (hF (f := f) (g := g) (AmbientIsotopic.setoid_r_iff.1 hfg))) f
+
+/-- Descend a binary function on bundled smooth embeddings to ambient-isotopy classes.
+
+The hypothesis says that the function is invariant under ambient isotopy in both variables. -/
+def lift₂ {β : Sort*}
+    (F : SmoothEmbedding I J n M N → SmoothEmbedding I' J' n' M' N' → β)
+    (hF : ∀ ⦃f f' : SmoothEmbedding I J n M N⦄,
+      SmoothEmbedding.AmbientIsotopic f f' →
+        ∀ ⦃g g' : SmoothEmbedding I' J' n' M' N'⦄,
+          SmoothEmbedding.AmbientIsotopic g g' → F f g = F f' g') :
+    AmbientIsotopyClass I J n M N → AmbientIsotopyClass I' J' n' M' N' → β :=
+  Quotient.lift₂ F fun f g f' g' hff' hgg' =>
+    hF (f := f) (f' := f') (AmbientIsotopic.setoid_r_iff.1 hff')
+      (g := g) (g' := g') (AmbientIsotopic.setoid_r_iff.1 hgg')
+
+/-- Computation rule for `AmbientIsotopyClass.lift₂` on representatives. -/
+@[simp]
+theorem lift₂_mk_mk {β : Sort*}
+    (F : SmoothEmbedding I J n M N → SmoothEmbedding I' J' n' M' N' → β)
+    (hF : ∀ ⦃f f' : SmoothEmbedding I J n M N⦄,
+      SmoothEmbedding.AmbientIsotopic f f' →
+        ∀ ⦃g g' : SmoothEmbedding I' J' n' M' N'⦄,
+          SmoothEmbedding.AmbientIsotopic g g' → F f g = F f' g')
+    (f : SmoothEmbedding I J n M N) (g : SmoothEmbedding I' J' n' M' N') :
+    lift₂ F hF (mk f) (mk g) = F f g :=
+  Quotient.lift₂_mk F (fun f g f' g' hff' hgg' =>
+    hF (f := f) (f' := f') (AmbientIsotopic.setoid_r_iff.1 hff')
+      (g := g) (g' := g') (AmbientIsotopic.setoid_r_iff.1 hgg')) f g
+
+/-- Descend a binary ambient-isotopy-preserving operation between bundled smooth-embedding types to
+their ambient-isotopy quotients. -/
+def map₂
+    (F : SmoothEmbedding I J n M N → SmoothEmbedding I' J' n' M' N' →
+      SmoothEmbedding I'' J'' n'' M'' N'')
+    (hF : ∀ ⦃f f' : SmoothEmbedding I J n M N⦄,
+      SmoothEmbedding.AmbientIsotopic f f' →
+        ∀ ⦃g g' : SmoothEmbedding I' J' n' M' N'⦄,
+          SmoothEmbedding.AmbientIsotopic g g' →
+            SmoothEmbedding.AmbientIsotopic (F f g) (F f' g')) :
+    AmbientIsotopyClass I J n M N → AmbientIsotopyClass I' J' n' M' N' →
+      AmbientIsotopyClass I'' J'' n'' M'' N'' :=
+  Quotient.map₂ F fun {f f'} hff' {g g'} hgg' =>
+    AmbientIsotopic.setoid_r_iff.2
+      (hF (f := f) (f' := f') (AmbientIsotopic.setoid_r_iff.1 hff')
+        (g := g) (g' := g') (AmbientIsotopic.setoid_r_iff.1 hgg'))
+
+/-- Computation rule for `AmbientIsotopyClass.map₂` on representatives. -/
+@[simp]
+theorem map₂_mk_mk
+    (F : SmoothEmbedding I J n M N → SmoothEmbedding I' J' n' M' N' →
+      SmoothEmbedding I'' J'' n'' M'' N'')
+    (hF : ∀ ⦃f f' : SmoothEmbedding I J n M N⦄,
+      SmoothEmbedding.AmbientIsotopic f f' →
+        ∀ ⦃g g' : SmoothEmbedding I' J' n' M' N'⦄,
+          SmoothEmbedding.AmbientIsotopic g g' →
+            SmoothEmbedding.AmbientIsotopic (F f g) (F f' g'))
+    (f : SmoothEmbedding I J n M N) (g : SmoothEmbedding I' J' n' M' N') :
+    map₂ F hF (mk f) (mk g) = mk (F f g) :=
+  Quotient.map₂_mk F (fun {f f'} hff' {g g'} hgg' =>
+    AmbientIsotopic.setoid_r_iff.2
+      (hF (f := f) (f' := f') (AmbientIsotopic.setoid_r_iff.1 hff')
+        (g := g) (g' := g') (AmbientIsotopic.setoid_r_iff.1 hgg'))) f g
 
 end AmbientIsotopyClass
 

--- a/TauCeti/Geometry/Manifold/SmoothEmbedding/AmbientIsotopyClass.lean
+++ b/TauCeti/Geometry/Manifold/SmoothEmbedding/AmbientIsotopyClass.lean
@@ -1,0 +1,184 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+module
+
+public import TauCeti.Geometry.Manifold.SmoothEmbedding.AmbientIsotopyProd
+
+/-!
+# Ambient-isotopy classes of smooth embeddings
+
+The geometric-topology roadmap asks for equivalence in each knot presentation, with the
+geometric presentation given by smooth embeddings and equivalence given by ambient isotopy. The
+previous files define ambient isotopy of bundled smooth embeddings and package it as a `Setoid`;
+this file adds the quotient type and its first functorial operation.
+
+This remains at the general manifold level. A geometric knot type such as smooth embeddings
+`S¹ ↪ S³` is a later specialization of `SmoothEmbedding`, and its ambient-isotopy classes are
+instances of the quotient defined here.
+
+## Main definitions
+
+* `TauCeti.SmoothEmbedding.AmbientIsotopyClass`: bundled smooth embeddings modulo ambient
+  isotopy.
+* `TauCeti.SmoothEmbedding.AmbientIsotopyClass.lift`: descend a relation-invariant function
+  from embeddings to ambient-isotopy classes.
+* `TauCeti.SmoothEmbedding.AmbientIsotopyClass.map`: descend a relation-preserving operation
+  between smooth-embedding types to their quotients.
+* `TauCeti.SmoothEmbedding.AmbientIsotopyClass.prodMap`: products of embeddings descend to
+  products of ambient-isotopy classes.
+
+The relation being quotiented follows Burde--Zieschang, *Knots*, Chapter 1, Definitions 1.1 and
+1.2, via `TauCeti.Topology.Homotopy.AmbientIsotopic`.
+-/
+
+public section
+
+namespace TauCeti
+
+open scoped Manifold ContDiff
+
+namespace SmoothEmbedding
+
+variable {𝕜 : Type*} [NontriviallyNormedField 𝕜]
+  {E : Type*} [NormedAddCommGroup E] [NormedSpace 𝕜 E]
+  {E' : Type*} [NormedAddCommGroup E'] [NormedSpace 𝕜 E']
+  {F : Type*} [NormedAddCommGroup F] [NormedSpace 𝕜 F]
+  {F' : Type*} [NormedAddCommGroup F'] [NormedSpace 𝕜 F']
+  {H : Type*} [TopologicalSpace H] {H' : Type*} [TopologicalSpace H']
+  {G : Type*} [TopologicalSpace G] {G' : Type*} [TopologicalSpace G']
+  {I : ModelWithCorners 𝕜 E H} {J : ModelWithCorners 𝕜 E' H'}
+  {I' : ModelWithCorners 𝕜 F G} {J' : ModelWithCorners 𝕜 F' G'}
+  {M : Type*} [TopologicalSpace M] [ChartedSpace H M]
+  {N : Type*} [TopologicalSpace N] [ChartedSpace H' N]
+  {M' : Type*} [TopologicalSpace M'] [ChartedSpace G M']
+  {N' : Type*} [TopologicalSpace N'] [ChartedSpace G' N']
+  {n : ℕ∞ω}
+
+/-- Ambient-isotopy classes of bundled smooth embeddings.
+
+This is the quotient of `SmoothEmbedding I J n M N` by the continuous ambient-isotopy relation on
+the underlying maps. It is the general ambient-isotopy-class type whose special cases include
+geometric knot presentations modulo ambient isotopy. -/
+abbrev AmbientIsotopyClass (I : ModelWithCorners 𝕜 E H) (J : ModelWithCorners 𝕜 E' H')
+    (n : ℕ∞ω) (M : Type*) [TopologicalSpace M] [ChartedSpace H M]
+    (N : Type*) [TopologicalSpace N] [ChartedSpace H' N] : Type _ :=
+  Quotient (AmbientIsotopic.setoid I J n M N)
+
+namespace AmbientIsotopyClass
+
+variable {f g : SmoothEmbedding I J n M N}
+
+/-- The ambient-isotopy class of a bundled smooth embedding. -/
+def mk (f : SmoothEmbedding I J n M N) : AmbientIsotopyClass I J n M N :=
+  Quotient.mk (AmbientIsotopic.setoid I J n M N) f
+
+@[simp]
+theorem mk_eq_mk_iff :
+    mk f = mk g ↔ SmoothEmbedding.AmbientIsotopic f g := by
+  change Quotient.mk (AmbientIsotopic.setoid I J n M N) f =
+      Quotient.mk (AmbientIsotopic.setoid I J n M N) g ↔
+    SmoothEmbedding.AmbientIsotopic f g
+  rw [Quotient.eq]
+  exact AmbientIsotopic.setoid_r_iff
+
+/-- Ambient-isotopic bundled smooth embeddings determine the same ambient-isotopy class. -/
+theorem mk_eq_mk (hfg : SmoothEmbedding.AmbientIsotopic f g) : mk f = mk g :=
+  mk_eq_mk_iff.2 hfg
+
+/-- Equality of ambient-isotopy classes of representatives recovers ambient isotopy. -/
+theorem ambientIsotopic_of_mk_eq (hfg : mk f = mk g) :
+    SmoothEmbedding.AmbientIsotopic f g :=
+  mk_eq_mk_iff.1 hfg
+
+/-- Descend a function on bundled smooth embeddings to ambient-isotopy classes.
+
+The hypothesis says exactly that the function is invariant under ambient isotopy. -/
+def lift {β : Sort*} (F : SmoothEmbedding I J n M N → β)
+    (hF : ∀ ⦃f g : SmoothEmbedding I J n M N⦄,
+      SmoothEmbedding.AmbientIsotopic f g → F f = F g) :
+    AmbientIsotopyClass I J n M N → β :=
+  Quotient.lift F fun f g hfg =>
+    hF (f := f) (g := g) (AmbientIsotopic.setoid_r_iff.1 hfg)
+
+@[simp]
+theorem lift_mk {β : Sort*} (F : SmoothEmbedding I J n M N → β)
+    (hF : ∀ ⦃f g : SmoothEmbedding I J n M N⦄,
+      SmoothEmbedding.AmbientIsotopic f g → F f = F g) (f : SmoothEmbedding I J n M N) :
+    lift F hF (mk f) = F f :=
+  Quotient.lift_mk F (fun f g hfg =>
+    hF (f := f) (g := g) (AmbientIsotopic.setoid_r_iff.1 hfg)) f
+
+/-- Descend an ambient-isotopy-preserving map between bundled smooth-embedding types to their
+ambient-isotopy quotients. -/
+def map (F : SmoothEmbedding I J n M N → SmoothEmbedding I' J' n M' N')
+    (hF : ∀ ⦃f g : SmoothEmbedding I J n M N⦄,
+      SmoothEmbedding.AmbientIsotopic f g → SmoothEmbedding.AmbientIsotopic (F f) (F g)) :
+    AmbientIsotopyClass I J n M N → AmbientIsotopyClass I' J' n M' N' :=
+  Quotient.map F fun {f g} hfg =>
+    AmbientIsotopic.setoid_r_iff.2
+      (hF (f := f) (g := g) (AmbientIsotopic.setoid_r_iff.1 hfg))
+
+@[simp]
+theorem map_mk (F : SmoothEmbedding I J n M N → SmoothEmbedding I' J' n M' N')
+    (hF : ∀ ⦃f g : SmoothEmbedding I J n M N⦄,
+      SmoothEmbedding.AmbientIsotopic f g → SmoothEmbedding.AmbientIsotopic (F f) (F g))
+    (f : SmoothEmbedding I J n M N) :
+    map F hF (mk f) = mk (F f) :=
+  Quotient.map_mk F (fun {f g} hfg =>
+    AmbientIsotopic.setoid_r_iff.2
+      (hF (f := f) (g := g) (AmbientIsotopic.setoid_r_iff.1 hfg))) f
+
+variable {E₁ : Type*} [NormedAddCommGroup E₁] [NormedSpace 𝕜 E₁]
+  {E₂ : Type*} [NormedAddCommGroup E₂] [NormedSpace 𝕜 E₂]
+  {F₁ : Type*} [NormedAddCommGroup F₁] [NormedSpace 𝕜 F₁]
+  {F₂ : Type*} [NormedAddCommGroup F₂] [NormedSpace 𝕜 F₂]
+  {H₁ : Type*} [TopologicalSpace H₁] {H₂ : Type*} [TopologicalSpace H₂]
+  {G₁ : Type*} [TopologicalSpace G₁] {G₂ : Type*} [TopologicalSpace G₂]
+  {I₁ : ModelWithCorners 𝕜 E₁ H₁} {I₂ : ModelWithCorners 𝕜 E₂ H₂}
+  {J₁ : ModelWithCorners 𝕜 F₁ G₁} {J₂ : ModelWithCorners 𝕜 F₂ G₂}
+  {M₁ : Type*} [TopologicalSpace M₁] [ChartedSpace H₁ M₁]
+  {M₂ : Type*} [TopologicalSpace M₂] [ChartedSpace H₂ M₂]
+  {N₁ : Type*} [TopologicalSpace N₁] [ChartedSpace G₁ N₁]
+  {N₂ : Type*} [TopologicalSpace N₂] [ChartedSpace G₂ N₂]
+
+/-- The product of ambient-isotopy classes of bundled smooth embeddings.
+
+This is the quotient-level operation induced by `SmoothEmbedding.prodMap`, using product closure
+of ambient isotopy of bundled smooth embeddings. -/
+def prodMap [IsManifold I₁ n M₁] [IsManifold I₂ n M₂]
+    [IsManifold J₁ n N₁] [IsManifold J₂ n N₂] :
+    AmbientIsotopyClass I₁ J₁ n M₁ N₁ →
+      AmbientIsotopyClass I₂ J₂ n M₂ N₂ →
+        AmbientIsotopyClass (I₁.prod I₂) (J₁.prod J₂) n (M₁ × M₂) (N₁ × N₂) :=
+  Quotient.map₂ (fun f g => f.prodMap g) fun {f f'} hff' {g g'} hgg' =>
+    AmbientIsotopic.prodMap_setoid (f := f) (f' := f') (g := g) (g' := g') hff' hgg'
+
+@[simp]
+theorem prodMap_mk_mk [IsManifold I₁ n M₁] [IsManifold I₂ n M₂]
+    [IsManifold J₁ n N₁] [IsManifold J₂ n N₂]
+    (f : SmoothEmbedding I₁ J₁ n M₁ N₁) (g : SmoothEmbedding I₂ J₂ n M₂ N₂) :
+    prodMap (mk f) (mk g) = mk (f.prodMap g) := by
+  change
+    Quotient.map₂
+        (fun (f : SmoothEmbedding I₁ J₁ n M₁ N₁) (g : SmoothEmbedding I₂ J₂ n M₂ N₂) =>
+          f.prodMap g)
+        (fun {f f'} hff' {g g'} hgg' =>
+          AmbientIsotopic.prodMap_setoid (f := f) (f' := f') (g := g) (g' := g') hff' hgg')
+        (Quotient.mk (AmbientIsotopic.setoid I₁ J₁ n M₁ N₁) f)
+        (Quotient.mk (AmbientIsotopic.setoid I₂ J₂ n M₂ N₂) g) =
+      Quotient.mk
+        (AmbientIsotopic.setoid (I₁.prod I₂) (J₁.prod J₂) n (M₁ × M₂) (N₁ × N₂))
+        (f.prodMap g)
+  exact Quotient.map₂_mk
+    (fun (f : SmoothEmbedding I₁ J₁ n M₁ N₁) (g : SmoothEmbedding I₂ J₂ n M₂ N₂) =>
+      f.prodMap g)
+    (fun {f f'} hff' {g g'} hgg' =>
+      AmbientIsotopic.prodMap_setoid (f := f) (f' := f') (g := g) (g' := g') hff' hgg') f g
+
+end AmbientIsotopyClass
+
+end SmoothEmbedding
+
+end TauCeti

--- a/TauCeti/Geometry/Manifold/SmoothEmbedding/AmbientIsotopyProd.lean
+++ b/TauCeti/Geometry/Manifold/SmoothEmbedding/AmbientIsotopyProd.lean
@@ -97,21 +97,18 @@ def prodMap [IsManifold I₁ n M₁] [IsManifold I₂ n M₂]
     AmbientIsotopyClass I₁ J₁ n M₁ N₁ →
       AmbientIsotopyClass I₂ J₂ n M₂ N₂ →
         AmbientIsotopyClass (I₁.prod I₂) (J₁.prod J₂) n (M₁ × M₂) (N₁ × N₂) :=
-  Quotient.map₂ (fun f g => f.prodMap g) fun {f f'} hff' {g g'} hgg' =>
-    AmbientIsotopic.prodMap_setoid (f := f) (f' := f') (g := g) (g' := g') hff' hgg'
+  map₂ (fun f g => f.prodMap g) fun {f f'} hff' {g g'} hgg' =>
+    AmbientIsotopic.prodMap (f := f) (f' := f') (g := g) (g' := g') hff' hgg'
 
 /-- Computation rule for `AmbientIsotopyClass.prodMap` on representatives. -/
 @[simp]
 theorem prodMap_mk_mk [IsManifold I₁ n M₁] [IsManifold I₂ n M₂]
     [IsManifold J₁ n N₁] [IsManifold J₂ n N₂]
     (f : SmoothEmbedding I₁ J₁ n M₁ N₁) (g : SmoothEmbedding I₂ J₂ n M₂ N₂) :
-    prodMap (mk f) (mk g) = mk (f.prodMap g) := by
-  unfold prodMap mk
-  exact Quotient.map₂_mk
-    (fun (f : SmoothEmbedding I₁ J₁ n M₁ N₁) (g : SmoothEmbedding I₂ J₂ n M₂ N₂) =>
-      f.prodMap g)
+    prodMap (mk f) (mk g) = mk (f.prodMap g) :=
+  map₂_mk_mk (fun f g => f.prodMap g)
     (fun {f f'} hff' {g g'} hgg' =>
-      AmbientIsotopic.prodMap_setoid (f := f) (f' := f') (g := g) (g' := g') hff' hgg')
+      AmbientIsotopic.prodMap (f := f) (f' := f') (g := g) (g' := g') hff' hgg')
     f g
 
 end AmbientIsotopyClass

--- a/TauCeti/Geometry/Manifold/SmoothEmbedding/AmbientIsotopyProd.lean
+++ b/TauCeti/Geometry/Manifold/SmoothEmbedding/AmbientIsotopyProd.lean
@@ -4,7 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 -/
 module
 
-public import TauCeti.Geometry.Manifold.SmoothEmbedding.AmbientIsotopy
+public import TauCeti.Geometry.Manifold.SmoothEmbedding.AmbientIsotopyClass
 public import TauCeti.Topology.Homotopy.IsotopyProd
 
 /-!
@@ -26,6 +26,8 @@ embeddings is again ambient isotopic, with the statement phrased entirely in the
 * `TauCeti.SmoothEmbedding.AmbientIsotopic.prodMap`: products preserve ambient isotopy of bundled
   smooth embeddings.
 * `TauCeti.SmoothEmbedding.AmbientIsotopic.prodMap_setoid`: the same fact in setoid-relation form.
+* `TauCeti.SmoothEmbedding.AmbientIsotopyClass.prodMap`: products of embeddings descend to
+  products of ambient-isotopy classes.
 -/
 
 public section
@@ -83,6 +85,36 @@ theorem prodMap_setoid
   setoid_r_iff.2 (prodMap (setoid_r_iff.1 hff') (setoid_r_iff.1 hgg'))
 
 end AmbientIsotopic
+
+namespace AmbientIsotopyClass
+
+/-- The product of ambient-isotopy classes of bundled smooth embeddings.
+
+This is the quotient-level operation induced by `SmoothEmbedding.prodMap`, using product closure
+of ambient isotopy of bundled smooth embeddings. -/
+def prodMap [IsManifold I₁ n M₁] [IsManifold I₂ n M₂]
+    [IsManifold J₁ n N₁] [IsManifold J₂ n N₂] :
+    AmbientIsotopyClass I₁ J₁ n M₁ N₁ →
+      AmbientIsotopyClass I₂ J₂ n M₂ N₂ →
+        AmbientIsotopyClass (I₁.prod I₂) (J₁.prod J₂) n (M₁ × M₂) (N₁ × N₂) :=
+  Quotient.map₂ (fun f g => f.prodMap g) fun {f f'} hff' {g g'} hgg' =>
+    AmbientIsotopic.prodMap_setoid (f := f) (f' := f') (g := g) (g' := g') hff' hgg'
+
+/-- Computation rule for `AmbientIsotopyClass.prodMap` on representatives. -/
+@[simp]
+theorem prodMap_mk_mk [IsManifold I₁ n M₁] [IsManifold I₂ n M₂]
+    [IsManifold J₁ n N₁] [IsManifold J₂ n N₂]
+    (f : SmoothEmbedding I₁ J₁ n M₁ N₁) (g : SmoothEmbedding I₂ J₂ n M₂ N₂) :
+    prodMap (mk f) (mk g) = mk (f.prodMap g) := by
+  unfold prodMap mk
+  exact Quotient.map₂_mk
+    (fun (f : SmoothEmbedding I₁ J₁ n M₁ N₁) (g : SmoothEmbedding I₂ J₂ n M₂ N₂) =>
+      f.prodMap g)
+    (fun {f f'} hff' {g g'} hgg' =>
+      AmbientIsotopic.prodMap_setoid (f := f) (f' := f') (g := g) (g' := g') hff' hgg')
+    f g
+
+end AmbientIsotopyClass
 
 end SmoothEmbedding
 


### PR DESCRIPTION
This PR adds ambient-isotopy classes of bundled smooth embeddings, together with the quotient API needed to descend ambient-isotopy-invariant functions and relation-preserving maps, and the product operation on classes induced by `SmoothEmbedding.prodMap`. It advances `TauCetiRoadmap/GeometricTopology/README.md`, Layer 4, the “Equivalence in each presentation” item for the geometric presentation, where ambient isotopy is the equivalence relation on smooth embeddings, building directly on the existing `SmoothEmbedding.AmbientIsotopic.setoid`.

I chose this as the lowest-hanging distinct GeometricTopology prerequisite after checking open and recently merged PRs: the bundled smooth-embedding type, continuous ambient-isotopy relation, setoid, and product closure already exist on `main`, while the quotient presentation classes downstream invariants need were still absent. This PR stays in the same general manifold API and does not introduce an umbrella `Knot` type.

No Mathlib infrastructure is vendored. The implementation reuses Tau Ceti’s existing `TauCeti.SmoothEmbedding.AmbientIsotopic.setoid`, `setoid_r_iff`, and `prodMap_setoid`, plus Mathlib’s `Quotient.lift`, `Quotient.map`, and `Quotient.map₂`.

`lake exe cache get` completed with `No files to download` and `Already decompressed 8586 file(s)`. `lake build` completed with `Build completed successfully (4270 jobs).` `lake exe axioms` completed with `axioms: audited 5545 TauCeti declaration(s); all within the allowlist [propext, Classical.choice, Quot.sound].`

<!--tauceti-target:v1 {"focus":"GeometricTopology","id":"smooth-embedding-ambient-isotopy-quotients"}-->

🤖 Prepared with Codex
