### PR TITLE
feat: add BCR Cauchy-Schwarz bounds

### DIFF
--- a/TauCeti/Analysis/PositiveDefinite/SemigroupGroupBounds.lean
+++ b/TauCeti/Analysis/PositiveDefinite/SemigroupGroupBounds.lean
@@ -1,0 +1,132 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+module
+
+public import TauCeti.Analysis.PositiveDefinite.KernelBounds
+public import TauCeti.Analysis.PositiveDefinite.SemigroupGroup
+
+/-!
+# Bounds for semigroup-group positive-definite functions
+
+This file records the Cauchy--Schwarz consumer API for Berg--Christensen--Ressel
+positive-definite functions on `ℝ≥0 × V`. The associated kernel is
+`K(p, q) = F (p.1 + q.1, p.2 - q.2)`, so the generic positive-definite-kernel estimates give
+bounds on every BCR kernel entry in terms of the two time-diagonal values
+`F (p.1 + p.1, 0)` and `F (q.1 + q.1, 0)`.
+
+These estimates are a small prerequisite for the BCR semigroup--Bochner representation milestone
+in `TauCetiRoadmap/OneParameterSemigroups/README.md`, Part C, Milestone 2: later arguments need to
+control normalized BCR kernels and detect zero diagonal slices without unfolding
+`IsSemigroupGroupPD`.
+
+## Main declarations
+
+In the namespace `TauCeti.IsSemigroupGroupPD`:
+
+* `normSq_le`: the BCR Cauchy--Schwarz estimate for product points.
+* `normSq_apply_le`: the same estimate in coordinates.
+* `eq_zero_of_diagonal_eq_zero_left` and `eq_zero_of_diagonal_eq_zero_right`: a zero time-diagonal
+  value kills the corresponding row or column of the BCR kernel.
+* `norm_le_one_of_diagonal_eq_one` and `norm_apply_le_one_of_diagonal_eq_one`: normalized diagonal
+  entries bound the BCR kernel entry by `1`.
+* `norm_apply_le_timeSlice_diagonal_re`: the direct fixed-time bound
+  `‖F (t, v)‖ ≤ (F (t, 0)).re`.
+* `timeSlice_eq_zero_of_diagonal_eq_zero`: a zero fixed-time diagonal value kills the whole
+  fixed-time spatial slice.
+
+## References
+
+* C. Berg, J. P. R. Christensen, P. Ressel, *Harmonic Analysis on Semigroups* (GTM 100, 1984),
+  Chapters 3 and 4.
+-/
+
+public section
+
+open ComplexConjugate
+open scoped ComplexOrder
+open scoped NNReal
+
+namespace TauCeti
+
+variable {V : Type*} [AddCommGroup V] {F : ℝ≥0 × V → ℂ}
+
+namespace IsSemigroupGroupPD
+
+/-- The BCR Cauchy--Schwarz estimate. For a semigroup-group positive-definite function, the
+kernel entry `F (p.1 + q.1, p.2 - q.2)` has squared norm bounded by the product of the two
+time-diagonal real parts. -/
+theorem normSq_le (hF : IsSemigroupGroupPD F) (p q : ℝ≥0 × V) :
+    RCLike.normSq (F (p.1 + q.1, p.2 - q.2))
+      ≤ RCLike.re (F (p.1 + p.1, 0)) * RCLike.re (F (q.1 + q.1, 0)) := by
+  simpa using isPositiveDefiniteKernel_normSq_le hF.isPositiveDefiniteKernel p q
+
+/-- Coordinate form of the BCR Cauchy--Schwarz estimate. -/
+theorem normSq_apply_le (hF : IsSemigroupGroupPD F) (t u : ℝ≥0) (v w : V) :
+    RCLike.normSq (F (t + u, v - w))
+      ≤ RCLike.re (F (t + t, 0)) * RCLike.re (F (u + u, 0)) := by
+  simpa using hF.normSq_le (t, v) (u, w)
+
+/-- If the left time-diagonal value is zero, then the corresponding BCR-kernel row entry is
+zero. -/
+theorem eq_zero_of_diagonal_eq_zero_left (hF : IsSemigroupGroupPD F) {p q : ℝ≥0 × V}
+    (hp : F (p.1 + p.1, 0) = 0) : F (p.1 + q.1, p.2 - q.2) = 0 := by
+  simpa using isPositiveDefiniteKernel_eq_zero_of_apply_self_eq_zero_left
+    hF.isPositiveDefiniteKernel (a := p) (b := q) (by simpa using hp)
+
+/-- Coordinate form of `eq_zero_of_diagonal_eq_zero_left`. -/
+theorem apply_eq_zero_of_diagonal_eq_zero_left (hF : IsSemigroupGroupPD F)
+    {t u : ℝ≥0} {v w : V} (ht : F (t + t, 0) = 0) : F (t + u, v - w) = 0 := by
+  simpa using hF.eq_zero_of_diagonal_eq_zero_left (p := (t, v)) (q := (u, w)) ht
+
+/-- If the right time-diagonal value is zero, then the corresponding BCR-kernel column entry is
+zero. -/
+theorem eq_zero_of_diagonal_eq_zero_right (hF : IsSemigroupGroupPD F) {p q : ℝ≥0 × V}
+    (hq : F (q.1 + q.1, 0) = 0) : F (p.1 + q.1, p.2 - q.2) = 0 := by
+  simpa using isPositiveDefiniteKernel_eq_zero_of_apply_self_eq_zero_right
+    hF.isPositiveDefiniteKernel (a := p) (b := q) (by simpa using hq)
+
+/-- Coordinate form of `eq_zero_of_diagonal_eq_zero_right`. -/
+theorem apply_eq_zero_of_diagonal_eq_zero_right (hF : IsSemigroupGroupPD F)
+    {t u : ℝ≥0} {v w : V} (hu : F (u + u, 0) = 0) : F (t + u, v - w) = 0 := by
+  simpa using hF.eq_zero_of_diagonal_eq_zero_right (p := (t, v)) (q := (u, w)) hu
+
+/-- If both time-diagonal entries are normalized to `1`, then the corresponding BCR-kernel entry
+has norm at most `1`. -/
+theorem norm_le_one_of_diagonal_eq_one (hF : IsSemigroupGroupPD F) {p q : ℝ≥0 × V}
+    (hp : F (p.1 + p.1, 0) = 1) (hq : F (q.1 + q.1, 0) = 1) :
+    ‖F (p.1 + q.1, p.2 - q.2)‖ ≤ 1 := by
+  simpa using isPositiveDefiniteKernel_norm_le_one_of_apply_self_eq_one
+    hF.isPositiveDefiniteKernel (a := p) (b := q) (by simpa using hp) (by simpa using hq)
+
+/-- Coordinate form of the normalized BCR-kernel bound. -/
+theorem norm_apply_le_one_of_diagonal_eq_one (hF : IsSemigroupGroupPD F)
+    {t u : ℝ≥0} {v w : V} (ht : F (t + t, 0) = 1) (hu : F (u + u, 0) = 1) :
+    ‖F (t + u, v - w)‖ ≤ 1 := by
+  simpa using hF.norm_le_one_of_diagonal_eq_one (p := (t, v)) (q := (u, w)) ht hu
+
+/-- At a fixed time, a semigroup-group positive-definite function is bounded by the real part of
+its zero-spatial value. -/
+theorem norm_apply_le_timeSlice_diagonal_re (hF : IsSemigroupGroupPD F) (t : ℝ≥0) (v : V) :
+    ‖F (t, v)‖ ≤ (F (t, 0)).re := by
+  refine le_of_sq_le_sq ?_ (by simpa [add_halves] using hF.diagonal_re_nonneg (t / 2))
+  have hsq := hF.normSq_apply_le (t / 2) (t / 2) v 0
+  simpa [Complex.normSq_eq_norm_sq, pow_two, add_halves] using hsq
+
+/-- If the fixed-time diagonal value is zero, then the whole fixed-time spatial slice is zero. -/
+theorem timeSlice_eq_zero_of_diagonal_eq_zero (hF : IsSemigroupGroupPD F)
+    {t : ℝ≥0} (ht : F (t, 0) = 0) (v : V) : F (t, v) = 0 := by
+  have ht' : F (t / 2 + t / 2, 0) = 0 := by simpa [add_halves] using ht
+  simpa [add_halves] using
+    hF.apply_eq_zero_of_diagonal_eq_zero_left (t := t / 2) (u := t / 2) (v := v) (w := 0) ht'
+
+/-- Normalized fixed-time slices are bounded by `1`. -/
+theorem norm_apply_le_one_of_timeSlice_diagonal_eq_one (hF : IsSemigroupGroupPD F)
+    {t : ℝ≥0} (ht : F (t, 0) = 1) (v : V) : ‖F (t, v)‖ ≤ 1 := by
+  have hbound := hF.norm_apply_le_timeSlice_diagonal_re t v
+  simpa [ht] using hbound
+
+end IsSemigroupGroupPD
+
+end TauCeti

--- a/TauCeti/Analysis/PositiveDefinite/SemigroupGroupBounds.lean
+++ b/TauCeti/Analysis/PositiveDefinite/SemigroupGroupBounds.lean
@@ -31,10 +31,6 @@ In the namespace `TauCeti.IsSemigroupGroupPD`:
   value kills the corresponding row or column of the BCR kernel.
 * `norm_le_one_of_diagonal_eq_one` and `norm_apply_le_one_of_diagonal_eq_one`: normalized diagonal
   entries bound the BCR kernel entry by `1`.
-* `norm_apply_le_timeSlice_diagonal_re`: the direct fixed-time bound
-  `‖F (t, v)‖ ≤ (F (t, 0)).re`.
-* `timeSlice_eq_zero_of_diagonal_eq_zero`: a zero fixed-time diagonal value kills the whole
-  fixed-time spatial slice.
 
 ## References
 
@@ -105,27 +101,6 @@ theorem norm_apply_le_one_of_diagonal_eq_one (hF : IsSemigroupGroupPD F)
     {t u : ℝ≥0} {v w : V} (ht : F (t + t, 0) = 1) (hu : F (u + u, 0) = 1) :
     ‖F (t + u, v - w)‖ ≤ 1 := by
   simpa using hF.norm_le_one_of_diagonal_eq_one (p := (t, v)) (q := (u, w)) ht hu
-
-/-- At a fixed time, a semigroup-group positive-definite function is bounded by the real part of
-its zero-spatial value. -/
-theorem norm_apply_le_timeSlice_diagonal_re (hF : IsSemigroupGroupPD F) (t : ℝ≥0) (v : V) :
-    ‖F (t, v)‖ ≤ (F (t, 0)).re := by
-  refine le_of_sq_le_sq ?_ (by simpa [add_halves] using hF.diagonal_re_nonneg (t / 2))
-  have hsq := hF.normSq_apply_le (t / 2) (t / 2) v 0
-  simpa [Complex.normSq_eq_norm_sq, pow_two, add_halves] using hsq
-
-/-- If the fixed-time diagonal value is zero, then the whole fixed-time spatial slice is zero. -/
-theorem timeSlice_eq_zero_of_diagonal_eq_zero (hF : IsSemigroupGroupPD F)
-    {t : ℝ≥0} (ht : F (t, 0) = 0) (v : V) : F (t, v) = 0 := by
-  have ht' : F (t / 2 + t / 2, 0) = 0 := by simpa [add_halves] using ht
-  simpa [add_halves] using
-    hF.apply_eq_zero_of_diagonal_eq_zero_left (t := t / 2) (u := t / 2) (v := v) (w := 0) ht'
-
-/-- Normalized fixed-time slices are bounded by `1`. -/
-theorem norm_apply_le_one_of_timeSlice_diagonal_eq_one (hF : IsSemigroupGroupPD F)
-    {t : ℝ≥0} (ht : F (t, 0) = 1) (v : V) : ‖F (t, v)‖ ≤ 1 := by
-  have hbound := hF.norm_apply_le_timeSlice_diagonal_re t v
-  simpa [ht] using hbound
 
 end IsSemigroupGroupPD
 

--- a/TauCeti/Analysis/PositiveDefinite/SemigroupGroupTimeSlice.lean
+++ b/TauCeti/Analysis/PositiveDefinite/SemigroupGroupTimeSlice.lean
@@ -34,6 +34,10 @@ positive-definite function on `[0,∞) × V` to spatial positive-definite functi
   nonnegative for arbitrary finite families.
 * `TauCeti.IsSemigroupGroupPD.timeSlice_normSq_le`: the fixed-time spatial Cauchy--Schwarz
   estimate.
+* `TauCeti.IsSemigroupGroupPD.norm_apply_le_timeSlice_diagonal_re`: the direct fixed-time bound
+  `‖F (t, v)‖ ≤ (F (t, 0)).re`.
+* `TauCeti.IsSemigroupGroupPD.timeSlice_eq_zero_of_timeSlice_diagonal_eq_zero`: a zero
+  fixed-time diagonal value kills the whole fixed-time spatial slice.
 * `TauCeti.IsSemigroupGroupPD.timeSlice_isPositiveDefinite`: the predicate form when the
   spatial involution is negation.
 * `TauCeti.IsSemigroupGroupPD.timeSlice_isPositiveDefiniteKernel_and_continuous`: packages
@@ -105,6 +109,26 @@ theorem timeSlice_sum_nonneg (hF : IsSemigroupGroupPD F) (t : ℝ≥0) {ι : Typ
 theorem timeSlice_normSq_le (hF : IsSemigroupGroupPD F) (t : ℝ≥0) (v w : V) :
     RCLike.normSq (F (t, v - w)) ≤ RCLike.re (F (t, 0)) * RCLike.re (F (t, 0)) := by
   simpa using isPositiveDefiniteKernel_normSq_le (hF.timeSlice_isPositiveDefiniteKernel t) v w
+
+/-- At a fixed time, a semigroup-group positive-definite function is bounded by the real part of
+its zero-spatial value. -/
+theorem norm_apply_le_timeSlice_diagonal_re (hF : IsSemigroupGroupPD F) (t : ℝ≥0) (v : V) :
+    ‖F (t, v)‖ ≤ (F (t, 0)).re := by
+  refine le_of_sq_le_sq ?_ (hF.timeSlice_diagonal_re_nonneg t)
+  have hsq := hF.timeSlice_normSq_le t v 0
+  simpa [Complex.normSq_eq_norm_sq, pow_two] using hsq
+
+/-- If the fixed-time diagonal value is zero, then the whole fixed-time spatial slice is zero. -/
+theorem timeSlice_eq_zero_of_timeSlice_diagonal_eq_zero (hF : IsSemigroupGroupPD F)
+    {t : ℝ≥0} (ht : F (t, 0) = 0) (v : V) : F (t, v) = 0 := by
+  simpa using isPositiveDefiniteKernel_eq_zero_of_apply_self_eq_zero_left
+    (hF.timeSlice_isPositiveDefiniteKernel t) (a := v) (b := 0) (by simpa using ht)
+
+/-- Normalized fixed-time slices are bounded by `1`. -/
+theorem norm_apply_le_one_of_timeSlice_diagonal_eq_one (hF : IsSemigroupGroupPD F)
+    {t : ℝ≥0} (ht : F (t, 0) = 1) (v : V) : ‖F (t, v)‖ ≤ 1 := by
+  have hbound := hF.norm_apply_le_timeSlice_diagonal_re t v
+  simpa [ht] using hbound
 
 /-- If the spatial type is equipped with the negation involution, then each fixed-time slice is a
 positive-definite function in the generic `IsPositiveDefinite` sense. -/


### PR DESCRIPTION
This PR adds the BCR Cauchy--Schwarz consumer API for semigroup-group positive-definite functions on `ℝ≥0 × V`: full kernel norm-square bounds, zero-diagonal row and column vanishing, normalized `‖·‖ ≤ 1` forms, and fixed-time slice norm/zero consequences. It advances `TauCetiRoadmap/OneParameterSemigroups/README.md`, Part C, Milestone 2, "BCR semigroup--Bochner", specifically the bounded continuous positive-definite-function API needed before the Laplace--Fourier representation. I chose this as the lowest-hanging distinct OneParameterSemigroups prerequisite after checking open and recently merged PRs: the Bernstein/Bochner representation lane is claimed or in flight, generic positive-definite kernels, BCR slices, normalization, pullbacks, limits, and the product construction already exist on `main`, while the direct BCR-wide Cauchy--Schwarz and normalized-kernel consumer forms were still absent.

No Mathlib infrastructure is vendored. The implementation reuses Tau Ceti's existing `IsSemigroupGroupPD.isPositiveDefiniteKernel` bridge and `KernelBounds` lemmas: `isPositiveDefiniteKernel_normSq_le`, `isPositiveDefiniteKernel_eq_zero_of_apply_self_eq_zero_left`, `isPositiveDefiniteKernel_eq_zero_of_apply_self_eq_zero_right`, and `isPositiveDefiniteKernel_norm_le_one_of_apply_self_eq_one`.

`lake exe cache get` completed with `No files to download` and `Already decompressed 8609 file(s)`. `lake build` completed with `Build completed successfully (4433 jobs).` `lake exe axioms` completed with `axioms: audited 6996 TauCeti declaration(s); all within the allowlist [propext, Classical.choice, Quot.sound].`

<!--tauceti-target:v1 {"focus":"OneParameterSemigroups","id":"semigroup-group-cauchy-schwarz"}-->

🤖 Prepared with Codex
