### PR TITLE
feat: add BCR product construction

### DIFF
--- a/TauCeti/Analysis/PositiveDefinite/SemigroupGroupProduct.lean
+++ b/TauCeti/Analysis/PositiveDefinite/SemigroupGroupProduct.lean
@@ -1,0 +1,112 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+module
+
+public import TauCeti.Analysis.PositiveDefinite.FunctionKernel
+public import TauCeti.Analysis.PositiveDefinite.SemigroupGroup
+public import Mathlib.Data.NNReal.Star
+public import Mathlib.Topology.Constructions.SumProd
+
+/-!
+# Product constructions for semigroup-group positive-definite functions
+
+This file builds Berg--Christensen--Ressel positive-definite functions on `ℝ≥0 × V`
+from separate time and spatial factors. If `f : ℝ≥0 → ℂ` is positive definite for the
+trivial involution on `ℝ≥0`, and `g : V → ℂ` is positive definite for the negation
+involution on the additive group `V`, then `(t, v) ↦ f t * g v` is
+semigroup-group positive definite.
+
+This is a small prerequisite for the BCR semigroup--Bochner representation milestone in
+`TauCetiRoadmap/OneParameterSemigroups/README.md`, Part C, Milestone 2
+("BCR semigroup--Bochner"). The eventual Laplace--Fourier examples have exactly this separated
+shape before integration: a time kernel multiplied by a spatial Fourier kernel.
+
+No Mathlib infrastructure is vendored. The proof reuses Tau Ceti's positive-definite
+function/kernel correspondence and the Schur product closure for positive-definite kernels.
+
+## Main declarations
+
+* `TauCeti.isSemigroupGroupPD_mul_time_spatial`: the product of a time positive-definite
+  function and a spatial positive-definite function is BCR positive definite.
+* `TauCeti.isSemigroupGroupPD_mul_time_spatial_of_kernel`: the same construction when the time
+  factor is supplied as the positive-definite kernel `(t, u) ↦ f (t + u)`.
+* `TauCeti.continuous_mul_time_spatial`: continuity of separated products.
+* `TauCeti.isSemigroupGroupPD_mul_time_spatial_and_continuous`: the packaged positive-definite
+  and continuous form used by BCR-facing examples.
+
+## References
+
+* C. Berg, J. P. R. Christensen, P. Ressel, *Harmonic Analysis on Semigroups* (GTM 100, 1984),
+  Chapter 4.
+-/
+
+public section
+
+open scoped ComplexOrder
+open scoped NNReal
+
+namespace TauCeti
+
+variable {V : Type*} [AddCommGroup V]
+
+/-- If the time factor already gives a positive-definite kernel `(t, u) ↦ f (t + u)`, and
+the spatial factor is positive definite for the negation involution on `V`, then their separated
+product is semigroup-group positive definite. -/
+theorem isSemigroupGroupPD_mul_time_spatial_of_kernel [StarAddMonoid V]
+    {f : ℝ≥0 → ℂ} {g : V → ℂ}
+    (hf : IsPositiveDefiniteKernel fun t u : ℝ≥0 => f (t + u))
+    (hg : IsPositiveDefinite g) (hstar : ∀ v : V, star v = -v) :
+    IsSemigroupGroupPD fun p : ℝ≥0 × V => f p.1 * g p.2 := by
+  refine IsSemigroupGroupPD.of_isPositiveDefiniteKernel ?_
+  have htime : IsPositiveDefiniteKernel fun p q : ℝ≥0 × V => f (p.1 + q.1) :=
+    isPositiveDefiniteKernel_comp hf Prod.fst
+  have hspace : IsPositiveDefiniteKernel fun p q : ℝ≥0 × V => g (p.2 - q.2) :=
+    isPositiveDefiniteKernel_comp (hg.isPositiveDefiniteKernel_sub hstar) Prod.snd
+  simpa using isPositiveDefiniteKernel_mul htime hspace
+
+/-- A separated product of a time positive-definite function and a spatial positive-definite
+function is semigroup-group positive definite. The time factor uses Mathlib's trivial involution
+on `ℝ≥0`; the spatial factor uses the supplied negation-involution hypothesis. -/
+theorem isSemigroupGroupPD_mul_time_spatial [StarAddMonoid V]
+    {f : ℝ≥0 → ℂ} {g : V → ℂ}
+    (hf : IsPositiveDefinite f) (hg : IsPositiveDefinite g)
+    (hstar : ∀ v : V, star v = -v) :
+    IsSemigroupGroupPD fun p : ℝ≥0 × V => f p.1 * g p.2 := by
+  refine isSemigroupGroupPD_mul_time_spatial_of_kernel ?_ hg hstar
+  have hK := hf.isPositiveDefiniteKernel
+  simpa [star_trivial] using hK
+
+section Topology
+
+variable [TopologicalSpace V] {f : ℝ≥0 → ℂ} {g : V → ℂ}
+
+omit [AddCommGroup V] in
+/-- Separated products are continuous when both factors are continuous. -/
+theorem continuous_mul_time_spatial (hf : Continuous f) (hg : Continuous g) :
+    Continuous fun p : ℝ≥0 × V => f p.1 * g p.2 :=
+  (hf.comp continuous_fst).mul (hg.comp continuous_snd)
+
+/-- Package the separated-product construction with continuity of the resulting BCR function. -/
+theorem isSemigroupGroupPD_mul_time_spatial_and_continuous [StarAddMonoid V]
+    (hfpd : IsPositiveDefinite f) (hgpd : IsPositiveDefinite g)
+    (hstar : ∀ v : V, star v = -v) (hfcont : Continuous f) (hgcont : Continuous g) :
+    IsSemigroupGroupPD (fun p : ℝ≥0 × V => f p.1 * g p.2) ∧
+      Continuous (fun p : ℝ≥0 × V => f p.1 * g p.2) :=
+  ⟨isSemigroupGroupPD_mul_time_spatial hfpd hgpd hstar,
+    continuous_mul_time_spatial hfcont hgcont⟩
+
+/-- Kernel-supplied version of the separated-product construction, packaged with continuity. -/
+theorem isSemigroupGroupPD_mul_time_spatial_of_kernel_and_continuous [StarAddMonoid V]
+    (hf : IsPositiveDefiniteKernel fun t u : ℝ≥0 => f (t + u))
+    (hgpd : IsPositiveDefinite g) (hstar : ∀ v : V, star v = -v)
+    (hfcont : Continuous f) (hgcont : Continuous g) :
+    IsSemigroupGroupPD (fun p : ℝ≥0 × V => f p.1 * g p.2) ∧
+      Continuous (fun p : ℝ≥0 × V => f p.1 * g p.2) :=
+  ⟨isSemigroupGroupPD_mul_time_spatial_of_kernel hf hgpd hstar,
+    continuous_mul_time_spatial hfcont hgcont⟩
+
+end Topology
+
+end TauCeti

--- a/TauCeti/Analysis/PositiveDefinite/SemigroupGroupProduct.lean
+++ b/TauCeti/Analysis/PositiveDefinite/SemigroupGroupProduct.lean
@@ -4,7 +4,6 @@ Released under Apache 2.0 license as described in the file LICENSE.
 -/
 module
 
-public import TauCeti.Analysis.PositiveDefinite.FunctionKernel
 public import TauCeti.Analysis.PositiveDefinite.SemigroupGroup
 public import Mathlib.Data.NNReal.Star
 public import Mathlib.Topology.Constructions.SumProd
@@ -13,10 +12,11 @@ public import Mathlib.Topology.Constructions.SumProd
 # Product constructions for semigroup-group positive-definite functions
 
 This file builds Berg--Christensen--Ressel positive-definite functions on `ℝ≥0 × V`
-from separate time and spatial factors. If `f : ℝ≥0 → ℂ` is positive definite for the
-trivial involution on `ℝ≥0`, and `g : V → ℂ` is positive definite for the negation
-involution on the additive group `V`, then `(t, v) ↦ f t * g v` is
-semigroup-group positive definite.
+from separate time and spatial factors. If `f : ℝ≥0 → ℂ` supplies the positive-definite
+time kernel `(t, u) ↦ f (t + u)`, and `g : V → ℂ` supplies the positive-definite spatial
+subtraction kernel `(v, w) ↦ g (v - w)`, then `(t, v) ↦ f t * g v` is semigroup-group
+positive definite. We also provide the convenience form where the spatial kernel comes from
+a positive-definite function for the negation involution on `V`.
 
 This is a small prerequisite for the BCR semigroup--Bochner representation milestone in
 `TauCetiRoadmap/OneParameterSemigroups/README.md`, Part C, Milestone 2
@@ -30,8 +30,10 @@ function/kernel correspondence and the Schur product closure for positive-defini
 
 * `TauCeti.isSemigroupGroupPD_mul_time_spatial`: the product of a time positive-definite
   function and a spatial positive-definite function is BCR positive definite.
-* `TauCeti.isSemigroupGroupPD_mul_time_spatial_of_kernel`: the same construction when the time
-  factor is supplied as the positive-definite kernel `(t, u) ↦ f (t + u)`.
+* `TauCeti.isSemigroupGroupPD_mul_time_spatial_of_kernels`: the same construction when the time
+  factor and spatial subtraction factor are supplied as positive-definite kernels.
+* `TauCeti.isSemigroupGroupPD_mul_time_spatial_of_kernel`: an alias with the same two-kernel
+  hypotheses, matching the singular kernel naming used before this file exposed both kernels.
 * `TauCeti.continuous_mul_time_spatial`: continuity of separated products.
 * `TauCeti.isSemigroupGroupPD_mul_time_spatial_and_continuous`: the packaged positive-definite
   and continuous form used by BCR-facing examples.
@@ -51,20 +53,30 @@ namespace TauCeti
 
 variable {V : Type*} [AddCommGroup V]
 
-/-- If the time factor already gives a positive-definite kernel `(t, u) ↦ f (t + u)`, and
-the spatial factor is positive definite for the negation involution on `V`, then their separated
+/-- If the time factor gives a positive-definite kernel `(t, u) ↦ f (t + u)`, and the spatial
+factor gives a positive-definite subtraction kernel `(v, w) ↦ g (v - w)`, then their separated
 product is semigroup-group positive definite. -/
-theorem isSemigroupGroupPD_mul_time_spatial_of_kernel [StarAddMonoid V]
+theorem isSemigroupGroupPD_mul_time_spatial_of_kernels
     {f : ℝ≥0 → ℂ} {g : V → ℂ}
     (hf : IsPositiveDefiniteKernel fun t u : ℝ≥0 => f (t + u))
-    (hg : IsPositiveDefinite g) (hstar : ∀ v : V, star v = -v) :
+    (hg : IsPositiveDefiniteKernel fun v w : V => g (v - w)) :
     IsSemigroupGroupPD fun p : ℝ≥0 × V => f p.1 * g p.2 := by
   refine IsSemigroupGroupPD.of_isPositiveDefiniteKernel ?_
   have htime : IsPositiveDefiniteKernel fun p q : ℝ≥0 × V => f (p.1 + q.1) :=
     isPositiveDefiniteKernel_comp hf Prod.fst
   have hspace : IsPositiveDefiniteKernel fun p q : ℝ≥0 × V => g (p.2 - q.2) :=
-    isPositiveDefiniteKernel_comp (hg.isPositiveDefiniteKernel_sub hstar) Prod.snd
+    isPositiveDefiniteKernel_comp hg Prod.snd
   simpa using isPositiveDefiniteKernel_mul htime hspace
+
+/-- If the time factor gives a positive-definite kernel `(t, u) ↦ f (t + u)`, and the spatial
+factor gives a positive-definite subtraction kernel `(v, w) ↦ g (v - w)`, then their separated
+product is semigroup-group positive definite. -/
+theorem isSemigroupGroupPD_mul_time_spatial_of_kernel
+    {f : ℝ≥0 → ℂ} {g : V → ℂ}
+    (hf : IsPositiveDefiniteKernel fun t u : ℝ≥0 => f (t + u))
+    (hg : IsPositiveDefiniteKernel fun v w : V => g (v - w)) :
+    IsSemigroupGroupPD fun p : ℝ≥0 × V => f p.1 * g p.2 :=
+  isSemigroupGroupPD_mul_time_spatial_of_kernels hf hg
 
 /-- A separated product of a time positive-definite function and a spatial positive-definite
 function is semigroup-group positive definite. The time factor uses Mathlib's trivial involution
@@ -74,7 +86,7 @@ theorem isSemigroupGroupPD_mul_time_spatial [StarAddMonoid V]
     (hf : IsPositiveDefinite f) (hg : IsPositiveDefinite g)
     (hstar : ∀ v : V, star v = -v) :
     IsSemigroupGroupPD fun p : ℝ≥0 × V => f p.1 * g p.2 := by
-  refine isSemigroupGroupPD_mul_time_spatial_of_kernel ?_ hg hstar
+  refine isSemigroupGroupPD_mul_time_spatial_of_kernels ?_ (hg.isPositiveDefiniteKernel_sub hstar)
   have hK := hf.isPositiveDefiniteKernel
   simpa [star_trivial] using hK
 
@@ -98,13 +110,23 @@ theorem isSemigroupGroupPD_mul_time_spatial_and_continuous [StarAddMonoid V]
     continuous_mul_time_spatial hfcont hgcont⟩
 
 /-- Kernel-supplied version of the separated-product construction, packaged with continuity. -/
-theorem isSemigroupGroupPD_mul_time_spatial_of_kernel_and_continuous [StarAddMonoid V]
+theorem isSemigroupGroupPD_mul_time_spatial_of_kernels_and_continuous
     (hf : IsPositiveDefiniteKernel fun t u : ℝ≥0 => f (t + u))
-    (hgpd : IsPositiveDefinite g) (hstar : ∀ v : V, star v = -v)
+    (hg : IsPositiveDefiniteKernel fun v w : V => g (v - w))
     (hfcont : Continuous f) (hgcont : Continuous g) :
     IsSemigroupGroupPD (fun p : ℝ≥0 × V => f p.1 * g p.2) ∧
       Continuous (fun p : ℝ≥0 × V => f p.1 * g p.2) :=
-  ⟨isSemigroupGroupPD_mul_time_spatial_of_kernel hf hgpd hstar,
+  ⟨isSemigroupGroupPD_mul_time_spatial_of_kernels hf hg,
+    continuous_mul_time_spatial hfcont hgcont⟩
+
+/-- Kernel-supplied version of the separated-product construction, packaged with continuity. -/
+theorem isSemigroupGroupPD_mul_time_spatial_of_kernel_and_continuous
+    (hf : IsPositiveDefiniteKernel fun t u : ℝ≥0 => f (t + u))
+    (hg : IsPositiveDefiniteKernel fun v w : V => g (v - w))
+    (hfcont : Continuous f) (hgcont : Continuous g) :
+    IsSemigroupGroupPD (fun p : ℝ≥0 × V => f p.1 * g p.2) ∧
+      Continuous (fun p : ℝ≥0 × V => f p.1 * g p.2) :=
+  ⟨isSemigroupGroupPD_mul_time_spatial_of_kernel hf hg,
     continuous_mul_time_spatial hfcont hgcont⟩
 
 end Topology

--- a/TauCeti/Analysis/PositiveDefinite/SemigroupGroupProduct.lean
+++ b/TauCeti/Analysis/PositiveDefinite/SemigroupGroupProduct.lean
@@ -32,8 +32,6 @@ function/kernel correspondence and the Schur product closure for positive-defini
   function and a spatial positive-definite function is BCR positive definite.
 * `TauCeti.isSemigroupGroupPD_mul_time_spatial_of_kernels`: the same construction when the time
   factor and spatial subtraction factor are supplied as positive-definite kernels.
-* `TauCeti.isSemigroupGroupPD_mul_time_spatial_of_kernel`: an alias with the same two-kernel
-  hypotheses, matching the singular kernel naming used before this file exposed both kernels.
 * `TauCeti.continuous_mul_time_spatial`: continuity of separated products.
 * `TauCeti.isSemigroupGroupPD_mul_time_spatial_and_continuous`: the packaged positive-definite
   and continuous form used by BCR-facing examples.
@@ -67,16 +65,6 @@ theorem isSemigroupGroupPD_mul_time_spatial_of_kernels
   have hspace : IsPositiveDefiniteKernel fun p q : ℝ≥0 × V => g (p.2 - q.2) :=
     isPositiveDefiniteKernel_comp hg Prod.snd
   simpa using isPositiveDefiniteKernel_mul htime hspace
-
-/-- If the time factor gives a positive-definite kernel `(t, u) ↦ f (t + u)`, and the spatial
-factor gives a positive-definite subtraction kernel `(v, w) ↦ g (v - w)`, then their separated
-product is semigroup-group positive definite. -/
-theorem isSemigroupGroupPD_mul_time_spatial_of_kernel
-    {f : ℝ≥0 → ℂ} {g : V → ℂ}
-    (hf : IsPositiveDefiniteKernel fun t u : ℝ≥0 => f (t + u))
-    (hg : IsPositiveDefiniteKernel fun v w : V => g (v - w)) :
-    IsSemigroupGroupPD fun p : ℝ≥0 × V => f p.1 * g p.2 :=
-  isSemigroupGroupPD_mul_time_spatial_of_kernels hf hg
 
 /-- A separated product of a time positive-definite function and a spatial positive-definite
 function is semigroup-group positive definite. The time factor uses Mathlib's trivial involution
@@ -117,16 +105,6 @@ theorem isSemigroupGroupPD_mul_time_spatial_of_kernels_and_continuous
     IsSemigroupGroupPD (fun p : ℝ≥0 × V => f p.1 * g p.2) ∧
       Continuous (fun p : ℝ≥0 × V => f p.1 * g p.2) :=
   ⟨isSemigroupGroupPD_mul_time_spatial_of_kernels hf hg,
-    continuous_mul_time_spatial hfcont hgcont⟩
-
-/-- Kernel-supplied version of the separated-product construction, packaged with continuity. -/
-theorem isSemigroupGroupPD_mul_time_spatial_of_kernel_and_continuous
-    (hf : IsPositiveDefiniteKernel fun t u : ℝ≥0 => f (t + u))
-    (hg : IsPositiveDefiniteKernel fun v w : V => g (v - w))
-    (hfcont : Continuous f) (hgcont : Continuous g) :
-    IsSemigroupGroupPD (fun p : ℝ≥0 × V => f p.1 * g p.2) ∧
-      Continuous (fun p : ℝ≥0 × V => f p.1 * g p.2) :=
-  ⟨isSemigroupGroupPD_mul_time_spatial_of_kernel hf hg,
     continuous_mul_time_spatial hfcont hgcont⟩
 
 end Topology


### PR DESCRIPTION
This PR adds the separated product construction for Berg--Christensen--Ressel positive-definite functions: a positive-definite time factor on `ℝ≥0` and a spatial positive-definite factor for the negation involution on `V` multiply to an `IsSemigroupGroupPD` function on `ℝ≥0 × V`, with continuous packaged forms for downstream examples.

It advances `TauCetiRoadmap/OneParameterSemigroups/README.md`, Part C, Milestone 2, "BCR semigroup--Bochner", specifically the product Laplace--Fourier shape of the representing integrand and the positive-definite-function API around products and pullbacks. I chose this as the lowest-hanging distinct OneParameterSemigroups prerequisite after checking open and recently merged PRs: Bernstein representation infrastructure is in flight, the generic/BCR positive-definite predicates, normalization, pullbacks, and time/spatial slices already exist on `main`, while the separated time-times-spatial product constructor was still absent.

No Mathlib infrastructure is vendored. The implementation reuses Tau Ceti's `IsPositiveDefinite.isPositiveDefiniteKernel`, `isPositiveDefinite_iff_isPositiveDefiniteKernel_sub`, `isPositiveDefiniteKernel_comp`, and `isPositiveDefiniteKernel_mul` APIs.

`lake exe cache get` completed with `No files to download` and `Already decompressed 8609 file(s)`. `lake build` completed with `Build completed successfully (4409 jobs).` `lake exe axioms` completed with `axioms: audited 6818 TauCeti declaration(s); all within the allowlist [propext, Classical.choice, Quot.sound].`

<!--tauceti-target:v1 {"focus":"OneParameterSemigroups","id":"semigroup-group-product-construction"}-->

🤖 Prepared with Codex
