### PR TITLE
feat: add J-holomorphic sign-change API

### DIFF
--- a/TauCeti/Geometry/Symplectic/AlmostComplex.lean
+++ b/TauCeti/Geometry/Symplectic/AlmostComplex.lean
@@ -208,6 +208,40 @@ lemma IsComplexLinearMap.neg {J : AlmostComplexStructure V} {J' : AlmostComplexS
     IsComplexLinearMap J J' (-F) :=
   IsComplexLinear.neg hF
 
+/-- Complex-linearity is unchanged after negating both the source and target almost complex
+structures. -/
+lemma IsComplexLinearMap.neg_structures {J : AlmostComplexStructure V}
+    {J' : AlmostComplexStructure W} {F : V →ₗ[ℝ] W} (hF : IsComplexLinearMap J J' F) :
+    IsComplexLinearMap (-J) (-J') F := by
+  change IsComplexLinear (-J).toLinearMap (-J').toLinearMap F
+  simpa using
+    (IsComplexLinear.neg_structures (J := J.toLinearMap) (J' := J'.toLinearMap) (F := F) hF)
+
+/-- If a map is complex-linear after negating both structures, then it was complex-linear before
+the sign change. -/
+lemma IsComplexLinearMap.of_neg_structures {J : AlmostComplexStructure V}
+    {J' : AlmostComplexStructure W} {F : V →ₗ[ℝ] W}
+    (hF : IsComplexLinearMap (-J) (-J') F) : IsComplexLinearMap J J' F := by
+  change IsComplexLinear J.toLinearMap J'.toLinearMap F
+  have hF' : IsComplexLinear (-J.toLinearMap) (-J'.toLinearMap) F := by
+    change F.comp (-J.toLinearMap) = (-J'.toLinearMap).comp F
+    exact hF
+  exact IsComplexLinear.of_neg_structures hF'
+
+/-- Negating both almost complex structures leaves the complex-linearity condition unchanged. -/
+@[simp]
+lemma isComplexLinearMap_neg_neg_iff {J : AlmostComplexStructure V}
+    {J' : AlmostComplexStructure W} {F : V →ₗ[ℝ] W} :
+    IsComplexLinearMap (-J) (-J') F ↔ IsComplexLinearMap J J' F :=
+  ⟨fun hF => hF.of_neg_structures, fun hF => hF.neg_structures⟩
+
+/-- Negating both almost complex structures is an involutive change of notation for
+complex-linearity. -/
+lemma isComplexLinearMap_iff_neg_neg {J : AlmostComplexStructure V}
+    {J' : AlmostComplexStructure W} {F : V →ₗ[ℝ] W} :
+    IsComplexLinearMap J J' F ↔ IsComplexLinearMap (-J) (-J') F :=
+  isComplexLinearMap_neg_neg_iff.symm
+
 /-- Complex-linear maps are closed under subtraction. -/
 lemma IsComplexLinearMap.sub {J : AlmostComplexStructure V} {J' : AlmostComplexStructure W}
     {F G : V →ₗ[ℝ] W} (hF : IsComplexLinearMap J J' F)

--- a/TauCeti/Geometry/Symplectic/AlmostComplex.lean
+++ b/TauCeti/Geometry/Symplectic/AlmostComplex.lean
@@ -210,37 +210,27 @@ lemma IsComplexLinearMap.neg {J : AlmostComplexStructure V} {J' : AlmostComplexS
 
 /-- Complex-linearity is unchanged after negating both the source and target almost complex
 structures. -/
-lemma IsComplexLinearMap.neg_structures {J : AlmostComplexStructure V}
+lemma IsComplexLinearMap.neg_neg {J : AlmostComplexStructure V}
     {J' : AlmostComplexStructure W} {F : V →ₗ[ℝ] W} (hF : IsComplexLinearMap J J' F) :
     IsComplexLinearMap (-J) (-J') F := by
-  change IsComplexLinear (-J).toLinearMap (-J').toLinearMap F
-  simpa using
-    (IsComplexLinear.neg_structures (J := J.toLinearMap) (J' := J'.toLinearMap) (F := F) hF)
+  rw [isComplexLinearMap_iff_isComplexLinear] at hF ⊢
+  simpa [AlmostComplexStructure.neg_toLinearMap] using
+    (IsComplexLinear.neg_neg (J := J.toLinearMap) (J' := J'.toLinearMap) (F := F) hF)
 
 /-- If a map is complex-linear after negating both structures, then it was complex-linear before
 the sign change. -/
-lemma IsComplexLinearMap.of_neg_structures {J : AlmostComplexStructure V}
+lemma IsComplexLinearMap.of_neg_neg {J : AlmostComplexStructure V}
     {J' : AlmostComplexStructure W} {F : V →ₗ[ℝ] W}
     (hF : IsComplexLinearMap (-J) (-J') F) : IsComplexLinearMap J J' F := by
-  change IsComplexLinear J.toLinearMap J'.toLinearMap F
-  have hF' : IsComplexLinear (-J.toLinearMap) (-J'.toLinearMap) F := by
-    change F.comp (-J.toLinearMap) = (-J'.toLinearMap).comp F
-    exact hF
-  exact IsComplexLinear.of_neg_structures hF'
+  rw [isComplexLinearMap_iff_isComplexLinear] at hF ⊢
+  exact IsComplexLinear.of_neg_neg (by simpa [AlmostComplexStructure.neg_toLinearMap] using hF)
 
 /-- Negating both almost complex structures leaves the complex-linearity condition unchanged. -/
 @[simp]
 lemma isComplexLinearMap_neg_neg_iff {J : AlmostComplexStructure V}
     {J' : AlmostComplexStructure W} {F : V →ₗ[ℝ] W} :
     IsComplexLinearMap (-J) (-J') F ↔ IsComplexLinearMap J J' F :=
-  ⟨fun hF => hF.of_neg_structures, fun hF => hF.neg_structures⟩
-
-/-- Negating both almost complex structures is an involutive change of notation for
-complex-linearity. -/
-lemma isComplexLinearMap_iff_neg_neg {J : AlmostComplexStructure V}
-    {J' : AlmostComplexStructure W} {F : V →ₗ[ℝ] W} :
-    IsComplexLinearMap J J' F ↔ IsComplexLinearMap (-J) (-J') F :=
-  isComplexLinearMap_neg_neg_iff.symm
+  ⟨fun hF => hF.of_neg_neg, fun hF => hF.neg_neg⟩
 
 /-- Complex-linear maps are closed under subtraction. -/
 lemma IsComplexLinearMap.sub {J : AlmostComplexStructure V} {J' : AlmostComplexStructure W}

--- a/TauCeti/Geometry/Symplectic/JHolomorphicNeg.lean
+++ b/TauCeti/Geometry/Symplectic/JHolomorphicNeg.lean
@@ -1,0 +1,181 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+module
+
+public import TauCeti.Geometry.Symplectic.JHolomorphic
+
+/-!
+# Negating both almost complex structures
+
+This file records the elementary sign-change invariance of the pointwise Cauchy--Riemann
+equation used by the analytic Heegaard Floer roadmap. A real-linear map satisfies
+`F ∘ J = J' ∘ F` exactly when it satisfies the same equation after both almost complex
+structures are negated:
+
+`F ∘ (-J) = (-J') ∘ F`.
+
+The same invariance is packaged for the pointwise, within-set, setwise, and global
+`J`-holomorphic predicates. These lemmas are useful bookkeeping before the local theory of
+`J`-holomorphic curves starts reflecting domains or changing orientation conventions: the
+analytic content stays in the Frechet derivative, while the simultaneous sign change is only
+linear algebra.
+
+## Main declarations
+
+* `TauCeti.IsComplexLinearMap.neg_structures`: complex-linearity survives negating source and
+  target almost complex structures.
+* `TauCeti.isComplexLinearMap_neg_neg_iff`: the corresponding equivalence.
+* `TauCeti.IsJHolomorphicAt.neg_structures`,
+  `TauCeti.IsJHolomorphicWithinAt.neg_structures`,
+  `TauCeti.IsJHolomorphicOn.neg_structures`, and
+  `TauCeti.IsJHolomorphic.neg_structures`: the four map-level forms.
+* `TauCeti.isJHolomorphicAt_neg_neg_iff` and its within-set, setwise, and global analogues:
+  rewrite-friendly equivalences.
+
+The convention follows McDuff--Salamon, *J-holomorphic Curves and Symplectic Topology*,
+Section 2.1: `J`-holomorphicity is the equation `df ∘ J = J' ∘ df`.
+-/
+
+public section
+
+namespace TauCeti
+
+variable {V W : Type*}
+
+section Linear
+
+variable [AddCommGroup V] [Module ℝ V]
+variable [AddCommGroup W] [Module ℝ W]
+
+variable {J : AlmostComplexStructure V} {J' : AlmostComplexStructure W}
+variable {F : V →ₗ[ℝ] W}
+
+namespace IsComplexLinearMap
+
+/-- Complex-linearity is unchanged after negating both the source and target almost complex
+structures. -/
+lemma neg_structures (hF : IsComplexLinearMap J J' F) : IsComplexLinearMap (-J) (-J') F := by
+  rw [isComplexLinearMap_iff_apply]
+  intro v
+  have hFv := (isComplexLinearMap_iff_apply J J' F).mp hF v
+  simp [hFv]
+
+/-- If a map is complex-linear after negating both structures, then it was complex-linear before
+the sign change. -/
+lemma of_neg_structures (hF : IsComplexLinearMap (-J) (-J') F) : IsComplexLinearMap J J' F := by
+  rw [isComplexLinearMap_iff_apply] at hF ⊢
+  intro v
+  simpa using congrArg Neg.neg (hF v)
+
+end IsComplexLinearMap
+
+/-- Negating both almost complex structures leaves the complex-linearity condition unchanged. -/
+lemma isComplexLinearMap_neg_neg_iff :
+    IsComplexLinearMap (-J) (-J') F ↔ IsComplexLinearMap J J' F :=
+  ⟨fun hF => hF.of_neg_structures, fun hF => hF.neg_structures⟩
+
+/-- Negating both almost complex structures is an involutive change of notation for
+complex-linearity. -/
+lemma isComplexLinearMap_iff_neg_neg :
+    IsComplexLinearMap J J' F ↔ IsComplexLinearMap (-J) (-J') F :=
+  isComplexLinearMap_neg_neg_iff.symm
+
+end Linear
+
+section JHolomorphic
+
+variable [NormedAddCommGroup V] [NormedSpace ℝ V]
+variable [NormedAddCommGroup W] [NormedSpace ℝ W]
+
+variable {J : AlmostComplexStructure V} {J' : AlmostComplexStructure W}
+variable {f : V → W} {s : Set V} {x : V}
+
+namespace IsJHolomorphicAt
+
+/-- Pointwise `J`-holomorphicity is unchanged after negating both almost complex structures. -/
+lemma neg_structures (hf : IsJHolomorphicAt J J' f x) :
+    IsJHolomorphicAt (-J) (-J') f x :=
+  ⟨hf.choose, hf.hasFDerivAt, hf.derivative_isComplexLinear.neg_structures⟩
+
+end IsJHolomorphicAt
+
+/-- Negating both almost complex structures leaves pointwise `J`-holomorphicity unchanged. -/
+lemma isJHolomorphicAt_neg_neg_iff :
+    IsJHolomorphicAt (-J) (-J') f x ↔ IsJHolomorphicAt J J' f x :=
+  ⟨fun hf => ⟨hf.choose, hf.hasFDerivAt, hf.derivative_isComplexLinear.of_neg_structures⟩,
+    fun hf => hf.neg_structures⟩
+
+/-- Negating both almost complex structures is an involutive change of notation for pointwise
+`J`-holomorphicity. -/
+lemma isJHolomorphicAt_iff_neg_neg :
+    IsJHolomorphicAt J J' f x ↔ IsJHolomorphicAt (-J) (-J') f x :=
+  isJHolomorphicAt_neg_neg_iff.symm
+
+namespace IsJHolomorphicWithinAt
+
+/-- Within-set `J`-holomorphicity is unchanged after negating both almost complex structures. -/
+lemma neg_structures (hf : IsJHolomorphicWithinAt J J' f s x) :
+    IsJHolomorphicWithinAt (-J) (-J') f s x :=
+  ⟨hf.choose, hf.hasFDerivWithinAt, hf.derivative_isComplexLinear.neg_structures⟩
+
+end IsJHolomorphicWithinAt
+
+/-- Negating both almost complex structures leaves within-set `J`-holomorphicity unchanged. -/
+lemma isJHolomorphicWithinAt_neg_neg_iff :
+    IsJHolomorphicWithinAt (-J) (-J') f s x ↔ IsJHolomorphicWithinAt J J' f s x :=
+  ⟨fun hf =>
+    ⟨hf.choose, hf.hasFDerivWithinAt, hf.derivative_isComplexLinear.of_neg_structures⟩,
+    fun hf => hf.neg_structures⟩
+
+/-- Negating both almost complex structures is an involutive change of notation for within-set
+`J`-holomorphicity. -/
+lemma isJHolomorphicWithinAt_iff_neg_neg :
+    IsJHolomorphicWithinAt J J' f s x ↔ IsJHolomorphicWithinAt (-J) (-J') f s x :=
+  isJHolomorphicWithinAt_neg_neg_iff.symm
+
+namespace IsJHolomorphicOn
+
+/-- Setwise `J`-holomorphicity is unchanged after negating both almost complex structures. -/
+lemma neg_structures (hf : IsJHolomorphicOn J J' f s) :
+    IsJHolomorphicOn (-J) (-J') f s :=
+  fun x hx => (hf x hx).neg_structures
+
+end IsJHolomorphicOn
+
+/-- Negating both almost complex structures leaves setwise `J`-holomorphicity unchanged. -/
+lemma isJHolomorphicOn_neg_neg_iff :
+    IsJHolomorphicOn (-J) (-J') f s ↔ IsJHolomorphicOn J J' f s :=
+  ⟨fun hf x hx => (isJHolomorphicWithinAt_neg_neg_iff (x := x)).mp (hf x hx),
+    fun hf => hf.neg_structures⟩
+
+/-- Negating both almost complex structures is an involutive change of notation for setwise
+`J`-holomorphicity. -/
+lemma isJHolomorphicOn_iff_neg_neg :
+    IsJHolomorphicOn J J' f s ↔ IsJHolomorphicOn (-J) (-J') f s :=
+  isJHolomorphicOn_neg_neg_iff.symm
+
+namespace IsJHolomorphic
+
+/-- Global `J`-holomorphicity is unchanged after negating both almost complex structures. -/
+lemma neg_structures (hf : IsJHolomorphic J J' f) : IsJHolomorphic (-J) (-J') f :=
+  fun x => (hf x).neg_structures
+
+end IsJHolomorphic
+
+/-- Negating both almost complex structures leaves global `J`-holomorphicity unchanged. -/
+lemma isJHolomorphic_neg_neg_iff :
+    IsJHolomorphic (-J) (-J') f ↔ IsJHolomorphic J J' f :=
+  ⟨fun hf x => (isJHolomorphicAt_neg_neg_iff (x := x)).mp (hf x),
+    fun hf => hf.neg_structures⟩
+
+/-- Negating both almost complex structures is an involutive change of notation for global
+`J`-holomorphicity. -/
+lemma isJHolomorphic_iff_neg_neg :
+    IsJHolomorphic J J' f ↔ IsJHolomorphic (-J) (-J') f :=
+  isJHolomorphic_neg_neg_iff.symm
+
+end JHolomorphic
+
+end TauCeti

--- a/TauCeti/Geometry/Symplectic/JHolomorphicNeg.lean
+++ b/TauCeti/Geometry/Symplectic/JHolomorphicNeg.lean
@@ -24,9 +24,6 @@ linear algebra.
 
 ## Main declarations
 
-* `TauCeti.IsComplexLinearMap.neg_structures`: complex-linearity survives negating source and
-  target almost complex structures.
-* `TauCeti.isComplexLinearMap_neg_neg_iff`: the corresponding equivalence.
 * `TauCeti.IsJHolomorphicAt.neg_structures`,
   `TauCeti.IsJHolomorphicWithinAt.neg_structures`,
   `TauCeti.IsJHolomorphicOn.neg_structures`, and
@@ -43,46 +40,6 @@ public section
 namespace TauCeti
 
 variable {V W : Type*}
-
-section Linear
-
-variable [AddCommGroup V] [Module ℝ V]
-variable [AddCommGroup W] [Module ℝ W]
-
-variable {J : AlmostComplexStructure V} {J' : AlmostComplexStructure W}
-variable {F : V →ₗ[ℝ] W}
-
-namespace IsComplexLinearMap
-
-/-- Complex-linearity is unchanged after negating both the source and target almost complex
-structures. -/
-lemma neg_structures (hF : IsComplexLinearMap J J' F) : IsComplexLinearMap (-J) (-J') F := by
-  rw [isComplexLinearMap_iff_apply]
-  intro v
-  have hFv := (isComplexLinearMap_iff_apply J J' F).mp hF v
-  simp [hFv]
-
-/-- If a map is complex-linear after negating both structures, then it was complex-linear before
-the sign change. -/
-lemma of_neg_structures (hF : IsComplexLinearMap (-J) (-J') F) : IsComplexLinearMap J J' F := by
-  rw [isComplexLinearMap_iff_apply] at hF ⊢
-  intro v
-  simpa using congrArg Neg.neg (hF v)
-
-end IsComplexLinearMap
-
-/-- Negating both almost complex structures leaves the complex-linearity condition unchanged. -/
-lemma isComplexLinearMap_neg_neg_iff :
-    IsComplexLinearMap (-J) (-J') F ↔ IsComplexLinearMap J J' F :=
-  ⟨fun hF => hF.of_neg_structures, fun hF => hF.neg_structures⟩
-
-/-- Negating both almost complex structures is an involutive change of notation for
-complex-linearity. -/
-lemma isComplexLinearMap_iff_neg_neg :
-    IsComplexLinearMap J J' F ↔ IsComplexLinearMap (-J) (-J') F :=
-  isComplexLinearMap_neg_neg_iff.symm
-
-end Linear
 
 section JHolomorphic
 
@@ -102,6 +59,7 @@ lemma neg_structures (hf : IsJHolomorphicAt J J' f x) :
 end IsJHolomorphicAt
 
 /-- Negating both almost complex structures leaves pointwise `J`-holomorphicity unchanged. -/
+@[simp]
 lemma isJHolomorphicAt_neg_neg_iff :
     IsJHolomorphicAt (-J) (-J') f x ↔ IsJHolomorphicAt J J' f x :=
   ⟨fun hf => ⟨hf.choose, hf.hasFDerivAt, hf.derivative_isComplexLinear.of_neg_structures⟩,
@@ -123,6 +81,7 @@ lemma neg_structures (hf : IsJHolomorphicWithinAt J J' f s x) :
 end IsJHolomorphicWithinAt
 
 /-- Negating both almost complex structures leaves within-set `J`-holomorphicity unchanged. -/
+@[simp]
 lemma isJHolomorphicWithinAt_neg_neg_iff :
     IsJHolomorphicWithinAt (-J) (-J') f s x ↔ IsJHolomorphicWithinAt J J' f s x :=
   ⟨fun hf =>
@@ -145,6 +104,7 @@ lemma neg_structures (hf : IsJHolomorphicOn J J' f s) :
 end IsJHolomorphicOn
 
 /-- Negating both almost complex structures leaves setwise `J`-holomorphicity unchanged. -/
+@[simp]
 lemma isJHolomorphicOn_neg_neg_iff :
     IsJHolomorphicOn (-J) (-J') f s ↔ IsJHolomorphicOn J J' f s :=
   ⟨fun hf x hx => (isJHolomorphicWithinAt_neg_neg_iff (x := x)).mp (hf x hx),
@@ -165,6 +125,7 @@ lemma neg_structures (hf : IsJHolomorphic J J' f) : IsJHolomorphic (-J) (-J') f 
 end IsJHolomorphic
 
 /-- Negating both almost complex structures leaves global `J`-holomorphicity unchanged. -/
+@[simp]
 lemma isJHolomorphic_neg_neg_iff :
     IsJHolomorphic (-J) (-J') f ↔ IsJHolomorphic J J' f :=
   ⟨fun hf x => (isJHolomorphicAt_neg_neg_iff (x := x)).mp (hf x),

--- a/TauCeti/Geometry/Symplectic/JHolomorphicNeg.lean
+++ b/TauCeti/Geometry/Symplectic/JHolomorphicNeg.lean
@@ -24,10 +24,10 @@ linear algebra.
 
 ## Main declarations
 
-* `TauCeti.IsJHolomorphicAt.neg_structures`,
-  `TauCeti.IsJHolomorphicWithinAt.neg_structures`,
-  `TauCeti.IsJHolomorphicOn.neg_structures`, and
-  `TauCeti.IsJHolomorphic.neg_structures`: the four map-level forms.
+* `TauCeti.IsJHolomorphicAt.neg_neg`,
+  `TauCeti.IsJHolomorphicWithinAt.neg_neg`,
+  `TauCeti.IsJHolomorphicOn.neg_neg`, and
+  `TauCeti.IsJHolomorphic.neg_neg`: the four map-level forms.
 * `TauCeti.isJHolomorphicAt_neg_neg_iff` and its within-set, setwise, and global analogues:
   rewrite-friendly equivalences.
 
@@ -52,9 +52,9 @@ variable {f : V → W} {s : Set V} {x : V}
 namespace IsJHolomorphicAt
 
 /-- Pointwise `J`-holomorphicity is unchanged after negating both almost complex structures. -/
-lemma neg_structures (hf : IsJHolomorphicAt J J' f x) :
+lemma neg_neg (hf : IsJHolomorphicAt J J' f x) :
     IsJHolomorphicAt (-J) (-J') f x :=
-  ⟨hf.choose, hf.hasFDerivAt, hf.derivative_isComplexLinear.neg_structures⟩
+  ⟨hf.choose, hf.hasFDerivAt, hf.derivative_isComplexLinear.neg_neg⟩
 
 end IsJHolomorphicAt
 
@@ -62,21 +62,15 @@ end IsJHolomorphicAt
 @[simp]
 lemma isJHolomorphicAt_neg_neg_iff :
     IsJHolomorphicAt (-J) (-J') f x ↔ IsJHolomorphicAt J J' f x :=
-  ⟨fun hf => ⟨hf.choose, hf.hasFDerivAt, hf.derivative_isComplexLinear.of_neg_structures⟩,
-    fun hf => hf.neg_structures⟩
-
-/-- Negating both almost complex structures is an involutive change of notation for pointwise
-`J`-holomorphicity. -/
-lemma isJHolomorphicAt_iff_neg_neg :
-    IsJHolomorphicAt J J' f x ↔ IsJHolomorphicAt (-J) (-J') f x :=
-  isJHolomorphicAt_neg_neg_iff.symm
+  ⟨fun hf => ⟨hf.choose, hf.hasFDerivAt, hf.derivative_isComplexLinear.of_neg_neg⟩,
+    fun hf => hf.neg_neg⟩
 
 namespace IsJHolomorphicWithinAt
 
 /-- Within-set `J`-holomorphicity is unchanged after negating both almost complex structures. -/
-lemma neg_structures (hf : IsJHolomorphicWithinAt J J' f s x) :
+lemma neg_neg (hf : IsJHolomorphicWithinAt J J' f s x) :
     IsJHolomorphicWithinAt (-J) (-J') f s x :=
-  ⟨hf.choose, hf.hasFDerivWithinAt, hf.derivative_isComplexLinear.neg_structures⟩
+  ⟨hf.choose, hf.hasFDerivWithinAt, hf.derivative_isComplexLinear.neg_neg⟩
 
 end IsJHolomorphicWithinAt
 
@@ -85,21 +79,15 @@ end IsJHolomorphicWithinAt
 lemma isJHolomorphicWithinAt_neg_neg_iff :
     IsJHolomorphicWithinAt (-J) (-J') f s x ↔ IsJHolomorphicWithinAt J J' f s x :=
   ⟨fun hf =>
-    ⟨hf.choose, hf.hasFDerivWithinAt, hf.derivative_isComplexLinear.of_neg_structures⟩,
-    fun hf => hf.neg_structures⟩
-
-/-- Negating both almost complex structures is an involutive change of notation for within-set
-`J`-holomorphicity. -/
-lemma isJHolomorphicWithinAt_iff_neg_neg :
-    IsJHolomorphicWithinAt J J' f s x ↔ IsJHolomorphicWithinAt (-J) (-J') f s x :=
-  isJHolomorphicWithinAt_neg_neg_iff.symm
+    ⟨hf.choose, hf.hasFDerivWithinAt, hf.derivative_isComplexLinear.of_neg_neg⟩,
+    fun hf => hf.neg_neg⟩
 
 namespace IsJHolomorphicOn
 
 /-- Setwise `J`-holomorphicity is unchanged after negating both almost complex structures. -/
-lemma neg_structures (hf : IsJHolomorphicOn J J' f s) :
+lemma neg_neg (hf : IsJHolomorphicOn J J' f s) :
     IsJHolomorphicOn (-J) (-J') f s :=
-  fun x hx => (hf x hx).neg_structures
+  fun x hx => (hf x hx).neg_neg
 
 end IsJHolomorphicOn
 
@@ -108,19 +96,13 @@ end IsJHolomorphicOn
 lemma isJHolomorphicOn_neg_neg_iff :
     IsJHolomorphicOn (-J) (-J') f s ↔ IsJHolomorphicOn J J' f s :=
   ⟨fun hf x hx => (isJHolomorphicWithinAt_neg_neg_iff (x := x)).mp (hf x hx),
-    fun hf => hf.neg_structures⟩
-
-/-- Negating both almost complex structures is an involutive change of notation for setwise
-`J`-holomorphicity. -/
-lemma isJHolomorphicOn_iff_neg_neg :
-    IsJHolomorphicOn J J' f s ↔ IsJHolomorphicOn (-J) (-J') f s :=
-  isJHolomorphicOn_neg_neg_iff.symm
+    fun hf => hf.neg_neg⟩
 
 namespace IsJHolomorphic
 
 /-- Global `J`-holomorphicity is unchanged after negating both almost complex structures. -/
-lemma neg_structures (hf : IsJHolomorphic J J' f) : IsJHolomorphic (-J) (-J') f :=
-  fun x => (hf x).neg_structures
+lemma neg_neg (hf : IsJHolomorphic J J' f) : IsJHolomorphic (-J) (-J') f :=
+  fun x => (hf x).neg_neg
 
 end IsJHolomorphic
 
@@ -129,13 +111,7 @@ end IsJHolomorphic
 lemma isJHolomorphic_neg_neg_iff :
     IsJHolomorphic (-J) (-J') f ↔ IsJHolomorphic J J' f :=
   ⟨fun hf x => (isJHolomorphicAt_neg_neg_iff (x := x)).mp (hf x),
-    fun hf => hf.neg_structures⟩
-
-/-- Negating both almost complex structures is an involutive change of notation for global
-`J`-holomorphicity. -/
-lemma isJHolomorphic_iff_neg_neg :
-    IsJHolomorphic J J' f ↔ IsJHolomorphic (-J) (-J') f :=
-  isJHolomorphic_neg_neg_iff.symm
+    fun hf => hf.neg_neg⟩
 
 end JHolomorphic
 

--- a/TauCeti/LinearAlgebra/ComplexLinearPart.lean
+++ b/TauCeti/LinearAlgebra/ComplexLinearPart.lean
@@ -151,6 +151,29 @@ theorem IsComplexLinear.neg {F : V →ₗ[ℝ] W} (h : IsComplexLinear J J' F) :
     IsComplexLinear J J' (-F) :=
   isComplexLinear_of_apply fun v => by simp [h.apply v]
 
+/-- Complex-linearity is unchanged after negating both source and target endomorphisms. -/
+theorem IsComplexLinear.neg_structures {F : V →ₗ[ℝ] W} (h : IsComplexLinear J J' F) :
+    IsComplexLinear (-J) (-J') F :=
+  isComplexLinear_of_apply fun v => by simp [h.apply v]
+
+/-- If a map is complex-linear after negating both endomorphisms, then it was complex-linear
+before the sign change. -/
+theorem IsComplexLinear.of_neg_structures {F : V →ₗ[ℝ] W}
+    (h : IsComplexLinear (-J) (-J') F) : IsComplexLinear J J' F :=
+  isComplexLinear_of_apply fun v => by
+    simpa using congrArg Neg.neg (h.apply v)
+
+/-- Negating both source and target endomorphisms leaves complex-linearity unchanged. -/
+theorem isComplexLinear_neg_neg_iff {F : V →ₗ[ℝ] W} :
+    IsComplexLinear (-J) (-J') F ↔ IsComplexLinear J J' F :=
+  ⟨fun hF => hF.of_neg_structures, fun hF => hF.neg_structures⟩
+
+/-- Negating both source and target endomorphisms is an involutive change of notation for
+complex-linearity. -/
+theorem isComplexLinear_iff_neg_neg {F : V →ₗ[ℝ] W} :
+    IsComplexLinear J J' F ↔ IsComplexLinear (-J) (-J') F :=
+  isComplexLinear_neg_neg_iff.symm
+
 /-- The negation of a complex-antilinear map is complex antilinear. -/
 theorem IsComplexAntilinear.neg {F : V →ₗ[ℝ] W} (h : IsComplexAntilinear J J' F) :
     IsComplexAntilinear J J' (-F) :=

--- a/TauCeti/LinearAlgebra/ComplexLinearPart.lean
+++ b/TauCeti/LinearAlgebra/ComplexLinearPart.lean
@@ -163,12 +163,6 @@ theorem IsComplexLinear.of_neg_neg {F : V →ₗ[ℝ] W}
   isComplexLinear_of_apply fun v => by
     simpa using congrArg Neg.neg (h.apply v)
 
-/-- Negating both source and target endomorphisms leaves complex-linearity unchanged. -/
-@[simp]
-theorem isComplexLinear_neg_neg_iff {F : V →ₗ[ℝ] W} :
-    IsComplexLinear (-J) (-J') F ↔ IsComplexLinear J J' F :=
-  ⟨fun hF => hF.of_neg_neg, fun hF => hF.neg_neg⟩
-
 /-- The negation of a complex-antilinear map is complex antilinear. -/
 theorem IsComplexAntilinear.neg {F : V →ₗ[ℝ] W} (h : IsComplexAntilinear J J' F) :
     IsComplexAntilinear J J' (-F) :=
@@ -185,12 +179,6 @@ theorem IsComplexAntilinear.of_neg_neg {F : V →ₗ[ℝ] W}
     (h : IsComplexAntilinear (-J) (-J') F) : IsComplexAntilinear J J' F :=
   isComplexAntilinear_of_apply fun v => by
     simpa using congrArg Neg.neg (h.apply v)
-
-/-- Negating both source and target endomorphisms leaves complex-antilinearity unchanged. -/
-@[simp]
-theorem isComplexAntilinear_neg_neg_iff {F : V →ₗ[ℝ] W} :
-    IsComplexAntilinear (-J) (-J') F ↔ IsComplexAntilinear J J' F :=
-  ⟨fun hF => hF.of_neg_neg, fun hF => hF.neg_neg⟩
 
 /-- The composite of two complex-linear maps is complex linear. -/
 theorem IsComplexLinear.comp {F : V →ₗ[ℝ] W} {G : W →ₗ[ℝ] U}

--- a/TauCeti/LinearAlgebra/ComplexLinearPart.lean
+++ b/TauCeti/LinearAlgebra/ComplexLinearPart.lean
@@ -152,32 +152,45 @@ theorem IsComplexLinear.neg {F : V →ₗ[ℝ] W} (h : IsComplexLinear J J' F) :
   isComplexLinear_of_apply fun v => by simp [h.apply v]
 
 /-- Complex-linearity is unchanged after negating both source and target endomorphisms. -/
-theorem IsComplexLinear.neg_structures {F : V →ₗ[ℝ] W} (h : IsComplexLinear J J' F) :
+theorem IsComplexLinear.neg_neg {F : V →ₗ[ℝ] W} (h : IsComplexLinear J J' F) :
     IsComplexLinear (-J) (-J') F :=
   isComplexLinear_of_apply fun v => by simp [h.apply v]
 
 /-- If a map is complex-linear after negating both endomorphisms, then it was complex-linear
 before the sign change. -/
-theorem IsComplexLinear.of_neg_structures {F : V →ₗ[ℝ] W}
+theorem IsComplexLinear.of_neg_neg {F : V →ₗ[ℝ] W}
     (h : IsComplexLinear (-J) (-J') F) : IsComplexLinear J J' F :=
   isComplexLinear_of_apply fun v => by
     simpa using congrArg Neg.neg (h.apply v)
 
 /-- Negating both source and target endomorphisms leaves complex-linearity unchanged. -/
+@[simp]
 theorem isComplexLinear_neg_neg_iff {F : V →ₗ[ℝ] W} :
     IsComplexLinear (-J) (-J') F ↔ IsComplexLinear J J' F :=
-  ⟨fun hF => hF.of_neg_structures, fun hF => hF.neg_structures⟩
-
-/-- Negating both source and target endomorphisms is an involutive change of notation for
-complex-linearity. -/
-theorem isComplexLinear_iff_neg_neg {F : V →ₗ[ℝ] W} :
-    IsComplexLinear J J' F ↔ IsComplexLinear (-J) (-J') F :=
-  isComplexLinear_neg_neg_iff.symm
+  ⟨fun hF => hF.of_neg_neg, fun hF => hF.neg_neg⟩
 
 /-- The negation of a complex-antilinear map is complex antilinear. -/
 theorem IsComplexAntilinear.neg {F : V →ₗ[ℝ] W} (h : IsComplexAntilinear J J' F) :
     IsComplexAntilinear J J' (-F) :=
   isComplexAntilinear_of_apply fun v => by simp [h.apply v]
+
+/-- Complex-antilinearity is unchanged after negating both source and target endomorphisms. -/
+theorem IsComplexAntilinear.neg_neg {F : V →ₗ[ℝ] W} (h : IsComplexAntilinear J J' F) :
+    IsComplexAntilinear (-J) (-J') F :=
+  isComplexAntilinear_of_apply fun v => by simp [h.apply v]
+
+/-- If a map is complex-antilinear after negating both endomorphisms, then it was
+complex-antilinear before the sign change. -/
+theorem IsComplexAntilinear.of_neg_neg {F : V →ₗ[ℝ] W}
+    (h : IsComplexAntilinear (-J) (-J') F) : IsComplexAntilinear J J' F :=
+  isComplexAntilinear_of_apply fun v => by
+    simpa using congrArg Neg.neg (h.apply v)
+
+/-- Negating both source and target endomorphisms leaves complex-antilinearity unchanged. -/
+@[simp]
+theorem isComplexAntilinear_neg_neg_iff {F : V →ₗ[ℝ] W} :
+    IsComplexAntilinear (-J) (-J') F ↔ IsComplexAntilinear J J' F :=
+  ⟨fun hF => hF.of_neg_neg, fun hF => hF.neg_neg⟩
 
 /-- The composite of two complex-linear maps is complex linear. -/
 theorem IsComplexLinear.comp {F : V →ₗ[ℝ] W} {G : W →ₗ[ℝ] U}
@@ -191,7 +204,7 @@ theorem IsComplexAntilinear.comp {F : V →ₗ[ℝ] W} {G : W →ₗ[ℝ] U}
     (hG : IsComplexAntilinear J' J'' G) (hF : IsComplexAntilinear J J' F) :
     IsComplexLinear J J'' (G ∘ₗ F) :=
   isComplexLinear_of_apply fun v => by
-    simp only [LinearMap.comp_apply, hF.apply v, map_neg, hG.apply (F v), neg_neg]
+    simp only [LinearMap.comp_apply, hF.apply v, map_neg, hG.apply (F v), _root_.neg_neg]
 
 /-- A complex-linear map after a complex-antilinear map is complex antilinear. -/
 theorem IsComplexLinear.comp_antilinear {F : V →ₗ[ℝ] W} {G : W →ₗ[ℝ] U}


### PR DESCRIPTION
This PR records the sign-change API for local `J`-holomorphic maps: complex-linearity, pointwise `J`-holomorphicity, within-set `J`-holomorphicity, setwise `J`-holomorphicity, and global `J`-holomorphicity are all unchanged when both source and target almost complex structures are negated. It advances `TauCetiRoadmap/HeegaardFloer/README.md`, Lane F2.1, “Definitions land immediately: almost complex structures, tame/compatible `J`, symplectic manifolds, `J`-holomorphic maps, energy,” as a small chart-level prerequisite for later reflection and orientation-convention bookkeeping in the local `J`-holomorphic curve theory.

I chose this as the lowest-hanging distinct HeegaardFloer target after checking open and recently merged PRs: the open HeegaardFloer work covers the standard complex symplectic line, while the existing `J`-holomorphic API on `main` already has products, transport, congruence, and energy-density lemmas but not the simultaneous `J ↦ -J` invariance of the Cauchy--Riemann equation.

No Mathlib infrastructure is vendored. The implementation reuses Tau Ceti’s existing `AlmostComplexStructure.neg`, `IsComplexLinearMap`, and `IsJHolomorphic*` predicates; the only proof ingredient is the pointwise equation `F ∘ J = J' ∘ F`, with the reverse direction obtained by negating both sides.

`lake exe cache get` completed with `No files to download` and `Already decompressed 8609 file(s)`. `lake build` completed with `Build completed successfully (4506 jobs).` `lake exe axioms` completed with `axioms: audited 7694 TauCeti declaration(s); all within the allowlist [propext, Classical.choice, Quot.sound].`

<!--tauceti-target:v1 {"focus":"HeegaardFloer","id":"j-holomorphic-negated-structures"}-->

🤖 Prepared with Codex
