### PR TITLE
chore(Analysis): drop simp attributes from lemmas not in simp normal form

### DIFF
--- a/TauCeti/Analysis/CompletelyMonotone/BernsteinMeasures.lean
+++ b/TauCeti/Analysis/CompletelyMonotone/BernsteinMeasures.lean
@@ -358,7 +358,6 @@ lemma chafaiRescaled_integral (f : ℝ → ℝ) (n : ℕ) {g : ℝ≥0 → ℝ}
 
 /-- On positive source points, pulling the Bernstein kernel back along the Chafaï rescaling
 gives the classical finite-order kernel `(max (1 - x / t) 0) ^ (n - 1)`. -/
-@[simp]
 lemma bernsteinKernel_chafaiRescaling_of_pos {n : ℕ} (hn : 2 ≤ n) (x : ℝ) {t : ℝ}
     (ht : 0 < t) :
     bernsteinKernel n x (chafaiRescaling n t : ℝ) = (max (1 - x / t) 0) ^ (n - 1) := by
@@ -409,7 +408,6 @@ lemma chafaiRescaled_integral_bernsteinKernelBoundedContinuous
   simp
 
 /-- `chafaiMeasure f n` lives on `(0, ∞)`: its complement has zero mass. -/
-@[simp]
 lemma chafaiMeasure_compl_Ioi (f : ℝ → ℝ) (n : ℕ) :
     (chafaiMeasure f n) (Ioi 0)ᶜ = 0 := by
   unfold chafaiMeasure

--- a/TauCeti/Analysis/Complex/Conformal/Moebius.lean
+++ b/TauCeti/Analysis/Complex/Conformal/Moebius.lean
@@ -68,7 +68,6 @@ lemma unitDiscMoebius_apply_zero (a : Complex.UnitDisc) :
   simp
 
 /-- The norm of the Moebius factor is the pseudo-hyperbolic expression. -/
-@[simp]
 lemma norm_unitDiscMoebius (a z : Complex.UnitDisc) :
     ‖(unitDiscMoebius a z : ℂ)‖ = pseudoHyperbolicExpr (z : ℂ) (a : ℂ) :=
   (pseudoHyperbolicExpr_def (z : ℂ) (a : ℂ)).symm

--- a/TauCeti/Analysis/Complex/Conformal/UnitDiscAutomorphism.lean
+++ b/TauCeti/Analysis/Complex/Conformal/UnitDiscAutomorphism.lean
@@ -84,7 +84,6 @@ lemma unitDiscStandardAutomorphismEquiv_apply_zero (u : Circle) (a : Complex.Uni
   simp [unitDiscStandardAutomorphismEquiv]
 
 /-- The norm of a standard automorphism value is the pseudo-hyperbolic expression. -/
-@[simp]
 lemma norm_unitDiscStandardAutomorphismEquiv (u : Circle) (a z : Complex.UnitDisc) :
     ‖(unitDiscStandardAutomorphismEquiv u a z : ℂ)‖ = pseudoHyperbolicExpr (z : ℂ) (a : ℂ) := by
   rw [unitDiscStandardAutomorphismEquiv_apply, Complex.UnitDisc.coe_circle_smul, norm_mul,

--- a/TauCeti/Analysis/PDE/EnergyForm.lean
+++ b/TauCeti/Analysis/PDE/EnergyForm.lean
@@ -101,7 +101,6 @@ lemma energyIntegrand_apply (A : Matrix n n ℝ) (b : EuclideanSpace ℝ n) (c :
   simp [energyIntegrand]
 
 /-- The diagonal of the jet form, the energy density `⟨a ∇u, ∇u⟩ + ⟪b, ∇u⟫ u + c u²`. -/
-@[simp]
 lemma energyIntegrand_self (A : Matrix n n ℝ) (b : EuclideanSpace ℝ n) (c : ℝ)
     (U : ℝ × EuclideanSpace ℝ n) :
     energyIntegrand A b c U U
@@ -116,7 +115,6 @@ lemma energyIntegrand_one_zero_zero_apply (U V : ℝ × EuclideanSpace ℝ n) :
   simp [energyIntegrand_apply]
 
 /-- The diagonal of the Laplacian model's jet form is the Dirichlet energy density `‖∇u‖²`. -/
-@[simp]
 lemma energyIntegrand_one_zero_zero_self (U : ℝ × EuclideanSpace ℝ n) :
     energyIntegrand (1 : Matrix n n ℝ) 0 0 U U = ‖U.2‖ ^ 2 := by
   rw [energyIntegrand_self, toQuadraticForm'_one]
@@ -130,7 +128,6 @@ lemma energyIntegrand_one_zero_mass_apply (c : ℝ) (U V : ℝ × EuclideanSpace
 
 /-- The shifted Laplacian model `-Δ + c` has diagonal jet density
 `‖∇u‖² + c u²`. -/
-@[simp]
 lemma energyIntegrand_one_zero_mass_self (c : ℝ) (U : ℝ × EuclideanSpace ℝ n) :
     energyIntegrand (1 : Matrix n n ℝ) 0 c U U = ‖U.2‖ ^ 2 + c * U.1 ^ 2 := by
   rw [energyIntegrand_self, toQuadraticForm'_one]

--- a/TauCeti/Analysis/PDE/SymmetricEnergy.lean
+++ b/TauCeti/Analysis/PDE/SymmetricEnergy.lean
@@ -47,7 +47,6 @@ open Matrix
 variable {X n : Type*} [Fintype n] [DecidableEq n]
 
 /-- With zero drift, transposing the principal coefficient swaps the two jet arguments. -/
-@[simp]
 lemma energyIntegrand_zero_drift_transpose_apply (A : Matrix n n ℝ) (c : ℝ)
     (U V : ℝ × EuclideanSpace ℝ n) :
     energyIntegrand Aᵀ 0 c U V = energyIntegrand A 0 c V U := by
@@ -87,7 +86,6 @@ lemma energyIntegrand_one_zero_drift_comm (c : ℝ) (U V : ℝ × EuclideanSpace
 
 /-- The symmetric part's zero-drift jet form is the average of the original form and its
 transpose. -/
-@[simp]
 lemma energyIntegrand_coefficientSymmetricPart_zero_drift_apply (A : Matrix n n ℝ)
     (c : ℝ) (U V : ℝ × EuclideanSpace ℝ n) :
     energyIntegrand (coefficientSymmetricPart A) 0 c U V =
@@ -99,7 +97,6 @@ lemma energyIntegrand_coefficientSymmetricPart_zero_drift_apply (A : Matrix n n 
 
 /-- Replacing the principal coefficient by its symmetric part does not change the diagonal
 energy density. -/
-@[simp]
 lemma energyIntegrand_coefficientSymmetricPart_self (A : Matrix n n ℝ)
     (b : EuclideanSpace ℝ n) (c : ℝ) (U : ℝ × EuclideanSpace ℝ n) :
     energyIntegrand (coefficientSymmetricPart A) b c U U =

--- a/TauCeti/Analysis/PDE/UniformEllipticity.lean
+++ b/TauCeti/Analysis/PDE/UniformEllipticity.lean
@@ -140,7 +140,6 @@ lemma toQuadraticForm'_add (A B : Matrix n n ℝ) (ξ : EuclideanSpace ℝ n) :
     toQuadraticForm'_eq_dotProduct, add_mulVec, dotProduct_add]
 
 /-- Matrix bilinear forms are linear in scalar multiplication of the coefficient matrix. -/
-@[simp]
 lemma matrixBilinearForm_smul_apply (c : ℝ) (A : Matrix n n ℝ)
     (η ξ : EuclideanSpace ℝ n) :
     matrixBilinearForm (c • A) η ξ = c * matrixBilinearForm A η ξ := by
@@ -148,7 +147,6 @@ lemma matrixBilinearForm_smul_apply (c : ℝ) (A : Matrix n n ℝ)
   simp [smul_eq_mul]
 
 /-- Matrix bilinear forms are additive in the coefficient matrix. -/
-@[simp]
 lemma matrixBilinearForm_add_apply (A B : Matrix n n ℝ) (η ξ : EuclideanSpace ℝ n) :
     matrixBilinearForm (A + B) η ξ = matrixBilinearForm A η ξ + matrixBilinearForm B η ξ := by
   rw [matrixBilinearForm_apply, matrixBilinearForm_apply, matrixBilinearForm_apply,
@@ -163,19 +161,16 @@ lemma toQuadraticForm'_transpose (A : Matrix n n ℝ) (ξ : EuclideanSpace ℝ n
 
 /-- Transposing the coefficient matrix swaps the arguments of the bundled matrix bilinear
 form. -/
-@[simp]
 lemma matrixBilinearForm_transpose_apply (A : Matrix n n ℝ) (η ξ : EuclideanSpace ℝ n) :
     matrixBilinearForm Aᵀ η ξ = matrixBilinearForm A ξ η := by
   rw [matrixBilinearForm_apply, matrixBilinearForm_apply, Matrix.dotProduct_transpose_mulVec]
 
 /-- The matrix bilinear form associated to `c • 1` is `c` times the Euclidean dot product. -/
-@[simp]
 lemma matrixBilinearForm_smul_one_apply (c : ℝ) (η ξ : EuclideanSpace ℝ n) :
     matrixBilinearForm (c • (1 : Matrix n n ℝ)) η ξ = c * (η ⬝ᵥ ξ) := by
   rw [matrixBilinearForm_smul_apply, matrixBilinearForm_one_apply]
 
 /-- The quadratic part of the matrix bilinear form is the matrix quadratic form. -/
-@[simp]
 lemma matrixBilinearForm_self (A : Matrix n n ℝ) (ξ : EuclideanSpace ℝ n) :
     matrixBilinearForm A ξ ξ = A.toQuadraticForm' ξ := by
   rw [matrixBilinearForm_apply, toQuadraticForm'_eq_dotProduct]
@@ -213,7 +208,6 @@ lemma toQuadraticForm'_coefficientSymmetricPart (A : Matrix n n ℝ)
 
 /-- The bundled bilinear form of the symmetric part is the average of the original bilinear
 form and its transpose. -/
-@[simp]
 lemma matrixBilinearForm_coefficientSymmetricPart_apply (A : Matrix n n ℝ)
     (η ξ : EuclideanSpace ℝ n) :
     matrixBilinearForm (coefficientSymmetricPart A) η ξ =

--- a/TauCeti/Analysis/PositiveDefinite/FunctionClosure.lean
+++ b/TauCeti/Analysis/PositiveDefinite/FunctionClosure.lean
@@ -138,7 +138,6 @@ theorem sum_real_smul_apply_of_apply_eq_one {ι : Type*} {s : Finset ι} {w : ι
 
 /-- A finite real-weighted sum of functions normalized at a point is normalized at that point when
 the weights sum to `1`. -/
-@[simp]
 theorem sum_real_smul_apply_eq_one {ι : Type*} {s : Finset ι} {w : ι → ℝ}
     {F : ι → N → ℂ} {x : N} (hFx : ∀ i ∈ s, F i x = 1)
     (hw_sum : ∑ i ∈ s, w i = 1) :
@@ -156,7 +155,6 @@ theorem sum_real_const_mul_apply_of_apply_eq_one {ι : Type*} {s : Finset ι}
 
 /-- A finite real-weighted sum, in multiplication form, of functions normalized at a point is
 normalized at that point when the weights sum to `1`. -/
-@[simp]
 theorem sum_real_const_mul_apply_eq_one {ι : Type*} {s : Finset ι} {w : ι → ℝ}
     {F : ι → N → ℂ} {x : N} (hFx : ∀ i ∈ s, F i x = 1)
     (hw_sum : ∑ i ∈ s, w i = 1) :
@@ -205,7 +203,6 @@ theorem sum_real_smul_apply_zero_of_apply_zero_eq_one {ι : Type*} {s : Finset �
 
 /-- A finite real-weighted sum of functions normalized at the origin is normalized when the weights
 sum to `1`. -/
-@[simp]
 theorem sum_real_smul_apply_zero_eq_one {ι : Type*} {s : Finset ι} {w : ι → ℝ}
     {F : ι → N → ℂ} (hF0 : ∀ i ∈ s, F i 0 = 1) (hw_sum : ∑ i ∈ s, w i = 1) :
     (fun x => ∑ i ∈ s, w i • F i x) 0 = 1 :=
@@ -220,7 +217,6 @@ theorem sum_real_const_mul_apply_zero_of_apply_zero_eq_one {ι : Type*} {s : Fin
 
 /-- A finite real-weighted sum, in multiplication form, of functions normalized at the origin is
 normalized when the weights sum to `1`. -/
-@[simp]
 theorem sum_real_const_mul_apply_zero_eq_one {ι : Type*} {s : Finset ι} {w : ι → ℝ}
     {F : ι → N → ℂ} (hF0 : ∀ i ∈ s, F i 0 = 1) (hw_sum : ∑ i ∈ s, w i = 1) :
     (fun x => ∑ i ∈ s, (w i : ℂ) * F i x) 0 = 1 :=


### PR DESCRIPTION
This PR drops the `@[simp]` attribute from 20 Analysis lemmas flagged by the simpNF linter with reason "Left-hand side simplifies from ..." (wave 2 of the simp normal-form cleanup). Every entry was re-verified against the current simp set on `main` before acting; all still violated.

In each case the existing simp set already rewrites the flagged left-hand side — via the files' own `*_apply` unfolding lemmas (`energyIntegrand_apply`, `matrixBilinearForm_apply`, `chafaiMeasure_apply`, `unitDiscStandardAutomorphismEquiv_apply`), the coercion normal form `coe_unitDiscMoebius`, the conditional unfolding `bernsteinKernel_of_two_le`, or plain beta reduction — so the flagged attribute cannot usefully fire on a simp-normalized goal. The lemmas are kept for manual use. The full library builds with no downstream repairs.

De-simped (20):

- `CompletelyMonotone/BernsteinMeasures.lean`: `chafaiMeasure_compl_Ioi`, `bernsteinKernel_chafaiRescaling_of_pos`
- `Complex/Conformal/Moebius.lean`: `norm_unitDiscMoebius`
- `Complex/Conformal/UnitDiscAutomorphism.lean`: `norm_unitDiscStandardAutomorphismEquiv`
- `PDE/EnergyForm.lean`: `energyIntegrand_self`, `energyIntegrand_one_zero_zero_self`, `energyIntegrand_one_zero_mass_self`
- `PDE/SymmetricEnergy.lean`: `energyIntegrand_coefficientSymmetricPart_self`, `energyIntegrand_coefficientSymmetricPart_zero_drift_apply`, `energyIntegrand_zero_drift_transpose_apply`
- `PDE/UniformEllipticity.lean`: `matrixBilinearForm_transpose_apply`, `matrixBilinearForm_add_apply`, `matrixBilinearForm_smul_apply`, `matrixBilinearForm_self`, `matrixBilinearForm_coefficientSymmetricPart_apply`, `matrixBilinearForm_smul_one_apply`
- `PositiveDefinite/FunctionClosure.lean`: `sum_real_smul_apply_eq_one`, `sum_real_const_mul_apply_eq_one`, `sum_real_smul_apply_zero_eq_one`, `sum_real_const_mul_apply_zero_eq_one` (their LHS is a lambda applied to a point, which simp beta-reduces before any matching, so these can never fire as stated)

Left in place, needs design attention (4). These look like the intended normal forms; the violation comes from another simp lemma being too aggressive, and silencing them here would lose useful automation rather than clean it up:

- `TauCeti.PDE.uniformlyEllipticOn_biUnion_iff` (`PDE/UniformEllipticity.lean`): `uniformlyEllipticOn_iUnion_iff` (simp) decomposes the bounded union `⋃ i ∈ s, Ωs i` into the junk form `∀ i, UniformlyEllipticOn (⋃ (_ : i ∈ s), Ωs i) ...`, which the simp set then cannot reduce. The two lemmas need a confluence decision (mirror of the Mathlib `iUnion`/`biUnion` simp pairing).
- `TauCeti.integral_normalizedChebyshevT_mul_normalizedChebyshevT_measureT_eq_ite` (`SpecialFunctions/Trigonometric/Chebyshev/Measure.lean`): this orthonormality Kronecker-delta lemma is the point of `normalizedChebyshevT`, but `normalizedChebyshevT_def` is `@[simp]` and unfolds the definition inside the integral first. Consider removing simp from the `_def` lemma instead.
- `TauCeti.unitDiscStandardAutomorphismEquiv_self` and `TauCeti.unitDiscStandardAutomorphismEquiv_eq_zero_iff` (`Complex/Conformal/UnitDiscAutomorphism.lean`): `unitDiscStandardAutomorphismEquiv_apply` (simp) rewrites the LHS to `u • unitDiscMoebius a z`, and the simp set then has no `Circle`-action `smul_zero` / `smul_eq_zero` lemmas for `Complex.UnitDisc` to finish the job. Either those normalization lemmas should be added or `_apply` should not be simp.

Restated: none.

🤖 Prepared with Claude Code
