### PR TITLE
feat: add finite Chebyshev measure API

### DIFF
--- a/TauCeti/Analysis/SpecialFunctions/Trigonometric/Chebyshev/Measure.lean
+++ b/TauCeti/Analysis/SpecialFunctions/Trigonometric/Chebyshev/Measure.lean
@@ -1,5 +1,7 @@
-import Mathlib.Analysis.SpecialFunctions.Trigonometric.Chebyshev.Orthogonality
-import Mathlib.MeasureTheory.Measure.Real
+module
+
+public import Mathlib.Analysis.SpecialFunctions.Trigonometric.Chebyshev.Orthogonality
+public import Mathlib.MeasureTheory.Measure.Real
 
 /-!
 # Finite measure API for the Chebyshev `T` weight
@@ -14,6 +16,8 @@ nonzero, and that the existing Mathlib orthogonality lemmas combine into one
 Kronecker-delta statement with squared norms `π` in degree zero and `π / 2` in
 positive degree.
 -/
+
+public section
 
 namespace TauCeti
 

--- a/TauCeti/Analysis/SpecialFunctions/Trigonometric/Chebyshev/Measure.lean
+++ b/TauCeti/Analysis/SpecialFunctions/Trigonometric/Chebyshev/Measure.lean
@@ -63,6 +63,7 @@ noncomputable def chebyshevTNormSq (n : ℕ) : ℝ :=
 lemma chebyshevTNormSq_zero : chebyshevTNormSq 0 = Real.pi := by
   simp [chebyshevTNormSq]
 
+@[simp]
 lemma chebyshevTNormSq_of_ne_zero {n : ℕ} (hn : n ≠ 0) :
     chebyshevTNormSq n = Real.pi / 2 := by
   simp [chebyshevTNormSq, hn]

--- a/TauCeti/Analysis/SpecialFunctions/Trigonometric/Chebyshev/Measure.lean
+++ b/TauCeti/Analysis/SpecialFunctions/Trigonometric/Chebyshev/Measure.lean
@@ -1,0 +1,98 @@
+import Mathlib.Analysis.SpecialFunctions.Trigonometric.Chebyshev.Orthogonality
+import Mathlib.MeasureTheory.Measure.Real
+
+/-!
+# Finite measure API for the Chebyshev `T` weight
+
+This file records the finite-measure bookkeeping for Mathlib's Chebyshev
+orthogonality measure `Polynomial.Chebyshev.measureT`, together with the
+single normalization constant used by the roadmap's Chebyshev Hilbert-basis
+target.
+
+The main facts are that `measureT` has total mass `π`, hence is finite and
+nonzero, and that the existing Mathlib orthogonality lemmas combine into one
+Kronecker-delta statement with squared norms `π` in degree zero and `π / 2` in
+positive degree.
+-/
+
+namespace TauCeti
+
+open MeasureTheory Polynomial.Chebyshev
+
+open scoped ENNReal
+
+/-- The Chebyshev `T` orthogonality measure has total mass `π`. -/
+lemma chebyshevMeasureT_univ :
+    Polynomial.Chebyshev.measureT Set.univ = ENNReal.ofReal Real.pi := by
+  have h := integral_eval_T_real_measureT_zero
+  have hreal : Polynomial.Chebyshev.measureT.real Set.univ = Real.pi := by
+    simpa using h
+  have hfinite : Polynomial.Chebyshev.measureT Set.univ ≠ ∞ := by
+    intro htop
+    have hzero : Polynomial.Chebyshev.measureT.real Set.univ = 0 := by
+      simp [Measure.real, htop]
+    linarith [hreal, Real.pi_pos]
+  rw [← MeasureTheory.ofReal_measureReal (μ := Polynomial.Chebyshev.measureT)
+    (s := Set.univ) hfinite, hreal]
+
+/-- Mathlib's Chebyshev `T` orthogonality measure is finite. -/
+noncomputable instance chebyshevMeasureT.instIsFiniteMeasure :
+    IsFiniteMeasure Polynomial.Chebyshev.measureT where
+  measure_univ_lt_top := by
+    rw [chebyshevMeasureT_univ]
+    exact ENNReal.ofReal_lt_top
+
+/-- The Chebyshev `T` orthogonality measure has positive total mass. -/
+lemma chebyshevMeasureT_univ_pos : 0 < Polynomial.Chebyshev.measureT Set.univ := by
+  rw [chebyshevMeasureT_univ]
+  exact ENNReal.ofReal_pos.mpr Real.pi_pos
+
+/-- Mathlib's Chebyshev `T` orthogonality measure is nonzero. -/
+lemma chebyshevMeasureT_ne_zero : Polynomial.Chebyshev.measureT ≠ 0 :=
+  Measure.measure_univ_pos.mp chebyshevMeasureT_univ_pos
+
+/-- The squared `L²(measureT)` norm of the `n`th Chebyshev `T` polynomial. -/
+noncomputable def chebyshevTNormSq (n : ℕ) : ℝ :=
+  if n = 0 then Real.pi else Real.pi / 2
+
+@[simp]
+lemma chebyshevTNormSq_zero : chebyshevTNormSq 0 = Real.pi := by
+  simp [chebyshevTNormSq]
+
+lemma chebyshevTNormSq_of_ne_zero {n : ℕ} (hn : n ≠ 0) :
+    chebyshevTNormSq n = Real.pi / 2 := by
+  simp [chebyshevTNormSq, hn]
+
+/-- The squared norm constant for Chebyshev `T` polynomials is positive. -/
+lemma chebyshevTNormSq_pos (n : ℕ) : 0 < chebyshevTNormSq n := by
+  by_cases hn : n = 0
+  · simp [hn, Real.pi_pos]
+  · rw [chebyshevTNormSq_of_ne_zero hn]
+    positivity
+
+/-- The squared norm constant for Chebyshev `T` polynomials is nonzero. -/
+lemma chebyshevTNormSq_ne_zero (n : ℕ) : chebyshevTNormSq n ≠ 0 :=
+  ne_of_gt (chebyshevTNormSq_pos n)
+
+/-- The diagonal Chebyshev `T` orthogonality integral, with the degree-zero and
+positive-degree cases hidden behind one normalization constant. -/
+lemma integral_eval_T_real_mul_self_measureT (n : ℕ) :
+    ∫ x, (T ℝ n).eval x * (T ℝ n).eval x ∂Polynomial.Chebyshev.measureT =
+      chebyshevTNormSq n := by
+  by_cases hn : n = 0
+  · subst hn
+    exact integral_eval_T_real_mul_self_measureT_zero
+  · rw [chebyshevTNormSq_of_ne_zero hn]
+    exact integral_T_real_mul_self_measureT_of_ne_zero hn
+
+/-- Chebyshev `T` orthogonality in the Kronecker-delta form expected by the
+general orthogonality-to-Hilbert-basis bridge. -/
+lemma integral_eval_T_real_mul_eval_T_real_measureT_eq_ite (m n : ℕ) :
+    ∫ x, (T ℝ m).eval x * (T ℝ n).eval x ∂Polynomial.Chebyshev.measureT =
+      if m = n then chebyshevTNormSq n else 0 := by
+  by_cases hmn : m = n
+  · subst hmn
+    simp [integral_eval_T_real_mul_self_measureT]
+  · simp [hmn, integral_eval_T_real_mul_eval_T_real_measureT_of_ne hmn]
+
+end TauCeti


### PR DESCRIPTION
This PR adds the finite-measure API for Mathlib\s Chebyshev `T` orthogonality measure `Polynomial.Chebyshev.measureT`: its total mass is `π`, it has an `IsFiniteMeasure` instance, it is nonzero, and its diagonal/off-diagonal orthogonality constants are packaged as one Kronecker-delta statement for downstream Hilbert-basis assembly.

It advances `TauCetiRoadmap/OrthogonalL2Bases/README.md`, Part C, specifically the open target “`IsFiniteMeasure measureT` (derivable, currently no instance)” and the Chebyshev Hilbert-basis prerequisite that the normalized constants are `c₀ = π` and `cₙ = π/2`. I chose this as the lowest-hanging distinct OrthogonalL2Bases target after checking open and recently merged PRs: open PR #499 covers Hermite A1, while the Chebyshev finite-measure prerequisite was still absent and follows directly from Mathlib\s existing Chebyshev orthogonality API.

No Mathlib infrastructure is vendored. The implementation reuses Mathlib\s `Polynomial.Chebyshev.measureT`, `integral_eval_T_real_measureT_zero`, `integral_eval_T_real_mul_eval_T_real_measureT_of_ne`, `integral_eval_T_real_mul_self_measureT_zero`, and `integral_T_real_mul_self_measureT_of_ne_zero`.

`lake exe cache get` completed with `No files to download` and `Already decompressed 8601 file(s)`. `lake build` completed with `Build completed successfully (4314 jobs).` `lake exe axioms` completed with `axioms: audited 6171 TauCeti declaration(s); all within the allowlist [propext, Classical.choice, Quot.sound].`

<!--tauceti-target:v1 {"focus":"OrthogonalL2Bases","id":"chebyshev-measure-finite"}-->

🤖 Prepared with Codex
