### PR TITLE
chore(AlgebraicGeometry): drop simp attributes from lemmas whose LHS is not in simp normal form

### DIFF
--- a/TauCeti/AlgebraicGeometry/WeilDivisor.lean
+++ b/TauCeti/AlgebraicGeometry/WeilDivisor.lean
@@ -78,7 +78,7 @@ lemma ext {D E : WeilDivisor X} (h : ∀ x, coeff D x = coeff E x) : D = E :=
 
 /-- A point lies in the support of a Weil divisor exactly when its coefficient is nonzero. This
 is the `coeff`-level restatement of `Finsupp.mem_support_iff`. -/
-@[simp, grind =]
+@[grind =]
 lemma mem_support_iff {D : WeilDivisor X} {x : X} : x ∈ D.support ↔ coeff D x ≠ 0 :=
   Finsupp.mem_support_iff
 

--- a/TauCeti/AlgebraicGeometry/WeilDivisor/AbelJacobiDegreeSplitting.lean
+++ b/TauCeti/AlgebraicGeometry/WeilDivisor/AbelJacobiDegreeSplitting.lean
@@ -59,7 +59,6 @@ lemma degreeCorrection_divisorClass_ofPoint (w : X → ℤ) (h : S.IsWeightedDeg
 
 /-- Under the splitting `Cl(X) ≃+ Pic⁰ × ℤ`, the class of the point divisor `[x]` has
 `Pic⁰` component the weighted Abel-Jacobi class of `x`, and degree component `w x`. -/
-@[simp]
 lemma classGroupAddEquivPicZeroProdInt_divisorClass_ofPoint (w : X → ℤ)
     (h : S.IsWeightedDegreeZero w) {x₀ : X} (hx₀ : w x₀ = 1) (x : X) :
     S.classGroupAddEquivPicZeroProdInt w h hx₀ (S.divisorClass (ofPoint x)) =
@@ -72,7 +71,6 @@ lemma classGroupAddEquivPicZeroProdInt_divisorClass_ofPoint (w : X → ℤ)
 
 /-- Under the splitting `Cl(X) ≃+ Pic⁰ × ℤ`, a coerced weighted Abel-Jacobi class has degree
 zero and `Pic⁰` component itself. -/
-@[simp]
 lemma classGroupAddEquivPicZeroProdInt_coe_weightedAbelJacobiClass (w : X → ℤ)
     (h : S.IsWeightedDegreeZero w) {x₀ : X} (hx₀ : w x₀ = 1) (x : X) :
     S.classGroupAddEquivPicZeroProdInt w h hx₀
@@ -82,7 +80,6 @@ lemma classGroupAddEquivPicZeroProdInt_coe_weightedAbelJacobiClass (w : X → �
 
 /-- The degree-corrected point divisor `[x] - w(x)[x₀]` maps to the weighted Abel-Jacobi class
 and degree `0` under the splitting `Cl(X) ≃+ Pic⁰ × ℤ`. -/
-@[simp]
 lemma classGroupAddEquivPicZeroProdInt_divisorClass_weightedPointBaseDifference
     (w : X → ℤ) (h : S.IsWeightedDegreeZero w) {x₀ : X} (hx₀ : w x₀ = 1) (x : X) :
     S.classGroupAddEquivPicZeroProdInt w h hx₀
@@ -93,7 +90,6 @@ lemma classGroupAddEquivPicZeroProdInt_divisorClass_weightedPointBaseDifference
 
 /-- The inverse splitting reconstructs the point class `[x]` from its weighted Abel-Jacobi
 component and its degree `w x`. -/
-@[simp]
 lemma classGroupAddEquivPicZeroProdInt_symm_weightedAbelJacobiClass (w : X → ℤ)
     (h : S.IsWeightedDegreeZero w) {x₀ : X} (hx₀ : w x₀ = 1) (x : X) :
     (S.classGroupAddEquivPicZeroProdInt w h hx₀).symm
@@ -115,7 +111,6 @@ lemma degreeCorrection_divisorClass_ofPoint_unweighted (h : S.IsUnweightedDegree
 
 /-- Under the unweighted splitting `Cl(X) ≃+ Pic⁰ × ℤ`, the class of `[x]` has `Pic⁰`
 component the unweighted Abel-Jacobi class of `x`, and degree component `1`. -/
-@[simp]
 lemma classGroupAddEquivUnweightedPicZeroProdInt_divisorClass_ofPoint
     (h : S.IsUnweightedDegreeZero) (x₀ x : X) :
     S.classGroupAddEquivUnweightedPicZeroProdInt h x₀ (S.divisorClass (ofPoint x)) =
@@ -127,7 +122,6 @@ lemma classGroupAddEquivUnweightedPicZeroProdInt_divisorClass_ofPoint
 
 /-- Under the unweighted splitting, a coerced unweighted Abel-Jacobi class has degree zero and
 `Pic⁰` component itself. -/
-@[simp]
 lemma classGroupAddEquivUnweightedPicZeroProdInt_coe_unweightedAbelJacobiClass
     (h : S.IsUnweightedDegreeZero) (x₀ x : X) :
     S.classGroupAddEquivUnweightedPicZeroProdInt h x₀
@@ -138,7 +132,6 @@ lemma classGroupAddEquivUnweightedPicZeroProdInt_coe_unweightedAbelJacobiClass
 
 /-- The point difference `[x] - [x₀]` maps to the unweighted Abel-Jacobi class and degree `0`
 under the unweighted splitting `Cl(X) ≃+ Pic⁰ × ℤ`. -/
-@[simp]
 lemma classGroupAddEquivUnweightedPicZeroProdInt_divisorClass_pointDifference
     (h : S.IsUnweightedDegreeZero) (x₀ x : X) :
     S.classGroupAddEquivUnweightedPicZeroProdInt h x₀ (S.divisorClass (pointDifference x x₀)) =
@@ -148,7 +141,6 @@ lemma classGroupAddEquivUnweightedPicZeroProdInt_divisorClass_pointDifference
 
 /-- The inverse unweighted splitting reconstructs the point class `[x]` from its Abel-Jacobi
 component and degree `1`. -/
-@[simp]
 lemma classGroupAddEquivUnweightedPicZeroProdInt_symm_unweightedAbelJacobiClass
     (h : S.IsUnweightedDegreeZero) (x₀ x : X) :
     (S.classGroupAddEquivUnweightedPicZeroProdInt h x₀).symm

--- a/TauCeti/AlgebraicGeometry/WeilDivisor/AbelJacobiQuotient.lean
+++ b/TauCeti/AlgebraicGeometry/WeilDivisor/AbelJacobiQuotient.lean
@@ -93,7 +93,6 @@ lemma weightedAbelJacobiQuotientClass_mk (w : X → ℤ) {x₀ : X} (hx₀ : w x
 
 /-- The quotient Abel-Jacobi representative of a sum is the sum of the quotient
 representatives. -/
-@[simp]
 lemma weightedAbelJacobiQuotientClass_add (w : X → ℤ) {x₀ : X} (hx₀ : w x₀ = 1)
     (D E : WeilDivisor X) :
     S.weightedAbelJacobiQuotientClass w hx₀ (D + E) =
@@ -103,7 +102,6 @@ lemma weightedAbelJacobiQuotientClass_add (w : X → ℤ) {x₀ : X} (hx₀ : w 
 
 /-- The quotient Abel-Jacobi representative of an integral multiple is the corresponding
 multiple of the quotient representative. -/
-@[simp]
 lemma weightedAbelJacobiQuotientClass_zsmul (w : X → ℤ) {x₀ : X} (hx₀ : w x₀ = 1)
     (n : ℤ) (D : WeilDivisor X) :
     S.weightedAbelJacobiQuotientClass w hx₀ (n • D) =
@@ -112,7 +110,6 @@ lemma weightedAbelJacobiQuotientClass_zsmul (w : X → ℤ) {x₀ : X} (hx₀ : 
 
 /-- The quotient representative maps to the weighted Abel-Jacobi divisor class under the
 degree-zero quotient equivalence. -/
-@[simp]
 lemma weightedDegreeZeroQuotientEquivPicZero_weightedAbelJacobiQuotientClass
     (w : X → ℤ) (h : S.IsWeightedDegreeZero w) {x₀ : X} (hx₀ : w x₀ = 1)
     (D : WeilDivisor X) :
@@ -125,7 +122,6 @@ lemma weightedDegreeZeroQuotientEquivPicZero_weightedAbelJacobiQuotientClass
     coe_weightedAbelJacobiDegreeZeroDivisor]
 
 /-- For point divisors, the quotient representative maps to the point Abel-Jacobi class. -/
-@[simp]
 lemma weightedDegreeZeroQuotientEquivPicZero_weightedAbelJacobiQuotientClass_ofPoint
     (w : X → ℤ) (h : S.IsWeightedDegreeZero w) {x₀ : X} (hx₀ : w x₀ = 1) (x : X) :
     S.weightedDegreeZeroQuotientEquivPicZero w h
@@ -157,7 +153,6 @@ lemma weightedAbelJacobiQuotientClass_eq_sum (w : X → ℤ) {x₀ : X} (hx₀ :
         simp [add_zsmul]
 
 /-- The base-point divisor represents zero in the degree-zero quotient. -/
-@[simp]
 lemma weightedAbelJacobiQuotientClass_ofPoint_base (w : X → ℤ) {x₀ : X} (hx₀ : w x₀ = 1) :
     S.weightedAbelJacobiQuotientClass w hx₀ (ofPoint x₀) = 0 := by
   rw [weightedAbelJacobiQuotientClass_mk]
@@ -167,7 +162,6 @@ lemma weightedAbelJacobiQuotientClass_ofPoint_base (w : X → ℤ) {x₀ : X} (h
   exact S.principalSubgroup.zero_mem
 
 /-- A principal divisor has zero weighted quotient Abel-Jacobi representative. -/
-@[simp]
 lemma weightedAbelJacobiQuotientClass_principalDivisor (w : X → ℤ)
     (h : S.IsWeightedDegreeZero w) {x₀ : X} (hx₀ : w x₀ = 1) (g : G) :
     S.weightedAbelJacobiQuotientClass w hx₀ (S.principalDivisor g) = 0 := by
@@ -231,7 +225,6 @@ lemma unweightedAbelJacobiQuotientClass_mk (x₀ : X) (D : WeilDivisor X) :
 
 /-- The unweighted quotient Abel-Jacobi representative of a sum is the sum of the quotient
 representatives. -/
-@[simp]
 lemma unweightedAbelJacobiQuotientClass_add (x₀ : X) (D E : WeilDivisor X) :
     S.unweightedAbelJacobiQuotientClass x₀ (D + E) =
       S.unweightedAbelJacobiQuotientClass x₀ D +
@@ -240,7 +233,6 @@ lemma unweightedAbelJacobiQuotientClass_add (x₀ : X) (D E : WeilDivisor X) :
 
 /-- The unweighted quotient Abel-Jacobi representative of an integral multiple is the
 corresponding multiple of the quotient representative. -/
-@[simp]
 lemma unweightedAbelJacobiQuotientClass_zsmul (x₀ : X) (n : ℤ) (D : WeilDivisor X) :
     S.unweightedAbelJacobiQuotientClass x₀ (n • D) =
       n • S.unweightedAbelJacobiQuotientClass x₀ D :=
@@ -248,7 +240,6 @@ lemma unweightedAbelJacobiQuotientClass_zsmul (x₀ : X) (n : ℤ) (D : WeilDivi
 
 /-- The quotient representative maps to the unweighted Abel-Jacobi divisor class under the
 degree-zero quotient equivalence. -/
-@[simp]
 lemma degreeZeroQuotientEquivUnweightedPicZero_unweightedAbelJacobiQuotientClass
     (h : S.IsUnweightedDegreeZero) (x₀ : X) (D : WeilDivisor X) :
     S.degreeZeroQuotientEquivUnweightedPicZero h
@@ -261,7 +252,6 @@ lemma degreeZeroQuotientEquivUnweightedPicZero_unweightedAbelJacobiQuotientClass
 
 /-- For point divisors, the unweighted quotient representative maps to the point
 Abel-Jacobi class. -/
-@[simp]
 lemma degreeZeroQuotientEquivUnweightedPicZero_unweightedAbelJacobiQuotientClass_ofPoint
     (h : S.IsUnweightedDegreeZero) (x₀ x : X) :
     S.degreeZeroQuotientEquivUnweightedPicZero h
@@ -291,14 +281,12 @@ lemma unweightedAbelJacobiQuotientClass_eq_sum (x₀ : X) (D : WeilDivisor X) :
   rw [map_zsmul, ← S.unweightedAbelJacobiQuotientClass_eq_weighted x₀ (ofPoint x)]
 
 /-- The unweighted base-point divisor represents zero in the degree-zero quotient. -/
-@[simp]
 lemma unweightedAbelJacobiQuotientClass_ofPoint_base (x₀ : X) :
     S.unweightedAbelJacobiQuotientClass x₀ (ofPoint x₀) = 0 := by
   rw [S.unweightedAbelJacobiQuotientClass_eq_weighted]
   simp
 
 /-- A principal divisor has zero unweighted quotient Abel-Jacobi representative. -/
-@[simp]
 lemma unweightedAbelJacobiQuotientClass_principalDivisor (h : S.IsUnweightedDegreeZero)
     (x₀ : X) (g : G) :
     S.unweightedAbelJacobiQuotientClass x₀ (S.principalDivisor g) = 0 := by

--- a/TauCeti/AlgebraicGeometry/WeilDivisor/AbelJacobiSum.lean
+++ b/TauCeti/AlgebraicGeometry/WeilDivisor/AbelJacobiSum.lean
@@ -187,7 +187,6 @@ lemma weightedAbelJacobiDivisorClass_eq_of_linearlyEquivalent
 
 /-- Under the splitting `Cl(X) ≃+ Pic⁰ × ℤ`, the class of a divisor has `Pic⁰` component
 its weighted Abel-Jacobi sum and degree component its weighted degree. -/
-@[simp]
 lemma classGroupAddEquivPicZeroProdInt_divisorClass (w : X → ℤ)
     (h : S.IsWeightedDegreeZero w) {x₀ : X} (hx₀ : w x₀ = 1) (D : WeilDivisor X) :
     S.classGroupAddEquivPicZeroProdInt w h hx₀ (S.divisorClass D) =
@@ -346,7 +345,6 @@ lemma unweightedAbelJacobiDivisorClass_principalDivisor (h : S.IsUnweightedDegre
 
 /-- Under the unweighted splitting, the class of a divisor has `Pic⁰` component its
 unweighted Abel-Jacobi sum and degree component its degree. -/
-@[simp]
 lemma classGroupAddEquivUnweightedPicZeroProdInt_divisorClass
     (h : S.IsUnweightedDegreeZero) (x₀ : X) (D : WeilDivisor X) :
     S.classGroupAddEquivUnweightedPicZeroProdInt h x₀ (S.divisorClass D) =

--- a/TauCeti/AlgebraicGeometry/WeilDivisor/Dedekind.lean
+++ b/TauCeti/AlgebraicGeometry/WeilDivisor/Dedekind.lean
@@ -273,7 +273,6 @@ lemma coeff_principalDivisor_eq_fractionalIdeal_count (u : Additive Kˣ)
 
 /-- A height-one prime lies in the support of a principal divisor exactly when the corresponding
 valuation is not one. -/
-@[simp]
 lemma mem_support_principalDivisor_iff_valuation_ne_one (u : Additive Kˣ)
     (v : HeightOneSpectrum R) :
     v ∈ ((OrderSystem.ofDedekindDomain R K).principalDivisor u).support ↔
@@ -323,7 +322,6 @@ lemma coeff_principalDivisor_pos_iff_mem {r : R} {u : Kˣ} (hu : (u : K) = algeb
 
 /-- The support of the divisor of a nonzero integral element `r : R`, presented as a unit
 `u : Kˣ` with value `algebraMap R K r`, is the set of height-one primes containing `r`. -/
-@[simp]
 lemma mem_support_principalDivisor_of_integral_iff_mem_asIdeal {r : R} {u : Kˣ}
     (hu : (u : K) = algebraMap R K r) (v : HeightOneSpectrum R) :
     v ∈ ((OrderSystem.ofDedekindDomain R K).principalDivisor (Additive.ofMul u)).support ↔

--- a/TauCeti/AlgebraicGeometry/WeilDivisor/DegreeSplitting.lean
+++ b/TauCeti/AlgebraicGeometry/WeilDivisor/DegreeSplitting.lean
@@ -153,7 +153,6 @@ lemma degreeCorrection_eq_self_of_mem_picZero (w : X → ℤ) (h : S.IsWeightedD
 
 /-- The degree correction of a coerced `picZero` class is the same class in the ambient class
 group. -/
-@[simp]
 lemma degreeCorrection_coe_picZero (w : X → ℤ) (h : S.IsWeightedDegreeZero w)
     (x₀ : X) (p : picZero w h) :
     S.degreeCorrection w h x₀ (p : S.ClassGroup) = p :=
@@ -241,7 +240,6 @@ lemma classGroupAddEquivPicZeroProdInt_symm_apply (w : X → ℤ) (h : S.IsWeigh
 
 /-- Under the splitting `Cl(X) ≃+ picZero × ℤ`, a coerced `picZero` class has `Pic⁰` component
 itself and degree component `0`. -/
-@[simp]
 lemma classGroupAddEquivPicZeroProdInt_coe_picZero (w : X → ℤ) (h : S.IsWeightedDegreeZero w)
     {x₀ : X} (hx₀ : w x₀ = 1) (p : picZero w h) :
     S.classGroupAddEquivPicZeroProdInt w h hx₀ (p : S.ClassGroup) = (p, 0) := by
@@ -277,7 +275,6 @@ lemma classGroupAddEquivUnweightedPicZeroProdInt_symm_apply (h : S.IsUnweightedD
 
 /-- Under the unweighted splitting, a coerced `unweightedPicZero` class has `Pic⁰` component
 itself and degree component `0`. -/
-@[simp]
 lemma classGroupAddEquivUnweightedPicZeroProdInt_coe_unweightedPicZero
     (h : S.IsUnweightedDegreeZero) (x₀ : X) (p : unweightedPicZero h) :
     S.classGroupAddEquivUnweightedPicZeroProdInt h x₀ (p : S.ClassGroup) = (p, 0) :=

--- a/TauCeti/AlgebraicGeometry/WeilDivisor/FiniteSum.lean
+++ b/TauCeti/AlgebraicGeometry/WeilDivisor/FiniteSum.lean
@@ -203,7 +203,6 @@ lemma support_ofFinsetWithMultiplicity_subset (s : Finset X) (m : X → ℕ) :
 
 /-- A point is in the support of a named finite-set divisor with multiplicities exactly when it
 is selected and has nonzero multiplicity. -/
-@[simp]
 lemma mem_support_ofFinsetWithMultiplicity_iff {s : Finset X} {m : X → ℕ} {x : X} :
     x ∈ (ofFinsetWithMultiplicity s m : WeilDivisor X).support ↔ x ∈ s ∧ m x ≠ 0 := by
   classical

--- a/TauCeti/AlgebraicGeometry/WeilDivisor/Order.lean
+++ b/TauCeti/AlgebraicGeometry/WeilDivisor/Order.lean
@@ -141,12 +141,10 @@ lemma support_posPart_disjoint_negPart (D : WeilDivisor X) :
   · exact hxn (by rwa [inf_eq_right.mpr h] at hinf)
 
 /-- A divisor is effective exactly when its negative part vanishes. -/
-@[simp]
 lemma negPart_eq_zero_iff_isEffective {D : WeilDivisor X} : D⁻ = 0 ↔ IsEffective D := by
   rw [negPart_eq_zero, isEffective_iff_zero_le]
 
 /-- A divisor is effective exactly when it equals its own positive part. -/
-@[simp]
 lemma posPart_eq_self_iff_isEffective {D : WeilDivisor X} : D⁺ = D ↔ IsEffective D := by
   rw [posPart_eq_self, isEffective_iff_zero_le]
 


### PR DESCRIPTION
This PR addresses 31 of the 38 AlgebraicGeometry declarations flagged by the simpNF linter with reason "Left-hand side simplifies from ..." (wave 2 of the simp normal-form cleanup; wave 1 was the "simp can prove this" batch, #643). Every entry was re-verified against the current simp set on `main` before acting; all 38 still violated. The full library builds with no downstream repairs, and all 31 touched declarations re-lint clean (`LINT-OK`); the remaining 7 are left in place with a needs-design-attention note below.

De-simped (31). In each case the simp set already rewrites the flagged LHS first, so the attribute can never usefully fire; the lemma is kept for manual use:

- `WeilDivisor/AbelJacobiQuotient.lean` (12): `weightedAbelJacobiQuotientClass_{add,zsmul,ofPoint_base,principalDivisor}`, `weightedDegreeZeroQuotientEquivPicZero_weightedAbelJacobiQuotientClass{,_ofPoint}`, and the six unweighted counterparts. The characterizing `weightedAbelJacobiQuotientClass_mk`/`unweightedAbelJacobiQuotientClass_mk` simp lemmas rewrite any applied occurrence to the quotient-`mk` form before these can match (for the equiv-composition lemmas the inner subterm is rewritten first, so they can never fire at all).
- `WeilDivisor/AbelJacobiDegreeSplitting.lean` (8): `classGroupAddEquiv{,Unweighted}PicZeroProdInt_divisorClass_{ofPoint,pointDifference,weightedPointBaseDifference}`, `..._coe_{weighted,unweighted}AbelJacobiClass`, `..._symm_{weighted,unweighted}AbelJacobiClass`; `WeilDivisor/AbelJacobiSum.lean` (2): `classGroupAddEquiv{,Unweighted}PicZeroProdInt_divisorClass`; `WeilDivisor/DegreeSplitting.lean` (3): `degreeCorrection_coe_picZero`, `classGroupAddEquiv{,Unweighted}PicZeroProdInt_coe_{,unweighted}PicZero`. The deliberate `classGroupAddEquiv*ProdInt_apply`/`_symm_apply` and `degreeCorrection_apply` unfolding calculus rewrites these LHSs (or their inner subterms) first.
- Support-membership lemmas (4): `mem_support_iff` (`WeilDivisor.lean`; keeps its `@[grind =]`), `mem_support_ofFinsetWithMultiplicity_iff` (`FiniteSum.lean`), `mem_support_principalDivisor_iff_valuation_ne_one` and `mem_support_principalDivisor_of_integral_iff_mem_asIdeal` (`Dedekind.lean`). `WeilDivisor` is an abbrev of `X →₀ ℤ`, so Mathlib's `Finsupp.mem_support_iff` rewrites `x ∈ D.support` to the raw-application form first; the coeff-level attributes are dead weight.
- `WeilDivisor/Order.lean` (2): `posPart_eq_self_iff_isEffective`, `negPart_eq_zero_iff_isEffective`. Mathlib's `posPart_eq_self`/`negPart_eq_zero` rewrite the LHS to `0 ≤ D`; the residual fact `0 ≤ D ↔ IsEffective D` is the existing `isEffective_iff_zero_le`.

Left in place, needs design attention (7): `pushforward_pointDifference`, `pushforward_add`, `pushforward_ofPoint`, `degree_pushforward` (`WeilDivisor.lean`), `pushforward_ofFinsetWithMultiplicity`, `pushforward_ofFinsupp`, `pushforward_ofFinset` (`FiniteSum.lean`). These are the intended normal forms (`pushforward f (ofPoint x) = ofPoint (f x)` and friends), but `pushforward_apply : pushforward f D = D.mapDomain f` is `@[simp]`, so simp unfolds the abstraction to `Finsupp.mapDomain` first and strands goals there (e.g. `mapDomain f (ofPoint x)` is not further reducible). `pushforward_apply` is an outlier in its own file — the parallel `degree_apply`, `weightedDegree_apply`, and `coeff` unfolding lemmas are deliberately not simp. Suggest removing simp from `pushforward_apply`; the seven flagged lemmas are then correct simp normal forms as stated. Restated: none.

All 31 fixed names are grandfathered entries in `scripts/simp-nf-baseline.txt`; the ratchet reminder to delete them is left for a human-reviewed follow-up since that file is human-owned.

🤖 Prepared with Claude Code
