### PR TITLE
feat: add J-holomorphic energy density

### DIFF
--- a/TauCeti/Geometry/Symplectic/AlmostComplex.lean
+++ b/TauCeti/Geometry/Symplectic/AlmostComplex.lean
@@ -385,6 +385,22 @@ lemma Compatible.associatedBilinForm_isSymm
     (h : ω.Compatible J) : (ω.associatedBilinForm J).IsSymm :=
   h.invariant.associatedBilinForm_isSymm
 
+/-- Applying the almost complex structure to both entries preserves the diagonal of the
+associated bilinear form. -/
+lemma associatedBilinForm_apply_apply_self_eq (ω : SymplecticForm V)
+    (J : AlmostComplexStructure V) (v : V) :
+    ω.associatedBilinForm J (J v) (J v) = ω.associatedBilinForm J v v := by
+  calc
+    ω.associatedBilinForm J (J v) (J v) = ω (J v) (-v) := by
+      rw [associatedBilinForm_apply, AlmostComplexStructure.apply_apply]
+    _ = -ω (J v) v := by
+      exact map_neg (ω.toBilinForm (J v)) v
+    _ = ω v (J v) := by
+      rw [← ω.neg_eq v (J v)]
+      simp
+    _ = ω.associatedBilinForm J v v := by
+      rw [associatedBilinForm_apply]
+
 lemma Compatible.associated_pos {ω : SymplecticForm V} {J : AlmostComplexStructure V}
     (h : ω.Compatible J) {v : V} (hv : v ≠ 0) : 0 < ω v (J v) :=
   h.tames v hv
@@ -405,17 +421,7 @@ lemma associatedBilinForm_apply_apply_self_eq
     ω.associatedBilinForm J (F (J₀ v)) (F (J₀ v)) =
       ω.associatedBilinForm J (F v) (F v) := by
   rw [(isComplexLinearMap_iff_apply J₀ J F).mp hF v]
-  calc
-    ω.associatedBilinForm J (J (F v)) (J (F v)) =
-        ω (J (F v)) (-F v) := by
-      rw [SymplecticForm.associatedBilinForm_apply, AlmostComplexStructure.apply_apply]
-    _ = -ω (J (F v)) (F v) := by
-      exact map_neg (ω.toBilinForm (J (F v))) (F v)
-    _ = ω (F v) (J (F v)) := by
-      rw [← ω.neg_eq (F v) (J (F v))]
-      simp
-    _ = ω.associatedBilinForm J (F v) (F v) := by
-      rw [SymplecticForm.associatedBilinForm_apply]
+  exact ω.associatedBilinForm_apply_apply_self_eq J (F v)
 
 /-- For a complex-linear map from any complex source, the associated-bilinear-form diagonal
 of an image vector is the symplectic area density of the ordered pair `(F v, F (J₀ v))`. -/

--- a/TauCeti/Geometry/Symplectic/AlmostComplex.lean
+++ b/TauCeti/Geometry/Symplectic/AlmostComplex.lean
@@ -391,4 +391,40 @@ lemma Compatible.associated_pos {ω : SymplecticForm V} {J : AlmostComplexStruct
 
 end SymplecticForm
 
+namespace IsComplexLinearMap
+
+variable {U : Type*} [AddCommGroup U] [Module ℝ U]
+variable [AddCommGroup V] [Module ℝ V]
+variable {J₀ : AlmostComplexStructure U} {J : AlmostComplexStructure V}
+variable {F : U →ₗ[ℝ] V} {ω : SymplecticForm V}
+
+/-- For a complex-linear map from any complex source, the associated-bilinear-form diagonal
+of the image of `J₀ v` equals that of the image of `v`. -/
+lemma associatedBilinForm_apply_apply_self_eq
+    (hF : IsComplexLinearMap J₀ J F) (v : U) :
+    ω.associatedBilinForm J (F (J₀ v)) (F (J₀ v)) =
+      ω.associatedBilinForm J (F v) (F v) := by
+  rw [(isComplexLinearMap_iff_apply J₀ J F).mp hF v]
+  calc
+    ω.associatedBilinForm J (J (F v)) (J (F v)) =
+        ω (J (F v)) (-F v) := by
+      rw [SymplecticForm.associatedBilinForm_apply, AlmostComplexStructure.apply_apply]
+    _ = -ω (J (F v)) (F v) := by
+      exact map_neg (ω.toBilinForm (J (F v))) (F v)
+    _ = ω (F v) (J (F v)) := by
+      rw [← ω.neg_eq (F v) (J (F v))]
+      simp
+    _ = ω.associatedBilinForm J (F v) (F v) := by
+      rw [SymplecticForm.associatedBilinForm_apply]
+
+/-- For a complex-linear map from any complex source, the associated-bilinear-form diagonal
+of an image vector is the symplectic area density of the ordered pair `(F v, F (J₀ v))`. -/
+lemma associatedBilinForm_apply_self_eq_symplecticForm
+    (hF : IsComplexLinearMap J₀ J F) (v : U) :
+    ω.associatedBilinForm J (F v) (F v) = ω (F v) (F (J₀ v)) := by
+  rw [SymplecticForm.associatedBilinForm_apply,
+    (isComplexLinearMap_iff_apply J₀ J F).mp hF v]
+
+end IsComplexLinearMap
+
 end TauCeti

--- a/TauCeti/Geometry/Symplectic/JHolomorphicEnergy.lean
+++ b/TauCeti/Geometry/Symplectic/JHolomorphicEnergy.lean
@@ -58,8 +58,38 @@ end SymplecticForm
 namespace IsComplexLinearMap
 
 variable {V : Type*} [AddCommGroup V] [Module ℝ V]
+variable {U : Type*} [AddCommGroup U] [Module ℝ U]
+variable {J₀ : AlmostComplexStructure U}
 variable {J : AlmostComplexStructure V} {ω : SymplecticForm V}
+variable {F₀ : U →ₗ[ℝ] V}
 variable {F : (ℝ × ℝ) →ₗ[ℝ] V}
+
+/-- For a complex-linear map from any complex source, the associated-bilinear-form diagonal
+of the image of `J₀ v` equals that of the image of `v`. -/
+lemma associatedBilinForm_apply_apply_self_eq
+    (hF : IsComplexLinearMap J₀ J F₀) (v : U) :
+    ω.associatedBilinForm J (F₀ (J₀ v)) (F₀ (J₀ v)) =
+      ω.associatedBilinForm J (F₀ v) (F₀ v) := by
+  rw [(isComplexLinearMap_iff_apply J₀ J F₀).mp hF v]
+  calc
+    ω.associatedBilinForm J (J (F₀ v)) (J (F₀ v)) =
+        ω (J (F₀ v)) (-F₀ v) := by
+      rw [SymplecticForm.associatedBilinForm_apply, AlmostComplexStructure.apply_apply]
+    _ = -ω (J (F₀ v)) (F₀ v) := by
+      exact map_neg (ω.toBilinForm (J (F₀ v))) (F₀ v)
+    _ = ω (F₀ v) (J (F₀ v)) := by
+      rw [← ω.neg_eq (F₀ v) (J (F₀ v))]
+      simp
+    _ = ω.associatedBilinForm J (F₀ v) (F₀ v) := by
+      rw [SymplecticForm.associatedBilinForm_apply]
+
+/-- For a complex-linear map from any complex source, the associated-bilinear-form diagonal
+of an image vector is the symplectic area density of the ordered pair `(F₀ v, F₀ (J₀ v))`. -/
+lemma associatedBilinForm_apply_self_eq_symplecticForm
+    (hF : IsComplexLinearMap J₀ J F₀) (v : U) :
+    ω.associatedBilinForm J (F₀ v) (F₀ v) = ω (F₀ v) (F₀ (J₀ v)) := by
+  rw [SymplecticForm.associatedBilinForm_apply,
+    (isComplexLinearMap_iff_apply J₀ J F₀).mp hF v]
 
 /-- For a complex-linear map out of the standard complex line, the associated-bilinear-form
 diagonal of the imaginary-coordinate image equals that of the real-coordinate image. -/
@@ -67,18 +97,8 @@ lemma associatedBilinForm_apply_stdComplexLineImag_self_eq
     (hF : IsComplexLinearMap (AlmostComplexStructure.product ℝ) J F) :
     ω.associatedBilinForm J (F stdComplexLineImag) (F stdComplexLineImag) =
       ω.associatedBilinForm J (F stdComplexLineReal) (F stdComplexLineReal) := by
-  rw [hF.apply_stdComplexLineImag]
-  calc
-    ω.associatedBilinForm J (J (F stdComplexLineReal)) (J (F stdComplexLineReal)) =
-        ω (J (F stdComplexLineReal)) (-F stdComplexLineReal) := by
-      rw [SymplecticForm.associatedBilinForm_apply, AlmostComplexStructure.apply_apply]
-    _ = -ω (J (F stdComplexLineReal)) (F stdComplexLineReal) := by
-      exact map_neg (ω.toBilinForm (J (F stdComplexLineReal))) (F stdComplexLineReal)
-    _ = ω (F stdComplexLineReal) (J (F stdComplexLineReal)) := by
-      rw [← ω.neg_eq (F stdComplexLineReal) (J (F stdComplexLineReal))]
-      simp
-    _ = ω.associatedBilinForm J (F stdComplexLineReal) (F stdComplexLineReal) := by
-      rw [SymplecticForm.associatedBilinForm_apply]
+  simpa [AlmostComplexStructure.product_apply_stdComplexLineReal, stdComplexLineImag] using
+    hF.associatedBilinForm_apply_apply_self_eq stdComplexLineReal
 
 /-- For a complex-linear map out of the standard complex line, the real-coordinate
 associated-bilinear-form diagonal is the symplectic area density of the ordered coordinate
@@ -87,7 +107,8 @@ lemma associatedBilinForm_apply_stdComplexLineReal_self_eq_symplecticForm
     (hF : IsComplexLinearMap (AlmostComplexStructure.product ℝ) J F) :
     ω.associatedBilinForm J (F stdComplexLineReal) (F stdComplexLineReal) =
       ω (F stdComplexLineReal) (F stdComplexLineImag) := by
-  rw [SymplecticForm.associatedBilinForm_apply, hF.apply_stdComplexLineImag]
+  simpa [AlmostComplexStructure.product_apply_stdComplexLineReal, stdComplexLineImag] using
+    hF.associatedBilinForm_apply_self_eq_symplecticForm stdComplexLineReal
 
 /-- For a complex-linear map out of the standard complex line, the standard pointwise energy
 density is twice the symplectic area density. -/

--- a/TauCeti/Geometry/Symplectic/JHolomorphicEnergy.lean
+++ b/TauCeti/Geometry/Symplectic/JHolomorphicEnergy.lean
@@ -4,7 +4,6 @@ Released under Apache 2.0 license as described in the file LICENSE.
 -/
 module
 
-public import TauCeti.Geometry.Symplectic.CompatibleMetric
 public import TauCeti.Geometry.Symplectic.JHolomorphicLine
 
 /-!
@@ -41,6 +40,8 @@ namespace TauCeti
 namespace SymplecticForm
 
 variable {V : Type*} [AddCommGroup V] [Module ℝ V]
+variable {J : AlmostComplexStructure V}
+variable {ω : SymplecticForm V}
 
 /-- The pointwise metric energy density of a real-linear map from the standard complex line.
 
@@ -53,43 +54,28 @@ irreducible_def stdComplexLineEnergyDensity (ω : SymplecticForm V) (J : AlmostC
 
 attribute [simp] stdComplexLineEnergyDensity_def
 
+/-- The standard pointwise energy density of any real-linear map is nonnegative under tameness. -/
+lemma stdComplexLineEnergyDensity_nonneg (hω : ω.Tames J)
+    (F : (ℝ × ℝ) →ₗ[ℝ] V) :
+    0 ≤ ω.stdComplexLineEnergyDensity J F := by
+  rw [stdComplexLineEnergyDensity_def]
+  refine add_nonneg ?_ ?_
+  · rw [associatedBilinForm_apply]
+    by_cases h : F stdComplexLineReal = 0
+    · simp [h]
+    · exact (hω (F stdComplexLineReal) h).le
+  · rw [associatedBilinForm_apply]
+    by_cases h : F stdComplexLineImag = 0
+    · simp [h]
+    · exact (hω (F stdComplexLineImag) h).le
+
 end SymplecticForm
 
 namespace IsComplexLinearMap
 
 variable {V : Type*} [AddCommGroup V] [Module ℝ V]
-variable {U : Type*} [AddCommGroup U] [Module ℝ U]
-variable {J₀ : AlmostComplexStructure U}
 variable {J : AlmostComplexStructure V} {ω : SymplecticForm V}
-variable {F₀ : U →ₗ[ℝ] V}
 variable {F : (ℝ × ℝ) →ₗ[ℝ] V}
-
-/-- For a complex-linear map from any complex source, the associated-bilinear-form diagonal
-of the image of `J₀ v` equals that of the image of `v`. -/
-lemma associatedBilinForm_apply_apply_self_eq
-    (hF : IsComplexLinearMap J₀ J F₀) (v : U) :
-    ω.associatedBilinForm J (F₀ (J₀ v)) (F₀ (J₀ v)) =
-      ω.associatedBilinForm J (F₀ v) (F₀ v) := by
-  rw [(isComplexLinearMap_iff_apply J₀ J F₀).mp hF v]
-  calc
-    ω.associatedBilinForm J (J (F₀ v)) (J (F₀ v)) =
-        ω (J (F₀ v)) (-F₀ v) := by
-      rw [SymplecticForm.associatedBilinForm_apply, AlmostComplexStructure.apply_apply]
-    _ = -ω (J (F₀ v)) (F₀ v) := by
-      exact map_neg (ω.toBilinForm (J (F₀ v))) (F₀ v)
-    _ = ω (F₀ v) (J (F₀ v)) := by
-      rw [← ω.neg_eq (F₀ v) (J (F₀ v))]
-      simp
-    _ = ω.associatedBilinForm J (F₀ v) (F₀ v) := by
-      rw [SymplecticForm.associatedBilinForm_apply]
-
-/-- For a complex-linear map from any complex source, the associated-bilinear-form diagonal
-of an image vector is the symplectic area density of the ordered pair `(F₀ v, F₀ (J₀ v))`. -/
-lemma associatedBilinForm_apply_self_eq_symplecticForm
-    (hF : IsComplexLinearMap J₀ J F₀) (v : U) :
-    ω.associatedBilinForm J (F₀ v) (F₀ v) = ω (F₀ v) (F₀ (J₀ v)) := by
-  rw [SymplecticForm.associatedBilinForm_apply,
-    (isComplexLinearMap_iff_apply J₀ J F₀).mp hF v]
 
 /-- For a complex-linear map out of the standard complex line, the associated-bilinear-form
 diagonal of the imaginary-coordinate image equals that of the real-coordinate image. -/
@@ -120,15 +106,6 @@ lemma stdComplexLineEnergyDensity_eq_two_mul_symplecticForm
     hF.associatedBilinForm_apply_stdComplexLineImag_self_eq,
     hF.associatedBilinForm_apply_stdComplexLineReal_self_eq_symplecticForm]
   ring
-
-/-- The standard pointwise energy density of a complex-linear map is nonnegative under tameness. -/
-lemma stdComplexLineEnergyDensity_nonneg
-    (hF : IsComplexLinearMap (AlmostComplexStructure.product ℝ) J F)
-    (hω : ω.Tames J) :
-    0 ≤ ω.stdComplexLineEnergyDensity J F := by
-  rw [hF.stdComplexLineEnergyDensity_eq_two_mul_symplecticForm]
-  exact mul_nonneg zero_le_two
-    (hF.symplecticForm_apply_stdComplexLineReal_stdComplexLineImag_nonneg hω)
 
 end IsComplexLinearMap
 
@@ -165,13 +142,10 @@ lemma fderiv_stdComplexLineEnergyDensity_eq_two_mul_symplecticForm
       2 * ω (fderiv ℝ f x stdComplexLineReal) (fderiv ℝ f x stdComplexLineImag) :=
   hf.fderiv_isComplexLinear.stdComplexLineEnergyDensity_eq_two_mul_symplecticForm
 
-/-- The derivative's standard pointwise energy density is nonnegative for a pointwise
-`J`-holomorphic map under tameness. -/
-lemma fderiv_stdComplexLineEnergyDensity_nonneg
-    (hf : IsJHolomorphicAt (AlmostComplexStructure.product ℝ) J f x)
-    (hω : ω.Tames J) :
+/-- The derivative's standard pointwise energy density is nonnegative under tameness. -/
+lemma fderiv_stdComplexLineEnergyDensity_nonneg (hω : ω.Tames J) :
     0 ≤ ω.stdComplexLineEnergyDensity J (fderiv ℝ f x).toLinearMap :=
-  hf.fderiv_isComplexLinear.stdComplexLineEnergyDensity_nonneg hω
+  ω.stdComplexLineEnergyDensity_nonneg hω (fderiv ℝ f x).toLinearMap
 
 end IsJHolomorphicAt
 
@@ -218,13 +192,10 @@ lemma fderivWithin_stdComplexLineEnergyDensity_eq_two_mul_symplecticForm
         (fderivWithin ℝ f s x stdComplexLineImag) :=
   (hf.fderivWithin_isComplexLinear hs).stdComplexLineEnergyDensity_eq_two_mul_symplecticForm
 
-/-- The within-set derivative's standard pointwise energy density is nonnegative for a
-within-set `J`-holomorphic map under tameness, provided derivatives within the set are unique. -/
-lemma fderivWithin_stdComplexLineEnergyDensity_nonneg
-    (hf : IsJHolomorphicWithinAt (AlmostComplexStructure.product ℝ) J f s x)
-    (hs : UniqueDiffWithinAt ℝ s x) (hω : ω.Tames J) :
+/-- The within-set derivative's standard pointwise energy density is nonnegative under tameness. -/
+lemma fderivWithin_stdComplexLineEnergyDensity_nonneg (hω : ω.Tames J) :
     0 ≤ ω.stdComplexLineEnergyDensity J (fderivWithin ℝ f s x).toLinearMap :=
-  (hf.fderivWithin_isComplexLinear hs).stdComplexLineEnergyDensity_nonneg hω
+  ω.stdComplexLineEnergyDensity_nonneg hω (fderivWithin ℝ f s x).toLinearMap
 
 end IsJHolomorphicWithinAt
 

--- a/TauCeti/Geometry/Symplectic/JHolomorphicEnergy.lean
+++ b/TauCeti/Geometry/Symplectic/JHolomorphicEnergy.lean
@@ -1,0 +1,158 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+module
+
+public import TauCeti.Geometry.Symplectic.CompatibleMetric
+public import TauCeti.Geometry.Symplectic.JHolomorphicLine
+
+/-!
+# Pointwise energy density for maps from the standard complex line
+
+This file adds the first pointwise energy-density bookkeeping for the analytic Heegaard Floer
+roadmap. For a compatible pair `(ω, J)`, the associated metric is
+`g(v, w) = ω(v, J w)`. If a real-linear map `F : ℝ × ℝ → V` is complex-linear, then the
+standard energy density
+`g(F ∂s, F ∂s) + g(F ∂t, F ∂t)` is twice the symplectic area density
+`ω(F ∂s, F ∂t)`.
+
+The statements here are still pointwise linear algebra and Frechet-derivative calculus. They are
+the local identities that the later holomorphic-curve energy theory will integrate over strips
+or disks.
+
+## Main declarations
+
+* `TauCeti.SymplecticForm.stdComplexLineEnergyDensity`: the metric energy density of a
+  real-linear map from the standard complex line.
+* `TauCeti.IsComplexLinearMap.stdComplexLineEnergyDensity_eq_two_mul_symplecticForm`:
+  for a complex-linear map, energy density is twice symplectic area density.
+* `TauCeti.IsJHolomorphicAt.fderiv_stdComplexLineEnergyDensity_eq_two_mul_symplecticForm`:
+  the corresponding Frechet-derivative statement for a pointwise `J`-holomorphic map.
+
+The convention follows McDuff--Salamon, *J-holomorphic Curves and Symplectic Topology*,
+Section 2.1: for a compatible pair, `g(·, ·) = ω(·, J ·)` and `du(∂t) = J du(∂s)`.
+-/
+
+public section
+
+namespace TauCeti
+
+namespace SymplecticForm
+
+variable {V : Type*} [AddCommGroup V] [Module ℝ V]
+
+/-- The pointwise metric energy density of a real-linear map from the standard complex line.
+
+For a compatible pair `(ω, J)`, this is
+`g(F ∂s, F ∂s) + g(F ∂t, F ∂t)`, where `g(v,w) = ω(v, J w)`. -/
+@[expose]
+def stdComplexLineEnergyDensity (ω : SymplecticForm V) (J : AlmostComplexStructure V)
+    (F : (ℝ × ℝ) →ₗ[ℝ] V) : ℝ :=
+  ω.associatedBilinForm J (F stdComplexLineReal) (F stdComplexLineReal) +
+    ω.associatedBilinForm J (F stdComplexLineImag) (F stdComplexLineImag)
+
+/-- The defining formula for the standard-line energy density. -/
+lemma stdComplexLineEnergyDensity_def (ω : SymplecticForm V) (J : AlmostComplexStructure V)
+    (F : (ℝ × ℝ) →ₗ[ℝ] V) :
+    ω.stdComplexLineEnergyDensity J F =
+      ω.associatedBilinForm J (F stdComplexLineReal) (F stdComplexLineReal) +
+        ω.associatedBilinForm J (F stdComplexLineImag) (F stdComplexLineImag) :=
+  rfl
+
+end SymplecticForm
+
+namespace IsComplexLinearMap
+
+variable {V : Type*} [AddCommGroup V] [Module ℝ V]
+variable {J : AlmostComplexStructure V} {ω : SymplecticForm V}
+variable {F : (ℝ × ℝ) →ₗ[ℝ] V}
+
+/-- For a complex-linear map out of the standard complex line, the metric norm-square of the
+imaginary-coordinate image equals that of the real-coordinate image. -/
+lemma associatedBilinForm_apply_stdComplexLineImag_self_eq
+    (hF : IsComplexLinearMap (AlmostComplexStructure.product ℝ) J F)
+    (hω : ω.Compatible J) :
+    ω.associatedBilinForm J (F stdComplexLineImag) (F stdComplexLineImag) =
+      ω.associatedBilinForm J (F stdComplexLineReal) (F stdComplexLineReal) := by
+  rw [hF.apply_stdComplexLineImag]
+  exact hω.associatedBilinForm_invariant (F stdComplexLineReal) (F stdComplexLineReal)
+
+/-- For a complex-linear map out of the standard complex line, the real-coordinate metric
+norm-square is the symplectic area density of the ordered coordinate pair. -/
+lemma associatedBilinForm_apply_stdComplexLineReal_self_eq_symplecticForm
+    (hF : IsComplexLinearMap (AlmostComplexStructure.product ℝ) J F) :
+    ω.associatedBilinForm J (F stdComplexLineReal) (F stdComplexLineReal) =
+      ω (F stdComplexLineReal) (F stdComplexLineImag) := by
+  rw [SymplecticForm.associatedBilinForm_apply, hF.apply_stdComplexLineImag]
+
+/-- For a complex-linear map out of the standard complex line, the standard pointwise energy
+density is twice the symplectic area density. -/
+lemma stdComplexLineEnergyDensity_eq_two_mul_symplecticForm
+    (hF : IsComplexLinearMap (AlmostComplexStructure.product ℝ) J F)
+    (hω : ω.Compatible J) :
+    ω.stdComplexLineEnergyDensity J F =
+      2 * ω (F stdComplexLineReal) (F stdComplexLineImag) := by
+  rw [SymplecticForm.stdComplexLineEnergyDensity_def,
+    hF.associatedBilinForm_apply_stdComplexLineImag_self_eq hω,
+    hF.associatedBilinForm_apply_stdComplexLineReal_self_eq_symplecticForm]
+  ring
+
+/-- The standard pointwise energy density of a complex-linear map is nonnegative under a
+compatible pair. -/
+lemma stdComplexLineEnergyDensity_nonneg
+    (hF : IsComplexLinearMap (AlmostComplexStructure.product ℝ) J F)
+    (hω : ω.Compatible J) :
+    0 ≤ ω.stdComplexLineEnergyDensity J F := by
+  rw [hF.stdComplexLineEnergyDensity_eq_two_mul_symplecticForm hω]
+  exact mul_nonneg zero_le_two
+    (hF.symplecticForm_apply_stdComplexLineReal_stdComplexLineImag_nonneg hω.tames)
+
+end IsComplexLinearMap
+
+namespace IsJHolomorphicAt
+
+variable {V : Type*} [NormedAddCommGroup V] [NormedSpace ℝ V]
+variable {J : AlmostComplexStructure V} {ω : SymplecticForm V}
+variable {f : ℝ × ℝ → V} {x : ℝ × ℝ}
+
+/-- For a pointwise `J`-holomorphic map from the standard complex line, the metric norm-square
+of the `∂t` derivative equals that of the `∂s` derivative. -/
+lemma associatedBilinForm_fderiv_stdComplexLineImag_self_eq
+    (hf : IsJHolomorphicAt (AlmostComplexStructure.product ℝ) J f x)
+    (hω : ω.Compatible J) :
+    ω.associatedBilinForm J (fderiv ℝ f x stdComplexLineImag)
+        (fderiv ℝ f x stdComplexLineImag) =
+      ω.associatedBilinForm J (fderiv ℝ f x stdComplexLineReal)
+        (fderiv ℝ f x stdComplexLineReal) :=
+  hf.fderiv_isComplexLinear.associatedBilinForm_apply_stdComplexLineImag_self_eq hω
+
+/-- For a pointwise `J`-holomorphic map from the standard complex line, the `∂s` metric
+norm-square is the symplectic area density `ω(∂s u, ∂t u)`. -/
+lemma associatedBilinForm_fderiv_stdComplexLineReal_self_eq_symplecticForm
+    (hf : IsJHolomorphicAt (AlmostComplexStructure.product ℝ) J f x) :
+    ω.associatedBilinForm J (fderiv ℝ f x stdComplexLineReal)
+        (fderiv ℝ f x stdComplexLineReal) =
+      ω (fderiv ℝ f x stdComplexLineReal) (fderiv ℝ f x stdComplexLineImag) :=
+  hf.fderiv_isComplexLinear.associatedBilinForm_apply_stdComplexLineReal_self_eq_symplecticForm
+
+/-- For a pointwise `J`-holomorphic map from the standard complex line, the derivative's
+standard energy density is twice its symplectic area density. -/
+lemma fderiv_stdComplexLineEnergyDensity_eq_two_mul_symplecticForm
+    (hf : IsJHolomorphicAt (AlmostComplexStructure.product ℝ) J f x)
+    (hω : ω.Compatible J) :
+    ω.stdComplexLineEnergyDensity J (fderiv ℝ f x).toLinearMap =
+      2 * ω (fderiv ℝ f x stdComplexLineReal) (fderiv ℝ f x stdComplexLineImag) :=
+  hf.fderiv_isComplexLinear.stdComplexLineEnergyDensity_eq_two_mul_symplecticForm hω
+
+/-- The derivative's standard pointwise energy density is nonnegative for a pointwise
+`J`-holomorphic map under a compatible pair. -/
+lemma fderiv_stdComplexLineEnergyDensity_nonneg
+    (hf : IsJHolomorphicAt (AlmostComplexStructure.product ℝ) J f x)
+    (hω : ω.Compatible J) :
+    0 ≤ ω.stdComplexLineEnergyDensity J (fderiv ℝ f x).toLinearMap :=
+  hf.fderiv_isComplexLinear.stdComplexLineEnergyDensity_nonneg hω
+
+end IsJHolomorphicAt
+
+end TauCeti

--- a/TauCeti/Geometry/Symplectic/JHolomorphicEnergy.lean
+++ b/TauCeti/Geometry/Symplectic/JHolomorphicEnergy.lean
@@ -46,19 +46,12 @@ variable {V : Type*} [AddCommGroup V] [Module ℝ V]
 
 For a compatible pair `(ω, J)`, this is
 `g(F ∂s, F ∂s) + g(F ∂t, F ∂t)`, where `g(v,w) = ω(v, J w)`. -/
-@[expose]
-def stdComplexLineEnergyDensity (ω : SymplecticForm V) (J : AlmostComplexStructure V)
+irreducible_def stdComplexLineEnergyDensity (ω : SymplecticForm V) (J : AlmostComplexStructure V)
     (F : (ℝ × ℝ) →ₗ[ℝ] V) : ℝ :=
   ω.associatedBilinForm J (F stdComplexLineReal) (F stdComplexLineReal) +
     ω.associatedBilinForm J (F stdComplexLineImag) (F stdComplexLineImag)
 
-/-- The defining formula for the standard-line energy density. -/
-lemma stdComplexLineEnergyDensity_def (ω : SymplecticForm V) (J : AlmostComplexStructure V)
-    (F : (ℝ × ℝ) →ₗ[ℝ] V) :
-    ω.stdComplexLineEnergyDensity J F =
-      ω.associatedBilinForm J (F stdComplexLineReal) (F stdComplexLineReal) +
-        ω.associatedBilinForm J (F stdComplexLineImag) (F stdComplexLineImag) :=
-  rfl
+attribute [simp] stdComplexLineEnergyDensity_def
 
 end SymplecticForm
 
@@ -68,18 +61,28 @@ variable {V : Type*} [AddCommGroup V] [Module ℝ V]
 variable {J : AlmostComplexStructure V} {ω : SymplecticForm V}
 variable {F : (ℝ × ℝ) →ₗ[ℝ] V}
 
-/-- For a complex-linear map out of the standard complex line, the metric norm-square of the
-imaginary-coordinate image equals that of the real-coordinate image. -/
+/-- For a complex-linear map out of the standard complex line, the associated-bilinear-form
+diagonal of the imaginary-coordinate image equals that of the real-coordinate image. -/
 lemma associatedBilinForm_apply_stdComplexLineImag_self_eq
-    (hF : IsComplexLinearMap (AlmostComplexStructure.product ℝ) J F)
-    (hω : ω.Compatible J) :
+    (hF : IsComplexLinearMap (AlmostComplexStructure.product ℝ) J F) :
     ω.associatedBilinForm J (F stdComplexLineImag) (F stdComplexLineImag) =
       ω.associatedBilinForm J (F stdComplexLineReal) (F stdComplexLineReal) := by
   rw [hF.apply_stdComplexLineImag]
-  exact hω.associatedBilinForm_invariant (F stdComplexLineReal) (F stdComplexLineReal)
+  calc
+    ω.associatedBilinForm J (J (F stdComplexLineReal)) (J (F stdComplexLineReal)) =
+        ω (J (F stdComplexLineReal)) (-F stdComplexLineReal) := by
+      rw [SymplecticForm.associatedBilinForm_apply, AlmostComplexStructure.apply_apply]
+    _ = -ω (J (F stdComplexLineReal)) (F stdComplexLineReal) := by
+      exact map_neg (ω.toBilinForm (J (F stdComplexLineReal))) (F stdComplexLineReal)
+    _ = ω (F stdComplexLineReal) (J (F stdComplexLineReal)) := by
+      rw [← ω.neg_eq (F stdComplexLineReal) (J (F stdComplexLineReal))]
+      simp
+    _ = ω.associatedBilinForm J (F stdComplexLineReal) (F stdComplexLineReal) := by
+      rw [SymplecticForm.associatedBilinForm_apply]
 
-/-- For a complex-linear map out of the standard complex line, the real-coordinate metric
-norm-square is the symplectic area density of the ordered coordinate pair. -/
+/-- For a complex-linear map out of the standard complex line, the real-coordinate
+associated-bilinear-form diagonal is the symplectic area density of the ordered coordinate
+pair. -/
 lemma associatedBilinForm_apply_stdComplexLineReal_self_eq_symplecticForm
     (hF : IsComplexLinearMap (AlmostComplexStructure.product ℝ) J F) :
     ω.associatedBilinForm J (F stdComplexLineReal) (F stdComplexLineReal) =
@@ -89,24 +92,22 @@ lemma associatedBilinForm_apply_stdComplexLineReal_self_eq_symplecticForm
 /-- For a complex-linear map out of the standard complex line, the standard pointwise energy
 density is twice the symplectic area density. -/
 lemma stdComplexLineEnergyDensity_eq_two_mul_symplecticForm
-    (hF : IsComplexLinearMap (AlmostComplexStructure.product ℝ) J F)
-    (hω : ω.Compatible J) :
+    (hF : IsComplexLinearMap (AlmostComplexStructure.product ℝ) J F) :
     ω.stdComplexLineEnergyDensity J F =
       2 * ω (F stdComplexLineReal) (F stdComplexLineImag) := by
   rw [SymplecticForm.stdComplexLineEnergyDensity_def,
-    hF.associatedBilinForm_apply_stdComplexLineImag_self_eq hω,
+    hF.associatedBilinForm_apply_stdComplexLineImag_self_eq,
     hF.associatedBilinForm_apply_stdComplexLineReal_self_eq_symplecticForm]
   ring
 
-/-- The standard pointwise energy density of a complex-linear map is nonnegative under a
-compatible pair. -/
+/-- The standard pointwise energy density of a complex-linear map is nonnegative under tameness. -/
 lemma stdComplexLineEnergyDensity_nonneg
     (hF : IsComplexLinearMap (AlmostComplexStructure.product ℝ) J F)
-    (hω : ω.Compatible J) :
+    (hω : ω.Tames J) :
     0 ≤ ω.stdComplexLineEnergyDensity J F := by
-  rw [hF.stdComplexLineEnergyDensity_eq_two_mul_symplecticForm hω]
+  rw [hF.stdComplexLineEnergyDensity_eq_two_mul_symplecticForm]
   exact mul_nonneg zero_le_two
-    (hF.symplecticForm_apply_stdComplexLineReal_stdComplexLineImag_nonneg hω.tames)
+    (hF.symplecticForm_apply_stdComplexLineReal_stdComplexLineImag_nonneg hω)
 
 end IsComplexLinearMap
 
@@ -116,19 +117,18 @@ variable {V : Type*} [NormedAddCommGroup V] [NormedSpace ℝ V]
 variable {J : AlmostComplexStructure V} {ω : SymplecticForm V}
 variable {f : ℝ × ℝ → V} {x : ℝ × ℝ}
 
-/-- For a pointwise `J`-holomorphic map from the standard complex line, the metric norm-square
-of the `∂t` derivative equals that of the `∂s` derivative. -/
+/-- For a pointwise `J`-holomorphic map from the standard complex line, the
+associated-bilinear-form diagonal of the `∂t` derivative equals that of the `∂s` derivative. -/
 lemma associatedBilinForm_fderiv_stdComplexLineImag_self_eq
-    (hf : IsJHolomorphicAt (AlmostComplexStructure.product ℝ) J f x)
-    (hω : ω.Compatible J) :
+    (hf : IsJHolomorphicAt (AlmostComplexStructure.product ℝ) J f x) :
     ω.associatedBilinForm J (fderiv ℝ f x stdComplexLineImag)
         (fderiv ℝ f x stdComplexLineImag) =
       ω.associatedBilinForm J (fderiv ℝ f x stdComplexLineReal)
         (fderiv ℝ f x stdComplexLineReal) :=
-  hf.fderiv_isComplexLinear.associatedBilinForm_apply_stdComplexLineImag_self_eq hω
+  hf.fderiv_isComplexLinear.associatedBilinForm_apply_stdComplexLineImag_self_eq
 
-/-- For a pointwise `J`-holomorphic map from the standard complex line, the `∂s` metric
-norm-square is the symplectic area density `ω(∂s u, ∂t u)`. -/
+/-- For a pointwise `J`-holomorphic map from the standard complex line, the `∂s`
+associated-bilinear-form diagonal is the symplectic area density `ω(∂s u, ∂t u)`. -/
 lemma associatedBilinForm_fderiv_stdComplexLineReal_self_eq_symplecticForm
     (hf : IsJHolomorphicAt (AlmostComplexStructure.product ℝ) J f x) :
     ω.associatedBilinForm J (fderiv ℝ f x stdComplexLineReal)
@@ -139,20 +139,72 @@ lemma associatedBilinForm_fderiv_stdComplexLineReal_self_eq_symplecticForm
 /-- For a pointwise `J`-holomorphic map from the standard complex line, the derivative's
 standard energy density is twice its symplectic area density. -/
 lemma fderiv_stdComplexLineEnergyDensity_eq_two_mul_symplecticForm
-    (hf : IsJHolomorphicAt (AlmostComplexStructure.product ℝ) J f x)
-    (hω : ω.Compatible J) :
+    (hf : IsJHolomorphicAt (AlmostComplexStructure.product ℝ) J f x) :
     ω.stdComplexLineEnergyDensity J (fderiv ℝ f x).toLinearMap =
       2 * ω (fderiv ℝ f x stdComplexLineReal) (fderiv ℝ f x stdComplexLineImag) :=
-  hf.fderiv_isComplexLinear.stdComplexLineEnergyDensity_eq_two_mul_symplecticForm hω
+  hf.fderiv_isComplexLinear.stdComplexLineEnergyDensity_eq_two_mul_symplecticForm
 
 /-- The derivative's standard pointwise energy density is nonnegative for a pointwise
-`J`-holomorphic map under a compatible pair. -/
+`J`-holomorphic map under tameness. -/
 lemma fderiv_stdComplexLineEnergyDensity_nonneg
     (hf : IsJHolomorphicAt (AlmostComplexStructure.product ℝ) J f x)
-    (hω : ω.Compatible J) :
+    (hω : ω.Tames J) :
     0 ≤ ω.stdComplexLineEnergyDensity J (fderiv ℝ f x).toLinearMap :=
   hf.fderiv_isComplexLinear.stdComplexLineEnergyDensity_nonneg hω
 
 end IsJHolomorphicAt
+
+namespace IsJHolomorphicWithinAt
+
+variable {V : Type*} [NormedAddCommGroup V] [NormedSpace ℝ V]
+variable {J : AlmostComplexStructure V} {ω : SymplecticForm V}
+variable {f : ℝ × ℝ → V} {s : Set (ℝ × ℝ)} {x : ℝ × ℝ}
+
+/-- For a within-set `J`-holomorphic map from the standard complex line, the
+associated-bilinear-form diagonal of the `∂t` derivative equals that of the `∂s` derivative,
+provided derivatives within the set are unique. -/
+lemma associatedBilinForm_fderivWithin_stdComplexLineImag_self_eq
+    (hf : IsJHolomorphicWithinAt (AlmostComplexStructure.product ℝ) J f s x)
+    (hs : UniqueDiffWithinAt ℝ s x) :
+    ω.associatedBilinForm J (fderivWithin ℝ f s x stdComplexLineImag)
+        (fderivWithin ℝ f s x stdComplexLineImag) =
+      ω.associatedBilinForm J (fderivWithin ℝ f s x stdComplexLineReal)
+        (fderivWithin ℝ f s x stdComplexLineReal) :=
+  (hf.fderivWithin_isComplexLinear hs).associatedBilinForm_apply_stdComplexLineImag_self_eq
+
+/-- For a within-set `J`-holomorphic map from the standard complex line, the `∂s`
+associated-bilinear-form diagonal is the symplectic area density `ω(∂s u, ∂t u)`,
+provided derivatives within the set are unique. -/
+lemma associatedBilinForm_fderivWithin_stdComplexLineReal_self_eq_symplecticForm
+    (hf : IsJHolomorphicWithinAt (AlmostComplexStructure.product ℝ) J f s x)
+    (hs : UniqueDiffWithinAt ℝ s x) :
+    ω.associatedBilinForm J (fderivWithin ℝ f s x stdComplexLineReal)
+        (fderivWithin ℝ f s x stdComplexLineReal) =
+      ω (fderivWithin ℝ f s x stdComplexLineReal)
+        (fderivWithin ℝ f s x stdComplexLineImag) :=
+  by
+    have hlin := hf.fderivWithin_isComplexLinear hs
+    exact hlin.associatedBilinForm_apply_stdComplexLineReal_self_eq_symplecticForm
+
+/-- For a within-set `J`-holomorphic map from the standard complex line, the derivative's
+standard energy density is twice its symplectic area density, provided derivatives within the
+set are unique. -/
+lemma fderivWithin_stdComplexLineEnergyDensity_eq_two_mul_symplecticForm
+    (hf : IsJHolomorphicWithinAt (AlmostComplexStructure.product ℝ) J f s x)
+    (hs : UniqueDiffWithinAt ℝ s x) :
+    ω.stdComplexLineEnergyDensity J (fderivWithin ℝ f s x).toLinearMap =
+      2 * ω (fderivWithin ℝ f s x stdComplexLineReal)
+        (fderivWithin ℝ f s x stdComplexLineImag) :=
+  (hf.fderivWithin_isComplexLinear hs).stdComplexLineEnergyDensity_eq_two_mul_symplecticForm
+
+/-- The within-set derivative's standard pointwise energy density is nonnegative for a
+within-set `J`-holomorphic map under tameness, provided derivatives within the set are unique. -/
+lemma fderivWithin_stdComplexLineEnergyDensity_nonneg
+    (hf : IsJHolomorphicWithinAt (AlmostComplexStructure.product ℝ) J f s x)
+    (hs : UniqueDiffWithinAt ℝ s x) (hω : ω.Tames J) :
+    0 ≤ ω.stdComplexLineEnergyDensity J (fderivWithin ℝ f s x).toLinearMap :=
+  (hf.fderivWithin_isComplexLinear hs).stdComplexLineEnergyDensity_nonneg hω
+
+end IsJHolomorphicWithinAt
 
 end TauCeti

--- a/TauCeti/Geometry/Symplectic/JHolomorphicLine.lean
+++ b/TauCeti/Geometry/Symplectic/JHolomorphicLine.lean
@@ -161,6 +161,33 @@ lemma symplecticForm_apply_apply_pos (hF : IsComplexLinearMap J₀ J F₀) (hω 
   rw [(isComplexLinearMap_iff_apply J₀ J F₀).mp hF v]
   exact hω (F₀ v) hv
 
+/-- For a complex-linear map from any complex source, the associated-bilinear-form diagonal
+of the image of `J₀ v` equals that of the image of `v`. -/
+lemma associatedBilinForm_apply_apply_self_eq
+    (hF : IsComplexLinearMap J₀ J F₀) (v : U) :
+    ω.associatedBilinForm J (F₀ (J₀ v)) (F₀ (J₀ v)) =
+      ω.associatedBilinForm J (F₀ v) (F₀ v) := by
+  rw [(isComplexLinearMap_iff_apply J₀ J F₀).mp hF v]
+  calc
+    ω.associatedBilinForm J (J (F₀ v)) (J (F₀ v)) =
+        ω (J (F₀ v)) (-F₀ v) := by
+      rw [SymplecticForm.associatedBilinForm_apply, AlmostComplexStructure.apply_apply]
+    _ = -ω (J (F₀ v)) (F₀ v) := by
+      exact map_neg (ω.toBilinForm (J (F₀ v))) (F₀ v)
+    _ = ω (F₀ v) (J (F₀ v)) := by
+      rw [← ω.neg_eq (F₀ v) (J (F₀ v))]
+      simp
+    _ = ω.associatedBilinForm J (F₀ v) (F₀ v) := by
+      rw [SymplecticForm.associatedBilinForm_apply]
+
+/-- For a complex-linear map from any complex source, the associated-bilinear-form diagonal
+of an image vector is the symplectic area density of the ordered pair `(F₀ v, F₀ (J₀ v))`. -/
+lemma associatedBilinForm_apply_self_eq_symplecticForm
+    (hF : IsComplexLinearMap J₀ J F₀) (v : U) :
+    ω.associatedBilinForm J (F₀ v) (F₀ v) = ω (F₀ v) (F₀ (J₀ v)) := by
+  rw [SymplecticForm.associatedBilinForm_apply,
+    (isComplexLinearMap_iff_apply J₀ J F₀).mp hF v]
+
 variable {F : (ℝ × ℝ) →ₗ[ℝ] V}
 
 /-- A real-linear map out of the standard complex line is complex-linear when it satisfies the

--- a/TauCeti/Geometry/Symplectic/JHolomorphicLine.lean
+++ b/TauCeti/Geometry/Symplectic/JHolomorphicLine.lean
@@ -161,33 +161,6 @@ lemma symplecticForm_apply_apply_pos (hF : IsComplexLinearMap J₀ J F₀) (hω 
   rw [(isComplexLinearMap_iff_apply J₀ J F₀).mp hF v]
   exact hω (F₀ v) hv
 
-/-- For a complex-linear map from any complex source, the associated-bilinear-form diagonal
-of the image of `J₀ v` equals that of the image of `v`. -/
-lemma associatedBilinForm_apply_apply_self_eq
-    (hF : IsComplexLinearMap J₀ J F₀) (v : U) :
-    ω.associatedBilinForm J (F₀ (J₀ v)) (F₀ (J₀ v)) =
-      ω.associatedBilinForm J (F₀ v) (F₀ v) := by
-  rw [(isComplexLinearMap_iff_apply J₀ J F₀).mp hF v]
-  calc
-    ω.associatedBilinForm J (J (F₀ v)) (J (F₀ v)) =
-        ω (J (F₀ v)) (-F₀ v) := by
-      rw [SymplecticForm.associatedBilinForm_apply, AlmostComplexStructure.apply_apply]
-    _ = -ω (J (F₀ v)) (F₀ v) := by
-      exact map_neg (ω.toBilinForm (J (F₀ v))) (F₀ v)
-    _ = ω (F₀ v) (J (F₀ v)) := by
-      rw [← ω.neg_eq (F₀ v) (J (F₀ v))]
-      simp
-    _ = ω.associatedBilinForm J (F₀ v) (F₀ v) := by
-      rw [SymplecticForm.associatedBilinForm_apply]
-
-/-- For a complex-linear map from any complex source, the associated-bilinear-form diagonal
-of an image vector is the symplectic area density of the ordered pair `(F₀ v, F₀ (J₀ v))`. -/
-lemma associatedBilinForm_apply_self_eq_symplecticForm
-    (hF : IsComplexLinearMap J₀ J F₀) (v : U) :
-    ω.associatedBilinForm J (F₀ v) (F₀ v) = ω (F₀ v) (F₀ (J₀ v)) := by
-  rw [SymplecticForm.associatedBilinForm_apply,
-    (isComplexLinearMap_iff_apply J₀ J F₀).mp hF v]
-
 variable {F : (ℝ × ℝ) →ₗ[ℝ] V}
 
 /-- A real-linear map out of the standard complex line is complex-linear when it satisfies the


### PR DESCRIPTION
This PR adds the pointwise standard-line energy-density bookkeeping for `J`-holomorphic maps: for a compatible pair `(ω, J)`, the density `g(F ∂s, F ∂s) + g(F ∂t, F ∂t)` of a complex-linear map from `ℝ × ℝ` is twice the symplectic area density `ω(F ∂s, F ∂t)`, with the corresponding Frechet-derivative identity for pointwise `J`-holomorphic maps.

It advances `TauCetiRoadmap/HeegaardFloer/README.md`, Lane F2.1, “Definitions land immediately ... `J`-holomorphic maps, energy,” as the local compatible-metric energy identity needed before integrated holomorphic-curve energy estimates. I chose this as the lowest-hanging distinct HeegaardFloer prerequisite after checking open and recently merged PRs: the pointwise almost-complex, compatible/tame, `J`-holomorphic map, transport, standard-line derivative, and area-positivity APIs already exist on `main`, while the standard energy-density equals twice area-density package was still absent.

No Mathlib infrastructure is vendored. The implementation reuses Tau Ceti’s existing `SymplecticForm.associatedBilinForm`, `SymplecticForm.Compatible`, `stdComplexLineReal`, `stdComplexLineImag`, `IsComplexLinearMap.apply_stdComplexLineImag`, and `IsJHolomorphicAt.fderiv_isComplexLinear` APIs. The mathematical convention follows McDuff--Salamon, *J-holomorphic Curves and Symplectic Topology*, Section 2.1.

`lake exe cache get` completed with `No files to download` and `Already decompressed 8601 file(s)`. `lake build` completed with `Build completed successfully (4303 jobs).` `lake exe axioms` completed with `axioms: audited 6001 TauCeti declaration(s); all within the allowlist [propext, Classical.choice, Quot.sound].`

<!--tauceti-target:v1 {"focus":"HeegaardFloer","id":"j-holomorphic-energy-density"}-->

🤖 Prepared with Codex
