### PR TITLE
fix: bring AlgebraicTopology simp lemmas into simp normal form

### DIFF
--- a/TauCeti/AlgebraicTopology/FundamentalGroup/BasepointChange.lean
+++ b/TauCeti/AlgebraicTopology/FundamentalGroup/BasepointChange.lean
@@ -75,12 +75,15 @@ path-conjugation isomorphism of fundamental groups. -/
 lemma basepointChangeNormalizerQuotientEquiv_mk (γ : Path x₀ x₁)
     (H : Subgroup (_root_.FundamentalGroup X x₀))
     (g : _root_.Subgroup.normalizer (H : Set (_root_.FundamentalGroup X x₀))) :
-    basepointChangeNormalizerQuotientEquiv γ H (Subgroup.normalizerQuotientMk H g) =
-      Subgroup.normalizerQuotientMk (basepointChangeSubgroup γ H)
-        (MulEquiv.subgroupCongr (by rw [basepointChangeSubgroup])
+    basepointChangeNormalizerQuotientEquiv γ H (g : Subgroup.normalizerQuotient H) =
+      ((MulEquiv.subgroupCongr (by rw [basepointChangeSubgroup])
           (Subgroup.normalizerEquivMap H
-            (_root_.FundamentalGroup.fundamentalGroupMulEquivOfPath γ) g)) := by
-  rw [basepointChangeNormalizerQuotientEquiv, MulEquiv.trans_apply,
+            (_root_.FundamentalGroup.fundamentalGroupMulEquivOfPath γ) g) :
+          _root_.Subgroup.normalizer
+            ((basepointChangeSubgroup γ H) : Set (_root_.FundamentalGroup X x₁))) :
+        Subgroup.normalizerQuotient (basepointChangeSubgroup γ H)) := by
+  rw [← Subgroup.normalizerQuotientMk_apply, ← Subgroup.normalizerQuotientMk_apply,
+    basepointChangeNormalizerQuotientEquiv, MulEquiv.trans_apply,
     Subgroup.normalizerQuotientEquivMap_mk,
     Subgroup.normalizerQuotientCongr_mk]
 
@@ -92,12 +95,13 @@ lemma basepointChangeNormalizerQuotientEquiv_symm_mk (γ : Path x₀ x₁)
     (g : _root_.Subgroup.normalizer
       ((basepointChangeSubgroup γ H) : Set (_root_.FundamentalGroup X x₁))) :
     (basepointChangeNormalizerQuotientEquiv γ H).symm
-        (Subgroup.normalizerQuotientMk (basepointChangeSubgroup γ H) g) =
-      Subgroup.normalizerQuotientMk H
-        ((Subgroup.normalizerEquivMap H
+        (g : Subgroup.normalizerQuotient (basepointChangeSubgroup γ H)) =
+      (((Subgroup.normalizerEquivMap H
           (_root_.FundamentalGroup.fundamentalGroupMulEquivOfPath γ)).symm
-          ((MulEquiv.subgroupCongr (by rw [basepointChangeSubgroup])).symm g)) := by
-  rw [basepointChangeNormalizerQuotientEquiv, MulEquiv.symm_trans_apply,
+          ((MulEquiv.subgroupCongr (by rw [basepointChangeSubgroup])).symm g)) :
+        Subgroup.normalizerQuotient H) := by
+  rw [← Subgroup.normalizerQuotientMk_apply, ← Subgroup.normalizerQuotientMk_apply,
+    basepointChangeNormalizerQuotientEquiv, MulEquiv.symm_trans_apply,
     Subgroup.normalizerQuotientCongr_symm_mk, Subgroup.normalizerQuotientEquivMap_symm_mk]
   -- The forward and inverse `subgroupCongr` agree on representatives (both are the identity on
   -- underlying elements), so the two transported representatives coincide.

--- a/TauCeti/AlgebraicTopology/SimplicialComplex/LinkStar.lean
+++ b/TauCeti/AlgebraicTopology/SimplicialComplex/LinkStar.lean
@@ -160,7 +160,6 @@ theorem mem_link_singleton {v : ι} {ρ : Finset ι} :
   rw [mem_link, disjoint_singleton_right, union_comm, ← insert_eq]
 
 /-- The closed star of a single vertex `{v}`, written with `insert`. -/
-@[simp]
 theorem mem_closedStar_singleton {v : ι} {ρ : Finset ι} :
     ρ ∈ closedStar K {v} ↔ ρ ∈ K ∧ insert v ρ ∈ K := by
   rw [mem_closedStar_iff, union_comm, ← insert_eq]

--- a/TauCeti/AlgebraicTopology/UniversalCover/AddCircle.lean
+++ b/TauCeti/AlgebraicTopology/UniversalCover/AddCircle.lean
@@ -60,7 +60,6 @@ variable {𝕜 : Type*} [AddCommGroup 𝕜] [TopologicalSpace 𝕜] [IsTopologic
 omit [IsTopologicalAddGroup 𝕜] in
 /-- A homeomorphism of `𝕜` is a deck transformation of `(↑) : 𝕜 → AddCircle p` exactly when it
 moves every point within the period subgroup `zmultiples p`. -/
-@[simp]
 theorem mem_addCircleCoe {φ : 𝕜 ≃ₜ 𝕜} :
     φ ∈ Deck ((↑) : 𝕜 → AddCircle p) ↔ ∀ e, φ e - e ∈ zmultiples p :=
   by

--- a/TauCeti/AlgebraicTopology/UniversalCover/CircleFundamentalGroup.lean
+++ b/TauCeti/AlgebraicTopology/UniversalCover/CircleFundamentalGroup.lean
@@ -142,7 +142,6 @@ lemma fundamentalGroupMulEquivZMultiples_symm_monodromy
 
 /-- A loop class maps to `1` under the period-subgroup equivalence exactly when its monodromy
 fixes the chosen lift. -/
-@[simp]
 lemma fundamentalGroupMulEquivZMultiples_eq_one_iff
     (hcov : IsCoveringMap ((↑) : 𝕜 → AddCircle p))
     {x : AddCircle p} (e : ((↑) : 𝕜 → AddCircle p) ⁻¹' {x})
@@ -189,7 +188,6 @@ lemma fundamentalGroupMulEquivInt_symm_monodromy
 
 /-- A loop class maps to `1` under the generic integer equivalence exactly when its monodromy
 fixes the chosen lift. -/
-@[simp]
 lemma fundamentalGroupMulEquivInt_eq_one_iff
     (hcov : IsCoveringMap ((↑) : 𝕜 → AddCircle p)) (hp : ¬ IsOfFinAddOrder p)
     {x : AddCircle p} (e : ((↑) : 𝕜 → AddCircle p) ⁻¹' {x})
@@ -232,7 +230,6 @@ lemma fundamentalGroupMulEquiv_symm_monodromy (hp : p ≠ 0) {x : AddCircle p}
 
 /-- A loop class maps to `1` under `fundamentalGroupMulEquiv` exactly when its monodromy fixes
 the chosen lift. -/
-@[simp]
 lemma fundamentalGroupMulEquiv_eq_one_iff (hp : p ≠ 0) {x : AddCircle p}
     (e : ((↑) : ℝ → AddCircle p) ⁻¹' {x}) (γ : FundamentalGroup (AddCircle p) x) :
     fundamentalGroupMulEquiv p hp e γ = 1 ↔ (AddCircle.isCoveringMap_coe p).monodromy γ e = e :=
@@ -276,7 +273,6 @@ lemma fundamentalGroupMulEquiv_zero_symm_monodromy (hp : p ≠ 0) (n : Multiplic
 
 /-- A loop class maps to `1` under the basepoint-`0` specialization exactly when its monodromy
 fixes the zero lift. -/
-@[simp]
 lemma fundamentalGroupMulEquiv_zero_eq_one_iff (hp : p ≠ 0)
     (γ : FundamentalGroup (AddCircle p) 0) :
     fundamentalGroupMulEquiv_zero p hp γ = 1 ↔
@@ -310,7 +306,6 @@ lemma fundamentalGroupMulEquiv_symm_monodromy (n : Multiplicative ℤ) :
   simp [fundamentalGroupMulEquiv]
 
 /-- A unit-circle loop class maps to `1` exactly when its monodromy fixes the zero lift. -/
-@[simp]
 lemma fundamentalGroupMulEquiv_eq_one_iff (γ : FundamentalGroup UnitAddCircle 0) :
     fundamentalGroupMulEquiv γ = 1 ↔
       (AddCircle.isCoveringMap_coe 1).monodromy γ ⟨0, by simp⟩ = ⟨0, by simp⟩ := by

--- a/TauCeti/AlgebraicTopology/UniversalCover/Deck/Connected.lean
+++ b/TauCeti/AlgebraicTopology/UniversalCover/Deck/Connected.lean
@@ -75,7 +75,7 @@ a chosen fibre. -/
 theorem eq_of_fiber_smul_eq_fiber_smul [PreconnectedSpace E] (hp : IsCoveringMap p)
     (φ ψ : Deck p) {e : p ⁻¹' {b}} (h : φ • e = ψ • e) : φ = ψ := by
   have hcoe : (φ • e : E) = (ψ • e : E) := congrArg Subtype.val h
-  rw [fiber_smul_coe, fiber_smul_coe] at hcoe
+  rw [smul_eq_apply, smul_eq_apply] at hcoe
   exact eq_of_apply_eq hp φ ψ hcoe
 
 /-- A deck transformation of a preconnected covering is determined by the value of its
@@ -83,7 +83,7 @@ restricted fibre homeomorphism at one point. -/
 theorem eq_of_fiberHomeomorph_apply_eq [PreconnectedSpace E] (hp : IsCoveringMap p)
     (φ ψ : Deck p) {e : p ⁻¹' {b}} (h : fiberHomeomorph φ b e = fiberHomeomorph ψ b e) :
     φ = ψ :=
-  eq_of_fiber_smul_eq_fiber_smul hp φ ψ (by simpa using h)
+  eq_of_fiber_smul_eq_fiber_smul hp φ ψ (by simpa [fiber_smul_eq_fiberHomeomorph] using h)
 
 /-- The induced deck action on a fibre of a preconnected covering is cancellative. -/
 theorem fiber_isCancelSMul [PreconnectedSpace E] (hp : IsCoveringMap p) :
@@ -141,7 +141,6 @@ lemma deckEquivFiberOfSurjective_apply [PreconnectedSpace E] (hp : IsCoveringMap
 
 /-- On underlying points, the local deck-to-fibre equivalence is evaluation of the
 underlying homeomorphism. -/
-@[simp]
 lemma deckEquivFiberOfSurjective_apply_coe [PreconnectedSpace E] (hp : IsCoveringMap p)
     (e : p ⁻¹' {b}) (hsurj : Function.Surjective fun φ : Deck p => φ • e) (φ : Deck p) :
     (deckEquivFiberOfSurjective hp e hsurj φ : E) = φ.1 e.1 := by
@@ -164,7 +163,7 @@ lemma deckEquivFiberOfSurjective_symm_apply_coe [PreconnectedSpace E]
     (hp : IsCoveringMap p) (e : p ⁻¹' {b})
     (hsurj : Function.Surjective fun φ : Deck p => φ • e) (e' : p ⁻¹' {b}) :
     (((deckEquivFiberOfSurjective hp e hsurj).symm e').1 e.1 : E) = e'.1 := by
-  simpa [fiber_smul_coe] using
+  simpa only [fiber_smul_eq_fiberHomeomorph, fiberHomeomorph_apply] using
     congrArg Subtype.val (deckEquivFiberOfSurjective_symm_smul hp e hsurj e')
 
 /-- The local deck-to-fibre equivalence sends the identity to the chosen base point. -/

--- a/TauCeti/AlgebraicTopology/UniversalCover/Deck/Fiber.lean
+++ b/TauCeti/AlgebraicTopology/UniversalCover/Deck/Fiber.lean
@@ -127,7 +127,6 @@ instance instFiberMulAction : MulAction (Deck p) (p ⁻¹' {b}) :=
   MulAction.compHom (p ⁻¹' {b}) (fiberHomeomorphHom p b)
 
 /-- The fibre action is evaluation of the fibre homeomorphism. -/
-@[simp]
 lemma fiber_smul_eq_fiberHomeomorph (φ : Deck p) (e : p ⁻¹' {b}) :
     φ • e = fiberHomeomorph φ b e :=
   rfl
@@ -136,7 +135,7 @@ lemma fiber_smul_eq_fiberHomeomorph (φ : Deck p) (e : p ⁻¹' {b}) :
 transformation. -/
 @[simp]
 lemma fiber_smul_coe (φ : Deck p) (e : p ⁻¹' {b}) :
-    (φ • e : E) = φ.1 e.1 :=
+    ((φ • e : p ⁻¹' {b}) : E) = φ.1 e.1 :=
   rfl
 
 /-- The projection value of a point in the fibre is unchanged after the restricted deck
@@ -146,7 +145,6 @@ lemma map_fiber_smul (φ : Deck p) (e : p ⁻¹' {b}) :
   exact (φ • e).2
 
 /-- The restricted deck action keeps points in the fibre over `b`. -/
-@[simp]
 lemma fiber_smul_mem (φ : Deck p) (e : p ⁻¹' {b}) :
     (φ • e : E) ∈ p ⁻¹' {b} := by
   exact map_fiber_smul φ e
@@ -154,16 +152,16 @@ lemma fiber_smul_mem (φ : Deck p) (e : p ⁻¹' {b}) :
 /-- The restricted fibre action agrees with the ambient action on the total space after
 coercing out of the fibre subtype. -/
 lemma fiber_smul_coe_eq_smul (φ : Deck p) (e : p ⁻¹' {b}) :
-    (φ • e : E) = φ • (e : E) := by
+    ((φ • e : p ⁻¹' {b}) : E) = φ • (e : E) := by
   trans φ.1 e.1
   · exact fiber_smul_coe φ e
   · exact (smul_eq_apply φ (e : E)).symm
 
 /-- Membership in the stabilizer of a fibre point is equality on the underlying point. -/
-@[simp, grind =]
+@[grind =]
 lemma mem_fiber_stabilizer_iff_coe (φ : Deck p) (e : p ⁻¹' {b}) :
     φ ∈ MulAction.stabilizer (Deck p) e ↔ φ.1 e.1 = e.1 := by
-  simp [Subtype.ext_iff]
+  simp [Subtype.ext_iff, fiber_smul_eq_fiberHomeomorph]
 
 end Deck
 

--- a/TauCeti/AlgebraicTopology/UniversalCover/Deck/FiberOrbit.lean
+++ b/TauCeti/AlgebraicTopology/UniversalCover/Deck/FiberOrbit.lean
@@ -58,7 +58,6 @@ abbrev FiberOrbitQuotient (p : E → B) (b : B) : Type _ :=
   Quotient.mk'' e
 
 /-- The deck-orbit quotient map sends a fibre point to its own class. -/
-@[simp]
 lemma fiberOrbitClass_eq_mk (e : p ⁻¹' {b}) :
     fiberOrbitClass e = (Quotient.mk'' e : FiberOrbitQuotient p b) :=
   rfl

--- a/TauCeti/AlgebraicTopology/UniversalCover/Deck/FiberTorsorTransport.lean
+++ b/TauCeti/AlgebraicTopology/UniversalCover/Deck/FiberTorsorTransport.lean
@@ -113,7 +113,6 @@ lemma fiberMap_sdiv_eq_conjMulEquiv_of_pretransitive [PreconnectedSpace E]
 
 /-- The local deck-to-fibre equivalence commutes with transport of deck transformations
 and fibre points along an over-base homeomorphism. -/
-@[simp]
 lemma deckEquivFiberOfSurjective_fiberMap [PreconnectedSpace E]
     (hp : IsCoveringMap p) (hq : IsCoveringMap q) (h : E ≃ₜ F)
     (hpq : ∀ e, q (h e) = p e) (e : p ⁻¹' {b})
@@ -159,7 +158,6 @@ lemma deckEquivFiber_symm_fiberMap [PreconnectedSpace E]
 
 /-- The regular deck-to-fibre equivalence commutes with transport of deck transformations
 and fibre points along an over-base homeomorphism. -/
-@[simp]
 lemma deckEquivFiber_fiberMap [PreconnectedSpace E]
     (hp : IsCoveringMap p) (hq : IsCoveringMap q) (hreg : IsRegular p)
     (h : E ≃ₜ F) (hpq : ∀ e, q (h e) = p e) (e : p ⁻¹' {b}) (φ : Deck p) :

--- a/TauCeti/AlgebraicTopology/UniversalCover/Deck/FiberTransport.lean
+++ b/TauCeti/AlgebraicTopology/UniversalCover/Deck/FiberTransport.lean
@@ -102,17 +102,16 @@ lemma fiberMap_smul (h : E ≃ₜ F) (hpq : ∀ e, q (h e) = p e) (φ : Deck p)
     (e : p ⁻¹' {b}) :
     fiberMap h hpq b (φ • e) = conjMulEquiv h hpq φ • fiberMap h hpq b e := by
   ext
-  simp
+  simp [fiber_smul_eq_fiberHomeomorph]
 
 /-- The inverse fibre transport intertwines the restricted deck action with inverse
 conjugation of deck transformations. -/
-@[simp]
 lemma fiberMap_symm_smul (h : E ≃ₜ F) (hpq : ∀ e, q (h e) = p e) (ψ : Deck q)
     (f : q ⁻¹' {b}) :
     (fiberMap h hpq b).symm (ψ • f) =
       (conjMulEquiv h hpq).symm ψ • (fiberMap h hpq b).symm f := by
   ext
-  simp
+  simp [fiber_smul_eq_fiberHomeomorph]
 
 /-- Transporting a deck transformation to the target cover and then restricting it to a fibre
 is the same as restricting first and conjugating the resulting fibre homeomorphism by the fibre
@@ -136,7 +135,7 @@ lemma fiberHomeomorphHom_conjMulEquiv (h : E ≃ₜ F) (hpq : ∀ e, q (h e) = p
   simp
 
 /-- Conjugation transports stabilizer membership along the fibre map. -/
-@[simp, grind =]
+@[grind =]
 lemma mem_stabilizer_conjMulEquiv_fiberMap_iff (h : E ≃ₜ F)
     (hpq : ∀ e, q (h e) = p e) (φ : Deck p) (e : p ⁻¹' {b}) :
     conjMulEquiv h hpq φ ∈ MulAction.stabilizer (Deck q) (fiberMap h hpq b e) ↔
@@ -211,7 +210,7 @@ theorem fiberMap_image_orbit (h : E ≃ₜ F) (hpq : ∀ e, q (h e) = p e) (e : 
     exact fiberMap_mem_orbit h hpq φ e
   · rintro ⟨ψ, rfl⟩
     refine ⟨(conjMulEquiv h hpq).symm ψ • e, ⟨(conjMulEquiv h hpq).symm ψ, rfl⟩, ?_⟩
-    simpa using fiberMap_smul h hpq ((conjMulEquiv h hpq).symm ψ) e
+    simp
 
 /-- Applying a deck transformation and then transporting back to the source fibre gives a
 point in the source deck orbit. -/

--- a/TauCeti/AlgebraicTopology/UniversalCover/Deck/FundamentalGroup.lean
+++ b/TauCeti/AlgebraicTopology/UniversalCover/Deck/FundamentalGroup.lean
@@ -82,6 +82,12 @@ lemma IsRegular.fundamentalGroupEquiv_unop_apply [SimplyConnectedSpace E]
     (hreg.fundamentalGroupEquiv hp e γ).unop.1 (e : E) = (hp.monodromy γ e : E) :=
   (hreg.isQuotientCoveringMap hp).unop_fundamentalGroupToMulOpposite_smul
 
+/-- Compatibility spelling of `fundamentalGroupEquiv_unop_apply` using the deck action. -/
+lemma IsRegular.fundamentalGroupEquiv_unop_smul [SimplyConnectedSpace E]
+    (hreg : IsRegular p) (hp : IsCoveringMap p) (e : p ⁻¹' {x}) (γ : FundamentalGroup X x) :
+    (hreg.fundamentalGroupEquiv hp e γ).unop • (e : E) = hp.monodromy γ e := by
+  simpa only [smul_eq_apply] using IsRegular.fundamentalGroupEquiv_unop_apply hreg hp e γ
+
 /-- The fundamental group element `γ` corresponds to a deck transformation `g` exactly when
 `g.unop` moves the chosen lift `e` to the monodromy translate of `e` along `γ`. -/
 lemma IsRegular.fundamentalGroupEquiv_apply_eq_iff [SimplyConnectedSpace E]

--- a/TauCeti/AlgebraicTopology/UniversalCover/Deck/FundamentalGroup.lean
+++ b/TauCeti/AlgebraicTopology/UniversalCover/Deck/FundamentalGroup.lean
@@ -41,7 +41,7 @@ identifies `π₁(X, x)` with that fibre via monodromy.
 
 * `TauCeti.Deck.IsRegular.fundamentalGroupEquiv`: the anti-isomorphism
   `FundamentalGroup X x ≃* (Deck p)ᵐᵒᵖ`.
-* `TauCeti.Deck.IsRegular.fundamentalGroupEquiv_unop_smul`: the deck element
+* `TauCeti.Deck.IsRegular.fundamentalGroupEquiv_unop_apply`: the deck element
   attached to `γ` moves the chosen lift `e` to `monodromy γ e`.
 * `TauCeti.Deck.IsRegular.fundamentalGroupEquiv_apply_eq_iff`: characterizes equality
   with an arbitrary deck transformation by its value at the chosen lift.
@@ -77,9 +77,9 @@ noncomputable def IsRegular.fundamentalGroupEquiv [SimplyConnectedSpace E]
 /-- The deck transformation attached to a loop class `γ` moves the chosen basepoint lift `e`
 along the monodromy of `γ`. -/
 @[simp]
-lemma IsRegular.fundamentalGroupEquiv_unop_smul [SimplyConnectedSpace E]
+lemma IsRegular.fundamentalGroupEquiv_unop_apply [SimplyConnectedSpace E]
     (hreg : IsRegular p) (hp : IsCoveringMap p) (e : p ⁻¹' {x}) (γ : FundamentalGroup X x) :
-    (hreg.fundamentalGroupEquiv hp e γ).unop • (e : E) = (hp.monodromy γ e : E) :=
+    (hreg.fundamentalGroupEquiv hp e γ).unop.1 (e : E) = (hp.monodromy γ e : E) :=
   (hreg.isQuotientCoveringMap hp).unop_fundamentalGroupToMulOpposite_smul
 
 /-- The fundamental group element `γ` corresponds to a deck transformation `g` exactly when
@@ -97,7 +97,7 @@ lemma IsRegular.fundamentalGroupEquiv_symm_monodromy [SimplyConnectedSpace E]
     (hreg : IsRegular p) (hp : IsCoveringMap p) (e : p ⁻¹' {x}) (g : (Deck p)ᵐᵒᵖ) :
     (hp.monodromy ((hreg.fundamentalGroupEquiv hp e).symm g) e : E) = g.unop • (e : E) := by
   simpa using
-    (IsRegular.fundamentalGroupEquiv_unop_smul hreg hp e
+    (IsRegular.fundamentalGroupEquiv_unop_apply hreg hp e
       ((hreg.fundamentalGroupEquiv hp e).symm g)).symm
 
 /-- A `Deck p` spelling of `fundamentalGroupEquiv_symm_monodromy`. The loop class
@@ -110,7 +110,6 @@ lemma IsRegular.fundamentalGroupEquiv_symm_op_monodromy [SimplyConnectedSpace E]
 
 /-- A loop class `γ` maps to the identity deck transformation exactly when its monodromy
 fixes the chosen basepoint lift `e`. -/
-@[simp]
 lemma IsRegular.fundamentalGroupEquiv_eq_one_iff [SimplyConnectedSpace E]
     (hreg : IsRegular p) (hp : IsCoveringMap p) (e : p ⁻¹' {x}) (γ : FundamentalGroup X x) :
     hreg.fundamentalGroupEquiv hp e γ = 1 ↔ hp.monodromy γ e = e :=

--- a/TauCeti/AlgebraicTopology/UniversalCover/Deck/FundamentalGroupOpposite.lean
+++ b/TauCeti/AlgebraicTopology/UniversalCover/Deck/FundamentalGroupOpposite.lean
@@ -89,7 +89,6 @@ lemma deckFundamentalGroupEquiv_symm_op [SimplyConnectedSpace E]
 
 /-- The loop class attached to a deck transformation has monodromy equal to that deck
 transformation on the chosen lift. -/
-@[simp]
 lemma deckFundamentalGroupEquiv_unop_monodromy [SimplyConnectedSpace E]
     (hreg : IsRegular p) (hp : IsCoveringMap p) (e : p ⁻¹' {x}) (φ : Deck p) :
     (hp.monodromy ((hreg.deckFundamentalGroupEquiv hp e φ).unop) e : E) = φ • (e : E) := by
@@ -135,7 +134,6 @@ lemma deckFundamentalGroupEquiv_symm_op_eq_iff [SimplyConnectedSpace E]
 
 /-- A deck transformation maps to the identity loop class exactly when it fixes the chosen
 lift. -/
-@[simp]
 lemma deckFundamentalGroupEquiv_eq_one_iff [SimplyConnectedSpace E]
     (hreg : IsRegular p) (hp : IsCoveringMap p) (e : p ⁻¹' {x}) (φ : Deck p) :
     hreg.deckFundamentalGroupEquiv hp e φ = 1 ↔ φ • (e : E) = e := by
@@ -151,7 +149,6 @@ lemma deckFundamentalGroupEquiv_eq_one_iff [SimplyConnectedSpace E]
 
 /-- Under the deck-to-fundamental-group comparison, the deck-to-fibre equivalence for a
 regular cover agrees with the monodromy equivalence from `π₁` to the same fibre. -/
-@[simp]
 lemma deckEquivFiber_eq_fundamentalGroupEquivFiber [SimplyConnectedSpace E]
     (hreg : IsRegular p) (hp : IsCoveringMap p)
     (e : p ⁻¹' {x}) (φ : Deck p) :

--- a/TauCeti/AlgebraicTopology/UniversalCover/Deck/NormalSubgroupFiberQuotient.lean
+++ b/TauCeti/AlgebraicTopology/UniversalCover/Deck/NormalSubgroupFiberQuotient.lean
@@ -118,8 +118,7 @@ lemma subgroupFiberOrbitQuotientEquivNormalizerQuotientOfNormal_apply_base
   apply (Subgroup.normalizerQuotientEquivQuotientOfNormal H).injective
   rw [normalizerQuotientEquivQuotientOfNormal_subgroupFiberOrbitQuotientEquiv,
     Subgroup.normalizerQuotientEquivQuotientOfNormal_mk]
-  simpa using
-    subgroupFiberOrbitQuotientEquivQuotientGroup_apply_inv_smul H e (1 : Deck p)
+  simp
 
 /-- For a regular cover, the chosen fibre point maps to the identity class in the normalizer
 quotient. -/
@@ -172,7 +171,6 @@ lemma regularSubgroupFiberOrbitQuotientEquivNormalizerQuotientOfNormal_apply_smu
 
 /-- The normal-subgroup fibre quotient equivalence sends the class of `φ⁻¹ • e` to the
 normalizer-quotient class of `φ`. -/
-@[simp]
 lemma subgroupFiberOrbitQuotientEquivNormalizerQuotientOfNormal_apply_inv_smul
     [MulAction.IsPretransitive (Deck p) (p ⁻¹' {b})] [IsCancelSMul (Deck p) (p ⁻¹' {b})]
     (H : Subgroup (Deck p)) [H.Normal] (e : p ⁻¹' {b}) (φ : Deck p) :
@@ -180,12 +178,10 @@ lemma subgroupFiberOrbitQuotientEquivNormalizerQuotientOfNormal_apply_inv_smul
         (subgroupFiberOrbitClass H (φ⁻¹ • e)) =
       Subgroup.normalizerQuotientMk H
         ⟨φ, by simp [_root_.Subgroup.normalizer_eq_top (H := H)]⟩ := by
-  simpa using
-    subgroupFiberOrbitQuotientEquivNormalizerQuotientOfNormal_apply_smul H e φ⁻¹
+  simp
 
 /-- For a regular cover, the normal-subgroup fibre quotient equivalence sends the class of
 `φ⁻¹ • e` to the normalizer-quotient class of `φ`. -/
-@[simp]
 lemma regularSubgroupFiberOrbitQuotientEquivNormalizerQuotientOfNormal_apply_inv_smul
     [TopologicalSpace B] [PreconnectedSpace E] (hp : IsCoveringMap p) (hreg : IsRegular p)
     (H : Subgroup (Deck p)) [H.Normal] (e : p ⁻¹' {b}) (φ : Deck p) :
@@ -193,9 +189,7 @@ lemma regularSubgroupFiberOrbitQuotientEquivNormalizerQuotientOfNormal_apply_inv
         (subgroupFiberOrbitClass H (φ⁻¹ • e)) =
       Subgroup.normalizerQuotientMk H
         ⟨φ, by simp [_root_.Subgroup.normalizer_eq_top (H := H)]⟩ := by
-  simpa using
-    regularSubgroupFiberOrbitQuotientEquivNormalizerQuotientOfNormal_apply_smul
-      hp hreg H e φ⁻¹
+  simp
 
 /-- Equality of subgroup fibre-orbit classes of two deck translates is equality of the
 corresponding inverse representatives in the normalizer quotient. -/
@@ -231,8 +225,9 @@ lemma subgroupFiberOrbitQuotientEquivNormalizerQuotientOfNormal_symm_mk
     (H : Subgroup (Deck p)) [H.Normal] (e : p ⁻¹' {b})
     (φ : _root_.Subgroup.normalizer (H : Set (Deck p))) :
     (subgroupFiberOrbitQuotientEquivNormalizerQuotientOfNormal H e).symm
-        (Subgroup.normalizerQuotientMk H φ) =
+        (φ : Subgroup.normalizerQuotient H) =
       subgroupFiberOrbitClass H ((φ : Deck p)⁻¹ • e) := by
+  rw [← Subgroup.normalizerQuotientMk_apply]
   apply (subgroupFiberOrbitQuotientEquivNormalizerQuotientOfNormal H e).injective
   rw [Equiv.apply_symm_apply,
     subgroupFiberOrbitQuotientEquivNormalizerQuotientOfNormal_apply_smul]
@@ -249,8 +244,9 @@ lemma regularSubgroupFiberOrbitQuotientEquivNormalizerQuotientOfNormal_symm_mk
     (H : Subgroup (Deck p)) [H.Normal] (e : p ⁻¹' {b})
     (φ : _root_.Subgroup.normalizer (H : Set (Deck p))) :
     (regularSubgroupFiberOrbitQuotientEquivNormalizerQuotientOfNormal hp hreg H e).symm
-        (Subgroup.normalizerQuotientMk H φ) =
+        (φ : Subgroup.normalizerQuotient H) =
       subgroupFiberOrbitClass H ((φ : Deck p)⁻¹ • e) := by
+  rw [← Subgroup.normalizerQuotientMk_apply]
   apply (regularSubgroupFiberOrbitQuotientEquivNormalizerQuotientOfNormal hp hreg H e).injective
   rw [Equiv.apply_symm_apply,
     regularSubgroupFiberOrbitQuotientEquivNormalizerQuotientOfNormal_apply_smul]
@@ -266,12 +262,10 @@ lemma subgroupFiberOrbitQuotientEquivNormalizerQuotientOfNormal_symm_one
     [MulAction.IsPretransitive (Deck p) (p ⁻¹' {b})] [IsCancelSMul (Deck p) (p ⁻¹' {b})]
     (H : Subgroup (Deck p)) [H.Normal] (e : p ⁻¹' {b}) :
     (subgroupFiberOrbitQuotientEquivNormalizerQuotientOfNormal H e).symm
-        (Subgroup.normalizerQuotientMk H
-          ⟨1, by simp [_root_.Subgroup.normalizer_eq_top (H := H)]⟩) =
+        (1 : Subgroup.normalizerQuotient H) =
       subgroupFiberOrbitClass H e := by
-  simpa using
-    subgroupFiberOrbitQuotientEquivNormalizerQuotientOfNormal_symm_mk
-      H e ⟨1, by simp [_root_.Subgroup.normalizer_eq_top (H := H)]⟩
+  rw [← QuotientGroup.mk_one, subgroupFiberOrbitQuotientEquivNormalizerQuotientOfNormal_symm_mk]
+  simp
 
 /-- For a regular cover, the inverse equivalence sends the identity normalizer quotient class
 to the chosen fibre-orbit class. -/
@@ -280,12 +274,11 @@ lemma regularSubgroupFiberOrbitQuotientEquivNormalizerQuotientOfNormal_symm_one
     [TopologicalSpace B] [PreconnectedSpace E] (hp : IsCoveringMap p) (hreg : IsRegular p)
     (H : Subgroup (Deck p)) [H.Normal] (e : p ⁻¹' {b}) :
     (regularSubgroupFiberOrbitQuotientEquivNormalizerQuotientOfNormal hp hreg H e).symm
-        (Subgroup.normalizerQuotientMk H
-          ⟨1, by simp [_root_.Subgroup.normalizer_eq_top (H := H)]⟩) =
+        (1 : Subgroup.normalizerQuotient H) =
       subgroupFiberOrbitClass H e := by
-  simpa using
-    regularSubgroupFiberOrbitQuotientEquivNormalizerQuotientOfNormal_symm_mk
-      hp hreg H e ⟨1, by simp [_root_.Subgroup.normalizer_eq_top (H := H)]⟩
+  rw [← QuotientGroup.mk_one,
+    regularSubgroupFiberOrbitQuotientEquivNormalizerQuotientOfNormal_symm_mk]
+  simp
 
 end Deck
 

--- a/TauCeti/AlgebraicTopology/UniversalCover/Deck/NormalizerQuotientConjugation.lean
+++ b/TauCeti/AlgebraicTopology/UniversalCover/Deck/NormalizerQuotientConjugation.lean
@@ -51,7 +51,6 @@ noncomputable abbrev normalizerQuotientConjEquiv (h : E ≃ₜ F)
 
 /-- On normalizer representatives, the deck normalizer-quotient conjugation equivalence is
 induced by conjugating deck transformations. -/
-@[simp]
 lemma normalizerQuotientConjEquiv_mk (h : E ≃ₜ F) (hpq : ∀ e, q (h e) = p e)
     (H : Subgroup (Deck p))
     (φ : _root_.Subgroup.normalizer (H : Set (Deck p))) :
@@ -63,7 +62,6 @@ lemma normalizerQuotientConjEquiv_mk (h : E ≃ₜ F) (hpq : ∀ e, q (h e) = p 
 
 /-- After the subgroup equality induced by identity conjugation, conjugating the normalizer
 quotient by the identity over-base homeomorphism is the canonical identity on representatives. -/
-@[simp]
 lemma normalizerQuotientConjEquiv_refl_mk_congr (H : Subgroup (Deck p))
     (φ : _root_.Subgroup.normalizer (H : Set (Deck p))) :
     Subgroup.normalizerQuotientCongr (subgroup_map_conj_refl (p := p) H)
@@ -83,7 +81,6 @@ lemma normalizerQuotientConjEquiv_refl_mk_congr (H : Subgroup (Deck p))
 
 /-- The inverse deck normalizer-quotient conjugation equivalence is induced by inverse
 conjugation of deck transformations. -/
-@[simp]
 lemma normalizerQuotientConjEquiv_symm_mk (h : E ≃ₜ F) (hpq : ∀ e, q (h e) = p e)
     (H : Subgroup (Deck p))
     (ψ : _root_.Subgroup.normalizer
@@ -98,7 +95,6 @@ lemma normalizerQuotientConjEquiv_symm_mk (h : E ≃ₜ F) (hpq : ∀ e, q (h e)
 
 /-- Composing two deck normalizer-quotient conjugation equivalences sends representatives through
 the two successive conjugation transports. -/
-@[simp]
 lemma normalizerQuotientConjEquiv_trans_mk
     {G : Type*} [TopologicalSpace G] {r : G → B}
     (h : E ≃ₜ F) (k : F ≃ₜ G)
@@ -121,7 +117,6 @@ lemma normalizerQuotientConjEquiv_trans_mk
 /-- After identifying the twice-conjugated subgroup with the subgroup conjugated by the
 composite over-base homeomorphism, composing deck normalizer-quotient conjugation equivalences
 agrees with conjugation by the composite on representatives. -/
-@[simp]
 lemma normalizerQuotientConjEquiv_trans_mk_congr
     {G : Type*} [TopologicalSpace G] {r : G → B}
     (h : E ≃ₜ F) (k : F ≃ₜ G)
@@ -148,7 +143,6 @@ lemma normalizerQuotientConjEquiv_trans_mk_congr
 
 /-- Inverse-conjugating a representative of the `h`-conjugated subgroup quotient gives the
 stated representative in the twice-mapped subgroup. -/
-@[simp]
 lemma normalizerQuotientConjEquiv_symm_mk' (h : E ≃ₜ F) (hpq : ∀ e, q (h e) = p e)
     (H : Subgroup (Deck p))
     (ψ : _root_.Subgroup.normalizer

--- a/TauCeti/AlgebraicTopology/UniversalCover/Deck/NormalizerQuotientFiberAction.lean
+++ b/TauCeti/AlgebraicTopology/UniversalCover/Deck/NormalizerQuotientFiberAction.lean
@@ -135,7 +135,7 @@ corresponding deck translate on fibre-orbit classes. -/
 lemma normalizerQuotientSubgroupFiberOrbitPermHom_mk_apply (H : Subgroup (Deck p))
     (φ : _root_.Subgroup.normalizer (H : Set (Deck p))) (e : p ⁻¹' {b}) :
     normalizerQuotientSubgroupFiberOrbitPermHom (b := b) H
-        (Subgroup.normalizerQuotientMk H φ) (subgroupFiberOrbitClass H e) =
+        (φ : Subgroup.normalizerQuotient H) (subgroupFiberOrbitClass H e) =
       subgroupFiberOrbitClass H ((φ : Deck p) • e) :=
   by
     simpa [normalizerQuotientSubgroupFiberOrbitPermHom, subgroupFiberOrbitClass] using
@@ -152,7 +152,7 @@ noncomputable instance instNormalizerQuotientSubgroupFiberOrbitMulAction
 @[simp]
 lemma normalizerQuotient_smul_subgroupFiberOrbitClass (H : Subgroup (Deck p))
     (φ : _root_.Subgroup.normalizer (H : Set (Deck p))) (e : p ⁻¹' {b}) :
-    Subgroup.normalizerQuotientMk H φ • subgroupFiberOrbitClass H e =
+    (φ : Subgroup.normalizerQuotient H) • subgroupFiberOrbitClass H e =
       subgroupFiberOrbitClass H ((φ : Deck p) • e) :=
   by
     simpa [instNormalizerQuotientSubgroupFiberOrbitMulAction,
@@ -168,10 +168,11 @@ lemma normalizerQuotient_one_smul_subgroupFiberOrbitClass (H : Subgroup (Deck p)
   simp
 
 /-- A representative from `H` acts trivially through the normalizer quotient. -/
-@[simp]
 lemma normalizerQuotient_mk_of_mem_smul_subgroupFiberOrbitClass
     (H : Subgroup (Deck p)) (φ : Deck p) (hφ : φ ∈ H) (e : p ⁻¹' {b}) :
-    Subgroup.normalizerQuotientMk H ⟨φ, _root_.Subgroup.le_normalizer hφ⟩ •
+    ((⟨φ, _root_.Subgroup.le_normalizer hφ⟩ :
+          _root_.Subgroup.normalizer (H : Set (Deck p))) :
+        Subgroup.normalizerQuotient H) •
         subgroupFiberOrbitClass H e =
       subgroupFiberOrbitClass H e := by
   rw [normalizerQuotient_smul_subgroupFiberOrbitClass]

--- a/TauCeti/AlgebraicTopology/UniversalCover/Deck/Quotient.lean
+++ b/TauCeti/AlgebraicTopology/UniversalCover/Deck/Quotient.lean
@@ -215,7 +215,6 @@ lemma orbitQuotientEquivBase_conj (hreg : IsRegular p) (h : E ≃ₜ F)
 
 /-- Representative form of compatibility between over-base homeomorphisms and the regular
 orbit-quotient equivalences. -/
-@[simp]
 lemma orbitQuotientEquivBase_conj_mk (hreg : IsRegular p) (h : E ≃ₜ F)
     (hpq : ∀ e, q (h e) = p e) (f : F) :
     (hreg.conj h hpq).orbitQuotientEquivBase

--- a/TauCeti/AlgebraicTopology/UniversalCover/Deck/Regular.lean
+++ b/TauCeti/AlgebraicTopology/UniversalCover/Deck/Regular.lean
@@ -79,7 +79,8 @@ lemma isRegular_iff_exists_apply_eq :
     let y : p ⁻¹' {b} := ⟨e', by simp [b, heq.symm]⟩
     letI := hreg.2 b
     rcases MulAction.exists_smul_eq (Deck p) x y with ⟨φ, hφ⟩
-    exact ⟨φ, by simpa [fiber_smul_coe] using congrArg Subtype.val hφ⟩
+    exact ⟨φ, by
+      simpa [fiber_smul_eq_fiberHomeomorph] using congrArg Subtype.val hφ⟩
   · rintro ⟨hsurj, hpoint⟩
     refine ⟨hsurj, fun b => ?_⟩
     refine MulAction.IsPretransitive.mk ?_
@@ -89,7 +90,7 @@ lemma isRegular_iff_exists_apply_eq :
       have hy : p y.1 = b := Set.mem_singleton_iff.mp y.2
       rw [hx, hy]
     rcases hpoint hxy with ⟨φ, hφ⟩
-    exact ⟨φ, by ext; simpa [fiber_smul_coe] using hφ⟩
+    exact ⟨φ, by ext; simpa [fiber_smul_eq_fiberHomeomorph] using hφ⟩
 
 namespace IsRegular
 
@@ -162,7 +163,6 @@ lemma deckEquivFiber_apply [PreconnectedSpace E] (hp : IsCoveringMap p) (hreg : 
 
 /-- On underlying points, the deck-to-fibre equivalence is evaluation of the underlying
 homeomorphism. -/
-@[simp]
 lemma deckEquivFiber_apply_coe [PreconnectedSpace E] (hp : IsCoveringMap p)
     (hreg : IsRegular p) (e : p ⁻¹' {b}) (φ : Deck p) :
     (deckEquivFiber hp hreg e φ : E) = φ.1 e.1 := by
@@ -187,7 +187,6 @@ lemma deckEquivFiber_mul [PreconnectedSpace E] (hp : IsCoveringMap p) (hreg : Is
 
 /-- The inverse of `deckEquivFiber` is characterized by the deck transformation it returns:
 it sends the chosen fibre point to the requested fibre point. -/
-@[simp]
 lemma deckEquivFiber_symm_smul [PreconnectedSpace E] (hp : IsCoveringMap p)
     (hreg : IsRegular p) (e e' : p ⁻¹' {b}) :
     (deckEquivFiber hp hreg e).symm e' • e = e' :=
@@ -195,15 +194,14 @@ lemma deckEquivFiber_symm_smul [PreconnectedSpace E] (hp : IsCoveringMap p)
 
 /-- On underlying points, the inverse of `deckEquivFiber` sends the chosen point to the
 requested point. -/
-@[simp]
 lemma deckEquivFiber_symm_apply_coe [PreconnectedSpace E] (hp : IsCoveringMap p)
     (hreg : IsRegular p) (e e' : p ⁻¹' {b}) :
     (((deckEquivFiber hp hreg e).symm e').1 e.1 : E) = e'.1 := by
-  simpa [fiber_smul_coe] using congrArg Subtype.val (deckEquivFiber_symm_smul hp hreg e e')
+  simpa only [fiber_smul_eq_fiberHomeomorph, fiberHomeomorph_apply] using
+    congrArg Subtype.val (deckEquivFiber_symm_smul hp hreg e e')
 
 /-- Translating a fibre point before applying the inverse `deckEquivFiber` multiplies the
 corresponding deck transformation on the left. -/
-@[simp]
 lemma deckEquivFiber_symm_apply_smul [PreconnectedSpace E] (hp : IsCoveringMap p)
     (hreg : IsRegular p) (e e' : p ⁻¹' {b}) (φ : Deck p) :
     (deckEquivFiber hp hreg e).symm (φ • e') =

--- a/TauCeti/AlgebraicTopology/UniversalCover/Deck/SubgroupFiberOrbit.lean
+++ b/TauCeti/AlgebraicTopology/UniversalCover/Deck/SubgroupFiberOrbit.lean
@@ -66,7 +66,6 @@ abbrev SubgroupFiberOrbitQuotient (H : Subgroup (Deck p)) (b : B) : Type _ :=
   Quotient.mk'' e
 
 /-- The subgroup fibre-orbit quotient map sends a fibre point to its own class. -/
-@[simp]
 lemma subgroupFiberOrbitClass_eq_mk (H : Subgroup (Deck p)) (e : p ⁻¹' {b}) :
     subgroupFiberOrbitClass H e =
       (Quotient.mk'' e : SubgroupFiberOrbitQuotient H b) :=
@@ -247,11 +246,12 @@ conjugation with the original subgroup. -/
 @[simp]
 lemma subgroupFiberOrbitQuotientEquiv_refl (H : Subgroup (Deck p))
     (x : SubgroupFiberOrbitQuotient H b) :
-    Equiv.cast (congrArg (fun H' => SubgroupFiberOrbitQuotient H' b)
+    cast (congrArg (fun H' => SubgroupFiberOrbitQuotient H' b)
         (subgroup_map_conj_refl (p := p) H))
       (subgroupFiberOrbitQuotientEquiv (Homeomorph.refl E) (p := p) (q := p)
         (fun e => by rfl) H b x) =
       x := by
+  rw [← Equiv.cast_apply]
   refine Quotient.inductionOn' x ?_
   intro e
   -- Quotient induction exposes the representative as `Quotient.mk''`; rewrite that
@@ -344,7 +344,6 @@ lemma subgroupFiberOrbitClass_bot_eq_iff (e e' : p ⁻¹' {b}) :
 
 /-- The quotient map induced by `⊥ ≤ H`, after identifying the bottom quotient with the
 fibre, is the `H`-orbit class map. -/
-@[simp]
 lemma subgroupFiberOrbitMapOfLE_bot_apply (H : Subgroup (Deck p)) (e : p ⁻¹' {b}) :
     subgroupFiberOrbitMapOfLE (b := b) (bot_le : (⊥ : Subgroup (Deck p)) ≤ H)
         ((subgroupFiberOrbitQuotientBotEquiv (p := p) (b := b)).symm e) =

--- a/TauCeti/AlgebraicTopology/UniversalCover/Deck/SubgroupFiberOrbitQuotientGroup.lean
+++ b/TauCeti/AlgebraicTopology/UniversalCover/Deck/SubgroupFiberOrbitQuotientGroup.lean
@@ -159,7 +159,6 @@ lemma regularSubgroupFiberOrbitQuotientEquivQuotientGroup_symm_mk
 
 /-- On underlying points, the inverse quotient equivalence sends the coset of `φ` to the
 class of the value of `φ⁻¹` on the chosen fibre point. -/
-@[simp]
 lemma subgroupFiberOrbitQuotientEquivQuotientGroup_symm_mk_coe
     [MulAction.IsPretransitive (Deck p) (p ⁻¹' {b})] [IsCancelSMul (Deck p) (p ⁻¹' {b})]
     (H : Subgroup (Deck p)) (e : p ⁻¹' {b}) (φ : Deck p) :
@@ -185,7 +184,6 @@ lemma subgroupFiberOrbitQuotientEquivQuotientGroup_symm_one
   rw [subgroupFiberOrbitQuotientEquivQuotientGroup_symm_mk, inv_one, one_smul]
 
 /-- The quotient equivalence sends the orbit class of `φ⁻¹ • e` to the coset of `φ`. -/
-@[simp]
 lemma subgroupFiberOrbitQuotientEquivQuotientGroup_apply_inv_smul
     [MulAction.IsPretransitive (Deck p) (p ⁻¹' {b})] [IsCancelSMul (Deck p) (p ⁻¹' {b})]
     (H : Subgroup (Deck p)) (e : p ⁻¹' {b}) (φ : Deck p) :
@@ -198,7 +196,6 @@ lemma subgroupFiberOrbitQuotientEquivQuotientGroup_apply_inv_smul
 
 /-- For a regular cover, the quotient equivalence sends the orbit class of `φ⁻¹ • e` to the
 coset of `φ`. -/
-@[simp]
 lemma regularSubgroupFiberOrbitQuotientEquivQuotientGroup_apply_inv_smul
     [TopologicalSpace B] [PreconnectedSpace E] (hp : IsCoveringMap p) (hreg : IsRegular p)
     (H : Subgroup (Deck p)) (e : p ⁻¹' {b}) (φ : Deck p) :
@@ -207,8 +204,8 @@ lemma regularSubgroupFiberOrbitQuotientEquivQuotientGroup_apply_inv_smul
       QuotientGroup.mk (s := H) φ := by
   letI := hreg.fiber_isPretransitive b
   letI := fiber_isCancelSMul (b := b) hp
-  simpa [regularSubgroupFiberOrbitQuotientEquivQuotientGroup] using
-    subgroupFiberOrbitQuotientEquivQuotientGroup_apply_inv_smul H e φ
+  simp only [regularSubgroupFiberOrbitQuotientEquivQuotientGroup]
+  exact subgroupFiberOrbitQuotientEquivQuotientGroup_apply_inv_smul H e φ
 
 /-- The quotient equivalence sends the chosen fibre point to the identity coset. -/
 @[simp]
@@ -243,8 +240,7 @@ lemma regularSubgroupFiberOrbitQuotientEquivQuotientGroup_apply_smul
       QuotientGroup.mk (s := H) φ⁻¹ := by
   letI := hreg.fiber_isPretransitive b
   letI := fiber_isCancelSMul (b := b) hp
-  simpa [regularSubgroupFiberOrbitQuotientEquivQuotientGroup] using
-    subgroupFiberOrbitQuotientEquivQuotientGroup_apply_smul H e φ
+  simp [regularSubgroupFiberOrbitQuotientEquivQuotientGroup]
 
 /-- For a free transitive deck action on a fibre, quotienting the fibre by the trivial
 subgroup identifies that quotient with the deck group. The representative convention is the


### PR DESCRIPTION
This PR resolves all 69 simpNF linter entries with reason "Left-hand side simplifies from ..." under `TauCeti/AlgebraicTopology/` (wave 2 of the simp normal-form cleanup; wave 1 handled the "simp can prove this" entries). Every entry was re-verified against the current simp set on `main` before acting; all 69 still violated.

**Root-cause `@[simp]` removals** (the flagged lemmas were stated in the intended normal form; one unfolding lemma pushed the whole API out of it):

- `Deck.fiberOrbitClass_eq_mk`, `Deck.subgroupFiberOrbitClass_eq_mk`: these unfolded the named orbit-class constructors to `Quotient.mk''`, so every `_apply` lemma in the fibre-orbit files was non-normal. The named constructor is now the normal form; the `_eq_mk` lemmas remain available for explicit rewriting. This alone un-flags ~30 entries with no statement changes.
- `Deck.fiber_smul_eq_fiberHomeomorph`: the induced fibre action's normal form is now `φ • e`, which is how every downstream statement (stabilizers, orbits, torsor lemmas) already spells it. The ambient tautological action keeps `smul_eq_apply` as simp, mirroring Mathlib's `Equiv.Perm.smul_def`.

**Restated with the simplified LHS** (names and content preserved):

- `FundamentalGroup.basepointChangeNormalizerQuotientEquiv_mk` / `_symm_mk`, `Deck.subgroupFiberOrbitQuotientEquivNormalizerQuotientOfNormal_symm_mk`, `Deck.regularSubgroupFiberOrbitQuotientEquivNormalizerQuotientOfNormal_symm_mk`, `Deck.normalizerQuotientSubgroupFiberOrbitPermHom_mk_apply`, `Deck.normalizerQuotient_smul_subgroupFiberOrbitClass`: `Subgroup.normalizerQuotientMk H φ` becomes the coercion `(φ : Subgroup.normalizerQuotient H)`. `normalizerQuotientMk` is an abbrev for `QuotientGroup.mk'`, so Mathlib's `QuotientGroup.mk'_apply` unconditionally rewrites it to the coercion; the coercion is the only stable normal form.
- `..._symm_one` (2): now stated at `1` instead of `normalizerQuotientMk H ⟨1, _⟩`, which is both normal and cleaner.
- `Deck.IsRegular.fundamentalGroupEquiv_unop_smul`: ambient `φ • e` becomes the application form the simp set normalizes to.
- `Deck.subgroupFiberOrbitQuotientEquiv_refl`: `Equiv.cast` becomes `cast` (Mathlib's `Equiv.cast_apply` is simp).
- `Deck.fiber_smul_coe`, `Deck.fiber_smul_coe_eq_smul`: these were documented as fibre-level coercion lemmas but elaborated with the ambient action (duplicating `smul_eq_apply`). They now state the fibre-level fact, and `fiber_smul_coe` supplies the `↑(φ • e)` normal form the simp set needs.

**De-simped** (statement kept, attribute removed, LHS reducible by other simp lemmas so the attribute could never fire on normal-form goals): `mem_closedStar_singleton`, `Deck.mem_addCircleCoe`, `AddCircle.fundamentalGroupMulEquivZMultiples_eq_one_iff`, `AddCircle.fundamentalGroupMulEquivInt_eq_one_iff`, `AddCircle.fundamentalGroupMulEquiv_eq_one_iff`, `AddCircle.fundamentalGroupMulEquiv_zero_eq_one_iff`, `UnitAddCircle.fundamentalGroupMulEquiv_eq_one_iff`, `Deck.fiber_smul_mem`, `Deck.mem_fiber_stabilizer_iff_coe` (keeps `grind =`), `Deck.fiberMap_symm_smul`, `Deck.mem_stabilizer_conjMulEquiv_fiberMap_iff` (keeps `grind =`), `Deck.deckEquivFiberOfSurjective_fiberMap`, `Deck.deckEquivFiber_fiberMap`, `Deck.deckEquivFiberOfSurjective_apply_coe`, `Deck.deckEquivFiber_apply_coe`, `Deck.IsRegular.fundamentalGroupEquiv_eq_one_iff`, `Deck.IsRegular.deckEquivFiber_eq_fundamentalGroupEquivFiber`, `Deck.IsRegular.deckFundamentalGroupEquiv_eq_one_iff`, `Deck.IsRegular.deckFundamentalGroupEquiv_unop_monodromy`, `Deck.IsRegular.orbitQuotientEquivBase_conj_mk`, `Deck.deckEquivFiber_symm_smul`, `Deck.deckEquivFiber_symm_apply_coe`, `Deck.deckEquivFiber_symm_apply_smul`, all six `Deck.normalizerQuotientConjEquiv_*` representative formulas, `Deck.subgroupFiberOrbitQuotientEquivQuotientGroup_symm_mk_coe`, `Deck.subgroupFiberOrbitMapOfLE_bot_apply`, `Deck.normalizerQuotient_mk_of_mem_smul_subgroupFiberOrbitClass`, and four `*_apply_inv_smul` variants that became simp-provable from their `*_apply_smul` counterparts plus `inv_inv`.

After the changes the simpNF linter reports zero "LHS simplifies" entries in these modules (verified by running the linter over every declaration in all 18 touched files).

**Needs design attention** (left as-is):

- `Deck.fiberOrbitQuotientEquiv_trans`, `Deck.subgroupFiberOrbitQuotientEquiv_trans`: pre-existing baseline entries of a different category ("LHS does not simplify when using the lemma on itself", caused by the proof-term arguments); out of scope for this wave.
- The `*_eq_one_iff` family cannot be simp lemmas while Mathlib's `EmbeddingLike.map_eq_one_iff` + `CategoryTheory.End.one_def` are simp: any `f γ = 1` LHS is instantly rewritten. If simp should solve these goals, the right of `FundamentalGroup` needs `1`-spelled monodromy lemmas.
- `Deck.normalizerQuotientConjEquiv` is an abbrev, so simp computes through it via the `Subgroup.normalizerQuotientEquivMap` lemmas, and Mathlib's `Subgroup.coe_map` rewrites inside the `Subgroup.normalizer (↑(H.map f))` type indices. Its representative formulas cannot be stated in simp-normal form at all; consider making it a `def` or restructuring the normalizer API to avoid `Set`-coercion indices.

🤖 Prepared with Claude Code