### PR TITLE
chore: bump TauCetiReview review pin to 21f3525

### DIFF
--- a/.github/workflows/review.yml
+++ b/.github/workflows/review.yml
@@ -79,7 +79,7 @@ jobs:
     if: ${{ vars.CI_REVIEW_ENABLED == 'true' && needs.resolve.outputs.pr != '' }}
     # Pinned to a TauCetiReview commit; bump deliberately (an unpinned @main lets an upstream change
     # break every contributor's review at once, and this workflow inherits TauCeti's secrets).
-    uses: FormalFrontier/TauCetiReview/.github/workflows/review.yml@8141201d620b0ae986222bea6ee25d7c0d3d1e72
+    uses: FormalFrontier/TauCetiReview/.github/workflows/review.yml@21f3525b96c22030f5b5b49307867b903cab28dc
     with:
       pr: ${{ needs.resolve.outputs.pr }}
       trigger: ${{ github.event_name }}


### PR DESCRIPTION
This PR bumps the pinned TauCetiReview reusable review workflow from 8141201 to 21f3525 (forward-only), so the review engine picks up two rubric fixes landed today: https://github.com/FormalFrontier/TauCetiReview/pull/88 (stop the placement rubric demanding a redundant direct import for something already available transitively) and https://github.com/FormalFrontier/TauCetiReview/pull/89 (have reviewers identify every instance of the same defect in one pass rather than one per round). The merge-only and merge-sweep pins are left untouched: those workflows read no rubrics.

🤖 Prepared with Claude Code