### PR TITLE
feat: add antiholomorphic composition API

### DIFF
--- a/TauCeti/Analysis/Complex/Conformal/Reflection.lean
+++ b/TauCeti/Analysis/Complex/Conformal/Reflection.lean
@@ -8,13 +8,13 @@ public import Mathlib.Analysis.Calculus.Deriv.Star
 public import Mathlib.Analysis.Complex.Basic
 
 /-!
-# Conjugation and open holomorphic domains
+# Conjugation and holomorphic domains
 
 This file records the elementary conjugation API used by the conformal-mapping roadmap's
 Schwarz-reflection layer.  Mathlib already proves the pointwise fact
 `DifferentiableAt.conj_conj`: if `f` is complex differentiable at `conj z`, then
-`z ↦ conj (f (conj z))` is complex differentiable at `z`.  The lemmas here package that
-pointwise result for open domains and reflected images, which is the form needed before the
+`z ↦ conj (f (conj z))` is complex differentiable at `z`.  The lemmas here package the
+corresponding within-set statement for reflected images, which is the form needed before the
 real-axis Schwarz reflection principle.
 -/
 
@@ -22,7 +22,7 @@ public section
 
 namespace TauCeti
 
-open Complex Set
+open Complex Filter Set
 open scoped ComplexConjugate
 
 variable {f : ℂ → ℂ} {S : Set ℂ} {z : ℂ}
@@ -53,39 +53,89 @@ lemma isOpen_starRingEnd_image (hS : IsOpen S) : IsOpen ((starRingEnd ℂ) '' S)
   rw [starRingEnd_image_eq_preimage]
   exact hS.preimage continuous_star
 
-/--
-Open-domain form of the antiholomorphic-composition prerequisite for Schwarz reflection.
+private lemma HasFDerivWithinAt.comp_semilinear_preimage
+    {𝕜 V V' W W' : Type*} [NontriviallyNormedField 𝕜] {σ σ' : RingHom 𝕜 𝕜}
+    [NormedAddCommGroup V] [NormedSpace 𝕜 V]
+    [NormedAddCommGroup V'] [NormedSpace 𝕜 V']
+    [NormedAddCommGroup W] [NormedSpace 𝕜 W]
+    [NormedAddCommGroup W'] [NormedSpace 𝕜 W']
+    [RingHomIsometric σ] [RingHomInvPair σ σ']
+    (L : W →SL[σ] W') (R : V' →SL[σ'] V)
+    {g : V → W} {g' : V →L[𝕜] W} {T : Set V} {x : V'}
+    (hg : HasFDerivWithinAt g g' T (R x)) :
+    HasFDerivWithinAt (L ∘ g ∘ R) (L.comp (g'.comp R)) (R ⁻¹' T) x := by
+  rw [hasFDerivWithinAt_iff_isLittleO] at ⊢ hg
+  have : RingHomIsometric σ' := .inv σ
+  have hR : Tendsto R (nhdsWithin x (R ⁻¹' T)) (nhdsWithin (R x) T) :=
+    R.continuous.continuousAt.continuousWithinAt.tendsto_nhdsWithin (mapsTo_preimage R T)
+  have hsmall := hg.comp_tendsto hR
+  have hRsub : ((fun x' => x' - R x) ∘ R) =O[nhdsWithin x (R ⁻¹' T)] fun x' => x' - x := by
+    simpa [Function.comp_def, map_sub] using R.isBigO_sub (nhdsWithin x (R ⁻¹' T)) x
+  simpa [Function.comp_def, map_sub] using
+    ((L.isBigO_comp _ _).trans_isLittleO hsmall).trans_isBigO hRsub
 
-If `f` is holomorphic on an open set `S`, then `z ↦ conj (f (conj z))` is holomorphic on the
-reflected open set `conj '' S`.  This is the `DifferentiableOn` wrapper around Mathlib's
-pointwise `DifferentiableAt.conj_conj`.
+/--
+Antiholomorphic-composition prerequisite for Schwarz reflection.
+
+If `f` is holomorphic on `S`, then `z ↦ conj (f (conj z))` is holomorphic on the reflected
+set `conj '' S`.
 -/
-lemma differentiableOn_starRingEnd_comp_starRingEnd_of_isOpen (hS : IsOpen S)
-    (hf : DifferentiableOn ℂ f S) :
+lemma differentiableOn_starRingEnd_comp_starRingEnd (hf : DifferentiableOn ℂ f S) :
     DifferentiableOn ℂ (fun z => (starRingEnd ℂ) (f ((starRingEnd ℂ) z)))
       ((starRingEnd ℂ) '' S) := by
   intro z hz
   have hzS : (starRingEnd ℂ) z ∈ S := mem_starRingEnd_image_iff.mp hz
-  have hfz : DifferentiableAt ℂ f ((starRingEnd ℂ) z) :=
-    (hf ((starRingEnd ℂ) z) hzS).differentiableAt (hS.mem_nhds hzS)
-  simpa [Function.comp_def] using (hfz.conj_conj).differentiableWithinAt
+  rcases (hf ((starRingEnd ℂ) z) hzS) with ⟨f', hf'⟩
+  have hstar :=
+    HasFDerivWithinAt.comp_semilinear_preimage
+      (starL ℂ).toContinuousLinearMap (starL ℂ).toContinuousLinearMap (x := z) hf'
+  rw [starRingEnd_image_eq_preimage]
+  have hfun :
+      (fun z => (starRingEnd ℂ) (f ((starRingEnd ℂ) z))) =
+        (⇑(starL ℂ).toContinuousLinearMap ∘ f ∘ ⇑(starL ℂ).toContinuousLinearMap) := by
+    funext w
+    change (starRingEnd ℂ) (f ((starRingEnd ℂ) w)) =
+      (starL ℂ : ℂ ≃L⋆[ℂ] ℂ) (f ((starL ℂ : ℂ ≃L⋆[ℂ] ℂ) w))
+    rw [starL_apply, starL_apply, starRingEnd_apply, starRingEnd_apply]
+  have hset : (starRingEnd ℂ) ⁻¹' S = ⇑(starL ℂ).toContinuousLinearMap ⁻¹' S := by
+    ext w
+    change (starRingEnd ℂ) w ∈ S ↔ (starL ℂ : ℂ ≃L⋆[ℂ] ℂ) w ∈ S
+    rw [starL_apply, starRingEnd_apply]
+  rw [hfun, hset]
+  exact hstar.differentiableWithinAt
 
 /--
-Conjugating both source and target preserves holomorphicity on open domains, in both
-directions.
+Open-domain form of `differentiableOn_starRingEnd_comp_starRingEnd`.
 -/
-lemma differentiableOn_starRingEnd_comp_starRingEnd_iff_of_isOpen (hS : IsOpen S) :
+lemma differentiableOn_starRingEnd_comp_starRingEnd_of_isOpen (_hS : IsOpen S)
+    (hf : DifferentiableOn ℂ f S) :
+    DifferentiableOn ℂ (fun z => (starRingEnd ℂ) (f ((starRingEnd ℂ) z)))
+      ((starRingEnd ℂ) '' S) :=
+  differentiableOn_starRingEnd_comp_starRingEnd hf
+
+/--
+Conjugating both source and target preserves holomorphicity on domains, in both directions.
+-/
+lemma differentiableOn_starRingEnd_comp_starRingEnd_iff :
     DifferentiableOn ℂ (fun z => (starRingEnd ℂ) (f ((starRingEnd ℂ) z)))
         ((starRingEnd ℂ) '' S) ↔
       DifferentiableOn ℂ f S := by
   constructor
   · intro h
-    have hopen : IsOpen ((starRingEnd ℂ) '' S) := isOpen_starRingEnd_image hS
     have htwice :=
-      differentiableOn_starRingEnd_comp_starRingEnd_of_isOpen
+      differentiableOn_starRingEnd_comp_starRingEnd
         (S := (starRingEnd ℂ) '' S)
-        (f := fun z => (starRingEnd ℂ) (f ((starRingEnd ℂ) z))) hopen h
+        (f := fun z => (starRingEnd ℂ) (f ((starRingEnd ℂ) z))) h
     simpa [starRingEnd_image_eq_preimage, Set.preimage_preimage, Function.comp_def] using htwice
-  · exact differentiableOn_starRingEnd_comp_starRingEnd_of_isOpen hS
+  · exact differentiableOn_starRingEnd_comp_starRingEnd
+
+/--
+Open-domain form of `differentiableOn_starRingEnd_comp_starRingEnd_iff`.
+-/
+lemma differentiableOn_starRingEnd_comp_starRingEnd_iff_of_isOpen (_hS : IsOpen S) :
+    DifferentiableOn ℂ (fun z => (starRingEnd ℂ) (f ((starRingEnd ℂ) z)))
+        ((starRingEnd ℂ) '' S) ↔
+      DifferentiableOn ℂ f S :=
+  differentiableOn_starRingEnd_comp_starRingEnd_iff
 
 end TauCeti

--- a/TauCeti/Analysis/Complex/Conformal/Reflection.lean
+++ b/TauCeti/Analysis/Complex/Conformal/Reflection.lean
@@ -83,9 +83,12 @@ lemma differentiableOn_conj_conj (hf : DifferentiableOn ℂ f S) :
     rw [starRingEnd_eq_starL, starRingEnd_eq_starL]
   have hset : (starRingEnd ℂ) ⁻¹' S = ⇑(starL ℂ).toContinuousLinearMap ⁻¹' S := by
     ext w
-    exact show (starRingEnd ℂ) w ∈ S ↔ ((starL ℂ).toContinuousLinearMap : ℂ → ℂ) w ∈ S by
+    -- Expose membership in the preimages before rewriting across the two conjugation coercions.
+    change (starRingEnd ℂ) w ∈ S ↔ ((starL ℂ).toContinuousLinearMap : ℂ → ℂ) w ∈ S
+    have hw : (starRingEnd ℂ) w = ((starL ℂ).toContinuousLinearMap : ℂ → ℂ) w := by
       rw [starRingEnd_eq_starL]
       rfl
+    rw [hw]
   rw [hfun, hset]
   exact hstar.differentiableWithinAt
 

--- a/TauCeti/Analysis/Complex/Conformal/Reflection.lean
+++ b/TauCeti/Analysis/Complex/Conformal/Reflection.lean
@@ -25,33 +25,7 @@ namespace TauCeti
 open Complex Filter Set
 open scoped ComplexConjugate
 
-variable {f : ℂ → ℂ} {S : Set ℂ} {z : ℂ}
-
-/-!
-Mathlib's conjugation lemmas are stated using both `conj` and `starRingEnd ℂ`; the
-conformal roadmap fixes `starRingEnd ℂ` as the reflection map.  The next two lemmas make the
-reflected set usable without unfolding the image witness.
--/
-
-/-- Membership in the conjugate image of a set, written with `starRingEnd ℂ`. -/
-lemma mem_starRingEnd_image_iff :
-    z ∈ (starRingEnd ℂ) '' S ↔ (starRingEnd ℂ) z ∈ S := by
-  constructor
-  · rintro ⟨w, hw, rfl⟩
-    simpa using hw
-  · intro hz
-    refine ⟨(starRingEnd ℂ) z, hz, ?_⟩
-    simp
-
-/-- Since complex conjugation is an involution, its image of a set is its preimage. -/
-lemma starRingEnd_image_eq_preimage : (starRingEnd ℂ) '' S = (starRingEnd ℂ) ⁻¹' S := by
-  ext z
-  exact mem_starRingEnd_image_iff
-
-/-- Complex conjugation sends open subsets of `ℂ` to open subsets of `ℂ`. -/
-lemma isOpen_starRingEnd_image (hS : IsOpen S) : IsOpen ((starRingEnd ℂ) '' S) := by
-  rw [starRingEnd_image_eq_preimage]
-  exact hS.preimage continuous_star
+variable {f : ℂ → ℂ} {S : Set ℂ}
 
 private lemma HasFDerivWithinAt.comp_semilinear_preimage
     {𝕜 V V' W W' : Type*} [NontriviallyNormedField 𝕜] {σ σ' : RingHom 𝕜 𝕜}
@@ -84,12 +58,18 @@ lemma differentiableOn_starRingEnd_comp_starRingEnd (hf : DifferentiableOn ℂ f
     DifferentiableOn ℂ (fun z => (starRingEnd ℂ) (f ((starRingEnd ℂ) z)))
       ((starRingEnd ℂ) '' S) := by
   intro z hz
-  have hzS : (starRingEnd ℂ) z ∈ S := mem_starRingEnd_image_iff.mp hz
+  have hzS : (starRingEnd ℂ) z ∈ S :=
+    (Set.mem_image_iff_of_inverse
+      (Function.Involutive.leftInverse (starRingEnd_self_apply : Function.Involutive
+        (starRingEnd ℂ)))
+      (Function.Involutive.rightInverse (starRingEnd_self_apply : Function.Involutive
+        (starRingEnd ℂ)))).mp hz
   rcases (hf ((starRingEnd ℂ) z) hzS) with ⟨f', hf'⟩
   have hstar :=
     HasFDerivWithinAt.comp_semilinear_preimage
       (starL ℂ).toContinuousLinearMap (starL ℂ).toContinuousLinearMap (x := z) hf'
-  rw [starRingEnd_image_eq_preimage]
+  rw [Function.Involutive.image_eq_preimage_symm
+    (starRingEnd_self_apply : Function.Involutive (starRingEnd ℂ))]
   have hfun :
       (fun z => (starRingEnd ℂ) (f ((starRingEnd ℂ) z))) =
         (⇑(starL ℂ).toContinuousLinearMap ∘ f ∘ ⇑(starL ℂ).toContinuousLinearMap) := by
@@ -105,15 +85,6 @@ lemma differentiableOn_starRingEnd_comp_starRingEnd (hf : DifferentiableOn ℂ f
   exact hstar.differentiableWithinAt
 
 /--
-Open-domain form of `differentiableOn_starRingEnd_comp_starRingEnd`.
--/
-lemma differentiableOn_starRingEnd_comp_starRingEnd_of_isOpen (_hS : IsOpen S)
-    (hf : DifferentiableOn ℂ f S) :
-    DifferentiableOn ℂ (fun z => (starRingEnd ℂ) (f ((starRingEnd ℂ) z)))
-      ((starRingEnd ℂ) '' S) :=
-  differentiableOn_starRingEnd_comp_starRingEnd hf
-
-/--
 Conjugating both source and target preserves holomorphicity on domains, in both directions.
 -/
 lemma differentiableOn_starRingEnd_comp_starRingEnd_iff :
@@ -126,16 +97,9 @@ lemma differentiableOn_starRingEnd_comp_starRingEnd_iff :
       differentiableOn_starRingEnd_comp_starRingEnd
         (S := (starRingEnd ℂ) '' S)
         (f := fun z => (starRingEnd ℂ) (f ((starRingEnd ℂ) z))) h
-    simpa [starRingEnd_image_eq_preimage, Set.preimage_preimage, Function.comp_def] using htwice
+    simpa [Function.Involutive.image_eq_preimage_symm
+      (starRingEnd_self_apply : Function.Involutive (starRingEnd ℂ)), Set.preimage_preimage,
+      Function.comp_def] using htwice
   · exact differentiableOn_starRingEnd_comp_starRingEnd
-
-/--
-Open-domain form of `differentiableOn_starRingEnd_comp_starRingEnd_iff`.
--/
-lemma differentiableOn_starRingEnd_comp_starRingEnd_iff_of_isOpen (_hS : IsOpen S) :
-    DifferentiableOn ℂ (fun z => (starRingEnd ℂ) (f ((starRingEnd ℂ) z)))
-        ((starRingEnd ℂ) '' S) ↔
-      DifferentiableOn ℂ f S :=
-  differentiableOn_starRingEnd_comp_starRingEnd_iff
 
 end TauCeti

--- a/TauCeti/Analysis/Complex/Conformal/Reflection.lean
+++ b/TauCeti/Analysis/Complex/Conformal/Reflection.lean
@@ -1,5 +1,11 @@
-import Mathlib.Analysis.Calculus.Deriv.Star
-import Mathlib.Analysis.Complex.Basic
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+module
+
+public import Mathlib.Analysis.Calculus.Deriv.Star
+public import Mathlib.Analysis.Complex.Basic
 
 /-!
 # Conjugation and open holomorphic domains
@@ -11,6 +17,8 @@ Schwarz-reflection layer.  Mathlib already proves the pointwise fact
 pointwise result for open domains and reflected images, which is the form needed before the
 real-axis Schwarz reflection principle.
 -/
+
+public section
 
 namespace TauCeti
 

--- a/TauCeti/Analysis/Complex/Conformal/Reflection.lean
+++ b/TauCeti/Analysis/Complex/Conformal/Reflection.lean
@@ -4,7 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 -/
 module
 
-public import Mathlib.Analysis.Calculus.Deriv.Star
+public import Mathlib.Analysis.Calculus.FDeriv.Star
 public import Mathlib.Analysis.Complex.Basic
 
 /-!
@@ -15,7 +15,8 @@ Schwarz-reflection layer.  Mathlib already proves the pointwise fact
 `DifferentiableAt.conj_conj`: if `f` is complex differentiable at `conj z`, then
 `z ↦ conj (f (conj z))` is complex differentiable at `z`.  The lemmas here package the
 corresponding within-set statement for reflected images, which is the form needed before the
-real-axis Schwarz reflection principle.
+real-axis Schwarz reflection principle.  The private semilinear within-set helper adapts the
+proof pattern of Mathlib's `HasFDerivAt.comp_semilinear`.
 -/
 
 public section
@@ -26,6 +27,10 @@ open Complex Filter Set
 open scoped ComplexConjugate
 
 variable {f : ℂ → ℂ} {S : Set ℂ}
+
+private lemma starRingEnd_eq_starL (z : ℂ) :
+    (starRingEnd ℂ) z = (starL ℂ : ℂ ≃L⋆[ℂ] ℂ) z := by
+  rw [starL_apply, starRingEnd_apply]
 
 private lemma HasFDerivWithinAt.comp_semilinear_preimage
     {𝕜 V V' W W' : Type*} [NontriviallyNormedField 𝕜] {σ σ' : RingHom 𝕜 𝕜}
@@ -54,7 +59,7 @@ Antiholomorphic-composition prerequisite for Schwarz reflection.
 If `f` is holomorphic on `S`, then `z ↦ conj (f (conj z))` is holomorphic on the reflected
 set `conj '' S`.
 -/
-lemma differentiableOn_starRingEnd_comp_starRingEnd (hf : DifferentiableOn ℂ f S) :
+lemma differentiableOn_conj_conj (hf : DifferentiableOn ℂ f S) :
     DifferentiableOn ℂ (fun z => (starRingEnd ℂ) (f ((starRingEnd ℂ) z)))
       ((starRingEnd ℂ) '' S) := by
   intro z hz
@@ -74,32 +79,33 @@ lemma differentiableOn_starRingEnd_comp_starRingEnd (hf : DifferentiableOn ℂ f
       (fun z => (starRingEnd ℂ) (f ((starRingEnd ℂ) z))) =
         (⇑(starL ℂ).toContinuousLinearMap ∘ f ∘ ⇑(starL ℂ).toContinuousLinearMap) := by
     funext w
-    change (starRingEnd ℂ) (f ((starRingEnd ℂ) w)) =
-      (starL ℂ : ℂ ≃L⋆[ℂ] ℂ) (f ((starL ℂ : ℂ ≃L⋆[ℂ] ℂ) w))
-    rw [starL_apply, starL_apply, starRingEnd_apply, starRingEnd_apply]
+    dsimp [Function.comp_def]
+    rw [starRingEnd_eq_starL, starRingEnd_eq_starL]
   have hset : (starRingEnd ℂ) ⁻¹' S = ⇑(starL ℂ).toContinuousLinearMap ⁻¹' S := by
     ext w
-    change (starRingEnd ℂ) w ∈ S ↔ (starL ℂ : ℂ ≃L⋆[ℂ] ℂ) w ∈ S
-    rw [starL_apply, starRingEnd_apply]
+    exact show (starRingEnd ℂ) w ∈ S ↔ ((starL ℂ).toContinuousLinearMap : ℂ → ℂ) w ∈ S by
+      rw [starRingEnd_eq_starL]
+      rfl
   rw [hfun, hset]
   exact hstar.differentiableWithinAt
 
 /--
 Conjugating both source and target preserves holomorphicity on domains, in both directions.
 -/
-lemma differentiableOn_starRingEnd_comp_starRingEnd_iff :
+@[simp]
+lemma differentiableOn_conj_conj_iff :
     DifferentiableOn ℂ (fun z => (starRingEnd ℂ) (f ((starRingEnd ℂ) z)))
         ((starRingEnd ℂ) '' S) ↔
       DifferentiableOn ℂ f S := by
   constructor
   · intro h
     have htwice :=
-      differentiableOn_starRingEnd_comp_starRingEnd
+      differentiableOn_conj_conj
         (S := (starRingEnd ℂ) '' S)
         (f := fun z => (starRingEnd ℂ) (f ((starRingEnd ℂ) z))) h
     simpa [Function.Involutive.image_eq_preimage_symm
       (starRingEnd_self_apply : Function.Involutive (starRingEnd ℂ)), Set.preimage_preimage,
       Function.comp_def] using htwice
-  · exact differentiableOn_starRingEnd_comp_starRingEnd
+  · exact differentiableOn_conj_conj
 
 end TauCeti

--- a/TauCeti/Analysis/Complex/Conformal/Reflection.lean
+++ b/TauCeti/Analysis/Complex/Conformal/Reflection.lean
@@ -1,0 +1,83 @@
+import Mathlib.Analysis.Calculus.Deriv.Star
+import Mathlib.Analysis.Complex.Basic
+
+/-!
+# Conjugation and open holomorphic domains
+
+This file records the elementary conjugation API used by the conformal-mapping roadmap's
+Schwarz-reflection layer.  Mathlib already proves the pointwise fact
+`DifferentiableAt.conj_conj`: if `f` is complex differentiable at `conj z`, then
+`z ↦ conj (f (conj z))` is complex differentiable at `z`.  The lemmas here package that
+pointwise result for open domains and reflected images, which is the form needed before the
+real-axis Schwarz reflection principle.
+-/
+
+namespace TauCeti
+
+open Complex Set
+open scoped ComplexConjugate
+
+variable {f : ℂ → ℂ} {S : Set ℂ} {z : ℂ}
+
+/-!
+Mathlib's conjugation lemmas are stated using both `conj` and `starRingEnd ℂ`; the
+conformal roadmap fixes `starRingEnd ℂ` as the reflection map.  The next two lemmas make the
+reflected set usable without unfolding the image witness.
+-/
+
+/-- Membership in the conjugate image of a set, written with `starRingEnd ℂ`. -/
+lemma mem_starRingEnd_image_iff :
+    z ∈ (starRingEnd ℂ) '' S ↔ (starRingEnd ℂ) z ∈ S := by
+  constructor
+  · rintro ⟨w, hw, rfl⟩
+    simpa using hw
+  · intro hz
+    refine ⟨(starRingEnd ℂ) z, hz, ?_⟩
+    simp
+
+/-- Since complex conjugation is an involution, its image of a set is its preimage. -/
+lemma starRingEnd_image_eq_preimage : (starRingEnd ℂ) '' S = (starRingEnd ℂ) ⁻¹' S := by
+  ext z
+  exact mem_starRingEnd_image_iff
+
+/-- Complex conjugation sends open subsets of `ℂ` to open subsets of `ℂ`. -/
+lemma isOpen_starRingEnd_image (hS : IsOpen S) : IsOpen ((starRingEnd ℂ) '' S) := by
+  rw [starRingEnd_image_eq_preimage]
+  exact hS.preimage continuous_star
+
+/--
+Open-domain form of the antiholomorphic-composition prerequisite for Schwarz reflection.
+
+If `f` is holomorphic on an open set `S`, then `z ↦ conj (f (conj z))` is holomorphic on the
+reflected open set `conj '' S`.  This is the `DifferentiableOn` wrapper around Mathlib's
+pointwise `DifferentiableAt.conj_conj`.
+-/
+lemma differentiableOn_starRingEnd_comp_starRingEnd_of_isOpen (hS : IsOpen S)
+    (hf : DifferentiableOn ℂ f S) :
+    DifferentiableOn ℂ (fun z => (starRingEnd ℂ) (f ((starRingEnd ℂ) z)))
+      ((starRingEnd ℂ) '' S) := by
+  intro z hz
+  have hzS : (starRingEnd ℂ) z ∈ S := mem_starRingEnd_image_iff.mp hz
+  have hfz : DifferentiableAt ℂ f ((starRingEnd ℂ) z) :=
+    (hf ((starRingEnd ℂ) z) hzS).differentiableAt (hS.mem_nhds hzS)
+  simpa [Function.comp_def] using (hfz.conj_conj).differentiableWithinAt
+
+/--
+Conjugating both source and target preserves holomorphicity on open domains, in both
+directions.
+-/
+lemma differentiableOn_starRingEnd_comp_starRingEnd_iff_of_isOpen (hS : IsOpen S) :
+    DifferentiableOn ℂ (fun z => (starRingEnd ℂ) (f ((starRingEnd ℂ) z)))
+        ((starRingEnd ℂ) '' S) ↔
+      DifferentiableOn ℂ f S := by
+  constructor
+  · intro h
+    have hopen : IsOpen ((starRingEnd ℂ) '' S) := isOpen_starRingEnd_image hS
+    have htwice :=
+      differentiableOn_starRingEnd_comp_starRingEnd_of_isOpen
+        (S := (starRingEnd ℂ) '' S)
+        (f := fun z => (starRingEnd ℂ) (f ((starRingEnd ℂ) z))) hopen h
+    simpa [starRingEnd_image_eq_preimage, Set.preimage_preimage, Function.comp_def] using htwice
+  · exact differentiableOn_starRingEnd_comp_starRingEnd_of_isOpen hS
+
+end TauCeti


### PR DESCRIPTION
This PR adds the open-domain antiholomorphic-composition adapter needed for Schwarz reflection: membership and openness bookkeeping for reflected subsets of `ℂ`, plus the `DifferentiableOn` theorem that `z ↦ conj (f (conj z))` is holomorphic on the reflected open set when `f` is holomorphic on the original open set.

This advances `TauCetiRoadmap/ConformalMapping/README.md`, Layer L4.0, “antiholomorphic composition (reflection prerequisite),” and the matching `TauCetiRoadmap/ConformalMapping/Targets.lean` L4.0 signature. I chose this as the lowest-hanging ConformalMapping target after checking open and recently merged PRs: Hurwitz, Montel, Schwarz--Pick, and RMT are much larger layers, while this is a proximate prerequisite for the real-axis Schwarz reflection principle and was not covered by existing PRs.

No Mathlib infrastructure is vendored. The implementation reuses Eric Wieser’s Mathlib pointwise conjugation calculus from `Mathlib.Analysis.Calculus.Deriv.Star`, especially `DifferentiableAt.conj_conj`, and Mathlib’s complex conjugation continuity API from `Mathlib.Analysis.Complex.Basic`.

`lake exe cache get` completed with `No files to download` and `Already decompressed 8602 file(s)`. `lake build` completed with `Build completed successfully (4349 jobs).` `lake exe axioms` completed with `axioms: audited 6469 TauCeti declaration(s); all within the allowlist [propext, Classical.choice, Quot.sound].`

<!--tauceti-target:v1 {"focus":"ConformalMapping","id":"antiholomorphic-composition"}-->

🤖 Prepared with Codex
