### PR TITLE
chore(LowDimTopology): drop simp attributes that simp can already prove

### DIFF
--- a/TauCeti/LowDimTopology/Plumbing/CubeGenerator.lean
+++ b/TauCeti/LowDimTopology/Plumbing/CubeGenerator.lean
@@ -413,7 +413,6 @@ theorem upperFace_lowerFace_comm (hv : v ∈ C.directions) (hw : w ∈ C.directi
 
 /-- The direction set of the lower-lower codimension-two face is the ambient direction set with the
 two chosen directions removed. -/
-@[simp]
 theorem lowerFace_lowerFace_directions (hv : v ∈ C.directions)
     (hwv : w ∈ (C.lowerFace v hv).directions) :
     ((C.lowerFace v hv).lowerFace w hwv).directions = (C.directions.erase v).erase w := by
@@ -421,7 +420,6 @@ theorem lowerFace_lowerFace_directions (hv : v ∈ C.directions)
 
 /-- The direction set of the upper-upper codimension-two face is the ambient direction set with the
 two chosen directions removed. -/
-@[simp]
 theorem upperFace_upperFace_directions (hv : v ∈ C.directions)
     (hwv : w ∈ (C.upperFace v hv).directions) :
     ((C.upperFace v hv).upperFace w hwv).directions = (C.directions.erase v).erase w := by
@@ -429,7 +427,6 @@ theorem upperFace_upperFace_directions (hv : v ∈ C.directions)
 
 /-- The direction set of the lower-upper codimension-two face is the ambient direction set with the
 two chosen directions removed. -/
-@[simp]
 theorem lowerFace_upperFace_directions (hv : v ∈ C.directions)
     (hwv : w ∈ (C.lowerFace v hv).directions) :
     ((C.lowerFace v hv).upperFace w hwv).directions = (C.directions.erase v).erase w := by
@@ -437,35 +434,30 @@ theorem lowerFace_upperFace_directions (hv : v ∈ C.directions)
 
 /-- The direction set of the upper-lower codimension-two face is the ambient direction set with the
 two chosen directions removed. -/
-@[simp]
 theorem upperFace_lowerFace_directions (hv : v ∈ C.directions)
     (hwv : w ∈ (C.upperFace v hv).directions) :
     ((C.upperFace v hv).lowerFace w hwv).directions = (C.directions.erase v).erase w := by
   simp
 
 /-- The lower-lower codimension-two face keeps the ambient base point. -/
-@[simp]
 theorem lowerFace_lowerFace_base (hv : v ∈ C.directions)
     (hwv : w ∈ (C.lowerFace v hv).directions) :
     ((C.lowerFace v hv).lowerFace w hwv).base = C.base := by
   simp
 
 /-- The upper-upper codimension-two face sits at the far corner `C.base + E_v + E_w`. -/
-@[simp]
 theorem upperFace_upperFace_base (hv : v ∈ C.directions)
     (hwv : w ∈ (C.upperFace v hv).directions) :
     ((C.upperFace v hv).upperFace w hwv).base = C.base + Pi.single v (1 : ℤ) + Pi.single w 1 := by
   simp
 
 /-- The lower-upper codimension-two face sits at the mixed corner `C.base + E_w`. -/
-@[simp]
 theorem lowerFace_upperFace_base (hv : v ∈ C.directions)
     (hwv : w ∈ (C.lowerFace v hv).directions) :
     ((C.lowerFace v hv).upperFace w hwv).base = C.base + Pi.single w (1 : ℤ) := by
   simp
 
 /-- The upper-lower codimension-two face sits at the mixed corner `C.base + E_v`. -/
-@[simp]
 theorem upperFace_lowerFace_base (hv : v ∈ C.directions)
     (hwv : w ∈ (C.upperFace v hv).directions) :
     ((C.upperFace v hv).lowerFace w hwv).base = C.base + Pi.single v (1 : ℤ) := by


### PR DESCRIPTION
This PR removes the `@[simp]` attribute from 8 lemmas under `TauCeti/LowDimTopology/` that were flagged by the simp normal-form linter: simp can prove these from existing simp lemmas, so the attribute contributes nothing to the simp set. Every finding was re-verified against current `main` by running the `simpNF` linter on the flagged declarations before editing. The lemmas themselves are kept; only the attribute is dropped (each was a bare `@[simp]`). The full build passes with no downstream proof needing repair, so none of these were load-bearing.

Affected declarations (all in the `TauCeti` namespace):

- `TauCeti/LowDimTopology/Plumbing/CubeGenerator.lean`: `PlumbingCube.lowerFace_lowerFace_base`, `PlumbingCube.lowerFace_lowerFace_directions`, `PlumbingCube.lowerFace_upperFace_base`, `PlumbingCube.lowerFace_upperFace_directions`, `PlumbingCube.upperFace_lowerFace_base`, `PlumbingCube.upperFace_lowerFace_directions`, `PlumbingCube.upperFace_upperFace_base`, `PlumbingCube.upperFace_upperFace_directions`

🤖 Prepared with Claude Code