### PR TITLE
feat: add Chebyshev cosine transfer

### DIFF
--- a/TauCeti/Analysis/SpecialFunctions/Trigonometric/Chebyshev/CosineTransfer.lean
+++ b/TauCeti/Analysis/SpecialFunctions/Trigonometric/Chebyshev/CosineTransfer.lean
@@ -1,0 +1,108 @@
+module
+
+public import TauCeti.Analysis.SpecialFunctions.Trigonometric.Chebyshev.Measure
+public import Mathlib.Analysis.SpecialFunctions.Trigonometric.Chebyshev.Basic
+
+/-!
+# Chebyshev `T` transfer to cosine integrals
+
+This file packages the cosine-side consequences of Mathlib's change of variables
+for the Chebyshev orthogonality measure.  The roadmap's Chebyshev Hilbert-basis
+target later identifies the normalized Chebyshev functions on `measureT` with
+the cosine basis under `x = cos θ`; the lemmas here expose the one-dimensional
+integral API needed for that transfer.
+-/
+
+public section
+
+namespace TauCeti
+
+open MeasureTheory Polynomial.Chebyshev
+
+/-- The cosine-side representative corresponding to the Chebyshev polynomial `Tₙ`. -/
+noncomputable def chebyshevCosine (n : ℕ) (θ : ℝ) : ℝ :=
+  Real.cos (n * θ)
+
+@[simp]
+lemma chebyshevCosine_zero (θ : ℝ) : chebyshevCosine 0 θ = 1 := by
+  simp [chebyshevCosine]
+
+lemma chebyshevCosine_one (θ : ℝ) : chebyshevCosine 1 θ = Real.cos θ := by
+  simp [chebyshevCosine]
+
+/-- Chebyshev polynomials restrict along `x = cos θ` to the cosine functions. -/
+lemma eval_T_real_cos_eq_chebyshevCosine (n : ℕ) (θ : ℝ) :
+    (T ℝ n).eval (Real.cos θ) = chebyshevCosine n θ := by
+  simp [chebyshevCosine, Polynomial.Chebyshev.T_real_cos]
+
+/-- The cosine-side representatives are continuous. -/
+lemma continuous_chebyshevCosine (n : ℕ) : Continuous (chebyshevCosine n) := by
+  have h : Continuous (fun θ : ℝ => Real.cos ((n : ℝ) * θ)) :=
+    Real.continuous_cos.comp (continuous_const.mul continuous_id)
+  unfold chebyshevCosine
+  exact h
+
+/-- Transfer a single Chebyshev `T` integral from `measureT` to the angular
+cosine-side integral. -/
+lemma integral_eval_T_real_measureT_eq_integral_chebyshevCosine (n : ℕ) :
+    ∫ x, (T ℝ n).eval x ∂Polynomial.Chebyshev.measureT =
+      ∫ θ in (0)..Real.pi, chebyshevCosine n θ := by
+  rw [integral_measureT_eq_integral_cos]
+  simp [chebyshevCosine]
+
+/-- Transfer a product of two Chebyshev `T` polynomials from `measureT` to the
+angular cosine-side integral. -/
+lemma integral_eval_T_real_mul_eval_T_real_measureT_eq_integral_chebyshevCosine_mul
+    (m n : ℕ) :
+    ∫ x, (T ℝ m).eval x * (T ℝ n).eval x ∂Polynomial.Chebyshev.measureT =
+      ∫ θ in (0)..Real.pi, chebyshevCosine m θ * chebyshevCosine n θ := by
+  rw [integral_measureT_eq_integral_cos]
+  simp [chebyshevCosine]
+
+/-- The cosine-side integral of the constant Chebyshev mode. -/
+lemma integral_chebyshevCosine_zero :
+    ∫ θ in (0)..Real.pi, chebyshevCosine 0 θ = Real.pi := by
+  rw [← integral_eval_T_real_measureT_eq_integral_chebyshevCosine]
+  exact integral_eval_T_real_measureT_zero
+
+/-- Nonzero cosine modes have zero integral over `[0, π]`. -/
+lemma integral_chebyshevCosine_of_ne_zero {n : ℕ} (hn : n ≠ 0) :
+    ∫ θ in (0)..Real.pi, chebyshevCosine n θ = 0 := by
+  rw [← integral_eval_T_real_measureT_eq_integral_chebyshevCosine]
+  exact integral_eval_T_real_measureT_of_ne_zero (by exact_mod_cast hn)
+
+/-- The diagonal cosine-side `L²` integral, using the same squared-norm
+constant as the Chebyshev `T` polynomials. -/
+lemma integral_chebyshevCosine_mul_self (n : ℕ) :
+    ∫ θ in (0)..Real.pi, chebyshevCosine n θ * chebyshevCosine n θ =
+      chebyshevTNormSq n := by
+  rw [← integral_eval_T_real_mul_eval_T_real_measureT_eq_integral_chebyshevCosine_mul]
+  exact integral_eval_T_real_mul_self_measureT n
+
+/-- Off-diagonal cosine modes are orthogonal over `[0, π]`. -/
+lemma integral_chebyshevCosine_mul_chebyshevCosine_of_ne {m n : ℕ} (hmn : m ≠ n) :
+    ∫ θ in (0)..Real.pi, chebyshevCosine m θ * chebyshevCosine n θ = 0 := by
+  rw [← integral_eval_T_real_mul_eval_T_real_measureT_eq_integral_chebyshevCosine_mul]
+  exact integral_eval_T_real_mul_eval_T_real_measureT_of_ne hmn
+
+/-- Cosine-side Chebyshev orthogonality in the Kronecker-delta form expected by
+the later Chebyshev Hilbert-basis construction. -/
+lemma integral_chebyshevCosine_mul_chebyshevCosine_eq_ite (m n : ℕ) :
+    ∫ θ in (0)..Real.pi, chebyshevCosine m θ * chebyshevCosine n θ =
+      if m = n then chebyshevTNormSq n else 0 := by
+  by_cases hmn : m = n
+  · subst hmn
+    simp [integral_chebyshevCosine_mul_self]
+  · simp [hmn, integral_chebyshevCosine_mul_chebyshevCosine_of_ne hmn]
+
+/-- The first nonconstant cosine mode has squared norm `π / 2`. -/
+lemma integral_chebyshevCosine_one_mul_self :
+    ∫ θ in (0)..Real.pi, chebyshevCosine 1 θ * chebyshevCosine 1 θ = Real.pi / 2 := by
+  simpa using integral_chebyshevCosine_mul_self 1
+
+/-- The constant and first cosine modes are orthogonal. -/
+lemma integral_chebyshevCosine_zero_mul_one :
+    ∫ θ in (0)..Real.pi, chebyshevCosine 0 θ * chebyshevCosine 1 θ = 0 := by
+  simpa using integral_chebyshevCosine_mul_chebyshevCosine_of_ne (m := 0) (n := 1) (by norm_num)
+
+end TauCeti

--- a/TauCeti/Analysis/SpecialFunctions/Trigonometric/Chebyshev/CosineTransfer.lean
+++ b/TauCeti/Analysis/SpecialFunctions/Trigonometric/Chebyshev/CosineTransfer.lean
@@ -1,7 +1,7 @@
 module
 
 public import TauCeti.Analysis.SpecialFunctions.Trigonometric.Chebyshev.Measure
-public import Mathlib.Analysis.SpecialFunctions.Trigonometric.Chebyshev.Basic
+import Mathlib.Analysis.SpecialFunctions.Trigonometric.Chebyshev.Basic
 
 /-!
 # Chebyshev `T` transfer to cosine integrals
@@ -20,13 +20,19 @@ namespace TauCeti
 open MeasureTheory Polynomial.Chebyshev
 
 /-- The cosine-side representative corresponding to the Chebyshev polynomial `Tₙ`. -/
+@[expose]
 noncomputable def chebyshevCosine (n : ℕ) (θ : ℝ) : ℝ :=
   Real.cos (n * θ)
+
+/-- The defining equation for the cosine-side Chebyshev representative. -/
+lemma chebyshevCosine_def (n : ℕ) (θ : ℝ) : chebyshevCosine n θ = Real.cos (n * θ) :=
+  rfl
 
 @[simp]
 lemma chebyshevCosine_zero (θ : ℝ) : chebyshevCosine 0 θ = 1 := by
   simp [chebyshevCosine]
 
+@[simp]
 lemma chebyshevCosine_one (θ : ℝ) : chebyshevCosine 1 θ = Real.cos θ := by
   simp [chebyshevCosine]
 
@@ -94,15 +100,5 @@ lemma integral_chebyshevCosine_mul_chebyshevCosine_eq_ite (m n : ℕ) :
   · subst hmn
     simp [integral_chebyshevCosine_mul_self]
   · simp [hmn, integral_chebyshevCosine_mul_chebyshevCosine_of_ne hmn]
-
-/-- The first nonconstant cosine mode has squared norm `π / 2`. -/
-lemma integral_chebyshevCosine_one_mul_self :
-    ∫ θ in (0)..Real.pi, chebyshevCosine 1 θ * chebyshevCosine 1 θ = Real.pi / 2 := by
-  simpa using integral_chebyshevCosine_mul_self 1
-
-/-- The constant and first cosine modes are orthogonal. -/
-lemma integral_chebyshevCosine_zero_mul_one :
-    ∫ θ in (0)..Real.pi, chebyshevCosine 0 θ * chebyshevCosine 1 θ = 0 := by
-  simpa using integral_chebyshevCosine_mul_chebyshevCosine_of_ne (m := 0) (n := 1) (by norm_num)
 
 end TauCeti

--- a/TauCeti/Analysis/SpecialFunctions/Trigonometric/Chebyshev/CosineTransfer.lean
+++ b/TauCeti/Analysis/SpecialFunctions/Trigonometric/Chebyshev/CosineTransfer.lean
@@ -20,33 +20,31 @@ namespace TauCeti
 open MeasureTheory Polynomial.Chebyshev
 
 /-- The cosine-side representative corresponding to the Chebyshev polynomial `Tₙ`. -/
-@[expose]
 noncomputable def chebyshevCosine (n : ℕ) (θ : ℝ) : ℝ :=
   Real.cos (n * θ)
 
 /-- The defining equation for the cosine-side Chebyshev representative. -/
 lemma chebyshevCosine_def (n : ℕ) (θ : ℝ) : chebyshevCosine n θ = Real.cos (n * θ) :=
-  rfl
+  chebyshevCosine.eq_1 n θ
 
 @[simp]
 lemma chebyshevCosine_zero (θ : ℝ) : chebyshevCosine 0 θ = 1 := by
-  simp [chebyshevCosine]
+  simp [chebyshevCosine_def]
 
 @[simp]
 lemma chebyshevCosine_one (θ : ℝ) : chebyshevCosine 1 θ = Real.cos θ := by
-  simp [chebyshevCosine]
+  simp [chebyshevCosine_def]
 
 /-- Chebyshev polynomials restrict along `x = cos θ` to the cosine functions. -/
 lemma eval_T_real_cos_eq_chebyshevCosine (n : ℕ) (θ : ℝ) :
     (T ℝ n).eval (Real.cos θ) = chebyshevCosine n θ := by
-  simp [chebyshevCosine, Polynomial.Chebyshev.T_real_cos]
+  simp [chebyshevCosine_def, Polynomial.Chebyshev.T_real_cos]
 
 /-- The cosine-side representatives are continuous. -/
 lemma continuous_chebyshevCosine (n : ℕ) : Continuous (chebyshevCosine n) := by
   have h : Continuous (fun θ : ℝ => Real.cos ((n : ℝ) * θ)) :=
     Real.continuous_cos.comp (continuous_const.mul continuous_id)
-  unfold chebyshevCosine
-  exact h
+  exact h.congr fun θ => (chebyshevCosine_def n θ).symm
 
 /-- Transfer a single Chebyshev `T` integral from `measureT` to the angular
 cosine-side integral. -/
@@ -54,7 +52,7 @@ lemma integral_eval_T_real_measureT_eq_integral_chebyshevCosine (n : ℕ) :
     ∫ x, (T ℝ n).eval x ∂Polynomial.Chebyshev.measureT =
       ∫ θ in (0)..Real.pi, chebyshevCosine n θ := by
   rw [integral_measureT_eq_integral_cos]
-  simp [chebyshevCosine]
+  simp [chebyshevCosine_def]
 
 /-- Transfer a product of two Chebyshev `T` polynomials from `measureT` to the
 angular cosine-side integral. -/
@@ -63,7 +61,7 @@ lemma integral_eval_T_real_mul_eval_T_real_measureT_eq_integral_chebyshevCosine_
     ∫ x, (T ℝ m).eval x * (T ℝ n).eval x ∂Polynomial.Chebyshev.measureT =
       ∫ θ in (0)..Real.pi, chebyshevCosine m θ * chebyshevCosine n θ := by
   rw [integral_measureT_eq_integral_cos]
-  simp [chebyshevCosine]
+  simp [chebyshevCosine_def]
 
 /-- The cosine-side integral of the constant Chebyshev mode. -/
 lemma integral_chebyshevCosine_zero :


### PR DESCRIPTION
This PR packages the cosine-transfer API for Mathlib's Chebyshev `T` orthogonality measure: the explicit angular representative `chebyshevCosine n θ = cos (n θ)`, the pointwise identity `Tₙ(cos θ) = chebyshevCosine n θ`, transfer lemmas for one and two Chebyshev factors, and the cosine-side diagonal/off-diagonal orthogonality constants matching `chebyshevTNormSq`.

It advances `TauCetiRoadmap/OrthogonalL2Bases/README.md`, Part C, specifically the Chebyshev acceptance target that `chebyshevHilbertBasis` correspond to the cosine basis via `integral_measureT_eq_integral_cos` plus a unitary-transfer statement. I chose this as the lowest-hanging distinct OrthogonalL2Bases prerequisite after checking open and recently merged PRs: open PR #499 covers Hermite A1, merged PR #516 covers the finite Chebyshev measure and norm constants, and Mathlib already supplies the raw `integral_measureT_eq_integral_cos`; the missing small Tau Ceti layer was the named cosine-side API downstream basis code can consume.

No Mathlib infrastructure is vendored. The implementation reuses Mathlib's `Polynomial.Chebyshev.integral_measureT_eq_integral_cos`, `Polynomial.Chebyshev.T_real_cos`, and Chebyshev orthogonality lemmas, together with Tau Ceti's existing `chebyshevTNormSq` package.

`lake exe cache get` completed with `No files to download` and `Already decompressed 8601 file(s)`. `lake build` completed with `Build completed successfully (4320 jobs).` `lake exe axioms` completed with `axioms: audited 6285 TauCeti declaration(s); all within the allowlist [propext, Classical.choice, Quot.sound].`

<!--tauceti-target:v1 {"focus":"OrthogonalL2Bases","id":"chebyshev-cosine-transfer"}-->

🤖 Prepared with Codex
