### PR TITLE
fix: delete the vacuous AlmostComplexStructure.coe_toLinearMap lemma

### DIFF
--- a/TauCeti/Geometry/Symplectic/AlmostComplex.lean
+++ b/TauCeti/Geometry/Symplectic/AlmostComplex.lean
@@ -70,10 +70,6 @@ theorem toLinearMap_injective :
 instance : CoeFun (AlmostComplexStructure V) fun _ => V → V :=
   ⟨fun J => J.toLinearMap⟩
 
-@[simp]
-lemma coe_toLinearMap (J : AlmostComplexStructure V) :
-    ⇑J.toLinearMap = J := rfl
-
 /-- Applying `J` twice gives `-v`. -/
 @[simp]
 lemma apply_apply (J : AlmostComplexStructure V) (v : V) : J (J v) = -v := by


### PR DESCRIPTION
This PR delete `TauCeti.AlmostComplexStructure.coe_toLinearMap`, flagged by the `synTaut` linter ("LHS equals RHS syntactically"). `AlmostComplexStructure` uses a plain `CoeFun` instance rather than `FunLike`, so the RHS `J` in function position elaborates to exactly `⇑J.toLinearMap`: the lemma is `a = a` after elaboration, and as a `@[simp]` lemma it never rewrites anything. There is no second coercion whose relationship it could have been intended to state, and nothing in the library uses it, so deletion (rather than a restatement) is the fix. The sibling `SymplecticForm` in the same file already has no such lemma.

Full `lake build` and `scripts/lint-simp-nf.sh` are green.

🤖 Prepared with Claude Code