### PR TITLE
feat: add two-step grid backtracking

### DIFF
--- a/TauCeti/KnotTheory/Grid/Diagram.lean
+++ b/TauCeti/KnotTheory/Grid/Diagram.lean
@@ -13,7 +13,9 @@ public import Mathlib.Data.Fintype.Perm
 public import Mathlib.Data.Fintype.Prod
 public import Mathlib.Data.Nat.Choose.Basic
 public import Mathlib.GroupTheory.Perm.Basic
-public import Mathlib.Data.Sym.Card
+public import Mathlib.Data.Sym.Sym2
+
+import Mathlib.Data.Sym.Card
 
 /-!
 # Grid diagrams and grid states
@@ -303,6 +305,13 @@ theorem swapColumns_apply (a b : Fin n) (x : GridState n) (c : Fin n) :
     x.swapColumns a b c = x (Equiv.swap a b c) := by
   simp [swapColumns, relabelColumns]
 
+/-- Swapping the same pair of columns twice is the identity on grid states. -/
+@[simp]
+theorem swapColumns_swapColumns (a b : Fin n) (x : GridState n) :
+    (x.swapColumns a b).swapColumns a b = x := by
+  ext c
+  simp [swapColumns]
+
 /-- The grid states obtained from `x` by transposing a pair of distinct columns.
 
 These are exactly the states a single grid rectangle can reach from `x`: the fully blocked
@@ -335,15 +344,13 @@ theorem mem_columnSwapNeighbors_comm {x y : GridState n} :
     rintro ⟨a, b, hab, rfl⟩
     rw [mem_columnSwapNeighbors]
     refine ⟨a, b, hab, ?_⟩
-    ext c
-    simp [swapColumns]
+    exact (GridState.swapColumns_swapColumns a b x).symm
   · rw [mem_columnSwapNeighbors]
     rintro ⟨a, b, hab, hxy⟩
     rw [mem_columnSwapNeighbors]
     refine ⟨a, b, hab, ?_⟩
     rw [hxy]
-    ext c
-    simp [swapColumns]
+    exact (GridState.swapColumns_swapColumns a b y).symm
 
 /-- The finite set of column-swap neighbours is the image of the off-diagonal of the
 column set: an ordered pair of distinct columns gives the state obtained by swapping
@@ -507,13 +514,6 @@ theorem swapRows_swapRows (a b : Fin n) (x : GridState n) :
     (x.swapRows a b).swapRows a b = x := by
   ext c
   simp [swapRows]
-
-/-- Swapping the same pair of columns twice is the identity on grid states. -/
-@[simp]
-theorem swapColumns_swapColumns (a b : Fin n) (x : GridState n) :
-    (x.swapColumns a b).swapColumns a b = x := by
-  ext c
-  simp [swapColumns]
 
 /-- A square is shared by a grid state and the state with columns `a` and `b` swapped exactly
 when it is a source-state square away from the two swapped columns. -/

--- a/TauCeti/KnotTheory/Grid/Diagram.lean
+++ b/TauCeti/KnotTheory/Grid/Diagram.lean
@@ -13,7 +13,7 @@ public import Mathlib.Data.Fintype.Perm
 public import Mathlib.Data.Fintype.Prod
 public import Mathlib.Data.Nat.Choose.Basic
 public import Mathlib.GroupTheory.Perm.Basic
-import Mathlib.Data.Sym.Card
+public import Mathlib.Data.Sym.Card
 
 /-!
 # Grid diagrams and grid states
@@ -324,6 +324,27 @@ theorem mem_columnSwapNeighbors {x y : GridState n} :
   · rintro ⟨c, d, hcd, rfl⟩
     exact ⟨c, d, hcd, rfl⟩
 
+/-- If `y` is a column-swap neighbour of `x`, then `x` is a column-swap neighbour of `y`.
+
+This is the elementary reversibility of a rectangle target: the same pair of side columns swaps
+back to the source state. -/
+theorem mem_columnSwapNeighbors_comm {x y : GridState n} :
+    y ∈ x.columnSwapNeighbors ↔ x ∈ y.columnSwapNeighbors := by
+  constructor
+  · rw [mem_columnSwapNeighbors]
+    rintro ⟨a, b, hab, rfl⟩
+    rw [mem_columnSwapNeighbors]
+    refine ⟨a, b, hab, ?_⟩
+    ext c
+    simp [swapColumns]
+  · rw [mem_columnSwapNeighbors]
+    rintro ⟨a, b, hab, hxy⟩
+    rw [mem_columnSwapNeighbors]
+    refine ⟨a, b, hab, ?_⟩
+    rw [hxy]
+    ext c
+    simp [swapColumns]
+
 /-- The finite set of column-swap neighbours is the image of the off-diagonal of the
 column set: an ordered pair of distinct columns gives the state obtained by swapping
 those columns. -/
@@ -335,7 +356,7 @@ theorem columnSwapNeighbors_eq_offDiag_image (x : GridState n) :
 
 /-- If two nontrivial column swaps of the same grid state agree, then they swap the same
 unordered pair of columns. -/
-private theorem sym2_mk_eq_of_swapColumns_eq {x : GridState n} {a b c d : Fin n} (hab : a ≠ b)
+theorem sym2_mk_eq_of_swapColumns_eq {x : GridState n} {a b c d : Fin n} (hab : a ≠ b)
     (hcd : c ≠ d) (h : x.swapColumns a b = x.swapColumns c d) : s(a, b) = s(c, d) := by
   have hswap : Equiv.swap a b = Equiv.swap c d := by
     ext k

--- a/TauCeti/KnotTheory/Grid/Diagram.lean
+++ b/TauCeti/KnotTheory/Grid/Diagram.lean
@@ -305,6 +305,12 @@ theorem swapColumns_apply (a b : Fin n) (x : GridState n) (c : Fin n) :
     x.swapColumns a b c = x (Equiv.swap a b c) := by
   simp [swapColumns, relabelColumns]
 
+/-- Swapping columns is symmetric in the two chosen columns. -/
+theorem swapColumns_comm (a b : Fin n) (x : GridState n) :
+    x.swapColumns a b = x.swapColumns b a := by
+  ext c
+  simp [swapColumns_apply, Equiv.swap_comm]
+
 /-- Swapping the same pair of columns twice is the identity on grid states. -/
 @[simp]
 theorem swapColumns_swapColumns (a b : Fin n) (x : GridState n) :

--- a/TauCeti/KnotTheory/Grid/DifferentialSquareBacktracking.lean
+++ b/TauCeti/KnotTheory/Grid/DifferentialSquareBacktracking.lean
@@ -79,10 +79,7 @@ theorem swapColumns_swapColumns_eq_self_iff_sym2_mk_eq (x : GridState n) {a b c 
     · cases hpair
       exact GridState.swapColumns_swapColumns a b x
     · cases hpair
-      rw [show x.swapColumns d c = x.swapColumns c d by
-        ext k
-        simp [swapColumns_apply, Equiv.swap_comm]]
-      exact GridState.swapColumns_swapColumns c d x
+      simp [GridState.swapColumns_comm]
 
 /-- The source state appears in its own two-step neighbour set exactly when there is a distinct
 pair of grid columns. -/

--- a/TauCeti/KnotTheory/Grid/DifferentialSquareBacktracking.lean
+++ b/TauCeti/KnotTheory/Grid/DifferentialSquareBacktracking.lean
@@ -114,7 +114,6 @@ theorem self_mem_twoStepColumnSwapNeighbors_of_two_le (x : GridState n) (hn : 2 
   exact Nat.zero_ne_one (congrArg Fin.val h)
 
 /-- The source state is a two-step neighbour of itself exactly in grid size at least two. -/
-@[simp]
 theorem self_mem_twoStepColumnSwapNeighbors_iff_two_le (x : GridState n) :
     x ∈ x.twoStepColumnSwapNeighbors ↔ 2 ≤ n := by
   rw [self_mem_twoStepColumnSwapNeighbors_iff_exists_pair_ne]
@@ -128,6 +127,16 @@ theorem self_mem_twoStepColumnSwapNeighbors_iff_two_le (x : GridState n) :
       ⟨1, Nat.lt_of_lt_of_le (by decide) hn⟩, ?_⟩
     intro h
     exact Nat.zero_ne_one (congrArg Fin.val h)
+
+/-- Simp-normal-form version of `self_mem_twoStepColumnSwapNeighbors_iff_two_le`. -/
+@[simp]
+theorem exists_twoStepColumnSwap_backtracking_iff_two_le (x : GridState n) :
+    (∃ y : GridState n,
+        (∃ c d : Fin n, ¬c = d ∧ y = x.swapColumns c d) ∧
+          ∃ c d : Fin n, ¬c = d ∧ x = y.swapColumns c d) ↔
+      2 ≤ n := by
+  simpa only [mem_twoStepColumnSwapNeighbors, mem_columnSwapNeighbors, ne_eq] using
+    x.self_mem_twoStepColumnSwapNeighbors_iff_two_le
 
 end GridState
 

--- a/TauCeti/KnotTheory/Grid/DifferentialSquareBacktracking.lean
+++ b/TauCeti/KnotTheory/Grid/DifferentialSquareBacktracking.lean
@@ -16,19 +16,21 @@ swaps the same pair of columns twice returns to the starting state, so the sourc
 its own two-step neighbour set exactly when the grid has at least two columns.
 
 This is small but useful bookkeeping for the later `∂² = 0` rectangle-pairing argument: diagonal
-coefficients of `∂²` are precisely the backtracking part of the two-step search space, while grids
-of size `0` and `1` have no such two-step targets at all.
+targets lie in the two-step search space exactly through such backtracking when `2 ≤ n`. Grids of
+size `0` and `1` have no two-step targets at all, so any coefficient-level vanishing there follows
+from the existing small-grid differential support API rather than from a cancellation argument in
+this file.
 
 ## Main results
 
-* `TauCeti.GridState.mem_twoStepColumnSwapNeighbors_of_backtrack`: swapping a pair of distinct
+* `TauCeti.GridState.self_mem_twoStepColumnSwapNeighbors_of_ne`: swapping a pair of distinct
   columns and then swapping it back puts `x` in its own two-step neighbour set.
-* `TauCeti.GridState.self_mem_twoStepColumnSwapNeighbors_iff_exists_pair`: this is possible
+* `TauCeti.GridState.sym2_mk_eq_of_swapColumns_swapColumns_eq_self`: any diagonal two-step
+  witness swaps the same unordered pair of columns twice.
+* `TauCeti.GridState.self_mem_twoStepColumnSwapNeighbors_iff_exists_pair_ne`: this is possible
   exactly when there is a distinct pair of columns.
 * `TauCeti.GridState.self_mem_twoStepColumnSwapNeighbors_iff_two_le`: equivalently, exactly when
   `2 ≤ n`.
-* `TauCeti.GridDiagram.fullyBlockedDifferential_sq_single_apply_eq_zero_self_of_le_one`: the
-  diagonal coefficient of `∂²` on a generator is zero in grid size at most `1`.
 
 ## References
 
@@ -46,42 +48,52 @@ namespace GridState
 
 variable {n : ℕ}
 
-/-- Swapping a distinct pair of columns gives a column-swap neighbour. -/
-theorem swapColumns_mem_columnSwapNeighbors (x : GridState n) {a b : Fin n} (hab : a ≠ b) :
-    x.swapColumns a b ∈ x.columnSwapNeighbors := by
-  rw [mem_columnSwapNeighbors]
-  exact ⟨a, b, hab, rfl⟩
-
-/-- If `y` is a column-swap neighbour of `x`, then `x` is a column-swap neighbour of `y`.
-
-This is the elementary reversibility of a rectangle target: the same pair of side columns swaps
-back to the source state. -/
-theorem mem_columnSwapNeighbors_comm {x y : GridState n} :
-    y ∈ x.columnSwapNeighbors ↔ x ∈ y.columnSwapNeighbors := by
-  constructor
-  · rw [mem_columnSwapNeighbors]
-    rintro ⟨a, b, hab, rfl⟩
-    rw [mem_columnSwapNeighbors]
-    exact ⟨a, b, hab, by simp⟩
-  · rw [mem_columnSwapNeighbors]
-    rintro ⟨a, b, hab, hxy⟩
-    rw [mem_columnSwapNeighbors]
-    refine ⟨a, b, hab, ?_⟩
-    rw [hxy]
-    simp
-
 /-- Swapping a distinct pair of columns and then swapping the same pair back puts the source state
 in its own two-step column-swap neighbour set. -/
-theorem mem_twoStepColumnSwapNeighbors_of_backtrack (x : GridState n) {a b : Fin n}
+theorem self_mem_twoStepColumnSwapNeighbors_of_ne (x : GridState n) {a b : Fin n}
     (hab : a ≠ b) : x ∈ x.twoStepColumnSwapNeighbors := by
   rw [mem_twoStepColumnSwapNeighbors]
-  refine ⟨x.swapColumns a b, x.swapColumns_mem_columnSwapNeighbors hab, ?_⟩
+  refine ⟨x.swapColumns a b, GridState.mem_columnSwapNeighbors.mpr ⟨a, b, hab, rfl⟩, ?_⟩
   rw [mem_columnSwapNeighbors]
   exact ⟨a, b, hab, by simp⟩
 
+/-- A diagonal two-step column-swap witness must swap the same unordered pair of columns twice. -/
+theorem sym2_mk_eq_of_swapColumns_swapColumns_eq_self (x : GridState n) {a b c d : Fin n}
+    (hab : a ≠ b) (hcd : c ≠ d) (h : (x.swapColumns a b).swapColumns c d = x) :
+    s(a, b) = s(c, d) := by
+  have hcomp : ∀ k : Fin n, Equiv.swap a b (Equiv.swap c d k) = k := by
+    intro k
+    exact x.toPerm.injective
+      (by simpa [swapColumns_apply] using congrArg (fun y : GridState n => y k) h)
+  have hperm : Equiv.swap a b = Equiv.swap c d := by
+    ext k
+    have hk := hcomp (Equiv.swap c d k)
+    simpa using congrArg Fin.val hk
+  have hswap : x.swapColumns a b = x.swapColumns c d := by
+    ext k
+    simp [swapColumns_apply, hperm]
+  exact sym2_mk_eq_of_swapColumns_eq hab hcd hswap
+
+/-- Two nontrivial column swaps form a diagonal two-step witness exactly when they use the same
+unordered pair of columns. -/
+theorem swapColumns_swapColumns_eq_self_iff_sym2_mk_eq (x : GridState n) {a b c d : Fin n}
+    (hab : a ≠ b) (hcd : c ≠ d) :
+    (x.swapColumns a b).swapColumns c d = x ↔ s(a, b) = s(c, d) := by
+  constructor
+  · exact x.sym2_mk_eq_of_swapColumns_swapColumns_eq_self hab hcd
+  · intro hsym
+    rw [Sym2.eq, Sym2.rel_iff'] at hsym
+    rcases hsym with hpair | hpair
+    · cases hpair
+      ext k
+      simp
+    · cases hpair
+      ext k
+      simp [swapColumns_apply, Equiv.swap_comm]
+
 /-- The source state appears in its own two-step neighbour set exactly when there is a distinct
 pair of grid columns. -/
-theorem self_mem_twoStepColumnSwapNeighbors_iff_exists_pair (x : GridState n) :
+theorem self_mem_twoStepColumnSwapNeighbors_iff_exists_pair_ne (x : GridState n) :
     x ∈ x.twoStepColumnSwapNeighbors ↔ ∃ a b : Fin n, a ≠ b := by
   constructor
   · intro hx
@@ -90,21 +102,22 @@ theorem self_mem_twoStepColumnSwapNeighbors_iff_exists_pair (x : GridState n) :
     rw [mem_columnSwapNeighbors] at hy
     exact hy.imp fun a ha => ha.imp fun b hb => hb.1
   · rintro ⟨a, b, hab⟩
-    exact x.mem_twoStepColumnSwapNeighbors_of_backtrack hab
+    exact x.self_mem_twoStepColumnSwapNeighbors_of_ne hab
 
 /-- If the grid has at least two columns, the source state is a two-step neighbour of itself. -/
 theorem self_mem_twoStepColumnSwapNeighbors_of_two_le (x : GridState n) (hn : 2 ≤ n) :
     x ∈ x.twoStepColumnSwapNeighbors := by
-  rw [self_mem_twoStepColumnSwapNeighbors_iff_exists_pair]
+  rw [self_mem_twoStepColumnSwapNeighbors_iff_exists_pair_ne]
   refine ⟨⟨0, Nat.lt_of_lt_of_le (by decide) hn⟩,
     ⟨1, Nat.lt_of_lt_of_le (by decide) hn⟩, ?_⟩
   intro h
   exact Nat.zero_ne_one (congrArg Fin.val h)
 
 /-- The source state is a two-step neighbour of itself exactly in grid size at least two. -/
+@[simp]
 theorem self_mem_twoStepColumnSwapNeighbors_iff_two_le (x : GridState n) :
     x ∈ x.twoStepColumnSwapNeighbors ↔ 2 ≤ n := by
-  rw [self_mem_twoStepColumnSwapNeighbors_iff_exists_pair]
+  rw [self_mem_twoStepColumnSwapNeighbors_iff_exists_pair_ne]
   constructor
   · rintro ⟨a, b, hab⟩
     have hcard : 1 < Fintype.card (Fin n) :=
@@ -116,50 +129,6 @@ theorem self_mem_twoStepColumnSwapNeighbors_iff_two_le (x : GridState n) :
     intro h
     exact Nat.zero_ne_one (congrArg Fin.val h)
 
-/-- In grid size at most `1`, the source state is not a two-step neighbour of itself. -/
-theorem self_notMem_twoStepColumnSwapNeighbors_of_le_one (x : GridState n) (hn : n ≤ 1) :
-    x ∉ x.twoStepColumnSwapNeighbors := by
-  rw [self_mem_twoStepColumnSwapNeighbors_iff_two_le]
-  omega
-
-/-- In grid size `0`, the source state is not a two-step neighbour of itself. -/
-theorem self_notMem_twoStepColumnSwapNeighbors_zero (x : GridState 0) :
-    x ∉ x.twoStepColumnSwapNeighbors :=
-  x.self_notMem_twoStepColumnSwapNeighbors_of_le_one (Nat.zero_le 1)
-
-/-- In grid size `1`, the source state is not a two-step neighbour of itself. -/
-theorem self_notMem_twoStepColumnSwapNeighbors_one (x : GridState 1) :
-    x ∉ x.twoStepColumnSwapNeighbors :=
-  x.self_notMem_twoStepColumnSwapNeighbors_of_le_one le_rfl
-
 end GridState
-
-namespace GridDiagram
-
-variable {n : ℕ} (G : GridDiagram n)
-
-/-- In grid size at most `1`, the diagonal coefficient of `∂²` on a generator is zero.
-
-This is the coefficient-level form of the fact that there are no nontrivial two-step
-backtracking paths when there are not two distinct columns to swap. -/
-theorem fullyBlockedDifferential_sq_single_apply_eq_zero_self_of_le_one
-    (hn : n ≤ 1) (x : GridState n) :
-    G.fullyBlockedDifferential (G.fullyBlockedDifferential (Finsupp.single x 1)) x = 0 :=
-  G.fullyBlockedDifferential_sq_single_apply_eq_zero_of_notMem_twoStep x
-    (x.self_notMem_twoStepColumnSwapNeighbors_of_le_one hn)
-
-/-- In grid size `0`, the diagonal coefficient of `∂²` on a generator is zero. -/
-theorem fullyBlockedDifferential_sq_single_apply_eq_zero_self_zero
-    (G : GridDiagram 0) (x : GridState 0) :
-    G.fullyBlockedDifferential (G.fullyBlockedDifferential (Finsupp.single x 1)) x = 0 :=
-  G.fullyBlockedDifferential_sq_single_apply_eq_zero_self_of_le_one (Nat.zero_le 1) x
-
-/-- In grid size `1`, the diagonal coefficient of `∂²` on a generator is zero. -/
-theorem fullyBlockedDifferential_sq_single_apply_eq_zero_self_one
-    (G : GridDiagram 1) (x : GridState 1) :
-    G.fullyBlockedDifferential (G.fullyBlockedDifferential (Finsupp.single x 1)) x = 0 :=
-  G.fullyBlockedDifferential_sq_single_apply_eq_zero_self_of_le_one le_rfl x
-
-end GridDiagram
 
 end TauCeti

--- a/TauCeti/KnotTheory/Grid/DifferentialSquareBacktracking.lean
+++ b/TauCeti/KnotTheory/Grid/DifferentialSquareBacktracking.lean
@@ -107,17 +107,15 @@ theorem self_mem_twoStepColumnSwapNeighbors_of_two_le (x : GridState n) (hn : 2 
 @[simp 1100]
 theorem self_mem_twoStepColumnSwapNeighbors_iff_two_le (x : GridState n) :
     x ∈ x.twoStepColumnSwapNeighbors ↔ 2 ≤ n := by
-  rw [self_mem_twoStepColumnSwapNeighbors_iff_exists_pair_ne]
   constructor
-  · rintro ⟨a, b, hab⟩
+  · intro hx
+    rw [self_mem_twoStepColumnSwapNeighbors_iff_exists_pair_ne] at hx
+    obtain ⟨a, b, hab⟩ := hx
     have hcard : 1 < Fintype.card (Fin n) :=
       Fintype.one_lt_card_iff.mpr ⟨a, b, hab⟩
     exact Nat.succ_le_of_lt (by simpa [Fintype.card_fin] using hcard)
   · intro hn
-    refine ⟨⟨0, Nat.lt_of_lt_of_le (by decide) hn⟩,
-      ⟨1, Nat.lt_of_lt_of_le (by decide) hn⟩, ?_⟩
-    intro h
-    exact Nat.zero_ne_one (congrArg Fin.val h)
+    exact x.self_mem_twoStepColumnSwapNeighbors_of_two_le hn
 
 end GridState
 

--- a/TauCeti/KnotTheory/Grid/DifferentialSquareBacktracking.lean
+++ b/TauCeti/KnotTheory/Grid/DifferentialSquareBacktracking.lean
@@ -114,7 +114,6 @@ theorem self_mem_twoStepColumnSwapNeighbors_of_two_le (x : GridState n) (hn : 2 
   exact Nat.zero_ne_one (congrArg Fin.val h)
 
 /-- The source state is a two-step neighbour of itself exactly in grid size at least two. -/
-@[simp]
 theorem self_mem_twoStepColumnSwapNeighbors_iff_two_le (x : GridState n) :
     x ∈ x.twoStepColumnSwapNeighbors ↔ 2 ≤ n := by
   rw [self_mem_twoStepColumnSwapNeighbors_iff_exists_pair_ne]

--- a/TauCeti/KnotTheory/Grid/DifferentialSquareBacktracking.lean
+++ b/TauCeti/KnotTheory/Grid/DifferentialSquareBacktracking.lean
@@ -114,6 +114,7 @@ theorem self_mem_twoStepColumnSwapNeighbors_of_two_le (x : GridState n) (hn : 2 
   exact Nat.zero_ne_one (congrArg Fin.val h)
 
 /-- The source state is a two-step neighbour of itself exactly in grid size at least two. -/
+@[simp]
 theorem self_mem_twoStepColumnSwapNeighbors_iff_two_le (x : GridState n) :
     x ∈ x.twoStepColumnSwapNeighbors ↔ 2 ≤ n := by
   rw [self_mem_twoStepColumnSwapNeighbors_iff_exists_pair_ne]

--- a/TauCeti/KnotTheory/Grid/DifferentialSquareBacktracking.lean
+++ b/TauCeti/KnotTheory/Grid/DifferentialSquareBacktracking.lean
@@ -5,6 +5,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 module
 
 public import TauCeti.KnotTheory.Grid.DifferentialSquareSupport
+public import Mathlib.Data.Sym.Sym2
 
 /-!
 # Backtracking in the two-step grid differential support
@@ -61,17 +62,8 @@ theorem self_mem_twoStepColumnSwapNeighbors_of_ne (x : GridState n) {a b : Fin n
 theorem sym2_mk_eq_of_swapColumns_swapColumns_eq_self (x : GridState n) {a b c d : Fin n}
     (hab : a ≠ b) (hcd : c ≠ d) (h : (x.swapColumns a b).swapColumns c d = x) :
     s(a, b) = s(c, d) := by
-  have hcomp : ∀ k : Fin n, Equiv.swap a b (Equiv.swap c d k) = k := by
-    intro k
-    exact x.toPerm.injective
-      (by simpa [swapColumns_apply] using congrArg (fun y : GridState n => y k) h)
-  have hperm : Equiv.swap a b = Equiv.swap c d := by
-    ext k
-    have hk := hcomp (Equiv.swap c d k)
-    simpa using congrArg Fin.val hk
   have hswap : x.swapColumns a b = x.swapColumns c d := by
-    ext k
-    simp [swapColumns_apply, hperm]
+    simpa using congrArg (fun y : GridState n => y.swapColumns c d) h
   exact sym2_mk_eq_of_swapColumns_eq hab hcd hswap
 
 /-- Two nontrivial column swaps form a diagonal two-step witness exactly when they use the same
@@ -85,11 +77,12 @@ theorem swapColumns_swapColumns_eq_self_iff_sym2_mk_eq (x : GridState n) {a b c 
     rw [Sym2.eq, Sym2.rel_iff'] at hsym
     rcases hsym with hpair | hpair
     · cases hpair
-      ext k
-      simp
+      exact GridState.swapColumns_swapColumns a b x
     · cases hpair
-      ext k
-      simp [swapColumns_apply, Equiv.swap_comm]
+      rw [show x.swapColumns d c = x.swapColumns c d by
+        ext k
+        simp [swapColumns_apply, Equiv.swap_comm]]
+      exact GridState.swapColumns_swapColumns c d x
 
 /-- The source state appears in its own two-step neighbour set exactly when there is a distinct
 pair of grid columns. -/
@@ -128,15 +121,6 @@ theorem self_mem_twoStepColumnSwapNeighbors_iff_two_le (x : GridState n) :
       ⟨1, Nat.lt_of_lt_of_le (by decide) hn⟩, ?_⟩
     intro h
     exact Nat.zero_ne_one (congrArg Fin.val h)
-
-/-- Expanded existential form of `self_mem_twoStepColumnSwapNeighbors_iff_two_le`. -/
-theorem exists_twoStepColumnSwap_backtracking_iff_two_le (x : GridState n) :
-    (∃ y : GridState n,
-        (∃ c d : Fin n, ¬c = d ∧ y = x.swapColumns c d) ∧
-          ∃ c d : Fin n, ¬c = d ∧ x = y.swapColumns c d) ↔
-      2 ≤ n := by
-  simpa only [mem_twoStepColumnSwapNeighbors, mem_columnSwapNeighbors, ne_eq] using
-    x.self_mem_twoStepColumnSwapNeighbors_iff_two_le
 
 end GridState
 

--- a/TauCeti/KnotTheory/Grid/DifferentialSquareBacktracking.lean
+++ b/TauCeti/KnotTheory/Grid/DifferentialSquareBacktracking.lean
@@ -114,6 +114,7 @@ theorem self_mem_twoStepColumnSwapNeighbors_of_two_le (x : GridState n) (hn : 2 
   exact Nat.zero_ne_one (congrArg Fin.val h)
 
 /-- The source state is a two-step neighbour of itself exactly in grid size at least two. -/
+@[simp 1100]
 theorem self_mem_twoStepColumnSwapNeighbors_iff_two_le (x : GridState n) :
     x ∈ x.twoStepColumnSwapNeighbors ↔ 2 ≤ n := by
   rw [self_mem_twoStepColumnSwapNeighbors_iff_exists_pair_ne]
@@ -128,8 +129,7 @@ theorem self_mem_twoStepColumnSwapNeighbors_iff_two_le (x : GridState n) :
     intro h
     exact Nat.zero_ne_one (congrArg Fin.val h)
 
-/-- Simp-normal-form version of `self_mem_twoStepColumnSwapNeighbors_iff_two_le`. -/
-@[simp]
+/-- Expanded existential form of `self_mem_twoStepColumnSwapNeighbors_iff_two_le`. -/
 theorem exists_twoStepColumnSwap_backtracking_iff_two_le (x : GridState n) :
     (∃ y : GridState n,
         (∃ c d : Fin n, ¬c = d ∧ y = x.swapColumns c d) ∧

--- a/TauCeti/KnotTheory/Grid/DifferentialSquareBacktracking.lean
+++ b/TauCeti/KnotTheory/Grid/DifferentialSquareBacktracking.lean
@@ -123,13 +123,11 @@ theorem self_notMem_twoStepColumnSwapNeighbors_of_le_one (x : GridState n) (hn :
   omega
 
 /-- In grid size `0`, the source state is not a two-step neighbour of itself. -/
-@[simp]
 theorem self_notMem_twoStepColumnSwapNeighbors_zero (x : GridState 0) :
     x ∉ x.twoStepColumnSwapNeighbors :=
   x.self_notMem_twoStepColumnSwapNeighbors_of_le_one (Nat.zero_le 1)
 
 /-- In grid size `1`, the source state is not a two-step neighbour of itself. -/
-@[simp]
 theorem self_notMem_twoStepColumnSwapNeighbors_one (x : GridState 1) :
     x ∉ x.twoStepColumnSwapNeighbors :=
   x.self_notMem_twoStepColumnSwapNeighbors_of_le_one le_rfl
@@ -151,14 +149,12 @@ theorem fullyBlockedDifferential_sq_single_apply_eq_zero_self_of_le_one
     (x.self_notMem_twoStepColumnSwapNeighbors_of_le_one hn)
 
 /-- In grid size `0`, the diagonal coefficient of `∂²` on a generator is zero. -/
-@[simp]
 theorem fullyBlockedDifferential_sq_single_apply_eq_zero_self_zero
     (G : GridDiagram 0) (x : GridState 0) :
     G.fullyBlockedDifferential (G.fullyBlockedDifferential (Finsupp.single x 1)) x = 0 :=
   G.fullyBlockedDifferential_sq_single_apply_eq_zero_self_of_le_one (Nat.zero_le 1) x
 
 /-- In grid size `1`, the diagonal coefficient of `∂²` on a generator is zero. -/
-@[simp]
 theorem fullyBlockedDifferential_sq_single_apply_eq_zero_self_one
     (G : GridDiagram 1) (x : GridState 1) :
     G.fullyBlockedDifferential (G.fullyBlockedDifferential (Finsupp.single x 1)) x = 0 :=

--- a/TauCeti/KnotTheory/Grid/DifferentialSquareBacktracking.lean
+++ b/TauCeti/KnotTheory/Grid/DifferentialSquareBacktracking.lean
@@ -1,0 +1,169 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+module
+
+public import TauCeti.KnotTheory.Grid.DifferentialSquareSupport
+
+/-!
+# Backtracking in the two-step grid differential support
+
+The support of the square of the fully blocked grid differential is already bounded by
+`GridState.twoStepColumnSwapNeighbors`: states reached from `x` by two nontrivial column
+transpositions. This file records the first exact feature of that two-step support. A path that
+swaps the same pair of columns twice returns to the starting state, so the source state appears in
+its own two-step neighbour set exactly when the grid has at least two columns.
+
+This is small but useful bookkeeping for the later `∂² = 0` rectangle-pairing argument: diagonal
+coefficients of `∂²` are precisely the backtracking part of the two-step search space, while grids
+of size `0` and `1` have no such two-step targets at all.
+
+## Main results
+
+* `TauCeti.GridState.mem_twoStepColumnSwapNeighbors_of_backtrack`: swapping a pair of distinct
+  columns and then swapping it back puts `x` in its own two-step neighbour set.
+* `TauCeti.GridState.self_mem_twoStepColumnSwapNeighbors_iff_exists_pair`: this is possible
+  exactly when there is a distinct pair of columns.
+* `TauCeti.GridState.self_mem_twoStepColumnSwapNeighbors_iff_two_le`: equivalently, exactly when
+  `2 ≤ n`.
+* `TauCeti.GridDiagram.fullyBlockedDifferential_sq_single_apply_eq_zero_self_of_le_one`: the
+  diagonal coefficient of `∂²` on a generator is zero in grid size at most `1`.
+
+## References
+
+This supplies a prerequisite for `TauCetiRoadmap/CombinatorialHeegaardFloer/README.md`, Lane G.3,
+"The complexes and `∂² = 0`", where the square-zero proof pairs two-step rectangle
+decompositions. The column-transposition model of rectangle targets follows
+Ozsváth--Stipsicz--Szabó, *Grid Homology for Knots and Links*, Chapters 3 and 4.
+-/
+
+public section
+
+namespace TauCeti
+
+namespace GridState
+
+variable {n : ℕ}
+
+/-- Swapping a distinct pair of columns gives a column-swap neighbour. -/
+theorem swapColumns_mem_columnSwapNeighbors (x : GridState n) {a b : Fin n} (hab : a ≠ b) :
+    x.swapColumns a b ∈ x.columnSwapNeighbors := by
+  rw [mem_columnSwapNeighbors]
+  exact ⟨a, b, hab, rfl⟩
+
+/-- If `y` is a column-swap neighbour of `x`, then `x` is a column-swap neighbour of `y`.
+
+This is the elementary reversibility of a rectangle target: the same pair of side columns swaps
+back to the source state. -/
+theorem mem_columnSwapNeighbors_comm {x y : GridState n} :
+    y ∈ x.columnSwapNeighbors ↔ x ∈ y.columnSwapNeighbors := by
+  constructor
+  · rw [mem_columnSwapNeighbors]
+    rintro ⟨a, b, hab, rfl⟩
+    rw [mem_columnSwapNeighbors]
+    exact ⟨a, b, hab, by simp⟩
+  · rw [mem_columnSwapNeighbors]
+    rintro ⟨a, b, hab, hxy⟩
+    rw [mem_columnSwapNeighbors]
+    refine ⟨a, b, hab, ?_⟩
+    rw [hxy]
+    simp
+
+/-- Swapping a distinct pair of columns and then swapping the same pair back puts the source state
+in its own two-step column-swap neighbour set. -/
+theorem mem_twoStepColumnSwapNeighbors_of_backtrack (x : GridState n) {a b : Fin n}
+    (hab : a ≠ b) : x ∈ x.twoStepColumnSwapNeighbors := by
+  rw [mem_twoStepColumnSwapNeighbors]
+  refine ⟨x.swapColumns a b, x.swapColumns_mem_columnSwapNeighbors hab, ?_⟩
+  rw [mem_columnSwapNeighbors]
+  exact ⟨a, b, hab, by simp⟩
+
+/-- The source state appears in its own two-step neighbour set exactly when there is a distinct
+pair of grid columns. -/
+theorem self_mem_twoStepColumnSwapNeighbors_iff_exists_pair (x : GridState n) :
+    x ∈ x.twoStepColumnSwapNeighbors ↔ ∃ a b : Fin n, a ≠ b := by
+  constructor
+  · intro hx
+    rw [mem_twoStepColumnSwapNeighbors] at hx
+    obtain ⟨y, hy, _hyx⟩ := hx
+    rw [mem_columnSwapNeighbors] at hy
+    exact hy.imp fun a ha => ha.imp fun b hb => hb.1
+  · rintro ⟨a, b, hab⟩
+    exact x.mem_twoStepColumnSwapNeighbors_of_backtrack hab
+
+/-- If the grid has at least two columns, the source state is a two-step neighbour of itself. -/
+theorem self_mem_twoStepColumnSwapNeighbors_of_two_le (x : GridState n) (hn : 2 ≤ n) :
+    x ∈ x.twoStepColumnSwapNeighbors := by
+  rw [self_mem_twoStepColumnSwapNeighbors_iff_exists_pair]
+  refine ⟨⟨0, Nat.lt_of_lt_of_le (by decide) hn⟩,
+    ⟨1, Nat.lt_of_lt_of_le (by decide) hn⟩, ?_⟩
+  intro h
+  exact Nat.zero_ne_one (congrArg Fin.val h)
+
+/-- The source state is a two-step neighbour of itself exactly in grid size at least two. -/
+theorem self_mem_twoStepColumnSwapNeighbors_iff_two_le (x : GridState n) :
+    x ∈ x.twoStepColumnSwapNeighbors ↔ 2 ≤ n := by
+  rw [self_mem_twoStepColumnSwapNeighbors_iff_exists_pair]
+  constructor
+  · rintro ⟨a, b, hab⟩
+    have hcard : 1 < Fintype.card (Fin n) :=
+      Fintype.one_lt_card_iff.mpr ⟨a, b, hab⟩
+    exact Nat.succ_le_of_lt (by simpa [Fintype.card_fin] using hcard)
+  · intro hn
+    refine ⟨⟨0, Nat.lt_of_lt_of_le (by decide) hn⟩,
+      ⟨1, Nat.lt_of_lt_of_le (by decide) hn⟩, ?_⟩
+    intro h
+    exact Nat.zero_ne_one (congrArg Fin.val h)
+
+/-- In grid size at most `1`, the source state is not a two-step neighbour of itself. -/
+theorem self_notMem_twoStepColumnSwapNeighbors_of_le_one (x : GridState n) (hn : n ≤ 1) :
+    x ∉ x.twoStepColumnSwapNeighbors := by
+  rw [self_mem_twoStepColumnSwapNeighbors_iff_two_le]
+  omega
+
+/-- In grid size `0`, the source state is not a two-step neighbour of itself. -/
+@[simp]
+theorem self_notMem_twoStepColumnSwapNeighbors_zero (x : GridState 0) :
+    x ∉ x.twoStepColumnSwapNeighbors :=
+  x.self_notMem_twoStepColumnSwapNeighbors_of_le_one (Nat.zero_le 1)
+
+/-- In grid size `1`, the source state is not a two-step neighbour of itself. -/
+@[simp]
+theorem self_notMem_twoStepColumnSwapNeighbors_one (x : GridState 1) :
+    x ∉ x.twoStepColumnSwapNeighbors :=
+  x.self_notMem_twoStepColumnSwapNeighbors_of_le_one le_rfl
+
+end GridState
+
+namespace GridDiagram
+
+variable {n : ℕ} (G : GridDiagram n)
+
+/-- In grid size at most `1`, the diagonal coefficient of `∂²` on a generator is zero.
+
+This is the coefficient-level form of the fact that there are no nontrivial two-step
+backtracking paths when there are not two distinct columns to swap. -/
+theorem fullyBlockedDifferential_sq_single_apply_eq_zero_self_of_le_one
+    (hn : n ≤ 1) (x : GridState n) :
+    G.fullyBlockedDifferential (G.fullyBlockedDifferential (Finsupp.single x 1)) x = 0 :=
+  G.fullyBlockedDifferential_sq_single_apply_eq_zero_of_notMem_twoStep x
+    (x.self_notMem_twoStepColumnSwapNeighbors_of_le_one hn)
+
+/-- In grid size `0`, the diagonal coefficient of `∂²` on a generator is zero. -/
+@[simp]
+theorem fullyBlockedDifferential_sq_single_apply_eq_zero_self_zero
+    (G : GridDiagram 0) (x : GridState 0) :
+    G.fullyBlockedDifferential (G.fullyBlockedDifferential (Finsupp.single x 1)) x = 0 :=
+  G.fullyBlockedDifferential_sq_single_apply_eq_zero_self_of_le_one (Nat.zero_le 1) x
+
+/-- In grid size `1`, the diagonal coefficient of `∂²` on a generator is zero. -/
+@[simp]
+theorem fullyBlockedDifferential_sq_single_apply_eq_zero_self_one
+    (G : GridDiagram 1) (x : GridState 1) :
+    G.fullyBlockedDifferential (G.fullyBlockedDifferential (Finsupp.single x 1)) x = 0 :=
+  G.fullyBlockedDifferential_sq_single_apply_eq_zero_self_of_le_one le_rfl x
+
+end GridDiagram
+
+end TauCeti


### PR DESCRIPTION
This PR records the backtracking part of the two-step support for the fully blocked grid differential: swapping a distinct pair of columns and then swapping the same pair back puts a grid state in its own two-step column-swap neighbour set, and this happens exactly in grid size at least two. It advances `TauCetiRoadmap/CombinatorialHeegaardFloer/README.md`, Lane G.3, "The complexes and `∂² = 0`", as a clean support-bookkeeping prerequisite for the later rectangle-pairing proof that `∂² = 0`.

The new module adds `GridState.mem_twoStepColumnSwapNeighbors_of_backtrack`, the equivalent criteria `self_mem_twoStepColumnSwapNeighbors_iff_exists_pair` and `self_mem_twoStepColumnSwapNeighbors_iff_two_le`, the small-grid negative forms, and coefficient-level consequences showing the diagonal coefficient of `∂²` on a generator is zero in grid sizes `0` and `1`.

No Mathlib infrastructure is vendored. The implementation reuses Tau Ceti's existing `GridState.columnSwapNeighbors`, `GridState.twoStepColumnSwapNeighbors`, `GridState.swapColumns_swapColumns`, and the fully blocked differential support API from `TauCeti.KnotTheory.Grid.DifferentialSquareSupport`. The column-transposition target model follows Ozsváth--Stipsicz--Szabó, *Grid Homology for Knots and Links*, Chapters 3 and 4.

`lake exe cache get` completed with `No files to download` and `Already decompressed 8609 file(s)`. `lake build` completed with `Build completed successfully (4499 jobs).` `lake exe axioms` completed with `axioms: audited 7599 TauCeti declaration(s); all within the allowlist [propext, Classical.choice, Quot.sound].`

<!--tauceti-target:v1 {"focus":"CombinatorialHeegaardFloer","id":"two-step-column-swap-backtracking"}-->

🤖 Prepared with Codex
