### PR TITLE
chore(NumberTheory): drop simp from the uniform prime-discriminant residue criteria

### DIFF
--- a/TauCeti/NumberTheory/Multiquadratic/LegendrePrimeDiscriminants.lean
+++ b/TauCeti/NumberTheory/Multiquadratic/LegendrePrimeDiscriminants.lean
@@ -72,7 +72,6 @@ theorem forall_legendreSym_primeDiscriminant_eq_one_iff_radicand {ι : Type*} (D
 For the three even prime discriminants this is the corresponding supplementary congruence
 condition on `q`; for an odd prime discriminant `p*` it is the reciprocal condition
 `(q / p) = 1`. -/
-@[simp]
 theorem legendreSym_primeDiscriminant_eq_one_iff {D : ℤ}
     (hD : IsPrimeDiscriminant D) (hq : q ≠ 2) :
     legendreSym q D = 1 ↔
@@ -110,7 +109,6 @@ theorem legendreSym_primeDiscriminant_eq_one_iff {D : ℤ}
 `legendreSym_primeDiscriminant_eq_one_iff`, stated for the associated squarefree radicand.
 This is the form consumed after converting a genus-field prime-discriminant list into
 multiquadratic radicands. -/
-@[simp]
 theorem legendreSym_primeDiscriminantRadicand_eq_one_iff {D : ℤ}
     (hD : IsPrimeDiscriminant D) (hq : q ≠ 2) :
     legendreSym q (primeDiscriminantRadicand D) = 1 ↔


### PR DESCRIPTION
This PR removes the `@[simp]` attribute from `Multiquadratic.legendreSym_primeDiscriminant_eq_one_iff` and `legendreSym_primeDiscriminantRadicand_eq_one_iff`, the two over-aggressive uniform criteria identified in the wave-2 simp normal-form cleanup (https://github.com/TauCetiProject/TauCeti/pull/655, "Left in place, needs design attention"). Their right-hand side is not itself a simp normal form: on concrete discriminants it strands goals in unreduced numeral tests (`if 8 = -4 then ... else ...`) joined to an existential over odd primes, defeating the concrete congruence criteria that are the intended normal forms. Both lemmas are kept for manual use.

The full library builds with no downstream repairs. `scripts/lint-simp-nf.sh` passes with no new violations, and 3 grandfathered baseline entries (`legendreSym_evenPrimeDiscriminant_{neg_four,eight,neg_eight}_eq_one_iff`) now re-lint clean and become ratchetable. The fourth lemma flagged in #655, `forall_legendreSym_neg_four_five_eq_one_iff`, remains grandfathered for an independent reason: its bounded `Fin 2` quantifier is rewritten by Mathlib's `Fin`/`Matrix.cons` simp lemmas before it can match, unrelated to these criteria. The baseline deletion is left for the human-owned ratchet follow-up.

🤖 Prepared with Claude Code