### PR TITLE
chore(AlgebraicGeometry): drop simp from pushforward_apply

### DIFF
--- a/TauCeti/AlgebraicGeometry/WeilDivisor.lean
+++ b/TauCeti/AlgebraicGeometry/WeilDivisor.lean
@@ -157,7 +157,6 @@ maps and residue-degree factors are available. -/
 @[expose] noncomputable def pushforward (f : X → Y) : WeilDivisor X →+ WeilDivisor Y :=
   (Finsupp.lmapDomain ℤ ℤ f).toAddMonoidHom
 
-@[simp]
 lemma pushforward_apply (f : X → Y) (D : WeilDivisor X) :
     pushforward f D = D.mapDomain f :=
   rfl
@@ -165,7 +164,7 @@ lemma pushforward_apply (f : X → Y) (D : WeilDivisor X) :
 lemma coeff_pushforward [DecidableEq Y] (f : X → Y) (D : WeilDivisor X) (y : Y) :
     coeff (pushforward f D) y = ∑ x ∈ D.support with f x = y, coeff D x := by
   rcases em (y ∈ Set.range f) with ⟨x, rfl⟩ | hy
-  · simp [coeff, Finsupp.mapDomain_apply_eq_sum]
+  · simp [coeff, pushforward_apply, Finsupp.mapDomain_apply_eq_sum]
   · rw [coeff, pushforward_apply, Finsupp.mapDomain_notin_range]
     · refine (Finset.sum_eq_zero fun x hx => ?_).symm
       rw [Finset.mem_filter] at hx

--- a/TauCeti/AlgebraicGeometry/WeilDivisor.lean
+++ b/TauCeti/AlgebraicGeometry/WeilDivisor.lean
@@ -157,10 +157,14 @@ maps and residue-degree factors are available. -/
 @[expose] noncomputable def pushforward (f : X → Y) : WeilDivisor X →+ WeilDivisor Y :=
   (Finsupp.lmapDomain ℤ ℤ f).toAddMonoidHom
 
+/-- The explicit unfolding equation for formal pushforward: `pushforward f D` is `D.mapDomain f`.
+Use this for manual rewriting rather than as a simp normal form. -/
 lemma pushforward_apply (f : X → Y) (D : WeilDivisor X) :
     pushforward f D = D.mapDomain f :=
   rfl
 
+/-- The coefficient of the pushed-forward divisor at `y` is the sum of the coefficients over
+the fibre of `f` above `y`. -/
 lemma coeff_pushforward [DecidableEq Y] (f : X → Y) (D : WeilDivisor X) (y : Y) :
     coeff (pushforward f D) y = ∑ x ∈ D.support with f x = y, coeff D x := by
   rcases em (y ∈ Set.range f) with ⟨x, rfl⟩ | hy

--- a/TauCeti/AlgebraicGeometry/WeilDivisor/FiniteSum.lean
+++ b/TauCeti/AlgebraicGeometry/WeilDivisor/FiniteSum.lean
@@ -344,7 +344,7 @@ lemma weightedDegree_ofFinset (w : X → ℤ) (s : Finset X) :
 @[simp]
 lemma pushforward_ofFinset (f : X → Y) (s : Finset X) :
     pushforward f (ofFinset s : WeilDivisor X) = ∑ x ∈ s, ofPoint (f x) := by
-  simpa [ofFinset] using pushforward_ofFinsetWithMultiplicity f s fun _ => 1
+  simp [ofFinset]
 
 /-- For positive weights, a named coefficient-one finite-set divisor lies in the weighted
 degree-zero subgroup exactly when the finite set is empty. -/


### PR DESCRIPTION
This PR removes the `@[simp]` attribute from `WeilDivisor.pushforward_apply`, the over-aggressive unfolding lemma identified in the wave-2 simp normal-form cleanup (https://github.com/TauCetiProject/TauCeti/pull/654, "Left in place, needs design attention"). As simp, it unfolds `pushforward f D` to `Finsupp.mapDomain f D` before the structural family can match, stranding goals at irreducible `mapDomain` terms; it is also an outlier in its own file, where the parallel `degree_apply`, `weightedDegree_apply`, and `coeff` unfolding lemmas are deliberately not simp. The lemma is kept for manual use.

Downstream repairs (2 sites): `coeff_pushforward` cites `pushforward_apply` explicitly in its simp call, and `pushforward_ofFinset` simplifies from `simpa ... using pushforward_ofFinsetWithMultiplicity` to plain `simp [ofFinset]` — the structural family now fires on its own, which is the point of the change.

`scripts/lint-simp-nf.sh` passes with no new violations, and 7 grandfathered baseline entries (`pushforward_{add,ofPoint,pointDifference,ofFinset,ofFinsetWithMultiplicity,ofFinsupp}` and `degree_pushforward`) now re-lint clean and become ratchetable; the baseline deletion is left for the human-owned ratchet follow-up.

🤖 Prepared with Claude Code