### PR TITLE
refactor: golf isOpenMap_orbitQuotientToBase via IsOpenMap.of_comp

### DIFF
--- a/TauCeti/AlgebraicTopology/UniversalCover/Deck/QuotientHomeomorph.lean
+++ b/TauCeti/AlgebraicTopology/UniversalCover/Deck/QuotientHomeomorph.lean
@@ -50,25 +50,8 @@ lemma continuous_orbitQuotientToBase (hp : Continuous p) :
 
 /-- An open map induces an open map from the deck-orbit quotient to the base. -/
 lemma isOpenMap_orbitQuotientToBase (hp : IsOpenMap p) :
-    IsOpenMap (orbitQuotientToBase p) := by
-  intro V hV
-  have hsurj : Function.Surjective
-      (Quotient.mk'' : E → MulAction.orbitRel.Quotient (Deck p) E) :=
-    Quotient.mk''_surjective
-  have hpre : IsOpen ((Quotient.mk'' : E → MulAction.orbitRel.Quotient (Deck p) E) ⁻¹' V) :=
-    hV.preimage continuous_quotient_mk'
-  have himg : orbitQuotientToBase p '' V =
-      p '' ((Quotient.mk'' : E → MulAction.orbitRel.Quotient (Deck p) E) ⁻¹' V) := by
-    ext b
-    simp only [Set.mem_image, Set.mem_preimage]
-    constructor
-    · rintro ⟨x, hxV, rfl⟩
-      obtain ⟨e, rfl⟩ := hsurj x
-      exact ⟨e, hxV, rfl⟩
-    · rintro ⟨e, heV, rfl⟩
-      exact ⟨Quotient.mk'' e, heV, rfl⟩
-  rw [himg]
-  exact hp _ hpre
+    IsOpenMap (orbitQuotientToBase p) :=
+  IsOpenMap.of_comp continuous_quotient_mk' Quotient.mk''_surjective hp
 
 namespace IsRegular
 

--- a/TauCeti/AlgebraicTopology/UniversalCover/Deck/QuotientHomeomorph.lean
+++ b/TauCeti/AlgebraicTopology/UniversalCover/Deck/QuotientHomeomorph.lean
@@ -51,7 +51,8 @@ lemma continuous_orbitQuotientToBase (hp : Continuous p) :
 /-- An open map induces an open map from the deck-orbit quotient to the base. -/
 lemma isOpenMap_orbitQuotientToBase (hp : IsOpenMap p) :
     IsOpenMap (orbitQuotientToBase p) :=
-  IsOpenMap.of_comp continuous_quotient_mk' Quotient.mk''_surjective hp
+  IsOpenMap.of_comp (f := Quotient.mk'') continuous_quotient_mk' Quotient.mk''_surjective
+    (by simpa [Function.comp_def] using hp)
 
 namespace IsRegular
 


### PR DESCRIPTION
This PR replaces the 20-line manual image computation in `TauCeti.Deck.isOpenMap_orbitQuotientToBase` (`TauCeti/AlgebraicTopology/UniversalCover/Deck/QuotientHomeomorph.lean`) with a one-line application of Mathlib's `IsOpenMap.of_comp`: since `orbitQuotientToBase p ∘ Quotient.mk''` is definitionally `p`, openness of the induced quotient map follows directly from openness of `p` together with continuity and surjectivity of `Quotient.mk''`. Follow-up to https://github.com/TauCetiProject/TauCeti/pull/256.

🤖 Prepared with Claude Code