### PR TITLE
chore(AlgebraicTopology): drop simp attributes that simp can already prove

### DIFF
--- a/TauCeti/AlgebraicTopology/SimplicialComplex/LinkStar.lean
+++ b/TauCeti/AlgebraicTopology/SimplicialComplex/LinkStar.lean
@@ -155,7 +155,6 @@ theorem link_le_deletion_of_nonempty (hσ : σ.Nonempty) : link K σ ≤ deletio
 /-- The link of a single vertex `{v}`, written with `insert`: the faces `ρ` not already containing
 `v` for which `insert v ρ` is a face. This is the form the combinatorial-manifold link condition
 uses. -/
-@[simp]
 theorem mem_link_singleton {v : ι} {ρ : Finset ι} :
     ρ ∈ link K {v} ↔ ρ.Nonempty ∧ v ∉ ρ ∧ insert v ρ ∈ K := by
   rw [mem_link, disjoint_singleton_right, union_comm, ← insert_eq]
@@ -168,7 +167,6 @@ theorem mem_closedStar_singleton {v : ι} {ρ : Finset ι} :
 
 omit [DecidableEq ι] in
 /-- The deletion of a single vertex `{v}` consists of the faces not containing `v`. -/
-@[simp]
 theorem mem_deletion_singleton {v : ι} {ρ : Finset ι} :
     ρ ∈ deletion K {v} ↔ ρ ∈ K ∧ v ∉ ρ := by
   rw [mem_deletion, singleton_subset_iff]

--- a/TauCeti/AlgebraicTopology/UniversalCover/CircleFundamentalGroup.lean
+++ b/TauCeti/AlgebraicTopology/UniversalCover/CircleFundamentalGroup.lean
@@ -268,7 +268,6 @@ lemma fundamentalGroupMulEquiv_zero_symm_apply (hp : p ≠ 0) (n : Multiplicativ
   rw [MulEquiv.apply_symm_apply, fundamentalGroupMulEquiv_zero_apply, MulEquiv.apply_symm_apply]
 
 /-- The inverse of the basepoint-`0` specialization has monodromy translation `n • p`. -/
-@[simp]
 lemma fundamentalGroupMulEquiv_zero_symm_monodromy (hp : p ≠ 0) (n : Multiplicative ℤ) :
     ((AddCircle.isCoveringMap_coe p).monodromy ((fundamentalGroupMulEquiv_zero p hp).symm n)
       ⟨0, by simp⟩ : ℝ) = n.toAdd • p := by

--- a/TauCeti/AlgebraicTopology/UniversalCover/Deck/Connected.lean
+++ b/TauCeti/AlgebraicTopology/UniversalCover/Deck/Connected.lean
@@ -168,7 +168,6 @@ lemma deckEquivFiberOfSurjective_symm_apply_coe [PreconnectedSpace E]
     congrArg Subtype.val (deckEquivFiberOfSurjective_symm_smul hp e hsurj e')
 
 /-- The local deck-to-fibre equivalence sends the identity to the chosen base point. -/
-@[simp]
 lemma deckEquivFiberOfSurjective_one [PreconnectedSpace E] (hp : IsCoveringMap p)
     (e : p ⁻¹' {b}) (hsurj : Function.Surjective fun φ : Deck p => φ • e) :
     deckEquivFiberOfSurjective hp e hsurj 1 = e := by
@@ -176,7 +175,6 @@ lemma deckEquivFiberOfSurjective_one [PreconnectedSpace E] (hp : IsCoveringMap p
 
 /-- The local deck-to-fibre equivalence is equivariant for left multiplication on the deck
 group and the deck action on the fibre. -/
-@[simp]
 lemma deckEquivFiberOfSurjective_mul [PreconnectedSpace E] (hp : IsCoveringMap p)
     (e : p ⁻¹' {b}) (hsurj : Function.Surjective fun φ : Deck p => φ • e) (φ ψ : Deck p) :
     deckEquivFiberOfSurjective hp e hsurj (φ * ψ) =

--- a/TauCeti/AlgebraicTopology/UniversalCover/Deck/FiberTorsorTransport.lean
+++ b/TauCeti/AlgebraicTopology/UniversalCover/Deck/FiberTorsorTransport.lean
@@ -128,7 +128,6 @@ lemma deckEquivFiberOfSurjective_fiberMap [PreconnectedSpace E]
 /-- On underlying points, local compatibility of `deckEquivFiberOfSurjective` with fibre
 transport says that conjugating a deck transformation and then evaluating on the transported
 fibre point is the same as transporting the original evaluation. -/
-@[simp]
 lemma deckEquivFiberOfSurjective_fiberMap_coe [PreconnectedSpace E]
     (hp : IsCoveringMap p) (hq : IsCoveringMap q) (h : E ≃ₜ F)
     (hpq : ∀ e, q (h e) = p e) (e : p ⁻¹' {b})
@@ -144,7 +143,6 @@ lemma deckEquivFiberOfSurjective_fiberMap_coe [PreconnectedSpace E]
 /-- The inverse of the regular deck-to-fibre equivalence is compatible with fibre transport:
 transport the target fibre point first, or compute the source deck transformation first and
 then conjugate it. -/
-@[simp]
 lemma deckEquivFiber_symm_fiberMap [PreconnectedSpace E]
     (hp : IsCoveringMap p) (hq : IsCoveringMap q) (hreg : IsRegular p)
     (h : E ≃ₜ F) (hpq : ∀ e, q (h e) = p e) (e e' : p ⁻¹' {b}) :
@@ -178,7 +176,6 @@ lemma deckEquivFiber_fiberMap [PreconnectedSpace E]
 /-- On underlying points, the compatibility of `deckEquivFiber` with fibre transport says
 that conjugating a deck transformation and then evaluating on the transported fibre point is
 the same as transporting the original evaluation. -/
-@[simp]
 lemma deckEquivFiber_fiberMap_coe [PreconnectedSpace E]
     (hp : IsCoveringMap p) (hq : IsCoveringMap q) (hreg : IsRegular p)
     (h : E ≃ₜ F) (hpq : ∀ e, q (h e) = p e) (e : p ⁻¹' {b}) (φ : Deck p) :

--- a/TauCeti/AlgebraicTopology/UniversalCover/Deck/FiberTransport.lean
+++ b/TauCeti/AlgebraicTopology/UniversalCover/Deck/FiberTransport.lean
@@ -223,7 +223,6 @@ lemma fiberMap_symm_mem_orbit (h : E ≃ₜ F) (hpq : ∀ e, q (h e) = p e) (ψ 
 
 /-- The inverse fibre map carries the deck orbit of a point onto the deck orbit of the
 transported point. -/
-@[simp]
 theorem fiberMap_symm_image_orbit (h : E ≃ₜ F) (hpq : ∀ e, q (h e) = p e)
     (f : q ⁻¹' {b}) :
     (fiberMap h hpq b).symm '' MulAction.orbit (Deck q) f =
@@ -261,7 +260,6 @@ theorem mem_orbit_fiberMap_iff (h : E ≃ₜ F) (hpq : ∀ e, q (h e) = p e)
     exact congrArg (fiberMap h hpq b) hφ
 
 /-- Transporting both target-fibre points back preserves membership in deck orbits. -/
-@[simp]
 theorem mem_orbit_fiberMap_symm_iff (h : E ≃ₜ F) (hpq : ∀ e, q (h e) = p e)
     (f f' : q ⁻¹' {b}) :
     (fiberMap h hpq b).symm f' ∈

--- a/TauCeti/AlgebraicTopology/UniversalCover/Deck/NormalizerQuotientFiberAction.lean
+++ b/TauCeti/AlgebraicTopology/UniversalCover/Deck/NormalizerQuotientFiberAction.lean
@@ -161,7 +161,6 @@ lemma normalizerQuotient_smul_subgroupFiberOrbitClass (H : Subgroup (Deck p))
           (X := p ⁻¹' {b}) H φ e
 
 /-- The identity class in `N(H) / H` fixes every subgroup fibre-orbit class. -/
-@[simp]
 lemma normalizerQuotient_one_smul_subgroupFiberOrbitClass (H : Subgroup (Deck p))
     (e : p ⁻¹' {b}) :
     (1 : Subgroup.normalizerQuotient H) • subgroupFiberOrbitClass H e =
@@ -180,7 +179,6 @@ lemma normalizerQuotient_mk_of_mem_smul_subgroupFiberOrbitClass
 
 /-- Equality after the `N(H) / H` action on an `H`-fibre quotient is equality of
 normalizer-quotient elements, provided the deck action on that fibre is free. -/
-@[simp]
 lemma normalizerQuotient_smul_subgroupFiberOrbit_eq_smul_iff
     [IsCancelSMul (Deck p) (p ⁻¹' {b})] (H : Subgroup (Deck p))
     (a c : Subgroup.normalizerQuotient H) (x : SubgroupFiberOrbitQuotient H b) :

--- a/TauCeti/AlgebraicTopology/UniversalCover/Deck/Regular.lean
+++ b/TauCeti/AlgebraicTopology/UniversalCover/Deck/Regular.lean
@@ -171,7 +171,6 @@ lemma deckEquivFiber_apply_coe [PreconnectedSpace E] (hp : IsCoveringMap p)
 
 /-- The equivalence from deck transformations to a fibre sends the identity to the chosen
 base point. -/
-@[simp]
 lemma deckEquivFiber_one [PreconnectedSpace E] (hp : IsCoveringMap p) (hreg : IsRegular p)
     (e : p ⁻¹' {b}) :
     deckEquivFiber hp hreg e 1 = e := by
@@ -180,7 +179,6 @@ lemma deckEquivFiber_one [PreconnectedSpace E] (hp : IsCoveringMap p) (hreg : Is
 
 /-- The equivalence from deck transformations to a fibre is equivariant for left
 multiplication on the deck group and the deck action on the fibre. -/
-@[simp]
 lemma deckEquivFiber_mul [PreconnectedSpace E] (hp : IsCoveringMap p) (hreg : IsRegular p)
     (e : p ⁻¹' {b}) (φ ψ : Deck p) :
     deckEquivFiber hp hreg e (φ * ψ) = φ • deckEquivFiber hp hreg e ψ := by

--- a/TauCeti/AlgebraicTopology/UniversalCover/Deck/SubgroupFiberOrbit.lean
+++ b/TauCeti/AlgebraicTopology/UniversalCover/Deck/SubgroupFiberOrbit.lean
@@ -335,7 +335,6 @@ lemma subgroupFiberOrbitQuotientBotEquiv_symm_apply (e : p ⁻¹' {b}) :
     (G := Deck p) (X := p ⁻¹' {b}) e
 
 /-- Equality of bottom-subgroup fibre-orbit classes is equality of fibre points. -/
-@[simp]
 lemma subgroupFiberOrbitClass_bot_eq_iff (e e' : p ⁻¹' {b}) :
     subgroupFiberOrbitClass (⊥ : Subgroup (Deck p)) e =
         subgroupFiberOrbitClass (⊥ : Subgroup (Deck p)) e' ↔

--- a/TauCeti/AlgebraicTopology/UniversalCover/Deck/SubgroupFiberOrbitQuotientGroup.lean
+++ b/TauCeti/AlgebraicTopology/UniversalCover/Deck/SubgroupFiberOrbitQuotientGroup.lean
@@ -176,7 +176,6 @@ lemma subgroupFiberOrbitQuotientEquivQuotientGroup_symm_mk_coe
 
 /-- The inverse quotient equivalence sends the identity coset to the orbit class of the chosen
 fibre point. -/
-@[simp]
 lemma subgroupFiberOrbitQuotientEquivQuotientGroup_symm_one
     [MulAction.IsPretransitive (Deck p) (p ⁻¹' {b})] [IsCancelSMul (Deck p) (p ⁻¹' {b})]
     (H : Subgroup (Deck p)) (e : p ⁻¹' {b}) :


### PR DESCRIPTION
This PR removes the `@[simp]` attribute from 16 lemmas under `TauCeti/AlgebraicTopology/` that were flagged by the simp normal-form linter: simp can prove these from existing simp lemmas, so the attribute contributes nothing to the simp set. Every finding was re-verified against current `main` by running the `simpNF` linter on the flagged declarations before editing. The lemmas themselves are kept; only the attribute is dropped (each was a bare `@[simp]`). The full build passes with no downstream proof needing repair, so none of these were load-bearing.

Affected declarations (all in the `TauCeti` namespace):

- `TauCeti/AlgebraicTopology/SimplicialComplex/LinkStar.lean`: `PreAbstractSimplicialComplex.mem_deletion_singleton`, `PreAbstractSimplicialComplex.mem_link_singleton`
- `TauCeti/AlgebraicTopology/UniversalCover/CircleFundamentalGroup.lean`: `AddCircle.fundamentalGroupMulEquiv_zero_symm_monodromy`
- `TauCeti/AlgebraicTopology/UniversalCover/Deck/Connected.lean`: `Deck.deckEquivFiberOfSurjective_mul`, `Deck.deckEquivFiberOfSurjective_one`
- `TauCeti/AlgebraicTopology/UniversalCover/Deck/FiberTorsorTransport.lean`: `Deck.deckEquivFiberOfSurjective_fiberMap_coe`, `Deck.deckEquivFiber_fiberMap_coe`, `Deck.deckEquivFiber_symm_fiberMap`
- `TauCeti/AlgebraicTopology/UniversalCover/Deck/FiberTransport.lean`: `Deck.fiberMap_symm_image_orbit`, `Deck.mem_orbit_fiberMap_symm_iff`
- `TauCeti/AlgebraicTopology/UniversalCover/Deck/NormalizerQuotientFiberAction.lean`: `Deck.normalizerQuotient_one_smul_subgroupFiberOrbitClass`, `Deck.normalizerQuotient_smul_subgroupFiberOrbit_eq_smul_iff`
- `TauCeti/AlgebraicTopology/UniversalCover/Deck/Regular.lean`: `Deck.deckEquivFiber_mul`, `Deck.deckEquivFiber_one`
- `TauCeti/AlgebraicTopology/UniversalCover/Deck/SubgroupFiberOrbit.lean`: `Deck.subgroupFiberOrbitClass_bot_eq_iff`
- `TauCeti/AlgebraicTopology/UniversalCover/Deck/SubgroupFiberOrbitQuotientGroup.lean`: `Deck.subgroupFiberOrbitQuotientEquivQuotientGroup_symm_one`

🤖 Prepared with Claude Code