### PR TITLE
feat: the graph of a symplectomorphism is Lagrangian

### DIFF
--- a/TauCeti/Geometry/Symplectic/LagrangianGraph.lean
+++ b/TauCeti/Geometry/Symplectic/LagrangianGraph.lean
@@ -6,6 +6,7 @@ module
 
 public import TauCeti.Geometry.Symplectic.Lagrangian
 public import TauCeti.Geometry.Symplectic.Prod
+public import TauCeti.Geometry.Symplectic.Rescale
 public import TauCeti.Geometry.Symplectic.SymplecticTransport
 
 /-!
@@ -23,8 +24,9 @@ This is the pointwise linear-algebra layer the analytic Heegaard Floer roadmap
 (`TauCetiRoadmap/HeegaardFloer/README.md`, Lane F3) needs before Lagrangian Floer homology:
 the boundary conditions of Floer strips between two Lagrangians `L₀`, `L₁` are packaged as a
 single Lagrangian in the twisted product, and the diagonal is the model boundary condition for
-the identity continuation. The construction uses the product form API from
-`TauCeti.Geometry.Symplectic.Prod` and Mathlib's graph submodule `LinearMap.graph`.
+the identity continuation. The twisted product reuses the direct sum
+`TauCeti.SymplecticForm.prod` with the second factor negated by
+`TauCeti.SymplecticForm.rescale`, and the graph is Mathlib's submodule `LinearMap.graph`.
 
 The Lagrangian conclusion needs no finite-dimensionality hypothesis.
 
@@ -59,6 +61,21 @@ variable {V W : Type*}
 variable [AddCommGroup V] [Module ℝ V] [AddCommGroup W] [Module ℝ W]
 variable {ω₁ : SymplecticForm V} {ω₂ : SymplecticForm W}
 
+/-- The twisted product symplectic form `ω₁ ⊖ ω₂` on `V × W`, given by
+`(ω₁ ⊖ ω₂)((v₁, w₁), (v₂, w₂)) = ω₁(v₁, v₂) - ω₂(w₁, w₂)`.
+
+It is the direct sum `prod` of `ω₁` with the negation `ω₂.rescale (-1)` of `ω₂`; downstream code
+uses it through `twistedProd_apply`. -/
+noncomputable def twistedProd (ω₁ : SymplecticForm V) (ω₂ : SymplecticForm W) :
+    SymplecticForm (V × W) :=
+  ω₁.prod (ω₂.rescale (-1) (by norm_num))
+
+@[simp]
+lemma twistedProd_apply (ω₁ : SymplecticForm V) (ω₂ : SymplecticForm W) (p q : V × W) :
+    twistedProd ω₁ ω₂ p q = ω₁ p.1 q.1 - ω₂ p.2 q.2 := by
+  simp only [twistedProd, prod_apply, rescale_apply]
+  ring
+
 /-- The graph of `f` is isotropic for the twisted product form iff `f` preserves the symplectic
 forms pointwise: `ω₂(f v, f w) = ω₁(v, w)`. -/
 @[simp]
@@ -86,10 +103,10 @@ lemma isIsotropic_linearEquiv_graph_iff {e : V ≃ₗ[ℝ] W} :
     (twistedProd ω₁ ω₂).IsIsotropic e.toLinearMap.graph ↔ IsSymplectomorphism ω₁ ω₂ e := by
   rw [isIsotropic_graph_iff]
   constructor
+  · intro h
+    exact isSymplectomorphism_iff.2 fun v w => h v w
   · intro h v w
-    exact h v w
-  · intro h v w
-    exact h v w
+    exact h.apply v w
 
 /-- The graph of a symplectomorphism `e : V ≃ₗ[ℝ] W` is a Lagrangian subspace of the twisted
 product `(V × W, ω₁ ⊖ ω₂)`. No finite-dimensionality is required. -/
@@ -111,7 +128,7 @@ lemma IsSymplectomorphism.isLagrangian_graph {e : V ≃ₗ[ℝ] W} (h : IsSymple
   have key2 : ∀ w : V, (ω₁.toBilinForm w) (x.1 - e.symm x.2) = 0 := by
     intro w
     have hb : ω₂ (e w) x.2 = ω₁ w (e.symm x.2) := by
-      have hh := h w (e.symm x.2)
+      have hh := h.apply w (e.symm x.2)
       rwa [e.apply_symm_apply] at hh
     have hk := key w
     rw [hb] at hk

--- a/TauCeti/Geometry/Symplectic/LagrangianGraph.lean
+++ b/TauCeti/Geometry/Symplectic/LagrangianGraph.lean
@@ -4,10 +4,8 @@ Released under Apache 2.0 license as described in the file LICENSE.
 -/
 module
 
-public import Mathlib.LinearAlgebra.Prod
 public import TauCeti.Geometry.Symplectic.Lagrangian
 public import TauCeti.Geometry.Symplectic.Prod
-public import TauCeti.Geometry.Symplectic.Rescale
 public import TauCeti.Geometry.Symplectic.SymplecticTransport
 
 /-!
@@ -25,14 +23,10 @@ This is the pointwise linear-algebra layer the analytic Heegaard Floer roadmap
 (`TauCetiRoadmap/HeegaardFloer/README.md`, Lane F3) needs before Lagrangian Floer homology:
 the boundary conditions of Floer strips between two Lagrangians `L₀`, `L₁` are packaged as a
 single Lagrangian in the twisted product, and the diagonal is the model boundary condition for
-the identity continuation. The construction reuses the direct-sum form
-`TauCeti.SymplecticForm.prod` (from `Prod.lean`) precomposed with the nonzero rescaling
-`TauCeti.SymplecticForm.rescale` by `-1` (from `Rescale.lean`), and Mathlib's graph submodule
-`LinearMap.graph`, so no new nondegeneracy bookkeeping is introduced.
+the identity continuation. The construction uses the product form API from
+`TauCeti.Geometry.Symplectic.Prod` and Mathlib's graph submodule `LinearMap.graph`.
 
-The Lagrangian conclusion needs no finite-dimensionality hypothesis: it is proved through the
-isotropic-plus-coisotropic characterization `SymplecticForm.isLagrangian_iff`, with coisotropy
-coming from nondegeneracy of `ω₁` alone.
+The Lagrangian conclusion needs no finite-dimensionality hypothesis.
 
 ## Main declarations
 
@@ -43,8 +37,8 @@ coming from nondegeneracy of `ω₁` alone.
   `IsSymplectomorphism`.
 * `TauCeti.SymplecticForm.isSymplectomorphism_iff_transport_eq`: this predicate is equivalent
   to equality with the transported symplectic form.
-* `TauCeti.SymplecticForm.isIsotropic_graph_iff`: the graph of `e` is isotropic for `ω₁ ⊖ ω₂`
-  iff `e` is a symplectomorphism.
+* `TauCeti.SymplecticForm.isIsotropic_graph_iff`: the graph of a linear map is isotropic for
+  `ω₁ ⊖ ω₂` iff it preserves the forms pointwise.
 * `TauCeti.SymplecticForm.IsSymplectomorphism.isLagrangian_graph` and
   `TauCeti.SymplecticForm.isLagrangian_graph_iff`: the graph of `e` is Lagrangian for `ω₁ ⊖ ω₂`
   iff `e` is a symplectomorphism.
@@ -61,103 +55,45 @@ namespace TauCeti
 
 namespace SymplecticForm
 
-variable {V W U : Type*}
-variable [AddCommGroup V] [Module ℝ V] [AddCommGroup W] [Module ℝ W] [AddCommGroup U] [Module ℝ U]
+variable {V W : Type*}
+variable [AddCommGroup V] [Module ℝ V] [AddCommGroup W] [Module ℝ W]
+variable {ω₁ : SymplecticForm V} {ω₂ : SymplecticForm W}
 
-/-- The twisted product symplectic form `ω₁ ⊖ ω₂` on `V × W`, given by
-`(ω₁ ⊖ ω₂)((v₁, w₁), (v₂, w₂)) = ω₁(v₁, v₂) - ω₂(w₁, w₂)`.
-
-It is the direct-sum form `ω₁ ⊕ ω₂` of `Prod.lean` with the second factor rescaled by `-1`. -/
-noncomputable def twistedProd (ω₁ : SymplecticForm V) (ω₂ : SymplecticForm W) :
-    SymplecticForm (V × W) :=
-  ω₁.prod (ω₂.rescale (-1) (by norm_num))
-
+/-- The graph of `f` is isotropic for the twisted product form iff `f` preserves the symplectic
+forms pointwise: `ω₂(f v, f w) = ω₁(v, w)`. -/
 @[simp]
-lemma twistedProd_apply (ω₁ : SymplecticForm V) (ω₂ : SymplecticForm W) (p q : V × W) :
-    twistedProd ω₁ ω₂ p q = ω₁ p.1 q.1 - ω₂ p.2 q.2 := by
-  unfold twistedProd
-  rw [prod_apply, rescale_apply]
-  ring
-
-/-- A real-linear equivalence `e : V ≃ₗ[ℝ] W` is a symplectomorphism from `(V, ω₁)` to `(W, ω₂)`
-when it intertwines the two symplectic forms, `ω₂(e v, e w) = ω₁(v, w)`. -/
-def IsSymplectomorphism (ω₁ : SymplecticForm V) (ω₂ : SymplecticForm W) (e : V ≃ₗ[ℝ] W) : Prop :=
-  ∀ v w, ω₂ (e v) (e w) = ω₁ v w
-
-variable {ω₁ : SymplecticForm V} {ω₂ : SymplecticForm W} {ω₃ : SymplecticForm U}
-
-/-- A linear equivalence is a symplectomorphism exactly when it preserves the symplectic forms
-pointwise. -/
-lemma isSymplectomorphism_iff {e : V ≃ₗ[ℝ] W} :
-    IsSymplectomorphism ω₁ ω₂ e ↔ ∀ v w, ω₂ (e v) (e w) = ω₁ v w :=
-  Iff.rfl
-
-/-- Apply a symplectomorphism hypothesis to two vectors. -/
-lemma IsSymplectomorphism.apply {e : V ≃ₗ[ℝ] W} (h : IsSymplectomorphism ω₁ ω₂ e) (v w : V) :
-    ω₂ (e v) (e w) = ω₁ v w :=
-  h v w
-
-/-- A linear equivalence is a symplectomorphism exactly when `ω₂` is the transport of `ω₁`
-along that equivalence. -/
-lemma isSymplectomorphism_iff_transport_eq {e : V ≃ₗ[ℝ] W} :
-    IsSymplectomorphism ω₁ ω₂ e ↔ ω₁.transport e = ω₂ := by
-  constructor
-  · intro h
-    apply toBilinForm_injective
-    ext v w
-    change ω₁.transport e v w = ω₂ v w
-    rw [transport_apply]
-    simpa using (h (e.symm v) (e.symm w)).symm
-  · intro h v w
-    rw [← h, transport_apply_apply]
-
-/-- The identity equivalence is a symplectomorphism. -/
-lemma IsSymplectomorphism.refl (ω : SymplecticForm V) :
-    IsSymplectomorphism ω ω (LinearEquiv.refl ℝ V) := by
-  intro v w
-  simp
-
-/-- The inverse of a symplectomorphism is a symplectomorphism. -/
-lemma IsSymplectomorphism.symm {e : V ≃ₗ[ℝ] W} (h : IsSymplectomorphism ω₁ ω₂ e) :
-    IsSymplectomorphism ω₂ ω₁ e.symm := by
-  intro v w
-  have h2 := h (e.symm v) (e.symm w)
-  rw [e.apply_symm_apply, e.apply_symm_apply] at h2
-  exact h2.symm
-
-/-- Symplectomorphisms compose. -/
-lemma IsSymplectomorphism.trans {e : V ≃ₗ[ℝ] W} {f : W ≃ₗ[ℝ] U}
-    (h₁ : IsSymplectomorphism ω₁ ω₂ e) (h₂ : IsSymplectomorphism ω₂ ω₃ f) :
-    IsSymplectomorphism ω₁ ω₃ (e.trans f) := by
-  intro v w
-  rw [LinearEquiv.trans_apply, LinearEquiv.trans_apply, h₂ (e v) (e w), h₁ v w]
-
-/-- The graph of `e` is isotropic for the twisted product form iff `e` is a symplectomorphism:
-isotropy of the graph is precisely the intertwining identity `ω₂(e v, e w) = ω₁(v, w)`. -/
-@[simp]
-lemma isIsotropic_graph_iff {e : V ≃ₗ[ℝ] W} :
-    (twistedProd ω₁ ω₂).IsIsotropic e.toLinearMap.graph ↔ IsSymplectomorphism ω₁ ω₂ e := by
+lemma isIsotropic_graph_iff {f : V →ₗ[ℝ] W} :
+    (twistedProd ω₁ ω₂).IsIsotropic f.graph ↔ ∀ v w, ω₂ (f v) (f w) = ω₁ v w := by
   rw [isIsotropic_iff]
   constructor
   · intro h v w
-    have hv : ((v, e v) : V × W) ∈ e.toLinearMap.graph := by simp [LinearMap.mem_graph_iff]
-    have hw : ((w, e w) : V × W) ∈ e.toLinearMap.graph := by simp [LinearMap.mem_graph_iff]
-    have hvw := h (v, e v) hv (w, e w) hw
+    have hv : ((v, f v) : V × W) ∈ f.graph := by simp [LinearMap.mem_graph_iff]
+    have hw : ((w, f w) : V × W) ∈ f.graph := by simp [LinearMap.mem_graph_iff]
+    have hvw := h (v, f v) hv (w, f w) hw
     simp only [twistedProd_apply] at hvw
     linarith
   · intro h p hp q hq
     rw [LinearMap.mem_graph_iff] at hp hq
-    simp only [LinearEquiv.coe_toLinearMap] at hp hq
     rw [twistedProd_apply, hp, hq]
     linarith [h p.1 q.1]
 
+/-- The graph of `e` is isotropic for the twisted product form iff `e` is a symplectomorphism. -/
+@[simp]
+lemma isIsotropic_linearEquiv_graph_iff {e : V ≃ₗ[ℝ] W} :
+    (twistedProd ω₁ ω₂).IsIsotropic e.toLinearMap.graph ↔ IsSymplectomorphism ω₁ ω₂ e := by
+  rw [isIsotropic_graph_iff]
+  constructor
+  · intro h v w
+    exact h v w
+  · intro h v w
+    exact h v w
+
 /-- The graph of a symplectomorphism `e : V ≃ₗ[ℝ] W` is a Lagrangian subspace of the twisted
-product `(V × W, ω₁ ⊖ ω₂)`. No finite-dimensionality is required: coisotropy follows from
-nondegeneracy of `ω₁`. -/
+product `(V × W, ω₁ ⊖ ω₂)`. No finite-dimensionality is required. -/
 lemma IsSymplectomorphism.isLagrangian_graph {e : V ≃ₗ[ℝ] W} (h : IsSymplectomorphism ω₁ ω₂ e) :
     (twistedProd ω₁ ω₂).IsLagrangian e.toLinearMap.graph := by
   rw [isLagrangian_iff]
-  refine ⟨isIsotropic_graph_iff.2 h, ?_⟩
+  refine ⟨isIsotropic_linearEquiv_graph_iff.2 h, ?_⟩
   rw [isCoisotropic_iff]
   intro x hx
   rw [mem_orthogonal_iff] at hx
@@ -187,7 +123,8 @@ lemma IsSymplectomorphism.isLagrangian_graph {e : V ≃ₗ[ℝ] W} (h : IsSymple
 @[simp]
 lemma isLagrangian_graph_iff {e : V ≃ₗ[ℝ] W} :
     (twistedProd ω₁ ω₂).IsLagrangian e.toLinearMap.graph ↔ IsSymplectomorphism ω₁ ω₂ e :=
-  ⟨fun h => isIsotropic_graph_iff.1 h.isIsotropic, IsSymplectomorphism.isLagrangian_graph⟩
+  ⟨fun h => isIsotropic_linearEquiv_graph_iff.1 h.isIsotropic,
+    IsSymplectomorphism.isLagrangian_graph⟩
 
 /-- The diagonal of `(V × V, ω ⊖ ω)`, realized as the graph of the identity equivalence, is
 Lagrangian. This is the boundary condition modeled by the identity continuation in Lagrangian

--- a/TauCeti/Geometry/Symplectic/LagrangianGraph.lean
+++ b/TauCeti/Geometry/Symplectic/LagrangianGraph.lean
@@ -39,6 +39,8 @@ coming from nondegeneracy of `ω₁` alone.
 * `TauCeti.SymplecticForm.twistedProd`: the twisted product form `ω₁ ⊖ ω₂` on `V × W`.
 * `TauCeti.SymplecticForm.IsSymplectomorphism`: a linear equivalence `e` with
   `ω₂(e v, e w) = ω₁(v, w)`, together with `refl`, `symm`, and `trans`.
+* `TauCeti.SymplecticForm.isSymplectomorphism_iff`: the pointwise characterization of
+  `IsSymplectomorphism`.
 * `TauCeti.SymplecticForm.isSymplectomorphism_iff_transport_eq`: this predicate is equivalent
   to equality with the transported symplectic form.
 * `TauCeti.SymplecticForm.isIsotropic_graph_iff`: the graph of `e` is isotropic for `ω₁ ⊖ ω₂`
@@ -83,6 +85,17 @@ def IsSymplectomorphism (ω₁ : SymplecticForm V) (ω₂ : SymplecticForm W) (e
   ∀ v w, ω₂ (e v) (e w) = ω₁ v w
 
 variable {ω₁ : SymplecticForm V} {ω₂ : SymplecticForm W} {ω₃ : SymplecticForm U}
+
+/-- A linear equivalence is a symplectomorphism exactly when it preserves the symplectic forms
+pointwise. -/
+lemma isSymplectomorphism_iff {e : V ≃ₗ[ℝ] W} :
+    IsSymplectomorphism ω₁ ω₂ e ↔ ∀ v w, ω₂ (e v) (e w) = ω₁ v w :=
+  Iff.rfl
+
+/-- Apply a symplectomorphism hypothesis to two vectors. -/
+lemma IsSymplectomorphism.apply {e : V ≃ₗ[ℝ] W} (h : IsSymplectomorphism ω₁ ω₂ e) (v w : V) :
+    ω₂ (e v) (e w) = ω₁ v w :=
+  h v w
 
 /-- A linear equivalence is a symplectomorphism exactly when `ω₂` is the transport of `ω₁`
 along that equivalence. -/

--- a/TauCeti/Geometry/Symplectic/LagrangianGraph.lean
+++ b/TauCeti/Geometry/Symplectic/LagrangianGraph.lean
@@ -1,0 +1,169 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+module
+
+public import Mathlib.LinearAlgebra.Prod
+public import TauCeti.Geometry.Symplectic.Lagrangian
+public import TauCeti.Geometry.Symplectic.Prod
+public import TauCeti.Geometry.Symplectic.Rescale
+
+/-!
+# The graph of a symplectomorphism is Lagrangian
+
+Two symplectic vector spaces `(V, ω₁)` and `(W, ω₂)` assemble into the *twisted* product
+`(V × W, ω₁ ⊖ ω₂)`, where the second form is negated:
+`(ω₁ ⊖ ω₂)((v₁, w₁), (v₂, w₂)) = ω₁(v₁, v₂) - ω₂(w₁, w₂)`. The point of the sign is that the
+graph `{(v, e v)}` of a real-linear isomorphism `e : V ≃ W` is *Lagrangian* for `ω₁ ⊖ ω₂`
+exactly when `e` is a symplectomorphism (`ω₂(e v, e w) = ω₁(v, w)`). This is the linear model of
+the Lagrangian-correspondence principle: symplectomorphisms are the same data as Lagrangian
+graphs, and the special case `e = id` makes the diagonal of `(V × V, ω ⊖ ω)` Lagrangian.
+
+This is the pointwise linear-algebra layer the analytic Heegaard Floer roadmap
+(`TauCetiRoadmap/HeegaardFloer/README.md`, Lane F3) needs before Lagrangian Floer homology:
+the boundary conditions of Floer strips between two Lagrangians `L₀`, `L₁` are packaged as a
+single Lagrangian in the twisted product, and the diagonal is the model boundary condition for
+the identity continuation. The construction reuses the direct-sum form
+`TauCeti.SymplecticForm.prod` (from `Prod.lean`) precomposed with the nonzero rescaling
+`TauCeti.SymplecticForm.rescale` by `-1` (from `Rescale.lean`), and Mathlib's graph submodule
+`LinearMap.graph`, so no new nondegeneracy bookkeeping is introduced.
+
+The Lagrangian conclusion needs no finite-dimensionality hypothesis: it is proved through the
+isotropic-plus-coisotropic characterization `SymplecticForm.isLagrangian_iff`, with coisotropy
+coming from nondegeneracy of `ω₁` alone.
+
+## Main declarations
+
+* `TauCeti.SymplecticForm.twistedProd`: the twisted product form `ω₁ ⊖ ω₂` on `V × W`.
+* `TauCeti.SymplecticForm.IsSymplectomorphism`: a linear equivalence `e` with
+  `ω₂(e v, e w) = ω₁(v, w)`, together with `refl`, `symm`, and `trans`.
+* `TauCeti.SymplecticForm.isIsotropic_graph_iff`: the graph of `e` is isotropic for `ω₁ ⊖ ω₂`
+  iff `e` is a symplectomorphism.
+* `TauCeti.SymplecticForm.IsSymplectomorphism.isLagrangian_graph` and
+  `TauCeti.SymplecticForm.isLagrangian_graph_iff`: the graph of `e` is Lagrangian for `ω₁ ⊖ ω₂`
+  iff `e` is a symplectomorphism.
+* `TauCeti.SymplecticForm.isLagrangian_diagonal`: the diagonal of `(V × V, ω ⊖ ω)` is Lagrangian.
+
+The conventions follow McDuff--Salamon, *J-holomorphic Curves and Symplectic Topology*,
+Section 2.3, where symplectomorphisms are identified with Lagrangian graphs in the twisted
+product.
+-/
+
+public section
+
+namespace TauCeti
+
+namespace SymplecticForm
+
+variable {V W U : Type*}
+variable [AddCommGroup V] [Module ℝ V] [AddCommGroup W] [Module ℝ W] [AddCommGroup U] [Module ℝ U]
+
+/-- The twisted product symplectic form `ω₁ ⊖ ω₂` on `V × W`, given by
+`(ω₁ ⊖ ω₂)((v₁, w₁), (v₂, w₂)) = ω₁(v₁, v₂) - ω₂(w₁, w₂)`.
+
+It is the direct-sum form `ω₁ ⊕ ω₂` of `Prod.lean` with the second factor rescaled by `-1`. -/
+noncomputable def twistedProd (ω₁ : SymplecticForm V) (ω₂ : SymplecticForm W) :
+    SymplecticForm (V × W) :=
+  ω₁.prod (ω₂.rescale (-1) (by norm_num))
+
+@[simp]
+lemma twistedProd_apply (ω₁ : SymplecticForm V) (ω₂ : SymplecticForm W) (p q : V × W) :
+    twistedProd ω₁ ω₂ p q = ω₁ p.1 q.1 - ω₂ p.2 q.2 := by
+  unfold twistedProd
+  rw [prod_apply, rescale_apply]
+  ring
+
+/-- A real-linear equivalence `e : V ≃ₗ[ℝ] W` is a symplectomorphism from `(V, ω₁)` to `(W, ω₂)`
+when it intertwines the two symplectic forms, `ω₂(e v, e w) = ω₁(v, w)`. -/
+def IsSymplectomorphism (ω₁ : SymplecticForm V) (ω₂ : SymplecticForm W) (e : V ≃ₗ[ℝ] W) : Prop :=
+  ∀ v w, ω₂ (e v) (e w) = ω₁ v w
+
+variable {ω₁ : SymplecticForm V} {ω₂ : SymplecticForm W} {ω₃ : SymplecticForm U}
+
+/-- The identity equivalence is a symplectomorphism. -/
+lemma IsSymplectomorphism.refl (ω : SymplecticForm V) :
+    IsSymplectomorphism ω ω (LinearEquiv.refl ℝ V) := by
+  intro v w
+  simp
+
+/-- The inverse of a symplectomorphism is a symplectomorphism. -/
+lemma IsSymplectomorphism.symm {e : V ≃ₗ[ℝ] W} (h : IsSymplectomorphism ω₁ ω₂ e) :
+    IsSymplectomorphism ω₂ ω₁ e.symm := by
+  intro v w
+  have h2 := h (e.symm v) (e.symm w)
+  rw [e.apply_symm_apply, e.apply_symm_apply] at h2
+  exact h2.symm
+
+/-- Symplectomorphisms compose. -/
+lemma IsSymplectomorphism.trans {e : V ≃ₗ[ℝ] W} {f : W ≃ₗ[ℝ] U}
+    (h₁ : IsSymplectomorphism ω₁ ω₂ e) (h₂ : IsSymplectomorphism ω₂ ω₃ f) :
+    IsSymplectomorphism ω₁ ω₃ (e.trans f) := by
+  intro v w
+  rw [LinearEquiv.trans_apply, LinearEquiv.trans_apply, h₂ (e v) (e w), h₁ v w]
+
+/-- The graph of `e` is isotropic for the twisted product form iff `e` is a symplectomorphism:
+isotropy of the graph is precisely the intertwining identity `ω₂(e v, e w) = ω₁(v, w)`. -/
+lemma isIsotropic_graph_iff {e : V ≃ₗ[ℝ] W} :
+    (twistedProd ω₁ ω₂).IsIsotropic e.toLinearMap.graph ↔ IsSymplectomorphism ω₁ ω₂ e := by
+  rw [isIsotropic_iff]
+  constructor
+  · intro h v w
+    have hv : ((v, e v) : V × W) ∈ e.toLinearMap.graph := by simp [LinearMap.mem_graph_iff]
+    have hw : ((w, e w) : V × W) ∈ e.toLinearMap.graph := by simp [LinearMap.mem_graph_iff]
+    have hvw := h (v, e v) hv (w, e w) hw
+    simp only [twistedProd_apply] at hvw
+    linarith
+  · intro h p hp q hq
+    rw [LinearMap.mem_graph_iff] at hp hq
+    simp only [LinearEquiv.coe_toLinearMap] at hp hq
+    rw [twistedProd_apply, hp, hq]
+    linarith [h p.1 q.1]
+
+/-- The graph of a symplectomorphism `e : V ≃ₗ[ℝ] W` is a Lagrangian subspace of the twisted
+product `(V × W, ω₁ ⊖ ω₂)`. No finite-dimensionality is required: coisotropy follows from
+nondegeneracy of `ω₁`. -/
+lemma IsSymplectomorphism.isLagrangian_graph {e : V ≃ₗ[ℝ] W} (h : IsSymplectomorphism ω₁ ω₂ e) :
+    (twistedProd ω₁ ω₂).IsLagrangian e.toLinearMap.graph := by
+  rw [isLagrangian_iff]
+  refine ⟨isIsotropic_graph_iff.2 h, ?_⟩
+  rw [isCoisotropic_iff]
+  intro x hx
+  rw [mem_orthogonal_iff] at hx
+  -- For every `w`, testing against `(w, e w) ∈ graph` gives `ω₁ w x.1 = ω₂ (e w) x.2`.
+  have key : ∀ w : V, ω₁ w x.1 - ω₂ (e w) x.2 = 0 := by
+    intro w
+    have hw : ((w, e w) : V × W) ∈ e.toLinearMap.graph := by simp [LinearMap.mem_graph_iff]
+    have hthis := hx (w, e w) hw
+    simp only [twistedProd_apply] at hthis
+    exact hthis
+  -- Rewrite `ω₂ (e w) x.2 = ω₁ w (e.symm x.2)`, so `ω₁ w (x.1 - e.symm x.2) = 0` for all `w`.
+  have key2 : ∀ w : V, (ω₁.toBilinForm w) (x.1 - e.symm x.2) = 0 := by
+    intro w
+    have hb : ω₂ (e w) x.2 = ω₁ w (e.symm x.2) := by
+      have hh := h w (e.symm x.2)
+      rwa [e.apply_symm_apply] at hh
+    have hk := key w
+    rw [hb] at hk
+    rw [map_sub]
+    exact hk
+  have hz : x.1 - e.symm x.2 = 0 := ω₁.separatingRight _ key2
+  have hx1 : x.1 = e.symm x.2 := sub_eq_zero.mp hz
+  rw [LinearMap.mem_graph_iff]
+  simp [hx1]
+
+/-- The graph of `e` is Lagrangian for the twisted product form iff `e` is a symplectomorphism. -/
+lemma isLagrangian_graph_iff {e : V ≃ₗ[ℝ] W} :
+    (twistedProd ω₁ ω₂).IsLagrangian e.toLinearMap.graph ↔ IsSymplectomorphism ω₁ ω₂ e :=
+  ⟨fun h => isIsotropic_graph_iff.1 h.isIsotropic, IsSymplectomorphism.isLagrangian_graph⟩
+
+/-- The diagonal of `(V × V, ω ⊖ ω)`, realized as the graph of the identity equivalence, is
+Lagrangian. This is the boundary condition modeled by the identity continuation in Lagrangian
+Floer homology. -/
+lemma isLagrangian_diagonal (ω : SymplecticForm V) :
+    (twistedProd ω ω).IsLagrangian (LinearEquiv.refl ℝ V).toLinearMap.graph :=
+  (IsSymplectomorphism.refl ω).isLagrangian_graph
+
+end SymplecticForm
+
+end TauCeti

--- a/TauCeti/Geometry/Symplectic/LagrangianGraph.lean
+++ b/TauCeti/Geometry/Symplectic/LagrangianGraph.lean
@@ -8,6 +8,7 @@ public import Mathlib.LinearAlgebra.Prod
 public import TauCeti.Geometry.Symplectic.Lagrangian
 public import TauCeti.Geometry.Symplectic.Prod
 public import TauCeti.Geometry.Symplectic.Rescale
+public import TauCeti.Geometry.Symplectic.SymplecticTransport
 
 /-!
 # The graph of a symplectomorphism is Lagrangian
@@ -38,6 +39,8 @@ coming from nondegeneracy of `ω₁` alone.
 * `TauCeti.SymplecticForm.twistedProd`: the twisted product form `ω₁ ⊖ ω₂` on `V × W`.
 * `TauCeti.SymplecticForm.IsSymplectomorphism`: a linear equivalence `e` with
   `ω₂(e v, e w) = ω₁(v, w)`, together with `refl`, `symm`, and `trans`.
+* `TauCeti.SymplecticForm.isSymplectomorphism_iff_transport_eq`: this predicate is equivalent
+  to equality with the transported symplectic form.
 * `TauCeti.SymplecticForm.isIsotropic_graph_iff`: the graph of `e` is isotropic for `ω₁ ⊖ ω₂`
   iff `e` is a symplectomorphism.
 * `TauCeti.SymplecticForm.IsSymplectomorphism.isLagrangian_graph` and
@@ -81,6 +84,20 @@ def IsSymplectomorphism (ω₁ : SymplecticForm V) (ω₂ : SymplecticForm W) (e
 
 variable {ω₁ : SymplecticForm V} {ω₂ : SymplecticForm W} {ω₃ : SymplecticForm U}
 
+/-- A linear equivalence is a symplectomorphism exactly when `ω₂` is the transport of `ω₁`
+along that equivalence. -/
+lemma isSymplectomorphism_iff_transport_eq {e : V ≃ₗ[ℝ] W} :
+    IsSymplectomorphism ω₁ ω₂ e ↔ ω₁.transport e = ω₂ := by
+  constructor
+  · intro h
+    apply toBilinForm_injective
+    ext v w
+    change ω₁.transport e v w = ω₂ v w
+    rw [transport_apply]
+    simpa using (h (e.symm v) (e.symm w)).symm
+  · intro h v w
+    rw [← h, transport_apply_apply]
+
 /-- The identity equivalence is a symplectomorphism. -/
 lemma IsSymplectomorphism.refl (ω : SymplecticForm V) :
     IsSymplectomorphism ω ω (LinearEquiv.refl ℝ V) := by
@@ -104,6 +121,7 @@ lemma IsSymplectomorphism.trans {e : V ≃ₗ[ℝ] W} {f : W ≃ₗ[ℝ] U}
 
 /-- The graph of `e` is isotropic for the twisted product form iff `e` is a symplectomorphism:
 isotropy of the graph is precisely the intertwining identity `ω₂(e v, e w) = ω₁(v, w)`. -/
+@[simp]
 lemma isIsotropic_graph_iff {e : V ≃ₗ[ℝ] W} :
     (twistedProd ω₁ ω₂).IsIsotropic e.toLinearMap.graph ↔ IsSymplectomorphism ω₁ ω₂ e := by
   rw [isIsotropic_iff]
@@ -153,6 +171,7 @@ lemma IsSymplectomorphism.isLagrangian_graph {e : V ≃ₗ[ℝ] W} (h : IsSymple
   simp [hx1]
 
 /-- The graph of `e` is Lagrangian for the twisted product form iff `e` is a symplectomorphism. -/
+@[simp]
 lemma isLagrangian_graph_iff {e : V ≃ₗ[ℝ] W} :
     (twistedProd ω₁ ω₂).IsLagrangian e.toLinearMap.graph ↔ IsSymplectomorphism ω₁ ω₂ e :=
   ⟨fun h => isIsotropic_graph_iff.1 h.isIsotropic, IsSymplectomorphism.isLagrangian_graph⟩

--- a/TauCeti/Geometry/Symplectic/LagrangianGraph.lean
+++ b/TauCeti/Geometry/Symplectic/LagrangianGraph.lean
@@ -6,7 +6,6 @@ module
 
 public import TauCeti.Geometry.Symplectic.Lagrangian
 public import TauCeti.Geometry.Symplectic.Prod
-public import TauCeti.Geometry.Symplectic.Rescale
 public import TauCeti.Geometry.Symplectic.SymplecticTransport
 
 /-!
@@ -30,9 +29,11 @@ the identity continuation. The twisted product reuses the direct sum
 
 The Lagrangian conclusion needs no finite-dimensionality hypothesis.
 
+The twisted product form `ω₁ ⊖ ω₂` itself lives with the rest of the product-form API in
+`TauCeti.Geometry.Symplectic.Prod`.
+
 ## Main declarations
 
-* `TauCeti.SymplecticForm.twistedProd`: the twisted product form `ω₁ ⊖ ω₂` on `V × W`.
 * `TauCeti.SymplecticForm.IsSymplectomorphism`: a linear equivalence `e` with
   `ω₂(e v, e w) = ω₁(v, w)`, together with `refl`, `symm`, and `trans`.
 * `TauCeti.SymplecticForm.isSymplectomorphism_iff`: the pointwise characterization of
@@ -60,21 +61,6 @@ namespace SymplecticForm
 variable {V W : Type*}
 variable [AddCommGroup V] [Module ℝ V] [AddCommGroup W] [Module ℝ W]
 variable {ω₁ : SymplecticForm V} {ω₂ : SymplecticForm W}
-
-/-- The twisted product symplectic form `ω₁ ⊖ ω₂` on `V × W`, given by
-`(ω₁ ⊖ ω₂)((v₁, w₁), (v₂, w₂)) = ω₁(v₁, v₂) - ω₂(w₁, w₂)`.
-
-It is the direct sum `prod` of `ω₁` with the negation `ω₂.rescale (-1)` of `ω₂`; downstream code
-uses it through `twistedProd_apply`. -/
-noncomputable def twistedProd (ω₁ : SymplecticForm V) (ω₂ : SymplecticForm W) :
-    SymplecticForm (V × W) :=
-  ω₁.prod (ω₂.rescale (-1) (by norm_num))
-
-@[simp]
-lemma twistedProd_apply (ω₁ : SymplecticForm V) (ω₂ : SymplecticForm W) (p q : V × W) :
-    twistedProd ω₁ ω₂ p q = ω₁ p.1 q.1 - ω₂ p.2 q.2 := by
-  simp only [twistedProd, prod_apply, rescale_apply]
-  ring
 
 /-- The graph of `f` is isotropic for the twisted product form iff `f` preserves the symplectic
 forms pointwise: `ω₂(f v, f w) = ω₁(v, w)`. -/

--- a/TauCeti/Geometry/Symplectic/LagrangianGraph.lean
+++ b/TauCeti/Geometry/Symplectic/LagrangianGraph.lean
@@ -77,8 +77,11 @@ lemma isIsotropic_graph_iff {f : V →ₗ[ℝ] W} :
     rw [twistedProd_apply, hp, hq]
     linarith [h p.1 q.1]
 
-/-- The graph of `e` is isotropic for the twisted product form iff `e` is a symplectomorphism. -/
-@[simp]
+/-- The graph of `e` is isotropic for the twisted product form iff `e` is a symplectomorphism.
+
+This is a plain bridging lemma, not a `simp` lemma: the general `isIsotropic_graph_iff` already
+puts graph isotropy into its own normal form, so marking this `@[simp]` too would leave two
+competing normal forms for `e.toLinearMap.graph`. -/
 lemma isIsotropic_linearEquiv_graph_iff {e : V ≃ₗ[ℝ] W} :
     (twistedProd ω₁ ω₂).IsIsotropic e.toLinearMap.graph ↔ IsSymplectomorphism ω₁ ω₂ e := by
   rw [isIsotropic_graph_iff]

--- a/TauCeti/Geometry/Symplectic/Prod.lean
+++ b/TauCeti/Geometry/Symplectic/Prod.lean
@@ -36,6 +36,7 @@ following Mathlib's `LinearMap.prodMap` naming convention.
 * `TauCeti.IsComplexLinearMap.prod` and `TauCeti.IsComplexLinearMap.prodMap`: complex-linearity is
   preserved by pairing maps with a common source and by product maps into the direct sum.
 * `TauCeti.SymplecticForm.prod`: the direct-sum symplectic form on `V × W`.
+* `TauCeti.SymplecticForm.twistedProd`: the twisted product form `ω₁ ⊖ ω₂` on `V × W`.
 * `TauCeti.SymplecticForm.prod_invariant`, `prod_tames`, `prod_compatible`: a direct sum of
   invariant / tame / compatible pairs is invariant / tame / compatible.
 
@@ -207,6 +208,39 @@ def prod (ω₁ : SymplecticForm V) (ω₂ : SymplecticForm W) : SymplecticForm 
 @[simp]
 lemma prod_apply (ω₁ : SymplecticForm V) (ω₂ : SymplecticForm W) (p q : V × W) :
     ω₁.prod ω₂ p q = ω₁ p.1 q.1 + ω₂ p.2 q.2 := rfl
+
+/-- The twisted product symplectic form `ω₁ ⊖ ω₂` on `V × W`, given by
+`(ω₁ ⊖ ω₂)((v₁, w₁), (v₂, w₂)) = ω₁(v₁, v₂) - ω₂(w₁, w₂)`. -/
+noncomputable def twistedProd (ω₁ : SymplecticForm V) (ω₂ : SymplecticForm W) :
+    SymplecticForm (V × W) where
+  toBilinForm :=
+    ω₁.toBilinForm.comp (LinearMap.fst ℝ V W) (LinearMap.fst ℝ V W) -
+      ω₂.toBilinForm.comp (LinearMap.snd ℝ V W) (LinearMap.snd ℝ V W)
+  isAlt := by
+    intro p
+    simp
+  nondegenerate := by
+    constructor
+    · intro p hp
+      have h1 : p.1 = 0 := ω₁.separatingLeft p.1 fun x => by
+        have := hp (x, 0)
+        simpa using this
+      have h2 : p.2 = 0 := ω₂.separatingLeft p.2 fun y => by
+        have := hp (0, y)
+        simpa using this
+      exact Prod.ext h1 h2
+    · intro q hq
+      have h1 : q.1 = 0 := ω₁.separatingRight q.1 fun x => by
+        have := hq (x, 0)
+        simpa using this
+      have h2 : q.2 = 0 := ω₂.separatingRight q.2 fun y => by
+        have := hq (0, y)
+        simpa using this
+      exact Prod.ext h1 h2
+
+@[simp]
+lemma twistedProd_apply (ω₁ : SymplecticForm V) (ω₂ : SymplecticForm W) (p q : V × W) :
+    twistedProd ω₁ ω₂ p q = ω₁ p.1 q.1 - ω₂ p.2 q.2 := rfl
 
 variable {J₁ : AlmostComplexStructure V} {J₂ : AlmostComplexStructure W}
 

--- a/TauCeti/Geometry/Symplectic/Prod.lean
+++ b/TauCeti/Geometry/Symplectic/Prod.lean
@@ -6,6 +6,7 @@ module
 
 public import Mathlib.LinearAlgebra.Prod
 public import TauCeti.Geometry.Symplectic.AlmostComplex
+public import TauCeti.Geometry.Symplectic.Rescale
 public import TauCeti.Geometry.Symplectic.Transport
 
 /-!
@@ -36,6 +37,8 @@ following Mathlib's `LinearMap.prodMap` naming convention.
 * `TauCeti.IsComplexLinearMap.prod` and `TauCeti.IsComplexLinearMap.prodMap`: complex-linearity is
   preserved by pairing maps with a common source and by product maps into the direct sum.
 * `TauCeti.SymplecticForm.prod`: the direct-sum symplectic form on `V × W`.
+* `TauCeti.SymplecticForm.twistedProd`: the twisted product form `ω₁ ⊖ ω₂` on `V × W`, the
+  direct sum with the second factor negated.
 * `TauCeti.SymplecticForm.prod_invariant`, `prod_tames`, `prod_compatible`: a direct sum of
   invariant / tame / compatible pairs is invariant / tame / compatible.
 
@@ -207,6 +210,21 @@ def prod (ω₁ : SymplecticForm V) (ω₂ : SymplecticForm W) : SymplecticForm 
 @[simp]
 lemma prod_apply (ω₁ : SymplecticForm V) (ω₂ : SymplecticForm W) (p q : V × W) :
     ω₁.prod ω₂ p q = ω₁ p.1 q.1 + ω₂ p.2 q.2 := rfl
+
+/-- The twisted product symplectic form `ω₁ ⊖ ω₂` on `V × W`, given by
+`(ω₁ ⊖ ω₂)((v₁, w₁), (v₂, w₂)) = ω₁(v₁, v₂) - ω₂(w₁, w₂)`.
+
+It is the direct sum `prod` of `ω₁` with the negation `ω₂.rescale (-1)` of `ω₂`; downstream code
+uses it through `twistedProd_apply`. -/
+noncomputable def twistedProd (ω₁ : SymplecticForm V) (ω₂ : SymplecticForm W) :
+    SymplecticForm (V × W) :=
+  ω₁.prod (ω₂.rescale (-1) (by norm_num))
+
+@[simp]
+lemma twistedProd_apply (ω₁ : SymplecticForm V) (ω₂ : SymplecticForm W) (p q : V × W) :
+    twistedProd ω₁ ω₂ p q = ω₁ p.1 q.1 - ω₂ p.2 q.2 := by
+  simp only [twistedProd, prod_apply, rescale_apply]
+  ring
 
 variable {J₁ : AlmostComplexStructure V} {J₂ : AlmostComplexStructure W}
 

--- a/TauCeti/Geometry/Symplectic/Prod.lean
+++ b/TauCeti/Geometry/Symplectic/Prod.lean
@@ -214,8 +214,9 @@ lemma prod_apply (ω₁ : SymplecticForm V) (ω₂ : SymplecticForm W) (p q : V 
 /-- The twisted product symplectic form `ω₁ ⊖ ω₂` on `V × W`, given by
 `(ω₁ ⊖ ω₂)((v₁, w₁), (v₂, w₂)) = ω₁(v₁, v₂) - ω₂(w₁, w₂)`.
 
-It is the direct sum `prod` of `ω₁` with the negation `ω₂.rescale (-1)` of `ω₂`; downstream code
-uses it through `twistedProd_apply`. -/
+It is the direct sum `prod` of `ω₁` with the negation `ω₂.rescale (-1)` of `ω₂`; the body is
+`@[no_expose]`, so downstream code uses it through `twistedProd_apply` rather than by unfolding. -/
+@[no_expose]
 noncomputable def twistedProd (ω₁ : SymplecticForm V) (ω₂ : SymplecticForm W) :
     SymplecticForm (V × W) :=
   ω₁.prod (ω₂.rescale (-1) (by norm_num))

--- a/TauCeti/Geometry/Symplectic/Prod.lean
+++ b/TauCeti/Geometry/Symplectic/Prod.lean
@@ -36,7 +36,6 @@ following Mathlib's `LinearMap.prodMap` naming convention.
 * `TauCeti.IsComplexLinearMap.prod` and `TauCeti.IsComplexLinearMap.prodMap`: complex-linearity is
   preserved by pairing maps with a common source and by product maps into the direct sum.
 * `TauCeti.SymplecticForm.prod`: the direct-sum symplectic form on `V × W`.
-* `TauCeti.SymplecticForm.twistedProd`: the twisted product form `ω₁ ⊖ ω₂` on `V × W`.
 * `TauCeti.SymplecticForm.prod_invariant`, `prod_tames`, `prod_compatible`: a direct sum of
   invariant / tame / compatible pairs is invariant / tame / compatible.
 
@@ -208,39 +207,6 @@ def prod (ω₁ : SymplecticForm V) (ω₂ : SymplecticForm W) : SymplecticForm 
 @[simp]
 lemma prod_apply (ω₁ : SymplecticForm V) (ω₂ : SymplecticForm W) (p q : V × W) :
     ω₁.prod ω₂ p q = ω₁ p.1 q.1 + ω₂ p.2 q.2 := rfl
-
-/-- The twisted product symplectic form `ω₁ ⊖ ω₂` on `V × W`, given by
-`(ω₁ ⊖ ω₂)((v₁, w₁), (v₂, w₂)) = ω₁(v₁, v₂) - ω₂(w₁, w₂)`. -/
-noncomputable def twistedProd (ω₁ : SymplecticForm V) (ω₂ : SymplecticForm W) :
-    SymplecticForm (V × W) where
-  toBilinForm :=
-    ω₁.toBilinForm.comp (LinearMap.fst ℝ V W) (LinearMap.fst ℝ V W) -
-      ω₂.toBilinForm.comp (LinearMap.snd ℝ V W) (LinearMap.snd ℝ V W)
-  isAlt := by
-    intro p
-    simp
-  nondegenerate := by
-    constructor
-    · intro p hp
-      have h1 : p.1 = 0 := ω₁.separatingLeft p.1 fun x => by
-        have := hp (x, 0)
-        simpa using this
-      have h2 : p.2 = 0 := ω₂.separatingLeft p.2 fun y => by
-        have := hp (0, y)
-        simpa using this
-      exact Prod.ext h1 h2
-    · intro q hq
-      have h1 : q.1 = 0 := ω₁.separatingRight q.1 fun x => by
-        have := hq (x, 0)
-        simpa using this
-      have h2 : q.2 = 0 := ω₂.separatingRight q.2 fun y => by
-        have := hq (0, y)
-        simpa using this
-      exact Prod.ext h1 h2
-
-@[simp]
-lemma twistedProd_apply (ω₁ : SymplecticForm V) (ω₂ : SymplecticForm W) (p q : V × W) :
-    twistedProd ω₁ ω₂ p q = ω₁ p.1 q.1 - ω₂ p.2 q.2 := rfl
 
 variable {J₁ : AlmostComplexStructure V} {J₂ : AlmostComplexStructure W}
 

--- a/TauCeti/Geometry/Symplectic/SymplecticTransport.lean
+++ b/TauCeti/Geometry/Symplectic/SymplecticTransport.lean
@@ -32,6 +32,8 @@ asks. The underlying form transport reuses Mathlib's `LinearMap.BilinForm.congr`
   `transport_transport_symm`: functoriality of transport in the linear equivalence.
 * `TauCeti.SymplecticForm.transport_apply_apply`: `e` is a symplectomorphism onto the transported
   form, `(ω.transport e)(e v, e w) = ω(v, w)`.
+* `TauCeti.SymplecticForm.IsSymplectomorphism`: a linear equivalence `e` with
+  `ω₂(e v, e w) = ω₁(v, w)`, together with its pointwise and transport characterizations.
 * `TauCeti.SymplecticForm.Invariant.transport`, `Tames.transport`, `Compatible.transport`:
   invariance, tameness, and compatibility of a pair `(ω, J)` transport along `e` to the pair
   `(ω.transport e, J.transport e)`.
@@ -105,6 +107,59 @@ under `e` recovers `ω`. -/
 lemma transport_apply_apply (ω : SymplecticForm V) (e : V ≃ₗ[ℝ] W) (v w : V) :
     ω.transport e (e v) (e w) = ω v w := by
   rw [transport_apply, e.symm_apply_apply, e.symm_apply_apply]
+
+variable {ω₁ : SymplecticForm V} {ω₂ : SymplecticForm W} {ω₃ : SymplecticForm X}
+
+/-- A real-linear equivalence `e : V ≃ₗ[ℝ] W` is a symplectomorphism from `(V, ω₁)` to `(W, ω₂)`
+when it intertwines the two symplectic forms, `ω₂(e v, e w) = ω₁(v, w)`. -/
+def IsSymplectomorphism (ω₁ : SymplecticForm V) (ω₂ : SymplecticForm W) (e : V ≃ₗ[ℝ] W) :
+    Prop :=
+  ∀ v w, ω₂ (e v) (e w) = ω₁ v w
+
+/-- A linear equivalence is a symplectomorphism exactly when it preserves the symplectic forms
+pointwise. -/
+lemma isSymplectomorphism_iff {e : V ≃ₗ[ℝ] W} :
+    IsSymplectomorphism ω₁ ω₂ e ↔ ∀ v w, ω₂ (e v) (e w) = ω₁ v w :=
+  Iff.rfl
+
+/-- Apply a symplectomorphism hypothesis to two vectors. -/
+lemma IsSymplectomorphism.apply {e : V ≃ₗ[ℝ] W} (h : IsSymplectomorphism ω₁ ω₂ e) (v w : V) :
+    ω₂ (e v) (e w) = ω₁ v w :=
+  h v w
+
+/-- A linear equivalence is a symplectomorphism exactly when `ω₂` is the transport of `ω₁`
+along that equivalence. -/
+lemma isSymplectomorphism_iff_transport_eq {e : V ≃ₗ[ℝ] W} :
+    IsSymplectomorphism ω₁ ω₂ e ↔ ω₁.transport e = ω₂ := by
+  constructor
+  · intro h
+    apply toBilinForm_injective
+    ext v w
+    rw [transport_toBilinForm, LinearMap.BilinForm.congr_apply]
+    simpa using (h (e.symm v) (e.symm w)).symm
+  · intro h v w
+    rw [← h, transport_apply_apply]
+
+/-- The identity equivalence is a symplectomorphism. -/
+lemma IsSymplectomorphism.refl (ω : SymplecticForm V) :
+    IsSymplectomorphism ω ω (LinearEquiv.refl ℝ V) := by
+  intro v w
+  simp
+
+/-- The inverse of a symplectomorphism is a symplectomorphism. -/
+lemma IsSymplectomorphism.symm {e : V ≃ₗ[ℝ] W} (h : IsSymplectomorphism ω₁ ω₂ e) :
+    IsSymplectomorphism ω₂ ω₁ e.symm := by
+  intro v w
+  have h2 := h (e.symm v) (e.symm w)
+  rw [e.apply_symm_apply, e.apply_symm_apply] at h2
+  exact h2.symm
+
+/-- Symplectomorphisms compose. -/
+lemma IsSymplectomorphism.trans {e : V ≃ₗ[ℝ] W} {f : W ≃ₗ[ℝ] X}
+    (h₁ : IsSymplectomorphism ω₁ ω₂ e) (h₂ : IsSymplectomorphism ω₂ ω₃ f) :
+    IsSymplectomorphism ω₁ ω₃ (e.trans f) := by
+  intro v w
+  rw [LinearEquiv.trans_apply, LinearEquiv.trans_apply, h₂ (e v) (e w), h₁ v w]
 
 section Compatible
 

--- a/TauCeti/Geometry/Symplectic/SymplecticTransport.lean
+++ b/TauCeti/Geometry/Symplectic/SymplecticTransport.lean
@@ -145,6 +145,7 @@ lemma isSymplectomorphism_iff_transport_eq {e : V ≃ₗ[ℝ] W} :
     rw [← h, transport_apply_apply]
 
 /-- The identity equivalence is a symplectomorphism. -/
+@[simp]
 lemma IsSymplectomorphism.refl (ω : SymplecticForm V) :
     IsSymplectomorphism ω ω (LinearEquiv.refl ℝ V) := by
   intro v w

--- a/TauCeti/Geometry/Symplectic/SymplecticTransport.lean
+++ b/TauCeti/Geometry/Symplectic/SymplecticTransport.lean
@@ -111,7 +111,11 @@ lemma transport_apply_apply (ω : SymplecticForm V) (e : V ≃ₗ[ℝ] W) (v w :
 variable {ω₁ : SymplecticForm V} {ω₂ : SymplecticForm W} {ω₃ : SymplecticForm X}
 
 /-- A real-linear equivalence `e : V ≃ₗ[ℝ] W` is a symplectomorphism from `(V, ω₁)` to `(W, ω₂)`
-when it intertwines the two symplectic forms, `ω₂(e v, e w) = ω₁(v, w)`. -/
+when it intertwines the two symplectic forms, `ω₂(e v, e w) = ω₁(v, w)`.
+
+The body is `@[no_expose]`: downstream code uses this predicate through `isSymplectomorphism_iff`,
+`IsSymplectomorphism.apply`, and `isSymplectomorphism_iff_transport_eq` rather than by unfolding. -/
+@[no_expose]
 def IsSymplectomorphism (ω₁ : SymplecticForm V) (ω₂ : SymplecticForm W) (e : V ≃ₗ[ℝ] W) :
     Prop :=
   ∀ v w, ω₂ (e v) (e w) = ω₁ v w


### PR DESCRIPTION
This PR adds the linear-algebra fact that the graph of a symplectomorphism is Lagrangian, together with the twisted product symplectic form and the notion of a linear symplectomorphism it is stated against. Given symplectic vector spaces `(V, ω₁)` and `(W, ω₂)`, the twisted product `ω₁ ⊖ ω₂` on `V × W` sends `((v₁, w₁), (v₂, w₂))` to `ω₁(v₁, v₂) - ω₂(w₁, w₂)`, and a real-linear equivalence `e : V ≃ₗ[ℝ] W` is a symplectomorphism when `ω₂(e v, e w) = ω₁(v, w)`. The graph `{(v, e v)}` is isotropic for `ω₁ ⊖ ω₂` exactly when `e` is a symplectomorphism, and is then Lagrangian; the diagonal of `(V × V, ω ⊖ ω)` is the special case `e = id`. The Lagrangian conclusion needs no finite-dimensionality: coisotropy comes from nondegeneracy of `ω₁` alone.

This is the linear model of the Lagrangian-correspondence principle that Lane F3 (exact Lagrangian Floer homology) of the analytic Heegaard Floer roadmap requires: the boundary conditions of a Floer strip between two Lagrangians are packaged as a single Lagrangian in the twisted product, and the diagonal is the model boundary condition for the identity continuation. It advances `TauCetiRoadmap/HeegaardFloer/README.md`, Lane F3 ("Generators, the action functional, moduli of strips, ... `HF(L, φ(L)) ≅ H_*(L)`-type computations"), extending the existing pointwise symplectic linear-algebra layer under `TauCeti/Geometry/Symplectic/`.

The construction reuses the direct-sum form `TauCeti.SymplecticForm.prod` precomposed with the nonzero rescaling `TauCeti.SymplecticForm.rescale` by `-1`, the isotropic/coisotropic/Lagrangian vocabulary of `TauCeti.SymplecticForm.Lagrangian`, and Mathlib's graph submodule `LinearMap.graph`, so no new nondegeneracy bookkeeping is introduced.

New file `TauCeti/Geometry/Symplectic/LagrangianGraph.lean` (~155 lines). `lake build` and `lake exe axioms` both pass; the axiom audit reports all declarations within the `[propext, Classical.choice, Quot.sound]` allowlist.

<!--tauceti-target:v1 {"focus":"HeegaardFloer","id":"lagrangian-graph-symplectomorphism"}-->

🤖 Prepared with Claude Code
