### PR TITLE
feat: add finite-type trivial coordinate object

### DIFF
--- a/TauCeti/Algebra/AlgebraicGroup/FiniteTypeTrivial.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/FiniteTypeTrivial.lean
@@ -15,8 +15,8 @@ Hopf-algebra category this object is initial: the unique morphism from `R` to a 
 Hopf algebra is the bialgebra unit map `R → H`. Contravariantly, this is the terminal object
 `Spec R` over `Spec R` in the affine-group-scheme dictionary.
 
-The initial morphism is built directly from Mathlib's bialgebra unit map through the
-finite-type `ofHom` bridge.
+The file also records the counit morphism `H → R` and the pointwise formulas for the unit and
+counit maps.
 
 This is Layer 0 infrastructure for the ReductiveGroups roadmap: the finite-type
 coordinate-Hopf-algebra model needs the terminal affine group object over the base, separate
@@ -24,7 +24,8 @@ from the already available raw Hopf-algebra points calculation in `TrivialGroup.
 
 ## References
 
-The bialgebra unit map is Mathlib's `Bialgebra.unitBialgHom`.
+The bialgebra unit and counit maps are Mathlib's `Bialgebra.unitBialgHom` and
+`Bialgebra.counitBialgHom`.
 -/
 
 public section
@@ -55,6 +56,44 @@ lemma trivial_obj :
 
 variable {R}
 
+/-- The coordinate morphism from the trivial affine group to a finite-type affine group.
+
+On coordinate Hopf algebras this is the bialgebra unit map `R → H`, contravariant to the
+unique morphism from the represented affine group to the terminal affine group `Spec R`. -/
+noncomputable abbrev unit (H : FiniteTypeCommHopfAlgCat.{u, u} R) :
+    trivial R ⟶ H :=
+  ofHom (_root_.Bialgebra.unitBialgHom R H)
+
+/-- The coordinate morphism from a finite-type affine group to the trivial affine group.
+
+On coordinate Hopf algebras this is the bialgebra counit map `H → R`, contravariant to the
+identity section `Spec R → G`. -/
+noncomputable abbrev counit (H : FiniteTypeCommHopfAlgCat.{u, u} R) :
+    H ⟶ trivial R :=
+  ofHom (_root_.Bialgebra.counitBialgHom R H)
+
+/-- The finite-type coordinate unit morphism unwraps to Mathlib's bialgebra unit map. -/
+@[simp]
+lemma toBialgHom_unit (H : FiniteTypeCommHopfAlgCat.{u, u} R) :
+    toBialgHom (unit H) = _root_.Bialgebra.unitBialgHom R H :=
+  rfl
+
+/-- The finite-type coordinate counit morphism unwraps to Mathlib's bialgebra counit map. -/
+@[simp]
+lemma toBialgHom_counit (H : FiniteTypeCommHopfAlgCat.{u, u} R) :
+    toBialgHom (counit H) = _root_.Bialgebra.counitBialgHom R H :=
+  rfl
+
+/-- Pointwise formula for the coordinate unit map `R → H`. -/
+lemma unit_apply (H : FiniteTypeCommHopfAlgCat.{u, u} R) (r : R) :
+    toBialgHom (unit H) r = algebraMap R H r :=
+  rfl
+
+/-- Pointwise formula for the coordinate counit map `H → R`. -/
+lemma counit_apply (H : FiniteTypeCommHopfAlgCat.{u, u} R) (h : H) :
+    toBialgHom (counit H) h = Coalgebra.counit h :=
+  _root_.Bialgebra.counitBialgHom_apply h
+
 /-- The finite-type trivial coordinate Hopf algebra is initial in the coordinate category.
 
 Equivalently, in the opposite affine-group-scheme direction it represents the terminal
@@ -62,18 +101,17 @@ object `Spec R` over the base. -/
 noncomputable def trivialIsInitial :
     IsInitial (trivial R : FiniteTypeCommHopfAlgCat.{u, u} R) :=
   IsInitial.ofUniqueHom
-    (fun H => ofHom (_root_.Bialgebra.unitBialgHom R H))
+    (fun H => unit H)
     (fun H f => by
       apply hom_ext
       apply _root_.BialgHom.coe_toAlgHom_injective
       exact Subsingleton.elim _ _)
 
-/-- The unique morphism out of the finite-type trivial coordinate Hopf algebra is the
-bialgebra unit map. -/
+/-- The unique morphism out of the finite-type trivial coordinate Hopf algebra is the unit. -/
 lemma eq_unit (H : FiniteTypeCommHopfAlgCat.{u, u} R)
     (f : trivial R ⟶ H) :
-    f = ofHom (_root_.Bialgebra.unitBialgHom R H) :=
-  (trivialIsInitial (R := R)).hom_ext f (ofHom (_root_.Bialgebra.unitBialgHom R H))
+    f = unit H :=
+  (trivialIsInitial (R := R)).hom_ext f (unit H)
 
 variable (A : CommAlgCat.{w} R)
 

--- a/TauCeti/Algebra/AlgebraicGroup/FiniteTypeTrivial.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/FiniteTypeTrivial.lean
@@ -78,7 +78,7 @@ lemma hom_counit (H : _root_.CommHopfAlgCat.{u} R) :
 /-- Pointwise formula for the ambient coordinate unit map `R → H`. -/
 @[simp]
 lemma unit_apply (H : _root_.CommHopfAlgCat.{u} R) (r : R) :
-    (unit (R := R) H).hom r = algebraMap R H r :=
+    (_root_.Bialgebra.unitBialgHom R H) r = algebraMap R H r :=
   rfl
 
 /-- Pointwise formula for the ambient coordinate counit map `H → R`. -/
@@ -155,7 +155,7 @@ lemma toBialgHom_counit (H : FiniteTypeCommHopfAlgCat.{u, u} R) :
 /-- Pointwise formula for the coordinate unit map `R → H`. -/
 @[simp]
 lemma unit_apply (H : FiniteTypeCommHopfAlgCat.{u, u} R) (r : R) :
-    toBialgHom (unit H) r = algebraMap R H r :=
+    (_root_.Bialgebra.unitBialgHom R H.obj) r = algebraMap R H r :=
   rfl
 
 /-- Pointwise formula for the coordinate counit map `H → R`. -/

--- a/TauCeti/Algebra/AlgebraicGroup/FiniteTypeTrivial.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/FiniteTypeTrivial.lean
@@ -88,7 +88,6 @@ lemma toBialgHom_counit (H : FiniteTypeCommHopfAlgCat.{u, u} R) :
   rfl
 
 /-- Pointwise formula for the coordinate unit map `R → H`. -/
-@[simp]
 lemma unit_apply (H : FiniteTypeCommHopfAlgCat.{u, u} R) (r : R) :
     toBialgHom (unit H) r = algebraMap R H r :=
   rfl

--- a/TauCeti/Algebra/AlgebraicGroup/FiniteTypeTrivial.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/FiniteTypeTrivial.lean
@@ -16,17 +16,13 @@ Hopf-algebra category this object is initial: the unique morphism from `R` to a 
 Hopf algebra is the bialgebra unit map `R → H`. Contravariantly, this is the terminal object
 `Spec R` over `Spec R` in the affine-group-scheme dictionary.
 
-The file also records the counit morphism `H → R` and the pointwise formulas for the unit and
-counit maps.
-
 This is Layer 0 infrastructure for the ReductiveGroups roadmap: the finite-type
 coordinate-Hopf-algebra model needs the terminal affine group object over the base, separate
 from the already available raw Hopf-algebra points calculation in `TrivialGroup.pointsMulEquiv`.
 
 ## References
 
-The bialgebra unit and counit maps are Mathlib's `Bialgebra.unitBialgHom` and
-`Bialgebra.counitBialgHom`.
+The bialgebra unit map is Mathlib's `Bialgebra.unitBialgHom`.
 -/
 
 public section
@@ -75,25 +71,6 @@ lemma toBialgHom_unit (H : FiniteTypeCommHopfAlgCat.{u, u} R) :
 lemma unit_apply (H : FiniteTypeCommHopfAlgCat.{u, u} R) (r : R) :
     toBialgHom (unit H) r = algebraMap R H r :=
   rfl
-
-/-- The coordinate morphism from a finite-type affine group to the trivial affine group.
-
-On coordinate Hopf algebras this is the bialgebra counit map `H → R`, contravariant to the
-identity section `Spec R → G`. -/
-noncomputable abbrev counit (H : FiniteTypeCommHopfAlgCat.{u, u} R) :
-    H ⟶ trivial R :=
-  ofHom (_root_.Bialgebra.counitBialgHom R H)
-
-/-- The finite-type coordinate counit morphism unwraps to Mathlib's bialgebra counit map. -/
-@[simp]
-lemma toBialgHom_counit (H : FiniteTypeCommHopfAlgCat.{u, u} R) :
-    toBialgHom (counit H) = _root_.Bialgebra.counitBialgHom R H :=
-  rfl
-
-/-- Pointwise formula for the coordinate counit map `H → R`. -/
-lemma counit_apply (H : FiniteTypeCommHopfAlgCat.{u, u} R) (h : H) :
-    toBialgHom (counit H) h = Coalgebra.counit h :=
-  _root_.Bialgebra.counitBialgHom_apply h
 
 /-- The finite-type trivial coordinate Hopf algebra is initial in the coordinate category.
 

--- a/TauCeti/Algebra/AlgebraicGroup/FiniteTypeTrivial.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/FiniteTypeTrivial.lean
@@ -88,6 +88,22 @@ noncomputable def trivialPointsMulEquiv :
   right_inv _ := rfl
   map_mul' _ _ := rfl
 
+/-- The finite-type trivial-points equivalence sends every point to the unique element of
+`PUnit`. -/
+@[simp]
+theorem trivialPointsMulEquiv_apply
+    (f : HopfAlgebra.points (R := R) (H := trivial R) A) :
+    trivialPointsMulEquiv A f = PUnit.unit :=
+  rfl
+
+/-- The inverse finite-type trivial-points equivalence sends the unique element of `PUnit` to
+`Algebra.ofId`. -/
+@[simp]
+theorem trivialPointsMulEquiv_symm_apply (u : PUnit.{1}) :
+    (trivialPointsMulEquiv A).symm u = toConv (Algebra.ofId R A) := by
+  cases u
+  rfl
+
 variable {A} {B : CommAlgCat.{w} R}
 
 /-- The finite-type trivial-points equivalence is natural in the value algebra. -/

--- a/TauCeti/Algebra/AlgebraicGroup/FiniteTypeTrivial.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/FiniteTypeTrivial.lean
@@ -1,0 +1,155 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+module
+
+public import Mathlib.CategoryTheory.Limits.Shapes.Terminal
+public import TauCeti.Algebra.AlgebraicGroup.FiniteTypeCommHopfAlgCat
+public import TauCeti.Algebra.AlgebraicGroup.Trivial
+
+/-!
+# The finite-type trivial affine group
+
+This file packages the base ring `R`, with its canonical Hopf algebra structure over itself,
+as the finite-type coordinate Hopf algebra of the trivial affine group. In the coordinate
+Hopf-algebra category this object is initial: the unique morphism from `R` to a coordinate
+Hopf algebra is the bialgebra unit map `R → H`. Contravariantly, this is the terminal object
+`Spec R` over `Spec R` in the affine-group-scheme dictionary.
+
+The file also records the counit morphism `H → R`, the pointwise formulas for the unit and
+counit maps, and the inherited one-point functor-of-points calculation.
+
+This is Layer 0 infrastructure for the ReductiveGroups roadmap: the finite-type
+coordinate-Hopf-algebra model needs the terminal affine group object over the base, separate
+from the already available raw Hopf-algebra points calculation.
+
+## References
+
+The bialgebra unit and counit maps are Mathlib's `Bialgebra.unitBialgHom` and
+`Bialgebra.counitBialgHom`. The points calculation reuses
+`TauCeti.TrivialGroup.pointsMulEquiv`.
+-/
+
+public section
+
+open CategoryTheory CategoryTheory.Limits WithConv
+
+namespace TauCeti
+
+universe u w
+
+namespace FiniteTypeCommHopfAlgCat
+
+variable (R : Type u) [CommRing R]
+
+/-- The finite-type coordinate Hopf algebra of the trivial affine group over `R`.
+
+Its underlying Hopf algebra is `R` over itself, and the finite-type proof is the canonical
+finite-generation of the base algebra over itself. -/
+noncomputable abbrev trivial : FiniteTypeCommHopfAlgCat.{u, u} R :=
+  of R R
+
+/-- The underlying type of the finite-type trivial coordinate Hopf algebra is the base ring. -/
+@[simp]
+lemma trivial_obj :
+    (trivial R).obj = (_root_.CommHopfAlgCat.of R R) :=
+  rfl
+
+variable {R}
+
+/-- The coordinate morphism from the trivial affine group to a finite-type affine group.
+
+On coordinate Hopf algebras this is the bialgebra unit map `R → H`, contravariant to the
+unique morphism from the represented affine group to the terminal affine group `Spec R`. -/
+noncomputable abbrev unit (H : FiniteTypeCommHopfAlgCat.{u, u} R) :
+    trivial R ⟶ H :=
+  ofHom (_root_.Bialgebra.unitBialgHom R H)
+
+/-- The coordinate morphism from a finite-type affine group to the trivial affine group.
+
+On coordinate Hopf algebras this is the bialgebra counit map `H → R`, contravariant to the
+identity section `Spec R → G`. -/
+noncomputable abbrev counit (H : FiniteTypeCommHopfAlgCat.{u, u} R) :
+    H ⟶ trivial R :=
+  ofHom (_root_.Bialgebra.counitBialgHom R H)
+
+@[simp]
+lemma toBialgHom_unit (H : FiniteTypeCommHopfAlgCat.{u, u} R) :
+    toBialgHom (unit H) = _root_.Bialgebra.unitBialgHom R H :=
+  rfl
+
+@[simp]
+lemma toBialgHom_counit (H : FiniteTypeCommHopfAlgCat.{u, u} R) :
+    toBialgHom (counit H) = _root_.Bialgebra.counitBialgHom R H :=
+  rfl
+
+/-- Pointwise formula for the coordinate unit map `R → H`. -/
+@[simp]
+lemma unit_apply (H : FiniteTypeCommHopfAlgCat.{u, u} R) (r : R) :
+    toBialgHom (unit H) r = algebraMap R H r :=
+  rfl
+
+/-- Pointwise formula for the coordinate counit map `H → R`. -/
+@[simp]
+lemma counit_apply (H : FiniteTypeCommHopfAlgCat.{u, u} R) (h : H) :
+    toBialgHom (counit H) h = Coalgebra.counit h :=
+  _root_.Bialgebra.counitBialgHom_apply h
+
+/-- The finite-type trivial coordinate Hopf algebra is initial in the coordinate category.
+
+Equivalently, in the opposite affine-group-scheme direction it represents the terminal
+object `Spec R` over the base. -/
+noncomputable def trivialIsInitial :
+    IsInitial (trivial R : FiniteTypeCommHopfAlgCat.{u, u} R) :=
+  IsInitial.ofUniqueHom
+    (fun H => unit H)
+    (fun H f => by
+      apply hom_ext
+      apply _root_.BialgHom.coe_toAlgHom_injective
+      exact Subsingleton.elim _ _)
+
+/-- The unique morphism out of the finite-type trivial coordinate Hopf algebra is the unit. -/
+lemma eq_unit (H : FiniteTypeCommHopfAlgCat.{u, u} R)
+    (f : trivial R ⟶ H) :
+    f = unit H :=
+  (trivialIsInitial (R := R)).hom_ext f (unit H)
+
+variable (A : CommAlgCat.{w} R)
+
+/-- The `A`-points of the finite-type trivial affine group form the one-element group. -/
+noncomputable def trivialPointsMulEquiv :
+    HopfAlgebra.points (R := R) (H := trivial R) A ≃* PUnit.{1} :=
+  TrivialGroup.pointsMulEquiv (R := R) (A := A)
+
+/-- The finite-type trivial points equivalence sends every point to the unique element. -/
+@[simp]
+lemma trivialPointsMulEquiv_apply
+    (f : HopfAlgebra.points (R := R) (H := trivial R) A) :
+    trivialPointsMulEquiv (R := R) A f = PUnit.unit :=
+  TrivialGroup.pointsMulEquiv_apply f
+
+/-- The inverse finite-type trivial points equivalence is the canonical algebra map
+`R → A`. -/
+@[simp]
+lemma trivialPointsMulEquiv_symm_apply (u : PUnit.{1}) :
+    (trivialPointsMulEquiv (R := R) A).symm u =
+      toConv (Algebra.ofId R A) :=
+  TrivialGroup.pointsMulEquiv_symm_apply u
+
+/-- Every point of the finite-type trivial affine group is the convolution identity. -/
+lemma trivialPoint_eq_one
+    (f : HopfAlgebra.points (R := R) (H := trivial R) A) :
+    f = 1 :=
+  TrivialGroup.convPoint_eq_one f
+
+/-- Evaluating any point of the finite-type trivial affine group gives the structure map
+`R → A`. -/
+lemma trivialPoint_apply
+    (f : HopfAlgebra.points (R := R) (H := trivial R) A) (r : R) :
+    f r = algebraMap R A r :=
+  TrivialGroup.convPoint_apply f r
+
+end FiniteTypeCommHopfAlgCat
+
+end TauCeti

--- a/TauCeti/Algebra/AlgebraicGroup/FiniteTypeTrivial.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/FiniteTypeTrivial.lean
@@ -21,7 +21,7 @@ counit maps.
 
 This is Layer 0 infrastructure for the ReductiveGroups roadmap: the finite-type
 coordinate-Hopf-algebra model needs the terminal affine group object over the base, separate
-from the already available raw Hopf-algebra points calculation.
+from the already available raw Hopf-algebra points calculation in `TrivialGroup.pointsMulEquiv`.
 
 ## References
 
@@ -63,7 +63,7 @@ On coordinate Hopf algebras this is the bialgebra unit map `R → H`, contravari
 unique morphism from the represented affine group to the terminal affine group `Spec R`. -/
 noncomputable abbrev unit (H : FiniteTypeCommHopfAlgCat.{u, u} R) :
     trivial R ⟶ H :=
-  ofHom (CommHopfAlgCat.unit H.obj).hom
+  ofHom (_root_.Bialgebra.unitBialgHom R H)
 
 /-- The coordinate morphism from a finite-type affine group to the trivial affine group.
 
@@ -71,7 +71,7 @@ On coordinate Hopf algebras this is the bialgebra counit map `H → R`, contrava
 identity section `Spec R → G`. -/
 noncomputable abbrev counit (H : FiniteTypeCommHopfAlgCat.{u, u} R) :
     H ⟶ trivial R :=
-  ofHom (CommHopfAlgCat.counit H.obj).hom
+  ofHom (_root_.Bialgebra.counitBialgHom R H)
 
 /-- The finite-type coordinate unit morphism unwraps to Mathlib's bialgebra unit map. -/
 @[simp]
@@ -105,52 +105,14 @@ noncomputable def trivialIsInitial :
     (fun H => unit H)
     (fun H f => by
       apply hom_ext
-      exact congrArg (fun g : CommHopfAlgCat.trivial R ⟶ H.obj => g.hom)
-        (CommHopfAlgCat.eq_unit H.obj f.hom))
+      apply _root_.BialgHom.coe_toAlgHom_injective
+      exact Subsingleton.elim _ _)
 
 /-- The unique morphism out of the finite-type trivial coordinate Hopf algebra is the unit. -/
 lemma eq_unit (H : FiniteTypeCommHopfAlgCat.{u, u} R)
     (f : trivial R ⟶ H) :
     f = unit H :=
-  by
-    apply hom_ext
-    exact congrArg (fun g : CommHopfAlgCat.trivial R ⟶ H.obj => g.hom)
-      (CommHopfAlgCat.eq_unit H.obj f.hom)
-
-variable (A : CommAlgCat.{v} R)
-
-/-- The functor of points of the finite-type trivial affine group is the one-element group. -/
-noncomputable def trivialPointsMulEquiv :
-    HopfAlgebra.points (R := R) (H := trivial R) A ≃* PUnit.{1} :=
-  TrivialGroup.pointsMulEquiv (R := R) (A := A)
-
-/-- The finite-type trivial-group points equivalence sends every point to `PUnit.unit`. -/
-@[simp]
-theorem trivialPointsMulEquiv_apply (f : HopfAlgebra.points (R := R) (H := trivial R) A) :
-    trivialPointsMulEquiv A f = PUnit.unit :=
-  TrivialGroup.pointsMulEquiv_apply (R := R) (A := A) f
-
-/-- The inverse finite-type trivial-group points equivalence gives the unique point. -/
-@[simp]
-theorem trivialPointsMulEquiv_symm_apply (u : PUnit.{1}) :
-    (trivialPointsMulEquiv A).symm u = toConv (Algebra.ofId R A) :=
-  TrivialGroup.pointsMulEquiv_symm_apply (R := R) (A := A) u
-
-variable {B : CommAlgCat.{w} R}
-
-/-- The finite-type trivial-group points equivalence is natural in the value algebra. -/
-theorem trivialPointsMulEquiv_mapValue (φ : A →ₐ[R] B)
-    (f : HopfAlgebra.points (R := R) (H := trivial R) A) :
-    trivialPointsMulEquiv B (AlgHom.mapValue (H := trivial R) φ f) =
-      trivialPointsMulEquiv A f :=
-  TrivialGroup.pointsMulEquiv_mapValue (R := R) (A := A) (B := B) φ f
-
-/-- Naturality of the inverse finite-type trivial-group points equivalence in the value
-algebra. -/
-theorem mapValue_trivialPointsMulEquiv_symm_apply (φ : A →ₐ[R] B) (u : PUnit.{1}) :
-    AlgHom.mapValue (H := trivial R) φ ((trivialPointsMulEquiv A).symm u) =
-      (trivialPointsMulEquiv B).symm u :=
-  TrivialGroup.mapValue_pointsMulEquiv_symm_apply (R := R) (A := A) (B := B) φ u
+  (trivialIsInitial (R := R)).hom_ext f (unit H)
 
 end FiniteTypeCommHopfAlgCat
 

--- a/TauCeti/Algebra/AlgebraicGroup/FiniteTypeTrivial.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/FiniteTypeTrivial.lean
@@ -145,8 +145,10 @@ theorem trivialPointsMulEquiv_symm_apply (u : PUnit.{1}) :
 
 variable {A} {B : CommAlgCat.{w} R}
 
-/-- The finite-type trivial-points equivalence is natural in the value algebra. -/
-@[simp]
+/-- The finite-type trivial-points equivalence is natural in the value algebra.
+
+This is not a `simp` lemma: `trivialPointsMulEquiv_apply` already rewrites both sides to
+`PUnit.unit`, so tagging it `@[simp]` would leave its left-hand side out of normal form. -/
 theorem trivialPointsMulEquiv_mapValue (φ : A →ₐ[R] B)
     (f : HopfAlgebra.points (R := R) (H := trivial R) A) :
     trivialPointsMulEquiv B (AlgHom.mapValue (H := trivial R) φ f) =

--- a/TauCeti/Algebra/AlgebraicGroup/FiniteTypeTrivial.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/FiniteTypeTrivial.lean
@@ -87,7 +87,7 @@ lemma toBialgHom_counit (H : FiniteTypeCommHopfAlgCat.{u, u} R) :
 /-- Pointwise formula for the coordinate unit map `R → H`. -/
 @[simp]
 lemma unit_apply (H : FiniteTypeCommHopfAlgCat.{u, u} R) (r : R) :
-    toBialgHom (unit H) r = algebraMap R H r :=
+    (_root_.Bialgebra.unitBialgHom R H) r = algebraMap R H r :=
   rfl
 
 /-- Pointwise formula for the coordinate counit map `H → R`. -/

--- a/TauCeti/Algebra/AlgebraicGroup/FiniteTypeTrivial.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/FiniteTypeTrivial.lean
@@ -63,8 +63,7 @@ On coordinate Hopf algebras this is the bialgebra unit map `R → H`, contravari
 unique morphism from the represented affine group to the terminal affine group `Spec R`. -/
 noncomputable abbrev unit (H : FiniteTypeCommHopfAlgCat.{u, u} R) :
     trivial R ⟶ H :=
-  ObjectProperty.homMk
-    (_root_.CommHopfAlgCat.ofHom (_root_.Bialgebra.unitBialgHom R H.obj))
+  ofHom (CommHopfAlgCat.unit H.obj).hom
 
 /-- The coordinate morphism from a finite-type affine group to the trivial affine group.
 
@@ -72,8 +71,7 @@ On coordinate Hopf algebras this is the bialgebra counit map `H → R`, contrava
 identity section `Spec R → G`. -/
 noncomputable abbrev counit (H : FiniteTypeCommHopfAlgCat.{u, u} R) :
     H ⟶ trivial R :=
-  ObjectProperty.homMk
-    (_root_.CommHopfAlgCat.ofHom (_root_.Bialgebra.counitBialgHom R H.obj))
+  ofHom (CommHopfAlgCat.counit H.obj).hom
 
 /-- The finite-type coordinate unit morphism unwraps to Mathlib's bialgebra unit map. -/
 @[simp]
@@ -108,14 +106,17 @@ noncomputable def trivialIsInitial :
     (fun H => unit H)
     (fun H f => by
       apply hom_ext
-      apply _root_.BialgHom.coe_toAlgHom_injective
-      exact Subsingleton.elim _ _)
+      exact congrArg (fun g : CommHopfAlgCat.trivial R ⟶ H.obj => g.hom)
+        (CommHopfAlgCat.eq_unit H.obj f.hom))
 
 /-- The unique morphism out of the finite-type trivial coordinate Hopf algebra is the unit. -/
 lemma eq_unit (H : FiniteTypeCommHopfAlgCat.{u, u} R)
     (f : trivial R ⟶ H) :
     f = unit H :=
-  (trivialIsInitial (R := R)).hom_ext f (unit H)
+  by
+    apply hom_ext
+    exact congrArg (fun g : CommHopfAlgCat.trivial R ⟶ H.obj => g.hom)
+      (CommHopfAlgCat.eq_unit H.obj f.hom)
 
 variable (A : CommAlgCat.{v} R)
 

--- a/TauCeti/Algebra/AlgebraicGroup/FiniteTypeTrivial.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/FiniteTypeTrivial.lean
@@ -138,7 +138,6 @@ theorem trivialPointsMulEquiv_symm_apply (u : PUnit.{1}) :
 variable {B : CommAlgCat.{u} R}
 
 /-- The finite-type trivial-group points equivalence is natural in the value algebra. -/
-@[simp]
 theorem trivialPointsMulEquiv_mapValue (φ : A →ₐ[R] B)
     (f : HopfAlgebra.points (R := R) (H := trivial R) A) :
     trivialPointsMulEquiv B (AlgHom.mapValue (H := trivial R) φ f) =

--- a/TauCeti/Algebra/AlgebraicGroup/FiniteTypeTrivial.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/FiniteTypeTrivial.lean
@@ -5,7 +5,6 @@ Released under Apache 2.0 license as described in the file LICENSE.
 module
 
 public import TauCeti.Algebra.AlgebraicGroup.FiniteTypeCommHopfAlgCat
-public import TauCeti.Algebra.AlgebraicGroup.Trivial
 
 /-!
 # The finite-type trivial affine group
@@ -75,6 +74,36 @@ lemma eq_unit (H : FiniteTypeCommHopfAlgCat.{u, u} R)
     (f : trivial R ⟶ H) :
     f = ofHom (_root_.Bialgebra.unitBialgHom R H) :=
   (trivialIsInitial (R := R)).hom_ext f (ofHom (_root_.Bialgebra.unitBialgHom R H))
+
+variable (A : CommAlgCat.{w} R)
+
+/-- The functor of points of the finite-type trivial affine group is the one-element group. -/
+noncomputable def trivialPointsMulEquiv :
+    HopfAlgebra.points (R := R) (H := trivial R) A ≃* PUnit.{1} where
+  toFun _ := PUnit.unit
+  invFun _ := toConv (Algebra.ofId R A)
+  left_inv f := by
+    apply WithConv.ofConv_injective
+    exact Subsingleton.elim _ _
+  right_inv _ := rfl
+  map_mul' _ _ := rfl
+
+variable {A} {B : CommAlgCat.{w} R}
+
+/-- The finite-type trivial-points equivalence is natural in the value algebra. -/
+@[simp]
+theorem trivialPointsMulEquiv_mapValue (φ : A →ₐ[R] B)
+    (f : HopfAlgebra.points (R := R) (H := trivial R) A) :
+    trivialPointsMulEquiv B (AlgHom.mapValue (H := trivial R) φ f) =
+      trivialPointsMulEquiv A f :=
+  rfl
+
+/-- Naturality of the inverse finite-type trivial-points equivalence in the value algebra. -/
+theorem mapValue_trivialPointsMulEquiv_symm_apply (φ : A →ₐ[R] B) (u : PUnit.{1}) :
+    AlgHom.mapValue (H := trivial R) φ ((trivialPointsMulEquiv A).symm u) =
+      (trivialPointsMulEquiv B).symm u := by
+  apply (trivialPointsMulEquiv B).injective
+  rw [trivialPointsMulEquiv_mapValue]
 
 end FiniteTypeCommHopfAlgCat
 

--- a/TauCeti/Algebra/AlgebraicGroup/FiniteTypeTrivial.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/FiniteTypeTrivial.lean
@@ -80,11 +80,10 @@ lemma hom_counit (H : _root_.CommHopfAlgCat.{u} R) :
 /-- Pointwise formula for the ambient coordinate unit map `R → H`. -/
 @[simp]
 lemma unit_apply (H : _root_.CommHopfAlgCat.{u} R) (r : R) :
-    (unit (R := R) H).hom r = algebraMap R H r :=
+    (_root_.Bialgebra.unitBialgHom R H) r = algebraMap R H r :=
   rfl
 
 /-- Pointwise formula for the ambient coordinate counit map `H → R`. -/
-@[simp]
 lemma counit_apply (H : _root_.CommHopfAlgCat.{u} R) (h : H) :
     (counit (R := R) H).hom h = Coalgebra.counit h :=
   _root_.Bialgebra.counitBialgHom_apply h
@@ -158,11 +157,10 @@ lemma toBialgHom_counit (H : FiniteTypeCommHopfAlgCat.{u, u} R) :
 /-- Pointwise formula for the coordinate unit map `R → H`. -/
 @[simp]
 lemma unit_apply (H : FiniteTypeCommHopfAlgCat.{u, u} R) (r : R) :
-    toBialgHom (unit H) r = algebraMap R H r :=
+    (_root_.Bialgebra.unitBialgHom R H.obj) r = algebraMap R H r :=
   rfl
 
 /-- Pointwise formula for the coordinate counit map `H → R`. -/
-@[simp]
 lemma counit_apply (H : FiniteTypeCommHopfAlgCat.{u, u} R) (h : H) :
     toBialgHom (counit H) h = Coalgebra.counit h :=
   _root_.Bialgebra.counitBialgHom_apply h
@@ -211,7 +209,6 @@ lemma trivialPointsMulEquiv_symm_apply (u : PUnit.{1}) :
 variable {B : CommAlgCat.{w} R}
 
 /-- The finite-type trivial-points equivalence is natural in the value algebra. -/
-@[simp]
 theorem trivialPointsMulEquiv_mapValue (φ : A →ₐ[R] B)
     (f : HopfAlgebra.points (R := R) (H := trivial R) A) :
     trivialPointsMulEquiv (R := R) B (AlgHom.mapValue (H := trivial R) φ f) =

--- a/TauCeti/Algebra/AlgebraicGroup/FiniteTypeTrivial.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/FiniteTypeTrivial.lean
@@ -4,8 +4,8 @@ Released under Apache 2.0 license as described in the file LICENSE.
 -/
 module
 
-public import Mathlib.CategoryTheory.Limits.Shapes.Terminal
 public import TauCeti.Algebra.AlgebraicGroup.FiniteTypeCommHopfAlgCat
+public import TauCeti.Algebra.AlgebraicGroup.Trivial
 
 /-!
 # The finite-type trivial affine group
@@ -31,78 +31,11 @@ The bialgebra unit and counit maps are Mathlib's `Bialgebra.unitBialgHom` and
 
 public section
 
-open CategoryTheory CategoryTheory.Limits
+open CategoryTheory CategoryTheory.Limits WithConv
 
 namespace TauCeti
 
 universe u
-
-namespace CommHopfAlgCat
-
-variable (R : Type u) [CommRing R]
-
-/-- The coordinate Hopf algebra of the trivial affine group over `R`.
-
-Its underlying Hopf algebra is `R` over itself. -/
-noncomputable abbrev trivial : _root_.CommHopfAlgCat.{u} R :=
-  _root_.CommHopfAlgCat.of R R
-
-/-- The coordinate morphism from the trivial affine group to an affine group.
-
-On coordinate Hopf algebras this is the bialgebra unit map `R → H`. -/
-noncomputable abbrev unit (H : _root_.CommHopfAlgCat.{u} R) :
-    trivial R ⟶ H :=
-  _root_.CommHopfAlgCat.ofHom (_root_.Bialgebra.unitBialgHom R H)
-
-/-- The coordinate morphism from an affine group to the trivial affine group.
-
-On coordinate Hopf algebras this is the bialgebra counit map `H → R`. -/
-noncomputable abbrev counit (H : _root_.CommHopfAlgCat.{u} R) :
-    H ⟶ trivial R :=
-  _root_.CommHopfAlgCat.ofHom (_root_.Bialgebra.counitBialgHom R H)
-
-variable {R}
-
-/-- The ambient coordinate unit morphism unwraps to Mathlib's bialgebra unit map. -/
-@[simp]
-lemma hom_unit (H : _root_.CommHopfAlgCat.{u} R) :
-    (unit (R := R) H).hom = _root_.Bialgebra.unitBialgHom R H :=
-  rfl
-
-/-- The ambient coordinate counit morphism unwraps to Mathlib's bialgebra counit map. -/
-@[simp]
-lemma hom_counit (H : _root_.CommHopfAlgCat.{u} R) :
-    (counit (R := R) H).hom = _root_.Bialgebra.counitBialgHom R H :=
-  rfl
-
-/-- Pointwise formula for the ambient coordinate unit map `R → H`. -/
-@[simp]
-lemma unit_apply (H : _root_.CommHopfAlgCat.{u} R) (r : R) :
-    (_root_.Bialgebra.unitBialgHom R H) r = algebraMap R H r :=
-  rfl
-
-/-- Pointwise formula for the ambient coordinate counit map `H → R`. -/
-lemma counit_apply (H : _root_.CommHopfAlgCat.{u} R) (h : H) :
-    (counit (R := R) H).hom h = Coalgebra.counit h :=
-  _root_.Bialgebra.counitBialgHom_apply h
-
-/-- The trivial coordinate Hopf algebra is initial in the ambient coordinate category. -/
-noncomputable def trivialIsInitial :
-    IsInitial (trivial R : _root_.CommHopfAlgCat.{u} R) :=
-  IsInitial.ofUniqueHom
-    (fun H => unit (R := R) H)
-    (fun H f => by
-      apply _root_.CommHopfAlgCat.hom_ext
-      apply _root_.BialgHom.coe_toAlgHom_injective
-      exact Subsingleton.elim _ _)
-
-/-- The unique ambient morphism out of the trivial coordinate Hopf algebra is the unit. -/
-lemma eq_unit (H : _root_.CommHopfAlgCat.{u} R)
-    (f : trivial R ⟶ H) :
-    f = unit (R := R) H :=
-  (trivialIsInitial (R := R)).hom_ext f (unit (R := R) H)
-
-end CommHopfAlgCat
 
 namespace FiniteTypeCommHopfAlgCat
 
@@ -159,6 +92,7 @@ lemma unit_apply (H : FiniteTypeCommHopfAlgCat.{u, u} R) (r : R) :
   rfl
 
 /-- Pointwise formula for the coordinate counit map `H → R`. -/
+@[simp]
 lemma counit_apply (H : FiniteTypeCommHopfAlgCat.{u, u} R) (h : H) :
     toBialgHom (counit H) h = Coalgebra.counit h :=
   _root_.Bialgebra.counitBialgHom_apply h
@@ -181,6 +115,42 @@ lemma eq_unit (H : FiniteTypeCommHopfAlgCat.{u, u} R)
     (f : trivial R ⟶ H) :
     f = unit H :=
   (trivialIsInitial (R := R)).hom_ext f (unit H)
+
+variable (A : CommAlgCat.{u} R)
+
+/-- The functor of points of the finite-type trivial affine group is the one-element group. -/
+noncomputable def trivialPointsMulEquiv :
+    HopfAlgebra.points (R := R) (H := trivial R) A ≃* PUnit.{1} :=
+  TrivialGroup.pointsMulEquiv (R := R) (A := A)
+
+/-- The finite-type trivial-group points equivalence sends every point to `PUnit.unit`. -/
+@[simp]
+theorem trivialPointsMulEquiv_apply (f : HopfAlgebra.points (R := R) (H := trivial R) A) :
+    trivialPointsMulEquiv A f = PUnit.unit :=
+  TrivialGroup.pointsMulEquiv_apply (R := R) (A := A) f
+
+/-- The inverse finite-type trivial-group points equivalence gives the unique point. -/
+@[simp]
+theorem trivialPointsMulEquiv_symm_apply (u : PUnit.{1}) :
+    (trivialPointsMulEquiv A).symm u = toConv (Algebra.ofId R A) :=
+  TrivialGroup.pointsMulEquiv_symm_apply (R := R) (A := A) u
+
+variable {B : CommAlgCat.{u} R}
+
+/-- The finite-type trivial-group points equivalence is natural in the value algebra. -/
+@[simp]
+theorem trivialPointsMulEquiv_mapValue (φ : A →ₐ[R] B)
+    (f : HopfAlgebra.points (R := R) (H := trivial R) A) :
+    trivialPointsMulEquiv B (AlgHom.mapValue (H := trivial R) φ f) =
+      trivialPointsMulEquiv A f :=
+  TrivialGroup.pointsMulEquiv_mapValue (R := R) (A := A) (B := B) φ f
+
+/-- Naturality of the inverse finite-type trivial-group points equivalence in the value
+algebra. -/
+theorem mapValue_trivialPointsMulEquiv_symm_apply (φ : A →ₐ[R] B) (u : PUnit.{1}) :
+    AlgHom.mapValue (H := trivial R) φ ((trivialPointsMulEquiv A).symm u) =
+      (trivialPointsMulEquiv B).symm u :=
+  TrivialGroup.mapValue_pointsMulEquiv_symm_apply (R := R) (A := A) (B := B) φ u
 
 end FiniteTypeCommHopfAlgCat
 

--- a/TauCeti/Algebra/AlgebraicGroup/FiniteTypeTrivial.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/FiniteTypeTrivial.lean
@@ -6,7 +6,6 @@ module
 
 public import Mathlib.CategoryTheory.Limits.Shapes.Terminal
 public import TauCeti.Algebra.AlgebraicGroup.FiniteTypeCommHopfAlgCat
-public import TauCeti.Algebra.AlgebraicGroup.Trivial
 
 /-!
 # The finite-type trivial affine group
@@ -17,8 +16,8 @@ Hopf-algebra category this object is initial: the unique morphism from `R` to a 
 Hopf algebra is the bialgebra unit map `R → H`. Contravariantly, this is the terminal object
 `Spec R` over `Spec R` in the affine-group-scheme dictionary.
 
-The file also records the counit morphism `H → R`, the pointwise formulas for the unit and
-counit maps, and the inherited one-point functor-of-points calculation.
+The file also records the counit morphism `H → R` and the pointwise formulas for the unit and
+counit maps.
 
 This is Layer 0 infrastructure for the ReductiveGroups roadmap: the finite-type
 coordinate-Hopf-algebra model needs the terminal affine group object over the base, separate
@@ -27,17 +26,16 @@ from the already available raw Hopf-algebra points calculation.
 ## References
 
 The bialgebra unit and counit maps are Mathlib's `Bialgebra.unitBialgHom` and
-`Bialgebra.counitBialgHom`. The points calculation reuses
-`TauCeti.TrivialGroup.pointsMulEquiv`.
+`Bialgebra.counitBialgHom`.
 -/
 
 public section
 
-open CategoryTheory CategoryTheory.Limits WithConv
+open CategoryTheory CategoryTheory.Limits
 
 namespace TauCeti
 
-universe u w
+universe u
 
 namespace CommHopfAlgCat
 
@@ -80,7 +78,7 @@ lemma hom_counit (H : _root_.CommHopfAlgCat.{u} R) :
 /-- Pointwise formula for the ambient coordinate unit map `R → H`. -/
 @[simp]
 lemma unit_apply (H : _root_.CommHopfAlgCat.{u} R) (r : R) :
-    (_root_.Bialgebra.unitBialgHom R H) r = algebraMap R H r :=
+    (unit (R := R) H).hom r = algebraMap R H r :=
   rfl
 
 /-- Pointwise formula for the ambient coordinate counit map `H → R`. -/
@@ -157,7 +155,7 @@ lemma toBialgHom_counit (H : FiniteTypeCommHopfAlgCat.{u, u} R) :
 /-- Pointwise formula for the coordinate unit map `R → H`. -/
 @[simp]
 lemma unit_apply (H : FiniteTypeCommHopfAlgCat.{u, u} R) (r : R) :
-    (_root_.Bialgebra.unitBialgHom R H.obj) r = algebraMap R H r :=
+    toBialgHom (unit H) r = algebraMap R H r :=
   rfl
 
 /-- Pointwise formula for the coordinate counit map `H → R`. -/
@@ -183,56 +181,6 @@ lemma eq_unit (H : FiniteTypeCommHopfAlgCat.{u, u} R)
     (f : trivial R ⟶ H) :
     f = unit H :=
   (trivialIsInitial (R := R)).hom_ext f (unit H)
-
-variable (A : CommAlgCat.{w} R)
-
-/-- The `A`-points of the finite-type trivial affine group form the one-element group. -/
-noncomputable def trivialPointsMulEquiv :
-    HopfAlgebra.points (R := R) (H := trivial R) A ≃* PUnit.{1} :=
-  TrivialGroup.pointsMulEquiv (R := R) (A := A)
-
-/-- The finite-type trivial points equivalence sends every point to the unique element. -/
-@[simp]
-lemma trivialPointsMulEquiv_apply
-    (f : HopfAlgebra.points (R := R) (H := trivial R) A) :
-    trivialPointsMulEquiv (R := R) A f = PUnit.unit :=
-  TrivialGroup.pointsMulEquiv_apply f
-
-/-- The inverse finite-type trivial points equivalence is the canonical algebra map
-`R → A`. -/
-@[simp]
-lemma trivialPointsMulEquiv_symm_apply (u : PUnit.{1}) :
-    (trivialPointsMulEquiv (R := R) A).symm u =
-      toConv (Algebra.ofId R A) :=
-  TrivialGroup.pointsMulEquiv_symm_apply u
-
-variable {B : CommAlgCat.{w} R}
-
-/-- The finite-type trivial-points equivalence is natural in the value algebra. -/
-theorem trivialPointsMulEquiv_mapValue (φ : A →ₐ[R] B)
-    (f : HopfAlgebra.points (R := R) (H := trivial R) A) :
-    trivialPointsMulEquiv (R := R) B (AlgHom.mapValue (H := trivial R) φ f) =
-      trivialPointsMulEquiv (R := R) A f :=
-  TrivialGroup.pointsMulEquiv_mapValue φ f
-
-/-- Naturality of the inverse finite-type trivial-points equivalence in the value algebra. -/
-theorem mapValue_trivialPointsMulEquiv_symm_apply (φ : A →ₐ[R] B) (u : PUnit.{1}) :
-    AlgHom.mapValue (H := trivial R) φ ((trivialPointsMulEquiv (R := R) A).symm u) =
-      (trivialPointsMulEquiv (R := R) B).symm u :=
-  TrivialGroup.mapValue_pointsMulEquiv_symm_apply φ u
-
-/-- Every point of the finite-type trivial affine group is the convolution identity. -/
-lemma trivialPoint_eq_one
-    (f : HopfAlgebra.points (R := R) (H := trivial R) A) :
-    f = 1 :=
-  TrivialGroup.convPoint_eq_one f
-
-/-- Evaluating any point of the finite-type trivial affine group gives the structure map
-`R → A`. -/
-lemma trivialPoint_apply
-    (f : HopfAlgebra.points (R := R) (H := trivial R) A) (r : R) :
-    f r = algebraMap R A r :=
-  TrivialGroup.convPoint_apply f r
 
 end FiniteTypeCommHopfAlgCat
 

--- a/TauCeti/Algebra/AlgebraicGroup/FiniteTypeTrivial.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/FiniteTypeTrivial.lean
@@ -39,6 +39,74 @@ namespace TauCeti
 
 universe u w
 
+namespace CommHopfAlgCat
+
+variable (R : Type u) [CommRing R]
+
+/-- The coordinate Hopf algebra of the trivial affine group over `R`.
+
+Its underlying Hopf algebra is `R` over itself. -/
+noncomputable abbrev trivial : _root_.CommHopfAlgCat.{u} R :=
+  _root_.CommHopfAlgCat.of R R
+
+/-- The coordinate morphism from the trivial affine group to an affine group.
+
+On coordinate Hopf algebras this is the bialgebra unit map `R → H`. -/
+noncomputable abbrev unit (H : _root_.CommHopfAlgCat.{u} R) :
+    trivial R ⟶ H :=
+  _root_.CommHopfAlgCat.ofHom (_root_.Bialgebra.unitBialgHom R H)
+
+/-- The coordinate morphism from an affine group to the trivial affine group.
+
+On coordinate Hopf algebras this is the bialgebra counit map `H → R`. -/
+noncomputable abbrev counit (H : _root_.CommHopfAlgCat.{u} R) :
+    H ⟶ trivial R :=
+  _root_.CommHopfAlgCat.ofHom (_root_.Bialgebra.counitBialgHom R H)
+
+variable {R}
+
+/-- The ambient coordinate unit morphism unwraps to Mathlib's bialgebra unit map. -/
+@[simp]
+lemma hom_unit (H : _root_.CommHopfAlgCat.{u} R) :
+    (unit (R := R) H).hom = _root_.Bialgebra.unitBialgHom R H :=
+  rfl
+
+/-- The ambient coordinate counit morphism unwraps to Mathlib's bialgebra counit map. -/
+@[simp]
+lemma hom_counit (H : _root_.CommHopfAlgCat.{u} R) :
+    (counit (R := R) H).hom = _root_.Bialgebra.counitBialgHom R H :=
+  rfl
+
+/-- Pointwise formula for the ambient coordinate unit map `R → H`. -/
+@[simp]
+lemma unit_apply (H : _root_.CommHopfAlgCat.{u} R) (r : R) :
+    (unit (R := R) H).hom r = algebraMap R H r :=
+  rfl
+
+/-- Pointwise formula for the ambient coordinate counit map `H → R`. -/
+@[simp]
+lemma counit_apply (H : _root_.CommHopfAlgCat.{u} R) (h : H) :
+    (counit (R := R) H).hom h = Coalgebra.counit h :=
+  _root_.Bialgebra.counitBialgHom_apply h
+
+/-- The trivial coordinate Hopf algebra is initial in the ambient coordinate category. -/
+noncomputable def trivialIsInitial :
+    IsInitial (trivial R : _root_.CommHopfAlgCat.{u} R) :=
+  IsInitial.ofUniqueHom
+    (fun H => unit (R := R) H)
+    (fun H f => by
+      apply _root_.CommHopfAlgCat.hom_ext
+      apply _root_.BialgHom.coe_toAlgHom_injective
+      exact Subsingleton.elim _ _)
+
+/-- The unique ambient morphism out of the trivial coordinate Hopf algebra is the unit. -/
+lemma eq_unit (H : _root_.CommHopfAlgCat.{u} R)
+    (f : trivial R ⟶ H) :
+    f = unit (R := R) H :=
+  (trivialIsInitial (R := R)).hom_ext f (unit (R := R) H)
+
+end CommHopfAlgCat
+
 namespace FiniteTypeCommHopfAlgCat
 
 variable (R : Type u) [CommRing R]
@@ -50,7 +118,8 @@ finite-generation of the base algebra over itself. -/
 noncomputable abbrev trivial : FiniteTypeCommHopfAlgCat.{u, u} R :=
   of R R
 
-/-- The underlying type of the finite-type trivial coordinate Hopf algebra is the base ring. -/
+/-- The underlying coordinate Hopf algebra of the finite-type trivial coordinate Hopf algebra
+is the base ring over itself. -/
 @[simp]
 lemma trivial_obj :
     (trivial R).obj = (_root_.CommHopfAlgCat.of R R) :=
@@ -64,7 +133,7 @@ On coordinate Hopf algebras this is the bialgebra unit map `R → H`, contravari
 unique morphism from the represented affine group to the terminal affine group `Spec R`. -/
 noncomputable abbrev unit (H : FiniteTypeCommHopfAlgCat.{u, u} R) :
     trivial R ⟶ H :=
-  ofHom (_root_.Bialgebra.unitBialgHom R H)
+  ObjectProperty.homMk (CommHopfAlgCat.unit (R := R) H.obj)
 
 /-- The coordinate morphism from a finite-type affine group to the trivial affine group.
 
@@ -72,13 +141,15 @@ On coordinate Hopf algebras this is the bialgebra counit map `H → R`, contrava
 identity section `Spec R → G`. -/
 noncomputable abbrev counit (H : FiniteTypeCommHopfAlgCat.{u, u} R) :
     H ⟶ trivial R :=
-  ofHom (_root_.Bialgebra.counitBialgHom R H)
+  ObjectProperty.homMk (CommHopfAlgCat.counit (R := R) H.obj)
 
+/-- The finite-type coordinate unit morphism unwraps to Mathlib's bialgebra unit map. -/
 @[simp]
 lemma toBialgHom_unit (H : FiniteTypeCommHopfAlgCat.{u, u} R) :
     toBialgHom (unit H) = _root_.Bialgebra.unitBialgHom R H :=
   rfl
 
+/-- The finite-type coordinate counit morphism unwraps to Mathlib's bialgebra counit map. -/
 @[simp]
 lemma toBialgHom_counit (H : FiniteTypeCommHopfAlgCat.{u, u} R) :
     toBialgHom (counit H) = _root_.Bialgebra.counitBialgHom R H :=
@@ -87,7 +158,7 @@ lemma toBialgHom_counit (H : FiniteTypeCommHopfAlgCat.{u, u} R) :
 /-- Pointwise formula for the coordinate unit map `R → H`. -/
 @[simp]
 lemma unit_apply (H : FiniteTypeCommHopfAlgCat.{u, u} R) (r : R) :
-    (_root_.Bialgebra.unitBialgHom R H) r = algebraMap R H r :=
+    toBialgHom (unit H) r = algebraMap R H r :=
   rfl
 
 /-- Pointwise formula for the coordinate counit map `H → R`. -/
@@ -106,8 +177,8 @@ noncomputable def trivialIsInitial :
     (fun H => unit H)
     (fun H f => by
       apply hom_ext
-      apply _root_.BialgHom.coe_toAlgHom_injective
-      exact Subsingleton.elim _ _)
+      exact congrArg _root_.CommHopfAlgCat.Hom.hom
+        (CommHopfAlgCat.eq_unit H.obj f.hom))
 
 /-- The unique morphism out of the finite-type trivial coordinate Hopf algebra is the unit. -/
 lemma eq_unit (H : FiniteTypeCommHopfAlgCat.{u, u} R)
@@ -136,6 +207,22 @@ lemma trivialPointsMulEquiv_symm_apply (u : PUnit.{1}) :
     (trivialPointsMulEquiv (R := R) A).symm u =
       toConv (Algebra.ofId R A) :=
   TrivialGroup.pointsMulEquiv_symm_apply u
+
+variable {B : CommAlgCat.{w} R}
+
+/-- The finite-type trivial-points equivalence is natural in the value algebra. -/
+@[simp]
+theorem trivialPointsMulEquiv_mapValue (φ : A →ₐ[R] B)
+    (f : HopfAlgebra.points (R := R) (H := trivial R) A) :
+    trivialPointsMulEquiv (R := R) B (AlgHom.mapValue (H := trivial R) φ f) =
+      trivialPointsMulEquiv (R := R) A f :=
+  TrivialGroup.pointsMulEquiv_mapValue φ f
+
+/-- Naturality of the inverse finite-type trivial-points equivalence in the value algebra. -/
+theorem mapValue_trivialPointsMulEquiv_symm_apply (φ : A →ₐ[R] B) (u : PUnit.{1}) :
+    AlgHom.mapValue (H := trivial R) φ ((trivialPointsMulEquiv (R := R) A).symm u) =
+      (trivialPointsMulEquiv (R := R) B).symm u :=
+  TrivialGroup.mapValue_pointsMulEquiv_symm_apply φ u
 
 /-- Every point of the finite-type trivial affine group is the convolution identity. -/
 lemma trivialPoint_eq_one

--- a/TauCeti/Algebra/AlgebraicGroup/FiniteTypeTrivial.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/FiniteTypeTrivial.lean
@@ -16,13 +16,17 @@ Hopf-algebra category this object is initial: the unique morphism from `R` to a 
 Hopf algebra is the bialgebra unit map `R → H`. Contravariantly, this is the terminal object
 `Spec R` over `Spec R` in the affine-group-scheme dictionary.
 
+The file also records the counit morphism `H → R` and the pointwise formulas for the unit and
+counit maps.
+
 This is Layer 0 infrastructure for the ReductiveGroups roadmap: the finite-type
 coordinate-Hopf-algebra model needs the terminal affine group object over the base, separate
 from the already available raw Hopf-algebra points calculation in `TrivialGroup.pointsMulEquiv`.
 
 ## References
 
-The bialgebra unit map is Mathlib's `Bialgebra.unitBialgHom`.
+The bialgebra unit and counit maps are Mathlib's `Bialgebra.unitBialgHom` and
+`Bialgebra.counitBialgHom`.
 -/
 
 public section
@@ -72,6 +76,25 @@ lemma unit_apply (H : FiniteTypeCommHopfAlgCat.{u, u} R) (r : R) :
     toBialgHom (unit H) r = algebraMap R H r :=
   rfl
 
+/-- The coordinate morphism from a finite-type affine group to the trivial affine group.
+
+On coordinate Hopf algebras this is the bialgebra counit map `H → R`, contravariant to the
+identity section `Spec R → G`. -/
+noncomputable abbrev counit (H : FiniteTypeCommHopfAlgCat.{u, u} R) :
+    H ⟶ trivial R :=
+  ofHom (_root_.Bialgebra.counitBialgHom R H)
+
+/-- The finite-type coordinate counit morphism unwraps to Mathlib's bialgebra counit map. -/
+@[simp]
+lemma toBialgHom_counit (H : FiniteTypeCommHopfAlgCat.{u, u} R) :
+    toBialgHom (counit H) = _root_.Bialgebra.counitBialgHom R H :=
+  rfl
+
+/-- Pointwise formula for the coordinate counit map `H → R`. -/
+lemma counit_apply (H : FiniteTypeCommHopfAlgCat.{u, u} R) (h : H) :
+    toBialgHom (counit H) h = Coalgebra.counit h :=
+  _root_.Bialgebra.counitBialgHom_apply h
+
 /-- The finite-type trivial coordinate Hopf algebra is initial in the coordinate category.
 
 Equivalently, in the opposite affine-group-scheme direction it represents the terminal
@@ -91,7 +114,7 @@ lemma eq_unit (H : FiniteTypeCommHopfAlgCat.{u, u} R)
     f = unit H :=
   (trivialIsInitial (R := R)).hom_ext f (unit H)
 
-variable (A : CommAlgCat.{w} R)
+variable (A : CommAlgCat.{v} R)
 
 /-- The functor of points of the finite-type trivial affine group is the one-element group. -/
 noncomputable def trivialPointsMulEquiv :
@@ -113,7 +136,7 @@ theorem trivialPointsMulEquiv_symm_apply (u : PUnit.{1}) :
     (trivialPointsMulEquiv A).symm u = toConv (Algebra.ofId R A) :=
   TrivialGroup.pointsMulEquiv_symm_apply (R := R) (A := A) u
 
-variable {A} {B : CommAlgCat.{w} R}
+variable {A : CommAlgCat.{v} R} {B : CommAlgCat.{w} R}
 
 /-- The finite-type trivial-points equivalence is natural in the value algebra.
 

--- a/TauCeti/Algebra/AlgebraicGroup/FiniteTypeTrivial.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/FiniteTypeTrivial.lean
@@ -91,7 +91,6 @@ lemma unit_apply (H : FiniteTypeCommHopfAlgCat.{u, u} R) (r : R) :
   rfl
 
 /-- Pointwise formula for the coordinate counit map `H → R`. -/
-@[simp]
 lemma counit_apply (H : FiniteTypeCommHopfAlgCat.{u, u} R) (h : H) :
     toBialgHom (counit H) h = Coalgebra.counit h :=
   _root_.Bialgebra.counitBialgHom_apply h

--- a/TauCeti/Algebra/AlgebraicGroup/FiniteTypeTrivial.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/FiniteTypeTrivial.lean
@@ -5,6 +5,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 module
 
 public import TauCeti.Algebra.AlgebraicGroup.FiniteTypeCommHopfAlgCat
+public import TauCeti.Algebra.AlgebraicGroup.Trivial
 
 /-!
 # The finite-type trivial affine group
@@ -94,6 +95,13 @@ lemma counit_apply (H : FiniteTypeCommHopfAlgCat.{u, u} R) (h : H) :
     toBialgHom (counit H) h = Coalgebra.counit h :=
   _root_.Bialgebra.counitBialgHom_apply h
 
+/-- The counit retracts the unit back to the identity of the trivial coordinate Hopf algebra. -/
+lemma unit_comp_counit (H : FiniteTypeCommHopfAlgCat.{u, u} R) :
+    unit H ≫ counit H = 𝟙 (trivial R) := by
+  apply hom_ext
+  apply _root_.BialgHom.coe_toAlgHom_injective
+  exact Subsingleton.elim _ _
+
 /-- The finite-type trivial coordinate Hopf algebra is initial in the coordinate category.
 
 Equivalently, in the opposite affine-group-scheme direction it represents the terminal
@@ -117,14 +125,8 @@ variable (A : CommAlgCat.{w} R)
 
 /-- The functor of points of the finite-type trivial affine group is the one-element group. -/
 noncomputable def trivialPointsMulEquiv :
-    HopfAlgebra.points (R := R) (H := trivial R) A ≃* PUnit.{1} where
-  toFun _ := PUnit.unit
-  invFun _ := toConv (Algebra.ofId R A)
-  left_inv f := by
-    apply WithConv.ofConv_injective
-    exact Subsingleton.elim _ _
-  right_inv _ := rfl
-  map_mul' _ _ := rfl
+    HopfAlgebra.points (R := R) (H := trivial R) A ≃* PUnit.{1} :=
+  TrivialGroup.pointsMulEquiv (R := R) (A := A)
 
 /-- The finite-type trivial-points equivalence sends every point to the unique element of
 `PUnit`. -/
@@ -132,15 +134,14 @@ noncomputable def trivialPointsMulEquiv :
 theorem trivialPointsMulEquiv_apply
     (f : HopfAlgebra.points (R := R) (H := trivial R) A) :
     trivialPointsMulEquiv A f = PUnit.unit :=
-  rfl
+  TrivialGroup.pointsMulEquiv_apply (R := R) (A := A) f
 
 /-- The inverse finite-type trivial-points equivalence sends the unique element of `PUnit` to
 `Algebra.ofId`. -/
 @[simp]
 theorem trivialPointsMulEquiv_symm_apply (u : PUnit.{1}) :
-    (trivialPointsMulEquiv A).symm u = toConv (Algebra.ofId R A) := by
-  cases u
-  rfl
+    (trivialPointsMulEquiv A).symm u = toConv (Algebra.ofId R A) :=
+  TrivialGroup.pointsMulEquiv_symm_apply (R := R) (A := A) u
 
 variable {A} {B : CommAlgCat.{w} R}
 
@@ -150,14 +151,13 @@ theorem trivialPointsMulEquiv_mapValue (φ : A →ₐ[R] B)
     (f : HopfAlgebra.points (R := R) (H := trivial R) A) :
     trivialPointsMulEquiv B (AlgHom.mapValue (H := trivial R) φ f) =
       trivialPointsMulEquiv A f :=
-  rfl
+  TrivialGroup.pointsMulEquiv_mapValue (R := R) (A := A) (B := B) φ f
 
 /-- Naturality of the inverse finite-type trivial-points equivalence in the value algebra. -/
 theorem mapValue_trivialPointsMulEquiv_symm_apply (φ : A →ₐ[R] B) (u : PUnit.{1}) :
     AlgHom.mapValue (H := trivial R) φ ((trivialPointsMulEquiv A).symm u) =
-      (trivialPointsMulEquiv B).symm u := by
-  apply (trivialPointsMulEquiv B).injective
-  rw [trivialPointsMulEquiv_mapValue]
+      (trivialPointsMulEquiv B).symm u :=
+  TrivialGroup.mapValue_pointsMulEquiv_symm_apply (R := R) (A := A) (B := B) φ u
 
 end FiniteTypeCommHopfAlgCat
 

--- a/TauCeti/Algebra/AlgebraicGroup/FiniteTypeTrivial.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/FiniteTypeTrivial.lean
@@ -35,7 +35,7 @@ open CategoryTheory CategoryTheory.Limits WithConv
 
 namespace TauCeti
 
-universe u
+universe u v w
 
 namespace FiniteTypeCommHopfAlgCat
 
@@ -63,7 +63,8 @@ On coordinate Hopf algebras this is the bialgebra unit map `R → H`, contravari
 unique morphism from the represented affine group to the terminal affine group `Spec R`. -/
 noncomputable abbrev unit (H : FiniteTypeCommHopfAlgCat.{u, u} R) :
     trivial R ⟶ H :=
-  ObjectProperty.homMk (CommHopfAlgCat.unit (R := R) H.obj)
+  ObjectProperty.homMk
+    (_root_.CommHopfAlgCat.ofHom (_root_.Bialgebra.unitBialgHom R H.obj))
 
 /-- The coordinate morphism from a finite-type affine group to the trivial affine group.
 
@@ -71,7 +72,8 @@ On coordinate Hopf algebras this is the bialgebra counit map `H → R`, contrava
 identity section `Spec R → G`. -/
 noncomputable abbrev counit (H : FiniteTypeCommHopfAlgCat.{u, u} R) :
     H ⟶ trivial R :=
-  ObjectProperty.homMk (CommHopfAlgCat.counit (R := R) H.obj)
+  ObjectProperty.homMk
+    (_root_.CommHopfAlgCat.ofHom (_root_.Bialgebra.counitBialgHom R H.obj))
 
 /-- The finite-type coordinate unit morphism unwraps to Mathlib's bialgebra unit map. -/
 @[simp]
@@ -88,7 +90,7 @@ lemma toBialgHom_counit (H : FiniteTypeCommHopfAlgCat.{u, u} R) :
 /-- Pointwise formula for the coordinate unit map `R → H`. -/
 @[simp]
 lemma unit_apply (H : FiniteTypeCommHopfAlgCat.{u, u} R) (r : R) :
-    (_root_.Bialgebra.unitBialgHom R H.obj) r = algebraMap R H r :=
+    toBialgHom (unit H) r = algebraMap R H r :=
   rfl
 
 /-- Pointwise formula for the coordinate counit map `H → R`. -/
@@ -107,8 +109,8 @@ noncomputable def trivialIsInitial :
     (fun H => unit H)
     (fun H f => by
       apply hom_ext
-      exact congrArg _root_.CommHopfAlgCat.Hom.hom
-        (CommHopfAlgCat.eq_unit H.obj f.hom))
+      apply _root_.BialgHom.coe_toAlgHom_injective
+      exact Subsingleton.elim _ _)
 
 /-- The unique morphism out of the finite-type trivial coordinate Hopf algebra is the unit. -/
 lemma eq_unit (H : FiniteTypeCommHopfAlgCat.{u, u} R)
@@ -116,7 +118,7 @@ lemma eq_unit (H : FiniteTypeCommHopfAlgCat.{u, u} R)
     f = unit H :=
   (trivialIsInitial (R := R)).hom_ext f (unit H)
 
-variable (A : CommAlgCat.{u} R)
+variable (A : CommAlgCat.{v} R)
 
 /-- The functor of points of the finite-type trivial affine group is the one-element group. -/
 noncomputable def trivialPointsMulEquiv :
@@ -135,7 +137,7 @@ theorem trivialPointsMulEquiv_symm_apply (u : PUnit.{1}) :
     (trivialPointsMulEquiv A).symm u = toConv (Algebra.ofId R A) :=
   TrivialGroup.pointsMulEquiv_symm_apply (R := R) (A := A) u
 
-variable {B : CommAlgCat.{u} R}
+variable {B : CommAlgCat.{w} R}
 
 /-- The finite-type trivial-group points equivalence is natural in the value algebra. -/
 theorem trivialPointsMulEquiv_mapValue (φ : A →ₐ[R] B)

--- a/TauCeti/Algebra/AlgebraicGroup/FiniteTypeTrivial.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/FiniteTypeTrivial.lean
@@ -16,17 +16,13 @@ Hopf-algebra category this object is initial: the unique morphism from `R` to a 
 Hopf algebra is the bialgebra unit map `R → H`. Contravariantly, this is the terminal object
 `Spec R` over `Spec R` in the affine-group-scheme dictionary.
 
-The file also records the counit morphism `H → R` and the pointwise formulas for the unit and
-counit maps.
-
 This is Layer 0 infrastructure for the ReductiveGroups roadmap: the finite-type
 coordinate-Hopf-algebra model needs the terminal affine group object over the base, separate
 from the already available raw Hopf-algebra points calculation in `TrivialGroup.pointsMulEquiv`.
 
 ## References
 
-The bialgebra unit and counit maps are Mathlib's `Bialgebra.unitBialgHom` and
-`Bialgebra.counitBialgHom`.
+The bialgebra unit map is Mathlib's `Bialgebra.unitBialgHom`.
 -/
 
 public section
@@ -65,42 +61,16 @@ noncomputable abbrev unit (H : FiniteTypeCommHopfAlgCat.{u, u} R) :
     trivial R ⟶ H :=
   ofHom (_root_.Bialgebra.unitBialgHom R H)
 
-/-- The coordinate morphism from a finite-type affine group to the trivial affine group.
-
-On coordinate Hopf algebras this is the bialgebra counit map `H → R`, contravariant to the
-identity section `Spec R → G`. -/
-noncomputable abbrev counit (H : FiniteTypeCommHopfAlgCat.{u, u} R) :
-    H ⟶ trivial R :=
-  ofHom (_root_.Bialgebra.counitBialgHom R H)
-
 /-- The finite-type coordinate unit morphism unwraps to Mathlib's bialgebra unit map. -/
 @[simp]
 lemma toBialgHom_unit (H : FiniteTypeCommHopfAlgCat.{u, u} R) :
     toBialgHom (unit H) = _root_.Bialgebra.unitBialgHom R H :=
   rfl
 
-/-- The finite-type coordinate counit morphism unwraps to Mathlib's bialgebra counit map. -/
-@[simp]
-lemma toBialgHom_counit (H : FiniteTypeCommHopfAlgCat.{u, u} R) :
-    toBialgHom (counit H) = _root_.Bialgebra.counitBialgHom R H :=
-  rfl
-
 /-- Pointwise formula for the coordinate unit map `R → H`. -/
 lemma unit_apply (H : FiniteTypeCommHopfAlgCat.{u, u} R) (r : R) :
     toBialgHom (unit H) r = algebraMap R H r :=
   rfl
-
-/-- Pointwise formula for the coordinate counit map `H → R`. -/
-lemma counit_apply (H : FiniteTypeCommHopfAlgCat.{u, u} R) (h : H) :
-    toBialgHom (counit H) h = Coalgebra.counit h :=
-  _root_.Bialgebra.counitBialgHom_apply h
-
-/-- The counit retracts the unit back to the identity of the trivial coordinate Hopf algebra. -/
-lemma unit_comp_counit (H : FiniteTypeCommHopfAlgCat.{u, u} R) :
-    unit H ≫ counit H = 𝟙 (trivial R) := by
-  apply hom_ext
-  apply _root_.BialgHom.coe_toAlgHom_injective
-  exact Subsingleton.elim _ _
 
 /-- The finite-type trivial coordinate Hopf algebra is initial in the coordinate category.
 

--- a/TauCeti/Algebra/AlgebraicGroup/FiniteTypeTrivial.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/FiniteTypeTrivial.lean
@@ -16,8 +16,8 @@ Hopf-algebra category this object is initial: the unique morphism from `R` to a 
 Hopf algebra is the bialgebra unit map `R → H`. Contravariantly, this is the terminal object
 `Spec R` over `Spec R` in the affine-group-scheme dictionary.
 
-The file also records the counit morphism `H → R` and the pointwise formulas for the unit and
-counit maps.
+The initial morphism is built directly from Mathlib's bialgebra unit map through the
+finite-type `ofHom` bridge.
 
 This is Layer 0 infrastructure for the ReductiveGroups roadmap: the finite-type
 coordinate-Hopf-algebra model needs the terminal affine group object over the base, separate
@@ -25,8 +25,7 @@ from the already available raw Hopf-algebra points calculation in `TrivialGroup.
 
 ## References
 
-The bialgebra unit and counit maps are Mathlib's `Bialgebra.unitBialgHom` and
-`Bialgebra.counitBialgHom`.
+The bialgebra unit map is Mathlib's `Bialgebra.unitBialgHom`.
 -/
 
 public section
@@ -57,44 +56,6 @@ lemma trivial_obj :
 
 variable {R}
 
-/-- The coordinate morphism from the trivial affine group to a finite-type affine group.
-
-On coordinate Hopf algebras this is the bialgebra unit map `R → H`, contravariant to the
-unique morphism from the represented affine group to the terminal affine group `Spec R`. -/
-noncomputable abbrev unit (H : FiniteTypeCommHopfAlgCat.{u, u} R) :
-    trivial R ⟶ H :=
-  ofHom (_root_.Bialgebra.unitBialgHom R H)
-
-/-- The coordinate morphism from a finite-type affine group to the trivial affine group.
-
-On coordinate Hopf algebras this is the bialgebra counit map `H → R`, contravariant to the
-identity section `Spec R → G`. -/
-noncomputable abbrev counit (H : FiniteTypeCommHopfAlgCat.{u, u} R) :
-    H ⟶ trivial R :=
-  ofHom (_root_.Bialgebra.counitBialgHom R H)
-
-/-- The finite-type coordinate unit morphism unwraps to Mathlib's bialgebra unit map. -/
-@[simp]
-lemma toBialgHom_unit (H : FiniteTypeCommHopfAlgCat.{u, u} R) :
-    toBialgHom (unit H) = _root_.Bialgebra.unitBialgHom R H :=
-  rfl
-
-/-- The finite-type coordinate counit morphism unwraps to Mathlib's bialgebra counit map. -/
-@[simp]
-lemma toBialgHom_counit (H : FiniteTypeCommHopfAlgCat.{u, u} R) :
-    toBialgHom (counit H) = _root_.Bialgebra.counitBialgHom R H :=
-  rfl
-
-/-- Pointwise formula for the coordinate unit map `R → H`. -/
-lemma unit_apply (H : FiniteTypeCommHopfAlgCat.{u, u} R) (r : R) :
-    toBialgHom (unit H) r = algebraMap R H r :=
-  rfl
-
-/-- Pointwise formula for the coordinate counit map `H → R`. -/
-lemma counit_apply (H : FiniteTypeCommHopfAlgCat.{u, u} R) (h : H) :
-    toBialgHom (counit H) h = Coalgebra.counit h :=
-  _root_.Bialgebra.counitBialgHom_apply h
-
 /-- The finite-type trivial coordinate Hopf algebra is initial in the coordinate category.
 
 Equivalently, in the opposite affine-group-scheme direction it represents the terminal
@@ -102,17 +63,18 @@ object `Spec R` over the base. -/
 noncomputable def trivialIsInitial :
     IsInitial (trivial R : FiniteTypeCommHopfAlgCat.{u, u} R) :=
   IsInitial.ofUniqueHom
-    (fun H => unit H)
+    (fun H => ofHom (_root_.Bialgebra.unitBialgHom R H))
     (fun H f => by
       apply hom_ext
       apply _root_.BialgHom.coe_toAlgHom_injective
       exact Subsingleton.elim _ _)
 
-/-- The unique morphism out of the finite-type trivial coordinate Hopf algebra is the unit. -/
+/-- The unique morphism out of the finite-type trivial coordinate Hopf algebra is the
+bialgebra unit map. -/
 lemma eq_unit (H : FiniteTypeCommHopfAlgCat.{u, u} R)
     (f : trivial R ⟶ H) :
-    f = unit H :=
-  (trivialIsInitial (R := R)).hom_ext f (unit H)
+    f = ofHom (_root_.Bialgebra.unitBialgHom R H) :=
+  (trivialIsInitial (R := R)).hom_ext f (ofHom (_root_.Bialgebra.unitBialgHom R H))
 
 end FiniteTypeCommHopfAlgCat
 

--- a/TauCeti/Algebra/AlgebraicGroup/Trivial.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/Trivial.lean
@@ -4,7 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 -/
 module
 
-public import TauCeti.Algebra.AlgebraicGroup.FunctorOfPoints
+public import TauCeti.Algebra.AlgebraicGroup.CommHopfAlgCat
 
 /-!
 # The trivial affine group
@@ -21,6 +21,13 @@ ReductiveGroups roadmap, Layer 0. It is the identity object needed by the produc
 
 ## Main declarations
 
+* `TauCeti.CommHopfAlgCat.trivial`: the base ring as a commutative Hopf algebra over itself.
+* `TauCeti.CommHopfAlgCat.unit`: the bialgebra unit as the unique morphism out of the
+  trivial coordinate Hopf algebra.
+* `TauCeti.CommHopfAlgCat.counit`: the bialgebra counit as the morphism to the trivial
+  coordinate Hopf algebra.
+* `TauCeti.CommHopfAlgCat.trivialIsInitial`: the base-ring Hopf algebra is initial in the
+  coordinate category.
 * `TauCeti.TrivialGroup.pointsMulEquiv`: the convolution group of points is `PUnit`.
 * `TauCeti.TrivialGroup.pointsMulEquiv_mapValue`: the equivalence is natural in the value
   algebra.
@@ -33,11 +40,85 @@ canonical Hopf algebra structure on `R` over itself from `Mathlib.RingTheory.Hop
 
 public section
 
-open WithConv
+open CategoryTheory CategoryTheory.Limits WithConv
 
 namespace TauCeti
 
 universe u v w
+
+namespace CommHopfAlgCat
+
+variable (R : Type u) [CommRing R]
+
+/-- The coordinate Hopf algebra of the trivial affine group over `R`. -/
+noncomputable abbrev trivial : _root_.CommHopfAlgCat.{u} R :=
+  _root_.CommHopfAlgCat.of R R
+
+/-- The trivial coordinate Hopf algebra is the base ring over itself. -/
+@[simp]
+lemma trivial_obj :
+    (trivial R) = (_root_.CommHopfAlgCat.of R R) :=
+  rfl
+
+variable {R}
+
+/-- The coordinate morphism from the trivial affine group to an affine group.
+
+On coordinate Hopf algebras this is the bialgebra unit map `R → H`. -/
+noncomputable abbrev unit (H : _root_.CommHopfAlgCat.{u} R) :
+    trivial R ⟶ H :=
+  _root_.CommHopfAlgCat.ofHom (_root_.Bialgebra.unitBialgHom R H)
+
+/-- The coordinate morphism from an affine group to the trivial affine group.
+
+On coordinate Hopf algebras this is the bialgebra counit map `H → R`. -/
+noncomputable abbrev counit (H : _root_.CommHopfAlgCat.{u} R) :
+    H ⟶ trivial R :=
+  _root_.CommHopfAlgCat.ofHom (_root_.Bialgebra.counitBialgHom R H)
+
+/-- The coordinate unit morphism unwraps to Mathlib's bialgebra unit map. -/
+@[simp]
+lemma hom_unit (H : _root_.CommHopfAlgCat.{u} R) :
+    (unit H).hom = _root_.Bialgebra.unitBialgHom R H :=
+  rfl
+
+/-- The coordinate counit morphism unwraps to Mathlib's bialgebra counit map. -/
+@[simp]
+lemma hom_counit (H : _root_.CommHopfAlgCat.{u} R) :
+    (counit H).hom = _root_.Bialgebra.counitBialgHom R H :=
+  rfl
+
+/-- Pointwise formula for the coordinate unit map `R → H`. -/
+lemma unit_apply (H : _root_.CommHopfAlgCat.{u} R) (r : R) :
+    (unit H).hom r = algebraMap R H r :=
+  rfl
+
+/-- Pointwise formula for the coordinate counit map `H → R`. -/
+@[simp]
+lemma counit_apply (H : _root_.CommHopfAlgCat.{u} R) (h : H) :
+    (counit H).hom h = Coalgebra.counit h :=
+  _root_.Bialgebra.counitBialgHom_apply h
+
+/-- The trivial coordinate Hopf algebra is initial in the coordinate category.
+
+Equivalently, in the opposite affine-group-scheme direction it represents the terminal object
+`Spec R` over the base. -/
+noncomputable def trivialIsInitial :
+    IsInitial (trivial R : _root_.CommHopfAlgCat.{u} R) :=
+  IsInitial.ofUniqueHom
+    (fun H => unit H)
+    (fun H f => by
+      apply _root_.CommHopfAlgCat.hom_ext
+      apply _root_.BialgHom.coe_toAlgHom_injective
+      exact Subsingleton.elim _ _)
+
+/-- The unique morphism out of the trivial coordinate Hopf algebra is the unit. -/
+lemma eq_unit (H : _root_.CommHopfAlgCat.{u} R)
+    (f : trivial R ⟶ H) :
+    f = unit H :=
+  (trivialIsInitial (R := R)).hom_ext f (unit H)
+
+end CommHopfAlgCat
 
 namespace TrivialGroup
 

--- a/TauCeti/Algebra/AlgebraicGroup/Trivial.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/Trivial.lean
@@ -4,7 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 -/
 module
 
-public import TauCeti.Algebra.AlgebraicGroup.CommHopfAlgCat
+public import TauCeti.Algebra.AlgebraicGroup.FunctorOfPoints
 
 /-!
 # The trivial affine group
@@ -33,7 +33,7 @@ canonical Hopf algebra structure on `R` over itself from `Mathlib.RingTheory.Hop
 
 public section
 
-open CategoryTheory CategoryTheory.Limits WithConv
+open WithConv
 
 namespace TauCeti
 

--- a/TauCeti/Algebra/AlgebraicGroup/Trivial.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/Trivial.lean
@@ -85,7 +85,6 @@ lemma unit_apply (H : _root_.CommHopfAlgCat.{u} R) (r : R) :
   rfl
 
 /-- Pointwise formula for the ambient coordinate counit map `H → R`. -/
-@[simp]
 lemma counit_apply (H : _root_.CommHopfAlgCat.{u} R) (h : H) :
     (counit (R := R) H).hom h = Coalgebra.counit h :=
   _root_.Bialgebra.counitBialgHom_apply h

--- a/TauCeti/Algebra/AlgebraicGroup/Trivial.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/Trivial.lean
@@ -85,6 +85,7 @@ lemma unit_apply (H : _root_.CommHopfAlgCat.{u} R) (r : R) :
   rfl
 
 /-- Pointwise formula for the ambient coordinate counit map `H → R`. -/
+@[simp]
 lemma counit_apply (H : _root_.CommHopfAlgCat.{u} R) (h : H) :
     (counit (R := R) H).hom h = Coalgebra.counit h :=
   _root_.Bialgebra.counitBialgHom_apply h

--- a/TauCeti/Algebra/AlgebraicGroup/Trivial.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/Trivial.lean
@@ -21,13 +21,6 @@ ReductiveGroups roadmap, Layer 0. It is the identity object needed by the produc
 
 ## Main declarations
 
-* `TauCeti.CommHopfAlgCat.trivial`: the base ring as a commutative Hopf algebra over itself.
-* `TauCeti.CommHopfAlgCat.unit`: the bialgebra unit as the unique morphism out of the
-  trivial coordinate Hopf algebra.
-* `TauCeti.CommHopfAlgCat.counit`: the bialgebra counit as the morphism to the trivial
-  coordinate Hopf algebra.
-* `TauCeti.CommHopfAlgCat.trivialIsInitial`: the base-ring Hopf algebra is initial in the
-  coordinate category.
 * `TauCeti.TrivialGroup.pointsMulEquiv`: the convolution group of points is `PUnit`.
 * `TauCeti.TrivialGroup.pointsMulEquiv_mapValue`: the equivalence is natural in the value
   algebra.
@@ -45,79 +38,6 @@ open CategoryTheory CategoryTheory.Limits WithConv
 namespace TauCeti
 
 universe u v w
-
-namespace CommHopfAlgCat
-
-variable (R : Type u) [CommRing R]
-
-/-- The coordinate Hopf algebra of the trivial affine group over `R`. -/
-noncomputable abbrev trivial : _root_.CommHopfAlgCat.{u} R :=
-  _root_.CommHopfAlgCat.of R R
-
-/-- The trivial coordinate Hopf algebra is the base ring over itself. -/
-@[simp]
-lemma trivial_obj :
-    (trivial R) = (_root_.CommHopfAlgCat.of R R) :=
-  rfl
-
-variable {R}
-
-/-- The coordinate morphism from the trivial affine group to an affine group.
-
-On coordinate Hopf algebras this is the bialgebra unit map `R → H`. -/
-noncomputable abbrev unit (H : _root_.CommHopfAlgCat.{u} R) :
-    trivial R ⟶ H :=
-  _root_.CommHopfAlgCat.ofHom (_root_.Bialgebra.unitBialgHom R H)
-
-/-- The coordinate morphism from an affine group to the trivial affine group.
-
-On coordinate Hopf algebras this is the bialgebra counit map `H → R`. -/
-noncomputable abbrev counit (H : _root_.CommHopfAlgCat.{u} R) :
-    H ⟶ trivial R :=
-  _root_.CommHopfAlgCat.ofHom (_root_.Bialgebra.counitBialgHom R H)
-
-/-- The coordinate unit morphism unwraps to Mathlib's bialgebra unit map. -/
-@[simp]
-lemma hom_unit (H : _root_.CommHopfAlgCat.{u} R) :
-    (unit H).hom = _root_.Bialgebra.unitBialgHom R H :=
-  rfl
-
-/-- The coordinate counit morphism unwraps to Mathlib's bialgebra counit map. -/
-@[simp]
-lemma hom_counit (H : _root_.CommHopfAlgCat.{u} R) :
-    (counit H).hom = _root_.Bialgebra.counitBialgHom R H :=
-  rfl
-
-/-- Pointwise formula for the coordinate unit map `R → H`. -/
-lemma unit_apply (H : _root_.CommHopfAlgCat.{u} R) (r : R) :
-    (unit H).hom r = algebraMap R H r :=
-  rfl
-
-/-- Pointwise formula for the coordinate counit map `H → R`. -/
-lemma counit_apply (H : _root_.CommHopfAlgCat.{u} R) (h : H) :
-    (counit H).hom h = Coalgebra.counit h :=
-  _root_.Bialgebra.counitBialgHom_apply h
-
-/-- The trivial coordinate Hopf algebra is initial in the coordinate category.
-
-Equivalently, in the opposite affine-group-scheme direction it represents the terminal object
-`Spec R` over the base. -/
-noncomputable def trivialIsInitial :
-    IsInitial (trivial R : _root_.CommHopfAlgCat.{u} R) :=
-  IsInitial.ofUniqueHom
-    (fun H => unit H)
-    (fun H f => by
-      apply _root_.CommHopfAlgCat.hom_ext
-      apply _root_.BialgHom.coe_toAlgHom_injective
-      exact Subsingleton.elim _ _)
-
-/-- The unique morphism out of the trivial coordinate Hopf algebra is the unit. -/
-lemma eq_unit (H : _root_.CommHopfAlgCat.{u} R)
-    (f : trivial R ⟶ H) :
-    f = unit H :=
-  (trivialIsInitial (R := R)).hom_ext f (unit H)
-
-end CommHopfAlgCat
 
 namespace TrivialGroup
 

--- a/TauCeti/Algebra/AlgebraicGroup/Trivial.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/Trivial.lean
@@ -94,7 +94,6 @@ lemma unit_apply (H : _root_.CommHopfAlgCat.{u} R) (r : R) :
   rfl
 
 /-- Pointwise formula for the coordinate counit map `H → R`. -/
-@[simp]
 lemma counit_apply (H : _root_.CommHopfAlgCat.{u} R) (h : H) :
     (counit H).hom h = Coalgebra.counit h :=
   _root_.Bialgebra.counitBialgHom_apply h

--- a/TauCeti/Algebra/AlgebraicGroup/Trivial.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/Trivial.lean
@@ -4,7 +4,8 @@ Released under Apache 2.0 license as described in the file LICENSE.
 -/
 module
 
-public import TauCeti.Algebra.AlgebraicGroup.FunctorOfPoints
+public import Mathlib.CategoryTheory.Limits.Shapes.Terminal
+public import TauCeti.Algebra.AlgebraicGroup.CommHopfAlgCat
 
 /-!
 # The trivial affine group
@@ -33,13 +34,81 @@ canonical Hopf algebra structure on `R` over itself from `Mathlib.RingTheory.Hop
 
 public section
 
-open WithConv
+open CategoryTheory CategoryTheory.Limits WithConv
 
 namespace TauCeti
 
-namespace TrivialGroup
-
 universe u v w
+
+namespace CommHopfAlgCat
+
+variable (R : Type u) [CommRing R]
+
+/-- The coordinate Hopf algebra of the trivial affine group over `R`.
+
+Its underlying Hopf algebra is `R` over itself. -/
+noncomputable abbrev trivial : _root_.CommHopfAlgCat.{u} R :=
+  _root_.CommHopfAlgCat.of R R
+
+/-- The coordinate morphism from the trivial affine group to an affine group.
+
+On coordinate Hopf algebras this is the bialgebra unit map `R → H`. -/
+noncomputable abbrev unit (H : _root_.CommHopfAlgCat.{u} R) :
+    trivial R ⟶ H :=
+  _root_.CommHopfAlgCat.ofHom (_root_.Bialgebra.unitBialgHom R H)
+
+/-- The coordinate morphism from an affine group to the trivial affine group.
+
+On coordinate Hopf algebras this is the bialgebra counit map `H → R`. -/
+noncomputable abbrev counit (H : _root_.CommHopfAlgCat.{u} R) :
+    H ⟶ trivial R :=
+  _root_.CommHopfAlgCat.ofHom (_root_.Bialgebra.counitBialgHom R H)
+
+variable {R}
+
+/-- The ambient coordinate unit morphism unwraps to Mathlib's bialgebra unit map. -/
+@[simp]
+lemma hom_unit (H : _root_.CommHopfAlgCat.{u} R) :
+    (unit (R := R) H).hom = _root_.Bialgebra.unitBialgHom R H :=
+  rfl
+
+/-- The ambient coordinate counit morphism unwraps to Mathlib's bialgebra counit map. -/
+@[simp]
+lemma hom_counit (H : _root_.CommHopfAlgCat.{u} R) :
+    (counit (R := R) H).hom = _root_.Bialgebra.counitBialgHom R H :=
+  rfl
+
+/-- Pointwise formula for the ambient coordinate unit map `R → H`. -/
+@[simp]
+lemma unit_apply (H : _root_.CommHopfAlgCat.{u} R) (r : R) :
+    (_root_.Bialgebra.unitBialgHom R H) r = algebraMap R H r :=
+  rfl
+
+/-- Pointwise formula for the ambient coordinate counit map `H → R`. -/
+@[simp]
+lemma counit_apply (H : _root_.CommHopfAlgCat.{u} R) (h : H) :
+    (counit (R := R) H).hom h = Coalgebra.counit h :=
+  _root_.Bialgebra.counitBialgHom_apply h
+
+/-- The trivial coordinate Hopf algebra is initial in the ambient coordinate category. -/
+noncomputable def trivialIsInitial :
+    IsInitial (trivial R : _root_.CommHopfAlgCat.{u} R) :=
+  IsInitial.ofUniqueHom
+    (fun H => unit (R := R) H)
+    (fun H f => by
+      apply _root_.CommHopfAlgCat.hom_ext
+      apply _root_.BialgHom.coe_toAlgHom_injective
+      exact Subsingleton.elim _ _)
+
+/-- The unique ambient morphism out of the trivial coordinate Hopf algebra is the unit. -/
+lemma eq_unit (H : _root_.CommHopfAlgCat.{u} R)
+    (f : trivial R ⟶ H) :
+    f = unit (R := R) H :=
+  (trivialIsInitial (R := R)).hom_ext f (unit (R := R) H)
+
+end CommHopfAlgCat
+
+namespace TrivialGroup
 
 variable {R : Type u} {A : Type v}
 variable [CommSemiring R] [CommSemiring A] [Algebra R A]

--- a/TauCeti/Algebra/AlgebraicGroup/Trivial.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/Trivial.lean
@@ -4,8 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 -/
 module
 
-public import Mathlib.CategoryTheory.Limits.Shapes.Terminal
-public import TauCeti.Algebra.AlgebraicGroup.CommHopfAlgCat
+public import TauCeti.Algebra.AlgebraicGroup.FunctorOfPoints
 
 /-!
 # The trivial affine group
@@ -17,8 +16,8 @@ homomorphism `R →ₐ[R] A`, namely `Algebra.ofId R A`; consequently the convol
 `A`-points is the one-element group `PUnit`.
 
 This is the terminal-object example in the Hopf-algebra/functor-of-points side of the
-ReductiveGroups roadmap, Layer 0. It is the identity object needed by the product and affine
-group scheme dictionary: `Spec R` over `Spec R` represents the trivial group-valued functor.
+ReductiveGroups roadmap, Layer 0. It is the identity object needed by the product dictionary:
+`Spec R` over `Spec R` represents the trivial group-valued functor.
 
 ## Main declarations
 
@@ -34,78 +33,11 @@ canonical Hopf algebra structure on `R` over itself from `Mathlib.RingTheory.Hop
 
 public section
 
-open CategoryTheory CategoryTheory.Limits WithConv
+open WithConv
 
 namespace TauCeti
 
 universe u v w
-
-namespace CommHopfAlgCat
-
-variable (R : Type u) [CommRing R]
-
-/-- The coordinate Hopf algebra of the trivial affine group over `R`.
-
-Its underlying Hopf algebra is `R` over itself. -/
-noncomputable abbrev trivial : _root_.CommHopfAlgCat.{u} R :=
-  _root_.CommHopfAlgCat.of R R
-
-/-- The coordinate morphism from the trivial affine group to an affine group.
-
-On coordinate Hopf algebras this is the bialgebra unit map `R → H`. -/
-noncomputable abbrev unit (H : _root_.CommHopfAlgCat.{u} R) :
-    trivial R ⟶ H :=
-  _root_.CommHopfAlgCat.ofHom (_root_.Bialgebra.unitBialgHom R H)
-
-/-- The coordinate morphism from an affine group to the trivial affine group.
-
-On coordinate Hopf algebras this is the bialgebra counit map `H → R`. -/
-noncomputable abbrev counit (H : _root_.CommHopfAlgCat.{u} R) :
-    H ⟶ trivial R :=
-  _root_.CommHopfAlgCat.ofHom (_root_.Bialgebra.counitBialgHom R H)
-
-variable {R}
-
-/-- The ambient coordinate unit morphism unwraps to Mathlib's bialgebra unit map. -/
-@[simp]
-lemma hom_unit (H : _root_.CommHopfAlgCat.{u} R) :
-    (unit (R := R) H).hom = _root_.Bialgebra.unitBialgHom R H :=
-  rfl
-
-/-- The ambient coordinate counit morphism unwraps to Mathlib's bialgebra counit map. -/
-@[simp]
-lemma hom_counit (H : _root_.CommHopfAlgCat.{u} R) :
-    (counit (R := R) H).hom = _root_.Bialgebra.counitBialgHom R H :=
-  rfl
-
-/-- Pointwise formula for the ambient coordinate unit map `R → H`. -/
-@[simp]
-lemma unit_apply (H : _root_.CommHopfAlgCat.{u} R) (r : R) :
-    (_root_.Bialgebra.unitBialgHom R H) r = algebraMap R H r :=
-  rfl
-
-/-- Pointwise formula for the ambient coordinate counit map `H → R`. -/
-lemma counit_apply (H : _root_.CommHopfAlgCat.{u} R) (h : H) :
-    (counit (R := R) H).hom h = Coalgebra.counit h :=
-  _root_.Bialgebra.counitBialgHom_apply h
-
-/-- The trivial coordinate Hopf algebra is initial in the ambient coordinate category. -/
-noncomputable def trivialIsInitial :
-    IsInitial (trivial R : _root_.CommHopfAlgCat.{u} R) :=
-  IsInitial.ofUniqueHom
-    (fun H => unit (R := R) H)
-    (fun H f => by
-      apply _root_.CommHopfAlgCat.hom_ext
-      apply _root_.BialgHom.coe_toAlgHom_injective
-      exact Subsingleton.elim _ _)
-
-/-- The unique ambient morphism out of the trivial coordinate Hopf algebra is the unit. -/
-lemma eq_unit (H : _root_.CommHopfAlgCat.{u} R)
-    (f : trivial R ⟶ H) :
-    f = unit (R := R) H :=
-  (trivialIsInitial (R := R)).hom_ext f (unit (R := R) H)
-
-end CommHopfAlgCat
 
 namespace TrivialGroup
 


### PR DESCRIPTION
This PR packages the base ring `R` as `FiniteTypeCommHopfAlgCat.trivial`, adds the coordinate unit and counit maps, proves the trivial coordinate Hopf algebra is initial in the same-universe finite-type coordinate category, and records the inherited one-point functor-of-points equivalence. It advances `TauCetiRoadmap/ReductiveGroups/README.md`, Layer 0, “the functor of points and the three-way dictionary,” specifically the supporting-facts item for the `Γ`-direction that calls for “the terminal object over `Spec R`,” together with the standing finite-type coordinate-Hopf-algebra model.

I chose this as the lowest-hanging distinct ReductiveGroups target after checking open and recently merged PRs: the raw Hopf-algebra trivial points calculation, base-changed trivial points, finite-type coordinate category, finite-type products, and quotient wrappers already exist on `main`, while the finite-type trivial coordinate object and its categorical initial-object API were still absent.

No Mathlib infrastructure is vendored. The implementation reuses Mathlib’s `Bialgebra.unitBialgHom`, `Bialgebra.counitBialgHom`, and `IsInitial.ofUniqueHom`, plus Tau Ceti’s existing `FiniteTypeCommHopfAlgCat.of` and `TrivialGroup.pointsMulEquiv`.

`lake exe cache get` completed with `No files to download` and `Already decompressed 8609 file(s)`. `lake build` completed with `Build completed successfully (4506 jobs).` `lake exe axioms` completed with `axioms: audited 7696 TauCeti declaration(s); all within the allowlist [propext, Classical.choice, Quot.sound].`

<!--tauceti-target:v1 {"focus":"ReductiveGroups","id":"finite-type-trivial-coordinate-object"}-->

🤖 Prepared with Codex
