### PR TITLE
feat: add Hermite polynomial derivative identities and three-term recurrence

### DIFF
--- a/TauCeti/RingTheory/Polynomial/Hermite/Derivative.lean
+++ b/TauCeti/RingTheory/Polynomial/Hermite/Derivative.lean
@@ -46,15 +46,21 @@ theorem _root_.Polynomial.derivative_hermite_succ (n : ℕ) :
   induction n with
   | zero => simp
   | succ n ih =>
-    rw [hermite_succ (n + 1)]
-    simp only [derivative_sub, derivative_mul, derivative_X, one_mul, ih, derivative_smul]
-    rw [mul_smul_comm]
-    rw [add_sub_assoc, ← smul_sub, ← hermite_succ n]
-    simp [add_smul, one_smul, add_comm, add_left_comm]
-    ring_nf
+    calc
+      derivative (hermite (n + 1 + 1))
+          = derivative (X * hermite (n + 1) - derivative (hermite (n + 1))) := by
+            rw [hermite_succ]
+      _ = hermite (n + 1) + X * ((n + 1) • hermite n) -
+            derivative ((n + 1) • hermite n) := by
+            simp only [derivative_sub, derivative_mul, derivative_X, one_mul, ih, derivative_smul]
+      _ = (n + 1 + 1) • hermite (n + 1) := by
+            rw [hermite_succ n]
+            simp only [derivative_smul]
+            ring_nf
 
 /-- The Hermite derivative identity restated at index `n`: `H'ₙ = n · Hₙ₋₁`. For `n = 0` both sides
 vanish (`H₀ = 1`). -/
+@[simp]
 theorem _root_.Polynomial.derivative_hermite (n : ℕ) :
     derivative (hermite n) = n • hermite (n - 1) := by
   cases n with
@@ -64,6 +70,7 @@ theorem _root_.Polynomial.derivative_hermite (n : ℕ) :
 /-- Iterating the lowering identity: the `k`-th derivative of `Hₙ` is the descending factorial
 `n (n-1) ⋯ (n-k+1)` times `H_{n-k}`. For `k > n` the descending factorial is `0` and both sides
 vanish. -/
+@[simp]
 theorem _root_.Polynomial.iterate_derivative_hermite (n k : ℕ) :
     derivative^[k] (hermite n) = n.descFactorial k • hermite (n - k) := by
   induction k with

--- a/TauCeti/RingTheory/Polynomial/Hermite/Derivative.lean
+++ b/TauCeti/RingTheory/Polynomial/Hermite/Derivative.lean
@@ -1,0 +1,80 @@
+module
+
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Claude
+-/
+public import Mathlib.RingTheory.Polynomial.Hermite.Basic
+
+/-!
+# Derivatives and the three-term recurrence of the probabilists' Hermite polynomials
+
+Mathlib's `Mathlib/RingTheory/Polynomial/Hermite/Basic.lean` defines `Polynomial.hermite` by the
+one-step recursion `hermite (n + 1) = X * hermite n - derivative (hermite n)` and develops its
+coefficient API, but it records nothing about the *derivative* of a Hermite polynomial in closed
+form. This file fills that gap with the classical lowering identity
+
+  `derivative (hermite (n + 1)) = (n + 1) • hermite n`,
+
+its `n`-indexed restatement `derivative (hermite n) = n • hermite (n - 1)`, the iterated form
+`derivative^[k] (hermite n) = n.descFactorial k • hermite (n - k)`, and the three-term recurrence
+
+  `hermite (n + 2) = X * hermite (n + 1) - (n + 1) • hermite n`
+
+obtained by eliminating the derivative from Mathlib's defining recursion. These are the polynomial
+inputs (target **A1**) of the `OrthogonalL2Bases` roadmap: the lowering identity is the algebraic
+content behind the weighted-pairing integration-by-parts recursion
+`∫ p · H_{n+1} · w = ∫ p' · Hₙ · w` and behind the Hermite generating function, and the three-term
+recurrence is the standard form `Hₙ₊₁ = X·Hₙ - n·Hₙ₋₁` that orthogonal-polynomial arguments
+consume. They mirror Mathlib's existing Hermite file and are stated in the `Polynomial` namespace as
+upstream candidates.
+-/
+
+public section
+
+namespace TauCeti
+
+open Polynomial
+
+/-- **Lowering (derivative) identity for the Hermite polynomials.** Differentiating the
+`(n + 1)`-st probabilists' Hermite polynomial lowers the index:
+`H'_{n+1} = (n + 1) · Hₙ`. -/
+@[simp]
+theorem _root_.Polynomial.derivative_hermite_succ (n : ℕ) :
+    derivative (hermite (n + 1)) = (n + 1) • hermite n := by
+  induction n with
+  | zero => simp
+  | succ n ih =>
+    rw [hermite_succ (n + 1), derivative_sub, derivative_mul, derivative_X, one_mul, ih,
+      derivative_smul, mul_smul_comm, add_sub_assoc, ← smul_sub, ← hermite_succ n]
+    conv_rhs => rw [add_smul, one_smul]
+    exact add_comm _ _
+
+/-- The Hermite derivative identity restated at index `n`: `H'ₙ = n · Hₙ₋₁`. For `n = 0` both sides
+vanish (`H₀ = 1`). -/
+theorem _root_.Polynomial.derivative_hermite (n : ℕ) :
+    derivative (hermite n) = n • hermite (n - 1) := by
+  cases n with
+  | zero => simp [hermite_zero]
+  | succ n => simpa using derivative_hermite_succ n
+
+/-- Iterating the lowering identity: the `k`-th derivative of `Hₙ` is the descending factorial
+`n (n-1) ⋯ (n-k+1)` times `H_{n-k}`. For `k > n` the descending factorial is `0` and both sides
+vanish. -/
+theorem _root_.Polynomial.iterate_derivative_hermite (n k : ℕ) :
+    derivative^[k] (hermite n) = n.descFactorial k • hermite (n - k) := by
+  induction k with
+  | zero => simp
+  | succ k ih =>
+    rw [Function.iterate_succ_apply', ih, derivative_smul, derivative_hermite, smul_smul,
+      Nat.descFactorial_succ, Nat.sub_sub, mul_comm]
+
+/-- **Three-term recurrence for the Hermite polynomials.** Eliminating the derivative from Mathlib's
+defining recursion `hermite_succ` gives the classical relation `H_{n+2} = X·H_{n+1} - (n+1)·Hₙ`,
+i.e. `H_{m+1} = X·H_m - m·H_{m-1}`. -/
+theorem _root_.Polynomial.hermite_add_two (n : ℕ) :
+    hermite (n + 2) = X * hermite (n + 1) - (n + 1) • hermite n := by
+  rw [hermite_succ (n + 1), derivative_hermite_succ]
+
+end TauCeti

--- a/TauCeti/RingTheory/Polynomial/Hermite/Derivative.lean
+++ b/TauCeti/RingTheory/Polynomial/Hermite/Derivative.lean
@@ -46,10 +46,12 @@ theorem _root_.Polynomial.derivative_hermite_succ (n : ℕ) :
   induction n with
   | zero => simp
   | succ n ih =>
-    rw [hermite_succ (n + 1), derivative_sub, derivative_mul, derivative_X, one_mul, ih,
-      derivative_smul, mul_smul_comm, add_sub_assoc, ← smul_sub, ← hermite_succ n]
-    conv_rhs => rw [add_smul, one_smul]
-    exact add_comm _ _
+    rw [hermite_succ (n + 1)]
+    simp only [derivative_sub, derivative_mul, derivative_X, one_mul, ih, derivative_smul]
+    rw [mul_smul_comm]
+    rw [add_sub_assoc, ← smul_sub, ← hermite_succ n]
+    simp [add_smul, one_smul, add_comm, add_left_comm]
+    ring_nf
 
 /-- The Hermite derivative identity restated at index `n`: `H'ₙ = n · Hₙ₋₁`. For `n = 0` both sides
 vanish (`H₀ = 1`). -/


### PR DESCRIPTION
This PR adds the closed-form derivative API and the three-term recurrence of the probabilists' Hermite polynomials, which Mathlib's `Mathlib/RingTheory/Polynomial/Hermite/Basic.lean` does not record. It proves `Polynomial.derivative_hermite_succ` (`derivative (hermite (n + 1)) = (n + 1) • hermite n`), its `n`-indexed restatement `Polynomial.derivative_hermite` (`derivative (hermite n) = n • hermite (n - 1)`), the iterated form `Polynomial.iterate_derivative_hermite` (`derivative^[k] (hermite n) = n.descFactorial k • hermite (n - k)`), and `Polynomial.hermite_add_two` (`hermite (n + 2) = X * hermite (n + 1) - (n + 1) • hermite n`), obtained by eliminating the derivative from Mathlib's defining recursion `hermite_succ`.

This is target **A1** of the `OrthogonalL2Bases` roadmap (`TauCetiRoadmap/OrthogonalL2Bases/README.md`, "Part A1 — Hermite polynomial API", item `derivative_hermite_succ`). The lowering identity is the algebraic content behind the weighted-pairing integration-by-parts recursion `∫ p · H_{n+1} · w = ∫ p' · Hₙ · w` and the Hermite generating function that A1 still needs, and `hermite_add_two` is the standard orthogonal-polynomial recurrence `Hₙ₊₁ = X·Hₙ - n·Hₙ₋₁`. The declarations mirror Mathlib's existing Hermite file and live in the `Polynomial` namespace as upstream candidates, following the precedent of `HilbertBasis.mapₗᵢ` from this roadmap.

The new file is `TauCeti/RingTheory/Polynomial/Hermite/Derivative.lean`. It builds against the pinned Mathlib and passes the axiom audit (`propext`, `Classical.choice`, `Quot.sound` only). The naming follows Mathlib convention (`T_add_two` for the Chebyshev recurrence, `iterate_derivative_*`).

<!--tauceti-target:v1 {"focus":"OrthogonalL2Bases","id":"derivative-hermite-succ"}-->

🤖 Prepared with Claude Code
