### PR TITLE
feat: add path-space shift iterate API

### DIFF
--- a/TauCeti/Probability/Exchangeability/Basic.lean
+++ b/TauCeti/Probability/Exchangeability/Basic.lean
@@ -171,6 +171,32 @@ theorem map_blockLaw_reindex (μ : Measure Ω) {X : ℕ → Ω → α} {n p : �
       (aemeasurable_pi_lambda _ hXk)]
   rfl
 
+omit [MeasurableSpace Ω] in
+/-- Reindexing the coordinates of path space along `φ` is measurable. -/
+theorem measurable_reindex (φ : ℕ → ℕ) :
+    Measurable (fun x : ℕ → α => fun k => x (φ k)) :=
+  measurable_pi_lambda _ fun k => measurable_pi_apply (φ k)
+
+/-- Reindexing a path law gives the path law of the reindexed process. -/
+theorem map_reindex_pathLaw (μ : Measure Ω) {X : ℕ → Ω → α}
+    (hX : ∀ i, AEMeasurable (X i) μ) (φ : ℕ → ℕ) :
+    (pathLaw μ X).map (fun x : ℕ → α => fun k => x (φ k)) =
+      pathLaw μ (fun k ω => X (φ k) ω) := by
+  rw [pathLaw_apply, pathLaw_apply]
+  rw [AEMeasurable.map_map_of_aemeasurable (measurable_reindex φ).aemeasurable
+    (aemeasurable_pi_lambda _ hX)]
+  rfl
+
+/-- Projecting the `φ`-reindexed path law onto its first `n` coordinates gives the law of the
+block `(X (φ 0), …, X (φ (n-1)))`. -/
+theorem map_reindex_prefixProj_pathLaw (μ : Measure Ω) {X : ℕ → Ω → α}
+    (hX : ∀ i, AEMeasurable (X i) μ) (φ : ℕ → ℕ) (n : ℕ) :
+    ((pathLaw μ X).map (fun x : ℕ → α => fun k => x (φ k))).map (prefixProj α n) =
+      blockLaw μ X (fun i : Fin n => φ i.val) := by
+  rw [map_reindex_pathLaw μ hX φ,
+    map_prefixProj_pathLaw μ (aemeasurable_pi_lambda _ fun i => hX (φ i)) n]
+  rw [prefixLaw_apply, blockLaw_apply, blockLaw_apply]
+
 /-- Projecting the prefix law on `Fin n` onto its first `m ≤ n` coordinates (via `Fin.castLE`)
 gives the prefix law on `Fin m`. -/
 theorem map_prefixLaw_castLE (μ : Measure Ω) {X : ℕ → Ω → α} {m n : ℕ} (hmn : m ≤ n)

--- a/TauCeti/Probability/Exchangeability/Contractability.lean
+++ b/TauCeti/Probability/Exchangeability/Contractability.lean
@@ -1,6 +1,6 @@
 module
 
-public import TauCeti.Probability.Exchangeability.Basic
+public import TauCeti.Probability.Exchangeability.PathSpace.Shift
 public import Mathlib.Order.Fin.Basic
 public import Mathlib.Dynamics.Ergodic.MeasurePreserving
 import Mathlib.Logic.Equiv.Fintype
@@ -129,21 +129,6 @@ theorem Exchangeable.contractable {μ : Measure Ω} {X : ℕ → Ω → α}
     (hX : Exchangeable μ X) (hX_meas : ∀ i, AEMeasurable (X i) μ) : Contractable μ X :=
   contractable_of_exchangeable hX hX_meas
 
-/-- Projecting the `φ`-reindexed path law onto its first `n` coordinates gives the law of the block
-`(X (φ 0), …, X (φ (n-1)))`. -/
-private theorem map_reindex_prefixProj_pathLaw {μ : Measure Ω} {X : ℕ → Ω → α}
-    (hX_meas : ∀ i, AEMeasurable (X i) μ) (φ : ℕ → ℕ) (n : ℕ) :
-    ((pathLaw μ X).map (fun x : ℕ → α => fun k => x (φ k))).map (prefixProj α n)
-      = blockLaw μ X (fun i : Fin n => φ i.val) := by
-  have hφ_meas : Measurable (fun x : ℕ → α => fun k => x (φ k)) :=
-    measurable_pi_lambda _ fun k => measurable_pi_apply (φ k)
-  rw [pathLaw_apply,
-    AEMeasurable.map_map_of_aemeasurable hφ_meas.aemeasurable
-      (aemeasurable_pi_lambda _ hX_meas),
-    AEMeasurable.map_map_of_aemeasurable (measurable_prefixProj n).aemeasurable
-      (hφ_meas.comp_aemeasurable (aemeasurable_pi_lambda _ hX_meas))]
-  rfl
-
 /-- **A contractable process's path law is invariant under strictly monotone time-reindexing:** for
 `StrictMono φ`, the reindexing `x ↦ x ∘ φ` preserves `pathLaw μ X`. -/
 theorem Contractable.measurePreserving_reindex {μ : Measure Ω} {X : ℕ → Ω → α} [IsFiniteMeasure μ]
@@ -153,7 +138,7 @@ theorem Contractable.measurePreserving_reindex {μ : Measure Ω} {X : ℕ → Ω
   haveI : IsFiniteMeasure (pathLaw μ X) := by rw [pathLaw_apply]; infer_instance
   refine measure_eq_of_prefixProj_map_eq ?_
   intro n
-  rw [map_reindex_prefixProj_pathLaw hX_meas φ n,
+  rw [map_reindex_prefixProj_pathLaw μ hX_meas φ n,
     map_prefixProj_pathLaw μ (aemeasurable_pi_lambda _ hX_meas) n]
   exact hX n (fun i : Fin n => φ i.val) (hφ.comp Fin.val_strictMono)
 

--- a/TauCeti/Probability/Exchangeability/Contractability.lean
+++ b/TauCeti/Probability/Exchangeability/Contractability.lean
@@ -1,6 +1,6 @@
 module
 
-public import TauCeti.Probability.Exchangeability.PathSpace.Shift
+public import TauCeti.Probability.Exchangeability.Basic
 public import Mathlib.Order.Fin.Basic
 public import Mathlib.Dynamics.Ergodic.MeasurePreserving
 import Mathlib.Logic.Equiv.Fintype

--- a/TauCeti/Probability/Exchangeability/PathSpace/Shift.lean
+++ b/TauCeti/Probability/Exchangeability/PathSpace/Shift.lean
@@ -3,15 +3,16 @@ module
 public import TauCeti.Probability.Exchangeability.Basic
 
 /-!
-# Iterates of the one-sided path-space shift
+# Path-space reindexing and iterates of the one-sided shift
 
 This file records the elementary path-space API for iterating the one-sided shift
 `TauCeti.Probability.shift`.  The Layer 2 exchangeability roadmap uses these lemmas before
 building shift-invariant sigma algebras and before comparing finite-dimensional path laws after
 discarding an initial block.
 
-The implementation is only a Tau Ceti adapter around the existing shift definition and Mathlib's
-generic `Measurable.iterate`; no Mathlib infrastructure is vendored.
+It also exposes the general time-reindexing path-law lemmas used by the shift-specialized
+statements. The implementation is only a Tau Ceti adapter around the existing path-space
+definitions and Mathlib's generic `Measurable.iterate`; no Mathlib infrastructure is vendored.
 -/
 
 public section
@@ -25,6 +26,32 @@ namespace TauCeti
 namespace Probability
 
 variable {Ω α : Type*} [MeasurableSpace Ω] [MeasurableSpace α]
+
+omit [MeasurableSpace Ω] in
+/-- Reindexing the coordinates of path space along `φ` is measurable. -/
+theorem measurable_reindex (φ : ℕ → ℕ) :
+    Measurable (fun x : ℕ → α => fun k => x (φ k)) :=
+  measurable_pi_lambda _ fun k => measurable_pi_apply (φ k)
+
+/-- Reindexing a path law gives the path law of the reindexed process. -/
+theorem map_reindex_pathLaw (μ : Measure Ω) {X : ℕ → Ω → α}
+    (hX : ∀ i, AEMeasurable (X i) μ) (φ : ℕ → ℕ) :
+    (pathLaw μ X).map (fun x : ℕ → α => fun k => x (φ k)) =
+      pathLaw μ (fun k ω => X (φ k) ω) := by
+  rw [pathLaw_apply, pathLaw_apply]
+  rw [AEMeasurable.map_map_of_aemeasurable (measurable_reindex φ).aemeasurable
+    (aemeasurable_pi_lambda _ hX)]
+  rfl
+
+/-- Projecting the `φ`-reindexed path law onto its first `n` coordinates gives the law of the
+block `(X (φ 0), …, X (φ (n-1)))`. -/
+theorem map_reindex_prefixProj_pathLaw (μ : Measure Ω) {X : ℕ → Ω → α}
+    (hX : ∀ i, AEMeasurable (X i) μ) (φ : ℕ → ℕ) (n : ℕ) :
+    ((pathLaw μ X).map (fun x : ℕ → α => fun k => x (φ k))).map (prefixProj α n) =
+      blockLaw μ X (fun i : Fin n => φ i.val) := by
+  rw [map_reindex_pathLaw μ hX φ,
+    map_prefixProj_pathLaw μ (aemeasurable_pi_lambda _ fun i => hX (φ i)) n]
+  rw [prefixLaw_apply, blockLaw_apply, blockLaw_apply]
 
 omit [MeasurableSpace α] in
 /-- Iterating the one-sided shift by `n` drops the first `n` coordinates. -/
@@ -73,12 +100,8 @@ theorem measurable_prefixProj_shift_iterate (n m : ℕ) :
 theorem map_shift_iterate_pathLaw (μ : Measure Ω) {X : ℕ → Ω → α}
     (hX : ∀ i, AEMeasurable (X i) μ) (n : ℕ) :
     (pathLaw μ X).map ((shift α)^[n]) = pathLaw μ (fun k ω => X (k + n) ω) := by
-  rw [pathLaw_apply, pathLaw_apply]
-  rw [AEMeasurable.map_map_of_aemeasurable (measurable_shift_iterate n).aemeasurable
-    (aemeasurable_pi_lambda _ hX)]
-  congr 1
-  funext ω k
-  simp
+  rw [shift_iterate_eq_reindex n]
+  exact map_reindex_pathLaw μ hX (fun k => k + n)
 
 /-- The first `m` coordinates of the path law after `n` shifts are the block law along
 `i ↦ i + n`. -/
@@ -86,9 +109,8 @@ theorem map_prefixProj_shift_iterate_pathLaw (μ : Measure Ω) {X : ℕ → Ω �
     (hX : ∀ i, AEMeasurable (X i) μ) (n m : ℕ) :
     ((pathLaw μ X).map ((shift α)^[n])).map (prefixProj α m) =
       blockLaw μ X (fun i : Fin m => i.val + n) := by
-  rw [map_shift_iterate_pathLaw μ hX n,
-    map_prefixProj_pathLaw μ (aemeasurable_pi_lambda _ fun i => hX (i + n)) m]
-  rw [prefixLaw_apply, blockLaw_apply, blockLaw_apply]
+  rw [shift_iterate_eq_reindex n]
+  exact map_reindex_prefixProj_pathLaw μ hX (fun k => k + n) m
 
 /-- The setwise form of `map_prefixProj_shift_iterate_pathLaw`. -/
 theorem map_prefixProj_shift_iterate_pathLaw_apply (μ : Measure Ω) {X : ℕ → Ω → α}

--- a/TauCeti/Probability/Exchangeability/PathSpace/Shift.lean
+++ b/TauCeti/Probability/Exchangeability/PathSpace/Shift.lean
@@ -10,9 +10,11 @@ This file records the elementary path-space API for iterating the one-sided shif
 building shift-invariant sigma algebras and before comparing finite-dimensional path laws after
 discarding an initial block.
 
-It also exposes the general time-reindexing path-law lemmas used by the shift-specialized
-statements. The implementation is only a Tau Ceti adapter around the existing path-space
-definitions and Mathlib's generic `Measurable.iterate`; no Mathlib infrastructure is vendored.
+The shift-specialized statements reuse the general time-reindexing path-law lemmas
+(`measurable_reindex`, `map_reindex_pathLaw`, `map_reindex_prefixProj_pathLaw`) from
+`TauCeti.Probability.Exchangeability.Basic`. The implementation is only a Tau Ceti adapter around
+the existing path-space definitions and Mathlib's generic `Measurable.iterate`; no Mathlib
+infrastructure is vendored.
 -/
 
 public section
@@ -26,32 +28,6 @@ namespace TauCeti
 namespace Probability
 
 variable {Ω α : Type*} [MeasurableSpace Ω] [MeasurableSpace α]
-
-omit [MeasurableSpace Ω] in
-/-- Reindexing the coordinates of path space along `φ` is measurable. -/
-theorem measurable_reindex (φ : ℕ → ℕ) :
-    Measurable (fun x : ℕ → α => fun k => x (φ k)) :=
-  measurable_pi_lambda _ fun k => measurable_pi_apply (φ k)
-
-/-- Reindexing a path law gives the path law of the reindexed process. -/
-theorem map_reindex_pathLaw (μ : Measure Ω) {X : ℕ → Ω → α}
-    (hX : ∀ i, AEMeasurable (X i) μ) (φ : ℕ → ℕ) :
-    (pathLaw μ X).map (fun x : ℕ → α => fun k => x (φ k)) =
-      pathLaw μ (fun k ω => X (φ k) ω) := by
-  rw [pathLaw_apply, pathLaw_apply]
-  rw [AEMeasurable.map_map_of_aemeasurable (measurable_reindex φ).aemeasurable
-    (aemeasurable_pi_lambda _ hX)]
-  rfl
-
-/-- Projecting the `φ`-reindexed path law onto its first `n` coordinates gives the law of the
-block `(X (φ 0), …, X (φ (n-1)))`. -/
-theorem map_reindex_prefixProj_pathLaw (μ : Measure Ω) {X : ℕ → Ω → α}
-    (hX : ∀ i, AEMeasurable (X i) μ) (φ : ℕ → ℕ) (n : ℕ) :
-    ((pathLaw μ X).map (fun x : ℕ → α => fun k => x (φ k))).map (prefixProj α n) =
-      blockLaw μ X (fun i : Fin n => φ i.val) := by
-  rw [map_reindex_pathLaw μ hX φ,
-    map_prefixProj_pathLaw μ (aemeasurable_pi_lambda _ fun i => hX (φ i)) n]
-  rw [prefixLaw_apply, blockLaw_apply, blockLaw_apply]
 
 omit [MeasurableSpace α] in
 /-- Iterating the one-sided shift by `n` drops the first `n` coordinates. -/

--- a/TauCeti/Probability/PathSpace/Shift.lean
+++ b/TauCeti/Probability/PathSpace/Shift.lean
@@ -1,0 +1,102 @@
+module
+
+public import TauCeti.Probability.Exchangeability.Basic
+
+/-!
+# Iterates of the one-sided path-space shift
+
+This file records the elementary path-space API for iterating the one-sided shift
+`TauCeti.Probability.shift`.  The Layer 2 exchangeability roadmap uses these lemmas before
+building shift-invariant sigma algebras and before comparing finite-dimensional path laws after
+discarding an initial block.
+
+The implementation is only a Tau Ceti adapter around the existing shift definition and Mathlib's
+generic `Measurable.iterate`; no Mathlib infrastructure is vendored.
+-/
+
+public section
+
+noncomputable section
+
+open MeasureTheory
+
+namespace TauCeti
+
+namespace Probability
+
+variable {Ω α : Type*} [MeasurableSpace Ω] [MeasurableSpace α]
+
+omit [MeasurableSpace α] in
+/-- Iterating the one-sided shift by `n` drops the first `n` coordinates. -/
+@[simp]
+theorem shift_iterate_apply (n k : ℕ) (x : ℕ → α) :
+    (shift α)^[n] x k = x (k + n) := by
+  induction n generalizing k x with
+  | zero =>
+      simp
+  | succ n ih =>
+      rw [Function.iterate_succ_apply]
+      simpa [shift_apply, Nat.add_assoc] using ih k (shift α x)
+
+omit [MeasurableSpace α] in
+/-- The `n`th shift iterate is the coordinate reindexing `k ↦ k + n`. -/
+theorem shift_iterate_eq_reindex (n : ℕ) :
+    (shift α)^[n] = fun x : ℕ → α => fun k => x (k + n) := by
+  funext x k
+  simp
+
+/-- Every iterate of the one-sided path-space shift is measurable. -/
+theorem measurable_shift_iterate (n : ℕ) : Measurable ((shift α)^[n]) :=
+  measurable_shift.iterate n
+
+/-- Every iterate of the one-sided path-space shift is a.e.-measurable with respect to any
+measure on path space. -/
+theorem aemeasurable_shift_iterate (n : ℕ) (μ : Measure (ℕ → α)) :
+    AEMeasurable ((shift α)^[n]) μ :=
+  (measurable_shift_iterate n).aemeasurable
+
+omit [MeasurableSpace α] in
+/-- A finite prefix after `n` shifts is the block of coordinates `n, …, n + m - 1`. -/
+@[simp]
+theorem prefixProj_shift_iterate (n m : ℕ) (x : ℕ → α) :
+    prefixProj α m ((shift α)^[n] x) = fun i : Fin m => x (i.val + n) := by
+  funext i
+  simp [prefixProj_apply]
+
+/-- The prefix projection after an `n`-fold shift is measurable. -/
+theorem measurable_prefixProj_shift_iterate (n m : ℕ) :
+    Measurable (fun x : ℕ → α => prefixProj α m ((shift α)^[n] x)) :=
+  (measurable_prefixProj m).comp (measurable_shift_iterate n)
+
+/-- Shifting the path law by `n` gives the path law of the reindexed process
+`k ↦ X (k + n)`. -/
+theorem map_shift_iterate_pathLaw (μ : Measure Ω) {X : ℕ → Ω → α}
+    (hX : ∀ i, AEMeasurable (X i) μ) (n : ℕ) :
+    (pathLaw μ X).map ((shift α)^[n]) = pathLaw μ (fun k ω => X (k + n) ω) := by
+  rw [pathLaw_apply, pathLaw_apply]
+  rw [AEMeasurable.map_map_of_aemeasurable (measurable_shift_iterate n).aemeasurable
+    (aemeasurable_pi_lambda _ hX)]
+  congr 1
+  funext ω k
+  simp
+
+/-- The first `m` coordinates of the path law after `n` shifts are the block law along
+`i ↦ i + n`. -/
+theorem map_prefixProj_shift_iterate_pathLaw (μ : Measure Ω) {X : ℕ → Ω → α}
+    (hX : ∀ i, AEMeasurable (X i) μ) (n m : ℕ) :
+    ((pathLaw μ X).map ((shift α)^[n])).map (prefixProj α m) =
+      blockLaw μ X (fun i : Fin m => i.val + n) := by
+  rw [map_shift_iterate_pathLaw μ hX n,
+    map_prefixProj_pathLaw μ (aemeasurable_pi_lambda _ fun i => hX (i + n)) m]
+  rw [prefixLaw_apply, blockLaw_apply, blockLaw_apply]
+
+/-- The setwise form of `map_prefixProj_shift_iterate_pathLaw`. -/
+theorem map_prefixProj_shift_iterate_pathLaw_apply (μ : Measure Ω) {X : ℕ → Ω → α}
+    (hX : ∀ i, AEMeasurable (X i) μ) (n m : ℕ) (s : Set (Fin m → α)) :
+    ((pathLaw μ X).map ((shift α)^[n])).map (prefixProj α m) s =
+      blockLaw μ X (fun i : Fin m => i.val + n) s := by
+  rw [map_prefixProj_shift_iterate_pathLaw μ hX n m]
+
+end Probability
+
+end TauCeti


### PR DESCRIPTION
This PR adds the path-space shift iterate API for Exchangeability: the pointwise normal form for `(shift α)^[n]`, measurability and a.e.-measurability of every shift iterate, the prefix-after-shift normal form, and path-law pushforward lemmas identifying shifted prefixes with finite block laws.

It advances `TauCetiRoadmap/Exchangeability/README.md`, Layer 2, specifically the path-space shift target `shift_iterate_measurable`, and supplies a clean prerequisite for the adjacent shift-invariant sigma-algebra targets `isShiftInvariant`, `shiftInvariantSigma`, `shiftInvariantSigma_le`, `mem_shiftInvariantSigma_iff`, `shiftInvariantSigma_measurable_shift_eq`, and `shiftInvariant_implies_shiftInvariantMeasurable`. I chose this as the lowest-hanging distinct Exchangeability target after checking open and recently merged PRs: Layer 0 basics, finite/full exchangeability, conditionally-iid implications, product-kernel measurability, adjacent swaps, and the process-tail sigma-algebra PR are already landed or in flight, while this small path-space shift-iterate adapter was still absent.

No Mathlib infrastructure is vendored. The implementation reuses Mathlib's generic `Measurable.iterate` and Tau Ceti's existing `shift`, `prefixProj`, `pathLaw`, and finite-dimensional law API.

`lake exe cache get` completed with `No files to download` and `Already decompressed 8602 file(s)`. `lake build` completed with `Build completed successfully (4325 jobs).` `lake exe axioms` completed with `axioms: audited 6338 TauCeti declaration(s); all within the allowlist [propext, Classical.choice, Quot.sound].`

<!--tauceti-target:v1 {"focus":"Exchangeability","id":"path-space-shift-iterates"}-->

🤖 Prepared with Codex
