### PR TITLE
feat: add semigroup-group time slice kernels

### DIFF
--- a/TauCeti/Analysis/PositiveDefinite/SemigroupGroupTimeSlice.lean
+++ b/TauCeti/Analysis/PositiveDefinite/SemigroupGroupTimeSlice.lean
@@ -4,6 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 -/
 module
 
+public import TauCeti.Analysis.PositiveDefinite.KernelBounds
 public import TauCeti.Analysis.PositiveDefinite.SemigroupGroup
 public import Mathlib.Topology.Constructions.SumProd
 
@@ -27,6 +28,10 @@ positive-definite function on `[0,∞) × V` to spatial positive-definite functi
 
 * `TauCeti.IsSemigroupGroupPD.timeSlice_isPositiveDefiniteKernel`: the fixed-time spatial
   kernel is positive definite.
+* `TauCeti.IsSemigroupGroupPD.timeSlice_kernel_sum_nonneg`,
+  `TauCeti.IsSemigroupGroupPD.timeSlice_kernel_conj_symm`,
+  `TauCeti.IsSemigroupGroupPD.timeSlice_kernel_apply_self_nonneg`, and
+  `TauCeti.IsSemigroupGroupPD.timeSlice_kernel_normSq_le`: fixed-time kernel consequences.
 * `TauCeti.IsSemigroupGroupPD.timeSlice_isPositiveDefinite`: the predicate form when the
   spatial involution is negation.
 * `TauCeti.IsSemigroupGroupPD.timeSlice_isPositiveDefiniteKernel_and_continuous`: packages
@@ -57,6 +62,29 @@ theorem timeSlice_isPositiveDefiniteKernel (hF : IsSemigroupGroupPD F) (t : ℝ�
   have hK := isPositiveDefiniteKernel_comp hF.isPositiveDefiniteKernel
     (fun v : V => (t / 2, v))
   simpa [add_halves] using hK
+
+/-- The finite quadratic-form inequality for the fixed-time spatial kernel. -/
+theorem timeSlice_kernel_sum_nonneg (hF : IsSemigroupGroupPD F) (t : ℝ≥0)
+    {ι : Type*} [Fintype ι] (v : ι → V) (c : ι → ℂ) :
+    0 ≤ ∑ i, ∑ j, conj (c i) * c j * F (t, v i - v j) :=
+  (isPositiveDefiniteKernel_iff.mp (hF.timeSlice_isPositiveDefiniteKernel t)).2 v c
+
+/-- The fixed-time spatial kernel is conjugate-symmetric. -/
+@[simp]
+theorem timeSlice_kernel_conj_symm (hF : IsSemigroupGroupPD F) (t : ℝ≥0) (v w : V) :
+    conj (F (t, v - w)) = F (t, w - v) :=
+  isPositiveDefiniteKernel_conj_symm (hF.timeSlice_isPositiveDefiniteKernel t) v w
+
+/-- Diagonal values of the fixed-time spatial kernel are nonnegative. -/
+theorem timeSlice_kernel_apply_self_nonneg (hF : IsSemigroupGroupPD F) (t : ℝ≥0) (v : V) :
+    0 ≤ F (t, v - v) :=
+  isPositiveDefiniteKernel_apply_self_nonneg (hF.timeSlice_isPositiveDefiniteKernel t) v
+
+/-- The fixed-time spatial-kernel Cauchy--Schwarz inequality. -/
+theorem timeSlice_kernel_normSq_le (hF : IsSemigroupGroupPD F) (t : ℝ≥0) (v w : V) :
+    RCLike.normSq (F (t, v - w)) ≤
+      RCLike.re (F (t, v - v)) * RCLike.re (F (t, w - w)) :=
+  isPositiveDefiniteKernel_normSq_le (hF.timeSlice_isPositiveDefiniteKernel t) v w
 
 /-- If the spatial type is equipped with the negation involution, then each fixed-time slice is a
 positive-definite function in the generic `IsPositiveDefinite` sense. -/

--- a/TauCeti/Analysis/PositiveDefinite/SemigroupGroupTimeSlice.lean
+++ b/TauCeti/Analysis/PositiveDefinite/SemigroupGroupTimeSlice.lean
@@ -5,7 +5,8 @@ Released under Apache 2.0 license as described in the file LICENSE.
 module
 
 public import TauCeti.Analysis.PositiveDefinite.SemigroupGroup
-public import Mathlib.Topology.Constructions
+public import TauCeti.Analysis.PositiveDefinite.KernelBounds
+public import Mathlib.Topology.Constructions.SumProd
 
 /-!
 # Time slices of semigroup-group positive-definite functions
@@ -14,8 +15,8 @@ A Berg--Christensen--Ressel positive-definite function on `ℝ≥0 × V` is posi
 spatial variable at every fixed time. Indeed, to test the kernel
 `(v, w) ↦ F (t, v - w)`, apply the BCR kernel to the family of points `(t / 2, v)`.
 
-This file records that fixed-time-slice API in kernel form, together with origin
-normalization facts and the predicate form for the fixed-time slice. These lemmas are
+This file records that fixed-time-slice API in kernel form, together with finite-form,
+symmetry, and bound facts and the predicate form for the fixed-time slice. These lemmas are
 prerequisites for the BCR representation milestone in the `OneParameterSemigroups` roadmap:
 later proofs can apply the spatial Bochner theorem to each time slice before handling the
 remaining Laplace/semigroup structure.
@@ -28,9 +29,10 @@ positive-definite function on `[0,∞) × V` to spatial positive-definite functi
 
 * `TauCeti.IsSemigroupGroupPD.timeSlice_isPositiveDefiniteKernel`: the fixed-time spatial
   kernel is positive definite.
-* `TauCeti.IsSemigroupGroupPD.timeSlice_apply_zero_nonneg` and
-  `TauCeti.IsSemigroupGroupPD.timeSlice_apply_zero_eq_ofReal_re`: origin facts for a fixed
-  time slice.
+* `TauCeti.IsSemigroupGroupPD.timeSlice_sum_nonneg`,
+  `TauCeti.IsSemigroupGroupPD.timeSlice_conj_symm`, and
+  `TauCeti.IsSemigroupGroupPD.timeSlice_normSq_le`: finite-form, symmetry, and bound facts for
+  the fixed-time spatial kernel.
 * `TauCeti.IsSemigroupGroupPD.timeSlice_isPositiveDefinite`: the predicate form when the
   spatial involution is negation.
 * `TauCeti.IsSemigroupGroupPD.timeSlice_isPositiveDefiniteKernel_and_continuous`: packages
@@ -62,30 +64,22 @@ theorem timeSlice_isPositiveDefiniteKernel (hF : IsSemigroupGroupPD F) (t : ℝ�
     (fun v : V => (t / 2, v))
   simpa [add_halves] using hK
 
-/-- The value at the spatial origin of a fixed-time slice is nonnegative. -/
-theorem timeSlice_apply_zero_nonneg (hF : IsSemigroupGroupPD F) (t : ℝ≥0) :
-    0 ≤ F (t, 0) := by
-  simpa using isPositiveDefiniteKernel_apply_self_nonneg
-    (hF.timeSlice_isPositiveDefiniteKernel t) (0 : V)
+/-- The finite quadratic form of the fixed-time spatial kernel is nonnegative. -/
+theorem timeSlice_sum_nonneg (hF : IsSemigroupGroupPD F) (t : ℝ≥0) {ι : Type*}
+    [Fintype ι] (v : ι → V) (x : ι → ℂ) :
+    0 ≤ ∑ i, ∑ j, conj (x i) * x j * F (t, v i - v j) :=
+  (isPositiveDefiniteKernel_iff.mp (hF.timeSlice_isPositiveDefiniteKernel t)).2 v x
 
-/-- The value at the spatial origin of a fixed-time slice has zero imaginary part. -/
+/-- The fixed-time spatial kernel is conjugate-symmetric. -/
 @[simp]
-theorem timeSlice_apply_zero_im (hF : IsSemigroupGroupPD F) (t : ℝ≥0) :
-    (F (t, 0)).im = 0 :=
-  ((Complex.nonneg_iff.mp (hF.timeSlice_apply_zero_nonneg t)).2).symm
+theorem timeSlice_conj_symm (hF : IsSemigroupGroupPD F) (t : ℝ≥0) (v w : V) :
+    conj (F (t, v - w)) = F (t, w - v) :=
+  isPositiveDefiniteKernel_conj_symm (hF.timeSlice_isPositiveDefiniteKernel t) v w
 
-/-- The real part of the value at the spatial origin of a fixed-time slice is nonnegative. -/
-theorem timeSlice_apply_zero_re_nonneg (hF : IsSemigroupGroupPD F) (t : ℝ≥0) :
-    0 ≤ (F (t, 0)).re :=
-  (Complex.nonneg_iff.mp (hF.timeSlice_apply_zero_nonneg t)).1
-
-/-- The value at the spatial origin of a fixed-time slice is equal to its real part, viewed as a
-complex number. -/
-theorem timeSlice_apply_zero_eq_ofReal_re (hF : IsSemigroupGroupPD F) (t : ℝ≥0) :
-    F (t, 0) = ((F (t, 0)).re : ℂ) := by
-  apply Complex.ext
-  · simp
-  · simpa using hF.timeSlice_apply_zero_im t
+/-- The Cauchy--Schwarz bound for the fixed-time spatial kernel. -/
+theorem timeSlice_normSq_le (hF : IsSemigroupGroupPD F) (t : ℝ≥0) (v w : V) :
+    Complex.normSq (F (t, v - w)) ≤ (F (t, 0)).re * (F (t, 0)).re := by
+  simpa using isPositiveDefiniteKernel_normSq_le (hF.timeSlice_isPositiveDefiniteKernel t) v w
 
 /-- If the spatial type is equipped with the negation involution, then each fixed-time slice is a
 positive-definite function in the generic `IsPositiveDefinite` sense. -/

--- a/TauCeti/Analysis/PositiveDefinite/SemigroupGroupTimeSlice.lean
+++ b/TauCeti/Analysis/PositiveDefinite/SemigroupGroupTimeSlice.lean
@@ -14,11 +14,10 @@ A Berg--Christensen--Ressel positive-definite function on `ℝ≥0 × V` is posi
 spatial variable at every fixed time. Indeed, to test the kernel
 `(v, w) ↦ F (t, v - w)`, apply the BCR kernel to the family of points `(t / 2, v)`.
 
-This file records that fixed-time-slice API in kernel form, together with origin normal forms
-and the predicate form for the fixed-time slice. These lemmas are
-prerequisites for the BCR representation milestone in the `OneParameterSemigroups` roadmap:
-later proofs can apply the spatial Bochner theorem to each time slice before handling the
-remaining Laplace/semigroup structure.
+This file records that fixed-time-slice API in kernel form, together with the predicate form for
+the fixed-time slice. These lemmas are prerequisites for the BCR representation milestone in the
+`OneParameterSemigroups` roadmap: later proofs can apply the spatial Bochner theorem to each time
+slice before handling the remaining Laplace/semigroup structure.
 
 This advances `TauCetiRoadmap/OneParameterSemigroups/README.md`, Part C, Milestone 2
 ("BCR semigroup--Bochner"), specifically the reduction of a bounded continuous
@@ -28,8 +27,6 @@ positive-definite function on `[0,∞) × V` to spatial positive-definite functi
 
 * `TauCeti.IsSemigroupGroupPD.timeSlice_isPositiveDefiniteKernel`: the fixed-time spatial
   kernel is positive definite.
-* `TauCeti.IsSemigroupGroupPD.timeSlice_apply_zero_nonneg` and related lemmas: origin
-  normal forms for the fixed-time spatial slice.
 * `TauCeti.IsSemigroupGroupPD.timeSlice_isPositiveDefinite`: the predicate form when the
   spatial involution is negation.
 * `TauCeti.IsSemigroupGroupPD.timeSlice_isPositiveDefiniteKernel_and_continuous`: packages
@@ -60,28 +57,6 @@ theorem timeSlice_isPositiveDefiniteKernel (hF : IsSemigroupGroupPD F) (t : ℝ�
   have hK := isPositiveDefiniteKernel_comp hF.isPositiveDefiniteKernel
     (fun v : V => (t / 2, v))
   simpa [add_halves] using hK
-
-/-- The value at the spatial origin of a fixed-time slice is nonnegative. -/
-theorem timeSlice_apply_zero_nonneg (hF : IsSemigroupGroupPD F) (t : ℝ≥0) :
-    0 ≤ F (t, 0) := by
-  simpa [add_halves] using hF.diagonal_nonneg (t / 2)
-
-/-- The value at the spatial origin of a fixed-time slice has zero imaginary part. -/
-@[simp]
-theorem timeSlice_apply_zero_im (hF : IsSemigroupGroupPD F) (t : ℝ≥0) :
-    (F (t, 0)).im = 0 := by
-  simpa [add_halves] using hF.diagonal_im (t / 2)
-
-/-- The real part of the value at the spatial origin of a fixed-time slice is nonnegative. -/
-theorem timeSlice_apply_zero_re_nonneg (hF : IsSemigroupGroupPD F) (t : ℝ≥0) :
-    0 ≤ (F (t, 0)).re := by
-  simpa [add_halves] using hF.diagonal_re_nonneg (t / 2)
-
-/-- The value at the spatial origin of a fixed-time slice is equal to its real part, viewed as a
-complex number. -/
-theorem timeSlice_apply_zero_eq_ofReal_re (hF : IsSemigroupGroupPD F) (t : ℝ≥0) :
-    F (t, 0) = ((F (t, 0)).re : ℂ) := by
-  simpa [add_halves] using hF.diagonal_eq_ofReal_re (t / 2)
 
 /-- If the spatial type is equipped with the negation involution, then each fixed-time slice is a
 positive-definite function in the generic `IsPositiveDefinite` sense. -/

--- a/TauCeti/Analysis/PositiveDefinite/SemigroupGroupTimeSlice.lean
+++ b/TauCeti/Analysis/PositiveDefinite/SemigroupGroupTimeSlice.lean
@@ -28,6 +28,8 @@ positive-definite function on `[0,∞) × V` to spatial positive-definite functi
 
 * `TauCeti.IsSemigroupGroupPD.timeSlice_isPositiveDefiniteKernel`: the fixed-time spatial
   kernel is positive definite.
+* `TauCeti.IsSemigroupGroupPD.timeSlice_conj_symm` and diagonal lemmas: basic symmetry and
+  real-nonnegative diagonal facts for fixed-time slices.
 * `TauCeti.IsSemigroupGroupPD.timeSlice_sum_nonneg`: the fixed-time spatial quadratic form is
   nonnegative for arbitrary finite families.
 * `TauCeti.IsSemigroupGroupPD.timeSlice_normSq_le`: the fixed-time spatial Cauchy--Schwarz
@@ -62,6 +64,36 @@ theorem timeSlice_isPositiveDefiniteKernel (hF : IsSemigroupGroupPD F) (t : ℝ�
   have hK := isPositiveDefiniteKernel_comp hF.isPositiveDefiniteKernel
     (fun v : V => (t / 2, v))
   simpa [add_halves] using hK
+
+/-- Fixed-time slices are conjugate-symmetric in the spatial variable:
+`conj (F (t, v - w)) = F (t, w - v)`. -/
+@[simp]
+theorem timeSlice_conj_symm (hF : IsSemigroupGroupPD F) (t : ℝ≥0) (v w : V) :
+    conj (F (t, v - w)) = F (t, w - v) :=
+  isPositiveDefiniteKernel_conj_symm (hF.timeSlice_isPositiveDefiniteKernel t) v w
+
+/-- The diagonal value `F (t, 0)` of a fixed-time slice is real and nonnegative. -/
+theorem timeSlice_diagonal_nonneg (hF : IsSemigroupGroupPD F) (t : ℝ≥0) : 0 ≤ F (t, 0) := by
+  simpa using isPositiveDefiniteKernel_apply_self_nonneg (hF.timeSlice_isPositiveDefiniteKernel t)
+    (0 : V)
+
+/-- The diagonal value `F (t, 0)` of a fixed-time slice has zero imaginary part. -/
+@[simp]
+theorem timeSlice_diagonal_im (hF : IsSemigroupGroupPD F) (t : ℝ≥0) : (F (t, 0)).im = 0 :=
+  ((Complex.nonneg_iff.mp (hF.timeSlice_diagonal_nonneg t)).2).symm
+
+/-- The real part of the diagonal value `F (t, 0)` of a fixed-time slice is nonnegative. -/
+theorem timeSlice_diagonal_re_nonneg (hF : IsSemigroupGroupPD F) (t : ℝ≥0) :
+    0 ≤ (F (t, 0)).re :=
+  (Complex.nonneg_iff.mp (hF.timeSlice_diagonal_nonneg t)).1
+
+/-- The diagonal value `F (t, 0)` of a fixed-time slice is equal to its real part, viewed as a
+complex number. -/
+theorem timeSlice_diagonal_eq_ofReal_re (hF : IsSemigroupGroupPD F) (t : ℝ≥0) :
+    F (t, 0) = ((F (t, 0)).re : ℂ) := by
+  apply Complex.ext
+  · simp
+  · simpa using hF.timeSlice_diagonal_im t
 
 /-- The fixed-time spatial quadratic form is nonnegative for arbitrary finite families. -/
 theorem timeSlice_sum_nonneg (hF : IsSemigroupGroupPD F) (t : ℝ≥0) {ι : Type*} [Fintype ι]

--- a/TauCeti/Analysis/PositiveDefinite/SemigroupGroupTimeSlice.lean
+++ b/TauCeti/Analysis/PositiveDefinite/SemigroupGroupTimeSlice.lean
@@ -4,6 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 -/
 module
 
+public import TauCeti.Analysis.PositiveDefinite.KernelBounds
 public import TauCeti.Analysis.PositiveDefinite.SemigroupGroup
 public import Mathlib.Topology.Constructions.SumProd
 
@@ -29,6 +30,8 @@ positive-definite function on `[0,∞) × V` to spatial positive-definite functi
   kernel is positive definite.
 * `TauCeti.IsSemigroupGroupPD.timeSlice_sum_nonneg`: the fixed-time spatial quadratic form is
   nonnegative for arbitrary finite families.
+* `TauCeti.IsSemigroupGroupPD.timeSlice_normSq_le`: the fixed-time spatial Cauchy--Schwarz
+  estimate.
 * `TauCeti.IsSemigroupGroupPD.timeSlice_isPositiveDefinite`: the predicate form when the
   spatial involution is negation.
 * `TauCeti.IsSemigroupGroupPD.timeSlice_isPositiveDefiniteKernel_and_continuous`: packages
@@ -65,6 +68,11 @@ theorem timeSlice_sum_nonneg (hF : IsSemigroupGroupPD F) (t : ℝ≥0) {ι : Typ
     (v : ι → V) (x : ι → ℂ) :
     0 ≤ ∑ i, ∑ j, conj (x i) * x j * F (t, v i - v j) :=
   (isPositiveDefiniteKernel_iff.mp (hF.timeSlice_isPositiveDefiniteKernel t)).2 v x
+
+/-- The fixed-time spatial Cauchy--Schwarz bound for the kernel entry `F (t, v - w)`. -/
+theorem timeSlice_normSq_le (hF : IsSemigroupGroupPD F) (t : ℝ≥0) (v w : V) :
+    RCLike.normSq (F (t, v - w)) ≤ RCLike.re (F (t, 0)) * RCLike.re (F (t, 0)) := by
+  simpa using isPositiveDefiniteKernel_normSq_le (hF.timeSlice_isPositiveDefiniteKernel t) v w
 
 /-- If the spatial type is equipped with the negation involution, then each fixed-time slice is a
 positive-definite function in the generic `IsPositiveDefinite` sense. -/

--- a/TauCeti/Analysis/PositiveDefinite/SemigroupGroupTimeSlice.lean
+++ b/TauCeti/Analysis/PositiveDefinite/SemigroupGroupTimeSlice.lean
@@ -28,6 +28,8 @@ positive-definite function on `[0,∞) × V` to spatial positive-definite functi
 
 * `TauCeti.IsSemigroupGroupPD.timeSlice_isPositiveDefiniteKernel`: the fixed-time spatial
   kernel is positive definite.
+* `TauCeti.IsSemigroupGroupPD.timeSlice_sum_nonneg`: the fixed-time spatial quadratic form is
+  nonnegative for arbitrary finite families.
 * `TauCeti.IsSemigroupGroupPD.timeSlice_conj`,
   `TauCeti.IsSemigroupGroupPD.timeSlice_zero_nonneg`, and
   `TauCeti.IsSemigroupGroupPD.timeSlice_normSq_le_zero`: origin-normalized fixed-time
@@ -62,6 +64,12 @@ theorem timeSlice_isPositiveDefiniteKernel (hF : IsSemigroupGroupPD F) (t : ℝ�
   have hK := isPositiveDefiniteKernel_comp hF.isPositiveDefiniteKernel
     (fun v : V => (t / 2, v))
   simpa [add_halves] using hK
+
+/-- The fixed-time spatial quadratic form is nonnegative for arbitrary finite families. -/
+theorem timeSlice_sum_nonneg (hF : IsSemigroupGroupPD F) (t : ℝ≥0) {ι : Type*} [Fintype ι]
+    (v : ι → V) (x : ι → ℂ) :
+    0 ≤ ∑ i, ∑ j, conj (x i) * x j * F (t, v i - v j) :=
+  (isPositiveDefiniteKernel_iff.mp (hF.timeSlice_isPositiveDefiniteKernel t)).2 v x
 
 /-- The fixed-time slice is conjugate-symmetric around the spatial origin. -/
 @[simp]

--- a/TauCeti/Analysis/PositiveDefinite/SemigroupGroupTimeSlice.lean
+++ b/TauCeti/Analysis/PositiveDefinite/SemigroupGroupTimeSlice.lean
@@ -4,7 +4,6 @@ Released under Apache 2.0 license as described in the file LICENSE.
 -/
 module
 
-public import TauCeti.Analysis.PositiveDefinite.KernelBounds
 public import TauCeti.Analysis.PositiveDefinite.SemigroupGroup
 public import Mathlib.Topology.Constructions.SumProd
 
@@ -30,10 +29,6 @@ positive-definite function on `[0,∞) × V` to spatial positive-definite functi
   kernel is positive definite.
 * `TauCeti.IsSemigroupGroupPD.timeSlice_sum_nonneg`: the fixed-time spatial quadratic form is
   nonnegative for arbitrary finite families.
-* `TauCeti.IsSemigroupGroupPD.timeSlice_conj`,
-  `TauCeti.IsSemigroupGroupPD.timeSlice_zero_nonneg`, and
-  `TauCeti.IsSemigroupGroupPD.timeSlice_normSq_le_zero`: origin-normalized fixed-time
-  consequences.
 * `TauCeti.IsSemigroupGroupPD.timeSlice_isPositiveDefinite`: the predicate form when the
   spatial involution is negation.
 * `TauCeti.IsSemigroupGroupPD.timeSlice_isPositiveDefiniteKernel_and_continuous`: packages
@@ -70,24 +65,6 @@ theorem timeSlice_sum_nonneg (hF : IsSemigroupGroupPD F) (t : ℝ≥0) {ι : Typ
     (v : ι → V) (x : ι → ℂ) :
     0 ≤ ∑ i, ∑ j, conj (x i) * x j * F (t, v i - v j) :=
   (isPositiveDefiniteKernel_iff.mp (hF.timeSlice_isPositiveDefiniteKernel t)).2 v x
-
-/-- The fixed-time slice is conjugate-symmetric around the spatial origin. -/
-@[simp]
-theorem timeSlice_conj (hF : IsSemigroupGroupPD F) (t : ℝ≥0) (v : V) :
-    conj (F (t, v)) = F (t, -v) := by
-  simpa using isPositiveDefiniteKernel_conj_symm
-    (hF.timeSlice_isPositiveDefiniteKernel t) v 0
-
-/-- The fixed-time slice is nonnegative at the spatial origin. -/
-theorem timeSlice_zero_nonneg (hF : IsSemigroupGroupPD F) (t : ℝ≥0) : 0 ≤ F (t, 0) := by
-  simpa using isPositiveDefiniteKernel_apply_self_nonneg
-    (hF.timeSlice_isPositiveDefiniteKernel t) (0 : V)
-
-/-- The fixed-time slice Cauchy--Schwarz bound against the spatial origin. -/
-theorem timeSlice_normSq_le_zero (hF : IsSemigroupGroupPD F) (t : ℝ≥0) (v : V) :
-    RCLike.normSq (F (t, v)) ≤ RCLike.re (F (t, 0)) * RCLike.re (F (t, 0)) := by
-  simpa using isPositiveDefiniteKernel_normSq_le
-    (hF.timeSlice_isPositiveDefiniteKernel t) v 0
 
 /-- If the spatial type is equipped with the negation involution, then each fixed-time slice is a
 positive-definite function in the generic `IsPositiveDefinite` sense. -/

--- a/TauCeti/Analysis/PositiveDefinite/SemigroupGroupTimeSlice.lean
+++ b/TauCeti/Analysis/PositiveDefinite/SemigroupGroupTimeSlice.lean
@@ -5,7 +5,6 @@ Released under Apache 2.0 license as described in the file LICENSE.
 module
 
 public import TauCeti.Analysis.PositiveDefinite.SemigroupGroup
-public import TauCeti.Analysis.PositiveDefinite.KernelBounds
 public import Mathlib.Topology.Constructions
 
 /-!
@@ -15,12 +14,11 @@ A Berg--Christensen--Ressel positive-definite function on `ℝ≥0 × V` is posi
 spatial variable at every fixed time. Indeed, to test the kernel
 `(v, w) ↦ F (t, v - w)`, apply the BCR kernel to the family of points `(t / 2, v)`.
 
-This file records that fixed-time-slice API in kernel form, together with the finite
-quadratic-form restatement, conjugate symmetry, diagonal nonnegativity, the scalar
-Cauchy--Schwarz bound on each slice, and the elementary continuity statement for continuous
-`F`. These lemmas are prerequisites for the BCR representation milestone in the
-`OneParameterSemigroups` roadmap: later proofs can apply the spatial Bochner theorem to each
-time slice before handling the remaining Laplace/semigroup structure.
+This file records that fixed-time-slice API in kernel form, together with origin
+normalization facts and the predicate form for the fixed-time slice. These lemmas are
+prerequisites for the BCR representation milestone in the `OneParameterSemigroups` roadmap:
+later proofs can apply the spatial Bochner theorem to each time slice before handling the
+remaining Laplace/semigroup structure.
 
 This advances `TauCetiRoadmap/OneParameterSemigroups/README.md`, Part C, Milestone 2
 ("BCR semigroup--Bochner"), specifically the reduction of a bounded continuous
@@ -30,13 +28,13 @@ positive-definite function on `[0,∞) × V` to spatial positive-definite functi
 
 * `TauCeti.IsSemigroupGroupPD.timeSlice_isPositiveDefiniteKernel`: the fixed-time spatial
   kernel is positive definite.
-* `TauCeti.IsSemigroupGroupPD.timeSlice_sum_nonneg`: the finite quadratic-form version.
-* `TauCeti.IsSemigroupGroupPD.timeSlice_conj_symm`,
-  `TauCeti.IsSemigroupGroupPD.timeSlice_apply_zero_nonneg`, and
-  `TauCeti.IsSemigroupGroupPD.timeSlice_normSq_le`: basic consequences on a fixed time slice.
+* `TauCeti.IsSemigroupGroupPD.timeSlice_apply_zero_nonneg` and
+  `TauCeti.IsSemigroupGroupPD.timeSlice_apply_zero_eq_ofReal_re`: origin facts for a fixed
+  time slice.
 * `TauCeti.IsSemigroupGroupPD.timeSlice_isPositiveDefinite`: the predicate form when the
   spatial involution is negation.
-* `TauCeti.continuous_timeSlice`: continuity of a fixed-time slice of a continuous function.
+* `TauCeti.IsSemigroupGroupPD.timeSlice_isPositiveDefiniteKernel_and_continuous`: packages
+  the fixed-time positive-definite kernel with continuity of the fixed-time slice.
 
 ## References
 
@@ -64,30 +62,6 @@ theorem timeSlice_isPositiveDefiniteKernel (hF : IsSemigroupGroupPD F) (t : ℝ�
     (fun v : V => (t / 2, v))
   simpa [add_halves] using hK
 
-/-- The finite quadratic-form restatement of fixed-time spatial positive definiteness. -/
-theorem timeSlice_sum_nonneg (hF : IsSemigroupGroupPD F) (t : ℝ≥0)
-    {ι : Type*} [Fintype ι] (c : ι → ℂ) (v : ι → V) :
-    0 ≤ ∑ i, ∑ j, c i * conj (c j) * F (t, v i - v j) := by
-  have hK := hF.timeSlice_isPositiveDefiniteKernel t
-  have hpos := (isPositiveDefiniteKernel_iff.mp hK).2 v (fun i => conj (c i))
-  simpa only [Complex.conj_conj] using hpos
-
-/-- The `2 × 2` Hermitian sub-form of a fixed-time spatial slice. -/
-theorem timeSlice_quadForm_two_nonneg (hF : IsSemigroupGroupPD F) (t : ℝ≥0)
-    (v w : V) (c₀ c₁ : ℂ) :
-    0 ≤ c₀ * conj c₀ * F (t, v - v) + c₀ * conj c₁ * F (t, v - w)
-      + c₁ * conj c₀ * F (t, w - v) + c₁ * conj c₁ * F (t, w - w) := by
-  have h := hF.timeSlice_sum_nonneg t ![c₀, c₁] ![v, w]
-  simp only [Fin.sum_univ_two, Matrix.cons_val_zero, Matrix.cons_val_one] at h
-  exact le_of_le_of_eq h (by ring)
-
-/-- A fixed-time spatial slice is conjugate symmetric:
-`conj (F (t, v - w)) = F (t, w - v)`. -/
-@[simp]
-theorem timeSlice_conj_symm (hF : IsSemigroupGroupPD F) (t : ℝ≥0) (v w : V) :
-    conj (F (t, v - w)) = F (t, w - v) :=
-  isPositiveDefiniteKernel_conj_symm (hF.timeSlice_isPositiveDefiniteKernel t) v w
-
 /-- The value at the spatial origin of a fixed-time slice is nonnegative. -/
 theorem timeSlice_apply_zero_nonneg (hF : IsSemigroupGroupPD F) (t : ℝ≥0) :
     0 ≤ F (t, 0) := by
@@ -105,12 +79,13 @@ theorem timeSlice_apply_zero_re_nonneg (hF : IsSemigroupGroupPD F) (t : ℝ≥0)
     0 ≤ (F (t, 0)).re :=
   (Complex.nonneg_iff.mp (hF.timeSlice_apply_zero_nonneg t)).1
 
-/-- On a fixed-time slice, the squared norm of an off-diagonal value is bounded by the square of
-the real diagonal value. -/
-theorem timeSlice_normSq_le (hF : IsSemigroupGroupPD F) (t : ℝ≥0) (v w : V) :
-    Complex.normSq (F (t, v - w)) ≤ (F (t, 0)).re * (F (t, 0)).re := by
-  simpa [sub_self] using
-    isPositiveDefiniteKernel_normSq_le (hF.timeSlice_isPositiveDefiniteKernel t) v w
+/-- The value at the spatial origin of a fixed-time slice is equal to its real part, viewed as a
+complex number. -/
+theorem timeSlice_apply_zero_eq_ofReal_re (hF : IsSemigroupGroupPD F) (t : ℝ≥0) :
+    F (t, 0) = ((F (t, 0)).re : ℂ) := by
+  apply Complex.ext
+  · simp
+  · simpa using hF.timeSlice_apply_zero_im t
 
 /-- If the spatial type is equipped with the negation involution, then each fixed-time slice is a
 positive-definite function in the generic `IsPositiveDefinite` sense. -/
@@ -124,21 +99,14 @@ end IsSemigroupGroupPD
 
 section Topology
 
-variable {W : Type*} [TopologicalSpace W]
-
-/-- A fixed-time slice of a continuous function on `ℝ≥0 × V` is continuous. -/
-theorem continuous_timeSlice {F : ℝ≥0 × W → ℂ} (hF : Continuous F) (t : ℝ≥0) :
-    Continuous fun v : W => F (t, v) :=
-  hF.comp (continuous_const.prodMk continuous_id)
-
 variable [TopologicalSpace V] {F : ℝ≥0 × V → ℂ}
 
-/-- A continuous semigroup-group positive-definite function has continuous positive-definite
-spatial kernels on every fixed time slice. -/
-theorem IsSemigroupGroupPD.continuous_timeSlice_isPositiveDefiniteKernel
+/-- Package the positive-definite kernel on a fixed-time slice with continuity of the
+one-variable fixed-time slice. -/
+theorem IsSemigroupGroupPD.timeSlice_isPositiveDefiniteKernel_and_continuous
     (hFpd : IsSemigroupGroupPD F) (hFcont : Continuous F) (t : ℝ≥0) :
     IsPositiveDefiniteKernel (fun v w : V => F (t, v - w)) ∧ Continuous (fun v : V => F (t, v)) :=
-  ⟨hFpd.timeSlice_isPositiveDefiniteKernel t, continuous_timeSlice hFcont t⟩
+  ⟨hFpd.timeSlice_isPositiveDefiniteKernel t, hFcont.comp (.prodMk_right t)⟩
 
 end Topology
 

--- a/TauCeti/Analysis/PositiveDefinite/SemigroupGroupTimeSlice.lean
+++ b/TauCeti/Analysis/PositiveDefinite/SemigroupGroupTimeSlice.lean
@@ -28,10 +28,10 @@ positive-definite function on `[0,∞) × V` to spatial positive-definite functi
 
 * `TauCeti.IsSemigroupGroupPD.timeSlice_isPositiveDefiniteKernel`: the fixed-time spatial
   kernel is positive definite.
-* `TauCeti.IsSemigroupGroupPD.timeSlice_kernel_sum_nonneg`,
-  `TauCeti.IsSemigroupGroupPD.timeSlice_kernel_conj_symm`,
-  `TauCeti.IsSemigroupGroupPD.timeSlice_kernel_apply_self_nonneg`, and
-  `TauCeti.IsSemigroupGroupPD.timeSlice_kernel_normSq_le`: fixed-time kernel consequences.
+* `TauCeti.IsSemigroupGroupPD.timeSlice_conj`,
+  `TauCeti.IsSemigroupGroupPD.timeSlice_zero_nonneg`, and
+  `TauCeti.IsSemigroupGroupPD.timeSlice_normSq_le_zero`: origin-normalized fixed-time
+  consequences.
 * `TauCeti.IsSemigroupGroupPD.timeSlice_isPositiveDefinite`: the predicate form when the
   spatial involution is negation.
 * `TauCeti.IsSemigroupGroupPD.timeSlice_isPositiveDefiniteKernel_and_continuous`: packages
@@ -63,28 +63,23 @@ theorem timeSlice_isPositiveDefiniteKernel (hF : IsSemigroupGroupPD F) (t : ℝ�
     (fun v : V => (t / 2, v))
   simpa [add_halves] using hK
 
-/-- The finite quadratic-form inequality for the fixed-time spatial kernel. -/
-theorem timeSlice_kernel_sum_nonneg (hF : IsSemigroupGroupPD F) (t : ℝ≥0)
-    {ι : Type*} [Fintype ι] (v : ι → V) (c : ι → ℂ) :
-    0 ≤ ∑ i, ∑ j, conj (c i) * c j * F (t, v i - v j) :=
-  (isPositiveDefiniteKernel_iff.mp (hF.timeSlice_isPositiveDefiniteKernel t)).2 v c
-
-/-- The fixed-time spatial kernel is conjugate-symmetric. -/
+/-- The fixed-time slice is conjugate-symmetric around the spatial origin. -/
 @[simp]
-theorem timeSlice_kernel_conj_symm (hF : IsSemigroupGroupPD F) (t : ℝ≥0) (v w : V) :
-    conj (F (t, v - w)) = F (t, w - v) :=
-  isPositiveDefiniteKernel_conj_symm (hF.timeSlice_isPositiveDefiniteKernel t) v w
+theorem timeSlice_conj (hF : IsSemigroupGroupPD F) (t : ℝ≥0) (v : V) :
+    conj (F (t, v)) = F (t, -v) := by
+  simpa using isPositiveDefiniteKernel_conj_symm
+    (hF.timeSlice_isPositiveDefiniteKernel t) v 0
 
-/-- Diagonal values of the fixed-time spatial kernel are nonnegative. -/
-theorem timeSlice_kernel_apply_self_nonneg (hF : IsSemigroupGroupPD F) (t : ℝ≥0) (v : V) :
-    0 ≤ F (t, v - v) :=
-  isPositiveDefiniteKernel_apply_self_nonneg (hF.timeSlice_isPositiveDefiniteKernel t) v
+/-- The fixed-time slice is nonnegative at the spatial origin. -/
+theorem timeSlice_zero_nonneg (hF : IsSemigroupGroupPD F) (t : ℝ≥0) : 0 ≤ F (t, 0) := by
+  simpa using isPositiveDefiniteKernel_apply_self_nonneg
+    (hF.timeSlice_isPositiveDefiniteKernel t) (0 : V)
 
-/-- The fixed-time spatial-kernel Cauchy--Schwarz inequality. -/
-theorem timeSlice_kernel_normSq_le (hF : IsSemigroupGroupPD F) (t : ℝ≥0) (v w : V) :
-    RCLike.normSq (F (t, v - w)) ≤
-      RCLike.re (F (t, v - v)) * RCLike.re (F (t, w - w)) :=
-  isPositiveDefiniteKernel_normSq_le (hF.timeSlice_isPositiveDefiniteKernel t) v w
+/-- The fixed-time slice Cauchy--Schwarz bound against the spatial origin. -/
+theorem timeSlice_normSq_le_zero (hF : IsSemigroupGroupPD F) (t : ℝ≥0) (v : V) :
+    RCLike.normSq (F (t, v)) ≤ RCLike.re (F (t, 0)) * RCLike.re (F (t, 0)) := by
+  simpa using isPositiveDefiniteKernel_normSq_le
+    (hF.timeSlice_isPositiveDefiniteKernel t) v 0
 
 /-- If the spatial type is equipped with the negation involution, then each fixed-time slice is a
 positive-definite function in the generic `IsPositiveDefinite` sense. -/

--- a/TauCeti/Analysis/PositiveDefinite/SemigroupGroupTimeSlice.lean
+++ b/TauCeti/Analysis/PositiveDefinite/SemigroupGroupTimeSlice.lean
@@ -1,0 +1,145 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+module
+
+public import TauCeti.Analysis.PositiveDefinite.SemigroupGroup
+public import TauCeti.Analysis.PositiveDefinite.KernelBounds
+public import Mathlib.Topology.Constructions
+
+/-!
+# Time slices of semigroup-group positive-definite functions
+
+A Berg--Christensen--Ressel positive-definite function on `ℝ≥0 × V` is positive definite in the
+spatial variable at every fixed time. Indeed, to test the kernel
+`(v, w) ↦ F (t, v - w)`, apply the BCR kernel to the family of points `(t / 2, v)`.
+
+This file records that fixed-time-slice API in kernel form, together with the finite
+quadratic-form restatement, conjugate symmetry, diagonal nonnegativity, the scalar
+Cauchy--Schwarz bound on each slice, and the elementary continuity statement for continuous
+`F`. These lemmas are prerequisites for the BCR representation milestone in the
+`OneParameterSemigroups` roadmap: later proofs can apply the spatial Bochner theorem to each
+time slice before handling the remaining Laplace/semigroup structure.
+
+This advances `TauCetiRoadmap/OneParameterSemigroups/README.md`, Part C, Milestone 2
+("BCR semigroup--Bochner"), specifically the reduction of a bounded continuous
+positive-definite function on `[0,∞) × V` to spatial positive-definite functions.
+
+## Main declarations
+
+* `TauCeti.IsSemigroupGroupPD.timeSlice_isPositiveDefiniteKernel`: the fixed-time spatial
+  kernel is positive definite.
+* `TauCeti.IsSemigroupGroupPD.timeSlice_sum_nonneg`: the finite quadratic-form version.
+* `TauCeti.IsSemigroupGroupPD.timeSlice_conj_symm`,
+  `TauCeti.IsSemigroupGroupPD.timeSlice_apply_zero_nonneg`, and
+  `TauCeti.IsSemigroupGroupPD.timeSlice_normSq_le`: basic consequences on a fixed time slice.
+* `TauCeti.IsSemigroupGroupPD.timeSlice_isPositiveDefinite`: the predicate form when the
+  spatial involution is negation.
+* `TauCeti.continuous_timeSlice`: continuity of a fixed-time slice of a continuous function.
+
+## References
+
+* C. Berg, J. P. R. Christensen, P. Ressel, *Harmonic Analysis on Semigroups* (GTM 100, 1984),
+  Chapter 4.
+-/
+
+public section
+
+open ComplexConjugate
+open scoped ComplexOrder
+open scoped NNReal
+
+namespace TauCeti
+
+variable {V : Type*} [AddCommGroup V] {F : ℝ≥0 × V → ℂ}
+
+namespace IsSemigroupGroupPD
+
+/-- At every fixed time `t`, a semigroup-group positive-definite function gives the spatial
+positive-definite kernel `(v, w) ↦ F (t, v - w)`. -/
+theorem timeSlice_isPositiveDefiniteKernel (hF : IsSemigroupGroupPD F) (t : ℝ≥0) :
+    IsPositiveDefiniteKernel fun v w : V => F (t, v - w) := by
+  have hK := isPositiveDefiniteKernel_comp hF.isPositiveDefiniteKernel
+    (fun v : V => (t / 2, v))
+  simpa [add_halves] using hK
+
+/-- The finite quadratic-form restatement of fixed-time spatial positive definiteness. -/
+theorem timeSlice_sum_nonneg (hF : IsSemigroupGroupPD F) (t : ℝ≥0)
+    {ι : Type*} [Fintype ι] (c : ι → ℂ) (v : ι → V) :
+    0 ≤ ∑ i, ∑ j, c i * conj (c j) * F (t, v i - v j) := by
+  have hK := hF.timeSlice_isPositiveDefiniteKernel t
+  have hpos := (isPositiveDefiniteKernel_iff.mp hK).2 v (fun i => conj (c i))
+  simpa only [Complex.conj_conj] using hpos
+
+/-- The `2 × 2` Hermitian sub-form of a fixed-time spatial slice. -/
+theorem timeSlice_quadForm_two_nonneg (hF : IsSemigroupGroupPD F) (t : ℝ≥0)
+    (v w : V) (c₀ c₁ : ℂ) :
+    0 ≤ c₀ * conj c₀ * F (t, v - v) + c₀ * conj c₁ * F (t, v - w)
+      + c₁ * conj c₀ * F (t, w - v) + c₁ * conj c₁ * F (t, w - w) := by
+  have h := hF.timeSlice_sum_nonneg t ![c₀, c₁] ![v, w]
+  simp only [Fin.sum_univ_two, Matrix.cons_val_zero, Matrix.cons_val_one] at h
+  exact le_of_le_of_eq h (by ring)
+
+/-- A fixed-time spatial slice is conjugate symmetric:
+`conj (F (t, v - w)) = F (t, w - v)`. -/
+@[simp]
+theorem timeSlice_conj_symm (hF : IsSemigroupGroupPD F) (t : ℝ≥0) (v w : V) :
+    conj (F (t, v - w)) = F (t, w - v) :=
+  isPositiveDefiniteKernel_conj_symm (hF.timeSlice_isPositiveDefiniteKernel t) v w
+
+/-- The value at the spatial origin of a fixed-time slice is nonnegative. -/
+theorem timeSlice_apply_zero_nonneg (hF : IsSemigroupGroupPD F) (t : ℝ≥0) :
+    0 ≤ F (t, 0) := by
+  simpa using isPositiveDefiniteKernel_apply_self_nonneg
+    (hF.timeSlice_isPositiveDefiniteKernel t) (0 : V)
+
+/-- The value at the spatial origin of a fixed-time slice has zero imaginary part. -/
+@[simp]
+theorem timeSlice_apply_zero_im (hF : IsSemigroupGroupPD F) (t : ℝ≥0) :
+    (F (t, 0)).im = 0 :=
+  ((Complex.nonneg_iff.mp (hF.timeSlice_apply_zero_nonneg t)).2).symm
+
+/-- The real part of the value at the spatial origin of a fixed-time slice is nonnegative. -/
+theorem timeSlice_apply_zero_re_nonneg (hF : IsSemigroupGroupPD F) (t : ℝ≥0) :
+    0 ≤ (F (t, 0)).re :=
+  (Complex.nonneg_iff.mp (hF.timeSlice_apply_zero_nonneg t)).1
+
+/-- On a fixed-time slice, the squared norm of an off-diagonal value is bounded by the square of
+the real diagonal value. -/
+theorem timeSlice_normSq_le (hF : IsSemigroupGroupPD F) (t : ℝ≥0) (v w : V) :
+    Complex.normSq (F (t, v - w)) ≤ (F (t, 0)).re * (F (t, 0)).re := by
+  simpa [sub_self] using
+    isPositiveDefiniteKernel_normSq_le (hF.timeSlice_isPositiveDefiniteKernel t) v w
+
+/-- If the spatial type is equipped with the negation involution, then each fixed-time slice is a
+positive-definite function in the generic `IsPositiveDefinite` sense. -/
+theorem timeSlice_isPositiveDefinite [StarAddMonoid V]
+    (hF : IsSemigroupGroupPD F) (hstar : ∀ v : V, star v = -v) (t : ℝ≥0) :
+    IsPositiveDefinite fun v : V => F (t, v) :=
+  (isPositiveDefinite_iff_isPositiveDefiniteKernel_sub hstar).mpr
+    (hF.timeSlice_isPositiveDefiniteKernel t)
+
+end IsSemigroupGroupPD
+
+section Topology
+
+variable {W : Type*} [TopologicalSpace W]
+
+/-- A fixed-time slice of a continuous function on `ℝ≥0 × V` is continuous. -/
+theorem continuous_timeSlice {F : ℝ≥0 × W → ℂ} (hF : Continuous F) (t : ℝ≥0) :
+    Continuous fun v : W => F (t, v) :=
+  hF.comp (continuous_const.prodMk continuous_id)
+
+variable [TopologicalSpace V] {F : ℝ≥0 × V → ℂ}
+
+/-- A continuous semigroup-group positive-definite function has continuous positive-definite
+spatial kernels on every fixed time slice. -/
+theorem IsSemigroupGroupPD.continuous_timeSlice_isPositiveDefiniteKernel
+    (hFpd : IsSemigroupGroupPD F) (hFcont : Continuous F) (t : ℝ≥0) :
+    IsPositiveDefiniteKernel (fun v w : V => F (t, v - w)) ∧ Continuous (fun v : V => F (t, v)) :=
+  ⟨hFpd.timeSlice_isPositiveDefiniteKernel t, continuous_timeSlice hFcont t⟩
+
+end Topology
+
+end TauCeti

--- a/TauCeti/Analysis/PositiveDefinite/SemigroupGroupTimeSlice.lean
+++ b/TauCeti/Analysis/PositiveDefinite/SemigroupGroupTimeSlice.lean
@@ -5,7 +5,6 @@ Released under Apache 2.0 license as described in the file LICENSE.
 module
 
 public import TauCeti.Analysis.PositiveDefinite.SemigroupGroup
-public import TauCeti.Analysis.PositiveDefinite.KernelBounds
 public import Mathlib.Topology.Constructions.SumProd
 
 /-!
@@ -15,8 +14,8 @@ A Berg--Christensen--Ressel positive-definite function on `ℝ≥0 × V` is posi
 spatial variable at every fixed time. Indeed, to test the kernel
 `(v, w) ↦ F (t, v - w)`, apply the BCR kernel to the family of points `(t / 2, v)`.
 
-This file records that fixed-time-slice API in kernel form, together with finite-form,
-symmetry, and bound facts and the predicate form for the fixed-time slice. These lemmas are
+This file records that fixed-time-slice API in kernel form, together with origin normal forms
+and the predicate form for the fixed-time slice. These lemmas are
 prerequisites for the BCR representation milestone in the `OneParameterSemigroups` roadmap:
 later proofs can apply the spatial Bochner theorem to each time slice before handling the
 remaining Laplace/semigroup structure.
@@ -29,10 +28,8 @@ positive-definite function on `[0,∞) × V` to spatial positive-definite functi
 
 * `TauCeti.IsSemigroupGroupPD.timeSlice_isPositiveDefiniteKernel`: the fixed-time spatial
   kernel is positive definite.
-* `TauCeti.IsSemigroupGroupPD.timeSlice_sum_nonneg`,
-  `TauCeti.IsSemigroupGroupPD.timeSlice_conj_symm`, and
-  `TauCeti.IsSemigroupGroupPD.timeSlice_normSq_le`: finite-form, symmetry, and bound facts for
-  the fixed-time spatial kernel.
+* `TauCeti.IsSemigroupGroupPD.timeSlice_apply_zero_nonneg` and related lemmas: origin
+  normal forms for the fixed-time spatial slice.
 * `TauCeti.IsSemigroupGroupPD.timeSlice_isPositiveDefinite`: the predicate form when the
   spatial involution is negation.
 * `TauCeti.IsSemigroupGroupPD.timeSlice_isPositiveDefiniteKernel_and_continuous`: packages
@@ -64,22 +61,27 @@ theorem timeSlice_isPositiveDefiniteKernel (hF : IsSemigroupGroupPD F) (t : ℝ�
     (fun v : V => (t / 2, v))
   simpa [add_halves] using hK
 
-/-- The finite quadratic form of the fixed-time spatial kernel is nonnegative. -/
-theorem timeSlice_sum_nonneg (hF : IsSemigroupGroupPD F) (t : ℝ≥0) {ι : Type*}
-    [Fintype ι] (v : ι → V) (x : ι → ℂ) :
-    0 ≤ ∑ i, ∑ j, conj (x i) * x j * F (t, v i - v j) :=
-  (isPositiveDefiniteKernel_iff.mp (hF.timeSlice_isPositiveDefiniteKernel t)).2 v x
+/-- The value at the spatial origin of a fixed-time slice is nonnegative. -/
+theorem timeSlice_apply_zero_nonneg (hF : IsSemigroupGroupPD F) (t : ℝ≥0) :
+    0 ≤ F (t, 0) := by
+  simpa [add_halves] using hF.diagonal_nonneg (t / 2)
 
-/-- The fixed-time spatial kernel is conjugate-symmetric. -/
+/-- The value at the spatial origin of a fixed-time slice has zero imaginary part. -/
 @[simp]
-theorem timeSlice_conj_symm (hF : IsSemigroupGroupPD F) (t : ℝ≥0) (v w : V) :
-    conj (F (t, v - w)) = F (t, w - v) :=
-  isPositiveDefiniteKernel_conj_symm (hF.timeSlice_isPositiveDefiniteKernel t) v w
+theorem timeSlice_apply_zero_im (hF : IsSemigroupGroupPD F) (t : ℝ≥0) :
+    (F (t, 0)).im = 0 := by
+  simpa [add_halves] using hF.diagonal_im (t / 2)
 
-/-- The Cauchy--Schwarz bound for the fixed-time spatial kernel. -/
-theorem timeSlice_normSq_le (hF : IsSemigroupGroupPD F) (t : ℝ≥0) (v w : V) :
-    Complex.normSq (F (t, v - w)) ≤ (F (t, 0)).re * (F (t, 0)).re := by
-  simpa using isPositiveDefiniteKernel_normSq_le (hF.timeSlice_isPositiveDefiniteKernel t) v w
+/-- The real part of the value at the spatial origin of a fixed-time slice is nonnegative. -/
+theorem timeSlice_apply_zero_re_nonneg (hF : IsSemigroupGroupPD F) (t : ℝ≥0) :
+    0 ≤ (F (t, 0)).re := by
+  simpa [add_halves] using hF.diagonal_re_nonneg (t / 2)
+
+/-- The value at the spatial origin of a fixed-time slice is equal to its real part, viewed as a
+complex number. -/
+theorem timeSlice_apply_zero_eq_ofReal_re (hF : IsSemigroupGroupPD F) (t : ℝ≥0) :
+    F (t, 0) = ((F (t, 0)).re : ℂ) := by
+  simpa [add_halves] using hF.diagonal_eq_ofReal_re (t / 2)
 
 /-- If the spatial type is equipped with the negation involution, then each fixed-time slice is a
 positive-definite function in the generic `IsPositiveDefinite` sense. -/


### PR DESCRIPTION
This PR adds fixed-time spatial slice API for Berg--Christensen--Ressel semigroup-group positive-definite functions: from `IsSemigroupGroupPD F`, each kernel `(v, w) ↦ F (t, v - w)` is positive definite, with finite quadratic-form, conjugate-symmetry, diagonal nonnegativity, Cauchy--Schwarz, negation-involution predicate, and continuity-of-slice wrappers for downstream Bochner use.

It advances `TauCetiRoadmap/OneParameterSemigroups/README.md`, Part C, Milestone 2, specifically the BCR semigroup--Bochner target for bounded continuous positive-definite functions on `[0,∞) × V`. I chose this as the lowest-hanging distinct prerequisite after checking open and recently merged PRs: the generic positive-definite predicates, the BCR object API, kernel Cauchy--Schwarz estimates, and an open finsupp Gram-form PR already exist, while the fixed-time spatial-kernel reduction needed before applying Bochner to BCR slices was still absent and does not overlap the claimed Bernstein/Bochner representation theorem work in #33/#475.

No Mathlib infrastructure is vendored. The implementation reuses Tau Ceti existing `IsSemigroupGroupPD.isPositiveDefiniteKernel`, `isPositiveDefiniteKernel_comp`, `isPositiveDefiniteKernel_iff`, `isPositiveDefiniteKernel_normSq_le`, and Mathlib `add_halves` and `Continuous.prodMk` product-continuity API. The BCR convention follows Berg--Christensen--Ressel, *Harmonic Analysis on Semigroups*, Chapter 4.

`lake exe cache get` completed with `No files to download` and `Already decompressed 8599 file(s)`. `lake build` completed with `Build completed successfully (4281 jobs).` `lake exe axioms` completed with `axioms: audited 5640 TauCeti declaration(s); all within the allowlist [propext, Classical.choice, Quot.sound].`

<!--tauceti-target:v1 {"focus":"OneParameterSemigroups","id":"semigroup-group-time-slice-kernels"}-->

🤖 Prepared with Codex
