### PR TITLE
chore(Algebra): drop simp attributes that simp can already prove

### DIFF
--- a/TauCeti/Algebra/AlgebraicGroup/AdditiveGroup.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/AdditiveGroup.lean
@@ -80,7 +80,6 @@ theorem toAdd_pointsMulEquiv (F : WithConv (SymmetricAlgebra R M →ₐ[R] A)) :
   rfl
 
 /-- The linear map underlying a point evaluates as `x ↦ F (ι x)`. -/
-@[simp]
 theorem toAdd_pointsMulEquiv_apply (F : WithConv (SymmetricAlgebra R M →ₐ[R] A)) (x : M) :
     Multiplicative.toAdd (pointsMulEquiv F) x = F.ofConv (ι R M x) :=
   TauCeti.SymmetricAlgebra.lift_symm_apply F.ofConv x
@@ -144,7 +143,6 @@ theorem pointsMulEquiv_inv (F : WithConv (SymmetricAlgebra R M →ₐ[R] A)) :
 
 /-- In additive notation, the convolution inverse of a point corresponds to negating its linear
 map of generator values. -/
-@[simp]
 theorem toAdd_pointsMulEquiv_inv (F : WithConv (SymmetricAlgebra R M →ₐ[R] A)) :
     Multiplicative.toAdd (pointsMulEquiv (F⁻¹)) = -Multiplicative.toAdd (pointsMulEquiv F) := by
   rw [pointsMulEquiv_inv]
@@ -185,7 +183,6 @@ theorem gaPointsMulEquiv_symm_apply_ι (a : Multiplicative A) :
 /-- Reading a `𝔾ₐ`-point as an element of the value algebra is natural in the value algebra:
 post-composing the point with an `R`-algebra map applies that map to the corresponding
 element. -/
-@[simp]
 theorem toAdd_gaPointsMulEquiv_mapValue (φ : A →ₐ[R] B)
     (F : WithConv (SymmetricAlgebra R R →ₐ[R] A)) :
     Multiplicative.toAdd
@@ -231,7 +228,6 @@ theorem gaPointsMulEquiv_inv (F : WithConv (SymmetricAlgebra R R →ₐ[R] A)) :
 
 /-- In additive notation, the convolution inverse of a `𝔾ₐ`-point is the negative of its value
 on the generator `ι 1`. -/
-@[simp]
 theorem toAdd_gaPointsMulEquiv_inv (F : WithConv (SymmetricAlgebra R R →ₐ[R] A)) :
     Multiplicative.toAdd (gaPointsMulEquiv (F⁻¹)) = -Multiplicative.toAdd (gaPointsMulEquiv F) := by
   rw [gaPointsMulEquiv_inv]

--- a/TauCeti/Algebra/AlgebraicGroup/AdditiveGroupBaseChange.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/AdditiveGroupBaseChange.lean
@@ -93,7 +93,6 @@ theorem baseChangePointsMulEquiv_symm_apply_tmul_ι
 
 /-- The inverse base-changed vector-group points equivalence takes the generator indexed by
 `m` to the value of the chosen linear map at `m`. -/
-@[simp]
 theorem baseChangePointsMulEquiv_symm_apply_ι
     (φ : Multiplicative (M →ₗ[k] A)) (m : M) :
     ((baseChangePointsMulEquiv (k := k) (K := K) (A := A) (M := M)).symm φ).ofConv
@@ -183,7 +182,6 @@ theorem gaBaseChangePointsMulEquiv_symm_apply_ι (a : Multiplicative A) :
 /-- Reading a base-changed `𝔾ₐ`-point as an element of the value algebra is natural in the
 value algebra: post-composing the point with a `K`-algebra map applies that map to the
 corresponding element. -/
-@[simp]
 theorem toAdd_gaBaseChangePointsMulEquiv_mapValue (ψ : A →ₐ[K] B)
     (F : WithConv (K ⊗[k] SymmetricAlgebra k k →ₐ[K] A)) :
     Multiplicative.toAdd

--- a/TauCeti/Algebra/AlgebraicGroup/CommHopfAlgCat.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/CommHopfAlgCat.lean
@@ -75,7 +75,6 @@ lemma mapPointsFunctor_app_apply {H K : CommHopfAlgCat.{v} R} (φ : H ⟶ K)
   exact AlgHom.mapDomain_apply (A := A) φ.hom f
 
 /-- Pointwise form of `mapPointsFunctor_app_apply`. -/
-@[simp]
 lemma mapPointsFunctor_app_apply_apply {H K : CommHopfAlgCat.{v} R} (φ : H ⟶ K)
     (A : CommAlgCat.{w} R) (f : HopfAlgebra.points (R := R) (H := K) A) (h : H) :
     (((mapPointsFunctor φ).app A f).ofConv) h = f.ofConv (φ.hom h) := by

--- a/TauCeti/Algebra/AlgebraicGroup/DiagonalizableGroup.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/DiagonalizableGroup.lean
@@ -85,7 +85,6 @@ theorem point_single (χ : G →* Aˣ) (g : G) (r : R) :
     Units.coeHom_apply]
 
 /-- The point associated to a character sends the group-like `single g 1` to `χ g`. -/
-@[simp]
 theorem point_single_one (χ : G →* Aˣ) (g : G) :
     point (R := R) χ (MonoidAlgebra.single g 1) = (χ g : A) := by
   rw [point_single, one_smul]

--- a/TauCeti/Algebra/AlgebraicGroup/DiagonalizableGroupBaseChange.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/DiagonalizableGroupBaseChange.lean
@@ -109,7 +109,6 @@ theorem baseChangePointsMulEquiv_symm_apply_tmul_single (χ : G →* Aˣ) (s : K
 
 /-- The inverse base-changed diagonalizable-points equivalence takes `1 ⊗ single g 1` to the
 value of the character at `g`. -/
-@[simp]
 theorem baseChangePointsMulEquiv_symm_apply_single_one (χ : G →* Aˣ) (g : G) :
     ((baseChangePointsMulEquiv (k := k) (K := K) (A := A) (G := G)).symm χ).ofConv
         (1 ⊗ₜ[k] MonoidAlgebra.single g (1 : k)) =

--- a/TauCeti/Algebra/AlgebraicGroup/DiagonalizableGroupFunctoriality.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/DiagonalizableGroupFunctoriality.lean
@@ -130,7 +130,6 @@ theorem charOfPoint_comp (φ : G →* G') (f : MonoidAlgebra R G' →ₐ[R] A) :
 /-- **The points homomorphism is precomposition of characters.** Under the identification of
 points of `D(G)` with characters of `G`, the homomorphism `pointsMap φ` induced by
 `φ : G →* G'` is intertwined with precomposition `χ ↦ χ ∘ φ` of characters. -/
-@[simp]
 theorem pointsMulEquiv_pointsMap (φ : G →* G') (f : WithConv (MonoidAlgebra R G' →ₐ[R] A)) :
     pointsMulEquiv (pointsMap (A := A) φ f) = (pointsMulEquiv f).comp φ := by
   rw [pointsMap_apply, pointsMulEquiv_apply, ofConv_toConv, pointsMulEquiv_apply, charOfPoint_comp]

--- a/TauCeti/Algebra/AlgebraicGroup/HopfIdealQuotient.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/HopfIdealQuotient.lean
@@ -64,7 +64,6 @@ noncomputable abbrev mkQuotient (H : _root_.CommHopfAlgCat.{v} R) (I : HopfIdeal
   _root_.CommHopfAlgCat.ofHom (Bialgebra.Quotient.mkBialgHom I.toIdeal)
 
 /-- The quotient morphism has the expected underlying bialgebra morphism. -/
-@[simp]
 lemma hom_mkQuotient (H : _root_.CommHopfAlgCat.{v} R) (I : HopfIdeal R H) :
     (mkQuotient H I).hom = Bialgebra.Quotient.mkBialgHom I.toIdeal :=
   _root_.CommHopfAlgCat.hom_ofHom _
@@ -97,7 +96,6 @@ noncomputable abbrev liftQuotient (I : HopfIdeal R H) (f : H ⟶ K)
   _root_.CommHopfAlgCat.ofHom (Bialgebra.Quotient.liftBialgHom I.toIdeal f.hom hf)
 
 /-- The quotient lift has the expected underlying bialgebra morphism. -/
-@[simp]
 lemma hom_liftQuotient (I : HopfIdeal R H) (f : H ⟶ K)
     (hf : I.toIdeal ≤ RingHom.ker f.hom.toAlgHom.toRingHom) :
     (liftQuotient I f hf).hom = Bialgebra.Quotient.liftBialgHom I.toIdeal f.hom hf :=

--- a/TauCeti/Algebra/AlgebraicGroup/MultiplicativeGroup.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/MultiplicativeGroup.lean
@@ -184,7 +184,6 @@ theorem unitOfPoint_comp (φ : A →ₐ[R] B) (f : R[T;T⁻¹] →ₐ[R] A) :
   simp [unitOfPoint_val, Units.coe_map]
 
 /-- The plain Laurent-polynomial points equivalence is natural in the value algebra. -/
-@[simp]
 theorem pointEquiv_comp (φ : A →ₐ[R] B) (f : R[T;T⁻¹] →ₐ[R] A) :
     pointEquiv (R := R) (A := B) (φ.comp f) =
       Units.map φ.toMonoidHom (pointEquiv (R := R) (A := A) f) :=
@@ -203,7 +202,6 @@ theorem comp_point (φ : A →ₐ[R] B) (u : Aˣ) :
 
 /-- Reading a multiplicative-group point as a unit is natural in the value algebra:
 post-composing the point with an `R`-algebra map applies the induced map on unit groups. -/
-@[simp]
 theorem unitOfPoint_mapValue (φ : A →ₐ[R] B)
     (f : WithConv (R[T;T⁻¹] →ₐ[R] A)) :
     unitOfPoint ((AlgHom.mapValue (H := R[T;T⁻¹]) φ f).ofConv) =
@@ -212,7 +210,6 @@ theorem unitOfPoint_mapValue (φ : A →ₐ[R] B)
   exact unitOfPoint_comp φ f.ofConv
 
 /-- The `𝔾ₘ` points equivalence is natural in the value algebra. -/
-@[simp]
 theorem pointsMulEquiv_mapValue (φ : A →ₐ[R] B)
     (f : WithConv (R[T;T⁻¹] →ₐ[R] A)) :
     pointsMulEquiv (R := R) (A := B)
@@ -223,7 +220,6 @@ theorem pointsMulEquiv_mapValue (φ : A →ₐ[R] B)
     exact unitOfPoint_mapValue φ f
 
 /-- Naturality of the inverse `𝔾ₘ` points equivalence in the value algebra. -/
-@[simp]
 theorem mapValue_pointsMulEquiv_symm_apply (φ : A →ₐ[R] B) (u : Aˣ) :
     AlgHom.mapValue (H := R[T;T⁻¹]) φ
         ((pointsMulEquiv (R := R) (A := A)).symm u) =

--- a/TauCeti/Algebra/AlgebraicGroup/MultiplicativeGroupBaseChange.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/MultiplicativeGroupBaseChange.lean
@@ -101,7 +101,6 @@ theorem baseChangePointsMulEquiv_symm_apply_tmul_T (u : Aˣ) (s : K) (n : ℤ) :
 
 /-- The inverse base-changed multiplicative-group points equivalence takes `1 ⊗ T` to the
 chosen unit. -/
-@[simp]
 theorem baseChangePointsMulEquiv_symm_apply_T (u : Aˣ) :
     ((baseChangePointsMulEquiv (k := k) (K := K) (A := A)).symm u).ofConv
         (1 ⊗ₜ[k] LaurentPolynomial.T 1) =

--- a/TauCeti/Algebra/AlgebraicGroup/Product.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/Product.lean
@@ -206,7 +206,6 @@ theorem mapValue_pointsMulEquiv_symm_apply (φ : A →ₐ[R] B)
 
 /-- On pure tensors, naturality of the inverse product-points map says that post-composition
 by `φ` evaluates as applying `φ` to the product of the two factor values. -/
-@[simp]
 theorem mapValue_pointsMulEquiv_symm_apply_tmul (φ : A →ₐ[R] B)
     (p : WithConv (H₁ →ₐ[R] A) × WithConv (H₂ →ₐ[R] A)) (x : H₁) (y : H₂) :
     (AlgHom.mapValue (H := H₁ ⊗[R] H₂) φ

--- a/TauCeti/Algebra/AlgebraicGroup/RootsOfUnity.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/RootsOfUnity.lean
@@ -148,7 +148,6 @@ lemma pointsMulEquiv_mapValue (n : ℕ) (φ : A →ₐ[R] B)
 
 /-- The inverse points equivalence sends a root of unity to the point taking the standard
 generator to that root. -/
-@[simp]
 lemma pointsMulEquiv_symm_apply_single_generator (n : ℕ) (ζ : rootsOfUnity n A) :
     ((pointsMulEquiv (R := R) (A := A) n).symm ζ).ofConv
         (MonoidAlgebra.single (generator n) 1) =
@@ -177,7 +176,6 @@ lemma pointsMulEquiv_symm_apply_single_generator_smul (n : ℕ) (ζ : rootsOfUni
 
 For `x = generator n`, this specializes to
 `RootsOfUnityGroup.pointsMulEquiv_symm_apply_single_generator`. -/
-@[simp]
 lemma pointsMulEquiv_symm_apply_single_zmod_val (n : ℕ) [NeZero n] (ζ : rootsOfUnity n A)
     (x : Multiplicative (ZMod n)) :
     ((pointsMulEquiv (R := R) (A := A) n).symm ζ).ofConv
@@ -205,7 +203,6 @@ lemma pointsMulEquiv_symm_apply_single_zmod_val_smul (n : ℕ) [NeZero n] (ζ : 
   rw [map_smul, pointsMulEquiv_symm_apply_single_zmod_val]
 
 /-- The previous normal form, specialized to an additive residue class `j : ZMod n`. -/
-@[simp]
 lemma pointsMulEquiv_symm_apply_single_ofAdd_val (n : ℕ) [NeZero n] (ζ : rootsOfUnity n A)
     (j : ZMod n) :
     ((pointsMulEquiv (R := R) (A := A) n).symm ζ).ofConv
@@ -216,7 +213,6 @@ lemma pointsMulEquiv_symm_apply_single_ofAdd_val (n : ℕ) [NeZero n] (ζ : root
       (Multiplicative.ofAdd j), toAdd_ofAdd]
 
 /-- The scalar version of `pointsMulEquiv_symm_apply_single_ofAdd_val`. -/
-@[simp]
 lemma pointsMulEquiv_symm_apply_single_ofAdd_val_smul (n : ℕ) [NeZero n] (ζ : rootsOfUnity n A)
     (j : ZMod n) (r : R) :
     ((pointsMulEquiv (R := R) (A := A) n).symm ζ).ofConv
@@ -240,7 +236,6 @@ lemma mapValue_pointsMulEquiv_symm_apply (n : ℕ) (φ : A →ₐ[R] B) (ζ : ro
 
 /-- Naturality of the inverse `μ_n` points equivalence, evaluated on an arbitrary cyclic
 group-algebra generator. -/
-@[simp]
 lemma mapValue_pointsMulEquiv_symm_apply_single_zmod_val (n : ℕ) [NeZero n] (φ : A →ₐ[R] B)
     (ζ : rootsOfUnity n A) (x : Multiplicative (ZMod n)) :
     (AlgHom.mapValue (H := MonoidAlgebra R (Multiplicative (ZMod n))) φ
@@ -252,7 +247,6 @@ lemma mapValue_pointsMulEquiv_symm_apply_single_zmod_val (n : ℕ) [NeZero n] (�
 
 /-- Naturality of the inverse `μ_n` points equivalence on scalar multiples of arbitrary cyclic
 group-algebra generators. -/
-@[simp]
 lemma mapValue_pointsMulEquiv_symm_apply_single_zmod_val_smul (n : ℕ) [NeZero n] (φ : A →ₐ[R] B)
     (ζ : rootsOfUnity n A) (x : Multiplicative (ZMod n)) (r : R) :
     (AlgHom.mapValue (H := MonoidAlgebra R (Multiplicative (ZMod n))) φ

--- a/TauCeti/Algebra/AlgebraicGroup/RootsOfUnityBaseChange.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/RootsOfUnityBaseChange.lean
@@ -107,7 +107,6 @@ lemma baseChangePointsMulEquiv_symm_apply_tmul_single_generator (n : ℕ)
 
 /-- The inverse base-changed roots-of-unity points equivalence takes the standard generator to
 the chosen root of unity. -/
-@[simp]
 lemma baseChangePointsMulEquiv_symm_apply_single_generator (n : ℕ) (ζ : rootsOfUnity n A) :
     ((baseChangePointsMulEquiv (k := k) (K := K) (A := A) n).symm ζ).ofConv
         (1 ⊗ₜ[k] MonoidAlgebra.single (generator n) (1 : k)) =

--- a/TauCeti/Algebra/AlgebraicGroup/SplitTorus.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/SplitTorus.lean
@@ -89,7 +89,6 @@ theorem pointsMulEquiv_symm_apply (c : σ → Aˣ) :
 
 /-- The inverse points equivalence sends a coordinate family to the point taking the `i`-th
 standard generator to the `i`-th coordinate. -/
-@[simp]
 theorem pointsMulEquiv_symm_apply_single (c : σ → Aˣ) (i : σ) :
     ((pointsMulEquiv (R := R) (A := A)).symm c).ofConv
         (MonoidAlgebra.single (Multiplicative.ofAdd (Finsupp.single i 1)) 1) =

--- a/TauCeti/Algebra/AlgebraicGroup/SplitTorusBaseChange.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/SplitTorusBaseChange.lean
@@ -97,7 +97,6 @@ theorem baseChangePointsMulEquiv_symm_apply_tmul_single (c : σ → Aˣ) (s : K)
 
 /-- The inverse base-changed split-torus points equivalence takes the standard coordinate
 generator indexed by `i` to the chosen coordinate `c i`. -/
-@[simp]
 theorem baseChangePointsMulEquiv_symm_apply_single_one (c : σ → Aˣ) (i : σ) :
     ((baseChangePointsMulEquiv (k := k) (K := K) (A := A) (σ := σ)).symm c).ofConv
         (1 ⊗ₜ[k] MonoidAlgebra.single (Multiplicative.ofAdd (Finsupp.single i 1)) (1 : k)) =

--- a/TauCeti/Algebra/AlgebraicGroup/Trivial.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/Trivial.lean
@@ -90,7 +90,6 @@ theorem ofConv_eq_ofId (f : WithConv (R →ₐ[R] A)) :
   Subsingleton.elim _ _
 
 /-- Evaluating any trivial-group convolution point gives the algebra map. -/
-@[simp]
 theorem convPoint_apply (f : WithConv (R →ₐ[R] A)) (r : R) :
     f r = algebraMap R A r := by
   rw [convPoint_eq_one f]
@@ -103,7 +102,6 @@ theorem toConv_eq_one (f : R →ₐ[R] A) : toConv f = (1 : WithConv (R →ₐ[R
   convPoint_eq_one (toConv f)
 
 /-- Evaluating the inverse of a trivial-group point gives the algebra map. -/
-@[simp]
 theorem convInv_apply (f : WithConv (R →ₐ[R] A)) (r : R) :
     f⁻¹ r = algebraMap R A r := by
   rw [convPoint_eq_one f]
@@ -123,7 +121,6 @@ theorem pointsMulEquiv_mapValue (φ : A →ₐ[R] B) (f : WithConv (R →ₐ[R] 
   rfl
 
 /-- Naturality of the inverse trivial-group points equivalence in the value algebra. -/
-@[simp]
 theorem mapValue_pointsMulEquiv_symm_apply (φ : A →ₐ[R] B) (u : PUnit.{1}) :
     AlgHom.mapValue (H := R) φ ((pointsMulEquiv (R := R) (A := A)).symm u) =
       (pointsMulEquiv (R := R) (A := B)).symm u := by

--- a/TauCeti/Algebra/AlgebraicGroup/TrivialBaseChange.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/TrivialBaseChange.lean
@@ -79,7 +79,6 @@ private theorem baseChangePointsMulEquiv_symm_apply (u : PUnit.{1}) :
 
 /-- The unique base-changed trivial-group point sends `s ⊗ r` to
 `s • algebraMap k A r`. -/
-@[simp]
 theorem baseChangePointsMulEquiv_symm_apply_tmul (u : PUnit.{1}) (s : K) (r : k) :
     ((baseChangePointsMulEquiv (k := k) (K := K) (A := A)).symm u).ofConv
         (s ⊗ₜ[k] r) =
@@ -89,7 +88,6 @@ theorem baseChangePointsMulEquiv_symm_apply_tmul (u : PUnit.{1}) (s : K) (r : k)
 
 /-- On `1 ⊗ r`, the unique base-changed trivial-group point is the structure map
 `k → A`. -/
-@[simp]
 theorem baseChangePointsMulEquiv_symm_apply_one_tmul (u : PUnit.{1}) (r : k) :
     ((baseChangePointsMulEquiv (k := k) (K := K) (A := A)).symm u).ofConv
         (1 ⊗ₜ[k] r) =
@@ -118,7 +116,6 @@ theorem convPoint_apply_tmul (f : WithConv (K ⊗[k] k →ₐ[K] A)) (s : K) (r 
   rw [hf, baseChangePointsMulEquiv_symm_apply_tmul]
 
 /-- The inverse of any base-changed trivial-group point is again the unique point. -/
-@[simp]
 theorem convInv_apply_tmul (f : WithConv (K ⊗[k] k →ₐ[K] A)) (s : K) (r : k) :
     (f⁻¹).ofConv (s ⊗ₜ[k] r) = s • algebraMap k A r := by
   rw [baseChangeConvPoint_eq_one (f⁻¹), convPoint_apply_tmul]
@@ -128,7 +125,6 @@ section Naturality
 variable {B : Type w'} [CommSemiring B] [Algebra K B] [Algebra k B] [IsScalarTower k K B]
 
 /-- The base-changed trivial-group points equivalence is natural in the value algebra. -/
-@[simp]
 theorem baseChangePointsMulEquiv_mapValue (φ : A →ₐ[K] B)
     (f : WithConv (K ⊗[k] k →ₐ[K] A)) :
     baseChangePointsMulEquiv (k := k) (K := K) (A := B)
@@ -148,7 +144,6 @@ theorem mapValue_baseChangePointsMulEquiv_symm_apply (φ : A →ₐ[K] B) (u : P
 
 /-- Pointwise naturality of the unique base-changed trivial-group point in the value
 algebra. -/
-@[simp]
 theorem mapValue_baseChangePointsMulEquiv_symm_apply_tmul
     (φ : A →ₐ[K] B) (u : PUnit.{1}) (s : K) (r : k) :
     (AlgHom.mapValue (H := K ⊗[k] k) φ

--- a/TauCeti/Algebra/Coalgebra/Comodule/MatrixCoefficient.lean
+++ b/TauCeti/Algebra/Coalgebra/Comodule/MatrixCoefficient.lean
@@ -189,7 +189,6 @@ variable {M : Type w} [AddCommMonoid M] [Module R M]
 attribute [local instance] trivial
 
 /-- Matrix coefficients of the trivial comodule are scalar multiples of `1`. -/
-@[simp]
 theorem matrixCoefficient_trivial (φ : M →ₗ[R] R) (m : M) :
     matrixCoefficient (R := R) (C := C) φ m = φ m • (1 : C) := by
   simp

--- a/TauCeti/Algebra/Coalgebra/Comodule/MatrixCoefficientRegular.lean
+++ b/TauCeti/Algebra/Coalgebra/Comodule/MatrixCoefficientRegular.lean
@@ -92,13 +92,11 @@ theorem mem_regularObj_matrixCoefficientSet (c : ComoduleCat.regular R C) :
   mem_regular_matrixCoefficientSet (R := R) (C := C) c
 
 /-- The bundled regular comodule's matrix coefficient set is the whole coalgebra. -/
-@[simp]
 theorem regularObj_matrixCoefficientSet_eq_univ :
     matrixCoefficientSet (R := R) (C := C) (M := ComoduleCat.regular R C) = Set.univ :=
   regular_matrixCoefficientSet_eq_univ (R := R) (C := C)
 
 /-- The bundled regular comodule's matrix coefficients span the whole coalgebra. -/
-@[simp]
 theorem regularObj_matrixCoefficientSubmodule_eq_top :
     matrixCoefficientSubmodule (R := R) (C := C) (M := ComoduleCat.regular R C) = ⊤ :=
   regular_matrixCoefficientSubmodule_eq_top (R := R) (C := C)
@@ -131,7 +129,6 @@ theorem regular_matrixCoefficientSubalgebra_eq_top :
     (regular_matrixCoefficientSubmodule_eq_top (R := R) (C := C))
 
 /-- The bundled regular comodule's matrix coefficients generate the whole ambient algebra. -/
-@[simp]
 theorem regularObj_matrixCoefficientSubalgebra_eq_top :
     matrixCoefficientSubalgebra (R := R) (C := C) (M := ComoduleCat.regular R C) = ⊤ :=
   regular_matrixCoefficientSubalgebra_eq_top (R := R) (C := C)

--- a/TauCeti/Algebra/Coalgebra/Comodule/MatrixCoefficientTrivial.lean
+++ b/TauCeti/Algebra/Coalgebra/Comodule/MatrixCoefficientTrivial.lean
@@ -187,7 +187,6 @@ theorem trivial_matrixCoefficientSubmodule_le_span_singleton_one :
 
 /-- The coefficient submodule of the rank-one trivial comodule is exactly the line spanned by
 `1`. -/
-@[simp]
 theorem trivial_rankOne_matrixCoefficientSubmodule_eq_span_singleton_one :
     matrixCoefficientSubmodule (R := R) (C := C) (M := R) =
       Submodule.span R ({1} : Set C) := by

--- a/TauCeti/Algebra/Coalgebra/Comodule/Product.lean
+++ b/TauCeti/Algebra/Coalgebra/Comodule/Product.lean
@@ -73,7 +73,6 @@ theorem prodCoact_apply (x : M × N) :
   rfl
 
 /-- The product coaction after the left inclusion. -/
-@[simp]
 theorem prodCoact_inl (m : M) :
     prodCoact (R := R) (C := C) (M := M) (N := N) (LinearMap.inl R M N m) =
       TensorProduct.map (LinearMap.inl R M N) LinearMap.id
@@ -81,7 +80,6 @@ theorem prodCoact_inl (m : M) :
   simp [prodCoact]
 
 /-- The product coaction after the right inclusion. -/
-@[simp]
 theorem prodCoact_inr (n : N) :
     prodCoact (R := R) (C := C) (M := M) (N := N) (LinearMap.inr R M N n) =
       TensorProduct.map (LinearMap.inr R M N) LinearMap.id

--- a/TauCeti/Algebra/Coalgebra/Comodule/Regular.lean
+++ b/TauCeti/Algebra/Coalgebra/Comodule/Regular.lean
@@ -174,7 +174,6 @@ abbrev trivialToRegular : trivial R C ⟶ regular R C :=
   Comodule.Hom.trivialToRegular (R := R) (C := C)
 
 /-- The bundled morphism `trivialToRegular` sends `r` to `algebraMap R C r`. -/
-@[simp]
 theorem trivialToRegular_apply (r : R) :
     trivialToRegular (R := R) (C := C) r = algebraMap R C r :=
   Comodule.Hom.trivialToRegular_apply (R := R) (C := C) r

--- a/TauCeti/Algebra/Coalgebra/ComoduleCat.lean
+++ b/TauCeti/Algebra/Coalgebra/ComoduleCat.lean
@@ -292,14 +292,12 @@ theorem comp_smul {M N P : ComoduleCat.{u, v, w} R C} (r : R) (f : M ⟶ N) (g :
   rfl
 
 /-- Composing the zero morphism on the left gives the zero morphism. -/
-@[simp]
 theorem zero_comp {M N P : ComoduleCat.{u, v, w} R C} (f : N ⟶ P) :
     (0 : M ⟶ N) ≫ f = 0 := by
   ext m
   exact map_zero f.toLinearMap
 
 /-- Composing the zero morphism on the right gives the zero morphism. -/
-@[simp]
 theorem comp_zero {M N P : ComoduleCat.{u, v, w} R C} (f : M ⟶ N) :
     f ≫ (0 : N ⟶ P) = 0 := by
   ext m

--- a/TauCeti/Algebra/Coalgebra/Subcoalgebra.lean
+++ b/TauCeti/Algebra/Coalgebra/Subcoalgebra.lean
@@ -86,7 +86,6 @@ instance : PartialOrder (Subcoalgebra R C) :=
 theorem mem_carrier {D : Subcoalgebra R C} {c : C} : c ∈ D.carrier ↔ c ∈ D :=
   Iff.rfl
 
-@[simp]
 theorem mem_toSubmodule {D : Subcoalgebra R C} {c : C} : c ∈ D.toSubmodule ↔ c ∈ D :=
   Iff.rfl
 

--- a/TauCeti/Algebra/Coalgebra/Subcomodule.lean
+++ b/TauCeti/Algebra/Coalgebra/Subcomodule.lean
@@ -94,7 +94,6 @@ instance : PartialOrder (Subcomodule R C M) :=
 theorem mem_carrier {N : Subcomodule R C M} {m : M} : m ∈ N.carrier ↔ m ∈ N :=
   Iff.rfl
 
-@[simp]
 theorem mem_toSubmodule {N : Subcomodule R C M} {m : M} : m ∈ N.toSubmodule ↔ m ∈ N :=
   Iff.rfl
 

--- a/TauCeti/Algebra/Group/FreeAbelianCharacter.lean
+++ b/TauCeti/Algebra/Group/FreeAbelianCharacter.lean
@@ -78,7 +78,6 @@ theorem freeAbelianCharEquiv_apply (χ : Multiplicative (σ →₀ ℤ) →* M) 
 
 /-- The inverse of `freeAbelianCharEquiv` sends the standard generator indexed by `i` to the
 chosen coordinate `c i`. -/
-@[simp]
 theorem freeAbelianCharEquiv_symm_apply_ofAdd_single (c : σ → M) (i : σ) :
     (freeAbelianCharEquiv (M := M)).symm c (Multiplicative.ofAdd (Finsupp.single i 1)) = c i := by
   simp [freeAbelianCharEquiv]

--- a/TauCeti/Algebra/Group/NormalizerQuotient.lean
+++ b/TauCeti/Algebra/Group/NormalizerQuotient.lean
@@ -76,7 +76,6 @@ lemma normalizerQuotientMk_eq_one_iff (H : Subgroup G)
 
 /-- The kernel of the quotient map `N(H) →* N(H) / H` is the copy of `H` inside its
 normalizer. -/
-@[simp]
 lemma normalizerQuotientMk_ker (H : Subgroup G) :
     (normalizerQuotientMk H).ker =
       H.subgroupOf (_root_.Subgroup.normalizer (H : Set G)) := by
@@ -90,7 +89,6 @@ lemma normalizerQuotientMk_surjective (H : Subgroup G) :
     (H.subgroupOf (_root_.Subgroup.normalizer (H : Set G)))
 
 /-- The canonical map `N(H) →* N(H) / H` has full range. -/
-@[simp]
 lemma normalizerQuotientMk_range (H : Subgroup G) :
     (normalizerQuotientMk H).range = ⊤ :=
   QuotientGroup.range_mk'

--- a/TauCeti/Algebra/HopfAlgebra.lean
+++ b/TauCeti/Algebra/HopfAlgebra.lean
@@ -73,7 +73,6 @@ lemma baseChange_antipode_tmul {k K A : Type*} [CommSemiring k] [CommSemiring K]
 /-- The antipode is a left convolution inverse of the identity in the convolution ring of
 linear maps: `S * id = 1`. This is a restatement of the antipode axiom
 `HopfAlgebra.mul_antipode_rTensor_comul`. -/
-@[simp]
 lemma antipode_convMul_id :
     (toConv (antipode R) : WithConv (H →ₗ[R] H)) * toConv LinearMap.id = 1 := by
   refine WithConv.ext ?_
@@ -85,7 +84,6 @@ lemma antipode_convMul_id :
 /-- The antipode is a right convolution inverse of the identity in the convolution ring of
 linear maps: `id * S = 1`. This is a restatement of the antipode axiom
 `HopfAlgebra.mul_antipode_lTensor_comul`. -/
-@[simp]
 lemma id_convMul_antipode :
     (toConv LinearMap.id : WithConv (H →ₗ[R] H)) * toConv (antipode R) = 1 := by
   refine WithConv.ext ?_
@@ -202,7 +200,6 @@ theorem toLinearMap_comp_antipode (φ : A →ₐc[R] B) :
   exact WithConv.toConv_injective h_eq
 
 /-- A bialgebra morphism between Hopf algebras commutes with the antipodes, pointwise. -/
-@[simp]
 theorem map_antipode (φ : A →ₐc[R] B) (a : A) :
     φ (HopfAlgebra.antipode R a) = HopfAlgebra.antipode R (φ a) :=
   LinearMap.congr_fun (toLinearMap_comp_antipode φ) a

--- a/TauCeti/Algebra/HopfAlgebra/HopfIdeal.lean
+++ b/TauCeti/Algebra/HopfAlgebra/HopfIdeal.lean
@@ -287,7 +287,6 @@ instance (I : HopfIdeal R H) : I.toIdeal.IsTwoSided :=
 theorem mem_carrier {I : HopfIdeal R H} {x : H} : x ∈ I.carrier ↔ x ∈ I :=
   Iff.rfl
 
-@[simp]
 theorem mem_toIdeal {I : HopfIdeal R H} {x : H} : x ∈ I.toIdeal ↔ x ∈ I :=
   Iff.rfl
 


### PR DESCRIPTION
This PR removes the `@[simp]` attribute from 54 lemmas under `TauCeti/Algebra/` that were flagged by the simp normal-form linter: simp can prove these from existing simp lemmas, so the attribute contributes nothing to the simp set. Every finding was re-verified against current `main` by running the `simpNF` linter on the flagged declarations before editing. The lemmas themselves are kept; only the attribute is dropped (each was a bare `@[simp]`). The full build passes with no downstream proof needing repair, so none of these were load-bearing.

Affected declarations (all in the `TauCeti` namespace):

- `TauCeti/Algebra/AlgebraicGroup/AdditiveGroup.lean`: `AdditiveGroup.toAdd_gaPointsMulEquiv_inv`, `AdditiveGroup.toAdd_gaPointsMulEquiv_mapValue`, `AdditiveGroup.toAdd_pointsMulEquiv_apply`, `AdditiveGroup.toAdd_pointsMulEquiv_inv`
- `TauCeti/Algebra/AlgebraicGroup/AdditiveGroupBaseChange.lean`: `AdditiveGroup.baseChangePointsMulEquiv_symm_apply_ι`, `AdditiveGroup.toAdd_gaBaseChangePointsMulEquiv_mapValue`
- `TauCeti/Algebra/AlgebraicGroup/CommHopfAlgCat.lean`: `CommHopfAlgCat.mapPointsFunctor_app_apply_apply`
- `TauCeti/Algebra/AlgebraicGroup/DiagonalizableGroup.lean`: `DiagonalizableGroup.point_single_one`
- `TauCeti/Algebra/AlgebraicGroup/DiagonalizableGroupBaseChange.lean`: `DiagonalizableGroup.baseChangePointsMulEquiv_symm_apply_single_one`
- `TauCeti/Algebra/AlgebraicGroup/DiagonalizableGroupFunctoriality.lean`: `DiagonalizableGroup.pointsMulEquiv_pointsMap`
- `TauCeti/Algebra/AlgebraicGroup/HopfIdealQuotient.lean`: `CommHopfAlgCat.hom_liftQuotient`, `CommHopfAlgCat.hom_mkQuotient`
- `TauCeti/Algebra/AlgebraicGroup/MultiplicativeGroup.lean`: `MultiplicativeGroup.mapValue_pointsMulEquiv_symm_apply`, `MultiplicativeGroup.pointEquiv_comp`, `MultiplicativeGroup.pointsMulEquiv_mapValue`, `MultiplicativeGroup.unitOfPoint_mapValue`
- `TauCeti/Algebra/AlgebraicGroup/MultiplicativeGroupBaseChange.lean`: `MultiplicativeGroup.baseChangePointsMulEquiv_symm_apply_T`
- `TauCeti/Algebra/AlgebraicGroup/Product.lean`: `AffineGroup.Product.mapValue_pointsMulEquiv_symm_apply_tmul`
- `TauCeti/Algebra/AlgebraicGroup/RootsOfUnity.lean`: `RootsOfUnityGroup.mapValue_pointsMulEquiv_symm_apply_single_zmod_val`, `RootsOfUnityGroup.mapValue_pointsMulEquiv_symm_apply_single_zmod_val_smul`, `RootsOfUnityGroup.pointsMulEquiv_symm_apply_single_generator`, `RootsOfUnityGroup.pointsMulEquiv_symm_apply_single_ofAdd_val`, `RootsOfUnityGroup.pointsMulEquiv_symm_apply_single_ofAdd_val_smul`, `RootsOfUnityGroup.pointsMulEquiv_symm_apply_single_zmod_val`
- `TauCeti/Algebra/AlgebraicGroup/RootsOfUnityBaseChange.lean`: `RootsOfUnityGroup.baseChangePointsMulEquiv_symm_apply_single_generator`
- `TauCeti/Algebra/AlgebraicGroup/SplitTorus.lean`: `SplitTorus.pointsMulEquiv_symm_apply_single`
- `TauCeti/Algebra/AlgebraicGroup/SplitTorusBaseChange.lean`: `SplitTorus.baseChangePointsMulEquiv_symm_apply_single_one`
- `TauCeti/Algebra/AlgebraicGroup/Trivial.lean`: `TrivialGroup.convInv_apply`, `TrivialGroup.convPoint_apply`, `TrivialGroup.mapValue_pointsMulEquiv_symm_apply`
- `TauCeti/Algebra/AlgebraicGroup/TrivialBaseChange.lean`: `TrivialGroup.baseChangePointsMulEquiv_mapValue`, `TrivialGroup.baseChangePointsMulEquiv_symm_apply_one_tmul`, `TrivialGroup.baseChangePointsMulEquiv_symm_apply_tmul`, `TrivialGroup.convInv_apply_tmul`, `TrivialGroup.mapValue_baseChangePointsMulEquiv_symm_apply_tmul`
- `TauCeti/Algebra/Coalgebra/Comodule/MatrixCoefficient.lean`: `Comodule.matrixCoefficient_trivial`
- `TauCeti/Algebra/Coalgebra/Comodule/MatrixCoefficientRegular.lean`: `Comodule.regularObj_matrixCoefficientSet_eq_univ`, `Comodule.regularObj_matrixCoefficientSubalgebra_eq_top`, `Comodule.regularObj_matrixCoefficientSubmodule_eq_top`
- `TauCeti/Algebra/Coalgebra/Comodule/MatrixCoefficientTrivial.lean`: `Comodule.trivial_rankOne_matrixCoefficientSubmodule_eq_span_singleton_one`
- `TauCeti/Algebra/Coalgebra/Comodule/Product.lean`: `Comodule.prodCoact_inl`, `Comodule.prodCoact_inr`
- `TauCeti/Algebra/Coalgebra/Comodule/Regular.lean`: `ComoduleCat.trivialToRegular_apply`
- `TauCeti/Algebra/Coalgebra/ComoduleCat.lean`: `ComoduleCat.comp_zero`, `ComoduleCat.zero_comp`
- `TauCeti/Algebra/Coalgebra/Subcoalgebra.lean`: `Subcoalgebra.mem_toSubmodule`
- `TauCeti/Algebra/Coalgebra/Subcomodule.lean`: `Subcomodule.mem_toSubmodule`
- `TauCeti/Algebra/Group/FreeAbelianCharacter.lean`: `freeAbelianCharEquiv_symm_apply_ofAdd_single`
- `TauCeti/Algebra/Group/NormalizerQuotient.lean`: `Subgroup.normalizerQuotientMk_ker`, `Subgroup.normalizerQuotientMk_range`
- `TauCeti/Algebra/HopfAlgebra.lean`: `BialgHom.map_antipode`, `HopfAlgebra.antipode_convMul_id`, `HopfAlgebra.id_convMul_antipode`
- `TauCeti/Algebra/HopfAlgebra/HopfIdeal.lean`: `HopfIdeal.mem_toIdeal`

🤖 Prepared with Claude Code