### PR TITLE
feat: add normalized Chebyshev modes

### DIFF
--- a/TauCeti/Analysis/SpecialFunctions/Trigonometric/Chebyshev/Measure.lean
+++ b/TauCeti/Analysis/SpecialFunctions/Trigonometric/Chebyshev/Measure.lean
@@ -224,8 +224,10 @@ lemma coeFn_normalizedChebyshevTLp {𝕜 : Type*} [RCLike 𝕜] (n : ℕ) :
       fun x : ℝ => (algebraMap ℝ 𝕜) (normalizedChebyshevT n x) :=
   MemLp.coeFn_toLp _
 
-/-- The real integral of two normalized Chebyshev `T` modes is the Kronecker delta. -/
-lemma integral_normalizedChebyshevT_mul_normalizedChebyshevT (m n : ℕ) :
+/-- The real `measureT` integral of two normalized Chebyshev `T` modes is the Kronecker
+delta. -/
+@[simp]
+lemma integral_normalizedChebyshevT_mul_normalizedChebyshevT_measureT_eq_ite (m n : ℕ) :
     ∫ x, normalizedChebyshevT m x * normalizedChebyshevT n x
         ∂Polynomial.Chebyshev.measureT = if m = n then 1 else 0 := by
   have hmpos := chebyshevTNormSq_pos m
@@ -252,27 +254,47 @@ lemma integral_normalizedChebyshevT_mul_normalizedChebyshevT (m n : ℕ) :
           · rw [if_neg hmn, if_neg hmn, mul_zero]
 
 /-- The normalized Chebyshev `T` modes have Kronecker-delta inner products in `L²(measureT)`. -/
-lemma inner_normalizedChebyshevTLp_real (m n : ℕ) :
-    inner ℝ (normalizedChebyshevTLp ℝ m) (normalizedChebyshevTLp ℝ n) =
+@[simp]
+lemma inner_normalizedChebyshevTLp {𝕜 : Type*} [RCLike 𝕜] (m n : ℕ) :
+    inner 𝕜 (normalizedChebyshevTLp 𝕜 m) (normalizedChebyshevTLp 𝕜 n) =
       if m = n then 1 else 0 := by
+  have hinner : ∀ a b : ℝ,
+      inner 𝕜 ((algebraMap ℝ 𝕜) a) ((algebraMap ℝ 𝕜) b) =
+        (algebraMap ℝ 𝕜) (a * b) := by
+    intro a b
+    simp [RCLike.inner_apply, RCLike.conj_ofReal, map_mul, mul_comm]
   calc
-    inner ℝ (normalizedChebyshevTLp ℝ m) (normalizedChebyshevTLp ℝ n)
-        = ∫ x, normalizedChebyshevT m x * normalizedChebyshevT n x
+    inner 𝕜 (normalizedChebyshevTLp 𝕜 m) (normalizedChebyshevTLp 𝕜 n)
+        = ∫ x, (algebraMap ℝ 𝕜) (normalizedChebyshevT m x * normalizedChebyshevT n x)
             ∂Polynomial.Chebyshev.measureT := by
           rw [MeasureTheory.L2.inner_def]
           refine integral_congr_ae ?_
-          filter_upwards [coeFn_normalizedChebyshevTLp (𝕜 := ℝ) m,
-            coeFn_normalizedChebyshevTLp (𝕜 := ℝ) n] with x hxm hxn
+          filter_upwards [coeFn_normalizedChebyshevTLp (𝕜 := 𝕜) m,
+            coeFn_normalizedChebyshevTLp (𝕜 := 𝕜) n] with x hxm hxn
           rw [hxm, hxn]
-          simp
-          ring_nf
+          exact hinner (normalizedChebyshevT m x) (normalizedChebyshevT n x)
     _ = if m = n then 1 else 0 :=
-          integral_normalizedChebyshevT_mul_normalizedChebyshevT m n
+          by
+            rw [integral_ofReal,
+              integral_normalizedChebyshevT_mul_normalizedChebyshevT_measureT_eq_ite]
+            by_cases hmn : m = n <;> simp [hmn]
+
+/-- The normalized Chebyshev `T` modes have Kronecker-delta inner products in real
+`L²(measureT)`. -/
+lemma inner_normalizedChebyshevTLp_real (m n : ℕ) :
+    inner ℝ (normalizedChebyshevTLp ℝ m) (normalizedChebyshevTLp ℝ n) =
+      if m = n then 1 else 0 :=
+  inner_normalizedChebyshevTLp (𝕜 := ℝ) m n
 
 /-- The normalized Chebyshev `T` modes form an orthonormal family in `L²(measureT)`. -/
-lemma orthonormal_normalizedChebyshevTLp_real :
-    Orthonormal ℝ (normalizedChebyshevTLp ℝ) := by
+lemma orthonormal_normalizedChebyshevTLp {𝕜 : Type*} [RCLike 𝕜] :
+    Orthonormal 𝕜 (normalizedChebyshevTLp 𝕜) := by
   rw [orthonormal_iff_ite]
-  exact inner_normalizedChebyshevTLp_real
+  exact inner_normalizedChebyshevTLp
+
+/-- The normalized Chebyshev `T` modes form an orthonormal family in real `L²(measureT)`. -/
+lemma orthonormal_normalizedChebyshevTLp_real :
+    Orthonormal ℝ (normalizedChebyshevTLp ℝ) :=
+  orthonormal_normalizedChebyshevTLp (𝕜 := ℝ)
 
 end TauCeti

--- a/TauCeti/Analysis/SpecialFunctions/Trigonometric/Chebyshev/Measure.lean
+++ b/TauCeti/Analysis/SpecialFunctions/Trigonometric/Chebyshev/Measure.lean
@@ -163,6 +163,21 @@ lemma integrable_exp_mul_abs_smul_measureT {𝕜 : Type*} [RCLike 𝕜] {g : ℝ
 
 /-! ### `L²` consumer forms -/
 
+/-- The real normalized Chebyshev `T` mode, with squared norm one in `L²(measureT)`. -/
+noncomputable def normalizedChebyshevT (n : ℕ) (x : ℝ) : ℝ :=
+  (T ℝ n).eval x / Real.sqrt (chebyshevTNormSq n)
+
+/-- The defining equation for the real normalized Chebyshev `T` mode. -/
+@[simp]
+lemma normalizedChebyshevT_def (n : ℕ) (x : ℝ) :
+    normalizedChebyshevT n x = (T ℝ n).eval x / Real.sqrt (chebyshevTNormSq n) :=
+  normalizedChebyshevT.eq_1 n x
+
+/-- The real normalized Chebyshev `T` mode is continuous. -/
+lemma continuous_normalizedChebyshevT (n : ℕ) :
+    Continuous (normalizedChebyshevT n) :=
+  ((T ℝ n).continuous.div_const _).congr fun x => (normalizedChebyshevT_def n x).symm
+
 /-- The real normalized Chebyshev `T` mode lies in `L²(measureT)`. -/
 lemma memLp_normalized_eval_T_real_measureT (n : ℕ) :
     MemLp (fun x : ℝ => (T ℝ n).eval x / Real.sqrt (chebyshevTNormSq n)) 2
@@ -173,6 +188,13 @@ lemma memLp_normalized_eval_T_real_measureT (n : ℕ) :
   rw [memLp_two_iff_integrable_sq hcont.aestronglyMeasurable]
   exact integrable_measureT (hcont.pow 2).continuousOn
 
+/-- The real normalized Chebyshev `T` mode lies in `L²(measureT)`. -/
+lemma memLp_normalizedChebyshevT_measureT (n : ℕ) :
+    MemLp (normalizedChebyshevT n) 2 Polynomial.Chebyshev.measureT := by
+  convert memLp_normalized_eval_T_real_measureT n using 1
+  ext x
+  rw [normalizedChebyshevT_def]
+
 /-- The scalar-cast normalized Chebyshev `T` mode lies in `L²(measureT)`, in
 the form consumed by the family-generic orthogonality-to-Hilbert-basis bridge. -/
 lemma memLp_algebraMap_normalized_eval_T_real_measureT {𝕜 : Type*} [RCLike 𝕜] (n : ℕ) :
@@ -181,5 +203,76 @@ lemma memLp_algebraMap_normalized_eval_T_real_measureT {𝕜 : Type*} [RCLike �
       Polynomial.Chebyshev.measureT := by
   simpa only [← RCLike.algebraMap_eq_ofReal] using
     (memLp_normalized_eval_T_real_measureT n).ofReal (K := 𝕜)
+
+/-- The scalar-cast normalized Chebyshev `T` mode lies in `L²(measureT)`. -/
+lemma memLp_algebraMap_normalizedChebyshevT_measureT {𝕜 : Type*} [RCLike 𝕜] (n : ℕ) :
+    MemLp (fun x : ℝ => (algebraMap ℝ 𝕜) (normalizedChebyshevT n x)) 2
+      Polynomial.Chebyshev.measureT := by
+  convert memLp_algebraMap_normalized_eval_T_real_measureT (𝕜 := 𝕜) n using 1
+  ext x
+  rw [normalizedChebyshevT_def]
+
+/-- The normalized Chebyshev `T` mode as a vector of `L²(measureT)`. -/
+noncomputable def normalizedChebyshevTLp (𝕜 : Type*) [RCLike 𝕜] (n : ℕ) :
+    Lp 𝕜 2 Polynomial.Chebyshev.measureT :=
+  (memLp_algebraMap_normalizedChebyshevT_measureT (𝕜 := 𝕜) n).toLp _
+
+/-- The `Lp` representative of the normalized Chebyshev `T` mode is the expected scalar-cast
+function. -/
+lemma coeFn_normalizedChebyshevTLp {𝕜 : Type*} [RCLike 𝕜] (n : ℕ) :
+    ⇑(normalizedChebyshevTLp 𝕜 n) =ᵐ[Polynomial.Chebyshev.measureT]
+      fun x : ℝ => (algebraMap ℝ 𝕜) (normalizedChebyshevT n x) :=
+  MemLp.coeFn_toLp _
+
+/-- The real integral of two normalized Chebyshev `T` modes is the Kronecker delta. -/
+lemma integral_normalizedChebyshevT_mul_normalizedChebyshevT (m n : ℕ) :
+    ∫ x, normalizedChebyshevT m x * normalizedChebyshevT n x
+        ∂Polynomial.Chebyshev.measureT = if m = n then 1 else 0 := by
+  have hmpos := chebyshevTNormSq_pos m
+  have hnpos := chebyshevTNormSq_pos n
+  calc
+    ∫ x, normalizedChebyshevT m x * normalizedChebyshevT n x
+        ∂Polynomial.Chebyshev.measureT
+        = (Real.sqrt (chebyshevTNormSq m) * Real.sqrt (chebyshevTNormSq n))⁻¹ *
+            ∫ x, (T ℝ m).eval x * (T ℝ n).eval x
+              ∂Polynomial.Chebyshev.measureT := by
+          rw [← integral_const_mul]
+          refine integral_congr_ae (Filter.Eventually.of_forall fun x => ?_)
+          dsimp only
+          rw [normalizedChebyshevT_def, normalizedChebyshevT_def]
+          field_simp [normalizedChebyshevT_def, Real.sqrt_ne_zero'.mpr hmpos,
+            Real.sqrt_ne_zero'.mpr hnpos]
+    _ = if m = n then 1 else 0 := by
+          rw [integral_eval_T_real_mul_eval_T_real_measureT_eq_ite]
+          by_cases hmn : m = n
+          · subst hmn
+            rw [if_pos rfl, if_pos rfl]
+            field_simp [Real.sqrt_ne_zero'.mpr hnpos]
+            rw [Real.sq_sqrt hnpos.le]
+          · rw [if_neg hmn, if_neg hmn, mul_zero]
+
+/-- The normalized Chebyshev `T` modes have Kronecker-delta inner products in `L²(measureT)`. -/
+lemma inner_normalizedChebyshevTLp_real (m n : ℕ) :
+    inner ℝ (normalizedChebyshevTLp ℝ m) (normalizedChebyshevTLp ℝ n) =
+      if m = n then 1 else 0 := by
+  calc
+    inner ℝ (normalizedChebyshevTLp ℝ m) (normalizedChebyshevTLp ℝ n)
+        = ∫ x, normalizedChebyshevT m x * normalizedChebyshevT n x
+            ∂Polynomial.Chebyshev.measureT := by
+          rw [MeasureTheory.L2.inner_def]
+          refine integral_congr_ae ?_
+          filter_upwards [coeFn_normalizedChebyshevTLp (𝕜 := ℝ) m,
+            coeFn_normalizedChebyshevTLp (𝕜 := ℝ) n] with x hxm hxn
+          rw [hxm, hxn]
+          simp
+          ring_nf
+    _ = if m = n then 1 else 0 :=
+          integral_normalizedChebyshevT_mul_normalizedChebyshevT m n
+
+/-- The normalized Chebyshev `T` modes form an orthonormal family in `L²(measureT)`. -/
+lemma orthonormal_normalizedChebyshevTLp_real :
+    Orthonormal ℝ (normalizedChebyshevTLp ℝ) := by
+  rw [orthonormal_iff_ite]
+  exact inner_normalizedChebyshevTLp_real
 
 end TauCeti


### PR DESCRIPTION
This PR packages the normalized Chebyshev `T` modes for the Part C Chebyshev basis target: it names `Tₙ / √cₙ`, exposes scalar-cast `L²(measureT)` vectors with their a.e. representatives, and records the real Kronecker-delta inner-product and orthonormal-family consumer forms.

It advances `TauCetiRoadmap/OrthogonalL2Bases/README.md`, Part C, specifically the `chebyshevHilbertBasis` milestone whose normalized modes are `Tₙ/√cₙ` with `c₀ = π` and `cₙ = π/2`, plus the acceptance checks `⟨T₀,T₀⟩ = π`, `⟨T₁,T₁⟩ = π/2`, and `⟨T₀,T₁⟩ = 0`. I chose this as the lowest-hanging distinct OrthogonalL2Bases prerequisite after checking open and recently merged PRs: Hermite Gaussian orthogonality is open in #499, Hilbert-basis transport and Chebyshev moment/membership APIs have landed, while the actual normalized `Lp` Chebyshev mode family and real orthonormality consumer lemma were still absent.

No Mathlib infrastructure is vendored. The implementation reuses Mathlib’s Chebyshev `measureT` orthogonality lemmas and `L2.inner_def`, together with Tau Ceti’s existing `chebyshevTNormSq`, positivity, `MemLp`, and Kronecker-delta integral API.

`lake exe cache get` completed with `No files to download` and `Already decompressed 8609 file(s)`. `lake build` completed with `Build completed successfully (4432 jobs).` `lake exe axioms` completed with `axioms: audited 7003 TauCeti declaration(s); all within the allowlist [propext, Classical.choice, Quot.sound].`

<!--tauceti-target:v1 {"focus":"OrthogonalL2Bases","id":"chebyshev-normalized-modes"}-->

🤖 Prepared with Codex
