### PR TITLE
feat: add positive definite weighted closure

### DIFF
--- a/TauCeti/Analysis/PositiveDefinite/FunctionClosure.lean
+++ b/TauCeti/Analysis/PositiveDefinite/FunctionClosure.lean
@@ -21,7 +21,6 @@ milestones. No external formalization is vendored.
 
 ## Main declarations
 
-* `TauCeti.IsPositiveDefinite.smul`: nonnegative complex scalar multiplication.
 * `TauCeti.IsPositiveDefinite.real_smul`: nonnegative real scalar multiplication.
 * `TauCeti.IsPositiveDefinite.sum_smul`: finite nonnegative weighted sums.
 * `TauCeti.IsPositiveDefinite.sum_real_smul`: finite nonnegative real-weighted sums.
@@ -45,16 +44,10 @@ namespace IsPositiveDefinite
 
 variable {M : Type*} [AddMonoid M] [StarAddMonoid M]
 
-/-- Positive-definite functions are closed under multiplication by a nonnegative complex scalar,
-stated with scalar notation. -/
-theorem smul {c : ℂ} {F : M → ℂ} (hc : 0 ≤ c) (hF : IsPositiveDefinite F) :
-    IsPositiveDefinite (fun x => c • F x) := by
-  simpa [Algebra.smul_def] using hF.const_mul hc
-
 /-- Positive-definite functions are closed under multiplication by a nonnegative real scalar. -/
 theorem real_smul {r : ℝ} {F : M → ℂ} (hr : 0 ≤ r) (hF : IsPositiveDefinite F) :
     IsPositiveDefinite (fun x => r • F x) := by
-  convert hF.smul (c := (r : ℂ)) (by exact_mod_cast hr) using 1
+  convert hF.const_mul (k := (r : ℂ)) (by exact_mod_cast hr) using 1
   ext x
   exact Algebra.smul_def r (F x)
 
@@ -64,7 +57,8 @@ nonnegative real value. -/
 theorem sum_smul {ι : Type*} {s : Finset ι} {w : ι → ℂ} {F : ι → M → ℂ}
     (hw : ∀ i ∈ s, 0 ≤ w i) (hF : ∀ i ∈ s, IsPositiveDefinite (F i)) :
     IsPositiveDefinite (fun x => ∑ i ∈ s, w i • F i x) :=
-  sum fun i hi => (hF i hi).smul (hw i hi)
+  sum fun i hi => by
+    simpa [Algebra.smul_def] using (hF i hi).const_mul (hw i hi)
 
 /-- Finite nonnegative complex-weighted sums, written using multiplication rather than scalar
 notation. -/
@@ -97,10 +91,11 @@ theorem pow {F : M → ℂ} (hF : IsPositiveDefinite F) (n : ℕ) :
 
 section Origin
 
-variable {N : Type*} [AddMonoid N]
+variable {N : Type*} [Zero N]
 
-/-- If each summand in a finite complex-weighted mixture is normalized at the origin, then the
-mixture's value at the origin is the sum of the weights. -/
+/-- If each summand in a finite complex-weighted sum is normalized at the origin, then the sum's
+value at the origin is the sum of the weights. -/
+@[simp]
 theorem sum_smul_apply_zero_of_apply_zero_eq_one {ι : Type*} {s : Finset ι}
     {w : ι → ℂ} {F : ι → N → ℂ} (hF0 : ∀ i ∈ s, F i 0 = 1) :
     (∑ i ∈ s, w i • F i 0) = ∑ i ∈ s, w i := by
@@ -108,16 +103,38 @@ theorem sum_smul_apply_zero_of_apply_zero_eq_one {ι : Type*} {s : Finset ι}
   rw [hF0 i hi]
   simp
 
-/-- A finite complex-weighted mixture of normalized positive-definite functions is normalized when
-the weights sum to `1`. -/
+/-- A finite complex-weighted sum of functions normalized at the origin is normalized when the
+weights sum to `1`. -/
+@[simp]
 theorem sum_smul_apply_zero_eq_one {ι : Type*} {s : Finset ι} {w : ι → ℂ}
     {F : ι → N → ℂ} (hF0 : ∀ i ∈ s, F i 0 = 1) (hw_sum : ∑ i ∈ s, w i = 1) :
     (fun x => ∑ i ∈ s, w i • F i x) 0 = 1 := by
   simpa using (sum_smul_apply_zero_of_apply_zero_eq_one (s := s) (w := w) (F := F) hF0).trans
     hw_sum
 
-/-- If each summand in a finite real-weighted mixture is normalized at the origin, then the
-mixture's value at the origin is the complex coercion of the sum of the real weights. -/
+/-- If each summand in a finite complex-weighted sum is normalized at the origin, then the
+sum's multiplication-form value at the origin is the sum of the weights. -/
+@[simp]
+theorem sum_const_mul_apply_zero_of_apply_zero_eq_one {ι : Type*} {s : Finset ι}
+    {w : ι → ℂ} {F : ι → N → ℂ} (hF0 : ∀ i ∈ s, F i 0 = 1) :
+    (∑ i ∈ s, w i * F i 0) = ∑ i ∈ s, w i := by
+  refine Finset.sum_congr rfl fun i hi => ?_
+  rw [hF0 i hi]
+  simp
+
+/-- A finite complex-weighted sum, in multiplication form, of functions normalized at the origin is
+normalized when the weights sum to `1`. -/
+@[simp]
+theorem sum_const_mul_apply_zero_eq_one {ι : Type*} {s : Finset ι} {w : ι → ℂ}
+    {F : ι → N → ℂ} (hF0 : ∀ i ∈ s, F i 0 = 1) (hw_sum : ∑ i ∈ s, w i = 1) :
+    (fun x => ∑ i ∈ s, w i * F i x) 0 = 1 := by
+  simpa using
+    (sum_const_mul_apply_zero_of_apply_zero_eq_one (s := s) (w := w) (F := F) hF0).trans
+      hw_sum
+
+/-- If each summand in a finite real-weighted sum is normalized at the origin, then the sum's value
+at the origin is the complex coercion of the sum of the real weights. -/
+@[simp]
 theorem sum_real_smul_apply_zero_of_apply_zero_eq_one {ι : Type*} {s : Finset ι}
     {w : ι → ℝ} {F : ι → N → ℂ} (hF0 : ∀ i ∈ s, F i 0 = 1) :
     (∑ i ∈ s, w i • F i 0) = ((∑ i ∈ s, w i : ℝ) : ℂ) := by
@@ -129,13 +146,37 @@ theorem sum_real_smul_apply_zero_of_apply_zero_eq_one {ι : Type*} {s : Finset �
     _ = ((∑ i ∈ s, w i : ℝ) : ℂ) := by
       simp
 
-/-- A finite real-weighted mixture of normalized positive-definite functions is normalized when
-the weights sum to `1`. -/
+/-- A finite real-weighted sum of functions normalized at the origin is normalized when the weights
+sum to `1`. -/
+@[simp]
 theorem sum_real_smul_apply_zero_eq_one {ι : Type*} {s : Finset ι} {w : ι → ℝ}
     {F : ι → N → ℂ} (hF0 : ∀ i ∈ s, F i 0 = 1) (hw_sum : ∑ i ∈ s, w i = 1) :
     (fun x => ∑ i ∈ s, w i • F i x) 0 = 1 := by
   simpa [hw_sum] using
     sum_real_smul_apply_zero_of_apply_zero_eq_one (s := s) (w := w) (F := F) hF0
+
+/-- If each summand in a finite real-weighted sum is normalized at the origin, then the sum's
+multiplication-form value at the origin is the complex coercion of the sum of the real weights. -/
+@[simp]
+theorem sum_real_const_mul_apply_zero_of_apply_zero_eq_one {ι : Type*} {s : Finset ι}
+    {w : ι → ℝ} {F : ι → N → ℂ} (hF0 : ∀ i ∈ s, F i 0 = 1) :
+    (∑ i ∈ s, (w i : ℂ) * F i 0) = ((∑ i ∈ s, w i : ℝ) : ℂ) := by
+  calc
+    (∑ i ∈ s, (w i : ℂ) * F i 0) = ∑ i ∈ s, (w i : ℂ) := by
+      refine Finset.sum_congr rfl fun i hi => ?_
+      rw [hF0 i hi]
+      simp
+    _ = ((∑ i ∈ s, w i : ℝ) : ℂ) := by
+      simp
+
+/-- A finite real-weighted sum, in multiplication form, of functions normalized at the origin is
+normalized when the weights sum to `1`. -/
+@[simp]
+theorem sum_real_const_mul_apply_zero_eq_one {ι : Type*} {s : Finset ι} {w : ι → ℝ}
+    {F : ι → N → ℂ} (hF0 : ∀ i ∈ s, F i 0 = 1) (hw_sum : ∑ i ∈ s, w i = 1) :
+    (fun x => ∑ i ∈ s, (w i : ℂ) * F i x) 0 = 1 := by
+  simpa [hw_sum] using
+    sum_real_const_mul_apply_zero_of_apply_zero_eq_one (s := s) (w := w) (F := F) hF0
 
 end Origin
 

--- a/TauCeti/Analysis/PositiveDefinite/FunctionClosure.lean
+++ b/TauCeti/Analysis/PositiveDefinite/FunctionClosure.lean
@@ -1,0 +1,144 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+module
+
+public import TauCeti.Analysis.PositiveDefinite.Basic
+
+/-!
+# Weighted closure for positive-definite functions
+
+This file adds the weighted finite-mixture and Schur-power API for
+`TauCeti.IsPositiveDefinite`, the positive-definite-function predicate on an involutive additive
+monoid. The basic file already proves binary sums, nonnegative complex scalar multiples, pointwise
+products, and unweighted finite sums/products. Here we package the forms used by examples and
+finite approximations: finite nonnegative weighted sums, real-weighted variants, and powers.
+
+This advances `TauCetiRoadmap/OneParameterSemigroups/README.md`, Part C, the positive-definite
+functions API asking for closure under sums and products before the Bochner and BCR representation
+milestones. No external formalization is vendored.
+
+## Main declarations
+
+* `TauCeti.IsPositiveDefinite.smul`: nonnegative complex scalar multiplication.
+* `TauCeti.IsPositiveDefinite.real_smul`: nonnegative real scalar multiplication.
+* `TauCeti.IsPositiveDefinite.sum_smul`: finite nonnegative weighted sums.
+* `TauCeti.IsPositiveDefinite.sum_real_smul`: finite nonnegative real-weighted sums.
+* `TauCeti.IsPositiveDefinite.pow`: Schur powers of a positive-definite function.
+* `TauCeti.IsPositiveDefinite.sum_smul_apply_zero_of_apply_zero_eq_one`: normalized finite
+  mixtures evaluate at the origin as the sum of their weights.
+
+## References
+
+* C. Berg, J. P. R. Christensen, P. Ressel, *Harmonic Analysis on Semigroups* (GTM 100, 1984),
+  Chapter 3.
+-/
+
+public section
+
+open scoped ComplexOrder
+
+namespace TauCeti
+
+namespace IsPositiveDefinite
+
+variable {M : Type*} [AddMonoid M] [StarAddMonoid M]
+
+/-- Positive-definite functions are closed under multiplication by a nonnegative complex scalar,
+stated with scalar notation. -/
+theorem smul {c : ℂ} {F : M → ℂ} (hc : 0 ≤ c) (hF : IsPositiveDefinite F) :
+    IsPositiveDefinite (fun x => c • F x) := by
+  simpa [Algebra.smul_def] using hF.const_mul hc
+
+/-- Positive-definite functions are closed under multiplication by a nonnegative real scalar. -/
+theorem real_smul {r : ℝ} {F : M → ℂ} (hr : 0 ≤ r) (hF : IsPositiveDefinite F) :
+    IsPositiveDefinite (fun x => r • F x) := by
+  convert hF.smul (c := (r : ℂ)) (by exact_mod_cast hr) using 1
+  ext x
+  exact Algebra.smul_def r (F x)
+
+/-- Finite nonnegative complex-weighted sums of positive-definite functions are positive
+definite. This is the finite-mixture form used when the weights are already complex scalars with
+nonnegative real value. -/
+theorem sum_smul {ι : Type*} {s : Finset ι} {w : ι → ℂ} {F : ι → M → ℂ}
+    (hw : ∀ i ∈ s, 0 ≤ w i) (hF : ∀ i ∈ s, IsPositiveDefinite (F i)) :
+    IsPositiveDefinite (fun x => ∑ i ∈ s, w i • F i x) :=
+  sum fun i hi => (hF i hi).smul (hw i hi)
+
+/-- Finite nonnegative complex-weighted sums, written using multiplication rather than scalar
+notation. -/
+theorem sum_const_mul {ι : Type*} {s : Finset ι} {w : ι → ℂ} {F : ι → M → ℂ}
+    (hw : ∀ i ∈ s, 0 ≤ w i) (hF : ∀ i ∈ s, IsPositiveDefinite (F i)) :
+    IsPositiveDefinite (fun x => ∑ i ∈ s, w i * F i x) := by
+  simpa [Algebra.smul_def] using sum_smul (M := M) (s := s) (w := w) (F := F) hw hF
+
+/-- Finite nonnegative real-weighted sums of positive-definite functions are positive definite. -/
+theorem sum_real_smul {ι : Type*} {s : Finset ι} {w : ι → ℝ} {F : ι → M → ℂ}
+    (hw : ∀ i ∈ s, 0 ≤ w i) (hF : ∀ i ∈ s, IsPositiveDefinite (F i)) :
+    IsPositiveDefinite (fun x => ∑ i ∈ s, w i • F i x) :=
+  sum fun i hi => (hF i hi).real_smul (hw i hi)
+
+/-- Finite nonnegative real-weighted sums, written with the real weight coerced to `ℂ` and
+multiplied in the codomain. -/
+theorem sum_real_const_mul {ι : Type*} {s : Finset ι} {w : ι → ℝ} {F : ι → M → ℂ}
+    (hw : ∀ i ∈ s, 0 ≤ w i) (hF : ∀ i ∈ s, IsPositiveDefinite (F i)) :
+    IsPositiveDefinite (fun x => ∑ i ∈ s, (w i : ℂ) * F i x) := by
+  simpa [Algebra.smul_def] using sum_real_smul (M := M) (s := s) (w := w) (F := F) hw hF
+
+/-- Schur powers of a positive-definite function are positive definite. -/
+theorem pow {F : M → ℂ} (hF : IsPositiveDefinite F) (n : ℕ) :
+    IsPositiveDefinite (fun x => F x ^ n) := by
+  induction n with
+  | zero =>
+      simpa using isPositiveDefinite_const (M := M) (k := (1 : ℂ)) zero_le_one
+  | succ n ih =>
+      simpa [pow_succ] using ih.mul hF
+
+section Origin
+
+variable {N : Type*} [AddMonoid N]
+
+/-- If each summand in a finite complex-weighted mixture is normalized at the origin, then the
+mixture's value at the origin is the sum of the weights. -/
+theorem sum_smul_apply_zero_of_apply_zero_eq_one {ι : Type*} {s : Finset ι}
+    {w : ι → ℂ} {F : ι → N → ℂ} (hF0 : ∀ i ∈ s, F i 0 = 1) :
+    (∑ i ∈ s, w i • F i 0) = ∑ i ∈ s, w i := by
+  refine Finset.sum_congr rfl fun i hi => ?_
+  rw [hF0 i hi]
+  simp
+
+/-- A finite complex-weighted mixture of normalized positive-definite functions is normalized when
+the weights sum to `1`. -/
+theorem sum_smul_apply_zero_eq_one {ι : Type*} {s : Finset ι} {w : ι → ℂ}
+    {F : ι → N → ℂ} (hF0 : ∀ i ∈ s, F i 0 = 1) (hw_sum : ∑ i ∈ s, w i = 1) :
+    (fun x => ∑ i ∈ s, w i • F i x) 0 = 1 := by
+  simpa using (sum_smul_apply_zero_of_apply_zero_eq_one (s := s) (w := w) (F := F) hF0).trans
+    hw_sum
+
+/-- If each summand in a finite real-weighted mixture is normalized at the origin, then the
+mixture's value at the origin is the complex coercion of the sum of the real weights. -/
+theorem sum_real_smul_apply_zero_of_apply_zero_eq_one {ι : Type*} {s : Finset ι}
+    {w : ι → ℝ} {F : ι → N → ℂ} (hF0 : ∀ i ∈ s, F i 0 = 1) :
+    (∑ i ∈ s, w i • F i 0) = ((∑ i ∈ s, w i : ℝ) : ℂ) := by
+  calc
+    (∑ i ∈ s, w i • F i 0) = ∑ i ∈ s, (w i : ℂ) := by
+      refine Finset.sum_congr rfl fun i hi => ?_
+      rw [hF0 i hi]
+      simp
+    _ = ((∑ i ∈ s, w i : ℝ) : ℂ) := by
+      simp
+
+/-- A finite real-weighted mixture of normalized positive-definite functions is normalized when
+the weights sum to `1`. -/
+theorem sum_real_smul_apply_zero_eq_one {ι : Type*} {s : Finset ι} {w : ι → ℝ}
+    {F : ι → N → ℂ} (hF0 : ∀ i ∈ s, F i 0 = 1) (hw_sum : ∑ i ∈ s, w i = 1) :
+    (fun x => ∑ i ∈ s, w i • F i x) 0 = 1 := by
+  simpa [hw_sum] using
+    sum_real_smul_apply_zero_of_apply_zero_eq_one (s := s) (w := w) (F := F) hF0
+
+end Origin
+
+end IsPositiveDefinite
+
+end TauCeti

--- a/TauCeti/Analysis/PositiveDefinite/FunctionClosure.lean
+++ b/TauCeti/Analysis/PositiveDefinite/FunctionClosure.lean
@@ -89,96 +89,158 @@ theorem pow {F : M → ℂ} (hF : IsPositiveDefinite F) (n : ℕ) :
   | succ n ih =>
       simpa [pow_succ] using ih.mul hF
 
+section Values
+
+variable {N : Type*}
+
+/-- If each summand in a finite complex-weighted sum is normalized at a point, then the sum's
+value at that point is the sum of the weights. -/
+@[simp]
+theorem sum_smul_apply_of_apply_eq_one {ι : Type*} {s : Finset ι} {w : ι → ℂ}
+    {F : ι → N → ℂ} {x : N} (hFx : ∀ i ∈ s, F i x = 1) :
+    (∑ i ∈ s, w i • F i x) = ∑ i ∈ s, w i := by
+  refine Finset.sum_congr rfl fun i hi => ?_
+  rw [hFx i hi]
+  simp
+
+/-- A finite complex-weighted sum of functions normalized at a point is normalized at that point
+when the weights sum to `1`. -/
+@[simp]
+theorem sum_smul_apply_eq_one {ι : Type*} {s : Finset ι} {w : ι → ℂ}
+    {F : ι → N → ℂ} {x : N} (hFx : ∀ i ∈ s, F i x = 1)
+    (hw_sum : ∑ i ∈ s, w i = 1) :
+    (fun y => ∑ i ∈ s, w i • F i y) x = 1 := by
+  simpa using (sum_smul_apply_of_apply_eq_one (s := s) (w := w) (F := F) hFx).trans
+    hw_sum
+
+/-- If each summand in a finite complex-weighted sum is normalized at a point, then the sum's
+multiplication-form value at that point is the sum of the weights. -/
+@[simp]
+theorem sum_const_mul_apply_of_apply_eq_one {ι : Type*} {s : Finset ι} {w : ι → ℂ}
+    {F : ι → N → ℂ} {x : N} (hFx : ∀ i ∈ s, F i x = 1) :
+    (∑ i ∈ s, w i * F i x) = ∑ i ∈ s, w i := by
+  simpa [Algebra.smul_def] using
+    sum_smul_apply_of_apply_eq_one (s := s) (w := w) (F := F) hFx
+
+/-- A finite complex-weighted sum, in multiplication form, of functions normalized at a point is
+normalized at that point when the weights sum to `1`. -/
+@[simp]
+theorem sum_const_mul_apply_eq_one {ι : Type*} {s : Finset ι} {w : ι → ℂ}
+    {F : ι → N → ℂ} {x : N} (hFx : ∀ i ∈ s, F i x = 1)
+    (hw_sum : ∑ i ∈ s, w i = 1) :
+    (fun y => ∑ i ∈ s, w i * F i y) x = 1 := by
+  simpa [Algebra.smul_def] using
+    sum_smul_apply_eq_one (s := s) (w := w) (F := F) hFx hw_sum
+
+/-- If each summand in a finite real-weighted sum is normalized at a point, then the sum's value at
+that point is the complex coercion of the sum of the real weights. -/
+@[simp]
+theorem sum_real_smul_apply_of_apply_eq_one {ι : Type*} {s : Finset ι} {w : ι → ℝ}
+    {F : ι → N → ℂ} {x : N} (hFx : ∀ i ∈ s, F i x = 1) :
+    (∑ i ∈ s, w i • F i x) = ((∑ i ∈ s, w i : ℝ) : ℂ) := by
+  simpa [Algebra.smul_def] using
+    sum_smul_apply_of_apply_eq_one (s := s) (w := fun i => (w i : ℂ)) (F := F) hFx
+
+/-- A finite real-weighted sum of functions normalized at a point is normalized at that point when
+the weights sum to `1`. -/
+@[simp]
+theorem sum_real_smul_apply_eq_one {ι : Type*} {s : Finset ι} {w : ι → ℝ}
+    {F : ι → N → ℂ} {x : N} (hFx : ∀ i ∈ s, F i x = 1)
+    (hw_sum : ∑ i ∈ s, w i = 1) :
+    (fun y => ∑ i ∈ s, w i • F i y) x = 1 := by
+  simpa [hw_sum] using
+    sum_real_smul_apply_of_apply_eq_one (s := s) (w := w) (F := F) hFx
+
+/-- If each summand in a finite real-weighted sum is normalized at a point, then the sum's
+multiplication-form value at that point is the complex coercion of the sum of the real weights. -/
+@[simp]
+theorem sum_real_const_mul_apply_of_apply_eq_one {ι : Type*} {s : Finset ι}
+    {w : ι → ℝ} {F : ι → N → ℂ} {x : N} (hFx : ∀ i ∈ s, F i x = 1) :
+    (∑ i ∈ s, (w i : ℂ) * F i x) = ((∑ i ∈ s, w i : ℝ) : ℂ) := by
+  simpa [Algebra.smul_def] using
+    sum_real_smul_apply_of_apply_eq_one (s := s) (w := w) (F := F) hFx
+
+/-- A finite real-weighted sum, in multiplication form, of functions normalized at a point is
+normalized at that point when the weights sum to `1`. -/
+@[simp]
+theorem sum_real_const_mul_apply_eq_one {ι : Type*} {s : Finset ι} {w : ι → ℝ}
+    {F : ι → N → ℂ} {x : N} (hFx : ∀ i ∈ s, F i x = 1)
+    (hw_sum : ∑ i ∈ s, w i = 1) :
+    (fun y => ∑ i ∈ s, (w i : ℂ) * F i y) x = 1 := by
+  simpa [hw_sum] using
+    sum_real_const_mul_apply_of_apply_eq_one (s := s) (w := w) (F := F) hFx
+
 section Origin
 
-variable {N : Type*} [Zero N]
+variable [Zero N]
 
 /-- If each summand in a finite complex-weighted sum is normalized at the origin, then the sum's
 value at the origin is the sum of the weights. -/
 @[simp]
 theorem sum_smul_apply_zero_of_apply_zero_eq_one {ι : Type*} {s : Finset ι}
     {w : ι → ℂ} {F : ι → N → ℂ} (hF0 : ∀ i ∈ s, F i 0 = 1) :
-    (∑ i ∈ s, w i • F i 0) = ∑ i ∈ s, w i := by
-  refine Finset.sum_congr rfl fun i hi => ?_
-  rw [hF0 i hi]
-  simp
+    (∑ i ∈ s, w i • F i 0) = ∑ i ∈ s, w i :=
+  sum_smul_apply_of_apply_eq_one (s := s) (w := w) (F := F) hF0
 
 /-- A finite complex-weighted sum of functions normalized at the origin is normalized when the
 weights sum to `1`. -/
 @[simp]
 theorem sum_smul_apply_zero_eq_one {ι : Type*} {s : Finset ι} {w : ι → ℂ}
     {F : ι → N → ℂ} (hF0 : ∀ i ∈ s, F i 0 = 1) (hw_sum : ∑ i ∈ s, w i = 1) :
-    (fun x => ∑ i ∈ s, w i • F i x) 0 = 1 := by
-  simpa using (sum_smul_apply_zero_of_apply_zero_eq_one (s := s) (w := w) (F := F) hF0).trans
-    hw_sum
+    (fun x => ∑ i ∈ s, w i • F i x) 0 = 1 :=
+  sum_smul_apply_eq_one (s := s) (w := w) (F := F) hF0 hw_sum
 
 /-- If each summand in a finite complex-weighted sum is normalized at the origin, then the
 sum's multiplication-form value at the origin is the sum of the weights. -/
 @[simp]
 theorem sum_const_mul_apply_zero_of_apply_zero_eq_one {ι : Type*} {s : Finset ι}
     {w : ι → ℂ} {F : ι → N → ℂ} (hF0 : ∀ i ∈ s, F i 0 = 1) :
-    (∑ i ∈ s, w i * F i 0) = ∑ i ∈ s, w i := by
-  refine Finset.sum_congr rfl fun i hi => ?_
-  rw [hF0 i hi]
-  simp
+    (∑ i ∈ s, w i * F i 0) = ∑ i ∈ s, w i :=
+  sum_const_mul_apply_of_apply_eq_one (s := s) (w := w) (F := F) hF0
 
 /-- A finite complex-weighted sum, in multiplication form, of functions normalized at the origin is
 normalized when the weights sum to `1`. -/
 @[simp]
 theorem sum_const_mul_apply_zero_eq_one {ι : Type*} {s : Finset ι} {w : ι → ℂ}
     {F : ι → N → ℂ} (hF0 : ∀ i ∈ s, F i 0 = 1) (hw_sum : ∑ i ∈ s, w i = 1) :
-    (fun x => ∑ i ∈ s, w i * F i x) 0 = 1 := by
-  simpa using
-    (sum_const_mul_apply_zero_of_apply_zero_eq_one (s := s) (w := w) (F := F) hF0).trans
-      hw_sum
+    (fun x => ∑ i ∈ s, w i * F i x) 0 = 1 :=
+  sum_const_mul_apply_eq_one (s := s) (w := w) (F := F) hF0 hw_sum
 
 /-- If each summand in a finite real-weighted sum is normalized at the origin, then the sum's value
 at the origin is the complex coercion of the sum of the real weights. -/
 @[simp]
 theorem sum_real_smul_apply_zero_of_apply_zero_eq_one {ι : Type*} {s : Finset ι}
     {w : ι → ℝ} {F : ι → N → ℂ} (hF0 : ∀ i ∈ s, F i 0 = 1) :
-    (∑ i ∈ s, w i • F i 0) = ((∑ i ∈ s, w i : ℝ) : ℂ) := by
-  calc
-    (∑ i ∈ s, w i • F i 0) = ∑ i ∈ s, (w i : ℂ) := by
-      refine Finset.sum_congr rfl fun i hi => ?_
-      rw [hF0 i hi]
-      simp
-    _ = ((∑ i ∈ s, w i : ℝ) : ℂ) := by
-      simp
+    (∑ i ∈ s, w i • F i 0) = ((∑ i ∈ s, w i : ℝ) : ℂ) :=
+  sum_real_smul_apply_of_apply_eq_one (s := s) (w := w) (F := F) hF0
 
 /-- A finite real-weighted sum of functions normalized at the origin is normalized when the weights
 sum to `1`. -/
 @[simp]
 theorem sum_real_smul_apply_zero_eq_one {ι : Type*} {s : Finset ι} {w : ι → ℝ}
     {F : ι → N → ℂ} (hF0 : ∀ i ∈ s, F i 0 = 1) (hw_sum : ∑ i ∈ s, w i = 1) :
-    (fun x => ∑ i ∈ s, w i • F i x) 0 = 1 := by
-  simpa [hw_sum] using
-    sum_real_smul_apply_zero_of_apply_zero_eq_one (s := s) (w := w) (F := F) hF0
+    (fun x => ∑ i ∈ s, w i • F i x) 0 = 1 :=
+  sum_real_smul_apply_eq_one (s := s) (w := w) (F := F) hF0 hw_sum
 
 /-- If each summand in a finite real-weighted sum is normalized at the origin, then the sum's
 multiplication-form value at the origin is the complex coercion of the sum of the real weights. -/
 @[simp]
 theorem sum_real_const_mul_apply_zero_of_apply_zero_eq_one {ι : Type*} {s : Finset ι}
     {w : ι → ℝ} {F : ι → N → ℂ} (hF0 : ∀ i ∈ s, F i 0 = 1) :
-    (∑ i ∈ s, (w i : ℂ) * F i 0) = ((∑ i ∈ s, w i : ℝ) : ℂ) := by
-  calc
-    (∑ i ∈ s, (w i : ℂ) * F i 0) = ∑ i ∈ s, (w i : ℂ) := by
-      refine Finset.sum_congr rfl fun i hi => ?_
-      rw [hF0 i hi]
-      simp
-    _ = ((∑ i ∈ s, w i : ℝ) : ℂ) := by
-      simp
+    (∑ i ∈ s, (w i : ℂ) * F i 0) = ((∑ i ∈ s, w i : ℝ) : ℂ) :=
+  sum_real_const_mul_apply_of_apply_eq_one (s := s) (w := w) (F := F) hF0
 
 /-- A finite real-weighted sum, in multiplication form, of functions normalized at the origin is
 normalized when the weights sum to `1`. -/
 @[simp]
 theorem sum_real_const_mul_apply_zero_eq_one {ι : Type*} {s : Finset ι} {w : ι → ℝ}
     {F : ι → N → ℂ} (hF0 : ∀ i ∈ s, F i 0 = 1) (hw_sum : ∑ i ∈ s, w i = 1) :
-    (fun x => ∑ i ∈ s, (w i : ℂ) * F i x) 0 = 1 := by
-  simpa [hw_sum] using
-    sum_real_const_mul_apply_zero_of_apply_zero_eq_one (s := s) (w := w) (F := F) hF0
+    (fun x => ∑ i ∈ s, (w i : ℂ) * F i x) 0 = 1 :=
+  sum_real_const_mul_apply_eq_one (s := s) (w := w) (F := F) hF0 hw_sum
 
 end Origin
+
+end Values
 
 end IsPositiveDefinite
 


### PR DESCRIPTION
This PR adds function-level weighted finite-mixture and Schur-power closure API for positive-definite functions: nonnegative complex and real scalar multiples, finite nonnegative weighted sums, pointwise powers, and origin-value lemmas for normalized finite mixtures.

It advances `TauCetiRoadmap/OneParameterSemigroups/README.md`, Part C, specifically the positive-definite-functions API item asking for closure under sums and products before the Bochner and BCR representation milestones. I chose this as the lowest-hanging distinct prerequisite after checking open and recently merged PRs: binary sums/products and unweighted finite sums/products for functions already exist, kernel weighted closure and powers already exist, and open PRs cover kernel finsupp forms and BCR time-slice kernels, while the function-level weighted finite-mixture and power API used by examples and finite approximations was still absent.

No Mathlib infrastructure is vendored. The implementation reuses Tau Ceti's existing `IsPositiveDefinite.const_mul`, `IsPositiveDefinite.sum`, `IsPositiveDefinite.mul`, and `isPositiveDefinite_const` APIs, with only routine `Finset` and scalar-normal-form reasoning.

`lake exe cache get` completed with `No files to download` and `Already decompressed 8599 file(s)`. `lake build` completed with `Build completed successfully (4282 jobs).` `lake exe axioms` completed with `axioms: audited 5645 TauCeti declaration(s); all within the allowlist [propext, Classical.choice, Quot.sound].`

<!--tauceti-target:v1 {"focus":"OneParameterSemigroups","id":"positive-definite-function-weighted-closure"}-->

🤖 Prepared with Codex
