### PR TITLE
feat: add plumbing cube face generators

### DIFF
--- a/TauCeti/LowDimTopology/Plumbing/CubeGenerator.lean
+++ b/TauCeti/LowDimTopology/Plumbing/CubeGenerator.lean
@@ -68,13 +68,15 @@ abbrev dimension (C : PlumbingCube V) : ℕ :=
 
 /-- The lower codimension-one face in a present direction `v`: keep the base point and remove
 `v` from the direction set. -/
-abbrev lowerFace (C : PlumbingCube V) (v : V) (_hv : v ∈ C.directions) : PlumbingCube V where
+irreducible_def lowerFace (C : PlumbingCube V) (v : V)
+    (_hv : v ∈ C.directions) : PlumbingCube V where
   base := C.base
   directions := C.directions.erase v
 
 /-- The upper codimension-one face in a present direction `v`: shift the base point by `E_v` and
 remove `v` from the direction set. -/
-abbrev upperFace (C : PlumbingCube V) (v : V) (_hv : v ∈ C.directions) : PlumbingCube V where
+irreducible_def upperFace (C : PlumbingCube V) (v : V)
+    (_hv : v ∈ C.directions) : PlumbingCube V where
   base := C.base + Pi.single v (1 : ℤ)
   directions := C.directions.erase v
 
@@ -88,67 +90,71 @@ theorem dimension_mk (x : V → ℤ) (S : Finset V) :
 theorem lowerFace_mk (x : V → ℤ) (S : Finset V) (v : V) (hv : v ∈ S) :
     lowerFace ({ base := x, directions := S } : PlumbingCube V) v hv =
       ({ base := x, directions := S.erase v } : PlumbingCube V) :=
-  rfl
+  by simp [lowerFace_def]
 
 @[simp]
 theorem upperFace_mk (x : V → ℤ) (S : Finset V) (v : V) (hv : v ∈ S) :
     upperFace ({ base := x, directions := S } : PlumbingCube V) v hv =
       ({ base := x + Pi.single v (1 : ℤ), directions := S.erase v } : PlumbingCube V) :=
-  rfl
+  by simp [upperFace_def]
 
 @[simp]
 theorem lowerFace_base (C : PlumbingCube V) (v : V) (hv : v ∈ C.directions) :
     (C.lowerFace v hv).base = C.base :=
-  rfl
+  by simp [lowerFace_def]
 
 @[simp]
 theorem lowerFace_directions (C : PlumbingCube V) (v : V) (hv : v ∈ C.directions) :
     (C.lowerFace v hv).directions = C.directions.erase v :=
-  rfl
+  by simp [lowerFace_def]
 
 @[simp]
 theorem upperFace_base (C : PlumbingCube V) (v : V) (hv : v ∈ C.directions) :
     (C.upperFace v hv).base = C.base + Pi.single v (1 : ℤ) :=
-  rfl
+  by simp [upperFace_def]
 
 @[simp]
 theorem upperFace_directions (C : PlumbingCube V) (v : V) (hv : v ∈ C.directions) :
     (C.upperFace v hv).directions = C.directions.erase v :=
-  rfl
+  by simp [upperFace_def]
 
 variable [DecidableEq (V → ℤ)]
 
 /-- The vertices of a bundled plumbing cube. -/
-noncomputable abbrev vertices (C : PlumbingCube V) : Finset (V → ℤ) :=
+noncomputable irreducible_def vertices (C : PlumbingCube V) : Finset (V → ℤ) :=
   PlumbingGraph.cubeVertices C.base C.directions
 
 @[simp]
 theorem vertices_mk (x : V → ℤ) (S : Finset V) :
     vertices ({ base := x, directions := S } : PlumbingCube V) =
       PlumbingGraph.cubeVertices x S :=
-  rfl
+  by simp [vertices_def]
 
 /-- Membership in the vertices of a bundled cube, expressed by a direction subset. -/
 theorem mem_vertices (C : PlumbingCube V) (y : V → ℤ) :
     y ∈ C.vertices ↔ ∃ T ⊆ C.directions, PlumbingGraph.cubeVertex C.base T = y :=
-  PlumbingGraph.mem_cubeVertices C.base C.directions y
+  by simpa [vertices_def] using PlumbingGraph.mem_cubeVertices C.base C.directions y
 
 /-- The base point is a vertex of every bundled cube. -/
 @[simp]
 theorem base_mem_vertices (C : PlumbingCube V) :
     C.base ∈ C.vertices :=
-  PlumbingGraph.base_mem_cubeVertices C.base C.directions
+  by simp [vertices_def]
 
 /-- The lower face's vertices are vertices of the ambient cube. -/
 theorem vertices_lowerFace_subset (C : PlumbingCube V) {v : V} (hv : v ∈ C.directions) :
     (C.lowerFace v hv).vertices ⊆ C.vertices :=
-  PlumbingGraph.cubeVertices_subset (Finset.erase_subset v C.directions) C.base
+  by
+    simpa [vertices_def, lowerFace_base, lowerFace_directions] using
+      PlumbingGraph.cubeVertices_subset (Finset.erase_subset v C.directions) C.base
 
 /-- The upper face's vertices are vertices of the ambient cube when the face direction belongs to
 the ambient cube. -/
 theorem vertices_upperFace_subset (C : PlumbingCube V) {v : V} (hv : v ∈ C.directions) :
     (C.upperFace v hv).vertices ⊆ C.vertices :=
-  PlumbingGraph.cubeVertices_upperFace_subset hv
+  by
+    simpa [vertices_def, upperFace_base, upperFace_directions] using
+      PlumbingGraph.cubeVertices_upperFace_subset (x := C.base) hv
 
 omit [DecidableEq (V → ℤ)] in
 /-- Removing a present direction drops the cubical dimension by one for the lower face. -/
@@ -165,7 +171,7 @@ theorem dimension_upperFace_of_mem (C : PlumbingCube V) {v : V} (hv : v ∈ C.di
   rw [dimension, dimension, upperFace_directions, Finset.card_erase_of_mem hv]
 
 /-- The characteristic cube weight of a bundled plumbing cube. -/
-noncomputable abbrev characteristicWeight [Fintype V] (P : PlumbingGraph V)
+noncomputable irreducible_def characteristicWeight [Fintype V] (P : PlumbingGraph V)
     (k : P.characteristicVectors) (C : PlumbingCube V) : ℤ :=
   P.characteristicCubeWeight k C.base C.directions
 
@@ -174,27 +180,31 @@ theorem characteristicWeight_mk [Fintype V] (P : PlumbingGraph V)
     (k : P.characteristicVectors) (x : V → ℤ) (S : Finset V) :
     characteristicWeight P k ({ base := x, directions := S } : PlumbingCube V) =
       P.characteristicCubeWeight k x S :=
-  rfl
+  by simp [characteristicWeight_def]
 
 /-- The lower face's characteristic weight is bounded by the ambient cube weight. -/
 theorem characteristicWeight_lowerFace_le [Fintype V] (P : PlumbingGraph V)
     (k : P.characteristicVectors) (C : PlumbingCube V) {v : V} (hv : v ∈ C.directions) :
     characteristicWeight P k (C.lowerFace v hv) ≤ characteristicWeight P k C :=
-  P.characteristicCubeWeight_mono k (Finset.erase_subset v C.directions) C.base
+  by
+    simpa [characteristicWeight_def, lowerFace_base, lowerFace_directions] using
+      P.characteristicCubeWeight_mono k (Finset.erase_subset v C.directions) C.base
 
 /-- The upper face's characteristic weight is bounded by the ambient cube weight. -/
 theorem characteristicWeight_upperFace_le [Fintype V] (P : PlumbingGraph V)
     (k : P.characteristicVectors) (C : PlumbingCube V) {v : V} (hv : v ∈ C.directions) :
     characteristicWeight P k (C.upperFace v hv) ≤ characteristicWeight P k C :=
-  P.characteristicUpperFaceWeight_le k hv
+  by
+    simpa [characteristicWeight_def, upperFace_base, upperFace_directions] using
+      P.characteristicUpperFaceWeight_le (x := C.base) k hv
 
 /-- The nonnegative exponent of the lower face in the lattice-homology differential. -/
-noncomputable abbrev characteristicLowerFaceExponent [Fintype V] (P : PlumbingGraph V)
+noncomputable irreducible_def characteristicLowerFaceExponent [Fintype V] (P : PlumbingGraph V)
     (k : P.characteristicVectors) (C : PlumbingCube V) {v : V} (_hv : v ∈ C.directions) : ℕ :=
   P.characteristicLowerFaceExponent k C.base C.directions v
 
 /-- The nonnegative exponent of the upper face in the lattice-homology differential. -/
-noncomputable abbrev characteristicUpperFaceExponent [Fintype V] (P : PlumbingGraph V)
+noncomputable irreducible_def characteristicUpperFaceExponent [Fintype V] (P : PlumbingGraph V)
     (k : P.characteristicVectors) (C : PlumbingCube V) {v : V} (hv : v ∈ C.directions) : ℕ :=
   P.characteristicUpperFaceExponent k C.base C.directions hv
 
@@ -203,14 +213,14 @@ theorem characteristicLowerFaceExponent_mk [Fintype V] (P : PlumbingGraph V)
     (k : P.characteristicVectors) (x : V → ℤ) (S : Finset V) {v : V} (hv : v ∈ S) :
     characteristicLowerFaceExponent P k ({ base := x, directions := S } : PlumbingCube V) hv =
       P.characteristicLowerFaceExponent k x S v :=
-  rfl
+  by simp [characteristicLowerFaceExponent_def]
 
 @[simp]
 theorem characteristicUpperFaceExponent_mk [Fintype V] (P : PlumbingGraph V)
     (k : P.characteristicVectors) (x : V → ℤ) (S : Finset V) {v : V} (hv : v ∈ S) :
     characteristicUpperFaceExponent P k ({ base := x, directions := S } : PlumbingCube V) hv =
       P.characteristicUpperFaceExponent k x S hv :=
-  rfl
+  by simp [characteristicUpperFaceExponent_def]
 
 /-- The lower-face exponent is the weight difference between the ambient cube and the lower face. -/
 @[simp]
@@ -218,7 +228,9 @@ theorem characteristicLowerFaceExponent_natCast [Fintype V] (P : PlumbingGraph V
     (k : P.characteristicVectors) (C : PlumbingCube V) {v : V} (hv : v ∈ C.directions) :
     (characteristicLowerFaceExponent P k C hv : ℤ) =
       characteristicWeight P k C - characteristicWeight P k (C.lowerFace v hv) :=
-  P.characteristicLowerFaceExponent_natCast k
+  by
+    simp [characteristicLowerFaceExponent_def, characteristicWeight_def, lowerFace_base,
+      lowerFace_directions]
 
 /-- The upper-face exponent is the weight difference between the ambient cube and the upper face. -/
 @[simp]
@@ -226,7 +238,9 @@ theorem characteristicUpperFaceExponent_natCast [Fintype V] (P : PlumbingGraph V
     (k : P.characteristicVectors) (C : PlumbingCube V) {v : V} (hv : v ∈ C.directions) :
     (characteristicUpperFaceExponent P k C hv : ℤ) =
       characteristicWeight P k C - characteristicWeight P k (C.upperFace v hv) :=
-  P.characteristicUpperFaceExponent_natCast k hv
+  by
+    simp [characteristicUpperFaceExponent_def, characteristicWeight_def, upperFace_base,
+      upperFace_directions]
 
 /-- The lower-face exponent vanishes exactly when the lower face has the ambient cube's
 characteristic weight. -/
@@ -234,7 +248,10 @@ theorem characteristicLowerFaceExponent_eq_zero_iff [Fintype V] (P : PlumbingGra
     (k : P.characteristicVectors) (C : PlumbingCube V) {v : V} (hv : v ∈ C.directions) :
     characteristicLowerFaceExponent P k C hv = 0 ↔
       characteristicWeight P k C = characteristicWeight P k (C.lowerFace v hv) :=
-  P.characteristicLowerFaceExponent_eq_zero_iff k
+  by
+    simpa [characteristicLowerFaceExponent_def, characteristicWeight_def, lowerFace_base,
+      lowerFace_directions] using
+      P.characteristicLowerFaceExponent_eq_zero_iff (x := C.base) (S := C.directions) (v := v) k
 
 /-- The upper-face exponent vanishes exactly when the upper face has the ambient cube's
 characteristic weight. -/
@@ -242,7 +259,10 @@ theorem characteristicUpperFaceExponent_eq_zero_iff [Fintype V] (P : PlumbingGra
     (k : P.characteristicVectors) (C : PlumbingCube V) {v : V} (hv : v ∈ C.directions) :
     characteristicUpperFaceExponent P k C hv = 0 ↔
       characteristicWeight P k C = characteristicWeight P k (C.upperFace v hv) :=
-  P.characteristicUpperFaceExponent_eq_zero_iff k hv
+  by
+    simpa [characteristicUpperFaceExponent_def, characteristicWeight_def, upperFace_base,
+      upperFace_directions] using
+      P.characteristicUpperFaceExponent_eq_zero_iff (x := C.base) k hv
 
 /-- In any present direction, the characteristic weight of a cube is the maximum of the weights
 of its lower and upper faces. -/
@@ -251,7 +271,10 @@ theorem characteristicWeight_eq_max_faces [Fintype V] (P : PlumbingGraph V)
     characteristicWeight P k C =
       max (characteristicWeight P k (C.lowerFace v hv))
         (characteristicWeight P k (C.upperFace v hv)) :=
-  P.characteristicCubeWeight_eq_max_erase k C.base hv
+  by
+    simpa [characteristicWeight_def, lowerFace_base, lowerFace_directions, upperFace_base,
+      upperFace_directions] using
+      P.characteristicCubeWeight_eq_max_erase k C.base hv
 
 /-- In any present direction, at least one of the two face exponents vanishes. -/
 @[simp]
@@ -259,7 +282,8 @@ theorem min_characteristicFaceExponent_eq_zero [Fintype V] (P : PlumbingGraph V)
     (k : P.characteristicVectors) (C : PlumbingCube V) {v : V} (hv : v ∈ C.directions) :
     min (characteristicLowerFaceExponent P k C hv)
       (characteristicUpperFaceExponent P k C hv) = 0 :=
-  P.min_characteristicFaceExponent_eq_zero k C.base hv
+  by
+    simp [characteristicLowerFaceExponent_def, characteristicUpperFaceExponent_def]
 
 end PlumbingCube
 

--- a/TauCeti/LowDimTopology/Plumbing/CubeGenerator.lean
+++ b/TauCeti/LowDimTopology/Plumbing/CubeGenerator.lean
@@ -25,6 +25,8 @@ lattice-homology differential can use directly.
   codimension-one faces in a direction.
 * `TauCeti.PlumbingCube.characteristicWeight`: the characteristic cube weight of a bundled
   generator.
+* `TauCeti.PlumbingCube.characteristicLowerFaceExponent` and
+  `TauCeti.PlumbingCube.characteristicUpperFaceExponent`: the bundled face exponents.
 
 ## References
 
@@ -187,6 +189,86 @@ theorem characteristicWeight_mk [Fintype V] (P : PlumbingGraph V)
     characteristicWeight P k ({ base := x, directions := S } : PlumbingCube V) =
       P.characteristicCubeWeight k x S :=
   by simp [characteristicWeight_def]
+
+/-- The nonnegative `U`-exponent contributed by the lower face of a bundled cube. -/
+noncomputable irreducible_def characteristicLowerFaceExponent [Fintype V] (P : PlumbingGraph V)
+    (k : P.characteristicVectors) (C : PlumbingCube V) (v : V) : ℕ :=
+  P.characteristicLowerFaceExponent k C.base C.directions v
+
+/-- The nonnegative `U`-exponent contributed by the upper face of a bundled cube. -/
+noncomputable irreducible_def characteristicUpperFaceExponent [Fintype V] (P : PlumbingGraph V)
+    (k : P.characteristicVectors) (C : PlumbingCube V) {v : V}
+    (hv : v ∈ C.directions) : ℕ :=
+  P.characteristicUpperFaceExponent k C.base C.directions hv
+
+@[simp]
+theorem characteristicLowerFaceExponent_mk [Fintype V] (P : PlumbingGraph V)
+    (k : P.characteristicVectors) (x : V → ℤ) (S : Finset V) (v : V) :
+    characteristicLowerFaceExponent P k ({ base := x, directions := S } : PlumbingCube V) v =
+      P.characteristicLowerFaceExponent k x S v :=
+  by simp [characteristicLowerFaceExponent_def]
+
+@[simp]
+theorem characteristicUpperFaceExponent_mk [Fintype V] (P : PlumbingGraph V)
+    (k : P.characteristicVectors) (x : V → ℤ) (S : Finset V) {v : V} (hv : v ∈ S) :
+    characteristicUpperFaceExponent P k ({ base := x, directions := S } : PlumbingCube V) hv =
+      P.characteristicUpperFaceExponent k x S hv :=
+  by simp [characteristicUpperFaceExponent_def]
+
+/-- The lower-face exponent, cast back to `ℤ`, is the difference between the bundled cube weight
+and the lower face weight. -/
+@[simp]
+theorem characteristicLowerFaceExponent_natCast [Fintype V] (P : PlumbingGraph V)
+    (k : P.characteristicVectors) (C : PlumbingCube V) (v : V) :
+    (characteristicLowerFaceExponent P k C v : ℤ) =
+      characteristicWeight P k C - characteristicWeight P k (C.lowerFace v) :=
+  by
+    simp [characteristicLowerFaceExponent_def, characteristicWeight_def, lowerFace_base,
+      lowerFace_directions]
+
+/-- The upper-face exponent, cast back to `ℤ`, is the difference between the bundled cube weight
+and the upper face weight. -/
+@[simp]
+theorem characteristicUpperFaceExponent_natCast [Fintype V] (P : PlumbingGraph V)
+    (k : P.characteristicVectors) (C : PlumbingCube V) {v : V} (hv : v ∈ C.directions) :
+    (characteristicUpperFaceExponent P k C hv : ℤ) =
+      characteristicWeight P k C - characteristicWeight P k (C.upperFace v hv) :=
+  by
+    simp [characteristicUpperFaceExponent_def, characteristicWeight_def, upperFace_base,
+      upperFace_directions]
+
+/-- The lower-face exponent is zero exactly when the lower face has the same bundled weight as the
+ambient cube. -/
+theorem characteristicLowerFaceExponent_eq_zero_iff [Fintype V] (P : PlumbingGraph V)
+    (k : P.characteristicVectors) (C : PlumbingCube V) (v : V) :
+    characteristicLowerFaceExponent P k C v = 0 ↔
+      characteristicWeight P k C = characteristicWeight P k (C.lowerFace v) :=
+  by
+    simpa [characteristicLowerFaceExponent_def, characteristicWeight_def, lowerFace_base,
+      lowerFace_directions] using
+      P.characteristicLowerFaceExponent_eq_zero_iff (k := k) (x := C.base) (S := C.directions)
+        (v := v)
+
+/-- The upper-face exponent is zero exactly when the upper face has the same bundled weight as the
+ambient cube. -/
+theorem characteristicUpperFaceExponent_eq_zero_iff [Fintype V] (P : PlumbingGraph V)
+    (k : P.characteristicVectors) (C : PlumbingCube V) {v : V} (hv : v ∈ C.directions) :
+    characteristicUpperFaceExponent P k C hv = 0 ↔
+      characteristicWeight P k C = characteristicWeight P k (C.upperFace v hv) :=
+  by
+    simpa [characteristicUpperFaceExponent_def, characteristicWeight_def, upperFace_base,
+      upperFace_directions] using
+      P.characteristicUpperFaceExponent_eq_zero_iff (k := k) (x := C.base) (S := C.directions)
+        hv
+
+/-- In any bundled cube direction, at least one face exponent is zero. -/
+@[simp]
+theorem min_characteristicFaceExponent_eq_zero [Fintype V] (P : PlumbingGraph V)
+    (k : P.characteristicVectors) (C : PlumbingCube V) {v : V} (hv : v ∈ C.directions) :
+    min (characteristicLowerFaceExponent P k C v)
+      (characteristicUpperFaceExponent P k C hv) = 0 :=
+  by
+    simp [characteristicLowerFaceExponent_def, characteristicUpperFaceExponent_def]
 
 /-- The lower face's characteristic weight is bounded by the ambient cube weight. -/
 theorem characteristicWeight_lowerFace_le [Fintype V] (P : PlumbingGraph V)

--- a/TauCeti/LowDimTopology/Plumbing/CubeGenerator.lean
+++ b/TauCeti/LowDimTopology/Plumbing/CubeGenerator.lean
@@ -63,45 +63,63 @@ theorem ext {C D : PlumbingCube V} (hbase : C.base = D.base)
   simp_all
 
 /-- The cubical dimension of a plumbing cube, namely the number of basis directions. -/
-@[expose] def dimension (C : PlumbingCube V) : ℕ :=
+abbrev dimension (C : PlumbingCube V) : ℕ :=
   C.directions.card
 
-/-- The lower codimension-one face in direction `v`: keep the base point and remove `v` from the
-direction set. -/
-@[expose] def lowerFace (C : PlumbingCube V) (v : V) : PlumbingCube V where
+/-- The lower codimension-one face in a present direction `v`: keep the base point and remove
+`v` from the direction set. -/
+abbrev lowerFace (C : PlumbingCube V) (v : V) (_hv : v ∈ C.directions) : PlumbingCube V where
   base := C.base
   directions := C.directions.erase v
 
-/-- The upper codimension-one face in direction `v`: shift the base point by `E_v` and remove
-`v` from the direction set. -/
-@[expose] def upperFace (C : PlumbingCube V) (v : V) : PlumbingCube V where
+/-- The upper codimension-one face in a present direction `v`: shift the base point by `E_v` and
+remove `v` from the direction set. -/
+abbrev upperFace (C : PlumbingCube V) (v : V) (_hv : v ∈ C.directions) : PlumbingCube V where
   base := C.base + Pi.single v (1 : ℤ)
   directions := C.directions.erase v
 
+omit [DecidableEq V] in
 @[simp]
-theorem lowerFace_base (C : PlumbingCube V) (v : V) :
-    (C.lowerFace v).base = C.base :=
+theorem dimension_mk (x : V → ℤ) (S : Finset V) :
+    dimension ({ base := x, directions := S } : PlumbingCube V) = S.card :=
   rfl
 
 @[simp]
-theorem lowerFace_directions (C : PlumbingCube V) (v : V) :
-    (C.lowerFace v).directions = C.directions.erase v :=
+theorem lowerFace_mk (x : V → ℤ) (S : Finset V) (v : V) (hv : v ∈ S) :
+    lowerFace ({ base := x, directions := S } : PlumbingCube V) v hv =
+      ({ base := x, directions := S.erase v } : PlumbingCube V) :=
   rfl
 
 @[simp]
-theorem upperFace_base (C : PlumbingCube V) (v : V) :
-    (C.upperFace v).base = C.base + Pi.single v (1 : ℤ) :=
+theorem upperFace_mk (x : V → ℤ) (S : Finset V) (v : V) (hv : v ∈ S) :
+    upperFace ({ base := x, directions := S } : PlumbingCube V) v hv =
+      ({ base := x + Pi.single v (1 : ℤ), directions := S.erase v } : PlumbingCube V) :=
   rfl
 
 @[simp]
-theorem upperFace_directions (C : PlumbingCube V) (v : V) :
-    (C.upperFace v).directions = C.directions.erase v :=
+theorem lowerFace_base (C : PlumbingCube V) (v : V) (hv : v ∈ C.directions) :
+    (C.lowerFace v hv).base = C.base :=
+  rfl
+
+@[simp]
+theorem lowerFace_directions (C : PlumbingCube V) (v : V) (hv : v ∈ C.directions) :
+    (C.lowerFace v hv).directions = C.directions.erase v :=
+  rfl
+
+@[simp]
+theorem upperFace_base (C : PlumbingCube V) (v : V) (hv : v ∈ C.directions) :
+    (C.upperFace v hv).base = C.base + Pi.single v (1 : ℤ) :=
+  rfl
+
+@[simp]
+theorem upperFace_directions (C : PlumbingCube V) (v : V) (hv : v ∈ C.directions) :
+    (C.upperFace v hv).directions = C.directions.erase v :=
   rfl
 
 variable [DecidableEq (V → ℤ)]
 
 /-- The vertices of a bundled plumbing cube. -/
-@[expose] noncomputable def vertices (C : PlumbingCube V) : Finset (V → ℤ) :=
+noncomputable abbrev vertices (C : PlumbingCube V) : Finset (V → ℤ) :=
   PlumbingGraph.cubeVertices C.base C.directions
 
 @[simp]
@@ -110,33 +128,44 @@ theorem vertices_mk (x : V → ℤ) (S : Finset V) :
       PlumbingGraph.cubeVertices x S :=
   rfl
 
+/-- Membership in the vertices of a bundled cube, expressed by a direction subset. -/
+theorem mem_vertices (C : PlumbingCube V) (y : V → ℤ) :
+    y ∈ C.vertices ↔ ∃ T ⊆ C.directions, PlumbingGraph.cubeVertex C.base T = y :=
+  PlumbingGraph.mem_cubeVertices C.base C.directions y
+
+/-- The base point is a vertex of every bundled cube. -/
+@[simp]
+theorem base_mem_vertices (C : PlumbingCube V) :
+    C.base ∈ C.vertices :=
+  PlumbingGraph.base_mem_cubeVertices C.base C.directions
+
 /-- The lower face's vertices are vertices of the ambient cube. -/
-theorem vertices_lowerFace_subset (C : PlumbingCube V) (v : V) :
-    (C.lowerFace v).vertices ⊆ C.vertices :=
+theorem vertices_lowerFace_subset (C : PlumbingCube V) {v : V} (hv : v ∈ C.directions) :
+    (C.lowerFace v hv).vertices ⊆ C.vertices :=
   PlumbingGraph.cubeVertices_subset (Finset.erase_subset v C.directions) C.base
 
 /-- The upper face's vertices are vertices of the ambient cube when the face direction belongs to
 the ambient cube. -/
 theorem vertices_upperFace_subset (C : PlumbingCube V) {v : V} (hv : v ∈ C.directions) :
-    (C.upperFace v).vertices ⊆ C.vertices :=
+    (C.upperFace v hv).vertices ⊆ C.vertices :=
   PlumbingGraph.cubeVertices_upperFace_subset hv
 
 omit [DecidableEq (V → ℤ)] in
 /-- Removing a present direction drops the cubical dimension by one for the lower face. -/
 @[simp]
 theorem dimension_lowerFace_of_mem (C : PlumbingCube V) {v : V} (hv : v ∈ C.directions) :
-    (C.lowerFace v).dimension = C.dimension - 1 := by
+    (C.lowerFace v hv).dimension = C.dimension - 1 := by
   rw [dimension, dimension, lowerFace_directions, Finset.card_erase_of_mem hv]
 
 omit [DecidableEq (V → ℤ)] in
 /-- Removing a present direction drops the cubical dimension by one for the upper face. -/
 @[simp]
 theorem dimension_upperFace_of_mem (C : PlumbingCube V) {v : V} (hv : v ∈ C.directions) :
-    (C.upperFace v).dimension = C.dimension - 1 := by
+    (C.upperFace v hv).dimension = C.dimension - 1 := by
   rw [dimension, dimension, upperFace_directions, Finset.card_erase_of_mem hv]
 
 /-- The characteristic cube weight of a bundled plumbing cube. -/
-@[expose] noncomputable def characteristicWeight [Fintype V] (P : PlumbingGraph V)
+noncomputable abbrev characteristicWeight [Fintype V] (P : PlumbingGraph V)
     (k : P.characteristicVectors) (C : PlumbingCube V) : ℤ :=
   P.characteristicCubeWeight k C.base C.directions
 
@@ -149,32 +178,46 @@ theorem characteristicWeight_mk [Fintype V] (P : PlumbingGraph V)
 
 /-- The lower face's characteristic weight is bounded by the ambient cube weight. -/
 theorem characteristicWeight_lowerFace_le [Fintype V] (P : PlumbingGraph V)
-    (k : P.characteristicVectors) (C : PlumbingCube V) (v : V) :
-    characteristicWeight P k (C.lowerFace v) ≤ characteristicWeight P k C :=
+    (k : P.characteristicVectors) (C : PlumbingCube V) {v : V} (hv : v ∈ C.directions) :
+    characteristicWeight P k (C.lowerFace v hv) ≤ characteristicWeight P k C :=
   P.characteristicCubeWeight_mono k (Finset.erase_subset v C.directions) C.base
 
 /-- The upper face's characteristic weight is bounded by the ambient cube weight. -/
 theorem characteristicWeight_upperFace_le [Fintype V] (P : PlumbingGraph V)
     (k : P.characteristicVectors) (C : PlumbingCube V) {v : V} (hv : v ∈ C.directions) :
-    characteristicWeight P k (C.upperFace v) ≤ characteristicWeight P k C :=
+    characteristicWeight P k (C.upperFace v hv) ≤ characteristicWeight P k C :=
   P.characteristicUpperFaceWeight_le k hv
 
 /-- The nonnegative exponent of the lower face in the lattice-homology differential. -/
-noncomputable def characteristicLowerFaceExponent [Fintype V] (P : PlumbingGraph V)
-    (k : P.characteristicVectors) (C : PlumbingCube V) (v : V) : ℕ :=
+noncomputable abbrev characteristicLowerFaceExponent [Fintype V] (P : PlumbingGraph V)
+    (k : P.characteristicVectors) (C : PlumbingCube V) {v : V} (_hv : v ∈ C.directions) : ℕ :=
   P.characteristicLowerFaceExponent k C.base C.directions v
 
 /-- The nonnegative exponent of the upper face in the lattice-homology differential. -/
-noncomputable def characteristicUpperFaceExponent [Fintype V] (P : PlumbingGraph V)
+noncomputable abbrev characteristicUpperFaceExponent [Fintype V] (P : PlumbingGraph V)
     (k : P.characteristicVectors) (C : PlumbingCube V) {v : V} (hv : v ∈ C.directions) : ℕ :=
   P.characteristicUpperFaceExponent k C.base C.directions hv
+
+@[simp]
+theorem characteristicLowerFaceExponent_mk [Fintype V] (P : PlumbingGraph V)
+    (k : P.characteristicVectors) (x : V → ℤ) (S : Finset V) {v : V} (hv : v ∈ S) :
+    characteristicLowerFaceExponent P k ({ base := x, directions := S } : PlumbingCube V) hv =
+      P.characteristicLowerFaceExponent k x S v :=
+  rfl
+
+@[simp]
+theorem characteristicUpperFaceExponent_mk [Fintype V] (P : PlumbingGraph V)
+    (k : P.characteristicVectors) (x : V → ℤ) (S : Finset V) {v : V} (hv : v ∈ S) :
+    characteristicUpperFaceExponent P k ({ base := x, directions := S } : PlumbingCube V) hv =
+      P.characteristicUpperFaceExponent k x S hv :=
+  rfl
 
 /-- The lower-face exponent is the weight difference between the ambient cube and the lower face. -/
 @[simp]
 theorem characteristicLowerFaceExponent_natCast [Fintype V] (P : PlumbingGraph V)
-    (k : P.characteristicVectors) (C : PlumbingCube V) (v : V) :
-    (characteristicLowerFaceExponent P k C v : ℤ) =
-      characteristicWeight P k C - characteristicWeight P k (C.lowerFace v) :=
+    (k : P.characteristicVectors) (C : PlumbingCube V) {v : V} (hv : v ∈ C.directions) :
+    (characteristicLowerFaceExponent P k C hv : ℤ) =
+      characteristicWeight P k C - characteristicWeight P k (C.lowerFace v hv) :=
   P.characteristicLowerFaceExponent_natCast k
 
 /-- The upper-face exponent is the weight difference between the ambient cube and the upper face. -/
@@ -182,23 +225,39 @@ theorem characteristicLowerFaceExponent_natCast [Fintype V] (P : PlumbingGraph V
 theorem characteristicUpperFaceExponent_natCast [Fintype V] (P : PlumbingGraph V)
     (k : P.characteristicVectors) (C : PlumbingCube V) {v : V} (hv : v ∈ C.directions) :
     (characteristicUpperFaceExponent P k C hv : ℤ) =
-      characteristicWeight P k C - characteristicWeight P k (C.upperFace v) :=
+      characteristicWeight P k C - characteristicWeight P k (C.upperFace v hv) :=
   P.characteristicUpperFaceExponent_natCast k hv
+
+/-- The lower-face exponent vanishes exactly when the lower face has the ambient cube's
+characteristic weight. -/
+theorem characteristicLowerFaceExponent_eq_zero_iff [Fintype V] (P : PlumbingGraph V)
+    (k : P.characteristicVectors) (C : PlumbingCube V) {v : V} (hv : v ∈ C.directions) :
+    characteristicLowerFaceExponent P k C hv = 0 ↔
+      characteristicWeight P k C = characteristicWeight P k (C.lowerFace v hv) :=
+  P.characteristicLowerFaceExponent_eq_zero_iff k
+
+/-- The upper-face exponent vanishes exactly when the upper face has the ambient cube's
+characteristic weight. -/
+theorem characteristicUpperFaceExponent_eq_zero_iff [Fintype V] (P : PlumbingGraph V)
+    (k : P.characteristicVectors) (C : PlumbingCube V) {v : V} (hv : v ∈ C.directions) :
+    characteristicUpperFaceExponent P k C hv = 0 ↔
+      characteristicWeight P k C = characteristicWeight P k (C.upperFace v hv) :=
+  P.characteristicUpperFaceExponent_eq_zero_iff k hv
 
 /-- In any present direction, the characteristic weight of a cube is the maximum of the weights
 of its lower and upper faces. -/
 theorem characteristicWeight_eq_max_faces [Fintype V] (P : PlumbingGraph V)
     (k : P.characteristicVectors) (C : PlumbingCube V) {v : V} (hv : v ∈ C.directions) :
     characteristicWeight P k C =
-      max (characteristicWeight P k (C.lowerFace v))
-        (characteristicWeight P k (C.upperFace v)) :=
+      max (characteristicWeight P k (C.lowerFace v hv))
+        (characteristicWeight P k (C.upperFace v hv)) :=
   P.characteristicCubeWeight_eq_max_erase k C.base hv
 
 /-- In any present direction, at least one of the two face exponents vanishes. -/
 @[simp]
 theorem min_characteristicFaceExponent_eq_zero [Fintype V] (P : PlumbingGraph V)
     (k : P.characteristicVectors) (C : PlumbingCube V) {v : V} (hv : v ∈ C.directions) :
-    min (characteristicLowerFaceExponent P k C v)
+    min (characteristicLowerFaceExponent P k C hv)
       (characteristicUpperFaceExponent P k C hv) = 0 :=
   P.min_characteristicFaceExponent_eq_zero k C.base hv
 

--- a/TauCeti/LowDimTopology/Plumbing/CubeGenerator.lean
+++ b/TauCeti/LowDimTopology/Plumbing/CubeGenerator.lean
@@ -25,8 +25,6 @@ lattice-homology differential can use directly.
   codimension-one faces in a direction.
 * `TauCeti.PlumbingCube.characteristicWeight`: the characteristic cube weight of a bundled
   generator.
-* `TauCeti.PlumbingCube.characteristicLowerFaceExponent` and
-  `TauCeti.PlumbingCube.characteristicUpperFaceExponent`: the `U`-exponents of the two faces.
 
 ## References
 
@@ -66,10 +64,9 @@ theorem ext {C D : PlumbingCube V} (hbase : C.base = D.base)
 abbrev dimension (C : PlumbingCube V) : ℕ :=
   C.directions.card
 
-/-- The lower codimension-one face in a present direction `v`: keep the base point and remove
-`v` from the direction set. -/
-irreducible_def lowerFace (C : PlumbingCube V) (v : V)
-    (_hv : v ∈ C.directions) : PlumbingCube V where
+/-- The lower codimension-one face in a direction `v`: keep the base point and remove `v` from the
+direction set. -/
+irreducible_def lowerFace (C : PlumbingCube V) (v : V) : PlumbingCube V where
   base := C.base
   directions := C.directions.erase v
 
@@ -87,8 +84,8 @@ theorem dimension_mk (x : V → ℤ) (S : Finset V) :
   rfl
 
 @[simp]
-theorem lowerFace_mk (x : V → ℤ) (S : Finset V) (v : V) (hv : v ∈ S) :
-    lowerFace ({ base := x, directions := S } : PlumbingCube V) v hv =
+theorem lowerFace_mk (x : V → ℤ) (S : Finset V) (v : V) :
+    lowerFace ({ base := x, directions := S } : PlumbingCube V) v =
       ({ base := x, directions := S.erase v } : PlumbingCube V) :=
   by simp [lowerFace_def]
 
@@ -99,13 +96,13 @@ theorem upperFace_mk (x : V → ℤ) (S : Finset V) (v : V) (hv : v ∈ S) :
   by simp [upperFace_def]
 
 @[simp]
-theorem lowerFace_base (C : PlumbingCube V) (v : V) (hv : v ∈ C.directions) :
-    (C.lowerFace v hv).base = C.base :=
+theorem lowerFace_base (C : PlumbingCube V) (v : V) :
+    (C.lowerFace v).base = C.base :=
   by simp [lowerFace_def]
 
 @[simp]
-theorem lowerFace_directions (C : PlumbingCube V) (v : V) (hv : v ∈ C.directions) :
-    (C.lowerFace v hv).directions = C.directions.erase v :=
+theorem lowerFace_directions (C : PlumbingCube V) (v : V) :
+    (C.lowerFace v).directions = C.directions.erase v :=
   by simp [lowerFace_def]
 
 @[simp]
@@ -142,8 +139,8 @@ theorem base_mem_vertices (C : PlumbingCube V) :
   by simp [vertices_def]
 
 /-- The lower face's vertices are vertices of the ambient cube. -/
-theorem vertices_lowerFace_subset (C : PlumbingCube V) {v : V} (hv : v ∈ C.directions) :
-    (C.lowerFace v hv).vertices ⊆ C.vertices :=
+theorem vertices_lowerFace_subset (C : PlumbingCube V) (v : V) :
+    (C.lowerFace v).vertices ⊆ C.vertices :=
   by
     simpa [vertices_def, lowerFace_base, lowerFace_directions] using
       PlumbingGraph.cubeVertices_subset (Finset.erase_subset v C.directions) C.base
@@ -156,11 +153,20 @@ theorem vertices_upperFace_subset (C : PlumbingCube V) {v : V} (hv : v ∈ C.dir
     simpa [vertices_def, upperFace_base, upperFace_directions] using
       PlumbingGraph.cubeVertices_upperFace_subset (x := C.base) hv
 
+/-- The vertices of a bundled cube split as the union of the vertices of its lower and upper faces
+in any present direction. -/
+theorem vertices_eq_union_faces (C : PlumbingCube V) {v : V} (hv : v ∈ C.directions) :
+    C.vertices = (C.lowerFace v).vertices ∪ (C.upperFace v hv).vertices :=
+  by
+    simpa [vertices_def, lowerFace_base, lowerFace_directions, upperFace_base,
+      upperFace_directions] using
+      PlumbingGraph.cubeVertices_eq_union_erase hv C.base
+
 omit [DecidableEq (V → ℤ)] in
 /-- Removing a present direction drops the cubical dimension by one for the lower face. -/
 @[simp]
 theorem dimension_lowerFace_of_mem (C : PlumbingCube V) {v : V} (hv : v ∈ C.directions) :
-    (C.lowerFace v hv).dimension = C.dimension - 1 := by
+    (C.lowerFace v).dimension = C.dimension - 1 := by
   rw [dimension, dimension, lowerFace_directions, Finset.card_erase_of_mem hv]
 
 omit [DecidableEq (V → ℤ)] in
@@ -184,8 +190,8 @@ theorem characteristicWeight_mk [Fintype V] (P : PlumbingGraph V)
 
 /-- The lower face's characteristic weight is bounded by the ambient cube weight. -/
 theorem characteristicWeight_lowerFace_le [Fintype V] (P : PlumbingGraph V)
-    (k : P.characteristicVectors) (C : PlumbingCube V) {v : V} (hv : v ∈ C.directions) :
-    characteristicWeight P k (C.lowerFace v hv) ≤ characteristicWeight P k C :=
+    (k : P.characteristicVectors) (C : PlumbingCube V) (v : V) :
+    characteristicWeight P k (C.lowerFace v) ≤ characteristicWeight P k C :=
   by
     simpa [characteristicWeight_def, lowerFace_base, lowerFace_directions] using
       P.characteristicCubeWeight_mono k (Finset.erase_subset v C.directions) C.base
@@ -198,92 +204,17 @@ theorem characteristicWeight_upperFace_le [Fintype V] (P : PlumbingGraph V)
     simpa [characteristicWeight_def, upperFace_base, upperFace_directions] using
       P.characteristicUpperFaceWeight_le (x := C.base) k hv
 
-/-- The nonnegative exponent of the lower face in the lattice-homology differential. -/
-noncomputable irreducible_def characteristicLowerFaceExponent [Fintype V] (P : PlumbingGraph V)
-    (k : P.characteristicVectors) (C : PlumbingCube V) {v : V} (_hv : v ∈ C.directions) : ℕ :=
-  P.characteristicLowerFaceExponent k C.base C.directions v
-
-/-- The nonnegative exponent of the upper face in the lattice-homology differential. -/
-noncomputable irreducible_def characteristicUpperFaceExponent [Fintype V] (P : PlumbingGraph V)
-    (k : P.characteristicVectors) (C : PlumbingCube V) {v : V} (hv : v ∈ C.directions) : ℕ :=
-  P.characteristicUpperFaceExponent k C.base C.directions hv
-
-@[simp]
-theorem characteristicLowerFaceExponent_mk [Fintype V] (P : PlumbingGraph V)
-    (k : P.characteristicVectors) (x : V → ℤ) (S : Finset V) {v : V} (hv : v ∈ S) :
-    characteristicLowerFaceExponent P k ({ base := x, directions := S } : PlumbingCube V) hv =
-      P.characteristicLowerFaceExponent k x S v :=
-  by simp [characteristicLowerFaceExponent_def]
-
-@[simp]
-theorem characteristicUpperFaceExponent_mk [Fintype V] (P : PlumbingGraph V)
-    (k : P.characteristicVectors) (x : V → ℤ) (S : Finset V) {v : V} (hv : v ∈ S) :
-    characteristicUpperFaceExponent P k ({ base := x, directions := S } : PlumbingCube V) hv =
-      P.characteristicUpperFaceExponent k x S hv :=
-  by simp [characteristicUpperFaceExponent_def]
-
-/-- The lower-face exponent is the weight difference between the ambient cube and the lower face. -/
-@[simp]
-theorem characteristicLowerFaceExponent_natCast [Fintype V] (P : PlumbingGraph V)
-    (k : P.characteristicVectors) (C : PlumbingCube V) {v : V} (hv : v ∈ C.directions) :
-    (characteristicLowerFaceExponent P k C hv : ℤ) =
-      characteristicWeight P k C - characteristicWeight P k (C.lowerFace v hv) :=
-  by
-    simp [characteristicLowerFaceExponent_def, characteristicWeight_def, lowerFace_base,
-      lowerFace_directions]
-
-/-- The upper-face exponent is the weight difference between the ambient cube and the upper face. -/
-@[simp]
-theorem characteristicUpperFaceExponent_natCast [Fintype V] (P : PlumbingGraph V)
-    (k : P.characteristicVectors) (C : PlumbingCube V) {v : V} (hv : v ∈ C.directions) :
-    (characteristicUpperFaceExponent P k C hv : ℤ) =
-      characteristicWeight P k C - characteristicWeight P k (C.upperFace v hv) :=
-  by
-    simp [characteristicUpperFaceExponent_def, characteristicWeight_def, upperFace_base,
-      upperFace_directions]
-
-/-- The lower-face exponent vanishes exactly when the lower face has the ambient cube's
-characteristic weight. -/
-theorem characteristicLowerFaceExponent_eq_zero_iff [Fintype V] (P : PlumbingGraph V)
-    (k : P.characteristicVectors) (C : PlumbingCube V) {v : V} (hv : v ∈ C.directions) :
-    characteristicLowerFaceExponent P k C hv = 0 ↔
-      characteristicWeight P k C = characteristicWeight P k (C.lowerFace v hv) :=
-  by
-    simpa [characteristicLowerFaceExponent_def, characteristicWeight_def, lowerFace_base,
-      lowerFace_directions] using
-      P.characteristicLowerFaceExponent_eq_zero_iff (x := C.base) (S := C.directions) (v := v) k
-
-/-- The upper-face exponent vanishes exactly when the upper face has the ambient cube's
-characteristic weight. -/
-theorem characteristicUpperFaceExponent_eq_zero_iff [Fintype V] (P : PlumbingGraph V)
-    (k : P.characteristicVectors) (C : PlumbingCube V) {v : V} (hv : v ∈ C.directions) :
-    characteristicUpperFaceExponent P k C hv = 0 ↔
-      characteristicWeight P k C = characteristicWeight P k (C.upperFace v hv) :=
-  by
-    simpa [characteristicUpperFaceExponent_def, characteristicWeight_def, upperFace_base,
-      upperFace_directions] using
-      P.characteristicUpperFaceExponent_eq_zero_iff (x := C.base) k hv
-
 /-- In any present direction, the characteristic weight of a cube is the maximum of the weights
 of its lower and upper faces. -/
 theorem characteristicWeight_eq_max_faces [Fintype V] (P : PlumbingGraph V)
     (k : P.characteristicVectors) (C : PlumbingCube V) {v : V} (hv : v ∈ C.directions) :
     characteristicWeight P k C =
-      max (characteristicWeight P k (C.lowerFace v hv))
+      max (characteristicWeight P k (C.lowerFace v))
         (characteristicWeight P k (C.upperFace v hv)) :=
   by
     simpa [characteristicWeight_def, lowerFace_base, lowerFace_directions, upperFace_base,
       upperFace_directions] using
       P.characteristicCubeWeight_eq_max_erase k C.base hv
-
-/-- In any present direction, at least one of the two face exponents vanishes. -/
-@[simp]
-theorem min_characteristicFaceExponent_eq_zero [Fintype V] (P : PlumbingGraph V)
-    (k : P.characteristicVectors) (C : PlumbingCube V) {v : V} (hv : v ∈ C.directions) :
-    min (characteristicLowerFaceExponent P k C hv)
-      (characteristicUpperFaceExponent P k C hv) = 0 :=
-  by
-    simp [characteristicLowerFaceExponent_def, characteristicUpperFaceExponent_def]
 
 end PlumbingCube
 

--- a/TauCeti/LowDimTopology/Plumbing/CubeGenerator.lean
+++ b/TauCeti/LowDimTopology/Plumbing/CubeGenerator.lean
@@ -1,0 +1,207 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+module
+
+public import TauCeti.LowDimTopology.Plumbing.CubeWeightRecursion
+
+/-!
+# Plumbing-lattice cube generators and their faces
+
+This file packages the cubical generators used in Némethi's lattice homology. A cube generator is
+the pair of a lattice base point `x : V → ℤ` and a finite set `S : Finset V` of basis directions.
+Its codimension-one faces in a direction `v ∈ S` are the lower face `(x, S.erase v)` and the
+upper face `(x + E_v, S.erase v)`.
+
+The earlier plumbing files define vertices, characteristic cube weights, and the lower/upper
+face exponents as functions of `(x, S)`. This file provides the bundled generator API that the
+lattice-homology differential can use directly.
+
+## Main definitions
+
+* `TauCeti.PlumbingCube`: a bundled plumbing-lattice cube generator.
+* `TauCeti.PlumbingCube.lowerFace` and `TauCeti.PlumbingCube.upperFace`: the two
+  codimension-one faces in a direction.
+* `TauCeti.PlumbingCube.characteristicWeight`: the characteristic cube weight of a bundled
+  generator.
+* `TauCeti.PlumbingCube.characteristicLowerFaceExponent` and
+  `TauCeti.PlumbingCube.characteristicUpperFaceExponent`: the `U`-exponents of the two faces.
+
+## References
+
+This supplies a prerequisite for `TauCetiRoadmap/CombinatorialHeegaardFloer/README.md`, Lane L
+("lattice homology"), whose opening item asks for Némethi's lattice (co)homology from lattice
+points and weight functions. The lower/upper face convention and exponents are the standard
+cubical-boundary data in Némethi, [arXiv:0709.0841](https://arxiv.org/abs/0709.0841).
+-/
+
+public section
+
+namespace TauCeti
+
+/-- A plumbing-lattice cube generator: a lattice base point together with a finite set of basis
+directions. In Némethi's lattice homology this is the cubical generator usually denoted by a pair
+`(x, S)`. -/
+structure PlumbingCube (V : Type*) where
+  /-- The lattice base point of the cube. -/
+  base : V → ℤ
+  /-- The finite set of basis directions spanning the cube. -/
+  directions : Finset V
+
+namespace PlumbingCube
+
+variable {V : Type*} [DecidableEq V]
+
+omit [DecidableEq V] in
+/-- Two plumbing cubes are equal when their base points and direction sets agree. -/
+@[ext]
+theorem ext {C D : PlumbingCube V} (hbase : C.base = D.base)
+    (hdirections : C.directions = D.directions) : C = D := by
+  cases C
+  cases D
+  simp_all
+
+/-- The cubical dimension of a plumbing cube, namely the number of basis directions. -/
+@[expose] def dimension (C : PlumbingCube V) : ℕ :=
+  C.directions.card
+
+/-- The lower codimension-one face in direction `v`: keep the base point and remove `v` from the
+direction set. -/
+@[expose] def lowerFace (C : PlumbingCube V) (v : V) : PlumbingCube V where
+  base := C.base
+  directions := C.directions.erase v
+
+/-- The upper codimension-one face in direction `v`: shift the base point by `E_v` and remove
+`v` from the direction set. -/
+@[expose] def upperFace (C : PlumbingCube V) (v : V) : PlumbingCube V where
+  base := C.base + Pi.single v (1 : ℤ)
+  directions := C.directions.erase v
+
+@[simp]
+theorem lowerFace_base (C : PlumbingCube V) (v : V) :
+    (C.lowerFace v).base = C.base :=
+  rfl
+
+@[simp]
+theorem lowerFace_directions (C : PlumbingCube V) (v : V) :
+    (C.lowerFace v).directions = C.directions.erase v :=
+  rfl
+
+@[simp]
+theorem upperFace_base (C : PlumbingCube V) (v : V) :
+    (C.upperFace v).base = C.base + Pi.single v (1 : ℤ) :=
+  rfl
+
+@[simp]
+theorem upperFace_directions (C : PlumbingCube V) (v : V) :
+    (C.upperFace v).directions = C.directions.erase v :=
+  rfl
+
+variable [DecidableEq (V → ℤ)]
+
+/-- The vertices of a bundled plumbing cube. -/
+@[expose] noncomputable def vertices (C : PlumbingCube V) : Finset (V → ℤ) :=
+  PlumbingGraph.cubeVertices C.base C.directions
+
+@[simp]
+theorem vertices_mk (x : V → ℤ) (S : Finset V) :
+    vertices ({ base := x, directions := S } : PlumbingCube V) =
+      PlumbingGraph.cubeVertices x S :=
+  rfl
+
+/-- The lower face's vertices are vertices of the ambient cube. -/
+theorem vertices_lowerFace_subset (C : PlumbingCube V) (v : V) :
+    (C.lowerFace v).vertices ⊆ C.vertices :=
+  PlumbingGraph.cubeVertices_subset (Finset.erase_subset v C.directions) C.base
+
+/-- The upper face's vertices are vertices of the ambient cube when the face direction belongs to
+the ambient cube. -/
+theorem vertices_upperFace_subset (C : PlumbingCube V) {v : V} (hv : v ∈ C.directions) :
+    (C.upperFace v).vertices ⊆ C.vertices :=
+  PlumbingGraph.cubeVertices_upperFace_subset hv
+
+omit [DecidableEq (V → ℤ)] in
+/-- Removing a present direction drops the cubical dimension by one for the lower face. -/
+@[simp]
+theorem dimension_lowerFace_of_mem (C : PlumbingCube V) {v : V} (hv : v ∈ C.directions) :
+    (C.lowerFace v).dimension = C.dimension - 1 := by
+  rw [dimension, dimension, lowerFace_directions, Finset.card_erase_of_mem hv]
+
+omit [DecidableEq (V → ℤ)] in
+/-- Removing a present direction drops the cubical dimension by one for the upper face. -/
+@[simp]
+theorem dimension_upperFace_of_mem (C : PlumbingCube V) {v : V} (hv : v ∈ C.directions) :
+    (C.upperFace v).dimension = C.dimension - 1 := by
+  rw [dimension, dimension, upperFace_directions, Finset.card_erase_of_mem hv]
+
+/-- The characteristic cube weight of a bundled plumbing cube. -/
+@[expose] noncomputable def characteristicWeight [Fintype V] (P : PlumbingGraph V)
+    (k : P.characteristicVectors) (C : PlumbingCube V) : ℤ :=
+  P.characteristicCubeWeight k C.base C.directions
+
+@[simp]
+theorem characteristicWeight_mk [Fintype V] (P : PlumbingGraph V)
+    (k : P.characteristicVectors) (x : V → ℤ) (S : Finset V) :
+    characteristicWeight P k ({ base := x, directions := S } : PlumbingCube V) =
+      P.characteristicCubeWeight k x S :=
+  rfl
+
+/-- The lower face's characteristic weight is bounded by the ambient cube weight. -/
+theorem characteristicWeight_lowerFace_le [Fintype V] (P : PlumbingGraph V)
+    (k : P.characteristicVectors) (C : PlumbingCube V) (v : V) :
+    characteristicWeight P k (C.lowerFace v) ≤ characteristicWeight P k C :=
+  P.characteristicCubeWeight_mono k (Finset.erase_subset v C.directions) C.base
+
+/-- The upper face's characteristic weight is bounded by the ambient cube weight. -/
+theorem characteristicWeight_upperFace_le [Fintype V] (P : PlumbingGraph V)
+    (k : P.characteristicVectors) (C : PlumbingCube V) {v : V} (hv : v ∈ C.directions) :
+    characteristicWeight P k (C.upperFace v) ≤ characteristicWeight P k C :=
+  P.characteristicUpperFaceWeight_le k hv
+
+/-- The nonnegative exponent of the lower face in the lattice-homology differential. -/
+noncomputable def characteristicLowerFaceExponent [Fintype V] (P : PlumbingGraph V)
+    (k : P.characteristicVectors) (C : PlumbingCube V) (v : V) : ℕ :=
+  P.characteristicLowerFaceExponent k C.base C.directions v
+
+/-- The nonnegative exponent of the upper face in the lattice-homology differential. -/
+noncomputable def characteristicUpperFaceExponent [Fintype V] (P : PlumbingGraph V)
+    (k : P.characteristicVectors) (C : PlumbingCube V) {v : V} (hv : v ∈ C.directions) : ℕ :=
+  P.characteristicUpperFaceExponent k C.base C.directions hv
+
+/-- The lower-face exponent is the weight difference between the ambient cube and the lower face. -/
+@[simp]
+theorem characteristicLowerFaceExponent_natCast [Fintype V] (P : PlumbingGraph V)
+    (k : P.characteristicVectors) (C : PlumbingCube V) (v : V) :
+    (characteristicLowerFaceExponent P k C v : ℤ) =
+      characteristicWeight P k C - characteristicWeight P k (C.lowerFace v) :=
+  P.characteristicLowerFaceExponent_natCast k
+
+/-- The upper-face exponent is the weight difference between the ambient cube and the upper face. -/
+@[simp]
+theorem characteristicUpperFaceExponent_natCast [Fintype V] (P : PlumbingGraph V)
+    (k : P.characteristicVectors) (C : PlumbingCube V) {v : V} (hv : v ∈ C.directions) :
+    (characteristicUpperFaceExponent P k C hv : ℤ) =
+      characteristicWeight P k C - characteristicWeight P k (C.upperFace v) :=
+  P.characteristicUpperFaceExponent_natCast k hv
+
+/-- In any present direction, the characteristic weight of a cube is the maximum of the weights
+of its lower and upper faces. -/
+theorem characteristicWeight_eq_max_faces [Fintype V] (P : PlumbingGraph V)
+    (k : P.characteristicVectors) (C : PlumbingCube V) {v : V} (hv : v ∈ C.directions) :
+    characteristicWeight P k C =
+      max (characteristicWeight P k (C.lowerFace v))
+        (characteristicWeight P k (C.upperFace v)) :=
+  P.characteristicCubeWeight_eq_max_erase k C.base hv
+
+/-- In any present direction, at least one of the two face exponents vanishes. -/
+@[simp]
+theorem min_characteristicFaceExponent_eq_zero [Fintype V] (P : PlumbingGraph V)
+    (k : P.characteristicVectors) (C : PlumbingCube V) {v : V} (hv : v ∈ C.directions) :
+    min (characteristicLowerFaceExponent P k C v)
+      (characteristicUpperFaceExponent P k C hv) = 0 :=
+  P.min_characteristicFaceExponent_eq_zero k C.base hv
+
+end PlumbingCube
+
+end TauCeti

--- a/TauCeti/LowDimTopology/Plumbing/CubeGenerator.lean
+++ b/TauCeti/LowDimTopology/Plumbing/CubeGenerator.lean
@@ -66,9 +66,10 @@ theorem ext {C D : PlumbingCube V} (hbase : C.base = D.base)
 abbrev dimension (C : PlumbingCube V) : ℕ :=
   C.directions.card
 
-/-- The lower codimension-one face in a direction `v`: keep the base point and remove `v` from the
-direction set. -/
-irreducible_def lowerFace (C : PlumbingCube V) (v : V) : PlumbingCube V where
+/-- The lower codimension-one face in a present direction `v`: keep the base point and remove `v`
+from the direction set. -/
+irreducible_def lowerFace (C : PlumbingCube V) (v : V)
+    (_hv : v ∈ C.directions) : PlumbingCube V where
   base := C.base
   directions := C.directions.erase v
 
@@ -86,8 +87,8 @@ theorem dimension_mk (x : V → ℤ) (S : Finset V) :
   rfl
 
 @[simp]
-theorem lowerFace_mk (x : V → ℤ) (S : Finset V) (v : V) :
-    lowerFace ({ base := x, directions := S } : PlumbingCube V) v =
+theorem lowerFace_mk (x : V → ℤ) (S : Finset V) (v : V) (hv : v ∈ S) :
+    lowerFace ({ base := x, directions := S } : PlumbingCube V) v hv =
       ({ base := x, directions := S.erase v } : PlumbingCube V) :=
   by simp [lowerFace_def]
 
@@ -98,13 +99,13 @@ theorem upperFace_mk (x : V → ℤ) (S : Finset V) (v : V) (hv : v ∈ S) :
   by simp [upperFace_def]
 
 @[simp]
-theorem lowerFace_base (C : PlumbingCube V) (v : V) :
-    (C.lowerFace v).base = C.base :=
+theorem lowerFace_base (C : PlumbingCube V) (v : V) (hv : v ∈ C.directions) :
+    (C.lowerFace v hv).base = C.base :=
   by simp [lowerFace_def]
 
 @[simp]
-theorem lowerFace_directions (C : PlumbingCube V) (v : V) :
-    (C.lowerFace v).directions = C.directions.erase v :=
+theorem lowerFace_directions (C : PlumbingCube V) (v : V) (hv : v ∈ C.directions) :
+    (C.lowerFace v hv).directions = C.directions.erase v :=
   by simp [lowerFace_def]
 
 @[simp]
@@ -141,8 +142,8 @@ theorem base_mem_vertices (C : PlumbingCube V) :
   by simp [vertices_def]
 
 /-- The lower face's vertices are vertices of the ambient cube. -/
-theorem vertices_lowerFace_subset (C : PlumbingCube V) (v : V) :
-    (C.lowerFace v).vertices ⊆ C.vertices :=
+theorem vertices_lowerFace_subset (C : PlumbingCube V) {v : V} (hv : v ∈ C.directions) :
+    (C.lowerFace v hv).vertices ⊆ C.vertices :=
   by
     simpa [vertices_def, lowerFace_base, lowerFace_directions] using
       PlumbingGraph.cubeVertices_subset (Finset.erase_subset v C.directions) C.base
@@ -158,7 +159,7 @@ theorem vertices_upperFace_subset (C : PlumbingCube V) {v : V} (hv : v ∈ C.dir
 /-- The vertices of a bundled cube split as the union of the vertices of its lower and upper faces
 in any present direction. -/
 theorem vertices_eq_union_faces (C : PlumbingCube V) {v : V} (hv : v ∈ C.directions) :
-    C.vertices = (C.lowerFace v).vertices ∪ (C.upperFace v hv).vertices :=
+    C.vertices = (C.lowerFace v hv).vertices ∪ (C.upperFace v hv).vertices :=
   by
     simpa [vertices_def, lowerFace_base, lowerFace_directions, upperFace_base,
       upperFace_directions] using
@@ -168,7 +169,7 @@ omit [DecidableEq (V → ℤ)] in
 /-- Removing a present direction drops the cubical dimension by one for the lower face. -/
 @[simp]
 theorem dimension_lowerFace_of_mem (C : PlumbingCube V) {v : V} (hv : v ∈ C.directions) :
-    (C.lowerFace v).dimension = C.dimension - 1 := by
+    (C.lowerFace v hv).dimension = C.dimension - 1 := by
   rw [dimension, dimension, lowerFace_directions, Finset.card_erase_of_mem hv]
 
 omit [DecidableEq (V → ℤ)] in
@@ -192,7 +193,8 @@ theorem characteristicWeight_mk [Fintype V] (P : PlumbingGraph V)
 
 /-- The nonnegative `U`-exponent contributed by the lower face of a bundled cube. -/
 noncomputable irreducible_def characteristicLowerFaceExponent [Fintype V] (P : PlumbingGraph V)
-    (k : P.characteristicVectors) (C : PlumbingCube V) (v : V) : ℕ :=
+    (k : P.characteristicVectors) (C : PlumbingCube V) {v : V}
+    (_hv : v ∈ C.directions) : ℕ :=
   P.characteristicLowerFaceExponent k C.base C.directions v
 
 /-- The nonnegative `U`-exponent contributed by the upper face of a bundled cube. -/
@@ -203,8 +205,8 @@ noncomputable irreducible_def characteristicUpperFaceExponent [Fintype V] (P : P
 
 @[simp]
 theorem characteristicLowerFaceExponent_mk [Fintype V] (P : PlumbingGraph V)
-    (k : P.characteristicVectors) (x : V → ℤ) (S : Finset V) (v : V) :
-    characteristicLowerFaceExponent P k ({ base := x, directions := S } : PlumbingCube V) v =
+    (k : P.characteristicVectors) (x : V → ℤ) (S : Finset V) {v : V} (hv : v ∈ S) :
+    characteristicLowerFaceExponent P k ({ base := x, directions := S } : PlumbingCube V) hv =
       P.characteristicLowerFaceExponent k x S v :=
   by simp [characteristicLowerFaceExponent_def]
 
@@ -219,9 +221,9 @@ theorem characteristicUpperFaceExponent_mk [Fintype V] (P : PlumbingGraph V)
 and the lower face weight. -/
 @[simp]
 theorem characteristicLowerFaceExponent_natCast [Fintype V] (P : PlumbingGraph V)
-    (k : P.characteristicVectors) (C : PlumbingCube V) (v : V) :
-    (characteristicLowerFaceExponent P k C v : ℤ) =
-      characteristicWeight P k C - characteristicWeight P k (C.lowerFace v) :=
+    (k : P.characteristicVectors) (C : PlumbingCube V) {v : V} (hv : v ∈ C.directions) :
+    (characteristicLowerFaceExponent P k C hv : ℤ) =
+      characteristicWeight P k C - characteristicWeight P k (C.lowerFace v hv) :=
   by
     simp [characteristicLowerFaceExponent_def, characteristicWeight_def, lowerFace_base,
       lowerFace_directions]
@@ -240,9 +242,9 @@ theorem characteristicUpperFaceExponent_natCast [Fintype V] (P : PlumbingGraph V
 /-- The lower-face exponent is zero exactly when the lower face has the same bundled weight as the
 ambient cube. -/
 theorem characteristicLowerFaceExponent_eq_zero_iff [Fintype V] (P : PlumbingGraph V)
-    (k : P.characteristicVectors) (C : PlumbingCube V) (v : V) :
-    characteristicLowerFaceExponent P k C v = 0 ↔
-      characteristicWeight P k C = characteristicWeight P k (C.lowerFace v) :=
+    (k : P.characteristicVectors) (C : PlumbingCube V) {v : V} (hv : v ∈ C.directions) :
+    characteristicLowerFaceExponent P k C hv = 0 ↔
+      characteristicWeight P k C = characteristicWeight P k (C.lowerFace v hv) :=
   by
     simpa [characteristicLowerFaceExponent_def, characteristicWeight_def, lowerFace_base,
       lowerFace_directions] using
@@ -265,15 +267,15 @@ theorem characteristicUpperFaceExponent_eq_zero_iff [Fintype V] (P : PlumbingGra
 @[simp]
 theorem min_characteristicFaceExponent_eq_zero [Fintype V] (P : PlumbingGraph V)
     (k : P.characteristicVectors) (C : PlumbingCube V) {v : V} (hv : v ∈ C.directions) :
-    min (characteristicLowerFaceExponent P k C v)
+    min (characteristicLowerFaceExponent P k C hv)
       (characteristicUpperFaceExponent P k C hv) = 0 :=
   by
     simp [characteristicLowerFaceExponent_def, characteristicUpperFaceExponent_def]
 
 /-- The lower face's characteristic weight is bounded by the ambient cube weight. -/
 theorem characteristicWeight_lowerFace_le [Fintype V] (P : PlumbingGraph V)
-    (k : P.characteristicVectors) (C : PlumbingCube V) (v : V) :
-    characteristicWeight P k (C.lowerFace v) ≤ characteristicWeight P k C :=
+    (k : P.characteristicVectors) (C : PlumbingCube V) {v : V} (hv : v ∈ C.directions) :
+    characteristicWeight P k (C.lowerFace v hv) ≤ characteristicWeight P k C :=
   by
     simpa [characteristicWeight_def, lowerFace_base, lowerFace_directions] using
       P.characteristicCubeWeight_mono k (Finset.erase_subset v C.directions) C.base
@@ -291,7 +293,7 @@ of its lower and upper faces. -/
 theorem characteristicWeight_eq_max_faces [Fintype V] (P : PlumbingGraph V)
     (k : P.characteristicVectors) (C : PlumbingCube V) {v : V} (hv : v ∈ C.directions) :
     characteristicWeight P k C =
-      max (characteristicWeight P k (C.lowerFace v))
+      max (characteristicWeight P k (C.lowerFace v hv))
         (characteristicWeight P k (C.upperFace v hv)) :=
   by
     simpa [characteristicWeight_def, lowerFace_base, lowerFace_directions, upperFace_base,

--- a/TauCeti/LowDimTopology/Plumbing/CubeGenerator.lean
+++ b/TauCeti/LowDimTopology/Plumbing/CubeGenerator.lean
@@ -21,8 +21,9 @@ lattice-homology differential can use directly.
 ## Main definitions
 
 * `TauCeti.PlumbingCube`: a bundled plumbing-lattice cube generator.
+* `TauCeti.PlumbingCube.eraseDirection`: the raw lower cube obtained by erasing a direction.
 * `TauCeti.PlumbingCube.lowerFace` and `TauCeti.PlumbingCube.upperFace`: the two
-  codimension-one faces in a direction.
+  codimension-one faces in a present direction.
 * `TauCeti.PlumbingCube.characteristicWeight`: the characteristic cube weight of a bundled
   generator.
 * `TauCeti.PlumbingCube.characteristicLowerFaceExponent` and
@@ -66,12 +67,17 @@ theorem ext {C D : PlumbingCube V} (hbase : C.base = D.base)
 abbrev dimension (C : PlumbingCube V) : ℕ :=
   C.directions.card
 
+/-- The raw lower cube obtained by keeping the base point and erasing a direction from the direction
+set. If the direction is absent, this is the original cube. -/
+irreducible_def eraseDirection (C : PlumbingCube V) (v : V) : PlumbingCube V where
+  base := C.base
+  directions := C.directions.erase v
+
 /-- The lower codimension-one face in a present direction `v`: keep the base point and remove `v`
 from the direction set. -/
 irreducible_def lowerFace (C : PlumbingCube V) (v : V)
-    (_hv : v ∈ C.directions) : PlumbingCube V where
-  base := C.base
-  directions := C.directions.erase v
+    (_hv : v ∈ C.directions) : PlumbingCube V :=
+  C.eraseDirection v
 
 /-- The upper codimension-one face in a present direction `v`: shift the base point by `E_v` and
 remove `v` from the direction set. -/
@@ -87,6 +93,12 @@ theorem dimension_mk (x : V → ℤ) (S : Finset V) :
   rfl
 
 @[simp]
+theorem eraseDirection_mk (x : V → ℤ) (S : Finset V) (v : V) :
+    eraseDirection ({ base := x, directions := S } : PlumbingCube V) v =
+      ({ base := x, directions := S.erase v } : PlumbingCube V) :=
+  by simp [eraseDirection_def]
+
+@[simp]
 theorem lowerFace_mk (x : V → ℤ) (S : Finset V) (v : V) (hv : v ∈ S) :
     lowerFace ({ base := x, directions := S } : PlumbingCube V) v hv =
       ({ base := x, directions := S.erase v } : PlumbingCube V) :=
@@ -97,6 +109,16 @@ theorem upperFace_mk (x : V → ℤ) (S : Finset V) (v : V) (hv : v ∈ S) :
     upperFace ({ base := x, directions := S } : PlumbingCube V) v hv =
       ({ base := x + Pi.single v (1 : ℤ), directions := S.erase v } : PlumbingCube V) :=
   by simp [upperFace_def]
+
+@[simp]
+theorem eraseDirection_base (C : PlumbingCube V) (v : V) :
+    (C.eraseDirection v).base = C.base :=
+  by simp [eraseDirection_def]
+
+@[simp]
+theorem eraseDirection_directions (C : PlumbingCube V) (v : V) :
+    (C.eraseDirection v).directions = C.directions.erase v :=
+  by simp [eraseDirection_def]
 
 @[simp]
 theorem lowerFace_base (C : PlumbingCube V) (v : V) (hv : v ∈ C.directions) :
@@ -142,11 +164,16 @@ theorem base_mem_vertices (C : PlumbingCube V) :
   by simp [vertices_def]
 
 /-- The lower face's vertices are vertices of the ambient cube. -/
+theorem vertices_eraseDirection_subset (C : PlumbingCube V) (v : V) :
+    (C.eraseDirection v).vertices ⊆ C.vertices :=
+  by
+    simpa [vertices_def, eraseDirection_base, eraseDirection_directions] using
+      PlumbingGraph.cubeVertices_subset (Finset.erase_subset v C.directions) C.base
+
+/-- The lower face's vertices are vertices of the ambient cube. -/
 theorem vertices_lowerFace_subset (C : PlumbingCube V) {v : V} (hv : v ∈ C.directions) :
     (C.lowerFace v hv).vertices ⊆ C.vertices :=
-  by
-    simpa [vertices_def, lowerFace_base, lowerFace_directions] using
-      PlumbingGraph.cubeVertices_subset (Finset.erase_subset v C.directions) C.base
+  by simpa [lowerFace_def] using C.vertices_eraseDirection_subset v
 
 /-- The upper face's vertices are vertices of the ambient cube when the face direction belongs to
 the ambient cube. -/
@@ -191,10 +218,10 @@ theorem characteristicWeight_mk [Fintype V] (P : PlumbingGraph V)
       P.characteristicCubeWeight k x S :=
   by simp [characteristicWeight_def]
 
-/-- The nonnegative `U`-exponent contributed by the lower face of a bundled cube. -/
+/-- The nonnegative `U`-exponent contributed by the raw lower cube obtained by erasing a direction.
+When the direction is present, this is the exponent of the lower face. -/
 noncomputable irreducible_def characteristicLowerFaceExponent [Fintype V] (P : PlumbingGraph V)
-    (k : P.characteristicVectors) (C : PlumbingCube V) {v : V}
-    (_hv : v ∈ C.directions) : ℕ :=
+    (k : P.characteristicVectors) (C : PlumbingCube V) (v : V) : ℕ :=
   P.characteristicLowerFaceExponent k C.base C.directions v
 
 /-- The nonnegative `U`-exponent contributed by the upper face of a bundled cube. -/
@@ -205,8 +232,8 @@ noncomputable irreducible_def characteristicUpperFaceExponent [Fintype V] (P : P
 
 @[simp]
 theorem characteristicLowerFaceExponent_mk [Fintype V] (P : PlumbingGraph V)
-    (k : P.characteristicVectors) (x : V → ℤ) (S : Finset V) {v : V} (hv : v ∈ S) :
-    characteristicLowerFaceExponent P k ({ base := x, directions := S } : PlumbingCube V) hv =
+    (k : P.characteristicVectors) (x : V → ℤ) (S : Finset V) (v : V) :
+    characteristicLowerFaceExponent P k ({ base := x, directions := S } : PlumbingCube V) v =
       P.characteristicLowerFaceExponent k x S v :=
   by simp [characteristicLowerFaceExponent_def]
 
@@ -217,16 +244,16 @@ theorem characteristicUpperFaceExponent_mk [Fintype V] (P : PlumbingGraph V)
       P.characteristicUpperFaceExponent k x S hv :=
   by simp [characteristicUpperFaceExponent_def]
 
-/-- The lower-face exponent, cast back to `ℤ`, is the difference between the bundled cube weight
-and the lower face weight. -/
+/-- The lower exponent, cast back to `ℤ`, is the difference between the bundled cube weight and the
+weight after erasing the direction. -/
 @[simp]
 theorem characteristicLowerFaceExponent_natCast [Fintype V] (P : PlumbingGraph V)
-    (k : P.characteristicVectors) (C : PlumbingCube V) {v : V} (hv : v ∈ C.directions) :
-    (characteristicLowerFaceExponent P k C hv : ℤ) =
-      characteristicWeight P k C - characteristicWeight P k (C.lowerFace v hv) :=
+    (k : P.characteristicVectors) (C : PlumbingCube V) (v : V) :
+    (characteristicLowerFaceExponent P k C v : ℤ) =
+      characteristicWeight P k C - characteristicWeight P k (C.eraseDirection v) :=
   by
-    simp [characteristicLowerFaceExponent_def, characteristicWeight_def, lowerFace_base,
-      lowerFace_directions]
+    simp [characteristicLowerFaceExponent_def, characteristicWeight_def, eraseDirection_base,
+      eraseDirection_directions]
 
 /-- The upper-face exponent, cast back to `ℤ`, is the difference between the bundled cube weight
 and the upper face weight. -/
@@ -239,15 +266,15 @@ theorem characteristicUpperFaceExponent_natCast [Fintype V] (P : PlumbingGraph V
     simp [characteristicUpperFaceExponent_def, characteristicWeight_def, upperFace_base,
       upperFace_directions]
 
-/-- The lower-face exponent is zero exactly when the lower face has the same bundled weight as the
-ambient cube. -/
+/-- The lower exponent is zero exactly when erasing the direction leaves the bundled weight
+unchanged. -/
 theorem characteristicLowerFaceExponent_eq_zero_iff [Fintype V] (P : PlumbingGraph V)
-    (k : P.characteristicVectors) (C : PlumbingCube V) {v : V} (hv : v ∈ C.directions) :
-    characteristicLowerFaceExponent P k C hv = 0 ↔
-      characteristicWeight P k C = characteristicWeight P k (C.lowerFace v hv) :=
+    (k : P.characteristicVectors) (C : PlumbingCube V) (v : V) :
+    characteristicLowerFaceExponent P k C v = 0 ↔
+      characteristicWeight P k C = characteristicWeight P k (C.eraseDirection v) :=
   by
-    simpa [characteristicLowerFaceExponent_def, characteristicWeight_def, lowerFace_base,
-      lowerFace_directions] using
+    simpa [characteristicLowerFaceExponent_def, characteristicWeight_def, eraseDirection_base,
+      eraseDirection_directions] using
       P.characteristicLowerFaceExponent_eq_zero_iff (k := k) (x := C.base) (S := C.directions)
         (v := v)
 
@@ -267,18 +294,25 @@ theorem characteristicUpperFaceExponent_eq_zero_iff [Fintype V] (P : PlumbingGra
 @[simp]
 theorem min_characteristicFaceExponent_eq_zero [Fintype V] (P : PlumbingGraph V)
     (k : P.characteristicVectors) (C : PlumbingCube V) {v : V} (hv : v ∈ C.directions) :
-    min (characteristicLowerFaceExponent P k C hv)
+    min (characteristicLowerFaceExponent P k C v)
       (characteristicUpperFaceExponent P k C hv) = 0 :=
   by
     simp [characteristicLowerFaceExponent_def, characteristicUpperFaceExponent_def]
+
+/-- Erasing a direction gives a cube whose characteristic weight is bounded by the ambient cube
+weight. -/
+theorem characteristicWeight_eraseDirection_le [Fintype V] (P : PlumbingGraph V)
+    (k : P.characteristicVectors) (C : PlumbingCube V) (v : V) :
+    characteristicWeight P k (C.eraseDirection v) ≤ characteristicWeight P k C :=
+  by
+    simpa [characteristicWeight_def, eraseDirection_base, eraseDirection_directions] using
+      P.characteristicCubeWeight_mono k (Finset.erase_subset v C.directions) C.base
 
 /-- The lower face's characteristic weight is bounded by the ambient cube weight. -/
 theorem characteristicWeight_lowerFace_le [Fintype V] (P : PlumbingGraph V)
     (k : P.characteristicVectors) (C : PlumbingCube V) {v : V} (hv : v ∈ C.directions) :
     characteristicWeight P k (C.lowerFace v hv) ≤ characteristicWeight P k C :=
-  by
-    simpa [characteristicWeight_def, lowerFace_base, lowerFace_directions] using
-      P.characteristicCubeWeight_mono k (Finset.erase_subset v C.directions) C.base
+  by simpa [lowerFace_def] using characteristicWeight_eraseDirection_le P k C v
 
 /-- The upper face's characteristic weight is bounded by the ambient cube weight. -/
 theorem characteristicWeight_upperFace_le [Fintype V] (P : PlumbingGraph V)


### PR DESCRIPTION
This PR adds bundled plumbing-lattice cube generators and their lower and upper codimension-one face API: a generator carries a lattice base point and direction set, its faces erase one present direction and optionally shift by the corresponding basis vector, and the existing vertex containment, dimension drop, characteristic cube-weight, and face-exponent facts are available directly on the bundled generator.

It advances `TauCetiRoadmap/CombinatorialHeegaardFloer/README.md`, Lane L, specifically “Plumbing trees/graphs and their lattices; Némethi's lattice (co)homology `ℍ⁻`/`ℍ⁰` as a `ℤ[U]`-module from lattice points and weight functions”, as the bundled cubical-generator prerequisite for the later lattice-homology differential. I chose this as the lowest-hanging distinct CombinatorialHeegaardFloer target after checking open and recently merged PRs: characteristic covectors, characteristic weights, cube weights, face exponents, cube cardinality, and the face-weight recursion already exist, while the actual bundled cube generator and face maps for the differential were still absent.

No Mathlib infrastructure is vendored. The implementation reuses Tau Ceti's existing `cubeVertices`, `characteristicCubeWeight`, `characteristicLowerFaceExponent`, `characteristicUpperFaceExponent`, and cube-weight recursion API, together with Mathlib's finite-set erasure bookkeeping.

`lake exe cache get` completed with `No files to download` and `Already decompressed 8601 file(s)`. `lake build` completed with `Build completed successfully (4301 jobs).` `lake exe axioms` completed with `axioms: audited 5922 TauCeti declaration(s); all within the allowlist [propext, Classical.choice, Quot.sound].`

<!--tauceti-target:v1 {"focus":"CombinatorialHeegaardFloer","id":"plumbing-cube-face-generators"}-->

🤖 Prepared with Codex
