### PR TITLE
fix: drop simp from dvd_primeDiscriminant_iff_dvd_radicand

### DIFF
--- a/TauCeti/NumberTheory/Multiquadratic/PrimeDiscriminants.lean
+++ b/TauCeti/NumberTheory/Multiquadratic/PrimeDiscriminants.lean
@@ -162,8 +162,8 @@ variable {q : ℕ} [Fact q.Prime]
 
 /-- Away from `2`, divisibility of an integer is the same as divisibility of its associated
 prime-discriminant radicand. In the even-prime cases the two differ by the square factor
-`4`; in all other cases they are equal. -/
-@[simp]
+`4`; in all other cases they are equal. Not a `simp` lemma: the right-hand side is again of
+the form `(q : ℤ) ∣ _`, so as a rewrite rule it matches its own output and loops. -/
 theorem dvd_primeDiscriminant_iff_dvd_radicand (D : ℤ) (hq : q ≠ 2) :
     (q : ℤ) ∣ D ↔ (q : ℤ) ∣ primeDiscriminantRadicand D := by
   have hq2 : ¬ (q : ℤ) ∣ (2 : ℤ) := by


### PR DESCRIPTION
This PR remove the `@[simp]` attribute from `TauCeti.Multiquadratic.dvd_primeDiscriminant_iff_dvd_radicand`, flagged by the `simpComm` linter. The right-hand side `(q : ℤ) ∣ primeDiscriminantRadicand D` is again an instance of the left-hand-side pattern `(q : ℤ) ∣ _`, so as a rewrite rule the lemma matches its own output and loops. The lemma itself stays (its one consumer, `forall_not_dvd_primeDiscriminant_iff_radicand`, applies it by name), and the docstring now records why it must not be `simp`.

Full `lake build` and `scripts/lint-simp-nf.sh` are green. The script now reports the declaration's `scripts/simp-nf-baseline.txt` entry as ratchetable; the baseline is human-owned, so deleting that line is left to a follow-up on the CI side.

🤖 Prepared with Claude Code