### PR TITLE
chore(KnotTheory): drop simp attributes from lemmas not in simp normal form

### DIFF
--- a/TauCeti/KnotTheory/Grid/CommutationRotation.lean
+++ b/TauCeti/KnotTheory/Grid/CommutationRotation.lean
@@ -53,7 +53,6 @@ theorem columnArc_rotate (c : Fin n) :
 
 /-- Membership in a rotated column arc is membership of the reversed row in the opposite oriented
 column arc of the original diagram. -/
-@[simp]
 theorem mem_columnArc_rotate (c r : Fin n) :
     r ∈ columnArc G.rotate c ↔ r.rev ∈ columnArc G.swapMarkings c.rev := by
   rw [columnArc_rotate, Finset.mem_image]
@@ -81,7 +80,6 @@ theorem rowArc_rotate (r : Fin n) :
 
 /-- Membership in a rotated row arc is membership of the reversed column in the opposite oriented
 row arc of the original diagram. -/
-@[simp]
 theorem mem_rowArc_rotate (r c : Fin n) :
     c ∈ rowArc G.rotate r ↔ c.rev ∈ rowArc G.swapMarkings r.rev := by
   rw [rowArc_rotate, Finset.mem_image]

--- a/TauCeti/KnotTheory/Grid/CyclicInterval.lean
+++ b/TauCeti/KnotTheory/Grid/CyclicInterval.lean
@@ -172,7 +172,6 @@ theorem disjoint_cIoo_swap (a b : Fin n) : Disjoint (cIoo a b) (cIoo b a) := by
 
 /-- Membership in one of the two opposite cyclic intervals is the same as being neither
 endpoint. -/
-@[simp]
 theorem mem_cIoo_or_mem_cIoo_swap_iff {a b x : Fin n} (h : a ≠ b) :
     x ∈ cIoo a b ∨ x ∈ cIoo b a ↔ x ≠ a ∧ x ≠ b := by
   constructor
@@ -207,7 +206,6 @@ theorem mem_cIoo_or_mem_cIoo_swap_iff {a b x : Fin n} (h : a ≠ b) :
 
 /-- A point outside the clockwise interval from `a` to `b` is either an endpoint or lies in
 the opposite clockwise interval. -/
-@[simp]
 theorem not_mem_cIoo_iff {a b x : Fin n} (h : a ≠ b) :
     x ∉ cIoo a b ↔ x = a ∨ x = b ∨ x ∈ cIoo b a := by
   constructor

--- a/TauCeti/KnotTheory/Grid/Diagram.lean
+++ b/TauCeti/KnotTheory/Grid/Diagram.lean
@@ -265,7 +265,6 @@ theorem relabelRows_relabelColumns (ρ κ : Equiv.Perm (Fin n)) (x : GridState n
   simp
 
 /-- Membership in the point set after a row relabeling. -/
-@[simp]
 theorem mem_pointSet_relabelRows (ρ : Equiv.Perm (Fin n)) (x : GridState n)
     (p : Fin n × Fin n) :
     p ∈ (x.relabelRows ρ).pointSet ↔ (p.1, ρ.symm p.2) ∈ x.pointSet := by
@@ -440,7 +439,6 @@ theorem columnSwapNeighbors_eq_empty_of_one (x : GridState 1) :
 
 /-- A grid state is not a column-swap neighbour of itself: swapping two distinct columns moves the
 occupied row of either column, so the result differs from the original. -/
-@[simp]
 theorem self_notMem_columnSwapNeighbors (x : GridState n) : x ∉ x.columnSwapNeighbors := by
   rw [mem_columnSwapNeighbors]
   rintro ⟨c, d, hcd, hx⟩
@@ -449,7 +447,6 @@ theorem self_notMem_columnSwapNeighbors (x : GridState n) : x ∉ x.columnSwapNe
   exact hcd (x.toPerm.injective hval)
 
 /-- Row swaps transport the point set by the row transposition. -/
-@[simp]
 theorem mem_pointSet_swapRows (a b : Fin n) (x : GridState n) (p : Fin n × Fin n) :
     p ∈ (x.swapRows a b).pointSet ↔ (p.1, Equiv.swap a b p.2) ∈ x.pointSet := by
   simpa [swapRows] using GridState.mem_pointSet_relabelRows (Equiv.swap a b) x p
@@ -461,7 +458,6 @@ theorem mem_pointSet_swapColumns (a b : Fin n) (x : GridState n) (p : Fin n × F
 
 /-- A square is shared by a grid state and a column relabeling exactly when it is a
 source-state square whose column is fixed by the relabeling permutation. -/
-@[simp]
 theorem mem_pointSet_inter_relabelColumns_iff (x : GridState n) (κ : Equiv.Perm (Fin n))
     (p : Fin n × Fin n) :
     p ∈ x.pointSet ∩ (x.relabelColumns κ).pointSet ↔ p ∈ x.pointSet ∧ κ p.1 = p.1 := by
@@ -500,7 +496,6 @@ theorem swapColumns_swapColumns (a b : Fin n) (x : GridState n) :
 
 /-- A square is shared by a grid state and the state with columns `a` and `b` swapped exactly
 when it is a source-state square away from the two swapped columns. -/
-@[simp]
 theorem mem_pointSet_inter_swapColumns_iff (x : GridState n) {a b : Fin n} (h : a ≠ b)
     (p : Fin n × Fin n) :
     p ∈ x.pointSet ∩ (x.swapColumns a b).pointSet ↔
@@ -644,7 +639,6 @@ theorem swapColumns_transpose (a b : Fin n) (x : GridState n) :
 
 /-- A square lies in the reflected state exactly when its diagonal reflection lies in the
 original state. -/
-@[simp]
 theorem mem_pointSet_transpose (x : GridState n) (p : Fin n × Fin n) :
     p ∈ x.transpose.pointSet ↔ Prod.swap p ∈ x.pointSet := by
   simp only [mem_pointSet, transpose_apply]
@@ -863,14 +857,12 @@ theorem relabelColumns_X_apply (κ : Equiv.Perm (Fin n)) (c : Fin n) :
   rfl
 
 /-- Row relabeling transports the `O` marking set by the row permutation. -/
-@[simp]
 theorem mem_OSet_relabelRows (ρ : Equiv.Perm (Fin n)) (p : Fin n × Fin n) :
     p ∈ (G.relabelRows ρ).OSet ↔ (p.1, ρ.symm p.2) ∈ G.OSet := by
   rw [OSet, OSet]
   exact GridState.mem_pointSet_relabelRows ρ G.O p
 
 /-- Row relabeling transports the `X` marking set by the row permutation. -/
-@[simp]
 theorem mem_XSet_relabelRows (ρ : Equiv.Perm (Fin n)) (p : Fin n × Fin n) :
     p ∈ (G.relabelRows ρ).XSet ↔ (p.1, ρ.symm p.2) ∈ G.XSet := by
   rw [XSet, XSet]
@@ -919,13 +911,11 @@ theorem swapColumns_X (a b : Fin n) :
   rfl
 
 /-- Row swaps transport the `O` marking set by the row transposition. -/
-@[simp]
 theorem mem_OSet_swapRows (a b : Fin n) (p : Fin n × Fin n) :
     p ∈ (G.swapRows a b).OSet ↔ (p.1, Equiv.swap a b p.2) ∈ G.OSet := by
   simpa [swapRows] using G.mem_OSet_relabelRows (Equiv.swap a b) p
 
 /-- Row swaps transport the `X` marking set by the row transposition. -/
-@[simp]
 theorem mem_XSet_swapRows (a b : Fin n) (p : Fin n × Fin n) :
     p ∈ (G.swapRows a b).XSet ↔ (p.1, Equiv.swap a b p.2) ∈ G.XSet := by
   simpa [swapRows] using G.mem_XSet_relabelRows (Equiv.swap a b) p
@@ -999,10 +989,8 @@ theorem transpose_O : G.transpose.O = G.O.transpose := rfl
 @[simp]
 theorem transpose_X : G.transpose.X = G.X.transpose := rfl
 /-- The reflected diagram's `O` row coordinate is the original `O` column in that row. -/
-@[simp]
 theorem transpose_O_apply (c : Fin n) : G.transpose.O c = OColumnOfRow G c := by simp [OColumnOfRow]
 /-- The reflected diagram's `X` row coordinate is the original `X` column in that row. -/
-@[simp]
 theorem transpose_X_apply (c : Fin n) : G.transpose.X c = XColumnOfRow G c := by simp [XColumnOfRow]
 /-- The `O` marking in row `c` of the reflected diagram lies in column `G.O c`. -/
 @[simp]
@@ -1053,7 +1041,6 @@ theorem transpose_XSet : G.transpose.XSet = G.XSet.image Prod.swap := by
 
 /-- A square lies in the reflected diagram's `O`-marking set exactly when its diagonal
 reflection lies in the original `O`-marking set. -/
-@[simp]
 theorem mem_OSet_transpose (p : Fin n × Fin n) :
     p ∈ G.transpose.OSet ↔ Prod.swap p ∈ G.OSet := by
   rw [OSet, OSet, transpose_O]
@@ -1061,7 +1048,6 @@ theorem mem_OSet_transpose (p : Fin n × Fin n) :
 
 /-- A square lies in the reflected diagram's `X`-marking set exactly when its diagonal
 reflection lies in the original `X`-marking set. -/
-@[simp]
 theorem mem_XSet_transpose (p : Fin n × Fin n) :
     p ∈ G.transpose.XSet ↔ Prod.swap p ∈ G.XSet := by
   rw [XSet, XSet, transpose_X]

--- a/TauCeti/KnotTheory/Grid/GradingInteger.lean
+++ b/TauCeti/KnotTheory/Grid/GradingInteger.lean
@@ -223,7 +223,6 @@ theorem maslovXℤ_swapMarkings (x : GridState n) :
 
 /-- The marking swap negates the integer numerator of twice the Alexander grading, up to twice
 the normalization shift: `2·A_swap(x) = −2·A(x) − 2(n − 1)`. -/
-@[simp]
 theorem alexanderTwoℤ_swapMarkings (x : GridState n) :
     G.swapMarkings.alexanderTwoℤ x = -G.alexanderTwoℤ x - 2 * ((n : ℤ) - 1) := by
   rw [alexanderTwoℤ_def, alexanderTwoℤ_def, maslovOℤ_swapMarkings, maslovXℤ_swapMarkings]

--- a/TauCeti/KnotTheory/Grid/Gradings.lean
+++ b/TauCeti/KnotTheory/Grid/Gradings.lean
@@ -179,7 +179,6 @@ theorem maslovX_swapMarkings (x : GridState n) :
 /-- The marking swap negates the Alexander grading, up to the constant normalization shift:
   `A_swap(x) = -A(x) - (n - 1)`. The grading is built antisymmetrically from the two Maslov
   gradings, which the swap exchanges, while the shift depends only on the grid size. -/
-@[simp]
 theorem alexander_swapMarkings (x : GridState n) :
     G.swapMarkings.alexander x = -G.alexander x - (((n : ℤ) - 1 : ℤ) : ℚ) := by
   rw [alexander_def, alexander_def, maslovO_swapMarkings, maslovX_swapMarkings]

--- a/TauCeti/KnotTheory/Grid/JFunction.lean
+++ b/TauCeti/KnotTheory/Grid/JFunction.lean
@@ -111,7 +111,6 @@ theorem I_def (s t : Finset (Fin n × Fin n)) :
   rfl
 
 /-- Membership in the finite set counted by `GridPoint.I`. -/
-@[simp]
 theorem mem_filter_product_isSouthWest (s t : Finset (Fin n × Fin n))
   (pq : (Fin n × Fin n) × (Fin n × Fin n)) :
     pq ∈ (s ×ˢ t).filter (fun pq => IsSouthWest pq.1 pq.2) ↔
@@ -422,7 +421,7 @@ theorem JNum_mono_right {s t₁ t₂ : Finset (Fin n × Fin n)} (h : t₁ ⊆ t�
 /-- The strict southwest relation is invariant under reflecting both points across the diagonal:
 exchanging the column and row coordinates of both endpoints exchanges the two strict
 inequalities. -/
-@[simp, grind =]
+@[grind =]
 theorem isSouthWest_swap (p q : Fin n × Fin n) :
     IsSouthWest (Prod.swap p) (Prod.swap q) ↔ IsSouthWest p q := by
   unfold IsSouthWest
@@ -465,7 +464,7 @@ theorem JDiff_image_swap (s a t b : Finset (Fin n × Fin n)) :
 
 /-- Reversing both coordinates of both points of a pair exchanges the two endpoints of the strict
 southwest relation: it sends the column and row comparisons to their reverses. -/
-@[simp, grind =]
+@[grind =]
 theorem isSouthWest_rev (p q : Fin n × Fin n) :
     IsSouthWest (Prod.map Fin.rev Fin.rev p) (Prod.map Fin.rev Fin.rev q) ↔ IsSouthWest q p := by
   simp only [IsSouthWest, Prod.map_fst, Prod.map_snd]

--- a/TauCeti/KnotTheory/Grid/Rectangle.lean
+++ b/TauCeti/KnotTheory/Grid/Rectangle.lean
@@ -493,49 +493,41 @@ theorem all_self (x : GridState n) : all x x = ∅ := by
   exact R.source_ne_target rfl |>.elim
 
 /-- The initial lower corner is a point of the source state. -/
-@[simp]
 theorem left_bottom_mem_source : (R.left, R.bottom) ∈ x.pointSet := by
   simp [bottom]
 
 /-- The terminal upper corner is a point of the source state. -/
-@[simp]
 theorem right_top_mem_source : (R.right, R.top) ∈ x.pointSet := by
   simp [top]
 
 /-- The initial upper corner is a point of the target state. -/
-@[simp]
 theorem left_top_mem_target : (R.left, R.top) ∈ y.pointSet := by
   simp [top, R.map_left]
 
 /-- The terminal lower corner is a point of the target state. -/
-@[simp]
 theorem right_bottom_mem_target : (R.right, R.bottom) ∈ y.pointSet := by
   simp [bottom, R.map_right]
 
 /-- The lower-left corner of the opposite rectangle is a target-state point of the original
 rectangle. -/
-@[simp]
 theorem symm_left_bottom_mem_source (R : GridRectangleBetween x y) :
     (R.symm.left, R.symm.bottom) ∈ y.pointSet := by
   simpa using R.right_bottom_mem_target
 
 /-- The upper-right corner of the opposite rectangle is a target-state point of the original
 rectangle. -/
-@[simp]
 theorem symm_right_top_mem_source (R : GridRectangleBetween x y) :
     (R.symm.right, R.symm.top) ∈ y.pointSet := by
   simpa using R.left_top_mem_target
 
 /-- The upper-left corner of the opposite rectangle is a source-state point of the original
 rectangle. -/
-@[simp]
 theorem symm_left_top_mem_target (R : GridRectangleBetween x y) :
     (R.symm.left, R.symm.top) ∈ x.pointSet := by
   simpa using R.right_top_mem_source
 
 /-- The lower-right corner of the opposite rectangle is a source-state point of the original
 rectangle. -/
-@[simp]
 theorem symm_right_bottom_mem_target (R : GridRectangleBetween x y) :
     (R.symm.right, R.symm.bottom) ∈ x.pointSet := by
   simpa using R.left_bottom_mem_source

--- a/TauCeti/KnotTheory/Grid/RectangleSwap.lean
+++ b/TauCeti/KnotTheory/Grid/RectangleSwap.lean
@@ -118,7 +118,6 @@ theorem mem_target_pointSet_iff (p : Fin n × Fin n) :
 /-- The two side columns carry the four corners of a rectangle, so a square that the two states
 share must avoid both side columns. Conversely, away from the side columns the two states agree,
 so every source square off the side columns is shared. -/
-@[simp]
 theorem mem_pointSet_inter_iff (p : Fin n × Fin n) :
     p ∈ x.pointSet ∩ y.pointSet ↔
       p ∈ x.pointSet ∧ p.1 ≠ R.left ∧ p.1 ≠ R.right := by
@@ -126,7 +125,6 @@ theorem mem_pointSet_inter_iff (p : Fin n × Fin n) :
     GridState.mem_pointSet_inter_swapColumns_iff x R.left_ne_right p
 
 /-- The lower-left corner is not shared with the target state: it sits on a side column. -/
-@[simp]
 theorem left_bottom_notMem_inter :
     (R.left, R.bottom) ∉ x.pointSet ∩ y.pointSet := by
   rw [mem_pointSet_inter_iff R]
@@ -134,7 +132,6 @@ theorem left_bottom_notMem_inter :
   exact hleft rfl
 
 /-- The upper-right corner is not shared with the target state: it sits on a side column. -/
-@[simp]
 theorem right_top_notMem_inter :
     (R.right, R.top) ∉ x.pointSet ∩ y.pointSet := by
   rw [mem_pointSet_inter_iff R]
@@ -142,7 +139,6 @@ theorem right_top_notMem_inter :
   exact hright rfl
 
 /-- The upper-left target corner is not shared with the source state: it sits on a side column. -/
-@[simp]
 theorem left_top_notMem_inter :
     (R.left, R.top) ∉ x.pointSet ∩ y.pointSet := by
   rw [mem_pointSet_inter_iff R]
@@ -150,7 +146,6 @@ theorem left_top_notMem_inter :
   exact hleft rfl
 
 /-- The lower-right target corner is not shared with the source state: it sits on a side column. -/
-@[simp]
 theorem right_bottom_notMem_inter :
     (R.right, R.bottom) ∉ x.pointSet ∩ y.pointSet := by
   rw [mem_pointSet_inter_iff R]

--- a/TauCeti/KnotTheory/Grid/Rotation.lean
+++ b/TauCeti/KnotTheory/Grid/Rotation.lean
@@ -96,7 +96,6 @@ theorem rotate_apply (x : GridState n) (c : Fin n) :
 
 /-- In the rotated state, the occupied square in row `r` lies in the reversed column of the
 occupied square in row `r.rev` of the original state. -/
-@[simp]
 theorem columnOfRow_rotate (x : GridState n) (r : Fin n) :
     x.rotate.columnOfRow r = (x.columnOfRow r.rev).rev := by
   apply x.rotate.toPerm.injective
@@ -104,7 +103,6 @@ theorem columnOfRow_rotate (x : GridState n) (r : Fin n) :
 
 /-- A square lies in the rotated state exactly when its half-turn rotation lies in the original
 state. -/
-@[simp]
 theorem mem_pointSet_rotate (x : GridState n) (p : Fin n × Fin n) :
     p ∈ x.rotate.pointSet ↔ Prod.map Fin.rev Fin.rev p ∈ x.pointSet := by
   simp only [mem_pointSet, rotate_apply, Prod.map_fst, Prod.map_snd, Fin.rev_eq_iff]
@@ -213,7 +211,6 @@ theorem rotate_XSet : G.rotate.XSet = G.XSet.image (Prod.map Fin.rev Fin.rev) :=
 
 /-- A square lies in the rotated diagram's `O`-marking set exactly when its half-turn rotation
 lies in the original `O`-marking set. -/
-@[simp]
 theorem mem_OSet_rotate (p : Fin n × Fin n) :
     p ∈ G.rotate.OSet ↔ Prod.map Fin.rev Fin.rev p ∈ G.OSet := by
   rw [OSet, OSet, rotate_O]
@@ -221,7 +218,6 @@ theorem mem_OSet_rotate (p : Fin n × Fin n) :
 
 /-- A square lies in the rotated diagram's `X`-marking set exactly when its half-turn rotation
 lies in the original `X`-marking set. -/
-@[simp]
 theorem mem_XSet_rotate (p : Fin n × Fin n) :
     p ∈ G.rotate.XSet ↔ Prod.map Fin.rev Fin.rev p ∈ G.XSet := by
   rw [XSet, XSet, rotate_X]


### PR DESCRIPTION
This PR drops the `@[simp]` attribute from 40 KnotTheory lemmas flagged by the simpNF linter with reason "Left-hand side simplifies from ..." (wave 2 of the simp normal-form cleanup; wave 1 was the "simp can prove this" batch). Every entry was re-verified against the current simp set on `main` before acting; all 40 still violated.

In each case the left-hand side is already rewritten by the file's own unfolding calculus — `mem_pointSet`, `mem_OSet`/`mem_XSet`, `mem_cIoo`, `mem_columnArc`/`mem_rowArc`, `isSouthWest_iff`, and the `*_apply`/`rotate_*`/`transpose_*`/`swapMarkings_*` simp lemmas — so the flagged attribute can never usefully fire on a simp-normalized goal. The lemmas themselves are kept for manual use; only the attributes are removed. The full library builds with no downstream repairs, confirming no proof relied on these attributes.

De-simped (40), by file:

- `Grid/CommutationRotation.lean`: `mem_columnArc_rotate`, `mem_rowArc_rotate`
- `Grid/CyclicInterval.lean`: `mem_cIoo_or_mem_cIoo_swap_iff`, `not_mem_cIoo_iff`
- `Grid/Diagram.lean`: `self_notMem_columnSwapNeighbors`, `transpose_O_apply`, `transpose_X_apply`, `mem_OSet_swapRows`, `mem_OSet_transpose`, `mem_OSet_relabelRows`, `mem_XSet_swapRows`, `mem_XSet_transpose`, `mem_XSet_relabelRows`, `mem_pointSet_relabelRows`, `mem_pointSet_swapRows`, `mem_pointSet_transpose`, `mem_pointSet_inter_swapColumns_iff`, `mem_pointSet_inter_relabelColumns_iff`
- `Grid/GradingInteger.lean`: `alexanderTwoℤ_swapMarkings`
- `Grid/Gradings.lean`: `alexander_swapMarkings`
- `Grid/JFunction.lean`: `isSouthWest_swap`, `isSouthWest_rev`, `mem_filter_product_isSouthWest`
- `Grid/Rectangle.lean`: `left_bottom_mem_source`, `right_top_mem_source`, `left_top_mem_target`, `right_bottom_mem_target`, `symm_left_bottom_mem_source`, `symm_right_top_mem_source`, `symm_left_top_mem_target`, `symm_right_bottom_mem_target`
- `Grid/RectangleSwap.lean`: `left_bottom_notMem_inter`, `left_top_notMem_inter`, `right_bottom_notMem_inter`, `right_top_notMem_inter`, `mem_pointSet_inter_iff`
- `Grid/Rotation.lean`: `columnOfRow_rotate`, `mem_OSet_rotate`, `mem_XSet_rotate`, `mem_pointSet_rotate`

Restated: none. Left with rationale: none. All 40 re-lint clean (`LINT-OK`) after the change.

🤖 Prepared with Claude Code
