### PR TITLE
feat: add normalizer quotient fibre actions

### DIFF
--- a/TauCeti/Algebra/GroupAction/OrbitRelQuotient.lean
+++ b/TauCeti/Algebra/GroupAction/OrbitRelQuotient.lean
@@ -311,7 +311,7 @@ lemma normalizerQuotientOrbitRelQuotientPermHom_mk_apply (H : Subgroup G)
   by simp [normalizerQuotientOrbitRelQuotientPermHom]
 
 /-- The normalizer quotient `N(H) / H` acts on the quotient by `H`-orbits. -/
-@[reducible]
+@[implicit_reducible]
 noncomputable def normalizerQuotientOrbitRelQuotientMulAction (H : Subgroup G) :
     MulAction (Subgroup.normalizerQuotient H) (_root_.MulAction.orbitRel.Quotient H X) :=
   MulAction.compHom (_root_.MulAction.orbitRel.Quotient H X)

--- a/TauCeti/Algebra/GroupAction/OrbitRelQuotient.lean
+++ b/TauCeti/Algebra/GroupAction/OrbitRelQuotient.lean
@@ -180,7 +180,7 @@ private lemma normalizer_smul_mem_orbit (H : Subgroup G)
     simp [Subgroup.smul_def, mul_smul]
 
 /-- A normalizer representative acts on the quotient by `H`-orbits. -/
-abbrev normalizerOrbitRelQuotientMap (H : Subgroup G)
+def normalizerOrbitRelQuotientMap (H : Subgroup G)
     (g : _root_.Subgroup.normalizer (H : Set G)) :
     _root_.MulAction.orbitRel.Quotient H X → _root_.MulAction.orbitRel.Quotient H X :=
   Quotient.map' (fun x : X => (g : G) • x) fun x y hxy => by
@@ -194,7 +194,7 @@ lemma normalizerOrbitRelQuotientMap_apply (H : Subgroup G)
     normalizerOrbitRelQuotientMap H g
         (Quotient.mk'' x : _root_.MulAction.orbitRel.Quotient H X) =
       Quotient.mk'' ((g : G) • x) :=
-  rfl
+  by simp [normalizerOrbitRelQuotientMap]
 
 /-- The normalizer representative `1` acts trivially on the orbit quotient. -/
 @[simp]
@@ -217,7 +217,7 @@ lemma normalizerOrbitRelQuotientMap_mul (H : Subgroup G)
   simp [normalizerOrbitRelQuotientMap, mul_smul]
 
 /-- A normalizer representative acts on the orbit quotient by a permutation. -/
-abbrev normalizerOrbitRelQuotientEquiv (H : Subgroup G)
+def normalizerOrbitRelQuotientEquiv (H : Subgroup G)
     (g : _root_.Subgroup.normalizer (H : Set G)) :
     Equiv.Perm (_root_.MulAction.orbitRel.Quotient H X) where
   toFun := normalizerOrbitRelQuotientMap H g
@@ -240,7 +240,7 @@ lemma normalizerOrbitRelQuotientEquiv_apply (H : Subgroup G)
     normalizerOrbitRelQuotientEquiv H g
         (Quotient.mk'' x : _root_.MulAction.orbitRel.Quotient H X) =
       Quotient.mk'' ((g : G) • x) :=
-  rfl
+  by simp [normalizerOrbitRelQuotientEquiv]
 
 /-- The inverse normalizer permutation translates representatives by the inverse element. -/
 @[simp]
@@ -249,10 +249,10 @@ lemma normalizerOrbitRelQuotientEquiv_symm_apply (H : Subgroup G)
     (normalizerOrbitRelQuotientEquiv H g).symm
         (Quotient.mk'' x : _root_.MulAction.orbitRel.Quotient H X) =
       Quotient.mk'' ((g : G)⁻¹ • x) :=
-  rfl
+  by simp [normalizerOrbitRelQuotientEquiv]
 
 /-- The normalizer action on the orbit quotient as a permutation representation. -/
-noncomputable abbrev normalizerOrbitRelQuotientPermHom (H : Subgroup G) :
+noncomputable def normalizerOrbitRelQuotientPermHom (H : Subgroup G) :
     _root_.Subgroup.normalizer (H : Set G) →*
       Equiv.Perm (_root_.MulAction.orbitRel.Quotient H X) where
   toFun := normalizerOrbitRelQuotientEquiv H
@@ -279,7 +279,7 @@ lemma normalizerOrbitRelQuotientPermHom_apply (H : Subgroup G)
     normalizerOrbitRelQuotientPermHom (X := X) H g
         (Quotient.mk'' x : _root_.MulAction.orbitRel.Quotient H X) =
       Quotient.mk'' ((g : G) • x) :=
-  rfl
+  by simp [normalizerOrbitRelQuotientPermHom]
 
 /-- Any normalizer representative whose underlying group element lies in `H` acts trivially
 on the quotient by `H`-orbits. -/
@@ -293,7 +293,7 @@ lemma normalizerOrbitRelQuotientPermHom_eq_one_of_mem
   exact Quotient.sound' ⟨⟨(g : G), hg⟩, rfl⟩
 
 /-- The action of the normalizer on an orbit quotient descends to `N(H) / H`. -/
-noncomputable abbrev normalizerQuotientOrbitRelQuotientPermHom (H : Subgroup G) :
+noncomputable def normalizerQuotientOrbitRelQuotientPermHom (H : Subgroup G) :
     Subgroup.normalizerQuotient H →*
       Equiv.Perm (_root_.MulAction.orbitRel.Quotient H X) :=
   Subgroup.normalizerQuotientLift H (normalizerOrbitRelQuotientPermHom (X := X) H)
@@ -308,7 +308,7 @@ lemma normalizerQuotientOrbitRelQuotientPermHom_mk_apply (H : Subgroup G)
         (Subgroup.normalizerQuotientMk H g)
         (Quotient.mk'' x : _root_.MulAction.orbitRel.Quotient H X) =
       Quotient.mk'' ((g : G) • x) :=
-  rfl
+  by simp [normalizerQuotientOrbitRelQuotientPermHom]
 
 /-- The normalizer quotient `N(H) / H` acts on the quotient by `H`-orbits. -/
 noncomputable abbrev normalizerQuotientOrbitRelQuotientMulAction (H : Subgroup G) :

--- a/TauCeti/Algebra/GroupAction/OrbitRelQuotient.lean
+++ b/TauCeti/Algebra/GroupAction/OrbitRelQuotient.lean
@@ -24,6 +24,10 @@ This file records small generic additions to Mathlib's `MulAction.orbitRel.Quoti
 * `TauCeti.MulAction.orbitRelQuotient_smul_eq_smul_iff_normalizerQuotientMk_inv_eq`: for a
   normal subgroup, equality of two translates in the `H`-orbit quotient is equality of the
   corresponding inverse representatives in `N(H) / H`.
+* `TauCeti.MulAction.normalizerOrbitRelQuotientPermHom`: the normalizer action on the
+  quotient by `H`-orbits.
+* `TauCeti.MulAction.normalizerQuotientOrbitRelQuotientPermHom`: the descended action of
+  `N(H) / H` on the quotient by `H`-orbits.
 -/
 
 public section
@@ -164,6 +168,153 @@ lemma orbitRelQuotient_smul_eq_smul_iff_normalizerQuotientMk_inv_eq [IsCancelSMu
     have hmem : g * k⁻¹ ∈ H := by
       simpa [mul_assoc] using (inferInstance : H.Normal).conj_mem _ (H.inv_mem h) g
     exact ⟨⟨g * k⁻¹, hmem⟩, by simp [Subgroup.smul_def, smul_smul]⟩
+
+private lemma normalizer_smul_mem_orbit (H : Subgroup G)
+    (g : _root_.Subgroup.normalizer (H : Set G))
+    {x y : X} (hxy : x ∈ _root_.MulAction.orbit H y) :
+    (g : G) • x ∈ _root_.MulAction.orbit H ((g : G) • y) := by
+  rcases hxy with ⟨h, hh⟩
+  refine ⟨⟨(g : G) * h * (g : G)⁻¹, ?_⟩, ?_⟩
+  · exact ((_root_.Subgroup.mem_normalizer_iff.mp g.2) (h : G)).1 h.2
+  · rw [← hh]
+    simp [Subgroup.smul_def, mul_smul]
+
+/-- A normalizer representative acts on the quotient by `H`-orbits. -/
+abbrev normalizerOrbitRelQuotientMap (H : Subgroup G)
+    (g : _root_.Subgroup.normalizer (H : Set G)) :
+    _root_.MulAction.orbitRel.Quotient H X → _root_.MulAction.orbitRel.Quotient H X :=
+  Quotient.map' (fun x : X => (g : G) • x) fun x y hxy => by
+    rw [_root_.MulAction.orbitRel_apply] at hxy ⊢
+    exact normalizer_smul_mem_orbit H g hxy
+
+/-- The normalizer action on an orbit quotient sends a class to the class of its translate. -/
+@[simp]
+lemma normalizerOrbitRelQuotientMap_apply (H : Subgroup G)
+    (g : _root_.Subgroup.normalizer (H : Set G)) (x : X) :
+    normalizerOrbitRelQuotientMap H g
+        (Quotient.mk'' x : _root_.MulAction.orbitRel.Quotient H X) =
+      Quotient.mk'' ((g : G) • x) :=
+  rfl
+
+/-- The normalizer representative `1` acts trivially on the orbit quotient. -/
+@[simp]
+lemma normalizerOrbitRelQuotientMap_one (H : Subgroup G) :
+    normalizerOrbitRelQuotientMap (X := X) H ⟨1, by simp⟩ = id := by
+  ext x
+  refine Quotient.inductionOn' x ?_
+  intro x
+  simp [normalizerOrbitRelQuotientMap]
+
+/-- Normalizer representatives act by composition on the orbit quotient. -/
+@[simp]
+lemma normalizerOrbitRelQuotientMap_mul (H : Subgroup G)
+    (g k : _root_.Subgroup.normalizer (H : Set G)) :
+    normalizerOrbitRelQuotientMap (X := X) H (g * k) =
+      normalizerOrbitRelQuotientMap H g ∘ normalizerOrbitRelQuotientMap H k := by
+  ext x
+  refine Quotient.inductionOn' x ?_
+  intro x
+  simp [normalizerOrbitRelQuotientMap, mul_smul]
+
+/-- A normalizer representative acts on the orbit quotient by a permutation. -/
+abbrev normalizerOrbitRelQuotientEquiv (H : Subgroup G)
+    (g : _root_.Subgroup.normalizer (H : Set G)) :
+    Equiv.Perm (_root_.MulAction.orbitRel.Quotient H X) where
+  toFun := normalizerOrbitRelQuotientMap H g
+  invFun := normalizerOrbitRelQuotientMap H g⁻¹
+  left_inv := by
+    intro x
+    refine Quotient.inductionOn' x ?_
+    intro x
+    simp [normalizerOrbitRelQuotientMap]
+  right_inv := by
+    intro x
+    refine Quotient.inductionOn' x ?_
+    intro x
+    simp [normalizerOrbitRelQuotientMap]
+
+/-- A normalizer representative permutes orbit classes by translating representatives. -/
+@[simp]
+lemma normalizerOrbitRelQuotientEquiv_apply (H : Subgroup G)
+    (g : _root_.Subgroup.normalizer (H : Set G)) (x : X) :
+    normalizerOrbitRelQuotientEquiv H g
+        (Quotient.mk'' x : _root_.MulAction.orbitRel.Quotient H X) =
+      Quotient.mk'' ((g : G) • x) :=
+  rfl
+
+/-- The inverse normalizer permutation translates representatives by the inverse element. -/
+@[simp]
+lemma normalizerOrbitRelQuotientEquiv_symm_apply (H : Subgroup G)
+    (g : _root_.Subgroup.normalizer (H : Set G)) (x : X) :
+    (normalizerOrbitRelQuotientEquiv H g).symm
+        (Quotient.mk'' x : _root_.MulAction.orbitRel.Quotient H X) =
+      Quotient.mk'' ((g : G)⁻¹ • x) :=
+  rfl
+
+/-- The normalizer action on the orbit quotient as a permutation representation. -/
+noncomputable abbrev normalizerOrbitRelQuotientPermHom (H : Subgroup G) :
+    _root_.Subgroup.normalizer (H : Set G) →*
+      Equiv.Perm (_root_.MulAction.orbitRel.Quotient H X) where
+  toFun := normalizerOrbitRelQuotientEquiv H
+  map_one' := by
+    ext x
+    refine Quotient.inductionOn' x ?_
+    intro x
+    simp [normalizerOrbitRelQuotientEquiv, normalizerOrbitRelQuotientMap]
+  map_mul' := by
+    intro g k
+    ext x
+    refine Quotient.inductionOn' x ?_
+    intro x
+    simp only [normalizerOrbitRelQuotientEquiv_apply, Equiv.Perm.coe_mul, Function.comp_apply]
+    have hgk : ((g * k : _root_.Subgroup.normalizer (H : Set G)) : G) = (g : G) * (k : G) :=
+      rfl
+    rw [hgk]
+    rw [mul_smul]
+
+/-- The normalizer permutation homomorphism sends representatives to their translates. -/
+@[simp]
+lemma normalizerOrbitRelQuotientPermHom_apply (H : Subgroup G)
+    (g : _root_.Subgroup.normalizer (H : Set G)) (x : X) :
+    normalizerOrbitRelQuotientPermHom (X := X) H g
+        (Quotient.mk'' x : _root_.MulAction.orbitRel.Quotient H X) =
+      Quotient.mk'' ((g : G) • x) :=
+  rfl
+
+/-- Any normalizer representative whose underlying group element lies in `H` acts trivially
+on the quotient by `H`-orbits. -/
+lemma normalizerOrbitRelQuotientPermHom_eq_one_of_mem
+    (H : Subgroup G) (g : _root_.Subgroup.normalizer (H : Set G)) (hg : (g : G) ∈ H) :
+    normalizerOrbitRelQuotientPermHom (X := X) H g = 1 := by
+  ext x
+  refine Quotient.inductionOn' x ?_
+  intro x
+  rw [normalizerOrbitRelQuotientPermHom_apply]
+  exact Quotient.sound' ⟨⟨(g : G), hg⟩, rfl⟩
+
+/-- The action of the normalizer on an orbit quotient descends to `N(H) / H`. -/
+noncomputable abbrev normalizerQuotientOrbitRelQuotientPermHom (H : Subgroup G) :
+    Subgroup.normalizerQuotient H →*
+      Equiv.Perm (_root_.MulAction.orbitRel.Quotient H X) :=
+  Subgroup.normalizerQuotientLift H (normalizerOrbitRelQuotientPermHom (X := X) H)
+    (normalizerOrbitRelQuotientPermHom_eq_one_of_mem (X := X) H)
+
+/-- The descended normalizer-quotient action sends a normalizer representative to the
+corresponding translate on orbit classes. -/
+@[simp]
+lemma normalizerQuotientOrbitRelQuotientPermHom_mk_apply (H : Subgroup G)
+    (g : _root_.Subgroup.normalizer (H : Set G)) (x : X) :
+    normalizerQuotientOrbitRelQuotientPermHom (X := X) H
+        (Subgroup.normalizerQuotientMk H g)
+        (Quotient.mk'' x : _root_.MulAction.orbitRel.Quotient H X) =
+      Quotient.mk'' ((g : G) • x) :=
+  rfl
+
+/-- The normalizer quotient `N(H) / H` acts on the quotient by `H`-orbits. -/
+noncomputable abbrev normalizerQuotientOrbitRelQuotientMulAction (H : Subgroup G) :
+    MulAction (Subgroup.normalizerQuotient H) (_root_.MulAction.orbitRel.Quotient H X) :=
+  MulAction.compHom (_root_.MulAction.orbitRel.Quotient H X)
+    (normalizerQuotientOrbitRelQuotientPermHom (X := X) H)
 
 end MulAction
 

--- a/TauCeti/Algebra/GroupAction/OrbitRelQuotient.lean
+++ b/TauCeti/Algebra/GroupAction/OrbitRelQuotient.lean
@@ -311,10 +311,29 @@ lemma normalizerQuotientOrbitRelQuotientPermHom_mk_apply (H : Subgroup G)
   by simp [normalizerQuotientOrbitRelQuotientPermHom]
 
 /-- The normalizer quotient `N(H) / H` acts on the quotient by `H`-orbits. -/
-noncomputable abbrev normalizerQuotientOrbitRelQuotientMulAction (H : Subgroup G) :
+@[reducible]
+noncomputable def normalizerQuotientOrbitRelQuotientMulAction (H : Subgroup G) :
     MulAction (Subgroup.normalizerQuotient H) (_root_.MulAction.orbitRel.Quotient H X) :=
   MulAction.compHom (_root_.MulAction.orbitRel.Quotient H X)
     (normalizerQuotientOrbitRelQuotientPermHom (X := X) H)
+
+/-- A normalizer-quotient representative acts on the orbit quotient by translating
+representatives. -/
+@[simp]
+lemma normalizerQuotientOrbitRelQuotient_smul_mk (H : Subgroup G)
+    (g : _root_.Subgroup.normalizer (H : Set G)) (x : X) :
+    letI := normalizerQuotientOrbitRelQuotientMulAction (X := X) H
+    Subgroup.normalizerQuotientMk H g •
+        (Quotient.mk'' x : _root_.MulAction.orbitRel.Quotient H X) =
+      Quotient.mk'' ((g : G) • x) :=
+  by
+    -- The named action is the `compHom` action, whose smul applies the underlying
+    -- permutation homomorphism to the point.
+    change normalizerQuotientOrbitRelQuotientPermHom (X := X) H
+        (Subgroup.normalizerQuotientMk H g)
+        (Quotient.mk'' x : _root_.MulAction.orbitRel.Quotient H X) =
+      Quotient.mk'' ((g : G) • x)
+    exact normalizerQuotientOrbitRelQuotientPermHom_mk_apply (X := X) H g x
 
 end MulAction
 

--- a/TauCeti/AlgebraicTopology/UniversalCover/Deck/NormalizerQuotientFiberAction.lean
+++ b/TauCeti/AlgebraicTopology/UniversalCover/Deck/NormalizerQuotientFiberAction.lean
@@ -44,7 +44,7 @@ namespace Deck
 variable {E B : Type*} [TopologicalSpace E] {p : E → B} {b : B}
 
 /-- A normalizer representative acts on the quotient of one fibre by `H`-orbits. -/
-abbrev normalizerSubgroupFiberOrbitMap (H : Subgroup (Deck p))
+def normalizerSubgroupFiberOrbitMap (H : Subgroup (Deck p))
     (φ : _root_.Subgroup.normalizer (H : Set (Deck p))) :
     SubgroupFiberOrbitQuotient H b → SubgroupFiberOrbitQuotient H b :=
   TauCeti.MulAction.normalizerOrbitRelQuotientMap H φ
@@ -56,7 +56,7 @@ lemma normalizerSubgroupFiberOrbitMap_apply (H : Subgroup (Deck p))
     (φ : _root_.Subgroup.normalizer (H : Set (Deck p))) (e : p ⁻¹' {b}) :
     normalizerSubgroupFiberOrbitMap H φ (subgroupFiberOrbitClass H e) =
       subgroupFiberOrbitClass H ((φ : Deck p) • e) :=
-  rfl
+  by simp [normalizerSubgroupFiberOrbitMap, subgroupFiberOrbitClass]
 
 /-- The normalizer representative `1` acts trivially on the subgroup fibre quotient. -/
 @[simp]
@@ -73,7 +73,7 @@ lemma normalizerSubgroupFiberOrbitMap_mul (H : Subgroup (Deck p))
   exact TauCeti.MulAction.normalizerOrbitRelQuotientMap_mul (X := p ⁻¹' {b}) H φ ψ
 
 /-- A normalizer representative acts on the subgroup fibre quotient by a permutation. -/
-abbrev normalizerSubgroupFiberOrbitEquiv (H : Subgroup (Deck p))
+def normalizerSubgroupFiberOrbitEquiv (H : Subgroup (Deck p))
     (φ : _root_.Subgroup.normalizer (H : Set (Deck p))) :
     Equiv.Perm (SubgroupFiberOrbitQuotient H b) :=
   TauCeti.MulAction.normalizerOrbitRelQuotientEquiv H φ
@@ -85,7 +85,7 @@ lemma normalizerSubgroupFiberOrbitEquiv_apply (H : Subgroup (Deck p))
     (φ : _root_.Subgroup.normalizer (H : Set (Deck p))) (e : p ⁻¹' {b}) :
     normalizerSubgroupFiberOrbitEquiv H φ (subgroupFiberOrbitClass H e) =
       subgroupFiberOrbitClass H ((φ : Deck p) • e) :=
-  rfl
+  by simp [normalizerSubgroupFiberOrbitEquiv, subgroupFiberOrbitClass]
 
 /-- The inverse normalizer permutation translates fibre-orbit representatives by the inverse
 deck transformation. -/
@@ -94,10 +94,10 @@ lemma normalizerSubgroupFiberOrbitEquiv_symm_apply (H : Subgroup (Deck p))
     (φ : _root_.Subgroup.normalizer (H : Set (Deck p))) (e : p ⁻¹' {b}) :
     (normalizerSubgroupFiberOrbitEquiv H φ).symm (subgroupFiberOrbitClass H e) =
       subgroupFiberOrbitClass H ((φ : Deck p)⁻¹ • e) :=
-  rfl
+  by simp [normalizerSubgroupFiberOrbitEquiv, subgroupFiberOrbitClass]
 
 /-- The normalizer action on the subgroup fibre quotient as a permutation representation. -/
-noncomputable abbrev normalizerSubgroupFiberOrbitPermHom (H : Subgroup (Deck p)) :
+noncomputable def normalizerSubgroupFiberOrbitPermHom (H : Subgroup (Deck p)) :
     _root_.Subgroup.normalizer (H : Set (Deck p)) →*
       Equiv.Perm (SubgroupFiberOrbitQuotient H b) :=
   TauCeti.MulAction.normalizerOrbitRelQuotientPermHom H
@@ -109,7 +109,7 @@ lemma normalizerSubgroupFiberOrbitPermHom_apply (H : Subgroup (Deck p))
     (φ : _root_.Subgroup.normalizer (H : Set (Deck p))) (e : p ⁻¹' {b}) :
     normalizerSubgroupFiberOrbitPermHom (b := b) H φ (subgroupFiberOrbitClass H e) =
       subgroupFiberOrbitClass H ((φ : Deck p) • e) :=
-  rfl
+  by simp [normalizerSubgroupFiberOrbitPermHom, subgroupFiberOrbitClass]
 
 /-- Any normalizer representative whose underlying deck transformation lies in `H` maps to
 the identity permutation on the quotient of each fibre by `H`-orbits. -/
@@ -121,7 +121,7 @@ lemma normalizerSubgroupFiberOrbitPermHom_eq_one_of_mem
     (X := p ⁻¹' {b}) H φ hφ
 
 /-- The action of the normalizer on subgroup fibre quotients descends to `N(H) / H`. -/
-noncomputable abbrev normalizerQuotientSubgroupFiberOrbitPermHom
+noncomputable def normalizerQuotientSubgroupFiberOrbitPermHom
     (H : Subgroup (Deck p)) :
     Subgroup.normalizerQuotient H →*
       Equiv.Perm (SubgroupFiberOrbitQuotient H b) :=
@@ -135,7 +135,10 @@ lemma normalizerQuotientSubgroupFiberOrbitPermHom_mk_apply (H : Subgroup (Deck p
     normalizerQuotientSubgroupFiberOrbitPermHom (b := b) H
         (Subgroup.normalizerQuotientMk H φ) (subgroupFiberOrbitClass H e) =
       subgroupFiberOrbitClass H ((φ : Deck p) • e) :=
-  rfl
+  by
+    simpa [normalizerQuotientSubgroupFiberOrbitPermHom, subgroupFiberOrbitClass] using
+      TauCeti.MulAction.normalizerQuotientOrbitRelQuotientPermHom_mk_apply
+        (X := p ⁻¹' {b}) H φ e
 
 /-- The normalizer quotient `N(H) / H` acts on the quotient of a fibre by `H`-orbits. -/
 noncomputable instance instNormalizerQuotientSubgroupFiberOrbitMulAction
@@ -149,7 +152,13 @@ lemma normalizerQuotient_smul_subgroupFiberOrbitClass (H : Subgroup (Deck p))
     (φ : _root_.Subgroup.normalizer (H : Set (Deck p))) (e : p ⁻¹' {b}) :
     Subgroup.normalizerQuotientMk H φ • subgroupFiberOrbitClass H e =
       subgroupFiberOrbitClass H ((φ : Deck p) • e) :=
-  rfl
+  by
+    simpa [instNormalizerQuotientSubgroupFiberOrbitMulAction,
+      TauCeti.MulAction.normalizerQuotientOrbitRelQuotientMulAction,
+      normalizerQuotientSubgroupFiberOrbitPermHom, subgroupFiberOrbitClass,
+      MulAction.compHom_smul_def] using
+        TauCeti.MulAction.normalizerQuotientOrbitRelQuotientPermHom_mk_apply
+          (X := p ⁻¹' {b}) H φ e
 
 /-- The identity class in `N(H) / H` fixes every subgroup fibre-orbit class. -/
 @[simp]

--- a/TauCeti/AlgebraicTopology/UniversalCover/Deck/NormalizerQuotientFiberAction.lean
+++ b/TauCeti/AlgebraicTopology/UniversalCover/Deck/NormalizerQuotientFiberAction.lean
@@ -43,23 +43,11 @@ namespace Deck
 
 variable {E B : Type*} [TopologicalSpace E] {p : E → B} {b : B}
 
-private lemma normalizer_smul_mem_orbit (H : Subgroup (Deck p))
-    (φ : _root_.Subgroup.normalizer (H : Set (Deck p)))
-    {e e' : p ⁻¹' {b}} (hee' : e ∈ MulAction.orbit H e') :
-    (φ : Deck p) • e ∈ MulAction.orbit H ((φ : Deck p) • e') := by
-  rcases hee' with ⟨ψ, hψ⟩
-  refine ⟨⟨(φ : Deck p) * ψ * (φ : Deck p)⁻¹, ?_⟩, ?_⟩
-  · exact ((Subgroup.mem_normalizer_iff.mp φ.2) (ψ : Deck p)).1 ψ.2
-  · rw [← hψ]
-    simp [Subgroup.smul_def, mul_smul]
-
 /-- A normalizer representative acts on the quotient of one fibre by `H`-orbits. -/
-@[expose] def normalizerSubgroupFiberOrbitMap (H : Subgroup (Deck p))
+abbrev normalizerSubgroupFiberOrbitMap (H : Subgroup (Deck p))
     (φ : _root_.Subgroup.normalizer (H : Set (Deck p))) :
     SubgroupFiberOrbitQuotient H b → SubgroupFiberOrbitQuotient H b :=
-  Quotient.map' (fun e : p ⁻¹' {b} => (φ : Deck p) • e) fun e e' hee' => by
-    rw [MulAction.orbitRel_apply] at hee' ⊢
-    exact normalizer_smul_mem_orbit H φ hee'
+  TauCeti.MulAction.normalizerOrbitRelQuotientMap H φ
 
 /-- The normalizer action on fibre quotients sends the class of a point to the class of its
 deck translate. -/
@@ -74,10 +62,7 @@ lemma normalizerSubgroupFiberOrbitMap_apply (H : Subgroup (Deck p))
 @[simp]
 lemma normalizerSubgroupFiberOrbitMap_one (H : Subgroup (Deck p)) :
     normalizerSubgroupFiberOrbitMap (b := b) H ⟨1, by simp⟩ = id := by
-  ext x
-  refine Quotient.inductionOn' x ?_
-  intro e
-  simp [normalizerSubgroupFiberOrbitMap]
+  exact TauCeti.MulAction.normalizerOrbitRelQuotientMap_one (X := p ⁻¹' {b}) H
 
 /-- Normalizer representatives act by composition on the subgroup fibre quotient. -/
 @[simp]
@@ -85,27 +70,13 @@ lemma normalizerSubgroupFiberOrbitMap_mul (H : Subgroup (Deck p))
     (φ ψ : _root_.Subgroup.normalizer (H : Set (Deck p))) :
     normalizerSubgroupFiberOrbitMap (b := b) H (φ * ψ) =
       normalizerSubgroupFiberOrbitMap H φ ∘ normalizerSubgroupFiberOrbitMap H ψ := by
-  ext x
-  refine Quotient.inductionOn' x ?_
-  intro e
-  simp [normalizerSubgroupFiberOrbitMap, mul_smul]
+  exact TauCeti.MulAction.normalizerOrbitRelQuotientMap_mul (X := p ⁻¹' {b}) H φ ψ
 
 /-- A normalizer representative acts on the subgroup fibre quotient by a permutation. -/
-@[expose] def normalizerSubgroupFiberOrbitEquiv (H : Subgroup (Deck p))
+abbrev normalizerSubgroupFiberOrbitEquiv (H : Subgroup (Deck p))
     (φ : _root_.Subgroup.normalizer (H : Set (Deck p))) :
-    Equiv.Perm (SubgroupFiberOrbitQuotient H b) where
-  toFun := normalizerSubgroupFiberOrbitMap H φ
-  invFun := normalizerSubgroupFiberOrbitMap H φ⁻¹
-  left_inv := by
-    intro x
-    refine Quotient.inductionOn' x ?_
-    intro e
-    simp [normalizerSubgroupFiberOrbitMap]
-  right_inv := by
-    intro x
-    refine Quotient.inductionOn' x ?_
-    intro e
-    simp [normalizerSubgroupFiberOrbitMap]
+    Equiv.Perm (SubgroupFiberOrbitQuotient H b) :=
+  TauCeti.MulAction.normalizerOrbitRelQuotientEquiv H φ
 
 /-- A normalizer representative permutes the subgroup fibre quotient by translating
 representatives. -/
@@ -116,22 +87,20 @@ lemma normalizerSubgroupFiberOrbitEquiv_apply (H : Subgroup (Deck p))
       subgroupFiberOrbitClass H ((φ : Deck p) • e) :=
   rfl
 
+/-- The inverse normalizer permutation translates fibre-orbit representatives by the inverse
+deck transformation. -/
+@[simp]
+lemma normalizerSubgroupFiberOrbitEquiv_symm_apply (H : Subgroup (Deck p))
+    (φ : _root_.Subgroup.normalizer (H : Set (Deck p))) (e : p ⁻¹' {b}) :
+    (normalizerSubgroupFiberOrbitEquiv H φ).symm (subgroupFiberOrbitClass H e) =
+      subgroupFiberOrbitClass H ((φ : Deck p)⁻¹ • e) :=
+  rfl
+
 /-- The normalizer action on the subgroup fibre quotient as a permutation representation. -/
-@[expose] noncomputable def normalizerSubgroupFiberOrbitPermHom (H : Subgroup (Deck p)) :
+noncomputable abbrev normalizerSubgroupFiberOrbitPermHom (H : Subgroup (Deck p)) :
     _root_.Subgroup.normalizer (H : Set (Deck p)) →*
-      Equiv.Perm (SubgroupFiberOrbitQuotient H b) where
-  toFun := normalizerSubgroupFiberOrbitEquiv H
-  map_one' := by
-    ext x
-    refine Quotient.inductionOn' x ?_
-    intro e
-    simp [normalizerSubgroupFiberOrbitEquiv, normalizerSubgroupFiberOrbitMap]
-  map_mul' := by
-    intro φ ψ
-    ext x
-    refine Quotient.inductionOn' x ?_
-    intro e
-    simp [normalizerSubgroupFiberOrbitEquiv, normalizerSubgroupFiberOrbitMap]
+      Equiv.Perm (SubgroupFiberOrbitQuotient H b) :=
+  TauCeti.MulAction.normalizerOrbitRelQuotientPermHom H
 
 /-- The normalizer permutation homomorphism sends representatives to the expected deck
 translate on fibre-orbit classes. -/
@@ -142,26 +111,21 @@ lemma normalizerSubgroupFiberOrbitPermHom_apply (H : Subgroup (Deck p))
       subgroupFiberOrbitClass H ((φ : Deck p) • e) :=
   rfl
 
+/-- Any normalizer representative whose underlying deck transformation lies in `H` maps to
+the identity permutation on the quotient of each fibre by `H`-orbits. -/
 lemma normalizerSubgroupFiberOrbitPermHom_eq_one_of_mem
     (H : Subgroup (Deck p)) (φ : _root_.Subgroup.normalizer (H : Set (Deck p)))
     (hφ : (φ : Deck p) ∈ H) :
     normalizerSubgroupFiberOrbitPermHom (b := b) H φ = 1 := by
-  ext x
-  refine Quotient.inductionOn' x ?_
-  intro e
-  change normalizerSubgroupFiberOrbitPermHom (b := b) H φ (subgroupFiberOrbitClass H e) =
-    (1 : Equiv.Perm (SubgroupFiberOrbitQuotient H b)) (subgroupFiberOrbitClass H e)
-  rw [normalizerSubgroupFiberOrbitPermHom_apply]
-  exact (subgroupFiberOrbitClass_eq_iff H ((φ : Deck p) • e) e).2
-    ⟨⟨(φ : Deck p), hφ⟩, rfl⟩
+  exact TauCeti.MulAction.normalizerOrbitRelQuotientPermHom_eq_one_of_mem
+    (X := p ⁻¹' {b}) H φ hφ
 
 /-- The action of the normalizer on subgroup fibre quotients descends to `N(H) / H`. -/
-@[expose] noncomputable def normalizerQuotientSubgroupFiberOrbitPermHom
+noncomputable abbrev normalizerQuotientSubgroupFiberOrbitPermHom
     (H : Subgroup (Deck p)) :
     Subgroup.normalizerQuotient H →*
       Equiv.Perm (SubgroupFiberOrbitQuotient H b) :=
-  Subgroup.normalizerQuotientLift H (normalizerSubgroupFiberOrbitPermHom (b := b) H)
-    (normalizerSubgroupFiberOrbitPermHom_eq_one_of_mem (b := b) H)
+  TauCeti.MulAction.normalizerQuotientOrbitRelQuotientPermHom H
 
 /-- The descended normalizer-quotient action sends a normalizer representative to the
 corresponding deck translate on fibre-orbit classes. -/
@@ -177,8 +141,7 @@ lemma normalizerQuotientSubgroupFiberOrbitPermHom_mk_apply (H : Subgroup (Deck p
 noncomputable instance instNormalizerQuotientSubgroupFiberOrbitMulAction
     (H : Subgroup (Deck p)) :
     MulAction (Subgroup.normalizerQuotient H) (SubgroupFiberOrbitQuotient H b) :=
-  MulAction.compHom (SubgroupFiberOrbitQuotient H b)
-    (normalizerQuotientSubgroupFiberOrbitPermHom (b := b) H)
+  TauCeti.MulAction.normalizerQuotientOrbitRelQuotientMulAction H
 
 /-- Representative formula for the action of `N(H) / H` on subgroup fibre quotients. -/
 @[simp]

--- a/TauCeti/AlgebraicTopology/UniversalCover/Deck/NormalizerQuotientFiberAction.lean
+++ b/TauCeti/AlgebraicTopology/UniversalCover/Deck/NormalizerQuotientFiberAction.lean
@@ -154,10 +154,8 @@ lemma normalizerQuotient_smul_subgroupFiberOrbitClass (H : Subgroup (Deck p))
       subgroupFiberOrbitClass H ((φ : Deck p) • e) :=
   by
     simpa [instNormalizerQuotientSubgroupFiberOrbitMulAction,
-      TauCeti.MulAction.normalizerQuotientOrbitRelQuotientMulAction,
-      normalizerQuotientSubgroupFiberOrbitPermHom, subgroupFiberOrbitClass,
-      MulAction.compHom_smul_def] using
-        TauCeti.MulAction.normalizerQuotientOrbitRelQuotientPermHom_mk_apply
+      subgroupFiberOrbitClass] using
+        TauCeti.MulAction.normalizerQuotientOrbitRelQuotient_smul_mk
           (X := p ⁻¹' {b}) H φ e
 
 /-- The identity class in `N(H) / H` fixes every subgroup fibre-orbit class. -/

--- a/TauCeti/AlgebraicTopology/UniversalCover/Deck/NormalizerQuotientFiberAction.lean
+++ b/TauCeti/AlgebraicTopology/UniversalCover/Deck/NormalizerQuotientFiberAction.lean
@@ -1,0 +1,211 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+module
+
+public import TauCeti.AlgebraicTopology.UniversalCover.Deck.SubgroupFiberOrbit
+
+/-!
+# Normalizer-quotient actions on subgroup fibre quotients
+
+For a subgroup `H ≤ Deck p`, the normalizer of `H` acts on the quotient of a fibre by
+`H`-orbits: a normalizer representative sends the class of `e` to the class of its deck
+translate. Elements of `H` act trivially on this quotient, so the action descends to the
+normalizer quotient `N(H) / H`.
+
+This is the fibre-level action bookkeeping needed before the universal-covers roadmap can
+identify the deck group of the cover attached to `H` with `N(H) / H`.
+
+## Main declarations
+
+* `TauCeti.Deck.normalizerSubgroupFiberOrbitEquiv`: the permutation of the `H`-fibre
+  quotient induced by one normalizer representative.
+* `TauCeti.Deck.normalizerSubgroupFiberOrbitPermHom`: the homomorphism from the normalizer
+  to permutations of the `H`-fibre quotient.
+* `TauCeti.Deck.normalizerQuotientSubgroupFiberOrbitPermHom`: the descended homomorphism
+  from `N(H) / H`.
+* `TauCeti.Deck.instNormalizerQuotientSubgroupFiberOrbitMulAction`: the resulting action of
+  `N(H) / H` on `SubgroupFiberOrbitQuotient H b`.
+
+## References
+
+This supplies a small prerequisite for `TauCetiRoadmap/UniversalCovers/README.md`, Stage 2,
+item 8: for the cover attached to `H`, the deck group is `N(H)/H`, with the regular case
+specializing to `π₁(X, x₀)/H`.
+-/
+
+public section
+
+namespace TauCeti
+
+namespace Deck
+
+variable {E B : Type*} [TopologicalSpace E] {p : E → B} {b : B}
+
+private lemma normalizer_smul_mem_orbit (H : Subgroup (Deck p))
+    (φ : _root_.Subgroup.normalizer (H : Set (Deck p)))
+    {e e' : p ⁻¹' {b}} (hee' : e ∈ MulAction.orbit H e') :
+    (φ : Deck p) • e ∈ MulAction.orbit H ((φ : Deck p) • e') := by
+  rcases hee' with ⟨ψ, hψ⟩
+  refine ⟨⟨(φ : Deck p) * ψ * (φ : Deck p)⁻¹, ?_⟩, ?_⟩
+  · exact ((Subgroup.mem_normalizer_iff.mp φ.2) (ψ : Deck p)).1 ψ.2
+  · rw [← hψ]
+    simp [Subgroup.smul_def, mul_smul]
+
+/-- A normalizer representative acts on the quotient of one fibre by `H`-orbits. -/
+@[expose] def normalizerSubgroupFiberOrbitMap (H : Subgroup (Deck p))
+    (φ : _root_.Subgroup.normalizer (H : Set (Deck p))) :
+    SubgroupFiberOrbitQuotient H b → SubgroupFiberOrbitQuotient H b :=
+  Quotient.map' (fun e : p ⁻¹' {b} => (φ : Deck p) • e) fun e e' hee' => by
+    rw [MulAction.orbitRel_apply] at hee' ⊢
+    exact normalizer_smul_mem_orbit H φ hee'
+
+/-- The normalizer action on fibre quotients sends the class of a point to the class of its
+deck translate. -/
+@[simp]
+lemma normalizerSubgroupFiberOrbitMap_apply (H : Subgroup (Deck p))
+    (φ : _root_.Subgroup.normalizer (H : Set (Deck p))) (e : p ⁻¹' {b}) :
+    normalizerSubgroupFiberOrbitMap H φ (subgroupFiberOrbitClass H e) =
+      subgroupFiberOrbitClass H ((φ : Deck p) • e) :=
+  rfl
+
+/-- The normalizer representative `1` acts trivially on the subgroup fibre quotient. -/
+@[simp]
+lemma normalizerSubgroupFiberOrbitMap_one (H : Subgroup (Deck p)) :
+    normalizerSubgroupFiberOrbitMap (b := b) H ⟨1, by simp⟩ = id := by
+  ext x
+  refine Quotient.inductionOn' x ?_
+  intro e
+  simp [normalizerSubgroupFiberOrbitMap]
+
+/-- Normalizer representatives act by composition on the subgroup fibre quotient. -/
+@[simp]
+lemma normalizerSubgroupFiberOrbitMap_mul (H : Subgroup (Deck p))
+    (φ ψ : _root_.Subgroup.normalizer (H : Set (Deck p))) :
+    normalizerSubgroupFiberOrbitMap (b := b) H (φ * ψ) =
+      normalizerSubgroupFiberOrbitMap H φ ∘ normalizerSubgroupFiberOrbitMap H ψ := by
+  ext x
+  refine Quotient.inductionOn' x ?_
+  intro e
+  simp [normalizerSubgroupFiberOrbitMap, mul_smul]
+
+/-- A normalizer representative acts on the subgroup fibre quotient by a permutation. -/
+@[expose] def normalizerSubgroupFiberOrbitEquiv (H : Subgroup (Deck p))
+    (φ : _root_.Subgroup.normalizer (H : Set (Deck p))) :
+    Equiv.Perm (SubgroupFiberOrbitQuotient H b) where
+  toFun := normalizerSubgroupFiberOrbitMap H φ
+  invFun := normalizerSubgroupFiberOrbitMap H φ⁻¹
+  left_inv := by
+    intro x
+    refine Quotient.inductionOn' x ?_
+    intro e
+    simp [normalizerSubgroupFiberOrbitMap]
+  right_inv := by
+    intro x
+    refine Quotient.inductionOn' x ?_
+    intro e
+    simp [normalizerSubgroupFiberOrbitMap]
+
+/-- A normalizer representative permutes the subgroup fibre quotient by translating
+representatives. -/
+@[simp]
+lemma normalizerSubgroupFiberOrbitEquiv_apply (H : Subgroup (Deck p))
+    (φ : _root_.Subgroup.normalizer (H : Set (Deck p))) (e : p ⁻¹' {b}) :
+    normalizerSubgroupFiberOrbitEquiv H φ (subgroupFiberOrbitClass H e) =
+      subgroupFiberOrbitClass H ((φ : Deck p) • e) :=
+  rfl
+
+/-- The normalizer action on the subgroup fibre quotient as a permutation representation. -/
+@[expose] noncomputable def normalizerSubgroupFiberOrbitPermHom (H : Subgroup (Deck p)) :
+    _root_.Subgroup.normalizer (H : Set (Deck p)) →*
+      Equiv.Perm (SubgroupFiberOrbitQuotient H b) where
+  toFun := normalizerSubgroupFiberOrbitEquiv H
+  map_one' := by
+    ext x
+    refine Quotient.inductionOn' x ?_
+    intro e
+    simp [normalizerSubgroupFiberOrbitEquiv, normalizerSubgroupFiberOrbitMap]
+  map_mul' := by
+    intro φ ψ
+    ext x
+    refine Quotient.inductionOn' x ?_
+    intro e
+    simp [normalizerSubgroupFiberOrbitEquiv, normalizerSubgroupFiberOrbitMap]
+
+/-- The normalizer permutation homomorphism sends representatives to the expected deck
+translate on fibre-orbit classes. -/
+@[simp]
+lemma normalizerSubgroupFiberOrbitPermHom_apply (H : Subgroup (Deck p))
+    (φ : _root_.Subgroup.normalizer (H : Set (Deck p))) (e : p ⁻¹' {b}) :
+    normalizerSubgroupFiberOrbitPermHom (b := b) H φ (subgroupFiberOrbitClass H e) =
+      subgroupFiberOrbitClass H ((φ : Deck p) • e) :=
+  rfl
+
+lemma normalizerSubgroupFiberOrbitPermHom_eq_one_of_mem
+    (H : Subgroup (Deck p)) (φ : _root_.Subgroup.normalizer (H : Set (Deck p)))
+    (hφ : (φ : Deck p) ∈ H) :
+    normalizerSubgroupFiberOrbitPermHom (b := b) H φ = 1 := by
+  ext x
+  refine Quotient.inductionOn' x ?_
+  intro e
+  change normalizerSubgroupFiberOrbitPermHom (b := b) H φ (subgroupFiberOrbitClass H e) =
+    (1 : Equiv.Perm (SubgroupFiberOrbitQuotient H b)) (subgroupFiberOrbitClass H e)
+  rw [normalizerSubgroupFiberOrbitPermHom_apply]
+  exact (subgroupFiberOrbitClass_eq_iff H ((φ : Deck p) • e) e).2
+    ⟨⟨(φ : Deck p), hφ⟩, rfl⟩
+
+/-- The action of the normalizer on subgroup fibre quotients descends to `N(H) / H`. -/
+@[expose] noncomputable def normalizerQuotientSubgroupFiberOrbitPermHom
+    (H : Subgroup (Deck p)) :
+    Subgroup.normalizerQuotient H →*
+      Equiv.Perm (SubgroupFiberOrbitQuotient H b) :=
+  Subgroup.normalizerQuotientLift H (normalizerSubgroupFiberOrbitPermHom (b := b) H)
+    (normalizerSubgroupFiberOrbitPermHom_eq_one_of_mem (b := b) H)
+
+/-- The descended normalizer-quotient action sends a normalizer representative to the
+corresponding deck translate on fibre-orbit classes. -/
+@[simp]
+lemma normalizerQuotientSubgroupFiberOrbitPermHom_mk_apply (H : Subgroup (Deck p))
+    (φ : _root_.Subgroup.normalizer (H : Set (Deck p))) (e : p ⁻¹' {b}) :
+    normalizerQuotientSubgroupFiberOrbitPermHom (b := b) H
+        (Subgroup.normalizerQuotientMk H φ) (subgroupFiberOrbitClass H e) =
+      subgroupFiberOrbitClass H ((φ : Deck p) • e) :=
+  rfl
+
+/-- The normalizer quotient `N(H) / H` acts on the quotient of a fibre by `H`-orbits. -/
+noncomputable instance instNormalizerQuotientSubgroupFiberOrbitMulAction
+    (H : Subgroup (Deck p)) :
+    MulAction (Subgroup.normalizerQuotient H) (SubgroupFiberOrbitQuotient H b) :=
+  MulAction.compHom (SubgroupFiberOrbitQuotient H b)
+    (normalizerQuotientSubgroupFiberOrbitPermHom (b := b) H)
+
+/-- Representative formula for the action of `N(H) / H` on subgroup fibre quotients. -/
+@[simp]
+lemma normalizerQuotient_smul_subgroupFiberOrbitClass (H : Subgroup (Deck p))
+    (φ : _root_.Subgroup.normalizer (H : Set (Deck p))) (e : p ⁻¹' {b}) :
+    Subgroup.normalizerQuotientMk H φ • subgroupFiberOrbitClass H e =
+      subgroupFiberOrbitClass H ((φ : Deck p) • e) :=
+  rfl
+
+/-- The identity class in `N(H) / H` fixes every subgroup fibre-orbit class. -/
+@[simp]
+lemma normalizerQuotient_one_smul_subgroupFiberOrbitClass (H : Subgroup (Deck p))
+    (e : p ⁻¹' {b}) :
+    (1 : Subgroup.normalizerQuotient H) • subgroupFiberOrbitClass H e =
+      subgroupFiberOrbitClass H e := by
+  simp
+
+/-- A representative from `H` acts trivially through the normalizer quotient. -/
+@[simp]
+lemma normalizerQuotient_mk_of_mem_smul_subgroupFiberOrbitClass
+    (H : Subgroup (Deck p)) (φ : Deck p) (hφ : φ ∈ H) (e : p ⁻¹' {b}) :
+    Subgroup.normalizerQuotientMk H ⟨φ, _root_.Subgroup.le_normalizer hφ⟩ •
+        subgroupFiberOrbitClass H e =
+      subgroupFiberOrbitClass H e := by
+  rw [normalizerQuotient_smul_subgroupFiberOrbitClass]
+  exact (subgroupFiberOrbitClass_eq_iff H (φ • e) e).2 ⟨⟨φ, hφ⟩, rfl⟩
+
+end Deck
+
+end TauCeti


### PR DESCRIPTION
This PR adds the normalizer-quotient action on subgroup fibre-orbit quotients for deck groups: a representative in `N(H)` permutes the quotient of one fibre by `H`-orbits, representatives from `H` act trivially, and the action descends to `N(H) / H` with class-level simp formulas.

It advances `TauCetiRoadmap/UniversalCovers/README.md`, Stage 2, item 8, specifically the regular-cover bookkeeping around the normalizer quotient `N(H)/H` before the regular normal-subgroup specialization. I chose this as the lowest-hanging distinct UniversalCovers prerequisite after checking open and recently merged PRs: the normal-subgroup fibre quotient criteria landed in #587, while the general non-normal action of `N(H)/H` on the `H`-fibre quotient was still absent.

No Mathlib infrastructure is vendored. The implementation reuses Tau Ceti's existing `Subgroup.normalizerQuotient`, `Subgroup.normalizerQuotientLift`, and subgroup fibre-orbit quotient API, plus Mathlib's `Subgroup.normalizer` conjugation criterion.

`lake exe cache get` completed with `No files to download` and `Already decompressed 8609 file(s)`. `lake build` completed with `Build completed successfully (4459 jobs).` `lake exe axioms` completed with `axioms: audited 7311 TauCeti declaration(s); all within the allowlist [propext, Classical.choice, Quot.sound].`

<!--tauceti-target:v1 {"focus":"UniversalCovers","id":"normalizer-quotient-fiber-action"}-->

🤖 Prepared with Codex
