### PR TITLE
feat: add smooth ambient class forgetful map

### DIFF
--- a/TauCeti/Geometry/Manifold/SmoothEmbedding.lean
+++ b/TauCeti/Geometry/Manifold/SmoothEmbedding.lean
@@ -215,6 +215,15 @@ theorem prodMap_coe [IsManifold I n M] [IsManifold J n N]
   funext x
   exact prodMap_apply f g x
 
+/-- The underlying continuous map of a product of smooth embeddings is the product of the
+underlying continuous maps. -/
+@[simp]
+theorem toContinuousMap_prodMap [IsManifold I n M] [IsManifold J n N]
+    [IsManifold I' n M'] [IsManifold J' n N']
+    (f : SmoothEmbedding I J n M N) (g : SmoothEmbedding I' J' n M' N') :
+    (f.prodMap g).toContinuousMap = f.toContinuousMap.prodMap g.toContinuousMap := by
+  ext x <;> simp [toContinuousMap_apply, prodMap_apply]
+
 /-- The left coproduct inclusion as a bundled smooth embedding. -/
 def sumInl {M₂ : Type*} [TopologicalSpace M₂] [ChartedSpace H M₂]
     [IsManifold I n M] [IsManifold I n M₂] :

--- a/TauCeti/Geometry/Manifold/SmoothEmbedding/AmbientIsotopyClassContinuous.lean
+++ b/TauCeti/Geometry/Manifold/SmoothEmbedding/AmbientIsotopyClassContinuous.lean
@@ -82,6 +82,7 @@ theorem toContinuousClass_unique
       (TauCeti.ambientIsotopic_def.2 (SmoothEmbedding.ambientIsotopic_def.1 hfg))) F hF
 
 /-- Forgetting smooth ambient-isotopy classes to continuous classes commutes with products. -/
+@[simp]
 theorem toContinuousClass_prodMap [IsManifold I₁ n M₁] [IsManifold I₂ n M₂]
     [IsManifold J₁ n N₁] [IsManifold J₂ n N₂]
     (x : AmbientIsotopyClass I₁ J₁ n M₁ N₁)
@@ -95,8 +96,7 @@ theorem toContinuousClass_prodMap [IsManifold I₁ n M₁] [IsManifold I₂ n M�
   rw [SmoothEmbedding.AmbientIsotopyClass.prodMap_mk_mk, toContinuousClass_mk,
     toContinuousClass_mk, toContinuousClass_mk, TauCeti.AmbientIsotopyClass.prodMap_mk_mk]
   apply TauCeti.AmbientIsotopyClass.mk_eq_mk
-  convert TauCeti.AmbientIsotopic.refl (f.toContinuousMap.prodMap g.toContinuousMap) using 1
-  ext p <;> simp [SmoothEmbedding.prodMap_apply]
+  rw [SmoothEmbedding.toContinuousMap_prodMap]
 
 end AmbientIsotopyClass
 

--- a/TauCeti/Geometry/Manifold/SmoothEmbedding/AmbientIsotopyClassContinuous.lean
+++ b/TauCeti/Geometry/Manifold/SmoothEmbedding/AmbientIsotopyClassContinuous.lean
@@ -1,0 +1,105 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+module
+
+public import TauCeti.Geometry.Manifold.SmoothEmbedding.AmbientIsotopyProd
+public import TauCeti.Topology.Homotopy.AmbientIsotopyClassProd
+
+/-!
+# Forgetting smooth ambient-isotopy classes to continuous classes
+
+The geometric-topology roadmap treats a geometric knot presentation as a smooth embedding, but
+also insists that isotopy and ambient isotopy be defined first for arbitrary continuous maps. This
+file connects the two layers: a bundled smooth embedding has an underlying continuous map, and
+ambient isotopy of smooth embeddings was defined by ambient isotopy of those underlying maps, so
+there is a canonical map from smooth-embedding ambient-isotopy classes to continuous
+ambient-isotopy classes.
+
+The map is deliberately only forgetful: it does not assert that every continuous class contains a
+smooth representative. The product compatibility theorem records that forgetting commutes with the
+already-defined product of smooth embedding classes.
+
+## Main definitions
+
+* `TauCeti.SmoothEmbedding.AmbientIsotopyClass.toContinuousClass`: forget a smooth-embedding
+  ambient-isotopy class to the ambient-isotopy class of its underlying continuous map.
+* `TauCeti.SmoothEmbedding.AmbientIsotopyClass.toContinuousClass_prodMap`: forgetting commutes
+  with product classes.
+-/
+
+public section
+
+namespace TauCeti
+
+open scoped Manifold ContDiff
+
+namespace SmoothEmbedding
+
+variable {𝕜 : Type*} [NontriviallyNormedField 𝕜]
+  {E₁ : Type*} [NormedAddCommGroup E₁] [NormedSpace 𝕜 E₁]
+  {E₂ : Type*} [NormedAddCommGroup E₂] [NormedSpace 𝕜 E₂]
+  {F₁ : Type*} [NormedAddCommGroup F₁] [NormedSpace 𝕜 F₁]
+  {F₂ : Type*} [NormedAddCommGroup F₂] [NormedSpace 𝕜 F₂]
+  {H₁ : Type*} [TopologicalSpace H₁] {H₂ : Type*} [TopologicalSpace H₂]
+  {G₁ : Type*} [TopologicalSpace G₁] {G₂ : Type*} [TopologicalSpace G₂]
+  {I₁ : ModelWithCorners 𝕜 E₁ H₁} {I₂ : ModelWithCorners 𝕜 E₂ H₂}
+  {J₁ : ModelWithCorners 𝕜 F₁ G₁} {J₂ : ModelWithCorners 𝕜 F₂ G₂}
+  {M₁ : Type*} [TopologicalSpace M₁] [ChartedSpace H₁ M₁]
+  {M₂ : Type*} [TopologicalSpace M₂] [ChartedSpace H₂ M₂]
+  {N₁ : Type*} [TopologicalSpace N₁] [ChartedSpace G₁ N₁]
+  {N₂ : Type*} [TopologicalSpace N₂] [ChartedSpace G₂ N₂]
+  {n : ℕ∞ω}
+
+namespace AmbientIsotopyClass
+
+/-- Forget a smooth-embedding ambient-isotopy class to the ambient-isotopy class of its underlying
+continuous map. -/
+def toContinuousClass :
+    AmbientIsotopyClass I₁ J₁ n M₁ N₁ → TauCeti.AmbientIsotopyClass M₁ N₁ :=
+  lift (fun f => TauCeti.AmbientIsotopyClass.mk f.toContinuousMap) fun {_ _} hfg =>
+    TauCeti.AmbientIsotopyClass.mk_eq_mk
+      (TauCeti.ambientIsotopic_def.2 (SmoothEmbedding.ambientIsotopic_def.1 hfg))
+
+/-- Computation rule for `AmbientIsotopyClass.toContinuousClass` on representatives. -/
+@[simp]
+theorem toContinuousClass_mk (f : SmoothEmbedding I₁ J₁ n M₁ N₁) :
+    toContinuousClass (mk f) = TauCeti.AmbientIsotopyClass.mk f.toContinuousMap :=
+  lift_mk (fun f => TauCeti.AmbientIsotopyClass.mk f.toContinuousMap)
+    (fun {_ _} hfg => TauCeti.AmbientIsotopyClass.mk_eq_mk
+      (TauCeti.ambientIsotopic_def.2 (SmoothEmbedding.ambientIsotopic_def.1 hfg))) f
+
+/-- The forgetful map to continuous ambient-isotopy classes is the unique map with the expected
+value on representatives. -/
+theorem toContinuousClass_unique
+    (F : AmbientIsotopyClass I₁ J₁ n M₁ N₁ → TauCeti.AmbientIsotopyClass M₁ N₁)
+    (hF : ∀ f : SmoothEmbedding I₁ J₁ n M₁ N₁,
+      F (mk f) = TauCeti.AmbientIsotopyClass.mk f.toContinuousMap) :
+    F = toContinuousClass :=
+  lift_unique (fun f => TauCeti.AmbientIsotopyClass.mk f.toContinuousMap)
+    (fun {_ _} hfg => TauCeti.AmbientIsotopyClass.mk_eq_mk
+      (TauCeti.ambientIsotopic_def.2 (SmoothEmbedding.ambientIsotopic_def.1 hfg))) F hF
+
+/-- Forgetting smooth ambient-isotopy classes to continuous classes commutes with products. -/
+theorem toContinuousClass_prodMap [IsManifold I₁ n M₁] [IsManifold I₂ n M₂]
+    [IsManifold J₁ n N₁] [IsManifold J₂ n N₂]
+    (x : AmbientIsotopyClass I₁ J₁ n M₁ N₁)
+    (y : AmbientIsotopyClass I₂ J₂ n M₂ N₂) :
+    toContinuousClass (prodMap x y) =
+      TauCeti.AmbientIsotopyClass.prodMap (toContinuousClass x) (toContinuousClass y) := by
+  refine induction_on x ?_
+  intro f
+  refine induction_on y ?_
+  intro g
+  rw [SmoothEmbedding.AmbientIsotopyClass.prodMap_mk_mk, toContinuousClass_mk,
+    toContinuousClass_mk, toContinuousClass_mk, TauCeti.AmbientIsotopyClass.prodMap_mk_mk]
+  apply TauCeti.AmbientIsotopyClass.mk_eq_mk
+  convert TauCeti.AmbientIsotopic.refl (f.toContinuousMap.prodMap g.toContinuousMap) using 1
+  ext p <;> simp [SmoothEmbedding.prodMap_apply]
+
+end AmbientIsotopyClass
+
+end SmoothEmbedding
+
+end TauCeti

--- a/TauCeti/Topology/Homotopy/AmbientIsotopyClass.lean
+++ b/TauCeti/Topology/Homotopy/AmbientIsotopyClass.lean
@@ -24,6 +24,7 @@ their own stronger smooth or PL data elsewhere.
 * `TauCeti.AmbientIsotopyClass X Y`: continuous maps `X → Y` modulo ambient isotopy of `Y`.
 * `TauCeti.AmbientIsotopyClass.lift`: descend ambient-isotopy-invariant functions.
 * `TauCeti.AmbientIsotopyClass.map`: descend ambient-isotopy-preserving operations.
+* `TauCeti.AmbientIsotopyClass.map₂`: descend binary ambient-isotopy-preserving operations.
 * `TauCeti.AmbientIsotopyClass.precomp`: precompose classes by a continuous source map.
 * `TauCeti.AmbientIsotopyClass.postcompHomeomorph`: postcompose classes by a homeomorphism of
   ambient spaces.
@@ -43,8 +44,9 @@ namespace TauCeti
 
 open ContinuousMap
 
-variable {U W X Y Z : Type*} [TopologicalSpace U] [TopologicalSpace W] [TopologicalSpace X]
-  [TopologicalSpace Y] [TopologicalSpace Z]
+variable {U W X Y Z X' Y' : Type*} [TopologicalSpace U] [TopologicalSpace W]
+  [TopologicalSpace X] [TopologicalSpace Y] [TopologicalSpace Z] [TopologicalSpace X']
+  [TopologicalSpace Y']
 
 /-- Continuous maps `X → Y` modulo ambient isotopy of the ambient space `Y`. -/
 abbrev AmbientIsotopyClass (X Y : Type*) [TopologicalSpace X] [TopologicalSpace Y] : Type _ :=
@@ -125,6 +127,28 @@ theorem map_mk (F : C(X, Y) → C(W, Z))
       AmbientIsotopic.setoid_r_iff.2
         (hF (f := f) (g := g) (AmbientIsotopic.setoid_r_iff.1 hfg)))
     f
+
+/-- Descend a binary ambient-isotopy-preserving operation between continuous-map types to their
+ambient-isotopy quotients. -/
+def map₂ (F : C(X, Y) → C(X', Y') → C(W, Z))
+    (hF : ∀ ⦃f f' : C(X, Y)⦄, AmbientIsotopic f f' →
+      ∀ ⦃g g' : C(X', Y')⦄, AmbientIsotopic g g' → AmbientIsotopic (F f g) (F f' g')) :
+    AmbientIsotopyClass X Y → AmbientIsotopyClass X' Y' → AmbientIsotopyClass W Z :=
+  Quotient.map₂ F fun {_ _} hff' {_ _} hgg' =>
+    AmbientIsotopic.setoid_r_iff.2
+      (hF (AmbientIsotopic.setoid_r_iff.1 hff') (AmbientIsotopic.setoid_r_iff.1 hgg'))
+
+/-- Computation rule for `AmbientIsotopyClass.map₂` on representatives. -/
+@[simp]
+theorem map₂_mk_mk (F : C(X, Y) → C(X', Y') → C(W, Z))
+    (hF : ∀ ⦃f f' : C(X, Y)⦄, AmbientIsotopic f f' →
+      ∀ ⦃g g' : C(X', Y')⦄, AmbientIsotopic g g' → AmbientIsotopic (F f g) (F f' g'))
+    (f : C(X, Y)) (g : C(X', Y')) :
+    map₂ F hF (mk f) (mk g) = mk (F f g) :=
+  (Quotient.map₂_mk F (fun {_ _} hff' {_ _} hgg' =>
+    AmbientIsotopic.setoid_r_iff.2
+      (hF (AmbientIsotopic.setoid_r_iff.1 hff')
+        (AmbientIsotopic.setoid_r_iff.1 hgg'))) f g)
 
 /-- Precompose an ambient-isotopy class by a continuous map of source spaces.
 

--- a/TauCeti/Topology/Homotopy/AmbientIsotopyClassProd.lean
+++ b/TauCeti/Topology/Homotopy/AmbientIsotopyClassProd.lean
@@ -1,0 +1,81 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+module
+
+public import TauCeti.Topology.Homotopy.AmbientIsotopyClass
+public import TauCeti.Topology.Homotopy.IsotopyProd
+
+/-!
+# Products of ambient-isotopy classes
+
+The geometric-topology roadmap asks for isotopy and ambient isotopy to be defined once for
+continuous maps, then specialised to geometric knot presentations and other embedding
+presentations. `TauCeti.Topology.Homotopy.IsotopyProd` proves that products preserve the
+ambient-isotopy relation. This file records the corresponding quotient-level product operation
+on continuous ambient-isotopy classes.
+
+This is still a point-set topological construction: it takes classes of continuous maps
+`X → Y` and `X' → Y'` to the class of the product map `X × X' → Y × Y'`.
+
+## Main definitions
+
+* `TauCeti.AmbientIsotopyClass.prodMap`: the product of two continuous ambient-isotopy classes.
+* `TauCeti.AmbientIsotopyClass.prodMap_mk_mk`: the representative computation rule.
+-/
+
+public section
+
+namespace TauCeti
+
+open ContinuousMap
+
+variable {X Y X' Y' : Type*} [TopologicalSpace X] [TopologicalSpace Y]
+  [TopologicalSpace X'] [TopologicalSpace Y']
+
+namespace AmbientIsotopyClass
+
+/-- Descend a binary ambient-isotopy-preserving operation between continuous-map types to their
+ambient-isotopy quotients. -/
+def map₂ (F : C(X, Y) → C(X', Y') → C(X × X', Y × Y'))
+    (hF : ∀ ⦃f f' : C(X, Y)⦄, AmbientIsotopic f f' →
+      ∀ ⦃g g' : C(X', Y')⦄, AmbientIsotopic g g' → AmbientIsotopic (F f g) (F f' g')) :
+    AmbientIsotopyClass X Y → AmbientIsotopyClass X' Y' →
+      AmbientIsotopyClass (X × X') (Y × Y') :=
+  Quotient.map₂ F fun {_ _} hff' {_ _} hgg' =>
+    AmbientIsotopic.setoid_r_iff.2
+      (hF (AmbientIsotopic.setoid_r_iff.1 hff') (AmbientIsotopic.setoid_r_iff.1 hgg'))
+
+/-- Computation rule for `AmbientIsotopyClass.map₂` on representatives. -/
+@[simp]
+theorem map₂_mk_mk (F : C(X, Y) → C(X', Y') → C(X × X', Y × Y'))
+    (hF : ∀ ⦃f f' : C(X, Y)⦄, AmbientIsotopic f f' →
+      ∀ ⦃g g' : C(X', Y')⦄, AmbientIsotopic g g' → AmbientIsotopic (F f g) (F f' g'))
+    (f : C(X, Y)) (g : C(X', Y')) :
+    map₂ F hF (mk f) (mk g) = mk (F f g) :=
+  (Quotient.map₂_mk F (fun {_ _} hff' {_ _} hgg' =>
+    AmbientIsotopic.setoid_r_iff.2
+      (hF (AmbientIsotopic.setoid_r_iff.1 hff')
+        (AmbientIsotopic.setoid_r_iff.1 hgg'))) f g)
+
+/-- The product of ambient-isotopy classes of continuous maps.
+
+This is the quotient-level operation induced by `ContinuousMap.prodMap`; product closure of
+ambient isotopy is supplied by `TauCeti.AmbientIsotopic.prodMap`. -/
+def prodMap :
+    AmbientIsotopyClass X Y → AmbientIsotopyClass X' Y' →
+      AmbientIsotopyClass (X × X') (Y × Y') :=
+  map₂ (fun f g => f.prodMap g) fun {_ _} hff' {_ _} hgg' =>
+    AmbientIsotopic.prodMap hff' hgg'
+
+/-- Computation rule for `AmbientIsotopyClass.prodMap` on representatives. -/
+@[simp]
+theorem prodMap_mk_mk (f : C(X, Y)) (g : C(X', Y')) :
+    prodMap (mk f) (mk g) = mk (f.prodMap g) :=
+  map₂_mk_mk (fun f g => f.prodMap g)
+    (fun {_ _} hff' {_ _} hgg' => AmbientIsotopic.prodMap hff' hgg') f g
+
+end AmbientIsotopyClass
+
+end TauCeti

--- a/TauCeti/Topology/Homotopy/AmbientIsotopyClassProd.lean
+++ b/TauCeti/Topology/Homotopy/AmbientIsotopyClassProd.lean
@@ -36,29 +36,6 @@ variable {X Y X' Y' : Type*} [TopologicalSpace X] [TopologicalSpace Y]
 
 namespace AmbientIsotopyClass
 
-/-- Descend a binary ambient-isotopy-preserving operation between continuous-map types to their
-ambient-isotopy quotients. -/
-def map₂ (F : C(X, Y) → C(X', Y') → C(X × X', Y × Y'))
-    (hF : ∀ ⦃f f' : C(X, Y)⦄, AmbientIsotopic f f' →
-      ∀ ⦃g g' : C(X', Y')⦄, AmbientIsotopic g g' → AmbientIsotopic (F f g) (F f' g')) :
-    AmbientIsotopyClass X Y → AmbientIsotopyClass X' Y' →
-      AmbientIsotopyClass (X × X') (Y × Y') :=
-  Quotient.map₂ F fun {_ _} hff' {_ _} hgg' =>
-    AmbientIsotopic.setoid_r_iff.2
-      (hF (AmbientIsotopic.setoid_r_iff.1 hff') (AmbientIsotopic.setoid_r_iff.1 hgg'))
-
-/-- Computation rule for `AmbientIsotopyClass.map₂` on representatives. -/
-@[simp]
-theorem map₂_mk_mk (F : C(X, Y) → C(X', Y') → C(X × X', Y × Y'))
-    (hF : ∀ ⦃f f' : C(X, Y)⦄, AmbientIsotopic f f' →
-      ∀ ⦃g g' : C(X', Y')⦄, AmbientIsotopic g g' → AmbientIsotopic (F f g) (F f' g'))
-    (f : C(X, Y)) (g : C(X', Y')) :
-    map₂ F hF (mk f) (mk g) = mk (F f g) :=
-  (Quotient.map₂_mk F (fun {_ _} hff' {_ _} hgg' =>
-    AmbientIsotopic.setoid_r_iff.2
-      (hF (AmbientIsotopic.setoid_r_iff.1 hff')
-        (AmbientIsotopic.setoid_r_iff.1 hgg'))) f g)
-
 /-- The product of ambient-isotopy classes of continuous maps.
 
 This is the quotient-level operation induced by `ContinuousMap.prodMap`; product closure of


### PR DESCRIPTION
This PR adds the quotient-level product operation for continuous ambient-isotopy classes and the forgetful map from bundled smooth-embedding ambient-isotopy classes to continuous ambient-isotopy classes, with a product compatibility theorem. Use this to connect the roadmap's smooth geometric presentations to the point-set isotopy layer without introducing a privileged knot type or assuming that continuous classes have smooth representatives.

This advances `TauCetiRoadmap/GeometricTopology/README.md`, the Encoding conventions item “Isotopy is defined generally, then specialised,” and Layer 4, “the geometric presentation is simply a smooth embedding `S¹ ↪ M`,” as a clean prerequisite for routing smooth geometric knot presentations through the general continuous ambient-isotopy quotient. I chose this after checking open and recently merged PRs: no open or recent PR covered GeometricTopology, and `main` already had the isotopy spine, smooth embedding quotient, and product closure, while the forgetful bridge from smooth presentation classes to the general continuous class layer was still absent.

No Mathlib infrastructure is vendored. The implementation reuses Tau Ceti’s existing `TauCeti.AmbientIsotopic.prodMap`, `TauCeti.AmbientIsotopyClass.{map,mk_eq_mk}`, `TauCeti.SmoothEmbedding.AmbientIsotopyClass.{lift,prodMap}`, and the existing definition of smooth-embedding ambient isotopy as ambient isotopy of the underlying continuous maps.

`lake exe cache get` completed with `No files to download` and `Already decompressed 8602 file(s)`. `lake build` completed with `Build completed successfully (4348 jobs).` `lake exe axioms` completed with `axioms: audited 6475 TauCeti declaration(s); all within the allowlist [propext, Classical.choice, Quot.sound].`

<!--tauceti-target:v1 {"focus":"GeometricTopology","id":"smooth-embedding-continuous-ambient-class"}-->

🤖 Prepared with Codex
