### PR TITLE
doc: correct the absolute-value description in classNumber_le_nat_of_abs_discr_le_of_finrank_le

### DIFF
--- a/TauCeti/NumberTheory/EffectiveBounds/ClassNumber.lean
+++ b/TauCeti/NumberTheory/EffectiveBounds/ClassNumber.lean
@@ -120,8 +120,9 @@ theorem classNumber_le_of_abs_discr_le_of_finrank_le (F : Type*) [Field F] [Numb
 /-- A version of `classNumber_le_of_abs_discr_le_of_finrank_le` with a natural-number
 discriminant bound and a natural-number conclusion.
 
-Here `|NumberField.discr F|` is the natural absolute value of the integer discriminant, so
-this is the form to use when the available discriminant estimate is stated in `ℕ`. -/
+Here `|NumberField.discr F|` is the integer absolute value of the discriminant, compared with
+the natural-number bound `D` coerced to `ℤ`, so this is the form to use when the available
+discriminant estimate is stated in `ℕ`. -/
 theorem classNumber_le_nat_of_abs_discr_le_of_finrank_le (F : Type*) [Field F] [NumberField F]
     {D n : ℕ} (hD : |NumberField.discr F| ≤ D) (hn : Module.finrank ℚ F ≤ n) :
     NumberField.classNumber F ≤ D * 4 ^ n := by


### PR DESCRIPTION
This PR fixes the docstring of `classNumber_le_nat_of_abs_discr_le_of_finrank_le` (from https://github.com/TauCetiProject/TauCeti/pull/539), which described `|NumberField.discr F|` as "the natural absolute value of the integer discriminant". The hypothesis actually uses the integer absolute value `|·| : ℤ → ℤ` compared with the natural-number bound `D` coerced to `ℤ`; there is no natural-valued absolute value involved. Wording only, no code changes.

🤖 Prepared with Claude Code