### PR TITLE
refactor: drop the unused finiteness instance from twoRank

### DIFF
--- a/TauCeti/Algebra/Group/ElementaryTwoQuotient.lean
+++ b/TauCeti/Algebra/Group/ElementaryTwoQuotient.lean
@@ -289,9 +289,10 @@ theorem card_elementaryTwoQuotient_eq_card_twoTorsion
     Subgroup.index_range]
   exact Nat.card_congr (Equiv.subtypeEquivRight fun g => by simp [MonoidHom.mem_ker])
 
-/-- **The 2-rank of a commutative group with finite-dimensional elementary-2 quotient**: the
-`ZMod 2`-dimension of the maximal elementary-2 quotient `G / G²`. -/
-noncomputable def twoRank [Module.Finite (ZMod 2) (ElementaryTwoQuotient G)] : ℕ :=
+/-- **The 2-rank of a commutative group**: the `ZMod 2`-dimension of the maximal elementary-2
+quotient `G / G²` (zero, by convention of `Module.finrank`, when the quotient is
+infinite-dimensional). -/
+noncomputable def twoRank : ℕ :=
   Module.finrank (ZMod 2) (ElementaryTwoQuotient G)
 
 /-- The maximal elementary-2 quotient has cardinality `2 ^ twoRank`: it is a finite `𝔽₂`-vector
@@ -308,15 +309,8 @@ theorem finrank_elementaryTwoQuotient_eq_of_mulEquiv (e : G ≃* H) :
       Module.finrank (ZMod 2) (ElementaryTwoQuotient H) :=
   (elementaryTwoQuotientCongr e).finrank_eq
 
-/-- If the elementary-2 quotient of `G` is finite-dimensional, then a multiplicatively equivalent
-commutative group has the same elementary-2 rank; target finite-dimensionality is transported by
-the induced equivalence. -/
-theorem twoRank_eq_of_mulEquiv (e : G ≃* H)
-    [Module.Finite (ZMod 2) (ElementaryTwoQuotient G)] :
-    letI : Module.Finite (ZMod 2) (ElementaryTwoQuotient H) :=
-      Module.Finite.of_surjective (elementaryTwoQuotientCongr e).toLinearMap
-        (elementaryTwoQuotientCongr e).surjective
-    twoRank G = twoRank H :=
+/-- Multiplicatively equivalent commutative groups have the same elementary-2 rank. -/
+theorem twoRank_eq_of_mulEquiv (e : G ≃* H) : twoRank G = twoRank H :=
   finrank_elementaryTwoQuotient_eq_of_mulEquiv (G := G) (H := H) e
 
 end TauCeti

--- a/TauCeti/Algebra/Group/ElementaryTwoQuotient.lean
+++ b/TauCeti/Algebra/Group/ElementaryTwoQuotient.lean
@@ -292,8 +292,12 @@ theorem card_elementaryTwoQuotient_eq_card_twoTorsion
 /-- **The 2-rank of a commutative group**: the `ZMod 2`-dimension of the maximal elementary-2
 quotient `G / G²` (zero, by convention of `Module.finrank`, when the quotient is
 infinite-dimensional). -/
-noncomputable def twoRank : ℕ :=
+@[expose] noncomputable def twoRank : ℕ :=
   Module.finrank (ZMod 2) (ElementaryTwoQuotient G)
+
+/-- The 2-rank of `G` is the `ZMod 2` dimension of its maximal elementary-2 quotient `G / G²`. -/
+@[simp] theorem twoRank_def :
+    twoRank G = Module.finrank (ZMod 2) (ElementaryTwoQuotient G) := rfl
 
 /-- The maximal elementary-2 quotient has cardinality `2 ^ twoRank`: it is a finite `𝔽₂`-vector
 space of dimension the 2-rank. -/

--- a/TauCeti/NumberTheory/ClassGroup/ElementaryTwoQuotient.lean
+++ b/TauCeti/NumberTheory/ClassGroup/ElementaryTwoQuotient.lean
@@ -156,8 +156,13 @@ variable (R)
 quotient `Cl(R)/Cl(R)²` (zero, by convention of `Module.finrank`, when the quotient is
 infinite-dimensional). In genus-theory applications the `t - 1` formula belongs to the narrow
 class group; for imaginary fields the narrow and ordinary class groups coincide. -/
-noncomputable def twoRank : ℕ :=
+@[expose] noncomputable def twoRank : ℕ :=
   TauCeti.twoRank (ClassGroup R)
+
+/-- The 2-rank of the class group is the `ZMod 2` dimension of its maximal elementary-2 quotient
+`Cl(R) / Cl(R)²`. -/
+@[simp] theorem twoRank_def :
+    twoRank R = Module.finrank (ZMod 2) (ElementaryTwoQuotient R) := rfl
 
 /-- The maximal elementary-2 quotient has cardinality `2 ^ twoRank`: it is a finite `𝔽₂`-vector
 space of dimension the 2-rank. -/

--- a/TauCeti/NumberTheory/ClassGroup/ElementaryTwoQuotient.lean
+++ b/TauCeti/NumberTheory/ClassGroup/ElementaryTwoQuotient.lean
@@ -156,13 +156,14 @@ variable (R)
 quotient `Cl(R)/Cl(R)²` (zero, by convention of `Module.finrank`, when the quotient is
 infinite-dimensional). In genus-theory applications the `t - 1` formula belongs to the narrow
 class group; for imaginary fields the narrow and ordinary class groups coincide. -/
-@[expose] noncomputable def twoRank : ℕ :=
+noncomputable def twoRank : ℕ :=
   TauCeti.twoRank (ClassGroup R)
 
 /-- The 2-rank of the class group is the `ZMod 2` dimension of its maximal elementary-2 quotient
 `Cl(R) / Cl(R)²`. -/
 @[simp] theorem twoRank_def :
-    twoRank R = Module.finrank (ZMod 2) (ElementaryTwoQuotient R) := rfl
+    twoRank R = Module.finrank (ZMod 2) (ElementaryTwoQuotient R) :=
+  TauCeti.twoRank_def (ClassGroup R)
 
 /-- The maximal elementary-2 quotient has cardinality `2 ^ twoRank`: it is a finite `𝔽₂`-vector
 space of dimension the 2-rank. -/

--- a/TauCeti/NumberTheory/ClassGroup/ElementaryTwoQuotient.lean
+++ b/TauCeti/NumberTheory/ClassGroup/ElementaryTwoQuotient.lean
@@ -152,11 +152,11 @@ of its inverse image. -/
 
 variable (R)
 
-/-- **The 2-rank of the class group when `Cl(R)/Cl(R)²` is finite-dimensional**: the `ZMod 2`
-dimension of the maximal elementary-2 quotient. In genus-theory applications the `t - 1` formula
-belongs to the narrow class group; for imaginary fields the narrow and ordinary class groups
-coincide. -/
-noncomputable def twoRank [Module.Finite (ZMod 2) (ElementaryTwoQuotient R)] : ℕ :=
+/-- **The 2-rank of the class group**: the `ZMod 2` dimension of the maximal elementary-2
+quotient `Cl(R)/Cl(R)²` (zero, by convention of `Module.finrank`, when the quotient is
+infinite-dimensional). In genus-theory applications the `t - 1` formula belongs to the narrow
+class group; for imaginary fields the narrow and ordinary class groups coincide. -/
+noncomputable def twoRank : ℕ :=
   TauCeti.twoRank (ClassGroup R)
 
 /-- The maximal elementary-2 quotient has cardinality `2 ^ twoRank`: it is a finite `𝔽₂`-vector
@@ -175,15 +175,9 @@ theorem finrank_elementaryTwoQuotient_eq_of_mulEquiv {S : Type*} [CommRing S] [I
   TauCeti.finrank_elementaryTwoQuotient_eq_of_mulEquiv
     (G := ClassGroup R) (H := ClassGroup S) e
 
-/-- If `Cl(R)/Cl(R)²` is finite-dimensional, then a multiplicatively equivalent class group has
-the same elementary-2 rank; target finite-dimensionality is transported by the induced
-equivalence. -/
+/-- Multiplicatively equivalent class groups have the same elementary-2 rank. -/
 theorem twoRank_eq_of_mulEquiv {S : Type*} [CommRing S] [IsDomain S]
-    (e : ClassGroup R ≃* ClassGroup S)
-    [Module.Finite (ZMod 2) (ElementaryTwoQuotient R)] :
-    letI : Module.Finite (ZMod 2) (ElementaryTwoQuotient S) :=
-      Module.Finite.of_surjective (elementaryTwoQuotientCongr e).toLinearMap
-        (elementaryTwoQuotientCongr e).surjective
+    (e : ClassGroup R ≃* ClassGroup S) :
     twoRank R = twoRank S :=
   TauCeti.twoRank_eq_of_mulEquiv (G := ClassGroup R) (H := ClassGroup S) e
 


### PR DESCRIPTION
This PR drops the unused `[Module.Finite (ZMod 2) (ElementaryTwoQuotient _)]` instance from the `twoRank` definitions in `TauCeti/Algebra/Group/ElementaryTwoQuotient.lean` and `TauCeti/NumberTheory/ClassGroup/ElementaryTwoQuotient.lean`. The instance is unused in the body: `Module.finrank` is total (returning 0 in the infinite-dimensional case), and Mathlib convention is to define such quantities unconditionally. As a consequence, `twoRank_eq_of_mulEquiv` in both files no longer needs its instance argument or its statement-level `letI` transporting finiteness along the equivalence. Docstrings are updated to note the junk-value convention. Original PR: https://github.com/TauCetiProject/TauCeti/pull/555

🤖 Prepared with Claude Code