### PR TITLE
feat: add the rectangle / indicator-product bridge for finite block laws

### DIFF
--- a/TauCeti/Probability/DeFinetti/Rectangles.lean
+++ b/TauCeti/Probability/DeFinetti/Rectangles.lean
@@ -1,0 +1,88 @@
+module
+
+public import TauCeti.Probability.Exchangeability.Basic
+public import Mathlib.MeasureTheory.Integral.Lebesgue.Basic
+
+/-!
+# Rectangle / indicator-product bridge for finite block laws
+
+The de-Finetti-facing bridge between a process's finite-dimensional **block law**, measurable
+**rectangles** `Set.univ.pi B`, and products of coordinate **indicators**:
+
+* `blockLaw_apply_rectangle` — `blockLaw μ X k` on a rectangle is the measure of the coordinate-wise
+  preimage `{ω | ∀ i, X (k i) ω ∈ B i}`.
+* `indicator_product_eq_indicator_rectangle_preimage` — the product of the coordinate indicators is
+  the indicator of that preimage.
+* `lintegral_indicator_product_eq_blockLaw_rectangle` — the integral of the indicator product is the
+  block law on the rectangle; the form the de Finetti common ending consumes.
+
+Everything is concrete over `Fin m`; Mathlib's product/π-system infrastructure supplies the rest.
+The indicator product is `ℝ≥0∞`-valued to line up with the product-kernel mixture
+(`TauCeti.MeasureTheory.bind_probabilityMeasure_pi_const_pi`).
+
+These bridge lemmas are motivated by the private `prod_indicators_eq_indicator_intersection` /
+`measure_via_indicator_integral` helpers of `cameronfreer/exchangeability`
+(`DeFinetti/CommonEnding.lean`, pin `e0532e59ceff23edab44dda9ab0655debbc9cc22`).
+-/
+
+public section
+
+noncomputable section
+
+open MeasureTheory Set
+
+open scoped ENNReal
+
+namespace TauCeti
+
+namespace Probability
+
+variable {Ω α : Type*} [MeasurableSpace Ω] [MeasurableSpace α]
+  {μ : Measure Ω} {X : ℕ → Ω → α} {m : ℕ}
+
+/-- The block law of `X` along `k`, evaluated on a measurable rectangle `Set.univ.pi B`, is the
+measure of the coordinate-wise preimage `{ω | ∀ i, X (k i) ω ∈ B i}`. -/
+theorem blockLaw_apply_rectangle (k : Fin m → ℕ) (hXk : ∀ i, AEMeasurable (X (k i)) μ)
+    (B : Fin m → Set α) (hB : ∀ i, MeasurableSet (B i)) :
+    blockLaw μ X k (Set.univ.pi B) = μ {ω | ∀ i, X (k i) ω ∈ B i} := by
+  rw [blockLaw_apply, Measure.map_apply_of_aemeasurable
+    (aemeasurable_pi_lambda _ hXk) (MeasurableSet.univ_pi hB)]
+  congr 1
+  ext ω
+  simp [Set.mem_preimage]
+
+omit [MeasurableSpace Ω] [MeasurableSpace α] in
+/-- The product of the coordinate indicators `∏ i, 𝟙_{B i}(X (k i) ω)` equals the indicator of the
+rectangle preimage `{ω | ∀ i, X (k i) ω ∈ B i}`. -/
+theorem indicator_product_eq_indicator_rectangle_preimage (k : Fin m → ℕ) (B : Fin m → Set α) :
+    (fun ω => ∏ i, (B i).indicator (fun _ => (1 : ℝ≥0∞)) (X (k i) ω))
+      = {ω | ∀ i, X (k i) ω ∈ B i}.indicator (fun _ => (1 : ℝ≥0∞)) := by
+  funext ω
+  by_cases h : ω ∈ {ω | ∀ i, X (k i) ω ∈ B i}
+  · rw [Set.indicator_of_mem h]
+    have h' : ∀ i, X (k i) ω ∈ B i := h
+    exact Finset.prod_eq_one fun i _ => Set.indicator_of_mem (h' i) _
+  · rw [Set.indicator_of_notMem h]
+    have h' : ¬ ∀ i, X (k i) ω ∈ B i := h
+    obtain ⟨i, hi⟩ := not_forall.1 h'
+    exact Finset.prod_eq_zero (Finset.mem_univ i) (Set.indicator_of_notMem hi _)
+
+/-- The integral of the coordinate indicator product is the block law on the rectangle — the
+finite-block identity the de Finetti common ending consumes. -/
+theorem lintegral_indicator_product_eq_blockLaw_rectangle (k : Fin m → ℕ)
+    (hXk : ∀ i, AEMeasurable (X (k i)) μ) (B : Fin m → Set α) (hB : ∀ i, MeasurableSet (B i)) :
+    ∫⁻ ω, ∏ i, (B i).indicator (fun _ => (1 : ℝ≥0∞)) (X (k i) ω) ∂μ
+      = blockLaw μ X k (Set.univ.pi B) := by
+  have hS : NullMeasurableSet {ω | ∀ i, X (k i) ω ∈ B i} μ := by
+    have hset : {ω | ∀ i, X (k i) ω ∈ B i}
+        = ⋂ i ∈ (Finset.univ : Finset (Fin m)), (X (k i)) ⁻¹' (B i) := by
+      ext ω; simp [Set.mem_iInter, Set.mem_preimage]
+    rw [hset]
+    exact Finset.nullMeasurableSet_biInter Finset.univ
+      fun i _ => (hXk i).nullMeasurableSet_preimage (hB i)
+  rw [indicator_product_eq_indicator_rectangle_preimage k B,
+    lintegral_indicator_const₀ hS, one_mul, blockLaw_apply_rectangle k hXk B hB]
+
+end Probability
+
+end TauCeti


### PR DESCRIPTION
<!--tauceti-target:v1 {"focus":"Exchangeability","id":"rectangle-indicator-bridge"}-->

## Summary

Adds `TauCeti/Probability/DeFinetti/Rectangles.lean` — the first de-Finetti-facing Layer 1 adapter:
the bridge between a process's finite-dimensional **block law**, measurable **rectangles**
`Set.univ.pi B`, and products of coordinate **indicators**. Three lemmas, concrete over `Fin m`:

- `blockLaw_apply_rectangle` — `blockLaw μ X k (Set.univ.pi B) = μ {ω | ∀ i, X (k i) ω ∈ B i}`
  (the block law on a rectangle is the measure of the coordinate-wise preimage).
- `indicator_product_eq_indicator_rectangle_preimage` — the product of the coordinate indicators
  `∏ i, 𝟙_{B i}(X (k i) ω)` is the indicator of that preimage.
- `lintegral_indicator_product_eq_blockLaw_rectangle` — `∫⁻ ω, ∏ i, 𝟙_{B i}(X (k i) ω) ∂μ =
  blockLaw μ X k (Set.univ.pi B)`. **The finite-block identity the de Finetti common ending consumes.**

## Roadmap

Advances `TauCetiRoadmap/Exchangeability`, **Layer 1** (product kernels, conditional independence,
mixtures) — the first file under `Probability/DeFinetti/`. It is a thin bridge over Mathlib's
infrastructure; it does **not** add the common ending (`conditional_iid_from_directing_measure`) or
any directing-measure construction (those are PRs 4–5).

## How it's proved (reuse)

No hand-rolled measure theory:
- block law on a rectangle: `blockLaw_apply` + `Measure.map_apply_of_aemeasurable`;
- the indicator identity is proved **directly** from Mathlib's finite-product lemmas
  (`Finset.prod_eq_one` / `Finset.prod_eq_zero`) and `Set.indicator_of_mem` /
  `Set.indicator_of_notMem` — small and transparent, using standard Mathlib lemmas rather than
  re-deriving measure theory;
- the integral: `lintegral_indicator_const₀`, with the preimage shown `NullMeasurableSet` via
  `AEMeasurable.nullMeasurableSet_preimage` + `Finset.nullMeasurableSet_biInter`.

## Review notes
- **generality:** hypotheses are the selection-local `∀ i, AEMeasurable (X (k i)) μ`, matching the
  `blockLaw` API — not global `Measurable (X i)`. The rectangle preimage is null-measurable, handled
  by the AE/null-measurable Mathlib API; no measurability is over-required.
- **indicator form:** the product is `ℝ≥0∞`-valued (`(B i).indicator (fun _ => (1 : ℝ≥0∞)) …`) to line
  up with PR 2's mixture integrand `∫⁻ ω, ∏ i, (ν ω) (B i) ∂μ`, so the eventual bridge
  `∫⁻ X-side = ∫⁻ ν-side` matches without an `ENNReal.ofReal` wrapper.
- **placement:** the de-Finetti bridge lives in `Probability/DeFinetti/Rectangles.lean`.
  `blockLaw_apply_rectangle` is a generic `blockLaw` fact; it is kept here as part of the bridge (it
  can move to `Exchangeability/Basic.lean` if preferred).
- **not `@[simp]`:** these are explicit `rw` lemmas (the form later de Finetti code rewrites with).
- **imports:** only `Exchangeability.Basic` and `Mathlib.MeasureTheory.Integral.Lebesgue.Basic`
  (the public statements use `∫⁻`); everything else arrives transitively.

## Test plan
```bash
lake build
lake exe axioms
lake exe module-system
```
All pass; sorry-free; axioms ⊆ {`propext`, `Classical.choice`, `Quot.sound`}; lines ≤100.

## Attribution
Motivated by the private `prod_indicators_eq_indicator_intersection` / `measure_via_indicator_integral`
helpers of `cameronfreer/exchangeability` (`DeFinetti/CommonEnding.lean`, pin
`e0532e59ceff23edab44dda9ab0655debbc9cc22`), here adapted to Tau Ceti's `blockLaw` API and
a.e.-measurable hypotheses over Mathlib's indicator / null-measurable / `lintegral` lemmas. Drafted
with Claude (Opus 4.8), human-directed.
