### PR TITLE
feat: directing measure is the conditional law of every coordinate (contractable)

### DIFF
--- a/TauCeti/Probability/DeFinetti/DirectingMeasureCoord.lean
+++ b/TauCeti/Probability/DeFinetti/DirectingMeasureCoord.lean
@@ -14,6 +14,9 @@ collapse `Contractable.condExp_indicator_tailProcess_eq`.
 
 This is the per-coordinate input to the de Finetti block-product factorisation: it is what lets the
 single directing measure serve as the common conditional law of all coordinates.
+
+Adapted from `cameronfreer/exchangeability` (`DeFinetti/ViaMartingale/CondExpConvergence.lean`, pin
+`e0532e59ceff23edab44dda9ab0655debbc9cc22`).
 -/
 
 public section

--- a/TauCeti/Probability/DeFinetti/DirectingMeasureCoord.lean
+++ b/TauCeti/Probability/DeFinetti/DirectingMeasureCoord.lean
@@ -1,7 +1,8 @@
 module
 
-public import TauCeti.Probability.DeFinetti.CondExpConvergence
+import TauCeti.Probability.DeFinetti.CondExpConvergence
 public import TauCeti.Probability.DeFinetti.DirectingMeasure
+public import TauCeti.Probability.Exchangeability.Basic
 
 /-!
 # The directing measure is the conditional law of every coordinate

--- a/TauCeti/Probability/DeFinetti/DirectingMeasureCoord.lean
+++ b/TauCeti/Probability/DeFinetti/DirectingMeasureCoord.lean
@@ -1,0 +1,46 @@
+module
+
+public import TauCeti.Probability.DeFinetti.CondExpConvergence
+public import TauCeti.Probability.DeFinetti.DirectingMeasure
+
+/-!
+# The directing measure is the conditional law of every coordinate
+
+`directingMeasure_ae_eq_condExp` (in `DirectingMeasure.lean`) identifies the directing measure with
+the conditional law of the initial coordinate `X 0` given the tail σ-algebra. For a **contractable**
+process the same holds for every coordinate. `Contractable.directingMeasure_ae_eq_condExp_coord`
+promotes that identity from `X 0` to every `X m`, using the "extreme members agree on the tail"
+collapse `Contractable.condExp_indicator_tailProcess_eq`.
+
+This is the per-coordinate input to the de Finetti block-product factorisation: it is what lets the
+single directing measure serve as the common conditional law of all coordinates.
+-/
+
+public section
+
+noncomputable section
+
+open MeasureTheory
+
+namespace TauCeti
+
+namespace Probability
+
+variable {Ω α : Type*} [MeasurableSpace Ω] [MeasurableSpace α]
+
+/-- **The directing measure is the conditional law of every coordinate.** For a contractable process
+and any `m`, the real evaluation `ω ↦ (directingMeasure μ X ω).real B` is a version of the
+conditional expectation of `𝟙_B ∘ X m` given the tail σ-algebra `tailProcess X`. -/
+theorem Contractable.directingMeasure_ae_eq_condExp_coord [StandardBorelSpace α] [Nonempty α]
+    {μ : Measure Ω} [IsFiniteMeasure μ] {X : ℕ → Ω → α} (hX : Contractable μ X)
+    (hX_meas : ∀ n, Measurable (X n))
+    (hTail : tailProcess X ≤ (inferInstance : MeasurableSpace Ω)) (m : ℕ)
+    {B : Set α} (hB : MeasurableSet B) :
+    (fun ω => (directingMeasure μ X ω).real B)
+      =ᵐ[μ] μ[Set.indicator B (fun _ => (1 : ℝ)) ∘ X m | tailProcess X] :=
+  (directingMeasure_ae_eq_condExp hTail (hX_meas 0) hB).trans
+    (hX.condExp_indicator_tailProcess_eq (j := 0) (k := m) hX_meas hB)
+
+end Probability
+
+end TauCeti

--- a/TauCeti/Probability/DeFinetti/DirectingMeasureCoord.lean
+++ b/TauCeti/Probability/DeFinetti/DirectingMeasureCoord.lean
@@ -36,12 +36,12 @@ and any `m`, the real evaluation `ω ↦ (directingMeasure μ X ω).real B` is a
 conditional expectation of `𝟙_B ∘ X m` given the tail σ-algebra `tailProcess X`. -/
 theorem Contractable.directingMeasure_ae_eq_condExp_coord [StandardBorelSpace α] [Nonempty α]
     {μ : Measure Ω} [IsFiniteMeasure μ] {X : ℕ → Ω → α} (hX : Contractable μ X)
-    (hX_meas : ∀ n, Measurable (X n))
-    (hTail : tailProcess X ≤ (inferInstance : MeasurableSpace Ω)) (m : ℕ)
+    (hX_meas : ∀ n, Measurable (X n)) (m : ℕ)
     {B : Set α} (hB : MeasurableSet B) :
     (fun ω => (directingMeasure μ X ω).real B)
       =ᵐ[μ] μ[Set.indicator B (fun _ => (1 : ℝ)) ∘ X m | tailProcess X] :=
-  (directingMeasure_ae_eq_condExp hTail (hX_meas 0) hB).trans
+  (directingMeasure_ae_eq_condExp (tailProcess_le_ambient 0 fun k _ => hX_meas k)
+      (hX_meas 0) hB).trans
     (hX.condExp_indicator_tailProcess_eq (j := 0) (k := m) hX_meas hB)
 
 end Probability


### PR DESCRIPTION
<!--tauceti-target:v1 {"focus":"Exchangeability","id":"directing-measure-coord"}-->

## Summary

Adds `TauCeti/Probability/DeFinetti/DirectingMeasureCoord.lean` with one lemma:

`Contractable.directingMeasure_ae_eq_condExp_coord` — for a contractable process and **every**
coordinate `m`, the real evaluation `ω ↦ (directingMeasure μ X ω).real B` is a version of the
conditional expectation `μ[𝟙_B ∘ X m | tailProcess X]`.

## Roadmap

Advances `TauCetiRoadmap/Exchangeability/README.md` toward **Layer 6 (de Finetti representation)**.
The merged `directingMeasure_ae_eq_condExp` identifies the directing measure with the conditional law
of the **initial** coordinate `X 0`; this promotes that identity to **all** coordinates. It is the
per-coordinate input to the block-product factorisation: it lets the single directing measure serve
as the common conditional law of every coordinate given the tail.

## How it's proved (reuse)

A two-line consequence of two merged results: `directingMeasure_ae_eq_condExp` (the `X 0` identity)
composed with `Contractable.condExp_indicator_tailProcess_eq` (#579, "extreme members agree on the
tail", now stated for arbitrary coordinate pairs). No new measure theory.

## Review notes
- **placement:** `DeFinetti/DirectingMeasureCoord.lean`, next to the directing-measure API it extends
  and the tail-conditional-expectation lemma it consumes.
- **generality:** `[StandardBorelSpace α]` + `[Nonempty α]` (required by `directingMeasure`/
  `condDistrib`), `[IsFiniteMeasure μ]`, measurable coordinates; the same hypotheses as the two lemmas
  it chains.
- **api-design:** a single `=ᵐ` bridge lemma (dot-notation on `Contractable`), no `@[simp]`/`def`.

## Test plan
```bash
lake build
lake exe axioms
lake exe module-system
```
All pass; sorry-free; axioms ⊆ {`propext`, `Classical.choice`, `Quot.sound`}; lines ≤100.

## Attribution
Adapted from `cameronfreer/exchangeability` (`DeFinetti/ViaMartingale/CondExpConvergence.lean`, pin
`e0532e59ceff23edab44dda9ab0655debbc9cc22`), over the merged TauCeti directing-measure / tail
conditional-expectation API. Drafted with Claude (Opus 4.8), human-directed.
