### PR TITLE
fix: bump TauCetiReview workflow pins past the FormalFrontier org move

### DIFF
--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -64,7 +64,7 @@ jobs:
     if: ${{ needs.resolve.outputs.pr != '' }}
     # Pinned to a TauCetiReview commit; bump deliberately. The reusable workflow receives the App
     # secrets, so a floating @main would be a supply-chain risk.
-    uses: TauCetiProject/TauCetiReview/.github/workflows/merge-only.yml@7bfab94c2d6d4e59f756775fb52e6eb58f7ca724
+    uses: TauCetiProject/TauCetiReview/.github/workflows/merge-only.yml@6375e7b54f691ae805c78bf060b4d883d7b5f5e9
     with:
       pr: ${{ needs.resolve.outputs.pr }}
     # Pass only the App credentials merge-only needs, not all of TauCeti's secrets.

--- a/.github/workflows/merge-sweep.yml
+++ b/.github/workflows/merge-sweep.yml
@@ -32,7 +32,7 @@ jobs:
   sweep:
     # Pinned to a TauCetiReview commit; bump deliberately. The reusable workflow receives the App
     # secrets, so a floating @main would be a supply-chain risk.
-    uses: TauCetiProject/TauCetiReview/.github/workflows/merge-sweep.yml@4bb1d34e2b3314fc6630b45f2be9200091ae4911
+    uses: TauCetiProject/TauCetiReview/.github/workflows/merge-sweep.yml@6375e7b54f691ae805c78bf060b4d883d7b5f5e9
     with:
       dry_run: ${{ inputs.dry-run || false }}
     secrets:

--- a/.github/workflows/review.yml
+++ b/.github/workflows/review.yml
@@ -79,7 +79,7 @@ jobs:
     if: ${{ vars.CI_REVIEW_ENABLED == 'true' && needs.resolve.outputs.pr != '' }}
     # Pinned to a TauCetiReview commit; bump deliberately (an unpinned @main lets an upstream change
     # break every contributor's review at once, and this workflow inherits TauCeti's secrets).
-    uses: TauCetiProject/TauCetiReview/.github/workflows/review.yml@21f3525b96c22030f5b5b49307867b903cab28dc
+    uses: TauCetiProject/TauCetiReview/.github/workflows/review.yml@6375e7b54f691ae805c78bf060b4d883d7b5f5e9
     with:
       pr: ${{ needs.resolve.outputs.pr }}
       trigger: ${{ github.event_name }}


### PR DESCRIPTION
This PR repoints the three `TauCetiReview` reusable-workflow pins to `6375e7b`, the commit that repointed `FormalFrontier` references to `TauCetiProject` after the org rename. The old pins (`auto-merge` → `7bfab94`, `merge-sweep` → `4bb1d34`, `review` → `21f3525`) all predate that move, so `merge-only` mints its App token with `owner: FormalFrontier`, which now returns 404 and kills the merge step before it can merge anything. Green PRs sit unmerged as a result (e.g. #561, green for over ten hours), and the scheduled `merge-sweep` fallback is dead for the same reason. Once this lands, the next scoreboard comment or scheduled sweep will pick up the stuck backlog.

🤖 Prepared with Claude Code