### PR TITLE
feat: add BCR spatial pullback API

### DIFF
--- a/TauCeti/Analysis/PositiveDefinite/SemigroupGroupPullback.lean
+++ b/TauCeti/Analysis/PositiveDefinite/SemigroupGroupPullback.lean
@@ -28,6 +28,8 @@ function API item "pullbacks" and Milestone 2 ("BCR semigroup--Bochner").
 
 * `TauCeti.IsSemigroupGroupPD.comp_spatial`: spatial pullback along an additive homomorphism,
   stated using Mathlib's homomorphism classes.
+* `TauCeti.IsSemigroupGroupPD.comp_spatial_comp`: composition of spatial pullbacks, stated
+  using Mathlib's homomorphism classes.
 * `TauCeti.IsSemigroupGroupPD.of_comp_spatial_surjective` and
   `TauCeti.IsSemigroupGroupPD.comp_spatial_iff_of_surjective`: descent and equivalence for
   surjective additive homomorphisms.
@@ -37,9 +39,11 @@ function API item "pullbacks" and Milestone 2 ("BCR semigroup--Bochner").
   used for real vector spaces.
 * `TauCeti.IsSemigroupGroupPD.continuous_comp_spatial`: spatial pullback preserves continuity
   along continuous maps.
-* `TauCeti.IsSemigroupGroupPD.comp_spatialAddMonoidHom_and_continuous` and
+* `TauCeti.IsSemigroupGroupPD.comp_spatial_and_continuous`,
+  `TauCeti.IsSemigroupGroupPD.comp_spatialAddMonoidHom_and_continuous`, and
   `TauCeti.IsSemigroupGroupPD.comp_spatialContinuousLinearMap_and_continuous`: packaged
-  additive and continuous-linear forms preserving both positive-definiteness and continuity.
+  homomorphism-class, additive, and continuous-linear forms preserving both
+  positive-definiteness and continuity.
 
 ## References
 
@@ -89,9 +93,15 @@ theorem comp_spatialAddMonoidHom (hF : IsSemigroupGroupPD F) (φ : W →+ V) :
   hF.comp_spatial φ
 
 /-- Spatial pullbacks compose as expected. -/
+theorem comp_spatial_comp {Φ Ψ : Type*} [FunLike Φ W V] [AddHomClass Φ W V]
+    [FunLike Ψ U W] [AddHomClass Ψ U W] (hF : IsSemigroupGroupPD F) (φ : Φ) (ψ : Ψ) :
+    IsSemigroupGroupPD fun p : ℝ≥0 × U => F (p.1, φ (ψ p.2)) :=
+  (hF.comp_spatial φ).comp_spatial ψ
+
+/-- The explicit `AddMonoidHom` form of composed spatial pullbacks. -/
 theorem comp_spatialAddMonoidHom_comp (hF : IsSemigroupGroupPD F) (φ : W →+ V) (ψ : U →+ W) :
     IsSemigroupGroupPD fun p : ℝ≥0 × U => F (p.1, φ (ψ p.2)) :=
-  (hF.comp_spatialAddMonoidHom φ).comp_spatialAddMonoidHom ψ
+  hF.comp_spatial_comp φ ψ
 
 /-- Semigroup-group positive-definiteness descends along a surjective spatial additive
 homomorphism. -/
@@ -137,11 +147,18 @@ theorem continuous_comp_spatial (hF : Continuous F) (φ : W → V) (hφ : Contin
 
 /-- Package spatial pullback of a semigroup-group positive-definite function with continuity
 of the pulled-back function. -/
+theorem comp_spatial_and_continuous {Φ : Type*} [FunLike Φ W V] [AddHomClass Φ W V]
+    (hFpd : IsSemigroupGroupPD F) (hFcont : Continuous F) (φ : Φ) (hφ : Continuous φ) :
+    IsSemigroupGroupPD (fun p : ℝ≥0 × W => F (p.1, φ p.2)) ∧
+      Continuous (fun p : ℝ≥0 × W => F (p.1, φ p.2)) :=
+  ⟨hFpd.comp_spatial φ, continuous_comp_spatial hFcont φ hφ⟩
+
+/-- The explicit `AddMonoidHom` form of spatial pullback packaged with continuity. -/
 theorem comp_spatialAddMonoidHom_and_continuous (hFpd : IsSemigroupGroupPD F)
     (hFcont : Continuous F) (φ : W →+ V) (hφ : Continuous φ) :
     IsSemigroupGroupPD (fun p : ℝ≥0 × W => F (p.1, φ p.2)) ∧
       Continuous (fun p : ℝ≥0 × W => F (p.1, φ p.2)) :=
-  ⟨hFpd.comp_spatialAddMonoidHom φ, continuous_comp_spatial hFcont φ hφ⟩
+  hFpd.comp_spatial_and_continuous hFcont φ hφ
 
 end Topology
 
@@ -169,7 +186,7 @@ theorem comp_spatialContinuousLinearMap_and_continuous (hGpd : IsSemigroupGroupP
     (hGcont : Continuous G) (φ : E' →L[ℝ] E) :
     IsSemigroupGroupPD (fun p : ℝ≥0 × E' => G (p.1, φ p.2)) ∧
       Continuous (fun p : ℝ≥0 × E' => G (p.1, φ p.2)) :=
-  ⟨hGpd.comp_spatialContinuousLinearMap φ, continuous_comp_spatial hGcont φ φ.continuous⟩
+  hGpd.comp_spatial_and_continuous hGcont φ φ.continuous
 
 end ContinuousLinearMap
 

--- a/TauCeti/Analysis/PositiveDefinite/SemigroupGroupPullback.lean
+++ b/TauCeti/Analysis/PositiveDefinite/SemigroupGroupPullback.lean
@@ -33,14 +33,14 @@ function API item "pullbacks" and Milestone 2 ("BCR semigroup--Bochner").
 * `TauCeti.IsSemigroupGroupPD.of_comp_spatial_surjective` and
   `TauCeti.IsSemigroupGroupPD.comp_spatial_iff_of_surjective`: descent and equivalence for
   surjective additive homomorphisms.
-* `TauCeti.IsSemigroupGroupPD.comp_spatialAddEquiv_iff`: invariance under a spatial additive
+* `TauCeti.IsSemigroupGroupPD.comp_spatial_addEquiv_iff`: invariance under a spatial additive
   equivalence.
-* `TauCeti.IsSemigroupGroupPD.comp_spatialContinuousLinearMap`: the continuous-linear-map form
+* `TauCeti.IsSemigroupGroupPD.comp_spatial_continuousLinearMap`: the continuous-linear-map form
   used for real vector spaces.
 * `TauCeti.IsSemigroupGroupPD.continuous_comp_spatial`: spatial pullback preserves continuity
   along continuous maps.
 * `TauCeti.IsSemigroupGroupPD.comp_spatial_and_continuous`,
-  `TauCeti.IsSemigroupGroupPD.comp_spatialContinuousLinearMap_and_continuous`: packaged
+  `TauCeti.IsSemigroupGroupPD.comp_spatial_continuousLinearMap_and_continuous`: packaged
   homomorphism-class and continuous-linear forms preserving both positive-definiteness and
   continuity.
 
@@ -87,7 +87,7 @@ theorem comp_spatial {Φ : Type*} [FunLike Φ W V] [AddHomClass Φ W V]
   simpa [map_sub_of_addHomClass φ] using hK
 
 /-- The explicit `AddMonoidHom` form of spatial pullback. -/
-theorem comp_spatialAddMonoidHom (hF : IsSemigroupGroupPD F) (φ : W →+ V) :
+theorem comp_spatial_addMonoidHom (hF : IsSemigroupGroupPD F) (φ : W →+ V) :
     IsSemigroupGroupPD fun p : ℝ≥0 × W => F (p.1, φ p.2) :=
   hF.comp_spatial φ
 
@@ -118,16 +118,16 @@ theorem comp_spatial_iff_of_surjective {Φ : Type*} [FunLike Φ W V] [AddHomClas
   ⟨of_comp_spatial_surjective φ hsurj, fun hF => hF.comp_spatial φ⟩
 
 /-- The explicit `AddMonoidHom` form of the spatial pullback equivalence for surjective maps. -/
-theorem comp_spatialAddMonoidHom_iff_of_surjective (φ : W →+ V)
+theorem comp_spatial_addMonoidHom_iff_of_surjective (φ : W →+ V)
     (hsurj : Function.Surjective φ) :
     IsSemigroupGroupPD (fun p : ℝ≥0 × W => F (p.1, φ p.2)) ↔ IsSemigroupGroupPD F :=
   comp_spatial_iff_of_surjective φ hsurj
 
 /-- Semigroup-group positive-definiteness is invariant under precomposition by a spatial
 additive equivalence. -/
-theorem comp_spatialAddEquiv_iff (e : W ≃+ V) :
+theorem comp_spatial_addEquiv_iff (e : W ≃+ V) :
     IsSemigroupGroupPD (fun p : ℝ≥0 × W => F (p.1, e p.2)) ↔ IsSemigroupGroupPD F :=
-  comp_spatialAddMonoidHom_iff_of_surjective e.toAddMonoidHom e.surjective
+  comp_spatial_addMonoidHom_iff_of_surjective e.toAddMonoidHom e.surjective
 
 section Topology
 
@@ -158,18 +158,18 @@ variable {E : Type*} {E' : Type*}
 
 /-- Spatial pullback along a continuous linear map preserves semigroup-group
 positive-definiteness. -/
-theorem comp_spatialContinuousLinearMap (hG : IsSemigroupGroupPD G) (φ : E' →L[ℝ] E) :
+theorem comp_spatial_continuousLinearMap (hG : IsSemigroupGroupPD G) (φ : E' →L[ℝ] E) :
     IsSemigroupGroupPD fun p : ℝ≥0 × E' => G (p.1, φ p.2) :=
   hG.comp_spatial φ
 
 /-- Spatial pullback along a continuous linear equivalence is an equivalence on
 semigroup-group positive-definiteness. -/
-theorem comp_spatialContinuousLinearEquiv_iff (e : E' ≃L[ℝ] E) :
+theorem comp_spatial_continuousLinearEquiv_iff (e : E' ≃L[ℝ] E) :
     IsSemigroupGroupPD (fun p : ℝ≥0 × E' => G (p.1, e p.2)) ↔ IsSemigroupGroupPD G :=
-  comp_spatialAddEquiv_iff e.toAddEquiv
+  comp_spatial_addEquiv_iff e.toAddEquiv
 
 /-- Package spatial pullback along a continuous linear map with preservation of continuity. -/
-theorem comp_spatialContinuousLinearMap_and_continuous (hGpd : IsSemigroupGroupPD G)
+theorem comp_spatial_continuousLinearMap_and_continuous (hGpd : IsSemigroupGroupPD G)
     (hGcont : Continuous G) (φ : E' →L[ℝ] E) :
     IsSemigroupGroupPD (fun p : ℝ≥0 × E' => G (p.1, φ p.2)) ∧
       Continuous (fun p : ℝ≥0 × E' => G (p.1, φ p.2)) :=

--- a/TauCeti/Analysis/PositiveDefinite/SemigroupGroupPullback.lean
+++ b/TauCeti/Analysis/PositiveDefinite/SemigroupGroupPullback.lean
@@ -26,15 +26,20 @@ function API item "pullbacks" and Milestone 2 ("BCR semigroup--Bochner").
 
 ## Main declarations
 
-* `TauCeti.IsSemigroupGroupPD.comp_spatialAddMonoidHom`: spatial pullback along an additive
-  homomorphism.
+* `TauCeti.IsSemigroupGroupPD.comp_spatial`: spatial pullback along an additive homomorphism,
+  stated using Mathlib's homomorphism classes.
+* `TauCeti.IsSemigroupGroupPD.of_comp_spatial_surjective` and
+  `TauCeti.IsSemigroupGroupPD.comp_spatial_iff_of_surjective`: descent and equivalence for
+  surjective additive homomorphisms.
 * `TauCeti.IsSemigroupGroupPD.comp_spatialAddEquiv_iff`: invariance under a spatial additive
   equivalence.
 * `TauCeti.IsSemigroupGroupPD.comp_spatialContinuousLinearMap`: the continuous-linear-map form
   used for real vector spaces.
+* `TauCeti.IsSemigroupGroupPD.continuous_comp_spatial`: spatial pullback preserves continuity
+  along continuous maps.
 * `TauCeti.IsSemigroupGroupPD.comp_spatialAddMonoidHom_and_continuous` and
-  `TauCeti.IsSemigroupGroupPD.comp_spatialContinuousLinearMap_and_continuous`: packaged forms
-  preserving both positive-definiteness and continuity.
+  `TauCeti.IsSemigroupGroupPD.comp_spatialContinuousLinearMap_and_continuous`: packaged
+  additive and continuous-linear forms preserving both positive-definiteness and continuity.
 
 ## References
 
@@ -44,7 +49,7 @@ function API item "pullbacks" and Milestone 2 ("BCR semigroup--Bochner").
 
 public section
 
-open scoped NNReal
+open scoped NNReal ComplexOrder
 
 namespace TauCeti
 
@@ -53,38 +58,80 @@ namespace IsSemigroupGroupPD
 variable {V W U : Type*} [AddCommGroup V] [AddCommGroup W] [AddCommGroup U]
   {F : ℝ≥0 × V → ℂ}
 
+private theorem map_sub_of_addHomClass {Φ : Type*} [FunLike Φ W V] [AddHomClass Φ W V]
+    (φ : Φ) (x y : W) : φ (x - y) = φ x - φ y := by
+  have hneg : φ (-y) = -φ y := by
+    have hzero : φ (0 : W) = 0 := by
+      have h := map_add φ (0 : W) (0 : W)
+      have h' : φ (0 : W) + φ (0 : W) = φ (0 : W) + 0 := by simpa using h.symm
+      exact add_left_cancel h'
+    have h := map_add φ y (-y)
+    have hsum : φ y + φ (-y) = 0 := by
+      simpa [hzero] using h.symm
+    exact eq_neg_of_add_eq_zero_right hsum
+  simp [sub_eq_add_neg, map_add, hneg]
+
 /-- Pulling back the spatial coordinate of a semigroup-group positive-definite function along an
-additive homomorphism preserves semigroup-group positive-definiteness. -/
-theorem comp_spatialAddMonoidHom (hF : IsSemigroupGroupPD F) (φ : W →+ V) :
+additive homomorphism preserves semigroup-group positive-definiteness. This is stated for
+Mathlib's homomorphism classes so it applies to bundled additive homomorphisms, additive
+equivalences, continuous linear maps, and similar maps. -/
+theorem comp_spatial {Φ : Type*} [FunLike Φ W V] [AddHomClass Φ W V]
+    (hF : IsSemigroupGroupPD F) (φ : Φ) :
     IsSemigroupGroupPD fun p : ℝ≥0 × W => F (p.1, φ p.2) := by
   refine IsSemigroupGroupPD.of_isPositiveDefiniteKernel ?_
   have hK := isPositiveDefiniteKernel_comp hF.isPositiveDefiniteKernel
     (fun p : ℝ≥0 × W => (p.1, φ p.2))
-  simpa [map_sub] using hK
+  simpa [map_sub_of_addHomClass φ] using hK
+
+/-- The explicit `AddMonoidHom` form of spatial pullback. -/
+theorem comp_spatialAddMonoidHom (hF : IsSemigroupGroupPD F) (φ : W →+ V) :
+    IsSemigroupGroupPD fun p : ℝ≥0 × W => F (p.1, φ p.2) :=
+  hF.comp_spatial φ
 
 /-- Spatial pullbacks compose as expected. -/
 theorem comp_spatialAddMonoidHom_comp (hF : IsSemigroupGroupPD F) (φ : W →+ V) (ψ : U →+ W) :
     IsSemigroupGroupPD fun p : ℝ≥0 × U => F (p.1, φ (ψ p.2)) :=
   (hF.comp_spatialAddMonoidHom φ).comp_spatialAddMonoidHom ψ
 
+/-- Semigroup-group positive-definiteness descends along a surjective spatial additive
+homomorphism. -/
+theorem of_comp_spatial_surjective {Φ : Type*} [FunLike Φ W V] [AddHomClass Φ W V]
+    (φ : Φ) (hsurj : Function.Surjective φ)
+    (hcomp : IsSemigroupGroupPD fun p : ℝ≥0 × W => F (p.1, φ p.2)) :
+    IsSemigroupGroupPD F := by
+  classical
+  refine IsSemigroupGroupPD.of_isPositiveDefiniteKernel ?_
+  choose w hw using hsurj
+  have hK := isPositiveDefiniteKernel_comp hcomp.isPositiveDefiniteKernel
+    (fun p : ℝ≥0 × V => (p.1, w p.2))
+  simpa [hw, map_sub_of_addHomClass φ] using hK
+
+/-- Along a surjective spatial additive homomorphism, a function is semigroup-group positive
+definite if and only if its spatial pullback is. -/
+theorem comp_spatial_iff_of_surjective {Φ : Type*} [FunLike Φ W V] [AddHomClass Φ W V]
+    (φ : Φ) (hsurj : Function.Surjective φ) :
+    IsSemigroupGroupPD (fun p : ℝ≥0 × W => F (p.1, φ p.2)) ↔ IsSemigroupGroupPD F :=
+  ⟨of_comp_spatial_surjective φ hsurj, fun hF => hF.comp_spatial φ⟩
+
+/-- The explicit `AddMonoidHom` form of the spatial pullback equivalence for surjective maps. -/
+theorem comp_spatialAddMonoidHom_iff_of_surjective (φ : W →+ V)
+    (hsurj : Function.Surjective φ) :
+    IsSemigroupGroupPD (fun p : ℝ≥0 × W => F (p.1, φ p.2)) ↔ IsSemigroupGroupPD F :=
+  comp_spatial_iff_of_surjective φ hsurj
+
 /-- Semigroup-group positive-definiteness is invariant under precomposition by a spatial
 additive equivalence. -/
 theorem comp_spatialAddEquiv_iff (e : W ≃+ V) :
-    IsSemigroupGroupPD (fun p : ℝ≥0 × W => F (p.1, e p.2)) ↔ IsSemigroupGroupPD F := by
-  constructor
-  · intro h
-    have h' := h.comp_spatialAddMonoidHom e.symm.toAddMonoidHom
-    simpa using h'
-  · intro h
-    exact h.comp_spatialAddMonoidHom e.toAddMonoidHom
+    IsSemigroupGroupPD (fun p : ℝ≥0 × W => F (p.1, e p.2)) ↔ IsSemigroupGroupPD F :=
+  comp_spatialAddMonoidHom_iff_of_surjective e.toAddMonoidHom e.surjective
 
 section Topology
 
 variable [TopologicalSpace V] [TopologicalSpace W]
 
-/-- If the spatial additive homomorphism is continuous, spatial pullback preserves continuity. -/
-theorem continuous_comp_spatialAddMonoidHom (hF : Continuous F) (φ : W →+ V)
-    (hφ : Continuous φ) :
+omit [AddCommGroup V] [AddCommGroup W] in
+/-- If the spatial map is continuous, spatial pullback preserves continuity. -/
+theorem continuous_comp_spatial (hF : Continuous F) (φ : W → V) (hφ : Continuous φ) :
     Continuous fun p : ℝ≥0 × W => F (p.1, φ p.2) :=
   hF.comp (continuous_fst.prodMk (hφ.comp continuous_snd))
 
@@ -94,7 +141,7 @@ theorem comp_spatialAddMonoidHom_and_continuous (hFpd : IsSemigroupGroupPD F)
     (hFcont : Continuous F) (φ : W →+ V) (hφ : Continuous φ) :
     IsSemigroupGroupPD (fun p : ℝ≥0 × W => F (p.1, φ p.2)) ∧
       Continuous (fun p : ℝ≥0 × W => F (p.1, φ p.2)) :=
-  ⟨hFpd.comp_spatialAddMonoidHom φ, continuous_comp_spatialAddMonoidHom hFcont φ hφ⟩
+  ⟨hFpd.comp_spatialAddMonoidHom φ, continuous_comp_spatial hFcont φ hφ⟩
 
 end Topology
 
@@ -109,7 +156,7 @@ variable {E : Type*} {E' : Type*}
 positive-definiteness. -/
 theorem comp_spatialContinuousLinearMap (hG : IsSemigroupGroupPD G) (φ : E' →L[ℝ] E) :
     IsSemigroupGroupPD fun p : ℝ≥0 × E' => G (p.1, φ p.2) :=
-  hG.comp_spatialAddMonoidHom φ.toAddMonoidHom
+  hG.comp_spatial φ
 
 /-- Spatial pullback along a continuous linear equivalence is an equivalence on
 semigroup-group positive-definiteness. -/
@@ -122,7 +169,7 @@ theorem comp_spatialContinuousLinearMap_and_continuous (hGpd : IsSemigroupGroupP
     (hGcont : Continuous G) (φ : E' →L[ℝ] E) :
     IsSemigroupGroupPD (fun p : ℝ≥0 × E' => G (p.1, φ p.2)) ∧
       Continuous (fun p : ℝ≥0 × E' => G (p.1, φ p.2)) :=
-  hGpd.comp_spatialAddMonoidHom_and_continuous hGcont φ.toAddMonoidHom φ.continuous
+  ⟨hGpd.comp_spatialContinuousLinearMap φ, continuous_comp_spatial hGcont φ φ.continuous⟩
 
 end ContinuousLinearMap
 

--- a/TauCeti/Analysis/PositiveDefinite/SemigroupGroupPullback.lean
+++ b/TauCeti/Analysis/PositiveDefinite/SemigroupGroupPullback.lean
@@ -40,10 +40,9 @@ function API item "pullbacks" and Milestone 2 ("BCR semigroup--Bochner").
 * `TauCeti.IsSemigroupGroupPD.continuous_comp_spatial`: spatial pullback preserves continuity
   along continuous maps.
 * `TauCeti.IsSemigroupGroupPD.comp_spatial_and_continuous`,
-  `TauCeti.IsSemigroupGroupPD.comp_spatialAddMonoidHom_and_continuous`, and
   `TauCeti.IsSemigroupGroupPD.comp_spatialContinuousLinearMap_and_continuous`: packaged
-  homomorphism-class, additive, and continuous-linear forms preserving both
-  positive-definiteness and continuity.
+  homomorphism-class and continuous-linear forms preserving both positive-definiteness and
+  continuity.
 
 ## References
 
@@ -98,11 +97,6 @@ theorem comp_spatial_comp {Φ Ψ : Type*} [FunLike Φ W V] [AddHomClass Φ W V]
     IsSemigroupGroupPD fun p : ℝ≥0 × U => F (p.1, φ (ψ p.2)) :=
   (hF.comp_spatial φ).comp_spatial ψ
 
-/-- The explicit `AddMonoidHom` form of composed spatial pullbacks. -/
-theorem comp_spatialAddMonoidHom_comp (hF : IsSemigroupGroupPD F) (φ : W →+ V) (ψ : U →+ W) :
-    IsSemigroupGroupPD fun p : ℝ≥0 × U => F (p.1, φ (ψ p.2)) :=
-  hF.comp_spatial_comp φ ψ
-
 /-- Semigroup-group positive-definiteness descends along a surjective spatial additive
 homomorphism. -/
 theorem of_comp_spatial_surjective {Φ : Type*} [FunLike Φ W V] [AddHomClass Φ W V]
@@ -152,13 +146,6 @@ theorem comp_spatial_and_continuous {Φ : Type*} [FunLike Φ W V] [AddHomClass �
     IsSemigroupGroupPD (fun p : ℝ≥0 × W => F (p.1, φ p.2)) ∧
       Continuous (fun p : ℝ≥0 × W => F (p.1, φ p.2)) :=
   ⟨hFpd.comp_spatial φ, continuous_comp_spatial hFcont φ hφ⟩
-
-/-- The explicit `AddMonoidHom` form of spatial pullback packaged with continuity. -/
-theorem comp_spatialAddMonoidHom_and_continuous (hFpd : IsSemigroupGroupPD F)
-    (hFcont : Continuous F) (φ : W →+ V) (hφ : Continuous φ) :
-    IsSemigroupGroupPD (fun p : ℝ≥0 × W => F (p.1, φ p.2)) ∧
-      Continuous (fun p : ℝ≥0 × W => F (p.1, φ p.2)) :=
-  hFpd.comp_spatial_and_continuous hFcont φ hφ
 
 end Topology
 

--- a/TauCeti/Analysis/PositiveDefinite/SemigroupGroupPullback.lean
+++ b/TauCeti/Analysis/PositiveDefinite/SemigroupGroupPullback.lean
@@ -1,0 +1,131 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+module
+
+public import TauCeti.Analysis.PositiveDefinite.SemigroupGroup
+public import Mathlib.Analysis.Normed.Module.Basic
+public import Mathlib.Topology.Constructions.SumProd
+
+/-!
+# Spatial pullbacks of semigroup-group positive-definite functions
+
+This file records the spatial-coordinate pullback API for Berg--Christensen--Ressel
+positive-definite functions on `ℝ≥0 × V`. If `F` is semigroup-group positive definite and
+`φ : W →+ V` is an additive homomorphism, then `(t, w) ↦ F (t, φ w)` is again
+semigroup-group positive definite.
+
+This is a small prerequisite for the BCR semigroup--Bochner representation milestone in the
+`OneParameterSemigroups` roadmap. The Bochner part is stated on an arbitrary finite-dimensional
+real inner-product space, so downstream arguments need to transport the spatial variable along
+additive equivalences and continuous linear maps without unfolding the private BCR wrapper.
+
+This advances `TauCetiRoadmap/OneParameterSemigroups/README.md`, Part C, the positive-definite
+function API item "pullbacks" and Milestone 2 ("BCR semigroup--Bochner").
+
+## Main declarations
+
+* `TauCeti.IsSemigroupGroupPD.comp_spatialAddMonoidHom`: spatial pullback along an additive
+  homomorphism.
+* `TauCeti.IsSemigroupGroupPD.comp_spatialAddEquiv_iff`: invariance under a spatial additive
+  equivalence.
+* `TauCeti.IsSemigroupGroupPD.comp_spatialContinuousLinearMap`: the continuous-linear-map form
+  used for real vector spaces.
+* `TauCeti.IsSemigroupGroupPD.comp_spatialAddMonoidHom_and_continuous` and
+  `TauCeti.IsSemigroupGroupPD.comp_spatialContinuousLinearMap_and_continuous`: packaged forms
+  preserving both positive-definiteness and continuity.
+
+## References
+
+* C. Berg, J. P. R. Christensen, P. Ressel, *Harmonic Analysis on Semigroups* (GTM 100, 1984),
+  Chapter 4.
+-/
+
+public section
+
+open scoped NNReal
+
+namespace TauCeti
+
+namespace IsSemigroupGroupPD
+
+variable {V W U : Type*} [AddCommGroup V] [AddCommGroup W] [AddCommGroup U]
+  {F : ℝ≥0 × V → ℂ}
+
+/-- Pulling back the spatial coordinate of a semigroup-group positive-definite function along an
+additive homomorphism preserves semigroup-group positive-definiteness. -/
+theorem comp_spatialAddMonoidHom (hF : IsSemigroupGroupPD F) (φ : W →+ V) :
+    IsSemigroupGroupPD fun p : ℝ≥0 × W => F (p.1, φ p.2) := by
+  refine IsSemigroupGroupPD.of_isPositiveDefiniteKernel ?_
+  have hK := isPositiveDefiniteKernel_comp hF.isPositiveDefiniteKernel
+    (fun p : ℝ≥0 × W => (p.1, φ p.2))
+  simpa [map_sub] using hK
+
+/-- Spatial pullbacks compose as expected. -/
+theorem comp_spatialAddMonoidHom_comp (hF : IsSemigroupGroupPD F) (φ : W →+ V) (ψ : U →+ W) :
+    IsSemigroupGroupPD fun p : ℝ≥0 × U => F (p.1, φ (ψ p.2)) :=
+  (hF.comp_spatialAddMonoidHom φ).comp_spatialAddMonoidHom ψ
+
+/-- Semigroup-group positive-definiteness is invariant under precomposition by a spatial
+additive equivalence. -/
+theorem comp_spatialAddEquiv_iff (e : W ≃+ V) :
+    IsSemigroupGroupPD (fun p : ℝ≥0 × W => F (p.1, e p.2)) ↔ IsSemigroupGroupPD F := by
+  constructor
+  · intro h
+    have h' := h.comp_spatialAddMonoidHom e.symm.toAddMonoidHom
+    simpa using h'
+  · intro h
+    exact h.comp_spatialAddMonoidHom e.toAddMonoidHom
+
+section Topology
+
+variable [TopologicalSpace V] [TopologicalSpace W]
+
+/-- If the spatial additive homomorphism is continuous, spatial pullback preserves continuity. -/
+theorem continuous_comp_spatialAddMonoidHom (hF : Continuous F) (φ : W →+ V)
+    (hφ : Continuous φ) :
+    Continuous fun p : ℝ≥0 × W => F (p.1, φ p.2) :=
+  hF.comp (continuous_fst.prodMk (hφ.comp continuous_snd))
+
+/-- Package spatial pullback of a semigroup-group positive-definite function with continuity
+of the pulled-back function. -/
+theorem comp_spatialAddMonoidHom_and_continuous (hFpd : IsSemigroupGroupPD F)
+    (hFcont : Continuous F) (φ : W →+ V) (hφ : Continuous φ) :
+    IsSemigroupGroupPD (fun p : ℝ≥0 × W => F (p.1, φ p.2)) ∧
+      Continuous (fun p : ℝ≥0 × W => F (p.1, φ p.2)) :=
+  ⟨hFpd.comp_spatialAddMonoidHom φ, continuous_comp_spatialAddMonoidHom hFcont φ hφ⟩
+
+end Topology
+
+section ContinuousLinearMap
+
+variable {E : Type*} {E' : Type*}
+  [NormedAddCommGroup E] [NormedSpace ℝ E]
+  [NormedAddCommGroup E'] [NormedSpace ℝ E']
+  {G : ℝ≥0 × E → ℂ}
+
+/-- Spatial pullback along a continuous linear map preserves semigroup-group
+positive-definiteness. -/
+theorem comp_spatialContinuousLinearMap (hG : IsSemigroupGroupPD G) (φ : E' →L[ℝ] E) :
+    IsSemigroupGroupPD fun p : ℝ≥0 × E' => G (p.1, φ p.2) :=
+  hG.comp_spatialAddMonoidHom φ.toAddMonoidHom
+
+/-- Spatial pullback along a continuous linear equivalence is an equivalence on
+semigroup-group positive-definiteness. -/
+theorem comp_spatialContinuousLinearEquiv_iff (e : E' ≃L[ℝ] E) :
+    IsSemigroupGroupPD (fun p : ℝ≥0 × E' => G (p.1, e p.2)) ↔ IsSemigroupGroupPD G :=
+  comp_spatialAddEquiv_iff e.toAddEquiv
+
+/-- Package spatial pullback along a continuous linear map with preservation of continuity. -/
+theorem comp_spatialContinuousLinearMap_and_continuous (hGpd : IsSemigroupGroupPD G)
+    (hGcont : Continuous G) (φ : E' →L[ℝ] E) :
+    IsSemigroupGroupPD (fun p : ℝ≥0 × E' => G (p.1, φ p.2)) ∧
+      Continuous (fun p : ℝ≥0 × E' => G (p.1, φ p.2)) :=
+  hGpd.comp_spatialAddMonoidHom_and_continuous hGcont φ.toAddMonoidHom φ.continuous
+
+end ContinuousLinearMap
+
+end IsSemigroupGroupPD
+
+end TauCeti


### PR DESCRIPTION
This PR adds the spatial-coordinate pullback API for Berg--Christensen--Ressel semigroup-group positive-definite functions: if `F : ℝ≥0 × V → ℂ` is `IsSemigroupGroupPD` and `φ : W →+ V` is additive, then `(t, w) ↦ F (t, φ w)` is again `IsSemigroupGroupPD`, with additive-equivalence, continuity, and continuous-linear-map forms.

It advances `TauCetiRoadmap/OneParameterSemigroups/README.md`, Part C, the positive-definite function API item “pullbacks” and Milestone 2, “BCR semigroup--Bochner.” I chose this as the lowest-hanging distinct OneParameterSemigroups prerequisite after checking open and recently merged PRs: Bernstein representation infrastructure and the first C₀-semigroup layer are in flight, while the merged positive-definite stack already has generic pullbacks but no public BCR spatial-pullback API because the BCR wrapper is intentionally private.

No Mathlib infrastructure is vendored. The implementation reuses Tau Ceti’s existing `IsSemigroupGroupPD.isPositiveDefiniteKernel` bridge, `IsSemigroupGroupPD.of_isPositiveDefiniteKernel`, and `isPositiveDefiniteKernel_comp`, together with Mathlib’s additive-homomorphism and continuous-linear-map APIs.

`lake exe cache get` completed with `No files to download` and `Already decompressed 8601 file(s)`. `lake build` completed with `Build completed successfully (4316 jobs).` `lake exe axioms` completed with `axioms: audited 6200 TauCeti declaration(s); all within the allowlist [propext, Classical.choice, Quot.sound].`

<!--tauceti-target:v1 {"focus":"OneParameterSemigroups","id":"semigroup-group-spatial-pullback"}-->

🤖 Prepared with Codex
