### PR TITLE
feat: time-reversal crossing bound

### DIFF
--- a/TauCeti/Probability/Martingale/Crossings/TimeReversal.lean
+++ b/TauCeti/Probability/Martingale/Crossings/TimeReversal.lean
@@ -41,6 +41,13 @@ def revProcess {Ω α : Type*} (X : ℕ → Ω → α) (N : ℕ) : ℕ → Ω �
 lemma revProcess_apply {Ω α : Type*} (X : ℕ → Ω → α) (N n : ℕ) (ω : Ω) :
     revProcess X N n ω = X (N - n) ω := by rfl
 
+/-- Package `hittingBtwn_le_of_mem` for `lowerCrossingTime`: if the process value at time `i` lies
+in `Set.Iic a` and `i` sits between the `n`-th upper-crossing time and the horizon `N`, then the
+`n`-th lower-crossing time is at most `i`. -/
+private lemma lowerCrossingTime_le_of_mem {Ω : Type*} {a b : ℝ} {Z : ℕ → Ω → ℝ} {N n i : ℕ}
+    {ω : Ω} (hui : upperCrossingTime a b Z N n ω ≤ i) (hiN : i ≤ N)
+    (his : Z i ω ∈ Set.Iic a) : lowerCrossingTime a b Z N n ω ≤ i := by
+  simpa only [lowerCrossingTime] using hittingBtwn_le_of_mem hui hiN his
 
 /-- Strong version tracking the bijection explicitly.
 
@@ -115,8 +122,8 @@ private lemma upperCrossingTime_neg_revProcess_le_strong
       simp only [hY_def, Pi.neg_apply, revProcess_apply, Nat.sub_sub_self (Nat.le_of_lt hτ_lt_N)]
       linarith
     -- lowerCrossingTime X j ≥ σ (hitting starts from σ)
-    have h_lct_ge : lowerCrossingTime a b X N j ω ≥ σ := by
-      simpa [lowerCrossingTime, hσ_def] using le_hittingBtwn (Nat.le_of_lt hσ_lt_N) ω
+    have h_lct_ge : lowerCrossingTime a b X N j ω ≥ σ :=
+      hσ_def ▸ upperCrossingTime_le_lowerCrossingTime
     -- From IH: upperCrossingTime Y m' ≤ N - lowerCrossingTime X j ≤ N - σ
     have h_uct_le_Nσ : upperCrossingTime (-b) (-a) Y (N + 1) m' ω ≤ N - σ := by
       calc upperCrossingTime (-b) (-a) Y (N + 1) m' ω
@@ -125,9 +132,8 @@ private lemma upperCrossingTime_neg_revProcess_le_strong
     -- lowerCrossingTime Y m' ≤ N - σ (by hittingBtwn_le_of_mem)
     have h_Nσ_le_N1 : N - σ ≤ N + 1 := Nat.le_succ_of_le (Nat.sub_le N σ)
     have hY_Nσ_in_Iic : Y (N - σ) ω ∈ Set.Iic (-b) := hY_Nσ_le_negb
-    have h_lctY_le_Nσ : lowerCrossingTime (-b) (-a) Y (N + 1) m' ω ≤ N - σ := by
-      simpa [lowerCrossingTime] using
-        hittingBtwn_le_of_mem h_uct_le_Nσ h_Nσ_le_N1 hY_Nσ_in_Iic
+    have h_lctY_le_Nσ : lowerCrossingTime (-b) (-a) Y (N + 1) m' ω ≤ N - σ :=
+      lowerCrossingTime_le_of_mem h_uct_le_Nσ h_Nσ_le_N1 hY_Nσ_in_Iic
     -- N - σ < N - τ and lowerCrossingTime Y m' < N - τ
     have hNσ_lt_Nτ : N - σ < N - τ := Nat.sub_lt_sub_left hτ_lt_N hτ_lt_σ
     have h_lctY_le_Nτ : lowerCrossingTime (-b) (-a) Y (N + 1) m' ω ≤ N - τ :=

--- a/TauCeti/Probability/Martingale/Crossings/TimeReversal.lean
+++ b/TauCeti/Probability/Martingale/Crossings/TimeReversal.lean
@@ -6,8 +6,7 @@ public import Mathlib.Probability.Martingale.Upcrossing
 # Time-reversal crossing bound
 
 Reverse-martingale infrastructure bounding the completion time of upcrossings in a time-reversed,
-negated process. This is the combinatorial ingredient feeding the pathwise crossing adapter in
-`Crossings/Pathwise.lean`.
+negated process. This is a combinatorial ingredient of the reverse-martingale upcrossing argument.
 
 ## Main definitions
 
@@ -15,7 +14,7 @@ negated process. This is the combinatorial ingredient feeding the pathwise cross
 
 ## Main results
 
-- `upperCrossingTime_negProcess_revProcess_le`: for a process `X` with `k` upcrossings `[a→b]`
+- `upperCrossingTime_neg_revProcess_le`: for a process `X` with `k` upcrossings `[a→b]`
   completing before time `N`, the time-reversed negated process `-(revProcess X N)` has
   its `k`-th upcrossing `[-b→-a]` completing at time `≤ N`.
 
@@ -34,11 +33,12 @@ open scoped ENNReal
 namespace ProbabilityTheory
 
 /-- Time reversal of a stochastic process up to time `N`. -/
-def revProcess {Ω : Type*} (X : ℕ → Ω → ℝ) (N : ℕ) : ℕ → Ω → ℝ :=
+def revProcess {Ω α : Type*} (X : ℕ → Ω → α) (N : ℕ) : ℕ → Ω → α :=
   fun n ω => X (N - n) ω
 
 /-- Defining equation for `revProcess` (whose body is deliberately not `@[expose]`d). -/
-lemma revProcess_apply {Ω : Type*} (X : ℕ → Ω → ℝ) (N n : ℕ) (ω : Ω) :
+@[simp]
+lemma revProcess_apply {Ω α : Type*} (X : ℕ → Ω → α) (N n : ℕ) (ω : Ω) :
     revProcess X N n ω = X (N - n) ω := by rfl
 
 
@@ -49,7 +49,7 @@ For `m ≤ k` with `X`'s `k`-th crossing completing before `N`:
 
 This captures that `Y`'s `m`-th crossing corresponds to `X`'s `(k - m + 1)`-th crossing (reversed
 order), with `Y`'s crossing ending at time `N - τ` where `τ` is the start of `X`'s crossing. -/
-private lemma upperCrossingTime_negProcess_revProcess_le_strong
+private lemma upperCrossingTime_neg_revProcess_le_strong
     {Ω : Type*} (X : ℕ → Ω → ℝ) (a b : ℝ) (hab : a < b) (N k m : ℕ) (ω : Ω)
     (hm : m ≤ k)
     (h_k : upperCrossingTime a b X N k ω < N) :
@@ -109,10 +109,10 @@ private lemma upperCrossingTime_negProcess_revProcess_le_strong
       stoppedValue_lowerCrossingTime (f := X) (n := j - 1) h_neq_τ
     -- Y's level conditions at bijected times
     have hY_Nσ_le_negb : Y (N - σ) ω ≤ -b := by
-      simp only [hY_def, Pi.neg_apply, revProcess, Nat.sub_sub_self (Nat.le_of_lt hσ_lt_N)]
+      simp only [hY_def, Pi.neg_apply, revProcess_apply, Nat.sub_sub_self (Nat.le_of_lt hσ_lt_N)]
       linarith
     have hY_Nτ_ge_nega : Y (N - τ) ω ≥ -a := by
-      simp only [hY_def, Pi.neg_apply, revProcess, Nat.sub_sub_self (Nat.le_of_lt hτ_lt_N)]
+      simp only [hY_def, Pi.neg_apply, revProcess_apply, Nat.sub_sub_self (Nat.le_of_lt hτ_lt_N)]
       linarith
     -- lowerCrossingTime X j ≥ σ (hitting starts from σ)
     have h_lct_ge : lowerCrossingTime a b X N j ω ≥ σ := by
@@ -136,8 +136,8 @@ private lemma upperCrossingTime_negProcess_revProcess_le_strong
     have hY_Nτ_in_Ici : Y (N - τ) ω ∈ Set.Ici (-a) := hY_Nτ_ge_nega
     -- Final: upperCrossingTime Y (m' + 1) ≤ N - τ
     calc upperCrossingTime (-b) (-a) Y (N + 1) (m' + 1) ω
-        = hittingBtwn Y (Set.Ici (-a)) (lowerCrossingTime (-b) (-a) Y (N + 1) m' ω) (N + 1) ω := by
-          simp only [upperCrossingTime, lowerCrossingTime]; rfl
+        = hittingBtwn Y (Set.Ici (-a)) (lowerCrossingTime (-b) (-a) Y (N + 1) m' ω) (N + 1) ω :=
+          upperCrossingTime_succ_eq ω
       _ ≤ N - τ := hittingBtwn_le_of_mem h_lctY_le_Nτ h_Nτ_le_N1 hY_Nτ_in_Ici
 
 /-- **Time-reversal crossing bound.**
@@ -145,13 +145,13 @@ private lemma upperCrossingTime_negProcess_revProcess_le_strong
 For a process `X` with `k` upcrossings `[a→b]` completing before time `N`, the time-reversed
 negated process `-(revProcess X N)` has its `k`-th upcrossing `[-b→-a]` completing at
 time `≤ N`. -/
-lemma upperCrossingTime_negProcess_revProcess_le
+lemma upperCrossingTime_neg_revProcess_le
     {Ω : Type*} (X : ℕ → Ω → ℝ) (a b : ℝ) (hab : a < b) (N k : ℕ) (ω : Ω)
     (h_k : upperCrossingTime a b X N k ω < N) :
     upperCrossingTime (-b) (-a) (-(revProcess X N)) (N + 1) k ω ≤ N := by
   -- The `strong` version bounds this by `N - lowerCrossingTime …` via the bijection
   -- `(τ, σ) ↦ (N - σ, N - τ)`; discard the subtraction with `Nat.sub_le`.
-  have h := upperCrossingTime_negProcess_revProcess_le_strong X a b hab N k k ω le_rfl h_k
+  have h := upperCrossingTime_neg_revProcess_le_strong X a b hab N k k ω le_rfl h_k
   exact le_trans (by simpa using h) (Nat.sub_le N _)
 
 end ProbabilityTheory

--- a/TauCeti/Probability/Martingale/Crossings/TimeReversal.lean
+++ b/TauCeti/Probability/Martingale/Crossings/TimeReversal.lean
@@ -1,0 +1,166 @@
+module
+
+public import Mathlib.Probability.Martingale.Upcrossing
+
+/-!
+# Time-reversal crossing bound
+
+Reverse-martingale infrastructure bounding the completion time of upcrossings in a time-reversed,
+negated process. This is the combinatorial ingredient feeding the pathwise crossing adapter in
+`Crossings/Pathwise.lean`.
+
+## Main definitions
+
+- `negProcess`: negation of a stochastic process.
+- `revProcess`: time reversal of a stochastic process up to a horizon `N`.
+
+## Main results
+
+- `upperCrossingTime_negProcess_revProcess_le`: for a process `X` with `k` upcrossings `[a→b]`
+  completing before time `N`, the time-reversed negated process `negProcess (revProcess X N)` has
+  its `k`-th upcrossing `[-b→-a]` completing at time `≤ N`.
+
+Adapted from `cameronfreer/exchangeability` (`Probability/TimeReversalCrossing.lean`, pin
+`e0532e59ceff23edab44dda9ab0655debbc9cc22`). Written Mathlib-shaped for eventual upstreaming.
+-/
+
+public section
+
+noncomputable section
+
+open MeasureTheory
+
+open scoped ENNReal
+
+namespace ProbabilityTheory
+
+/-- Negation of a stochastic process. -/
+def negProcess {Ω : Type*} (X : ℕ → Ω → ℝ) : ℕ → Ω → ℝ :=
+  fun n ω => -X n ω
+
+/-- Time reversal of a stochastic process up to time `N`. -/
+def revProcess {Ω : Type*} (X : ℕ → Ω → ℝ) (N : ℕ) : ℕ → Ω → ℝ :=
+  fun n ω => X (N - n) ω
+
+/-- Defining equation for `negProcess` (whose body is deliberately not `@[expose]`d). -/
+lemma negProcess_apply {Ω : Type*} (X : ℕ → Ω → ℝ) (n : ℕ) (ω : Ω) :
+    negProcess X n ω = -X n ω := by rfl
+
+/-- Defining equation for `revProcess` (whose body is deliberately not `@[expose]`d). -/
+lemma revProcess_apply {Ω : Type*} (X : ℕ → Ω → ℝ) (N n : ℕ) (ω : Ω) :
+    revProcess X N n ω = X (N - n) ω := by rfl
+
+
+/-- Strong version tracking the bijection explicitly.
+
+For `m ≤ k` with `X`'s `k`-th crossing completing before `N`:
+  `upperCrossingTime Y (N + 1) m ≤ N - lowerCrossingTime X (k - m)`.
+
+This captures that `Y`'s `m`-th crossing corresponds to `X`'s `(k - m + 1)`-th crossing (reversed
+order), with `Y`'s crossing ending at time `N - τ` where `τ` is the start of `X`'s crossing. -/
+private lemma upperCrossingTime_negProcess_revProcess_le_strong
+    {Ω : Type*} (X : ℕ → Ω → ℝ) (a b : ℝ) (hab : a < b) (N k m : ℕ) (ω : Ω)
+    (hm : m ≤ k)
+    (h_k : upperCrossingTime a b X N k ω < N) :
+    upperCrossingTime (-b) (-a) (negProcess (revProcess X N)) (N + 1) m ω
+      ≤ N - lowerCrossingTime a b X N (k - m) ω := by
+  set Y := negProcess (revProcess X N) with hY_def
+  -- All of X's crossing times are < N
+  have h_j : ∀ j ≤ k, upperCrossingTime a b X N j ω < N := by
+    intro j hj
+    calc upperCrossingTime a b X N j ω
+        ≤ upperCrossingTime a b X N k ω := upperCrossingTime_mono hj
+      _ < N := h_k
+  have h_τ_lt : ∀ j < k, lowerCrossingTime a b X N j ω < N := by
+    intro j hj
+    have h_j1 : j + 1 ≤ k := hj
+    have h_uct : upperCrossingTime a b X N (j + 1) ω < N := h_j (j + 1) h_j1
+    exact lt_trans (lowerCrossingTime_lt_upperCrossingTime hab (Nat.ne_of_lt h_uct)) h_uct
+  induction m with
+  | zero =>
+    simp only [upperCrossingTime_zero, Nat.sub_zero]
+    exact Nat.zero_le _
+  | succ m' ih =>
+    have hm'_lt_k : m' < k := Nat.lt_of_succ_le hm
+    have hm' : m' ≤ k := Nat.le_of_lt hm'_lt_k
+    set j := k - m' with hj_def
+    have hj_pos : 1 ≤ j := by omega
+    have hj_le_k : j ≤ k := Nat.sub_le k m'
+    have h_km1_eq : k - (m' + 1) = j - 1 := by omega
+    have ih' := ih hm'
+    -- X's j-th crossing times
+    set σ := upperCrossingTime a b X N j ω with hσ_def
+    set τ := lowerCrossingTime a b X N (j - 1) ω with hτ_def
+    have hσ_lt_N : σ < N := h_j j hj_le_k
+    have hτ_lt_N : τ < N := by
+      have h : j - 1 < k := by omega
+      exact h_τ_lt (j - 1) h
+    -- τ < σ : lowerCrossingTime (j - 1) < upperCrossingTime j
+    have hτ_lt_σ : τ < σ := by
+      have h_j_eq : j = (j - 1) + 1 := by omega
+      have h_uct_lt : upperCrossingTime a b X N ((j - 1) + 1) ω < N := by
+        simp only [← h_j_eq]; exact hσ_lt_N
+      have := lowerCrossingTime_lt_upperCrossingTime hab (Nat.ne_of_lt h_uct_lt)
+      simp only [← hτ_def, ← hσ_def, ← h_j_eq] at this
+      exact this
+    rw [h_km1_eq]
+    -- X's level conditions
+    have h_neq_σ : σ ≠ N := Nat.ne_of_lt hσ_lt_N
+    have h_neq_τ : τ ≠ N := Nat.ne_of_lt hτ_lt_N
+    have hX_σ_ge_b : b ≤ X σ ω := by
+      have h_j_eq : j = (j - 1) + 1 := by omega
+      have h_neq_σ' : upperCrossingTime a b X N ((j - 1) + 1) ω ≠ N := by
+        simp only [← h_j_eq]; exact h_neq_σ
+      have h2 := stoppedValue_upperCrossingTime (f := X) (n := j - 1) h_neq_σ'
+      rw [← h_j_eq] at h2
+      exact h2
+    have hX_τ_le_a : X τ ω ≤ a :=
+      stoppedValue_lowerCrossingTime (f := X) (n := j - 1) h_neq_τ
+    -- Y's level conditions at bijected times
+    have hY_Nσ_le_negb : Y (N - σ) ω ≤ -b := by
+      simp only [hY_def, negProcess, revProcess, Nat.sub_sub_self (Nat.le_of_lt hσ_lt_N)]
+      linarith
+    have hY_Nτ_ge_nega : Y (N - τ) ω ≥ -a := by
+      simp only [hY_def, negProcess, revProcess, Nat.sub_sub_self (Nat.le_of_lt hτ_lt_N)]
+      linarith
+    -- lowerCrossingTime X j ≥ σ (hitting starts from σ)
+    have h_lct_ge : lowerCrossingTime a b X N j ω ≥ σ := by
+      simpa [lowerCrossingTime, hσ_def] using le_hittingBtwn (Nat.le_of_lt hσ_lt_N) ω
+    -- From IH: upperCrossingTime Y m' ≤ N - lowerCrossingTime X j ≤ N - σ
+    have h_uct_le_Nσ : upperCrossingTime (-b) (-a) Y (N + 1) m' ω ≤ N - σ := by
+      calc upperCrossingTime (-b) (-a) Y (N + 1) m' ω
+          ≤ N - lowerCrossingTime a b X N j ω := ih'
+        _ ≤ N - σ := Nat.sub_le_sub_left h_lct_ge N
+    -- lowerCrossingTime Y m' ≤ N - σ (by hittingBtwn_le_of_mem)
+    have h_Nσ_le_N1 : N - σ ≤ N + 1 := Nat.le_succ_of_le (Nat.sub_le N σ)
+    have hY_Nσ_in_Iic : Y (N - σ) ω ∈ Set.Iic (-b) := hY_Nσ_le_negb
+    have h_lctY_le_Nσ : lowerCrossingTime (-b) (-a) Y (N + 1) m' ω ≤ N - σ := by
+      simpa [lowerCrossingTime] using
+        hittingBtwn_le_of_mem h_uct_le_Nσ h_Nσ_le_N1 hY_Nσ_in_Iic
+    -- N - σ < N - τ and lowerCrossingTime Y m' < N - τ
+    have hNσ_lt_Nτ : N - σ < N - τ := Nat.sub_lt_sub_left hτ_lt_N hτ_lt_σ
+    have h_lctY_le_Nτ : lowerCrossingTime (-b) (-a) Y (N + 1) m' ω ≤ N - τ :=
+      Nat.le_of_lt (lt_of_le_of_lt h_lctY_le_Nσ hNσ_lt_Nτ)
+    have h_Nτ_le_N1 : N - τ ≤ N + 1 := Nat.le_succ_of_le (Nat.sub_le N τ)
+    have hY_Nτ_in_Ici : Y (N - τ) ω ∈ Set.Ici (-a) := hY_Nτ_ge_nega
+    -- Final: upperCrossingTime Y (m' + 1) ≤ N - τ
+    calc upperCrossingTime (-b) (-a) Y (N + 1) (m' + 1) ω
+        = hittingBtwn Y (Set.Ici (-a)) (lowerCrossingTime (-b) (-a) Y (N + 1) m' ω) (N + 1) ω := by
+          simp only [upperCrossingTime, lowerCrossingTime]; rfl
+      _ ≤ N - τ := hittingBtwn_le_of_mem h_lctY_le_Nτ h_Nτ_le_N1 hY_Nτ_in_Ici
+
+/-- **Time-reversal crossing bound.**
+
+For a process `X` with `k` upcrossings `[a→b]` completing before time `N`, the time-reversed
+negated process `negProcess (revProcess X N)` has its `k`-th upcrossing `[-b→-a]` completing at
+time `≤ N`. -/
+lemma upperCrossingTime_negProcess_revProcess_le
+    {Ω : Type*} (X : ℕ → Ω → ℝ) (a b : ℝ) (hab : a < b) (N k : ℕ) (ω : Ω)
+    (h_k : upperCrossingTime a b X N k ω < N) :
+    upperCrossingTime (-b) (-a) (negProcess (revProcess X N)) (N + 1) k ω ≤ N := by
+  -- The `strong` version bounds this by `N - lowerCrossingTime …` via the bijection
+  -- `(τ, σ) ↦ (N - σ, N - τ)`; discard the subtraction with `Nat.sub_le`.
+  have h := upperCrossingTime_negProcess_revProcess_le_strong X a b hab N k k ω le_rfl h_k
+  exact le_trans (by simpa using h) (Nat.sub_le N _)
+
+end ProbabilityTheory

--- a/TauCeti/Probability/Martingale/Crossings/TimeReversal.lean
+++ b/TauCeti/Probability/Martingale/Crossings/TimeReversal.lean
@@ -11,13 +11,12 @@ negated process. This is the combinatorial ingredient feeding the pathwise cross
 
 ## Main definitions
 
-- `negProcess`: negation of a stochastic process.
 - `revProcess`: time reversal of a stochastic process up to a horizon `N`.
 
 ## Main results
 
 - `upperCrossingTime_negProcess_revProcess_le`: for a process `X` with `k` upcrossings `[a→b]`
-  completing before time `N`, the time-reversed negated process `negProcess (revProcess X N)` has
+  completing before time `N`, the time-reversed negated process `-(revProcess X N)` has
   its `k`-th upcrossing `[-b→-a]` completing at time `≤ N`.
 
 Adapted from `cameronfreer/exchangeability` (`Probability/TimeReversalCrossing.lean`, pin
@@ -34,17 +33,9 @@ open scoped ENNReal
 
 namespace ProbabilityTheory
 
-/-- Negation of a stochastic process. -/
-def negProcess {Ω : Type*} (X : ℕ → Ω → ℝ) : ℕ → Ω → ℝ :=
-  fun n ω => -X n ω
-
 /-- Time reversal of a stochastic process up to time `N`. -/
 def revProcess {Ω : Type*} (X : ℕ → Ω → ℝ) (N : ℕ) : ℕ → Ω → ℝ :=
   fun n ω => X (N - n) ω
-
-/-- Defining equation for `negProcess` (whose body is deliberately not `@[expose]`d). -/
-lemma negProcess_apply {Ω : Type*} (X : ℕ → Ω → ℝ) (n : ℕ) (ω : Ω) :
-    negProcess X n ω = -X n ω := by rfl
 
 /-- Defining equation for `revProcess` (whose body is deliberately not `@[expose]`d). -/
 lemma revProcess_apply {Ω : Type*} (X : ℕ → Ω → ℝ) (N n : ℕ) (ω : Ω) :
@@ -62,9 +53,9 @@ private lemma upperCrossingTime_negProcess_revProcess_le_strong
     {Ω : Type*} (X : ℕ → Ω → ℝ) (a b : ℝ) (hab : a < b) (N k m : ℕ) (ω : Ω)
     (hm : m ≤ k)
     (h_k : upperCrossingTime a b X N k ω < N) :
-    upperCrossingTime (-b) (-a) (negProcess (revProcess X N)) (N + 1) m ω
+    upperCrossingTime (-b) (-a) (-(revProcess X N)) (N + 1) m ω
       ≤ N - lowerCrossingTime a b X N (k - m) ω := by
-  set Y := negProcess (revProcess X N) with hY_def
+  set Y := -(revProcess X N) with hY_def
   -- All of X's crossing times are < N
   have h_j : ∀ j ≤ k, upperCrossingTime a b X N j ω < N := by
     intro j hj
@@ -118,10 +109,10 @@ private lemma upperCrossingTime_negProcess_revProcess_le_strong
       stoppedValue_lowerCrossingTime (f := X) (n := j - 1) h_neq_τ
     -- Y's level conditions at bijected times
     have hY_Nσ_le_negb : Y (N - σ) ω ≤ -b := by
-      simp only [hY_def, negProcess, revProcess, Nat.sub_sub_self (Nat.le_of_lt hσ_lt_N)]
+      simp only [hY_def, Pi.neg_apply, revProcess, Nat.sub_sub_self (Nat.le_of_lt hσ_lt_N)]
       linarith
     have hY_Nτ_ge_nega : Y (N - τ) ω ≥ -a := by
-      simp only [hY_def, negProcess, revProcess, Nat.sub_sub_self (Nat.le_of_lt hτ_lt_N)]
+      simp only [hY_def, Pi.neg_apply, revProcess, Nat.sub_sub_self (Nat.le_of_lt hτ_lt_N)]
       linarith
     -- lowerCrossingTime X j ≥ σ (hitting starts from σ)
     have h_lct_ge : lowerCrossingTime a b X N j ω ≥ σ := by
@@ -152,12 +143,12 @@ private lemma upperCrossingTime_negProcess_revProcess_le_strong
 /-- **Time-reversal crossing bound.**
 
 For a process `X` with `k` upcrossings `[a→b]` completing before time `N`, the time-reversed
-negated process `negProcess (revProcess X N)` has its `k`-th upcrossing `[-b→-a]` completing at
+negated process `-(revProcess X N)` has its `k`-th upcrossing `[-b→-a]` completing at
 time `≤ N`. -/
 lemma upperCrossingTime_negProcess_revProcess_le
     {Ω : Type*} (X : ℕ → Ω → ℝ) (a b : ℝ) (hab : a < b) (N k : ℕ) (ω : Ω)
     (h_k : upperCrossingTime a b X N k ω < N) :
-    upperCrossingTime (-b) (-a) (negProcess (revProcess X N)) (N + 1) k ω ≤ N := by
+    upperCrossingTime (-b) (-a) (-(revProcess X N)) (N + 1) k ω ≤ N := by
   -- The `strong` version bounds this by `N - lowerCrossingTime …` via the bijection
   -- `(τ, σ) ↦ (N - σ, N - τ)`; discard the subtraction with `Nat.sub_le`.
   have h := upperCrossingTime_negProcess_revProcess_le_strong X a b hab N k k ω le_rfl h_k

--- a/TauCeti/Probability/Martingale/Crossings/TimeReversal.lean
+++ b/TauCeti/Probability/Martingale/Crossings/TimeReversal.lean
@@ -1,5 +1,6 @@
 module
 
+public import Mathlib.Algebra.Polynomial.Reverse
 public import Mathlib.Probability.Martingale.Upcrossing
 
 /-!
@@ -14,9 +15,9 @@ negated process. This is a combinatorial ingredient of the reverse-martingale up
 
 ## Main results
 
-- `upperCrossingTime_neg_revProcess_le`: for a process `X` with `k` upcrossings `[a→b]`
-  completing before time `N`, the time-reversed negated process `-(revProcess X N)` has
-  its `k`-th upcrossing `[-b→-a]` completing at time `≤ N`.
+- `MeasureTheory.upperCrossingTime_neg_revProcess_le`: for a process `X` with `k`
+  upcrossings `[a→b]` completing before time `N`, the time-reversed negated process
+  `-(revProcess X N)` has its `k`-th upcrossing `[-b→-a]` completing at time `≤ N`.
 
 Adapted from `cameronfreer/exchangeability` (`Probability/TimeReversalCrossing.lean`, pin
 `e0532e59ceff23edab44dda9ab0655debbc9cc22`). Written Mathlib-shaped for eventual upstreaming.
@@ -30,24 +31,21 @@ open MeasureTheory
 
 open scoped ENNReal
 
-namespace ProbabilityTheory
+namespace MeasureTheory
 
-/-- Time reversal of a stochastic process up to time `N`. -/
+/-- Time reversal of a stochastic process up to time `N`, using Mathlib's horizon reversal
+`Polynomial.revAt`. For `n ≤ N` this is `X (N - n)`; see `revProcess_apply_of_le`. -/
 def revProcess {Ω α : Type*} (X : ℕ → Ω → α) (N : ℕ) : ℕ → Ω → α :=
-  fun n ω => X (N - n) ω
+  fun n ω => X (Polynomial.revAt N n) ω
 
 /-- Defining equation for `revProcess` (whose body is deliberately not `@[expose]`d). -/
 @[simp]
 lemma revProcess_apply {Ω α : Type*} (X : ℕ → Ω → α) (N n : ℕ) (ω : Ω) :
-    revProcess X N n ω = X (N - n) ω := by rfl
+    revProcess X N n ω = X (Polynomial.revAt N n) ω := by rfl
 
-/-- Package `hittingBtwn_le_of_mem` for `lowerCrossingTime`: if the process value at time `i` lies
-in `Set.Iic a` and `i` sits between the `n`-th upper-crossing time and the horizon `N`, then the
-`n`-th lower-crossing time is at most `i`. -/
-private lemma lowerCrossingTime_le_of_mem {Ω : Type*} {a b : ℝ} {Z : ℕ → Ω → ℝ} {N n i : ℕ}
-    {ω : Ω} (hui : upperCrossingTime a b Z N n ω ≤ i) (hiN : i ≤ N)
-    (his : Z i ω ∈ Set.Iic a) : lowerCrossingTime a b Z N n ω ≤ i := by
-  simpa only [lowerCrossingTime] using hittingBtwn_le_of_mem hui hiN his
+/-- Below the horizon, `Polynomial.revAt N` is genuine subtraction, so `revProcess` reverses. -/
+lemma revProcess_apply_of_le {Ω α : Type*} (X : ℕ → Ω → α) {N n : ℕ} (h : n ≤ N) (ω : Ω) :
+    revProcess X N n ω = X (N - n) ω := by simp [revProcess, Polynomial.revAt_le h]
 
 /-- Strong version tracking the bijection explicitly.
 
@@ -116,10 +114,14 @@ private lemma upperCrossingTime_neg_revProcess_le_strong
       stoppedValue_lowerCrossingTime (f := X) (n := j - 1) h_neq_τ
     -- Y's level conditions at bijected times
     have hY_Nσ_le_negb : Y (N - σ) ω ≤ -b := by
-      simp only [hY_def, Pi.neg_apply, revProcess_apply, Nat.sub_sub_self (Nat.le_of_lt hσ_lt_N)]
+      have hrev : revProcess X N (N - σ) ω = X σ ω := by
+        rw [revProcess_apply_of_le X (Nat.sub_le N σ) ω, Nat.sub_sub_self (Nat.le_of_lt hσ_lt_N)]
+      simp only [hY_def, Pi.neg_apply, hrev]
       linarith
     have hY_Nτ_ge_nega : Y (N - τ) ω ≥ -a := by
-      simp only [hY_def, Pi.neg_apply, revProcess_apply, Nat.sub_sub_self (Nat.le_of_lt hτ_lt_N)]
+      have hrev : revProcess X N (N - τ) ω = X τ ω := by
+        rw [revProcess_apply_of_le X (Nat.sub_le N τ) ω, Nat.sub_sub_self (Nat.le_of_lt hτ_lt_N)]
+      simp only [hY_def, Pi.neg_apply, hrev]
       linarith
     -- lowerCrossingTime X j ≥ σ (hitting starts from σ)
     have h_lct_ge : lowerCrossingTime a b X N j ω ≥ σ :=
@@ -132,8 +134,9 @@ private lemma upperCrossingTime_neg_revProcess_le_strong
     -- lowerCrossingTime Y m' ≤ N - σ (by hittingBtwn_le_of_mem)
     have h_Nσ_le_N1 : N - σ ≤ N + 1 := Nat.le_succ_of_le (Nat.sub_le N σ)
     have hY_Nσ_in_Iic : Y (N - σ) ω ∈ Set.Iic (-b) := hY_Nσ_le_negb
-    have h_lctY_le_Nσ : lowerCrossingTime (-b) (-a) Y (N + 1) m' ω ≤ N - σ :=
-      lowerCrossingTime_le_of_mem h_uct_le_Nσ h_Nσ_le_N1 hY_Nσ_in_Iic
+    have h_lctY_le_Nσ : lowerCrossingTime (-b) (-a) Y (N + 1) m' ω ≤ N - σ := by
+      simpa only [lowerCrossingTime] using
+        hittingBtwn_le_of_mem h_uct_le_Nσ h_Nσ_le_N1 hY_Nσ_in_Iic
     -- N - σ < N - τ and lowerCrossingTime Y m' < N - τ
     have hNσ_lt_Nτ : N - σ < N - τ := Nat.sub_lt_sub_left hτ_lt_N hτ_lt_σ
     have h_lctY_le_Nτ : lowerCrossingTime (-b) (-a) Y (N + 1) m' ω ≤ N - τ :=
@@ -160,4 +163,4 @@ lemma upperCrossingTime_neg_revProcess_le
   have h := upperCrossingTime_neg_revProcess_le_strong X a b hab N k k ω le_rfl h_k
   exact le_trans (by simpa using h) (Nat.sub_le N _)
 
-end ProbabilityTheory
+end MeasureTheory


### PR DESCRIPTION
<!--tauceti-target:v1 {"focus":"Exchangeability","id":"time-reversal-crossing-bound"}-->

## Summary

Adds `TauCeti/Probability/Martingale/Crossings/TimeReversal.lean` — the **pathwise time-reversal
crossing bound**, a small self-contained (Mathlib-only) combinatorial ingredient of the
reverse-martingale argument:

- `revProcess` — finite-horizon time reversal of a stochastic process, via Mathlib's bundled index
  reversal `Polynomial.revAt` (negation is Mathlib's pointwise `Pi.neg`, `-(revProcess X N)`).
- `upperCrossingTime_neg_revProcess_le` — for a process `X` whose `k`-th upcrossing `[a→b]`
  completes before time `N`, the time-reversed negated process `-(revProcess X N)` has its
  `k`-th upcrossing `[-b→-a]` completing at time `≤ N`.

## Roadmap

Advances `TauCetiRoadmap/Exchangeability/README.md` **Layer 4 (reverse martingales)**: this is the
pathwise crossing correspondence — reversing time maps `X`'s upcrossings of `[a,b]` to upcrossings of
`[-b,-a]` of the negated reversed process — feeding the reverse-martingale upcrossing bound (a
downstream PR). Peeled off as a standalone one-topic PR so it can land independently of the fuller
convergence chain.

## How it's proved (reuse)

Built on Mathlib's upcrossing API (`upperCrossingTime`, `lowerCrossingTime`, `hittingBtwn`,
`stoppedValue_upperCrossingTime`/`_lowerCrossingTime`, `lowerCrossingTime_lt_upperCrossingTime`): the
main lemma follows from a `strong` private form tracking the reversal bijection `(τ, σ) ↦ (N-σ, N-τ)`
between `X`'s and the reversed process's crossing times.

## Review notes
- **placement:** `TauCeti/Probability/Martingale/Crossings/` — the crossing layer of the
  reverse-martingale development; Mathlib-only.
- **generality:** arbitrary process `ℕ → Ω → ℝ`, general `a < b`, `N`.
- **api-design:** `revProcess` with a `@[simp]` `_apply` characterization
  (`= X (Polynomial.revAt N n) ω`) plus a conditional `revProcess_apply_of_le`
  (`n ≤ N ⟹ = X (N - n) ω`) for the proof; the bijection-tracking `strong` form is `private`.
- **generality:** `revProcess` is polymorphic in the value type (`{Ω α}`); the crossing lemmas
  instantiate `α := ℝ`.
- **placement:** `namespace MeasureTheory`, matching Mathlib's `upperCrossingTime`/`lowerCrossingTime`.
- **reuse:** built entirely on Mathlib's upcrossing/hitting-time API (`upperCrossingTime_succ_eq`,
  `upperCrossingTime_le_lowerCrossingTime`, `hittingBtwn_le_of_mem`), `Polynomial.revAt`, and `Pi.neg`;
  only the reversal correspondence is new.

## Review response

Across review rounds: `revProcess` reuses Mathlib's `Polynomial.revAt` bundled reversal (with a
conditional `revProcess_apply_of_le` for the `n ≤ N` proof sites) and `Pi.neg` for negation;
`revProcess_apply` is `@[simp]`; the theorem was renamed `…_negProcess_…` → `…_neg_…`; a stale
module-doc file reference was removed; the proof uses named crossing API (`upperCrossingTime_succ_eq`,
`upperCrossingTime_le_lowerCrossingTime`, and a local `hittingBtwn_le_of_mem` step); and the
declarations were moved to `namespace MeasureTheory`.

## Test plan
```bash
lake build
lake exe axioms
lake exe module-system
bash scripts/lint-env.sh
```
All pass; sorry-free; `upperCrossingTime_neg_revProcess_le` axioms ⊆ {`propext`,
`Classical.choice`, `Quot.sound`}; lines ≤100; module-system opts in.

## Attribution
Adapted from `cameronfreer/exchangeability` (`Probability/TimeReversalCrossing.lean`, pin
`e0532e59ceff23edab44dda9ab0655debbc9cc22`), reworked into TauCeti's module system and stated
Mathlib-shaped for eventual upstreaming. Drafted with Claude (Opus 4.8), human-directed.
