### PR TITLE
feat: add condIndep indicator adapters for the de Finetti factorisation

### DIFF
--- a/TauCeti/Probability/DeFinetti/CondIndepIndicator.lean
+++ b/TauCeti/Probability/DeFinetti/CondIndepIndicator.lean
@@ -7,17 +7,15 @@ public import Mathlib.MeasureTheory.Integral.IntegrableOn
 /-!
 # Conditional independence from an indicator conditional-expectation criterion
 
-Two adapters between Mathlib's `ProbabilityTheory.CondIndep` and the
-indicator/conditional-expectation form used by the de Finetti block-product factorisation:
+`condIndep_of_indicator_condexp_eq` — the "drop-information" adapter for Mathlib's
+`ProbabilityTheory.CondIndep`, used by the de Finetti block-product factorisation: it builds
+`CondIndep mG mF mH` from the criterion `μ[𝟙_H | mF ⊔ mG] =ᵐ μ[𝟙_H | mG]` (for all `mH`-measurable
+`H`).
 
-* `condIndep_of_indicator_condexp_eq` — builds `CondIndep mG mF mH` from the "drop-information"
-  criterion `μ[𝟙_H | mF ⊔ mG] =ᵐ μ[𝟙_H | mG]` for all `mH`-measurable `H`;
-* `condexp_indicator_inter_bridge` — the product formula
-  `μ[𝟙_{A ∩ B} | m] =ᵐ μ[𝟙_A | m] * μ[𝟙_B | m]` extracted from `CondIndep`.
-
-Both are thin layers over Mathlib's `condIndep_iff`; the work in the first is pulling the indicator
+It is a layer over Mathlib's `condIndep_iff` (`.2` direction); the work is pulling the indicator
 factors through the conditional expectation (`condExp_mul_of_aestronglyMeasurable_*`) and the tower
-property (`condExp_condExp_of_le`).
+property (`condExp_condExp_of_le`). (The forward product-formula direction is Mathlib's
+`condIndep_iff … |>.mp` applied directly, so no wrapper is provided here.)
 
 Adapted from `cameronfreer/exchangeability` (`Probability/CondExp.lean`, pin
 `e0532e59ceff23edab44dda9ab0655debbc9cc22`).
@@ -85,17 +83,6 @@ theorem condIndep_of_indicator_condexp_eq {Ω : Type*} {mΩ : MeasurableSpace Ω
       simp [hf1, hf2, Set.indicator, h1, h2, Set.mem_inter_iff] at *
   rw [h_f1f2] at h_prod
   simpa only [hf1, hf2] using h_prod
-
-/-- **Conditional-independence product formula for indicators.** From `CondIndep m mF mH`, the
-conditional expectation of `𝟙_{A ∩ B}` factors as the product of the conditional expectations of
-`𝟙_A` and `𝟙_B`, for `mF`-measurable `A` and `mH`-measurable `B`. -/
-theorem condexp_indicator_inter_bridge {Ω : Type*} {m₀ : MeasurableSpace Ω} [StandardBorelSpace Ω]
-    {μ : Measure Ω} [IsFiniteMeasure μ] {m mF mH : MeasurableSpace Ω} (hm : m ≤ m₀)
-    (hmF : mF ≤ m₀) (hmH : mH ≤ m₀) (hCI : CondIndep m mF mH hm μ) {A B : Set Ω}
-    (hA : MeasurableSet[mF] A) (hB : MeasurableSet[mH] B) :
-    μ[(A ∩ B).indicator (fun _ => (1 : ℝ)) | m]
-      =ᵐ[μ] μ[A.indicator (fun _ => (1 : ℝ)) | m] * μ[B.indicator (fun _ => (1 : ℝ)) | m] :=
-  (condIndep_iff m mF mH hm hmF hmH μ).mp hCI A B hA hB
 
 end Probability
 

--- a/TauCeti/Probability/DeFinetti/CondIndepIndicator.lean
+++ b/TauCeti/Probability/DeFinetti/CondIndepIndicator.lean
@@ -1,0 +1,102 @@
+module
+
+public import Mathlib.Probability.Independence.Conditional
+public import Mathlib.MeasureTheory.Function.ConditionalExpectation.PullOut
+public import Mathlib.MeasureTheory.Integral.IntegrableOn
+
+/-!
+# Conditional independence from an indicator conditional-expectation criterion
+
+Two adapters between Mathlib's `ProbabilityTheory.CondIndep` and the
+indicator/conditional-expectation form used by the de Finetti block-product factorisation:
+
+* `condIndep_of_indicator_condexp_eq` — builds `CondIndep mG mF mH` from the "drop-information"
+  criterion `μ[𝟙_H | mF ⊔ mG] =ᵐ μ[𝟙_H | mG]` for all `mH`-measurable `H`;
+* `condexp_indicator_inter_bridge` — the product formula
+  `μ[𝟙_{A ∩ B} | m] =ᵐ μ[𝟙_A | m] * μ[𝟙_B | m]` extracted from `CondIndep`.
+
+Both are thin layers over Mathlib's `condIndep_iff`; the work in the first is pulling the indicator
+factors through the conditional expectation (`condExp_mul_of_aestronglyMeasurable_*`) and the tower
+property (`condExp_condExp_of_le`).
+
+Adapted from `cameronfreer/exchangeability` (`Probability/CondExp.lean`, pin
+`e0532e59ceff23edab44dda9ab0655debbc9cc22`).
+-/
+
+public section
+
+noncomputable section
+
+open MeasureTheory ProbabilityTheory
+
+namespace TauCeti
+
+namespace Probability
+
+/-- **Conditional independence from the drop-information criterion.** If conditioning `𝟙_H` on
+`mF ⊔ mG` is a.e. the same as conditioning on `mG` (for every `mH`-measurable `H`), then `mF` and
+`mH` are conditionally independent given `mG`. -/
+theorem condIndep_of_indicator_condexp_eq {Ω : Type*} {mΩ : MeasurableSpace Ω}
+    [StandardBorelSpace Ω] {μ : Measure Ω} [IsFiniteMeasure μ] {mF mG mH : MeasurableSpace Ω}
+    (hmF : mF ≤ mΩ) (hmG : mG ≤ mΩ) (hmH : mH ≤ mΩ)
+    (h : ∀ H, MeasurableSet[mH] H →
+      μ[H.indicator (fun _ => (1 : ℝ)) | mF ⊔ mG]
+        =ᵐ[μ] μ[H.indicator (fun _ => (1 : ℝ)) | mG]) :
+    CondIndep mG mF mH hmG μ := by
+  classical
+  refine (condIndep_iff mG mF mH hmG hmF hmH μ).2 ?_
+  intro tF tH htF htH
+  set f1 : Ω → ℝ := tF.indicator (fun _ : Ω => (1 : ℝ)) with hf1
+  set f2 : Ω → ℝ := tH.indicator (fun _ : Ω => (1 : ℝ)) with hf2
+  have hf1_int : Integrable f1 μ := Integrable.indicator (integrable_const (1 : ℝ)) (hmF _ htF)
+  have hf2_int : Integrable f2 μ := Integrable.indicator (integrable_const (1 : ℝ)) (hmH _ htH)
+  have hf1_aesm : AEStronglyMeasurable[mF ⊔ mG] f1 μ :=
+    ((stronglyMeasurable_const.indicator htF).aestronglyMeasurable).mono
+      (le_sup_left : mF ≤ mF ⊔ mG)
+  have hProj : μ[f2 | mF ⊔ mG] =ᵐ[μ] μ[f2 | mG] := h tH htH
+  have h_tower : μ[(fun ω => f1 ω * f2 ω) | mG]
+      =ᵐ[μ] μ[ μ[(fun ω => f1 ω * f2 ω) | mF ⊔ mG] | mG] := by
+    simpa using (condExp_condExp_of_le (μ := μ) (hm₁₂ := le_sup_right) (hm₂ := sup_le hmF hmG)
+      (f := fun ω => f1 ω * f2 ω)).symm
+  have hf1f2_int : Integrable (fun ω => f1 ω * f2 ω) μ := by
+    have heq : (fun ω => f1 ω * f2 ω) = (tF ∩ tH).indicator (fun _ : Ω => (1 : ℝ)) := by
+      funext ω; by_cases h1 : ω ∈ tF <;> by_cases h2 : ω ∈ tH <;>
+        simp [hf1, hf2, Set.indicator, h1, h2, Set.mem_inter_iff] at *
+    rw [heq]
+    exact Integrable.indicator (integrable_const (1 : ℝ))
+      (MeasurableSet.inter (hmF _ htF) (hmH _ htH))
+  have h_pull_middle : μ[(fun ω => f1 ω * f2 ω) | mF ⊔ mG] =ᵐ[μ] f1 * μ[f2 | mF ⊔ mG] :=
+    condExp_mul_of_aestronglyMeasurable_left (μ := μ) (m := mF ⊔ mG) hf1_aesm hf1f2_int hf2_int
+  have h_middle_to_G : μ[(fun ω => f1 ω * f2 ω) | mF ⊔ mG] =ᵐ[μ] f1 * μ[f2 | mG] :=
+    h_pull_middle.trans <| Filter.EventuallyEq.mul Filter.EventuallyEq.rfl hProj
+  have hf1_condexp_int : Integrable (f1 * μ[f2 | mG]) μ := by
+    have heq : f1 * μ[f2 | mG] = tF.indicator (fun ω => μ[f2 | mG] ω) := by
+      funext ω; by_cases hω : ω ∈ tF <;> simp [hf1, Set.indicator, hω]
+    rw [heq]
+    exact Integrable.indicator (integrable_condExp (μ := μ) (m := mG) (f := f2)) (hmF _ htF)
+  have h_pull_outer : μ[f1 * μ[f2 | mG] | mG] =ᵐ[μ] μ[f1 | mG] * μ[f2 | mG] :=
+    condExp_mul_of_aestronglyMeasurable_right (μ := μ) (m := mG)
+      (stronglyMeasurable_condExp (μ := μ) (m := mG) (f := f2)).aestronglyMeasurable
+      hf1_condexp_int hf1_int
+  have h_prod : μ[(fun ω => f1 ω * f2 ω) | mG] =ᵐ[μ] μ[f1 | mG] * μ[f2 | mG] :=
+    h_tower.trans ((condExp_congr_ae h_middle_to_G).trans h_pull_outer)
+  have h_f1f2 : (fun ω => f1 ω * f2 ω) = (tF ∩ tH).indicator (fun _ => (1 : ℝ)) := by
+    funext ω; by_cases h1 : ω ∈ tF <;> by_cases h2 : ω ∈ tH <;>
+      simp [hf1, hf2, Set.indicator, h1, h2, Set.mem_inter_iff] at *
+  rw [h_f1f2] at h_prod
+  simpa only [hf1, hf2] using h_prod
+
+/-- **Conditional-independence product formula for indicators.** From `CondIndep m mF mH`, the
+conditional expectation of `𝟙_{A ∩ B}` factors as the product of the conditional expectations of
+`𝟙_A` and `𝟙_B`, for `mF`-measurable `A` and `mH`-measurable `B`. -/
+theorem condexp_indicator_inter_bridge {Ω : Type*} {m₀ : MeasurableSpace Ω} [StandardBorelSpace Ω]
+    {μ : Measure Ω} [IsFiniteMeasure μ] {m mF mH : MeasurableSpace Ω} (hm : m ≤ m₀)
+    (hmF : mF ≤ m₀) (hmH : mH ≤ m₀) (hCI : CondIndep m mF mH hm μ) {A B : Set Ω}
+    (hA : MeasurableSet[mF] A) (hB : MeasurableSet[mH] B) :
+    μ[(A ∩ B).indicator (fun _ => (1 : ℝ)) | m]
+      =ᵐ[μ] μ[A.indicator (fun _ => (1 : ℝ)) | m] * μ[B.indicator (fun _ => (1 : ℝ)) | m] :=
+  (condIndep_iff m mF mH hm hmF hmH μ).mp hCI A B hA hB
+
+end Probability
+
+end TauCeti

--- a/TauCeti/Probability/Independence/Conditional.lean
+++ b/TauCeti/Probability/Independence/Conditional.lean
@@ -1,13 +1,13 @@
 module
 
 public import Mathlib.Probability.Independence.Conditional
-public import Mathlib.MeasureTheory.Function.ConditionalExpectation.PullOut
-public import Mathlib.MeasureTheory.Integral.IntegrableOn
+import Mathlib.MeasureTheory.Function.ConditionalExpectation.PullOut
+import Mathlib.MeasureTheory.Integral.IntegrableOn
 
 /-!
 # Conditional independence from an indicator conditional-expectation criterion
 
-`condIndep_of_indicator_condexp_eq` — the "drop-information" adapter for Mathlib's
+`condIndep_of_indicator_condExp_eq` — the "drop-information" adapter for Mathlib's
 `ProbabilityTheory.CondIndep`, used by the de Finetti block-product factorisation: it builds
 `CondIndep mG mF mH` from the criterion `μ[𝟙_H | mF ⊔ mG] =ᵐ μ[𝟙_H | mG]` (for all `mH`-measurable
 `H`).
@@ -17,7 +17,9 @@ factors through the conditional expectation (`condExp_mul_of_aestronglyMeasurabl
 property (`condExp_condExp_of_le`). (The forward product-formula direction is Mathlib's
 `condIndep_iff … |>.mp` applied directly, so no wrapper is provided here.)
 
-Adapted from `cameronfreer/exchangeability` (`Probability/CondExp.lean`, pin
+The "drop-information" step is the standard conditional-independence characterisation of the de
+Finetti route; see Kallenberg, *Probabilistic Symmetries and Invariance Principles* (Springer,
+2005). Adapted from `cameronfreer/exchangeability` (`Probability/CondExp.lean`, pin
 `e0532e59ceff23edab44dda9ab0655debbc9cc22`).
 -/
 
@@ -34,7 +36,7 @@ namespace Probability
 /-- **Conditional independence from the drop-information criterion.** If conditioning `𝟙_H` on
 `mF ⊔ mG` is a.e. the same as conditioning on `mG` (for every `mH`-measurable `H`), then `mF` and
 `mH` are conditionally independent given `mG`. -/
-theorem condIndep_of_indicator_condexp_eq {Ω : Type*} {mΩ : MeasurableSpace Ω}
+theorem condIndep_of_indicator_condExp_eq {Ω : Type*} {mΩ : MeasurableSpace Ω}
     [StandardBorelSpace Ω] {μ : Measure Ω} [IsFiniteMeasure μ] {mF mG mH : MeasurableSpace Ω}
     (hmF : mF ≤ mΩ) (hmG : mG ≤ mΩ) (hmH : mH ≤ mΩ)
     (h : ∀ H, MeasurableSet[mH] H →
@@ -46,6 +48,10 @@ theorem condIndep_of_indicator_condexp_eq {Ω : Type*} {mΩ : MeasurableSpace Ω
   intro tF tH htF htH
   set f1 : Ω → ℝ := tF.indicator (fun _ : Ω => (1 : ℝ)) with hf1
   set f2 : Ω → ℝ := tH.indicator (fun _ : Ω => (1 : ℝ)) with hf2
+  -- The product of the two indicators is the indicator of the intersection; named once and reused.
+  have h_f1f2 : (fun ω => f1 ω * f2 ω) = (tF ∩ tH).indicator (fun _ => (1 : ℝ)) := by
+    funext ω; by_cases h1 : ω ∈ tF <;> by_cases h2 : ω ∈ tH <;>
+      simp [hf1, hf2, Set.indicator, h1, h2, Set.mem_inter_iff] at *
   have hf1_int : Integrable f1 μ := Integrable.indicator (integrable_const (1 : ℝ)) (hmF _ htF)
   have hf2_int : Integrable f2 μ := Integrable.indicator (integrable_const (1 : ℝ)) (hmH _ htH)
   have hf1_aesm : AEStronglyMeasurable[mF ⊔ mG] f1 μ :=
@@ -57,17 +63,14 @@ theorem condIndep_of_indicator_condexp_eq {Ω : Type*} {mΩ : MeasurableSpace Ω
     simpa using (condExp_condExp_of_le (μ := μ) (hm₁₂ := le_sup_right) (hm₂ := sup_le hmF hmG)
       (f := fun ω => f1 ω * f2 ω)).symm
   have hf1f2_int : Integrable (fun ω => f1 ω * f2 ω) μ := by
-    have heq : (fun ω => f1 ω * f2 ω) = (tF ∩ tH).indicator (fun _ : Ω => (1 : ℝ)) := by
-      funext ω; by_cases h1 : ω ∈ tF <;> by_cases h2 : ω ∈ tH <;>
-        simp [hf1, hf2, Set.indicator, h1, h2, Set.mem_inter_iff] at *
-    rw [heq]
+    rw [h_f1f2]
     exact Integrable.indicator (integrable_const (1 : ℝ))
       (MeasurableSet.inter (hmF _ htF) (hmH _ htH))
   have h_pull_middle : μ[(fun ω => f1 ω * f2 ω) | mF ⊔ mG] =ᵐ[μ] f1 * μ[f2 | mF ⊔ mG] :=
     condExp_mul_of_aestronglyMeasurable_left (μ := μ) (m := mF ⊔ mG) hf1_aesm hf1f2_int hf2_int
   have h_middle_to_G : μ[(fun ω => f1 ω * f2 ω) | mF ⊔ mG] =ᵐ[μ] f1 * μ[f2 | mG] :=
     h_pull_middle.trans <| Filter.EventuallyEq.mul Filter.EventuallyEq.rfl hProj
-  have hf1_condexp_int : Integrable (f1 * μ[f2 | mG]) μ := by
+  have hf1_condExp_int : Integrable (f1 * μ[f2 | mG]) μ := by
     have heq : f1 * μ[f2 | mG] = tF.indicator (fun ω => μ[f2 | mG] ω) := by
       funext ω; by_cases hω : ω ∈ tF <;> simp [hf1, Set.indicator, hω]
     rw [heq]
@@ -75,12 +78,9 @@ theorem condIndep_of_indicator_condexp_eq {Ω : Type*} {mΩ : MeasurableSpace Ω
   have h_pull_outer : μ[f1 * μ[f2 | mG] | mG] =ᵐ[μ] μ[f1 | mG] * μ[f2 | mG] :=
     condExp_mul_of_aestronglyMeasurable_right (μ := μ) (m := mG)
       (stronglyMeasurable_condExp (μ := μ) (m := mG) (f := f2)).aestronglyMeasurable
-      hf1_condexp_int hf1_int
+      hf1_condExp_int hf1_int
   have h_prod : μ[(fun ω => f1 ω * f2 ω) | mG] =ᵐ[μ] μ[f1 | mG] * μ[f2 | mG] :=
     h_tower.trans ((condExp_congr_ae h_middle_to_G).trans h_pull_outer)
-  have h_f1f2 : (fun ω => f1 ω * f2 ω) = (tF ∩ tH).indicator (fun _ => (1 : ℝ)) := by
-    funext ω; by_cases h1 : ω ∈ tF <;> by_cases h2 : ω ∈ tH <;>
-      simp [hf1, hf2, Set.indicator, h1, h2, Set.mem_inter_iff] at *
   rw [h_f1f2] at h_prod
   simpa only [hf1, hf2] using h_prod
 


### PR DESCRIPTION
<!--tauceti-target:v1 {"focus":"Exchangeability","id":"condindep-indicator"}-->

## Summary

Adds `TauCeti/Probability/Independence/Conditional.lean` with the **drop-information** adapter for
Mathlib's `ProbabilityTheory.CondIndep`, used by the de Finetti block-product factorisation:

- `condIndep_of_indicator_condExp_eq` — builds `CondIndep mG mF mH` from the criterion
  `μ[𝟙_H | mF ⊔ mG] =ᵐ μ[𝟙_H | mG]` (for every `mH`-measurable `H`).

(The reverse product-formula direction is Mathlib's `condIndep_iff … |>.mp` applied directly — a
one-liner — so no wrapper is added for it.)

## Roadmap

Advances **`TauCetiRoadmap/Exchangeability/README.md`, Layer 1 — *product kernels, conditional
independence, and mixtures*** (the conditional-independence node). It is Kallenberg's "drop
information" step: it *produces* a `CondIndep` witness from a conditional-expectation collapse — the
direction the **block-product factorisation** needs to package the directing measure into a
`ConditionallyIIDWith` witness (Layer 6, *directing measures and the de Finetti representation*), and
that Mathlib does not already provide (it has only the `condIndep_iff` characterisation).

## How it's proved (reuse)

A layer over Mathlib's `condIndep_iff` (`.2` direction): the build pulls the indicator factors through
the conditional expectation (`condExp_mul_of_aestronglyMeasurable_left`/`_right`) and uses the tower
property (`condExp_condExp_of_le`). No new measure theory.

## Review notes (addresses the round-1 findings)
- **naming:** the lemma (and the local `hf1_condExp_int`) now use the Mathlib/TauCeti `condExp`
  spelling — `condIndep_of_indicator_condExp_eq`.
- **placement:** moved from `Probability/DeFinetti/` to the generic
  `Probability/Independence/Conditional.lean` (mirroring Mathlib's `Probability/Independence/
  Conditional`), since it is generic `CondIndep` ↔ indicator-`condExp` API with no de Finetti
  hypotheses; later probability code can import it without depending on de Finetti material.
- **api-design:** only `Mathlib.Probability.Independence.Conditional` is a `public import` (the
  statement uses `CondIndep`); the proof-only `ConditionalExpectation.PullOut` and
  `Integral.IntegrableOn` are demoted to plain `import` so downstream cannot depend on them.
- **proof-quality:** the indicator-product identity (`f1 * f2 = 𝟙_{tF ∩ tH}`) is named once as
  `h_f1f2` and reused, replacing the two duplicated inline derivations.
- **attribution:** the informal Kallenberg source for the drop-information step (Kallenberg,
  *Probabilistic Symmetries and Invariance Principles*, Springer 2005) is now credited in the module
  docstring alongside the formal `cameronfreer/exchangeability` adaptation.
- **generality:** `condIndep_of_indicator_condExp_eq` needs `[StandardBorelSpace Ω]` and
  `[IsFiniteMeasure μ]`, both required by Mathlib's `condIndep_iff` / regular conditional expectation.

## Test plan
```bash
lake build
lake exe axioms
lake exe module-system
```
All pass; sorry-free; axioms ⊆ {`propext`, `Classical.choice`, `Quot.sound`}; lines ≤100.

## Attribution
Adapted from `cameronfreer/exchangeability` (`Probability/CondExp.lean`, pin
`e0532e59ceff23edab44dda9ab0655debbc9cc22`), over Mathlib's conditional-independence + conditional-
expectation API; the drop-information step follows Kallenberg, *Probabilistic Symmetries and
Invariance Principles* (Springer, 2005). Drafted with Claude (Opus 4.8), human-directed.
