### PR TITLE
feat: add discriminant natAbs basis bounds

### DIFF
--- a/TauCeti/NumberTheory/EffectiveBounds/DiscriminantCorollaries.lean
+++ b/TauCeti/NumberTheory/EffectiveBounds/DiscriminantCorollaries.lean
@@ -1,0 +1,95 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+module
+
+public import TauCeti.NumberTheory.EffectiveBounds.Discriminant
+
+/-!
+# Consumer forms of the effective discriminant bound
+
+The EffectiveBounds roadmap's Layer 1 discriminant target gives the rational estimate
+
+`|NumberField.discr K| ≤ |Algebra.discr ℚ b|`
+
+for every `ℚ`-basis `b` of algebraic integers. Concrete trace-form computations usually evaluate
+the basis discriminant as an integer and then carry a natural-number bound, for example in the
+roadmap's `ℚ(i)` worked example. This file records those conversion forms so later estimates can
+reuse the migrated discriminant theorem without redoing coercion bookkeeping.
+
+## Main results
+
+* `TauCeti.NumberField.abs_discr_le_of_basis_isIntegral_of_abs_discr_le`: a monotone rational
+  bound from an external bound on the basis discriminant.
+* `TauCeti.NumberField.natAbs_discr_le_of_basis_isIntegral_of_discr_eq_int`: if the basis
+  discriminant computes to an integer `d`, then `(NumberField.discr K).natAbs ≤ d.natAbs`.
+* `TauCeti.NumberField.natAbs_discr_le_of_basis_isIntegral_of_discr_eq_int_of_natAbs_le`: the same
+  with a separate natural-number upper bound.
+* `TauCeti.NumberField.natAbs_discr_le_of_basis_isIntegral_of_discr_eq_nat`: the nonnegative
+  integer specialization.
+
+No formal code is vendored. These are direct API corollaries of the migrated Layer 1 bound
+`TauCeti.NumberField.abs_discr_le_of_basis_isIntegral`, whose source attribution is in
+`TauCeti/NumberTheory/EffectiveBounds/Discriminant.lean`.
+-/
+
+public section
+
+open Module
+
+namespace TauCeti.NumberField
+
+/-- If the discriminant of an algebraic-integer basis is bounded by `B`, then the number-field
+discriminant is bounded by the same rational number. -/
+theorem abs_discr_le_of_basis_isIntegral_of_abs_discr_le {K : Type*} [Field K] [NumberField K]
+    {ι : Type*} [Fintype ι] [DecidableEq ι] (b : Module.Basis ι ℚ K)
+    (hb : ∀ i, IsIntegral ℤ (b i)) {B : ℚ}
+    (hB : |Algebra.discr ℚ (b : ι → K)| ≤ B) :
+    |(NumberField.discr K : ℚ)| ≤ B :=
+  (abs_discr_le_of_basis_isIntegral b hb).trans hB
+
+/-- If the trace-form discriminant of an algebraic-integer basis computes to the integer `d`, then
+the natural absolute discriminant of the number field is at most `d.natAbs`. -/
+theorem natAbs_discr_le_of_basis_isIntegral_of_discr_eq_int {K : Type*} [Field K] [NumberField K]
+    {ι : Type*} [Fintype ι] [DecidableEq ι] (b : Module.Basis ι ℚ K)
+    (hb : ∀ i, IsIntegral ℤ (b i)) {d : ℤ}
+    (hdisc : Algebra.discr ℚ (b : ι → K) = (d : ℚ)) :
+    (NumberField.discr K).natAbs ≤ d.natAbs := by
+  have hq : |(NumberField.discr K : ℚ)| ≤ |(d : ℚ)| := by
+    simpa [hdisc] using abs_discr_le_of_basis_isIntegral b hb
+  rw [← Nat.cast_le (α := ℤ), Nat.cast_natAbs, Nat.cast_natAbs]
+  exact_mod_cast hq
+
+/-- If the trace-form discriminant of an algebraic-integer basis computes to the integer `d`, and
+`d.natAbs ≤ D`, then `(NumberField.discr K).natAbs ≤ D`. -/
+theorem natAbs_discr_le_of_basis_isIntegral_of_discr_eq_int_of_natAbs_le
+    {K : Type*} [Field K] [NumberField K] {ι : Type*} [Fintype ι] [DecidableEq ι]
+    (b : Module.Basis ι ℚ K) (hb : ∀ i, IsIntegral ℤ (b i)) {d : ℤ} {D : ℕ}
+    (hdisc : Algebra.discr ℚ (b : ι → K) = (d : ℚ)) (hd : d.natAbs ≤ D) :
+    (NumberField.discr K).natAbs ≤ D :=
+  (natAbs_discr_le_of_basis_isIntegral_of_discr_eq_int b hb hdisc).trans hd
+
+/-- If the trace-form discriminant of an algebraic-integer basis computes to the natural number
+`D`, then `(NumberField.discr K).natAbs ≤ D`. -/
+theorem natAbs_discr_le_of_basis_isIntegral_of_discr_eq_nat
+    {K : Type*} [Field K] [NumberField K] {ι : Type*} [Fintype ι] [DecidableEq ι]
+    (b : Module.Basis ι ℚ K) (hb : ∀ i, IsIntegral ℤ (b i)) {D : ℕ}
+    (hdisc : Algebra.discr ℚ (b : ι → K) = (D : ℚ)) :
+    (NumberField.discr K).natAbs ≤ D := by
+  exact natAbs_discr_le_of_basis_isIntegral_of_discr_eq_int_of_natAbs_le
+    b hb (d := (D : ℤ)) (by simpa using hdisc) (by simp)
+
+/-- If the trace-form discriminant of an algebraic-integer basis computes to an integer `d` with
+`d.natAbs ≤ D`, the same natural-number discriminant bound may be read as an integer absolute-value
+bound. -/
+theorem abs_discr_le_int_of_basis_isIntegral_of_discr_eq_int_of_natAbs_le
+    {K : Type*} [Field K] [NumberField K] {ι : Type*} [Fintype ι] [DecidableEq ι]
+    (b : Module.Basis ι ℚ K) (hb : ∀ i, IsIntegral ℤ (b i)) {d : ℤ} {D : ℕ}
+    (hdisc : Algebra.discr ℚ (b : ι → K) = (d : ℚ)) (hd : d.natAbs ≤ D) :
+    |NumberField.discr K| ≤ (D : ℤ) := by
+  rw [Int.abs_eq_natAbs]
+  exact_mod_cast
+    natAbs_discr_le_of_basis_isIntegral_of_discr_eq_int_of_natAbs_le b hb hdisc hd
+
+end TauCeti.NumberField


### PR DESCRIPTION
This PR adds consumer forms of the EffectiveBounds discriminant-from-basis theorem for concrete basis-discriminant computations: a monotone rational wrapper, integer-valued trace-form discriminant wrappers, natural-absolute-value bounds, and an integer absolute-value reading. Use these when a later worked example evaluates `Algebra.discr ℚ b` as an integer and needs a bound on `(NumberField.discr K).natAbs` without repeating coercion bookkeeping.

It advances `TauCetiRoadmap/EffectiveBounds/README.md`, Layer 1, the “Discriminant from a basis of integers” item `|d_F| ≤ |disc b|`, and supports the worked-example acceptance criterion that the discriminant bound recovers `|d_{ℚ(i)}| = 4` from the basis `{1, i}`. I chose this as the lowest-hanging distinct EffectiveBounds target after checking open and recently merged PRs: the core migrated discriminant theorem and quadratic square-root specialization already exist, and the recently merged EffectiveBounds PR covers class-number natAbs forms, while the general basis-discriminant natAbs consumer API was still absent.

No Mathlib infrastructure is vendored. The implementation reuses Tau Ceti's migrated `TauCeti.NumberField.abs_discr_le_of_basis_isIntegral`; the formal source attribution for that migrated Layer 1 bound is in `TauCeti/NumberTheory/EffectiveBounds/Discriminant.lean`, from `kim-em/erdos-unit-distance` at the roadmap-pinned commit.

`lake exe cache get` completed with `No files to download` and `Already decompressed 8609 file(s)`. `lake build` completed with `Build completed successfully (4455 jobs).` `lake exe axioms` completed with `axioms: audited 7250 TauCeti declaration(s); all within the allowlist [propext, Classical.choice, Quot.sound].`

<!--tauceti-target:v1 {"focus":"EffectiveBounds","id":"discriminant-basis-natabs-bounds"}-->

🤖 Prepared with Codex
