### PR TITLE
feat: add de Finetti rectangle common ending

### DIFF
--- a/TauCeti/MeasureTheory/Measure/ProductKernel.lean
+++ b/TauCeti/MeasureTheory/Measure/ProductKernel.lean
@@ -30,6 +30,10 @@ Bind-evaluation of the mixture `μ.bind fun ω => (ProbabilityMeasure.pi fun i =
   product of coordinate measures, with `Fin m` constant-coordinate forms
   `bind_probabilityMeasure_pi_const_apply` and `bind_probabilityMeasure_pi_const_pi`.
 
+Extensionality:
+* `measure_eq_of_forall_univ_pi` — two measures on a finite product space are equal once the first
+  is finite and they agree on all measurable rectangles `Set.univ.pi B`.
+
 This file does not introduce a new product-kernel structure; the lemmas live directly over Mathlib's
 `ProbabilityMeasure.pi`. It advances `TauCetiRoadmap/Exchangeability`, Layer 1 (product kernels,
 conditional independence, mixtures), and is motivated by the product-kernel layer of
@@ -51,6 +55,25 @@ namespace MeasureTheory
 
 variable {Ω ι : Type*} [MeasurableSpace Ω] [Fintype ι] {α : ι → Type*}
   [∀ i, MeasurableSpace (α i)] {μ : Measure Ω}
+
+/-- Two measures on a finite product space are equal if they agree on all measurable rectangles
+`Set.univ.pi B`. Only the first measure is assumed finite. -/
+theorem measure_eq_of_forall_univ_pi {ι : Type*} [Finite ι] {α : ι → Type*}
+    [∀ i, MeasurableSpace (α i)] {μ ν : Measure (∀ i, α i)} [IsFiniteMeasure μ]
+    (h : ∀ B : ∀ i, Set (α i), (∀ i, MeasurableSet (B i)) →
+      μ (Set.univ.pi B) = ν (Set.univ.pi B)) :
+    μ = ν := by
+  letI := Fintype.ofFinite ι
+  refine Measure.ext_of_generateFrom_of_iUnion
+    (C := Set.pi Set.univ '' Set.pi Set.univ fun i => {s : Set (α i) | MeasurableSet s})
+    (B := fun _ : ℕ => Set.univ) generateFrom_pi.symm isPiSystem_pi ?_ ?_ ?_ ?_
+  · simpa using (iUnion_const (Set.univ : Set (∀ i, α i)))
+  · intro n
+    exact ⟨fun _ => Set.univ, fun i _ => MeasurableSet.univ, by simp⟩
+  · intro n
+    exact measure_ne_top μ Set.univ
+  · rintro _ ⟨B, hB, rfl⟩
+    exact h B fun i => hB i (mem_univ i)
 
 /-- The finite product combinator `ProbabilityMeasure.pi` is a measurable map
 `(Π i, ProbabilityMeasure (α i)) → ProbabilityMeasure (Π i, α i)`. -/

--- a/TauCeti/MeasureTheory/Measure/ProductKernel.lean
+++ b/TauCeti/MeasureTheory/Measure/ProductKernel.lean
@@ -30,10 +30,6 @@ Bind-evaluation of the mixture `μ.bind fun ω => (ProbabilityMeasure.pi fun i =
   product of coordinate measures, with `Fin m` constant-coordinate forms
   `bind_probabilityMeasure_pi_const_apply` and `bind_probabilityMeasure_pi_const_pi`.
 
-Extensionality:
-* `measure_eq_of_forall_univ_pi` — two measures on a finite product space are equal once the first
-  is finite and they agree on all measurable rectangles `Set.univ.pi B`.
-
 This file does not introduce a new product-kernel structure; the lemmas live directly over Mathlib's
 `ProbabilityMeasure.pi`. It advances `TauCetiRoadmap/Exchangeability`, Layer 1 (product kernels,
 conditional independence, mixtures), and is motivated by the product-kernel layer of
@@ -55,25 +51,6 @@ namespace MeasureTheory
 
 variable {Ω ι : Type*} [MeasurableSpace Ω] [Fintype ι] {α : ι → Type*}
   [∀ i, MeasurableSpace (α i)] {μ : Measure Ω}
-
-/-- Two measures on a finite product space are equal if they agree on all measurable rectangles
-`Set.univ.pi B`. Only the first measure is assumed finite. -/
-theorem measure_eq_of_forall_univ_pi {ι : Type*} [Finite ι] {α : ι → Type*}
-    [∀ i, MeasurableSpace (α i)] {μ ν : Measure (∀ i, α i)} [IsFiniteMeasure μ]
-    (h : ∀ B : ∀ i, Set (α i), (∀ i, MeasurableSet (B i)) →
-      μ (Set.univ.pi B) = ν (Set.univ.pi B)) :
-    μ = ν := by
-  letI := Fintype.ofFinite ι
-  refine Measure.ext_of_generateFrom_of_iUnion
-    (C := Set.pi Set.univ '' Set.pi Set.univ fun i => {s : Set (α i) | MeasurableSet s})
-    (B := fun _ : ℕ => Set.univ) generateFrom_pi.symm isPiSystem_pi ?_ ?_ ?_ ?_
-  · simpa using (iUnion_const (Set.univ : Set (∀ i, α i)))
-  · intro n
-    exact ⟨fun _ => Set.univ, fun i _ => MeasurableSet.univ, by simp⟩
-  · intro n
-    exact measure_ne_top μ Set.univ
-  · rintro _ ⟨B, hB, rfl⟩
-    exact h B fun i => hB i (mem_univ i)
 
 /-- The finite product combinator `ProbabilityMeasure.pi` is a measurable map
 `(Π i, ProbabilityMeasure (α i)) → ProbabilityMeasure (Π i, α i)`. -/

--- a/TauCeti/Probability/DeFinetti/CommonEnding.lean
+++ b/TauCeti/Probability/DeFinetti/CommonEnding.lean
@@ -14,7 +14,7 @@ The work is done by the `ConditionallyIIDWith` rectangle characterization
 finite product σ-algebra by Mathlib's `generateFrom_pi` / `isPiSystem_pi`, and Tau Ceti's
 product-kernel API evaluates the mixture on rectangles.  This file packages that as the existential
 wrapper.  This advances `TauCetiRoadmap/Exchangeability/README.md`, Layer 1, the common de Finetti
-ending `conditional_iid_from_directing_measure`.
+ending `conditionallyIID_of_directing_forall_rectangles`.
 
 This is adapted from the rectangle common-ending strategy in
 `cameronfreer/exchangeability` (`DeFinetti/CommonEnding.lean`, pin
@@ -36,7 +36,7 @@ variable {Ω α : Type*} [MeasurableSpace Ω] [MeasurableSpace α]
 
 /-- **Common de Finetti ending.** Rectangle-wise product-kernel factorization against a named
 directing measure supplies a `ConditionallyIID` witness for the process. -/
-theorem conditional_iid_from_directing_measure {μ : Measure Ω} [IsFiniteMeasure μ]
+theorem conditionallyIID_of_directing_forall_rectangles {μ : Measure Ω} [IsFiniteMeasure μ]
     {X : ℕ → Ω → α} {ν : Ω → ProbabilityMeasure α} (hν : Measurable ν)
     (h_rect : ∀ (m : ℕ) (k : Fin m → ℕ), Function.Injective k →
       ∀ B : Fin m → Set α, (∀ i, MeasurableSet (B i)) →

--- a/TauCeti/Probability/DeFinetti/CommonEnding.lean
+++ b/TauCeti/Probability/DeFinetti/CommonEnding.lean
@@ -1,6 +1,5 @@
 module
 
-public import TauCeti.MeasureTheory.Measure.ProductKernel
 public import TauCeti.Probability.Exchangeability.ConditionallyIID
 
 /-!
@@ -8,12 +7,14 @@ public import TauCeti.Probability.Exchangeability.ConditionallyIID
 
 This file provides the first shared de Finetti common-ending adapter.  If a measurable random
 probability measure `ν : Ω → ProbabilityMeasure α` has the expected rectangle factorization for
-every finite injective block of a process, then `ν` is a `ConditionallyIIDWith` directing measure.
+every finite injective block of a process, then the process is `ConditionallyIID`.
 
-The proof is intentionally only a bridge: rectangles generate the finite product σ-algebra by
-Mathlib's `generateFrom_pi` / `isPiSystem_pi`, and Tau Ceti's product-kernel API evaluates the
-mixture on rectangles.  This advances `TauCetiRoadmap/Exchangeability/README.md`, Layer 1, the
-common de Finetti ending `conditional_iid_from_directing_measure`.
+The work is done by the `ConditionallyIIDWith` rectangle characterization
+(`conditionallyIIDWith_of_forall_rectangles`, next to its definition): rectangles generate the
+finite product σ-algebra by Mathlib's `generateFrom_pi` / `isPiSystem_pi`, and Tau Ceti's
+product-kernel API evaluates the mixture on rectangles.  This file packages that as the existential
+wrapper.  This advances `TauCetiRoadmap/Exchangeability/README.md`, Layer 1, the common de Finetti
+ending `conditional_iid_from_directing_measure`.
 
 This is adapted from the rectangle common-ending strategy in
 `cameronfreer/exchangeability` (`DeFinetti/CommonEnding.lean`, pin
@@ -33,73 +34,8 @@ namespace Probability
 
 variable {Ω α : Type*} [MeasurableSpace Ω] [MeasurableSpace α]
 
-/-- Two finite product measures are equal if they agree on all measurable rectangles
-`Set.univ.pi B`. -/
-theorem measure_eq_of_forall_univ_pi {ι : Type*} [Finite ι] {α : ι → Type*}
-    [∀ i, MeasurableSpace (α i)] {μ ν : Measure (∀ i, α i)} [IsFiniteMeasure μ]
-    (h : ∀ B : ∀ i, Set (α i), (∀ i, MeasurableSet (B i)) →
-      μ (Set.univ.pi B) = ν (Set.univ.pi B)) :
-    μ = ν := by
-  letI := Fintype.ofFinite ι
-  refine Measure.ext_of_generateFrom_of_iUnion
-    (C := Set.pi Set.univ '' Set.pi Set.univ fun i => {s : Set (α i) | MeasurableSet s})
-    (B := fun _ : ℕ => Set.univ) generateFrom_pi.symm isPiSystem_pi ?_ ?_ ?_ ?_
-  · simpa using (iUnion_const (Set.univ : Set (∀ i, α i)))
-  · intro n
-    exact ⟨fun _ => Set.univ, fun i _ => MeasurableSet.univ, by simp⟩
-  · intro n
-    exact measure_ne_top μ Set.univ
-  · rintro _ ⟨B, hB, rfl⟩
-    exact h B fun i => hB i (mem_univ i)
-
-/-- A named directing measure is conditionally i.i.d. once every injective finite block has the
-same rectangle values as the corresponding random product-measure mixture. -/
-theorem conditionallyIIDWith_of_forall_rectangles {μ : Measure Ω} [IsFiniteMeasure μ]
-    {X : ℕ → Ω → α} {ν : Ω → ProbabilityMeasure α} (hν : Measurable ν)
-    (h_rect : ∀ (m : ℕ) (k : Fin m → ℕ), Function.Injective k →
-      ∀ B : Fin m → Set α, (∀ i, MeasurableSet (B i)) →
-        blockLaw μ X k (Set.univ.pi B) =
-          ∫⁻ ω, ∏ i : Fin m, (ν ω : Measure α) (B i) ∂μ) :
-    ConditionallyIIDWith μ X ν := by
-  refine ConditionallyIIDWith.intro hν ?_
-  intro m k hk
-  haveI : IsFiniteMeasure (blockLaw μ X k) := by
-    rw [blockLaw_apply]
-    infer_instance
-  refine measure_eq_of_forall_univ_pi ?_
-  intro B hB
-  rw [h_rect m k hk B hB]
-  rw [TauCeti.MeasureTheory.bind_probabilityMeasure_pi_const_pi ν hν.aemeasurable B hB]
-
-/-- A named conditionally i.i.d. directing measure gives the expected rectangle factorization
-for every injective finite block. -/
-theorem ConditionallyIIDWith.blockLaw_univ_pi {μ : Measure Ω} {X : ℕ → Ω → α}
-    {ν : Ω → ProbabilityMeasure α} (h : ConditionallyIIDWith μ X ν)
-    {m : ℕ} (k : Fin m → ℕ) (hk : Function.Injective k)
-    (B : Fin m → Set α) (hB : ∀ i, MeasurableSet (B i)) :
-    blockLaw μ X k (Set.univ.pi B) =
-      ∫⁻ ω, ∏ i : Fin m, (ν ω : Measure α) (B i) ∂μ := by
-  rw [h.map k hk]
-  have hν_ae : AEMeasurable ν μ := h.measurable_directing.aemeasurable
-  rw [TauCeti.MeasureTheory.bind_probabilityMeasure_pi_const_pi ν hν_ae B hB]
-
-/-- Rectangle factorization is equivalent to the named `ConditionallyIIDWith` relation. -/
-theorem conditionallyIIDWith_iff_forall_rectangles {μ : Measure Ω} [IsFiniteMeasure μ]
-    {X : ℕ → Ω → α} {ν : Ω → ProbabilityMeasure α} :
-    ConditionallyIIDWith μ X ν ↔
-      Measurable ν ∧
-        ∀ (m : ℕ) (k : Fin m → ℕ), Function.Injective k →
-          ∀ B : Fin m → Set α, (∀ i, MeasurableSet (B i)) →
-            blockLaw μ X k (Set.univ.pi B) =
-              ∫⁻ ω, ∏ i : Fin m, (ν ω : Measure α) (B i) ∂μ := by
-  constructor
-  · intro h
-    exact ⟨h.measurable_directing, fun m k hk B hB => h.blockLaw_univ_pi k hk B hB⟩
-  · rintro ⟨hν, h_rect⟩
-    exact conditionallyIIDWith_of_forall_rectangles hν h_rect
-
-/-- **Common de Finetti ending.** Rectangle-wise product-kernel factorization supplies a
-conditionally i.i.d. directing measure. -/
+/-- **Common de Finetti ending.** Rectangle-wise product-kernel factorization against a named
+directing measure supplies a `ConditionallyIID` witness for the process. -/
 theorem conditional_iid_from_directing_measure {μ : Measure Ω} [IsFiniteMeasure μ]
     {X : ℕ → Ω → α} {ν : Ω → ProbabilityMeasure α} (hν : Measurable ν)
     (h_rect : ∀ (m : ℕ) (k : Fin m → ℕ), Function.Injective k →

--- a/TauCeti/Probability/DeFinetti/CommonEnding.lean
+++ b/TauCeti/Probability/DeFinetti/CommonEnding.lean
@@ -1,0 +1,114 @@
+module
+
+public import TauCeti.MeasureTheory.Measure.ProductKernel
+public import TauCeti.Probability.Exchangeability.ConditionallyIID
+
+/-!
+# The rectangle common ending for de Finetti
+
+This file provides the first shared de Finetti common-ending adapter.  If a measurable random
+probability measure `ν : Ω → ProbabilityMeasure α` has the expected rectangle factorization for
+every finite injective block of a process, then `ν` is a `ConditionallyIIDWith` directing measure.
+
+The proof is intentionally only a bridge: rectangles generate the finite product σ-algebra by
+Mathlib's `generateFrom_pi` / `isPiSystem_pi`, and Tau Ceti's product-kernel API evaluates the
+mixture on rectangles.  This advances `TauCetiRoadmap/Exchangeability/README.md`, Layer 1, the
+common de Finetti ending `conditional_iid_from_directing_measure`.
+
+This is adapted from the rectangle common-ending strategy in
+`cameronfreer/exchangeability` (`DeFinetti/CommonEnding.lean`, pin
+`e0532e59ceff23edab44dda9ab0655debbc9cc22`), but stated over Tau Ceti's current
+`ConditionallyIIDWith` and `ProbabilityMeasure.pi` APIs.
+-/
+
+public section
+
+noncomputable section
+
+open MeasureTheory Set
+
+namespace TauCeti
+
+namespace Probability
+
+variable {Ω α : Type*} [MeasurableSpace Ω] [MeasurableSpace α]
+
+/-- Two finite product measures are equal if they agree on all measurable rectangles
+`Set.univ.pi B`. -/
+theorem measure_eq_of_forall_univ_pi {ι : Type*} [Finite ι] {α : ι → Type*}
+    [∀ i, MeasurableSpace (α i)] {μ ν : Measure (∀ i, α i)} [IsFiniteMeasure μ]
+    (h : ∀ B : ∀ i, Set (α i), (∀ i, MeasurableSet (B i)) →
+      μ (Set.univ.pi B) = ν (Set.univ.pi B)) :
+    μ = ν := by
+  letI := Fintype.ofFinite ι
+  refine Measure.ext_of_generateFrom_of_iUnion
+    (C := Set.pi Set.univ '' Set.pi Set.univ fun i => {s : Set (α i) | MeasurableSet s})
+    (B := fun _ : ℕ => Set.univ) generateFrom_pi.symm isPiSystem_pi ?_ ?_ ?_ ?_
+  · simpa using (iUnion_const (Set.univ : Set (∀ i, α i)))
+  · intro n
+    exact ⟨fun _ => Set.univ, fun i _ => MeasurableSet.univ, by simp⟩
+  · intro n
+    exact measure_ne_top μ Set.univ
+  · rintro _ ⟨B, hB, rfl⟩
+    exact h B fun i => hB i (mem_univ i)
+
+/-- A named directing measure is conditionally i.i.d. once every injective finite block has the
+same rectangle values as the corresponding random product-measure mixture. -/
+theorem conditionallyIIDWith_of_forall_rectangles {μ : Measure Ω} [IsFiniteMeasure μ]
+    {X : ℕ → Ω → α} {ν : Ω → ProbabilityMeasure α} (hν : Measurable ν)
+    (h_rect : ∀ (m : ℕ) (k : Fin m → ℕ), Function.Injective k →
+      ∀ B : Fin m → Set α, (∀ i, MeasurableSet (B i)) →
+        blockLaw μ X k (Set.univ.pi B) =
+          ∫⁻ ω, ∏ i : Fin m, (ν ω : Measure α) (B i) ∂μ) :
+    ConditionallyIIDWith μ X ν := by
+  refine ConditionallyIIDWith.intro hν ?_
+  intro m k hk
+  haveI : IsFiniteMeasure (blockLaw μ X k) := by
+    rw [blockLaw_apply]
+    infer_instance
+  refine measure_eq_of_forall_univ_pi ?_
+  intro B hB
+  rw [h_rect m k hk B hB]
+  rw [TauCeti.MeasureTheory.bind_probabilityMeasure_pi_const_pi ν hν.aemeasurable B hB]
+
+/-- A named conditionally i.i.d. directing measure gives the expected rectangle factorization
+for every injective finite block. -/
+theorem ConditionallyIIDWith.blockLaw_univ_pi {μ : Measure Ω} {X : ℕ → Ω → α}
+    {ν : Ω → ProbabilityMeasure α} (h : ConditionallyIIDWith μ X ν)
+    {m : ℕ} (k : Fin m → ℕ) (hk : Function.Injective k)
+    (B : Fin m → Set α) (hB : ∀ i, MeasurableSet (B i)) :
+    blockLaw μ X k (Set.univ.pi B) =
+      ∫⁻ ω, ∏ i : Fin m, (ν ω : Measure α) (B i) ∂μ := by
+  rw [h.map k hk]
+  have hν_ae : AEMeasurable ν μ := h.measurable_directing.aemeasurable
+  rw [TauCeti.MeasureTheory.bind_probabilityMeasure_pi_const_pi ν hν_ae B hB]
+
+/-- Rectangle factorization is equivalent to the named `ConditionallyIIDWith` relation. -/
+theorem conditionallyIIDWith_iff_forall_rectangles {μ : Measure Ω} [IsFiniteMeasure μ]
+    {X : ℕ → Ω → α} {ν : Ω → ProbabilityMeasure α} :
+    ConditionallyIIDWith μ X ν ↔
+      Measurable ν ∧
+        ∀ (m : ℕ) (k : Fin m → ℕ), Function.Injective k →
+          ∀ B : Fin m → Set α, (∀ i, MeasurableSet (B i)) →
+            blockLaw μ X k (Set.univ.pi B) =
+              ∫⁻ ω, ∏ i : Fin m, (ν ω : Measure α) (B i) ∂μ := by
+  constructor
+  · intro h
+    exact ⟨h.measurable_directing, fun m k hk B hB => h.blockLaw_univ_pi k hk B hB⟩
+  · rintro ⟨hν, h_rect⟩
+    exact conditionallyIIDWith_of_forall_rectangles hν h_rect
+
+/-- **Common de Finetti ending.** Rectangle-wise product-kernel factorization supplies a
+conditionally i.i.d. directing measure. -/
+theorem conditional_iid_from_directing_measure {μ : Measure Ω} [IsFiniteMeasure μ]
+    {X : ℕ → Ω → α} {ν : Ω → ProbabilityMeasure α} (hν : Measurable ν)
+    (h_rect : ∀ (m : ℕ) (k : Fin m → ℕ), Function.Injective k →
+      ∀ B : Fin m → Set α, (∀ i, MeasurableSet (B i)) →
+        blockLaw μ X k (Set.univ.pi B) =
+          ∫⁻ ω, ∏ i : Fin m, (ν ω : Measure α) (B i) ∂μ) :
+    ConditionallyIID μ X :=
+  ConditionallyIID.of_directing (conditionallyIIDWith_of_forall_rectangles hν h_rect)
+
+end Probability
+
+end TauCeti

--- a/TauCeti/Probability/Exchangeability/ConditionallyIID.lean
+++ b/TauCeti/Probability/Exchangeability/ConditionallyIID.lean
@@ -14,9 +14,10 @@ every finite block of **distinct** coordinates has, as its law, the `ν`-mixture
 corresponding product measure. `ConditionallyIIDWith μ X ν` names the directing measure;
 `ConditionallyIID` is the existential wrapper.
 
-This file adds the Layer 0 directing-measure definitions and their destructors only. The
-bridge `ConditionallyIID → Exchangeable` (permutation invariance of the finite product
-measures) is a later milestone.
+This file adds the Layer 0 directing-measure definitions and destructors, together with the
+Layer 1 rectangle-factorization characterization used by the common de Finetti ending. The bridge
+`ConditionallyIID → Exchangeable` (permutation invariance of the finite product measures) is a later
+milestone.
 
 These declarations follow the roadmap signatures in
 `TauCetiRoadmap/Exchangeability/README.md` and
@@ -31,13 +32,33 @@ public section
 
 noncomputable section
 
-open MeasureTheory
+open MeasureTheory Set
 
 namespace TauCeti
 
 namespace Probability
 
 variable {Ω α : Type*} [MeasurableSpace Ω] [MeasurableSpace α]
+
+/-- Implementation helper for the rectangle characterization: two measures on a finite product
+space are equal if they agree on all measurable rectangles `Set.univ.pi B`. Only the first measure
+is assumed finite. -/
+private theorem measure_eq_of_forall_univ_pi {ι : Type*} [Finite ι] {α : ι → Type*}
+    [∀ i, MeasurableSpace (α i)] {μ ν : Measure (∀ i, α i)} [IsFiniteMeasure μ]
+    (h : ∀ B : ∀ i, Set (α i), (∀ i, MeasurableSet (B i)) →
+      μ (Set.univ.pi B) = ν (Set.univ.pi B)) :
+    μ = ν := by
+  letI := Fintype.ofFinite ι
+  refine Measure.ext_of_generateFrom_of_iUnion
+    (C := Set.pi Set.univ '' Set.pi Set.univ fun i => {s : Set (α i) | MeasurableSet s})
+    (B := fun _ : ℕ => Set.univ) generateFrom_pi.symm isPiSystem_pi ?_ ?_ ?_ ?_
+  · simpa using (iUnion_const (Set.univ : Set (∀ i, α i)))
+  · intro n
+    exact ⟨fun _ => Set.univ, fun i _ => MeasurableSet.univ, by simp⟩
+  · intro n
+    exact measure_ne_top μ Set.univ
+  · rintro _ ⟨B, hB, rfl⟩
+    exact h B fun i => hB i (mem_univ i)
 
 /-- Conditional i.i.d.-ness with a specified directing probability measure `ν`: the random
 measure `ν` is measurable, and along every finite selection `k` of **distinct** coordinates
@@ -116,7 +137,7 @@ theorem conditionallyIIDWith_of_forall_rectangles {μ : Measure Ω} [IsFiniteMea
   haveI : IsFiniteMeasure (blockLaw μ X k) := by
     rw [blockLaw_apply]
     infer_instance
-  refine TauCeti.MeasureTheory.measure_eq_of_forall_univ_pi ?_
+  refine measure_eq_of_forall_univ_pi ?_
   intro B hB
   rw [h_rect m k hk B hB]
   rw [TauCeti.MeasureTheory.bind_probabilityMeasure_pi_const_pi ν hν.aemeasurable B hB]

--- a/TauCeti/Probability/Exchangeability/ConditionallyIID.lean
+++ b/TauCeti/Probability/Exchangeability/ConditionallyIID.lean
@@ -2,8 +2,6 @@ module
 
 public import TauCeti.Probability.Exchangeability.Basic
 public import TauCeti.MeasureTheory.Measure.ProductKernel
-public import Mathlib.MeasureTheory.Measure.FiniteMeasurePi
-public import Mathlib.MeasureTheory.Measure.GiryMonad
 
 /-!
 # Conditionally i.i.d. sequences
@@ -144,6 +142,7 @@ theorem conditionallyIIDWith_of_forall_rectangles {μ : Measure Ω} [IsFiniteMea
 
 /-- A `ConditionallyIIDWith` witness gives the expected rectangle factorization for every injective
 finite block. -/
+@[grind =>]
 theorem ConditionallyIIDWith.blockLaw_univ_pi {μ : Measure Ω} {X : ℕ → Ω → α}
     {ν : Ω → ProbabilityMeasure α} (h : ConditionallyIIDWith μ X ν)
     {m : ℕ} (k : Fin m → ℕ) (hk : Function.Injective k)

--- a/TauCeti/Probability/Exchangeability/ConditionallyIID.lean
+++ b/TauCeti/Probability/Exchangeability/ConditionallyIID.lean
@@ -13,9 +13,9 @@ corresponding product measure. `ConditionallyIIDWith μ X ν` names the directin
 `ConditionallyIID` is the existential wrapper.
 
 This file adds the Layer 0 directing-measure definitions and destructors, together with the
-Layer 1 rectangle-factorization characterization used by the common de Finetti ending. The bridge
-`ConditionallyIID → Exchangeable` (permutation invariance of the finite product measures) is a later
-milestone.
+Layer 1 rectangle-factorization characterization used by the common de Finetti ending. The
+exchangeability implications from conditionally i.i.d. processes live in
+`ConditionallyIIDImplications.lean`.
 
 These declarations follow the roadmap signatures in
 `TauCetiRoadmap/Exchangeability/README.md` and

--- a/TauCeti/Probability/Exchangeability/ConditionallyIID.lean
+++ b/TauCeti/Probability/Exchangeability/ConditionallyIID.lean
@@ -1,6 +1,7 @@
 module
 
 public import TauCeti.Probability.Exchangeability.Basic
+public import TauCeti.MeasureTheory.Measure.ProductKernel
 public import Mathlib.MeasureTheory.Measure.FiniteMeasurePi
 public import Mathlib.MeasureTheory.Measure.GiryMonad
 
@@ -100,6 +101,63 @@ theorem ConditionallyIID.exists_directing {μ : Measure Ω} {X : ℕ → Ω → 
     (h : ConditionallyIID μ X) :
     ∃ ν : Ω → ProbabilityMeasure α, ConditionallyIIDWith μ X ν :=
   h
+
+/-- A process is `ConditionallyIIDWith μ X ν` once every injective finite block has the same
+rectangle values as the corresponding random product-measure mixture. -/
+theorem conditionallyIIDWith_of_forall_rectangles {μ : Measure Ω} [IsFiniteMeasure μ]
+    {X : ℕ → Ω → α} {ν : Ω → ProbabilityMeasure α} (hν : Measurable ν)
+    (h_rect : ∀ (m : ℕ) (k : Fin m → ℕ), Function.Injective k →
+      ∀ B : Fin m → Set α, (∀ i, MeasurableSet (B i)) →
+        blockLaw μ X k (Set.univ.pi B) =
+          ∫⁻ ω, ∏ i : Fin m, (ν ω : Measure α) (B i) ∂μ) :
+    ConditionallyIIDWith μ X ν := by
+  refine ConditionallyIIDWith.intro hν ?_
+  intro m k hk
+  haveI : IsFiniteMeasure (blockLaw μ X k) := by
+    rw [blockLaw_apply]
+    infer_instance
+  refine TauCeti.MeasureTheory.measure_eq_of_forall_univ_pi ?_
+  intro B hB
+  rw [h_rect m k hk B hB]
+  rw [TauCeti.MeasureTheory.bind_probabilityMeasure_pi_const_pi ν hν.aemeasurable B hB]
+
+/-- A `ConditionallyIIDWith` witness gives the expected rectangle factorization for every injective
+finite block. -/
+theorem ConditionallyIIDWith.blockLaw_univ_pi {μ : Measure Ω} {X : ℕ → Ω → α}
+    {ν : Ω → ProbabilityMeasure α} (h : ConditionallyIIDWith μ X ν)
+    {m : ℕ} (k : Fin m → ℕ) (hk : Function.Injective k)
+    (B : Fin m → Set α) (hB : ∀ i, MeasurableSet (B i)) :
+    blockLaw μ X k (Set.univ.pi B) =
+      ∫⁻ ω, ∏ i : Fin m, (ν ω : Measure α) (B i) ∂μ := by
+  rw [h.map k hk]
+  have hν_ae : AEMeasurable ν μ := h.measurable_directing.aemeasurable
+  rw [TauCeti.MeasureTheory.bind_probabilityMeasure_pi_const_pi ν hν_ae B hB]
+
+/-- Rectangle factorization is equivalent to the named `ConditionallyIIDWith` relation. -/
+theorem conditionallyIIDWith_iff_forall_rectangles {μ : Measure Ω} [IsFiniteMeasure μ]
+    {X : ℕ → Ω → α} {ν : Ω → ProbabilityMeasure α} :
+    ConditionallyIIDWith μ X ν ↔
+      Measurable ν ∧
+        ∀ (m : ℕ) (k : Fin m → ℕ), Function.Injective k →
+          ∀ B : Fin m → Set α, (∀ i, MeasurableSet (B i)) →
+            blockLaw μ X k (Set.univ.pi B) =
+              ∫⁻ ω, ∏ i : Fin m, (ν ω : Measure α) (B i) ∂μ := by
+  constructor
+  · intro h
+    exact ⟨h.measurable_directing, fun m k hk B hB => h.blockLaw_univ_pi k hk B hB⟩
+  · rintro ⟨hν, h_rect⟩
+    exact conditionallyIIDWith_of_forall_rectangles hν h_rect
+
+/-- Rectangle factorization is equivalent to the existential `ConditionallyIID` relation. -/
+theorem conditionallyIID_iff_exists_forall_rectangles {μ : Measure Ω} [IsFiniteMeasure μ]
+    {X : ℕ → Ω → α} :
+    ConditionallyIID μ X ↔
+      ∃ ν : Ω → ProbabilityMeasure α, Measurable ν ∧
+        ∀ (m : ℕ) (k : Fin m → ℕ), Function.Injective k →
+          ∀ B : Fin m → Set α, (∀ i, MeasurableSet (B i)) →
+            blockLaw μ X k (Set.univ.pi B) =
+              ∫⁻ ω, ∏ i : Fin m, (ν ω : Measure α) (B i) ∂μ := by
+  simp_rw [conditionallyIID_iff, conditionallyIIDWith_iff_forall_rectangles]
 
 end Probability
 


### PR DESCRIPTION
This PR adds the Layer 1 de Finetti common-ending adapter: rectangle-wise factorization of every injective finite block against a measurable random probability measure now yields the existing `ConditionallyIIDWith` relation, plus the corresponding existential `ConditionallyIID` wrapper and rectangle characterization API.

This advances `TauCetiRoadmap/Exchangeability/README.md`, Layer 1, specifically the common de Finetti ending target `conditional_iid_from_directing_measure`. I chose this as the lowest-hanging distinct Exchangeability target after checking open and recently merged PRs: Layer 0 definitions and implications, adjacent transpositions, product-kernel measurability, and the rectangle/indicator bridge are already landed or in flight, while the π-system step from rectangle factorization to `ConditionallyIIDWith` was still absent and is a direct consumer of the existing product-kernel bind API.

No Mathlib infrastructure is vendored. The implementation reuses Mathlib's `generateFrom_pi`, `isPiSystem_pi`, and `Measure.ext_of_generateFrom_of_iUnion`, together with Tau Ceti's `ConditionallyIIDWith`, `blockLaw`, and `TauCeti.MeasureTheory.bind_probabilityMeasure_pi_const_pi`. The proof strategy is adapted from `cameronfreer/exchangeability` (`DeFinetti/CommonEnding.lean`, pin `e0532e59ceff23edab44dda9ab0655debbc9cc22`) to Tau Ceti's current `ProbabilityMeasure.pi` API.

`lake exe cache get` completed with `No files to download` and `Already decompressed 8602 file(s)`. `lake build` completed with `Build completed successfully (4354 jobs).` `lake exe axioms` completed with `axioms: audited 6521 TauCeti declaration(s); all within the allowlist [propext, Classical.choice, Quot.sound].`

<!--tauceti-target:v1 {"focus":"Exchangeability","id":"conditional-iid-from-directing-measure"}-->

🤖 Prepared with Codex
