### PR TITLE
feat: add ambient-isotopy class actions

### DIFF
--- a/TauCeti/Geometry/Diffeomorphism/AmbientIsotopyClassAction.lean
+++ b/TauCeti/Geometry/Diffeomorphism/AmbientIsotopyClassAction.lean
@@ -1,0 +1,97 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+module
+
+public import TauCeti.Geometry.Diffeomorphism.Group
+public import TauCeti.Topology.Homotopy.AmbientIsotopyClassAction
+
+/-!
+# Diffeomorphisms acting on continuous ambient-isotopy classes
+
+The geometric-topology roadmap first builds the group `Diff(M)` and then uses smooth
+presentations of knots and links whose underlying maps have continuous ambient-isotopy classes.
+This file records the immediate action available without adding any new smooth-isotopy
+technology: a self-diffeomorphism acts on continuous ambient-isotopy classes through its
+underlying self-homeomorphism.
+
+This is a thin restriction of the ambient-homeomorphism action along
+`TauCeti.Diffeomorph.toHomeomorphHom`. It does not assert that postcomposing a bundled smooth
+embedding by a diffeomorphism has been bundled again; that stronger smooth-presentation action is
+a later API once the required smooth-embedding composition theorem is available.
+
+## Main results
+
+* `TauCeti.Diffeomorph.ambientIsotopyClassMulAction`: the action of `Diff(M)` on
+  `AmbientIsotopyClass X M`.
+* `TauCeti.Diffeomorph.ambientIsotopyClass_smul_mk`: the representative formula.
+* `TauCeti.Diffeomorph.ambientIsotopyClass_smul_eq_homeomorph_smul`: the action is the
+  underlying-homeomorphism action.
+-/
+
+public section
+
+namespace TauCeti
+
+open scoped Manifold ContDiff
+open ContinuousMap
+
+namespace Diffeomorph
+
+variable {𝕜 : Type*} [NontriviallyNormedField 𝕜]
+  {E : Type*} [NormedAddCommGroup E] [NormedSpace 𝕜 E]
+  {H : Type*} [TopologicalSpace H] {I : ModelWithCorners 𝕜 E H}
+  {M : Type*} [TopologicalSpace M] [ChartedSpace H M] {n : ℕ∞ω}
+  {X : Type*} [TopologicalSpace X]
+
+/-- The self-diffeomorphism group acts on continuous ambient-isotopy classes through the
+underlying self-homeomorphism. -/
+instance ambientIsotopyClassSMul : SMul (M ≃ₘ^n⟮I, I⟯ M) (AmbientIsotopyClass X M) where
+  smul φ x := φ.toHomeomorph • x
+
+/-- The diffeomorphism action on continuous ambient-isotopy classes is the underlying
+homeomorphism action. -/
+@[simp]
+theorem ambientIsotopyClass_smul_eq_homeomorph_smul
+    (φ : M ≃ₘ^n⟮I, I⟯ M) (x : AmbientIsotopyClass X M) :
+    φ • x = φ.toHomeomorph • x :=
+  rfl
+
+/-- Self-diffeomorphisms act on continuous ambient-isotopy classes. -/
+instance ambientIsotopyClassMulAction : MulAction (M ≃ₘ^n⟮I, I⟯ M) (AmbientIsotopyClass X M) where
+  one_smul x := by
+    rw [ambientIsotopyClass_smul_eq_homeomorph_smul]
+    rw [← toHomeomorphHom_apply (I := I) (M := M) (n := n)
+      (f := (1 : M ≃ₘ^n⟮I, I⟯ M))]
+    rw [map_one, one_smul]
+  mul_smul φ ψ x := by
+    rw [ambientIsotopyClass_smul_eq_homeomorph_smul,
+      ambientIsotopyClass_smul_eq_homeomorph_smul,
+      ambientIsotopyClass_smul_eq_homeomorph_smul]
+    rw [← toHomeomorphHom_apply (I := I) (M := M) (n := n) (f := φ * ψ),
+      ← toHomeomorphHom_apply (I := I) (M := M) (n := n) (f := φ),
+      ← toHomeomorphHom_apply (I := I) (M := M) (n := n) (f := ψ)]
+    rw [map_mul, mul_smul]
+
+/-- The diffeomorphism action on representatives is postcomposition by the underlying
+homeomorphism. -/
+@[simp]
+theorem ambientIsotopyClass_smul_mk (φ : M ≃ₘ^n⟮I, I⟯ M) (f : C(X, M)) :
+    φ • AmbientIsotopyClass.mk f =
+      AmbientIsotopyClass.mk ((φ.toHomeomorph : C(M, M)).comp f) :=
+  AmbientIsotopyClass.smul_mk φ.toHomeomorph f
+
+/-- The homeomorphism-induced quotient equivalence of the underlying homeomorphism agrees with the
+diffeomorphism action. -/
+@[simp]
+theorem ambientIsotopyClass_postcompHomeomorphEquiv_apply
+    (φ : M ≃ₘ^n⟮I, I⟯ M) (x : AmbientIsotopyClass X M) :
+    AmbientIsotopyClass.postcompHomeomorphEquiv φ.toHomeomorph x = φ • x := by
+  refine AmbientIsotopyClass.induction_on x ?_
+  intro f
+  rw [AmbientIsotopyClass.postcompHomeomorphEquiv_mk, ambientIsotopyClass_smul_mk]
+
+end Diffeomorph
+
+end TauCeti

--- a/TauCeti/Geometry/Diffeomorphism/AmbientIsotopyClassAction.lean
+++ b/TauCeti/Geometry/Diffeomorphism/AmbientIsotopyClassAction.lean
@@ -45,34 +45,18 @@ variable {𝕜 : Type*} [NontriviallyNormedField 𝕜]
   {M : Type*} [TopologicalSpace M] [ChartedSpace H M] {n : ℕ∞ω}
   {X : Type*} [TopologicalSpace X]
 
-/-- The self-diffeomorphism group acts on continuous ambient-isotopy classes through the
-underlying self-homeomorphism. -/
-instance ambientIsotopyClassSMul : SMul (M ≃ₘ^n⟮I, I⟯ M) (AmbientIsotopyClass X M) where
-  smul φ x := φ.toHomeomorph • x
+/-- Self-diffeomorphisms act on continuous ambient-isotopy classes. -/
+instance ambientIsotopyClassMulAction : MulAction (M ≃ₘ^n⟮I, I⟯ M)
+    (AmbientIsotopyClass X M) :=
+  MulAction.compHom (AmbientIsotopyClass X M) (toHomeomorphHom (I := I) (M := M) (n := n))
 
 /-- The diffeomorphism action on continuous ambient-isotopy classes is the underlying
 homeomorphism action. -/
 @[simp]
 theorem ambientIsotopyClass_smul_eq_homeomorph_smul
     (φ : M ≃ₘ^n⟮I, I⟯ M) (x : AmbientIsotopyClass X M) :
-    φ • x = φ.toHomeomorph • x :=
-  rfl
-
-/-- Self-diffeomorphisms act on continuous ambient-isotopy classes. -/
-instance ambientIsotopyClassMulAction : MulAction (M ≃ₘ^n⟮I, I⟯ M) (AmbientIsotopyClass X M) where
-  one_smul x := by
-    rw [ambientIsotopyClass_smul_eq_homeomorph_smul]
-    rw [← toHomeomorphHom_apply (I := I) (M := M) (n := n)
-      (f := (1 : M ≃ₘ^n⟮I, I⟯ M))]
-    rw [map_one, one_smul]
-  mul_smul φ ψ x := by
-    rw [ambientIsotopyClass_smul_eq_homeomorph_smul,
-      ambientIsotopyClass_smul_eq_homeomorph_smul,
-      ambientIsotopyClass_smul_eq_homeomorph_smul]
-    rw [← toHomeomorphHom_apply (I := I) (M := M) (n := n) (f := φ * ψ),
-      ← toHomeomorphHom_apply (I := I) (M := M) (n := n) (f := φ),
-      ← toHomeomorphHom_apply (I := I) (M := M) (n := n) (f := ψ)]
-    rw [map_mul, mul_smul]
+    φ • x = φ.toHomeomorph • x := by
+  rw [MulAction.compHom_smul_def, toHomeomorphHom_apply]
 
 /-- The diffeomorphism action on representatives is postcomposition by the underlying
 homeomorphism. -/
@@ -80,7 +64,8 @@ homeomorphism. -/
 theorem ambientIsotopyClass_smul_mk (φ : M ≃ₘ^n⟮I, I⟯ M) (f : C(X, M)) :
     φ • AmbientIsotopyClass.mk f =
       AmbientIsotopyClass.mk ((φ.toHomeomorph : C(M, M)).comp f) :=
-  AmbientIsotopyClass.smul_mk φ.toHomeomorph f
+  ambientIsotopyClass_smul_eq_homeomorph_smul φ (AmbientIsotopyClass.mk f) ▸
+    AmbientIsotopyClass.smul_mk φ.toHomeomorph f
 
 /-- The homeomorphism-induced quotient equivalence of the underlying homeomorphism agrees with the
 diffeomorphism action. -/

--- a/TauCeti/Geometry/Diffeomorphism/AmbientIsotopyClassAction.lean
+++ b/TauCeti/Geometry/Diffeomorphism/AmbientIsotopyClassAction.lean
@@ -70,12 +70,11 @@ theorem ambientIsotopyClass_smul_mk (φ : M ≃ₘ^n⟮I, I⟯ M) (f : C(X, M)) 
 /-- The homeomorphism-induced quotient equivalence of the underlying homeomorphism agrees with the
 diffeomorphism action. -/
 @[simp]
-theorem ambientIsotopyClass_postcompHomeomorphEquiv_apply
+theorem ambientIsotopyClass_postcompHomeomorphEquiv_apply_eq_smul
     (φ : M ≃ₘ^n⟮I, I⟯ M) (x : AmbientIsotopyClass X M) :
     AmbientIsotopyClass.postcompHomeomorphEquiv φ.toHomeomorph x = φ • x := by
-  refine AmbientIsotopyClass.induction_on x ?_
-  intro f
-  rw [AmbientIsotopyClass.postcompHomeomorphEquiv_mk, ambientIsotopyClass_smul_mk]
+  rw [AmbientIsotopyClass.postcompHomeomorphEquiv_apply_eq_smul,
+    ← ambientIsotopyClass_smul_eq_homeomorph_smul]
 
 end Diffeomorph
 

--- a/TauCeti/Topology/Homotopy/AmbientIsotopyClassAction.lean
+++ b/TauCeti/Topology/Homotopy/AmbientIsotopyClassAction.lean
@@ -49,7 +49,7 @@ theorem smul_def (h : Y ≃ₜ Y) (x : AmbientIsotopyClass X Y) :
 /-- Ambient homeomorphisms act on ambient-isotopy classes by postcomposition. -/
 instance instMulAction : MulAction (Y ≃ₜ Y) (AmbientIsotopyClass X Y) where
   one_smul x := by
-    change postcompHomeomorph (Homeomorph.refl Y) x = x
+    rw [smul_def, show (1 : Y ≃ₜ Y) = Homeomorph.refl Y by ext y; simp]
     exact postcompHomeomorph_refl x
   mul_smul h k x := by
     rw [smul_def, smul_def, smul_def]

--- a/TauCeti/Topology/Homotopy/AmbientIsotopyClassAction.lean
+++ b/TauCeti/Topology/Homotopy/AmbientIsotopyClassAction.lean
@@ -46,10 +46,14 @@ theorem smul_def (h : Y ≃ₜ Y) (x : AmbientIsotopyClass X Y) :
     h • x = postcompHomeomorph h x :=
   rfl
 
+private theorem one_eq_homeomorph_refl : (1 : Y ≃ₜ Y) = Homeomorph.refl Y := by
+  ext y
+  simp
+
 /-- Ambient homeomorphisms act on ambient-isotopy classes by postcomposition. -/
 instance instMulAction : MulAction (Y ≃ₜ Y) (AmbientIsotopyClass X Y) where
   one_smul x := by
-    rw [smul_def, show (1 : Y ≃ₜ Y) = Homeomorph.refl Y by ext y; simp]
+    rw [smul_def, one_eq_homeomorph_refl]
     exact postcompHomeomorph_refl x
   mul_smul h k x := by
     rw [smul_def, smul_def, smul_def]

--- a/TauCeti/Topology/Homotopy/AmbientIsotopyClassAction.lean
+++ b/TauCeti/Topology/Homotopy/AmbientIsotopyClassAction.lean
@@ -1,0 +1,88 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+module
+
+public import TauCeti.Topology.Homotopy.AmbientIsotopyClass
+
+/-!
+# The ambient homeomorphism action on ambient-isotopy classes
+
+The geometric-topology roadmap uses ambient-isotopy classes as the point-set quotient layer
+underlying later smooth and PL knot presentations. This file packages the already-defined
+postcomposition by ambient homeomorphisms as a genuine group action of `Y ≃ₜ Y` on
+`AmbientIsotopyClass X Y`.
+
+The action is deliberately point-set topological: smooth and PL presentations can map to this
+quotient and then use the ambient homeomorphism action, while stronger differentiable actions are
+added only when their smooth or PL prerequisites are available.
+
+## Main results
+
+* `TauCeti.AmbientIsotopyClass.instMulAction`: the action of the ambient homeomorphism group.
+* `TauCeti.AmbientIsotopyClass.smul_mk`: the representative formula for the action.
+* `TauCeti.AmbientIsotopyClass.postcompHomeomorph_eq_smul`: the old postcomposition map is the
+  scalar action.
+-/
+
+public section
+
+namespace TauCeti
+
+open ContinuousMap
+
+variable {X Y : Type*} [TopologicalSpace X] [TopologicalSpace Y]
+
+namespace AmbientIsotopyClass
+
+/-- The ambient homeomorphism group acts on ambient-isotopy classes by postcomposition. -/
+instance instSMul : SMul (Y ≃ₜ Y) (AmbientIsotopyClass X Y) where
+  smul h x := postcompHomeomorph h x
+
+/-- The action of an ambient homeomorphism on an ambient-isotopy class is postcomposition. -/
+@[simp]
+theorem smul_def (h : Y ≃ₜ Y) (x : AmbientIsotopyClass X Y) :
+    h • x = postcompHomeomorph h x :=
+  rfl
+
+/-- Ambient homeomorphisms act on ambient-isotopy classes by postcomposition. -/
+instance instMulAction : MulAction (Y ≃ₜ Y) (AmbientIsotopyClass X Y) where
+  one_smul x := by
+    change postcompHomeomorph (Homeomorph.refl Y) x = x
+    exact postcompHomeomorph_refl x
+  mul_smul h k x := by
+    rw [smul_def, smul_def, smul_def]
+    exact (postcompHomeomorph_trans k h x).symm
+
+/-- Postcomposition by an ambient homeomorphism is the scalar action of that homeomorphism. -/
+theorem postcompHomeomorph_eq_smul (h : Y ≃ₜ Y) :
+    postcompHomeomorph h = fun x : AmbientIsotopyClass X Y => h • x :=
+  rfl
+
+/-- The ambient homeomorphism action on representatives. -/
+@[simp]
+theorem smul_mk (h : Y ≃ₜ Y) (f : C(X, Y)) :
+    h • mk f = mk ((h : C(Y, Y)).comp f) :=
+  postcompHomeomorph_mk h f
+
+/-- The equivalence induced by an ambient self-homeomorphism has the same forward map as the
+ambient homeomorphism action. -/
+@[simp]
+theorem postcompHomeomorphEquiv_apply_eq_smul (h : Y ≃ₜ Y)
+    (x : AmbientIsotopyClass X Y) :
+    postcompHomeomorphEquiv h x = h • x := by
+  refine induction_on x ?_
+  intro f
+  rw [postcompHomeomorphEquiv_mk, smul_mk]
+
+/-- Acting by a product of ambient homeomorphisms is iterated postcomposition, with the usual
+function-composition convention for the homeomorphism group. -/
+@[simp]
+theorem mul_smul_apply (h k : Y ≃ₜ Y) (x : AmbientIsotopyClass X Y) :
+    (h * k) • x = h • k • x :=
+  mul_smul h k x
+
+end AmbientIsotopyClass
+
+end TauCeti

--- a/TauCeti/Topology/Homotopy/AmbientIsotopyClassAction.lean
+++ b/TauCeti/Topology/Homotopy/AmbientIsotopyClassAction.lean
@@ -76,13 +76,6 @@ theorem postcompHomeomorphEquiv_apply_eq_smul (h : Y ≃ₜ Y)
   intro f
   rw [postcompHomeomorphEquiv_mk, smul_mk]
 
-/-- Acting by a product of ambient homeomorphisms is iterated postcomposition, with the usual
-function-composition convention for the homeomorphism group. -/
-@[simp]
-theorem mul_smul_apply (h k : Y ≃ₜ Y) (x : AmbientIsotopyClass X Y) :
-    (h * k) • x = h • k • x :=
-  mul_smul h k x
-
 end AmbientIsotopyClass
 
 end TauCeti


### PR DESCRIPTION
This PR packages the ambient-homeomorphism action on continuous ambient-isotopy classes and restricts it along the self-diffeomorphism-to-homeomorphism homomorphism, so later geometric knot and link presentations can use the point-set quotient action already available before a bundled smooth postcomposition API lands.

It advances `TauCetiRoadmap/GeometricTopology/README.md`, the Encoding conventions item “Isotopy is defined generally, then specialised,” plus Layer 3, “diffeomorphism groups with the C^∞ topology,” and Layer 4, “the geometric presentation is simply a smooth embedding `S¹ ↪ M`,” as a clean prerequisite for letting ambient coordinate changes act on the general continuous ambient-isotopy quotient consumed by smooth presentations. I chose this as the lowest-hanging distinct GeometricTopology target after checking open and recently merged PRs: recent work added continuous class coordinate-change equivalences and smooth-to-continuous quotient bridges, while no open PR covers GeometricTopology and the quotient-level group action API was still absent.

No Mathlib infrastructure is vendored. The implementation reuses Tau Ceti’s existing `AmbientIsotopyClass.postcompHomeomorph`, `postcompHomeomorphEquiv`, representative quotient API, `Diffeomorph.toHomeomorphHom`, and Mathlib’s group structure on self-homeomorphisms.

`lake exe cache get` completed with `No files to download` and `Already decompressed 8609 file(s)`. `lake build` completed with `Build completed successfully (4368 jobs).` `lake exe axioms` completed with `axioms: audited 6772 TauCeti declaration(s); all within the allowlist [propext, Classical.choice, Quot.sound].`

<!--tauceti-target:v1 {"focus":"GeometricTopology","id":"ambient-homeomorphism-action-classes"}-->

🤖 Prepared with Codex
