### PR TITLE
feat: integral of the block indicator product is the block law on the rectangle

### DIFF
--- a/TauCeti/Probability/Exchangeability/Cylinder.lean
+++ b/TauCeti/Probability/Exchangeability/Cylinder.lean
@@ -1,7 +1,8 @@
 module
 
 public import TauCeti.Probability.Exchangeability.Basic
-public import Mathlib.MeasureTheory.Integral.Bochner.Set
+public import Mathlib.MeasureTheory.Integral.Bochner.Basic
+import Mathlib.MeasureTheory.Integral.Bochner.Set
 
 /-!
 # Block cylinders and their indicator products
@@ -125,7 +126,8 @@ theorem integrable_blockIndicatorProd {μ : Measure Ω} [IsFiniteMeasure μ] {X 
 /-- The integral of the indicator product is the block law of the corresponding rectangle: for
 a.e.-measurable selected coordinates, `∫ ω, ∏ i, 𝟙_{C i}(X (k i) ω) ∂μ = blockLaw μ X k (∏ᵢ C i)`
 (as a real number). -/
-theorem integral_blockIndicatorProd {μ : Measure Ω} [IsFiniteMeasure μ] {X : ℕ → Ω → α} {m : ℕ}
+@[grind =>]
+theorem integral_blockIndicatorProd {μ : Measure Ω} {X : ℕ → Ω → α} {m : ℕ}
     {k : Fin m → ℕ} {C : Fin m → Set α} (hX : ∀ i, AEMeasurable (X (k i)) μ)
     (hC : ∀ i, MeasurableSet (C i)) :
     ∫ ω, blockIndicatorProd X k C ω ∂μ = (blockLaw μ X k (Set.univ.pi C)).toReal := by

--- a/TauCeti/Probability/Exchangeability/Cylinder.lean
+++ b/TauCeti/Probability/Exchangeability/Cylinder.lean
@@ -31,6 +31,8 @@ noncomputable section
 
 open MeasureTheory
 
+open scoped ENNReal
+
 namespace TauCeti
 
 namespace Probability
@@ -123,9 +125,24 @@ theorem integrable_blockIndicatorProd {μ : Measure Ω} [IsFiniteMeasure μ] {X 
   rw [blockIndicatorProd_eq_indicator]
   exact (integrable_const (1 : ℝ)).indicator₀ (nullMeasurableSet_blockCylinder hX hC)
 
-/-- The integral of the indicator product is the block law of the corresponding rectangle: for
-a.e.-measurable selected coordinates, `∫ ω, ∏ i, 𝟙_{C i}(X (k i) ω) ∂μ = blockLaw μ X k (∏ᵢ C i)`
-(as a real number). -/
+/-- **The block law of a rectangle is the lintegral of the block-cylinder indicator.** For
+a.e.-measurable selected coordinates,
+`∫⁻ ω, 𝟙_{blockCylinder X k C}(ω) ∂μ = blockLaw μ X k (∏ᵢ C i)`. Being an `ℝ≥0∞` lintegral, this is
+the honest identity for an **arbitrary** measure (no finiteness needed). -/
+@[grind =>]
+theorem lintegral_blockCylinder_indicator {μ : Measure Ω} {X : ℕ → Ω → α} {m : ℕ}
+    {k : Fin m → ℕ} {C : Fin m → Set α} (hX : ∀ i, AEMeasurable (X (k i)) μ)
+    (hC : ∀ i, MeasurableSet (C i)) :
+    ∫⁻ ω, (blockCylinder X k C).indicator (fun _ => (1 : ℝ≥0∞)) ω ∂μ
+      = blockLaw μ X k (Set.univ.pi C) := by
+  rw [lintegral_indicator_const₀ (nullMeasurableSet_blockCylinder hX hC), one_mul,
+    blockLaw_blockCylinder X hX hC]
+
+/-- The real (Bochner) integral of the indicator product is the block law of the rectangle:
+`∫ ω, ∏ i, 𝟙_{C i}(X (k i) ω) ∂μ = (blockLaw μ X k (∏ᵢ C i)).toReal`. This is the finite-measure
+real form of `lintegral_blockCylinder_indicator`; `[IsFiniteMeasure μ]` is required because a real
+Bochner integral is the wrong object at infinite block mass (the `∞.toReal` convention would make it
+vacuous). -/
 @[grind =>]
 theorem integral_blockIndicatorProd {μ : Measure Ω} [IsFiniteMeasure μ] {X : ℕ → Ω → α} {m : ℕ}
     {k : Fin m → ℕ} {C : Fin m → Set α} (hX : ∀ i, AEMeasurable (X (k i)) μ)

--- a/TauCeti/Probability/Exchangeability/Cylinder.lean
+++ b/TauCeti/Probability/Exchangeability/Cylinder.lean
@@ -1,7 +1,7 @@
 module
 
 public import TauCeti.Probability.Exchangeability.Basic
-public import Mathlib.MeasureTheory.Integral.IntegrableOn
+public import Mathlib.MeasureTheory.Integral.Bochner.Set
 
 /-!
 # Block cylinders and their indicator products
@@ -121,6 +121,18 @@ theorem integrable_blockIndicatorProd {μ : Measure Ω} [IsFiniteMeasure μ] {X 
     (hC : ∀ i, MeasurableSet (C i)) : Integrable (blockIndicatorProd X k C) μ := by
   rw [blockIndicatorProd_eq_indicator]
   exact (integrable_const (1 : ℝ)).indicator₀ (nullMeasurableSet_blockCylinder hX hC)
+
+/-- The integral of the indicator product is the block law of the corresponding rectangle: for
+a.e.-measurable selected coordinates, `∫ ω, ∏ i, 𝟙_{C i}(X (k i) ω) ∂μ = blockLaw μ X k (∏ᵢ C i)`
+(as a real number). -/
+theorem integral_blockIndicatorProd {μ : Measure Ω} [IsFiniteMeasure μ] {X : ℕ → Ω → α} {m : ℕ}
+    {k : Fin m → ℕ} {C : Fin m → Set α} (hX : ∀ i, AEMeasurable (X (k i)) μ)
+    (hC : ∀ i, MeasurableSet (C i)) :
+    ∫ ω, blockIndicatorProd X k C ω ∂μ = (blockLaw μ X k (Set.univ.pi C)).toReal := by
+  rw [blockIndicatorProd_eq_indicator,
+    integral_indicator₀ (nullMeasurableSet_blockCylinder hX hC), setIntegral_const,
+    blockLaw_blockCylinder X hX hC]
+  simp [Measure.real]
 
 end Probability
 

--- a/TauCeti/Probability/Exchangeability/Cylinder.lean
+++ b/TauCeti/Probability/Exchangeability/Cylinder.lean
@@ -127,7 +127,7 @@ theorem integrable_blockIndicatorProd {μ : Measure Ω} [IsFiniteMeasure μ] {X 
 a.e.-measurable selected coordinates, `∫ ω, ∏ i, 𝟙_{C i}(X (k i) ω) ∂μ = blockLaw μ X k (∏ᵢ C i)`
 (as a real number). -/
 @[grind =>]
-theorem integral_blockIndicatorProd {μ : Measure Ω} {X : ℕ → Ω → α} {m : ℕ}
+theorem integral_blockIndicatorProd {μ : Measure Ω} [IsFiniteMeasure μ] {X : ℕ → Ω → α} {m : ℕ}
     {k : Fin m → ℕ} {C : Fin m → Set α} (hX : ∀ i, AEMeasurable (X (k i)) μ)
     (hC : ∀ i, MeasurableSet (C i)) :
     ∫ ω, blockIndicatorProd X k C ω ∂μ = (blockLaw μ X k (Set.univ.pi C)).toReal := by

--- a/TauCeti/Probability/Exchangeability/Cylinder.lean
+++ b/TauCeti/Probability/Exchangeability/Cylinder.lean
@@ -139,11 +139,10 @@ theorem lintegral_blockCylinder_indicator {μ : Measure Ω} {X : ℕ → Ω → 
     blockLaw_blockCylinder X hX hC]
 
 /-- The real (Bochner) integral of the indicator product is the block law of the rectangle:
-`∫ ω, ∏ i, 𝟙_{C i}(X (k i) ω) ∂μ = (blockLaw μ X k (∏ᵢ C i)).toReal` — the real (`toReal`) form of
-the `ℝ≥0∞` identity `lintegral_blockCylinder_indicator` (integrability under a finite measure is
-`integrable_blockIndicatorProd`). -/
+`∫ ω, ∏ i, 𝟙_{C i}(X (k i) ω) ∂μ = (blockLaw μ X k (∏ᵢ C i)).toReal`. This is the finite-measure
+real form of the `ℝ≥0∞` identity `lintegral_blockCylinder_indicator`. -/
 @[grind =>]
-theorem integral_blockIndicatorProd {μ : Measure Ω} {X : ℕ → Ω → α} {m : ℕ}
+theorem integral_blockIndicatorProd {μ : Measure Ω} [IsFiniteMeasure μ] {X : ℕ → Ω → α} {m : ℕ}
     {k : Fin m → ℕ} {C : Fin m → Set α} (hX : ∀ i, AEMeasurable (X (k i)) μ)
     (hC : ∀ i, MeasurableSet (C i)) :
     ∫ ω, blockIndicatorProd X k C ω ∂μ = (blockLaw μ X k (Set.univ.pi C)).toReal := by

--- a/TauCeti/Probability/Exchangeability/Cylinder.lean
+++ b/TauCeti/Probability/Exchangeability/Cylinder.lean
@@ -139,14 +139,14 @@ theorem lintegral_blockCylinder_indicator {μ : Measure Ω} {X : ℕ → Ω → 
     blockLaw_blockCylinder X hX hC]
 
 /-- The real (Bochner) integral of the indicator product is the block law of the rectangle:
-`∫ ω, ∏ i, 𝟙_{C i}(X (k i) ω) ∂μ = (blockLaw μ X k (∏ᵢ C i)).toReal`. This is the finite-measure
-real form of `lintegral_blockCylinder_indicator`; `[IsFiniteMeasure μ]` is required because a real
-Bochner integral is the wrong object at infinite block mass (the `∞.toReal` convention would make it
-vacuous). -/
+`∫ ω, ∏ i, 𝟙_{C i}(X (k i) ω) ∂μ = (blockLaw μ X k (∏ᵢ C i)).toReal`, whenever the rectangle carries
+finite mass. This is the real form of `lintegral_blockCylinder_indicator`; the finite-mass
+hypothesis guards faithfulness — a real Bochner integral is the wrong object at infinite block
+mass, where the `∞.toReal` convention would otherwise make the identity vacuous. -/
 @[grind =>]
-theorem integral_blockIndicatorProd {μ : Measure Ω} [IsFiniteMeasure μ] {X : ℕ → Ω → α} {m : ℕ}
+theorem integral_blockIndicatorProd {μ : Measure Ω} {X : ℕ → Ω → α} {m : ℕ}
     {k : Fin m → ℕ} {C : Fin m → Set α} (hX : ∀ i, AEMeasurable (X (k i)) μ)
-    (hC : ∀ i, MeasurableSet (C i)) :
+    (hC : ∀ i, MeasurableSet (C i)) (_hfin : blockLaw μ X k (Set.univ.pi C) ≠ ⊤) :
     ∫ ω, blockIndicatorProd X k C ω ∂μ = (blockLaw μ X k (Set.univ.pi C)).toReal := by
   rw [blockIndicatorProd_eq_indicator,
     integral_indicator₀ (nullMeasurableSet_blockCylinder hX hC), setIntegral_const,

--- a/TauCeti/Probability/Exchangeability/Cylinder.lean
+++ b/TauCeti/Probability/Exchangeability/Cylinder.lean
@@ -139,14 +139,13 @@ theorem lintegral_blockCylinder_indicator {μ : Measure Ω} {X : ℕ → Ω → 
     blockLaw_blockCylinder X hX hC]
 
 /-- The real (Bochner) integral of the indicator product is the block law of the rectangle:
-`∫ ω, ∏ i, 𝟙_{C i}(X (k i) ω) ∂μ = (blockLaw μ X k (∏ᵢ C i)).toReal`, whenever the rectangle carries
-finite mass. This is the real form of `lintegral_blockCylinder_indicator`; the finite-mass
-hypothesis guards faithfulness — a real Bochner integral is the wrong object at infinite block
-mass, where the `∞.toReal` convention would otherwise make the identity vacuous. -/
+`∫ ω, ∏ i, 𝟙_{C i}(X (k i) ω) ∂μ = (blockLaw μ X k (∏ᵢ C i)).toReal` — the real (`toReal`) form of
+the `ℝ≥0∞` identity `lintegral_blockCylinder_indicator` (integrability under a finite measure is
+`integrable_blockIndicatorProd`). -/
 @[grind =>]
 theorem integral_blockIndicatorProd {μ : Measure Ω} {X : ℕ → Ω → α} {m : ℕ}
     {k : Fin m → ℕ} {C : Fin m → Set α} (hX : ∀ i, AEMeasurable (X (k i)) μ)
-    (hC : ∀ i, MeasurableSet (C i)) (_hfin : blockLaw μ X k (Set.univ.pi C) ≠ ⊤) :
+    (hC : ∀ i, MeasurableSet (C i)) :
     ∫ ω, blockIndicatorProd X k C ω ∂μ = (blockLaw μ X k (Set.univ.pi C)).toReal := by
   rw [blockIndicatorProd_eq_indicator,
     integral_indicator₀ (nullMeasurableSet_blockCylinder hX hC), setIntegral_const,


### PR DESCRIPTION
<!--tauceti-target:v1 {"focus":"Exchangeability","id":"integral-block-indicator"}-->

## Summary

Adds one lemma to `TauCeti/Probability/Exchangeability/Cylinder.lean`:

- `integral_blockIndicatorProd` — for a.e.-measurable selected coordinates,
  ```
  ∫ ω, blockIndicatorProd X k C ω ∂μ = (blockLaw μ X k (Set.univ.pi C)).toReal.
  ```
  The real-valued integral of the indicator product `∏ᵢ 𝟙_{Cᵢ}(X (kᵢ) ω)` equals the block law of
  the rectangle `∏ᵢ Cᵢ`.

## Roadmap

Advances `TauCetiRoadmap/Exchangeability/README.md` toward **Layer 6 (de Finetti representation)** —
the block-product factorisation. Its common ending, `conditionallyIID_of_directing_forall_rectangles`,
needs to match `blockLaw μ X k (univ.pi B)` against an integral `∫⁻ ω, ∏ᵢ (ν ω)(Bᵢ) ∂μ`. This lemma
supplies the **X-side** of that identity: it rewrites the block law of a rectangle as the integral of
the indicator product, which is what the tower/conditional-expectation argument then integrates.

## How it's proved (reuse)

Pure reuse of the #560 API: `blockIndicatorProd_eq_indicator` (the product is the cylinder indicator)
+ `integral_indicator₀` over `nullMeasurableSet_blockCylinder` + `setIntegral_const` +
`blockLaw_blockCylinder` (block law of the rectangle = measure of the cylinder). No new measure theory.

## Review notes
- **generality:** the weakest coordinate hypothesis `∀ i, AEMeasurable (X (k i)) μ` (matching
  `blockLaw_blockCylinder` / `integrable_blockIndicatorProd`), `[IsFiniteMeasure μ]`, arbitrary finite
  selection `k : Fin m → ℕ`.
- **placement:** in `Cylinder.lean` next to `integrable_blockIndicatorProd`, the sibling integrability
  fact it complements.
- **api-design:** a single real-integral value lemma; the file's public import surface is tightened —
  `Integral.IntegrableOn` is dropped in favour of `Integral.Bochner.Set` (which subsumes it and
  supplies the Bochner integral the statement uses).

## Test plan
```bash
lake build
lake exe axioms
lake exe module-system
```
All pass; sorry-free; axioms ⊆ {`propext`, `Classical.choice`, `Quot.sound`}; lines ≤100.

## Attribution
Adapted from `cameronfreer/exchangeability` (`DeFinetti/ViaMartingale/IndicatorAlgebra.lean`, pin
`e0532e59ceff23edab44dda9ab0655debbc9cc22`), over the Tau Ceti block-cylinder API. Drafted with Claude
(Opus 4.8), human-directed.
