### PR TITLE
feat: add principal divisor kernel API

### DIFF
--- a/TauCeti/AlgebraicGeometry/WeilDivisor/Principal.lean
+++ b/TauCeti/AlgebraicGeometry/WeilDivisor/Principal.lean
@@ -121,6 +121,12 @@ lemma mem_principalSubgroup {D : WeilDivisor X} :
     D ∈ S.principalSubgroup ↔ ∃ g, S.principalDivisor g = D :=
   AddMonoidHom.mem_range
 
+/-- The subgroup of principal divisors is the range of the principal-divisor homomorphism. -/
+lemma principalSubgroup_eq_range : S.principalSubgroup = S.principalHom.range := by
+  ext D
+  rw [mem_principalSubgroup, AddMonoidHom.mem_range]
+  simp only [principalHom_apply]
+
 @[simp]
 lemma principalDivisor_mem_principalSubgroup (g : G) :
     S.principalDivisor g ∈ S.principalSubgroup :=

--- a/TauCeti/AlgebraicGeometry/WeilDivisor/PrincipalKernel.lean
+++ b/TauCeti/AlgebraicGeometry/WeilDivisor/PrincipalKernel.lean
@@ -20,7 +20,8 @@ the abstract group of principal divisors, canonically identified with
 `S.principalSubgroup`.
 
 In geometric applications, `G` is the additive form of the multiplicative group of a function
-field. This quotient is the formal shadow of rational functions modulo constants, embedded as
+field. After additional geometric input identifying the zero-principal-divisor functions with
+constants, this quotient specializes to rational functions modulo constants, embedded as
 principal divisors before taking the divisor class quotient.
 
 This advances `TauCetiRoadmap/JacobianChallenge/README.md`, Layer A, specifically the

--- a/TauCeti/AlgebraicGeometry/WeilDivisor/PrincipalKernel.lean
+++ b/TauCeti/AlgebraicGeometry/WeilDivisor/PrincipalKernel.lean
@@ -4,6 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 -/
 module
 
+public import Mathlib.GroupTheory.QuotientGroup.Basic
 public import TauCeti.AlgebraicGeometry.WeilDivisor.Principal
 
 /-!
@@ -15,7 +16,7 @@ sequence built in `TauCeti.AlgebraicGeometry.WeilDivisor.Principal`.
 For an order system `S : OrderSystem X G`, the homomorphism
 `S.principalHom : G →+ WeilDivisor X` sends a function to its principal divisor. Its kernel is
 the subgroup of functions with zero order at every point. Quotienting `G` by this kernel gives
-the abstract group of nonzero principal divisors, canonically identified with
+the abstract group of principal divisors, canonically identified with
 `S.principalSubgroup`.
 
 In geometric applications, `G` is the additive form of the multiplicative group of a function
@@ -42,6 +43,12 @@ namespace OrderSystem
 variable {X G : Type*} [AddCommGroup G] (S : OrderSystem X G)
 
 noncomputable section
+
+private lemma quotientKerEquivRange_mk {H : Type*} [AddCommGroup H] (φ : G →+ H) (g : G) :
+    QuotientAddGroup.quotientKerEquivRange φ (QuotientAddGroup.mk g) =
+      ⟨φ g, ⟨g, rfl⟩⟩ :=
+  Subtype.ext <| by
+    simp [QuotientAddGroup.quotientKerEquivRange, QuotientAddGroup.rangeKerLift]
 
 /-! ### The kernel of the principal-divisor map -/
 
@@ -102,15 +109,17 @@ to the subgroup of principal divisors. -/
 def principalFunctionClassEquivPrincipalSubgroup :
     S.PrincipalFunctionClass ≃+ S.principalSubgroup :=
   (QuotientAddGroup.quotientKerEquivRange S.principalHom).trans
-    (AddEquiv.addSubgroupCongr S.principalSubgroup_eq_range.symm)
+    (AddEquiv.addSubgroupCongr <| by
+      ext D
+      rw [mem_principalSubgroup, AddMonoidHom.mem_range]
+      simp only [principalHom_apply])
 
 @[simp]
 lemma principalFunctionClassEquivPrincipalSubgroup_mk (g : G) :
     S.principalFunctionClassEquivPrincipalSubgroup (QuotientAddGroup.mk g) =
       ⟨S.principalDivisor g, S.principalDivisor_mem_principalSubgroup g⟩ :=
   Subtype.ext <| by
-    simp [principalFunctionClassEquivPrincipalSubgroup, QuotientAddGroup.quotientKerEquivRange,
-      QuotientAddGroup.rangeKerLift]
+    simp [principalFunctionClassEquivPrincipalSubgroup, quotientKerEquivRange_mk]
 
 /-- The principal divisor associated to a function class, as a homomorphism into all Weil
 divisors. -/
@@ -121,6 +130,13 @@ def principalFunctionClassDivisor : S.PrincipalFunctionClass →+ WeilDivisor X 
 lemma principalFunctionClassDivisor_mk (g : G) :
     S.principalFunctionClassDivisor (QuotientAddGroup.mk g) = S.principalDivisor g :=
   QuotientAddGroup.kerLift_mk S.principalHom g
+
+@[simp]
+lemma coe_principalFunctionClassEquivPrincipalSubgroup (q : S.PrincipalFunctionClass) :
+    ((S.principalFunctionClassEquivPrincipalSubgroup q : S.principalSubgroup) : WeilDivisor X) =
+      S.principalFunctionClassDivisor q := by
+  induction q using QuotientAddGroup.induction_on with
+  | _ g => simp
 
 /-- The map from function classes to principal divisors is injective. -/
 lemma principalFunctionClassDivisor_injective :

--- a/TauCeti/AlgebraicGeometry/WeilDivisor/PrincipalKernel.lean
+++ b/TauCeti/AlgebraicGeometry/WeilDivisor/PrincipalKernel.lean
@@ -46,9 +46,11 @@ noncomputable section
 
 /-! ### The kernel of the principal-divisor map -/
 
-/-- The subgroup of functions whose principal divisor is zero. Geometrically, for a proper
-curve this is the subgroup of nonzero constants, expressed in the additive notation used for
-the function-field unit group. -/
+/-- The subgroup of functions whose principal divisor is zero.
+
+In geometric applications this is the subgroup quotiented out before passing from rational
+functions to principal divisors. Identifying it with constants requires additional geometric
+input, such as a global-units or constant-field theorem. -/
 abbrev principalKernel : AddSubgroup G :=
   S.principalHom.ker
 
@@ -92,9 +94,11 @@ lemma principalKernel_eq_bot_of_principalHom_injective
 
 /-! ### Principal divisors as a quotient of functions -/
 
-/-- The quotient of the function group by functions with zero principal divisor. Geometrically,
-for a proper curve this is the additive form of `K(X)ˣ / kˣ`, the group of nonzero rational
-functions modulo nonzero constants. -/
+/-- The quotient of the function group by functions with zero principal divisor.
+
+In geometric applications this is the group of rational functions modulo the subgroup with
+zero principal divisor. Under further hypotheses identifying that subgroup with the base-field
+constants, it specializes to the usual rational-functions-modulo-constants group. -/
 abbrev PrincipalFunctionClass : Type _ :=
   G ⧸ S.principalKernel
 
@@ -112,6 +116,25 @@ lemma principalFunctionClassDivisor_mk (g : G) :
 lemma principalFunctionClassDivisor_injective :
     Function.Injective S.principalFunctionClassDivisor :=
   QuotientAddGroup.kerLift_injective S.principalHom
+
+/-- Every divisor attached to a function class is principal. -/
+@[simp]
+lemma principalFunctionClassDivisor_mem_principalSubgroup (q : S.PrincipalFunctionClass) :
+    S.principalFunctionClassDivisor q ∈ S.principalSubgroup := by
+  induction q using QuotientAddGroup.induction_on with
+  | _ g => simp
+
+/-- The image of function classes in all Weil divisors is exactly the subgroup of principal
+divisors. -/
+lemma principalFunctionClassDivisor_range :
+    S.principalFunctionClassDivisor.range = S.principalSubgroup := by
+  ext D
+  constructor
+  · rintro ⟨q, rfl⟩
+    exact S.principalFunctionClassDivisor_mem_principalSubgroup q
+  · intro hD
+    rcases S.mem_principalSubgroup.mp hD with ⟨g, rfl⟩
+    exact ⟨QuotientAddGroup.mk g, by simp⟩
 
 /-- The quotient of functions by the zero-principal-divisor subgroup is canonically equivalent
 to the subgroup of principal divisors. -/

--- a/TauCeti/AlgebraicGeometry/WeilDivisor/PrincipalKernel.lean
+++ b/TauCeti/AlgebraicGeometry/WeilDivisor/PrincipalKernel.lean
@@ -44,12 +44,6 @@ variable {X G : Type*} [AddCommGroup G] (S : OrderSystem X G)
 
 noncomputable section
 
-private lemma quotientKerEquivRange_mk {H : Type*} [AddCommGroup H] (φ : G →+ H) (g : G) :
-    QuotientAddGroup.quotientKerEquivRange φ (QuotientAddGroup.mk g) =
-      ⟨φ g, ⟨g, rfl⟩⟩ :=
-  Subtype.ext <| by
-    simp [QuotientAddGroup.quotientKerEquivRange, QuotientAddGroup.rangeKerLift]
-
 /-! ### The kernel of the principal-divisor map -/
 
 /-- The subgroup of functions whose principal divisor is zero. Geometrically, for a proper
@@ -104,23 +98,6 @@ functions modulo nonzero constants. -/
 abbrev PrincipalFunctionClass : Type _ :=
   G ⧸ S.principalKernel
 
-/-- The quotient of functions by the zero-principal-divisor subgroup is canonically equivalent
-to the subgroup of principal divisors. -/
-def principalFunctionClassEquivPrincipalSubgroup :
-    S.PrincipalFunctionClass ≃+ S.principalSubgroup :=
-  (QuotientAddGroup.quotientKerEquivRange S.principalHom).trans
-    (AddEquiv.addSubgroupCongr <| by
-      ext D
-      rw [mem_principalSubgroup, AddMonoidHom.mem_range]
-      simp only [principalHom_apply])
-
-@[simp]
-lemma principalFunctionClassEquivPrincipalSubgroup_mk (g : G) :
-    S.principalFunctionClassEquivPrincipalSubgroup (QuotientAddGroup.mk g) =
-      ⟨S.principalDivisor g, S.principalDivisor_mem_principalSubgroup g⟩ :=
-  Subtype.ext <| by
-    simp [principalFunctionClassEquivPrincipalSubgroup, quotientKerEquivRange_mk]
-
 /-- The principal divisor associated to a function class, as a homomorphism into all Weil
 divisors. -/
 def principalFunctionClassDivisor : S.PrincipalFunctionClass →+ WeilDivisor X :=
@@ -131,17 +108,45 @@ lemma principalFunctionClassDivisor_mk (g : G) :
     S.principalFunctionClassDivisor (QuotientAddGroup.mk g) = S.principalDivisor g :=
   QuotientAddGroup.kerLift_mk S.principalHom g
 
+/-- The map from function classes to principal divisors is injective. -/
+lemma principalFunctionClassDivisor_injective :
+    Function.Injective S.principalFunctionClassDivisor :=
+  QuotientAddGroup.kerLift_injective S.principalHom
+
+private lemma principalFunctionClassDivisor_range_eq_principalSubgroup :
+    S.principalFunctionClassDivisor.range = S.principalSubgroup := by
+  ext D
+  rw [AddMonoidHom.mem_range, mem_principalSubgroup]
+  constructor
+  · rintro ⟨q, hq⟩
+    induction q using QuotientAddGroup.induction_on with
+    | _ g =>
+        exact ⟨g, hq⟩
+  · rintro ⟨g, hg⟩
+    exact ⟨QuotientAddGroup.mk g, by simp [hg]⟩
+
+/-- The quotient of functions by the zero-principal-divisor subgroup is canonically equivalent
+to the subgroup of principal divisors. -/
+def principalFunctionClassEquivPrincipalSubgroup :
+    S.PrincipalFunctionClass ≃+ S.principalSubgroup :=
+  (AddMonoidHom.ofInjective S.principalFunctionClassDivisor_injective).trans
+    (AddEquiv.addSubgroupCongr S.principalFunctionClassDivisor_range_eq_principalSubgroup)
+
+@[simp]
+lemma principalFunctionClassEquivPrincipalSubgroup_mk (g : G) :
+    S.principalFunctionClassEquivPrincipalSubgroup (QuotientAddGroup.mk g) =
+      ⟨S.principalDivisor g, S.principalDivisor_mem_principalSubgroup g⟩ :=
+  Subtype.ext <| by
+    simp only [principalFunctionClassEquivPrincipalSubgroup, AddEquiv.trans_apply,
+      AddEquiv.addSubgroupCongr_apply]
+    exact AddMonoidHom.ofInjective_apply S.principalFunctionClassDivisor_injective
+
 @[simp]
 lemma coe_principalFunctionClassEquivPrincipalSubgroup (q : S.PrincipalFunctionClass) :
     ((S.principalFunctionClassEquivPrincipalSubgroup q : S.principalSubgroup) : WeilDivisor X) =
       S.principalFunctionClassDivisor q := by
   induction q using QuotientAddGroup.induction_on with
   | _ g => simp
-
-/-- The map from function classes to principal divisors is injective. -/
-lemma principalFunctionClassDivisor_injective :
-    Function.Injective S.principalFunctionClassDivisor :=
-  QuotientAddGroup.kerLift_injective S.principalHom
 
 @[simp]
 lemma principalFunctionClassDivisor_eq_zero_iff {q : S.PrincipalFunctionClass} :

--- a/TauCeti/AlgebraicGeometry/WeilDivisor/PrincipalKernel.lean
+++ b/TauCeti/AlgebraicGeometry/WeilDivisor/PrincipalKernel.lean
@@ -113,24 +113,12 @@ lemma principalFunctionClassDivisor_injective :
     Function.Injective S.principalFunctionClassDivisor :=
   QuotientAddGroup.kerLift_injective S.principalHom
 
-private lemma principalFunctionClassDivisor_range_eq_principalSubgroup :
-    S.principalFunctionClassDivisor.range = S.principalSubgroup := by
-  ext D
-  rw [AddMonoidHom.mem_range, mem_principalSubgroup]
-  constructor
-  · rintro ⟨q, hq⟩
-    induction q using QuotientAddGroup.induction_on with
-    | _ g =>
-        exact ⟨g, by simpa using hq⟩
-  · rintro ⟨g, hg⟩
-    exact ⟨QuotientAddGroup.mk g, by simp [hg]⟩
-
 /-- The quotient of functions by the zero-principal-divisor subgroup is canonically equivalent
 to the subgroup of principal divisors. -/
 def principalFunctionClassEquivPrincipalSubgroup :
     S.PrincipalFunctionClass ≃+ S.principalSubgroup :=
-  (AddMonoidHom.ofInjective S.principalFunctionClassDivisor_injective).trans
-    (AddEquiv.addSubgroupCongr S.principalFunctionClassDivisor_range_eq_principalSubgroup)
+  (QuotientAddGroup.quotientKerEquivRange S.principalHom).trans
+    (AddEquiv.addSubgroupCongr S.principalSubgroup_eq_range.symm)
 
 @[simp]
 lemma principalFunctionClassEquivPrincipalSubgroup_mk (g : G) :
@@ -138,8 +126,8 @@ lemma principalFunctionClassEquivPrincipalSubgroup_mk (g : G) :
       ⟨S.principalDivisor g, S.principalDivisor_mem_principalSubgroup g⟩ :=
   Subtype.ext <| by
     simp only [principalFunctionClassEquivPrincipalSubgroup, AddEquiv.trans_apply,
-      AddEquiv.addSubgroupCongr_apply]
-    exact AddMonoidHom.ofInjective_apply S.principalFunctionClassDivisor_injective
+      AddEquiv.addSubgroupCongr_apply, QuotientAddGroup.quotientKerEquivRange]
+    rfl
 
 @[simp]
 lemma coe_principalFunctionClassEquivPrincipalSubgroup (q : S.PrincipalFunctionClass) :

--- a/TauCeti/AlgebraicGeometry/WeilDivisor/PrincipalKernel.lean
+++ b/TauCeti/AlgebraicGeometry/WeilDivisor/PrincipalKernel.lean
@@ -102,7 +102,7 @@ to the subgroup of principal divisors. -/
 def principalFunctionClassEquivPrincipalSubgroup :
     S.PrincipalFunctionClass ≃+ S.principalSubgroup :=
   (QuotientAddGroup.quotientKerEquivRange S.principalHom).trans
-    (AddEquiv.addSubgroupCongr (principalSubgroup_eq_range S).symm)
+    (AddEquiv.addSubgroupCongr S.principalSubgroup_eq_range.symm)
 
 @[simp]
 lemma principalFunctionClassEquivPrincipalSubgroup_mk (g : G) :
@@ -115,19 +115,17 @@ lemma principalFunctionClassEquivPrincipalSubgroup_mk (g : G) :
 /-- The principal divisor associated to a function class, as a homomorphism into all Weil
 divisors. -/
 def principalFunctionClassDivisor : S.PrincipalFunctionClass →+ WeilDivisor X :=
-  S.principalSubgroup.subtype.comp
-    S.principalFunctionClassEquivPrincipalSubgroup.toAddMonoidHom
+  QuotientAddGroup.kerLift S.principalHom
 
 @[simp]
 lemma principalFunctionClassDivisor_mk (g : G) :
     S.principalFunctionClassDivisor (QuotientAddGroup.mk g) = S.principalDivisor g :=
-  congr_arg Subtype.val (S.principalFunctionClassEquivPrincipalSubgroup_mk g)
+  QuotientAddGroup.kerLift_mk S.principalHom g
 
 /-- The map from function classes to principal divisors is injective. -/
 lemma principalFunctionClassDivisor_injective :
     Function.Injective S.principalFunctionClassDivisor :=
-  S.principalSubgroup.subtype_injective.comp
-    S.principalFunctionClassEquivPrincipalSubgroup.injective
+  QuotientAddGroup.kerLift_injective S.principalHom
 
 @[simp]
 lemma principalFunctionClassDivisor_eq_zero_iff {q : S.PrincipalFunctionClass} :

--- a/TauCeti/AlgebraicGeometry/WeilDivisor/PrincipalKernel.lean
+++ b/TauCeti/AlgebraicGeometry/WeilDivisor/PrincipalKernel.lean
@@ -1,0 +1,170 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+module
+
+public import TauCeti.AlgebraicGeometry.WeilDivisor.Principal
+
+/-!
+# The kernel of the principal-divisor map
+
+This file records the exactness at the rational-function side of the formal divisor-class
+sequence built in `TauCeti.AlgebraicGeometry.WeilDivisor.Principal`.
+
+For an order system `S : OrderSystem X G`, the homomorphism
+`S.principalHom : G →+ WeilDivisor X` sends a function to its principal divisor. Its kernel is
+the subgroup of functions with zero order at every point. Quotienting `G` by this kernel gives
+the abstract group of nonzero principal divisors, canonically identified with
+`S.principalSubgroup`.
+
+In geometric applications, `G` is the additive form of the multiplicative group of a function
+field. This quotient is the formal shadow of rational functions modulo constants, embedded as
+principal divisors before taking the divisor class quotient.
+
+This advances `TauCetiRoadmap/JacobianChallenge/README.md`, Layer A, specifically the
+"principal divisors" and "`Cl(X) ≅ Pic X`" prerequisite lane: the class group is the quotient by
+principal divisors, and this file packages the source-side quotient that maps onto that
+subgroup. It reuses Tau Ceti's `OrderSystem.principalHom` API and Mathlib's first isomorphism
+theorem for quotient groups; no external mathematics is vendored.
+-/
+
+public section
+
+namespace TauCeti
+
+namespace AlgebraicGeometry
+
+namespace WeilDivisor
+
+namespace OrderSystem
+
+variable {X G : Type*} [AddCommGroup G] (S : OrderSystem X G)
+
+noncomputable section
+
+/-! ### The kernel of the principal-divisor map -/
+
+/-- The subgroup of functions whose principal divisor is zero. Geometrically, for a proper
+curve this is the subgroup of nonzero constants, expressed in the additive notation used for
+the function-field unit group. -/
+abbrev principalKernel : AddSubgroup G :=
+  S.principalHom.ker
+
+@[simp]
+lemma mem_principalKernel {g : G} :
+    g ∈ S.principalKernel ↔ S.principalDivisor g = 0 :=
+  AddMonoidHom.mem_ker
+
+/-- A function has zero principal divisor exactly when all of its orders vanish. -/
+lemma mem_principalKernel_iff_forall_ord_eq_zero {g : G} :
+    g ∈ S.principalKernel ↔ ∀ x, S.ord x g = 0 := by
+  rw [mem_principalKernel]
+  constructor
+  · intro h x
+    rw [← S.coeff_principalDivisor g x, h]
+    simp
+  · intro h
+    ext x
+    rw [S.coeff_principalDivisor, h x]
+    simp
+
+@[simp]
+lemma zero_mem_principalKernel : (0 : G) ∈ S.principalKernel := by
+  rw [mem_principalKernel]
+  simp
+
+lemma principalKernel_eq_bot_iff :
+    S.principalKernel = ⊥ ↔ Function.Injective S.principalHom :=
+  AddMonoidHom.ker_eq_bot_iff S.principalHom
+
+/-- If the only function with zero principal divisor is zero, the principal-divisor map is
+injective. -/
+lemma principalHom_injective_of_principalKernel_eq_bot (h : S.principalKernel = ⊥) :
+    Function.Injective S.principalHom :=
+  S.principalKernel_eq_bot_iff.mp h
+
+/-- An injective principal-divisor map has trivial kernel. -/
+lemma principalKernel_eq_bot_of_principalHom_injective
+    (h : Function.Injective S.principalHom) : S.principalKernel = ⊥ :=
+  S.principalKernel_eq_bot_iff.mpr h
+
+/-! ### Principal divisors as a quotient of functions -/
+
+/-- The quotient of the function group by functions with zero principal divisor. Geometrically,
+for a proper curve this is the additive form of `K(X)ˣ / kˣ`, the group of nonzero rational
+functions modulo nonzero constants. -/
+abbrev PrincipalFunctionClass : Type _ :=
+  G ⧸ S.principalKernel
+
+/-- The quotient of functions by the zero-principal-divisor subgroup is canonically equivalent
+to the subgroup of principal divisors. -/
+def principalFunctionClassEquivPrincipalSubgroup :
+    S.PrincipalFunctionClass ≃+ S.principalSubgroup :=
+  (QuotientAddGroup.quotientKerEquivRange S.principalHom).trans
+    (AddEquiv.addSubgroupCongr (principalSubgroup_eq_range S).symm)
+
+@[simp]
+lemma principalFunctionClassEquivPrincipalSubgroup_mk (g : G) :
+    S.principalFunctionClassEquivPrincipalSubgroup (QuotientAddGroup.mk g) =
+      ⟨S.principalDivisor g, S.principalDivisor_mem_principalSubgroup g⟩ :=
+  Subtype.ext <| by
+    simp [principalFunctionClassEquivPrincipalSubgroup, QuotientAddGroup.quotientKerEquivRange,
+      QuotientAddGroup.rangeKerLift]
+
+/-- The principal divisor associated to a function class, as a homomorphism into all Weil
+divisors. -/
+def principalFunctionClassDivisor : S.PrincipalFunctionClass →+ WeilDivisor X :=
+  S.principalSubgroup.subtype.comp
+    S.principalFunctionClassEquivPrincipalSubgroup.toAddMonoidHom
+
+@[simp]
+lemma principalFunctionClassDivisor_mk (g : G) :
+    S.principalFunctionClassDivisor (QuotientAddGroup.mk g) = S.principalDivisor g :=
+  congr_arg Subtype.val (S.principalFunctionClassEquivPrincipalSubgroup_mk g)
+
+/-- The map from function classes to principal divisors is injective. -/
+lemma principalFunctionClassDivisor_injective :
+    Function.Injective S.principalFunctionClassDivisor :=
+  S.principalSubgroup.subtype_injective.comp
+    S.principalFunctionClassEquivPrincipalSubgroup.injective
+
+@[simp]
+lemma principalFunctionClassDivisor_eq_zero_iff {q : S.PrincipalFunctionClass} :
+    S.principalFunctionClassDivisor q = 0 ↔ q = 0 :=
+  S.principalFunctionClassDivisor_injective.eq_iff' (map_zero S.principalFunctionClassDivisor)
+
+/-- Equality of principal divisors is equality of the corresponding function classes. -/
+lemma principalDivisor_eq_iff_mk_eq_mk {g h : G} :
+    S.principalDivisor g = S.principalDivisor h ↔
+      QuotientAddGroup.mk g = (QuotientAddGroup.mk h : S.PrincipalFunctionClass) := by
+  constructor
+  · intro hgh
+    apply S.principalFunctionClassDivisor_injective
+    simpa using hgh
+  · intro hgh
+    simpa using congr_arg S.principalFunctionClassDivisor hgh
+
+/-- Two functions define the same class modulo the zero-principal-divisor subgroup exactly when
+their principal divisors are equal. -/
+lemma mk_eq_mk_iff_principalDivisor_eq {g h : G} :
+    QuotientAddGroup.mk g = (QuotientAddGroup.mk h : S.PrincipalFunctionClass) ↔
+      S.principalDivisor g = S.principalDivisor h :=
+  (S.principalDivisor_eq_iff_mk_eq_mk).symm
+
+/-- A function class is zero exactly when the representative has zero principal divisor. -/
+@[simp]
+lemma mk_eq_zero_iff_principalDivisor_eq_zero {g : G} :
+    (QuotientAddGroup.mk g : S.PrincipalFunctionClass) = 0 ↔ S.principalDivisor g = 0 := by
+  rw [← principalFunctionClassDivisor_eq_zero_iff]
+  simp
+
+end
+
+end OrderSystem
+
+end WeilDivisor
+
+end AlgebraicGeometry
+
+end TauCeti

--- a/TauCeti/AlgebraicGeometry/WeilDivisor/PrincipalKernel.lean
+++ b/TauCeti/AlgebraicGeometry/WeilDivisor/PrincipalKernel.lean
@@ -121,7 +121,7 @@ private lemma principalFunctionClassDivisor_range_eq_principalSubgroup :
   · rintro ⟨q, hq⟩
     induction q using QuotientAddGroup.induction_on with
     | _ g =>
-        exact ⟨g, hq⟩
+        exact ⟨g, by simpa using hq⟩
   · rintro ⟨g, hg⟩
     exact ⟨QuotientAddGroup.mk g, by simp [hg]⟩
 


### PR DESCRIPTION
This PR packages the kernel of the formal principal-divisor map for an abstract `OrderSystem`: functions whose principal divisor is zero, the pointwise order-vanishing criterion for membership, the quotient of the function group by that kernel, its canonical equivalence with the subgroup of principal divisors, and the induced injection into the full Weil-divisor group. It also adds the local range-characterization lemma `OrderSystem.principalSubgroup_eq_range` needed to use the existing opaque `principalSubgroup` definition without unfolding it across modules.

It advances `TauCetiRoadmap/JacobianChallenge/README.md`, Layer A, specifically "Divisors on a curve: Weil divisors `⊕_x ℤ` and Cartier divisors; ... principal divisors; `Cl(X) ≅ Pic X`" and the degree-zero divisor-class setup before the Picard functor exists. I chose this as the lowest-hanging distinct JacobianChallenge prerequisite after checking open and recently merged PRs: the formal Weil divisor group, principal divisors, class group, abstract `Pic⁰`, degree splitting, linear systems, and Abel-Jacobi divisor-class API already exist on `main`, while the source-side exactness of the principal-divisor map was still absent.

No Mathlib infrastructure is vendored. The implementation reuses Tau Ceti's existing `WeilDivisor.OrderSystem`, `principalHom`, and `principalSubgroup` APIs, together with Mathlib's `QuotientAddGroup.quotientKerEquivRange` first-isomorphism theorem.

`lake exe cache get` completed with `No files to download` and `Already decompressed 8599 file(s)`. `lake build` completed with `Build completed successfully (4292 jobs).` `lake exe axioms` completed with `axioms: audited 5774 TauCeti declaration(s); all within the allowlist [propext, Classical.choice, Quot.sound].`

<!--tauceti-target:v1 {"focus":"JacobianChallenge","id":"principal-divisor-kernel"}-->

🤖 Prepared with Codex
