### PR TITLE
chore(KnotTheory): drop simp attributes that simp can already prove

### DIFF
--- a/TauCeti/KnotTheory/Grid/ChainCardinality.lean
+++ b/TauCeti/KnotTheory/Grid/ChainCardinality.lean
@@ -47,7 +47,6 @@ namespace GridChain
 /-- The number of chains over a finite coefficient type is `#R ^ n!`.
 
 This is the exact size of the finite search space for the ambient free module on grid states. -/
-@[simp]
 theorem card (R : Type*) [Zero R] [Fintype R] (n : ℕ) :
     Fintype.card (GridChain R n) = Fintype.card R ^ n.factorial := by
   rw [Fintype.card_finsupp, GridState.card]
@@ -70,14 +69,12 @@ theorem support_card_le_factorial {R : Type*} [Zero R] {n : ℕ} (c : GridChain 
   exact Finset.card_le_univ c.support
 
 /-- The fully blocked `ZMod 2` chain module has `2 ^ n!` elements. -/
-@[simp]
 theorem card_zmod_two (n : ℕ) :
     Fintype.card (GridChain (ZMod 2) n) = 2 ^ n.factorial := by
   rw [card]
   rw [ZMod.card]
 
 /-- The natural cardinality of the fully blocked `ZMod 2` chain module is `2 ^ n!`. -/
-@[simp]
 theorem natCard_zmod_two (n : ℕ) :
     Nat.card (GridChain (ZMod 2) n) = 2 ^ n.factorial := by
   rw [natCard, Nat.card_eq_fintype_card, ZMod.card]

--- a/TauCeti/KnotTheory/Grid/Commutation.lean
+++ b/TauCeti/KnotTheory/Grid/Commutation.lean
@@ -69,12 +69,10 @@ theorem mem_columnArc (c r : Fin n) : r ∈ columnArc G c ↔ r ∈ Grid.cIoo (G
   Iff.rfl
 
 /-- The `O` endpoint of a column is not in its own open column arc. -/
-@[simp]
 theorem O_notMem_columnArc (c : Fin n) : G.O c ∉ columnArc G c := by
   simp [columnArc]
 
 /-- The `X` endpoint of a column is not in its own open column arc. -/
-@[simp]
 theorem X_notMem_columnArc (c : Fin n) : G.X c ∉ columnArc G c := by
   simp [columnArc]
 
@@ -93,12 +91,10 @@ theorem mem_rowArc (r c : Fin n) :
   Iff.rfl
 
 /-- The `O` endpoint of a row is not in its own open row arc. -/
-@[simp]
 theorem OColumn_notMem_rowArc (r : Fin n) : OColumnOfRow G r ∉ rowArc G r := by
   simp [rowArc]
 
 /-- The `X` endpoint of a row is not in its own open row arc. -/
-@[simp]
 theorem XColumn_notMem_rowArc (r : Fin n) : XColumnOfRow G r ∉ rowArc G r := by
   simp [rowArc]
 

--- a/TauCeti/KnotTheory/Grid/CommutationRelabeling.lean
+++ b/TauCeti/KnotTheory/Grid/CommutationRelabeling.lean
@@ -58,7 +58,6 @@ theorem columnArc_relabelColumns (κ : Equiv.Perm (Fin n)) (c : Fin n) :
 
 /-- Membership in a column arc after column relabeling is membership in the old arc with the
 inverse column label. -/
-@[simp]
 theorem mem_columnArc_relabelColumns (κ : Equiv.Perm (Fin n)) (c r : Fin n) :
     r ∈ columnArc (G.relabelColumns κ) c ↔ r ∈ columnArc G (κ.symm c) := by
   rw [columnArc_relabelColumns]
@@ -71,7 +70,6 @@ theorem columnArc_swapColumns (a b c : Fin n) :
 
 /-- Membership in a column arc after a column swap is membership in the old arc with the swapped
 column label. -/
-@[simp]
 theorem mem_columnArc_swapColumns (a b c r : Fin n) :
     r ∈ columnArc (G.swapColumns a b) c ↔ r ∈ columnArc G (Equiv.swap a b c) := by
   rw [columnArc_swapColumns]
@@ -98,7 +96,6 @@ theorem rowArc_relabelRows (ρ : Equiv.Perm (Fin n)) (r : Fin n) :
 
 /-- Membership in a row arc after row relabeling is membership in the old arc with the inverse
 row label. -/
-@[simp]
 theorem mem_rowArc_relabelRows (ρ : Equiv.Perm (Fin n)) (r c : Fin n) :
     c ∈ rowArc (G.relabelRows ρ) r ↔ c ∈ rowArc G (ρ.symm r) := by
   rw [rowArc_relabelRows]
@@ -111,7 +108,6 @@ theorem rowArc_swapRows (a b r : Fin n) :
 
 /-- Membership in a row arc after a row swap is membership in the old arc with the swapped row
 label. -/
-@[simp]
 theorem mem_rowArc_swapRows (a b r c : Fin n) :
     c ∈ rowArc (G.swapRows a b) r ↔ c ∈ rowArc G (Equiv.swap a b r) := by
   rw [rowArc_swapRows]

--- a/TauCeti/KnotTheory/Grid/Complex.lean
+++ b/TauCeti/KnotTheory/Grid/Complex.lean
@@ -208,7 +208,6 @@ theorem fullyBlockedDifferential_single (x : GridState n) :
 
 /-- The matrix coefficient of the fully blocked differential on a single generator is the fully
 blocked rectangle count. -/
-@[simp]
 theorem fullyBlockedDifferential_single_apply (x y : GridState n) :
     G.fullyBlockedDifferential (Finsupp.single x 1) y =
       G.fullyBlockedRectangleCount x y := by

--- a/TauCeti/KnotTheory/Grid/CyclicInterval.lean
+++ b/TauCeti/KnotTheory/Grid/CyclicInterval.lean
@@ -90,7 +90,6 @@ theorem cIoo_self (a : Fin n) : cIoo a a = ∅ := by
   simp
 
 /-- The initial endpoint is not in its open cyclic interval. -/
-@[simp]
 theorem left_notMem_cIoo (a b : Fin n) : a ∉ cIoo a b := by
   intro ha
   rw [mem_cIoo] at ha
@@ -105,7 +104,6 @@ theorem left_notMem_cIoo (a b : Fin n) : a ∉ cIoo a b := by
     | inr hlt => exact hab hlt
 
 /-- The terminal endpoint is not in its open cyclic interval. -/
-@[simp]
 theorem right_notMem_cIoo (a b : Fin n) : b ∉ cIoo a b := by
   intro hb
   rw [mem_cIoo] at hb

--- a/TauCeti/KnotTheory/Grid/Diagram.lean
+++ b/TauCeti/KnotTheory/Grid/Diagram.lean
@@ -123,7 +123,6 @@ theorem mem_pointSet (x : GridState n) (p : Fin n × Fin n) :
     exact Finset.mem_image.mpr ⟨p.1, Finset.mem_univ _, by ext <;> simp [hp]⟩
 
 /-- The square `(c, r)` lies in a grid state's point set exactly when `x c = r`. -/
-@[simp]
 theorem mk_mem_pointSet (x : GridState n) (c r : Fin n) :
     (c, r) ∈ x.pointSet ↔ x c = r := by
   simp
@@ -155,12 +154,10 @@ def columnOfRow (x : GridState n) (r : Fin n) : Fin n :=
   x.toPerm.symm r
 
 /-- The point in row `r` lies in column `columnOfRow x r`. -/
-@[simp]
 theorem apply_columnOfRow (x : GridState n) (r : Fin n) : x (x.columnOfRow r) = r := by
   simp [columnOfRow]
 
 /-- The column containing the point in row `x c` is `c`. -/
-@[simp]
 theorem columnOfRow_apply (x : GridState n) (c : Fin n) : x.columnOfRow (x c) = c := by
   simp [columnOfRow]
 
@@ -177,7 +174,6 @@ theorem pointSet_inj {x y : GridState n} : x.pointSet = y.pointSet ↔ x = y := 
 
 /-- A square lies in both state point sets exactly when both state permutations send its
 column to its row. -/
-@[simp]
 theorem mem_pointSet_inter (x y : GridState n) (p : Fin n × Fin n) :
     p ∈ x.pointSet ∩ y.pointSet ↔ x p.1 = p.2 ∧ y p.1 = p.2 := by
   simp
@@ -283,7 +279,6 @@ theorem mem_pointSet_relabelRows (ρ : Equiv.Perm (Fin n)) (x : GridState n)
     simp
 
 /-- Membership in the point set after a column relabeling. -/
-@[simp]
 theorem mem_pointSet_relabelColumns (κ : Equiv.Perm (Fin n)) (x : GridState n)
     (p : Fin n × Fin n) :
     p ∈ (x.relabelColumns κ).pointSet ↔ (κ.symm p.1, p.2) ∈ x.pointSet := by
@@ -460,7 +455,6 @@ theorem mem_pointSet_swapRows (a b : Fin n) (x : GridState n) (p : Fin n × Fin 
   simpa [swapRows] using GridState.mem_pointSet_relabelRows (Equiv.swap a b) x p
 
 /-- Column swaps transport the point set by the column transposition. -/
-@[simp]
 theorem mem_pointSet_swapColumns (a b : Fin n) (x : GridState n) (p : Fin n × Fin n) :
     p ∈ (x.swapColumns a b).pointSet ↔ (Equiv.swap a b p.1, p.2) ∈ x.pointSet := by
   simp [swapColumns]
@@ -614,7 +608,6 @@ theorem transpose_apply (x : GridState n) (c : Fin n) : x.transpose c = x.toPerm
 theorem columnOfRow_eq_transpose (x : GridState n) (r : Fin n) :
     x.columnOfRow r = x.transpose r := rfl
 /-- The column in row `r` of the reflected state is the original row-coordinate value at `r`. -/
-@[simp]
 theorem columnOfRow_transpose (x : GridState n) (r : Fin n) : x.transpose.columnOfRow r = x r := by
   simp [columnOfRow, transpose]
 /-- The diagonal reflection is an involution on grid states. -/
@@ -716,12 +709,10 @@ theorem mem_XSet (p : Fin n × Fin n) : p ∈ G.XSet ↔ G.X p.1 = p.2 := by
   simp [XSet]
 
 /-- The square `(c, r)` contains an `O` marking exactly when `G.O c = r`. -/
-@[simp]
 theorem mk_mem_OSet (c r : Fin n) : (c, r) ∈ G.OSet ↔ G.O c = r := by
   simp [OSet]
 
 /-- The square `(c, r)` contains an `X` marking exactly when `G.X c = r`. -/
-@[simp]
 theorem mk_mem_XSet (c r : Fin n) : (c, r) ∈ G.XSet ↔ G.X c = r := by
   simp [XSet]
 
@@ -886,13 +877,11 @@ theorem mem_XSet_relabelRows (ρ : Equiv.Perm (Fin n)) (p : Fin n × Fin n) :
   exact GridState.mem_pointSet_relabelRows ρ G.X p
 
 /-- Column relabeling transports the `O` marking set by the column permutation. -/
-@[simp]
 theorem mem_OSet_relabelColumns (κ : Equiv.Perm (Fin n)) (p : Fin n × Fin n) :
     p ∈ (G.relabelColumns κ).OSet ↔ (κ.symm p.1, p.2) ∈ G.OSet := by
   simp [OSet]
 
 /-- Column relabeling transports the `X` marking set by the column permutation. -/
-@[simp]
 theorem mem_XSet_relabelColumns (κ : Equiv.Perm (Fin n)) (p : Fin n × Fin n) :
     p ∈ (G.relabelColumns κ).XSet ↔ (κ.symm p.1, p.2) ∈ G.XSet := by
   simp [XSet]
@@ -942,13 +931,11 @@ theorem mem_XSet_swapRows (a b : Fin n) (p : Fin n × Fin n) :
   simpa [swapRows] using G.mem_XSet_relabelRows (Equiv.swap a b) p
 
 /-- Column swaps transport the `O` marking set by the column transposition. -/
-@[simp]
 theorem mem_OSet_swapColumns (a b : Fin n) (p : Fin n × Fin n) :
     p ∈ (G.swapColumns a b).OSet ↔ (Equiv.swap a b p.1, p.2) ∈ G.OSet := by
   simp [swapColumns]
 
 /-- Column swaps transport the `X` marking set by the column transposition. -/
-@[simp]
 theorem mem_XSet_swapColumns (a b : Fin n) (p : Fin n × Fin n) :
     p ∈ (G.swapColumns a b).XSet ↔ (Equiv.swap a b p.1, p.2) ∈ G.XSet := by
   simp [swapColumns]
@@ -1117,13 +1104,11 @@ theorem swapMarkings_XSet : G.swapMarkings.XSet = G.OSet := rfl
 
 /-- Membership in the marking swap's `O`-marking set is membership in the original
 `X`-marking set. -/
-@[simp]
 theorem mem_OSet_swapMarkings (p : Fin n × Fin n) :
     p ∈ G.swapMarkings.OSet ↔ p ∈ G.XSet := Iff.rfl
 
 /-- Membership in the marking swap's `X`-marking set is membership in the original
 `O`-marking set. -/
-@[simp]
 theorem mem_XSet_swapMarkings (p : Fin n × Fin n) :
     p ∈ G.swapMarkings.XSet ↔ p ∈ G.OSet := Iff.rfl
 

--- a/TauCeti/KnotTheory/Grid/DiagramRelabeling.lean
+++ b/TauCeti/KnotTheory/Grid/DiagramRelabeling.lean
@@ -36,7 +36,6 @@ variable {n : ℕ} (x : GridState n)
 
 /-- Row relabeling moves the column containing a given row by reading the old state at the
 inverse row label. -/
-@[simp]
 theorem columnOfRow_relabelRows (ρ : Equiv.Perm (Fin n)) (r : Fin n) :
     (x.relabelRows ρ).columnOfRow r = x.columnOfRow (ρ.symm r) := by
   apply (x.relabelRows ρ).toPerm.injective
@@ -44,7 +43,6 @@ theorem columnOfRow_relabelRows (ρ : Equiv.Perm (Fin n)) (r : Fin n) :
 
 /-- Column relabeling moves the column containing a given row by applying the column permutation
 to the old column. -/
-@[simp]
 theorem columnOfRow_relabelColumns (κ : Equiv.Perm (Fin n)) (r : Fin n) :
     (x.relabelColumns κ).columnOfRow r = κ (x.columnOfRow r) := by
   apply (x.relabelColumns κ).toPerm.injective
@@ -52,14 +50,12 @@ theorem columnOfRow_relabelColumns (κ : Equiv.Perm (Fin n)) (r : Fin n) :
 
 /-- After swapping rows, the column containing row `r` is the old column containing the swapped
 row label. -/
-@[simp]
 theorem columnOfRow_swapRows (a b r : Fin n) :
     (x.swapRows a b).columnOfRow r = x.columnOfRow (Equiv.swap a b r) := by
   simp [swapRows]
 
 /-- After swapping columns, the column containing row `r` is the swap of the old column
 containing that row. -/
-@[simp]
 theorem columnOfRow_swapColumns (a b r : Fin n) :
     (x.swapColumns a b).columnOfRow r = Equiv.swap a b (x.columnOfRow r) := by
   simp [swapColumns]

--- a/TauCeti/KnotTheory/Grid/JFunction.lean
+++ b/TauCeti/KnotTheory/Grid/JFunction.lean
@@ -82,7 +82,6 @@ theorem isSouthWest_iff (p q : Fin n × Fin n) :
   Iff.rfl
 
 /-- A point is not strictly southwest of itself. -/
-@[simp]
 theorem not_isSouthWest_self (p : Fin n × Fin n) : ¬ IsSouthWest p p := by
   intro h
   exact (lt_self_iff_false p.1.val).mp h.1
@@ -140,7 +139,6 @@ theorem I_singleton_singleton (p q : Fin n × Fin n) :
   · simp only [h, if_false, Finset.card_empty]
 
 /-- No point contributes a southwest pair with itself. -/
-@[simp]
 theorem I_singleton_self (p : Fin n × Fin n) : I {p} {p} = 0 := by
   simp
 
@@ -391,7 +389,6 @@ theorem J_singleton_singleton_of_isSouthWest_or_isSouthWest {p q : Fin n × Fin 
     simp [J_singleton_singleton, hpqfin, hqpcoord]
 
 /-- The `J`-function of a singleton with itself is zero. -/
-@[simp]
 theorem J_singleton_self (p : Fin n × Fin n) : GridPoint.J {p} {p} = 0 := by
   simp [GridPoint.J]
 

--- a/TauCeti/KnotTheory/Grid/Rectangle.lean
+++ b/TauCeti/KnotTheory/Grid/Rectangle.lean
@@ -140,22 +140,18 @@ theorem mem_rowInterior (r : Fin n) :
   rfl
 
 /-- The left side is not an interior column. -/
-@[simp]
 theorem left_notMem_columnInterior : R.left ∉ R.columnInterior := by
   simp [columnInterior]
 
 /-- The right side is not an interior column. -/
-@[simp]
 theorem right_notMem_columnInterior : R.right ∉ R.columnInterior := by
   simp [columnInterior]
 
 /-- The bottom side is not an interior row. -/
-@[simp]
 theorem bottom_notMem_rowInterior : R.bottom ∉ R.rowInterior := by
   simp [rowInterior]
 
 /-- The top side is not an interior row. -/
-@[simp]
 theorem top_notMem_rowInterior : R.top ∉ R.rowInterior := by
   simp [rowInterior]
 
@@ -171,7 +167,6 @@ theorem mem_interior (p : Fin n × Fin n) :
 
 /-- A coordinate pair lies in the rectangle interior exactly when its column and row lie in
 the corresponding open cyclic intervals. -/
-@[simp]
 theorem mk_mem_interior (c r : Fin n) :
     (c, r) ∈ R.interior ↔ c ∈ R.columnInterior ∧ r ∈ R.rowInterior := by
   simp

--- a/TauCeti/KnotTheory/Grid/StateCardinality.lean
+++ b/TauCeti/KnotTheory/Grid/StateCardinality.lean
@@ -50,12 +50,10 @@ theorem card (n : ℕ) : Fintype.card (GridState n) = n.factorial := by
   rw [Fintype.card_congr (equivPerm n), Fintype.card_perm, Fintype.card_fin]
 
 /-- The universe finite set of grid states has cardinality `n!`. -/
-@[simp]
 theorem card_univ (n : ℕ) : (Finset.univ : Finset (GridState n)).card = n.factorial := by
   rw [Finset.card_univ, card]
 
 /-- The natural cardinality of grid states is `n!`. -/
-@[simp]
 theorem natCard (n : ℕ) : Nat.card (GridState n) = n.factorial := by
   rw [Nat.card_eq_fintype_card, card]
 


### PR DESCRIPTION
This PR removes the `@[simp]` attribute from 43 lemmas under `TauCeti/KnotTheory/` that were flagged by the simp normal-form linter: simp can prove these from existing simp lemmas, so the attribute contributes nothing to the simp set. Every finding was re-verified against current `main` by running the `simpNF` linter on the flagged declarations before editing. The lemmas themselves are kept; only the attribute is dropped (each was a bare `@[simp]`). The full build passes with no downstream proof needing repair, so none of these were load-bearing.

Affected declarations (all in the `TauCeti` namespace):

- `TauCeti/KnotTheory/Grid/ChainCardinality.lean`: `GridChain.card`, `GridChain.card_zmod_two`, `GridChain.natCard_zmod_two`
- `TauCeti/KnotTheory/Grid/Commutation.lean`: `GridDiagram.OColumn_notMem_rowArc`, `GridDiagram.O_notMem_columnArc`, `GridDiagram.XColumn_notMem_rowArc`, `GridDiagram.X_notMem_columnArc`
- `TauCeti/KnotTheory/Grid/CommutationRelabeling.lean`: `GridDiagram.mem_columnArc_relabelColumns`, `GridDiagram.mem_columnArc_swapColumns`, `GridDiagram.mem_rowArc_relabelRows`, `GridDiagram.mem_rowArc_swapRows`
- `TauCeti/KnotTheory/Grid/Complex.lean`: `GridDiagram.fullyBlockedDifferential_single_apply`
- `TauCeti/KnotTheory/Grid/CyclicInterval.lean`: `Grid.left_notMem_cIoo`, `Grid.right_notMem_cIoo`
- `TauCeti/KnotTheory/Grid/Diagram.lean`: `GridDiagram.mem_OSet_relabelColumns`, `GridDiagram.mem_OSet_swapColumns`, `GridDiagram.mem_OSet_swapMarkings`, `GridDiagram.mem_XSet_relabelColumns`, `GridDiagram.mem_XSet_swapColumns`, `GridDiagram.mem_XSet_swapMarkings`, `GridDiagram.mk_mem_OSet`, `GridDiagram.mk_mem_XSet`, `GridState.apply_columnOfRow`, `GridState.columnOfRow_apply`, `GridState.columnOfRow_transpose`, `GridState.mem_pointSet_inter`, `GridState.mem_pointSet_relabelColumns`, `GridState.mem_pointSet_swapColumns`, `GridState.mk_mem_pointSet`
- `TauCeti/KnotTheory/Grid/DiagramRelabeling.lean`: `GridState.columnOfRow_relabelColumns`, `GridState.columnOfRow_relabelRows`, `GridState.columnOfRow_swapColumns`, `GridState.columnOfRow_swapRows`
- `TauCeti/KnotTheory/Grid/JFunction.lean`: `GridPoint.I_singleton_self`, `GridPoint.J_singleton_self`, `GridPoint.not_isSouthWest_self`
- `TauCeti/KnotTheory/Grid/Rectangle.lean`: `GridRectangle.bottom_notMem_rowInterior`, `GridRectangle.left_notMem_columnInterior`, `GridRectangle.mk_mem_interior`, `GridRectangle.right_notMem_columnInterior`, `GridRectangle.top_notMem_rowInterior`
- `TauCeti/KnotTheory/Grid/StateCardinality.lean`: `GridState.card_univ`, `GridState.natCard`

🤖 Prepared with Claude Code