### PR TITLE
feat: add symmetric coercive energy integrands

### DIFF
--- a/TauCeti/Analysis/PDE/CoerciveEnergy.lean
+++ b/TauCeti/Analysis/PDE/CoerciveEnergy.lean
@@ -36,6 +36,8 @@ energy method, as in Evans, *Partial Differential Equations*, Chapter 6.
   from one principal coefficient, drift vector, and mass coefficient.
 * `TauCeti.PDE.isCoercive_energyIntegrand_zero_drift`: the zero-drift specialization,
   needing only a positive zeroth-order coefficient.
+* `TauCeti.PDE.min_lam_mass_mul_norm_sq_le_energyIntegrand_zero_drift_self`: explicit
+  zero-drift diagonal lower bound from a principal quadratic lower bound and nonnegative mass.
 * `TauCeti.PDE.isCoercive_energyIntegrand_of_bounds_on`: pointwise coercivity on a domain
   from an ellipticity floor, a drift bound, and a dominating mass lower bound.
 -/
@@ -155,6 +157,32 @@ lemma isCoercive_energyIntegrand_zero_drift (hlam : 0 < lam) {A : Matrix n n ℝ
     IsCoercive (energyIntegrand A 0 c₀) :=
   isCoercive_energyIntegrand_of_bounds (beta := 0) (mu := c₀) hlam hA (by simp) le_rfl
     (by simpa using hc₀)
+
+/-- Zero-drift diagonal lower bound from a principal quadratic lower bound and nonnegative
+mass coefficient. -/
+lemma min_lam_mass_mul_norm_sq_le_energyIntegrand_zero_drift_self {A : Matrix n n ℝ}
+    {c₀ : ℝ} (hlam : 0 ≤ lam)
+    (hA : ∀ ξ : EuclideanSpace ℝ n, lam * ‖ξ‖ ^ 2 ≤ A.toQuadraticForm' ξ)
+    (hc : 0 ≤ c₀) (U : ℝ × EuclideanSpace ℝ n) :
+    min lam c₀ * ‖U‖ ^ 2 ≤ energyIntegrand A 0 c₀ U U := by
+  have hprod := min_mul_prod_norm_sq_le_add hlam hc U
+  have hA' := hA U.2
+  rw [energyIntegrand_self]
+  simp only [inner_zero_left, zero_mul, add_zero]
+  rw [Real.norm_eq_abs, sq_abs] at hprod
+  exact hprod.trans (add_le_add hA' le_rfl)
+
+/-- The shifted Laplacian jet form is coercive when the mass is positive. -/
+lemma isCoercive_energyIntegrand_one_zero_mass {c : ℝ} (hc : 0 < c) :
+    IsCoercive (energyIntegrand (1 : Matrix n n ℝ) 0 c) :=
+  isCoercive_energyIntegrand_zero_drift zero_lt_one hc (by intro ξ; simp)
+
+/-- Explicit diagonal lower bound for the shifted Laplacian jet form with nonnegative mass. -/
+lemma min_one_mass_mul_norm_sq_le_energyIntegrand_one_zero_mass_self {c : ℝ} (hc : 0 ≤ c)
+    (U : ℝ × EuclideanSpace ℝ n) :
+    min 1 c * ‖U‖ ^ 2 ≤ energyIntegrand (1 : Matrix n n ℝ) 0 c U U :=
+  min_lam_mass_mul_norm_sq_le_energyIntegrand_zero_drift_self zero_le_one
+    (by intro ξ; simp) hc U
 
 /-- Coercivity of the pointwise jet bilinear form on a domain from raw lower bounds.
 

--- a/TauCeti/Analysis/PDE/EnergyForm.lean
+++ b/TauCeti/Analysis/PDE/EnergyForm.lean
@@ -48,6 +48,9 @@ explicit (never hidden in a `∃ C`):
 * `TauCeti.PDE.energyIntegrand_one_zero_zero_apply`,
   `TauCeti.PDE.energyIntegrand_one_zero_zero_self`: the Laplacian model `−Δ`, whose jet form
   is the Dirichlet integrand `⟨∇u, ∇v⟩`, with diagonal `‖∇u‖²`.
+* `TauCeti.PDE.energyIntegrand_one_zero_mass_apply`,
+  `TauCeti.PDE.energyIntegrand_one_zero_mass_self`: the shifted Laplacian model `−Δ + c`,
+  whose jet form is `⟨∇u, ∇v⟩ + c u v`.
 * `TauCeti.PDE.norm_energyIntegrand_apply_le_of_bounds`,
   `TauCeti.PDE.opNorm_energyIntegrand_le_of_bounds`: pointwise boundedness with explicit
   constant `Λ + β + γ`.
@@ -120,6 +123,21 @@ lemma energyIntegrand_one_zero_zero_self (U : ℝ × EuclideanSpace ℝ n) :
   rw [energyIntegrand_self, toQuadraticForm'_one]
   simp
 
+/-- The shifted Laplacian model `-Δ + c` has jet form
+`(U, V) ↦ ∇u · ∇v + c u v`. -/
+@[simp]
+lemma energyIntegrand_one_zero_mass_apply (c : ℝ) (U V : ℝ × EuclideanSpace ℝ n) :
+    energyIntegrand (1 : Matrix n n ℝ) 0 c U V = V.2 ⬝ᵥ U.2 + c * U.1 * V.1 := by
+  simp [energyIntegrand_apply, massForm_apply]
+
+/-- The shifted Laplacian model `-Δ + c` has diagonal jet density
+`‖∇u‖² + c u²`. -/
+@[simp]
+lemma energyIntegrand_one_zero_mass_self (c : ℝ) (U : ℝ × EuclideanSpace ℝ n) :
+    energyIntegrand (1 : Matrix n n ℝ) 0 c U U = ‖U.2‖ ^ 2 + c * U.1 ^ 2 := by
+  rw [energyIntegrand_self, toQuadraticForm'_one]
+  simp
+
 variable {Ω : Set X} {a : X → Matrix n n ℝ} {b : X → EuclideanSpace ℝ n} {c : X → ℝ}
 variable {lam Lam beta gamma : ℝ}
 
@@ -138,6 +156,12 @@ private lemma mul_norm_abs_le_half_mul_sq_add (hlam : 0 < lam) (beta u : ℝ) (r
   rw [expand]
   apply div_nonneg _ h2lam.le
   nlinarith [hkey]
+
+private lemma abs_dotProduct_one_mulVec_le (η ξ : EuclideanSpace ℝ n) :
+    |η ⬝ᵥ ((1 : Matrix n n ℝ) *ᵥ ξ)| ≤ 1 * ‖η‖ * ‖ξ‖ := by
+  rw [one_mulVec, one_mul]
+  simpa [EuclideanSpace.inner_eq_star_dotProduct, dotProduct_comm] using
+    abs_real_inner_le_norm η ξ
 
 /-- Pointwise boundedness of the jet form with explicit constant `Λ + β + γ`: the principal,
 drift, and mass contributions are each controlled by the corresponding constant times the jet
@@ -215,6 +239,24 @@ lemma opNorm_energyIntegrand_le_of_bounds (hLam : 0 ≤ Lam)
     (_root_.add_nonneg (_root_.add_nonneg hLam hbeta) hgamma) ?_
   intro U V
   exact norm_energyIntegrand_apply_le_of_bounds hLam ha hb hc U V
+
+/-- Pointwise boundedness of the shifted Laplacian jet form with constant `1 + ‖c‖`. -/
+lemma norm_energyIntegrand_one_zero_mass_apply_le (c : ℝ)
+    (U V : ℝ × EuclideanSpace ℝ n) :
+    ‖energyIntegrand (1 : Matrix n n ℝ) 0 c U V‖ ≤
+      (1 + ‖c‖) * ‖U‖ * ‖V‖ := by
+  simpa using
+    norm_energyIntegrand_apply_le_of_bounds (n := n) (Lam := 1) (beta := 0) (b₀ := 0)
+      (gamma := ‖c‖) zero_le_one
+      (fun η ξ => abs_dotProduct_one_mulVec_le η ξ) (by simp) le_rfl U V
+
+/-- Operator-norm boundedness of the shifted Laplacian jet form with constant `1 + ‖c‖`. -/
+lemma opNorm_energyIntegrand_one_zero_mass_le (c : ℝ) :
+    ‖energyIntegrand (1 : Matrix n n ℝ) 0 c‖ ≤ 1 + ‖c‖ := by
+  simpa using
+    opNorm_energyIntegrand_le_of_bounds (n := n) (Lam := 1) (beta := 0) (b₀ := 0)
+      (gamma := ‖c‖) zero_le_one
+      (fun η ξ => abs_dotProduct_one_mulVec_le η ξ) (by simp) le_rfl
 
 /-- Operator-norm boundedness on a domain, obtained by applying
 `opNorm_energyIntegrand_le_of_bounds` at `x`. -/

--- a/TauCeti/Analysis/PDE/SymmetricCoerciveEnergy.lean
+++ b/TauCeti/Analysis/PDE/SymmetricCoerciveEnergy.lean
@@ -24,19 +24,10 @@ coefficient test case.
 
 ## Main declarations
 
-* `TauCeti.PDE.energyIntegrand_zero_drift_flip_eq_on`: a symmetric coefficient field gives a
-  bundled symmetric zero-drift jet form at each point.
 * `TauCeti.PDE.UniformlyEllipticOn.zero_drift_flip_eq_and_isCoercive_energyIntegrand`:
   uniform ellipticity, coefficient symmetry, and positive mass give symmetry and coercivity.
-* `TauCeti.PDE.energyIntegrand_one_zero_mass_apply` and
-  `TauCeti.PDE.energyIntegrand_one_zero_mass_self`: normal forms for the shifted Laplacian
-  jet integrand.
-* `TauCeti.PDE.norm_energyIntegrand_one_zero_mass_apply_le` and
-  `TauCeti.PDE.opNorm_energyIntegrand_one_zero_mass_le`: boundedness of the shifted
-  Laplacian jet integrand.
-* `TauCeti.PDE.energyIntegrand_one_zero_mass_flip_eq` and
-  `TauCeti.PDE.isCoercive_energyIntegrand_one_zero_mass`: symmetry and coercivity of the
-  shifted Laplacian model with positive mass.
+* `TauCeti.PDE.energyIntegrand_one_zero_mass_flip_eq_and_isCoercive`: symmetry and
+  coercivity of the shifted Laplacian model with positive mass.
 -/
 
 public section
@@ -49,20 +40,6 @@ open Matrix
 open scoped InnerProductSpace
 
 variable {X n : Type*} [Fintype n] [DecidableEq n]
-
-private lemma abs_dotProduct_one_mulVec_le (η ξ : EuclideanSpace ℝ n) :
-    |η ⬝ᵥ ((1 : Matrix n n ℝ) *ᵥ ξ)| ≤ 1 * ‖η‖ * ‖ξ‖ := by
-  rw [one_mulVec, one_mul]
-  simpa [EuclideanSpace.inner_eq_star_dotProduct, dotProduct_comm] using
-    abs_real_inner_le_norm η ξ
-
-/-- A pointwise symmetric coefficient field gives a bundled symmetric zero-drift jet form at
-each point of the domain. -/
-@[simp]
-lemma energyIntegrand_zero_drift_flip_eq_on {Ω : Set X} {a : X → Matrix n n ℝ}
-    (ha : ∀ ⦃x⦄, x ∈ Ω → (a x).IsSymm) {x : X} (hx : x ∈ Ω) (c : X → ℝ) :
-    (energyIntegrand (a x) 0 (c x)).flip = energyIntegrand (a x) 0 (c x) :=
-  energyIntegrand_zero_drift_flip_eq_of_isSymm (ha hx) (c x)
 
 namespace UniformlyEllipticOn
 
@@ -92,66 +69,12 @@ lemma zero_drift_flip_eq_and_isCoercive_energyIntegrand_on
 
 end UniformlyEllipticOn
 
-/-- The shifted Laplacian model `-Δ + c` has jet form
-`(U, V) ↦ ∇u · ∇v + c u v`. -/
-@[simp]
-lemma energyIntegrand_one_zero_mass_apply (c : ℝ) (U V : ℝ × EuclideanSpace ℝ n) :
-    energyIntegrand (1 : Matrix n n ℝ) 0 c U V = V.2 ⬝ᵥ U.2 + c * U.1 * V.1 := by
-  simp [energyIntegrand_apply, massForm_apply]
-
-/-- The shifted Laplacian model `-Δ + c` has diagonal jet density
-`‖∇u‖² + c u²`. -/
-@[simp]
-lemma energyIntegrand_one_zero_mass_self (c : ℝ) (U : ℝ × EuclideanSpace ℝ n) :
-    energyIntegrand (1 : Matrix n n ℝ) 0 c U U = ‖U.2‖ ^ 2 + c * U.1 ^ 2 := by
-  rw [energyIntegrand_self, toQuadraticForm'_one]
-  simp
-
-/-- Pointwise boundedness of the shifted Laplacian jet form with constant `1 + ‖c‖`. -/
-lemma norm_energyIntegrand_one_zero_mass_apply_le (c : ℝ)
-    (U V : ℝ × EuclideanSpace ℝ n) :
-    ‖energyIntegrand (1 : Matrix n n ℝ) 0 c U V‖ ≤
-      (1 + ‖c‖) * ‖U‖ * ‖V‖ := by
-  simpa using
-    norm_energyIntegrand_apply_le_of_bounds (n := n) (Lam := 1) (beta := 0) (b₀ := 0)
-      (gamma := ‖c‖) zero_le_one
-      (fun η ξ => abs_dotProduct_one_mulVec_le η ξ) (by simp) le_rfl U V
-
-/-- Operator-norm boundedness of the shifted Laplacian jet form with constant `1 + ‖c‖`. -/
-lemma opNorm_energyIntegrand_one_zero_mass_le (c : ℝ) :
-    ‖energyIntegrand (1 : Matrix n n ℝ) 0 c‖ ≤ 1 + ‖c‖ := by
-  simpa using
-    opNorm_energyIntegrand_le_of_bounds (n := n) (Lam := 1) (beta := 0) (b₀ := 0)
-      (gamma := ‖c‖) zero_le_one
-      (fun η ξ => abs_dotProduct_one_mulVec_le η ξ) (by simp) le_rfl
-
-/-- Bundled symmetry of the shifted Laplacian jet form. -/
-@[simp]
-lemma energyIntegrand_one_zero_mass_flip_eq (c : ℝ) :
-    (energyIntegrand (1 : Matrix n n ℝ) 0 c).flip =
-      energyIntegrand (1 : Matrix n n ℝ) 0 c :=
-  energyIntegrand_zero_drift_flip_eq_of_isSymm isSymm_one c
-
-/-- The shifted Laplacian jet form is coercive when the mass is positive. -/
-lemma isCoercive_energyIntegrand_one_zero_mass {c : ℝ} (hc : 0 < c) :
-    IsCoercive (energyIntegrand (1 : Matrix n n ℝ) 0 c) :=
-  isCoercive_energyIntegrand_zero_drift zero_lt_one hc (by intro ξ; simp)
-
 /-- The shifted Laplacian jet form is both symmetric and coercive when the mass is positive. -/
 lemma energyIntegrand_one_zero_mass_flip_eq_and_isCoercive {c : ℝ} (hc : 0 < c) :
     (energyIntegrand (1 : Matrix n n ℝ) 0 c).flip =
         energyIntegrand (1 : Matrix n n ℝ) 0 c ∧
       IsCoercive (energyIntegrand (1 : Matrix n n ℝ) 0 c) :=
   ⟨energyIntegrand_one_zero_mass_flip_eq c, isCoercive_energyIntegrand_one_zero_mass hc⟩
-
-/-- Explicit diagonal lower bound for the shifted Laplacian jet form with nonnegative mass. -/
-lemma min_one_mass_mul_norm_sq_le_energyIntegrand_one_zero_mass_self {c : ℝ} (hc : 0 ≤ c)
-    (U : ℝ × EuclideanSpace ℝ n) :
-    min 1 c * ‖U‖ ^ 2 ≤ energyIntegrand (1 : Matrix n n ℝ) 0 c U U := by
-  have hprod := min_mul_prod_norm_sq_le_add zero_le_one hc U
-  rw [energyIntegrand_one_zero_mass_self]
-  rw [Real.norm_eq_abs, sq_abs] at hprod
-  simpa [one_mul] using hprod
 
 end PDE
 

--- a/TauCeti/Analysis/PDE/SymmetricCoerciveEnergy.lean
+++ b/TauCeti/Analysis/PDE/SymmetricCoerciveEnergy.lean
@@ -1,0 +1,158 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+module
+
+public import TauCeti.Analysis.PDE.SymmetricEnergy
+public import TauCeti.Analysis.PDE.UniformEllipticEnergy
+
+/-!
+# Symmetric coercive pointwise energy integrands
+
+Lane D of the PDE roadmap eventually feeds an integrated weak energy form into
+Lax--Milgram and, for the Dirichlet spectrum, into the symmetric-operator API.  The existing
+pointwise files prove symmetry of zero-drift jet forms and coercivity of uniformly elliptic
+jet forms separately.  This file packages the common zero-drift case where both estimates hold
+for the same pointwise integrand.
+
+The statements remain finite-dimensional and pointwise: a jet is an element of
+`ℝ × EuclideanSpace ℝ n`, representing `(u, ∇u)` at one point.  The main consumer form is a
+uniformly elliptic symmetric principal coefficient with a positive mass term.  The shifted
+Laplacian model `energyIntegrand 1 0 c`, corresponding to `-Δ + c`, is included as the constant
+coefficient test case.
+
+## Main declarations
+
+* `TauCeti.PDE.energyIntegrand_zero_drift_flip_eq_on`: a symmetric coefficient field gives a
+  bundled symmetric zero-drift jet form at each point.
+* `TauCeti.PDE.UniformlyEllipticOn.zero_drift_flip_eq_and_isCoercive_energyIntegrand`:
+  uniform ellipticity, coefficient symmetry, and positive mass give symmetry and coercivity.
+* `TauCeti.PDE.energyIntegrand_one_zero_mass_apply` and
+  `TauCeti.PDE.energyIntegrand_one_zero_mass_self`: normal forms for the shifted Laplacian
+  jet integrand.
+* `TauCeti.PDE.norm_energyIntegrand_one_zero_mass_apply_le` and
+  `TauCeti.PDE.opNorm_energyIntegrand_one_zero_mass_le`: boundedness of the shifted
+  Laplacian jet integrand.
+* `TauCeti.PDE.energyIntegrand_one_zero_mass_flip_eq` and
+  `TauCeti.PDE.isCoercive_energyIntegrand_one_zero_mass`: symmetry and coercivity of the
+  shifted Laplacian model with positive mass.
+-/
+
+public section
+
+namespace TauCeti
+
+namespace PDE
+
+open Matrix
+open scoped InnerProductSpace
+
+variable {X n : Type*} [Fintype n] [DecidableEq n]
+
+private lemma abs_dotProduct_one_mulVec_le (η ξ : EuclideanSpace ℝ n) :
+    |η ⬝ᵥ ((1 : Matrix n n ℝ) *ᵥ ξ)| ≤ 1 * ‖η‖ * ‖ξ‖ := by
+  rw [one_mulVec, one_mul]
+  simpa [EuclideanSpace.inner_eq_star_dotProduct, dotProduct_comm] using
+    abs_real_inner_le_norm η ξ
+
+/-- A pointwise symmetric coefficient field gives a bundled symmetric zero-drift jet form at
+each point of the domain. -/
+@[simp]
+lemma energyIntegrand_zero_drift_flip_eq_on {Ω : Set X} {a : X → Matrix n n ℝ}
+    (ha : ∀ ⦃x⦄, x ∈ Ω → (a x).IsSymm) {x : X} (hx : x ∈ Ω) (c : X → ℝ) :
+    (energyIntegrand (a x) 0 (c x)).flip = energyIntegrand (a x) 0 (c x) :=
+  energyIntegrand_zero_drift_flip_eq_of_isSymm (ha hx) (c x)
+
+namespace UniformlyEllipticOn
+
+variable {Ω : Set X} {a : X → Matrix n n ℝ} {lam Lam : ℝ}
+
+/-- For a symmetric uniformly elliptic principal coefficient and a positive mass coefficient,
+the zero-drift pointwise jet form is both symmetric and coercive.
+
+This is the pointwise package later integrated energy forms need before applying the
+Lax--Milgram and symmetric spectral APIs. -/
+lemma zero_drift_flip_eq_and_isCoercive_energyIntegrand
+    (h : UniformlyEllipticOn Ω a lam Lam) (ha : ∀ ⦃x⦄, x ∈ Ω → (a x).IsSymm)
+    {x : X} (hx : x ∈ Ω) {c₀ : ℝ} (hc : 0 < c₀) :
+    (energyIntegrand (a x) 0 c₀).flip = energyIntegrand (a x) 0 c₀ ∧
+      IsCoercive (energyIntegrand (a x) 0 c₀) :=
+  ⟨energyIntegrand_zero_drift_flip_eq_of_isSymm (ha hx) c₀,
+    h.isCoercive_energyIntegrand_zero_drift hx hc⟩
+
+/-- Coefficient-field form of
+`UniformlyEllipticOn.zero_drift_flip_eq_and_isCoercive_energyIntegrand`. -/
+lemma zero_drift_flip_eq_and_isCoercive_energyIntegrand_on
+    (h : UniformlyEllipticOn Ω a lam Lam) (ha : ∀ ⦃x⦄, x ∈ Ω → (a x).IsSymm)
+    {c : X → ℝ} (hc : ∀ ⦃x⦄, x ∈ Ω → 0 < c x) {x : X} (hx : x ∈ Ω) :
+    (energyIntegrand (a x) 0 (c x)).flip = energyIntegrand (a x) 0 (c x) ∧
+      IsCoercive (energyIntegrand (a x) 0 (c x)) :=
+  h.zero_drift_flip_eq_and_isCoercive_energyIntegrand ha hx (hc hx)
+
+end UniformlyEllipticOn
+
+/-- The shifted Laplacian model `-Δ + c` has jet form
+`(U, V) ↦ ∇u · ∇v + c u v`. -/
+@[simp]
+lemma energyIntegrand_one_zero_mass_apply (c : ℝ) (U V : ℝ × EuclideanSpace ℝ n) :
+    energyIntegrand (1 : Matrix n n ℝ) 0 c U V = V.2 ⬝ᵥ U.2 + c * U.1 * V.1 := by
+  simp [energyIntegrand_apply, massForm_apply]
+
+/-- The shifted Laplacian model `-Δ + c` has diagonal jet density
+`‖∇u‖² + c u²`. -/
+@[simp]
+lemma energyIntegrand_one_zero_mass_self (c : ℝ) (U : ℝ × EuclideanSpace ℝ n) :
+    energyIntegrand (1 : Matrix n n ℝ) 0 c U U = ‖U.2‖ ^ 2 + c * U.1 ^ 2 := by
+  rw [energyIntegrand_self, toQuadraticForm'_one]
+  simp
+
+/-- Pointwise boundedness of the shifted Laplacian jet form with constant `1 + ‖c‖`. -/
+lemma norm_energyIntegrand_one_zero_mass_apply_le (c : ℝ)
+    (U V : ℝ × EuclideanSpace ℝ n) :
+    ‖energyIntegrand (1 : Matrix n n ℝ) 0 c U V‖ ≤
+      (1 + ‖c‖) * ‖U‖ * ‖V‖ := by
+  simpa using
+    norm_energyIntegrand_apply_le_of_bounds (n := n) (Lam := 1) (beta := 0) (b₀ := 0)
+      (gamma := ‖c‖) zero_le_one
+      (fun η ξ => abs_dotProduct_one_mulVec_le η ξ) (by simp) le_rfl U V
+
+/-- Operator-norm boundedness of the shifted Laplacian jet form with constant `1 + ‖c‖`. -/
+lemma opNorm_energyIntegrand_one_zero_mass_le (c : ℝ) :
+    ‖energyIntegrand (1 : Matrix n n ℝ) 0 c‖ ≤ 1 + ‖c‖ := by
+  simpa using
+    opNorm_energyIntegrand_le_of_bounds (n := n) (Lam := 1) (beta := 0) (b₀ := 0)
+      (gamma := ‖c‖) zero_le_one
+      (fun η ξ => abs_dotProduct_one_mulVec_le η ξ) (by simp) le_rfl
+
+/-- Bundled symmetry of the shifted Laplacian jet form. -/
+@[simp]
+lemma energyIntegrand_one_zero_mass_flip_eq (c : ℝ) :
+    (energyIntegrand (1 : Matrix n n ℝ) 0 c).flip =
+      energyIntegrand (1 : Matrix n n ℝ) 0 c :=
+  energyIntegrand_zero_drift_flip_eq_of_isSymm isSymm_one c
+
+/-- The shifted Laplacian jet form is coercive when the mass is positive. -/
+lemma isCoercive_energyIntegrand_one_zero_mass {c : ℝ} (hc : 0 < c) :
+    IsCoercive (energyIntegrand (1 : Matrix n n ℝ) 0 c) :=
+  isCoercive_energyIntegrand_zero_drift zero_lt_one hc (by intro ξ; simp)
+
+/-- The shifted Laplacian jet form is both symmetric and coercive when the mass is positive. -/
+lemma energyIntegrand_one_zero_mass_flip_eq_and_isCoercive {c : ℝ} (hc : 0 < c) :
+    (energyIntegrand (1 : Matrix n n ℝ) 0 c).flip =
+        energyIntegrand (1 : Matrix n n ℝ) 0 c ∧
+      IsCoercive (energyIntegrand (1 : Matrix n n ℝ) 0 c) :=
+  ⟨energyIntegrand_one_zero_mass_flip_eq c, isCoercive_energyIntegrand_one_zero_mass hc⟩
+
+/-- Explicit diagonal lower bound for the shifted Laplacian jet form with nonnegative mass. -/
+lemma min_one_mass_mul_norm_sq_le_energyIntegrand_one_zero_mass_self {c : ℝ} (hc : 0 ≤ c)
+    (U : ℝ × EuclideanSpace ℝ n) :
+    min 1 c * ‖U‖ ^ 2 ≤ energyIntegrand (1 : Matrix n n ℝ) 0 c U U := by
+  have hprod := min_mul_prod_norm_sq_le_add zero_le_one hc U
+  rw [energyIntegrand_one_zero_mass_self]
+  rw [Real.norm_eq_abs, sq_abs] at hprod
+  simpa [one_mul] using hprod
+
+end PDE
+
+end TauCeti

--- a/TauCeti/Analysis/PDE/SymmetricCoerciveEnergy.lean
+++ b/TauCeti/Analysis/PDE/SymmetricCoerciveEnergy.lean
@@ -24,8 +24,10 @@ coefficient test case.
 
 ## Main declarations
 
+* `TauCeti.PDE.zero_drift_flip_eq_and_isCoercive_energyIntegrand`: a symmetric principal
+  coefficient, a quadratic lower bound, and positive mass give symmetry and coercivity.
 * `TauCeti.PDE.UniformlyEllipticOn.zero_drift_flip_eq_and_isCoercive_energyIntegrand`:
-  uniform ellipticity, coefficient symmetry, and positive mass give symmetry and coercivity.
+  bundled uniform ellipticity wrapper for the same pointwise package.
 * `TauCeti.PDE.energyIntegrand_one_zero_mass_flip_eq_and_isCoercive`: symmetry and
   coercivity of the shifted Laplacian model with positive mass.
 -/
@@ -41,22 +43,36 @@ open scoped InnerProductSpace
 
 variable {X n : Type*} [Fintype n] [DecidableEq n]
 
+variable {lam : ℝ}
+
+/-- A symmetric principal coefficient with a positive quadratic lower bound and a positive
+mass coefficient gives a zero-drift pointwise jet form that is both symmetric and coercive.
+
+This is the raw pointwise package later integrated energy forms need before applying the
+Lax--Milgram and symmetric spectral APIs. -/
+lemma zero_drift_flip_eq_and_isCoercive_energyIntegrand {A : Matrix n n ℝ} (hlam : 0 < lam)
+    (hA : ∀ ξ : EuclideanSpace ℝ n, lam * ‖ξ‖ ^ 2 ≤ A.toQuadraticForm' ξ)
+    (ha : A.IsSymm) {c₀ : ℝ} (hc : 0 < c₀) :
+    (energyIntegrand A 0 c₀).flip = energyIntegrand A 0 c₀ ∧
+      IsCoercive (energyIntegrand A 0 c₀) :=
+  ⟨energyIntegrand_zero_drift_flip_eq_of_isSymm ha c₀,
+    isCoercive_energyIntegrand_zero_drift hlam hc hA⟩
+
 namespace UniformlyEllipticOn
 
-variable {Ω : Set X} {a : X → Matrix n n ℝ} {lam Lam : ℝ}
+variable {Ω : Set X} {a : X → Matrix n n ℝ} {Lam : ℝ}
 
 /-- For a symmetric uniformly elliptic principal coefficient and a positive mass coefficient,
 the zero-drift pointwise jet form is both symmetric and coercive.
 
-This is the pointwise package later integrated energy forms need before applying the
-Lax--Milgram and symmetric spectral APIs. -/
+This is the bundled uniform ellipticity wrapper around
+`PDE.zero_drift_flip_eq_and_isCoercive_energyIntegrand`. -/
 lemma zero_drift_flip_eq_and_isCoercive_energyIntegrand
     (h : UniformlyEllipticOn Ω a lam Lam) (ha : ∀ ⦃x⦄, x ∈ Ω → (a x).IsSymm)
     {x : X} (hx : x ∈ Ω) {c₀ : ℝ} (hc : 0 < c₀) :
     (energyIntegrand (a x) 0 c₀).flip = energyIntegrand (a x) 0 c₀ ∧
       IsCoercive (energyIntegrand (a x) 0 c₀) :=
-  ⟨energyIntegrand_zero_drift_flip_eq_of_isSymm (ha hx) c₀,
-    h.isCoercive_energyIntegrand_zero_drift hx hc⟩
+  PDE.zero_drift_flip_eq_and_isCoercive_energyIntegrand h.pos (h.lower_bound hx) (ha hx) hc
 
 /-- Coefficient-field form of
 `UniformlyEllipticOn.zero_drift_flip_eq_and_isCoercive_energyIntegrand`. -/

--- a/TauCeti/Analysis/PDE/SymmetricCoerciveEnergy.lean
+++ b/TauCeti/Analysis/PDE/SymmetricCoerciveEnergy.lean
@@ -5,7 +5,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 module
 
 public import TauCeti.Analysis.PDE.SymmetricEnergy
-public import TauCeti.Analysis.PDE.UniformEllipticEnergy
+public import TauCeti.Analysis.PDE.CoerciveEnergy
 
 /-!
 # Symmetric coercive pointwise energy integrands

--- a/TauCeti/Analysis/PDE/SymmetricEnergy.lean
+++ b/TauCeti/Analysis/PDE/SymmetricEnergy.lean
@@ -32,6 +32,8 @@ the full zero-drift jet integrand.
   is unchanged by replacing the principal coefficient by its symmetric part.
 * `TauCeti.PDE.energyIntegrand_zero_drift_comm_on`: a pointwise symmetric coefficient field
   gives symmetric zero-drift jet forms at every point of the domain.
+* `TauCeti.PDE.energyIntegrand_one_zero_mass_flip_eq`: bundled symmetry of the shifted
+  Laplacian jet form.
 -/
 
 public section
@@ -120,6 +122,21 @@ lemma energyIntegrand_zero_drift_comm_on {Ω : Set X} {a : X → Matrix n n ℝ}
     (U V : ℝ × EuclideanSpace ℝ n) :
     energyIntegrand (a x) 0 (c x) U V = energyIntegrand (a x) 0 (c x) V U :=
   energyIntegrand_zero_drift_comm_of_isSymm (ha hx) (c x) U V
+
+/-- A pointwise symmetric coefficient field gives a bundled symmetric zero-drift jet form at
+each point of the domain. -/
+@[simp]
+lemma energyIntegrand_zero_drift_flip_eq_on {Ω : Set X} {a : X → Matrix n n ℝ}
+    (ha : ∀ ⦃x⦄, x ∈ Ω → (a x).IsSymm) {x : X} (hx : x ∈ Ω) (c : X → ℝ) :
+    (energyIntegrand (a x) 0 (c x)).flip = energyIntegrand (a x) 0 (c x) :=
+  energyIntegrand_zero_drift_flip_eq_of_isSymm (ha hx) (c x)
+
+/-- Bundled symmetry of the shifted Laplacian jet form. -/
+@[simp]
+lemma energyIntegrand_one_zero_mass_flip_eq (c : ℝ) :
+    (energyIntegrand (1 : Matrix n n ℝ) 0 c).flip =
+      energyIntegrand (1 : Matrix n n ℝ) 0 c :=
+  energyIntegrand_zero_drift_flip_eq_of_isSymm isSymm_one c
 
 end PDE
 


### PR DESCRIPTION
This PR adds a pointwise symmetric-coercive energy API for zero-drift divergence-form operators: a symmetric uniformly elliptic principal coefficient with positive mass now gives both bundled symmetry and `IsCoercive` for the same jet integrand, and the shifted Laplacian model `energyIntegrand 1 0 c` has normal forms, boundedness, symmetry, coercivity, and an explicit diagonal lower bound.

It advances `TauCetiRoadmap/PDE/README.md`, Lane D, item 16, specifically the weak-form energy bilinear-form boundedness and Gårding/coercivity prerequisites for the Lax--Milgram lane, and item 17 as a clean prerequisite for the coercive existence theorem. I chose this as the lowest-hanging distinct PDE target after checking open and recently merged PRs: the existing PDE files already provide uniform ellipticity, lower-order pointwise forms, raw energy estimates, symmetry, and coercivity separately, while the zero-drift symmetric-coercive consumer package and shifted Laplacian bounded/coercive model were still absent.

No Mathlib infrastructure is vendored. The implementation reuses Mathlib's `IsCoercive` and continuous-bilinear-map API, plus Tau Ceti's existing `energyIntegrand`, `UniformlyEllipticOn.isCoercive_energyIntegrand_zero_drift`, `energyIntegrand_zero_drift_flip_eq_of_isSymm`, and pointwise boundedness estimates.

`lake exe cache get` completed with `No files to download` and `Already decompressed 8586 file(s)`. `lake build` completed with `Build completed successfully (4274 jobs).` `lake exe axioms` completed with `axioms: audited 5604 TauCeti declaration(s); all within the allowlist [propext, Classical.choice, Quot.sound].`

<!--tauceti-target:v1 {"focus":"PDE","id":"symmetric-coercive-energy-integrand"}-->

🤖 Prepared with Codex
