### PR TITLE
chore(Topology): drop the simp attribute from postcompHomeomorphPrecompEquiv_trans_apply

### DIFF
--- a/TauCeti/Topology/Homotopy/AmbientIsotopyClass.lean
+++ b/TauCeti/Topology/Homotopy/AmbientIsotopyClass.lean
@@ -360,7 +360,6 @@ theorem postcompHomeomorphPrecompEquiv_apply_eq (h : Y ≃ₜ Z) (e : W ≃ₜ X
   rfl
 
 /-- Two-sided coordinate change is functorial for iterated coordinate changes. -/
-@[simp]
 theorem postcompHomeomorphPrecompEquiv_trans_apply (h : Y ≃ₜ Z) (k : Z ≃ₜ Y')
     (e : W ≃ₜ X) (d : X' ≃ₜ W) (x : AmbientIsotopyClass X Y) :
     postcompHomeomorphPrecompEquiv k d (postcompHomeomorphPrecompEquiv h e x) =


### PR DESCRIPTION
This PR addresses the single Topology declaration flagged by the simpNF linter with reason "Left-hand side simplifies from ..." (wave 2 of the simp normal-form cleanup; wave 1 was the "simp can prove this" batch, #648). The entry was re-verified against the current simp set on `main` before acting and still violated. The full library builds with no downstream repairs, and the declaration re-lints clean (`LINT-OK`).

De-simped (1):

- `Homotopy/AmbientIsotopyClass.lean`: `postcompHomeomorphPrecompEquiv_trans_apply`. The decomposition rule `postcompHomeomorphPrecompEquiv_apply_eq` (simp, same file) rewrites the inner `postcompHomeomorphPrecompEquiv h e x` subterm into the `postcompHomeomorph`/`precompHomeomorphEquiv` factorization before the outer functoriality lemma can ever match, so the attribute is dead weight. The lemma is kept for manual use.

Restated: none. Left with rationale: none.

The fixed name is a grandfathered entry in `scripts/simp-nf-baseline.txt`; the ratchet deletion is left for a human-reviewed follow-up since that file is human-owned.

🤖 Prepared with Claude Code
