### PR TITLE
chore(Geometry): drop simp attributes that simp can already prove

### DIFF
--- a/TauCeti/Geometry/Diffeomorphism/AmbientIsotopyClassAction.lean
+++ b/TauCeti/Geometry/Diffeomorphism/AmbientIsotopyClassAction.lean
@@ -60,7 +60,6 @@ theorem ambientIsotopyClass_smul_eq_homeomorph_smul
 
 /-- The diffeomorphism action on representatives is postcomposition by the underlying
 homeomorphism. -/
-@[simp]
 theorem ambientIsotopyClass_smul_mk (φ : M ≃ₘ^n⟮I, I⟯ M) (f : C(X, M)) :
     φ • AmbientIsotopyClass.mk f =
       AmbientIsotopyClass.mk ((φ.toHomeomorph : C(M, M)).comp f) :=
@@ -69,7 +68,6 @@ theorem ambientIsotopyClass_smul_mk (φ : M ≃ₘ^n⟮I, I⟯ M) (f : C(X, M)) 
 
 /-- The homeomorphism-induced quotient equivalence of the underlying homeomorphism agrees with the
 diffeomorphism action. -/
-@[simp]
 theorem ambientIsotopyClass_postcompHomeomorphEquiv_apply_eq_smul
     (φ : M ≃ₘ^n⟮I, I⟯ M) (x : AmbientIsotopyClass X M) :
     AmbientIsotopyClass.postcompHomeomorphEquiv φ.toHomeomorph x = φ • x := by

--- a/TauCeti/Geometry/Diffeomorphism/FixingSubgroup.lean
+++ b/TauCeti/Geometry/Diffeomorphism/FixingSubgroup.lean
@@ -85,13 +85,11 @@ theorem mem_fixingSubgroup_of_forall {s : Set M} {f : M ≃ₘ^n⟮I, I⟯ M}
   mem_fixingSubgroup_iff.mpr hf
 
 /-- The relative diffeomorphism group fixing the empty set is the full diffeomorphism group. -/
-@[simp]
 theorem fixingSubgroup_empty :
     fixingSubgroup (I := I) (M := M) (n := n) (∅ : Set M) = ⊤ := by
   exact _root_.fixingSubgroup_empty (M := M ≃ₘ^n⟮I, I⟯ M) (α := M)
 
 /-- The relative diffeomorphism group fixing all points is trivial. -/
-@[simp]
 theorem fixingSubgroup_univ :
     fixingSubgroup (I := I) (M := M) (n := n) (Set.univ : Set M) = ⊥ := by
   exact TauCeti.fixingSubgroup_univ (G := M ≃ₘ^n⟮I, I⟯ M) (α := M)

--- a/TauCeti/Geometry/Manifold/SmoothEmbedding.lean
+++ b/TauCeti/Geometry/Manifold/SmoothEmbedding.lean
@@ -112,7 +112,6 @@ theorem toContinuousMap_injective :
     Function.Injective (toContinuousMap : SmoothEmbedding I J n M N → C(M, N)) :=
   ContinuousMap.coe_injective'
 
-@[simp]
 theorem toContinuousMap_inj {f g : SmoothEmbedding I J n M N} :
     (toContinuousMap f : C(M, N)) = toContinuousMap g ↔ f = g :=
   toContinuousMap_injective.eq_iff

--- a/TauCeti/Geometry/Symplectic/AlmostComplex.lean
+++ b/TauCeti/Geometry/Symplectic/AlmostComplex.lean
@@ -114,7 +114,6 @@ lemma map_eq_zero_iff (J : AlmostComplexStructure V) {v : V} :
     J v = 0 ↔ v = 0 :=
   J.injective.eq_iff' J.toLinearMap.map_zero
 
-@[simp]
 lemma map_ne_zero_iff (J : AlmostComplexStructure V) {v : V} :
     J v ≠ 0 ↔ v ≠ 0 :=
   not_congr J.map_eq_zero_iff

--- a/TauCeti/Geometry/Symplectic/CompatibleMetric.lean
+++ b/TauCeti/Geometry/Symplectic/CompatibleMetric.lean
@@ -54,7 +54,6 @@ variable {ω : SymplecticForm V} {J : AlmostComplexStructure V}
 
 /-- Applying `J` to the right argument of the metric `g(v, w) = ω(v, J w)` negates the symplectic
 form: `g(v, J w) = -ω(v, w)`. This uses only `J² = -1`, not compatibility. -/
-@[simp]
 lemma associatedBilinForm_apply_right_apply (v w : V) :
     ω.associatedBilinForm J v (J w) = -ω v w := by
   rw [associatedBilinForm_apply, AlmostComplexStructure.apply_apply]

--- a/TauCeti/Geometry/Symplectic/ComplexModule.lean
+++ b/TauCeti/Geometry/Symplectic/ComplexModule.lean
@@ -89,7 +89,6 @@ lemma complexModule_smul_def (J : AlmostComplexStructure V) (z : ℂ) (v : V) :
   exact liftAux_toRingHom_apply J J.toLinearMap_mul_toLinearMap z v
 
 /-- In the induced complex structure, multiplication by `i` is `J`. -/
-@[simp]
 lemma complexModule_I_smul (J : AlmostComplexStructure V) (v : V) :
     letI := J.complexModule
     (Complex.I) • v = J v := by
@@ -97,7 +96,6 @@ lemma complexModule_I_smul (J : AlmostComplexStructure V) (v : V) :
   rw [complexModule_smul_def, Complex.I_re, Complex.I_im, zero_smul, one_smul, zero_add]
 
 /-- The induced complex action restricts along `ℝ → ℂ` to the original real action. -/
-@[simp]
 lemma complexModule_ofReal_smul (J : AlmostComplexStructure V) (r : ℝ) (v : V) :
     letI := J.complexModule
     (r : ℂ) • v = r • v := by

--- a/TauCeti/Geometry/Symplectic/Hermitian.lean
+++ b/TauCeti/Geometry/Symplectic/Hermitian.lean
@@ -84,14 +84,12 @@ lemma complexAssociatedForm_apply (ω : SymplecticForm V) (J : AlmostComplexStru
     ω.complexAssociatedForm J v w = (ω v (J w) : ℂ) + Complex.I * (ω v w : ℂ) := rfl
 
 /-- The real part of the complex associated form is the metric `g(v, w) = ω(v, J w)`. -/
-@[simp]
 lemma complexAssociatedForm_re (ω : SymplecticForm V) (J : AlmostComplexStructure V)
     (v w : V) :
     (ω.complexAssociatedForm J v w).re = ω v (J w) := by
   simp [complexAssociatedForm]
 
 /-- The imaginary part of the complex associated form is the symplectic form `ω(v, w)`. -/
-@[simp]
 lemma complexAssociatedForm_im (ω : SymplecticForm V) (J : AlmostComplexStructure V)
     (v w : V) :
     (ω.complexAssociatedForm J v w).im = ω v w := by
@@ -145,7 +143,6 @@ lemma complexAssociatedForm_smul_right (ω : SymplecticForm V) (J : AlmostComple
 
 /-- The diagonal of the complex associated form is real and equals the metric diagonal
 `ω(v, J v)`. -/
-@[simp]
 lemma complexAssociatedForm_self (ω : SymplecticForm V) (J : AlmostComplexStructure V) (v : V) :
     ω.complexAssociatedForm J v v = (ω v (J v) : ℂ) := by
   simp [complexAssociatedForm]

--- a/TauCeti/Geometry/Symplectic/StandardCompatible.lean
+++ b/TauCeti/Geometry/Symplectic/StandardCompatible.lean
@@ -128,7 +128,6 @@ lemma stdSymplecticForm_compatible_product :
 
 /-- The metric `g = ω₀(·, J ·)` associated to the standard compatible triple is the
 componentwise inner product on `V × V`. -/
-@[simp]
 lemma stdSymplecticForm_associatedBilinForm_product (u w : V × V) :
     (stdSymplecticForm (V := V)).associatedBilinForm (AlmostComplexStructure.product V) u w =
       ⟪u.1, w.1⟫_ℝ + ⟪u.2, w.2⟫_ℝ := by

--- a/TauCeti/Geometry/Symplectic/SymplecticTransport.lean
+++ b/TauCeti/Geometry/Symplectic/SymplecticTransport.lean
@@ -90,20 +90,17 @@ lemma transport_trans (ω : SymplecticForm V) (e₁ : V ≃ₗ[ℝ] W) (e₂ : W
     rw [LinearMap.BilinForm.congr_congr]
 
 /-- Transporting forward along `e` and back along `e.symm` returns the original form. -/
-@[simp]
 lemma transport_symm_transport (ω : SymplecticForm V) (e : V ≃ₗ[ℝ] W) :
     (ω.transport e).transport e.symm = ω := by
   rw [transport_trans, e.self_trans_symm, transport_refl]
 
 /-- Transporting back along `e.symm` and forward along `e` returns the original form. -/
-@[simp]
 lemma transport_transport_symm (ω : SymplecticForm W) (e : V ≃ₗ[ℝ] W) :
     (ω.transport e.symm).transport e = ω := by
   rw [transport_trans, e.symm_trans_self, transport_refl]
 
 /-- `e` is a symplectomorphism onto the transported form: evaluating `ω.transport e` on images
 under `e` recovers `ω`. -/
-@[simp]
 lemma transport_apply_apply (ω : SymplecticForm V) (e : V ≃ₗ[ℝ] W) (v w : V) :
     ω.transport e (e v) (e w) = ω v w := by
   rw [transport_apply, e.symm_apply_apply, e.symm_apply_apply]

--- a/TauCeti/Geometry/Symplectic/Transport.lean
+++ b/TauCeti/Geometry/Symplectic/Transport.lean
@@ -84,13 +84,11 @@ lemma transport_trans (J : AlmostComplexStructure V) (e₁ : V ≃ₗ[ℝ] W) (e
   rw [← LinearEquiv.trans_apply, LinearEquiv.conj_trans]
 
 /-- Transporting forward along `e` and back along `e.symm` returns the original structure. -/
-@[simp]
 lemma transport_symm_transport (J : AlmostComplexStructure V) (e : V ≃ₗ[ℝ] W) :
     (J.transport e).transport e.symm = J := by
   rw [transport_trans, e.self_trans_symm, transport_refl]
 
 /-- Transporting back along `e.symm` and forward along `e` returns the original structure. -/
-@[simp]
 lemma transport_transport_symm (J : AlmostComplexStructure W) (e : V ≃ₗ[ℝ] W) :
     (J.transport e.symm).transport e = J := by
   rw [transport_trans, e.symm_trans_self, transport_refl]


### PR DESCRIPTION
This PR removes the `@[simp]` attribute from 18 lemmas under `TauCeti/Geometry/` that were flagged by the simp normal-form linter: simp can prove these from existing simp lemmas, so the attribute contributes nothing to the simp set. Every finding was re-verified against current `main` by running the `simpNF` linter on the flagged declarations before editing. The lemmas themselves are kept; only the attribute is dropped (each was a bare `@[simp]`). The full build passes with no downstream proof needing repair, so none of these were load-bearing.

Affected declarations (all in the `TauCeti` namespace):

- `TauCeti/Geometry/Diffeomorphism/AmbientIsotopyClassAction.lean`: `Diffeomorph.ambientIsotopyClass_postcompHomeomorphEquiv_apply_eq_smul`, `Diffeomorph.ambientIsotopyClass_smul_mk`
- `TauCeti/Geometry/Diffeomorphism/FixingSubgroup.lean`: `Diffeomorph.fixingSubgroup_empty`, `Diffeomorph.fixingSubgroup_univ`
- `TauCeti/Geometry/Manifold/SmoothEmbedding.lean`: `SmoothEmbedding.toContinuousMap_inj`
- `TauCeti/Geometry/Symplectic/AlmostComplex.lean`: `AlmostComplexStructure.map_ne_zero_iff`
- `TauCeti/Geometry/Symplectic/CompatibleMetric.lean`: `SymplecticForm.associatedBilinForm_apply_right_apply`
- `TauCeti/Geometry/Symplectic/ComplexModule.lean`: `AlmostComplexStructure.complexModule_I_smul`, `AlmostComplexStructure.complexModule_ofReal_smul`
- `TauCeti/Geometry/Symplectic/Hermitian.lean`: `SymplecticForm.complexAssociatedForm_im`, `SymplecticForm.complexAssociatedForm_re`, `SymplecticForm.complexAssociatedForm_self`
- `TauCeti/Geometry/Symplectic/StandardCompatible.lean`: `stdSymplecticForm_associatedBilinForm_product`
- `TauCeti/Geometry/Symplectic/SymplecticTransport.lean`: `SymplecticForm.transport_apply_apply`, `SymplecticForm.transport_symm_transport`, `SymplecticForm.transport_transport_symm`
- `TauCeti/Geometry/Symplectic/Transport.lean`: `AlmostComplexStructure.transport_symm_transport`, `AlmostComplexStructure.transport_transport_symm`

🤖 Prepared with Claude Code