### PR TITLE
feat: add finite-type Hopf products

### DIFF
--- a/TauCeti/Algebra/AlgebraicGroup/FiniteTypeProduct.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/FiniteTypeProduct.lean
@@ -6,7 +6,7 @@ module
 
 public import Mathlib.RingTheory.FiniteStability
 public import TauCeti.Algebra.AlgebraicGroup.FiniteTypeCommHopfAlgCat
-public import TauCeti.Algebra.Bialgebra.TensorProduct
+public import TauCeti.Algebra.AlgebraicGroup.Product
 
 /-!
 # Products of finite-type commutative Hopf algebras
@@ -18,8 +18,9 @@ the finite-type input is Mathlib's stability of finite type under base change, f
 transitivity of finite type along `R → H₁ → H₁ ⊗[R] H₂`.
 
 The coordinate inclusions `H₁ → H₁ ⊗[R] H₂` and `H₂ → H₁ ⊗[R] H₂` are also bundled as
-morphisms in `FiniteTypeCommHopfAlgCat`, and the points API is connected to the existing
-product-points equivalence from `TauCeti.Algebra.AlgebraicGroup.Product`.
+morphisms in `FiniteTypeCommHopfAlgCat`. The points of the finite-type product are identified
+with pairs of points by the existing product-points equivalence from
+`TauCeti.Algebra.AlgebraicGroup.Product`.
 
 This is a finite-type wrapper for the ReductiveGroups roadmap Layer 0 product/functor-of-points
 infrastructure: affine group schemes of finite type should remain finite type under products.
@@ -37,11 +38,11 @@ namespace FiniteTypeCommHopfAlgCat
 
 variable {R : Type u} [CommRing R]
 
-/-- The coordinate algebra `H ⊗[R] K` of a product of finite-type affine group schemes is
-again finite type over `R`. -/
-theorem tensorProduct_finiteType (H K : FiniteTypeCommHopfAlgCat.{u, v} R) :
-    Algebra.FiniteType R (H ⊗[R] K) :=
-  Algebra.FiniteType.trans (R := R) (S := H) (A := H ⊗[R] K) inferInstance inferInstance
+/-- The tensor product of two finite-type commutative algebras is finite type over the base. -/
+theorem tensorProduct_finiteType (A B : Type v) [CommRing A] [CommRing B]
+    [Algebra R A] [Algebra R B] [Algebra.FiniteType R A] [Algebra.FiniteType R B] :
+    Algebra.FiniteType R (A ⊗[R] B) :=
+  Algebra.FiniteType.trans (R := R) (S := A) (A := A ⊗[R] B) inferInstance inferInstance
 
 /-- The tensor product of two finite-type commutative Hopf algebras, bundled as a finite-type
 commutative Hopf algebra.
@@ -50,60 +51,62 @@ Contravariantly, this is the coordinate-Hopf-algebra model for the product of th
 affine group schemes. -/
 noncomputable abbrev tensorProduct (H K : FiniteTypeCommHopfAlgCat.{u, v} R) :
     FiniteTypeCommHopfAlgCat.{u, v} R :=
-  letI : Algebra.FiniteType R (H ⊗[R] K) := tensorProduct_finiteType H K
+  letI : Algebra.FiniteType R (H ⊗[R] K) := tensorProduct_finiteType (R := R) H K
   of R (H ⊗[R] K)
 
 /-- The left coordinate inclusion `H → H ⊗[R] K`, bundled in the finite-type commutative
 Hopf-algebra category. On points this is the first projection from product points. -/
 noncomputable abbrev includeLeft (H K : FiniteTypeCommHopfAlgCat.{u, v} R) :
     H ⟶ tensorProduct H K :=
-  letI : Algebra.FiniteType R (H ⊗[R] K) := tensorProduct_finiteType H K
+  letI : Algebra.FiniteType R (H ⊗[R] K) := tensorProduct_finiteType (R := R) H K
   ofHom (Bialgebra.TensorProduct.includeLeft (R := R) (H₁ := H) (H₂ := K))
 
 /-- The right coordinate inclusion `K → H ⊗[R] K`, bundled in the finite-type commutative
 Hopf-algebra category. On points this is the second projection from product points. -/
 noncomputable abbrev includeRight (H K : FiniteTypeCommHopfAlgCat.{u, v} R) :
     K ⟶ tensorProduct H K :=
-  letI : Algebra.FiniteType R (H ⊗[R] K) := tensorProduct_finiteType H K
+  letI : Algebra.FiniteType R (H ⊗[R] K) := tensorProduct_finiteType (R := R) H K
   ofHom (Bialgebra.TensorProduct.includeRight (R := R) (H₁ := H) (H₂ := K))
-
-/-- The underlying bialgebra morphism of `includeLeft` is `x ↦ x ⊗ 1`. -/
-@[simp]
-lemma toBialgHom_includeLeft (H K : FiniteTypeCommHopfAlgCat.{u, v} R) :
-    toBialgHom (includeLeft H K) =
-      Bialgebra.TensorProduct.includeLeft (R := R) (H₁ := H) (H₂ := K) := by
-  letI : Algebra.FiniteType R (H ⊗[R] K) := tensorProduct_finiteType H K
-  exact toBialgHom_ofHom (Bialgebra.TensorProduct.includeLeft (R := R) (H₁ := H) (H₂ := K))
-
-/-- The underlying bialgebra morphism of `includeRight` is `y ↦ 1 ⊗ y`. -/
-@[simp]
-lemma toBialgHom_includeRight (H K : FiniteTypeCommHopfAlgCat.{u, v} R) :
-    toBialgHom (includeRight H K) =
-      Bialgebra.TensorProduct.includeRight (R := R) (H₁ := H) (H₂ := K) := by
-  letI : Algebra.FiniteType R (H ⊗[R] K) := tensorProduct_finiteType H K
-  exact toBialgHom_ofHom (Bialgebra.TensorProduct.includeRight (R := R) (H₁ := H) (H₂ := K))
 
 variable (A : CommAlgCat.{w} R)
 
-/-- The finite-type points functor sends the left coordinate inclusion to first-factor
-restriction on product points. -/
-@[simp]
-theorem pointsFunctor_map_includeLeft_app_apply_apply
-    (H K : FiniteTypeCommHopfAlgCat.{u, v} R)
-    (f : HopfAlgebra.points (R := R) (H := tensorProduct H K) A) (h : H) :
-    (((pointsFunctor (R := R)).map (includeLeft H K).op).app A f).ofConv h =
-      f.ofConv (Bialgebra.TensorProduct.includeLeft (R := R) (H₁ := H) (H₂ := K) h) := by
-  simp [pointsFunctor_map_app_apply_apply]
+/-- The product-points equivalence for the finite-type tensor-product object. -/
+noncomputable def pointsMulEquiv (H K : FiniteTypeCommHopfAlgCat.{u, v} R) :
+    HopfAlgebra.points (R := R) (H := tensorProduct H K) A ≃*
+      HopfAlgebra.points (R := R) (H := H) A × HopfAlgebra.points (R := R) (H := K) A :=
+  AffineGroup.Product.pointsMulEquiv (R := R) (H₁ := H) (H₂ := K) (A := A)
 
-/-- The finite-type points functor sends the right coordinate inclusion to second-factor
-restriction on product points. -/
+/-- The first component of `pointsMulEquiv` is induced by the left coordinate inclusion. -/
 @[simp]
-theorem pointsFunctor_map_includeRight_app_apply_apply
+theorem pointsMulEquiv_fst
     (H K : FiniteTypeCommHopfAlgCat.{u, v} R)
-    (f : HopfAlgebra.points (R := R) (H := tensorProduct H K) A) (k : K) :
-    (((pointsFunctor (R := R)).map (includeRight H K).op).app A f).ofConv k =
-      f.ofConv (Bialgebra.TensorProduct.includeRight (R := R) (H₁ := H) (H₂ := K) k) := by
-  simp [pointsFunctor_map_app_apply_apply]
+    (f : HopfAlgebra.points (R := R) (H := tensorProduct H K) A) :
+    (pointsMulEquiv A H K f).1 =
+      (((pointsFunctor (R := R)).map (includeLeft H K).op).app A f) := by
+  apply WithConv.ofConv_injective
+  ext h
+  rw [pointsMulEquiv]
+  exact (pointsFunctor_map_app_apply_apply (R := R) (φ := (includeLeft H K).op) A f h).symm
+
+/-- The second component of `pointsMulEquiv` is induced by the right coordinate inclusion. -/
+@[simp]
+theorem pointsMulEquiv_snd
+    (H K : FiniteTypeCommHopfAlgCat.{u, v} R)
+    (f : HopfAlgebra.points (R := R) (H := tensorProduct H K) A) :
+    (pointsMulEquiv A H K f).2 =
+      (((pointsFunctor (R := R)).map (includeRight H K).op).app A f) := by
+  apply WithConv.ofConv_injective
+  ext k
+  rw [pointsMulEquiv]
+  exact (pointsFunctor_map_app_apply_apply (R := R) (φ := (includeRight H K).op) A f k).symm
+
+/-- The inverse of `pointsMulEquiv` is Mathlib's tensor-product product map. -/
+@[simp]
+theorem pointsMulEquiv_symm_apply (H K : FiniteTypeCommHopfAlgCat.{u, v} R)
+    (p : HopfAlgebra.points (R := R) (H := H) A × HopfAlgebra.points (R := R) (H := K) A) :
+    (pointsMulEquiv A H K).symm p =
+      toConv (Algebra.TensorProduct.productMap p.1.ofConv p.2.ofConv) :=
+  AffineGroup.Product.pointsMulEquiv_symm_apply (R := R) (H₁ := H) (H₂ := K) (A := A) p
 
 end FiniteTypeCommHopfAlgCat
 

--- a/TauCeti/Algebra/AlgebraicGroup/FiniteTypeProduct.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/FiniteTypeProduct.lean
@@ -6,7 +6,7 @@ module
 
 public import Mathlib.RingTheory.FiniteStability
 public import TauCeti.Algebra.AlgebraicGroup.FiniteTypeCommHopfAlgCat
-public import TauCeti.Algebra.AlgebraicGroup.Product
+public import TauCeti.Algebra.Bialgebra.TensorProduct
 
 /-!
 # Products of finite-type commutative Hopf algebras

--- a/TauCeti/Algebra/AlgebraicGroup/FiniteTypeProduct.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/FiniteTypeProduct.lean
@@ -5,7 +5,6 @@ Released under Apache 2.0 license as described in the file LICENSE.
 module
 
 public import Mathlib.RingTheory.FiniteStability
-public import Mathlib.RingTheory.HopfAlgebra.TensorProduct
 public import TauCeti.Algebra.AlgebraicGroup.FiniteTypeCommHopfAlgCat
 public import TauCeti.Algebra.AlgebraicGroup.Product
 
@@ -72,45 +71,19 @@ noncomputable abbrev includeRight (H K : FiniteTypeCommHopfAlgCat.{u, v} R) :
 @[simp]
 lemma toBialgHom_includeLeft (H K : FiniteTypeCommHopfAlgCat.{u, v} R) :
     toBialgHom (includeLeft H K) =
-      Bialgebra.TensorProduct.includeLeft (R := R) (H₁ := H) (H₂ := K) :=
-  rfl
+      Bialgebra.TensorProduct.includeLeft (R := R) (H₁ := H) (H₂ := K) := by
+  letI : Algebra.FiniteType R (H ⊗[R] K) := tensorProduct_finiteType H K
+  exact toBialgHom_ofHom (Bialgebra.TensorProduct.includeLeft (R := R) (H₁ := H) (H₂ := K))
 
 /-- The underlying bialgebra morphism of `includeRight` is `y ↦ 1 ⊗ y`. -/
 @[simp]
 lemma toBialgHom_includeRight (H K : FiniteTypeCommHopfAlgCat.{u, v} R) :
     toBialgHom (includeRight H K) =
-      Bialgebra.TensorProduct.includeRight (R := R) (H₁ := H) (H₂ := K) :=
-  rfl
+      Bialgebra.TensorProduct.includeRight (R := R) (H₁ := H) (H₂ := K) := by
+  letI : Algebra.FiniteType R (H ⊗[R] K) := tensorProduct_finiteType H K
+  exact toBialgHom_ofHom (Bialgebra.TensorProduct.includeRight (R := R) (H₁ := H) (H₂ := K))
 
 variable (A : CommAlgCat.{w} R)
-
-/-- Points of the product finite-type Hopf algebra are the product of the two points groups. -/
-noncomputable abbrev tensorProductPointsMulEquiv (H K : FiniteTypeCommHopfAlgCat.{u, v} R) :
-    HopfAlgebra.points (R := R) (H := tensorProduct H K) A ≃*
-      HopfAlgebra.points (R := R) (H := H) A ×
-        HopfAlgebra.points (R := R) (H := K) A :=
-  AffineGroup.Product.pointsMulEquiv (R := R) (H₁ := H) (H₂ := K) (A := A)
-
-/-- The product-points equivalence restricts a point along the two coordinate inclusions. -/
-@[simp]
-theorem tensorProductPointsMulEquiv_apply (H K : FiniteTypeCommHopfAlgCat.{u, v} R)
-    (f : HopfAlgebra.points (R := R) (H := tensorProduct H K) A) :
-    tensorProductPointsMulEquiv A H K f =
-      (AlgHom.mapDomain (Bialgebra.TensorProduct.includeLeft (R := R) (H₁ := H) (H₂ := K)) f,
-        AlgHom.mapDomain
-          (Bialgebra.TensorProduct.includeRight (R := R) (H₁ := H) (H₂ := K)) f) :=
-  rfl
-
-/-- The inverse product-points equivalence evaluates on pure tensors by multiplying the two
-factor point values. -/
-@[simp]
-theorem tensorProductPointsMulEquiv_symm_apply_tmul
-    (H K : FiniteTypeCommHopfAlgCat.{u, v} R)
-    (p : HopfAlgebra.points (R := R) (H := H) A × HopfAlgebra.points (R := R) (H := K) A)
-    (x : H) (y : K) :
-    (((tensorProductPointsMulEquiv A H K).symm p).ofConv) (x ⊗ₜ[R] y) =
-      p.1.ofConv x * p.2.ofConv y :=
-  rfl
 
 /-- The finite-type points functor sends the left coordinate inclusion to first-factor
 restriction on product points. -/
@@ -120,7 +93,7 @@ theorem pointsFunctor_map_includeLeft_app_apply_apply
     (f : HopfAlgebra.points (R := R) (H := tensorProduct H K) A) (h : H) :
     (((pointsFunctor (R := R)).map (includeLeft H K).op).app A f).ofConv h =
       f.ofConv (Bialgebra.TensorProduct.includeLeft (R := R) (H₁ := H) (H₂ := K) h) := by
-  simp [pointsFunctor_map_app_apply_apply, includeLeft]
+  simp [pointsFunctor_map_app_apply_apply]
 
 /-- The finite-type points functor sends the right coordinate inclusion to second-factor
 restriction on product points. -/
@@ -130,7 +103,7 @@ theorem pointsFunctor_map_includeRight_app_apply_apply
     (f : HopfAlgebra.points (R := R) (H := tensorProduct H K) A) (k : K) :
     (((pointsFunctor (R := R)).map (includeRight H K).op).app A f).ofConv k =
       f.ofConv (Bialgebra.TensorProduct.includeRight (R := R) (H₁ := H) (H₂ := K) k) := by
-  simp [pointsFunctor_map_app_apply_apply, includeRight]
+  simp [pointsFunctor_map_app_apply_apply]
 
 end FiniteTypeCommHopfAlgCat
 

--- a/TauCeti/Algebra/AlgebraicGroup/FiniteTypeProduct.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/FiniteTypeProduct.lean
@@ -1,0 +1,137 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+module
+
+public import Mathlib.RingTheory.FiniteStability
+public import Mathlib.RingTheory.HopfAlgebra.TensorProduct
+public import TauCeti.Algebra.AlgebraicGroup.FiniteTypeCommHopfAlgCat
+public import TauCeti.Algebra.AlgebraicGroup.Product
+
+/-!
+# Products of finite-type commutative Hopf algebras
+
+This file packages the tensor product of two finite-type commutative Hopf algebras as another
+object of `FiniteTypeCommHopfAlgCat`. On affine group schemes this is the coordinate algebra
+of the direct product. The Hopf-algebra structure is Mathlib's tensor-product Hopf algebra;
+the finite-type input is Mathlib's stability of finite type under base change, followed by
+transitivity of finite type along `R → H₁ → H₁ ⊗[R] H₂`.
+
+The coordinate inclusions `H₁ → H₁ ⊗[R] H₂` and `H₂ → H₁ ⊗[R] H₂` are also bundled as
+morphisms in `FiniteTypeCommHopfAlgCat`, and the points API is connected to the existing
+product-points equivalence from `TauCeti.Algebra.AlgebraicGroup.Product`.
+
+This is a finite-type wrapper for the ReductiveGroups roadmap Layer 0 product/functor-of-points
+infrastructure: affine group schemes of finite type should remain finite type under products.
+-/
+
+public section
+
+open CategoryTheory TensorProduct WithConv
+
+namespace TauCeti
+
+universe u v w
+
+namespace FiniteTypeCommHopfAlgCat
+
+variable {R : Type u} [CommRing R]
+
+/-- The coordinate algebra `H ⊗[R] K` of a product of finite-type affine group schemes is
+again finite type over `R`. -/
+theorem tensorProduct_finiteType (H K : FiniteTypeCommHopfAlgCat.{u, v} R) :
+    Algebra.FiniteType R (H ⊗[R] K) :=
+  Algebra.FiniteType.trans (R := R) (S := H) (A := H ⊗[R] K) inferInstance inferInstance
+
+/-- The tensor product of two finite-type commutative Hopf algebras, bundled as a finite-type
+commutative Hopf algebra.
+
+Contravariantly, this is the coordinate-Hopf-algebra model for the product of the represented
+affine group schemes. -/
+noncomputable abbrev tensorProduct (H K : FiniteTypeCommHopfAlgCat.{u, v} R) :
+    FiniteTypeCommHopfAlgCat.{u, v} R :=
+  letI : Algebra.FiniteType R (H ⊗[R] K) := tensorProduct_finiteType H K
+  of R (H ⊗[R] K)
+
+/-- The left coordinate inclusion `H → H ⊗[R] K`, bundled in the finite-type commutative
+Hopf-algebra category. On points this is the first projection from product points. -/
+noncomputable abbrev includeLeft (H K : FiniteTypeCommHopfAlgCat.{u, v} R) :
+    H ⟶ tensorProduct H K :=
+  letI : Algebra.FiniteType R (H ⊗[R] K) := tensorProduct_finiteType H K
+  ofHom (Bialgebra.TensorProduct.includeLeft (R := R) (H₁ := H) (H₂ := K))
+
+/-- The right coordinate inclusion `K → H ⊗[R] K`, bundled in the finite-type commutative
+Hopf-algebra category. On points this is the second projection from product points. -/
+noncomputable abbrev includeRight (H K : FiniteTypeCommHopfAlgCat.{u, v} R) :
+    K ⟶ tensorProduct H K :=
+  letI : Algebra.FiniteType R (H ⊗[R] K) := tensorProduct_finiteType H K
+  ofHom (Bialgebra.TensorProduct.includeRight (R := R) (H₁ := H) (H₂ := K))
+
+/-- The underlying bialgebra morphism of `includeLeft` is `x ↦ x ⊗ 1`. -/
+@[simp]
+lemma toBialgHom_includeLeft (H K : FiniteTypeCommHopfAlgCat.{u, v} R) :
+    toBialgHom (includeLeft H K) =
+      Bialgebra.TensorProduct.includeLeft (R := R) (H₁ := H) (H₂ := K) :=
+  rfl
+
+/-- The underlying bialgebra morphism of `includeRight` is `y ↦ 1 ⊗ y`. -/
+@[simp]
+lemma toBialgHom_includeRight (H K : FiniteTypeCommHopfAlgCat.{u, v} R) :
+    toBialgHom (includeRight H K) =
+      Bialgebra.TensorProduct.includeRight (R := R) (H₁ := H) (H₂ := K) :=
+  rfl
+
+variable (A : CommAlgCat.{w} R)
+
+/-- Points of the product finite-type Hopf algebra are the product of the two points groups. -/
+noncomputable abbrev tensorProductPointsMulEquiv (H K : FiniteTypeCommHopfAlgCat.{u, v} R) :
+    HopfAlgebra.points (R := R) (H := tensorProduct H K) A ≃*
+      HopfAlgebra.points (R := R) (H := H) A ×
+        HopfAlgebra.points (R := R) (H := K) A :=
+  AffineGroup.Product.pointsMulEquiv (R := R) (H₁ := H) (H₂ := K) (A := A)
+
+/-- The product-points equivalence restricts a point along the two coordinate inclusions. -/
+@[simp]
+theorem tensorProductPointsMulEquiv_apply (H K : FiniteTypeCommHopfAlgCat.{u, v} R)
+    (f : HopfAlgebra.points (R := R) (H := tensorProduct H K) A) :
+    tensorProductPointsMulEquiv A H K f =
+      (AlgHom.mapDomain (Bialgebra.TensorProduct.includeLeft (R := R) (H₁ := H) (H₂ := K)) f,
+        AlgHom.mapDomain
+          (Bialgebra.TensorProduct.includeRight (R := R) (H₁ := H) (H₂ := K)) f) :=
+  rfl
+
+/-- The inverse product-points equivalence evaluates on pure tensors by multiplying the two
+factor point values. -/
+@[simp]
+theorem tensorProductPointsMulEquiv_symm_apply_tmul
+    (H K : FiniteTypeCommHopfAlgCat.{u, v} R)
+    (p : HopfAlgebra.points (R := R) (H := H) A × HopfAlgebra.points (R := R) (H := K) A)
+    (x : H) (y : K) :
+    (((tensorProductPointsMulEquiv A H K).symm p).ofConv) (x ⊗ₜ[R] y) =
+      p.1.ofConv x * p.2.ofConv y :=
+  rfl
+
+/-- The finite-type points functor sends the left coordinate inclusion to first-factor
+restriction on product points. -/
+@[simp]
+theorem pointsFunctor_map_includeLeft_app_apply_apply
+    (H K : FiniteTypeCommHopfAlgCat.{u, v} R)
+    (f : HopfAlgebra.points (R := R) (H := tensorProduct H K) A) (h : H) :
+    (((pointsFunctor (R := R)).map (includeLeft H K).op).app A f).ofConv h =
+      f.ofConv (Bialgebra.TensorProduct.includeLeft (R := R) (H₁ := H) (H₂ := K) h) := by
+  simp [pointsFunctor_map_app_apply_apply, includeLeft]
+
+/-- The finite-type points functor sends the right coordinate inclusion to second-factor
+restriction on product points. -/
+@[simp]
+theorem pointsFunctor_map_includeRight_app_apply_apply
+    (H K : FiniteTypeCommHopfAlgCat.{u, v} R)
+    (f : HopfAlgebra.points (R := R) (H := tensorProduct H K) A) (k : K) :
+    (((pointsFunctor (R := R)).map (includeRight H K).op).app A f).ofConv k =
+      f.ofConv (Bialgebra.TensorProduct.includeRight (R := R) (H₁ := H) (H₂ := K) k) := by
+  simp [pointsFunctor_map_app_apply_apply, includeRight]
+
+end FiniteTypeCommHopfAlgCat
+
+end TauCeti

--- a/TauCeti/Algebra/AlgebraicGroup/FiniteTypeProduct.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/FiniteTypeProduct.lean
@@ -108,6 +108,73 @@ theorem pointsMulEquiv_symm_apply (H K : FiniteTypeCommHopfAlgCat.{u, v} R)
       toConv (Algebra.TensorProduct.productMap p.1.ofConv p.2.ofConv) :=
   AffineGroup.Product.pointsMulEquiv_symm_apply (R := R) (H₁ := H) (H₂ := K) (A := A) p
 
+variable {B : CommAlgCat.{w} R}
+
+/-- The product-points equivalence is natural in the value algebra: post-composing a point of
+the product by `φ`, then splitting it into its two factor points, agrees with splitting first
+and then post-composing each factor point by `φ`. -/
+@[simp]
+theorem pointsMulEquiv_mapValue (H K : FiniteTypeCommHopfAlgCat.{u, v} R) (φ : A →ₐ[R] B)
+    (f : HopfAlgebra.points (R := R) (H := tensorProduct H K) A) :
+    pointsMulEquiv B H K (AlgHom.mapValue (H := tensorProduct H K) φ f) =
+      (AlgHom.mapValue (H := H) φ (pointsMulEquiv A H K f).1,
+        AlgHom.mapValue (H := K) φ (pointsMulEquiv A H K f).2) :=
+  AffineGroup.Product.pointsMulEquiv_mapValue (R := R) (H₁ := H) (H₂ := K) φ f
+
+/-- First-component form of `pointsMulEquiv_mapValue`. -/
+@[simp]
+theorem pointsMulEquiv_mapValue_fst (H K : FiniteTypeCommHopfAlgCat.{u, v} R) (φ : A →ₐ[R] B)
+    (f : HopfAlgebra.points (R := R) (H := tensorProduct H K) A) :
+    (pointsMulEquiv B H K (AlgHom.mapValue (H := tensorProduct H K) φ f)).1 =
+      AlgHom.mapValue (H := H) φ (pointsMulEquiv A H K f).1 :=
+  AffineGroup.Product.pointsMulEquiv_mapValue_fst (R := R) (H₁ := H) (H₂ := K) φ f
+
+/-- Second-component form of `pointsMulEquiv_mapValue`. -/
+@[simp]
+theorem pointsMulEquiv_mapValue_snd (H K : FiniteTypeCommHopfAlgCat.{u, v} R) (φ : A →ₐ[R] B)
+    (f : HopfAlgebra.points (R := R) (H := tensorProduct H K) A) :
+    (pointsMulEquiv B H K (AlgHom.mapValue (H := tensorProduct H K) φ f)).2 =
+      AlgHom.mapValue (H := K) φ (pointsMulEquiv A H K f).2 :=
+  AffineGroup.Product.pointsMulEquiv_mapValue_snd (R := R) (H₁ := H) (H₂ := K) φ f
+
+/-- The inverse product-points map is natural in the value algebra: assembling an `A`-valued
+product point from a pair of factor points and post-composing by `φ` is the same as
+post-composing both factor points by `φ` and then assembling the resulting `B`-valued point. -/
+@[simp]
+theorem mapValue_pointsMulEquiv_symm_apply (H K : FiniteTypeCommHopfAlgCat.{u, v} R)
+    (φ : A →ₐ[R] B)
+    (p : HopfAlgebra.points (R := R) (H := H) A × HopfAlgebra.points (R := R) (H := K) A) :
+    AlgHom.mapValue (H := tensorProduct H K) φ ((pointsMulEquiv A H K).symm p) =
+      (pointsMulEquiv B H K).symm
+        (AlgHom.mapValue (H := H) φ p.1, AlgHom.mapValue (H := K) φ p.2) :=
+  AffineGroup.Product.mapValue_pointsMulEquiv_symm_apply (R := R) (H₁ := H) (H₂ := K) φ p
+
+/-- On pure tensors, naturality of the inverse product-points map evaluates post-composition by
+`φ` as applying `φ` to the product of the two factor values. -/
+@[simp]
+theorem mapValue_pointsMulEquiv_symm_apply_tmul (H K : FiniteTypeCommHopfAlgCat.{u, v} R)
+    (φ : A →ₐ[R] B)
+    (p : HopfAlgebra.points (R := R) (H := H) A × HopfAlgebra.points (R := R) (H := K) A)
+    (x : H) (y : K) :
+    (AlgHom.mapValue (H := tensorProduct H K) φ ((pointsMulEquiv A H K).symm p)).ofConv
+        (x ⊗ₜ[R] y) =
+      φ (p.1.ofConv x * p.2.ofConv y) :=
+  AffineGroup.Product.mapValue_pointsMulEquiv_symm_apply_tmul
+    (R := R) (H₁ := H) (H₂ := K) φ p x y
+
+/-- On pure tensors, assembling after post-composing both factor points by `φ` multiplies the
+two post-composed factor values. -/
+@[simp]
+theorem pointsMulEquiv_symm_mapValue_apply_tmul (H K : FiniteTypeCommHopfAlgCat.{u, v} R)
+    (φ : A →ₐ[R] B)
+    (p : HopfAlgebra.points (R := R) (H := H) A × HopfAlgebra.points (R := R) (H := K) A)
+    (x : H) (y : K) :
+    ((pointsMulEquiv B H K).symm
+        (AlgHom.mapValue (H := H) φ p.1, AlgHom.mapValue (H := K) φ p.2)).ofConv (x ⊗ₜ[R] y) =
+      φ (p.1.ofConv x) * φ (p.2.ofConv y) :=
+  AffineGroup.Product.pointsMulEquiv_symm_mapValue_apply_tmul
+    (R := R) (H₁ := H) (H₂ := K) φ p x y
+
 end FiniteTypeCommHopfAlgCat
 
 end TauCeti


### PR DESCRIPTION
This PR packages the finite-type coordinate-Hopf-algebra product: the tensor product of two objects of `FiniteTypeCommHopfAlgCat R` is bundled again as a finite-type commutative Hopf algebra, with the two coordinate inclusions and points-projection formulas linked to the existing product-points equivalence.

This advances `TauCetiRoadmap/ReductiveGroups/README.md`, Layer 0, specifically the three synchronized models and product/functor-of-points infrastructure around affine group schemes of finite type and “R-points as a group,” as a clean prerequisite for treating products of finite-type affine group schemes inside the finite-type coordinate-Hopf-algebra category. I chose this as the lowest-hanging distinct ReductiveGroups target after checking open and recently merged PRs: the generic product-points equivalence and finite-type quotient wrapper already exist on `main`, while the finite-type product object and finite-type coordinate inclusions were still absent.

No Mathlib infrastructure is vendored. The implementation reuses Mathlib’s tensor-product Hopf algebra and `Algebra.FiniteType` stability under base change from `Mathlib.RingTheory.FiniteStability`, together with Tau Ceti’s existing `FiniteTypeCommHopfAlgCat`, tensor-product bialgebra inclusions, and `AffineGroup.Product.pointsMulEquiv`.

`lake exe cache get` completed with `No files to download`, `Decompressed 5005 already-cached file(s)`, and `Completed successfully in 2842 ms!`. `lake build` completed with `Build completed successfully (4356 jobs).` `lake exe axioms` completed with `axioms: audited 6574 TauCeti declaration(s); all within the allowlist [propext, Classical.choice, Quot.sound].`

<!--tauceti-target:v1 {"focus":"ReductiveGroups","id":"finite-type-product"}-->

🤖 Prepared with Codex
