### PR TITLE
feat: add finite product probability-kernel measurability

### DIFF
--- a/TauCeti/MeasureTheory/Measure/ProductKernel.lean
+++ b/TauCeti/MeasureTheory/Measure/ProductKernel.lean
@@ -1,7 +1,6 @@
 module
 
 public import Mathlib.MeasureTheory.Measure.FiniteMeasurePi
-import Mathlib.MeasureTheory.Measure.GiryMonad
 
 /-!
 # Measurability of finite product probability-measure kernels
@@ -27,7 +26,8 @@ This file does not introduce a new product-kernel structure; the lemmas live dir
 conditional independence, mixtures), and is motivated by the product-kernel layer of
 `cameronfreer/exchangeability` (`MeasureKernels.lean`, pin
 `e0532e59ceff23edab44dda9ab0655debbc9cc22`), implemented using Mathlib's `ProbabilityMeasure.pi` and
-Giry measurability API.
+Giry measurability API; the combinator generalizes Mathlib's binary
+`ProbabilityMeasure.measurable_fun_prod` to finite index types.
 -/
 
 public section
@@ -73,6 +73,7 @@ theorem measurable_probabilityMeasure_pi_toMeasure
 /-- A finite product of a.e.-measurable probability-measure kernels is an a.e.-measurable
 measure-valued map: if each `ν i : Ω → ProbabilityMeasure (α i)` is `AEMeasurable`, then so is
 `ω ↦ (ProbabilityMeasure.pi fun i => ν i ω).toMeasure`. -/
+@[fun_prop]
 theorem aemeasurable_probabilityMeasure_pi_toMeasure
     (ν : ∀ i, Ω → ProbabilityMeasure (α i)) (hν : ∀ i, AEMeasurable (ν i) μ) :
     AEMeasurable (fun ω => (ProbabilityMeasure.pi fun i => ν i ω).toMeasure) μ :=
@@ -95,6 +96,7 @@ theorem measurable_probabilityMeasure_pi_const_toMeasure {α : Type*} [Measurabl
 
 /-- Constant-coordinate specialization of `aemeasurable_probabilityMeasure_pi_toMeasure`: the random
 product `ω ↦ (ν ω)^{⊗ Fin m}` is `AEMeasurable` from an a.e.-measurable directing kernel. -/
+@[fun_prop]
 theorem aemeasurable_probabilityMeasure_pi_const_toMeasure {α : Type*} [MeasurableSpace α] {m : ℕ}
     (ν : Ω → ProbabilityMeasure α) (hν : AEMeasurable ν μ) :
     AEMeasurable (fun ω => (ProbabilityMeasure.pi fun _ : Fin m => ν ω).toMeasure) μ :=

--- a/TauCeti/MeasureTheory/Measure/ProductKernel.lean
+++ b/TauCeti/MeasureTheory/Measure/ProductKernel.lean
@@ -6,28 +6,28 @@ import Mathlib.MeasureTheory.Measure.GiryMonad
 /-!
 # Measurability of finite product probability-measure kernels
 
-A finite product of measurable probability-measure kernels is a measurable measure-valued map.
-Given `ν i : Ω → ProbabilityMeasure (α i)` measurable for each coordinate of a finite index type,
-`ω ↦ (ProbabilityMeasure.pi fun i => ν i ω).toMeasure` is measurable into `Measure (Π i, α i)`,
-together with its `AEMeasurable` corollary and the constant-coordinate specialization
-(`fun _ : Fin m => ν ω`) used by `ConditionallyIIDWith`.
+This file provides the measurability API for the finite product of probability measures over a
+finite index type, phrased directly over Mathlib's `ProbabilityMeasure.pi`:
 
-This file does not introduce a new product-kernel structure; it is a home for product-kernel
-measurability lemmas phrased directly over Mathlib's `ProbabilityMeasure.pi`. The proof is the
-finite-product analogue of Mathlib's binary `ProbabilityMeasure.measurable_fun_prod`: measurability
-of the measure-valued map is checked on the generating π-system of measurable rectangles
-(`generateFrom_pi`, `isPiSystem_pi`), where `ProbabilityMeasure.pi` evaluates to a finite product of
-coordinate measures (`Measure.pi_pi`).
+* `measurable_probabilityMeasure_pi` — the product combinator
+  `ProbabilityMeasure.pi : (Π i, ProbabilityMeasure (α i)) → ProbabilityMeasure (Π i, α i)`
+  is measurable.
+* `measurable_probabilityMeasure_pi_toMeasure` — the measure-valued random product
+  `ω ↦ (ProbabilityMeasure.pi fun i => ν i ω).toMeasure` is measurable, for measurable coordinate
+  kernels `ν i`.
+* `aemeasurable_probabilityMeasure_pi_toMeasure` — the same map is `AEMeasurable` from
+  a.e.-measurable coordinate kernels (`∀ i, AEMeasurable (ν i) μ`); the `_of_measurable` corollary
+  is the measurable-input form.
+* the constant-coordinate (`fun _ : Fin m => ν ω`) specializations
+  `measurable_probabilityMeasure_pi_const_toMeasure` and
+  `aemeasurable_probabilityMeasure_pi_const_toMeasure`, used by `ConditionallyIIDWith`.
 
-The `AEMeasurable` lemmas here are the corollaries from **measurable** coordinate kernels; the
-stronger statement from merely `∀ i, AEMeasurable (ν i) μ` is deferred to a later product-kernel
-strengthening — this file supplies the measurable-input form the current `ConditionallyIIDWith` API
-needs.
-
-This advances `TauCetiRoadmap/Exchangeability`, Layer 1 (product kernels, conditional independence,
-mixtures). It is motivated by the product-kernel layer of `cameronfreer/exchangeability`
-(`MeasureKernels.lean`, pin `e0532e59ceff23edab44dda9ab0655debbc9cc22`) and implemented using
-Mathlib's `ProbabilityMeasure.pi` and Giry measurability API.
+This file does not introduce a new product-kernel structure; the lemmas live directly over Mathlib's
+`ProbabilityMeasure.pi`. It advances `TauCetiRoadmap/Exchangeability`, Layer 1 (product kernels,
+conditional independence, mixtures), and is motivated by the product-kernel layer of
+`cameronfreer/exchangeability` (`MeasureKernels.lean`, pin
+`e0532e59ceff23edab44dda9ab0655debbc9cc22`), implemented using Mathlib's `ProbabilityMeasure.pi` and
+Giry measurability API.
 -/
 
 public section
@@ -40,47 +40,71 @@ namespace TauCeti
 
 namespace MeasureTheory
 
+variable {Ω ι : Type*} [MeasurableSpace Ω] [Fintype ι] {α : ι → Type*}
+  [∀ i, MeasurableSpace (α i)] {μ : Measure Ω}
+
+/-- The finite product combinator `ProbabilityMeasure.pi` is a measurable map
+`(Π i, ProbabilityMeasure (α i)) → ProbabilityMeasure (Π i, α i)`. -/
+@[fun_prop]
+theorem measurable_probabilityMeasure_pi :
+    Measurable (ProbabilityMeasure.pi : (∀ i, ProbabilityMeasure (α i)) → ProbabilityMeasure
+      (∀ i, α i)) := by
+  have hcore : Measurable fun p : ∀ i, ProbabilityMeasure (α i) =>
+      (ProbabilityMeasure.pi p).toMeasure := by
+    refine Measurable.measure_of_isPiSystem_of_isProbabilityMeasure
+      (S := Set.pi univ '' Set.pi univ fun i => {s : Set (α i) | MeasurableSet s})
+      generateFrom_pi.symm isPiSystem_pi ?_
+    rintro _ ⟨B, hB, rfl⟩
+    have hBmeas : ∀ i, MeasurableSet (B i) := fun i => hB i (mem_univ i)
+    simp_rw [ProbabilityMeasure.toMeasure_pi, Measure.pi_pi]
+    exact Finset.measurable_prod Finset.univ fun i _ =>
+      (Measure.measurable_coe (hBmeas i)).comp (measurable_subtype_coe.comp (measurable_pi_apply i))
+  exact hcore.subtype_mk
+
 /-- A finite product of measurable probability-measure kernels is a measurable measure-valued map:
 if each `ν i : Ω → ProbabilityMeasure (α i)` is measurable, then
 `ω ↦ (ProbabilityMeasure.pi fun i => ν i ω).toMeasure` is measurable. -/
 @[fun_prop]
-theorem measurable_probabilityMeasure_pi_toMeasure {Ω ι : Type*} [MeasurableSpace Ω] [Fintype ι]
-    {α : ι → Type*} [∀ i, MeasurableSpace (α i)]
+theorem measurable_probabilityMeasure_pi_toMeasure
     (ν : ∀ i, Ω → ProbabilityMeasure (α i)) (hν : ∀ i, Measurable (ν i)) :
-    Measurable fun ω => (ProbabilityMeasure.pi fun i => ν i ω).toMeasure := by
-  refine Measurable.measure_of_isPiSystem_of_isProbabilityMeasure
-    (S := Set.pi univ '' Set.pi univ fun i => {s : Set (α i) | MeasurableSet s})
-    generateFrom_pi.symm isPiSystem_pi ?_
-  rintro _ ⟨B, hB, rfl⟩
-  have hBmeas : ∀ i, MeasurableSet (B i) := fun i => hB i (mem_univ i)
-  simp_rw [ProbabilityMeasure.toMeasure_pi, Measure.pi_pi]
-  exact Finset.measurable_prod Finset.univ fun i _ =>
-    (Measure.measurable_coe (hBmeas i)).comp (measurable_subtype_coe.comp (hν i))
+    Measurable fun ω => (ProbabilityMeasure.pi fun i => ν i ω).toMeasure :=
+  (measurable_subtype_coe.comp measurable_probabilityMeasure_pi).comp (measurable_pi_lambda _ hν)
 
-/-- `AEMeasurable` form of `measurable_probabilityMeasure_pi_toMeasure` from **measurable**
-coordinate kernels (hence the `_of_measurable` suffix — this is not the stronger statement from
-merely `∀ i, AEMeasurable (ν i) μ`). This is the form `Measure.bind_apply` consumers need. -/
-theorem aemeasurable_probabilityMeasure_pi_toMeasure_of_measurable {Ω ι : Type*}
-    [MeasurableSpace Ω] [Fintype ι] {α : ι → Type*} [∀ i, MeasurableSpace (α i)] {μ : Measure Ω}
+/-- A finite product of a.e.-measurable probability-measure kernels is an a.e.-measurable
+measure-valued map: if each `ν i : Ω → ProbabilityMeasure (α i)` is `AEMeasurable`, then so is
+`ω ↦ (ProbabilityMeasure.pi fun i => ν i ω).toMeasure`. -/
+theorem aemeasurable_probabilityMeasure_pi_toMeasure
+    (ν : ∀ i, Ω → ProbabilityMeasure (α i)) (hν : ∀ i, AEMeasurable (ν i) μ) :
+    AEMeasurable (fun ω => (ProbabilityMeasure.pi fun i => ν i ω).toMeasure) μ :=
+  (measurable_subtype_coe.comp measurable_probabilityMeasure_pi).comp_aemeasurable
+    (aemeasurable_pi_lambda _ hν)
+
+/-- Measurable-input corollary of `aemeasurable_probabilityMeasure_pi_toMeasure`. -/
+theorem aemeasurable_probabilityMeasure_pi_toMeasure_of_measurable
     (ν : ∀ i, Ω → ProbabilityMeasure (α i)) (hν : ∀ i, Measurable (ν i)) :
     AEMeasurable (fun ω => (ProbabilityMeasure.pi fun i => ν i ω).toMeasure) μ :=
-  (measurable_probabilityMeasure_pi_toMeasure ν hν).aemeasurable
+  aemeasurable_probabilityMeasure_pi_toMeasure ν fun i => (hν i).aemeasurable
 
 /-- Constant-coordinate specialization of `measurable_probabilityMeasure_pi_toMeasure`: the random
 product `ω ↦ (ν ω)^{⊗ Fin m}` is measurable. This is the form `ConditionallyIIDWith` uses. -/
 @[fun_prop]
-theorem measurable_probabilityMeasure_pi_const_toMeasure {Ω α : Type*} [MeasurableSpace Ω]
-    [MeasurableSpace α] {m : ℕ} (ν : Ω → ProbabilityMeasure α) (hν : Measurable ν) :
+theorem measurable_probabilityMeasure_pi_const_toMeasure {α : Type*} [MeasurableSpace α] {m : ℕ}
+    (ν : Ω → ProbabilityMeasure α) (hν : Measurable ν) :
     Measurable fun ω => (ProbabilityMeasure.pi fun _ : Fin m => ν ω).toMeasure :=
   measurable_probabilityMeasure_pi_toMeasure (fun _ => ν) (fun _ => hν)
 
-/-- `AEMeasurable` form of `measurable_probabilityMeasure_pi_const_toMeasure` from a **measurable**
-directing kernel. -/
-theorem aemeasurable_probabilityMeasure_pi_const_toMeasure_of_measurable {Ω α : Type*}
-    [MeasurableSpace Ω] [MeasurableSpace α] {μ : Measure Ω} {m : ℕ}
-    (ν : Ω → ProbabilityMeasure α) (hν : Measurable ν) :
+/-- Constant-coordinate specialization of `aemeasurable_probabilityMeasure_pi_toMeasure`: the random
+product `ω ↦ (ν ω)^{⊗ Fin m}` is `AEMeasurable` from an a.e.-measurable directing kernel. -/
+theorem aemeasurable_probabilityMeasure_pi_const_toMeasure {α : Type*} [MeasurableSpace α] {m : ℕ}
+    (ν : Ω → ProbabilityMeasure α) (hν : AEMeasurable ν μ) :
     AEMeasurable (fun ω => (ProbabilityMeasure.pi fun _ : Fin m => ν ω).toMeasure) μ :=
-  (measurable_probabilityMeasure_pi_const_toMeasure ν hν).aemeasurable
+  aemeasurable_probabilityMeasure_pi_toMeasure (fun _ => ν) (fun _ => hν)
+
+/-- Measurable-input corollary of `aemeasurable_probabilityMeasure_pi_const_toMeasure`. -/
+theorem aemeasurable_probabilityMeasure_pi_const_toMeasure_of_measurable {α : Type*}
+    [MeasurableSpace α] {m : ℕ} (ν : Ω → ProbabilityMeasure α) (hν : Measurable ν) :
+    AEMeasurable (fun ω => (ProbabilityMeasure.pi fun _ : Fin m => ν ω).toMeasure) μ :=
+  aemeasurable_probabilityMeasure_pi_const_toMeasure ν hν.aemeasurable
 
 end MeasureTheory
 

--- a/TauCeti/MeasureTheory/Measure/ProductKernel.lean
+++ b/TauCeti/MeasureTheory/Measure/ProductKernel.lean
@@ -1,0 +1,87 @@
+module
+
+public import Mathlib.MeasureTheory.Measure.FiniteMeasurePi
+import Mathlib.MeasureTheory.Measure.GiryMonad
+
+/-!
+# Measurability of finite product probability-measure kernels
+
+A finite product of measurable probability-measure kernels is a measurable measure-valued map.
+Given `ν i : Ω → ProbabilityMeasure (α i)` measurable for each coordinate of a finite index type,
+`ω ↦ (ProbabilityMeasure.pi fun i => ν i ω).toMeasure` is measurable into `Measure (Π i, α i)`,
+together with its `AEMeasurable` corollary and the constant-coordinate specialization
+(`fun _ : Fin m => ν ω`) used by `ConditionallyIIDWith`.
+
+This file does not introduce a new product-kernel structure; it is a home for product-kernel
+measurability lemmas phrased directly over Mathlib's `ProbabilityMeasure.pi`. The proof is the
+finite-product analogue of Mathlib's binary `ProbabilityMeasure.measurable_fun_prod`: measurability
+of the measure-valued map is checked on the generating π-system of measurable rectangles
+(`generateFrom_pi`, `isPiSystem_pi`), where `ProbabilityMeasure.pi` evaluates to a finite product of
+coordinate measures (`Measure.pi_pi`).
+
+The `AEMeasurable` lemmas here are the corollaries from **measurable** coordinate kernels; the
+stronger statement from merely `∀ i, AEMeasurable (ν i) μ` is deferred to a later product-kernel
+strengthening — this file supplies the measurable-input form the current `ConditionallyIIDWith` API
+needs.
+
+This advances `TauCetiRoadmap/Exchangeability`, Layer 1 (product kernels, conditional independence,
+mixtures). It is motivated by the product-kernel layer of `cameronfreer/exchangeability`
+(`MeasureKernels.lean`, pin `e0532e59ceff23edab44dda9ab0655debbc9cc22`) and implemented using
+Mathlib's `ProbabilityMeasure.pi` and Giry measurability API.
+-/
+
+public section
+
+noncomputable section
+
+open MeasureTheory Set
+
+namespace TauCeti
+
+namespace MeasureTheory
+
+/-- A finite product of measurable probability-measure kernels is a measurable measure-valued map:
+if each `ν i : Ω → ProbabilityMeasure (α i)` is measurable, then
+`ω ↦ (ProbabilityMeasure.pi fun i => ν i ω).toMeasure` is measurable. -/
+@[fun_prop]
+theorem measurable_probabilityMeasure_pi_toMeasure {Ω ι : Type*} [MeasurableSpace Ω] [Fintype ι]
+    {α : ι → Type*} [∀ i, MeasurableSpace (α i)]
+    (ν : ∀ i, Ω → ProbabilityMeasure (α i)) (hν : ∀ i, Measurable (ν i)) :
+    Measurable fun ω => (ProbabilityMeasure.pi fun i => ν i ω).toMeasure := by
+  refine Measurable.measure_of_isPiSystem_of_isProbabilityMeasure
+    (S := Set.pi univ '' Set.pi univ fun i => {s : Set (α i) | MeasurableSet s})
+    generateFrom_pi.symm isPiSystem_pi ?_
+  rintro _ ⟨B, hB, rfl⟩
+  have hBmeas : ∀ i, MeasurableSet (B i) := fun i => hB i (mem_univ i)
+  simp_rw [ProbabilityMeasure.toMeasure_pi, Measure.pi_pi]
+  exact Finset.measurable_prod Finset.univ fun i _ =>
+    (Measure.measurable_coe (hBmeas i)).comp (measurable_subtype_coe.comp (hν i))
+
+/-- `AEMeasurable` form of `measurable_probabilityMeasure_pi_toMeasure` from **measurable**
+coordinate kernels (hence the `_of_measurable` suffix — this is not the stronger statement from
+merely `∀ i, AEMeasurable (ν i) μ`). This is the form `Measure.bind_apply` consumers need. -/
+theorem aemeasurable_probabilityMeasure_pi_toMeasure_of_measurable {Ω ι : Type*}
+    [MeasurableSpace Ω] [Fintype ι] {α : ι → Type*} [∀ i, MeasurableSpace (α i)] {μ : Measure Ω}
+    (ν : ∀ i, Ω → ProbabilityMeasure (α i)) (hν : ∀ i, Measurable (ν i)) :
+    AEMeasurable (fun ω => (ProbabilityMeasure.pi fun i => ν i ω).toMeasure) μ :=
+  (measurable_probabilityMeasure_pi_toMeasure ν hν).aemeasurable
+
+/-- Constant-coordinate specialization of `measurable_probabilityMeasure_pi_toMeasure`: the random
+product `ω ↦ (ν ω)^{⊗ Fin m}` is measurable. This is the form `ConditionallyIIDWith` uses. -/
+@[fun_prop]
+theorem measurable_probabilityMeasure_pi_const_toMeasure {Ω α : Type*} [MeasurableSpace Ω]
+    [MeasurableSpace α] {m : ℕ} (ν : Ω → ProbabilityMeasure α) (hν : Measurable ν) :
+    Measurable fun ω => (ProbabilityMeasure.pi fun _ : Fin m => ν ω).toMeasure :=
+  measurable_probabilityMeasure_pi_toMeasure (fun _ => ν) (fun _ => hν)
+
+/-- `AEMeasurable` form of `measurable_probabilityMeasure_pi_const_toMeasure` from a **measurable**
+directing kernel. -/
+theorem aemeasurable_probabilityMeasure_pi_const_toMeasure_of_measurable {Ω α : Type*}
+    [MeasurableSpace Ω] [MeasurableSpace α] {μ : Measure Ω} {m : ℕ}
+    (ν : Ω → ProbabilityMeasure α) (hν : Measurable ν) :
+    AEMeasurable (fun ω => (ProbabilityMeasure.pi fun _ : Fin m => ν ω).toMeasure) μ :=
+  (measurable_probabilityMeasure_pi_const_toMeasure ν hν).aemeasurable
+
+end MeasureTheory
+
+end TauCeti


### PR DESCRIPTION
<!--tauceti-target:v1 {"focus":"Exchangeability","id":"product-kernel-measurability"}-->

## Summary

Adds `TauCeti/MeasureTheory/Measure/ProductKernel.lean` — the first Layer 1 measure-theory adapter
for the Exchangeability roadmap: the measurability API for finite products of probability measures
over a finite index type, phrased directly over Mathlib's `ProbabilityMeasure.pi`.

- `measurable_probabilityMeasure_pi` — the product **combinator**
  `ProbabilityMeasure.pi : (Π i, ProbabilityMeasure (α i)) → ProbabilityMeasure (Π i, α i)` is
  measurable.
- `measurable_probabilityMeasure_pi_toMeasure` — the measure-valued random product
  `ω ↦ (ProbabilityMeasure.pi fun i => ν i ω).toMeasure` is measurable, for measurable coordinate
  kernels (derived from the combinator via the subtype coercion).
- `aemeasurable_probabilityMeasure_pi_toMeasure` — the same map is `AEMeasurable` from
  **a.e.-measurable** coordinate kernels (`∀ i, AEMeasurable (ν i) μ`), with
  `aemeasurable_probabilityMeasure_pi_toMeasure_of_measurable` as the measurable-input corollary.
- `measurable_probabilityMeasure_pi_const_toMeasure` /
  `aemeasurable_probabilityMeasure_pi_const_toMeasure` (+ `_of_measurable`) — the constant-coordinate
  (`fun _ : Fin m => ν ω`) specializations used by `ConditionallyIIDWith`.

## Roadmap

Advances `TauCetiRoadmap/Exchangeability`, **Layer 1** (product kernels, conditional independence,
mixtures). This is deliberately general measure-theory infrastructure — it does **not** add the
common ending or any de Finetti-specific theorem.

## How it's proved (reuse)

The combinator measurability is the **finite-product analogue of Mathlib's binary
`ProbabilityMeasure.measurable_fun_prod`**: measurability of the measure-valued map is checked on the
generating π-system of measurable rectangles via
`Measurable.measure_of_isPiSystem_of_isProbabilityMeasure` (`generateFrom_pi.symm`, `isPiSystem_pi`),
where `ProbabilityMeasure.pi` evaluates to `∏ i, (ν i ω) (B i)` on a rectangle
(`ProbabilityMeasure.toMeasure_pi` + `Measure.pi_pi`), measurable by `Finset.measurable_prod` from
per-coordinate `Measure.measurable_coe` ∘ `measurable_subtype_coe`. The family and AE forms then
follow by composing with `measurable_pi_lambda` / `aemeasurable_pi_lambda`. No re-proved measure
theory.

## Review notes
- This file does **not** introduce a new `ProductKernel` structure; the lemmas live directly over
  Mathlib's `ProbabilityMeasure.pi`.
- **generality:** stated for a general finite index type (`[Fintype ι]`, `α : ι → Type*`); the
  headline is the `ProbabilityMeasure`-valued combinator, the `.toMeasure` family form is derived
  from it, and the AE lemmas take a.e.-measurable coordinate kernels (`∀ i, AEMeasurable (ν i) μ`)
  with the measurable-input `_of_measurable` versions as corollaries. The constant-coordinate `Fin m`
  forms are one-line specializations.
- **placement:** general-purpose measure theory under `TauCeti/MeasureTheory/Measure/`, namespace
  `TauCeti.MeasureTheory` — not exchangeability-specific.
- **import visibility:** only `Mathlib.MeasureTheory.Measure.FiniteMeasurePi` is imported
  (`public` — `ProbabilityMeasure.pi` is in the exported signatures); the Giry π-system tool
  `measure_of_isPiSystem_of_isProbabilityMeasure` arrives transitively, so no separate import.

## Test plan
```bash
lake build
lake exe axioms
lake exe module-system
```
All pass; sorry-free; axioms ⊆ {`propext`, `Classical.choice`, `Quot.sound`}; lines ≤100.

## Attribution
Motivated by the product-kernel layer of `cameronfreer/exchangeability` (`MeasureKernels.lean`, pin
`e0532e59ceff23edab44dda9ab0655debbc9cc22`); implemented using Mathlib's `ProbabilityMeasure.pi` and
Giry measurability API, with Tau Ceti API names. Drafted with Claude (Opus 4.8), human-directed.
