### PR TITLE
feat: add the fundamental group of a product space

### DIFF
--- a/TauCeti/AlgebraicTopology/FundamentalGroupProduct.lean
+++ b/TauCeti/AlgebraicTopology/FundamentalGroupProduct.lean
@@ -1,0 +1,108 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+module
+
+public import Mathlib.AlgebraicTopology.FundamentalGroupoid.FundamentalGroup
+public import Mathlib.Topology.Homotopy.Product
+
+/-!
+# The fundamental group of a product space
+
+Mathlib knows that the fundamental *groupoid* preserves products
+(`FundamentalGroupoidFunctor.prodIso`, `…piIso`), but the corresponding group-level
+statement is missing: the fundamental *group* of a product is the product of the
+fundamental groups. This file supplies it, both for binary and for indexed products.
+
+The two equivalences are built directly from the path-class product operations
+`Path.Homotopic.prod` / `Path.Homotopic.pi` and their coordinate projections, which already
+descend homotopy and composition through the quotient. The forward map is the pair (resp.
+tuple) of the maps induced by the coordinate projections, packaged through Mathlib's
+`FundamentalGroup.map`; the inverse assembles a loop in the product from its coordinate
+loops. The projection-product round trips
+(`Path.Homotopic.prod_projLeft_projRight`, `…projLeft_prod`, `…projRight_prod`,
+`…pi_proj`, `…proj_pi`) make both composites the identity, and `FundamentalGroup.map`
+being a `MonoidHom` supplies multiplicativity.
+
+This is the group-level input the universal-covers roadmap calls for when computing
+`π₁(Tᵏ)` (Stage 4, "applications": `π_n(Tᵏ)`); see
+`TauCeti/AlgebraicTopology/UniversalCover/TorusFundamentalGroup.lean` for the torus
+application built on top.
+
+## Main declarations
+
+* `TauCeti.FundamentalGroup.prodMulEquiv`: `π₁(X × Y, (x, y)) ≃* π₁(X, x) × π₁(Y, y)`.
+* `TauCeti.FundamentalGroup.piMulEquiv`: `π₁(Π i, X i, x) ≃* Π i, π₁(X i, x i)`.
+-/
+
+public section
+
+namespace TauCeti
+
+open Path.Homotopic
+
+noncomputable section
+
+variable {X Y : Type*} [TopologicalSpace X] [TopologicalSpace Y]
+
+/-- The fundamental group of a binary product is the product of the fundamental groups:
+`π₁(X × Y, (x, y)) ≃* π₁(X, x) × π₁(Y, y)`. The forward map is the pair of the maps induced
+by the two coordinate projections; the inverse sends a pair of loop classes to their product
+`Path.Homotopic.prod`. -/
+@[expose] def FundamentalGroup.prodMulEquiv (x : X) (y : Y) :
+    FundamentalGroup (X × Y) (x, y) ≃*
+      FundamentalGroup X x × FundamentalGroup Y y where
+  toFun γ :=
+    (FundamentalGroup.map (ContinuousMap.fst : C(X × Y, X)) (x, y) γ,
+      FundamentalGroup.map (ContinuousMap.snd : C(X × Y, Y)) (x, y) γ)
+  invFun γ := prod γ.1 γ.2
+  left_inv γ := prod_projLeft_projRight γ
+  right_inv γ := Prod.ext (projLeft_prod γ.1 γ.2) (projRight_prod γ.1 γ.2)
+  map_mul' γ δ :=
+    Prod.ext ((FundamentalGroup.map (ContinuousMap.fst : C(X × Y, X)) (x, y)).map_mul γ δ)
+      ((FundamentalGroup.map (ContinuousMap.snd : C(X × Y, Y)) (x, y)).map_mul γ δ)
+
+@[simp]
+theorem FundamentalGroup.prodMulEquiv_apply (x : X) (y : Y)
+    (γ : FundamentalGroup (X × Y) (x, y)) :
+    FundamentalGroup.prodMulEquiv x y γ =
+      (FundamentalGroup.map (ContinuousMap.fst : C(X × Y, X)) (x, y) γ,
+        FundamentalGroup.map (ContinuousMap.snd : C(X × Y, Y)) (x, y) γ) :=
+  rfl
+
+@[simp]
+theorem FundamentalGroup.prodMulEquiv_symm_apply (x : X) (y : Y)
+    (γ : FundamentalGroup X x × FundamentalGroup Y y) :
+    (FundamentalGroup.prodMulEquiv x y).symm γ = prod γ.1 γ.2 :=
+  rfl
+
+variable {ι : Type*} {X : ι → Type*} [∀ i, TopologicalSpace (X i)]
+
+/-- The fundamental group of an indexed product is the product of the fundamental groups:
+`π₁(Π i, X i, x) ≃* Π i, π₁(X i, x i)`. The forward map records the loop's image under each
+coordinate projection; the inverse assembles a loop from its coordinate loops via
+`Path.Homotopic.pi`. -/
+@[expose] def FundamentalGroup.piMulEquiv (x : ∀ i, X i) :
+    FundamentalGroup (∀ i, X i) x ≃* ∀ i, FundamentalGroup (X i) (x i) where
+  toFun γ i := FundamentalGroup.map (ContinuousMap.eval i) x γ
+  invFun γ := pi γ
+  left_inv γ := pi_proj γ
+  right_inv γ := funext fun i => proj_pi i γ
+  map_mul' γ δ := funext fun i => (FundamentalGroup.map (ContinuousMap.eval i) x).map_mul γ δ
+
+@[simp]
+theorem FundamentalGroup.piMulEquiv_apply (x : ∀ i, X i)
+    (γ : FundamentalGroup (∀ i, X i) x) (i : ι) :
+    FundamentalGroup.piMulEquiv x γ i = FundamentalGroup.map (ContinuousMap.eval i) x γ :=
+  rfl
+
+@[simp]
+theorem FundamentalGroup.piMulEquiv_symm_apply (x : ∀ i, X i)
+    (γ : ∀ i, FundamentalGroup (X i) (x i)) :
+    (FundamentalGroup.piMulEquiv x).symm γ = pi γ :=
+  rfl
+
+end
+
+end TauCeti

--- a/TauCeti/AlgebraicTopology/UniversalCover/CircleFundamentalGroup.lean
+++ b/TauCeti/AlgebraicTopology/UniversalCover/CircleFundamentalGroup.lean
@@ -253,6 +253,20 @@ lemma fundamentalGroupMulEquiv_zero_apply_eq_iff (hp : p ≠ 0)
   rw [fundamentalGroupMulEquiv_zero]
   simpa using fundamentalGroupMulEquiv_apply_eq_iff p hp ⟨0, by simp⟩ γ n
 
+@[simp]
+lemma fundamentalGroupMulEquiv_zero_apply (hp : p ≠ 0)
+    (γ : FundamentalGroup (AddCircle p) 0) :
+    fundamentalGroupMulEquiv_zero p hp γ = fundamentalGroupMulEquiv p hp ⟨0, by simp⟩ γ := by
+  apply (fundamentalGroupMulEquiv_zero_apply_eq_iff p hp γ _).2
+  simpa using (fundamentalGroupMulEquiv_apply_eq_iff p hp ⟨0, by simp⟩ γ _).1 rfl
+
+@[simp]
+lemma fundamentalGroupMulEquiv_zero_symm_apply (hp : p ≠ 0) (n : Multiplicative ℤ) :
+    (fundamentalGroupMulEquiv_zero p hp).symm n =
+      (fundamentalGroupMulEquiv p hp ⟨0, by simp⟩).symm n := by
+  apply (fundamentalGroupMulEquiv_zero p hp).injective
+  rw [MulEquiv.apply_symm_apply, fundamentalGroupMulEquiv_zero_apply, MulEquiv.apply_symm_apply]
+
 /-- The inverse of the basepoint-`0` specialization has monodromy translation `n • p`. -/
 @[simp]
 lemma fundamentalGroupMulEquiv_zero_symm_monodromy (hp : p ≠ 0) (n : Multiplicative ℤ) :
@@ -294,8 +308,7 @@ lemma fundamentalGroupMulEquiv_apply_eq_iff (γ : FundamentalGroup UnitAddCircle
 lemma fundamentalGroupMulEquiv_symm_monodromy (n : Multiplicative ℤ) :
     ((AddCircle.isCoveringMap_coe 1).monodromy (fundamentalGroupMulEquiv.symm n)
       ⟨0, by simp⟩ : ℝ) = n.toAdd := by
-  simp [fundamentalGroupMulEquiv,
-    AddCircle.fundamentalGroupMulEquiv_zero_symm_monodromy 1 one_ne_zero n]
+  simp [fundamentalGroupMulEquiv]
 
 /-- A unit-circle loop class maps to `1` exactly when its monodromy fixes the zero lift. -/
 @[simp]

--- a/TauCeti/AlgebraicTopology/UniversalCover/TorusFundamentalGroup.lean
+++ b/TauCeti/AlgebraicTopology/UniversalCover/TorusFundamentalGroup.lean
@@ -1,0 +1,59 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+module
+
+public import TauCeti.AlgebraicTopology.FundamentalGroupProduct
+public import TauCeti.AlgebraicTopology.UniversalCover.CircleFundamentalGroup
+
+/-!
+# The fundamental group of a torus
+
+Combining the product formula for fundamental groups
+(`TauCeti.FundamentalGroup.prodMulEquiv`, `…piMulEquiv`) with the circle computation
+`π₁(AddCircle p) ≃* Multiplicative ℤ` (`TauCeti.AddCircle.fundamentalGroupMulEquiv_zero`)
+gives the fundamental group of a torus. For a finite product of circles this is the free
+abelian group `(Multiplicative ℤ)ᵏ`; in particular the standard two-torus
+`AddCircle p × AddCircle q` has fundamental group `Multiplicative ℤ × Multiplicative ℤ`.
+
+This realises the universal-covers roadmap Stage 4 "applications" target `π_n(Tᵏ)` at
+`n = 1`: `π₁(Tᵏ) ≅ ℤᵏ`.
+
+## Main declarations
+
+* `TauCeti.AddCircle.prodFundamentalGroupMulEquiv`:
+  `π₁(AddCircle p × AddCircle q, (0, 0)) ≃* Multiplicative ℤ × Multiplicative ℤ`.
+* `TauCeti.AddCircle.piFundamentalGroupMulEquiv`:
+  `π₁(Π i, AddCircle (p i), 0) ≃* Π i, Multiplicative ℤ`, the fundamental group of a torus.
+-/
+
+public section
+
+namespace TauCeti
+
+noncomputable section
+
+namespace AddCircle
+
+/-- The fundamental group of the two-torus `AddCircle p × AddCircle q`, based at `(0, 0)`, is
+`Multiplicative ℤ × Multiplicative ℤ`, for nonzero real periods `p` and `q`. -/
+def prodFundamentalGroupMulEquiv {p q : ℝ} (hp : p ≠ 0) (hq : q ≠ 0) :
+    FundamentalGroup (AddCircle p × AddCircle q) (0, 0) ≃*
+      Multiplicative ℤ × Multiplicative ℤ :=
+  (FundamentalGroup.prodMulEquiv (0 : AddCircle p) (0 : AddCircle q)).trans
+    ((fundamentalGroupMulEquiv_zero p hp).prodCongr (fundamentalGroupMulEquiv_zero q hq))
+
+/-- The fundamental group of a torus `Π i, AddCircle (p i)`, based at `0`, is the product
+`Π i, Multiplicative ℤ`, for a family of nonzero real periods. For a finite index this is the
+free abelian group `(Multiplicative ℤ)ᵏ`, i.e. `π₁(Tᵏ) ≅ ℤᵏ`. -/
+def piFundamentalGroupMulEquiv {ι : Type*} {p : ι → ℝ} (hp : ∀ i, p i ≠ 0) :
+    FundamentalGroup (∀ i, AddCircle (p i)) (fun _ => 0) ≃* ∀ _ : ι, Multiplicative ℤ :=
+  (FundamentalGroup.piMulEquiv (fun i => (0 : AddCircle (p i)))).trans
+    (MulEquiv.piCongrRight fun i => fundamentalGroupMulEquiv_zero (p i) (hp i))
+
+end AddCircle
+
+end
+
+end TauCeti

--- a/TauCeti/AlgebraicTopology/UniversalCover/TorusFundamentalGroup.lean
+++ b/TauCeti/AlgebraicTopology/UniversalCover/TorusFundamentalGroup.lean
@@ -113,12 +113,47 @@ def prodFundamentalGroupMulEquiv_zero {p q : ℝ} (hp : p ≠ 0) (hq : q ≠ 0) 
       Multiplicative ℤ × Multiplicative ℤ :=
   prodFundamentalGroupMulEquiv hp hq ⟨0, by simp⟩ ⟨0, by simp⟩
 
+@[simp]
+theorem prodFundamentalGroupMulEquiv_zero_apply {p q : ℝ} (hp : p ≠ 0) (hq : q ≠ 0)
+    (γ : FundamentalGroup (AddCircle p × AddCircle q) (0, 0)) :
+    prodFundamentalGroupMulEquiv_zero hp hq γ =
+      (fundamentalGroupMulEquiv_zero p hp
+          (FundamentalGroup.map (ContinuousMap.fst : C(AddCircle p × AddCircle q, _)) (0, 0) γ),
+        fundamentalGroupMulEquiv_zero q hq
+          (FundamentalGroup.map
+            (ContinuousMap.snd : C(AddCircle p × AddCircle q, _)) (0, 0) γ)) := by
+  simp [prodFundamentalGroupMulEquiv_zero]
+
+@[simp]
+theorem prodFundamentalGroupMulEquiv_zero_symm_apply {p q : ℝ} (hp : p ≠ 0) (hq : q ≠ 0)
+    (mn : Multiplicative ℤ × Multiplicative ℤ) :
+    (prodFundamentalGroupMulEquiv_zero hp hq).symm mn =
+      prod ((fundamentalGroupMulEquiv_zero p hp).symm mn.1)
+        ((fundamentalGroupMulEquiv_zero q hq).symm mn.2) := by
+  simp [prodFundamentalGroupMulEquiv_zero]
+
 /-- The fundamental group of a torus `Π i, AddCircle (p i)`, based at `0`, is the product
 `Π i, Multiplicative ℤ`, for a family of nonzero real periods. For a finite index this is the
 free abelian group `(Multiplicative ℤ)ᵏ`, i.e. `π₁(Tᵏ) ≅ ℤᵏ`. -/
 def piFundamentalGroupMulEquiv_zero {ι : Type*} {p : ι → ℝ} (hp : ∀ i, p i ≠ 0) :
     FundamentalGroup (∀ i, AddCircle (p i)) (fun _ => 0) ≃* ∀ _ : ι, Multiplicative ℤ :=
   piFundamentalGroupMulEquiv hp fun i => ⟨0, by simp⟩
+
+@[simp]
+theorem piFundamentalGroupMulEquiv_zero_apply {ι : Type*} {p : ι → ℝ}
+    (hp : ∀ i, p i ≠ 0)
+    (γ : FundamentalGroup (∀ i, AddCircle (p i)) (fun _ => 0)) (i : ι) :
+    piFundamentalGroupMulEquiv_zero hp γ i =
+      fundamentalGroupMulEquiv_zero (p i) (hp i)
+        (FundamentalGroup.map (ContinuousMap.eval i) (fun _ => 0) γ) := by
+  simp [piFundamentalGroupMulEquiv_zero]
+
+@[simp]
+theorem piFundamentalGroupMulEquiv_zero_symm_apply {ι : Type*} {p : ι → ℝ}
+    (hp : ∀ i, p i ≠ 0) (n : ∀ _ : ι, Multiplicative ℤ) :
+    (piFundamentalGroupMulEquiv_zero hp).symm n =
+      pi fun i => (fundamentalGroupMulEquiv_zero (p i) (hp i)).symm (n i) := by
+  simp [piFundamentalGroupMulEquiv_zero]
 
 end AddCircle
 

--- a/TauCeti/AlgebraicTopology/UniversalCover/TorusFundamentalGroup.lean
+++ b/TauCeti/AlgebraicTopology/UniversalCover/TorusFundamentalGroup.lean
@@ -23,34 +23,102 @@ This realises the universal-covers roadmap Stage 4 "applications" target `π_n(T
 ## Main declarations
 
 * `TauCeti.AddCircle.prodFundamentalGroupMulEquiv`:
-  `π₁(AddCircle p × AddCircle q, (0, 0)) ≃* Multiplicative ℤ × Multiplicative ℤ`.
+  `π₁(AddCircle p × AddCircle q, (x, y)) ≃* Multiplicative ℤ × Multiplicative ℤ`.
 * `TauCeti.AddCircle.piFundamentalGroupMulEquiv`:
-  `π₁(Π i, AddCircle (p i), 0) ≃* Π i, Multiplicative ℤ`, the fundamental group of a torus.
+  `π₁(Π i, AddCircle (p i), x) ≃* Π i, Multiplicative ℤ`, the fundamental group of a torus.
+* `TauCeti.AddCircle.prodFundamentalGroupMulEquiv_zero`,
+  `TauCeti.AddCircle.piFundamentalGroupMulEquiv_zero`: the basepoint-`0` specialisations.
 -/
 
 public section
 
 namespace TauCeti
 
+open Path.Homotopic
+
 noncomputable section
 
 namespace AddCircle
 
+/-- The fundamental group of the two-torus `AddCircle p × AddCircle q`, based at any point
+`(x, y)` with chosen lifts `ex`, `ey`, is `Multiplicative ℤ × Multiplicative ℤ`, for nonzero
+real periods `p` and `q`. The forward map records, in each coordinate, the integer the
+corresponding projected loop winds around that circle. -/
+def prodFundamentalGroupMulEquiv {p q : ℝ} (hp : p ≠ 0) (hq : q ≠ 0)
+    {x : AddCircle p} {y : AddCircle q}
+    (ex : ((↑) : ℝ → AddCircle p) ⁻¹' {x}) (ey : ((↑) : ℝ → AddCircle q) ⁻¹' {y}) :
+    FundamentalGroup (AddCircle p × AddCircle q) (x, y) ≃*
+      Multiplicative ℤ × Multiplicative ℤ :=
+  (FundamentalGroup.prodMulEquiv x y).trans
+    ((fundamentalGroupMulEquiv p hp ex).prodCongr (fundamentalGroupMulEquiv q hq ey))
+
+@[simp]
+theorem prodFundamentalGroupMulEquiv_apply {p q : ℝ} (hp : p ≠ 0) (hq : q ≠ 0)
+    {x : AddCircle p} {y : AddCircle q}
+    (ex : ((↑) : ℝ → AddCircle p) ⁻¹' {x}) (ey : ((↑) : ℝ → AddCircle q) ⁻¹' {y})
+    (γ : FundamentalGroup (AddCircle p × AddCircle q) (x, y)) :
+    prodFundamentalGroupMulEquiv hp hq ex ey γ =
+      (fundamentalGroupMulEquiv p hp ex
+          (FundamentalGroup.map (ContinuousMap.fst : C(AddCircle p × AddCircle q, _)) (x, y) γ),
+        fundamentalGroupMulEquiv q hq ey
+          (FundamentalGroup.map (ContinuousMap.snd : C(AddCircle p × AddCircle q, _)) (x, y) γ)) :=
+  congrArg ((fundamentalGroupMulEquiv p hp ex).prodCongr (fundamentalGroupMulEquiv q hq ey))
+    (FundamentalGroup.prodMulEquiv_apply x y γ)
+
+@[simp]
+theorem prodFundamentalGroupMulEquiv_symm_apply {p q : ℝ} (hp : p ≠ 0) (hq : q ≠ 0)
+    {x : AddCircle p} {y : AddCircle q}
+    (ex : ((↑) : ℝ → AddCircle p) ⁻¹' {x}) (ey : ((↑) : ℝ → AddCircle q) ⁻¹' {y})
+    (mn : Multiplicative ℤ × Multiplicative ℤ) :
+    (prodFundamentalGroupMulEquiv hp hq ex ey).symm mn =
+      prod ((fundamentalGroupMulEquiv p hp ex).symm mn.1)
+        ((fundamentalGroupMulEquiv q hq ey).symm mn.2) :=
+  FundamentalGroup.prodMulEquiv_symm_apply x y
+    (((fundamentalGroupMulEquiv p hp ex).prodCongr (fundamentalGroupMulEquiv q hq ey)).symm mn)
+
+/-- The fundamental group of a torus `Π i, AddCircle (p i)`, based at any point `x` with chosen
+lifts `e`, is the product `Π i, Multiplicative ℤ`, for a family of nonzero real periods. For a
+finite index this is the free abelian group `(Multiplicative ℤ)ᵏ`, i.e. `π₁(Tᵏ) ≅ ℤᵏ`. The
+forward map records, in each coordinate, the winding integer of the corresponding projected
+loop. -/
+def piFundamentalGroupMulEquiv {ι : Type*} {p : ι → ℝ} (hp : ∀ i, p i ≠ 0)
+    {x : ∀ i, AddCircle (p i)} (e : ∀ i, ((↑) : ℝ → AddCircle (p i)) ⁻¹' {x i}) :
+    FundamentalGroup (∀ i, AddCircle (p i)) x ≃* ∀ _ : ι, Multiplicative ℤ :=
+  (FundamentalGroup.piMulEquiv x).trans
+    (MulEquiv.piCongrRight fun i => fundamentalGroupMulEquiv (p i) (hp i) (e i))
+
+@[simp]
+theorem piFundamentalGroupMulEquiv_apply {ι : Type*} {p : ι → ℝ} (hp : ∀ i, p i ≠ 0)
+    {x : ∀ i, AddCircle (p i)} (e : ∀ i, ((↑) : ℝ → AddCircle (p i)) ⁻¹' {x i})
+    (γ : FundamentalGroup (∀ i, AddCircle (p i)) x) (i : ι) :
+    piFundamentalGroupMulEquiv hp e γ i =
+      fundamentalGroupMulEquiv (p i) (hp i) (e i)
+        (FundamentalGroup.map (ContinuousMap.eval i) x γ) :=
+  congrArg (fundamentalGroupMulEquiv (p i) (hp i) (e i))
+    (FundamentalGroup.piMulEquiv_apply x γ i)
+
+@[simp]
+theorem piFundamentalGroupMulEquiv_symm_apply {ι : Type*} {p : ι → ℝ} (hp : ∀ i, p i ≠ 0)
+    {x : ∀ i, AddCircle (p i)} (e : ∀ i, ((↑) : ℝ → AddCircle (p i)) ⁻¹' {x i})
+    (n : ∀ _ : ι, Multiplicative ℤ) :
+    (piFundamentalGroupMulEquiv hp e).symm n =
+      pi fun i => (fundamentalGroupMulEquiv (p i) (hp i) (e i)).symm (n i) :=
+  FundamentalGroup.piMulEquiv_symm_apply x
+    ((MulEquiv.piCongrRight fun i => fundamentalGroupMulEquiv (p i) (hp i) (e i)).symm n)
+
 /-- The fundamental group of the two-torus `AddCircle p × AddCircle q`, based at `(0, 0)`, is
 `Multiplicative ℤ × Multiplicative ℤ`, for nonzero real periods `p` and `q`. -/
-def prodFundamentalGroupMulEquiv {p q : ℝ} (hp : p ≠ 0) (hq : q ≠ 0) :
+def prodFundamentalGroupMulEquiv_zero {p q : ℝ} (hp : p ≠ 0) (hq : q ≠ 0) :
     FundamentalGroup (AddCircle p × AddCircle q) (0, 0) ≃*
       Multiplicative ℤ × Multiplicative ℤ :=
-  (FundamentalGroup.prodMulEquiv (0 : AddCircle p) (0 : AddCircle q)).trans
-    ((fundamentalGroupMulEquiv_zero p hp).prodCongr (fundamentalGroupMulEquiv_zero q hq))
+  prodFundamentalGroupMulEquiv hp hq ⟨0, by simp⟩ ⟨0, by simp⟩
 
 /-- The fundamental group of a torus `Π i, AddCircle (p i)`, based at `0`, is the product
 `Π i, Multiplicative ℤ`, for a family of nonzero real periods. For a finite index this is the
 free abelian group `(Multiplicative ℤ)ᵏ`, i.e. `π₁(Tᵏ) ≅ ℤᵏ`. -/
-def piFundamentalGroupMulEquiv {ι : Type*} {p : ι → ℝ} (hp : ∀ i, p i ≠ 0) :
+def piFundamentalGroupMulEquiv_zero {ι : Type*} {p : ι → ℝ} (hp : ∀ i, p i ≠ 0) :
     FundamentalGroup (∀ i, AddCircle (p i)) (fun _ => 0) ≃* ∀ _ : ι, Multiplicative ℤ :=
-  (FundamentalGroup.piMulEquiv (fun i => (0 : AddCircle (p i)))).trans
-    (MulEquiv.piCongrRight fun i => fundamentalGroupMulEquiv_zero (p i) (hp i))
+  piFundamentalGroupMulEquiv hp fun i => ⟨0, by simp⟩
 
 end AddCircle
 


### PR DESCRIPTION
This PR adds the group-level product formula for fundamental groups, which Mathlib lacks even though it has the groupoid-level statement (`FundamentalGroupoidFunctor.prodIso` / `…piIso`). It supplies `TauCeti.FundamentalGroup.prodMulEquiv : π₁(X × Y, (x, y)) ≃* π₁(X, x) × π₁(Y, y)` and its indexed counterpart `TauCeti.FundamentalGroup.piMulEquiv : π₁(Π i, X i, x) ≃* Π i, π₁(X i, x i)`, built directly from the path-class product operations `Path.Homotopic.prod` / `Path.Homotopic.pi` and their coordinate projections (the forward map is the tuple of the maps induced by the coordinate projections via `FundamentalGroup.map`, the inverse assembles a loop from its coordinate loops, and the projection-product round trips together with `FundamentalGroup.map` being a `MonoidHom` give the equivalence). It then applies these, with the existing circle computation `π₁(AddCircle p) ≃* Multiplicative ℤ`, to compute the fundamental group of a torus: `AddCircle.prodFundamentalGroupMulEquiv` for the two-torus and `AddCircle.piFundamentalGroupMulEquiv` for `Π i, AddCircle (p i)`, giving `π₁(Tᵏ) ≅ ℤᵏ`.

This advances the UniversalCovers roadmap (`TauCetiRoadmap/UniversalCovers/README.md`, Stage 4 "Applications", item 13: `π_n(Tᵏ)`) at `n = 1`, and the product formula is the reusable group-level input that target needs. The construction reuses Mathlib's `Path.Homotopic` product/projection API and the existing `TauCeti.AddCircle.fundamentalGroupMulEquiv_zero`.

`lake build` and `lake exe axioms` both pass (audit: all within the allowlist `[propext, Classical.choice, Quot.sound]`).

<!--tauceti-target:v1 {"focus":"UniversalCovers","id":"fundamental-group-prod-mul-equiv"}-->

🤖 Prepared with Claude Code
