### PR TITLE
feat: bundle the directing measure as a ProbabilityMeasure-valued ν

### DIFF
--- a/TauCeti/Probability/DeFinetti/DirectingMeasure.lean
+++ b/TauCeti/Probability/DeFinetti/DirectingMeasure.lean
@@ -2,6 +2,7 @@ module
 
 public import TauCeti.Probability.Process.Tail
 public import Mathlib.Probability.Kernel.CondDistrib
+public import Mathlib.MeasureTheory.Measure.ProbabilityMeasure
 
 /-!
 # The de Finetti directing measure
@@ -23,8 +24,10 @@ Finetti's theorem. This file records its basic theory: it is a probability measu
 (`isProbabilityMeasure_directingMeasure`), its set evaluations are `tailProcess X`-measurable
 (`measurable_tailProcess_directingMeasure_coe`, with the ambient corollary
 `measurable_directingMeasure_coe`), and it is the conditional law of `X 0` given the tail
-(`directingMeasure_ae_eq_condExp`). Packaging it as a directing measure for `ConditionallyIIDWith`
-(the product factorisation across a whole block) is left to a later step.
+(`directingMeasure_ae_eq_condExp`). It is also bundled as the `ProbabilityMeasure`-valued
+`directingProbabilityMeasure`, with measurability `measurable_directingProbabilityMeasure` — the
+form `ConditionallyIIDWith` consumes as its directing measure `ν`. The full block-product
+factorisation (conditional independence across a whole block) is left to a later step.
 
 Adapted from `cameronfreer/exchangeability` (`DeFinetti/ViaMartingale/DirectingMeasure.lean`, pin
 `e0532e59ceff23edab44dda9ab0655debbc9cc22`); that version conditions over `Ω` (needing
@@ -97,6 +100,27 @@ theorem directingMeasure_ae_eq_condExp {μ : Measure Ω} [IsFiniteMeasure μ] {X
   have h := condDistrib_ae_eq_condExp (μ := μ) (Y := X 0) (X := (id : Ω → Ω)) hid hX0 hB
   rw [MeasurableSpace.comap_id, hcomp] at h
   exact h
+
+/-- The directing measure bundled as a `ProbabilityMeasure`-valued map — the form that
+`ConditionallyIIDWith` consumes as its directing measure `ν`. -/
+@[expose]
+def directingProbabilityMeasure (μ : Measure Ω) [IsFiniteMeasure μ] (X : ℕ → Ω → α) (ω : Ω) :
+    ProbabilityMeasure α :=
+  ⟨directingMeasure μ X ω, inferInstance⟩
+
+@[simp]
+theorem directingProbabilityMeasure_toMeasure {μ : Measure Ω} [IsFiniteMeasure μ] {X : ℕ → Ω → α}
+    (ω : Ω) : (directingProbabilityMeasure μ X ω : Measure α) = directingMeasure μ X ω :=
+  rfl
+
+/-- The bundled directing measure is measurable into `ProbabilityMeasure α` — the measurability of
+the directing measure that `ConditionallyIIDWith` requires. -/
+theorem measurable_directingProbabilityMeasure {μ : Measure Ω} [IsFiniteMeasure μ] {X : ℕ → Ω → α}
+    (hTail : tailProcess X ≤ (inferInstance : MeasurableSpace Ω)) :
+    Measurable (directingProbabilityMeasure μ X) := by
+  refine Measurable.subtype_mk ?_
+  exact Measure.measurable_of_measurable_coe _ fun B hB =>
+    measurable_directingMeasure_coe hTail hB
 
 end Probability
 

--- a/TauCeti/Probability/DeFinetti/DirectingMeasure.lean
+++ b/TauCeti/Probability/DeFinetti/DirectingMeasure.lean
@@ -103,11 +103,15 @@ theorem directingMeasure_ae_eq_condExp {μ : Measure Ω} [IsFiniteMeasure μ] {X
 
 /-- The directing measure bundled as a `ProbabilityMeasure`-valued map — the form that
 `ConditionallyIIDWith` consumes as its directing measure `ν`. -/
+-- This wrapper is exposed because its public characteristic lemma
+-- `directingProbabilityMeasure_toMeasure` is an exported `rfl` coercion lemma, which requires the
+-- definition body to be visible (unlike `directingMeasure`, characterised by property lemmas).
 @[expose]
 def directingProbabilityMeasure (μ : Measure Ω) [IsFiniteMeasure μ] (X : ℕ → Ω → α) (ω : Ω) :
     ProbabilityMeasure α :=
   ⟨directingMeasure μ X ω, inferInstance⟩
 
+/-- The underlying measure of the bundled directing measure is `directingMeasure μ X ω`. -/
 @[simp]
 theorem directingProbabilityMeasure_toMeasure {μ : Measure Ω} [IsFiniteMeasure μ] {X : ℕ → Ω → α}
     (ω : Ω) : (directingProbabilityMeasure μ X ω : Measure α) = directingMeasure μ X ω :=
@@ -115,6 +119,7 @@ theorem directingProbabilityMeasure_toMeasure {μ : Measure Ω} [IsFiniteMeasure
 
 /-- The bundled directing measure is measurable into `ProbabilityMeasure α` — the measurability of
 the directing measure that `ConditionallyIIDWith` requires. -/
+@[fun_prop]
 theorem measurable_directingProbabilityMeasure {μ : Measure Ω} [IsFiniteMeasure μ] {X : ℕ → Ω → α}
     (hTail : tailProcess X ≤ (inferInstance : MeasurableSpace Ω)) :
     Measurable (directingProbabilityMeasure μ X) := by

--- a/TauCeti/Probability/DeFinetti/DirectingMeasure.lean
+++ b/TauCeti/Probability/DeFinetti/DirectingMeasure.lean
@@ -25,9 +25,11 @@ Finetti's theorem. This file records its basic theory: it is a probability measu
 (`measurable_tailProcess_directingMeasure_coe`, with the ambient corollary
 `measurable_directingMeasure_coe`), and it is the conditional law of `X 0` given the tail
 (`directingMeasure_ae_eq_condExp`). It is also bundled as the `ProbabilityMeasure`-valued
-`directingProbabilityMeasure`, with measurability `measurable_directingProbabilityMeasure` — the
-form `ConditionallyIIDWith` consumes as its directing measure `ν`. The full block-product
-factorisation (conditional independence across a whole block) is left to a later step.
+`directingProbabilityMeasure`, measurable at the `tailProcess X` level
+(`measurable_tailProcess_directingProbabilityMeasure`, with the ambient corollary
+`measurable_directingProbabilityMeasure`) — the form `ConditionallyIIDWith` consumes as its
+directing measure `ν`. The full block-product factorisation
+(conditional independence across a whole block) is left to a later step.
 
 Adapted from `cameronfreer/exchangeability` (`DeFinetti/ViaMartingale/DirectingMeasure.lean`, pin
 `e0532e59ceff23edab44dda9ab0655debbc9cc22`); that version conditions over `Ω` (needing
@@ -103,10 +105,6 @@ theorem directingMeasure_ae_eq_condExp {μ : Measure Ω} [IsFiniteMeasure μ] {X
 
 /-- The directing measure bundled as a `ProbabilityMeasure`-valued map — the form that
 `ConditionallyIIDWith` consumes as its directing measure `ν`. -/
--- This wrapper is exposed because its public characteristic lemma
--- `directingProbabilityMeasure_toMeasure` is an exported `rfl` coercion lemma, which requires the
--- definition body to be visible (unlike `directingMeasure`, characterised by property lemmas).
-@[expose]
 def directingProbabilityMeasure (μ : Measure Ω) [IsFiniteMeasure μ] (X : ℕ → Ω → α) (ω : Ω) :
     ProbabilityMeasure α :=
   ⟨directingMeasure μ X ω, inferInstance⟩
@@ -114,18 +112,23 @@ def directingProbabilityMeasure (μ : Measure Ω) [IsFiniteMeasure μ] (X : ℕ 
 /-- The underlying measure of the bundled directing measure is `directingMeasure μ X ω`. -/
 @[simp]
 theorem directingProbabilityMeasure_toMeasure {μ : Measure Ω} [IsFiniteMeasure μ] {X : ℕ → Ω → α}
-    (ω : Ω) : (directingProbabilityMeasure μ X ω : Measure α) = directingMeasure μ X ω :=
-  rfl
+    (ω : Ω) : (directingProbabilityMeasure μ X ω : Measure α) = directingMeasure μ X ω := by
+  simp only [directingProbabilityMeasure, ProbabilityMeasure.coe_mk]
 
-/-- The bundled directing measure is measurable into `ProbabilityMeasure α` — the measurability of
-the directing measure that `ConditionallyIIDWith` requires. -/
+/-- The bundled directing measure is **`tailProcess X`-measurable** into `ProbabilityMeasure α`. -/
+theorem measurable_tailProcess_directingProbabilityMeasure {μ : Measure Ω} [IsFiniteMeasure μ]
+    {X : ℕ → Ω → α} : Measurable[tailProcess X] (directingProbabilityMeasure μ X) := by
+  refine Measurable.subtype_mk ?_
+  exact Measure.measurable_of_measurable_coe _ fun B hB =>
+    measurable_tailProcess_directingMeasure_coe hB
+
+/-- The bundled directing measure is measurable into `ProbabilityMeasure α` — the ambient corollary
+of the `tailProcess X`-measurable form, the measurability that `ConditionallyIIDWith` requires. -/
 @[fun_prop]
 theorem measurable_directingProbabilityMeasure {μ : Measure Ω} [IsFiniteMeasure μ] {X : ℕ → Ω → α}
     (hTail : tailProcess X ≤ (inferInstance : MeasurableSpace Ω)) :
-    Measurable (directingProbabilityMeasure μ X) := by
-  refine Measurable.subtype_mk ?_
-  exact Measure.measurable_of_measurable_coe _ fun B hB =>
-    measurable_directingMeasure_coe hTail hB
+    Measurable (directingProbabilityMeasure μ X) :=
+  measurable_tailProcess_directingProbabilityMeasure.mono hTail le_rfl
 
 end Probability
 


### PR DESCRIPTION
<!--tauceti-target:v1 {"focus":"Exchangeability","id":"directing-probability-measure"}-->

## Summary

Extends `TauCeti/Probability/DeFinetti/DirectingMeasure.lean` (merged in #558) with the directing
measure bundled as a `ProbabilityMeasure`-valued map — the exact form `ConditionallyIIDWith` consumes:

- `directingProbabilityMeasure μ X ω : ProbabilityMeasure α` `= ⟨directingMeasure μ X ω, …⟩` (the
  `IsProbabilityMeasure` instance is automatic, so no measurability hypothesis is needed).
- `directingProbabilityMeasure_toMeasure` (`@[simp]`) — its `toMeasure` is `directingMeasure μ X ω`.
- `measurable_directingProbabilityMeasure (hTail : tailProcess X ≤ ‹MeasurableSpace Ω›)` — `Measurable`
  into the `ProbabilityMeasure α` subtype, via `Measure.measurable_of_measurable_coe` +
  `measurable_directingMeasure_coe` + `Measurable.subtype_mk`.

## Roadmap

Advances `TauCetiRoadmap/Exchangeability` toward the de Finetti routes. This is exactly the
`ν : Ω → ProbabilityMeasure α` together with the `Measurable ν` that the merged
`conditionallyIIDWith_of_forall_rectangles` requires of a directing measure — a remaining piece of
the directing-measure construction before the block-product factorisation.

## How it's proved (reuse)

Bundles the merged `directingMeasure` and its `isProbabilityMeasure_directingMeasure` instance into the
`ProbabilityMeasure` subtype; measurability is `Measure.measurable_of_measurable_coe` over the merged
`measurable_tailProcess_directingMeasure_coe`, lifted with `Measurable.subtype_mk` (ambient version by
`.mono`). No new measure theory.

## Review notes
- **api-design:** `directingProbabilityMeasure` is **not** `@[expose]`; its `@[simp]` `toMeasure`
  characterization is proved via `simp only [directingProbabilityMeasure, ProbabilityMeasure.coe_mk]`
  (the equation lemma + the coercion lemma), so downstream reasons through `toMeasure` + the
  measurability lemmas without unfolding the body.
- **generality:** the natural `measurable_tailProcess_directingProbabilityMeasure` is stated at the
  `Measurable[tailProcess X]` level (matching the unbundled `measurable_tailProcess_directingMeasure_coe`);
  `measurable_directingProbabilityMeasure` is its ambient corollary via `.mono hTail le_rfl`.

## Test plan
```bash
lake build
lake exe axioms
lake exe module-system
```
All pass; sorry-free; axioms ⊆ {`propext`, `Classical.choice`, `Quot.sound`}; lines ≤100.

## Attribution
The bundled wrapper extends the merged `DirectingMeasure.lean`, whose module docstring credits
`cameronfreer/exchangeability` (`DeFinetti/ViaMartingale/DirectingMeasure.lean`, pin
`e0532e59ceff23edab44dda9ab0655debbc9cc22`). Drafted with Claude (Opus 4.8), human-directed.
