### PR TITLE
feat: add regular normal deck fibre quotients

### DIFF
--- a/TauCeti/AlgebraicTopology/UniversalCover/Deck/NormalSubgroupFiberQuotient.lean
+++ b/TauCeti/AlgebraicTopology/UniversalCover/Deck/NormalSubgroupFiberQuotient.lean
@@ -95,6 +95,7 @@ lemma normalizerQuotientEquivQuotientOfNormal_regularSubgroupFiberOrbitQuotientE
   intro e'
   obtain ⟨φ, hφ⟩ := MulAction.exists_smul_eq (Deck p) e e'
   rw [← hφ]
+  -- The regular wrapper unfolds, with the two instances above, to the fibre-action equivalence.
   change
     Subgroup.normalizerQuotientEquivQuotientOfNormal H
         (subgroupFiberOrbitQuotientEquivNormalizerQuotientOfNormal H e

--- a/TauCeti/AlgebraicTopology/UniversalCover/Deck/NormalSubgroupFiberQuotient.lean
+++ b/TauCeti/AlgebraicTopology/UniversalCover/Deck/NormalSubgroupFiberQuotient.lean
@@ -1,0 +1,149 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+module
+
+public import TauCeti.Algebra.Group.NormalizerQuotient
+public import TauCeti.AlgebraicTopology.UniversalCover.Deck.SubgroupFiberOrbitQuotientGroup
+
+/-!
+# Normal deck-subgroup fibre quotients
+
+For a regular preconnected covering map, the quotient of one fibre by a subgroup
+`H ≤ Deck p` is already identified with the coset quotient `Deck p ⧸ H`. When `H` is normal,
+the universal-covers roadmap uses this quotient as the regular-cover specialization of the
+normalizer quotient `N(H) / H`. This file records that specialization directly, so later
+deck-group computations for quotient covers can move between fibre quotients and
+normalizer quotients without redoing the algebraic comparison.
+
+## Main declarations
+
+* `TauCeti.Deck.regularSubgroupFiberOrbitQuotientEquivNormalizerQuotientOfNormal`: for a
+  regular preconnected cover and a normal subgroup `H ≤ Deck p`, the quotient of a fibre by
+  `H` is equivalent to `N(H) / H`.
+* Simp lemmas for the image of the chosen lift, its deck translates, and representatives of
+  the inverse map.
+
+## References
+
+This is a small prerequisite for `TauCetiRoadmap/UniversalCovers/README.md`, Stage 2, item 8:
+in the regular case `H ◁ π₁(X, x₀)`, the deck group of the cover attached to `H` is
+`π₁(X, x₀) / H`. The file combines the existing Tau Ceti regular fibre-quotient equivalence
+with the algebraic normalizer-quotient comparison; no Mathlib infrastructure is vendored.
+-/
+
+public section
+
+namespace TauCeti
+
+namespace Deck
+
+variable {E B : Type*} [TopologicalSpace E] [TopologicalSpace B] {p : E → B} {b : B}
+
+/-- For a regular preconnected covering and a normal subgroup `H ≤ Deck p`, the quotient of a
+fibre by the restricted `H`-action is the normalizer quotient `N(H) / H`.
+
+Under normality, `N(H) = Deck p`, so this is the fibre-level version of the regular-cover
+specialization from `N(H) / H` to `Deck p / H`. -/
+noncomputable def regularSubgroupFiberOrbitQuotientEquivNormalizerQuotientOfNormal
+    [PreconnectedSpace E] (hp : IsCoveringMap p) (hreg : IsRegular p)
+    (H : Subgroup (Deck p)) [H.Normal] (e : p ⁻¹' {b}) :
+    SubgroupFiberOrbitQuotient H b ≃ Subgroup.normalizerQuotient H :=
+  (regularSubgroupFiberOrbitQuotientEquivQuotientGroup hp hreg H e).trans
+    (Subgroup.normalizerQuotientEquivQuotientOfNormal H).toEquiv.symm
+
+/-- The normal-subgroup fibre quotient equivalence, followed by the normalizer quotient's
+normal-case comparison, is the existing equivalence to `Deck p ⧸ H`. -/
+@[simp]
+lemma normalizerQuotientEquivQuotientOfNormal_regularSubgroupFiberOrbitQuotientEquiv
+    [PreconnectedSpace E] (hp : IsCoveringMap p) (hreg : IsRegular p)
+    (H : Subgroup (Deck p)) [H.Normal] (e : p ⁻¹' {b})
+    (x : SubgroupFiberOrbitQuotient H b) :
+    Subgroup.normalizerQuotientEquivQuotientOfNormal H
+        (regularSubgroupFiberOrbitQuotientEquivNormalizerQuotientOfNormal hp hreg H e x) =
+      regularSubgroupFiberOrbitQuotientEquivQuotientGroup hp hreg H e x := by
+  exact (Subgroup.normalizerQuotientEquivQuotientOfNormal H).toEquiv.apply_symm_apply
+    (regularSubgroupFiberOrbitQuotientEquivQuotientGroup hp hreg H e x)
+
+/-- The chosen fibre point maps to the identity class in the normalizer quotient. -/
+@[simp]
+lemma regularSubgroupFiberOrbitQuotientEquivNormalizerQuotientOfNormal_apply_base
+    [PreconnectedSpace E] (hp : IsCoveringMap p) (hreg : IsRegular p)
+    (H : Subgroup (Deck p)) [H.Normal] (e : p ⁻¹' {b}) :
+    regularSubgroupFiberOrbitQuotientEquivNormalizerQuotientOfNormal hp hreg H e
+        (subgroupFiberOrbitClass H e) =
+      Subgroup.normalizerQuotientMk H
+        ⟨1, by simp [_root_.Subgroup.normalizer_eq_top (H := H)]⟩ := by
+  apply (Subgroup.normalizerQuotientEquivQuotientOfNormal H).injective
+  rw [normalizerQuotientEquivQuotientOfNormal_regularSubgroupFiberOrbitQuotientEquiv,
+    Subgroup.normalizerQuotientEquivQuotientOfNormal_mk]
+  simpa using
+    regularSubgroupFiberOrbitQuotientEquivQuotientGroup_apply_inv_smul
+      hp hreg H e (1 : Deck p)
+
+/-- The normal-subgroup fibre quotient equivalence sends the class of `φ • e` to the
+normalizer-quotient class of `φ⁻¹`. -/
+@[simp]
+lemma regularSubgroupFiberOrbitQuotientEquivNormalizerQuotientOfNormal_apply_smul
+    [PreconnectedSpace E] (hp : IsCoveringMap p) (hreg : IsRegular p)
+    (H : Subgroup (Deck p)) [H.Normal] (e : p ⁻¹' {b}) (φ : Deck p) :
+    regularSubgroupFiberOrbitQuotientEquivNormalizerQuotientOfNormal hp hreg H e
+        (subgroupFiberOrbitClass H (φ • e)) =
+      Subgroup.normalizerQuotientMk H
+        ⟨φ⁻¹, by simp [_root_.Subgroup.normalizer_eq_top (H := H)]⟩ := by
+  apply (Subgroup.normalizerQuotientEquivQuotientOfNormal H).injective
+  rw [normalizerQuotientEquivQuotientOfNormal_regularSubgroupFiberOrbitQuotientEquiv,
+    regularSubgroupFiberOrbitQuotientEquivQuotientGroup_apply_smul,
+    Subgroup.normalizerQuotientEquivQuotientOfNormal_mk]
+  rfl
+
+/-- The normal-subgroup fibre quotient equivalence sends the class of `φ⁻¹ • e` to the
+normalizer-quotient class of `φ`. -/
+@[simp]
+lemma regularSubgroupFiberOrbitQuotientEquivNormalizerQuotientOfNormal_apply_inv_smul
+    [PreconnectedSpace E] (hp : IsCoveringMap p) (hreg : IsRegular p)
+    (H : Subgroup (Deck p)) [H.Normal] (e : p ⁻¹' {b}) (φ : Deck p) :
+    regularSubgroupFiberOrbitQuotientEquivNormalizerQuotientOfNormal hp hreg H e
+        (subgroupFiberOrbitClass H (φ⁻¹ • e)) =
+      Subgroup.normalizerQuotientMk H
+        ⟨φ, by simp [_root_.Subgroup.normalizer_eq_top (H := H)]⟩ := by
+  simpa using
+    regularSubgroupFiberOrbitQuotientEquivNormalizerQuotientOfNormal_apply_smul
+      hp hreg H e φ⁻¹
+
+/-- The inverse equivalence sends a normalizer representative to the fibre-orbit class of its
+inverse acting on the chosen fibre point. -/
+@[simp]
+lemma regularSubgroupFiberOrbitQuotientEquivNormalizerQuotientOfNormal_symm_mk
+    [PreconnectedSpace E] (hp : IsCoveringMap p) (hreg : IsRegular p)
+    (H : Subgroup (Deck p)) [H.Normal] (e : p ⁻¹' {b})
+    (φ : _root_.Subgroup.normalizer (H : Set (Deck p))) :
+    (regularSubgroupFiberOrbitQuotientEquivNormalizerQuotientOfNormal hp hreg H e).symm
+        (Subgroup.normalizerQuotientMk H φ) =
+      subgroupFiberOrbitClass H ((φ : Deck p)⁻¹ • e) := by
+  apply (regularSubgroupFiberOrbitQuotientEquivNormalizerQuotientOfNormal hp hreg H e).injective
+  rw [Equiv.apply_symm_apply,
+    regularSubgroupFiberOrbitQuotientEquivNormalizerQuotientOfNormal_apply_smul]
+  apply (Subgroup.normalizerQuotientEquivQuotientOfNormal H).injective
+  rw [Subgroup.normalizerQuotientEquivQuotientOfNormal_mk,
+    Subgroup.normalizerQuotientEquivQuotientOfNormal_mk]
+  simp
+
+/-- In particular, the inverse equivalence sends the identity normalizer quotient class to the
+chosen fibre-orbit class. -/
+@[simp]
+lemma regularSubgroupFiberOrbitQuotientEquivNormalizerQuotientOfNormal_symm_one
+    [PreconnectedSpace E] (hp : IsCoveringMap p) (hreg : IsRegular p)
+    (H : Subgroup (Deck p)) [H.Normal] (e : p ⁻¹' {b}) :
+    (regularSubgroupFiberOrbitQuotientEquivNormalizerQuotientOfNormal hp hreg H e).symm
+        (Subgroup.normalizerQuotientMk H
+          ⟨1, by simp [_root_.Subgroup.normalizer_eq_top (H := H)]⟩) =
+      subgroupFiberOrbitClass H e := by
+  simpa using
+    regularSubgroupFiberOrbitQuotientEquivNormalizerQuotientOfNormal_symm_mk
+      hp hreg H e ⟨1, by simp [_root_.Subgroup.normalizer_eq_top (H := H)]⟩
+
+end Deck
+
+end TauCeti

--- a/TauCeti/AlgebraicTopology/UniversalCover/Deck/NormalSubgroupFiberQuotient.lean
+++ b/TauCeti/AlgebraicTopology/UniversalCover/Deck/NormalSubgroupFiberQuotient.lean
@@ -49,7 +49,7 @@ transitive.
 
 Under normality, `N(H) = Deck p`, so this is the fibre-level version of the regular-cover
 specialization from `N(H) / H` to `Deck p / H`. -/
-@[expose] noncomputable def subgroupFiberOrbitQuotientEquivNormalizerQuotientOfNormal
+noncomputable def subgroupFiberOrbitQuotientEquivNormalizerQuotientOfNormal
     [MulAction.IsPretransitive (Deck p) (p ⁻¹' {b})] [IsCancelSMul (Deck p) (p ⁻¹' {b})]
     (H : Subgroup (Deck p)) [H.Normal] (e : p ⁻¹' {b}) :
     SubgroupFiberOrbitQuotient H b ≃ Subgroup.normalizerQuotient H :=
@@ -58,7 +58,7 @@ specialization from `N(H) / H` to `Deck p / H`. -/
 
 /-- For a regular preconnected covering and a normal subgroup `H ≤ Deck p`, the quotient of a
 fibre by the restricted `H`-action is the normalizer quotient `N(H) / H`. -/
-@[expose] noncomputable def regularSubgroupFiberOrbitQuotientEquivNormalizerQuotientOfNormal
+noncomputable def regularSubgroupFiberOrbitQuotientEquivNormalizerQuotientOfNormal
     [TopologicalSpace B] [PreconnectedSpace E] (hp : IsCoveringMap p) (hreg : IsRegular p)
     (H : Subgroup (Deck p)) [H.Normal] (e : p ⁻¹' {b}) :
     SubgroupFiberOrbitQuotient H b ≃ Subgroup.normalizerQuotient H :=
@@ -89,8 +89,21 @@ lemma normalizerQuotientEquivQuotientOfNormal_regularSubgroupFiberOrbitQuotientE
     Subgroup.normalizerQuotientEquivQuotientOfNormal H
         (regularSubgroupFiberOrbitQuotientEquivNormalizerQuotientOfNormal hp hreg H e x) =
       regularSubgroupFiberOrbitQuotientEquivQuotientGroup hp hreg H e x := by
-  exact (Subgroup.normalizerQuotientEquivQuotientOfNormal H).toEquiv.apply_symm_apply
-    (regularSubgroupFiberOrbitQuotientEquivQuotientGroup hp hreg H e x)
+  letI := hreg.fiber_isPretransitive b
+  letI := fiber_isCancelSMul (b := b) hp
+  refine Quotient.inductionOn' x ?_
+  intro e'
+  obtain ⟨φ, hφ⟩ := MulAction.exists_smul_eq (Deck p) e e'
+  rw [← hφ]
+  change
+    Subgroup.normalizerQuotientEquivQuotientOfNormal H
+        (subgroupFiberOrbitQuotientEquivNormalizerQuotientOfNormal H e
+          (subgroupFiberOrbitClass H (φ • e))) =
+      regularSubgroupFiberOrbitQuotientEquivQuotientGroup hp hreg H e
+        (subgroupFiberOrbitClass H (φ • e))
+  rw [normalizerQuotientEquivQuotientOfNormal_subgroupFiberOrbitQuotientEquiv,
+    subgroupFiberOrbitQuotientEquivQuotientGroup_apply_smul,
+    regularSubgroupFiberOrbitQuotientEquivQuotientGroup_apply_smul]
 
 /-- The chosen fibre point maps to the identity class in the normalizer quotient. -/
 @[simp]

--- a/TauCeti/AlgebraicTopology/UniversalCover/Deck/NormalSubgroupFiberQuotient.lean
+++ b/TauCeti/AlgebraicTopology/UniversalCover/Deck/NormalSubgroupFiberQuotient.lean
@@ -19,11 +19,13 @@ normalizer quotients without redoing the algebraic comparison.
 
 ## Main declarations
 
-* `TauCeti.Deck.regularSubgroupFiberOrbitQuotientEquivNormalizerQuotientOfNormal`: for a
-  regular preconnected cover and a normal subgroup `H ≤ Deck p`, the quotient of a fibre by
-  `H` is equivalent to `N(H) / H`.
-* Simp lemmas for the image of the chosen lift, its deck translates, and representatives of
-  the inverse map.
+* `TauCeti.Deck.subgroupFiberOrbitQuotientEquivNormalizerQuotientOfNormal`: for a normal
+  subgroup `H ≤ Deck p`, identifies the subgroup fibre-orbit quotient with `N(H) / H` when
+  the deck action on the chosen fibre is free and transitive.
+* `TauCeti.Deck.regularSubgroupFiberOrbitQuotientEquivNormalizerQuotientOfNormal`: the
+  regular-cover specialization.
+* Simp lemmas for the image of the chosen fibre point, its deck translates, and
+  representatives of the inverse map.
 
 ## References
 
@@ -39,25 +41,49 @@ namespace TauCeti
 
 namespace Deck
 
-variable {E B : Type*} [TopologicalSpace E] [TopologicalSpace B] {p : E → B} {b : B}
+variable {E B : Type*} [TopologicalSpace E] {p : E → B} {b : B}
 
-/-- For a regular preconnected covering and a normal subgroup `H ≤ Deck p`, the quotient of a
-fibre by the restricted `H`-action is the normalizer quotient `N(H) / H`.
+/-- For a normal subgroup `H ≤ Deck p`, the quotient of a fibre by the restricted `H`-action
+is the normalizer quotient `N(H) / H`, once the deck action on the fibre is free and
+transitive.
 
 Under normality, `N(H) = Deck p`, so this is the fibre-level version of the regular-cover
 specialization from `N(H) / H` to `Deck p / H`. -/
-noncomputable def regularSubgroupFiberOrbitQuotientEquivNormalizerQuotientOfNormal
-    [PreconnectedSpace E] (hp : IsCoveringMap p) (hreg : IsRegular p)
+@[expose] noncomputable def subgroupFiberOrbitQuotientEquivNormalizerQuotientOfNormal
+    [MulAction.IsPretransitive (Deck p) (p ⁻¹' {b})] [IsCancelSMul (Deck p) (p ⁻¹' {b})]
     (H : Subgroup (Deck p)) [H.Normal] (e : p ⁻¹' {b}) :
     SubgroupFiberOrbitQuotient H b ≃ Subgroup.normalizerQuotient H :=
-  (regularSubgroupFiberOrbitQuotientEquivQuotientGroup hp hreg H e).trans
+  (subgroupFiberOrbitQuotientEquivQuotientGroup H e).trans
     (Subgroup.normalizerQuotientEquivQuotientOfNormal H).toEquiv.symm
+
+/-- For a regular preconnected covering and a normal subgroup `H ≤ Deck p`, the quotient of a
+fibre by the restricted `H`-action is the normalizer quotient `N(H) / H`. -/
+@[expose] noncomputable def regularSubgroupFiberOrbitQuotientEquivNormalizerQuotientOfNormal
+    [TopologicalSpace B] [PreconnectedSpace E] (hp : IsCoveringMap p) (hreg : IsRegular p)
+    (H : Subgroup (Deck p)) [H.Normal] (e : p ⁻¹' {b}) :
+    SubgroupFiberOrbitQuotient H b ≃ Subgroup.normalizerQuotient H :=
+  letI := hreg.fiber_isPretransitive b
+  letI := fiber_isCancelSMul (b := b) hp
+  subgroupFiberOrbitQuotientEquivNormalizerQuotientOfNormal H e
 
 /-- The normal-subgroup fibre quotient equivalence, followed by the normalizer quotient's
 normal-case comparison, is the existing equivalence to `Deck p ⧸ H`. -/
 @[simp]
+lemma normalizerQuotientEquivQuotientOfNormal_subgroupFiberOrbitQuotientEquiv
+    [MulAction.IsPretransitive (Deck p) (p ⁻¹' {b})] [IsCancelSMul (Deck p) (p ⁻¹' {b})]
+    (H : Subgroup (Deck p)) [H.Normal] (e : p ⁻¹' {b})
+    (x : SubgroupFiberOrbitQuotient H b) :
+    Subgroup.normalizerQuotientEquivQuotientOfNormal H
+        (subgroupFiberOrbitQuotientEquivNormalizerQuotientOfNormal H e x) =
+      subgroupFiberOrbitQuotientEquivQuotientGroup H e x := by
+  exact (Subgroup.normalizerQuotientEquivQuotientOfNormal H).toEquiv.apply_symm_apply
+    (subgroupFiberOrbitQuotientEquivQuotientGroup H e x)
+
+/-- For a regular cover, the normal-subgroup fibre quotient equivalence, followed by the
+normalizer quotient's normal-case comparison, is the existing equivalence to `Deck p ⧸ H`. -/
+@[simp]
 lemma normalizerQuotientEquivQuotientOfNormal_regularSubgroupFiberOrbitQuotientEquiv
-    [PreconnectedSpace E] (hp : IsCoveringMap p) (hreg : IsRegular p)
+    [TopologicalSpace B] [PreconnectedSpace E] (hp : IsCoveringMap p) (hreg : IsRegular p)
     (H : Subgroup (Deck p)) [H.Normal] (e : p ⁻¹' {b})
     (x : SubgroupFiberOrbitQuotient H b) :
     Subgroup.normalizerQuotientEquivQuotientOfNormal H
@@ -68,8 +94,24 @@ lemma normalizerQuotientEquivQuotientOfNormal_regularSubgroupFiberOrbitQuotientE
 
 /-- The chosen fibre point maps to the identity class in the normalizer quotient. -/
 @[simp]
+lemma subgroupFiberOrbitQuotientEquivNormalizerQuotientOfNormal_apply_base
+    [MulAction.IsPretransitive (Deck p) (p ⁻¹' {b})] [IsCancelSMul (Deck p) (p ⁻¹' {b})]
+    (H : Subgroup (Deck p)) [H.Normal] (e : p ⁻¹' {b}) :
+    subgroupFiberOrbitQuotientEquivNormalizerQuotientOfNormal H e
+        (subgroupFiberOrbitClass H e) =
+      Subgroup.normalizerQuotientMk H
+        ⟨1, by simp [_root_.Subgroup.normalizer_eq_top (H := H)]⟩ := by
+  apply (Subgroup.normalizerQuotientEquivQuotientOfNormal H).injective
+  rw [normalizerQuotientEquivQuotientOfNormal_subgroupFiberOrbitQuotientEquiv,
+    Subgroup.normalizerQuotientEquivQuotientOfNormal_mk]
+  simpa using
+    subgroupFiberOrbitQuotientEquivQuotientGroup_apply_inv_smul H e (1 : Deck p)
+
+/-- For a regular cover, the chosen fibre point maps to the identity class in the normalizer
+quotient. -/
+@[simp]
 lemma regularSubgroupFiberOrbitQuotientEquivNormalizerQuotientOfNormal_apply_base
-    [PreconnectedSpace E] (hp : IsCoveringMap p) (hreg : IsRegular p)
+    [TopologicalSpace B] [PreconnectedSpace E] (hp : IsCoveringMap p) (hreg : IsRegular p)
     (H : Subgroup (Deck p)) [H.Normal] (e : p ⁻¹' {b}) :
     regularSubgroupFiberOrbitQuotientEquivNormalizerQuotientOfNormal hp hreg H e
         (subgroupFiberOrbitClass H e) =
@@ -85,8 +127,24 @@ lemma regularSubgroupFiberOrbitQuotientEquivNormalizerQuotientOfNormal_apply_bas
 /-- The normal-subgroup fibre quotient equivalence sends the class of `φ • e` to the
 normalizer-quotient class of `φ⁻¹`. -/
 @[simp]
+lemma subgroupFiberOrbitQuotientEquivNormalizerQuotientOfNormal_apply_smul
+    [MulAction.IsPretransitive (Deck p) (p ⁻¹' {b})] [IsCancelSMul (Deck p) (p ⁻¹' {b})]
+    (H : Subgroup (Deck p)) [H.Normal] (e : p ⁻¹' {b}) (φ : Deck p) :
+    subgroupFiberOrbitQuotientEquivNormalizerQuotientOfNormal H e
+        (subgroupFiberOrbitClass H (φ • e)) =
+      Subgroup.normalizerQuotientMk H
+        ⟨φ⁻¹, by simp [_root_.Subgroup.normalizer_eq_top (H := H)]⟩ := by
+  apply (Subgroup.normalizerQuotientEquivQuotientOfNormal H).injective
+  rw [normalizerQuotientEquivQuotientOfNormal_subgroupFiberOrbitQuotientEquiv,
+    subgroupFiberOrbitQuotientEquivQuotientGroup_apply_smul,
+    Subgroup.normalizerQuotientEquivQuotientOfNormal_mk]
+  rfl
+
+/-- For a regular cover, the normal-subgroup fibre quotient equivalence sends the class of
+`φ • e` to the normalizer-quotient class of `φ⁻¹`. -/
+@[simp]
 lemma regularSubgroupFiberOrbitQuotientEquivNormalizerQuotientOfNormal_apply_smul
-    [PreconnectedSpace E] (hp : IsCoveringMap p) (hreg : IsRegular p)
+    [TopologicalSpace B] [PreconnectedSpace E] (hp : IsCoveringMap p) (hreg : IsRegular p)
     (H : Subgroup (Deck p)) [H.Normal] (e : p ⁻¹' {b}) (φ : Deck p) :
     regularSubgroupFiberOrbitQuotientEquivNormalizerQuotientOfNormal hp hreg H e
         (subgroupFiberOrbitClass H (φ • e)) =
@@ -101,8 +159,21 @@ lemma regularSubgroupFiberOrbitQuotientEquivNormalizerQuotientOfNormal_apply_smu
 /-- The normal-subgroup fibre quotient equivalence sends the class of `φ⁻¹ • e` to the
 normalizer-quotient class of `φ`. -/
 @[simp]
+lemma subgroupFiberOrbitQuotientEquivNormalizerQuotientOfNormal_apply_inv_smul
+    [MulAction.IsPretransitive (Deck p) (p ⁻¹' {b})] [IsCancelSMul (Deck p) (p ⁻¹' {b})]
+    (H : Subgroup (Deck p)) [H.Normal] (e : p ⁻¹' {b}) (φ : Deck p) :
+    subgroupFiberOrbitQuotientEquivNormalizerQuotientOfNormal H e
+        (subgroupFiberOrbitClass H (φ⁻¹ • e)) =
+      Subgroup.normalizerQuotientMk H
+        ⟨φ, by simp [_root_.Subgroup.normalizer_eq_top (H := H)]⟩ := by
+  simpa using
+    subgroupFiberOrbitQuotientEquivNormalizerQuotientOfNormal_apply_smul H e φ⁻¹
+
+/-- For a regular cover, the normal-subgroup fibre quotient equivalence sends the class of
+`φ⁻¹ • e` to the normalizer-quotient class of `φ`. -/
+@[simp]
 lemma regularSubgroupFiberOrbitQuotientEquivNormalizerQuotientOfNormal_apply_inv_smul
-    [PreconnectedSpace E] (hp : IsCoveringMap p) (hreg : IsRegular p)
+    [TopologicalSpace B] [PreconnectedSpace E] (hp : IsCoveringMap p) (hreg : IsRegular p)
     (H : Subgroup (Deck p)) [H.Normal] (e : p ⁻¹' {b}) (φ : Deck p) :
     regularSubgroupFiberOrbitQuotientEquivNormalizerQuotientOfNormal hp hreg H e
         (subgroupFiberOrbitClass H (φ⁻¹ • e)) =
@@ -115,8 +186,26 @@ lemma regularSubgroupFiberOrbitQuotientEquivNormalizerQuotientOfNormal_apply_inv
 /-- The inverse equivalence sends a normalizer representative to the fibre-orbit class of its
 inverse acting on the chosen fibre point. -/
 @[simp]
+lemma subgroupFiberOrbitQuotientEquivNormalizerQuotientOfNormal_symm_mk
+    [MulAction.IsPretransitive (Deck p) (p ⁻¹' {b})] [IsCancelSMul (Deck p) (p ⁻¹' {b})]
+    (H : Subgroup (Deck p)) [H.Normal] (e : p ⁻¹' {b})
+    (φ : _root_.Subgroup.normalizer (H : Set (Deck p))) :
+    (subgroupFiberOrbitQuotientEquivNormalizerQuotientOfNormal H e).symm
+        (Subgroup.normalizerQuotientMk H φ) =
+      subgroupFiberOrbitClass H ((φ : Deck p)⁻¹ • e) := by
+  apply (subgroupFiberOrbitQuotientEquivNormalizerQuotientOfNormal H e).injective
+  rw [Equiv.apply_symm_apply,
+    subgroupFiberOrbitQuotientEquivNormalizerQuotientOfNormal_apply_smul]
+  apply (Subgroup.normalizerQuotientEquivQuotientOfNormal H).injective
+  rw [Subgroup.normalizerQuotientEquivQuotientOfNormal_mk,
+    Subgroup.normalizerQuotientEquivQuotientOfNormal_mk]
+  simp
+
+/-- For a regular cover, the inverse equivalence sends a normalizer representative to the
+fibre-orbit class of its inverse acting on the chosen fibre point. -/
+@[simp]
 lemma regularSubgroupFiberOrbitQuotientEquivNormalizerQuotientOfNormal_symm_mk
-    [PreconnectedSpace E] (hp : IsCoveringMap p) (hreg : IsRegular p)
+    [TopologicalSpace B] [PreconnectedSpace E] (hp : IsCoveringMap p) (hreg : IsRegular p)
     (H : Subgroup (Deck p)) [H.Normal] (e : p ⁻¹' {b})
     (φ : _root_.Subgroup.normalizer (H : Set (Deck p))) :
     (regularSubgroupFiberOrbitQuotientEquivNormalizerQuotientOfNormal hp hreg H e).symm
@@ -133,8 +222,22 @@ lemma regularSubgroupFiberOrbitQuotientEquivNormalizerQuotientOfNormal_symm_mk
 /-- In particular, the inverse equivalence sends the identity normalizer quotient class to the
 chosen fibre-orbit class. -/
 @[simp]
+lemma subgroupFiberOrbitQuotientEquivNormalizerQuotientOfNormal_symm_one
+    [MulAction.IsPretransitive (Deck p) (p ⁻¹' {b})] [IsCancelSMul (Deck p) (p ⁻¹' {b})]
+    (H : Subgroup (Deck p)) [H.Normal] (e : p ⁻¹' {b}) :
+    (subgroupFiberOrbitQuotientEquivNormalizerQuotientOfNormal H e).symm
+        (Subgroup.normalizerQuotientMk H
+          ⟨1, by simp [_root_.Subgroup.normalizer_eq_top (H := H)]⟩) =
+      subgroupFiberOrbitClass H e := by
+  simpa using
+    subgroupFiberOrbitQuotientEquivNormalizerQuotientOfNormal_symm_mk
+      H e ⟨1, by simp [_root_.Subgroup.normalizer_eq_top (H := H)]⟩
+
+/-- For a regular cover, the inverse equivalence sends the identity normalizer quotient class
+to the chosen fibre-orbit class. -/
+@[simp]
 lemma regularSubgroupFiberOrbitQuotientEquivNormalizerQuotientOfNormal_symm_one
-    [PreconnectedSpace E] (hp : IsCoveringMap p) (hreg : IsRegular p)
+    [TopologicalSpace B] [PreconnectedSpace E] (hp : IsCoveringMap p) (hreg : IsRegular p)
     (H : Subgroup (Deck p)) [H.Normal] (e : p ⁻¹' {b}) :
     (regularSubgroupFiberOrbitQuotientEquivNormalizerQuotientOfNormal hp hreg H e).symm
         (Subgroup.normalizerQuotientMk H

--- a/TauCeti/AlgebraicTopology/UniversalCover/Deck/SubgroupFiberOrbitQuotientGroup.lean
+++ b/TauCeti/AlgebraicTopology/UniversalCover/Deck/SubgroupFiberOrbitQuotientGroup.lean
@@ -111,7 +111,7 @@ variable {E B : Type*} [TopologicalSpace E] {p : E → B} {b : B}
 
 /-- The subgroup-fibre orbit quotient is equivalent to the quotient of the deck group by the
 subgroup, once the deck action on the chosen fibre is free and transitive. -/
-noncomputable def subgroupFiberOrbitQuotientEquivQuotientGroup
+@[expose] noncomputable def subgroupFiberOrbitQuotientEquivQuotientGroup
     [MulAction.IsPretransitive (Deck p) (p ⁻¹' {b})] [IsCancelSMul (Deck p) (p ⁻¹' {b})]
     (H : Subgroup (Deck p)) (e : p ⁻¹' {b}) :
     SubgroupFiberOrbitQuotient H b ≃ Deck p ⧸ H :=
@@ -119,7 +119,7 @@ noncomputable def subgroupFiberOrbitQuotientEquivQuotientGroup
 
 /-- For a regular preconnected covering map, the subgroup-fibre orbit quotient is equivalent
 to the quotient of the deck group by the subgroup. -/
-noncomputable def regularSubgroupFiberOrbitQuotientEquivQuotientGroup
+@[expose] noncomputable def regularSubgroupFiberOrbitQuotientEquivQuotientGroup
     [TopologicalSpace B] [PreconnectedSpace E] (hp : IsCoveringMap p) (hreg : IsRegular p)
     (H : Subgroup (Deck p)) (e : p ⁻¹' {b}) :
     SubgroupFiberOrbitQuotient H b ≃ Deck p ⧸ H :=

--- a/TauCeti/AlgebraicTopology/UniversalCover/Deck/SubgroupFiberOrbitQuotientGroup.lean
+++ b/TauCeti/AlgebraicTopology/UniversalCover/Deck/SubgroupFiberOrbitQuotientGroup.lean
@@ -111,7 +111,7 @@ variable {E B : Type*} [TopologicalSpace E] {p : E → B} {b : B}
 
 /-- The subgroup-fibre orbit quotient is equivalent to the quotient of the deck group by the
 subgroup, once the deck action on the chosen fibre is free and transitive. -/
-@[expose] noncomputable def subgroupFiberOrbitQuotientEquivQuotientGroup
+noncomputable def subgroupFiberOrbitQuotientEquivQuotientGroup
     [MulAction.IsPretransitive (Deck p) (p ⁻¹' {b})] [IsCancelSMul (Deck p) (p ⁻¹' {b})]
     (H : Subgroup (Deck p)) (e : p ⁻¹' {b}) :
     SubgroupFiberOrbitQuotient H b ≃ Deck p ⧸ H :=
@@ -119,7 +119,7 @@ subgroup, once the deck action on the chosen fibre is free and transitive. -/
 
 /-- For a regular preconnected covering map, the subgroup-fibre orbit quotient is equivalent
 to the quotient of the deck group by the subgroup. -/
-@[expose] noncomputable def regularSubgroupFiberOrbitQuotientEquivQuotientGroup
+noncomputable def regularSubgroupFiberOrbitQuotientEquivQuotientGroup
     [TopologicalSpace B] [PreconnectedSpace E] (hp : IsCoveringMap p) (hreg : IsRegular p)
     (H : Subgroup (Deck p)) (e : p ⁻¹' {b}) :
     SubgroupFiberOrbitQuotient H b ≃ Deck p ⧸ H :=


### PR DESCRIPTION
This PR adds the normal-subgroup specialization of the regular deck fibre quotient: for a regular preconnected covering map and a normal subgroup `H ≤ Deck p`, the quotient of a fibre by the restricted `H`-action is identified directly with the normalizer quotient `N(H) / H`, with simp lemmas for the chosen lift, deck translates, and inverse representatives.

It advances `TauCetiRoadmap/UniversalCovers/README.md`, Stage 2, item 8, specifically the regular-cover bookkeeping where “For the cover attached to `H`, the deck group is `N(H)/H`; it is a regular (normal/Galois) cover iff `H ◁ π₁(X, x₀)`, and then the deck group is `π₁(X, x₀)/H`.” I chose this as the lowest-hanging distinct UniversalCovers prerequisite after checking open and recently merged PRs: #455 covers fundamental-group subgroup basepoint change, while merged UniversalCovers work already covers the lifting criterion, normalizer quotient API, deck subgroup fibre-orbit quotients, regular fibre torsors, and regular fibre quotient groups. This PR only packages the remaining normal-subgroup comparison needed by later quotient-cover deck-group computations.

No Mathlib infrastructure is vendored. The implementation reuses Tau Ceti’s existing `Deck.regularSubgroupFiberOrbitQuotientEquivQuotientGroup` and `Subgroup.normalizerQuotientEquivQuotientOfNormal`, which in turn build on Mathlib’s `MulAction.equivSubgroupOrbitsQuotientGroup` and quotient-group API.

`lake exe cache get` completed with `No files to download` and `Already decompressed 8586 file(s)`. `lake build` completed with `Build completed successfully (4272 jobs).` `lake exe axioms` completed with `axioms: audited 5574 TauCeti declaration(s); all within the allowlist [propext, Classical.choice, Quot.sound].`

<!--tauceti-target:v1 {"focus":"UniversalCovers","id":"regular-normal-deck-subgroup-fiber-quotient"}-->

🤖 Prepared with Codex
