### PR TITLE
chore(LowDimTopology): drop simp from characteristicWeight_single

### DIFF
--- a/TauCeti/LowDimTopology/Plumbing/Weight.lean
+++ b/TauCeti/LowDimTopology/Plumbing/Weight.lean
@@ -177,7 +177,6 @@ theorem characteristicWeightNumerator_canonical_single (v : V) :
     P.canonicalCharacteristic_apply_add_intersection_single v
 
 /-- The characteristic weight of any characteristic covector on a plumbing basis sphere. -/
-@[simp]
 theorem characteristicWeight_single (k : P.characteristicVectors) (v : V) :
     P.characteristicWeight k (Pi.single v 1) = -((k.val v + P.weight v) / 2) := by
   rw [characteristicWeight_def, characteristicWeightNumerator_single]


### PR DESCRIPTION
This PR removes the `@[simp]` attribute from `PlumbingGraph.characteristicWeight_single`, the over-aggressive rewrite identified in the wave-2 simp normal-form cleanup (the LowDimTopology analogue of the aggressor pattern documented in https://github.com/TauCetiProject/TauCeti/pull/654 and https://github.com/TauCetiProject/TauCeti/pull/651). As simp, it rewrites the characteristic weight of every concrete covector on a basis sphere to the integer-division form `-((k.val v + P.weight v) / 2)`, which simp cannot finish for concrete covectors, stranding goals that the concrete evaluation lemmas would close outright. The lemma is kept for manual use; its two existing consumers (`Plumbing/Conjugation.lean`, `Plumbing/WeightPolarization.lean`) already cite it by name in `rw` calls.

The full library builds with no downstream repairs. `scripts/lint-simp-nf.sh` passes with no new violations, and 2 grandfathered baseline entries (`characteristicWeight_canonical_single`, `characteristicWeight_conjugate_canonical_single`) now re-lint clean and become ratchetable; the baseline deletion is left for the human-owned ratchet follow-up.

🤖 Prepared with Claude Code