### PR TITLE
chore(NumberTheory): drop simp attributes that simp can already prove

### DIFF
--- a/TauCeti/NumberTheory/EffectiveBounds/HermiteCountMonotone.lean
+++ b/TauCeti/NumberTheory/EffectiveBounds/HermiteCountMonotone.lean
@@ -48,11 +48,9 @@ theorem hermiteCountBound_def (D C : ℕ) :
     hermiteCountBound D C = (2 * C + 1) ^ (D + 1) * D :=
   by simp [hermiteCountBound]
 
-@[simp]
 theorem hermiteCountBound_zero_left (C : ℕ) : hermiteCountBound 0 C = 0 := by
   simp [hermiteCountBound]
 
-@[simp]
 theorem hermiteCountBound_zero_right (D : ℕ) : hermiteCountBound D 0 = D := by
   simp [hermiteCountBound]
 

--- a/TauCeti/NumberTheory/EffectiveBounds/Regulator.lean
+++ b/TauCeti/NumberTheory/EffectiveBounds/Regulator.lean
@@ -135,7 +135,6 @@ theorem one_le_regulator_of_finrank_eq_one (h : finrank ℚ K = 1) : 1 ≤ regul
   one_le_regulator_of_finrank_le_one K h.le
 
 /-- **The rational regulator lower bound.** For `ℚ`, `1 ≤ R_ℚ`. -/
-@[simp]
 theorem one_le_regulator_rat : 1 ≤ regulator ℚ := by
   rw [regulator_rat_eq_one]
 

--- a/TauCeti/NumberTheory/LegendreSymbol/SquareClass.lean
+++ b/TauCeti/NumberTheory/LegendreSymbol/SquareClass.lean
@@ -38,7 +38,6 @@ theorem dvd_mul_sq_iff {a u : ℤ} (hu : ¬ (p : ℤ) ∣ u) :
   · exact absurd ((prime_intCast_of_fact (p := p)).dvd_of_dvd_pow hu2) hu
 
 /-- Multiplying by `u ^ 2` with `p ∤ u` preserves non-divisibility by `p`. -/
-@[simp]
 theorem not_dvd_mul_sq_iff {a u : ℤ} (hu : ¬ (p : ℤ) ∣ u) :
     ¬ (p : ℤ) ∣ a * u ^ 2 ↔ ¬ (p : ℤ) ∣ a :=
   not_congr (dvd_mul_sq_iff hu)

--- a/TauCeti/NumberTheory/Multiquadratic/LegendrePrimeDiscriminant.lean
+++ b/TauCeti/NumberTheory/Multiquadratic/LegendrePrimeDiscriminant.lean
@@ -79,7 +79,7 @@ reciprocity used by genus-field splitting criteria. -/
 reciprocal Legendre symbol `(q / p) = 1`. This is the form consumed by the multiquadratic
 prime-splitting law after the genus-field radicands have been normalized to prime
 discriminants. -/
-@[simp] theorem legendreSym_oddPrimeDiscriminant_eq_one_iff [Fact p.Prime] [Fact q.Prime]
+theorem legendreSym_oddPrimeDiscriminant_eq_one_iff [Fact p.Prime] [Fact q.Prime]
     (hp : p ≠ 2) (hq : q ≠ 2) :
     legendreSym q (oddPrimeDiscriminant p) = 1 ↔ legendreSym p (q : ℤ) = 1 := by
   rw [legendreSym_oddPrimeDiscriminant_eq_legendreSym hp hq]

--- a/TauCeti/NumberTheory/Multiquadratic/PrimeDiscriminant.lean
+++ b/TauCeti/NumberTheory/Multiquadratic/PrimeDiscriminant.lean
@@ -110,7 +110,7 @@ splitting law. -/
 /-- An integer does not divide an odd prime discriminant exactly when it does not divide the
 underlying natural number.
 The negated form is convenient for the unramifiedness side of the splitting law. -/
-@[simp] theorem not_dvd_oddPrimeDiscriminant_iff {p : ℕ} {q : ℤ} :
+theorem not_dvd_oddPrimeDiscriminant_iff {p : ℕ} {q : ℤ} :
     ¬ q ∣ oddPrimeDiscriminant p ↔ ¬ q ∣ (p : ℤ) := by
   exact not_congr dvd_oddPrimeDiscriminant_iff
 

--- a/TauCeti/NumberTheory/Multiquadratic/PrimeDiscriminants.lean
+++ b/TauCeti/NumberTheory/Multiquadratic/PrimeDiscriminants.lean
@@ -116,17 +116,17 @@ theorem primeDiscriminantRadicand_def (D : ℤ) :
   rfl
 
 /-- The prime-discriminant radicand of `-4` is `-1`. -/
-@[simp] theorem primeDiscriminantRadicand_neg_four :
+theorem primeDiscriminantRadicand_neg_four :
     primeDiscriminantRadicand (-4) = -1 := by
   simp [primeDiscriminantRadicand]
 
 /-- The prime-discriminant radicand of `8` is `2`. -/
-@[simp] theorem primeDiscriminantRadicand_eight :
+theorem primeDiscriminantRadicand_eight :
     primeDiscriminantRadicand 8 = 2 := by
   simp [primeDiscriminantRadicand]
 
 /-- The prime-discriminant radicand of `-8` is `-2`. -/
-@[simp] theorem primeDiscriminantRadicand_neg_eight :
+theorem primeDiscriminantRadicand_neg_eight :
     primeDiscriminantRadicand (-8) = -2 := by
   simp [primeDiscriminantRadicand]
 

--- a/TauCeti/NumberTheory/Multiquadratic/SubfieldLattice.lean
+++ b/TauCeti/NumberTheory/Multiquadratic/SubfieldLattice.lean
@@ -92,7 +92,7 @@ by
 
 /-- A sign vector belongs to the subspace attached to an intermediate field exactly when it is the
 sign pattern of an automorphism fixing that field. -/
-@[simp] theorem mem_intermediateFieldEquivSubmodule_apply_ofDual_iff [Finite ι] [NeZero (2 : K)]
+theorem mem_intermediateFieldEquivSubmodule_apply_ofDual_iff [Finite ι] [NeZero (2 : K)]
     (hroot : ∀ i, root i ^ 2 = algebraMap K L (d i))
     (hindep : ∀ S : Finset ι, S.Nonempty → ¬ IsSquare (∏ i ∈ S, d i))
     (F : IntermediateField K (adjoin K (Set.range root))) (v : ι → ZMod 2) :


### PR DESCRIPTION
This PR removes the `@[simp]` attribute from 10 lemmas under `TauCeti/NumberTheory/` that were flagged by the simp normal-form linter: simp can prove these from existing simp lemmas, so the attribute contributes nothing to the simp set. Every finding was re-verified against current `main` by running the `simpNF` linter on the flagged declarations before editing. The lemmas themselves are kept; only the attribute is dropped (each was a bare `@[simp]`). The full build passes with no downstream proof needing repair, so none of these were load-bearing.

Affected declarations (all in the `TauCeti` namespace):

- `TauCeti/NumberTheory/EffectiveBounds/HermiteCountMonotone.lean`: `NumberField.hermiteCountBound_zero_left`, `NumberField.hermiteCountBound_zero_right`
- `TauCeti/NumberTheory/EffectiveBounds/Regulator.lean`: `NumberField.Units.one_le_regulator_rat`
- `TauCeti/NumberTheory/LegendreSymbol/SquareClass.lean`: `not_dvd_mul_sq_iff`
- `TauCeti/NumberTheory/Multiquadratic/LegendrePrimeDiscriminant.lean`: `Multiquadratic.legendreSym_oddPrimeDiscriminant_eq_one_iff`
- `TauCeti/NumberTheory/Multiquadratic/PrimeDiscriminant.lean`: `Multiquadratic.not_dvd_oddPrimeDiscriminant_iff`
- `TauCeti/NumberTheory/Multiquadratic/PrimeDiscriminants.lean`: `Multiquadratic.primeDiscriminantRadicand_eight`, `Multiquadratic.primeDiscriminantRadicand_neg_eight`, `Multiquadratic.primeDiscriminantRadicand_neg_four`
- `TauCeti/NumberTheory/Multiquadratic/SubfieldLattice.lean`: `Multiquadratic.mem_intermediateFieldEquivSubmodule_apply_ofDual_iff`

🤖 Prepared with Claude Code