### PR TITLE
feat: add condExp_indicator_eq_of_pair_law_eq (factorisation condExp bridge)

### DIFF
--- a/TauCeti/MeasureTheory/Function/ConditionalExpectation.lean
+++ b/TauCeti/MeasureTheory/Function/ConditionalExpectation.lean
@@ -59,11 +59,8 @@ theorem condExp_indicator_eq_of_pair_law_eq {Ω α β : Type*} [mΩ : Measurable
       ∫ ω in Z ⁻¹' E, (W ⁻¹' B).indicator (fun _ => (1 : ℝ)) ω ∂μ
         = (μ (W ⁻¹' B ∩ Z ⁻¹' E)).toReal := by
     intro W hW
-    simp_rw [integral_indicator (hW hB)]
-    simp only [integral_const]
-    simp_rw [Measure.restrict_restrict (hW hB)]
-    simp only [smul_eq_mul, mul_one]
-    simp [Measure.real, Measure.restrict_apply MeasurableSet.univ, Set.univ_inter]
+    rw [setIntegral_indicator (hW hB), setIntegral_const, Set.inter_comm]
+    simp [Measure.real]
   have h_lhs : ∫ ω in Z ⁻¹' E, f ω ∂μ = (μ (Y ⁻¹' B ∩ Z ⁻¹' E)).toReal := by
     have hf_eq : f = (Y ⁻¹' B).indicator (fun _ => (1 : ℝ)) := by
       ext ω; simp only [hf_def, Function.comp_apply, Set.indicator, Set.mem_preimage]

--- a/TauCeti/MeasureTheory/Function/ConditionalExpectation.lean
+++ b/TauCeti/MeasureTheory/Function/ConditionalExpectation.lean
@@ -1,8 +1,6 @@
 module
 
 public import Mathlib.MeasureTheory.Function.ConditionalExpectation.Basic
-public import Mathlib.MeasureTheory.Integral.Bochner.Set
-public import Mathlib.MeasureTheory.Integral.IntegrableOn
 
 /-!
 # Conditional expectation of an indicator under pair-law equality
@@ -11,10 +9,9 @@ public import Mathlib.MeasureTheory.Integral.IntegrableOn
 for every measurable `B` the conditional expectations of `𝟙_B ∘ Y` and `𝟙_B ∘ Y'` given `σ(Z)` agree
 almost everywhere.
 
-This is the bridge that turns a pair-law (distributional) equality into a conditional-expectation
-identity. It is consumed by the de Finetti block-product factorisation, where contractability
-supplies the pair-law equality that extends the per-coordinate conditional law from `X 0` to every
-`X n`.
+This is a generic conditional-expectation fact (no exchangeability/tail/directing-measure
+hypotheses); it is the bridge that turns a pair-law (distributional) equality into a
+conditional-expectation identity, consumed by the de Finetti block-product factorisation.
 
 Adapted from `cameronfreer/exchangeability` (`Probability/CondExp.lean`, pin
 `e0532e59ceff23edab44dda9ab0655debbc9cc22`).
@@ -28,7 +25,7 @@ open MeasureTheory
 
 namespace TauCeti
 
-namespace Probability
+namespace MeasureTheory
 
 /-- If the pairs `(Y, Z)` and `(Y', Z)` have the same law, then for measurable `B` the conditional
 expectations of `𝟙_B ∘ Y` and `𝟙_B ∘ Y'` given `σ(Z)` agree almost everywhere. -/
@@ -57,26 +54,28 @@ theorem condExp_indicator_eq_of_pair_law_eq {Ω α β : Type*} [mΩ : Measurable
     simp only [Measure.map_apply (hY.prodMk hZ) (hB.prod hE),
       Measure.map_apply (hY'.prodMk hZ) (hB.prod hE), Set.mk_preimage_prod] at h
     exact h
+  -- The set-integral of a preimage indicator over `Z ⁻¹' E`, shared by both coordinates.
+  have hint : ∀ W : Ω → α, Measurable[mΩ] W →
+      ∫ ω in Z ⁻¹' E, (W ⁻¹' B).indicator (fun _ => (1 : ℝ)) ω ∂μ
+        = (μ (W ⁻¹' B ∩ Z ⁻¹' E)).toReal := by
+    intro W hW
+    simp_rw [integral_indicator (hW hB)]
+    simp only [integral_const]
+    simp_rw [Measure.restrict_restrict (hW hB)]
+    simp only [smul_eq_mul, mul_one]
+    simp [Measure.real, Measure.restrict_apply MeasurableSet.univ, Set.univ_inter]
   have h_lhs : ∫ ω in Z ⁻¹' E, f ω ∂μ = (μ (Y ⁻¹' B ∩ Z ⁻¹' E)).toReal := by
     have hf_eq : f = (Y ⁻¹' B).indicator (fun _ => (1 : ℝ)) := by
       ext ω; simp only [hf_def, Function.comp_apply, Set.indicator, Set.mem_preimage]
-    simp_rw [hf_eq, integral_indicator (hY hB)]
-    simp only [integral_const]
-    simp_rw [Measure.restrict_restrict (hY hB)]
-    simp only [smul_eq_mul, mul_one]
-    simp [Measure.real, Measure.restrict_apply MeasurableSet.univ, Set.univ_inter]
+    rw [hf_eq]; exact hint Y hY
   have h_rhs_ce : ∫ ω in Z ⁻¹' E, μ[f' | mZ] ω ∂μ = ∫ ω in Z ⁻¹' E, f' ω ∂μ :=
     setIntegral_condExp hmZ_le hf'_int ⟨E, hE, rfl⟩
   have h_rhs : ∫ ω in Z ⁻¹' E, f' ω ∂μ = (μ (Y' ⁻¹' B ∩ Z ⁻¹' E)).toReal := by
     have hf'_eq : f' = (Y' ⁻¹' B).indicator (fun _ => (1 : ℝ)) := by
       ext ω; simp only [hf'_def, Function.comp_apply, Set.indicator, Set.mem_preimage]
-    simp_rw [hf'_eq, integral_indicator (hY' hB)]
-    simp only [integral_const]
-    simp_rw [Measure.restrict_restrict (hY' hB)]
-    simp only [smul_eq_mul, mul_one]
-    simp [Measure.real, Measure.restrict_apply MeasurableSet.univ, Set.univ_inter]
+    rw [hf'_eq]; exact hint Y' hY'
   simp_rw [h_lhs, h_rhs_ce, h_rhs, h_meas_eq]
 
-end Probability
+end MeasureTheory
 
 end TauCeti

--- a/TauCeti/Probability/DeFinetti/CondExpPairLaw.lean
+++ b/TauCeti/Probability/DeFinetti/CondExpPairLaw.lean
@@ -1,0 +1,82 @@
+module
+
+public import Mathlib.MeasureTheory.Function.ConditionalExpectation.Basic
+public import Mathlib.MeasureTheory.Integral.Bochner.Set
+public import Mathlib.MeasureTheory.Integral.IntegrableOn
+
+/-!
+# Conditional expectation of an indicator under pair-law equality
+
+`condExp_indicator_eq_of_pair_law_eq`: if the pairs `(Y, Z)` and `(Y', Z)` have the same law, then
+for every measurable `B` the conditional expectations of `𝟙_B ∘ Y` and `𝟙_B ∘ Y'` given `σ(Z)` agree
+almost everywhere.
+
+This is the bridge that turns a pair-law (distributional) equality into a conditional-expectation
+identity. It is consumed by the de Finetti block-product factorisation, where contractability
+supplies the pair-law equality that extends the per-coordinate conditional law from `X 0` to every
+`X n`.
+
+Adapted from `cameronfreer/exchangeability` (`Probability/CondExp.lean`, pin
+`e0532e59ceff23edab44dda9ab0655debbc9cc22`).
+-/
+
+public section
+
+noncomputable section
+
+open MeasureTheory
+
+namespace TauCeti
+
+namespace Probability
+
+/-- If the pairs `(Y, Z)` and `(Y', Z)` have the same law, then for measurable `B` the conditional
+expectations of `𝟙_B ∘ Y` and `𝟙_B ∘ Y'` given `σ(Z)` agree almost everywhere. -/
+theorem condExp_indicator_eq_of_pair_law_eq {Ω α β : Type*} [mΩ : MeasurableSpace Ω]
+    [MeasurableSpace α] [mβ : MeasurableSpace β] {μ : Measure Ω} [IsFiniteMeasure μ]
+    (Y Y' : Ω → α) (Z : Ω → β) (hY : Measurable Y) (hY' : Measurable Y') (hZ : Measurable Z)
+    (hpair : μ.map (fun ω => (Y ω, Z ω)) = μ.map (fun ω => (Y' ω, Z ω)))
+    {B : Set α} (hB : MeasurableSet B) :
+    μ[Set.indicator B (fun _ => (1 : ℝ)) ∘ Y | MeasurableSpace.comap Z mβ]
+      =ᵐ[μ] μ[Set.indicator B (fun _ => (1 : ℝ)) ∘ Y' | MeasurableSpace.comap Z mβ] := by
+  classical
+  set f := Set.indicator B (fun _ => (1 : ℝ)) ∘ Y with hf_def
+  set f' := Set.indicator B (fun _ => (1 : ℝ)) ∘ Y' with hf'_def
+  set mZ := MeasurableSpace.comap Z mβ with hmZ_def
+  have hmZ_le : mZ ≤ mΩ := by
+    rintro s ⟨E, hE, rfl⟩
+    exact hZ hE
+  have hf_int : Integrable f μ := Integrable.indicator (integrable_const (1 : ℝ)) (hY hB)
+  have hf'_int : Integrable f' μ := Integrable.indicator (integrable_const (1 : ℝ)) (hY' hB)
+  refine (ae_eq_condExp_of_forall_setIntegral_eq hmZ_le hf_int
+    (fun s _ _ => integrable_condExp.integrableOn) (fun A hA _ => ?_)
+    stronglyMeasurable_condExp.aestronglyMeasurable).symm
+  obtain ⟨E, hE, rfl⟩ := hA
+  have h_meas_eq : μ (Y ⁻¹' B ∩ Z ⁻¹' E) = μ (Y' ⁻¹' B ∩ Z ⁻¹' E) := by
+    have h := congr_arg (fun ν => ν (B ×ˢ E)) hpair
+    simp only [Measure.map_apply (hY.prodMk hZ) (hB.prod hE),
+      Measure.map_apply (hY'.prodMk hZ) (hB.prod hE), Set.mk_preimage_prod] at h
+    exact h
+  have h_lhs : ∫ ω in Z ⁻¹' E, f ω ∂μ = (μ (Y ⁻¹' B ∩ Z ⁻¹' E)).toReal := by
+    have hf_eq : f = (Y ⁻¹' B).indicator (fun _ => (1 : ℝ)) := by
+      ext ω; simp only [hf_def, Function.comp_apply, Set.indicator, Set.mem_preimage]
+    simp_rw [hf_eq, integral_indicator (hY hB)]
+    simp only [integral_const]
+    simp_rw [Measure.restrict_restrict (hY hB)]
+    simp only [smul_eq_mul, mul_one]
+    simp [Measure.real, Measure.restrict_apply MeasurableSet.univ, Set.univ_inter]
+  have h_rhs_ce : ∫ ω in Z ⁻¹' E, μ[f' | mZ] ω ∂μ = ∫ ω in Z ⁻¹' E, f' ω ∂μ :=
+    setIntegral_condExp hmZ_le hf'_int ⟨E, hE, rfl⟩
+  have h_rhs : ∫ ω in Z ⁻¹' E, f' ω ∂μ = (μ (Y' ⁻¹' B ∩ Z ⁻¹' E)).toReal := by
+    have hf'_eq : f' = (Y' ⁻¹' B).indicator (fun _ => (1 : ℝ)) := by
+      ext ω; simp only [hf'_def, Function.comp_apply, Set.indicator, Set.mem_preimage]
+    simp_rw [hf'_eq, integral_indicator (hY' hB)]
+    simp only [integral_const]
+    simp_rw [Measure.restrict_restrict (hY' hB)]
+    simp only [smul_eq_mul, mul_one]
+    simp [Measure.real, Measure.restrict_apply MeasurableSet.univ, Set.univ_inter]
+  simp_rw [h_lhs, h_rhs_ce, h_rhs, h_meas_eq]
+
+end Probability
+
+end TauCeti


### PR DESCRIPTION
<!--tauceti-target:v1 {"focus":"Exchangeability","id":"condexp-pair-law"}-->

## Summary

Adds `TauCeti/MeasureTheory/Function/ConditionalExpectation.lean` with one generic
conditional-expectation lemma:

`condExp_indicator_eq_of_pair_law_eq` — if the pairs `(Y, Z)` and `(Y', Z)` have the same law
(`μ.map (fun ω => (Y ω, Z ω)) = μ.map (fun ω => (Y' ω, Z ω))`), then for every measurable `B`,
```
μ[𝟙_B ∘ Y | σ(Z)]  =ᵐ[μ]  μ[𝟙_B ∘ Y' | σ(Z)].
```

## Roadmap

A prerequisite for `TauCetiRoadmap/Exchangeability/README.md` **Layer 3 (the directing-measure
bridge)** / **Layer 6 (finite-product factorization)**: it turns a **distributional** (pair-law)
equality into a **conditional-expectation** identity. In the block-product factorisation,
contractability supplies the pair-law equality of `(X n, tail)` with `(X 0, tail)`, and this lemma
promotes it to the equality of conditional laws that extends the per-coordinate directing measure
from `X 0` to every `X n`.

## How it's proved (reuse)

Uniqueness of conditional expectation (`ae_eq_condExp_of_forall_setIntegral_eq` +
`setIntegral_condExp`): both sides integrate to the same thing on every `σ(Z)`-set `Z ⁻¹' E`, because
the pair-law equality evaluated on the rectangle `B ×ˢ E` (`Measure.map_apply` + `Set.mk_preimage_prod`)
gives `μ(Y⁻¹B ∩ Z⁻¹E) = μ(Y'⁻¹B ∩ Z⁻¹E)`. A single factored `hint` computes the shared set-integral of
a preimage indicator over `Z ⁻¹' E` (used for both `Y` and `Y'`). No hand-rolled measure theory.

## Review notes
- **placement:** it is a *generic* conditional-expectation fact (arbitrary `Ω α β`, finite measure,
  measurable `Y Y' Z` — no exchangeability/tail/directing-measure hypotheses), so it lives in the
  generic `MeasureTheory/Function/` home, not under `DeFinetti/`.
- **api-design:** a single `=ᵐ` bridge lemma (no `@[simp]`/`def`), and only the statement-level import
  `…ConditionalExpectation.Basic` is public — the set-integral/`IntegrableOn` imports were redundant
  with it and are dropped.
- **proof-quality:** the previously-duplicated set-integral normalization is factored into one local
  `hint` lemma, applied for `Y` and `Y'`.
- **generality:** `Y, Y', Z` are taken `Measurable` (not `AEMeasurable`) — the hypothesis is an equality
  of pushforwards of the measurable pair maps, and the proof uses `Measure.map_apply`; consumers have
  measurable coordinates, so this is the natural strength.

## Test plan
```bash
lake build
lake exe axioms
lake exe module-system
```
All pass; sorry-free; axioms ⊆ {`propext`, `Classical.choice`, `Quot.sound`}; lines ≤100.

## Attribution
Adapted from `cameronfreer/exchangeability` (`Probability/CondExp.lean`, pin
`e0532e59ceff23edab44dda9ab0655debbc9cc22`), over Mathlib's conditional-expectation uniqueness API.
Drafted with Claude (Opus 4.8), human-directed.
