### PR TITLE
feat: add ExchangeableAt monotonicity

### DIFF
--- a/TauCeti/Probability/Exchangeability/Contractability.lean
+++ b/TauCeti/Probability/Exchangeability/Contractability.lean
@@ -6,7 +6,6 @@ public import Mathlib.Data.Fin.VecNotation
 public import Mathlib.Dynamics.Ergodic.MeasurePreserving
 import TauCeti.Probability.Exchangeability.ExchangeableAtMonotone
 import Mathlib.Order.Fin.Tuple
-import Mathlib.Logic.Equiv.Fintype
 import TauCeti.Probability.Exchangeability.FiniteMarginals
 
 /-!

--- a/TauCeti/Probability/Exchangeability/Contractability.lean
+++ b/TauCeti/Probability/Exchangeability/Contractability.lean
@@ -4,6 +4,7 @@ public import TauCeti.Probability.Exchangeability.Basic
 public import Mathlib.Order.Fin.Basic
 public import Mathlib.Data.Fin.VecNotation
 public import Mathlib.Dynamics.Ergodic.MeasurePreserving
+import TauCeti.Probability.Exchangeability.ExchangeableAtMonotone
 import Mathlib.Order.Fin.Tuple
 import Mathlib.Logic.Equiv.Fintype
 import TauCeti.Probability.Exchangeability.FiniteMarginals
@@ -87,25 +88,11 @@ theorem Exchangeable.blockLaw_eq_prefixLaw_of_injective {μ : Measure Ω} {X : �
     have h1 : k i ≤ Finset.univ.sup k := Finset.le_sup (Finset.mem_univ i)
     have h2 : Finset.univ.sup k + 1 ≤ N := le_max_right _ _
     omega
-  obtain ⟨σ, hσ⟩ := Equiv.Perm.exists_extending_pair (Fin.castLE hnN)
-    (fun i => (⟨k i, hk_bound i⟩ : Fin N))
-    (fun a b h => by
-      apply Fin.val_injective
-      exact (congrArg Fin.val h : (Fin.castLE hnN a).val = (Fin.castLE hnN b).val))
-    (fun _ _ h => hk (Fin.mk.inj h))
-  have hexch : blockLaw μ X (fun j : Fin N => (σ j).val) = prefixLaw μ X N :=
-    (hX.exchangeableAt N).permute σ
-  have hLHS : (blockLaw μ X (fun j : Fin N => (σ j).val)).map
-        (fun x : Fin N → α => fun i : Fin n => x (Fin.castLE hnN i)) = blockLaw μ X k := by
-    have hidx : (fun j : Fin N => (σ j).val) ∘ Fin.castLE hnN = k := by
-      funext i; exact congrArg Fin.val (hσ i)
-    rw [map_blockLaw_reindex μ _ (Fin.castLE hnN) (fun j => hX_meas (σ j).val), hidx]
-  have hRHS : (prefixLaw μ X N).map (fun x : Fin N → α => fun i : Fin n =>
-        x (Fin.castLE hnN i)) = prefixLaw μ X n :=
-    map_prefixLaw_castLE μ hnN (fun j => hX_meas j.val)
-  have key := congrArg
-    (Measure.map (fun x : Fin N → α => fun i : Fin n => x (Fin.castLE hnN i))) hexch
-  rwa [hLHS, hRHS] at key
+  simpa using
+    (hX.exchangeableAt N).blockLaw_eq_prefixLaw_of_injective
+      (fun i : Fin n => (⟨k i, hk_bound i⟩ : Fin N))
+      (fun _ _ h => hk (congrArg Fin.val h))
+      (fun j : Fin N => hX_meas j.val)
 
 /-- **Every exchangeable sequence with a.e. measurable coordinates is contractable**: along any
 strictly increasing finite selection `k`, `blockLaw μ X k = prefixLaw μ X m`. One direction of the

--- a/TauCeti/Probability/Exchangeability/ExchangeableAtMonotone.lean
+++ b/TauCeti/Probability/Exchangeability/ExchangeableAtMonotone.lean
@@ -1,0 +1,102 @@
+module
+
+public import TauCeti.Probability.Exchangeability.Basic
+import Mathlib.Logic.Equiv.Fintype
+
+/-!
+# Monotonicity of finite exchangeability
+
+This file records the Layer 0 implication-lattice API for `ExchangeableAt`: if the first `n`
+coordinates have permutation-invariant law, then so do the first `m` coordinates for every
+`m ≤ n`. The proof is the finite-dimensional marginal argument: extend a permutation of
+`Fin m` to one of `Fin n`, use exchangeability at `n`, and project the `n`-prefix law back to
+the first `m` coordinates.
+
+The permutation-extension step reuses Mathlib's `Equiv.Perm.exists_extending_pair`; the
+measure-level projection step reuses Tau Ceti's `map_blockLaw_reindex` and
+`map_prefixLaw_castLE`.
+-/
+
+public section
+
+noncomputable section
+
+open MeasureTheory
+
+namespace TauCeti
+
+namespace Probability
+
+variable {Ω α : Type*} [MeasurableSpace Ω] [MeasurableSpace α]
+
+namespace ExchangeableAt
+
+/-- An injective map `k : Fin m → Fin n` extends across the canonical inclusion
+`Fin.castLE hmn` to a permutation of `Fin n`. -/
+private theorem exists_perm_extending_castLE {m n : ℕ} (hmn : m ≤ n)
+    (k : Fin m → Fin n) (hk : Function.Injective k) :
+    ∃ σ : Equiv.Perm (Fin n),
+      ∀ i : Fin m, σ (Fin.castLE hmn i) = k i :=
+  Equiv.Perm.exists_extending_pair (Fin.castLE hmn) k
+    (fun _ _ h => Fin.castLE_injective hmn h)
+    hk
+
+/-- An exchangeable `n`-prefix has the prefix law on every injective `m`-subselection inside
+that prefix. -/
+theorem blockLaw_eq_prefixLaw_of_injective {μ : Measure Ω} {X : ℕ → Ω → α} {m n : ℕ}
+    (h : ExchangeableAt μ X n) (k : Fin m → Fin n) (hk : Function.Injective k)
+    (hX : ∀ i : Fin n, AEMeasurable (X i.val) μ) :
+    blockLaw μ X (fun i : Fin m => (k i).val) = prefixLaw μ X m := by
+  have hmn : m ≤ n := by
+    simpa using Fintype.card_le_of_injective k hk
+  obtain ⟨σ, hσ⟩ := exists_perm_extending_castLE hmn k hk
+  have hperm : blockLaw μ X (fun j : Fin n => (σ j).val) = prefixLaw μ X n := h.permute σ
+  have hLHS :
+      (blockLaw μ X (fun j : Fin n => (σ j).val)).map
+          (fun x : Fin n → α => fun i : Fin m => x (Fin.castLE hmn i)) =
+        blockLaw μ X (fun i : Fin m => (k i).val) := by
+    have hidx :
+        (fun j : Fin n => (σ j).val) ∘ Fin.castLE hmn =
+          fun i : Fin m => (k i).val := by
+      funext i
+      exact congrArg Fin.val (hσ i)
+    rw [map_blockLaw_reindex μ _ (Fin.castLE hmn) (fun j => hX (σ j)), hidx]
+  have hRHS :
+      (prefixLaw μ X n).map (fun x : Fin n → α => fun i : Fin m => x (Fin.castLE hmn i)) =
+        prefixLaw μ X m :=
+    map_prefixLaw_castLE μ hmn hX
+  have key := congrArg
+    (Measure.map (fun x : Fin n → α => fun i : Fin m => x (Fin.castLE hmn i))) hperm
+  rwa [hLHS, hRHS] at key
+
+/-- Finite exchangeability at length `n` descends to every shorter prefix length `m ≤ n`. -/
+theorem of_le {μ : Measure Ω} {X : ℕ → Ω → α} {m n : ℕ}
+    (h : ExchangeableAt μ X n) (hmn : m ≤ n)
+    (hX : ∀ i : Fin n, AEMeasurable (X i.val) μ) :
+    ExchangeableAt μ X m := by
+  intro τ
+  exact h.blockLaw_eq_prefixLaw_of_injective (fun i => Fin.castLE hmn (τ i))
+    (by
+      intro i j hij
+      exact τ.injective (Fin.castLE_injective hmn hij))
+    hX
+
+/-- Finite exchangeability at length `n` descends to any strictly shorter prefix length. -/
+theorem of_lt {μ : Measure Ω} {X : ℕ → Ω → α} {m n : ℕ}
+    (h : ExchangeableAt μ X n) (hmn : m < n)
+    (hX : ∀ i : Fin n, AEMeasurable (X i.val) μ) :
+    ExchangeableAt μ X m :=
+  h.of_le hmn.le hX
+
+/-- Exchangeability at `n + 1` descends to exchangeability at `n`. -/
+theorem pred {μ : Measure Ω} {X : ℕ → Ω → α} {n : ℕ}
+    (h : ExchangeableAt μ X (n + 1))
+    (hX : ∀ i : Fin (n + 1), AEMeasurable (X i.val) μ) :
+    ExchangeableAt μ X n :=
+  h.of_le (Nat.le_succ n) hX
+
+end ExchangeableAt
+
+end Probability
+
+end TauCeti

--- a/TauCeti/Probability/Exchangeability/ExchangeableAtMonotone.lean
+++ b/TauCeti/Probability/Exchangeability/ExchangeableAtMonotone.lean
@@ -15,6 +15,10 @@ the first `m` coordinates.
 The permutation-extension step reuses Mathlib's `Equiv.Perm.exists_extending_pair`; the
 measure-level projection step reuses Tau Ceti's `map_blockLaw_reindex` and
 `map_prefixLaw_castLE`.
+
+This projection argument is adapted from Tau Ceti's credited
+`Exchangeable.blockLaw_eq_prefixLaw_of_injective` proof in `Contractability.lean`, following the
+`cameronfreer/exchangeability` Layer 0 sources.
 -/
 
 public section


### PR DESCRIPTION
This PR adds the finite-prefix implication-lattice API for `ExchangeableAt`: an exchangeable `n`-prefix has the prefix law on every injective shorter subselection, and finite exchangeability at length `n` descends to every `m ≤ n`. It advances `TauCetiRoadmap/Exchangeability/README.md`, Layer 0, the item “the implication lattice among `ExchangeableAt n`, `Exchangeable`, `FullyExchangeable`, `Contractable`, and `ConditionallyIID`, with every easy arrow named,” as the local `ExchangeableAt` monotonicity prerequisite.

The new module proves `ExchangeableAt.blockLaw_eq_prefixLaw_of_injective`, `ExchangeableAt.of_le`, `ExchangeableAt.of_lt`, and `ExchangeableAt.pred`. No Mathlib infrastructure is vendored. The implementation reuses Tau Ceti’s existing `blockLaw`, `prefixLaw`, `map_blockLaw_reindex`, and `map_prefixLaw_castLE` API, together with Mathlib’s `Equiv.Perm.exists_extending_pair` and `Fintype.card_le_of_injective`.

`lake exe cache get` completed with `No files to download` and `Already decompressed 8609 file(s)`. `lake build` completed with `Build completed successfully (4503 jobs).` `lake exe axioms` completed with `axioms: audited 7667 TauCeti declaration(s); all within the allowlist [propext, Classical.choice, Quot.sound].`

<!--tauceti-target:v1 {"focus":"Exchangeability","id":"exchangeableat-monotone"}-->

🤖 Prepared with Codex
