### PR TITLE
chore: rename definitional law restatements to _def

### DIFF
--- a/TauCeti/Probability/Exchangeability/AdjacentTranspositions.lean
+++ b/TauCeti/Probability/Exchangeability/AdjacentTranspositions.lean
@@ -43,7 +43,7 @@ private theorem prefixLaw_map_perm {μ : Measure Ω} {X : ℕ → Ω → α} {n 
     (hX : ∀ i : Fin n, AEMeasurable (X i.val) μ) (τ : Equiv.Perm (Fin n)) :
     (prefixLaw μ X n).map (fun x : Fin n → α => fun i => x (τ i)) =
       blockLaw μ X fun i : Fin n => (τ i).val := by
-  simpa [Function.comp_def, prefixLaw_apply] using
+  simpa [Function.comp_def, prefixLaw_def] using
     map_blockLaw_reindex μ (fun i : Fin n => i.val) τ hX
 
 /-- The submonoid of finite permutations preserving the `n`-dimensional law of a process. -/
@@ -51,7 +51,7 @@ private def invariantSubmonoid (μ : Measure Ω) (X : ℕ → Ω → α) {n : �
     (hX : ∀ i : Fin n, AEMeasurable (X i.val) μ) : Submonoid (Equiv.Perm (Fin n)) where
   carrier := {σ | blockLaw μ X (fun i : Fin n => (σ i).val) = prefixLaw μ X n}
   one_mem' := by
-    simp [prefixLaw_apply]
+    simp [prefixLaw_def]
   mul_mem' := by
     intro σ τ hσ hτ
     calc
@@ -109,7 +109,7 @@ private theorem exchangeableAt_zero {μ : Measure Ω} {X : ℕ → Ω → α} :
     ExchangeableAt μ X 0 := by
   intro σ
   have hσ : σ = 1 := Subsingleton.elim σ 1
-  simp [hσ, prefixLaw_apply]
+  simp [hσ, prefixLaw_def]
 
 /-- A process is exchangeable iff each finite block is invariant under adjacent swaps. -/
 theorem iff_forall_adjacent_swap {μ : Measure Ω} {X : ℕ → Ω → α}

--- a/TauCeti/Probability/Exchangeability/Basic.lean
+++ b/TauCeti/Probability/Exchangeability/Basic.lean
@@ -81,11 +81,11 @@ def Contractable (μ : Measure Ω) (X : ℕ → Ω → α) : Prop :=
   ∀ (m : ℕ) (k : Fin m → ℕ), StrictMono k → blockLaw μ X k = prefixLaw μ X m
 
 @[simp]
-theorem blockLaw_apply (μ : Measure Ω) (X : ℕ → Ω → α) {m : ℕ} (k : Fin m → ℕ) :
+theorem blockLaw_def (μ : Measure Ω) (X : ℕ → Ω → α) {m : ℕ} (k : Fin m → ℕ) :
     blockLaw μ X k = μ.map (fun ω i => X (k i) ω) :=
   rfl
 
--- Annotated `@[grind =>]` rather than `@[simp]`: `blockLaw_apply` already simp-normalizes
+-- Annotated `@[grind =>]` rather than `@[simp]`: `blockLaw_def` already simp-normalizes
 -- `blockLaw μ X k` to `μ.map …` (so a `@[simp]` here would be shadowed), and the preimage form
 -- needs the a.e.-measurability side condition `hXk`, which `simp` cannot discharge.
 /-- The block law of `X` along `k`, evaluated on any measurable set `S`, is the measure of its
@@ -95,7 +95,7 @@ coordinate-wise preimage. This is the characteristic evaluation of `blockLaw` as
 theorem blockLaw_apply_of_measurable (μ : Measure Ω) (X : ℕ → Ω → α) {m : ℕ} (k : Fin m → ℕ)
     (hXk : ∀ i, AEMeasurable (X (k i)) μ) {S : Set (Fin m → α)} (hS : MeasurableSet S) :
     blockLaw μ X k S = μ ((fun ω i => X (k i) ω) ⁻¹' S) := by
-  rw [blockLaw_apply, Measure.map_apply_of_aemeasurable (aemeasurable_pi_lambda _ hXk) hS]
+  rw [blockLaw_def, Measure.map_apply_of_aemeasurable (aemeasurable_pi_lambda _ hXk) hS]
 
 /-- The block law of `X` along `k`, evaluated on a measurable rectangle `Set.univ.pi B`, is the
 measure of the coordinate-wise preimage `{ω | ∀ i, X (k i) ω ∈ B i}` — the rectangle specialization
@@ -110,12 +110,12 @@ theorem blockLaw_apply_rectangle (μ : Measure Ω) (X : ℕ → Ω → α) {m : 
   simp [Set.mem_preimage]
 
 @[simp]
-theorem prefixLaw_apply (μ : Measure Ω) (X : ℕ → Ω → α) (n : ℕ) :
+theorem prefixLaw_def (μ : Measure Ω) (X : ℕ → Ω → α) (n : ℕ) :
     prefixLaw μ X n = blockLaw μ X (fun i : Fin n => i.val) :=
   rfl
 
 @[simp]
-theorem pathLaw_apply (μ : Measure Ω) (X : ℕ → Ω → α) :
+theorem pathLaw_def (μ : Measure Ω) (X : ℕ → Ω → α) :
     pathLaw μ X = μ.map (fun ω i => X i ω) :=
   rfl
 
@@ -144,7 +144,7 @@ theorem measurable_shift : Measurable (shift α) := by
 theorem map_prefixProj_pathLaw (μ : Measure Ω) {X : ℕ → Ω → α}
     (hX : AEMeasurable (fun ω => fun i => X i ω) μ) (n : ℕ) :
     (pathLaw μ X).map (prefixProj α n) = prefixLaw μ X n := by
-  rw [pathLaw_apply, prefixLaw_apply, blockLaw_apply]
+  rw [pathLaw_def, prefixLaw_def, blockLaw_def]
   rw [AEMeasurable.map_map_of_aemeasurable (measurable_prefixProj n).aemeasurable hX,
     Function.comp_def]
   rfl
@@ -155,7 +155,7 @@ theorem map_blockLaw (μ : Measure Ω) {X : ℕ → Ω → α} {m : ℕ} (k : Fi
     (hXk : ∀ i : Fin m, AEMeasurable (X (k i)) μ) :
     (blockLaw μ X k).map (fun x : Fin m → α => fun i => f (x i)) =
       blockLaw μ (fun n ω => f (X n ω)) k := by
-  rw [blockLaw_apply, blockLaw_apply]
+  rw [blockLaw_def, blockLaw_def]
   rw [AEMeasurable.map_map_of_aemeasurable]
   · rfl
   · exact (measurable_pi_lambda (fun x : Fin m → α => fun i => f (x i)) fun i =>
@@ -176,7 +176,7 @@ theorem map_pathLaw (μ : Measure Ω) {X : ℕ → Ω → α}
     (hX : ∀ i, AEMeasurable (X i) μ) :
     (pathLaw μ X).map (fun x : ℕ → α => fun i => f (x i)) =
       pathLaw μ (fun n ω => f (X n ω)) := by
-  rw [pathLaw_apply, pathLaw_apply]
+  rw [pathLaw_def, pathLaw_def]
   rw [AEMeasurable.map_map_of_aemeasurable]
   · rfl
   · exact (measurable_pi_lambda (fun x : ℕ → α => fun i => f (x i)) fun i =>
@@ -189,7 +189,7 @@ theorem map_blockLaw_reindex (μ : Measure Ω) {X : ℕ → Ω → α} {n p : �
     (k : Fin n → ℕ) (g : Fin p → Fin n) (hXk : ∀ j : Fin n, AEMeasurable (X (k j)) μ) :
     (blockLaw μ X k).map (fun x : Fin n → α => fun i : Fin p => x (g i)) =
       blockLaw μ X (k ∘ g) := by
-  rw [blockLaw_apply, blockLaw_apply,
+  rw [blockLaw_def, blockLaw_def,
     AEMeasurable.map_map_of_aemeasurable
       ((measurable_pi_lambda _ fun i => measurable_pi_apply (g i)).aemeasurable)
       (aemeasurable_pi_lambda _ hXk)]
@@ -206,7 +206,7 @@ theorem map_reindex_pathLaw (μ : Measure Ω) {X : ℕ → Ω → α}
     (hX : ∀ i, AEMeasurable (X i) μ) (φ : ℕ → ℕ) :
     (pathLaw μ X).map (fun x : ℕ → α => fun k => x (φ k)) =
       pathLaw μ (fun k ω => X (φ k) ω) := by
-  rw [pathLaw_apply, pathLaw_apply]
+  rw [pathLaw_def, pathLaw_def]
   rw [AEMeasurable.map_map_of_aemeasurable (measurable_reindex φ).aemeasurable
     (aemeasurable_pi_lambda _ hX)]
   rfl
@@ -219,7 +219,7 @@ theorem map_reindex_prefixProj_pathLaw (μ : Measure Ω) {X : ℕ → Ω → α}
       blockLaw μ X (fun i : Fin n => φ i.val) := by
   rw [map_reindex_pathLaw μ hX φ,
     map_prefixProj_pathLaw μ (aemeasurable_pi_lambda _ fun i => hX (φ i)) n]
-  rw [prefixLaw_apply, blockLaw_apply, blockLaw_apply]
+  rw [prefixLaw_def, blockLaw_def, blockLaw_def]
 
 /-- Projecting the prefix law on `Fin n` onto its first `m ≤ n` coordinates (via `Fin.castLE`)
 gives the prefix law on `Fin m`. -/
@@ -229,8 +229,8 @@ theorem map_prefixLaw_castLE (μ : Measure Ω) {X : ℕ → Ω → α} {m n : �
       prefixLaw μ X m := by
   have hidx : (fun i : Fin n => i.val) ∘ Fin.castLE hmn = fun i : Fin m => i.val := by
     funext i; simp
-  rw [prefixLaw_apply, map_blockLaw_reindex μ _ (Fin.castLE hmn) hX, hidx]
-  exact (prefixLaw_apply μ X m).symm
+  rw [prefixLaw_def, map_blockLaw_reindex μ _ (Fin.castLE hmn) hX, hidx]
+  exact (prefixLaw_def μ X m).symm
 
 theorem Exchangeable.exchangeableAt {μ : Measure Ω} {X : ℕ → Ω → α}
     (h : Exchangeable μ X) (n : ℕ) : ExchangeableAt μ X n :=

--- a/TauCeti/Probability/Exchangeability/ConditionallyIID.lean
+++ b/TauCeti/Probability/Exchangeability/ConditionallyIID.lean
@@ -133,7 +133,7 @@ theorem conditionallyIIDWith_of_forall_rectangles {μ : Measure Ω} [IsFiniteMea
   refine ConditionallyIIDWith.intro hν ?_
   intro m k hk
   haveI : IsFiniteMeasure (blockLaw μ X k) := by
-    rw [blockLaw_apply]
+    rw [blockLaw_def]
     infer_instance
   refine measure_eq_of_forall_univ_pi ?_
   intro B hB

--- a/TauCeti/Probability/Exchangeability/ConditionallyIIDImplications.lean
+++ b/TauCeti/Probability/Exchangeability/ConditionallyIIDImplications.lean
@@ -49,7 +49,7 @@ theorem ConditionallyIIDWith.prefixLaw_eq_mixture {μ : Measure Ω} {X : ℕ →
     {ν : Ω → ProbabilityMeasure α} (h : ConditionallyIIDWith μ X ν) (n : ℕ) :
     prefixLaw μ X n =
       μ.bind fun ω => (ProbabilityMeasure.pi fun _ : Fin n => ν ω).toMeasure := by
-  rw [prefixLaw_apply]
+  rw [prefixLaw_def]
   exact h.map (fun i : Fin n => i.val) injective_fin_val
 
 /-- Under a named conditional-i.i.d. directing measure, every injective finite block has the

--- a/TauCeti/Probability/Exchangeability/Contractability.lean
+++ b/TauCeti/Probability/Exchangeability/Contractability.lean
@@ -86,7 +86,7 @@ theorem Exchangeable.blockLaw_eq_prefixLaw_of_injective {μ : Measure Ω} {X : �
     blockLaw μ X k = prefixLaw μ X n := by
   cases n with
   | zero =>
-    rw [blockLaw_apply, prefixLaw_apply, blockLaw_apply]
+    rw [blockLaw_def, prefixLaw_def, blockLaw_def]
     congr 1
     funext ω i
     exact i.elim0
@@ -137,7 +137,7 @@ theorem Contractable.measurePreserving_reindex {μ : Measure Ω} {X : ℕ → Ω
     (hX : Contractable μ X) (hX_meas : ∀ i, AEMeasurable (X i) μ) {φ : ℕ → ℕ} (hφ : StrictMono φ) :
     MeasurePreserving (fun x : ℕ → α => fun k => x (φ k)) (pathLaw μ X) (pathLaw μ X) := by
   refine ⟨measurable_pi_lambda _ fun k => measurable_pi_apply (φ k), ?_⟩
-  haveI : IsFiniteMeasure (pathLaw μ X) := by rw [pathLaw_apply]; infer_instance
+  haveI : IsFiniteMeasure (pathLaw μ X) := by rw [pathLaw_def]; infer_instance
   refine measure_eq_of_prefixProj_map_eq ?_
   intro n
   rw [map_reindex_prefixProj_pathLaw μ hX_meas φ n,

--- a/TauCeti/Probability/Exchangeability/IID.lean
+++ b/TauCeti/Probability/Exchangeability/IID.lean
@@ -58,7 +58,7 @@ theorem ConditionallyIIDWith.of_iIndepFun_identDistrib {μ : Measure Ω}
   have hindep_k : iIndepFun (fun i : Fin m => X (k i)) μ := hindep.precomp hk
   have hblock : blockLaw μ X k = Measure.pi (fun _ : Fin m => μ.map (X 0)) := by
     have h1 : blockLaw μ X k = Measure.pi (fun i : Fin m => μ.map (X (k i))) := by
-      rw [blockLaw_apply]
+      rw [blockLaw_def]
       exact hindep_k.map_fun_eq_pi_map (fun i => (hident (k i)).aemeasurable_fst)
     rw [h1]
     exact congrArg Measure.pi (funext fun i => (hident (k i)).map_eq)

--- a/TauCeti/Probability/Exchangeability/Map.lean
+++ b/TauCeti/Probability/Exchangeability/Map.lean
@@ -66,7 +66,7 @@ theorem FullyExchangeable.map_values {μ : Measure Ω} {X : ℕ → Ω → α}
           (fun x : ℕ → α => fun i => f (x i)) := by
       exact (map_pathLaw μ hf (fun i => hX (π i))).symm
     _ = (pathLaw μ X).map (fun x : ℕ → α => fun i => f (x i)) := by
-      rw [pathLaw_apply, h.permute π]
+      rw [pathLaw_def, h.permute π]
     _ = pathLaw μ (fun n ω => f (X n ω)) := by
       exact map_pathLaw μ hf hX
 

--- a/TauCeti/Probability/Exchangeability/PathSpace/ProcessShift.lean
+++ b/TauCeti/Probability/Exchangeability/PathSpace/ProcessShift.lean
@@ -63,7 +63,7 @@ theorem processShift_eq_shift_iterate (X : ℕ → Ω → α) (m : ℕ) :
 `m`-fold path shift `(shift α)^[m]`. -/
 theorem map_processShift (μ : Measure Ω) {X : ℕ → Ω → α} (hX : ∀ i, AEMeasurable (X i) μ) (m : ℕ) :
     μ.map (processShift X m) = (pathLaw μ X).map ((shift α)^[m]) := by
-  rw [processShift_eq_shift_iterate, pathLaw_apply,
+  rw [processShift_eq_shift_iterate, pathLaw_def,
     AEMeasurable.map_map_of_aemeasurable (measurable_shift_iterate m).aemeasurable
       (aemeasurable_pi_lambda _ hX)]
 


### PR DESCRIPTION
This PR renames `blockLaw_apply`, `prefixLaw_apply`, and `pathLaw_apply` in `TauCeti/Probability/Exchangeability/Basic.lean` to `blockLaw_def`, `prefixLaw_def`, and `pathLaw_def`, updating all uses across the repository. These lemmas are definitional restatements (`blockLaw μ X k = μ.map …`), for which the Mathlib convention is a `_def` suffix; the `_apply` suffix means evaluation at an argument, as in the same file's genuine applications `blockLaw_apply_of_measurable` and `blockLaw_apply_rectangle`. Follow-up to https://github.com/TauCetiProject/TauCeti/pull/451.

🤖 Prepared with Claude Code