### PR TITLE
feat: add finite point divisor sums

### DIFF
--- a/TauCeti/AlgebraicGeometry/WeilDivisor.lean
+++ b/TauCeti/AlgebraicGeometry/WeilDivisor.lean
@@ -306,6 +306,32 @@ lemma IsEffective.eq_zero_of_weightedDegree_eq_zero_of_pos {w : X → ℤ} (hw :
     {D : WeilDivisor X} (hD : IsEffective D) (hdeg : weightedDegree w D = 0) : D = 0 :=
   (hD.weightedDegree_eq_zero_iff_of_pos hw).mp hdeg
 
+/-- With strictly positive weights on the support, an effective divisor has weighted degree
+zero iff it is zero. -/
+lemma IsEffective.weightedDegree_eq_zero_iff_of_pos_on_support {w : X → ℤ}
+    {D : WeilDivisor X} (hD : IsEffective D) (hw : ∀ x ∈ D.support, 0 < w x) :
+    weightedDegree w D = 0 ↔ D = 0 := by
+  constructor
+  · intro hdeg
+    by_contra hD0
+    obtain ⟨x, hxpos⟩ := hD.exists_pos_coeff_of_ne_zero hD0
+    have hxs : x ∈ D.support := Finsupp.mem_support_iff.mpr (ne_of_gt hxpos)
+    have hsum_pos : 0 < D.sum fun y n => n * w y := by
+      exact Finsupp.sum_pos'
+        (fun y hy => mul_nonneg ((isEffective_iff D).mp hD y) (le_of_lt (hw y hy)))
+        ⟨x, hxs, mul_pos hxpos (hw x hxs)⟩
+    rw [← weightedDegree_apply] at hsum_pos
+    exact (ne_of_gt hsum_pos) hdeg
+  · intro h
+    simp [h]
+
+/-- With strictly positive weights on the support, an effective divisor of weighted degree zero
+is zero. -/
+lemma IsEffective.eq_zero_of_weightedDegree_eq_zero_of_pos_on_support {w : X → ℤ}
+    {D : WeilDivisor X} (hD : IsEffective D) (hw : ∀ x ∈ D.support, 0 < w x)
+    (hdeg : weightedDegree w D = 0) : D = 0 :=
+  (hD.weightedDegree_eq_zero_iff_of_pos_on_support hw).mp hdeg
+
 /-- With strictly positive weights, a nonzero effective divisor has positive weighted degree. -/
 lemma IsEffective.weightedDegree_pos_of_pos {w : X → ℤ} (hw : ∀ x, 0 < w x)
     {D : WeilDivisor X} (hD : IsEffective D) (hD0 : D ≠ 0) :

--- a/TauCeti/AlgebraicGeometry/WeilDivisor/FiniteSum.lean
+++ b/TauCeti/AlgebraicGeometry/WeilDivisor/FiniteSum.lean
@@ -265,10 +265,10 @@ private lemma pushforward_indicator_nat (f : X → Y) (s : Finset X) (m : X → 
   refine Finset.sum_congr rfl fun x hx => ?_
   rw [map_zsmul, pushforward_ofPoint]
 
-/-- With positive weights on the selected set, an indicator divisor with multiplicities has
-weighted degree zero exactly when every selected multiplicity vanishes. -/
+/-- With positive weights at the selected points with nonzero multiplicity, an indicator divisor
+with multiplicities has weighted degree zero exactly when every selected multiplicity vanishes. -/
 private lemma weightedDegree_indicator_nat_eq_zero_iff_of_pos
-    (s : Finset X) {w : X → ℤ} (hw : ∀ x ∈ s, 0 < w x) (m : X → ℕ) :
+    (s : Finset X) {w : X → ℤ} (m : X → ℕ) (hw : ∀ x ∈ s, m x ≠ 0 → 0 < w x) :
     weightedDegree w (Finsupp.indicator s (fun x _ => (m x : ℤ)) : WeilDivisor X) = 0 ↔
       ∀ x ∈ s, m x = 0 := by
   classical
@@ -277,21 +277,24 @@ private lemma weightedDegree_indicator_nat_eq_zero_iff_of_pos
     have hzero :
         (Finsupp.indicator s (fun x _ => (m x : ℤ)) : WeilDivisor X) = 0 :=
       (isEffective_indicator_nat s m).eq_zero_of_weightedDegree_eq_zero_of_pos_on_support
-        (fun y hy => hw y (support_indicator_nat_subset s m hy)) hdeg
+        (fun y hy => by
+          obtain ⟨hys, hmy⟩ := mem_support_indicator_nat_iff.mp hy
+          exact hw y hys hmy)
+        hdeg
     have hcoeff := congrArg (fun D : WeilDivisor X => coeff D x) hzero
     simpa [coeff_indicator_nat, hx] using hcoeff
   · intro hm
     rw [weightedDegree_indicator_nat]
     exact Finset.sum_eq_zero fun x hx => by simp [hm x hx]
 
-/-- An indicator divisor with positive weights on the selected set lies in the weighted
-degree-zero subgroup exactly when all selected multiplicities vanish. -/
+/-- An indicator divisor with positive weights at selected points with nonzero multiplicity lies
+in the weighted degree-zero subgroup exactly when all selected multiplicities vanish. -/
 private lemma indicator_nat_mem_weightedDegreeZeroSubgroup_iff_of_pos
-    (s : Finset X) {w : X → ℤ} (hw : ∀ x ∈ s, 0 < w x) (m : X → ℕ) :
+    (s : Finset X) {w : X → ℤ} (m : X → ℕ) (hw : ∀ x ∈ s, m x ≠ 0 → 0 < w x) :
     (Finsupp.indicator s (fun x _ => (m x : ℤ)) : WeilDivisor X) ∈
         weightedDegreeZeroSubgroup w ↔
       ∀ x ∈ s, m x = 0 := by
-  rw [mem_weightedDegreeZeroSubgroup, weightedDegree_indicator_nat_eq_zero_iff_of_pos s hw]
+  rw [mem_weightedDegreeZeroSubgroup, weightedDegree_indicator_nat_eq_zero_iff_of_pos s m hw]
 
 /-- An indicator divisor with multiplicities has unweighted degree zero exactly when every
 selected multiplicity vanishes. -/
@@ -300,7 +303,7 @@ private lemma indicator_nat_mem_degreeZeroSubgroup_iff (s : Finset X) (m : X →
       ∀ x ∈ s, m x = 0 := by
   rw [mem_degreeZeroSubgroup, ← weightedDegree_one_eq_degree]
   exact weightedDegree_indicator_nat_eq_zero_iff_of_pos
-    (w := fun _ : X => (1 : ℤ)) s (fun _ _ => zero_lt_one) m
+    (w := fun _ : X => (1 : ℤ)) s m (fun _ _ _ => zero_lt_one)
 
 /-! ### Named finite-set multiplicity divisors -/
 
@@ -379,21 +382,23 @@ lemma pushforward_ofFinsetWithMultiplicity (f : X → Y) (s : Finset X) (m : X �
       ∑ x ∈ s, (m x : ℤ) • ofPoint (f x) := by
   simpa [ofFinsetWithMultiplicity] using pushforward_indicator_nat (f := f) (s := s) (m := m)
 
-/-- With positive weights on `s`, `ofFinsetWithMultiplicity s m` has weighted degree zero
-exactly when every selected multiplicity vanishes. -/
+/-- With positive weights at selected points with nonzero multiplicity,
+`ofFinsetWithMultiplicity s m` has weighted degree zero exactly when every selected multiplicity
+vanishes. -/
 lemma weightedDegree_ofFinsetWithMultiplicity_eq_zero_iff_of_pos
-    (s : Finset X) {w : X → ℤ} (hw : ∀ x ∈ s, 0 < w x) (m : X → ℕ) :
+    (s : Finset X) {w : X → ℤ} (m : X → ℕ) (hw : ∀ x ∈ s, m x ≠ 0 → 0 < w x) :
     weightedDegree w (ofFinsetWithMultiplicity s m) = 0 ↔ ∀ x ∈ s, m x = 0 := by
   simpa [ofFinsetWithMultiplicity] using
-    weightedDegree_indicator_nat_eq_zero_iff_of_pos (s := s) (w := w) hw m
+    weightedDegree_indicator_nat_eq_zero_iff_of_pos (s := s) (w := w) m hw
 
-/-- With positive weights on `s`, `ofFinsetWithMultiplicity s m` lies in the weighted
-degree-zero subgroup exactly when every selected multiplicity vanishes. -/
+/-- With positive weights at selected points with nonzero multiplicity,
+`ofFinsetWithMultiplicity s m` lies in the weighted degree-zero subgroup exactly when every
+selected multiplicity vanishes. -/
 lemma ofFinsetWithMultiplicity_mem_weightedDegreeZeroSubgroup_iff_of_pos
-    (s : Finset X) {w : X → ℤ} (hw : ∀ x ∈ s, 0 < w x) (m : X → ℕ) :
+    (s : Finset X) {w : X → ℤ} (m : X → ℕ) (hw : ∀ x ∈ s, m x ≠ 0 → 0 < w x) :
     ofFinsetWithMultiplicity s m ∈ weightedDegreeZeroSubgroup w ↔ ∀ x ∈ s, m x = 0 := by
   simpa [ofFinsetWithMultiplicity] using
-    indicator_nat_mem_weightedDegreeZeroSubgroup_iff_of_pos (s := s) (w := w) hw m
+    indicator_nat_mem_weightedDegreeZeroSubgroup_iff_of_pos (s := s) (w := w) m hw
 
 /-- `ofFinsetWithMultiplicity s m` has unweighted degree zero exactly when every selected
 multiplicity vanishes. -/
@@ -496,7 +501,8 @@ private lemma indicator_one_mem_weightedDegreeZeroSubgroup_iff_of_pos
         weightedDegreeZeroSubgroup w ↔
       s = ∅ := by
   classical
-  exact (indicator_nat_mem_weightedDegreeZeroSubgroup_iff_of_pos s hw (fun _ : X => 1)).trans
+  exact (indicator_nat_mem_weightedDegreeZeroSubgroup_iff_of_pos s
+    (fun _ : X => 1) (fun x hx _ => hw x hx)).trans
     (forall_mem_one_eq_zero_iff_empty s)
 
 /-- A coefficient-one indicator divisor has unweighted degree zero exactly when the set is empty. -/
@@ -584,7 +590,7 @@ lemma ofFinset_mem_weightedDegreeZeroSubgroup_iff_of_pos
     ofFinset s ∈ weightedDegreeZeroSubgroup w ↔ s = ∅ := by
   rw [ofFinset]
   rw [ofFinsetWithMultiplicity_mem_weightedDegreeZeroSubgroup_iff_of_pos
-    (s := s) (w := w) hw (fun _ : X => 1)]
+    (s := s) (w := w) (fun _ : X => 1) (fun x hx _ => hw x hx)]
   exact forall_mem_one_eq_zero_iff_empty s
 
 /-- `ofFinset s` has unweighted degree zero exactly when `s` is empty. -/

--- a/TauCeti/AlgebraicGeometry/WeilDivisor/FiniteSum.lean
+++ b/TauCeti/AlgebraicGeometry/WeilDivisor/FiniteSum.lean
@@ -74,6 +74,7 @@ private lemma coeff_sum_zsmul_ofPoint_of_notMem {s : Finset X} {a : X → ℤ} {
 def ofFinsuppMultiplicity (m : X →₀ ℕ) : WeilDivisor X :=
   Finsupp.mapRange (fun n : ℕ => (n : ℤ)) (by simp) m
 
+/-- Coefficients of `ofFinsuppMultiplicity m` are the natural multiplicities `m x`. -/
 @[simp]
 lemma coeff_ofFinsuppMultiplicity (m : X →₀ ℕ) (x : X) :
     coeff (ofFinsuppMultiplicity m) x = m x := by
@@ -323,11 +324,13 @@ lemma ofFinsetWithMultiplicity_eq_sum (s : Finset X) (m : X → ℕ) :
     ofFinsetWithMultiplicity s m = ∑ x ∈ s, (m x : ℤ) • ofPoint x := by
   simpa [ofFinsetWithMultiplicity] using indicator_nat_eq_sum (s := s) (m := m)
 
+/-- The finite-set multiplicity divisor over the empty set is zero. -/
 @[simp]
 lemma ofFinsetWithMultiplicity_empty (m : X → ℕ) :
     ofFinsetWithMultiplicity (∅ : Finset X) m = 0 := by
   simp [ofFinsetWithMultiplicity]
 
+/-- Inserting a new point splits off the corresponding weighted point divisor. -/
 @[simp]
 lemma ofFinsetWithMultiplicity_insert [DecidableEq X] {s : Finset X} {x : X} (hx : x ∉ s)
     (m : X → ℕ) :
@@ -475,17 +478,8 @@ private lemma pushforward_indicator_one (f : X → Y) (s : Finset X) :
   classical
   simpa using pushforward_indicator_nat (f := f) (s := s) (m := fun _ : X => 1)
 
-/-- For positive weights, a coefficient-one indicator divisor lies in the weighted degree-zero
-subgroup exactly when the finite set is empty. -/
-private lemma indicator_one_mem_weightedDegreeZeroSubgroup_iff_of_pos
-    (s : Finset X) {w : X → ℤ} (hw : ∀ x ∈ s, 0 < w x) :
-    (Finsupp.indicator s (fun _ _ => (1 : ℤ)) : WeilDivisor X) ∈
-        weightedDegreeZeroSubgroup w ↔
-      s = ∅ := by
-  classical
-  rw [show ((Finsupp.indicator s (fun _ _ => (1 : ℤ)) : WeilDivisor X) ∈
-      weightedDegreeZeroSubgroup w ↔ ∀ x ∈ s, (fun _ : X => 1) x = 0) from
-    indicator_nat_mem_weightedDegreeZeroSubgroup_iff_of_pos s hw (fun _ : X => 1)]
+private lemma forall_mem_one_eq_zero_iff_empty (s : Finset X) :
+    (∀ x ∈ s, (1 : ℕ) = 0) ↔ s = ∅ := by
   constructor
   · intro h
     ext x
@@ -497,24 +491,24 @@ private lemma indicator_one_mem_weightedDegreeZeroSubgroup_iff_of_pos
   · intro hs x hx
     simp [hs] at hx
 
+/-- For positive weights, a coefficient-one indicator divisor lies in the weighted degree-zero
+subgroup exactly when the finite set is empty. -/
+private lemma indicator_one_mem_weightedDegreeZeroSubgroup_iff_of_pos
+    (s : Finset X) {w : X → ℤ} (hw : ∀ x ∈ s, 0 < w x) :
+    (Finsupp.indicator s (fun _ _ => (1 : ℤ)) : WeilDivisor X) ∈
+        weightedDegreeZeroSubgroup w ↔
+      s = ∅ := by
+  classical
+  exact (indicator_nat_mem_weightedDegreeZeroSubgroup_iff_of_pos s hw (fun _ : X => 1)).trans
+    (forall_mem_one_eq_zero_iff_empty s)
+
 /-- A coefficient-one indicator divisor has unweighted degree zero exactly when the set is empty. -/
 private lemma indicator_one_mem_degreeZeroSubgroup_iff (s : Finset X) :
     (Finsupp.indicator s (fun _ _ => (1 : ℤ)) : WeilDivisor X) ∈ degreeZeroSubgroup X ↔
       s = ∅ := by
   classical
-  rw [show ((Finsupp.indicator s (fun _ _ => (1 : ℤ)) : WeilDivisor X) ∈
-      degreeZeroSubgroup X ↔ ∀ x ∈ s, (fun _ : X => 1) x = 0) from
-    indicator_nat_mem_degreeZeroSubgroup_iff (s := s) (m := fun _ : X => 1)]
-  constructor
-  · intro h
-    ext x
-    constructor
-    · intro hx
-      exact (one_ne_zero (h x hx)).elim
-    · intro hx
-      exact (Finset.notMem_empty x hx).elim
-  · intro hs x hx
-    simp [hs] at hx
+  exact (indicator_nat_mem_degreeZeroSubgroup_iff (s := s) (m := fun _ : X => 1)).trans
+    (forall_mem_one_eq_zero_iff_empty s)
 
 /-! ### Named finite-set divisors -/
 
@@ -528,10 +522,12 @@ lemma ofFinset_eq_sum (s : Finset X) :
   simpa [ofFinset] using
     ofFinsetWithMultiplicity_eq_sum (s := s) (m := fun _ : X => 1)
 
+/-- The coefficient-one finite-set divisor over the empty set is zero. -/
 @[simp]
 lemma ofFinset_empty : ofFinset (∅ : Finset X) = 0 := by
   simp [ofFinset]
 
+/-- Inserting a new point splits off the corresponding point divisor. -/
 @[simp]
 lemma ofFinset_insert [DecidableEq X] {s : Finset X} {x : X} (hx : x ∉ s) :
     ofFinset (insert x s) = ofPoint x + ofFinset s := by
@@ -591,32 +587,14 @@ lemma ofFinset_mem_weightedDegreeZeroSubgroup_iff_of_pos
   rw [ofFinset]
   rw [ofFinsetWithMultiplicity_mem_weightedDegreeZeroSubgroup_iff_of_pos
     (s := s) (w := w) hw (fun _ : X => 1)]
-  constructor
-  · intro h
-    ext x
-    constructor
-    · intro hx
-      exact (one_ne_zero (h x hx)).elim
-    · intro hx
-      exact (Finset.notMem_empty x hx).elim
-  · intro hs x hx
-    simp [hs] at hx
+  exact forall_mem_one_eq_zero_iff_empty s
 
 /-- `ofFinset s` has unweighted degree zero exactly when `s` is empty. -/
 lemma ofFinset_mem_degreeZeroSubgroup_iff (s : Finset X) :
     ofFinset s ∈ degreeZeroSubgroup X ↔ s = ∅ := by
   rw [ofFinset]
   rw [ofFinsetWithMultiplicity_mem_degreeZeroSubgroup_iff (s := s) (m := fun _ : X => 1)]
-  constructor
-  · intro h
-    ext x
-    constructor
-    · intro hx
-      exact (one_ne_zero (h x hx)).elim
-    · intro hx
-      exact (Finset.notMem_empty x hx).elim
-  · intro hs x hx
-    simp [hs] at hx
+  exact forall_mem_one_eq_zero_iff_empty s
 
 end
 

--- a/TauCeti/AlgebraicGeometry/WeilDivisor/FiniteSum.lean
+++ b/TauCeti/AlgebraicGeometry/WeilDivisor/FiniteSum.lean
@@ -11,17 +11,17 @@ public import TauCeti.AlgebraicGeometry.WeilDivisor
 # Finite sums of point divisors
 
 This file adds constructors for the effective Weil divisors represented by finitely supported
-natural-number multiplicities, together with their finite-set specializations via
-`Finsupp.indicator`. These are the formal Layer A divisor objects that later receive geometric
-restrictions from symmetric powers and relative effective divisors: before any scheme-level
-construction exists, a finite collection of points gives the divisor `Σ nₓ[x]`.
+natural-number multiplicities and by finite sets with multiplicities. These are the formal
+Layer A divisor objects that later receive geometric restrictions from symmetric powers and
+relative effective divisors: before any scheme-level construction exists, a finite collection
+of points gives the divisor `Σ nₓ[x]`.
 
 The API records the coefficient, support, degree, weighted degree, pushforward, and degree-zero
 normal forms needed by the existing Abel-Jacobi and linear-system files.
 
 This advances `TauCetiRoadmap/JacobianChallenge/README.md`, Layer A, "Divisors on a curve:
 Weil divisors `⊕_x ℤ`" and "Degree", and supplies a clean formal prerequisite for the Layer C/D
-Abel-map lane `D ↦ 𝒪_X(D - d·x₀)` from symmetric powers.  No external mathematics is vendored;
+Abel-map lane `D ↦ 𝒪_X(D - d·x₀)` from symmetric powers. No external mathematics is vendored;
 the proofs use Tau Ceti's `WeilDivisor.ofPoint`, `degree`, `weightedDegree`, and `pushforward`
 API together with Mathlib's finite-sum lemmas.
 -/
@@ -37,6 +37,36 @@ namespace WeilDivisor
 variable {X Y : Type*}
 
 noncomputable section
+
+private lemma coeff_sum_zsmul_ofPoint_of_mem {s : Finset X} {a : X → ℤ} {x : X}
+    (hxs : x ∈ s) :
+    coeff (∑ y ∈ s, a y • ofPoint y : WeilDivisor X) x = a x := by
+  classical
+  rw [coeff]
+  rw [Finset.sum_apply', Finset.sum_eq_single x]
+  -- After unfolding `coeff`, the goal is pointwise evaluation of a `Finsupp` `ℤ`-smul.
+  · change a x * (ofPoint x : WeilDivisor X) x = a x
+    rw [show (ofPoint x : WeilDivisor X) x = coeff (ofPoint x) x from rfl,
+      coeff_ofPoint_self, mul_one]
+  · intro y hy hyx
+    have hxy : x ≠ y := fun h => hyx h.symm
+    change a y * (ofPoint y : WeilDivisor X) x = 0
+    rw [show (ofPoint y : WeilDivisor X) x = coeff (ofPoint y) x from rfl,
+      coeff_ofPoint_of_ne hxy, mul_zero]
+  · intro hx
+    exact (hx hxs).elim
+
+private lemma coeff_sum_zsmul_ofPoint_of_notMem {s : Finset X} {a : X → ℤ} {x : X}
+    (hxs : x ∉ s) :
+    coeff (∑ y ∈ s, a y • ofPoint y : WeilDivisor X) x = 0 := by
+  classical
+  rw [coeff, Finset.sum_apply']
+  exact Finset.sum_eq_zero fun y hy => by
+    have hxy : x ≠ y := fun h => hxs (h.symm ▸ hy)
+    -- After unfolding `coeff`, the goal is pointwise evaluation of a `Finsupp` `ℤ`-smul.
+    change a y * (ofPoint y : WeilDivisor X) x = 0
+    rw [show (ofPoint y : WeilDivisor X) x = coeff (ofPoint y) x from rfl,
+      coeff_ofPoint_of_ne hxy, mul_zero]
 
 /-! ### Finitely supported multiplicities -/
 
@@ -62,34 +92,13 @@ divisors over the support. -/
 lemma ofFinsuppMultiplicity_eq_sum (m : X →₀ ℕ) :
     ofFinsuppMultiplicity m = ∑ x ∈ m.support, (m x : ℤ) • ofPoint x := by
   classical
-  apply Finsupp.ext
-  intro x
-  simp only [ofFinsuppMultiplicity, Finsupp.mapRange_apply]
+  ext x
   by_cases hxs : x ∈ m.support
-  · simp_rw [Finset.sum_apply']
-    change (m x : ℤ) = ∑ y ∈ m.support, (((m y : ℤ) • ofPoint y : WeilDivisor X) x)
-    rw [Finset.sum_eq_single x]
-    · have hpoint : (ofPoint x : WeilDivisor X) x = 1 := by
-        simpa [coeff] using coeff_ofPoint_self x
-      simp [hpoint]
-    · intro y hy hyx
-      have hxy : x ≠ y := fun h => hyx h.symm
-      have hpoint : (ofPoint y : WeilDivisor X) x = 0 := by
-        simpa [coeff] using coeff_ofPoint_of_ne (x := y) (y := x) hxy
-      simp [hpoint]
-    · intro hx
-      exact (hx hxs).elim
+  · rw [coeff_ofFinsuppMultiplicity, coeff_sum_zsmul_ofPoint_of_mem hxs]
   · have hmx : m x = 0 := by
-      by_contra hmx
-      exact hxs (Finsupp.mem_support_iff.mpr hmx)
-    rw [hmx]
-    simp_rw [Finset.sum_apply']
-    change (0 : ℤ) = ∑ y ∈ m.support, (((m y : ℤ) • ofPoint y : WeilDivisor X) x)
-    exact (Finset.sum_eq_zero fun y hy => by
-      have hxy : x ≠ y := fun h => hxs (h.symm ▸ hy)
-      have hpoint : (ofPoint y : WeilDivisor X) x = 0 := by
-        simpa [coeff] using coeff_ofPoint_of_ne (x := y) (y := x) hxy
-      simp [hpoint]).symm
+      simpa [Finsupp.mem_support_iff] using hxs
+    rw [coeff_ofFinsuppMultiplicity, coeff_sum_zsmul_ofPoint_of_notMem hxs, hmx]
+    simp
 
 /-- The support of the divisor from finitely supported natural multiplicities is the support
 of those multiplicities. -/
@@ -133,170 +142,166 @@ lemma pushforward_ofFinsuppMultiplicity (f : X → Y) (m : X →₀ ℕ) :
   refine Finset.sum_congr rfl fun x hx => ?_
   rw [map_zsmul, pushforward_ofPoint]
 
-/-! ### Finite-set specializations -/
+/-- With strictly positive weights on the support, an effective divisor has weighted degree
+zero iff it is zero. -/
+lemma IsEffective.weightedDegree_eq_zero_iff_of_pos_on_support {w : X → ℤ}
+    {D : WeilDivisor X} (hD : IsEffective D) (hw : ∀ x ∈ D.support, 0 < w x) :
+    weightedDegree w D = 0 ↔ D = 0 := by
+  constructor
+  · intro hdeg
+    by_contra hD0
+    obtain ⟨x, hxpos⟩ := hD.exists_pos_coeff_of_ne_zero hD0
+    have hxs : x ∈ D.support := Finsupp.mem_support_iff.mpr (ne_of_gt hxpos)
+    have hsum_pos : 0 < D.sum fun y n => n * w y := by
+      exact Finsupp.sum_pos'
+        (fun y hy => mul_nonneg ((isEffective_iff D).mp hD y) (le_of_lt (hw y hy)))
+        ⟨x, hxs, mul_pos hxpos (hw x hxs)⟩
+    rw [← weightedDegree_apply] at hsum_pos
+    exact (ne_of_gt hsum_pos) hdeg
+  · intro h
+    simp [h]
 
-/-- Coefficient formula for the `Finsupp.indicator` specialization of finitely supported
-multiplicities. -/
+/-- With strictly positive weights on the support, an effective divisor of weighted degree zero
+is zero. -/
+lemma IsEffective.eq_zero_of_weightedDegree_eq_zero_of_pos_on_support {w : X → ℤ}
+    {D : WeilDivisor X} (hD : IsEffective D) (hw : ∀ x ∈ D.support, 0 < w x)
+    (hdeg : weightedDegree w D = 0) : D = 0 :=
+  (hD.weightedDegree_eq_zero_iff_of_pos_on_support hw).mp hdeg
+
+/-! ### Finite-set multiplicities -/
+
+/-- The effective divisor with natural-number multiplicities on a chosen finite set. Points
+outside the set have multiplicity zero. -/
+def ofFinsetWithMultiplicity (s : Finset X) (m : X → ℕ) : WeilDivisor X :=
+  ofFinsuppMultiplicity (Finsupp.indicator s fun x _ => m x)
+
+/-- Coefficient formula for a finite-set divisor with multiplicities. -/
 @[simp]
-lemma coeff_ofFinsuppMultiplicity_indicator [DecidableEq X] (s : Finset X) (m : X → ℕ)
-    (x : X) :
-    coeff (ofFinsuppMultiplicity (Finsupp.indicator s fun x _ => m x)) x =
-      if x ∈ s then m x else 0 := by
-  simp [Finsupp.indicator_apply]
+lemma coeff_ofFinsetWithMultiplicity [DecidableEq X] (s : Finset X) (m : X → ℕ) (x : X) :
+    coeff (ofFinsetWithMultiplicity s m) x = if x ∈ s then m x else 0 := by
+  simp [ofFinsetWithMultiplicity, Finsupp.indicator_apply]
 
-/-- The `Finsupp.indicator` specialization agrees with the finite sum of point divisors. -/
-lemma ofFinsuppMultiplicity_indicator_eq_sum (s : Finset X) (m : X → ℕ) :
-    ofFinsuppMultiplicity (Finsupp.indicator s fun x _ => m x) =
-      ∑ x ∈ s, (m x : ℤ) • ofPoint x := by
-  classical
-  apply Finsupp.ext
-  intro x
-  simp only [ofFinsuppMultiplicity, Finsupp.mapRange_apply, Finsupp.indicator_apply]
-  by_cases hxs : x ∈ s
-  · rw [dif_pos hxs]
-    simp_rw [Finset.sum_apply']
-    change (m x : ℤ) = ∑ y ∈ s, (((m y : ℤ) • ofPoint y : WeilDivisor X) x)
-    rw [Finset.sum_eq_single x]
-    · have hpoint : (ofPoint x : WeilDivisor X) x = 1 := by
-        simpa [coeff] using coeff_ofPoint_self x
-      simp [hpoint]
-    · intro y hy hyx
-      have hxy : x ≠ y := fun h => hyx h.symm
-      have hpoint : (ofPoint y : WeilDivisor X) x = 0 := by
-        simpa [coeff] using coeff_ofPoint_of_ne (x := y) (y := x) hxy
-      simp [hpoint]
-    · intro hx
-      exact (hx hxs).elim
-  · rw [dif_neg hxs]
-    simp_rw [Finset.sum_apply']
-    change (0 : ℤ) = ∑ y ∈ s, (((m y : ℤ) • ofPoint y : WeilDivisor X) x)
-    exact (Finset.sum_eq_zero fun y hy => by
-      have hxy : x ≠ y := fun h => hxs (h.symm ▸ hy)
-      have hpoint : (ofPoint y : WeilDivisor X) x = 0 := by
-        simpa [coeff] using coeff_ofPoint_of_ne (x := y) (y := x) hxy
-      simp [hpoint]).symm
-
-@[simp]
-lemma ofFinsuppMultiplicity_indicator_empty (m : X → ℕ) :
-    ofFinsuppMultiplicity (Finsupp.indicator (∅ : Finset X) fun x _ => m x) = 0 := by
+/-- The finite-set multiplicity divisor agrees with the corresponding finite sum of point
+divisors. -/
+lemma ofFinsetWithMultiplicity_eq_sum (s : Finset X) (m : X → ℕ) :
+    ofFinsetWithMultiplicity s m = ∑ x ∈ s, (m x : ℤ) • ofPoint x := by
   classical
   ext x
-  rw [coeff_ofFinsuppMultiplicity_indicator]
+  by_cases hxs : x ∈ s
+  · rw [coeff_ofFinsetWithMultiplicity, coeff_sum_zsmul_ofPoint_of_mem hxs, if_pos hxs]
+  · rw [coeff_ofFinsetWithMultiplicity, coeff_sum_zsmul_ofPoint_of_notMem hxs, if_neg hxs]
+    simp
+
+@[simp]
+lemma ofFinsetWithMultiplicity_empty (m : X → ℕ) :
+    ofFinsetWithMultiplicity (∅ : Finset X) m = 0 := by
+  classical
+  ext x
   simp
 
 @[simp]
-lemma ofFinsuppMultiplicity_indicator_insert [DecidableEq X] {s : Finset X} {x : X}
+lemma ofFinsetWithMultiplicity_insert [DecidableEq X] {s : Finset X} {x : X}
     (hx : x ∉ s) (m : X → ℕ) :
-    ofFinsuppMultiplicity (Finsupp.indicator (insert x s) fun y _ => m y) =
-      (m x : ℤ) • ofPoint x +
-        ofFinsuppMultiplicity (Finsupp.indicator s fun y _ => m y) := by
-  rw [ofFinsuppMultiplicity_indicator_eq_sum, ofFinsuppMultiplicity_indicator_eq_sum]
+    ofFinsetWithMultiplicity (insert x s) m =
+      (m x : ℤ) • ofPoint x + ofFinsetWithMultiplicity s m := by
+  rw [ofFinsetWithMultiplicity_eq_sum, ofFinsetWithMultiplicity_eq_sum]
   simp [hx]
 
-/-- The `Finsupp.indicator` specialization of finitely supported multiplicities is effective. -/
+/-- Finite-set divisors with natural-number multiplicities are effective. -/
 @[simp]
-lemma isEffective_ofFinsuppMultiplicity_indicator (s : Finset X) (m : X → ℕ) :
-    IsEffective (ofFinsuppMultiplicity (Finsupp.indicator s fun x _ => m x)) := by
+lemma isEffective_ofFinsetWithMultiplicity (s : Finset X) (m : X → ℕ) :
+    IsEffective (ofFinsetWithMultiplicity s m) := by
   classical
-  simp
+  simp [ofFinsetWithMultiplicity]
 
 @[simp]
-lemma ofFinsuppMultiplicity_indicator_mem_effectiveSubmonoid (s : Finset X) (m : X → ℕ) :
-    ofFinsuppMultiplicity (Finsupp.indicator s fun x _ => m x) ∈ effectiveSubmonoid X :=
-  (mem_effectiveSubmonoid _).mpr (isEffective_ofFinsuppMultiplicity_indicator s m)
+lemma ofFinsetWithMultiplicity_mem_effectiveSubmonoid (s : Finset X) (m : X → ℕ) :
+    ofFinsetWithMultiplicity s m ∈ effectiveSubmonoid X :=
+  (mem_effectiveSubmonoid _).mpr (isEffective_ofFinsetWithMultiplicity s m)
 
-/-- The support of an indicator-specialized divisor is contained in the chosen finite set.
-Points in `s` whose multiplicity is zero may drop out of the support. -/
-lemma support_ofFinsuppMultiplicity_indicator_subset (s : Finset X) (m : X → ℕ) :
-    (ofFinsuppMultiplicity (Finsupp.indicator s fun x _ => m x)).support ⊆ s := by
+/-- The support of a finite-set divisor with multiplicities is contained in the chosen finite
+set. Points in the set whose multiplicity is zero may drop out of the support. -/
+lemma support_ofFinsetWithMultiplicity_subset (s : Finset X) (m : X → ℕ) :
+    (ofFinsetWithMultiplicity s m).support ⊆ s := by
   classical
   intro x hx
-  rw [mem_support_iff, coeff_ofFinsuppMultiplicity_indicator] at hx
+  rw [mem_support_iff, coeff_ofFinsetWithMultiplicity] at hx
   by_contra hxs
   simp [hxs] at hx
 
-/-- A point is in the support of an indicator-specialized divisor exactly when it is selected
-and has nonzero multiplicity. -/
-lemma mem_support_ofFinsuppMultiplicity_indicator_iff {s : Finset X} {m : X → ℕ} {x : X} :
-    x ∈ (ofFinsuppMultiplicity (Finsupp.indicator s fun x _ => m x)).support ↔
-      x ∈ s ∧ m x ≠ 0 := by
+/-- A point is in the support of a finite-set divisor with multiplicities exactly when it is
+selected and has nonzero multiplicity. -/
+lemma mem_support_ofFinsetWithMultiplicity_iff {s : Finset X} {m : X → ℕ} {x : X} :
+    x ∈ (ofFinsetWithMultiplicity s m).support ↔ x ∈ s ∧ m x ≠ 0 := by
   classical
-  rw [mem_support_iff, coeff_ofFinsuppMultiplicity_indicator]
+  rw [mem_support_iff, coeff_ofFinsetWithMultiplicity]
   by_cases hxs : x ∈ s <;> simp [hxs]
 
-/-- The degree of an indicator-specialized divisor is the sum of the multiplicities. -/
+/-- The degree of a finite-set divisor with multiplicities is the sum of the multiplicities. -/
 @[simp]
-lemma degree_ofFinsuppMultiplicity_indicator (s : Finset X) (m : X → ℕ) :
-    degree (ofFinsuppMultiplicity (Finsupp.indicator s fun x _ => m x)) =
-      ∑ x ∈ s, (m x : ℤ) := by
+lemma degree_ofFinsetWithMultiplicity (s : Finset X) (m : X → ℕ) :
+    degree (ofFinsetWithMultiplicity s m) = ∑ x ∈ s, (m x : ℤ) := by
   classical
-  simp [ofFinsuppMultiplicity_indicator_eq_sum]
+  simp [ofFinsetWithMultiplicity_eq_sum]
 
-/-- The weighted degree of an indicator-specialized divisor is the corresponding weighted
-finite sum. -/
+/-- The weighted degree of a finite-set divisor with multiplicities is the corresponding
+weighted finite sum. -/
 @[simp]
-lemma weightedDegree_ofFinsuppMultiplicity_indicator (w : X → ℤ) (s : Finset X) (m : X → ℕ) :
-    weightedDegree w (ofFinsuppMultiplicity (Finsupp.indicator s fun x _ => m x)) =
+lemma weightedDegree_ofFinsetWithMultiplicity (w : X → ℤ) (s : Finset X) (m : X → ℕ) :
+    weightedDegree w (ofFinsetWithMultiplicity s m) =
       ∑ x ∈ s, (m x : ℤ) * w x := by
   classical
-  simp [ofFinsuppMultiplicity_indicator_eq_sum, mul_comm]
+  simp [ofFinsetWithMultiplicity_eq_sum, mul_comm]
 
-/-- Pushing forward an indicator-specialized divisor applies the map to each point in the
-finite sum. -/
+/-- Pushing forward a finite-set divisor with multiplicities applies the map to each point in
+the finite sum. -/
 @[simp]
-lemma pushforward_ofFinsuppMultiplicity_indicator (f : X → Y) (s : Finset X) (m : X → ℕ) :
-    pushforward f (ofFinsuppMultiplicity (Finsupp.indicator s fun x _ => m x)) =
+lemma pushforward_ofFinsetWithMultiplicity (f : X → Y) (s : Finset X) (m : X → ℕ) :
+    pushforward f (ofFinsetWithMultiplicity s m) =
       ∑ x ∈ s, (m x : ℤ) • ofPoint (f x) := by
   classical
-  rw [ofFinsuppMultiplicity_indicator_eq_sum, map_sum]
+  rw [ofFinsetWithMultiplicity_eq_sum, map_sum]
   refine Finset.sum_congr rfl fun x hx => ?_
   rw [map_zsmul, pushforward_ofPoint]
 
-/-- With positive weights on the selected set, an indicator-specialized divisor has weighted
-degree zero exactly when every selected point has zero multiplicity. -/
-lemma weightedDegree_ofFinsuppMultiplicity_indicator_eq_zero_iff_of_pos
+/-- With positive weights on the selected set, a finite-set divisor with multiplicities has
+weighted degree zero exactly when every selected multiplicity vanishes. -/
+lemma weightedDegree_ofFinsetWithMultiplicity_eq_zero_iff_of_pos
     (s : Finset X) {w : X → ℤ} (hw : ∀ x ∈ s, 0 < w x) (m : X → ℕ) :
-    weightedDegree w (ofFinsuppMultiplicity (Finsupp.indicator s fun x _ => m x)) = 0 ↔
-      ∀ x ∈ s, m x = 0 := by
+    weightedDegree w (ofFinsetWithMultiplicity s m) = 0 ↔ ∀ x ∈ s, m x = 0 := by
   classical
   constructor
   · intro hdeg x hx
-    rw [weightedDegree_ofFinsuppMultiplicity_indicator] at hdeg
-    have hterm :
-        (m x : ℤ) * w x = 0 :=
-      (Finset.sum_eq_zero_iff_of_nonneg
-        (fun y hy => mul_nonneg (Int.natCast_nonneg _) (le_of_lt (hw y hy)))).mp
-          hdeg x hx
-    rcases mul_eq_zero.mp hterm with hmx | hwx
-    · exact_mod_cast hmx
-    · exact False.elim ((ne_of_gt (hw x hx)) hwx)
+    have hzero : ofFinsetWithMultiplicity s m = 0 :=
+      (isEffective_ofFinsetWithMultiplicity s m).eq_zero_of_weightedDegree_eq_zero_of_pos_on_support
+        (fun y hy => hw y (support_ofFinsetWithMultiplicity_subset s m hy)) hdeg
+    have hcoeff := congrArg (fun D : WeilDivisor X => coeff D x) hzero
+    simpa [coeff_ofFinsetWithMultiplicity, hx] using hcoeff
   · intro hm
-    rw [weightedDegree_ofFinsuppMultiplicity_indicator]
+    rw [weightedDegree_ofFinsetWithMultiplicity]
     exact Finset.sum_eq_zero fun x hx => by simp [hm x hx]
 
-/-- An indicator-specialized divisor with positive weights on the selected set lies in the
-weighted degree-zero subgroup exactly when all selected multiplicities vanish. -/
-lemma ofFinsuppMultiplicity_indicator_mem_weightedDegreeZeroSubgroup_iff_of_pos
+/-- A finite-set divisor with positive weights on the selected set lies in the weighted
+degree-zero subgroup exactly when all selected multiplicities vanish. -/
+lemma ofFinsetWithMultiplicity_mem_weightedDegreeZeroSubgroup_iff_of_pos
     (s : Finset X) {w : X → ℤ} (hw : ∀ x ∈ s, 0 < w x) (m : X → ℕ) :
-    ofFinsuppMultiplicity (Finsupp.indicator s fun x _ => m x) ∈
-      weightedDegreeZeroSubgroup w ↔ ∀ x ∈ s, m x = 0 := by
+    ofFinsetWithMultiplicity s m ∈ weightedDegreeZeroSubgroup w ↔ ∀ x ∈ s, m x = 0 := by
   rw [mem_weightedDegreeZeroSubgroup,
-    weightedDegree_ofFinsuppMultiplicity_indicator_eq_zero_iff_of_pos s hw]
+    weightedDegree_ofFinsetWithMultiplicity_eq_zero_iff_of_pos s hw]
 
-/-- An indicator-specialized divisor has unweighted degree zero exactly when every selected
-multiplicity vanishes. -/
-lemma ofFinsuppMultiplicity_indicator_mem_degreeZeroSubgroup_iff (s : Finset X) (m : X → ℕ) :
-    ofFinsuppMultiplicity (Finsupp.indicator s fun x _ => m x) ∈ degreeZeroSubgroup X ↔
-      ∀ x ∈ s, m x = 0 := by
+/-- A finite-set divisor with multiplicities has unweighted degree zero exactly when every
+selected multiplicity vanishes. -/
+lemma ofFinsetWithMultiplicity_mem_degreeZeroSubgroup_iff (s : Finset X) (m : X → ℕ) :
+    ofFinsetWithMultiplicity s m ∈ degreeZeroSubgroup X ↔ ∀ x ∈ s, m x = 0 := by
   rw [mem_degreeZeroSubgroup, ← weightedDegree_one_eq_degree]
-  exact weightedDegree_ofFinsuppMultiplicity_indicator_eq_zero_iff_of_pos
+  exact weightedDegree_ofFinsetWithMultiplicity_eq_zero_iff_of_pos
     (w := fun _ : X => (1 : ℤ)) s (fun _ _ => zero_lt_one) m
 
 /-! ### Finite sums with coefficient one -/
 
 /-- The effective divisor `Σ x ∈ s, [x]` attached to a finite set of points. -/
 def ofFinset (s : Finset X) : WeilDivisor X :=
-  ofFinsuppMultiplicity (Finsupp.indicator s fun _ _ => 1)
+  ofFinsetWithMultiplicity s fun _ => 1
 
 @[simp]
 lemma ofFinset_empty : ofFinset (∅ : Finset X) = 0 := by
@@ -329,14 +334,14 @@ lemma ofFinset_mem_effectiveSubmonoid (s : Finset X) :
 lemma support_ofFinset (s : Finset X) : (ofFinset s).support = s := by
   classical
   ext x
-  rw [ofFinset, mem_support_ofFinsuppMultiplicity_indicator_iff]
+  rw [ofFinset, mem_support_ofFinsetWithMultiplicity_iff]
   simp
 
 /-- The degree of the coefficient-one divisor attached to a finite set is its cardinality. -/
 @[simp]
 lemma degree_ofFinset (s : Finset X) : degree (ofFinset s) = s.card := by
   classical
-  rw [ofFinset, degree_ofFinsuppMultiplicity_indicator]
+  rw [ofFinset, degree_ofFinsetWithMultiplicity]
   simp
 
 /-- The weighted degree of the divisor attached to a finite set is the sum of weights on it. -/
@@ -344,7 +349,7 @@ lemma degree_ofFinset (s : Finset X) : degree (ofFinset s) = s.card := by
 lemma weightedDegree_ofFinset (w : X → ℤ) (s : Finset X) :
     weightedDegree w (ofFinset s) = ∑ x ∈ s, w x := by
   classical
-  rw [ofFinset, weightedDegree_ofFinsuppMultiplicity_indicator]
+  rw [ofFinset, weightedDegree_ofFinsetWithMultiplicity]
   simp
 
 /-- Pushing forward the divisor attached to a finite set applies the map to each point. -/
@@ -352,7 +357,7 @@ lemma weightedDegree_ofFinset (w : X → ℤ) (s : Finset X) :
 lemma pushforward_ofFinset (f : X → Y) (s : Finset X) :
     pushforward f (ofFinset s) = ∑ x ∈ s, ofPoint (f x) := by
   classical
-  rw [ofFinset, pushforward_ofFinsuppMultiplicity_indicator]
+  rw [ofFinset, pushforward_ofFinsetWithMultiplicity]
   simp
 
 /-- For positive weights, a finite set divisor lies in the weighted degree-zero subgroup exactly
@@ -361,7 +366,7 @@ lemma ofFinset_mem_weightedDegreeZeroSubgroup_iff_of_pos
     (s : Finset X) {w : X → ℤ} (hw : ∀ x ∈ s, 0 < w x) :
     ofFinset s ∈ weightedDegreeZeroSubgroup w ↔ s = ∅ := by
   classical
-  rw [ofFinset, ofFinsuppMultiplicity_indicator_mem_weightedDegreeZeroSubgroup_iff_of_pos s hw]
+  rw [ofFinset, ofFinsetWithMultiplicity_mem_weightedDegreeZeroSubgroup_iff_of_pos s hw]
   constructor
   · intro h
     ext x
@@ -378,7 +383,7 @@ empty. -/
 lemma ofFinset_mem_degreeZeroSubgroup_iff (s : Finset X) :
     ofFinset s ∈ degreeZeroSubgroup X ↔ s = ∅ := by
   classical
-  rw [ofFinset, ofFinsuppMultiplicity_indicator_mem_degreeZeroSubgroup_iff]
+  rw [ofFinset, ofFinsetWithMultiplicity_mem_degreeZeroSubgroup_iff]
   constructor
   · intro h
     ext x

--- a/TauCeti/AlgebraicGeometry/WeilDivisor/FiniteSum.lean
+++ b/TauCeti/AlgebraicGeometry/WeilDivisor/FiniteSum.lean
@@ -1,0 +1,250 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+module
+
+public import TauCeti.AlgebraicGeometry.WeilDivisor
+
+/-!
+# Finite sums of point divisors
+
+This file adds constructors for the effective Weil divisors represented by a finite set of
+points, or by a finite set together with natural-number multiplicities.  These are the formal
+Layer A divisor objects that later receive geometric restrictions from symmetric powers and
+relative effective divisors: before any scheme-level construction exists, a finite collection of
+points gives the divisor `Σ nₓ[x]`.
+
+The API records the coefficient, support, degree, weighted degree, pushforward, and degree-zero
+normal forms needed by the existing Abel-Jacobi and linear-system files.
+
+This advances `TauCetiRoadmap/JacobianChallenge/README.md`, Layer A, "Divisors on a curve:
+Weil divisors `⊕_x ℤ`" and "Degree", and supplies a clean formal prerequisite for the Layer C/D
+Abel-map lane `D ↦ 𝒪_X(D - d·x₀)` from symmetric powers.  No external mathematics is vendored;
+the proofs use Tau Ceti's `WeilDivisor.ofPoint`, `degree`, `weightedDegree`, and `pushforward`
+API together with Mathlib's finite-sum lemmas.
+-/
+
+public section
+
+namespace TauCeti
+
+namespace AlgebraicGeometry
+
+namespace WeilDivisor
+
+variable {X Y : Type*}
+
+noncomputable section
+
+/-! ### Finite sums with multiplicity -/
+
+/-- The effective divisor `Σ x ∈ s, m x • [x]` attached to a finite set of points and
+natural-number multiplicities.  Points outside `s` have coefficient zero. -/
+def ofFinsetWithMultiplicity (s : Finset X) (m : X → ℕ) : WeilDivisor X :=
+  ∑ x ∈ s, (m x : ℤ) • ofPoint x
+
+@[simp]
+lemma ofFinsetWithMultiplicity_empty (m : X → ℕ) :
+    ofFinsetWithMultiplicity (∅ : Finset X) m = 0 := by
+  simp [ofFinsetWithMultiplicity]
+
+@[simp]
+lemma ofFinsetWithMultiplicity_insert [DecidableEq X] {s : Finset X} {x : X}
+    (hx : x ∉ s) (m : X → ℕ) :
+    ofFinsetWithMultiplicity (insert x s) m =
+      (m x : ℤ) • ofPoint x + ofFinsetWithMultiplicity s m := by
+  simp [ofFinsetWithMultiplicity, hx]
+
+/-- Coefficient formula for a finite point divisor with multiplicities. -/
+@[simp]
+lemma coeff_ofFinsetWithMultiplicity [DecidableEq X] (s : Finset X) (m : X → ℕ) (x : X) :
+    coeff (ofFinsetWithMultiplicity s m) x = if x ∈ s then m x else 0 := by
+  classical
+  induction s using Finset.induction with
+  | empty =>
+      simp
+  | insert y s hy ih =>
+      rw [ofFinsetWithMultiplicity_insert hy, coeff_add]
+      by_cases hxy : x = y
+      · subst y
+        have hsx : (ofFinsetWithMultiplicity s m) x = 0 := by
+          simpa [coeff, hy] using ih
+        have hpoint : (ofPoint x : WeilDivisor X) x = 1 := by
+          simpa [coeff] using coeff_ofPoint_self x
+        rw [show coeff ((m x : ℤ) • ofPoint x) x = (m x : ℤ) by simp [coeff, hpoint]]
+        rw [show coeff (ofFinsetWithMultiplicity s m) x = 0 by simpa [coeff] using hsx]
+        simp
+      · have hsx : (ofFinsetWithMultiplicity s m) x = if x ∈ s then m x else 0 := by
+          simpa [coeff] using ih
+        have hpoint : (ofPoint y : WeilDivisor X) x = 0 := by
+          simpa [coeff] using coeff_ofPoint_of_ne (x := y) (y := x) hxy
+        rw [show coeff ((m y : ℤ) • ofPoint y) x = 0 by simp [coeff, hpoint]]
+        rw [show coeff (ofFinsetWithMultiplicity s m) x =
+          (if x ∈ s then (m x : ℤ) else 0) by simpa [coeff] using hsx]
+        simp [hxy]
+
+/-- Finite point divisors with natural multiplicities are effective. -/
+@[simp]
+lemma isEffective_ofFinsetWithMultiplicity (s : Finset X) (m : X → ℕ) :
+    IsEffective (ofFinsetWithMultiplicity s m) := by
+  classical
+  rw [isEffective_iff]
+  intro x
+  rw [coeff_ofFinsetWithMultiplicity]
+  split
+  · exact Int.natCast_nonneg _
+  · rfl
+
+@[simp]
+lemma ofFinsetWithMultiplicity_mem_effectiveSubmonoid (s : Finset X) (m : X → ℕ) :
+    ofFinsetWithMultiplicity s m ∈ effectiveSubmonoid X :=
+  (mem_effectiveSubmonoid _).mpr (isEffective_ofFinsetWithMultiplicity s m)
+
+/-- The support of a finite point divisor with multiplicities is contained in the chosen
+finite set.  Points in `s` whose multiplicity is zero may drop out of the support. -/
+lemma support_ofFinsetWithMultiplicity_subset (s : Finset X) (m : X → ℕ) :
+    (ofFinsetWithMultiplicity s m).support ⊆ s := by
+  classical
+  intro x hx
+  rw [mem_support_iff, coeff_ofFinsetWithMultiplicity] at hx
+  by_contra hxs
+  simp [hxs] at hx
+
+lemma mem_support_ofFinsetWithMultiplicity_iff {s : Finset X} {m : X → ℕ}
+    {x : X} :
+    x ∈ (ofFinsetWithMultiplicity s m).support ↔ x ∈ s ∧ m x ≠ 0 := by
+  classical
+  rw [mem_support_iff, coeff_ofFinsetWithMultiplicity]
+  by_cases hxs : x ∈ s <;> simp [hxs]
+
+/-- The degree of `Σ x ∈ s, m x • [x]` is the sum of the multiplicities. -/
+@[simp]
+lemma degree_ofFinsetWithMultiplicity (s : Finset X) (m : X → ℕ) :
+    degree (ofFinsetWithMultiplicity s m) = ∑ x ∈ s, (m x : ℤ) := by
+  classical
+  simp [ofFinsetWithMultiplicity]
+
+/-- The weighted degree of `Σ x ∈ s, m x • [x]` is the corresponding weighted finite sum. -/
+@[simp]
+lemma weightedDegree_ofFinsetWithMultiplicity (w : X → ℤ) (s : Finset X) (m : X → ℕ) :
+    weightedDegree w (ofFinsetWithMultiplicity s m) =
+      ∑ x ∈ s, (m x : ℤ) * w x := by
+  classical
+  simp [ofFinsetWithMultiplicity, mul_comm]
+
+/-- Pushing forward a finite point divisor applies the map to each point in the finite sum. -/
+@[simp]
+lemma pushforward_ofFinsetWithMultiplicity (f : X → Y) (s : Finset X) (m : X → ℕ) :
+    pushforward f (ofFinsetWithMultiplicity s m) =
+      ∑ x ∈ s, (m x : ℤ) • ofPoint (f x) := by
+  classical
+  rw [ofFinsetWithMultiplicity, map_sum]
+  refine Finset.sum_congr rfl fun x hx => ?_
+  rw [map_zsmul, pushforward_ofPoint]
+
+/-- With positive weights, a finite point divisor has weighted degree zero exactly when every
+selected point has zero multiplicity. -/
+lemma weightedDegree_ofFinsetWithMultiplicity_eq_zero_iff_of_pos
+    {w : X → ℤ} (hw : ∀ x, 0 < w x) (s : Finset X) (m : X → ℕ) :
+    weightedDegree w (ofFinsetWithMultiplicity s m) = 0 ↔ ∀ x ∈ s, m x = 0 := by
+  classical
+  constructor
+  · intro hdeg x hx
+    have hzero : ofFinsetWithMultiplicity s m = 0 :=
+      (isEffective_ofFinsetWithMultiplicity s m).eq_zero_of_weightedDegree_eq_zero_of_pos hw
+        hdeg
+    have hcoeff := congr_arg (fun D : WeilDivisor X => coeff D x) hzero
+    simpa [hx] using hcoeff
+  · intro hm
+    rw [weightedDegree_ofFinsetWithMultiplicity]
+    exact Finset.sum_eq_zero fun x hx => by simp [hm x hx]
+
+/-- A finite point divisor with positive weights lies in the weighted degree-zero subgroup
+exactly when all selected multiplicities vanish. -/
+lemma ofFinsetWithMultiplicity_mem_weightedDegreeZeroSubgroup_iff_of_pos
+    {w : X → ℤ} (hw : ∀ x, 0 < w x) (s : Finset X) (m : X → ℕ) :
+    ofFinsetWithMultiplicity s m ∈ weightedDegreeZeroSubgroup w ↔ ∀ x ∈ s, m x = 0 := by
+  rw [mem_weightedDegreeZeroSubgroup,
+    weightedDegree_ofFinsetWithMultiplicity_eq_zero_iff_of_pos hw]
+
+/-! ### Finite sums with coefficient one -/
+
+/-- The effective divisor `Σ x ∈ s, [x]` attached to a finite set of points. -/
+def ofFinset (s : Finset X) : WeilDivisor X :=
+  ofFinsetWithMultiplicity s fun _ => 1
+
+@[simp]
+lemma ofFinset_empty : ofFinset (∅ : Finset X) = 0 := by
+  simp [ofFinset]
+
+@[simp]
+lemma ofFinset_insert [DecidableEq X] {s : Finset X} {x : X} (hx : x ∉ s) :
+    ofFinset (insert x s) = ofPoint x + ofFinset s := by
+  simp [ofFinset, hx]
+
+@[simp]
+lemma coeff_ofFinset [DecidableEq X] (s : Finset X) (x : X) :
+    coeff (ofFinset s) x = if x ∈ s then 1 else 0 := by
+  simp [ofFinset]
+
+@[simp]
+lemma isEffective_ofFinset (s : Finset X) : IsEffective (ofFinset s) := by
+  classical
+  simp [ofFinset]
+
+@[simp]
+lemma ofFinset_mem_effectiveSubmonoid (s : Finset X) :
+    ofFinset s ∈ effectiveSubmonoid X :=
+  (mem_effectiveSubmonoid _).mpr (isEffective_ofFinset s)
+
+@[simp]
+lemma support_ofFinset (s : Finset X) : (ofFinset s).support = s := by
+  classical
+  ext x
+  rw [ofFinset, mem_support_ofFinsetWithMultiplicity_iff]
+  simp
+
+@[simp]
+lemma degree_ofFinset (s : Finset X) : degree (ofFinset s) = s.card := by
+  classical
+  simp [ofFinset]
+
+@[simp]
+lemma weightedDegree_ofFinset (w : X → ℤ) (s : Finset X) :
+    weightedDegree w (ofFinset s) = ∑ x ∈ s, w x := by
+  classical
+  simp [ofFinset]
+
+@[simp]
+lemma pushforward_ofFinset (f : X → Y) (s : Finset X) :
+    pushforward f (ofFinset s) = ∑ x ∈ s, ofPoint (f x) := by
+  classical
+  rw [ofFinset, pushforward_ofFinsetWithMultiplicity]
+  simp
+
+/-- For positive weights, a finite set divisor lies in the weighted degree-zero subgroup exactly
+when the finite set is empty. -/
+lemma ofFinset_mem_weightedDegreeZeroSubgroup_iff_of_pos
+    {w : X → ℤ} (hw : ∀ x, 0 < w x) (s : Finset X) :
+    ofFinset s ∈ weightedDegreeZeroSubgroup w ↔ s = ∅ := by
+  classical
+  rw [ofFinset, ofFinsetWithMultiplicity_mem_weightedDegreeZeroSubgroup_iff_of_pos hw]
+  constructor
+  · intro h
+    ext x
+    constructor
+    · intro hx
+      exact (one_ne_zero (h x hx)).elim
+    · intro hx
+      exact (Finset.notMem_empty x hx).elim
+  · intro hs x hx
+    simp [hs] at hx
+
+end
+
+end WeilDivisor
+
+end AlgebraicGeometry
+
+end TauCeti

--- a/TauCeti/AlgebraicGeometry/WeilDivisor/FiniteSum.lean
+++ b/TauCeti/AlgebraicGeometry/WeilDivisor/FiniteSum.lean
@@ -38,21 +38,20 @@ variable {X Y : Type*}
 
 noncomputable section
 
+private lemma coeff_zsmul_ofPoint (n : ℤ) (y x : X) :
+    coeff (n • ofPoint y : WeilDivisor X) x = n * coeff (ofPoint y) x := by
+  simp [coeff]
+
 private lemma coeff_sum_zsmul_ofPoint_of_mem {s : Finset X} {a : X → ℤ} {x : X}
     (hxs : x ∈ s) :
     coeff (∑ y ∈ s, a y • ofPoint y : WeilDivisor X) x = a x := by
   classical
   rw [coeff]
   rw [Finset.sum_apply', Finset.sum_eq_single x]
-  -- After unfolding `coeff`, the goal is pointwise evaluation of a `Finsupp` `ℤ`-smul.
-  · change a x * (ofPoint x : WeilDivisor X) x = a x
-    rw [show (ofPoint x : WeilDivisor X) x = coeff (ofPoint x) x from rfl,
-      coeff_ofPoint_self, mul_one]
+  · rw [← coeff, coeff_zsmul_ofPoint, coeff_ofPoint_self, mul_one]
   · intro y hy hyx
     have hxy : x ≠ y := fun h => hyx h.symm
-    change a y * (ofPoint y : WeilDivisor X) x = 0
-    rw [show (ofPoint y : WeilDivisor X) x = coeff (ofPoint y) x from rfl,
-      coeff_ofPoint_of_ne hxy, mul_zero]
+    rw [← coeff, coeff_zsmul_ofPoint, coeff_ofPoint_of_ne hxy, mul_zero]
   · intro hx
     exact (hx hxs).elim
 
@@ -63,10 +62,7 @@ private lemma coeff_sum_zsmul_ofPoint_of_notMem {s : Finset X} {a : X → ℤ} {
   rw [coeff, Finset.sum_apply']
   exact Finset.sum_eq_zero fun y hy => by
     have hxy : x ≠ y := fun h => hxs (h.symm ▸ hy)
-    -- After unfolding `coeff`, the goal is pointwise evaluation of a `Finsupp` `ℤ`-smul.
-    change a y * (ofPoint y : WeilDivisor X) x = 0
-    rw [show (ofPoint y : WeilDivisor X) x = coeff (ofPoint y) x from rfl,
-      coeff_ofPoint_of_ne hxy, mul_zero]
+    rw [← coeff, coeff_zsmul_ofPoint, coeff_ofPoint_of_ne hxy, mul_zero]
 
 /-! ### Finitely supported multiplicities -/
 
@@ -344,6 +340,7 @@ lemma isEffective_ofFinsetWithMultiplicity (s : Finset X) (m : X → ℕ) :
     IsEffective (ofFinsetWithMultiplicity s m) := by
   simp [ofFinsetWithMultiplicity]
 
+/-- `ofFinsetWithMultiplicity s m` belongs to the effective divisor submonoid. -/
 @[simp]
 lemma ofFinsetWithMultiplicity_mem_effectiveSubmonoid (s : Finset X) (m : X → ℕ) :
     ofFinsetWithMultiplicity s m ∈ effectiveSubmonoid X :=
@@ -546,6 +543,7 @@ lemma isEffective_ofFinset (s : Finset X) :
     IsEffective (ofFinset s) := by
   simp [ofFinset]
 
+/-- `ofFinset s` belongs to the effective divisor submonoid. -/
 @[simp]
 lemma ofFinset_mem_effectiveSubmonoid (s : Finset X) :
     ofFinset s ∈ effectiveSubmonoid X :=

--- a/TauCeti/AlgebraicGeometry/WeilDivisor/FiniteSum.lean
+++ b/TauCeti/AlgebraicGeometry/WeilDivisor/FiniteSum.lean
@@ -11,10 +11,10 @@ public import TauCeti.AlgebraicGeometry.WeilDivisor
 # Finite sums of point divisors
 
 This file adds an API for the effective Weil divisors represented by finitely supported
-natural-number multiplicities and by Mathlib's `Finsupp.indicator` on finite sets. These are
-the formal Layer A divisor objects that later receive geometric restrictions from symmetric
-powers and relative effective divisors: before any scheme-level construction exists, a finite
-collection of points gives the divisor `Σ nₓ[x]`.
+natural-number multiplicities and by named finite-set constructors. These are the formal
+Layer A divisor objects that later receive geometric restrictions from symmetric powers and
+relative effective divisors: before any scheme-level construction exists, a finite collection
+of points gives the divisor `Σ nₓ[x]`.
 
 The API records the coefficient, support, degree, weighted degree, pushforward, and degree-zero
 normal forms needed by the existing Abel-Jacobi and linear-system files.
@@ -170,6 +170,11 @@ lemma IsEffective.eq_zero_of_weightedDegree_eq_zero_of_pos_on_support {w : X →
 
 /-! ### Finite-set multiplicities via `Finsupp.indicator` -/
 
+/-- The effective divisor whose coefficients on `s` are the natural-number multiplicities `m`
+and whose coefficients off `s` are zero. -/
+@[expose] def ofFinsetWithMultiplicity (s : Finset X) (m : X → ℕ) : WeilDivisor X :=
+  Finsupp.indicator s (fun x _ => (m x : ℤ))
+
 /-- Coefficient formula for `Finsupp.indicator` with natural-number multiplicities. -/
 @[simp]
 lemma coeff_indicator_nat [DecidableEq X] (s : Finset X) (m : X → ℕ) (x : X) :
@@ -299,7 +304,109 @@ lemma indicator_nat_mem_degreeZeroSubgroup_iff (s : Finset X) (m : X → ℕ) :
   exact weightedDegree_indicator_nat_eq_zero_iff_of_pos
     (w := fun _ : X => (1 : ℤ)) s (fun _ _ => zero_lt_one) m
 
+/-! ### Named finite-set multiplicity divisors -/
+
+@[simp]
+lemma ofFinsetWithMultiplicity_eq_indicator (s : Finset X) (m : X → ℕ) :
+    ofFinsetWithMultiplicity s m =
+      (Finsupp.indicator s (fun x _ => (m x : ℤ)) : WeilDivisor X) :=
+  rfl
+
+/-- Coefficients of `ofFinsetWithMultiplicity s m` are `m x` on `s` and zero off `s`. -/
+@[simp]
+lemma coeff_ofFinsetWithMultiplicity [DecidableEq X] (s : Finset X) (m : X → ℕ) (x : X) :
+    coeff (ofFinsetWithMultiplicity s m) x = if x ∈ s then m x else 0 := by
+  simp [ofFinsetWithMultiplicity]
+
+/-- `ofFinsetWithMultiplicity s m` is the finite sum of point divisors with coefficients `m`. -/
+lemma ofFinsetWithMultiplicity_eq_sum (s : Finset X) (m : X → ℕ) :
+    ofFinsetWithMultiplicity s m = ∑ x ∈ s, (m x : ℤ) • ofPoint x := by
+  simpa [ofFinsetWithMultiplicity] using indicator_nat_eq_sum (s := s) (m := m)
+
+@[simp]
+lemma ofFinsetWithMultiplicity_empty (m : X → ℕ) :
+    ofFinsetWithMultiplicity (∅ : Finset X) m = 0 := by
+  simp [ofFinsetWithMultiplicity]
+
+@[simp]
+lemma ofFinsetWithMultiplicity_insert [DecidableEq X] {s : Finset X} {x : X} (hx : x ∉ s)
+    (m : X → ℕ) :
+    ofFinsetWithMultiplicity (insert x s) m =
+      (m x : ℤ) • ofPoint x + ofFinsetWithMultiplicity s m := by
+  simpa [ofFinsetWithMultiplicity] using indicator_nat_insert (s := s) (x := x) hx m
+
+/-- `ofFinsetWithMultiplicity s m` is effective. -/
+@[simp]
+lemma isEffective_ofFinsetWithMultiplicity (s : Finset X) (m : X → ℕ) :
+    IsEffective (ofFinsetWithMultiplicity s m) := by
+  simp [ofFinsetWithMultiplicity]
+
+@[simp]
+lemma ofFinsetWithMultiplicity_mem_effectiveSubmonoid (s : Finset X) (m : X → ℕ) :
+    ofFinsetWithMultiplicity s m ∈ effectiveSubmonoid X :=
+  (mem_effectiveSubmonoid _).mpr (isEffective_ofFinsetWithMultiplicity s m)
+
+/-- The support of `ofFinsetWithMultiplicity s m` is contained in `s`. -/
+lemma support_ofFinsetWithMultiplicity_subset (s : Finset X) (m : X → ℕ) :
+    (ofFinsetWithMultiplicity s m).support ⊆ s := by
+  simpa [ofFinsetWithMultiplicity] using support_indicator_nat_subset (s := s) (m := m)
+
+/-- A point is in the support of `ofFinsetWithMultiplicity s m` exactly when it lies in `s`
+and has nonzero multiplicity. -/
+@[simp]
+lemma mem_support_ofFinsetWithMultiplicity_iff {s : Finset X} {m : X → ℕ} {x : X} :
+    x ∈ (ofFinsetWithMultiplicity s m).support ↔ x ∈ s ∧ m x ≠ 0 := by
+  simpa [ofFinsetWithMultiplicity] using
+    mem_support_indicator_nat_iff (s := s) (m := m) (x := x)
+
+/-- The degree of `ofFinsetWithMultiplicity s m` is the sum of the selected multiplicities. -/
+@[simp]
+lemma degree_ofFinsetWithMultiplicity (s : Finset X) (m : X → ℕ) :
+    degree (ofFinsetWithMultiplicity s m) = ∑ x ∈ s, (m x : ℤ) := by
+  simp [ofFinsetWithMultiplicity]
+
+/-- The weighted degree of `ofFinsetWithMultiplicity s m` is the selected weighted sum. -/
+@[simp]
+lemma weightedDegree_ofFinsetWithMultiplicity (w : X → ℤ) (s : Finset X) (m : X → ℕ) :
+    weightedDegree w (ofFinsetWithMultiplicity s m) =
+      ∑ x ∈ s, (m x : ℤ) * w x := by
+  simp [ofFinsetWithMultiplicity]
+
+/-- Pushing forward `ofFinsetWithMultiplicity s m` applies the map to each selected point. -/
+@[simp]
+lemma pushforward_ofFinsetWithMultiplicity (f : X → Y) (s : Finset X) (m : X → ℕ) :
+    pushforward f (ofFinsetWithMultiplicity s m) =
+      ∑ x ∈ s, (m x : ℤ) • ofPoint (f x) := by
+  simpa [ofFinsetWithMultiplicity] using pushforward_indicator_nat (f := f) (s := s) (m := m)
+
+/-- With positive weights on `s`, `ofFinsetWithMultiplicity s m` has weighted degree zero
+exactly when every selected multiplicity vanishes. -/
+lemma weightedDegree_ofFinsetWithMultiplicity_eq_zero_iff_of_pos
+    (s : Finset X) {w : X → ℤ} (hw : ∀ x ∈ s, 0 < w x) (m : X → ℕ) :
+    weightedDegree w (ofFinsetWithMultiplicity s m) = 0 ↔ ∀ x ∈ s, m x = 0 := by
+  simpa [ofFinsetWithMultiplicity] using
+    weightedDegree_indicator_nat_eq_zero_iff_of_pos (s := s) (w := w) hw m
+
+/-- With positive weights on `s`, `ofFinsetWithMultiplicity s m` lies in the weighted
+degree-zero subgroup exactly when every selected multiplicity vanishes. -/
+lemma ofFinsetWithMultiplicity_mem_weightedDegreeZeroSubgroup_iff_of_pos
+    (s : Finset X) {w : X → ℤ} (hw : ∀ x ∈ s, 0 < w x) (m : X → ℕ) :
+    ofFinsetWithMultiplicity s m ∈ weightedDegreeZeroSubgroup w ↔ ∀ x ∈ s, m x = 0 := by
+  simpa [ofFinsetWithMultiplicity] using
+    indicator_nat_mem_weightedDegreeZeroSubgroup_iff_of_pos (s := s) (w := w) hw m
+
+/-- `ofFinsetWithMultiplicity s m` has unweighted degree zero exactly when every selected
+multiplicity vanishes. -/
+lemma ofFinsetWithMultiplicity_mem_degreeZeroSubgroup_iff (s : Finset X) (m : X → ℕ) :
+    ofFinsetWithMultiplicity s m ∈ degreeZeroSubgroup X ↔ ∀ x ∈ s, m x = 0 := by
+  simpa [ofFinsetWithMultiplicity] using
+    indicator_nat_mem_degreeZeroSubgroup_iff (s := s) (m := m)
+
 /-! ### Finite sums with coefficient one via `Finsupp.indicator` -/
+
+/-- The effective divisor that puts coefficient one on every point of `s` and zero elsewhere. -/
+@[expose] def ofFinset (s : Finset X) : WeilDivisor X :=
+  Finsupp.indicator s (fun _ _ => (1 : ℤ))
 
 /-- The coefficient-one `Finsupp.indicator` divisor is the corresponding finite sum of point
 divisors. -/
@@ -408,6 +515,81 @@ lemma indicator_one_mem_degreeZeroSubgroup_iff (s : Finset X) :
       exact (Finset.notMem_empty x hx).elim
   · intro hs x hx
     simp [hs] at hx
+
+/-! ### Named finite-set divisors -/
+
+@[simp]
+lemma ofFinset_eq_indicator (s : Finset X) :
+    ofFinset s = (Finsupp.indicator s (fun _ _ => (1 : ℤ)) : WeilDivisor X) :=
+  rfl
+
+/-- `ofFinset s` is the finite sum of the point divisors at the points of `s`. -/
+lemma ofFinset_eq_sum (s : Finset X) :
+    ofFinset s = ∑ x ∈ s, ofPoint x := by
+  simpa [ofFinset] using indicator_one_eq_sum (s := s)
+
+@[simp]
+lemma ofFinset_empty : ofFinset (∅ : Finset X) = 0 := by
+  simp [ofFinset]
+
+@[simp]
+lemma ofFinset_insert [DecidableEq X] {s : Finset X} {x : X} (hx : x ∉ s) :
+    ofFinset (insert x s) = ofPoint x + ofFinset s := by
+  simpa [ofFinset] using indicator_one_insert (s := s) (x := x) hx
+
+/-- Coefficients of `ofFinset s` are `1` on `s` and `0` off `s`. -/
+@[simp]
+lemma coeff_ofFinset [DecidableEq X] (s : Finset X) (x : X) :
+    coeff (ofFinset s) x = if x ∈ s then 1 else 0 := by
+  simp [ofFinset]
+
+/-- `ofFinset s` is effective. -/
+@[simp]
+lemma isEffective_ofFinset (s : Finset X) :
+    IsEffective (ofFinset s) := by
+  simp [ofFinset]
+
+@[simp]
+lemma ofFinset_mem_effectiveSubmonoid (s : Finset X) :
+    ofFinset s ∈ effectiveSubmonoid X :=
+  (mem_effectiveSubmonoid _).mpr (isEffective_ofFinset s)
+
+/-- The support of `ofFinset s` is exactly `s`. -/
+@[simp]
+lemma support_ofFinset (s : Finset X) :
+    (ofFinset s).support = s := by
+  simp [ofFinset]
+
+/-- The degree of `ofFinset s` is the cardinality of `s`. -/
+@[simp]
+lemma degree_ofFinset (s : Finset X) :
+    degree (ofFinset s) = s.card := by
+  simp [ofFinset]
+
+/-- The weighted degree of `ofFinset s` is the sum of the weights on `s`. -/
+@[simp]
+lemma weightedDegree_ofFinset (w : X → ℤ) (s : Finset X) :
+    weightedDegree w (ofFinset s) = ∑ x ∈ s, w x := by
+  simp [ofFinset]
+
+/-- Pushing forward `ofFinset s` applies the map to each selected point. -/
+@[simp]
+lemma pushforward_ofFinset (f : X → Y) (s : Finset X) :
+    pushforward f (ofFinset s) = ∑ x ∈ s, ofPoint (f x) := by
+  simpa [ofFinset] using pushforward_indicator_one (f := f) (s := s)
+
+/-- With positive weights on `s`, `ofFinset s` lies in the weighted degree-zero subgroup exactly
+when `s` is empty. -/
+lemma ofFinset_mem_weightedDegreeZeroSubgroup_iff_of_pos
+    (s : Finset X) {w : X → ℤ} (hw : ∀ x ∈ s, 0 < w x) :
+    ofFinset s ∈ weightedDegreeZeroSubgroup w ↔ s = ∅ := by
+  simpa [ofFinset] using
+    indicator_one_mem_weightedDegreeZeroSubgroup_iff_of_pos (s := s) (w := w) hw
+
+/-- `ofFinset s` has unweighted degree zero exactly when `s` is empty. -/
+lemma ofFinset_mem_degreeZeroSubgroup_iff (s : Finset X) :
+    ofFinset s ∈ degreeZeroSubgroup X ↔ s = ∅ := by
+  simp [ofFinset]
 
 end
 

--- a/TauCeti/AlgebraicGeometry/WeilDivisor/FiniteSum.lean
+++ b/TauCeti/AlgebraicGeometry/WeilDivisor/FiniteSum.lean
@@ -10,11 +10,11 @@ public import TauCeti.AlgebraicGeometry.WeilDivisor
 /-!
 # Finite sums of point divisors
 
-This file adds constructors for the effective Weil divisors represented by a finite set of
-points, or by a finite set together with natural-number multiplicities.  These are the formal
-Layer A divisor objects that later receive geometric restrictions from symmetric powers and
-relative effective divisors: before any scheme-level construction exists, a finite collection of
-points gives the divisor `Σ nₓ[x]`.
+This file adds constructors for the effective Weil divisors represented by finitely supported
+natural-number multiplicities, together with their finite-set specializations via
+`Finsupp.indicator`. These are the formal Layer A divisor objects that later receive geometric
+restrictions from symmetric powers and relative effective divisors: before any scheme-level
+construction exists, a finite collection of points gives the divisor `Σ nₓ[x]`.
 
 The API records the coefficient, support, degree, weighted degree, pushforward, and degree-zero
 normal forms needed by the existing Abel-Jacobi and linear-system files.
@@ -38,7 +38,7 @@ variable {X Y : Type*}
 
 noncomputable section
 
-/-! ### Finite sums with multiplicity -/
+/-! ### Finitely supported multiplicities -/
 
 /-- The effective divisor with finitely supported natural-number multiplicities. -/
 def ofFinsuppMultiplicity (m : X →₀ ℕ) : WeilDivisor X :=
@@ -133,25 +133,25 @@ lemma pushforward_ofFinsuppMultiplicity (f : X → Y) (m : X →₀ ℕ) :
   refine Finset.sum_congr rfl fun x hx => ?_
   rw [map_zsmul, pushforward_ofPoint]
 
-/-- The effective divisor `Σ x ∈ s, m x • [x]` attached to a finite set of points and
-natural-number multiplicities.  Points outside `s` have coefficient zero. -/
-def ofFinsetWithMultiplicity (s : Finset X) (m : X → ℕ) : WeilDivisor X :=
-  ofFinsuppMultiplicity (Finsupp.indicator s fun x _ => m x)
+/-! ### Finite-set specializations -/
 
-/-- Coefficient formula for a finite point divisor with multiplicities. -/
+/-- Coefficient formula for the `Finsupp.indicator` specialization of finitely supported
+multiplicities. -/
 @[simp]
-lemma coeff_ofFinsetWithMultiplicity [DecidableEq X] (s : Finset X) (m : X → ℕ) (x : X) :
-    coeff (ofFinsetWithMultiplicity s m) x = if x ∈ s then m x else 0 := by
-  simp [ofFinsetWithMultiplicity, Finsupp.indicator_apply]
+lemma coeff_ofFinsuppMultiplicity_indicator [DecidableEq X] (s : Finset X) (m : X → ℕ)
+    (x : X) :
+    coeff (ofFinsuppMultiplicity (Finsupp.indicator s fun x _ => m x)) x =
+      if x ∈ s then m x else 0 := by
+  simp [Finsupp.indicator_apply]
 
-/-- The `Finsupp.indicator` constructor agrees with the finite sum of point divisors. -/
-lemma ofFinsetWithMultiplicity_eq_sum (s : Finset X) (m : X → ℕ) :
-    ofFinsetWithMultiplicity s m = ∑ x ∈ s, (m x : ℤ) • ofPoint x := by
+/-- The `Finsupp.indicator` specialization agrees with the finite sum of point divisors. -/
+lemma ofFinsuppMultiplicity_indicator_eq_sum (s : Finset X) (m : X → ℕ) :
+    ofFinsuppMultiplicity (Finsupp.indicator s fun x _ => m x) =
+      ∑ x ∈ s, (m x : ℤ) • ofPoint x := by
   classical
   apply Finsupp.ext
   intro x
-  simp only [ofFinsetWithMultiplicity, ofFinsuppMultiplicity, Finsupp.mapRange_apply,
-    Finsupp.indicator_apply]
+  simp only [ofFinsuppMultiplicity, Finsupp.mapRange_apply, Finsupp.indicator_apply]
   by_cases hxs : x ∈ s
   · rw [dif_pos hxs]
     simp_rw [Finset.sum_apply']
@@ -177,123 +177,126 @@ lemma ofFinsetWithMultiplicity_eq_sum (s : Finset X) (m : X → ℕ) :
       simp [hpoint]).symm
 
 @[simp]
-lemma ofFinsetWithMultiplicity_empty (m : X → ℕ) :
-    ofFinsetWithMultiplicity (∅ : Finset X) m = 0 := by
+lemma ofFinsuppMultiplicity_indicator_empty (m : X → ℕ) :
+    ofFinsuppMultiplicity (Finsupp.indicator (∅ : Finset X) fun x _ => m x) = 0 := by
   classical
   ext x
-  rw [coeff_ofFinsetWithMultiplicity]
+  rw [coeff_ofFinsuppMultiplicity_indicator]
   simp
 
 @[simp]
-lemma ofFinsetWithMultiplicity_insert [DecidableEq X] {s : Finset X} {x : X}
+lemma ofFinsuppMultiplicity_indicator_insert [DecidableEq X] {s : Finset X} {x : X}
     (hx : x ∉ s) (m : X → ℕ) :
-    ofFinsetWithMultiplicity (insert x s) m =
-      (m x : ℤ) • ofPoint x + ofFinsetWithMultiplicity s m := by
-  rw [ofFinsetWithMultiplicity_eq_sum, ofFinsetWithMultiplicity_eq_sum]
+    ofFinsuppMultiplicity (Finsupp.indicator (insert x s) fun y _ => m y) =
+      (m x : ℤ) • ofPoint x +
+        ofFinsuppMultiplicity (Finsupp.indicator s fun y _ => m y) := by
+  rw [ofFinsuppMultiplicity_indicator_eq_sum, ofFinsuppMultiplicity_indicator_eq_sum]
   simp [hx]
 
-/-- Finite point divisors with natural multiplicities are effective. -/
+/-- The `Finsupp.indicator` specialization of finitely supported multiplicities is effective. -/
 @[simp]
-lemma isEffective_ofFinsetWithMultiplicity (s : Finset X) (m : X → ℕ) :
-    IsEffective (ofFinsetWithMultiplicity s m) := by
+lemma isEffective_ofFinsuppMultiplicity_indicator (s : Finset X) (m : X → ℕ) :
+    IsEffective (ofFinsuppMultiplicity (Finsupp.indicator s fun x _ => m x)) := by
   classical
-  rw [isEffective_iff]
-  intro x
-  rw [coeff_ofFinsetWithMultiplicity]
-  split
-  · exact Int.natCast_nonneg _
-  · rfl
+  simp
 
 @[simp]
-lemma ofFinsetWithMultiplicity_mem_effectiveSubmonoid (s : Finset X) (m : X → ℕ) :
-    ofFinsetWithMultiplicity s m ∈ effectiveSubmonoid X :=
-  (mem_effectiveSubmonoid _).mpr (isEffective_ofFinsetWithMultiplicity s m)
+lemma ofFinsuppMultiplicity_indicator_mem_effectiveSubmonoid (s : Finset X) (m : X → ℕ) :
+    ofFinsuppMultiplicity (Finsupp.indicator s fun x _ => m x) ∈ effectiveSubmonoid X :=
+  (mem_effectiveSubmonoid _).mpr (isEffective_ofFinsuppMultiplicity_indicator s m)
 
-/-- The support of a finite point divisor with multiplicities is contained in the chosen
-finite set.  Points in `s` whose multiplicity is zero may drop out of the support. -/
-lemma support_ofFinsetWithMultiplicity_subset (s : Finset X) (m : X → ℕ) :
-    (ofFinsetWithMultiplicity s m).support ⊆ s := by
+/-- The support of an indicator-specialized divisor is contained in the chosen finite set.
+Points in `s` whose multiplicity is zero may drop out of the support. -/
+lemma support_ofFinsuppMultiplicity_indicator_subset (s : Finset X) (m : X → ℕ) :
+    (ofFinsuppMultiplicity (Finsupp.indicator s fun x _ => m x)).support ⊆ s := by
   classical
   intro x hx
-  rw [mem_support_iff, coeff_ofFinsetWithMultiplicity] at hx
+  rw [mem_support_iff, coeff_ofFinsuppMultiplicity_indicator] at hx
   by_contra hxs
   simp [hxs] at hx
 
-/-- A point is in the support of a finite point divisor with multiplicities exactly when it is
-selected and has nonzero multiplicity. -/
-lemma mem_support_ofFinsetWithMultiplicity_iff {s : Finset X} {m : X → ℕ}
-    {x : X} :
-    x ∈ (ofFinsetWithMultiplicity s m).support ↔ x ∈ s ∧ m x ≠ 0 := by
+/-- A point is in the support of an indicator-specialized divisor exactly when it is selected
+and has nonzero multiplicity. -/
+lemma mem_support_ofFinsuppMultiplicity_indicator_iff {s : Finset X} {m : X → ℕ} {x : X} :
+    x ∈ (ofFinsuppMultiplicity (Finsupp.indicator s fun x _ => m x)).support ↔
+      x ∈ s ∧ m x ≠ 0 := by
   classical
-  rw [mem_support_iff, coeff_ofFinsetWithMultiplicity]
+  rw [mem_support_iff, coeff_ofFinsuppMultiplicity_indicator]
   by_cases hxs : x ∈ s <;> simp [hxs]
 
-/-- The degree of `Σ x ∈ s, m x • [x]` is the sum of the multiplicities. -/
+/-- The degree of an indicator-specialized divisor is the sum of the multiplicities. -/
 @[simp]
-lemma degree_ofFinsetWithMultiplicity (s : Finset X) (m : X → ℕ) :
-    degree (ofFinsetWithMultiplicity s m) = ∑ x ∈ s, (m x : ℤ) := by
+lemma degree_ofFinsuppMultiplicity_indicator (s : Finset X) (m : X → ℕ) :
+    degree (ofFinsuppMultiplicity (Finsupp.indicator s fun x _ => m x)) =
+      ∑ x ∈ s, (m x : ℤ) := by
   classical
-  simp [ofFinsetWithMultiplicity_eq_sum]
+  simp [ofFinsuppMultiplicity_indicator_eq_sum]
 
-/-- The weighted degree of `Σ x ∈ s, m x • [x]` is the corresponding weighted finite sum. -/
+/-- The weighted degree of an indicator-specialized divisor is the corresponding weighted
+finite sum. -/
 @[simp]
-lemma weightedDegree_ofFinsetWithMultiplicity (w : X → ℤ) (s : Finset X) (m : X → ℕ) :
-    weightedDegree w (ofFinsetWithMultiplicity s m) =
+lemma weightedDegree_ofFinsuppMultiplicity_indicator (w : X → ℤ) (s : Finset X) (m : X → ℕ) :
+    weightedDegree w (ofFinsuppMultiplicity (Finsupp.indicator s fun x _ => m x)) =
       ∑ x ∈ s, (m x : ℤ) * w x := by
   classical
-  simp [ofFinsetWithMultiplicity_eq_sum, mul_comm]
+  simp [ofFinsuppMultiplicity_indicator_eq_sum, mul_comm]
 
-/-- Pushing forward a finite point divisor applies the map to each point in the finite sum. -/
+/-- Pushing forward an indicator-specialized divisor applies the map to each point in the
+finite sum. -/
 @[simp]
-lemma pushforward_ofFinsetWithMultiplicity (f : X → Y) (s : Finset X) (m : X → ℕ) :
-    pushforward f (ofFinsetWithMultiplicity s m) =
+lemma pushforward_ofFinsuppMultiplicity_indicator (f : X → Y) (s : Finset X) (m : X → ℕ) :
+    pushforward f (ofFinsuppMultiplicity (Finsupp.indicator s fun x _ => m x)) =
       ∑ x ∈ s, (m x : ℤ) • ofPoint (f x) := by
   classical
-  rw [ofFinsetWithMultiplicity_eq_sum, map_sum]
+  rw [ofFinsuppMultiplicity_indicator_eq_sum, map_sum]
   refine Finset.sum_congr rfl fun x hx => ?_
   rw [map_zsmul, pushforward_ofPoint]
 
-/-- With positive weights, a finite point divisor has weighted degree zero exactly when every
-selected point has zero multiplicity. -/
-lemma weightedDegree_ofFinsetWithMultiplicity_eq_zero_iff_of_pos
+/-- With positive weights on the selected set, an indicator-specialized divisor has weighted
+degree zero exactly when every selected point has zero multiplicity. -/
+lemma weightedDegree_ofFinsuppMultiplicity_indicator_eq_zero_iff_of_pos
     (s : Finset X) {w : X → ℤ} (hw : ∀ x ∈ s, 0 < w x) (m : X → ℕ) :
-    weightedDegree w (ofFinsetWithMultiplicity s m) = 0 ↔ ∀ x ∈ s, m x = 0 := by
+    weightedDegree w (ofFinsuppMultiplicity (Finsupp.indicator s fun x _ => m x)) = 0 ↔
+      ∀ x ∈ s, m x = 0 := by
   classical
   constructor
   · intro hdeg x hx
+    rw [weightedDegree_ofFinsuppMultiplicity_indicator] at hdeg
     have hterm :
         (m x : ℤ) * w x = 0 :=
       (Finset.sum_eq_zero_iff_of_nonneg
         (fun y hy => mul_nonneg (Int.natCast_nonneg _) (le_of_lt (hw y hy)))).mp
-          (by simpa [weightedDegree_ofFinsetWithMultiplicity] using hdeg) x hx
+          hdeg x hx
     rcases mul_eq_zero.mp hterm with hmx | hwx
     · exact_mod_cast hmx
     · exact False.elim ((ne_of_gt (hw x hx)) hwx)
   · intro hm
-    rw [weightedDegree_ofFinsetWithMultiplicity]
+    rw [weightedDegree_ofFinsuppMultiplicity_indicator]
     exact Finset.sum_eq_zero fun x hx => by simp [hm x hx]
 
-/-- A finite point divisor with positive weights lies in the weighted degree-zero subgroup
-exactly when all selected multiplicities vanish. -/
-lemma ofFinsetWithMultiplicity_mem_weightedDegreeZeroSubgroup_iff_of_pos
+/-- An indicator-specialized divisor with positive weights on the selected set lies in the
+weighted degree-zero subgroup exactly when all selected multiplicities vanish. -/
+lemma ofFinsuppMultiplicity_indicator_mem_weightedDegreeZeroSubgroup_iff_of_pos
     (s : Finset X) {w : X → ℤ} (hw : ∀ x ∈ s, 0 < w x) (m : X → ℕ) :
-    ofFinsetWithMultiplicity s m ∈ weightedDegreeZeroSubgroup w ↔ ∀ x ∈ s, m x = 0 := by
+    ofFinsuppMultiplicity (Finsupp.indicator s fun x _ => m x) ∈
+      weightedDegreeZeroSubgroup w ↔ ∀ x ∈ s, m x = 0 := by
   rw [mem_weightedDegreeZeroSubgroup,
-    weightedDegree_ofFinsetWithMultiplicity_eq_zero_iff_of_pos s hw]
+    weightedDegree_ofFinsuppMultiplicity_indicator_eq_zero_iff_of_pos s hw]
 
-/-- A finite point divisor with multiplicities has unweighted degree zero exactly when every
-selected multiplicity vanishes. -/
-lemma ofFinsetWithMultiplicity_mem_degreeZeroSubgroup_iff (s : Finset X) (m : X → ℕ) :
-    ofFinsetWithMultiplicity s m ∈ degreeZeroSubgroup X ↔ ∀ x ∈ s, m x = 0 := by
+/-- An indicator-specialized divisor has unweighted degree zero exactly when every selected
+multiplicity vanishes. -/
+lemma ofFinsuppMultiplicity_indicator_mem_degreeZeroSubgroup_iff (s : Finset X) (m : X → ℕ) :
+    ofFinsuppMultiplicity (Finsupp.indicator s fun x _ => m x) ∈ degreeZeroSubgroup X ↔
+      ∀ x ∈ s, m x = 0 := by
   rw [mem_degreeZeroSubgroup, ← weightedDegree_one_eq_degree]
-  exact weightedDegree_ofFinsetWithMultiplicity_eq_zero_iff_of_pos
+  exact weightedDegree_ofFinsuppMultiplicity_indicator_eq_zero_iff_of_pos
     (w := fun _ : X => (1 : ℤ)) s (fun _ _ => zero_lt_one) m
 
 /-! ### Finite sums with coefficient one -/
 
 /-- The effective divisor `Σ x ∈ s, [x]` attached to a finite set of points. -/
 def ofFinset (s : Finset X) : WeilDivisor X :=
-  ofFinsetWithMultiplicity s fun _ => 1
+  ofFinsuppMultiplicity (Finsupp.indicator s fun _ _ => 1)
 
 @[simp]
 lemma ofFinset_empty : ofFinset (∅ : Finset X) = 0 := by
@@ -326,28 +329,30 @@ lemma ofFinset_mem_effectiveSubmonoid (s : Finset X) :
 lemma support_ofFinset (s : Finset X) : (ofFinset s).support = s := by
   classical
   ext x
-  rw [ofFinset, mem_support_ofFinsetWithMultiplicity_iff]
+  rw [ofFinset, mem_support_ofFinsuppMultiplicity_indicator_iff]
   simp
 
 /-- The degree of the coefficient-one divisor attached to a finite set is its cardinality. -/
 @[simp]
 lemma degree_ofFinset (s : Finset X) : degree (ofFinset s) = s.card := by
   classical
-  simp [ofFinset]
+  rw [ofFinset, degree_ofFinsuppMultiplicity_indicator]
+  simp
 
 /-- The weighted degree of the divisor attached to a finite set is the sum of weights on it. -/
 @[simp]
 lemma weightedDegree_ofFinset (w : X → ℤ) (s : Finset X) :
     weightedDegree w (ofFinset s) = ∑ x ∈ s, w x := by
   classical
-  simp [ofFinset]
+  rw [ofFinset, weightedDegree_ofFinsuppMultiplicity_indicator]
+  simp
 
 /-- Pushing forward the divisor attached to a finite set applies the map to each point. -/
 @[simp]
 lemma pushforward_ofFinset (f : X → Y) (s : Finset X) :
     pushforward f (ofFinset s) = ∑ x ∈ s, ofPoint (f x) := by
   classical
-  rw [ofFinset, pushforward_ofFinsetWithMultiplicity]
+  rw [ofFinset, pushforward_ofFinsuppMultiplicity_indicator]
   simp
 
 /-- For positive weights, a finite set divisor lies in the weighted degree-zero subgroup exactly
@@ -356,7 +361,7 @@ lemma ofFinset_mem_weightedDegreeZeroSubgroup_iff_of_pos
     (s : Finset X) {w : X → ℤ} (hw : ∀ x ∈ s, 0 < w x) :
     ofFinset s ∈ weightedDegreeZeroSubgroup w ↔ s = ∅ := by
   classical
-  rw [ofFinset, ofFinsetWithMultiplicity_mem_weightedDegreeZeroSubgroup_iff_of_pos s hw]
+  rw [ofFinset, ofFinsuppMultiplicity_indicator_mem_weightedDegreeZeroSubgroup_iff_of_pos s hw]
   constructor
   · intro h
     ext x
@@ -373,7 +378,7 @@ empty. -/
 lemma ofFinset_mem_degreeZeroSubgroup_iff (s : Finset X) :
     ofFinset s ∈ degreeZeroSubgroup X ↔ s = ∅ := by
   classical
-  rw [ofFinset, ofFinsetWithMultiplicity_mem_degreeZeroSubgroup_iff]
+  rw [ofFinset, ofFinsuppMultiplicity_indicator_mem_degreeZeroSubgroup_iff]
   constructor
   · intro h
     ext x

--- a/TauCeti/AlgebraicGeometry/WeilDivisor/FiniteSum.lean
+++ b/TauCeti/AlgebraicGeometry/WeilDivisor/FiniteSum.lean
@@ -64,7 +64,7 @@ private lemma coeff_sum_zsmul_ofPoint_of_notMem {s : Finset X} {a : X → ℤ} {
     have hxy : x ≠ y := fun h => hxs (h.symm ▸ hy)
     rw [← coeff, coeff_zsmul_ofPoint, coeff_ofPoint_of_ne hxy, mul_zero]
 
-/-! ### Finitely supported multiplicities via `Finsupp.mapRange` -/
+/-! ### Finitely supported multiplicities -/
 
 /-- Every Weil divisor is the finite sum of its coefficients times point divisors over its
 support. -/
@@ -78,24 +78,28 @@ lemma eq_sum_coeff_smul_ofPoint (D : WeilDivisor X) :
       simpa [mem_support_iff, coeff] using hxs
     rw [coeff_sum_zsmul_ofPoint_of_notMem hxs, hcoeff]
 
-/-- Coefficients of `Finsupp.mapRange` from natural multiplicities are the multiplicities. -/
+/-- The Weil divisor associated to finitely supported natural-number multiplicities. -/
+noncomputable def ofFinsupp (m : X →₀ ℕ) : WeilDivisor X :=
+  Finsupp.mapRange (fun n : ℕ => (n : ℤ)) (by simp) m
+
+/-- Coefficients of the raw `Finsupp.mapRange` implementation are the multiplicities. -/
 @[simp]
-lemma coeff_mapRange_natCast (m : X →₀ ℕ) (x : X) :
+private lemma coeff_mapRange_natCast (m : X →₀ ℕ) (x : X) :
     coeff (Finsupp.mapRange (fun n : ℕ => (n : ℤ)) (by simp) m : WeilDivisor X) x =
       m x := by
   simp [coeff]
 
-/-- Finitely supported natural multiplicities give effective divisors. -/
+/-- The raw `Finsupp.mapRange` implementation gives an effective divisor. -/
 @[simp]
-lemma isEffective_mapRange_natCast (m : X →₀ ℕ) :
+private lemma isEffective_mapRange_natCast (m : X →₀ ℕ) :
     IsEffective (Finsupp.mapRange (fun n : ℕ => (n : ℤ)) (by simp) m : WeilDivisor X) := by
   rw [isEffective_iff]
   intro x
   simp
 
-/-- The divisor from finitely supported multiplicities is the corresponding sum of point
-divisors over the support. -/
-lemma mapRange_natCast_eq_sum (m : X →₀ ℕ) :
+/-- The raw `Finsupp.mapRange` implementation is the corresponding sum of point divisors over the
+support. -/
+private lemma mapRange_natCast_eq_sum (m : X →₀ ℕ) :
     (Finsupp.mapRange (fun n : ℕ => (n : ℤ)) (by simp) m : WeilDivisor X) =
       ∑ x ∈ m.support, (m x : ℤ) • ofPoint x := by
   classical
@@ -107,10 +111,10 @@ lemma mapRange_natCast_eq_sum (m : X →₀ ℕ) :
     rw [coeff_mapRange_natCast, coeff_sum_zsmul_ofPoint_of_notMem hxs, hmx]
     simp
 
-/-- The support of the divisor from finitely supported natural multiplicities is the support
-of those multiplicities. -/
+/-- The support of the raw `Finsupp.mapRange` implementation is the support of the
+multiplicities. -/
 @[simp]
-lemma support_mapRange_natCast (m : X →₀ ℕ) :
+private lemma support_mapRange_natCast (m : X →₀ ℕ) :
     (Finsupp.mapRange (fun n : ℕ => (n : ℤ)) (by simp) m : WeilDivisor X).support =
       m.support := by
   classical
@@ -118,28 +122,28 @@ lemma support_mapRange_natCast (m : X →₀ ℕ) :
   rw [mem_support_iff, coeff_mapRange_natCast, Finsupp.mem_support_iff]
   exact Int.natCast_ne_zero
 
-/-- The degree of a divisor from finitely supported multiplicities is the sum over the support. -/
+/-- The degree of the raw `Finsupp.mapRange` implementation is the sum over the support. -/
 @[simp]
-lemma degree_mapRange_natCast (m : X →₀ ℕ) :
+private lemma degree_mapRange_natCast (m : X →₀ ℕ) :
     degree (Finsupp.mapRange (fun n : ℕ => (n : ℤ)) (by simp) m : WeilDivisor X) =
       ∑ x ∈ m.support, (m x : ℤ) := by
   classical
   simp [mapRange_natCast_eq_sum]
 
-/-- The weighted degree of a divisor from finitely supported multiplicities is the weighted
-sum over the support. -/
+/-- The weighted degree of the raw `Finsupp.mapRange` implementation is the weighted sum over the
+support. -/
 @[simp]
-lemma weightedDegree_mapRange_natCast (w : X → ℤ) (m : X →₀ ℕ) :
+private lemma weightedDegree_mapRange_natCast (w : X → ℤ) (m : X →₀ ℕ) :
     weightedDegree w
         (Finsupp.mapRange (fun n : ℕ => (n : ℤ)) (by simp) m : WeilDivisor X) =
       ∑ x ∈ m.support, (m x : ℤ) * w x := by
   classical
   simp [mapRange_natCast_eq_sum, mul_comm]
 
-/-- Pushing forward a divisor from finitely supported multiplicities applies the map to each
-point in the support sum. -/
+/-- Pushing forward the raw `Finsupp.mapRange` implementation applies the map to each point in the
+support sum. -/
 @[simp]
-lemma pushforward_mapRange_natCast (f : X → Y) (m : X →₀ ℕ) :
+private lemma pushforward_mapRange_natCast (f : X → Y) (m : X →₀ ℕ) :
     pushforward f
         (Finsupp.mapRange (fun n : ℕ => (n : ℤ)) (by simp) m : WeilDivisor X) =
       ∑ x ∈ m.support, (m x : ℤ) • ofPoint (f x) := by
@@ -148,9 +152,9 @@ lemma pushforward_mapRange_natCast (f : X → Y) (m : X →₀ ℕ) :
   refine Finset.sum_congr rfl fun x hx => ?_
   rw [map_zsmul, pushforward_ofPoint]
 
-/-- With positive weights on the support, a divisor from finitely supported multiplicities has
-weighted degree zero exactly when all multiplicities vanish. -/
-lemma weightedDegree_mapRange_natCast_eq_zero_iff_of_pos
+/-- With positive weights on the support, the raw `Finsupp.mapRange` implementation has weighted
+degree zero exactly when all multiplicities vanish. -/
+private lemma weightedDegree_mapRange_natCast_eq_zero_iff_of_pos
     (m : X →₀ ℕ) {w : X → ℤ} (hw : ∀ x ∈ m.support, 0 < w x) :
     weightedDegree w
         (Finsupp.mapRange (fun n : ℕ => (n : ℤ)) (by simp) m : WeilDivisor X) = 0 ↔
@@ -169,9 +173,9 @@ lemma weightedDegree_mapRange_natCast_eq_zero_iff_of_pos
   · intro hm
     simp [hm]
 
-/-- With positive weights on the support, a divisor from finitely supported multiplicities lies
-in the weighted degree-zero subgroup exactly when all multiplicities vanish. -/
-lemma mapRange_natCast_mem_weightedDegreeZeroSubgroup_iff_of_pos
+/-- With positive weights on the support, the raw `Finsupp.mapRange` implementation lies in the
+weighted degree-zero subgroup exactly when all multiplicities vanish. -/
+private lemma mapRange_natCast_mem_weightedDegreeZeroSubgroup_iff_of_pos
     (m : X →₀ ℕ) {w : X → ℤ} (hw : ∀ x ∈ m.support, 0 < w x) :
     (Finsupp.mapRange (fun n : ℕ => (n : ℤ)) (by simp) m : WeilDivisor X) ∈
         weightedDegreeZeroSubgroup w ↔
@@ -179,15 +183,82 @@ lemma mapRange_natCast_mem_weightedDegreeZeroSubgroup_iff_of_pos
   rw [mem_weightedDegreeZeroSubgroup,
     weightedDegree_mapRange_natCast_eq_zero_iff_of_pos m hw]
 
-/-- A divisor from finitely supported multiplicities has unweighted degree zero exactly when all
+/-- The raw `Finsupp.mapRange` implementation has unweighted degree zero exactly when all
 multiplicities vanish. -/
-lemma mapRange_natCast_mem_degreeZeroSubgroup_iff (m : X →₀ ℕ) :
+private lemma mapRange_natCast_mem_degreeZeroSubgroup_iff (m : X →₀ ℕ) :
     (Finsupp.mapRange (fun n : ℕ => (n : ℤ)) (by simp) m : WeilDivisor X) ∈
         degreeZeroSubgroup X ↔
       m = 0 := by
   rw [mem_degreeZeroSubgroup, ← weightedDegree_one_eq_degree]
   exact weightedDegree_mapRange_natCast_eq_zero_iff_of_pos
     (w := fun _ : X => (1 : ℤ)) m (fun _ _ => zero_lt_one)
+
+/-- Coefficients of the divisor from finitely supported natural multiplicities are the
+multiplicities. -/
+@[simp]
+lemma coeff_ofFinsupp (m : X →₀ ℕ) (x : X) :
+    coeff (ofFinsupp m : WeilDivisor X) x = m x := by
+  exact coeff_mapRange_natCast m x
+
+/-- Finitely supported natural multiplicities give effective divisors. -/
+@[simp]
+lemma isEffective_ofFinsupp (m : X →₀ ℕ) : IsEffective (ofFinsupp m : WeilDivisor X) := by
+  exact isEffective_mapRange_natCast m
+
+/-- A divisor from finitely supported multiplicities is the corresponding sum of point divisors
+over the support. -/
+lemma ofFinsupp_eq_sum (m : X →₀ ℕ) :
+    ofFinsupp m = ∑ x ∈ m.support, (m x : ℤ) • ofPoint x := by
+  exact mapRange_natCast_eq_sum m
+
+/-- The support of a divisor from finitely supported natural multiplicities is the support of
+those multiplicities. -/
+@[simp]
+lemma support_ofFinsupp (m : X →₀ ℕ) :
+    (ofFinsupp m : WeilDivisor X).support = m.support := by
+  exact support_mapRange_natCast m
+
+/-- The degree of a divisor from finitely supported multiplicities is the sum over the support. -/
+@[simp]
+lemma degree_ofFinsupp (m : X →₀ ℕ) :
+    degree (ofFinsupp m : WeilDivisor X) = ∑ x ∈ m.support, (m x : ℤ) := by
+  exact degree_mapRange_natCast m
+
+/-- The weighted degree of a divisor from finitely supported multiplicities is the weighted sum over
+the support. -/
+@[simp]
+lemma weightedDegree_ofFinsupp (w : X → ℤ) (m : X →₀ ℕ) :
+    weightedDegree w (ofFinsupp m : WeilDivisor X) =
+      ∑ x ∈ m.support, (m x : ℤ) * w x := by
+  exact weightedDegree_mapRange_natCast w m
+
+/-- Pushing forward a divisor from finitely supported multiplicities applies the map to each point
+in the support sum. -/
+@[simp]
+lemma pushforward_ofFinsupp (f : X → Y) (m : X →₀ ℕ) :
+    pushforward f (ofFinsupp m : WeilDivisor X) =
+      ∑ x ∈ m.support, (m x : ℤ) • ofPoint (f x) := by
+  exact pushforward_mapRange_natCast f m
+
+/-- With positive weights on the support, a divisor from finitely supported multiplicities has
+weighted degree zero exactly when all multiplicities vanish. -/
+lemma weightedDegree_ofFinsupp_eq_zero_iff_of_pos
+    (m : X →₀ ℕ) {w : X → ℤ} (hw : ∀ x ∈ m.support, 0 < w x) :
+    weightedDegree w (ofFinsupp m : WeilDivisor X) = 0 ↔ m = 0 := by
+  exact weightedDegree_mapRange_natCast_eq_zero_iff_of_pos m hw
+
+/-- With positive weights on the support, a divisor from finitely supported multiplicities lies in
+the weighted degree-zero subgroup exactly when all multiplicities vanish. -/
+lemma ofFinsupp_mem_weightedDegreeZeroSubgroup_iff_of_pos
+    (m : X →₀ ℕ) {w : X → ℤ} (hw : ∀ x ∈ m.support, 0 < w x) :
+    (ofFinsupp m : WeilDivisor X) ∈ weightedDegreeZeroSubgroup w ↔ m = 0 := by
+  exact mapRange_natCast_mem_weightedDegreeZeroSubgroup_iff_of_pos m hw
+
+/-- A divisor from finitely supported multiplicities has unweighted degree zero exactly when all
+multiplicities vanish. -/
+lemma ofFinsupp_mem_degreeZeroSubgroup_iff (m : X →₀ ℕ) :
+    (ofFinsupp m : WeilDivisor X) ∈ degreeZeroSubgroup X ↔ m = 0 := by
+  exact mapRange_natCast_mem_degreeZeroSubgroup_iff m
 
 /-! ### Finite-set multiplicities via `Finsupp.indicator` -/
 
@@ -201,14 +272,14 @@ noncomputable def ofFinset (s : Finset X) : WeilDivisor X :=
 
 /-- Coefficient formula for `Finsupp.indicator` with integer coefficients. -/
 @[simp]
-lemma coeff_indicator_int [DecidableEq X] (s : Finset X) (a : X → ℤ) (x : X) :
+private lemma coeff_indicator_int [DecidableEq X] (s : Finset X) (a : X → ℤ) (x : X) :
     coeff (Finsupp.indicator s (fun x _ => a x) : WeilDivisor X) x =
       if x ∈ s then a x else 0 := by
   simp [coeff, Finsupp.indicator_apply]
 
 /-- The `Finsupp.indicator` divisor with integer coefficients agrees with the corresponding
 finite sum of point divisors. -/
-lemma indicator_int_eq_sum (s : Finset X) (a : X → ℤ) :
+private lemma indicator_int_eq_sum (s : Finset X) (a : X → ℤ) :
     (Finsupp.indicator s (fun x _ => a x) : WeilDivisor X) =
       ∑ x ∈ s, a x • ofPoint x := by
   classical
@@ -219,7 +290,7 @@ lemma indicator_int_eq_sum (s : Finset X) (a : X → ℤ) :
 
 /-- The degree of `Finsupp.indicator` with integer coefficients is the sum of the coefficients. -/
 @[simp]
-lemma degree_indicator_int (s : Finset X) (a : X → ℤ) :
+private lemma degree_indicator_int (s : Finset X) (a : X → ℤ) :
     degree (Finsupp.indicator s (fun x _ => a x) : WeilDivisor X) =
       ∑ x ∈ s, a x := by
   classical
@@ -228,7 +299,7 @@ lemma degree_indicator_int (s : Finset X) (a : X → ℤ) :
 /-- The weighted degree of `Finsupp.indicator` with integer coefficients is the corresponding
 weighted finite sum. -/
 @[simp]
-lemma weightedDegree_indicator_int (w : X → ℤ) (s : Finset X) (a : X → ℤ) :
+private lemma weightedDegree_indicator_int (w : X → ℤ) (s : Finset X) (a : X → ℤ) :
     weightedDegree w (Finsupp.indicator s (fun x _ => a x) : WeilDivisor X) =
       ∑ x ∈ s, a x * w x := by
   classical
@@ -237,7 +308,7 @@ lemma weightedDegree_indicator_int (w : X → ℤ) (s : Finset X) (a : X → ℤ
 /-- Pushing forward `Finsupp.indicator` with integer coefficients applies the map to each point
 in the finite sum. -/
 @[simp]
-lemma pushforward_indicator_int (f : X → Y) (s : Finset X) (a : X → ℤ) :
+private lemma pushforward_indicator_int (f : X → Y) (s : Finset X) (a : X → ℤ) :
     pushforward f (Finsupp.indicator s (fun x _ => a x) : WeilDivisor X) =
       ∑ x ∈ s, a x • ofPoint (f x) := by
   classical
@@ -247,21 +318,21 @@ lemma pushforward_indicator_int (f : X → Y) (s : Finset X) (a : X → ℤ) :
 
 /-- Coefficient formula for `Finsupp.indicator` with natural-number multiplicities. -/
 @[simp]
-lemma coeff_indicator_nat [DecidableEq X] (s : Finset X) (m : X → ℕ) (x : X) :
+private lemma coeff_indicator_nat [DecidableEq X] (s : Finset X) (m : X → ℕ) (x : X) :
     coeff (Finsupp.indicator s (fun x _ => (m x : ℤ)) : WeilDivisor X) x =
       if x ∈ s then m x else 0 := by
   simp
 
 /-- The `Finsupp.indicator` divisor with multiplicities agrees with the corresponding finite sum
 of point divisors. -/
-lemma indicator_nat_eq_sum (s : Finset X) (m : X → ℕ) :
+private lemma indicator_nat_eq_sum (s : Finset X) (m : X → ℕ) :
     (Finsupp.indicator s (fun x _ => (m x : ℤ)) : WeilDivisor X) =
       ∑ x ∈ s, (m x : ℤ) • ofPoint x := by
   exact indicator_int_eq_sum s fun x => (m x : ℤ)
 
 /-- The `Finsupp.indicator` divisor with natural multiplicities over the empty set is zero. -/
 @[simp]
-lemma indicator_nat_empty (m : X → ℕ) :
+private lemma indicator_nat_empty (m : X → ℕ) :
     (Finsupp.indicator (∅ : Finset X) (fun x _ => (m x : ℤ)) : WeilDivisor X) = 0 := by
   classical
   ext x
@@ -269,7 +340,7 @@ lemma indicator_nat_empty (m : X → ℕ) :
 
 /-- Inserting a new point in `Finsupp.indicator` splits off its weighted point divisor. -/
 @[simp]
-lemma indicator_nat_insert [DecidableEq X] {s : Finset X} {x : X}
+private lemma indicator_nat_insert [DecidableEq X] {s : Finset X} {x : X}
     (hx : x ∉ s) (m : X → ℕ) :
     (Finsupp.indicator (insert x s) (fun y _ => (m y : ℤ)) : WeilDivisor X) =
       (m x : ℤ) • ofPoint x + Finsupp.indicator s (fun y _ => (m y : ℤ)) := by
@@ -278,7 +349,7 @@ lemma indicator_nat_insert [DecidableEq X] {s : Finset X} {x : X}
 
 /-- `Finsupp.indicator` with natural-number multiplicities is an effective divisor. -/
 @[simp]
-lemma isEffective_indicator_nat (s : Finset X) (m : X → ℕ) :
+private lemma isEffective_indicator_nat (s : Finset X) (m : X → ℕ) :
     IsEffective (Finsupp.indicator s (fun x _ => (m x : ℤ)) : WeilDivisor X) := by
   classical
   rw [isEffective_iff]
@@ -289,20 +360,20 @@ lemma isEffective_indicator_nat (s : Finset X) (m : X → ℕ) :
 /-- `Finsupp.indicator` with natural-number multiplicities belongs to the effective divisor
 submonoid. -/
 @[simp]
-lemma indicator_nat_mem_effectiveSubmonoid (s : Finset X) (m : X → ℕ) :
+private lemma indicator_nat_mem_effectiveSubmonoid (s : Finset X) (m : X → ℕ) :
     (Finsupp.indicator s (fun x _ => (m x : ℤ)) : WeilDivisor X) ∈ effectiveSubmonoid X :=
   (mem_effectiveSubmonoid _).mpr (isEffective_indicator_nat s m)
 
 /-- The support of `Finsupp.indicator` with multiplicities is contained in the chosen finite set.
 Points in the set whose multiplicity is zero may drop out of the support. -/
-lemma support_indicator_nat_subset (s : Finset X) (m : X → ℕ) :
+private lemma support_indicator_nat_subset (s : Finset X) (m : X → ℕ) :
     (Finsupp.indicator s (fun x _ => (m x : ℤ)) : WeilDivisor X).support ⊆ s :=
   Finsupp.support_indicator_subset s (fun x _ => (m x : ℤ))
 
 /-- A point is in the support of `Finsupp.indicator` with multiplicities exactly when it is
 selected and has nonzero multiplicity. -/
 @[simp]
-lemma mem_support_indicator_nat_iff {s : Finset X} {m : X → ℕ} {x : X} :
+private lemma mem_support_indicator_nat_iff {s : Finset X} {m : X → ℕ} {x : X} :
     x ∈ (Finsupp.indicator s (fun x _ => (m x : ℤ)) : WeilDivisor X).support ↔
       x ∈ s ∧ m x ≠ 0 := by
   classical
@@ -311,7 +382,7 @@ lemma mem_support_indicator_nat_iff {s : Finset X} {m : X → ℕ} {x : X} :
 
 /-- The degree of `Finsupp.indicator` with multiplicities is the sum of the multiplicities. -/
 @[simp]
-lemma degree_indicator_nat (s : Finset X) (m : X → ℕ) :
+private lemma degree_indicator_nat (s : Finset X) (m : X → ℕ) :
     degree (Finsupp.indicator s (fun x _ => (m x : ℤ)) : WeilDivisor X) =
       ∑ x ∈ s, (m x : ℤ) := by
   exact degree_indicator_int s fun x => (m x : ℤ)
@@ -319,7 +390,7 @@ lemma degree_indicator_nat (s : Finset X) (m : X → ℕ) :
 /-- The weighted degree of `Finsupp.indicator` with multiplicities is the corresponding weighted
 finite sum. -/
 @[simp]
-lemma weightedDegree_indicator_nat (w : X → ℤ) (s : Finset X) (m : X → ℕ) :
+private lemma weightedDegree_indicator_nat (w : X → ℤ) (s : Finset X) (m : X → ℕ) :
     weightedDegree w (Finsupp.indicator s (fun x _ => (m x : ℤ)) : WeilDivisor X) =
       ∑ x ∈ s, (m x : ℤ) * w x := by
   exact weightedDegree_indicator_int w s fun x => (m x : ℤ)
@@ -327,14 +398,14 @@ lemma weightedDegree_indicator_nat (w : X → ℤ) (s : Finset X) (m : X → ℕ
 /-- Pushing forward `Finsupp.indicator` with multiplicities applies the map to each point in the
 finite sum. -/
 @[simp]
-lemma pushforward_indicator_nat (f : X → Y) (s : Finset X) (m : X → ℕ) :
+private lemma pushforward_indicator_nat (f : X → Y) (s : Finset X) (m : X → ℕ) :
     pushforward f (Finsupp.indicator s (fun x _ => (m x : ℤ)) : WeilDivisor X) =
       ∑ x ∈ s, (m x : ℤ) • ofPoint (f x) := by
   exact pushforward_indicator_int f s fun x => (m x : ℤ)
 
 /-- With positive weights at the selected points with nonzero multiplicity, an indicator divisor
 with multiplicities has weighted degree zero exactly when every selected multiplicity vanishes. -/
-lemma weightedDegree_indicator_nat_eq_zero_iff_of_pos
+private lemma weightedDegree_indicator_nat_eq_zero_iff_of_pos
     (s : Finset X) {w : X → ℤ} (m : X → ℕ) (hw : ∀ x ∈ s, m x ≠ 0 → 0 < w x) :
     weightedDegree w (Finsupp.indicator s (fun x _ => (m x : ℤ)) : WeilDivisor X) = 0 ↔
       ∀ x ∈ s, m x = 0 := by
@@ -357,7 +428,7 @@ lemma weightedDegree_indicator_nat_eq_zero_iff_of_pos
 
 /-- An indicator divisor with positive weights at selected points with nonzero multiplicity lies
 in the weighted degree-zero subgroup exactly when all selected multiplicities vanish. -/
-lemma indicator_nat_mem_weightedDegreeZeroSubgroup_iff_of_pos
+private lemma indicator_nat_mem_weightedDegreeZeroSubgroup_iff_of_pos
     (s : Finset X) {w : X → ℤ} (m : X → ℕ) (hw : ∀ x ∈ s, m x ≠ 0 → 0 < w x) :
     (Finsupp.indicator s (fun x _ => (m x : ℤ)) : WeilDivisor X) ∈
         weightedDegreeZeroSubgroup w ↔
@@ -366,7 +437,7 @@ lemma indicator_nat_mem_weightedDegreeZeroSubgroup_iff_of_pos
 
 /-- An indicator divisor with multiplicities has unweighted degree zero exactly when every
 selected multiplicity vanishes. -/
-lemma indicator_nat_mem_degreeZeroSubgroup_iff (s : Finset X) (m : X → ℕ) :
+private lemma indicator_nat_mem_degreeZeroSubgroup_iff (s : Finset X) (m : X → ℕ) :
     (Finsupp.indicator s (fun x _ => (m x : ℤ)) : WeilDivisor X) ∈ degreeZeroSubgroup X ↔
       ∀ x ∈ s, m x = 0 := by
   rw [mem_degreeZeroSubgroup, ← weightedDegree_one_eq_degree]
@@ -478,46 +549,46 @@ lemma ofFinsetWithMultiplicity_mem_degreeZeroSubgroup_iff (s : Finset X) (m : X 
 
 /-- The coefficient-one `Finsupp.indicator` divisor is the corresponding finite sum of point
 divisors. -/
-lemma indicator_one_eq_sum (s : Finset X) :
+private lemma indicator_one_eq_sum (s : Finset X) :
     (Finsupp.indicator s (fun _ _ => (1 : ℤ)) : WeilDivisor X) = ∑ x ∈ s, ofPoint x := by
   simpa using indicator_nat_eq_sum (s := s) (m := fun _ : X => 1)
 
 /-- The coefficient-one `Finsupp.indicator` divisor over the empty set is zero. -/
 @[simp]
-lemma indicator_one_empty :
+private lemma indicator_one_empty :
     (Finsupp.indicator (∅ : Finset X) (fun _ _ => (1 : ℤ)) : WeilDivisor X) = 0 := by
   simpa using indicator_nat_empty (X := X) (fun _ : X => 1)
 
 /-- Inserting a new point in a coefficient-one indicator splits off its point divisor. -/
 @[simp]
-lemma indicator_one_insert [DecidableEq X] {s : Finset X} {x : X} (hx : x ∉ s) :
+private lemma indicator_one_insert [DecidableEq X] {s : Finset X} {x : X} (hx : x ∉ s) :
     (Finsupp.indicator (insert x s) (fun _ _ => (1 : ℤ)) : WeilDivisor X) =
       ofPoint x + Finsupp.indicator s (fun _ _ => (1 : ℤ)) := by
   simpa using indicator_nat_insert (s := s) (x := x) hx (fun _ : X => 1)
 
 /-- Coefficients of the coefficient-one indicator divisor are `1` on the set and `0` off it. -/
 @[simp]
-lemma coeff_indicator_one [DecidableEq X] (s : Finset X) (x : X) :
+private lemma coeff_indicator_one [DecidableEq X] (s : Finset X) (x : X) :
     coeff (Finsupp.indicator s (fun _ _ => (1 : ℤ)) : WeilDivisor X) x =
       if x ∈ s then 1 else 0 := by
   simp [coeff, Finsupp.indicator_apply]
 
 /-- The coefficient-one indicator divisor is effective. -/
 @[simp]
-lemma isEffective_indicator_one (s : Finset X) :
+private lemma isEffective_indicator_one (s : Finset X) :
     IsEffective (Finsupp.indicator s (fun _ _ => (1 : ℤ)) : WeilDivisor X) := by
   classical
   simpa using isEffective_indicator_nat (X := X) s (fun _ => 1)
 
 /-- The coefficient-one indicator divisor belongs to the effective divisor submonoid. -/
 @[simp]
-lemma indicator_one_mem_effectiveSubmonoid (s : Finset X) :
+private lemma indicator_one_mem_effectiveSubmonoid (s : Finset X) :
     (Finsupp.indicator s (fun _ _ => (1 : ℤ)) : WeilDivisor X) ∈ effectiveSubmonoid X :=
   (mem_effectiveSubmonoid _).mpr (isEffective_indicator_one s)
 
 /-- The support of the coefficient-one indicator divisor is exactly the chosen finite set. -/
 @[simp]
-lemma support_indicator_one (s : Finset X) :
+private lemma support_indicator_one (s : Finset X) :
     (Finsupp.indicator s (fun _ _ => (1 : ℤ)) : WeilDivisor X).support = s := by
   classical
   ext x
@@ -525,14 +596,14 @@ lemma support_indicator_one (s : Finset X) :
 
 /-- The degree of the coefficient-one indicator divisor is the finite set's cardinality. -/
 @[simp]
-lemma degree_indicator_one (s : Finset X) :
+private lemma degree_indicator_one (s : Finset X) :
     degree (Finsupp.indicator s (fun _ _ => (1 : ℤ)) : WeilDivisor X) = s.card := by
   classical
   simp
 
 /-- The weighted degree of the coefficient-one indicator divisor is the sum of weights on it. -/
 @[simp]
-lemma weightedDegree_indicator_one (w : X → ℤ) (s : Finset X) :
+private lemma weightedDegree_indicator_one (w : X → ℤ) (s : Finset X) :
     weightedDegree w (Finsupp.indicator s (fun _ _ => (1 : ℤ)) : WeilDivisor X) =
       ∑ x ∈ s, w x := by
   classical
@@ -540,7 +611,7 @@ lemma weightedDegree_indicator_one (w : X → ℤ) (s : Finset X) :
 
 /-- Pushing forward the coefficient-one indicator divisor applies the map to each point. -/
 @[simp]
-lemma pushforward_indicator_one (f : X → Y) (s : Finset X) :
+private lemma pushforward_indicator_one (f : X → Y) (s : Finset X) :
     pushforward f (Finsupp.indicator s (fun _ _ => (1 : ℤ)) : WeilDivisor X) =
       ∑ x ∈ s, ofPoint (f x) := by
   classical
@@ -561,7 +632,7 @@ private lemma forall_mem_one_eq_zero_iff_empty (s : Finset X) :
 
 /-- For positive weights, a coefficient-one indicator divisor lies in the weighted degree-zero
 subgroup exactly when the finite set is empty. -/
-lemma indicator_one_mem_weightedDegreeZeroSubgroup_iff_of_pos
+private lemma indicator_one_mem_weightedDegreeZeroSubgroup_iff_of_pos
     (s : Finset X) {w : X → ℤ} (hw : ∀ x ∈ s, 0 < w x) :
     (Finsupp.indicator s (fun _ _ => (1 : ℤ)) : WeilDivisor X) ∈
         weightedDegreeZeroSubgroup w ↔
@@ -572,7 +643,7 @@ lemma indicator_one_mem_weightedDegreeZeroSubgroup_iff_of_pos
     (forall_mem_one_eq_zero_iff_empty s)
 
 /-- A coefficient-one indicator divisor has unweighted degree zero exactly when the set is empty. -/
-lemma indicator_one_mem_degreeZeroSubgroup_iff (s : Finset X) :
+private lemma indicator_one_mem_degreeZeroSubgroup_iff (s : Finset X) :
     (Finsupp.indicator s (fun _ _ => (1 : ℤ)) : WeilDivisor X) ∈ degreeZeroSubgroup X ↔
       s = ∅ := by
   classical

--- a/TauCeti/AlgebraicGeometry/WeilDivisor/FiniteSum.lean
+++ b/TauCeti/AlgebraicGeometry/WeilDivisor/FiniteSum.lean
@@ -139,32 +139,6 @@ lemma pushforward_ofFinsuppMultiplicity (f : X → Y) (m : X →₀ ℕ) :
   refine Finset.sum_congr rfl fun x hx => ?_
   rw [map_zsmul, pushforward_ofPoint]
 
-/-- With strictly positive weights on the support, an effective divisor has weighted degree
-zero iff it is zero. -/
-lemma IsEffective.weightedDegree_eq_zero_iff_of_pos_on_support {w : X → ℤ}
-    {D : WeilDivisor X} (hD : IsEffective D) (hw : ∀ x ∈ D.support, 0 < w x) :
-    weightedDegree w D = 0 ↔ D = 0 := by
-  constructor
-  · intro hdeg
-    by_contra hD0
-    obtain ⟨x, hxpos⟩ := hD.exists_pos_coeff_of_ne_zero hD0
-    have hxs : x ∈ D.support := Finsupp.mem_support_iff.mpr (ne_of_gt hxpos)
-    have hsum_pos : 0 < D.sum fun y n => n * w y := by
-      exact Finsupp.sum_pos'
-        (fun y hy => mul_nonneg ((isEffective_iff D).mp hD y) (le_of_lt (hw y hy)))
-        ⟨x, hxs, mul_pos hxpos (hw x hxs)⟩
-    rw [← weightedDegree_apply] at hsum_pos
-    exact (ne_of_gt hsum_pos) hdeg
-  · intro h
-    simp [h]
-
-/-- With strictly positive weights on the support, an effective divisor of weighted degree zero
-is zero. -/
-lemma IsEffective.eq_zero_of_weightedDegree_eq_zero_of_pos_on_support {w : X → ℤ}
-    {D : WeilDivisor X} (hD : IsEffective D) (hw : ∀ x ∈ D.support, 0 < w x)
-    (hdeg : weightedDegree w D = 0) : D = 0 :=
-  (hD.weightedDegree_eq_zero_iff_of_pos_on_support hw).mp hdeg
-
 /-! ### Finite-set multiplicities via `Finsupp.indicator` -/
 
 /-- The effective divisor whose coefficients on `s` are the natural-number multiplicities `m`

--- a/TauCeti/AlgebraicGeometry/WeilDivisor/FiniteSum.lean
+++ b/TauCeti/AlgebraicGeometry/WeilDivisor/FiniteSum.lean
@@ -172,19 +172,19 @@ lemma IsEffective.eq_zero_of_weightedDegree_eq_zero_of_pos_on_support {w : X →
 
 /-- The effective divisor whose coefficients on `s` are the natural-number multiplicities `m`
 and whose coefficients off `s` are zero. -/
-@[expose] def ofFinsetWithMultiplicity (s : Finset X) (m : X → ℕ) : WeilDivisor X :=
+def ofFinsetWithMultiplicity (s : Finset X) (m : X → ℕ) : WeilDivisor X :=
   Finsupp.indicator s (fun x _ => (m x : ℤ))
 
 /-- Coefficient formula for `Finsupp.indicator` with natural-number multiplicities. -/
 @[simp]
-lemma coeff_indicator_nat [DecidableEq X] (s : Finset X) (m : X → ℕ) (x : X) :
+private lemma coeff_indicator_nat [DecidableEq X] (s : Finset X) (m : X → ℕ) (x : X) :
     coeff (Finsupp.indicator s (fun x _ => (m x : ℤ)) : WeilDivisor X) x =
       if x ∈ s then m x else 0 := by
   simp [coeff, Finsupp.indicator_apply]
 
 /-- The `Finsupp.indicator` divisor with multiplicities agrees with the corresponding finite sum
 of point divisors. -/
-lemma indicator_nat_eq_sum (s : Finset X) (m : X → ℕ) :
+private lemma indicator_nat_eq_sum (s : Finset X) (m : X → ℕ) :
     (Finsupp.indicator s (fun x _ => (m x : ℤ)) : WeilDivisor X) =
       ∑ x ∈ s, (m x : ℤ) • ofPoint x := by
   classical
@@ -195,14 +195,15 @@ lemma indicator_nat_eq_sum (s : Finset X) (m : X → ℕ) :
     simp
 
 @[simp]
-lemma indicator_nat_empty (m : X → ℕ) :
+private lemma indicator_nat_empty (m : X → ℕ) :
     (Finsupp.indicator (∅ : Finset X) (fun x _ => (m x : ℤ)) : WeilDivisor X) = 0 := by
   classical
   ext x
   simp
 
 @[simp]
-lemma indicator_nat_insert [DecidableEq X] {s : Finset X} {x : X} (hx : x ∉ s) (m : X → ℕ) :
+private lemma indicator_nat_insert [DecidableEq X] {s : Finset X} {x : X}
+    (hx : x ∉ s) (m : X → ℕ) :
     (Finsupp.indicator (insert x s) (fun y _ => (m y : ℤ)) : WeilDivisor X) =
       (m x : ℤ) • ofPoint x + Finsupp.indicator s (fun y _ => (m y : ℤ)) := by
   rw [indicator_nat_eq_sum, indicator_nat_eq_sum]
@@ -210,7 +211,7 @@ lemma indicator_nat_insert [DecidableEq X] {s : Finset X} {x : X} (hx : x ∉ s)
 
 /-- `Finsupp.indicator` with natural-number multiplicities is an effective divisor. -/
 @[simp]
-lemma isEffective_indicator_nat (s : Finset X) (m : X → ℕ) :
+private lemma isEffective_indicator_nat (s : Finset X) (m : X → ℕ) :
     IsEffective (Finsupp.indicator s (fun x _ => (m x : ℤ)) : WeilDivisor X) := by
   classical
   rw [isEffective_iff]
@@ -219,20 +220,20 @@ lemma isEffective_indicator_nat (s : Finset X) (m : X → ℕ) :
   split_ifs <;> simp
 
 @[simp]
-lemma indicator_nat_mem_effectiveSubmonoid (s : Finset X) (m : X → ℕ) :
+private lemma indicator_nat_mem_effectiveSubmonoid (s : Finset X) (m : X → ℕ) :
     (Finsupp.indicator s (fun x _ => (m x : ℤ)) : WeilDivisor X) ∈ effectiveSubmonoid X :=
   (mem_effectiveSubmonoid _).mpr (isEffective_indicator_nat s m)
 
 /-- The support of `Finsupp.indicator` with multiplicities is contained in the chosen finite set.
 Points in the set whose multiplicity is zero may drop out of the support. -/
-lemma support_indicator_nat_subset (s : Finset X) (m : X → ℕ) :
+private lemma support_indicator_nat_subset (s : Finset X) (m : X → ℕ) :
     (Finsupp.indicator s (fun x _ => (m x : ℤ)) : WeilDivisor X).support ⊆ s :=
   Finsupp.support_indicator_subset s (fun x _ => (m x : ℤ))
 
 /-- A point is in the support of `Finsupp.indicator` with multiplicities exactly when it is
 selected and has nonzero multiplicity. -/
 @[simp]
-lemma mem_support_indicator_nat_iff {s : Finset X} {m : X → ℕ} {x : X} :
+private lemma mem_support_indicator_nat_iff {s : Finset X} {m : X → ℕ} {x : X} :
     x ∈ (Finsupp.indicator s (fun x _ => (m x : ℤ)) : WeilDivisor X).support ↔
       x ∈ s ∧ m x ≠ 0 := by
   classical
@@ -241,7 +242,7 @@ lemma mem_support_indicator_nat_iff {s : Finset X} {m : X → ℕ} {x : X} :
 
 /-- The degree of `Finsupp.indicator` with multiplicities is the sum of the multiplicities. -/
 @[simp]
-lemma degree_indicator_nat (s : Finset X) (m : X → ℕ) :
+private lemma degree_indicator_nat (s : Finset X) (m : X → ℕ) :
     degree (Finsupp.indicator s (fun x _ => (m x : ℤ)) : WeilDivisor X) =
       ∑ x ∈ s, (m x : ℤ) := by
   classical
@@ -250,7 +251,7 @@ lemma degree_indicator_nat (s : Finset X) (m : X → ℕ) :
 /-- The weighted degree of `Finsupp.indicator` with multiplicities is the corresponding weighted
 finite sum. -/
 @[simp]
-lemma weightedDegree_indicator_nat (w : X → ℤ) (s : Finset X) (m : X → ℕ) :
+private lemma weightedDegree_indicator_nat (w : X → ℤ) (s : Finset X) (m : X → ℕ) :
     weightedDegree w (Finsupp.indicator s (fun x _ => (m x : ℤ)) : WeilDivisor X) =
       ∑ x ∈ s, (m x : ℤ) * w x := by
   classical
@@ -259,7 +260,7 @@ lemma weightedDegree_indicator_nat (w : X → ℤ) (s : Finset X) (m : X → ℕ
 /-- Pushing forward `Finsupp.indicator` with multiplicities applies the map to each point in the
 finite sum. -/
 @[simp]
-lemma pushforward_indicator_nat (f : X → Y) (s : Finset X) (m : X → ℕ) :
+private lemma pushforward_indicator_nat (f : X → Y) (s : Finset X) (m : X → ℕ) :
     pushforward f (Finsupp.indicator s (fun x _ => (m x : ℤ)) : WeilDivisor X) =
       ∑ x ∈ s, (m x : ℤ) • ofPoint (f x) := by
   classical
@@ -269,7 +270,7 @@ lemma pushforward_indicator_nat (f : X → Y) (s : Finset X) (m : X → ℕ) :
 
 /-- With positive weights on the selected set, an indicator divisor with multiplicities has
 weighted degree zero exactly when every selected multiplicity vanishes. -/
-lemma weightedDegree_indicator_nat_eq_zero_iff_of_pos
+private lemma weightedDegree_indicator_nat_eq_zero_iff_of_pos
     (s : Finset X) {w : X → ℤ} (hw : ∀ x ∈ s, 0 < w x) (m : X → ℕ) :
     weightedDegree w (Finsupp.indicator s (fun x _ => (m x : ℤ)) : WeilDivisor X) = 0 ↔
       ∀ x ∈ s, m x = 0 := by
@@ -288,7 +289,7 @@ lemma weightedDegree_indicator_nat_eq_zero_iff_of_pos
 
 /-- An indicator divisor with positive weights on the selected set lies in the weighted
 degree-zero subgroup exactly when all selected multiplicities vanish. -/
-lemma indicator_nat_mem_weightedDegreeZeroSubgroup_iff_of_pos
+private lemma indicator_nat_mem_weightedDegreeZeroSubgroup_iff_of_pos
     (s : Finset X) {w : X → ℤ} (hw : ∀ x ∈ s, 0 < w x) (m : X → ℕ) :
     (Finsupp.indicator s (fun x _ => (m x : ℤ)) : WeilDivisor X) ∈
         weightedDegreeZeroSubgroup w ↔
@@ -297,7 +298,7 @@ lemma indicator_nat_mem_weightedDegreeZeroSubgroup_iff_of_pos
 
 /-- An indicator divisor with multiplicities has unweighted degree zero exactly when every
 selected multiplicity vanishes. -/
-lemma indicator_nat_mem_degreeZeroSubgroup_iff (s : Finset X) (m : X → ℕ) :
+private lemma indicator_nat_mem_degreeZeroSubgroup_iff (s : Finset X) (m : X → ℕ) :
     (Finsupp.indicator s (fun x _ => (m x : ℤ)) : WeilDivisor X) ∈ degreeZeroSubgroup X ↔
       ∀ x ∈ s, m x = 0 := by
   rw [mem_degreeZeroSubgroup, ← weightedDegree_one_eq_degree]
@@ -306,8 +307,7 @@ lemma indicator_nat_mem_degreeZeroSubgroup_iff (s : Finset X) (m : X → ℕ) :
 
 /-! ### Named finite-set multiplicity divisors -/
 
-@[simp]
-lemma ofFinsetWithMultiplicity_eq_indicator (s : Finset X) (m : X → ℕ) :
+private lemma ofFinsetWithMultiplicity_eq_indicator (s : Finset X) (m : X → ℕ) :
     ofFinsetWithMultiplicity s m =
       (Finsupp.indicator s (fun x _ => (m x : ℤ)) : WeilDivisor X) :=
   rfl
@@ -405,48 +405,48 @@ lemma ofFinsetWithMultiplicity_mem_degreeZeroSubgroup_iff (s : Finset X) (m : X 
 /-! ### Finite sums with coefficient one via `Finsupp.indicator` -/
 
 /-- The effective divisor that puts coefficient one on every point of `s` and zero elsewhere. -/
-@[expose] def ofFinset (s : Finset X) : WeilDivisor X :=
-  Finsupp.indicator s (fun _ _ => (1 : ℤ))
+def ofFinset (s : Finset X) : WeilDivisor X :=
+  ofFinsetWithMultiplicity s (fun _ => 1)
 
 /-- The coefficient-one `Finsupp.indicator` divisor is the corresponding finite sum of point
 divisors. -/
-lemma indicator_one_eq_sum (s : Finset X) :
+private lemma indicator_one_eq_sum (s : Finset X) :
     (Finsupp.indicator s (fun _ _ => (1 : ℤ)) : WeilDivisor X) = ∑ x ∈ s, ofPoint x := by
   simpa using indicator_nat_eq_sum (s := s) (m := fun _ : X => 1)
 
 @[simp]
-lemma indicator_one_empty :
+private lemma indicator_one_empty :
     (Finsupp.indicator (∅ : Finset X) (fun _ _ => (1 : ℤ)) : WeilDivisor X) = 0 := by
   simpa using indicator_nat_empty (X := X) (fun _ : X => 1)
 
 @[simp]
-lemma indicator_one_insert [DecidableEq X] {s : Finset X} {x : X} (hx : x ∉ s) :
+private lemma indicator_one_insert [DecidableEq X] {s : Finset X} {x : X} (hx : x ∉ s) :
     (Finsupp.indicator (insert x s) (fun _ _ => (1 : ℤ)) : WeilDivisor X) =
       ofPoint x + Finsupp.indicator s (fun _ _ => (1 : ℤ)) := by
   simpa using indicator_nat_insert (s := s) (x := x) hx (fun _ : X => 1)
 
 /-- Coefficients of the coefficient-one indicator divisor are `1` on the set and `0` off it. -/
 @[simp]
-lemma coeff_indicator_one [DecidableEq X] (s : Finset X) (x : X) :
+private lemma coeff_indicator_one [DecidableEq X] (s : Finset X) (x : X) :
     coeff (Finsupp.indicator s (fun _ _ => (1 : ℤ)) : WeilDivisor X) x =
       if x ∈ s then 1 else 0 := by
   simp [coeff, Finsupp.indicator_apply]
 
 /-- The coefficient-one indicator divisor is effective. -/
 @[simp]
-lemma isEffective_indicator_one (s : Finset X) :
+private lemma isEffective_indicator_one (s : Finset X) :
     IsEffective (Finsupp.indicator s (fun _ _ => (1 : ℤ)) : WeilDivisor X) := by
   classical
   simpa using isEffective_indicator_nat (X := X) s (fun _ => 1)
 
 @[simp]
-lemma indicator_one_mem_effectiveSubmonoid (s : Finset X) :
+private lemma indicator_one_mem_effectiveSubmonoid (s : Finset X) :
     (Finsupp.indicator s (fun _ _ => (1 : ℤ)) : WeilDivisor X) ∈ effectiveSubmonoid X :=
   (mem_effectiveSubmonoid _).mpr (isEffective_indicator_one s)
 
 /-- The support of the coefficient-one indicator divisor is exactly the chosen finite set. -/
 @[simp]
-lemma support_indicator_one (s : Finset X) :
+private lemma support_indicator_one (s : Finset X) :
     (Finsupp.indicator s (fun _ _ => (1 : ℤ)) : WeilDivisor X).support = s := by
   classical
   ext x
@@ -454,14 +454,14 @@ lemma support_indicator_one (s : Finset X) :
 
 /-- The degree of the coefficient-one indicator divisor is the finite set's cardinality. -/
 @[simp]
-lemma degree_indicator_one (s : Finset X) :
+private lemma degree_indicator_one (s : Finset X) :
     degree (Finsupp.indicator s (fun _ _ => (1 : ℤ)) : WeilDivisor X) = s.card := by
   classical
   simpa using degree_indicator_nat (s := s) (m := fun _ : X => 1)
 
 /-- The weighted degree of the coefficient-one indicator divisor is the sum of weights on it. -/
 @[simp]
-lemma weightedDegree_indicator_one (w : X → ℤ) (s : Finset X) :
+private lemma weightedDegree_indicator_one (w : X → ℤ) (s : Finset X) :
     weightedDegree w (Finsupp.indicator s (fun _ _ => (1 : ℤ)) : WeilDivisor X) =
       ∑ x ∈ s, w x := by
   classical
@@ -469,7 +469,7 @@ lemma weightedDegree_indicator_one (w : X → ℤ) (s : Finset X) :
 
 /-- Pushing forward the coefficient-one indicator divisor applies the map to each point. -/
 @[simp]
-lemma pushforward_indicator_one (f : X → Y) (s : Finset X) :
+private lemma pushforward_indicator_one (f : X → Y) (s : Finset X) :
     pushforward f (Finsupp.indicator s (fun _ _ => (1 : ℤ)) : WeilDivisor X) =
       ∑ x ∈ s, ofPoint (f x) := by
   classical
@@ -477,7 +477,7 @@ lemma pushforward_indicator_one (f : X → Y) (s : Finset X) :
 
 /-- For positive weights, a coefficient-one indicator divisor lies in the weighted degree-zero
 subgroup exactly when the finite set is empty. -/
-lemma indicator_one_mem_weightedDegreeZeroSubgroup_iff_of_pos
+private lemma indicator_one_mem_weightedDegreeZeroSubgroup_iff_of_pos
     (s : Finset X) {w : X → ℤ} (hw : ∀ x ∈ s, 0 < w x) :
     (Finsupp.indicator s (fun _ _ => (1 : ℤ)) : WeilDivisor X) ∈
         weightedDegreeZeroSubgroup w ↔
@@ -498,7 +498,7 @@ lemma indicator_one_mem_weightedDegreeZeroSubgroup_iff_of_pos
     simp [hs] at hx
 
 /-- A coefficient-one indicator divisor has unweighted degree zero exactly when the set is empty. -/
-lemma indicator_one_mem_degreeZeroSubgroup_iff (s : Finset X) :
+private lemma indicator_one_mem_degreeZeroSubgroup_iff (s : Finset X) :
     (Finsupp.indicator s (fun _ _ => (1 : ℤ)) : WeilDivisor X) ∈ degreeZeroSubgroup X ↔
       s = ∅ := by
   classical
@@ -518,15 +518,15 @@ lemma indicator_one_mem_degreeZeroSubgroup_iff (s : Finset X) :
 
 /-! ### Named finite-set divisors -/
 
-@[simp]
-lemma ofFinset_eq_indicator (s : Finset X) :
+private lemma ofFinset_eq_indicator (s : Finset X) :
     ofFinset s = (Finsupp.indicator s (fun _ _ => (1 : ℤ)) : WeilDivisor X) :=
   rfl
 
 /-- `ofFinset s` is the finite sum of the point divisors at the points of `s`. -/
 lemma ofFinset_eq_sum (s : Finset X) :
     ofFinset s = ∑ x ∈ s, ofPoint x := by
-  simpa [ofFinset] using indicator_one_eq_sum (s := s)
+  simpa [ofFinset] using
+    ofFinsetWithMultiplicity_eq_sum (s := s) (m := fun _ : X => 1)
 
 @[simp]
 lemma ofFinset_empty : ofFinset (∅ : Finset X) = 0 := by
@@ -535,7 +535,8 @@ lemma ofFinset_empty : ofFinset (∅ : Finset X) = 0 := by
 @[simp]
 lemma ofFinset_insert [DecidableEq X] {s : Finset X} {x : X} (hx : x ∉ s) :
     ofFinset (insert x s) = ofPoint x + ofFinset s := by
-  simpa [ofFinset] using indicator_one_insert (s := s) (x := x) hx
+  simpa [ofFinset] using
+    ofFinsetWithMultiplicity_insert (s := s) (x := x) hx (fun _ : X => 1)
 
 /-- Coefficients of `ofFinset s` are `1` on `s` and `0` off `s`. -/
 @[simp]
@@ -558,7 +559,10 @@ lemma ofFinset_mem_effectiveSubmonoid (s : Finset X) :
 @[simp]
 lemma support_ofFinset (s : Finset X) :
     (ofFinset s).support = s := by
-  simp [ofFinset]
+  rw [ofFinset]
+  ext x
+  rw [mem_support_ofFinsetWithMultiplicity_iff]
+  simp
 
 /-- The degree of `ofFinset s` is the cardinality of `s`. -/
 @[simp]
@@ -576,20 +580,43 @@ lemma weightedDegree_ofFinset (w : X → ℤ) (s : Finset X) :
 @[simp]
 lemma pushforward_ofFinset (f : X → Y) (s : Finset X) :
     pushforward f (ofFinset s) = ∑ x ∈ s, ofPoint (f x) := by
-  simpa [ofFinset] using pushforward_indicator_one (f := f) (s := s)
+  simpa [ofFinset] using
+    pushforward_ofFinsetWithMultiplicity (f := f) (s := s) (m := fun _ : X => 1)
 
 /-- With positive weights on `s`, `ofFinset s` lies in the weighted degree-zero subgroup exactly
 when `s` is empty. -/
 lemma ofFinset_mem_weightedDegreeZeroSubgroup_iff_of_pos
     (s : Finset X) {w : X → ℤ} (hw : ∀ x ∈ s, 0 < w x) :
     ofFinset s ∈ weightedDegreeZeroSubgroup w ↔ s = ∅ := by
-  simpa [ofFinset] using
-    indicator_one_mem_weightedDegreeZeroSubgroup_iff_of_pos (s := s) (w := w) hw
+  rw [ofFinset]
+  rw [ofFinsetWithMultiplicity_mem_weightedDegreeZeroSubgroup_iff_of_pos
+    (s := s) (w := w) hw (fun _ : X => 1)]
+  constructor
+  · intro h
+    ext x
+    constructor
+    · intro hx
+      exact (one_ne_zero (h x hx)).elim
+    · intro hx
+      exact (Finset.notMem_empty x hx).elim
+  · intro hs x hx
+    simp [hs] at hx
 
 /-- `ofFinset s` has unweighted degree zero exactly when `s` is empty. -/
 lemma ofFinset_mem_degreeZeroSubgroup_iff (s : Finset X) :
     ofFinset s ∈ degreeZeroSubgroup X ↔ s = ∅ := by
-  simp [ofFinset]
+  rw [ofFinset]
+  rw [ofFinsetWithMultiplicity_mem_degreeZeroSubgroup_iff (s := s) (m := fun _ : X => 1)]
+  constructor
+  · intro h
+    ext x
+    constructor
+    · intro hx
+      exact (one_ne_zero (h x hx)).elim
+    · intro hx
+      exact (Finset.notMem_empty x hx).elim
+  · intro hs x hx
+    simp [hs] at hx
 
 end
 

--- a/TauCeti/AlgebraicGeometry/WeilDivisor/FiniteSum.lean
+++ b/TauCeti/AlgebraicGeometry/WeilDivisor/FiniteSum.lean
@@ -66,6 +66,18 @@ private lemma coeff_sum_zsmul_ofPoint_of_notMem {s : Finset X} {a : X → ℤ} {
 
 /-! ### Finitely supported multiplicities via `Finsupp.mapRange` -/
 
+/-- Every Weil divisor is the finite sum of its coefficients times point divisors over its
+support. -/
+lemma eq_sum_coeff_smul_ofPoint (D : WeilDivisor X) :
+    D = ∑ x ∈ D.support, coeff D x • ofPoint x := by
+  classical
+  ext x
+  by_cases hxs : x ∈ D.support
+  · rw [coeff_sum_zsmul_ofPoint_of_mem hxs]
+  · have hcoeff : coeff D x = 0 := by
+      simpa [mem_support_iff, coeff] using hxs
+    rw [coeff_sum_zsmul_ofPoint_of_notMem hxs, hcoeff]
+
 /-- Coefficients of `Finsupp.mapRange` from natural multiplicities are the multiplicities. -/
 @[simp]
 lemma coeff_mapRange_natCast (m : X →₀ ℕ) (x : X) :
@@ -136,26 +148,116 @@ lemma pushforward_mapRange_natCast (f : X → Y) (m : X →₀ ℕ) :
   refine Finset.sum_congr rfl fun x hx => ?_
   rw [map_zsmul, pushforward_ofPoint]
 
+/-- With positive weights on the support, a divisor from finitely supported multiplicities has
+weighted degree zero exactly when all multiplicities vanish. -/
+lemma weightedDegree_mapRange_natCast_eq_zero_iff_of_pos
+    (m : X →₀ ℕ) {w : X → ℤ} (hw : ∀ x ∈ m.support, 0 < w x) :
+    weightedDegree w
+        (Finsupp.mapRange (fun n : ℕ => (n : ℤ)) (by simp) m : WeilDivisor X) = 0 ↔
+      m = 0 := by
+  classical
+  constructor
+  · intro hdeg
+    have hzero :
+        (Finsupp.mapRange (fun n : ℕ => (n : ℤ)) (by simp) m : WeilDivisor X) = 0 :=
+      IsEffective.eq_zero_of_weightedDegree_eq_zero_of_pos_on_support
+        (isEffective_mapRange_natCast m)
+        (by simpa [support_mapRange_natCast] using hw) hdeg
+    ext x
+    have hcoeff := congrArg (fun D : WeilDivisor X => coeff D x) hzero
+    simpa [coeff_mapRange_natCast] using hcoeff
+  · intro hm
+    simp [hm]
+
+/-- With positive weights on the support, a divisor from finitely supported multiplicities lies
+in the weighted degree-zero subgroup exactly when all multiplicities vanish. -/
+lemma mapRange_natCast_mem_weightedDegreeZeroSubgroup_iff_of_pos
+    (m : X →₀ ℕ) {w : X → ℤ} (hw : ∀ x ∈ m.support, 0 < w x) :
+    (Finsupp.mapRange (fun n : ℕ => (n : ℤ)) (by simp) m : WeilDivisor X) ∈
+        weightedDegreeZeroSubgroup w ↔
+      m = 0 := by
+  rw [mem_weightedDegreeZeroSubgroup,
+    weightedDegree_mapRange_natCast_eq_zero_iff_of_pos m hw]
+
+/-- A divisor from finitely supported multiplicities has unweighted degree zero exactly when all
+multiplicities vanish. -/
+lemma mapRange_natCast_mem_degreeZeroSubgroup_iff (m : X →₀ ℕ) :
+    (Finsupp.mapRange (fun n : ℕ => (n : ℤ)) (by simp) m : WeilDivisor X) ∈
+        degreeZeroSubgroup X ↔
+      m = 0 := by
+  rw [mem_degreeZeroSubgroup, ← weightedDegree_one_eq_degree]
+  exact weightedDegree_mapRange_natCast_eq_zero_iff_of_pos
+    (w := fun _ : X => (1 : ℤ)) m (fun _ _ => zero_lt_one)
+
 /-! ### Finite-set multiplicities via `Finsupp.indicator` -/
+
+/-- The Weil divisor supported on a finite set with prescribed natural multiplicities. -/
+noncomputable def ofFinsetWithMultiplicity (s : Finset X) (m : X → ℕ) : WeilDivisor X :=
+  Finsupp.indicator s (fun x _ => (m x : ℤ))
+
+/-- The Weil divisor with coefficient `1` on each point of a finite set. -/
+noncomputable def ofFinset (s : Finset X) : WeilDivisor X :=
+  ofFinsetWithMultiplicity s fun _ => 1
+
+/-- Coefficient formula for `Finsupp.indicator` with integer coefficients. -/
+@[simp]
+lemma coeff_indicator_int [DecidableEq X] (s : Finset X) (a : X → ℤ) (x : X) :
+    coeff (Finsupp.indicator s (fun x _ => a x) : WeilDivisor X) x =
+      if x ∈ s then a x else 0 := by
+  simp [coeff, Finsupp.indicator_apply]
+
+/-- The `Finsupp.indicator` divisor with integer coefficients agrees with the corresponding
+finite sum of point divisors. -/
+lemma indicator_int_eq_sum (s : Finset X) (a : X → ℤ) :
+    (Finsupp.indicator s (fun x _ => a x) : WeilDivisor X) =
+      ∑ x ∈ s, a x • ofPoint x := by
+  classical
+  ext x
+  by_cases hxs : x ∈ s
+  · rw [coeff_indicator_int, coeff_sum_zsmul_ofPoint_of_mem hxs, if_pos hxs]
+  · rw [coeff_indicator_int, coeff_sum_zsmul_ofPoint_of_notMem hxs, if_neg hxs]
+
+/-- The degree of `Finsupp.indicator` with integer coefficients is the sum of the coefficients. -/
+@[simp]
+lemma degree_indicator_int (s : Finset X) (a : X → ℤ) :
+    degree (Finsupp.indicator s (fun x _ => a x) : WeilDivisor X) =
+      ∑ x ∈ s, a x := by
+  classical
+  simp [indicator_int_eq_sum]
+
+/-- The weighted degree of `Finsupp.indicator` with integer coefficients is the corresponding
+weighted finite sum. -/
+@[simp]
+lemma weightedDegree_indicator_int (w : X → ℤ) (s : Finset X) (a : X → ℤ) :
+    weightedDegree w (Finsupp.indicator s (fun x _ => a x) : WeilDivisor X) =
+      ∑ x ∈ s, a x * w x := by
+  classical
+  simp [indicator_int_eq_sum, mul_comm]
+
+/-- Pushing forward `Finsupp.indicator` with integer coefficients applies the map to each point
+in the finite sum. -/
+@[simp]
+lemma pushforward_indicator_int (f : X → Y) (s : Finset X) (a : X → ℤ) :
+    pushforward f (Finsupp.indicator s (fun x _ => a x) : WeilDivisor X) =
+      ∑ x ∈ s, a x • ofPoint (f x) := by
+  classical
+  rw [indicator_int_eq_sum, map_sum]
+  refine Finset.sum_congr rfl fun x hx => ?_
+  rw [map_zsmul, pushforward_ofPoint]
 
 /-- Coefficient formula for `Finsupp.indicator` with natural-number multiplicities. -/
 @[simp]
 lemma coeff_indicator_nat [DecidableEq X] (s : Finset X) (m : X → ℕ) (x : X) :
     coeff (Finsupp.indicator s (fun x _ => (m x : ℤ)) : WeilDivisor X) x =
       if x ∈ s then m x else 0 := by
-  simp [coeff, Finsupp.indicator_apply]
+  simp
 
 /-- The `Finsupp.indicator` divisor with multiplicities agrees with the corresponding finite sum
 of point divisors. -/
 lemma indicator_nat_eq_sum (s : Finset X) (m : X → ℕ) :
     (Finsupp.indicator s (fun x _ => (m x : ℤ)) : WeilDivisor X) =
       ∑ x ∈ s, (m x : ℤ) • ofPoint x := by
-  classical
-  ext x
-  by_cases hxs : x ∈ s
-  · rw [coeff_indicator_nat, coeff_sum_zsmul_ofPoint_of_mem hxs, if_pos hxs]
-  · rw [coeff_indicator_nat, coeff_sum_zsmul_ofPoint_of_notMem hxs, if_neg hxs]
-    simp
+  exact indicator_int_eq_sum s fun x => (m x : ℤ)
 
 /-- The `Finsupp.indicator` divisor with natural multiplicities over the empty set is zero. -/
 @[simp]
@@ -212,8 +314,7 @@ lemma mem_support_indicator_nat_iff {s : Finset X} {m : X → ℕ} {x : X} :
 lemma degree_indicator_nat (s : Finset X) (m : X → ℕ) :
     degree (Finsupp.indicator s (fun x _ => (m x : ℤ)) : WeilDivisor X) =
       ∑ x ∈ s, (m x : ℤ) := by
-  classical
-  simp [indicator_nat_eq_sum]
+  exact degree_indicator_int s fun x => (m x : ℤ)
 
 /-- The weighted degree of `Finsupp.indicator` with multiplicities is the corresponding weighted
 finite sum. -/
@@ -221,8 +322,7 @@ finite sum. -/
 lemma weightedDegree_indicator_nat (w : X → ℤ) (s : Finset X) (m : X → ℕ) :
     weightedDegree w (Finsupp.indicator s (fun x _ => (m x : ℤ)) : WeilDivisor X) =
       ∑ x ∈ s, (m x : ℤ) * w x := by
-  classical
-  simp [indicator_nat_eq_sum, mul_comm]
+  exact weightedDegree_indicator_int w s fun x => (m x : ℤ)
 
 /-- Pushing forward `Finsupp.indicator` with multiplicities applies the map to each point in the
 finite sum. -/
@@ -230,10 +330,7 @@ finite sum. -/
 lemma pushforward_indicator_nat (f : X → Y) (s : Finset X) (m : X → ℕ) :
     pushforward f (Finsupp.indicator s (fun x _ => (m x : ℤ)) : WeilDivisor X) =
       ∑ x ∈ s, (m x : ℤ) • ofPoint (f x) := by
-  classical
-  rw [indicator_nat_eq_sum, map_sum]
-  refine Finset.sum_congr rfl fun x hx => ?_
-  rw [map_zsmul, pushforward_ofPoint]
+  exact pushforward_indicator_int f s fun x => (m x : ℤ)
 
 /-- With positive weights at the selected points with nonzero multiplicity, an indicator divisor
 with multiplicities has weighted degree zero exactly when every selected multiplicity vanishes. -/
@@ -246,7 +343,8 @@ lemma weightedDegree_indicator_nat_eq_zero_iff_of_pos
   · intro hdeg x hx
     have hzero :
         (Finsupp.indicator s (fun x _ => (m x : ℤ)) : WeilDivisor X) = 0 :=
-      (isEffective_indicator_nat s m).eq_zero_of_weightedDegree_eq_zero_of_pos_on_support
+      IsEffective.eq_zero_of_weightedDegree_eq_zero_of_pos_on_support
+        (isEffective_indicator_nat s m)
         (fun y hy => by
           obtain ⟨hys, hmy⟩ := mem_support_indicator_nat_iff.mp hy
           exact hw y hys hmy)
@@ -274,6 +372,107 @@ lemma indicator_nat_mem_degreeZeroSubgroup_iff (s : Finset X) (m : X → ℕ) :
   rw [mem_degreeZeroSubgroup, ← weightedDegree_one_eq_degree]
   exact weightedDegree_indicator_nat_eq_zero_iff_of_pos
     (w := fun _ : X => (1 : ℤ)) s m (fun _ _ _ => zero_lt_one)
+
+/-! ### Named finite-set constructors -/
+
+/-- Coefficients of the named finite-set divisor with prescribed multiplicities. -/
+@[simp]
+lemma coeff_ofFinsetWithMultiplicity [DecidableEq X] (s : Finset X) (m : X → ℕ) (x : X) :
+    coeff (ofFinsetWithMultiplicity s m : WeilDivisor X) x = if x ∈ s then m x else 0 := by
+  simp [ofFinsetWithMultiplicity]
+
+/-- The named finite-set divisor with multiplicities is the corresponding finite sum of point
+divisors. -/
+lemma ofFinsetWithMultiplicity_eq_sum (s : Finset X) (m : X → ℕ) :
+    ofFinsetWithMultiplicity s m = ∑ x ∈ s, (m x : ℤ) • ofPoint x := by
+  exact indicator_nat_eq_sum s m
+
+/-- The named finite-set divisor with multiplicities over the empty set is zero. -/
+@[simp]
+lemma ofFinsetWithMultiplicity_empty (m : X → ℕ) :
+    ofFinsetWithMultiplicity (∅ : Finset X) m = (0 : WeilDivisor X) := by
+  exact indicator_nat_empty m
+
+/-- Inserting a new point in a named finite-set divisor splits off its weighted point divisor. -/
+@[simp]
+lemma ofFinsetWithMultiplicity_insert [DecidableEq X] {s : Finset X} {x : X}
+    (hx : x ∉ s) (m : X → ℕ) :
+    ofFinsetWithMultiplicity (insert x s) m =
+      (m x : ℤ) • ofPoint x + ofFinsetWithMultiplicity s m := by
+  exact indicator_nat_insert hx m
+
+/-- A named finite-set divisor with natural multiplicities is effective. -/
+@[simp]
+lemma isEffective_ofFinsetWithMultiplicity (s : Finset X) (m : X → ℕ) :
+    IsEffective (ofFinsetWithMultiplicity s m : WeilDivisor X) := by
+  exact isEffective_indicator_nat s m
+
+/-- A named finite-set divisor with natural multiplicities belongs to the effective divisor
+submonoid. -/
+@[simp]
+lemma ofFinsetWithMultiplicity_mem_effectiveSubmonoid (s : Finset X) (m : X → ℕ) :
+    ofFinsetWithMultiplicity s m ∈ effectiveSubmonoid X :=
+  (mem_effectiveSubmonoid _).mpr (isEffective_ofFinsetWithMultiplicity s m)
+
+/-- The support of a named finite-set divisor with multiplicities is contained in the chosen
+finite set. Points in the set whose multiplicity is zero may drop out of the support. -/
+lemma support_ofFinsetWithMultiplicity_subset (s : Finset X) (m : X → ℕ) :
+    (ofFinsetWithMultiplicity s m : WeilDivisor X).support ⊆ s :=
+  support_indicator_nat_subset s m
+
+/-- A point is in the support of a named finite-set divisor with multiplicities exactly when it
+is selected and has nonzero multiplicity. -/
+@[simp]
+lemma mem_support_ofFinsetWithMultiplicity_iff {s : Finset X} {m : X → ℕ} {x : X} :
+    x ∈ (ofFinsetWithMultiplicity s m : WeilDivisor X).support ↔ x ∈ s ∧ m x ≠ 0 := by
+  exact mem_support_indicator_nat_iff
+
+/-- The degree of a named finite-set divisor with multiplicities is the sum of the
+multiplicities. -/
+@[simp]
+lemma degree_ofFinsetWithMultiplicity (s : Finset X) (m : X → ℕ) :
+    degree (ofFinsetWithMultiplicity s m : WeilDivisor X) = ∑ x ∈ s, (m x : ℤ) :=
+  degree_indicator_nat s m
+
+/-- The weighted degree of a named finite-set divisor with multiplicities is the corresponding
+weighted finite sum. -/
+@[simp]
+lemma weightedDegree_ofFinsetWithMultiplicity (w : X → ℤ) (s : Finset X) (m : X → ℕ) :
+    weightedDegree w (ofFinsetWithMultiplicity s m : WeilDivisor X) =
+      ∑ x ∈ s, (m x : ℤ) * w x :=
+  weightedDegree_indicator_nat w s m
+
+/-- Pushing forward a named finite-set divisor with multiplicities applies the map to each
+point in the finite sum. -/
+@[simp]
+lemma pushforward_ofFinsetWithMultiplicity (f : X → Y) (s : Finset X) (m : X → ℕ) :
+    pushforward f (ofFinsetWithMultiplicity s m : WeilDivisor X) =
+      ∑ x ∈ s, (m x : ℤ) • ofPoint (f x) :=
+  pushforward_indicator_nat f s m
+
+/-- With positive weights at selected points with nonzero multiplicity, a named finite-set
+divisor has weighted degree zero exactly when every selected multiplicity vanishes. -/
+lemma weightedDegree_ofFinsetWithMultiplicity_eq_zero_iff_of_pos
+    (s : Finset X) {w : X → ℤ} (m : X → ℕ) (hw : ∀ x ∈ s, m x ≠ 0 → 0 < w x) :
+    weightedDegree w (ofFinsetWithMultiplicity s m : WeilDivisor X) = 0 ↔
+      ∀ x ∈ s, m x = 0 :=
+  weightedDegree_indicator_nat_eq_zero_iff_of_pos s m hw
+
+/-- With positive weights at selected points with nonzero multiplicity, a named finite-set
+divisor lies in the weighted degree-zero subgroup exactly when every selected multiplicity
+vanishes. -/
+lemma ofFinsetWithMultiplicity_mem_weightedDegreeZeroSubgroup_iff_of_pos
+    (s : Finset X) {w : X → ℤ} (m : X → ℕ) (hw : ∀ x ∈ s, m x ≠ 0 → 0 < w x) :
+    (ofFinsetWithMultiplicity s m : WeilDivisor X) ∈ weightedDegreeZeroSubgroup w ↔
+      ∀ x ∈ s, m x = 0 :=
+  indicator_nat_mem_weightedDegreeZeroSubgroup_iff_of_pos s m hw
+
+/-- A named finite-set divisor with multiplicities has unweighted degree zero exactly when every
+selected multiplicity vanishes. -/
+lemma ofFinsetWithMultiplicity_mem_degreeZeroSubgroup_iff (s : Finset X) (m : X → ℕ) :
+    (ofFinsetWithMultiplicity s m : WeilDivisor X) ∈ degreeZeroSubgroup X ↔
+      ∀ x ∈ s, m x = 0 :=
+  indicator_nat_mem_degreeZeroSubgroup_iff s m
 
 /-! ### Finite sums with coefficient one via `Finsupp.indicator` -/
 
@@ -329,7 +528,7 @@ lemma support_indicator_one (s : Finset X) :
 lemma degree_indicator_one (s : Finset X) :
     degree (Finsupp.indicator s (fun _ _ => (1 : ℤ)) : WeilDivisor X) = s.card := by
   classical
-  simpa using degree_indicator_nat (s := s) (m := fun _ : X => 1)
+  simp
 
 /-- The weighted degree of the coefficient-one indicator divisor is the sum of weights on it. -/
 @[simp]
@@ -337,7 +536,7 @@ lemma weightedDegree_indicator_one (w : X → ℤ) (s : Finset X) :
     weightedDegree w (Finsupp.indicator s (fun _ _ => (1 : ℤ)) : WeilDivisor X) =
       ∑ x ∈ s, w x := by
   classical
-  simpa using weightedDegree_indicator_nat (w := w) (s := s) (m := fun _ : X => 1)
+  simp
 
 /-- Pushing forward the coefficient-one indicator divisor applies the map to each point. -/
 @[simp]
@@ -379,6 +578,82 @@ lemma indicator_one_mem_degreeZeroSubgroup_iff (s : Finset X) :
   classical
   exact (indicator_nat_mem_degreeZeroSubgroup_iff (s := s) (m := fun _ : X => 1)).trans
     (forall_mem_one_eq_zero_iff_empty s)
+
+/-! ### Named coefficient-one finite-set constructors -/
+
+/-- The named coefficient-one finite-set divisor is the corresponding finite sum of point
+divisors. -/
+lemma ofFinset_eq_sum (s : Finset X) :
+    ofFinset s = ∑ x ∈ s, ofPoint x := by
+  exact indicator_one_eq_sum s
+
+/-- The named coefficient-one finite-set divisor over the empty set is zero. -/
+@[simp]
+lemma ofFinset_empty : ofFinset (∅ : Finset X) = (0 : WeilDivisor X) := by
+  exact indicator_one_empty
+
+/-- Inserting a new point in a named coefficient-one finite-set divisor splits off its point
+divisor. -/
+@[simp]
+lemma ofFinset_insert [DecidableEq X] {s : Finset X} {x : X} (hx : x ∉ s) :
+    ofFinset (insert x s) = ofPoint x + ofFinset s := by
+  exact indicator_one_insert hx
+
+/-- Coefficients of the named coefficient-one finite-set divisor are `1` on the set and `0` off
+it. -/
+@[simp]
+lemma coeff_ofFinset [DecidableEq X] (s : Finset X) (x : X) :
+    coeff (ofFinset s : WeilDivisor X) x = if x ∈ s then 1 else 0 := by
+  simp [ofFinset]
+
+/-- The named coefficient-one finite-set divisor is effective. -/
+@[simp]
+lemma isEffective_ofFinset (s : Finset X) : IsEffective (ofFinset s : WeilDivisor X) := by
+  exact isEffective_indicator_one s
+
+/-- The named coefficient-one finite-set divisor belongs to the effective divisor submonoid. -/
+@[simp]
+lemma ofFinset_mem_effectiveSubmonoid (s : Finset X) :
+    ofFinset s ∈ effectiveSubmonoid X :=
+  (mem_effectiveSubmonoid _).mpr (isEffective_ofFinset s)
+
+/-- The support of the named coefficient-one finite-set divisor is exactly the chosen finite
+set. -/
+@[simp]
+lemma support_ofFinset (s : Finset X) :
+    (ofFinset s : WeilDivisor X).support = s := by
+  exact support_indicator_one s
+
+/-- The degree of the named coefficient-one finite-set divisor is the finite set's cardinality. -/
+@[simp]
+lemma degree_ofFinset (s : Finset X) : degree (ofFinset s : WeilDivisor X) = s.card :=
+  degree_indicator_one s
+
+/-- The weighted degree of the named coefficient-one finite-set divisor is the sum of weights on
+it. -/
+@[simp]
+lemma weightedDegree_ofFinset (w : X → ℤ) (s : Finset X) :
+    weightedDegree w (ofFinset s : WeilDivisor X) = ∑ x ∈ s, w x :=
+  weightedDegree_indicator_one w s
+
+/-- Pushing forward the named coefficient-one finite-set divisor applies the map to each point. -/
+@[simp]
+lemma pushforward_ofFinset (f : X → Y) (s : Finset X) :
+    pushforward f (ofFinset s : WeilDivisor X) = ∑ x ∈ s, ofPoint (f x) :=
+  pushforward_indicator_one f s
+
+/-- For positive weights, a named coefficient-one finite-set divisor lies in the weighted
+degree-zero subgroup exactly when the finite set is empty. -/
+lemma ofFinset_mem_weightedDegreeZeroSubgroup_iff_of_pos
+    (s : Finset X) {w : X → ℤ} (hw : ∀ x ∈ s, 0 < w x) :
+    (ofFinset s : WeilDivisor X) ∈ weightedDegreeZeroSubgroup w ↔ s = ∅ :=
+  indicator_one_mem_weightedDegreeZeroSubgroup_iff_of_pos s hw
+
+/-- A named coefficient-one finite-set divisor has unweighted degree zero exactly when the set is
+empty. -/
+lemma ofFinset_mem_degreeZeroSubgroup_iff (s : Finset X) :
+    (ofFinset s : WeilDivisor X) ∈ degreeZeroSubgroup X ↔ s = ∅ :=
+  indicator_one_mem_degreeZeroSubgroup_iff s
 
 end
 

--- a/TauCeti/AlgebraicGeometry/WeilDivisor/FiniteSum.lean
+++ b/TauCeti/AlgebraicGeometry/WeilDivisor/FiniteSum.lean
@@ -10,11 +10,11 @@ public import TauCeti.AlgebraicGeometry.WeilDivisor
 /-!
 # Finite sums of point divisors
 
-This file adds constructors for the effective Weil divisors represented by finitely supported
-natural-number multiplicities and by finite sets with multiplicities. These are the formal
-Layer A divisor objects that later receive geometric restrictions from symmetric powers and
-relative effective divisors: before any scheme-level construction exists, a finite collection
-of points gives the divisor `Σ nₓ[x]`.
+This file adds an API for the effective Weil divisors represented by finitely supported
+natural-number multiplicities and by Mathlib's `Finsupp.indicator` on finite sets. These are
+the formal Layer A divisor objects that later receive geometric restrictions from symmetric
+powers and relative effective divisors: before any scheme-level construction exists, a finite
+collection of points gives the divisor `Σ nₓ[x]`.
 
 The API records the coefficient, support, degree, weighted degree, pushforward, and degree-zero
 normal forms needed by the existing Abel-Jacobi and linear-system files.
@@ -168,212 +168,217 @@ lemma IsEffective.eq_zero_of_weightedDegree_eq_zero_of_pos_on_support {w : X →
     (hdeg : weightedDegree w D = 0) : D = 0 :=
   (hD.weightedDegree_eq_zero_iff_of_pos_on_support hw).mp hdeg
 
-/-! ### Finite-set multiplicities -/
+/-! ### Finite-set multiplicities via `Finsupp.indicator` -/
 
-/-- The effective divisor with natural-number multiplicities on a chosen finite set. Points
-outside the set have multiplicity zero. -/
-def ofFinsetWithMultiplicity (s : Finset X) (m : X → ℕ) : WeilDivisor X :=
-  ofFinsuppMultiplicity (Finsupp.indicator s fun x _ => m x)
-
-/-- Coefficient formula for a finite-set divisor with multiplicities. -/
+/-- Coefficient formula for `Finsupp.indicator` with natural-number multiplicities. -/
 @[simp]
-lemma coeff_ofFinsetWithMultiplicity [DecidableEq X] (s : Finset X) (m : X → ℕ) (x : X) :
-    coeff (ofFinsetWithMultiplicity s m) x = if x ∈ s then m x else 0 := by
-  simp [ofFinsetWithMultiplicity, Finsupp.indicator_apply]
+lemma coeff_indicator_nat [DecidableEq X] (s : Finset X) (m : X → ℕ) (x : X) :
+    coeff (Finsupp.indicator s (fun x _ => (m x : ℤ)) : WeilDivisor X) x =
+      if x ∈ s then m x else 0 := by
+  simp [coeff, Finsupp.indicator_apply]
 
-/-- The finite-set multiplicity divisor agrees with the corresponding finite sum of point
-divisors. -/
-lemma ofFinsetWithMultiplicity_eq_sum (s : Finset X) (m : X → ℕ) :
-    ofFinsetWithMultiplicity s m = ∑ x ∈ s, (m x : ℤ) • ofPoint x := by
+/-- The `Finsupp.indicator` divisor with multiplicities agrees with the corresponding finite sum
+of point divisors. -/
+lemma indicator_nat_eq_sum (s : Finset X) (m : X → ℕ) :
+    (Finsupp.indicator s (fun x _ => (m x : ℤ)) : WeilDivisor X) =
+      ∑ x ∈ s, (m x : ℤ) • ofPoint x := by
   classical
   ext x
   by_cases hxs : x ∈ s
-  · rw [coeff_ofFinsetWithMultiplicity, coeff_sum_zsmul_ofPoint_of_mem hxs, if_pos hxs]
-  · rw [coeff_ofFinsetWithMultiplicity, coeff_sum_zsmul_ofPoint_of_notMem hxs, if_neg hxs]
+  · rw [coeff_indicator_nat, coeff_sum_zsmul_ofPoint_of_mem hxs, if_pos hxs]
+  · rw [coeff_indicator_nat, coeff_sum_zsmul_ofPoint_of_notMem hxs, if_neg hxs]
     simp
 
 @[simp]
-lemma ofFinsetWithMultiplicity_empty (m : X → ℕ) :
-    ofFinsetWithMultiplicity (∅ : Finset X) m = 0 := by
+lemma indicator_nat_empty (m : X → ℕ) :
+    (Finsupp.indicator (∅ : Finset X) (fun x _ => (m x : ℤ)) : WeilDivisor X) = 0 := by
   classical
   ext x
   simp
 
 @[simp]
-lemma ofFinsetWithMultiplicity_insert [DecidableEq X] {s : Finset X} {x : X}
-    (hx : x ∉ s) (m : X → ℕ) :
-    ofFinsetWithMultiplicity (insert x s) m =
-      (m x : ℤ) • ofPoint x + ofFinsetWithMultiplicity s m := by
-  rw [ofFinsetWithMultiplicity_eq_sum, ofFinsetWithMultiplicity_eq_sum]
+lemma indicator_nat_insert [DecidableEq X] {s : Finset X} {x : X} (hx : x ∉ s) (m : X → ℕ) :
+    (Finsupp.indicator (insert x s) (fun y _ => (m y : ℤ)) : WeilDivisor X) =
+      (m x : ℤ) • ofPoint x + Finsupp.indicator s (fun y _ => (m y : ℤ)) := by
+  rw [indicator_nat_eq_sum, indicator_nat_eq_sum]
   simp [hx]
 
-/-- Finite-set divisors with natural-number multiplicities are effective. -/
+/-- `Finsupp.indicator` with natural-number multiplicities is an effective divisor. -/
 @[simp]
-lemma isEffective_ofFinsetWithMultiplicity (s : Finset X) (m : X → ℕ) :
-    IsEffective (ofFinsetWithMultiplicity s m) := by
+lemma isEffective_indicator_nat (s : Finset X) (m : X → ℕ) :
+    IsEffective (Finsupp.indicator s (fun x _ => (m x : ℤ)) : WeilDivisor X) := by
   classical
-  simp [ofFinsetWithMultiplicity]
+  rw [isEffective_iff]
+  intro x
+  simp only [coeff_indicator_nat]
+  split_ifs <;> simp
 
 @[simp]
-lemma ofFinsetWithMultiplicity_mem_effectiveSubmonoid (s : Finset X) (m : X → ℕ) :
-    ofFinsetWithMultiplicity s m ∈ effectiveSubmonoid X :=
-  (mem_effectiveSubmonoid _).mpr (isEffective_ofFinsetWithMultiplicity s m)
+lemma indicator_nat_mem_effectiveSubmonoid (s : Finset X) (m : X → ℕ) :
+    (Finsupp.indicator s (fun x _ => (m x : ℤ)) : WeilDivisor X) ∈ effectiveSubmonoid X :=
+  (mem_effectiveSubmonoid _).mpr (isEffective_indicator_nat s m)
 
-/-- The support of a finite-set divisor with multiplicities is contained in the chosen finite
-set. Points in the set whose multiplicity is zero may drop out of the support. -/
-lemma support_ofFinsetWithMultiplicity_subset (s : Finset X) (m : X → ℕ) :
-    (ofFinsetWithMultiplicity s m).support ⊆ s := by
-  classical
-  intro x hx
-  rw [mem_support_iff, coeff_ofFinsetWithMultiplicity] at hx
-  by_contra hxs
-  simp [hxs] at hx
+/-- The support of `Finsupp.indicator` with multiplicities is contained in the chosen finite set.
+Points in the set whose multiplicity is zero may drop out of the support. -/
+lemma support_indicator_nat_subset (s : Finset X) (m : X → ℕ) :
+    (Finsupp.indicator s (fun x _ => (m x : ℤ)) : WeilDivisor X).support ⊆ s :=
+  Finsupp.support_indicator_subset s (fun x _ => (m x : ℤ))
 
-/-- A point is in the support of a finite-set divisor with multiplicities exactly when it is
+/-- A point is in the support of `Finsupp.indicator` with multiplicities exactly when it is
 selected and has nonzero multiplicity. -/
 @[simp]
-lemma mem_support_ofFinsetWithMultiplicity_iff {s : Finset X} {m : X → ℕ} {x : X} :
-    x ∈ (ofFinsetWithMultiplicity s m).support ↔ x ∈ s ∧ m x ≠ 0 := by
+lemma mem_support_indicator_nat_iff {s : Finset X} {m : X → ℕ} {x : X} :
+    x ∈ (Finsupp.indicator s (fun x _ => (m x : ℤ)) : WeilDivisor X).support ↔
+      x ∈ s ∧ m x ≠ 0 := by
   classical
-  rw [mem_support_iff, coeff_ofFinsetWithMultiplicity]
+  rw [mem_support_iff, coeff_indicator_nat]
   by_cases hxs : x ∈ s <;> simp [hxs]
 
-/-- The degree of a finite-set divisor with multiplicities is the sum of the multiplicities. -/
+/-- The degree of `Finsupp.indicator` with multiplicities is the sum of the multiplicities. -/
 @[simp]
-lemma degree_ofFinsetWithMultiplicity (s : Finset X) (m : X → ℕ) :
-    degree (ofFinsetWithMultiplicity s m) = ∑ x ∈ s, (m x : ℤ) := by
+lemma degree_indicator_nat (s : Finset X) (m : X → ℕ) :
+    degree (Finsupp.indicator s (fun x _ => (m x : ℤ)) : WeilDivisor X) =
+      ∑ x ∈ s, (m x : ℤ) := by
   classical
-  simp [ofFinsetWithMultiplicity_eq_sum]
+  simp [indicator_nat_eq_sum]
 
-/-- The weighted degree of a finite-set divisor with multiplicities is the corresponding
-weighted finite sum. -/
+/-- The weighted degree of `Finsupp.indicator` with multiplicities is the corresponding weighted
+finite sum. -/
 @[simp]
-lemma weightedDegree_ofFinsetWithMultiplicity (w : X → ℤ) (s : Finset X) (m : X → ℕ) :
-    weightedDegree w (ofFinsetWithMultiplicity s m) =
+lemma weightedDegree_indicator_nat (w : X → ℤ) (s : Finset X) (m : X → ℕ) :
+    weightedDegree w (Finsupp.indicator s (fun x _ => (m x : ℤ)) : WeilDivisor X) =
       ∑ x ∈ s, (m x : ℤ) * w x := by
   classical
-  simp [ofFinsetWithMultiplicity_eq_sum, mul_comm]
+  simp [indicator_nat_eq_sum, mul_comm]
 
-/-- Pushing forward a finite-set divisor with multiplicities applies the map to each point in
-the finite sum. -/
+/-- Pushing forward `Finsupp.indicator` with multiplicities applies the map to each point in the
+finite sum. -/
 @[simp]
-lemma pushforward_ofFinsetWithMultiplicity (f : X → Y) (s : Finset X) (m : X → ℕ) :
-    pushforward f (ofFinsetWithMultiplicity s m) =
+lemma pushforward_indicator_nat (f : X → Y) (s : Finset X) (m : X → ℕ) :
+    pushforward f (Finsupp.indicator s (fun x _ => (m x : ℤ)) : WeilDivisor X) =
       ∑ x ∈ s, (m x : ℤ) • ofPoint (f x) := by
   classical
-  rw [ofFinsetWithMultiplicity_eq_sum, map_sum]
+  rw [indicator_nat_eq_sum, map_sum]
   refine Finset.sum_congr rfl fun x hx => ?_
   rw [map_zsmul, pushforward_ofPoint]
 
-/-- With positive weights on the selected set, a finite-set divisor with multiplicities has
+/-- With positive weights on the selected set, an indicator divisor with multiplicities has
 weighted degree zero exactly when every selected multiplicity vanishes. -/
-lemma weightedDegree_ofFinsetWithMultiplicity_eq_zero_iff_of_pos
+lemma weightedDegree_indicator_nat_eq_zero_iff_of_pos
     (s : Finset X) {w : X → ℤ} (hw : ∀ x ∈ s, 0 < w x) (m : X → ℕ) :
-    weightedDegree w (ofFinsetWithMultiplicity s m) = 0 ↔ ∀ x ∈ s, m x = 0 := by
+    weightedDegree w (Finsupp.indicator s (fun x _ => (m x : ℤ)) : WeilDivisor X) = 0 ↔
+      ∀ x ∈ s, m x = 0 := by
   classical
   constructor
   · intro hdeg x hx
-    have hzero : ofFinsetWithMultiplicity s m = 0 :=
-      (isEffective_ofFinsetWithMultiplicity s m).eq_zero_of_weightedDegree_eq_zero_of_pos_on_support
-        (fun y hy => hw y (support_ofFinsetWithMultiplicity_subset s m hy)) hdeg
+    have hzero :
+        (Finsupp.indicator s (fun x _ => (m x : ℤ)) : WeilDivisor X) = 0 :=
+      (isEffective_indicator_nat s m).eq_zero_of_weightedDegree_eq_zero_of_pos_on_support
+        (fun y hy => hw y (support_indicator_nat_subset s m hy)) hdeg
     have hcoeff := congrArg (fun D : WeilDivisor X => coeff D x) hzero
-    simpa [coeff_ofFinsetWithMultiplicity, hx] using hcoeff
+    simpa [coeff_indicator_nat, hx] using hcoeff
   · intro hm
-    rw [weightedDegree_ofFinsetWithMultiplicity]
+    rw [weightedDegree_indicator_nat]
     exact Finset.sum_eq_zero fun x hx => by simp [hm x hx]
 
-/-- A finite-set divisor with positive weights on the selected set lies in the weighted
+/-- An indicator divisor with positive weights on the selected set lies in the weighted
 degree-zero subgroup exactly when all selected multiplicities vanish. -/
-lemma ofFinsetWithMultiplicity_mem_weightedDegreeZeroSubgroup_iff_of_pos
+lemma indicator_nat_mem_weightedDegreeZeroSubgroup_iff_of_pos
     (s : Finset X) {w : X → ℤ} (hw : ∀ x ∈ s, 0 < w x) (m : X → ℕ) :
-    ofFinsetWithMultiplicity s m ∈ weightedDegreeZeroSubgroup w ↔ ∀ x ∈ s, m x = 0 := by
-  rw [mem_weightedDegreeZeroSubgroup,
-    weightedDegree_ofFinsetWithMultiplicity_eq_zero_iff_of_pos s hw]
+    (Finsupp.indicator s (fun x _ => (m x : ℤ)) : WeilDivisor X) ∈
+        weightedDegreeZeroSubgroup w ↔
+      ∀ x ∈ s, m x = 0 := by
+  rw [mem_weightedDegreeZeroSubgroup, weightedDegree_indicator_nat_eq_zero_iff_of_pos s hw]
 
-/-- A finite-set divisor with multiplicities has unweighted degree zero exactly when every
+/-- An indicator divisor with multiplicities has unweighted degree zero exactly when every
 selected multiplicity vanishes. -/
-lemma ofFinsetWithMultiplicity_mem_degreeZeroSubgroup_iff (s : Finset X) (m : X → ℕ) :
-    ofFinsetWithMultiplicity s m ∈ degreeZeroSubgroup X ↔ ∀ x ∈ s, m x = 0 := by
+lemma indicator_nat_mem_degreeZeroSubgroup_iff (s : Finset X) (m : X → ℕ) :
+    (Finsupp.indicator s (fun x _ => (m x : ℤ)) : WeilDivisor X) ∈ degreeZeroSubgroup X ↔
+      ∀ x ∈ s, m x = 0 := by
   rw [mem_degreeZeroSubgroup, ← weightedDegree_one_eq_degree]
-  exact weightedDegree_ofFinsetWithMultiplicity_eq_zero_iff_of_pos
+  exact weightedDegree_indicator_nat_eq_zero_iff_of_pos
     (w := fun _ : X => (1 : ℤ)) s (fun _ _ => zero_lt_one) m
 
-/-! ### Finite sums with coefficient one -/
+/-! ### Finite sums with coefficient one via `Finsupp.indicator` -/
 
-/-- The effective divisor `Σ x ∈ s, [x]` attached to a finite set of points. -/
-def ofFinset (s : Finset X) : WeilDivisor X :=
-  ofFinsetWithMultiplicity s fun _ => 1
-
-/-- The coefficient-one finite-set divisor is the corresponding finite sum of point divisors. -/
-lemma ofFinset_eq_sum (s : Finset X) :
-    ofFinset s = ∑ x ∈ s, ofPoint x := by
-  rw [ofFinset, ofFinsetWithMultiplicity_eq_sum]
-  simp
+/-- The coefficient-one `Finsupp.indicator` divisor is the corresponding finite sum of point
+divisors. -/
+lemma indicator_one_eq_sum (s : Finset X) :
+    (Finsupp.indicator s (fun _ _ => (1 : ℤ)) : WeilDivisor X) = ∑ x ∈ s, ofPoint x := by
+  simpa using indicator_nat_eq_sum (s := s) (m := fun _ : X => 1)
 
 @[simp]
-lemma ofFinset_empty : ofFinset (∅ : Finset X) = 0 := by
-  simp [ofFinset]
+lemma indicator_one_empty :
+    (Finsupp.indicator (∅ : Finset X) (fun _ _ => (1 : ℤ)) : WeilDivisor X) = 0 := by
+  simpa using indicator_nat_empty (X := X) (fun _ : X => 1)
 
 @[simp]
-lemma ofFinset_insert [DecidableEq X] {s : Finset X} {x : X} (hx : x ∉ s) :
-    ofFinset (insert x s) = ofPoint x + ofFinset s := by
-  simp [ofFinset, hx]
+lemma indicator_one_insert [DecidableEq X] {s : Finset X} {x : X} (hx : x ∉ s) :
+    (Finsupp.indicator (insert x s) (fun _ _ => (1 : ℤ)) : WeilDivisor X) =
+      ofPoint x + Finsupp.indicator s (fun _ _ => (1 : ℤ)) := by
+  simpa using indicator_nat_insert (s := s) (x := x) hx (fun _ : X => 1)
 
-/-- Coefficients of the divisor attached to a finite set are `1` on the set and `0` off it. -/
+/-- Coefficients of the coefficient-one indicator divisor are `1` on the set and `0` off it. -/
 @[simp]
-lemma coeff_ofFinset [DecidableEq X] (s : Finset X) (x : X) :
-    coeff (ofFinset s) x = if x ∈ s then 1 else 0 := by
-  simp [ofFinset]
+lemma coeff_indicator_one [DecidableEq X] (s : Finset X) (x : X) :
+    coeff (Finsupp.indicator s (fun _ _ => (1 : ℤ)) : WeilDivisor X) x =
+      if x ∈ s then 1 else 0 := by
+  simp [coeff, Finsupp.indicator_apply]
 
-/-- The divisor attached to a finite set is effective. -/
+/-- The coefficient-one indicator divisor is effective. -/
 @[simp]
-lemma isEffective_ofFinset (s : Finset X) : IsEffective (ofFinset s) := by
+lemma isEffective_indicator_one (s : Finset X) :
+    IsEffective (Finsupp.indicator s (fun _ _ => (1 : ℤ)) : WeilDivisor X) := by
   classical
-  simp [ofFinset]
+  simpa using isEffective_indicator_nat (X := X) s (fun _ => 1)
 
 @[simp]
-lemma ofFinset_mem_effectiveSubmonoid (s : Finset X) :
-    ofFinset s ∈ effectiveSubmonoid X :=
-  (mem_effectiveSubmonoid _).mpr (isEffective_ofFinset s)
+lemma indicator_one_mem_effectiveSubmonoid (s : Finset X) :
+    (Finsupp.indicator s (fun _ _ => (1 : ℤ)) : WeilDivisor X) ∈ effectiveSubmonoid X :=
+  (mem_effectiveSubmonoid _).mpr (isEffective_indicator_one s)
 
-/-- The support of the coefficient-one divisor attached to a finite set is exactly that set. -/
+/-- The support of the coefficient-one indicator divisor is exactly the chosen finite set. -/
 @[simp]
-lemma support_ofFinset (s : Finset X) : (ofFinset s).support = s := by
+lemma support_indicator_one (s : Finset X) :
+    (Finsupp.indicator s (fun _ _ => (1 : ℤ)) : WeilDivisor X).support = s := by
   classical
   ext x
-  rw [ofFinset, mem_support_ofFinsetWithMultiplicity_iff]
   simp
 
-/-- The degree of the coefficient-one divisor attached to a finite set is its cardinality. -/
+/-- The degree of the coefficient-one indicator divisor is the finite set's cardinality. -/
 @[simp]
-lemma degree_ofFinset (s : Finset X) : degree (ofFinset s) = s.card := by
+lemma degree_indicator_one (s : Finset X) :
+    degree (Finsupp.indicator s (fun _ _ => (1 : ℤ)) : WeilDivisor X) = s.card := by
   classical
-  rw [ofFinset, degree_ofFinsetWithMultiplicity]
-  simp
+  simpa using degree_indicator_nat (s := s) (m := fun _ : X => 1)
 
-/-- The weighted degree of the divisor attached to a finite set is the sum of weights on it. -/
+/-- The weighted degree of the coefficient-one indicator divisor is the sum of weights on it. -/
 @[simp]
-lemma weightedDegree_ofFinset (w : X → ℤ) (s : Finset X) :
-    weightedDegree w (ofFinset s) = ∑ x ∈ s, w x := by
+lemma weightedDegree_indicator_one (w : X → ℤ) (s : Finset X) :
+    weightedDegree w (Finsupp.indicator s (fun _ _ => (1 : ℤ)) : WeilDivisor X) =
+      ∑ x ∈ s, w x := by
   classical
-  rw [ofFinset, weightedDegree_ofFinsetWithMultiplicity]
-  simp
+  simpa using weightedDegree_indicator_nat (w := w) (s := s) (m := fun _ : X => 1)
 
-/-- Pushing forward the divisor attached to a finite set applies the map to each point. -/
+/-- Pushing forward the coefficient-one indicator divisor applies the map to each point. -/
 @[simp]
-lemma pushforward_ofFinset (f : X → Y) (s : Finset X) :
-    pushforward f (ofFinset s) = ∑ x ∈ s, ofPoint (f x) := by
+lemma pushforward_indicator_one (f : X → Y) (s : Finset X) :
+    pushforward f (Finsupp.indicator s (fun _ _ => (1 : ℤ)) : WeilDivisor X) =
+      ∑ x ∈ s, ofPoint (f x) := by
   classical
-  rw [ofFinset, pushforward_ofFinsetWithMultiplicity]
-  simp
+  simpa using pushforward_indicator_nat (f := f) (s := s) (m := fun _ : X => 1)
 
-/-- For positive weights, a finite set divisor lies in the weighted degree-zero subgroup exactly
-when the finite set is empty. -/
-lemma ofFinset_mem_weightedDegreeZeroSubgroup_iff_of_pos
+/-- For positive weights, a coefficient-one indicator divisor lies in the weighted degree-zero
+subgroup exactly when the finite set is empty. -/
+lemma indicator_one_mem_weightedDegreeZeroSubgroup_iff_of_pos
     (s : Finset X) {w : X → ℤ} (hw : ∀ x ∈ s, 0 < w x) :
-    ofFinset s ∈ weightedDegreeZeroSubgroup w ↔ s = ∅ := by
+    (Finsupp.indicator s (fun _ _ => (1 : ℤ)) : WeilDivisor X) ∈
+        weightedDegreeZeroSubgroup w ↔
+      s = ∅ := by
   classical
-  rw [ofFinset, ofFinsetWithMultiplicity_mem_weightedDegreeZeroSubgroup_iff_of_pos s hw]
+  rw [show ((Finsupp.indicator s (fun _ _ => (1 : ℤ)) : WeilDivisor X) ∈
+      weightedDegreeZeroSubgroup w ↔ ∀ x ∈ s, (fun _ : X => 1) x = 0) from
+    indicator_nat_mem_weightedDegreeZeroSubgroup_iff_of_pos s hw (fun _ : X => 1)]
   constructor
   · intro h
     ext x
@@ -385,12 +390,14 @@ lemma ofFinset_mem_weightedDegreeZeroSubgroup_iff_of_pos
   · intro hs x hx
     simp [hs] at hx
 
-/-- A coefficient-one finite set divisor has unweighted degree zero exactly when the set is
-empty. -/
-lemma ofFinset_mem_degreeZeroSubgroup_iff (s : Finset X) :
-    ofFinset s ∈ degreeZeroSubgroup X ↔ s = ∅ := by
+/-- A coefficient-one indicator divisor has unweighted degree zero exactly when the set is empty. -/
+lemma indicator_one_mem_degreeZeroSubgroup_iff (s : Finset X) :
+    (Finsupp.indicator s (fun _ _ => (1 : ℤ)) : WeilDivisor X) ∈ degreeZeroSubgroup X ↔
+      s = ∅ := by
   classical
-  rw [ofFinset, ofFinsetWithMultiplicity_mem_degreeZeroSubgroup_iff]
+  rw [show ((Finsupp.indicator s (fun _ _ => (1 : ℤ)) : WeilDivisor X) ∈
+      degreeZeroSubgroup X ↔ ∀ x ∈ s, (fun _ : X => 1) x = 0) from
+    indicator_nat_mem_degreeZeroSubgroup_iff (s := s) (m := fun _ : X => 1)]
   constructor
   · intro h
     ext x

--- a/TauCeti/AlgebraicGeometry/WeilDivisor/FiniteSum.lean
+++ b/TauCeti/AlgebraicGeometry/WeilDivisor/FiniteSum.lean
@@ -231,6 +231,7 @@ lemma support_ofFinsetWithMultiplicity_subset (s : Finset X) (m : X → ℕ) :
 
 /-- A point is in the support of a finite-set divisor with multiplicities exactly when it is
 selected and has nonzero multiplicity. -/
+@[simp]
 lemma mem_support_ofFinsetWithMultiplicity_iff {s : Finset X} {m : X → ℕ} {x : X} :
     x ∈ (ofFinsetWithMultiplicity s m).support ↔ x ∈ s ∧ m x ≠ 0 := by
   classical
@@ -302,6 +303,12 @@ lemma ofFinsetWithMultiplicity_mem_degreeZeroSubgroup_iff (s : Finset X) (m : X 
 /-- The effective divisor `Σ x ∈ s, [x]` attached to a finite set of points. -/
 def ofFinset (s : Finset X) : WeilDivisor X :=
   ofFinsetWithMultiplicity s fun _ => 1
+
+/-- The coefficient-one finite-set divisor is the corresponding finite sum of point divisors. -/
+lemma ofFinset_eq_sum (s : Finset X) :
+    ofFinset s = ∑ x ∈ s, ofPoint x := by
+  rw [ofFinset, ofFinsetWithMultiplicity_eq_sum]
+  simp
 
 @[simp]
 lemma ofFinset_empty : ofFinset (∅ : Finset X) = 0 := by

--- a/TauCeti/AlgebraicGeometry/WeilDivisor/FiniteSum.lean
+++ b/TauCeti/AlgebraicGeometry/WeilDivisor/FiniteSum.lean
@@ -64,98 +64,90 @@ private lemma coeff_sum_zsmul_ofPoint_of_notMem {s : Finset X} {a : X → ℤ} {
     have hxy : x ≠ y := fun h => hxs (h.symm ▸ hy)
     rw [← coeff, coeff_zsmul_ofPoint, coeff_ofPoint_of_ne hxy, mul_zero]
 
-/-! ### Finitely supported multiplicities -/
+/-! ### Finitely supported multiplicities via `Finsupp.mapRange` -/
 
-/-- The effective divisor with finitely supported natural-number multiplicities. -/
-def ofFinsuppMultiplicity (m : X →₀ ℕ) : WeilDivisor X :=
-  Finsupp.mapRange (fun n : ℕ => (n : ℤ)) (by simp) m
-
-/-- Coefficients of `ofFinsuppMultiplicity m` are the natural multiplicities `m x`. -/
+/-- Coefficients of `Finsupp.mapRange` from natural multiplicities are the multiplicities. -/
 @[simp]
-lemma coeff_ofFinsuppMultiplicity (m : X →₀ ℕ) (x : X) :
-    coeff (ofFinsuppMultiplicity m) x = m x := by
-  simp [ofFinsuppMultiplicity, coeff]
+lemma coeff_mapRange_natCast (m : X →₀ ℕ) (x : X) :
+    coeff (Finsupp.mapRange (fun n : ℕ => (n : ℤ)) (by simp) m : WeilDivisor X) x =
+      m x := by
+  simp [coeff]
 
 /-- Finitely supported natural multiplicities give effective divisors. -/
 @[simp]
-lemma isEffective_ofFinsuppMultiplicity (m : X →₀ ℕ) :
-    IsEffective (ofFinsuppMultiplicity m) := by
+lemma isEffective_mapRange_natCast (m : X →₀ ℕ) :
+    IsEffective (Finsupp.mapRange (fun n : ℕ => (n : ℤ)) (by simp) m : WeilDivisor X) := by
   rw [isEffective_iff]
   intro x
   simp
 
 /-- The divisor from finitely supported multiplicities is the corresponding sum of point
 divisors over the support. -/
-lemma ofFinsuppMultiplicity_eq_sum (m : X →₀ ℕ) :
-    ofFinsuppMultiplicity m = ∑ x ∈ m.support, (m x : ℤ) • ofPoint x := by
+lemma mapRange_natCast_eq_sum (m : X →₀ ℕ) :
+    (Finsupp.mapRange (fun n : ℕ => (n : ℤ)) (by simp) m : WeilDivisor X) =
+      ∑ x ∈ m.support, (m x : ℤ) • ofPoint x := by
   classical
   ext x
   by_cases hxs : x ∈ m.support
-  · rw [coeff_ofFinsuppMultiplicity, coeff_sum_zsmul_ofPoint_of_mem hxs]
+  · rw [coeff_mapRange_natCast, coeff_sum_zsmul_ofPoint_of_mem hxs]
   · have hmx : m x = 0 := by
       simpa [Finsupp.mem_support_iff] using hxs
-    rw [coeff_ofFinsuppMultiplicity, coeff_sum_zsmul_ofPoint_of_notMem hxs, hmx]
+    rw [coeff_mapRange_natCast, coeff_sum_zsmul_ofPoint_of_notMem hxs, hmx]
     simp
 
 /-- The support of the divisor from finitely supported natural multiplicities is the support
 of those multiplicities. -/
 @[simp]
-lemma support_ofFinsuppMultiplicity (m : X →₀ ℕ) :
-    (ofFinsuppMultiplicity m).support = m.support := by
+lemma support_mapRange_natCast (m : X →₀ ℕ) :
+    (Finsupp.mapRange (fun n : ℕ => (n : ℤ)) (by simp) m : WeilDivisor X).support =
+      m.support := by
   classical
   ext x
-  rw [mem_support_iff, coeff_ofFinsuppMultiplicity, Finsupp.mem_support_iff]
-  constructor
-  · intro h hx
-    exact h (by simp [hx])
-  · intro h hx
-    apply h
-    exact_mod_cast hx
+  rw [mem_support_iff, coeff_mapRange_natCast, Finsupp.mem_support_iff]
+  exact Int.natCast_ne_zero
 
 /-- The degree of a divisor from finitely supported multiplicities is the sum over the support. -/
 @[simp]
-lemma degree_ofFinsuppMultiplicity (m : X →₀ ℕ) :
-    degree (ofFinsuppMultiplicity m) = ∑ x ∈ m.support, (m x : ℤ) := by
+lemma degree_mapRange_natCast (m : X →₀ ℕ) :
+    degree (Finsupp.mapRange (fun n : ℕ => (n : ℤ)) (by simp) m : WeilDivisor X) =
+      ∑ x ∈ m.support, (m x : ℤ) := by
   classical
-  simp [ofFinsuppMultiplicity_eq_sum]
+  simp [mapRange_natCast_eq_sum]
 
 /-- The weighted degree of a divisor from finitely supported multiplicities is the weighted
 sum over the support. -/
 @[simp]
-lemma weightedDegree_ofFinsuppMultiplicity (w : X → ℤ) (m : X →₀ ℕ) :
-    weightedDegree w (ofFinsuppMultiplicity m) =
+lemma weightedDegree_mapRange_natCast (w : X → ℤ) (m : X →₀ ℕ) :
+    weightedDegree w
+        (Finsupp.mapRange (fun n : ℕ => (n : ℤ)) (by simp) m : WeilDivisor X) =
       ∑ x ∈ m.support, (m x : ℤ) * w x := by
   classical
-  simp [ofFinsuppMultiplicity_eq_sum, mul_comm]
+  simp [mapRange_natCast_eq_sum, mul_comm]
 
 /-- Pushing forward a divisor from finitely supported multiplicities applies the map to each
 point in the support sum. -/
 @[simp]
-lemma pushforward_ofFinsuppMultiplicity (f : X → Y) (m : X →₀ ℕ) :
-    pushforward f (ofFinsuppMultiplicity m) =
+lemma pushforward_mapRange_natCast (f : X → Y) (m : X →₀ ℕ) :
+    pushforward f
+        (Finsupp.mapRange (fun n : ℕ => (n : ℤ)) (by simp) m : WeilDivisor X) =
       ∑ x ∈ m.support, (m x : ℤ) • ofPoint (f x) := by
   classical
-  rw [ofFinsuppMultiplicity_eq_sum, map_sum]
+  rw [mapRange_natCast_eq_sum, map_sum]
   refine Finset.sum_congr rfl fun x hx => ?_
   rw [map_zsmul, pushforward_ofPoint]
 
 /-! ### Finite-set multiplicities via `Finsupp.indicator` -/
 
-/-- The effective divisor whose coefficients on `s` are the natural-number multiplicities `m`
-and whose coefficients off `s` are zero. -/
-def ofFinsetWithMultiplicity (s : Finset X) (m : X → ℕ) : WeilDivisor X :=
-  Finsupp.indicator s (fun x _ => (m x : ℤ))
-
 /-- Coefficient formula for `Finsupp.indicator` with natural-number multiplicities. -/
 @[simp]
-private lemma coeff_indicator_nat [DecidableEq X] (s : Finset X) (m : X → ℕ) (x : X) :
+lemma coeff_indicator_nat [DecidableEq X] (s : Finset X) (m : X → ℕ) (x : X) :
     coeff (Finsupp.indicator s (fun x _ => (m x : ℤ)) : WeilDivisor X) x =
       if x ∈ s then m x else 0 := by
   simp [coeff, Finsupp.indicator_apply]
 
 /-- The `Finsupp.indicator` divisor with multiplicities agrees with the corresponding finite sum
 of point divisors. -/
-private lemma indicator_nat_eq_sum (s : Finset X) (m : X → ℕ) :
+lemma indicator_nat_eq_sum (s : Finset X) (m : X → ℕ) :
     (Finsupp.indicator s (fun x _ => (m x : ℤ)) : WeilDivisor X) =
       ∑ x ∈ s, (m x : ℤ) • ofPoint x := by
   classical
@@ -165,15 +157,17 @@ private lemma indicator_nat_eq_sum (s : Finset X) (m : X → ℕ) :
   · rw [coeff_indicator_nat, coeff_sum_zsmul_ofPoint_of_notMem hxs, if_neg hxs]
     simp
 
+/-- The `Finsupp.indicator` divisor with natural multiplicities over the empty set is zero. -/
 @[simp]
-private lemma indicator_nat_empty (m : X → ℕ) :
+lemma indicator_nat_empty (m : X → ℕ) :
     (Finsupp.indicator (∅ : Finset X) (fun x _ => (m x : ℤ)) : WeilDivisor X) = 0 := by
   classical
   ext x
   simp
 
+/-- Inserting a new point in `Finsupp.indicator` splits off its weighted point divisor. -/
 @[simp]
-private lemma indicator_nat_insert [DecidableEq X] {s : Finset X} {x : X}
+lemma indicator_nat_insert [DecidableEq X] {s : Finset X} {x : X}
     (hx : x ∉ s) (m : X → ℕ) :
     (Finsupp.indicator (insert x s) (fun y _ => (m y : ℤ)) : WeilDivisor X) =
       (m x : ℤ) • ofPoint x + Finsupp.indicator s (fun y _ => (m y : ℤ)) := by
@@ -182,7 +176,7 @@ private lemma indicator_nat_insert [DecidableEq X] {s : Finset X} {x : X}
 
 /-- `Finsupp.indicator` with natural-number multiplicities is an effective divisor. -/
 @[simp]
-private lemma isEffective_indicator_nat (s : Finset X) (m : X → ℕ) :
+lemma isEffective_indicator_nat (s : Finset X) (m : X → ℕ) :
     IsEffective (Finsupp.indicator s (fun x _ => (m x : ℤ)) : WeilDivisor X) := by
   classical
   rw [isEffective_iff]
@@ -190,21 +184,23 @@ private lemma isEffective_indicator_nat (s : Finset X) (m : X → ℕ) :
   simp only [coeff_indicator_nat]
   split_ifs <;> simp
 
+/-- `Finsupp.indicator` with natural-number multiplicities belongs to the effective divisor
+submonoid. -/
 @[simp]
-private lemma indicator_nat_mem_effectiveSubmonoid (s : Finset X) (m : X → ℕ) :
+lemma indicator_nat_mem_effectiveSubmonoid (s : Finset X) (m : X → ℕ) :
     (Finsupp.indicator s (fun x _ => (m x : ℤ)) : WeilDivisor X) ∈ effectiveSubmonoid X :=
   (mem_effectiveSubmonoid _).mpr (isEffective_indicator_nat s m)
 
 /-- The support of `Finsupp.indicator` with multiplicities is contained in the chosen finite set.
 Points in the set whose multiplicity is zero may drop out of the support. -/
-private lemma support_indicator_nat_subset (s : Finset X) (m : X → ℕ) :
+lemma support_indicator_nat_subset (s : Finset X) (m : X → ℕ) :
     (Finsupp.indicator s (fun x _ => (m x : ℤ)) : WeilDivisor X).support ⊆ s :=
   Finsupp.support_indicator_subset s (fun x _ => (m x : ℤ))
 
 /-- A point is in the support of `Finsupp.indicator` with multiplicities exactly when it is
 selected and has nonzero multiplicity. -/
 @[simp]
-private lemma mem_support_indicator_nat_iff {s : Finset X} {m : X → ℕ} {x : X} :
+lemma mem_support_indicator_nat_iff {s : Finset X} {m : X → ℕ} {x : X} :
     x ∈ (Finsupp.indicator s (fun x _ => (m x : ℤ)) : WeilDivisor X).support ↔
       x ∈ s ∧ m x ≠ 0 := by
   classical
@@ -213,7 +209,7 @@ private lemma mem_support_indicator_nat_iff {s : Finset X} {m : X → ℕ} {x : 
 
 /-- The degree of `Finsupp.indicator` with multiplicities is the sum of the multiplicities. -/
 @[simp]
-private lemma degree_indicator_nat (s : Finset X) (m : X → ℕ) :
+lemma degree_indicator_nat (s : Finset X) (m : X → ℕ) :
     degree (Finsupp.indicator s (fun x _ => (m x : ℤ)) : WeilDivisor X) =
       ∑ x ∈ s, (m x : ℤ) := by
   classical
@@ -222,7 +218,7 @@ private lemma degree_indicator_nat (s : Finset X) (m : X → ℕ) :
 /-- The weighted degree of `Finsupp.indicator` with multiplicities is the corresponding weighted
 finite sum. -/
 @[simp]
-private lemma weightedDegree_indicator_nat (w : X → ℤ) (s : Finset X) (m : X → ℕ) :
+lemma weightedDegree_indicator_nat (w : X → ℤ) (s : Finset X) (m : X → ℕ) :
     weightedDegree w (Finsupp.indicator s (fun x _ => (m x : ℤ)) : WeilDivisor X) =
       ∑ x ∈ s, (m x : ℤ) * w x := by
   classical
@@ -231,7 +227,7 @@ private lemma weightedDegree_indicator_nat (w : X → ℤ) (s : Finset X) (m : X
 /-- Pushing forward `Finsupp.indicator` with multiplicities applies the map to each point in the
 finite sum. -/
 @[simp]
-private lemma pushforward_indicator_nat (f : X → Y) (s : Finset X) (m : X → ℕ) :
+lemma pushforward_indicator_nat (f : X → Y) (s : Finset X) (m : X → ℕ) :
     pushforward f (Finsupp.indicator s (fun x _ => (m x : ℤ)) : WeilDivisor X) =
       ∑ x ∈ s, (m x : ℤ) • ofPoint (f x) := by
   classical
@@ -241,7 +237,7 @@ private lemma pushforward_indicator_nat (f : X → Y) (s : Finset X) (m : X → 
 
 /-- With positive weights at the selected points with nonzero multiplicity, an indicator divisor
 with multiplicities has weighted degree zero exactly when every selected multiplicity vanishes. -/
-private lemma weightedDegree_indicator_nat_eq_zero_iff_of_pos
+lemma weightedDegree_indicator_nat_eq_zero_iff_of_pos
     (s : Finset X) {w : X → ℤ} (m : X → ℕ) (hw : ∀ x ∈ s, m x ≠ 0 → 0 < w x) :
     weightedDegree w (Finsupp.indicator s (fun x _ => (m x : ℤ)) : WeilDivisor X) = 0 ↔
       ∀ x ∈ s, m x = 0 := by
@@ -263,7 +259,7 @@ private lemma weightedDegree_indicator_nat_eq_zero_iff_of_pos
 
 /-- An indicator divisor with positive weights at selected points with nonzero multiplicity lies
 in the weighted degree-zero subgroup exactly when all selected multiplicities vanish. -/
-private lemma indicator_nat_mem_weightedDegreeZeroSubgroup_iff_of_pos
+lemma indicator_nat_mem_weightedDegreeZeroSubgroup_iff_of_pos
     (s : Finset X) {w : X → ℤ} (m : X → ℕ) (hw : ∀ x ∈ s, m x ≠ 0 → 0 < w x) :
     (Finsupp.indicator s (fun x _ => (m x : ℤ)) : WeilDivisor X) ∈
         weightedDegreeZeroSubgroup w ↔
@@ -272,160 +268,57 @@ private lemma indicator_nat_mem_weightedDegreeZeroSubgroup_iff_of_pos
 
 /-- An indicator divisor with multiplicities has unweighted degree zero exactly when every
 selected multiplicity vanishes. -/
-private lemma indicator_nat_mem_degreeZeroSubgroup_iff (s : Finset X) (m : X → ℕ) :
+lemma indicator_nat_mem_degreeZeroSubgroup_iff (s : Finset X) (m : X → ℕ) :
     (Finsupp.indicator s (fun x _ => (m x : ℤ)) : WeilDivisor X) ∈ degreeZeroSubgroup X ↔
       ∀ x ∈ s, m x = 0 := by
   rw [mem_degreeZeroSubgroup, ← weightedDegree_one_eq_degree]
   exact weightedDegree_indicator_nat_eq_zero_iff_of_pos
     (w := fun _ : X => (1 : ℤ)) s m (fun _ _ _ => zero_lt_one)
 
-/-! ### Named finite-set multiplicity divisors -/
-
-private lemma ofFinsetWithMultiplicity_eq_indicator (s : Finset X) (m : X → ℕ) :
-    ofFinsetWithMultiplicity s m =
-      (Finsupp.indicator s (fun x _ => (m x : ℤ)) : WeilDivisor X) :=
-  rfl
-
-/-- Coefficients of `ofFinsetWithMultiplicity s m` are `m x` on `s` and zero off `s`. -/
-@[simp]
-lemma coeff_ofFinsetWithMultiplicity [DecidableEq X] (s : Finset X) (m : X → ℕ) (x : X) :
-    coeff (ofFinsetWithMultiplicity s m) x = if x ∈ s then m x else 0 := by
-  simp [ofFinsetWithMultiplicity]
-
-/-- `ofFinsetWithMultiplicity s m` is the finite sum of point divisors with coefficients `m`. -/
-lemma ofFinsetWithMultiplicity_eq_sum (s : Finset X) (m : X → ℕ) :
-    ofFinsetWithMultiplicity s m = ∑ x ∈ s, (m x : ℤ) • ofPoint x := by
-  simpa [ofFinsetWithMultiplicity] using indicator_nat_eq_sum (s := s) (m := m)
-
-/-- The finite-set multiplicity divisor over the empty set is zero. -/
-@[simp]
-lemma ofFinsetWithMultiplicity_empty (m : X → ℕ) :
-    ofFinsetWithMultiplicity (∅ : Finset X) m = 0 := by
-  simp [ofFinsetWithMultiplicity]
-
-/-- Inserting a new point splits off the corresponding weighted point divisor. -/
-@[simp]
-lemma ofFinsetWithMultiplicity_insert [DecidableEq X] {s : Finset X} {x : X} (hx : x ∉ s)
-    (m : X → ℕ) :
-    ofFinsetWithMultiplicity (insert x s) m =
-      (m x : ℤ) • ofPoint x + ofFinsetWithMultiplicity s m := by
-  simpa [ofFinsetWithMultiplicity] using indicator_nat_insert (s := s) (x := x) hx m
-
-/-- `ofFinsetWithMultiplicity s m` is effective. -/
-@[simp]
-lemma isEffective_ofFinsetWithMultiplicity (s : Finset X) (m : X → ℕ) :
-    IsEffective (ofFinsetWithMultiplicity s m) := by
-  simp [ofFinsetWithMultiplicity]
-
-/-- `ofFinsetWithMultiplicity s m` belongs to the effective divisor submonoid. -/
-@[simp]
-lemma ofFinsetWithMultiplicity_mem_effectiveSubmonoid (s : Finset X) (m : X → ℕ) :
-    ofFinsetWithMultiplicity s m ∈ effectiveSubmonoid X :=
-  (mem_effectiveSubmonoid _).mpr (isEffective_ofFinsetWithMultiplicity s m)
-
-/-- The support of `ofFinsetWithMultiplicity s m` is contained in `s`. -/
-lemma support_ofFinsetWithMultiplicity_subset (s : Finset X) (m : X → ℕ) :
-    (ofFinsetWithMultiplicity s m).support ⊆ s := by
-  simpa [ofFinsetWithMultiplicity] using support_indicator_nat_subset (s := s) (m := m)
-
-/-- A point is in the support of `ofFinsetWithMultiplicity s m` exactly when it lies in `s`
-and has nonzero multiplicity. -/
-@[simp]
-lemma mem_support_ofFinsetWithMultiplicity_iff {s : Finset X} {m : X → ℕ} {x : X} :
-    x ∈ (ofFinsetWithMultiplicity s m).support ↔ x ∈ s ∧ m x ≠ 0 := by
-  simpa [ofFinsetWithMultiplicity] using
-    mem_support_indicator_nat_iff (s := s) (m := m) (x := x)
-
-/-- The degree of `ofFinsetWithMultiplicity s m` is the sum of the selected multiplicities. -/
-@[simp]
-lemma degree_ofFinsetWithMultiplicity (s : Finset X) (m : X → ℕ) :
-    degree (ofFinsetWithMultiplicity s m) = ∑ x ∈ s, (m x : ℤ) := by
-  simp [ofFinsetWithMultiplicity]
-
-/-- The weighted degree of `ofFinsetWithMultiplicity s m` is the selected weighted sum. -/
-@[simp]
-lemma weightedDegree_ofFinsetWithMultiplicity (w : X → ℤ) (s : Finset X) (m : X → ℕ) :
-    weightedDegree w (ofFinsetWithMultiplicity s m) =
-      ∑ x ∈ s, (m x : ℤ) * w x := by
-  simp [ofFinsetWithMultiplicity]
-
-/-- Pushing forward `ofFinsetWithMultiplicity s m` applies the map to each selected point. -/
-@[simp]
-lemma pushforward_ofFinsetWithMultiplicity (f : X → Y) (s : Finset X) (m : X → ℕ) :
-    pushforward f (ofFinsetWithMultiplicity s m) =
-      ∑ x ∈ s, (m x : ℤ) • ofPoint (f x) := by
-  simpa [ofFinsetWithMultiplicity] using pushforward_indicator_nat (f := f) (s := s) (m := m)
-
-/-- With positive weights at selected points with nonzero multiplicity,
-`ofFinsetWithMultiplicity s m` has weighted degree zero exactly when every selected multiplicity
-vanishes. -/
-lemma weightedDegree_ofFinsetWithMultiplicity_eq_zero_iff_of_pos
-    (s : Finset X) {w : X → ℤ} (m : X → ℕ) (hw : ∀ x ∈ s, m x ≠ 0 → 0 < w x) :
-    weightedDegree w (ofFinsetWithMultiplicity s m) = 0 ↔ ∀ x ∈ s, m x = 0 := by
-  simpa [ofFinsetWithMultiplicity] using
-    weightedDegree_indicator_nat_eq_zero_iff_of_pos (s := s) (w := w) m hw
-
-/-- With positive weights at selected points with nonzero multiplicity,
-`ofFinsetWithMultiplicity s m` lies in the weighted degree-zero subgroup exactly when every
-selected multiplicity vanishes. -/
-lemma ofFinsetWithMultiplicity_mem_weightedDegreeZeroSubgroup_iff_of_pos
-    (s : Finset X) {w : X → ℤ} (m : X → ℕ) (hw : ∀ x ∈ s, m x ≠ 0 → 0 < w x) :
-    ofFinsetWithMultiplicity s m ∈ weightedDegreeZeroSubgroup w ↔ ∀ x ∈ s, m x = 0 := by
-  simpa [ofFinsetWithMultiplicity] using
-    indicator_nat_mem_weightedDegreeZeroSubgroup_iff_of_pos (s := s) (w := w) m hw
-
-/-- `ofFinsetWithMultiplicity s m` has unweighted degree zero exactly when every selected
-multiplicity vanishes. -/
-lemma ofFinsetWithMultiplicity_mem_degreeZeroSubgroup_iff (s : Finset X) (m : X → ℕ) :
-    ofFinsetWithMultiplicity s m ∈ degreeZeroSubgroup X ↔ ∀ x ∈ s, m x = 0 := by
-  simpa [ofFinsetWithMultiplicity] using
-    indicator_nat_mem_degreeZeroSubgroup_iff (s := s) (m := m)
-
 /-! ### Finite sums with coefficient one via `Finsupp.indicator` -/
-
-/-- The effective divisor that puts coefficient one on every point of `s` and zero elsewhere. -/
-def ofFinset (s : Finset X) : WeilDivisor X :=
-  ofFinsetWithMultiplicity s (fun _ => 1)
 
 /-- The coefficient-one `Finsupp.indicator` divisor is the corresponding finite sum of point
 divisors. -/
-private lemma indicator_one_eq_sum (s : Finset X) :
+lemma indicator_one_eq_sum (s : Finset X) :
     (Finsupp.indicator s (fun _ _ => (1 : ℤ)) : WeilDivisor X) = ∑ x ∈ s, ofPoint x := by
   simpa using indicator_nat_eq_sum (s := s) (m := fun _ : X => 1)
 
+/-- The coefficient-one `Finsupp.indicator` divisor over the empty set is zero. -/
 @[simp]
-private lemma indicator_one_empty :
+lemma indicator_one_empty :
     (Finsupp.indicator (∅ : Finset X) (fun _ _ => (1 : ℤ)) : WeilDivisor X) = 0 := by
   simpa using indicator_nat_empty (X := X) (fun _ : X => 1)
 
+/-- Inserting a new point in a coefficient-one indicator splits off its point divisor. -/
 @[simp]
-private lemma indicator_one_insert [DecidableEq X] {s : Finset X} {x : X} (hx : x ∉ s) :
+lemma indicator_one_insert [DecidableEq X] {s : Finset X} {x : X} (hx : x ∉ s) :
     (Finsupp.indicator (insert x s) (fun _ _ => (1 : ℤ)) : WeilDivisor X) =
       ofPoint x + Finsupp.indicator s (fun _ _ => (1 : ℤ)) := by
   simpa using indicator_nat_insert (s := s) (x := x) hx (fun _ : X => 1)
 
 /-- Coefficients of the coefficient-one indicator divisor are `1` on the set and `0` off it. -/
 @[simp]
-private lemma coeff_indicator_one [DecidableEq X] (s : Finset X) (x : X) :
+lemma coeff_indicator_one [DecidableEq X] (s : Finset X) (x : X) :
     coeff (Finsupp.indicator s (fun _ _ => (1 : ℤ)) : WeilDivisor X) x =
       if x ∈ s then 1 else 0 := by
   simp [coeff, Finsupp.indicator_apply]
 
 /-- The coefficient-one indicator divisor is effective. -/
 @[simp]
-private lemma isEffective_indicator_one (s : Finset X) :
+lemma isEffective_indicator_one (s : Finset X) :
     IsEffective (Finsupp.indicator s (fun _ _ => (1 : ℤ)) : WeilDivisor X) := by
   classical
   simpa using isEffective_indicator_nat (X := X) s (fun _ => 1)
 
+/-- The coefficient-one indicator divisor belongs to the effective divisor submonoid. -/
 @[simp]
-private lemma indicator_one_mem_effectiveSubmonoid (s : Finset X) :
+lemma indicator_one_mem_effectiveSubmonoid (s : Finset X) :
     (Finsupp.indicator s (fun _ _ => (1 : ℤ)) : WeilDivisor X) ∈ effectiveSubmonoid X :=
   (mem_effectiveSubmonoid _).mpr (isEffective_indicator_one s)
 
 /-- The support of the coefficient-one indicator divisor is exactly the chosen finite set. -/
 @[simp]
-private lemma support_indicator_one (s : Finset X) :
+lemma support_indicator_one (s : Finset X) :
     (Finsupp.indicator s (fun _ _ => (1 : ℤ)) : WeilDivisor X).support = s := by
   classical
   ext x
@@ -433,14 +326,14 @@ private lemma support_indicator_one (s : Finset X) :
 
 /-- The degree of the coefficient-one indicator divisor is the finite set's cardinality. -/
 @[simp]
-private lemma degree_indicator_one (s : Finset X) :
+lemma degree_indicator_one (s : Finset X) :
     degree (Finsupp.indicator s (fun _ _ => (1 : ℤ)) : WeilDivisor X) = s.card := by
   classical
   simpa using degree_indicator_nat (s := s) (m := fun _ : X => 1)
 
 /-- The weighted degree of the coefficient-one indicator divisor is the sum of weights on it. -/
 @[simp]
-private lemma weightedDegree_indicator_one (w : X → ℤ) (s : Finset X) :
+lemma weightedDegree_indicator_one (w : X → ℤ) (s : Finset X) :
     weightedDegree w (Finsupp.indicator s (fun _ _ => (1 : ℤ)) : WeilDivisor X) =
       ∑ x ∈ s, w x := by
   classical
@@ -448,7 +341,7 @@ private lemma weightedDegree_indicator_one (w : X → ℤ) (s : Finset X) :
 
 /-- Pushing forward the coefficient-one indicator divisor applies the map to each point. -/
 @[simp]
-private lemma pushforward_indicator_one (f : X → Y) (s : Finset X) :
+lemma pushforward_indicator_one (f : X → Y) (s : Finset X) :
     pushforward f (Finsupp.indicator s (fun _ _ => (1 : ℤ)) : WeilDivisor X) =
       ∑ x ∈ s, ofPoint (f x) := by
   classical
@@ -469,7 +362,7 @@ private lemma forall_mem_one_eq_zero_iff_empty (s : Finset X) :
 
 /-- For positive weights, a coefficient-one indicator divisor lies in the weighted degree-zero
 subgroup exactly when the finite set is empty. -/
-private lemma indicator_one_mem_weightedDegreeZeroSubgroup_iff_of_pos
+lemma indicator_one_mem_weightedDegreeZeroSubgroup_iff_of_pos
     (s : Finset X) {w : X → ℤ} (hw : ∀ x ∈ s, 0 < w x) :
     (Finsupp.indicator s (fun _ _ => (1 : ℤ)) : WeilDivisor X) ∈
         weightedDegreeZeroSubgroup w ↔
@@ -480,99 +373,12 @@ private lemma indicator_one_mem_weightedDegreeZeroSubgroup_iff_of_pos
     (forall_mem_one_eq_zero_iff_empty s)
 
 /-- A coefficient-one indicator divisor has unweighted degree zero exactly when the set is empty. -/
-private lemma indicator_one_mem_degreeZeroSubgroup_iff (s : Finset X) :
+lemma indicator_one_mem_degreeZeroSubgroup_iff (s : Finset X) :
     (Finsupp.indicator s (fun _ _ => (1 : ℤ)) : WeilDivisor X) ∈ degreeZeroSubgroup X ↔
       s = ∅ := by
   classical
   exact (indicator_nat_mem_degreeZeroSubgroup_iff (s := s) (m := fun _ : X => 1)).trans
     (forall_mem_one_eq_zero_iff_empty s)
-
-/-! ### Named finite-set divisors -/
-
-private lemma ofFinset_eq_indicator (s : Finset X) :
-    ofFinset s = (Finsupp.indicator s (fun _ _ => (1 : ℤ)) : WeilDivisor X) :=
-  rfl
-
-/-- `ofFinset s` is the finite sum of the point divisors at the points of `s`. -/
-lemma ofFinset_eq_sum (s : Finset X) :
-    ofFinset s = ∑ x ∈ s, ofPoint x := by
-  simpa [ofFinset] using
-    ofFinsetWithMultiplicity_eq_sum (s := s) (m := fun _ : X => 1)
-
-/-- The coefficient-one finite-set divisor over the empty set is zero. -/
-@[simp]
-lemma ofFinset_empty : ofFinset (∅ : Finset X) = 0 := by
-  simp [ofFinset]
-
-/-- Inserting a new point splits off the corresponding point divisor. -/
-@[simp]
-lemma ofFinset_insert [DecidableEq X] {s : Finset X} {x : X} (hx : x ∉ s) :
-    ofFinset (insert x s) = ofPoint x + ofFinset s := by
-  simpa [ofFinset] using
-    ofFinsetWithMultiplicity_insert (s := s) (x := x) hx (fun _ : X => 1)
-
-/-- Coefficients of `ofFinset s` are `1` on `s` and `0` off `s`. -/
-@[simp]
-lemma coeff_ofFinset [DecidableEq X] (s : Finset X) (x : X) :
-    coeff (ofFinset s) x = if x ∈ s then 1 else 0 := by
-  simp [ofFinset]
-
-/-- `ofFinset s` is effective. -/
-@[simp]
-lemma isEffective_ofFinset (s : Finset X) :
-    IsEffective (ofFinset s) := by
-  simp [ofFinset]
-
-/-- `ofFinset s` belongs to the effective divisor submonoid. -/
-@[simp]
-lemma ofFinset_mem_effectiveSubmonoid (s : Finset X) :
-    ofFinset s ∈ effectiveSubmonoid X :=
-  (mem_effectiveSubmonoid _).mpr (isEffective_ofFinset s)
-
-/-- The support of `ofFinset s` is exactly `s`. -/
-@[simp]
-lemma support_ofFinset (s : Finset X) :
-    (ofFinset s).support = s := by
-  rw [ofFinset]
-  ext x
-  rw [mem_support_ofFinsetWithMultiplicity_iff]
-  simp
-
-/-- The degree of `ofFinset s` is the cardinality of `s`. -/
-@[simp]
-lemma degree_ofFinset (s : Finset X) :
-    degree (ofFinset s) = s.card := by
-  simp [ofFinset]
-
-/-- The weighted degree of `ofFinset s` is the sum of the weights on `s`. -/
-@[simp]
-lemma weightedDegree_ofFinset (w : X → ℤ) (s : Finset X) :
-    weightedDegree w (ofFinset s) = ∑ x ∈ s, w x := by
-  simp [ofFinset]
-
-/-- Pushing forward `ofFinset s` applies the map to each selected point. -/
-@[simp]
-lemma pushforward_ofFinset (f : X → Y) (s : Finset X) :
-    pushforward f (ofFinset s) = ∑ x ∈ s, ofPoint (f x) := by
-  simpa [ofFinset] using
-    pushforward_ofFinsetWithMultiplicity (f := f) (s := s) (m := fun _ : X => 1)
-
-/-- With positive weights on `s`, `ofFinset s` lies in the weighted degree-zero subgroup exactly
-when `s` is empty. -/
-lemma ofFinset_mem_weightedDegreeZeroSubgroup_iff_of_pos
-    (s : Finset X) {w : X → ℤ} (hw : ∀ x ∈ s, 0 < w x) :
-    ofFinset s ∈ weightedDegreeZeroSubgroup w ↔ s = ∅ := by
-  rw [ofFinset]
-  rw [ofFinsetWithMultiplicity_mem_weightedDegreeZeroSubgroup_iff_of_pos
-    (s := s) (w := w) (fun _ : X => 1) (fun x hx _ => hw x hx)]
-  exact forall_mem_one_eq_zero_iff_empty s
-
-/-- `ofFinset s` has unweighted degree zero exactly when `s` is empty. -/
-lemma ofFinset_mem_degreeZeroSubgroup_iff (s : Finset X) :
-    ofFinset s ∈ degreeZeroSubgroup X ↔ s = ∅ := by
-  rw [ofFinset]
-  rw [ofFinsetWithMultiplicity_mem_degreeZeroSubgroup_iff (s := s) (m := fun _ : X => 1)]
-  exact forall_mem_one_eq_zero_iff_empty s
 
 end
 

--- a/TauCeti/AlgebraicGeometry/WeilDivisor/FiniteSum.lean
+++ b/TauCeti/AlgebraicGeometry/WeilDivisor/FiniteSum.lean
@@ -4,6 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 -/
 module
 
+public import Mathlib.Data.Finsupp.Indicator
 public import TauCeti.AlgebraicGeometry.WeilDivisor
 
 /-!
@@ -39,50 +40,157 @@ noncomputable section
 
 /-! ### Finite sums with multiplicity -/
 
+/-- The effective divisor with finitely supported natural-number multiplicities. -/
+def ofFinsuppMultiplicity (m : X →₀ ℕ) : WeilDivisor X :=
+  Finsupp.mapRange (fun n : ℕ => (n : ℤ)) (by simp) m
+
+@[simp]
+lemma coeff_ofFinsuppMultiplicity (m : X →₀ ℕ) (x : X) :
+    coeff (ofFinsuppMultiplicity m) x = m x := by
+  simp [ofFinsuppMultiplicity, coeff]
+
+/-- Finitely supported natural multiplicities give effective divisors. -/
+@[simp]
+lemma isEffective_ofFinsuppMultiplicity (m : X →₀ ℕ) :
+    IsEffective (ofFinsuppMultiplicity m) := by
+  rw [isEffective_iff]
+  intro x
+  simp
+
+/-- The divisor from finitely supported multiplicities is the corresponding sum of point
+divisors over the support. -/
+lemma ofFinsuppMultiplicity_eq_sum (m : X →₀ ℕ) :
+    ofFinsuppMultiplicity m = ∑ x ∈ m.support, (m x : ℤ) • ofPoint x := by
+  classical
+  apply Finsupp.ext
+  intro x
+  simp only [ofFinsuppMultiplicity, Finsupp.mapRange_apply]
+  by_cases hxs : x ∈ m.support
+  · simp_rw [Finset.sum_apply']
+    change (m x : ℤ) = ∑ y ∈ m.support, (((m y : ℤ) • ofPoint y : WeilDivisor X) x)
+    rw [Finset.sum_eq_single x]
+    · have hpoint : (ofPoint x : WeilDivisor X) x = 1 := by
+        simpa [coeff] using coeff_ofPoint_self x
+      simp [hpoint]
+    · intro y hy hyx
+      have hxy : x ≠ y := fun h => hyx h.symm
+      have hpoint : (ofPoint y : WeilDivisor X) x = 0 := by
+        simpa [coeff] using coeff_ofPoint_of_ne (x := y) (y := x) hxy
+      simp [hpoint]
+    · intro hx
+      exact (hx hxs).elim
+  · have hmx : m x = 0 := by
+      by_contra hmx
+      exact hxs (Finsupp.mem_support_iff.mpr hmx)
+    rw [hmx]
+    simp_rw [Finset.sum_apply']
+    change (0 : ℤ) = ∑ y ∈ m.support, (((m y : ℤ) • ofPoint y : WeilDivisor X) x)
+    exact (Finset.sum_eq_zero fun y hy => by
+      have hxy : x ≠ y := fun h => hxs (h.symm ▸ hy)
+      have hpoint : (ofPoint y : WeilDivisor X) x = 0 := by
+        simpa [coeff] using coeff_ofPoint_of_ne (x := y) (y := x) hxy
+      simp [hpoint]).symm
+
+/-- The support of the divisor from finitely supported natural multiplicities is the support
+of those multiplicities. -/
+@[simp]
+lemma support_ofFinsuppMultiplicity (m : X →₀ ℕ) :
+    (ofFinsuppMultiplicity m).support = m.support := by
+  classical
+  ext x
+  rw [mem_support_iff, coeff_ofFinsuppMultiplicity, Finsupp.mem_support_iff]
+  constructor
+  · intro h hx
+    exact h (by simp [hx])
+  · intro h hx
+    apply h
+    exact_mod_cast hx
+
+/-- The degree of a divisor from finitely supported multiplicities is the sum over the support. -/
+@[simp]
+lemma degree_ofFinsuppMultiplicity (m : X →₀ ℕ) :
+    degree (ofFinsuppMultiplicity m) = ∑ x ∈ m.support, (m x : ℤ) := by
+  classical
+  simp [ofFinsuppMultiplicity_eq_sum]
+
+/-- The weighted degree of a divisor from finitely supported multiplicities is the weighted
+sum over the support. -/
+@[simp]
+lemma weightedDegree_ofFinsuppMultiplicity (w : X → ℤ) (m : X →₀ ℕ) :
+    weightedDegree w (ofFinsuppMultiplicity m) =
+      ∑ x ∈ m.support, (m x : ℤ) * w x := by
+  classical
+  simp [ofFinsuppMultiplicity_eq_sum, mul_comm]
+
+/-- Pushing forward a divisor from finitely supported multiplicities applies the map to each
+point in the support sum. -/
+@[simp]
+lemma pushforward_ofFinsuppMultiplicity (f : X → Y) (m : X →₀ ℕ) :
+    pushforward f (ofFinsuppMultiplicity m) =
+      ∑ x ∈ m.support, (m x : ℤ) • ofPoint (f x) := by
+  classical
+  rw [ofFinsuppMultiplicity_eq_sum, map_sum]
+  refine Finset.sum_congr rfl fun x hx => ?_
+  rw [map_zsmul, pushforward_ofPoint]
+
 /-- The effective divisor `Σ x ∈ s, m x • [x]` attached to a finite set of points and
 natural-number multiplicities.  Points outside `s` have coefficient zero. -/
 def ofFinsetWithMultiplicity (s : Finset X) (m : X → ℕ) : WeilDivisor X :=
-  ∑ x ∈ s, (m x : ℤ) • ofPoint x
+  ofFinsuppMultiplicity (Finsupp.indicator s fun x _ => m x)
+
+/-- Coefficient formula for a finite point divisor with multiplicities. -/
+@[simp]
+lemma coeff_ofFinsetWithMultiplicity [DecidableEq X] (s : Finset X) (m : X → ℕ) (x : X) :
+    coeff (ofFinsetWithMultiplicity s m) x = if x ∈ s then m x else 0 := by
+  simp [ofFinsetWithMultiplicity, Finsupp.indicator_apply]
+
+/-- The `Finsupp.indicator` constructor agrees with the finite sum of point divisors. -/
+lemma ofFinsetWithMultiplicity_eq_sum (s : Finset X) (m : X → ℕ) :
+    ofFinsetWithMultiplicity s m = ∑ x ∈ s, (m x : ℤ) • ofPoint x := by
+  classical
+  apply Finsupp.ext
+  intro x
+  simp only [ofFinsetWithMultiplicity, ofFinsuppMultiplicity, Finsupp.mapRange_apply,
+    Finsupp.indicator_apply]
+  by_cases hxs : x ∈ s
+  · rw [dif_pos hxs]
+    simp_rw [Finset.sum_apply']
+    change (m x : ℤ) = ∑ y ∈ s, (((m y : ℤ) • ofPoint y : WeilDivisor X) x)
+    rw [Finset.sum_eq_single x]
+    · have hpoint : (ofPoint x : WeilDivisor X) x = 1 := by
+        simpa [coeff] using coeff_ofPoint_self x
+      simp [hpoint]
+    · intro y hy hyx
+      have hxy : x ≠ y := fun h => hyx h.symm
+      have hpoint : (ofPoint y : WeilDivisor X) x = 0 := by
+        simpa [coeff] using coeff_ofPoint_of_ne (x := y) (y := x) hxy
+      simp [hpoint]
+    · intro hx
+      exact (hx hxs).elim
+  · rw [dif_neg hxs]
+    simp_rw [Finset.sum_apply']
+    change (0 : ℤ) = ∑ y ∈ s, (((m y : ℤ) • ofPoint y : WeilDivisor X) x)
+    exact (Finset.sum_eq_zero fun y hy => by
+      have hxy : x ≠ y := fun h => hxs (h.symm ▸ hy)
+      have hpoint : (ofPoint y : WeilDivisor X) x = 0 := by
+        simpa [coeff] using coeff_ofPoint_of_ne (x := y) (y := x) hxy
+      simp [hpoint]).symm
 
 @[simp]
 lemma ofFinsetWithMultiplicity_empty (m : X → ℕ) :
     ofFinsetWithMultiplicity (∅ : Finset X) m = 0 := by
-  simp [ofFinsetWithMultiplicity]
+  classical
+  ext x
+  rw [coeff_ofFinsetWithMultiplicity]
+  simp
 
 @[simp]
 lemma ofFinsetWithMultiplicity_insert [DecidableEq X] {s : Finset X} {x : X}
     (hx : x ∉ s) (m : X → ℕ) :
     ofFinsetWithMultiplicity (insert x s) m =
       (m x : ℤ) • ofPoint x + ofFinsetWithMultiplicity s m := by
-  simp [ofFinsetWithMultiplicity, hx]
-
-/-- Coefficient formula for a finite point divisor with multiplicities. -/
-@[simp]
-lemma coeff_ofFinsetWithMultiplicity [DecidableEq X] (s : Finset X) (m : X → ℕ) (x : X) :
-    coeff (ofFinsetWithMultiplicity s m) x = if x ∈ s then m x else 0 := by
-  classical
-  induction s using Finset.induction with
-  | empty =>
-      simp
-  | insert y s hy ih =>
-      rw [ofFinsetWithMultiplicity_insert hy, coeff_add]
-      by_cases hxy : x = y
-      · subst y
-        have hsx : (ofFinsetWithMultiplicity s m) x = 0 := by
-          simpa [coeff, hy] using ih
-        have hpoint : (ofPoint x : WeilDivisor X) x = 1 := by
-          simpa [coeff] using coeff_ofPoint_self x
-        rw [show coeff ((m x : ℤ) • ofPoint x) x = (m x : ℤ) by simp [coeff, hpoint]]
-        rw [show coeff (ofFinsetWithMultiplicity s m) x = 0 by simpa [coeff] using hsx]
-        simp
-      · have hsx : (ofFinsetWithMultiplicity s m) x = if x ∈ s then m x else 0 := by
-          simpa [coeff] using ih
-        have hpoint : (ofPoint y : WeilDivisor X) x = 0 := by
-          simpa [coeff] using coeff_ofPoint_of_ne (x := y) (y := x) hxy
-        rw [show coeff ((m y : ℤ) • ofPoint y) x = 0 by simp [coeff, hpoint]]
-        rw [show coeff (ofFinsetWithMultiplicity s m) x =
-          (if x ∈ s then (m x : ℤ) else 0) by simpa [coeff] using hsx]
-        simp [hxy]
+  rw [ofFinsetWithMultiplicity_eq_sum, ofFinsetWithMultiplicity_eq_sum]
+  simp [hx]
 
 /-- Finite point divisors with natural multiplicities are effective. -/
 @[simp]
@@ -111,6 +219,8 @@ lemma support_ofFinsetWithMultiplicity_subset (s : Finset X) (m : X → ℕ) :
   by_contra hxs
   simp [hxs] at hx
 
+/-- A point is in the support of a finite point divisor with multiplicities exactly when it is
+selected and has nonzero multiplicity. -/
 lemma mem_support_ofFinsetWithMultiplicity_iff {s : Finset X} {m : X → ℕ}
     {x : X} :
     x ∈ (ofFinsetWithMultiplicity s m).support ↔ x ∈ s ∧ m x ≠ 0 := by
@@ -123,7 +233,7 @@ lemma mem_support_ofFinsetWithMultiplicity_iff {s : Finset X} {m : X → ℕ}
 lemma degree_ofFinsetWithMultiplicity (s : Finset X) (m : X → ℕ) :
     degree (ofFinsetWithMultiplicity s m) = ∑ x ∈ s, (m x : ℤ) := by
   classical
-  simp [ofFinsetWithMultiplicity]
+  simp [ofFinsetWithMultiplicity_eq_sum]
 
 /-- The weighted degree of `Σ x ∈ s, m x • [x]` is the corresponding weighted finite sum. -/
 @[simp]
@@ -131,7 +241,7 @@ lemma weightedDegree_ofFinsetWithMultiplicity (w : X → ℤ) (s : Finset X) (m 
     weightedDegree w (ofFinsetWithMultiplicity s m) =
       ∑ x ∈ s, (m x : ℤ) * w x := by
   classical
-  simp [ofFinsetWithMultiplicity, mul_comm]
+  simp [ofFinsetWithMultiplicity_eq_sum, mul_comm]
 
 /-- Pushing forward a finite point divisor applies the map to each point in the finite sum. -/
 @[simp]
@@ -139,23 +249,26 @@ lemma pushforward_ofFinsetWithMultiplicity (f : X → Y) (s : Finset X) (m : X �
     pushforward f (ofFinsetWithMultiplicity s m) =
       ∑ x ∈ s, (m x : ℤ) • ofPoint (f x) := by
   classical
-  rw [ofFinsetWithMultiplicity, map_sum]
+  rw [ofFinsetWithMultiplicity_eq_sum, map_sum]
   refine Finset.sum_congr rfl fun x hx => ?_
   rw [map_zsmul, pushforward_ofPoint]
 
 /-- With positive weights, a finite point divisor has weighted degree zero exactly when every
 selected point has zero multiplicity. -/
 lemma weightedDegree_ofFinsetWithMultiplicity_eq_zero_iff_of_pos
-    {w : X → ℤ} (hw : ∀ x, 0 < w x) (s : Finset X) (m : X → ℕ) :
+    (s : Finset X) {w : X → ℤ} (hw : ∀ x ∈ s, 0 < w x) (m : X → ℕ) :
     weightedDegree w (ofFinsetWithMultiplicity s m) = 0 ↔ ∀ x ∈ s, m x = 0 := by
   classical
   constructor
   · intro hdeg x hx
-    have hzero : ofFinsetWithMultiplicity s m = 0 :=
-      (isEffective_ofFinsetWithMultiplicity s m).eq_zero_of_weightedDegree_eq_zero_of_pos hw
-        hdeg
-    have hcoeff := congr_arg (fun D : WeilDivisor X => coeff D x) hzero
-    simpa [hx] using hcoeff
+    have hterm :
+        (m x : ℤ) * w x = 0 :=
+      (Finset.sum_eq_zero_iff_of_nonneg
+        (fun y hy => mul_nonneg (Int.natCast_nonneg _) (le_of_lt (hw y hy)))).mp
+          (by simpa [weightedDegree_ofFinsetWithMultiplicity] using hdeg) x hx
+    rcases mul_eq_zero.mp hterm with hmx | hwx
+    · exact_mod_cast hmx
+    · exact False.elim ((ne_of_gt (hw x hx)) hwx)
   · intro hm
     rw [weightedDegree_ofFinsetWithMultiplicity]
     exact Finset.sum_eq_zero fun x hx => by simp [hm x hx]
@@ -163,10 +276,18 @@ lemma weightedDegree_ofFinsetWithMultiplicity_eq_zero_iff_of_pos
 /-- A finite point divisor with positive weights lies in the weighted degree-zero subgroup
 exactly when all selected multiplicities vanish. -/
 lemma ofFinsetWithMultiplicity_mem_weightedDegreeZeroSubgroup_iff_of_pos
-    {w : X → ℤ} (hw : ∀ x, 0 < w x) (s : Finset X) (m : X → ℕ) :
+    (s : Finset X) {w : X → ℤ} (hw : ∀ x ∈ s, 0 < w x) (m : X → ℕ) :
     ofFinsetWithMultiplicity s m ∈ weightedDegreeZeroSubgroup w ↔ ∀ x ∈ s, m x = 0 := by
   rw [mem_weightedDegreeZeroSubgroup,
-    weightedDegree_ofFinsetWithMultiplicity_eq_zero_iff_of_pos hw]
+    weightedDegree_ofFinsetWithMultiplicity_eq_zero_iff_of_pos s hw]
+
+/-- A finite point divisor with multiplicities has unweighted degree zero exactly when every
+selected multiplicity vanishes. -/
+lemma ofFinsetWithMultiplicity_mem_degreeZeroSubgroup_iff (s : Finset X) (m : X → ℕ) :
+    ofFinsetWithMultiplicity s m ∈ degreeZeroSubgroup X ↔ ∀ x ∈ s, m x = 0 := by
+  rw [mem_degreeZeroSubgroup, ← weightedDegree_one_eq_degree]
+  exact weightedDegree_ofFinsetWithMultiplicity_eq_zero_iff_of_pos
+    (w := fun _ : X => (1 : ℤ)) s (fun _ _ => zero_lt_one) m
 
 /-! ### Finite sums with coefficient one -/
 
@@ -183,11 +304,13 @@ lemma ofFinset_insert [DecidableEq X] {s : Finset X} {x : X} (hx : x ∉ s) :
     ofFinset (insert x s) = ofPoint x + ofFinset s := by
   simp [ofFinset, hx]
 
+/-- Coefficients of the divisor attached to a finite set are `1` on the set and `0` off it. -/
 @[simp]
 lemma coeff_ofFinset [DecidableEq X] (s : Finset X) (x : X) :
     coeff (ofFinset s) x = if x ∈ s then 1 else 0 := by
   simp [ofFinset]
 
+/-- The divisor attached to a finite set is effective. -/
 @[simp]
 lemma isEffective_ofFinset (s : Finset X) : IsEffective (ofFinset s) := by
   classical
@@ -198,6 +321,7 @@ lemma ofFinset_mem_effectiveSubmonoid (s : Finset X) :
     ofFinset s ∈ effectiveSubmonoid X :=
   (mem_effectiveSubmonoid _).mpr (isEffective_ofFinset s)
 
+/-- The support of the coefficient-one divisor attached to a finite set is exactly that set. -/
 @[simp]
 lemma support_ofFinset (s : Finset X) : (ofFinset s).support = s := by
   classical
@@ -205,17 +329,20 @@ lemma support_ofFinset (s : Finset X) : (ofFinset s).support = s := by
   rw [ofFinset, mem_support_ofFinsetWithMultiplicity_iff]
   simp
 
+/-- The degree of the coefficient-one divisor attached to a finite set is its cardinality. -/
 @[simp]
 lemma degree_ofFinset (s : Finset X) : degree (ofFinset s) = s.card := by
   classical
   simp [ofFinset]
 
+/-- The weighted degree of the divisor attached to a finite set is the sum of weights on it. -/
 @[simp]
 lemma weightedDegree_ofFinset (w : X → ℤ) (s : Finset X) :
     weightedDegree w (ofFinset s) = ∑ x ∈ s, w x := by
   classical
   simp [ofFinset]
 
+/-- Pushing forward the divisor attached to a finite set applies the map to each point. -/
 @[simp]
 lemma pushforward_ofFinset (f : X → Y) (s : Finset X) :
     pushforward f (ofFinset s) = ∑ x ∈ s, ofPoint (f x) := by
@@ -226,10 +353,27 @@ lemma pushforward_ofFinset (f : X → Y) (s : Finset X) :
 /-- For positive weights, a finite set divisor lies in the weighted degree-zero subgroup exactly
 when the finite set is empty. -/
 lemma ofFinset_mem_weightedDegreeZeroSubgroup_iff_of_pos
-    {w : X → ℤ} (hw : ∀ x, 0 < w x) (s : Finset X) :
+    (s : Finset X) {w : X → ℤ} (hw : ∀ x ∈ s, 0 < w x) :
     ofFinset s ∈ weightedDegreeZeroSubgroup w ↔ s = ∅ := by
   classical
-  rw [ofFinset, ofFinsetWithMultiplicity_mem_weightedDegreeZeroSubgroup_iff_of_pos hw]
+  rw [ofFinset, ofFinsetWithMultiplicity_mem_weightedDegreeZeroSubgroup_iff_of_pos s hw]
+  constructor
+  · intro h
+    ext x
+    constructor
+    · intro hx
+      exact (one_ne_zero (h x hx)).elim
+    · intro hx
+      exact (Finset.notMem_empty x hx).elim
+  · intro hs x hx
+    simp [hs] at hx
+
+/-- A coefficient-one finite set divisor has unweighted degree zero exactly when the set is
+empty. -/
+lemma ofFinset_mem_degreeZeroSubgroup_iff (s : Finset X) :
+    ofFinset s ∈ degreeZeroSubgroup X ↔ s = ∅ := by
+  classical
+  rw [ofFinset, ofFinsetWithMultiplicity_mem_degreeZeroSubgroup_iff]
   constructor
   · intro h
     ext x


### PR DESCRIPTION
This PR adds finite-sum constructors for effective Weil divisors: `ofFinsetWithMultiplicity s m = Σ x ∈ s, m x • [x]` and the coefficient-one specialization `ofFinset s = Σ x ∈ s, [x]`, together with coefficient, support, degree, weighted-degree, pushforward, effectivity, and positive-weight degree-zero criteria.

It advances `TauCetiRoadmap/JacobianChallenge/README.md`, Layer A, specifically “Divisors on a curve: Weil divisors `⊕_x ℤ`” and “Degree”, and supplies a formal prerequisite for the Layer C/D Abel-map lane `D ↦ 𝒪_X(D - d·x₀)` from symmetric powers. I chose this as the lowest-hanging distinct JacobianChallenge prerequisite after checking open and recently merged PRs: the abstract Weil divisor group, principal divisors, `Pic⁰` quotient, degree splitting, Abel-Jacobi point and divisor-sum APIs, basepoint change, and principal-divisor kernel already exist on `main`, while finite effective divisor constructors for the later symmetric-power input were still absent.

No Mathlib infrastructure is vendored. The implementation reuses Tau Ceti’s existing `WeilDivisor.ofPoint`, `IsEffective`, `degree`, `weightedDegree`, `weightedDegreeZeroSubgroup`, and `pushforward` APIs, together with Mathlib’s finite-sum lemmas.

`lake exe cache get` completed with `No files to download` and `Already decompressed 8601 file(s)`. `lake build` completed with `Build completed successfully (4300 jobs).` `lake exe axioms` completed with `axioms: audited 5899 TauCeti declaration(s); all within the allowlist [propext, Classical.choice, Quot.sound].`

<!--tauceti-target:v1 {"focus":"JacobianChallenge","id":"effective-divisor-finite-sums"}-->

🤖 Prepared with Codex
