### PR TITLE
chore: bump merge-sweep pin to include the enqueue-race fix

### DIFF
--- a/.github/workflows/merge-sweep.yml
+++ b/.github/workflows/merge-sweep.yml
@@ -32,7 +32,7 @@ jobs:
   sweep:
     # Pinned to a TauCetiReview commit; bump deliberately. The reusable workflow receives the App
     # secrets, so a floating @main would be a supply-chain risk.
-    uses: FormalFrontier/TauCetiReview/.github/workflows/merge-sweep.yml@d1bbbe5e3c3951f28877cd30508c3b3bbf834d61
+    uses: FormalFrontier/TauCetiReview/.github/workflows/merge-sweep.yml@4bb1d34e2b3314fc6630b45f2be9200091ae4911
     with:
       dry_run: ${{ inputs.dry-run || false }}
     secrets:


### PR DESCRIPTION
This PR moves the `merge-sweep` reusable-workflow pin forward to TauCetiReview `4bb1d34`, so the "already in the queue" benign-race fix (TauCetiReview #87) takes effect. The sweep loads `runner/sweep.py` from the pinned commit, so without this bump it would keep running the pre-fix code and the job would still flip red on a benign concurrent-enqueue race. It touches `.github/`, so it is human-owned and needs human review and merge.

🤖 Prepared with Claude Code