### PR TITLE
refactor: simplify blockLaw proofs left over from the shift-bound refactor

### DIFF
--- a/TauCeti/Probability/Exchangeability/Contractability.lean
+++ b/TauCeti/Probability/Exchangeability/Contractability.lean
@@ -84,39 +84,32 @@ theorem Exchangeable.blockLaw_eq_prefixLaw_of_injective {μ : Measure Ω} {X : �
     (hX : Exchangeable μ X) (hX_meas : ∀ i, AEMeasurable (X i) μ)
     {n : ℕ} (k : Fin n → ℕ) (hk : Function.Injective k) :
     blockLaw μ X k = prefixLaw μ X n := by
-  cases n with
-  | zero =>
-    rw [blockLaw_def, prefixLaw_def, blockLaw_def]
-    congr 1
-    funext ω i
-    exact i.elim0
-  | succ m =>
-    set N := max (m + 1) (Finset.univ.sup k + 1) with hN
-    have hnN : m + 1 ≤ N := le_max_left _ _
-    have hk_bound : ∀ i, k i < N := by
-      intro i
-      have h1 : k i ≤ Finset.univ.sup k := Finset.le_sup (Finset.mem_univ i)
-      have h2 : Finset.univ.sup k + 1 ≤ N := le_max_right _ _
-      omega
-    obtain ⟨σ, hσ⟩ := Equiv.Perm.exists_extending_pair (Fin.castLE hnN)
-      (fun i => (⟨k i, hk_bound i⟩ : Fin N))
-      (fun a b h => by
-        apply Fin.val_injective
-        exact (congrArg Fin.val h : (Fin.castLE hnN a).val = (Fin.castLE hnN b).val))
-      (fun _ _ h => hk (Fin.mk.inj h))
-    have hexch : blockLaw μ X (fun j : Fin N => (σ j).val) = prefixLaw μ X N :=
-      (hX.exchangeableAt N).permute σ
-    have hLHS : (blockLaw μ X (fun j : Fin N => (σ j).val)).map
-          (fun x : Fin N → α => fun i : Fin (m + 1) => x (Fin.castLE hnN i)) = blockLaw μ X k := by
-      have hidx : (fun j : Fin N => (σ j).val) ∘ Fin.castLE hnN = k := by
-        funext i; exact congrArg Fin.val (hσ i)
-      rw [map_blockLaw_reindex μ _ (Fin.castLE hnN) (fun j => hX_meas (σ j).val), hidx]
-    have hRHS : (prefixLaw μ X N).map (fun x : Fin N → α => fun i : Fin (m + 1) =>
-          x (Fin.castLE hnN i)) = prefixLaw μ X (m + 1) :=
-      map_prefixLaw_castLE μ hnN (fun j => hX_meas j.val)
-    have key := congrArg
-      (Measure.map (fun x : Fin N → α => fun i : Fin (m + 1) => x (Fin.castLE hnN i))) hexch
-    rwa [hLHS, hRHS] at key
+  set N := max n (Finset.univ.sup k + 1) with hN
+  have hnN : n ≤ N := le_max_left _ _
+  have hk_bound : ∀ i, k i < N := by
+    intro i
+    have h1 : k i ≤ Finset.univ.sup k := Finset.le_sup (Finset.mem_univ i)
+    have h2 : Finset.univ.sup k + 1 ≤ N := le_max_right _ _
+    omega
+  obtain ⟨σ, hσ⟩ := Equiv.Perm.exists_extending_pair (Fin.castLE hnN)
+    (fun i => (⟨k i, hk_bound i⟩ : Fin N))
+    (fun a b h => by
+      apply Fin.val_injective
+      exact (congrArg Fin.val h : (Fin.castLE hnN a).val = (Fin.castLE hnN b).val))
+    (fun _ _ h => hk (Fin.mk.inj h))
+  have hexch : blockLaw μ X (fun j : Fin N => (σ j).val) = prefixLaw μ X N :=
+    (hX.exchangeableAt N).permute σ
+  have hLHS : (blockLaw μ X (fun j : Fin N => (σ j).val)).map
+        (fun x : Fin N → α => fun i : Fin n => x (Fin.castLE hnN i)) = blockLaw μ X k := by
+    have hidx : (fun j : Fin N => (σ j).val) ∘ Fin.castLE hnN = k := by
+      funext i; exact congrArg Fin.val (hσ i)
+    rw [map_blockLaw_reindex μ _ (Fin.castLE hnN) (fun j => hX_meas (σ j).val), hidx]
+  have hRHS : (prefixLaw μ X N).map (fun x : Fin N → α => fun i : Fin n =>
+        x (Fin.castLE hnN i)) = prefixLaw μ X n :=
+    map_prefixLaw_castLE μ hnN (fun j => hX_meas j.val)
+  have key := congrArg
+    (Measure.map (fun x : Fin N → α => fun i : Fin n => x (Fin.castLE hnN i))) hexch
+  rwa [hLHS, hRHS] at key
 
 /-- **Every exchangeable sequence with a.e. measurable coordinates is contractable**: along any
 strictly increasing finite selection `k`, `blockLaw μ X k = prefixLaw μ X m`. One direction of the

--- a/TauCeti/Probability/Exchangeability/FullyExchangeable.lean
+++ b/TauCeti/Probability/Exchangeability/FullyExchangeable.lean
@@ -51,9 +51,8 @@ private theorem map_reindex_prefixProj {μ : Measure Ω} {X : ℕ → Ω → α}
     (hX_meas : ∀ i, AEMeasurable (X i) μ) (π : Equiv.Perm ℕ) (n : ℕ) :
     (μ.map fun ω i => X (π i) ω).map (prefixProj α n)
       = blockLaw μ X (fun j : Fin n => π j.val) := by
-  rw [AEMeasurable.map_map_of_aemeasurable (measurable_prefixProj n).aemeasurable
-    (aemeasurable_pi_lambda _ fun i => hX_meas (π i))]
-  rfl
+  rw [← pathLaw_def, ← map_reindex_pathLaw μ hX_meas π,
+    map_reindex_prefixProj_pathLaw μ hX_meas π n]
 
 /-- **Full exchangeability implies finite exchangeability at each dimension `n`.** -/
 theorem FullyExchangeable.exchangeableAt {μ : Measure Ω} {X : ℕ → Ω → α}


### PR DESCRIPTION
This PR simplifies two proofs left over from the shift-bound refactor around https://github.com/TauCetiProject/TauCeti/pull/489.

In `Exchangeable.blockLaw_eq_prefixLaw_of_injective` (Contractability.lean), the `cases n` zero-branch is vestigial: taking `N := max n (Finset.univ.sup k + 1)` makes the permutation-extension argument uniform in `n` (the bound already covers `Fin 0`, and `Equiv.Perm.exists_extending_pair` places no positivity requirement on the index type), so the case split is deleted.

In FullyExchangeable.lean, the private `map_reindex_prefixProj` is now reprovable in one line from the public `map_reindex_pathLaw` and `map_reindex_prefixProj_pathLaw`; its twin in Contractability.lean was already removed by the same refactor, which missed this copy.

🤖 Prepared with Claude Code