### PR TITLE
feat: transport elementary two quotients

### DIFF
--- a/TauCeti/Algebra/Group/ElementaryTwoQuotient.lean
+++ b/TauCeti/Algebra/Group/ElementaryTwoQuotient.lean
@@ -197,16 +197,16 @@ noncomputable def elementaryTwoQuotientMap (f : G →* H) :
       elementaryTwoQuotientMk (f g) := by
   rfl
 
-/-- The identity homomorphism induces the identity map on the elementary-2 quotient. -/
-@[simp] theorem elementaryTwoQuotientMap_id (x : ElementaryTwoQuotient G) :
+/-- The map induced by the identity homomorphism fixes each class in the elementary-2 quotient. -/
+@[simp] theorem elementaryTwoQuotientMap_id_apply (x : ElementaryTwoQuotient G) :
     elementaryTwoQuotientMap (MonoidHom.id G) x = x := by
   obtain ⟨g, rfl⟩ := elementaryTwoQuotientMk_surjective (G := G) x
   simp
 
 variable {K : Type*} [CommGroup K]
 
-/-- Induced maps on elementary-2 quotients compose functorially. -/
-@[simp] theorem elementaryTwoQuotientMap_comp (f : G →* H) (g : H →* K)
+/-- Induced maps on elementary-2 quotients compose pointwise. -/
+@[simp] theorem elementaryTwoQuotientMap_comp_apply (f : G →* H) (g : H →* K)
     (x : ElementaryTwoQuotient G) :
     elementaryTwoQuotientMap (g.comp f) x =
       elementaryTwoQuotientMap g (elementaryTwoQuotientMap f x) := by
@@ -240,14 +240,14 @@ noncomputable def elementaryTwoQuotientCongr (e : G ≃* H) :
 /-- The identity equivalence induces the identity equivalence on the elementary-2 quotient. -/
 @[simp] theorem elementaryTwoQuotientCongr_refl_apply (x : ElementaryTwoQuotient G) :
     elementaryTwoQuotientCongr (MulEquiv.refl G) x = x :=
-  elementaryTwoQuotientMap_id x
+  elementaryTwoQuotientMap_id_apply x
 
 /-- Induced equivalences on elementary-2 quotients compose functorially. -/
 @[simp] theorem elementaryTwoQuotientCongr_trans_apply (e : G ≃* H) (e' : H ≃* K)
     (x : ElementaryTwoQuotient G) :
     elementaryTwoQuotientCongr (e.trans e') x =
       elementaryTwoQuotientCongr e' (elementaryTwoQuotientCongr e x) :=
-  elementaryTwoQuotientMap_comp e.toMonoidHom e'.toMonoidHom x
+  elementaryTwoQuotientMap_comp_apply e.toMonoidHom e'.toMonoidHom x
 
 variable (G)
 

--- a/TauCeti/Algebra/Group/ElementaryTwoQuotient.lean
+++ b/TauCeti/Algebra/Group/ElementaryTwoQuotient.lean
@@ -238,12 +238,12 @@ noncomputable def elementaryTwoQuotientCongr (e : G ≃* H) :
   exact elementaryTwoQuotientMap_mk e.symm.toMonoidHom h
 
 /-- The identity equivalence induces the identity equivalence on the elementary-2 quotient. -/
-@[simp] theorem elementaryTwoQuotientCongr_refl (x : ElementaryTwoQuotient G) :
+@[simp] theorem elementaryTwoQuotientCongr_refl_apply (x : ElementaryTwoQuotient G) :
     elementaryTwoQuotientCongr (MulEquiv.refl G) x = x :=
   elementaryTwoQuotientMap_id x
 
 /-- Induced equivalences on elementary-2 quotients compose functorially. -/
-@[simp] theorem elementaryTwoQuotientCongr_trans (e : G ≃* H) (e' : H ≃* K)
+@[simp] theorem elementaryTwoQuotientCongr_trans_apply (e : G ≃* H) (e' : H ≃* K)
     (x : ElementaryTwoQuotient G) :
     elementaryTwoQuotientCongr (e.trans e') x =
       elementaryTwoQuotientCongr e' (elementaryTwoQuotientCongr e x) :=

--- a/TauCeti/Algebra/Group/ElementaryTwoQuotient.lean
+++ b/TauCeti/Algebra/Group/ElementaryTwoQuotient.lean
@@ -197,6 +197,22 @@ noncomputable def elementaryTwoQuotientMap (f : G →* H) :
       elementaryTwoQuotientMk (f g) := by
   rfl
 
+/-- The identity homomorphism induces the identity map on the elementary-2 quotient. -/
+@[simp] theorem elementaryTwoQuotientMap_id (x : ElementaryTwoQuotient G) :
+    elementaryTwoQuotientMap (MonoidHom.id G) x = x := by
+  obtain ⟨g, rfl⟩ := elementaryTwoQuotientMk_surjective (G := G) x
+  simp
+
+variable {K : Type*} [CommGroup K]
+
+/-- Induced maps on elementary-2 quotients compose functorially. -/
+theorem elementaryTwoQuotientMap_comp (f : G →* H) (g : H →* K)
+    (x : ElementaryTwoQuotient G) :
+    elementaryTwoQuotientMap (g.comp f) x =
+      elementaryTwoQuotientMap g (elementaryTwoQuotientMap f x) := by
+  obtain ⟨a, rfl⟩ := elementaryTwoQuotientMk_surjective (G := G) x
+  simp
+
 /-- A multiplicative equivalence of commutative groups induces a `ZMod 2`-linear equivalence of
 their maximal elementary-2 quotients. -/
 noncomputable def elementaryTwoQuotientCongr (e : G ≃* H) :
@@ -220,6 +236,18 @@ noncomputable def elementaryTwoQuotientCongr (e : G ≃* H) :
     (elementaryTwoQuotientCongr e).symm (elementaryTwoQuotientMk h) =
       elementaryTwoQuotientMk (e.symm h) := by
   exact elementaryTwoQuotientMap_mk e.symm.toMonoidHom h
+
+/-- The identity equivalence induces the identity equivalence on the elementary-2 quotient. -/
+@[simp] theorem elementaryTwoQuotientCongr_refl (x : ElementaryTwoQuotient G) :
+    elementaryTwoQuotientCongr (MulEquiv.refl G) x = x :=
+  elementaryTwoQuotientMap_id x
+
+/-- Induced equivalences on elementary-2 quotients compose functorially. -/
+theorem elementaryTwoQuotientCongr_trans (e : G ≃* H) (e' : H ≃* K)
+    (x : ElementaryTwoQuotient G) :
+    elementaryTwoQuotientCongr (e.trans e') x =
+      elementaryTwoQuotientCongr e' (elementaryTwoQuotientCongr e x) :=
+  elementaryTwoQuotientMap_comp e.toMonoidHom e'.toMonoidHom x
 
 variable (G)
 

--- a/TauCeti/Algebra/Group/ElementaryTwoQuotient.lean
+++ b/TauCeti/Algebra/Group/ElementaryTwoQuotient.lean
@@ -206,7 +206,7 @@ noncomputable def elementaryTwoQuotientMap (f : G →* H) :
 variable {K : Type*} [CommGroup K]
 
 /-- Induced maps on elementary-2 quotients compose functorially. -/
-theorem elementaryTwoQuotientMap_comp (f : G →* H) (g : H →* K)
+@[simp] theorem elementaryTwoQuotientMap_comp (f : G →* H) (g : H →* K)
     (x : ElementaryTwoQuotient G) :
     elementaryTwoQuotientMap (g.comp f) x =
       elementaryTwoQuotientMap g (elementaryTwoQuotientMap f x) := by
@@ -243,7 +243,7 @@ noncomputable def elementaryTwoQuotientCongr (e : G ≃* H) :
   elementaryTwoQuotientMap_id x
 
 /-- Induced equivalences on elementary-2 quotients compose functorially. -/
-theorem elementaryTwoQuotientCongr_trans (e : G ≃* H) (e' : H ≃* K)
+@[simp] theorem elementaryTwoQuotientCongr_trans (e : G ≃* H) (e' : H ≃* K)
     (x : ElementaryTwoQuotient G) :
     elementaryTwoQuotientCongr (e.trans e') x =
       elementaryTwoQuotientCongr e' (elementaryTwoQuotientCongr e x) :=

--- a/TauCeti/Algebra/Group/ElementaryTwoQuotient.lean
+++ b/TauCeti/Algebra/Group/ElementaryTwoQuotient.lean
@@ -46,6 +46,8 @@ names around it. The cardinality identity is still expressed through the squarin
   class map is surjective, and two elements have the same class iff they differ by a square.
 * `TauCeti.elementaryTwoQuotientLiftEquiv` and `TauCeti.elementaryTwoQuotientLinearLiftEquiv`: the
   universal property for maps out of `G/G²`, inherited from `ModN.liftEquiv`.
+* `TauCeti.elementaryTwoQuotientMap` and `TauCeti.elementaryTwoQuotientCongr`: transport along
+  homomorphisms and equivalences of commutative groups.
 * `TauCeti.elementaryTwoQuotientEquivSquareQuotient`: the equivalence between Mathlib's `ModN`
   model and the quotient by the additive form of `G²`.
 * `TauCeti.card_elementaryTwoQuotient_eq_index_square`: the quotient cardinality as the index of
@@ -163,6 +165,62 @@ theorem elementaryTwoQuotientMk_eq_iff (g h : G) :
     elementaryTwoQuotientMk g = elementaryTwoQuotientMk h ↔ IsSquare (g / h) := by
   rw [← elementaryTwoQuotientMk_eq_zero_iff, elementaryTwoQuotientMk_div, sub_eq_zero]
 
+variable {H : Type*} [CommGroup H]
+
+/-- A homomorphism of commutative groups induces a `ZMod 2`-linear map on maximal elementary-2
+quotients. -/
+noncomputable def elementaryTwoQuotientMap (f : G →* H) :
+    ElementaryTwoQuotient G →ₗ[ZMod 2] ElementaryTwoQuotient H :=
+  (TauCeti.elementaryTwoQuotientLinearLiftEquiv (G := G) (H := ElementaryTwoQuotient H)).symm
+    ⟨{ toFun := fun g => elementaryTwoQuotientMk (f (Additive.toMul g))
+       map_zero' := by
+        -- The source is written additively as `Additive G`; expose its multiplicative zero.
+        change elementaryTwoQuotientMk (f 1) = 0
+        simp
+       map_add' := by
+        intro g h
+        -- The source addition is multiplication in `G`, so the quotient map is additive.
+        change elementaryTwoQuotientMk (f (Additive.toMul (g + h))) =
+          elementaryTwoQuotientMk (f (Additive.toMul g)) +
+            elementaryTwoQuotientMk (f (Additive.toMul h))
+        simp },
+      fun g => by
+        -- `G/G²` is killed by `2` because the square of any representative maps to zero.
+        change 2 • elementaryTwoQuotientMk (f (Additive.toMul g)) = 0
+        rw [← elementaryTwoQuotientMk_pow]
+        exact (elementaryTwoQuotientMk_eq_zero_iff _).2
+          ⟨f (Additive.toMul g), by rw [pow_two]⟩⟩
+
+/-- The induced map on `G/G²` sends the class of `g` to the class of `f g`. -/
+@[simp] theorem elementaryTwoQuotientMap_mk (f : G →* H) (g : G) :
+    elementaryTwoQuotientMap f (elementaryTwoQuotientMk g) =
+      elementaryTwoQuotientMk (f g) := by
+  rfl
+
+/-- A multiplicative equivalence of commutative groups induces a `ZMod 2`-linear equivalence of
+their maximal elementary-2 quotients. -/
+noncomputable def elementaryTwoQuotientCongr (e : G ≃* H) :
+    ElementaryTwoQuotient G ≃ₗ[ZMod 2] ElementaryTwoQuotient H where
+  toLinearMap := elementaryTwoQuotientMap e.toMonoidHom
+  invFun := elementaryTwoQuotientMap e.symm.toMonoidHom
+  left_inv x := by
+    obtain ⟨g, rfl⟩ := elementaryTwoQuotientMk_surjective (G := G) x
+    simp
+  right_inv x := by
+    obtain ⟨h, rfl⟩ := elementaryTwoQuotientMk_surjective (G := H) x
+    simp
+
+/-- The induced equivalence on `G/G²` sends the class of `g` to the class of `e g`. -/
+@[simp] theorem elementaryTwoQuotientCongr_mk (e : G ≃* H) (g : G) :
+    elementaryTwoQuotientCongr e (elementaryTwoQuotientMk g) = elementaryTwoQuotientMk (e g) := by
+  exact elementaryTwoQuotientMap_mk e.toMonoidHom g
+
+/-- The inverse induced equivalence on `G/G²` sends the class of `h` to the class of `e.symm h`. -/
+@[simp] theorem elementaryTwoQuotientCongr_symm_mk (e : G ≃* H) (h : H) :
+    (elementaryTwoQuotientCongr e).symm (elementaryTwoQuotientMk h) =
+      elementaryTwoQuotientMk (e.symm h) := by
+  exact elementaryTwoQuotientMap_mk e.symm.toMonoidHom h
+
 variable (G)
 
 /-- The doubling subgroup of `Additive G` is the additive form of the subgroup of squares of `G`.
@@ -214,5 +272,12 @@ theorem card_elementaryTwoQuotient_eq_two_pow_twoRank
     [Module.Finite (ZMod 2) (ElementaryTwoQuotient G)] :
     Nat.card (ElementaryTwoQuotient G) = 2 ^ twoRank G := by
   rw [twoRank, Module.natCard_eq_pow_finrank (K := ZMod 2), Nat.card_zmod]
+
+/-- Multiplicatively equivalent commutative groups have the same elementary-2 rank. -/
+theorem twoRank_eq_of_mulEquiv (e : G ≃* H)
+    [Module.Finite (ZMod 2) (ElementaryTwoQuotient G)]
+    [Module.Finite (ZMod 2) (ElementaryTwoQuotient H)] :
+    twoRank G = twoRank H :=
+  (elementaryTwoQuotientCongr e).finrank_eq
 
 end TauCeti

--- a/TauCeti/Algebra/Group/ElementaryTwoQuotient.lean
+++ b/TauCeti/Algebra/Group/ElementaryTwoQuotient.lean
@@ -301,11 +301,22 @@ theorem card_elementaryTwoQuotient_eq_two_pow_twoRank
     Nat.card (ElementaryTwoQuotient G) = 2 ^ twoRank G := by
   rw [twoRank, Module.natCard_eq_pow_finrank (K := ZMod 2), Nat.card_zmod]
 
-/-- Multiplicatively equivalent commutative groups have the same elementary-2 rank. -/
-theorem twoRank_eq_of_mulEquiv (e : G ≃* H)
-    [Module.Finite (ZMod 2) (ElementaryTwoQuotient G)]
-    [Module.Finite (ZMod 2) (ElementaryTwoQuotient H)] :
-    twoRank G = twoRank H :=
+/-- Multiplicatively equivalent commutative groups have elementary-2 quotients with the same
+`ZMod 2` finrank. -/
+theorem finrank_elementaryTwoQuotient_eq_of_mulEquiv (e : G ≃* H) :
+    Module.finrank (ZMod 2) (ElementaryTwoQuotient G) =
+      Module.finrank (ZMod 2) (ElementaryTwoQuotient H) :=
   (elementaryTwoQuotientCongr e).finrank_eq
+
+/-- If the elementary-2 quotient of `G` is finite-dimensional, then a multiplicatively equivalent
+commutative group has the same elementary-2 rank; target finite-dimensionality is transported by
+the induced equivalence. -/
+theorem twoRank_eq_of_mulEquiv (e : G ≃* H)
+    [Module.Finite (ZMod 2) (ElementaryTwoQuotient G)] :
+    letI : Module.Finite (ZMod 2) (ElementaryTwoQuotient H) :=
+      Module.Finite.of_surjective (elementaryTwoQuotientCongr e).toLinearMap
+        (elementaryTwoQuotientCongr e).surjective
+    twoRank G = twoRank H :=
+  finrank_elementaryTwoQuotient_eq_of_mulEquiv (G := G) (H := H) e
 
 end TauCeti

--- a/TauCeti/NumberTheory/ClassGroup/ElementaryTwoQuotient.lean
+++ b/TauCeti/NumberTheory/ClassGroup/ElementaryTwoQuotient.lean
@@ -166,11 +166,24 @@ theorem card_elementaryTwoQuotient_eq_two_pow_twoRank
     Nat.card (ElementaryTwoQuotient R) = 2 ^ twoRank R :=
   TauCeti.card_elementaryTwoQuotient_eq_two_pow_twoRank (ClassGroup R)
 
-/-- Multiplicatively equivalent class groups have the same elementary-2 rank. -/
+/-- Multiplicatively equivalent class groups have `Cl/Cl²` quotients with the same `ZMod 2`
+finrank. -/
+theorem finrank_elementaryTwoQuotient_eq_of_mulEquiv {S : Type*} [CommRing S] [IsDomain S]
+    (e : ClassGroup R ≃* ClassGroup S) :
+    Module.finrank (ZMod 2) (ElementaryTwoQuotient R) =
+      Module.finrank (ZMod 2) (ElementaryTwoQuotient S) :=
+  TauCeti.finrank_elementaryTwoQuotient_eq_of_mulEquiv
+    (G := ClassGroup R) (H := ClassGroup S) e
+
+/-- If `Cl(R)/Cl(R)²` is finite-dimensional, then a multiplicatively equivalent class group has
+the same elementary-2 rank; target finite-dimensionality is transported by the induced
+equivalence. -/
 theorem twoRank_eq_of_mulEquiv {S : Type*} [CommRing S] [IsDomain S]
     (e : ClassGroup R ≃* ClassGroup S)
-    [Module.Finite (ZMod 2) (ElementaryTwoQuotient R)]
-    [Module.Finite (ZMod 2) (ElementaryTwoQuotient S)] :
+    [Module.Finite (ZMod 2) (ElementaryTwoQuotient R)] :
+    letI : Module.Finite (ZMod 2) (ElementaryTwoQuotient S) :=
+      Module.Finite.of_surjective (elementaryTwoQuotientCongr e).toLinearMap
+        (elementaryTwoQuotientCongr e).surjective
     twoRank R = twoRank S :=
   TauCeti.twoRank_eq_of_mulEquiv (G := ClassGroup R) (H := ClassGroup S) e
 

--- a/TauCeti/NumberTheory/ClassGroup/ElementaryTwoQuotient.lean
+++ b/TauCeti/NumberTheory/ClassGroup/ElementaryTwoQuotient.lean
@@ -137,6 +137,19 @@ of its inverse image. -/
     TauCeti.elementaryTwoQuotientMk (e.symm C)
   exact TauCeti.elementaryTwoQuotientCongr_symm_mk e C
 
+/-- The identity equivalence of class groups induces the identity equivalence on `Cl/Cl²`. -/
+@[simp] theorem elementaryTwoQuotientCongr_refl (x : ElementaryTwoQuotient R) :
+    elementaryTwoQuotientCongr (MulEquiv.refl (ClassGroup R)) x = x :=
+  TauCeti.elementaryTwoQuotientCongr_refl x
+
+/-- Induced class-group equivalences on `Cl/Cl²` compose functorially. -/
+theorem elementaryTwoQuotientCongr_trans {S T : Type*} [CommRing S] [IsDomain S]
+    [CommRing T] [IsDomain T] (e : ClassGroup R ≃* ClassGroup S)
+    (e' : ClassGroup S ≃* ClassGroup T) (x : ElementaryTwoQuotient R) :
+    elementaryTwoQuotientCongr (e.trans e') x =
+      elementaryTwoQuotientCongr e' (elementaryTwoQuotientCongr e x) :=
+  TauCeti.elementaryTwoQuotientCongr_trans e e' x
+
 variable (R)
 
 /-- **The 2-rank of the class group when `Cl(R)/Cl(R)²` is finite-dimensional**: the `ZMod 2`

--- a/TauCeti/NumberTheory/ClassGroup/ElementaryTwoQuotient.lean
+++ b/TauCeti/NumberTheory/ClassGroup/ElementaryTwoQuotient.lean
@@ -143,7 +143,7 @@ of its inverse image. -/
   TauCeti.elementaryTwoQuotientCongr_refl x
 
 /-- Induced class-group equivalences on `Cl/Cl²` compose functorially. -/
-theorem elementaryTwoQuotientCongr_trans {S T : Type*} [CommRing S] [IsDomain S]
+@[simp] theorem elementaryTwoQuotientCongr_trans {S T : Type*} [CommRing S] [IsDomain S]
     [CommRing T] [IsDomain T] (e : ClassGroup R ≃* ClassGroup S)
     (e' : ClassGroup S ≃* ClassGroup T) (x : ElementaryTwoQuotient R) :
     elementaryTwoQuotientCongr (e.trans e') x =

--- a/TauCeti/NumberTheory/ClassGroup/ElementaryTwoQuotient.lean
+++ b/TauCeti/NumberTheory/ClassGroup/ElementaryTwoQuotient.lean
@@ -36,6 +36,8 @@ square-class group `Kˣ ⧸ (Kˣ)²` of `TauCeti.FieldTheory.SquareClassGroup` f
   `elementaryTwoQuotientMk_div`, `elementaryTwoQuotientMk_pow`, and
   `elementaryTwoQuotientMk_prod` record its additivity, while `elementaryTwoQuotientMk_surjective`
   and `elementaryTwoQuotientMk_eq_iff` give surjectivity and the equality criterion.
+* `TauCeti.ClassGroup.elementaryTwoQuotientCongr`: a multiplicative equivalence of class groups
+  induces a `ZMod 2`-linear equivalence of their elementary-2 quotients.
 * `TauCeti.ClassGroup.card_elementaryTwoQuotient_eq_card_twoTorsion`: `|Cl(R)/Cl(R)²| = |Cl(R)[2]|`,
   the quotient and the 2-torsion subgroup have equal cardinality.
 * `TauCeti.ClassGroup.twoRank` and `card_elementaryTwoQuotient_eq_two_pow_twoRank`: the 2-rank, with
@@ -103,6 +105,40 @@ theorem elementaryTwoQuotientMk_eq_iff (C D : ClassGroup R) :
     elementaryTwoQuotientMk R C = elementaryTwoQuotientMk R D ↔ IsSquare (C / D) :=
   TauCeti.elementaryTwoQuotientMk_eq_iff C D
 
+variable {R}
+
+/-- A multiplicative equivalence of class groups induces a `ZMod 2`-linear equivalence on the
+maximal elementary-2 quotients. This is the transport API used when genus-field constructions
+identify class groups through canonical isomorphisms. -/
+noncomputable def elementaryTwoQuotientCongr {S : Type*} [CommRing S] [IsDomain S]
+    (e : ClassGroup R ≃* ClassGroup S) :
+    ElementaryTwoQuotient R ≃ₗ[ZMod 2] ElementaryTwoQuotient S :=
+  TauCeti.elementaryTwoQuotientCongr e
+
+/-- The induced equivalence on `Cl/Cl²` sends the class of an ideal class to the class of its
+image. -/
+@[simp] theorem elementaryTwoQuotientCongr_mk {S : Type*} [CommRing S] [IsDomain S]
+    (e : ClassGroup R ≃* ClassGroup S) (C : ClassGroup R) :
+    elementaryTwoQuotientCongr e (elementaryTwoQuotientMk R C) =
+      elementaryTwoQuotientMk S (e C) := by
+  -- Reduce the class-group wrapper names to the generic elementary-2 quotient statement.
+  change TauCeti.elementaryTwoQuotientCongr e (TauCeti.elementaryTwoQuotientMk C) =
+    TauCeti.elementaryTwoQuotientMk (e C)
+  exact TauCeti.elementaryTwoQuotientCongr_mk e C
+
+/-- The inverse induced equivalence on `Cl/Cl²` sends the class of an ideal class to the class
+of its inverse image. -/
+@[simp] theorem elementaryTwoQuotientCongr_symm_mk {S : Type*} [CommRing S] [IsDomain S]
+    (e : ClassGroup R ≃* ClassGroup S) (C : ClassGroup S) :
+    (elementaryTwoQuotientCongr e).symm (elementaryTwoQuotientMk S C) =
+      elementaryTwoQuotientMk R (e.symm C) := by
+  -- Reduce the class-group wrapper names to the generic elementary-2 quotient statement.
+  change (TauCeti.elementaryTwoQuotientCongr e).symm (TauCeti.elementaryTwoQuotientMk C) =
+    TauCeti.elementaryTwoQuotientMk (e.symm C)
+  exact TauCeti.elementaryTwoQuotientCongr_symm_mk e C
+
+variable (R)
+
 /-- **The 2-rank of the class group when `Cl(R)/Cl(R)²` is finite-dimensional**: the `ZMod 2`
 dimension of the maximal elementary-2 quotient. In genus-theory applications the `t - 1` formula
 belongs to the narrow class group; for imaginary fields the narrow and ordinary class groups
@@ -116,6 +152,14 @@ theorem card_elementaryTwoQuotient_eq_two_pow_twoRank
     [Module.Finite (ZMod 2) (ElementaryTwoQuotient R)] :
     Nat.card (ElementaryTwoQuotient R) = 2 ^ twoRank R :=
   TauCeti.card_elementaryTwoQuotient_eq_two_pow_twoRank (ClassGroup R)
+
+/-- Multiplicatively equivalent class groups have the same elementary-2 rank. -/
+theorem twoRank_eq_of_mulEquiv {S : Type*} [CommRing S] [IsDomain S]
+    (e : ClassGroup R ≃* ClassGroup S)
+    [Module.Finite (ZMod 2) (ElementaryTwoQuotient R)]
+    [Module.Finite (ZMod 2) (ElementaryTwoQuotient S)] :
+    twoRank R = twoRank S :=
+  TauCeti.twoRank_eq_of_mulEquiv (G := ClassGroup R) (H := ClassGroup S) e
 
 variable [Finite (ClassGroup R)]
 

--- a/TauCeti/NumberTheory/ClassGroup/ElementaryTwoQuotient.lean
+++ b/TauCeti/NumberTheory/ClassGroup/ElementaryTwoQuotient.lean
@@ -138,17 +138,17 @@ of its inverse image. -/
   exact TauCeti.elementaryTwoQuotientCongr_symm_mk e C
 
 /-- The identity equivalence of class groups induces the identity equivalence on `Cl/Cl²`. -/
-@[simp] theorem elementaryTwoQuotientCongr_refl (x : ElementaryTwoQuotient R) :
+@[simp] theorem elementaryTwoQuotientCongr_refl_apply (x : ElementaryTwoQuotient R) :
     elementaryTwoQuotientCongr (MulEquiv.refl (ClassGroup R)) x = x :=
-  TauCeti.elementaryTwoQuotientCongr_refl x
+  TauCeti.elementaryTwoQuotientCongr_refl_apply x
 
 /-- Induced class-group equivalences on `Cl/Cl²` compose functorially. -/
-@[simp] theorem elementaryTwoQuotientCongr_trans {S T : Type*} [CommRing S] [IsDomain S]
+@[simp] theorem elementaryTwoQuotientCongr_trans_apply {S T : Type*} [CommRing S] [IsDomain S]
     [CommRing T] [IsDomain T] (e : ClassGroup R ≃* ClassGroup S)
     (e' : ClassGroup S ≃* ClassGroup T) (x : ElementaryTwoQuotient R) :
     elementaryTwoQuotientCongr (e.trans e') x =
       elementaryTwoQuotientCongr e' (elementaryTwoQuotientCongr e x) :=
-  TauCeti.elementaryTwoQuotientCongr_trans e e' x
+  TauCeti.elementaryTwoQuotientCongr_trans_apply e e' x
 
 variable (R)
 


### PR DESCRIPTION
This PR adds transport API for maximal elementary-2 quotients: a commutative-group homomorphism induces a `ZMod 2`-linear map on `G/G²`, a multiplicative equivalence induces a linear equivalence, and multiplicatively equivalent groups have the same elementary-2 rank. It also exposes the class-group specialization for `Cl(R)/Cl(R)²`, so later genus-field constructions can transport the Layer 2 quotient and its 2-rank across canonical class-group isomorphisms without unfolding the generic quotient model.

It advances `TauCetiRoadmap/Multiquadratic/README.md`, Layer 2, “The squaring map on `Cl(K)` and the quotient `Cl(K)/Cl(K)²`,” as a clean prerequisite for the genus-field comparison `Gal(K_gen/K) ≅ Cl(K)/Cl(K)²` in Layer 3. I chose this as the lowest-hanging distinct Multiquadratic target after checking open and recently merged PRs: the multiquadratic degree, Galois, subfield, splitting, prime-discriminant, and class-group quotient base APIs already exist on `main`, while the elementary-2 quotient still lacked transport along equivalences.

No Mathlib infrastructure is vendored. The implementation reuses Tau Ceti’s existing `ElementaryTwoQuotient`, `elementaryTwoQuotientLinearLiftEquiv`, quotient representative API, and class-group specialization, together with Mathlib’s `LinearEquiv.finrank_eq`.

`lake exe cache get` completed with `No files to download` and `Already decompressed 8609 file(s)`. `lake build` completed with `Build completed successfully (4366 jobs).` `lake exe axioms` completed with `axioms: audited 6772 TauCeti declaration(s); all within the allowlist [propext, Classical.choice, Quot.sound].`

<!--tauceti-target:v1 {"focus":"Multiquadratic","id":"elementary-two-quotient-transport"}-->

🤖 Prepared with Codex
