### PR TITLE
feat: add Lagrangian rescale API

### DIFF
--- a/TauCeti/Geometry/Symplectic/Lagrangian.lean
+++ b/TauCeti/Geometry/Symplectic/Lagrangian.lean
@@ -87,17 +87,14 @@ lemma le_orthogonal_orthogonal : L ≤ ω.orthogonal (ω.orthogonal L) :=
 
 /-- A submodule is isotropic if it is contained in its symplectic complement, equivalently `ω`
 vanishes on it. -/
-@[expose]
 def IsIsotropic (ω : SymplecticForm V) (L : Submodule ℝ V) : Prop :=
   L ≤ ω.orthogonal L
 
 /-- A submodule is coisotropic if it contains its symplectic complement. -/
-@[expose]
 def IsCoisotropic (ω : SymplecticForm V) (L : Submodule ℝ V) : Prop :=
   ω.orthogonal L ≤ L
 
 /-- A submodule is Lagrangian if it equals its own symplectic complement. -/
-@[expose]
 def IsLagrangian (ω : SymplecticForm V) (L : Submodule ℝ V) : Prop :=
   ω.orthogonal L = L
 

--- a/TauCeti/Geometry/Symplectic/Lagrangian.lean
+++ b/TauCeti/Geometry/Symplectic/Lagrangian.lean
@@ -87,14 +87,17 @@ lemma le_orthogonal_orthogonal : L ≤ ω.orthogonal (ω.orthogonal L) :=
 
 /-- A submodule is isotropic if it is contained in its symplectic complement, equivalently `ω`
 vanishes on it. -/
+@[expose]
 def IsIsotropic (ω : SymplecticForm V) (L : Submodule ℝ V) : Prop :=
   L ≤ ω.orthogonal L
 
 /-- A submodule is coisotropic if it contains its symplectic complement. -/
+@[expose]
 def IsCoisotropic (ω : SymplecticForm V) (L : Submodule ℝ V) : Prop :=
   ω.orthogonal L ≤ L
 
 /-- A submodule is Lagrangian if it equals its own symplectic complement. -/
+@[expose]
 def IsLagrangian (ω : SymplecticForm V) (L : Submodule ℝ V) : Prop :=
   ω.orthogonal L = L
 

--- a/TauCeti/Geometry/Symplectic/Rescale.lean
+++ b/TauCeti/Geometry/Symplectic/Rescale.lean
@@ -41,16 +41,10 @@ public section
 
 namespace TauCeti
 
-namespace LinearMap
-
-namespace BilinForm
-
-variable {R : Type*} {M : Type*} [CommRing R] [IsDomain R] [AddCommGroup M] [Module R M]
-variable (B : _root_.LinearMap.BilinForm R M) {L : Submodule R M}
-
-/-- Nonzero scalar multiplication of a bilinear form leaves orthogonal complements unchanged. -/
-@[simp]
-lemma orthogonal_smul {c : R} (hc : c ≠ 0) : (c • B).orthogonal L = B.orthogonal L := by
+private lemma bilinearForm_orthogonal_smul {R : Type*} {M : Type*}
+    [CommSemiring R] [NoZeroDivisors R] [AddCommMonoid M] [Module R M]
+    (B : _root_.LinearMap.BilinForm R M) {L : Submodule R M} {c : R} (hc : c ≠ 0) :
+    (c • B).orthogonal L = B.orthogonal L := by
   ext x
   rw [_root_.LinearMap.BilinForm.mem_orthogonal_iff,
     _root_.LinearMap.BilinForm.mem_orthogonal_iff]
@@ -60,10 +54,6 @@ lemma orthogonal_smul {c : R} (hc : c ≠ 0) : (c • B).orthogonal L = B.orthog
     exact (mul_eq_zero.mp hyx).resolve_left hc
   · intro h y hy
     simp [h y hy]
-
-end BilinForm
-
-end LinearMap
 
 namespace SymplecticForm
 
@@ -125,15 +115,19 @@ variable {L : Submodule ℝ V}
 lemma orthogonal_rescale (c : ℝ) (hc : c ≠ 0) :
     (ω.rescale c hc).orthogonal L = ω.orthogonal L := by
   rw [orthogonal_def, orthogonal_def, rescale_toBilinForm,
-    TauCeti.LinearMap.BilinForm.orthogonal_smul ω.toBilinForm hc]
+    bilinearForm_orthogonal_smul ω.toBilinForm hc]
 
 /-- Nonzero rescaling preserves and reflects isotropic subspaces. -/
 @[simp]
 lemma isIsotropic_rescale_iff (c : ℝ) (hc : c ≠ 0) :
     (ω.rescale c hc).IsIsotropic L ↔ ω.IsIsotropic L := by
-  rw [TauCeti.SymplecticForm.IsIsotropic.eq_def,
-    TauCeti.SymplecticForm.IsIsotropic.eq_def]
-  rw [orthogonal_rescale c hc]
+  rw [isIsotropic_iff, isIsotropic_iff]
+  constructor
+  · intro h v hv w hw
+    have hvw := h v hv w hw
+    simpa only [rescale_apply] using (mul_eq_zero.mp hvw).resolve_left hc
+  · intro h v hv w hw
+    simp [h v hv w hw]
 
 /-- Isotropy is preserved by nonzero rescaling of the symplectic form. -/
 lemma IsIsotropic.rescale (h : ω.IsIsotropic L) (c : ℝ) (hc : c ≠ 0) :
@@ -144,9 +138,7 @@ lemma IsIsotropic.rescale (h : ω.IsIsotropic L) (c : ℝ) (hc : c ≠ 0) :
 @[simp]
 lemma isCoisotropic_rescale_iff (c : ℝ) (hc : c ≠ 0) :
     (ω.rescale c hc).IsCoisotropic L ↔ ω.IsCoisotropic L := by
-  rw [TauCeti.SymplecticForm.IsCoisotropic.eq_def,
-    TauCeti.SymplecticForm.IsCoisotropic.eq_def]
-  rw [orthogonal_rescale c hc]
+  rw [isCoisotropic_iff, isCoisotropic_iff, orthogonal_rescale c hc]
 
 /-- Coisotropy is preserved by nonzero rescaling of the symplectic form. -/
 lemma IsCoisotropic.rescale (h : ω.IsCoisotropic L) (c : ℝ) (hc : c ≠ 0) :
@@ -157,9 +149,8 @@ lemma IsCoisotropic.rescale (h : ω.IsCoisotropic L) (c : ℝ) (hc : c ≠ 0) :
 @[simp]
 lemma isLagrangian_rescale_iff (c : ℝ) (hc : c ≠ 0) :
     (ω.rescale c hc).IsLagrangian L ↔ ω.IsLagrangian L := by
-  rw [TauCeti.SymplecticForm.IsLagrangian.eq_def,
-    TauCeti.SymplecticForm.IsLagrangian.eq_def]
-  rw [orthogonal_rescale c hc]
+  rw [isLagrangian_iff, isLagrangian_iff, isIsotropic_rescale_iff c hc,
+    isCoisotropic_rescale_iff c hc]
 
 /-- Lagrangian subspaces are preserved by nonzero rescaling of the symplectic form. -/
 lemma IsLagrangian.rescale (h : ω.IsLagrangian L) (c : ℝ) (hc : c ≠ 0) :

--- a/TauCeti/Geometry/Symplectic/Rescale.lean
+++ b/TauCeti/Geometry/Symplectic/Rescale.lean
@@ -41,6 +41,30 @@ public section
 
 namespace TauCeti
 
+namespace LinearMap
+
+namespace BilinForm
+
+variable {R : Type*} {M : Type*} [CommRing R] [IsDomain R] [AddCommGroup M] [Module R M]
+variable (B : _root_.LinearMap.BilinForm R M) {L : Submodule R M}
+
+/-- Nonzero scalar multiplication of a bilinear form leaves orthogonal complements unchanged. -/
+@[simp]
+lemma orthogonal_smul {c : R} (hc : c ≠ 0) : (c • B).orthogonal L = B.orthogonal L := by
+  ext x
+  rw [_root_.LinearMap.BilinForm.mem_orthogonal_iff,
+    _root_.LinearMap.BilinForm.mem_orthogonal_iff]
+  constructor
+  · intro h y hy
+    have hyx : c * B y x = 0 := by simpa using h y hy
+    exact (mul_eq_zero.mp hyx).resolve_left hc
+  · intro h y hy
+    simp [h y hy]
+
+end BilinForm
+
+end LinearMap
+
 namespace SymplecticForm
 
 variable {V : Type*} [AddCommGroup V] [Module ℝ V]
@@ -100,28 +124,16 @@ variable {L : Submodule ℝ V}
 @[simp]
 lemma orthogonal_rescale (c : ℝ) (hc : c ≠ 0) :
     (ω.rescale c hc).orthogonal L = ω.orthogonal L := by
-  ext x
-  rw [mem_orthogonal_iff, mem_orthogonal_iff]
-  constructor
-  · intro h y hy
-    have hyx := h y hy
-    simp only [rescale_apply] at hyx
-    exact (mul_eq_zero.mp hyx).resolve_left hc
-  · intro h y hy
-    simp [h y hy]
+  rw [orthogonal_def, orthogonal_def, rescale_toBilinForm,
+    TauCeti.LinearMap.BilinForm.orthogonal_smul ω.toBilinForm hc]
 
 /-- Nonzero rescaling preserves and reflects isotropic subspaces. -/
 @[simp]
 lemma isIsotropic_rescale_iff (c : ℝ) (hc : c ≠ 0) :
     (ω.rescale c hc).IsIsotropic L ↔ ω.IsIsotropic L := by
-  rw [isIsotropic_iff, isIsotropic_iff]
-  constructor
-  · intro h v hv w hw
-    have hvw := h v hv w hw
-    simp only [rescale_apply] at hvw
-    exact (mul_eq_zero.mp hvw).resolve_left hc
-  · intro h v hv w hw
-    simp [h v hv w hw]
+  rw [TauCeti.SymplecticForm.IsIsotropic.eq_def,
+    TauCeti.SymplecticForm.IsIsotropic.eq_def]
+  rw [orthogonal_rescale c hc]
 
 /-- Isotropy is preserved by nonzero rescaling of the symplectic form. -/
 lemma IsIsotropic.rescale (h : ω.IsIsotropic L) (c : ℝ) (hc : c ≠ 0) :
@@ -132,7 +144,9 @@ lemma IsIsotropic.rescale (h : ω.IsIsotropic L) (c : ℝ) (hc : c ≠ 0) :
 @[simp]
 lemma isCoisotropic_rescale_iff (c : ℝ) (hc : c ≠ 0) :
     (ω.rescale c hc).IsCoisotropic L ↔ ω.IsCoisotropic L := by
-  rw [isCoisotropic_iff, isCoisotropic_iff, orthogonal_rescale]
+  rw [TauCeti.SymplecticForm.IsCoisotropic.eq_def,
+    TauCeti.SymplecticForm.IsCoisotropic.eq_def]
+  rw [orthogonal_rescale c hc]
 
 /-- Coisotropy is preserved by nonzero rescaling of the symplectic form. -/
 lemma IsCoisotropic.rescale (h : ω.IsCoisotropic L) (c : ℝ) (hc : c ≠ 0) :
@@ -143,8 +157,9 @@ lemma IsCoisotropic.rescale (h : ω.IsCoisotropic L) (c : ℝ) (hc : c ≠ 0) :
 @[simp]
 lemma isLagrangian_rescale_iff (c : ℝ) (hc : c ≠ 0) :
     (ω.rescale c hc).IsLagrangian L ↔ ω.IsLagrangian L := by
-  rw [isLagrangian_iff, isLagrangian_iff, isIsotropic_rescale_iff c hc,
-    isCoisotropic_rescale_iff c hc]
+  rw [TauCeti.SymplecticForm.IsLagrangian.eq_def,
+    TauCeti.SymplecticForm.IsLagrangian.eq_def]
+  rw [orthogonal_rescale c hc]
 
 /-- Lagrangian subspaces are preserved by nonzero rescaling of the symplectic form. -/
 lemma IsLagrangian.rescale (h : ω.IsLagrangian L) (c : ℝ) (hc : c ≠ 0) :

--- a/TauCeti/Geometry/Symplectic/Rescale.lean
+++ b/TauCeti/Geometry/Symplectic/Rescale.lean
@@ -4,7 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 -/
 module
 
-public import TauCeti.Geometry.Symplectic.AlmostComplex
+public import TauCeti.Geometry.Symplectic.Lagrangian
 
 /-!
 # Rescaling symplectic forms
@@ -28,6 +28,10 @@ they do preserve invariance because invariance is linear in the form.
   reflects compatibility.
 * `TauCeti.SymplecticForm.compatible_rescale_neg_iff_of_neg`: negative rescaling preserves and
   reflects compatibility after replacing `J` by `-J`.
+* `TauCeti.SymplecticForm.orthogonal_rescale`: nonzero rescaling leaves symplectic complements
+  unchanged.
+* `TauCeti.SymplecticForm.isLagrangian_rescale_iff`: nonzero rescaling preserves and reflects
+  Lagrangian subspaces.
 
 The convention is the standard one from symplectic geometry: changing the overall positive scale
 of `ω` changes the metric scale but not the compatible almost complex structure.
@@ -90,6 +94,62 @@ lemma rescale_rescale (ω : SymplecticForm V) (c d : ℝ) (hc : c ≠ 0) (hd : d
     simp [mul_assoc]
 
 variable {ω : SymplecticForm V} {J : AlmostComplexStructure V}
+variable {L : Submodule ℝ V}
+
+/-- Nonzero rescaling leaves the symplectic complement of a subspace unchanged. -/
+@[simp]
+lemma orthogonal_rescale (c : ℝ) (hc : c ≠ 0) :
+    (ω.rescale c hc).orthogonal L = ω.orthogonal L := by
+  ext x
+  rw [mem_orthogonal_iff, mem_orthogonal_iff]
+  constructor
+  · intro h y hy
+    have hyx := h y hy
+    simp only [rescale_apply] at hyx
+    exact (mul_eq_zero.mp hyx).resolve_left hc
+  · intro h y hy
+    simp [h y hy]
+
+/-- Nonzero rescaling preserves and reflects isotropic subspaces. -/
+@[simp]
+lemma isIsotropic_rescale_iff (c : ℝ) (hc : c ≠ 0) :
+    (ω.rescale c hc).IsIsotropic L ↔ ω.IsIsotropic L := by
+  rw [isIsotropic_iff, isIsotropic_iff]
+  constructor
+  · intro h v hv w hw
+    have hvw := h v hv w hw
+    simp only [rescale_apply] at hvw
+    exact (mul_eq_zero.mp hvw).resolve_left hc
+  · intro h v hv w hw
+    simp [h v hv w hw]
+
+/-- Isotropy is preserved by nonzero rescaling of the symplectic form. -/
+lemma IsIsotropic.rescale (h : ω.IsIsotropic L) (c : ℝ) (hc : c ≠ 0) :
+    (ω.rescale c hc).IsIsotropic L :=
+  (isIsotropic_rescale_iff c hc).mpr h
+
+/-- Nonzero rescaling preserves and reflects coisotropic subspaces. -/
+@[simp]
+lemma isCoisotropic_rescale_iff (c : ℝ) (hc : c ≠ 0) :
+    (ω.rescale c hc).IsCoisotropic L ↔ ω.IsCoisotropic L := by
+  rw [isCoisotropic_iff, isCoisotropic_iff, orthogonal_rescale]
+
+/-- Coisotropy is preserved by nonzero rescaling of the symplectic form. -/
+lemma IsCoisotropic.rescale (h : ω.IsCoisotropic L) (c : ℝ) (hc : c ≠ 0) :
+    (ω.rescale c hc).IsCoisotropic L :=
+  (isCoisotropic_rescale_iff c hc).mpr h
+
+/-- Nonzero rescaling preserves and reflects Lagrangian subspaces. -/
+@[simp]
+lemma isLagrangian_rescale_iff (c : ℝ) (hc : c ≠ 0) :
+    (ω.rescale c hc).IsLagrangian L ↔ ω.IsLagrangian L := by
+  rw [isLagrangian_iff, isLagrangian_iff, isIsotropic_rescale_iff c hc,
+    isCoisotropic_rescale_iff c hc]
+
+/-- Lagrangian subspaces are preserved by nonzero rescaling of the symplectic form. -/
+lemma IsLagrangian.rescale (h : ω.IsLagrangian L) (c : ℝ) (hc : c ≠ 0) :
+    (ω.rescale c hc).IsLagrangian L :=
+  (isLagrangian_rescale_iff c hc).mpr h
 
 /-- The associated bilinear form of a rescaled symplectic form is rescaled by the same factor. -/
 @[simp]


### PR DESCRIPTION
This PR records the scale-invariance API for pointwise Lagrangian boundary subspaces: nonzero rescaling of a symplectic form leaves symplectic complements unchanged, and therefore preserves and reflects isotropic, coisotropic, and Lagrangian subspaces. Use these lemmas when later energy or taming arguments replace a symplectic form by a scalar multiple without changing the boundary-condition linear algebra.

This advances `TauCetiRoadmap/HeegaardFloer/README.md`, Lane F2 item 1, “Definitions land immediately,” specifically the immediate almost-complex, symplectic, compatible/tame, boundary-condition definitions needed before `J`-holomorphic curves and exact Lagrangian Floer homology. I chose this after checking open and recently merged PRs: product, transport, metric, and energy-splitting HeegaardFloer prerequisites already exist or are in flight, while the rescaling file still lacked the corresponding Lagrangian-boundary bookkeeping and this is a small direct prerequisite for treating positive scalar changes of the symplectic form as the same boundary condition.

No Mathlib infrastructure is vendored. The implementation reuses Tau Ceti’s existing `SymplecticForm.rescale`, `SymplecticForm.orthogonal`, `isIsotropic_iff`, `isCoisotropic_iff`, and `isLagrangian_iff` APIs, together with elementary scalar cancellation in `ℝ`.

`lake exe cache get` completed with `No files to download` and `Already decompressed 8602 file(s)`. `lake build` completed with `Build completed successfully (4352 jobs).` `lake exe axioms` completed with `axioms: audited 6509 TauCeti declaration(s); all within the allowlist [propext, Classical.choice, Quot.sound].`

<!--tauceti-target:v1 {"focus":"HeegaardFloer","id":"lagrangian-rescale"}-->

🤖 Prepared with Codex
