### PR TITLE
feat: add blockLaw_apply_rectangle (block law on a measurable rectangle)

### DIFF
--- a/TauCeti/Probability/Exchangeability/Basic.lean
+++ b/TauCeti/Probability/Exchangeability/Basic.lean
@@ -85,6 +85,17 @@ theorem blockLaw_apply (μ : Measure Ω) (X : ℕ → Ω → α) {m : ℕ} (k : 
     blockLaw μ X k = μ.map (fun ω i => X (k i) ω) :=
   rfl
 
+/-- The block law of `X` along `k`, evaluated on a measurable rectangle `Set.univ.pi B`, is the
+measure of the coordinate-wise preimage `{ω | ∀ i, X (k i) ω ∈ B i}`. -/
+theorem blockLaw_apply_rectangle (μ : Measure Ω) (X : ℕ → Ω → α) {m : ℕ} (k : Fin m → ℕ)
+    (hXk : ∀ i, AEMeasurable (X (k i)) μ) (B : Fin m → Set α) (hB : ∀ i, MeasurableSet (B i)) :
+    blockLaw μ X k (Set.univ.pi B) = μ {ω | ∀ i, X (k i) ω ∈ B i} := by
+  rw [blockLaw_apply, Measure.map_apply_of_aemeasurable
+    (aemeasurable_pi_lambda _ hXk) (MeasurableSet.univ_pi hB)]
+  congr 1
+  ext ω
+  simp [Set.mem_preimage]
+
 @[simp]
 theorem prefixLaw_apply (μ : Measure Ω) (X : ℕ → Ω → α) (n : ℕ) :
     prefixLaw μ X n = blockLaw μ X (fun i : Fin n => i.val) :=

--- a/TauCeti/Probability/Exchangeability/Basic.lean
+++ b/TauCeti/Probability/Exchangeability/Basic.lean
@@ -85,13 +85,24 @@ theorem blockLaw_apply (μ : Measure Ω) (X : ℕ → Ω → α) {m : ℕ} (k : 
     blockLaw μ X k = μ.map (fun ω i => X (k i) ω) :=
   rfl
 
+-- Not `@[simp]`: `blockLaw_apply` already simp-normalizes `blockLaw μ X k` to `μ.map …`, and the
+-- preimage form needs the a.e.-measurability side condition `hXk`, which `simp` cannot discharge,
+-- so this and `blockLaw_apply_rectangle` are explicit `rw` lemmas.
+/-- The block law of `X` along `k`, evaluated on any measurable set `S`, is the measure of its
+coordinate-wise preimage. This is the characteristic evaluation of `blockLaw` as a pushforward;
+`blockLaw_apply_rectangle` is the rectangle specialization. -/
+theorem blockLaw_apply_of_measurable (μ : Measure Ω) (X : ℕ → Ω → α) {m : ℕ} (k : Fin m → ℕ)
+    (hXk : ∀ i, AEMeasurable (X (k i)) μ) {S : Set (Fin m → α)} (hS : MeasurableSet S) :
+    blockLaw μ X k S = μ ((fun ω i => X (k i) ω) ⁻¹' S) := by
+  rw [blockLaw_apply, Measure.map_apply_of_aemeasurable (aemeasurable_pi_lambda _ hXk) hS]
+
 /-- The block law of `X` along `k`, evaluated on a measurable rectangle `Set.univ.pi B`, is the
-measure of the coordinate-wise preimage `{ω | ∀ i, X (k i) ω ∈ B i}`. -/
+measure of the coordinate-wise preimage `{ω | ∀ i, X (k i) ω ∈ B i}` — the rectangle specialization
+of `blockLaw_apply_of_measurable`. -/
 theorem blockLaw_apply_rectangle (μ : Measure Ω) (X : ℕ → Ω → α) {m : ℕ} (k : Fin m → ℕ)
     (hXk : ∀ i, AEMeasurable (X (k i)) μ) (B : Fin m → Set α) (hB : ∀ i, MeasurableSet (B i)) :
     blockLaw μ X k (Set.univ.pi B) = μ {ω | ∀ i, X (k i) ω ∈ B i} := by
-  rw [blockLaw_apply, Measure.map_apply_of_aemeasurable
-    (aemeasurable_pi_lambda _ hXk) (MeasurableSet.univ_pi hB)]
+  rw [blockLaw_apply_of_measurable μ X k hXk (MeasurableSet.univ_pi hB)]
   congr 1
   ext ω
   simp [Set.mem_preimage]

--- a/TauCeti/Probability/Exchangeability/Basic.lean
+++ b/TauCeti/Probability/Exchangeability/Basic.lean
@@ -85,12 +85,13 @@ theorem blockLaw_apply (μ : Measure Ω) (X : ℕ → Ω → α) {m : ℕ} (k : 
     blockLaw μ X k = μ.map (fun ω i => X (k i) ω) :=
   rfl
 
--- Not `@[simp]`: `blockLaw_apply` already simp-normalizes `blockLaw μ X k` to `μ.map …`, and the
--- preimage form needs the a.e.-measurability side condition `hXk`, which `simp` cannot discharge,
--- so this and `blockLaw_apply_rectangle` are explicit `rw` lemmas.
+-- Annotated `@[grind =>]` rather than `@[simp]`: `blockLaw_apply` already simp-normalizes
+-- `blockLaw μ X k` to `μ.map …` (so a `@[simp]` here would be shadowed), and the preimage form
+-- needs the a.e.-measurability side condition `hXk`, which `simp` cannot discharge.
 /-- The block law of `X` along `k`, evaluated on any measurable set `S`, is the measure of its
 coordinate-wise preimage. This is the characteristic evaluation of `blockLaw` as a pushforward;
 `blockLaw_apply_rectangle` is the rectangle specialization. -/
+@[grind =>]
 theorem blockLaw_apply_of_measurable (μ : Measure Ω) (X : ℕ → Ω → α) {m : ℕ} (k : Fin m → ℕ)
     (hXk : ∀ i, AEMeasurable (X (k i)) μ) {S : Set (Fin m → α)} (hS : MeasurableSet S) :
     blockLaw μ X k S = μ ((fun ω i => X (k i) ω) ⁻¹' S) := by
@@ -99,6 +100,7 @@ theorem blockLaw_apply_of_measurable (μ : Measure Ω) (X : ℕ → Ω → α) {
 /-- The block law of `X` along `k`, evaluated on a measurable rectangle `Set.univ.pi B`, is the
 measure of the coordinate-wise preimage `{ω | ∀ i, X (k i) ω ∈ B i}` — the rectangle specialization
 of `blockLaw_apply_of_measurable`. -/
+@[grind =>]
 theorem blockLaw_apply_rectangle (μ : Measure Ω) (X : ℕ → Ω → α) {m : ℕ} (k : Fin m → ℕ)
     (hXk : ∀ i, AEMeasurable (X (k i)) μ) (B : Fin m → Set α) (hB : ∀ i, MeasurableSet (B i)) :
     blockLaw μ X k (Set.univ.pi B) = μ {ω | ∀ i, X (k i) ω ∈ B i} := by


### PR DESCRIPTION
<!--tauceti-target:v1 {"focus":"Exchangeability","id":"blocklaw-apply-rectangle"}-->

## Summary

Adds two `blockLaw` evaluation lemmas to `TauCeti/Probability/Exchangeability/Basic.lean`, next to
`blockLaw_apply`:

- `blockLaw_apply_of_measurable (S) (hS : MeasurableSet S) : blockLaw μ X k S =
  μ ((fun ω i => X (k i) ω) ⁻¹' S)` — the characteristic evaluation of `blockLaw` as a pushforward,
  on any measurable set.
- `blockLaw_apply_rectangle (B) (hB) : blockLaw μ X k (Set.univ.pi B) = μ {ω | ∀ i, X (k i) ω ∈ B i}`
  — the rectangle specialization, derived from the general lemma.

## Roadmap

Advances `TauCetiRoadmap/Exchangeability` — this is **characteristic `blockLaw` API** (how the block
law evaluates on a rectangle), the elementary `Measure.map_apply` step every de Finetti proof route
uses to relate a finite-block law on a rectangle to its coordinate preimage (in the reference repo:
`measure_via_indicator_integral`, `finite_product_formula_id`, `BridgeProperty`). It sits in `Basic`
beside the other `blockLaw` evaluation lemmas.

## How it's proved (reuse)

`blockLaw_apply` (`= μ.map (fun ω i => X (k i) ω)`) + `Measure.map_apply_of_aemeasurable` gives the
general lemma; the rectangle preimage `{ω | ∀ i, X (k i) ω ∈ B i}` follows by `Set.mem_univ_pi`.
Selection-local `∀ i, AEMeasurable (X (k i)) μ` hypotheses, matching the `blockLaw` API. No new measure
theory, no new imports (Basic already imports `Measure.Map` and `MeasurableSpace.Constructions`).

## Review notes
- **generality:** the lemma is stated at the general measurable-set level
  (`blockLaw_apply_of_measurable`), and the rectangle form is the derived specialization.
- **api-design (automation):** both evaluators are annotated `@[grind =>]`. Not `@[simp]` —
  `blockLaw_apply` already `@[simp]`-normalizes the head `blockLaw μ X k → μ.map …` (so a `@[simp]`
  here is shadowed) and recovering the preimage form needs the `AEMeasurable` side condition, which
  `simp` cannot discharge; `grind` can still use them as forward evaluation rules. A code comment
  records the rationale.

## Note (supersedes the original PR)

This reframes the original rectangle/indicator-product bridge. The merged de Finetti common ending
(#547) reached `conditional_iid_from_directing_measure` via a **direct rectangle-measure** route, so
the indicator-product lemmas are not needed; the one generally-useful piece,
`blockLaw_apply_rectangle`, is kept here as `blockLaw` basic API.

## Test plan
```bash
lake build
lake exe axioms
lake exe module-system
```
All pass; sorry-free; axioms ⊆ {`propext`, `Classical.choice`, `Quot.sound`}; lines ≤100.

## Attribution
Drafted with Claude (Opus 4.8), human-directed.
