### PR TITLE
feat: transport the self-diffeomorphism group along a diffeomorphism

### DIFF
--- a/TauCeti/Geometry/Diffeomorphism/Congr.lean
+++ b/TauCeti/Geometry/Diffeomorphism/Congr.lean
@@ -5,6 +5,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 module
 
 public import TauCeti.Geometry.Diffeomorphism.Group
+public import TauCeti.Topology.Algebra.HomeomorphCongr
 
 /-!
 # Transporting the self-diffeomorphism group along a diffeomorphism
@@ -37,9 +38,9 @@ for the naturality statement.
 
 * `TauCeti.Diffeomorph.diffCongr e`: the group isomorphism `Diff I M n ≃* Diff J N n` conjugating by
   a diffeomorphism `e : M ≃ₘ^n⟮I, J⟯ N`.
-* `TauCeti.Homeomorph.homeoCongr e`: the analogous group isomorphism `(M ≃ₜ M) ≃* (N ≃ₜ N)`
-  conjugating self-homeomorphisms by a homeomorphism `e : M ≃ₜ N`, the target of the forgetful
-  naturality below.
+
+The analogous self-homeomorphism-group isomorphism `TauCeti.Homeomorph.homeoCongr`, the target of
+the forgetful naturality below, lives in `TauCeti.Topology.Algebra.HomeomorphCongr`.
 
 ## Main results
 
@@ -49,9 +50,6 @@ for the naturality statement.
 * `TauCeti.Diffeomorph.diffCongr_trans`: `diffCongr` turns `Diffeomorph.trans` into
   `MulEquiv.trans`, so it is functorial on the groupoid of diffeomorphisms.
 * `TauCeti.Diffeomorph.diffCongr_symm`: the inverse isomorphism conjugates by `e.symm`.
-* `TauCeti.Homeomorph.homeoCongr_refl`, `TauCeti.Homeomorph.homeoCongr_trans`, and
-  `TauCeti.Homeomorph.homeoCongr_symm`: the parallel functoriality of `homeoCongr` on the groupoid
-  of homeomorphisms.
 * `TauCeti.Diffeomorph.toHomeomorphHom_comp_diffCongr` and
   `TauCeti.Diffeomorph.toPerm_comp_diffCongr`: naturality of `diffCongr` against the forgetful
   homomorphisms `toHomeomorphHom` and `toPerm`, as commutative squares of group homomorphisms
@@ -77,50 +75,6 @@ variable {𝕜 : Type*} [NontriviallyNormedField 𝕜]
   {N : Type*} [TopologicalSpace N] [ChartedSpace H' N]
   {P : Type*} [TopologicalSpace P] [ChartedSpace H'' P]
   {n : ℕ∞ω}
-
-namespace Homeomorph
-
-/-- Conjugation by a homeomorphism `e : M ≃ₜ N` as a group isomorphism between the
-self-homeomorphism groups: `homeoCongr e φ = e ∘ φ ∘ e⁻¹`. This is the homeomorphism analogue of
-`Equiv.permCongrHom` and the target of the forgetful naturality of `Diffeomorph.diffCongr`. -/
-@[expose, simps]
-def homeoCongr (e : M ≃ₜ N) : (M ≃ₜ M) ≃* (N ≃ₜ N) where
-  toFun φ := (e.symm.trans φ).trans e
-  invFun ψ := (e.trans ψ).trans e.symm
-  left_inv φ := by ext x; simp
-  right_inv ψ := by ext x; simp
-  map_mul' φ ψ := by ext x; simp
-
-/-- The conjugating isomorphism acts pointwise by `homeoCongr e φ x = e (φ (e.symm x))`. -/
-@[simp, grind =]
-theorem homeoCongr_apply_apply (e : M ≃ₜ N) (φ : M ≃ₜ M) (x : N) :
-    homeoCongr e φ x = e (φ (e.symm x)) := rfl
-
-/-- The inverse of `homeoCongr e φ` is `homeoCongr e φ⁻¹`, since conjugation is a homomorphism. -/
-theorem homeoCongr_inv (e : M ≃ₜ N) (φ : M ≃ₜ M) :
-    (homeoCongr e φ)⁻¹ = homeoCongr e φ⁻¹ := (map_inv (homeoCongr e) φ).symm
-
-/-- Conjugating by the identity homeomorphism is the identity isomorphism. -/
-@[simp]
-theorem homeoCongr_refl : homeoCongr (_root_.Homeomorph.refl M) = MulEquiv.refl (M ≃ₜ M) := by
-  ext φ x
-  simp
-
-/-- Conjugation is functorial: conjugating by a composite homeomorphism is the composite of the
-conjugating isomorphisms. -/
-@[simp]
-theorem homeoCongr_trans (e : M ≃ₜ N) (e' : N ≃ₜ P) :
-    homeoCongr (e.trans e') = (homeoCongr e).trans (homeoCongr e') := by
-  ext φ x
-  simp
-
-/-- The isomorphism conjugating by `e.symm` is the inverse of the one conjugating by `e`. -/
-@[simp, grind =]
-theorem homeoCongr_symm (e : M ≃ₜ N) : (homeoCongr e).symm = homeoCongr e.symm := by
-  ext ψ x
-  rfl
-
-end Homeomorph
 
 namespace Diffeomorph
 

--- a/TauCeti/Geometry/Diffeomorphism/Congr.lean
+++ b/TauCeti/Geometry/Diffeomorphism/Congr.lean
@@ -18,14 +18,15 @@ group isomorphism `Diff I M n ≃* Diff J N n` between the self-diffeomorphism g
 forgetful homomorphism to the permutation group (`Diffeomorph.toPerm`) through Mathlib's
 `Equiv.permCongr`.
 
-This is the sense in which the group object of the geometric-topology roadmap
+This expresses that the *algebraic* group object of the geometric-topology roadmap
 (`TauCetiRoadmap/GeometricTopology/README.md`, layer 3, "diffeomorphism groups with the C^∞
 topology") is a diffeomorphism invariant: diffeomorphic manifolds have isomorphic
-self-diffeomorphism groups, so the homotopy-type statements the layer targets — the Smale
+self-diffeomorphism groups as abstract groups. The construction is purely algebraic and stops at the
+bare group isomorphism; it does *not yet* carry the `C^∞` topology, so on its own it says nothing
+about homotopy type. Transporting the homotopy-type statements the layer targets — the Smale
 conjecture `Diff(S³) ≃ O(4)`, `[Kir97, Problem 4.34]`, and Watanabe's `π_k(Diff(D⁴, ∂))` classes,
-`[Kir97, Problem 4.126]` — transport along a chosen diffeomorphism of the underlying manifold. The
-construction is purely algebraic and stops at the bare group isomorphism; the `C^∞` topology making
-it a topological-group isomorphism is a separate, later layer-3 deliverable. It works for every
+`[Kir97, Problem 4.126]` — needs the refinement of this isomorphism to a topological-group (indeed
+homeomorphism) isomorphism, which is a separate, later layer-3 deliverable. It works for every
 smoothness exponent `n`.
 
 The construction is the diffeomorphism analogue of `Equiv.permCongr`
@@ -45,6 +46,8 @@ for the naturality statement.
 * `TauCeti.Diffeomorph.diffCongr_trans`: `diffCongr` turns `Diffeomorph.trans` into
   `MulEquiv.trans`, so it is functorial on the groupoid of diffeomorphisms.
 * `TauCeti.Diffeomorph.diffCongr_symm`: the inverse isomorphism conjugates by `e.symm`.
+* `TauCeti.Diffeomorph.toHomeomorph_diffCongr`: the forgetful homomorphism to the self-homeomorphism
+  group intertwines `diffCongr` with conjugation of homeomorphisms.
 * `TauCeti.Diffeomorph.toPerm_diffCongr`: the forgetful homomorphism to the permutation group
   intertwines `diffCongr` with `Equiv.permCongr`.
 -/
@@ -87,7 +90,7 @@ groups. -/
     simp [mul_def, _root_.Diffeomorph.coe_trans]
 
 /-- The conjugating isomorphism acts pointwise by `diffCongr e φ x = e (φ (e.symm x))`. -/
-@[simp]
+@[simp, grind =]
 theorem diffCongr_apply_apply (e : M ≃ₘ^n⟮I, J⟯ N) (φ : M ≃ₘ^n⟮I, I⟯ M) (x : N) :
     diffCongr e φ x = e (φ (e.symm x)) := rfl
 
@@ -120,12 +123,24 @@ theorem diffCongr_symm (e : M ≃ₘ^n⟮I, J⟯ N) : (diffCongr e).symm = diffC
   ext ψ x
   rfl
 
-/-- Forgetting smoothness intertwines `diffCongr` with `Equiv.permCongr` on the permutation
-groups. -/
+/-- Forgetting only smoothness (keeping the topology) sends `diffCongr e φ` to the conjugate of
+underlying self-homeomorphisms `e ∘ φ ∘ e⁻¹`. This is the naturality of `diffCongr` against the
+stronger forgetful homomorphism `Diffeomorph.toHomeomorphHom`, refining `toPerm_diffCongr`. -/
+theorem toHomeomorph_diffCongr (e : M ≃ₘ^n⟮I, J⟯ N) (φ : M ≃ₘ^n⟮I, I⟯ M) :
+    (diffCongr e φ).toHomeomorph =
+      (e.toHomeomorph.symm.trans φ.toHomeomorph).trans e.toHomeomorph := by
+  ext x
+  rfl
+
+/-- Forgetting all topology intertwines `diffCongr` with `Equiv.permCongr` on the permutation
+groups; this is the `toPerm`-level shadow of `toHomeomorph_diffCongr`. -/
 theorem toPerm_diffCongr (e : M ≃ₘ^n⟮I, J⟯ N) (φ : M ≃ₘ^n⟮I, I⟯ M) :
     toPerm (diffCongr e φ) = e.toEquiv.permCongr (toPerm φ) := by
-  ext x
-  simp [toPerm, Equiv.permCongr_apply]
+  have key : (diffCongr e φ).toEquiv = e.toEquiv.permCongr φ.toEquiv := by
+    rw [← _root_.Diffeomorph.toHomeomorph_toEquiv, toHomeomorph_diffCongr]
+    ext x
+    simp [Equiv.permCongr_apply, _root_.Diffeomorph.coe_toHomeomorph_symm]
+  simpa [toPerm] using key
 
 end Diffeomorph
 

--- a/TauCeti/Geometry/Diffeomorphism/Congr.lean
+++ b/TauCeti/Geometry/Diffeomorphism/Congr.lean
@@ -37,6 +37,9 @@ for the naturality statement.
 
 * `TauCeti.Diffeomorph.diffCongr e`: the group isomorphism `Diff I M n ≃* Diff J N n` conjugating by
   a diffeomorphism `e : M ≃ₘ^n⟮I, J⟯ N`.
+* `TauCeti.Homeomorph.homeoCongr e`: the analogous group isomorphism `(M ≃ₜ M) ≃* (N ≃ₜ N)`
+  conjugating self-homeomorphisms by a homeomorphism `e : M ≃ₜ N`, the target of the forgetful
+  naturality below.
 
 ## Main results
 
@@ -46,10 +49,12 @@ for the naturality statement.
 * `TauCeti.Diffeomorph.diffCongr_trans`: `diffCongr` turns `Diffeomorph.trans` into
   `MulEquiv.trans`, so it is functorial on the groupoid of diffeomorphisms.
 * `TauCeti.Diffeomorph.diffCongr_symm`: the inverse isomorphism conjugates by `e.symm`.
-* `TauCeti.Diffeomorph.toHomeomorph_diffCongr`: the forgetful homomorphism to the self-homeomorphism
-  group intertwines `diffCongr` with conjugation of homeomorphisms.
-* `TauCeti.Diffeomorph.toPerm_diffCongr`: the forgetful homomorphism to the permutation group
-  intertwines `diffCongr` with `Equiv.permCongr`.
+* `TauCeti.Diffeomorph.toHomeomorphHom_comp_diffCongr` and
+  `TauCeti.Diffeomorph.toPerm_comp_diffCongr`: naturality of `diffCongr` against the forgetful
+  homomorphisms `toHomeomorphHom` and `toPerm`, as commutative squares of group homomorphisms
+  intertwining `diffCongr` with `Homeomorph.homeoCongr` and `Equiv.permCongrHom` respectively.
+* `TauCeti.Diffeomorph.toHomeomorph_diffCongr` and `TauCeti.Diffeomorph.toPerm_diffCongr`: the
+  elementwise shadows of those squares.
 -/
 
 public section
@@ -69,6 +74,21 @@ variable {𝕜 : Type*} [NontriviallyNormedField 𝕜]
   {N : Type*} [TopologicalSpace N] [ChartedSpace H' N]
   {P : Type*} [TopologicalSpace P] [ChartedSpace H'' P]
   {n : ℕ∞ω}
+
+namespace Homeomorph
+
+/-- Conjugation by a homeomorphism `e : M ≃ₜ N` as a group isomorphism between the
+self-homeomorphism groups: `homeoCongr e φ = e ∘ φ ∘ e⁻¹`. This is the homeomorphism analogue of
+`Equiv.permCongrHom` and the target of the forgetful naturality of `Diffeomorph.diffCongr`. -/
+@[expose, simps]
+def homeoCongr (e : M ≃ₜ N) : (M ≃ₜ M) ≃* (N ≃ₜ N) where
+  toFun φ := (e.symm.trans φ).trans e
+  invFun ψ := (e.trans ψ).trans e.symm
+  left_inv φ := by ext x; simp
+  right_inv ψ := by ext x; simp
+  map_mul' φ ψ := by ext x; simp
+
+end Homeomorph
 
 namespace Diffeomorph
 
@@ -118,29 +138,45 @@ theorem diffCongr_trans (e : M ≃ₘ^n⟮I, J⟯ N) (e' : N ≃ₘ^n⟮J, K⟯ 
   simp [_root_.Diffeomorph.coe_trans, _root_.Diffeomorph.symm_trans']
 
 /-- The isomorphism conjugating by `e.symm` is the inverse of the one conjugating by `e`. -/
-@[simp]
+@[simp, grind =]
 theorem diffCongr_symm (e : M ≃ₘ^n⟮I, J⟯ N) : (diffCongr e).symm = diffCongr e.symm := by
   ext ψ x
   rfl
 
+/-- Naturality of `diffCongr` against the forgetful homomorphism to self-homeomorphisms, as a
+commutative square of group homomorphisms: conjugating diffeomorphisms by `e` and then forgetting
+smoothness equals forgetting smoothness and then conjugating homeomorphisms by `e` through
+`Homeomorph.homeoCongr`. This is the naturality of `diffCongr` against the stronger forgetful
+homomorphism `Diffeomorph.toHomeomorphHom`, refining `toPerm_comp_diffCongr`. -/
+theorem toHomeomorphHom_comp_diffCongr (e : M ≃ₘ^n⟮I, J⟯ N) :
+    toHomeomorphHom.comp (diffCongr e).toMonoidHom =
+      (Homeomorph.homeoCongr e.toHomeomorph).toMonoidHom.comp toHomeomorphHom := by
+  ext φ x
+  simp [toHomeomorphHom_apply]
+
+/-- Naturality of `diffCongr` against the forgetful homomorphism to permutations, as a commutative
+square of group homomorphisms intertwining `diffCongr` with `Equiv.permCongrHom`; this is the
+`toPerm`-level shadow of `toHomeomorphHom_comp_diffCongr`. -/
+theorem toPerm_comp_diffCongr (e : M ≃ₘ^n⟮I, J⟯ N) :
+    toPerm.comp (diffCongr e).toMonoidHom = e.toEquiv.permCongrHom.toMonoidHom.comp toPerm := by
+  ext φ x
+  simp [Equiv.permCongr_apply]
+
 /-- Forgetting only smoothness (keeping the topology) sends `diffCongr e φ` to the conjugate of
-underlying self-homeomorphisms `e ∘ φ ∘ e⁻¹`. This is the naturality of `diffCongr` against the
-stronger forgetful homomorphism `Diffeomorph.toHomeomorphHom`, refining `toPerm_diffCongr`. -/
+underlying self-homeomorphisms `e ∘ φ ∘ e⁻¹`; the elementwise shadow of
+`toHomeomorphHom_comp_diffCongr`. -/
 theorem toHomeomorph_diffCongr (e : M ≃ₘ^n⟮I, J⟯ N) (φ : M ≃ₘ^n⟮I, I⟯ M) :
     (diffCongr e φ).toHomeomorph =
       (e.toHomeomorph.symm.trans φ.toHomeomorph).trans e.toHomeomorph := by
-  ext x
-  rfl
+  have h := DFunLike.congr_fun (toHomeomorphHom_comp_diffCongr e) φ
+  simpa using h
 
 /-- Forgetting all topology intertwines `diffCongr` with `Equiv.permCongr` on the permutation
-groups; this is the `toPerm`-level shadow of `toHomeomorph_diffCongr`. -/
+groups; the elementwise shadow of `toPerm_comp_diffCongr`. -/
 theorem toPerm_diffCongr (e : M ≃ₘ^n⟮I, J⟯ N) (φ : M ≃ₘ^n⟮I, I⟯ M) :
     toPerm (diffCongr e φ) = e.toEquiv.permCongr (toPerm φ) := by
-  have key : (diffCongr e φ).toEquiv = e.toEquiv.permCongr φ.toEquiv := by
-    rw [← _root_.Diffeomorph.toHomeomorph_toEquiv, toHomeomorph_diffCongr]
-    ext x
-    simp [Equiv.permCongr_apply, _root_.Diffeomorph.coe_toHomeomorph_symm]
-  simpa [toPerm] using key
+  have h := DFunLike.congr_fun (toPerm_comp_diffCongr e) φ
+  simpa using h
 
 end Diffeomorph
 

--- a/TauCeti/Geometry/Diffeomorphism/Congr.lean
+++ b/TauCeti/Geometry/Diffeomorphism/Congr.lean
@@ -1,0 +1,128 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+module
+
+public import TauCeti.Geometry.Diffeomorphism.Group
+
+/-!
+# Transporting the self-diffeomorphism group along a diffeomorphism
+
+A diffeomorphism `e : M ≃ₘ^n⟮I, J⟯ N` conjugates self-diffeomorphisms of `M` into
+self-diffeomorphisms of `N` by `φ ↦ e ∘ φ ∘ e⁻¹`. Because this preserves composition, it is a
+group isomorphism `Diff I M n ≃* Diff J N n` between the self-diffeomorphism groups built in
+`TauCeti.Geometry.Diffeomorphism.Group`. This file records that isomorphism, `Diffeomorph.congr`,
+its pointwise action, and its functoriality: it is the identity on `Diffeomorph.refl`, respects
+`Diffeomorph.trans` and `Diffeomorph.symm`, and commutes with the forgetful homomorphism to the
+permutation group (`Diffeomorph.toPerm`) through Mathlib's `Equiv.permCongr`.
+
+This is the sense in which the group object of the geometric-topology roadmap
+(`TauCetiRoadmap/GeometricTopology/README.md`, layer 3, "diffeomorphism groups with the C^∞
+topology") is a diffeomorphism invariant: diffeomorphic manifolds have isomorphic
+self-diffeomorphism groups, so the homotopy-type statements the layer targets — the Smale
+conjecture `Diff(S³) ≃ O(4)`, `[Kir97, Problem 4.34]`, and Watanabe's `π_k(Diff(D⁴, ∂))` classes,
+`[Kir97, Problem 4.126]` — transport along a chosen diffeomorphism of the underlying manifold. The
+construction is purely algebraic and stops at the bare group isomorphism; the `C^∞` topology making
+it a topological-group isomorphism is a separate, later layer-3 deliverable. It works for every
+smoothness exponent `n`.
+
+The construction is the diffeomorphism analogue of `Equiv.permCongr`
+(`Mathlib/Logic/Equiv/Defs.lean`), the conjugation isomorphism of permutation groups, and reuses it
+for the naturality statement.
+
+## Main definitions
+
+* `TauCeti.Diffeomorph.congr e`: the group isomorphism `Diff I M n ≃* Diff J N n` conjugating by a
+  diffeomorphism `e : M ≃ₘ^n⟮I, J⟯ N`.
+
+## Main results
+
+* `TauCeti.Diffeomorph.congr_apply_apply`: the pointwise action `congr e φ x = e (φ (e.symm x))`.
+* `TauCeti.Diffeomorph.congr_refl`: conjugating by the identity is the identity isomorphism.
+* `TauCeti.Diffeomorph.congr_trans`: `congr` turns `Diffeomorph.trans` into `MulEquiv.trans`, so it
+  is functorial on the groupoid of diffeomorphisms.
+* `TauCeti.Diffeomorph.congr_symm`: the inverse isomorphism conjugates by `e.symm`.
+* `TauCeti.Diffeomorph.toPerm_congr`: the forgetful homomorphism to the permutation group
+  intertwines `congr` with `Equiv.permCongr`.
+-/
+
+public section
+
+namespace TauCeti
+
+open scoped Manifold ContDiff
+
+variable {𝕜 : Type*} [NontriviallyNormedField 𝕜]
+  {E : Type*} [NormedAddCommGroup E] [NormedSpace 𝕜 E]
+  {E' : Type*} [NormedAddCommGroup E'] [NormedSpace 𝕜 E']
+  {E'' : Type*} [NormedAddCommGroup E''] [NormedSpace 𝕜 E'']
+  {H : Type*} [TopologicalSpace H] {I : ModelWithCorners 𝕜 E H}
+  {H' : Type*} [TopologicalSpace H'] {J : ModelWithCorners 𝕜 E' H'}
+  {H'' : Type*} [TopologicalSpace H''] {K : ModelWithCorners 𝕜 E'' H''}
+  {M : Type*} [TopologicalSpace M] [ChartedSpace H M]
+  {N : Type*} [TopologicalSpace N] [ChartedSpace H' N]
+  {P : Type*} [TopologicalSpace P] [ChartedSpace H'' P]
+  {n : ℕ∞ω}
+
+namespace Diffeomorph
+
+/-- Conjugation by a diffeomorphism `e : M ≃ₘ^n⟮I, J⟯ N` as a group isomorphism between the
+self-diffeomorphism groups: `congr e φ = e ∘ φ ∘ e⁻¹`. This is the diffeomorphism analogue of
+`Equiv.permCongr` and expresses that diffeomorphic manifolds have isomorphic self-diffeomorphism
+groups. -/
+@[expose] def congr (e : M ≃ₘ^n⟮I, J⟯ N) : (M ≃ₘ^n⟮I, I⟯ M) ≃* (N ≃ₘ^n⟮J, J⟯ N) where
+  toFun φ := (e.symm.trans φ).trans e
+  invFun ψ := (e.trans ψ).trans e.symm
+  left_inv φ := by
+    ext x
+    simp [_root_.Diffeomorph.coe_trans]
+  right_inv ψ := by
+    ext x
+    simp [_root_.Diffeomorph.coe_trans]
+  map_mul' φ ψ := by
+    ext x
+    simp [mul_def, _root_.Diffeomorph.coe_trans]
+
+/-- The conjugating isomorphism acts pointwise by `congr e φ x = e (φ (e.symm x))`. -/
+@[simp]
+theorem congr_apply_apply (e : M ≃ₘ^n⟮I, J⟯ N) (φ : M ≃ₘ^n⟮I, I⟯ M) (x : N) :
+    congr e φ x = e (φ (e.symm x)) := rfl
+
+/-- The underlying diffeomorphism of `congr e φ` is `e ∘ φ ∘ e⁻¹`. -/
+theorem congr_apply (e : M ≃ₘ^n⟮I, J⟯ N) (φ : M ≃ₘ^n⟮I, I⟯ M) :
+    congr e φ = (e.symm.trans φ).trans e := rfl
+
+/-- The inverse of `congr e φ` is `congr e φ⁻¹`, since conjugation is a homomorphism. -/
+theorem congr_inv (e : M ≃ₘ^n⟮I, J⟯ N) (φ : M ≃ₘ^n⟮I, I⟯ M) :
+    (congr e φ)⁻¹ = congr e φ⁻¹ := (map_inv (congr e) φ).symm
+
+/-- Conjugating by the identity diffeomorphism is the identity isomorphism. -/
+@[simp]
+theorem congr_refl : congr (_root_.Diffeomorph.refl I M n) = MulEquiv.refl (M ≃ₘ^n⟮I, I⟯ M) := by
+  ext φ x
+  simp
+
+/-- Conjugation is functorial: conjugating by a composite diffeomorphism is the composite of the
+conjugating isomorphisms. -/
+@[simp]
+theorem congr_trans (e : M ≃ₘ^n⟮I, J⟯ N) (e' : N ≃ₘ^n⟮J, K⟯ P) :
+    congr (e.trans e') = (congr e).trans (congr e') := by
+  ext φ x
+  simp [_root_.Diffeomorph.coe_trans, _root_.Diffeomorph.symm_trans']
+
+/-- The isomorphism conjugating by `e.symm` is the inverse of the one conjugating by `e`. -/
+@[simp]
+theorem congr_symm (e : M ≃ₘ^n⟮I, J⟯ N) : (congr e).symm = congr e.symm := by
+  ext ψ x
+  rfl
+
+/-- Forgetting smoothness intertwines `congr` with `Equiv.permCongr` on the permutation groups. -/
+theorem toPerm_congr (e : M ≃ₘ^n⟮I, J⟯ N) (φ : M ≃ₘ^n⟮I, I⟯ M) :
+    toPerm (congr e φ) = e.toEquiv.permCongr (toPerm φ) := by
+  ext x
+  simp [toPerm, Equiv.permCongr_apply]
+
+end Diffeomorph
+
+end TauCeti

--- a/TauCeti/Geometry/Diffeomorphism/Congr.lean
+++ b/TauCeti/Geometry/Diffeomorphism/Congr.lean
@@ -12,10 +12,11 @@ public import TauCeti.Geometry.Diffeomorphism.Group
 A diffeomorphism `e : M ≃ₘ^n⟮I, J⟯ N` conjugates self-diffeomorphisms of `M` into
 self-diffeomorphisms of `N` by `φ ↦ e ∘ φ ∘ e⁻¹`. Because this preserves composition, it is a
 group isomorphism `Diff I M n ≃* Diff J N n` between the self-diffeomorphism groups built in
-`TauCeti.Geometry.Diffeomorphism.Group`. This file records that isomorphism, `Diffeomorph.congr`,
-its pointwise action, and its functoriality: it is the identity on `Diffeomorph.refl`, respects
-`Diffeomorph.trans` and `Diffeomorph.symm`, and commutes with the forgetful homomorphism to the
-permutation group (`Diffeomorph.toPerm`) through Mathlib's `Equiv.permCongr`.
+`TauCeti.Geometry.Diffeomorphism.Group`. This file records that isomorphism,
+`Diffeomorph.diffCongr`, its pointwise action, and its functoriality: it is the identity on
+`Diffeomorph.refl`, respects `Diffeomorph.trans` and `Diffeomorph.symm`, and commutes with the
+forgetful homomorphism to the permutation group (`Diffeomorph.toPerm`) through Mathlib's
+`Equiv.permCongr`.
 
 This is the sense in which the group object of the geometric-topology roadmap
 (`TauCetiRoadmap/GeometricTopology/README.md`, layer 3, "diffeomorphism groups with the C^∞
@@ -33,18 +34,19 @@ for the naturality statement.
 
 ## Main definitions
 
-* `TauCeti.Diffeomorph.congr e`: the group isomorphism `Diff I M n ≃* Diff J N n` conjugating by a
-  diffeomorphism `e : M ≃ₘ^n⟮I, J⟯ N`.
+* `TauCeti.Diffeomorph.diffCongr e`: the group isomorphism `Diff I M n ≃* Diff J N n` conjugating by
+  a diffeomorphism `e : M ≃ₘ^n⟮I, J⟯ N`.
 
 ## Main results
 
-* `TauCeti.Diffeomorph.congr_apply_apply`: the pointwise action `congr e φ x = e (φ (e.symm x))`.
-* `TauCeti.Diffeomorph.congr_refl`: conjugating by the identity is the identity isomorphism.
-* `TauCeti.Diffeomorph.congr_trans`: `congr` turns `Diffeomorph.trans` into `MulEquiv.trans`, so it
-  is functorial on the groupoid of diffeomorphisms.
-* `TauCeti.Diffeomorph.congr_symm`: the inverse isomorphism conjugates by `e.symm`.
-* `TauCeti.Diffeomorph.toPerm_congr`: the forgetful homomorphism to the permutation group
-  intertwines `congr` with `Equiv.permCongr`.
+* `TauCeti.Diffeomorph.diffCongr_apply_apply`: the pointwise action
+  `diffCongr e φ x = e (φ (e.symm x))`.
+* `TauCeti.Diffeomorph.diffCongr_refl`: conjugating by the identity is the identity isomorphism.
+* `TauCeti.Diffeomorph.diffCongr_trans`: `diffCongr` turns `Diffeomorph.trans` into
+  `MulEquiv.trans`, so it is functorial on the groupoid of diffeomorphisms.
+* `TauCeti.Diffeomorph.diffCongr_symm`: the inverse isomorphism conjugates by `e.symm`.
+* `TauCeti.Diffeomorph.toPerm_diffCongr`: the forgetful homomorphism to the permutation group
+  intertwines `diffCongr` with `Equiv.permCongr`.
 -/
 
 public section
@@ -68,10 +70,10 @@ variable {𝕜 : Type*} [NontriviallyNormedField 𝕜]
 namespace Diffeomorph
 
 /-- Conjugation by a diffeomorphism `e : M ≃ₘ^n⟮I, J⟯ N` as a group isomorphism between the
-self-diffeomorphism groups: `congr e φ = e ∘ φ ∘ e⁻¹`. This is the diffeomorphism analogue of
+self-diffeomorphism groups: `diffCongr e φ = e ∘ φ ∘ e⁻¹`. This is the diffeomorphism analogue of
 `Equiv.permCongr` and expresses that diffeomorphic manifolds have isomorphic self-diffeomorphism
 groups. -/
-@[expose] def congr (e : M ≃ₘ^n⟮I, J⟯ N) : (M ≃ₘ^n⟮I, I⟯ M) ≃* (N ≃ₘ^n⟮J, J⟯ N) where
+@[expose] def diffCongr (e : M ≃ₘ^n⟮I, J⟯ N) : (M ≃ₘ^n⟮I, I⟯ M) ≃* (N ≃ₘ^n⟮J, J⟯ N) where
   toFun φ := (e.symm.trans φ).trans e
   invFun ψ := (e.trans ψ).trans e.symm
   left_inv φ := by
@@ -84,42 +86,44 @@ groups. -/
     ext x
     simp [mul_def, _root_.Diffeomorph.coe_trans]
 
-/-- The conjugating isomorphism acts pointwise by `congr e φ x = e (φ (e.symm x))`. -/
+/-- The conjugating isomorphism acts pointwise by `diffCongr e φ x = e (φ (e.symm x))`. -/
 @[simp]
-theorem congr_apply_apply (e : M ≃ₘ^n⟮I, J⟯ N) (φ : M ≃ₘ^n⟮I, I⟯ M) (x : N) :
-    congr e φ x = e (φ (e.symm x)) := rfl
+theorem diffCongr_apply_apply (e : M ≃ₘ^n⟮I, J⟯ N) (φ : M ≃ₘ^n⟮I, I⟯ M) (x : N) :
+    diffCongr e φ x = e (φ (e.symm x)) := rfl
 
-/-- The underlying diffeomorphism of `congr e φ` is `e ∘ φ ∘ e⁻¹`. -/
-theorem congr_apply (e : M ≃ₘ^n⟮I, J⟯ N) (φ : M ≃ₘ^n⟮I, I⟯ M) :
-    congr e φ = (e.symm.trans φ).trans e := rfl
+/-- The underlying diffeomorphism of `diffCongr e φ` is `e ∘ φ ∘ e⁻¹`. -/
+theorem diffCongr_apply (e : M ≃ₘ^n⟮I, J⟯ N) (φ : M ≃ₘ^n⟮I, I⟯ M) :
+    diffCongr e φ = (e.symm.trans φ).trans e := rfl
 
-/-- The inverse of `congr e φ` is `congr e φ⁻¹`, since conjugation is a homomorphism. -/
-theorem congr_inv (e : M ≃ₘ^n⟮I, J⟯ N) (φ : M ≃ₘ^n⟮I, I⟯ M) :
-    (congr e φ)⁻¹ = congr e φ⁻¹ := (map_inv (congr e) φ).symm
+/-- The inverse of `diffCongr e φ` is `diffCongr e φ⁻¹`, since conjugation is a homomorphism. -/
+theorem diffCongr_inv (e : M ≃ₘ^n⟮I, J⟯ N) (φ : M ≃ₘ^n⟮I, I⟯ M) :
+    (diffCongr e φ)⁻¹ = diffCongr e φ⁻¹ := (map_inv (diffCongr e) φ).symm
 
 /-- Conjugating by the identity diffeomorphism is the identity isomorphism. -/
 @[simp]
-theorem congr_refl : congr (_root_.Diffeomorph.refl I M n) = MulEquiv.refl (M ≃ₘ^n⟮I, I⟯ M) := by
+theorem diffCongr_refl :
+    diffCongr (_root_.Diffeomorph.refl I M n) = MulEquiv.refl (M ≃ₘ^n⟮I, I⟯ M) := by
   ext φ x
   simp
 
 /-- Conjugation is functorial: conjugating by a composite diffeomorphism is the composite of the
 conjugating isomorphisms. -/
 @[simp]
-theorem congr_trans (e : M ≃ₘ^n⟮I, J⟯ N) (e' : N ≃ₘ^n⟮J, K⟯ P) :
-    congr (e.trans e') = (congr e).trans (congr e') := by
+theorem diffCongr_trans (e : M ≃ₘ^n⟮I, J⟯ N) (e' : N ≃ₘ^n⟮J, K⟯ P) :
+    diffCongr (e.trans e') = (diffCongr e).trans (diffCongr e') := by
   ext φ x
   simp [_root_.Diffeomorph.coe_trans, _root_.Diffeomorph.symm_trans']
 
 /-- The isomorphism conjugating by `e.symm` is the inverse of the one conjugating by `e`. -/
 @[simp]
-theorem congr_symm (e : M ≃ₘ^n⟮I, J⟯ N) : (congr e).symm = congr e.symm := by
+theorem diffCongr_symm (e : M ≃ₘ^n⟮I, J⟯ N) : (diffCongr e).symm = diffCongr e.symm := by
   ext ψ x
   rfl
 
-/-- Forgetting smoothness intertwines `congr` with `Equiv.permCongr` on the permutation groups. -/
-theorem toPerm_congr (e : M ≃ₘ^n⟮I, J⟯ N) (φ : M ≃ₘ^n⟮I, I⟯ M) :
-    toPerm (congr e φ) = e.toEquiv.permCongr (toPerm φ) := by
+/-- Forgetting smoothness intertwines `diffCongr` with `Equiv.permCongr` on the permutation
+groups. -/
+theorem toPerm_diffCongr (e : M ≃ₘ^n⟮I, J⟯ N) (φ : M ≃ₘ^n⟮I, I⟯ M) :
+    toPerm (diffCongr e φ) = e.toEquiv.permCongr (toPerm φ) := by
   ext x
   simp [toPerm, Equiv.permCongr_apply]
 

--- a/TauCeti/Geometry/Diffeomorphism/Congr.lean
+++ b/TauCeti/Geometry/Diffeomorphism/Congr.lean
@@ -49,6 +49,9 @@ for the naturality statement.
 * `TauCeti.Diffeomorph.diffCongr_trans`: `diffCongr` turns `Diffeomorph.trans` into
   `MulEquiv.trans`, so it is functorial on the groupoid of diffeomorphisms.
 * `TauCeti.Diffeomorph.diffCongr_symm`: the inverse isomorphism conjugates by `e.symm`.
+* `TauCeti.Homeomorph.homeoCongr_refl`, `TauCeti.Homeomorph.homeoCongr_trans`, and
+  `TauCeti.Homeomorph.homeoCongr_symm`: the parallel functoriality of `homeoCongr` on the groupoid
+  of homeomorphisms.
 * `TauCeti.Diffeomorph.toHomeomorphHom_comp_diffCongr` and
   `TauCeti.Diffeomorph.toPerm_comp_diffCongr`: naturality of `diffCongr` against the forgetful
   homomorphisms `toHomeomorphHom` and `toPerm`, as commutative squares of group homomorphisms
@@ -87,6 +90,35 @@ def homeoCongr (e : M ≃ₜ N) : (M ≃ₜ M) ≃* (N ≃ₜ N) where
   left_inv φ := by ext x; simp
   right_inv ψ := by ext x; simp
   map_mul' φ ψ := by ext x; simp
+
+/-- The conjugating isomorphism acts pointwise by `homeoCongr e φ x = e (φ (e.symm x))`. -/
+@[simp, grind =]
+theorem homeoCongr_apply_apply (e : M ≃ₜ N) (φ : M ≃ₜ M) (x : N) :
+    homeoCongr e φ x = e (φ (e.symm x)) := rfl
+
+/-- The inverse of `homeoCongr e φ` is `homeoCongr e φ⁻¹`, since conjugation is a homomorphism. -/
+theorem homeoCongr_inv (e : M ≃ₜ N) (φ : M ≃ₜ M) :
+    (homeoCongr e φ)⁻¹ = homeoCongr e φ⁻¹ := (map_inv (homeoCongr e) φ).symm
+
+/-- Conjugating by the identity homeomorphism is the identity isomorphism. -/
+@[simp]
+theorem homeoCongr_refl : homeoCongr (_root_.Homeomorph.refl M) = MulEquiv.refl (M ≃ₜ M) := by
+  ext φ x
+  simp
+
+/-- Conjugation is functorial: conjugating by a composite homeomorphism is the composite of the
+conjugating isomorphisms. -/
+@[simp]
+theorem homeoCongr_trans (e : M ≃ₜ N) (e' : N ≃ₜ P) :
+    homeoCongr (e.trans e') = (homeoCongr e).trans (homeoCongr e') := by
+  ext φ x
+  simp
+
+/-- The isomorphism conjugating by `e.symm` is the inverse of the one conjugating by `e`. -/
+@[simp, grind =]
+theorem homeoCongr_symm (e : M ≃ₜ N) : (homeoCongr e).symm = homeoCongr e.symm := by
+  ext ψ x
+  rfl
 
 end Homeomorph
 

--- a/TauCeti/Topology/Algebra/HomeomorphCongr.lean
+++ b/TauCeti/Topology/Algebra/HomeomorphCongr.lean
@@ -1,0 +1,91 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+module
+
+public import Mathlib.Topology.Homeomorph.Defs
+public import Mathlib.Algebra.Group.Equiv.Defs
+
+/-!
+# Transporting the self-homeomorphism group along a homeomorphism
+
+A homeomorphism `e : M ≃ₜ N` conjugates self-homeomorphisms of `M` into self-homeomorphisms of `N`
+by `φ ↦ e ∘ φ ∘ e⁻¹`. Because this preserves composition, it is a group isomorphism
+`(M ≃ₜ M) ≃* (N ≃ₜ N)` between the self-homeomorphism groups. This file records that isomorphism,
+`Homeomorph.homeoCongr`, its pointwise action, and its functoriality: it is the identity on
+`Homeomorph.refl`, respects `Homeomorph.trans` and `Homeomorph.symm`, and sends inverses to
+inverses.
+
+This is the topological analogue of `Equiv.permCongr` (`Mathlib/Logic/Equiv/Defs.lean`), the
+conjugation isomorphism of permutation groups, and is the target of the forgetful naturality of the
+diffeomorphism-level `TauCeti.Diffeomorph.diffCongr` in
+`TauCeti.Geometry.Diffeomorphism.Congr`.
+
+## Main definitions
+
+* `TauCeti.Homeomorph.homeoCongr e`: the group isomorphism `(M ≃ₜ M) ≃* (N ≃ₜ N)` conjugating
+  self-homeomorphisms by a homeomorphism `e : M ≃ₜ N`.
+
+## Main results
+
+* `TauCeti.Homeomorph.homeoCongr_apply_apply`: the pointwise action
+  `homeoCongr e φ x = e (φ (e.symm x))`.
+* `TauCeti.Homeomorph.homeoCongr_refl`, `TauCeti.Homeomorph.homeoCongr_trans`, and
+  `TauCeti.Homeomorph.homeoCongr_symm`: the functoriality of `homeoCongr` on the groupoid of
+  homeomorphisms.
+-/
+
+public section
+
+namespace TauCeti
+
+variable {M : Type*} [TopologicalSpace M]
+  {N : Type*} [TopologicalSpace N]
+  {P : Type*} [TopologicalSpace P]
+
+namespace Homeomorph
+
+/-- Conjugation by a homeomorphism `e : M ≃ₜ N` as a group isomorphism between the
+self-homeomorphism groups: `homeoCongr e φ = e ∘ φ ∘ e⁻¹`. This is the homeomorphism analogue of
+`Equiv.permCongrHom` and the target of the forgetful naturality of `Diffeomorph.diffCongr`. -/
+@[expose, simps]
+def homeoCongr (e : M ≃ₜ N) : (M ≃ₜ M) ≃* (N ≃ₜ N) where
+  toFun φ := (e.symm.trans φ).trans e
+  invFun ψ := (e.trans ψ).trans e.symm
+  left_inv φ := by ext x; simp
+  right_inv ψ := by ext x; simp
+  map_mul' φ ψ := by ext x; simp
+
+/-- The conjugating isomorphism acts pointwise by `homeoCongr e φ x = e (φ (e.symm x))`. -/
+@[simp, grind =]
+theorem homeoCongr_apply_apply (e : M ≃ₜ N) (φ : M ≃ₜ M) (x : N) :
+    homeoCongr e φ x = e (φ (e.symm x)) := rfl
+
+/-- The inverse of `homeoCongr e φ` is `homeoCongr e φ⁻¹`, since conjugation is a homomorphism. -/
+theorem homeoCongr_inv (e : M ≃ₜ N) (φ : M ≃ₜ M) :
+    (homeoCongr e φ)⁻¹ = homeoCongr e φ⁻¹ := (map_inv (homeoCongr e) φ).symm
+
+/-- Conjugating by the identity homeomorphism is the identity isomorphism. -/
+@[simp]
+theorem homeoCongr_refl : homeoCongr (_root_.Homeomorph.refl M) = MulEquiv.refl (M ≃ₜ M) := by
+  ext φ x
+  simp
+
+/-- Conjugation is functorial: conjugating by a composite homeomorphism is the composite of the
+conjugating isomorphisms. -/
+@[simp]
+theorem homeoCongr_trans (e : M ≃ₜ N) (e' : N ≃ₜ P) :
+    homeoCongr (e.trans e') = (homeoCongr e).trans (homeoCongr e') := by
+  ext φ x
+  simp
+
+/-- The isomorphism conjugating by `e.symm` is the inverse of the one conjugating by `e`. -/
+@[simp, grind =]
+theorem homeoCongr_symm (e : M ≃ₜ N) : (homeoCongr e).symm = homeoCongr e.symm := by
+  ext ψ x
+  rfl
+
+end Homeomorph
+
+end TauCeti


### PR DESCRIPTION
This PR adds `TauCeti.Diffeomorph.congr`, the group isomorphism `Diff I M n ≃* Diff J N n` that conjugates self-diffeomorphisms of `M` into self-diffeomorphisms of `N` along a diffeomorphism `e : M ≃ₘ^n⟮I, J⟯ N` by `φ ↦ e ∘ φ ∘ e⁻¹`. It records the pointwise action `congr e φ x = e (φ (e.symm x))`, functoriality on the groupoid of diffeomorphisms (`congr_refl`, `congr_trans`, `congr_symm`, and `congr_inv`), and naturality against the forgetful homomorphism to the permutation group (`toPerm_congr`), reusing Mathlib's `Equiv.permCongr`. Concretely this expresses that the self-diffeomorphism group is a diffeomorphism invariant: diffeomorphic manifolds have isomorphic self-diffeomorphism groups, so the homotopy-type statements that layer 3 targets transport along a chosen diffeomorphism of the underlying manifold. The construction is purely algebraic and works for every smoothness exponent `n`; the `C^∞` topology making it a topological-group isomorphism is a separate, later layer-3 deliverable.

This advances the geometric-topology roadmap `TauCetiRoadmap/GeometricTopology/README.md`, layer 3 ("diffeomorphism groups with the C^∞ topology"), whose first deliverable is the group `Diff(M) := M ≃ₘ^∞⟮I, I⟯ M`; it builds directly on the existing `TauCeti.Geometry.Diffeomorphism.Group` and is the diffeomorphism analogue of Mathlib's `Equiv.permCongr` (`Mathlib/Logic/Equiv/Defs.lean`), which it also reuses.

`lake build` and `lake exe axioms` are green (`all within the allowlist [propext, Classical.choice, Quot.sound]`).

<!--tauceti-target:v1 {"focus":"GeometricTopology","id":"diffeomorphism-group-congr"}-->

🤖 Prepared with Claude Code
