### PR TITLE
chore(Analysis): drop simp attributes that simp can already prove

### DIFF
--- a/TauCeti/Analysis/CompletelyMonotone/BernsteinMeasures.lean
+++ b/TauCeti/Analysis/CompletelyMonotone/BernsteinMeasures.lean
@@ -150,7 +150,7 @@ lemma chafaiDensity_nonneg {n : ℕ} {t : ℝ} (ht : 0 ≤ t)
       _ ≥ 0 := mul_nonneg (div_nonneg (pow_nonneg ht _) hfact_pos.le) hsign
 
 /-- For `n = 1`, the density simplifies to `-f'(t)`. -/
-@[simp] lemma chafaiDensity_one (t : ℝ) :
+lemma chafaiDensity_one (t : ℝ) :
     chafaiDensity f 1 t = -iteratedDerivWithin 1 f (Ici 0) t := by
   simp [chafaiDensity]
 
@@ -382,7 +382,6 @@ lemma ae_nonneg_bernsteinKernel_chafaiRescaled (f : ℝ → ℝ) (n : ℕ) (x : 
 
 /-- Bundled version of `ae_nonneg_bernsteinKernel_chafaiRescaled` for the bounded-continuous
 Bernstein kernel. -/
-@[simp]
 lemma ae_nonneg_bernsteinKernelBoundedContinuous_chafaiRescaled
     (f : ℝ → ℝ) (n : ℕ) {x : ℝ} (hx : 0 ≤ x) :
     0 ≤ᵐ[chafaiRescaled f n] fun p : ℝ≥0 => bernsteinKernelBoundedContinuous n hx p := by
@@ -421,7 +420,6 @@ lemma chafaiMeasure_compl_Ioi (f : ℝ → ℝ) (n : ℕ) :
   rw [this, measure_empty]
 
 /-- Pushforward preserves total mass. -/
-@[simp]
 lemma chafaiRescaled_mass_eq (f : ℝ → ℝ) (n : ℕ) :
     (chafaiRescaled f n) univ = (chafaiMeasure f n) univ := by
   unfold chafaiRescaled

--- a/TauCeti/Analysis/Complex/Conformal/Reflection.lean
+++ b/TauCeti/Analysis/Complex/Conformal/Reflection.lean
@@ -61,7 +61,6 @@ lemma schwarzReflection_of_im_neg {z : ℂ} (hz : z.im < 0) :
   simp [schwarzReflection, not_le.mpr hz]
 
 /-- On the real axis, Schwarz reflection agrees with the original function. -/
-@[simp]
 lemma schwarzReflection_of_im_zero {z : ℂ} (hz : z.im = 0) :
     schwarzReflection f z = f z := by
   exact schwarzReflection_of_im_nonneg (f := f) (z := z) hz.ge

--- a/TauCeti/Analysis/Complex/Conformal/UnitDiscAutomorphism.lean
+++ b/TauCeti/Analysis/Complex/Conformal/UnitDiscAutomorphism.lean
@@ -48,7 +48,7 @@ lemma unitDiscStandardAutomorphismEquiv_apply (u : Circle) (a z : Complex.UnitDi
   by simp [unitDiscStandardAutomorphismEquiv]
 
 /-- The scalar formula for the standard disc automorphism. -/
-@[simp, norm_cast]
+@[norm_cast]
 lemma coe_unitDiscStandardAutomorphismEquiv_apply (u : Circle) (a z : Complex.UnitDisc) :
     (unitDiscStandardAutomorphismEquiv u a z : ℂ) =
       (u : ℂ) *
@@ -79,7 +79,6 @@ lemma unitDiscStandardAutomorphismEquiv_self (u : Circle) (a : Complex.UnitDisc)
   simp
 
 /-- The standard automorphism sends zero to `-u * a`. -/
-@[simp]
 lemma unitDiscStandardAutomorphismEquiv_apply_zero (u : Circle) (a : Complex.UnitDisc) :
     unitDiscStandardAutomorphismEquiv u a 0 = u • (-a) := by
   simp [unitDiscStandardAutomorphismEquiv]

--- a/TauCeti/Analysis/InnerProductSpace/HilbertBasisMap.lean
+++ b/TauCeti/Analysis/InnerProductSpace/HilbertBasisMap.lean
@@ -80,7 +80,6 @@ theorem _root_.HilbertBasis.mapₗᵢ_trans {G : Type*} [NormedAddCommGroup G] [
 
 /-- Transporting a Hilbert basis across an isometry and then back across the inverse isometry
 recovers the original basis. -/
-@[simp]
 theorem _root_.HilbertBasis.mapₗᵢ_symm
     (b : _root_.HilbertBasis ι 𝕜 E) (e : E ≃ₗᵢ[𝕜] F) :
     (b.mapₗᵢ e).mapₗᵢ e.symm = b := by
@@ -89,7 +88,6 @@ theorem _root_.HilbertBasis.mapₗᵢ_symm
 
 /-- Transporting a Hilbert basis back across an inverse isometry and then forward again recovers
 the original basis. -/
-@[simp]
 theorem _root_.HilbertBasis.mapₗᵢ_symm_self
     (b : _root_.HilbertBasis ι 𝕜 F) (e : E ≃ₗᵢ[𝕜] F) :
     (b.mapₗᵢ e.symm).mapₗᵢ e = b := by

--- a/TauCeti/Analysis/PDE/EnergyForm.lean
+++ b/TauCeti/Analysis/PDE/EnergyForm.lean
@@ -111,7 +111,6 @@ lemma energyIntegrand_self (A : Matrix n n ℝ) (b : EuclideanSpace ℝ n) (c : 
 
 /-- The Laplacian model `−Δ` (`a = 1`, no drift, no mass) has jet form the Dirichlet
 integrand `⟨∇u, ∇v⟩`. -/
-@[simp]
 lemma energyIntegrand_one_zero_zero_apply (U V : ℝ × EuclideanSpace ℝ n) :
     energyIntegrand (1 : Matrix n n ℝ) 0 0 U V = V.2 ⬝ᵥ U.2 := by
   simp [energyIntegrand_apply]
@@ -125,7 +124,6 @@ lemma energyIntegrand_one_zero_zero_self (U : ℝ × EuclideanSpace ℝ n) :
 
 /-- The shifted Laplacian model `-Δ + c` has jet form
 `(U, V) ↦ ∇u · ∇v + c u v`. -/
-@[simp]
 lemma energyIntegrand_one_zero_mass_apply (c : ℝ) (U V : ℝ × EuclideanSpace ℝ n) :
     energyIntegrand (1 : Matrix n n ℝ) 0 c U V = V.2 ⬝ᵥ U.2 + c * U.1 * V.1 := by
   simp [energyIntegrand_apply, massForm_apply]

--- a/TauCeti/Analysis/PDE/EnergyFormLinearity.lean
+++ b/TauCeti/Analysis/PDE/EnergyFormLinearity.lean
@@ -67,7 +67,6 @@ lemma energyIntegrand_add :
   ring_nf
 
 /-- Pointwise evaluation form of `energyIntegrand_add`. -/
-@[simp]
 lemma energyIntegrand_add_apply :
     energyIntegrand (A + B) (b + d) (c + e) U V =
       energyIntegrand A b c U V + energyIntegrand B d e U V := by
@@ -86,7 +85,6 @@ lemma energyIntegrand_neg :
   ring_nf
 
 /-- Pointwise evaluation form of `energyIntegrand_neg`. -/
-@[simp]
 lemma energyIntegrand_neg_apply :
     energyIntegrand (-A) (-b) (-c) U V = -energyIntegrand A b c U V := by
   simp
@@ -103,7 +101,6 @@ lemma energyIntegrand_sub :
   simp [sub_eq_add_neg]
 
 /-- Pointwise evaluation form of `energyIntegrand_sub`. -/
-@[simp]
 lemma energyIntegrand_sub_apply :
     energyIntegrand (A - B) (b - d) (c - e) U V =
       energyIntegrand A b c U V - energyIntegrand B d e U V := by
@@ -122,7 +119,6 @@ lemma energyIntegrand_smul :
   ring
 
 /-- Pointwise evaluation form of `energyIntegrand_smul`. -/
-@[simp]
 lemma energyIntegrand_smul_apply :
     energyIntegrand (r • A) (r • b) (r * c) U V = r * energyIntegrand A b c U V := by
   simp [smul_eq_mul]

--- a/TauCeti/Analysis/PDE/SymmetricEnergy.lean
+++ b/TauCeti/Analysis/PDE/SymmetricEnergy.lean
@@ -131,14 +131,12 @@ lemma energyIntegrand_zero_drift_comm_on {Ω : Set X} {a : X → Matrix n n ℝ}
 
 /-- A pointwise symmetric coefficient field gives a bundled symmetric zero-drift jet form at
 each point of the domain. -/
-@[simp]
 lemma energyIntegrand_zero_drift_flip_eq_on {Ω : Set X} {a : X → Matrix n n ℝ}
     (ha : ∀ ⦃x⦄, x ∈ Ω → (a x).IsSymm) {x : X} (hx : x ∈ Ω) (c : X → ℝ) :
     (energyIntegrand (a x) 0 (c x)).flip = energyIntegrand (a x) 0 (c x) :=
   energyIntegrand_zero_drift_flip_eq_of_isSymm (ha hx) (c x)
 
 /-- Bundled symmetry of the shifted Laplacian jet form. -/
-@[simp]
 lemma energyIntegrand_one_zero_mass_flip_eq (c : ℝ) :
     (energyIntegrand (1 : Matrix n n ℝ) 0 c).flip =
       energyIntegrand (1 : Matrix n n ℝ) 0 c :=

--- a/TauCeti/Analysis/PDE/UniformEllipticity.lean
+++ b/TauCeti/Analysis/PDE/UniformEllipticity.lean
@@ -115,7 +115,6 @@ lemma matrixBilinearForm_apply (A : Matrix n n ℝ) (η ξ : EuclideanSpace ℝ 
   rfl
 
 /-- The matrix bilinear form associated to the identity matrix is the Euclidean dot product. -/
-@[simp]
 lemma matrixBilinearForm_one_apply (η ξ : EuclideanSpace ℝ n) :
     matrixBilinearForm (1 : Matrix n n ℝ) η ξ = η ⬝ᵥ ξ := by
   rw [matrixBilinearForm_apply, one_mulVec]
@@ -129,7 +128,6 @@ lemma toQuadraticForm'_smul (c : ℝ) (A : Matrix n n ℝ) (ξ : EuclideanSpace 
   simp [smul_eq_mul]
 
 /-- The scalar identity matrix has quadratic form `c ‖ξ‖²`. -/
-@[simp]
 lemma toQuadraticForm'_smul_one (c : ℝ) (ξ : EuclideanSpace ℝ n) :
     (c • (1 : Matrix n n ℝ)).toQuadraticForm' ξ = c * ‖ξ‖ ^ 2 := by
   rw [toQuadraticForm'_smul, toQuadraticForm'_one]

--- a/TauCeti/Analysis/PositiveDefinite/FunctionClosure.lean
+++ b/TauCeti/Analysis/PositiveDefinite/FunctionClosure.lean
@@ -95,7 +95,6 @@ variable {N : Type*}
 
 /-- If each summand in a finite complex-weighted sum is normalized at a point, then the sum's
 value at that point is the sum of the weights. -/
-@[simp]
 theorem sum_smul_apply_of_apply_eq_one {ι : Type*} {s : Finset ι} {w : ι → ℂ}
     {F : ι → N → ℂ} {x : N} (hFx : ∀ i ∈ s, F i x = 1) :
     (∑ i ∈ s, w i • F i x) = ∑ i ∈ s, w i := by
@@ -105,7 +104,6 @@ theorem sum_smul_apply_of_apply_eq_one {ι : Type*} {s : Finset ι} {w : ι → 
 
 /-- A finite complex-weighted sum of functions normalized at a point is normalized at that point
 when the weights sum to `1`. -/
-@[simp]
 theorem sum_smul_apply_eq_one {ι : Type*} {s : Finset ι} {w : ι → ℂ}
     {F : ι → N → ℂ} {x : N} (hFx : ∀ i ∈ s, F i x = 1)
     (hw_sum : ∑ i ∈ s, w i = 1) :
@@ -115,7 +113,6 @@ theorem sum_smul_apply_eq_one {ι : Type*} {s : Finset ι} {w : ι → ℂ}
 
 /-- If each summand in a finite complex-weighted sum is normalized at a point, then the sum's
 multiplication-form value at that point is the sum of the weights. -/
-@[simp]
 theorem sum_const_mul_apply_of_apply_eq_one {ι : Type*} {s : Finset ι} {w : ι → ℂ}
     {F : ι → N → ℂ} {x : N} (hFx : ∀ i ∈ s, F i x = 1) :
     (∑ i ∈ s, w i * F i x) = ∑ i ∈ s, w i := by
@@ -124,7 +121,6 @@ theorem sum_const_mul_apply_of_apply_eq_one {ι : Type*} {s : Finset ι} {w : ι
 
 /-- A finite complex-weighted sum, in multiplication form, of functions normalized at a point is
 normalized at that point when the weights sum to `1`. -/
-@[simp]
 theorem sum_const_mul_apply_eq_one {ι : Type*} {s : Finset ι} {w : ι → ℂ}
     {F : ι → N → ℂ} {x : N} (hFx : ∀ i ∈ s, F i x = 1)
     (hw_sum : ∑ i ∈ s, w i = 1) :
@@ -134,7 +130,6 @@ theorem sum_const_mul_apply_eq_one {ι : Type*} {s : Finset ι} {w : ι → ℂ}
 
 /-- If each summand in a finite real-weighted sum is normalized at a point, then the sum's value at
 that point is the complex coercion of the sum of the real weights. -/
-@[simp]
 theorem sum_real_smul_apply_of_apply_eq_one {ι : Type*} {s : Finset ι} {w : ι → ℝ}
     {F : ι → N → ℂ} {x : N} (hFx : ∀ i ∈ s, F i x = 1) :
     (∑ i ∈ s, w i • F i x) = ((∑ i ∈ s, w i : ℝ) : ℂ) := by
@@ -153,7 +148,6 @@ theorem sum_real_smul_apply_eq_one {ι : Type*} {s : Finset ι} {w : ι → ℝ}
 
 /-- If each summand in a finite real-weighted sum is normalized at a point, then the sum's
 multiplication-form value at that point is the complex coercion of the sum of the real weights. -/
-@[simp]
 theorem sum_real_const_mul_apply_of_apply_eq_one {ι : Type*} {s : Finset ι}
     {w : ι → ℝ} {F : ι → N → ℂ} {x : N} (hFx : ∀ i ∈ s, F i x = 1) :
     (∑ i ∈ s, (w i : ℂ) * F i x) = ((∑ i ∈ s, w i : ℝ) : ℂ) := by
@@ -176,7 +170,6 @@ variable [Zero N]
 
 /-- If each summand in a finite complex-weighted sum is normalized at the origin, then the sum's
 value at the origin is the sum of the weights. -/
-@[simp]
 theorem sum_smul_apply_zero_of_apply_zero_eq_one {ι : Type*} {s : Finset ι}
     {w : ι → ℂ} {F : ι → N → ℂ} (hF0 : ∀ i ∈ s, F i 0 = 1) :
     (∑ i ∈ s, w i • F i 0) = ∑ i ∈ s, w i :=
@@ -184,7 +177,6 @@ theorem sum_smul_apply_zero_of_apply_zero_eq_one {ι : Type*} {s : Finset ι}
 
 /-- A finite complex-weighted sum of functions normalized at the origin is normalized when the
 weights sum to `1`. -/
-@[simp]
 theorem sum_smul_apply_zero_eq_one {ι : Type*} {s : Finset ι} {w : ι → ℂ}
     {F : ι → N → ℂ} (hF0 : ∀ i ∈ s, F i 0 = 1) (hw_sum : ∑ i ∈ s, w i = 1) :
     (fun x => ∑ i ∈ s, w i • F i x) 0 = 1 :=
@@ -192,7 +184,6 @@ theorem sum_smul_apply_zero_eq_one {ι : Type*} {s : Finset ι} {w : ι → ℂ}
 
 /-- If each summand in a finite complex-weighted sum is normalized at the origin, then the
 sum's multiplication-form value at the origin is the sum of the weights. -/
-@[simp]
 theorem sum_const_mul_apply_zero_of_apply_zero_eq_one {ι : Type*} {s : Finset ι}
     {w : ι → ℂ} {F : ι → N → ℂ} (hF0 : ∀ i ∈ s, F i 0 = 1) :
     (∑ i ∈ s, w i * F i 0) = ∑ i ∈ s, w i :=
@@ -200,7 +191,6 @@ theorem sum_const_mul_apply_zero_of_apply_zero_eq_one {ι : Type*} {s : Finset �
 
 /-- A finite complex-weighted sum, in multiplication form, of functions normalized at the origin is
 normalized when the weights sum to `1`. -/
-@[simp]
 theorem sum_const_mul_apply_zero_eq_one {ι : Type*} {s : Finset ι} {w : ι → ℂ}
     {F : ι → N → ℂ} (hF0 : ∀ i ∈ s, F i 0 = 1) (hw_sum : ∑ i ∈ s, w i = 1) :
     (fun x => ∑ i ∈ s, w i * F i x) 0 = 1 :=
@@ -208,7 +198,6 @@ theorem sum_const_mul_apply_zero_eq_one {ι : Type*} {s : Finset ι} {w : ι →
 
 /-- If each summand in a finite real-weighted sum is normalized at the origin, then the sum's value
 at the origin is the complex coercion of the sum of the real weights. -/
-@[simp]
 theorem sum_real_smul_apply_zero_of_apply_zero_eq_one {ι : Type*} {s : Finset ι}
     {w : ι → ℝ} {F : ι → N → ℂ} (hF0 : ∀ i ∈ s, F i 0 = 1) :
     (∑ i ∈ s, w i • F i 0) = ((∑ i ∈ s, w i : ℝ) : ℂ) :=
@@ -224,7 +213,6 @@ theorem sum_real_smul_apply_zero_eq_one {ι : Type*} {s : Finset ι} {w : ι →
 
 /-- If each summand in a finite real-weighted sum is normalized at the origin, then the sum's
 multiplication-form value at the origin is the complex coercion of the sum of the real weights. -/
-@[simp]
 theorem sum_real_const_mul_apply_zero_of_apply_zero_eq_one {ι : Type*} {s : Finset ι}
     {w : ι → ℝ} {F : ι → N → ℂ} (hF0 : ∀ i ∈ s, F i 0 = 1) :
     (∑ i ∈ s, (w i : ℂ) * F i 0) = ((∑ i ∈ s, w i : ℝ) : ℂ) :=

--- a/TauCeti/Analysis/PositiveDefinite/SemigroupGroupNormalize.lean
+++ b/TauCeti/Analysis/PositiveDefinite/SemigroupGroupNormalize.lean
@@ -76,7 +76,6 @@ theorem normalize_apply_zero (hF : IsSemigroupGroupPD F) (h0 : F (0, 0) ≠ 0) :
 
 /-- A normalized semigroup-group positive-definite function has origin value `1`, stated as the
 map-zero lemma for the normalized function. -/
-@[simp]
 theorem normalize_map_zero (hF : IsSemigroupGroupPD F) (h0 : F (0, 0) ≠ 0) :
     (fun p => (((F (0, 0)).re)⁻¹ : ℂ) * F p) (0, 0) = 1 :=
   hF.normalize_apply_zero h0

--- a/TauCeti/Analysis/Semigroups/Basic.lean
+++ b/TauCeti/Analysis/Semigroups/Basic.lean
@@ -75,7 +75,6 @@ theorem map_zero (S : StronglyContinuousSemigroup X) :
 
 omit [CompleteSpace X] in
 /-- Pointwise form of `StronglyContinuousSemigroup.map_zero`. -/
-@[simp]
 theorem map_zero_apply (S : StronglyContinuousSemigroup X) (x : X) :
     S 0 x = x := by
   rw [S.map_zero]
@@ -90,7 +89,6 @@ theorem map_add (S : StronglyContinuousSemigroup X) (s t : ℝ≥0) :
 
 omit [CompleteSpace X] in
 /-- Pointwise form of `StronglyContinuousSemigroup.map_add`. -/
-@[simp]
 theorem map_add_apply (S : StronglyContinuousSemigroup X) (s t : ℝ≥0) (x : X) :
     S (s + t) x = S s (S t x) := by
   rw [S.map_add]
@@ -202,7 +200,6 @@ theorem ContractionSemigroup.contracting_real (S : ContractionSemigroup X)
 
 omit [CompleteSpace X] in
 /-- `S(t) x` at `t = 0` equals `x`, pointwise version. -/
-@[simp]
 theorem StronglyContinuousSemigroup.realOperator_zero_apply
     (S : StronglyContinuousSemigroup X) (x : X) :
     S.realOperator 0 x = x := by

--- a/TauCeti/Analysis/SpecialFunctions/Trigonometric/Chebyshev/CosineTransfer.lean
+++ b/TauCeti/Analysis/SpecialFunctions/Trigonometric/Chebyshev/CosineTransfer.lean
@@ -116,7 +116,6 @@ lemma normalizedChebyshevCosine_zero (θ : ℝ) :
     normalizedChebyshevCosine 0 θ = 1 / Real.sqrt Real.pi := by
   simp [normalizedChebyshevCosine_def]
 
-@[simp]
 lemma normalizedChebyshevCosine_one (θ : ℝ) :
     normalizedChebyshevCosine 1 θ = Real.cos θ / Real.sqrt (Real.pi / 2) := by
   simp [normalizedChebyshevCosine_def]


### PR DESCRIPTION
This PR removes the `@[simp]` attribute from 35 lemmas under `TauCeti/Analysis/` that were flagged by the simp normal-form linter: simp can prove these from existing simp lemmas, so the attribute contributes nothing to the simp set. Every finding was re-verified against current `main` by running the `simpNF` linter on the flagged declarations before editing. The lemmas themselves are kept; only the simp attribute is dropped. `coe_unitDiscStandardAutomorphismEquiv_apply` was `@[simp, norm_cast]` and keeps `@[norm_cast]`. The full build passes with no downstream proof needing repair, so none of these were load-bearing.

Affected declarations (all in the `TauCeti` namespace unless noted):

- `TauCeti/Analysis/CompletelyMonotone/BernsteinMeasures.lean`: `ae_nonneg_bernsteinKernelBoundedContinuous_chafaiRescaled`, `chafaiDensity_one`, `chafaiRescaled_mass_eq`
- `TauCeti/Analysis/Complex/Conformal/Reflection.lean`: `schwarzReflection_of_im_zero`
- `TauCeti/Analysis/Complex/Conformal/UnitDiscAutomorphism.lean`: `coe_unitDiscStandardAutomorphismEquiv_apply`, `unitDiscStandardAutomorphismEquiv_apply_zero`
- `TauCeti/Analysis/InnerProductSpace/HilbertBasisMap.lean`: `HilbertBasis.mapₗᵢ_symm`, `HilbertBasis.mapₗᵢ_symm_self`
- `TauCeti/Analysis/PDE/EnergyForm.lean`: `PDE.energyIntegrand_one_zero_mass_apply`, `PDE.energyIntegrand_one_zero_zero_apply`
- `TauCeti/Analysis/PDE/EnergyFormLinearity.lean`: `PDE.energyIntegrand_add_apply`, `PDE.energyIntegrand_neg_apply`, `PDE.energyIntegrand_smul_apply`, `PDE.energyIntegrand_sub_apply`
- `TauCeti/Analysis/PDE/SymmetricEnergy.lean`: `PDE.energyIntegrand_one_zero_mass_flip_eq`, `PDE.energyIntegrand_zero_drift_flip_eq_on`
- `TauCeti/Analysis/PDE/UniformEllipticity.lean`: `PDE.matrixBilinearForm_one_apply`, `PDE.toQuadraticForm'_smul_one`
- `TauCeti/Analysis/PositiveDefinite/FunctionClosure.lean`: `IsPositiveDefinite.sum_const_mul_apply_eq_one`, `IsPositiveDefinite.sum_const_mul_apply_of_apply_eq_one`, `IsPositiveDefinite.sum_const_mul_apply_zero_eq_one`, `IsPositiveDefinite.sum_const_mul_apply_zero_of_apply_zero_eq_one`, `IsPositiveDefinite.sum_real_const_mul_apply_of_apply_eq_one`, `IsPositiveDefinite.sum_real_const_mul_apply_zero_of_apply_zero_eq_one`, `IsPositiveDefinite.sum_real_smul_apply_of_apply_eq_one`, `IsPositiveDefinite.sum_real_smul_apply_zero_of_apply_zero_eq_one`, `IsPositiveDefinite.sum_smul_apply_eq_one`, `IsPositiveDefinite.sum_smul_apply_of_apply_eq_one`, `IsPositiveDefinite.sum_smul_apply_zero_eq_one`, `IsPositiveDefinite.sum_smul_apply_zero_of_apply_zero_eq_one`
- `TauCeti/Analysis/PositiveDefinite/SemigroupGroupNormalize.lean`: `IsSemigroupGroupPD.normalize_map_zero`
- `TauCeti/Analysis/Semigroups/Basic.lean`: `Semigroups.StronglyContinuousSemigroup.map_add_apply`, `Semigroups.StronglyContinuousSemigroup.map_zero_apply`, `Semigroups.StronglyContinuousSemigroup.realOperator_zero_apply`
- `TauCeti/Analysis/SpecialFunctions/Trigonometric/Chebyshev/CosineTransfer.lean`: `normalizedChebyshevCosine_one`

🤖 Prepared with Claude Code