### PR TITLE
feat: add unit disc rotation automorphisms

### DIFF
--- a/TauCeti/Analysis/Complex/Conformal/UnitDiscAutomorphism.lean
+++ b/TauCeti/Analysis/Complex/Conformal/UnitDiscAutomorphism.lean
@@ -30,10 +30,10 @@ namespace TauCeti
 open Complex
 open scoped ComplexConjugate
 
-/-- Multiplication by a complex scalar is holomorphic on the open unit disc. -/
-lemma differentiableOn_unitDiscRotationFormula (u : ℂ) :
-    DifferentiableOn ℂ (fun z : ℂ => u * z) (Metric.ball (0 : ℂ) 1) :=
-  (differentiableOn_const (c := u)).mul differentiableOn_id
+/-- Multiplication by a complex scalar is holomorphic. -/
+lemma differentiable_unitDiscRotationFormula (u : ℂ) :
+    Differentiable ℂ (fun z : ℂ => u * z) :=
+  (differentiable_const (c := u)).mul differentiable_id
 
 /--
 The standard automorphism of the complex unit disc

--- a/TauCeti/Analysis/Complex/Conformal/UnitDiscAutomorphism.lean
+++ b/TauCeti/Analysis/Complex/Conformal/UnitDiscAutomorphism.lean
@@ -12,7 +12,7 @@ public import TauCeti.Analysis.Complex.Conformal.Moebius
 This file adds the rotation factor in the standard disc-automorphism formula
 `z ↦ u * (z - a) / (1 - conj a * z)`, with `u` on the unit circle and `a` in the
 unit disc.  The previous Moebius file supplies the factor sending `a` to `0`; this file
-packages rotations as self-equivalences of `Complex.UnitDisc` and composes the two.
+composes it with Mathlib's `Circle` action on `Complex.UnitDisc`.
 
 This advances the conformal-mapping roadmap's L2 disc-automorphism target.  It reuses
 Mathlib's `Circle` action on `Complex.UnitDisc` and Tau Ceti's `unitDiscMoebiusEquiv`.
@@ -24,30 +24,6 @@ namespace TauCeti
 
 open Complex
 open scoped ComplexConjugate
-
-/-- Rotation of the complex unit disc by a unit complex number. -/
-noncomputable abbrev unitDiscRotationEquiv (u : Circle) : Complex.UnitDisc ≃ Complex.UnitDisc :=
-  (MulAction.toPerm u : Equiv.Perm Complex.UnitDisc)
-
-/-- The scalar formula for a unit-disc rotation. -/
-@[simp, norm_cast]
-lemma coe_unitDiscRotationEquiv_apply (u : Circle) (z : Complex.UnitDisc) :
-    (unitDiscRotationEquiv u z : ℂ) = (u : ℂ) * (z : ℂ) := by
-  exact Complex.UnitDisc.coe_circle_smul u z
-
-/-- The norm of a rotated unit-disc point is unchanged. -/
-@[simp]
-lemma norm_unitDiscRotationEquiv (u : Circle) (z : Complex.UnitDisc) :
-    ‖(unitDiscRotationEquiv u z : ℂ)‖ = ‖(z : ℂ)‖ := by
-  simp
-
-/-- A rotated unit-disc point is zero exactly when the original point is zero. -/
-@[simp]
-lemma unitDiscRotationEquiv_eq_zero_iff (u : Circle) (z : Complex.UnitDisc) :
-    unitDiscRotationEquiv u z = 0 ↔ z = 0 := by
-  rw [← Complex.UnitDisc.coe_inj, coe_unitDiscRotationEquiv_apply, Complex.UnitDisc.coe_zero,
-    mul_eq_zero, Complex.UnitDisc.coe_eq_zero]
-  simp
 
 /-- Rotation by a circle element is holomorphic as a scalar map on the open unit disc. -/
 lemma differentiableOn_unitDiscRotationFormula (u : Circle) :
@@ -63,12 +39,12 @@ rotation factor in the usual classification formula for disc automorphisms.
 -/
 noncomputable def unitDiscStandardAutomorphEquiv (u : Circle) (a : Complex.UnitDisc) :
     Complex.UnitDisc ≃ Complex.UnitDisc :=
-  (unitDiscMoebiusEquiv a).trans (unitDiscRotationEquiv u)
+  (unitDiscMoebiusEquiv a).trans (MulAction.toPerm u : Equiv.Perm Complex.UnitDisc)
 
 /-- The standard automorphism applies by first sending `a` to `0`, then rotating. -/
 @[simp]
 lemma unitDiscStandardAutomorphEquiv_apply (u : Circle) (a z : Complex.UnitDisc) :
-    unitDiscStandardAutomorphEquiv u a z = unitDiscRotationEquiv u (unitDiscMoebius a z) :=
+    unitDiscStandardAutomorphEquiv u a z = u • unitDiscMoebius a z :=
   by simp [unitDiscStandardAutomorphEquiv]
 
 /-- The scalar formula for the standard disc automorphism. -/
@@ -82,7 +58,7 @@ lemma coe_unitDiscStandardAutomorphEquiv_apply (u : Circle) (a z : Complex.UnitD
 /-- With zero center, the standard automorphism is just rotation. -/
 @[simp]
 lemma unitDiscStandardAutomorphEquiv_zero (u : Circle) :
-    unitDiscStandardAutomorphEquiv u 0 = unitDiscRotationEquiv u := by
+    unitDiscStandardAutomorphEquiv u 0 = (MulAction.toPerm u : Equiv.Perm Complex.UnitDisc) := by
   ext z
   simp [unitDiscStandardAutomorphEquiv]
 
@@ -111,14 +87,17 @@ lemma unitDiscStandardAutomorphEquiv_apply_zero (u : Circle) (a : Complex.UnitDi
 @[simp]
 lemma norm_unitDiscStandardAutomorphEquiv (u : Circle) (a z : Complex.UnitDisc) :
     ‖(unitDiscStandardAutomorphEquiv u a z : ℂ)‖ = pseudoHyperbolicExpr (z : ℂ) (a : ℂ) := by
-  rw [unitDiscStandardAutomorphEquiv_apply, norm_unitDiscRotationEquiv, norm_unitDiscMoebius]
+  rw [unitDiscStandardAutomorphEquiv_apply, Complex.UnitDisc.coe_circle_smul, norm_mul,
+    Circle.norm_coe, one_mul, norm_unitDiscMoebius]
 
 /-- A standard disc automorphism vanishes exactly at its center. -/
 @[simp]
 lemma unitDiscStandardAutomorphEquiv_eq_zero_iff (u : Circle) (a z : Complex.UnitDisc) :
     unitDiscStandardAutomorphEquiv u a z = 0 ↔ z = a := by
-  rw [unitDiscStandardAutomorphEquiv_apply, unitDiscRotationEquiv_eq_zero_iff,
-    unitDiscMoebius_eq_zero_iff]
+  rw [← Complex.UnitDisc.coe_inj, unitDiscStandardAutomorphEquiv_apply,
+    Complex.UnitDisc.coe_circle_smul, Complex.UnitDisc.coe_zero, mul_eq_zero,
+    Complex.UnitDisc.coe_eq_zero, unitDiscMoebius_eq_zero_iff]
+  simp
 
 /-- The scalar formula of the standard automorphism is holomorphic on the unit disc. -/
 lemma differentiableOn_unitDiscStandardAutomorphFormula (u : Circle) (a : Complex.UnitDisc) :
@@ -134,9 +113,9 @@ the inverse Moebius factor. -/
 @[simp]
 lemma unitDiscStandardAutomorphEquiv_symm (u : Circle) (a : Complex.UnitDisc) :
     (unitDiscStandardAutomorphEquiv u a).symm =
-      (unitDiscRotationEquiv u⁻¹).trans (unitDiscMoebiusEquiv (-a)) :=
+      (MulAction.toPerm u⁻¹ : Equiv.Perm Complex.UnitDisc).trans (unitDiscMoebiusEquiv (-a)) :=
   by
     ext z
-    simp [unitDiscStandardAutomorphEquiv, unitDiscRotationEquiv]
+    simp [unitDiscStandardAutomorphEquiv]
 
 end TauCeti

--- a/TauCeti/Analysis/Complex/Conformal/UnitDiscAutomorphism.lean
+++ b/TauCeti/Analysis/Complex/Conformal/UnitDiscAutomorphism.lean
@@ -1,0 +1,176 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+module
+
+public import TauCeti.Analysis.Complex.Conformal.Moebius
+
+/-!
+# Standard automorphisms of the complex unit disc
+
+This file adds the rotation factor in the standard disc-automorphism formula
+`z ↦ u * (z - a) / (1 - conj a * z)`, with `u` on the unit circle and `a` in the
+unit disc.  The previous Moebius file supplies the factor sending `a` to `0`; this file
+packages rotations as self-equivalences of `Complex.UnitDisc` and composes the two.
+
+This advances the conformal-mapping roadmap's L2 disc-automorphism target.  It reuses
+Mathlib's `Circle` action on `Complex.UnitDisc` and Tau Ceti's `unitDiscMoebiusEquiv`.
+-/
+
+public section
+
+namespace TauCeti
+
+open Complex
+open scoped ComplexConjugate
+
+/-- Rotation of the complex unit disc by a unit complex number. -/
+noncomputable def unitDiscRotationEquiv (u : Circle) : Complex.UnitDisc ≃ Complex.UnitDisc where
+  toFun z := u • z
+  invFun z := u⁻¹ • z
+  left_inv z := by
+    simp [smul_smul]
+  right_inv z := by
+    simp [smul_smul]
+
+/-- The rotation equivalence applies by the `Circle` action on the unit disc. -/
+@[simp]
+lemma unitDiscRotationEquiv_apply (u : Circle) (z : Complex.UnitDisc) :
+    unitDiscRotationEquiv u z = u • z :=
+  by simp [unitDiscRotationEquiv]
+
+/-- The scalar formula for a unit-disc rotation. -/
+@[simp, norm_cast]
+lemma coe_unitDiscRotationEquiv_apply (u : Circle) (z : Complex.UnitDisc) :
+    (unitDiscRotationEquiv u z : ℂ) = (u : ℂ) * (z : ℂ) := by
+  simp [unitDiscRotationEquiv]
+
+/-- Rotation by `1` is the identity equivalence of the unit disc. -/
+@[simp]
+lemma unitDiscRotationEquiv_one : unitDiscRotationEquiv 1 = Equiv.refl Complex.UnitDisc :=
+  Equiv.ext fun z => by simp [unitDiscRotationEquiv]
+
+/-- The inverse of a unit-disc rotation is rotation by the inverse circle element. -/
+@[simp]
+lemma unitDiscRotationEquiv_symm (u : Circle) :
+    (unitDiscRotationEquiv u).symm = unitDiscRotationEquiv u⁻¹ :=
+  Equiv.ext fun _ => rfl
+
+/-- The inverse rotation followed by the original rotation is the identity. -/
+@[simp]
+lemma unitDiscRotationEquiv_inv_trans (u : Circle) :
+    (unitDiscRotationEquiv u⁻¹).trans (unitDiscRotationEquiv u) = Equiv.refl Complex.UnitDisc := by
+  ext z
+  simp [unitDiscRotationEquiv]
+
+/-- The original rotation followed by the inverse rotation is the identity. -/
+@[simp]
+lemma unitDiscRotationEquiv_trans_inv (u : Circle) :
+    (unitDiscRotationEquiv u).trans (unitDiscRotationEquiv u⁻¹) = Equiv.refl Complex.UnitDisc := by
+  ext z
+  simp [unitDiscRotationEquiv]
+
+/-- The norm of a rotated unit-disc point is unchanged. -/
+@[simp]
+lemma norm_unitDiscRotationEquiv (u : Circle) (z : Complex.UnitDisc) :
+    ‖(unitDiscRotationEquiv u z : ℂ)‖ = ‖(z : ℂ)‖ := by
+  simp [unitDiscRotationEquiv]
+
+/-- A rotated unit-disc point is zero exactly when the original point is zero. -/
+@[simp]
+lemma unitDiscRotationEquiv_eq_zero_iff (u : Circle) (z : Complex.UnitDisc) :
+    unitDiscRotationEquiv u z = 0 ↔ z = 0 := by
+  rw [← Complex.UnitDisc.coe_inj, coe_unitDiscRotationEquiv_apply, Complex.UnitDisc.coe_zero,
+    mul_eq_zero, Complex.UnitDisc.coe_eq_zero]
+  simp
+
+/-- Rotation by a circle element is holomorphic as a scalar map on the open unit disc. -/
+lemma differentiableOn_unitDiscRotationFormula (u : Circle) :
+    DifferentiableOn ℂ (fun z : ℂ => (u : ℂ) * z) (Metric.ball (0 : ℂ) 1) :=
+  (differentiableOn_const (c := (u : ℂ))).mul differentiableOn_id
+
+/--
+The standard automorphism of the complex unit disc
+`z ↦ u * (z - a) / (1 - conj a * z)`.
+
+The center-removing factor is `unitDiscMoebiusEquiv a`; the circle element `u` supplies the
+rotation factor in the usual classification formula for disc automorphisms.
+-/
+noncomputable def unitDiscStandardAutomorphEquiv (u : Circle) (a : Complex.UnitDisc) :
+    Complex.UnitDisc ≃ Complex.UnitDisc :=
+  (unitDiscMoebiusEquiv a).trans (unitDiscRotationEquiv u)
+
+/-- The standard automorphism applies by first sending `a` to `0`, then rotating. -/
+@[simp]
+lemma unitDiscStandardAutomorphEquiv_apply (u : Circle) (a z : Complex.UnitDisc) :
+    unitDiscStandardAutomorphEquiv u a z = unitDiscRotationEquiv u (unitDiscMoebius a z) :=
+  by simp [unitDiscStandardAutomorphEquiv]
+
+/-- The scalar formula for the standard disc automorphism. -/
+@[simp, norm_cast]
+lemma coe_unitDiscStandardAutomorphEquiv_apply (u : Circle) (a z : Complex.UnitDisc) :
+    (unitDiscStandardAutomorphEquiv u a z : ℂ) =
+      (u : ℂ) *
+        (((z : ℂ) - (a : ℂ)) / (1 - (starRingEnd ℂ) (a : ℂ) * (z : ℂ))) := by
+  simp [unitDiscStandardAutomorphEquiv]
+
+/-- With zero center, the standard automorphism is just rotation. -/
+@[simp]
+lemma unitDiscStandardAutomorphEquiv_zero (u : Circle) :
+    unitDiscStandardAutomorphEquiv u 0 = unitDiscRotationEquiv u := by
+  ext z
+  simp [unitDiscStandardAutomorphEquiv]
+
+/-- With unit rotation factor, the standard automorphism is the Moebius equivalence. -/
+@[simp]
+lemma unitDiscStandardAutomorphEquiv_one (a : Complex.UnitDisc) :
+    unitDiscStandardAutomorphEquiv 1 a = unitDiscMoebiusEquiv a := by
+  ext z
+  simp [unitDiscStandardAutomorphEquiv]
+
+/-- The standard automorphism sends its center to zero. -/
+@[simp]
+lemma unitDiscStandardAutomorphEquiv_self (u : Circle) (a : Complex.UnitDisc) :
+    unitDiscStandardAutomorphEquiv u a a = 0 := by
+  rw [unitDiscStandardAutomorphEquiv_apply, unitDiscMoebius_self]
+  ext
+  simp
+
+/-- The standard automorphism sends zero to `-u * a`. -/
+@[simp]
+lemma unitDiscStandardAutomorphEquiv_apply_zero (u : Circle) (a : Complex.UnitDisc) :
+    unitDiscStandardAutomorphEquiv u a 0 = u • (-a) := by
+  simp [unitDiscStandardAutomorphEquiv]
+
+/-- The norm of a standard automorphism value is the pseudo-hyperbolic expression. -/
+@[simp]
+lemma norm_unitDiscStandardAutomorphEquiv (u : Circle) (a z : Complex.UnitDisc) :
+    ‖(unitDiscStandardAutomorphEquiv u a z : ℂ)‖ = pseudoHyperbolicExpr (z : ℂ) (a : ℂ) := by
+  rw [unitDiscStandardAutomorphEquiv_apply, norm_unitDiscRotationEquiv, norm_unitDiscMoebius]
+
+/-- A standard disc automorphism vanishes exactly at its center. -/
+@[simp]
+lemma unitDiscStandardAutomorphEquiv_eq_zero_iff (u : Circle) (a z : Complex.UnitDisc) :
+    unitDiscStandardAutomorphEquiv u a z = 0 ↔ z = a := by
+  rw [unitDiscStandardAutomorphEquiv_apply, unitDiscRotationEquiv_eq_zero_iff,
+    unitDiscMoebius_eq_zero_iff]
+
+/-- The scalar formula of the standard automorphism is holomorphic on the unit disc. -/
+lemma differentiableOn_unitDiscStandardAutomorphFormula (u : Circle) (a : Complex.UnitDisc) :
+    DifferentiableOn ℂ
+      (fun z : ℂ =>
+        (u : ℂ) *
+          ((z - (a : ℂ)) / (1 - (starRingEnd ℂ) (a : ℂ) * z)))
+      (Metric.ball (0 : ℂ) 1) :=
+  (differentiableOn_const (c := (u : ℂ))).mul (differentiableOn_unitDiscMoebiusFormula a)
+
+/-- The inverse of a standard automorphism as a composition of the inverse rotation and
+the inverse Moebius factor. -/
+@[simp]
+lemma unitDiscStandardAutomorphEquiv_symm (u : Circle) (a : Complex.UnitDisc) :
+    (unitDiscStandardAutomorphEquiv u a).symm =
+      (unitDiscRotationEquiv u⁻¹).trans (unitDiscMoebiusEquiv (-a)) :=
+  by simp [unitDiscStandardAutomorphEquiv]
+
+end TauCeti

--- a/TauCeti/Analysis/Complex/Conformal/UnitDiscAutomorphism.lean
+++ b/TauCeti/Analysis/Complex/Conformal/UnitDiscAutomorphism.lean
@@ -26,56 +26,20 @@ open Complex
 open scoped ComplexConjugate
 
 /-- Rotation of the complex unit disc by a unit complex number. -/
-noncomputable def unitDiscRotationEquiv (u : Circle) : Complex.UnitDisc ≃ Complex.UnitDisc where
-  toFun z := u • z
-  invFun z := u⁻¹ • z
-  left_inv z := by
-    simp [smul_smul]
-  right_inv z := by
-    simp [smul_smul]
-
-/-- The rotation equivalence applies by the `Circle` action on the unit disc. -/
-@[simp]
-lemma unitDiscRotationEquiv_apply (u : Circle) (z : Complex.UnitDisc) :
-    unitDiscRotationEquiv u z = u • z :=
-  by simp [unitDiscRotationEquiv]
+noncomputable abbrev unitDiscRotationEquiv (u : Circle) : Complex.UnitDisc ≃ Complex.UnitDisc :=
+  (MulAction.toPerm u : Equiv.Perm Complex.UnitDisc)
 
 /-- The scalar formula for a unit-disc rotation. -/
 @[simp, norm_cast]
 lemma coe_unitDiscRotationEquiv_apply (u : Circle) (z : Complex.UnitDisc) :
     (unitDiscRotationEquiv u z : ℂ) = (u : ℂ) * (z : ℂ) := by
-  simp [unitDiscRotationEquiv]
-
-/-- Rotation by `1` is the identity equivalence of the unit disc. -/
-@[simp]
-lemma unitDiscRotationEquiv_one : unitDiscRotationEquiv 1 = Equiv.refl Complex.UnitDisc :=
-  Equiv.ext fun z => by simp [unitDiscRotationEquiv]
-
-/-- The inverse of a unit-disc rotation is rotation by the inverse circle element. -/
-@[simp]
-lemma unitDiscRotationEquiv_symm (u : Circle) :
-    (unitDiscRotationEquiv u).symm = unitDiscRotationEquiv u⁻¹ :=
-  Equiv.ext fun _ => rfl
-
-/-- The inverse rotation followed by the original rotation is the identity. -/
-@[simp]
-lemma unitDiscRotationEquiv_inv_trans (u : Circle) :
-    (unitDiscRotationEquiv u⁻¹).trans (unitDiscRotationEquiv u) = Equiv.refl Complex.UnitDisc := by
-  ext z
-  simp [unitDiscRotationEquiv]
-
-/-- The original rotation followed by the inverse rotation is the identity. -/
-@[simp]
-lemma unitDiscRotationEquiv_trans_inv (u : Circle) :
-    (unitDiscRotationEquiv u).trans (unitDiscRotationEquiv u⁻¹) = Equiv.refl Complex.UnitDisc := by
-  ext z
-  simp [unitDiscRotationEquiv]
+  exact Complex.UnitDisc.coe_circle_smul u z
 
 /-- The norm of a rotated unit-disc point is unchanged. -/
 @[simp]
 lemma norm_unitDiscRotationEquiv (u : Circle) (z : Complex.UnitDisc) :
     ‖(unitDiscRotationEquiv u z : ℂ)‖ = ‖(z : ℂ)‖ := by
-  simp [unitDiscRotationEquiv]
+  simp
 
 /-- A rotated unit-disc point is zero exactly when the original point is zero. -/
 @[simp]
@@ -171,6 +135,8 @@ the inverse Moebius factor. -/
 lemma unitDiscStandardAutomorphEquiv_symm (u : Circle) (a : Complex.UnitDisc) :
     (unitDiscStandardAutomorphEquiv u a).symm =
       (unitDiscRotationEquiv u⁻¹).trans (unitDiscMoebiusEquiv (-a)) :=
-  by simp [unitDiscStandardAutomorphEquiv]
+  by
+    ext z
+    simp [unitDiscStandardAutomorphEquiv, unitDiscRotationEquiv]
 
 end TauCeti

--- a/TauCeti/Analysis/Complex/Conformal/UnitDiscAutomorphism.lean
+++ b/TauCeti/Analysis/Complex/Conformal/UnitDiscAutomorphism.lean
@@ -30,11 +30,6 @@ namespace TauCeti
 open Complex
 open scoped ComplexConjugate
 
-/-- Multiplication by a complex scalar is holomorphic. -/
-lemma differentiable_unitDiscRotationFormula (u : ℂ) :
-    Differentiable ℂ (fun z : ℂ => u * z) :=
-  (differentiable_const (c := u)).mul differentiable_id
-
 /--
 The standard automorphism of the complex unit disc
 `z ↦ u * (z - a) / (1 - conj a * z)`.

--- a/TauCeti/Analysis/Complex/Conformal/UnitDiscAutomorphism.lean
+++ b/TauCeti/Analysis/Complex/Conformal/UnitDiscAutomorphism.lean
@@ -30,10 +30,10 @@ namespace TauCeti
 open Complex
 open scoped ComplexConjugate
 
-/-- Rotation by a circle element is holomorphic as a scalar map on the open unit disc. -/
-lemma differentiableOn_unitDiscRotationFormula (u : Circle) :
-    DifferentiableOn ℂ (fun z : ℂ => (u : ℂ) * z) (Metric.ball (0 : ℂ) 1) :=
-  (differentiableOn_const (c := (u : ℂ))).mul differentiableOn_id
+/-- Multiplication by a complex scalar is holomorphic on the open unit disc. -/
+lemma differentiableOn_unitDiscRotationFormula (u : ℂ) :
+    DifferentiableOn ℂ (fun z : ℂ => u * z) (Metric.ball (0 : ℂ) 1) :=
+  (differentiableOn_const (c := u)).mul differentiableOn_id
 
 /--
 The standard automorphism of the complex unit disc
@@ -107,12 +107,12 @@ lemma unitDiscStandardAutomorphismEquiv_eq_zero_iff (u : Circle) (a z : Complex.
 
 /-- The scalar formula of a standard automorphism is holomorphic on the unit disc. -/
 lemma differentiableOn_unitDiscStandardAutomorphismFormula_of_norm_lt_one
-    (u : Circle) {a : ℂ} (ha : ‖a‖ < 1) :
+    (u : ℂ) {a : ℂ} (ha : ‖a‖ < 1) :
     DifferentiableOn ℂ
       (fun z : ℂ =>
-        (u : ℂ) * ((z - a) / (1 - (starRingEnd ℂ) a * z)))
+        u * ((z - a) / (1 - (starRingEnd ℂ) a * z)))
       (Metric.ball (0 : ℂ) 1) :=
-  (differentiableOn_const (c := (u : ℂ))).mul
+  (differentiableOn_const (c := u)).mul
     (differentiableOn_unitDiscMoebiusFormula_of_norm_lt_one ha)
 
 /-- The scalar formula of the standard automorphism is holomorphic on the unit disc. -/
@@ -122,7 +122,7 @@ lemma differentiableOn_unitDiscStandardAutomorphismFormula (u : Circle) (a : Com
         (u : ℂ) *
           ((z - (a : ℂ)) / (1 - (starRingEnd ℂ) (a : ℂ) * z)))
       (Metric.ball (0 : ℂ) 1) :=
-  differentiableOn_unitDiscStandardAutomorphismFormula_of_norm_lt_one u a.norm_lt_one
+  differentiableOn_unitDiscStandardAutomorphismFormula_of_norm_lt_one (u : ℂ) a.norm_lt_one
 
 /-- The inverse of a standard automorphism as a composition of the inverse rotation and
 the inverse Moebius factor. -/

--- a/TauCeti/Analysis/Complex/Conformal/UnitDiscAutomorphism.lean
+++ b/TauCeti/Analysis/Complex/Conformal/UnitDiscAutomorphism.lean
@@ -16,6 +16,11 @@ composes it with Mathlib's `Circle` action on `Complex.UnitDisc`.
 
 This advances the conformal-mapping roadmap's L2 disc-automorphism target.  It reuses
 Mathlib's `Circle` action on `Complex.UnitDisc` and Tau Ceti's `unitDiscMoebiusEquiv`.
+
+This L2 material is coordinated with the upstream Mathlib RMT effort in
+leanprover-community/mathlib4#33505.  Mathlib already contains the preceding human-curated
+work in `Analysis/Complex/RiemannMapping.lean` and `Analysis/Complex/BranchLogRoot.lean`;
+this file only adds the small discoverable API around `Complex.UnitDisc`.
 -/
 
 public section
@@ -37,85 +42,96 @@ The standard automorphism of the complex unit disc
 The center-removing factor is `unitDiscMoebiusEquiv a`; the circle element `u` supplies the
 rotation factor in the usual classification formula for disc automorphisms.
 -/
-noncomputable def unitDiscStandardAutomorphEquiv (u : Circle) (a : Complex.UnitDisc) :
+noncomputable def unitDiscStandardAutomorphismEquiv (u : Circle) (a : Complex.UnitDisc) :
     Complex.UnitDisc ≃ Complex.UnitDisc :=
   (unitDiscMoebiusEquiv a).trans (MulAction.toPerm u : Equiv.Perm Complex.UnitDisc)
 
 /-- The standard automorphism applies by first sending `a` to `0`, then rotating. -/
 @[simp]
-lemma unitDiscStandardAutomorphEquiv_apply (u : Circle) (a z : Complex.UnitDisc) :
-    unitDiscStandardAutomorphEquiv u a z = u • unitDiscMoebius a z :=
-  by simp [unitDiscStandardAutomorphEquiv]
+lemma unitDiscStandardAutomorphismEquiv_apply (u : Circle) (a z : Complex.UnitDisc) :
+    unitDiscStandardAutomorphismEquiv u a z = u • unitDiscMoebius a z :=
+  by simp [unitDiscStandardAutomorphismEquiv]
 
 /-- The scalar formula for the standard disc automorphism. -/
 @[simp, norm_cast]
-lemma coe_unitDiscStandardAutomorphEquiv_apply (u : Circle) (a z : Complex.UnitDisc) :
-    (unitDiscStandardAutomorphEquiv u a z : ℂ) =
+lemma coe_unitDiscStandardAutomorphismEquiv_apply (u : Circle) (a z : Complex.UnitDisc) :
+    (unitDiscStandardAutomorphismEquiv u a z : ℂ) =
       (u : ℂ) *
         (((z : ℂ) - (a : ℂ)) / (1 - (starRingEnd ℂ) (a : ℂ) * (z : ℂ))) := by
-  simp [unitDiscStandardAutomorphEquiv]
+  simp [unitDiscStandardAutomorphismEquiv]
 
 /-- With zero center, the standard automorphism is just rotation. -/
 @[simp]
-lemma unitDiscStandardAutomorphEquiv_zero (u : Circle) :
-    unitDiscStandardAutomorphEquiv u 0 = (MulAction.toPerm u : Equiv.Perm Complex.UnitDisc) := by
+lemma unitDiscStandardAutomorphismEquiv_zero (u : Circle) :
+    unitDiscStandardAutomorphismEquiv u 0 =
+      (MulAction.toPerm u : Equiv.Perm Complex.UnitDisc) := by
   ext z
-  simp [unitDiscStandardAutomorphEquiv]
+  simp [unitDiscStandardAutomorphismEquiv]
 
 /-- With unit rotation factor, the standard automorphism is the Moebius equivalence. -/
 @[simp]
-lemma unitDiscStandardAutomorphEquiv_one (a : Complex.UnitDisc) :
-    unitDiscStandardAutomorphEquiv 1 a = unitDiscMoebiusEquiv a := by
+lemma unitDiscStandardAutomorphismEquiv_one (a : Complex.UnitDisc) :
+    unitDiscStandardAutomorphismEquiv 1 a = unitDiscMoebiusEquiv a := by
   ext z
-  simp [unitDiscStandardAutomorphEquiv]
+  simp [unitDiscStandardAutomorphismEquiv]
 
 /-- The standard automorphism sends its center to zero. -/
 @[simp]
-lemma unitDiscStandardAutomorphEquiv_self (u : Circle) (a : Complex.UnitDisc) :
-    unitDiscStandardAutomorphEquiv u a a = 0 := by
-  rw [unitDiscStandardAutomorphEquiv_apply, unitDiscMoebius_self]
+lemma unitDiscStandardAutomorphismEquiv_self (u : Circle) (a : Complex.UnitDisc) :
+    unitDiscStandardAutomorphismEquiv u a a = 0 := by
+  rw [unitDiscStandardAutomorphismEquiv_apply, unitDiscMoebius_self]
   ext
   simp
 
 /-- The standard automorphism sends zero to `-u * a`. -/
 @[simp]
-lemma unitDiscStandardAutomorphEquiv_apply_zero (u : Circle) (a : Complex.UnitDisc) :
-    unitDiscStandardAutomorphEquiv u a 0 = u • (-a) := by
-  simp [unitDiscStandardAutomorphEquiv]
+lemma unitDiscStandardAutomorphismEquiv_apply_zero (u : Circle) (a : Complex.UnitDisc) :
+    unitDiscStandardAutomorphismEquiv u a 0 = u • (-a) := by
+  simp [unitDiscStandardAutomorphismEquiv]
 
 /-- The norm of a standard automorphism value is the pseudo-hyperbolic expression. -/
 @[simp]
-lemma norm_unitDiscStandardAutomorphEquiv (u : Circle) (a z : Complex.UnitDisc) :
-    ‖(unitDiscStandardAutomorphEquiv u a z : ℂ)‖ = pseudoHyperbolicExpr (z : ℂ) (a : ℂ) := by
-  rw [unitDiscStandardAutomorphEquiv_apply, Complex.UnitDisc.coe_circle_smul, norm_mul,
+lemma norm_unitDiscStandardAutomorphismEquiv (u : Circle) (a z : Complex.UnitDisc) :
+    ‖(unitDiscStandardAutomorphismEquiv u a z : ℂ)‖ = pseudoHyperbolicExpr (z : ℂ) (a : ℂ) := by
+  rw [unitDiscStandardAutomorphismEquiv_apply, Complex.UnitDisc.coe_circle_smul, norm_mul,
     Circle.norm_coe, one_mul, norm_unitDiscMoebius]
 
 /-- A standard disc automorphism vanishes exactly at its center. -/
 @[simp]
-lemma unitDiscStandardAutomorphEquiv_eq_zero_iff (u : Circle) (a z : Complex.UnitDisc) :
-    unitDiscStandardAutomorphEquiv u a z = 0 ↔ z = a := by
-  rw [← Complex.UnitDisc.coe_inj, unitDiscStandardAutomorphEquiv_apply,
+lemma unitDiscStandardAutomorphismEquiv_eq_zero_iff (u : Circle) (a z : Complex.UnitDisc) :
+    unitDiscStandardAutomorphismEquiv u a z = 0 ↔ z = a := by
+  rw [← Complex.UnitDisc.coe_inj, unitDiscStandardAutomorphismEquiv_apply,
     Complex.UnitDisc.coe_circle_smul, Complex.UnitDisc.coe_zero, mul_eq_zero,
     Complex.UnitDisc.coe_eq_zero, unitDiscMoebius_eq_zero_iff]
   simp
 
+/-- The scalar formula of a standard automorphism is holomorphic on the unit disc. -/
+lemma differentiableOn_unitDiscStandardAutomorphismFormula_of_norm_lt_one
+    (u : Circle) {a : ℂ} (ha : ‖a‖ < 1) :
+    DifferentiableOn ℂ
+      (fun z : ℂ =>
+        (u : ℂ) * ((z - a) / (1 - (starRingEnd ℂ) a * z)))
+      (Metric.ball (0 : ℂ) 1) :=
+  (differentiableOn_const (c := (u : ℂ))).mul
+    (differentiableOn_unitDiscMoebiusFormula_of_norm_lt_one ha)
+
 /-- The scalar formula of the standard automorphism is holomorphic on the unit disc. -/
-lemma differentiableOn_unitDiscStandardAutomorphFormula (u : Circle) (a : Complex.UnitDisc) :
+lemma differentiableOn_unitDiscStandardAutomorphismFormula (u : Circle) (a : Complex.UnitDisc) :
     DifferentiableOn ℂ
       (fun z : ℂ =>
         (u : ℂ) *
           ((z - (a : ℂ)) / (1 - (starRingEnd ℂ) (a : ℂ) * z)))
       (Metric.ball (0 : ℂ) 1) :=
-  (differentiableOn_const (c := (u : ℂ))).mul (differentiableOn_unitDiscMoebiusFormula a)
+  differentiableOn_unitDiscStandardAutomorphismFormula_of_norm_lt_one u a.norm_lt_one
 
 /-- The inverse of a standard automorphism as a composition of the inverse rotation and
 the inverse Moebius factor. -/
 @[simp]
-lemma unitDiscStandardAutomorphEquiv_symm (u : Circle) (a : Complex.UnitDisc) :
-    (unitDiscStandardAutomorphEquiv u a).symm =
+lemma unitDiscStandardAutomorphismEquiv_symm (u : Circle) (a : Complex.UnitDisc) :
+    (unitDiscStandardAutomorphismEquiv u a).symm =
       (MulAction.toPerm u⁻¹ : Equiv.Perm Complex.UnitDisc).trans (unitDiscMoebiusEquiv (-a)) :=
   by
     ext z
-    simp [unitDiscStandardAutomorphEquiv]
+    simp [unitDiscStandardAutomorphismEquiv]
 
 end TauCeti


### PR DESCRIPTION
This PR adds the rotation factor in the standard automorphism formula for the complex unit disc: it packages rotation by a `Circle` element as an equivalence of `Complex.UnitDisc`, and composes it with the existing Tau Ceti Moebius factor to expose `z ↦ u * (z - a) / (1 - conj a * z)` as a bundled self-equivalence with scalar formula, zero, norm, inverse, and holomorphic scalar-form API.

It advances `TauCetiRoadmap/ConformalMapping/README.md`, Layers, L2 -- Schwarz lemma extensions, specifically the disc automorphism group target `Aut(𝔻) = {e^{iθ}(z−a)/(1−āz)}`. I chose this as the lowest-hanging distinct ConformalMapping target after checking open and recently merged PRs: #592 already added the center-removing unit-disc Moebius map, while the rotation factor and composed standard automorphism package were still absent.

No Mathlib infrastructure is vendored. The implementation reuses Mathlib's `Circle` action on `Complex.UnitDisc` from `Mathlib.Analysis.Complex.UnitDisc.Basic`, and Tau Ceti's existing `unitDiscMoebius`, `unitDiscMoebiusEquiv`, pseudo-hyperbolic norm API, and Moebius holomorphic scalar-form lemma. This L2 shim remains coordinated with the upstream Mathlib RMT effort leanprover-community/mathlib4#33505, as described in the ConformalMapping roadmap.

`lake exe cache get` completed with `No files to download` and `Already decompressed 8609 file(s)`. `lake build` completed with `Build completed successfully (4456 jobs).` `lake exe axioms` completed with `axioms: audited 7277 TauCeti declaration(s); all within the allowlist [propext, Classical.choice, Quot.sound].`

<!--tauceti-target:v1 {"focus":"ConformalMapping","id":"unit-disc-rotation-automorphism"}-->

🤖 Prepared with Codex
