### PR TITLE
feat: add fixed-degree effective divisors

### DIFF
--- a/TauCeti/AlgebraicGeometry/WeilDivisor/FixedDegree.lean
+++ b/TauCeti/AlgebraicGeometry/WeilDivisor/FixedDegree.lean
@@ -180,7 +180,6 @@ def equivSym : EffectiveDivisorOfDegree X d ≃ Sym X d := by
 
 /-- Applying the symmetric-power equivalence is the same as applying Mathlib's multiplicity
 equivalence to the fixed-degree divisor's multiplicity function. -/
-@[simp]
 lemma equivSym_apply (D : EffectiveDivisorOfDegree X d) :
     equivSym D =
       (letI := Classical.decEq X; (Sym.equivNatSum X d).symm (equivFinsupp D)) := by
@@ -266,7 +265,7 @@ lemma equivSym_pushforward (f : X → Y) (D : EffectiveDivisorOfDegree X d) :
   classical
   apply (Sym.equivNatSum Y d).injective
   ext y
-  simp [Finsupp.toMultiset_map]
+  simp [equivSym_apply, Finsupp.toMultiset_map]
 
 end EffectiveDivisorOfDegree
 

--- a/TauCeti/AlgebraicGeometry/WeilDivisor/FixedDegree.lean
+++ b/TauCeti/AlgebraicGeometry/WeilDivisor/FixedDegree.lean
@@ -62,8 +62,7 @@ lemma mem_effectiveSubmonoid (D : EffectiveDivisorOfDegree X d) :
 
 /-- An effective divisor of degree `d` from finitely supported natural multiplicities whose
 total multiplicity is `d`. -/
-@[expose]
-def ofFinsupp (m : X →₀ ℕ) (hm : m.sum (fun _ n => n) = d) :
+abbrev ofFinsupp (m : X →₀ ℕ) (hm : m.sum (fun _ n => n) = d) :
     EffectiveDivisorOfDegree X d :=
   ⟨WeilDivisor.ofFinsupp m, isEffective_ofFinsupp m, by
     rw [degree_ofFinsupp]
@@ -79,8 +78,7 @@ lemma coeff_ofFinsupp (m : X →₀ ℕ) (hm : m.sum (fun _ n => n) = d) (x : X)
   WeilDivisor.coeff_ofFinsupp m x
 
 /-- The finitely supported natural multiplicity function underlying an effective divisor. -/
-@[expose]
-def multiplicityFinsupp (D : EffectiveDivisorOfDegree X d) : X →₀ ℕ :=
+abbrev multiplicityFinsupp (D : EffectiveDivisorOfDegree X d) : X →₀ ℕ :=
   Finsupp.ofSupportFinite (fun x => (coeff (D : WeilDivisor X) x).toNat) <|
     (D : WeilDivisor X).support.finite_toSet.subset <| by
       intro x hx
@@ -89,10 +87,7 @@ def multiplicityFinsupp (D : EffectiveDivisorOfDegree X d) : X →₀ ℕ :=
       change x ∈ (D : WeilDivisor X).support
       rw [WeilDivisor.mem_support_iff]
       intro hcoeff
-      exact hx (by
-        change (coeff (D : WeilDivisor X) x).toNat = 0
-        rw [hcoeff]
-        exact Int.toNat_zero)
+      exact hx (by simp [hcoeff])
 
 @[simp]
 lemma multiplicityFinsupp_apply (D : EffectiveDivisorOfDegree X d) (x : X) :
@@ -135,8 +130,7 @@ lemma multiplicityFinsupp_ofFinsupp (m : X →₀ ℕ) (hm : m.sum (fun _ n => n
 
 /-- Fixed-degree effective divisors are equivalently finitely supported natural multiplicities
 with total mass `d`. -/
-@[expose]
-def equivFinsupp :
+abbrev equivFinsupp :
     EffectiveDivisorOfDegree X d ≃ {m : X →₀ ℕ // m.sum (fun _ n => n) = d} where
   toFun D := ⟨D.multiplicityFinsupp, D.sum_multiplicityFinsupp⟩
   invFun m := ofFinsupp m.1 m.2
@@ -203,23 +197,22 @@ lemma equivSym_symm_apply (s : Sym X d) :
 /-- Converting a divisor to the symmetric power and back gives the original divisor. -/
 @[simp]
 lemma ofSym_equivSym (D : EffectiveDivisorOfDegree X d) :
-    ofSym (letI := Classical.decEq X; (Sym.equivNatSum X d).symm (equivFinsupp D)) = D := by
+    ofSym (equivSym D) = D := by
   classical
-  simpa [equivSym_apply] using (equivSym.left_inv D)
+  exact equivSym.left_inv D
 
 /-- Converting a symmetric-power point to a divisor and back gives the original symmetric-power
 point. -/
 @[simp]
 lemma equivSym_ofSym (s : Sym X d) :
-    (letI := Classical.decEq X; (Sym.equivNatSum X d).symm (equivFinsupp (ofSym s))) = s := by
+    equivSym (ofSym s) = s := by
   classical
-  simpa [equivSym_apply] using (equivSym.right_inv s)
+  exact equivSym.right_inv s
 
 end Sym
 
 /-- Pushing forward a fixed-degree effective divisor preserves its degree. -/
-@[expose]
-def pushforward (f : X → Y) (D : EffectiveDivisorOfDegree X d) :
+abbrev pushforward (f : X → Y) (D : EffectiveDivisorOfDegree X d) :
     EffectiveDivisorOfDegree Y d :=
   ⟨WeilDivisor.pushforward f D, D.isEffective.pushforward f, by
     rw [degree_pushforward, D.degree_eq]⟩
@@ -269,16 +262,11 @@ lemma multiplicityFinsupp_pushforward (f : X → Y) (D : EffectiveDivisorOfDegre
 /-- The symmetric-power equivalence sends divisor pushforward to `Sym.map`. -/
 @[simp]
 lemma equivSym_pushforward (f : X → Y) (D : EffectiveDivisorOfDegree X d) :
-    (letI := Classical.decEq Y; (Sym.equivNatSum Y d).symm (equivFinsupp (D.pushforward f))) =
-      Sym.map f (equivSym D) := by
+    equivSym (D.pushforward f) = Sym.map f (equivSym D) := by
   classical
   apply (Sym.equivNatSum Y d).injective
   ext y
   simp [Finsupp.toMultiset_map]
-
-/-- The zero divisor is the unique effective divisor of degree zero. -/
-def zeroEquivPUnit : EffectiveDivisorOfDegree X 0 ≃ PUnit :=
-  (equivSym (X := X) (d := 0)).trans (Equiv.equivPUnit (Sym X 0))
 
 end EffectiveDivisorOfDegree
 

--- a/TauCeti/AlgebraicGeometry/WeilDivisor/FixedDegree.lean
+++ b/TauCeti/AlgebraicGeometry/WeilDivisor/FixedDegree.lean
@@ -82,18 +82,19 @@ lemma coeff_ofFinsupp (m : X →₀ ℕ) (hm : m.sum (fun _ n => n) = d) (x : X)
 /-- The finitely supported natural multiplicity function underlying an effective divisor. -/
 @[expose]
 def multiplicityFinsupp (D : EffectiveDivisorOfDegree X d) : X →₀ ℕ :=
-  Finsupp.onFinset (D : WeilDivisor X).support
-    (fun x => (coeff (D : WeilDivisor X) x).toNat)
-    (fun x hx => by
+  Finsupp.ofSupportFinite (fun x => (coeff (D : WeilDivisor X) x).toNat) <|
+    (D : WeilDivisor X).support.finite_toSet.subset <| by
+      intro x hx
+      change x ∈ (D : WeilDivisor X).support
       rw [Finsupp.mem_support_iff]
       intro hcoeff
-      rw [coeff, hcoeff] at hx
-      exact hx rfl)
+      exact hx (by change ((D : WeilDivisor X) x).toNat = 0; rw [hcoeff]; exact Int.toNat_zero)
 
 @[simp]
 lemma multiplicityFinsupp_apply (D : EffectiveDivisorOfDegree X d) (x : X) :
     D.multiplicityFinsupp x = (coeff (D : WeilDivisor X) x).toNat :=
-  Finsupp.onFinset_apply
+  by
+    rw [multiplicityFinsupp, Finsupp.ofSupportFinite_coe]
 
 @[simp]
 lemma ofFinsupp_multiplicityFinsupp (D : EffectiveDivisorOfDegree X d) :
@@ -121,48 +122,75 @@ lemma multiplicityFinsupp_ofFinsupp (m : X →₀ ℕ) (hm : m.sum (fun _ n => n
   ext x
   simp
 
+/-- Fixed-degree effective divisors are equivalently finitely supported natural multiplicities
+with total mass `d`. -/
+@[expose]
+def equivFinsupp :
+    EffectiveDivisorOfDegree X d ≃ {m : X →₀ ℕ // m.sum (fun _ n => n) = d} where
+  toFun D := ⟨D.multiplicityFinsupp, D.sum_multiplicityFinsupp⟩
+  invFun m := ofFinsupp m.1 m.2
+  left_inv D := by simp
+  right_inv m := by
+    ext x
+    simp
+
+@[simp]
+lemma equivFinsupp_apply_coe (D : EffectiveDivisorOfDegree X d) :
+    (equivFinsupp D : X →₀ ℕ) = D.multiplicityFinsupp :=
+  rfl
+
+@[simp]
+lemma equivFinsupp_symm_apply (m : {m : X →₀ ℕ // m.sum (fun _ n => n) = d}) :
+    (equivFinsupp.symm m : WeilDivisor X) = WeilDivisor.ofFinsupp m.1 :=
+  rfl
+
 section Sym
 
-variable [DecidableEq X]
-
 /-- The effective divisor associated to an unordered degree-`d` collection of points. -/
-@[expose]
 def ofSym (s : Sym X d) : EffectiveDivisorOfDegree X d :=
-  ofFinsupp (Multiset.toFinsupp (s : Multiset X)) (by
-    change (Multiset.toFinsupp (s : Multiset X)).sum (fun _ => id) = d
-    rw [Multiset.toFinsupp_sum_eq, Sym.card_coe])
+  letI := Classical.decEq X
+  equivFinsupp.symm (Sym.equivNatSum X d s)
 
 @[simp]
 lemma coe_ofSym (s : Sym X d) :
-    (ofSym s : WeilDivisor X) = WeilDivisor.ofFinsupp (Multiset.toFinsupp (s : Multiset X)) :=
+    (ofSym s : WeilDivisor X) =
+      WeilDivisor.ofFinsupp (letI := Classical.decEq X; (Sym.equivNatSum X d s).1) := by
+  classical
   rfl
 
 lemma coeff_ofSym (s : Sym X d) (x : X) :
-    coeff (ofSym s : WeilDivisor X) x = (s : Multiset X).count x := by
-  rw [coe_ofSym, WeilDivisor.coeff_ofFinsupp, Multiset.toFinsupp_apply]
+    coeff (ofSym s : WeilDivisor X) x =
+      (letI := Classical.decEq X; (s : Multiset X).count x) := by
+  classical
+  rw [coe_ofSym, WeilDivisor.coeff_ofFinsupp]
+  exact_mod_cast Sym.coe_equivNatSum_apply_apply X d s x
 
 /-- Effective degree-`d` divisors are the same data as the `d`-th symmetric power of the
 underlying point type. -/
-@[expose]
-def equivSym : EffectiveDivisorOfDegree X d ≃ Sym X d where
-  toFun D :=
-    Sym.mk (Finsupp.toMultiset D.multiplicityFinsupp) (by
-      rw [Finsupp.card_toMultiset]
-      change D.multiplicityFinsupp.sum (fun _ n => n) = d
-      exact D.sum_multiplicityFinsupp)
-  invFun := ofSym
-  left_inv D := by
-    apply Subtype.ext
-    rw [coe_ofSym]
-    change WeilDivisor.ofFinsupp
-        (Multiset.toFinsupp (Finsupp.toMultiset D.multiplicityFinsupp)) = (D : WeilDivisor X)
-    rw [Finsupp.toMultiset_toFinsupp, ofFinsupp_multiplicityFinsupp]
-  right_inv s := by
-    apply Sym.ext
-    change Finsupp.toMultiset (ofSym s).multiplicityFinsupp = (s : Multiset X)
-    rw [show (ofSym s).multiplicityFinsupp = Multiset.toFinsupp (s : Multiset X) by
-      exact multiplicityFinsupp_ofFinsupp _ _]
-    exact Multiset.toFinsupp_toMultiset (s : Multiset X)
+def equivSym : EffectiveDivisorOfDegree X d ≃ Sym X d := by
+  letI := Classical.decEq X
+  exact equivFinsupp.trans (Sym.equivNatSum X d).symm
+
+@[simp]
+lemma equivSym_apply (D : EffectiveDivisorOfDegree X d) :
+    equivSym D =
+      (letI := Classical.decEq X; (Sym.equivNatSum X d).symm (equivFinsupp D)) := by
+  classical
+  rfl
+
+@[simp]
+lemma equivSym_symm_apply (s : Sym X d) :
+    (equivSym.symm s : EffectiveDivisorOfDegree X d) = ofSym s := by
+  classical
+  rfl
+
+@[simp]
+lemma ofSym_equivSym (D : EffectiveDivisorOfDegree X d) : ofSym (equivSym D) = D := by
+  exact equivSym.left_inv D
+
+@[simp]
+lemma equivSym_ofSym (s : Sym X d) : equivSym (ofSym s) = s := by
+  exact equivSym.right_inv s
 
 end Sym
 
@@ -184,6 +212,40 @@ lemma pushforward_id (D : EffectiveDivisorOfDegree X d) :
   ext
   rw [coe_pushforward, WeilDivisor.pushforward_id]
   rfl
+
+@[simp]
+lemma pushforward_comp {Z : Type*} (g : Y → Z) (f : X → Y) (D : EffectiveDivisorOfDegree X d) :
+    (D.pushforward f).pushforward g = D.pushforward (g ∘ f) := by
+  ext
+  rw [coe_pushforward, coe_pushforward, coe_pushforward, WeilDivisor.pushforward_comp]
+  rfl
+
+@[simp]
+lemma pushforward_ofFinsupp (f : X → Y) (m : X →₀ ℕ) (hm : m.sum (fun _ n => n) = d) :
+    (ofFinsupp m hm).pushforward f = ofFinsupp (m.mapDomain f) (by
+      exact (Finsupp.sum_mapDomain_index_addMonoidHom
+        (f := f) (s := m) (fun _ : Y => AddMonoidHom.id ℕ)).trans hm) := by
+  classical
+  apply Subtype.ext
+  ext y
+  rw [coe_pushforward, coe_ofFinsupp, coe_ofFinsupp, WeilDivisor.coeff_pushforward,
+    WeilDivisor.coeff_ofFinsupp]
+  simp [Finsupp.mapDomain, Finsupp.sum, Finsupp.single_apply, Finset.sum_ite]
+
+@[simp]
+lemma multiplicityFinsupp_pushforward (f : X → Y) (D : EffectiveDivisorOfDegree X d) :
+    (D.pushforward f).multiplicityFinsupp = D.multiplicityFinsupp.mapDomain f := by
+  have h := pushforward_ofFinsupp f D.multiplicityFinsupp D.sum_multiplicityFinsupp
+  rw [ofFinsupp_multiplicityFinsupp_eq D] at h
+  rw [h, multiplicityFinsupp_ofFinsupp]
+
+@[simp]
+lemma equivSym_pushforward (f : X → Y) (D : EffectiveDivisorOfDegree X d) :
+    equivSym (D.pushforward f) = Sym.map f (equivSym D) := by
+  classical
+  apply (Sym.equivNatSum Y d).injective
+  ext y
+  simp [Finsupp.toMultiset_map]
 
 /-- The zero divisor is the unique effective divisor of degree zero. -/
 def zeroEquivPUnit : EffectiveDivisorOfDegree X 0 ≃ PUnit where

--- a/TauCeti/AlgebraicGeometry/WeilDivisor/FixedDegree.lean
+++ b/TauCeti/AlgebraicGeometry/WeilDivisor/FixedDegree.lean
@@ -1,0 +1,209 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+module
+
+public import Mathlib.Data.Finsupp.Multiset
+public import Mathlib.Data.Sym.Basic
+public import TauCeti.AlgebraicGeometry.WeilDivisor.FiniteSum
+
+/-!
+# Effective Weil divisors of fixed degree
+
+This file packages the fixed-degree part of the effective Weil-divisor monoid.  For a type of
+points `X`, the type `EffectiveDivisorOfDegree X d` consists of effective formal divisors of
+degree `d`.  It is equivalent to Mathlib's symmetric power `Sym X d`, by reading a multiset as
+its finitely supported multiplicity function and conversely reading an effective divisor by its
+natural-number coefficients.
+
+This is the formal divisor model behind the Jacobian roadmap's Layer C symmetric-power lane:
+the scheme-level construction of `Symᵈ X` and relative effective Cartier divisors is later
+geometry, but the Abel-map input already needs the divisor represented by an unordered
+degree-`d` collection of points.
+
+This advances `TauCetiRoadmap/JacobianChallenge/README.md`, Layer C, "Relative effective
+Cartier divisors and symmetric powers `Symᵈ X`", as a small prerequisite built from the
+existing Layer A `WeilDivisor` API.  No external mathematics is vendored.
+-/
+
+public section
+
+namespace TauCeti
+
+namespace AlgebraicGeometry
+
+namespace WeilDivisor
+
+variable {X Y : Type*}
+
+noncomputable section
+
+/-- The effective Weil divisors of degree `d`. -/
+abbrev EffectiveDivisorOfDegree (X : Type*) (d : ℕ) : Type _ :=
+  {D : WeilDivisor X // IsEffective D ∧ degree D = d}
+
+namespace EffectiveDivisorOfDegree
+
+@[ext]
+lemma ext {D E : EffectiveDivisorOfDegree X d} (h : (D : WeilDivisor X) = E) : D = E :=
+  Subtype.ext h
+
+@[simp]
+lemma isEffective (D : EffectiveDivisorOfDegree X d) : IsEffective (D : WeilDivisor X) :=
+  D.property.1
+
+@[simp]
+lemma degree_eq (D : EffectiveDivisorOfDegree X d) : degree (D : WeilDivisor X) = d :=
+  D.property.2
+
+@[simp]
+lemma mem_effectiveSubmonoid (D : EffectiveDivisorOfDegree X d) :
+    (D : WeilDivisor X) ∈ effectiveSubmonoid X :=
+  (WeilDivisor.mem_effectiveSubmonoid _).mpr D.isEffective
+
+/-- An effective divisor of degree `d` from finitely supported natural multiplicities whose
+total multiplicity is `d`. -/
+@[expose]
+def ofFinsupp (m : X →₀ ℕ) (hm : m.sum (fun _ n => n) = d) :
+    EffectiveDivisorOfDegree X d :=
+  ⟨WeilDivisor.ofFinsupp m, isEffective_ofFinsupp m, by
+    rw [degree_ofFinsupp]
+    exact_mod_cast hm⟩
+
+@[simp]
+lemma coe_ofFinsupp (m : X →₀ ℕ) (hm : m.sum (fun _ n => n) = d) :
+    (ofFinsupp m hm : WeilDivisor X) = WeilDivisor.ofFinsupp m :=
+  rfl
+
+@[simp]
+lemma coeff_ofFinsupp (m : X →₀ ℕ) (hm : m.sum (fun _ n => n) = d) (x : X) :
+    coeff (ofFinsupp m hm : WeilDivisor X) x = m x :=
+  WeilDivisor.coeff_ofFinsupp m x
+
+/-- The finitely supported natural multiplicity function underlying an effective divisor. -/
+@[expose]
+def multiplicityFinsupp (D : EffectiveDivisorOfDegree X d) : X →₀ ℕ :=
+  Finsupp.onFinset (D : WeilDivisor X).support
+    (fun x => (coeff (D : WeilDivisor X) x).toNat)
+    (fun x hx => by
+      rw [Finsupp.mem_support_iff]
+      intro hcoeff
+      rw [coeff, hcoeff] at hx
+      exact hx rfl)
+
+@[simp]
+lemma multiplicityFinsupp_apply (D : EffectiveDivisorOfDegree X d) (x : X) :
+    D.multiplicityFinsupp x = (coeff (D : WeilDivisor X) x).toNat :=
+  Finsupp.onFinset_apply
+
+@[simp]
+lemma ofFinsupp_multiplicityFinsupp (D : EffectiveDivisorOfDegree X d) :
+    WeilDivisor.ofFinsupp D.multiplicityFinsupp = (D : WeilDivisor X) := by
+  ext x
+  rw [WeilDivisor.coeff_ofFinsupp, multiplicityFinsupp_apply]
+  exact Int.toNat_of_nonneg ((isEffective_iff (D : WeilDivisor X)).mp D.property.1 x)
+
+lemma sum_multiplicityFinsupp (D : EffectiveDivisorOfDegree X d) :
+    D.multiplicityFinsupp.sum (fun _ n => n) = d := by
+  have hcast :
+      (D.multiplicityFinsupp.sum fun _ n => (n : ℤ)) = degree (D : WeilDivisor X) := by
+    rw [← ofFinsupp_multiplicityFinsupp D, degree_ofFinsupp]
+    simp [Finsupp.sum]
+  exact_mod_cast hcast.trans D.degree_eq
+
+@[simp]
+lemma ofFinsupp_multiplicityFinsupp_eq (D : EffectiveDivisorOfDegree X d) :
+    ofFinsupp D.multiplicityFinsupp D.sum_multiplicityFinsupp = D := by
+  exact Subtype.ext (ofFinsupp_multiplicityFinsupp D)
+
+@[simp]
+lemma multiplicityFinsupp_ofFinsupp (m : X →₀ ℕ) (hm : m.sum (fun _ n => n) = d) :
+    (ofFinsupp m hm).multiplicityFinsupp = m := by
+  ext x
+  simp
+
+section Sym
+
+variable [DecidableEq X]
+
+/-- The effective divisor associated to an unordered degree-`d` collection of points. -/
+@[expose]
+def ofSym (s : Sym X d) : EffectiveDivisorOfDegree X d :=
+  ofFinsupp (Multiset.toFinsupp (s : Multiset X)) (by
+    change (Multiset.toFinsupp (s : Multiset X)).sum (fun _ => id) = d
+    rw [Multiset.toFinsupp_sum_eq, Sym.card_coe])
+
+@[simp]
+lemma coe_ofSym (s : Sym X d) :
+    (ofSym s : WeilDivisor X) = WeilDivisor.ofFinsupp (Multiset.toFinsupp (s : Multiset X)) :=
+  rfl
+
+@[simp]
+lemma coeff_ofSym (s : Sym X d) (x : X) :
+    coeff (ofSym s : WeilDivisor X) x = (s : Multiset X).count x := by
+  rw [coe_ofSym, WeilDivisor.coeff_ofFinsupp, Multiset.toFinsupp_apply]
+
+/-- Effective degree-`d` divisors are the same data as the `d`-th symmetric power of the
+underlying point type. -/
+@[expose]
+def equivSym : EffectiveDivisorOfDegree X d ≃ Sym X d where
+  toFun D :=
+    Sym.mk (Finsupp.toMultiset D.multiplicityFinsupp) (by
+      rw [Finsupp.card_toMultiset]
+      change D.multiplicityFinsupp.sum (fun _ n => n) = d
+      exact D.sum_multiplicityFinsupp)
+  invFun := ofSym
+  left_inv D := by
+    apply Subtype.ext
+    rw [coe_ofSym]
+    change WeilDivisor.ofFinsupp
+        (Multiset.toFinsupp (Finsupp.toMultiset D.multiplicityFinsupp)) = (D : WeilDivisor X)
+    rw [Finsupp.toMultiset_toFinsupp, ofFinsupp_multiplicityFinsupp]
+  right_inv s := by
+    apply Sym.ext
+    change Finsupp.toMultiset (ofSym s).multiplicityFinsupp = (s : Multiset X)
+    rw [show (ofSym s).multiplicityFinsupp = Multiset.toFinsupp (s : Multiset X) by
+      exact multiplicityFinsupp_ofFinsupp _ _]
+    exact Multiset.toFinsupp_toMultiset (s : Multiset X)
+
+end Sym
+
+/-- Pushing forward a fixed-degree effective divisor preserves its degree. -/
+@[expose]
+def pushforward (f : X → Y) (D : EffectiveDivisorOfDegree X d) :
+    EffectiveDivisorOfDegree Y d :=
+  ⟨WeilDivisor.pushforward f D, D.isEffective.pushforward f, by
+    rw [degree_pushforward, D.degree_eq]⟩
+
+@[simp]
+lemma coe_pushforward (f : X → Y) (D : EffectiveDivisorOfDegree X d) :
+    (D.pushforward f : WeilDivisor Y) = WeilDivisor.pushforward f D :=
+  rfl
+
+@[simp]
+lemma pushforward_id (D : EffectiveDivisorOfDegree X d) :
+    D.pushforward (fun x : X => x) = D := by
+  ext
+  rw [coe_pushforward, WeilDivisor.pushforward_id]
+  rfl
+
+/-- The zero divisor is the unique effective divisor of degree zero. -/
+def zeroEquivPUnit : EffectiveDivisorOfDegree X 0 ≃ PUnit where
+  toFun _ := PUnit.unit
+  invFun _ := ⟨0, isEffective_zero, degree_zero⟩
+  left_inv D := by
+    have hzero : (D : WeilDivisor X) = 0 :=
+      D.isEffective.eq_zero_of_degree_eq_zero D.degree_eq
+    exact Subtype.ext hzero.symm
+  right_inv _ := rfl
+
+end EffectiveDivisorOfDegree
+
+end
+
+end WeilDivisor
+
+end AlgebraicGeometry
+
+end TauCeti

--- a/TauCeti/AlgebraicGeometry/WeilDivisor/FixedDegree.lean
+++ b/TauCeti/AlgebraicGeometry/WeilDivisor/FixedDegree.lean
@@ -57,7 +57,6 @@ lemma isEffective (D : EffectiveDivisorOfDegree X d) : IsEffective (D : WeilDivi
 lemma degree_eq (D : EffectiveDivisorOfDegree X d) : degree (D : WeilDivisor X) = d :=
   D.property.2
 
-@[simp]
 lemma mem_effectiveSubmonoid (D : EffectiveDivisorOfDegree X d) :
     (D : WeilDivisor X) ∈ effectiveSubmonoid X :=
   (WeilDivisor.mem_effectiveSubmonoid _).mpr D.isEffective
@@ -76,7 +75,6 @@ lemma coe_ofFinsupp (m : X →₀ ℕ) (hm : m.sum (fun _ n => n) = d) :
     (ofFinsupp m hm : WeilDivisor X) = WeilDivisor.ofFinsupp m :=
   rfl
 
-@[simp]
 lemma coeff_ofFinsupp (m : X →₀ ℕ) (hm : m.sum (fun _ n => n) = d) (x : X) :
     coeff (ofFinsupp m hm : WeilDivisor X) x = m x :=
   WeilDivisor.coeff_ofFinsupp m x
@@ -139,7 +137,6 @@ lemma coe_ofSym (s : Sym X d) :
     (ofSym s : WeilDivisor X) = WeilDivisor.ofFinsupp (Multiset.toFinsupp (s : Multiset X)) :=
   rfl
 
-@[simp]
 lemma coeff_ofSym (s : Sym X d) (x : X) :
     coeff (ofSym s : WeilDivisor X) x = (s : Multiset X).count x := by
   rw [coe_ofSym, WeilDivisor.coeff_ofFinsupp, Multiset.toFinsupp_apply]

--- a/TauCeti/AlgebraicGeometry/WeilDivisor/FixedDegree.lean
+++ b/TauCeti/AlgebraicGeometry/WeilDivisor/FixedDegree.lean
@@ -203,15 +203,17 @@ lemma equivSym_symm_apply (s : Sym X d) :
 /-- Converting a divisor to the symmetric power and back gives the original divisor. -/
 @[simp]
 lemma ofSym_equivSym (D : EffectiveDivisorOfDegree X d) :
-    ofSym (equivSym D) = D :=
-  equivSym.left_inv D
+    ofSym (letI := Classical.decEq X; (Sym.equivNatSum X d).symm (equivFinsupp D)) = D := by
+  classical
+  simpa [equivSym_apply] using (equivSym.left_inv D)
 
 /-- Converting a symmetric-power point to a divisor and back gives the original symmetric-power
 point. -/
 @[simp]
 lemma equivSym_ofSym (s : Sym X d) :
-    equivSym (ofSym s) = s :=
-  equivSym.right_inv s
+    (letI := Classical.decEq X; (Sym.equivNatSum X d).symm (equivFinsupp (ofSym s))) = s := by
+  classical
+  simpa [equivSym_apply] using (equivSym.right_inv s)
 
 end Sym
 
@@ -267,7 +269,8 @@ lemma multiplicityFinsupp_pushforward (f : X → Y) (D : EffectiveDivisorOfDegre
 /-- The symmetric-power equivalence sends divisor pushforward to `Sym.map`. -/
 @[simp]
 lemma equivSym_pushforward (f : X → Y) (D : EffectiveDivisorOfDegree X d) :
-    equivSym (D.pushforward f) = Sym.map f (equivSym D) := by
+    (letI := Classical.decEq Y; (Sym.equivNatSum Y d).symm (equivFinsupp (D.pushforward f))) =
+      Sym.map f (equivSym D) := by
   classical
   apply (Sym.equivNatSum Y d).injective
   ext y

--- a/TauCeti/AlgebraicGeometry/WeilDivisor/FixedDegree.lean
+++ b/TauCeti/AlgebraicGeometry/WeilDivisor/FixedDegree.lean
@@ -185,11 +185,15 @@ lemma equivSym_symm_apply (s : Sym X d) :
   rfl
 
 @[simp]
-lemma ofSym_equivSym (D : EffectiveDivisorOfDegree X d) : ofSym (equivSym D) = D := by
+lemma ofSym_equivSym (D : EffectiveDivisorOfDegree X d) :
+    ofSym (letI := Classical.decEq X; (Sym.equivNatSum X d).symm (equivFinsupp D)) = D := by
+  rw [← equivSym_apply D]
   exact equivSym.left_inv D
 
 @[simp]
-lemma equivSym_ofSym (s : Sym X d) : equivSym (ofSym s) = s := by
+lemma equivSym_ofSym (s : Sym X d) :
+    (letI := Classical.decEq X; (Sym.equivNatSum X d).symm (equivFinsupp (ofSym s))) = s := by
+  rw [← equivSym_apply (ofSym s)]
   exact equivSym.right_inv s
 
 end Sym
@@ -241,7 +245,8 @@ lemma multiplicityFinsupp_pushforward (f : X → Y) (D : EffectiveDivisorOfDegre
 
 @[simp]
 lemma equivSym_pushforward (f : X → Y) (D : EffectiveDivisorOfDegree X d) :
-    equivSym (D.pushforward f) = Sym.map f (equivSym D) := by
+    (letI := Classical.decEq Y; (Sym.equivNatSum Y d).symm (equivFinsupp (D.pushforward f))) =
+      Sym.map f (equivSym D) := by
   classical
   apply (Sym.equivNatSum Y d).injective
   ext y

--- a/TauCeti/AlgebraicGeometry/WeilDivisor/FixedDegree.lean
+++ b/TauCeti/AlgebraicGeometry/WeilDivisor/FixedDegree.lean
@@ -5,7 +5,6 @@ Released under Apache 2.0 license as described in the file LICENSE.
 module
 
 public import Mathlib.Data.Finsupp.Multiset
-public import Mathlib.Data.Sym.Basic
 public import TauCeti.AlgebraicGeometry.WeilDivisor.FiniteSum
 
 /-!
@@ -85,10 +84,15 @@ def multiplicityFinsupp (D : EffectiveDivisorOfDegree X d) : X →₀ ℕ :=
   Finsupp.ofSupportFinite (fun x => (coeff (D : WeilDivisor X) x).toNat) <|
     (D : WeilDivisor X).support.finite_toSet.subset <| by
       intro x hx
+      -- `support.finite_toSet` exposes membership in the set coercion of the finset support;
+      -- switch to finset membership before using the coefficient support lemma.
       change x ∈ (D : WeilDivisor X).support
-      rw [Finsupp.mem_support_iff]
+      rw [WeilDivisor.mem_support_iff]
       intro hcoeff
-      exact hx (by change ((D : WeilDivisor X) x).toNat = 0; rw [hcoeff]; exact Int.toNat_zero)
+      exact hx (by
+        change (coeff (D : WeilDivisor X) x).toNat = 0
+        rw [hcoeff]
+        exact Int.toNat_zero)
 
 @[simp]
 lemma multiplicityFinsupp_apply (D : EffectiveDivisorOfDegree X d) (x : X) :
@@ -96,6 +100,8 @@ lemma multiplicityFinsupp_apply (D : EffectiveDivisorOfDegree X d) (x : X) :
   by
     rw [multiplicityFinsupp, Finsupp.ofSupportFinite_coe]
 
+/-- Rebuilding an effective divisor from its natural multiplicity function recovers the
+underlying Weil divisor. -/
 @[simp]
 lemma ofFinsupp_multiplicityFinsupp (D : EffectiveDivisorOfDegree X d) :
     WeilDivisor.ofFinsupp D.multiplicityFinsupp = (D : WeilDivisor X) := by
@@ -103,6 +109,7 @@ lemma ofFinsupp_multiplicityFinsupp (D : EffectiveDivisorOfDegree X d) :
   rw [WeilDivisor.coeff_ofFinsupp, multiplicityFinsupp_apply]
   exact Int.toNat_of_nonneg ((isEffective_iff (D : WeilDivisor X)).mp D.property.1 x)
 
+/-- The natural multiplicity function of a degree-`d` effective divisor has total mass `d`. -/
 lemma sum_multiplicityFinsupp (D : EffectiveDivisorOfDegree X d) :
     D.multiplicityFinsupp.sum (fun _ n => n) = d := by
   have hcast :
@@ -111,11 +118,15 @@ lemma sum_multiplicityFinsupp (D : EffectiveDivisorOfDegree X d) :
     simp [Finsupp.sum]
   exact_mod_cast hcast.trans D.degree_eq
 
+/-- Rebuilding an effective divisor from its natural multiplicity function recovers the
+original fixed-degree divisor. -/
 @[simp]
 lemma ofFinsupp_multiplicityFinsupp_eq (D : EffectiveDivisorOfDegree X d) :
     ofFinsupp D.multiplicityFinsupp D.sum_multiplicityFinsupp = D := by
   exact Subtype.ext (ofFinsupp_multiplicityFinsupp D)
 
+/-- The natural multiplicity function of a divisor built from a finitely supported function is
+that function. -/
 @[simp]
 lemma multiplicityFinsupp_ofFinsupp (m : X →₀ ℕ) (hm : m.sum (fun _ n => n) = d) :
     (ofFinsupp m hm).multiplicityFinsupp = m := by
@@ -158,6 +169,8 @@ lemma coe_ofSym (s : Sym X d) :
   classical
   rfl
 
+/-- The symmetric-power divisor has coefficient equal to the multiplicity of the point in the
+unordered collection. -/
 lemma coeff_ofSym (s : Sym X d) (x : X) :
     coeff (ofSym s : WeilDivisor X) x =
       (letI := Classical.decEq X; (s : Multiset X).count x) := by
@@ -171,6 +184,8 @@ def equivSym : EffectiveDivisorOfDegree X d ≃ Sym X d := by
   letI := Classical.decEq X
   exact equivFinsupp.trans (Sym.equivNatSum X d).symm
 
+/-- Applying the symmetric-power equivalence is the same as applying Mathlib's multiplicity
+equivalence to the fixed-degree divisor's multiplicity function. -/
 @[simp]
 lemma equivSym_apply (D : EffectiveDivisorOfDegree X d) :
     equivSym D =
@@ -178,23 +193,25 @@ lemma equivSym_apply (D : EffectiveDivisorOfDegree X d) :
   classical
   rfl
 
+/-- The inverse of the symmetric-power equivalence is `ofSym`. -/
 @[simp]
 lemma equivSym_symm_apply (s : Sym X d) :
     (equivSym.symm s : EffectiveDivisorOfDegree X d) = ofSym s := by
   classical
   rfl
 
+/-- Converting a divisor to the symmetric power and back gives the original divisor. -/
 @[simp]
 lemma ofSym_equivSym (D : EffectiveDivisorOfDegree X d) :
-    ofSym (letI := Classical.decEq X; (Sym.equivNatSum X d).symm (equivFinsupp D)) = D := by
-  rw [← equivSym_apply D]
-  exact equivSym.left_inv D
+    ofSym (equivSym D) = D :=
+  equivSym.left_inv D
 
+/-- Converting a symmetric-power point to a divisor and back gives the original symmetric-power
+point. -/
 @[simp]
 lemma equivSym_ofSym (s : Sym X d) :
-    (letI := Classical.decEq X; (Sym.equivNatSum X d).symm (equivFinsupp (ofSym s))) = s := by
-  rw [← equivSym_apply (ofSym s)]
-  exact equivSym.right_inv s
+    equivSym (ofSym s) = s :=
+  equivSym.right_inv s
 
 end Sym
 
@@ -210,6 +227,7 @@ lemma coe_pushforward (f : X → Y) (D : EffectiveDivisorOfDegree X d) :
     (D.pushforward f : WeilDivisor Y) = WeilDivisor.pushforward f D :=
   rfl
 
+/-- Pushing forward along the identity function is the identity on fixed-degree divisors. -/
 @[simp]
 lemma pushforward_id (D : EffectiveDivisorOfDegree X d) :
     D.pushforward (fun x : X => x) = D := by
@@ -217,6 +235,7 @@ lemma pushforward_id (D : EffectiveDivisorOfDegree X d) :
   rw [coe_pushforward, WeilDivisor.pushforward_id]
   rfl
 
+/-- Pushforwards of fixed-degree divisors compose functorially. -/
 @[simp]
 lemma pushforward_comp {Z : Type*} (g : Y → Z) (f : X → Y) (D : EffectiveDivisorOfDegree X d) :
     (D.pushforward f).pushforward g = D.pushforward (g ∘ f) := by
@@ -224,6 +243,7 @@ lemma pushforward_comp {Z : Type*} (g : Y → Z) (f : X → Y) (D : EffectiveDiv
   rw [coe_pushforward, coe_pushforward, coe_pushforward, WeilDivisor.pushforward_comp]
   rfl
 
+/-- Pushing forward a divisor built from multiplicities corresponds to `Finsupp.mapDomain`. -/
 @[simp]
 lemma pushforward_ofFinsupp (f : X → Y) (m : X →₀ ℕ) (hm : m.sum (fun _ n => n) = d) :
     (ofFinsupp m hm).pushforward f = ofFinsupp (m.mapDomain f) (by
@@ -236,6 +256,7 @@ lemma pushforward_ofFinsupp (f : X → Y) (m : X →₀ ℕ) (hm : m.sum (fun _ 
     WeilDivisor.coeff_ofFinsupp]
   simp [Finsupp.mapDomain, Finsupp.sum, Finsupp.single_apply, Finset.sum_ite]
 
+/-- The multiplicity function of a pushforward is the pushed-forward multiplicity function. -/
 @[simp]
 lemma multiplicityFinsupp_pushforward (f : X → Y) (D : EffectiveDivisorOfDegree X d) :
     (D.pushforward f).multiplicityFinsupp = D.multiplicityFinsupp.mapDomain f := by
@@ -243,24 +264,18 @@ lemma multiplicityFinsupp_pushforward (f : X → Y) (D : EffectiveDivisorOfDegre
   rw [ofFinsupp_multiplicityFinsupp_eq D] at h
   rw [h, multiplicityFinsupp_ofFinsupp]
 
+/-- The symmetric-power equivalence sends divisor pushforward to `Sym.map`. -/
 @[simp]
 lemma equivSym_pushforward (f : X → Y) (D : EffectiveDivisorOfDegree X d) :
-    (letI := Classical.decEq Y; (Sym.equivNatSum Y d).symm (equivFinsupp (D.pushforward f))) =
-      Sym.map f (equivSym D) := by
+    equivSym (D.pushforward f) = Sym.map f (equivSym D) := by
   classical
   apply (Sym.equivNatSum Y d).injective
   ext y
   simp [Finsupp.toMultiset_map]
 
 /-- The zero divisor is the unique effective divisor of degree zero. -/
-def zeroEquivPUnit : EffectiveDivisorOfDegree X 0 ≃ PUnit where
-  toFun _ := PUnit.unit
-  invFun _ := ⟨0, isEffective_zero, degree_zero⟩
-  left_inv D := by
-    have hzero : (D : WeilDivisor X) = 0 :=
-      D.isEffective.eq_zero_of_degree_eq_zero D.degree_eq
-    exact Subtype.ext hzero.symm
-  right_inv _ := rfl
+def zeroEquivPUnit : EffectiveDivisorOfDegree X 0 ≃ PUnit :=
+  (equivSym (X := X) (d := 0)).trans (Equiv.equivPUnit (Sym X 0))
 
 end EffectiveDivisorOfDegree
 


### PR DESCRIPTION
This PR adds the fixed-degree effective-divisor model for the Jacobian roadmap: `EffectiveDivisorOfDegree X d` packages effective formal Weil divisors whose unweighted degree is `d`, and `EffectiveDivisorOfDegree.equivSym` identifies them with Mathlib's symmetric power `Sym X d` by passing through multiset multiplicities. This supplies the formal divisor bridge needed before the scheme-level construction of symmetric powers and relative effective Cartier divisors.

It advances `TauCetiRoadmap/JacobianChallenge/README.md`, Layer C, the item "Relative effective Cartier divisors and symmetric powers `Symᵈ X`", as a clean prerequisite built on the existing Layer A formal Weil-divisor API. The scheme-level `Symᵈ X` remains later geometry; this PR only records the honest combinatorial divisor data consumed by Abel-map statements from unordered degree-`d` collections of points.

No Mathlib infrastructure is vendored. The implementation reuses Tau Ceti's `WeilDivisor.ofFinsupp`, `degree`, `IsEffective`, and `pushforward` API, and Mathlib's `Sym`, `Multiset.toFinsupp`, `Finsupp.toMultiset`, and their inverse/cardinality lemmas.

`lake exe cache get` completed with `No files to download` and `Already decompressed 8609 file(s)`. `lake build` completed with `Build completed successfully (4498 jobs).` `lake exe axioms` completed with `axioms: audited 7613 TauCeti declaration(s); all within the allowlist [propext, Classical.choice, Quot.sound].`

<!--tauceti-target:v1 {"focus":"JacobianChallenge","id":"effective-divisors-fixed-degree"}-->

🤖 Prepared with Codex
