### PR TITLE
chore(Topology): drop simp attributes that simp can already prove

### DIFF
--- a/TauCeti/Topology/Algebra/HomeomorphCongr.lean
+++ b/TauCeti/Topology/Algebra/HomeomorphCongr.lean
@@ -49,7 +49,7 @@ namespace Homeomorph
 /-- Conjugation by a homeomorphism `e : M ≃ₜ N` as a group isomorphism between the
 self-homeomorphism groups: `homeoCongr e φ = e ∘ φ ∘ e⁻¹`. This is the homeomorphism analogue of
 `Equiv.permCongrHom` and the target of the forgetful naturality of `Diffeomorph.diffCongr`. -/
-@[expose, simps]
+@[expose, simps apply]
 def homeoCongr (e : M ≃ₜ N) : (M ≃ₜ M) ≃* (N ≃ₜ N) where
   toFun φ := (e.symm.trans φ).trans e
   invFun ψ := (e.trans ψ).trans e.symm

--- a/TauCeti/Topology/Homotopy/AmbientIsotopyClass.lean
+++ b/TauCeti/Topology/Homotopy/AmbientIsotopyClass.lean
@@ -301,7 +301,6 @@ def postcompHomeomorphPrecomp (h : Y ≃ₜ Z) (e : C(W, X)) :
     AmbientIsotopic.postcomp_homeomorph_precomp hfg h e
 
 /-- Computation rule for the two-sided coordinate-change map on representatives. -/
-@[simp]
 theorem postcompHomeomorphPrecomp_mk (h : Y ≃ₜ Z) (e : C(W, X)) (f : C(X, Y)) :
     postcompHomeomorphPrecomp h e (mk f) = mk ((h : C(Y, Z)).comp (f.comp e)) :=
   map_mk (fun f => (h : C(Y, Z)).comp (f.comp e))
@@ -315,7 +314,7 @@ theorem postcompHomeomorphPrecomp_apply (h : Y ≃ₜ Z) (e : C(W, X))
     postcompHomeomorphPrecomp h e x = postcompHomeomorph h (precomp e x) := by
   refine induction_on x ?_
   intro f
-  simp
+  simp [postcompHomeomorphPrecomp_mk]
 
 /-- The two-sided coordinate-change map equals the composite of the primitive coordinate-change
 maps. -/
@@ -332,7 +331,6 @@ def postcompHomeomorphPrecompEquiv (h : Y ≃ₜ Z) (e : W ≃ₜ X) :
   (precompHomeomorphEquiv e).trans (postcompHomeomorphEquiv h)
 
 /-- Computation rule for two-sided coordinate change on representatives. -/
-@[simp]
 theorem postcompHomeomorphPrecompEquiv_mk (h : Y ≃ₜ Z) (e : W ≃ₜ X) (f : C(X, Y)) :
     postcompHomeomorphPrecompEquiv h e (mk f) =
       mk ((h : C(Y, Z)).comp (f.comp (e : C(W, X)))) :=
@@ -373,7 +371,6 @@ theorem postcompHomeomorphPrecompEquiv_trans_apply (h : Y ≃ₜ Z) (k : Z ≃�
 
 /-- With the identity source reparametrisation, the two-sided coordinate-change equivalence is
 ambient postcomposition. -/
-@[simp]
 theorem postcompHomeomorphPrecompEquiv_refl_source_apply (h : Y ≃ₜ Z)
     (x : AmbientIsotopyClass X Y) :
     postcompHomeomorphPrecompEquiv h (Homeomorph.refl X) x = postcompHomeomorph h x := by
@@ -381,7 +378,6 @@ theorem postcompHomeomorphPrecompEquiv_refl_source_apply (h : Y ≃ₜ Z)
 
 /-- With the identity ambient homeomorphism, the two-sided coordinate-change equivalence is source
 reparametrisation. -/
-@[simp]
 theorem postcompHomeomorphPrecompEquiv_refl_ambient_apply (e : W ≃ₜ X)
     (x : AmbientIsotopyClass X Y) :
     postcompHomeomorphPrecompEquiv (Homeomorph.refl Y) e x =
@@ -390,7 +386,6 @@ theorem postcompHomeomorphPrecompEquiv_refl_ambient_apply (e : W ≃ₜ X)
 
 /-- The two-sided coordinate-change equivalence is the identity when both coordinate changes are
 identities. -/
-@[simp]
 theorem postcompHomeomorphPrecompEquiv_refl_refl_apply (x : AmbientIsotopyClass X Y) :
     postcompHomeomorphPrecompEquiv (Homeomorph.refl Y) (Homeomorph.refl X) x = x := by
   rw [postcompHomeomorphPrecompEquiv_refl_source_apply, postcompHomeomorph_refl]

--- a/TauCeti/Topology/Homotopy/AmbientIsotopyClassAction.lean
+++ b/TauCeti/Topology/Homotopy/AmbientIsotopyClassAction.lean
@@ -65,7 +65,6 @@ theorem postcompHomeomorph_eq_smul (h : Y ≃ₜ Y) :
   rfl
 
 /-- The ambient homeomorphism action on representatives. -/
-@[simp]
 theorem smul_mk (h : Y ≃ₜ Y) (f : C(X, Y)) :
     h • mk f = mk ((h : C(Y, Y)).comp f) :=
   postcompHomeomorph_mk h f

--- a/TauCeti/Topology/Homotopy/Covering.lean
+++ b/TauCeti/Topology/Homotopy/Covering.lean
@@ -135,7 +135,6 @@ lemma IsCoveringMap.fundamentalGroupEquivFiber_apply_symm_apply [SimplyConnected
 
 /-- On underlying points, the inverse of the general fibre equivalence is characterized by
 the loop class whose monodromy sends the chosen lift to the requested fibre point. -/
-@[simp]
 lemma IsCoveringMap.fundamentalGroupEquivFiber_apply_symm_apply_coe [SimplyConnectedSpace E]
     (hp : IsCoveringMap p) (e e' : p ⁻¹' {x}) :
     (hp.monodromy ((IsCoveringMap.fundamentalGroupEquivFiber hp e).symm e') e : E) = e' := by


### PR DESCRIPTION
This PR removes the `@[simp]` attribute from the 8 lemmas under `TauCeti/Topology/` flagged by the simp normal-form linter: simp can prove these from existing simp lemmas, so the attribute contributes nothing to the simp set. Every finding was re-verified against current `main` by running the `simpNF` linter on the flagged declarations before editing.

Seven lemmas keep their statements and lose only a bare `@[simp]`. The eighth, `Homeomorph.homeoCongr_symm_apply`, is generated by `@[simps]` on `homeoCongr`; the linter witness shows it follows from `homeoCongr_symm` and `homeoCongr_apply`, and it has no consumers in the repo, so the definition now uses `@[simps apply]` and the redundant generated lemma is no longer produced. This is the one deletion in the PR; flagging it here as requested for anything stronger than an attribute drop.

One downstream proof (`postcompHomeomorphPrecomp_apply`) silently relied on the dropped attribute of `postcompHomeomorphPrecomp_mk`; its `simp` call now names that lemma explicitly. Full build is green, so nothing here is load-bearing beyond that one-line repair.

Affected declarations (all in the `TauCeti` namespace):

- `TauCeti/Topology/Algebra/HomeomorphCongr.lean`: `Homeomorph.homeoCongr_symm_apply`
- `TauCeti/Topology/Homotopy/AmbientIsotopyClass.lean`: `AmbientIsotopyClass.postcompHomeomorphPrecompEquiv_mk`, `AmbientIsotopyClass.postcompHomeomorphPrecompEquiv_refl_ambient_apply`, `AmbientIsotopyClass.postcompHomeomorphPrecompEquiv_refl_refl_apply`, `AmbientIsotopyClass.postcompHomeomorphPrecompEquiv_refl_source_apply`, `AmbientIsotopyClass.postcompHomeomorphPrecomp_mk`
- `TauCeti/Topology/Homotopy/AmbientIsotopyClassAction.lean`: `AmbientIsotopyClass.smul_mk`
- `TauCeti/Topology/Homotopy/Covering.lean`: `IsCoveringMap.fundamentalGroupEquivFiber_apply_symm_apply_coe`

🤖 Prepared with Claude Code