### PR TITLE
feat: add harmonic dilation invariance

### DIFF
--- a/TauCeti/Analysis/InnerProductSpace/HarmonicDilation.lean
+++ b/TauCeti/Analysis/InnerProductSpace/HarmonicDilation.lean
@@ -4,16 +4,16 @@ Released under Apache 2.0 license as described in the file LICENSE.
 -/
 module
 
-public import TauCeti.Analysis.InnerProductSpace.HarmonicIsometry
+public import Mathlib.Analysis.InnerProductSpace.Harmonic.Basic
+public import TauCeti.Analysis.InnerProductSpace.Laplacian
 
 /-!
 # Dilation invariance of the Laplacian and harmonic functions
 
-`TauCeti.Analysis.InnerProductSpace.Laplacian` and
-`TauCeti.Analysis.InnerProductSpace.HarmonicIsometry` record invariance under rigid motions.
-This file adds the companion scale-change bookkeeping: under the right-composition
-`x ↦ c • x`, the Laplacian scales by `c ^ 2`, and harmonicity is preserved and reflected when
-`c ≠ 0`.
+`TauCeti.Analysis.InnerProductSpace.Laplacian` records invariance under rigid motions and the
+Laplacian scaling law under affine homotheties. This file transports the homothety bookkeeping to
+harmonicity: under the right-composition `AffineMap.homothety a c`, harmonicity is preserved and
+reflected when `c ≠ 0`.
 
 These lemmas are a small Lane C prerequisite from the PDE roadmap. They let later mean-value,
 maximum-principle, and Poisson-kernel arguments normalize balls by translating and rescaling
@@ -21,8 +21,9 @@ without reproving the Laplacian calculation each time.
 
 ## Main declarations
 
-* `TauCeti.laplacian_comp_smul_right`: `Δ (fun x ↦ f (c • x)) =
-  fun x ↦ c ^ 2 • Δ f (c • x)`.
+* `TauCeti.harmonicAt_comp_homothety_right_iff`: harmonicity is invariant under nonzero
+  homothety about an arbitrary center.
+* `TauCeti.harmonicOnNhd_comp_homothety_right_iff`: set-level nonzero homothety invariance.
 * `TauCeti.harmonicAt_comp_smul_right_iff`: harmonicity is invariant under nonzero dilation.
 * `TauCeti.harmonicOnNhd_comp_smul_right_iff`: set-level nonzero dilation invariance.
 -/
@@ -39,15 +40,26 @@ variable
   {E : Type*} [NormedAddCommGroup E] [InnerProductSpace ℝ E] [FiniteDimensional ℝ E]
   {F : Type*} [NormedAddCommGroup F] [NormedSpace ℝ F]
 
-omit [InnerProductSpace ℝ E] [FiniteDimensional ℝ E] [NormedSpace ℝ F] in
-/-- Scalar dilation as a continuous linear equivalence. -/
-private abbrev smulLeftContinuousLinearEquiv (c : ℝ) (hc : c ≠ 0) : E ≃L[ℝ] E :=
-  ContinuousLinearEquiv.smulLeft (Units.mk0 c hc)
+/-- Homotheties of a finite-dimensional normed affine space are homeomorphisms when the scale is
+nonzero. -/
+private abbrev homothetyHomeomorph (a : E) (c : ℝ) (hc : c ≠ 0) : E ≃ₜ E :=
+  (AffineEquiv.toContinuousAffineEquiv
+    (AffineEquiv.homothetyUnitsMulHom a (Units.mk0 c hc))).toHomeomorph
+
+private lemma homothetyHomeomorph_apply (a : E) (c : ℝ) (hc : c ≠ 0) (x : E) :
+    homothetyHomeomorph a c hc x = AffineMap.homothety a c x := by
+  change (AffineEquiv.toContinuousAffineEquiv
+    (AffineEquiv.homothetyUnitsMulHom a (Units.mk0 c hc)) : E ≃ᴬ[ℝ] E) x =
+      AffineMap.homothety a c x
+  rw [AffineEquiv.coe_toContinuousAffineEquiv]
+  exact congrFun (AffineEquiv.coe_homothetyUnitsMulHom_apply a (Units.mk0 c hc)) x
 
 omit [FiniteDimensional ℝ E] in
-private lemma smulLeftContinuousLinearEquiv_apply (c : ℝ) (hc : c ≠ 0) (x : E) :
-    smulLeftContinuousLinearEquiv (E := E) c hc x = c • x := by
-  simp [smulLeftContinuousLinearEquiv]
+private lemma contDiffAt_homothety (a : E) (c : ℝ) (x : E) :
+    ContDiffAt ℝ 2 (fun y : E ↦ AffineMap.homothety a c y) x := by
+  have h : ContDiffAt ℝ 2 (fun y : E ↦ c • (y - a) + a) x := by
+    fun_prop
+  simpa [AffineMap.homothety_apply, vsub_eq_sub, vadd_eq_add] using h
 
 omit [InnerProductSpace ℝ E] [FiniteDimensional ℝ E] [NormedSpace ℝ F] in
 /-- Precomposition by a homeomorphism transports vanishing in a neighbourhood. -/
@@ -64,46 +76,90 @@ private theorem eventuallyEq_zero_comp_homeomorph_iff (h : E ≃ₜ E) (g : E �
     filter_upwards [hyp'] with y hy
     simpa using hy
 
-/-- **Scaling law for the Laplacian under dilation.**
+/-- **Harmonicity is invariant under nonzero homothety.**
 
-Right-composition by `x ↦ c • x` multiplies the Laplacian by `c ^ 2`. The statement is
-unconditional in `f`, matching Mathlib's unconditional definition of `Δ` through iterated
-Fréchet derivatives. -/
-theorem laplacian_comp_smul_right (c : ℝ) (f : E → F) :
-    Δ (fun x ↦ f (c • x)) = fun x ↦ c ^ 2 • (Δ f) (c • x) := by
-  by_cases hc : c = 0
-  · subst c
-    ext x
-    simp
-  · let l : E ≃L[ℝ] E := smulLeftContinuousLinearEquiv c hc
-    have hfun : (fun x : E ↦ f (c • x)) = f ∘ l := by
-      funext x
-      simp [l, smulLeftContinuousLinearEquiv]
-    rw [hfun]
-    ext x
-    simp only [laplacian_eq_iteratedFDeriv_orthonormalBasis (f ∘ l)
-      (stdOrthonormalBasis ℝ E), laplacian_eq_iteratedFDeriv_orthonormalBasis f
-      (stdOrthonormalBasis ℝ E), Finset.smul_sum]
-    refine Finset.sum_congr rfl fun i _ ↦ ?_
-    have hder :
-        (iteratedFDeriv ℝ 2 (f ∘ l) x)
-            ![(stdOrthonormalBasis ℝ E) i, (stdOrthonormalBasis ℝ E) i] =
-          ((iteratedFDeriv ℝ 2 f (l x)).compContinuousLinearMap fun _ => (l : E →L[ℝ] E))
-            ![(stdOrthonormalBasis ℝ E) i, (stdOrthonormalBasis ℝ E) i] := by
-      have h := l.iteratedFDerivWithin_comp_right f uniqueDiffOn_univ (Set.mem_univ (l x)) 2
-      simpa [← iteratedFDerivWithin_univ, Set.preimage_univ] using
-        congrArg
-          (fun L : ContinuousMultilinearMap ℝ (fun _ : Fin 2 => E) F =>
-            L ![(stdOrthonormalBasis ℝ E) i, (stdOrthonormalBasis ℝ E) i]) h
-    rw [hder]
-    rw [ContinuousMultilinearMap.compContinuousLinearMap_apply]
-    have hx : l x = c • x := by
-      simp [l, smulLeftContinuousLinearEquiv]
-    rw [hx]
-    let M := iteratedFDeriv ℝ 2 f (c • x)
-    let v : Fin 2 → E := ![(stdOrthonormalBasis ℝ E) i, (stdOrthonormalBasis ℝ E) i]
-    change M (fun j => c • v j) = c ^ 2 • M v
-    simpa [M, v, pow_two] using M.map_smul_univ (fun _ : Fin 2 => c) v
+For `c ≠ 0`, the function `y ↦ f (AffineMap.homothety a c y)` is harmonic at `x` iff `f`
+is harmonic at `AffineMap.homothety a c x`. -/
+theorem harmonicAt_comp_homothety_right_iff (a : E) (c : ℝ) (hc : c ≠ 0) {f : E → F}
+    {x : E} :
+    HarmonicAt (fun y ↦ f (AffineMap.homothety a c y)) x ↔
+      HarmonicAt f (AffineMap.homothety a c x) := by
+  let e : E ≃ₜ E := homothetyHomeomorph a c hc
+  have he : ∀ y : E, e y = AffineMap.homothety a c y := fun y ↦
+    homothetyHomeomorph_apply a c hc y
+  have hcd : ContDiffAt ℝ 2 (fun y : E ↦ f (AffineMap.homothety a c y)) x ↔
+      ContDiffAt ℝ 2 f (AffineMap.homothety a c x) := by
+    constructor
+    · intro h
+      have hφ : ContDiffAt ℝ 2 (fun y : E ↦ AffineMap.homothety a c⁻¹ y)
+          (AffineMap.homothety a c x) :=
+        contDiffAt_homothety a c⁻¹ (AffineMap.homothety a c x)
+      have hx : AffineMap.homothety a c⁻¹ (AffineMap.homothety a c x) = x := by
+        rw [← AffineMap.homothety_mul_apply]
+        simp [hc]
+      have h' : ContDiffAt ℝ 2 (fun y : E ↦ f (AffineMap.homothety a c y))
+          ((fun y : E ↦ AffineMap.homothety a c⁻¹ y)
+            (AffineMap.homothety a c x)) := by
+        simpa [hx] using h
+      have hc' := h'.comp (AffineMap.homothety a c x) hφ
+      have hgf :
+          (fun y : E ↦ f (AffineMap.homothety a c y)) ∘
+              (fun y : E ↦ AffineMap.homothety a c⁻¹ y) = f := by
+        funext y
+        simp only [Function.comp_apply]
+        rw [← AffineMap.homothety_mul_apply]
+        simp [hc]
+      rwa [hgf] at hc'
+    · intro h
+      exact h.comp x (contDiffAt_homothety a c x)
+  have hlap : (Δ (fun y : E ↦ f (AffineMap.homothety a c y)) =ᶠ[𝓝 x] 0) ↔
+      (Δ f =ᶠ[𝓝 (AffineMap.homothety a c x)] 0) := by
+    rw [laplacian_comp_homothety_right a c f]
+    have hscale :
+        (fun y : E ↦ c ^ 2 • (Δ f) (AffineMap.homothety a c y)) =
+          (fun z ↦ c ^ 2 • z) ∘ (Δ f ∘ e) := by
+      funext y
+      simp [he y, Function.comp_apply]
+    rw [hscale]
+    have hzero : Function.Injective (fun z : F ↦ c ^ 2 • z) := by
+      exact smul_right_injective F (pow_ne_zero 2 hc)
+    constructor
+    · intro h
+      have h' : Δ f ∘ e =ᶠ[𝓝 x] 0 := by
+        filter_upwards [h] with y hy
+        exact hzero (by simpa [Function.comp_apply] using hy)
+      have hmain := (eventuallyEq_zero_comp_homeomorph_iff e (Δ f) x).1 h'
+      simpa [he x] using hmain
+    · intro h
+      have h' : Δ f ∘ e =ᶠ[𝓝 x] 0 :=
+        (eventuallyEq_zero_comp_homeomorph_iff e (Δ f) x).2 (by simpa [he x] using h)
+      filter_upwards [h'] with y hy
+      change c ^ 2 • ((Δ f ∘ e) y) = 0
+      rw [hy]
+      simp
+  exact ⟨fun hf ↦ ⟨hcd.1 hf.1, hlap.1 hf.2⟩,
+    fun hf ↦ ⟨hcd.2 hf.1, hlap.2 hf.2⟩⟩
+
+/-- Harmonicity on a neighbourhood of a set is invariant under nonzero homothety. -/
+theorem harmonicOnNhd_comp_homothety_right_iff (a : E) (c : ℝ) (hc : c ≠ 0) {f : E → F}
+    {s : Set E} :
+    HarmonicOnNhd (fun y ↦ f (AffineMap.homothety a c y))
+        ((fun y ↦ AffineMap.homothety a c y) ⁻¹' s) ↔
+      HarmonicOnNhd f s := by
+  let e : E ≃ₜ E := homothetyHomeomorph a c hc
+  have he : ∀ y : E, e y = AffineMap.homothety a c y := fun y ↦
+    homothetyHomeomorph_apply a c hc y
+  constructor
+  · intro hf y hy
+    have hye : AffineMap.homothety a c (e.symm y) = y := by
+      rw [← he (e.symm y)]
+      exact e.apply_symm_apply y
+    have hpre : AffineMap.homothety a c (e.symm y) ∈ s := by rwa [hye]
+    have h := hf (e.symm y) hpre
+    simpa [hye] using (harmonicAt_comp_homothety_right_iff a c hc).1 h
+  · intro hf x hx
+    exact (harmonicAt_comp_homothety_right_iff a c hc).2
+      (hf (AffineMap.homothety a c x) hx)
 
 /-- **Harmonicity is invariant under nonzero dilation.**
 
@@ -111,62 +167,29 @@ For `c ≠ 0`, the function `x ↦ f (c • x)` is harmonic at `x` iff `f` is ha
 `c • x`. -/
 theorem harmonicAt_comp_smul_right_iff (c : ℝ) (hc : c ≠ 0) {f : E → F} {x : E} :
     HarmonicAt (fun y ↦ f (c • y)) x ↔ HarmonicAt f (c • x) := by
-  let l : E ≃L[ℝ] E := smulLeftContinuousLinearEquiv c hc
-  have hfun : (fun y : E ↦ f (c • y)) = f ∘ l := by
+  have hfun : (fun y : E ↦ f (c • y)) =
+      fun y ↦ f (AffineMap.homothety (0 : E) c y) := by
     funext y
-    simp [l, smulLeftContinuousLinearEquiv]
-  have hcd : ContDiffAt ℝ 2 (fun y : E ↦ f (c • y)) x ↔
-      ContDiffAt ℝ 2 f (c • x) := by
-    rw [hfun]
-    have h := l.contDiffAt_comp_iff (f := f) (n := 2) (x := l x)
-    have hx₁ : l.symm (l x) = x := by simp
-    have hx₂ : l x = c • x := by
-      simp [l, smulLeftContinuousLinearEquiv]
-    rwa [hx₁, hx₂] at h
-  have hlap : (Δ (fun y : E ↦ f (c • y)) =ᶠ[𝓝 x] 0) ↔
-      (Δ f =ᶠ[𝓝 (c • x)] 0) := by
-    rw [laplacian_comp_smul_right c f]
-    have hscale : (fun y : E ↦ c ^ 2 • (Δ f) (c • y)) = (fun z ↦ c ^ 2 • z) ∘ (Δ f ∘ l) := by
-      funext y
-      simp [l, smulLeftContinuousLinearEquiv, Function.comp_apply]
-    rw [hscale]
-    have hzero : Function.Injective (fun z : F ↦ c ^ 2 • z) := by
-      exact smul_right_injective F (pow_ne_zero 2 hc)
-    constructor
-    · intro h
-      have h' : Δ f ∘ l =ᶠ[𝓝 x] 0 := by
-        filter_upwards [h] with y hy
-        exact hzero (by simpa using hy)
-      have := eventuallyEq_zero_comp_homeomorph_iff l.toHomeomorph (Δ f) x
-      have hmain := this.1 h'
-      simpa [l, smulLeftContinuousLinearEquiv] using hmain
-    · intro h
-      have := eventuallyEq_zero_comp_homeomorph_iff l.toHomeomorph (Δ f) x
-      have h' : Δ f ∘ l =ᶠ[𝓝 x] 0 := this.2 (by simpa [l, smulLeftContinuousLinearEquiv] using h)
-      filter_upwards [h'] with y hy
-      change c ^ 2 • (Δ f (l y)) = 0
-      have hy0 : Δ f (l y) = 0 := by simpa [Function.comp_apply] using hy
-      rw [hy0]
-      simp
-  exact ⟨fun hf ↦ ⟨hcd.1 hf.1, hlap.1 hf.2⟩,
-    fun hf ↦ ⟨hcd.2 hf.1, hlap.2 hf.2⟩⟩
+    simp [AffineMap.homothety_apply]
+  have hx : AffineMap.homothety (0 : E) c x = c • x := by
+    simp [AffineMap.homothety_apply]
+  rw [hfun, harmonicAt_comp_homothety_right_iff (0 : E) c hc, hx]
 
 /-- Harmonicity on a neighbourhood of a set is invariant under nonzero dilation. -/
 theorem harmonicOnNhd_comp_smul_right_iff (c : ℝ) (hc : c ≠ 0) {f : E → F}
     {s : Set E} :
     HarmonicOnNhd (fun y ↦ f (c • y)) ((fun y ↦ c • y) ⁻¹' s) ↔
       HarmonicOnNhd f s := by
-  let l : E ≃L[ℝ] E := smulLeftContinuousLinearEquiv c hc
-  constructor
-  · intro hf y hy
-    have hy' : c • (l.symm y) = y := by
-      change l (l.symm y) = y
-      exact l.apply_symm_apply y
-    have hpre : c • (l.symm y) ∈ s := by rwa [hy']
-    have h := hf (l.symm y) hpre
-    simpa [hy'] using (harmonicAt_comp_smul_right_iff c hc).1 h
-  · intro hf x hx
-    exact (harmonicAt_comp_smul_right_iff c hc).2 (hf (c • x) hx)
+  have hfun : (fun y : E ↦ f (c • y)) =
+      fun y ↦ f (AffineMap.homothety (0 : E) c y) := by
+    funext y
+    simp [AffineMap.homothety_apply]
+  have hset : ((fun y : E ↦ c • y) ⁻¹' s) =
+      ((fun y : E ↦ AffineMap.homothety (0 : E) c y) ⁻¹' s) := by
+    ext y
+    simp [AffineMap.homothety_apply]
+  rw [hfun, hset]
+  exact harmonicOnNhd_comp_homothety_right_iff (0 : E) c hc
 
 end TauCeti
 

--- a/TauCeti/Analysis/InnerProductSpace/HarmonicDilation.lean
+++ b/TauCeti/Analysis/InnerProductSpace/HarmonicDilation.lean
@@ -48,6 +48,7 @@ private abbrev homothetyHomeomorph (a : E) (c : ℝ) (hc : c ≠ 0) : E ≃ₜ E
 
 private lemma homothetyHomeomorph_apply (a : E) (c : ℝ) (hc : c ≠ 0) (x : E) :
     homothetyHomeomorph a c hc x = AffineMap.homothety a c x := by
+  -- Expose the `toHomeomorph` coercion back to the continuous affine equivalence it wraps.
   change (AffineEquiv.toContinuousAffineEquiv
     (AffineEquiv.homothetyUnitsMulHom a (Units.mk0 c hc)) : E ≃ᴬ[ℝ] E) x =
       AffineMap.homothety a c x
@@ -134,6 +135,7 @@ theorem harmonicAt_comp_homothety_right_iff (a : E) (c : ℝ) (hc : c ≠ 0) {f 
       have h' : Δ f ∘ e =ᶠ[𝓝 x] 0 :=
         (eventuallyEq_zero_comp_homeomorph_iff e (Δ f) x).2 (by simpa [he x] using h)
       filter_upwards [h'] with y hy
+      -- Unfold the scaled composition produced by `hscale` at this point.
       change c ^ 2 • ((Δ f ∘ e) y) = 0
       rw [hy]
       simp

--- a/TauCeti/Analysis/InnerProductSpace/HarmonicDilation.lean
+++ b/TauCeti/Analysis/InnerProductSpace/HarmonicDilation.lean
@@ -1,0 +1,173 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+module
+
+public import TauCeti.Analysis.InnerProductSpace.HarmonicIsometry
+
+/-!
+# Dilation invariance of the Laplacian and harmonic functions
+
+`TauCeti.Analysis.InnerProductSpace.Laplacian` and
+`TauCeti.Analysis.InnerProductSpace.HarmonicIsometry` record invariance under rigid motions.
+This file adds the companion scale-change bookkeeping: under the right-composition
+`x ↦ c • x`, the Laplacian scales by `c ^ 2`, and harmonicity is preserved and reflected when
+`c ≠ 0`.
+
+These lemmas are a small Lane C prerequisite from the PDE roadmap. They let later mean-value,
+maximum-principle, and Poisson-kernel arguments normalize balls by translating and rescaling
+without reproving the Laplacian calculation each time.
+
+## Main declarations
+
+* `TauCeti.laplacian_comp_smul_right`: `Δ (fun x ↦ f (c • x)) =
+  fun x ↦ c ^ 2 • Δ f (c • x)`.
+* `TauCeti.harmonicAt_comp_smul_right_iff`: harmonicity is invariant under nonzero dilation.
+* `TauCeti.harmonicOnNhd_comp_smul_right_iff`: set-level nonzero dilation invariance.
+-/
+
+public section
+
+noncomputable section
+
+namespace TauCeti
+
+open InnerProductSpace Laplacian Topology
+
+variable
+  {E : Type*} [NormedAddCommGroup E] [InnerProductSpace ℝ E] [FiniteDimensional ℝ E]
+  {F : Type*} [NormedAddCommGroup F] [NormedSpace ℝ F]
+
+omit [InnerProductSpace ℝ E] [FiniteDimensional ℝ E] [NormedSpace ℝ F] in
+/-- Scalar dilation as a continuous linear equivalence. -/
+private abbrev smulLeftContinuousLinearEquiv (c : ℝ) (hc : c ≠ 0) : E ≃L[ℝ] E :=
+  ContinuousLinearEquiv.smulLeft (Units.mk0 c hc)
+
+omit [FiniteDimensional ℝ E] in
+private lemma smulLeftContinuousLinearEquiv_apply (c : ℝ) (hc : c ≠ 0) (x : E) :
+    smulLeftContinuousLinearEquiv (E := E) c hc x = c • x := by
+  simp [smulLeftContinuousLinearEquiv]
+
+omit [InnerProductSpace ℝ E] [FiniteDimensional ℝ E] [NormedSpace ℝ F] in
+/-- Precomposition by a homeomorphism transports vanishing in a neighbourhood. -/
+private theorem eventuallyEq_zero_comp_homeomorph_iff (h : E ≃ₜ E) (g : E → F) (x : E) :
+    (g ∘ h =ᶠ[𝓝 x] 0) ↔ (g =ᶠ[𝓝 (h x)] 0) := by
+  rw [← h.map_nhds_eq x]
+  constructor
+  · intro hyp
+    refine Filter.eventually_map.mpr ?_
+    filter_upwards [hyp] with y hy
+    simpa using hy
+  · intro hyp
+    have hyp' := Filter.eventually_map.mp hyp
+    filter_upwards [hyp'] with y hy
+    simpa using hy
+
+/-- **Scaling law for the Laplacian under dilation.**
+
+Right-composition by `x ↦ c • x` multiplies the Laplacian by `c ^ 2`. The statement is
+unconditional in `f`, matching Mathlib's unconditional definition of `Δ` through iterated
+Fréchet derivatives. -/
+theorem laplacian_comp_smul_right (c : ℝ) (f : E → F) :
+    Δ (fun x ↦ f (c • x)) = fun x ↦ c ^ 2 • (Δ f) (c • x) := by
+  by_cases hc : c = 0
+  · subst c
+    ext x
+    simp
+  · let l : E ≃L[ℝ] E := smulLeftContinuousLinearEquiv c hc
+    have hfun : (fun x : E ↦ f (c • x)) = f ∘ l := by
+      funext x
+      simp [l, smulLeftContinuousLinearEquiv]
+    rw [hfun]
+    ext x
+    simp only [laplacian_eq_iteratedFDeriv_orthonormalBasis (f ∘ l)
+      (stdOrthonormalBasis ℝ E), laplacian_eq_iteratedFDeriv_orthonormalBasis f
+      (stdOrthonormalBasis ℝ E), Finset.smul_sum]
+    refine Finset.sum_congr rfl fun i _ ↦ ?_
+    have hder :
+        (iteratedFDeriv ℝ 2 (f ∘ l) x)
+            ![(stdOrthonormalBasis ℝ E) i, (stdOrthonormalBasis ℝ E) i] =
+          ((iteratedFDeriv ℝ 2 f (l x)).compContinuousLinearMap fun _ => (l : E →L[ℝ] E))
+            ![(stdOrthonormalBasis ℝ E) i, (stdOrthonormalBasis ℝ E) i] := by
+      have h := l.iteratedFDerivWithin_comp_right f uniqueDiffOn_univ (Set.mem_univ (l x)) 2
+      simpa [← iteratedFDerivWithin_univ, Set.preimage_univ] using
+        congrArg
+          (fun L : ContinuousMultilinearMap ℝ (fun _ : Fin 2 => E) F =>
+            L ![(stdOrthonormalBasis ℝ E) i, (stdOrthonormalBasis ℝ E) i]) h
+    rw [hder]
+    rw [ContinuousMultilinearMap.compContinuousLinearMap_apply]
+    have hx : l x = c • x := by
+      simp [l, smulLeftContinuousLinearEquiv]
+    rw [hx]
+    let M := iteratedFDeriv ℝ 2 f (c • x)
+    let v : Fin 2 → E := ![(stdOrthonormalBasis ℝ E) i, (stdOrthonormalBasis ℝ E) i]
+    change M (fun j => c • v j) = c ^ 2 • M v
+    simpa [M, v, pow_two] using M.map_smul_univ (fun _ : Fin 2 => c) v
+
+/-- **Harmonicity is invariant under nonzero dilation.**
+
+For `c ≠ 0`, the function `x ↦ f (c • x)` is harmonic at `x` iff `f` is harmonic at
+`c • x`. -/
+theorem harmonicAt_comp_smul_right_iff (c : ℝ) (hc : c ≠ 0) {f : E → F} {x : E} :
+    HarmonicAt (fun y ↦ f (c • y)) x ↔ HarmonicAt f (c • x) := by
+  let l : E ≃L[ℝ] E := smulLeftContinuousLinearEquiv c hc
+  have hfun : (fun y : E ↦ f (c • y)) = f ∘ l := by
+    funext y
+    simp [l, smulLeftContinuousLinearEquiv]
+  have hcd : ContDiffAt ℝ 2 (fun y : E ↦ f (c • y)) x ↔
+      ContDiffAt ℝ 2 f (c • x) := by
+    rw [hfun]
+    have h := l.contDiffAt_comp_iff (f := f) (n := 2) (x := l x)
+    have hx₁ : l.symm (l x) = x := by simp
+    have hx₂ : l x = c • x := by
+      simp [l, smulLeftContinuousLinearEquiv]
+    rwa [hx₁, hx₂] at h
+  have hlap : (Δ (fun y : E ↦ f (c • y)) =ᶠ[𝓝 x] 0) ↔
+      (Δ f =ᶠ[𝓝 (c • x)] 0) := by
+    rw [laplacian_comp_smul_right c f]
+    have hscale : (fun y : E ↦ c ^ 2 • (Δ f) (c • y)) = (fun z ↦ c ^ 2 • z) ∘ (Δ f ∘ l) := by
+      funext y
+      simp [l, smulLeftContinuousLinearEquiv, Function.comp_apply]
+    rw [hscale]
+    have hzero : Function.Injective (fun z : F ↦ c ^ 2 • z) := by
+      exact smul_right_injective F (pow_ne_zero 2 hc)
+    constructor
+    · intro h
+      have h' : Δ f ∘ l =ᶠ[𝓝 x] 0 := by
+        filter_upwards [h] with y hy
+        exact hzero (by simpa using hy)
+      have := eventuallyEq_zero_comp_homeomorph_iff l.toHomeomorph (Δ f) x
+      have hmain := this.1 h'
+      simpa [l, smulLeftContinuousLinearEquiv] using hmain
+    · intro h
+      have := eventuallyEq_zero_comp_homeomorph_iff l.toHomeomorph (Δ f) x
+      have h' : Δ f ∘ l =ᶠ[𝓝 x] 0 := this.2 (by simpa [l, smulLeftContinuousLinearEquiv] using h)
+      filter_upwards [h'] with y hy
+      change c ^ 2 • (Δ f (l y)) = 0
+      have hy0 : Δ f (l y) = 0 := by simpa [Function.comp_apply] using hy
+      rw [hy0]
+      simp
+  exact ⟨fun hf ↦ ⟨hcd.1 hf.1, hlap.1 hf.2⟩,
+    fun hf ↦ ⟨hcd.2 hf.1, hlap.2 hf.2⟩⟩
+
+/-- Harmonicity on a neighbourhood of a set is invariant under nonzero dilation. -/
+theorem harmonicOnNhd_comp_smul_right_iff (c : ℝ) (hc : c ≠ 0) {f : E → F}
+    {s : Set E} :
+    HarmonicOnNhd (fun y ↦ f (c • y)) ((fun y ↦ c • y) ⁻¹' s) ↔
+      HarmonicOnNhd f s := by
+  let l : E ≃L[ℝ] E := smulLeftContinuousLinearEquiv c hc
+  constructor
+  · intro hf y hy
+    have hy' : c • (l.symm y) = y := by
+      change l (l.symm y) = y
+      exact l.apply_symm_apply y
+    have hpre : c • (l.symm y) ∈ s := by rwa [hy']
+    have h := hf (l.symm y) hpre
+    simpa [hy'] using (harmonicAt_comp_smul_right_iff c hc).1 h
+  · intro hf x hx
+    exact (harmonicAt_comp_smul_right_iff c hc).2 (hf (c • x) hx)
+
+end TauCeti
+
+end

--- a/TauCeti/Analysis/InnerProductSpace/Laplacian.lean
+++ b/TauCeti/Analysis/InnerProductSpace/Laplacian.lean
@@ -14,9 +14,9 @@ Mathlib's `Mathlib/Analysis/InnerProductSpace/Laplacian.lean` records that the L
 commutes with *left* composition by a continuous linear map or equivalence acting on the
 *values* of a function (`ContDiffAt.laplacian_CLM_comp_left`, `laplacian_CLE_comp_left`).
 This file supplies the complementary *right* composition, acting on the *domain* variable: the
-geometric invariance of `Δ` under the rigid motions of a Euclidean space — affine isometry
-equivalences, with orthogonal changes of variable (linear isometry equivalences) and translations
-as special cases.
+geometric invariance of `Δ` under rigid motions and scalar homotheties of a Euclidean space:
+affine isometry equivalences, with orthogonal changes of variable (linear isometry equivalences)
+and translations as special cases, and affine homotheties with the expected quadratic scaling.
 
 For an affine isometry equivalence `e : E ≃ᵃⁱ[ℝ] E'` and any `f : E' → F`,
 
@@ -43,6 +43,9 @@ corollaries, where smoothness re-enters, live in
 * `TauCeti.laplacian_comp_linearIsometryEquiv_right`: `Δ (f ∘ l) = (Δ f) ∘ l` for an
   isometry `l`.
 * `TauCeti.laplacian_comp_add_right`: translation invariance of `Δ`.
+* `TauCeti.laplacian_comp_homothety_right`: `Δ` scales by `c ^ 2` under
+  `AffineMap.homothety a c`.
+* `TauCeti.laplacian_comp_smul_right`: the origin-centered homothety special case.
 -/
 
 public section
@@ -55,6 +58,11 @@ variable
   {E : Type*} [NormedAddCommGroup E] [InnerProductSpace ℝ E] [FiniteDimensional ℝ E]
   {E' : Type*} [NormedAddCommGroup E'] [InnerProductSpace ℝ E'] [FiniteDimensional ℝ E']
   {F : Type*} [NormedAddCommGroup F] [NormedSpace ℝ F]
+
+omit [InnerProductSpace ℝ E] [FiniteDimensional ℝ E] [NormedSpace ℝ F] in
+/-- Scalar dilation as a continuous linear equivalence. -/
+private noncomputable abbrev smulLeftContinuousLinearEquiv (c : ℝ) (hc : c ≠ 0) : E ≃L[ℝ] E :=
+  ContinuousLinearEquiv.smulLeft (Units.mk0 c hc)
 
 omit [FiniteDimensional ℝ E] [FiniteDimensional ℝ E'] in
 /-- The iterated derivative transforms under a linear isometry equivalence on the right by
@@ -112,5 +120,64 @@ theorem laplacian_comp_affineIsometryEquiv_right (e : E ≃ᵃⁱ[ℝ] E') (f : 
   have hx : e x = e.linearIsometryEquiv x + e 0 := by
     simpa using e.map_vadd (0 : E) x
   simp [Function.comp_apply, hx]
+
+/-- **Scaling law for the Laplacian under origin-centered dilation.**
+
+Right-composition by `x ↦ c • x` multiplies the Laplacian by `c ^ 2`. The statement is
+unconditional in `f`, matching Mathlib's unconditional definition of `Δ` through iterated
+Fréchet derivatives. -/
+theorem laplacian_comp_smul_right (c : ℝ) (f : E → F) :
+    Δ (fun x ↦ f (c • x)) = fun x ↦ c ^ 2 • (Δ f) (c • x) := by
+  by_cases hc : c = 0
+  · subst c
+    ext x
+    simp
+  · let l : E ≃L[ℝ] E := smulLeftContinuousLinearEquiv c hc
+    have hfun : (fun x : E ↦ f (c • x)) = f ∘ l := by
+      funext x
+      simp [l, smulLeftContinuousLinearEquiv]
+    rw [hfun]
+    ext x
+    simp only [laplacian_eq_iteratedFDeriv_orthonormalBasis (f ∘ l)
+      (stdOrthonormalBasis ℝ E), laplacian_eq_iteratedFDeriv_orthonormalBasis f
+      (stdOrthonormalBasis ℝ E), Finset.smul_sum]
+    refine Finset.sum_congr rfl fun i _ ↦ ?_
+    have hder :
+        (iteratedFDeriv ℝ 2 (f ∘ l) x)
+            ![(stdOrthonormalBasis ℝ E) i, (stdOrthonormalBasis ℝ E) i] =
+          ((iteratedFDeriv ℝ 2 f (l x)).compContinuousLinearMap fun _ => (l : E →L[ℝ] E))
+            ![(stdOrthonormalBasis ℝ E) i, (stdOrthonormalBasis ℝ E) i] := by
+      have h := l.iteratedFDerivWithin_comp_right f uniqueDiffOn_univ (Set.mem_univ (l x)) 2
+      simpa [← iteratedFDerivWithin_univ, Set.preimage_univ] using
+        congrArg
+          (fun L : ContinuousMultilinearMap ℝ (fun _ : Fin 2 => E) F =>
+            L ![(stdOrthonormalBasis ℝ E) i, (stdOrthonormalBasis ℝ E) i]) h
+    rw [hder]
+    rw [ContinuousMultilinearMap.compContinuousLinearMap_apply]
+    have hx : l x = c • x := by
+      simp [l, smulLeftContinuousLinearEquiv]
+    rw [hx]
+    let M := iteratedFDeriv ℝ 2 f (c • x)
+    let v : Fin 2 → E := ![(stdOrthonormalBasis ℝ E) i, (stdOrthonormalBasis ℝ E) i]
+    -- `compContinuousLinearMap_apply` exposes the two derivative directions as `fun j ↦ c • v j`;
+    -- `map_smul_univ` then pulls the two scalar factors out of the bilinear map.
+    change M (fun j => c • v j) = c ^ 2 • M v
+    simpa [M, v, pow_two] using M.map_smul_univ (fun _ : Fin 2 => c) v
+
+/-- **Scaling law for the Laplacian under a homothety.**
+
+Right-composition by `AffineMap.homothety a c` multiplies the Laplacian by `c ^ 2`. -/
+theorem laplacian_comp_homothety_right (a : E) (c : ℝ) (f : E → F) :
+    Δ (fun x ↦ f (AffineMap.homothety a c x)) =
+      fun x ↦ c ^ 2 • (Δ f) (AffineMap.homothety a c x) := by
+  have hfun : (fun x : E ↦ f (AffineMap.homothety a c x)) =
+      fun x ↦ (fun z ↦ f (c • z + a)) (x + -a) := by
+    funext x
+    simp [AffineMap.homothety_apply, vsub_eq_sub, vadd_eq_add, sub_eq_add_neg, add_comm]
+  rw [hfun, laplacian_comp_add_right (fun z ↦ f (c • z + a)) (-a)]
+  rw [laplacian_comp_smul_right c (fun z ↦ f (z + a))]
+  rw [laplacian_comp_add_right f a]
+  ext x
+  simp [AffineMap.homothety_apply, vsub_eq_sub, vadd_eq_add, sub_eq_add_neg, add_comm]
 
 end TauCeti

--- a/TauCeti/Analysis/InnerProductSpace/Laplacian.lean
+++ b/TauCeti/Analysis/InnerProductSpace/Laplacian.lean
@@ -33,8 +33,9 @@ and for a translation by `a : E`,
 All three identities hold with *no* differentiability hypothesis on `f`, because the underlying
 `iteratedFDeriv` composition laws are unconditional (the iterated derivative is junk-valued off
 the smooth locus, yet still transforms correctly under a linear change of variable). The harmonic
-corollaries, where smoothness re-enters, live in
-`TauCeti/Analysis/InnerProductSpace/HarmonicIsometry.lean`.
+corollaries, where smoothness re-enters, live in the companion files
+`TauCeti/Analysis/InnerProductSpace/HarmonicIsometry.lean` and
+`TauCeti/Analysis/InnerProductSpace/HarmonicDilation.lean`.
 
 ## Main declarations
 


### PR DESCRIPTION
This PR adds scalar-dilation bookkeeping for the Laplacian and harmonic functions: `Δ (fun x ↦ f (c • x)) = fun x ↦ c ^ 2 • Δ f (c • x)`, plus pointwise and set-level nonzero-dilation invariance for `HarmonicAt` and `HarmonicOnNhd`.

It advances `TauCetiRoadmap/PDE/README.md`, Lane C, specifically item 12, “Mean-value property and smoothness of harmonic functions on `ℝⁿ`,” as a small normalization prerequisite for later mean-value, maximum-principle, and Poisson-kernel arguments on balls. I chose this as the lowest-hanging distinct PDE prerequisite after checking open and recently merged PRs: the generic Lax--Milgram existence API already landed, the semigroup layer is in flight outside PDE, and Tau Ceti already has isometry and translation invariance for the Laplacian and harmonic functions, while scalar dilation was still absent.

No Mathlib infrastructure is vendored. The implementation reuses Mathlib's `ContinuousLinearEquiv.smulLeft`, `ContinuousLinearEquiv.iteratedFDerivWithin_comp_right`, and `ContinuousMultilinearMap.map_smul_univ`, together with Tau Ceti's existing `TauCeti.Analysis.InnerProductSpace.HarmonicIsometry` layer.

`lake exe cache get` completed with `No files to download` and `Already decompressed 8601 file(s)`. `lake build` completed with `Build completed successfully (4323 jobs).` `lake exe axioms` completed with `axioms: audited 6317 TauCeti declaration(s); all within the allowlist [propext, Classical.choice, Quot.sound].`

<!--tauceti-target:v1 {"focus":"PDE","id":"harmonic-dilation-invariance"}-->

🤖 Prepared with Codex
