### PR TITLE
chore(AlgebraicGeometry): drop simp attributes that simp can already prove

### DIFF
--- a/TauCeti/AlgebraicGeometry/WeilDivisor.lean
+++ b/TauCeti/AlgebraicGeometry/WeilDivisor.lean
@@ -631,7 +631,7 @@ lemma weightedPointBaseDifference_eq_ofPoint_sub_zsmul (w : X → ℤ) (x₀ x :
   weightedPointBaseDifference_def w x₀ x
 
 /-- At the constant weight `1`, the degree-corrected point divisor is the usual point
-difference. This simp lemma lets unweighted API reuse the weighted construction. -/
+difference. This lets unweighted API reuse the weighted construction. -/
 lemma weightedPointBaseDifference_eq_pointDifference (x₀ x : X) :
     weightedPointBaseDifference (fun _ : X => (1 : ℤ)) x₀ x = pointDifference x x₀ := by
   simp [weightedPointBaseDifference, pointDifference]

--- a/TauCeti/AlgebraicGeometry/WeilDivisor.lean
+++ b/TauCeti/AlgebraicGeometry/WeilDivisor.lean
@@ -172,7 +172,6 @@ lemma coeff_pushforward [DecidableEq Y] (f : X → Y) (D : WeilDivisor X) (y : Y
       exact (hy ⟨x, hx.2⟩).elim
     · exact hy
 
-@[simp]
 lemma pushforward_zero (f : X → Y) : pushforward f (0 : WeilDivisor X) = 0 :=
   map_zero (pushforward f)
 
@@ -445,7 +444,6 @@ lemma weightedDegree_pointDifference (w : X → ℤ) (x y : X) :
     weightedDegree w (pointDifference x y) = w x - w y := by
   simp [pointDifference]
 
-@[simp]
 lemma pointDifference_mem_degreeZeroSubgroup (x y : X) :
     pointDifference x y ∈ degreeZeroSubgroup X := by
   simp
@@ -608,7 +606,6 @@ lemma coe_weightedDegreeZeroSubgroup_eq_zero_of_isEffective {w : X → ℤ} (hw 
   hD.eq_zero_of_weightedDegree_eq_zero_of_pos hw
     (weightedDegree_coe_weightedDegreeZeroSubgroup w D)
 
-@[simp]
 lemma pointDifference_mem_weightedDegreeZeroSubgroup {w : X → ℤ} {x y : X}
     (h : w x = w y) : pointDifference x y ∈ weightedDegreeZeroSubgroup w := by
   simp [h]
@@ -635,7 +632,6 @@ lemma weightedPointBaseDifference_eq_ofPoint_sub_zsmul (w : X → ℤ) (x₀ x :
 
 /-- At the constant weight `1`, the degree-corrected point divisor is the usual point
 difference. This simp lemma lets unweighted API reuse the weighted construction. -/
-@[simp]
 lemma weightedPointBaseDifference_eq_pointDifference (x₀ x : X) :
     weightedPointBaseDifference (fun _ : X => (1 : ℤ)) x₀ x = pointDifference x x₀ := by
   simp [weightedPointBaseDifference, pointDifference]
@@ -673,7 +669,6 @@ lemma support_weightedPointBaseDifference_subset [DecidableEq X] (w : X → ℤ)
     simp [weightedPointBaseDifference, ofPoint, hyx.1, hyx.2])
 
 /-- If the base point has weight `1`, the divisor `[x₀] - w(x₀)[x₀]` is zero. -/
-@[simp]
 lemma weightedPointBaseDifference_self {w : X → ℤ} {x₀ : X} (hx₀ : w x₀ = 1) :
     weightedPointBaseDifference w x₀ x₀ = 0 := by
   simp [weightedPointBaseDifference, hx₀]
@@ -686,7 +681,6 @@ lemma weightedDegree_weightedPointBaseDifference (w : X → ℤ) (x₀ x : X) :
   ring
 
 /-- If the base point has weight `1`, then `[x] - w(x)[x₀]` has weighted degree zero. -/
-@[simp]
 lemma weightedPointBaseDifference_mem_weightedDegreeZeroSubgroup {w : X → ℤ} {x₀ : X}
     (hx₀ : w x₀ = 1) (x : X) :
     weightedPointBaseDifference w x₀ x ∈ weightedDegreeZeroSubgroup w := by

--- a/TauCeti/AlgebraicGeometry/WeilDivisor/AbelJacobiSum.lean
+++ b/TauCeti/AlgebraicGeometry/WeilDivisor/AbelJacobiSum.lean
@@ -203,7 +203,6 @@ lemma classGroupAddEquivPicZeroProdInt_divisorClass (w : X → ℤ)
 
 /-- The inverse splitting reconstructs the divisor class from its weighted Abel-Jacobi sum and
 weighted degree. -/
-@[simp]
 lemma classGroupAddEquivPicZeroProdInt_symm_weightedAbelJacobiDivisorClass
     (w : X → ℤ) (h : S.IsWeightedDegreeZero w) {x₀ : X} (hx₀ : w x₀ = 1)
     (D : WeilDivisor X) :
@@ -364,7 +363,6 @@ lemma classGroupAddEquivUnweightedPicZeroProdInt_divisorClass
 
 /-- The inverse unweighted splitting reconstructs the divisor class from its unweighted
 Abel-Jacobi sum and degree. -/
-@[simp]
 lemma classGroupAddEquivUnweightedPicZeroProdInt_symm_unweightedAbelJacobiDivisorClass
     (h : S.IsUnweightedDegreeZero) (x₀ : X) (D : WeilDivisor X) :
     (S.classGroupAddEquivUnweightedPicZeroProdInt h x₀).symm

--- a/TauCeti/AlgebraicGeometry/WeilDivisor/Dedekind.lean
+++ b/TauCeti/AlgebraicGeometry/WeilDivisor/Dedekind.lean
@@ -103,7 +103,6 @@ lemma adicOrd_apply (v : HeightOneSpectrum R) (u : Additive Kˣ) :
 
 /-- The computational form of `adicOrd` applied to `Additive.ofMul u` for a multiplicative unit
 `u : Kˣ`: it is the sign-flipped logarithm `-log v(u)` of the `v`-adic valuation of `u : K`. -/
-@[simp]
 lemma adicOrd_ofMul (v : HeightOneSpectrum R) (u : Kˣ) :
     adicOrd R K v (Additive.ofMul u) = -WithZero.log (v.valuation K (u : K)) := by
   rw [adicOrd_apply]

--- a/TauCeti/AlgebraicGeometry/WeilDivisor/DegreeSplitting.lean
+++ b/TauCeti/AlgebraicGeometry/WeilDivisor/DegreeSplitting.lean
@@ -63,19 +63,16 @@ lemma degreeSection_apply (x₀ : X) (n : ℤ) :
     S.degreeSection x₀ n = n • S.divisorClass (ofPoint x₀) :=
   rfl
 
-@[simp]
 lemma degreeSection_one (x₀ : X) :
     S.degreeSection x₀ 1 = S.divisorClass (ofPoint x₀) := by
   simp
 
 /-- The descended weighted degree of the base-point class is the weight of the base point. -/
-@[simp]
 lemma weightedDegreeClass_divisorClass_ofPoint (w : X → ℤ) (h : S.IsWeightedDegreeZero w)
     (x₀ : X) : weightedDegreeClass w h (S.divisorClass (ofPoint x₀)) = w x₀ := by
   rw [weightedDegreeClass_divisorClass, weightedDegree_ofPoint]
 
 /-- The descended weighted degree of the degree section at `n` is `n * w x₀`. -/
-@[simp]
 lemma weightedDegreeClass_degreeSection (w : X → ℤ) (h : S.IsWeightedDegreeZero w)
     (x₀ : X) (n : ℤ) :
     weightedDegreeClass w h (S.degreeSection x₀ n) = n * w x₀ := by

--- a/TauCeti/AlgebraicGeometry/WeilDivisor/FiniteSum.lean
+++ b/TauCeti/AlgebraicGeometry/WeilDivisor/FiniteSum.lean
@@ -191,7 +191,6 @@ lemma isEffective_ofFinsetWithMultiplicity (s : Finset X) (m : X → ℕ) :
 
 /-- A named finite-set divisor with natural multiplicities belongs to the effective divisor
 submonoid. -/
-@[simp]
 lemma ofFinsetWithMultiplicity_mem_effectiveSubmonoid (s : Finset X) (m : X → ℕ) :
     ofFinsetWithMultiplicity s m ∈ effectiveSubmonoid X :=
   (mem_effectiveSubmonoid _).mpr (isEffective_ofFinsetWithMultiplicity s m)
@@ -317,7 +316,6 @@ lemma isEffective_ofFinset (s : Finset X) : IsEffective (ofFinset s : WeilDiviso
   isEffective_ofFinsetWithMultiplicity s fun _ => 1
 
 /-- The named coefficient-one finite-set divisor belongs to the effective divisor submonoid. -/
-@[simp]
 lemma ofFinset_mem_effectiveSubmonoid (s : Finset X) :
     ofFinset s ∈ effectiveSubmonoid X :=
   (mem_effectiveSubmonoid _).mpr (isEffective_ofFinset s)

--- a/TauCeti/AlgebraicGeometry/WeilDivisor/PicZeroQuotient.lean
+++ b/TauCeti/AlgebraicGeometry/WeilDivisor/PicZeroQuotient.lean
@@ -144,7 +144,6 @@ lemma weightedDegreeZeroQuotientEquivPicZero_mk {w : X → ℤ}
       (QuotientAddGroup.mk D) = S.weightedDegreeZeroClassHom w h D
   rw [QuotientAddGroup.kerLift_mk]
 
-@[simp]
 lemma coe_weightedDegreeZeroQuotientEquivPicZero_mk {w : X → ℤ}
     (h : S.IsWeightedDegreeZero w) (D : weightedDegreeZeroSubgroup w) :
     (S.weightedDegreeZeroQuotientEquivPicZero w h
@@ -296,7 +295,6 @@ lemma degreeZeroQuotientEquivUnweightedPicZero_mk
       (h := (h : S.IsWeightedDegreeZero (fun _ : X => (1 : ℤ))))]
   rfl
 
-@[simp]
 lemma coe_degreeZeroQuotientEquivUnweightedPicZero_mk
     (h : S.IsUnweightedDegreeZero) (D : degreeZeroSubgroup X) :
     (S.degreeZeroQuotientEquivUnweightedPicZero h

--- a/TauCeti/AlgebraicGeometry/WeilDivisor/PrincipalKernel.lean
+++ b/TauCeti/AlgebraicGeometry/WeilDivisor/PrincipalKernel.lean
@@ -55,7 +55,6 @@ input, such as a global-units or constant-field theorem. -/
 abbrev principalKernel : AddSubgroup G :=
   S.principalHom.ker
 
-@[simp]
 lemma mem_principalKernel {g : G} :
     g ∈ S.principalKernel ↔ S.principalDivisor g = 0 := by
   simp only [principalKernel, AddMonoidHom.mem_ker, principalHom_apply]
@@ -73,7 +72,6 @@ lemma mem_principalKernel_iff_forall_ord_eq_zero {g : G} :
     rw [S.coeff_principalDivisor, h x]
     simp
 
-@[simp]
 lemma zero_mem_principalKernel : (0 : G) ∈ S.principalKernel := by
   rw [mem_principalKernel]
   simp
@@ -184,7 +182,6 @@ lemma mk_eq_mk_iff_principalDivisor_eq {g h : G} :
   (S.principalDivisor_eq_iff_mk_eq_mk).symm
 
 /-- A function class is zero exactly when the representative has zero principal divisor. -/
-@[simp]
 lemma mk_eq_zero_iff_principalDivisor_eq_zero {g : G} :
     (QuotientAddGroup.mk g : S.PrincipalFunctionClass) = 0 ↔ S.principalDivisor g = 0 := by
   rw [← principalFunctionClassDivisor_eq_zero_iff]


### PR DESCRIPTION
This PR removes the `@[simp]` attribute from 19 lemmas under `TauCeti/AlgebraicGeometry/` that were flagged by the simp normal-form linter: simp can prove these from existing simp lemmas, so the attribute contributes nothing to the simp set. Every finding was re-verified against current `main` by running the `simpNF` linter on the flagged declarations before editing. The lemmas themselves are kept; only the attribute is dropped (each was a bare `@[simp]`). The full build passes with no downstream proof needing repair, so none of these were load-bearing.

Affected declarations (all in the `TauCeti` namespace):

- `TauCeti/AlgebraicGeometry/WeilDivisor.lean`: `AlgebraicGeometry.WeilDivisor.pointDifference_mem_degreeZeroSubgroup`, `AlgebraicGeometry.WeilDivisor.pointDifference_mem_weightedDegreeZeroSubgroup`, `AlgebraicGeometry.WeilDivisor.pushforward_zero`, `AlgebraicGeometry.WeilDivisor.weightedPointBaseDifference_eq_pointDifference`, `AlgebraicGeometry.WeilDivisor.weightedPointBaseDifference_mem_weightedDegreeZeroSubgroup`, `AlgebraicGeometry.WeilDivisor.weightedPointBaseDifference_self`
- `TauCeti/AlgebraicGeometry/WeilDivisor/AbelJacobiSum.lean`: `AlgebraicGeometry.WeilDivisor.OrderSystem.classGroupAddEquivPicZeroProdInt_symm_weightedAbelJacobiDivisorClass`, `AlgebraicGeometry.WeilDivisor.OrderSystem.classGroupAddEquivUnweightedPicZeroProdInt_symm_unweightedAbelJacobiDivisorClass`
- `TauCeti/AlgebraicGeometry/WeilDivisor/Dedekind.lean`: `AlgebraicGeometry.WeilDivisor.adicOrd_ofMul`
- `TauCeti/AlgebraicGeometry/WeilDivisor/DegreeSplitting.lean`: `AlgebraicGeometry.WeilDivisor.OrderSystem.degreeSection_one`, `AlgebraicGeometry.WeilDivisor.OrderSystem.weightedDegreeClass_degreeSection`, `AlgebraicGeometry.WeilDivisor.OrderSystem.weightedDegreeClass_divisorClass_ofPoint`
- `TauCeti/AlgebraicGeometry/WeilDivisor/FiniteSum.lean`: `AlgebraicGeometry.WeilDivisor.ofFinsetWithMultiplicity_mem_effectiveSubmonoid`, `AlgebraicGeometry.WeilDivisor.ofFinset_mem_effectiveSubmonoid`
- `TauCeti/AlgebraicGeometry/WeilDivisor/PicZeroQuotient.lean`: `AlgebraicGeometry.WeilDivisor.OrderSystem.coe_degreeZeroQuotientEquivUnweightedPicZero_mk`, `AlgebraicGeometry.WeilDivisor.OrderSystem.coe_weightedDegreeZeroQuotientEquivPicZero_mk`
- `TauCeti/AlgebraicGeometry/WeilDivisor/PrincipalKernel.lean`: `AlgebraicGeometry.WeilDivisor.OrderSystem.mem_principalKernel`, `AlgebraicGeometry.WeilDivisor.OrderSystem.mk_eq_zero_iff_principalDivisor_eq_zero`, `AlgebraicGeometry.WeilDivisor.OrderSystem.zero_mem_principalKernel`

🤖 Prepared with Claude Code