### PR TITLE
feat: shift/cons/cylinder/indicator support for the de Finetti factorisation

### DIFF
--- a/TauCeti/Probability/Exchangeability/Cylinder.lean
+++ b/TauCeti/Probability/Exchangeability/Cylinder.lean
@@ -68,6 +68,7 @@ theorem measurableSet_blockCylinder {X : ℕ → Ω → α} {m : ℕ} {k : Fin m
 /-- The block law evaluated on a measurable rectangle is the measure of the block cylinder:
 `blockLaw μ X k (Set.univ.pi C) = μ (blockCylinder X k C)`. A `blockCylinder`-named restatement of
 the merged `blockLaw_apply_rectangle`. -/
+@[grind =>]
 theorem blockLaw_blockCylinder {μ : Measure Ω} (X : ℕ → Ω → α) {m : ℕ} {k : Fin m → ℕ}
     {C : Fin m → Set α} (hX : ∀ i, AEMeasurable (X (k i)) μ) (hC : ∀ i, MeasurableSet (C i)) :
     blockLaw μ X k (Set.univ.pi C) = μ (blockCylinder X k C) := by
@@ -107,12 +108,19 @@ theorem blockIndicatorProd_empty (X : ℕ → Ω → α) (k : Fin 0 → ℕ) (C 
   funext ω
   simp [blockIndicatorProd]
 
-/-- The indicator product is integrable under a finite measure. -/
+/-- The block cylinder is null-measurable when the selected coordinates are a.e. measurable. -/
+theorem nullMeasurableSet_blockCylinder {μ : Measure Ω} {X : ℕ → Ω → α} {m : ℕ} {k : Fin m → ℕ}
+    {C : Fin m → Set α} (hX : ∀ i, AEMeasurable (X (k i)) μ) (hC : ∀ i, MeasurableSet (C i)) :
+    NullMeasurableSet (blockCylinder X k C) μ := by
+  rw [blockCylinder, Set.setOf_forall]
+  exact NullMeasurableSet.iInter fun i => (hX i).nullMeasurableSet_preimage (hC i)
+
+/-- The indicator product is integrable under a finite measure (a.e.-measurable coordinates). -/
 theorem integrable_blockIndicatorProd {μ : Measure Ω} [IsFiniteMeasure μ] {X : ℕ → Ω → α} {m : ℕ}
-    {k : Fin m → ℕ} {C : Fin m → Set α} (hX : ∀ i, Measurable (X (k i)))
+    {k : Fin m → ℕ} {C : Fin m → Set α} (hX : ∀ i, AEMeasurable (X (k i)) μ)
     (hC : ∀ i, MeasurableSet (C i)) : Integrable (blockIndicatorProd X k C) μ := by
   rw [blockIndicatorProd_eq_indicator]
-  exact Integrable.indicator (integrable_const (1 : ℝ)) (measurableSet_blockCylinder hX hC)
+  exact (integrable_const (1 : ℝ)).indicator₀ (nullMeasurableSet_blockCylinder hX hC)
 
 end Probability
 

--- a/TauCeti/Probability/Exchangeability/Cylinder.lean
+++ b/TauCeti/Probability/Exchangeability/Cylinder.lean
@@ -1,5 +1,6 @@
 module
 
+public import TauCeti.Probability.Exchangeability.Basic
 public import Mathlib.MeasureTheory.Integral.IntegrableOn
 
 /-!
@@ -12,9 +13,11 @@ For a process `X : ℕ → Ω → α` and a finite coordinate selection `k : Fin
   `k = fun i => i.val`);
 * `blockIndicatorProd X k C ω = ∏ i, 𝟙_{C i}(X (k i) ω)` — its (`ℝ`-valued) indicator product.
 
-These are the events and integrands the de Finetti block-product factorisation manipulates;
-`blockIndicatorProd_eq_indicator` identifies the product with the cylinder indicator, and
-`integrable_blockIndicatorProd` records that it is integrable under a finite measure.
+These are the finite-dimensional events and integrands the de Finetti block-product factorisation
+manipulates. `blockCylinder_eq_preimage_univ_pi` and `blockLaw_blockCylinder` bridge the cylinder to
+the existing rectangle/`blockLaw` interface; `blockIndicatorProd_eq_indicator` identifies the
+product with the cylinder indicator; and `integrable_blockIndicatorProd` records integrability under
+a finite measure.
 
 Adapted from `cameronfreer/exchangeability` (`PathSpace/CylinderHelpers.lean`,
 `DeFinetti/ViaMartingale/IndicatorAlgebra.lean`, pin
@@ -45,6 +48,15 @@ theorem mem_blockCylinder {X : ℕ → Ω → α} {m : ℕ} {k : Fin m → ℕ} 
     ω ∈ blockCylinder X k C ↔ ∀ i, X (k i) ω ∈ C i :=
   Iff.rfl
 
+omit [MeasurableSpace Ω] [MeasurableSpace α] in
+/-- The block cylinder is the preimage of the rectangle `Set.univ.pi C` under the
+selected-coordinate map `ω ↦ (X (k ·) ω)`. -/
+theorem blockCylinder_eq_preimage_univ_pi (X : ℕ → Ω → α) {m : ℕ} (k : Fin m → ℕ)
+    (C : Fin m → Set α) :
+    blockCylinder X k C = (fun ω i => X (k i) ω) ⁻¹' Set.univ.pi C := by
+  ext ω
+  simp only [mem_blockCylinder, Set.mem_preimage, Set.mem_univ_pi]
+
 /-- The block cylinder of a process with measurable selected coordinates on measurable sets is
 measurable. -/
 theorem measurableSet_blockCylinder {X : ℕ → Ω → α} {m : ℕ} {k : Fin m → ℕ} {C : Fin m → Set α}
@@ -52,6 +64,14 @@ theorem measurableSet_blockCylinder {X : ℕ → Ω → α} {m : ℕ} {k : Fin m
     MeasurableSet (blockCylinder X k C) := by
   simp only [blockCylinder, Set.setOf_forall]
   exact MeasurableSet.iInter fun i => (hX i) (hC i)
+
+/-- The block law evaluated on a measurable rectangle is the measure of the block cylinder:
+`blockLaw μ X k (Set.univ.pi C) = μ (blockCylinder X k C)`. A `blockCylinder`-named restatement of
+the merged `blockLaw_apply_rectangle`. -/
+theorem blockLaw_blockCylinder {μ : Measure Ω} (X : ℕ → Ω → α) {m : ℕ} {k : Fin m → ℕ}
+    {C : Fin m → Set α} (hX : ∀ i, AEMeasurable (X (k i)) μ) (hC : ∀ i, MeasurableSet (C i)) :
+    blockLaw μ X k (Set.univ.pi C) = μ (blockCylinder X k C) := by
+  rw [blockLaw_apply_rectangle μ X k hX C hC, blockCylinder]
 
 /-- The product of the selected coordinate indicators, `∏ i, 𝟙_{C i}(X (k i) ω)`. -/
 def blockIndicatorProd (X : ℕ → Ω → α) {m : ℕ} (k : Fin m → ℕ) (C : Fin m → Set α) : Ω → ℝ :=

--- a/TauCeti/Probability/Exchangeability/PathSpace/Cylinder.lean
+++ b/TauCeti/Probability/Exchangeability/PathSpace/Cylinder.lean
@@ -3,21 +3,18 @@ module
 public import Mathlib.MeasureTheory.Integral.IntegrableOn
 
 /-!
-# First-`r` prefix cylinders and their indicator products
+# Block cylinders and their indicator products
 
-For a process `X : ℕ → Ω → α`:
+For a process `X : ℕ → Ω → α` and a finite coordinate selection `k : Fin m → ℕ`:
 
-* `prefixCylinder X r C = {ω | ∀ i : Fin r, X i ω ∈ C i}` — the prefix cylinder event on the first
-  `r` coordinates (named to match `prefixProj` / `prefixLaw`);
-* `indProd X r C ω = ∏ i, 𝟙_{C i}(X i ω)` — its (`ℝ`-valued) indicator product.
+* `blockCylinder X k C = {ω | ∀ i, X (k i) ω ∈ C i}` — the cylinder event on the selected
+  coordinates (matching the `blockLaw` selection vocabulary; the first-`r` prefix is the case
+  `k = fun i => i.val`);
+* `blockIndicatorProd X k C ω = ∏ i, 𝟙_{C i}(X (k i) ω)` — its (`ℝ`-valued) indicator product.
 
 These are the events and integrands the de Finetti block-product factorisation manipulates;
-`indProd_eq_indicator` identifies the product with the cylinder indicator, and `integrable_indProd`
-records that it is integrable under a finite measure.
-
-The definitions keep `@[expose]` because their characteristic API is the computational `mem_…` /
-`_apply` lemmas, whose `rfl` proofs must unfold the definition body (an exported unfold requires the
-body to be exposed); downstream code uses those `@[simp]` lemmas rather than the raw body.
+`blockIndicatorProd_eq_indicator` identifies the product with the cylinder indicator, and
+`integrable_blockIndicatorProd` records that it is integrable under a finite measure.
 
 Adapted from `cameronfreer/exchangeability` (`PathSpace/CylinderHelpers.lean`,
 `DeFinetti/ViaMartingale/IndicatorAlgebra.lean`, pin
@@ -36,63 +33,56 @@ namespace Probability
 
 variable {Ω α : Type*} [MeasurableSpace Ω] [MeasurableSpace α]
 
-/-- The prefix cylinder event on the first `r` coordinates: `{ω | ∀ i : Fin r, X i ω ∈ C i}`. -/
-@[expose]
-def prefixCylinder (X : ℕ → Ω → α) (r : ℕ) (C : Fin r → Set α) : Set Ω :=
-  {ω | ∀ i : Fin r, X i ω ∈ C i}
+/-- The block cylinder event on the selected coordinates: `{ω | ∀ i, X (k i) ω ∈ C i}`. -/
+def blockCylinder (X : ℕ → Ω → α) {m : ℕ} (k : Fin m → ℕ) (C : Fin m → Set α) : Set Ω :=
+  {ω | ∀ i, X (k i) ω ∈ C i}
 
 omit [MeasurableSpace Ω] [MeasurableSpace α] in
 @[simp]
-theorem mem_prefixCylinder {X : ℕ → Ω → α} {r : ℕ} {C : Fin r → Set α} {ω : Ω} :
-    ω ∈ prefixCylinder X r C ↔ ∀ i : Fin r, X i ω ∈ C i :=
+theorem mem_blockCylinder {X : ℕ → Ω → α} {m : ℕ} {k : Fin m → ℕ} {C : Fin m → Set α} {ω : Ω} :
+    ω ∈ blockCylinder X k C ↔ ∀ i, X (k i) ω ∈ C i :=
   Iff.rfl
 
-/-- The first-`r` prefix cylinder of a process with measurable prefix coordinates on measurable sets
-is measurable. -/
-theorem measurableSet_prefixCylinder {X : ℕ → Ω → α} {r : ℕ} {C : Fin r → Set α}
-    (hX : ∀ i : Fin r, Measurable (X i.val)) (hC : ∀ i, MeasurableSet (C i)) :
-    MeasurableSet (prefixCylinder X r C) := by
-  rw [prefixCylinder, Set.setOf_forall]
+/-- The block cylinder of a process with measurable selected coordinates on measurable sets is
+measurable. -/
+theorem measurableSet_blockCylinder {X : ℕ → Ω → α} {m : ℕ} {k : Fin m → ℕ} {C : Fin m → Set α}
+    (hX : ∀ i, Measurable (X (k i))) (hC : ∀ i, MeasurableSet (C i)) :
+    MeasurableSet (blockCylinder X k C) := by
+  simp only [blockCylinder, Set.setOf_forall]
   exact MeasurableSet.iInter fun i => (hX i) (hC i)
 
-/-- The product of the first-`r` coordinate indicators, `∏ i, 𝟙_{C i}(X i ω)`. -/
-@[expose]
-def indProd (X : ℕ → Ω → α) (r : ℕ) (C : Fin r → Set α) : Ω → ℝ :=
-  fun ω => ∏ i : Fin r, (C i).indicator (fun _ => (1 : ℝ)) (X i ω)
+/-- The product of the selected coordinate indicators, `∏ i, 𝟙_{C i}(X (k i) ω)`. -/
+def blockIndicatorProd (X : ℕ → Ω → α) {m : ℕ} (k : Fin m → ℕ) (C : Fin m → Set α) : Ω → ℝ :=
+  fun ω => ∏ i, (C i).indicator (fun _ => (1 : ℝ)) (X (k i) ω)
 
 omit [MeasurableSpace Ω] [MeasurableSpace α] in
-@[simp]
-theorem indProd_apply (X : ℕ → Ω → α) (r : ℕ) (C : Fin r → Set α) (ω : Ω) :
-    indProd X r C ω = ∏ i : Fin r, (C i).indicator (fun _ => (1 : ℝ)) (X i ω) :=
-  rfl
-
-omit [MeasurableSpace Ω] [MeasurableSpace α] in
-/-- The indicator product is the indicator of the prefix cylinder. -/
-theorem indProd_eq_indicator (X : ℕ → Ω → α) (r : ℕ) (C : Fin r → Set α) :
-    indProd X r C = (prefixCylinder X r C).indicator (fun _ => (1 : ℝ)) := by
+/-- The indicator product is the indicator of the block cylinder. -/
+theorem blockIndicatorProd_eq_indicator (X : ℕ → Ω → α) {m : ℕ} (k : Fin m → ℕ)
+    (C : Fin m → Set α) :
+    blockIndicatorProd X k C = (blockCylinder X k C).indicator (fun _ => (1 : ℝ)) := by
   funext ω
-  by_cases h : ω ∈ prefixCylinder X r C
+  simp only [blockIndicatorProd]
+  by_cases h : ω ∈ blockCylinder X k C
   · rw [Set.indicator_of_mem h]
-    have h' : ∀ i : Fin r, X i ω ∈ C i := h
-    exact Finset.prod_eq_one fun i _ => Set.indicator_of_mem (h' i) _
+    exact Finset.prod_eq_one fun i _ => Set.indicator_of_mem (mem_blockCylinder.mp h i) _
   · rw [Set.indicator_of_notMem h]
-    have h' : ¬ ∀ i : Fin r, X i ω ∈ C i := h
-    obtain ⟨i, hi⟩ := not_forall.1 h'
+    obtain ⟨i, hi⟩ := not_forall.1 (mem_blockCylinder.not.mp h)
     exact Finset.prod_eq_zero (Finset.mem_univ i) (Set.indicator_of_notMem hi _)
 
 omit [MeasurableSpace Ω] [MeasurableSpace α] in
 /-- The empty (zero-coordinate) indicator product is the constant-one function. -/
 @[simp]
-theorem indProd_zero (X : ℕ → Ω → α) (C : Fin 0 → Set α) : indProd X 0 C = fun _ => 1 := by
+theorem blockIndicatorProd_empty (X : ℕ → Ω → α) (k : Fin 0 → ℕ) (C : Fin 0 → Set α) :
+    blockIndicatorProd X k C = fun _ => 1 := by
   funext ω
-  simp [indProd]
+  simp [blockIndicatorProd]
 
 /-- The indicator product is integrable under a finite measure. -/
-theorem integrable_indProd {μ : Measure Ω} [IsFiniteMeasure μ] {X : ℕ → Ω → α} {r : ℕ}
-    {C : Fin r → Set α} (hX : ∀ i : Fin r, Measurable (X i.val)) (hC : ∀ i, MeasurableSet (C i)) :
-    Integrable (indProd X r C) μ := by
-  rw [indProd_eq_indicator]
-  exact Integrable.indicator (integrable_const (1 : ℝ)) (measurableSet_prefixCylinder hX hC)
+theorem integrable_blockIndicatorProd {μ : Measure Ω} [IsFiniteMeasure μ] {X : ℕ → Ω → α} {m : ℕ}
+    {k : Fin m → ℕ} {C : Fin m → Set α} (hX : ∀ i, Measurable (X (k i)))
+    (hC : ∀ i, MeasurableSet (C i)) : Integrable (blockIndicatorProd X k C) μ := by
+  rw [blockIndicatorProd_eq_indicator]
+  exact Integrable.indicator (integrable_const (1 : ℝ)) (measurableSet_blockCylinder hX hC)
 
 end Probability
 

--- a/TauCeti/Probability/Exchangeability/PathSpace/Cylinder.lean
+++ b/TauCeti/Probability/Exchangeability/PathSpace/Cylinder.lean
@@ -1,0 +1,83 @@
+module
+
+public import TauCeti.Probability.Exchangeability.Basic
+public import Mathlib.MeasureTheory.Integral.IntegrableOn
+
+/-!
+# First-`r` cylinders and their indicator products
+
+For a process `X : ℕ → Ω → α`:
+
+* `firstRCylinder X r C = {ω | ∀ i : Fin r, X i ω ∈ C i}` — the cylinder event on the first `r`
+  coordinates;
+* `indProd X r C ω = ∏ i, 𝟙_{C i}(X i ω)` — its (`ℝ`-valued) indicator product.
+
+These are the events and integrands the de Finetti block-product factorisation manipulates;
+`indProd_eq_indicator` identifies the product with the cylinder indicator, and `integrable_indProd`
+records that it is integrable under a finite measure.
+
+Adapted from `cameronfreer/exchangeability` (`PathSpace/CylinderHelpers.lean`,
+`DeFinetti/ViaMartingale/IndicatorAlgebra.lean`, pin
+`e0532e59ceff23edab44dda9ab0655debbc9cc22`).
+-/
+
+public section
+
+noncomputable section
+
+open MeasureTheory
+
+namespace TauCeti
+
+namespace Probability
+
+variable {Ω α : Type*} [MeasurableSpace Ω] [MeasurableSpace α]
+
+/-- The cylinder event on the first `r` coordinates: `{ω | ∀ i : Fin r, X i ω ∈ C i}`. -/
+@[expose]
+def firstRCylinder (X : ℕ → Ω → α) (r : ℕ) (C : Fin r → Set α) : Set Ω :=
+  {ω | ∀ i : Fin r, X i ω ∈ C i}
+
+/-- The first-`r` cylinder of a process with measurable coordinates on measurable sets is
+measurable. -/
+theorem measurableSet_firstRCylinder {X : ℕ → Ω → α} (hX : ∀ i, Measurable (X i)) {r : ℕ}
+    {C : Fin r → Set α} (hC : ∀ i, MeasurableSet (C i)) :
+    MeasurableSet (firstRCylinder X r C) := by
+  rw [firstRCylinder, Set.setOf_forall]
+  exact MeasurableSet.iInter fun i => (hX i) (hC i)
+
+/-- The product of the first-`r` coordinate indicators, `∏ i, 𝟙_{C i}(X i ω)`. -/
+@[expose]
+def indProd (X : ℕ → Ω → α) (r : ℕ) (C : Fin r → Set α) : Ω → ℝ :=
+  fun ω => ∏ i : Fin r, (C i).indicator (fun _ => (1 : ℝ)) (X i ω)
+
+omit [MeasurableSpace Ω] [MeasurableSpace α] in
+/-- The indicator product is the indicator of the first-`r` cylinder. -/
+theorem indProd_eq_indicator (X : ℕ → Ω → α) (r : ℕ) (C : Fin r → Set α) :
+    indProd X r C = (firstRCylinder X r C).indicator (fun _ => (1 : ℝ)) := by
+  funext ω
+  by_cases h : ω ∈ firstRCylinder X r C
+  · rw [Set.indicator_of_mem h]
+    have h' : ∀ i : Fin r, X i ω ∈ C i := h
+    exact Finset.prod_eq_one fun i _ => Set.indicator_of_mem (h' i) _
+  · rw [Set.indicator_of_notMem h]
+    have h' : ¬ ∀ i : Fin r, X i ω ∈ C i := h
+    obtain ⟨i, hi⟩ := not_forall.1 h'
+    exact Finset.prod_eq_zero (Finset.mem_univ i) (Set.indicator_of_notMem hi _)
+
+omit [MeasurableSpace Ω] [MeasurableSpace α] in
+@[simp]
+theorem indProd_zero (X : ℕ → Ω → α) (C : Fin 0 → Set α) : indProd X 0 C = fun _ => 1 := by
+  funext ω
+  simp [indProd]
+
+/-- The indicator product is integrable under a finite measure. -/
+theorem integrable_indProd {μ : Measure Ω} [IsFiniteMeasure μ] {X : ℕ → Ω → α}
+    (hX : ∀ i, Measurable (X i)) {r : ℕ} {C : Fin r → Set α} (hC : ∀ i, MeasurableSet (C i)) :
+    Integrable (indProd X r C) μ := by
+  rw [indProd_eq_indicator]
+  exact Integrable.indicator (integrable_const (1 : ℝ)) (measurableSet_firstRCylinder hX hC)
+
+end Probability
+
+end TauCeti

--- a/TauCeti/Probability/Exchangeability/PathSpace/Cylinder.lean
+++ b/TauCeti/Probability/Exchangeability/PathSpace/Cylinder.lean
@@ -38,6 +38,8 @@ def blockCylinder (X : ℕ → Ω → α) {m : ℕ} (k : Fin m → ℕ) (C : Fin
   {ω | ∀ i, X (k i) ω ∈ C i}
 
 omit [MeasurableSpace Ω] [MeasurableSpace α] in
+/-- Membership in the block cylinder: `ω` lies in `blockCylinder X k C` iff every selected
+coordinate `X (k i) ω` lies in its set `C i`. -/
 @[simp]
 theorem mem_blockCylinder {X : ℕ → Ω → α} {m : ℕ} {k : Fin m → ℕ} {C : Fin m → Set α} {ω : Ω} :
     ω ∈ blockCylinder X k C ↔ ∀ i, X (k i) ω ∈ C i :=
@@ -56,12 +58,20 @@ def blockIndicatorProd (X : ℕ → Ω → α) {m : ℕ} (k : Fin m → ℕ) (C 
   fun ω => ∏ i, (C i).indicator (fun _ => (1 : ℝ)) (X (k i) ω)
 
 omit [MeasurableSpace Ω] [MeasurableSpace α] in
+/-- Pointwise value of the indicator product: the product of the selected coordinate indicators. -/
+@[simp]
+theorem blockIndicatorProd_apply (X : ℕ → Ω → α) {m : ℕ} (k : Fin m → ℕ) (C : Fin m → Set α)
+    (ω : Ω) :
+    blockIndicatorProd X k C ω = ∏ i, (C i).indicator (fun _ => (1 : ℝ)) (X (k i) ω) := by
+  simp only [blockIndicatorProd]
+
+omit [MeasurableSpace Ω] [MeasurableSpace α] in
 /-- The indicator product is the indicator of the block cylinder. -/
 theorem blockIndicatorProd_eq_indicator (X : ℕ → Ω → α) {m : ℕ} (k : Fin m → ℕ)
     (C : Fin m → Set α) :
     blockIndicatorProd X k C = (blockCylinder X k C).indicator (fun _ => (1 : ℝ)) := by
   funext ω
-  simp only [blockIndicatorProd]
+  rw [blockIndicatorProd_apply]
   by_cases h : ω ∈ blockCylinder X k C
   · rw [Set.indicator_of_mem h]
     exact Finset.prod_eq_one fun i _ => Set.indicator_of_mem (mem_blockCylinder.mp h i) _

--- a/TauCeti/Probability/Exchangeability/PathSpace/Cylinder.lean
+++ b/TauCeti/Probability/Exchangeability/PathSpace/Cylinder.lean
@@ -1,20 +1,23 @@
 module
 
-public import TauCeti.Probability.Exchangeability.Basic
 public import Mathlib.MeasureTheory.Integral.IntegrableOn
 
 /-!
-# First-`r` cylinders and their indicator products
+# First-`r` prefix cylinders and their indicator products
 
 For a process `X : ℕ → Ω → α`:
 
-* `firstRCylinder X r C = {ω | ∀ i : Fin r, X i ω ∈ C i}` — the cylinder event on the first `r`
-  coordinates;
+* `prefixCylinder X r C = {ω | ∀ i : Fin r, X i ω ∈ C i}` — the prefix cylinder event on the first
+  `r` coordinates (named to match `prefixProj` / `prefixLaw`);
 * `indProd X r C ω = ∏ i, 𝟙_{C i}(X i ω)` — its (`ℝ`-valued) indicator product.
 
 These are the events and integrands the de Finetti block-product factorisation manipulates;
 `indProd_eq_indicator` identifies the product with the cylinder indicator, and `integrable_indProd`
 records that it is integrable under a finite measure.
+
+The definitions keep `@[expose]` because their characteristic API is the computational `mem_…` /
+`_apply` lemmas, whose `rfl` proofs must unfold the definition body (an exported unfold requires the
+body to be exposed); downstream code uses those `@[simp]` lemmas rather than the raw body.
 
 Adapted from `cameronfreer/exchangeability` (`PathSpace/CylinderHelpers.lean`,
 `DeFinetti/ViaMartingale/IndicatorAlgebra.lean`, pin
@@ -33,17 +36,23 @@ namespace Probability
 
 variable {Ω α : Type*} [MeasurableSpace Ω] [MeasurableSpace α]
 
-/-- The cylinder event on the first `r` coordinates: `{ω | ∀ i : Fin r, X i ω ∈ C i}`. -/
+/-- The prefix cylinder event on the first `r` coordinates: `{ω | ∀ i : Fin r, X i ω ∈ C i}`. -/
 @[expose]
-def firstRCylinder (X : ℕ → Ω → α) (r : ℕ) (C : Fin r → Set α) : Set Ω :=
+def prefixCylinder (X : ℕ → Ω → α) (r : ℕ) (C : Fin r → Set α) : Set Ω :=
   {ω | ∀ i : Fin r, X i ω ∈ C i}
 
-/-- The first-`r` cylinder of a process with measurable coordinates on measurable sets is
-measurable. -/
-theorem measurableSet_firstRCylinder {X : ℕ → Ω → α} (hX : ∀ i, Measurable (X i)) {r : ℕ}
-    {C : Fin r → Set α} (hC : ∀ i, MeasurableSet (C i)) :
-    MeasurableSet (firstRCylinder X r C) := by
-  rw [firstRCylinder, Set.setOf_forall]
+omit [MeasurableSpace Ω] [MeasurableSpace α] in
+@[simp]
+theorem mem_prefixCylinder {X : ℕ → Ω → α} {r : ℕ} {C : Fin r → Set α} {ω : Ω} :
+    ω ∈ prefixCylinder X r C ↔ ∀ i : Fin r, X i ω ∈ C i :=
+  Iff.rfl
+
+/-- The first-`r` prefix cylinder of a process with measurable prefix coordinates on measurable sets
+is measurable. -/
+theorem measurableSet_prefixCylinder {X : ℕ → Ω → α} {r : ℕ} {C : Fin r → Set α}
+    (hX : ∀ i : Fin r, Measurable (X i.val)) (hC : ∀ i, MeasurableSet (C i)) :
+    MeasurableSet (prefixCylinder X r C) := by
+  rw [prefixCylinder, Set.setOf_forall]
   exact MeasurableSet.iInter fun i => (hX i) (hC i)
 
 /-- The product of the first-`r` coordinate indicators, `∏ i, 𝟙_{C i}(X i ω)`. -/
@@ -52,11 +61,17 @@ def indProd (X : ℕ → Ω → α) (r : ℕ) (C : Fin r → Set α) : Ω → �
   fun ω => ∏ i : Fin r, (C i).indicator (fun _ => (1 : ℝ)) (X i ω)
 
 omit [MeasurableSpace Ω] [MeasurableSpace α] in
-/-- The indicator product is the indicator of the first-`r` cylinder. -/
+@[simp]
+theorem indProd_apply (X : ℕ → Ω → α) (r : ℕ) (C : Fin r → Set α) (ω : Ω) :
+    indProd X r C ω = ∏ i : Fin r, (C i).indicator (fun _ => (1 : ℝ)) (X i ω) :=
+  rfl
+
+omit [MeasurableSpace Ω] [MeasurableSpace α] in
+/-- The indicator product is the indicator of the prefix cylinder. -/
 theorem indProd_eq_indicator (X : ℕ → Ω → α) (r : ℕ) (C : Fin r → Set α) :
-    indProd X r C = (firstRCylinder X r C).indicator (fun _ => (1 : ℝ)) := by
+    indProd X r C = (prefixCylinder X r C).indicator (fun _ => (1 : ℝ)) := by
   funext ω
-  by_cases h : ω ∈ firstRCylinder X r C
+  by_cases h : ω ∈ prefixCylinder X r C
   · rw [Set.indicator_of_mem h]
     have h' : ∀ i : Fin r, X i ω ∈ C i := h
     exact Finset.prod_eq_one fun i _ => Set.indicator_of_mem (h' i) _
@@ -66,17 +81,18 @@ theorem indProd_eq_indicator (X : ℕ → Ω → α) (r : ℕ) (C : Fin r → Se
     exact Finset.prod_eq_zero (Finset.mem_univ i) (Set.indicator_of_notMem hi _)
 
 omit [MeasurableSpace Ω] [MeasurableSpace α] in
+/-- The empty (zero-coordinate) indicator product is the constant-one function. -/
 @[simp]
 theorem indProd_zero (X : ℕ → Ω → α) (C : Fin 0 → Set α) : indProd X 0 C = fun _ => 1 := by
   funext ω
   simp [indProd]
 
 /-- The indicator product is integrable under a finite measure. -/
-theorem integrable_indProd {μ : Measure Ω} [IsFiniteMeasure μ] {X : ℕ → Ω → α}
-    (hX : ∀ i, Measurable (X i)) {r : ℕ} {C : Fin r → Set α} (hC : ∀ i, MeasurableSet (C i)) :
+theorem integrable_indProd {μ : Measure Ω} [IsFiniteMeasure μ] {X : ℕ → Ω → α} {r : ℕ}
+    {C : Fin r → Set α} (hX : ∀ i : Fin r, Measurable (X i.val)) (hC : ∀ i, MeasurableSet (C i)) :
     Integrable (indProd X r C) μ := by
   rw [indProd_eq_indicator]
-  exact Integrable.indicator (integrable_const (1 : ℝ)) (measurableSet_firstRCylinder hX hC)
+  exact Integrable.indicator (integrable_const (1 : ℝ)) (measurableSet_prefixCylinder hX hC)
 
 end Probability
 

--- a/TauCeti/Probability/Exchangeability/PathSpace/ProcessShift.lean
+++ b/TauCeti/Probability/Exchangeability/PathSpace/ProcessShift.lean
@@ -42,6 +42,7 @@ def processShift (X : ℕ → Ω → α) (m : ℕ) : Ω → (ℕ → α) :=
   fun ω n => X (m + n) ω
 
 omit [MeasurableSpace Ω] [MeasurableSpace α] in
+/-- Coordinate equation for `processShift`: its `n`th coordinate is `X (m + n)`. -/
 @[simp]
 theorem processShift_apply (X : ℕ → Ω → α) (m n : ℕ) (ω : Ω) :
     processShift X m ω n = X (m + n) ω := by
@@ -60,11 +61,13 @@ def processCons (x : Ω → α) (t : Ω → ℕ → α) : Ω → ℕ → α
   | ω, (n + 1) => t ω n
 
 omit [MeasurableSpace Ω] [MeasurableSpace α] in
+/-- Leading coordinate of a cons: `processCons x t ω 0 = x ω`. -/
 @[simp]
 theorem processCons_zero (x : Ω → α) (t : Ω → ℕ → α) (ω : Ω) : processCons x t ω 0 = x ω := by
   simp only [processCons]
 
 omit [MeasurableSpace Ω] [MeasurableSpace α] in
+/-- Later coordinates of a cons: `processCons x t ω (n + 1) = t ω n`. -/
 @[simp]
 theorem processCons_succ (x : Ω → α) (t : Ω → ℕ → α) (ω : Ω) (n : ℕ) :
     processCons x t ω (n + 1) = t ω n := by
@@ -75,6 +78,7 @@ t ω (n+1)`. -/
 def processTail (t : Ω → ℕ → α) : Ω → ℕ → α := fun ω n => t ω (n + 1)
 
 omit [MeasurableSpace Ω] [MeasurableSpace α] in
+/-- Coordinate equation for `processTail`: its `n`th coordinate is `t (n + 1)`. -/
 @[simp]
 theorem processTail_apply (t : Ω → ℕ → α) (ω : Ω) (n : ℕ) : processTail t ω n = t ω (n + 1) := by
   simp only [processTail]
@@ -102,11 +106,11 @@ theorem measurable_processCons {x : Ω → α} {t : Ω → ℕ → α} (hx : Mea
   | zero => exact hx
   | succ n => exact (measurable_pi_apply n).comp ht
 
-/-- The tail of a measurable process is measurable. -/
+/-- The tail of a process is measurable when its tail coordinates `t (· + 1)` are. -/
 @[fun_prop]
-theorem measurable_processTail {t : Ω → ℕ → α} (ht : Measurable t) :
+theorem measurable_processTail {t : Ω → ℕ → α} (ht : ∀ n, Measurable fun ω => t ω (n + 1)) :
     Measurable (processTail t) :=
-  measurable_pi_lambda _ fun n => (measurable_pi_apply (n + 1)).comp ht
+  measurable_pi_lambda _ ht
 
 omit [MeasurableSpace Ω] in
 /-- The tail of a sequence-valued random variable generates a coarser σ-algebra. It is the

--- a/TauCeti/Probability/Exchangeability/PathSpace/ProcessShift.lean
+++ b/TauCeti/Probability/Exchangeability/PathSpace/ProcessShift.lean
@@ -14,9 +14,8 @@ block-product factorisation:
 The `processCons` / `processTail` operations on sequence-valued random variables, together with
 their σ-algebra-contraction lemmas, live in `TauCeti.Probability.Process.Tail`.
 
-The definition is not `@[expose]`; its characteristic API is the `@[simp]` `processShift_apply`
-lemma (proved through the equation lemma), so downstream code reasons through that rather than the
-definition body.
+Its exported API is the `@[simp]` coordinate equation `processShift_apply` and the path-shift
+identity `processShift_eq`.
 
 Adapted from `cameronfreer/exchangeability` (`DeFinetti/ViaMartingale/ShiftOperations.lean`, pin
 `e0532e59ceff23edab44dda9ab0655debbc9cc22`).

--- a/TauCeti/Probability/Exchangeability/PathSpace/ProcessShift.lean
+++ b/TauCeti/Probability/Exchangeability/PathSpace/ProcessShift.lean
@@ -3,23 +3,20 @@ module
 public import TauCeti.Probability.Exchangeability.PathSpace.Shift
 
 /-!
-# Process shift, cons, and tail operations
+# Process shift operation
 
-Process-level path operations for a process `X : ℕ → Ω → α`, used to build the de Finetti
+The process-level path shift for a process `X : ℕ → Ω → α`, used to build the de Finetti
 block-product factorisation:
 
-* `processShift X m` — the shifted random path `ω ↦ (n ↦ X (m + n) ω)` (the `m`-fold path shift of
-  the process, see `processShift_eq`);
-* `processCons x t` / `processTail t` — prepend / drop the leading coordinate of a sequence-valued
-  random variable.
+* `processShift X m` — the shifted random path `ω ↦ (n ↦ X (m + n) ω)`, the `m`-fold path-space
+  shift of the process's path (`processShift_eq`).
 
-The `comap` contraction lemmas (`comap_processTail_le`, `comap_le_comap_processCons`) record that
-the tail of a sequence-valued random variable generates a coarser σ-algebra; they feed the
-Kallenberg conditional independence step of the factorisation.
+The `processCons` / `processTail` operations on sequence-valued random variables, together with
+their σ-algebra-contraction lemmas, live in `TauCeti.Probability.Process.Tail`.
 
-The definitions are not `@[expose]`; their characteristic API is the `@[simp]` `_apply` /
-interaction lemmas below (proved through the equation lemmas), so downstream code reasons through
-those rather than the definition bodies.
+The definition is not `@[expose]`; its characteristic API is the `@[simp]` `processShift_apply`
+lemma (proved through the equation lemma), so downstream code reasons through that rather than the
+definition body.
 
 Adapted from `cameronfreer/exchangeability` (`DeFinetti/ViaMartingale/ShiftOperations.lean`, pin
 `e0532e59ceff23edab44dda9ab0655debbc9cc22`).
@@ -55,84 +52,11 @@ theorem processShift_eq (X : ℕ → Ω → α) (m : ℕ) :
   funext ω n
   simp [processShift, shift_iterate_apply, Nat.add_comm]
 
-/-- Cons a head random variable onto a sequence-valued one: `processCons x t = [x, t 0, t 1, …]`. -/
-def processCons (x : Ω → α) (t : Ω → ℕ → α) : Ω → ℕ → α
-  | ω, 0 => x ω
-  | ω, (n + 1) => t ω n
-
-omit [MeasurableSpace Ω] [MeasurableSpace α] in
-/-- Leading coordinate of a cons: `processCons x t ω 0 = x ω`. -/
-@[simp]
-theorem processCons_zero (x : Ω → α) (t : Ω → ℕ → α) (ω : Ω) : processCons x t ω 0 = x ω := by
-  simp only [processCons]
-
-omit [MeasurableSpace Ω] [MeasurableSpace α] in
-/-- Later coordinates of a cons: `processCons x t ω (n + 1) = t ω n`. -/
-@[simp]
-theorem processCons_succ (x : Ω → α) (t : Ω → ℕ → α) (ω : Ω) (n : ℕ) :
-    processCons x t ω (n + 1) = t ω n := by
-  simp only [processCons]
-
-/-- Drop the leading coordinate of a sequence-valued random variable: `processTail t ω n =
-t ω (n+1)`. -/
-def processTail (t : Ω → ℕ → α) : Ω → ℕ → α := fun ω n => t ω (n + 1)
-
-omit [MeasurableSpace Ω] [MeasurableSpace α] in
-/-- Coordinate equation for `processTail`: its `n`th coordinate is `t (n + 1)`. -/
-@[simp]
-theorem processTail_apply (t : Ω → ℕ → α) (ω : Ω) (n : ℕ) : processTail t ω n = t ω (n + 1) := by
-  simp only [processTail]
-
-omit [MeasurableSpace Ω] [MeasurableSpace α] in
-/-- The tail of a cons recovers the original sequence. -/
-@[simp]
-theorem processTail_processCons (x : Ω → α) (t : Ω → ℕ → α) :
-    processTail (processCons x t) = t := by
-  funext ω n
-  simp only [processTail, processCons]
-
 /-- The shifted process is measurable when its tail coordinates `X (m + ·)` are. -/
 @[fun_prop]
 theorem measurable_processShift {X : ℕ → Ω → α} {m : ℕ} (hX : ∀ n, Measurable (X (m + n))) :
     Measurable (processShift X m) :=
   measurable_pi_lambda _ hX
-
-/-- Consing a measurable head onto a measurable process is measurable. -/
-@[fun_prop]
-theorem measurable_processCons {x : Ω → α} {t : Ω → ℕ → α} (hx : Measurable x) (ht : Measurable t) :
-    Measurable (processCons x t) := by
-  refine measurable_pi_lambda _ fun n => ?_
-  cases n with
-  | zero => exact hx
-  | succ n => exact (measurable_pi_apply n).comp ht
-
-/-- The tail of a process is measurable when its tail coordinates `t (· + 1)` are. -/
-@[fun_prop]
-theorem measurable_processTail {t : Ω → ℕ → α} (ht : ∀ n, Measurable fun ω => t ω (n + 1)) :
-    Measurable (processTail t) :=
-  measurable_pi_lambda _ ht
-
-omit [MeasurableSpace Ω] in
-/-- The tail of a sequence-valued random variable generates a coarser σ-algebra. It is the
-composition of the measurable index shift with `t`. -/
-theorem comap_processTail_le {t : Ω → ℕ → α} :
-    MeasurableSpace.comap (processTail t) inferInstance
-      ≤ MeasurableSpace.comap t inferInstance := by
-  have hcomp : processTail t = (fun s : ℕ → α => fun n => s (n + 1)) ∘ t := by
-    funext ω n; simp only [processTail, Function.comp_apply]
-  rw [hcomp, ← MeasurableSpace.comap_comp]
-  have hshift : Measurable fun s : ℕ → α => fun n => s (n + 1) := by fun_prop
-  exact MeasurableSpace.comap_mono hshift.comap_le
-
-omit [MeasurableSpace Ω] in
-/-- Consing a head onto a sequence-valued random variable refines its σ-algebra: `σ(t) ≤
-σ(processCons x t)`. -/
-theorem comap_le_comap_processCons (x : Ω → α) (t : Ω → ℕ → α) :
-    MeasurableSpace.comap t inferInstance ≤ MeasurableSpace.comap (processCons x t) inferInstance :=
-  calc MeasurableSpace.comap t inferInstance
-      = MeasurableSpace.comap (processTail (processCons x t)) inferInstance := by
-        rw [processTail_processCons]
-    _ ≤ MeasurableSpace.comap (processCons x t) inferInstance := comap_processTail_le
 
 end Probability
 

--- a/TauCeti/Probability/Exchangeability/PathSpace/ProcessShift.lean
+++ b/TauCeti/Probability/Exchangeability/PathSpace/ProcessShift.lean
@@ -1,6 +1,6 @@
 module
 
-public import TauCeti.Probability.Exchangeability.Basic
+public import TauCeti.Probability.Exchangeability.PathSpace.Shift
 
 /-!
 # Process shift, cons, and tail operations
@@ -8,13 +8,18 @@ public import TauCeti.Probability.Exchangeability.Basic
 Process-level path operations for a process `X : ℕ → Ω → α`, used to build the de Finetti
 block-product factorisation:
 
-* `shiftRV X m` — the shifted random path `ω ↦ (n ↦ X (m + n) ω)`;
-* `consRV x t` / `tailRV t` — prepend / drop the leading coordinate of a sequence-valued random
-  variable.
+* `processShift X m` — the shifted random path `ω ↦ (n ↦ X (m + n) ω)` (the `m`-fold path shift of
+  the process, see `processShift_eq`);
+* `processCons x t` / `processTail t` — prepend / drop the leading coordinate of a sequence-valued
+  random variable.
 
-The `comap` contraction lemmas (`comap_tailRV_le`, `comap_le_comap_consRV`) record that the tail of
-a sequence-valued random variable generates a coarser σ-algebra; they feed the Kallenberg
-conditional independence step of the factorisation.
+The `comap` contraction lemmas (`comap_processTail_le`, `comap_le_comap_processCons`) record that
+the tail of a sequence-valued random variable generates a coarser σ-algebra; they feed the
+Kallenberg conditional independence step of the factorisation.
+
+The definitions keep `@[expose]` because their characteristic API is the computational `_apply`
+lemmas below, whose `rfl` proofs must unfold the definition body (an exported unfold requires the
+body to be exposed); downstream code uses those `@[simp]` lemmas rather than the raw body.
 
 Adapted from `cameronfreer/exchangeability` (`DeFinetti/ViaMartingale/ShiftOperations.lean`, pin
 `e0532e59ceff23edab44dda9ab0655debbc9cc22`).
@@ -34,56 +39,94 @@ variable {Ω α : Type*} [MeasurableSpace Ω] [MeasurableSpace α]
 
 /-- The shifted random path of a process: `ω ↦ (n ↦ X (m + n) ω)`. -/
 @[expose]
-def shiftRV (X : ℕ → Ω → α) (m : ℕ) : Ω → (ℕ → α) :=
+def processShift (X : ℕ → Ω → α) (m : ℕ) : Ω → (ℕ → α) :=
   fun ω n => X (m + n) ω
-
-/-- Cons a head random variable onto a sequence-valued one: `consRV x t` is `[x, t 0, t 1, …]`. -/
-@[expose]
-def consRV (x : Ω → α) (t : Ω → ℕ → α) : Ω → ℕ → α
-  | ω, 0 => x ω
-  | ω, (n + 1) => t ω n
-
-/-- Drop the leading coordinate of a sequence-valued random variable: `tailRV t ω n = t ω (n+1)`. -/
-@[expose]
-def tailRV (t : Ω → ℕ → α) : Ω → ℕ → α := fun ω n => t ω (n + 1)
 
 omit [MeasurableSpace Ω] [MeasurableSpace α] in
 @[simp]
-theorem tailRV_consRV (x : Ω → α) (t : Ω → ℕ → α) : tailRV (consRV x t) = t := rfl
+theorem processShift_apply (X : ℕ → Ω → α) (m n : ℕ) (ω : Ω) :
+    processShift X m ω n = X (m + n) ω :=
+  rfl
 
-@[fun_prop]
-theorem measurable_shiftRV {X : ℕ → Ω → α} (hX : ∀ n, Measurable (X n)) (m : ℕ) :
-    Measurable (shiftRV X m) :=
-  measurable_pi_lambda _ fun n => hX (m + n)
+omit [MeasurableSpace Ω] [MeasurableSpace α] in
+/-- `processShift X m` is the `m`-fold path-space shift `(shift α)^[m]` of the process's path. -/
+theorem processShift_eq (X : ℕ → Ω → α) (m : ℕ) :
+    processShift X m = fun ω => (shift α)^[m] fun n => X n ω := by
+  funext ω n
+  simp [processShift, shift_iterate_apply, Nat.add_comm]
 
+/-- Cons a head random variable onto a sequence-valued one: `processCons x t = [x, t 0, t 1, …]`. -/
+@[expose]
+def processCons (x : Ω → α) (t : Ω → ℕ → α) : Ω → ℕ → α
+  | ω, 0 => x ω
+  | ω, (n + 1) => t ω n
+
+omit [MeasurableSpace Ω] [MeasurableSpace α] in
+@[simp]
+theorem processCons_zero (x : Ω → α) (t : Ω → ℕ → α) (ω : Ω) : processCons x t ω 0 = x ω :=
+  rfl
+
+omit [MeasurableSpace Ω] [MeasurableSpace α] in
+@[simp]
+theorem processCons_succ (x : Ω → α) (t : Ω → ℕ → α) (ω : Ω) (n : ℕ) :
+    processCons x t ω (n + 1) = t ω n :=
+  rfl
+
+/-- Drop the leading coordinate of a sequence-valued random variable: `processTail t ω n =
+t ω (n+1)`. -/
+@[expose]
+def processTail (t : Ω → ℕ → α) : Ω → ℕ → α := fun ω n => t ω (n + 1)
+
+omit [MeasurableSpace Ω] [MeasurableSpace α] in
+@[simp]
+theorem processTail_apply (t : Ω → ℕ → α) (ω : Ω) (n : ℕ) : processTail t ω n = t ω (n + 1) :=
+  rfl
+
+omit [MeasurableSpace Ω] [MeasurableSpace α] in
+/-- The tail of a cons recovers the original sequence. -/
+@[simp]
+theorem processTail_processCons (x : Ω → α) (t : Ω → ℕ → α) : processTail (processCons x t) = t :=
+  rfl
+
+/-- The shifted process is measurable when its tail coordinates `X (m + ·)` are. -/
 @[fun_prop]
-theorem measurable_consRV {x : Ω → α} {t : Ω → ℕ → α} (hx : Measurable x) (ht : Measurable t) :
-    Measurable (consRV x t) := by
+theorem measurable_processShift {X : ℕ → Ω → α} {m : ℕ} (hX : ∀ n, Measurable (X (m + n))) :
+    Measurable (processShift X m) :=
+  measurable_pi_lambda _ hX
+
+/-- Consing a measurable head onto a measurable process is measurable. -/
+@[fun_prop]
+theorem measurable_processCons {x : Ω → α} {t : Ω → ℕ → α} (hx : Measurable x) (ht : Measurable t) :
+    Measurable (processCons x t) := by
   refine measurable_pi_lambda _ fun n => ?_
   cases n with
   | zero => exact hx
   | succ n => exact (measurable_pi_apply n).comp ht
 
+/-- The tail of a measurable process is measurable. -/
 @[fun_prop]
-theorem measurable_tailRV {t : Ω → ℕ → α} (ht : Measurable t) : Measurable (tailRV t) :=
+theorem measurable_processTail {t : Ω → ℕ → α} (ht : Measurable t) :
+    Measurable (processTail t) :=
   measurable_pi_lambda _ fun n => (measurable_pi_apply (n + 1)).comp ht
 
 omit [MeasurableSpace Ω] in
 /-- The tail of a sequence-valued random variable generates a coarser σ-algebra. -/
-theorem comap_tailRV_le {t : Ω → ℕ → α} :
-    MeasurableSpace.comap (tailRV t) inferInstance ≤ MeasurableSpace.comap t inferInstance := by
+theorem comap_processTail_le {t : Ω → ℕ → α} :
+    MeasurableSpace.comap (processTail t) inferInstance
+      ≤ MeasurableSpace.comap t inferInstance := by
   have hshift : Measurable fun s : ℕ → α => fun n => s (n + 1) := by fun_prop
   rintro _ ⟨A, hA, rfl⟩
   exact ⟨_, hA.preimage hshift, rfl⟩
 
 omit [MeasurableSpace Ω] in
 /-- Consing a head onto a sequence-valued random variable refines its σ-algebra: `σ(t) ≤
-σ(consRV x t)`. -/
-theorem comap_le_comap_consRV (x : Ω → α) (t : Ω → ℕ → α) :
-    MeasurableSpace.comap t inferInstance ≤ MeasurableSpace.comap (consRV x t) inferInstance :=
+σ(processCons x t)`. -/
+theorem comap_le_comap_processCons (x : Ω → α) (t : Ω → ℕ → α) :
+    MeasurableSpace.comap t inferInstance ≤ MeasurableSpace.comap (processCons x t) inferInstance :=
   calc MeasurableSpace.comap t inferInstance
-      = MeasurableSpace.comap (tailRV (consRV x t)) inferInstance := by rw [tailRV_consRV]
-    _ ≤ MeasurableSpace.comap (consRV x t) inferInstance := comap_tailRV_le
+      = MeasurableSpace.comap (processTail (processCons x t)) inferInstance := by
+        rw [processTail_processCons]
+    _ ≤ MeasurableSpace.comap (processCons x t) inferInstance := comap_processTail_le
 
 end Probability
 

--- a/TauCeti/Probability/Exchangeability/PathSpace/ProcessShift.lean
+++ b/TauCeti/Probability/Exchangeability/PathSpace/ProcessShift.lean
@@ -8,14 +8,13 @@ public import TauCeti.Probability.Exchangeability.PathSpace.Shift
 The process-level path shift for a process `X : ℕ → Ω → α`, used to build the de Finetti
 block-product factorisation:
 
-* `processShift X m` — the shifted random path `ω ↦ (n ↦ X (m + n) ω)`, the `m`-fold path-space
-  shift of the process's path (`processShift_eq`).
+* `processShift X m` — the shifted random path `ω ↦ (n ↦ X (m + n) ω)`, defined as the `m`-fold
+  merged path-space shift `(shift α)^[m]` of the process's path.
 
 The `processCons` / `processTail` operations on sequence-valued random variables, together with
 their σ-algebra-contraction lemmas, live in `TauCeti.Probability.Process.Tail`.
 
-Its exported API is the `@[simp]` coordinate equation `processShift_apply` and the path-shift
-identity `processShift_eq`.
+Its exported API is the `@[simp]` coordinate equation `processShift_apply`.
 
 Adapted from `cameronfreer/exchangeability` (`DeFinetti/ViaMartingale/ShiftOperations.lean`, pin
 `e0532e59ceff23edab44dda9ab0655debbc9cc22`).
@@ -33,29 +32,24 @@ namespace Probability
 
 variable {Ω α : Type*} [MeasurableSpace Ω] [MeasurableSpace α]
 
-/-- The shifted random path of a process: `ω ↦ (n ↦ X (m + n) ω)`. -/
+/-- The shifted random path of a process, as the `m`-fold path-space shift `(shift α)^[m]` of the
+process's path (reusing the merged path shift): `ω ↦ (n ↦ X (m + n) ω)`. -/
 def processShift (X : ℕ → Ω → α) (m : ℕ) : Ω → (ℕ → α) :=
-  fun ω n => X (m + n) ω
+  fun ω => (shift α)^[m] fun n => X n ω
 
 omit [MeasurableSpace Ω] [MeasurableSpace α] in
 /-- Coordinate equation for `processShift`: its `n`th coordinate is `X (m + n)`. -/
 @[simp]
 theorem processShift_apply (X : ℕ → Ω → α) (m n : ℕ) (ω : Ω) :
     processShift X m ω n = X (m + n) ω := by
-  simp only [processShift]
-
-omit [MeasurableSpace Ω] [MeasurableSpace α] in
-/-- `processShift X m` is the `m`-fold path-space shift `(shift α)^[m]` of the process's path. -/
-theorem processShift_eq (X : ℕ → Ω → α) (m : ℕ) :
-    processShift X m = fun ω => (shift α)^[m] fun n => X n ω := by
-  funext ω n
-  simp [processShift, shift_iterate_apply, Nat.add_comm]
+  simp only [processShift, shift_iterate_apply, Nat.add_comm]
 
 /-- The shifted process is measurable when its tail coordinates `X (m + ·)` are. -/
 @[fun_prop]
 theorem measurable_processShift {X : ℕ → Ω → α} {m : ℕ} (hX : ∀ n, Measurable (X (m + n))) :
-    Measurable (processShift X m) :=
-  measurable_pi_lambda _ hX
+    Measurable (processShift X m) := by
+  refine measurable_pi_lambda _ fun n => ?_
+  simpa only [processShift_apply] using hX n
 
 end Probability
 

--- a/TauCeti/Probability/Exchangeability/PathSpace/ProcessShift.lean
+++ b/TauCeti/Probability/Exchangeability/PathSpace/ProcessShift.lean
@@ -14,7 +14,8 @@ block-product factorisation:
 The `processCons` / `processTail` operations on sequence-valued random variables, together with
 their σ-algebra-contraction lemmas, live in `TauCeti.Probability.Process.Tail`.
 
-Its exported API is the `@[simp]` coordinate equation `processShift_apply`.
+Its exported API is the `@[simp]` coordinate equation `processShift_apply` and the bridges to the
+path shift: `processShift_eq_shift_iterate` (composition) and `map_processShift` (measure level).
 
 Adapted from `cameronfreer/exchangeability` (`DeFinetti/ViaMartingale/ShiftOperations.lean`, pin
 `e0532e59ceff23edab44dda9ab0655debbc9cc22`).
@@ -50,6 +51,21 @@ theorem measurable_processShift {X : ℕ → Ω → α} {m : ℕ} (hX : ∀ n, M
     Measurable (processShift X m) := by
   refine measurable_pi_lambda _ fun n => ?_
   simpa only [processShift_apply] using hX n
+
+omit [MeasurableSpace Ω] [MeasurableSpace α] in
+/-- `processShift X m` is the `m`-fold path shift `(shift α)^[m]` composed with the process path. -/
+theorem processShift_eq_shift_iterate (X : ℕ → Ω → α) (m : ℕ) :
+    processShift X m = (shift α)^[m] ∘ fun ω n => X n ω := by
+  funext ω
+  simp only [processShift, Function.comp_apply]
+
+/-- Measure-level bridge: the law of the shifted process is the pushforward of the path law by the
+`m`-fold path shift `(shift α)^[m]`. -/
+theorem map_processShift (μ : Measure Ω) {X : ℕ → Ω → α} (hX : ∀ i, AEMeasurable (X i) μ) (m : ℕ) :
+    μ.map (processShift X m) = (pathLaw μ X).map ((shift α)^[m]) := by
+  rw [processShift_eq_shift_iterate, pathLaw_apply,
+    AEMeasurable.map_map_of_aemeasurable (measurable_shift_iterate m).aemeasurable
+      (aemeasurable_pi_lambda _ hX)]
 
 end Probability
 

--- a/TauCeti/Probability/Exchangeability/PathSpace/ProcessShift.lean
+++ b/TauCeti/Probability/Exchangeability/PathSpace/ProcessShift.lean
@@ -1,0 +1,90 @@
+module
+
+public import TauCeti.Probability.Exchangeability.Basic
+
+/-!
+# Process shift, cons, and tail operations
+
+Process-level path operations for a process `X : ℕ → Ω → α`, used to build the de Finetti
+block-product factorisation:
+
+* `shiftRV X m` — the shifted random path `ω ↦ (n ↦ X (m + n) ω)`;
+* `consRV x t` / `tailRV t` — prepend / drop the leading coordinate of a sequence-valued random
+  variable.
+
+The `comap` contraction lemmas (`comap_tailRV_le`, `comap_le_comap_consRV`) record that the tail of
+a sequence-valued random variable generates a coarser σ-algebra; they feed the Kallenberg
+conditional independence step of the factorisation.
+
+Adapted from `cameronfreer/exchangeability` (`DeFinetti/ViaMartingale/ShiftOperations.lean`, pin
+`e0532e59ceff23edab44dda9ab0655debbc9cc22`).
+-/
+
+public section
+
+noncomputable section
+
+open MeasureTheory
+
+namespace TauCeti
+
+namespace Probability
+
+variable {Ω α : Type*} [MeasurableSpace Ω] [MeasurableSpace α]
+
+/-- The shifted random path of a process: `ω ↦ (n ↦ X (m + n) ω)`. -/
+@[expose]
+def shiftRV (X : ℕ → Ω → α) (m : ℕ) : Ω → (ℕ → α) :=
+  fun ω n => X (m + n) ω
+
+/-- Cons a head random variable onto a sequence-valued one: `consRV x t` is `[x, t 0, t 1, …]`. -/
+@[expose]
+def consRV (x : Ω → α) (t : Ω → ℕ → α) : Ω → ℕ → α
+  | ω, 0 => x ω
+  | ω, (n + 1) => t ω n
+
+/-- Drop the leading coordinate of a sequence-valued random variable: `tailRV t ω n = t ω (n+1)`. -/
+@[expose]
+def tailRV (t : Ω → ℕ → α) : Ω → ℕ → α := fun ω n => t ω (n + 1)
+
+omit [MeasurableSpace Ω] [MeasurableSpace α] in
+@[simp]
+theorem tailRV_consRV (x : Ω → α) (t : Ω → ℕ → α) : tailRV (consRV x t) = t := rfl
+
+@[fun_prop]
+theorem measurable_shiftRV {X : ℕ → Ω → α} (hX : ∀ n, Measurable (X n)) (m : ℕ) :
+    Measurable (shiftRV X m) :=
+  measurable_pi_lambda _ fun n => hX (m + n)
+
+@[fun_prop]
+theorem measurable_consRV {x : Ω → α} {t : Ω → ℕ → α} (hx : Measurable x) (ht : Measurable t) :
+    Measurable (consRV x t) := by
+  refine measurable_pi_lambda _ fun n => ?_
+  cases n with
+  | zero => exact hx
+  | succ n => exact (measurable_pi_apply n).comp ht
+
+@[fun_prop]
+theorem measurable_tailRV {t : Ω → ℕ → α} (ht : Measurable t) : Measurable (tailRV t) :=
+  measurable_pi_lambda _ fun n => (measurable_pi_apply (n + 1)).comp ht
+
+omit [MeasurableSpace Ω] in
+/-- The tail of a sequence-valued random variable generates a coarser σ-algebra. -/
+theorem comap_tailRV_le {t : Ω → ℕ → α} :
+    MeasurableSpace.comap (tailRV t) inferInstance ≤ MeasurableSpace.comap t inferInstance := by
+  have hshift : Measurable fun s : ℕ → α => fun n => s (n + 1) := by fun_prop
+  rintro _ ⟨A, hA, rfl⟩
+  exact ⟨_, hA.preimage hshift, rfl⟩
+
+omit [MeasurableSpace Ω] in
+/-- Consing a head onto a sequence-valued random variable refines its σ-algebra: `σ(t) ≤
+σ(consRV x t)`. -/
+theorem comap_le_comap_consRV (x : Ω → α) (t : Ω → ℕ → α) :
+    MeasurableSpace.comap t inferInstance ≤ MeasurableSpace.comap (consRV x t) inferInstance :=
+  calc MeasurableSpace.comap t inferInstance
+      = MeasurableSpace.comap (tailRV (consRV x t)) inferInstance := by rw [tailRV_consRV]
+    _ ≤ MeasurableSpace.comap (consRV x t) inferInstance := comap_tailRV_le
+
+end Probability
+
+end TauCeti

--- a/TauCeti/Probability/Exchangeability/PathSpace/ProcessShift.lean
+++ b/TauCeti/Probability/Exchangeability/PathSpace/ProcessShift.lean
@@ -17,9 +17,9 @@ The `comap` contraction lemmas (`comap_processTail_le`, `comap_le_comap_processC
 the tail of a sequence-valued random variable generates a coarser σ-algebra; they feed the
 Kallenberg conditional independence step of the factorisation.
 
-The definitions keep `@[expose]` because their characteristic API is the computational `_apply`
-lemmas below, whose `rfl` proofs must unfold the definition body (an exported unfold requires the
-body to be exposed); downstream code uses those `@[simp]` lemmas rather than the raw body.
+The definitions are not `@[expose]`; their characteristic API is the `@[simp]` `_apply` /
+interaction lemmas below (proved through the equation lemmas), so downstream code reasons through
+those rather than the definition bodies.
 
 Adapted from `cameronfreer/exchangeability` (`DeFinetti/ViaMartingale/ShiftOperations.lean`, pin
 `e0532e59ceff23edab44dda9ab0655debbc9cc22`).
@@ -38,15 +38,14 @@ namespace Probability
 variable {Ω α : Type*} [MeasurableSpace Ω] [MeasurableSpace α]
 
 /-- The shifted random path of a process: `ω ↦ (n ↦ X (m + n) ω)`. -/
-@[expose]
 def processShift (X : ℕ → Ω → α) (m : ℕ) : Ω → (ℕ → α) :=
   fun ω n => X (m + n) ω
 
 omit [MeasurableSpace Ω] [MeasurableSpace α] in
 @[simp]
 theorem processShift_apply (X : ℕ → Ω → α) (m n : ℕ) (ω : Ω) :
-    processShift X m ω n = X (m + n) ω :=
-  rfl
+    processShift X m ω n = X (m + n) ω := by
+  simp only [processShift]
 
 omit [MeasurableSpace Ω] [MeasurableSpace α] in
 /-- `processShift X m` is the `m`-fold path-space shift `(shift α)^[m]` of the process's path. -/
@@ -56,37 +55,37 @@ theorem processShift_eq (X : ℕ → Ω → α) (m : ℕ) :
   simp [processShift, shift_iterate_apply, Nat.add_comm]
 
 /-- Cons a head random variable onto a sequence-valued one: `processCons x t = [x, t 0, t 1, …]`. -/
-@[expose]
 def processCons (x : Ω → α) (t : Ω → ℕ → α) : Ω → ℕ → α
   | ω, 0 => x ω
   | ω, (n + 1) => t ω n
 
 omit [MeasurableSpace Ω] [MeasurableSpace α] in
 @[simp]
-theorem processCons_zero (x : Ω → α) (t : Ω → ℕ → α) (ω : Ω) : processCons x t ω 0 = x ω :=
-  rfl
+theorem processCons_zero (x : Ω → α) (t : Ω → ℕ → α) (ω : Ω) : processCons x t ω 0 = x ω := by
+  simp only [processCons]
 
 omit [MeasurableSpace Ω] [MeasurableSpace α] in
 @[simp]
 theorem processCons_succ (x : Ω → α) (t : Ω → ℕ → α) (ω : Ω) (n : ℕ) :
-    processCons x t ω (n + 1) = t ω n :=
-  rfl
+    processCons x t ω (n + 1) = t ω n := by
+  simp only [processCons]
 
 /-- Drop the leading coordinate of a sequence-valued random variable: `processTail t ω n =
 t ω (n+1)`. -/
-@[expose]
 def processTail (t : Ω → ℕ → α) : Ω → ℕ → α := fun ω n => t ω (n + 1)
 
 omit [MeasurableSpace Ω] [MeasurableSpace α] in
 @[simp]
-theorem processTail_apply (t : Ω → ℕ → α) (ω : Ω) (n : ℕ) : processTail t ω n = t ω (n + 1) :=
-  rfl
+theorem processTail_apply (t : Ω → ℕ → α) (ω : Ω) (n : ℕ) : processTail t ω n = t ω (n + 1) := by
+  simp only [processTail]
 
 omit [MeasurableSpace Ω] [MeasurableSpace α] in
 /-- The tail of a cons recovers the original sequence. -/
 @[simp]
-theorem processTail_processCons (x : Ω → α) (t : Ω → ℕ → α) : processTail (processCons x t) = t :=
-  rfl
+theorem processTail_processCons (x : Ω → α) (t : Ω → ℕ → α) :
+    processTail (processCons x t) = t := by
+  funext ω n
+  simp only [processTail, processCons]
 
 /-- The shifted process is measurable when its tail coordinates `X (m + ·)` are. -/
 @[fun_prop]
@@ -110,13 +109,16 @@ theorem measurable_processTail {t : Ω → ℕ → α} (ht : Measurable t) :
   measurable_pi_lambda _ fun n => (measurable_pi_apply (n + 1)).comp ht
 
 omit [MeasurableSpace Ω] in
-/-- The tail of a sequence-valued random variable generates a coarser σ-algebra. -/
+/-- The tail of a sequence-valued random variable generates a coarser σ-algebra. It is the
+composition of the measurable index shift with `t`. -/
 theorem comap_processTail_le {t : Ω → ℕ → α} :
     MeasurableSpace.comap (processTail t) inferInstance
       ≤ MeasurableSpace.comap t inferInstance := by
+  have hcomp : processTail t = (fun s : ℕ → α => fun n => s (n + 1)) ∘ t := by
+    funext ω n; simp only [processTail, Function.comp_apply]
+  rw [hcomp, ← MeasurableSpace.comap_comp]
   have hshift : Measurable fun s : ℕ → α => fun n => s (n + 1) := by fun_prop
-  rintro _ ⟨A, hA, rfl⟩
-  exact ⟨_, hA.preimage hshift, rfl⟩
+  exact MeasurableSpace.comap_mono hshift.comap_le
 
 omit [MeasurableSpace Ω] in
 /-- Consing a head onto a sequence-valued random variable refines its σ-algebra: `σ(t) ≤

--- a/TauCeti/Probability/Process/Tail.lean
+++ b/TauCeti/Probability/Process/Tail.lean
@@ -2,9 +2,10 @@ module
 
 public import Mathlib.Probability.Process.Filtration
 public import Mathlib.Order.LiminfLimsup
+import Mathlib.Data.Stream.Init
 
 /-!
-# Tail σ-algebras of a process
+# Tail σ-algebras of a process, and cons/tail of sequence-valued random variables
 
 This file provides the process-relative tail σ-algebra API requested in the Exchangeability
 roadmap, Layer 2.  For a process `X : (k : ℕ) → Ω → β k`, `tailFamily X n` is the
@@ -12,6 +13,11 @@ roadmap, Layer 2.  For a process `X : (k : ℕ) → Ω → β k`, `tailFamily X 
 tail σ-algebra `limsup ... atTop` of the coordinate σ-algebras.  The same future σ-algebras are
 also bundled as a filtration indexed by `ℕᵒᵈ`, so later reverse-martingale statements can consume
 Mathlib's `Filtration` interface.
+
+It also provides the pointwise `Stream'.cons`/`Stream'.tail` operations `processCons`/`processTail`
+on sequence-valued random variables `t : Ω → ℕ → α`, with their measurability and `comap`
+σ-algebra-contraction lemmas — kept here because their contraction lemmas are exactly the tail
+σ-algebra facts the Kallenberg conditional-independence step of the de Finetti factorisation needs.
 -/
 
 public section
@@ -156,16 +162,17 @@ Adapted from `cameronfreer/exchangeability` (`DeFinetti/ViaMartingale/ShiftOpera
 
 variable {α : Type*} [MeasurableSpace α]
 
-/-- Cons a head random variable onto a sequence-valued one: `processCons x t = [x, t 0, t 1, …]`. -/
-def processCons (x : Ω → α) (t : Ω → ℕ → α) : Ω → ℕ → α
-  | ω, 0 => x ω
-  | ω, (n + 1) => t ω n
+/-- Cons a head random variable onto a sequence-valued one (a pointwise `Stream'.cons`):
+`processCons x t = [x, t 0, t 1, …]`. -/
+def processCons (x : Ω → α) (t : Ω → ℕ → α) : Ω → ℕ → α :=
+  fun ω => Stream'.cons (x ω) (t ω)
 
 omit [MeasurableSpace Ω] [MeasurableSpace α] in
 /-- Leading coordinate of a cons: `processCons x t ω 0 = x ω`. -/
 @[simp]
 theorem processCons_zero (x : Ω → α) (t : Ω → ℕ → α) (ω : Ω) : processCons x t ω 0 = x ω := by
   simp only [processCons]
+  exact Stream'.get_zero_cons (x ω) (t ω)
 
 omit [MeasurableSpace Ω] [MeasurableSpace α] in
 /-- Later coordinates of a cons: `processCons x t ω (n + 1) = t ω n`. -/
@@ -173,24 +180,37 @@ omit [MeasurableSpace Ω] [MeasurableSpace α] in
 theorem processCons_succ (x : Ω → α) (t : Ω → ℕ → α) (ω : Ω) (n : ℕ) :
     processCons x t ω (n + 1) = t ω n := by
   simp only [processCons]
+  exact Stream'.get_succ_cons n (t ω) (x ω)
 
-/-- Drop the leading coordinate of a sequence-valued random variable: `processTail t ω n =
-t ω (n+1)`. -/
-def processTail (t : Ω → ℕ → α) : Ω → ℕ → α := fun ω n => t ω (n + 1)
+/-- Drop the leading coordinate of a sequence-valued random variable (a pointwise `Stream'.tail`):
+`processTail t ω n = t ω (n+1)`. -/
+def processTail (t : Ω → ℕ → α) : Ω → ℕ → α :=
+  fun ω => Stream'.tail (t ω)
 
 omit [MeasurableSpace Ω] [MeasurableSpace α] in
 /-- Coordinate equation for `processTail`: its `n`th coordinate is `t (n + 1)`. -/
 @[simp]
 theorem processTail_apply (t : Ω → ℕ → α) (ω : Ω) (n : ℕ) : processTail t ω n = t ω (n + 1) := by
-  simp only [processTail]
+  simp only [processTail, Stream'.tail, Stream'.get]
 
 omit [MeasurableSpace Ω] [MeasurableSpace α] in
 /-- The tail of a cons recovers the original sequence. -/
 @[simp]
 theorem processTail_processCons (x : Ω → α) (t : Ω → ℕ → α) :
     processTail (processCons x t) = t := by
-  funext ω n
+  funext ω
   simp only [processTail, processCons]
+  exact Stream'.tail_cons (x ω) (t ω)
+
+omit [MeasurableSpace Ω] [MeasurableSpace α] in
+/-- Reconstruct a sequence from its head and tail (the reverse of `processTail_processCons`). -/
+@[simp]
+theorem processCons_processTail (t : Ω → ℕ → α) :
+    processCons (fun ω => t ω 0) (processTail t) = t := by
+  funext ω n
+  cases n with
+  | zero => simp only [processCons_zero]
+  | succ n => simp only [processCons_succ, processTail_apply]
 
 /-- Consing a measurable head onto a process is measurable when its coordinates `t (· ·)` are. -/
 @[fun_prop]
@@ -198,14 +218,15 @@ theorem measurable_processCons {x : Ω → α} {t : Ω → ℕ → α} (hx : Mea
     (ht : ∀ n, Measurable fun ω => t ω n) : Measurable (processCons x t) := by
   refine measurable_pi_lambda _ fun n => ?_
   cases n with
-  | zero => exact hx
-  | succ n => exact ht n
+  | zero => simpa only [processCons_zero] using hx
+  | succ n => simpa only [processCons_succ] using ht n
 
 /-- The tail of a process is measurable when its tail coordinates `t (· + 1)` are. -/
 @[fun_prop]
 theorem measurable_processTail {t : Ω → ℕ → α} (ht : ∀ n, Measurable fun ω => t ω (n + 1)) :
-    Measurable (processTail t) :=
-  measurable_pi_lambda _ ht
+    Measurable (processTail t) := by
+  refine measurable_pi_lambda _ fun n => ?_
+  simpa only [processTail_apply] using ht n
 
 omit [MeasurableSpace Ω] in
 /-- The tail of a sequence-valued random variable generates a coarser σ-algebra than the variable
@@ -214,7 +235,7 @@ theorem comap_processTail_le {t : Ω → ℕ → α} :
     MeasurableSpace.comap (processTail t) inferInstance
       ≤ MeasurableSpace.comap t inferInstance := by
   have hcomp : processTail t = (fun s : ℕ → α => fun n => s (n + 1)) ∘ t := by
-    funext ω n; simp only [processTail, Function.comp_apply]
+    funext ω n; simp only [processTail, Stream'.tail, Stream'.get, Function.comp_apply]
   rw [hcomp, ← MeasurableSpace.comap_comp]
   have hshift : Measurable fun s : ℕ → α => fun n => s (n + 1) := by fun_prop
   exact MeasurableSpace.comap_mono hshift.comap_le

--- a/TauCeti/Probability/Process/Tail.lean
+++ b/TauCeti/Probability/Process/Tail.lean
@@ -149,7 +149,10 @@ variable `t : Ω → ℕ → α`.  The `comap` contraction lemmas (`comap_proces
 `comap_le_comap_processCons`) record that the tail generates a coarser σ-algebra and that consing
 refines it; these feed the Kallenberg conditional-independence step of the de Finetti block-product
 factorisation.  The definitions are not `@[expose]`; their characteristic API is the `@[simp]`
-`_apply` / interaction lemmas below. -/
+`_apply` / interaction lemmas below.
+
+Adapted from `cameronfreer/exchangeability` (`DeFinetti/ViaMartingale/ShiftOperations.lean`, pin
+`e0532e59ceff23edab44dda9ab0655debbc9cc22`). -/
 
 variable {α : Type*} [MeasurableSpace α]
 
@@ -189,14 +192,14 @@ theorem processTail_processCons (x : Ω → α) (t : Ω → ℕ → α) :
   funext ω n
   simp only [processTail, processCons]
 
-/-- Consing a measurable head onto a measurable process is measurable. -/
+/-- Consing a measurable head onto a process is measurable when its coordinates `t (· ·)` are. -/
 @[fun_prop]
-theorem measurable_processCons {x : Ω → α} {t : Ω → ℕ → α} (hx : Measurable x) (ht : Measurable t) :
-    Measurable (processCons x t) := by
+theorem measurable_processCons {x : Ω → α} {t : Ω → ℕ → α} (hx : Measurable x)
+    (ht : ∀ n, Measurable fun ω => t ω n) : Measurable (processCons x t) := by
   refine measurable_pi_lambda _ fun n => ?_
   cases n with
   | zero => exact hx
-  | succ n => exact (measurable_pi_apply n).comp ht
+  | succ n => exact ht n
 
 /-- The tail of a process is measurable when its tail coordinates `t (· + 1)` are. -/
 @[fun_prop]
@@ -205,8 +208,8 @@ theorem measurable_processTail {t : Ω → ℕ → α} (ht : ∀ n, Measurable f
   measurable_pi_lambda _ ht
 
 omit [MeasurableSpace Ω] in
-/-- The tail of a sequence-valued random variable generates a coarser σ-algebra. It is the
-composition of the measurable index shift with `t`. -/
+/-- The tail of a sequence-valued random variable generates a coarser σ-algebra than the variable
+itself. -/
 theorem comap_processTail_le {t : Ω → ℕ → α} :
     MeasurableSpace.comap (processTail t) inferInstance
       ≤ MeasurableSpace.comap t inferInstance := by

--- a/TauCeti/Probability/Process/Tail.lean
+++ b/TauCeti/Probability/Process/Tail.lean
@@ -142,6 +142,90 @@ theorem measurable_futureFiltration_of_le {X : (k : ℕ) → Ω → β k}
   rw [futureFiltration_apply]
   exact measurable_tailFamily_of_le hnk
 
+/-! ## Cons and tail of sequence-valued random variables
+
+`processCons` / `processTail` prepend / drop the leading coordinate of a sequence-valued random
+variable `t : Ω → ℕ → α`.  The `comap` contraction lemmas (`comap_processTail_le`,
+`comap_le_comap_processCons`) record that the tail generates a coarser σ-algebra and that consing
+refines it; these feed the Kallenberg conditional-independence step of the de Finetti block-product
+factorisation.  The definitions are not `@[expose]`; their characteristic API is the `@[simp]`
+`_apply` / interaction lemmas below. -/
+
+variable {α : Type*} [MeasurableSpace α]
+
+/-- Cons a head random variable onto a sequence-valued one: `processCons x t = [x, t 0, t 1, …]`. -/
+def processCons (x : Ω → α) (t : Ω → ℕ → α) : Ω → ℕ → α
+  | ω, 0 => x ω
+  | ω, (n + 1) => t ω n
+
+omit [MeasurableSpace Ω] [MeasurableSpace α] in
+/-- Leading coordinate of a cons: `processCons x t ω 0 = x ω`. -/
+@[simp]
+theorem processCons_zero (x : Ω → α) (t : Ω → ℕ → α) (ω : Ω) : processCons x t ω 0 = x ω := by
+  simp only [processCons]
+
+omit [MeasurableSpace Ω] [MeasurableSpace α] in
+/-- Later coordinates of a cons: `processCons x t ω (n + 1) = t ω n`. -/
+@[simp]
+theorem processCons_succ (x : Ω → α) (t : Ω → ℕ → α) (ω : Ω) (n : ℕ) :
+    processCons x t ω (n + 1) = t ω n := by
+  simp only [processCons]
+
+/-- Drop the leading coordinate of a sequence-valued random variable: `processTail t ω n =
+t ω (n+1)`. -/
+def processTail (t : Ω → ℕ → α) : Ω → ℕ → α := fun ω n => t ω (n + 1)
+
+omit [MeasurableSpace Ω] [MeasurableSpace α] in
+/-- Coordinate equation for `processTail`: its `n`th coordinate is `t (n + 1)`. -/
+@[simp]
+theorem processTail_apply (t : Ω → ℕ → α) (ω : Ω) (n : ℕ) : processTail t ω n = t ω (n + 1) := by
+  simp only [processTail]
+
+omit [MeasurableSpace Ω] [MeasurableSpace α] in
+/-- The tail of a cons recovers the original sequence. -/
+@[simp]
+theorem processTail_processCons (x : Ω → α) (t : Ω → ℕ → α) :
+    processTail (processCons x t) = t := by
+  funext ω n
+  simp only [processTail, processCons]
+
+/-- Consing a measurable head onto a measurable process is measurable. -/
+@[fun_prop]
+theorem measurable_processCons {x : Ω → α} {t : Ω → ℕ → α} (hx : Measurable x) (ht : Measurable t) :
+    Measurable (processCons x t) := by
+  refine measurable_pi_lambda _ fun n => ?_
+  cases n with
+  | zero => exact hx
+  | succ n => exact (measurable_pi_apply n).comp ht
+
+/-- The tail of a process is measurable when its tail coordinates `t (· + 1)` are. -/
+@[fun_prop]
+theorem measurable_processTail {t : Ω → ℕ → α} (ht : ∀ n, Measurable fun ω => t ω (n + 1)) :
+    Measurable (processTail t) :=
+  measurable_pi_lambda _ ht
+
+omit [MeasurableSpace Ω] in
+/-- The tail of a sequence-valued random variable generates a coarser σ-algebra. It is the
+composition of the measurable index shift with `t`. -/
+theorem comap_processTail_le {t : Ω → ℕ → α} :
+    MeasurableSpace.comap (processTail t) inferInstance
+      ≤ MeasurableSpace.comap t inferInstance := by
+  have hcomp : processTail t = (fun s : ℕ → α => fun n => s (n + 1)) ∘ t := by
+    funext ω n; simp only [processTail, Function.comp_apply]
+  rw [hcomp, ← MeasurableSpace.comap_comp]
+  have hshift : Measurable fun s : ℕ → α => fun n => s (n + 1) := by fun_prop
+  exact MeasurableSpace.comap_mono hshift.comap_le
+
+omit [MeasurableSpace Ω] in
+/-- Consing a head onto a sequence-valued random variable refines its σ-algebra: `σ(t) ≤
+σ(processCons x t)`. -/
+theorem comap_le_comap_processCons (x : Ω → α) (t : Ω → ℕ → α) :
+    MeasurableSpace.comap t inferInstance ≤ MeasurableSpace.comap (processCons x t) inferInstance :=
+  calc MeasurableSpace.comap t inferInstance
+      = MeasurableSpace.comap (processTail (processCons x t)) inferInstance := by
+        rw [processTail_processCons]
+    _ ≤ MeasurableSpace.comap (processCons x t) inferInstance := comap_processTail_le
+
 end Probability
 
 end TauCeti


### PR DESCRIPTION
<!--tauceti-target:v1 {"focus":"Exchangeability","id":"factorization-support"}-->

## Summary

Foundational support for the de Finetti block-product factorisation, across three files:

**`Exchangeability/PathSpace/ProcessShift.lean`** — the process path shift:
- `processShift X m` — the shifted random path `ω ↦ (n ↦ X (m + n) ω)`, defined as the merged path
  shift `(shift α)^[m]` of the process's path, with `processShift_apply`, `measurable_processShift`,
  and the bridges `processShift_eq_shift_iterate` (composition) and `map_processShift` (measure level:
  `μ.map (processShift X m) = (pathLaw μ X).map ((shift α)^[m])`).

**`Process/Tail.lean`** (extended) — cons/tail of sequence-valued random variables:
- `processCons x t` / `processTail t` — prepend / drop the leading coordinate of a sequence-valued
  random variable, with `_apply` lemmas, `measurable_*`, and the `comap` contraction lemmas
  `comap_processTail_le`, `comap_le_comap_processCons` (`σ(processTail t) ≤ σ(t) ≤ σ(processCons x t)`),
  placed next to the existing tail-σ-algebra API.

**`Exchangeability/Cylinder.lean`** — block cylinders and indicator products, over a finite
coordinate selection `k : Fin m → ℕ` (the first-`r` prefix is the case `k = fun i => i.val`):
- `blockCylinder X k C = {ω | ∀ i, X (k i) ω ∈ C i}` + `mem_blockCylinder`,
  `measurableSet_blockCylinder`;
- `blockCylinder_eq_preimage_univ_pi` and `blockLaw_blockCylinder` — bridge the cylinder to the
  rectangle / `blockLaw` interface (`blockLaw_blockCylinder` is a `blockCylinder`-named restatement of
  the merged `blockLaw_apply_rectangle`);
- `blockIndicatorProd X k C ω = ∏ i, 𝟙_{C i}(X (k i) ω)`, with `blockIndicatorProd_eq_indicator`
  (the product is the cylinder indicator), `blockIndicatorProd_empty`, and `integrable_blockIndicatorProd`.

## Roadmap

Advances `TauCetiRoadmap/Exchangeability/README.md` — Layer 1 (*product kernels, conditional
independence, and mixtures*): these are the finite-dimensional events (block cylinders), integrands
(indicator products, bridged to `blockLaw` rectangles), and σ-algebra-contraction operations
(cons/tail/shift) that the **block-product factorisation** manipulates — the step that turns the
directing measure into a `ConditionallyIIDWith` witness (Layer 6, *directing measures and de Finetti
representation*). This PR is **support only** (no factorisation theorem yet); it is the first,
P1-independent slice of that work. Rebased onto current `main` (picks up #557's rectangle API).

## How it's proved (reuse)

Built on existing APIs: `processShift` is the merged path shift `(shift α)^[m]`; `processCons`/
`processTail` are pointwise `Stream'.cons`/`Stream'.tail`; `blockLaw_blockCylinder` is a
`blockCylinder`-named restatement of the merged `blockLaw_apply_rectangle` (#557, `@[grind =>]`).
The rest is elementary: `measurable_pi_lambda`/`measurable_pi_apply` for the combinators,
`MeasurableSpace.comap_comp` + `comap_mono` for the contraction lemmas, a `Finset.prod_eq_one`/
`prod_eq_zero` split (via the public `mem_blockCylinder`) for `blockIndicatorProd_eq_indicator`, and
`Integrable.indicator₀` over `nullMeasurableSet_blockCylinder` for integrability.

## Review notes
- **generality:** the cylinder/indicator API is over arbitrary finite selections `k : Fin m → ℕ`
  (`blockCylinder`/`blockIndicatorProd`), matching `blockLaw`; the first-`r` prefix is `k = val`.
  Measurability/integrability take the weakest coordinate hypotheses: `measurableSet_blockCylinder`
  takes `∀ i, Measurable (X (k i))`, `integrable_blockIndicatorProd` takes `∀ i, AEMeasurable (X (k i)) μ`
  (matching the `blockLaw` API), and `measurable_processCons`/`_processTail` take coordinatewise
  measurability.
- **api-design:** the definitions are **not** `@[expose]` — their characteristic API is the `@[simp]`
  `_apply` / `mem_*` / interaction lemmas (proved through the equation lemmas, which is
  exported-safe), so downstream reasons through those, not the bodies. `@[fun_prop]` on the
  measurability lemmas.
- **proof-quality:** proofs route through the public `mem_blockCylinder` and the stable
  `comap_comp`/`comap_mono` API rather than definitional unfolding.
- **placement:** the generic cons/tail sequence API lives in `Process/Tail.lean` next to the
  tail-σ-algebra API; only the path shift stays in `Exchangeability/PathSpace/ProcessShift.lean`.
  ⚠️ This adds declarations to `Process/Tail.lean`, which open PR #556 also edits — expect a merge
  conflict to resolve once one of the two lands.
- **scope:** support layer; the factorisation that consumes it is the next chunk, squarely on the
  de Finetti roadmap path.

## Test plan
```bash
lake build
lake exe axioms
lake exe module-system
```
All pass; sorry-free; axioms ⊆ {`propext`, `Classical.choice`, `Quot.sound`}; lines ≤100.

## Attribution
Adapted from `cameronfreer/exchangeability` (`DeFinetti/ViaMartingale/ShiftOperations.lean`,
`PathSpace/CylinderHelpers.lean`, `DeFinetti/ViaMartingale/IndicatorAlgebra.lean`, pin
`e0532e59ceff23edab44dda9ab0655debbc9cc22`), over Mathlib + the Tau Ceti Layer 0 API. Drafted with
Claude (Opus 4.8), human-directed.
