### PR TITLE
feat: finite-horizon reverse-martingale infrastructure

### DIFF
--- a/TauCeti/Probability/Martingale/Reverse.lean
+++ b/TauCeti/Probability/Martingale/Reverse.lean
@@ -1,14 +1,16 @@
 module
 
-public import Mathlib.Probability.Martingale.Basic
+public import Mathlib.Probability.Process.Filtration
+public import Mathlib.MeasureTheory.Function.ConditionalExpectation.Basic
 
 /-!
 # Reverse martingale infrastructure (finite horizon)
 
 Reversing time on a finite horizon `N` turns an antitone family of σ-algebras `𝔽`, and its
-conditional-expectation process `n ↦ μ[f | 𝔽 n]`, into a *forward* filtration and a genuine forward
-martingale. This finite-horizon reversal is the base step of the reverse (Lévy-downward) martingale
-convergence argument.
+conditional-expectation process `n ↦ μ[f | 𝔽 n]`, into a *forward* filtration `revFiltration` on
+which the conditional-expectation process is a genuine forward martingale (via Mathlib's
+`martingale_condExp`). This finite-horizon reversal is the base step of the reverse (Lévy-downward)
+martingale convergence argument.
 
 ## Main definitions
 
@@ -18,8 +20,10 @@ convergence argument.
 
 ## Main results
 
-- `martingale_revCondExpFinite`: the reversed conditional-expectation process is a martingale for
-  `revFiltration`.
+`revFiltration_apply` / `revCondExpFinite_apply` are the `@[simp]` defining equations. The reversed
+process is a forward martingale for `revFiltration` directly via Mathlib's
+`MeasureTheory.martingale_condExp f (revFiltration 𝔽 … N) μ`, so no dedicated finite-horizon
+martingale wrapper is exported here.
 
 Adapted from `cameronfreer/exchangeability` (`Probability/Martingale/Reverse.lean`, pin
 `e0532e59ceff23edab44dda9ab0655debbc9cc22`). Written Mathlib-shaped for eventual upstreaming.
@@ -31,12 +35,10 @@ noncomputable section
 
 open MeasureTheory Filter
 
-open scoped Topology ENNReal
-
 namespace MeasureTheory
 
 variable {Ω : Type*} [MeasurableSpace Ω] {μ : Measure Ω} {𝔽 : ℕ → MeasurableSpace Ω}
-  {E : Type*} [NormedAddCommGroup E] [NormedSpace ℝ E] [CompleteSpace E]
+  {E : Type*} [NormedAddCommGroup E] [NormedSpace ℝ E]
 
 /-- Reverse filtration on a finite horizon `N`: its level `n` is `𝔽 (N - n)`. Used for
 finite-horizon time reversal of an antitone family `𝔽`. -/
@@ -57,7 +59,6 @@ noncomputable def revCondExpFinite (f : Ω → E) (𝔽 : ℕ → MeasurableSpac
     Ω → E :=
   μ[f | 𝔽 (N - n)]
 
-omit [CompleteSpace E] in
 /-- Defining equation for `revCondExpFinite` (whose body is deliberately not `@[expose]`d). -/
 @[simp]
 lemma revCondExpFinite_apply (f : Ω → E) (𝔽 : ℕ → MeasurableSpace Ω) (N n : ℕ) :
@@ -69,19 +70,5 @@ lemma revFiltration_apply (𝔽 : ℕ → MeasurableSpace Ω) (h_antitone : Anti
     (h_le : ∀ n, 𝔽 n ≤ (inferInstance : MeasurableSpace Ω)) (N n : ℕ) :
     (revFiltration 𝔽 h_antitone h_le N) n = 𝔽 (N - n) := by
   simp only [revFiltration]
-
-/-- The reversed conditional-expectation process `revCondExpFinite f 𝔽 N` is a martingale for the
-forward filtration `revFiltration 𝔽 … N`: reversing time on a finite horizon turns the antitone
-conditional-expectation family into a genuine (forward) martingale. -/
-lemma martingale_revCondExpFinite (h_antitone : Antitone 𝔽)
-    (h_le : ∀ n, 𝔽 n ≤ (inferInstance : MeasurableSpace Ω)) (f : Ω → E) (N : ℕ)
-    [SigmaFiniteFiltration μ (revFiltration 𝔽 h_antitone h_le N)] :
-    Martingale (fun n => revCondExpFinite (μ := μ) f 𝔽 N n)
-      (revFiltration 𝔽 h_antitone h_le N) μ := by
-  have hfun : (fun n => revCondExpFinite (μ := μ) f 𝔽 N n)
-      = fun n => μ[f | (revFiltration 𝔽 h_antitone h_le N) n] := by
-    funext n; rw [revCondExpFinite_apply, revFiltration_apply]
-  rw [hfun]
-  exact martingale_condExp f (revFiltration 𝔽 h_antitone h_le N) μ
 
 end MeasureTheory

--- a/TauCeti/Probability/Martingale/Reverse.lean
+++ b/TauCeti/Probability/Martingale/Reverse.lean
@@ -1,0 +1,92 @@
+module
+
+public import Mathlib.Probability.Martingale.Basic
+
+/-!
+# Reverse martingale infrastructure (finite horizon)
+
+Reversing time on a finite horizon `N` turns an antitone family of σ-algebras `𝔽`, and its
+conditional-expectation process `n ↦ μ[f | 𝔽 n]`, into a *forward* filtration and a genuine forward
+martingale. This finite-horizon reversal is the base step of the reverse (Lévy-downward) martingale
+convergence argument.
+
+## Main definitions
+
+- `revFiltration`: the time-reversed filtration on a finite horizon `N` (`k ↦ 𝔽 (N - k)`).
+- `revCondExpFinite`: the time-reversed conditional-expectation process (`n ↦ μ[f | 𝔽 (N - n)]`).
+
+## Main results
+
+- `martingale_revCondExpFinite`: the reversed conditional-expectation process is a martingale for
+  `revFiltration`.
+- `submartingale_revCondExpFinite`: the reversed conditional-expectation process is a submartingale
+  for `revFiltration` (derived from `martingale_revCondExpFinite`).
+
+Adapted from `cameronfreer/exchangeability` (`Probability/Martingale/Reverse.lean`, pin
+`e0532e59ceff23edab44dda9ab0655debbc9cc22`). Written Mathlib-shaped for eventual upstreaming.
+-/
+
+public section
+
+noncomputable section
+
+open MeasureTheory Filter
+
+open scoped Topology ENNReal
+
+namespace ProbabilityTheory
+
+variable {Ω : Type*} [MeasurableSpace Ω] {μ : Measure Ω} {𝔽 : ℕ → MeasurableSpace Ω}
+
+/-- Reverse filtration on a finite horizon `N`: its level `n` is `𝔽 (N - n)`. Used for
+finite-horizon time reversal of an antitone family `𝔽`. -/
+-- This is a (forward, increasing) filtration because `k ≤ ℓ` gives `N - ℓ ≤ N - k`, so
+-- antitonicity of `𝔽` yields `𝔽 (N - k) ≤ 𝔽 (N - ℓ)`.
+def revFiltration (𝔽 : ℕ → MeasurableSpace Ω) (h_antitone : Antitone 𝔽)
+    (h_le : ∀ n, 𝔽 n ≤ (inferInstance : MeasurableSpace Ω))
+    (N : ℕ) : Filtration ℕ (inferInstance : MeasurableSpace Ω) where
+  seq := fun n => 𝔽 (N - n)
+  mono' := by
+    intro i j hij
+    exact h_antitone (tsub_le_tsub_left hij N)
+  le' := fun _ => h_le _
+
+/-- Reverse conditional-expectation process at finite horizon `N`: for `n ≤ N` this is
+`μ[f | 𝔽 (N - n)]`. -/
+noncomputable def revCondExpFinite (f : Ω → ℝ) (𝔽 : ℕ → MeasurableSpace Ω) (N n : ℕ) :
+    Ω → ℝ :=
+  μ[f | 𝔽 (N - n)]
+
+/-- Defining equation for `revCondExpFinite` (whose body is deliberately not `@[expose]`d). -/
+lemma revCondExpFinite_apply (f : Ω → ℝ) (𝔽 : ℕ → MeasurableSpace Ω) (N n : ℕ) :
+    revCondExpFinite (μ := μ) f 𝔽 N n = μ[f | 𝔽 (N - n)] := by rfl
+
+/-- Levels of the reverse filtration: `revFiltration 𝔽 … N` at `n` is `𝔽 (N - n)`. -/
+lemma revFiltration_apply (𝔽 : ℕ → MeasurableSpace Ω) (h_antitone : Antitone 𝔽)
+    (h_le : ∀ n, 𝔽 n ≤ (inferInstance : MeasurableSpace Ω)) (N n : ℕ) :
+    (revFiltration 𝔽 h_antitone h_le N) n = 𝔽 (N - n) := by
+  simp only [revFiltration]
+
+/-- The reversed conditional-expectation process `revCondExpFinite f 𝔽 N` is a martingale for the
+forward filtration `revFiltration 𝔽 … N`: reversing time on a finite horizon turns the antitone
+conditional-expectation family into a genuine (forward) martingale. -/
+lemma martingale_revCondExpFinite [IsFiniteMeasure μ] (h_antitone : Antitone 𝔽)
+    (h_le : ∀ n, 𝔽 n ≤ (inferInstance : MeasurableSpace Ω)) (f : Ω → ℝ) (N : ℕ) :
+    Martingale (fun n => revCondExpFinite (μ := μ) f 𝔽 N n)
+      (revFiltration 𝔽 h_antitone h_le N) μ := by
+  have hfun : (fun n => revCondExpFinite (μ := μ) f 𝔽 N n)
+      = fun n => μ[f | (revFiltration 𝔽 h_antitone h_le N) n] := by
+    funext n; rw [revCondExpFinite_apply, revFiltration_apply]
+  rw [hfun]
+  exact martingale_condExp f (revFiltration 𝔽 h_antitone h_le N) μ
+
+/-- The reversed conditional-expectation process `revCondExpFinite f 𝔽 N` is a submartingale for the
+forward filtration `revFiltration 𝔽 … N`. It is in fact a genuine (forward) martingale; see
+`martingale_revCondExpFinite`. -/
+lemma submartingale_revCondExpFinite [IsFiniteMeasure μ] (h_antitone : Antitone 𝔽)
+    (h_le : ∀ n, 𝔽 n ≤ (inferInstance : MeasurableSpace Ω)) (f : Ω → ℝ) (N : ℕ) :
+    Submartingale (fun n => revCondExpFinite (μ := μ) f 𝔽 N n)
+      (revFiltration 𝔽 h_antitone h_le N) μ :=
+  (martingale_revCondExpFinite h_antitone h_le f N).submartingale
+
+end ProbabilityTheory

--- a/TauCeti/Probability/Martingale/Reverse.lean
+++ b/TauCeti/Probability/Martingale/Reverse.lean
@@ -13,14 +13,13 @@ convergence argument.
 ## Main definitions
 
 - `revFiltration`: the time-reversed filtration on a finite horizon `N` (`k ↦ 𝔽 (N - k)`).
-- `revCondExpFinite`: the time-reversed conditional-expectation process (`n ↦ μ[f | 𝔽 (N - n)]`).
+- `revCondExpFinite`: the time-reversed conditional-expectation process (`n ↦ μ[f | 𝔽 (N - n)]`),
+  for a Banach-space-valued `f`.
 
 ## Main results
 
 - `martingale_revCondExpFinite`: the reversed conditional-expectation process is a martingale for
   `revFiltration`.
-- `submartingale_revCondExpFinite`: the reversed conditional-expectation process is a submartingale
-  for `revFiltration` (derived from `martingale_revCondExpFinite`).
 
 Adapted from `cameronfreer/exchangeability` (`Probability/Martingale/Reverse.lean`, pin
 `e0532e59ceff23edab44dda9ab0655debbc9cc22`). Written Mathlib-shaped for eventual upstreaming.
@@ -34,9 +33,10 @@ open MeasureTheory Filter
 
 open scoped Topology ENNReal
 
-namespace ProbabilityTheory
+namespace MeasureTheory
 
 variable {Ω : Type*} [MeasurableSpace Ω] {μ : Measure Ω} {𝔽 : ℕ → MeasurableSpace Ω}
+  {E : Type*} [NormedAddCommGroup E] [NormedSpace ℝ E] [CompleteSpace E]
 
 /-- Reverse filtration on a finite horizon `N`: its level `n` is `𝔽 (N - n)`. Used for
 finite-horizon time reversal of an antitone family `𝔽`. -/
@@ -52,16 +52,19 @@ def revFiltration (𝔽 : ℕ → MeasurableSpace Ω) (h_antitone : Antitone �
   le' := fun _ => h_le _
 
 /-- Reverse conditional-expectation process at finite horizon `N`: for `n ≤ N` this is
-`μ[f | 𝔽 (N - n)]`. -/
-noncomputable def revCondExpFinite (f : Ω → ℝ) (𝔽 : ℕ → MeasurableSpace Ω) (N n : ℕ) :
-    Ω → ℝ :=
+`μ[f | 𝔽 (N - n)]`, for a Banach-space-valued `f`. -/
+noncomputable def revCondExpFinite (f : Ω → E) (𝔽 : ℕ → MeasurableSpace Ω) (N n : ℕ) :
+    Ω → E :=
   μ[f | 𝔽 (N - n)]
 
+omit [CompleteSpace E] in
 /-- Defining equation for `revCondExpFinite` (whose body is deliberately not `@[expose]`d). -/
-lemma revCondExpFinite_apply (f : Ω → ℝ) (𝔽 : ℕ → MeasurableSpace Ω) (N n : ℕ) :
+@[simp]
+lemma revCondExpFinite_apply (f : Ω → E) (𝔽 : ℕ → MeasurableSpace Ω) (N n : ℕ) :
     revCondExpFinite (μ := μ) f 𝔽 N n = μ[f | 𝔽 (N - n)] := by rfl
 
 /-- Levels of the reverse filtration: `revFiltration 𝔽 … N` at `n` is `𝔽 (N - n)`. -/
+@[simp]
 lemma revFiltration_apply (𝔽 : ℕ → MeasurableSpace Ω) (h_antitone : Antitone 𝔽)
     (h_le : ∀ n, 𝔽 n ≤ (inferInstance : MeasurableSpace Ω)) (N n : ℕ) :
     (revFiltration 𝔽 h_antitone h_le N) n = 𝔽 (N - n) := by
@@ -70,8 +73,9 @@ lemma revFiltration_apply (𝔽 : ℕ → MeasurableSpace Ω) (h_antitone : Anti
 /-- The reversed conditional-expectation process `revCondExpFinite f 𝔽 N` is a martingale for the
 forward filtration `revFiltration 𝔽 … N`: reversing time on a finite horizon turns the antitone
 conditional-expectation family into a genuine (forward) martingale. -/
-lemma martingale_revCondExpFinite [IsFiniteMeasure μ] (h_antitone : Antitone 𝔽)
-    (h_le : ∀ n, 𝔽 n ≤ (inferInstance : MeasurableSpace Ω)) (f : Ω → ℝ) (N : ℕ) :
+lemma martingale_revCondExpFinite (h_antitone : Antitone 𝔽)
+    (h_le : ∀ n, 𝔽 n ≤ (inferInstance : MeasurableSpace Ω)) (f : Ω → E) (N : ℕ)
+    [SigmaFiniteFiltration μ (revFiltration 𝔽 h_antitone h_le N)] :
     Martingale (fun n => revCondExpFinite (μ := μ) f 𝔽 N n)
       (revFiltration 𝔽 h_antitone h_le N) μ := by
   have hfun : (fun n => revCondExpFinite (μ := μ) f 𝔽 N n)
@@ -80,13 +84,4 @@ lemma martingale_revCondExpFinite [IsFiniteMeasure μ] (h_antitone : Antitone �
   rw [hfun]
   exact martingale_condExp f (revFiltration 𝔽 h_antitone h_le N) μ
 
-/-- The reversed conditional-expectation process `revCondExpFinite f 𝔽 N` is a submartingale for the
-forward filtration `revFiltration 𝔽 … N`. It is in fact a genuine (forward) martingale; see
-`martingale_revCondExpFinite`. -/
-lemma submartingale_revCondExpFinite [IsFiniteMeasure μ] (h_antitone : Antitone 𝔽)
-    (h_le : ∀ n, 𝔽 n ≤ (inferInstance : MeasurableSpace Ω)) (f : Ω → ℝ) (N : ℕ) :
-    Submartingale (fun n => revCondExpFinite (μ := μ) f 𝔽 N n)
-      (revFiltration 𝔽 h_antitone h_le N) μ :=
-  (martingale_revCondExpFinite h_antitone h_le f N).submartingale
-
-end ProbabilityTheory
+end MeasureTheory

--- a/TauCeti/Probability/Martingale/Reverse.lean
+++ b/TauCeti/Probability/Martingale/Reverse.lean
@@ -37,7 +37,7 @@ open MeasureTheory Filter
 
 namespace MeasureTheory
 
-variable {Ω : Type*} [MeasurableSpace Ω] {μ : Measure Ω} {𝔽 : ℕ → MeasurableSpace Ω}
+variable {Ω : Type*} {m0 : MeasurableSpace Ω} {μ : Measure[m0] Ω} {𝔽 : ℕ → MeasurableSpace Ω}
   {E : Type*} [NormedAddCommGroup E] [NormedSpace ℝ E]
 
 /-- Reverse filtration on a finite horizon `N`: its level `n` is `𝔽 (N - n)`. Used for
@@ -45,8 +45,8 @@ finite-horizon time reversal of an antitone family `𝔽`. -/
 -- This is a (forward, increasing) filtration because `k ≤ ℓ` gives `N - ℓ ≤ N - k`, so
 -- antitonicity of `𝔽` yields `𝔽 (N - k) ≤ 𝔽 (N - ℓ)`.
 def revFiltration (𝔽 : ℕ → MeasurableSpace Ω) (h_antitone : Antitone 𝔽)
-    (h_le : ∀ n, 𝔽 n ≤ (inferInstance : MeasurableSpace Ω))
-    (N : ℕ) : Filtration ℕ (inferInstance : MeasurableSpace Ω) where
+    (h_le : ∀ n, 𝔽 n ≤ m0)
+    (N : ℕ) : Filtration ℕ m0 where
   seq := fun n => 𝔽 (N - n)
   mono' := by
     intro i j hij
@@ -67,7 +67,7 @@ lemma revCondExpFinite_apply (f : Ω → E) (𝔽 : ℕ → MeasurableSpace Ω) 
 /-- Levels of the reverse filtration: `revFiltration 𝔽 … N` at `n` is `𝔽 (N - n)`. -/
 @[simp]
 lemma revFiltration_apply (𝔽 : ℕ → MeasurableSpace Ω) (h_antitone : Antitone 𝔽)
-    (h_le : ∀ n, 𝔽 n ≤ (inferInstance : MeasurableSpace Ω)) (N n : ℕ) :
+    (h_le : ∀ n, 𝔽 n ≤ m0) (N n : ℕ) :
     (revFiltration 𝔽 h_antitone h_le N) n = 𝔽 (N - n) := by
   simp only [revFiltration]
 

--- a/TauCeti/Probability/Martingale/Reverse.lean
+++ b/TauCeti/Probability/Martingale/Reverse.lean
@@ -1,7 +1,6 @@
 module
 
-public import Mathlib.Probability.Process.Filtration
-public import Mathlib.MeasureTheory.Function.ConditionalExpectation.Basic
+public import Mathlib.Probability.Martingale.Basic
 
 /-!
 # Reverse martingale infrastructure (finite horizon)
@@ -15,15 +14,15 @@ martingale convergence argument.
 ## Main definitions
 
 - `revFiltration`: the time-reversed filtration on a finite horizon `N` (`k ↦ 𝔽 (N - k)`).
-- `revCondExpFinite`: the time-reversed conditional-expectation process (`n ↦ μ[f | 𝔽 (N - n)]`),
+- `revCEFinite`: the time-reversed conditional-expectation process (`n ↦ μ[f | 𝔽 (N - n)]`),
   for a Banach-space-valued `f`.
 
 ## Main results
 
-`revFiltration_apply` / `revCondExpFinite_apply` are the `@[simp]` defining equations. The reversed
-process is a forward martingale for `revFiltration` directly via Mathlib's
-`MeasureTheory.martingale_condExp f (revFiltration 𝔽 … N) μ`, so no dedicated finite-horizon
-martingale wrapper is exported here.
+- `revCEFinite_martingale`: the reversed conditional-expectation process is a forward martingale for
+  `revFiltration` (the finite-horizon reversal adapter for Mathlib's `martingale_condExp`).
+
+`revFiltration_apply` / `revCEFinite_apply` are the `@[simp]` defining equations.
 
 Adapted from `cameronfreer/exchangeability` (`Probability/Martingale/Reverse.lean`, pin
 `e0532e59ceff23edab44dda9ab0655debbc9cc22`). Written Mathlib-shaped for eventual upstreaming.
@@ -38,7 +37,7 @@ open MeasureTheory Filter
 namespace MeasureTheory
 
 variable {Ω : Type*} {m0 : MeasurableSpace Ω} {μ : Measure[m0] Ω} {𝔽 : ℕ → MeasurableSpace Ω}
-  {E : Type*} [NormedAddCommGroup E] [NormedSpace ℝ E]
+  {E : Type*} [NormedAddCommGroup E] [NormedSpace ℝ E] [CompleteSpace E]
 
 /-- Reverse filtration on a finite horizon `N`: its level `n` is `𝔽 (N - n)`. Used for
 finite-horizon time reversal of an antitone family `𝔽`. -/
@@ -55,14 +54,15 @@ def revFiltration (𝔽 : ℕ → MeasurableSpace Ω) (h_antitone : Antitone �
 
 /-- Reverse conditional-expectation process at finite horizon `N`: for `n ≤ N` this is
 `μ[f | 𝔽 (N - n)]`, for a Banach-space-valued `f`. -/
-noncomputable def revCondExpFinite (f : Ω → E) (𝔽 : ℕ → MeasurableSpace Ω) (N n : ℕ) :
+noncomputable def revCEFinite (f : Ω → E) (𝔽 : ℕ → MeasurableSpace Ω) (N n : ℕ) :
     Ω → E :=
   μ[f | 𝔽 (N - n)]
 
-/-- Defining equation for `revCondExpFinite` (whose body is deliberately not `@[expose]`d). -/
+omit [CompleteSpace E] in
+/-- Defining equation for `revCEFinite` (whose body is deliberately not `@[expose]`d). -/
 @[simp]
-lemma revCondExpFinite_apply (f : Ω → E) (𝔽 : ℕ → MeasurableSpace Ω) (N n : ℕ) :
-    revCondExpFinite (μ := μ) f 𝔽 N n = μ[f | 𝔽 (N - n)] := by rfl
+lemma revCEFinite_apply (f : Ω → E) (𝔽 : ℕ → MeasurableSpace Ω) (N n : ℕ) :
+    revCEFinite (μ := μ) f 𝔽 N n = μ[f | 𝔽 (N - n)] := by rfl
 
 /-- Levels of the reverse filtration: `revFiltration 𝔽 … N` at `n` is `𝔽 (N - n)`. -/
 @[simp]
@@ -70,5 +70,14 @@ lemma revFiltration_apply (𝔽 : ℕ → MeasurableSpace Ω) (h_antitone : Anti
     (h_le : ∀ n, 𝔽 n ≤ m0) (N n : ℕ) :
     (revFiltration 𝔽 h_antitone h_le N) n = 𝔽 (N - n) := by
   simp only [revFiltration]
+
+/-- Finite-horizon reversal adapter for Mathlib's `martingale_condExp`: the reversed
+conditional-expectation process `revCEFinite … N` is a genuine (forward) martingale for the forward
+filtration `revFiltration 𝔽 … N`. -/
+theorem revCEFinite_martingale (h_antitone : Antitone 𝔽) (h_le : ∀ n, 𝔽 n ≤ m0) (f : Ω → E)
+    (N : ℕ) [SigmaFiniteFiltration μ (revFiltration 𝔽 h_antitone h_le N)] :
+    Martingale (fun n => revCEFinite (μ := μ) f 𝔽 N n) (revFiltration 𝔽 h_antitone h_le N) μ := by
+  simpa only [revCEFinite_apply, revFiltration_apply] using
+    martingale_condExp f (revFiltration 𝔽 h_antitone h_le N) μ
 
 end MeasureTheory


### PR DESCRIPTION
<!--tauceti-target:v1 {"focus":"Exchangeability","id":"reverse-martingale-finite-horizon"}-->

## Summary

Adds `TauCeti/Probability/Martingale/Reverse.lean` — the **finite-horizon reversal** targets of
`TauCetiRoadmap/Exchangeability` **Layer 4** (roadmap-named `revFiltration` / `revCEFinite` /
`revCEFinite_martingale`, suggested home this exact file):

- `revFiltration 𝔽 … N` — the time-reversed filtration on horizon `N` (level `n` is `𝔽 (N - n)`);
  a *forward* `Filtration ℕ m0` because `𝔽` is antitone.
- `revCEFinite f 𝔽 N` — the reversed conditional-expectation process (`n ↦ μ[f | 𝔽 (N - n)]`) for a
  Banach-valued `f : Ω → E`.
- `revCEFinite_martingale` — the reversed process is a forward **martingale** for `revFiltration`; a
  thin finite-horizon-reversal adapter over Mathlib's `martingale_condExp`.
- `@[simp]` defining equations `revFiltration_apply` / `revCEFinite_apply`.

## Roadmap

Directly builds the Layer-4 "finite-horizon reversal" deliverables named in
`TauCetiRoadmap/Exchangeability/README.md` (`revFiltration`, `revCEFinite`, `revCEFinite_martingale`).
Mathlib supplies the upward/forward martingale API; this file builds only the reversal that the
antitone-upcrossing adapter and the `⨅ n, 𝔽 n` identification consume.

## How it's proved (reuse)

`revFiltration` is a `Filtration` from antitonicity of `𝔽`; `revCEFinite` is `condExp` along it; and
`revCEFinite_martingale` is a direct adapter over `MeasureTheory.martingale_condExp f
(revFiltration 𝔽 … N) μ` (rewriting the process to `fun n => μ[f | (revFiltration …) n]` via the
`@[simp]` `_apply` lemmas). No new martingale theory.

## Generality / naming (review response)

- **generality:** Banach-valued `E` (`[NormedAddCommGroup E] [NormedSpace ℝ E] [CompleteSpace E]`);
  the ambient measurable space is an **explicit** `{m0 : MeasurableSpace Ω}` with `μ : Measure[m0] Ω`
  and `revFiltration … : Filtration ℕ m0`, matching Mathlib's `Filtration`/`condExp` signatures.
- **naming:** roadmap names `revFiltration` / `revCEFinite` / `revCEFinite_martingale`; `namespace
  MeasureTheory` (matching Mathlib's `Filtration`/`Martingale`/`condExp`).
- **api-design:** `@[simp]` on both `_apply` defining equations; `revCEFinite_martingale` is the
  public characteristic bridge (the roadmap's Layer-4 target).
- **imports:** single `public import Mathlib.Probability.Martingale.Basic` (re-exports `Filtration`,
  `condExp`, `Martingale`).

## Test plan
```bash
lake build && lake exe axioms && lake exe module-system && bash scripts/lint-env.sh
```
All pass; sorry-free; `revCEFinite_martingale` axioms ⊆ {`propext`, `Classical.choice`, `Quot.sound`};
lines ≤100; module-system opts in.

## Attribution
Adapted from `cameronfreer/exchangeability` (`Probability/Martingale/Reverse.lean`, pin
`e0532e59ceff23edab44dda9ab0655debbc9cc22`), reworked into TauCeti's module system and stated
Mathlib-shaped for eventual upstreaming. Drafted with Claude (Opus 4.8), human-directed.
