### PR TITLE
feat: add prime-discriminant radicand injectivity

### DIFF
--- a/TauCeti/NumberTheory/Multiquadratic/PrimeDiscriminantIndependence.lean
+++ b/TauCeti/NumberTheory/Multiquadratic/PrimeDiscriminantIndependence.lean
@@ -58,21 +58,6 @@ private theorem isSquare_of_isSquare_four_mul {q : ℚ} (h : IsSquare ((4 : ℚ)
   have h4 : IsSquare (4 : ℚ) := ⟨2, by norm_num⟩
   simpa using h.div h4
 
-/-- If the radicand of a prime discriminant has absolute value `1`, the discriminant is `-4`.
-The odd prime discriminants have radicand of absolute value their underlying prime `≥ 2`, and the
-even radicands `-1`, `2`, `-2` have absolute value `1` only in the `-4` case. -/
-private theorem eq_neg_four_of_primeDiscriminantRadicand_natAbs_eq_one {D : ℤ}
-    (hD : IsPrimeDiscriminant D) (h : (primeDiscriminantRadicand D).natAbs = 1) :
-    D = -4 := by
-  rcases isPrimeDiscriminant_iff.mp hD with hev | ⟨p, hp, hpodd, rfl⟩
-  · rw [primeDiscriminantRadicand_of_isEvenPrimeDiscriminant hev] at h
-    rcases evenPrimeDiscriminantRadicand_eq_neg_one_or_eq_two_or_eq_neg_two hev with h1 | h2 | h3
-    · exact (evenPrimeDiscriminantRadicand_eq_neg_one_iff hev).mp h1
-    · rw [h2] at h; exact absurd h (by decide)
-    · rw [h3] at h; exact absurd h (by decide)
-  · rw [primeDiscriminantRadicand_oddPrimeDiscriminant hpodd, oddPrimeDiscriminant_natAbs] at h
-    exact absurd h hp.ne_one
-
 /-- The negative of a squarefree integer is squarefree. -/
 private theorem Squarefree.int_neg {n : ℤ} (hn : Squarefree n) : Squarefree (-n) := by
   rw [← Int.squarefree_natAbs, Int.natAbs_neg, Int.squarefree_natAbs]
@@ -94,7 +79,7 @@ private theorem prod_primeDiscriminantRadicands_ne_neg_one {ι : Type*} {D : ι 
     have hall : ∀ i ∈ S, (primeDiscriminantRadicand (D i)).natAbs = 1 :=
       (Finset.prod_eq_one_iff).mp habs
     obtain ⟨i, hi⟩ := hS
-    exact hno_neg_four i hi (eq_neg_four_of_primeDiscriminantRadicand_natAbs_eq_one (hD i)
+    exact hno_neg_four i hi ((primeDiscriminantRadicand_natAbs_eq_one_iff (hD i)).mp
       (hall i hi))
   · rw [Finset.not_nonempty_iff_eq_empty.mp hS] at hprod
     norm_num at hprod
@@ -136,7 +121,7 @@ private theorem prod_primeDiscriminantRadicands_ne_one_of_nonempty {ι : Type*} 
   have hall : ∀ i ∈ S, (primeDiscriminantRadicand (D i)).natAbs = 1 :=
     (Finset.prod_eq_one_iff).mp habs
   have hallD : ∀ i ∈ S, D i = -4 := fun i hi =>
-    eq_neg_four_of_primeDiscriminantRadicand_natAbs_eq_one (hD i) (hall i hi)
+    (primeDiscriminantRadicand_natAbs_eq_one_iff (hD i)).mp (hall i hi)
   obtain ⟨i₀, hi₀⟩ := hS
   have hsingle : S = {i₀} :=
     Finset.eq_singleton_iff_unique_mem.mpr

--- a/TauCeti/NumberTheory/Multiquadratic/PrimeDiscriminants.lean
+++ b/TauCeti/NumberTheory/Multiquadratic/PrimeDiscriminants.lean
@@ -240,7 +240,7 @@ modulo `4`. -/
 theorem isEvenPrimeDiscriminant_or_primeDiscriminantRadicand_mod_four_eq_one {D : ℤ}
     (hD : IsPrimeDiscriminant D) :
     IsEvenPrimeDiscriminant D ∨ primeDiscriminantRadicand D % 4 = 1 := by
-  rcases hD with hD | ⟨p, hp, hodd, rfl⟩
+  rcases isPrimeDiscriminant_iff.mp hD with hD | ⟨p, hp, hodd, rfl⟩
   · exact Or.inl hD
   · exact Or.inr (primeDiscriminantRadicand_mod_four_eq_one_of_odd hodd)
 
@@ -252,7 +252,7 @@ theorem primeDiscriminantRadicand_natAbs_eq_one_iff {D : ℤ}
     (primeDiscriminantRadicand D).natAbs = 1 ↔ D = -4 := by
   constructor
   · intro h
-    rcases hD with hev | ⟨p, hp, hodd, rfl⟩
+    rcases isPrimeDiscriminant_iff.mp hD with hev | ⟨p, hp, hodd, rfl⟩
     · rw [primeDiscriminantRadicand_of_isEvenPrimeDiscriminant hev] at h
       rcases hev with rfl | rfl | rfl
       · rfl
@@ -282,7 +282,7 @@ theorem primeDiscriminantRadicand_eq_two_iff {D : ℤ}
     primeDiscriminantRadicand D = 2 ↔ D = 8 := by
   constructor
   · intro h
-    rcases hD with hev | ⟨p, hp, hodd, rfl⟩
+    rcases isPrimeDiscriminant_iff.mp hD with hev | ⟨p, hp, hodd, rfl⟩
     · rw [primeDiscriminantRadicand_of_isEvenPrimeDiscriminant hev] at h
       exact (evenPrimeDiscriminantRadicand_eq_two_iff hev).mp h
     · have hp2 : p = 2 := by
@@ -300,7 +300,7 @@ theorem primeDiscriminantRadicand_eq_neg_two_iff {D : ℤ}
     primeDiscriminantRadicand D = -2 ↔ D = -8 := by
   constructor
   · intro h
-    rcases hD with hev | ⟨p, hp, hodd, rfl⟩
+    rcases isPrimeDiscriminant_iff.mp hD with hev | ⟨p, hp, hodd, rfl⟩
     · rw [primeDiscriminantRadicand_of_isEvenPrimeDiscriminant hev] at h
       exact (evenPrimeDiscriminantRadicand_eq_neg_two_iff hev).mp h
     · have hp2 : p = 2 := by
@@ -318,8 +318,8 @@ theorem eq_of_primeDiscriminantRadicand_eq {D E : ℤ}
     (hD : IsPrimeDiscriminant D) (hE : IsPrimeDiscriminant E)
     (h : primeDiscriminantRadicand D = primeDiscriminantRadicand E) :
     D = E := by
-  rcases hD with hevD | ⟨p, hp, hpodd, rfl⟩
-  · rcases hE with hevE | ⟨q, hq, hqodd, rfl⟩
+  rcases isPrimeDiscriminant_iff.mp hD with hevD | ⟨p, hp, hpodd, rfl⟩
+  · rcases isPrimeDiscriminant_iff.mp hE with hevE | ⟨q, hq, hqodd, rfl⟩
     · rcases hevD with rfl | rfl | rfl
       · have hE' : E = -4 :=
           (primeDiscriminantRadicand_eq_neg_one_iff (Or.inl hevE)).mp (by simpa using h.symm)
@@ -340,7 +340,7 @@ theorem eq_of_primeDiscriminantRadicand_eq {D E : ℤ}
       · rw [h2] at habs
         rcases hqodd with ⟨k, hk⟩
         omega
-  · rcases hE with hevE | ⟨q, hq, hqodd, rfl⟩
+  · rcases isPrimeDiscriminant_iff.mp hE with hevE | ⟨q, hq, hqodd, rfl⟩
     · have habs := congrArg Int.natAbs h
       rw [primeDiscriminantRadicand_oddPrimeDiscriminant hpodd,
         primeDiscriminantRadicand_of_isEvenPrimeDiscriminant hevE,
@@ -369,10 +369,8 @@ theorem injective_primeDiscriminantRadicand_comp_iff {ι : Type*} {D : ι → �
     (hD : ∀ i, IsPrimeDiscriminant (D i)) :
     Function.Injective (fun i => primeDiscriminantRadicand (D i)) ↔
       Function.Injective D := by
-  constructor
-  · intro hinj i j h
-    exact hinj (congrArg primeDiscriminantRadicand h)
-  · intro hinj i j h
-    exact hinj (eq_of_primeDiscriminantRadicand_eq (hD i) (hD j) h)
+  simpa only [Function.comp_def] using
+    (Set.InjOn.injective_iff {D : ℤ | IsPrimeDiscriminant D} injOn_primeDiscriminantRadicand
+      (by rintro _ ⟨i, rfl⟩; exact hD i))
 
 end TauCeti.Multiquadratic

--- a/TauCeti/NumberTheory/Multiquadratic/PrimeDiscriminants.lean
+++ b/TauCeti/NumberTheory/Multiquadratic/PrimeDiscriminants.lean
@@ -244,4 +244,135 @@ theorem isEvenPrimeDiscriminant_or_primeDiscriminantRadicand_mod_four_eq_one {D 
   · exact Or.inl hD
   · exact Or.inr (primeDiscriminantRadicand_mod_four_eq_one_of_odd hodd)
 
+/-- The only prime discriminant whose radicand has absolute value `1` is `-4`. This is the
+small exceptional case in the radicand map: the odd prime-discriminant radicands have prime
+absolute value, and the other even prime-discriminant radicands have absolute value `2`. -/
+theorem primeDiscriminantRadicand_natAbs_eq_one_iff {D : ℤ}
+    (hD : IsPrimeDiscriminant D) :
+    (primeDiscriminantRadicand D).natAbs = 1 ↔ D = -4 := by
+  constructor
+  · intro h
+    rcases hD with hev | ⟨p, hp, hodd, rfl⟩
+    · rw [primeDiscriminantRadicand_of_isEvenPrimeDiscriminant hev] at h
+      rcases hev with rfl | rfl | rfl
+      · rfl
+      · norm_num at h
+      · norm_num at h
+    · rw [primeDiscriminantRadicand_oddPrimeDiscriminant hodd,
+        oddPrimeDiscriminant_natAbs] at h
+      exact False.elim (hp.ne_one h)
+  · intro h
+    rw [h, primeDiscriminantRadicand_neg_four]
+    norm_num
+
+/-- Among prime discriminants, radicand `-1` comes only from the even prime discriminant
+`-4`. -/
+theorem primeDiscriminantRadicand_eq_neg_one_iff {D : ℤ}
+    (hD : IsPrimeDiscriminant D) :
+    primeDiscriminantRadicand D = -1 ↔ D = -4 := by
+  constructor
+  · intro h
+    exact (primeDiscriminantRadicand_natAbs_eq_one_iff hD).mp (by rw [h]; norm_num)
+  · intro h
+    rw [h, primeDiscriminantRadicand_neg_four]
+
+/-- Among prime discriminants, radicand `2` comes only from the even prime discriminant `8`. -/
+theorem primeDiscriminantRadicand_eq_two_iff {D : ℤ}
+    (hD : IsPrimeDiscriminant D) :
+    primeDiscriminantRadicand D = 2 ↔ D = 8 := by
+  constructor
+  · intro h
+    rcases hD with hev | ⟨p, hp, hodd, rfl⟩
+    · rw [primeDiscriminantRadicand_of_isEvenPrimeDiscriminant hev] at h
+      exact (evenPrimeDiscriminantRadicand_eq_two_iff hev).mp h
+    · have hp2 : p = 2 := by
+        simpa [primeDiscriminantRadicand_oddPrimeDiscriminant hodd,
+          oddPrimeDiscriminant_natAbs] using congrArg Int.natAbs h
+      rcases hodd with ⟨k, hk⟩
+      omega
+  · intro h
+    rw [h, primeDiscriminantRadicand_eight]
+
+/-- Among prime discriminants, radicand `-2` comes only from the even prime discriminant
+`-8`. -/
+theorem primeDiscriminantRadicand_eq_neg_two_iff {D : ℤ}
+    (hD : IsPrimeDiscriminant D) :
+    primeDiscriminantRadicand D = -2 ↔ D = -8 := by
+  constructor
+  · intro h
+    rcases hD with hev | ⟨p, hp, hodd, rfl⟩
+    · rw [primeDiscriminantRadicand_of_isEvenPrimeDiscriminant hev] at h
+      exact (evenPrimeDiscriminantRadicand_eq_neg_two_iff hev).mp h
+    · have hp2 : p = 2 := by
+        simpa [primeDiscriminantRadicand_oddPrimeDiscriminant hodd,
+          oddPrimeDiscriminant_natAbs] using congrArg Int.natAbs h
+      rcases hodd with ⟨k, hk⟩
+      omega
+  · intro h
+    rw [h, primeDiscriminantRadicand_neg_eight]
+
+/-- The radicand map is injective on prime discriminants. This is the bookkeeping that lets
+later genus-field code pass between a list of prime discriminants and the corresponding
+multiquadratic radicands without identifying two different quadratic factors. -/
+theorem eq_of_primeDiscriminantRadicand_eq {D E : ℤ}
+    (hD : IsPrimeDiscriminant D) (hE : IsPrimeDiscriminant E)
+    (h : primeDiscriminantRadicand D = primeDiscriminantRadicand E) :
+    D = E := by
+  rcases hD with hevD | ⟨p, hp, hpodd, rfl⟩
+  · rcases hE with hevE | ⟨q, hq, hqodd, rfl⟩
+    · rcases hevD with rfl | rfl | rfl
+      · have hE' : E = -4 :=
+          (primeDiscriminantRadicand_eq_neg_one_iff (Or.inl hevE)).mp (by simpa using h.symm)
+        rw [hE']
+      · have hE' : E = 8 :=
+          (primeDiscriminantRadicand_eq_two_iff (Or.inl hevE)).mp (by simpa using h.symm)
+        rw [hE']
+      · have hE' : E = -8 :=
+          (primeDiscriminantRadicand_eq_neg_two_iff (Or.inl hevE)).mp (by simpa using h.symm)
+        rw [hE']
+    · have habs := congrArg Int.natAbs h
+      rw [primeDiscriminantRadicand_of_isEvenPrimeDiscriminant hevD,
+        primeDiscriminantRadicand_oddPrimeDiscriminant hqodd,
+        oddPrimeDiscriminant_natAbs] at habs
+      rcases evenPrimeDiscriminantRadicand_natAbs_eq_one_or_two hevD with h1 | h2
+      · rw [h1] at habs
+        exact False.elim (hq.ne_one habs.symm)
+      · rw [h2] at habs
+        rcases hqodd with ⟨k, hk⟩
+        omega
+  · rcases hE with hevE | ⟨q, hq, hqodd, rfl⟩
+    · have habs := congrArg Int.natAbs h
+      rw [primeDiscriminantRadicand_oddPrimeDiscriminant hpodd,
+        primeDiscriminantRadicand_of_isEvenPrimeDiscriminant hevE,
+        oddPrimeDiscriminant_natAbs] at habs
+      rcases evenPrimeDiscriminantRadicand_natAbs_eq_one_or_two hevE with h1 | h2
+      · rw [h1] at habs
+        exact False.elim (hp.ne_one habs)
+      · rw [h2] at habs
+        rcases hpodd with ⟨k, hk⟩
+        omega
+    · rw [primeDiscriminantRadicand_oddPrimeDiscriminant hpodd,
+        primeDiscriminantRadicand_oddPrimeDiscriminant hqodd] at h
+      have hpq : p = q := by
+        simpa [oddPrimeDiscriminant_natAbs] using congrArg Int.natAbs h
+      rw [hpq]
+
+/-- `primeDiscriminantRadicand` is injective on the set of prime discriminants. -/
+theorem injOn_primeDiscriminantRadicand :
+    Set.InjOn primeDiscriminantRadicand {D : ℤ | IsPrimeDiscriminant D} := by
+  intro D hD E hE h
+  exact eq_of_primeDiscriminantRadicand_eq hD hE h
+
+/-- For a family of prime discriminants, injectivity is unchanged after replacing each
+discriminant by its multiquadratic radicand. -/
+theorem injective_primeDiscriminantRadicand_comp_iff {ι : Type*} {D : ι → ℤ}
+    (hD : ∀ i, IsPrimeDiscriminant (D i)) :
+    Function.Injective (fun i => primeDiscriminantRadicand (D i)) ↔
+      Function.Injective D := by
+  constructor
+  · intro hinj i j h
+    exact hinj (congrArg primeDiscriminantRadicand h)
+  · intro hinj i j h
+    exact hinj (eq_of_primeDiscriminantRadicand_eq (hD i) (hD j) h)
+
 end TauCeti.Multiquadratic


### PR DESCRIPTION
This PR records the classification and injectivity API for the prime-discriminant radicand map: among prime discriminants, radicand absolute value `1` occurs only for `-4`, the exceptional radicands `-1`, `2`, and `-2` identify exactly `-4`, `8`, and `-8`, and `primeDiscriminantRadicand` is injective on prime discriminants. It also replaces a private duplicate in `PrimeDiscriminantIndependence` with the new public lemma.

This advances `TauCetiRoadmap/Multiquadratic/README.md`, Layer 3, specifically the genus-field description as "the compositum of the `ℚ(√p*)` for the prime discriminants dividing `disc K`", and supports the Layer 0 prime-discriminant specialization used by that target. The later genus-field construction needs to move between prime discriminants and the squarefree radicands used by the multiquadratic field without identifying two distinct quadratic factors; this PR supplies that exact bookkeeping. It is distinct from the open subfield-degree PR, which concerns degrees of intermediate fields in the existing subfield lattice.

No Mathlib infrastructure is vendored. The implementation reuses the existing Tau Ceti prime-discriminant normalization API: `IsPrimeDiscriminant`, `IsEvenPrimeDiscriminant`, `primeDiscriminantRadicand_of_isEvenPrimeDiscriminant`, `primeDiscriminantRadicand_oddPrimeDiscriminant`, `oddPrimeDiscriminant_natAbs`, and the even-prime radicand classification lemmas.

`lake exe cache get` completed with `No files to download` and `Already decompressed 8602 file(s)`. `lake build` completed with `Build completed successfully (4342 jobs).` `lake exe axioms` completed with `axioms: audited 6403 TauCeti declaration(s); all within the allowlist [propext, Classical.choice, Quot.sound].`

<!--tauceti-target:v1 {"focus":"Multiquadratic","id":"prime-discriminant-radicand-injectivity"}-->

🤖 Prepared with Codex
