### PR TITLE
feat(Analysis/CompletelyMonotone): Bernstein representation infrastructure (1/2)

### DIFF
--- a/TauCeti/Analysis/CompletelyMonotone/Basic.lean
+++ b/TauCeti/Analysis/CompletelyMonotone/Basic.lean
@@ -209,13 +209,16 @@ end IsCompletelyMonotone
 variable {f : ℝ → ℝ}
 
 /-- At a point `x` in the interior of a unique-differentiability set `s` (`s ∈ 𝓝 x`),
-the derivative of the `k`-th iterated derivative-within-`s` of a `C^∞` function is the
+the derivative of the `k`-th iterated derivative-within-`s` of a `C^(k+1)` function is the
 `(k+1)`-th iterated derivative-within-`s`. -/
 theorem ContDiffOn.hasDerivAt_iteratedDerivWithin
-    (hf : ContDiffOn ℝ ∞ f s) (hs : UniqueDiffOn ℝ s) (k : ℕ) {x : ℝ} (hx : s ∈ nhds x) :
+    {k : ℕ} (hf : ContDiffOn ℝ ((k + 1 : ℕ) : WithTop ℕ∞) f s)
+    (hs : UniqueDiffOn ℝ s) {x : ℝ} (hx : s ∈ nhds x) :
     HasDerivAt (iteratedDerivWithin k f s) (iteratedDerivWithin (k + 1) f s x) x := by
+  have hklt : (k : WithTop ℕ∞) < ((k + 1 : ℕ) : WithTop ℕ∞) := by
+    exact_mod_cast (Nat.lt_succ_self k)
   have hda := (hf.differentiableOn_iteratedDerivWithin
-    (WithTop.coe_lt_coe.mpr (WithTop.coe_lt_top k)) hs).hasDerivAt hx
+    hklt hs).hasDerivAt hx
   have hval : iteratedDerivWithin (k + 1) f s x =
       deriv (iteratedDerivWithin k f s) x := by
     rw [iteratedDerivWithin_succ, derivWithin_of_mem_nhds hx]
@@ -230,9 +233,10 @@ differentiable at any `t > 0`, with derivative the `(k+1)`-th iterated derivativ
 lemma hasDerivAt_iteratedDerivWithin_succ
     (hcm : IsCompletelyMonotone f) (k : ℕ) {t : ℝ} (ht : 0 < t) :
     HasDerivAt (iteratedDerivWithin k f (Ici 0))
-      (iteratedDerivWithin (k + 1) f (Ici 0) t) t :=
-  ContDiffOn.hasDerivAt_iteratedDerivWithin hcm.contDiffOn (uniqueDiffOn_Ici 0) k
-    (Ici_mem_nhds ht)
+      (iteratedDerivWithin (k + 1) f (Ici 0) t) t := by
+  have horder : ((k + 1 : ℕ) : WithTop ℕ∞) ≤ ∞ := by exact_mod_cast le_top
+  exact ContDiffOn.hasDerivAt_iteratedDerivWithin (k := k)
+    (hcm.contDiffOn.of_le horder) (uniqueDiffOn_Ici 0) (Ici_mem_nhds ht)
 
 /-- Completely monotone functions are closed under addition. -/
 lemma add (hf : IsCompletelyMonotone f) (hg : IsCompletelyMonotone g) :

--- a/TauCeti/Analysis/CompletelyMonotone/Basic.lean
+++ b/TauCeti/Analysis/CompletelyMonotone/Basic.lean
@@ -206,21 +206,20 @@ lemma le_of_tendsto_atTop (hcm : IsCompletelyMonotone f) {L : ℝ}
 
 end IsCompletelyMonotone
 
-variable {f : ℝ → ℝ}
-
 /-- At a point `x` in the interior of a unique-differentiability set `s` (`s ∈ 𝓝 x`),
 the derivative of the `k`-th iterated derivative-within-`s` of a `C^(k+1)` function is the
 `(k+1)`-th iterated derivative-within-`s`. -/
 theorem ContDiffOn.hasDerivAt_iteratedDerivWithin
-    {k : ℕ} (hf : ContDiffOn ℝ ((k + 1 : ℕ) : WithTop ℕ∞) f s)
+    {E : Type*} [NormedAddCommGroup E] [NormedSpace ℝ E] {g : ℝ → E}
+    {k : ℕ} (hf : ContDiffOn ℝ ((k + 1 : ℕ) : WithTop ℕ∞) g s)
     (hs : UniqueDiffOn ℝ s) {x : ℝ} (hx : s ∈ nhds x) :
-    HasDerivAt (iteratedDerivWithin k f s) (iteratedDerivWithin (k + 1) f s x) x := by
+    HasDerivAt (iteratedDerivWithin k g s) (iteratedDerivWithin (k + 1) g s x) x := by
   have hklt : (k : WithTop ℕ∞) < ((k + 1 : ℕ) : WithTop ℕ∞) := by
     exact_mod_cast (Nat.lt_succ_self k)
   have hda := (hf.differentiableOn_iteratedDerivWithin
     hklt hs).hasDerivAt hx
-  have hval : iteratedDerivWithin (k + 1) f s x =
-      deriv (iteratedDerivWithin k f s) x := by
+  have hval : iteratedDerivWithin (k + 1) g s x =
+      deriv (iteratedDerivWithin k g s) x := by
     rw [iteratedDerivWithin_succ, derivWithin_of_mem_nhds hx]
   rw [hval]; exact hda
 

--- a/TauCeti/Analysis/CompletelyMonotone/Basic.lean
+++ b/TauCeti/Analysis/CompletelyMonotone/Basic.lean
@@ -210,9 +210,10 @@ end IsCompletelyMonotone
 the derivative of the `k`-th iterated derivative-within-`s` of a `C^(k+1)` function is the
 `(k+1)`-th iterated derivative-within-`s`. -/
 theorem ContDiffOn.hasDerivAt_iteratedDerivWithin
-    {E : Type*} [NormedAddCommGroup E] [NormedSpace ℝ E] {g : ℝ → E}
-    {k : ℕ} (hf : ContDiffOn ℝ ((k + 1 : ℕ) : WithTop ℕ∞) g s)
-    (hs : UniqueDiffOn ℝ s) {x : ℝ} (hx : s ∈ nhds x) :
+    {𝕜 E : Type*} [NontriviallyNormedField 𝕜] [NormedAddCommGroup E] [NormedSpace 𝕜 E]
+    {g : 𝕜 → E} {s : Set 𝕜} {k : ℕ}
+    (hf : ContDiffOn 𝕜 ((k + 1 : ℕ) : WithTop ℕ∞) g s)
+    (hs : UniqueDiffOn 𝕜 s) {x : 𝕜} (hx : s ∈ nhds x) :
     HasDerivAt (iteratedDerivWithin k g s) (iteratedDerivWithin (k + 1) g s x) x := by
   have hklt : (k : WithTop ℕ∞) < ((k + 1 : ℕ) : WithTop ℕ∞) := by
     exact_mod_cast (Nat.lt_succ_self k)

--- a/TauCeti/Analysis/CompletelyMonotone/Basic.lean
+++ b/TauCeti/Analysis/CompletelyMonotone/Basic.lean
@@ -8,6 +8,7 @@ public import Mathlib.Analysis.Calculus.AbsolutelyMonotone
 public import Mathlib.Analysis.Calculus.Deriv.MeanValue
 public import Mathlib.Analysis.Calculus.IteratedDeriv.Lemmas
 public import Mathlib.Analysis.SpecialFunctions.ExpDeriv
+public import Mathlib.Topology.Order.MonotoneConvergence
 
 /-!
 # Completely monotone functions
@@ -40,6 +41,9 @@ point `0`); on the open half-line it agrees with the ordinary iterated derivativ
 * `TauCeti.IsCompletelyMonotone.nonneg`, `TauCeti.IsCompletelyMonotone.derivWithin_nonpos`,
   `TauCeti.IsCompletelyMonotone.antitoneOn`: a completely monotone function is nonnegative
   and nonincreasing on `[0, ∞)`.
+* `TauCeti.IsCompletelyMonotone.tendsto_atTop`,
+  `TauCeti.IsCompletelyMonotone.le_of_tendsto_atTop`: order-limit consequences of
+  nonnegativity and monotonicity on `[0, ∞)`.
 * `TauCeti.IsCompletelyMonotone.neg_one_pow_mul_iteratedDeriv_nonneg`: on the open half-line,
   the sign condition also holds for ordinary iterated derivatives.
 * `TauCeti.IsCompletelyMonotone.add`, `TauCeti.IsCompletelyMonotone.smul`: closure under
@@ -173,6 +177,62 @@ lemma antitoneOn (hf : IsCompletelyMonotone f) : AntitoneOn f (Ici 0) := by
   have hmem : Ici (0 : ℝ) ∈ 𝓝 x := mem_of_superset (isOpen_Ioi.mem_nhds hx) Ioi_subset_Ici_self
   rw [← derivWithin_of_mem_nhds hmem]
   exact hf.derivWithin_nonpos (le_of_lt hx)
+
+/-- A completely monotone function has a limit `L ≥ 0` at infinity: it is antitone on `[0, ∞)`
+and bounded below by `0`. -/
+lemma tendsto_atTop (hf : IsCompletelyMonotone f) :
+    ∃ L, Tendsto f atTop (nhds L) ∧ 0 ≤ L := by
+  have hanti := hf.antitoneOn
+  set g := fun t : ℝ => f (max t 0) with hg
+  have hg_anti : Antitone g := fun a b hab =>
+    hanti (mem_Ici.mpr (le_max_right _ _)) (mem_Ici.mpr (le_max_right _ _))
+      (max_le_max_right 0 hab)
+  have hg_bdd : BddBelow (Set.range g) :=
+    ⟨0, fun _ ⟨t, ht⟩ => ht ▸ hf.nonneg (le_max_right _ _)⟩
+  refine ⟨⨅ i, g i, ?_, le_ciInf (fun _ => hf.nonneg (le_max_right _ _))⟩
+  exact (tendsto_atTop_ciInf hg_anti hg_bdd).congr'
+    (eventually_atTop.mpr ⟨0, fun t ht => by simp [hg, max_eq_left ht]⟩)
+
+/-- A completely monotone function lies above its limit at infinity on `[0, ∞)`. -/
+lemma le_of_tendsto_atTop (hcm : IsCompletelyMonotone f) {L : ℝ}
+    (hL : Tendsto f atTop (nhds L)) {T : ℝ} (hT : 0 ≤ T) : L ≤ f T := by
+  set g₀ := fun t : ℝ => f (max t 0) with hg₀
+  have hg_anti : Antitone g₀ := fun a b hab =>
+    hcm.antitoneOn (mem_Ici.mpr (le_max_right _ _)) (mem_Ici.mpr (le_max_right _ _))
+      (max_le_max_right 0 hab)
+  have := hg_anti.le_of_tendsto
+    (hL.congr' (eventually_atTop.mpr ⟨0, fun t ht => by simp [hg₀, max_eq_left ht]⟩)) T
+  simpa [hg₀, max_eq_left hT] using this
+
+end IsCompletelyMonotone
+
+variable {f : ℝ → ℝ}
+
+/-- At a point `x` in the interior of a unique-differentiability set `s` (`s ∈ 𝓝 x`),
+the derivative of the `k`-th iterated derivative-within-`s` of a `C^∞` function is the
+`(k+1)`-th iterated derivative-within-`s`. -/
+theorem ContDiffOn.hasDerivAt_iteratedDerivWithin
+    (hf : ContDiffOn ℝ ∞ f s) (hs : UniqueDiffOn ℝ s) (k : ℕ) {x : ℝ} (hx : s ∈ nhds x) :
+    HasDerivAt (iteratedDerivWithin k f s) (iteratedDerivWithin (k + 1) f s x) x := by
+  have hda := (hf.differentiableOn_iteratedDerivWithin
+    (WithTop.coe_lt_coe.mpr (WithTop.coe_lt_top k)) hs).hasDerivAt hx
+  have hval : iteratedDerivWithin (k + 1) f s x =
+      deriv (iteratedDerivWithin k f s) x := by
+    rw [iteratedDerivWithin_succ, derivWithin_of_mem_nhds hx]
+  rw [hval]; exact hda
+
+namespace IsCompletelyMonotone
+
+variable {f g : ℝ → ℝ}
+
+/-- For a completely monotone `f`, the `k`-th iterated derivative within `[0, ∞)` is
+differentiable at any `t > 0`, with derivative the `(k+1)`-th iterated derivative. -/
+lemma hasDerivAt_iteratedDerivWithin_succ
+    (hcm : IsCompletelyMonotone f) (k : ℕ) {t : ℝ} (ht : 0 < t) :
+    HasDerivAt (iteratedDerivWithin k f (Ici 0))
+      (iteratedDerivWithin (k + 1) f (Ici 0) t) t :=
+  ContDiffOn.hasDerivAt_iteratedDerivWithin hcm.contDiffOn (uniqueDiffOn_Ici 0) k
+    (Ici_mem_nhds ht)
 
 /-- Completely monotone functions are closed under addition. -/
 lemma add (hf : IsCompletelyMonotone f) (hg : IsCompletelyMonotone g) :

--- a/TauCeti/Analysis/CompletelyMonotone/Basic.lean
+++ b/TauCeti/Analysis/CompletelyMonotone/Basic.lean
@@ -41,7 +41,7 @@ point `0`); on the open half-line it agrees with the ordinary iterated derivativ
 * `TauCeti.IsCompletelyMonotone.nonneg`, `TauCeti.IsCompletelyMonotone.derivWithin_nonpos`,
   `TauCeti.IsCompletelyMonotone.antitoneOn`: a completely monotone function is nonnegative
   and nonincreasing on `[0, ∞)`.
-* `TauCeti.IsCompletelyMonotone.tendsto_atTop`,
+* `TauCeti.IsCompletelyMonotone.exists_nonneg_tendsto_atTop`,
   `TauCeti.IsCompletelyMonotone.le_of_tendsto_atTop`: order-limit consequences of
   nonnegativity and monotonicity on `[0, ∞)`.
 * `TauCeti.IsCompletelyMonotone.neg_one_pow_mul_iteratedDeriv_nonneg`: on the open half-line,
@@ -180,7 +180,7 @@ lemma antitoneOn (hf : IsCompletelyMonotone f) : AntitoneOn f (Ici 0) := by
 
 /-- A completely monotone function has a limit `L ≥ 0` at infinity: it is antitone on `[0, ∞)`
 and bounded below by `0`. -/
-lemma tendsto_atTop (hf : IsCompletelyMonotone f) :
+lemma exists_nonneg_tendsto_atTop (hf : IsCompletelyMonotone f) :
     ∃ L, Tendsto f atTop (nhds L) ∧ 0 ≤ L := by
   have hanti := hf.antitoneOn
   set g := fun t : ℝ => f (max t 0) with hg

--- a/TauCeti/Analysis/CompletelyMonotone/BernsteinMeasures.lean
+++ b/TauCeti/Analysis/CompletelyMonotone/BernsteinMeasures.lean
@@ -545,7 +545,7 @@ lemma chafaiMeasure_finite_mass (f : ℝ → ℝ) (hcm : IsCompletelyMonotone f)
       ∀ n,
         IsFiniteMeasure (chafaiMeasure f n) ∧
         (chafaiMeasure f n) univ ≤ ENNReal.ofReal (f 0 - L) := by
-  obtain ⟨L, hL, hL_nn⟩ := hcm.tendsto_atTop
+  obtain ⟨L, hL, hL_nn⟩ := hcm.exists_nonneg_tendsto_atTop
   exact ⟨L, hL, hL_nn, fun n => chafaiMeasure_finite_mass_of_tendsto f hcm n L hL⟩
 
 /-- **Natural rescaled total mass bound**: for a completely monotone `f`, the rescaled

--- a/TauCeti/Analysis/CompletelyMonotone/BernsteinMeasures.lean
+++ b/TauCeti/Analysis/CompletelyMonotone/BernsteinMeasures.lean
@@ -23,8 +23,10 @@ These build on the `IsCompletelyMonotone` API in `CompletelyMonotone/Basic.lean`
 ## Main declarations
 
 * `TauCeti.chafaiDensity`, `TauCeti.chafaiMeasure`: the approximating densities and measures.
-* `TauCeti.bernstein_kernel`, `TauCeti.bernstein_kernel_tendsto`: the rescaled Laplace kernel and
-  its pointwise limit `e^{-xp}`.
+* `TauCeti.bernstein_kernel`, `TauCeti.continuous_bernstein_kernel`,
+  `TauCeti.bernstein_kernel_nonneg`, `TauCeti.bernstein_kernel_le_one`,
+  `TauCeti.bernstein_kernel_tendsto`: the rescaled Laplace kernel, its bounded-continuous
+  `p`-dependence on the nonnegative half-line, and its pointwise limit `e^{-xp}`.
 * `TauCeti.chafaiRescaled`, `TauCeti.chafaiRescaled_mass_eq`: the `ℝ≥0`-valued pushed-forward
   measures and mass preservation.
 * `TauCeti.chafaiMeasure_finite_mass`, `TauCeti.chafaiRescaled_finite_mass`: finiteness and the
@@ -163,6 +165,19 @@ private lemma chafaiDensity_succ_succ_sub_succ (f : ℝ → ℝ) (m : ℕ) (t : 
   field_simp
   ring
 
+private lemma ContDiffOn.hasDerivAt_iteratedDerivWithin_of_nat {s : Set ℝ} {k : ℕ}
+    (hf : ContDiffOn ℝ ((k + 1 : ℕ) : WithTop ℕ∞) f s) (hs : UniqueDiffOn ℝ s)
+    {x : ℝ} (hx : s ∈ nhds x) :
+    HasDerivAt (iteratedDerivWithin k f s) (iteratedDerivWithin (k + 1) f s x) x := by
+  have hklt : (k : WithTop ℕ∞) < ((k + 1 : ℕ) : WithTop ℕ∞) := by
+    exact_mod_cast (Nat.lt_succ_self k)
+  have hda := (hf.differentiableOn_iteratedDerivWithin hklt hs).hasDerivAt hx
+  have hval : iteratedDerivWithin (k + 1) f s x =
+      deriv (iteratedDerivWithin k f s) x := by
+    rw [iteratedDerivWithin_succ, derivWithin_of_mem_nhds hx]
+  rw [hval]
+  exact hda
+
 /-! ## Rescaled measures and Prokhorov extraction -/
 
 /-- The Bernstein kernel `φ_n(x,p) = max(1 - xp/(n-1), 0)ⁿ⁻¹` for `n ≥ 2`. After the change of
@@ -182,9 +197,28 @@ lemma bernstein_kernel_of_two_le {n : ℕ} (hn : 2 ≤ n) (x p : ℝ) :
   have hnle : ¬ n ≤ 1 := by omega
   rw [bernstein_kernel, if_neg hnle]
 
+/-- The Bernstein kernel is continuous in `p` for fixed `n` and `x`. -/
+lemma continuous_bernstein_kernel (n : ℕ) (x : ℝ) : Continuous (bernstein_kernel n x) := by
+  unfold bernstein_kernel
+  split_ifs <;> fun_prop
+
 /-- The Bernstein kernel is nonnegative. -/
 @[simp] lemma bernstein_kernel_nonneg (n : ℕ) (x p : ℝ) : 0 ≤ bernstein_kernel n x p := by
   rw [bernstein_kernel]; split_ifs <;> positivity
+
+/-- On the nonnegative half-plane, the Bernstein kernel is bounded above by `1`. -/
+lemma bernstein_kernel_le_one {n : ℕ} {x p : ℝ} (hx : 0 ≤ x) (hp : 0 ≤ p) :
+    bernstein_kernel n x p ≤ 1 := by
+  rw [bernstein_kernel]
+  split_ifs with hn
+  · norm_num
+  · have hn_pos : (0 : ℝ) < (↑(n - 1) : ℝ) := Nat.cast_pos.mpr (by omega)
+    have hratio_nonneg : 0 ≤ x * p / (↑(n - 1) : ℝ) :=
+      div_nonneg (mul_nonneg hx hp) hn_pos.le
+    have hbase_nonneg : 0 ≤ max (1 - x * p / (↑(n - 1) : ℝ)) 0 := le_max_right _ _
+    have hbase_le_one : max (1 - x * p / (↑(n - 1) : ℝ)) 0 ≤ 1 := by
+      exact max_le (by linarith) zero_le_one
+    exact pow_le_one₀ hbase_nonneg hbase_le_one
 
 /-- The Bernstein kernel is measurable in `p` for fixed `n` and `x`. -/
 lemma measurable_bernstein_kernel (n : ℕ) (x : ℝ) : Measurable (bernstein_kernel n x) := by
@@ -276,8 +310,8 @@ lemma chafaiRescaled_mass_eq (f : ℝ → ℝ) (n : ℕ) :
 
 /-- **IBP identity** for the CM density:
 `∫₀ᵀ ρ_{m+2}(t) dt = B_{m+2}(T) + ∫₀ᵀ ρ_{m+1}(t) dt`. -/
-private lemma chafaiDensity_ibp_identity (f : ℝ → ℝ) (hcm : IsCompletelyMonotone f)
-    (m : ℕ) (T : ℝ) (hT : 0 < T) :
+private lemma chafaiDensity_ibp_identity (f : ℝ → ℝ) {m : ℕ}
+    (hf : ContDiffOn ℝ ((m + 2 : ℕ) : WithTop ℕ∞) f (Ici 0)) (T : ℝ) (hT : 0 < T) :
     ∫ t in (0 : ℝ)..T, chafaiDensity f (m + 2) t =
     (-1 : ℝ) ^ (m + 2) * T ^ (m + 1) / ↑(m + 1).factorial *
       iteratedDerivWithin (m + 1) f (Ici 0) T +
@@ -287,9 +321,11 @@ private lemma chafaiDensity_ibp_identity (f : ℝ → ℝ) (hcm : IsCompletelyMo
   set c : ℝ := (-1) ^ (m + 2) / ↑(m + 1).factorial
   set F := fun t : ℝ => t ^ (m + 1) * (c * g t)
   have hg_cont : ContinuousOn g (Ici 0) :=
-    hcm.contDiffOn.continuousOn_iteratedDerivWithin (nat_le_top _) (uniqueDiffOn_Ici 0)
+    (hf.of_le (by exact_mod_cast (by omega : m + 1 ≤ m + 2))).continuousOn_iteratedDerivWithin
+      le_rfl (uniqueDiffOn_Ici 0)
   have hg_deriv : ∀ t, 0 < t → HasDerivAt g (g' t) t :=
-    fun t ht => hcm.hasDerivAt_iteratedDerivWithin_succ (m + 1) ht
+    fun t ht =>
+      ContDiffOn.hasDerivAt_iteratedDerivWithin_of_nat hf (uniqueDiffOn_Ici 0) (Ici_mem_nhds ht)
   have huIcc : uIcc (0 : ℝ) T = Icc 0 T := uIcc_of_le hT.le
   have hF_cont : ContinuousOn F (Icc 0 T) :=
     ((continuous_pow _).continuousOn).mul
@@ -297,10 +333,13 @@ private lemma chafaiDensity_ibp_identity (f : ℝ → ℝ) (hcm : IsCompletelyMo
   have hF_deriv : ∀ t ∈ Ioo 0 T, HasDerivAt F
       (↑(m + 1) * t ^ m * (c * g t) + t ^ (m + 1) * (c * g' t)) t :=
     fun t ht => (hasDerivAt_pow (m + 1) t).mul ((hg_deriv t ht.1).const_mul c)
-  have hcm_int : ∀ k, k ≠ 0 → IntervalIntegrable (fun t => chafaiDensity f k t) volume 0 T := by
-    intro k hk; apply ContinuousOn.intervalIntegrable; rw [huIcc]
-    exact (continuousOn_chafaiDensity (n := k)
-      ((hcm.contDiffOn).of_le (nat_le_top k))).mono Icc_subset_Ici_self
+  have h_int_m2 : IntervalIntegrable (fun t => chafaiDensity f (m + 2) t) volume 0 T := by
+    apply ContinuousOn.intervalIntegrable; rw [huIcc]
+    exact (continuousOn_chafaiDensity (n := m + 2) hf).mono Icc_subset_Ici_self
+  have h_int_m1 : IntervalIntegrable (fun t => chafaiDensity f (m + 1) t) volume 0 T := by
+    apply ContinuousOn.intervalIntegrable; rw [huIcc]
+    exact (continuousOn_chafaiDensity (n := m + 1)
+      (hf.of_le (by exact_mod_cast (by omega : m + 1 ≤ m + 2)))).mono Icc_subset_Ici_self
   have hF'_eq : ∀ t, ↑(m + 1) * t ^ m * (c * g t) + t ^ (m + 1) * (c * g' t) =
       chafaiDensity f (m + 2) t - chafaiDensity f (m + 1) t := by
     intro t
@@ -308,7 +347,7 @@ private lemma chafaiDensity_ibp_identity (f : ℝ → ℝ) (hcm : IsCompletelyMo
     exact (chafaiDensity_succ_succ_sub_succ f m t).symm
   have hF'_int : IntervalIntegrable
       (fun t => ↑(m + 1) * t ^ m * (c * g t) + t ^ (m + 1) * (c * g' t)) volume 0 T :=
-    ((hcm_int _ (by omega)).sub (hcm_int _ (by omega))).congr fun t _ => (hF'_eq t).symm
+    (h_int_m2.sub h_int_m1).congr fun t _ => (hF'_eq t).symm
   have hftc := intervalIntegral.integral_eq_sub_of_hasDerivAt_of_le hT.le hF_cont hF_deriv hF'_int
   have hstep1 : ∫ t in (0 : ℝ)..T,
       (chafaiDensity f (m + 2) t - chafaiDensity f (m + 1) t) = F T - F 0 := by
@@ -318,7 +357,7 @@ private lemma chafaiDensity_ibp_identity (f : ℝ → ℝ) (hcm : IsCompletelyMo
   have hm1 : m + 1 ≠ 0 := by omega
   have hF0 : F 0 = 0 := by simp [F, zero_pow hm1]
   rw [hF0, sub_zero] at hstep1
-  rw [intervalIntegral.integral_sub (hcm_int _ (by omega)) (hcm_int _ (by omega))] at hstep1
+  rw [intervalIntegral.integral_sub h_int_m2 h_int_m1] at hstep1
   suffices hgoal : (-1 : ℝ) ^ (m + 2) * T ^ (m + 1) / ↑(m + 1).factorial * g T = F T by linarith
   simp only [F, c]; ring
 
@@ -327,21 +366,25 @@ private lemma chafaiDensity_ibp_identity (f : ℝ → ℝ) (hcm : IsCompletelyMo
 integration-by-parts consequence
 (the raw IBP identity `chafaiDensity_ibp_identity` is private); it is the per-step density
 mass-monotonicity bound consumed by the Bernstein-identity assembly. -/
-lemma integral_chafaiDensity_le_pred (f : ℝ → ℝ) (hcm : IsCompletelyMonotone f)
-    (k : ℕ) (hk : 2 ≤ k) (T : ℝ) (hT : 0 ≤ T) :
+lemma integral_chafaiDensity_le_pred (f : ℝ → ℝ) {k : ℕ} (hk : 2 ≤ k)
+    (hf : ContDiffOn ℝ (k : WithTop ℕ∞) f (Ici 0))
+    (T : ℝ) (hT : 0 ≤ T)
+    (hsign : 0 ≤ (-1 : ℝ) ^ (k - 1) * iteratedDerivWithin (k - 1) f (Ici 0) T) :
     ∫ t in (0 : ℝ)..T, chafaiDensity f k t ≤ ∫ t in (0 : ℝ)..T, chafaiDensity f (k - 1) t := by
   rcases hT.eq_or_lt with rfl | hT_pos
   · simp
   obtain ⟨m, rfl⟩ : ∃ m, k = m + 2 := ⟨k - 2, by omega⟩
   have hsub : m + 2 - 1 = m + 1 := by omega
   simp only [hsub]
-  have hibp := chafaiDensity_ibp_identity f hcm m T hT_pos
+  have hibp := chafaiDensity_ibp_identity (m := m) f hf T hT_pos
   set B := (-1 : ℝ) ^ (m + 2) * T ^ (m + 1) / ↑(m + 1).factorial *
     iteratedDerivWithin (m + 1) f (Ici 0) T
   have hB : B ≤ 0 := by
+    have hsign_m : 0 ≤ (-1 : ℝ) ^ (m + 1) * iteratedDerivWithin (m + 1) f (Ici 0) T := by
+      simpa [hsub] using hsign
     have h_neg : (-1 : ℝ) ^ (m + 2) * iteratedDerivWithin (m + 1) f (Ici 0) T ≤ 0 := by
       have : (-1 : ℝ) ^ (m + 2) = (-1) ^ (m + 1) * (-1) := pow_succ (-1) (m + 1)
-      rw [this]; nlinarith [hcm.neg_one_pow_mul_iteratedDerivWithin_nonneg (m + 1) hT_pos.le]
+      rw [this]; nlinarith [hsign_m]
     suffices B = T ^ (m + 1) / ↑(m + 1).factorial *
         ((-1 : ℝ) ^ (m + 2) * iteratedDerivWithin (m + 1) f (Ici 0) T) by
       rw [this]
@@ -385,7 +428,10 @@ private lemma integral_chafaiDensity_le_sub (f : ℝ → ℝ) (hcm : IsCompletel
       exact le_of_eq (integral_chafaiDensity_one_eq f hcm T hT)
     · calc ∫ t in (0 : ℝ)..T, chafaiDensity f (p + 1) t
           ≤ ∫ t in (0 : ℝ)..T, chafaiDensity f p t := by
-            simpa using integral_chafaiDensity_le_pred f hcm (p + 1) (by omega) T hT.le
+            exact integral_chafaiDensity_le_pred f (k := p + 1) (by omega)
+              (hcm.contDiffOn.of_le (nat_le_top (p + 1)))
+              T hT.le (by
+                simpa using hcm.neg_one_pow_mul_iteratedDerivWithin_nonneg p hT.le)
         _ ≤ f 0 - f T := ih (Nat.one_le_iff_ne_zero.mpr hp)
 
 private lemma integral_chafaiDensity_le_tendsto_sub (f : ℝ → ℝ)

--- a/TauCeti/Analysis/CompletelyMonotone/BernsteinMeasures.lean
+++ b/TauCeti/Analysis/CompletelyMonotone/BernsteinMeasures.lean
@@ -5,6 +5,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 module
 
 public import Mathlib.Analysis.SpecialFunctions.Complex.LogBounds
+public import Mathlib.Topology.ContinuousMap.Bounded.Basic
 public import TauCeti.Analysis.CompletelyMonotone.Integral
 
 /-!
@@ -25,8 +26,10 @@ These build on the `IsCompletelyMonotone` API in `CompletelyMonotone/Basic.lean`
 * `TauCeti.chafaiDensity`, `TauCeti.chafaiMeasure`: the approximating densities and measures.
 * `TauCeti.bernstein_kernel`, `TauCeti.continuous_bernstein_kernel`,
   `TauCeti.bernstein_kernel_nonneg`, `TauCeti.bernstein_kernel_le_one`,
-  `TauCeti.bernstein_kernel_tendsto`: the rescaled Laplace kernel, its bounded-continuous
-  `p`-dependence on the nonnegative half-line, and its pointwise limit `e^{-xp}`.
+  `TauCeti.bernsteinKernelBCF`, `TauCeti.bernsteinKernelBCF_apply`,
+  `TauCeti.bernstein_kernel_tendsto`: the rescaled Laplace kernel, its bundled
+  bounded-continuous `p`-dependence on the nonnegative half-line, and its pointwise limit
+  `e^{-xp}`.
 * `TauCeti.chafaiRescaled`, `TauCeti.chafaiRescaled_mass_eq`: the `ℝ≥0`-valued pushed-forward
   measures and mass preservation.
 * `TauCeti.chafaiMeasure_finite_mass`, `TauCeti.chafaiRescaled_finite_mass`: finiteness and the
@@ -43,7 +46,7 @@ These build on the `IsCompletelyMonotone` API in `CompletelyMonotone/Basic.lean`
 public section
 
 open MeasureTheory Set intervalIntegral Filter
-open scoped ContDiff NNReal Topology
+open scoped BoundedContinuousFunction ContDiff NNReal Topology
 
 namespace TauCeti
 
@@ -165,19 +168,6 @@ private lemma chafaiDensity_succ_succ_sub_succ (f : ℝ → ℝ) (m : ℕ) (t : 
   field_simp
   ring
 
-private lemma ContDiffOn.hasDerivAt_iteratedDerivWithin_of_nat {s : Set ℝ} {k : ℕ}
-    (hf : ContDiffOn ℝ ((k + 1 : ℕ) : WithTop ℕ∞) f s) (hs : UniqueDiffOn ℝ s)
-    {x : ℝ} (hx : s ∈ nhds x) :
-    HasDerivAt (iteratedDerivWithin k f s) (iteratedDerivWithin (k + 1) f s x) x := by
-  have hklt : (k : WithTop ℕ∞) < ((k + 1 : ℕ) : WithTop ℕ∞) := by
-    exact_mod_cast (Nat.lt_succ_self k)
-  have hda := (hf.differentiableOn_iteratedDerivWithin hklt hs).hasDerivAt hx
-  have hval : iteratedDerivWithin (k + 1) f s x =
-      deriv (iteratedDerivWithin k f s) x := by
-    rw [iteratedDerivWithin_succ, derivWithin_of_mem_nhds hx]
-  rw [hval]
-  exact hda
-
 /-! ## Rescaled measures and Prokhorov extraction -/
 
 /-- The Bernstein kernel `φ_n(x,p) = max(1 - xp/(n-1), 0)ⁿ⁻¹` for `n ≥ 2`. After the change of
@@ -219,6 +209,26 @@ lemma bernstein_kernel_le_one {n : ℕ} {x p : ℝ} (hx : 0 ≤ x) (hp : 0 ≤ p
     have hbase_le_one : max (1 - x * p / (↑(n - 1) : ℝ)) 0 ≤ 1 := by
       exact max_le (by linarith) zero_le_one
     exact pow_le_one₀ hbase_nonneg hbase_le_one
+
+/-- The Bernstein kernel as a bundled bounded continuous test function of the nonnegative
+variable `p`, for fixed `n` and nonnegative `x`. -/
+@[expose]
+noncomputable def bernsteinKernelBCF (n : ℕ) {x : ℝ} (hx : 0 ≤ x) : ℝ≥0 →ᵇ ℝ where
+  toFun := fun p => bernstein_kernel n x (p : ℝ)
+  continuous_toFun := (continuous_bernstein_kernel n x).comp continuous_subtype_val
+  map_bounded' :=
+    ⟨1, fun p q => by
+      rw [Real.dist_eq]
+      have hp0 : 0 ≤ bernstein_kernel n x (p : ℝ) := bernstein_kernel_nonneg n x (p : ℝ)
+      have hp1 : bernstein_kernel n x (p : ℝ) ≤ 1 := bernstein_kernel_le_one hx p.2
+      have hq0 : 0 ≤ bernstein_kernel n x (q : ℝ) := bernstein_kernel_nonneg n x (q : ℝ)
+      have hq1 : bernstein_kernel n x (q : ℝ) ≤ 1 := bernstein_kernel_le_one hx q.2
+      exact abs_sub_le_iff.mpr ⟨by linarith, by linarith⟩⟩
+
+/-- The bundled Bernstein kernel evaluates to the unbundled kernel on `ℝ≥0`. -/
+@[simp]
+lemma bernsteinKernelBCF_apply (n : ℕ) {x : ℝ} (hx : 0 ≤ x) (p : ℝ≥0) :
+    bernsteinKernelBCF n hx p = bernstein_kernel n x (p : ℝ) := rfl
 
 /-- The Bernstein kernel is measurable in `p` for fixed `n` and `x`. -/
 lemma measurable_bernstein_kernel (n : ℕ) (x : ℝ) : Measurable (bernstein_kernel n x) := by
@@ -325,7 +335,7 @@ private lemma chafaiDensity_ibp_identity (f : ℝ → ℝ) {m : ℕ}
       le_rfl (uniqueDiffOn_Ici 0)
   have hg_deriv : ∀ t, 0 < t → HasDerivAt g (g' t) t :=
     fun t ht =>
-      ContDiffOn.hasDerivAt_iteratedDerivWithin_of_nat hf (uniqueDiffOn_Ici 0) (Ici_mem_nhds ht)
+      ContDiffOn.hasDerivAt_iteratedDerivWithin hf (uniqueDiffOn_Ici 0) (Ici_mem_nhds ht)
   have huIcc : uIcc (0 : ℝ) T = Icc 0 T := uIcc_of_le hT.le
   have hF_cont : ContinuousOn F (Icc 0 T) :=
     ((continuous_pow _).continuousOn).mul

--- a/TauCeti/Analysis/CompletelyMonotone/BernsteinMeasures.lean
+++ b/TauCeti/Analysis/CompletelyMonotone/BernsteinMeasures.lean
@@ -70,8 +70,10 @@ lemma chafaiDensity_of_ne_zero {n : ℕ} (hn : n ≠ 0) (f : ℝ → ℝ) (t : �
       t ^ (n - 1) * iteratedDerivWithin n f (Ici 0) t := by
   rw [chafaiDensity, if_neg hn]
 
-/-- `chafaiDensity f n` is continuous on `[0, ∞)` for a completely monotone `f`. -/
-lemma continuousOn_chafaiDensity (hcm : IsCompletelyMonotone f) (n : ℕ) :
+/-- `chafaiDensity f n` is continuous on `[0, ∞)` when `f` has `n` continuous derivatives
+there. -/
+lemma continuousOn_chafaiDensity {n : ℕ}
+    (hf : ContDiffOn ℝ (n : WithTop ℕ∞) f (Ici 0)) :
     ContinuousOn (chafaiDensity f n) (Ici 0) := by
   by_cases hn : n = 0
   · subst n
@@ -83,7 +85,7 @@ lemma continuousOn_chafaiDensity (hcm : IsCompletelyMonotone f) (n : ℕ) :
     funext (chafaiDensity_of_ne_zero hn f)
   rw [heq]
   exact (continuousOn_const.mul ((continuousOn_pow _).mono fun _ _ => trivial)).mul
-    (hcm.contDiffOn.continuousOn_iteratedDerivWithin (nat_le_top _) (uniqueDiffOn_Ici 0))
+    (hf.continuousOn_iteratedDerivWithin le_rfl (uniqueDiffOn_Ici 0))
 
 /-- The `n`-th approximating measure `σ_n` for the Bernstein proof, with density `ρ_n` on
 `(0, ∞)`. -/
@@ -102,20 +104,21 @@ lemma chafaiMeasure_apply (f : ℝ → ℝ) (n : ℕ) {s : Set ℝ} (hs : Measur
       ∫⁻ t in s, ENNReal.ofReal (chafaiDensity f n t) ∂(volume.restrict (Ioi 0)) := by
   rw [chafaiMeasure, withDensity_apply _ hs]
 
-/-- The density `ρ_n` is nonnegative for completely monotone functions on `[0, ∞)`. -/
-lemma chafaiDensity_nonneg (hcm : IsCompletelyMonotone f) (n : ℕ)
-    (t : ℝ) (ht : 0 ≤ t) : 0 ≤ chafaiDensity f n t := by
+/-- The density `ρ_n(t)` is nonnegative when `t ≥ 0` and the `n`-th derivative has the
+alternating sign at `t`. -/
+lemma chafaiDensity_nonneg {n : ℕ} {t : ℝ} (ht : 0 ≤ t)
+    (hsign : 0 ≤ (-1 : ℝ) ^ n * iteratedDerivWithin n f (Ici 0) t) :
+    0 ≤ chafaiDensity f n t := by
   simp only [chafaiDensity]
   split_ifs with hn
   · exact le_refl 0
-  · have hcm_sign := hcm.neg_one_pow_mul_iteratedDerivWithin_nonneg n ht
-    have hfact_pos : (0 : ℝ) < ↑(Nat.factorial (n - 1)) :=
+  · have hfact_pos : (0 : ℝ) < ↑(Nat.factorial (n - 1)) :=
       Nat.cast_pos.mpr (Nat.factorial_pos _)
     calc (-1 : ℝ) ^ n / ↑(Nat.factorial (n - 1)) * t ^ (n - 1) *
           iteratedDerivWithin n f (Ici 0) t
         = t ^ (n - 1) / ↑(Nat.factorial (n - 1)) *
           ((-1 : ℝ) ^ n * iteratedDerivWithin n f (Ici 0) t) := by field_simp
-      _ ≥ 0 := mul_nonneg (div_nonneg (pow_nonneg ht _) hfact_pos.le) hcm_sign
+      _ ≥ 0 := mul_nonneg (div_nonneg (pow_nonneg ht _) hfact_pos.le) hsign
 
 /-- For `n = 1`, the density simplifies to `-f'(t)`. -/
 @[simp] lemma chafaiDensity_one (t : ℝ) :
@@ -295,7 +298,8 @@ private lemma chafaiDensity_ibp_identity (f : ℝ → ℝ) (hcm : IsCompletelyMo
     fun t ht => (hasDerivAt_pow (m + 1) t).mul ((hg_deriv t ht.1).const_mul c)
   have hcm_int : ∀ k, k ≠ 0 → IntervalIntegrable (fun t => chafaiDensity f k t) volume 0 T := by
     intro k hk; apply ContinuousOn.intervalIntegrable; rw [huIcc]
-    exact (continuousOn_chafaiDensity hcm k).mono Icc_subset_Ici_self
+    exact (continuousOn_chafaiDensity (n := k)
+      ((hcm.contDiffOn).of_le (nat_le_top k))).mono Icc_subset_Ici_self
   have hF'_eq : ∀ t, ↑(m + 1) * t ^ m * (c * g t) + t ^ (m + 1) * (c * g' t) =
       chafaiDensity f (m + 2) t - chafaiDensity f (m + 1) t := by
     intro t
@@ -351,6 +355,12 @@ lemma chafaiMeasure_zero (f : ℝ → ℝ) : chafaiMeasure f 0 = 0 := by
   rw [withDensity_apply _ hs]
   simp
 
+/-- The rescaled Chafaï measure on the target type `ℝ≥0` shares the `n = 0` zero convention:
+`chafaiRescaled f 0 = 0`, as the pushforward of the zero measure. -/
+@[simp]
+lemma chafaiRescaled_zero (f : ℝ → ℝ) : chafaiRescaled f 0 = 0 := by
+  rw [chafaiRescaled_eq_map, chafaiMeasure_zero, Measure.map_zero]
+
 private lemma integral_chafaiDensity_one_eq (f : ℝ → ℝ) (hcm : IsCompletelyMonotone f)
     (T : ℝ) (hT : 0 < T) :
     ∫ t in (0 : ℝ)..T, chafaiDensity f 1 t = f 0 - f T := by
@@ -385,7 +395,8 @@ private lemma chafaiDensity_integrableOn_Ioi_of_tendsto (f : ℝ → ℝ)
     (hcm : IsCompletelyMonotone f) (n : ℕ) (hn : 1 ≤ n) (L : ℝ)
     (hL : Tendsto f atTop (nhds L)) :
     IntegrableOn (chafaiDensity f n) (Ioi 0) := by
-  have hcont : ContinuousOn (chafaiDensity f n) (Ici 0) := continuousOn_chafaiDensity hcm n
+  have hcont : ContinuousOn (chafaiDensity f n) (Ici 0) :=
+    continuousOn_chafaiDensity (n := n) ((hcm.contDiffOn).of_le (nat_le_top n))
   apply integrableOn_Ioi_of_intervalIntegral_norm_bounded (f 0 - L) 0
     (l := atTop) (b := id)
   · intro T
@@ -400,7 +411,9 @@ private lemma chafaiDensity_integrableOn_Ioi_of_tendsto (f : ℝ → ℝ)
           apply ae_of_all
           intro t ht
           rw [uIoc_of_le hT.le] at ht
-          rw [Real.norm_eq_abs, abs_of_nonneg (chafaiDensity_nonneg hcm n t ht.1.le)]
+          rw [Real.norm_eq_abs,
+            abs_of_nonneg (chafaiDensity_nonneg ht.1.le
+              (hcm.neg_one_pow_mul_iteratedDerivWithin_nonneg n ht.1.le))]
       _ ≤ f 0 - L := integral_chafaiDensity_le_tendsto_sub f hcm n hn L hL T hT
 
 private lemma chafaiMeasure_mass_le_of_tendsto (f : ℝ → ℝ)
@@ -413,7 +426,7 @@ private lemma chafaiMeasure_mass_le_of_tendsto (f : ℝ → ℝ)
   simp only [Measure.restrict_univ]
   rw [← ofReal_integral_eq_lintegral_ofReal hint
     ((ae_restrict_mem measurableSet_Ioi).mono fun t (ht : 0 < t) =>
-      chafaiDensity_nonneg hcm n t ht.le)]
+      chafaiDensity_nonneg ht.le (hcm.neg_one_pow_mul_iteratedDerivWithin_nonneg n ht.le))]
   exact ENNReal.ofReal_le_ofReal
     (le_of_tendsto (intervalIntegral_tendsto_integral_Ioi 0 hint tendsto_id)
       (eventually_atTop.mpr ⟨1, fun T hT =>

--- a/TauCeti/Analysis/CompletelyMonotone/BernsteinMeasures.lean
+++ b/TauCeti/Analysis/CompletelyMonotone/BernsteinMeasures.lean
@@ -212,7 +212,7 @@ lemma bernstein_kernel_le_one {n : ℕ} {x p : ℝ} (hx : 0 ≤ x) (hp : 0 ≤ p
 
 /-- The Bernstein kernel as a bundled bounded continuous test function of the nonnegative
 variable `p`, for fixed `n` and nonnegative `x`. -/
-noncomputable abbrev bernsteinKernelBCF (n : ℕ) {x : ℝ} (hx : 0 ≤ x) : ℝ≥0 →ᵇ ℝ where
+noncomputable def bernsteinKernelBCF (n : ℕ) {x : ℝ} (hx : 0 ≤ x) : ℝ≥0 →ᵇ ℝ where
   toFun := fun p => bernstein_kernel n x (p : ℝ)
   continuous_toFun := (continuous_bernstein_kernel n x).comp continuous_subtype_val
   map_bounded' :=
@@ -227,7 +227,8 @@ noncomputable abbrev bernsteinKernelBCF (n : ℕ) {x : ℝ} (hx : 0 ≤ x) : ℝ
 /-- The bundled Bernstein kernel evaluates to the unbundled kernel on `ℝ≥0`. -/
 @[simp]
 lemma bernsteinKernelBCF_apply (n : ℕ) {x : ℝ} (hx : 0 ≤ x) (p : ℝ≥0) :
-    bernsteinKernelBCF n hx p = bernstein_kernel n x (p : ℝ) := rfl
+    bernsteinKernelBCF n hx p = bernstein_kernel n x (p : ℝ) := by
+  rw [bernsteinKernelBCF]; rfl
 
 /-- The Bernstein kernel is measurable in `p` for fixed `n` and `x`. -/
 lemma measurable_bernstein_kernel (n : ℕ) (x : ℝ) : Measurable (bernstein_kernel n x) := by

--- a/TauCeti/Analysis/CompletelyMonotone/BernsteinMeasures.lean
+++ b/TauCeti/Analysis/CompletelyMonotone/BernsteinMeasures.lean
@@ -27,9 +27,10 @@ These build on the `IsCompletelyMonotone` API in `CompletelyMonotone/Basic.lean`
 * `TauCeti.bernstein_kernel`, `TauCeti.continuous_bernstein_kernel`,
   `TauCeti.bernstein_kernel_nonneg`, `TauCeti.bernstein_kernel_le_one`,
   `TauCeti.bernsteinKernelBCF`, `TauCeti.bernsteinKernelBCF_apply`,
+  `TauCeti.laplaceKernelBCF`, `TauCeti.laplaceKernelBCF_apply`,
   `TauCeti.bernstein_kernel_tendsto`: the rescaled Laplace kernel, its bundled
-  bounded-continuous `p`-dependence on the nonnegative half-line, and its pointwise limit
-  `e^{-xp}`.
+  bounded-continuous `p`-dependence on the nonnegative half-line, and its bundled pointwise
+  limit `e^{-xp}`.
 * `TauCeti.chafaiRescaled`, `TauCeti.chafaiRescaled_mass_eq`: the `ℝ≥0`-valued pushed-forward
   measures and mass preservation.
 * `TauCeti.chafaiMeasure_finite_mass`, `TauCeti.chafaiRescaled_finite_mass`: finiteness and the
@@ -229,6 +230,30 @@ noncomputable def bernsteinKernelBCF (n : ℕ) {x : ℝ} (hx : 0 ≤ x) : ℝ≥
 lemma bernsteinKernelBCF_apply (n : ℕ) {x : ℝ} (hx : 0 ≤ x) (p : ℝ≥0) :
     bernsteinKernelBCF n hx p = bernstein_kernel n x (p : ℝ) := by
   rw [bernsteinKernelBCF]; rfl
+
+/-- The limiting Laplace kernel as a bundled bounded continuous test function of the
+nonnegative variable `p`, for fixed nonnegative `x`. -/
+noncomputable def laplaceKernelBCF {x : ℝ} (hx : 0 ≤ x) : ℝ≥0 →ᵇ ℝ where
+  toFun := fun p => Real.exp (-(x * (p : ℝ)))
+  continuous_toFun := Real.continuous_exp.comp ((continuous_const.mul continuous_subtype_val).neg)
+  map_bounded' :=
+    ⟨1, fun p q => by
+      rw [Real.dist_eq]
+      have hp0 : 0 < Real.exp (-(x * (p : ℝ))) := Real.exp_pos _
+      have hp1 : Real.exp (-(x * (p : ℝ))) ≤ 1 := by
+        rw [Real.exp_le_one_iff]
+        exact neg_nonpos.mpr (mul_nonneg hx p.2)
+      have hq0 : 0 < Real.exp (-(x * (q : ℝ))) := Real.exp_pos _
+      have hq1 : Real.exp (-(x * (q : ℝ))) ≤ 1 := by
+        rw [Real.exp_le_one_iff]
+        exact neg_nonpos.mpr (mul_nonneg hx q.2)
+      exact abs_sub_le_iff.mpr ⟨by linarith, by linarith⟩⟩
+
+/-- The bundled limiting Laplace kernel evaluates to the usual exponential kernel on `ℝ≥0`. -/
+@[simp]
+lemma laplaceKernelBCF_apply {x : ℝ} (hx : 0 ≤ x) (p : ℝ≥0) :
+    laplaceKernelBCF hx p = Real.exp (-(x * (p : ℝ))) := by
+  rw [laplaceKernelBCF]; rfl
 
 /-- The Bernstein kernel is measurable in `p` for fixed `n` and `x`. -/
 lemma measurable_bernstein_kernel (n : ℕ) (x : ℝ) : Measurable (bernstein_kernel n x) := by

--- a/TauCeti/Analysis/CompletelyMonotone/BernsteinMeasures.lean
+++ b/TauCeti/Analysis/CompletelyMonotone/BernsteinMeasures.lean
@@ -1,0 +1,453 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+module
+
+public import Mathlib.Analysis.SpecialFunctions.Complex.LogBounds
+public import TauCeti.Analysis.CompletelyMonotone.Integral
+
+/-!
+# Approximating measures for Bernstein's theorem
+
+The Chafaï-style construction of the representing measure in Bernstein's theorem. For a
+completely monotone `f` the densities `ρ_n(t) = (-1)ⁿ/(n-1)! · tⁿ⁻¹ · f⁽ⁿ⁾(t)` are nonnegative on
+`[0, ∞)`, the positive support used by `chafaiMeasure`; they define finite measures whose total
+mass is bounded by `f(0) - f(∞)`, and after the rescaling `t ↦ (n-1)/t` give measures
+`chafaiRescaled f n` on `ℝ≥0` whose Laplace kernels `(1 - xp/(n-1))₊ⁿ⁻¹` converge to `e^{-xp}`.
+These feed the Prokhorov tightness argument.
+
+These build on the `IsCompletelyMonotone` API in `CompletelyMonotone/Basic.lean` and
+`CompletelyMonotone/Integral.lean`.
+
+## Main declarations
+
+* `TauCeti.chafaiDensity`, `TauCeti.chafaiMeasure`: the approximating densities and measures.
+* `TauCeti.bernstein_kernel`, `TauCeti.bernstein_kernel_tendsto`: the rescaled Laplace kernel and
+  its pointwise limit `e^{-xp}`.
+* `TauCeti.chafaiRescaled`, `TauCeti.chafaiRescaled_mass_eq`: the `ℝ≥0`-valued pushed-forward
+  measures and mass preservation.
+* `TauCeti.chafaiMeasure_finite_mass`: finiteness and the total-mass bound `≤ f(0) - L`.
+
+## References
+
+* Roadmap: `TauCetiRoadmap/OneParameterSemigroups/README.md`, Part B (Bernstein theorem milestone).
+
+* D. Chafaï, *Aspects of the Bernstein theorem* (2013).
+* R. Schilling, R. Song, Z. Vondraček, *Bernstein Functions* (de Gruyter, 2nd ed. 2012), Ch. 1.
+-/
+
+public section
+
+open MeasureTheory Set intervalIntegral Filter
+open scoped ContDiff NNReal Topology
+
+namespace TauCeti
+
+variable {f : ℝ → ℝ}
+
+/-! ## Smoothness-index helpers -/
+
+private lemma nat_le_top (n : ℕ) : (n : WithTop ℕ∞) ≤ ∞ := by exact_mod_cast le_top
+
+/-! ## Measure construction for Bernstein -/
+
+/-- The density `ρ_n(t) = (-1)ⁿ/(n-1)! · tⁿ⁻¹ · f⁽ⁿ⁾(t)` for nonzero `n`, used for the `n`-th
+approximating measure in the Bernstein proof (Chafaï 2013). By convention the `n = 0` branch
+returns `0`. -/
+noncomputable def chafaiDensity (f : ℝ → ℝ) (n : ℕ) (t : ℝ) : ℝ :=
+  if n = 0 then 0
+  else (-1 : ℝ) ^ n / (Nat.factorial (n - 1) : ℝ) *
+    t ^ (n - 1) * iteratedDerivWithin n f (Ici 0) t
+
+/-- `chafaiDensity f 0 = 0`. -/
+@[simp] lemma chafaiDensity_zero (f : ℝ → ℝ) (t : ℝ) : chafaiDensity f 0 t = 0 := by
+  rw [chafaiDensity, if_pos rfl]
+
+/-- The defining formula for `chafaiDensity` at a nonzero order. -/
+lemma chafaiDensity_of_ne_zero {n : ℕ} (hn : n ≠ 0) (f : ℝ → ℝ) (t : ℝ) :
+    chafaiDensity f n t = (-1 : ℝ) ^ n / (Nat.factorial (n - 1) : ℝ) *
+      t ^ (n - 1) * iteratedDerivWithin n f (Ici 0) t := by
+  rw [chafaiDensity, if_neg hn]
+
+/-- `chafaiDensity f n` is continuous on `[0, ∞)` for a completely monotone `f`. -/
+lemma continuousOn_chafaiDensity (hcm : IsCompletelyMonotone f) (n : ℕ) :
+    ContinuousOn (chafaiDensity f n) (Ici 0) := by
+  by_cases hn : n = 0
+  · subst n
+    have hzero : chafaiDensity f 0 = fun _ : ℝ => 0 := funext (chafaiDensity_zero f)
+    rw [hzero]
+    exact continuousOn_const
+  have heq : chafaiDensity f n = fun t => (-1 : ℝ) ^ n / (Nat.factorial (n - 1) : ℝ) *
+      t ^ (n - 1) * iteratedDerivWithin n f (Ici 0) t :=
+    funext (chafaiDensity_of_ne_zero hn f)
+  rw [heq]
+  exact (continuousOn_const.mul ((continuousOn_pow _).mono fun _ _ => trivial)).mul
+    (hcm.contDiffOn.continuousOn_iteratedDerivWithin (nat_le_top _) (uniqueDiffOn_Ici 0))
+
+/-- The `n`-th approximating measure `σ_n` for the Bernstein proof, with density `ρ_n` on
+`(0, ∞)`. -/
+noncomputable def chafaiMeasure (f : ℝ → ℝ) (n : ℕ) : Measure ℝ :=
+  (volume.restrict (Ioi 0)).withDensity (fun t => ENNReal.ofReal (chafaiDensity f n t))
+
+/-- `chafaiMeasure` as a `withDensity`, exposed as a lemma rather than an unfoldable body. -/
+lemma chafaiMeasure_eq_withDensity (f : ℝ → ℝ) (n : ℕ) :
+    chafaiMeasure f n =
+      (volume.restrict (Ioi 0)).withDensity (fun t => ENNReal.ofReal (chafaiDensity f n t)) := by
+  rw [chafaiMeasure]
+
+/-- The mass `chafaiMeasure f n` assigns to a measurable set, as a set lintegral of the density. -/
+lemma chafaiMeasure_apply (f : ℝ → ℝ) (n : ℕ) {s : Set ℝ} (hs : MeasurableSet s) :
+    chafaiMeasure f n s =
+      ∫⁻ t in s, ENNReal.ofReal (chafaiDensity f n t) ∂(volume.restrict (Ioi 0)) := by
+  rw [chafaiMeasure, withDensity_apply _ hs]
+
+/-- The density `ρ_n` is nonnegative for completely monotone functions on `[0, ∞)`. -/
+lemma chafaiDensity_nonneg (hcm : IsCompletelyMonotone f) (n : ℕ)
+    (t : ℝ) (ht : 0 ≤ t) : 0 ≤ chafaiDensity f n t := by
+  simp only [chafaiDensity]
+  split_ifs with hn
+  · exact le_refl 0
+  · have hcm_sign := hcm.neg_one_pow_mul_iteratedDerivWithin_nonneg n ht
+    have hfact_pos : (0 : ℝ) < ↑(Nat.factorial (n - 1)) :=
+      Nat.cast_pos.mpr (Nat.factorial_pos _)
+    calc (-1 : ℝ) ^ n / ↑(Nat.factorial (n - 1)) * t ^ (n - 1) *
+          iteratedDerivWithin n f (Ici 0) t
+        = t ^ (n - 1) / ↑(Nat.factorial (n - 1)) *
+          ((-1 : ℝ) ^ n * iteratedDerivWithin n f (Ici 0) t) := by field_simp
+      _ ≥ 0 := mul_nonneg (div_nonneg (pow_nonneg ht _) hfact_pos.le) hcm_sign
+
+/-- For `n = 1`, the density simplifies to `-f'(t)`. -/
+@[simp] lemma chafaiDensity_one (t : ℝ) :
+    chafaiDensity f 1 t = -iteratedDerivWithin 1 f (Ici 0) t := by
+  simp [chafaiDensity]
+
+/-- Difference of two successive Chafaï densities, in the algebraic form used by integration by
+parts. -/
+private lemma chafaiDensity_succ_succ_sub_succ (f : ℝ → ℝ) (m : ℕ) (t : ℝ) :
+    chafaiDensity f (m + 2) t - chafaiDensity f (m + 1) t =
+      ↑(m + 1) * t ^ m *
+          (((-1 : ℝ) ^ (m + 2) / ↑(m + 1).factorial) *
+            iteratedDerivWithin (m + 1) f (Ici 0) t) +
+        t ^ (m + 1) *
+          (((-1 : ℝ) ^ (m + 2) / ↑(m + 1).factorial) *
+            iteratedDerivWithin (m + 2) f (Ici 0) t) := by
+  have hm2 : m + 2 ≠ 0 := by omega
+  have hm1 : m + 1 ≠ 0 := by omega
+  have hdens_m2 :
+      chafaiDensity f (m + 2) t =
+        (-1 : ℝ) ^ (m + 2) / ((m + 1).factorial : ℝ) *
+          t ^ (m + 1) * iteratedDerivWithin (m + 2) f (Ici 0) t := by
+    rw [chafaiDensity_of_ne_zero hm2]
+    norm_num
+  have hdens_m1 :
+      chafaiDensity f (m + 1) t =
+        (-1 : ℝ) ^ (m + 1) / (m.factorial : ℝ) *
+          t ^ m * iteratedDerivWithin (m + 1) f (Ici 0) t := by
+    rw [chafaiDensity_of_ne_zero hm1]
+    norm_num
+  rw [hdens_m2, hdens_m1]
+  have hfact : ((m + 1).factorial : ℝ) = ((m + 1 : ℕ) : ℝ) * ↑m.factorial := by
+    rw [Nat.factorial_succ]
+    push_cast
+    ring
+  rw [hfact]
+  have hfact_ne : (m.factorial : ℝ) ≠ 0 := Nat.cast_ne_zero.mpr (Nat.factorial_ne_zero _)
+  have hsucc_ne : ((m : ℝ) + 1) ≠ 0 := by positivity
+  have hneg : (-1 : ℝ) ^ (m + 2) = (-1) ^ (m + 1) * (-1) := pow_succ (-1) (m + 1)
+  rw [hneg]
+  field_simp
+  ring
+
+/-! ## Rescaled measures and Prokhorov extraction -/
+
+/-- The Bernstein kernel `φ_n(x,p) = max(1 - xp/(n-1), 0)ⁿ⁻¹` for `n ≥ 2`. After the change of
+variable `p = (n-1)/t`, the Taylor integral kernel on `[0, T]` becomes `φ_n(x, p)`, which
+converges pointwise to `e^{-xp}` as `n → ∞` (the classical `(1-x/n)ⁿ → e^{-x}` limit). -/
+noncomputable def bernstein_kernel (n : ℕ) (x p : ℝ) : ℝ :=
+  if n ≤ 1 then 0 else (max (1 - x * p / (↑(n - 1) : ℝ)) 0) ^ (n - 1)
+
+/-- The Bernstein kernel vanishes for `n ≤ 1`. -/
+@[simp] lemma bernstein_kernel_of_le_one {n : ℕ} (hn : n ≤ 1) (x p : ℝ) :
+    bernstein_kernel n x p = 0 := by
+  rw [bernstein_kernel, if_pos hn]
+
+/-- The defining formula for the Bernstein kernel at `2 ≤ n`. -/
+lemma bernstein_kernel_of_two_le {n : ℕ} (hn : 2 ≤ n) (x p : ℝ) :
+    bernstein_kernel n x p = (max (1 - x * p / (↑(n - 1) : ℝ)) 0) ^ (n - 1) := by
+  have hnle : ¬ n ≤ 1 := by omega
+  rw [bernstein_kernel, if_neg hnle]
+
+/-- The Bernstein kernel is nonnegative. -/
+@[simp] lemma bernstein_kernel_nonneg (n : ℕ) (x p : ℝ) : 0 ≤ bernstein_kernel n x p := by
+  rw [bernstein_kernel]; split_ifs <;> positivity
+
+/-- The Bernstein kernel is measurable in `p` for fixed `n` and `x`. -/
+lemma measurable_bernstein_kernel (n : ℕ) (x : ℝ) : Measurable (bernstein_kernel n x) := by
+  unfold bernstein_kernel; split_ifs
+  · exact measurable_const
+  · fun_prop
+
+/-- **Pointwise convergence of the Bernstein kernel** to the Laplace kernel:
+`φ_n(x,p) → e^{-xp}` as `n → ∞`. -/
+lemma bernstein_kernel_tendsto (x p : ℝ) :
+    Tendsto (fun n : ℕ => bernstein_kernel n x p) atTop (nhds (Real.exp (-(x * p)))) := by
+  set g := fun n : ℕ => (1 + (-(x * p)) / (↑n : ℝ)) ^ n with hg_def
+  have hg_tendsto : Tendsto g atTop (nhds (Real.exp (-(x * p)))) :=
+    Real.tendsto_one_add_div_pow_exp (-(x * p))
+  have hshift : Tendsto (fun n : ℕ => g (n - 1)) atTop (nhds (Real.exp (-(x * p)))) :=
+    hg_tendsto.comp (tendsto_atTop_atTop.mpr (fun b => ⟨b + 1, fun n hn => by omega⟩))
+  apply Tendsto.congr' _ hshift
+  rw [eventuallyEq_iff_exists_mem]
+  refine ⟨{n : ℕ | n ≥ Nat.ceil (x * p) + 2}, mem_atTop _, ?_⟩
+  intro n hn
+  simp only [Set.mem_setOf_eq] at hn
+  simp only [bernstein_kernel, hg_def]
+  have hn1 : ¬(n ≤ 1) := by omega
+  simp only [hn1, ite_false]
+  have hn1_pos : (0 : ℝ) < ↑(n - 1) := Nat.cast_pos.mpr (by omega)
+  have hn1_ge : x * p ≤ ↑(n - 1) := by
+    calc x * p ≤ ↑(Nat.ceil (x * p)) := Nat.le_ceil _
+    _ ≤ ↑(n - 1) := by exact_mod_cast (by omega : Nat.ceil (x * p) ≤ n - 1)
+  congr 1
+  rw [max_eq_left]
+  · ring
+  · rw [sub_nonneg]; exact div_le_one_of_le₀ hn1_ge hn1_pos.le
+
+/-- The rescaling map `t ↦ max ((n-1)/t) 0`, valued in `ℝ≥0`. -/
+noncomputable def chafaiRescaling (n : ℕ) (t : ℝ) : ℝ≥0 :=
+  Real.toNNReal (((n : ℝ) - 1) / t)
+
+/-- The rescaling map `t ↦ max ((n-1)/t) 0`, valued in `ℝ≥0`, is measurable. -/
+lemma chafaiRescaling_measurable (n : ℕ) :
+    Measurable (chafaiRescaling n) :=
+  continuous_real_toNNReal.measurable.comp (measurable_const.div measurable_id)
+
+/-- On the positive part of the source, the `ℝ≥0` rescaling coerces back to `(n-1)/t`. -/
+lemma chafaiRescaling_coe_of_pos {n : ℕ} (hn : 1 ≤ n) {t : ℝ} (ht : 0 < t) :
+    (chafaiRescaling n t : ℝ) = ((n : ℝ) - 1) / t := by
+  have hnum : 0 ≤ (n : ℝ) - 1 := by
+    exact sub_nonneg.mpr (by exact_mod_cast hn)
+  have hnonneg : 0 ≤ ((n : ℝ) - 1) / t := div_nonneg hnum ht.le
+  simp [chafaiRescaling, Real.coe_toNNReal', max_eq_left hnonneg]
+
+/-- The rescaled measure `σ̃_n`: pushforward of `chafaiMeasure f n` under the `ℝ≥0` rescaling. -/
+noncomputable def chafaiRescaled (f : ℝ → ℝ) (n : ℕ) : Measure ℝ≥0 :=
+  Measure.map (chafaiRescaling n) (chafaiMeasure f n)
+
+/-- `chafaiRescaled` as a pushforward, exposed as a lemma rather than an unfoldable body. -/
+lemma chafaiRescaled_eq_map (f : ℝ → ℝ) (n : ℕ) :
+    chafaiRescaled f n = Measure.map (chafaiRescaling n) (chafaiMeasure f n) := by
+  rw [chafaiRescaled]
+
+/-- The mass `chafaiRescaled f n` assigns to a measurable set, as the pushforward formula. -/
+lemma chafaiRescaled_apply (f : ℝ → ℝ) (n : ℕ) {s : Set ℝ≥0} (hs : MeasurableSet s) :
+    chafaiRescaled f n s = chafaiMeasure f n ((chafaiRescaling n) ⁻¹' s) := by
+  rw [chafaiRescaled, Measure.map_apply (chafaiRescaling_measurable n) hs]
+
+/-- Integrating against `chafaiRescaled f n` is integrating the pullback along the Chafaï
+rescaling against `chafaiMeasure f n`. -/
+lemma chafaiRescaled_integral (f : ℝ → ℝ) (n : ℕ) {g : ℝ≥0 → ℝ}
+    (hg : AEStronglyMeasurable g (chafaiRescaled f n)) :
+    ∫ x, g x ∂(chafaiRescaled f n) =
+      ∫ t, g (chafaiRescaling n t) ∂(chafaiMeasure f n) := by
+  rw [chafaiRescaled_eq_map] at hg ⊢
+  exact MeasureTheory.integral_map (chafaiRescaling_measurable n).aemeasurable hg
+
+/-- `chafaiMeasure f n` lives on `(0, ∞)`: its complement has zero mass. -/
+lemma chafaiMeasure_compl_Ioi (f : ℝ → ℝ) (n : ℕ) :
+    (chafaiMeasure f n) (Ioi 0)ᶜ = 0 := by
+  unfold chafaiMeasure
+  rw [withDensity_apply _ (measurableSet_Ioi.compl)]
+  apply setLIntegral_measure_zero
+  rw [Measure.restrict_apply (measurableSet_Ioi.compl)]
+  have : (Ioi (0 : ℝ))ᶜ ∩ Ioi 0 = ∅ := by ext x; simp [Set.mem_Ioi]
+  rw [this, measure_empty]
+
+/-- Pushforward preserves total mass. -/
+lemma chafaiRescaled_mass_eq (f : ℝ → ℝ) (n : ℕ) :
+    (chafaiRescaled f n) univ = (chafaiMeasure f n) univ := by
+  unfold chafaiRescaled
+  rw [Measure.map_apply (chafaiRescaling_measurable n) MeasurableSet.univ, Set.preimage_univ]
+
+/-- **IBP identity** for the CM density:
+`∫₀ᵀ ρ_{m+2}(t) dt = B_{m+2}(T) + ∫₀ᵀ ρ_{m+1}(t) dt`. -/
+private lemma chafaiDensity_ibp_identity (f : ℝ → ℝ) (hcm : IsCompletelyMonotone f)
+    (m : ℕ) (T : ℝ) (hT : 0 < T) :
+    ∫ t in (0 : ℝ)..T, chafaiDensity f (m + 2) t =
+    (-1 : ℝ) ^ (m + 2) * T ^ (m + 1) / ↑(m + 1).factorial *
+      iteratedDerivWithin (m + 1) f (Ici 0) T +
+    ∫ t in (0 : ℝ)..T, chafaiDensity f (m + 1) t := by
+  set g := iteratedDerivWithin (m + 1) f (Ici 0)
+  set g' := iteratedDerivWithin (m + 2) f (Ici 0)
+  set c : ℝ := (-1) ^ (m + 2) / ↑(m + 1).factorial
+  set F := fun t : ℝ => t ^ (m + 1) * (c * g t)
+  have hg_cont : ContinuousOn g (Ici 0) :=
+    hcm.contDiffOn.continuousOn_iteratedDerivWithin (nat_le_top _) (uniqueDiffOn_Ici 0)
+  have hg_deriv : ∀ t, 0 < t → HasDerivAt g (g' t) t :=
+    fun t ht => hcm.hasDerivAt_iteratedDerivWithin_succ (m + 1) ht
+  have huIcc : uIcc (0 : ℝ) T = Icc 0 T := uIcc_of_le hT.le
+  have hF_cont : ContinuousOn F (Icc 0 T) :=
+    ((continuous_pow _).continuousOn).mul
+      (continuousOn_const.mul (hg_cont.mono Icc_subset_Ici_self))
+  have hF_deriv : ∀ t ∈ Ioo 0 T, HasDerivAt F
+      (↑(m + 1) * t ^ m * (c * g t) + t ^ (m + 1) * (c * g' t)) t :=
+    fun t ht => (hasDerivAt_pow (m + 1) t).mul ((hg_deriv t ht.1).const_mul c)
+  have hcm_int : ∀ k, k ≠ 0 → IntervalIntegrable (fun t => chafaiDensity f k t) volume 0 T := by
+    intro k hk; apply ContinuousOn.intervalIntegrable; rw [huIcc]
+    exact (continuousOn_chafaiDensity hcm k).mono Icc_subset_Ici_self
+  have hF'_eq : ∀ t, ↑(m + 1) * t ^ m * (c * g t) + t ^ (m + 1) * (c * g' t) =
+      chafaiDensity f (m + 2) t - chafaiDensity f (m + 1) t := by
+    intro t
+    simp only [g, g', c]
+    exact (chafaiDensity_succ_succ_sub_succ f m t).symm
+  have hF'_int : IntervalIntegrable
+      (fun t => ↑(m + 1) * t ^ m * (c * g t) + t ^ (m + 1) * (c * g' t)) volume 0 T :=
+    ((hcm_int _ (by omega)).sub (hcm_int _ (by omega))).congr fun t _ => (hF'_eq t).symm
+  have hftc := intervalIntegral.integral_eq_sub_of_hasDerivAt_of_le hT.le hF_cont hF_deriv hF'_int
+  have hstep1 : ∫ t in (0 : ℝ)..T,
+      (chafaiDensity f (m + 2) t - chafaiDensity f (m + 1) t) = F T - F 0 := by
+    rw [← hftc]
+    exact intervalIntegral.integral_congr_ae
+      (Filter.Eventually.of_forall fun t _ => (hF'_eq t).symm)
+  have hm1 : m + 1 ≠ 0 := by omega
+  have hF0 : F 0 = 0 := by simp [F, zero_pow hm1]
+  rw [hF0, sub_zero] at hstep1
+  rw [intervalIntegral.integral_sub (hcm_int _ (by omega)) (hcm_int _ (by omega))] at hstep1
+  suffices hgoal : (-1 : ℝ) ^ (m + 2) * T ^ (m + 1) / ↑(m + 1).factorial * g T = F T by linarith
+  simp only [F, c]; ring
+
+/-- Monotonicity of the finite-interval Chafaï-density masses in the order:
+`∫₀ᵀ dₖ ≤ ∫₀ᵀ dₖ₋₁` for `2 ≤ k`. This is the exported integration-by-parts consequence
+(the raw IBP identity `chafaiDensity_ibp_identity` is private); it is the per-step density
+mass-monotonicity bound consumed by the Bernstein-identity assembly. -/
+lemma integral_chafaiDensity_le_pred (f : ℝ → ℝ) (hcm : IsCompletelyMonotone f)
+    (k : ℕ) (hk : 2 ≤ k) (T : ℝ) (hT : 0 < T) :
+    ∫ t in (0 : ℝ)..T, chafaiDensity f k t ≤ ∫ t in (0 : ℝ)..T, chafaiDensity f (k - 1) t := by
+  obtain ⟨m, rfl⟩ : ∃ m, k = m + 2 := ⟨k - 2, by omega⟩
+  have hsub : m + 2 - 1 = m + 1 := by omega
+  simp only [hsub]
+  have hibp := chafaiDensity_ibp_identity f hcm m T hT
+  set B := (-1 : ℝ) ^ (m + 2) * T ^ (m + 1) / ↑(m + 1).factorial *
+    iteratedDerivWithin (m + 1) f (Ici 0) T
+  have hB : B ≤ 0 := by
+    have h_neg : (-1 : ℝ) ^ (m + 2) * iteratedDerivWithin (m + 1) f (Ici 0) T ≤ 0 := by
+      have : (-1 : ℝ) ^ (m + 2) = (-1) ^ (m + 1) * (-1) := pow_succ (-1) (m + 1)
+      rw [this]; nlinarith [hcm.neg_one_pow_mul_iteratedDerivWithin_nonneg (m + 1) hT.le]
+    suffices B = T ^ (m + 1) / ↑(m + 1).factorial *
+        ((-1 : ℝ) ^ (m + 2) * iteratedDerivWithin (m + 1) f (Ici 0) T) by
+      rw [this]
+      exact mul_nonpos_of_nonneg_of_nonpos
+        (div_nonneg (pow_nonneg hT.le _) (Nat.cast_nonneg _)) h_neg
+    simp only [B]; ring
+  linarith
+
+/-- The public `n = 0` convention for Chafaï measures: the zeroth approximating measure is
+zero. -/
+@[simp]
+lemma chafaiMeasure_zero (f : ℝ → ℝ) : chafaiMeasure f 0 = 0 := by
+  rw [chafaiMeasure_eq_withDensity]
+  ext s hs
+  rw [withDensity_apply _ hs]
+  simp
+
+private lemma integral_chafaiDensity_one_eq (f : ℝ → ℝ) (hcm : IsCompletelyMonotone f)
+    (T : ℝ) (hT : 0 < T) :
+    ∫ t in (0 : ℝ)..T, chafaiDensity f 1 t = f 0 - f T := by
+  have h1 : ∫ t in (0 : ℝ)..T, chafaiDensity f 1 t =
+      ∫ t in (0 : ℝ)..T, -iteratedDerivWithin 1 f (Ici 0) t :=
+    intervalIntegral.integral_congr_ae
+      (Filter.Eventually.of_forall fun t _ => chafaiDensity_one t)
+  rw [h1, ← hcm.integral_neg_deriv_Ici T hT.le, hcm.integral_mass T hT.le]
+
+private lemma integral_chafaiDensity_le_sub (f : ℝ → ℝ) (hcm : IsCompletelyMonotone f)
+    (j : ℕ) (hj : 1 ≤ j) (T : ℝ) (hT : 0 < T) :
+    ∫ t in (0 : ℝ)..T, chafaiDensity f j t ≤ f 0 - f T := by
+  induction j with
+  | zero => omega
+  | succ p ih =>
+    by_cases hp : p = 0
+    · subst hp
+      exact le_of_eq (integral_chafaiDensity_one_eq f hcm T hT)
+    · calc ∫ t in (0 : ℝ)..T, chafaiDensity f (p + 1) t
+          ≤ ∫ t in (0 : ℝ)..T, chafaiDensity f p t := by
+            simpa using integral_chafaiDensity_le_pred f hcm (p + 1) (by omega) T hT
+        _ ≤ f 0 - f T := ih (Nat.one_le_iff_ne_zero.mpr hp)
+
+private lemma integral_chafaiDensity_le_tendsto_sub (f : ℝ → ℝ)
+    (hcm : IsCompletelyMonotone f) (n : ℕ) (hn : 1 ≤ n) (L : ℝ)
+    (hL : Tendsto f atTop (nhds L)) (T : ℝ) (hT : 0 < T) :
+    ∫ t in (0 : ℝ)..T, chafaiDensity f n t ≤ f 0 - L := by
+  linarith [integral_chafaiDensity_le_sub f hcm n hn T hT,
+    hcm.le_of_tendsto_atTop hL hT.le]
+
+private lemma chafaiDensity_integrableOn_Ioi_of_tendsto (f : ℝ → ℝ)
+    (hcm : IsCompletelyMonotone f) (n : ℕ) (hn : 1 ≤ n) (L : ℝ)
+    (hL : Tendsto f atTop (nhds L)) :
+    IntegrableOn (chafaiDensity f n) (Ioi 0) := by
+  have hcont : ContinuousOn (chafaiDensity f n) (Ici 0) := continuousOn_chafaiDensity hcm n
+  apply integrableOn_Ioi_of_intervalIntegral_norm_bounded (f 0 - L) 0
+    (l := atTop) (b := id)
+  · intro T
+    exact (hcont.mono Icc_subset_Ici_self).integrableOn_compact isCompact_Icc
+      |>.mono_set Ioc_subset_Icc_self
+  · exact tendsto_id
+  · filter_upwards [eventually_gt_atTop 0] with T hT
+    simp only [id]
+    calc ∫ t in (0 : ℝ)..T, ‖chafaiDensity f n t‖
+        = ∫ t in (0 : ℝ)..T, chafaiDensity f n t := by
+          apply intervalIntegral.integral_congr_ae
+          apply ae_of_all
+          intro t ht
+          rw [uIoc_of_le hT.le] at ht
+          rw [Real.norm_eq_abs, abs_of_nonneg (chafaiDensity_nonneg hcm n t ht.1.le)]
+      _ ≤ f 0 - L := integral_chafaiDensity_le_tendsto_sub f hcm n hn L hL T hT
+
+private lemma chafaiMeasure_mass_le_of_tendsto (f : ℝ → ℝ)
+    (hcm : IsCompletelyMonotone f) (n : ℕ) (hn : 1 ≤ n) (L : ℝ)
+    (hL : Tendsto f atTop (nhds L))
+    (hint : IntegrableOn (chafaiDensity f n) (Ioi 0)) :
+    (chafaiMeasure f n) univ ≤ ENNReal.ofReal (f 0 - L) := by
+  rw [chafaiMeasure_eq_withDensity]
+  rw [withDensity_apply _ MeasurableSet.univ]
+  simp only [Measure.restrict_univ]
+  rw [← ofReal_integral_eq_lintegral_ofReal hint
+    ((ae_restrict_mem measurableSet_Ioi).mono fun t (ht : 0 < t) =>
+      chafaiDensity_nonneg hcm n t ht.le)]
+  exact ENNReal.ofReal_le_ofReal
+    (le_of_tendsto (intervalIntegral_tendsto_integral_Ioi 0 hint tendsto_id)
+      (eventually_atTop.mpr ⟨1, fun T hT =>
+        integral_chafaiDensity_le_tendsto_sub f hcm n hn L hL T (by linarith)⟩))
+
+/-- **Total mass bound with a chosen limit**: `chafaiMeasure f n` is finite with total mass
+`≤ f(0) - L` whenever `f(t) → L` at infinity. -/
+lemma chafaiMeasure_finite_mass_of_tendsto (f : ℝ → ℝ) (hcm : IsCompletelyMonotone f)
+    (n : ℕ) (L : ℝ) (hL : Tendsto f atTop (nhds L)) :
+    IsFiniteMeasure (chafaiMeasure f n) ∧
+    (chafaiMeasure f n) univ ≤ ENNReal.ofReal (f 0 - L) := by
+  by_cases hn0 : n = 0
+  · subst n
+    rw [chafaiMeasure_zero]
+    exact ⟨inferInstance, by simp⟩
+  have hn : 1 ≤ n := Nat.one_le_iff_ne_zero.mpr hn0
+  have hint : IntegrableOn (chafaiDensity f n) (Ioi 0) :=
+    chafaiDensity_integrableOn_Ioi_of_tendsto f hcm n hn L hL
+  have hfin : IsFiniteMeasure (chafaiMeasure f n) := by
+    unfold chafaiMeasure
+    exact isFiniteMeasure_withDensity_ofReal hint.hasFiniteIntegral
+  have hmass : (chafaiMeasure f n) univ ≤ ENNReal.ofReal (f 0 - L) :=
+    chafaiMeasure_mass_le_of_tendsto f hcm n hn L hL hint
+  exact ⟨hfin, hmass⟩
+
+/-- **Natural total mass bound**: for a completely monotone `f`, the Chafaï measures are finite
+and uniformly bounded by `f(0) - L`, where `L` is the automatically obtained limit of `f` at
+infinity. -/
+lemma chafaiMeasure_finite_mass (f : ℝ → ℝ) (hcm : IsCompletelyMonotone f) :
+    ∃ L : ℝ, Tendsto f atTop (nhds L) ∧ 0 ≤ L ∧
+      ∀ n,
+        IsFiniteMeasure (chafaiMeasure f n) ∧
+        (chafaiMeasure f n) univ ≤ ENNReal.ofReal (f 0 - L) := by
+  obtain ⟨L, hL, hL_nn⟩ := hcm.tendsto_atTop
+  exact ⟨L, hL, hL_nn, fun n => chafaiMeasure_finite_mass_of_tendsto f hcm n L hL⟩
+
+end TauCeti

--- a/TauCeti/Analysis/CompletelyMonotone/BernsteinMeasures.lean
+++ b/TauCeti/Analysis/CompletelyMonotone/BernsteinMeasures.lean
@@ -212,8 +212,7 @@ lemma bernstein_kernel_le_one {n : ℕ} {x p : ℝ} (hx : 0 ≤ x) (hp : 0 ≤ p
 
 /-- The Bernstein kernel as a bundled bounded continuous test function of the nonnegative
 variable `p`, for fixed `n` and nonnegative `x`. -/
-@[expose]
-noncomputable def bernsteinKernelBCF (n : ℕ) {x : ℝ} (hx : 0 ≤ x) : ℝ≥0 →ᵇ ℝ where
+noncomputable abbrev bernsteinKernelBCF (n : ℕ) {x : ℝ} (hx : 0 ≤ x) : ℝ≥0 →ᵇ ℝ where
   toFun := fun p => bernstein_kernel n x (p : ℝ)
   continuous_toFun := (continuous_bernstein_kernel n x).comp continuous_subtype_val
   map_bounded' :=

--- a/TauCeti/Analysis/CompletelyMonotone/BernsteinMeasures.lean
+++ b/TauCeti/Analysis/CompletelyMonotone/BernsteinMeasures.lean
@@ -27,7 +27,8 @@ These build on the `IsCompletelyMonotone` API in `CompletelyMonotone/Basic.lean`
   its pointwise limit `e^{-xp}`.
 * `TauCeti.chafaiRescaled`, `TauCeti.chafaiRescaled_mass_eq`: the `ℝ≥0`-valued pushed-forward
   measures and mass preservation.
-* `TauCeti.chafaiMeasure_finite_mass`: finiteness and the total-mass bound `≤ f(0) - L`.
+* `TauCeti.chafaiMeasure_finite_mass`, `TauCeti.chafaiRescaled_finite_mass`: finiteness and the
+  total-mass bound `≤ f(0) - L`.
 
 ## References
 
@@ -322,27 +323,30 @@ private lemma chafaiDensity_ibp_identity (f : ℝ → ℝ) (hcm : IsCompletelyMo
   simp only [F, c]; ring
 
 /-- Monotonicity of the finite-interval Chafaï-density masses in the order:
-`∫₀ᵀ dₖ ≤ ∫₀ᵀ dₖ₋₁` for `2 ≤ k`. This is the exported integration-by-parts consequence
+`∫₀ᵀ dₖ ≤ ∫₀ᵀ dₖ₋₁` for `2 ≤ k` and `0 ≤ T`. This is the exported
+integration-by-parts consequence
 (the raw IBP identity `chafaiDensity_ibp_identity` is private); it is the per-step density
 mass-monotonicity bound consumed by the Bernstein-identity assembly. -/
 lemma integral_chafaiDensity_le_pred (f : ℝ → ℝ) (hcm : IsCompletelyMonotone f)
-    (k : ℕ) (hk : 2 ≤ k) (T : ℝ) (hT : 0 < T) :
+    (k : ℕ) (hk : 2 ≤ k) (T : ℝ) (hT : 0 ≤ T) :
     ∫ t in (0 : ℝ)..T, chafaiDensity f k t ≤ ∫ t in (0 : ℝ)..T, chafaiDensity f (k - 1) t := by
+  rcases hT.eq_or_lt with rfl | hT_pos
+  · simp
   obtain ⟨m, rfl⟩ : ∃ m, k = m + 2 := ⟨k - 2, by omega⟩
   have hsub : m + 2 - 1 = m + 1 := by omega
   simp only [hsub]
-  have hibp := chafaiDensity_ibp_identity f hcm m T hT
+  have hibp := chafaiDensity_ibp_identity f hcm m T hT_pos
   set B := (-1 : ℝ) ^ (m + 2) * T ^ (m + 1) / ↑(m + 1).factorial *
     iteratedDerivWithin (m + 1) f (Ici 0) T
   have hB : B ≤ 0 := by
     have h_neg : (-1 : ℝ) ^ (m + 2) * iteratedDerivWithin (m + 1) f (Ici 0) T ≤ 0 := by
       have : (-1 : ℝ) ^ (m + 2) = (-1) ^ (m + 1) * (-1) := pow_succ (-1) (m + 1)
-      rw [this]; nlinarith [hcm.neg_one_pow_mul_iteratedDerivWithin_nonneg (m + 1) hT.le]
+      rw [this]; nlinarith [hcm.neg_one_pow_mul_iteratedDerivWithin_nonneg (m + 1) hT_pos.le]
     suffices B = T ^ (m + 1) / ↑(m + 1).factorial *
         ((-1 : ℝ) ^ (m + 2) * iteratedDerivWithin (m + 1) f (Ici 0) T) by
       rw [this]
       exact mul_nonpos_of_nonneg_of_nonpos
-        (div_nonneg (pow_nonneg hT.le _) (Nat.cast_nonneg _)) h_neg
+        (div_nonneg (pow_nonneg hT_pos.le _) (Nat.cast_nonneg _)) h_neg
     simp only [B]; ring
   linarith
 
@@ -381,7 +385,7 @@ private lemma integral_chafaiDensity_le_sub (f : ℝ → ℝ) (hcm : IsCompletel
       exact le_of_eq (integral_chafaiDensity_one_eq f hcm T hT)
     · calc ∫ t in (0 : ℝ)..T, chafaiDensity f (p + 1) t
           ≤ ∫ t in (0 : ℝ)..T, chafaiDensity f p t := by
-            simpa using integral_chafaiDensity_le_pred f hcm (p + 1) (by omega) T hT
+            simpa using integral_chafaiDensity_le_pred f hcm (p + 1) (by omega) T hT.le
         _ ≤ f 0 - f T := ih (Nat.one_le_iff_ne_zero.mpr hp)
 
 private lemma integral_chafaiDensity_le_tendsto_sub (f : ℝ → ℝ)
@@ -462,5 +466,21 @@ lemma chafaiMeasure_finite_mass (f : ℝ → ℝ) (hcm : IsCompletelyMonotone f)
         (chafaiMeasure f n) univ ≤ ENNReal.ofReal (f 0 - L) := by
   obtain ⟨L, hL, hL_nn⟩ := hcm.tendsto_atTop
   exact ⟨L, hL, hL_nn, fun n => chafaiMeasure_finite_mass_of_tendsto f hcm n L hL⟩
+
+/-- **Natural rescaled total mass bound**: for a completely monotone `f`, the rescaled
+Chafaï measures on `ℝ≥0` are finite and uniformly bounded by `f(0) - L`, where `L` is the
+automatically obtained limit of `f` at infinity. -/
+lemma chafaiRescaled_finite_mass (f : ℝ → ℝ) (hcm : IsCompletelyMonotone f) :
+    ∃ L : ℝ, Tendsto f atTop (nhds L) ∧ 0 ≤ L ∧
+      ∀ n,
+        IsFiniteMeasure (chafaiRescaled f n) ∧
+        (chafaiRescaled f n) univ ≤ ENNReal.ofReal (f 0 - L) := by
+  obtain ⟨L, hL, hL_nn, hfinite⟩ := chafaiMeasure_finite_mass f hcm
+  refine ⟨L, hL, hL_nn, fun n => ?_⟩
+  have hmass := chafaiRescaled_mass_eq f n
+  refine ⟨?_, ?_⟩
+  · exact ⟨by rw [hmass]; exact (hfinite n).1.measure_univ_lt_top⟩
+  · rw [hmass]
+    exact (hfinite n).2
 
 end TauCeti

--- a/TauCeti/Analysis/CompletelyMonotone/Integral.lean
+++ b/TauCeti/Analysis/CompletelyMonotone/Integral.lean
@@ -21,7 +21,7 @@ fundamental-theorem identities, and improper-integral facts for `-f'`.
 ## Main declarations
 
 * `TauCeti.ContDiffAt.iteratedDerivWithin_Icc_eq_Ici`: iterated derivatives within `Icc x T`
-  and within `Ici 0` agree at interior points.
+  and within `Ici a` agree at interior points.
 * `TauCeti.ContDiffOn.integral_neg_derivWithin_Icc`,
   `TauCeti.ContDiffOn.integral_neg_derivWithin_Icc_zero_left`: finite-interval
   fundamental-theorem identities for smooth functions.
@@ -51,17 +51,17 @@ namespace TauCeti
 
 variable {E : Type*} [NormedAddCommGroup E] [NormedSpace ℝ E] {f : ℝ → E}
 
-/-- `iteratedDerivWithin` on `Icc x T` agrees with `iteratedDerivWithin` on `Ici 0` at interior
+/-- `iteratedDerivWithin` on `Icc x T` agrees with `iteratedDerivWithin` on `Ici a` at interior
 points, since both equal `iteratedDeriv n f t` under local smoothness at `t`. -/
 lemma ContDiffAt.iteratedDerivWithin_Icc_eq_Ici {n : ℕ}
-    {x T t : ℝ} (hf : ContDiffAt ℝ (n : WithTop ℕ∞) f t) (ht_pos : 0 < t)
+    {a x T t : ℝ} (hf : ContDiffAt ℝ (n : WithTop ℕ∞) f t) (ht_lo : a < t)
     (ht : t ∈ Ioo x T) :
-    iteratedDerivWithin n f (Icc x T) t = iteratedDerivWithin n f (Ici 0) t := by
+    iteratedDerivWithin n f (Icc x T) t = iteratedDerivWithin n f (Ici a) t := by
   have hxT : x < T := lt_trans ht.1 ht.2
   rw [iteratedDerivWithin_eq_iteratedDeriv (uniqueDiffOn_Icc hxT) hf
         (Ioo_subset_Icc_self ht),
-      ← iteratedDerivWithin_eq_iteratedDeriv (uniqueDiffOn_Ici 0) hf
-        (mem_Ici.mpr ht_pos.le)]
+      ← iteratedDerivWithin_eq_iteratedDeriv (uniqueDiffOn_Ici a) hf
+        (mem_Ici.mpr ht_lo.le)]
 
 /-- The fundamental-theorem identity
 `f x - f T = ∫ₓᵀ -f'` on a compact interval, with derivatives taken within that interval. -/
@@ -117,7 +117,7 @@ lemma iteratedDerivWithin_Icc_eq_Ici {n : ℕ} (hf : IsCompletelyMonotone f)
     iteratedDerivWithin n f (Icc x T) t = iteratedDerivWithin n f (Ici 0) t := by
   have hcda : ContDiffAt ℝ (n : WithTop ℕ∞) f t :=
     (hf.contDiffOn.contDiffAt (Ici_mem_nhds ht_pos)).of_le (by exact_mod_cast le_top)
-  exact ContDiffAt.iteratedDerivWithin_Icc_eq_Ici hcda ht_pos ht
+  exact ContDiffAt.iteratedDerivWithin_Icc_eq_Ici (a := 0) hcda ht_pos ht
 
 /-- **CM sign of the Taylor remainder.** For a completely monotone function the Taylor
 integral remainder `∫ₓᵀ (T-t)ⁿ⁻¹/(n-1)! · f⁽ⁿ⁾(t) dt` has sign `(-1)ⁿ`:

--- a/TauCeti/Analysis/CompletelyMonotone/Integral.lean
+++ b/TauCeti/Analysis/CompletelyMonotone/Integral.lean
@@ -1,0 +1,236 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+module
+
+public import Mathlib.MeasureTheory.Integral.IntegralEqImproper
+public import Mathlib.MeasureTheory.Integral.IntervalIntegral.ContDiff
+public import TauCeti.Analysis.CompletelyMonotone.Basic
+
+/-!
+# Integral and analysis lemmas for completely monotone functions
+
+The generic completely-monotone integral/analysis layer: FTC, Taylor-remainder, and
+improper-integral facts about completely monotone functions.
+
+These extend the object API in `CompletelyMonotone/Basic.lean` with derivative-within transfer
+on compact intervals, the sign of the Taylor integral remainder, finite-interval
+fundamental-theorem identities, and improper-integral facts for `-f'`.
+
+## Main declarations
+
+* `TauCeti.ContDiffAt.iteratedDerivWithin_Icc_eq_Ici`: iterated derivatives within `Icc x T`
+  and within `Ici 0` agree at interior points.
+* `TauCeti.ContDiffOn.integral_neg_derivWithin_Icc`,
+  `TauCeti.ContDiffOn.integral_neg_derivWithin_Icc_zero_left`: finite-interval
+  fundamental-theorem identities for smooth functions.
+* `TauCeti.IsCompletelyMonotone.neg_one_pow_mul_taylor_remainder_nonneg`: the Taylor integral
+  remainder has sign `(-1)ⁿ`.
+* `TauCeti.IsCompletelyMonotone.integral_neg_deriv`, `TauCeti.IsCompletelyMonotone.integral_mass`:
+  compatibility wrappers for the smooth finite-interval identities.
+* `TauCeti.IsCompletelyMonotone.neg_deriv_integrableOn`,
+  `TauCeti.IsCompletelyMonotone.integral_Ioi_neg_deriv`: integrability and the improper integral
+  of `-f'` on `(0, ∞)`.
+
+## References
+
+* Roadmap: `TauCetiRoadmap/OneParameterSemigroups/README.md`, Part B (Bernstein theorem
+  milestone).
+
+* D. V. Widder, *The Laplace Transform* (Princeton, 1941), Ch. IV.
+* D. Chafaï, *Aspects of the Bernstein theorem* (2013).
+-/
+
+public section
+
+open MeasureTheory Set intervalIntegral Filter
+open scoped ContDiff Topology
+
+namespace TauCeti
+
+variable {f : ℝ → ℝ}
+
+/-- `iteratedDerivWithin` on `Icc x T` agrees with `iteratedDerivWithin` on `Ici 0` at interior
+points, since both equal `iteratedDeriv n f t` under local smoothness at `t`. -/
+lemma ContDiffAt.iteratedDerivWithin_Icc_eq_Ici {n : ℕ}
+    {x T t : ℝ} (hf : ContDiffAt ℝ (n : WithTop ℕ∞) f t) (hx : 0 ≤ x)
+    (ht : t ∈ Ioo x T) :
+    iteratedDerivWithin n f (Icc x T) t = iteratedDerivWithin n f (Ici 0) t := by
+  have ht_pos : 0 < t := lt_of_le_of_lt hx ht.1
+  have hxT : x < T := lt_trans ht.1 ht.2
+  rw [iteratedDerivWithin_eq_iteratedDeriv (uniqueDiffOn_Icc hxT) hf
+        (Ioo_subset_Icc_self ht),
+      ← iteratedDerivWithin_eq_iteratedDeriv (uniqueDiffOn_Ici 0) hf
+        (mem_Ici.mpr ht_pos.le)]
+
+/-- The fundamental-theorem identity
+`f x - f T = ∫ₓᵀ -f'` on a compact interval, with derivatives taken within that interval. -/
+lemma ContDiffOn.integral_neg_derivWithin_Icc {x T : ℝ}
+    (hf : ContDiffOn ℝ 1 f (Icc x T)) (hxT : x ≤ T) :
+    f x - f T = ∫ t in x..T, -iteratedDerivWithin 1 f (Icc x T) t := by
+  have hFTC := intervalIntegral.integral_derivWithin_Icc_of_contDiffOn_Icc hf hxT
+  rw [iteratedDerivWithin_one]
+  rw [intervalIntegral.integral_neg]
+  linarith [hFTC]
+
+/-- The zero-left specialization of `ContDiffOn.integral_neg_derivWithin_Icc`. -/
+lemma ContDiffOn.integral_neg_derivWithin_Icc_zero_left {T : ℝ}
+    (hf : ContDiffOn ℝ 1 f (Icc 0 T)) (hT : 0 ≤ T) :
+    ∫ t in (0 : ℝ)..T, -iteratedDerivWithin 1 f (Icc 0 T) t = f 0 - f T := by
+  exact (ContDiffOn.integral_neg_derivWithin_Icc hf hT).symm
+
+/-- The interval integral of `-f'` with the `T`-dependent set `Icc 0 T` equals the integral with
+the fixed set `Ici 0`, under smoothness on the open half-line. -/
+lemma ContDiffOn.integral_neg_derivWithin_Icc_eq_Ici
+    (hf : ContDiffOn ℝ 1 f (Ioi 0)) (T : ℝ) (hT : 0 ≤ T) :
+    ∫ t in (0 : ℝ)..T, -iteratedDerivWithin 1 f (Icc 0 T) t =
+    ∫ t in (0 : ℝ)..T, -iteratedDerivWithin 1 f (Ici 0) t := by
+  apply intervalIntegral.integral_congr_ae
+  apply ae_of_all volume
+  intro t ht
+  rw [uIoc_of_le hT] at ht
+  have ht_pos : 0 < t := ht.1
+  have hT_pos : 0 < T := lt_of_lt_of_le ht_pos ht.2
+  have hcda : ContDiffAt ℝ 1 f t := hf.contDiffAt (isOpen_Ioi.mem_nhds ht_pos)
+  simp only [iteratedDerivWithin_eq_iteratedDeriv (uniqueDiffOn_Icc hT_pos) hcda
+      (Ioc_subset_Icc_self ht),
+    iteratedDerivWithin_eq_iteratedDeriv (uniqueDiffOn_Ici 0) hcda
+      (mem_Ici.mpr ht_pos.le)]
+
+/-- The total mass `∫₀ᵀ (-f') dt → f(0) - L` as `T → ∞`, assuming smoothness on `[0, ∞)`
+and convergence of `f` to `L` at infinity. -/
+lemma ContDiffOn.tendsto_total_mass
+    (hf : ContDiffOn ℝ 1 f (Ici 0)) {L : ℝ} (hL : Tendsto f atTop (nhds L)) :
+    Tendsto (fun T => ∫ t in (0 : ℝ)..T, -iteratedDerivWithin 1 f (Icc 0 T) t) atTop
+        (nhds (f 0 - L)) := by
+  refine Tendsto.congr' (EventuallyEq.symm ?_) (Tendsto.sub tendsto_const_nhds hL)
+  exact (eventually_gt_atTop 0).mono fun T hT =>
+    ContDiffOn.integral_neg_derivWithin_Icc_zero_left (hf.mono Icc_subset_Ici_self) hT.le
+
+namespace IsCompletelyMonotone
+
+/-- `iteratedDerivWithin` on `Icc x T` agrees with `iteratedDerivWithin` on `Ici 0` at interior
+points, since both equal `iteratedDeriv n f t` when `0 < t`. -/
+lemma iteratedDerivWithin_Icc_eq_Ici {n : ℕ} (hf : IsCompletelyMonotone f)
+    {x T t : ℝ} (hx : 0 ≤ x) (ht : t ∈ Ioo x T) :
+    iteratedDerivWithin n f (Icc x T) t = iteratedDerivWithin n f (Ici 0) t := by
+  have ht_pos : 0 < t := lt_of_le_of_lt hx ht.1
+  have hcda : ContDiffAt ℝ (n : WithTop ℕ∞) f t :=
+    (hf.contDiffOn.contDiffAt (Ici_mem_nhds ht_pos)).of_le (by exact_mod_cast le_top)
+  exact ContDiffAt.iteratedDerivWithin_Icc_eq_Ici hcda hx ht
+
+/-- **CM sign of the Taylor remainder.** For a completely monotone function the Taylor
+integral remainder `∫ₓᵀ (T-t)ⁿ⁻¹/(n-1)! · f⁽ⁿ⁾(t) dt` has sign `(-1)ⁿ`:
+`0 ≤ (-1)ⁿ` times it. -/
+lemma neg_one_pow_mul_taylor_remainder_nonneg (hf : IsCompletelyMonotone f) {x T : ℝ} {n : ℕ}
+    (hx : 0 ≤ x) (hxT : x ≤ T) :
+    0 ≤ (-1 : ℝ) ^ n * ∫ t in x..T,
+      (↑(n - 1).factorial)⁻¹ * (T - t) ^ (n - 1) *
+      iteratedDerivWithin n f (Icc x T) t := by
+  rw [← intervalIntegral.integral_const_mul]
+  apply intervalIntegral.integral_nonneg_of_ae_restrict hxT
+  have hIoo : ∀ t ∈ Ioo x T, (0 : ℝ) ≤ ((-1 : ℝ) ^ n *
+      ((↑(n - 1).factorial)⁻¹ * (T - t) ^ (n - 1) *
+        iteratedDerivWithin n f (Icc x T) t)) := fun t ht =>
+    calc (0 : ℝ) ≤ (↑(n - 1).factorial)⁻¹ * (T - t) ^ (n - 1) *
+          ((-1 : ℝ) ^ n * iteratedDerivWithin n f (Icc x T) t) :=
+          mul_nonneg (mul_nonneg (inv_nonneg.mpr (Nat.cast_nonneg _))
+            (pow_nonneg (sub_nonneg.mpr ht.2.le) _))
+            (by rw [hf.iteratedDerivWithin_Icc_eq_Ici hx ht]
+                exact hf.neg_one_pow_mul_iteratedDerivWithin_nonneg n
+                  (lt_of_le_of_lt hx ht.1).le)
+      _ = _ := by ring
+  have h_mem : ∀ᵐ t ∂volume.restrict (Icc x T), t ∈ Ioo x T := by
+    rw [ae_restrict_iff' measurableSet_Icc]
+    exact (Ioo_ae_eq_Icc (a := x) (b := T)).mono (fun t h ht => h.mpr ht)
+  exact h_mem.mono fun t ht => by simp only [Pi.zero_apply]; exact hIoo t ht
+
+/-- For a completely monotone `f` the `n = 1` fundamental-theorem identity gives
+`f(x) - f(T) = ∫ₓᵀ (-f'(t)) dt`, with the integrand nonnegative by the sign condition. -/
+lemma integral_neg_deriv (hf : IsCompletelyMonotone f)
+    (x T : ℝ) (hx : 0 ≤ x) (hxT : x ≤ T) :
+    f x - f T = ∫ t in x..T, -iteratedDerivWithin 1 f (Icc x T) t := by
+  have hsubset : Icc x T ⊆ Ici 0 := Icc_subset_Ici_self.trans (Ici_subset_Ici.mpr hx)
+  have hcm_Icc : ContDiffOn ℝ 1 f (Icc x T) :=
+    (hf.contDiffOn.mono hsubset).of_le (by exact_mod_cast le_top)
+  exact ContDiffOn.integral_neg_derivWithin_Icc hcm_Icc hxT
+
+/-- The total mass identity `∫₀ᵀ (-f') = f(0) - f(T)` for a completely monotone function. -/
+lemma integral_mass (hf : IsCompletelyMonotone f) (T : ℝ) (hT : 0 ≤ T) :
+    ∫ t in (0 : ℝ)..T, -iteratedDerivWithin 1 f (Icc 0 T) t = f 0 - f T := by
+  have hsubset : Icc 0 T ⊆ Ici 0 := Icc_subset_Ici_self
+  have hcm_Icc : ContDiffOn ℝ 1 f (Icc 0 T) :=
+    (hf.contDiffOn.mono hsubset).of_le (by exact_mod_cast le_top)
+  exact ContDiffOn.integral_neg_derivWithin_Icc_zero_left hcm_Icc hT
+
+end IsCompletelyMonotone
+
+/-! ## Smoothness-index helpers -/
+
+private lemma nat_le_top (n : ℕ) : (n : WithTop ℕ∞) ≤ ∞ := by exact_mod_cast le_top
+
+/-- The first iterated derivative within `[0, ∞)` of a completely monotone function is
+nonpositive (the `derivWithin` sign condition restated for `iteratedDerivWithin 1`). -/
+private lemma IsCompletelyMonotone.iteratedDerivWithin_one_nonpos
+    (hf : IsCompletelyMonotone f) {t : ℝ} (ht : 0 ≤ t) :
+    iteratedDerivWithin 1 f (Ici 0) t ≤ 0 := by
+  rw [iteratedDerivWithin_one]; exact hf.derivWithin_nonpos ht
+
+/-- The interval integral of `-f'` with the `T`-dependent set `Icc 0 T` equals the integral with
+the fixed set `Ici 0` (both agree a.e. by set transfer at interior points). -/
+lemma IsCompletelyMonotone.integral_neg_deriv_Ici
+    (hcm : IsCompletelyMonotone f) (T : ℝ) (hT : 0 ≤ T) :
+    ∫ t in (0 : ℝ)..T, -iteratedDerivWithin 1 f (Icc 0 T) t =
+    ∫ t in (0 : ℝ)..T, -iteratedDerivWithin 1 f (Ici 0) t := by
+  exact ContDiffOn.integral_neg_derivWithin_Icc_eq_Ici
+    ((hcm.contDiffOn.mono Ioi_subset_Ici_self).of_le (nat_le_top _)) T hT
+
+/-- The total mass `∫₀ᵀ (-f') dt → f(0) - L` as `T → ∞`, where `L = lim f(t)`. This is
+the key uniform bound for the tightness argument in Bernstein's theorem. -/
+lemma IsCompletelyMonotone.tendsto_total_mass
+    (hcm : IsCompletelyMonotone f) {L : ℝ} (hL : Tendsto f atTop (nhds L)) :
+    Tendsto (fun T => ∫ t in (0 : ℝ)..T, -iteratedDerivWithin 1 f (Icc 0 T) t) atTop
+        (nhds (f 0 - L)) :=
+  ContDiffOn.tendsto_total_mass (hcm.contDiffOn.of_le (nat_le_top _)) hL
+
+/-- `-f'` is integrable on `(0, ∞)` for a completely monotone function, where the derivative is
+taken within the closed half-line `[0, ∞)`. -/
+lemma IsCompletelyMonotone.neg_deriv_integrableOn (hcm : IsCompletelyMonotone f) :
+    IntegrableOn (fun t => -iteratedDerivWithin 1 f (Ici 0) t) (Ioi 0) := by
+  obtain ⟨L, hL, -⟩ := hcm.tendsto_atTop
+  apply integrableOn_Ioi_of_intervalIntegral_norm_tendsto (f 0 - L) 0
+      (l := atTop) (b := id)
+  · intro T
+    exact ((hcm.contDiffOn.continuousOn_iteratedDerivWithin (nat_le_top _)
+      (uniqueDiffOn_Ici 0)).neg.mono Icc_subset_Ici_self).integrableOn_compact
+        isCompact_Icc |>.mono_set Ioc_subset_Icc_self
+  · exact tendsto_id
+  · have hnorm : ∀ᶠ T in atTop, (∫ t in (0 : ℝ)..id T,
+        ‖(fun t => -iteratedDerivWithin 1 f (Ici 0) t) t‖) = f 0 - f T := by
+      filter_upwards [eventually_gt_atTop 0] with T hT
+      simp only [id]
+      have : (∫ t in (0 : ℝ)..T, ‖(fun t => -iteratedDerivWithin 1 f (Ici 0) t) t‖) =
+          ∫ t in (0 : ℝ)..T, -iteratedDerivWithin 1 f (Ici 0) t :=
+        intervalIntegral.integral_congr_ae (ae_of_all _ fun t ht => by
+          rw [uIoc_of_le hT.le] at ht
+          simp only [Real.norm_eq_abs]
+          rw [abs_of_nonneg (by linarith [hcm.iteratedDerivWithin_one_nonpos ht.1.le])])
+      rw [this, ← hcm.integral_neg_deriv_Ici T hT.le, hcm.integral_mass T hT.le]
+    exact Tendsto.congr' (EventuallyEq.symm hnorm) (Tendsto.sub tendsto_const_nhds hL)
+
+/-- The improper integral `∫₀^∞ (-f') dt = f(0) - L` for completely monotone functions. -/
+lemma IsCompletelyMonotone.integral_Ioi_neg_deriv
+    (hcm : IsCompletelyMonotone f) {L : ℝ} (hL : Tendsto f atTop (nhds L)) :
+    ∫ t in Ioi 0, -iteratedDerivWithin 1 f (Ici 0) t = f 0 - L := by
+  have hint := hcm.neg_deriv_integrableOn
+  have htend := intervalIntegral_tendsto_integral_Ioi 0 hint tendsto_id
+  have htend2 : Tendsto (fun T => ∫ t in (0 : ℝ)..T,
+      -iteratedDerivWithin 1 f (Ici 0) t) atTop (nhds (f 0 - L)) :=
+    Tendsto.congr'
+      ((eventually_gt_atTop 0).mono fun T hT =>
+        ((hcm.integral_neg_deriv_Ici T hT.le).symm.trans (hcm.integral_mass T hT.le)).symm)
+      (Tendsto.sub tendsto_const_nhds hL)
+  exact tendsto_nhds_unique htend htend2
+
+end TauCeti

--- a/TauCeti/Analysis/CompletelyMonotone/Integral.lean
+++ b/TauCeti/Analysis/CompletelyMonotone/Integral.lean
@@ -81,20 +81,19 @@ lemma ContDiffOn.integral_neg_derivWithin_Icc_zero_left {T : ℝ}
   exact (ContDiffOn.integral_neg_derivWithin_Icc hf hT).symm
 
 /-- The interval integral of `-f'` with the `T`-dependent set `Icc 0 T` equals the integral with
-the fixed set `Ici 0`, under smoothness on the open half-line. -/
+the fixed set `Ici 0`, under local smoothness at the strict interior points. -/
 lemma ContDiffOn.integral_neg_derivWithin_Icc_eq_Ici
-    (hf : ContDiffOn ℝ 1 f (Ioi 0)) (T : ℝ) (hT : 0 ≤ T) :
+    {T : ℝ} (hf : ∀ t ∈ Ioo (0 : ℝ) T, ContDiffAt ℝ 1 f t) (hT : 0 ≤ T) :
     ∫ t in (0 : ℝ)..T, -iteratedDerivWithin 1 f (Icc 0 T) t =
     ∫ t in (0 : ℝ)..T, -iteratedDerivWithin 1 f (Ici 0) t := by
-  apply intervalIntegral.integral_congr_ae
-  apply ae_of_all volume
+  apply intervalIntegral.integral_congr_uIoo
   intro t ht
-  rw [uIoc_of_le hT] at ht
+  rw [uIoo_of_le hT] at ht
   have ht_pos : 0 < t := ht.1
-  have hT_pos : 0 < T := lt_of_lt_of_le ht_pos ht.2
-  have hcda : ContDiffAt ℝ 1 f t := hf.contDiffAt (isOpen_Ioi.mem_nhds ht_pos)
+  have hT_pos : 0 < T := lt_trans ht_pos ht.2
+  have hcda : ContDiffAt ℝ 1 f t := hf t ht
   simp only [iteratedDerivWithin_eq_iteratedDeriv (uniqueDiffOn_Icc hT_pos) hcda
-      (Ioc_subset_Icc_self ht),
+      (Ioo_subset_Icc_self ht),
     iteratedDerivWithin_eq_iteratedDeriv (uniqueDiffOn_Ici 0) hcda
       (mem_Ici.mpr ht_pos.le)]
 
@@ -184,7 +183,7 @@ lemma IsCompletelyMonotone.integral_neg_deriv_Ici
     ∫ t in (0 : ℝ)..T, -iteratedDerivWithin 1 f (Icc 0 T) t =
     ∫ t in (0 : ℝ)..T, -iteratedDerivWithin 1 f (Ici 0) t := by
   exact ContDiffOn.integral_neg_derivWithin_Icc_eq_Ici
-    ((hcm.contDiffOn.mono Ioi_subset_Ici_self).of_le (nat_le_top _)) T hT
+    (fun t ht => (hcm.contDiffOn.contDiffAt (Ici_mem_nhds ht.1)).of_le (nat_le_top _)) hT
 
 /-- The total mass `∫₀ᵀ (-f') dt → f(0) - L` as `T → ∞`, where `L = lim f(t)`. This is
 the key uniform bound for the tightness argument in Bernstein's theorem. -/

--- a/TauCeti/Analysis/CompletelyMonotone/Integral.lean
+++ b/TauCeti/Analysis/CompletelyMonotone/Integral.lean
@@ -54,10 +54,9 @@ variable {f : ℝ → ℝ}
 /-- `iteratedDerivWithin` on `Icc x T` agrees with `iteratedDerivWithin` on `Ici 0` at interior
 points, since both equal `iteratedDeriv n f t` under local smoothness at `t`. -/
 lemma ContDiffAt.iteratedDerivWithin_Icc_eq_Ici {n : ℕ}
-    {x T t : ℝ} (hf : ContDiffAt ℝ (n : WithTop ℕ∞) f t) (hx : 0 ≤ x)
+    {x T t : ℝ} (hf : ContDiffAt ℝ (n : WithTop ℕ∞) f t) (ht_pos : 0 < t)
     (ht : t ∈ Ioo x T) :
     iteratedDerivWithin n f (Icc x T) t = iteratedDerivWithin n f (Ici 0) t := by
-  have ht_pos : 0 < t := lt_of_le_of_lt hx ht.1
   have hxT : x < T := lt_trans ht.1 ht.2
   rw [iteratedDerivWithin_eq_iteratedDeriv (uniqueDiffOn_Icc hxT) hf
         (Ioo_subset_Icc_self ht),
@@ -112,12 +111,11 @@ namespace IsCompletelyMonotone
 /-- `iteratedDerivWithin` on `Icc x T` agrees with `iteratedDerivWithin` on `Ici 0` at interior
 points, since both equal `iteratedDeriv n f t` when `0 < t`. -/
 lemma iteratedDerivWithin_Icc_eq_Ici {n : ℕ} (hf : IsCompletelyMonotone f)
-    {x T t : ℝ} (hx : 0 ≤ x) (ht : t ∈ Ioo x T) :
+    {x T t : ℝ} (ht_pos : 0 < t) (ht : t ∈ Ioo x T) :
     iteratedDerivWithin n f (Icc x T) t = iteratedDerivWithin n f (Ici 0) t := by
-  have ht_pos : 0 < t := lt_of_le_of_lt hx ht.1
   have hcda : ContDiffAt ℝ (n : WithTop ℕ∞) f t :=
     (hf.contDiffOn.contDiffAt (Ici_mem_nhds ht_pos)).of_le (by exact_mod_cast le_top)
-  exact ContDiffAt.iteratedDerivWithin_Icc_eq_Ici hcda hx ht
+  exact ContDiffAt.iteratedDerivWithin_Icc_eq_Ici hcda ht_pos ht
 
 /-- **CM sign of the Taylor remainder.** For a completely monotone function the Taylor
 integral remainder `∫ₓᵀ (T-t)ⁿ⁻¹/(n-1)! · f⁽ⁿ⁾(t) dt` has sign `(-1)ⁿ`:
@@ -136,7 +134,7 @@ lemma neg_one_pow_mul_taylor_remainder_nonneg (hf : IsCompletelyMonotone f) {x T
           ((-1 : ℝ) ^ n * iteratedDerivWithin n f (Icc x T) t) :=
           mul_nonneg (mul_nonneg (inv_nonneg.mpr (Nat.cast_nonneg _))
             (pow_nonneg (sub_nonneg.mpr ht.2.le) _))
-            (by rw [hf.iteratedDerivWithin_Icc_eq_Ici hx ht]
+            (by rw [hf.iteratedDerivWithin_Icc_eq_Ici (lt_of_le_of_lt hx ht.1) ht]
                 exact hf.neg_one_pow_mul_iteratedDerivWithin_nonneg n
                   (lt_of_le_of_lt hx ht.1).le)
       _ = _ := by ring

--- a/TauCeti/Analysis/CompletelyMonotone/Integral.lean
+++ b/TauCeti/Analysis/CompletelyMonotone/Integral.lean
@@ -158,10 +158,7 @@ lemma integral_neg_deriv (hf : IsCompletelyMonotone f)
 /-- The total mass identity `∫₀ᵀ (-f') = f(0) - f(T)` for a completely monotone function. -/
 lemma integral_mass (hf : IsCompletelyMonotone f) (T : ℝ) (hT : 0 ≤ T) :
     ∫ t in (0 : ℝ)..T, -iteratedDerivWithin 1 f (Icc 0 T) t = f 0 - f T := by
-  have hsubset : Icc 0 T ⊆ Ici 0 := Icc_subset_Ici_self
-  have hcm_Icc : ContDiffOn ℝ 1 f (Icc 0 T) :=
-    (hf.contDiffOn.mono hsubset).of_le (by exact_mod_cast le_top)
-  exact ContDiffOn.integral_neg_derivWithin_Icc_zero_left hcm_Icc hT
+  exact (hf.integral_neg_deriv 0 T le_rfl hT).symm
 
 end IsCompletelyMonotone
 
@@ -197,7 +194,7 @@ lemma IsCompletelyMonotone.tendsto_total_mass
 taken within the closed half-line `[0, ∞)`. -/
 lemma IsCompletelyMonotone.neg_deriv_integrableOn (hcm : IsCompletelyMonotone f) :
     IntegrableOn (fun t => -iteratedDerivWithin 1 f (Ici 0) t) (Ioi 0) := by
-  obtain ⟨L, hL, -⟩ := hcm.tendsto_atTop
+  obtain ⟨L, hL, -⟩ := hcm.exists_nonneg_tendsto_atTop
   apply integrableOn_Ioi_of_intervalIntegral_norm_tendsto (f 0 - L) 0
       (l := atTop) (b := id)
   · intro T

--- a/TauCeti/Analysis/CompletelyMonotone/Integral.lean
+++ b/TauCeti/Analysis/CompletelyMonotone/Integral.lean
@@ -49,7 +49,7 @@ open scoped ContDiff Topology
 
 namespace TauCeti
 
-variable {f : ℝ → ℝ}
+variable {E : Type*} [NormedAddCommGroup E] [NormedSpace ℝ E] {f : ℝ → E}
 
 /-- `iteratedDerivWithin` on `Icc x T` agrees with `iteratedDerivWithin` on `Ici 0` at interior
 points, since both equal `iteratedDeriv n f t` under local smoothness at `t`. -/
@@ -66,16 +66,15 @@ lemma ContDiffAt.iteratedDerivWithin_Icc_eq_Ici {n : ℕ}
 /-- The fundamental-theorem identity
 `f x - f T = ∫ₓᵀ -f'` on a compact interval, with derivatives taken within that interval. -/
 lemma ContDiffOn.integral_neg_derivWithin_Icc {x T : ℝ}
-    (hf : ContDiffOn ℝ 1 f (Icc x T)) (hxT : x ≤ T) :
+    [CompleteSpace E] (hf : ContDiffOn ℝ 1 f (Icc x T)) (hxT : x ≤ T) :
     f x - f T = ∫ t in x..T, -iteratedDerivWithin 1 f (Icc x T) t := by
   have hFTC := intervalIntegral.integral_derivWithin_Icc_of_contDiffOn_Icc hf hxT
   rw [iteratedDerivWithin_one]
-  rw [intervalIntegral.integral_neg]
-  linarith [hFTC]
+  rw [intervalIntegral.integral_neg, hFTC, neg_sub]
 
 /-- The zero-left specialization of `ContDiffOn.integral_neg_derivWithin_Icc`. -/
 lemma ContDiffOn.integral_neg_derivWithin_Icc_zero_left {T : ℝ}
-    (hf : ContDiffOn ℝ 1 f (Icc 0 T)) (hT : 0 ≤ T) :
+    [CompleteSpace E] (hf : ContDiffOn ℝ 1 f (Icc 0 T)) (hT : 0 ≤ T) :
     ∫ t in (0 : ℝ)..T, -iteratedDerivWithin 1 f (Icc 0 T) t = f 0 - f T := by
   exact (ContDiffOn.integral_neg_derivWithin_Icc hf hT).symm
 
@@ -99,12 +98,15 @@ lemma ContDiffOn.integral_neg_derivWithin_Icc_eq_Ici
 /-- The total mass `∫₀ᵀ (-f') dt → f(0) - L` as `T → ∞`, assuming smoothness on `[0, ∞)`
 and convergence of `f` to `L` at infinity. -/
 lemma ContDiffOn.tendsto_total_mass
-    (hf : ContDiffOn ℝ 1 f (Ici 0)) {L : ℝ} (hL : Tendsto f atTop (nhds L)) :
+    [CompleteSpace E] (hf : ContDiffOn ℝ 1 f (Ici 0)) {L : E}
+    (hL : Tendsto f atTop (nhds L)) :
     Tendsto (fun T => ∫ t in (0 : ℝ)..T, -iteratedDerivWithin 1 f (Icc 0 T) t) atTop
         (nhds (f 0 - L)) := by
   refine Tendsto.congr' (EventuallyEq.symm ?_) (Tendsto.sub tendsto_const_nhds hL)
   exact (eventually_gt_atTop 0).mono fun T hT =>
     ContDiffOn.integral_neg_derivWithin_Icc_zero_left (hf.mono Icc_subset_Ici_self) hT.le
+
+variable {f : ℝ → ℝ}
 
 namespace IsCompletelyMonotone
 

--- a/TauCeti/MeasureTheory/Measure/Prokhorov.lean
+++ b/TauCeti/MeasureTheory/Measure/Prokhorov.lean
@@ -1,0 +1,134 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+module
+
+public import Mathlib.MeasureTheory.Measure.Prokhorov
+public import Mathlib.MeasureTheory.Integral.BoundedContinuousFunction
+
+/-!
+# Weak cluster limits of tight finite measures
+
+This file contains a generic finite-measure extraction lemma based on Mathlib's Prokhorov
+compactness theorem for finite measures. It has no real-line support condition and no
+normalization step: tightness and a uniform mass bound place the sequence in a compact set of
+`FiniteMeasure`s, and compactness gives a weak cluster limit.
+
+## Main declarations
+
+* `TauCeti.finite_measure_cluster_limit`: a tight, mass-bounded sequence of finite measures has a
+  weak cluster limit along an ultrafilter below `atTop`.
+* `TauCeti.finite_measure_subseq_limit`: the corresponding subsequence form when the weak topology
+  on `FiniteMeasure α` is first-countable.
+
+## References
+
+* Roadmap: `TauCetiRoadmap/OneParameterSemigroups/README.md`, Part B (Bernstein theorem milestone).
+-/
+
+public section
+
+open MeasureTheory Set Filter Topology
+open scoped NNReal Topology
+
+namespace TauCeti
+
+variable {α : Type*} [MeasurableSpace α] [TopologicalSpace α]
+  [T2Space α] [BorelSpace α]
+
+/-- A tight, uniformly mass-bounded sequence of finite measures has a weak cluster limit.
+
+The compactness input is Mathlib's
+`isCompact_setOf_finiteMeasure_mass_le_compl_isCompact_le`; the conclusion is phrased as
+convergence along an ultrafilter `U ≤ atTop`, which is enough for diagonal limit arguments and does
+not require a metrizability instance for `FiniteMeasure α`. -/
+lemma finite_measure_cluster_limit
+    (σ : ℕ → Measure α) (C : ℝ)
+    [hfin : ∀ n, IsFiniteMeasure (σ n)]
+    (hmass : ∀ n, (σ n) univ ≤ ENNReal.ofReal C)
+    (htight : ∀ ε : ℝ, 0 < ε →
+      ∃ K : Set α, IsCompact K ∧ ∀ n, (σ n) Kᶜ ≤ ENNReal.ofReal ε) :
+    ∃ (μ₀ : Measure α) (U : Ultrafilter ℕ), (U : Filter ℕ) ≤ atTop ∧ IsFiniteMeasure μ₀ ∧
+      μ₀ univ ≤ ENNReal.ofReal C ∧
+      ∀ g : BoundedContinuousFunction α ℝ,
+        Tendsto (fun n => ∫ x, g x ∂(σ n)) (U : Filter ℕ)
+          (nhds (∫ x, g x ∂μ₀)) := by
+  let σf : ℕ → FiniteMeasure α := fun n => ⟨σ n, hfin n⟩
+  let Cnn : ℝ≥0 := Real.toNNReal C
+  obtain ⟨u, -, hu_pos, hu_lim⟩ :
+      ∃ u : ℕ → ℝ≥0, StrictAnti u ∧ (∀ n, 0 < u n) ∧ Tendsto u atTop (𝓝 0) :=
+    exists_seq_strictAnti_tendsto 0
+  have hchoose : ∀ j, ∃ K : Set α, IsCompact K ∧
+      ∀ n, (σ n) Kᶜ ≤ (u j : ENNReal) := by
+    intro j
+    obtain ⟨K, hK, htail⟩ := htight (u j : ℝ) (by exact_mod_cast hu_pos j)
+    refine ⟨K, hK, fun n => ?_⟩
+    simpa using htail n
+  choose K hK_comp hK_tail using hchoose
+  let Kacc : ℕ → Set α := Set.accumulate K
+  let S : Set (FiniteMeasure α) :=
+    {μ | μ.mass ≤ Cnn ∧ ∀ j, μ (Kacc j)ᶜ ≤ u j}
+  have hKacc_comp : ∀ j, IsCompact (Kacc j) := by
+    intro j
+    exact isCompact_accumulate hK_comp j
+  have hcompact : IsCompact S := by
+    simpa [S] using
+      isCompact_setOf_finiteMeasure_mass_le_compl_isCompact_le
+        (E := α) (C := Cnn) (u := u) (K := Kacc) hu_lim hKacc_comp
+        (Or.inr Set.monotone_accumulate)
+  have hσ_mem : ∀ n, σf n ∈ S := by
+    intro n
+    constructor
+    · dsimp [σf, S, Cnn, FiniteMeasure.mass]
+      exact ENNReal.toNNReal_mono ENNReal.ofReal_ne_top (hmass n)
+    · intro j
+      have hsubset : (Kacc j)ᶜ ⊆ (K j)ᶜ :=
+        compl_subset_compl.mpr (Set.subset_accumulate (s := K) (x := j))
+      have htail : (σ n) (Kacc j)ᶜ ≤ (u j : ENNReal) :=
+        (measure_mono hsubset).trans (hK_tail j n)
+      exact ENNReal.coe_le_coe.mp (by simpa [σf] using htail)
+  have hmap_le : map σf atTop ≤ 𝓟 S :=
+    tendsto_principal.mpr (Eventually.of_forall hσ_mem)
+  obtain ⟨μf, hμfS, hcluster⟩ := hcompact hmap_le
+  have hmapcluster : MapClusterPt μf atTop σf := hcluster
+  obtain ⟨U, hUle, hUtend⟩ := mapClusterPt_iff_ultrafilter.mp hmapcluster
+  refine ⟨(μf : Measure α), U, hUle, inferInstance, ?_, ?_⟩
+  · have hle : (μf.mass : ENNReal) ≤ (Cnn : ENNReal) := ENNReal.coe_le_coe.mpr hμfS.1
+    rw [← FiniteMeasure.ennreal_mass]
+    simpa [Cnn, ENNReal.ofNNReal_toNNReal] using hle
+  · intro g
+    have hweak :=
+      (FiniteMeasure.tendsto_iff_forall_integral_tendsto.mp hUtend) g
+    simpa [σf] using hweak
+
+/-- Sequential form of `finite_measure_cluster_limit` when `FiniteMeasure α` is first-countable. -/
+lemma finite_measure_subseq_limit
+    [FirstCountableTopology (FiniteMeasure α)]
+    (σ : ℕ → Measure α) (C : ℝ)
+    [hfin : ∀ n, IsFiniteMeasure (σ n)]
+    (hmass : ∀ n, (σ n) univ ≤ ENNReal.ofReal C)
+    (htight : ∀ ε : ℝ, 0 < ε →
+      ∃ K : Set α, IsCompact K ∧ ∀ n, (σ n) Kᶜ ≤ ENNReal.ofReal ε) :
+    ∃ (μ₀ : Measure α) (φ : ℕ → ℕ), IsFiniteMeasure μ₀ ∧ StrictMono φ ∧
+      μ₀ univ ≤ ENNReal.ofReal C ∧
+      ∀ g : BoundedContinuousFunction α ℝ,
+        Tendsto (fun k => ∫ x, g x ∂(σ (φ k))) atTop
+          (nhds (∫ x, g x ∂μ₀)) := by
+  obtain ⟨μ₀, U, hUle, hμ₀_fin, hmass_μ₀, hweakU⟩ :=
+    finite_measure_cluster_limit (α := α) σ C hmass htight
+  let σf : ℕ → FiniteMeasure α := fun n => ⟨σ n, hfin n⟩
+  let μf : FiniteMeasure α := ⟨μ₀, hμ₀_fin⟩
+  have hUtend : Tendsto σf (U : Filter ℕ) (nhds μf) := by
+    rw [FiniteMeasure.tendsto_iff_forall_integral_tendsto]
+    intro g
+    simpa [σf, μf] using hweakU g
+  have hclusterU : MapClusterPt μf (U : Filter ℕ) σf := hUtend.mapClusterPt
+  have hcluster : MapClusterPt μf atTop σf := hclusterU.mono hUle
+  obtain ⟨φ, hφ, hφ_tendsto⟩ := hcluster.tendsto_subseq
+  refine ⟨μ₀, φ, hμ₀_fin, hφ, hmass_μ₀, fun g => ?_⟩
+  have hweak :=
+    (FiniteMeasure.tendsto_iff_forall_integral_tendsto.mp hφ_tendsto) g
+  simpa [σf, μf, Function.comp_def] using hweak
+
+end TauCeti


### PR DESCRIPTION
Part 1/2 of the forward **Bernstein representation theorem** (roadmap intention #33): completely monotone ⇔ Laplace transform of a finite measure on `ℝ≥0`.

This is the infrastructure layer: the opaque `chafai*` measure API (with characteristic lemmas), the general completely-monotone integral/limit layer, and a generic Mathlib-based finite-measure Prokhorov extraction (`Measure ℝ≥0`). The two generic `IsCompletelyMonotone` lemmas (`tendsto_atTop`, `hasDerivAt_iteratedDerivWithin_succ`) live in `CompletelyMonotone/Basic.lean`.

**Reopens #426**, which was auto-closed at the review round cap. Every prior rubric finding has been addressed in this one batch:
- placement: generic CM lemmas moved to `Basic.lean`; the `Limits.lean` split file removed.
- api-design: `chafaiDensity_succ_succ_sub_succ` made `private`.
- generality: dropped a redundant `x < T` hypothesis from `iteratedDerivWithin_Icc_eq_Ici`.
- documentation: `chafaiDensity` `n = 0` convention noted; `neg_deriv_integrableOn` docstring corrected.
- reuse: built on Mathlib's finite-measure Prokhorov rather than a hand-rolled construction.

Rebased onto current `main`. Sorry-free; axioms `{propext, Classical.choice, Quot.sound}`. Part 2/2 (the theorem assembly) follows once this merges.