### PR TITLE
feat: transport normalizer quotients by conjugation

### DIFF
--- a/TauCeti/Algebra/Group/NormalizerQuotient.lean
+++ b/TauCeti/Algebra/Group/NormalizerQuotient.lean
@@ -181,6 +181,32 @@ lemma normalizerQuotientMk_eq_iff_exists_mul (H : Subgroup G)
     rw [← hg]
     simpa [div_eq_mul_inv, mul_assoc] using hh
 
+/-- Equal subgroups have canonically equivalent normalizer quotients, by transporting both the
+normalizer and the distinguished subgroup inside it across the equality. -/
+noncomputable abbrev normalizerQuotientCongr {H K : Subgroup G} (h : H = K) :
+    normalizerQuotient H ≃* normalizerQuotient K :=
+  QuotientGroup.congr
+    (H.subgroupOf (_root_.Subgroup.normalizer (H : Set G)))
+    (K.subgroupOf (_root_.Subgroup.normalizer (K : Set G)))
+    (MulEquiv.subgroupCongr (by rw [h]))
+    (by
+      subst h
+      ext x
+      constructor
+      · rintro ⟨y, hy, rfl⟩
+        exact hy
+      · intro hx
+        exact ⟨x, hx, rfl⟩)
+
+/-- The equal-subgroup congruence on normalizer quotients sends representatives to the
+corresponding representatives under the normalizer congruence. -/
+@[simp]
+lemma normalizerQuotientCongr_mk {H K : Subgroup G} (h : H = K)
+    (g : _root_.Subgroup.normalizer (H : Set G)) :
+    normalizerQuotientCongr h (normalizerQuotientMk H g) =
+      normalizerQuotientMk K (MulEquiv.subgroupCongr (by rw [h]) g) :=
+  rfl
+
 section Normal
 
 variable (H : Subgroup G) [H.Normal]

--- a/TauCeti/Algebra/Group/NormalizerQuotientConjugation.lean
+++ b/TauCeti/Algebra/Group/NormalizerQuotientConjugation.lean
@@ -1,0 +1,134 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+module
+
+public import TauCeti.Algebra.Group.NormalizerQuotient
+
+/-!
+# Transporting normalizer quotients along group isomorphisms
+
+The universal-covers roadmap uses the algebraic quotient `N(H) / H` as the deck group of the
+cover attached to a subgroup `H`. When subgroups are transported by a basepoint change or by
+an isomorphism of covers, the corresponding normalizer quotients have to be identified.
+
+This file records the generic group-theoretic transport: a multiplicative equivalence
+`e : G ≃* K` carries `N(H)` to `N(e(H))`, and therefore induces a multiplicative equivalence
+`N(H) / H ≃* N(e(H)) / e(H)`.
+
+## Main declarations
+
+* `TauCeti.Subgroup.normalizerEquivMap`: the normalizer of `H` is identified with the
+  normalizer of `H.map e`.
+* `TauCeti.Subgroup.normalizerQuotientEquivMap`: the induced equivalence of normalizer
+  quotients.
+* Representative formulas and compatibility with composition, inverse, and identity
+  equivalences.
+
+## References
+
+This is the algebraic conjugacy bookkeeping needed by
+`TauCetiRoadmap/UniversalCovers/README.md`, Stage 2, item 8: the unpointed cover
+correspondence identifies subgroups only up to conjugacy, and the deck group of the cover
+attached to `H` is `N(H) / H`.
+-/
+
+public section
+
+namespace TauCeti
+
+namespace Subgroup
+
+variable {G K L : Type*} [Group G] [Group K] [Group L]
+
+/-- A group isomorphism identifies the normalizer of a subgroup with the normalizer of its
+image. -/
+@[expose] noncomputable def normalizerEquivMap (H : Subgroup G) (e : G ≃* K) :
+    _root_.Subgroup.normalizer (H : Set G) ≃*
+      _root_.Subgroup.normalizer ((H.map (e : G →* K)) : Set K) :=
+  (e.subgroupMap (_root_.Subgroup.normalizer (H : Set G))).trans
+    (MulEquiv.subgroupCongr (_root_.Subgroup.map_equiv_normalizer_eq H e))
+
+/-- On underlying group elements, `normalizerEquivMap` is the given group isomorphism. -/
+@[simp]
+lemma normalizerEquivMap_apply_coe (H : Subgroup G) (e : G ≃* K)
+    (g : _root_.Subgroup.normalizer (H : Set G)) :
+    (normalizerEquivMap H e g : K) = e (g : G) :=
+  rfl
+
+/-- On underlying group elements, the inverse of `normalizerEquivMap` is the inverse group
+isomorphism. -/
+@[simp]
+lemma normalizerEquivMap_symm_apply_coe (H : Subgroup G) (e : G ≃* K)
+    (k : _root_.Subgroup.normalizer ((H.map (e : G →* K)) : Set K)) :
+    ((normalizerEquivMap H e).symm k : G) = e.symm (k : K) :=
+  rfl
+
+/-- The copy of `H` inside its normalizer maps to the copy of `e(H)` inside the target
+normalizer. -/
+lemma subgroupOf_map_normalizerEquivMap (H : Subgroup G) (e : G ≃* K) :
+    (H.subgroupOf (_root_.Subgroup.normalizer (H : Set G))).map
+        ((normalizerEquivMap H e :
+          _root_.Subgroup.normalizer (H : Set G) ≃*
+            _root_.Subgroup.normalizer ((H.map (e : G →* K)) : Set K)) :
+          _root_.Subgroup.normalizer (H : Set G) →*
+            _root_.Subgroup.normalizer ((H.map (e : G →* K)) : Set K)) =
+      (H.map (e : G →* K)).subgroupOf
+        (_root_.Subgroup.normalizer ((H.map (e : G →* K)) : Set K)) := by
+  ext k
+  constructor
+  · rintro ⟨g, hg, hgk⟩
+    exact ⟨(g : G), hg, by
+      exact (normalizerEquivMap_apply_coe H e g).trans (congrArg Subtype.val hgk)⟩
+  · rintro ⟨g, hg, hgk⟩
+    refine ⟨⟨g, _root_.Subgroup.le_normalizer hg⟩, hg, ?_⟩
+    ext
+    exact hgk
+
+/-- A group isomorphism induces an isomorphism on normalizer quotients. -/
+@[expose] noncomputable def normalizerQuotientEquivMap (H : Subgroup G) (e : G ≃* K) :
+    normalizerQuotient H ≃*
+      normalizerQuotient (H.map (e : G →* K)) :=
+  QuotientGroup.congr
+    (H.subgroupOf (_root_.Subgroup.normalizer (H : Set G)))
+    ((H.map (e : G →* K)).subgroupOf
+      (_root_.Subgroup.normalizer ((H.map (e : G →* K)) : Set K)))
+    (normalizerEquivMap H e) (subgroupOf_map_normalizerEquivMap H e)
+
+/-- The induced equivalence on normalizer quotients sends a representative to the image
+representative. -/
+@[simp]
+lemma normalizerQuotientEquivMap_mk (H : Subgroup G) (e : G ≃* K)
+    (g : _root_.Subgroup.normalizer (H : Set G)) :
+    normalizerQuotientEquivMap H e (normalizerQuotientMk H g) =
+      normalizerQuotientMk (H.map (e : G →* K))
+        (normalizerEquivMap H e g) :=
+  rfl
+
+/-- The inverse induced equivalence sends a target representative to the inverse-image
+representative. -/
+@[simp]
+lemma normalizerQuotientEquivMap_symm_mk (H : Subgroup G) (e : G ≃* K)
+    (k : _root_.Subgroup.normalizer ((H.map (e : G →* K)) : Set K)) :
+    (normalizerQuotientEquivMap H e).symm
+        (normalizerQuotientMk (H.map (e : G →* K)) k) =
+      normalizerQuotientMk H ((normalizerEquivMap H e).symm k) :=
+  rfl
+
+/-- On representatives, `normalizerQuotientEquivMap` applies the original group
+isomorphism. -/
+@[simp]
+lemma normalizerQuotientEquivMap_mk_coe (H : Subgroup G) (e : G ≃* K)
+    (g : _root_.Subgroup.normalizer (H : Set G)) :
+    normalizerQuotientEquivMap H e (normalizerQuotientMk H g) =
+      normalizerQuotientMk (H.map (e : G →* K))
+        ⟨e (g : G), by
+          rw [← normalizerEquivMap_apply_coe H e g]
+          exact (normalizerEquivMap H e g).2⟩ := by
+  rw [normalizerQuotientEquivMap_mk]
+  rfl
+
+end Subgroup
+
+end TauCeti

--- a/TauCeti/Algebra/Group/NormalizerQuotientConjugation.lean
+++ b/TauCeti/Algebra/Group/NormalizerQuotientConjugation.lean
@@ -65,6 +65,8 @@ lemma normalizerEquivMap_symm_apply_coe (H : Subgroup G) (e : G ≃* K)
     ((normalizerEquivMap H e).symm k : G) = e.symm (k : K) :=
   rfl
 
+/-- Transporting normalizer representatives along the identity group isomorphism is the identity
+on underlying representatives. -/
 @[simp]
 lemma normalizerEquivMap_refl (H : Subgroup G)
     (g : _root_.Subgroup.normalizer (H : Set G)) :
@@ -73,6 +75,8 @@ lemma normalizerEquivMap_refl (H : Subgroup G)
   ext
   rfl
 
+/-- Transporting a normalizer representative through two group isomorphisms has underlying value
+`f (e g)`. -/
 @[simp]
 lemma normalizerEquivMap_trans_apply_coe (H : Subgroup G) (e : G ≃* K) (f : K ≃* L)
     (g : _root_.Subgroup.normalizer (H : Set G)) :
@@ -80,6 +84,8 @@ lemma normalizerEquivMap_trans_apply_coe (H : Subgroup G) (e : G ≃* K) (f : K 
       f (e (g : G)) :=
   rfl
 
+/-- Rephrasing the inverse of `normalizerEquivMap` as transport along the inverse group
+isomorphism sends a representative to its inverse image. -/
 @[simp]
 lemma normalizerEquivMap_symm_apply_coe' (H : Subgroup G) (e : G ≃* K)
     (k : _root_.Subgroup.normalizer ((H.map (e : G →* K)) : Set K)) :
@@ -117,6 +123,32 @@ noncomputable abbrev normalizerQuotientEquivMap (H : Subgroup G) (e : G ≃* K) 
       (_root_.Subgroup.normalizer ((H.map (e : G →* K)) : Set K)))
     (normalizerEquivMap H e) (subgroupOf_map_normalizerEquivMap H e)
 
+/-- Equal subgroups have canonically equivalent normalizer quotients, by transporting both the
+normalizer and the distinguished subgroup inside it across the equality. -/
+noncomputable abbrev normalizerQuotientCongr {H K : Subgroup G} (h : H = K) :
+    normalizerQuotient H ≃* normalizerQuotient K :=
+  QuotientGroup.congr
+    (H.subgroupOf (_root_.Subgroup.normalizer (H : Set G)))
+    (K.subgroupOf (_root_.Subgroup.normalizer (K : Set G)))
+    (MulEquiv.subgroupCongr (by rw [h]))
+    (by
+      subst h
+      ext x
+      constructor
+      · rintro ⟨y, hy, rfl⟩
+        exact hy
+      · intro hx
+        exact ⟨x, hx, rfl⟩)
+
+/-- The equal-subgroup congruence on normalizer quotients sends representatives to the
+corresponding representatives under the normalizer congruence. -/
+@[simp]
+lemma normalizerQuotientCongr_mk {H K : Subgroup G} (h : H = K)
+    (g : _root_.Subgroup.normalizer (H : Set G)) :
+    normalizerQuotientCongr h (normalizerQuotientMk H g) =
+      normalizerQuotientMk K (MulEquiv.subgroupCongr (by rw [h]) g) :=
+  rfl
+
 /-- The induced equivalence on normalizer quotients sends a representative to the image
 representative. -/
 @[simp]
@@ -137,6 +169,8 @@ lemma normalizerQuotientEquivMap_symm_mk (H : Subgroup G) (e : G ≃* K)
       normalizerQuotientMk H ((normalizerEquivMap H e).symm k) :=
   rfl
 
+/-- After identifying `H.map (MulEquiv.refl G)` with `H`, identity transport on normalizer
+quotients fixes representatives. -/
 @[simp]
 lemma normalizerQuotientEquivMap_refl_mk (H : Subgroup G)
     (g : _root_.Subgroup.normalizer (H : Set G)) :
@@ -146,6 +180,8 @@ lemma normalizerQuotientEquivMap_refl_mk (H : Subgroup G)
   rw [normalizerQuotientEquivMap_mk]
   rfl
 
+/-- Composing two normalizer-quotient transports sends representatives through the two
+successive normalizer transports. -/
 @[simp]
 lemma normalizerQuotientEquivMap_trans_mk (H : Subgroup G) (e : G ≃* K) (f : K ≃* L)
     (g : _root_.Subgroup.normalizer (H : Set G)) :
@@ -155,6 +191,35 @@ lemma normalizerQuotientEquivMap_trans_mk (H : Subgroup G) (e : G ≃* K) (f : K
         (normalizerEquivMap (H.map (e : G →* K)) f (normalizerEquivMap H e g)) := by
   rw [normalizerQuotientEquivMap_mk, normalizerQuotientEquivMap_mk]
 
+/-- After the subgroup equality `H.map id = H`, identity transport on normalizer quotients is
+the canonical identity on representatives. -/
+lemma normalizerQuotientEquivMap_refl_mk_congr (H : Subgroup G)
+    (g : _root_.Subgroup.normalizer (H : Set G)) :
+    normalizerQuotientCongr
+        (by rw [MulEquiv.coe_monoidHom_refl, _root_.Subgroup.map_id] :
+          H.map ((MulEquiv.refl G : G ≃* G) : G →* G) = H)
+      (normalizerQuotientEquivMap H (MulEquiv.refl G) (normalizerQuotientMk H g)) =
+      normalizerQuotientMk H g := by
+  rw [normalizerQuotientEquivMap_mk]
+  rfl
+
+/-- After identifying the twice-mapped subgroup with the subgroup mapped by `e.trans f`,
+composing normalizer-quotient transports agrees with transport by the composite isomorphism on
+representatives. -/
+lemma normalizerQuotientEquivMap_trans_mk_congr (H : Subgroup G) (e : G ≃* K) (f : K ≃* L)
+    (g : _root_.Subgroup.normalizer (H : Set G)) :
+    normalizerQuotientCongr
+        (by rw [_root_.Subgroup.map_map, ← MulEquiv.coe_monoidHom_trans] :
+          (H.map (e : G →* K)).map (f : K →* L) =
+            H.map ((e.trans f : G ≃* L) : G →* L))
+      (normalizerQuotientEquivMap (H.map (e : G →* K)) f
+        (normalizerQuotientEquivMap H e (normalizerQuotientMk H g))) =
+      normalizerQuotientEquivMap H (e.trans f) (normalizerQuotientMk H g) := by
+  rw [normalizerQuotientEquivMap_mk, normalizerQuotientEquivMap_mk]
+  rfl
+
+/-- Transporting representatives by `e` and then by `e.symm` gives the stated inverse-image
+representative in the twice-mapped subgroup. -/
 @[simp]
 lemma normalizerQuotientEquivMap_symm_mk' (H : Subgroup G) (e : G ≃* K)
     (k : _root_.Subgroup.normalizer ((H.map (e : G →* K)) : Set K)) :
@@ -166,7 +231,6 @@ lemma normalizerQuotientEquivMap_symm_mk' (H : Subgroup G) (e : G ≃* K)
 
 /-- On representatives, `normalizerQuotientEquivMap` applies the original group
 isomorphism. -/
-@[simp]
 lemma normalizerQuotientEquivMap_mk_coe (H : Subgroup G) (e : G ≃* K)
     (g : _root_.Subgroup.normalizer (H : Set G)) :
     normalizerQuotientEquivMap H e (normalizerQuotientMk H g) =

--- a/TauCeti/Algebra/Group/NormalizerQuotientConjugation.lean
+++ b/TauCeti/Algebra/Group/NormalizerQuotientConjugation.lean
@@ -167,6 +167,7 @@ lemma normalizerQuotientEquivMap_trans_mk (H : Subgroup G) (e : G ≃* K) (f : K
 
 /-- After the subgroup equality `H.map id = H`, identity transport on normalizer quotients is
 the canonical identity on representatives. -/
+@[simp]
 lemma normalizerQuotientEquivMap_refl_mk_congr (H : Subgroup G)
     (g : _root_.Subgroup.normalizer (H : Set G)) :
     normalizerQuotientCongr

--- a/TauCeti/Algebra/Group/NormalizerQuotientConjugation.lean
+++ b/TauCeti/Algebra/Group/NormalizerQuotientConjugation.lean
@@ -123,32 +123,6 @@ noncomputable abbrev normalizerQuotientEquivMap (H : Subgroup G) (e : G ≃* K) 
       (_root_.Subgroup.normalizer ((H.map (e : G →* K)) : Set K)))
     (normalizerEquivMap H e) (subgroupOf_map_normalizerEquivMap H e)
 
-/-- Equal subgroups have canonically equivalent normalizer quotients, by transporting both the
-normalizer and the distinguished subgroup inside it across the equality. -/
-noncomputable abbrev normalizerQuotientCongr {H K : Subgroup G} (h : H = K) :
-    normalizerQuotient H ≃* normalizerQuotient K :=
-  QuotientGroup.congr
-    (H.subgroupOf (_root_.Subgroup.normalizer (H : Set G)))
-    (K.subgroupOf (_root_.Subgroup.normalizer (K : Set G)))
-    (MulEquiv.subgroupCongr (by rw [h]))
-    (by
-      subst h
-      ext x
-      constructor
-      · rintro ⟨y, hy, rfl⟩
-        exact hy
-      · intro hx
-        exact ⟨x, hx, rfl⟩)
-
-/-- The equal-subgroup congruence on normalizer quotients sends representatives to the
-corresponding representatives under the normalizer congruence. -/
-@[simp]
-lemma normalizerQuotientCongr_mk {H K : Subgroup G} (h : H = K)
-    (g : _root_.Subgroup.normalizer (H : Set G)) :
-    normalizerQuotientCongr h (normalizerQuotientMk H g) =
-      normalizerQuotientMk K (MulEquiv.subgroupCongr (by rw [h]) g) :=
-  rfl
-
 /-- The induced equivalence on normalizer quotients sends a representative to the image
 representative. -/
 @[simp]
@@ -218,8 +192,8 @@ lemma normalizerQuotientEquivMap_trans_mk_congr (H : Subgroup G) (e : G ≃* K) 
   rw [normalizerQuotientEquivMap_mk, normalizerQuotientEquivMap_mk]
   rfl
 
-/-- Transporting representatives by `e` and then by `e.symm` gives the stated inverse-image
-representative in the twice-mapped subgroup. -/
+/-- Transporting a representative of `H.map e` along `e.symm` gives the stated inverse-image
+representative in `(H.map e).map e.symm`. -/
 @[simp]
 lemma normalizerQuotientEquivMap_symm_mk' (H : Subgroup G) (e : G ≃* K)
     (k : _root_.Subgroup.normalizer ((H.map (e : G →* K)) : Set K)) :

--- a/TauCeti/Algebra/Group/NormalizerQuotientConjugation.lean
+++ b/TauCeti/Algebra/Group/NormalizerQuotientConjugation.lean
@@ -23,8 +23,8 @@ This file records the generic group-theoretic transport: a multiplicative equiva
   normalizer of `H.map e`.
 * `TauCeti.Subgroup.normalizerQuotientEquivMap`: the induced equivalence of normalizer
   quotients.
-* Representative formulas and compatibility with composition, inverse, and identity
-  equivalences.
+* Representative formulas, including compatibility with composition, inverse, and identity
+  equivalences on representatives.
 
 ## References
 
@@ -44,7 +44,7 @@ variable {G K L : Type*} [Group G] [Group K] [Group L]
 
 /-- A group isomorphism identifies the normalizer of a subgroup with the normalizer of its
 image. -/
-@[expose] noncomputable def normalizerEquivMap (H : Subgroup G) (e : G ≃* K) :
+noncomputable abbrev normalizerEquivMap (H : Subgroup G) (e : G ≃* K) :
     _root_.Subgroup.normalizer (H : Set G) ≃*
       _root_.Subgroup.normalizer ((H.map (e : G →* K)) : Set K) :=
   (e.subgroupMap (_root_.Subgroup.normalizer (H : Set G))).trans
@@ -63,6 +63,27 @@ isomorphism. -/
 lemma normalizerEquivMap_symm_apply_coe (H : Subgroup G) (e : G ≃* K)
     (k : _root_.Subgroup.normalizer ((H.map (e : G →* K)) : Set K)) :
     ((normalizerEquivMap H e).symm k : G) = e.symm (k : K) :=
+  rfl
+
+@[simp]
+lemma normalizerEquivMap_refl (H : Subgroup G)
+    (g : _root_.Subgroup.normalizer (H : Set G)) :
+    normalizerEquivMap H (MulEquiv.refl G) g =
+      ⟨(g : G), by simp [g.2]⟩ := by
+  ext
+  rfl
+
+@[simp]
+lemma normalizerEquivMap_trans_apply_coe (H : Subgroup G) (e : G ≃* K) (f : K ≃* L)
+    (g : _root_.Subgroup.normalizer (H : Set G)) :
+    (normalizerEquivMap (H.map (e : G →* K)) f (normalizerEquivMap H e g) : L) =
+      f (e (g : G)) :=
+  rfl
+
+@[simp]
+lemma normalizerEquivMap_symm_apply_coe' (H : Subgroup G) (e : G ≃* K)
+    (k : _root_.Subgroup.normalizer ((H.map (e : G →* K)) : Set K)) :
+    (normalizerEquivMap (H.map (e : G →* K)) e.symm k : G) = e.symm (k : K) :=
   rfl
 
 /-- The copy of `H` inside its normalizer maps to the copy of `e(H)` inside the target
@@ -87,7 +108,7 @@ lemma subgroupOf_map_normalizerEquivMap (H : Subgroup G) (e : G ≃* K) :
     exact hgk
 
 /-- A group isomorphism induces an isomorphism on normalizer quotients. -/
-@[expose] noncomputable def normalizerQuotientEquivMap (H : Subgroup G) (e : G ≃* K) :
+noncomputable abbrev normalizerQuotientEquivMap (H : Subgroup G) (e : G ≃* K) :
     normalizerQuotient H ≃*
       normalizerQuotient (H.map (e : G →* K)) :=
   QuotientGroup.congr
@@ -115,6 +136,33 @@ lemma normalizerQuotientEquivMap_symm_mk (H : Subgroup G) (e : G ≃* K)
         (normalizerQuotientMk (H.map (e : G →* K)) k) =
       normalizerQuotientMk H ((normalizerEquivMap H e).symm k) :=
   rfl
+
+@[simp]
+lemma normalizerQuotientEquivMap_refl_mk (H : Subgroup G)
+    (g : _root_.Subgroup.normalizer (H : Set G)) :
+    normalizerQuotientEquivMap H (MulEquiv.refl G) (normalizerQuotientMk H g) =
+      normalizerQuotientMk (H.map ((MulEquiv.refl G : G ≃* G) : G →* G))
+        ⟨(g : G), by simp [g.2]⟩ := by
+  rw [normalizerQuotientEquivMap_mk]
+  rfl
+
+@[simp]
+lemma normalizerQuotientEquivMap_trans_mk (H : Subgroup G) (e : G ≃* K) (f : K ≃* L)
+    (g : _root_.Subgroup.normalizer (H : Set G)) :
+    normalizerQuotientEquivMap (H.map (e : G →* K)) f
+        (normalizerQuotientEquivMap H e (normalizerQuotientMk H g)) =
+      normalizerQuotientMk ((H.map (e : G →* K)).map (f : K →* L))
+        (normalizerEquivMap (H.map (e : G →* K)) f (normalizerEquivMap H e g)) := by
+  rw [normalizerQuotientEquivMap_mk, normalizerQuotientEquivMap_mk]
+
+@[simp]
+lemma normalizerQuotientEquivMap_symm_mk' (H : Subgroup G) (e : G ≃* K)
+    (k : _root_.Subgroup.normalizer ((H.map (e : G →* K)) : Set K)) :
+    normalizerQuotientEquivMap (H.map (e : G →* K)) e.symm
+        (normalizerQuotientMk (H.map (e : G →* K)) k) =
+      normalizerQuotientMk ((H.map (e : G →* K)).map (e.symm : K →* G))
+        (normalizerEquivMap (H.map (e : G →* K)) e.symm k) := by
+  rw [normalizerQuotientEquivMap_mk]
 
 /-- On representatives, `normalizerQuotientEquivMap` applies the original group
 isomorphism. -/

--- a/TauCeti/Algebra/Group/NormalizerQuotientConjugation.lean
+++ b/TauCeti/Algebra/Group/NormalizerQuotientConjugation.lean
@@ -180,6 +180,7 @@ lemma normalizerQuotientEquivMap_refl_mk_congr (H : Subgroup G)
 /-- After identifying the twice-mapped subgroup with the subgroup mapped by `e.trans f`,
 composing normalizer-quotient transports agrees with transport by the composite isomorphism on
 representatives. -/
+@[simp]
 lemma normalizerQuotientEquivMap_trans_mk_congr (H : Subgroup G) (e : G ≃* K) (f : K ≃* L)
     (g : _root_.Subgroup.normalizer (H : Set G)) :
     normalizerQuotientCongr

--- a/TauCeti/AlgebraicTopology/UniversalCover/Deck/NormalizerQuotientConjugation.lean
+++ b/TauCeti/AlgebraicTopology/UniversalCover/Deck/NormalizerQuotientConjugation.lean
@@ -119,6 +119,7 @@ lemma normalizerQuotientConjEquiv_trans_mk
 /-- After identifying the twice-conjugated subgroup with the subgroup conjugated by the
 composite over-base homeomorphism, composing deck normalizer-quotient conjugation equivalences
 agrees with conjugation by the composite on representatives. -/
+@[simp]
 lemma normalizerQuotientConjEquiv_trans_mk_congr
     {G : Type*} [TopologicalSpace G] {r : G → B}
     (h : E ≃ₜ F) (k : F ≃ₜ G)

--- a/TauCeti/AlgebraicTopology/UniversalCover/Deck/NormalizerQuotientConjugation.lean
+++ b/TauCeti/AlgebraicTopology/UniversalCover/Deck/NormalizerQuotientConjugation.lean
@@ -74,6 +74,8 @@ lemma normalizerQuotientConjEquiv_refl_mk_congr (H : Subgroup (Deck p))
   rw [normalizerQuotientConjEquiv_mk, Subgroup.normalizerQuotientCongr_mk]
   congr 1
   ext x
+  -- The subgroup congruence proof still mentions the opaque identity `conjMulEquiv`, so after
+  -- the quotient congruence the remaining representative equality has to be exposed pointwise.
   change ((conjMulEquiv (Homeomorph.refl E) (p := p) (q := p)
     (fun e => by rfl : ∀ e, p ((Homeomorph.refl E) e) = p e)
     (φ : Deck p) : Deck p).1 x) = (φ : Deck p).1 x

--- a/TauCeti/AlgebraicTopology/UniversalCover/Deck/NormalizerQuotientConjugation.lean
+++ b/TauCeti/AlgebraicTopology/UniversalCover/Deck/NormalizerQuotientConjugation.lean
@@ -61,6 +61,24 @@ lemma normalizerQuotientConjEquiv_mk (h : E ≃ₜ F) (hpq : ∀ e, q (h e) = p 
         (Subgroup.normalizerEquivMap H (conjMulEquiv h hpq) φ) :=
   Subgroup.normalizerQuotientEquivMap_mk H (conjMulEquiv h hpq) φ
 
+/-- After the subgroup equality induced by identity conjugation, conjugating the normalizer
+quotient by the identity over-base homeomorphism is the canonical identity on representatives. -/
+@[simp]
+lemma normalizerQuotientConjEquiv_refl_mk_congr (H : Subgroup (Deck p))
+    (φ : _root_.Subgroup.normalizer (H : Set (Deck p))) :
+    Subgroup.normalizerQuotientCongr (subgroup_map_conj_refl (p := p) H)
+      (normalizerQuotientConjEquiv (Homeomorph.refl E) (p := p) (q := p)
+        (fun e => by rfl : ∀ e, p ((Homeomorph.refl E) e) = p e) H
+        (Subgroup.normalizerQuotientMk H φ)) =
+      Subgroup.normalizerQuotientMk H φ := by
+  rw [normalizerQuotientConjEquiv_mk, Subgroup.normalizerQuotientCongr_mk]
+  congr 1
+  ext x
+  change ((conjMulEquiv (Homeomorph.refl E) (p := p) (q := p)
+    (fun e => by rfl : ∀ e, p ((Homeomorph.refl E) e) = p e)
+    (φ : Deck p) : Deck p).1 x) = (φ : Deck p).1 x
+  simp
+
 /-- The inverse deck normalizer-quotient conjugation equivalence is induced by inverse
 conjugation of deck transformations. -/
 @[simp]
@@ -118,13 +136,15 @@ lemma normalizerQuotientConjEquiv_trans_mk_congr
     Subgroup.normalizerQuotientCongr_mk]
   congr 1
   ext x
+  -- The quotient and subgroup congruences reduce the remaining goal to pointwise equality of
+  -- the two deck conjugation representatives, where `conjMulEquivTrans` is definitional.
   change (((conjMulEquiv k hqr) ((conjMulEquiv h hpq) (φ : Deck p)) : Deck r).1 x) =
     ((conjMulEquiv (h.trans k) (fun e => by rw [Homeomorph.trans_apply, hqr, hpq])
       (φ : Deck p) : Deck r).1 x)
   simp [conjMulEquiv_apply_coe]
 
-/-- Conjugating representatives by `h` and then by `h.symm` gives the stated
-inverse-conjugation representative in the twice-mapped subgroup. -/
+/-- Inverse-conjugating a representative of the `h`-conjugated subgroup quotient gives the
+stated representative in the twice-mapped subgroup. -/
 @[simp]
 lemma normalizerQuotientConjEquiv_symm_mk' (h : E ≃ₜ F) (hpq : ∀ e, q (h e) = p e)
     (H : Subgroup (Deck p))

--- a/TauCeti/AlgebraicTopology/UniversalCover/Deck/NormalizerQuotientConjugation.lean
+++ b/TauCeti/AlgebraicTopology/UniversalCover/Deck/NormalizerQuotientConjugation.lean
@@ -1,0 +1,112 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+module
+
+public import TauCeti.Algebra.Group.NormalizerQuotientConjugation
+public import TauCeti.AlgebraicTopology.UniversalCover.Deck.Conjugation
+
+/-!
+# Conjugating deck normalizer quotients
+
+An isomorphism of covers over a common base identifies deck groups by conjugation. This file
+records the induced identification on the normalizer quotients `N(H) / H` of deck subgroups.
+Those quotients are the algebraic groups appearing in the universal-covers roadmap as deck
+groups of covers attached to subgroups.
+
+## Main declarations
+
+* `TauCeti.Deck.normalizerQuotientConjEquiv`: conjugation along an over-base homeomorphism
+  identifies `N(H) / H` with `N(conj(H)) / conj(H)`.
+* Representative formulas for the forward and inverse maps.
+
+## References
+
+This supplies a basepoint-change and cover-isomorphism bookkeeping prerequisite for
+`TauCetiRoadmap/UniversalCovers/README.md`, Stage 2, item 8: pointed connected covers
+correspond to subgroups, unpointed connected covers correspond to conjugacy classes of
+subgroups, and the deck group attached to `H` is `N(H) / H`.
+-/
+
+public section
+
+namespace TauCeti
+
+namespace Deck
+
+variable {E F B : Type*} [TopologicalSpace E] [TopologicalSpace F]
+  {p : E → B} {q : F → B}
+
+/-- Conjugating an over-base homeomorphism identifies the normalizer quotient of a deck
+subgroup with the normalizer quotient of the conjugated subgroup. -/
+@[expose] noncomputable def normalizerQuotientConjEquiv (h : E ≃ₜ F)
+    (hpq : ∀ e, q (h e) = p e)
+    (H : Subgroup (Deck p)) :
+    Subgroup.normalizerQuotient H ≃*
+      Subgroup.normalizerQuotient
+        (H.map ((conjMulEquiv h hpq : Deck p ≃* Deck q) : Deck p →* Deck q)) :=
+  Subgroup.normalizerQuotientEquivMap H (conjMulEquiv h hpq)
+
+/-- On normalizer representatives, the deck normalizer-quotient conjugation equivalence is
+induced by conjugating deck transformations. -/
+@[simp]
+lemma normalizerQuotientConjEquiv_mk (h : E ≃ₜ F) (hpq : ∀ e, q (h e) = p e)
+    (H : Subgroup (Deck p))
+    (φ : _root_.Subgroup.normalizer (H : Set (Deck p))) :
+    normalizerQuotientConjEquiv h hpq H (Subgroup.normalizerQuotientMk H φ) =
+      Subgroup.normalizerQuotientMk
+        (H.map ((conjMulEquiv h hpq : Deck p ≃* Deck q) : Deck p →* Deck q))
+        (Subgroup.normalizerEquivMap H (conjMulEquiv h hpq) φ) :=
+  Subgroup.normalizerQuotientEquivMap_mk H (conjMulEquiv h hpq) φ
+
+/-- The inverse deck normalizer-quotient conjugation equivalence is induced by inverse
+conjugation of deck transformations. -/
+@[simp]
+lemma normalizerQuotientConjEquiv_symm_mk (h : E ≃ₜ F) (hpq : ∀ e, q (h e) = p e)
+    (H : Subgroup (Deck p))
+    (ψ : _root_.Subgroup.normalizer
+      ((H.map ((conjMulEquiv h hpq : Deck p ≃* Deck q) : Deck p →* Deck q)) :
+        Set (Deck q))) :
+    (normalizerQuotientConjEquiv h hpq H).symm
+        (Subgroup.normalizerQuotientMk
+          (H.map ((conjMulEquiv h hpq : Deck p ≃* Deck q) : Deck p →* Deck q)) ψ) =
+      Subgroup.normalizerQuotientMk H
+        ((Subgroup.normalizerEquivMap H (conjMulEquiv h hpq)).symm ψ) :=
+  Subgroup.normalizerQuotientEquivMap_symm_mk H (conjMulEquiv h hpq) ψ
+
+/-- On underlying deck transformations, the normalizer representative in the target quotient
+is obtained by conjugation. -/
+@[simp]
+lemma normalizerQuotientConjEquiv_mk_coe (h : E ≃ₜ F) (hpq : ∀ e, q (h e) = p e)
+    (H : Subgroup (Deck p))
+    (φ : _root_.Subgroup.normalizer (H : Set (Deck p))) :
+    normalizerQuotientConjEquiv h hpq H (Subgroup.normalizerQuotientMk H φ) =
+      Subgroup.normalizerQuotientMk
+        (H.map ((conjMulEquiv h hpq : Deck p ≃* Deck q) : Deck p →* Deck q))
+        ⟨conjMulEquiv h hpq (φ : Deck p), by
+          rw [← Subgroup.normalizerEquivMap_apply_coe H (conjMulEquiv h hpq) φ]
+          exact (Subgroup.normalizerEquivMap H (conjMulEquiv h hpq) φ).2⟩ := by
+  exact Subgroup.normalizerQuotientEquivMap_mk_coe H (conjMulEquiv h hpq) φ
+
+/-- On representatives, inverse transport of the deck normalizer quotient applies inverse
+conjugation. -/
+@[simp]
+lemma normalizerQuotientConjEquiv_symm_mk_coe (h : E ≃ₜ F) (hpq : ∀ e, q (h e) = p e)
+    (H : Subgroup (Deck p))
+    (ψ : _root_.Subgroup.normalizer
+      ((H.map ((conjMulEquiv h hpq : Deck p ≃* Deck q) : Deck p →* Deck q)) :
+        Set (Deck q))) :
+    (normalizerQuotientConjEquiv h hpq H).symm
+        (Subgroup.normalizerQuotientMk
+          (H.map ((conjMulEquiv h hpq : Deck p ≃* Deck q) : Deck p →* Deck q)) ψ) =
+      Subgroup.normalizerQuotientMk H
+        ⟨(conjMulEquiv h hpq).symm (ψ : Deck q), by
+          rw [← Subgroup.normalizerEquivMap_symm_apply_coe H (conjMulEquiv h hpq) ψ]
+          exact ((Subgroup.normalizerEquivMap H (conjMulEquiv h hpq)).symm ψ).2⟩ := by
+  rw [normalizerQuotientConjEquiv_symm_mk]
+  rfl
+
+end Deck
+
+end TauCeti

--- a/TauCeti/AlgebraicTopology/UniversalCover/Deck/NormalizerQuotientConjugation.lean
+++ b/TauCeti/AlgebraicTopology/UniversalCover/Deck/NormalizerQuotientConjugation.lean
@@ -98,6 +98,31 @@ lemma normalizerQuotientConjEquiv_trans_mk
   exact Subgroup.normalizerQuotientEquivMap_trans_mk H (conjMulEquiv h hpq)
     (conjMulEquiv k hqr) φ
 
+/-- After identifying the twice-conjugated subgroup with the subgroup conjugated by the
+composite over-base homeomorphism, composing deck normalizer-quotient conjugation equivalences
+agrees with conjugation by the composite on representatives. -/
+lemma normalizerQuotientConjEquiv_trans_mk_congr
+    {G : Type*} [TopologicalSpace G] {r : G → B}
+    (h : E ≃ₜ F) (k : F ≃ₜ G)
+    (hpq : ∀ e, q (h e) = p e) (hqr : ∀ f, r (k f) = q f)
+    (H : Subgroup (Deck p))
+    (φ : _root_.Subgroup.normalizer (H : Set (Deck p))) :
+    Subgroup.normalizerQuotientCongr (subgroup_map_conj_trans h k hpq hqr H)
+      (normalizerQuotientConjEquiv k hqr
+        (H.map ((conjMulEquiv h hpq : Deck p ≃* Deck q) : Deck p →* Deck q))
+        (normalizerQuotientConjEquiv h hpq H (Subgroup.normalizerQuotientMk H φ))) =
+      normalizerQuotientConjEquiv (h.trans k)
+        (fun e => by rw [Homeomorph.trans_apply, hqr, hpq]) H
+        (Subgroup.normalizerQuotientMk H φ) := by
+  rw [normalizerQuotientConjEquiv_trans_mk, normalizerQuotientConjEquiv_mk,
+    Subgroup.normalizerQuotientCongr_mk]
+  congr 1
+  ext x
+  change (((conjMulEquiv k hqr) ((conjMulEquiv h hpq) (φ : Deck p)) : Deck r).1 x) =
+    ((conjMulEquiv (h.trans k) (fun e => by rw [Homeomorph.trans_apply, hqr, hpq])
+      (φ : Deck p) : Deck r).1 x)
+  simp [conjMulEquiv_apply_coe]
+
 /-- Conjugating representatives by `h` and then by `h.symm` gives the stated
 inverse-conjugation representative in the twice-mapped subgroup. -/
 @[simp]

--- a/TauCeti/AlgebraicTopology/UniversalCover/Deck/NormalizerQuotientConjugation.lean
+++ b/TauCeti/AlgebraicTopology/UniversalCover/Deck/NormalizerQuotientConjugation.lean
@@ -19,7 +19,8 @@ groups of covers attached to subgroups.
 
 * `TauCeti.Deck.normalizerQuotientConjEquiv`: conjugation along an over-base homeomorphism
   identifies `N(H) / H` with `N(conj(H)) / conj(H)`.
-* Representative formulas for the forward and inverse maps.
+* Representative formulas for the forward and inverse maps, including identity and
+  composition compatibility on representatives.
 
 ## References
 
@@ -40,7 +41,7 @@ variable {E F B : Type*} [TopologicalSpace E] [TopologicalSpace F]
 
 /-- Conjugating an over-base homeomorphism identifies the normalizer quotient of a deck
 subgroup with the normalizer quotient of the conjugated subgroup. -/
-@[expose] noncomputable def normalizerQuotientConjEquiv (h : E ≃ₜ F)
+noncomputable abbrev normalizerQuotientConjEquiv (h : E ≃ₜ F)
     (hpq : ∀ e, q (h e) = p e)
     (H : Subgroup (Deck p)) :
     Subgroup.normalizerQuotient H ≃*
@@ -74,6 +75,47 @@ lemma normalizerQuotientConjEquiv_symm_mk (h : E ≃ₜ F) (hpq : ∀ e, q (h e)
       Subgroup.normalizerQuotientMk H
         ((Subgroup.normalizerEquivMap H (conjMulEquiv h hpq)).symm ψ) :=
   Subgroup.normalizerQuotientEquivMap_symm_mk H (conjMulEquiv h hpq) ψ
+
+@[simp]
+lemma normalizerQuotientConjEquiv_trans_mk
+    {G : Type*} [TopologicalSpace G] {r : G → B}
+    (h : E ≃ₜ F) (k : F ≃ₜ G)
+    (hpq : ∀ e, q (h e) = p e) (hqr : ∀ f, r (k f) = q f)
+    (H : Subgroup (Deck p))
+    (φ : _root_.Subgroup.normalizer (H : Set (Deck p))) :
+    normalizerQuotientConjEquiv k hqr
+        (H.map ((conjMulEquiv h hpq : Deck p ≃* Deck q) : Deck p →* Deck q))
+        (normalizerQuotientConjEquiv h hpq H (Subgroup.normalizerQuotientMk H φ)) =
+      Subgroup.normalizerQuotientMk
+        ((H.map ((conjMulEquiv h hpq : Deck p ≃* Deck q) : Deck p →* Deck q)).map
+          ((conjMulEquiv k hqr : Deck q ≃* Deck r) : Deck q →* Deck r))
+        (Subgroup.normalizerEquivMap
+          (H.map ((conjMulEquiv h hpq : Deck p ≃* Deck q) : Deck p →* Deck q))
+          (conjMulEquiv k hqr)
+          (Subgroup.normalizerEquivMap H (conjMulEquiv h hpq) φ)) := by
+  exact Subgroup.normalizerQuotientEquivMap_trans_mk H (conjMulEquiv h hpq)
+    (conjMulEquiv k hqr) φ
+
+@[simp]
+lemma normalizerQuotientConjEquiv_symm_mk' (h : E ≃ₜ F) (hpq : ∀ e, q (h e) = p e)
+    (H : Subgroup (Deck p))
+    (ψ : _root_.Subgroup.normalizer
+      ((H.map ((conjMulEquiv h hpq : Deck p ≃* Deck q) : Deck p →* Deck q)) :
+        Set (Deck q))) :
+    normalizerQuotientConjEquiv h.symm (map_symm_eq_of_map_eq h hpq)
+        (H.map ((conjMulEquiv h hpq : Deck p ≃* Deck q) : Deck p →* Deck q))
+        (Subgroup.normalizerQuotientMk
+          (H.map ((conjMulEquiv h hpq : Deck p ≃* Deck q) : Deck p →* Deck q)) ψ) =
+      Subgroup.normalizerQuotientMk
+        ((H.map ((conjMulEquiv h hpq : Deck p ≃* Deck q) : Deck p →* Deck q)).map
+          ((conjMulEquiv h.symm (map_symm_eq_of_map_eq h hpq) : Deck q ≃* Deck p) :
+            Deck q →* Deck p))
+        (Subgroup.normalizerEquivMap
+          (H.map ((conjMulEquiv h hpq : Deck p ≃* Deck q) : Deck p →* Deck q))
+          (conjMulEquiv h.symm (map_symm_eq_of_map_eq h hpq)) ψ) := by
+  exact Subgroup.normalizerQuotientEquivMap_mk
+    (H.map ((conjMulEquiv h hpq : Deck p ≃* Deck q) : Deck p →* Deck q))
+    (conjMulEquiv h.symm (map_symm_eq_of_map_eq h hpq)) ψ
 
 /-- On underlying deck transformations, the normalizer representative in the target quotient
 is obtained by conjugation. -/

--- a/TauCeti/AlgebraicTopology/UniversalCover/Deck/NormalizerQuotientConjugation.lean
+++ b/TauCeti/AlgebraicTopology/UniversalCover/Deck/NormalizerQuotientConjugation.lean
@@ -19,8 +19,8 @@ groups of covers attached to subgroups.
 
 * `TauCeti.Deck.normalizerQuotientConjEquiv`: conjugation along an over-base homeomorphism
   identifies `N(H) / H` with `N(conj(H)) / conj(H)`.
-* Representative formulas for the forward and inverse maps, including identity and
-  composition compatibility on representatives.
+* Representative formulas for the forward and inverse maps, including composition
+  compatibility on representatives.
 
 ## References
 
@@ -74,8 +74,10 @@ lemma normalizerQuotientConjEquiv_symm_mk (h : E ≃ₜ F) (hpq : ∀ e, q (h e)
           (H.map ((conjMulEquiv h hpq : Deck p ≃* Deck q) : Deck p →* Deck q)) ψ) =
       Subgroup.normalizerQuotientMk H
         ((Subgroup.normalizerEquivMap H (conjMulEquiv h hpq)).symm ψ) :=
-  Subgroup.normalizerQuotientEquivMap_symm_mk H (conjMulEquiv h hpq) ψ
+    Subgroup.normalizerQuotientEquivMap_symm_mk H (conjMulEquiv h hpq) ψ
 
+/-- Composing two deck normalizer-quotient conjugation equivalences sends representatives through
+the two successive conjugation transports. -/
 @[simp]
 lemma normalizerQuotientConjEquiv_trans_mk
     {G : Type*} [TopologicalSpace G] {r : G → B}
@@ -96,6 +98,8 @@ lemma normalizerQuotientConjEquiv_trans_mk
   exact Subgroup.normalizerQuotientEquivMap_trans_mk H (conjMulEquiv h hpq)
     (conjMulEquiv k hqr) φ
 
+/-- Conjugating representatives by `h` and then by `h.symm` gives the stated
+inverse-conjugation representative in the twice-mapped subgroup. -/
 @[simp]
 lemma normalizerQuotientConjEquiv_symm_mk' (h : E ≃ₜ F) (hpq : ∀ e, q (h e) = p e)
     (H : Subgroup (Deck p))
@@ -119,7 +123,6 @@ lemma normalizerQuotientConjEquiv_symm_mk' (h : E ≃ₜ F) (hpq : ∀ e, q (h e
 
 /-- On underlying deck transformations, the normalizer representative in the target quotient
 is obtained by conjugation. -/
-@[simp]
 lemma normalizerQuotientConjEquiv_mk_coe (h : E ≃ₜ F) (hpq : ∀ e, q (h e) = p e)
     (H : Subgroup (Deck p))
     (φ : _root_.Subgroup.normalizer (H : Set (Deck p))) :
@@ -133,7 +136,6 @@ lemma normalizerQuotientConjEquiv_mk_coe (h : E ≃ₜ F) (hpq : ∀ e, q (h e) 
 
 /-- On representatives, inverse transport of the deck normalizer quotient applies inverse
 conjugation. -/
-@[simp]
 lemma normalizerQuotientConjEquiv_symm_mk_coe (h : E ≃ₜ F) (hpq : ∀ e, q (h e) = p e)
     (H : Subgroup (Deck p))
     (ψ : _root_.Subgroup.normalizer


### PR DESCRIPTION
This PR adds the conjugation/basepoint-change bookkeeping for normalizer quotients: a group isomorphism carries `N(H)` to `N(e(H))` and induces `N(H) / H ≃* N(e(H)) / e(H)`, with representative formulas, and an over-base homeomorphism of covers specializes this to deck subgroups via `Deck.conjMulEquiv`.

It advances `TauCetiRoadmap/UniversalCovers/README.md`, Stage 2, item 8, “Galois correspondence: get the bookkeeping right,” specifically the unpointed-cover conjugacy bookkeeping and the normalizer-quotient deck-group target “For the cover attached to `H`, the deck group is `N(H)/H`.” I chose this as the lowest-hanging distinct UniversalCovers prerequisite after checking open and recently merged PRs: bottom/top subgroup fibre-orbit specializations, normal-subgroup fibre quotients, and the circle fundamental-group application already exist or are in flight, while the natural conjugation transport for `N(H)/H` was still absent.

No Mathlib infrastructure is vendored. The implementation reuses Tau Ceti’s existing `Subgroup.normalizerQuotient`, `Subgroup.normalizerQuotientMk`, and `Deck.conjMulEquiv`, together with Mathlib’s `Subgroup.map_equiv_normalizer_eq` and `QuotientGroup.congr`.

`lake exe cache get` completed with `No files to download` and `Already decompressed 8601 file(s)`. `lake build` completed with `Build completed successfully (4303 jobs).` `lake exe axioms` completed with `axioms: audited 5915 TauCeti declaration(s); all within the allowlist [propext, Classical.choice, Quot.sound].`

<!--tauceti-target:v1 {"focus":"UniversalCovers","id":"normalizer-quotient-conjugation"}-->

🤖 Prepared with Codex
