### PR TITLE
doc: document Deck.addRightZMultiplesHom in UniversalCover/AddCircle

### DIFF
--- a/TauCeti/AlgebraicTopology/UniversalCover/AddCircle.lean
+++ b/TauCeti/AlgebraicTopology/UniversalCover/AddCircle.lean
@@ -123,6 +123,9 @@ theorem addCircleCoe_eq_add_apply_zero [PreconnectedSpace 𝕜]
   rw [sub_zero, sub_eq_iff_eq_add] at h
   rw [h, add_comm]
 
+/-- Right translation by elements of the period subgroup, as a monoid homomorphism from the
+multiplicatively written `zmultiples p` to the deck transformation group of
+`(↑) : 𝕜 → AddCircle p`. This bundles `addRightZMultiples`. -/
 @[expose] def addRightZMultiplesHom :
     Multiplicative (zmultiples p) →* Deck ((↑) : 𝕜 → AddCircle p) where
   toFun a := addRightZMultiples a.toAdd


### PR DESCRIPTION
This PR adds a docstring to `TauCeti.Deck.addRightZMultiplesHom`, the only public definition in `TauCeti/AlgebraicTopology/` still missing one: it packages right translation by the period subgroup as a monoid homomorphism into the deck transformation group of `(↑) : 𝕜 → AddCircle p`.

Part of the docBlame linter sweep over `TauCeti/AlgebraicTopology/`; the remaining declarations flagged by the sweep in this directory are already documented on current main (1 documented here / 0 made private).

🤖 Prepared with Claude Code