### PR TITLE
chore: close PRs whose diff against main is empty

### DIFF
--- a/scripts/housekeeping.py
+++ b/scripts/housekeeping.py
@@ -5,6 +5,11 @@ Green PRs merge on their own (the merge queue, fed by auto-merge.yml). This cove
 jobs, in CI so the autonomous worker can stay focused on producing work, and so that EVERY PR ends up
 either merged or closed — never stranded:
 
+  empty    Close a roadmap PR (one carrying the `<!--tauceti-target:v1 ...-->` marker) whose diff
+           against main is empty — its changes already landed in main, typically because a sibling
+           worker attempt at the same target merged first. dedup only matches an OPEN twin, so once the
+           twin merges this is what reaps the loser, instead of leaving it for the 7-day stale timer.
+           Acts only on a PR quiet for EMPTY_QUIET_MINUTES, so an actively-pushing worker is never raced.
   budget   Close a PR that has been reviewed to the round cap (REVIEW_BUDGET) at its current head and
            is still blocking. CI is the single budget authority — the worker no longer caps itself — so
            a PR is reviewed and fixed until it merges or this closes it. The decision is read from the
@@ -25,7 +30,7 @@ PR author are frequently the same account (the worker reviews its own roadmap PR
 association, not by "not the author": an external author cannot forge a repo-associated comment.
 
 Env: GH_TOKEN (a token that can close PRs), REPO (owner/name), optional DRY_RUN=1, REVIEW_BUDGET,
-BUDGET_LABEL, STALE_DAYS.
+BUDGET_LABEL, STALE_DAYS, EMPTY_QUIET_MINUTES.
 """
 import datetime
 import json
@@ -45,6 +50,9 @@ REVIEW_BUDGET = int(os.environ.get("REVIEW_BUDGET", "10"))
 BUDGET_LABEL = os.environ.get("BUDGET_LABEL", "review-budget-spent")
 # How long a blocked PR may sit untouched (under budget) before the stale job retires it.
 STALE_DAYS = int(os.environ.get("STALE_DAYS", "7"))
+# How long an empty-diff roadmap PR must be QUIET before the empty job closes it — long enough that an
+# actively-pushing worker (which would bump updatedAt) is never raced into a wrong close.
+EMPTY_QUIET_MINUTES = int(os.environ.get("EMPTY_QUIET_MINUTES", "30"))
 
 TARGET_MARKER_RE = re.compile(r"<!--tauceti-target:v1 \{[^}]*\}-->")
 TARGET_ID_RE = re.compile(r'"id"\s*:\s*"([^"]+)"')
@@ -153,28 +161,35 @@ def main() -> int:
     failures = 0
     suffix = " [dry-run]" if DRY_RUN else ""
 
-    # empty: a PR whose diff against main is empty has nothing left to merge — all of its changes are
-    # already in main (typically a sibling worker attempt at the same roadmap target merged first). dedup
-    # only matches an OPEN twin, so once the twin merges nothing reaps the loser; this closes it directly
-    # instead of waiting out the 7-day stale timer (and stops the worker thrashing on a done target). The
-    # emptiness is re-confirmed from a fresh per-PR view right before closing — `changedFiles == 0` with
-    # mergeability already computed (not UNKNOWN), so a still-computing or just-pushed PR is never closed.
+    # empty: a PR whose diff against main is empty has nothing left to merge — its changes are already in
+    # main (typically a sibling worker attempt at the same roadmap target merged first). dedup only
+    # matches an OPEN twin, so once the twin merges nothing reaps the loser; this closes it directly
+    # instead of waiting out the 7-day stale timer (and stops the worker thrashing on a done target).
+    # Two guards keep a destructive close safe: it is scoped to autonomous roadmap PRs (those carrying the
+    # tauceti-target marker), so an intentionally empty human PR is left alone; and it acts only on a PR
+    # QUIET for EMPTY_QUIET_MINUTES, so an actively-pushing worker (which bumps updatedAt) is never raced.
+    # Emptiness, draft, keep, and quiet are ALL re-confirmed from a fresh per-PR view right before the
+    # close, with the diff computed (mergeable != UNKNOWN), so a just-pushed or still-computing PR is safe.
+    quiet_cutoff = datetime.datetime.now(datetime.timezone.utc) - datetime.timedelta(minutes=EMPTY_QUIET_MINUTES)
     open_empty = gh_json(["pr", "list", "--repo", REPO, "--state", "open", "--limit", "1000",
-                          "--json", "number,isDraft,labels"]) or []
-    cand = [p for p in open_empty if p.get("isDraft") is False and not has_keep_label(p)]
-    print(f"empty: scanning {len(cand)} open PR(s) for an empty diff{suffix}")
+                          "--json", "number,isDraft,labels,body,updatedAt"]) or []
+    cand = [p for p in open_empty if p.get("isDraft") is False and not has_keep_label(p)
+            and TARGET_MARKER_RE.search((p.get("body") or "").replace("\n", " "))
+            and parse_ts(p.get("updatedAt", "")) < quiet_cutoff]
+    print(f"empty: {len(cand)} quiet roadmap PR(s) to check for an empty diff{suffix}")
     for p in cand:
         n = p["number"]
         v = gh_json(["pr", "view", str(n), "--repo", REPO,
-                     "--json", "changedFiles,additions,deletions,mergeable,labels"]) or {}
-        if v.get("mergeable") == "UNKNOWN":
-            continue                           # GitHub has not finished computing the diff yet — wait
+                     "--json", "isDraft,changedFiles,additions,deletions,mergeable,labels,updatedAt"]) or {}
+        # Final eligibility read right before the close: skip on ANY change since the listing — a pushed
+        # commit or new activity (updatedAt back inside the quiet window), a new draft/keep state, a diff
+        # GitHub has not finished computing, or a now-non-empty diff.
+        if (v.get("isDraft") is not False or has_keep_label(v) or v.get("mergeable") == "UNKNOWN"
+                or parse_ts(v.get("updatedAt", "")) >= quiet_cutoff):
+            continue
         if v.get("changedFiles") != 0 or v.get("additions") != 0 or v.get("deletions") != 0:
             continue
-        if has_keep_label(v):
-            print(f"empty: #{n} has an empty diff but a keep label; leaving it")
-            continue
-        print(f"empty: #{n} (diff against {REPO.split('/')[-1]} main is empty — content already merged)")
+        print(f"empty: #{n} (empty diff, quiet >{EMPTY_QUIET_MINUTES}m — content already in main)")
         failures += not close(n, EMPTY_COMMENT)
 
     # budget: a PR reviewed to REVIEW_BUDGET rounds at its CURRENT head and still blocking is terminal —

--- a/scripts/housekeeping.py
+++ b/scripts/housekeeping.py
@@ -70,6 +70,11 @@ STALE_COMMENT = (
     "has sat untouched for over {days} days, so the queue housekeeping is retiring it to keep things "
     "moving. The branch is kept, so nothing is lost. It is completely fine to open a fresh PR once the "
     "findings are addressed. Add the `keep` label if you would rather it stay open.")
+EMPTY_COMMENT = (
+    "Closing automatically: this PR's diff against `main` is empty — all of its changes are already in "
+    "`main` (typically a sibling attempt at the same roadmap target merged first), so there is nothing "
+    "left to merge. The branch is kept, so nothing is lost. Add the `keep` label if you want it to stay "
+    "open.")
 
 
 def gh_json(args):
@@ -147,6 +152,30 @@ def close(pr: int, comment: str) -> bool:
 def main() -> int:
     failures = 0
     suffix = " [dry-run]" if DRY_RUN else ""
+
+    # empty: a PR whose diff against main is empty has nothing left to merge — all of its changes are
+    # already in main (typically a sibling worker attempt at the same roadmap target merged first). dedup
+    # only matches an OPEN twin, so once the twin merges nothing reaps the loser; this closes it directly
+    # instead of waiting out the 7-day stale timer (and stops the worker thrashing on a done target). The
+    # emptiness is re-confirmed from a fresh per-PR view right before closing — `changedFiles == 0` with
+    # mergeability already computed (not UNKNOWN), so a still-computing or just-pushed PR is never closed.
+    open_empty = gh_json(["pr", "list", "--repo", REPO, "--state", "open", "--limit", "1000",
+                          "--json", "number,isDraft,labels"]) or []
+    cand = [p for p in open_empty if p.get("isDraft") is False and not has_keep_label(p)]
+    print(f"empty: scanning {len(cand)} open PR(s) for an empty diff{suffix}")
+    for p in cand:
+        n = p["number"]
+        v = gh_json(["pr", "view", str(n), "--repo", REPO,
+                     "--json", "changedFiles,additions,deletions,mergeable,labels"]) or {}
+        if v.get("mergeable") == "UNKNOWN":
+            continue                           # GitHub has not finished computing the diff yet — wait
+        if v.get("changedFiles") != 0 or v.get("additions") != 0 or v.get("deletions") != 0:
+            continue
+        if has_keep_label(v):
+            print(f"empty: #{n} has an empty diff but a keep label; leaving it")
+            continue
+        print(f"empty: #{n} (diff against {REPO.split('/')[-1]} main is empty — content already merged)")
+        failures += not close(n, EMPTY_COMMENT)
 
     # budget: a PR reviewed to REVIEW_BUDGET rounds at its CURRENT head and still blocking is terminal —
     # close it. Read from the scoreboard ledger (full_rounds + states), so it holds even when the worker


### PR DESCRIPTION
This PR adds a housekeeping job that closes any open PR whose diff against `main` is empty. Such a PR has nothing left to merge — all of its changes are already in `main`, which happens when a sibling worker attempt at the same roadmap target merges first, leaving the loser with 14 commits but a net-zero diff (for example #455 right now: `ahead 14, behind 35`, yet `0` changed files). The existing `dedup` job only matches an *open* twin, so once the twin merges nothing reaps the loser; it lingers until the 7-day `stale` timer, and the worker may keep thrashing against an already-done target in the meantime.

The new `empty` job closes these directly. It re-confirms emptiness from a fresh per-PR view immediately before closing — `changedFiles == 0` (with `additions`/`deletions` zero) and mergeability already computed (not `UNKNOWN`) — so a PR whose diff GitHub is still computing, or one that just had a commit pushed, is never closed, and the `keep` label still opts a PR out. It lives under `scripts/`, so it is human-owned and needs human review and merge.

🤖 Prepared with Claude Code