### PR TITLE
feat: add shift-invariant sigma algebra

### DIFF
--- a/TauCeti/Probability/Ergodic/ShiftInvariantSigma.lean
+++ b/TauCeti/Probability/Ergodic/ShiftInvariantSigma.lean
@@ -69,38 +69,16 @@ theorem isShiftInvariant.measurableSet_shiftInvariantSigma {s : Set (ℕ → α)
     MeasurableSet[shiftInvariantSigma α] s :=
   mem_shiftInvariantSigma_iff.mpr ⟨hsm, hs⟩
 
-omit [MeasurableSpace (ℕ → α)] in
-/-- A shift-invariant path-space event is fixed by every iterate of the one-sided shift. -/
-@[simp]
-theorem isShiftInvariant.preimage_shift_iterate_eq {s : Set (ℕ → α)}
-    (hs : isShiftInvariant s) (n : ℕ) : ((shift α)^[n]) ⁻¹' s = s :=
-  Function.IsFixedPt.preimage_iterate hs n
-
-/-- A `shiftInvariantSigma`-measurable set is fixed by every iterate of the one-sided shift. -/
-@[simp]
-theorem MeasurableSet.preimage_shift_iterate_eq_of_shiftInvariantSigma {s : Set (ℕ → α)}
-    (hs : MeasurableSet[shiftInvariantSigma α] s) (n : ℕ) : ((shift α)^[n]) ⁻¹' s = s :=
-  (MeasurableSet.isShiftInvariant_of_shiftInvariantSigma hs).preimage_shift_iterate_eq n
-
-/-- Every iterate of the one-sided shift is measurable as a map on the shift-invariant
-σ-algebra. -/
-theorem measurable_shift_iterate_shiftInvariantSigma (n : ℕ) :
-    @Measurable (ℕ → α) (ℕ → α) (shiftInvariantSigma α) (shiftInvariantSigma α)
-      ((shift α)^[n]) := by
-  intro s hs
-  have hs_iter : MeasurableSet[MeasurableSpace.invariants ((shift α)^[n])] s :=
-    (MeasurableSpace.le_invariants_iterate (shift α) n) s hs
-  rw [(MeasurableSpace.measurableSet_invariants.mp hs_iter).2]
-  exact hs
-
 /-- The one-sided shift is measurable as a map on the shift-invariant σ-algebra. -/
-theorem measurable_shift_shiftInvariantSigma :
+theorem shiftInvariantSigma_measurable_shift_eq :
     @Measurable (ℕ → α) (ℕ → α) (shiftInvariantSigma α) (shiftInvariantSigma α) (shift α) := by
-  simpa using (measurable_shift_iterate_shiftInvariantSigma (α := α) 1)
+  intro s hs
+  rw [MeasurableSet.isShiftInvariant_of_shiftInvariantSigma hs]
+  exact hs
 
 /-- An ambient-measurable observable fixed by the one-sided shift is measurable with respect to
 the shift-invariant σ-algebra. -/
-theorem measurable_shiftInvariantSigma_of_comp_shift_eq [MeasurableSpace β]
+theorem shiftInvariant_implies_shiftInvariantMeasurable [MeasurableSpace β]
     {g : (ℕ → α) → β} (hg : Measurable g) (hg_shift : g ∘ shift α = g) :
     @Measurable (ℕ → α) β (shiftInvariantSigma α) inferInstance g :=
   MeasurableSpace.measurable_invariants_dom.mpr ⟨hg, fun _ _ => by rw [hg_shift]⟩

--- a/TauCeti/Probability/Ergodic/ShiftInvariantSigma.lean
+++ b/TauCeti/Probability/Ergodic/ShiftInvariantSigma.lean
@@ -28,10 +28,6 @@ variable {α β : Type*}
 def isShiftInvariant (s : Set (ℕ → α)) : Prop :=
   shift α ⁻¹' s = s
 
-/-- Compatibility alias for `isShiftInvariant`. -/
-abbrev IsShiftInvariant (s : Set (ℕ → α)) : Prop :=
-  isShiftInvariant s
-
 /-- The defining characterization of shift-invariant path-space events. -/
 @[simp]
 theorem isShiftInvariant_iff {s : Set (ℕ → α)} :
@@ -49,7 +45,7 @@ def shiftInvariantSigma (α : Type*) [MeasurableSpace (ℕ → α)] : Measurable
 under the one-sided shift. -/
 @[simp]
 theorem mem_shiftInvariantSigma_iff {s : Set (ℕ → α)} :
-    MeasurableSet[shiftInvariantSigma α] s ↔ MeasurableSet s ∧ IsShiftInvariant s :=
+    MeasurableSet[shiftInvariantSigma α] s ↔ MeasurableSet s ∧ isShiftInvariant s :=
   MeasurableSpace.measurableSet_invariants
 
 /-- The shift-invariant σ-algebra is a sub-σ-algebra of the ambient path-space σ-algebra. -/
@@ -64,20 +60,20 @@ theorem MeasurableSet.ambient_of_shiftInvariantSigma {s : Set (ℕ → α)}
 
 /-- A `shiftInvariantSigma`-measurable set is invariant under the one-sided shift. -/
 theorem MeasurableSet.isShiftInvariant_of_shiftInvariantSigma {s : Set (ℕ → α)}
-    (hs : MeasurableSet[shiftInvariantSigma α] s) : IsShiftInvariant s :=
+    (hs : MeasurableSet[shiftInvariantSigma α] s) : isShiftInvariant s :=
   (mem_shiftInvariantSigma_iff.mp hs).2
 
 /-- An ambient-measurable shift-invariant set is measurable for `shiftInvariantSigma`. -/
-theorem IsShiftInvariant.measurableSet_shiftInvariantSigma {s : Set (ℕ → α)}
-    (hs : IsShiftInvariant s) (hsm : MeasurableSet s) :
+theorem isShiftInvariant.measurableSet_shiftInvariantSigma {s : Set (ℕ → α)}
+    (hs : isShiftInvariant s) (hsm : MeasurableSet s) :
     MeasurableSet[shiftInvariantSigma α] s :=
   mem_shiftInvariantSigma_iff.mpr ⟨hsm, hs⟩
 
 omit [MeasurableSpace (ℕ → α)] in
 /-- A shift-invariant path-space event is fixed by every iterate of the one-sided shift. -/
 @[simp]
-theorem IsShiftInvariant.preimage_shift_iterate_eq {s : Set (ℕ → α)}
-    (hs : IsShiftInvariant s) (n : ℕ) : ((shift α)^[n]) ⁻¹' s = s :=
+theorem isShiftInvariant.preimage_shift_iterate_eq {s : Set (ℕ → α)}
+    (hs : isShiftInvariant s) (n : ℕ) : ((shift α)^[n]) ⁻¹' s = s :=
   Function.IsFixedPt.preimage_iterate hs n
 
 /-- A `shiftInvariantSigma`-measurable set is fixed by every iterate of the one-sided shift. -/
@@ -87,16 +83,11 @@ theorem MeasurableSet.preimage_shift_iterate_eq_of_shiftInvariantSigma {s : Set 
   (MeasurableSet.isShiftInvariant_of_shiftInvariantSigma hs).preimage_shift_iterate_eq n
 
 /-- The one-sided shift is measurable as a map on the shift-invariant σ-algebra. -/
-theorem shiftInvariantSigma_measurable_shift_eq :
+theorem measurable_shift_shiftInvariantSigma :
     @Measurable (ℕ → α) (ℕ → α) (shiftInvariantSigma α) (shiftInvariantSigma α) (shift α) := by
   intro s hs
   rw [MeasurableSet.isShiftInvariant_of_shiftInvariantSigma hs]
   exact hs
-
-/-- The one-sided shift is measurable as a map on the shift-invariant σ-algebra. -/
-theorem measurable_shift_shiftInvariantSigma :
-    @Measurable (ℕ → α) (ℕ → α) (shiftInvariantSigma α) (shiftInvariantSigma α) (shift α) :=
-  shiftInvariantSigma_measurable_shift_eq
 
 /-- Every iterate of the one-sided shift is measurable as a map on the shift-invariant
 σ-algebra. -/
@@ -111,7 +102,7 @@ theorem measurable_shift_iterate_shiftInvariantSigma (n : ℕ) :
 
 /-- An ambient-measurable observable fixed by the one-sided shift is measurable with respect to
 the shift-invariant σ-algebra. -/
-theorem shiftInvariant_implies_shiftInvariantMeasurable [MeasurableSpace β]
+theorem measurable_shiftInvariantSigma_of_comp_shift_eq [MeasurableSpace β]
     {g : (ℕ → α) → β} (hg : Measurable g) (hg_shift : g ∘ shift α = g) :
     @Measurable (ℕ → α) β (shiftInvariantSigma α) inferInstance g :=
   MeasurableSpace.measurable_invariants_dom.mpr ⟨hg, fun _ _ => by rw [hg_shift]⟩

--- a/TauCeti/Probability/Ergodic/ShiftInvariantSigma.lean
+++ b/TauCeti/Probability/Ergodic/ShiftInvariantSigma.lean
@@ -1,6 +1,7 @@
 module
 
-public import TauCeti.Probability.Exchangeability.PathSpace.Shift
+public import TauCeti.Probability.Exchangeability.Basic
+public import Mathlib.Dynamics.FixedPoints.Basic
 public import Mathlib.MeasureTheory.MeasurableSpace.Invariants
 
 /-!
@@ -29,15 +30,22 @@ def IsShiftInvariant (s : Set (ℕ → α)) : Prop :=
   shift α ⁻¹' s = s
 
 /-- The σ-algebra of measurable shift-invariant events on one-sided path space. -/
-@[expose, implicit_reducible]
+@[implicit_reducible]
 def shiftInvariantSigma (α : Type*) [MeasurableSpace α] : MeasurableSpace (ℕ → α) :=
   MeasurableSpace.invariants (shift α)
 
 /-- A set is measurable for `shiftInvariantSigma` iff it is ambient-measurable and invariant
 under the one-sided shift. -/
-theorem measurableSet_shiftInvariantSigma_iff {s : Set (ℕ → α)} :
+@[simp]
+theorem mem_shiftInvariantSigma_iff {s : Set (ℕ → α)} :
     MeasurableSet[shiftInvariantSigma α] s ↔ MeasurableSet s ∧ IsShiftInvariant s :=
   MeasurableSpace.measurableSet_invariants
+
+/-- A set is measurable for `shiftInvariantSigma` iff it is ambient-measurable and invariant
+under the one-sided shift. -/
+theorem measurableSet_shiftInvariantSigma_iff {s : Set (ℕ → α)} :
+    MeasurableSet[shiftInvariantSigma α] s ↔ MeasurableSet s ∧ IsShiftInvariant s :=
+  mem_shiftInvariantSigma_iff
 
 /-- The shift-invariant σ-algebra is a sub-σ-algebra of the ambient path-space σ-algebra. -/
 theorem shiftInvariantSigma_le :
@@ -58,22 +66,19 @@ theorem MeasurableSet.isShiftInvariant_of_shiftInvariantSigma {s : Set (ℕ → 
 theorem IsShiftInvariant.measurableSet_shiftInvariantSigma {s : Set (ℕ → α)}
     (hs : IsShiftInvariant s) (hsm : MeasurableSet s) :
     MeasurableSet[shiftInvariantSigma α] s :=
-  measurableSet_shiftInvariantSigma_iff.mpr ⟨hsm, hs⟩
+  mem_shiftInvariantSigma_iff.mpr ⟨hsm, hs⟩
+
+/-- An ambient-measurable shift-invariant set is measurable for `shiftInvariantSigma`. -/
+theorem shiftInvariant_implies_shiftInvariantMeasurable {s : Set (ℕ → α)}
+    (hsm : MeasurableSet s) (hs : IsShiftInvariant s) :
+    MeasurableSet[shiftInvariantSigma α] s :=
+  hs.measurableSet_shiftInvariantSigma hsm
 
 omit [MeasurableSpace α] in
 /-- A shift-invariant set is invariant under every iterate of the one-sided shift. -/
 theorem IsShiftInvariant.iterate {s : Set (ℕ → α)} (hs : IsShiftInvariant s) (n : ℕ) :
-    (shift α)^[n] ⁻¹' s = s := by
-  induction n with
-  | zero =>
-      simp
-  | succ n ihn =>
-      calc
-        (shift α)^[n + 1] ⁻¹' s = (shift α) ⁻¹' ((shift α)^[n] ⁻¹' s) := by
-          ext x
-          simp
-        _ = (shift α) ⁻¹' s := by rw [ihn]
-        _ = s := hs
+    (shift α)^[n] ⁻¹' s = s :=
+  (Function.IsFixedPt.preimage_iterate hs n).eq
 
 /-- Sets in the shift-invariant σ-algebra are fixed by every shift iterate. -/
 theorem MeasurableSet.shift_iterate_preimage_eq {s : Set (ℕ → α)}
@@ -87,6 +92,11 @@ theorem measurable_shift_shiftInvariantSigma :
   intro s hs
   rw [MeasurableSet.isShiftInvariant_of_shiftInvariantSigma hs]
   exact hs
+
+/-- The one-sided shift is measurable as a map on the shift-invariant σ-algebra. -/
+theorem shiftInvariantSigma_measurable_shift_eq :
+    @Measurable (ℕ → α) (ℕ → α) (shiftInvariantSigma α) (shiftInvariantSigma α) (shift α) :=
+  measurable_shift_shiftInvariantSigma
 
 /-- Every iterate of the one-sided shift is measurable as a map on the shift-invariant
 σ-algebra. -/

--- a/TauCeti/Probability/Ergodic/ShiftInvariantSigma.lean
+++ b/TauCeti/Probability/Ergodic/ShiftInvariantSigma.lean
@@ -70,7 +70,7 @@ theorem isShiftInvariant.measurableSet_shiftInvariantSigma {s : Set (ℕ → α)
   mem_shiftInvariantSigma_iff.mpr ⟨hsm, hs⟩
 
 /-- The one-sided shift is measurable as a map on the shift-invariant σ-algebra. -/
-theorem shiftInvariantSigma_measurable_shift_eq :
+theorem measurable_shift_shiftInvariantSigma :
     @Measurable (ℕ → α) (ℕ → α) (shiftInvariantSigma α) (shiftInvariantSigma α) (shift α) := by
   intro s hs
   rw [MeasurableSet.isShiftInvariant_of_shiftInvariantSigma hs]
@@ -78,7 +78,7 @@ theorem shiftInvariantSigma_measurable_shift_eq :
 
 /-- An ambient-measurable observable fixed by the one-sided shift is measurable with respect to
 the shift-invariant σ-algebra. -/
-theorem shiftInvariant_implies_shiftInvariantMeasurable [MeasurableSpace β]
+theorem measurable_shiftInvariantSigma_of_comp_shift_eq [MeasurableSpace β]
     {g : (ℕ → α) → β} (hg : Measurable g) (hg_shift : g ∘ shift α = g) :
     @Measurable (ℕ → α) β (shiftInvariantSigma α) inferInstance g :=
   MeasurableSpace.measurable_invariants_dom.mpr ⟨hg, fun _ _ => by rw [hg_shift]⟩

--- a/TauCeti/Probability/Ergodic/ShiftInvariantSigma.lean
+++ b/TauCeti/Probability/Ergodic/ShiftInvariantSigma.lean
@@ -23,11 +23,19 @@ namespace TauCeti
 
 namespace Probability
 
-variable {α β : Type*} [MeasurableSpace α]
+variable {α β : Type*}
 
 /-- A path-space event is shift-invariant if its preimage under the one-sided shift is itself. -/
 def IsShiftInvariant (s : Set (ℕ → α)) : Prop :=
   shift α ⁻¹' s = s
+
+/-- The defining characterization of shift-invariant path-space events. -/
+@[simp]
+theorem isShiftInvariant_iff {s : Set (ℕ → α)} :
+    IsShiftInvariant s ↔ shift α ⁻¹' s = s :=
+  Iff.rfl
+
+variable [MeasurableSpace α]
 
 /-- The σ-algebra of measurable shift-invariant events on one-sided path space. -/
 @[implicit_reducible]
@@ -40,12 +48,6 @@ under the one-sided shift. -/
 theorem mem_shiftInvariantSigma_iff {s : Set (ℕ → α)} :
     MeasurableSet[shiftInvariantSigma α] s ↔ MeasurableSet s ∧ IsShiftInvariant s :=
   MeasurableSpace.measurableSet_invariants
-
-/-- A set is measurable for `shiftInvariantSigma` iff it is ambient-measurable and invariant
-under the one-sided shift. -/
-theorem measurableSet_shiftInvariantSigma_iff {s : Set (ℕ → α)} :
-    MeasurableSet[shiftInvariantSigma α] s ↔ MeasurableSet s ∧ IsShiftInvariant s :=
-  mem_shiftInvariantSigma_iff
 
 /-- The shift-invariant σ-algebra is a sub-σ-algebra of the ambient path-space σ-algebra. -/
 theorem shiftInvariantSigma_le :
@@ -60,7 +62,7 @@ theorem MeasurableSet.ambient_of_shiftInvariantSigma {s : Set (ℕ → α)}
 /-- A `shiftInvariantSigma`-measurable set is invariant under the one-sided shift. -/
 theorem MeasurableSet.isShiftInvariant_of_shiftInvariantSigma {s : Set (ℕ → α)}
     (hs : MeasurableSet[shiftInvariantSigma α] s) : IsShiftInvariant s :=
-  (measurableSet_shiftInvariantSigma_iff.mp hs).2
+  (mem_shiftInvariantSigma_iff.mp hs).2
 
 /-- An ambient-measurable shift-invariant set is measurable for `shiftInvariantSigma`. -/
 theorem IsShiftInvariant.measurableSet_shiftInvariantSigma {s : Set (ℕ → α)}
@@ -68,19 +70,15 @@ theorem IsShiftInvariant.measurableSet_shiftInvariantSigma {s : Set (ℕ → α)
     MeasurableSet[shiftInvariantSigma α] s :=
   mem_shiftInvariantSigma_iff.mpr ⟨hsm, hs⟩
 
-/-- An ambient-measurable shift-invariant set is measurable for `shiftInvariantSigma`. -/
-theorem shiftInvariant_implies_shiftInvariantMeasurable {s : Set (ℕ → α)}
-    (hsm : MeasurableSet s) (hs : IsShiftInvariant s) :
-    MeasurableSet[shiftInvariantSigma α] s :=
-  hs.measurableSet_shiftInvariantSigma hsm
-
 omit [MeasurableSpace α] in
 /-- A shift-invariant set is invariant under every iterate of the one-sided shift. -/
+@[simp]
 theorem IsShiftInvariant.iterate {s : Set (ℕ → α)} (hs : IsShiftInvariant s) (n : ℕ) :
     (shift α)^[n] ⁻¹' s = s :=
   (Function.IsFixedPt.preimage_iterate hs n).eq
 
 /-- Sets in the shift-invariant σ-algebra are fixed by every shift iterate. -/
+@[simp]
 theorem MeasurableSet.shift_iterate_preimage_eq {s : Set (ℕ → α)}
     (hs : MeasurableSet[shiftInvariantSigma α] s) (n : ℕ) :
     (shift α)^[n] ⁻¹' s = s :=
@@ -92,11 +90,6 @@ theorem measurable_shift_shiftInvariantSigma :
   intro s hs
   rw [MeasurableSet.isShiftInvariant_of_shiftInvariantSigma hs]
   exact hs
-
-/-- The one-sided shift is measurable as a map on the shift-invariant σ-algebra. -/
-theorem shiftInvariantSigma_measurable_shift_eq :
-    @Measurable (ℕ → α) (ℕ → α) (shiftInvariantSigma α) (shiftInvariantSigma α) (shift α) :=
-  measurable_shift_shiftInvariantSigma
 
 /-- Every iterate of the one-sided shift is measurable as a map on the shift-invariant
 σ-algebra. -/

--- a/TauCeti/Probability/Ergodic/ShiftInvariantSigma.lean
+++ b/TauCeti/Probability/Ergodic/ShiftInvariantSigma.lean
@@ -69,12 +69,34 @@ theorem isShiftInvariant.measurableSet_shiftInvariantSigma {s : Set (ℕ → α)
     MeasurableSet[shiftInvariantSigma α] s :=
   mem_shiftInvariantSigma_iff.mpr ⟨hsm, hs⟩
 
+omit [MeasurableSpace (ℕ → α)] in
+/-- A shift-invariant path-space event is fixed by every iterate of the one-sided shift. -/
+@[simp]
+theorem isShiftInvariant.preimage_shift_iterate_eq {s : Set (ℕ → α)}
+    (hs : isShiftInvariant s) (n : ℕ) : ((shift α)^[n]) ⁻¹' s = s :=
+  Function.IsFixedPt.preimage_iterate hs n
+
+/-- A `shiftInvariantSigma`-measurable set is fixed by every iterate of the one-sided shift. -/
+@[simp]
+theorem MeasurableSet.preimage_shift_iterate_eq_of_shiftInvariantSigma {s : Set (ℕ → α)}
+    (hs : MeasurableSet[shiftInvariantSigma α] s) (n : ℕ) : ((shift α)^[n]) ⁻¹' s = s :=
+  (MeasurableSet.isShiftInvariant_of_shiftInvariantSigma hs).preimage_shift_iterate_eq n
+
+/-- Every iterate of the one-sided shift is measurable as a map on the shift-invariant
+σ-algebra. -/
+theorem measurable_shift_iterate_shiftInvariantSigma (n : ℕ) :
+    @Measurable (ℕ → α) (ℕ → α) (shiftInvariantSigma α) (shiftInvariantSigma α)
+      ((shift α)^[n]) := by
+  intro s hs
+  have hs_iter : MeasurableSet[MeasurableSpace.invariants ((shift α)^[n])] s :=
+    (MeasurableSpace.le_invariants_iterate (shift α) n) s hs
+  rw [(MeasurableSpace.measurableSet_invariants.mp hs_iter).2]
+  exact hs
+
 /-- The one-sided shift is measurable as a map on the shift-invariant σ-algebra. -/
 theorem measurable_shift_shiftInvariantSigma :
     @Measurable (ℕ → α) (ℕ → α) (shiftInvariantSigma α) (shiftInvariantSigma α) (shift α) := by
-  intro s hs
-  rw [MeasurableSet.isShiftInvariant_of_shiftInvariantSigma hs]
-  exact hs
+  simpa using measurable_shift_iterate_shiftInvariantSigma (α := α) 1
 
 /-- An ambient-measurable observable fixed by the one-sided shift is measurable with respect to
 the shift-invariant σ-algebra. -/

--- a/TauCeti/Probability/Ergodic/ShiftInvariantSigma.lean
+++ b/TauCeti/Probability/Ergodic/ShiftInvariantSigma.lean
@@ -75,11 +75,13 @@ theorem IsShiftInvariant.measurableSet_shiftInvariantSigma {s : Set (ℕ → α)
 
 omit [MeasurableSpace (ℕ → α)] in
 /-- A shift-invariant path-space event is fixed by every iterate of the one-sided shift. -/
+@[simp]
 theorem IsShiftInvariant.preimage_shift_iterate_eq {s : Set (ℕ → α)}
     (hs : IsShiftInvariant s) (n : ℕ) : ((shift α)^[n]) ⁻¹' s = s :=
   Function.IsFixedPt.preimage_iterate hs n
 
 /-- A `shiftInvariantSigma`-measurable set is fixed by every iterate of the one-sided shift. -/
+@[simp]
 theorem MeasurableSet.preimage_shift_iterate_eq_of_shiftInvariantSigma {s : Set (ℕ → α)}
     (hs : MeasurableSet[shiftInvariantSigma α] s) (n : ℕ) : ((shift α)^[n]) ⁻¹' s = s :=
   (MeasurableSet.isShiftInvariant_of_shiftInvariantSigma hs).preimage_shift_iterate_eq n

--- a/TauCeti/Probability/Ergodic/ShiftInvariantSigma.lean
+++ b/TauCeti/Probability/Ergodic/ShiftInvariantSigma.lean
@@ -82,13 +82,6 @@ theorem MeasurableSet.preimage_shift_iterate_eq_of_shiftInvariantSigma {s : Set 
     (hs : MeasurableSet[shiftInvariantSigma α] s) (n : ℕ) : ((shift α)^[n]) ⁻¹' s = s :=
   (MeasurableSet.isShiftInvariant_of_shiftInvariantSigma hs).preimage_shift_iterate_eq n
 
-/-- The one-sided shift is measurable as a map on the shift-invariant σ-algebra. -/
-theorem measurable_shift_shiftInvariantSigma :
-    @Measurable (ℕ → α) (ℕ → α) (shiftInvariantSigma α) (shiftInvariantSigma α) (shift α) := by
-  intro s hs
-  rw [MeasurableSet.isShiftInvariant_of_shiftInvariantSigma hs]
-  exact hs
-
 /-- Every iterate of the one-sided shift is measurable as a map on the shift-invariant
 σ-algebra. -/
 theorem measurable_shift_iterate_shiftInvariantSigma (n : ℕ) :
@@ -99,6 +92,11 @@ theorem measurable_shift_iterate_shiftInvariantSigma (n : ℕ) :
     (MeasurableSpace.le_invariants_iterate (shift α) n) s hs
   rw [(MeasurableSpace.measurableSet_invariants.mp hs_iter).2]
   exact hs
+
+/-- The one-sided shift is measurable as a map on the shift-invariant σ-algebra. -/
+theorem measurable_shift_shiftInvariantSigma :
+    @Measurable (ℕ → α) (ℕ → α) (shiftInvariantSigma α) (shiftInvariantSigma α) (shift α) := by
+  simpa using (measurable_shift_iterate_shiftInvariantSigma (α := α) 1)
 
 /-- An ambient-measurable observable fixed by the one-sided shift is measurable with respect to
 the shift-invariant σ-algebra. -/

--- a/TauCeti/Probability/Ergodic/ShiftInvariantSigma.lean
+++ b/TauCeti/Probability/Ergodic/ShiftInvariantSigma.lean
@@ -73,6 +73,17 @@ theorem IsShiftInvariant.measurableSet_shiftInvariantSigma {s : Set (ℕ → α)
     MeasurableSet[shiftInvariantSigma α] s :=
   mem_shiftInvariantSigma_iff.mpr ⟨hsm, hs⟩
 
+omit [MeasurableSpace (ℕ → α)] in
+/-- A shift-invariant path-space event is fixed by every iterate of the one-sided shift. -/
+theorem IsShiftInvariant.preimage_shift_iterate_eq {s : Set (ℕ → α)}
+    (hs : IsShiftInvariant s) (n : ℕ) : ((shift α)^[n]) ⁻¹' s = s :=
+  Function.IsFixedPt.preimage_iterate hs n
+
+/-- A `shiftInvariantSigma`-measurable set is fixed by every iterate of the one-sided shift. -/
+theorem MeasurableSet.preimage_shift_iterate_eq_of_shiftInvariantSigma {s : Set (ℕ → α)}
+    (hs : MeasurableSet[shiftInvariantSigma α] s) (n : ℕ) : ((shift α)^[n]) ⁻¹' s = s :=
+  (MeasurableSet.isShiftInvariant_of_shiftInvariantSigma hs).preimage_shift_iterate_eq n
+
 /-- The one-sided shift is measurable as a map on the shift-invariant σ-algebra. -/
 theorem shiftInvariantSigma_measurable_shift_eq :
     @Measurable (ℕ → α) (ℕ → α) (shiftInvariantSigma α) (shiftInvariantSigma α) (shift α) := by

--- a/TauCeti/Probability/Ergodic/ShiftInvariantSigma.lean
+++ b/TauCeti/Probability/Ergodic/ShiftInvariantSigma.lean
@@ -35,11 +35,11 @@ theorem isShiftInvariant_iff {s : Set (ℕ → α)} :
     IsShiftInvariant s ↔ shift α ⁻¹' s = s :=
   Iff.rfl
 
-variable [MeasurableSpace α]
+variable [MeasurableSpace (ℕ → α)]
 
 /-- The σ-algebra of measurable shift-invariant events on one-sided path space. -/
 @[implicit_reducible]
-def shiftInvariantSigma (α : Type*) [MeasurableSpace α] : MeasurableSpace (ℕ → α) :=
+def shiftInvariantSigma (α : Type*) [MeasurableSpace (ℕ → α)] : MeasurableSpace (ℕ → α) :=
   MeasurableSpace.invariants (shift α)
 
 /-- A set is measurable for `shiftInvariantSigma` iff it is ambient-measurable and invariant
@@ -70,7 +70,7 @@ theorem IsShiftInvariant.measurableSet_shiftInvariantSigma {s : Set (ℕ → α)
     MeasurableSet[shiftInvariantSigma α] s :=
   mem_shiftInvariantSigma_iff.mpr ⟨hsm, hs⟩
 
-omit [MeasurableSpace α] in
+omit [MeasurableSpace (ℕ → α)] in
 /-- A shift-invariant set is invariant under every iterate of the one-sided shift. -/
 @[simp]
 theorem IsShiftInvariant.iterate {s : Set (ℕ → α)} (hs : IsShiftInvariant s) (n : ℕ) :
@@ -99,6 +99,13 @@ theorem measurable_shift_iterate_shiftInvariantSigma (n : ℕ) :
   intro s hs
   rw [MeasurableSet.shift_iterate_preimage_eq hs n]
   exact hs
+
+/-- An ambient-measurable observable fixed by the one-sided shift is measurable with respect to
+the shift-invariant σ-algebra. -/
+theorem shiftInvariant_implies_shiftInvariantMeasurable [MeasurableSpace β]
+    {g : (ℕ → α) → β} (hg : Measurable g) (hg_shift : g ∘ shift α = g) :
+    @Measurable (ℕ → α) β (shiftInvariantSigma α) inferInstance g :=
+  MeasurableSpace.measurable_invariants_dom.mpr ⟨hg, fun _ _ => by rw [hg_shift]⟩
 
 /-- A function measurable with respect to the shift-invariant σ-algebra is fixed by the
 one-sided shift. -/

--- a/TauCeti/Probability/Ergodic/ShiftInvariantSigma.lean
+++ b/TauCeti/Probability/Ergodic/ShiftInvariantSigma.lean
@@ -1,7 +1,6 @@
 module
 
 public import TauCeti.Probability.Exchangeability.Basic
-public import Mathlib.Dynamics.FixedPoints.Basic
 public import Mathlib.MeasureTheory.MeasurableSpace.Invariants
 
 /-!
@@ -26,13 +25,17 @@ namespace Probability
 variable {α β : Type*}
 
 /-- A path-space event is shift-invariant if its preimage under the one-sided shift is itself. -/
-def IsShiftInvariant (s : Set (ℕ → α)) : Prop :=
+def isShiftInvariant (s : Set (ℕ → α)) : Prop :=
   shift α ⁻¹' s = s
+
+/-- Compatibility alias for `isShiftInvariant`. -/
+abbrev IsShiftInvariant (s : Set (ℕ → α)) : Prop :=
+  isShiftInvariant s
 
 /-- The defining characterization of shift-invariant path-space events. -/
 @[simp]
 theorem isShiftInvariant_iff {s : Set (ℕ → α)} :
-    IsShiftInvariant s ↔ shift α ⁻¹' s = s :=
+    isShiftInvariant s ↔ shift α ⁻¹' s = s :=
   Iff.rfl
 
 variable [MeasurableSpace (ℕ → α)]
@@ -70,26 +73,17 @@ theorem IsShiftInvariant.measurableSet_shiftInvariantSigma {s : Set (ℕ → α)
     MeasurableSet[shiftInvariantSigma α] s :=
   mem_shiftInvariantSigma_iff.mpr ⟨hsm, hs⟩
 
-omit [MeasurableSpace (ℕ → α)] in
-/-- A shift-invariant set is invariant under every iterate of the one-sided shift. -/
-@[simp]
-theorem IsShiftInvariant.iterate {s : Set (ℕ → α)} (hs : IsShiftInvariant s) (n : ℕ) :
-    (shift α)^[n] ⁻¹' s = s :=
-  (Function.IsFixedPt.preimage_iterate hs n).eq
-
-/-- Sets in the shift-invariant σ-algebra are fixed by every shift iterate. -/
-@[simp]
-theorem MeasurableSet.shift_iterate_preimage_eq {s : Set (ℕ → α)}
-    (hs : MeasurableSet[shiftInvariantSigma α] s) (n : ℕ) :
-    (shift α)^[n] ⁻¹' s = s :=
-  (MeasurableSet.isShiftInvariant_of_shiftInvariantSigma hs).iterate n
-
 /-- The one-sided shift is measurable as a map on the shift-invariant σ-algebra. -/
-theorem measurable_shift_shiftInvariantSigma :
+theorem shiftInvariantSigma_measurable_shift_eq :
     @Measurable (ℕ → α) (ℕ → α) (shiftInvariantSigma α) (shiftInvariantSigma α) (shift α) := by
   intro s hs
   rw [MeasurableSet.isShiftInvariant_of_shiftInvariantSigma hs]
   exact hs
+
+/-- The one-sided shift is measurable as a map on the shift-invariant σ-algebra. -/
+theorem measurable_shift_shiftInvariantSigma :
+    @Measurable (ℕ → α) (ℕ → α) (shiftInvariantSigma α) (shiftInvariantSigma α) (shift α) :=
+  shiftInvariantSigma_measurable_shift_eq
 
 /-- Every iterate of the one-sided shift is measurable as a map on the shift-invariant
 σ-algebra. -/
@@ -97,7 +91,9 @@ theorem measurable_shift_iterate_shiftInvariantSigma (n : ℕ) :
     @Measurable (ℕ → α) (ℕ → α) (shiftInvariantSigma α) (shiftInvariantSigma α)
       ((shift α)^[n]) := by
   intro s hs
-  rw [MeasurableSet.shift_iterate_preimage_eq hs n]
+  have hs_iter : MeasurableSet[MeasurableSpace.invariants ((shift α)^[n])] s :=
+    (MeasurableSpace.le_invariants_iterate (shift α) n) s hs
+  rw [(MeasurableSpace.measurableSet_invariants.mp hs_iter).2]
   exact hs
 
 /-- An ambient-measurable observable fixed by the one-sided shift is measurable with respect to

--- a/TauCeti/Probability/Ergodic/ShiftInvariantSigma.lean
+++ b/TauCeti/Probability/Ergodic/ShiftInvariantSigma.lean
@@ -1,0 +1,110 @@
+module
+
+public import TauCeti.Probability.Exchangeability.PathSpace.Shift
+public import Mathlib.MeasureTheory.MeasurableSpace.Invariants
+
+/-!
+# Shift-invariant σ-algebra on one-sided path space
+
+This file records the Layer 2 Exchangeability roadmap API for the σ-algebra of measurable
+events on path space that are invariant under the one-sided shift.  The construction is the
+shift-specialized form of Mathlib's `MeasurableSpace.invariants`; the lemmas here are only
+adapters for Tau Ceti's path-space shift notation.
+-/
+
+public section
+
+noncomputable section
+
+open MeasureTheory
+
+namespace TauCeti
+
+namespace Probability
+
+variable {α β : Type*} [MeasurableSpace α]
+
+/-- A path-space event is shift-invariant if its preimage under the one-sided shift is itself. -/
+def IsShiftInvariant (s : Set (ℕ → α)) : Prop :=
+  shift α ⁻¹' s = s
+
+/-- The σ-algebra of measurable shift-invariant events on one-sided path space. -/
+@[expose, implicit_reducible]
+def shiftInvariantSigma (α : Type*) [MeasurableSpace α] : MeasurableSpace (ℕ → α) :=
+  MeasurableSpace.invariants (shift α)
+
+/-- A set is measurable for `shiftInvariantSigma` iff it is ambient-measurable and invariant
+under the one-sided shift. -/
+theorem measurableSet_shiftInvariantSigma_iff {s : Set (ℕ → α)} :
+    MeasurableSet[shiftInvariantSigma α] s ↔ MeasurableSet s ∧ IsShiftInvariant s :=
+  MeasurableSpace.measurableSet_invariants
+
+/-- The shift-invariant σ-algebra is a sub-σ-algebra of the ambient path-space σ-algebra. -/
+theorem shiftInvariantSigma_le :
+    shiftInvariantSigma α ≤ (inferInstance : MeasurableSpace (ℕ → α)) :=
+  MeasurableSpace.invariants_le (shift α)
+
+/-- A `shiftInvariantSigma`-measurable set is ambient-measurable. -/
+theorem MeasurableSet.ambient_of_shiftInvariantSigma {s : Set (ℕ → α)}
+    (hs : MeasurableSet[shiftInvariantSigma α] s) : MeasurableSet s :=
+  shiftInvariantSigma_le s hs
+
+/-- A `shiftInvariantSigma`-measurable set is invariant under the one-sided shift. -/
+theorem MeasurableSet.isShiftInvariant_of_shiftInvariantSigma {s : Set (ℕ → α)}
+    (hs : MeasurableSet[shiftInvariantSigma α] s) : IsShiftInvariant s :=
+  (measurableSet_shiftInvariantSigma_iff.mp hs).2
+
+/-- An ambient-measurable shift-invariant set is measurable for `shiftInvariantSigma`. -/
+theorem IsShiftInvariant.measurableSet_shiftInvariantSigma {s : Set (ℕ → α)}
+    (hs : IsShiftInvariant s) (hsm : MeasurableSet s) :
+    MeasurableSet[shiftInvariantSigma α] s :=
+  measurableSet_shiftInvariantSigma_iff.mpr ⟨hsm, hs⟩
+
+omit [MeasurableSpace α] in
+/-- A shift-invariant set is invariant under every iterate of the one-sided shift. -/
+theorem IsShiftInvariant.iterate {s : Set (ℕ → α)} (hs : IsShiftInvariant s) (n : ℕ) :
+    (shift α)^[n] ⁻¹' s = s := by
+  induction n with
+  | zero =>
+      simp
+  | succ n ihn =>
+      calc
+        (shift α)^[n + 1] ⁻¹' s = (shift α) ⁻¹' ((shift α)^[n] ⁻¹' s) := by
+          ext x
+          simp
+        _ = (shift α) ⁻¹' s := by rw [ihn]
+        _ = s := hs
+
+/-- Sets in the shift-invariant σ-algebra are fixed by every shift iterate. -/
+theorem MeasurableSet.shift_iterate_preimage_eq {s : Set (ℕ → α)}
+    (hs : MeasurableSet[shiftInvariantSigma α] s) (n : ℕ) :
+    (shift α)^[n] ⁻¹' s = s :=
+  (MeasurableSet.isShiftInvariant_of_shiftInvariantSigma hs).iterate n
+
+/-- The one-sided shift is measurable as a map on the shift-invariant σ-algebra. -/
+theorem measurable_shift_shiftInvariantSigma :
+    @Measurable (ℕ → α) (ℕ → α) (shiftInvariantSigma α) (shiftInvariantSigma α) (shift α) := by
+  intro s hs
+  rw [MeasurableSet.isShiftInvariant_of_shiftInvariantSigma hs]
+  exact hs
+
+/-- Every iterate of the one-sided shift is measurable as a map on the shift-invariant
+σ-algebra. -/
+theorem measurable_shift_iterate_shiftInvariantSigma (n : ℕ) :
+    @Measurable (ℕ → α) (ℕ → α) (shiftInvariantSigma α) (shiftInvariantSigma α)
+      ((shift α)^[n]) := by
+  intro s hs
+  rw [MeasurableSet.shift_iterate_preimage_eq hs n]
+  exact hs
+
+/-- A function measurable with respect to the shift-invariant σ-algebra is fixed by the
+one-sided shift. -/
+theorem comp_shift_eq_of_measurable_shiftInvariantSigma [MeasurableSpace β]
+    [MeasurableSingletonClass β] {g : (ℕ → α) → β}
+    (hg : @Measurable (ℕ → α) β (shiftInvariantSigma α) inferInstance g) :
+    g ∘ shift α = g :=
+  MeasurableSpace.comp_eq_of_measurable_invariants hg
+
+end Probability
+
+end TauCeti


### PR DESCRIPTION
This PR adds the one-sided path-space shift-invariant sigma algebra adapter for the Exchangeability roadmap: `IsShiftInvariant`, `shiftInvariantSigma`, the measurable-set characterization, ambient containment, shift and shift-iterate measurability on the invariant sigma algebra, iterate preimage normal forms, and the fixed-function consequence for invariant-measurable observables.

This advances `TauCetiRoadmap/Exchangeability/README.md`, Layer 2, specifically the path-space dynamics and shift-invariant sigma-algebra targets `isShiftInvariant`, `shiftInvariantSigma`, `shiftInvariantSigma_le`, `mem_shiftInvariantSigma_iff`, `shiftInvariantSigma_measurable_shift_eq`, and `shiftInvariant_implies_shiftInvariantMeasurable`. I chose this as the lowest-hanging distinct Exchangeability target after checking open and recently merged PRs: Layer 0 definitions and bridges, adjacent transpositions, product-kernel measurability, the rectangle bridge, and the common de Finetti ending are already landed or in flight, while this Layer 2 path-space invariant sigma-algebra adapter was still absent and is a direct prerequisite for the Koopman and tail/invariant sigma-algebra lanes.

No Mathlib infrastructure is vendored. The implementation reuses Mathlib's `MeasurableSpace.invariants`, `measurableSet_invariants`, `invariants_le`, and `comp_eq_of_measurable_invariants`, together with Tau Ceti's existing one-sided path-space `shift` and shift-iterate API.

`lake exe cache get` completed with `No files to download` and `Already decompressed 8602 file(s)`. `lake build` completed with `Build completed successfully (4355 jobs).` `lake exe axioms` completed with `axioms: audited 6539 TauCeti declaration(s); all within the allowlist [propext, Classical.choice, Quot.sound].`

<!--tauceti-target:v1 {"focus":"Exchangeability","id":"shift-invariant-sigma"}-->

🤖 Prepared with Codex
