### PR TITLE
feat(CompletelyMonotone): Bernstein representation infrastructure (Part 2/2)

### DIFF
--- a/TauCeti/Analysis/CompletelyMonotone/BernsteinMeasures.lean
+++ b/TauCeti/Analysis/CompletelyMonotone/BernsteinMeasures.lean
@@ -911,40 +911,6 @@ private lemma ibp_finite_interval (f : ℝ → ℝ) (hcm : IsCompletelyMonotone 
     intervalIntegral.integral_congr_ae (ae_of_all _ fun t _ => by rw [hu'_eq])
   linarith
 
-private lemma tail_setIntegral_tendsto_zero {g : ℝ → ℝ} {a : ℝ}
-    (hg : IntegrableOn g (Ioi a)) :
-    Tendsto (fun T => ∫ t in Ioi T, g t) atTop (nhds 0) := by
-  set I := ∫ t in Ioi a, g t
-  have h_total : Tendsto (fun T => ∫ t in a..T, g t) atTop (nhds I) :=
-    (intervalIntegral_tendsto_integral_Ioi a hg tendsto_id).congr fun _ => by simp [id]
-  have hsub : Tendsto (fun T => I - ∫ t in a..T, g t) atTop (nhds 0) := by
-    convert tendsto_const_nhds.sub h_total using 1
-    simp
-  apply hsub.congr'
-  filter_upwards [eventually_gt_atTop a] with T hT
-  symm
-  have hdisj : Disjoint (Ioc a T) (Ioi T) := by
-    rw [disjoint_left]
-    intro y hy1 hy2
-    simp at hy1 hy2
-    linarith
-  have hunion : Ioc a T ∪ Ioi T = Ioi a := by
-    ext y
-    simp only [mem_union, mem_Ioc, mem_Ioi]
-    constructor
-    · rintro (⟨hy, _⟩ | hy) <;> linarith
-    · intro hy
-      by_cases hyT : y ≤ T
-      · left
-        exact ⟨hy, hyT⟩
-      · right
-        linarith
-  have hd := setIntegral_union hdisj measurableSet_Ioi
-    (hg.mono_set Ioc_subset_Ioi_self) (hg.mono_set (Ioi_subset_Ioi hT.le))
-  rw [hunion] at hd
-  rw [intervalIntegral.integral_of_le hT.le]
-  linarith
-
 private lemma boundary_term_decay (f : ℝ → ℝ) (hcm : IsCompletelyMonotone f)
     (k : ℕ) (hk : k ≠ 0) (x : ℝ) (hx : 0 ≤ x)
     (L : ℝ) (hL : Tendsto f atTop (nhds L)) :
@@ -986,7 +952,7 @@ private lemma boundary_term_decay (f : ℝ → ℝ) (hcm : IsCompletelyMonotone 
       chafaiDensity_integrableOn_Ioi_of_tendsto f hcm k hk1 L hL
     have htail : Tendsto (fun S : ℝ => ∫ t in Ioi S, chafaiDensity f k t)
         atTop (nhds 0) :=
-      tail_setIntegral_tendsto_zero hint_density
+      tendsto_integral_Ioi_zero tendsto_id
     have htail_half : Tendsto (fun T : ℝ => ∫ t in Ioi (T / 2), chafaiDensity f k t)
         atTop (nhds 0) := by
       have hhalf_map : Tendsto (fun T : ℝ => (1 / 2 : ℝ) * T) atTop atTop :=

--- a/TauCeti/Analysis/CompletelyMonotone/BernsteinMeasures.lean
+++ b/TauCeti/Analysis/CompletelyMonotone/BernsteinMeasures.lean
@@ -5,7 +5,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 module
 
 public import Mathlib.Analysis.SpecialFunctions.Complex.LogBounds
-public import TauCeti.Analysis.CompletelyMonotone.Closure
+import TauCeti.Analysis.CompletelyMonotone.Closure
 public import TauCeti.Analysis.CompletelyMonotone.Integral
 
 /-!

--- a/TauCeti/Analysis/CompletelyMonotone/BernsteinMeasures.lean
+++ b/TauCeti/Analysis/CompletelyMonotone/BernsteinMeasures.lean
@@ -52,7 +52,8 @@ These build on the `IsCompletelyMonotone` API in `CompletelyMonotone/Basic.lean`
 * `TauCeti.chafaiRescaled_lintegral_coe_le`: first-moment / coe-lintegral bound.
 * `TauCeti.chafaiRescaled_integral_bernsteinKernel_eq_sub_tendsto_atTop`: Chafaï
   reconstruction identity `f x - L = ∫ bernsteinKernel ∂chafaiRescaled`.
-* `TauCeti.kernel_approx_error_tendsto`: Bernstein-kernel to Laplace-kernel error tends to `0`.
+* `TauCeti.integral_bernsteinKernel_sub_laplaceKernel_tendsto_zero_of_mass_bound`:
+  Bernstein-kernel to Laplace-kernel error tends to `0`.
 
 ## References
 
@@ -916,6 +917,157 @@ private lemma ibp_finite_interval (f : ℝ → ℝ) (hcm : IsCompletelyMonotone 
     intervalIntegral.integral_congr_ae (ae_of_all _ fun t _ => by rw [hu'_eq])
   linarith
 
+private lemma normalized_iteratedDerivWithin_nonneg_antitone (f : ℝ → ℝ)
+    (hcm : IsCompletelyMonotone f) (k : ℕ) :
+    (∀ T, 0 ≤ T → 0 ≤ (-1 : ℝ) ^ k * iteratedDerivWithin k f (Ici 0) T) ∧
+      AntitoneOn (fun T => (-1 : ℝ) ^ k * iteratedDerivWithin k f (Ici 0) T) (Ici 0) := by
+  constructor
+  · intro T hT
+    exact hcm.neg_one_pow_mul_iteratedDerivWithin_nonneg k hT
+  · apply antitoneOn_of_deriv_nonpos (convex_Ici 0)
+    · exact (hcm.contDiffOn.continuousOn_iteratedDerivWithin (nat_le_top k)
+        (uniqueDiffOn_Ici 0)).const_mul ((-1 : ℝ) ^ k)
+    · rw [interior_Ici]
+      intro T hT
+      exact ((hcm.hasDerivAt_iteratedDerivWithin_succ k hT).const_mul
+        ((-1 : ℝ) ^ k)).differentiableAt.differentiableWithinAt
+    · rw [interior_Ici]
+      intro T hT
+      have hderiv : deriv (fun T => (-1 : ℝ) ^ k *
+            iteratedDerivWithin k f (Ici 0) T) T =
+          (-1 : ℝ) ^ k * iteratedDerivWithin (k + 1) f (Ici 0) T := by
+        simpa using
+          ((hcm.hasDerivAt_iteratedDerivWithin_succ k hT).const_mul
+            ((-1 : ℝ) ^ k)).deriv
+      rw [hderiv]
+      have hsign : 0 ≤ (-1 : ℝ) ^ (k + 1) *
+          iteratedDerivWithin (k + 1) f (Ici 0) T :=
+        hcm.neg_one_pow_mul_iteratedDerivWithin_nonneg (k + 1) hT.le
+      have hneg : 0 ≤ -(((-1 : ℝ) ^ k) *
+          iteratedDerivWithin (k + 1) f (Ici 0) T) := by
+        simpa [pow_succ, mul_assoc] using hsign
+      linarith
+
+/-- Boundary-term tail estimate factored out of `boundary_term_decay`: `(T-x)^k · h T` is
+eventually squeezed by a multiple of the vanishing density tail `∫_{Ioi (T/2)}`. -/
+private lemma density_tail_lower_bound_eventually (f : ℝ → ℝ)
+    (hcm : IsCompletelyMonotone f) (k : ℕ) (hk : k ≠ 0) (x : ℝ) (hx : 0 ≤ x)
+    (h : ℝ → ℝ) (h_nonneg : ∀ T, 0 ≤ T → 0 ≤ h T)
+    (h_antitone : AntitoneOn h (Ici 0))
+    (h_density_eq : ∀ t, chafaiDensity f k t =
+      (1 / ↑((k - 1).factorial)) * t ^ (k - 1) * h t)
+    (hint_density : IntegrableOn (chafaiDensity f k) (Ioi 0)) :
+    ∀ᶠ T in atTop,
+      (T - x) ^ k * h T ≤
+        ((2 : ℝ) ^ k * ↑((k - 1).factorial)) *
+          ∫ t in Ioi (T / 2), chafaiDensity f k t := by
+  have hcont_density : ContinuousOn (chafaiDensity f k) (Ici 0) :=
+    continuousOn_chafaiDensity (n := k) (hcm.contDiffOn.of_le (nat_le_top k))
+  filter_upwards [eventually_gt_atTop (max (2 * x) 2)] with T hT
+  have hT2 : (2 : ℝ) < T := lt_of_le_of_lt (le_max_right (2 * x) 2) hT
+  have hTpos : 0 < T := by linarith
+  have hxT : x < T := by
+    have h2xT : 2 * x < T := lt_of_le_of_lt (le_max_left (2 * x) 2) hT
+    linarith
+  have hTx_nonneg : 0 ≤ T - x := sub_nonneg.mpr hxT.le
+  have hT_nonneg : 0 ≤ T := hTpos.le
+  have hhalf_nonneg : 0 ≤ T / 2 := by positivity
+  have hhT_nonneg : 0 ≤ h T := h_nonneg T hT_nonneg
+  have h_interval_le :
+      ∫ t in T / 2..T, chafaiDensity f k t ≤
+        ∫ t in Ioi (T / 2), chafaiDensity f k t := by
+    rw [intervalIntegral.integral_of_le (by linarith)]
+    apply setIntegral_mono_set (hint_density.mono_set (Ioi_subset_Ioi hhalf_nonneg))
+    · exact (ae_restrict_mem measurableSet_Ioi).mono fun t ht =>
+        chafaiDensity_nonneg (lt_of_le_of_lt hhalf_nonneg ht).le
+          (hcm.neg_one_pow_mul_iteratedDerivWithin_nonneg k
+            (lt_of_le_of_lt hhalf_nonneg ht).le)
+    · exact ae_of_all _ fun t ht => Ioc_subset_Ioi_self ht
+  have h_const_le :
+      (1 / ↑((k - 1).factorial)) * (T / 2) ^ k * h T ≤
+        ∫ t in T / 2..T, chafaiDensity f k t := by
+    have hmono :
+        ∀ᵐ t ∂(volume.restrict (Icc (T / 2) T)),
+          (1 / ↑((k - 1).factorial)) * (T / 2) ^ (k - 1) * h T ≤
+            chafaiDensity f k t := by
+      filter_upwards [ae_restrict_mem measurableSet_Icc] with t ht
+      have ht_nonneg : 0 ≤ t := le_trans hhalf_nonneg ht.1
+      have ht_pos : 0 < t := lt_of_lt_of_le (by positivity : 0 < T / 2) ht.1
+      have hpow : (T / 2) ^ (k - 1) ≤ t ^ (k - 1) :=
+        pow_le_pow_left₀ hhalf_nonneg ht.1 _
+      have hh_le : h T ≤ h t :=
+        h_antitone ht_nonneg hT_nonneg ht.2
+      have hmul :
+          (1 / ↑((k - 1).factorial)) * (T / 2) ^ (k - 1) * h T ≤
+            (1 / ↑((k - 1).factorial)) * t ^ (k - 1) * h t := by
+        have hcoeff_nonneg : 0 ≤ (1 / ↑((k - 1).factorial) : ℝ) := by positivity
+        have hright_nonneg : 0 ≤ (1 / ↑((k - 1).factorial)) * t ^ (k - 1) :=
+          mul_nonneg hcoeff_nonneg (pow_nonneg ht_nonneg _)
+        calc
+          (1 / ↑((k - 1).factorial)) * (T / 2) ^ (k - 1) * h T
+              ≤ ((1 / ↑((k - 1).factorial)) * t ^ (k - 1)) * h T := by
+                simpa [mul_assoc] using
+                  mul_le_mul_of_nonneg_right
+                    (mul_le_mul_of_nonneg_left hpow hcoeff_nonneg)
+                    hhT_nonneg
+          _ ≤ ((1 / ↑((k - 1).factorial)) * t ^ (k - 1)) * h t :=
+                mul_le_mul_of_nonneg_left hh_le hright_nonneg
+      simpa [h_density_eq t] using hmul
+    have hconst_int :
+        IntervalIntegrable (fun _ : ℝ =>
+          (1 / ↑((k - 1).factorial)) * (T / 2) ^ (k - 1) * h T) volume (T / 2) T :=
+      intervalIntegrable_const
+    have hIcc_subset : Icc (T / 2) T ⊆ Ici 0 := by
+      intro t ht
+      exact le_trans hhalf_nonneg ht.1
+    have hdens_int : IntervalIntegrable (chafaiDensity f k) volume (T / 2) T :=
+      (hcont_density.mono hIcc_subset).intervalIntegrable_of_Icc (by linarith)
+    have hmono_int :=
+      intervalIntegral.integral_mono_ae_restrict (μ := volume) (a := T / 2) (b := T)
+        (hab := by linarith) hconst_int hdens_int hmono
+    rw [intervalIntegral.integral_const] at hmono_int
+    have hhalf_eq : (T - T / 2) = T / 2 := by ring
+    rw [hhalf_eq] at hmono_int
+    rw [smul_eq_mul] at hmono_int
+    have hconst_eq :
+        T / 2 * ((1 / ↑((k - 1).factorial)) * (T / 2) ^ (k - 1) * h T) =
+          (1 / ↑((k - 1).factorial)) * (T / 2) ^ k * h T := by
+      have hk_succ : k = (k - 1) + 1 := by omega
+      rw [hk_succ]
+      ring_nf
+      have hnat : 1 + (k - 1) - 1 = k - 1 := by omega
+      simp [hnat]
+    rw [hconst_eq] at hmono_int
+    exact hmono_int
+  have hhalf_le :
+      (T / 2) ^ k * h T ≤
+        ↑((k - 1).factorial) * ∫ t in Ioi (T / 2), chafaiDensity f k t := by
+    have hfact_pos : (0 : ℝ) < ↑((k - 1).factorial) :=
+      Nat.cast_pos.mpr (Nat.factorial_pos _)
+    have haux := le_trans h_const_le h_interval_le
+    have hmul := mul_le_mul_of_nonneg_left haux hfact_pos.le
+    have hleft_eq :
+        ↑((k - 1).factorial) *
+            ((1 / ↑((k - 1).factorial)) * (T / 2) ^ k * h T) =
+          (T / 2) ^ k * h T := by
+      field_simp [hfact_pos.ne']
+    rw [hleft_eq] at hmul
+    exact hmul
+  have hpow_le : (T - x) ^ k ≤ T ^ k :=
+    pow_le_pow_left₀ hTx_nonneg (by linarith) _
+  have hTk_eq : T ^ k * h T = (2 : ℝ) ^ k * ((T / 2) ^ k * h T) := by
+    calc
+      T ^ k * h T = ((2 : ℝ) * (T / 2)) ^ k * h T := by congr 1; field_simp
+      _ = (2 : ℝ) ^ k * ((T / 2) ^ k * h T) := by rw [mul_pow]; ring
+  calc
+    (T - x) ^ k * h T ≤ T ^ k * h T := by gcongr
+    _ = (2 : ℝ) ^ k * ((T / 2) ^ k * h T) := hTk_eq
+    _ ≤ (2 : ℝ) ^ k *
+        (↑((k - 1).factorial) * ∫ t in Ioi (T / 2), chafaiDensity f k t) := by
+          gcongr
+    _ = ((2 : ℝ) ^ k * ↑((k - 1).factorial)) *
+          ∫ t in Ioi (T / 2), chafaiDensity f k t := by ring
+
 private lemma boundary_term_decay (f : ℝ → ℝ) (hcm : IsCompletelyMonotone f)
     (k : ℕ) (hk : k ≠ 0) (x : ℝ) (hx : 0 ≤ x)
     (L : ℝ) (hL : Tendsto f atTop (nhds L)) :
@@ -924,36 +1076,10 @@ private lemma boundary_term_decay (f : ℝ → ℝ) (hcm : IsCompletelyMonotone 
   set h := fun T => (-1 : ℝ) ^ k * iteratedDerivWithin k f (Ici 0) T
   have hk1 : 1 ≤ k := Nat.one_le_iff_ne_zero.mpr hk
   have hkey : Tendsto (fun T => (T - x) ^ k * h T) atTop (nhds 0) := by
-    -- Phase: sign and antitone control for the normalized derivative.
-    have h_nonneg : ∀ T, 0 ≤ T → 0 ≤ h T := by
-      intro T hT
-      simpa [h] using hcm.neg_one_pow_mul_iteratedDerivWithin_nonneg k hT
-    have h_antitone : AntitoneOn h (Ici 0) := by
-      apply antitoneOn_of_deriv_nonpos (convex_Ici 0)
-      · simpa [h] using
-          (hcm.contDiffOn.continuousOn_iteratedDerivWithin (nat_le_top k)
-            (uniqueDiffOn_Ici 0)).const_mul ((-1 : ℝ) ^ k)
-      · rw [interior_Ici]
-        intro T hT
-        exact ((hcm.hasDerivAt_iteratedDerivWithin_succ k hT).const_mul
-          ((-1 : ℝ) ^ k)).differentiableAt.differentiableWithinAt
-      · rw [interior_Ici]
-        intro T hT
-        have hderiv :
-            deriv h T = (-1 : ℝ) ^ k * iteratedDerivWithin (k + 1) f (Ici 0) T := by
-          simpa [h] using
-            ((hcm.hasDerivAt_iteratedDerivWithin_succ k hT).const_mul
-              ((-1 : ℝ) ^ k)).deriv
-        rw [hderiv]
-        have hsign : 0 ≤ (-1 : ℝ) ^ (k + 1) *
-            iteratedDerivWithin (k + 1) f (Ici 0) T :=
-          hcm.neg_one_pow_mul_iteratedDerivWithin_nonneg (k + 1) hT.le
-        have hneg : 0 ≤ -(((-1 : ℝ) ^ k) *
-            iteratedDerivWithin (k + 1) f (Ici 0) T) := by
-          simpa [pow_succ, mul_assoc] using hsign
-        linarith
-    have hcont_density : ContinuousOn (chafaiDensity f k) (Ici 0) :=
-      continuousOn_chafaiDensity (n := k) (hcm.contDiffOn.of_le (nat_le_top k))
+    obtain ⟨h_nonneg₀, h_antitone₀⟩ :=
+      normalized_iteratedDerivWithin_nonneg_antitone f hcm k
+    have h_nonneg : ∀ T, 0 ≤ T → 0 ≤ h T := by simpa [h] using h_nonneg₀
+    have h_antitone : AntitoneOn h (Ici 0) := by simpa [h] using h_antitone₀
     have hint_density : IntegrableOn (chafaiDensity f k) (Ioi 0) :=
       chafaiDensity_integrableOn_Ioi_of_tendsto f hcm k hk1 L hL
     have htail : Tendsto (fun S : ℝ => ∫ t in Ioi S, chafaiDensity f k t)
@@ -967,123 +1093,13 @@ private lemma boundary_term_decay (f : ℝ → ℝ) (hcm : IsCompletelyMonotone 
       filter_upwards with T
       simp
       ring_nf
-    -- Phase: compare `(T - x)^k h T` with the density tail on `[T / 2, ∞)`.
-    have hupper :
-        ∀ᶠ T in atTop,
-          (T - x) ^ k * h T ≤
-            ((2 : ℝ) ^ k * ↑((k - 1).factorial)) *
-              ∫ t in Ioi (T / 2), chafaiDensity f k t := by
-      filter_upwards [eventually_gt_atTop (max (2 * x) 2)] with T hT
-      have hT2 : (2 : ℝ) < T := lt_of_le_of_lt (le_max_right (2 * x) 2) hT
-      have hTpos : 0 < T := by linarith
-      have hxT : x < T := by
-        have h2xT : 2 * x < T := lt_of_le_of_lt (le_max_left (2 * x) 2) hT
-        linarith
-      have hTx_nonneg : 0 ≤ T - x := sub_nonneg.mpr hxT.le
-      have hT_nonneg : 0 ≤ T := hTpos.le
-      have hhalf_nonneg : 0 ≤ T / 2 := by positivity
-      have hhT_nonneg : 0 ≤ h T := h_nonneg T hT_nonneg
-      have h_interval_le :
-          ∫ t in T / 2..T, chafaiDensity f k t ≤
-            ∫ t in Ioi (T / 2), chafaiDensity f k t := by
-        rw [intervalIntegral.integral_of_le (by linarith)]
-        apply setIntegral_mono_set (hint_density.mono_set (Ioi_subset_Ioi hhalf_nonneg))
-        · exact (ae_restrict_mem measurableSet_Ioi).mono fun t ht =>
-            chafaiDensity_nonneg (lt_of_le_of_lt hhalf_nonneg ht).le
-              (hcm.neg_one_pow_mul_iteratedDerivWithin_nonneg k
-                (lt_of_le_of_lt hhalf_nonneg ht).le)
-        · exact ae_of_all _ fun t ht => Ioc_subset_Ioi_self ht
-      have h_density_eq :
-          ∀ t, chafaiDensity f k t =
-            (1 / ↑((k - 1).factorial)) * t ^ (k - 1) * h t := by
+    have hupper := density_tail_lower_bound_eventually f hcm k hk x hx h h_nonneg h_antitone
+      (by
         intro t
         rw [chafaiDensity_of_ne_zero hk]
         simp only [h]
-        field_simp
-      have h_const_le :
-          (1 / ↑((k - 1).factorial)) * (T / 2) ^ k * h T ≤
-            ∫ t in T / 2..T, chafaiDensity f k t := by
-        have hmono :
-            ∀ᵐ t ∂(volume.restrict (Icc (T / 2) T)),
-              (1 / ↑((k - 1).factorial)) * (T / 2) ^ (k - 1) * h T ≤
-                chafaiDensity f k t := by
-          filter_upwards [ae_restrict_mem measurableSet_Icc] with t ht
-          have ht_nonneg : 0 ≤ t := le_trans hhalf_nonneg ht.1
-          have ht_pos : 0 < t := lt_of_lt_of_le (by positivity : 0 < T / 2) ht.1
-          have hpow : (T / 2) ^ (k - 1) ≤ t ^ (k - 1) :=
-            pow_le_pow_left₀ hhalf_nonneg ht.1 _
-          have hh_le : h T ≤ h t :=
-            h_antitone ht_nonneg hT_nonneg ht.2
-          have hmul :
-              (1 / ↑((k - 1).factorial)) * (T / 2) ^ (k - 1) * h T ≤
-                (1 / ↑((k - 1).factorial)) * t ^ (k - 1) * h t := by
-            have hcoeff_nonneg : 0 ≤ (1 / ↑((k - 1).factorial) : ℝ) := by positivity
-            have hright_nonneg : 0 ≤ (1 / ↑((k - 1).factorial)) * t ^ (k - 1) :=
-              mul_nonneg hcoeff_nonneg (pow_nonneg ht_nonneg _)
-            calc
-              (1 / ↑((k - 1).factorial)) * (T / 2) ^ (k - 1) * h T
-                  ≤ ((1 / ↑((k - 1).factorial)) * t ^ (k - 1)) * h T := by
-                    simpa [mul_assoc] using
-                      mul_le_mul_of_nonneg_right
-                        (mul_le_mul_of_nonneg_left hpow hcoeff_nonneg)
-                        hhT_nonneg
-              _ ≤ ((1 / ↑((k - 1).factorial)) * t ^ (k - 1)) * h t :=
-                    mul_le_mul_of_nonneg_left hh_le hright_nonneg
-          simpa [h_density_eq t] using hmul
-        have hconst_int :
-            IntervalIntegrable (fun _ : ℝ =>
-              (1 / ↑((k - 1).factorial)) * (T / 2) ^ (k - 1) * h T) volume (T / 2) T :=
-          intervalIntegrable_const
-        have hIcc_subset : Icc (T / 2) T ⊆ Ici 0 := by
-          intro t ht
-          exact le_trans hhalf_nonneg ht.1
-        have hdens_int : IntervalIntegrable (chafaiDensity f k) volume (T / 2) T :=
-          (hcont_density.mono hIcc_subset).intervalIntegrable_of_Icc (by linarith)
-        have hmono_int :=
-          intervalIntegral.integral_mono_ae_restrict (μ := volume) (a := T / 2) (b := T)
-            (hab := by linarith) hconst_int hdens_int hmono
-        rw [intervalIntegral.integral_const] at hmono_int
-        have hhalf_eq : (T - T / 2) = T / 2 := by ring
-        rw [hhalf_eq] at hmono_int
-        rw [smul_eq_mul] at hmono_int
-        have hconst_eq :
-            T / 2 * ((1 / ↑((k - 1).factorial)) * (T / 2) ^ (k - 1) * h T) =
-              (1 / ↑((k - 1).factorial)) * (T / 2) ^ k * h T := by
-          have hk_succ : k = (k - 1) + 1 := by omega
-          rw [hk_succ]
-          ring_nf
-          have hnat : 1 + (k - 1) - 1 = k - 1 := by omega
-          simp [hnat]
-        rw [hconst_eq] at hmono_int
-        exact hmono_int
-      have hhalf_le :
-          (T / 2) ^ k * h T ≤
-            ↑((k - 1).factorial) * ∫ t in Ioi (T / 2), chafaiDensity f k t := by
-        have hfact_pos : (0 : ℝ) < ↑((k - 1).factorial) :=
-          Nat.cast_pos.mpr (Nat.factorial_pos _)
-        have haux := le_trans h_const_le h_interval_le
-        have hmul := mul_le_mul_of_nonneg_left haux hfact_pos.le
-        have hleft_eq :
-            ↑((k - 1).factorial) *
-                ((1 / ↑((k - 1).factorial)) * (T / 2) ^ k * h T) =
-              (T / 2) ^ k * h T := by
-          field_simp [hfact_pos.ne']
-        rw [hleft_eq] at hmul
-        exact hmul
-      have hpow_le : (T - x) ^ k ≤ T ^ k :=
-        pow_le_pow_left₀ hTx_nonneg (by linarith) _
-      have hTk_eq : T ^ k * h T = (2 : ℝ) ^ k * ((T / 2) ^ k * h T) := by
-        calc
-          T ^ k * h T = ((2 : ℝ) * (T / 2)) ^ k * h T := by congr 1; field_simp
-          _ = (2 : ℝ) ^ k * ((T / 2) ^ k * h T) := by rw [mul_pow]; ring
-      calc
-        (T - x) ^ k * h T ≤ T ^ k * h T := by gcongr
-        _ = (2 : ℝ) ^ k * ((T / 2) ^ k * h T) := hTk_eq
-        _ ≤ (2 : ℝ) ^ k *
-            (↑((k - 1).factorial) * ∫ t in Ioi (T / 2), chafaiDensity f k t) := by
-              gcongr
-        _ = ((2 : ℝ) ^ k * ↑((k - 1).factorial)) *
-              ∫ t in Ioi (T / 2), chafaiDensity f k t := by ring
+        field_simp)
+      hint_density
     have hnonneg_event : ∀ᶠ T in atTop, 0 ≤ (T - x) ^ k * h T := by
       filter_upwards [eventually_gt_atTop (max x 0)] with T hT
       have hT0 : 0 < T := lt_of_le_of_lt (le_max_right x 0) hT
@@ -1154,6 +1170,24 @@ private lemma ibp_kernel_integrableOn (f : ℝ → ℝ) (hcm : IsCompletelyMonot
       _ = (-1 : ℝ) ^ k / ↑(k - 1).factorial * t ^ (k - 1) *
           iteratedDerivWithin k f (Ici 0) t := by field_simp
 
+private lemma integral_neg_iteratedDerivWithin_one_Ici_eq_Icc
+    (f : ℝ → ℝ) (hcm : IsCompletelyMonotone f)
+    {x T : ℝ} (hx : 0 ≤ x) (hxT : x < T) :
+    (∫ t in x..T, -iteratedDerivWithin 1 f (Ici 0) t) =
+      ∫ t in x..T, -iteratedDerivWithin 1 f (Icc x T) t := by
+  apply intervalIntegral.integral_congr_ae
+  apply ae_of_all
+  intro t ht
+  rw [uIoc_of_le hxT.le] at ht
+  have ht_pos : 0 < t := lt_of_le_of_lt hx ht.1
+  have hcda : ContDiffAt ℝ (↑1 : WithTop ℕ∞) f t :=
+    (hcm.contDiffOn.of_le (nat_le_top 1)).contDiffAt (Ici_mem_nhds ht_pos)
+  congr 1
+  rw [iteratedDerivWithin_eq_iteratedDeriv
+      (uniqueDiffOn_Icc hxT) hcda (Ioc_subset_Icc_self ht),
+    iteratedDerivWithin_eq_iteratedDeriv
+      (uniqueDiffOn_Ici 0) hcda (mem_Ici.mpr ht_pos.le)]
+
 private lemma chafai_repeated_ibp (f : ℝ → ℝ) (hcm : IsCompletelyMonotone f)
     (n : ℕ) (hn : 1 ≤ n) (x : ℝ) (hx : 0 ≤ x)
     (L : ℝ) (hL : Tendsto f atTop (nhds L)) :
@@ -1185,20 +1219,7 @@ private lemma chafai_repeated_ibp (f : ℝ → ℝ) (hcm : IsCompletelyMonotone 
       refine Tendsto.congr' ?_ (Tendsto.sub tendsto_const_nhds hL)
       filter_upwards [eventually_gt_atTop (max x 1)] with T hT
       have hxT : x < T := lt_of_le_of_lt (le_max_left x 1) hT
-      rw [show (∫ t in x..T, -iteratedDerivWithin 1 f (Ici 0) t) =
-          ∫ t in x..T, -iteratedDerivWithin 1 f (Icc x T) t from by
-        apply intervalIntegral.integral_congr_ae
-        apply ae_of_all
-        intro t ht
-        rw [uIoc_of_le hxT.le] at ht
-        have ht_pos : 0 < t := lt_of_le_of_lt hx ht.1
-        have hcda : ContDiffAt ℝ (↑1 : WithTop ℕ∞) f t :=
-          (hcm.contDiffOn.of_le (nat_le_top 1)).contDiffAt (Ici_mem_nhds ht_pos)
-        congr 1
-        rw [iteratedDerivWithin_eq_iteratedDeriv
-            (uniqueDiffOn_Icc hxT) hcda (Ioc_subset_Icc_self ht),
-          iteratedDerivWithin_eq_iteratedDeriv
-            (uniqueDiffOn_Ici 0) hcda (mem_Ici.mpr ht_pos.le)]]
+      rw [integral_neg_iteratedDerivWithin_one_Ici_eq_Icc f hcm hx hxT]
       exact hcm.integral_neg_iteratedDerivWithin_one_Icc x T hx hxT.le
     · -- Inductive step `n = k+1`: integrate by parts once (`ibp_finite_interval`); the boundary
       -- term vanishes in the limit (`boundary_term_decay`), leaving the order-`k` integral, which
@@ -1412,9 +1433,9 @@ private lemma kernel_uniform_conv (x : ℝ) (hx : 0 < x) (ε : ℝ) (hε : 0 < �
     linarith [bernsteinKernel_nonneg n x p]
 
 /-- Bernstein-to-Laplace replacement against a uniformly finite sequence of measures. -/
-lemma kernel_approx_error_tendsto
+lemma integral_bernsteinKernel_sub_laplaceKernel_tendsto_zero_of_mass_bound
     (σ : ℕ → Measure ℝ≥0)
-    (hmass : ∀ n, (σ n) univ ≤ ENNReal.ofReal C)
+    (hmass : ∀ᶠ n in atTop, (σ n) univ ≤ ENNReal.ofReal C)
     (x : ℝ) (hx : 0 ≤ x) :
     Tendsto (fun n => ∫ p : ℝ≥0,
         (bernsteinKernel n x (p : ℝ) - Real.exp (-(x * (p : ℝ)))) ∂(σ n))
@@ -1438,9 +1459,10 @@ lemma kernel_approx_error_tendsto
     have hmax_pos : 0 < max C 1 := lt_max_of_lt_right one_pos
     obtain ⟨N, hN⟩ := kernel_uniform_conv x hx_pos
       (ε / (2 * max C 1)) (div_pos hε (by positivity))
-    refine ⟨N, fun n hn => ?_⟩
+    refine eventually_atTop.1 <| ((eventually_ge_atTop N).and hmass).mono fun n hn => ?_
+    rcases hn with ⟨hn, hmass_n⟩
     rw [dist_zero_right]
-    haveI : IsFiniteMeasure (σ n) := ⟨(hmass n).trans_lt ENNReal.ofReal_lt_top⟩
+    haveI : IsFiniteMeasure (σ n) := ⟨hmass_n.trans_lt ENNReal.ofReal_lt_top⟩
     calc
       ‖∫ p : ℝ≥0, (bernsteinKernel n x (p : ℝ) - Real.exp (-(x * (p : ℝ)))) ∂(σ n)‖
           ≤ ∫ p : ℝ≥0,
@@ -1456,7 +1478,7 @@ lemma kernel_approx_error_tendsto
       _ ≤ ε / (2 * max C 1) * max C 1 := by
           apply mul_le_mul_of_nonneg_left _ (le_of_lt (div_pos hε (by positivity)))
           exact ENNReal.toReal_le_of_le_ofReal (le_of_lt hmax_pos)
-            (le_trans (hmass n) (ENNReal.ofReal_le_ofReal (le_max_left C 1)))
+            (le_trans hmass_n (ENNReal.ofReal_le_ofReal (le_max_left C 1)))
       _ = ε / 2 := by field_simp
       _ < ε := half_lt_self hε
 

--- a/TauCeti/Analysis/CompletelyMonotone/BernsteinMeasures.lean
+++ b/TauCeti/Analysis/CompletelyMonotone/BernsteinMeasures.lean
@@ -49,6 +49,10 @@ These build on the `IsCompletelyMonotone` API in `CompletelyMonotone/Basic.lean`
 * `TauCeti.chafaiRescaled_prokhorov_mass_bound`,
   `TauCeti.chafaiRescaled_tendsto_laplace_integral_of_weak`: Prokhorov-ready mass bounds and
   the Laplace test-function specialization of weak convergence for the rescaled measures.
+* `TauCeti.chafaiRescaled_lintegral_coe_le`: first-moment / coe-lintegral bound.
+* `TauCeti.chafaiRescaled_integral_bernsteinKernel_eq_sub_tendsto_atTop`: Chafaï
+  reconstruction identity `f x - L = ∫ bernsteinKernel ∂chafaiRescaled`.
+* `TauCeti.kernel_approx_error_tendsto`: Bernstein-kernel to Laplace-kernel error tends to `0`.
 
 ## References
 
@@ -440,6 +444,7 @@ private lemma chafaiDensity_neg_derivWithin_pred (f : ℝ → ℝ)
   have hiter : iteratedDerivWithin (n - 1)
         (fun t => -derivWithin f (Ici 0) t) (Ici 0) t =
       -iteratedDerivWithin n f (Ici 0) t := by
+    -- The negated function elaborates as negation of `derivWithin`; expose that defeq.
     change iteratedDerivWithin (n - 1) (-(derivWithin f (Ici 0))) (Ici 0) t =
       -iteratedDerivWithin n f (Ici 0) t
     rw [iteratedDerivWithin_neg]
@@ -919,6 +924,7 @@ private lemma boundary_term_decay (f : ℝ → ℝ) (hcm : IsCompletelyMonotone 
   set h := fun T => (-1 : ℝ) ^ k * iteratedDerivWithin k f (Ici 0) T
   have hk1 : 1 ≤ k := Nat.one_le_iff_ne_zero.mpr hk
   have hkey : Tendsto (fun T => (T - x) ^ k * h T) atTop (nhds 0) := by
+    -- Phase: sign and antitone control for the normalized derivative.
     have h_nonneg : ∀ T, 0 ≤ T → 0 ≤ h T := by
       intro T hT
       simpa [h] using hcm.neg_one_pow_mul_iteratedDerivWithin_nonneg k hT
@@ -961,6 +967,7 @@ private lemma boundary_term_decay (f : ℝ → ℝ) (hcm : IsCompletelyMonotone 
       filter_upwards with T
       simp
       ring_nf
+    -- Phase: compare `(T - x)^k h T` with the density tail on `[T / 2, ∞)`.
     have hupper :
         ∀ᶠ T in atTop,
           (T - x) ^ k * h T ≤
@@ -1087,6 +1094,7 @@ private lemma boundary_term_decay (f : ℝ → ℝ) (hcm : IsCompletelyMonotone 
           ((2 : ℝ) ^ k * ↑((k - 1).factorial)) *
             ∫ t in Ioi (T / 2), chafaiDensity f k t) atTop (nhds 0) := by
       simpa [mul_zero] using htail_half.const_mul (((2 : ℝ) ^ k) * ↑((k - 1).factorial))
+    -- Phase: squeeze between nonnegativity and the vanishing tail bound.
     exact squeeze_zero' hnonneg_event hupper hupper_tendsto
   have heq : ∀ T, (-1 : ℝ) ^ (k + 1) / ↑k.factorial * (T - x) ^ k *
       iteratedDerivWithin k f (Ici 0) T =
@@ -1152,11 +1160,15 @@ private lemma chafai_repeated_ibp (f : ℝ → ℝ) (hcm : IsCompletelyMonotone 
     ∫ t in Ioi x, (-1 : ℝ) ^ n / ↑(n - 1).factorial *
       (t - x) ^ (n - 1) *
       iteratedDerivWithin n f (Ici 0) t = f x - L := by
+  -- Induction on `n`. Base case `n = 1`: the integral is `∫ -f'` on `(x, ∞)`, which equals
+  -- `f x - L` by the FTC and `f → L`. Inductive step: one integration by parts lowers the order
+  -- from `k+1` to `k`; the boundary term decays, and the interior term is the `k`-th case.
   induction n with
   | zero => omega
   | succ k ih =>
     by_cases hk : k = 0
-    · subst hk
+    · -- Base case `n = 1`: reduce to `∫ (x,∞) -f' = f x - L` via the fundamental theorem.
+      subst hk
       have hsimpl :
           (fun t => (-1 : ℝ) ^ (0 + 1) / ↑(0 + 1 - 1).factorial *
             (t - x) ^ (0 + 1 - 1) *
@@ -1188,7 +1200,10 @@ private lemma chafai_repeated_ibp (f : ℝ → ℝ) (hcm : IsCompletelyMonotone 
           iteratedDerivWithin_eq_iteratedDeriv
             (uniqueDiffOn_Ici 0) hcda (mem_Ici.mpr ht_pos.le)]]
       exact hcm.integral_neg_iteratedDerivWithin_one_Icc x T hx hxT.le
-    · have hk1 : 1 ≤ k := Nat.one_le_iff_ne_zero.mpr hk
+    · -- Inductive step `n = k+1`: integrate by parts once (`ibp_finite_interval`); the boundary
+      -- term vanishes in the limit (`boundary_term_decay`), leaving the order-`k` integral, which
+      -- the induction hypothesis identifies with `f x - L`.
+      have hk1 : 1 ≤ k := Nat.one_le_iff_ne_zero.mpr hk
       have ih_applied := ih hk1
       simp only [show k + 1 - 1 = k by omega]
       have hintk := ibp_kernel_integrableOn f hcm k hk1 x hx L hL
@@ -1231,7 +1246,8 @@ private lemma chafai_repeated_ibp (f : ℝ → ℝ) (hcm : IsCompletelyMonotone 
           (fun T => by simp [id])) htend_via_ibp
 
 /-- **Chafaï reconstruction identity** for the nonconstant part. -/
-lemma chafai_identity (f : ℝ → ℝ) (hcm : IsCompletelyMonotone f)
+lemma chafaiRescaled_integral_bernsteinKernel_eq_sub_tendsto_atTop
+    (f : ℝ → ℝ) (hcm : IsCompletelyMonotone f)
     (n : ℕ) (hn : 2 ≤ n) (x : ℝ) (hx : 0 ≤ x)
     (L : ℝ) (hL : Tendsto f atTop (nhds L)) :
     f x - L = ∫ p, bernsteinKernel n x (p : ℝ) ∂(chafaiRescaled f n) := by
@@ -1319,6 +1335,7 @@ private lemma kernel_uniform_conv_compact (x R ε : ℝ) (hx : 0 < x) (hR : 0 < 
     rw [bernsteinKernel_of_two_le hn_ge2]
     congr 1
     exact max_eq_left (by
+      -- `max_eq_left` needs the truncated factor `1 - x*p/m` nonneg; expose it as the defeq goal.
       change 0 ≤ 1 - x * p / (↑m : ℝ)
       rw [← hu_def]
       linarith)
@@ -1329,6 +1346,7 @@ private lemma kernel_uniform_conv_compact (x R ε : ℝ) (hx : 0 < x) (hR : 0 < 
   have hmu : ↑m * u = x * p := by
     simp only [hu_def]
     field_simp [hm_pos.ne']
+  -- Phase: the logarithmic lower bound converts the power into an exponential error term.
   have hpow_ge : (1 - u) ^ m ≥ Real.exp (-(x * p) - b) := by
     have heq : (1 - u) ^ m = Real.exp (↑m * Real.log (1 - u)) := by
       rw [← Real.rpow_natCast (1 - u) m, Real.rpow_def_of_pos h1u, mul_comm]
@@ -1355,6 +1373,7 @@ private lemma kernel_uniform_conv_compact (x R ε : ℝ) (hx : 0 < x) (hR : 0 < 
     simp only [hb_def, hu_def]
     field_simp [hm_pos.ne']
   have hm_gt_C' : 0 < ↑m - C := by linarith
+  -- Phase: bound the local error parameter using the compact restriction `p ≤ R`.
   have hb_le : b ≤ C ^ 2 / (↑m - C) := by
     rw [hb_eq]
     exact div_le_div₀ (sq_nonneg C) (sq_le_sq' (by linarith) hxp_le_C)
@@ -1395,7 +1414,6 @@ private lemma kernel_uniform_conv (x : ℝ) (hx : 0 < x) (ε : ℝ) (hε : 0 < �
 /-- Bernstein-to-Laplace replacement against a uniformly finite sequence of measures. -/
 lemma kernel_approx_error_tendsto
     (σ : ℕ → Measure ℝ≥0)
-    (hfin : ∀ n, IsFiniteMeasure (σ n))
     (hmass : ∀ n, (σ n) univ ≤ ENNReal.ofReal C)
     (x : ℝ) (hx : 0 ≤ x) :
     Tendsto (fun n => ∫ p : ℝ≥0,
@@ -1410,6 +1428,7 @@ lemma kernel_approx_error_tendsto
     apply integral_eq_zero_of_ae
     apply ae_of_all
     intro p
+    -- At `x = 0` the integrand is defeq to this explicit difference; expose it before rewriting.
     change bernsteinKernel n 0 (p : ℝ) - Real.exp (-(0 * (p : ℝ))) = 0
     rw [bernsteinKernel_of_two_le hn]
     simp
@@ -1421,7 +1440,7 @@ lemma kernel_approx_error_tendsto
       (ε / (2 * max C 1)) (div_pos hε (by positivity))
     refine ⟨N, fun n hn => ?_⟩
     rw [dist_zero_right]
-    letI := hfin n
+    haveI : IsFiniteMeasure (σ n) := ⟨(hmass n).trans_lt ENNReal.ofReal_lt_top⟩
     calc
       ‖∫ p : ℝ≥0, (bernsteinKernel n x (p : ℝ) - Real.exp (-(x * (p : ℝ)))) ∂(σ n)‖
           ≤ ∫ p : ℝ≥0,

--- a/TauCeti/Analysis/CompletelyMonotone/BernsteinMeasures.lean
+++ b/TauCeti/Analysis/CompletelyMonotone/BernsteinMeasures.lean
@@ -1271,7 +1271,7 @@ lemma chafaiRescaled_integral_bernsteinKernel_eq_sub_tendsto_atTop
     (f : ℝ → ℝ) (hcm : IsCompletelyMonotone f)
     (n : ℕ) (hn : 2 ≤ n) (x : ℝ) (hx : 0 ≤ x)
     (L : ℝ) (hL : Tendsto f atTop (nhds L)) :
-    f x - L = ∫ p, bernsteinKernel n x (p : ℝ) ∂(chafaiRescaled f n) := by
+    ∫ p, bernsteinKernel n x (p : ℝ) ∂(chafaiRescaled f n) = f x - L := by
   have h_integral_pullback :
       ∫ p : ℝ≥0, bernsteinKernel n x (p : ℝ) ∂(chafaiRescaled f n) =
         ∫ t, bernsteinKernel n x (chafaiRescaling n t : ℝ) ∂(chafaiMeasure f n) := by
@@ -1301,7 +1301,7 @@ lemma chafaiRescaled_integral_bernsteinKernel_eq_sub_tendsto_atTop
   have hkernel := chafai_kernel_density_eq f n hn x hx
   have hibp := chafai_repeated_ibp f hcm n (by omega) x hx L hL
   rw [h_integral_pullback, h_integral_density, hkernel]
-  exact hibp.symm
+  exact hibp
 
 private lemma bernsteinKernel_le_exp {n : ℕ} (hn : 2 ≤ n) {x p : ℝ} (_hx : 0 ≤ x)
     (_hp : 0 ≤ p) :

--- a/TauCeti/Analysis/CompletelyMonotone/BernsteinMeasures.lean
+++ b/TauCeti/Analysis/CompletelyMonotone/BernsteinMeasures.lean
@@ -5,6 +5,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 module
 
 public import Mathlib.Analysis.SpecialFunctions.Complex.LogBounds
+public import TauCeti.Analysis.CompletelyMonotone.Closure
 public import TauCeti.Analysis.CompletelyMonotone.Integral
 
 /-!
@@ -421,6 +422,93 @@ lemma chafaiRescaled_mass_eq (f : ℝ → ℝ) (n : ℕ) :
   unfold chafaiRescaled
   rw [Measure.map_apply (measurable_chafaiRescaling n) MeasurableSet.univ, Set.preimage_univ]
 
+private lemma aemeasurable_chafaiDensity_ofReal (f : ℝ → ℝ)
+    (hcm : IsCompletelyMonotone f) (n : ℕ) :
+    AEMeasurable (fun t => ENNReal.ofReal (chafaiDensity f n t))
+      (volume.restrict (Ioi 0)) := by
+  have hcont : ContinuousOn (chafaiDensity f n) (Ici 0) :=
+    continuousOn_chafaiDensity (n := n) (hcm.contDiffOn.of_le (nat_le_top n))
+  exact ((hcont.mono Ioi_subset_Ici_self).aemeasurable measurableSet_Ioi).ennreal_ofReal
+
+private lemma chafaiDensity_neg_derivWithin_pred (f : ℝ → ℝ)
+    {n : ℕ} (hn : 2 ≤ n) {t : ℝ} (ht : 0 < t) :
+    chafaiDensity (fun t => -derivWithin f (Ici 0) t) (n - 1) t =
+      ((n : ℝ) - 1) / t * chafaiDensity f n t := by
+  have hn0 : n ≠ 0 := by omega
+  have hn10 : n - 1 ≠ 0 := by omega
+  rw [chafaiDensity_of_ne_zero hn10, chafaiDensity_of_ne_zero hn0]
+  have hiter : iteratedDerivWithin (n - 1)
+        (fun t => -derivWithin f (Ici 0) t) (Ici 0) t =
+      -iteratedDerivWithin n f (Ici 0) t := by
+    change iteratedDerivWithin (n - 1) (-(derivWithin f (Ici 0))) (Ici 0) t =
+      -iteratedDerivWithin n f (Ici 0) t
+    rw [iteratedDerivWithin_neg]
+    congr 1
+    rw [← iteratedDerivWithin_succ']
+    congr 1
+    omega
+  rw [hiter]
+  have hfact : ((n - 1).factorial : ℝ) =
+      ((n - 1 : ℕ) : ℝ) * ((n - 2).factorial : ℝ) := by
+    rw [show n - 1 = (n - 2) + 1 by omega, Nat.factorial_succ]
+    norm_num
+  rw [hfact]
+  have hnp : ((n - 1 : ℕ) : ℝ) = (n : ℝ) - 1 := by
+    norm_num [Nat.cast_sub (by omega : 1 ≤ n)]
+  have hsub : n - 1 - 1 = n - 2 := by omega
+  have hpow' : t ^ (n - 2) * t = t ^ (n - 1) := by
+    rw [show n - 1 = (n - 2) + 1 by omega, pow_succ]
+  have hsign : -((-1 : ℝ) ^ (n - 1)) = (-1 : ℝ) ^ n := by
+    have hpow : ((-1 : ℝ) ^ n) = (-1 : ℝ) ^ ((n - 1) + 1) := by
+      congr
+      omega
+    rw [hpow, pow_succ]
+    ring
+  have hden : (n : ℝ) - 1 ≠ 0 := by
+    have hnR : (2 : ℝ) ≤ n := by exact_mod_cast hn
+    nlinarith
+  rw [hnp, hsub]
+  field_simp [ht.ne', hden]
+  calc
+    -(((-1 : ℝ) ^ (n - 1) * t ^ (n - 2) *
+          iteratedDerivWithin n f (Ici 0) t * t))
+        = -((-1 : ℝ) ^ (n - 1)) * (t ^ (n - 2) * t) *
+            iteratedDerivWithin n f (Ici 0) t := by ring
+    _ = (-1 : ℝ) ^ n * t ^ (n - 1) *
+            iteratedDerivWithin n f (Ici 0) t := by rw [hsign, hpow']
+    _ = iteratedDerivWithin n f (Ici 0) t * (-1 : ℝ) ^ n * t ^ (n - 1) := by
+          ring
+
+private lemma chafaiRescaled_lintegral_coe_eq_chafaiMeasure_neg_derivWithin
+    (f : ℝ → ℝ) (hcm : IsCompletelyMonotone f) {n : ℕ} (hn : 2 ≤ n) :
+    ∫⁻ p : ℝ≥0, ENNReal.ofReal (p : ℝ) ∂(chafaiRescaled f n) =
+      (chafaiMeasure (fun t => -derivWithin f (Ici 0) t) (n - 1)) univ := by
+  rw [chafaiRescaled_eq_map]
+  rw [lintegral_map]
+  swap
+  · exact ENNReal.measurable_ofReal.comp (by fun_prop : Measurable fun p : ℝ≥0 => (p : ℝ))
+  swap
+  · exact measurable_chafaiRescaling n
+  rw [chafaiMeasure_eq_withDensity]
+  rw [lintegral_withDensity_eq_lintegral_mul₀]
+  swap
+  · exact aemeasurable_chafaiDensity_ofReal f hcm n
+  swap
+  · exact ((NNReal.continuous_coe.measurable.comp (measurable_chafaiRescaling n)).aemeasurable)
+      |>.ennreal_ofReal
+  rw [chafaiMeasure_eq_withDensity, withDensity_apply _ MeasurableSet.univ]
+  simp only [Measure.restrict_univ]
+  refine lintegral_congr_ae ?_
+  filter_upwards [ae_restrict_mem measurableSet_Ioi] with t ht
+  have htpos : 0 < t := ht
+  have hscale : (chafaiRescaling n t : ℝ) = ((n : ℝ) - 1) / t :=
+    chafaiRescaling_coe_of_pos (by omega : 1 ≤ n) htpos
+  have hdens_nonneg : 0 ≤ chafaiDensity f n t :=
+    chafaiDensity_nonneg htpos.le (hcm.neg_one_pow_mul_iteratedDerivWithin_nonneg n htpos.le)
+  have hdens_eq := chafaiDensity_neg_derivWithin_pred f hn htpos
+  simp only [Pi.mul_apply]
+  rw [hscale, ← ENNReal.ofReal_mul hdens_nonneg, mul_comm, ← hdens_eq]
+
 /-- **IBP identity** for the CM density:
 `∫₀ᵀ ρ_{m+2}(t) dt = B_{m+2}(T) + ∫₀ᵀ ρ_{m+1}(t) dt`. -/
 private lemma chafaiDensity_ibp_identity (f : ℝ → ℝ) {m : ℕ}
@@ -655,6 +743,35 @@ lemma chafaiRescaled_finite_mass (f : ℝ → ℝ) (hcm : IsCompletelyMonotone f
   · rw [hmass]
     exact (hfinite n).2
 
+/-- Uniform first-moment bound for the rescaled Chafaï measures. -/
+lemma chafaiRescaled_lintegral_coe_le (f : ℝ → ℝ) (hcm : IsCompletelyMonotone f) :
+    ∀ n,
+      ∫⁻ p : ℝ≥0, ENNReal.ofReal (p : ℝ) ∂(chafaiRescaled f n) ≤
+        ENNReal.ofReal (-derivWithin f (Ici 0) 0) := by
+  intro n
+  have hderiv_nonneg : 0 ≤ -derivWithin f (Ici 0) 0 := by
+    linarith [hcm.derivWithin_nonpos le_rfl]
+  rcases lt_or_ge n 2 with hn | hn
+  · interval_cases n
+    · rw [chafaiRescaled_zero]
+      simp
+    · rw [chafaiRescaled_eq_map, lintegral_map]
+      swap
+      · exact ENNReal.measurable_ofReal.comp
+          (by fun_prop : Measurable fun p : ℝ≥0 => (p : ℝ))
+      swap
+      · exact measurable_chafaiRescaling 1
+      simp [chafaiRescaling]
+  · obtain ⟨L, _hL, hL_nonneg, hfinite⟩ :=
+      chafaiMeasure_finite_mass (fun t => -derivWithin f (Ici 0) t) hcm.neg_derivWithin
+    calc
+      ∫⁻ p : ℝ≥0, ENNReal.ofReal (p : ℝ) ∂(chafaiRescaled f n)
+          = (chafaiMeasure (fun t => -derivWithin f (Ici 0) t) (n - 1)) univ :=
+              chafaiRescaled_lintegral_coe_eq_chafaiMeasure_neg_derivWithin f hcm hn
+      _ ≤ ENNReal.ofReal (-derivWithin f (Ici 0) 0 - L) := (hfinite (n - 1)).2
+      _ ≤ ENNReal.ofReal (-derivWithin f (Ici 0) 0) :=
+          ENNReal.ofReal_le_ofReal (by linarith)
+
 /-- Prokhorov-ready mass bound for the rescaled Chafaï measures: a completely monotone function
 supplies a nonnegative real mass constant `C = f(0) - L`, where `L` is the limit of `f` at
 infinity, such that every `chafaiRescaled f n` is finite and has total mass at most `C`. -/
@@ -673,6 +790,690 @@ lemma chafaiRescaled_prokhorov_mass_bound (f : ℝ → ℝ) (hcm : IsCompletelyM
     rfl
   rw [hC]
   exact (hfinite n).2
+
+/-! ## Chafaï reconstruction and Bernstein-to-Laplace replacement -/
+
+private lemma chafai_kernel_density_eq (f : ℝ → ℝ)
+    (n : ℕ) (hn : 2 ≤ n) (x : ℝ) (hx : 0 ≤ x) :
+    ∫ t in Ioi 0, bernsteinKernel n x (((n : ℝ) - 1) / t) *
+      chafaiDensity f n t =
+    ∫ t in Ioi x, (-1 : ℝ) ^ n / ↑(n - 1).factorial *
+      (t - x) ^ (n - 1) * iteratedDerivWithin n f (Ici 0) t := by
+  have hn0 : n ≠ 0 := by omega
+  have hn1 : ¬ n ≤ 1 := by omega
+  have hne : ((n : ℝ) - 1) ≠ 0 := by
+    have : (2 : ℝ) ≤ (n : ℝ) := by exact_mod_cast hn
+    linarith
+  have hsubset : Ioi x ⊆ Ioi 0 := Ioi_subset_Ioi hx
+  have hvanish : ∀ t ∈ Ioi 0 \ Ioi x,
+      bernsteinKernel n x (((n : ℝ) - 1) / t) * chafaiDensity f n t = 0 := by
+    intro t ht
+    simp only [Set.mem_sdiff, mem_Ioi, not_lt] at ht
+    simp only [bernsteinKernel, hn1, ite_false]
+    have hcast : (↑(n - 1) : ℝ) = ↑n - 1 := by
+      rw [Nat.cast_sub (by omega : 1 ≤ n)]
+      simp
+    have hratio : x * (((n : ℝ) - 1) / t) / ↑(n - 1) = x / t := by
+      rw [hcast]
+      field_simp [hne, ne_of_gt ht.1]
+    rw [hratio, max_eq_right (by rw [sub_nonpos, le_div_iff₀ ht.1]; linarith)]
+    rw [zero_pow (by omega : n - 1 ≠ 0), zero_mul]
+  rw [setIntegral_eq_of_subset_of_forall_sdiff_eq_zero measurableSet_Ioi hsubset hvanish]
+  apply setIntegral_congr_fun measurableSet_Ioi
+  intro t ht
+  simp only [mem_Ioi] at ht
+  have ht_pos : 0 < t := lt_of_le_of_lt hx ht
+  have hcast : (↑(n - 1) : ℝ) = ↑n - 1 := by
+    rw [Nat.cast_sub (by omega : 1 ≤ n)]
+    simp
+  simp only [bernsteinKernel, hn1, ite_false]
+  have hratio : x * (((n : ℝ) - 1) / t) / ↑(n - 1) = x / t := by
+    rw [hcast]
+    field_simp [hne, ne_of_gt ht_pos]
+  rw [hratio, max_eq_left (by rw [sub_nonneg, div_le_one₀ ht_pos]; linarith)]
+  rw [chafaiDensity_of_ne_zero hn0]
+  have key : (1 - x / t) ^ (n - 1) * t ^ (n - 1) = (t - x) ^ (n - 1) := by
+    rw [← mul_pow]
+    congr 1
+    field_simp [ne_of_gt ht_pos]
+  calc
+    (1 - x / t) ^ (n - 1) *
+        (((-1 : ℝ) ^ n / ↑(n - 1).factorial * t ^ (n - 1)) *
+          iteratedDerivWithin n f (Ici 0) t)
+        = (-1 : ℝ) ^ n / ↑(n - 1).factorial *
+          ((1 - x / t) ^ (n - 1) * t ^ (n - 1)) *
+          iteratedDerivWithin n f (Ici 0) t := by ring
+    _ = _ := by rw [key]
+
+private lemma ibp_finite_interval (f : ℝ → ℝ) (hcm : IsCompletelyMonotone f)
+    (k : ℕ) (hk : k ≠ 0) (x T : ℝ) (hx : 0 ≤ x) (hxT : x < T) :
+    ∫ t in x..T, (-1 : ℝ) ^ (k + 1) / ↑k.factorial * (t - x) ^ k *
+      iteratedDerivWithin (k + 1) f (Ici 0) t =
+    (-1 : ℝ) ^ (k + 1) / ↑k.factorial * (T - x) ^ k *
+      iteratedDerivWithin k f (Ici 0) T -
+    ∫ t in x..T, (-1 : ℝ) ^ (k + 1) / ↑(k - 1).factorial * (t - x) ^ (k - 1) *
+      iteratedDerivWithin k f (Ici 0) t := by
+  set c := (-1 : ℝ) ^ (k + 1) / ↑k.factorial
+  set g := iteratedDerivWithin k f (Ici 0)
+  set g' := iteratedDerivWithin (k + 1) f (Ici 0)
+  set u := fun t : ℝ => c * (t - x) ^ k
+  set u' := fun t : ℝ => c * (↑k * (t - x) ^ (k - 1))
+  have hu'_eq : ∀ t, u' t =
+      (-1 : ℝ) ^ (k + 1) / ↑(k - 1).factorial * (t - x) ^ (k - 1) := by
+    intro t
+    simp only [u', c]
+    have hfact : k.factorial = k * (k - 1).factorial := by
+      cases k with
+      | zero => contradiction
+      | succ n => simp [Nat.factorial_succ]
+    rw [hfact]
+    push_cast
+    field_simp
+  have hu_cont : ContinuousOn u (uIcc x T) :=
+    continuousOn_const.mul ((continuousOn_id.sub continuousOn_const).pow _)
+  have hg_cont : ContinuousOn g (uIcc x T) := by
+    rw [uIcc_of_le hxT.le]
+    exact (hcm.contDiffOn.continuousOn_iteratedDerivWithin (nat_le_top k)
+      (uniqueDiffOn_Ici 0)).mono
+        (Icc_subset_Ici_self.trans (Ici_subset_Ici.mpr hx))
+  have hu_deriv : ∀ t ∈ Ioo (min x T) (max x T),
+      HasDerivWithinAt u (u' t) (Ioi t) t := by
+    intro t _ht
+    apply HasDerivAt.hasDerivWithinAt
+    simpa [u, u', mul_assoc] using
+      (((hasDerivAt_pow k (t - x)).comp t
+        ((hasDerivAt_id t).sub_const x)).const_mul c)
+  have hg_deriv : ∀ t ∈ Ioo (min x T) (max x T),
+      HasDerivWithinAt g (g' t) (Ioi t) t := by
+    intro t ht
+    rw [min_eq_left hxT.le, max_eq_right hxT.le] at ht
+    exact (hcm.hasDerivAt_iteratedDerivWithin_succ k (lt_of_le_of_lt hx ht.1)).hasDerivWithinAt
+  have hu'_int : IntervalIntegrable u' volume x T :=
+    (continuousOn_const.mul (continuousOn_const.mul
+      ((continuousOn_id.sub continuousOn_const).pow _))).intervalIntegrable
+  have hg'_int : IntervalIntegrable g' volume x T := by
+    apply ContinuousOn.intervalIntegrable
+    rw [uIcc_of_le hxT.le]
+    exact (hcm.contDiffOn.continuousOn_iteratedDerivWithin (nat_le_top (k + 1))
+      (uniqueDiffOn_Ici 0)).mono
+        (Icc_subset_Ici_self.trans (Ici_subset_Ici.mpr hx))
+  have hibp := integral_mul_deriv_eq_deriv_mul_of_hasDeriv_right
+    hu_cont hg_cont hu_deriv hg_deriv hu'_int hg'_int
+  have hu0 : u x = 0 := by simp [u, sub_self, zero_pow hk]
+  rw [hu0, zero_mul, sub_zero] at hibp
+  have h1 : ∫ t in x..T, (-1 : ℝ) ^ (k + 1) / ↑k.factorial * (t - x) ^ k *
+        iteratedDerivWithin (k + 1) f (Ici 0) t =
+      ∫ t in x..T, u t * g' t :=
+    intervalIntegral.integral_congr_ae (ae_of_all _ fun t _ => by ring)
+  have h2 : ∫ t in x..T, u' t * g t =
+      ∫ t in x..T, (-1 : ℝ) ^ (k + 1) / ↑(k - 1).factorial * (t - x) ^ (k - 1) *
+        iteratedDerivWithin k f (Ici 0) t :=
+    intervalIntegral.integral_congr_ae (ae_of_all _ fun t _ => by rw [hu'_eq])
+  linarith
+
+private lemma tail_setIntegral_tendsto_zero {g : ℝ → ℝ} {a : ℝ}
+    (hg : IntegrableOn g (Ioi a)) :
+    Tendsto (fun T => ∫ t in Ioi T, g t) atTop (nhds 0) := by
+  set I := ∫ t in Ioi a, g t
+  have h_total : Tendsto (fun T => ∫ t in a..T, g t) atTop (nhds I) :=
+    (intervalIntegral_tendsto_integral_Ioi a hg tendsto_id).congr fun _ => by simp [id]
+  have hsub : Tendsto (fun T => I - ∫ t in a..T, g t) atTop (nhds 0) := by
+    convert tendsto_const_nhds.sub h_total using 1
+    simp
+  apply hsub.congr'
+  filter_upwards [eventually_gt_atTop a] with T hT
+  symm
+  have hdisj : Disjoint (Ioc a T) (Ioi T) := by
+    rw [disjoint_left]
+    intro y hy1 hy2
+    simp at hy1 hy2
+    linarith
+  have hunion : Ioc a T ∪ Ioi T = Ioi a := by
+    ext y
+    simp only [mem_union, mem_Ioc, mem_Ioi]
+    constructor
+    · rintro (⟨hy, _⟩ | hy) <;> linarith
+    · intro hy
+      by_cases hyT : y ≤ T
+      · left
+        exact ⟨hy, hyT⟩
+      · right
+        linarith
+  have hd := setIntegral_union hdisj measurableSet_Ioi
+    (hg.mono_set Ioc_subset_Ioi_self) (hg.mono_set (Ioi_subset_Ioi hT.le))
+  rw [hunion] at hd
+  rw [intervalIntegral.integral_of_le hT.le]
+  linarith
+
+private lemma boundary_term_decay (f : ℝ → ℝ) (hcm : IsCompletelyMonotone f)
+    (k : ℕ) (hk : k ≠ 0) (x : ℝ) (hx : 0 ≤ x)
+    (L : ℝ) (hL : Tendsto f atTop (nhds L)) :
+    Tendsto (fun T => (-1 : ℝ) ^ (k + 1) / ↑k.factorial * (T - x) ^ k *
+      iteratedDerivWithin k f (Ici 0) T) atTop (nhds 0) := by
+  set h := fun T => (-1 : ℝ) ^ k * iteratedDerivWithin k f (Ici 0) T
+  have hk1 : 1 ≤ k := Nat.one_le_iff_ne_zero.mpr hk
+  have hkey : Tendsto (fun T => (T - x) ^ k * h T) atTop (nhds 0) := by
+    have h_nonneg : ∀ T, 0 ≤ T → 0 ≤ h T := by
+      intro T hT
+      simpa [h] using hcm.neg_one_pow_mul_iteratedDerivWithin_nonneg k hT
+    have h_antitone : AntitoneOn h (Ici 0) := by
+      apply antitoneOn_of_deriv_nonpos (convex_Ici 0)
+      · simpa [h] using
+          (hcm.contDiffOn.continuousOn_iteratedDerivWithin (nat_le_top k)
+            (uniqueDiffOn_Ici 0)).const_mul ((-1 : ℝ) ^ k)
+      · rw [interior_Ici]
+        intro T hT
+        exact ((hcm.hasDerivAt_iteratedDerivWithin_succ k hT).const_mul
+          ((-1 : ℝ) ^ k)).differentiableAt.differentiableWithinAt
+      · rw [interior_Ici]
+        intro T hT
+        have hderiv :
+            deriv h T = (-1 : ℝ) ^ k * iteratedDerivWithin (k + 1) f (Ici 0) T := by
+          simpa [h] using
+            ((hcm.hasDerivAt_iteratedDerivWithin_succ k hT).const_mul
+              ((-1 : ℝ) ^ k)).deriv
+        rw [hderiv]
+        have hsign : 0 ≤ (-1 : ℝ) ^ (k + 1) *
+            iteratedDerivWithin (k + 1) f (Ici 0) T :=
+          hcm.neg_one_pow_mul_iteratedDerivWithin_nonneg (k + 1) hT.le
+        have hneg : 0 ≤ -(((-1 : ℝ) ^ k) *
+            iteratedDerivWithin (k + 1) f (Ici 0) T) := by
+          simpa [pow_succ, mul_assoc] using hsign
+        linarith
+    have hcont_density : ContinuousOn (chafaiDensity f k) (Ici 0) :=
+      continuousOn_chafaiDensity (n := k) (hcm.contDiffOn.of_le (nat_le_top k))
+    have hint_density : IntegrableOn (chafaiDensity f k) (Ioi 0) :=
+      chafaiDensity_integrableOn_Ioi_of_tendsto f hcm k hk1 L hL
+    have htail : Tendsto (fun S : ℝ => ∫ t in Ioi S, chafaiDensity f k t)
+        atTop (nhds 0) :=
+      tail_setIntegral_tendsto_zero hint_density
+    have htail_half : Tendsto (fun T : ℝ => ∫ t in Ioi (T / 2), chafaiDensity f k t)
+        atTop (nhds 0) := by
+      have hhalf_map : Tendsto (fun T : ℝ => (1 / 2 : ℝ) * T) atTop atTop :=
+        (tendsto_const_mul_atTop_of_pos (show (0 : ℝ) < 1 / 2 by positivity)).2 tendsto_id
+      refine (htail.comp hhalf_map).congr' ?_
+      filter_upwards with T
+      simp
+      ring_nf
+    have hupper :
+        ∀ᶠ T in atTop,
+          (T - x) ^ k * h T ≤
+            ((2 : ℝ) ^ k * ↑((k - 1).factorial)) *
+              ∫ t in Ioi (T / 2), chafaiDensity f k t := by
+      filter_upwards [eventually_gt_atTop (max (2 * x) 2)] with T hT
+      have hT2 : (2 : ℝ) < T := lt_of_le_of_lt (le_max_right (2 * x) 2) hT
+      have hTpos : 0 < T := by linarith
+      have hxT : x < T := by
+        have h2xT : 2 * x < T := lt_of_le_of_lt (le_max_left (2 * x) 2) hT
+        linarith
+      have hTx_nonneg : 0 ≤ T - x := sub_nonneg.mpr hxT.le
+      have hT_nonneg : 0 ≤ T := hTpos.le
+      have hhalf_nonneg : 0 ≤ T / 2 := by positivity
+      have hhT_nonneg : 0 ≤ h T := h_nonneg T hT_nonneg
+      have h_interval_le :
+          ∫ t in T / 2..T, chafaiDensity f k t ≤
+            ∫ t in Ioi (T / 2), chafaiDensity f k t := by
+        rw [intervalIntegral.integral_of_le (by linarith)]
+        apply setIntegral_mono_set (hint_density.mono_set (Ioi_subset_Ioi hhalf_nonneg))
+        · exact (ae_restrict_mem measurableSet_Ioi).mono fun t ht =>
+            chafaiDensity_nonneg (lt_of_le_of_lt hhalf_nonneg ht).le
+              (hcm.neg_one_pow_mul_iteratedDerivWithin_nonneg k
+                (lt_of_le_of_lt hhalf_nonneg ht).le)
+        · exact ae_of_all _ fun t ht => Ioc_subset_Ioi_self ht
+      have h_density_eq :
+          ∀ t, chafaiDensity f k t =
+            (1 / ↑((k - 1).factorial)) * t ^ (k - 1) * h t := by
+        intro t
+        rw [chafaiDensity_of_ne_zero hk]
+        simp only [h]
+        field_simp
+      have h_const_le :
+          (1 / ↑((k - 1).factorial)) * (T / 2) ^ k * h T ≤
+            ∫ t in T / 2..T, chafaiDensity f k t := by
+        have hmono :
+            ∀ᵐ t ∂(volume.restrict (Icc (T / 2) T)),
+              (1 / ↑((k - 1).factorial)) * (T / 2) ^ (k - 1) * h T ≤
+                chafaiDensity f k t := by
+          filter_upwards [ae_restrict_mem measurableSet_Icc] with t ht
+          have ht_nonneg : 0 ≤ t := le_trans hhalf_nonneg ht.1
+          have ht_pos : 0 < t := lt_of_lt_of_le (by positivity : 0 < T / 2) ht.1
+          have hpow : (T / 2) ^ (k - 1) ≤ t ^ (k - 1) :=
+            pow_le_pow_left₀ hhalf_nonneg ht.1 _
+          have hh_le : h T ≤ h t :=
+            h_antitone ht_nonneg hT_nonneg ht.2
+          have hmul :
+              (1 / ↑((k - 1).factorial)) * (T / 2) ^ (k - 1) * h T ≤
+                (1 / ↑((k - 1).factorial)) * t ^ (k - 1) * h t := by
+            have hcoeff_nonneg : 0 ≤ (1 / ↑((k - 1).factorial) : ℝ) := by positivity
+            have hright_nonneg : 0 ≤ (1 / ↑((k - 1).factorial)) * t ^ (k - 1) :=
+              mul_nonneg hcoeff_nonneg (pow_nonneg ht_nonneg _)
+            calc
+              (1 / ↑((k - 1).factorial)) * (T / 2) ^ (k - 1) * h T
+                  ≤ ((1 / ↑((k - 1).factorial)) * t ^ (k - 1)) * h T := by
+                    simpa [mul_assoc] using
+                      mul_le_mul_of_nonneg_right
+                        (mul_le_mul_of_nonneg_left hpow hcoeff_nonneg)
+                        hhT_nonneg
+              _ ≤ ((1 / ↑((k - 1).factorial)) * t ^ (k - 1)) * h t :=
+                    mul_le_mul_of_nonneg_left hh_le hright_nonneg
+          simpa [h_density_eq t] using hmul
+        have hconst_int :
+            IntervalIntegrable (fun _ : ℝ =>
+              (1 / ↑((k - 1).factorial)) * (T / 2) ^ (k - 1) * h T) volume (T / 2) T :=
+          intervalIntegrable_const
+        have hIcc_subset : Icc (T / 2) T ⊆ Ici 0 := by
+          intro t ht
+          exact le_trans hhalf_nonneg ht.1
+        have hdens_int : IntervalIntegrable (chafaiDensity f k) volume (T / 2) T :=
+          (hcont_density.mono hIcc_subset).intervalIntegrable_of_Icc (by linarith)
+        have hmono_int :=
+          intervalIntegral.integral_mono_ae_restrict (μ := volume) (a := T / 2) (b := T)
+            (hab := by linarith) hconst_int hdens_int hmono
+        rw [intervalIntegral.integral_const] at hmono_int
+        have hhalf_eq : (T - T / 2) = T / 2 := by ring
+        rw [hhalf_eq] at hmono_int
+        rw [smul_eq_mul] at hmono_int
+        have hconst_eq :
+            T / 2 * ((1 / ↑((k - 1).factorial)) * (T / 2) ^ (k - 1) * h T) =
+              (1 / ↑((k - 1).factorial)) * (T / 2) ^ k * h T := by
+          have hk_succ : k = (k - 1) + 1 := by omega
+          rw [hk_succ]
+          ring_nf
+          have hnat : 1 + (k - 1) - 1 = k - 1 := by omega
+          simp [hnat]
+        rw [hconst_eq] at hmono_int
+        exact hmono_int
+      have hhalf_le :
+          (T / 2) ^ k * h T ≤
+            ↑((k - 1).factorial) * ∫ t in Ioi (T / 2), chafaiDensity f k t := by
+        have hfact_pos : (0 : ℝ) < ↑((k - 1).factorial) :=
+          Nat.cast_pos.mpr (Nat.factorial_pos _)
+        have haux := le_trans h_const_le h_interval_le
+        have hmul := mul_le_mul_of_nonneg_left haux hfact_pos.le
+        have hleft_eq :
+            ↑((k - 1).factorial) *
+                ((1 / ↑((k - 1).factorial)) * (T / 2) ^ k * h T) =
+              (T / 2) ^ k * h T := by
+          field_simp [hfact_pos.ne']
+        rw [hleft_eq] at hmul
+        exact hmul
+      have hpow_le : (T - x) ^ k ≤ T ^ k :=
+        pow_le_pow_left₀ hTx_nonneg (by linarith) _
+      have hTk_eq : T ^ k * h T = (2 : ℝ) ^ k * ((T / 2) ^ k * h T) := by
+        calc
+          T ^ k * h T = ((2 : ℝ) * (T / 2)) ^ k * h T := by congr 1; field_simp
+          _ = (2 : ℝ) ^ k * ((T / 2) ^ k * h T) := by rw [mul_pow]; ring
+      calc
+        (T - x) ^ k * h T ≤ T ^ k * h T := by gcongr
+        _ = (2 : ℝ) ^ k * ((T / 2) ^ k * h T) := hTk_eq
+        _ ≤ (2 : ℝ) ^ k *
+            (↑((k - 1).factorial) * ∫ t in Ioi (T / 2), chafaiDensity f k t) := by
+              gcongr
+        _ = ((2 : ℝ) ^ k * ↑((k - 1).factorial)) *
+              ∫ t in Ioi (T / 2), chafaiDensity f k t := by ring
+    have hnonneg_event : ∀ᶠ T in atTop, 0 ≤ (T - x) ^ k * h T := by
+      filter_upwards [eventually_gt_atTop (max x 0)] with T hT
+      have hT0 : 0 < T := lt_of_le_of_lt (le_max_right x 0) hT
+      have hxT : x < T := lt_of_le_of_lt (le_max_left x 0) hT
+      exact mul_nonneg (pow_nonneg (sub_nonneg.mpr hxT.le) _) (h_nonneg T hT0.le)
+    have hupper_tendsto :
+        Tendsto (fun T : ℝ =>
+          ((2 : ℝ) ^ k * ↑((k - 1).factorial)) *
+            ∫ t in Ioi (T / 2), chafaiDensity f k t) atTop (nhds 0) := by
+      simpa [mul_zero] using htail_half.const_mul (((2 : ℝ) ^ k) * ↑((k - 1).factorial))
+    exact squeeze_zero' hnonneg_event hupper hupper_tendsto
+  have heq : ∀ T, (-1 : ℝ) ^ (k + 1) / ↑k.factorial * (T - x) ^ k *
+      iteratedDerivWithin k f (Ici 0) T =
+      -(1 / ↑k.factorial) * ((T - x) ^ k * h T) := by
+    intro T
+    simp only [h, pow_succ]
+    ring
+  simp_rw [heq]
+  rw [show (0 : ℝ) = -(1 / ↑k.factorial) * 0 from by ring]
+  exact hkey.const_mul _
+
+private lemma ibp_kernel_integrableOn (f : ℝ → ℝ) (hcm : IsCompletelyMonotone f)
+    (k : ℕ) (hk : 1 ≤ k) (x : ℝ) (hx : 0 ≤ x)
+    (L : ℝ) (hL : Tendsto f atTop (nhds L)) :
+    IntegrableOn (fun t => (-1 : ℝ) ^ k / ↑(k - 1).factorial * (t - x) ^ (k - 1) *
+      iteratedDerivWithin k f (Ici 0) t) (Ioi x) := by
+  have hk0 : k ≠ 0 := by omega
+  have hint_density : IntegrableOn (chafaiDensity f k) (Ioi 0) :=
+    chafaiDensity_integrableOn_Ioi_of_tendsto f hcm k hk L hL
+  apply Integrable.mono' (hint_density.mono_set (Ioi_subset_Ioi hx))
+  · apply (ContinuousOn.aestronglyMeasurable _ measurableSet_Ioi)
+    exact ((continuousOn_const.mul
+      ((continuousOn_id.sub continuousOn_const).pow _)).mul
+      ((hcm.contDiffOn.continuousOn_iteratedDerivWithin (nat_le_top k)
+        (uniqueDiffOn_Ici 0)).mono
+        (fun t ht => mem_Ici.mpr (lt_of_le_of_lt hx ht).le)))
+  · rw [ae_restrict_iff' measurableSet_Ioi]
+    apply ae_of_all
+    intro t ht
+    simp only [Ioi, mem_setOf_eq] at ht
+    have ht0 : 0 < t := lt_of_le_of_lt hx ht
+    have htx : 0 ≤ t - x := by linarith
+    have htx_le : t - x ≤ t := by linarith
+    rw [chafaiDensity_of_ne_zero hk0]
+    have hcm_sign : 0 ≤ (-1 : ℝ) ^ k * iteratedDerivWithin k f (Ici 0) t :=
+      hcm.neg_one_pow_mul_iteratedDerivWithin_nonneg k ht0.le
+    have hfact : (0 : ℝ) < ↑(k - 1).factorial := Nat.cast_pos.mpr (Nat.factorial_pos _)
+    have hval_nn : 0 ≤ (-1 : ℝ) ^ k / ↑(k - 1).factorial * (t - x) ^ (k - 1) *
+        iteratedDerivWithin k f (Ici 0) t := by
+      calc
+        (-1 : ℝ) ^ k / ↑(k - 1).factorial * (t - x) ^ (k - 1) *
+            iteratedDerivWithin k f (Ici 0) t
+            = (t - x) ^ (k - 1) / ↑(k - 1).factorial *
+              ((-1 : ℝ) ^ k * iteratedDerivWithin k f (Ici 0) t) := by field_simp
+        _ ≥ 0 := mul_nonneg (div_nonneg (pow_nonneg htx _) hfact.le) hcm_sign
+    rw [Real.norm_eq_abs, abs_of_nonneg hval_nn]
+    calc
+      (-1 : ℝ) ^ k / ↑(k - 1).factorial * (t - x) ^ (k - 1) *
+          iteratedDerivWithin k f (Ici 0) t
+          = (1 / ↑(k - 1).factorial) * (t - x) ^ (k - 1) *
+            ((-1 : ℝ) ^ k * iteratedDerivWithin k f (Ici 0) t) := by field_simp
+      _ ≤ (1 / ↑(k - 1).factorial) * t ^ (k - 1) *
+          ((-1 : ℝ) ^ k * iteratedDerivWithin k f (Ici 0) t) := by
+            exact mul_le_mul_of_nonneg_right
+              (mul_le_mul_of_nonneg_left (pow_le_pow_left₀ htx htx_le _) (by positivity))
+              hcm_sign
+      _ = (-1 : ℝ) ^ k / ↑(k - 1).factorial * t ^ (k - 1) *
+          iteratedDerivWithin k f (Ici 0) t := by field_simp
+
+private lemma chafai_repeated_ibp (f : ℝ → ℝ) (hcm : IsCompletelyMonotone f)
+    (n : ℕ) (hn : 1 ≤ n) (x : ℝ) (hx : 0 ≤ x)
+    (L : ℝ) (hL : Tendsto f atTop (nhds L)) :
+    ∫ t in Ioi x, (-1 : ℝ) ^ n / ↑(n - 1).factorial *
+      (t - x) ^ (n - 1) *
+      iteratedDerivWithin n f (Ici 0) t = f x - L := by
+  induction n with
+  | zero => omega
+  | succ k ih =>
+    by_cases hk : k = 0
+    · subst hk
+      have hsimpl :
+          (fun t => (-1 : ℝ) ^ (0 + 1) / ↑(0 + 1 - 1).factorial *
+            (t - x) ^ (0 + 1 - 1) *
+            iteratedDerivWithin (0 + 1) f (Ici 0) t) =
+          (fun t => -iteratedDerivWithin 1 f (Ici 0) t) := by
+        ext t
+        simp
+      rw [hsimpl]
+      have hintx : IntegrableOn (fun t => -iteratedDerivWithin 1 f (Ici 0) t) (Ioi x) :=
+        hcm.neg_iteratedDerivWithin_one_integrableOn.mono_set (Ioi_subset_Ioi hx)
+      refine tendsto_nhds_unique
+        (intervalIntegral_tendsto_integral_Ioi x hintx tendsto_id) ?_
+      simp only [id]
+      refine Tendsto.congr' ?_ (Tendsto.sub tendsto_const_nhds hL)
+      filter_upwards [eventually_gt_atTop (max x 1)] with T hT
+      have hxT : x < T := lt_of_le_of_lt (le_max_left x 1) hT
+      rw [show (∫ t in x..T, -iteratedDerivWithin 1 f (Ici 0) t) =
+          ∫ t in x..T, -iteratedDerivWithin 1 f (Icc x T) t from by
+        apply intervalIntegral.integral_congr_ae
+        apply ae_of_all
+        intro t ht
+        rw [uIoc_of_le hxT.le] at ht
+        have ht_pos : 0 < t := lt_of_le_of_lt hx ht.1
+        have hcda : ContDiffAt ℝ (↑1 : WithTop ℕ∞) f t :=
+          (hcm.contDiffOn.of_le (nat_le_top 1)).contDiffAt (Ici_mem_nhds ht_pos)
+        congr 1
+        rw [iteratedDerivWithin_eq_iteratedDeriv
+            (uniqueDiffOn_Icc hxT) hcda (Ioc_subset_Icc_self ht),
+          iteratedDerivWithin_eq_iteratedDeriv
+            (uniqueDiffOn_Ici 0) hcda (mem_Ici.mpr ht_pos.le)]]
+      exact hcm.integral_neg_iteratedDerivWithin_one_Icc x T hx hxT.le
+    · have hk1 : 1 ≤ k := Nat.one_le_iff_ne_zero.mpr hk
+      have ih_applied := ih hk1
+      simp only [show k + 1 - 1 = k by omega]
+      have hintk := ibp_kernel_integrableOn f hcm k hk1 x hx L hL
+      have hintkp1 := ibp_kernel_integrableOn f hcm (k + 1) (by omega) x hx L hL
+      simp only [show k + 1 - 1 = k by omega] at hintkp1
+      have hibp := fun T (hT : x < T) => ibp_finite_interval f hcm k hk x T hx hT
+      have hbdry := boundary_term_decay f hcm k hk x hx L hL
+      have htend_k : Tendsto (fun T => ∫ t in x..T,
+          (-1 : ℝ) ^ k / ↑(k - 1).factorial * (t - x) ^ (k - 1) *
+          iteratedDerivWithin k f (Ici 0) t) atTop (nhds (f x - L)) := by
+        rw [← ih_applied]
+        exact intervalIntegral_tendsto_integral_Ioi x hintk tendsto_id
+      have hsign : ∀ T, ∫ t in x..T,
+          (-1 : ℝ) ^ (k + 1) / ↑(k - 1).factorial * (t - x) ^ (k - 1) *
+          iteratedDerivWithin k f (Ici 0) t =
+          -(∫ t in x..T, (-1 : ℝ) ^ k / ↑(k - 1).factorial * (t - x) ^ (k - 1) *
+          iteratedDerivWithin k f (Ici 0) t) := by
+        intro T
+        rw [← intervalIntegral.integral_neg]
+        apply intervalIntegral.integral_congr_ae
+        apply ae_of_all
+        intro t _
+        have : (-1 : ℝ) ^ (k + 1) = (-1) ^ k * (-1) := pow_succ (-1) k
+        rw [this]
+        ring
+      have htend_sum : Tendsto (fun T =>
+          (-1 : ℝ) ^ (k + 1) / ↑k.factorial * (T - x) ^ k *
+            iteratedDerivWithin k f (Ici 0) T +
+          ∫ t in x..T, (-1 : ℝ) ^ k / ↑(k - 1).factorial * (t - x) ^ (k - 1) *
+            iteratedDerivWithin k f (Ici 0) t) atTop (nhds (f x - L)) := by
+        simpa [zero_add] using hbdry.add htend_k
+      have htend_via_ibp : Tendsto (fun T => ∫ t in x..T,
+          (-1 : ℝ) ^ (k + 1) / ↑k.factorial * (t - x) ^ k *
+          iteratedDerivWithin (k + 1) f (Ici 0) t) atTop (nhds (f x - L)) :=
+        Tendsto.congr' ((eventually_gt_atTop x).mono fun T hxT => by
+          have := hibp T hxT
+          linarith [hsign T]) htend_sum
+      exact tendsto_nhds_unique
+        ((intervalIntegral_tendsto_integral_Ioi x hintkp1 tendsto_id).congr
+          (fun T => by simp [id])) htend_via_ibp
+
+/-- **Chafaï reconstruction identity** for the nonconstant part. -/
+lemma chafai_identity (f : ℝ → ℝ) (hcm : IsCompletelyMonotone f)
+    (n : ℕ) (hn : 2 ≤ n) (x : ℝ) (hx : 0 ≤ x)
+    (L : ℝ) (hL : Tendsto f atTop (nhds L)) :
+    f x - L = ∫ p, bernsteinKernel n x (p : ℝ) ∂(chafaiRescaled f n) := by
+  have h_integral_pullback :
+      ∫ p : ℝ≥0, bernsteinKernel n x (p : ℝ) ∂(chafaiRescaled f n) =
+        ∫ t, bernsteinKernel n x (chafaiRescaling n t : ℝ) ∂(chafaiMeasure f n) := by
+    exact chafaiRescaled_integral f n
+      ((measurable_bernsteinKernel n x).comp (by fun_prop : Measurable fun p : ℝ≥0 => (p : ℝ))
+        |>.aestronglyMeasurable)
+  have h_integral_density :
+      ∫ t, bernsteinKernel n x (chafaiRescaling n t : ℝ) ∂(chafaiMeasure f n) =
+        ∫ t in Ioi 0,
+          bernsteinKernel n x (((n : ℝ) - 1) / t) * chafaiDensity f n t := by
+    rw [chafaiMeasure_eq_withDensity]
+    have hcont_density : ContinuousOn (chafaiDensity f n) (Ici 0) :=
+      continuousOn_chafaiDensity (n := n) (hcm.contDiffOn.of_le (nat_le_top n))
+    rw [integral_withDensity_eq_integral_toReal_smul₀
+      (AEMeasurable.ennreal_ofReal
+        ((hcont_density.mono Ioi_subset_Ici_self).aestronglyMeasurable
+          measurableSet_Ioi |>.aemeasurable))
+      (ae_of_all _ fun _ => ENNReal.ofReal_lt_top)]
+    exact setIntegral_congr_ae measurableSet_Ioi
+      (ae_of_all _ fun t ht => by
+        simp only [smul_eq_mul, mem_Ioi] at ht ⊢
+        rw [chafaiRescaling_coe_of_pos (by omega : 1 ≤ n) ht]
+        rw [ENNReal.toReal_ofReal
+          (chafaiDensity_nonneg ht.le
+            (hcm.neg_one_pow_mul_iteratedDerivWithin_nonneg n ht.le))]
+        ring)
+  have hkernel := chafai_kernel_density_eq f n hn x hx
+  have hibp := chafai_repeated_ibp f hcm n (by omega) x hx L hL
+  rw [h_integral_pullback, h_integral_density, hkernel]
+  exact hibp.symm
+
+private lemma bernsteinKernel_le_exp {n : ℕ} (hn : 2 ≤ n) {x p : ℝ} (_hx : 0 ≤ x)
+    (_hp : 0 ≤ p) :
+    bernsteinKernel n x p ≤ Real.exp (-(x * p)) := by
+  rw [bernsteinKernel_of_two_le hn]
+  by_cases h : 1 - x * p / ↑(n - 1) ≤ 0
+  · rw [max_eq_right h]
+    rw [zero_pow (by omega : n - 1 ≠ 0)]
+    exact le_of_lt (Real.exp_pos _)
+  · push Not at h
+    rw [max_eq_left h.le]
+    have hden_pos : (0 : ℝ) < ↑(n - 1) := Nat.cast_pos.mpr (by omega)
+    have hle : 1 - x * p / ↑(n - 1) ≤ Real.exp (-(x * p / ↑(n - 1))) := by
+      linarith [Real.add_one_le_exp (-(x * p / ↑(n - 1)))]
+    calc
+      (1 - x * p / ↑(n - 1)) ^ (n - 1)
+          ≤ (Real.exp (-(x * p / ↑(n - 1)))) ^ (n - 1) :=
+            pow_le_pow_left₀ h.le hle _
+      _ = Real.exp (↑(n - 1) * -(x * p / ↑(n - 1))) := by
+            rw [← Real.exp_nat_mul]
+      _ = Real.exp (-(x * p)) := by
+            congr 1
+            field_simp [hden_pos.ne']
+
+private lemma kernel_uniform_conv_compact (x R ε : ℝ) (hx : 0 < x) (hR : 0 < R)
+    (hε : 0 < ε) :
+    ∃ N : ℕ, ∀ n, N ≤ n → ∀ p, 0 ≤ p → p ≤ R →
+      |bernsteinKernel n x p - Real.exp (-(x * p))| < ε := by
+  set C := x * R
+  have hC_pos : 0 < C := mul_pos hx hR
+  obtain ⟨N₀, hN₀⟩ := exists_nat_gt (C + 2 + 2 * C ^ 2 / ε)
+  refine ⟨N₀, fun n hn p hp hpR => ?_⟩
+  have hn_gt : (↑n : ℝ) > C + 2 + 2 * C ^ 2 / ε :=
+    lt_of_lt_of_le hN₀ (Nat.cast_le.mpr hn)
+  have haux : 0 ≤ 2 * C ^ 2 / ε := div_nonneg (by positivity) hε.le
+  have hn_ge2 : 2 ≤ n := by exact_mod_cast (show (2 : ℝ) < ↑n by linarith [hC_pos]).le
+  have hle := bernsteinKernel_le_exp hn_ge2 hx.le hp
+  rw [abs_of_nonpos (by linarith), neg_sub]
+  set m := n - 1
+  have hm_pos : (0 : ℝ) < ↑m := Nat.cast_pos.mpr (by omega)
+  have hm_eq : (↑m : ℝ) = ↑n - 1 := by
+    rw [Nat.cast_sub (show 1 ≤ n by omega)]
+    simp
+  have hxp_nn : 0 ≤ x * p := mul_nonneg hx.le hp
+  have hxp_le_C : x * p ≤ C := mul_le_mul_of_nonneg_left hpR hx.le
+  have hm_gt_C : C < ↑m := by linarith
+  set u := x * p / ↑m with hu_def
+  have hu_nn : 0 ≤ u := div_nonneg hxp_nn hm_pos.le
+  have hu_lt_1 : u < 1 := by rw [div_lt_one hm_pos]; linarith
+  have h1u : 0 < 1 - u := by linarith
+  have hkernel_eq : bernsteinKernel n x p = (1 - u) ^ m := by
+    rw [bernsteinKernel_of_two_le hn_ge2]
+    congr 1
+    exact max_eq_left (by
+      change 0 ≤ 1 - x * p / (↑m : ℝ)
+      rw [← hu_def]
+      linarith)
+  rw [hkernel_eq]
+  set b := ↑m * u ^ 2 / (1 - u) with hb_def
+  have hb_nn : 0 ≤ b :=
+    div_nonneg (mul_nonneg (Nat.cast_nonneg m) (sq_nonneg u)) h1u.le
+  have hmu : ↑m * u = x * p := by
+    simp only [hu_def]
+    field_simp [hm_pos.ne']
+  have hpow_ge : (1 - u) ^ m ≥ Real.exp (-(x * p) - b) := by
+    have heq : (1 - u) ^ m = Real.exp (↑m * Real.log (1 - u)) := by
+      rw [← Real.rpow_natCast (1 - u) m, Real.rpow_def_of_pos h1u, mul_comm]
+    rw [heq]
+    gcongr
+    rw [show -(x * p) - b = ↑m * (-u - u ^ 2 / (1 - u)) by
+      rw [← hmu, hb_def]
+      ring]
+    apply mul_le_mul_of_nonneg_left _ (Nat.cast_nonneg m)
+    have habs : |u| < 1 := by rwa [abs_of_nonneg hu_nn]
+    have hlog := Real.abs_log_sub_add_sum_range_le habs 1
+    simp only [Finset.sum_range_one, Nat.cast_zero, zero_add, div_one, pow_one] at hlog
+    rw [abs_of_nonneg hu_nn, show u ^ (1 + 1) = u ^ 2 by ring] at hlog
+    linarith [(abs_le.mp hlog).1]
+  have hstep : Real.exp (-(x * p)) - (1 - u) ^ m ≤ b := by
+    suffices h : Real.exp (-(x * p)) - Real.exp (-(x * p) - b) ≤ b by linarith
+    have : Real.exp (-(x * p) - b) = Real.exp (-(x * p)) * Real.exp (-b) := by
+      rw [← Real.exp_add]
+      ring_nf
+    rw [this]
+    nlinarith [Real.exp_pos (-(x * p)), Real.exp_pos (-b),
+      Real.exp_le_one_iff.mpr (neg_nonpos.mpr hxp_nn), Real.add_one_le_exp (-b)]
+  have hb_eq : b = (x * p) ^ 2 / (↑m - x * p) := by
+    simp only [hb_def, hu_def]
+    field_simp [hm_pos.ne']
+  have hm_gt_C' : 0 < ↑m - C := by linarith
+  have hb_le : b ≤ C ^ 2 / (↑m - C) := by
+    rw [hb_eq]
+    exact div_le_div₀ (sq_nonneg C) (sq_le_sq' (by linarith) hxp_le_C)
+      hm_gt_C' (by linarith)
+  have hfinal : C ^ 2 / (↑m - C) < ε / 2 := by
+    rw [div_lt_div_iff₀ hm_gt_C' (by positivity : (0 : ℝ) < 2)]
+    have h1 : ↑m - C > 2 * C ^ 2 / ε := by linarith [hm_eq]
+    have h2 : ε * (↑m - C) > ε * (2 * C ^ 2 / ε) := mul_lt_mul_of_pos_left h1 hε
+    rw [mul_div_cancel₀ _ (ne_of_gt hε)] at h2
+    linarith
+  linarith
+
+private lemma kernel_uniform_conv (x : ℝ) (hx : 0 < x) (ε : ℝ) (hε : 0 < ε) :
+    ∃ N : ℕ, ∀ n, N ≤ n → ∀ p, 0 ≤ p →
+      |bernsteinKernel n x p - Real.exp (-(x * p))| < ε := by
+  have htail : Tendsto (fun R => Real.exp (-(x * R))) atTop (nhds 0) := by
+    apply Tendsto.comp Real.tendsto_exp_neg_atTop_nhds_zero
+    exact tendsto_id.const_mul_atTop hx
+  obtain ⟨R₀, hR₀⟩ := Metric.tendsto_atTop.mp htail (ε / 2) (half_pos hε)
+  set R := max R₀ 1
+  have hR_pos : 0 < R := lt_of_lt_of_le one_pos (le_max_right R₀ 1)
+  have hR_tail : Real.exp (-(x * R)) < ε / 2 := by
+    have h1 := hR₀ R (le_max_left _ _)
+    rwa [dist_zero_right, Real.norm_eq_abs, abs_of_pos (Real.exp_pos _)] at h1
+  obtain ⟨N₁, hN₁⟩ := kernel_uniform_conv_compact x R (ε / 2) hx hR_pos (half_pos hε)
+  refine ⟨max N₁ 2, fun n hn p hp => ?_⟩
+  have hn2 : 2 ≤ n := le_trans (le_max_right N₁ 2) hn
+  by_cases hpR : p ≤ R
+  · linarith [hN₁ n (le_trans (le_max_left _ _) hn) p hp hpR]
+  · push Not at hpR
+    have h1 := bernsteinKernel_le_exp hn2 hx.le hp
+    rw [abs_of_nonpos (by linarith)]
+    have h2 : Real.exp (-(x * p)) ≤ Real.exp (-(x * R)) := by
+      apply Real.exp_le_exp_of_le
+      linarith [mul_le_mul_of_nonneg_left (le_of_lt hpR) hx.le]
+    linarith [bernsteinKernel_nonneg n x p]
+
+/-- Bernstein-to-Laplace replacement against a uniformly finite sequence of measures. -/
+lemma kernel_approx_error_tendsto
+    (σ : ℕ → Measure ℝ≥0)
+    (hfin : ∀ n, IsFiniteMeasure (σ n))
+    (hmass : ∀ n, (σ n) univ ≤ ENNReal.ofReal C)
+    (x : ℝ) (hx : 0 ≤ x) :
+    Tendsto (fun n => ∫ p : ℝ≥0,
+        (bernsteinKernel n x (p : ℝ) - Real.exp (-(x * (p : ℝ)))) ∂(σ n))
+      atTop (nhds 0) := by
+  by_cases hx0 : x = 0
+  · subst hx0
+    suffices h : ∀ᶠ n in atTop, ∫ p : ℝ≥0,
+        (bernsteinKernel n 0 (p : ℝ) - Real.exp (-(0 * (p : ℝ)))) ∂(σ n) = 0 by
+      exact Tendsto.congr' (EventuallyEq.symm h) tendsto_const_nhds
+    filter_upwards [eventually_ge_atTop 2] with n hn
+    apply integral_eq_zero_of_ae
+    apply ae_of_all
+    intro p
+    change bernsteinKernel n 0 (p : ℝ) - Real.exp (-(0 * (p : ℝ))) = 0
+    rw [bernsteinKernel_of_two_le hn]
+    simp
+  · have hx_pos : 0 < x := lt_of_le_of_ne hx (Ne.symm hx0)
+    rw [Metric.tendsto_atTop]
+    intro ε hε
+    have hmax_pos : 0 < max C 1 := lt_max_of_lt_right one_pos
+    obtain ⟨N, hN⟩ := kernel_uniform_conv x hx_pos
+      (ε / (2 * max C 1)) (div_pos hε (by positivity))
+    refine ⟨N, fun n hn => ?_⟩
+    rw [dist_zero_right]
+    letI := hfin n
+    calc
+      ‖∫ p : ℝ≥0, (bernsteinKernel n x (p : ℝ) - Real.exp (-(x * (p : ℝ)))) ∂(σ n)‖
+          ≤ ∫ p : ℝ≥0,
+              ‖bernsteinKernel n x (p : ℝ) - Real.exp (-(x * (p : ℝ)))‖ ∂(σ n) :=
+            norm_integral_le_integral_norm _
+      _ ≤ ∫ _ : ℝ≥0, (ε / (2 * max C 1)) ∂(σ n) := by
+          apply integral_mono_of_nonneg
+            (ae_of_all _ fun _ => norm_nonneg _) (integrable_const _)
+          exact ae_of_all _ fun p => by
+            simpa [Real.norm_eq_abs] using le_of_lt (hN n hn (p : ℝ) p.2)
+      _ = ε / (2 * max C 1) * ((σ n) univ).toReal := by
+          simp [MeasureTheory.integral_const, smul_eq_mul, Measure.real, mul_comm]
+      _ ≤ ε / (2 * max C 1) * max C 1 := by
+          apply mul_le_mul_of_nonneg_left _ (le_of_lt (div_pos hε (by positivity)))
+          exact ENNReal.toReal_le_of_le_ofReal (le_of_lt hmax_pos)
+            (le_trans (hmass n) (ENNReal.ofReal_le_ofReal (le_max_left C 1)))
+      _ = ε / 2 := by field_simp
+      _ < ε := half_lt_self hε
 
 /-- Weak convergence of the rescaled Chafaï measures specializes to the Laplace kernel:
 if all bounded-continuous test integrals for `chafaiRescaled f n` converge to those for `μ₀`,


### PR DESCRIPTION
Second half of the Chafaï-measure infrastructure for the Hausdorff–Bernstein–Widder theorem, extending the Part-1 file merged in #563.

Adds the support lemmas the theorem consumes: the IBP chain (`ibp_finite_interval`, `chafai_repeated_ibp`), `chafai_identity`, `bernsteinKernel_le_exp`, `kernel_uniform_conv(_compact)`, `kernel_approx_error_tendsto`, plus measurability/density helpers. Consumes main's already-merged `chafaiRescaled_finite_mass` / `_prokhorov_mass_bound` / `_tendsto_laplace_integral_of_weak` rather than redefining them.

**Prerequisite for #575** (the Bernstein theorem), split out to keep each PR under the review size gate. One file, +801 lines; standalone build green; axiom-clean.