### PR TITLE
chore: drop unneeded @[expose] annotations from the Abel-Jacobi lane

### DIFF
--- a/TauCeti/AlgebraicGeometry/WeilDivisor.lean
+++ b/TauCeti/AlgebraicGeometry/WeilDivisor.lean
@@ -620,14 +620,18 @@ lemma pointDifference_mem_weightedDegreeZeroSubgroup {w : X → ℤ} {x y : X}
 For the geometric weight `w x = [κ(x) : k]` and a rational base point `x₀` with `w x₀ = 1`,
 this is the degree-zero divisor underlying the Abel-Jacobi class of the closed point `x`.
 In the algebraically closed/unweighted specialization, this recovers `pointDifference x x₀`. -/
-@[expose] noncomputable def weightedPointBaseDifference (w : X → ℤ) (x₀ x : X) : WeilDivisor X :=
+noncomputable def weightedPointBaseDifference (w : X → ℤ) (x₀ x : X) : WeilDivisor X :=
   ofPoint x - w x • ofPoint x₀
+
+private lemma weightedPointBaseDifference_def (w : X → ℤ) (x₀ x : X) :
+    weightedPointBaseDifference w x₀ x = ofPoint x - w x • ofPoint x₀ :=
+  rfl
 
 /-- The degree-corrected point divisor is `[x]` minus `w x` copies of the base point `[x₀]`.
 This exposes the definition as a public equation for use across modules. -/
 lemma weightedPointBaseDifference_eq_ofPoint_sub_zsmul (w : X → ℤ) (x₀ x : X) :
     weightedPointBaseDifference w x₀ x = ofPoint x - w x • ofPoint x₀ :=
-  rfl
+  weightedPointBaseDifference_def w x₀ x
 
 /-- At the constant weight `1`, the degree-corrected point divisor is the usual point
 difference. This simp lemma lets unweighted API reuse the weighted construction. -/

--- a/TauCeti/AlgebraicGeometry/WeilDivisor/AbelJacobiDegreeSplitting.lean
+++ b/TauCeti/AlgebraicGeometry/WeilDivisor/AbelJacobiDegreeSplitting.lean
@@ -30,7 +30,7 @@ Ceti's existing `OrderSystem.picZero`, `weightedAbelJacobiClass`, and
 `classGroupAddEquivPicZeroProdInt` APIs.
 -/
 
-@[expose] public section
+public section
 
 namespace TauCeti
 


### PR DESCRIPTION
This PR removes two `@[expose]` annotations introduced in https://github.com/TauCetiProject/TauCeti/pull/420 that the api-design rubric's "keep bodies unexposed (no `@[expose]`) unless a consumer must unfold or compute" rule flags:

* `weightedPointBaseDifference` in `TauCeti/AlgebraicGeometry/WeilDivisor.lean`: no external consumer unfolds the body; every use goes through the named lemmas (`weightedPointBaseDifference_eq_ofPoint_sub_zsmul` states the defining equation right below). Dropping the exposure follows the file's existing idiom for the Abel-Jacobi representatives: the defining equality is unfolded once in a `private` `rfl` lemma and re-exported through the public lemma.
* the file-wide `@[expose] public section` in `TauCeti/AlgebraicGeometry/WeilDivisor/AbelJacobiDegreeSplitting.lean`, which contains no definitions at all, becomes a plain `public section`.

A full `lake build` passes, confirming all downstream modules use the named API rather than the exposed bodies.

🤖 Prepared with Claude Code