### PR TITLE
feat: add basepoint-change subgroup API

### DIFF
--- a/TauCeti/AlgebraicTopology/FundamentalGroup/BasepointChange.lean
+++ b/TauCeti/AlgebraicTopology/FundamentalGroup/BasepointChange.lean
@@ -19,13 +19,13 @@ attached to subgroups.
 Mathlib already supplies the fundamental-group isomorphism
 `FundamentalGroup.fundamentalGroupMulEquivOfPath`; the declarations here are only the
 subgroup and normalizer-quotient bookkeeping needed by the universal-covers roadmap.
-For inclusion, monotonicity, and normality questions about `basepointChangeSubgroup`, unfold
-the definition and use the generic `Subgroup.map` and `MulEquiv` API.
 
 ## Main declarations
 
 * `TauCeti.FundamentalGroup.basepointChangeSubgroup`: transport a subgroup of `π₁(X, x₀)`
   along a path `γ : Path x₀ x₁`.
+* Domain-specific membership, inclusion, monotonicity, and normality lemmas for
+  `basepointChangeSubgroup`.
 * `TauCeti.FundamentalGroup.basepointChangeNormalizerQuotientEquiv`: the corresponding
   isomorphism `N(H) / H ≃* N(γ₊H) / γ₊H`.
 * `TauCeti.FundamentalGroup.mem_basepointChangeSubgroup` and the representative `[simp]`
@@ -61,6 +61,68 @@ lemma mem_basepointChangeSubgroup (γ : Path x₀ x₁)
     g ∈ basepointChangeSubgroup γ H ↔
       ∃ h ∈ H, _root_.FundamentalGroup.fundamentalGroupMulEquivOfPath γ h = g :=
   Iff.rfl
+
+/-- Membership in a transported subgroup, expressed by applying the inverse basepoint-change
+isomorphism. -/
+@[simp]
+lemma mem_basepointChangeSubgroup_iff (γ : Path x₀ x₁)
+    (H : Subgroup (_root_.FundamentalGroup X x₀))
+    (g : _root_.FundamentalGroup X x₁) :
+    g ∈ basepointChangeSubgroup γ H ↔
+      (_root_.FundamentalGroup.fundamentalGroupMulEquivOfPath γ).symm g ∈ H := by
+  simpa [basepointChangeSubgroup] using
+    (Subgroup.mem_map_equiv
+      (f := _root_.FundamentalGroup.fundamentalGroupMulEquivOfPath γ) (K := H) (x := g))
+
+/-- A subgroup of the target fundamental group is contained in the transported subgroup iff
+its inverse basepoint-change image is contained in the original subgroup. -/
+lemma le_basepointChangeSubgroup_iff (γ : Path x₀ x₁)
+    (K : Subgroup (_root_.FundamentalGroup X x₁))
+    (H : Subgroup (_root_.FundamentalGroup X x₀)) :
+    K ≤ basepointChangeSubgroup γ H ↔
+      K.map (((_root_.FundamentalGroup.fundamentalGroupMulEquivOfPath γ).symm) :
+        _root_.FundamentalGroup X x₁ →* _root_.FundamentalGroup X x₀) ≤ H := by
+  rw [basepointChangeSubgroup]
+  constructor
+  · intro h x hx
+    rcases Subgroup.mem_map.mp hx with ⟨y, hyK, rfl⟩
+    exact (Subgroup.mem_map_equiv
+      (f := _root_.FundamentalGroup.fundamentalGroupMulEquivOfPath γ) (K := H)
+        (x := y)).mp (h hyK)
+  · intro h y hy
+    exact (Subgroup.mem_map_equiv
+      (f := _root_.FundamentalGroup.fundamentalGroupMulEquivOfPath γ) (K := H)
+        (x := y)).mpr (h (Subgroup.mem_map_of_mem _ hy))
+
+/-- The transported subgroup is contained in a target subgroup iff the original subgroup is
+contained in the target subgroup's inverse image under basepoint change. -/
+lemma basepointChangeSubgroup_le_iff (γ : Path x₀ x₁)
+    (H : Subgroup (_root_.FundamentalGroup X x₀))
+    (K : Subgroup (_root_.FundamentalGroup X x₁)) :
+    basepointChangeSubgroup γ H ≤ K ↔
+      H ≤ K.comap (((_root_.FundamentalGroup.fundamentalGroupMulEquivOfPath γ) :
+        _root_.FundamentalGroup X x₀ →* _root_.FundamentalGroup X x₁)) := by
+  rw [basepointChangeSubgroup, Subgroup.map_le_iff_le_comap]
+
+/-- Basepoint-change transport is monotone on subgroups. -/
+lemma basepointChangeSubgroup_mono (γ : Path x₀ x₁)
+    {H K : Subgroup (_root_.FundamentalGroup X x₀)} (h : H ≤ K) :
+    basepointChangeSubgroup γ H ≤ basepointChangeSubgroup γ K := by
+  rw [basepointChangeSubgroup, basepointChangeSubgroup]
+  exact Subgroup.map_mono h
+
+/-- Normality is invariant under basepoint-change transport. -/
+lemma basepointChangeSubgroup_normal_iff (γ : Path x₀ x₁)
+    (H : Subgroup (_root_.FundamentalGroup X x₀)) :
+    (basepointChangeSubgroup γ H).Normal ↔ H.Normal := by
+  rw [basepointChangeSubgroup]
+  exact MulEquiv.normal_map_iff
+
+/-- A normal subgroup remains normal after basepoint-change transport. -/
+lemma basepointChangeSubgroup.normal (γ : Path x₀ x₁)
+    {H : Subgroup (_root_.FundamentalGroup X x₀)} (hH : H.Normal) :
+    (basepointChangeSubgroup γ H).Normal :=
+  (basepointChangeSubgroup_normal_iff γ H).2 hH
 
 /-- The normalizer quotient `N(H) / H` transported along a basepoint-change path. -/
 noncomputable def basepointChangeNormalizerQuotientEquiv (γ : Path x₀ x₁)

--- a/TauCeti/AlgebraicTopology/FundamentalGroup/BasepointChange.lean
+++ b/TauCeti/AlgebraicTopology/FundamentalGroup/BasepointChange.lean
@@ -28,8 +28,6 @@ subgroup and normalizer-quotient bookkeeping needed by the universal-covers road
   isomorphism `N(H) / H ≃* N(γ₊H) / γ₊H`.
 * `TauCeti.FundamentalGroup.mem_basepointChangeSubgroup` and the representative `[simp]`
   lemmas for membership and quotient calculations under these domain-specific names.
-* `TauCeti.FundamentalGroup.basepointChangeSubgroup_normal_iff`: normality is invariant
-  under basepoint-change transport.
 
 ## References
 
@@ -62,45 +60,6 @@ lemma mem_basepointChangeSubgroup (γ : Path x₀ x₁)
       ∃ h ∈ H, _root_.FundamentalGroup.fundamentalGroupMulEquivOfPath γ h = g :=
   Iff.rfl
 
-/-- Membership in a basepoint-changed subgroup can be checked after applying the inverse
-path-conjugation isomorphism. -/
-lemma mem_basepointChangeSubgroup_iff (γ : Path x₀ x₁)
-    (H : Subgroup (_root_.FundamentalGroup X x₀))
-    (g : _root_.FundamentalGroup X x₁) :
-    g ∈ basepointChangeSubgroup γ H ↔
-      (_root_.FundamentalGroup.fundamentalGroupMulEquivOfPath γ).symm g ∈ H := by
-  simpa [basepointChangeSubgroup] using
-    (Subgroup.mem_map_equiv
-      (f := (_root_.FundamentalGroup.fundamentalGroupMulEquivOfPath γ))
-      (K := H) (x := g))
-
-/-- Applying the path-conjugation isomorphism sends exactly the original subgroup into its
-basepoint-changed subgroup. -/
-lemma fundamentalGroupMulEquivOfPath_mem_basepointChangeSubgroup_iff
-    (γ : Path x₀ x₁) (H : Subgroup (_root_.FundamentalGroup X x₀))
-    (g : _root_.FundamentalGroup X x₀) :
-    _root_.FundamentalGroup.fundamentalGroupMulEquivOfPath γ g ∈
-        basepointChangeSubgroup γ H ↔
-      g ∈ H := by
-  simp [mem_basepointChangeSubgroup_iff]
-
-/-- Basepoint-change transport of fundamental-group subgroups is monotone. -/
-lemma basepointChangeSubgroup_mono (γ : Path x₀ x₁)
-    {H K : Subgroup (_root_.FundamentalGroup X x₀)} (hHK : H ≤ K) :
-    basepointChangeSubgroup γ H ≤ basepointChangeSubgroup γ K :=
-  Subgroup.map_mono hHK
-
-/-- To prove an inclusion out of a basepoint-changed subgroup, it suffices to prove the
-corresponding inclusion after comapping along the path-conjugation isomorphism. -/
-lemma basepointChangeSubgroup_le_iff (γ : Path x₀ x₁)
-    (H : Subgroup (_root_.FundamentalGroup X x₀))
-    (K : Subgroup (_root_.FundamentalGroup X x₁)) :
-    basepointChangeSubgroup γ H ≤ K ↔
-      H ≤ K.comap ((_root_.FundamentalGroup.fundamentalGroupMulEquivOfPath γ :
-        _root_.FundamentalGroup X x₀ →* _root_.FundamentalGroup X x₁)) := by
-  rw [basepointChangeSubgroup]
-  exact Subgroup.map_le_iff_le_comap
-
 /-- To prove an inclusion into a basepoint-changed subgroup, pull each element back along the
 path-conjugation isomorphism and check membership in the original subgroup. -/
 lemma le_basepointChangeSubgroup_iff (γ : Path x₀ x₁)
@@ -110,10 +69,15 @@ lemma le_basepointChangeSubgroup_iff (γ : Path x₀ x₁)
       ∀ g ∈ K, (_root_.FundamentalGroup.fundamentalGroupMulEquivOfPath γ).symm g ∈ H := by
   constructor
   · intro hK g hg
-    exact (mem_basepointChangeSubgroup_iff γ H g).1 (hK hg)
+    exact
+      (Subgroup.mem_map_equiv
+        (f := (_root_.FundamentalGroup.fundamentalGroupMulEquivOfPath γ))
+        (K := H) (x := g)).1 (by simpa [basepointChangeSubgroup] using hK hg)
   · intro hK g hg
-    rw [mem_basepointChangeSubgroup_iff]
-    exact hK g hg
+    exact
+      (Subgroup.mem_map_equiv
+        (f := (_root_.FundamentalGroup.fundamentalGroupMulEquivOfPath γ))
+        (K := H) (x := g)).2 (hK g hg)
 
 /-- Normality of a fundamental-group subgroup is preserved by basepoint-change transport. -/
 instance basepointChangeSubgroup.normal (γ : Path x₀ x₁)
@@ -122,30 +86,6 @@ instance basepointChangeSubgroup.normal (γ : Path x₀ x₁)
   hH.map ((_root_.FundamentalGroup.fundamentalGroupMulEquivOfPath γ :
     _root_.FundamentalGroup X x₀ →* _root_.FundamentalGroup X x₁))
     (_root_.FundamentalGroup.fundamentalGroupMulEquivOfPath γ).surjective
-
-/-- A basepoint-changed subgroup is normal if and only if the original subgroup is normal. -/
-lemma basepointChangeSubgroup_normal_iff (γ : Path x₀ x₁)
-    (H : Subgroup (_root_.FundamentalGroup X x₀)) :
-    (basepointChangeSubgroup γ H).Normal ↔ H.Normal := by
-  constructor
-  · intro h
-    let e := _root_.FundamentalGroup.fundamentalGroupMulEquivOfPath γ
-    have hcomap :
-        (Subgroup.comap (e : _root_.FundamentalGroup X x₀ →* _root_.FundamentalGroup X x₁)
-          (basepointChangeSubgroup γ H)).Normal :=
-      h.comap (e : _root_.FundamentalGroup X x₀ →* _root_.FundamentalGroup X x₁)
-    have hsub :
-        Subgroup.comap (e : _root_.FundamentalGroup X x₀ →* _root_.FundamentalGroup X x₁)
-          (basepointChangeSubgroup γ H) = H := by
-      rw [basepointChangeSubgroup, Subgroup.comap_map_eq]
-      have hker :
-          (e : _root_.FundamentalGroup X x₀ →* _root_.FundamentalGroup X x₁).ker = ⊥ :=
-        (MonoidHom.ker_eq_bot_iff _).2 e.injective
-      rw [hker, sup_bot_eq]
-    rw [← hsub]
-    exact hcomap
-  · intro h
-    exact basepointChangeSubgroup.normal γ H
 
 /-- The normalizer quotient `N(H) / H` transported along a basepoint-change path. -/
 noncomputable def basepointChangeNormalizerQuotientEquiv (γ : Path x₀ x₁)

--- a/TauCeti/AlgebraicTopology/FundamentalGroup/BasepointChange.lean
+++ b/TauCeti/AlgebraicTopology/FundamentalGroup/BasepointChange.lean
@@ -60,58 +60,6 @@ lemma mem_basepointChangeSubgroup (γ : Path x₀ x₁)
       ∃ h ∈ H, _root_.FundamentalGroup.fundamentalGroupMulEquivOfPath γ h = g :=
   Iff.rfl
 
-/-- To prove an inclusion into a basepoint-changed subgroup, pull each element back along the
-path-conjugation isomorphism and check membership in the original subgroup. -/
-lemma le_basepointChangeSubgroup_iff (γ : Path x₀ x₁)
-    (H : Subgroup (_root_.FundamentalGroup X x₀))
-    (K : Subgroup (_root_.FundamentalGroup X x₁)) :
-    K ≤ basepointChangeSubgroup γ H ↔
-      ∀ g ∈ K, (_root_.FundamentalGroup.fundamentalGroupMulEquivOfPath γ).symm g ∈ H := by
-  constructor
-  · intro hK g hg
-    exact
-      (Subgroup.mem_map_equiv
-        (f := (_root_.FundamentalGroup.fundamentalGroupMulEquivOfPath γ))
-        (K := H) (x := g)).1 (by simpa [basepointChangeSubgroup] using hK hg)
-  · intro hK g hg
-    exact
-      (Subgroup.mem_map_equiv
-        (f := (_root_.FundamentalGroup.fundamentalGroupMulEquivOfPath γ))
-        (K := H) (x := g)).2 (hK g hg)
-
-/-- To prove an inclusion out of a basepoint-changed subgroup, it suffices to prove the
-corresponding inclusion after comapping along the path-conjugation isomorphism. -/
-lemma basepointChangeSubgroup_le_iff (γ : Path x₀ x₁)
-    (H : Subgroup (_root_.FundamentalGroup X x₀))
-    (K : Subgroup (_root_.FundamentalGroup X x₁)) :
-    basepointChangeSubgroup γ H ≤ K ↔
-      H ≤ K.comap ((_root_.FundamentalGroup.fundamentalGroupMulEquivOfPath γ :
-        _root_.FundamentalGroup X x₀ →* _root_.FundamentalGroup X x₁)) := by
-  rw [basepointChangeSubgroup]
-  exact Subgroup.map_le_iff_le_comap
-
-/-- Basepoint-change transport of fundamental-group subgroups is monotone. -/
-lemma basepointChangeSubgroup_mono (γ : Path x₀ x₁)
-    {H K : Subgroup (_root_.FundamentalGroup X x₀)} (hHK : H ≤ K) :
-    basepointChangeSubgroup γ H ≤ basepointChangeSubgroup γ K := by
-  exact Subgroup.map_mono hHK
-
-/-- Normality of a fundamental-group subgroup is preserved by basepoint-change transport. -/
-instance basepointChangeSubgroup.normal (γ : Path x₀ x₁)
-    (H : Subgroup (_root_.FundamentalGroup X x₀)) [hH : H.Normal] :
-    (basepointChangeSubgroup γ H).Normal :=
-  hH.map ((_root_.FundamentalGroup.fundamentalGroupMulEquivOfPath γ :
-    _root_.FundamentalGroup X x₀ →* _root_.FundamentalGroup X x₁))
-    (_root_.FundamentalGroup.fundamentalGroupMulEquivOfPath γ).surjective
-
-/-- A basepoint-changed subgroup is normal if and only if the original subgroup is normal. -/
-lemma basepointChangeSubgroup_normal_iff (γ : Path x₀ x₁)
-    (H : Subgroup (_root_.FundamentalGroup X x₀)) :
-    (basepointChangeSubgroup γ H).Normal ↔ H.Normal := by
-  simpa [basepointChangeSubgroup] using
-    (MulEquiv.normal_map_iff
-      (f := _root_.FundamentalGroup.fundamentalGroupMulEquivOfPath γ) (H := H))
-
 /-- The normalizer quotient `N(H) / H` transported along a basepoint-change path. -/
 noncomputable def basepointChangeNormalizerQuotientEquiv (γ : Path x₀ x₁)
     (H : Subgroup (_root_.FundamentalGroup X x₀)) :

--- a/TauCeti/AlgebraicTopology/FundamentalGroup/BasepointChange.lean
+++ b/TauCeti/AlgebraicTopology/FundamentalGroup/BasepointChange.lean
@@ -19,6 +19,8 @@ attached to subgroups.
 Mathlib already supplies the fundamental-group isomorphism
 `FundamentalGroup.fundamentalGroupMulEquivOfPath`; the declarations here are only the
 subgroup and normalizer-quotient bookkeeping needed by the universal-covers roadmap.
+For inclusion, monotonicity, and normality questions about `basepointChangeSubgroup`, unfold
+the definition and use the generic `Subgroup.map` and `MulEquiv` API.
 
 ## Main declarations
 

--- a/TauCeti/AlgebraicTopology/FundamentalGroup/BasepointChange.lean
+++ b/TauCeti/AlgebraicTopology/FundamentalGroup/BasepointChange.lean
@@ -79,6 +79,23 @@ lemma le_basepointChangeSubgroup_iff (γ : Path x₀ x₁)
         (f := (_root_.FundamentalGroup.fundamentalGroupMulEquivOfPath γ))
         (K := H) (x := g)).2 (hK g hg)
 
+/-- To prove an inclusion out of a basepoint-changed subgroup, it suffices to prove the
+corresponding inclusion after comapping along the path-conjugation isomorphism. -/
+lemma basepointChangeSubgroup_le_iff (γ : Path x₀ x₁)
+    (H : Subgroup (_root_.FundamentalGroup X x₀))
+    (K : Subgroup (_root_.FundamentalGroup X x₁)) :
+    basepointChangeSubgroup γ H ≤ K ↔
+      H ≤ K.comap ((_root_.FundamentalGroup.fundamentalGroupMulEquivOfPath γ :
+        _root_.FundamentalGroup X x₀ →* _root_.FundamentalGroup X x₁)) := by
+  rw [basepointChangeSubgroup]
+  exact Subgroup.map_le_iff_le_comap
+
+/-- Basepoint-change transport of fundamental-group subgroups is monotone. -/
+lemma basepointChangeSubgroup_mono (γ : Path x₀ x₁)
+    {H K : Subgroup (_root_.FundamentalGroup X x₀)} (hHK : H ≤ K) :
+    basepointChangeSubgroup γ H ≤ basepointChangeSubgroup γ K := by
+  exact Subgroup.map_mono hHK
+
 /-- Normality of a fundamental-group subgroup is preserved by basepoint-change transport. -/
 instance basepointChangeSubgroup.normal (γ : Path x₀ x₁)
     (H : Subgroup (_root_.FundamentalGroup X x₀)) [hH : H.Normal] :
@@ -86,6 +103,14 @@ instance basepointChangeSubgroup.normal (γ : Path x₀ x₁)
   hH.map ((_root_.FundamentalGroup.fundamentalGroupMulEquivOfPath γ :
     _root_.FundamentalGroup X x₀ →* _root_.FundamentalGroup X x₁))
     (_root_.FundamentalGroup.fundamentalGroupMulEquivOfPath γ).surjective
+
+/-- A basepoint-changed subgroup is normal if and only if the original subgroup is normal. -/
+lemma basepointChangeSubgroup_normal_iff (γ : Path x₀ x₁)
+    (H : Subgroup (_root_.FundamentalGroup X x₀)) :
+    (basepointChangeSubgroup γ H).Normal ↔ H.Normal := by
+  simpa [basepointChangeSubgroup] using
+    (MulEquiv.normal_map_iff
+      (f := _root_.FundamentalGroup.fundamentalGroupMulEquivOfPath γ) (H := H))
 
 /-- The normalizer quotient `N(H) / H` transported along a basepoint-change path. -/
 noncomputable def basepointChangeNormalizerQuotientEquiv (γ : Path x₀ x₁)

--- a/TauCeti/AlgebraicTopology/FundamentalGroup/BasepointChange.lean
+++ b/TauCeti/AlgebraicTopology/FundamentalGroup/BasepointChange.lean
@@ -28,6 +28,8 @@ subgroup and normalizer-quotient bookkeeping needed by the universal-covers road
   isomorphism `N(H) / H ≃* N(γ₊H) / γ₊H`.
 * `TauCeti.FundamentalGroup.mem_basepointChangeSubgroup` and the representative `[simp]`
   lemmas for membership and quotient calculations under these domain-specific names.
+* `TauCeti.FundamentalGroup.basepointChangeSubgroup_normal_iff`: normality is invariant
+  under basepoint-change transport.
 
 ## References
 
@@ -59,6 +61,91 @@ lemma mem_basepointChangeSubgroup (γ : Path x₀ x₁)
     g ∈ basepointChangeSubgroup γ H ↔
       ∃ h ∈ H, _root_.FundamentalGroup.fundamentalGroupMulEquivOfPath γ h = g :=
   Iff.rfl
+
+/-- Membership in a basepoint-changed subgroup can be checked after applying the inverse
+path-conjugation isomorphism. -/
+lemma mem_basepointChangeSubgroup_iff (γ : Path x₀ x₁)
+    (H : Subgroup (_root_.FundamentalGroup X x₀))
+    (g : _root_.FundamentalGroup X x₁) :
+    g ∈ basepointChangeSubgroup γ H ↔
+      (_root_.FundamentalGroup.fundamentalGroupMulEquivOfPath γ).symm g ∈ H := by
+  simpa [basepointChangeSubgroup] using
+    (Subgroup.mem_map_equiv
+      (f := (_root_.FundamentalGroup.fundamentalGroupMulEquivOfPath γ))
+      (K := H) (x := g))
+
+/-- Applying the path-conjugation isomorphism sends exactly the original subgroup into its
+basepoint-changed subgroup. -/
+lemma fundamentalGroupMulEquivOfPath_mem_basepointChangeSubgroup_iff
+    (γ : Path x₀ x₁) (H : Subgroup (_root_.FundamentalGroup X x₀))
+    (g : _root_.FundamentalGroup X x₀) :
+    _root_.FundamentalGroup.fundamentalGroupMulEquivOfPath γ g ∈
+        basepointChangeSubgroup γ H ↔
+      g ∈ H := by
+  simp [mem_basepointChangeSubgroup_iff]
+
+/-- Basepoint-change transport of fundamental-group subgroups is monotone. -/
+lemma basepointChangeSubgroup_mono (γ : Path x₀ x₁)
+    {H K : Subgroup (_root_.FundamentalGroup X x₀)} (hHK : H ≤ K) :
+    basepointChangeSubgroup γ H ≤ basepointChangeSubgroup γ K :=
+  Subgroup.map_mono hHK
+
+/-- To prove an inclusion out of a basepoint-changed subgroup, it suffices to prove the
+corresponding inclusion after comapping along the path-conjugation isomorphism. -/
+lemma basepointChangeSubgroup_le_iff (γ : Path x₀ x₁)
+    (H : Subgroup (_root_.FundamentalGroup X x₀))
+    (K : Subgroup (_root_.FundamentalGroup X x₁)) :
+    basepointChangeSubgroup γ H ≤ K ↔
+      H ≤ K.comap ((_root_.FundamentalGroup.fundamentalGroupMulEquivOfPath γ :
+        _root_.FundamentalGroup X x₀ →* _root_.FundamentalGroup X x₁)) := by
+  rw [basepointChangeSubgroup]
+  exact Subgroup.map_le_iff_le_comap
+
+/-- To prove an inclusion into a basepoint-changed subgroup, pull each element back along the
+path-conjugation isomorphism and check membership in the original subgroup. -/
+lemma le_basepointChangeSubgroup_iff (γ : Path x₀ x₁)
+    (H : Subgroup (_root_.FundamentalGroup X x₀))
+    (K : Subgroup (_root_.FundamentalGroup X x₁)) :
+    K ≤ basepointChangeSubgroup γ H ↔
+      ∀ g ∈ K, (_root_.FundamentalGroup.fundamentalGroupMulEquivOfPath γ).symm g ∈ H := by
+  constructor
+  · intro hK g hg
+    exact (mem_basepointChangeSubgroup_iff γ H g).1 (hK hg)
+  · intro hK g hg
+    rw [mem_basepointChangeSubgroup_iff]
+    exact hK g hg
+
+/-- Normality of a fundamental-group subgroup is preserved by basepoint-change transport. -/
+instance basepointChangeSubgroup.normal (γ : Path x₀ x₁)
+    (H : Subgroup (_root_.FundamentalGroup X x₀)) [hH : H.Normal] :
+    (basepointChangeSubgroup γ H).Normal :=
+  hH.map ((_root_.FundamentalGroup.fundamentalGroupMulEquivOfPath γ :
+    _root_.FundamentalGroup X x₀ →* _root_.FundamentalGroup X x₁))
+    (_root_.FundamentalGroup.fundamentalGroupMulEquivOfPath γ).surjective
+
+/-- A basepoint-changed subgroup is normal if and only if the original subgroup is normal. -/
+lemma basepointChangeSubgroup_normal_iff (γ : Path x₀ x₁)
+    (H : Subgroup (_root_.FundamentalGroup X x₀)) :
+    (basepointChangeSubgroup γ H).Normal ↔ H.Normal := by
+  constructor
+  · intro h
+    let e := _root_.FundamentalGroup.fundamentalGroupMulEquivOfPath γ
+    have hcomap :
+        (Subgroup.comap (e : _root_.FundamentalGroup X x₀ →* _root_.FundamentalGroup X x₁)
+          (basepointChangeSubgroup γ H)).Normal :=
+      h.comap (e : _root_.FundamentalGroup X x₀ →* _root_.FundamentalGroup X x₁)
+    have hsub :
+        Subgroup.comap (e : _root_.FundamentalGroup X x₀ →* _root_.FundamentalGroup X x₁)
+          (basepointChangeSubgroup γ H) = H := by
+      rw [basepointChangeSubgroup, Subgroup.comap_map_eq]
+      have hker :
+          (e : _root_.FundamentalGroup X x₀ →* _root_.FundamentalGroup X x₁).ker = ⊥ :=
+        (MonoidHom.ker_eq_bot_iff _).2 e.injective
+      rw [hker, sup_bot_eq]
+    rw [← hsub]
+    exact hcomap
+  · intro h
+    exact basepointChangeSubgroup.normal γ H
 
 /-- The normalizer quotient `N(H) / H` transported along a basepoint-change path. -/
 noncomputable def basepointChangeNormalizerQuotientEquiv (γ : Path x₀ x₁)


### PR DESCRIPTION
This PR adds basepoint-change subgroup API for fundamental-group subgroups: membership after inverse path-conjugation, exact membership of transported elements, inclusion criteria, monotonicity, and invariance of normality under transport. It advances `TauCetiRoadmap/UniversalCovers/README.md`, Stage 2, item 7, "Separately, prove how the recovered subgroup transforms (by conjugacy) under basepoint change," as a small bookkeeping prerequisite for comparing pointed covers after changing the chosen lift/basepoint.

No Mathlib infrastructure is vendored. The implementation reuses Mathlib's `FundamentalGroup.fundamentalGroupMulEquivOfPath`, `Subgroup.mem_map_equiv`, `Subgroup.map_le_iff_le_comap`, `Subgroup.Normal.map`, and `Subgroup.Normal.comap`, together with the existing Tau Ceti `basepointChangeSubgroup` and normalizer-quotient transport API.

`lake exe cache get` completed with `No files to download` and `Already decompressed 8609 file(s)`. `lake build` completed with `Build completed successfully (4501 jobs).` `lake exe axioms` completed with `axioms: audited 7654 TauCeti declaration(s); all within the allowlist [propext, Classical.choice, Quot.sound].`

<!--tauceti-target:v1 {"focus":"UniversalCovers","id":"basepoint-change-subgroup-functoriality"}-->

🤖 Prepared with Codex
