### PR TITLE
feat: add finite product mixture evaluation

### DIFF
--- a/TauCeti/MeasureTheory/Measure/ProductKernel.lean
+++ b/TauCeti/MeasureTheory/Measure/ProductKernel.lean
@@ -3,11 +3,13 @@ module
 public import Mathlib.MeasureTheory.Measure.FiniteMeasurePi
 
 /-!
-# Measurability of finite product probability-measure kernels
+# Finite product probability-measure kernels
 
-This file provides the measurability API for the finite product of probability measures over a
-finite index type, phrased directly over Mathlib's `ProbabilityMeasure.pi`:
+This file provides the basic theory of the finite product of probability measures over a finite
+index type, phrased directly over Mathlib's `ProbabilityMeasure.pi`: measurability of the product
+kernel, and `Measure.bind`-evaluation of the mixture it induces.
 
+Measurability:
 * `measurable_probabilityMeasure_pi` — the product combinator
   `ProbabilityMeasure.pi : (Π i, ProbabilityMeasure (α i)) → ProbabilityMeasure (Π i, α i)`
   is measurable.
@@ -21,13 +23,20 @@ finite index type, phrased directly over Mathlib's `ProbabilityMeasure.pi`:
   `measurable_probabilityMeasure_pi_const_toMeasure` and
   `aemeasurable_probabilityMeasure_pi_const_toMeasure`, used by `ConditionallyIIDWith`.
 
+Bind-evaluation of the mixture `μ.bind fun ω => (ProbabilityMeasure.pi fun i => ν i ω).toMeasure`:
+* `bind_probabilityMeasure_pi_apply` — evaluation on a measurable set as the integral of the product
+  kernel, from a.e.-measurable coordinate kernels.
+* `bind_probabilityMeasure_pi_pi` — evaluation on a measurable rectangle as the integral of the
+  product of coordinate measures, with `Fin m` constant-coordinate forms
+  `bind_probabilityMeasure_pi_const_apply` and `bind_probabilityMeasure_pi_const_pi`.
+
 This file does not introduce a new product-kernel structure; the lemmas live directly over Mathlib's
 `ProbabilityMeasure.pi`. It advances `TauCetiRoadmap/Exchangeability`, Layer 1 (product kernels,
 conditional independence, mixtures), and is motivated by the product-kernel layer of
-`cameronfreer/exchangeability` (`MeasureKernels.lean`, pin
-`e0532e59ceff23edab44dda9ab0655debbc9cc22`), implemented using Mathlib's `ProbabilityMeasure.pi` and
-Giry measurability API; the combinator generalizes Mathlib's binary
-`ProbabilityMeasure.measurable_fun_prod` to finite index types.
+`cameronfreer/exchangeability` (`MeasureKernels.lean` and the `bind_pi_apply` of
+`DeFinetti/CommonEnding.lean`, pin `e0532e59ceff23edab44dda9ab0655debbc9cc22`), implemented using
+Mathlib's `ProbabilityMeasure.pi`, `Measure.bind_apply`, and Giry measurability API; the combinator
+generalizes Mathlib's binary `ProbabilityMeasure.measurable_fun_prod` to finite index types.
 -/
 
 public section
@@ -107,6 +116,43 @@ theorem aemeasurable_probabilityMeasure_pi_const_toMeasure_of_measurable {α : T
     [MeasurableSpace α] {m : ℕ} (ν : Ω → ProbabilityMeasure α) (hν : Measurable ν) :
     AEMeasurable (fun ω => (ProbabilityMeasure.pi fun _ : Fin m => ν ω).toMeasure) μ :=
   aemeasurable_probabilityMeasure_pi_const_toMeasure ν hν.aemeasurable
+
+/-- **Bind-evaluation.** Evaluating the mixture
+`μ.bind fun ω => (ProbabilityMeasure.pi fun i => ν i ω).toMeasure` on a measurable set `s` gives
+`∫⁻ ω, … s ∂μ`, requiring only a.e.-measurability of each coordinate kernel `ν i`. -/
+theorem bind_probabilityMeasure_pi_apply
+    (ν : ∀ i, Ω → ProbabilityMeasure (α i)) (hν : ∀ i, AEMeasurable (ν i) μ)
+    {s : Set (∀ i, α i)} (hs : MeasurableSet s) :
+    (μ.bind fun ω => (ProbabilityMeasure.pi fun i => ν i ω).toMeasure) s
+      = ∫⁻ ω, (ProbabilityMeasure.pi fun i => ν i ω).toMeasure s ∂μ :=
+  Measure.bind_apply hs (aemeasurable_probabilityMeasure_pi_toMeasure ν hν)
+
+/-- **Bind-evaluation on a rectangle.** On a rectangle `Set.univ.pi B`, the mixture equals
+`∫⁻ ω, ∏ i, (ν i ω) (B i) ∂μ`. -/
+theorem bind_probabilityMeasure_pi_pi
+    (ν : ∀ i, Ω → ProbabilityMeasure (α i)) (hν : ∀ i, AEMeasurable (ν i) μ)
+    (B : ∀ i, Set (α i)) (hB : ∀ i, MeasurableSet (B i)) :
+    (μ.bind fun ω => (ProbabilityMeasure.pi fun i => ν i ω).toMeasure) (Set.univ.pi B)
+      = ∫⁻ ω, ∏ i, (ν i ω : Measure (α i)) (B i) ∂μ := by
+  rw [bind_probabilityMeasure_pi_apply ν hν (MeasurableSet.univ_pi hB)]
+  simp_rw [ProbabilityMeasure.toMeasure_pi, Measure.pi_pi]
+
+/-- Constant-coordinate `Fin m` specialization of `bind_probabilityMeasure_pi_apply`. -/
+theorem bind_probabilityMeasure_pi_const_apply {α : Type*} [MeasurableSpace α] {m : ℕ}
+    (ν : Ω → ProbabilityMeasure α) (hν : AEMeasurable ν μ)
+    {s : Set (Fin m → α)} (hs : MeasurableSet s) :
+    (μ.bind fun ω => (ProbabilityMeasure.pi fun _ : Fin m => ν ω).toMeasure) s
+      = ∫⁻ ω, (ProbabilityMeasure.pi fun _ : Fin m => ν ω).toMeasure s ∂μ :=
+  bind_probabilityMeasure_pi_apply (fun _ => ν) (fun _ => hν) hs
+
+/-- Constant-coordinate `Fin m` specialization of `bind_probabilityMeasure_pi_pi`: the
+finite-block mixture identity the de Finetti common ending consumes. -/
+theorem bind_probabilityMeasure_pi_const_pi {α : Type*} [MeasurableSpace α] {m : ℕ}
+    (ν : Ω → ProbabilityMeasure α) (hν : AEMeasurable ν μ)
+    (B : Fin m → Set α) (hB : ∀ i, MeasurableSet (B i)) :
+    (μ.bind fun ω => (ProbabilityMeasure.pi fun _ : Fin m => ν ω).toMeasure) (Set.univ.pi B)
+      = ∫⁻ ω, ∏ i : Fin m, (ν ω : Measure α) (B i) ∂μ :=
+  bind_probabilityMeasure_pi_pi (fun _ => ν) (fun _ => hν) B hB
 
 end MeasureTheory
 

--- a/TauCeti/MeasureTheory/Measure/ProductKernel.lean
+++ b/TauCeti/MeasureTheory/Measure/ProductKernel.lean
@@ -127,10 +127,11 @@ theorem bind_probabilityMeasure_pi_apply
       = ∫⁻ ω, (ProbabilityMeasure.pi fun i => ν i ω).toMeasure s ∂μ :=
   Measure.bind_apply hs (aemeasurable_probabilityMeasure_pi_toMeasure ν hν)
 
+-- Not `@[simp]`: `simp` unfolds `(ProbabilityMeasure.pi …).toMeasure` via `toMeasure_pi`, so the
+-- `.toMeasure`-shaped (`ConditionallyIIDWith`-shaped) LHS here is not simp-normal and a `@[simp]`
+-- tag never fires; this is an explicit `rw` lemma in the shape later de Finetti code rewrites with.
 /-- **Bind-evaluation on a rectangle.** On a rectangle `Set.univ.pi B`, the mixture equals
-`∫⁻ ω, ∏ i, (ν i ω) (B i) ∂μ`. Stated as an explicit `rw` lemma, not `@[simp]`: `simp` first
-unfolds `(ProbabilityMeasure.pi …).toMeasure` via `toMeasure_pi`, so this `.toMeasure`-shaped LHS is
-not simp-normal. -/
+`∫⁻ ω, ∏ i, (ν i ω) (B i) ∂μ`. -/
 theorem bind_probabilityMeasure_pi_pi
     (ν : ∀ i, Ω → ProbabilityMeasure (α i)) (hν : ∀ i, AEMeasurable (ν i) μ)
     (B : ∀ i, Set (α i)) (hB : ∀ i, MeasurableSet (B i)) :

--- a/TauCeti/MeasureTheory/Measure/ProductKernel.lean
+++ b/TauCeti/MeasureTheory/Measure/ProductKernel.lean
@@ -128,7 +128,9 @@ theorem bind_probabilityMeasure_pi_apply
   Measure.bind_apply hs (aemeasurable_probabilityMeasure_pi_toMeasure ν hν)
 
 /-- **Bind-evaluation on a rectangle.** On a rectangle `Set.univ.pi B`, the mixture equals
-`∫⁻ ω, ∏ i, (ν i ω) (B i) ∂μ`. -/
+`∫⁻ ω, ∏ i, (ν i ω) (B i) ∂μ`. Stated as an explicit `rw` lemma, not `@[simp]`: `simp` first
+unfolds `(ProbabilityMeasure.pi …).toMeasure` via `toMeasure_pi`, so this `.toMeasure`-shaped LHS is
+not simp-normal. -/
 theorem bind_probabilityMeasure_pi_pi
     (ν : ∀ i, Ω → ProbabilityMeasure (α i)) (hν : ∀ i, AEMeasurable (ν i) μ)
     (B : ∀ i, Set (α i)) (hB : ∀ i, MeasurableSet (B i)) :


### PR DESCRIPTION
<!--tauceti-target:v1 {"focus":"Exchangeability","id":"product-mixture-evaluation"}-->

## Summary

Extends `TauCeti/MeasureTheory/Measure/ProductKernel.lean` (merged in #501) with the
`Measure.bind`-evaluation of the finite-product probability-measure mixture — the next Layer 1
general adapter:

- `bind_probabilityMeasure_pi_apply` — for a.e.-measurable coordinate kernels `ν i`, the mixture
  `μ.bind fun ω => (ProbabilityMeasure.pi fun i => ν i ω).toMeasure` evaluated on a measurable set
  `s` equals `∫⁻ ω, (ProbabilityMeasure.pi fun i => ν i ω).toMeasure s ∂μ`.
- `bind_probabilityMeasure_pi_pi` — on a measurable rectangle `Set.univ.pi B`, it equals
  `∫⁻ ω, ∏ i, (ν i ω) (B i) ∂μ`.
- `bind_probabilityMeasure_pi_const_apply` / `bind_probabilityMeasure_pi_const_pi` — the `Fin m`
  constant-coordinate specializations; the second is the finite-block mixture identity the de
  Finetti common ending consumes.

## Roadmap

Advances `TauCetiRoadmap/Exchangeability`, **Layer 1** (product kernels, conditional independence,
mixtures). This is general measure-theory infrastructure — still **no** de Finetti-specific theorem
(no `blockLaw`, indicator-product bridge, or `conditional_iid_from_directing_measure`); those are the
next PRs.

## How it's proved (reuse)

`bind_probabilityMeasure_pi_apply` is a thin adapter over Mathlib's `Measure.bind_apply`, with the
required product-kernel `AEMeasurable` hypothesis supplied directly by #501's
`aemeasurable_probabilityMeasure_pi_toMeasure`. The rectangle form rewrites the integrand with
`ProbabilityMeasure.toMeasure_pi` + `Measure.pi_pi`; the `Fin m` forms are one-line specializations.
No re-proved measure theory.

The `_apply` lemma is intentionally thin: it packages exactly the stable bind-evaluation API the
later de Finetti code (rectangle bridge, common ending) consumes, so those proofs do not each
re-derive the kernel's a.e.-measurability and re-apply `bind_apply`.

## Review notes
- **not `@[simp]` (deliberate):** the rectangle lemmas are explicit `rw` lemmas rather than `@[simp]`
  lemmas — `simp` first unfolds `(ProbabilityMeasure.pi …).toMeasure` via `toMeasure_pi`, so the
  public `ConditionallyIIDWith`-shaped (`.toMeasure`) statements are not simp-normal and a `@[simp]`
  tag would never fire. They are stated in the shape later code will `rw` with.
- **placement:** the lemmas are fully general (any `ν : Ω → ProbabilityMeasure α`), so they live with
  the rest of the product-kernel basic theory in `MeasureTheory/Measure/ProductKernel.lean`, **not**
  in a `DeFinetti/` file.
- **generality:** stated for a general finite index type (`[Fintype ι]`, `α : ι → Type*`) on
  a.e.-measurable coordinate kernels; the `Fin m` constant-coordinate forms are derived corollaries.
- **naming:** `bind_…_apply` / `…_pi` echo Mathlib's `Measure.bind_apply` / `Measure.pi_pi`.
- **imports:** no new import — `Measure.bind_apply` / `Measure.pi_pi` / `MeasurableSet.univ_pi` are
  already in scope transitively via the `FiniteMeasurePi` import #501 needs for `ProbabilityMeasure.pi`.

## Test plan
```bash
lake build
lake exe axioms
lake exe module-system
```
All pass; sorry-free; axioms ⊆ {`propext`, `Classical.choice`, `Quot.sound`}; lines ≤100.

## Attribution
Motivated by the `bind_pi_apply` lemma of `cameronfreer/exchangeability`
(`DeFinetti/CommonEnding.lean`, pin `e0532e59ceff23edab44dda9ab0655debbc9cc22`); implemented using
Mathlib's `Measure.bind_apply` and the merged #501 product-kernel AE lemmas, with Tau Ceti API names.
Credited in the module docstring. Drafted with Claude (Opus 4.8), human-directed.
