### PR TITLE
feat: add the de Finetti directing measure (conditional law given the tail)

### DIFF
--- a/TauCeti/Probability/DeFinetti/DirectingMeasure.lean
+++ b/TauCeti/Probability/DeFinetti/DirectingMeasure.lean
@@ -20,9 +20,10 @@ Because it lives over the **value** space `α`, it needs only `[StandardBorelSpa
 
 This is the random directing measure of the martingale (and kernel-based Koopman) route to de
 Finetti's theorem. This file records its basic theory: it is a probability measure
-(`isProbabilityMeasure_directingMeasure`), its set evaluations are measurable
-(`measurable_directingMeasure_coe`), and it is the conditional law of `X 0` given the tail
-(`directingMeasure_X0_marginal`). Packaging it as a directing measure for `ConditionallyIIDWith`
+(`isProbabilityMeasure_directingMeasure`), its set evaluations are `tailProcess X`-measurable
+(`measurable_tailProcess_directingMeasure_coe`, with the ambient corollary
+`measurable_directingMeasure_coe`), and it is the conditional law of `X 0` given the tail
+(`directingMeasure_ae_eq_condExp`). Packaging it as a directing measure for `ConditionallyIIDWith`
 (the product factorisation across a whole block) is left to a later step.
 
 Adapted from `cameronfreer/exchangeability` (`DeFinetti/ViaMartingale/DirectingMeasure.lean`, pin
@@ -47,7 +48,11 @@ variable {Ω α : Type*} [MeasurableSpace Ω] [MeasurableSpace α] [StandardBore
 the process tail σ-algebra `tailProcess X`, as the regular conditional distribution of `X 0` given
 that σ-algebra (Mathlib's `condDistrib`, conditioning on `tailProcess X` via the identity map). It
 lives over the value space `α`, so it needs `α` standard Borel, not `Ω`. -/
-@[expose]
+-- `directingMeasure` is intentionally opaque (no `@[expose]`): downstream code uses the
+-- characteristic lemmas below (probability measure, `tailProcess`-measurability,
+-- `directingMeasure_ae_eq_condExp`) rather than the definition body. A public `rfl`-unfold lemma is
+-- incompatible with hiding the body (an exported unfold would require `@[expose]`), so the
+-- characteristic API takes its place.
 def directingMeasure (μ : Measure Ω) [IsFiniteMeasure μ] (X : ℕ → Ω → α) (ω : Ω) : Measure α :=
   @condDistrib Ω Ω α _ _ _ _ (tailProcess X) (X 0) id μ _ ω
 
@@ -58,31 +63,38 @@ instance isProbabilityMeasure_directingMeasure {μ : Measure Ω} [IsFiniteMeasur
   rw [directingMeasure]
   infer_instance
 
-/-- Each set-evaluation `ω ↦ directingMeasure μ X ω B` is measurable: it is `tailProcess`-measurable
-(the regular conditional distribution's coordinate is), hence ambient-measurable. -/
-@[fun_prop]
-theorem measurable_directingMeasure_coe {μ : Measure Ω} [IsFiniteMeasure μ] {X : ℕ → Ω → α}
-    (hX : ∀ n, Measurable (X n)) {B : Set α} (hB : MeasurableSet B) :
-    Measurable fun ω => directingMeasure μ X ω B := by
+/-- The characteristic measurability of the directing measure: each set-evaluation
+`ω ↦ directingMeasure μ X ω B` is **`tailProcess X`-measurable** (it is a coordinate of the
+conditional-distribution kernel conditioning on `tailProcess X`). -/
+theorem measurable_tailProcess_directingMeasure_coe {μ : Measure Ω} [IsFiniteMeasure μ]
+    {X : ℕ → Ω → α} {B : Set α} (hB : MeasurableSet B) :
+    Measurable[tailProcess X] fun ω => directingMeasure μ X ω B := by
   have h := measurable_condDistrib (μ := μ) (Y := X 0) (X := (id : Ω → Ω))
     (mβ := tailProcess X) hB
-  rw [MeasurableSpace.comap_id] at h
-  exact h.mono (tailProcess_le_ambient 0 fun k _ => hX k) le_rfl
+  rwa [MeasurableSpace.comap_id] at h
+
+/-- Ambient-measurability of the set-evaluation, a corollary of the `tailProcess`-measurable form
+via `hTail : tailProcess X ≤ ‹MeasurableSpace Ω›`. -/
+@[fun_prop]
+theorem measurable_directingMeasure_coe {μ : Measure Ω} [IsFiniteMeasure μ] {X : ℕ → Ω → α}
+    (hTail : tailProcess X ≤ (inferInstance : MeasurableSpace Ω)) {B : Set α}
+    (hB : MeasurableSet B) : Measurable fun ω => directingMeasure μ X ω B :=
+  (measurable_tailProcess_directingMeasure_coe hB).mono hTail le_rfl
 
 /-- The directing measure is the **conditional law of the initial coordinate** `X 0` given the tail
 σ-algebra: for measurable `B`, the real evaluation `ω ↦ directingMeasure μ X ω B` is a version of
 the conditional expectation of `𝟙_B ∘ X 0` given `tailProcess X`. -/
-theorem directingMeasure_X0_marginal {μ : Measure Ω} [IsFiniteMeasure μ] {X : ℕ → Ω → α}
-    (hX : ∀ n, Measurable (X n)) {B : Set α} (hB : MeasurableSet B) :
+theorem directingMeasure_ae_eq_condExp {μ : Measure Ω} [IsFiniteMeasure μ] {X : ℕ → Ω → α}
+    (hTail : tailProcess X ≤ (inferInstance : MeasurableSpace Ω)) (hX0 : Measurable (X 0))
+    {B : Set α} (hB : MeasurableSet B) :
     (fun ω => (directingMeasure μ X ω).real B)
       =ᵐ[μ] μ[Set.indicator B (fun _ => (1 : ℝ)) ∘ X 0 | tailProcess X] := by
-  have hid : @Measurable Ω Ω _ (tailProcess X) id :=
-    measurable_id'' (tailProcess_le_ambient 0 fun k _ => hX k)
+  have hid : @Measurable Ω Ω _ (tailProcess X) id := measurable_id'' hTail
   have hcomp : ((X 0) ⁻¹' B).indicator (fun _ => (1 : ℝ))
       = Set.indicator B (fun _ => (1 : ℝ)) ∘ X 0 := by
     funext y
     by_cases h : X 0 y ∈ B <;> simp [Set.mem_preimage, h]
-  have h := condDistrib_ae_eq_condExp (μ := μ) (Y := X 0) (X := (id : Ω → Ω)) hid (hX 0) hB
+  have h := condDistrib_ae_eq_condExp (μ := μ) (Y := X 0) (X := (id : Ω → Ω)) hid hX0 hB
   rw [MeasurableSpace.comap_id, hcomp] at h
   exact h
 

--- a/TauCeti/Probability/DeFinetti/DirectingMeasure.lean
+++ b/TauCeti/Probability/DeFinetti/DirectingMeasure.lean
@@ -1,18 +1,22 @@
 module
 
 public import TauCeti.Probability.Process.Tail
-public import Mathlib.Probability.Kernel.Condexp
+public import Mathlib.Probability.Kernel.CondDistrib
 
 /-!
 # The de Finetti directing measure
 
-For a process `X : ℕ → Ω → α` on a standard Borel space, `directingMeasure μ X ω` is the conditional
-law of the initial coordinate `X 0` given the process tail σ-algebra `tailProcess X`, realised
-through Mathlib's conditional-expectation kernel `condExpKernel`:
+For a process `X : ℕ → Ω → α` valued in a standard Borel space `α`, `directingMeasure μ X ω` is the
+conditional law of the initial coordinate `X 0` given the process tail σ-algebra `tailProcess X`,
+realised as Mathlib's regular conditional distribution `condDistrib` of `X 0`, conditioning on
+`tailProcess X` via the identity map:
 
 ```
-directingMeasure μ X ω = (condExpKernel μ (tailProcess X) ω).map (X 0).
+directingMeasure μ X ω = condDistrib (X 0) (id) μ ω    (conditioning on tailProcess X).
 ```
+
+Because it lives over the **value** space `α`, it needs only `[StandardBorelSpace α]` (and
+`[Nonempty α]`); the sample space `Ω` is an arbitrary measurable space.
 
 This is the random directing measure of the martingale (and kernel-based Koopman) route to de
 Finetti's theorem. This file records its basic theory: it is a probability measure
@@ -22,8 +26,9 @@ Finetti's theorem. This file records its basic theory: it is a probability measu
 (the product factorisation across a whole block) is left to a later step.
 
 Adapted from `cameronfreer/exchangeability` (`DeFinetti/ViaMartingale/DirectingMeasure.lean`, pin
-`e0532e59ceff23edab44dda9ab0655debbc9cc22`), here over Mathlib's `condExpKernel` and the Tau Ceti
-`tailProcess` API.
+`e0532e59ceff23edab44dda9ab0655debbc9cc22`); that version conditions over `Ω` (needing
+`[StandardBorelSpace Ω]`), here strengthened to the value-space formulation over Mathlib's
+`condDistrib` and the Tau Ceti `tailProcess` API.
 -/
 
 public section
@@ -36,54 +41,50 @@ namespace TauCeti
 
 namespace Probability
 
-variable {Ω α : Type*} [MeasurableSpace Ω] [StandardBorelSpace Ω] [MeasurableSpace α]
+variable {Ω α : Type*} [MeasurableSpace Ω] [MeasurableSpace α] [StandardBorelSpace α] [Nonempty α]
 
 /-- The **de Finetti directing measure**: the conditional law of the initial coordinate `X 0` given
-the process tail σ-algebra `tailProcess X`, as the pushforward of the conditional-expectation kernel
-`condExpKernel μ (tailProcess X)` along `X 0`. -/
+the process tail σ-algebra `tailProcess X`, as the regular conditional distribution of `X 0` given
+that σ-algebra (Mathlib's `condDistrib`, conditioning on `tailProcess X` via the identity map). It
+lives over the value space `α`, so it needs `α` standard Borel, not `Ω`. -/
 @[expose]
 def directingMeasure (μ : Measure Ω) [IsFiniteMeasure μ] (X : ℕ → Ω → α) (ω : Ω) : Measure α :=
-  (condExpKernel μ (tailProcess X) ω).map (X 0)
+  @condDistrib Ω Ω α _ _ _ _ (tailProcess X) (X 0) id μ _ ω
 
-/-- The directing measure is a probability measure: the conditional-expectation kernel is Markov and
-`X 0` is measurable. -/
-theorem isProbabilityMeasure_directingMeasure {μ : Measure Ω} [IsFiniteMeasure μ] {X : ℕ → Ω → α}
-    (hX0 : Measurable (X 0)) (ω : Ω) : IsProbabilityMeasure (directingMeasure μ X ω) := by
+/-- The directing measure is a probability measure: the regular conditional distribution is a Markov
+kernel. -/
+instance isProbabilityMeasure_directingMeasure {μ : Measure Ω} [IsFiniteMeasure μ] {X : ℕ → Ω → α}
+    {ω : Ω} : IsProbabilityMeasure (directingMeasure μ X ω) := by
   rw [directingMeasure]
-  exact Measure.isProbabilityMeasure_map hX0.aemeasurable
+  infer_instance
 
 /-- Each set-evaluation `ω ↦ directingMeasure μ X ω B` is measurable: it is `tailProcess`-measurable
-(the conditional-expectation kernel's coordinate is), hence ambient-measurable. -/
+(the regular conditional distribution's coordinate is), hence ambient-measurable. -/
 @[fun_prop]
 theorem measurable_directingMeasure_coe {μ : Measure Ω} [IsFiniteMeasure μ] {X : ℕ → Ω → α}
     (hX : ∀ n, Measurable (X n)) {B : Set α} (hB : MeasurableSet B) :
     Measurable fun ω => directingMeasure μ X ω B := by
-  simp_rw [directingMeasure, Measure.map_apply (hX 0) hB]
-  exact ((condExpKernel μ (tailProcess X)).measurable_coe ((hX 0) hB)).mono
-    (tailProcess_le_ambient 0 fun k _ => hX k) le_rfl
+  have h := measurable_condDistrib (μ := μ) (Y := X 0) (X := (id : Ω → Ω))
+    (mβ := tailProcess X) hB
+  rw [MeasurableSpace.comap_id] at h
+  exact h.mono (tailProcess_le_ambient 0 fun k _ => hX k) le_rfl
 
 /-- The directing measure is the **conditional law of the initial coordinate** `X 0` given the tail
 σ-algebra: for measurable `B`, the real evaluation `ω ↦ directingMeasure μ X ω B` is a version of
 the conditional expectation of `𝟙_B ∘ X 0` given `tailProcess X`. -/
 theorem directingMeasure_X0_marginal {μ : Measure Ω} [IsFiniteMeasure μ] {X : ℕ → Ω → α}
     (hX : ∀ n, Measurable (X n)) {B : Set α} (hB : MeasurableSet B) :
-    (fun ω => (directingMeasure μ X ω B).toReal)
+    (fun ω => (directingMeasure μ X ω).real B)
       =ᵐ[μ] μ[Set.indicator B (fun _ => (1 : ℝ)) ∘ X 0 | tailProcess X] := by
-  have hcomp : (Set.indicator B (fun _ => (1 : ℝ)) ∘ X 0)
-      = ((X 0) ⁻¹' B).indicator (fun _ => (1 : ℝ)) := by
+  have hid : @Measurable Ω Ω _ (tailProcess X) id :=
+    measurable_id'' (tailProcess_le_ambient 0 fun k _ => hX k)
+  have hcomp : ((X 0) ⁻¹' B).indicator (fun _ => (1 : ℝ))
+      = Set.indicator B (fun _ => (1 : ℝ)) ∘ X 0 := by
     funext y
     by_cases h : X 0 y ∈ B <;> simp [Set.mem_preimage, h]
-  have hint : Integrable (Set.indicator B (fun _ => (1 : ℝ)) ∘ X 0) μ := by
-    rw [hcomp]; exact (integrable_const (1 : ℝ)).indicator ((hX 0) hB)
-  have hpt : (fun ω => (directingMeasure μ X ω B).toReal)
-      = fun ω => ∫ y, (Set.indicator B (fun _ => (1 : ℝ)) ∘ X 0) y
-          ∂(condExpKernel μ (tailProcess X) ω) := by
-    funext ω
-    rw [hcomp, directingMeasure, Measure.map_apply (hX 0) hB,
-      integral_indicator_const (1 : ℝ) ((hX 0) hB), smul_eq_mul, mul_one, measureReal_def]
-  rw [hpt]
-  exact (condExp_ae_eq_integral_condExpKernel
-    (tailProcess_le_ambient 0 fun k _ => hX k) hint).symm
+  have h := condDistrib_ae_eq_condExp (μ := μ) (Y := X 0) (X := (id : Ω → Ω)) hid (hX 0) hB
+  rw [MeasurableSpace.comap_id, hcomp] at h
+  exact h
 
 end Probability
 

--- a/TauCeti/Probability/DeFinetti/DirectingMeasure.lean
+++ b/TauCeti/Probability/DeFinetti/DirectingMeasure.lean
@@ -1,0 +1,90 @@
+module
+
+public import TauCeti.Probability.Process.Tail
+public import Mathlib.Probability.Kernel.Condexp
+
+/-!
+# The de Finetti directing measure
+
+For a process `X : ℕ → Ω → α` on a standard Borel space, `directingMeasure μ X ω` is the conditional
+law of the initial coordinate `X 0` given the process tail σ-algebra `tailProcess X`, realised
+through Mathlib's conditional-expectation kernel `condExpKernel`:
+
+```
+directingMeasure μ X ω = (condExpKernel μ (tailProcess X) ω).map (X 0).
+```
+
+This is the random directing measure of the martingale (and kernel-based Koopman) route to de
+Finetti's theorem. This file records its basic theory: it is a probability measure
+(`isProbabilityMeasure_directingMeasure`), its set evaluations are measurable
+(`measurable_directingMeasure_coe`), and it is the conditional law of `X 0` given the tail
+(`directingMeasure_X0_marginal`). Packaging it as a directing measure for `ConditionallyIIDWith`
+(the product factorisation across a whole block) is left to a later step.
+
+Adapted from `cameronfreer/exchangeability` (`DeFinetti/ViaMartingale/DirectingMeasure.lean`, pin
+`e0532e59ceff23edab44dda9ab0655debbc9cc22`), here over Mathlib's `condExpKernel` and the Tau Ceti
+`tailProcess` API.
+-/
+
+public section
+
+noncomputable section
+
+open MeasureTheory ProbabilityTheory
+
+namespace TauCeti
+
+namespace Probability
+
+variable {Ω α : Type*} [MeasurableSpace Ω] [StandardBorelSpace Ω] [MeasurableSpace α]
+
+/-- The **de Finetti directing measure**: the conditional law of the initial coordinate `X 0` given
+the process tail σ-algebra `tailProcess X`, as the pushforward of the conditional-expectation kernel
+`condExpKernel μ (tailProcess X)` along `X 0`. -/
+@[expose]
+def directingMeasure (μ : Measure Ω) [IsFiniteMeasure μ] (X : ℕ → Ω → α) (ω : Ω) : Measure α :=
+  (condExpKernel μ (tailProcess X) ω).map (X 0)
+
+/-- The directing measure is a probability measure: the conditional-expectation kernel is Markov and
+`X 0` is measurable. -/
+theorem isProbabilityMeasure_directingMeasure {μ : Measure Ω} [IsFiniteMeasure μ] {X : ℕ → Ω → α}
+    (hX0 : Measurable (X 0)) (ω : Ω) : IsProbabilityMeasure (directingMeasure μ X ω) := by
+  rw [directingMeasure]
+  exact Measure.isProbabilityMeasure_map hX0.aemeasurable
+
+/-- Each set-evaluation `ω ↦ directingMeasure μ X ω B` is measurable: it is `tailProcess`-measurable
+(the conditional-expectation kernel's coordinate is), hence ambient-measurable. -/
+@[fun_prop]
+theorem measurable_directingMeasure_coe {μ : Measure Ω} [IsFiniteMeasure μ] {X : ℕ → Ω → α}
+    (hX : ∀ n, Measurable (X n)) {B : Set α} (hB : MeasurableSet B) :
+    Measurable fun ω => directingMeasure μ X ω B := by
+  simp_rw [directingMeasure, Measure.map_apply (hX 0) hB]
+  exact ((condExpKernel μ (tailProcess X)).measurable_coe ((hX 0) hB)).mono
+    (tailProcess_le_ambient 0 fun k _ => hX k) le_rfl
+
+/-- The directing measure is the **conditional law of the initial coordinate** `X 0` given the tail
+σ-algebra: for measurable `B`, the real evaluation `ω ↦ directingMeasure μ X ω B` is a version of
+the conditional expectation of `𝟙_B ∘ X 0` given `tailProcess X`. -/
+theorem directingMeasure_X0_marginal {μ : Measure Ω} [IsFiniteMeasure μ] {X : ℕ → Ω → α}
+    (hX : ∀ n, Measurable (X n)) {B : Set α} (hB : MeasurableSet B) :
+    (fun ω => (directingMeasure μ X ω B).toReal)
+      =ᵐ[μ] μ[Set.indicator B (fun _ => (1 : ℝ)) ∘ X 0 | tailProcess X] := by
+  have hcomp : (Set.indicator B (fun _ => (1 : ℝ)) ∘ X 0)
+      = ((X 0) ⁻¹' B).indicator (fun _ => (1 : ℝ)) := by
+    funext y
+    by_cases h : X 0 y ∈ B <;> simp [Set.mem_preimage, h]
+  have hint : Integrable (Set.indicator B (fun _ => (1 : ℝ)) ∘ X 0) μ := by
+    rw [hcomp]; exact (integrable_const (1 : ℝ)).indicator ((hX 0) hB)
+  have hpt : (fun ω => (directingMeasure μ X ω B).toReal)
+      = fun ω => ∫ y, (Set.indicator B (fun _ => (1 : ℝ)) ∘ X 0) y
+          ∂(condExpKernel μ (tailProcess X) ω) := by
+    funext ω
+    rw [hcomp, directingMeasure, Measure.map_apply (hX 0) hB,
+      integral_indicator_const (1 : ℝ) ((hX 0) hB), smul_eq_mul, mul_one, measureReal_def]
+  rw [hpt]
+  exact (condExp_ae_eq_integral_condExpKernel
+    (tailProcess_le_ambient 0 fun k _ => hX k) hint).symm
+
+end Probability
+
+end TauCeti


### PR DESCRIPTION
<!--tauceti-target:v1 {"focus":"Exchangeability","id":"directing-measure"}-->

## Summary

Adds `TauCeti/Probability/DeFinetti/DirectingMeasure.lean` — the **de Finetti directing measure**.
For a process `X : ℕ → Ω → α` valued in a standard Borel space `α`, `directingMeasure μ X ω` is the
conditional law of the initial coordinate `X 0` given the process tail σ-algebra `tailProcess X`,
realised as Mathlib's regular conditional distribution `condDistrib` of `X 0`, conditioning on
`tailProcess X` via the identity map:

```
directingMeasure μ X ω = condDistrib (X 0) (id) μ ω    (conditioning on tailProcess X).
```

It lives over the **value** space `α`, so it needs only `[StandardBorelSpace α]` (and `[Nonempty α]`);
the sample space `Ω` is an arbitrary measurable space.

Basic API (`directingMeasure` is opaque — no `@[expose]`; characterized by these lemmas):
- `isProbabilityMeasure_directingMeasure` — an unconditional **instance** (`condDistrib` is Markov).
- `measurable_tailProcess_directingMeasure_coe` — the **characteristic** measurability,
  `Measurable[tailProcess X] (fun ω => directingMeasure μ X ω B)`; `measurable_directingMeasure_coe`
  (`@[fun_prop]`) is the ambient corollary via `hTail : tailProcess X ≤ ‹MeasurableSpace Ω›`.
- `directingMeasure_ae_eq_condExp` — **the conditional-law identity**:
  `ω ↦ (directingMeasure μ X ω).real B` is a version of `μ[𝟙_B ∘ X 0 | tailProcess X]`.

## Roadmap

Advances `TauCetiRoadmap/Exchangeability` toward the de Finetti proof routes. This is the random
directing measure that the martingale and kernel-based Koopman routes condition on — the object `ν` an
eventual `ConditionallyIIDWith μ X ν` witness is built from. This PR is the construction + its
single-coordinate conditional-law API only; the bundling as `ν : Ω → ProbabilityMeasure α` and the full
block-product factorisation are later steps.

## How it's proved (reuse)

No hand-rolled measure theory — entirely Mathlib's `condDistrib` API:
- the construction is `condDistrib (X 0) id μ` conditioning on `tailProcess X` (the same `id`-trick
  `condExpKernel` itself uses), `IsMarkovKernel` ⇒ probability measure;
- measurability is `measurable_condDistrib` (`tailProcess`-measurable, via `MeasurableSpace.comap_id`)
  downgraded to ambient with the merged `tailProcess_le_ambient`;
- the conditional-law identity is `condDistrib_ae_eq_condExp` (`μ⟦(X 0)⁻¹'B | tailProcess X⟧ =
  μ[𝟙_B ∘ X 0 | tailProcess X]`).

## Review notes
- **correctness / generality (value-space formulation):** the directing measure needs
  `[StandardBorelSpace α]` on the **value** space, not `[StandardBorelSpace Ω]` on the sample space —
  `Ω` is an arbitrary measurable space. Achieved by conditioning the α-valued `X 0` with `condDistrib`
  (standard Borel only on the target) rather than the whole-space `condExpKernel`.
- **generality (hypotheses):** the measurability and conditional-law lemmas take
  `hTail : tailProcess X ≤ ‹MeasurableSpace Ω›` (and `hX0 : Measurable (X 0)` for the latter) — exactly
  what the proofs use — rather than `∀ n, Measurable (X n)`.
- **api-design:** `directingMeasure` is opaque (no `@[expose]`); the stable interface is the
  characteristic lemmas (`isProbabilityMeasure`, `measurable_tailProcess_directingMeasure_coe` +
  `@[fun_prop]` ambient corollary, `directingMeasure_ae_eq_condExp`). A public `rfl`-unfold lemma is
  incompatible with hiding the body in the module system (it would require `@[expose]`), so the
  characteristic API replaces it (documented in a code comment).
- **naming:** the conditional-law lemma is `directingMeasure_ae_eq_condExp` (an a.e. `condExp`
  identity), not `…_marginal`.
- **placement:** de-Finetti-specific, so it lives in `DeFinetti/` next to `CommonEnding.lean`.

## Test plan
```bash
lake build
lake exe axioms
lake exe module-system
```
All pass; sorry-free; axioms ⊆ {`propext`, `Classical.choice`, `Quot.sound`}; lines ≤100.

## Attribution
Adapted from `cameronfreer/exchangeability` (`DeFinetti/ViaMartingale/DirectingMeasure.lean`, pin
`e0532e59ceff23edab44dda9ab0655debbc9cc22`); that version conditions over `Ω` (needing
`[StandardBorelSpace Ω]`), here strengthened to the value-space formulation over Mathlib's
`condDistrib` + the Tau Ceti `tailProcess` API. Drafted with Claude (Opus 4.8), human-directed.
