### PR TITLE
feat: add the Galois group of a multiquadratic CM field

### DIFF
--- a/TauCeti/NumberTheory/Multiquadratic/CMField.lean
+++ b/TauCeti/NumberTheory/Multiquadratic/CMField.lean
@@ -92,6 +92,65 @@ theorem not_isSquare_prod_optionNeg {K : Type*} [Field K] [LinearOrder K] [IsStr
     | none => exact absurd hx hnone
     | some i => exact ⟨i, Finset.mem_eraseNone.mpr hx⟩
 
+section CMFamily
+
+variable {ι : Type*} (p : ι → ℕ)
+
+/-- The `Option ι`-indexed radicand family of a multiquadratic CM field: `none ↦ -1` (for `i`)
+and `some i ↦ p i` (for `√(p i)`). -/
+@[expose] def cmRadicand : Option ι → ℚ := fun x => x.elim (-1) (fun i => (p i : ℚ))
+
+/-- The `Option ι`-indexed generator family of a multiquadratic CM field: `none ↦ i` and
+`some i ↦ √(p i)` (as a complex number). -/
+@[expose] noncomputable def cmRoot : Option ι → ℂ :=
+  fun x => x.elim Complex.I (fun i => ((Real.sqrt (p i) : ℝ) : ℂ))
+
+@[simp] theorem cmRadicand_none : cmRadicand p none = -1 := rfl
+
+@[simp] theorem cmRadicand_some (i : ι) : cmRadicand p (some i) = (p i : ℚ) := rfl
+
+@[simp] theorem cmRoot_none : cmRoot p none = Complex.I := rfl
+
+@[simp] theorem cmRoot_some (i : ι) : cmRoot p (some i) = ((Real.sqrt (p i) : ℝ) : ℂ) := rfl
+
+/-- The generator family squares to the radicand family: `i² = -1` and `√(p i)² = p i`. This is
+the `hroot` hypothesis the field-generic multiquadratic results consume. -/
+theorem cmRoot_sq (x : Option ι) : cmRoot p x ^ 2 = algebraMap ℚ ℂ (cmRadicand p x) := by
+  cases x with
+  | none => simp [cmRoot, cmRadicand, Complex.I_sq]
+  | some i =>
+      simp only [cmRoot, cmRadicand, Option.elim_some]
+      rw [← Complex.ofReal_pow, Real.sq_sqrt (Nat.cast_nonneg _), Complex.ofReal_natCast,
+        map_natCast]
+
+/-- The range of the CM generator family is the inserted generator set: `i` together with the
+real square roots `√(p i)`. This identifies `adjoin ℚ (Set.range (cmRoot p))` with the named
+field `ℚ(i, √p₁, …, √pₙ)`. -/
+theorem range_cmRoot :
+    Set.range (cmRoot p)
+      = insert Complex.I (Set.range fun i => ((Real.sqrt (p i) : ℝ) : ℂ)) := by
+  ext z
+  simp only [Set.mem_range, Set.mem_insert_iff]
+  constructor
+  · rintro ⟨x, rfl⟩
+    cases x with
+    | none => exact Or.inl rfl
+    | some i => exact Or.inr ⟨i, rfl⟩
+  · rintro (rfl | ⟨i, rfl⟩)
+    · exact ⟨none, rfl⟩
+    · exact ⟨some i, rfl⟩
+
+/-- The CM radicand family is square-class independent: for distinct primes `p`, no nonempty
+subset product of `-1, p₁, …, pₙ` is a square in `ℚ`. -/
+theorem not_isSquare_prod_cmRadicand (hp : ∀ i, (p i).Prime) (hinj : Function.Injective p)
+    (S : Finset (Option ι)) (hS : S.Nonempty) : ¬ IsSquare (∏ x ∈ S, cmRadicand p x) := by
+  have h := not_isSquare_prod_optionNeg (K := ℚ) (d := fun i => (p i : ℚ))
+    (fun i => by exact_mod_cast (hp i).pos)
+    (not_isSquare_prod_primes_of_injective p hp hinj) (c := -1) (by norm_num) S hS
+  exact h
+
+end CMFamily
+
 /-- **Degree of a multiquadratic CM field.** For a finite family of distinct primes `p : ι → ℕ`,
 the field `ℚ(i, √p₁, …, √pₙ)` generated over `ℚ` by `i` and the real square roots of the `p i`
 has degree `2^{|ι|+1}`. This recovers the Erdős CM field `ℚ(i, √q₀, …, √q_{g-1})` as a
@@ -102,39 +161,12 @@ theorem finrank_adjoin_I_sqrt_primes {ι : Type*} [Finite ι] (p : ι → ℕ)
         (IntermediateField.adjoin ℚ
           (insert Complex.I (Set.range fun i => ((Real.sqrt (p i) : ℝ) : ℂ))))
       = 2 ^ (Nat.card ι + 1) := by
-  classical
-  set d : Option ι → ℚ := fun x => x.elim (-1) (fun i => (p i : ℚ)) with hd
-  set root : Option ι → ℂ :=
-    fun x => x.elim Complex.I (fun i => ((Real.sqrt (p i) : ℝ) : ℂ)) with hr
-  have hroot : ∀ x : Option ι, root x ^ 2 = algebraMap ℚ ℂ (d x) := by
-    intro x
-    cases x with
-    | none => simp [hr, hd, Complex.I_sq]
-    | some i =>
-        simp only [hr, hd, Option.elim_some]
-        rw [← Complex.ofReal_pow, Real.sq_sqrt (Nat.cast_nonneg _), Complex.ofReal_natCast,
-          map_natCast]
-  have hindep : ∀ S : Finset (Option ι), S.Nonempty → ¬ IsSquare (∏ x ∈ S, d x) := by
-    intro S hS
-    exact not_isSquare_prod_optionNeg (fun i => by exact_mod_cast (hp i).pos)
-      (not_isSquare_prod_primes_of_injective p hp hinj) (by norm_num) S hS
-  have hrange : Set.range root
-      = insert Complex.I (Set.range fun i => ((Real.sqrt (p i) : ℝ) : ℂ)) := by
-    ext z
-    simp only [Set.mem_range, Set.mem_insert_iff]
-    constructor
-    · rintro ⟨x, rfl⟩
-      cases x with
-      | none => exact Or.inl rfl
-      | some i => exact Or.inr ⟨i, rfl⟩
-    · rintro (rfl | ⟨i, rfl⟩)
-      · exact ⟨none, rfl⟩
-      · exact ⟨some i, rfl⟩
   have hcard : Nat.card (Option ι) = Nat.card ι + 1 := by
     letI := Fintype.ofFinite ι
     simp [Nat.card_eq_fintype_card, Fintype.card_option]
-  have hkey := finrank_adjoin_range (d := d) (root := root) hroot hindep
-  rw [hrange, hcard] at hkey
+  have hkey := finrank_adjoin_range (d := cmRadicand p) (root := cmRoot p)
+    (cmRoot_sq p) (not_isSquare_prod_cmRadicand p hp hinj)
+  rw [range_cmRoot p, hcard] at hkey
   exact hkey
 
 /-- **Worked example: `[ℚ(i, √2) : ℚ] = 4`.** The smallest nontrivial multiquadratic CM degree,

--- a/TauCeti/NumberTheory/Multiquadratic/CMFieldGaloisGroup.lean
+++ b/TauCeti/NumberTheory/Multiquadratic/CMFieldGaloisGroup.lean
@@ -49,44 +49,6 @@ namespace TauCeti.Multiquadratic
 
 variable {ι : Type*} (p : ι → ℕ)
 
-/-- The `Option ι`-indexed radicand family of a multiquadratic CM field: `none ↦ -1` (for `i`)
-and `some i ↦ p i` (for `√(p i)`). -/
-@[expose] def cmRadicand : Option ι → ℚ := fun x => x.elim (-1) (fun i => (p i : ℚ))
-
-/-- The `Option ι`-indexed generator family of a multiquadratic CM field: `none ↦ i` and
-`some i ↦ √(p i)` (as a complex number). -/
-@[expose] noncomputable def cmRoot : Option ι → ℂ :=
-  fun x => x.elim Complex.I (fun i => ((Real.sqrt (p i) : ℝ) : ℂ))
-
-@[simp] theorem cmRadicand_none : cmRadicand p none = -1 := rfl
-
-@[simp] theorem cmRadicand_some (i : ι) : cmRadicand p (some i) = (p i : ℚ) := rfl
-
-@[simp] theorem cmRoot_none : cmRoot p none = Complex.I := rfl
-
-@[simp] theorem cmRoot_some (i : ι) : cmRoot p (some i) = ((Real.sqrt (p i) : ℝ) : ℂ) := rfl
-
-/-- The generator family squares to the radicand family: `i² = -1` and `√(p i)² = p i`. This is
-the `hroot` hypothesis the field-generic multiquadratic results consume. -/
-theorem cmRoot_sq (x : Option ι) : cmRoot p x ^ 2 = algebraMap ℚ ℂ (cmRadicand p x) := by
-  cases x with
-  | none => simp [cmRoot, cmRadicand, Complex.I_sq]
-  | some i =>
-      simp only [cmRoot, cmRadicand, Option.elim_some]
-      rw [← Complex.ofReal_pow, Real.sq_sqrt (Nat.cast_nonneg _), Complex.ofReal_natCast,
-        map_natCast]
-
-/-- The CM radicand family is square-class independent: for distinct primes `p`, no nonempty subset
-product of `-1, p₁, …, pₙ` is a square in `ℚ`. A subset avoiding `-1` is a nonempty product of
-distinct primes, hence not a square; a subset containing `-1` has a negative product, so it is not
-a square in the ordered field `ℚ`. -/
-theorem not_isSquare_prod_cmRadicand (hp : ∀ i, (p i).Prime) (hinj : Function.Injective p)
-    (S : Finset (Option ι)) (hS : S.Nonempty) : ¬ IsSquare (∏ x ∈ S, cmRadicand p x) := by
-  have h := not_isSquare_prod_optionNeg (K := ℚ) (d := fun i => (p i : ℚ))
-    (fun i => by exact_mod_cast (hp i).pos)
-    (not_isSquare_prod_primes_of_injective p hp hinj) (c := -1) (by norm_num) S hS
-  exact h
-
 variable [Finite ι] (hp : ∀ i, (p i).Prime) (hinj : Function.Injective p)
 
 include hp hinj
@@ -126,30 +88,18 @@ theorem card_aut_adjoin_I_sqrt_primes :
           (adjoin ℚ (insert Complex.I (Set.range fun i => ((Real.sqrt (p i) : ℝ) : ℂ))) :
             IntermediateField ℚ ℂ))
       = 2 ^ (Nat.card ι + 1) := by
-  have hrange : Set.range (cmRoot p)
-      = insert Complex.I (Set.range fun i => ((Real.sqrt (p i) : ℝ) : ℂ)) := by
-    ext z
-    simp only [Set.mem_range, Set.mem_insert_iff]
-    constructor
-    · rintro ⟨x, rfl⟩
-      cases x with
-      | none => exact Or.inl rfl
-      | some i => exact Or.inr ⟨i, rfl⟩
-    · rintro (rfl | ⟨i, rfl⟩)
-      · exact ⟨none, rfl⟩
-      · exact ⟨some i, rfl⟩
   have hcard : Nat.card (Option ι) = Nat.card ι + 1 := by
     letI := Fintype.ofFinite ι
     simp [Nat.card_eq_fintype_card, Fintype.card_option]
   have hkey := card_aut_adjoin_range (cmRoot_sq p) (not_isSquare_prod_cmRadicand p hp hinj)
-  rw [hrange, hcard] at hkey
+  rw [range_cmRoot p, hcard] at hkey
   exact hkey
 
 end TauCeti.Multiquadratic
 
 namespace TauCeti.Multiquadratic
 
-/-- **Worked example: `|Gal(ℚ(i, √2)/ℚ)| = 4`.** The smallest nontrivial multiquadratic CM field,
+/-- **Worked example: `|Gal(ℚ(i, √2)/ℚ)| = 4`.** The one-real-prime worked example,
 obtained from `card_aut_adjoin_I_sqrt_primes` with the single prime `2`. -/
 theorem card_aut_adjoin_I_sqrt_two :
     Nat.card

--- a/TauCeti/NumberTheory/Multiquadratic/CMFieldGaloisGroup.lean
+++ b/TauCeti/NumberTheory/Multiquadratic/CMFieldGaloisGroup.lean
@@ -1,0 +1,169 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+module
+
+public import TauCeti.NumberTheory.Multiquadratic.GaloisGroup
+public import TauCeti.NumberTheory.Multiquadratic.CMField
+
+/-!
+# The Galois group of a multiquadratic CM field is `(ℤ/2)^{n+1}`
+
+The multiquadratic CM field `ℚ(i, √p₁, …, √pₙ)` has degree `2^{n+1}` over `ℚ`
+(`TauCeti.Multiquadratic.finrank_adjoin_I_sqrt_primes`). This file supplies its Galois group:
+adjoining `i = √(-1)` together with the real square roots of a finite family of distinct primes
+gives a field whose Galois group over `ℚ` is elementary abelian of exponent `2` and rank `n + 1`.
+
+The single new ingredient over the prime-radicand theory
+(`TauCeti.Multiquadratic.galoisGroupEquivSqrtPrimes`) is the extra radicand `-1`. Indexing the
+combined radicand family by `Option ι` — `none ↦ -1`, `some i ↦ p i` — the negative-radicand
+square-class combinator `TauCeti.Multiquadratic.not_isSquare_prod_optionNeg` shows this family is
+still square-class independent, so the field-generic isomorphism
+`TauCeti.Multiquadratic.galoisGroupEquiv` applies verbatim. This gives the explicit isomorphism,
+its cardinality reading, and the worked example `|Gal(ℚ(i, √2)/ℚ)| = 4`.
+
+## Main results
+
+* `TauCeti.Multiquadratic.galoisGroupEquivISqrtPrimes`: for a finite family of distinct primes
+  `p : ι → ℕ`, the explicit isomorphism
+  `Gal(ℚ(i, √p₁, …, √pₙ)/ℚ) ≃ Multiplicative (Option ι → ℤ/2)`.
+* `TauCeti.Multiquadratic.card_aut_adjoin_I_sqrt_primes`: `|Gal(ℚ(i, √p₁, …, √pₙ)/ℚ)| = 2^{|ι|+1}`.
+* `TauCeti.Multiquadratic.card_aut_adjoin_I_sqrt_two`: `|Gal(ℚ(i, √2)/ℚ)| = 4`.
+
+## Provenance
+
+Like the CM degree it accompanies, this parallels the analysis of one concrete CM field in
+[kim-em/erdos-unit-distance](https://github.com/kim-em/erdos-unit-distance), the formalization of
+L. Alpöge's disproof of the uniform-constant Erdős unit-distance conjecture. The `Option`-indexed
+route — treating `i = √(-1)` as one more radicand rather than a separate quadratic step — matches
+the CM degree file `TauCeti.NumberTheory.Multiquadratic.CMField` and reuses its square-class
+combinator.
+-/
+
+public section
+
+open IntermediateField
+
+namespace TauCeti.Multiquadratic
+
+variable {ι : Type*} (p : ι → ℕ)
+
+/-- The `Option ι`-indexed radicand family of a multiquadratic CM field: `none ↦ -1` (for `i`)
+and `some i ↦ p i` (for `√(p i)`). -/
+@[expose] def cmRadicand : Option ι → ℚ := fun x => x.elim (-1) (fun i => (p i : ℚ))
+
+/-- The `Option ι`-indexed generator family of a multiquadratic CM field: `none ↦ i` and
+`some i ↦ √(p i)` (as a complex number). -/
+@[expose] noncomputable def cmRoot : Option ι → ℂ :=
+  fun x => x.elim Complex.I (fun i => ((Real.sqrt (p i) : ℝ) : ℂ))
+
+@[simp] theorem cmRadicand_none : cmRadicand p none = -1 := rfl
+
+@[simp] theorem cmRadicand_some (i : ι) : cmRadicand p (some i) = (p i : ℚ) := rfl
+
+@[simp] theorem cmRoot_none : cmRoot p none = Complex.I := rfl
+
+@[simp] theorem cmRoot_some (i : ι) : cmRoot p (some i) = ((Real.sqrt (p i) : ℝ) : ℂ) := rfl
+
+/-- The generator family squares to the radicand family: `i² = -1` and `√(p i)² = p i`. This is
+the `hroot` hypothesis the field-generic multiquadratic results consume. -/
+theorem cmRoot_sq (x : Option ι) : cmRoot p x ^ 2 = algebraMap ℚ ℂ (cmRadicand p x) := by
+  cases x with
+  | none => simp [cmRoot, cmRadicand, Complex.I_sq]
+  | some i =>
+      simp only [cmRoot, cmRadicand, Option.elim_some]
+      rw [← Complex.ofReal_pow, Real.sq_sqrt (Nat.cast_nonneg _), Complex.ofReal_natCast,
+        map_natCast]
+
+/-- The CM radicand family is square-class independent: for distinct primes `p`, no nonempty subset
+product of `-1, p₁, …, pₙ` is a square in `ℚ`. A subset avoiding `-1` is a nonempty product of
+distinct primes, hence not a square; a subset containing `-1` has a negative product, so it is not
+a square in the ordered field `ℚ`. -/
+theorem not_isSquare_prod_cmRadicand (hp : ∀ i, (p i).Prime) (hinj : Function.Injective p)
+    (S : Finset (Option ι)) (hS : S.Nonempty) : ¬ IsSquare (∏ x ∈ S, cmRadicand p x) := by
+  have h := not_isSquare_prod_optionNeg (K := ℚ) (d := fun i => (p i : ℚ))
+    (fun i => by exact_mod_cast (hp i).pos)
+    (not_isSquare_prod_primes_of_injective p hp hinj) (c := -1) (by norm_num) S hS
+  exact h
+
+variable [Finite ι] (hp : ∀ i, (p i).Prime) (hinj : Function.Injective p)
+
+include hp hinj
+
+/-- **The Galois group of a multiquadratic CM field is `(ℤ/2)^{n+1}`.** For a finite family of
+distinct primes `p : ι → ℕ`, the field `ℚ(i, √p₁, …, √pₙ)` generated over `ℚ` by `i` and the real
+square roots of the `p i` has Galois group isomorphic to `Multiplicative (Option ι → ℤ/2)`. This
+is the `Option`-indexed corollary of the field-generic isomorphism `galoisGroupEquiv`. -/
+noncomputable def galoisGroupEquivISqrtPrimes :
+    (adjoin ℚ (Set.range (cmRoot p)) ≃ₐ[ℚ] adjoin ℚ (Set.range (cmRoot p))) ≃*
+      Multiplicative (Option ι → ZMod 2) :=
+  galoisGroupEquiv (cmRoot_sq p) (not_isSquare_prod_cmRadicand p hp hinj)
+
+/-- The CM Galois equivalence sends an automorphism to its sign pattern on the generators
+`i, √(p i)`. -/
+@[simp] theorem galoisGroupEquivISqrtPrimes_apply
+    (σ : adjoin ℚ (Set.range (cmRoot p)) ≃ₐ[ℚ] adjoin ℚ (Set.range (cmRoot p))) :
+    galoisGroupEquivISqrtPrimes p hp hinj σ =
+      Multiplicative.ofAdd (signPattern (cmRoot p) σ) :=
+  galoisGroupEquiv_apply (cmRoot_sq p) (not_isSquare_prod_cmRadicand p hp hinj) σ
+
+/-- The inverse CM Galois equivalence realizes a sign pattern by sending each generator to
+`(-1)^(ε x)` times itself: `i ↦ ±i` and `√(p i) ↦ ±√(p i)`. -/
+@[simp] theorem galoisGroupEquivISqrtPrimes_symm_apply_gen (ε : Option ι → ZMod 2)
+    (x : Option ι) :
+    ((galoisGroupEquivISqrtPrimes p hp hinj).symm (Multiplicative.ofAdd ε)) (gen (cmRoot p) x)
+      = (-1) ^ (ε x).val * gen (cmRoot p) x :=
+  galoisGroupEquiv_symm_apply_gen (cmRoot_sq p) (not_isSquare_prod_cmRadicand p hp hinj) ε x
+
+/-- **Cardinality of the Galois group of a multiquadratic CM field.** For a finite family of
+distinct primes `p : ι → ℕ`, `|Gal(ℚ(i, √p₁, …, √pₙ)/ℚ)| = 2^{|ι|+1}`. This is the cardinality
+reading of `galoisGroupEquivISqrtPrimes`, matching the CM degree `finrank_adjoin_I_sqrt_primes`. -/
+theorem card_aut_adjoin_I_sqrt_primes :
+    Nat.card
+        ((adjoin ℚ (insert Complex.I (Set.range fun i => ((Real.sqrt (p i) : ℝ) : ℂ))) :
+            IntermediateField ℚ ℂ) ≃ₐ[ℚ]
+          (adjoin ℚ (insert Complex.I (Set.range fun i => ((Real.sqrt (p i) : ℝ) : ℂ))) :
+            IntermediateField ℚ ℂ))
+      = 2 ^ (Nat.card ι + 1) := by
+  have hrange : Set.range (cmRoot p)
+      = insert Complex.I (Set.range fun i => ((Real.sqrt (p i) : ℝ) : ℂ)) := by
+    ext z
+    simp only [Set.mem_range, Set.mem_insert_iff]
+    constructor
+    · rintro ⟨x, rfl⟩
+      cases x with
+      | none => exact Or.inl rfl
+      | some i => exact Or.inr ⟨i, rfl⟩
+    · rintro (rfl | ⟨i, rfl⟩)
+      · exact ⟨none, rfl⟩
+      · exact ⟨some i, rfl⟩
+  have hcard : Nat.card (Option ι) = Nat.card ι + 1 := by
+    letI := Fintype.ofFinite ι
+    simp [Nat.card_eq_fintype_card, Fintype.card_option]
+  have hkey := card_aut_adjoin_range (cmRoot_sq p) (not_isSquare_prod_cmRadicand p hp hinj)
+  rw [hrange, hcard] at hkey
+  exact hkey
+
+end TauCeti.Multiquadratic
+
+namespace TauCeti.Multiquadratic
+
+/-- **Worked example: `|Gal(ℚ(i, √2)/ℚ)| = 4`.** The smallest nontrivial multiquadratic CM field,
+obtained from `card_aut_adjoin_I_sqrt_primes` with the single prime `2`. -/
+theorem card_aut_adjoin_I_sqrt_two :
+    Nat.card
+        ((adjoin ℚ ({Complex.I, ((Real.sqrt 2 : ℝ) : ℂ)} : Set ℂ) : IntermediateField ℚ ℂ) ≃ₐ[ℚ]
+          (adjoin ℚ ({Complex.I, ((Real.sqrt 2 : ℝ) : ℂ)} : Set ℂ) : IntermediateField ℚ ℂ))
+      = 4 := by
+  have h := card_aut_adjoin_I_sqrt_primes ![2] (by decide) (by decide)
+  have hset : insert Complex.I
+      (Set.range fun i : Fin 1 => ((Real.sqrt ((![2] : Fin 1 → ℕ) i) : ℝ) : ℂ))
+      = ({Complex.I, ((Real.sqrt 2 : ℝ) : ℂ)} : Set ℂ) := by
+    rw [Set.range_unique]
+    simp [Matrix.cons_val_fin_one]
+  rw [hset] at h
+  rw [h, Nat.card_fin]
+  norm_num
+
+end TauCeti.Multiquadratic


### PR DESCRIPTION
This PR adds the Galois group of a multiquadratic CM field. For a finite family of distinct primes `p : ι → ℕ`, it proves that `ℚ(i, √p₁, …, √pₙ)` — the field obtained by adjoining `i` together with the real square roots of the `p i` — has Galois group over `ℚ` isomorphic to `Multiplicative (Option ι → ℤ/2)`, elementary abelian of exponent `2` and rank `|ι| + 1`, of cardinality `2^{|ι|+1}`, and it records the worked example `|Gal(ℚ(i, √2)/ℚ)| = 4`. It indexes the combined radicand family by `Option ι` (`none ↦ -1`, `some i ↦ p i`), uses the existing negative-radicand square-class combinator to show the family is still square-class independent, and feeds the field-generic multiquadratic Galois isomorphism.

It advances `TauCetiRoadmap/Multiquadratic/README.md`, Layer 0, the Galois-group milestone (`Gal(K(√d₁,…,√dₙ)/K) ≅ (ℤ/2)ⁿ`), specialised to the CM family, and the worked example "The erdos CM field `ℚ(i, √q₀, …, √q_{g−1})` recovered as a multiquadratic field of degree `2^{g+1}`: the general theory must reproduce what the bespoke proof needed." The degree of this field already landed as `finrank_adjoin_I_sqrt_primes`; this supplies the matching Galois group. I chose this as the lowest-hanging distinct Multiquadratic target after checking open and merged PRs: the field-generic Galois isomorphism, the prime-radicand corollary, the prime-discriminant corollary, and the specific genus-field cases `ℚ(i, √5)` and `ℚ(i, √-3, √-7)` all exist, while the general CM prime-radicand Galois group — the companion to the already-landed CM degree — was still absent.

No Mathlib infrastructure is vendored. The implementation reuses Tau Ceti's `galoisGroupEquiv`, `card_aut_adjoin_range`, the CM square-class combinator `not_isSquare_prod_optionNeg`, and the distinct-prime independence lemma `not_isSquare_prod_primes_of_injective`. Like the CM degree it accompanies, it parallels the analysis of one concrete CM field in [kim-em/erdos-unit-distance](https://github.com/kim-em/erdos-unit-distance), the formalization of L. Alpöge's disproof of the uniform-constant Erdős unit-distance conjecture; the `Option`-indexed route is the original one already adopted in the CM degree file.

`lake build` completed with `Build completed successfully (4482 jobs).` `lake exe axioms` completed with `axioms: audited 7549 TauCeti declaration(s); all within the allowlist [propext, Classical.choice, Quot.sound].`

<!--tauceti-target:v1 {"focus":"Multiquadratic","id":"cm-field-galois-group-z2n"}-->

🤖 Prepared with Claude Code
