### PR TITLE
feat: add Hermite count threshold bounds

### DIFF
--- a/TauCeti/NumberTheory/EffectiveBounds/HermiteCountThreshold.lean
+++ b/TauCeti/NumberTheory/EffectiveBounds/HermiteCountThreshold.lean
@@ -12,9 +12,9 @@ public import TauCeti.NumberTheory.EffectiveBounds.HermiteCountMonotone
 
 The exact effective Hermite--Minkowski bound in
 `TauCeti.NumberField.ncard_setOf_finiteDimensional_abs_discr_le_le` counts number fields in a fixed
-ambient extension whose discriminant is at most a chosen threshold `N`. The monotone wrappers in
-`TauCeti.NumberTheory.EffectiveBounds.HermiteCountMonotone` allow the degree and coefficient-height
-constants for that same threshold to be replaced by larger constants.
+ambient extension whose absolute discriminant is at most a chosen threshold `N`. The monotone
+wrappers in `TauCeti.NumberTheory.EffectiveBounds.HermiteCountMonotone` allow the degree and
+coefficient-height constants for that same threshold to be replaced by larger constants.
 
 This file records the other monotonicity that later effective estimates need: a field family cut
 out by `|d_K| ≤ N` may be counted using the explicit constants attached to any larger threshold
@@ -56,8 +56,8 @@ private theorem setOf_finiteDimensional_abs_discr_le_subset_of_le {N M : ℕ} (h
   exact @le_trans ℤ _ |discr K| (N : ℤ) (M : ℤ) hK (by exact_mod_cast hNM)
 
 /-- **Threshold-monotone effective Hermite--Minkowski.** If `N ≤ M`, then the number of
-finite-dimensional subfields of an ambient extension `A / ℚ` with discriminant at most `N` is
-bounded by the explicit Hermite-count expression attached to the larger threshold `M`. -/
+finite-dimensional subfields of an ambient extension `A / ℚ` with absolute discriminant at most `N`
+is bounded by the explicit Hermite-count expression attached to the larger threshold `M`. -/
 theorem ncard_setOf_finiteDimensional_abs_discr_le_le_of_threshold_le {N M : ℕ}
     (hNM : N ≤ M) :
     {K : {F : IntermediateField ℚ A // FiniteDimensional ℚ F} |
@@ -70,8 +70,8 @@ theorem ncard_setOf_finiteDimensional_abs_discr_le_le_of_threshold_le {N M : ℕ
 
 /-- **Threshold-monotone effective Hermite--Minkowski with coarser constants.** If `N ≤ M`, and
 `D` and `C` bound the degree and coefficient-height constants attached to `M`, then the number of
-finite-dimensional subfields of an ambient extension `A / ℚ` with discriminant at most `N` is at
-most `hermiteCountBound D C`. -/
+finite-dimensional subfields of an ambient extension `A / ℚ` with absolute discriminant at most `N`
+is at most `hermiteCountBound D C`. -/
 theorem ncard_setOf_finiteDimensional_abs_discr_le_le_of_threshold_bounds {N M D C : ℕ}
     (hNM : N ≤ M) (hD : rankOfDiscrBdd M ≤ D) (hC : coeffBoundOfDiscrBdd M ≤ C) :
     {K : {F : IntermediateField ℚ A // FiniteDimensional ℚ F} |

--- a/TauCeti/NumberTheory/EffectiveBounds/HermiteCountThreshold.lean
+++ b/TauCeti/NumberTheory/EffectiveBounds/HermiteCountThreshold.lean
@@ -1,0 +1,95 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+module
+
+public import TauCeti.NumberTheory.EffectiveBounds.HermiteCountMonotone
+
+/-!
+# Threshold-monotone forms of the effective Hermite--Minkowski count
+
+The exact effective Hermite--Minkowski bound in
+`TauCeti.NumberField.ncard_setOf_finiteDimensional_abs_discr_le_le` counts number fields in a fixed
+ambient extension whose discriminant is at most a chosen threshold `N`. The monotone wrappers in
+`TauCeti.NumberTheory.EffectiveBounds.HermiteCountMonotone` allow the degree and coefficient-height
+constants for that same threshold to be replaced by larger constants.
+
+This file records the other monotonicity that later effective estimates need: a field family cut
+out by `|d_K| ≤ N` may be counted using the explicit constants attached to any larger threshold
+`M`. This keeps downstream arithmetic free to round the discriminant threshold upward first and then
+use the Hermite-count constants for the rounded bound.
+
+## Main results
+
+* `TauCeti.NumberField.ncard_setOf_finiteDimensional_abs_discr_le_le_of_threshold_le`: if
+  `N ≤ M`, then the fields with `|d_K| ≤ N` are bounded by the exact Hermite count at `M`.
+* `TauCeti.NumberField.ncard_setOf_finiteDimensional_abs_discr_le_le_of_threshold_bounds`: the
+  same statement with the degree and coefficient-height constants at `M` replaced by any larger
+  explicit bounds.
+
+No formal code is vendored. The proof reuses Mathlib's qualitative
+`NumberField.finite_of_discr_bdd` for the finite target set, and Tau Ceti's existing explicit
+Hermite-count API.
+-/
+
+public section
+
+open Module NumberField NumberField.hermiteTheorem
+
+namespace TauCeti.NumberField
+
+variable (A : Type*) [Field A] [CharZero A]
+
+/-- The bounded-discriminant subfields at threshold `N` form a subset of those at threshold `M`
+whenever `N ≤ M`. -/
+private theorem setOf_finiteDimensional_abs_discr_le_subset_of_le {N M : ℕ} (hNM : N ≤ M) :
+    {K : {F : IntermediateField ℚ A // FiniteDimensional ℚ F} |
+        haveI : _root_.NumberField K := @NumberField.mk _ _ inferInstance K.prop
+        |discr K| ≤ (N : ℤ)} ⊆
+      {K : {F : IntermediateField ℚ A // FiniteDimensional ℚ F} |
+        haveI : _root_.NumberField K := @NumberField.mk _ _ inferInstance K.prop
+        |discr K| ≤ (M : ℤ)} := by
+  intro K hK
+  haveI : _root_.NumberField K := @NumberField.mk _ _ inferInstance K.prop
+  exact @le_trans ℤ _ |discr K| (N : ℤ) (M : ℤ) hK (by exact_mod_cast hNM)
+
+/-- **Threshold-monotone effective Hermite--Minkowski.** If `N ≤ M`, then the number of
+finite-dimensional subfields of an ambient extension `A / ℚ` with discriminant at most `N` is
+bounded by the explicit Hermite-count expression attached to the larger threshold `M`. -/
+theorem ncard_setOf_finiteDimensional_abs_discr_le_le_of_threshold_le {N M : ℕ}
+    (hNM : N ≤ M) :
+    {K : {F : IntermediateField ℚ A // FiniteDimensional ℚ F} |
+        haveI : _root_.NumberField K := @NumberField.mk _ _ inferInstance K.prop
+        |discr K| ≤ (N : ℤ)}.ncard ≤
+      hermiteCountBound (rankOfDiscrBdd M) (coeffBoundOfDiscrBdd M) :=
+  (Set.ncard_le_ncard (setOf_finiteDimensional_abs_discr_le_subset_of_le (A := A) hNM)
+      (NumberField.finite_of_discr_bdd A M)).trans
+    (ncard_setOf_finiteDimensional_abs_discr_le_le_hermiteCountBound (A := A) M)
+
+/-- **Threshold-monotone effective Hermite--Minkowski with coarser constants.** If `N ≤ M`, and
+`D` and `C` bound the degree and coefficient-height constants attached to `M`, then the number of
+finite-dimensional subfields of an ambient extension `A / ℚ` with discriminant at most `N` is at
+most `hermiteCountBound D C`. -/
+theorem ncard_setOf_finiteDimensional_abs_discr_le_le_of_threshold_bounds {N M D C : ℕ}
+    (hNM : N ≤ M) (hD : rankOfDiscrBdd M ≤ D) (hC : coeffBoundOfDiscrBdd M ≤ C) :
+    {K : {F : IntermediateField ℚ A // FiniteDimensional ℚ F} |
+        haveI : _root_.NumberField K := @NumberField.mk _ _ inferInstance K.prop
+        |discr K| ≤ (N : ℤ)}.ncard ≤ hermiteCountBound D C :=
+  (ncard_setOf_finiteDimensional_abs_discr_le_le_of_threshold_le (A := A) hNM).trans
+    (hermiteCountBound_mono hD hC)
+
+/-- If all later arithmetic is carried out with a single rounded discriminant threshold `M`, this is
+the direct exact-constant form of
+`TauCeti.NumberField.ncard_setOf_finiteDimensional_abs_discr_le_le_of_threshold_bounds`. -/
+theorem ncard_setOf_finiteDimensional_abs_discr_le_le_of_threshold_le_of_bounds {N M D C : ℕ}
+    (hNM : N ≤ M) (hD : rankOfDiscrBdd M ≤ D) (hC : coeffBoundOfDiscrBdd M ≤ C) :
+    {K : {F : IntermediateField ℚ A // FiniteDimensional ℚ F} |
+        haveI : _root_.NumberField K := @NumberField.mk _ _ inferInstance K.prop
+        |discr K| ≤ (N : ℤ)}.ncard ≤ (2 * C + 1) ^ (D + 1) * D := by
+  rw [← hermiteCountBound_def]
+  exact
+    ncard_setOf_finiteDimensional_abs_discr_le_le_of_threshold_bounds
+      (A := A) hNM hD hC
+
+end TauCeti.NumberField

--- a/TauCeti/NumberTheory/EffectiveBounds/HermiteCountThreshold.lean
+++ b/TauCeti/NumberTheory/EffectiveBounds/HermiteCountThreshold.lean
@@ -4,6 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 -/
 module
 
+public import Mathlib.NumberTheory.NumberField.Discriminant.Basic
 public import TauCeti.NumberTheory.EffectiveBounds.HermiteCountMonotone
 
 /-!
@@ -78,18 +79,5 @@ theorem ncard_setOf_finiteDimensional_abs_discr_le_le_of_threshold_bounds {N M D
         |discr K| ≤ (N : ℤ)}.ncard ≤ hermiteCountBound D C :=
   (ncard_setOf_finiteDimensional_abs_discr_le_le_of_threshold_le (A := A) hNM).trans
     (hermiteCountBound_mono hD hC)
-
-/-- If all later arithmetic is carried out with a single rounded discriminant threshold `M`, this is
-the direct exact-constant form of
-`TauCeti.NumberField.ncard_setOf_finiteDimensional_abs_discr_le_le_of_threshold_bounds`. -/
-theorem ncard_setOf_finiteDimensional_abs_discr_le_le_of_threshold_le_of_bounds {N M D C : ℕ}
-    (hNM : N ≤ M) (hD : rankOfDiscrBdd M ≤ D) (hC : coeffBoundOfDiscrBdd M ≤ C) :
-    {K : {F : IntermediateField ℚ A // FiniteDimensional ℚ F} |
-        haveI : _root_.NumberField K := @NumberField.mk _ _ inferInstance K.prop
-        |discr K| ≤ (N : ℤ)}.ncard ≤ (2 * C + 1) ^ (D + 1) * D := by
-  rw [← hermiteCountBound_def]
-  exact
-    ncard_setOf_finiteDimensional_abs_discr_le_le_of_threshold_bounds
-      (A := A) hNM hD hC
 
 end TauCeti.NumberField


### PR DESCRIPTION
This PR adds threshold-monotone consumer forms of the effective Hermite--Minkowski count: if `N ≤ M`, then the finite-dimensional subfields of a fixed ambient extension `A / ℚ` with `|d_K| ≤ N` can be counted using the explicit Hermite-count constants attached to the larger threshold `M`, and also using any coarser degree and coefficient-height bounds above those constants.

It advances `TauCetiRoadmap/EffectiveBounds/README.md`, Layer 2, specifically the effective Hermite--Minkowski item asking for “an explicit upper bound on the number of number fields (in a fixed `A/ℚ`) of discriminant `≤ B`”. I chose this as the lowest-hanging distinct EffectiveBounds prerequisite after checking open and recently merged PRs: the core Layer 1 bounds, quadratic consumers, exact effective Hermite count, fixed-threshold Hermite monotone wrappers, ideal-count monotone wrappers, and rank-zero regulator lower bounds already exist, while this discriminant-threshold wrapper was still absent and is a direct consumer API for later rounded explicit estimates.

No Mathlib infrastructure is vendored. The implementation reuses Mathlib's qualitative `NumberField.finite_of_discr_bdd` for finite target-set comparison, and Tau Ceti's existing `TauCeti.NumberField.ncard_setOf_finiteDimensional_abs_discr_le_le_hermiteCountBound`, `TauCeti.NumberField.hermiteCountBound_mono`, and `TauCeti.NumberField.hermiteCountBound_def`.

`lake exe cache get` completed with `No files to download` and `Already decompressed 8586 file(s)`. `lake build` completed with `Build completed successfully (4274 jobs).` `lake exe axioms` completed with `axioms: audited 5588 TauCeti declaration(s); all within the allowlist [propext, Classical.choice, Quot.sound].`

<!--tauceti-target:v1 {"focus":"EffectiveBounds","id":"hermite-count-discriminant-threshold"}-->

🤖 Prepared with Codex
