### PR TITLE
chore: remove an unused open in Plumbing.IntersectionForm

### DIFF
--- a/TauCeti/LowDimTopology/Plumbing/IntersectionForm.lean
+++ b/TauCeti/LowDimTopology/Plumbing/IntersectionForm.lean
@@ -65,8 +65,6 @@ intersection form of a plumbing graph follows Némethi,
 
 public section
 
-open scoped Matrix
-
 namespace TauCeti
 
 /-- A plumbing graph: a simple graph together with an integer weight on each vertex.


### PR DESCRIPTION
This PR removes the unused `open scoped Matrix` from `TauCeti/LowDimTopology/Plumbing/IntersectionForm.lean`, added in https://github.com/TauCetiProject/TauCeti/pull/422. The file uses no scoped Matrix notation (the `!![...]` literal is unscoped), and the whole project builds unchanged without the open.

🤖 Prepared with Claude Code