### PR TITLE
feat: add multiplicative group base change

### DIFF
--- a/TauCeti/Algebra/AlgebraicGroup/MultiplicativeGroupBaseChange.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/MultiplicativeGroupBaseChange.lean
@@ -62,7 +62,7 @@ the unit group `Aˣ`.
 
 The source is the convolution group of `K`-algebra maps out of the base-changed Hopf algebra.
 The target is the ordinary unit group of the value algebra. -/
-@[expose] noncomputable def baseChangePointsMulEquiv :
+noncomputable def baseChangePointsMulEquiv :
     WithConv (K ⊗[k] k[T;T⁻¹] →ₐ[K] A) ≃* Aˣ :=
   (AlgHom.baseChangePointsMulEquiv (k := k) (K := K) (A := k[T;T⁻¹]) (R := A)).symm.trans
     (pointsMulEquiv (R := k) (A := A))

--- a/TauCeti/Algebra/AlgebraicGroup/MultiplicativeGroupBaseChange.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/MultiplicativeGroupBaseChange.lean
@@ -18,7 +18,8 @@ out of `K ⊗[k] k[T;T⁻¹]` is the unit group `Aˣ`.
 The equivalence first restricts a base-changed point along `f ↦ f (1 ⊗ T)` using
 `AlgHom.baseChangePointsMulEquiv`, then applies the Laurent-polynomial calculation
 `MultiplicativeGroup.pointsMulEquiv`. The characteristic lemmas give the values on
-`1 ⊗ T`, on the inverse map at pure tensors `s ⊗ T n`, and naturality in the value algebra.
+`1 ⊗ T`, on the inverse map at pure tensors `s ⊗ C r * T n`, and naturality in the value
+algebra.
 
 This is the direct Laurent-polynomial `𝔾_m` worked example for the ReductiveGroups roadmap,
 Layer 0 ("R-points as a group" and "Base change. `K ⊗[k] A` as a Hopf algebra over `K`"),
@@ -30,8 +31,8 @@ alongside the more general diagonalizable and split-torus base-change APIs.
   units of the value algebra.
 * `TauCeti.MultiplicativeGroup.baseChangePointsMulEquiv_apply`: the equivalence reads a
   point on the base-changed coordinate `1 ⊗ T`.
-* `TauCeti.MultiplicativeGroup.baseChangePointsMulEquiv_symm_apply_tmul_T`: the inverse
-  equivalence evaluates pure tensors `s ⊗ T n`.
+* `TauCeti.MultiplicativeGroup.baseChangePointsMulEquiv_symm_apply_tmul_C_mul_T`: the inverse
+  equivalence evaluates pure Laurent monomials `s ⊗ C r * T n`.
 * `TauCeti.MultiplicativeGroup.baseChangePointsMulEquiv_mapValue`: the equivalence is
   natural in the value algebra.
 
@@ -77,6 +78,17 @@ theorem baseChangePointsMulEquiv_apply
   rw [baseChangePointsMulEquiv, MulEquiv.trans_apply, pointsMulEquiv_apply,
     unitOfPoint_val, AlgHom.baseChangePointsMulEquiv_symm_apply]
 
+/-- The inverse base-changed multiplicative-group points equivalence evaluates pure Laurent
+monomials `s ⊗ C r * T n` as scalar multiples of the corresponding power of the chosen unit. -/
+@[simp]
+theorem baseChangePointsMulEquiv_symm_apply_tmul_C_mul_T (u : Aˣ) (s : K) (r : k) (n : ℤ) :
+    ((baseChangePointsMulEquiv (k := k) (K := K) (A := A)).symm u).ofConv
+        (s ⊗ₜ[k] (LaurentPolynomial.C r * LaurentPolynomial.T n)) =
+      s • (r • ((u ^ n : Aˣ) : A)) := by
+  simp only [baseChangePointsMulEquiv, MulEquiv.symm_trans_apply, MulEquiv.symm_symm,
+    AlgHom.baseChangePointsMulEquiv_apply_tmul, pointsMulEquiv_symm_apply]
+  simp [Algebra.smul_def]
+
 /-- The inverse base-changed multiplicative-group points equivalence evaluates pure tensors
 `s ⊗ T n` as scalar multiples of the corresponding power of the chosen unit. -/
 @[simp]
@@ -84,8 +96,8 @@ theorem baseChangePointsMulEquiv_symm_apply_tmul_T (u : Aˣ) (s : K) (n : ℤ) :
     ((baseChangePointsMulEquiv (k := k) (K := K) (A := A)).symm u).ofConv
         (s ⊗ₜ[k] LaurentPolynomial.T n) =
       s • ((u ^ n : Aˣ) : A) := by
-  simp only [baseChangePointsMulEquiv, MulEquiv.symm_trans_apply, MulEquiv.symm_symm,
-    AlgHom.baseChangePointsMulEquiv_apply_tmul, pointsMulEquiv_symm_apply, point_T]
+  simpa using baseChangePointsMulEquiv_symm_apply_tmul_C_mul_T
+    (k := k) (K := K) (A := A) u s (1 : k) n
 
 /-- The inverse base-changed multiplicative-group points equivalence takes `1 ⊗ T` to the
 chosen unit. -/
@@ -124,6 +136,18 @@ theorem mapValue_baseChangePointsMulEquiv_symm_apply (φ : A →ₐ[K] B) (u : A
   simp
 
 /-- Naturality of the inverse base-changed multiplicative-group points equivalence, evaluated
+on a pure Laurent monomial `s ⊗ C r * T n`. -/
+@[simp]
+theorem mapValue_baseChangePointsMulEquiv_symm_apply_tmul_C_mul_T
+    (φ : A →ₐ[K] B) (u : Aˣ) (s : K) (r : k) (n : ℤ) :
+    (AlgHom.mapValue (H := K ⊗[k] k[T;T⁻¹]) φ
+        ((baseChangePointsMulEquiv (k := k) (K := K) (A := A)).symm u)).ofConv
+        (s ⊗ₜ[k] (LaurentPolynomial.C r * LaurentPolynomial.T n)) =
+      s • (r • (((Units.map φ.toMonoidHom u) ^ n : Bˣ) : B)) := by
+  rw [mapValue_baseChangePointsMulEquiv_symm_apply,
+    baseChangePointsMulEquiv_symm_apply_tmul_C_mul_T]
+
+/-- Naturality of the inverse base-changed multiplicative-group points equivalence, evaluated
 on a pure tensor `s ⊗ T n`. -/
 @[simp]
 theorem mapValue_baseChangePointsMulEquiv_symm_apply_tmul_T
@@ -132,8 +156,8 @@ theorem mapValue_baseChangePointsMulEquiv_symm_apply_tmul_T
         ((baseChangePointsMulEquiv (k := k) (K := K) (A := A)).symm u)).ofConv
         (s ⊗ₜ[k] LaurentPolynomial.T n) =
       s • (((Units.map φ.toMonoidHom u) ^ n : Bˣ) : B) := by
-  rw [mapValue_baseChangePointsMulEquiv_symm_apply,
-    baseChangePointsMulEquiv_symm_apply_tmul_T]
+  simpa using mapValue_baseChangePointsMulEquiv_symm_apply_tmul_C_mul_T
+    (k := k) (K := K) (A := A) (B := B) φ u s (1 : k) n
 
 end MultiplicativeGroup
 

--- a/TauCeti/Algebra/AlgebraicGroup/MultiplicativeGroupBaseChange.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/MultiplicativeGroupBaseChange.lean
@@ -1,0 +1,140 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+module
+
+public import TauCeti.Algebra.AlgebraicGroup.BaseChange
+public import TauCeti.Algebra.AlgebraicGroup.MultiplicativeGroup
+
+/-!
+# Base change of multiplicative-group points
+
+The multiplicative group `𝔾_m` over `k` is represented here by the Laurent-polynomial Hopf
+algebra `k[T;T⁻¹]`. This file records the base-changed functor-of-points calculation: for a
+`k`-algebra `K` and a commutative `K`-algebra `A`, the convolution group of `K`-algebra maps
+out of `K ⊗[k] k[T;T⁻¹]` is the unit group `Aˣ`.
+
+The equivalence first restricts a base-changed point along `f ↦ f (1 ⊗ T)` using
+`AlgHom.baseChangePointsMulEquiv`, then applies the Laurent-polynomial calculation
+`MultiplicativeGroup.pointsMulEquiv`. The characteristic lemmas give the values on
+`1 ⊗ T`, on the inverse map at pure tensors `s ⊗ T n`, and naturality in the value algebra.
+
+This is the direct Laurent-polynomial `𝔾_m` worked example for the ReductiveGroups roadmap,
+Layer 0 ("R-points as a group" and "Base change. `K ⊗[k] A` as a Hopf algebra over `K`"),
+alongside the more general diagonalizable and split-torus base-change APIs.
+
+## Main declarations
+
+* `TauCeti.MultiplicativeGroup.baseChangePointsMulEquiv`: base-changed `𝔾_m` points are
+  units of the value algebra.
+* `TauCeti.MultiplicativeGroup.baseChangePointsMulEquiv_apply`: the equivalence reads a
+  point on the base-changed coordinate `1 ⊗ T`.
+* `TauCeti.MultiplicativeGroup.baseChangePointsMulEquiv_symm_apply_tmul_T`: the inverse
+  equivalence evaluates pure tensors `s ⊗ T n`.
+* `TauCeti.MultiplicativeGroup.baseChangePointsMulEquiv_mapValue`: the equivalence is
+  natural in the value algebra.
+
+## References
+
+This reuses Tau Ceti's `AlgHom.baseChangePointsMulEquiv` and
+`MultiplicativeGroup.pointsMulEquiv`, which in turn build on Mathlib's tensor-product
+base-change adjunction and Laurent-polynomial Hopf algebra structure.
+-/
+
+public section
+
+open WithConv
+open scoped LaurentPolynomial TensorProduct
+
+namespace TauCeti
+
+namespace MultiplicativeGroup
+
+universe u v w w'
+
+variable {k : Type u} {K : Type v} {A : Type w}
+variable [CommSemiring k] [CommSemiring K] [CommSemiring A]
+variable [Algebra k K] [Algebra K A] [Algebra k A] [IsScalarTower k K A]
+
+/-- The `A`-points of the base change `K ⊗[k] k[T;T⁻¹]` of the multiplicative group are
+the unit group `Aˣ`.
+
+The source is the convolution group of `K`-algebra maps out of the base-changed Hopf algebra.
+The target is the ordinary unit group of the value algebra. -/
+@[expose] noncomputable def baseChangePointsMulEquiv :
+    WithConv (K ⊗[k] k[T;T⁻¹] →ₐ[K] A) ≃* Aˣ :=
+  (AlgHom.baseChangePointsMulEquiv (k := k) (K := K) (A := k[T;T⁻¹]) (R := A)).symm.trans
+    (pointsMulEquiv (R := k) (A := A))
+
+/-- The base-changed multiplicative-group points equivalence reads a point by evaluating it
+on the base-changed coordinate `1 ⊗ T`. -/
+@[simp]
+theorem baseChangePointsMulEquiv_apply
+    (f : WithConv (K ⊗[k] k[T;T⁻¹] →ₐ[K] A)) :
+    (baseChangePointsMulEquiv f : A) =
+      f.ofConv (1 ⊗ₜ[k] LaurentPolynomial.T 1) := by
+  rw [baseChangePointsMulEquiv, MulEquiv.trans_apply, pointsMulEquiv_apply,
+    unitOfPoint_val, AlgHom.baseChangePointsMulEquiv_symm_apply]
+
+/-- The inverse base-changed multiplicative-group points equivalence evaluates pure tensors
+`s ⊗ T n` as scalar multiples of the corresponding power of the chosen unit. -/
+@[simp]
+theorem baseChangePointsMulEquiv_symm_apply_tmul_T (u : Aˣ) (s : K) (n : ℤ) :
+    ((baseChangePointsMulEquiv (k := k) (K := K) (A := A)).symm u).ofConv
+        (s ⊗ₜ[k] LaurentPolynomial.T n) =
+      s • ((u ^ n : Aˣ) : A) := by
+  simp only [baseChangePointsMulEquiv, MulEquiv.symm_trans_apply, MulEquiv.symm_symm,
+    AlgHom.baseChangePointsMulEquiv_apply_tmul, pointsMulEquiv_symm_apply, point_T]
+
+/-- The inverse base-changed multiplicative-group points equivalence takes `1 ⊗ T` to the
+chosen unit. -/
+@[simp]
+theorem baseChangePointsMulEquiv_symm_apply_T (u : Aˣ) :
+    ((baseChangePointsMulEquiv (k := k) (K := K) (A := A)).symm u).ofConv
+        (1 ⊗ₜ[k] LaurentPolynomial.T 1) =
+      (u : A) := by
+  rw [baseChangePointsMulEquiv_symm_apply_tmul_T]
+  simp
+
+variable {B : Type w'} [CommSemiring B] [Algebra K B] [Algebra k B] [IsScalarTower k K B]
+
+/-- Reading a base-changed `𝔾_m` point as a unit is natural in the value algebra:
+post-composing the point with a `K`-algebra map applies the induced map on unit groups. -/
+@[simp]
+theorem baseChangePointsMulEquiv_mapValue (φ : A →ₐ[K] B)
+    (f : WithConv (K ⊗[k] k[T;T⁻¹] →ₐ[K] A)) :
+    baseChangePointsMulEquiv
+        (AlgHom.mapValue (H := K ⊗[k] k[T;T⁻¹]) φ f) =
+      Units.map φ.toMonoidHom
+        (baseChangePointsMulEquiv (k := k) (K := K) (A := A) f) := by
+  ext
+  simp [baseChangePointsMulEquiv_apply, Units.coe_map]
+
+/-- Naturality of the inverse base-changed multiplicative-group points equivalence in the
+value algebra. -/
+@[simp]
+theorem mapValue_baseChangePointsMulEquiv_symm_apply (φ : A →ₐ[K] B) (u : Aˣ) :
+    AlgHom.mapValue (H := K ⊗[k] k[T;T⁻¹]) φ
+        ((baseChangePointsMulEquiv (k := k) (K := K) (A := A)).symm u) =
+      (baseChangePointsMulEquiv (k := k) (K := K) (A := B)).symm
+        (Units.map φ.toMonoidHom u) := by
+  apply (baseChangePointsMulEquiv (k := k) (K := K) (A := B)).injective
+  rw [baseChangePointsMulEquiv_mapValue]
+  simp
+
+/-- Naturality of the inverse base-changed multiplicative-group points equivalence, evaluated
+on a pure tensor `s ⊗ T n`. -/
+@[simp]
+theorem mapValue_baseChangePointsMulEquiv_symm_apply_tmul_T
+    (φ : A →ₐ[K] B) (u : Aˣ) (s : K) (n : ℤ) :
+    (AlgHom.mapValue (H := K ⊗[k] k[T;T⁻¹]) φ
+        ((baseChangePointsMulEquiv (k := k) (K := K) (A := A)).symm u)).ofConv
+        (s ⊗ₜ[k] LaurentPolynomial.T n) =
+      s • (((Units.map φ.toMonoidHom u) ^ n : Bˣ) : B) := by
+  rw [mapValue_baseChangePointsMulEquiv_symm_apply,
+    baseChangePointsMulEquiv_symm_apply_tmul_T]
+
+end MultiplicativeGroup
+
+end TauCeti


### PR DESCRIPTION
This PR adds the direct Laurent-polynomial base-change functor-of-points calculation for the multiplicative group: for a `k`-algebra `K` and a commutative `K`-algebra `A`, convolution points of `K ⊗[k] k[T;T⁻¹]` are identified with `Aˣ`, with formulas on `1 ⊗ T`, inverse points on pure tensors `s ⊗ T n`, and naturality in the value algebra.

It advances `TauCetiRoadmap/ReductiveGroups/README.md`, Layer 0, specifically the “R-points as a group” item and the “Base change. `K ⊗[k] A` as a Hopf algebra over `K`” item, as a direct worked-example prerequisite for the listed `𝔾_m` example. I chose this as the lowest-hanging distinct ReductiveGroups target after checking open and recently merged PRs: the generic convolution points, generic base-change equivalence, diagonalizable/split-torus base change, additive-group base change, and trivial-group base change already exist on `main`, while the Laurent-polynomial `𝔾_m` base-change API was still absent.

No Mathlib infrastructure is vendored. The implementation reuses Tau Ceti’s existing `AlgHom.baseChangePointsMulEquiv` and `MultiplicativeGroup.pointsMulEquiv`, which build on Mathlib’s tensor-product base-change adjunction and Laurent-polynomial Hopf algebra structure.

`lake exe cache get` completed with `No files to download` and `Already decompressed 8601 file(s)`. `lake build` completed with `Build completed successfully (4305 jobs).` `lake exe axioms` completed with `axioms: audited 6040 TauCeti declaration(s); all within the allowlist [propext, Classical.choice, Quot.sound].`

<!--tauceti-target:v1 {"focus":"ReductiveGroups","id":"multiplicative-group-base-change"}-->

🤖 Prepared with Codex
