### PR TITLE
feat: add Hermite count natAbs bounds

### DIFF
--- a/TauCeti/NumberTheory/EffectiveBounds/HermiteCountNatAbs.lean
+++ b/TauCeti/NumberTheory/EffectiveBounds/HermiteCountNatAbs.lean
@@ -21,11 +21,11 @@ existing integer-absolute-value API, and then reuse the threshold and monotone w
 
 ## Main results
 
-* `TauCeti.NumberField.ncard_setOf_finiteDimensional_discr_natAbs_le_le_hermiteCountBound`:
+* `TauCeti.NumberField.ncard_setOf_finiteDimensional_natAbs_discr_le_le_hermiteCountBound`:
   the `natAbs` version with the exact constants attached to the same threshold.
-* `TauCeti.NumberField.ncard_setOf_finiteDimensional_discr_natAbs_le_le_of_threshold_le`:
+* `TauCeti.NumberField.ncard_setOf_finiteDimensional_natAbs_discr_le_le_of_threshold_le`:
   the `natAbs` version counted using a larger discriminant threshold.
-* `TauCeti.NumberField.ncard_setOf_finiteDimensional_discr_natAbs_le_le_of_threshold_bounds`:
+* `TauCeti.NumberField.ncard_setOf_finiteDimensional_natAbs_discr_le_le_of_threshold_bounds`:
   the same form with separate larger degree and coefficient-height bounds.
 
 No formal code is vendored. This is a direct API layer over the existing effective
@@ -42,7 +42,7 @@ variable (A : Type*) [Field A] [CharZero A]
 
 /-- The subfields whose discriminant has natural absolute value at most `N` are contained in the
 integer-absolute-value family used by Mathlib's Hermite theorem. -/
-private theorem setOf_finiteDimensional_discr_natAbs_le_subset_abs_discr_le (N : ℕ) :
+private theorem setOf_finiteDimensional_natAbs_discr_le_subset_abs_discr_le (N : ℕ) :
     {K : {F : IntermediateField ℚ A // FiniteDimensional ℚ F} |
         haveI : _root_.NumberField K := @NumberField.mk _ _ inferInstance K.prop
         (discr K).natAbs ≤ N} ⊆
@@ -51,61 +51,60 @@ private theorem setOf_finiteDimensional_discr_natAbs_le_subset_abs_discr_le (N :
         |discr K| ≤ (N : ℤ)} := by
   intro K hK
   haveI : _root_.NumberField K := @NumberField.mk _ _ inferInstance K.prop
+  -- The set predicate elaborates its own `haveI`; normalize the target to the local instance
+  -- before rewriting `Int.natAbs`.
   change |discr K| ≤ (N : ℤ)
   rw [Int.abs_eq_natAbs]
   exact_mod_cast hK
-
-/-- **Effective Hermite--Minkowski, natural-discriminant form.** Inside a fixed extension
-`A / ℚ`, the number of finite-dimensional subfields whose discriminant has natural absolute value
-at most `N` is bounded by the explicit Hermite-count expression attached to `N`. -/
-theorem ncard_setOf_finiteDimensional_discr_natAbs_le_le_hermiteCountBound (N : ℕ) :
-    {K : {F : IntermediateField ℚ A // FiniteDimensional ℚ F} |
-        haveI : _root_.NumberField K := @NumberField.mk _ _ inferInstance K.prop
-        (discr K).natAbs ≤ N}.ncard ≤
-      hermiteCountBound (rankOfDiscrBdd N) (coeffBoundOfDiscrBdd N) :=
-  (Set.ncard_le_ncard
-      (setOf_finiteDimensional_discr_natAbs_le_subset_abs_discr_le (A := A) N)
-      (NumberField.finite_of_discr_bdd A N)).trans
-    (ncard_setOf_finiteDimensional_abs_discr_le_le_hermiteCountBound (A := A) N)
 
 /-- **Threshold-monotone effective Hermite--Minkowski, natural-discriminant form.** If `N ≤ M`,
 then the number of finite-dimensional subfields of an ambient extension `A / ℚ` whose
 discriminant has natural absolute value at most `N` is bounded by the explicit Hermite-count
 expression attached to the larger threshold `M`. -/
-theorem ncard_setOf_finiteDimensional_discr_natAbs_le_le_of_threshold_le {N M : ℕ}
+theorem ncard_setOf_finiteDimensional_natAbs_discr_le_le_of_threshold_le {N M : ℕ}
     (hNM : N ≤ M) :
     {K : {F : IntermediateField ℚ A // FiniteDimensional ℚ F} |
         haveI : _root_.NumberField K := @NumberField.mk _ _ inferInstance K.prop
         (discr K).natAbs ≤ N}.ncard ≤
       hermiteCountBound (rankOfDiscrBdd M) (coeffBoundOfDiscrBdd M) :=
   (Set.ncard_le_ncard
-      (setOf_finiteDimensional_discr_natAbs_le_subset_abs_discr_le (A := A) N)
+      (setOf_finiteDimensional_natAbs_discr_le_subset_abs_discr_le (A := A) N)
       (NumberField.finite_of_discr_bdd A N)).trans
     (ncard_setOf_finiteDimensional_abs_discr_le_le_of_threshold_le (A := A) hNM)
+
+/-- **Effective Hermite--Minkowski, natural-discriminant form.** Inside a fixed extension
+`A / ℚ`, the number of finite-dimensional subfields whose discriminant has natural absolute value
+at most `N` is bounded by the explicit Hermite-count expression attached to `N`. -/
+theorem ncard_setOf_finiteDimensional_natAbs_discr_le_le_hermiteCountBound (N : ℕ) :
+    {K : {F : IntermediateField ℚ A // FiniteDimensional ℚ F} |
+        haveI : _root_.NumberField K := @NumberField.mk _ _ inferInstance K.prop
+        (discr K).natAbs ≤ N}.ncard ≤
+      hermiteCountBound (rankOfDiscrBdd N) (coeffBoundOfDiscrBdd N) :=
+  ncard_setOf_finiteDimensional_natAbs_discr_le_le_of_threshold_le (A := A) le_rfl
 
 /-- **Threshold-monotone effective Hermite--Minkowski with coarser constants,
 natural-discriminant form.** If `N ≤ M`, and `D` and `C` bound the degree and coefficient-height
 constants attached to `M`, then the number of finite-dimensional subfields of an ambient extension
 `A / ℚ` whose discriminant has natural absolute value at most `N` is at most
 `hermiteCountBound D C`. -/
-theorem ncard_setOf_finiteDimensional_discr_natAbs_le_le_of_threshold_bounds {N M D C : ℕ}
+theorem ncard_setOf_finiteDimensional_natAbs_discr_le_le_of_threshold_bounds {N M D C : ℕ}
     (hNM : N ≤ M) (hD : rankOfDiscrBdd M ≤ D) (hC : coeffBoundOfDiscrBdd M ≤ C) :
     {K : {F : IntermediateField ℚ A // FiniteDimensional ℚ F} |
         haveI : _root_.NumberField K := @NumberField.mk _ _ inferInstance K.prop
         (discr K).natAbs ≤ N}.ncard ≤ hermiteCountBound D C :=
-  (ncard_setOf_finiteDimensional_discr_natAbs_le_le_of_threshold_le (A := A) hNM).trans
+  (ncard_setOf_finiteDimensional_natAbs_discr_le_le_of_threshold_le (A := A) hNM).trans
     (hermiteCountBound_mono hD hC)
 
 /-- **Monotone effective Hermite--Minkowski, natural-discriminant form.** If `D` and `C` bound the
 degree and coefficient-height constants attached to `N`, then the number of finite-dimensional
 subfields of an ambient extension `A / ℚ` whose discriminant has natural absolute value at most
 `N` is at most `hermiteCountBound D C`. -/
-theorem ncard_setOf_finiteDimensional_discr_natAbs_le_le_of_bounds (N D C : ℕ)
+theorem ncard_setOf_finiteDimensional_natAbs_discr_le_le_of_bounds (N D C : ℕ)
     (hD : rankOfDiscrBdd N ≤ D) (hC : coeffBoundOfDiscrBdd N ≤ C) :
     {K : {F : IntermediateField ℚ A // FiniteDimensional ℚ F} |
         haveI : _root_.NumberField K := @NumberField.mk _ _ inferInstance K.prop
         (discr K).natAbs ≤ N}.ncard ≤ hermiteCountBound D C :=
-  ncard_setOf_finiteDimensional_discr_natAbs_le_le_of_threshold_bounds
+  ncard_setOf_finiteDimensional_natAbs_discr_le_le_of_threshold_bounds
     (A := A) le_rfl hD hC
 
 end TauCeti.NumberField

--- a/TauCeti/NumberTheory/EffectiveBounds/HermiteCountNatAbs.lean
+++ b/TauCeti/NumberTheory/EffectiveBounds/HermiteCountNatAbs.lean
@@ -1,0 +1,111 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+module
+
+public import TauCeti.NumberTheory.EffectiveBounds.HermiteCountThreshold
+
+/-!
+# Natural-discriminant forms of the effective Hermite--Minkowski count
+
+The effective Hermite--Minkowski count in `TauCeti.NumberTheory.EffectiveBounds.HermiteCount`
+counts finite-dimensional subfields of a fixed ambient extension `A / ℚ` satisfying
+`|NumberField.discr K| ≤ (N : ℤ)`. That spelling matches Mathlib's
+`NumberField.finite_of_discr_bdd`, but later explicit estimates often carry natural-number
+absolute discriminants, namely `(NumberField.discr K).natAbs ≤ N`.
+
+This file records the corresponding consumer forms. They do not change the constants or re-run the
+Hermite--Minkowski proof; they only bridge the natural-number discriminant inequality to the
+existing integer-absolute-value API, and then reuse the threshold and monotone wrappers.
+
+## Main results
+
+* `TauCeti.NumberField.ncard_setOf_finiteDimensional_discr_natAbs_le_le_hermiteCountBound`:
+  the `natAbs` version with the exact constants attached to the same threshold.
+* `TauCeti.NumberField.ncard_setOf_finiteDimensional_discr_natAbs_le_le_of_threshold_le`:
+  the `natAbs` version counted using a larger discriminant threshold.
+* `TauCeti.NumberField.ncard_setOf_finiteDimensional_discr_natAbs_le_le_of_threshold_bounds`:
+  the same form with separate larger degree and coefficient-height bounds.
+
+No formal code is vendored. This is a direct API layer over the existing effective
+Hermite--Minkowski count and Mathlib's `NumberField.finite_of_discr_bdd` target shape.
+-/
+
+public section
+
+open Module NumberField NumberField.hermiteTheorem
+
+namespace TauCeti.NumberField
+
+variable (A : Type*) [Field A] [CharZero A]
+
+/-- The subfields whose discriminant has natural absolute value at most `N` are contained in the
+integer-absolute-value family used by Mathlib's Hermite theorem. -/
+private theorem setOf_finiteDimensional_discr_natAbs_le_subset_abs_discr_le (N : ℕ) :
+    {K : {F : IntermediateField ℚ A // FiniteDimensional ℚ F} |
+        haveI : _root_.NumberField K := @NumberField.mk _ _ inferInstance K.prop
+        (discr K).natAbs ≤ N} ⊆
+      {K : {F : IntermediateField ℚ A // FiniteDimensional ℚ F} |
+        haveI : _root_.NumberField K := @NumberField.mk _ _ inferInstance K.prop
+        |discr K| ≤ (N : ℤ)} := by
+  intro K hK
+  haveI : _root_.NumberField K := @NumberField.mk _ _ inferInstance K.prop
+  change |discr K| ≤ (N : ℤ)
+  rw [Int.abs_eq_natAbs]
+  exact_mod_cast hK
+
+/-- **Effective Hermite--Minkowski, natural-discriminant form.** Inside a fixed extension
+`A / ℚ`, the number of finite-dimensional subfields whose discriminant has natural absolute value
+at most `N` is bounded by the explicit Hermite-count expression attached to `N`. -/
+theorem ncard_setOf_finiteDimensional_discr_natAbs_le_le_hermiteCountBound (N : ℕ) :
+    {K : {F : IntermediateField ℚ A // FiniteDimensional ℚ F} |
+        haveI : _root_.NumberField K := @NumberField.mk _ _ inferInstance K.prop
+        (discr K).natAbs ≤ N}.ncard ≤
+      hermiteCountBound (rankOfDiscrBdd N) (coeffBoundOfDiscrBdd N) :=
+  (Set.ncard_le_ncard
+      (setOf_finiteDimensional_discr_natAbs_le_subset_abs_discr_le (A := A) N)
+      (NumberField.finite_of_discr_bdd A N)).trans
+    (ncard_setOf_finiteDimensional_abs_discr_le_le_hermiteCountBound (A := A) N)
+
+/-- **Threshold-monotone effective Hermite--Minkowski, natural-discriminant form.** If `N ≤ M`,
+then the number of finite-dimensional subfields of an ambient extension `A / ℚ` whose
+discriminant has natural absolute value at most `N` is bounded by the explicit Hermite-count
+expression attached to the larger threshold `M`. -/
+theorem ncard_setOf_finiteDimensional_discr_natAbs_le_le_of_threshold_le {N M : ℕ}
+    (hNM : N ≤ M) :
+    {K : {F : IntermediateField ℚ A // FiniteDimensional ℚ F} |
+        haveI : _root_.NumberField K := @NumberField.mk _ _ inferInstance K.prop
+        (discr K).natAbs ≤ N}.ncard ≤
+      hermiteCountBound (rankOfDiscrBdd M) (coeffBoundOfDiscrBdd M) :=
+  (Set.ncard_le_ncard
+      (setOf_finiteDimensional_discr_natAbs_le_subset_abs_discr_le (A := A) N)
+      (NumberField.finite_of_discr_bdd A N)).trans
+    (ncard_setOf_finiteDimensional_abs_discr_le_le_of_threshold_le (A := A) hNM)
+
+/-- **Threshold-monotone effective Hermite--Minkowski with coarser constants,
+natural-discriminant form.** If `N ≤ M`, and `D` and `C` bound the degree and coefficient-height
+constants attached to `M`, then the number of finite-dimensional subfields of an ambient extension
+`A / ℚ` whose discriminant has natural absolute value at most `N` is at most
+`hermiteCountBound D C`. -/
+theorem ncard_setOf_finiteDimensional_discr_natAbs_le_le_of_threshold_bounds {N M D C : ℕ}
+    (hNM : N ≤ M) (hD : rankOfDiscrBdd M ≤ D) (hC : coeffBoundOfDiscrBdd M ≤ C) :
+    {K : {F : IntermediateField ℚ A // FiniteDimensional ℚ F} |
+        haveI : _root_.NumberField K := @NumberField.mk _ _ inferInstance K.prop
+        (discr K).natAbs ≤ N}.ncard ≤ hermiteCountBound D C :=
+  (ncard_setOf_finiteDimensional_discr_natAbs_le_le_of_threshold_le (A := A) hNM).trans
+    (hermiteCountBound_mono hD hC)
+
+/-- **Monotone effective Hermite--Minkowski, natural-discriminant form.** If `D` and `C` bound the
+degree and coefficient-height constants attached to `N`, then the number of finite-dimensional
+subfields of an ambient extension `A / ℚ` whose discriminant has natural absolute value at most
+`N` is at most `hermiteCountBound D C`. -/
+theorem ncard_setOf_finiteDimensional_discr_natAbs_le_le_of_bounds (N D C : ℕ)
+    (hD : rankOfDiscrBdd N ≤ D) (hC : coeffBoundOfDiscrBdd N ≤ C) :
+    {K : {F : IntermediateField ℚ A // FiniteDimensional ℚ F} |
+        haveI : _root_.NumberField K := @NumberField.mk _ _ inferInstance K.prop
+        (discr K).natAbs ≤ N}.ncard ≤ hermiteCountBound D C :=
+  ncard_setOf_finiteDimensional_discr_natAbs_le_le_of_threshold_bounds
+    (A := A) le_rfl hD hC
+
+end TauCeti.NumberField


### PR DESCRIPTION
This PR add natural-discriminant consumer forms of the effective Hermite--Minkowski count: the existing Layer 2 API counts subfields satisfying `|discr K| ≤ (N : ℤ)`, and the new module lets later EffectiveBounds estimates use the equivalent natural-number shape `(discr K).natAbs ≤ N` directly, with exact constants, larger thresholds, and coarser degree/coefficient bounds.

It advances `TauCetiRoadmap/EffectiveBounds/README.md`, Layer 2, specifically the effective Hermite--Minkowski item asking for “an explicit upper bound on the number of number fields (in a fixed `A/ℚ`) of discriminant `≤ B`”. I chose this as the lowest-hanging distinct EffectiveBounds prerequisite after checking open and recently merged PRs: the core explicit Hermite count, coarser-constant wrapper, and threshold-monotone wrapper already exist, while this natural-discriminant spelling was still absent and follows directly from the reviewed APIs.

No Mathlib infrastructure is vendored. The implementation reuses Mathlib's qualitative `NumberField.finite_of_discr_bdd` for finite target-set comparison, and Tau Ceti's existing `TauCeti.NumberField.ncard_setOf_finiteDimensional_abs_discr_le_le_hermiteCountBound`, `TauCeti.NumberField.ncard_setOf_finiteDimensional_abs_discr_le_le_of_threshold_le`, and `TauCeti.NumberField.hermiteCountBound_mono`.

`lake exe cache get` completed with `Decompressed 8599 file(s)` and `Already decompressed 8599 file(s)`. `lake build` completed with `Build completed successfully (4280 jobs).` `lake exe axioms` completed with `axioms: audited 5620 TauCeti declaration(s); all within the allowlist [propext, Classical.choice, Quot.sound].`

<!--tauceti-target:v1 {"focus":"EffectiveBounds","id":"hermite-count-natabs"}-->

🤖 Prepared with Codex
