### PR TITLE
feat: add Abel-Jacobi finite divisor sums

### DIFF
--- a/TauCeti/AlgebraicGeometry/WeilDivisor/AbelJacobiFiniteSum.lean
+++ b/TauCeti/AlgebraicGeometry/WeilDivisor/AbelJacobiFiniteSum.lean
@@ -49,6 +49,7 @@ variable (S : OrderSystem X G)
 
 /-- The weighted Abel-Jacobi sum of a divisor from finitely supported natural multiplicities is
 the finite sum of the point Abel-Jacobi classes with those multiplicities. -/
+@[simp]
 lemma weightedAbelJacobiDivisorClass_ofFinsupp (w : X → ℤ) (h : S.IsWeightedDegreeZero w)
     {x₀ : X} (hx₀ : w x₀ = 1) (m : X →₀ ℕ) :
     S.weightedAbelJacobiDivisorClass w h hx₀ (ofFinsupp m) =
@@ -59,6 +60,7 @@ lemma weightedAbelJacobiDivisorClass_ofFinsupp (w : X → ℤ) (h : S.IsWeighted
 
 /-- The weighted Abel-Jacobi sum of a finite-set divisor with multiplicities is the finite sum
 of the point Abel-Jacobi classes with those multiplicities. -/
+@[simp]
 lemma weightedAbelJacobiDivisorClass_ofFinsetWithMultiplicity (w : X → ℤ)
     (h : S.IsWeightedDegreeZero w) {x₀ : X} (hx₀ : w x₀ = 1) (s : Finset X)
     (m : X → ℕ) :
@@ -70,6 +72,7 @@ lemma weightedAbelJacobiDivisorClass_ofFinsetWithMultiplicity (w : X → ℤ)
 
 /-- The weighted Abel-Jacobi sum of a coefficient-one finite-set divisor is the sum of the
 point Abel-Jacobi classes over the finite set. -/
+@[simp]
 lemma weightedAbelJacobiDivisorClass_ofFinset (w : X → ℤ) (h : S.IsWeightedDegreeZero w)
     {x₀ : X} (hx₀ : w x₀ = 1) (s : Finset X) :
     S.weightedAbelJacobiDivisorClass w h hx₀ (ofFinset s) =
@@ -82,6 +85,7 @@ lemma weightedAbelJacobiDivisorClass_ofFinset (w : X → ℤ) (h : S.IsWeightedD
 
 /-- The unweighted Abel-Jacobi sum of a divisor from finitely supported natural multiplicities is
 the finite sum of the point Abel-Jacobi classes with those multiplicities. -/
+@[simp]
 lemma unweightedAbelJacobiDivisorClass_ofFinsupp (h : S.IsUnweightedDegreeZero)
     (x₀ : X) (m : X →₀ ℕ) :
     S.unweightedAbelJacobiDivisorClass h x₀ (ofFinsupp m) =
@@ -92,6 +96,7 @@ lemma unweightedAbelJacobiDivisorClass_ofFinsupp (h : S.IsUnweightedDegreeZero)
 
 /-- The unweighted Abel-Jacobi sum of a finite-set divisor with multiplicities is the finite sum
 of the point Abel-Jacobi classes with those multiplicities. -/
+@[simp]
 lemma unweightedAbelJacobiDivisorClass_ofFinsetWithMultiplicity
     (h : S.IsUnweightedDegreeZero) (x₀ : X) (s : Finset X) (m : X → ℕ) :
     S.unweightedAbelJacobiDivisorClass h x₀ (ofFinsetWithMultiplicity s m) =
@@ -102,6 +107,7 @@ lemma unweightedAbelJacobiDivisorClass_ofFinsetWithMultiplicity
 
 /-- The unweighted Abel-Jacobi sum of a coefficient-one finite-set divisor is the sum of the
 point Abel-Jacobi classes over the finite set. -/
+@[simp]
 lemma unweightedAbelJacobiDivisorClass_ofFinset (h : S.IsUnweightedDegreeZero)
     (x₀ : X) (s : Finset X) :
     S.unweightedAbelJacobiDivisorClass h x₀ (ofFinset s) =

--- a/TauCeti/AlgebraicGeometry/WeilDivisor/AbelJacobiFiniteSum.lean
+++ b/TauCeti/AlgebraicGeometry/WeilDivisor/AbelJacobiFiniteSum.lean
@@ -1,0 +1,119 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+module
+
+public import TauCeti.AlgebraicGeometry.WeilDivisor.AbelJacobiSum
+public import TauCeti.AlgebraicGeometry.WeilDivisor.FiniteSum
+
+/-!
+# Abel-Jacobi sums of finite effective divisors
+
+This file connects the formal finite effective divisor constructors from
+`TauCeti.AlgebraicGeometry.WeilDivisor.FiniteSum` with the divisor-level Abel-Jacobi sum from
+`TauCeti.AlgebraicGeometry.WeilDivisor.AbelJacobiSum`.
+
+For an order system whose principal divisors have weighted degree zero and a weight-one base
+point `x₀`, the Abel-Jacobi sum of a finite effective divisor is the corresponding finite sum
+of point Abel-Jacobi classes:
+
+`AJ(Σ nₓ[x]) = Σ nₓ • AJ(x)`.
+
+The same statements are provided for finitely supported multiplicities, for a finite set with
+external multiplicity function, and for the coefficient-one divisor attached to a finite set.
+These are the formal divisor-class normal forms used by the later symmetric-power Abel maps
+`D ↦ 𝒪_X(D - d·x₀)` in the Jacobian roadmap.
+
+This advances `TauCetiRoadmap/JacobianChallenge/README.md`, Layer A, "`Pic⁰ X = ker deg` (as
+an abstract group)", and supplies a direct prerequisite for the Layer C/D Abel-map lane from
+symmetric powers. No external mathematics is vendored; the proofs reuse Tau Ceti's existing
+finite divisor constructors and Abel-Jacobi homomorphism API.
+-/
+
+public section
+
+namespace TauCeti
+
+namespace AlgebraicGeometry
+
+namespace WeilDivisor
+
+variable {X G : Type*} [AddCommGroup G]
+
+namespace OrderSystem
+
+variable (S : OrderSystem X G)
+
+/-! ### Weighted finite effective divisors -/
+
+/-- The weighted Abel-Jacobi sum of a divisor from finitely supported natural multiplicities is
+the finite sum of the point Abel-Jacobi classes with those multiplicities. -/
+lemma weightedAbelJacobiDivisorClass_ofFinsupp (w : X → ℤ) (h : S.IsWeightedDegreeZero w)
+    {x₀ : X} (hx₀ : w x₀ = 1) (m : X →₀ ℕ) :
+    S.weightedAbelJacobiDivisorClass w h hx₀ (ofFinsupp m) =
+      ∑ x ∈ m.support, (m x : ℤ) • S.weightedAbelJacobiClass w h hx₀ x := by
+  rw [ofFinsupp_eq_sum, map_sum]
+  refine Finset.sum_congr rfl fun x hx => ?_
+  rw [map_zsmul, S.weightedAbelJacobiDivisorClass_ofPoint w h hx₀ x]
+
+/-- The weighted Abel-Jacobi sum of a finite-set divisor with multiplicities is the finite sum
+of the point Abel-Jacobi classes with those multiplicities. -/
+lemma weightedAbelJacobiDivisorClass_ofFinsetWithMultiplicity (w : X → ℤ)
+    (h : S.IsWeightedDegreeZero w) {x₀ : X} (hx₀ : w x₀ = 1) (s : Finset X)
+    (m : X → ℕ) :
+    S.weightedAbelJacobiDivisorClass w h hx₀ (ofFinsetWithMultiplicity s m) =
+      ∑ x ∈ s, (m x : ℤ) • S.weightedAbelJacobiClass w h hx₀ x := by
+  rw [ofFinsetWithMultiplicity_eq_sum, map_sum]
+  refine Finset.sum_congr rfl fun x hx => ?_
+  rw [map_zsmul, S.weightedAbelJacobiDivisorClass_ofPoint w h hx₀ x]
+
+/-- The weighted Abel-Jacobi sum of a coefficient-one finite-set divisor is the sum of the
+point Abel-Jacobi classes over the finite set. -/
+lemma weightedAbelJacobiDivisorClass_ofFinset (w : X → ℤ) (h : S.IsWeightedDegreeZero w)
+    {x₀ : X} (hx₀ : w x₀ = 1) (s : Finset X) :
+    S.weightedAbelJacobiDivisorClass w h hx₀ (ofFinset s) =
+      ∑ x ∈ s, S.weightedAbelJacobiClass w h hx₀ x := by
+  rw [ofFinset_eq_sum, map_sum]
+  refine Finset.sum_congr rfl fun x hx => ?_
+  rw [S.weightedAbelJacobiDivisorClass_ofPoint w h hx₀ x]
+
+/-! ### Unweighted finite effective divisors -/
+
+/-- The unweighted Abel-Jacobi sum of a divisor from finitely supported natural multiplicities is
+the finite sum of the point Abel-Jacobi classes with those multiplicities. -/
+lemma unweightedAbelJacobiDivisorClass_ofFinsupp (h : S.IsUnweightedDegreeZero)
+    (x₀ : X) (m : X →₀ ℕ) :
+    S.unweightedAbelJacobiDivisorClass h x₀ (ofFinsupp m) =
+      ∑ x ∈ m.support, (m x : ℤ) • S.unweightedAbelJacobiClass h x₀ x := by
+  rw [ofFinsupp_eq_sum, map_sum]
+  refine Finset.sum_congr rfl fun x hx => ?_
+  rw [map_zsmul, S.unweightedAbelJacobiDivisorClass_ofPoint h x₀ x]
+
+/-- The unweighted Abel-Jacobi sum of a finite-set divisor with multiplicities is the finite sum
+of the point Abel-Jacobi classes with those multiplicities. -/
+lemma unweightedAbelJacobiDivisorClass_ofFinsetWithMultiplicity
+    (h : S.IsUnweightedDegreeZero) (x₀ : X) (s : Finset X) (m : X → ℕ) :
+    S.unweightedAbelJacobiDivisorClass h x₀ (ofFinsetWithMultiplicity s m) =
+      ∑ x ∈ s, (m x : ℤ) • S.unweightedAbelJacobiClass h x₀ x := by
+  rw [ofFinsetWithMultiplicity_eq_sum, map_sum]
+  refine Finset.sum_congr rfl fun x hx => ?_
+  rw [map_zsmul, S.unweightedAbelJacobiDivisorClass_ofPoint h x₀ x]
+
+/-- The unweighted Abel-Jacobi sum of a coefficient-one finite-set divisor is the sum of the
+point Abel-Jacobi classes over the finite set. -/
+lemma unweightedAbelJacobiDivisorClass_ofFinset (h : S.IsUnweightedDegreeZero)
+    (x₀ : X) (s : Finset X) :
+    S.unweightedAbelJacobiDivisorClass h x₀ (ofFinset s) =
+      ∑ x ∈ s, S.unweightedAbelJacobiClass h x₀ x := by
+  rw [ofFinset_eq_sum, map_sum]
+  refine Finset.sum_congr rfl fun x hx => ?_
+  rw [S.unweightedAbelJacobiDivisorClass_ofPoint h x₀ x]
+
+end OrderSystem
+
+end WeilDivisor
+
+end AlgebraicGeometry
+
+end TauCeti


### PR DESCRIPTION
This PR adds finite effective divisor normal forms for the formal Abel-Jacobi divisor sum: the Abel-Jacobi sum of `ofFinsupp`, `ofFinsetWithMultiplicity`, and `ofFinset` is the corresponding finite sum of point Abel-Jacobi classes, in both the weighted and unweighted divisor-class APIs.

It advances `TauCetiRoadmap/JacobianChallenge/README.md`, Layer A, specifically "`Pic⁰ X = ker deg` (as an abstract group)" and supplies a direct prerequisite for the Layer C/D Abel-map lane `D ↦ 𝒪_X(D - d·x₀)` from symmetric powers. I chose this as the lowest-hanging distinct JacobianChallenge prerequisite after checking open and recently merged PRs: the abstract Weil divisor group, principal divisors, `Pic⁰` quotient, degree splitting, finite effective divisor constructors, Abel-Jacobi point and divisor-sum APIs, and basepoint-change bookkeeping already exist on `main`, while the named finite-effective-divisor Abel-Jacobi formulas consumed by symmetric-power inputs were still absent.

No Mathlib infrastructure is vendored. The implementation reuses Tau Ceti's existing `ofFinsupp`, `ofFinsetWithMultiplicity`, `ofFinset`, `weightedAbelJacobiDivisorClass`, `unweightedAbelJacobiDivisorClass`, and point Abel-Jacobi APIs, plus Mathlib's additive homomorphism `map_sum` and `map_zsmul` lemmas.

`lake exe cache get` completed with `No files to download` and `Already decompressed 8602 file(s)`. `lake build` completed with `Build completed successfully (4342 jobs).` `lake exe axioms` completed with `axioms: audited 6378 TauCeti declaration(s); all within the allowlist [propext, Classical.choice, Quot.sound].`

<!--tauceti-target:v1 {"focus":"JacobianChallenge","id":"abel-jacobi-finite-divisors"}-->

🤖 Prepared with Codex
