### PR TITLE
doc: add docstrings to the two undocumented Algebra declarations

### DIFF
--- a/TauCeti/Algebra/Coalgebra/Comodule/Hom.lean
+++ b/TauCeti/Algebra/Coalgebra/Comodule/Hom.lean
@@ -129,6 +129,8 @@ instance instAddCommMonoid : AddCommMonoid (Hom R C M N) where
     rw [show (Nat.succ n • f : Hom R C M N) = f + n • f from rfl]
     rw [add_apply, add_apply, add_comm]
 
+/-- The map sending a comodule morphism to its underlying linear map, bundled as an
+additive monoid homomorphism. -/
 @[expose] def toLinearMapAddMonoidHom : Hom R C M N →+ M →ₗ[R] N where
   toFun f := f.toLinearMap
   map_zero' := zero_toLinearMap

--- a/TauCeti/Algebra/Coalgebra/Comodule/Trivial.lean
+++ b/TauCeti/Algebra/Coalgebra/Comodule/Trivial.lean
@@ -63,6 +63,9 @@ section GroupLikeDef
 
 variable [AddCommMonoid C] [Module R C] [Coalgebra R C]
 
+/-- The map `m ↦ m ⊗ g` attached to a group-like element `g : GroupLike R C`, as an
+`R`-linear map `M →ₗ[R] M ⊗[R] C`. It serves as the coaction of the comodule structure
+`Comodule.groupLike g`. -/
 def groupLikeCoact (g : GroupLike R C) : M →ₗ[R] M ⊗[R] C :=
   (TensorProduct.mk R M C).flip (g : C)
 


### PR DESCRIPTION
This PR add docstrings to the two remaining undocumented public definitions under `TauCeti/Algebra/`: `TauCeti.Comodule.groupLikeCoact` (the linear map `m ↦ m ⊗ g` serving as the coaction of the group-like comodule structure) and `TauCeti.Comodule.Hom.toLinearMapAddMonoidHom` (the bundled additive monoid homomorphism taking a comodule morphism to its underlying linear map).

From a docBlame linter sweep that flagged 435 declarations repo-wide; on current main all but these two of the in-scope (`Algebra`, `NumberTheory`, `Analysis`, `Probability`) declarations are already documented, so no NumberTheory/Analysis/Probability PRs are needed. Neither declaration was made private: both sit in `@[expose] public section`s and are referenced by public definitions in their files.

🤖 Prepared with Claude Code