### PR TITLE
feat(Analysis/CompletelyMonotone): Bernstein representation infrastructure (1/2)

### DIFF
--- a/TauCeti/Analysis/Calculus/IteratedDerivWithin.lean
+++ b/TauCeti/Analysis/Calculus/IteratedDerivWithin.lean
@@ -1,0 +1,117 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+module
+
+public import Mathlib.Analysis.Calculus.IteratedDeriv.Lemmas
+public import Mathlib.MeasureTheory.Integral.IntervalIntegral.ContDiff
+
+/-!
+# Generic lemmas for iterated derivatives within sets
+
+This file records calculus lemmas about `iteratedDerivWithin` and interval integrals that are
+independent of any completely-monotone or Bernstein-function structure.
+
+## Main declarations
+
+* `TauCeti.ContDiffOn.hasDerivAt_iteratedDerivWithin`: differentiability of an
+  `iteratedDerivWithin` on a neighbourhood inside a unique-differentiability set.
+* `TauCeti.ContDiffAt.iteratedDerivWithin_Icc_eq_Ici`: agreement of iterated derivatives within
+  `Icc x T` and `Ici a` at strict interior points.
+* `TauCeti.ContDiffOn.integral_neg_iteratedDerivWithin_one_Icc`,
+  `TauCeti.ContDiffOn.integral_neg_iteratedDerivWithin_one_Icc_zero_left`,
+  `TauCeti.ContDiffOn.integral_neg_iteratedDerivWithin_one_Icc_eq_Ici`: finite-interval
+  fundamental-theorem identities for first iterated derivatives within intervals.
+* `TauCeti.ContDiffOn.tendsto_total_mass`: convergence of the finite-interval total-mass
+  primitive under convergence at infinity.
+-/
+
+public section
+
+open MeasureTheory Set intervalIntegral Filter
+open scoped ContDiff Topology
+
+namespace TauCeti
+
+variable {E : Type*} [NormedAddCommGroup E] [NormedSpace ℝ E] {f : ℝ → E}
+
+/-- At a point `x` in the interior of a unique-differentiability set `s` (`s ∈ 𝓝 x`),
+the derivative of the `k`-th iterated derivative-within-`s` of a `C^(k+1)` function is the
+`(k+1)`-th iterated derivative-within-`s`. -/
+theorem ContDiffOn.hasDerivAt_iteratedDerivWithin
+    {𝕜 E : Type*} [NontriviallyNormedField 𝕜] [NormedAddCommGroup E] [NormedSpace 𝕜 E]
+    {g : 𝕜 → E} {s : Set 𝕜} {k : ℕ}
+    (hf : ContDiffOn 𝕜 ((k + 1 : ℕ) : WithTop ℕ∞) g s)
+    (hs : UniqueDiffOn 𝕜 s) {x : 𝕜} (hx : s ∈ nhds x) :
+    HasDerivAt (iteratedDerivWithin k g s) (iteratedDerivWithin (k + 1) g s x) x := by
+  have hklt : (k : WithTop ℕ∞) < ((k + 1 : ℕ) : WithTop ℕ∞) := by
+    exact_mod_cast (Nat.lt_succ_self k)
+  have hda := (hf.differentiableOn_iteratedDerivWithin
+    hklt hs).hasDerivAt hx
+  have hval : iteratedDerivWithin (k + 1) g s x =
+      deriv (iteratedDerivWithin k g s) x := by
+    rw [iteratedDerivWithin_succ, derivWithin_of_mem_nhds hx]
+  rw [hval]; exact hda
+
+/-- `iteratedDerivWithin` on `Icc x T` agrees with `iteratedDerivWithin` on `Ici a` at interior
+points, since both equal `iteratedDeriv n f t` under local smoothness at `t`. -/
+lemma ContDiffAt.iteratedDerivWithin_Icc_eq_Ici {n : ℕ}
+    {a x T t : ℝ} (hf : ContDiffAt ℝ (n : WithTop ℕ∞) f t) (ht_lo : a < t)
+    (ht : t ∈ Ioo x T) :
+    iteratedDerivWithin n f (Icc x T) t = iteratedDerivWithin n f (Ici a) t := by
+  have hxT : x < T := lt_trans ht.1 ht.2
+  rw [iteratedDerivWithin_eq_iteratedDeriv (uniqueDiffOn_Icc hxT) hf
+        (Ioo_subset_Icc_self ht),
+      ← iteratedDerivWithin_eq_iteratedDeriv (uniqueDiffOn_Ici a) hf
+        (mem_Ici.mpr ht_lo.le)]
+
+/-- The fundamental-theorem identity
+`f x - f T = ∫ₓᵀ -f'` on a compact interval, with the derivative represented as the first
+iterated derivative within that interval. -/
+lemma ContDiffOn.integral_neg_iteratedDerivWithin_one_Icc {x T : ℝ}
+    [CompleteSpace E] (hf : ContDiffOn ℝ 1 f (Icc x T)) (hxT : x ≤ T) :
+    f x - f T = ∫ t in x..T, -iteratedDerivWithin 1 f (Icc x T) t := by
+  have hFTC := intervalIntegral.integral_derivWithin_Icc_of_contDiffOn_Icc hf hxT
+  rw [iteratedDerivWithin_one]
+  rw [intervalIntegral.integral_neg, hFTC, neg_sub]
+
+/-- The zero-left specialization of
+`ContDiffOn.integral_neg_iteratedDerivWithin_one_Icc`. -/
+lemma ContDiffOn.integral_neg_iteratedDerivWithin_one_Icc_zero_left {T : ℝ}
+    [CompleteSpace E] (hf : ContDiffOn ℝ 1 f (Icc 0 T)) (hT : 0 ≤ T) :
+    ∫ t in (0 : ℝ)..T, -iteratedDerivWithin 1 f (Icc 0 T) t = f 0 - f T := by
+  exact (ContDiffOn.integral_neg_iteratedDerivWithin_one_Icc hf hT).symm
+
+/-- The interval integral of `-f'` with the `T`-dependent set `Icc x T` equals the integral with
+the fixed set `Ici a`, under local smoothness at the strict interior points. The derivative is
+represented as `iteratedDerivWithin 1`. -/
+lemma ContDiffOn.integral_neg_iteratedDerivWithin_one_Icc_eq_Ici
+    {a x T : ℝ} (hf : ∀ t ∈ Ioo x T, ContDiffAt ℝ 1 f t) (hax : a ≤ x) (hxT : x ≤ T) :
+    ∫ t in x..T, -iteratedDerivWithin 1 f (Icc x T) t =
+    ∫ t in x..T, -iteratedDerivWithin 1 f (Ici a) t := by
+  apply intervalIntegral.integral_congr_uIoo
+  intro t ht
+  rw [uIoo_of_le hxT] at ht
+  have ha_lt : a < t := lt_of_le_of_lt hax ht.1
+  have hxT_pos : x < T := lt_trans ht.1 ht.2
+  have hcda : ContDiffAt ℝ 1 f t := hf t ht
+  simp only [iteratedDerivWithin_eq_iteratedDeriv (uniqueDiffOn_Icc hxT_pos) hcda
+      (Ioo_subset_Icc_self ht),
+    iteratedDerivWithin_eq_iteratedDeriv (uniqueDiffOn_Ici a) hcda
+      (mem_Ici.mpr ha_lt.le)]
+
+/-- The total mass `∫ₐᵀ (-f') dt → f(a) - L` as `T → ∞`, assuming smoothness on
+`[a, ∞)` and convergence of `f` to `L` at infinity. The derivative is represented as
+`iteratedDerivWithin 1`. -/
+lemma ContDiffOn.tendsto_total_mass
+    [CompleteSpace E] {a : ℝ} (hf : ContDiffOn ℝ 1 f (Ici a)) {L : E}
+    (hL : Tendsto f atTop (nhds L)) :
+    Tendsto (fun T => ∫ t in a..T, -iteratedDerivWithin 1 f (Icc a T) t) atTop
+        (nhds (f a - L)) := by
+  refine Tendsto.congr' (EventuallyEq.symm ?_) (Tendsto.sub tendsto_const_nhds hL)
+  exact (eventually_gt_atTop a).mono fun T hT =>
+    (ContDiffOn.integral_neg_iteratedDerivWithin_one_Icc
+      (hf.mono Icc_subset_Ici_self) hT.le).symm
+
+end TauCeti

--- a/TauCeti/Analysis/Calculus/IteratedDerivWithin.lean
+++ b/TauCeti/Analysis/Calculus/IteratedDerivWithin.lean
@@ -23,8 +23,8 @@ independent of any completely-monotone or Bernstein-function structure.
   `TauCeti.ContDiffOn.integral_neg_iteratedDerivWithin_one_Icc_zero_left`,
   `TauCeti.ContDiffOn.integral_neg_iteratedDerivWithin_one_Icc_eq_Ici`: finite-interval
   fundamental-theorem identities for first iterated derivatives within intervals.
-* `TauCeti.ContDiffOn.tendsto_total_mass`: convergence of the finite-interval total-mass
-  primitive under convergence at infinity.
+* `TauCeti.ContDiffOn.tendsto_integral_neg_iteratedDerivWithin_one_Icc_atTop`: convergence of
+  the finite-interval primitive under convergence at infinity.
 -/
 
 public section
@@ -101,10 +101,10 @@ lemma ContDiffOn.integral_neg_iteratedDerivWithin_one_Icc_eq_Ici
     iteratedDerivWithin_eq_iteratedDeriv (uniqueDiffOn_Ici a) hcda
       (mem_Ici.mpr ha_lt.le)]
 
-/-- The total mass `∫ₐᵀ (-f') dt → f(a) - L` as `T → ∞`, assuming smoothness on
+/-- The integral `∫ₐᵀ (-f') dt → f(a) - L` as `T → ∞`, assuming smoothness on
 `[a, ∞)` and convergence of `f` to `L` at infinity. The derivative is represented as
 `iteratedDerivWithin 1`. -/
-lemma ContDiffOn.tendsto_total_mass
+lemma ContDiffOn.tendsto_integral_neg_iteratedDerivWithin_one_Icc_atTop
     [CompleteSpace E] {a : ℝ} (hf : ContDiffOn ℝ 1 f (Ici a)) {L : E}
     (hL : Tendsto f atTop (nhds L)) :
     Tendsto (fun T => ∫ t in a..T, -iteratedDerivWithin 1 f (Icc a T) t) atTop

--- a/TauCeti/Analysis/CompletelyMonotone/Basic.lean
+++ b/TauCeti/Analysis/CompletelyMonotone/Basic.lean
@@ -209,13 +209,16 @@ end IsCompletelyMonotone
 variable {f : ℝ → ℝ}
 
 /-- At a point `x` in the interior of a unique-differentiability set `s` (`s ∈ 𝓝 x`),
-the derivative of the `k`-th iterated derivative-within-`s` of a `C^∞` function is the
+the derivative of the `k`-th iterated derivative-within-`s` of a `C^(k+1)` function is the
 `(k+1)`-th iterated derivative-within-`s`. -/
 theorem ContDiffOn.hasDerivAt_iteratedDerivWithin
-    (hf : ContDiffOn ℝ ∞ f s) (hs : UniqueDiffOn ℝ s) (k : ℕ) {x : ℝ} (hx : s ∈ nhds x) :
+    {k : ℕ} (hf : ContDiffOn ℝ ((k + 1 : ℕ) : WithTop ℕ∞) f s)
+    (hs : UniqueDiffOn ℝ s) {x : ℝ} (hx : s ∈ nhds x) :
     HasDerivAt (iteratedDerivWithin k f s) (iteratedDerivWithin (k + 1) f s x) x := by
+  have hklt : (k : WithTop ℕ∞) < ((k + 1 : ℕ) : WithTop ℕ∞) := by
+    exact_mod_cast (Nat.lt_succ_self k)
   have hda := (hf.differentiableOn_iteratedDerivWithin
-    (WithTop.coe_lt_coe.mpr (WithTop.coe_lt_top k)) hs).hasDerivAt hx
+    hklt hs).hasDerivAt hx
   have hval : iteratedDerivWithin (k + 1) f s x =
       deriv (iteratedDerivWithin k f s) x := by
     rw [iteratedDerivWithin_succ, derivWithin_of_mem_nhds hx]
@@ -230,9 +233,10 @@ differentiable at any `t > 0`, with derivative the `(k+1)`-th iterated derivativ
 lemma hasDerivAt_iteratedDerivWithin_succ
     (hcm : IsCompletelyMonotone f) (k : ℕ) {t : ℝ} (ht : 0 < t) :
     HasDerivAt (iteratedDerivWithin k f (Ici 0))
-      (iteratedDerivWithin (k + 1) f (Ici 0) t) t :=
-  ContDiffOn.hasDerivAt_iteratedDerivWithin hcm.contDiffOn (uniqueDiffOn_Ici 0) k
-    (Ici_mem_nhds ht)
+      (iteratedDerivWithin (k + 1) f (Ici 0) t) t := by
+  have horder : ((k + 1 : ℕ) : WithTop ℕ∞) ≤ ∞ := by exact_mod_cast le_top
+  exact ContDiffOn.hasDerivAt_iteratedDerivWithin (k := k)
+    (hcm.contDiffOn.of_le horder) (uniqueDiffOn_Ici 0) (Ici_mem_nhds ht)
 
 /-- Completely monotone functions are closed under addition. -/
 lemma add (hf : IsCompletelyMonotone f) (hg : IsCompletelyMonotone g) :

--- a/TauCeti/Analysis/CompletelyMonotone/Basic.lean
+++ b/TauCeti/Analysis/CompletelyMonotone/Basic.lean
@@ -206,21 +206,20 @@ lemma le_of_tendsto_atTop (hcm : IsCompletelyMonotone f) {L : ℝ}
 
 end IsCompletelyMonotone
 
-variable {f : ℝ → ℝ}
-
 /-- At a point `x` in the interior of a unique-differentiability set `s` (`s ∈ 𝓝 x`),
 the derivative of the `k`-th iterated derivative-within-`s` of a `C^(k+1)` function is the
 `(k+1)`-th iterated derivative-within-`s`. -/
 theorem ContDiffOn.hasDerivAt_iteratedDerivWithin
-    {k : ℕ} (hf : ContDiffOn ℝ ((k + 1 : ℕ) : WithTop ℕ∞) f s)
+    {E : Type*} [NormedAddCommGroup E] [NormedSpace ℝ E] {g : ℝ → E}
+    {k : ℕ} (hf : ContDiffOn ℝ ((k + 1 : ℕ) : WithTop ℕ∞) g s)
     (hs : UniqueDiffOn ℝ s) {x : ℝ} (hx : s ∈ nhds x) :
-    HasDerivAt (iteratedDerivWithin k f s) (iteratedDerivWithin (k + 1) f s x) x := by
+    HasDerivAt (iteratedDerivWithin k g s) (iteratedDerivWithin (k + 1) g s x) x := by
   have hklt : (k : WithTop ℕ∞) < ((k + 1 : ℕ) : WithTop ℕ∞) := by
     exact_mod_cast (Nat.lt_succ_self k)
   have hda := (hf.differentiableOn_iteratedDerivWithin
     hklt hs).hasDerivAt hx
-  have hval : iteratedDerivWithin (k + 1) f s x =
-      deriv (iteratedDerivWithin k f s) x := by
+  have hval : iteratedDerivWithin (k + 1) g s x =
+      deriv (iteratedDerivWithin k g s) x := by
     rw [iteratedDerivWithin_succ, derivWithin_of_mem_nhds hx]
   rw [hval]; exact hda
 

--- a/TauCeti/Analysis/CompletelyMonotone/Basic.lean
+++ b/TauCeti/Analysis/CompletelyMonotone/Basic.lean
@@ -210,9 +210,10 @@ end IsCompletelyMonotone
 the derivative of the `k`-th iterated derivative-within-`s` of a `C^(k+1)` function is the
 `(k+1)`-th iterated derivative-within-`s`. -/
 theorem ContDiffOn.hasDerivAt_iteratedDerivWithin
-    {E : Type*} [NormedAddCommGroup E] [NormedSpace ℝ E] {g : ℝ → E}
-    {k : ℕ} (hf : ContDiffOn ℝ ((k + 1 : ℕ) : WithTop ℕ∞) g s)
-    (hs : UniqueDiffOn ℝ s) {x : ℝ} (hx : s ∈ nhds x) :
+    {𝕜 E : Type*} [NontriviallyNormedField 𝕜] [NormedAddCommGroup E] [NormedSpace 𝕜 E]
+    {g : 𝕜 → E} {s : Set 𝕜} {k : ℕ}
+    (hf : ContDiffOn 𝕜 ((k + 1 : ℕ) : WithTop ℕ∞) g s)
+    (hs : UniqueDiffOn 𝕜 s) {x : 𝕜} (hx : s ∈ nhds x) :
     HasDerivAt (iteratedDerivWithin k g s) (iteratedDerivWithin (k + 1) g s x) x := by
   have hklt : (k : WithTop ℕ∞) < ((k + 1 : ℕ) : WithTop ℕ∞) := by
     exact_mod_cast (Nat.lt_succ_self k)

--- a/TauCeti/Analysis/CompletelyMonotone/Basic.lean
+++ b/TauCeti/Analysis/CompletelyMonotone/Basic.lean
@@ -6,9 +6,9 @@ module
 
 public import Mathlib.Analysis.Calculus.AbsolutelyMonotone
 public import Mathlib.Analysis.Calculus.Deriv.MeanValue
-public import Mathlib.Analysis.Calculus.IteratedDeriv.Lemmas
 public import Mathlib.Analysis.SpecialFunctions.ExpDeriv
 public import Mathlib.Topology.Order.MonotoneConvergence
+public import TauCeti.Analysis.Calculus.IteratedDerivWithin
 
 /-!
 # Completely monotone functions
@@ -205,24 +205,6 @@ lemma le_of_tendsto_atTop (hcm : IsCompletelyMonotone f) {L : ℝ}
   simpa [hg₀, max_eq_left hT] using this
 
 end IsCompletelyMonotone
-
-/-- At a point `x` in the interior of a unique-differentiability set `s` (`s ∈ 𝓝 x`),
-the derivative of the `k`-th iterated derivative-within-`s` of a `C^(k+1)` function is the
-`(k+1)`-th iterated derivative-within-`s`. -/
-theorem ContDiffOn.hasDerivAt_iteratedDerivWithin
-    {𝕜 E : Type*} [NontriviallyNormedField 𝕜] [NormedAddCommGroup E] [NormedSpace 𝕜 E]
-    {g : 𝕜 → E} {s : Set 𝕜} {k : ℕ}
-    (hf : ContDiffOn 𝕜 ((k + 1 : ℕ) : WithTop ℕ∞) g s)
-    (hs : UniqueDiffOn 𝕜 s) {x : 𝕜} (hx : s ∈ nhds x) :
-    HasDerivAt (iteratedDerivWithin k g s) (iteratedDerivWithin (k + 1) g s x) x := by
-  have hklt : (k : WithTop ℕ∞) < ((k + 1 : ℕ) : WithTop ℕ∞) := by
-    exact_mod_cast (Nat.lt_succ_self k)
-  have hda := (hf.differentiableOn_iteratedDerivWithin
-    hklt hs).hasDerivAt hx
-  have hval : iteratedDerivWithin (k + 1) g s x =
-      deriv (iteratedDerivWithin k g s) x := by
-    rw [iteratedDerivWithin_succ, derivWithin_of_mem_nhds hx]
-  rw [hval]; exact hda
 
 namespace IsCompletelyMonotone
 

--- a/TauCeti/Analysis/CompletelyMonotone/Basic.lean
+++ b/TauCeti/Analysis/CompletelyMonotone/Basic.lean
@@ -8,6 +8,7 @@ public import Mathlib.Analysis.Calculus.AbsolutelyMonotone
 public import Mathlib.Analysis.Calculus.Deriv.MeanValue
 public import Mathlib.Analysis.Calculus.IteratedDeriv.Lemmas
 public import Mathlib.Analysis.SpecialFunctions.ExpDeriv
+public import Mathlib.Topology.Order.MonotoneConvergence
 
 /-!
 # Completely monotone functions
@@ -40,6 +41,9 @@ point `0`); on the open half-line it agrees with the ordinary iterated derivativ
 * `TauCeti.IsCompletelyMonotone.nonneg`, `TauCeti.IsCompletelyMonotone.derivWithin_nonpos`,
   `TauCeti.IsCompletelyMonotone.antitoneOn`: a completely monotone function is nonnegative
   and nonincreasing on `[0, ∞)`.
+* `TauCeti.IsCompletelyMonotone.tendsto_atTop`,
+  `TauCeti.IsCompletelyMonotone.le_of_tendsto_atTop`: order-limit consequences of
+  nonnegativity and monotonicity on `[0, ∞)`.
 * `TauCeti.IsCompletelyMonotone.neg_one_pow_mul_iteratedDeriv_nonneg`: on the open half-line,
   the sign condition also holds for ordinary iterated derivatives.
 * `TauCeti.IsCompletelyMonotone.add`, `TauCeti.IsCompletelyMonotone.smul`: closure under
@@ -173,6 +177,62 @@ lemma antitoneOn (hf : IsCompletelyMonotone f) : AntitoneOn f (Ici 0) := by
   have hmem : Ici (0 : ℝ) ∈ 𝓝 x := mem_of_superset (isOpen_Ioi.mem_nhds hx) Ioi_subset_Ici_self
   rw [← derivWithin_of_mem_nhds hmem]
   exact hf.derivWithin_nonpos (le_of_lt hx)
+
+/-- A completely monotone function has a limit `L ≥ 0` at infinity: it is antitone on `[0, ∞)`
+and bounded below by `0`. -/
+lemma tendsto_atTop (hf : IsCompletelyMonotone f) :
+    ∃ L, Tendsto f atTop (nhds L) ∧ 0 ≤ L := by
+  have hanti := hf.antitoneOn
+  set g := fun t : ℝ => f (max t 0) with hg
+  have hg_anti : Antitone g := fun a b hab =>
+    hanti (mem_Ici.mpr (le_max_right _ _)) (mem_Ici.mpr (le_max_right _ _))
+      (max_le_max_right 0 hab)
+  have hg_bdd : BddBelow (Set.range g) :=
+    ⟨0, fun _ ⟨t, ht⟩ => ht ▸ hf.nonneg (le_max_right _ _)⟩
+  refine ⟨⨅ i, g i, ?_, le_ciInf (fun _ => hf.nonneg (le_max_right _ _))⟩
+  exact (tendsto_atTop_ciInf hg_anti hg_bdd).congr'
+    (eventually_atTop.mpr ⟨0, fun t ht => by simp [hg, max_eq_left ht]⟩)
+
+/-- A completely monotone function lies above its limit at infinity on `[0, ∞)`. -/
+lemma le_of_tendsto_atTop (hcm : IsCompletelyMonotone f) {L : ℝ}
+    (hL : Tendsto f atTop (nhds L)) {T : ℝ} (hT : 0 ≤ T) : L ≤ f T := by
+  set g₀ := fun t : ℝ => f (max t 0) with hg₀
+  have hg_anti : Antitone g₀ := fun a b hab =>
+    hcm.antitoneOn (mem_Ici.mpr (le_max_right _ _)) (mem_Ici.mpr (le_max_right _ _))
+      (max_le_max_right 0 hab)
+  have := hg_anti.le_of_tendsto
+    (hL.congr' (eventually_atTop.mpr ⟨0, fun t ht => by simp [hg₀, max_eq_left ht]⟩)) T
+  simpa [hg₀, max_eq_left hT] using this
+
+end IsCompletelyMonotone
+
+variable {f : ℝ → ℝ}
+
+/-- At a point `x` in the interior of a unique-differentiability set `s` (`s ∈ 𝓝 x`),
+the derivative of the `k`-th iterated derivative-within-`s` of a `C^∞` function is the
+`(k+1)`-th iterated derivative-within-`s`. -/
+theorem ContDiffOn.hasDerivAt_iteratedDerivWithin
+    (hf : ContDiffOn ℝ ∞ f s) (hs : UniqueDiffOn ℝ s) (k : ℕ) {x : ℝ} (hx : s ∈ nhds x) :
+    HasDerivAt (iteratedDerivWithin k f s) (iteratedDerivWithin (k + 1) f s x) x := by
+  have hda := (hf.differentiableOn_iteratedDerivWithin
+    (WithTop.coe_lt_coe.mpr (WithTop.coe_lt_top k)) hs).hasDerivAt hx
+  have hval : iteratedDerivWithin (k + 1) f s x =
+      deriv (iteratedDerivWithin k f s) x := by
+    rw [iteratedDerivWithin_succ, derivWithin_of_mem_nhds hx]
+  rw [hval]; exact hda
+
+namespace IsCompletelyMonotone
+
+variable {f g : ℝ → ℝ}
+
+/-- For a completely monotone `f`, the `k`-th iterated derivative within `[0, ∞)` is
+differentiable at any `t > 0`, with derivative the `(k+1)`-th iterated derivative. -/
+lemma hasDerivAt_iteratedDerivWithin_succ
+    (hcm : IsCompletelyMonotone f) (k : ℕ) {t : ℝ} (ht : 0 < t) :
+    HasDerivAt (iteratedDerivWithin k f (Ici 0))
+      (iteratedDerivWithin (k + 1) f (Ici 0) t) t :=
+  ContDiffOn.hasDerivAt_iteratedDerivWithin hcm.contDiffOn (uniqueDiffOn_Ici 0) k
+    (Ici_mem_nhds ht)
 
 /-- Completely monotone functions are closed under addition. -/
 lemma add (hf : IsCompletelyMonotone f) (hg : IsCompletelyMonotone g) :

--- a/TauCeti/Analysis/CompletelyMonotone/Basic.lean
+++ b/TauCeti/Analysis/CompletelyMonotone/Basic.lean
@@ -41,7 +41,7 @@ point `0`); on the open half-line it agrees with the ordinary iterated derivativ
 * `TauCeti.IsCompletelyMonotone.nonneg`, `TauCeti.IsCompletelyMonotone.derivWithin_nonpos`,
   `TauCeti.IsCompletelyMonotone.antitoneOn`: a completely monotone function is nonnegative
   and nonincreasing on `[0, ∞)`.
-* `TauCeti.IsCompletelyMonotone.tendsto_atTop`,
+* `TauCeti.IsCompletelyMonotone.exists_nonneg_tendsto_atTop`,
   `TauCeti.IsCompletelyMonotone.le_of_tendsto_atTop`: order-limit consequences of
   nonnegativity and monotonicity on `[0, ∞)`.
 * `TauCeti.IsCompletelyMonotone.neg_one_pow_mul_iteratedDeriv_nonneg`: on the open half-line,
@@ -180,7 +180,7 @@ lemma antitoneOn (hf : IsCompletelyMonotone f) : AntitoneOn f (Ici 0) := by
 
 /-- A completely monotone function has a limit `L ≥ 0` at infinity: it is antitone on `[0, ∞)`
 and bounded below by `0`. -/
-lemma tendsto_atTop (hf : IsCompletelyMonotone f) :
+lemma exists_nonneg_tendsto_atTop (hf : IsCompletelyMonotone f) :
     ∃ L, Tendsto f atTop (nhds L) ∧ 0 ≤ L := by
   have hanti := hf.antitoneOn
   set g := fun t : ℝ => f (max t 0) with hg

--- a/TauCeti/Analysis/CompletelyMonotone/Basic.lean
+++ b/TauCeti/Analysis/CompletelyMonotone/Basic.lean
@@ -89,6 +89,7 @@ lemma isCompletelyMonotone_iff_absolutelyMonotoneOn_comp_neg {f : ℝ → ℝ} :
   rw [isCompletelyMonotone_iff,
     AbsolutelyMonotoneOn.iff_iteratedDerivWithin_nonneg (uniqueDiffOn_Iic 0)]
   constructor
+  -- Reflect smoothness and the alternating-sign condition from `[0, ∞)` to `(-∞, 0]`.
   · rintro ⟨hcont, hsign⟩
     refine ⟨?_, fun n u hu => ?_⟩
     · have hpre : ((-ContinuousLinearMap.id ℝ ℝ) ⁻¹' Ici 0) = Iic 0 := by
@@ -103,6 +104,7 @@ lemma isCompletelyMonotone_iff_absolutelyMonotoneOn_comp_neg {f : ℝ → ℝ} :
         simp
       rw [hset]
       simpa [smul_eq_mul] using hsign n (-u) (neg_nonneg.mpr hu)
+  -- Reflect the absolutely-monotone data back to the original closed half-line.
   · rintro ⟨hcont, hsign⟩
     refine ⟨?_, fun n t ht => ?_⟩
     · have hpre : ((-ContinuousLinearMap.id ℝ ℝ) ⁻¹' Iic 0) = Ici 0 := by

--- a/TauCeti/Analysis/CompletelyMonotone/BernsteinMeasures.lean
+++ b/TauCeti/Analysis/CompletelyMonotone/BernsteinMeasures.lean
@@ -545,7 +545,7 @@ lemma chafaiMeasure_finite_mass (f : ℝ → ℝ) (hcm : IsCompletelyMonotone f)
       ∀ n,
         IsFiniteMeasure (chafaiMeasure f n) ∧
         (chafaiMeasure f n) univ ≤ ENNReal.ofReal (f 0 - L) := by
-  obtain ⟨L, hL, hL_nn⟩ := hcm.tendsto_atTop
+  obtain ⟨L, hL, hL_nn⟩ := hcm.exists_nonneg_tendsto_atTop
   exact ⟨L, hL, hL_nn, fun n => chafaiMeasure_finite_mass_of_tendsto f hcm n L hL⟩
 
 /-- **Natural rescaled total mass bound**: for a completely monotone `f`, the rescaled

--- a/TauCeti/Analysis/CompletelyMonotone/BernsteinMeasures.lean
+++ b/TauCeti/Analysis/CompletelyMonotone/BernsteinMeasures.lean
@@ -23,8 +23,10 @@ These build on the `IsCompletelyMonotone` API in `CompletelyMonotone/Basic.lean`
 ## Main declarations
 
 * `TauCeti.chafaiDensity`, `TauCeti.chafaiMeasure`: the approximating densities and measures.
-* `TauCeti.bernstein_kernel`, `TauCeti.bernstein_kernel_tendsto`: the rescaled Laplace kernel and
-  its pointwise limit `e^{-xp}`.
+* `TauCeti.bernstein_kernel`, `TauCeti.continuous_bernstein_kernel`,
+  `TauCeti.bernstein_kernel_nonneg`, `TauCeti.bernstein_kernel_le_one`,
+  `TauCeti.bernstein_kernel_tendsto`: the rescaled Laplace kernel, its bounded-continuous
+  `p`-dependence on the nonnegative half-line, and its pointwise limit `e^{-xp}`.
 * `TauCeti.chafaiRescaled`, `TauCeti.chafaiRescaled_mass_eq`: the `ℝ≥0`-valued pushed-forward
   measures and mass preservation.
 * `TauCeti.chafaiMeasure_finite_mass`, `TauCeti.chafaiRescaled_finite_mass`: finiteness and the
@@ -163,6 +165,19 @@ private lemma chafaiDensity_succ_succ_sub_succ (f : ℝ → ℝ) (m : ℕ) (t : 
   field_simp
   ring
 
+private lemma ContDiffOn.hasDerivAt_iteratedDerivWithin_of_nat {s : Set ℝ} {k : ℕ}
+    (hf : ContDiffOn ℝ ((k + 1 : ℕ) : WithTop ℕ∞) f s) (hs : UniqueDiffOn ℝ s)
+    {x : ℝ} (hx : s ∈ nhds x) :
+    HasDerivAt (iteratedDerivWithin k f s) (iteratedDerivWithin (k + 1) f s x) x := by
+  have hklt : (k : WithTop ℕ∞) < ((k + 1 : ℕ) : WithTop ℕ∞) := by
+    exact_mod_cast (Nat.lt_succ_self k)
+  have hda := (hf.differentiableOn_iteratedDerivWithin hklt hs).hasDerivAt hx
+  have hval : iteratedDerivWithin (k + 1) f s x =
+      deriv (iteratedDerivWithin k f s) x := by
+    rw [iteratedDerivWithin_succ, derivWithin_of_mem_nhds hx]
+  rw [hval]
+  exact hda
+
 /-! ## Rescaled measures and Prokhorov extraction -/
 
 /-- The Bernstein kernel `φ_n(x,p) = max(1 - xp/(n-1), 0)ⁿ⁻¹` for `n ≥ 2`. After the change of
@@ -182,9 +197,28 @@ lemma bernstein_kernel_of_two_le {n : ℕ} (hn : 2 ≤ n) (x p : ℝ) :
   have hnle : ¬ n ≤ 1 := by omega
   rw [bernstein_kernel, if_neg hnle]
 
+/-- The Bernstein kernel is continuous in `p` for fixed `n` and `x`. -/
+lemma continuous_bernstein_kernel (n : ℕ) (x : ℝ) : Continuous (bernstein_kernel n x) := by
+  unfold bernstein_kernel
+  split_ifs <;> fun_prop
+
 /-- The Bernstein kernel is nonnegative. -/
 @[simp] lemma bernstein_kernel_nonneg (n : ℕ) (x p : ℝ) : 0 ≤ bernstein_kernel n x p := by
   rw [bernstein_kernel]; split_ifs <;> positivity
+
+/-- On the nonnegative half-plane, the Bernstein kernel is bounded above by `1`. -/
+lemma bernstein_kernel_le_one {n : ℕ} {x p : ℝ} (hx : 0 ≤ x) (hp : 0 ≤ p) :
+    bernstein_kernel n x p ≤ 1 := by
+  rw [bernstein_kernel]
+  split_ifs with hn
+  · norm_num
+  · have hn_pos : (0 : ℝ) < (↑(n - 1) : ℝ) := Nat.cast_pos.mpr (by omega)
+    have hratio_nonneg : 0 ≤ x * p / (↑(n - 1) : ℝ) :=
+      div_nonneg (mul_nonneg hx hp) hn_pos.le
+    have hbase_nonneg : 0 ≤ max (1 - x * p / (↑(n - 1) : ℝ)) 0 := le_max_right _ _
+    have hbase_le_one : max (1 - x * p / (↑(n - 1) : ℝ)) 0 ≤ 1 := by
+      exact max_le (by linarith) zero_le_one
+    exact pow_le_one₀ hbase_nonneg hbase_le_one
 
 /-- The Bernstein kernel is measurable in `p` for fixed `n` and `x`. -/
 lemma measurable_bernstein_kernel (n : ℕ) (x : ℝ) : Measurable (bernstein_kernel n x) := by
@@ -276,8 +310,8 @@ lemma chafaiRescaled_mass_eq (f : ℝ → ℝ) (n : ℕ) :
 
 /-- **IBP identity** for the CM density:
 `∫₀ᵀ ρ_{m+2}(t) dt = B_{m+2}(T) + ∫₀ᵀ ρ_{m+1}(t) dt`. -/
-private lemma chafaiDensity_ibp_identity (f : ℝ → ℝ) (hcm : IsCompletelyMonotone f)
-    (m : ℕ) (T : ℝ) (hT : 0 < T) :
+private lemma chafaiDensity_ibp_identity (f : ℝ → ℝ) {m : ℕ}
+    (hf : ContDiffOn ℝ ((m + 2 : ℕ) : WithTop ℕ∞) f (Ici 0)) (T : ℝ) (hT : 0 < T) :
     ∫ t in (0 : ℝ)..T, chafaiDensity f (m + 2) t =
     (-1 : ℝ) ^ (m + 2) * T ^ (m + 1) / ↑(m + 1).factorial *
       iteratedDerivWithin (m + 1) f (Ici 0) T +
@@ -287,9 +321,11 @@ private lemma chafaiDensity_ibp_identity (f : ℝ → ℝ) (hcm : IsCompletelyMo
   set c : ℝ := (-1) ^ (m + 2) / ↑(m + 1).factorial
   set F := fun t : ℝ => t ^ (m + 1) * (c * g t)
   have hg_cont : ContinuousOn g (Ici 0) :=
-    hcm.contDiffOn.continuousOn_iteratedDerivWithin (nat_le_top _) (uniqueDiffOn_Ici 0)
+    (hf.of_le (by exact_mod_cast (by omega : m + 1 ≤ m + 2))).continuousOn_iteratedDerivWithin
+      le_rfl (uniqueDiffOn_Ici 0)
   have hg_deriv : ∀ t, 0 < t → HasDerivAt g (g' t) t :=
-    fun t ht => hcm.hasDerivAt_iteratedDerivWithin_succ (m + 1) ht
+    fun t ht =>
+      ContDiffOn.hasDerivAt_iteratedDerivWithin_of_nat hf (uniqueDiffOn_Ici 0) (Ici_mem_nhds ht)
   have huIcc : uIcc (0 : ℝ) T = Icc 0 T := uIcc_of_le hT.le
   have hF_cont : ContinuousOn F (Icc 0 T) :=
     ((continuous_pow _).continuousOn).mul
@@ -297,10 +333,13 @@ private lemma chafaiDensity_ibp_identity (f : ℝ → ℝ) (hcm : IsCompletelyMo
   have hF_deriv : ∀ t ∈ Ioo 0 T, HasDerivAt F
       (↑(m + 1) * t ^ m * (c * g t) + t ^ (m + 1) * (c * g' t)) t :=
     fun t ht => (hasDerivAt_pow (m + 1) t).mul ((hg_deriv t ht.1).const_mul c)
-  have hcm_int : ∀ k, k ≠ 0 → IntervalIntegrable (fun t => chafaiDensity f k t) volume 0 T := by
-    intro k hk; apply ContinuousOn.intervalIntegrable; rw [huIcc]
-    exact (continuousOn_chafaiDensity (n := k)
-      ((hcm.contDiffOn).of_le (nat_le_top k))).mono Icc_subset_Ici_self
+  have h_int_m2 : IntervalIntegrable (fun t => chafaiDensity f (m + 2) t) volume 0 T := by
+    apply ContinuousOn.intervalIntegrable; rw [huIcc]
+    exact (continuousOn_chafaiDensity (n := m + 2) hf).mono Icc_subset_Ici_self
+  have h_int_m1 : IntervalIntegrable (fun t => chafaiDensity f (m + 1) t) volume 0 T := by
+    apply ContinuousOn.intervalIntegrable; rw [huIcc]
+    exact (continuousOn_chafaiDensity (n := m + 1)
+      (hf.of_le (by exact_mod_cast (by omega : m + 1 ≤ m + 2)))).mono Icc_subset_Ici_self
   have hF'_eq : ∀ t, ↑(m + 1) * t ^ m * (c * g t) + t ^ (m + 1) * (c * g' t) =
       chafaiDensity f (m + 2) t - chafaiDensity f (m + 1) t := by
     intro t
@@ -308,7 +347,7 @@ private lemma chafaiDensity_ibp_identity (f : ℝ → ℝ) (hcm : IsCompletelyMo
     exact (chafaiDensity_succ_succ_sub_succ f m t).symm
   have hF'_int : IntervalIntegrable
       (fun t => ↑(m + 1) * t ^ m * (c * g t) + t ^ (m + 1) * (c * g' t)) volume 0 T :=
-    ((hcm_int _ (by omega)).sub (hcm_int _ (by omega))).congr fun t _ => (hF'_eq t).symm
+    (h_int_m2.sub h_int_m1).congr fun t _ => (hF'_eq t).symm
   have hftc := intervalIntegral.integral_eq_sub_of_hasDerivAt_of_le hT.le hF_cont hF_deriv hF'_int
   have hstep1 : ∫ t in (0 : ℝ)..T,
       (chafaiDensity f (m + 2) t - chafaiDensity f (m + 1) t) = F T - F 0 := by
@@ -318,7 +357,7 @@ private lemma chafaiDensity_ibp_identity (f : ℝ → ℝ) (hcm : IsCompletelyMo
   have hm1 : m + 1 ≠ 0 := by omega
   have hF0 : F 0 = 0 := by simp [F, zero_pow hm1]
   rw [hF0, sub_zero] at hstep1
-  rw [intervalIntegral.integral_sub (hcm_int _ (by omega)) (hcm_int _ (by omega))] at hstep1
+  rw [intervalIntegral.integral_sub h_int_m2 h_int_m1] at hstep1
   suffices hgoal : (-1 : ℝ) ^ (m + 2) * T ^ (m + 1) / ↑(m + 1).factorial * g T = F T by linarith
   simp only [F, c]; ring
 
@@ -327,21 +366,25 @@ private lemma chafaiDensity_ibp_identity (f : ℝ → ℝ) (hcm : IsCompletelyMo
 integration-by-parts consequence
 (the raw IBP identity `chafaiDensity_ibp_identity` is private); it is the per-step density
 mass-monotonicity bound consumed by the Bernstein-identity assembly. -/
-lemma integral_chafaiDensity_le_pred (f : ℝ → ℝ) (hcm : IsCompletelyMonotone f)
-    (k : ℕ) (hk : 2 ≤ k) (T : ℝ) (hT : 0 ≤ T) :
+lemma integral_chafaiDensity_le_pred (f : ℝ → ℝ) {k : ℕ} (hk : 2 ≤ k)
+    (hf : ContDiffOn ℝ (k : WithTop ℕ∞) f (Ici 0))
+    (T : ℝ) (hT : 0 ≤ T)
+    (hsign : 0 ≤ (-1 : ℝ) ^ (k - 1) * iteratedDerivWithin (k - 1) f (Ici 0) T) :
     ∫ t in (0 : ℝ)..T, chafaiDensity f k t ≤ ∫ t in (0 : ℝ)..T, chafaiDensity f (k - 1) t := by
   rcases hT.eq_or_lt with rfl | hT_pos
   · simp
   obtain ⟨m, rfl⟩ : ∃ m, k = m + 2 := ⟨k - 2, by omega⟩
   have hsub : m + 2 - 1 = m + 1 := by omega
   simp only [hsub]
-  have hibp := chafaiDensity_ibp_identity f hcm m T hT_pos
+  have hibp := chafaiDensity_ibp_identity (m := m) f hf T hT_pos
   set B := (-1 : ℝ) ^ (m + 2) * T ^ (m + 1) / ↑(m + 1).factorial *
     iteratedDerivWithin (m + 1) f (Ici 0) T
   have hB : B ≤ 0 := by
+    have hsign_m : 0 ≤ (-1 : ℝ) ^ (m + 1) * iteratedDerivWithin (m + 1) f (Ici 0) T := by
+      simpa [hsub] using hsign
     have h_neg : (-1 : ℝ) ^ (m + 2) * iteratedDerivWithin (m + 1) f (Ici 0) T ≤ 0 := by
       have : (-1 : ℝ) ^ (m + 2) = (-1) ^ (m + 1) * (-1) := pow_succ (-1) (m + 1)
-      rw [this]; nlinarith [hcm.neg_one_pow_mul_iteratedDerivWithin_nonneg (m + 1) hT_pos.le]
+      rw [this]; nlinarith [hsign_m]
     suffices B = T ^ (m + 1) / ↑(m + 1).factorial *
         ((-1 : ℝ) ^ (m + 2) * iteratedDerivWithin (m + 1) f (Ici 0) T) by
       rw [this]
@@ -385,7 +428,10 @@ private lemma integral_chafaiDensity_le_sub (f : ℝ → ℝ) (hcm : IsCompletel
       exact le_of_eq (integral_chafaiDensity_one_eq f hcm T hT)
     · calc ∫ t in (0 : ℝ)..T, chafaiDensity f (p + 1) t
           ≤ ∫ t in (0 : ℝ)..T, chafaiDensity f p t := by
-            simpa using integral_chafaiDensity_le_pred f hcm (p + 1) (by omega) T hT.le
+            exact integral_chafaiDensity_le_pred f (k := p + 1) (by omega)
+              (hcm.contDiffOn.of_le (nat_le_top (p + 1)))
+              T hT.le (by
+                simpa using hcm.neg_one_pow_mul_iteratedDerivWithin_nonneg p hT.le)
         _ ≤ f 0 - f T := ih (Nat.one_le_iff_ne_zero.mpr hp)
 
 private lemma integral_chafaiDensity_le_tendsto_sub (f : ℝ → ℝ)

--- a/TauCeti/Analysis/CompletelyMonotone/BernsteinMeasures.lean
+++ b/TauCeti/Analysis/CompletelyMonotone/BernsteinMeasures.lean
@@ -5,6 +5,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 module
 
 public import Mathlib.Analysis.SpecialFunctions.Complex.LogBounds
+public import Mathlib.Topology.ContinuousMap.Bounded.Basic
 public import TauCeti.Analysis.CompletelyMonotone.Integral
 
 /-!
@@ -25,8 +26,10 @@ These build on the `IsCompletelyMonotone` API in `CompletelyMonotone/Basic.lean`
 * `TauCeti.chafaiDensity`, `TauCeti.chafaiMeasure`: the approximating densities and measures.
 * `TauCeti.bernstein_kernel`, `TauCeti.continuous_bernstein_kernel`,
   `TauCeti.bernstein_kernel_nonneg`, `TauCeti.bernstein_kernel_le_one`,
-  `TauCeti.bernstein_kernel_tendsto`: the rescaled Laplace kernel, its bounded-continuous
-  `p`-dependence on the nonnegative half-line, and its pointwise limit `e^{-xp}`.
+  `TauCeti.bernsteinKernelBCF`, `TauCeti.bernsteinKernelBCF_apply`,
+  `TauCeti.bernstein_kernel_tendsto`: the rescaled Laplace kernel, its bundled
+  bounded-continuous `p`-dependence on the nonnegative half-line, and its pointwise limit
+  `e^{-xp}`.
 * `TauCeti.chafaiRescaled`, `TauCeti.chafaiRescaled_mass_eq`: the `ℝ≥0`-valued pushed-forward
   measures and mass preservation.
 * `TauCeti.chafaiMeasure_finite_mass`, `TauCeti.chafaiRescaled_finite_mass`: finiteness and the
@@ -43,7 +46,7 @@ These build on the `IsCompletelyMonotone` API in `CompletelyMonotone/Basic.lean`
 public section
 
 open MeasureTheory Set intervalIntegral Filter
-open scoped ContDiff NNReal Topology
+open scoped BoundedContinuousFunction ContDiff NNReal Topology
 
 namespace TauCeti
 
@@ -165,19 +168,6 @@ private lemma chafaiDensity_succ_succ_sub_succ (f : ℝ → ℝ) (m : ℕ) (t : 
   field_simp
   ring
 
-private lemma ContDiffOn.hasDerivAt_iteratedDerivWithin_of_nat {s : Set ℝ} {k : ℕ}
-    (hf : ContDiffOn ℝ ((k + 1 : ℕ) : WithTop ℕ∞) f s) (hs : UniqueDiffOn ℝ s)
-    {x : ℝ} (hx : s ∈ nhds x) :
-    HasDerivAt (iteratedDerivWithin k f s) (iteratedDerivWithin (k + 1) f s x) x := by
-  have hklt : (k : WithTop ℕ∞) < ((k + 1 : ℕ) : WithTop ℕ∞) := by
-    exact_mod_cast (Nat.lt_succ_self k)
-  have hda := (hf.differentiableOn_iteratedDerivWithin hklt hs).hasDerivAt hx
-  have hval : iteratedDerivWithin (k + 1) f s x =
-      deriv (iteratedDerivWithin k f s) x := by
-    rw [iteratedDerivWithin_succ, derivWithin_of_mem_nhds hx]
-  rw [hval]
-  exact hda
-
 /-! ## Rescaled measures and Prokhorov extraction -/
 
 /-- The Bernstein kernel `φ_n(x,p) = max(1 - xp/(n-1), 0)ⁿ⁻¹` for `n ≥ 2`. After the change of
@@ -219,6 +209,26 @@ lemma bernstein_kernel_le_one {n : ℕ} {x p : ℝ} (hx : 0 ≤ x) (hp : 0 ≤ p
     have hbase_le_one : max (1 - x * p / (↑(n - 1) : ℝ)) 0 ≤ 1 := by
       exact max_le (by linarith) zero_le_one
     exact pow_le_one₀ hbase_nonneg hbase_le_one
+
+/-- The Bernstein kernel as a bundled bounded continuous test function of the nonnegative
+variable `p`, for fixed `n` and nonnegative `x`. -/
+@[expose]
+noncomputable def bernsteinKernelBCF (n : ℕ) {x : ℝ} (hx : 0 ≤ x) : ℝ≥0 →ᵇ ℝ where
+  toFun := fun p => bernstein_kernel n x (p : ℝ)
+  continuous_toFun := (continuous_bernstein_kernel n x).comp continuous_subtype_val
+  map_bounded' :=
+    ⟨1, fun p q => by
+      rw [Real.dist_eq]
+      have hp0 : 0 ≤ bernstein_kernel n x (p : ℝ) := bernstein_kernel_nonneg n x (p : ℝ)
+      have hp1 : bernstein_kernel n x (p : ℝ) ≤ 1 := bernstein_kernel_le_one hx p.2
+      have hq0 : 0 ≤ bernstein_kernel n x (q : ℝ) := bernstein_kernel_nonneg n x (q : ℝ)
+      have hq1 : bernstein_kernel n x (q : ℝ) ≤ 1 := bernstein_kernel_le_one hx q.2
+      exact abs_sub_le_iff.mpr ⟨by linarith, by linarith⟩⟩
+
+/-- The bundled Bernstein kernel evaluates to the unbundled kernel on `ℝ≥0`. -/
+@[simp]
+lemma bernsteinKernelBCF_apply (n : ℕ) {x : ℝ} (hx : 0 ≤ x) (p : ℝ≥0) :
+    bernsteinKernelBCF n hx p = bernstein_kernel n x (p : ℝ) := rfl
 
 /-- The Bernstein kernel is measurable in `p` for fixed `n` and `x`. -/
 lemma measurable_bernstein_kernel (n : ℕ) (x : ℝ) : Measurable (bernstein_kernel n x) := by
@@ -325,7 +335,7 @@ private lemma chafaiDensity_ibp_identity (f : ℝ → ℝ) {m : ℕ}
       le_rfl (uniqueDiffOn_Ici 0)
   have hg_deriv : ∀ t, 0 < t → HasDerivAt g (g' t) t :=
     fun t ht =>
-      ContDiffOn.hasDerivAt_iteratedDerivWithin_of_nat hf (uniqueDiffOn_Ici 0) (Ici_mem_nhds ht)
+      ContDiffOn.hasDerivAt_iteratedDerivWithin hf (uniqueDiffOn_Ici 0) (Ici_mem_nhds ht)
   have huIcc : uIcc (0 : ℝ) T = Icc 0 T := uIcc_of_le hT.le
   have hF_cont : ContinuousOn F (Icc 0 T) :=
     ((continuous_pow _).continuousOn).mul

--- a/TauCeti/Analysis/CompletelyMonotone/BernsteinMeasures.lean
+++ b/TauCeti/Analysis/CompletelyMonotone/BernsteinMeasures.lean
@@ -70,8 +70,10 @@ lemma chafaiDensity_of_ne_zero {n : ℕ} (hn : n ≠ 0) (f : ℝ → ℝ) (t : �
       t ^ (n - 1) * iteratedDerivWithin n f (Ici 0) t := by
   rw [chafaiDensity, if_neg hn]
 
-/-- `chafaiDensity f n` is continuous on `[0, ∞)` for a completely monotone `f`. -/
-lemma continuousOn_chafaiDensity (hcm : IsCompletelyMonotone f) (n : ℕ) :
+/-- `chafaiDensity f n` is continuous on `[0, ∞)` when `f` has `n` continuous derivatives
+there. -/
+lemma continuousOn_chafaiDensity {n : ℕ}
+    (hf : ContDiffOn ℝ (n : WithTop ℕ∞) f (Ici 0)) :
     ContinuousOn (chafaiDensity f n) (Ici 0) := by
   by_cases hn : n = 0
   · subst n
@@ -83,7 +85,7 @@ lemma continuousOn_chafaiDensity (hcm : IsCompletelyMonotone f) (n : ℕ) :
     funext (chafaiDensity_of_ne_zero hn f)
   rw [heq]
   exact (continuousOn_const.mul ((continuousOn_pow _).mono fun _ _ => trivial)).mul
-    (hcm.contDiffOn.continuousOn_iteratedDerivWithin (nat_le_top _) (uniqueDiffOn_Ici 0))
+    (hf.continuousOn_iteratedDerivWithin le_rfl (uniqueDiffOn_Ici 0))
 
 /-- The `n`-th approximating measure `σ_n` for the Bernstein proof, with density `ρ_n` on
 `(0, ∞)`. -/
@@ -102,20 +104,21 @@ lemma chafaiMeasure_apply (f : ℝ → ℝ) (n : ℕ) {s : Set ℝ} (hs : Measur
       ∫⁻ t in s, ENNReal.ofReal (chafaiDensity f n t) ∂(volume.restrict (Ioi 0)) := by
   rw [chafaiMeasure, withDensity_apply _ hs]
 
-/-- The density `ρ_n` is nonnegative for completely monotone functions on `[0, ∞)`. -/
-lemma chafaiDensity_nonneg (hcm : IsCompletelyMonotone f) (n : ℕ)
-    (t : ℝ) (ht : 0 ≤ t) : 0 ≤ chafaiDensity f n t := by
+/-- The density `ρ_n(t)` is nonnegative when `t ≥ 0` and the `n`-th derivative has the
+alternating sign at `t`. -/
+lemma chafaiDensity_nonneg {n : ℕ} {t : ℝ} (ht : 0 ≤ t)
+    (hsign : 0 ≤ (-1 : ℝ) ^ n * iteratedDerivWithin n f (Ici 0) t) :
+    0 ≤ chafaiDensity f n t := by
   simp only [chafaiDensity]
   split_ifs with hn
   · exact le_refl 0
-  · have hcm_sign := hcm.neg_one_pow_mul_iteratedDerivWithin_nonneg n ht
-    have hfact_pos : (0 : ℝ) < ↑(Nat.factorial (n - 1)) :=
+  · have hfact_pos : (0 : ℝ) < ↑(Nat.factorial (n - 1)) :=
       Nat.cast_pos.mpr (Nat.factorial_pos _)
     calc (-1 : ℝ) ^ n / ↑(Nat.factorial (n - 1)) * t ^ (n - 1) *
           iteratedDerivWithin n f (Ici 0) t
         = t ^ (n - 1) / ↑(Nat.factorial (n - 1)) *
           ((-1 : ℝ) ^ n * iteratedDerivWithin n f (Ici 0) t) := by field_simp
-      _ ≥ 0 := mul_nonneg (div_nonneg (pow_nonneg ht _) hfact_pos.le) hcm_sign
+      _ ≥ 0 := mul_nonneg (div_nonneg (pow_nonneg ht _) hfact_pos.le) hsign
 
 /-- For `n = 1`, the density simplifies to `-f'(t)`. -/
 @[simp] lemma chafaiDensity_one (t : ℝ) :
@@ -295,7 +298,8 @@ private lemma chafaiDensity_ibp_identity (f : ℝ → ℝ) (hcm : IsCompletelyMo
     fun t ht => (hasDerivAt_pow (m + 1) t).mul ((hg_deriv t ht.1).const_mul c)
   have hcm_int : ∀ k, k ≠ 0 → IntervalIntegrable (fun t => chafaiDensity f k t) volume 0 T := by
     intro k hk; apply ContinuousOn.intervalIntegrable; rw [huIcc]
-    exact (continuousOn_chafaiDensity hcm k).mono Icc_subset_Ici_self
+    exact (continuousOn_chafaiDensity (n := k)
+      ((hcm.contDiffOn).of_le (nat_le_top k))).mono Icc_subset_Ici_self
   have hF'_eq : ∀ t, ↑(m + 1) * t ^ m * (c * g t) + t ^ (m + 1) * (c * g' t) =
       chafaiDensity f (m + 2) t - chafaiDensity f (m + 1) t := by
     intro t
@@ -351,6 +355,12 @@ lemma chafaiMeasure_zero (f : ℝ → ℝ) : chafaiMeasure f 0 = 0 := by
   rw [withDensity_apply _ hs]
   simp
 
+/-- The rescaled Chafaï measure on the target type `ℝ≥0` shares the `n = 0` zero convention:
+`chafaiRescaled f 0 = 0`, as the pushforward of the zero measure. -/
+@[simp]
+lemma chafaiRescaled_zero (f : ℝ → ℝ) : chafaiRescaled f 0 = 0 := by
+  rw [chafaiRescaled_eq_map, chafaiMeasure_zero, Measure.map_zero]
+
 private lemma integral_chafaiDensity_one_eq (f : ℝ → ℝ) (hcm : IsCompletelyMonotone f)
     (T : ℝ) (hT : 0 < T) :
     ∫ t in (0 : ℝ)..T, chafaiDensity f 1 t = f 0 - f T := by
@@ -385,7 +395,8 @@ private lemma chafaiDensity_integrableOn_Ioi_of_tendsto (f : ℝ → ℝ)
     (hcm : IsCompletelyMonotone f) (n : ℕ) (hn : 1 ≤ n) (L : ℝ)
     (hL : Tendsto f atTop (nhds L)) :
     IntegrableOn (chafaiDensity f n) (Ioi 0) := by
-  have hcont : ContinuousOn (chafaiDensity f n) (Ici 0) := continuousOn_chafaiDensity hcm n
+  have hcont : ContinuousOn (chafaiDensity f n) (Ici 0) :=
+    continuousOn_chafaiDensity (n := n) ((hcm.contDiffOn).of_le (nat_le_top n))
   apply integrableOn_Ioi_of_intervalIntegral_norm_bounded (f 0 - L) 0
     (l := atTop) (b := id)
   · intro T
@@ -400,7 +411,9 @@ private lemma chafaiDensity_integrableOn_Ioi_of_tendsto (f : ℝ → ℝ)
           apply ae_of_all
           intro t ht
           rw [uIoc_of_le hT.le] at ht
-          rw [Real.norm_eq_abs, abs_of_nonneg (chafaiDensity_nonneg hcm n t ht.1.le)]
+          rw [Real.norm_eq_abs,
+            abs_of_nonneg (chafaiDensity_nonneg ht.1.le
+              (hcm.neg_one_pow_mul_iteratedDerivWithin_nonneg n ht.1.le))]
       _ ≤ f 0 - L := integral_chafaiDensity_le_tendsto_sub f hcm n hn L hL T hT
 
 private lemma chafaiMeasure_mass_le_of_tendsto (f : ℝ → ℝ)
@@ -413,7 +426,7 @@ private lemma chafaiMeasure_mass_le_of_tendsto (f : ℝ → ℝ)
   simp only [Measure.restrict_univ]
   rw [← ofReal_integral_eq_lintegral_ofReal hint
     ((ae_restrict_mem measurableSet_Ioi).mono fun t (ht : 0 < t) =>
-      chafaiDensity_nonneg hcm n t ht.le)]
+      chafaiDensity_nonneg ht.le (hcm.neg_one_pow_mul_iteratedDerivWithin_nonneg n ht.le))]
   exact ENNReal.ofReal_le_ofReal
     (le_of_tendsto (intervalIntegral_tendsto_integral_Ioi 0 hint tendsto_id)
       (eventually_atTop.mpr ⟨1, fun T hT =>

--- a/TauCeti/Analysis/CompletelyMonotone/BernsteinMeasures.lean
+++ b/TauCeti/Analysis/CompletelyMonotone/BernsteinMeasures.lean
@@ -212,7 +212,7 @@ lemma bernstein_kernel_le_one {n : ℕ} {x p : ℝ} (hx : 0 ≤ x) (hp : 0 ≤ p
 
 /-- The Bernstein kernel as a bundled bounded continuous test function of the nonnegative
 variable `p`, for fixed `n` and nonnegative `x`. -/
-noncomputable abbrev bernsteinKernelBCF (n : ℕ) {x : ℝ} (hx : 0 ≤ x) : ℝ≥0 →ᵇ ℝ where
+noncomputable def bernsteinKernelBCF (n : ℕ) {x : ℝ} (hx : 0 ≤ x) : ℝ≥0 →ᵇ ℝ where
   toFun := fun p => bernstein_kernel n x (p : ℝ)
   continuous_toFun := (continuous_bernstein_kernel n x).comp continuous_subtype_val
   map_bounded' :=
@@ -227,7 +227,8 @@ noncomputable abbrev bernsteinKernelBCF (n : ℕ) {x : ℝ} (hx : 0 ≤ x) : ℝ
 /-- The bundled Bernstein kernel evaluates to the unbundled kernel on `ℝ≥0`. -/
 @[simp]
 lemma bernsteinKernelBCF_apply (n : ℕ) {x : ℝ} (hx : 0 ≤ x) (p : ℝ≥0) :
-    bernsteinKernelBCF n hx p = bernstein_kernel n x (p : ℝ) := rfl
+    bernsteinKernelBCF n hx p = bernstein_kernel n x (p : ℝ) := by
+  rw [bernsteinKernelBCF]; rfl
 
 /-- The Bernstein kernel is measurable in `p` for fixed `n` and `x`. -/
 lemma measurable_bernstein_kernel (n : ℕ) (x : ℝ) : Measurable (bernstein_kernel n x) := by

--- a/TauCeti/Analysis/CompletelyMonotone/BernsteinMeasures.lean
+++ b/TauCeti/Analysis/CompletelyMonotone/BernsteinMeasures.lean
@@ -5,7 +5,6 @@ Released under Apache 2.0 license as described in the file LICENSE.
 module
 
 public import Mathlib.Analysis.SpecialFunctions.Complex.LogBounds
-public import Mathlib.Topology.ContinuousMap.Bounded.Basic
 public import TauCeti.Analysis.CompletelyMonotone.Integral
 
 /-!
@@ -35,6 +34,10 @@ These build on the `IsCompletelyMonotone` API in `CompletelyMonotone/Basic.lean`
   limit `e^{-xp}`.
 * `TauCeti.chafaiRescaled`, `TauCeti.chafaiRescaled_mass_eq`: the `ℝ≥0`-valued pushed-forward
   measures and mass preservation.
+* `TauCeti.chafaiRescaled_integral_bernsteinKernel`,
+  `TauCeti.chafaiRescaled_integral_bernsteinKernelBoundedContinuous`,
+  `TauCeti.ae_nonneg_bernsteinKernel_chafaiRescaled`: characteristic lemmas pairing the
+  rescaled Chafaï measures with the Bernstein kernel without unfolding either definition.
 * `TauCeti.chafaiMeasure_finite_mass`, `TauCeti.chafaiRescaled_finite_mass`: finiteness and the
   total-mass bound `≤ f(0) - L`.
 * `TauCeti.chafaiRescaled_prokhorov_mass_bound`,
@@ -341,6 +344,59 @@ lemma chafaiRescaled_integral (f : ℝ → ℝ) (n : ℕ) {g : ℝ≥0 → ℝ}
       ∫ t, g (chafaiRescaling n t) ∂(chafaiMeasure f n) := by
   rw [chafaiRescaled_eq_map] at hg ⊢
   exact MeasureTheory.integral_map (measurable_chafaiRescaling n).aemeasurable hg
+
+/-- On positive source points, pulling the Bernstein kernel back along the Chafaï rescaling
+gives the classical finite-order kernel `(max (1 - x / t) 0) ^ (n - 1)`. -/
+@[simp]
+lemma bernsteinKernel_chafaiRescaling_of_pos {n : ℕ} (hn : 2 ≤ n) (x : ℝ) {t : ℝ}
+    (ht : 0 < t) :
+    bernsteinKernel n x (chafaiRescaling n t : ℝ) = (max (1 - x / t) 0) ^ (n - 1) := by
+  rw [bernsteinKernel_of_two_le hn]
+  rw [chafaiRescaling_coe_of_pos (by omega : 1 ≤ n) ht]
+  congr 2
+  have hcast : ((n : ℝ) - 1) = (↑(n - 1) : ℝ) := by
+    norm_num [Nat.cast_sub (by omega : 1 ≤ n)]
+  have hn1 : (↑(n - 1) : ℝ) ≠ 0 := by
+    exact_mod_cast (by omega : n - 1 ≠ 0)
+  rw [hcast]
+  field_simp [hn1, ht.ne']
+
+/-- The Bernstein kernel is nonnegative almost everywhere against every rescaled Chafaï measure.
+This is the public positivity lemma consumers need before using monotone or positivity facts for
+the kernel pairing. -/
+@[simp]
+lemma ae_nonneg_bernsteinKernel_chafaiRescaled (f : ℝ → ℝ) (n : ℕ) (x : ℝ) :
+    0 ≤ᵐ[chafaiRescaled f n] fun p : ℝ≥0 => bernsteinKernel n x (p : ℝ) := by
+  exact Filter.Eventually.of_forall fun p => bernsteinKernel_nonneg n x (p : ℝ)
+
+/-- Bundled version of `ae_nonneg_bernsteinKernel_chafaiRescaled` for the bounded-continuous
+Bernstein kernel. -/
+@[simp]
+lemma ae_nonneg_bernsteinKernelBoundedContinuous_chafaiRescaled
+    (f : ℝ → ℝ) (n : ℕ) {x : ℝ} (hx : 0 ≤ x) :
+    0 ≤ᵐ[chafaiRescaled f n] fun p : ℝ≥0 => bernsteinKernelBoundedContinuous n hx p := by
+  exact ae_nonneg_bernsteinKernel_chafaiRescaled f n x
+
+/-- Characteristic pairing of the rescaled Chafaï measure with the Bernstein kernel: integrating
+`p ↦ φ_n(x,p)` against `chafaiRescaled f n` is the same as integrating its Chafaï-rescaling
+pullback against the original Chafaï measure. -/
+@[simp]
+lemma chafaiRescaled_integral_bernsteinKernel (f : ℝ → ℝ) (n : ℕ) (x : ℝ) :
+    ∫ p, bernsteinKernel n x (p : ℝ) ∂(chafaiRescaled f n) =
+      ∫ t, bernsteinKernel n x (chafaiRescaling n t : ℝ) ∂(chafaiMeasure f n) := by
+  exact chafaiRescaled_integral f n
+    (((continuous_bernsteinKernel n x).comp continuous_subtype_val).measurable.aestronglyMeasurable)
+
+/-- Bounded-continuous characteristic pairing of the rescaled Chafaï measure with the Bernstein
+kernel. This lets weak-convergence consumers use the bundled test function while the right-hand
+side is the concrete pullback along the Chafaï rescaling. -/
+lemma chafaiRescaled_integral_bernsteinKernelBoundedContinuous
+    (f : ℝ → ℝ) (n : ℕ) {x : ℝ} (hx : 0 ≤ x) :
+    ∫ p, bernsteinKernelBoundedContinuous n hx p ∂(chafaiRescaled f n) =
+      ∫ t, bernsteinKernel n x (chafaiRescaling n t : ℝ) ∂(chafaiMeasure f n) := by
+  rw [chafaiRescaled_integral f n
+    ((bernsteinKernelBoundedContinuous n hx).continuous.measurable.aestronglyMeasurable)]
+  simp
 
 /-- `chafaiMeasure f n` lives on `(0, ∞)`: its complement has zero mass. -/
 @[simp]

--- a/TauCeti/Analysis/CompletelyMonotone/BernsteinMeasures.lean
+++ b/TauCeti/Analysis/CompletelyMonotone/BernsteinMeasures.lean
@@ -27,9 +27,10 @@ These build on the `IsCompletelyMonotone` API in `CompletelyMonotone/Basic.lean`
 * `TauCeti.bernstein_kernel`, `TauCeti.continuous_bernstein_kernel`,
   `TauCeti.bernstein_kernel_nonneg`, `TauCeti.bernstein_kernel_le_one`,
   `TauCeti.bernsteinKernelBCF`, `TauCeti.bernsteinKernelBCF_apply`,
+  `TauCeti.laplaceKernelBCF`, `TauCeti.laplaceKernelBCF_apply`,
   `TauCeti.bernstein_kernel_tendsto`: the rescaled Laplace kernel, its bundled
-  bounded-continuous `p`-dependence on the nonnegative half-line, and its pointwise limit
-  `e^{-xp}`.
+  bounded-continuous `p`-dependence on the nonnegative half-line, and its bundled pointwise
+  limit `e^{-xp}`.
 * `TauCeti.chafaiRescaled`, `TauCeti.chafaiRescaled_mass_eq`: the `ℝ≥0`-valued pushed-forward
   measures and mass preservation.
 * `TauCeti.chafaiMeasure_finite_mass`, `TauCeti.chafaiRescaled_finite_mass`: finiteness and the
@@ -229,6 +230,30 @@ noncomputable def bernsteinKernelBCF (n : ℕ) {x : ℝ} (hx : 0 ≤ x) : ℝ≥
 lemma bernsteinKernelBCF_apply (n : ℕ) {x : ℝ} (hx : 0 ≤ x) (p : ℝ≥0) :
     bernsteinKernelBCF n hx p = bernstein_kernel n x (p : ℝ) := by
   rw [bernsteinKernelBCF]; rfl
+
+/-- The limiting Laplace kernel as a bundled bounded continuous test function of the
+nonnegative variable `p`, for fixed nonnegative `x`. -/
+noncomputable def laplaceKernelBCF {x : ℝ} (hx : 0 ≤ x) : ℝ≥0 →ᵇ ℝ where
+  toFun := fun p => Real.exp (-(x * (p : ℝ)))
+  continuous_toFun := Real.continuous_exp.comp ((continuous_const.mul continuous_subtype_val).neg)
+  map_bounded' :=
+    ⟨1, fun p q => by
+      rw [Real.dist_eq]
+      have hp0 : 0 < Real.exp (-(x * (p : ℝ))) := Real.exp_pos _
+      have hp1 : Real.exp (-(x * (p : ℝ))) ≤ 1 := by
+        rw [Real.exp_le_one_iff]
+        exact neg_nonpos.mpr (mul_nonneg hx p.2)
+      have hq0 : 0 < Real.exp (-(x * (q : ℝ))) := Real.exp_pos _
+      have hq1 : Real.exp (-(x * (q : ℝ))) ≤ 1 := by
+        rw [Real.exp_le_one_iff]
+        exact neg_nonpos.mpr (mul_nonneg hx q.2)
+      exact abs_sub_le_iff.mpr ⟨by linarith, by linarith⟩⟩
+
+/-- The bundled limiting Laplace kernel evaluates to the usual exponential kernel on `ℝ≥0`. -/
+@[simp]
+lemma laplaceKernelBCF_apply {x : ℝ} (hx : 0 ≤ x) (p : ℝ≥0) :
+    laplaceKernelBCF hx p = Real.exp (-(x * (p : ℝ))) := by
+  rw [laplaceKernelBCF]; rfl
 
 /-- The Bernstein kernel is measurable in `p` for fixed `n` and `x`. -/
 lemma measurable_bernstein_kernel (n : ℕ) (x : ℝ) : Measurable (bernstein_kernel n x) := by

--- a/TauCeti/Analysis/CompletelyMonotone/BernsteinMeasures.lean
+++ b/TauCeti/Analysis/CompletelyMonotone/BernsteinMeasures.lean
@@ -26,8 +26,10 @@ These build on the `IsCompletelyMonotone` API in `CompletelyMonotone/Basic.lean`
 * `TauCeti.chafaiDensity`, `TauCeti.chafaiMeasure`: the approximating densities and measures.
 * `TauCeti.bernstein_kernel`, `TauCeti.continuous_bernstein_kernel`,
   `TauCeti.bernstein_kernel_nonneg`, `TauCeti.bernstein_kernel_le_one`,
-  `TauCeti.bernsteinKernelBCF`, `TauCeti.bernsteinKernelBCF_apply`,
-  `TauCeti.laplaceKernelBCF`, `TauCeti.laplaceKernelBCF_apply`,
+  `TauCeti.bernsteinKernelBoundedContinuous`,
+  `TauCeti.bernsteinKernelBoundedContinuous_apply`,
+  `TauCeti.laplaceKernelBoundedContinuous`,
+  `TauCeti.laplaceKernelBoundedContinuous_apply`,
   `TauCeti.bernstein_kernel_tendsto`: the rescaled Laplace kernel, its bundled
   bounded-continuous `p`-dependence on the nonnegative half-line, and its bundled pointwise
   limit `e^{-xp}`.
@@ -213,7 +215,8 @@ lemma bernstein_kernel_le_one {n : ℕ} {x p : ℝ} (hx : 0 ≤ x) (hp : 0 ≤ p
 
 /-- The Bernstein kernel as a bundled bounded continuous test function of the nonnegative
 variable `p`, for fixed `n` and nonnegative `x`. -/
-noncomputable def bernsteinKernelBCF (n : ℕ) {x : ℝ} (hx : 0 ≤ x) : ℝ≥0 →ᵇ ℝ where
+noncomputable def bernsteinKernelBoundedContinuous (n : ℕ) {x : ℝ} (hx : 0 ≤ x) :
+    ℝ≥0 →ᵇ ℝ where
   toFun := fun p => bernstein_kernel n x (p : ℝ)
   continuous_toFun := (continuous_bernstein_kernel n x).comp continuous_subtype_val
   map_bounded' :=
@@ -227,13 +230,13 @@ noncomputable def bernsteinKernelBCF (n : ℕ) {x : ℝ} (hx : 0 ≤ x) : ℝ≥
 
 /-- The bundled Bernstein kernel evaluates to the unbundled kernel on `ℝ≥0`. -/
 @[simp]
-lemma bernsteinKernelBCF_apply (n : ℕ) {x : ℝ} (hx : 0 ≤ x) (p : ℝ≥0) :
-    bernsteinKernelBCF n hx p = bernstein_kernel n x (p : ℝ) := by
-  rw [bernsteinKernelBCF]; rfl
+lemma bernsteinKernelBoundedContinuous_apply (n : ℕ) {x : ℝ} (hx : 0 ≤ x) (p : ℝ≥0) :
+    bernsteinKernelBoundedContinuous n hx p = bernstein_kernel n x (p : ℝ) := by
+  rw [bernsteinKernelBoundedContinuous]; rfl
 
 /-- The limiting Laplace kernel as a bundled bounded continuous test function of the
 nonnegative variable `p`, for fixed nonnegative `x`. -/
-noncomputable def laplaceKernelBCF {x : ℝ} (hx : 0 ≤ x) : ℝ≥0 →ᵇ ℝ where
+noncomputable def laplaceKernelBoundedContinuous {x : ℝ} (hx : 0 ≤ x) : ℝ≥0 →ᵇ ℝ where
   toFun := fun p => Real.exp (-(x * (p : ℝ)))
   continuous_toFun := Real.continuous_exp.comp ((continuous_const.mul continuous_subtype_val).neg)
   map_bounded' :=
@@ -251,9 +254,9 @@ noncomputable def laplaceKernelBCF {x : ℝ} (hx : 0 ≤ x) : ℝ≥0 →ᵇ ℝ
 
 /-- The bundled limiting Laplace kernel evaluates to the usual exponential kernel on `ℝ≥0`. -/
 @[simp]
-lemma laplaceKernelBCF_apply {x : ℝ} (hx : 0 ≤ x) (p : ℝ≥0) :
-    laplaceKernelBCF hx p = Real.exp (-(x * (p : ℝ))) := by
-  rw [laplaceKernelBCF]; rfl
+lemma laplaceKernelBoundedContinuous_apply {x : ℝ} (hx : 0 ≤ x) (p : ℝ≥0) :
+    laplaceKernelBoundedContinuous hx p = Real.exp (-(x * (p : ℝ))) := by
+  rw [laplaceKernelBoundedContinuous]; rfl
 
 /-- The Bernstein kernel is measurable in `p` for fixed `n` and `x`. -/
 lemma measurable_bernstein_kernel (n : ℕ) (x : ℝ) : Measurable (bernstein_kernel n x) := by
@@ -450,7 +453,8 @@ private lemma integral_chafaiDensity_one_eq (f : ℝ → ℝ) (hcm : IsCompletel
       ∫ t in (0 : ℝ)..T, -iteratedDerivWithin 1 f (Ici 0) t :=
     intervalIntegral.integral_congr_ae
       (Filter.Eventually.of_forall fun t _ => chafaiDensity_one t)
-  rw [h1, ← hcm.integral_neg_deriv_Ici T hT.le, hcm.integral_mass T hT.le]
+  rw [h1, ← hcm.integral_neg_iteratedDerivWithin_one_Ici T hT.le,
+    hcm.integral_mass T hT.le]
 
 private lemma integral_chafaiDensity_le_sub (f : ℝ → ℝ) (hcm : IsCompletelyMonotone f)
     (j : ℕ) (hj : 1 ≤ j) (T : ℝ) (hT : 0 < T) :

--- a/TauCeti/Analysis/CompletelyMonotone/BernsteinMeasures.lean
+++ b/TauCeti/Analysis/CompletelyMonotone/BernsteinMeasures.lean
@@ -1,0 +1,453 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+module
+
+public import Mathlib.Analysis.SpecialFunctions.Complex.LogBounds
+public import TauCeti.Analysis.CompletelyMonotone.Integral
+
+/-!
+# Approximating measures for Bernstein's theorem
+
+The Chafaï-style construction of the representing measure in Bernstein's theorem. For a
+completely monotone `f` the densities `ρ_n(t) = (-1)ⁿ/(n-1)! · tⁿ⁻¹ · f⁽ⁿ⁾(t)` are nonnegative on
+`[0, ∞)`, the positive support used by `chafaiMeasure`; they define finite measures whose total
+mass is bounded by `f(0) - f(∞)`, and after the rescaling `t ↦ (n-1)/t` give measures
+`chafaiRescaled f n` on `ℝ≥0` whose Laplace kernels `(1 - xp/(n-1))₊ⁿ⁻¹` converge to `e^{-xp}`.
+These feed the Prokhorov tightness argument.
+
+These build on the `IsCompletelyMonotone` API in `CompletelyMonotone/Basic.lean` and
+`CompletelyMonotone/Integral.lean`.
+
+## Main declarations
+
+* `TauCeti.chafaiDensity`, `TauCeti.chafaiMeasure`: the approximating densities and measures.
+* `TauCeti.bernstein_kernel`, `TauCeti.bernstein_kernel_tendsto`: the rescaled Laplace kernel and
+  its pointwise limit `e^{-xp}`.
+* `TauCeti.chafaiRescaled`, `TauCeti.chafaiRescaled_mass_eq`: the `ℝ≥0`-valued pushed-forward
+  measures and mass preservation.
+* `TauCeti.chafaiMeasure_finite_mass`: finiteness and the total-mass bound `≤ f(0) - L`.
+
+## References
+
+* Roadmap: `TauCetiRoadmap/OneParameterSemigroups/README.md`, Part B (Bernstein theorem milestone).
+
+* D. Chafaï, *Aspects of the Bernstein theorem* (2013).
+* R. Schilling, R. Song, Z. Vondraček, *Bernstein Functions* (de Gruyter, 2nd ed. 2012), Ch. 1.
+-/
+
+public section
+
+open MeasureTheory Set intervalIntegral Filter
+open scoped ContDiff NNReal Topology
+
+namespace TauCeti
+
+variable {f : ℝ → ℝ}
+
+/-! ## Smoothness-index helpers -/
+
+private lemma nat_le_top (n : ℕ) : (n : WithTop ℕ∞) ≤ ∞ := by exact_mod_cast le_top
+
+/-! ## Measure construction for Bernstein -/
+
+/-- The density `ρ_n(t) = (-1)ⁿ/(n-1)! · tⁿ⁻¹ · f⁽ⁿ⁾(t)` for nonzero `n`, used for the `n`-th
+approximating measure in the Bernstein proof (Chafaï 2013). By convention the `n = 0` branch
+returns `0`. -/
+noncomputable def chafaiDensity (f : ℝ → ℝ) (n : ℕ) (t : ℝ) : ℝ :=
+  if n = 0 then 0
+  else (-1 : ℝ) ^ n / (Nat.factorial (n - 1) : ℝ) *
+    t ^ (n - 1) * iteratedDerivWithin n f (Ici 0) t
+
+/-- `chafaiDensity f 0 = 0`. -/
+@[simp] lemma chafaiDensity_zero (f : ℝ → ℝ) (t : ℝ) : chafaiDensity f 0 t = 0 := by
+  rw [chafaiDensity, if_pos rfl]
+
+/-- The defining formula for `chafaiDensity` at a nonzero order. -/
+lemma chafaiDensity_of_ne_zero {n : ℕ} (hn : n ≠ 0) (f : ℝ → ℝ) (t : ℝ) :
+    chafaiDensity f n t = (-1 : ℝ) ^ n / (Nat.factorial (n - 1) : ℝ) *
+      t ^ (n - 1) * iteratedDerivWithin n f (Ici 0) t := by
+  rw [chafaiDensity, if_neg hn]
+
+/-- `chafaiDensity f n` is continuous on `[0, ∞)` for a completely monotone `f`. -/
+lemma continuousOn_chafaiDensity (hcm : IsCompletelyMonotone f) (n : ℕ) :
+    ContinuousOn (chafaiDensity f n) (Ici 0) := by
+  by_cases hn : n = 0
+  · subst n
+    have hzero : chafaiDensity f 0 = fun _ : ℝ => 0 := funext (chafaiDensity_zero f)
+    rw [hzero]
+    exact continuousOn_const
+  have heq : chafaiDensity f n = fun t => (-1 : ℝ) ^ n / (Nat.factorial (n - 1) : ℝ) *
+      t ^ (n - 1) * iteratedDerivWithin n f (Ici 0) t :=
+    funext (chafaiDensity_of_ne_zero hn f)
+  rw [heq]
+  exact (continuousOn_const.mul ((continuousOn_pow _).mono fun _ _ => trivial)).mul
+    (hcm.contDiffOn.continuousOn_iteratedDerivWithin (nat_le_top _) (uniqueDiffOn_Ici 0))
+
+/-- The `n`-th approximating measure `σ_n` for the Bernstein proof, with density `ρ_n` on
+`(0, ∞)`. -/
+noncomputable def chafaiMeasure (f : ℝ → ℝ) (n : ℕ) : Measure ℝ :=
+  (volume.restrict (Ioi 0)).withDensity (fun t => ENNReal.ofReal (chafaiDensity f n t))
+
+/-- `chafaiMeasure` as a `withDensity`, exposed as a lemma rather than an unfoldable body. -/
+lemma chafaiMeasure_eq_withDensity (f : ℝ → ℝ) (n : ℕ) :
+    chafaiMeasure f n =
+      (volume.restrict (Ioi 0)).withDensity (fun t => ENNReal.ofReal (chafaiDensity f n t)) := by
+  rw [chafaiMeasure]
+
+/-- The mass `chafaiMeasure f n` assigns to a measurable set, as a set lintegral of the density. -/
+lemma chafaiMeasure_apply (f : ℝ → ℝ) (n : ℕ) {s : Set ℝ} (hs : MeasurableSet s) :
+    chafaiMeasure f n s =
+      ∫⁻ t in s, ENNReal.ofReal (chafaiDensity f n t) ∂(volume.restrict (Ioi 0)) := by
+  rw [chafaiMeasure, withDensity_apply _ hs]
+
+/-- The density `ρ_n` is nonnegative for completely monotone functions on `[0, ∞)`. -/
+lemma chafaiDensity_nonneg (hcm : IsCompletelyMonotone f) (n : ℕ)
+    (t : ℝ) (ht : 0 ≤ t) : 0 ≤ chafaiDensity f n t := by
+  simp only [chafaiDensity]
+  split_ifs with hn
+  · exact le_refl 0
+  · have hcm_sign := hcm.neg_one_pow_mul_iteratedDerivWithin_nonneg n ht
+    have hfact_pos : (0 : ℝ) < ↑(Nat.factorial (n - 1)) :=
+      Nat.cast_pos.mpr (Nat.factorial_pos _)
+    calc (-1 : ℝ) ^ n / ↑(Nat.factorial (n - 1)) * t ^ (n - 1) *
+          iteratedDerivWithin n f (Ici 0) t
+        = t ^ (n - 1) / ↑(Nat.factorial (n - 1)) *
+          ((-1 : ℝ) ^ n * iteratedDerivWithin n f (Ici 0) t) := by field_simp
+      _ ≥ 0 := mul_nonneg (div_nonneg (pow_nonneg ht _) hfact_pos.le) hcm_sign
+
+/-- For `n = 1`, the density simplifies to `-f'(t)`. -/
+@[simp] lemma chafaiDensity_one (t : ℝ) :
+    chafaiDensity f 1 t = -iteratedDerivWithin 1 f (Ici 0) t := by
+  simp [chafaiDensity]
+
+/-- Difference of two successive Chafaï densities, in the algebraic form used by integration by
+parts. -/
+private lemma chafaiDensity_succ_succ_sub_succ (f : ℝ → ℝ) (m : ℕ) (t : ℝ) :
+    chafaiDensity f (m + 2) t - chafaiDensity f (m + 1) t =
+      ↑(m + 1) * t ^ m *
+          (((-1 : ℝ) ^ (m + 2) / ↑(m + 1).factorial) *
+            iteratedDerivWithin (m + 1) f (Ici 0) t) +
+        t ^ (m + 1) *
+          (((-1 : ℝ) ^ (m + 2) / ↑(m + 1).factorial) *
+            iteratedDerivWithin (m + 2) f (Ici 0) t) := by
+  have hm2 : m + 2 ≠ 0 := by omega
+  have hm1 : m + 1 ≠ 0 := by omega
+  have hdens_m2 :
+      chafaiDensity f (m + 2) t =
+        (-1 : ℝ) ^ (m + 2) / ((m + 1).factorial : ℝ) *
+          t ^ (m + 1) * iteratedDerivWithin (m + 2) f (Ici 0) t := by
+    rw [chafaiDensity_of_ne_zero hm2]
+    norm_num
+  have hdens_m1 :
+      chafaiDensity f (m + 1) t =
+        (-1 : ℝ) ^ (m + 1) / (m.factorial : ℝ) *
+          t ^ m * iteratedDerivWithin (m + 1) f (Ici 0) t := by
+    rw [chafaiDensity_of_ne_zero hm1]
+    norm_num
+  rw [hdens_m2, hdens_m1]
+  have hfact : ((m + 1).factorial : ℝ) = ((m + 1 : ℕ) : ℝ) * ↑m.factorial := by
+    rw [Nat.factorial_succ]
+    push_cast
+    ring
+  rw [hfact]
+  have hfact_ne : (m.factorial : ℝ) ≠ 0 := Nat.cast_ne_zero.mpr (Nat.factorial_ne_zero _)
+  have hsucc_ne : ((m : ℝ) + 1) ≠ 0 := by positivity
+  have hneg : (-1 : ℝ) ^ (m + 2) = (-1) ^ (m + 1) * (-1) := pow_succ (-1) (m + 1)
+  rw [hneg]
+  field_simp
+  ring
+
+/-! ## Rescaled measures and Prokhorov extraction -/
+
+/-- The Bernstein kernel `φ_n(x,p) = max(1 - xp/(n-1), 0)ⁿ⁻¹` for `n ≥ 2`. After the change of
+variable `p = (n-1)/t`, the Taylor integral kernel on `[0, T]` becomes `φ_n(x, p)`, which
+converges pointwise to `e^{-xp}` as `n → ∞` (the classical `(1-x/n)ⁿ → e^{-x}` limit). -/
+noncomputable def bernstein_kernel (n : ℕ) (x p : ℝ) : ℝ :=
+  if n ≤ 1 then 0 else (max (1 - x * p / (↑(n - 1) : ℝ)) 0) ^ (n - 1)
+
+/-- The Bernstein kernel vanishes for `n ≤ 1`. -/
+@[simp] lemma bernstein_kernel_of_le_one {n : ℕ} (hn : n ≤ 1) (x p : ℝ) :
+    bernstein_kernel n x p = 0 := by
+  rw [bernstein_kernel, if_pos hn]
+
+/-- The defining formula for the Bernstein kernel at `2 ≤ n`. -/
+lemma bernstein_kernel_of_two_le {n : ℕ} (hn : 2 ≤ n) (x p : ℝ) :
+    bernstein_kernel n x p = (max (1 - x * p / (↑(n - 1) : ℝ)) 0) ^ (n - 1) := by
+  have hnle : ¬ n ≤ 1 := by omega
+  rw [bernstein_kernel, if_neg hnle]
+
+/-- The Bernstein kernel is nonnegative. -/
+@[simp] lemma bernstein_kernel_nonneg (n : ℕ) (x p : ℝ) : 0 ≤ bernstein_kernel n x p := by
+  rw [bernstein_kernel]; split_ifs <;> positivity
+
+/-- The Bernstein kernel is measurable in `p` for fixed `n` and `x`. -/
+lemma measurable_bernstein_kernel (n : ℕ) (x : ℝ) : Measurable (bernstein_kernel n x) := by
+  unfold bernstein_kernel; split_ifs
+  · exact measurable_const
+  · fun_prop
+
+/-- **Pointwise convergence of the Bernstein kernel** to the Laplace kernel:
+`φ_n(x,p) → e^{-xp}` as `n → ∞`. -/
+lemma bernstein_kernel_tendsto (x p : ℝ) :
+    Tendsto (fun n : ℕ => bernstein_kernel n x p) atTop (nhds (Real.exp (-(x * p)))) := by
+  set g := fun n : ℕ => (1 + (-(x * p)) / (↑n : ℝ)) ^ n with hg_def
+  have hg_tendsto : Tendsto g atTop (nhds (Real.exp (-(x * p)))) :=
+    Real.tendsto_one_add_div_pow_exp (-(x * p))
+  have hshift : Tendsto (fun n : ℕ => g (n - 1)) atTop (nhds (Real.exp (-(x * p)))) :=
+    hg_tendsto.comp (tendsto_atTop_atTop.mpr (fun b => ⟨b + 1, fun n hn => by omega⟩))
+  apply Tendsto.congr' _ hshift
+  rw [eventuallyEq_iff_exists_mem]
+  refine ⟨{n : ℕ | n ≥ Nat.ceil (x * p) + 2}, mem_atTop _, ?_⟩
+  intro n hn
+  simp only [Set.mem_setOf_eq] at hn
+  simp only [bernstein_kernel, hg_def]
+  have hn1 : ¬(n ≤ 1) := by omega
+  simp only [hn1, ite_false]
+  have hn1_pos : (0 : ℝ) < ↑(n - 1) := Nat.cast_pos.mpr (by omega)
+  have hn1_ge : x * p ≤ ↑(n - 1) := by
+    calc x * p ≤ ↑(Nat.ceil (x * p)) := Nat.le_ceil _
+    _ ≤ ↑(n - 1) := by exact_mod_cast (by omega : Nat.ceil (x * p) ≤ n - 1)
+  congr 1
+  rw [max_eq_left]
+  · ring
+  · rw [sub_nonneg]; exact div_le_one_of_le₀ hn1_ge hn1_pos.le
+
+/-- The rescaling map `t ↦ max ((n-1)/t) 0`, valued in `ℝ≥0`. -/
+noncomputable def chafaiRescaling (n : ℕ) (t : ℝ) : ℝ≥0 :=
+  Real.toNNReal (((n : ℝ) - 1) / t)
+
+/-- The rescaling map `t ↦ max ((n-1)/t) 0`, valued in `ℝ≥0`, is measurable. -/
+lemma chafaiRescaling_measurable (n : ℕ) :
+    Measurable (chafaiRescaling n) :=
+  continuous_real_toNNReal.measurable.comp (measurable_const.div measurable_id)
+
+/-- On the positive part of the source, the `ℝ≥0` rescaling coerces back to `(n-1)/t`. -/
+lemma chafaiRescaling_coe_of_pos {n : ℕ} (hn : 1 ≤ n) {t : ℝ} (ht : 0 < t) :
+    (chafaiRescaling n t : ℝ) = ((n : ℝ) - 1) / t := by
+  have hnum : 0 ≤ (n : ℝ) - 1 := by
+    exact sub_nonneg.mpr (by exact_mod_cast hn)
+  have hnonneg : 0 ≤ ((n : ℝ) - 1) / t := div_nonneg hnum ht.le
+  simp [chafaiRescaling, Real.coe_toNNReal', max_eq_left hnonneg]
+
+/-- The rescaled measure `σ̃_n`: pushforward of `chafaiMeasure f n` under the `ℝ≥0` rescaling. -/
+noncomputable def chafaiRescaled (f : ℝ → ℝ) (n : ℕ) : Measure ℝ≥0 :=
+  Measure.map (chafaiRescaling n) (chafaiMeasure f n)
+
+/-- `chafaiRescaled` as a pushforward, exposed as a lemma rather than an unfoldable body. -/
+lemma chafaiRescaled_eq_map (f : ℝ → ℝ) (n : ℕ) :
+    chafaiRescaled f n = Measure.map (chafaiRescaling n) (chafaiMeasure f n) := by
+  rw [chafaiRescaled]
+
+/-- The mass `chafaiRescaled f n` assigns to a measurable set, as the pushforward formula. -/
+lemma chafaiRescaled_apply (f : ℝ → ℝ) (n : ℕ) {s : Set ℝ≥0} (hs : MeasurableSet s) :
+    chafaiRescaled f n s = chafaiMeasure f n ((chafaiRescaling n) ⁻¹' s) := by
+  rw [chafaiRescaled, Measure.map_apply (chafaiRescaling_measurable n) hs]
+
+/-- Integrating against `chafaiRescaled f n` is integrating the pullback along the Chafaï
+rescaling against `chafaiMeasure f n`. -/
+lemma chafaiRescaled_integral (f : ℝ → ℝ) (n : ℕ) {g : ℝ≥0 → ℝ}
+    (hg : AEStronglyMeasurable g (chafaiRescaled f n)) :
+    ∫ x, g x ∂(chafaiRescaled f n) =
+      ∫ t, g (chafaiRescaling n t) ∂(chafaiMeasure f n) := by
+  rw [chafaiRescaled_eq_map] at hg ⊢
+  exact MeasureTheory.integral_map (chafaiRescaling_measurable n).aemeasurable hg
+
+/-- `chafaiMeasure f n` lives on `(0, ∞)`: its complement has zero mass. -/
+lemma chafaiMeasure_compl_Ioi (f : ℝ → ℝ) (n : ℕ) :
+    (chafaiMeasure f n) (Ioi 0)ᶜ = 0 := by
+  unfold chafaiMeasure
+  rw [withDensity_apply _ (measurableSet_Ioi.compl)]
+  apply setLIntegral_measure_zero
+  rw [Measure.restrict_apply (measurableSet_Ioi.compl)]
+  have : (Ioi (0 : ℝ))ᶜ ∩ Ioi 0 = ∅ := by ext x; simp [Set.mem_Ioi]
+  rw [this, measure_empty]
+
+/-- Pushforward preserves total mass. -/
+lemma chafaiRescaled_mass_eq (f : ℝ → ℝ) (n : ℕ) :
+    (chafaiRescaled f n) univ = (chafaiMeasure f n) univ := by
+  unfold chafaiRescaled
+  rw [Measure.map_apply (chafaiRescaling_measurable n) MeasurableSet.univ, Set.preimage_univ]
+
+/-- **IBP identity** for the CM density:
+`∫₀ᵀ ρ_{m+2}(t) dt = B_{m+2}(T) + ∫₀ᵀ ρ_{m+1}(t) dt`. -/
+private lemma chafaiDensity_ibp_identity (f : ℝ → ℝ) (hcm : IsCompletelyMonotone f)
+    (m : ℕ) (T : ℝ) (hT : 0 < T) :
+    ∫ t in (0 : ℝ)..T, chafaiDensity f (m + 2) t =
+    (-1 : ℝ) ^ (m + 2) * T ^ (m + 1) / ↑(m + 1).factorial *
+      iteratedDerivWithin (m + 1) f (Ici 0) T +
+    ∫ t in (0 : ℝ)..T, chafaiDensity f (m + 1) t := by
+  set g := iteratedDerivWithin (m + 1) f (Ici 0)
+  set g' := iteratedDerivWithin (m + 2) f (Ici 0)
+  set c : ℝ := (-1) ^ (m + 2) / ↑(m + 1).factorial
+  set F := fun t : ℝ => t ^ (m + 1) * (c * g t)
+  have hg_cont : ContinuousOn g (Ici 0) :=
+    hcm.contDiffOn.continuousOn_iteratedDerivWithin (nat_le_top _) (uniqueDiffOn_Ici 0)
+  have hg_deriv : ∀ t, 0 < t → HasDerivAt g (g' t) t :=
+    fun t ht => hcm.hasDerivAt_iteratedDerivWithin_succ (m + 1) ht
+  have huIcc : uIcc (0 : ℝ) T = Icc 0 T := uIcc_of_le hT.le
+  have hF_cont : ContinuousOn F (Icc 0 T) :=
+    ((continuous_pow _).continuousOn).mul
+      (continuousOn_const.mul (hg_cont.mono Icc_subset_Ici_self))
+  have hF_deriv : ∀ t ∈ Ioo 0 T, HasDerivAt F
+      (↑(m + 1) * t ^ m * (c * g t) + t ^ (m + 1) * (c * g' t)) t :=
+    fun t ht => (hasDerivAt_pow (m + 1) t).mul ((hg_deriv t ht.1).const_mul c)
+  have hcm_int : ∀ k, k ≠ 0 → IntervalIntegrable (fun t => chafaiDensity f k t) volume 0 T := by
+    intro k hk; apply ContinuousOn.intervalIntegrable; rw [huIcc]
+    exact (continuousOn_chafaiDensity hcm k).mono Icc_subset_Ici_self
+  have hF'_eq : ∀ t, ↑(m + 1) * t ^ m * (c * g t) + t ^ (m + 1) * (c * g' t) =
+      chafaiDensity f (m + 2) t - chafaiDensity f (m + 1) t := by
+    intro t
+    simp only [g, g', c]
+    exact (chafaiDensity_succ_succ_sub_succ f m t).symm
+  have hF'_int : IntervalIntegrable
+      (fun t => ↑(m + 1) * t ^ m * (c * g t) + t ^ (m + 1) * (c * g' t)) volume 0 T :=
+    ((hcm_int _ (by omega)).sub (hcm_int _ (by omega))).congr fun t _ => (hF'_eq t).symm
+  have hftc := intervalIntegral.integral_eq_sub_of_hasDerivAt_of_le hT.le hF_cont hF_deriv hF'_int
+  have hstep1 : ∫ t in (0 : ℝ)..T,
+      (chafaiDensity f (m + 2) t - chafaiDensity f (m + 1) t) = F T - F 0 := by
+    rw [← hftc]
+    exact intervalIntegral.integral_congr_ae
+      (Filter.Eventually.of_forall fun t _ => (hF'_eq t).symm)
+  have hm1 : m + 1 ≠ 0 := by omega
+  have hF0 : F 0 = 0 := by simp [F, zero_pow hm1]
+  rw [hF0, sub_zero] at hstep1
+  rw [intervalIntegral.integral_sub (hcm_int _ (by omega)) (hcm_int _ (by omega))] at hstep1
+  suffices hgoal : (-1 : ℝ) ^ (m + 2) * T ^ (m + 1) / ↑(m + 1).factorial * g T = F T by linarith
+  simp only [F, c]; ring
+
+/-- Monotonicity of the finite-interval Chafaï-density masses in the order:
+`∫₀ᵀ dₖ ≤ ∫₀ᵀ dₖ₋₁` for `2 ≤ k`. This is the exported integration-by-parts consequence
+(the raw IBP identity `chafaiDensity_ibp_identity` is private); it is the per-step density
+mass-monotonicity bound consumed by the Bernstein-identity assembly. -/
+lemma integral_chafaiDensity_le_pred (f : ℝ → ℝ) (hcm : IsCompletelyMonotone f)
+    (k : ℕ) (hk : 2 ≤ k) (T : ℝ) (hT : 0 < T) :
+    ∫ t in (0 : ℝ)..T, chafaiDensity f k t ≤ ∫ t in (0 : ℝ)..T, chafaiDensity f (k - 1) t := by
+  obtain ⟨m, rfl⟩ : ∃ m, k = m + 2 := ⟨k - 2, by omega⟩
+  have hsub : m + 2 - 1 = m + 1 := by omega
+  simp only [hsub]
+  have hibp := chafaiDensity_ibp_identity f hcm m T hT
+  set B := (-1 : ℝ) ^ (m + 2) * T ^ (m + 1) / ↑(m + 1).factorial *
+    iteratedDerivWithin (m + 1) f (Ici 0) T
+  have hB : B ≤ 0 := by
+    have h_neg : (-1 : ℝ) ^ (m + 2) * iteratedDerivWithin (m + 1) f (Ici 0) T ≤ 0 := by
+      have : (-1 : ℝ) ^ (m + 2) = (-1) ^ (m + 1) * (-1) := pow_succ (-1) (m + 1)
+      rw [this]; nlinarith [hcm.neg_one_pow_mul_iteratedDerivWithin_nonneg (m + 1) hT.le]
+    suffices B = T ^ (m + 1) / ↑(m + 1).factorial *
+        ((-1 : ℝ) ^ (m + 2) * iteratedDerivWithin (m + 1) f (Ici 0) T) by
+      rw [this]
+      exact mul_nonpos_of_nonneg_of_nonpos
+        (div_nonneg (pow_nonneg hT.le _) (Nat.cast_nonneg _)) h_neg
+    simp only [B]; ring
+  linarith
+
+/-- The public `n = 0` convention for Chafaï measures: the zeroth approximating measure is
+zero. -/
+@[simp]
+lemma chafaiMeasure_zero (f : ℝ → ℝ) : chafaiMeasure f 0 = 0 := by
+  rw [chafaiMeasure_eq_withDensity]
+  ext s hs
+  rw [withDensity_apply _ hs]
+  simp
+
+private lemma integral_chafaiDensity_one_eq (f : ℝ → ℝ) (hcm : IsCompletelyMonotone f)
+    (T : ℝ) (hT : 0 < T) :
+    ∫ t in (0 : ℝ)..T, chafaiDensity f 1 t = f 0 - f T := by
+  have h1 : ∫ t in (0 : ℝ)..T, chafaiDensity f 1 t =
+      ∫ t in (0 : ℝ)..T, -iteratedDerivWithin 1 f (Ici 0) t :=
+    intervalIntegral.integral_congr_ae
+      (Filter.Eventually.of_forall fun t _ => chafaiDensity_one t)
+  rw [h1, ← hcm.integral_neg_deriv_Ici T hT.le, hcm.integral_mass T hT.le]
+
+private lemma integral_chafaiDensity_le_sub (f : ℝ → ℝ) (hcm : IsCompletelyMonotone f)
+    (j : ℕ) (hj : 1 ≤ j) (T : ℝ) (hT : 0 < T) :
+    ∫ t in (0 : ℝ)..T, chafaiDensity f j t ≤ f 0 - f T := by
+  induction j with
+  | zero => omega
+  | succ p ih =>
+    by_cases hp : p = 0
+    · subst hp
+      exact le_of_eq (integral_chafaiDensity_one_eq f hcm T hT)
+    · calc ∫ t in (0 : ℝ)..T, chafaiDensity f (p + 1) t
+          ≤ ∫ t in (0 : ℝ)..T, chafaiDensity f p t := by
+            simpa using integral_chafaiDensity_le_pred f hcm (p + 1) (by omega) T hT
+        _ ≤ f 0 - f T := ih (Nat.one_le_iff_ne_zero.mpr hp)
+
+private lemma integral_chafaiDensity_le_tendsto_sub (f : ℝ → ℝ)
+    (hcm : IsCompletelyMonotone f) (n : ℕ) (hn : 1 ≤ n) (L : ℝ)
+    (hL : Tendsto f atTop (nhds L)) (T : ℝ) (hT : 0 < T) :
+    ∫ t in (0 : ℝ)..T, chafaiDensity f n t ≤ f 0 - L := by
+  linarith [integral_chafaiDensity_le_sub f hcm n hn T hT,
+    hcm.le_of_tendsto_atTop hL hT.le]
+
+private lemma chafaiDensity_integrableOn_Ioi_of_tendsto (f : ℝ → ℝ)
+    (hcm : IsCompletelyMonotone f) (n : ℕ) (hn : 1 ≤ n) (L : ℝ)
+    (hL : Tendsto f atTop (nhds L)) :
+    IntegrableOn (chafaiDensity f n) (Ioi 0) := by
+  have hcont : ContinuousOn (chafaiDensity f n) (Ici 0) := continuousOn_chafaiDensity hcm n
+  apply integrableOn_Ioi_of_intervalIntegral_norm_bounded (f 0 - L) 0
+    (l := atTop) (b := id)
+  · intro T
+    exact (hcont.mono Icc_subset_Ici_self).integrableOn_compact isCompact_Icc
+      |>.mono_set Ioc_subset_Icc_self
+  · exact tendsto_id
+  · filter_upwards [eventually_gt_atTop 0] with T hT
+    simp only [id]
+    calc ∫ t in (0 : ℝ)..T, ‖chafaiDensity f n t‖
+        = ∫ t in (0 : ℝ)..T, chafaiDensity f n t := by
+          apply intervalIntegral.integral_congr_ae
+          apply ae_of_all
+          intro t ht
+          rw [uIoc_of_le hT.le] at ht
+          rw [Real.norm_eq_abs, abs_of_nonneg (chafaiDensity_nonneg hcm n t ht.1.le)]
+      _ ≤ f 0 - L := integral_chafaiDensity_le_tendsto_sub f hcm n hn L hL T hT
+
+private lemma chafaiMeasure_mass_le_of_tendsto (f : ℝ → ℝ)
+    (hcm : IsCompletelyMonotone f) (n : ℕ) (hn : 1 ≤ n) (L : ℝ)
+    (hL : Tendsto f atTop (nhds L))
+    (hint : IntegrableOn (chafaiDensity f n) (Ioi 0)) :
+    (chafaiMeasure f n) univ ≤ ENNReal.ofReal (f 0 - L) := by
+  rw [chafaiMeasure_eq_withDensity]
+  rw [withDensity_apply _ MeasurableSet.univ]
+  simp only [Measure.restrict_univ]
+  rw [← ofReal_integral_eq_lintegral_ofReal hint
+    ((ae_restrict_mem measurableSet_Ioi).mono fun t (ht : 0 < t) =>
+      chafaiDensity_nonneg hcm n t ht.le)]
+  exact ENNReal.ofReal_le_ofReal
+    (le_of_tendsto (intervalIntegral_tendsto_integral_Ioi 0 hint tendsto_id)
+      (eventually_atTop.mpr ⟨1, fun T hT =>
+        integral_chafaiDensity_le_tendsto_sub f hcm n hn L hL T (by linarith)⟩))
+
+/-- **Total mass bound with a chosen limit**: `chafaiMeasure f n` is finite with total mass
+`≤ f(0) - L` whenever `f(t) → L` at infinity. -/
+lemma chafaiMeasure_finite_mass_of_tendsto (f : ℝ → ℝ) (hcm : IsCompletelyMonotone f)
+    (n : ℕ) (L : ℝ) (hL : Tendsto f atTop (nhds L)) :
+    IsFiniteMeasure (chafaiMeasure f n) ∧
+    (chafaiMeasure f n) univ ≤ ENNReal.ofReal (f 0 - L) := by
+  by_cases hn0 : n = 0
+  · subst n
+    rw [chafaiMeasure_zero]
+    exact ⟨inferInstance, by simp⟩
+  have hn : 1 ≤ n := Nat.one_le_iff_ne_zero.mpr hn0
+  have hint : IntegrableOn (chafaiDensity f n) (Ioi 0) :=
+    chafaiDensity_integrableOn_Ioi_of_tendsto f hcm n hn L hL
+  have hfin : IsFiniteMeasure (chafaiMeasure f n) := by
+    unfold chafaiMeasure
+    exact isFiniteMeasure_withDensity_ofReal hint.hasFiniteIntegral
+  have hmass : (chafaiMeasure f n) univ ≤ ENNReal.ofReal (f 0 - L) :=
+    chafaiMeasure_mass_le_of_tendsto f hcm n hn L hL hint
+  exact ⟨hfin, hmass⟩
+
+/-- **Natural total mass bound**: for a completely monotone `f`, the Chafaï measures are finite
+and uniformly bounded by `f(0) - L`, where `L` is the automatically obtained limit of `f` at
+infinity. -/
+lemma chafaiMeasure_finite_mass (f : ℝ → ℝ) (hcm : IsCompletelyMonotone f) :
+    ∃ L : ℝ, Tendsto f atTop (nhds L) ∧ 0 ≤ L ∧
+      ∀ n,
+        IsFiniteMeasure (chafaiMeasure f n) ∧
+        (chafaiMeasure f n) univ ≤ ENNReal.ofReal (f 0 - L) := by
+  obtain ⟨L, hL, hL_nn⟩ := hcm.tendsto_atTop
+  exact ⟨L, hL, hL_nn, fun n => chafaiMeasure_finite_mass_of_tendsto f hcm n L hL⟩
+
+end TauCeti

--- a/TauCeti/Analysis/CompletelyMonotone/BernsteinMeasures.lean
+++ b/TauCeti/Analysis/CompletelyMonotone/BernsteinMeasures.lean
@@ -212,8 +212,7 @@ lemma bernstein_kernel_le_one {n : ℕ} {x p : ℝ} (hx : 0 ≤ x) (hp : 0 ≤ p
 
 /-- The Bernstein kernel as a bundled bounded continuous test function of the nonnegative
 variable `p`, for fixed `n` and nonnegative `x`. -/
-@[expose]
-noncomputable def bernsteinKernelBCF (n : ℕ) {x : ℝ} (hx : 0 ≤ x) : ℝ≥0 →ᵇ ℝ where
+noncomputable abbrev bernsteinKernelBCF (n : ℕ) {x : ℝ} (hx : 0 ≤ x) : ℝ≥0 →ᵇ ℝ where
   toFun := fun p => bernstein_kernel n x (p : ℝ)
   continuous_toFun := (continuous_bernstein_kernel n x).comp continuous_subtype_val
   map_bounded' :=

--- a/TauCeti/Analysis/CompletelyMonotone/BernsteinMeasures.lean
+++ b/TauCeti/Analysis/CompletelyMonotone/BernsteinMeasures.lean
@@ -37,6 +37,9 @@ These build on the `IsCompletelyMonotone` API in `CompletelyMonotone/Basic.lean`
   measures and mass preservation.
 * `TauCeti.chafaiMeasure_finite_mass`, `TauCeti.chafaiRescaled_finite_mass`: finiteness and the
   total-mass bound `≤ f(0) - L`.
+* `TauCeti.chafaiRescaled_prokhorov_mass_bound`,
+  `TauCeti.chafaiRescaled_tendsto_laplace_integral_of_weak`: Prokhorov-ready mass bounds and
+  the Laplace test-function specialization of weak convergence for the rescaled measures.
 
 ## References
 
@@ -97,7 +100,8 @@ lemma continuousOn_chafaiDensity {n : ℕ}
   exact (continuousOn_const.mul ((continuousOn_pow _).mono fun _ _ => trivial)).mul
     (hf.continuousOn_iteratedDerivWithin le_rfl (uniqueDiffOn_Ici 0))
 
-/-- The `n`-th approximating measure `σ_n` for the Bernstein proof, with density `ρ_n` on
+/-- The `n`-th Chafaï approximating measure `σ_n` for the Bernstein representation, with density
+`ρ_n` on
 `(0, ∞)`. -/
 noncomputable def chafaiMeasure (f : ℝ → ℝ) (n : ℕ) : Measure ℝ :=
   (volume.restrict (Ioi 0)).withDensity (fun t => ENNReal.ofReal (chafaiDensity f n t))
@@ -417,10 +421,8 @@ private lemma chafaiDensity_ibp_identity (f : ℝ → ℝ) {m : ℕ}
   simp only [F, c]; ring
 
 /-- Monotonicity of the finite-interval Chafaï-density integrals in the order:
-`∫₀ᵀ dₖ ≤ ∫₀ᵀ dₖ₋₁` for `2 ≤ k` and `0 ≤ T`. This is the exported
-integration-by-parts consequence
-(the raw IBP identity `chafaiDensity_ibp_identity` is private); it is the per-step density
-integral-monotonicity bound consumed by the Bernstein-identity assembly. -/
+for `2 ≤ k` and `0 ≤ T`, the integral of the `k`-th density on `[0,T]` is bounded above by the
+integral of the preceding density, assuming the endpoint has the required alternating sign. -/
 lemma integral_chafaiDensity_le_pred (f : ℝ → ℝ) {k : ℕ} (hk : 2 ≤ k)
     (hf : ContDiffOn ℝ (k : WithTop ℕ∞) f (Ici 0))
     (T : ℝ) (hT : 0 ≤ T)
@@ -472,7 +474,7 @@ private lemma integral_chafaiDensity_one_eq (f : ℝ → ℝ) (hcm : IsCompletel
       ∫ t in (0 : ℝ)..T, -iteratedDerivWithin 1 f (Ici 0) t :=
     intervalIntegral.integral_congr_ae
       (Filter.Eventually.of_forall fun t _ => chafaiDensity_one t)
-  rw [h1, ← hcm.integral_neg_iteratedDerivWithin_one_Ici T hT.le,
+  rw [h1, ← hcm.integral_neg_iteratedDerivWithin_one_Icc_eq_Ici T hT.le,
     hcm.integral_neg_iteratedDerivWithin_one_Icc_zero_left T hT.le]
 
 private lemma integral_chafaiDensity_le_sub (f : ℝ → ℝ) (hcm : IsCompletelyMonotone f)
@@ -591,5 +593,37 @@ lemma chafaiRescaled_finite_mass (f : ℝ → ℝ) (hcm : IsCompletelyMonotone f
   · exact ⟨by rw [hmass]; exact (hfinite n).1.measure_univ_lt_top⟩
   · rw [hmass]
     exact (hfinite n).2
+
+/-- Prokhorov-ready mass bound for the rescaled Chafaï measures: a completely monotone function
+supplies a nonnegative real mass constant `C = f(0) - L`, where `L` is the limit of `f` at
+infinity, such that every `chafaiRescaled f n` is finite and has total mass at most `C`. -/
+lemma chafaiRescaled_prokhorov_mass_bound (f : ℝ → ℝ) (hcm : IsCompletelyMonotone f) :
+    ∃ L : ℝ, ∃ C : ℝ≥0, Tendsto f atTop (nhds L) ∧ 0 ≤ L ∧ (C : ℝ) = f 0 - L ∧
+      ∀ n,
+        IsFiniteMeasure (chafaiRescaled f n) ∧
+        (chafaiRescaled f n) univ ≤ (C : ENNReal) := by
+  obtain ⟨L, hL, hL_nn, hfinite⟩ := chafaiRescaled_finite_mass f hcm
+  have hL_le : L ≤ f 0 := hcm.le_of_tendsto_atTop hL le_rfl
+  let C : ℝ≥0 := ⟨f 0 - L, sub_nonneg.mpr hL_le⟩
+  refine ⟨L, C, hL, hL_nn, rfl, fun n => ?_⟩
+  refine ⟨(hfinite n).1, ?_⟩
+  have hC : (C : ENNReal) = ENNReal.ofReal (f 0 - L) := by
+    rw [← ENNReal.ofReal_coe_nnreal (p := C)]
+    rfl
+  rw [hC]
+  exact (hfinite n).2
+
+/-- Weak convergence of the rescaled Chafaï measures specializes to the Laplace kernel:
+if all bounded-continuous test integrals for `chafaiRescaled f n` converge to those for `μ₀`,
+then the integrals of `p ↦ exp (-x * p)` converge for every `x ≥ 0`. -/
+lemma chafaiRescaled_tendsto_laplace_integral_of_weak
+    {μ₀ : Measure ℝ≥0} {l : Filter ℕ}
+    (hweak : ∀ g : BoundedContinuousFunction ℝ≥0 ℝ,
+        Tendsto (fun n => ∫ p, g p ∂(chafaiRescaled f n)) l
+          (nhds (∫ p, g p ∂μ₀)))
+    {x : ℝ} (hx : 0 ≤ x) :
+    Tendsto (fun n => ∫ p, Real.exp (-(x * (p : ℝ))) ∂(chafaiRescaled f n)) l
+      (nhds (∫ p, Real.exp (-(x * (p : ℝ))) ∂μ₀)) := by
+  simpa using hweak (laplaceKernelBoundedContinuous hx)
 
 end TauCeti

--- a/TauCeti/Analysis/CompletelyMonotone/BernsteinMeasures.lean
+++ b/TauCeti/Analysis/CompletelyMonotone/BernsteinMeasures.lean
@@ -292,7 +292,7 @@ noncomputable def chafaiRescaling (n : ℕ) (t : ℝ) : ℝ≥0 :=
   Real.toNNReal (((n : ℝ) - 1) / t)
 
 /-- The rescaling map `t ↦ max ((n-1)/t) 0`, valued in `ℝ≥0`, is measurable. -/
-lemma chafaiRescaling_measurable (n : ℕ) :
+lemma measurable_chafaiRescaling (n : ℕ) :
     Measurable (chafaiRescaling n) :=
   continuous_real_toNNReal.measurable.comp (measurable_const.div measurable_id)
 
@@ -316,7 +316,7 @@ lemma chafaiRescaled_eq_map (f : ℝ → ℝ) (n : ℕ) :
 /-- The mass `chafaiRescaled f n` assigns to a measurable set, as the pushforward formula. -/
 lemma chafaiRescaled_apply (f : ℝ → ℝ) (n : ℕ) {s : Set ℝ≥0} (hs : MeasurableSet s) :
     chafaiRescaled f n s = chafaiMeasure f n ((chafaiRescaling n) ⁻¹' s) := by
-  rw [chafaiRescaled, Measure.map_apply (chafaiRescaling_measurable n) hs]
+  rw [chafaiRescaled, Measure.map_apply (measurable_chafaiRescaling n) hs]
 
 /-- Integrating against `chafaiRescaled f n` is integrating the pullback along the Chafaï
 rescaling against `chafaiMeasure f n`. -/
@@ -325,7 +325,7 @@ lemma chafaiRescaled_integral (f : ℝ → ℝ) (n : ℕ) {g : ℝ≥0 → ℝ}
     ∫ x, g x ∂(chafaiRescaled f n) =
       ∫ t, g (chafaiRescaling n t) ∂(chafaiMeasure f n) := by
   rw [chafaiRescaled_eq_map] at hg ⊢
-  exact MeasureTheory.integral_map (chafaiRescaling_measurable n).aemeasurable hg
+  exact MeasureTheory.integral_map (measurable_chafaiRescaling n).aemeasurable hg
 
 /-- `chafaiMeasure f n` lives on `(0, ∞)`: its complement has zero mass. -/
 lemma chafaiMeasure_compl_Ioi (f : ℝ → ℝ) (n : ℕ) :
@@ -341,7 +341,7 @@ lemma chafaiMeasure_compl_Ioi (f : ℝ → ℝ) (n : ℕ) :
 lemma chafaiRescaled_mass_eq (f : ℝ → ℝ) (n : ℕ) :
     (chafaiRescaled f n) univ = (chafaiMeasure f n) univ := by
   unfold chafaiRescaled
-  rw [Measure.map_apply (chafaiRescaling_measurable n) MeasurableSet.univ, Set.preimage_univ]
+  rw [Measure.map_apply (measurable_chafaiRescaling n) MeasurableSet.univ, Set.preimage_univ]
 
 /-- **IBP identity** for the CM density:
 `∫₀ᵀ ρ_{m+2}(t) dt = B_{m+2}(T) + ∫₀ᵀ ρ_{m+1}(t) dt`. -/

--- a/TauCeti/Analysis/CompletelyMonotone/BernsteinMeasures.lean
+++ b/TauCeti/Analysis/CompletelyMonotone/BernsteinMeasures.lean
@@ -74,6 +74,7 @@ noncomputable def chafaiDensity (f : ℝ → ℝ) (n : ℕ) (t : ℝ) : ℝ :=
   rw [chafaiDensity, if_pos rfl]
 
 /-- The defining formula for `chafaiDensity` at a nonzero order. -/
+@[simp]
 lemma chafaiDensity_of_ne_zero {n : ℕ} (hn : n ≠ 0) (f : ℝ → ℝ) (t : ℝ) :
     chafaiDensity f n t = (-1 : ℝ) ^ n / (Nat.factorial (n - 1) : ℝ) *
       t ^ (n - 1) * iteratedDerivWithin n f (Ici 0) t := by
@@ -108,6 +109,7 @@ lemma chafaiMeasure_eq_withDensity (f : ℝ → ℝ) (n : ℕ) :
   rw [chafaiMeasure]
 
 /-- The mass `chafaiMeasure f n` assigns to a measurable set, as a set lintegral of the density. -/
+@[simp]
 lemma chafaiMeasure_apply (f : ℝ → ℝ) (n : ℕ) {s : Set ℝ} (hs : MeasurableSet s) :
     chafaiMeasure f n s =
       ∫⁻ t in s, ENNReal.ofReal (chafaiDensity f n t) ∂(volume.restrict (Ioi 0)) := by
@@ -144,6 +146,7 @@ private lemma chafaiDensity_succ_succ_sub_succ (f : ℝ → ℝ) (m : ℕ) (t : 
         t ^ (m + 1) *
           (((-1 : ℝ) ^ (m + 2) / ↑(m + 1).factorial) *
             iteratedDerivWithin (m + 2) f (Ici 0) t) := by
+  -- Put both densities into their nonzero defining branches.
   have hm2 : m + 2 ≠ 0 := by omega
   have hm1 : m + 1 ≠ 0 := by omega
   have hdens_m2 :
@@ -159,6 +162,8 @@ private lemma chafaiDensity_succ_succ_sub_succ (f : ℝ → ℝ) (m : ℕ) (t : 
     rw [chafaiDensity_of_ne_zero hm1]
     norm_num
   rw [hdens_m2, hdens_m1]
+  -- Move the two factorial denominators to the same `(m + 1)!` denominator and normalize the
+  -- alternating sign.
   have hfact : ((m + 1).factorial : ℝ) = ((m + 1 : ℕ) : ℝ) * ↑m.factorial := by
     rw [Nat.factorial_succ]
     push_cast
@@ -185,6 +190,7 @@ noncomputable def bernstein_kernel (n : ℕ) (x p : ℝ) : ℝ :=
   rw [bernstein_kernel, if_pos hn]
 
 /-- The defining formula for the Bernstein kernel at `2 ≤ n`. -/
+@[simp]
 lemma bernstein_kernel_of_two_le {n : ℕ} (hn : 2 ≤ n) (x p : ℝ) :
     bernstein_kernel n x p = (max (1 - x * p / (↑(n - 1) : ℝ)) 0) ^ (n - 1) := by
   have hnle : ¬ n ≤ 1 := by omega
@@ -300,6 +306,7 @@ lemma measurable_chafaiRescaling (n : ℕ) :
   continuous_real_toNNReal.measurable.comp (measurable_const.div measurable_id)
 
 /-- On the positive part of the source, the `ℝ≥0` rescaling coerces back to `(n-1)/t`. -/
+@[simp]
 lemma chafaiRescaling_coe_of_pos {n : ℕ} (hn : 1 ≤ n) {t : ℝ} (ht : 0 < t) :
     (chafaiRescaling n t : ℝ) = ((n : ℝ) - 1) / t := by
   have hnum : 0 ≤ (n : ℝ) - 1 := by
@@ -317,6 +324,7 @@ lemma chafaiRescaled_eq_map (f : ℝ → ℝ) (n : ℕ) :
   rw [chafaiRescaled]
 
 /-- The mass `chafaiRescaled f n` assigns to a measurable set, as the pushforward formula. -/
+@[simp]
 lemma chafaiRescaled_apply (f : ℝ → ℝ) (n : ℕ) {s : Set ℝ≥0} (hs : MeasurableSet s) :
     chafaiRescaled f n s = chafaiMeasure f n ((chafaiRescaling n) ⁻¹' s) := by
   rw [chafaiRescaled, Measure.map_apply (measurable_chafaiRescaling n) hs]
@@ -331,6 +339,7 @@ lemma chafaiRescaled_integral (f : ℝ → ℝ) (n : ℕ) {g : ℝ≥0 → ℝ}
   exact MeasureTheory.integral_map (measurable_chafaiRescaling n).aemeasurable hg
 
 /-- `chafaiMeasure f n` lives on `(0, ∞)`: its complement has zero mass. -/
+@[simp]
 lemma chafaiMeasure_compl_Ioi (f : ℝ → ℝ) (n : ℕ) :
     (chafaiMeasure f n) (Ioi 0)ᶜ = 0 := by
   unfold chafaiMeasure
@@ -341,6 +350,7 @@ lemma chafaiMeasure_compl_Ioi (f : ℝ → ℝ) (n : ℕ) :
   rw [this, measure_empty]
 
 /-- Pushforward preserves total mass. -/
+@[simp]
 lemma chafaiRescaled_mass_eq (f : ℝ → ℝ) (n : ℕ) :
     (chafaiRescaled f n) univ = (chafaiMeasure f n) univ := by
   unfold chafaiRescaled
@@ -354,10 +364,13 @@ private lemma chafaiDensity_ibp_identity (f : ℝ → ℝ) {m : ℕ}
     (-1 : ℝ) ^ (m + 2) * T ^ (m + 1) / ↑(m + 1).factorial *
       iteratedDerivWithin (m + 1) f (Ici 0) T +
     ∫ t in (0 : ℝ)..T, chafaiDensity f (m + 1) t := by
+  -- Set up the primitive whose derivative is the difference of successive densities.
   set g := iteratedDerivWithin (m + 1) f (Ici 0)
   set g' := iteratedDerivWithin (m + 2) f (Ici 0)
   set c : ℝ := (-1) ^ (m + 2) / ↑(m + 1).factorial
   set F := fun t : ℝ => t ^ (m + 1) * (c * g t)
+  -- Smoothness gives continuity of the primitive and differentiability of the iterated
+  -- derivative on the open interval.
   have hg_cont : ContinuousOn g (Ici 0) :=
     (hf.of_le (by exact_mod_cast (by omega : m + 1 ≤ m + 2))).continuousOn_iteratedDerivWithin
       le_rfl (uniqueDiffOn_Ici 0)
@@ -371,6 +384,7 @@ private lemma chafaiDensity_ibp_identity (f : ℝ → ℝ) {m : ℕ}
   have hF_deriv : ∀ t ∈ Ioo 0 T, HasDerivAt F
       (↑(m + 1) * t ^ m * (c * g t) + t ^ (m + 1) * (c * g' t)) t :=
     fun t ht => (hasDerivAt_pow (m + 1) t).mul ((hg_deriv t ht.1).const_mul c)
+  -- Transfer interval integrability from continuity of the two density branches.
   have h_int_m2 : IntervalIntegrable (fun t => chafaiDensity f (m + 2) t) volume 0 T := by
     apply ContinuousOn.intervalIntegrable; rw [huIcc]
     exact (continuousOn_chafaiDensity (n := m + 2) hf).mono Icc_subset_Ici_self
@@ -386,6 +400,8 @@ private lemma chafaiDensity_ibp_identity (f : ℝ → ℝ) {m : ℕ}
   have hF'_int : IntervalIntegrable
       (fun t => ↑(m + 1) * t ^ m * (c * g t) + t ^ (m + 1) * (c * g' t)) volume 0 T :=
     (h_int_m2.sub h_int_m1).congr fun t _ => (hF'_eq t).symm
+  -- Apply FTC to the primitive and rewrite the derivative integral as the difference of the
+  -- Chafaï density integrals.
   have hftc := intervalIntegral.integral_eq_sub_of_hasDerivAt_of_le hT.le hF_cont hF_deriv hF'_int
   have hstep1 : ∫ t in (0 : ℝ)..T,
       (chafaiDensity f (m + 2) t - chafaiDensity f (m + 1) t) = F T - F 0 := by
@@ -396,19 +412,21 @@ private lemma chafaiDensity_ibp_identity (f : ℝ → ℝ) {m : ℕ}
   have hF0 : F 0 = 0 := by simp [F, zero_pow hm1]
   rw [hF0, sub_zero] at hstep1
   rw [intervalIntegral.integral_sub h_int_m2 h_int_m1] at hstep1
+  -- The lower endpoint vanishes; the upper endpoint is the boundary term in the statement.
   suffices hgoal : (-1 : ℝ) ^ (m + 2) * T ^ (m + 1) / ↑(m + 1).factorial * g T = F T by linarith
   simp only [F, c]; ring
 
-/-- Monotonicity of the finite-interval Chafaï-density masses in the order:
+/-- Monotonicity of the finite-interval Chafaï-density integrals in the order:
 `∫₀ᵀ dₖ ≤ ∫₀ᵀ dₖ₋₁` for `2 ≤ k` and `0 ≤ T`. This is the exported
 integration-by-parts consequence
 (the raw IBP identity `chafaiDensity_ibp_identity` is private); it is the per-step density
-mass-monotonicity bound consumed by the Bernstein-identity assembly. -/
+integral-monotonicity bound consumed by the Bernstein-identity assembly. -/
 lemma integral_chafaiDensity_le_pred (f : ℝ → ℝ) {k : ℕ} (hk : 2 ≤ k)
     (hf : ContDiffOn ℝ (k : WithTop ℕ∞) f (Ici 0))
     (T : ℝ) (hT : 0 ≤ T)
     (hsign : 0 ≤ (-1 : ℝ) ^ (k - 1) * iteratedDerivWithin (k - 1) f (Ici 0) T) :
     ∫ t in (0 : ℝ)..T, chafaiDensity f k t ≤ ∫ t in (0 : ℝ)..T, chafaiDensity f (k - 1) t := by
+  -- The degenerate interval is immediate; otherwise reindex `k` as `m + 2` for the IBP lemma.
   rcases hT.eq_or_lt with rfl | hT_pos
   · simp
   obtain ⟨m, rfl⟩ : ∃ m, k = m + 2 := ⟨k - 2, by omega⟩
@@ -417,6 +435,7 @@ lemma integral_chafaiDensity_le_pred (f : ℝ → ℝ) {k : ℕ} (hk : 2 ≤ k)
   have hibp := chafaiDensity_ibp_identity (m := m) f hf T hT_pos
   set B := (-1 : ℝ) ^ (m + 2) * T ^ (m + 1) / ↑(m + 1).factorial *
     iteratedDerivWithin (m + 1) f (Ici 0) T
+  -- The boundary term in the IBP identity is nonpositive by complete-monotone sign alternation.
   have hB : B ≤ 0 := by
     have hsign_m : 0 ≤ (-1 : ℝ) ^ (m + 1) * iteratedDerivWithin (m + 1) f (Ici 0) T := by
       simpa [hsub] using hsign
@@ -454,7 +473,7 @@ private lemma integral_chafaiDensity_one_eq (f : ℝ → ℝ) (hcm : IsCompletel
     intervalIntegral.integral_congr_ae
       (Filter.Eventually.of_forall fun t _ => chafaiDensity_one t)
   rw [h1, ← hcm.integral_neg_iteratedDerivWithin_one_Ici T hT.le,
-    hcm.integral_mass T hT.le]
+    hcm.integral_neg_iteratedDerivWithin_one_Icc_zero_left T hT.le]
 
 private lemma integral_chafaiDensity_le_sub (f : ℝ → ℝ) (hcm : IsCompletelyMonotone f)
     (j : ℕ) (hj : 1 ≤ j) (T : ℝ) (hT : 0 < T) :
@@ -486,12 +505,17 @@ private lemma chafaiDensity_integrableOn_Ioi_of_tendsto (f : ℝ → ℝ)
     IntegrableOn (chafaiDensity f n) (Ioi 0) := by
   have hcont : ContinuousOn (chafaiDensity f n) (Ici 0) :=
     continuousOn_chafaiDensity (n := n) ((hcm.contDiffOn).of_le (nat_le_top n))
+  -- The improper-integrability criterion reduces the proof to compact integrability on each
+  -- interval and a uniform bound for interval integrals of `|ρ_n|`.
   apply integrableOn_Ioi_of_intervalIntegral_norm_bounded (f 0 - L) 0
     (l := atTop) (b := id)
+  -- Compact integrability comes from continuity of the density on `[0, ∞)`.
   · intro T
     exact (hcont.mono Icc_subset_Ici_self).integrableOn_compact isCompact_Icc
       |>.mono_set Ioc_subset_Icc_self
   · exact tendsto_id
+  -- On positive intervals the density is nonnegative, so the norm integral is the density
+  -- integral, bounded by the finite-interval Chafaï estimate.
   · filter_upwards [eventually_gt_atTop 0] with T hT
     simp only [id]
     calc ∫ t in (0 : ℝ)..T, ‖chafaiDensity f n t‖

--- a/TauCeti/Analysis/CompletelyMonotone/BernsteinMeasures.lean
+++ b/TauCeti/Analysis/CompletelyMonotone/BernsteinMeasures.lean
@@ -10,12 +10,17 @@ public import TauCeti.Analysis.CompletelyMonotone.Integral
 /-!
 # Approximating measures for Bernstein's theorem
 
-The Chafaï-style construction of the representing measure in Bernstein's theorem. For a
-completely monotone `f` the densities `ρ_n(t) = (-1)ⁿ/(n-1)! · tⁿ⁻¹ · f⁽ⁿ⁾(t)` are nonnegative on
-`[0, ∞)`, the positive support used by `chafaiMeasure`; they define finite measures whose total
-mass is bounded by `f(0) - f(∞)`, and after the rescaling `t ↦ (n-1)/t` give measures
-`chafaiRescaled f n` on `ℝ≥0` whose Laplace kernels `(1 - xp/(n-1))₊ⁿ⁻¹` converge to `e^{-xp}`.
-These feed the Prokhorov tightness argument.
+The Chafaï-style approximating measures for the **non-constant part** of a completely monotone
+function in Bernstein's theorem. For a completely monotone `f` with `L = lim_{t→∞} f t`, the
+densities `ρ_n(t) = (-1)ⁿ/(n-1)! · tⁿ⁻¹ · f⁽ⁿ⁾(t)` are nonnegative on `[0, ∞)`, the positive
+support used by `chafaiMeasure`; they define finite measures whose total mass is bounded by
+`f(0) - f(∞) = f(0) - L`, and after the rescaling `t ↦ (n-1)/t` give measures `chafaiRescaled f n`
+on `ℝ≥0` whose Laplace kernels `(1 - xp/(n-1))₊ⁿ⁻¹` converge to `e^{-xp}`. These feed the Prokhorov
+tightness argument and, in the limit, represent `f - L` (mass `f(0) - L`), i.e. the non-constant
+part; the **full** Bernstein representing measure adds the atom `L · δ₀` at `0` (the constant `L =
+∫ e^{-tx} d(L·δ₀)`). That final assembly — recovering `f` itself, not merely `f - L` — is performed
+downstream in the Bernstein-theorem file, not here. This file supplies only the approximating
+infrastructure.
 
 These build on the `IsCompletelyMonotone` API in `CompletelyMonotone/Basic.lean` and
 `CompletelyMonotone/Integral.lean`.

--- a/TauCeti/Analysis/CompletelyMonotone/BernsteinMeasures.lean
+++ b/TauCeti/Analysis/CompletelyMonotone/BernsteinMeasures.lean
@@ -27,7 +27,8 @@ These build on the `IsCompletelyMonotone` API in `CompletelyMonotone/Basic.lean`
   its pointwise limit `e^{-xp}`.
 * `TauCeti.chafaiRescaled`, `TauCeti.chafaiRescaled_mass_eq`: the `ℝ≥0`-valued pushed-forward
   measures and mass preservation.
-* `TauCeti.chafaiMeasure_finite_mass`: finiteness and the total-mass bound `≤ f(0) - L`.
+* `TauCeti.chafaiMeasure_finite_mass`, `TauCeti.chafaiRescaled_finite_mass`: finiteness and the
+  total-mass bound `≤ f(0) - L`.
 
 ## References
 
@@ -322,27 +323,30 @@ private lemma chafaiDensity_ibp_identity (f : ℝ → ℝ) (hcm : IsCompletelyMo
   simp only [F, c]; ring
 
 /-- Monotonicity of the finite-interval Chafaï-density masses in the order:
-`∫₀ᵀ dₖ ≤ ∫₀ᵀ dₖ₋₁` for `2 ≤ k`. This is the exported integration-by-parts consequence
+`∫₀ᵀ dₖ ≤ ∫₀ᵀ dₖ₋₁` for `2 ≤ k` and `0 ≤ T`. This is the exported
+integration-by-parts consequence
 (the raw IBP identity `chafaiDensity_ibp_identity` is private); it is the per-step density
 mass-monotonicity bound consumed by the Bernstein-identity assembly. -/
 lemma integral_chafaiDensity_le_pred (f : ℝ → ℝ) (hcm : IsCompletelyMonotone f)
-    (k : ℕ) (hk : 2 ≤ k) (T : ℝ) (hT : 0 < T) :
+    (k : ℕ) (hk : 2 ≤ k) (T : ℝ) (hT : 0 ≤ T) :
     ∫ t in (0 : ℝ)..T, chafaiDensity f k t ≤ ∫ t in (0 : ℝ)..T, chafaiDensity f (k - 1) t := by
+  rcases hT.eq_or_lt with rfl | hT_pos
+  · simp
   obtain ⟨m, rfl⟩ : ∃ m, k = m + 2 := ⟨k - 2, by omega⟩
   have hsub : m + 2 - 1 = m + 1 := by omega
   simp only [hsub]
-  have hibp := chafaiDensity_ibp_identity f hcm m T hT
+  have hibp := chafaiDensity_ibp_identity f hcm m T hT_pos
   set B := (-1 : ℝ) ^ (m + 2) * T ^ (m + 1) / ↑(m + 1).factorial *
     iteratedDerivWithin (m + 1) f (Ici 0) T
   have hB : B ≤ 0 := by
     have h_neg : (-1 : ℝ) ^ (m + 2) * iteratedDerivWithin (m + 1) f (Ici 0) T ≤ 0 := by
       have : (-1 : ℝ) ^ (m + 2) = (-1) ^ (m + 1) * (-1) := pow_succ (-1) (m + 1)
-      rw [this]; nlinarith [hcm.neg_one_pow_mul_iteratedDerivWithin_nonneg (m + 1) hT.le]
+      rw [this]; nlinarith [hcm.neg_one_pow_mul_iteratedDerivWithin_nonneg (m + 1) hT_pos.le]
     suffices B = T ^ (m + 1) / ↑(m + 1).factorial *
         ((-1 : ℝ) ^ (m + 2) * iteratedDerivWithin (m + 1) f (Ici 0) T) by
       rw [this]
       exact mul_nonpos_of_nonneg_of_nonpos
-        (div_nonneg (pow_nonneg hT.le _) (Nat.cast_nonneg _)) h_neg
+        (div_nonneg (pow_nonneg hT_pos.le _) (Nat.cast_nonneg _)) h_neg
     simp only [B]; ring
   linarith
 
@@ -381,7 +385,7 @@ private lemma integral_chafaiDensity_le_sub (f : ℝ → ℝ) (hcm : IsCompletel
       exact le_of_eq (integral_chafaiDensity_one_eq f hcm T hT)
     · calc ∫ t in (0 : ℝ)..T, chafaiDensity f (p + 1) t
           ≤ ∫ t in (0 : ℝ)..T, chafaiDensity f p t := by
-            simpa using integral_chafaiDensity_le_pred f hcm (p + 1) (by omega) T hT
+            simpa using integral_chafaiDensity_le_pred f hcm (p + 1) (by omega) T hT.le
         _ ≤ f 0 - f T := ih (Nat.one_le_iff_ne_zero.mpr hp)
 
 private lemma integral_chafaiDensity_le_tendsto_sub (f : ℝ → ℝ)
@@ -462,5 +466,21 @@ lemma chafaiMeasure_finite_mass (f : ℝ → ℝ) (hcm : IsCompletelyMonotone f)
         (chafaiMeasure f n) univ ≤ ENNReal.ofReal (f 0 - L) := by
   obtain ⟨L, hL, hL_nn⟩ := hcm.tendsto_atTop
   exact ⟨L, hL, hL_nn, fun n => chafaiMeasure_finite_mass_of_tendsto f hcm n L hL⟩
+
+/-- **Natural rescaled total mass bound**: for a completely monotone `f`, the rescaled
+Chafaï measures on `ℝ≥0` are finite and uniformly bounded by `f(0) - L`, where `L` is the
+automatically obtained limit of `f` at infinity. -/
+lemma chafaiRescaled_finite_mass (f : ℝ → ℝ) (hcm : IsCompletelyMonotone f) :
+    ∃ L : ℝ, Tendsto f atTop (nhds L) ∧ 0 ≤ L ∧
+      ∀ n,
+        IsFiniteMeasure (chafaiRescaled f n) ∧
+        (chafaiRescaled f n) univ ≤ ENNReal.ofReal (f 0 - L) := by
+  obtain ⟨L, hL, hL_nn, hfinite⟩ := chafaiMeasure_finite_mass f hcm
+  refine ⟨L, hL, hL_nn, fun n => ?_⟩
+  have hmass := chafaiRescaled_mass_eq f n
+  refine ⟨?_, ?_⟩
+  · exact ⟨by rw [hmass]; exact (hfinite n).1.measure_univ_lt_top⟩
+  · rw [hmass]
+    exact (hfinite n).2
 
 end TauCeti

--- a/TauCeti/Analysis/CompletelyMonotone/BernsteinMeasures.lean
+++ b/TauCeti/Analysis/CompletelyMonotone/BernsteinMeasures.lean
@@ -24,13 +24,13 @@ These build on the `IsCompletelyMonotone` API in `CompletelyMonotone/Basic.lean`
 ## Main declarations
 
 * `TauCeti.chafaiDensity`, `TauCeti.chafaiMeasure`: the approximating densities and measures.
-* `TauCeti.bernstein_kernel`, `TauCeti.continuous_bernstein_kernel`,
-  `TauCeti.bernstein_kernel_nonneg`, `TauCeti.bernstein_kernel_le_one`,
+* `TauCeti.bernsteinKernel`, `TauCeti.continuous_bernsteinKernel`,
+  `TauCeti.bernsteinKernel_nonneg`, `TauCeti.bernsteinKernel_le_one`,
   `TauCeti.bernsteinKernelBoundedContinuous`,
   `TauCeti.bernsteinKernelBoundedContinuous_apply`,
   `TauCeti.laplaceKernelBoundedContinuous`,
   `TauCeti.laplaceKernelBoundedContinuous_apply`,
-  `TauCeti.bernstein_kernel_tendsto`: the rescaled Laplace kernel, its bundled
+  `TauCeti.bernsteinKernel_tendsto`: the rescaled Laplace kernel, its bundled
   bounded-continuous `p`-dependence on the nonnegative half-line, and its bundled pointwise
   limit `e^{-xp}`.
 * `TauCeti.chafaiRescaled`, `TauCeti.chafaiRescaled_mass_eq`: the `ℝ≥0`-valued pushed-forward
@@ -185,34 +185,34 @@ private lemma chafaiDensity_succ_succ_sub_succ (f : ℝ → ℝ) (m : ℕ) (t : 
 /-- The Bernstein kernel `φ_n(x,p) = max(1 - xp/(n-1), 0)ⁿ⁻¹` for `n ≥ 2`. After the change of
 variable `p = (n-1)/t`, the Taylor integral kernel on `[0, T]` becomes `φ_n(x, p)`, which
 converges pointwise to `e^{-xp}` as `n → ∞` (the classical `(1-x/n)ⁿ → e^{-x}` limit). -/
-noncomputable def bernstein_kernel (n : ℕ) (x p : ℝ) : ℝ :=
+noncomputable def bernsteinKernel (n : ℕ) (x p : ℝ) : ℝ :=
   if n ≤ 1 then 0 else (max (1 - x * p / (↑(n - 1) : ℝ)) 0) ^ (n - 1)
 
 /-- The Bernstein kernel vanishes for `n ≤ 1`. -/
-@[simp] lemma bernstein_kernel_of_le_one {n : ℕ} (hn : n ≤ 1) (x p : ℝ) :
-    bernstein_kernel n x p = 0 := by
-  rw [bernstein_kernel, if_pos hn]
+@[simp] lemma bernsteinKernel_of_le_one {n : ℕ} (hn : n ≤ 1) (x p : ℝ) :
+    bernsteinKernel n x p = 0 := by
+  rw [bernsteinKernel, if_pos hn]
 
 /-- The defining formula for the Bernstein kernel at `2 ≤ n`. -/
 @[simp]
-lemma bernstein_kernel_of_two_le {n : ℕ} (hn : 2 ≤ n) (x p : ℝ) :
-    bernstein_kernel n x p = (max (1 - x * p / (↑(n - 1) : ℝ)) 0) ^ (n - 1) := by
+lemma bernsteinKernel_of_two_le {n : ℕ} (hn : 2 ≤ n) (x p : ℝ) :
+    bernsteinKernel n x p = (max (1 - x * p / (↑(n - 1) : ℝ)) 0) ^ (n - 1) := by
   have hnle : ¬ n ≤ 1 := by omega
-  rw [bernstein_kernel, if_neg hnle]
+  rw [bernsteinKernel, if_neg hnle]
 
 /-- The Bernstein kernel is continuous in `p` for fixed `n` and `x`. -/
-lemma continuous_bernstein_kernel (n : ℕ) (x : ℝ) : Continuous (bernstein_kernel n x) := by
-  unfold bernstein_kernel
+lemma continuous_bernsteinKernel (n : ℕ) (x : ℝ) : Continuous (bernsteinKernel n x) := by
+  unfold bernsteinKernel
   split_ifs <;> fun_prop
 
 /-- The Bernstein kernel is nonnegative. -/
-@[simp] lemma bernstein_kernel_nonneg (n : ℕ) (x p : ℝ) : 0 ≤ bernstein_kernel n x p := by
-  rw [bernstein_kernel]; split_ifs <;> positivity
+@[simp] lemma bernsteinKernel_nonneg (n : ℕ) (x p : ℝ) : 0 ≤ bernsteinKernel n x p := by
+  rw [bernsteinKernel]; split_ifs <;> positivity
 
 /-- On the nonnegative half-plane, the Bernstein kernel is bounded above by `1`. -/
-lemma bernstein_kernel_le_one {n : ℕ} {x p : ℝ} (hx : 0 ≤ x) (hp : 0 ≤ p) :
-    bernstein_kernel n x p ≤ 1 := by
-  rw [bernstein_kernel]
+lemma bernsteinKernel_le_one {n : ℕ} {x p : ℝ} (hx : 0 ≤ x) (hp : 0 ≤ p) :
+    bernsteinKernel n x p ≤ 1 := by
+  rw [bernsteinKernel]
   split_ifs with hn
   · norm_num
   · have hn_pos : (0 : ℝ) < (↑(n - 1) : ℝ) := Nat.cast_pos.mpr (by omega)
@@ -227,21 +227,21 @@ lemma bernstein_kernel_le_one {n : ℕ} {x p : ℝ} (hx : 0 ≤ x) (hp : 0 ≤ p
 variable `p`, for fixed `n` and nonnegative `x`. -/
 noncomputable def bernsteinKernelBoundedContinuous (n : ℕ) {x : ℝ} (hx : 0 ≤ x) :
     ℝ≥0 →ᵇ ℝ where
-  toFun := fun p => bernstein_kernel n x (p : ℝ)
-  continuous_toFun := (continuous_bernstein_kernel n x).comp continuous_subtype_val
+  toFun := fun p => bernsteinKernel n x (p : ℝ)
+  continuous_toFun := (continuous_bernsteinKernel n x).comp continuous_subtype_val
   map_bounded' :=
     ⟨1, fun p q => by
       rw [Real.dist_eq]
-      have hp0 : 0 ≤ bernstein_kernel n x (p : ℝ) := bernstein_kernel_nonneg n x (p : ℝ)
-      have hp1 : bernstein_kernel n x (p : ℝ) ≤ 1 := bernstein_kernel_le_one hx p.2
-      have hq0 : 0 ≤ bernstein_kernel n x (q : ℝ) := bernstein_kernel_nonneg n x (q : ℝ)
-      have hq1 : bernstein_kernel n x (q : ℝ) ≤ 1 := bernstein_kernel_le_one hx q.2
+      have hp0 : 0 ≤ bernsteinKernel n x (p : ℝ) := bernsteinKernel_nonneg n x (p : ℝ)
+      have hp1 : bernsteinKernel n x (p : ℝ) ≤ 1 := bernsteinKernel_le_one hx p.2
+      have hq0 : 0 ≤ bernsteinKernel n x (q : ℝ) := bernsteinKernel_nonneg n x (q : ℝ)
+      have hq1 : bernsteinKernel n x (q : ℝ) ≤ 1 := bernsteinKernel_le_one hx q.2
       exact abs_sub_le_iff.mpr ⟨by linarith, by linarith⟩⟩
 
 /-- The bundled Bernstein kernel evaluates to the unbundled kernel on `ℝ≥0`. -/
 @[simp]
 lemma bernsteinKernelBoundedContinuous_apply (n : ℕ) {x : ℝ} (hx : 0 ≤ x) (p : ℝ≥0) :
-    bernsteinKernelBoundedContinuous n hx p = bernstein_kernel n x (p : ℝ) := by
+    bernsteinKernelBoundedContinuous n hx p = bernsteinKernel n x (p : ℝ) := by
   rw [bernsteinKernelBoundedContinuous]; rfl
 
 /-- The limiting Laplace kernel as a bundled bounded continuous test function of the
@@ -269,15 +269,15 @@ lemma laplaceKernelBoundedContinuous_apply {x : ℝ} (hx : 0 ≤ x) (p : ℝ≥0
   rw [laplaceKernelBoundedContinuous]; rfl
 
 /-- The Bernstein kernel is measurable in `p` for fixed `n` and `x`. -/
-lemma measurable_bernstein_kernel (n : ℕ) (x : ℝ) : Measurable (bernstein_kernel n x) := by
-  unfold bernstein_kernel; split_ifs
+lemma measurable_bernsteinKernel (n : ℕ) (x : ℝ) : Measurable (bernsteinKernel n x) := by
+  unfold bernsteinKernel; split_ifs
   · exact measurable_const
   · fun_prop
 
 /-- **Pointwise convergence of the Bernstein kernel** to the Laplace kernel:
 `φ_n(x,p) → e^{-xp}` as `n → ∞`. -/
-lemma bernstein_kernel_tendsto (x p : ℝ) :
-    Tendsto (fun n : ℕ => bernstein_kernel n x p) atTop (nhds (Real.exp (-(x * p)))) := by
+lemma bernsteinKernel_tendsto (x p : ℝ) :
+    Tendsto (fun n : ℕ => bernsteinKernel n x p) atTop (nhds (Real.exp (-(x * p)))) := by
   set g := fun n : ℕ => (1 + (-(x * p)) / (↑n : ℝ)) ^ n with hg_def
   have hg_tendsto : Tendsto g atTop (nhds (Real.exp (-(x * p)))) :=
     Real.tendsto_one_add_div_pow_exp (-(x * p))
@@ -288,7 +288,7 @@ lemma bernstein_kernel_tendsto (x p : ℝ) :
   refine ⟨{n : ℕ | n ≥ Nat.ceil (x * p) + 2}, mem_atTop _, ?_⟩
   intro n hn
   simp only [Set.mem_setOf_eq] at hn
-  simp only [bernstein_kernel, hg_def]
+  simp only [bernsteinKernel, hg_def]
   have hn1 : ¬(n ≤ 1) := by omega
   simp only [hn1, ite_false]
   have hn1_pos : (0 : ℝ) < ↑(n - 1) := Nat.cast_pos.mpr (by omega)

--- a/TauCeti/Analysis/CompletelyMonotone/Integral.lean
+++ b/TauCeti/Analysis/CompletelyMonotone/Integral.lean
@@ -21,7 +21,7 @@ fundamental-theorem identities, and improper-integral facts for `-f'`.
 ## Main declarations
 
 * `TauCeti.ContDiffAt.iteratedDerivWithin_Icc_eq_Ici`: iterated derivatives within `Icc x T`
-  and within `Ici 0` agree at interior points.
+  and within `Ici a` agree at interior points.
 * `TauCeti.ContDiffOn.integral_neg_derivWithin_Icc`,
   `TauCeti.ContDiffOn.integral_neg_derivWithin_Icc_zero_left`: finite-interval
   fundamental-theorem identities for smooth functions.
@@ -51,17 +51,17 @@ namespace TauCeti
 
 variable {E : Type*} [NormedAddCommGroup E] [NormedSpace ℝ E] {f : ℝ → E}
 
-/-- `iteratedDerivWithin` on `Icc x T` agrees with `iteratedDerivWithin` on `Ici 0` at interior
+/-- `iteratedDerivWithin` on `Icc x T` agrees with `iteratedDerivWithin` on `Ici a` at interior
 points, since both equal `iteratedDeriv n f t` under local smoothness at `t`. -/
 lemma ContDiffAt.iteratedDerivWithin_Icc_eq_Ici {n : ℕ}
-    {x T t : ℝ} (hf : ContDiffAt ℝ (n : WithTop ℕ∞) f t) (ht_pos : 0 < t)
+    {a x T t : ℝ} (hf : ContDiffAt ℝ (n : WithTop ℕ∞) f t) (ht_lo : a < t)
     (ht : t ∈ Ioo x T) :
-    iteratedDerivWithin n f (Icc x T) t = iteratedDerivWithin n f (Ici 0) t := by
+    iteratedDerivWithin n f (Icc x T) t = iteratedDerivWithin n f (Ici a) t := by
   have hxT : x < T := lt_trans ht.1 ht.2
   rw [iteratedDerivWithin_eq_iteratedDeriv (uniqueDiffOn_Icc hxT) hf
         (Ioo_subset_Icc_self ht),
-      ← iteratedDerivWithin_eq_iteratedDeriv (uniqueDiffOn_Ici 0) hf
-        (mem_Ici.mpr ht_pos.le)]
+      ← iteratedDerivWithin_eq_iteratedDeriv (uniqueDiffOn_Ici a) hf
+        (mem_Ici.mpr ht_lo.le)]
 
 /-- The fundamental-theorem identity
 `f x - f T = ∫ₓᵀ -f'` on a compact interval, with derivatives taken within that interval. -/
@@ -117,7 +117,7 @@ lemma iteratedDerivWithin_Icc_eq_Ici {n : ℕ} (hf : IsCompletelyMonotone f)
     iteratedDerivWithin n f (Icc x T) t = iteratedDerivWithin n f (Ici 0) t := by
   have hcda : ContDiffAt ℝ (n : WithTop ℕ∞) f t :=
     (hf.contDiffOn.contDiffAt (Ici_mem_nhds ht_pos)).of_le (by exact_mod_cast le_top)
-  exact ContDiffAt.iteratedDerivWithin_Icc_eq_Ici hcda ht_pos ht
+  exact ContDiffAt.iteratedDerivWithin_Icc_eq_Ici (a := 0) hcda ht_pos ht
 
 /-- **CM sign of the Taylor remainder.** For a completely monotone function the Taylor
 integral remainder `∫ₓᵀ (T-t)ⁿ⁻¹/(n-1)! · f⁽ⁿ⁾(t) dt` has sign `(-1)ⁿ`:

--- a/TauCeti/Analysis/CompletelyMonotone/Integral.lean
+++ b/TauCeti/Analysis/CompletelyMonotone/Integral.lean
@@ -1,0 +1,236 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+module
+
+public import Mathlib.MeasureTheory.Integral.IntegralEqImproper
+public import Mathlib.MeasureTheory.Integral.IntervalIntegral.ContDiff
+public import TauCeti.Analysis.CompletelyMonotone.Basic
+
+/-!
+# Integral and analysis lemmas for completely monotone functions
+
+The generic completely-monotone integral/analysis layer: FTC, Taylor-remainder, and
+improper-integral facts about completely monotone functions.
+
+These extend the object API in `CompletelyMonotone/Basic.lean` with derivative-within transfer
+on compact intervals, the sign of the Taylor integral remainder, finite-interval
+fundamental-theorem identities, and improper-integral facts for `-f'`.
+
+## Main declarations
+
+* `TauCeti.ContDiffAt.iteratedDerivWithin_Icc_eq_Ici`: iterated derivatives within `Icc x T`
+  and within `Ici 0` agree at interior points.
+* `TauCeti.ContDiffOn.integral_neg_derivWithin_Icc`,
+  `TauCeti.ContDiffOn.integral_neg_derivWithin_Icc_zero_left`: finite-interval
+  fundamental-theorem identities for smooth functions.
+* `TauCeti.IsCompletelyMonotone.neg_one_pow_mul_taylor_remainder_nonneg`: the Taylor integral
+  remainder has sign `(-1)ⁿ`.
+* `TauCeti.IsCompletelyMonotone.integral_neg_deriv`, `TauCeti.IsCompletelyMonotone.integral_mass`:
+  compatibility wrappers for the smooth finite-interval identities.
+* `TauCeti.IsCompletelyMonotone.neg_deriv_integrableOn`,
+  `TauCeti.IsCompletelyMonotone.integral_Ioi_neg_deriv`: integrability and the improper integral
+  of `-f'` on `(0, ∞)`.
+
+## References
+
+* Roadmap: `TauCetiRoadmap/OneParameterSemigroups/README.md`, Part B (Bernstein theorem
+  milestone).
+
+* D. V. Widder, *The Laplace Transform* (Princeton, 1941), Ch. IV.
+* D. Chafaï, *Aspects of the Bernstein theorem* (2013).
+-/
+
+public section
+
+open MeasureTheory Set intervalIntegral Filter
+open scoped ContDiff Topology
+
+namespace TauCeti
+
+variable {f : ℝ → ℝ}
+
+/-- `iteratedDerivWithin` on `Icc x T` agrees with `iteratedDerivWithin` on `Ici 0` at interior
+points, since both equal `iteratedDeriv n f t` under local smoothness at `t`. -/
+lemma ContDiffAt.iteratedDerivWithin_Icc_eq_Ici {n : ℕ}
+    {x T t : ℝ} (hf : ContDiffAt ℝ (n : WithTop ℕ∞) f t) (hx : 0 ≤ x)
+    (ht : t ∈ Ioo x T) :
+    iteratedDerivWithin n f (Icc x T) t = iteratedDerivWithin n f (Ici 0) t := by
+  have ht_pos : 0 < t := lt_of_le_of_lt hx ht.1
+  have hxT : x < T := lt_trans ht.1 ht.2
+  rw [iteratedDerivWithin_eq_iteratedDeriv (uniqueDiffOn_Icc hxT) hf
+        (Ioo_subset_Icc_self ht),
+      ← iteratedDerivWithin_eq_iteratedDeriv (uniqueDiffOn_Ici 0) hf
+        (mem_Ici.mpr ht_pos.le)]
+
+/-- The fundamental-theorem identity
+`f x - f T = ∫ₓᵀ -f'` on a compact interval, with derivatives taken within that interval. -/
+lemma ContDiffOn.integral_neg_derivWithin_Icc {x T : ℝ}
+    (hf : ContDiffOn ℝ 1 f (Icc x T)) (hxT : x ≤ T) :
+    f x - f T = ∫ t in x..T, -iteratedDerivWithin 1 f (Icc x T) t := by
+  have hFTC := intervalIntegral.integral_derivWithin_Icc_of_contDiffOn_Icc hf hxT
+  rw [iteratedDerivWithin_one]
+  rw [intervalIntegral.integral_neg]
+  linarith [hFTC]
+
+/-- The zero-left specialization of `ContDiffOn.integral_neg_derivWithin_Icc`. -/
+lemma ContDiffOn.integral_neg_derivWithin_Icc_zero_left {T : ℝ}
+    (hf : ContDiffOn ℝ 1 f (Icc 0 T)) (hT : 0 ≤ T) :
+    ∫ t in (0 : ℝ)..T, -iteratedDerivWithin 1 f (Icc 0 T) t = f 0 - f T := by
+  exact (ContDiffOn.integral_neg_derivWithin_Icc hf hT).symm
+
+/-- The interval integral of `-f'` with the `T`-dependent set `Icc 0 T` equals the integral with
+the fixed set `Ici 0`, under smoothness on the open half-line. -/
+lemma ContDiffOn.integral_neg_derivWithin_Icc_eq_Ici
+    (hf : ContDiffOn ℝ 1 f (Ioi 0)) (T : ℝ) (hT : 0 ≤ T) :
+    ∫ t in (0 : ℝ)..T, -iteratedDerivWithin 1 f (Icc 0 T) t =
+    ∫ t in (0 : ℝ)..T, -iteratedDerivWithin 1 f (Ici 0) t := by
+  apply intervalIntegral.integral_congr_ae
+  apply ae_of_all volume
+  intro t ht
+  rw [uIoc_of_le hT] at ht
+  have ht_pos : 0 < t := ht.1
+  have hT_pos : 0 < T := lt_of_lt_of_le ht_pos ht.2
+  have hcda : ContDiffAt ℝ 1 f t := hf.contDiffAt (isOpen_Ioi.mem_nhds ht_pos)
+  simp only [iteratedDerivWithin_eq_iteratedDeriv (uniqueDiffOn_Icc hT_pos) hcda
+      (Ioc_subset_Icc_self ht),
+    iteratedDerivWithin_eq_iteratedDeriv (uniqueDiffOn_Ici 0) hcda
+      (mem_Ici.mpr ht_pos.le)]
+
+/-- The total mass `∫₀ᵀ (-f') dt → f(0) - L` as `T → ∞`, assuming smoothness on `[0, ∞)`
+and convergence of `f` to `L` at infinity. -/
+lemma ContDiffOn.tendsto_total_mass
+    (hf : ContDiffOn ℝ 1 f (Ici 0)) {L : ℝ} (hL : Tendsto f atTop (nhds L)) :
+    Tendsto (fun T => ∫ t in (0 : ℝ)..T, -iteratedDerivWithin 1 f (Icc 0 T) t) atTop
+        (nhds (f 0 - L)) := by
+  refine Tendsto.congr' (EventuallyEq.symm ?_) (Tendsto.sub tendsto_const_nhds hL)
+  exact (eventually_gt_atTop 0).mono fun T hT =>
+    ContDiffOn.integral_neg_derivWithin_Icc_zero_left (hf.mono Icc_subset_Ici_self) hT.le
+
+namespace IsCompletelyMonotone
+
+/-- `iteratedDerivWithin` on `Icc x T` agrees with `iteratedDerivWithin` on `Ici 0` at interior
+points, since both equal `iteratedDeriv n f t` when `0 < t`. -/
+lemma iteratedDerivWithin_Icc_eq_Ici {n : ℕ} (hf : IsCompletelyMonotone f)
+    {x T t : ℝ} (hx : 0 ≤ x) (ht : t ∈ Ioo x T) :
+    iteratedDerivWithin n f (Icc x T) t = iteratedDerivWithin n f (Ici 0) t := by
+  have ht_pos : 0 < t := lt_of_le_of_lt hx ht.1
+  have hcda : ContDiffAt ℝ (n : WithTop ℕ∞) f t :=
+    (hf.contDiffOn.contDiffAt (Ici_mem_nhds ht_pos)).of_le (by exact_mod_cast le_top)
+  exact ContDiffAt.iteratedDerivWithin_Icc_eq_Ici hcda hx ht
+
+/-- **CM sign of the Taylor remainder.** For a completely monotone function the Taylor
+integral remainder `∫ₓᵀ (T-t)ⁿ⁻¹/(n-1)! · f⁽ⁿ⁾(t) dt` has sign `(-1)ⁿ`:
+`0 ≤ (-1)ⁿ` times it. -/
+lemma neg_one_pow_mul_taylor_remainder_nonneg (hf : IsCompletelyMonotone f) {x T : ℝ} {n : ℕ}
+    (hx : 0 ≤ x) (hxT : x ≤ T) :
+    0 ≤ (-1 : ℝ) ^ n * ∫ t in x..T,
+      (↑(n - 1).factorial)⁻¹ * (T - t) ^ (n - 1) *
+      iteratedDerivWithin n f (Icc x T) t := by
+  rw [← intervalIntegral.integral_const_mul]
+  apply intervalIntegral.integral_nonneg_of_ae_restrict hxT
+  have hIoo : ∀ t ∈ Ioo x T, (0 : ℝ) ≤ ((-1 : ℝ) ^ n *
+      ((↑(n - 1).factorial)⁻¹ * (T - t) ^ (n - 1) *
+        iteratedDerivWithin n f (Icc x T) t)) := fun t ht =>
+    calc (0 : ℝ) ≤ (↑(n - 1).factorial)⁻¹ * (T - t) ^ (n - 1) *
+          ((-1 : ℝ) ^ n * iteratedDerivWithin n f (Icc x T) t) :=
+          mul_nonneg (mul_nonneg (inv_nonneg.mpr (Nat.cast_nonneg _))
+            (pow_nonneg (sub_nonneg.mpr ht.2.le) _))
+            (by rw [hf.iteratedDerivWithin_Icc_eq_Ici hx ht]
+                exact hf.neg_one_pow_mul_iteratedDerivWithin_nonneg n
+                  (lt_of_le_of_lt hx ht.1).le)
+      _ = _ := by ring
+  have h_mem : ∀ᵐ t ∂volume.restrict (Icc x T), t ∈ Ioo x T := by
+    rw [ae_restrict_iff' measurableSet_Icc]
+    exact (Ioo_ae_eq_Icc (a := x) (b := T)).mono (fun t h ht => h.mpr ht)
+  exact h_mem.mono fun t ht => by simp only [Pi.zero_apply]; exact hIoo t ht
+
+/-- For a completely monotone `f` the `n = 1` fundamental-theorem identity gives
+`f(x) - f(T) = ∫ₓᵀ (-f'(t)) dt`, with the integrand nonnegative by the sign condition. -/
+lemma integral_neg_deriv (hf : IsCompletelyMonotone f)
+    (x T : ℝ) (hx : 0 ≤ x) (hxT : x ≤ T) :
+    f x - f T = ∫ t in x..T, -iteratedDerivWithin 1 f (Icc x T) t := by
+  have hsubset : Icc x T ⊆ Ici 0 := Icc_subset_Ici_self.trans (Ici_subset_Ici.mpr hx)
+  have hcm_Icc : ContDiffOn ℝ 1 f (Icc x T) :=
+    (hf.contDiffOn.mono hsubset).of_le (by exact_mod_cast le_top)
+  exact ContDiffOn.integral_neg_derivWithin_Icc hcm_Icc hxT
+
+/-- The total mass identity `∫₀ᵀ (-f') = f(0) - f(T)` for a completely monotone function. -/
+lemma integral_mass (hf : IsCompletelyMonotone f) (T : ℝ) (hT : 0 ≤ T) :
+    ∫ t in (0 : ℝ)..T, -iteratedDerivWithin 1 f (Icc 0 T) t = f 0 - f T := by
+  have hsubset : Icc 0 T ⊆ Ici 0 := Icc_subset_Ici_self
+  have hcm_Icc : ContDiffOn ℝ 1 f (Icc 0 T) :=
+    (hf.contDiffOn.mono hsubset).of_le (by exact_mod_cast le_top)
+  exact ContDiffOn.integral_neg_derivWithin_Icc_zero_left hcm_Icc hT
+
+end IsCompletelyMonotone
+
+/-! ## Smoothness-index helpers -/
+
+private lemma nat_le_top (n : ℕ) : (n : WithTop ℕ∞) ≤ ∞ := by exact_mod_cast le_top
+
+/-- The first iterated derivative within `[0, ∞)` of a completely monotone function is
+nonpositive (the `derivWithin` sign condition restated for `iteratedDerivWithin 1`). -/
+private lemma IsCompletelyMonotone.iteratedDerivWithin_one_nonpos
+    (hf : IsCompletelyMonotone f) {t : ℝ} (ht : 0 ≤ t) :
+    iteratedDerivWithin 1 f (Ici 0) t ≤ 0 := by
+  rw [iteratedDerivWithin_one]; exact hf.derivWithin_nonpos ht
+
+/-- The interval integral of `-f'` with the `T`-dependent set `Icc 0 T` equals the integral with
+the fixed set `Ici 0` (both agree a.e. by set transfer at interior points). -/
+lemma IsCompletelyMonotone.integral_neg_deriv_Ici
+    (hcm : IsCompletelyMonotone f) (T : ℝ) (hT : 0 ≤ T) :
+    ∫ t in (0 : ℝ)..T, -iteratedDerivWithin 1 f (Icc 0 T) t =
+    ∫ t in (0 : ℝ)..T, -iteratedDerivWithin 1 f (Ici 0) t := by
+  exact ContDiffOn.integral_neg_derivWithin_Icc_eq_Ici
+    ((hcm.contDiffOn.mono Ioi_subset_Ici_self).of_le (nat_le_top _)) T hT
+
+/-- The total mass `∫₀ᵀ (-f') dt → f(0) - L` as `T → ∞`, where `L = lim f(t)`. This is
+the key uniform bound for the tightness argument in Bernstein's theorem. -/
+lemma IsCompletelyMonotone.tendsto_total_mass
+    (hcm : IsCompletelyMonotone f) {L : ℝ} (hL : Tendsto f atTop (nhds L)) :
+    Tendsto (fun T => ∫ t in (0 : ℝ)..T, -iteratedDerivWithin 1 f (Icc 0 T) t) atTop
+        (nhds (f 0 - L)) :=
+  ContDiffOn.tendsto_total_mass (hcm.contDiffOn.of_le (nat_le_top _)) hL
+
+/-- `-f'` is integrable on `(0, ∞)` for a completely monotone function, where the derivative is
+taken within the closed half-line `[0, ∞)`. -/
+lemma IsCompletelyMonotone.neg_deriv_integrableOn (hcm : IsCompletelyMonotone f) :
+    IntegrableOn (fun t => -iteratedDerivWithin 1 f (Ici 0) t) (Ioi 0) := by
+  obtain ⟨L, hL, -⟩ := hcm.tendsto_atTop
+  apply integrableOn_Ioi_of_intervalIntegral_norm_tendsto (f 0 - L) 0
+      (l := atTop) (b := id)
+  · intro T
+    exact ((hcm.contDiffOn.continuousOn_iteratedDerivWithin (nat_le_top _)
+      (uniqueDiffOn_Ici 0)).neg.mono Icc_subset_Ici_self).integrableOn_compact
+        isCompact_Icc |>.mono_set Ioc_subset_Icc_self
+  · exact tendsto_id
+  · have hnorm : ∀ᶠ T in atTop, (∫ t in (0 : ℝ)..id T,
+        ‖(fun t => -iteratedDerivWithin 1 f (Ici 0) t) t‖) = f 0 - f T := by
+      filter_upwards [eventually_gt_atTop 0] with T hT
+      simp only [id]
+      have : (∫ t in (0 : ℝ)..T, ‖(fun t => -iteratedDerivWithin 1 f (Ici 0) t) t‖) =
+          ∫ t in (0 : ℝ)..T, -iteratedDerivWithin 1 f (Ici 0) t :=
+        intervalIntegral.integral_congr_ae (ae_of_all _ fun t ht => by
+          rw [uIoc_of_le hT.le] at ht
+          simp only [Real.norm_eq_abs]
+          rw [abs_of_nonneg (by linarith [hcm.iteratedDerivWithin_one_nonpos ht.1.le])])
+      rw [this, ← hcm.integral_neg_deriv_Ici T hT.le, hcm.integral_mass T hT.le]
+    exact Tendsto.congr' (EventuallyEq.symm hnorm) (Tendsto.sub tendsto_const_nhds hL)
+
+/-- The improper integral `∫₀^∞ (-f') dt = f(0) - L` for completely monotone functions. -/
+lemma IsCompletelyMonotone.integral_Ioi_neg_deriv
+    (hcm : IsCompletelyMonotone f) {L : ℝ} (hL : Tendsto f atTop (nhds L)) :
+    ∫ t in Ioi 0, -iteratedDerivWithin 1 f (Ici 0) t = f 0 - L := by
+  have hint := hcm.neg_deriv_integrableOn
+  have htend := intervalIntegral_tendsto_integral_Ioi 0 hint tendsto_id
+  have htend2 : Tendsto (fun T => ∫ t in (0 : ℝ)..T,
+      -iteratedDerivWithin 1 f (Ici 0) t) atTop (nhds (f 0 - L)) :=
+    Tendsto.congr'
+      ((eventually_gt_atTop 0).mono fun T hT =>
+        ((hcm.integral_neg_deriv_Ici T hT.le).symm.trans (hcm.integral_mass T hT.le)).symm)
+      (Tendsto.sub tendsto_const_nhds hL)
+  exact tendsto_nhds_unique htend htend2
+
+end TauCeti

--- a/TauCeti/Analysis/CompletelyMonotone/Integral.lean
+++ b/TauCeti/Analysis/CompletelyMonotone/Integral.lean
@@ -81,20 +81,19 @@ lemma ContDiffOn.integral_neg_derivWithin_Icc_zero_left {T : ℝ}
   exact (ContDiffOn.integral_neg_derivWithin_Icc hf hT).symm
 
 /-- The interval integral of `-f'` with the `T`-dependent set `Icc 0 T` equals the integral with
-the fixed set `Ici 0`, under smoothness on the open half-line. -/
+the fixed set `Ici 0`, under local smoothness at the strict interior points. -/
 lemma ContDiffOn.integral_neg_derivWithin_Icc_eq_Ici
-    (hf : ContDiffOn ℝ 1 f (Ioi 0)) (T : ℝ) (hT : 0 ≤ T) :
+    {T : ℝ} (hf : ∀ t ∈ Ioo (0 : ℝ) T, ContDiffAt ℝ 1 f t) (hT : 0 ≤ T) :
     ∫ t in (0 : ℝ)..T, -iteratedDerivWithin 1 f (Icc 0 T) t =
     ∫ t in (0 : ℝ)..T, -iteratedDerivWithin 1 f (Ici 0) t := by
-  apply intervalIntegral.integral_congr_ae
-  apply ae_of_all volume
+  apply intervalIntegral.integral_congr_uIoo
   intro t ht
-  rw [uIoc_of_le hT] at ht
+  rw [uIoo_of_le hT] at ht
   have ht_pos : 0 < t := ht.1
-  have hT_pos : 0 < T := lt_of_lt_of_le ht_pos ht.2
-  have hcda : ContDiffAt ℝ 1 f t := hf.contDiffAt (isOpen_Ioi.mem_nhds ht_pos)
+  have hT_pos : 0 < T := lt_trans ht_pos ht.2
+  have hcda : ContDiffAt ℝ 1 f t := hf t ht
   simp only [iteratedDerivWithin_eq_iteratedDeriv (uniqueDiffOn_Icc hT_pos) hcda
-      (Ioc_subset_Icc_self ht),
+      (Ioo_subset_Icc_self ht),
     iteratedDerivWithin_eq_iteratedDeriv (uniqueDiffOn_Ici 0) hcda
       (mem_Ici.mpr ht_pos.le)]
 
@@ -184,7 +183,7 @@ lemma IsCompletelyMonotone.integral_neg_deriv_Ici
     ∫ t in (0 : ℝ)..T, -iteratedDerivWithin 1 f (Icc 0 T) t =
     ∫ t in (0 : ℝ)..T, -iteratedDerivWithin 1 f (Ici 0) t := by
   exact ContDiffOn.integral_neg_derivWithin_Icc_eq_Ici
-    ((hcm.contDiffOn.mono Ioi_subset_Ici_self).of_le (nat_le_top _)) T hT
+    (fun t ht => (hcm.contDiffOn.contDiffAt (Ici_mem_nhds ht.1)).of_le (nat_le_top _)) hT
 
 /-- The total mass `∫₀ᵀ (-f') dt → f(0) - L` as `T → ∞`, where `L = lim f(t)`. This is
 the key uniform bound for the tightness argument in Bernstein's theorem. -/

--- a/TauCeti/Analysis/CompletelyMonotone/Integral.lean
+++ b/TauCeti/Analysis/CompletelyMonotone/Integral.lean
@@ -54,10 +54,9 @@ variable {f : ℝ → ℝ}
 /-- `iteratedDerivWithin` on `Icc x T` agrees with `iteratedDerivWithin` on `Ici 0` at interior
 points, since both equal `iteratedDeriv n f t` under local smoothness at `t`. -/
 lemma ContDiffAt.iteratedDerivWithin_Icc_eq_Ici {n : ℕ}
-    {x T t : ℝ} (hf : ContDiffAt ℝ (n : WithTop ℕ∞) f t) (hx : 0 ≤ x)
+    {x T t : ℝ} (hf : ContDiffAt ℝ (n : WithTop ℕ∞) f t) (ht_pos : 0 < t)
     (ht : t ∈ Ioo x T) :
     iteratedDerivWithin n f (Icc x T) t = iteratedDerivWithin n f (Ici 0) t := by
-  have ht_pos : 0 < t := lt_of_le_of_lt hx ht.1
   have hxT : x < T := lt_trans ht.1 ht.2
   rw [iteratedDerivWithin_eq_iteratedDeriv (uniqueDiffOn_Icc hxT) hf
         (Ioo_subset_Icc_self ht),
@@ -112,12 +111,11 @@ namespace IsCompletelyMonotone
 /-- `iteratedDerivWithin` on `Icc x T` agrees with `iteratedDerivWithin` on `Ici 0` at interior
 points, since both equal `iteratedDeriv n f t` when `0 < t`. -/
 lemma iteratedDerivWithin_Icc_eq_Ici {n : ℕ} (hf : IsCompletelyMonotone f)
-    {x T t : ℝ} (hx : 0 ≤ x) (ht : t ∈ Ioo x T) :
+    {x T t : ℝ} (ht_pos : 0 < t) (ht : t ∈ Ioo x T) :
     iteratedDerivWithin n f (Icc x T) t = iteratedDerivWithin n f (Ici 0) t := by
-  have ht_pos : 0 < t := lt_of_le_of_lt hx ht.1
   have hcda : ContDiffAt ℝ (n : WithTop ℕ∞) f t :=
     (hf.contDiffOn.contDiffAt (Ici_mem_nhds ht_pos)).of_le (by exact_mod_cast le_top)
-  exact ContDiffAt.iteratedDerivWithin_Icc_eq_Ici hcda hx ht
+  exact ContDiffAt.iteratedDerivWithin_Icc_eq_Ici hcda ht_pos ht
 
 /-- **CM sign of the Taylor remainder.** For a completely monotone function the Taylor
 integral remainder `∫ₓᵀ (T-t)ⁿ⁻¹/(n-1)! · f⁽ⁿ⁾(t) dt` has sign `(-1)ⁿ`:
@@ -136,7 +134,7 @@ lemma neg_one_pow_mul_taylor_remainder_nonneg (hf : IsCompletelyMonotone f) {x T
           ((-1 : ℝ) ^ n * iteratedDerivWithin n f (Icc x T) t) :=
           mul_nonneg (mul_nonneg (inv_nonneg.mpr (Nat.cast_nonneg _))
             (pow_nonneg (sub_nonneg.mpr ht.2.le) _))
-            (by rw [hf.iteratedDerivWithin_Icc_eq_Ici hx ht]
+            (by rw [hf.iteratedDerivWithin_Icc_eq_Ici (lt_of_le_of_lt hx ht.1) ht]
                 exact hf.neg_one_pow_mul_iteratedDerivWithin_nonneg n
                   (lt_of_le_of_lt hx ht.1).le)
       _ = _ := by ring

--- a/TauCeti/Analysis/CompletelyMonotone/Integral.lean
+++ b/TauCeti/Analysis/CompletelyMonotone/Integral.lean
@@ -158,10 +158,7 @@ lemma integral_neg_deriv (hf : IsCompletelyMonotone f)
 /-- The total mass identity `∫₀ᵀ (-f') = f(0) - f(T)` for a completely monotone function. -/
 lemma integral_mass (hf : IsCompletelyMonotone f) (T : ℝ) (hT : 0 ≤ T) :
     ∫ t in (0 : ℝ)..T, -iteratedDerivWithin 1 f (Icc 0 T) t = f 0 - f T := by
-  have hsubset : Icc 0 T ⊆ Ici 0 := Icc_subset_Ici_self
-  have hcm_Icc : ContDiffOn ℝ 1 f (Icc 0 T) :=
-    (hf.contDiffOn.mono hsubset).of_le (by exact_mod_cast le_top)
-  exact ContDiffOn.integral_neg_derivWithin_Icc_zero_left hcm_Icc hT
+  exact (hf.integral_neg_deriv 0 T le_rfl hT).symm
 
 end IsCompletelyMonotone
 
@@ -197,7 +194,7 @@ lemma IsCompletelyMonotone.tendsto_total_mass
 taken within the closed half-line `[0, ∞)`. -/
 lemma IsCompletelyMonotone.neg_deriv_integrableOn (hcm : IsCompletelyMonotone f) :
     IntegrableOn (fun t => -iteratedDerivWithin 1 f (Ici 0) t) (Ioi 0) := by
-  obtain ⟨L, hL, -⟩ := hcm.tendsto_atTop
+  obtain ⟨L, hL, -⟩ := hcm.exists_nonneg_tendsto_atTop
   apply integrableOn_Ioi_of_intervalIntegral_norm_tendsto (f 0 - L) 0
       (l := atTop) (b := id)
   · intro T

--- a/TauCeti/Analysis/CompletelyMonotone/Integral.lean
+++ b/TauCeti/Analysis/CompletelyMonotone/Integral.lean
@@ -5,33 +5,29 @@ Released under Apache 2.0 license as described in the file LICENSE.
 module
 
 public import Mathlib.MeasureTheory.Integral.IntegralEqImproper
-public import Mathlib.MeasureTheory.Integral.IntervalIntegral.ContDiff
+public import TauCeti.Analysis.Calculus.IteratedDerivWithin
 public import TauCeti.Analysis.CompletelyMonotone.Basic
 
 /-!
-# Integral and analysis lemmas for completely monotone functions
+# Integral lemmas for completely monotone functions
 
-The generic completely-monotone integral/analysis layer: FTC, Taylor-remainder, and
-improper-integral facts about completely monotone functions.
+FTC wrappers, Taylor-remainder sign bounds, and improper-integral facts about completely monotone
+functions.
 
-These extend the object API in `CompletelyMonotone/Basic.lean` with derivative-within transfer
-on compact intervals, the sign of the Taylor integral remainder, finite-interval
-fundamental-theorem identities, and improper-integral facts for `-f'`.
+These extend the object API in `CompletelyMonotone/Basic.lean` with the sign of the Taylor
+integral remainder, finite-interval fundamental-theorem identities specialized to completely
+monotone functions, and improper-integral facts for the first derivative within `[0, ∞)`.
 
 ## Main declarations
 
-* `TauCeti.ContDiffAt.iteratedDerivWithin_Icc_eq_Ici`: iterated derivatives within `Icc x T`
-  and within `Ici a` agree at interior points.
-* `TauCeti.ContDiffOn.integral_neg_derivWithin_Icc`,
-  `TauCeti.ContDiffOn.integral_neg_derivWithin_Icc_zero_left`: finite-interval
-  fundamental-theorem identities for smooth functions.
 * `TauCeti.IsCompletelyMonotone.neg_one_pow_mul_taylor_remainder_nonneg`: the Taylor integral
   remainder has sign `(-1)ⁿ`.
-* `TauCeti.IsCompletelyMonotone.integral_neg_deriv`, `TauCeti.IsCompletelyMonotone.integral_mass`:
-  compatibility wrappers for the smooth finite-interval identities.
-* `TauCeti.IsCompletelyMonotone.neg_deriv_integrableOn`,
-  `TauCeti.IsCompletelyMonotone.integral_Ioi_neg_deriv`: integrability and the improper integral
-  of `-f'` on `(0, ∞)`.
+* `TauCeti.IsCompletelyMonotone.integral_neg_iteratedDerivWithin_one_Icc`,
+  `TauCeti.IsCompletelyMonotone.integral_mass`: compatibility wrappers for the smooth
+  finite-interval identities.
+* `TauCeti.IsCompletelyMonotone.neg_iteratedDerivWithin_one_integrableOn`,
+  `TauCeti.IsCompletelyMonotone.integral_Ioi_neg_iteratedDerivWithin_one`: integrability and the
+  improper integral of `-f'` on `(0, ∞)`, represented as `iteratedDerivWithin 1`.
 
 ## References
 
@@ -48,63 +44,6 @@ open MeasureTheory Set intervalIntegral Filter
 open scoped ContDiff Topology
 
 namespace TauCeti
-
-variable {E : Type*} [NormedAddCommGroup E] [NormedSpace ℝ E] {f : ℝ → E}
-
-/-- `iteratedDerivWithin` on `Icc x T` agrees with `iteratedDerivWithin` on `Ici a` at interior
-points, since both equal `iteratedDeriv n f t` under local smoothness at `t`. -/
-lemma ContDiffAt.iteratedDerivWithin_Icc_eq_Ici {n : ℕ}
-    {a x T t : ℝ} (hf : ContDiffAt ℝ (n : WithTop ℕ∞) f t) (ht_lo : a < t)
-    (ht : t ∈ Ioo x T) :
-    iteratedDerivWithin n f (Icc x T) t = iteratedDerivWithin n f (Ici a) t := by
-  have hxT : x < T := lt_trans ht.1 ht.2
-  rw [iteratedDerivWithin_eq_iteratedDeriv (uniqueDiffOn_Icc hxT) hf
-        (Ioo_subset_Icc_self ht),
-      ← iteratedDerivWithin_eq_iteratedDeriv (uniqueDiffOn_Ici a) hf
-        (mem_Ici.mpr ht_lo.le)]
-
-/-- The fundamental-theorem identity
-`f x - f T = ∫ₓᵀ -f'` on a compact interval, with derivatives taken within that interval. -/
-lemma ContDiffOn.integral_neg_derivWithin_Icc {x T : ℝ}
-    [CompleteSpace E] (hf : ContDiffOn ℝ 1 f (Icc x T)) (hxT : x ≤ T) :
-    f x - f T = ∫ t in x..T, -iteratedDerivWithin 1 f (Icc x T) t := by
-  have hFTC := intervalIntegral.integral_derivWithin_Icc_of_contDiffOn_Icc hf hxT
-  rw [iteratedDerivWithin_one]
-  rw [intervalIntegral.integral_neg, hFTC, neg_sub]
-
-/-- The zero-left specialization of `ContDiffOn.integral_neg_derivWithin_Icc`. -/
-lemma ContDiffOn.integral_neg_derivWithin_Icc_zero_left {T : ℝ}
-    [CompleteSpace E] (hf : ContDiffOn ℝ 1 f (Icc 0 T)) (hT : 0 ≤ T) :
-    ∫ t in (0 : ℝ)..T, -iteratedDerivWithin 1 f (Icc 0 T) t = f 0 - f T := by
-  exact (ContDiffOn.integral_neg_derivWithin_Icc hf hT).symm
-
-/-- The interval integral of `-f'` with the `T`-dependent set `Icc x T` equals the integral with
-the fixed set `Ici a`, under local smoothness at the strict interior points. -/
-lemma ContDiffOn.integral_neg_derivWithin_Icc_eq_Ici
-    {a x T : ℝ} (hf : ∀ t ∈ Ioo x T, ContDiffAt ℝ 1 f t) (hax : a ≤ x) (hxT : x ≤ T) :
-    ∫ t in x..T, -iteratedDerivWithin 1 f (Icc x T) t =
-    ∫ t in x..T, -iteratedDerivWithin 1 f (Ici a) t := by
-  apply intervalIntegral.integral_congr_uIoo
-  intro t ht
-  rw [uIoo_of_le hxT] at ht
-  have ha_lt : a < t := lt_of_le_of_lt hax ht.1
-  have hxT_pos : x < T := lt_trans ht.1 ht.2
-  have hcda : ContDiffAt ℝ 1 f t := hf t ht
-  simp only [iteratedDerivWithin_eq_iteratedDeriv (uniqueDiffOn_Icc hxT_pos) hcda
-      (Ioo_subset_Icc_self ht),
-    iteratedDerivWithin_eq_iteratedDeriv (uniqueDiffOn_Ici a) hcda
-      (mem_Ici.mpr ha_lt.le)]
-
-/-- The total mass `∫ₐᵀ (-f') dt → f(a) - L` as `T → ∞`, assuming smoothness on `[a, ∞)`
-and convergence of `f` to `L` at infinity. -/
-lemma ContDiffOn.tendsto_total_mass
-    [CompleteSpace E] {a : ℝ} (hf : ContDiffOn ℝ 1 f (Ici a)) {L : E}
-    (hL : Tendsto f atTop (nhds L)) :
-    Tendsto (fun T => ∫ t in a..T, -iteratedDerivWithin 1 f (Icc a T) t) atTop
-        (nhds (f a - L)) := by
-  refine Tendsto.congr' (EventuallyEq.symm ?_) (Tendsto.sub tendsto_const_nhds hL)
-  exact (eventually_gt_atTop a).mono fun T hT =>
-    (ContDiffOn.integral_neg_derivWithin_Icc (hf.mono Icc_subset_Ici_self) hT.le).symm
 
 variable {f : ℝ → ℝ}
 
@@ -146,19 +85,20 @@ lemma neg_one_pow_mul_taylor_remainder_nonneg (hf : IsCompletelyMonotone f) {x T
   exact h_mem.mono fun t ht => by simp only [Pi.zero_apply]; exact hIoo t ht
 
 /-- For a completely monotone `f` the `n = 1` fundamental-theorem identity gives
-`f(x) - f(T) = ∫ₓᵀ (-f'(t)) dt`, with the integrand nonnegative by the sign condition. -/
-lemma integral_neg_deriv (hf : IsCompletelyMonotone f)
+`f(x) - f(T) = ∫ₓᵀ (-f'(t)) dt`, with `f'` represented by `iteratedDerivWithin 1` on
+`Icc x T`. -/
+lemma integral_neg_iteratedDerivWithin_one_Icc (hf : IsCompletelyMonotone f)
     (x T : ℝ) (hx : 0 ≤ x) (hxT : x ≤ T) :
     f x - f T = ∫ t in x..T, -iteratedDerivWithin 1 f (Icc x T) t := by
   have hsubset : Icc x T ⊆ Ici 0 := Icc_subset_Ici_self.trans (Ici_subset_Ici.mpr hx)
   have hcm_Icc : ContDiffOn ℝ 1 f (Icc x T) :=
     (hf.contDiffOn.mono hsubset).of_le (by exact_mod_cast le_top)
-  exact ContDiffOn.integral_neg_derivWithin_Icc hcm_Icc hxT
+  exact ContDiffOn.integral_neg_iteratedDerivWithin_one_Icc hcm_Icc hxT
 
 /-- The total mass identity `∫₀ᵀ (-f') = f(0) - f(T)` for a completely monotone function. -/
 lemma integral_mass (hf : IsCompletelyMonotone f) (T : ℝ) (hT : 0 ≤ T) :
     ∫ t in (0 : ℝ)..T, -iteratedDerivWithin 1 f (Icc 0 T) t = f 0 - f T := by
-  exact (hf.integral_neg_deriv 0 T le_rfl hT).symm
+  exact (hf.integral_neg_iteratedDerivWithin_one_Icc 0 T le_rfl hT).symm
 
 end IsCompletelyMonotone
 
@@ -175,11 +115,11 @@ private lemma IsCompletelyMonotone.iteratedDerivWithin_one_nonpos
 
 /-- The interval integral of `-f'` with the `T`-dependent set `Icc 0 T` equals the integral with
 the fixed set `Ici 0` (both agree a.e. by set transfer at interior points). -/
-lemma IsCompletelyMonotone.integral_neg_deriv_Ici
+lemma IsCompletelyMonotone.integral_neg_iteratedDerivWithin_one_Ici
     (hcm : IsCompletelyMonotone f) (T : ℝ) (hT : 0 ≤ T) :
     ∫ t in (0 : ℝ)..T, -iteratedDerivWithin 1 f (Icc 0 T) t =
     ∫ t in (0 : ℝ)..T, -iteratedDerivWithin 1 f (Ici 0) t := by
-  exact ContDiffOn.integral_neg_derivWithin_Icc_eq_Ici
+  exact ContDiffOn.integral_neg_iteratedDerivWithin_one_Icc_eq_Ici
     (fun t ht => (hcm.contDiffOn.contDiffAt (Ici_mem_nhds ht.1)).of_le (nat_le_top _))
     le_rfl hT
 
@@ -193,7 +133,8 @@ lemma IsCompletelyMonotone.tendsto_total_mass
 
 /-- `-f'` is integrable on `(0, ∞)` for a completely monotone function, where the derivative is
 taken within the closed half-line `[0, ∞)`. -/
-lemma IsCompletelyMonotone.neg_deriv_integrableOn (hcm : IsCompletelyMonotone f) :
+lemma IsCompletelyMonotone.neg_iteratedDerivWithin_one_integrableOn
+    (hcm : IsCompletelyMonotone f) :
     IntegrableOn (fun t => -iteratedDerivWithin 1 f (Ici 0) t) (Ioi 0) := by
   obtain ⟨L, hL, -⟩ := hcm.exists_nonneg_tendsto_atTop
   apply integrableOn_Ioi_of_intervalIntegral_norm_tendsto (f 0 - L) 0
@@ -213,20 +154,22 @@ lemma IsCompletelyMonotone.neg_deriv_integrableOn (hcm : IsCompletelyMonotone f)
           rw [uIoc_of_le hT.le] at ht
           simp only [Real.norm_eq_abs]
           rw [abs_of_nonneg (by linarith [hcm.iteratedDerivWithin_one_nonpos ht.1.le])])
-      rw [this, ← hcm.integral_neg_deriv_Ici T hT.le, hcm.integral_mass T hT.le]
+      rw [this, ← hcm.integral_neg_iteratedDerivWithin_one_Ici T hT.le,
+        hcm.integral_mass T hT.le]
     exact Tendsto.congr' (EventuallyEq.symm hnorm) (Tendsto.sub tendsto_const_nhds hL)
 
 /-- The improper integral `∫₀^∞ (-f') dt = f(0) - L` for completely monotone functions. -/
-lemma IsCompletelyMonotone.integral_Ioi_neg_deriv
+lemma IsCompletelyMonotone.integral_Ioi_neg_iteratedDerivWithin_one
     (hcm : IsCompletelyMonotone f) {L : ℝ} (hL : Tendsto f atTop (nhds L)) :
     ∫ t in Ioi 0, -iteratedDerivWithin 1 f (Ici 0) t = f 0 - L := by
-  have hint := hcm.neg_deriv_integrableOn
+  have hint := hcm.neg_iteratedDerivWithin_one_integrableOn
   have htend := intervalIntegral_tendsto_integral_Ioi 0 hint tendsto_id
   have htend2 : Tendsto (fun T => ∫ t in (0 : ℝ)..T,
       -iteratedDerivWithin 1 f (Ici 0) t) atTop (nhds (f 0 - L)) :=
     Tendsto.congr'
       ((eventually_gt_atTop 0).mono fun T hT =>
-        ((hcm.integral_neg_deriv_Ici T hT.le).symm.trans (hcm.integral_mass T hT.le)).symm)
+        ((hcm.integral_neg_iteratedDerivWithin_one_Ici T hT.le).symm.trans
+          (hcm.integral_mass T hT.le)).symm)
       (Tendsto.sub tendsto_const_nhds hL)
   exact tendsto_nhds_unique htend htend2
 

--- a/TauCeti/Analysis/CompletelyMonotone/Integral.lean
+++ b/TauCeti/Analysis/CompletelyMonotone/Integral.lean
@@ -49,7 +49,7 @@ open scoped ContDiff Topology
 
 namespace TauCeti
 
-variable {f : ℝ → ℝ}
+variable {E : Type*} [NormedAddCommGroup E] [NormedSpace ℝ E] {f : ℝ → E}
 
 /-- `iteratedDerivWithin` on `Icc x T` agrees with `iteratedDerivWithin` on `Ici 0` at interior
 points, since both equal `iteratedDeriv n f t` under local smoothness at `t`. -/
@@ -66,16 +66,15 @@ lemma ContDiffAt.iteratedDerivWithin_Icc_eq_Ici {n : ℕ}
 /-- The fundamental-theorem identity
 `f x - f T = ∫ₓᵀ -f'` on a compact interval, with derivatives taken within that interval. -/
 lemma ContDiffOn.integral_neg_derivWithin_Icc {x T : ℝ}
-    (hf : ContDiffOn ℝ 1 f (Icc x T)) (hxT : x ≤ T) :
+    [CompleteSpace E] (hf : ContDiffOn ℝ 1 f (Icc x T)) (hxT : x ≤ T) :
     f x - f T = ∫ t in x..T, -iteratedDerivWithin 1 f (Icc x T) t := by
   have hFTC := intervalIntegral.integral_derivWithin_Icc_of_contDiffOn_Icc hf hxT
   rw [iteratedDerivWithin_one]
-  rw [intervalIntegral.integral_neg]
-  linarith [hFTC]
+  rw [intervalIntegral.integral_neg, hFTC, neg_sub]
 
 /-- The zero-left specialization of `ContDiffOn.integral_neg_derivWithin_Icc`. -/
 lemma ContDiffOn.integral_neg_derivWithin_Icc_zero_left {T : ℝ}
-    (hf : ContDiffOn ℝ 1 f (Icc 0 T)) (hT : 0 ≤ T) :
+    [CompleteSpace E] (hf : ContDiffOn ℝ 1 f (Icc 0 T)) (hT : 0 ≤ T) :
     ∫ t in (0 : ℝ)..T, -iteratedDerivWithin 1 f (Icc 0 T) t = f 0 - f T := by
   exact (ContDiffOn.integral_neg_derivWithin_Icc hf hT).symm
 
@@ -99,12 +98,15 @@ lemma ContDiffOn.integral_neg_derivWithin_Icc_eq_Ici
 /-- The total mass `∫₀ᵀ (-f') dt → f(0) - L` as `T → ∞`, assuming smoothness on `[0, ∞)`
 and convergence of `f` to `L` at infinity. -/
 lemma ContDiffOn.tendsto_total_mass
-    (hf : ContDiffOn ℝ 1 f (Ici 0)) {L : ℝ} (hL : Tendsto f atTop (nhds L)) :
+    [CompleteSpace E] (hf : ContDiffOn ℝ 1 f (Ici 0)) {L : E}
+    (hL : Tendsto f atTop (nhds L)) :
     Tendsto (fun T => ∫ t in (0 : ℝ)..T, -iteratedDerivWithin 1 f (Icc 0 T) t) atTop
         (nhds (f 0 - L)) := by
   refine Tendsto.congr' (EventuallyEq.symm ?_) (Tendsto.sub tendsto_const_nhds hL)
   exact (eventually_gt_atTop 0).mono fun T hT =>
     ContDiffOn.integral_neg_derivWithin_Icc_zero_left (hf.mono Icc_subset_Ici_self) hT.le
+
+variable {f : ℝ → ℝ}
 
 namespace IsCompletelyMonotone
 

--- a/TauCeti/Analysis/CompletelyMonotone/Integral.lean
+++ b/TauCeti/Analysis/CompletelyMonotone/Integral.lean
@@ -5,7 +5,6 @@ Released under Apache 2.0 license as described in the file LICENSE.
 module
 
 public import Mathlib.MeasureTheory.Integral.IntegralEqImproper
-public import TauCeti.Analysis.Calculus.IteratedDerivWithin
 public import TauCeti.Analysis.CompletelyMonotone.Basic
 
 /-!

--- a/TauCeti/Analysis/CompletelyMonotone/Integral.lean
+++ b/TauCeti/Analysis/CompletelyMonotone/Integral.lean
@@ -23,8 +23,8 @@ monotone functions, and improper-integral facts for the first derivative within 
 * `TauCeti.IsCompletelyMonotone.neg_one_pow_mul_taylor_remainder_nonneg`: the Taylor integral
   remainder has sign `(-1)ⁿ`.
 * `TauCeti.IsCompletelyMonotone.integral_neg_iteratedDerivWithin_one_Icc`,
-  `TauCeti.IsCompletelyMonotone.integral_mass`: compatibility wrappers for the smooth
-  finite-interval identities.
+  `TauCeti.IsCompletelyMonotone.integral_neg_iteratedDerivWithin_one_Icc_zero_left`:
+  compatibility wrappers for the smooth finite-interval identities.
 * `TauCeti.IsCompletelyMonotone.neg_iteratedDerivWithin_one_integrableOn`,
   `TauCeti.IsCompletelyMonotone.integral_Ioi_neg_iteratedDerivWithin_one`: integrability and the
   improper integral of `-f'` on `(0, ∞)`, represented as `iteratedDerivWithin 1`.
@@ -95,8 +95,10 @@ lemma integral_neg_iteratedDerivWithin_one_Icc (hf : IsCompletelyMonotone f)
     (hf.contDiffOn.mono hsubset).of_le (by exact_mod_cast le_top)
   exact ContDiffOn.integral_neg_iteratedDerivWithin_one_Icc hcm_Icc hxT
 
-/-- The total mass identity `∫₀ᵀ (-f') = f(0) - f(T)` for a completely monotone function. -/
-lemma integral_mass (hf : IsCompletelyMonotone f) (T : ℝ) (hT : 0 ≤ T) :
+/-- The zero-left integral identity `∫₀ᵀ (-f') = f(0) - f(T)` for a completely monotone
+function. -/
+lemma integral_neg_iteratedDerivWithin_one_Icc_zero_left
+    (hf : IsCompletelyMonotone f) (T : ℝ) (hT : 0 ≤ T) :
     ∫ t in (0 : ℝ)..T, -iteratedDerivWithin 1 f (Icc 0 T) t = f 0 - f T := by
   exact (hf.integral_neg_iteratedDerivWithin_one_Icc 0 T le_rfl hT).symm
 
@@ -123,13 +125,14 @@ lemma IsCompletelyMonotone.integral_neg_iteratedDerivWithin_one_Ici
     (fun t ht => (hcm.contDiffOn.contDiffAt (Ici_mem_nhds ht.1)).of_le (nat_le_top _))
     le_rfl hT
 
-/-- The total mass `∫₀ᵀ (-f') dt → f(0) - L` as `T → ∞`, where `L = lim f(t)`. This is
+/-- The integral `∫₀ᵀ (-f') dt → f(0) - L` as `T → ∞`, where `L = lim f(t)`. This is
 the key uniform bound for the tightness argument in Bernstein's theorem. -/
-lemma IsCompletelyMonotone.tendsto_total_mass
+lemma IsCompletelyMonotone.tendsto_integral_neg_iteratedDerivWithin_one_Icc_atTop
     (hcm : IsCompletelyMonotone f) {L : ℝ} (hL : Tendsto f atTop (nhds L)) :
     Tendsto (fun T => ∫ t in (0 : ℝ)..T, -iteratedDerivWithin 1 f (Icc 0 T) t) atTop
         (nhds (f 0 - L)) :=
-  ContDiffOn.tendsto_total_mass (a := 0) (hcm.contDiffOn.of_le (nat_le_top _)) hL
+  ContDiffOn.tendsto_integral_neg_iteratedDerivWithin_one_Icc_atTop
+    (a := 0) (hcm.contDiffOn.of_le (nat_le_top _)) hL
 
 /-- `-f'` is integrable on `(0, ∞)` for a completely monotone function, where the derivative is
 taken within the closed half-line `[0, ∞)`. -/
@@ -137,25 +140,31 @@ lemma IsCompletelyMonotone.neg_iteratedDerivWithin_one_integrableOn
     (hcm : IsCompletelyMonotone f) :
     IntegrableOn (fun t => -iteratedDerivWithin 1 f (Ici 0) t) (Ioi 0) := by
   obtain ⟨L, hL, -⟩ := hcm.exists_nonneg_tendsto_atTop
+  -- Reduce the improper-integrability criterion to convergence of the interval integrals of
+  -- the nonnegative function `-f'`.
   apply integrableOn_Ioi_of_intervalIntegral_norm_tendsto (f 0 - L) 0
       (l := atTop) (b := id)
+  -- Local integrability on each compact interval follows from continuity of the derivative
+  -- within the fixed half-line.
   · intro T
     exact ((hcm.contDiffOn.continuousOn_iteratedDerivWithin (nat_le_top _)
       (uniqueDiffOn_Ici 0)).neg.mono Icc_subset_Ici_self).integrableOn_compact
         isCompact_Icc |>.mono_set Ioc_subset_Icc_self
   · exact tendsto_id
+  -- On positive intervals the norm drops because `f' ≤ 0`; the finite-interval FTC identity
+  -- then identifies the primitive with `f(0) - f(T)`.
   · have hnorm : ∀ᶠ T in atTop, (∫ t in (0 : ℝ)..id T,
         ‖(fun t => -iteratedDerivWithin 1 f (Ici 0) t) t‖) = f 0 - f T := by
       filter_upwards [eventually_gt_atTop 0] with T hT
       simp only [id]
       have : (∫ t in (0 : ℝ)..T, ‖(fun t => -iteratedDerivWithin 1 f (Ici 0) t) t‖) =
-          ∫ t in (0 : ℝ)..T, -iteratedDerivWithin 1 f (Ici 0) t :=
+              ∫ t in (0 : ℝ)..T, -iteratedDerivWithin 1 f (Ici 0) t :=
         intervalIntegral.integral_congr_ae (ae_of_all _ fun t ht => by
           rw [uIoc_of_le hT.le] at ht
           simp only [Real.norm_eq_abs]
           rw [abs_of_nonneg (by linarith [hcm.iteratedDerivWithin_one_nonpos ht.1.le])])
       rw [this, ← hcm.integral_neg_iteratedDerivWithin_one_Ici T hT.le,
-        hcm.integral_mass T hT.le]
+        hcm.integral_neg_iteratedDerivWithin_one_Icc_zero_left T hT.le]
     exact Tendsto.congr' (EventuallyEq.symm hnorm) (Tendsto.sub tendsto_const_nhds hL)
 
 /-- The improper integral `∫₀^∞ (-f') dt = f(0) - L` for completely monotone functions. -/
@@ -169,7 +178,7 @@ lemma IsCompletelyMonotone.integral_Ioi_neg_iteratedDerivWithin_one
     Tendsto.congr'
       ((eventually_gt_atTop 0).mono fun T hT =>
         ((hcm.integral_neg_iteratedDerivWithin_one_Ici T hT.le).symm.trans
-          (hcm.integral_mass T hT.le)).symm)
+          (hcm.integral_neg_iteratedDerivWithin_one_Icc_zero_left T hT.le)).symm)
       (Tendsto.sub tendsto_const_nhds hL)
   exact tendsto_nhds_unique htend htend2
 

--- a/TauCeti/Analysis/CompletelyMonotone/Integral.lean
+++ b/TauCeti/Analysis/CompletelyMonotone/Integral.lean
@@ -78,33 +78,33 @@ lemma ContDiffOn.integral_neg_derivWithin_Icc_zero_left {T : ℝ}
     ∫ t in (0 : ℝ)..T, -iteratedDerivWithin 1 f (Icc 0 T) t = f 0 - f T := by
   exact (ContDiffOn.integral_neg_derivWithin_Icc hf hT).symm
 
-/-- The interval integral of `-f'` with the `T`-dependent set `Icc 0 T` equals the integral with
-the fixed set `Ici 0`, under local smoothness at the strict interior points. -/
+/-- The interval integral of `-f'` with the `T`-dependent set `Icc x T` equals the integral with
+the fixed set `Ici a`, under local smoothness at the strict interior points. -/
 lemma ContDiffOn.integral_neg_derivWithin_Icc_eq_Ici
-    {T : ℝ} (hf : ∀ t ∈ Ioo (0 : ℝ) T, ContDiffAt ℝ 1 f t) (hT : 0 ≤ T) :
-    ∫ t in (0 : ℝ)..T, -iteratedDerivWithin 1 f (Icc 0 T) t =
-    ∫ t in (0 : ℝ)..T, -iteratedDerivWithin 1 f (Ici 0) t := by
+    {a x T : ℝ} (hf : ∀ t ∈ Ioo x T, ContDiffAt ℝ 1 f t) (hax : a ≤ x) (hxT : x ≤ T) :
+    ∫ t in x..T, -iteratedDerivWithin 1 f (Icc x T) t =
+    ∫ t in x..T, -iteratedDerivWithin 1 f (Ici a) t := by
   apply intervalIntegral.integral_congr_uIoo
   intro t ht
-  rw [uIoo_of_le hT] at ht
-  have ht_pos : 0 < t := ht.1
-  have hT_pos : 0 < T := lt_trans ht_pos ht.2
+  rw [uIoo_of_le hxT] at ht
+  have ha_lt : a < t := lt_of_le_of_lt hax ht.1
+  have hxT_pos : x < T := lt_trans ht.1 ht.2
   have hcda : ContDiffAt ℝ 1 f t := hf t ht
-  simp only [iteratedDerivWithin_eq_iteratedDeriv (uniqueDiffOn_Icc hT_pos) hcda
+  simp only [iteratedDerivWithin_eq_iteratedDeriv (uniqueDiffOn_Icc hxT_pos) hcda
       (Ioo_subset_Icc_self ht),
-    iteratedDerivWithin_eq_iteratedDeriv (uniqueDiffOn_Ici 0) hcda
-      (mem_Ici.mpr ht_pos.le)]
+    iteratedDerivWithin_eq_iteratedDeriv (uniqueDiffOn_Ici a) hcda
+      (mem_Ici.mpr ha_lt.le)]
 
-/-- The total mass `∫₀ᵀ (-f') dt → f(0) - L` as `T → ∞`, assuming smoothness on `[0, ∞)`
+/-- The total mass `∫ₐᵀ (-f') dt → f(a) - L` as `T → ∞`, assuming smoothness on `[a, ∞)`
 and convergence of `f` to `L` at infinity. -/
 lemma ContDiffOn.tendsto_total_mass
-    [CompleteSpace E] (hf : ContDiffOn ℝ 1 f (Ici 0)) {L : E}
+    [CompleteSpace E] {a : ℝ} (hf : ContDiffOn ℝ 1 f (Ici a)) {L : E}
     (hL : Tendsto f atTop (nhds L)) :
-    Tendsto (fun T => ∫ t in (0 : ℝ)..T, -iteratedDerivWithin 1 f (Icc 0 T) t) atTop
-        (nhds (f 0 - L)) := by
+    Tendsto (fun T => ∫ t in a..T, -iteratedDerivWithin 1 f (Icc a T) t) atTop
+        (nhds (f a - L)) := by
   refine Tendsto.congr' (EventuallyEq.symm ?_) (Tendsto.sub tendsto_const_nhds hL)
-  exact (eventually_gt_atTop 0).mono fun T hT =>
-    ContDiffOn.integral_neg_derivWithin_Icc_zero_left (hf.mono Icc_subset_Ici_self) hT.le
+  exact (eventually_gt_atTop a).mono fun T hT =>
+    (ContDiffOn.integral_neg_derivWithin_Icc (hf.mono Icc_subset_Ici_self) hT.le).symm
 
 variable {f : ℝ → ℝ}
 
@@ -180,7 +180,8 @@ lemma IsCompletelyMonotone.integral_neg_deriv_Ici
     ∫ t in (0 : ℝ)..T, -iteratedDerivWithin 1 f (Icc 0 T) t =
     ∫ t in (0 : ℝ)..T, -iteratedDerivWithin 1 f (Ici 0) t := by
   exact ContDiffOn.integral_neg_derivWithin_Icc_eq_Ici
-    (fun t ht => (hcm.contDiffOn.contDiffAt (Ici_mem_nhds ht.1)).of_le (nat_le_top _)) hT
+    (fun t ht => (hcm.contDiffOn.contDiffAt (Ici_mem_nhds ht.1)).of_le (nat_le_top _))
+    le_rfl hT
 
 /-- The total mass `∫₀ᵀ (-f') dt → f(0) - L` as `T → ∞`, where `L = lim f(t)`. This is
 the key uniform bound for the tightness argument in Bernstein's theorem. -/
@@ -188,7 +189,7 @@ lemma IsCompletelyMonotone.tendsto_total_mass
     (hcm : IsCompletelyMonotone f) {L : ℝ} (hL : Tendsto f atTop (nhds L)) :
     Tendsto (fun T => ∫ t in (0 : ℝ)..T, -iteratedDerivWithin 1 f (Icc 0 T) t) atTop
         (nhds (f 0 - L)) :=
-  ContDiffOn.tendsto_total_mass (hcm.contDiffOn.of_le (nat_le_top _)) hL
+  ContDiffOn.tendsto_total_mass (a := 0) (hcm.contDiffOn.of_le (nat_le_top _)) hL
 
 /-- `-f'` is integrable on `(0, ∞)` for a completely monotone function, where the derivative is
 taken within the closed half-line `[0, ∞)`. -/

--- a/TauCeti/Analysis/CompletelyMonotone/Integral.lean
+++ b/TauCeti/Analysis/CompletelyMonotone/Integral.lean
@@ -25,6 +25,9 @@ monotone functions, and improper-integral facts for the first derivative within 
 * `TauCeti.IsCompletelyMonotone.integral_neg_iteratedDerivWithin_one_Icc`,
   `TauCeti.IsCompletelyMonotone.integral_neg_iteratedDerivWithin_one_Icc_zero_left`:
   compatibility wrappers for the smooth finite-interval identities.
+* `TauCeti.IsCompletelyMonotone.integral_neg_iteratedDerivWithin_one_Icc_eq_Ici`:
+  transfer of the first-derivative integral from the interval-dependent differentiability set
+  `Icc 0 T` to the fixed half-line `Ici 0`.
 * `TauCeti.IsCompletelyMonotone.neg_iteratedDerivWithin_one_integrableOn`,
   `TauCeti.IsCompletelyMonotone.integral_Ioi_neg_iteratedDerivWithin_one`: integrability and the
   improper integral of `-f'` on `(0, ∞)`, represented as `iteratedDerivWithin 1`.
@@ -116,8 +119,8 @@ private lemma IsCompletelyMonotone.iteratedDerivWithin_one_nonpos
   rw [iteratedDerivWithin_one]; exact hf.derivWithin_nonpos ht
 
 /-- The interval integral of `-f'` with the `T`-dependent set `Icc 0 T` equals the integral with
-the fixed set `Ici 0` (both agree a.e. by set transfer at interior points). -/
-lemma IsCompletelyMonotone.integral_neg_iteratedDerivWithin_one_Ici
+the fixed set `Ici 0` for a completely monotone function. -/
+lemma IsCompletelyMonotone.integral_neg_iteratedDerivWithin_one_Icc_eq_Ici
     (hcm : IsCompletelyMonotone f) (T : ℝ) (hT : 0 ≤ T) :
     ∫ t in (0 : ℝ)..T, -iteratedDerivWithin 1 f (Icc 0 T) t =
     ∫ t in (0 : ℝ)..T, -iteratedDerivWithin 1 f (Ici 0) t := by
@@ -163,7 +166,7 @@ lemma IsCompletelyMonotone.neg_iteratedDerivWithin_one_integrableOn
           rw [uIoc_of_le hT.le] at ht
           simp only [Real.norm_eq_abs]
           rw [abs_of_nonneg (by linarith [hcm.iteratedDerivWithin_one_nonpos ht.1.le])])
-      rw [this, ← hcm.integral_neg_iteratedDerivWithin_one_Ici T hT.le,
+      rw [this, ← hcm.integral_neg_iteratedDerivWithin_one_Icc_eq_Ici T hT.le,
         hcm.integral_neg_iteratedDerivWithin_one_Icc_zero_left T hT.le]
     exact Tendsto.congr' (EventuallyEq.symm hnorm) (Tendsto.sub tendsto_const_nhds hL)
 
@@ -177,7 +180,7 @@ lemma IsCompletelyMonotone.integral_Ioi_neg_iteratedDerivWithin_one
       -iteratedDerivWithin 1 f (Ici 0) t) atTop (nhds (f 0 - L)) :=
     Tendsto.congr'
       ((eventually_gt_atTop 0).mono fun T hT =>
-        ((hcm.integral_neg_iteratedDerivWithin_one_Ici T hT.le).symm.trans
+        ((hcm.integral_neg_iteratedDerivWithin_one_Icc_eq_Ici T hT.le).symm.trans
           (hcm.integral_neg_iteratedDerivWithin_one_Icc_zero_left T hT.le)).symm)
       (Tendsto.sub tendsto_const_nhds hL)
   exact tendsto_nhds_unique htend htend2

--- a/TauCeti/MeasureTheory/Measure/Prokhorov.lean
+++ b/TauCeti/MeasureTheory/Measure/Prokhorov.lean
@@ -1,0 +1,134 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+module
+
+public import Mathlib.MeasureTheory.Measure.Prokhorov
+public import Mathlib.MeasureTheory.Integral.BoundedContinuousFunction
+
+/-!
+# Weak cluster limits of tight finite measures
+
+This file contains a generic finite-measure extraction lemma based on Mathlib's Prokhorov
+compactness theorem for finite measures. It has no real-line support condition and no
+normalization step: tightness and a uniform mass bound place the sequence in a compact set of
+`FiniteMeasure`s, and compactness gives a weak cluster limit.
+
+## Main declarations
+
+* `TauCeti.finite_measure_cluster_limit`: a tight, mass-bounded sequence of finite measures has a
+  weak cluster limit along an ultrafilter below `atTop`.
+* `TauCeti.finite_measure_subseq_limit`: the corresponding subsequence form when the weak topology
+  on `FiniteMeasure α` is first-countable.
+
+## References
+
+* Roadmap: `TauCetiRoadmap/OneParameterSemigroups/README.md`, Part B (Bernstein theorem milestone).
+-/
+
+public section
+
+open MeasureTheory Set Filter Topology
+open scoped NNReal Topology
+
+namespace TauCeti
+
+variable {α : Type*} [MeasurableSpace α] [TopologicalSpace α]
+  [T2Space α] [BorelSpace α]
+
+/-- A tight, uniformly mass-bounded sequence of finite measures has a weak cluster limit.
+
+The compactness input is Mathlib's
+`isCompact_setOf_finiteMeasure_mass_le_compl_isCompact_le`; the conclusion is phrased as
+convergence along an ultrafilter `U ≤ atTop`, which is enough for diagonal limit arguments and does
+not require a metrizability instance for `FiniteMeasure α`. -/
+lemma finite_measure_cluster_limit
+    (σ : ℕ → Measure α) (C : ℝ)
+    [hfin : ∀ n, IsFiniteMeasure (σ n)]
+    (hmass : ∀ n, (σ n) univ ≤ ENNReal.ofReal C)
+    (htight : ∀ ε : ℝ, 0 < ε →
+      ∃ K : Set α, IsCompact K ∧ ∀ n, (σ n) Kᶜ ≤ ENNReal.ofReal ε) :
+    ∃ (μ₀ : Measure α) (U : Ultrafilter ℕ), (U : Filter ℕ) ≤ atTop ∧ IsFiniteMeasure μ₀ ∧
+      μ₀ univ ≤ ENNReal.ofReal C ∧
+      ∀ g : BoundedContinuousFunction α ℝ,
+        Tendsto (fun n => ∫ x, g x ∂(σ n)) (U : Filter ℕ)
+          (nhds (∫ x, g x ∂μ₀)) := by
+  let σf : ℕ → FiniteMeasure α := fun n => ⟨σ n, hfin n⟩
+  let Cnn : ℝ≥0 := Real.toNNReal C
+  obtain ⟨u, -, hu_pos, hu_lim⟩ :
+      ∃ u : ℕ → ℝ≥0, StrictAnti u ∧ (∀ n, 0 < u n) ∧ Tendsto u atTop (𝓝 0) :=
+    exists_seq_strictAnti_tendsto 0
+  have hchoose : ∀ j, ∃ K : Set α, IsCompact K ∧
+      ∀ n, (σ n) Kᶜ ≤ (u j : ENNReal) := by
+    intro j
+    obtain ⟨K, hK, htail⟩ := htight (u j : ℝ) (by exact_mod_cast hu_pos j)
+    refine ⟨K, hK, fun n => ?_⟩
+    simpa using htail n
+  choose K hK_comp hK_tail using hchoose
+  let Kacc : ℕ → Set α := Set.accumulate K
+  let S : Set (FiniteMeasure α) :=
+    {μ | μ.mass ≤ Cnn ∧ ∀ j, μ (Kacc j)ᶜ ≤ u j}
+  have hKacc_comp : ∀ j, IsCompact (Kacc j) := by
+    intro j
+    exact isCompact_accumulate hK_comp j
+  have hcompact : IsCompact S := by
+    simpa [S] using
+      isCompact_setOf_finiteMeasure_mass_le_compl_isCompact_le
+        (E := α) (C := Cnn) (u := u) (K := Kacc) hu_lim hKacc_comp
+        (Or.inr Set.monotone_accumulate)
+  have hσ_mem : ∀ n, σf n ∈ S := by
+    intro n
+    constructor
+    · dsimp [σf, S, Cnn, FiniteMeasure.mass]
+      exact ENNReal.toNNReal_mono ENNReal.ofReal_ne_top (hmass n)
+    · intro j
+      have hsubset : (Kacc j)ᶜ ⊆ (K j)ᶜ :=
+        compl_subset_compl.mpr (Set.subset_accumulate (s := K) (x := j))
+      have htail : (σ n) (Kacc j)ᶜ ≤ (u j : ENNReal) :=
+        (measure_mono hsubset).trans (hK_tail j n)
+      exact ENNReal.coe_le_coe.mp (by simpa [σf] using htail)
+  have hmap_le : map σf atTop ≤ 𝓟 S :=
+    tendsto_principal.mpr (Eventually.of_forall hσ_mem)
+  obtain ⟨μf, hμfS, hcluster⟩ := hcompact hmap_le
+  have hmapcluster : MapClusterPt μf atTop σf := hcluster
+  obtain ⟨U, hUle, hUtend⟩ := mapClusterPt_iff_ultrafilter.mp hmapcluster
+  refine ⟨(μf : Measure α), U, hUle, inferInstance, ?_, ?_⟩
+  · have hle : (μf.mass : ENNReal) ≤ (Cnn : ENNReal) := ENNReal.coe_le_coe.mpr hμfS.1
+    rw [← FiniteMeasure.ennreal_mass]
+    simpa [Cnn, ENNReal.ofNNReal_toNNReal] using hle
+  · intro g
+    have hweak :=
+      (FiniteMeasure.tendsto_iff_forall_integral_tendsto.mp hUtend) g
+    simpa [σf] using hweak
+
+/-- Sequential form of `finite_measure_cluster_limit` when `FiniteMeasure α` is first-countable. -/
+lemma finite_measure_subseq_limit
+    [FirstCountableTopology (FiniteMeasure α)]
+    (σ : ℕ → Measure α) (C : ℝ)
+    [hfin : ∀ n, IsFiniteMeasure (σ n)]
+    (hmass : ∀ n, (σ n) univ ≤ ENNReal.ofReal C)
+    (htight : ∀ ε : ℝ, 0 < ε →
+      ∃ K : Set α, IsCompact K ∧ ∀ n, (σ n) Kᶜ ≤ ENNReal.ofReal ε) :
+    ∃ (μ₀ : Measure α) (φ : ℕ → ℕ), IsFiniteMeasure μ₀ ∧ StrictMono φ ∧
+      μ₀ univ ≤ ENNReal.ofReal C ∧
+      ∀ g : BoundedContinuousFunction α ℝ,
+        Tendsto (fun k => ∫ x, g x ∂(σ (φ k))) atTop
+          (nhds (∫ x, g x ∂μ₀)) := by
+  obtain ⟨μ₀, U, hUle, hμ₀_fin, hmass_μ₀, hweakU⟩ :=
+    finite_measure_cluster_limit (α := α) σ C hmass htight
+  let σf : ℕ → FiniteMeasure α := fun n => ⟨σ n, hfin n⟩
+  let μf : FiniteMeasure α := ⟨μ₀, hμ₀_fin⟩
+  have hUtend : Tendsto σf (U : Filter ℕ) (nhds μf) := by
+    rw [FiniteMeasure.tendsto_iff_forall_integral_tendsto]
+    intro g
+    simpa [σf, μf] using hweakU g
+  have hclusterU : MapClusterPt μf (U : Filter ℕ) σf := hUtend.mapClusterPt
+  have hcluster : MapClusterPt μf atTop σf := hclusterU.mono hUle
+  obtain ⟨φ, hφ, hφ_tendsto⟩ := hcluster.tendsto_subseq
+  refine ⟨μ₀, φ, hμ₀_fin, hφ, hmass_μ₀, fun g => ?_⟩
+  have hweak :=
+    (FiniteMeasure.tendsto_iff_forall_integral_tendsto.mp hφ_tendsto) g
+  simpa [σf, μf, Function.comp_def] using hweak
+
+end TauCeti

--- a/TauCeti/MeasureTheory/Measure/Prokhorov.lean
+++ b/TauCeti/MeasureTheory/Measure/Prokhorov.lean
@@ -45,7 +45,6 @@ convergence along an ultrafilter `U ≤ atTop`, which is enough for diagonal lim
 not require a metrizability instance for `FiniteMeasure α`. -/
 lemma finite_measure_cluster_limit
     (σ : ℕ → Measure α) (C : ℝ≥0)
-    [hfin : ∀ n, IsFiniteMeasure (σ n)]
     (hmass : ∀ n, (σ n) univ ≤ (C : ENNReal))
     (hTight : IsTightMeasureSet (Set.range σ)) :
     ∃ (μ₀ : Measure α) (U : Ultrafilter ℕ), (U : Filter ℕ) ≤ atTop ∧ IsFiniteMeasure μ₀ ∧
@@ -53,6 +52,8 @@ lemma finite_measure_cluster_limit
       ∀ g : BoundedContinuousFunction α ℝ,
         Tendsto (fun n => ∫ x, g x ∂(σ n)) (U : Filter ℕ)
           (nhds (∫ x, g x ∂μ₀)) := by
+  have hfin : ∀ n, IsFiniteMeasure (σ n) := fun n =>
+    ⟨(hmass n).trans_lt ENNReal.coe_lt_top⟩
   let σf : ℕ → FiniteMeasure α := fun n => ⟨σ n, hfin n⟩
   obtain ⟨u, -, hu_pos, hu_lim⟩ :
       ∃ u : ℕ → ℝ≥0, StrictAnti u ∧ (∀ n, 0 < u n) ∧ Tendsto u atTop (𝓝 0) :=
@@ -106,7 +107,6 @@ lemma finite_measure_cluster_limit
 lemma finite_measure_subseq_limit
     [FirstCountableTopology (FiniteMeasure α)]
     (σ : ℕ → Measure α) (C : ℝ≥0)
-    [hfin : ∀ n, IsFiniteMeasure (σ n)]
     (hmass : ∀ n, (σ n) univ ≤ (C : ENNReal))
     (hTight : IsTightMeasureSet (Set.range σ)) :
     ∃ (μ₀ : Measure α) (φ : ℕ → ℕ), IsFiniteMeasure μ₀ ∧ StrictMono φ ∧
@@ -116,6 +116,8 @@ lemma finite_measure_subseq_limit
           (nhds (∫ x, g x ∂μ₀)) := by
   obtain ⟨μ₀, U, hUle, hμ₀_fin, hmass_μ₀, hweakU⟩ :=
     finite_measure_cluster_limit (α := α) σ C hmass hTight
+  have hfin : ∀ n, IsFiniteMeasure (σ n) := fun n =>
+    ⟨(hmass n).trans_lt ENNReal.coe_lt_top⟩
   let σf : ℕ → FiniteMeasure α := fun n => ⟨σ n, hfin n⟩
   let μf : FiniteMeasure α := ⟨μ₀, hμ₀_fin⟩
   have hUtend : Tendsto σf (U : Filter ℕ) (nhds μf) := by

--- a/TauCeti/MeasureTheory/Measure/Prokhorov.lean
+++ b/TauCeti/MeasureTheory/Measure/Prokhorov.lean
@@ -39,10 +39,10 @@ variable {α : Type*} [MeasurableSpace α] [TopologicalSpace α]
 
 /-- A tight, uniformly mass-bounded sequence of finite measures has a weak cluster limit.
 
-The compactness input is Mathlib's
-`isCompact_setOf_finiteMeasure_mass_le_compl_isCompact_le`; the conclusion is phrased as
-convergence along an ultrafilter `U ≤ atTop`, which is enough for diagonal limit arguments and does
-not require a metrizability instance for `FiniteMeasure α`. -/
+Given tightness of the sequence and a common total-mass bound, the conclusion is a finite limiting
+measure with the same mass bound and weak convergence of all bounded-continuous test-function
+integrals along an ultrafilter `U ≤ atTop`; no first-countability assumption on `FiniteMeasure α`
+is needed. -/
 lemma finite_measure_cluster_limit
     (σ : ℕ → Measure α) (C : ℝ≥0)
     (hmass : ∀ n, (σ n) univ ≤ (C : ENNReal))

--- a/TauCeti/MeasureTheory/Measure/Prokhorov.lean
+++ b/TauCeti/MeasureTheory/Measure/Prokhorov.lean
@@ -44,44 +44,44 @@ The compactness input is Mathlib's
 convergence along an ultrafilter `U ≤ atTop`, which is enough for diagonal limit arguments and does
 not require a metrizability instance for `FiniteMeasure α`. -/
 lemma finite_measure_cluster_limit
-    (σ : ℕ → Measure α) (C : ℝ)
+    (σ : ℕ → Measure α) (C : ℝ≥0)
     [hfin : ∀ n, IsFiniteMeasure (σ n)]
-    (hmass : ∀ n, (σ n) univ ≤ ENNReal.ofReal C)
-    (htight : ∀ ε : ℝ, 0 < ε →
-      ∃ K : Set α, IsCompact K ∧ ∀ n, (σ n) Kᶜ ≤ ENNReal.ofReal ε) :
+    (hmass : ∀ n, (σ n) univ ≤ (C : ENNReal))
+    (hTight : IsTightMeasureSet (Set.range σ)) :
     ∃ (μ₀ : Measure α) (U : Ultrafilter ℕ), (U : Filter ℕ) ≤ atTop ∧ IsFiniteMeasure μ₀ ∧
-      μ₀ univ ≤ ENNReal.ofReal C ∧
+      μ₀ univ ≤ (C : ENNReal) ∧
       ∀ g : BoundedContinuousFunction α ℝ,
         Tendsto (fun n => ∫ x, g x ∂(σ n)) (U : Filter ℕ)
           (nhds (∫ x, g x ∂μ₀)) := by
   let σf : ℕ → FiniteMeasure α := fun n => ⟨σ n, hfin n⟩
-  let Cnn : ℝ≥0 := Real.toNNReal C
   obtain ⟨u, -, hu_pos, hu_lim⟩ :
       ∃ u : ℕ → ℝ≥0, StrictAnti u ∧ (∀ n, 0 < u n) ∧ Tendsto u atTop (𝓝 0) :=
     exists_seq_strictAnti_tendsto 0
   have hchoose : ∀ j, ∃ K : Set α, IsCompact K ∧
       ∀ n, (σ n) Kᶜ ≤ (u j : ENNReal) := by
     intro j
-    obtain ⟨K, hK, htail⟩ := htight (u j : ℝ) (by exact_mod_cast hu_pos j)
+    obtain ⟨K, hK, htail⟩ :=
+      isTightMeasureSet_iff_exists_isCompact_measure_compl_le.mp hTight
+        (u j : ENNReal) (by exact_mod_cast hu_pos j)
     refine ⟨K, hK, fun n => ?_⟩
-    simpa using htail n
+    exact htail (σ n) (Set.mem_range_self n)
   choose K hK_comp hK_tail using hchoose
   let Kacc : ℕ → Set α := Set.accumulate K
   let S : Set (FiniteMeasure α) :=
-    {μ | μ.mass ≤ Cnn ∧ ∀ j, μ (Kacc j)ᶜ ≤ u j}
+    {μ | μ.mass ≤ C ∧ ∀ j, μ (Kacc j)ᶜ ≤ u j}
   have hKacc_comp : ∀ j, IsCompact (Kacc j) := by
     intro j
     exact isCompact_accumulate hK_comp j
   have hcompact : IsCompact S := by
     simpa [S] using
       isCompact_setOf_finiteMeasure_mass_le_compl_isCompact_le
-        (E := α) (C := Cnn) (u := u) (K := Kacc) hu_lim hKacc_comp
+        (E := α) (C := C) (u := u) (K := Kacc) hu_lim hKacc_comp
         (Or.inr Set.monotone_accumulate)
   have hσ_mem : ∀ n, σf n ∈ S := by
     intro n
     constructor
-    · dsimp [σf, S, Cnn, FiniteMeasure.mass]
-      exact ENNReal.toNNReal_mono ENNReal.ofReal_ne_top (hmass n)
+    · dsimp [σf, S, FiniteMeasure.mass]
+      exact ENNReal.coe_le_coe.mp (by simpa using hmass n)
     · intro j
       have hsubset : (Kacc j)ᶜ ⊆ (K j)ᶜ :=
         compl_subset_compl.mpr (Set.subset_accumulate (s := K) (x := j))
@@ -94,9 +94,9 @@ lemma finite_measure_cluster_limit
   have hmapcluster : MapClusterPt μf atTop σf := hcluster
   obtain ⟨U, hUle, hUtend⟩ := mapClusterPt_iff_ultrafilter.mp hmapcluster
   refine ⟨(μf : Measure α), U, hUle, inferInstance, ?_, ?_⟩
-  · have hle : (μf.mass : ENNReal) ≤ (Cnn : ENNReal) := ENNReal.coe_le_coe.mpr hμfS.1
+  · have hle : (μf.mass : ENNReal) ≤ (C : ENNReal) := ENNReal.coe_le_coe.mpr hμfS.1
     rw [← FiniteMeasure.ennreal_mass]
-    simpa [Cnn, ENNReal.ofNNReal_toNNReal] using hle
+    simpa using hle
   · intro g
     have hweak :=
       (FiniteMeasure.tendsto_iff_forall_integral_tendsto.mp hUtend) g
@@ -105,18 +105,17 @@ lemma finite_measure_cluster_limit
 /-- Sequential form of `finite_measure_cluster_limit` when `FiniteMeasure α` is first-countable. -/
 lemma finite_measure_subseq_limit
     [FirstCountableTopology (FiniteMeasure α)]
-    (σ : ℕ → Measure α) (C : ℝ)
+    (σ : ℕ → Measure α) (C : ℝ≥0)
     [hfin : ∀ n, IsFiniteMeasure (σ n)]
-    (hmass : ∀ n, (σ n) univ ≤ ENNReal.ofReal C)
-    (htight : ∀ ε : ℝ, 0 < ε →
-      ∃ K : Set α, IsCompact K ∧ ∀ n, (σ n) Kᶜ ≤ ENNReal.ofReal ε) :
+    (hmass : ∀ n, (σ n) univ ≤ (C : ENNReal))
+    (hTight : IsTightMeasureSet (Set.range σ)) :
     ∃ (μ₀ : Measure α) (φ : ℕ → ℕ), IsFiniteMeasure μ₀ ∧ StrictMono φ ∧
-      μ₀ univ ≤ ENNReal.ofReal C ∧
+      μ₀ univ ≤ (C : ENNReal) ∧
       ∀ g : BoundedContinuousFunction α ℝ,
         Tendsto (fun k => ∫ x, g x ∂(σ (φ k))) atTop
           (nhds (∫ x, g x ∂μ₀)) := by
   obtain ⟨μ₀, U, hUle, hμ₀_fin, hmass_μ₀, hweakU⟩ :=
-    finite_measure_cluster_limit (α := α) σ C hmass htight
+    finite_measure_cluster_limit (α := α) σ C hmass hTight
   let σf : ℕ → FiniteMeasure α := fun n => ⟨σ n, hfin n⟩
   let μf : FiniteMeasure α := ⟨μ₀, hμ₀_fin⟩
   have hUtend : Tendsto σf (U : Filter ℕ) (nhds μf) := by

--- a/TauCeti/MeasureTheory/Measure/Prokhorov.lean
+++ b/TauCeti/MeasureTheory/Measure/Prokhorov.lean
@@ -52,12 +52,17 @@ lemma finite_measure_cluster_limit
       ∀ g : BoundedContinuousFunction α ℝ,
         Tendsto (fun n => ∫ x, g x ∂(σ n)) (U : Filter ℕ)
           (nhds (∫ x, g x ∂μ₀)) := by
+  -- First coerce the sequence to `FiniteMeasure`; the uniform mass bound supplies finiteness.
   have hfin : ∀ n, IsFiniteMeasure (σ n) := fun n =>
     ⟨(hmass n).trans_lt ENNReal.coe_lt_top⟩
   let σf : ℕ → FiniteMeasure α := fun n => ⟨σ n, hfin n⟩
+  -- Choose a positive sequence decreasing to zero; these values are the tail tolerances in
+  -- Prokhorov's compact set criterion.
   obtain ⟨u, -, hu_pos, hu_lim⟩ :
       ∃ u : ℕ → ℝ≥0, StrictAnti u ∧ (∀ n, 0 < u n) ∧ Tendsto u atTop (𝓝 0) :=
     exists_seq_strictAnti_tendsto 0
+  -- Tightness gives one compact set for each tolerance, uniformly for all measures in the
+  -- original sequence.
   have hchoose : ∀ j, ∃ K : Set α, IsCompact K ∧
       ∀ n, (σ n) Kᶜ ≤ (u j : ENNReal) := by
     intro j
@@ -67,6 +72,7 @@ lemma finite_measure_cluster_limit
     refine ⟨K, hK, fun n => ?_⟩
     exact htail (σ n) (Set.mem_range_self n)
   choose K hK_comp hK_tail using hchoose
+  -- Accumulate the compact sets to fit Mathlib's monotone compact-family formulation.
   let Kacc : ℕ → Set α := Set.accumulate K
   let S : Set (FiniteMeasure α) :=
     {μ | μ.mass ≤ C ∧ ∀ j, μ (Kacc j)ᶜ ≤ u j}
@@ -78,6 +84,8 @@ lemma finite_measure_cluster_limit
       isCompact_setOf_finiteMeasure_mass_le_compl_isCompact_le
         (E := α) (C := C) (u := u) (K := Kacc) hu_lim hKacc_comp
         (Or.inr Set.monotone_accumulate)
+  -- The finite-measure sequence lies in the compact Prokhorov set: the mass condition is direct,
+  -- and the tail condition follows by enlarging `K j` to `Kacc j`.
   have hσ_mem : ∀ n, σf n ∈ S := by
     intro n
     constructor
@@ -89,12 +97,16 @@ lemma finite_measure_cluster_limit
       have htail : (σ n) (Kacc j)ᶜ ≤ (u j : ENNReal) :=
         (measure_mono hsubset).trans (hK_tail j n)
       exact ENNReal.coe_le_coe.mp (by simpa [σf] using htail)
+  -- Compactness gives a cluster point and an ultrafilter below `atTop` along which `σf`
+  -- converges weakly.
   have hmap_le : map σf atTop ≤ 𝓟 S :=
     tendsto_principal.mpr (Eventually.of_forall hσ_mem)
   obtain ⟨μf, hμfS, hcluster⟩ := hcompact hmap_le
   have hmapcluster : MapClusterPt μf atTop σf := hcluster
   obtain ⟨U, hUle, hUtend⟩ := mapClusterPt_iff_ultrafilter.mp hmapcluster
   refine ⟨(μf : Measure α), U, hUle, inferInstance, ?_, ?_⟩
+  -- Finally unwrap the compact-set membership into the mass bound and weak convergence of
+  -- integrals against bounded continuous test functions.
   · have hle : (μf.mass : ENNReal) ≤ (C : ENNReal) := ENNReal.coe_le_coe.mpr hμfS.1
     rw [← FiniteMeasure.ennreal_mass]
     simpa using hle
@@ -114,8 +126,11 @@ lemma finite_measure_subseq_limit
       ∀ g : BoundedContinuousFunction α ℝ,
         Tendsto (fun k => ∫ x, g x ∂(σ (φ k))) atTop
           (nhds (∫ x, g x ∂μ₀)) := by
+  -- Start from the ultrafilter cluster limit supplied by compactness.
   obtain ⟨μ₀, U, hUle, hμ₀_fin, hmass_μ₀, hweakU⟩ :=
     finite_measure_cluster_limit (α := α) σ C hmass hTight
+  -- Repackage the sequence and limit as finite measures so that weak convergence can be read
+  -- through bounded-continuous integrals.
   have hfin : ∀ n, IsFiniteMeasure (σ n) := fun n =>
     ⟨(hmass n).trans_lt ENNReal.coe_lt_top⟩
   let σf : ℕ → FiniteMeasure α := fun n => ⟨σ n, hfin n⟩
@@ -126,6 +141,7 @@ lemma finite_measure_subseq_limit
     simpa [σf, μf] using hweakU g
   have hclusterU : MapClusterPt μf (U : Filter ℕ) σf := hUtend.mapClusterPt
   have hcluster : MapClusterPt μf atTop σf := hclusterU.mono hUle
+  -- First countability turns the cluster point into an ordinary subsequential limit.
   obtain ⟨φ, hφ, hφ_tendsto⟩ := hcluster.tendsto_subseq
   refine ⟨μ₀, φ, hμ₀_fin, hφ, hmass_μ₀, fun g => ?_⟩
   have hweak :=


### PR DESCRIPTION
Bernstein representation infrastructure (Part 1/2) for the completely-monotone / Bernstein theorem roadmap: the `IsCompletelyMonotone` API, the Chafaï density/measure construction, the Bernstein kernel (+ its bundled bounded-continuous form and the limiting Laplace kernel), the FTC/iterated-derivative inputs, and the Prokhorov weak-limit extraction.

Resubmission of #475, which was auto-retired at the review round cap. Before reopening, the **entire public surface was exhaustively audited** for the recurring review axes — generality (codomain `E` / scalar field `𝕜` / arbitrary interval endpoints / minimal smoothness hypotheses on the *generic* calculus & measure helpers), naming (Mathlib conventions), and reuse (special cases as thin corollaries) — so the generic helpers are at natural Mathlib level while the completely-monotone/Bernstein/Chafaï-specific lemmas stay real-valued. Build is green; `#print axioms` on the public results shows only `propext`, `Classical.choice`, `Quot.sound`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)