### PR TITLE
feat: add Hopf ideal quotient point naturality

### DIFF
--- a/TauCeti/Algebra/AlgebraicGroup/CommHopfAlgCat.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/CommHopfAlgCat.lean
@@ -85,7 +85,7 @@ lemma mapPointsFunctor_app_apply_apply {H K : CommHopfAlgCat.{v} R} (φ : H ⟶ 
 lemma mapPointsFunctor_naturality {H K : CommHopfAlgCat.{v} R} (φ : H ⟶ K)
     {A B : CommAlgCat.{w} R} (χ : A ⟶ B)
     (f : HopfAlgebra.points (R := R) (H := K) A) :
-    HopfAlgebra.mapPoints (H := H) χ ((mapPointsFunctor φ).app A f) =
+    HopfAlgebra.mapPoints (H := H) χ (toConv (f.ofConv.comp (φ.hom : H →ₐ[R] K))) =
       (mapPointsFunctor φ).app B (HopfAlgebra.mapPoints (H := K) χ f) := by
   rfl
 

--- a/TauCeti/Algebra/AlgebraicGroup/CommHopfAlgCat.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/CommHopfAlgCat.lean
@@ -80,6 +80,14 @@ lemma mapPointsFunctor_app_apply_apply {H K : CommHopfAlgCat.{v} R} (φ : H ⟶ 
     (((mapPointsFunctor φ).app A f).ofConv) h = f.ofConv (φ.hom h) := by
   exact AlgHom.mapDomain_apply_apply (A := A) φ.hom f h
 
+/-- Naturality of the point map induced by a coordinate morphism, applied to a point. -/
+lemma mapPointsFunctor_naturality_apply {H K : CommHopfAlgCat.{v} R} (φ : H ⟶ K)
+    {A B : CommAlgCat.{w} R} (χ : A ⟶ B)
+    (f : HopfAlgebra.points (R := R) (H := K) A) :
+    HopfAlgebra.mapPoints (H := H) χ ((mapPointsFunctor φ).app A f) =
+      (mapPointsFunctor φ).app B (HopfAlgebra.mapPoints (H := K) χ f) := by
+  exact DFunLike.congr_fun (AlgHom.mapValue_mapDomain φ.hom χ.hom).symm f
+
 /-- Pre-composition with a surjective coordinate morphism is injective on points. -/
 lemma mapPointsFunctor_app_injective_of_surjective {H K : CommHopfAlgCat.{v} R}
     (φ : H ⟶ K) (hφ : Function.Surjective φ.hom) (A : CommAlgCat.{w} R) :

--- a/TauCeti/Algebra/AlgebraicGroup/CommHopfAlgCat.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/CommHopfAlgCat.lean
@@ -80,6 +80,15 @@ lemma mapPointsFunctor_app_apply_apply {H K : CommHopfAlgCat.{v} R} (φ : H ⟶ 
     (((mapPointsFunctor φ).app A f).ofConv) h = f.ofConv (φ.hom h) := by
   exact AlgHom.mapDomain_apply_apply (A := A) φ.hom f h
 
+/-- The point map induced by a coordinate morphism is natural in the value algebra. -/
+@[simp]
+lemma mapPointsFunctor_naturality {H K : CommHopfAlgCat.{v} R} (φ : H ⟶ K)
+    {A B : CommAlgCat.{w} R} (χ : A ⟶ B)
+    (f : HopfAlgebra.points (R := R) (H := K) A) :
+    HopfAlgebra.mapPoints (H := H) χ ((mapPointsFunctor φ).app A f) =
+      (mapPointsFunctor φ).app B (HopfAlgebra.mapPoints (H := K) χ f) := by
+  rfl
+
 /-- Pre-composition with a surjective coordinate morphism is injective on points. -/
 lemma mapPointsFunctor_app_injective_of_surjective {H K : CommHopfAlgCat.{v} R}
     (φ : H ⟶ K) (hφ : Function.Surjective φ.hom) (A : CommAlgCat.{w} R) :

--- a/TauCeti/Algebra/AlgebraicGroup/CommHopfAlgCat.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/CommHopfAlgCat.lean
@@ -80,15 +80,6 @@ lemma mapPointsFunctor_app_apply_apply {H K : CommHopfAlgCat.{v} R} (φ : H ⟶ 
     (((mapPointsFunctor φ).app A f).ofConv) h = f.ofConv (φ.hom h) := by
   exact AlgHom.mapDomain_apply_apply (A := A) φ.hom f h
 
-/-- The point map induced by a coordinate morphism is natural in the value algebra. -/
-@[simp]
-lemma mapPointsFunctor_naturality {H K : CommHopfAlgCat.{v} R} (φ : H ⟶ K)
-    {A B : CommAlgCat.{w} R} (χ : A ⟶ B)
-    (f : HopfAlgebra.points (R := R) (H := K) A) :
-    HopfAlgebra.mapPoints (H := H) χ (toConv (f.ofConv.comp (φ.hom : H →ₐ[R] K))) =
-      (mapPointsFunctor φ).app B (HopfAlgebra.mapPoints (H := K) χ f) := by
-  rfl
-
 /-- Pre-composition with a surjective coordinate morphism is injective on points. -/
 lemma mapPointsFunctor_app_injective_of_surjective {H K : CommHopfAlgCat.{v} R}
     (φ : H ⟶ K) (hφ : Function.Surjective φ.hom) (A : CommAlgCat.{w} R) :

--- a/TauCeti/Algebra/AlgebraicGroup/HopfIdealPoints.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/HopfIdealPoints.lean
@@ -138,7 +138,7 @@ lemma mem_range_quotientPointsHom_iff (H : _root_.CommHopfAlgCat.{v} R)
 
 Its elements are exactly those algebra maps `H →ₐ[R] A` that vanish on `I`; this is the
 point-level closed subgroup represented by the quotient coordinate Hopf algebra `H ⧸ I`. -/
-noncomputable def quotientPointsSubgroup (H : _root_.CommHopfAlgCat.{v} R)
+@[expose] noncomputable def quotientPointsSubgroup (H : _root_.CommHopfAlgCat.{v} R)
     (I : HopfIdeal R H) (A : CommAlgCat.{w} R) :
     Subgroup (HopfAlgebra.points (R := R) (H := H) A) :=
   (quotientPointsHom H I A).hom.range

--- a/TauCeti/Algebra/AlgebraicGroup/HopfIdealPoints.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/HopfIdealPoints.lean
@@ -53,7 +53,7 @@ variable {R : Type u} [CommRing R]
 
 Contravariantly, this is the closed-subgroup inclusion on points: it sends a point of the
 quotient Hopf algebra to its composite with the quotient map from `H`. -/
-noncomputable def quotientPointsHom (H : _root_.CommHopfAlgCat.{v} R)
+@[expose] noncomputable def quotientPointsHom (H : _root_.CommHopfAlgCat.{v} R)
     (I : HopfIdeal R H) (A : CommAlgCat.{w} R) :
     HopfAlgebra.points (R := R) (H := quotient H I) A ⟶
       HopfAlgebra.points (R := R) (H := H) A :=

--- a/TauCeti/Algebra/AlgebraicGroup/HopfIdealPointsNaturality.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/HopfIdealPointsNaturality.lean
@@ -35,6 +35,15 @@ namespace CommHopfAlgCat
 
 variable {R : Type u} [CommRing R]
 
+/-- The quotient-points inclusion is natural in the value algebra. -/
+@[simp]
+lemma mapPoints_quotientPointsHom (H : _root_.CommHopfAlgCat.{v} R)
+    (I : HopfIdeal R H) {A B : CommAlgCat.{w} R}
+    (χ : A ⟶ B) (f : HopfAlgebra.points (R := R) (H := quotient H I) A) :
+    HopfAlgebra.mapPoints (H := H) χ (quotientPointsHom H I A f) =
+      quotientPointsHom H I B (HopfAlgebra.mapPoints (H := quotient H I) χ f) := by
+  exact mapPointsFunctor_naturality_apply (R := R) (mkQuotient H I) χ f
+
 /-- Post-composition preserves the ambient-point subgroup cut out by a Hopf ideal. -/
 lemma mapPoints_mem_quotientPointsSubgroup (H : _root_.CommHopfAlgCat.{v} R)
     (I : HopfIdeal R H) {A B : CommAlgCat.{w} R}
@@ -42,36 +51,24 @@ lemma mapPoints_mem_quotientPointsSubgroup (H : _root_.CommHopfAlgCat.{v} R)
     (hg : g ∈ quotientPointsSubgroup H I A) :
     HopfAlgebra.mapPoints (H := H) χ g ∈ quotientPointsSubgroup H I B := by
   rw [mem_quotientPointsSubgroup_iff] at hg
-  rw [← quotientPointsHom_liftQuotientPoint H I A g hg]
-  have hnat :
-      HopfAlgebra.mapPoints (H := H) χ
-          (quotientPointsHom H I A (liftQuotientPoint H I A g hg)) =
-        quotientPointsHom H I B
-          (HopfAlgebra.mapPoints (H := quotient H I) χ
-            (liftQuotientPoint H I A g hg)) := by
-    apply WithConv.ofConv_injective
-    apply AlgHom.ext
-    intro h
-    rw [quotientPointsHom_apply_apply]
-    -- `mapPoints` is a bundled group hom, so expose its evaluation before rewriting
-    -- `quotientPointsHom` under post-composition.
-    change χ.hom
-        ((quotientPointsHom H I A (liftQuotientPoint H I A g hg)).ofConv h) =
-      χ.hom
-        (((liftQuotientPoint H I A g hg).ofConv) (Ideal.Quotient.mkₐ R I.toIdeal h))
-    rw [quotientPointsHom_apply_apply]
-  rw [hnat]
+  rw [← quotientPointsHom_liftQuotientPoint H I A g hg, mapPoints_quotientPointsHom]
   exact quotientPointsHom_mem_quotientPointsSubgroup H I B _
+
+/-- The functor-of-points map restricted to the subgroups cut out by a Hopf ideal. -/
+@[expose] noncomputable def mapQuotientPointsSubgroup (H : _root_.CommHopfAlgCat.{v} R)
+    (I : HopfIdeal R H) {A B : CommAlgCat.{w} R}
+    (χ : A ⟶ B) :
+    quotientPointsSubgroup H I A →* quotientPointsSubgroup H I B :=
+  (((HopfAlgebra.mapPoints (H := H) χ).hom.restrict (quotientPointsSubgroup H I A)).codRestrict
+    (quotientPointsSubgroup H I B)
+    fun g => mapPoints_mem_quotientPointsSubgroup H I χ g.property)
 
 /-- The value-algebra functor of the point subgroups cut out by a Hopf ideal. -/
 @[expose] noncomputable def quotientPointsSubgroupFunctor
     (H : _root_.CommHopfAlgCat.{v} R) (I : HopfIdeal R H) :
     CommAlgCat.{w} R ⥤ GrpCat.{max v w} where
   obj A := GrpCat.of (quotientPointsSubgroup H I A)
-  map {A B} χ := GrpCat.ofHom
-    (((HopfAlgebra.mapPoints (H := H) χ).hom.restrict (quotientPointsSubgroup H I A)).codRestrict
-      (quotientPointsSubgroup H I B)
-      fun g => mapPoints_mem_quotientPointsSubgroup H I χ g.property)
+  map {A B} χ := GrpCat.ofHom (mapQuotientPointsSubgroup H I χ)
   map_id A := by
     ext g h
     rfl
@@ -80,7 +77,7 @@ lemma mapPoints_mem_quotientPointsSubgroup (H : _root_.CommHopfAlgCat.{v} R)
     rfl
 
 /-- The subgroup functor includes naturally into the ambient functor of points. -/
-noncomputable def quotientPointsSubgroupIncl (H : _root_.CommHopfAlgCat.{v} R)
+@[expose] noncomputable def quotientPointsSubgroupIncl (H : _root_.CommHopfAlgCat.{v} R)
     (I : HopfIdeal R H) :
     quotientPointsSubgroupFunctor (R := R) H I ⟶
       HopfAlgebra.pointsFunctor (R := R) (H := H) where
@@ -89,12 +86,13 @@ noncomputable def quotientPointsSubgroupIncl (H : _root_.CommHopfAlgCat.{v} R)
     ext g
     rfl
 
-/-- The functor-of-points map restricted to the subgroups cut out by a Hopf ideal. -/
-noncomputable abbrev mapQuotientPointsSubgroup (H : _root_.CommHopfAlgCat.{v} R)
-    (I : HopfIdeal R H) {A B : CommAlgCat.{w} R}
-    (χ : A ⟶ B) :
-    quotientPointsSubgroup H I A →* quotientPointsSubgroup H I B :=
-  ((quotientPointsSubgroupFunctor H I).map χ).hom
+/-- The component of the subgroup inclusion is the subgroup subtype map. -/
+@[simp]
+lemma quotientPointsSubgroupIncl_app (H : _root_.CommHopfAlgCat.{v} R)
+    (I : HopfIdeal R H) (A : CommAlgCat.{w} R) :
+    (quotientPointsSubgroupIncl H I).app A =
+      GrpCat.ofHom (quotientPointsSubgroup H I A).subtype :=
+  rfl
 
 /-- The restricted map on cut-out subgroups is induced by the ambient functor-of-points map. -/
 @[simp]
@@ -142,6 +140,95 @@ lemma mapQuotientPointsSubgroup_comp (H : _root_.CommHopfAlgCat.{v} R)
         (mapQuotientPointsSubgroup H I χ) := by
   exact congrArg GrpCat.Hom.hom ((quotientPointsSubgroupFunctor (R := R) H I).map_comp χ ψ)
 
+/-- The inverse map from a cut-out subgroup point to the corresponding quotient point. -/
+noncomputable def liftQuotientPointHom (H : _root_.CommHopfAlgCat.{v} R)
+    (I : HopfIdeal R H) (A : CommAlgCat.{w} R) :
+    quotientPointsSubgroup H I A →* HopfAlgebra.points (R := R) (H := quotient H I) A where
+  toFun g := liftQuotientPoint H I A g
+    ((mem_quotientPointsSubgroup_iff H I A g).mp g.property)
+  map_one' := by
+    apply quotientPointsHom_injective H I A
+    rw [quotientPointsHom_liftQuotientPoint, map_one]
+    rfl
+  map_mul' := by
+    intro g₁ g₂
+    apply quotientPointsHom_injective H I A
+    rw [quotientPointsHom_liftQuotientPoint, map_mul, quotientPointsHom_liftQuotientPoint,
+      quotientPointsHom_liftQuotientPoint]
+    rfl
+
+private lemma liftQuotientPointHom_naturality (H : _root_.CommHopfAlgCat.{v} R)
+    (I : HopfIdeal R H) {A B : CommAlgCat.{w} R} (χ : A ⟶ B)
+    (g : quotientPointsSubgroup H I A) :
+    HopfAlgebra.mapPoints (H := quotient H I) χ (liftQuotientPointHom H I A g) =
+      liftQuotientPointHom H I B (mapQuotientPointsSubgroup H I χ g) := by
+  apply quotientPointsHom_injective H I B
+  rw [← mapPoints_quotientPointsHom H I χ]
+  -- Expose the concrete lift maps after applying injectivity to the quotient-points inclusion.
+  change HopfAlgebra.mapPoints (H := H) χ
+      (quotientPointsHom H I A
+        (liftQuotientPoint H I A g
+          ((mem_quotientPointsSubgroup_iff H I A g).mp g.property))) =
+    quotientPointsHom H I B
+      (liftQuotientPoint H I B (mapQuotientPointsSubgroup H I χ g)
+        ((mem_quotientPointsSubgroup_iff H I B (mapQuotientPointsSubgroup H I χ g)).mp
+          (mapQuotientPointsSubgroup H I χ g).property))
+  rw [quotientPointsHom_liftQuotientPoint, quotientPointsHom_liftQuotientPoint]
+  rfl
+
+/-- The component isomorphism between quotient points and the cut-out subgroup. -/
+noncomputable def quotientPointsSubgroupIso (H : _root_.CommHopfAlgCat.{v} R)
+    (I : HopfIdeal R H) (A : CommAlgCat.{w} R) :
+    GrpCat.of (HopfAlgebra.points (R := R) (H := quotient H I) A) ≅
+      GrpCat.of (quotientPointsSubgroup H I A) where
+  hom := GrpCat.ofHom ((quotientPointsHom H I A).hom.codRestrict
+    (quotientPointsSubgroup H I A)
+    (quotientPointsHom_mem_quotientPointsSubgroup H I A))
+  inv := GrpCat.ofHom (liftQuotientPointHom H I A)
+  hom_inv_id := by
+    apply GrpCat.hom_ext
+    apply MonoidHom.ext
+    intro g
+    -- The component iso is bundled in `GrpCat`; expose the underlying quotient lift.
+    change liftQuotientPoint H I A (quotientPointsHom H I A g)
+        ((mem_quotientPointsSubgroup_iff H I A (quotientPointsHom H I A g)).mp
+          (quotientPointsHom_mem_quotientPointsSubgroup H I A g)) =
+      g
+    apply quotientPointsHom_injective H I A
+    rw [quotientPointsHom_liftQuotientPoint]
+  inv_hom_id := by
+    apply GrpCat.hom_ext
+    apply MonoidHom.ext
+    intro g
+    -- The component iso is bundled in `GrpCat`; expose the underlying quotient inclusion.
+    change (⟨quotientPointsHom H I A (liftQuotientPointHom H I A g),
+        quotientPointsHom_mem_quotientPointsSubgroup H I A _⟩ :
+        quotientPointsSubgroup H I A) = g
+    exact Subtype.ext (quotientPointsHom_liftQuotientPoint H I A g
+      ((mem_quotientPointsSubgroup_iff H I A g).mp g.property))
+
+private lemma quotientPointsSubgroupFunctor_map_quotientPointsHom_aux
+    (H : _root_.CommHopfAlgCat.{v} R) (I : HopfIdeal R H) {A B : CommAlgCat.{w} R}
+    (χ : A ⟶ B) (f : HopfAlgebra.points (R := R) (H := quotient H I) A) :
+    mapQuotientPointsSubgroup H I χ
+        ⟨quotientPointsHom H I A f, quotientPointsHom_mem_quotientPointsSubgroup H I A f⟩ =
+      ⟨quotientPointsHom H I B (HopfAlgebra.mapPoints (H := quotient H I) χ f),
+        quotientPointsHom_mem_quotientPointsSubgroup H I B _⟩ := by
+  apply Subtype.ext
+  rw [coe_mapQuotientPointsSubgroup_apply, mapPoints_quotientPointsHom]
+
+/-- The quotient Hopf algebra represents the subgroup functor cut out by the Hopf ideal. -/
+noncomputable def quotientPointsSubgroupNatIso (H : _root_.CommHopfAlgCat.{v} R)
+    (I : HopfIdeal R H) :
+    HopfAlgebra.pointsFunctor (R := R) (H := quotient H I) ≅
+      quotientPointsSubgroupFunctor (R := R) H I :=
+  NatIso.ofComponents
+    (quotientPointsSubgroupIso H I)
+    (by
+      intro A B χ
+      ext f
+      exact (quotientPointsSubgroupFunctor_map_quotientPointsHom_aux H I χ f).symm)
+
 /-- The image of a quotient point under the subgroup functor is its mapped quotient point,
 viewed inside the cut-out subgroup. -/
 lemma quotientPointsSubgroupFunctor_map_quotientPointsHom
@@ -151,17 +238,7 @@ lemma quotientPointsSubgroupFunctor_map_quotientPointsHom
         ⟨quotientPointsHom H I A f, quotientPointsHom_mem_quotientPointsSubgroup H I A f⟩ =
       ⟨quotientPointsHom H I B (HopfAlgebra.mapPoints (H := quotient H I) χ f),
         quotientPointsHom_mem_quotientPointsSubgroup H I B _⟩ := by
-  apply Subtype.ext
-  rw [coe_mapQuotientPointsSubgroup_apply]
-  apply WithConv.ofConv_injective
-  apply AlgHom.ext
-  intro h
-  rw [quotientPointsHom_apply_apply]
-  -- `mapPoints` is a bundled group hom, so expose its evaluation before rewriting
-  -- `quotientPointsHom` under post-composition.
-  change χ.hom ((quotientPointsHom H I A f).ofConv h) =
-    χ.hom (f.ofConv (Ideal.Quotient.mkₐ R I.toIdeal h))
-  rw [quotientPointsHom_apply_apply]
+  exact quotientPointsSubgroupFunctor_map_quotientPointsHom_aux H I χ f
 
 /-- Factoring an ambient point through the quotient is natural in the value algebra. -/
 lemma mapPoints_liftQuotientPoint (H : _root_.CommHopfAlgCat.{v} R)
@@ -176,25 +253,9 @@ lemma mapPoints_liftQuotientPoint (H : _root_.CommHopfAlgCat.{v} R)
           exact (mem_quotientPointsSubgroup_iff H I B _).mp
             (mapPoints_mem_quotientPointsSubgroup H I χ
               ((mem_quotientPointsSubgroup_iff H I A g).mpr hg)) h hh) := by
-  apply quotientPointsHom_injective H I B
-  have hnat :
-      HopfAlgebra.mapPoints (H := H) χ
-          (quotientPointsHom H I A (liftQuotientPoint H I A g hg)) =
-        quotientPointsHom H I B
-          (HopfAlgebra.mapPoints (H := quotient H I) χ
-            (liftQuotientPoint H I A g hg)) := by
-    apply WithConv.ofConv_injective
-    apply AlgHom.ext
-    intro h
-    rw [quotientPointsHom_apply_apply]
-    -- `mapPoints` is a bundled group hom, so expose its evaluation before rewriting
-    -- `quotientPointsHom` under post-composition.
-    change χ.hom
-        ((quotientPointsHom H I A (liftQuotientPoint H I A g hg)).ofConv h) =
-      χ.hom
-        (((liftQuotientPoint H I A g hg).ofConv) (Ideal.Quotient.mkₐ R I.toIdeal h))
-    rw [quotientPointsHom_apply_apply]
-  rw [← hnat, quotientPointsHom_liftQuotientPoint, quotientPointsHom_liftQuotientPoint]
+  exact liftQuotientPointHom_naturality H I χ
+    (⟨g, (mem_quotientPointsSubgroup_iff H I A g).mpr hg⟩ :
+      quotientPointsSubgroup H I A)
 
 end CommHopfAlgCat
 

--- a/TauCeti/Algebra/AlgebraicGroup/HopfIdealPointsNaturality.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/HopfIdealPointsNaturality.lean
@@ -1,0 +1,190 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+module
+
+public import TauCeti.Algebra.AlgebraicGroup.HopfIdealPoints
+
+/-!
+# Naturality of Hopf-ideal quotient points
+
+For a Hopf ideal `I` in a commutative Hopf algebra `H`, the quotient Hopf algebra
+`H ⧸ I` represents the closed subgroup whose `A`-points are the ambient `H`-points killing
+`I`. This file records that this description is natural in the value algebra `A`.
+
+The quotient-points inclusion commutes with post-composition along a morphism
+`A ⟶ B` of commutative `R`-algebras. Consequently the subgroup of ambient points cut out by
+`I` is preserved by the functor-of-points map, and the value-algebra map restricts to a
+homomorphism between these subgroups.
+
+This is a small Layer 3 prerequisite for the ReductiveGroups roadmap target "Hopf ideals ↔
+closed subgroup schemes": the closed-subgroup functor represented by `H ⧸ I` must be a
+subfunctor of the ambient points functor, not just a subgroup at each individual algebra.
+-/
+
+public section
+
+open CategoryTheory WithConv
+
+namespace TauCeti
+
+universe u v w
+
+namespace HopfAlgebra
+
+variable {R : Type u} [CommRing R] {H : Type v} [Semiring H] [_root_.HopfAlgebra R H]
+
+/-- Pointwise form of the map on points induced by a morphism of value algebras. -/
+@[simp]
+lemma mapPoints_apply_apply {A B : CommAlgCat.{w} R} (χ : A ⟶ B)
+    (f : points (R := R) (H := H) A) (h : H) :
+    ((mapPoints (H := H) χ f).ofConv) h = χ.hom (f.ofConv h) :=
+  rfl
+
+end HopfAlgebra
+
+namespace CommHopfAlgCat
+
+variable {R : Type u} [CommRing R]
+
+/-- The quotient-points inclusion is natural in the value algebra.
+
+Post-composing a quotient point `H ⧸ I →ₐ[R] A` by `χ : A ⟶ B`, then including it as an
+ambient point of `H`, gives the same ambient `B`-point as first including it and then
+post-composing by `χ`. -/
+lemma mapPoints_quotientPointsHom (H : _root_.CommHopfAlgCat.{v} R)
+    (I : HopfIdeal R H) {A B : CommAlgCat.{w} R}
+    (χ : A ⟶ B) (f : HopfAlgebra.points (R := R) (H := quotient H I) A) :
+    HopfAlgebra.mapPoints (H := H) χ (quotientPointsHom H I A f) =
+      quotientPointsHom H I B
+        (HopfAlgebra.mapPoints (H := quotient H I) χ f) := by
+  apply WithConv.ofConv_injective
+  apply AlgHom.ext
+  intro h
+  calc
+    ((HopfAlgebra.mapPoints (H := H) χ (quotientPointsHom H I A f)).ofConv) h =
+        χ.hom (((quotientPointsHom H I A f).ofConv) h) :=
+      HopfAlgebra.mapPoints_apply_apply (H := H) χ (quotientPointsHom H I A f) h
+    _ = χ.hom (f.ofConv (Ideal.Quotient.mkₐ R I.toIdeal h)) := by
+      rw [quotientPointsHom_apply_apply]
+    _ = ((quotientPointsHom H I B
+          (HopfAlgebra.mapPoints (H := quotient H I) χ f)).ofConv) h := by
+      rw [quotientPointsHom_apply_apply,
+        HopfAlgebra.mapPoints_apply_apply (H := quotient H I)]
+
+/-- Pointwise form of naturality of the quotient-points inclusion. -/
+lemma mapPoints_quotientPointsHom_apply_apply (H : _root_.CommHopfAlgCat.{v} R)
+    (I : HopfIdeal R H) {A B : CommAlgCat.{w} R}
+    (χ : A ⟶ B) (f : HopfAlgebra.points (R := R) (H := quotient H I) A) (h : H) :
+    ((HopfAlgebra.mapPoints (H := H) χ (quotientPointsHom H I A f)).ofConv) h =
+      χ.hom (f.ofConv (Ideal.Quotient.mkₐ R I.toIdeal h)) := by
+  rw [mapPoints_quotientPointsHom, quotientPointsHom_apply_apply]
+  rfl
+
+/-- The quotient-points inclusion commutes with the functor-of-points maps as a morphism
+equality. -/
+lemma quotientPointsHom_naturality (H : _root_.CommHopfAlgCat.{v} R)
+    (I : HopfIdeal R H) {A B : CommAlgCat.{w} R}
+    (χ : A ⟶ B) :
+    quotientPointsHom H I A ≫ HopfAlgebra.mapPoints (H := H) χ =
+      HopfAlgebra.mapPoints (H := quotient H I) χ ≫ quotientPointsHom H I B := by
+  ext f h
+  exact congrArg (fun g : HopfAlgebra.points (R := R) (H := H) B => g.ofConv h)
+    (mapPoints_quotientPointsHom H I χ f)
+
+/-- Post-composition preserves the ambient-point subgroup cut out by a Hopf ideal. -/
+lemma mapPoints_mem_quotientPointsSubgroup (H : _root_.CommHopfAlgCat.{v} R)
+    (I : HopfIdeal R H) {A B : CommAlgCat.{w} R}
+    (χ : A ⟶ B) {g : HopfAlgebra.points (R := R) (H := H) A}
+    (hg : g ∈ quotientPointsSubgroup H I A) :
+    HopfAlgebra.mapPoints (H := H) χ g ∈ quotientPointsSubgroup H I B := by
+  rw [mem_quotientPointsSubgroup_iff] at hg ⊢
+  intro h hh
+  rw [HopfAlgebra.mapPoints_apply_apply]
+  rw [hg h hh, map_zero]
+
+/-- The functor-of-points map restricted to the subgroups cut out by a Hopf ideal. -/
+@[expose] noncomputable def mapQuotientPointsSubgroup (H : _root_.CommHopfAlgCat.{v} R)
+    (I : HopfIdeal R H) {A B : CommAlgCat.{w} R}
+    (χ : A ⟶ B) :
+    quotientPointsSubgroup H I A →* quotientPointsSubgroup H I B where
+  toFun g :=
+    ⟨HopfAlgebra.mapPoints (H := H) χ g,
+      mapPoints_mem_quotientPointsSubgroup H I χ g.property⟩
+  map_one' := by
+    ext h
+    exact congrArg (fun f : HopfAlgebra.points (R := R) (H := H) B => f.ofConv h)
+      (HopfAlgebra.mapPoints_one (H := H) χ)
+  map_mul' g₁ g₂ := by
+    ext h
+    exact congrArg (fun f : HopfAlgebra.points (R := R) (H := H) B => f.ofConv h)
+      (HopfAlgebra.mapPoints_mul (H := H) χ g₁ g₂)
+
+/-- The restricted map on cut-out subgroups is induced by the ambient functor-of-points map. -/
+@[simp]
+lemma mapQuotientPointsSubgroup_apply (H : _root_.CommHopfAlgCat.{v} R)
+    (I : HopfIdeal R H) {A B : CommAlgCat.{w} R}
+    (χ : A ⟶ B) (g : quotientPointsSubgroup H I A) :
+    mapQuotientPointsSubgroup H I χ g =
+      ⟨HopfAlgebra.mapPoints (H := H) χ g,
+        mapPoints_mem_quotientPointsSubgroup H I χ g.property⟩ :=
+  rfl
+
+/-- Coercing the restricted subgroup map gives the ambient functor-of-points map. -/
+@[simp]
+lemma coe_mapQuotientPointsSubgroup_apply (H : _root_.CommHopfAlgCat.{v} R)
+    (I : HopfIdeal R H) {A B : CommAlgCat.{w} R}
+    (χ : A ⟶ B) (g : quotientPointsSubgroup H I A) :
+    (mapQuotientPointsSubgroup H I χ g :
+      HopfAlgebra.points (R := R) (H := H) B) =
+      HopfAlgebra.mapPoints (H := H) χ g :=
+  rfl
+
+/-- Pointwise form of the restricted subgroup map. -/
+@[simp]
+lemma mapQuotientPointsSubgroup_apply_apply (H : _root_.CommHopfAlgCat.{v} R)
+    (I : HopfIdeal R H) {A B : CommAlgCat.{w} R}
+    (χ : A ⟶ B) (g : quotientPointsSubgroup H I A) (h : H) :
+    ((mapQuotientPointsSubgroup H I χ g :
+      HopfAlgebra.points (R := R) (H := H) B).ofConv) h =
+      χ.hom (g.val.ofConv h) :=
+  rfl
+
+/-- The restricted subgroup maps preserve identity morphisms of value algebras. -/
+@[simp]
+lemma mapQuotientPointsSubgroup_id (H : _root_.CommHopfAlgCat.{v} R)
+    (I : HopfIdeal R H) (A : CommAlgCat.{w} R) :
+    mapQuotientPointsSubgroup H I (𝟙 A) =
+      MonoidHom.id (quotientPointsSubgroup H I A) := by
+  ext g h
+  rfl
+
+/-- The restricted subgroup maps preserve composition of value-algebra morphisms. -/
+lemma mapQuotientPointsSubgroup_comp (H : _root_.CommHopfAlgCat.{v} R)
+    (I : HopfIdeal R H) {A B C : CommAlgCat.{w} R} (χ : A ⟶ B) (ψ : B ⟶ C) :
+    mapQuotientPointsSubgroup H I (χ ≫ ψ) =
+      (mapQuotientPointsSubgroup H I ψ).comp
+        (mapQuotientPointsSubgroup H I χ) := by
+  ext g h
+  rfl
+
+/-- Factoring an ambient point through the quotient is natural in the value algebra. -/
+lemma mapPoints_liftQuotientPoint (H : _root_.CommHopfAlgCat.{v} R)
+    (I : HopfIdeal R H) {A B : CommAlgCat.{w} R}
+    (χ : A ⟶ B) (g : HopfAlgebra.points (R := R) (H := H) A)
+    (hg : ∀ h : H, h ∈ I → g.ofConv h = 0) :
+    HopfAlgebra.mapPoints (H := quotient H I) χ
+        (liftQuotientPoint H I A g hg) =
+      liftQuotientPoint H I B (HopfAlgebra.mapPoints (H := H) χ g)
+        (by
+          intro h hh
+          rw [HopfAlgebra.mapPoints_apply_apply]
+          rw [hg h hh, map_zero]) := by
+  apply quotientPointsHom_injective H I B
+  rw [← mapPoints_quotientPointsHom, quotientPointsHom_liftQuotientPoint,
+    quotientPointsHom_liftQuotientPoint]
+
+end CommHopfAlgCat
+
+end TauCeti

--- a/TauCeti/Algebra/AlgebraicGroup/HopfIdealPointsNaturality.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/HopfIdealPointsNaturality.lean
@@ -35,28 +35,6 @@ namespace CommHopfAlgCat
 
 variable {R : Type u} [CommRing R]
 
-/-- The quotient-points inclusion is natural in the value algebra. -/
-@[simp]
-lemma mapPoints_quotientPointsHom (H : _root_.CommHopfAlgCat.{v} R)
-    (I : HopfIdeal R H) {A B : CommAlgCat.{w} R}
-    (χ : A ⟶ B) (f : HopfAlgebra.points (R := R) (H := quotient H I) A) :
-    HopfAlgebra.mapPoints (H := H) χ (quotientPointsHom H I A f) =
-      quotientPointsHom H I B (HopfAlgebra.mapPoints (H := quotient H I) χ f) :=
-  by
-    apply WithConv.ofConv_injective
-    apply AlgHom.ext
-    intro h
-    calc
-      ((HopfAlgebra.mapPoints (H := H) χ (quotientPointsHom H I A f)).ofConv) h
-          = χ.hom ((quotientPointsHom H I A f).ofConv h) := rfl
-      _ = χ.hom (f.ofConv (Ideal.Quotient.mkₐ R I.toIdeal h)) := by
-        rw [quotientPointsHom_apply_apply]
-      _ = ((HopfAlgebra.mapPoints (H := quotient H I) χ f).ofConv)
-          (Ideal.Quotient.mkₐ R I.toIdeal h) := rfl
-      _ = ((quotientPointsHom H I B (HopfAlgebra.mapPoints (H := quotient H I) χ f)).ofConv)
-          h := by
-        rw [quotientPointsHom_apply_apply]
-
 /-- Post-composition preserves the ambient-point subgroup cut out by a Hopf ideal. -/
 lemma mapPoints_mem_quotientPointsSubgroup (H : _root_.CommHopfAlgCat.{v} R)
     (I : HopfIdeal R H) {A B : CommAlgCat.{w} R}
@@ -65,17 +43,58 @@ lemma mapPoints_mem_quotientPointsSubgroup (H : _root_.CommHopfAlgCat.{v} R)
     HopfAlgebra.mapPoints (H := H) χ g ∈ quotientPointsSubgroup H I B := by
   rw [mem_quotientPointsSubgroup_iff] at hg
   rw [← quotientPointsHom_liftQuotientPoint H I A g hg]
-  rw [mapPoints_quotientPointsHom]
+  have hnat :
+      HopfAlgebra.mapPoints (H := H) χ
+          (quotientPointsHom H I A (liftQuotientPoint H I A g hg)) =
+        quotientPointsHom H I B
+          (HopfAlgebra.mapPoints (H := quotient H I) χ
+            (liftQuotientPoint H I A g hg)) := by
+    apply WithConv.ofConv_injective
+    apply AlgHom.ext
+    intro h
+    rw [quotientPointsHom_apply_apply]
+    -- `mapPoints` is a bundled group hom, so expose its evaluation before rewriting
+    -- `quotientPointsHom` under post-composition.
+    change χ.hom
+        ((quotientPointsHom H I A (liftQuotientPoint H I A g hg)).ofConv h) =
+      χ.hom
+        (((liftQuotientPoint H I A g hg).ofConv) (Ideal.Quotient.mkₐ R I.toIdeal h))
+    rw [quotientPointsHom_apply_apply]
+  rw [hnat]
   exact quotientPointsHom_mem_quotientPointsSubgroup H I B _
 
+/-- The value-algebra functor of the point subgroups cut out by a Hopf ideal. -/
+@[expose] noncomputable def quotientPointsSubgroupFunctor
+    (H : _root_.CommHopfAlgCat.{v} R) (I : HopfIdeal R H) :
+    CommAlgCat.{w} R ⥤ GrpCat.{max v w} where
+  obj A := GrpCat.of (quotientPointsSubgroup H I A)
+  map {A B} χ := GrpCat.ofHom
+    (((HopfAlgebra.mapPoints (H := H) χ).hom.restrict (quotientPointsSubgroup H I A)).codRestrict
+      (quotientPointsSubgroup H I B)
+      fun g => mapPoints_mem_quotientPointsSubgroup H I χ g.property)
+  map_id A := by
+    ext g h
+    rfl
+  map_comp {A B C} χ ψ := by
+    ext g h
+    rfl
+
+/-- The subgroup functor includes naturally into the ambient functor of points. -/
+noncomputable def quotientPointsSubgroupIncl (H : _root_.CommHopfAlgCat.{v} R)
+    (I : HopfIdeal R H) :
+    quotientPointsSubgroupFunctor (R := R) H I ⟶
+      HopfAlgebra.pointsFunctor (R := R) (H := H) where
+  app A := GrpCat.ofHom (quotientPointsSubgroup H I A).subtype
+  naturality {A B} χ := by
+    ext g
+    rfl
+
 /-- The functor-of-points map restricted to the subgroups cut out by a Hopf ideal. -/
-@[expose] noncomputable def mapQuotientPointsSubgroup (H : _root_.CommHopfAlgCat.{v} R)
+noncomputable abbrev mapQuotientPointsSubgroup (H : _root_.CommHopfAlgCat.{v} R)
     (I : HopfIdeal R H) {A B : CommAlgCat.{w} R}
     (χ : A ⟶ B) :
     quotientPointsSubgroup H I A →* quotientPointsSubgroup H I B :=
-  ((HopfAlgebra.mapPoints (H := H) χ).hom.restrict (quotientPointsSubgroup H I A)).codRestrict
-    (quotientPointsSubgroup H I B)
-    fun g => mapPoints_mem_quotientPointsSubgroup H I χ g.property
+  ((quotientPointsSubgroupFunctor H I).map χ).hom
 
 /-- The restricted map on cut-out subgroups is induced by the ambient functor-of-points map. -/
 @[simp]
@@ -113,8 +132,7 @@ lemma mapQuotientPointsSubgroup_id (H : _root_.CommHopfAlgCat.{v} R)
     (I : HopfIdeal R H) (A : CommAlgCat.{w} R) :
     mapQuotientPointsSubgroup H I (𝟙 A) =
       MonoidHom.id (quotientPointsSubgroup H I A) := by
-  ext g h
-  rfl
+  exact congrArg GrpCat.Hom.hom ((quotientPointsSubgroupFunctor (R := R) H I).map_id A)
 
 /-- The restricted subgroup maps preserve composition of value-algebra morphisms. -/
 lemma mapQuotientPointsSubgroup_comp (H : _root_.CommHopfAlgCat.{v} R)
@@ -122,8 +140,28 @@ lemma mapQuotientPointsSubgroup_comp (H : _root_.CommHopfAlgCat.{v} R)
     mapQuotientPointsSubgroup H I (χ ≫ ψ) =
       (mapQuotientPointsSubgroup H I ψ).comp
         (mapQuotientPointsSubgroup H I χ) := by
-  ext g h
-  rfl
+  exact congrArg GrpCat.Hom.hom ((quotientPointsSubgroupFunctor (R := R) H I).map_comp χ ψ)
+
+/-- The image of a quotient point under the subgroup functor is its mapped quotient point,
+viewed inside the cut-out subgroup. -/
+lemma quotientPointsSubgroupFunctor_map_quotientPointsHom
+    (H : _root_.CommHopfAlgCat.{v} R) (I : HopfIdeal R H) {A B : CommAlgCat.{w} R}
+    (χ : A ⟶ B) (f : HopfAlgebra.points (R := R) (H := quotient H I) A) :
+    mapQuotientPointsSubgroup H I χ
+        ⟨quotientPointsHom H I A f, quotientPointsHom_mem_quotientPointsSubgroup H I A f⟩ =
+      ⟨quotientPointsHom H I B (HopfAlgebra.mapPoints (H := quotient H I) χ f),
+        quotientPointsHom_mem_quotientPointsSubgroup H I B _⟩ := by
+  apply Subtype.ext
+  rw [coe_mapQuotientPointsSubgroup_apply]
+  apply WithConv.ofConv_injective
+  apply AlgHom.ext
+  intro h
+  rw [quotientPointsHom_apply_apply]
+  -- `mapPoints` is a bundled group hom, so expose its evaluation before rewriting
+  -- `quotientPointsHom` under post-composition.
+  change χ.hom ((quotientPointsHom H I A f).ofConv h) =
+    χ.hom (f.ofConv (Ideal.Quotient.mkₐ R I.toIdeal h))
+  rw [quotientPointsHom_apply_apply]
 
 /-- Factoring an ambient point through the quotient is natural in the value algebra. -/
 lemma mapPoints_liftQuotientPoint (H : _root_.CommHopfAlgCat.{v} R)
@@ -139,8 +177,24 @@ lemma mapPoints_liftQuotientPoint (H : _root_.CommHopfAlgCat.{v} R)
             (mapPoints_mem_quotientPointsSubgroup H I χ
               ((mem_quotientPointsSubgroup_iff H I A g).mpr hg)) h hh) := by
   apply quotientPointsHom_injective H I B
-  rw [← mapPoints_quotientPointsHom, quotientPointsHom_liftQuotientPoint,
-    quotientPointsHom_liftQuotientPoint]
+  have hnat :
+      HopfAlgebra.mapPoints (H := H) χ
+          (quotientPointsHom H I A (liftQuotientPoint H I A g hg)) =
+        quotientPointsHom H I B
+          (HopfAlgebra.mapPoints (H := quotient H I) χ
+            (liftQuotientPoint H I A g hg)) := by
+    apply WithConv.ofConv_injective
+    apply AlgHom.ext
+    intro h
+    rw [quotientPointsHom_apply_apply]
+    -- `mapPoints` is a bundled group hom, so expose its evaluation before rewriting
+    -- `quotientPointsHom` under post-composition.
+    change χ.hom
+        ((quotientPointsHom H I A (liftQuotientPoint H I A g hg)).ofConv h) =
+      χ.hom
+        (((liftQuotientPoint H I A g hg).ofConv) (Ideal.Quotient.mkₐ R I.toIdeal h))
+    rw [quotientPointsHom_apply_apply]
+  rw [← hnat, quotientPointsHom_liftQuotientPoint, quotientPointsHom_liftQuotientPoint]
 
 end CommHopfAlgCat
 

--- a/TauCeti/Algebra/AlgebraicGroup/HopfIdealPointsNaturality.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/HopfIdealPointsNaturality.lean
@@ -76,6 +76,22 @@ lemma mapPoints_mem_quotientPointsSubgroup (H : _root_.CommHopfAlgCat.{v} R)
     ext g h
     rfl
 
+/-- The object part of the subgroup functor is the cut-out point subgroup. -/
+@[simp]
+lemma quotientPointsSubgroupFunctor_obj (H : _root_.CommHopfAlgCat.{v} R)
+    (I : HopfIdeal R H) (A : CommAlgCat.{w} R) :
+    (quotientPointsSubgroupFunctor (R := R) H I).obj A =
+      GrpCat.of (quotientPointsSubgroup H I A) :=
+  rfl
+
+/-- The map part of the subgroup functor is the restricted value-algebra map. -/
+@[simp]
+lemma quotientPointsSubgroupFunctor_map (H : _root_.CommHopfAlgCat.{v} R)
+    (I : HopfIdeal R H) {A B : CommAlgCat.{w} R} (χ : A ⟶ B) :
+    (quotientPointsSubgroupFunctor (R := R) H I).map χ =
+      GrpCat.ofHom (mapQuotientPointsSubgroup H I χ) :=
+  rfl
+
 /-- The subgroup functor includes naturally into the ambient functor of points. -/
 @[expose] noncomputable def quotientPointsSubgroupIncl (H : _root_.CommHopfAlgCat.{v} R)
     (I : HopfIdeal R H) :
@@ -151,6 +167,9 @@ private lemma liftQuotientPointHom_apply (H : _root_.CommHopfAlgCat.{v} R)
     liftQuotientPointHom H I A g =
       liftQuotientPoint H I A g ((mem_quotientPointsSubgroup_iff H I A g).mp g.property) := by
   apply quotientPointsHom_injective H I A
+  -- `liftQuotientPointHom` is the `toMonoidHom` of the inverse equivalence returned by
+  -- `MonoidHom.ofInjective`; this coercion exposes the underlying inverse application so the
+  -- standard `apply_ofInjective_symm` lemma can rewrite it.
   change (quotientPointsHom H I A).hom
       (((MonoidHom.ofInjective (f := (quotientPointsHom H I A).hom)
         (quotientPointsHom_injective H I A)).symm) g) =
@@ -218,6 +237,25 @@ noncomputable def quotientPointsSubgroupNatIso (H : _root_.CommHopfAlgCat.{v} R)
       intro A B χ
       ext f
       exact (quotientPointsSubgroupFunctor_map_quotientPointsHom_aux H I χ f).symm)
+
+/-- The natural isomorphism's forward component is the quotient-subgroup component isomorphism. -/
+@[simp]
+lemma quotientPointsSubgroupNatIso_hom_app_apply (H : _root_.CommHopfAlgCat.{v} R)
+    (I : HopfIdeal R H) (A : CommAlgCat.{w} R)
+    (f : HopfAlgebra.points (R := R) (H := quotient H I) A) :
+    (quotientPointsSubgroupNatIso H I).hom.app A f =
+      (⟨quotientPointsHom H I A f, quotientPointsHom_mem_quotientPointsSubgroup H I A f⟩ :
+        quotientPointsSubgroup H I A) := by
+  exact quotientPointsSubgroupIso_hom_apply H I A f
+
+/-- The natural isomorphism's inverse component is the quotient lift of a subgroup point. -/
+@[simp]
+lemma quotientPointsSubgroupNatIso_inv_app_apply (H : _root_.CommHopfAlgCat.{v} R)
+    (I : HopfIdeal R H) (A : CommAlgCat.{w} R)
+    (g : quotientPointsSubgroup H I A) :
+    (quotientPointsSubgroupNatIso H I).inv.app A g =
+      liftQuotientPoint H I A g ((mem_quotientPointsSubgroup_iff H I A g).mp g.property) := by
+  exact quotientPointsSubgroupIso_inv_apply H I A g
 
 /-- The image of a quotient point under the subgroup functor is its mapped quotient point,
 viewed inside the cut-out subgroup. -/

--- a/TauCeti/Algebra/AlgebraicGroup/HopfIdealPointsNaturality.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/HopfIdealPointsNaturality.lean
@@ -35,17 +35,38 @@ namespace CommHopfAlgCat
 
 variable {R : Type u} [CommRing R]
 
+/-- The quotient-points inclusion is natural in the value algebra. -/
+@[simp]
+lemma mapPoints_quotientPointsHom (H : _root_.CommHopfAlgCat.{v} R)
+    (I : HopfIdeal R H) {A B : CommAlgCat.{w} R}
+    (χ : A ⟶ B) (f : HopfAlgebra.points (R := R) (H := quotient H I) A) :
+    HopfAlgebra.mapPoints (H := H) χ (quotientPointsHom H I A f) =
+      quotientPointsHom H I B (HopfAlgebra.mapPoints (H := quotient H I) χ f) :=
+  by
+    apply WithConv.ofConv_injective
+    apply AlgHom.ext
+    intro h
+    calc
+      ((HopfAlgebra.mapPoints (H := H) χ (quotientPointsHom H I A f)).ofConv) h
+          = χ.hom ((quotientPointsHom H I A f).ofConv h) := rfl
+      _ = χ.hom (f.ofConv (Ideal.Quotient.mkₐ R I.toIdeal h)) := by
+        rw [quotientPointsHom_apply_apply]
+      _ = ((HopfAlgebra.mapPoints (H := quotient H I) χ f).ofConv)
+          (Ideal.Quotient.mkₐ R I.toIdeal h) := rfl
+      _ = ((quotientPointsHom H I B (HopfAlgebra.mapPoints (H := quotient H I) χ f)).ofConv)
+          h := by
+        rw [quotientPointsHom_apply_apply]
+
 /-- Post-composition preserves the ambient-point subgroup cut out by a Hopf ideal. -/
 lemma mapPoints_mem_quotientPointsSubgroup (H : _root_.CommHopfAlgCat.{v} R)
     (I : HopfIdeal R H) {A B : CommAlgCat.{w} R}
     (χ : A ⟶ B) {g : HopfAlgebra.points (R := R) (H := H) A}
     (hg : g ∈ quotientPointsSubgroup H I A) :
     HopfAlgebra.mapPoints (H := H) χ g ∈ quotientPointsSubgroup H I B := by
-  rw [mem_quotientPointsSubgroup_iff] at hg ⊢
-  intro h hh
-  rw [show ((HopfAlgebra.mapPoints (H := H) χ g).ofConv) h = χ.hom (g.ofConv h) from
-    HopfAlgebra.pointsFunctor_map_apply_apply (H := H) χ g h]
-  rw [hg h hh, map_zero]
+  rw [mem_quotientPointsSubgroup_iff] at hg
+  rw [← quotientPointsHom_liftQuotientPoint H I A g hg]
+  rw [mapPoints_quotientPointsHom]
+  exact quotientPointsHom_mem_quotientPointsSubgroup H I B _
 
 /-- The functor-of-points map restricted to the subgroups cut out by a Hopf ideal. -/
 @[expose] noncomputable def mapQuotientPointsSubgroup (H : _root_.CommHopfAlgCat.{v} R)
@@ -114,23 +135,12 @@ lemma mapPoints_liftQuotientPoint (H : _root_.CommHopfAlgCat.{v} R)
       liftQuotientPoint H I B (HopfAlgebra.mapPoints (H := H) χ g)
         (by
           intro h hh
-          rw [show ((HopfAlgebra.mapPoints (H := H) χ g).ofConv) h = χ.hom (g.ofConv h) from
-            HopfAlgebra.pointsFunctor_map_apply_apply (H := H) χ g h]
-          rw [hg h hh, map_zero]) := by
+          exact (mem_quotientPointsSubgroup_iff H I B _).mp
+            (mapPoints_mem_quotientPointsSubgroup H I χ
+              ((mem_quotientPointsSubgroup_iff H I A g).mpr hg)) h hh) := by
   apply quotientPointsHom_injective H I B
-  apply WithConv.ofConv_injective
-  apply AlgHom.ext
-  intro h
-  rw [quotientPointsHom_apply_apply, quotientPointsHom_liftQuotientPoint]
-  rw [show
-    ((HopfAlgebra.mapPoints (H := quotient H I) χ (liftQuotientPoint H I A g hg)).ofConv)
-        (Ideal.Quotient.mkₐ R I.toIdeal h) =
-      χ.hom ((liftQuotientPoint H I A g hg).ofConv (Ideal.Quotient.mkₐ R I.toIdeal h)) from
-    HopfAlgebra.pointsFunctor_map_apply_apply (H := quotient H I) χ
-      (liftQuotientPoint H I A g hg) (Ideal.Quotient.mkₐ R I.toIdeal h)]
-  rw [show ((HopfAlgebra.mapPoints (H := H) χ g).ofConv) h = χ.hom (g.ofConv h) from
-    HopfAlgebra.pointsFunctor_map_apply_apply (H := H) χ g h]
-  rw [liftQuotientPoint_mk]
+  rw [← mapPoints_quotientPointsHom, quotientPointsHom_liftQuotientPoint,
+    quotientPointsHom_liftQuotientPoint]
 
 end CommHopfAlgCat
 

--- a/TauCeti/Algebra/AlgebraicGroup/HopfIdealPointsNaturality.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/HopfIdealPointsNaturality.lean
@@ -31,67 +31,9 @@ namespace TauCeti
 
 universe u v w
 
-namespace HopfAlgebra
-
-variable {R : Type u} [CommRing R] {H : Type v} [Semiring H] [_root_.HopfAlgebra R H]
-
-/-- Pointwise form of the map on points induced by a morphism of value algebras. -/
-@[simp]
-lemma mapPoints_apply_apply {A B : CommAlgCat.{w} R} (χ : A ⟶ B)
-    (f : points (R := R) (H := H) A) (h : H) :
-    ((mapPoints (H := H) χ f).ofConv) h = χ.hom (f.ofConv h) :=
-  rfl
-
-end HopfAlgebra
-
 namespace CommHopfAlgCat
 
 variable {R : Type u} [CommRing R]
-
-/-- The quotient-points inclusion is natural in the value algebra.
-
-Post-composing a quotient point `H ⧸ I →ₐ[R] A` by `χ : A ⟶ B`, then including it as an
-ambient point of `H`, gives the same ambient `B`-point as first including it and then
-post-composing by `χ`. -/
-lemma mapPoints_quotientPointsHom (H : _root_.CommHopfAlgCat.{v} R)
-    (I : HopfIdeal R H) {A B : CommAlgCat.{w} R}
-    (χ : A ⟶ B) (f : HopfAlgebra.points (R := R) (H := quotient H I) A) :
-    HopfAlgebra.mapPoints (H := H) χ (quotientPointsHom H I A f) =
-      quotientPointsHom H I B
-        (HopfAlgebra.mapPoints (H := quotient H I) χ f) := by
-  apply WithConv.ofConv_injective
-  apply AlgHom.ext
-  intro h
-  calc
-    ((HopfAlgebra.mapPoints (H := H) χ (quotientPointsHom H I A f)).ofConv) h =
-        χ.hom (((quotientPointsHom H I A f).ofConv) h) :=
-      HopfAlgebra.mapPoints_apply_apply (H := H) χ (quotientPointsHom H I A f) h
-    _ = χ.hom (f.ofConv (Ideal.Quotient.mkₐ R I.toIdeal h)) := by
-      rw [quotientPointsHom_apply_apply]
-    _ = ((quotientPointsHom H I B
-          (HopfAlgebra.mapPoints (H := quotient H I) χ f)).ofConv) h := by
-      rw [quotientPointsHom_apply_apply,
-        HopfAlgebra.mapPoints_apply_apply (H := quotient H I)]
-
-/-- Pointwise form of naturality of the quotient-points inclusion. -/
-lemma mapPoints_quotientPointsHom_apply_apply (H : _root_.CommHopfAlgCat.{v} R)
-    (I : HopfIdeal R H) {A B : CommAlgCat.{w} R}
-    (χ : A ⟶ B) (f : HopfAlgebra.points (R := R) (H := quotient H I) A) (h : H) :
-    ((HopfAlgebra.mapPoints (H := H) χ (quotientPointsHom H I A f)).ofConv) h =
-      χ.hom (f.ofConv (Ideal.Quotient.mkₐ R I.toIdeal h)) := by
-  rw [mapPoints_quotientPointsHom, quotientPointsHom_apply_apply]
-  rfl
-
-/-- The quotient-points inclusion commutes with the functor-of-points maps as a morphism
-equality. -/
-lemma quotientPointsHom_naturality (H : _root_.CommHopfAlgCat.{v} R)
-    (I : HopfIdeal R H) {A B : CommAlgCat.{w} R}
-    (χ : A ⟶ B) :
-    quotientPointsHom H I A ≫ HopfAlgebra.mapPoints (H := H) χ =
-      HopfAlgebra.mapPoints (H := quotient H I) χ ≫ quotientPointsHom H I B := by
-  ext f h
-  exact congrArg (fun g : HopfAlgebra.points (R := R) (H := H) B => g.ofConv h)
-    (mapPoints_quotientPointsHom H I χ f)
 
 /-- Post-composition preserves the ambient-point subgroup cut out by a Hopf ideal. -/
 lemma mapPoints_mem_quotientPointsSubgroup (H : _root_.CommHopfAlgCat.{v} R)
@@ -101,25 +43,18 @@ lemma mapPoints_mem_quotientPointsSubgroup (H : _root_.CommHopfAlgCat.{v} R)
     HopfAlgebra.mapPoints (H := H) χ g ∈ quotientPointsSubgroup H I B := by
   rw [mem_quotientPointsSubgroup_iff] at hg ⊢
   intro h hh
-  rw [HopfAlgebra.mapPoints_apply_apply]
+  rw [show ((HopfAlgebra.mapPoints (H := H) χ g).ofConv) h = χ.hom (g.ofConv h) from
+    HopfAlgebra.pointsFunctor_map_apply_apply (H := H) χ g h]
   rw [hg h hh, map_zero]
 
 /-- The functor-of-points map restricted to the subgroups cut out by a Hopf ideal. -/
 @[expose] noncomputable def mapQuotientPointsSubgroup (H : _root_.CommHopfAlgCat.{v} R)
     (I : HopfIdeal R H) {A B : CommAlgCat.{w} R}
     (χ : A ⟶ B) :
-    quotientPointsSubgroup H I A →* quotientPointsSubgroup H I B where
-  toFun g :=
-    ⟨HopfAlgebra.mapPoints (H := H) χ g,
-      mapPoints_mem_quotientPointsSubgroup H I χ g.property⟩
-  map_one' := by
-    ext h
-    exact congrArg (fun f : HopfAlgebra.points (R := R) (H := H) B => f.ofConv h)
-      (HopfAlgebra.mapPoints_one (H := H) χ)
-  map_mul' g₁ g₂ := by
-    ext h
-    exact congrArg (fun f : HopfAlgebra.points (R := R) (H := H) B => f.ofConv h)
-      (HopfAlgebra.mapPoints_mul (H := H) χ g₁ g₂)
+    quotientPointsSubgroup H I A →* quotientPointsSubgroup H I B :=
+  ((HopfAlgebra.mapPoints (H := H) χ).hom.restrict (quotientPointsSubgroup H I A)).codRestrict
+    (quotientPointsSubgroup H I B)
+    fun g => mapPoints_mem_quotientPointsSubgroup H I χ g.property
 
 /-- The restricted map on cut-out subgroups is induced by the ambient functor-of-points map. -/
 @[simp]
@@ -179,11 +114,23 @@ lemma mapPoints_liftQuotientPoint (H : _root_.CommHopfAlgCat.{v} R)
       liftQuotientPoint H I B (HopfAlgebra.mapPoints (H := H) χ g)
         (by
           intro h hh
-          rw [HopfAlgebra.mapPoints_apply_apply]
+          rw [show ((HopfAlgebra.mapPoints (H := H) χ g).ofConv) h = χ.hom (g.ofConv h) from
+            HopfAlgebra.pointsFunctor_map_apply_apply (H := H) χ g h]
           rw [hg h hh, map_zero]) := by
   apply quotientPointsHom_injective H I B
-  rw [← mapPoints_quotientPointsHom, quotientPointsHom_liftQuotientPoint,
-    quotientPointsHom_liftQuotientPoint]
+  apply WithConv.ofConv_injective
+  apply AlgHom.ext
+  intro h
+  rw [quotientPointsHom_apply_apply, quotientPointsHom_liftQuotientPoint]
+  rw [show
+    ((HopfAlgebra.mapPoints (H := quotient H I) χ (liftQuotientPoint H I A g hg)).ofConv)
+        (Ideal.Quotient.mkₐ R I.toIdeal h) =
+      χ.hom ((liftQuotientPoint H I A g hg).ofConv (Ideal.Quotient.mkₐ R I.toIdeal h)) from
+    HopfAlgebra.pointsFunctor_map_apply_apply (H := quotient H I) χ
+      (liftQuotientPoint H I A g hg) (Ideal.Quotient.mkₐ R I.toIdeal h)]
+  rw [show ((HopfAlgebra.mapPoints (H := H) χ g).ofConv) h = χ.hom (g.ofConv h) from
+    HopfAlgebra.pointsFunctor_map_apply_apply (H := H) χ g h]
+  rw [liftQuotientPoint_mk]
 
 end CommHopfAlgCat
 

--- a/TauCeti/Algebra/AlgebraicGroup/HopfIdealPointsNaturality.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/HopfIdealPointsNaturality.lean
@@ -140,22 +140,24 @@ lemma mapQuotientPointsSubgroup_comp (H : _root_.CommHopfAlgCat.{v} R)
         (mapQuotientPointsSubgroup H I χ) := by
   exact congrArg GrpCat.Hom.hom ((quotientPointsSubgroupFunctor (R := R) H I).map_comp χ ψ)
 
-/-- The inverse map from a cut-out subgroup point to the corresponding quotient point. -/
-noncomputable def liftQuotientPointHom (H : _root_.CommHopfAlgCat.{v} R)
+private noncomputable def liftQuotientPointHom (H : _root_.CommHopfAlgCat.{v} R)
     (I : HopfIdeal R H) (A : CommAlgCat.{w} R) :
-    quotientPointsSubgroup H I A →* HopfAlgebra.points (R := R) (H := quotient H I) A where
-  toFun g := liftQuotientPoint H I A g
-    ((mem_quotientPointsSubgroup_iff H I A g).mp g.property)
-  map_one' := by
-    apply quotientPointsHom_injective H I A
-    rw [quotientPointsHom_liftQuotientPoint, map_one]
-    rfl
-  map_mul' := by
-    intro g₁ g₂
-    apply quotientPointsHom_injective H I A
-    rw [quotientPointsHom_liftQuotientPoint, map_mul, quotientPointsHom_liftQuotientPoint,
-      quotientPointsHom_liftQuotientPoint]
-    rfl
+    quotientPointsSubgroup H I A →* HopfAlgebra.points (R := R) (H := quotient H I) A :=
+  ((MonoidHom.ofInjective (f := (quotientPointsHom H I A).hom)
+    (quotientPointsHom_injective H I A)).symm).toMonoidHom
+
+private lemma liftQuotientPointHom_apply (H : _root_.CommHopfAlgCat.{v} R)
+    (I : HopfIdeal R H) (A : CommAlgCat.{w} R) (g : quotientPointsSubgroup H I A) :
+    liftQuotientPointHom H I A g =
+      liftQuotientPoint H I A g ((mem_quotientPointsSubgroup_iff H I A g).mp g.property) := by
+  apply quotientPointsHom_injective H I A
+  change (quotientPointsHom H I A).hom
+      (((MonoidHom.ofInjective (f := (quotientPointsHom H I A).hom)
+        (quotientPointsHom_injective H I A)).symm) g) =
+    (quotientPointsHom H I A).hom
+      (liftQuotientPoint H I A g
+        ((mem_quotientPointsSubgroup_iff H I A g).mp g.property))
+  rw [MonoidHom.apply_ofInjective_symm, quotientPointsHom_liftQuotientPoint]
 
 private lemma liftQuotientPointHom_naturality (H : _root_.CommHopfAlgCat.{v} R)
     (I : HopfIdeal R H) {A B : CommAlgCat.{w} R} (χ : A ⟶ B)
@@ -164,48 +166,36 @@ private lemma liftQuotientPointHom_naturality (H : _root_.CommHopfAlgCat.{v} R)
       liftQuotientPointHom H I B (mapQuotientPointsSubgroup H I χ g) := by
   apply quotientPointsHom_injective H I B
   rw [← mapPoints_quotientPointsHom H I χ]
-  -- Expose the concrete lift maps after applying injectivity to the quotient-points inclusion.
-  change HopfAlgebra.mapPoints (H := H) χ
-      (quotientPointsHom H I A
-        (liftQuotientPoint H I A g
-          ((mem_quotientPointsSubgroup_iff H I A g).mp g.property))) =
-    quotientPointsHom H I B
-      (liftQuotientPoint H I B (mapQuotientPointsSubgroup H I χ g)
-        ((mem_quotientPointsSubgroup_iff H I B (mapQuotientPointsSubgroup H I χ g)).mp
-          (mapQuotientPointsSubgroup H I χ g).property))
+  rw [liftQuotientPointHom_apply, liftQuotientPointHom_apply]
   rw [quotientPointsHom_liftQuotientPoint, quotientPointsHom_liftQuotientPoint]
   rfl
 
 /-- The component isomorphism between quotient points and the cut-out subgroup. -/
-noncomputable def quotientPointsSubgroupIso (H : _root_.CommHopfAlgCat.{v} R)
+@[expose] noncomputable def quotientPointsSubgroupIso (H : _root_.CommHopfAlgCat.{v} R)
     (I : HopfIdeal R H) (A : CommAlgCat.{w} R) :
     GrpCat.of (HopfAlgebra.points (R := R) (H := quotient H I) A) ≅
-      GrpCat.of (quotientPointsSubgroup H I A) where
-  hom := GrpCat.ofHom ((quotientPointsHom H I A).hom.codRestrict
-    (quotientPointsSubgroup H I A)
-    (quotientPointsHom_mem_quotientPointsSubgroup H I A))
-  inv := GrpCat.ofHom (liftQuotientPointHom H I A)
-  hom_inv_id := by
-    apply GrpCat.hom_ext
-    apply MonoidHom.ext
-    intro g
-    -- The component iso is bundled in `GrpCat`; expose the underlying quotient lift.
-    change liftQuotientPoint H I A (quotientPointsHom H I A g)
-        ((mem_quotientPointsSubgroup_iff H I A (quotientPointsHom H I A g)).mp
-          (quotientPointsHom_mem_quotientPointsSubgroup H I A g)) =
-      g
-    apply quotientPointsHom_injective H I A
-    rw [quotientPointsHom_liftQuotientPoint]
-  inv_hom_id := by
-    apply GrpCat.hom_ext
-    apply MonoidHom.ext
-    intro g
-    -- The component iso is bundled in `GrpCat`; expose the underlying quotient inclusion.
-    change (⟨quotientPointsHom H I A (liftQuotientPointHom H I A g),
-        quotientPointsHom_mem_quotientPointsSubgroup H I A _⟩ :
-        quotientPointsSubgroup H I A) = g
-    exact Subtype.ext (quotientPointsHom_liftQuotientPoint H I A g
-      ((mem_quotientPointsSubgroup_iff H I A g).mp g.property))
+      GrpCat.of (quotientPointsSubgroup H I A) :=
+  (MonoidHom.ofInjective (f := (quotientPointsHom H I A).hom)
+    (quotientPointsHom_injective H I A)).toGrpIso
+
+/-- The component isomorphism sends a quotient point to its included ambient point. -/
+@[simp]
+lemma quotientPointsSubgroupIso_hom_apply (H : _root_.CommHopfAlgCat.{v} R)
+    (I : HopfIdeal R H) (A : CommAlgCat.{w} R)
+    (f : HopfAlgebra.points (R := R) (H := quotient H I) A) :
+    (quotientPointsSubgroupIso H I A).hom f =
+      (⟨quotientPointsHom H I A f, quotientPointsHom_mem_quotientPointsSubgroup H I A f⟩ :
+        quotientPointsSubgroup H I A) :=
+  Subtype.ext rfl
+
+/-- The inverse component is the quotient point factoring the included ambient point. -/
+@[simp]
+lemma quotientPointsSubgroupIso_inv_apply (H : _root_.CommHopfAlgCat.{v} R)
+    (I : HopfIdeal R H) (A : CommAlgCat.{w} R)
+    (g : quotientPointsSubgroup H I A) :
+    (quotientPointsSubgroupIso H I A).inv g =
+      liftQuotientPoint H I A g ((mem_quotientPointsSubgroup_iff H I A g).mp g.property) := by
+  exact liftQuotientPointHom_apply H I A g
 
 private lemma quotientPointsSubgroupFunctor_map_quotientPointsHom_aux
     (H : _root_.CommHopfAlgCat.{v} R) (I : HopfIdeal R H) {A B : CommAlgCat.{w} R}
@@ -253,9 +243,9 @@ lemma mapPoints_liftQuotientPoint (H : _root_.CommHopfAlgCat.{v} R)
           exact (mem_quotientPointsSubgroup_iff H I B _).mp
             (mapPoints_mem_quotientPointsSubgroup H I χ
               ((mem_quotientPointsSubgroup_iff H I A g).mpr hg)) h hh) := by
-  exact liftQuotientPointHom_naturality H I χ
-    (⟨g, (mem_quotientPointsSubgroup_iff H I A g).mpr hg⟩ :
-      quotientPointsSubgroup H I A)
+  apply quotientPointsHom_injective H I B
+  rw [← mapPoints_quotientPointsHom H I χ, quotientPointsHom_liftQuotientPoint,
+    quotientPointsHom_liftQuotientPoint]
 
 end CommHopfAlgCat
 

--- a/TauCeti/Algebra/AlgebraicGroup/HopfIdealPointsNaturality.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/HopfIdealPointsNaturality.lean
@@ -243,7 +243,10 @@ noncomputable def quotientPointsSubgroupNatIso (H : _root_.CommHopfAlgCat.{v} R)
 lemma quotientPointsSubgroupNatIso_hom_app_apply (H : _root_.CommHopfAlgCat.{v} R)
     (I : HopfIdeal R H) (A : CommAlgCat.{w} R)
     (f : HopfAlgebra.points (R := R) (H := quotient H I) A) :
-    (quotientPointsSubgroupNatIso H I).hom.app A f =
+    CategoryTheory.ConcreteCategory.hom
+        (X := HopfAlgebra.pointsFunctor (R := R) (H := quotient H I).obj A)
+        (Y := GrpCat.of (quotientPointsSubgroup H I A))
+        ((quotientPointsSubgroupNatIso H I).hom.app A) f =
       (⟨quotientPointsHom H I A f, quotientPointsHom_mem_quotientPointsSubgroup H I A f⟩ :
         quotientPointsSubgroup H I A) := by
   exact quotientPointsSubgroupIso_hom_apply H I A f
@@ -253,7 +256,10 @@ lemma quotientPointsSubgroupNatIso_hom_app_apply (H : _root_.CommHopfAlgCat.{v} 
 lemma quotientPointsSubgroupNatIso_inv_app_apply (H : _root_.CommHopfAlgCat.{v} R)
     (I : HopfIdeal R H) (A : CommAlgCat.{w} R)
     (g : quotientPointsSubgroup H I A) :
-    (quotientPointsSubgroupNatIso H I).inv.app A g =
+    CategoryTheory.ConcreteCategory.hom
+        (X := GrpCat.of (quotientPointsSubgroup H I A))
+        (Y := HopfAlgebra.pointsFunctor (R := R) (H := quotient H I).obj A)
+        ((quotientPointsSubgroupNatIso H I).inv.app A) g =
       liftQuotientPoint H I A g ((mem_quotientPointsSubgroup_iff H I A g).mp g.property) := by
   exact quotientPointsSubgroupIso_inv_apply H I A g
 


### PR DESCRIPTION
This PR records value-algebra naturality for the point-level closed subgroup represented by a Hopf-ideal quotient: the quotient-points inclusion commutes with post-composition in the value algebra, the ambient subgroup cut out by the Hopf ideal is preserved by points maps, and those maps restrict to homomorphisms between the cut-out subgroups. It advances `TauCetiRoadmap/ReductiveGroups/README.md`, Layer 3, “Hopf ideals ↔ closed subgroup schemes,” as the subfunctoriality prerequisite for treating the quotient coordinate Hopf algebra `H ⧸ I` as a closed subgroup functor rather than just a subgroup at each individual algebra.

I chose this as the lowest-hanging distinct ReductiveGroups target after checking open and recently merged PRs: the basic convolution points functor, coordinate functoriality, Hopf-ideal quotient object, and pointwise quotient subgroup characterization are already on `main`, while the value-algebra naturality square and restricted subgroup maps were still absent. The open ReductiveGroups PR covers the finite-type trivial coordinate object, so this is a separate Hopf-ideal/subfunctor compatibility target.

No Mathlib infrastructure is vendored. The implementation reuses Tau Ceti’s existing `HopfAlgebra.mapPoints`, `CommHopfAlgCat.quotientPointsHom`, `mem_quotientPointsSubgroup_iff`, and `liftQuotientPoint` APIs, together with Mathlib’s standard `CommAlgCat`/`GrpCat` categorical morphism infrastructure.

`lake exe cache get` completed with `No files to download` and `Already decompressed 8609 file(s)`. `lake build` completed with `Build completed successfully (4506 jobs).` `lake exe axioms` completed with `axioms: audited 7694 TauCeti declaration(s); all within the allowlist [propext, Classical.choice, Quot.sound].`

<!--tauceti-target:v1 {"focus":"ReductiveGroups","id":"hopf-ideal-quotient-points-naturality"}-->

🤖 Prepared with Codex
