### PR TITLE
feat: add zero comodule matrix coefficients

### DIFF
--- a/TauCeti/Algebra/Coalgebra/Comodule/MatrixCoefficientZero.lean
+++ b/TauCeti/Algebra/Coalgebra/Comodule/MatrixCoefficientZero.lean
@@ -111,15 +111,18 @@ section Submodule
 variable [CommSemiring R]
 variable [AddCommMonoid C] [Module R C] [Coalgebra R C]
 
+private theorem subsingleton_zero :
+    Subsingleton (zero R C : ComoduleCat.{u, v, w} R C) := by
+  rw [zero]
+  infer_instance
+
 /-- Matrix coefficients of the bundled zero comodule are zero. -/
 @[simp]
 theorem matrixCoefficient_zero
     (φ : (zero R C : ComoduleCat.{u, v, w} R C) →ₗ[R] R)
     (m : (zero R C : ComoduleCat.{u, v, w} R C)) :
     Comodule.matrixCoefficient (R := R) (C := C) φ m = 0 := by
-  haveI : Subsingleton (zero R C : ComoduleCat.{u, v, w} R C) := by
-    rw [zero]
-    infer_instance
+  haveI := subsingleton_zero (R := R) (C := C)
   exact Comodule.matrixCoefficient_eq_zero_of_subsingleton (R := R) (C := C) φ m
 
 /-- The coefficient set of the bundled zero comodule is `{0}`. -/
@@ -127,18 +130,18 @@ theorem matrixCoefficient_zero
 theorem matrixCoefficientSet_zero :
     Comodule.matrixCoefficientSet (R := R) (C := C)
         (M := (zero R C : ComoduleCat.{u, v, w} R C)) = ({0} : Set C) := by
-  rw [zero]
+  haveI := subsingleton_zero (R := R) (C := C)
   exact Comodule.matrixCoefficientSet_eq_singleton_zero_of_subsingleton (R := R) (C := C)
-    (M := PUnit.{w + 1})
+    (M := (zero R C : ComoduleCat.{u, v, w} R C))
 
 /-- The coefficient submodule of the bundled zero comodule is bottom. -/
 @[simp]
 theorem matrixCoefficientSubmodule_zero :
     Comodule.matrixCoefficientSubmodule (R := R) (C := C)
         (M := (zero R C : ComoduleCat.{u, v, w} R C)) = ⊥ := by
-  rw [zero]
+  haveI := subsingleton_zero (R := R) (C := C)
   exact Comodule.matrixCoefficientSubmodule_eq_bot_of_subsingleton (R := R) (C := C)
-    (M := PUnit.{w + 1})
+    (M := (zero R C : ComoduleCat.{u, v, w} R C))
 
 end Submodule
 
@@ -152,9 +155,9 @@ variable [Semiring C] [Algebra R C] [Coalgebra R C]
 theorem matrixCoefficientSubalgebra_zero :
     Comodule.matrixCoefficientSubalgebra (R := R) (C := C)
         (M := (zero R C : ComoduleCat.{u, v, w} R C)) = ⊥ := by
-  rw [zero]
+  haveI := subsingleton_zero (R := R) (C := C)
   exact Comodule.matrixCoefficientSubalgebra_eq_bot_of_subsingleton (R := R) (C := C)
-    (M := PUnit.{w + 1})
+    (M := (zero R C : ComoduleCat.{u, v, w} R C))
 
 end Algebra
 

--- a/TauCeti/Algebra/Coalgebra/Comodule/MatrixCoefficientZero.lean
+++ b/TauCeti/Algebra/Coalgebra/Comodule/MatrixCoefficientZero.lean
@@ -25,8 +25,8 @@ the additive API.
 * `TauCeti.Comodule.matrixCoefficient_eq_zero_of_subsingleton`.
 * `TauCeti.Comodule.matrixCoefficientSubmodule_eq_bot_of_subsingleton`.
 * `TauCeti.Comodule.matrixCoefficientSubalgebra_eq_bot_of_subsingleton`.
-* `TauCeti.Comodule.matrixCoefficientSubmodule_punit` and
-  `TauCeti.Comodule.matrixCoefficientSubalgebra_punit`.
+* `TauCeti.ComoduleCat.matrixCoefficient_zero` and
+  `TauCeti.ComoduleCat.matrixCoefficientSet_zero`.
 * `TauCeti.ComoduleCat.matrixCoefficientSubmodule_zero` and
   `TauCeti.ComoduleCat.matrixCoefficientSubalgebra_zero`.
 
@@ -98,49 +98,6 @@ theorem matrixCoefficientSubalgebra_eq_bot_of_subsingleton [Subsingleton M] :
 
 end Algebra
 
-section PUnit
-
-variable (R : Type u) (C : Type v)
-variable [CommSemiring R]
-variable [AddCommMonoid C] [Module R C] [Coalgebra R C]
-
-/-- Matrix coefficients of the concrete zero comodule `PUnit` are zero. -/
-@[simp]
-theorem matrixCoefficient_punit (φ : PUnit.{w + 1} →ₗ[R] R) (u : PUnit.{w + 1}) :
-    matrixCoefficient (R := R) (C := C) φ u = 0 :=
-  matrixCoefficient_eq_zero_of_subsingleton (R := R) (C := C) φ u
-
-/-- The coefficient set of the concrete zero comodule `PUnit` is `{0}`. -/
-@[simp]
-theorem matrixCoefficientSet_punit :
-    matrixCoefficientSet (R := R) (C := C) (M := PUnit.{w + 1}) = ({0} : Set C) :=
-  matrixCoefficientSet_eq_singleton_zero_of_subsingleton (R := R) (C := C)
-    (M := PUnit.{w + 1})
-
-/-- The coefficient submodule of the concrete zero comodule `PUnit` is bottom. -/
-@[simp]
-theorem matrixCoefficientSubmodule_punit :
-    matrixCoefficientSubmodule (R := R) (C := C) (M := PUnit.{w + 1}) = ⊥ :=
-  matrixCoefficientSubmodule_eq_bot_of_subsingleton (R := R) (C := C)
-    (M := PUnit.{w + 1})
-
-end PUnit
-
-section PUnitAlgebra
-
-variable (R : Type u) (C : Type v)
-variable [CommSemiring R]
-variable [Semiring C] [Algebra R C] [Coalgebra R C]
-
-/-- The coefficient subalgebra of the concrete zero comodule `PUnit` is bottom. -/
-@[simp]
-theorem matrixCoefficientSubalgebra_punit :
-    matrixCoefficientSubalgebra (R := R) (C := C) (M := PUnit.{w + 1}) = ⊥ :=
-  matrixCoefficientSubalgebra_eq_bot_of_subsingleton (R := R) (C := C)
-    (M := PUnit.{w + 1})
-
-end PUnitAlgebra
-
 end Comodule
 
 namespace ComoduleCat
@@ -154,13 +111,34 @@ section Submodule
 variable [CommSemiring R]
 variable [AddCommMonoid C] [Module R C] [Coalgebra R C]
 
+/-- Matrix coefficients of the bundled zero comodule are zero. -/
+@[simp]
+theorem matrixCoefficient_zero
+    (φ : (zero R C : ComoduleCat.{u, v, w} R C) →ₗ[R] R)
+    (m : (zero R C : ComoduleCat.{u, v, w} R C)) :
+    Comodule.matrixCoefficient (R := R) (C := C) φ m = 0 := by
+  rw [show m = 0 by
+    rw [zero] at m
+    exact Subsingleton.elim m 0]
+  simp
+
+/-- The coefficient set of the bundled zero comodule is `{0}`. -/
+@[simp]
+theorem matrixCoefficientSet_zero :
+    Comodule.matrixCoefficientSet (R := R) (C := C)
+        (M := (zero R C : ComoduleCat.{u, v, w} R C)) = ({0} : Set C) := by
+  rw [zero]
+  exact Comodule.matrixCoefficientSet_eq_singleton_zero_of_subsingleton (R := R) (C := C)
+    (M := PUnit.{w + 1})
+
 /-- The coefficient submodule of the bundled zero comodule is bottom. -/
 @[simp]
 theorem matrixCoefficientSubmodule_zero :
     Comodule.matrixCoefficientSubmodule (R := R) (C := C)
         (M := (zero R C : ComoduleCat.{u, v, w} R C)) = ⊥ := by
   rw [zero]
-  exact Comodule.matrixCoefficientSubmodule_punit (R := R) (C := C)
+  exact Comodule.matrixCoefficientSubmodule_eq_bot_of_subsingleton (R := R) (C := C)
+    (M := PUnit.{w + 1})
 
 end Submodule
 
@@ -175,7 +153,8 @@ theorem matrixCoefficientSubalgebra_zero :
     Comodule.matrixCoefficientSubalgebra (R := R) (C := C)
         (M := (zero R C : ComoduleCat.{u, v, w} R C)) = ⊥ := by
   rw [zero]
-  exact Comodule.matrixCoefficientSubalgebra_punit (R := R) (C := C)
+  exact Comodule.matrixCoefficientSubalgebra_eq_bot_of_subsingleton (R := R) (C := C)
+    (M := PUnit.{w + 1})
 
 end Algebra
 

--- a/TauCeti/Algebra/Coalgebra/Comodule/MatrixCoefficientZero.lean
+++ b/TauCeti/Algebra/Coalgebra/Comodule/MatrixCoefficientZero.lean
@@ -117,10 +117,10 @@ theorem matrixCoefficient_zero
     (φ : (zero R C : ComoduleCat.{u, v, w} R C) →ₗ[R] R)
     (m : (zero R C : ComoduleCat.{u, v, w} R C)) :
     Comodule.matrixCoefficient (R := R) (C := C) φ m = 0 := by
-  rw [show m = 0 by
-    rw [zero] at m
-    exact Subsingleton.elim m 0]
-  simp
+  haveI : Subsingleton (zero R C : ComoduleCat.{u, v, w} R C) := by
+    rw [zero]
+    infer_instance
+  exact Comodule.matrixCoefficient_eq_zero_of_subsingleton (R := R) (C := C) φ m
 
 /-- The coefficient set of the bundled zero comodule is `{0}`. -/
 @[simp]

--- a/TauCeti/Algebra/Coalgebra/Comodule/MatrixCoefficientZero.lean
+++ b/TauCeti/Algebra/Coalgebra/Comodule/MatrixCoefficientZero.lean
@@ -1,0 +1,184 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+module
+
+public import TauCeti.Algebra.Coalgebra.Comodule.MatrixCoefficientAdjoin
+public import TauCeti.Algebra.Coalgebra.Comodule.Zero
+
+/-!
+# Matrix coefficients of zero comodules
+
+This file packages the matrix-coefficient objects for zero comodules.  A comodule whose
+underlying module is subsingleton has only the zero vector, so every matrix coefficient is
+zero.  Consequently its coefficient set is `{0}`, its coefficient submodule is `⊥`, and, in
+an algebra, its coefficient subalgebra is the bottom `R`-subalgebra.
+
+These are small Layer 1 bookkeeping facts for the reductive-groups roadmap: matrix
+coefficients are the coalgebra-side functions attached to representations, and the
+finite-dimensional representation category needs their behavior on zero objects as part of
+the additive API.
+
+## Main declarations
+
+* `TauCeti.Comodule.matrixCoefficient_eq_zero_of_subsingleton`.
+* `TauCeti.Comodule.matrixCoefficientSubmodule_eq_bot_of_subsingleton`.
+* `TauCeti.Comodule.matrixCoefficientSubalgebra_eq_bot_of_subsingleton`.
+* `TauCeti.Comodule.matrixCoefficientSubmodule_punit` and
+  `TauCeti.Comodule.matrixCoefficientSubalgebra_punit`.
+* `TauCeti.ComoduleCat.matrixCoefficientSubmodule_zero` and
+  `TauCeti.ComoduleCat.matrixCoefficientSubalgebra_zero`.
+
+## References
+
+This is the standard zero-representation behavior of matrix coefficients.  It uses Tau
+Ceti's existing matrix-coefficient API and zero comodule, supplying a prerequisite for
+`ReductiveGroups/README.md` in TauCetiRoadmap, Layer 1, "Comodules over a coalgebra/Hopf
+algebra" and "The dictionary: representation of `G` ⇆ `A`-comodule; matrix coefficients."
+-/
+
+public section
+
+namespace TauCeti
+
+namespace Comodule
+
+universe u v w
+
+variable {R : Type u} {C : Type v} {M : Type w}
+
+section Submodule
+
+variable [CommSemiring R]
+variable [AddCommMonoid C] [Module R C] [Coalgebra R C]
+variable [AddCommMonoid M] [Module R M] [Comodule R C M]
+
+/-- In a subsingleton comodule, every matrix coefficient is zero. -/
+@[simp]
+theorem matrixCoefficient_eq_zero_of_subsingleton [Subsingleton M] (φ : M →ₗ[R] R) (m : M) :
+    matrixCoefficient (R := R) (C := C) φ m = 0 := by
+  rw [Subsingleton.elim m (0 : M)]
+  simp
+
+/-- The coefficient set of a subsingleton comodule is `{0}`. -/
+@[simp]
+theorem matrixCoefficientSet_eq_singleton_zero_of_subsingleton [Subsingleton M] :
+    matrixCoefficientSet (R := R) (C := C) (M := M) = ({0} : Set C) := by
+  ext c
+  rw [mem_matrixCoefficientSet_iff]
+  constructor
+  · rintro ⟨φ, m, rfl⟩
+    simp
+  · intro hc
+    rw [Set.mem_singleton_iff.mp hc]
+    exact ⟨0, 0, by simp⟩
+
+/-- The coefficient submodule of a subsingleton comodule is bottom. -/
+@[simp]
+theorem matrixCoefficientSubmodule_eq_bot_of_subsingleton [Subsingleton M] :
+    matrixCoefficientSubmodule (R := R) (C := C) (M := M) = ⊥ := by
+  rw [matrixCoefficientSubmodule_def, matrixCoefficientSet_eq_singleton_zero_of_subsingleton]
+  simp
+
+end Submodule
+
+section Algebra
+
+variable [CommSemiring R]
+variable [Semiring C] [Algebra R C] [Coalgebra R C]
+variable [AddCommMonoid M] [Module R M] [Comodule R C M]
+
+/-- The coefficient subalgebra of a subsingleton comodule is bottom. -/
+@[simp]
+theorem matrixCoefficientSubalgebra_eq_bot_of_subsingleton [Subsingleton M] :
+    matrixCoefficientSubalgebra (R := R) (C := C) (M := M) = ⊥ := by
+  rw [matrixCoefficientSubalgebra_def, matrixCoefficientSet_eq_singleton_zero_of_subsingleton]
+  simp
+
+end Algebra
+
+section PUnit
+
+variable (R : Type u) (C : Type v)
+variable [CommSemiring R]
+variable [AddCommMonoid C] [Module R C] [Coalgebra R C]
+
+/-- Matrix coefficients of the concrete zero comodule `PUnit` are zero. -/
+@[simp]
+theorem matrixCoefficient_punit (φ : PUnit.{w + 1} →ₗ[R] R) (u : PUnit.{w + 1}) :
+    matrixCoefficient (R := R) (C := C) φ u = 0 :=
+  matrixCoefficient_eq_zero_of_subsingleton (R := R) (C := C) φ u
+
+/-- The coefficient set of the concrete zero comodule `PUnit` is `{0}`. -/
+@[simp]
+theorem matrixCoefficientSet_punit :
+    matrixCoefficientSet (R := R) (C := C) (M := PUnit.{w + 1}) = ({0} : Set C) :=
+  matrixCoefficientSet_eq_singleton_zero_of_subsingleton (R := R) (C := C)
+    (M := PUnit.{w + 1})
+
+/-- The coefficient submodule of the concrete zero comodule `PUnit` is bottom. -/
+@[simp]
+theorem matrixCoefficientSubmodule_punit :
+    matrixCoefficientSubmodule (R := R) (C := C) (M := PUnit.{w + 1}) = ⊥ :=
+  matrixCoefficientSubmodule_eq_bot_of_subsingleton (R := R) (C := C)
+    (M := PUnit.{w + 1})
+
+end PUnit
+
+section PUnitAlgebra
+
+variable (R : Type u) (C : Type v)
+variable [CommSemiring R]
+variable [Semiring C] [Algebra R C] [Coalgebra R C]
+
+/-- The coefficient subalgebra of the concrete zero comodule `PUnit` is bottom. -/
+@[simp]
+theorem matrixCoefficientSubalgebra_punit :
+    matrixCoefficientSubalgebra (R := R) (C := C) (M := PUnit.{w + 1}) = ⊥ :=
+  matrixCoefficientSubalgebra_eq_bot_of_subsingleton (R := R) (C := C)
+    (M := PUnit.{w + 1})
+
+end PUnitAlgebra
+
+end Comodule
+
+namespace ComoduleCat
+
+universe u v w
+
+variable (R : Type u) (C : Type v)
+
+section Submodule
+
+variable [CommSemiring R]
+variable [AddCommMonoid C] [Module R C] [Coalgebra R C]
+
+/-- The coefficient submodule of the bundled zero comodule is bottom. -/
+@[simp]
+theorem matrixCoefficientSubmodule_zero :
+    Comodule.matrixCoefficientSubmodule (R := R) (C := C)
+        (M := (zero R C : ComoduleCat.{u, v, w} R C)) = ⊥ := by
+  rw [zero]
+  exact Comodule.matrixCoefficientSubmodule_punit (R := R) (C := C)
+
+end Submodule
+
+section Algebra
+
+variable [CommSemiring R]
+variable [Semiring C] [Algebra R C] [Coalgebra R C]
+
+/-- The coefficient subalgebra of the bundled zero comodule is bottom. -/
+@[simp]
+theorem matrixCoefficientSubalgebra_zero :
+    Comodule.matrixCoefficientSubalgebra (R := R) (C := C)
+        (M := (zero R C : ComoduleCat.{u, v, w} R C)) = ⊥ := by
+  rw [zero]
+  exact Comodule.matrixCoefficientSubalgebra_punit (R := R) (C := C)
+
+end Algebra
+
+end ComoduleCat
+
+end TauCeti

--- a/TauCeti/Algebra/Coalgebra/Comodule/MatrixCoefficientZero.lean
+++ b/TauCeti/Algebra/Coalgebra/Comodule/MatrixCoefficientZero.lean
@@ -111,18 +111,13 @@ section Submodule
 variable [CommSemiring R]
 variable [AddCommMonoid C] [Module R C] [Coalgebra R C]
 
-private theorem subsingleton_zero :
-    Subsingleton (zero R C : ComoduleCat.{u, v, w} R C) := by
-  rw [zero]
-  infer_instance
-
 /-- Matrix coefficients of the bundled zero comodule are zero. -/
 @[simp]
 theorem matrixCoefficient_zero
     (φ : (zero R C : ComoduleCat.{u, v, w} R C) →ₗ[R] R)
     (m : (zero R C : ComoduleCat.{u, v, w} R C)) :
     Comodule.matrixCoefficient (R := R) (C := C) φ m = 0 := by
-  haveI := subsingleton_zero (R := R) (C := C)
+  haveI := ComoduleCat.subsingleton_zero (R := R) (C := C)
   exact Comodule.matrixCoefficient_eq_zero_of_subsingleton (R := R) (C := C) φ m
 
 /-- The coefficient set of the bundled zero comodule is `{0}`. -/
@@ -130,7 +125,7 @@ theorem matrixCoefficient_zero
 theorem matrixCoefficientSet_zero :
     Comodule.matrixCoefficientSet (R := R) (C := C)
         (M := (zero R C : ComoduleCat.{u, v, w} R C)) = ({0} : Set C) := by
-  haveI := subsingleton_zero (R := R) (C := C)
+  haveI := ComoduleCat.subsingleton_zero (R := R) (C := C)
   exact Comodule.matrixCoefficientSet_eq_singleton_zero_of_subsingleton (R := R) (C := C)
     (M := (zero R C : ComoduleCat.{u, v, w} R C))
 
@@ -139,7 +134,7 @@ theorem matrixCoefficientSet_zero :
 theorem matrixCoefficientSubmodule_zero :
     Comodule.matrixCoefficientSubmodule (R := R) (C := C)
         (M := (zero R C : ComoduleCat.{u, v, w} R C)) = ⊥ := by
-  haveI := subsingleton_zero (R := R) (C := C)
+  haveI := ComoduleCat.subsingleton_zero (R := R) (C := C)
   exact Comodule.matrixCoefficientSubmodule_eq_bot_of_subsingleton (R := R) (C := C)
     (M := (zero R C : ComoduleCat.{u, v, w} R C))
 
@@ -155,7 +150,7 @@ variable [Semiring C] [Algebra R C] [Coalgebra R C]
 theorem matrixCoefficientSubalgebra_zero :
     Comodule.matrixCoefficientSubalgebra (R := R) (C := C)
         (M := (zero R C : ComoduleCat.{u, v, w} R C)) = ⊥ := by
-  haveI := subsingleton_zero (R := R) (C := C)
+  haveI := ComoduleCat.subsingleton_zero (R := R) (C := C)
   exact Comodule.matrixCoefficientSubalgebra_eq_bot_of_subsingleton (R := R) (C := C)
     (M := (zero R C : ComoduleCat.{u, v, w} R C))
 

--- a/TauCeti/Algebra/Coalgebra/Comodule/Zero.lean
+++ b/TauCeti/Algebra/Coalgebra/Comodule/Zero.lean
@@ -22,6 +22,7 @@ concrete carrier.
 ## Main declarations
 
 * `TauCeti.ComoduleCat.zero`: the bundled zero comodule.
+* `TauCeti.ComoduleCat.subsingleton_zero`: the bundled zero comodule has subsingleton carrier.
 * `TauCeti.ComoduleCat.isZero_zero`: `ComoduleCat.zero` is a zero object.
 * `HasZeroObject (ComoduleCat R C)`.
 
@@ -71,6 +72,11 @@ variable [AddCommMonoid C] [Module R C] [Coalgebra R C]
 @[expose] def zero : ComoduleCat.{u, v, w} R C :=
   of R C PUnit.{w + 1}
 
+/-- The named zero comodule has subsingleton carrier. -/
+theorem subsingleton_zero : Subsingleton (zero R C : ComoduleCat.{u, v, w} R C) := by
+  rw [zero]
+  infer_instance
+
 /-- A comodule whose underlying type is subsingleton is a zero object. -/
 theorem isZero_of_subsingleton (M : ComoduleCat.{u, v, w} R C) [Subsingleton M] : IsZero M where
   unique_to N :=
@@ -89,8 +95,8 @@ theorem isZero_of_subsingleton (M : ComoduleCat.{u, v, w} R C) [Subsingleton M] 
 
 /-- The named zero comodule is a zero object. -/
 theorem isZero_zero : IsZero (zero R C : ComoduleCat.{u, v, w} R C) := by
-  rw [zero]
-  exact isZero_of_subsingleton (R := R) (C := C) (of R C PUnit.{w + 1})
+  haveI := subsingleton_zero (R := R) (C := C)
+  exact isZero_of_subsingleton (R := R) (C := C) (zero R C)
 
 /-- Any morphism from the named zero comodule is zero. -/
 theorem zero_hom_eq_zero (M : ComoduleCat.{u, v, w} R C) (f : zero R C ⟶ M) : f = 0 :=


### PR DESCRIPTION
This PR records the zero-object behavior of matrix coefficients for comodules: every coefficient of a subsingleton comodule is zero, the coefficient set is `{0}`, the coefficient submodule is `⊥`, and the coefficient subalgebra is the bottom `R`-subalgebra. It also specializes these facts to the concrete `PUnit` zero comodule and the bundled `ComoduleCat.zero`.

It advances `TauCetiRoadmap/ReductiveGroups/README.md`, Layer 1, specifically "Comodules over a coalgebra/Hopf algebra" and "The dictionary: representation of `G` ⇆ `A`-comodule; matrix coefficients." I chose this as the lowest-hanging distinct ReductiveGroups prerequisite after checking open and recently merged PRs: the comodule, zero-object, matrix-coefficient, generated-submodule/subalgebra, product-comodule, and product-coefficient APIs already exist on `main`, while the zero-comodule coefficient package was still absent and is needed for additive finite-dimensional representation-category bookkeeping.

No Mathlib infrastructure is vendored. The implementation reuses Tau Ceti's existing `Comodule.matrixCoefficient`, `matrixCoefficientSet`, `matrixCoefficientSubmodule`, `matrixCoefficientSubalgebra`, and `ComoduleCat.zero` APIs, together with routine Mathlib `Subsingleton`, `Submodule.span`, and `Algebra.adjoin` simplification.

`lake exe cache get` completed with `No files to download` and `Already decompressed 8599 file(s)`. `lake build` completed with `Build completed successfully (4288 jobs).` `lake exe axioms` completed with `axioms: audited 5707 TauCeti declaration(s); all within the allowlist [propext, Classical.choice, Quot.sound].`

<!--tauceti-target:v1 {"focus":"ReductiveGroups","id":"zero-comodule-matrix-coefficients"}-->

🤖 Prepared with Codex
