### PR TITLE
feat: add regular fibre torsor transport

### DIFF
--- a/TauCeti/AlgebraicTopology/UniversalCover/Deck/FiberTorsorTransport.lean
+++ b/TauCeti/AlgebraicTopology/UniversalCover/Deck/FiberTorsorTransport.lean
@@ -42,6 +42,29 @@ namespace Deck
 variable {E F B : Type*} [TopologicalSpace E] [TopologicalSpace F] [TopologicalSpace B]
   {p : E → B} {q : F → B} {b : B}
 
+omit [TopologicalSpace B] in
+/-- Fibre transport carries a pretransitive deck action on the source fibre to a pretransitive
+deck action on the target fibre. -/
+lemma isPretransitive_fiberMap (h : E ≃ₜ F) (hpq : ∀ e, q (h e) = p e)
+    [MulAction.IsPretransitive (Deck p) (p ⁻¹' {b})] :
+    MulAction.IsPretransitive (Deck q) (q ⁻¹' {b}) := by
+  refine ⟨fun x y => ?_⟩
+  obtain ⟨x', rfl⟩ := (fiberMap h hpq b).surjective x
+  obtain ⟨y', rfl⟩ := (fiberMap h hpq b).surjective y
+  obtain ⟨g, rfl⟩ := MulAction.exists_smul_eq (Deck p) x' y'
+  exact ⟨conjMulEquiv h hpq g, (fiberMap_smul h hpq g x').symm⟩
+
+omit [TopologicalSpace B] in
+/-- Fibre transport carries surjectivity of evaluation at a source fibre point to surjectivity
+of evaluation at the transported target fibre point. -/
+lemma surjective_smul_fiberMap (h : E ≃ₜ F) (hpq : ∀ e, q (h e) = p e)
+    (e : p ⁻¹' {b}) (hsurj : Function.Surjective fun φ : Deck p => φ • e) :
+    Function.Surjective fun ψ : Deck q => ψ • fiberMap h hpq b e := by
+  intro f
+  obtain ⟨e', rfl⟩ := (fiberMap h hpq b).surjective f
+  obtain ⟨φ, rfl⟩ := hsurj e'
+  exact ⟨conjMulEquiv h hpq φ, (fiberMap_smul h hpq φ e).symm⟩
+
 /-- Fibre transport preserves torsor division, with the deck-group element transported by
 conjugation along the over-base homeomorphism.
 
@@ -51,13 +74,16 @@ nonemptiness and pretransitivity hypotheses from `Deck.IsRegular`. -/
 lemma fiberMap_sdiv_eq_conjMulEquiv_of_pretransitive [PreconnectedSpace E]
     [PreconnectedSpace F] (hp : IsCoveringMap p) (hq : IsCoveringMap q)
     [Nonempty (p ⁻¹' {b})] [MulAction.IsPretransitive (Deck p) (p ⁻¹' {b})]
-    [Nonempty (q ⁻¹' {b})] [MulAction.IsPretransitive (Deck q) (q ⁻¹' {b})]
     (h : E ≃ₜ F) (hpq : ∀ e, q (h e) = p e) (e₁ e₂ : p ⁻¹' {b}) :
     letI := fiberTorsorOfPretransitive hp b
+    letI : Nonempty (q ⁻¹' {b}) := ‹Nonempty (p ⁻¹' {b})›.map (fiberMap h hpq b)
+    letI : MulAction.IsPretransitive (Deck q) (q ⁻¹' {b}) := isPretransitive_fiberMap h hpq
     letI := fiberTorsorOfPretransitive hq b
     (fiberMap h hpq b e₁ /ₛ fiberMap h hpq b e₂ : Deck q) =
       conjMulEquiv h hpq (e₁ /ₛ e₂ : Deck p) := by
   letI := fiberTorsorOfPretransitive hp b
+  letI : Nonempty (q ⁻¹' {b}) := ‹Nonempty (p ⁻¹' {b})›.map (fiberMap h hpq b)
+  letI : MulAction.IsPretransitive (Deck q) (q ⁻¹' {b}) := isPretransitive_fiberMap h hpq
   letI := fiberTorsorOfPretransitive hq b
   rw [← deckEquivFiberOfSurjective_symm_eq_sdiv hq,
     ← deckEquivFiberOfSurjective_symm_eq_sdiv hp]
@@ -80,23 +106,6 @@ lemma fiberMap_sdiv_eq_conjMulEquiv_of_pretransitive [PreconnectedSpace E]
         fiberMap h hpq b e₂ := by
       rw [fiberMap_smul]
 
-/-- For regular preconnected covers, fibre transport preserves torsor division, with the
-deck transformation conjugated to the target deck group. -/
-@[simp]
-lemma fiberMap_sdiv_eq_conjMulEquiv [PreconnectedSpace E] [PreconnectedSpace F]
-    (hp : IsCoveringMap p) (hq : IsCoveringMap q) (hreg : IsRegular p)
-    (h : E ≃ₜ F) (hpq : ∀ e, q (h e) = p e) (e₁ e₂ : p ⁻¹' {b}) :
-    letI := fiberTorsor hp hreg b
-    letI := fiberTorsor hq (hreg.conj h hpq) b
-    (fiberMap h hpq b e₁ /ₛ fiberMap h hpq b e₂ : Deck q) =
-      conjMulEquiv h hpq (e₁ /ₛ e₂ : Deck p) := by
-  let hregq := hreg.conj h hpq
-  letI := hreg.nonempty_fiber b
-  letI := hreg.fiber_isPretransitive b
-  letI := hregq.nonempty_fiber b
-  letI := hregq.fiber_isPretransitive b
-  exact fiberMap_sdiv_eq_conjMulEquiv_of_pretransitive hp hq h hpq e₁ e₂
-
 /-- The inverse of the local deck-to-fibre equivalence is compatible with fibre transport:
 transport the target fibre point first, or compute the source deck transformation first and
 then conjugate it. -/
@@ -104,12 +113,13 @@ then conjugate it. -/
 lemma deckEquivFiberOfSurjective_symm_fiberMap [PreconnectedSpace E] [PreconnectedSpace F]
     (hp : IsCoveringMap p) (hq : IsCoveringMap q) (h : E ≃ₜ F)
     (hpq : ∀ e, q (h e) = p e) (e e' : p ⁻¹' {b})
-    (hsurj : Function.Surjective fun φ : Deck p => φ • e)
-    (hsurjq : Function.Surjective fun ψ : Deck q => ψ • fiberMap h hpq b e) :
-    (deckEquivFiberOfSurjective hq (fiberMap h hpq b e) hsurjq).symm
+    (hsurj : Function.Surjective fun φ : Deck p => φ • e) :
+    (deckEquivFiberOfSurjective hq (fiberMap h hpq b e)
+          (surjective_smul_fiberMap h hpq e hsurj)).symm
         (fiberMap h hpq b e') =
       conjMulEquiv h hpq ((deckEquivFiberOfSurjective hp e hsurj).symm e') := by
-  apply (deckEquivFiberOfSurjective hq (fiberMap h hpq b e) hsurjq).injective
+  apply (deckEquivFiberOfSurjective hq (fiberMap h hpq b e)
+    (surjective_smul_fiberMap h hpq e hsurj)).injective
   rw [Equiv.apply_symm_apply, deckEquivFiberOfSurjective_apply, ← fiberMap_smul,
     deckEquivFiberOfSurjective_symm_smul]
 
@@ -119,9 +129,9 @@ and fibre points along an over-base homeomorphism. -/
 lemma deckEquivFiberOfSurjective_fiberMap [PreconnectedSpace E] [PreconnectedSpace F]
     (hp : IsCoveringMap p) (hq : IsCoveringMap q) (h : E ≃ₜ F)
     (hpq : ∀ e, q (h e) = p e) (e : p ⁻¹' {b})
-    (hsurj : Function.Surjective fun φ : Deck p => φ • e)
-    (hsurjq : Function.Surjective fun ψ : Deck q => ψ • fiberMap h hpq b e) (φ : Deck p) :
-    deckEquivFiberOfSurjective hq (fiberMap h hpq b e) hsurjq (conjMulEquiv h hpq φ) =
+    (hsurj : Function.Surjective fun φ : Deck p => φ • e) (φ : Deck p) :
+    deckEquivFiberOfSurjective hq (fiberMap h hpq b e)
+        (surjective_smul_fiberMap h hpq e hsurj) (conjMulEquiv h hpq φ) =
       fiberMap h hpq b (deckEquivFiberOfSurjective hp e hsurj φ) := by
   rw [deckEquivFiberOfSurjective_apply, deckEquivFiberOfSurjective_apply, fiberMap_smul]
 
@@ -132,12 +142,11 @@ fibre point is the same as transporting the original evaluation. -/
 lemma deckEquivFiberOfSurjective_fiberMap_coe [PreconnectedSpace E] [PreconnectedSpace F]
     (hp : IsCoveringMap p) (hq : IsCoveringMap q) (h : E ≃ₜ F)
     (hpq : ∀ e, q (h e) = p e) (e : p ⁻¹' {b})
-    (hsurj : Function.Surjective fun φ : Deck p => φ • e)
-    (hsurjq : Function.Surjective fun ψ : Deck q => ψ • fiberMap h hpq b e) (φ : Deck p) :
-    (deckEquivFiberOfSurjective hq (fiberMap h hpq b e) hsurjq
-        (conjMulEquiv h hpq φ) : F) =
+    (hsurj : Function.Surjective fun φ : Deck p => φ • e) (φ : Deck p) :
+    (deckEquivFiberOfSurjective hq (fiberMap h hpq b e)
+        (surjective_smul_fiberMap h hpq e hsurj) (conjMulEquiv h hpq φ) : F) =
       h (φ.1 e.1) := by
-  rw [deckEquivFiberOfSurjective_fiberMap hp hq h hpq e hsurj hsurjq φ,
+  rw [deckEquivFiberOfSurjective_fiberMap hp hq h hpq e hsurj φ,
     fiberMap_apply_coe, deckEquivFiberOfSurjective_apply_coe]
 
 /-- The inverse of the regular deck-to-fibre equivalence is compatible with fibre transport:
@@ -155,7 +164,6 @@ lemma deckEquivFiber_symm_fiberMap [PreconnectedSpace E] [PreconnectedSpace F]
   letI := hregq.fiber_isPretransitive b
   exact deckEquivFiberOfSurjective_symm_fiberMap hp hq h hpq e e'
     (MulAction.surjective_smul (Deck p) e)
-    (MulAction.surjective_smul (Deck q) (fiberMap h hpq b e))
 
 /-- The regular deck-to-fibre equivalence commutes with transport of deck transformations
 and fibre points along an over-base homeomorphism. -/
@@ -169,8 +177,7 @@ lemma deckEquivFiber_fiberMap [PreconnectedSpace E] [PreconnectedSpace F]
   letI := hreg.fiber_isPretransitive b
   letI := hregq.fiber_isPretransitive b
   exact deckEquivFiberOfSurjective_fiberMap hp hq h hpq e
-    (MulAction.surjective_smul (Deck p) e)
-    (MulAction.surjective_smul (Deck q) (fiberMap h hpq b e)) φ
+    (MulAction.surjective_smul (Deck p) e) φ
 
 /-- On underlying points, the compatibility of `deckEquivFiber` with fibre transport says
 that conjugating a deck transformation and then evaluating on the transported fibre point is
@@ -184,6 +191,20 @@ lemma deckEquivFiber_fiberMap_coe [PreconnectedSpace E] [PreconnectedSpace F]
       h (φ.1 e.1) := by
   rw [deckEquivFiber_fiberMap hp hq hreg h hpq e φ, fiberMap_apply_coe,
     deckEquivFiber_apply_coe]
+
+/-- For regular preconnected covers, fibre transport preserves torsor division, with the
+deck transformation conjugated to the target deck group. -/
+@[simp]
+lemma fiberMap_sdiv_eq_conjMulEquiv [PreconnectedSpace E] [PreconnectedSpace F]
+    (hp : IsCoveringMap p) (hq : IsCoveringMap q) (hreg : IsRegular p)
+    (h : E ≃ₜ F) (hpq : ∀ e, q (h e) = p e) (e₁ e₂ : p ⁻¹' {b}) :
+    letI := fiberTorsor hp hreg b
+    letI := fiberTorsor hq (hreg.conj h hpq) b
+    (fiberMap h hpq b e₁ /ₛ fiberMap h hpq b e₂ : Deck q) =
+      conjMulEquiv h hpq (e₁ /ₛ e₂ : Deck p) := by
+  rw [fiber_sdiv_eq_deckEquivFiber_symm hq (hreg.conj h hpq),
+    fiber_sdiv_eq_deckEquivFiber_symm hp hreg]
+  exact deckEquivFiber_symm_fiberMap hp hq hreg h hpq e₂ e₁
 
 end Deck
 

--- a/TauCeti/AlgebraicTopology/UniversalCover/Deck/FiberTorsorTransport.lean
+++ b/TauCeti/AlgebraicTopology/UniversalCover/Deck/FiberTorsorTransport.lean
@@ -1,0 +1,150 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+module
+
+public import TauCeti.AlgebraicTopology.UniversalCover.Deck.RegularTorsor
+
+/-!
+# Transporting deck fibre torsors
+
+An over-base homeomorphism between two covers identifies their deck groups by conjugation
+and their corresponding fibres by `Deck.fiberMap`. This file records that these two
+identifications are compatible with the torsor structures on fibres.
+
+The main statement is first proved for the local situation of a preconnected covering whose
+chosen fibre has a free transitive deck action. The regular-cover wrappers then specialize
+it using `Deck.IsRegular`, which is the form used in the universal-covers roadmap when
+pointed covers are compared up to changing representatives over the same base.
+
+## Main declarations
+
+* `TauCeti.Deck.fiberMap_sdiv_eq_conjMulEquiv_of_pretransitive`: fibre transport carries
+  torsor division to conjugation of the corresponding deck transformation.
+* `TauCeti.Deck.regular_fiberMap_sdiv_eq_conjMulEquiv`: the regular-cover specialization.
+* `TauCeti.Deck.regular_deckEquivFiber_fiberMap`: transport is compatible with the
+  deck-to-fibre equivalence of a regular cover.
+
+## References
+
+This supplies a bookkeeping prerequisite for `TauCetiRoadmap/UniversalCovers/README.md`,
+Stage 2: the pointed and unpointed cover correspondences require changing the chosen lift in
+a fibre while transporting deck actions along isomorphisms of covers.
+-/
+
+public section
+
+namespace TauCeti
+
+namespace Deck
+
+variable {E F B : Type*} [TopologicalSpace E] [TopologicalSpace F] [TopologicalSpace B]
+  {p : E → B} {q : F → B} {b : B}
+
+/-- Fibre transport preserves torsor division, with the deck-group element transported by
+conjugation along the over-base homeomorphism.
+
+This is the local pretransitive-fibre form. The regular-cover API below supplies the
+nonemptiness and pretransitivity hypotheses from `Deck.IsRegular`. -/
+lemma fiberMap_sdiv_eq_conjMulEquiv_of_pretransitive [PreconnectedSpace E]
+    [PreconnectedSpace F] (hp : IsCoveringMap p) (hq : IsCoveringMap q)
+    [Nonempty (p ⁻¹' {b})] [MulAction.IsPretransitive (Deck p) (p ⁻¹' {b})]
+    [Nonempty (q ⁻¹' {b})] [MulAction.IsPretransitive (Deck q) (q ⁻¹' {b})]
+    (h : E ≃ₜ F) (hpq : ∀ e, q (h e) = p e) (e₁ e₂ : p ⁻¹' {b}) :
+    letI := fiberTorsorOfPretransitive hp b
+    letI := fiberTorsorOfPretransitive hq b
+    (fiberMap h hpq b e₁ /ₛ fiberMap h hpq b e₂ : Deck q) =
+      conjMulEquiv h hpq (e₁ /ₛ e₂ : Deck p) := by
+  letI := fiberTorsorOfPretransitive hp b
+  letI := fiberTorsorOfPretransitive hq b
+  rw [← deckEquivFiberOfSurjective_symm_eq_sdiv hq,
+    ← deckEquivFiberOfSurjective_symm_eq_sdiv hp]
+  apply eq_of_fiber_smul_eq_fiber_smul hq
+  calc
+    ((deckEquivFiberOfSurjective hq (fiberMap h hpq b e₂)
+          (MulAction.surjective_smul (Deck q) (fiberMap h hpq b e₂))).symm
+        (fiberMap h hpq b e₁)) • fiberMap h hpq b e₂ =
+        fiberMap h hpq b e₁ := by
+      exact deckEquivFiberOfSurjective_symm_smul hq (fiberMap h hpq b e₂)
+        (MulAction.surjective_smul (Deck q) (fiberMap h hpq b e₂))
+        (fiberMap h hpq b e₁)
+    _ = fiberMap h hpq b
+        (((deckEquivFiberOfSurjective hp e₂
+            (MulAction.surjective_smul (Deck p) e₂)).symm e₁) • e₂) := by
+      rw [deckEquivFiberOfSurjective_symm_smul]
+    _ = conjMulEquiv h hpq
+          ((deckEquivFiberOfSurjective hp e₂
+            (MulAction.surjective_smul (Deck p) e₂)).symm e₁) •
+        fiberMap h hpq b e₂ := by
+      rw [fiberMap_smul]
+
+/-- For regular preconnected covers, fibre transport preserves torsor division, with the
+deck transformation conjugated to the target deck group. -/
+lemma regular_fiberMap_sdiv_eq_conjMulEquiv [PreconnectedSpace E] [PreconnectedSpace F]
+    (hp : IsCoveringMap p) (hq : IsCoveringMap q) (hreg : IsRegular p)
+    (h : E ≃ₜ F) (hpq : ∀ e, q (h e) = p e) (e₁ e₂ : p ⁻¹' {b}) :
+    letI := fiberTorsor hp hreg b
+    letI := fiberTorsor hq (hreg.conj h hpq) b
+    (fiberMap h hpq b e₁ /ₛ fiberMap h hpq b e₂ : Deck q) =
+      conjMulEquiv h hpq (e₁ /ₛ e₂ : Deck p) := by
+  let hregq := hreg.conj h hpq
+  letI := hreg.nonempty_fiber b
+  letI := hreg.fiber_isPretransitive b
+  letI := hregq.nonempty_fiber b
+  letI := hregq.fiber_isPretransitive b
+  letI := fiberTorsor hp hreg b
+  letI := fiberTorsor hq hregq b
+  rw [← deckEquivFiber_symm_eq_sdiv hq hregq, ← deckEquivFiber_symm_eq_sdiv hp hreg]
+  apply eq_of_fiber_smul_eq_fiber_smul hq
+  calc
+    (deckEquivFiber hq hregq (fiberMap h hpq b e₂)).symm
+          (fiberMap h hpq b e₁) • fiberMap h hpq b e₂ =
+        fiberMap h hpq b e₁ := by
+      exact deckEquivFiber_symm_smul hq hregq (fiberMap h hpq b e₂) (fiberMap h hpq b e₁)
+    _ = fiberMap h hpq b ((deckEquivFiber hp hreg e₂).symm e₁ • e₂) := by
+      rw [deckEquivFiber_symm_smul]
+    _ = conjMulEquiv h hpq ((deckEquivFiber hp hreg e₂).symm e₁) •
+        fiberMap h hpq b e₂ := by
+      rw [fiberMap_smul]
+
+/-- The inverse of the regular deck-to-fibre equivalence is compatible with fibre transport:
+transport the target fibre point first, or compute the source deck transformation first and
+then conjugate it. -/
+lemma regular_deckEquivFiber_symm_fiberMap [PreconnectedSpace E] [PreconnectedSpace F]
+    (hp : IsCoveringMap p) (hq : IsCoveringMap q) (hreg : IsRegular p)
+    (h : E ≃ₜ F) (hpq : ∀ e, q (h e) = p e) (e e' : p ⁻¹' {b}) :
+    (deckEquivFiber hq (hreg.conj h hpq) (fiberMap h hpq b e)).symm
+        (fiberMap h hpq b e') =
+      conjMulEquiv h hpq ((deckEquivFiber hp hreg e).symm e') := by
+  let hregq := hreg.conj h hpq
+  letI := fiberTorsor hp hreg b
+  letI := fiberTorsor hq hregq b
+  rw [deckEquivFiber_symm_eq_sdiv hq hregq,
+    deckEquivFiber_symm_eq_sdiv hp hreg,
+    regular_fiberMap_sdiv_eq_conjMulEquiv hp hq hreg h hpq]
+
+/-- The regular deck-to-fibre equivalence commutes with transport of deck transformations
+and fibre points along an over-base homeomorphism. -/
+lemma regular_deckEquivFiber_fiberMap [PreconnectedSpace E] [PreconnectedSpace F]
+    (hp : IsCoveringMap p) (hq : IsCoveringMap q) (hreg : IsRegular p)
+    (h : E ≃ₜ F) (hpq : ∀ e, q (h e) = p e) (e : p ⁻¹' {b}) (φ : Deck p) :
+    deckEquivFiber hq (hreg.conj h hpq) (fiberMap h hpq b e) (conjMulEquiv h hpq φ) =
+      fiberMap h hpq b (deckEquivFiber hp hreg e φ) := by
+  rw [deckEquivFiber_apply, deckEquivFiber_apply, fiberMap_smul]
+
+/-- On underlying points, the compatibility of `deckEquivFiber` with fibre transport says
+that conjugating a deck transformation and then evaluating on the transported fibre point is
+the same as transporting the original evaluation. -/
+lemma regular_deckEquivFiber_fiberMap_coe [PreconnectedSpace E] [PreconnectedSpace F]
+    (hp : IsCoveringMap p) (hq : IsCoveringMap q) (hreg : IsRegular p)
+    (h : E ≃ₜ F) (hpq : ∀ e, q (h e) = p e) (e : p ⁻¹' {b}) (φ : Deck p) :
+    (deckEquivFiber hq (hreg.conj h hpq) (fiberMap h hpq b e)
+        (conjMulEquiv h hpq φ) : F) =
+      h (φ.1 e.1) := by
+  rw [regular_deckEquivFiber_fiberMap hp hq hreg h hpq e φ, fiberMap_apply_coe,
+    deckEquivFiber_apply_coe]
+
+end Deck
+
+end TauCeti

--- a/TauCeti/AlgebraicTopology/UniversalCover/Deck/FiberTorsorTransport.lean
+++ b/TauCeti/AlgebraicTopology/UniversalCover/Deck/FiberTorsorTransport.lean
@@ -65,6 +65,23 @@ lemma surjective_smul_fiberMap (h : E ≃ₜ F) (hpq : ∀ e, q (h e) = p e)
   obtain ⟨φ, rfl⟩ := hsurj e'
   exact ⟨conjMulEquiv h hpq φ, (fiberMap_smul h hpq φ e).symm⟩
 
+/-- The inverse of the local deck-to-fibre equivalence is compatible with fibre transport:
+transport the target fibre point first, or compute the source deck transformation first and
+then conjugate it. -/
+@[simp]
+lemma deckEquivFiberOfSurjective_symm_fiberMap [PreconnectedSpace E] [PreconnectedSpace F]
+    (hp : IsCoveringMap p) (hq : IsCoveringMap q) (h : E ≃ₜ F)
+    (hpq : ∀ e, q (h e) = p e) (e e' : p ⁻¹' {b})
+    (hsurj : Function.Surjective fun φ : Deck p => φ • e) :
+    (deckEquivFiberOfSurjective hq (fiberMap h hpq b e)
+          (surjective_smul_fiberMap h hpq e hsurj)).symm
+        (fiberMap h hpq b e') =
+      conjMulEquiv h hpq ((deckEquivFiberOfSurjective hp e hsurj).symm e') := by
+  apply (deckEquivFiberOfSurjective hq (fiberMap h hpq b e)
+    (surjective_smul_fiberMap h hpq e hsurj)).injective
+  rw [Equiv.apply_symm_apply, deckEquivFiberOfSurjective_apply, ← fiberMap_smul,
+    deckEquivFiberOfSurjective_symm_smul]
+
 /-- Fibre transport preserves torsor division, with the deck-group element transported by
 conjugation along the over-base homeomorphism.
 
@@ -87,41 +104,8 @@ lemma fiberMap_sdiv_eq_conjMulEquiv_of_pretransitive [PreconnectedSpace E]
   letI := fiberTorsorOfPretransitive hq b
   rw [← deckEquivFiberOfSurjective_symm_eq_sdiv hq,
     ← deckEquivFiberOfSurjective_symm_eq_sdiv hp]
-  apply eq_of_fiber_smul_eq_fiber_smul hq
-  calc
-    ((deckEquivFiberOfSurjective hq (fiberMap h hpq b e₂)
-          (MulAction.surjective_smul (Deck q) (fiberMap h hpq b e₂))).symm
-        (fiberMap h hpq b e₁)) • fiberMap h hpq b e₂ =
-        fiberMap h hpq b e₁ := by
-      exact deckEquivFiberOfSurjective_symm_smul hq (fiberMap h hpq b e₂)
-        (MulAction.surjective_smul (Deck q) (fiberMap h hpq b e₂))
-        (fiberMap h hpq b e₁)
-    _ = fiberMap h hpq b
-        (((deckEquivFiberOfSurjective hp e₂
-            (MulAction.surjective_smul (Deck p) e₂)).symm e₁) • e₂) := by
-      rw [deckEquivFiberOfSurjective_symm_smul]
-    _ = conjMulEquiv h hpq
-          ((deckEquivFiberOfSurjective hp e₂
-            (MulAction.surjective_smul (Deck p) e₂)).symm e₁) •
-        fiberMap h hpq b e₂ := by
-      rw [fiberMap_smul]
-
-/-- The inverse of the local deck-to-fibre equivalence is compatible with fibre transport:
-transport the target fibre point first, or compute the source deck transformation first and
-then conjugate it. -/
-@[simp]
-lemma deckEquivFiberOfSurjective_symm_fiberMap [PreconnectedSpace E] [PreconnectedSpace F]
-    (hp : IsCoveringMap p) (hq : IsCoveringMap q) (h : E ≃ₜ F)
-    (hpq : ∀ e, q (h e) = p e) (e e' : p ⁻¹' {b})
-    (hsurj : Function.Surjective fun φ : Deck p => φ • e) :
-    (deckEquivFiberOfSurjective hq (fiberMap h hpq b e)
-          (surjective_smul_fiberMap h hpq e hsurj)).symm
-        (fiberMap h hpq b e') =
-      conjMulEquiv h hpq ((deckEquivFiberOfSurjective hp e hsurj).symm e') := by
-  apply (deckEquivFiberOfSurjective hq (fiberMap h hpq b e)
-    (surjective_smul_fiberMap h hpq e hsurj)).injective
-  rw [Equiv.apply_symm_apply, deckEquivFiberOfSurjective_apply, ← fiberMap_smul,
-    deckEquivFiberOfSurjective_symm_smul]
+  exact deckEquivFiberOfSurjective_symm_fiberMap hp hq h hpq e₂ e₁
+    (MulAction.surjective_smul (Deck p) e₂)
 
 /-- The local deck-to-fibre equivalence commutes with transport of deck transformations
 and fibre points along an over-base homeomorphism. -/

--- a/TauCeti/AlgebraicTopology/UniversalCover/Deck/FiberTorsorTransport.lean
+++ b/TauCeti/AlgebraicTopology/UniversalCover/Deck/FiberTorsorTransport.lean
@@ -69,14 +69,16 @@ lemma surjective_smul_fiberMap (h : E ≃ₜ F) (hpq : ∀ e, q (h e) = p e)
 transport the target fibre point first, or compute the source deck transformation first and
 then conjugate it. -/
 @[simp]
-lemma deckEquivFiberOfSurjective_symm_fiberMap [PreconnectedSpace E] [PreconnectedSpace F]
+lemma deckEquivFiberOfSurjective_symm_fiberMap [PreconnectedSpace E]
     (hp : IsCoveringMap p) (hq : IsCoveringMap q) (h : E ≃ₜ F)
     (hpq : ∀ e, q (h e) = p e) (e e' : p ⁻¹' {b})
     (hsurj : Function.Surjective fun φ : Deck p => φ • e) :
+    letI : PreconnectedSpace F := h.surjective.denseRange.preconnectedSpace h.continuous
     (deckEquivFiberOfSurjective hq (fiberMap h hpq b e)
           (surjective_smul_fiberMap h hpq e hsurj)).symm
         (fiberMap h hpq b e') =
       conjMulEquiv h hpq ((deckEquivFiberOfSurjective hp e hsurj).symm e') := by
+  letI : PreconnectedSpace F := h.surjective.denseRange.preconnectedSpace h.continuous
   apply (deckEquivFiberOfSurjective hq (fiberMap h hpq b e)
     (surjective_smul_fiberMap h hpq e hsurj)).injective
   rw [Equiv.apply_symm_apply, deckEquivFiberOfSurjective_apply, ← fiberMap_smul,
@@ -89,15 +91,17 @@ This is the local pretransitive-fibre form. The regular-cover API below supplies
 nonemptiness and pretransitivity hypotheses from `Deck.IsRegular`. -/
 @[simp]
 lemma fiberMap_sdiv_eq_conjMulEquiv_of_pretransitive [PreconnectedSpace E]
-    [PreconnectedSpace F] (hp : IsCoveringMap p) (hq : IsCoveringMap q)
+    (hp : IsCoveringMap p) (hq : IsCoveringMap q)
     [Nonempty (p ⁻¹' {b})] [MulAction.IsPretransitive (Deck p) (p ⁻¹' {b})]
     (h : E ≃ₜ F) (hpq : ∀ e, q (h e) = p e) (e₁ e₂ : p ⁻¹' {b}) :
+    letI : PreconnectedSpace F := h.surjective.denseRange.preconnectedSpace h.continuous
     letI := fiberTorsorOfPretransitive hp b
     letI : Nonempty (q ⁻¹' {b}) := ‹Nonempty (p ⁻¹' {b})›.map (fiberMap h hpq b)
     letI : MulAction.IsPretransitive (Deck q) (q ⁻¹' {b}) := isPretransitive_fiberMap h hpq
     letI := fiberTorsorOfPretransitive hq b
     (fiberMap h hpq b e₁ /ₛ fiberMap h hpq b e₂ : Deck q) =
       conjMulEquiv h hpq (e₁ /ₛ e₂ : Deck p) := by
+  letI : PreconnectedSpace F := h.surjective.denseRange.preconnectedSpace h.continuous
   letI := fiberTorsorOfPretransitive hp b
   letI : Nonempty (q ⁻¹' {b}) := ‹Nonempty (p ⁻¹' {b})›.map (fiberMap h hpq b)
   letI : MulAction.IsPretransitive (Deck q) (q ⁻¹' {b}) := isPretransitive_fiberMap h hpq
@@ -110,26 +114,30 @@ lemma fiberMap_sdiv_eq_conjMulEquiv_of_pretransitive [PreconnectedSpace E]
 /-- The local deck-to-fibre equivalence commutes with transport of deck transformations
 and fibre points along an over-base homeomorphism. -/
 @[simp]
-lemma deckEquivFiberOfSurjective_fiberMap [PreconnectedSpace E] [PreconnectedSpace F]
+lemma deckEquivFiberOfSurjective_fiberMap [PreconnectedSpace E]
     (hp : IsCoveringMap p) (hq : IsCoveringMap q) (h : E ≃ₜ F)
     (hpq : ∀ e, q (h e) = p e) (e : p ⁻¹' {b})
     (hsurj : Function.Surjective fun φ : Deck p => φ • e) (φ : Deck p) :
+    letI : PreconnectedSpace F := h.surjective.denseRange.preconnectedSpace h.continuous
     deckEquivFiberOfSurjective hq (fiberMap h hpq b e)
         (surjective_smul_fiberMap h hpq e hsurj) (conjMulEquiv h hpq φ) =
       fiberMap h hpq b (deckEquivFiberOfSurjective hp e hsurj φ) := by
+  letI : PreconnectedSpace F := h.surjective.denseRange.preconnectedSpace h.continuous
   rw [deckEquivFiberOfSurjective_apply, deckEquivFiberOfSurjective_apply, fiberMap_smul]
 
 /-- On underlying points, local compatibility of `deckEquivFiberOfSurjective` with fibre
 transport says that conjugating a deck transformation and then evaluating on the transported
 fibre point is the same as transporting the original evaluation. -/
 @[simp]
-lemma deckEquivFiberOfSurjective_fiberMap_coe [PreconnectedSpace E] [PreconnectedSpace F]
+lemma deckEquivFiberOfSurjective_fiberMap_coe [PreconnectedSpace E]
     (hp : IsCoveringMap p) (hq : IsCoveringMap q) (h : E ≃ₜ F)
     (hpq : ∀ e, q (h e) = p e) (e : p ⁻¹' {b})
     (hsurj : Function.Surjective fun φ : Deck p => φ • e) (φ : Deck p) :
+    letI : PreconnectedSpace F := h.surjective.denseRange.preconnectedSpace h.continuous
     (deckEquivFiberOfSurjective hq (fiberMap h hpq b e)
         (surjective_smul_fiberMap h hpq e hsurj) (conjMulEquiv h hpq φ) : F) =
       h (φ.1 e.1) := by
+  letI : PreconnectedSpace F := h.surjective.denseRange.preconnectedSpace h.continuous
   rw [deckEquivFiberOfSurjective_fiberMap hp hq h hpq e hsurj φ,
     fiberMap_apply_coe, deckEquivFiberOfSurjective_apply_coe]
 
@@ -137,12 +145,14 @@ lemma deckEquivFiberOfSurjective_fiberMap_coe [PreconnectedSpace E] [Preconnecte
 transport the target fibre point first, or compute the source deck transformation first and
 then conjugate it. -/
 @[simp]
-lemma deckEquivFiber_symm_fiberMap [PreconnectedSpace E] [PreconnectedSpace F]
+lemma deckEquivFiber_symm_fiberMap [PreconnectedSpace E]
     (hp : IsCoveringMap p) (hq : IsCoveringMap q) (hreg : IsRegular p)
     (h : E ≃ₜ F) (hpq : ∀ e, q (h e) = p e) (e e' : p ⁻¹' {b}) :
+    letI : PreconnectedSpace F := h.surjective.denseRange.preconnectedSpace h.continuous
     (deckEquivFiber hq (hreg.conj h hpq) (fiberMap h hpq b e)).symm
         (fiberMap h hpq b e') =
       conjMulEquiv h hpq ((deckEquivFiber hp hreg e).symm e') := by
+  letI : PreconnectedSpace F := h.surjective.denseRange.preconnectedSpace h.continuous
   let hregq := hreg.conj h hpq
   letI := hreg.fiber_isPretransitive b
   letI := hregq.fiber_isPretransitive b
@@ -152,11 +162,13 @@ lemma deckEquivFiber_symm_fiberMap [PreconnectedSpace E] [PreconnectedSpace F]
 /-- The regular deck-to-fibre equivalence commutes with transport of deck transformations
 and fibre points along an over-base homeomorphism. -/
 @[simp]
-lemma deckEquivFiber_fiberMap [PreconnectedSpace E] [PreconnectedSpace F]
+lemma deckEquivFiber_fiberMap [PreconnectedSpace E]
     (hp : IsCoveringMap p) (hq : IsCoveringMap q) (hreg : IsRegular p)
     (h : E ≃ₜ F) (hpq : ∀ e, q (h e) = p e) (e : p ⁻¹' {b}) (φ : Deck p) :
+    letI : PreconnectedSpace F := h.surjective.denseRange.preconnectedSpace h.continuous
     deckEquivFiber hq (hreg.conj h hpq) (fiberMap h hpq b e) (conjMulEquiv h hpq φ) =
       fiberMap h hpq b (deckEquivFiber hp hreg e φ) := by
+  letI : PreconnectedSpace F := h.surjective.denseRange.preconnectedSpace h.continuous
   let hregq := hreg.conj h hpq
   letI := hreg.fiber_isPretransitive b
   letI := hregq.fiber_isPretransitive b
@@ -167,25 +179,29 @@ lemma deckEquivFiber_fiberMap [PreconnectedSpace E] [PreconnectedSpace F]
 that conjugating a deck transformation and then evaluating on the transported fibre point is
 the same as transporting the original evaluation. -/
 @[simp]
-lemma deckEquivFiber_fiberMap_coe [PreconnectedSpace E] [PreconnectedSpace F]
+lemma deckEquivFiber_fiberMap_coe [PreconnectedSpace E]
     (hp : IsCoveringMap p) (hq : IsCoveringMap q) (hreg : IsRegular p)
     (h : E ≃ₜ F) (hpq : ∀ e, q (h e) = p e) (e : p ⁻¹' {b}) (φ : Deck p) :
+    letI : PreconnectedSpace F := h.surjective.denseRange.preconnectedSpace h.continuous
     (deckEquivFiber hq (hreg.conj h hpq) (fiberMap h hpq b e)
         (conjMulEquiv h hpq φ) : F) =
       h (φ.1 e.1) := by
+  letI : PreconnectedSpace F := h.surjective.denseRange.preconnectedSpace h.continuous
   rw [deckEquivFiber_fiberMap hp hq hreg h hpq e φ, fiberMap_apply_coe,
     deckEquivFiber_apply_coe]
 
 /-- For regular preconnected covers, fibre transport preserves torsor division, with the
 deck transformation conjugated to the target deck group. -/
 @[simp]
-lemma fiberMap_sdiv_eq_conjMulEquiv [PreconnectedSpace E] [PreconnectedSpace F]
+lemma fiberMap_sdiv_eq_conjMulEquiv [PreconnectedSpace E]
     (hp : IsCoveringMap p) (hq : IsCoveringMap q) (hreg : IsRegular p)
     (h : E ≃ₜ F) (hpq : ∀ e, q (h e) = p e) (e₁ e₂ : p ⁻¹' {b}) :
+    letI : PreconnectedSpace F := h.surjective.denseRange.preconnectedSpace h.continuous
     letI := fiberTorsor hp hreg b
     letI := fiberTorsor hq (hreg.conj h hpq) b
     (fiberMap h hpq b e₁ /ₛ fiberMap h hpq b e₂ : Deck q) =
       conjMulEquiv h hpq (e₁ /ₛ e₂ : Deck p) := by
+  letI : PreconnectedSpace F := h.surjective.denseRange.preconnectedSpace h.continuous
   rw [fiber_sdiv_eq_deckEquivFiber_symm hq (hreg.conj h hpq),
     fiber_sdiv_eq_deckEquivFiber_symm hp hreg]
   exact deckEquivFiber_symm_fiberMap hp hq hreg h hpq e₂ e₁

--- a/TauCeti/AlgebraicTopology/UniversalCover/Deck/FiberTorsorTransport.lean
+++ b/TauCeti/AlgebraicTopology/UniversalCover/Deck/FiberTorsorTransport.lean
@@ -22,8 +22,8 @@ pointed covers are compared up to changing representatives over the same base.
 
 * `TauCeti.Deck.fiberMap_sdiv_eq_conjMulEquiv_of_pretransitive`: fibre transport carries
   torsor division to conjugation of the corresponding deck transformation.
-* `TauCeti.Deck.regular_fiberMap_sdiv_eq_conjMulEquiv`: the regular-cover specialization.
-* `TauCeti.Deck.regular_deckEquivFiber_fiberMap`: transport is compatible with the
+* `TauCeti.Deck.fiberMap_sdiv_eq_conjMulEquiv`: the regular-cover specialization.
+* `TauCeti.Deck.deckEquivFiber_fiberMap`: transport is compatible with the
   deck-to-fibre equivalence of a regular cover.
 
 ## References
@@ -47,6 +47,7 @@ conjugation along the over-base homeomorphism.
 
 This is the local pretransitive-fibre form. The regular-cover API below supplies the
 nonemptiness and pretransitivity hypotheses from `Deck.IsRegular`. -/
+@[simp]
 lemma fiberMap_sdiv_eq_conjMulEquiv_of_pretransitive [PreconnectedSpace E]
     [PreconnectedSpace F] (hp : IsCoveringMap p) (hq : IsCoveringMap q)
     [Nonempty (p ⁻¹' {b})] [MulAction.IsPretransitive (Deck p) (p ⁻¹' {b})]
@@ -81,7 +82,8 @@ lemma fiberMap_sdiv_eq_conjMulEquiv_of_pretransitive [PreconnectedSpace E]
 
 /-- For regular preconnected covers, fibre transport preserves torsor division, with the
 deck transformation conjugated to the target deck group. -/
-lemma regular_fiberMap_sdiv_eq_conjMulEquiv [PreconnectedSpace E] [PreconnectedSpace F]
+@[simp]
+lemma fiberMap_sdiv_eq_conjMulEquiv [PreconnectedSpace E] [PreconnectedSpace F]
     (hp : IsCoveringMap p) (hq : IsCoveringMap q) (hreg : IsRegular p)
     (h : E ≃ₜ F) (hpq : ∀ e, q (h e) = p e) (e₁ e₂ : p ⁻¹' {b}) :
     letI := fiberTorsor hp hreg b
@@ -93,56 +95,94 @@ lemma regular_fiberMap_sdiv_eq_conjMulEquiv [PreconnectedSpace E] [PreconnectedS
   letI := hreg.fiber_isPretransitive b
   letI := hregq.nonempty_fiber b
   letI := hregq.fiber_isPretransitive b
-  letI := fiberTorsor hp hreg b
-  letI := fiberTorsor hq hregq b
-  rw [← deckEquivFiber_symm_eq_sdiv hq hregq, ← deckEquivFiber_symm_eq_sdiv hp hreg]
-  apply eq_of_fiber_smul_eq_fiber_smul hq
-  calc
-    (deckEquivFiber hq hregq (fiberMap h hpq b e₂)).symm
-          (fiberMap h hpq b e₁) • fiberMap h hpq b e₂ =
-        fiberMap h hpq b e₁ := by
-      exact deckEquivFiber_symm_smul hq hregq (fiberMap h hpq b e₂) (fiberMap h hpq b e₁)
-    _ = fiberMap h hpq b ((deckEquivFiber hp hreg e₂).symm e₁ • e₂) := by
-      rw [deckEquivFiber_symm_smul]
-    _ = conjMulEquiv h hpq ((deckEquivFiber hp hreg e₂).symm e₁) •
-        fiberMap h hpq b e₂ := by
-      rw [fiberMap_smul]
+  exact fiberMap_sdiv_eq_conjMulEquiv_of_pretransitive hp hq h hpq e₁ e₂
+
+/-- The inverse of the local deck-to-fibre equivalence is compatible with fibre transport:
+transport the target fibre point first, or compute the source deck transformation first and
+then conjugate it. -/
+@[simp]
+lemma deckEquivFiberOfSurjective_symm_fiberMap [PreconnectedSpace E] [PreconnectedSpace F]
+    (hp : IsCoveringMap p) (hq : IsCoveringMap q) (h : E ≃ₜ F)
+    (hpq : ∀ e, q (h e) = p e) (e e' : p ⁻¹' {b})
+    (hsurj : Function.Surjective fun φ : Deck p => φ • e)
+    (hsurjq : Function.Surjective fun ψ : Deck q => ψ • fiberMap h hpq b e) :
+    (deckEquivFiberOfSurjective hq (fiberMap h hpq b e) hsurjq).symm
+        (fiberMap h hpq b e') =
+      conjMulEquiv h hpq ((deckEquivFiberOfSurjective hp e hsurj).symm e') := by
+  apply (deckEquivFiberOfSurjective hq (fiberMap h hpq b e) hsurjq).injective
+  rw [Equiv.apply_symm_apply, deckEquivFiberOfSurjective_apply, ← fiberMap_smul,
+    deckEquivFiberOfSurjective_symm_smul]
+
+/-- The local deck-to-fibre equivalence commutes with transport of deck transformations
+and fibre points along an over-base homeomorphism. -/
+@[simp]
+lemma deckEquivFiberOfSurjective_fiberMap [PreconnectedSpace E] [PreconnectedSpace F]
+    (hp : IsCoveringMap p) (hq : IsCoveringMap q) (h : E ≃ₜ F)
+    (hpq : ∀ e, q (h e) = p e) (e : p ⁻¹' {b})
+    (hsurj : Function.Surjective fun φ : Deck p => φ • e)
+    (hsurjq : Function.Surjective fun ψ : Deck q => ψ • fiberMap h hpq b e) (φ : Deck p) :
+    deckEquivFiberOfSurjective hq (fiberMap h hpq b e) hsurjq (conjMulEquiv h hpq φ) =
+      fiberMap h hpq b (deckEquivFiberOfSurjective hp e hsurj φ) := by
+  rw [deckEquivFiberOfSurjective_apply, deckEquivFiberOfSurjective_apply, fiberMap_smul]
+
+/-- On underlying points, local compatibility of `deckEquivFiberOfSurjective` with fibre
+transport says that conjugating a deck transformation and then evaluating on the transported
+fibre point is the same as transporting the original evaluation. -/
+@[simp]
+lemma deckEquivFiberOfSurjective_fiberMap_coe [PreconnectedSpace E] [PreconnectedSpace F]
+    (hp : IsCoveringMap p) (hq : IsCoveringMap q) (h : E ≃ₜ F)
+    (hpq : ∀ e, q (h e) = p e) (e : p ⁻¹' {b})
+    (hsurj : Function.Surjective fun φ : Deck p => φ • e)
+    (hsurjq : Function.Surjective fun ψ : Deck q => ψ • fiberMap h hpq b e) (φ : Deck p) :
+    (deckEquivFiberOfSurjective hq (fiberMap h hpq b e) hsurjq
+        (conjMulEquiv h hpq φ) : F) =
+      h (φ.1 e.1) := by
+  rw [deckEquivFiberOfSurjective_fiberMap hp hq h hpq e hsurj hsurjq φ,
+    fiberMap_apply_coe, deckEquivFiberOfSurjective_apply_coe]
 
 /-- The inverse of the regular deck-to-fibre equivalence is compatible with fibre transport:
 transport the target fibre point first, or compute the source deck transformation first and
 then conjugate it. -/
-lemma regular_deckEquivFiber_symm_fiberMap [PreconnectedSpace E] [PreconnectedSpace F]
+@[simp]
+lemma deckEquivFiber_symm_fiberMap [PreconnectedSpace E] [PreconnectedSpace F]
     (hp : IsCoveringMap p) (hq : IsCoveringMap q) (hreg : IsRegular p)
     (h : E ≃ₜ F) (hpq : ∀ e, q (h e) = p e) (e e' : p ⁻¹' {b}) :
     (deckEquivFiber hq (hreg.conj h hpq) (fiberMap h hpq b e)).symm
         (fiberMap h hpq b e') =
       conjMulEquiv h hpq ((deckEquivFiber hp hreg e).symm e') := by
   let hregq := hreg.conj h hpq
-  letI := fiberTorsor hp hreg b
-  letI := fiberTorsor hq hregq b
-  rw [deckEquivFiber_symm_eq_sdiv hq hregq,
-    deckEquivFiber_symm_eq_sdiv hp hreg,
-    regular_fiberMap_sdiv_eq_conjMulEquiv hp hq hreg h hpq]
+  letI := hreg.fiber_isPretransitive b
+  letI := hregq.fiber_isPretransitive b
+  exact deckEquivFiberOfSurjective_symm_fiberMap hp hq h hpq e e'
+    (MulAction.surjective_smul (Deck p) e)
+    (MulAction.surjective_smul (Deck q) (fiberMap h hpq b e))
 
 /-- The regular deck-to-fibre equivalence commutes with transport of deck transformations
 and fibre points along an over-base homeomorphism. -/
-lemma regular_deckEquivFiber_fiberMap [PreconnectedSpace E] [PreconnectedSpace F]
+@[simp]
+lemma deckEquivFiber_fiberMap [PreconnectedSpace E] [PreconnectedSpace F]
     (hp : IsCoveringMap p) (hq : IsCoveringMap q) (hreg : IsRegular p)
     (h : E ≃ₜ F) (hpq : ∀ e, q (h e) = p e) (e : p ⁻¹' {b}) (φ : Deck p) :
     deckEquivFiber hq (hreg.conj h hpq) (fiberMap h hpq b e) (conjMulEquiv h hpq φ) =
       fiberMap h hpq b (deckEquivFiber hp hreg e φ) := by
-  rw [deckEquivFiber_apply, deckEquivFiber_apply, fiberMap_smul]
+  let hregq := hreg.conj h hpq
+  letI := hreg.fiber_isPretransitive b
+  letI := hregq.fiber_isPretransitive b
+  exact deckEquivFiberOfSurjective_fiberMap hp hq h hpq e
+    (MulAction.surjective_smul (Deck p) e)
+    (MulAction.surjective_smul (Deck q) (fiberMap h hpq b e)) φ
 
 /-- On underlying points, the compatibility of `deckEquivFiber` with fibre transport says
 that conjugating a deck transformation and then evaluating on the transported fibre point is
 the same as transporting the original evaluation. -/
-lemma regular_deckEquivFiber_fiberMap_coe [PreconnectedSpace E] [PreconnectedSpace F]
+@[simp]
+lemma deckEquivFiber_fiberMap_coe [PreconnectedSpace E] [PreconnectedSpace F]
     (hp : IsCoveringMap p) (hq : IsCoveringMap q) (hreg : IsRegular p)
     (h : E ≃ₜ F) (hpq : ∀ e, q (h e) = p e) (e : p ⁻¹' {b}) (φ : Deck p) :
     (deckEquivFiber hq (hreg.conj h hpq) (fiberMap h hpq b e)
         (conjMulEquiv h hpq φ) : F) =
       h (φ.1 e.1) := by
-  rw [regular_deckEquivFiber_fiberMap hp hq hreg h hpq e φ, fiberMap_apply_coe,
+  rw [deckEquivFiber_fiberMap hp hq hreg h hpq e φ, fiberMap_apply_coe,
     deckEquivFiber_apply_coe]
 
 end Deck

--- a/TauCeti/AlgebraicTopology/UniversalCover/Deck/RegularTorsor.lean
+++ b/TauCeti/AlgebraicTopology/UniversalCover/Deck/RegularTorsor.lean
@@ -41,7 +41,7 @@ namespace Deck
 variable {E B : Type*} [TopologicalSpace E] [TopologicalSpace B] {p : E → B} {b : B}
 
 /-- The fibre of a regular preconnected covering is a torsor for its deck group. -/
-@[reducible, expose]
+@[reducible]
 noncomputable def fiberTorsor [PreconnectedSpace E]
     (hp : IsCoveringMap p) (hreg : IsRegular p) (b : B) :
     Torsor (Deck p) (p ⁻¹' {b}) := by

--- a/TauCeti/AlgebraicTopology/UniversalCover/Deck/RegularTorsor.lean
+++ b/TauCeti/AlgebraicTopology/UniversalCover/Deck/RegularTorsor.lean
@@ -41,7 +41,7 @@ namespace Deck
 variable {E B : Type*} [TopologicalSpace E] [TopologicalSpace B] {p : E → B} {b : B}
 
 /-- The fibre of a regular preconnected covering is a torsor for its deck group. -/
-@[reducible]
+@[reducible, expose]
 noncomputable def fiberTorsor [PreconnectedSpace E]
     (hp : IsCoveringMap p) (hreg : IsRegular p) (b : B) :
     Torsor (Deck p) (p ⁻¹' {b}) := by


### PR DESCRIPTION
This PR adds transport bookkeeping for regular-cover fibre torsors: an over-base homeomorphism carries torsor division in a source fibre to torsor division in the target fibre after conjugating the corresponding deck transformation, and the regular `deckEquivFiber` equivalence commutes with the same transport.

It advances `TauCetiRoadmap/UniversalCovers/README.md`, Stage 2, item 8, specifically the pointed/unpointed connected-cover bookkeeping around regular covers, where “regular covers are characterized by transitivity of the deck action on fibres” and the cover correspondence must track how chosen lifts vary under cover isomorphisms. I chose this as the lowest-hanging distinct UniversalCovers prerequisite after checking open and recently merged PRs: recent work already covers normal-subgroup fibre quotients, subgroup fibre-orbit quotients, regular torsors, and normalizer quotient comparisons, while the torsor-transport compatibility needed to move those fibre calculations across isomorphic cover representatives was still absent.

No Mathlib infrastructure is vendored. The implementation reuses Tau Ceti’s existing `Deck.conjMulEquiv`, `Deck.fiberMap`, `Deck.fiberTorsor`, `Deck.deckEquivFiber`, and connected-cover freeness API, plus Mathlib’s torsor division API from `Mathlib.Algebra.Torsor.Basic`.

`lake exe cache get` completed with `No files to download` and `Already decompressed 8602 file(s)`. `lake build` completed with `Build completed successfully (4325 jobs).` `lake exe axioms` completed with `axioms: audited 6334 TauCeti declaration(s); all within the allowlist [propext, Classical.choice, Quot.sound].`

<!--tauceti-target:v1 {"focus":"UniversalCovers","id":"regular-fiber-torsor-transport"}-->

🤖 Prepared with Codex
