### PR TITLE
feat: add conditionally iid exchangeability

### DIFF
--- a/TauCeti/Probability/Exchangeability/ConditionallyIIDImplications.lean
+++ b/TauCeti/Probability/Exchangeability/ConditionallyIIDImplications.lean
@@ -1,0 +1,118 @@
+module
+
+public import TauCeti.Probability.Exchangeability.ConditionallyIID
+
+/-!
+# Basic implications from conditional i.i.d.-ness
+
+This file records the first implication out of the Layer 0 directing-measure API:
+conditionally i.i.d. processes are exchangeable.  The definition
+`ConditionallyIIDWith μ X ν` already states that every injective finite coordinate selection
+has the same product-mixture law, so the exchangeability proof is just the specialization to
+the permuted and identity selections of `Fin n`.
+
+The resulting exchangeability theorem is one of the Layer 0 bridges listed in
+`TauCetiRoadmap/Exchangeability/Targets.lean`; the contractability corollaries use the same
+injective-block identity, since strictly increasing finite selections are injective.
+
+These declarations follow the `cameronfreer/exchangeability` Layer 0 implication lattice
+pinned at `e0532e59ceff23edab44dda9ab0655debbc9cc22`, but use Tau Ceti's current
+`ConditionallyIIDWith` API, where the finite-block mixture identity is already stated for
+arbitrary injective selections.
+-/
+
+public section
+
+noncomputable section
+
+open MeasureTheory
+
+namespace TauCeti
+
+namespace Probability
+
+variable {Ω α : Type*} [MeasurableSpace Ω] [MeasurableSpace α]
+
+private theorem injective_perm_val {n : ℕ} (σ : Equiv.Perm (Fin n)) :
+    Function.Injective fun i : Fin n => (σ i).val := by
+  intro i j hij
+  exact σ.injective (Fin.ext hij)
+
+private theorem injective_fin_val {n : ℕ} :
+    Function.Injective fun i : Fin n => i.val := by
+  intro i j hij
+  exact Fin.ext hij
+
+/-- Under a named conditional-i.i.d. directing measure, every permuted prefix block has the
+common finite-product mixture law. -/
+theorem ConditionallyIIDWith.permuted_prefixLaw_eq_mixture {μ : Measure Ω}
+    {X : ℕ → Ω → α} {ν : Ω → ProbabilityMeasure α} (h : ConditionallyIIDWith μ X ν)
+    {n : ℕ} (σ : Equiv.Perm (Fin n)) :
+    blockLaw μ X (fun i : Fin n => (σ i).val) =
+      μ.bind fun ω => (ProbabilityMeasure.pi fun _ : Fin n => ν ω).toMeasure :=
+  h.map (fun i : Fin n => (σ i).val) (injective_perm_val σ)
+
+/-- Under a named conditional-i.i.d. directing measure, the prefix law has the common
+finite-product mixture law. -/
+theorem ConditionallyIIDWith.prefixLaw_eq_mixture {μ : Measure Ω} {X : ℕ → Ω → α}
+    {ν : Ω → ProbabilityMeasure α} (h : ConditionallyIIDWith μ X ν) (n : ℕ) :
+    prefixLaw μ X n =
+      μ.bind fun ω => (ProbabilityMeasure.pi fun _ : Fin n => ν ω).toMeasure := by
+  rw [prefixLaw_apply]
+  exact h.map (fun i : Fin n => i.val) injective_fin_val
+
+/-- Under a named conditional-i.i.d. directing measure, every injective finite block has the
+same law as the corresponding prefix. -/
+theorem ConditionallyIIDWith.blockLaw_eq_prefixLaw_of_injective {μ : Measure Ω}
+    {X : ℕ → Ω → α} {ν : Ω → ProbabilityMeasure α} (h : ConditionallyIIDWith μ X ν)
+    {m : ℕ} {k : Fin m → ℕ} (hk : Function.Injective k) :
+    blockLaw μ X k = prefixLaw μ X m := by
+  rw [h.map k hk, h.prefixLaw_eq_mixture m]
+
+/-- A conditionally i.i.d. process has the same law along every injective finite block as along
+the corresponding prefix. -/
+theorem ConditionallyIID.blockLaw_eq_prefixLaw_of_injective {μ : Measure Ω}
+    {X : ℕ → Ω → α} (h : ConditionallyIID μ X) {m : ℕ} {k : Fin m → ℕ}
+    (hk : Function.Injective k) :
+    blockLaw μ X k = prefixLaw μ X m := by
+  obtain ⟨ν, hν⟩ := h.exists_directing
+  exact hν.blockLaw_eq_prefixLaw_of_injective hk
+
+/-- A named conditional-i.i.d. directing measure makes the law of each finite prefix invariant
+under permutations of that prefix. -/
+theorem ConditionallyIIDWith.exchangeableAt {μ : Measure Ω} {X : ℕ → Ω → α}
+    {ν : Ω → ProbabilityMeasure α} (h : ConditionallyIIDWith μ X ν) (n : ℕ) :
+    ExchangeableAt μ X n := by
+  intro σ
+  rw [h.permuted_prefixLaw_eq_mixture σ, h.prefixLaw_eq_mixture n]
+
+/-- A process with a named conditional-i.i.d. directing measure is exchangeable. -/
+theorem ConditionallyIIDWith.exchangeable {μ : Measure Ω} {X : ℕ → Ω → α}
+    {ν : Ω → ProbabilityMeasure α} (h : ConditionallyIIDWith μ X ν) : Exchangeable μ X := by
+  intro n
+  exact h.exchangeableAt n
+
+/-- A conditionally i.i.d. process is exchangeable. This is the Layer 0 bridge from the
+directing-measure API to finite exchangeability. -/
+theorem ConditionallyIID.exchangeable {μ : Measure Ω} {X : ℕ → Ω → α}
+    (h : ConditionallyIID μ X) : Exchangeable μ X := by
+  obtain ⟨ν, hν⟩ := h.exists_directing
+  exact hν.exchangeable
+
+/-- A named conditional-i.i.d. process is contractable: strictly increasing finite selections
+are injective finite selections. -/
+theorem ConditionallyIIDWith.contractable {μ : Measure Ω} {X : ℕ → Ω → α}
+    {ν : Ω → ProbabilityMeasure α} (h : ConditionallyIIDWith μ X ν) : Contractable μ X := by
+  intro m k hk
+  exact h.blockLaw_eq_prefixLaw_of_injective hk.injective
+
+/-- A conditionally i.i.d. process is contractable: strictly increasing finite selections are
+injective finite selections. -/
+theorem ConditionallyIID.contractable {μ : Measure Ω} {X : ℕ → Ω → α}
+    (h : ConditionallyIID μ X) : Contractable μ X := by
+  intro m k hk
+  exact h.blockLaw_eq_prefixLaw_of_injective hk.injective
+
+end Probability
+
+end TauCeti

--- a/TauCeti/Probability/Exchangeability/ConditionallyIIDImplications.lean
+++ b/TauCeti/Probability/Exchangeability/ConditionallyIIDImplications.lean
@@ -43,15 +43,6 @@ private theorem injective_fin_val {n : ℕ} :
   intro i j hij
   exact Fin.ext hij
 
-/-- Under a named conditional-i.i.d. directing measure, every permuted prefix block has the
-common finite-product mixture law. -/
-theorem ConditionallyIIDWith.permuted_prefixLaw_eq_mixture {μ : Measure Ω}
-    {X : ℕ → Ω → α} {ν : Ω → ProbabilityMeasure α} (h : ConditionallyIIDWith μ X ν)
-    {n : ℕ} (σ : Equiv.Perm (Fin n)) :
-    blockLaw μ X (fun i : Fin n => (σ i).val) =
-      μ.bind fun ω => (ProbabilityMeasure.pi fun _ : Fin n => ν ω).toMeasure :=
-  h.map (fun i : Fin n => (σ i).val) (injective_perm_val σ)
-
 /-- Under a named conditional-i.i.d. directing measure, the prefix law has the common
 finite-product mixture law. -/
 theorem ConditionallyIIDWith.prefixLaw_eq_mixture {μ : Measure Ω} {X : ℕ → Ω → α}
@@ -84,7 +75,7 @@ theorem ConditionallyIIDWith.exchangeableAt {μ : Measure Ω} {X : ℕ → Ω �
     {ν : Ω → ProbabilityMeasure α} (h : ConditionallyIIDWith μ X ν) (n : ℕ) :
     ExchangeableAt μ X n := by
   intro σ
-  rw [h.permuted_prefixLaw_eq_mixture σ, h.prefixLaw_eq_mixture n]
+  exact h.blockLaw_eq_prefixLaw_of_injective (injective_perm_val σ)
 
 /-- A process with a named conditional-i.i.d. directing measure is exchangeable. -/
 theorem ConditionallyIIDWith.exchangeable {μ : Measure Ω} {X : ℕ → Ω → α}


### PR DESCRIPTION
This PR adds the Layer 0 bridge from conditionally i.i.d. processes to finite exchangeability: a named directing-measure witness now gives the common finite-product mixture law for permuted prefixes, prefix laws, every injective finite block, and hence `Exchangeable` and `Contractable` corollaries for both `ConditionallyIIDWith` and `ConditionallyIID`.

It advances `TauCetiRoadmap/Exchangeability/Targets.lean`, Layer 0 bridge, specifically “conditionally i.i.d. ⇒ exchangeable,” and the corresponding implication-lattice/API discussion in `TauCetiRoadmap/Exchangeability/README.md`, Layer 0. I chose this as the lowest-hanging distinct Exchangeability target after checking open and recently merged PRs: the basic definitions, `Exchangeable → Contractable`, the named directing-measure API, and coordinatewise pushforward closure already exist, while the `ConditionallyIID → Exchangeable` bridge was still absent and is explicitly noted as future work in `TauCeti/Probability/Exchangeability/ConditionallyIID.lean`.

No Mathlib infrastructure is vendored. The proof reuses Tau Ceti's existing `ConditionallyIIDWith.map`, `prefixLaw`, `blockLaw`, `ExchangeableAt`, `Exchangeable`, and `Contractable` APIs; the implementation follows the `cameronfreer/exchangeability` Layer 0 implication lattice pinned at `e0532e59ceff23edab44dda9ab0655debbc9cc22`, adapted to Tau Ceti's current directing-measure definition where the finite-block mixture identity is already stated for arbitrary injective selections.

`lake exe cache get` completed with `No files to download` and `Already decompressed 8586 file(s)`. `lake build` completed with `Build completed successfully (4272 jobs).` `lake exe axioms` completed with `axioms: audited 5572 TauCeti declaration(s); all within the allowlist [propext, Classical.choice, Quot.sound].`

<!--tauceti-target:v1 {"focus":"Exchangeability","id":"conditionally-iid-exchangeable"}-->

🤖 Prepared with Codex
