### PR TITLE
feat: make normalizer quotient fibre actions free

### DIFF
--- a/TauCeti/Algebra/GroupAction/OrbitRelQuotient.lean
+++ b/TauCeti/Algebra/GroupAction/OrbitRelQuotient.lean
@@ -31,6 +31,8 @@ This file records small generic additions to Mathlib's `MulAction.orbitRel.Quoti
   quotient by `H`-orbits.
 * `TauCeti.MulAction.normalizerQuotientOrbitRelQuotientPermHom`: the descended action of
   `N(H) / H` on the quotient by `H`-orbits.
+* `TauCeti.MulAction.normalizerQuotientOrbitRelQuotient_smul_eq_smul_iff`: if the original
+  action is free, then the descended `N(H) / H` action on the `H`-orbit quotient is free.
 -/
 
 public section
@@ -336,6 +338,28 @@ lemma normalizerQuotientOrbitRelQuotient_smul_mk (H : Subgroup G)
         (Quotient.mk'' x : _root_.MulAction.orbitRel.Quotient H X) =
       Quotient.mk'' ((g : G) • x)
     exact normalizerQuotientOrbitRelQuotientPermHom_mk_apply (X := X) H g x
+
+/-- Equality after the descended `N(H) / H` action on an `H`-orbit quotient is equality of
+normalizer-quotient elements, provided the original action is free. -/
+lemma normalizerQuotientOrbitRelQuotient_smul_eq_smul_iff [IsCancelSMul G X]
+    (H : Subgroup G) (a c : Subgroup.normalizerQuotient H)
+    (x : _root_.MulAction.orbitRel.Quotient H X) :
+    letI := normalizerQuotientOrbitRelQuotientMulAction (X := X) H
+    a • x = c • x ↔ a = c := by
+  letI := normalizerQuotientOrbitRelQuotientMulAction (X := X) H
+  constructor
+  · intro h
+    obtain ⟨g, rfl⟩ := Subgroup.normalizerQuotientMk_surjective H a
+    obtain ⟨k, rfl⟩ := Subgroup.normalizerQuotientMk_surjective H c
+    refine Quotient.inductionOn' x ?_ h
+    intro x h
+    rw [normalizerQuotientOrbitRelQuotient_smul_mk,
+      normalizerQuotientOrbitRelQuotient_smul_mk] at h
+    rw [Subgroup.normalizerQuotientMk_eq_iff_div_mem]
+    simpa [div_eq_mul_inv] using
+      (orbitRelQuotient_smul_eq_smul_iff_mul_inv_mem H x (g : G) (k : G)).mp h
+  · intro h
+    rw [h]
 
 end MulAction
 

--- a/TauCeti/Algebra/GroupAction/OrbitRelQuotient.lean
+++ b/TauCeti/Algebra/GroupAction/OrbitRelQuotient.lean
@@ -341,6 +341,7 @@ lemma normalizerQuotientOrbitRelQuotient_smul_mk (H : Subgroup G)
 
 /-- Equality after the descended `N(H) / H` action on an `H`-orbit quotient is equality of
 normalizer-quotient elements, provided the original action is free. -/
+@[simp]
 lemma normalizerQuotientOrbitRelQuotient_smul_eq_smul_iff [IsCancelSMul G X]
     (H : Subgroup G) (a c : Subgroup.normalizerQuotient H)
     (x : _root_.MulAction.orbitRel.Quotient H X) :

--- a/TauCeti/Algebra/GroupAction/OrbitRelQuotient.lean
+++ b/TauCeti/Algebra/GroupAction/OrbitRelQuotient.lean
@@ -361,6 +361,17 @@ lemma normalizerQuotientOrbitRelQuotient_smul_eq_smul_iff [IsCancelSMul G X]
   · intro h
     rw [h]
 
+/-- If a group acts freely on `X`, then the descended `N(H) / H` action on the quotient of `X`
+by `H`-orbits is free. This packages `normalizerQuotientOrbitRelQuotient_smul_eq_smul_iff` as the
+cancellativity of the descended action. -/
+theorem normalizerQuotientOrbitRelQuotientIsCancelSMul [IsCancelSMul G X]
+    (H : Subgroup G) :
+    letI := normalizerQuotientOrbitRelQuotientMulAction (X := X) H
+    IsCancelSMul (Subgroup.normalizerQuotient H) (_root_.MulAction.orbitRel.Quotient H X) :=
+  letI := normalizerQuotientOrbitRelQuotientMulAction (X := X) H
+  { right_cancel' := fun a c x h =>
+      (normalizerQuotientOrbitRelQuotient_smul_eq_smul_iff H a c x).mp h }
+
 end MulAction
 
 end TauCeti

--- a/TauCeti/AlgebraicTopology/UniversalCover/Deck/NormalizerQuotientFiberAction.lean
+++ b/TauCeti/AlgebraicTopology/UniversalCover/Deck/NormalizerQuotientFiberAction.lean
@@ -27,6 +27,8 @@ identify the deck group of the cover attached to `H` with `N(H) / H`.
   from `N(H) / H`.
 * `TauCeti.Deck.instNormalizerQuotientSubgroupFiberOrbitMulAction`: the resulting action of
   `N(H) / H` on `SubgroupFiberOrbitQuotient H b`.
+* `TauCeti.Deck.instNormalizerQuotientSubgroupFiberOrbitIsCancelSMul`: freeness of this
+  descended action when the deck action on the fibre is free.
 
 ## References
 
@@ -175,6 +177,31 @@ lemma normalizerQuotient_mk_of_mem_smul_subgroupFiberOrbitClass
       subgroupFiberOrbitClass H e := by
   rw [normalizerQuotient_smul_subgroupFiberOrbitClass]
   exact (subgroupFiberOrbitClass_eq_iff H (φ • e) e).2 ⟨⟨φ, hφ⟩, rfl⟩
+
+/-- Equality after the `N(H) / H` action on an `H`-fibre quotient is equality of
+normalizer-quotient elements, provided the deck action on that fibre is free. -/
+lemma normalizerQuotient_smul_subgroupFiberOrbit_eq_smul_iff
+    [IsCancelSMul (Deck p) (p ⁻¹' {b})] (H : Subgroup (Deck p))
+    (a c : Subgroup.normalizerQuotient H) (x : SubgroupFiberOrbitQuotient H b) :
+    a • x = c • x ↔ a = c :=
+  TauCeti.MulAction.normalizerQuotientOrbitRelQuotient_smul_eq_smul_iff H a c x
+
+/-- If the deck action on a fibre is free, then the descended `N(H) / H` action on the
+quotient of that fibre by `H`-orbits is free. -/
+noncomputable instance instNormalizerQuotientSubgroupFiberOrbitIsCancelSMul
+    [IsCancelSMul (Deck p) (p ⁻¹' {b})] (H : Subgroup (Deck p)) :
+    IsCancelSMul (Subgroup.normalizerQuotient H) (SubgroupFiberOrbitQuotient H b) where
+  right_cancel' a c x h :=
+    (normalizerQuotient_smul_subgroupFiberOrbit_eq_smul_iff H a c x).mp h
+
+/-- For a preconnected covering map, the descended `N(H) / H` action on every `H`-fibre
+quotient is free. -/
+theorem normalizerQuotientSubgroupFiberOrbitIsCancelSMulOfIsCoveringMap
+    [TopologicalSpace B] [PreconnectedSpace E] (hp : IsCoveringMap p)
+    (H : Subgroup (Deck p)) :
+    IsCancelSMul (Subgroup.normalizerQuotient H) (SubgroupFiberOrbitQuotient H b) := by
+  letI := fiber_isCancelSMul (b := b) hp
+  exact instNormalizerQuotientSubgroupFiberOrbitIsCancelSMul H
 
 end Deck
 

--- a/TauCeti/AlgebraicTopology/UniversalCover/Deck/NormalizerQuotientFiberAction.lean
+++ b/TauCeti/AlgebraicTopology/UniversalCover/Deck/NormalizerQuotientFiberAction.lean
@@ -180,6 +180,7 @@ lemma normalizerQuotient_mk_of_mem_smul_subgroupFiberOrbitClass
 
 /-- Equality after the `N(H) / H` action on an `H`-fibre quotient is equality of
 normalizer-quotient elements, provided the deck action on that fibre is free. -/
+@[simp]
 lemma normalizerQuotient_smul_subgroupFiberOrbit_eq_smul_iff
     [IsCancelSMul (Deck p) (p ⁻¹' {b})] (H : Subgroup (Deck p))
     (a c : Subgroup.normalizerQuotient H) (x : SubgroupFiberOrbitQuotient H b) :
@@ -190,9 +191,8 @@ lemma normalizerQuotient_smul_subgroupFiberOrbit_eq_smul_iff
 quotient of that fibre by `H`-orbits is free. -/
 noncomputable instance instNormalizerQuotientSubgroupFiberOrbitIsCancelSMul
     [IsCancelSMul (Deck p) (p ⁻¹' {b})] (H : Subgroup (Deck p)) :
-    IsCancelSMul (Subgroup.normalizerQuotient H) (SubgroupFiberOrbitQuotient H b) where
-  right_cancel' a c x h :=
-    (normalizerQuotient_smul_subgroupFiberOrbit_eq_smul_iff H a c x).mp h
+    IsCancelSMul (Subgroup.normalizerQuotient H) (SubgroupFiberOrbitQuotient H b) :=
+  TauCeti.MulAction.normalizerQuotientOrbitRelQuotientIsCancelSMul (X := p ⁻¹' {b}) H
 
 /-- For a preconnected covering map, the descended `N(H) / H` action on every `H`-fibre
 quotient is free. -/


### PR DESCRIPTION
This PR records freeness for the normalizer-quotient action on subgroup orbit quotients: if a group acts freely on `X`, then the descended `N(H) / H` action on `X / H` is free, and specializes this to deck actions on fibre-orbit quotients. Use the generic equality criterion to turn equality after action by two normalizer-quotient classes into equality of those classes, then expose the deck-level `IsCancelSMul` instance and the covering-map wrapper for later quotient-cover deck-group computations.

It advances `TauCetiRoadmap/UniversalCovers/README.md`, Stage 2, item 8, specifically the normalizer quotient milestone: “For the cover attached to `H`, the deck group is `N(H)/H`; it is a regular (normal/Galois) cover iff `H ◁ π₁(X, x₀)`, and then the deck group is `π₁(X, x₀)/H`.” I chose this as the lowest-hanging distinct prerequisite after checking open and recently merged PRs: the normalizer-quotient action, endpoint comparisons, and equality criteria already exist, while freeness of the descended action was not packaged.

No Mathlib infrastructure is vendored. The implementation reuses Tau Ceti’s existing `Subgroup.normalizerQuotientMk_surjective`, `Subgroup.normalizerQuotientMk_eq_iff_div_mem`, `MulAction.orbitRelQuotient_smul_eq_smul_iff_mul_inv_mem`, `Deck.normalizerQuotient_smul_subgroupFiberOrbitClass`, and the covering-map fibre freeness instance `Deck.fiber_isCancelSMul`.

`lake exe cache get` completed with `No files to download` and `Already decompressed 8609 file(s)`. `lake build` completed with `Build completed successfully (4488 jobs).` `lake exe axioms` completed with `axioms: audited 7604 TauCeti declaration(s); all within the allowlist [propext, Classical.choice, Quot.sound].`

<!--tauceti-target:v1 {"focus":"UniversalCovers","id":"normalizer-quotient-fiber-action-free"}-->

🤖 Prepared with Codex
