### PR TITLE
refactor: tidy Contractable.map_single and map_pair

### DIFF
--- a/TauCeti/Probability/Exchangeability/Contractability.lean
+++ b/TauCeti/Probability/Exchangeability/Contractability.lean
@@ -2,7 +2,7 @@ module
 
 public import TauCeti.Probability.Exchangeability.Basic
 public import Mathlib.Order.Fin.Basic
-public import Mathlib.Data.Fin.VecNotation
+public import Mathlib.Order.Fin.Tuple
 public import Mathlib.Dynamics.Ergodic.MeasurePreserving
 import Mathlib.Logic.Equiv.Fintype
 import TauCeti.Probability.Exchangeability.FiniteMarginals
@@ -57,10 +57,8 @@ theorem Contractable.map_single {μ : Measure Ω} {X : ℕ → Ω → α} (h : C
 /-- The two-coordinate specialization of contractability. -/
 theorem Contractable.map_pair {μ : Measure Ω} {X : ℕ → Ω → α} (h : Contractable μ X)
     {i j : ℕ} (hij : i < j) :
-    blockLaw μ X ![i, j] = prefixLaw μ X 2 := by
-  refine h.map ?_
-  intro r s hrs
-  fin_cases r <;> fin_cases s <;> simp_all
+    blockLaw μ X ![i, j] = prefixLaw μ X 2 :=
+  h.map (strictMono_vecEmpty.vecCons hij)
 
 /-- Contractability is preserved by passing to a strictly increasing subsequence. -/
 theorem Contractable.comp {μ : Measure Ω} {X : ℕ → Ω → α} (h : Contractable μ X)

--- a/TauCeti/Probability/Exchangeability/Contractability.lean
+++ b/TauCeti/Probability/Exchangeability/Contractability.lean
@@ -2,6 +2,7 @@ module
 
 public import TauCeti.Probability.Exchangeability.Basic
 public import Mathlib.Order.Fin.Basic
+public import Mathlib.Data.Fin.VecNotation
 public import Mathlib.Dynamics.Ergodic.MeasurePreserving
 import Mathlib.Logic.Equiv.Fintype
 import TauCeti.Probability.Exchangeability.FiniteMarginals
@@ -50,17 +51,13 @@ theorem Contractable.map {μ : Measure Ω} {X : ℕ → Ω → α} (h : Contract
 /-- The one-coordinate specialization of contractability. -/
 theorem Contractable.map_single {μ : Measure Ω} {X : ℕ → Ω → α} (h : Contractable μ X)
     (k : Fin 1 → ℕ) :
-    blockLaw μ X k = prefixLaw μ X 1 := by
-  exact h.map (by
-    intro i j hij
-    fin_cases i
-    fin_cases j
-    omega)
+    blockLaw μ X k = prefixLaw μ X 1 :=
+  h.map (Subsingleton.strictMono k)
 
 /-- The two-coordinate specialization of contractability. -/
 theorem Contractable.map_pair {μ : Measure Ω} {X : ℕ → Ω → α} (h : Contractable μ X)
     {i j : ℕ} (hij : i < j) :
-    blockLaw μ X (fun r : Fin 2 => if r = 0 then i else j) = prefixLaw μ X 2 := by
+    blockLaw μ X ![i, j] = prefixLaw μ X 2 := by
   refine h.map ?_
   intro r s hrs
   fin_cases r <;> fin_cases s <;> simp_all

--- a/TauCeti/Probability/Exchangeability/Contractability.lean
+++ b/TauCeti/Probability/Exchangeability/Contractability.lean
@@ -2,8 +2,9 @@ module
 
 public import TauCeti.Probability.Exchangeability.Basic
 public import Mathlib.Order.Fin.Basic
-public import Mathlib.Order.Fin.Tuple
+public import Mathlib.Data.Fin.VecNotation
 public import Mathlib.Dynamics.Ergodic.MeasurePreserving
+import Mathlib.Order.Fin.Tuple
 import Mathlib.Logic.Equiv.Fintype
 import TauCeti.Probability.Exchangeability.FiniteMarginals
 


### PR DESCRIPTION
This PR tidies the two small specialization lemmas in `TauCeti/Probability/Exchangeability/Contractability.lean`. `Contractable.map_single` proved `StrictMono k` for `k : Fin 1 → ℕ` by `fin_cases`/`omega`; Mathlib's `Subsingleton.strictMono` says exactly this, so the whole lemma becomes `h.map (Subsingleton.strictMono k)`. `Contractable.map_pair` spelled its two-point tuple as `fun r : Fin 2 => if r = 0 then i else j`; this PR switches the statement to the canonical vector notation `![i, j]` (adding the `Mathlib.Data.Fin.VecNotation` import). Neither lemma has consumers yet, so the statement change breaks nothing. Follow-up to https://github.com/TauCetiProject/TauCeti/pull/451.

Roadmap: Exchangeability

🤖 Prepared with Claude Code