### PR TITLE
feat: add finite-dimensional marginal uniqueness

### DIFF
--- a/TauCeti/Probability/Exchangeability/FiniteMarginals.lean
+++ b/TauCeti/Probability/Exchangeability/FiniteMarginals.lean
@@ -1,0 +1,67 @@
+module
+
+public import TauCeti.Probability.Exchangeability.Basic
+import Mathlib.MeasureTheory.Constructions.Projective
+
+/-!
+# Finite-dimensional marginal uniqueness
+
+Two finite measures on path space `ℕ → α` that agree on every finite prefix marginal
+(`prefixProj α n`, the projection to the first `n` coordinates) are equal. This is the Layer 0
+finite-marginal uniqueness milestone of `TauCetiRoadmap/Exchangeability`: a thin ℕ-prefix wrapper
+over Mathlib's projective-limit machinery (`IsProjectiveLimit.unique`), not new measure theory.
+
+`measure_eq_of_prefixProj_map_eq` is the main API (marginals as `Measure.map` equalities);
+`measure_eq_of_prefixProj_setwise` is the setwise form matching the roadmap target, with a
+probability-measure specialization. Since `IsProbabilityMeasure` provides `IsFiniteMeasure`, the
+finite-measure statements already apply to probability measures.
+-/
+
+public section
+
+noncomputable section
+
+open MeasureTheory
+
+namespace TauCeti
+
+namespace Probability
+
+variable {α : Type*} [MeasurableSpace α]
+
+/-- **Finite-marginal uniqueness.** Two finite measures on `ℕ → α` that have the same law under
+every finite prefix projection `prefixProj α n` are equal. -/
+theorem measure_eq_of_prefixProj_map_eq {μ ν : Measure (ℕ → α)}
+    [IsFiniteMeasure μ] [IsFiniteMeasure ν]
+    (h : ∀ n, μ.map (prefixProj α n) = ν.map (prefixProj α n)) : μ = ν := by
+  -- The two `Finset ℕ`-restriction families agree: a finite index set `I` sits inside the
+  -- prefix `{0, …, n-1}` for `n = I.sup id + 1`, so its restriction factors through `prefixProj`.
+  have key : ∀ I : Finset ℕ, μ.map I.restrict = ν.map I.restrict := by
+    intro I
+    obtain ⟨n, hn⟩ : ∃ n, ∀ i ∈ I, i < n :=
+      ⟨I.sup id + 1, fun i hi => Nat.lt_succ_of_le (Finset.le_sup (f := id) hi)⟩
+    let g : (Fin n → α) → ((i : I) → α) := fun y i => y ⟨i.1, hn i.1 i.2⟩
+    have hg : Measurable g := measurable_pi_lambda _ fun i => measurable_pi_apply _
+    have hcomp : (Finset.restrict I : (ℕ → α) → ((i : I) → α)) = g ∘ prefixProj α n := by
+      funext x i; rfl
+    calc μ.map I.restrict
+        = μ.map (g ∘ prefixProj α n) := by rw [hcomp]
+      _ = (μ.map (prefixProj α n)).map g := (Measure.map_map hg (measurable_prefixProj n)).symm
+      _ = (ν.map (prefixProj α n)).map g := by rw [h n]
+      _ = ν.map (g ∘ prefixProj α n) := Measure.map_map hg (measurable_prefixProj n)
+      _ = ν.map I.restrict := by rw [hcomp]
+  -- `μ` and `ν` are both projective limits of the family `I ↦ μ.map I.restrict`.
+  exact IsProjectiveLimit.unique (P := fun I => μ.map I.restrict)
+    (fun I => rfl) (fun I => (key I).symm)
+
+/-- **Finite-marginal uniqueness, setwise form** (matching the roadmap target): two finite measures
+on `ℕ → α` agreeing on every measurable prefix-cylinder are equal. -/
+theorem measure_eq_of_prefixProj_setwise {μ ν : Measure (ℕ → α)}
+    [IsFiniteMeasure μ] [IsFiniteMeasure ν]
+    (h : ∀ (n : ℕ) (S : Set (Fin n → α)), MeasurableSet S →
+      μ.map (prefixProj α n) S = ν.map (prefixProj α n) S) : μ = ν :=
+  measure_eq_of_prefixProj_map_eq fun n => Measure.ext fun S hS => h n S hS
+
+end Probability
+
+end TauCeti

--- a/TauCeti/Probability/Exchangeability/FiniteMarginals.lean
+++ b/TauCeti/Probability/Exchangeability/FiniteMarginals.lean
@@ -1,7 +1,6 @@
 module
 
 public import TauCeti.Probability.Exchangeability.Basic
-public import Mathlib.MeasureTheory.Measure.Typeclasses.Probability
 import Mathlib.MeasureTheory.Constructions.Projective
 
 /-!
@@ -16,11 +15,10 @@ machinery (`IsProjectiveLimit.unique`), not new measure theory.
 The public API:
 * `measure_eq_of_prefixProj_map_eq` — the clean map-equality form;
 * `measure_eq_of_prefixProj_setwise` — the setwise form;
-* `measure_eq_of_fin_marginals_eq` — the roadmap-named finite-measure version;
-* `measure_eq_of_fin_marginals_eq_prob` — the roadmap-named probability version.
+* `measure_eq_of_fin_marginals_eq` — the roadmap-named version.
 
-The finite-measure statements apply directly to probability measures, since `IsProbabilityMeasure`
-provides `IsFiniteMeasure`.
+These statements apply directly to probability measures, since `IsProbabilityMeasure` provides
+`IsFiniteMeasure`, so no separate probability-measure theorem is needed.
 -/
 
 public section
@@ -84,13 +82,6 @@ theorem measure_eq_of_fin_marginals_eq {μ ν : Measure (ℕ → α)} [IsFiniteM
     (h : ∀ (n : ℕ) (S : Set (Fin n → α)), MeasurableSet S →
       μ.map (prefixProj α n) S = ν.map (prefixProj α n) S) : μ = ν :=
   measure_eq_of_prefixProj_setwise h
-
-/-- Roadmap-named probability version of finite-marginal uniqueness. It assumes only `μ` is a
-probability measure; equality then forces `ν` to be that same probability measure. -/
-theorem measure_eq_of_fin_marginals_eq_prob {μ ν : Measure (ℕ → α)} [IsProbabilityMeasure μ]
-    (h : ∀ (n : ℕ) (S : Set (Fin n → α)), MeasurableSet S →
-      μ.map (prefixProj α n) S = ν.map (prefixProj α n) S) : μ = ν :=
-  measure_eq_of_fin_marginals_eq h
 
 end Probability
 

--- a/TauCeti/Probability/Exchangeability/FiniteMarginals.lean
+++ b/TauCeti/Probability/Exchangeability/FiniteMarginals.lean
@@ -1,6 +1,7 @@
 module
 
 public import TauCeti.Probability.Exchangeability.Basic
+public import Mathlib.MeasureTheory.Measure.Typeclasses.Probability
 import Mathlib.MeasureTheory.Constructions.Projective
 
 /-!
@@ -12,9 +13,13 @@ coordinates) is equal to it. This is the Layer 0 finite-marginal uniqueness mile
 `TauCetiRoadmap/Exchangeability`: a thin ℕ-prefix wrapper over Mathlib's projective-limit
 machinery (`IsProjectiveLimit.unique`), not new measure theory.
 
-`measure_eq_of_prefixProj_map_eq` is the main API (marginals as `Measure.map` equalities);
-`measure_eq_of_prefixProj_setwise` is the setwise form matching the roadmap target. The same
-finite-measure statements apply directly to probability measures, since `IsProbabilityMeasure`
+The public API:
+* `measure_eq_of_prefixProj_map_eq` — the clean map-equality form;
+* `measure_eq_of_prefixProj_setwise` — the setwise form;
+* `measure_eq_of_fin_marginals_eq` — the roadmap-named finite-measure version;
+* `measure_eq_of_fin_marginals_eq_prob` — the roadmap-named probability version.
+
+The finite-measure statements apply directly to probability measures, since `IsProbabilityMeasure`
 provides `IsFiniteMeasure`.
 -/
 
@@ -29,6 +34,16 @@ namespace TauCeti
 namespace Probability
 
 variable {α : Type*} [MeasurableSpace α]
+
+omit [MeasurableSpace α] in
+/-- The restriction to a finite index set `I ⊆ {0, …, n-1}` factors through the prefix projection
+to the first `n` coordinates. -/
+private theorem finsetRestrict_eq_comp_prefixProj (I : Finset ℕ) {n : ℕ}
+    (hn : ∀ i ∈ I, i < n) :
+    (Finset.restrict I : (ℕ → α) → ((i : I) → α)) =
+      (fun y : Fin n → α => fun i : I => y ⟨i.1, hn i.1 i.2⟩) ∘ prefixProj α n := by
+  funext x i
+  simp [prefixProj_apply]
 
 /-- **Finite-marginal uniqueness.** Two measures on `ℕ → α`, with `μ` finite, that have the same
 law under every finite prefix projection `prefixProj α n` are equal. (Finiteness of `ν` is not
@@ -45,7 +60,7 @@ theorem measure_eq_of_prefixProj_map_eq {μ ν : Measure (ℕ → α)} [IsFinite
     let g : (Fin n → α) → ((i : I) → α) := fun y i => y ⟨i.1, hn i.1 i.2⟩
     have hg : Measurable g := measurable_pi_lambda _ fun i => measurable_pi_apply _
     have hcomp : (Finset.restrict I : (ℕ → α) → ((i : I) → α)) = g ∘ prefixProj α n := by
-      funext x i; rfl
+      simpa [g] using finsetRestrict_eq_comp_prefixProj (α := α) I hn
     calc μ.map I.restrict
         = μ.map (g ∘ prefixProj α n) := by rw [hcomp]
       _ = (μ.map (prefixProj α n)).map g := (Measure.map_map hg (measurable_prefixProj n)).symm
@@ -62,6 +77,20 @@ theorem measure_eq_of_prefixProj_setwise {μ ν : Measure (ℕ → α)} [IsFinit
     (h : ∀ (n : ℕ) (S : Set (Fin n → α)), MeasurableSet S →
       μ.map (prefixProj α n) S = ν.map (prefixProj α n) S) : μ = ν :=
   measure_eq_of_prefixProj_map_eq fun n => Measure.ext fun S hS => h n S hS
+
+/-- Roadmap-named finite-measure version of finite-marginal uniqueness. -/
+theorem measure_eq_of_fin_marginals_eq {μ ν : Measure (ℕ → α)}
+    [IsFiniteMeasure μ] [IsFiniteMeasure ν]
+    (h : ∀ (n : ℕ) (S : Set (Fin n → α)), MeasurableSet S →
+      μ.map (prefixProj α n) S = ν.map (prefixProj α n) S) : μ = ν :=
+  measure_eq_of_prefixProj_setwise h
+
+/-- Roadmap-named probability version of finite-marginal uniqueness. -/
+theorem measure_eq_of_fin_marginals_eq_prob {μ ν : Measure (ℕ → α)}
+    [IsProbabilityMeasure μ] [IsProbabilityMeasure ν]
+    (h : ∀ (n : ℕ) (S : Set (Fin n → α)), MeasurableSet S →
+      μ.map (prefixProj α n) S = ν.map (prefixProj α n) S) : μ = ν :=
+  measure_eq_of_fin_marginals_eq h
 
 end Probability
 

--- a/TauCeti/Probability/Exchangeability/FiniteMarginals.lean
+++ b/TauCeti/Probability/Exchangeability/FiniteMarginals.lean
@@ -13,11 +13,10 @@ coordinates) is equal to it. This is the Layer 0 finite-marginal uniqueness mile
 machinery (`IsProjectiveLimit.unique`), not new measure theory.
 
 The public API:
-* `measure_eq_of_prefixProj_map_eq` — the clean map-equality form;
-* `measure_eq_of_prefixProj_setwise` — the setwise form;
-* `measure_eq_of_fin_marginals_eq` — the roadmap-named version.
+* `measure_eq_of_prefixProj_map_eq` — the map-equality form;
+* `measure_eq_of_fin_marginals_eq` — the roadmap-named setwise form.
 
-These statements apply directly to probability measures, since `IsProbabilityMeasure` provides
+Both apply directly to probability measures, since `IsProbabilityMeasure` provides
 `IsFiniteMeasure`, so no separate probability-measure theorem is needed.
 -/
 
@@ -69,19 +68,13 @@ theorem measure_eq_of_prefixProj_map_eq {μ ν : Measure (ℕ → α)} [IsFinite
   exact IsProjectiveLimit.unique (P := fun I => μ.map I.restrict)
     (fun I => rfl) (fun I => (key I).symm)
 
-/-- **Finite-marginal uniqueness, setwise form** (matching the roadmap target): two measures on
-`ℕ → α`, with `μ` finite, agreeing on every measurable prefix-cylinder are equal. -/
-theorem measure_eq_of_prefixProj_setwise {μ ν : Measure (ℕ → α)} [IsFiniteMeasure μ]
-    (h : ∀ (n : ℕ) (S : Set (Fin n → α)), MeasurableSet S →
-      μ.map (prefixProj α n) S = ν.map (prefixProj α n) S) : μ = ν :=
-  measure_eq_of_prefixProj_map_eq fun n => Measure.ext fun S hS => h n S hS
-
-/-- Roadmap-named finite-measure version of finite-marginal uniqueness. It assumes only `μ` is
-finite; `ν`'s finiteness is forced by the conclusion. -/
+/-- **Finite-marginal uniqueness, setwise form** (the roadmap-named milestone): two measures on
+`ℕ → α`, with `μ` finite, agreeing on every measurable prefix-cylinder are equal. It assumes only
+`μ` is finite; `ν`'s finiteness is forced by the conclusion. -/
 theorem measure_eq_of_fin_marginals_eq {μ ν : Measure (ℕ → α)} [IsFiniteMeasure μ]
     (h : ∀ (n : ℕ) (S : Set (Fin n → α)), MeasurableSet S →
       μ.map (prefixProj α n) S = ν.map (prefixProj α n) S) : μ = ν :=
-  measure_eq_of_prefixProj_setwise h
+  measure_eq_of_prefixProj_map_eq fun n => Measure.ext fun S hS => h n S hS
 
 end Probability
 

--- a/TauCeti/Probability/Exchangeability/FiniteMarginals.lean
+++ b/TauCeti/Probability/Exchangeability/FiniteMarginals.lean
@@ -78,15 +78,15 @@ theorem measure_eq_of_prefixProj_setwise {μ ν : Measure (ℕ → α)} [IsFinit
       μ.map (prefixProj α n) S = ν.map (prefixProj α n) S) : μ = ν :=
   measure_eq_of_prefixProj_map_eq fun n => Measure.ext fun S hS => h n S hS
 
-/-- Roadmap-named finite-measure version of finite-marginal uniqueness. Only `μ` need be finite
-(`ν`'s finiteness is forced by the conclusion). -/
+/-- Roadmap-named finite-measure version of finite-marginal uniqueness. It assumes only `μ` is
+finite; `ν`'s finiteness is forced by the conclusion. -/
 theorem measure_eq_of_fin_marginals_eq {μ ν : Measure (ℕ → α)} [IsFiniteMeasure μ]
     (h : ∀ (n : ℕ) (S : Set (Fin n → α)), MeasurableSet S →
       μ.map (prefixProj α n) S = ν.map (prefixProj α n) S) : μ = ν :=
   measure_eq_of_prefixProj_setwise h
 
-/-- Roadmap-named probability version of finite-marginal uniqueness. Only `μ` need be a probability
-measure (`ν` is then forced to equal it). -/
+/-- Roadmap-named probability version of finite-marginal uniqueness. It assumes only `μ` is a
+probability measure; equality then forces `ν` to be that same probability measure. -/
 theorem measure_eq_of_fin_marginals_eq_prob {μ ν : Measure (ℕ → α)} [IsProbabilityMeasure μ]
     (h : ∀ (n : ℕ) (S : Set (Fin n → α)), MeasurableSet S →
       μ.map (prefixProj α n) S = ν.map (prefixProj α n) S) : μ = ν :=

--- a/TauCeti/Probability/Exchangeability/FiniteMarginals.lean
+++ b/TauCeti/Probability/Exchangeability/FiniteMarginals.lean
@@ -78,16 +78,16 @@ theorem measure_eq_of_prefixProj_setwise {μ ν : Measure (ℕ → α)} [IsFinit
       μ.map (prefixProj α n) S = ν.map (prefixProj α n) S) : μ = ν :=
   measure_eq_of_prefixProj_map_eq fun n => Measure.ext fun S hS => h n S hS
 
-/-- Roadmap-named finite-measure version of finite-marginal uniqueness. -/
-theorem measure_eq_of_fin_marginals_eq {μ ν : Measure (ℕ → α)}
-    [IsFiniteMeasure μ] [IsFiniteMeasure ν]
+/-- Roadmap-named finite-measure version of finite-marginal uniqueness. Only `μ` need be finite
+(`ν`'s finiteness is forced by the conclusion). -/
+theorem measure_eq_of_fin_marginals_eq {μ ν : Measure (ℕ → α)} [IsFiniteMeasure μ]
     (h : ∀ (n : ℕ) (S : Set (Fin n → α)), MeasurableSet S →
       μ.map (prefixProj α n) S = ν.map (prefixProj α n) S) : μ = ν :=
   measure_eq_of_prefixProj_setwise h
 
-/-- Roadmap-named probability version of finite-marginal uniqueness. -/
-theorem measure_eq_of_fin_marginals_eq_prob {μ ν : Measure (ℕ → α)}
-    [IsProbabilityMeasure μ] [IsProbabilityMeasure ν]
+/-- Roadmap-named probability version of finite-marginal uniqueness. Only `μ` need be a probability
+measure (`ν` is then forced to equal it). -/
+theorem measure_eq_of_fin_marginals_eq_prob {μ ν : Measure (ℕ → α)} [IsProbabilityMeasure μ]
     (h : ∀ (n : ℕ) (S : Set (Fin n → α)), MeasurableSet S →
       μ.map (prefixProj α n) S = ν.map (prefixProj α n) S) : μ = ν :=
   measure_eq_of_fin_marginals_eq h

--- a/TauCeti/Probability/Exchangeability/FiniteMarginals.lean
+++ b/TauCeti/Probability/Exchangeability/FiniteMarginals.lean
@@ -6,10 +6,11 @@ import Mathlib.MeasureTheory.Constructions.Projective
 /-!
 # Finite-dimensional marginal uniqueness
 
-Two finite measures on path space `ℕ → α` that agree on every finite prefix marginal
-(`prefixProj α n`, the projection to the first `n` coordinates) are equal. This is the Layer 0
-finite-marginal uniqueness milestone of `TauCetiRoadmap/Exchangeability`: a thin ℕ-prefix wrapper
-over Mathlib's projective-limit machinery (`IsProjectiveLimit.unique`), not new measure theory.
+A finite measure on path space `ℕ → α` is determined by its finite prefix marginals: any measure
+agreeing with it on every prefix projection (`prefixProj α n`, the projection to the first `n`
+coordinates) is equal to it. This is the Layer 0 finite-marginal uniqueness milestone of
+`TauCetiRoadmap/Exchangeability`: a thin ℕ-prefix wrapper over Mathlib's projective-limit
+machinery (`IsProjectiveLimit.unique`), not new measure theory.
 
 `measure_eq_of_prefixProj_map_eq` is the main API (marginals as `Measure.map` equalities);
 `measure_eq_of_prefixProj_setwise` is the setwise form matching the roadmap target. The same
@@ -29,10 +30,11 @@ namespace Probability
 
 variable {α : Type*} [MeasurableSpace α]
 
-/-- **Finite-marginal uniqueness.** Two finite measures on `ℕ → α` that have the same law under
-every finite prefix projection `prefixProj α n` are equal. -/
-theorem measure_eq_of_prefixProj_map_eq {μ ν : Measure (ℕ → α)}
-    [IsFiniteMeasure μ] [IsFiniteMeasure ν]
+/-- **Finite-marginal uniqueness.** Two measures on `ℕ → α`, with `μ` finite, that have the same
+law under every finite prefix projection `prefixProj α n` are equal. (Finiteness of `ν` is not
+needed: projective-limit uniqueness only requires the prefix-marginal family, supplied by `μ`, to
+be finite.) -/
+theorem measure_eq_of_prefixProj_map_eq {μ ν : Measure (ℕ → α)} [IsFiniteMeasure μ]
     (h : ∀ n, μ.map (prefixProj α n) = ν.map (prefixProj α n)) : μ = ν := by
   -- The two `Finset ℕ`-restriction families agree: a finite index set `I` sits inside the
   -- prefix `{0, …, n-1}` for `n = I.sup id + 1`, so its restriction factors through `prefixProj`.
@@ -54,10 +56,9 @@ theorem measure_eq_of_prefixProj_map_eq {μ ν : Measure (ℕ → α)}
   exact IsProjectiveLimit.unique (P := fun I => μ.map I.restrict)
     (fun I => rfl) (fun I => (key I).symm)
 
-/-- **Finite-marginal uniqueness, setwise form** (matching the roadmap target): two finite measures
-on `ℕ → α` agreeing on every measurable prefix-cylinder are equal. -/
-theorem measure_eq_of_prefixProj_setwise {μ ν : Measure (ℕ → α)}
-    [IsFiniteMeasure μ] [IsFiniteMeasure ν]
+/-- **Finite-marginal uniqueness, setwise form** (matching the roadmap target): two measures on
+`ℕ → α`, with `μ` finite, agreeing on every measurable prefix-cylinder are equal. -/
+theorem measure_eq_of_prefixProj_setwise {μ ν : Measure (ℕ → α)} [IsFiniteMeasure μ]
     (h : ∀ (n : ℕ) (S : Set (Fin n → α)), MeasurableSet S →
       μ.map (prefixProj α n) S = ν.map (prefixProj α n) S) : μ = ν :=
   measure_eq_of_prefixProj_map_eq fun n => Measure.ext fun S hS => h n S hS

--- a/TauCeti/Probability/Exchangeability/FiniteMarginals.lean
+++ b/TauCeti/Probability/Exchangeability/FiniteMarginals.lean
@@ -12,9 +12,9 @@ finite-marginal uniqueness milestone of `TauCetiRoadmap/Exchangeability`: a thin
 over Mathlib's projective-limit machinery (`IsProjectiveLimit.unique`), not new measure theory.
 
 `measure_eq_of_prefixProj_map_eq` is the main API (marginals as `Measure.map` equalities);
-`measure_eq_of_prefixProj_setwise` is the setwise form matching the roadmap target, with a
-probability-measure specialization. Since `IsProbabilityMeasure` provides `IsFiniteMeasure`, the
-finite-measure statements already apply to probability measures.
+`measure_eq_of_prefixProj_setwise` is the setwise form matching the roadmap target. The same
+finite-measure statements apply directly to probability measures, since `IsProbabilityMeasure`
+provides `IsFiniteMeasure`.
 -/
 
 public section


### PR DESCRIPTION
<!--tauceti-target:v1 {"focus":"Exchangeability","id":"exchangeability-finite-marginals"}-->

## Summary

Adds `TauCeti/Probability/Exchangeability/FiniteMarginals.lean` — the Layer 0 **finite-dimensional
marginal uniqueness** milestone: two finite measures on path space `ℕ → α` that agree on every
finite prefix marginal are equal.

- `measure_eq_of_prefixProj_map_eq` — main API (marginals as `Measure.map` equalities under
  `prefixProj α n`).
- `measure_eq_of_prefixProj_setwise` — the setwise form matching the roadmap target (derived via
  `Measure.ext`).

The roadmap lists a probability version of finite-marginal uniqueness separately; this PR does
**not** add a duplicate theorem, because the finite-measure theorems apply directly under
`[IsProbabilityMeasure μ] [IsProbabilityMeasure ν]` (the instance provides `IsFiniteMeasure`).

## Roadmap

Advances `TauCetiRoadmap/Exchangeability`, Layer 0 (finite-marginal uniqueness). As the roadmap
specifies, this is a **thin ℕ-prefix wrapper over Mathlib's machinery, not new measure theory**:
the proof uses `MeasureTheory.IsProjectiveLimit.unique` (the same tool Mathlib's own
`FiniteDimensionalLaws` uses), with the only real step being the adapter that a finite index set
sits inside a prefix `{0,…,n-1}`, so its `Finset.restrict` factors through `prefixProj α n`.

Builds on the merged Basic.lean (#451) `prefixProj` / `measurable_prefixProj`. Unblocks the next
Layer 0 PRs: finite ↔ full exchangeability and full ⇒ shift-preservation, which both lift per-`n`
marginal agreement to the path law via this lemma.

Checked open PRs: no unmerged Exchangeability PR overlaps this target.

## Review notes

- **reuse:** closes via Mathlib's `IsProjectiveLimit.unique` — no new cylinder / π-system proof, and
  no duplicate probability theorem (the finite-measure statements cover probability measures).
- **scope:** one new file, two public theorems, on the single finite-marginal-uniqueness topic; no
  process- or `pathLaw`-level API (that's the next PR).
- **placement:** `FiniteMarginals.lean` is the dedicated Layer 0 file for this milestone, beside the
  other `Exchangeability/` modules.
- **import visibility:** `Mathlib.MeasureTheory.Constructions.Projective` is a non-public `import`
  (used only in the proof; no projective-limit name appears in an exported signature).

## Test plan

```bash
lake build
lake exe axioms
lake exe module-system
```

All pass: axiom audit reports only `propext`, `Classical.choice`, `Quot.sound`; module-system
audit passes; touched Lean lines are ≤100 chars. `Mathlib.MeasureTheory.Constructions.Projective`
is a non-public `import` (used only in the proof; no projective-limit name appears in an exported
signature).

## Attribution

The proof is a wrapper over Mathlib's projective-limit API (`IsProjectiveLimit.unique`), cited in
the module docstring. PR contents and description drafted with Claude (Opus 4.8) and human-directed.
