### PR TITLE
feat: add Hilbert basis transport inverse API

### DIFF
--- a/TauCeti/Analysis/InnerProductSpace/HilbertBasisMap.lean
+++ b/TauCeti/Analysis/InnerProductSpace/HilbertBasisMap.lean
@@ -78,4 +78,59 @@ theorem _root_.HilbertBasis.mapₗᵢ_trans {G : Type*} [NormedAddCommGroup G] [
   cases b
   rfl
 
+/-- Transporting a Hilbert basis across an isometry and then back across the inverse isometry
+recovers the original basis. -/
+@[simp]
+theorem _root_.HilbertBasis.mapₗᵢ_symm
+    (b : _root_.HilbertBasis ι 𝕜 E) (e : E ≃ₗᵢ[𝕜] F) :
+    (b.mapₗᵢ e).mapₗᵢ e.symm = b := by
+  rw [_root_.HilbertBasis.mapₗᵢ_trans]
+  simp
+
+/-- Transporting a Hilbert basis back across an inverse isometry and then forward again recovers
+the original basis. -/
+@[simp]
+theorem _root_.HilbertBasis.mapₗᵢ_symm_self
+    (b : _root_.HilbertBasis ι 𝕜 F) (e : E ≃ₗᵢ[𝕜] F) :
+    (b.mapₗᵢ e.symm).mapₗᵢ e = b := by
+  rw [_root_.HilbertBasis.mapₗᵢ_trans]
+  simp
+
+/-- Transporting Hilbert bases across a fixed linear isometric equivalence is injective. -/
+theorem _root_.HilbertBasis.mapₗᵢ_injective (e : E ≃ₗᵢ[𝕜] F) :
+    Function.Injective (fun b : _root_.HilbertBasis ι 𝕜 E => b.mapₗᵢ e) := by
+  intro b c hbc
+  simpa using congrArg (fun b' : _root_.HilbertBasis ι 𝕜 F => b'.mapₗᵢ e.symm) hbc
+
+/-- Every Hilbert basis of the target is the transport of a Hilbert basis of the source. -/
+theorem _root_.HilbertBasis.mapₗᵢ_surjective (e : E ≃ₗᵢ[𝕜] F) :
+    Function.Surjective (fun b : _root_.HilbertBasis ι 𝕜 E => b.mapₗᵢ e) := by
+  intro b
+  exact ⟨b.mapₗᵢ e.symm, by simp⟩
+
+/-- Transporting Hilbert bases across a fixed linear isometric equivalence is bijective. -/
+theorem _root_.HilbertBasis.mapₗᵢ_bijective (e : E ≃ₗᵢ[𝕜] F) :
+    Function.Bijective (fun b : _root_.HilbertBasis ι 𝕜 E => b.mapₗᵢ e) :=
+  ⟨_root_.HilbertBasis.mapₗᵢ_injective e, _root_.HilbertBasis.mapₗᵢ_surjective e⟩
+
+/-- Equality after transporting a Hilbert basis across an isometry is the same as equality after
+transporting the right-hand side back across the inverse isometry. -/
+@[simp]
+theorem _root_.HilbertBasis.mapₗᵢ_eq_iff
+    (b : _root_.HilbertBasis ι 𝕜 E) (c : _root_.HilbertBasis ι 𝕜 F) (e : E ≃ₗᵢ[𝕜] F) :
+    b.mapₗᵢ e = c ↔ b = c.mapₗᵢ e.symm := by
+  constructor
+  · intro h
+    simpa using congrArg (fun b' : _root_.HilbertBasis ι 𝕜 F => b'.mapₗᵢ e.symm) h
+  · intro h
+    simp [h]
+
+/-- Equality to a transported Hilbert basis is the same as equality after transporting the
+left-hand side back across the inverse isometry. -/
+@[simp]
+theorem _root_.HilbertBasis.eq_mapₗᵢ_iff
+    (c : _root_.HilbertBasis ι 𝕜 F) (b : _root_.HilbertBasis ι 𝕜 E) (e : E ≃ₗᵢ[𝕜] F) :
+    c = b.mapₗᵢ e ↔ c.mapₗᵢ e.symm = b := by
+  rw [eq_comm, _root_.HilbertBasis.mapₗᵢ_eq_iff, eq_comm]
+
 end TauCeti

--- a/TauCeti/Analysis/InnerProductSpace/HilbertBasisMap.lean
+++ b/TauCeti/Analysis/InnerProductSpace/HilbertBasisMap.lean
@@ -96,38 +96,38 @@ theorem _root_.HilbertBasis.mapₗᵢ_symm_self
   rw [_root_.HilbertBasis.mapₗᵢ_trans]
   simp
 
+/-- Transporting Hilbert bases across a fixed linear isometric equivalence is an equivalence. -/
+protected noncomputable def _root_.HilbertBasis.mapₗᵢEquiv (e : E ≃ₗᵢ[𝕜] F) :
+    _root_.HilbertBasis ι 𝕜 E ≃ _root_.HilbertBasis ι 𝕜 F where
+  toFun b := b.mapₗᵢ e
+  invFun b := b.mapₗᵢ e.symm
+  left_inv b := by simp
+  right_inv b := by simp
+
 /-- Transporting Hilbert bases across a fixed linear isometric equivalence is injective. -/
 theorem _root_.HilbertBasis.mapₗᵢ_injective (e : E ≃ₗᵢ[𝕜] F) :
-    Function.Injective (fun b : _root_.HilbertBasis ι 𝕜 E => b.mapₗᵢ e) := by
-  intro b c hbc
-  simpa using congrArg (fun b' : _root_.HilbertBasis ι 𝕜 F => b'.mapₗᵢ e.symm) hbc
+    Function.Injective (fun b : _root_.HilbertBasis ι 𝕜 E => b.mapₗᵢ e) :=
+  (_root_.HilbertBasis.mapₗᵢEquiv e).injective
 
 /-- Every Hilbert basis of the target is the transport of a Hilbert basis of the source. -/
 theorem _root_.HilbertBasis.mapₗᵢ_surjective (e : E ≃ₗᵢ[𝕜] F) :
-    Function.Surjective (fun b : _root_.HilbertBasis ι 𝕜 E => b.mapₗᵢ e) := by
-  intro b
-  exact ⟨b.mapₗᵢ e.symm, by simp⟩
+    Function.Surjective (fun b : _root_.HilbertBasis ι 𝕜 E => b.mapₗᵢ e) :=
+  (_root_.HilbertBasis.mapₗᵢEquiv e).surjective
 
 /-- Transporting Hilbert bases across a fixed linear isometric equivalence is bijective. -/
 theorem _root_.HilbertBasis.mapₗᵢ_bijective (e : E ≃ₗᵢ[𝕜] F) :
     Function.Bijective (fun b : _root_.HilbertBasis ι 𝕜 E => b.mapₗᵢ e) :=
-  ⟨_root_.HilbertBasis.mapₗᵢ_injective e, _root_.HilbertBasis.mapₗᵢ_surjective e⟩
+  (_root_.HilbertBasis.mapₗᵢEquiv e).bijective
 
 /-- Equality after transporting a Hilbert basis across an isometry is the same as equality after
 transporting the right-hand side back across the inverse isometry. -/
-@[simp]
 theorem _root_.HilbertBasis.mapₗᵢ_eq_iff
     (b : _root_.HilbertBasis ι 𝕜 E) (c : _root_.HilbertBasis ι 𝕜 F) (e : E ≃ₗᵢ[𝕜] F) :
-    b.mapₗᵢ e = c ↔ b = c.mapₗᵢ e.symm := by
-  constructor
-  · intro h
-    simpa using congrArg (fun b' : _root_.HilbertBasis ι 𝕜 F => b'.mapₗᵢ e.symm) h
-  · intro h
-    simp [h]
+    b.mapₗᵢ e = c ↔ b = c.mapₗᵢ e.symm :=
+  (_root_.HilbertBasis.mapₗᵢEquiv e).apply_eq_iff_eq_symm_apply
 
 /-- Equality to a transported Hilbert basis is the same as equality after transporting the
 left-hand side back across the inverse isometry. -/
-@[simp]
 theorem _root_.HilbertBasis.eq_mapₗᵢ_iff
     (c : _root_.HilbertBasis ι 𝕜 F) (b : _root_.HilbertBasis ι 𝕜 E) (e : E ≃ₗᵢ[𝕜] F) :
     c = b.mapₗᵢ e ↔ c.mapₗᵢ e.symm = b := by


### PR DESCRIPTION
This PR adds inverse-direction API for `HilbertBasis.mapₗᵢ`: cancellation across an isometry and its inverse, injectivity, surjectivity, bijectivity, and equality criteria that move a transported basis back across the inverse isometry. Use these lemmas to compare the weighted-measure and function-side bases in either normalization without unfolding the transported representation.

It advances `TauCetiRoadmap/OrthogonalL2Bases/README.md`, Part B2, "Both normalizations via the weight↔measure isometry (the enhancement)," specifically the `HilbertBasis.mapₗᵢ` transport primitive and its element-level transport API; it also supports the representative Part 0 target in `TauCetiRoadmap/OrthogonalL2Bases/Targets.lean`. I chose this as the lowest-hanging distinct OrthogonalL2Bases prerequisite after checking open and recently merged PRs: A1 Hermite orthogonality is open in #499, Chebyshev normalized mode work has landed, and the already-merged transport primitive still lacked the inverse/cancellation facts needed when the later weight-change isometry is used in both directions.

No Mathlib infrastructure is vendored. The implementation reuses Tau Ceti's existing `HilbertBasis.mapₗᵢ`, `mapₗᵢ_trans`, and Mathlib's `LinearIsometryEquiv.symm`/`trans` API.

`lake exe cache get` completed with `No files to download` and `Already decompressed 8609 file(s)`. `lake build` completed with `Build completed successfully (4457 jobs).` `lake exe axioms` completed with `axioms: audited 7277 TauCeti declaration(s); all within the allowlist [propext, Classical.choice, Quot.sound].`

<!--tauceti-target:v1 {"focus":"OrthogonalL2Bases","id":"hilbertbasis-mapli-inverse"}-->

🤖 Prepared with Codex
