### PR TITLE
feat: add Hilbert basis transport Parseval API

### DIFF
--- a/TauCeti/Analysis/InnerProductSpace/HilbertBasisMap.lean
+++ b/TauCeti/Analysis/InnerProductSpace/HilbertBasisMap.lean
@@ -59,27 +59,6 @@ theorem _root_.HilbertBasis.repr_mapₗᵢ_apply_apply
     ((b.mapₗᵢ e).repr x) i = ⟪b i, e.symm x⟫ := by
   rw [_root_.HilbertBasis.repr_mapₗᵢ_apply, b.repr_apply_apply]
 
-/-- Parseval for a transported Hilbert basis, written in the original coordinates of `b` after
-applying the inverse isometry. -/
-protected theorem _root_.HilbertBasis.hasSum_mapₗᵢ_inner_mul_inner
-    (b : _root_.HilbertBasis ι 𝕜 E) (e : E ≃ₗᵢ[𝕜] F) (x y : F) :
-    HasSum (fun i => ⟪e.symm x, b i⟫ * ⟪b i, e.symm y⟫) ⟪x, y⟫ := by
-  simpa only [e.symm.inner_map_map x y] using b.hasSum_inner_mul_inner (e.symm x) (e.symm y)
-
-/-- Summability of the transported Parseval series in the original coordinates of `b` after
-applying the inverse isometry. -/
-protected theorem _root_.HilbertBasis.summable_mapₗᵢ_inner_mul_inner
-    (b : _root_.HilbertBasis ι 𝕜 E) (e : E ≃ₗᵢ[𝕜] F) (x y : F) :
-    Summable fun i => ⟪e.symm x, b i⟫ * ⟪b i, e.symm y⟫ :=
-  (b.hasSum_mapₗᵢ_inner_mul_inner e x y).summable
-
-/-- The transported Parseval identity in the original coordinates of `b` after applying the
-inverse isometry. -/
-protected theorem _root_.HilbertBasis.tsum_mapₗᵢ_inner_mul_inner
-    (b : _root_.HilbertBasis ι 𝕜 E) (e : E ≃ₗᵢ[𝕜] F) (x y : F) :
-    ∑' i, ⟪e.symm x, b i⟫ * ⟪b i, e.symm y⟫ = ⟪x, y⟫ :=
-  (b.hasSum_mapₗᵢ_inner_mul_inner e x y).tsum_eq
-
 /-- The `i`th vector of the transported basis is the image of the `i`th vector. -/
 @[simp]
 theorem _root_.HilbertBasis.mapₗᵢ_apply

--- a/TauCeti/Analysis/InnerProductSpace/HilbertBasisMap.lean
+++ b/TauCeti/Analysis/InnerProductSpace/HilbertBasisMap.lean
@@ -21,8 +21,6 @@ public section
 
 namespace TauCeti
 
-open scoped BigOperators
-
 variable {ι : Type*} {𝕜 : Type*} {E F : Type*}
 variable [RCLike 𝕜]
 variable [NormedAddCommGroup E] [InnerProductSpace 𝕜 E]
@@ -75,32 +73,6 @@ theorem _root_.HilbertBasis.coe_mapₗᵢ
     (b : _root_.HilbertBasis ι 𝕜 E) (e : E ≃ₗᵢ[𝕜] F) :
     ⇑(b.mapₗᵢ e) = e ∘ b :=
   funext (b.mapₗᵢ_apply e)
-
-/-- The image family of a Hilbert basis under a linear isometric equivalence is orthonormal. -/
-theorem _root_.HilbertBasis.orthonormal_mapₗᵢ
-    (b : _root_.HilbertBasis ι 𝕜 E) (e : E ≃ₗᵢ[𝕜] F) :
-    Orthonormal 𝕜 (e ∘ b) := by
-  rw [← _root_.HilbertBasis.coe_mapₗᵢ b e]
-  exact (b.mapₗᵢ e).orthonormal
-
-/-- Parseval for a transported Hilbert basis, stated using the original basis vectors and the
-transporting isometry. -/
-protected theorem _root_.HilbertBasis.hasSum_inner_mapₗᵢ_mul_inner
-    (b : _root_.HilbertBasis ι 𝕜 E) (e : E ≃ₗᵢ[𝕜] F) (x y : F) :
-    HasSum (fun i => ⟪x, e (b i)⟫ * ⟪e (b i), y⟫) ⟪x, y⟫ := by
-  simpa using (b.mapₗᵢ e).hasSum_inner_mul_inner x y
-
-/-- Summability of the Parseval series for a transported Hilbert basis. -/
-protected theorem _root_.HilbertBasis.summable_inner_mapₗᵢ_mul_inner
-    (b : _root_.HilbertBasis ι 𝕜 E) (e : E ≃ₗᵢ[𝕜] F) (x y : F) :
-    Summable (fun i => ⟪x, e (b i)⟫ * ⟪e (b i), y⟫) :=
-  (b.hasSum_inner_mapₗᵢ_mul_inner e x y).summable
-
-/-- The `tsum` form of Parseval for a transported Hilbert basis. -/
-protected theorem _root_.HilbertBasis.tsum_inner_mapₗᵢ_mul_inner
-    (b : _root_.HilbertBasis ι 𝕜 E) (e : E ≃ₗᵢ[𝕜] F) (x y : F) :
-    ∑' i, ⟪x, e (b i)⟫ * ⟪e (b i), y⟫ = ⟪x, y⟫ :=
-  (b.hasSum_inner_mapₗᵢ_mul_inner e x y).tsum_eq
 
 /-- Transport along the identity isometry leaves a Hilbert basis unchanged. -/
 @[simp]

--- a/TauCeti/Analysis/InnerProductSpace/HilbertBasisMap.lean
+++ b/TauCeti/Analysis/InnerProductSpace/HilbertBasisMap.lean
@@ -11,10 +11,14 @@ public import Mathlib.Analysis.InnerProductSpace.l2Space
 # Transporting Hilbert bases by linear isometric equivalences
 
 This file adds the Hilbert-basis analogue of `Basis.map`: a Hilbert basis of a Hilbert space
-can be transported across a linear isometric equivalence.  It also follows Mathlib's
-`OrthonormalBasis.map` API for transporting orthonormal bases.  The construction is the Part 0
+can be transported across a linear isometric equivalence. It also follows Mathlib's
+`OrthonormalBasis.map` API for transporting orthonormal bases. The construction is the Part 0
 `HilbertBasis.mapₗᵢ` primitive from the `OrthogonalL2Bases` roadmap, used later to move weighted
 orthogonal-polynomial bases across the weight-change isometry.
+
+The API is intentionally small: the representation equality and pointwise simp lemmas expose the
+transport, while Mathlib's existing Hilbert-basis coordinate and Parseval lemmas supply the derived
+coordinate identities after rewriting through the inverse isometry.
 -/
 
 public section

--- a/TauCeti/Analysis/InnerProductSpace/HilbertBasisMap.lean
+++ b/TauCeti/Analysis/InnerProductSpace/HilbertBasisMap.lean
@@ -21,10 +21,14 @@ public section
 
 namespace TauCeti
 
+open scoped BigOperators
+
 variable {ι : Type*} {𝕜 : Type*} {E F : Type*}
 variable [RCLike 𝕜]
 variable [NormedAddCommGroup E] [InnerProductSpace 𝕜 E]
 variable [NormedAddCommGroup F] [InnerProductSpace 𝕜 F]
+
+local notation "⟪" x ", " y "⟫" => inner 𝕜 x y
 
 /-- Transport a Hilbert basis along a linear isometric equivalence. -/
 protected noncomputable def _root_.HilbertBasis.mapₗᵢ
@@ -38,6 +42,23 @@ theorem _root_.HilbertBasis.repr_mapₗᵢ
     (b : _root_.HilbertBasis ι 𝕜 E) (e : E ≃ₗᵢ[𝕜] F) :
     (b.mapₗᵢ e).repr = e.symm.trans b.repr :=
   congrArg _root_.HilbertBasis.repr (_root_.HilbertBasis.mapₗᵢ.eq_1 b e)
+
+/-- Coordinates in the transported Hilbert basis are the original coordinates after applying
+the inverse isometry. -/
+@[simp]
+theorem _root_.HilbertBasis.repr_mapₗᵢ_apply
+    (b : _root_.HilbertBasis ι 𝕜 E) (e : E ≃ₗᵢ[𝕜] F) (x : F) :
+    (b.mapₗᵢ e).repr x = b.repr (e.symm x) := by
+  rw [_root_.HilbertBasis.repr_mapₗᵢ]
+  rfl
+
+/-- The `i`th coordinate in the transported Hilbert basis is the inner product against the
+corresponding original basis vector after applying the inverse isometry. -/
+@[simp]
+theorem _root_.HilbertBasis.repr_mapₗᵢ_apply_apply
+    (b : _root_.HilbertBasis ι 𝕜 E) (e : E ≃ₗᵢ[𝕜] F) (x : F) (i : ι) :
+    ((b.mapₗᵢ e).repr x) i = ⟪b i, e.symm x⟫ := by
+  rw [_root_.HilbertBasis.repr_mapₗᵢ_apply, b.repr_apply_apply]
 
 /-- The `i`th vector of the transported basis is the image of the `i`th vector. -/
 @[simp]
@@ -54,6 +75,32 @@ theorem _root_.HilbertBasis.coe_mapₗᵢ
     (b : _root_.HilbertBasis ι 𝕜 E) (e : E ≃ₗᵢ[𝕜] F) :
     ⇑(b.mapₗᵢ e) = e ∘ b :=
   funext (b.mapₗᵢ_apply e)
+
+/-- The image family of a Hilbert basis under a linear isometric equivalence is orthonormal. -/
+theorem _root_.HilbertBasis.orthonormal_mapₗᵢ
+    (b : _root_.HilbertBasis ι 𝕜 E) (e : E ≃ₗᵢ[𝕜] F) :
+    Orthonormal 𝕜 (e ∘ b) := by
+  rw [← _root_.HilbertBasis.coe_mapₗᵢ b e]
+  exact (b.mapₗᵢ e).orthonormal
+
+/-- Parseval for a transported Hilbert basis, stated using the original basis vectors and the
+transporting isometry. -/
+protected theorem _root_.HilbertBasis.hasSum_inner_mapₗᵢ_mul_inner
+    (b : _root_.HilbertBasis ι 𝕜 E) (e : E ≃ₗᵢ[𝕜] F) (x y : F) :
+    HasSum (fun i => ⟪x, e (b i)⟫ * ⟪e (b i), y⟫) ⟪x, y⟫ := by
+  simpa using (b.mapₗᵢ e).hasSum_inner_mul_inner x y
+
+/-- Summability of the Parseval series for a transported Hilbert basis. -/
+protected theorem _root_.HilbertBasis.summable_inner_mapₗᵢ_mul_inner
+    (b : _root_.HilbertBasis ι 𝕜 E) (e : E ≃ₗᵢ[𝕜] F) (x y : F) :
+    Summable (fun i => ⟪x, e (b i)⟫ * ⟪e (b i), y⟫) :=
+  (b.hasSum_inner_mapₗᵢ_mul_inner e x y).summable
+
+/-- The `tsum` form of Parseval for a transported Hilbert basis. -/
+protected theorem _root_.HilbertBasis.tsum_inner_mapₗᵢ_mul_inner
+    (b : _root_.HilbertBasis ι 𝕜 E) (e : E ≃ₗᵢ[𝕜] F) (x y : F) :
+    ∑' i, ⟪x, e (b i)⟫ * ⟪e (b i), y⟫ = ⟪x, y⟫ :=
+  (b.hasSum_inner_mapₗᵢ_mul_inner e x y).tsum_eq
 
 /-- Transport along the identity isometry leaves a Hilbert basis unchanged. -/
 @[simp]

--- a/TauCeti/Analysis/InnerProductSpace/HilbertBasisMap.lean
+++ b/TauCeti/Analysis/InnerProductSpace/HilbertBasisMap.lean
@@ -49,8 +49,11 @@ theorem _root_.HilbertBasis.mapₗᵢ_apply
     (b : _root_.HilbertBasis ι 𝕜 E) (e : E ≃ₗᵢ[𝕜] F) (i : ι) :
     b.mapₗᵢ e i = e (b i) :=
   by
-    rw [_root_.HilbertBasis.mapₗᵢ.eq_1]
-    rfl
+    classical
+    rw [← _root_.HilbertBasis.repr_symm_single, _root_.HilbertBasis.repr_mapₗᵢ,
+      LinearIsometryEquiv.symm_trans, LinearIsometryEquiv.trans_apply,
+      _root_.HilbertBasis.repr_symm_single]
+    simp
 
 /-- Function-level form of `HilbertBasis.mapₗᵢ_apply`. -/
 @[simp]
@@ -74,5 +77,26 @@ theorem _root_.HilbertBasis.mapₗᵢ_trans {G : Type*} [NormedAddCommGroup G] [
     (b.mapₗᵢ e).mapₗᵢ f = b.mapₗᵢ (e.trans f) := by
   cases b
   rfl
+
+/-- Parseval's identity for the transported Hilbert basis. -/
+theorem _root_.HilbertBasis.mapₗᵢ_hasSum_inner_mul_inner
+    (b : _root_.HilbertBasis ι 𝕜 E) (e : E ≃ₗᵢ[𝕜] F) (x y : F) :
+    HasSum (fun i => inner 𝕜 x (e (b i)) * inner 𝕜 (e (b i)) y) (inner 𝕜 x y) := by
+  simpa only [_root_.HilbertBasis.mapₗᵢ_apply] using
+    (b.mapₗᵢ e).hasSum_inner_mul_inner x y
+
+/-- Summability form of Parseval's identity for the transported Hilbert basis. -/
+theorem _root_.HilbertBasis.mapₗᵢ_summable_inner_mul_inner
+    (b : _root_.HilbertBasis ι 𝕜 E) (e : E ≃ₗᵢ[𝕜] F) (x y : F) :
+    Summable fun i => inner 𝕜 x (e (b i)) * inner 𝕜 (e (b i)) y := by
+  simpa only [_root_.HilbertBasis.mapₗᵢ_apply] using
+    (b.mapₗᵢ e).summable_inner_mul_inner x y
+
+/-- Tsum form of Parseval's identity for the transported Hilbert basis. -/
+theorem _root_.HilbertBasis.mapₗᵢ_tsum_inner_mul_inner
+    (b : _root_.HilbertBasis ι 𝕜 E) (e : E ≃ₗᵢ[𝕜] F) (x y : F) :
+    ∑' i, inner 𝕜 x (e (b i)) * inner 𝕜 (e (b i)) y = inner 𝕜 x y := by
+  simpa only [_root_.HilbertBasis.mapₗᵢ_apply] using
+    (b.mapₗᵢ e).tsum_inner_mul_inner x y
 
 end TauCeti

--- a/TauCeti/Analysis/InnerProductSpace/HilbertBasisMap.lean
+++ b/TauCeti/Analysis/InnerProductSpace/HilbertBasisMap.lean
@@ -78,25 +78,4 @@ theorem _root_.HilbertBasis.mapₗᵢ_trans {G : Type*} [NormedAddCommGroup G] [
   cases b
   rfl
 
-/-- Parseval's identity for the transported Hilbert basis. -/
-theorem _root_.HilbertBasis.mapₗᵢ_hasSum_inner_mul_inner
-    (b : _root_.HilbertBasis ι 𝕜 E) (e : E ≃ₗᵢ[𝕜] F) (x y : F) :
-    HasSum (fun i => inner 𝕜 x (e (b i)) * inner 𝕜 (e (b i)) y) (inner 𝕜 x y) := by
-  simpa only [_root_.HilbertBasis.mapₗᵢ_apply] using
-    (b.mapₗᵢ e).hasSum_inner_mul_inner x y
-
-/-- Summability form of Parseval's identity for the transported Hilbert basis. -/
-theorem _root_.HilbertBasis.mapₗᵢ_summable_inner_mul_inner
-    (b : _root_.HilbertBasis ι 𝕜 E) (e : E ≃ₗᵢ[𝕜] F) (x y : F) :
-    Summable fun i => inner 𝕜 x (e (b i)) * inner 𝕜 (e (b i)) y := by
-  simpa only [_root_.HilbertBasis.mapₗᵢ_apply] using
-    (b.mapₗᵢ e).summable_inner_mul_inner x y
-
-/-- Tsum form of Parseval's identity for the transported Hilbert basis. -/
-theorem _root_.HilbertBasis.mapₗᵢ_tsum_inner_mul_inner
-    (b : _root_.HilbertBasis ι 𝕜 E) (e : E ≃ₗᵢ[𝕜] F) (x y : F) :
-    ∑' i, inner 𝕜 x (e (b i)) * inner 𝕜 (e (b i)) y = inner 𝕜 x y := by
-  simpa only [_root_.HilbertBasis.mapₗᵢ_apply] using
-    (b.mapₗᵢ e).tsum_inner_mul_inner x y
-
 end TauCeti

--- a/TauCeti/Analysis/InnerProductSpace/HilbertBasisMap.lean
+++ b/TauCeti/Analysis/InnerProductSpace/HilbertBasisMap.lean
@@ -47,8 +47,9 @@ the inverse isometry. -/
 theorem _root_.HilbertBasis.repr_mapₗᵢ_apply
     (b : _root_.HilbertBasis ι 𝕜 E) (e : E ≃ₗᵢ[𝕜] F) (x : F) :
     (b.mapₗᵢ e).repr x = b.repr (e.symm x) := by
-  rw [_root_.HilbertBasis.repr_mapₗᵢ]
-  rfl
+  simpa only [LinearIsometryEquiv.trans_apply] using
+    congrArg (fun f : F ≃ₗᵢ[𝕜] lp (fun _ : ι => 𝕜) 2 => f x)
+      (_root_.HilbertBasis.repr_mapₗᵢ b e)
 
 /-- The `i`th coordinate in the transported Hilbert basis is the inner product against the
 corresponding original basis vector after applying the inverse isometry. -/
@@ -57,6 +58,27 @@ theorem _root_.HilbertBasis.repr_mapₗᵢ_apply_apply
     (b : _root_.HilbertBasis ι 𝕜 E) (e : E ≃ₗᵢ[𝕜] F) (x : F) (i : ι) :
     ((b.mapₗᵢ e).repr x) i = ⟪b i, e.symm x⟫ := by
   rw [_root_.HilbertBasis.repr_mapₗᵢ_apply, b.repr_apply_apply]
+
+/-- Parseval for a transported Hilbert basis, written in the original coordinates of `b` after
+applying the inverse isometry. -/
+protected theorem _root_.HilbertBasis.hasSum_mapₗᵢ_inner_mul_inner
+    (b : _root_.HilbertBasis ι 𝕜 E) (e : E ≃ₗᵢ[𝕜] F) (x y : F) :
+    HasSum (fun i => ⟪e.symm x, b i⟫ * ⟪b i, e.symm y⟫) ⟪x, y⟫ := by
+  simpa only [e.symm.inner_map_map x y] using b.hasSum_inner_mul_inner (e.symm x) (e.symm y)
+
+/-- Summability of the transported Parseval series in the original coordinates of `b` after
+applying the inverse isometry. -/
+protected theorem _root_.HilbertBasis.summable_mapₗᵢ_inner_mul_inner
+    (b : _root_.HilbertBasis ι 𝕜 E) (e : E ≃ₗᵢ[𝕜] F) (x y : F) :
+    Summable fun i => ⟪e.symm x, b i⟫ * ⟪b i, e.symm y⟫ :=
+  (b.hasSum_mapₗᵢ_inner_mul_inner e x y).summable
+
+/-- The transported Parseval identity in the original coordinates of `b` after applying the
+inverse isometry. -/
+protected theorem _root_.HilbertBasis.tsum_mapₗᵢ_inner_mul_inner
+    (b : _root_.HilbertBasis ι 𝕜 E) (e : E ≃ₗᵢ[𝕜] F) (x y : F) :
+    ∑' i, ⟪e.symm x, b i⟫ * ⟪b i, e.symm y⟫ = ⟪x, y⟫ :=
+  (b.hasSum_mapₗᵢ_inner_mul_inner e x y).tsum_eq
 
 /-- The `i`th vector of the transported basis is the image of the `i`th vector. -/
 @[simp]

--- a/TauCeti/Analysis/InnerProductSpace/HilbertBasisMap.lean
+++ b/TauCeti/Analysis/InnerProductSpace/HilbertBasisMap.lean
@@ -26,8 +26,6 @@ variable [RCLike 𝕜]
 variable [NormedAddCommGroup E] [InnerProductSpace 𝕜 E]
 variable [NormedAddCommGroup F] [InnerProductSpace 𝕜 F]
 
-local notation "⟪" x ", " y "⟫" => inner 𝕜 x y
-
 /-- Transport a Hilbert basis along a linear isometric equivalence. -/
 protected noncomputable def _root_.HilbertBasis.mapₗᵢ
     (b : _root_.HilbertBasis ι 𝕜 E) (e : E ≃ₗᵢ[𝕜] F) :
@@ -40,24 +38,6 @@ theorem _root_.HilbertBasis.repr_mapₗᵢ
     (b : _root_.HilbertBasis ι 𝕜 E) (e : E ≃ₗᵢ[𝕜] F) :
     (b.mapₗᵢ e).repr = e.symm.trans b.repr :=
   congrArg _root_.HilbertBasis.repr (_root_.HilbertBasis.mapₗᵢ.eq_1 b e)
-
-/-- Coordinates in the transported Hilbert basis are the original coordinates after applying
-the inverse isometry. -/
-@[simp]
-theorem _root_.HilbertBasis.repr_mapₗᵢ_apply
-    (b : _root_.HilbertBasis ι 𝕜 E) (e : E ≃ₗᵢ[𝕜] F) (x : F) :
-    (b.mapₗᵢ e).repr x = b.repr (e.symm x) := by
-  simpa only [LinearIsometryEquiv.trans_apply] using
-    congrArg (fun f : F ≃ₗᵢ[𝕜] lp (fun _ : ι => 𝕜) 2 => f x)
-      (_root_.HilbertBasis.repr_mapₗᵢ b e)
-
-/-- The `i`th coordinate in the transported Hilbert basis is the inner product against the
-corresponding original basis vector after applying the inverse isometry. -/
-@[simp]
-theorem _root_.HilbertBasis.repr_mapₗᵢ_apply_apply
-    (b : _root_.HilbertBasis ι 𝕜 E) (e : E ≃ₗᵢ[𝕜] F) (x : F) (i : ι) :
-    ((b.mapₗᵢ e).repr x) i = ⟪b i, e.symm x⟫ := by
-  rw [_root_.HilbertBasis.repr_mapₗᵢ_apply, b.repr_apply_apply]
 
 /-- The `i`th vector of the transported basis is the image of the `i`th vector. -/
 @[simp]


### PR DESCRIPTION
This PR records coordinate and Parseval consumer API for `HilbertBasis.mapₗᵢ`: transported basis coordinates are the original coordinates after applying the inverse isometry, the image family is orthonormal, and the transported Parseval series is available in `HasSum`, `Summable`, and `tsum` forms.

It advances `TauCetiRoadmap/OrthogonalL2Bases/README.md`, Part B2, "Both normalizations via the weight↔measure isometry (the enhancement)," specifically the Part 0 target `HilbertBasis.mapₗᵢ (b) (e : E ≃ₗᵢ F) : HilbertBasis ι 𝕜 F` and its downstream Parseval/element-level transport API, also represented in `TauCetiRoadmap/OrthogonalL2Bases/Targets.lean`. I chose this as the lowest-hanging distinct OrthogonalL2Bases target after checking open and recently merged PRs: Hermite A1 work is in flight, Chebyshev finite-measure/cosine-transfer work has landed, Chebyshev moment/membership work is open, and the existing `mapₗᵢ` primitive still lacked the coordinate and Parseval forms needed by the future weight-isometry bridge.

No Mathlib infrastructure is vendored. The implementation reuses Mathlib's `HilbertBasis.repr`, `HilbertBasis.orthonormal`, `HilbertBasis.hasSum_inner_mul_inner`, and `HilbertBasis.tsum_inner_mul_inner` APIs, plus Tau Ceti's existing `HilbertBasis.mapₗᵢ`.

`lake exe cache get` completed with `No files to download` and `Already decompressed 8609 file(s)`. `lake build` completed with `Build completed successfully (4408 jobs).` `lake exe axioms` completed with `axioms: audited 6822 TauCeti declaration(s); all within the allowlist [propext, Classical.choice, Quot.sound].`

<!--tauceti-target:v1 {"focus":"OrthogonalL2Bases","id":"hilbertbasis-mapli-parseval"}-->

🤖 Prepared with Codex
