### PR TITLE
fix: name the convolution Inv instance instInv

### DIFF
--- a/TauCeti/Algebra/AlgebraicGroup/FunctorOfPoints.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/FunctorOfPoints.lean
@@ -86,7 +86,7 @@ private lemma toLinearMap_antipodeComp (f : H →ₐ[R] A) :
 
 /-- The convolution inverse of an `R`-algebra homomorphism `f : H →ₐ[R] A` out of a Hopf
 algebra is `f ∘ S`, where `S` is the antipode. -/
-noncomputable instance : Inv (WithConv (H →ₐ[R] A)) where
+noncomputable instance instInv : Inv (WithConv (H →ₐ[R] A)) where
   inv f := toConv (antipodeComp f.ofConv)
 
 /-- The convolution inverse of `f` is `f ∘ S`, where `S` is the antipode: definitionally,


### PR DESCRIPTION
This PR give the anonymous `Inv (WithConv (H →ₐ[R] A))` instance in `TauCeti/Algebra/AlgebraicGroup/FunctorOfPoints.lean` the explicit name `instInv`. The `defsWithUnderscore` linter flags the auto-generated name `TauCeti.AlgHom.instInvWithConvAlgHom_tauCeti`, whose module-system disambiguation suffix `_tauCeti` contains an underscore. The explicit name follows the file's own `instGroup` / `instCommGroup` convention and the common Mathlib `instInv` spelling.

Full `lake build` and `scripts/lint-simp-nf.sh` are green.

🤖 Prepared with Claude Code