### PR TITLE
feat: add energy integrand coefficient continuity

### DIFF
--- a/TauCeti/Analysis/PDE/EnergyForm.lean
+++ b/TauCeti/Analysis/PDE/EnergyForm.lean
@@ -92,6 +92,7 @@ noncomputable def energyIntegrand (A : Matrix n n ℝ) (b : EuclideanSpace ℝ n
         (ContinuousLinearMap.fst ℝ ℝ (EuclideanSpace ℝ n))
         (ContinuousLinearMap.fst ℝ ℝ (EuclideanSpace ℝ n))
 
+omit [DecidableEq n] in
 /-- The jet form evaluates to `⟨a ∇u, ∇v⟩ + ⟪b, ∇u⟫ v + c u v` on jets `U`, `V`. -/
 @[simp]
 lemma energyIntegrand_apply (A : Matrix n n ℝ) (b : EuclideanSpace ℝ n) (c : ℝ)
@@ -158,6 +159,7 @@ private lemma abs_dotProduct_one_mulVec_le (η ξ : EuclideanSpace ℝ n) :
   simpa [EuclideanSpace.inner_eq_star_dotProduct, dotProduct_comm] using
     abs_real_inner_le_norm η ξ
 
+omit [DecidableEq n] in
 /-- Pointwise boundedness of the jet form with explicit constant `Λ + β + γ`: the principal,
 drift, and mass contributions are each controlled by the corresponding constant times the jet
 norms. -/
@@ -209,6 +211,7 @@ lemma norm_energyIntegrand_apply_le_of_bounds (hLam : 0 ≤ Lam)
         add_le_add (add_le_add hmat hdrift) hmass
     _ = (Lam + beta + gamma) * ‖U‖ * ‖V‖ := by ring
 
+omit [DecidableEq n] in
 /-- Pointwise boundedness on a domain, obtained by applying
 `norm_energyIntegrand_apply_le_of_bounds` at `x`. -/
 lemma norm_energyIntegrand_apply_le_of_bounds_on (hLam : 0 ≤ Lam)
@@ -220,6 +223,7 @@ lemma norm_energyIntegrand_apply_le_of_bounds_on (hLam : 0 ≤ Lam)
     ‖energyIntegrand (a x) (b x) (c x) U V‖ ≤ (Lam + beta + gamma) * ‖U‖ * ‖V‖ :=
   norm_energyIntegrand_apply_le_of_bounds hLam (ha hx) (hb hx) (hc hx) U V
 
+omit [DecidableEq n] in
 /-- The operator norm of the jet form is at most `Λ + β + γ`. This is the boundedness
 hypothesis of Lax--Milgram, with the constant explicit in the ellipticity, drift, and mass
 bounds. -/
@@ -253,6 +257,7 @@ lemma opNorm_energyIntegrand_one_zero_mass_le (c : ℝ) :
       (gamma := ‖c‖) zero_le_one
       (fun η ξ => abs_dotProduct_one_mulVec_le η ξ) (by simp) le_rfl
 
+omit [DecidableEq n] in
 /-- Operator-norm boundedness on a domain, obtained by applying
 `opNorm_energyIntegrand_le_of_bounds` at `x`. -/
 lemma opNorm_energyIntegrand_le_of_bounds_on (hLam : 0 ≤ Lam)

--- a/TauCeti/Analysis/PDE/EnergyFormContinuity.lean
+++ b/TauCeti/Analysis/PDE/EnergyFormContinuity.lean
@@ -37,7 +37,7 @@ namespace PDE
 open Matrix
 open scoped InnerProductSpace
 
-variable {X n : Type*} [Fintype n] [DecidableEq n]
+variable {X n : Type*} [Fintype n]
 
 /-- The coefficient triple-to-energy-integrand map as a continuous linear map. -/
 noncomputable def energyIntegrandLinear :

--- a/TauCeti/Analysis/PDE/EnergyFormContinuity.lean
+++ b/TauCeti/Analysis/PDE/EnergyFormContinuity.lean
@@ -1,0 +1,236 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+module
+
+public import TauCeti.Analysis.PDE.EnergyFormLinearity
+
+/-!
+# Continuity of pointwise PDE energy integrands in the coefficients
+
+The finite-dimensional weak-form integrand
+`energyIntegrand A b c` is linear in the principal, drift, and mass coefficients.  This file
+bundles that linearity as continuous linear maps from coefficient spaces to spaces of
+continuous bilinear maps.
+
+This is a pointwise prerequisite for Lane D of the PDE roadmap.  Once the weak energy form is
+defined by integrating `x ↦ energyIntegrand (a x) (b x) (c x)` over a domain, continuous
+coefficient fields and continuous perturbation families should give continuous integrand
+families without unfolding the jet form.
+
+## Main declarations
+
+* `TauCeti.PDE.matrixBilinearFormLinear`, `TauCeti.PDE.driftFormLinear`, and
+  `TauCeti.PDE.massFormLinear`: the coefficient-to-form maps as continuous linear maps.
+* `TauCeti.PDE.energyIntegrandLinear`: the full coefficient triple-to-integrand map as a
+  continuous linear map.
+* `TauCeti.PDE.continuous_matrixBilinearForm`, `TauCeti.PDE.continuous_driftForm`,
+  `TauCeti.PDE.continuous_massForm`, and `TauCeti.PDE.continuous_energyIntegrand`: continuity
+  of the corresponding unbundled maps.
+* `Continuous.energyIntegrand`, `ContinuousOn.energyIntegrand`, and the lower-order analogues:
+  composition lemmas for coefficient fields.
+-/
+
+public section
+
+namespace TauCeti
+
+namespace PDE
+
+open Matrix
+open scoped InnerProductSpace
+
+variable {X n : Type*} [Fintype n] [DecidableEq n]
+
+/-- The principal coefficient matrix-to-bilinear-form map as a continuous linear map. -/
+@[expose]
+noncomputable def matrixBilinearFormLinear :
+    Matrix n n ℝ →L[ℝ] EuclideanSpace ℝ n →L[ℝ] EuclideanSpace ℝ n →L[ℝ] ℝ :=
+  LinearMap.toContinuousLinearMap
+    { toFun := matrixBilinearForm
+      map_add' := by
+        intro A B
+        ext η ξ
+        exact matrixBilinearForm_add_apply A B η ξ
+      map_smul' := by
+        intro r A
+        ext η ξ
+        exact matrixBilinearForm_smul_apply r A η ξ }
+
+/-- Applying `matrixBilinearFormLinear` recovers `matrixBilinearForm`. -/
+@[simp]
+lemma matrixBilinearFormLinear_apply (A : Matrix n n ℝ) :
+    matrixBilinearFormLinear (n := n) A = matrixBilinearForm A :=
+  rfl
+
+/-- The drift coefficient-to-form map as a continuous linear map. -/
+@[expose]
+noncomputable def driftFormLinear :
+    EuclideanSpace ℝ n →L[ℝ] ℝ →L[ℝ] EuclideanSpace ℝ n →L[ℝ] ℝ :=
+  LinearMap.toContinuousLinearMap
+    { toFun := driftForm
+      map_add' := by
+        intro b d
+        apply ContinuousLinearMap.ext
+        intro u
+        apply ContinuousLinearMap.ext
+        intro ξ
+        simp [driftForm_apply, inner_add_left]
+        ring
+      map_smul' := by
+        intro r b
+        apply ContinuousLinearMap.ext
+        intro u
+        apply ContinuousLinearMap.ext
+        intro ξ
+        simp [driftForm_apply, inner_smul_left, smul_eq_mul]
+        ring }
+
+omit [DecidableEq n] in
+/-- Applying `driftFormLinear` recovers `driftForm`. -/
+@[simp]
+lemma driftFormLinear_apply (b : EuclideanSpace ℝ n) :
+    driftFormLinear (n := n) b = driftForm b :=
+  rfl
+
+/-- The mass coefficient-to-form map as a continuous linear map. -/
+@[expose]
+noncomputable def massFormLinear : ℝ →L[ℝ] ℝ →L[ℝ] ℝ →L[ℝ] ℝ :=
+  LinearMap.toContinuousLinearMap
+    { toFun := massForm
+      map_add' := by
+        intro c e
+        apply ContinuousLinearMap.ext
+        intro u
+        apply ContinuousLinearMap.ext
+        intro v
+        simp [massForm_apply]
+        ring
+      map_smul' := by
+        intro r c
+        apply ContinuousLinearMap.ext
+        intro u
+        apply ContinuousLinearMap.ext
+        intro v
+        simp [massForm_apply, smul_eq_mul]
+        ring }
+
+/-- Applying `massFormLinear` recovers `massForm`. -/
+@[simp]
+lemma massFormLinear_apply (c : ℝ) : massFormLinear c = massForm c :=
+  rfl
+
+/-- The coefficient triple-to-energy-integrand map as a continuous linear map. -/
+@[expose]
+noncomputable def energyIntegrandLinear :
+    (Matrix n n ℝ × EuclideanSpace ℝ n × ℝ) →L[ℝ]
+      (ℝ × EuclideanSpace ℝ n) →L[ℝ] (ℝ × EuclideanSpace ℝ n) →L[ℝ] ℝ :=
+  LinearMap.toContinuousLinearMap
+    { toFun := fun p => energyIntegrand p.1 p.2.1 p.2.2
+      map_add' := by
+        rintro ⟨A, b, c⟩ ⟨B, d, e⟩
+        apply ContinuousLinearMap.ext
+        intro U
+        apply ContinuousLinearMap.ext
+        intro V
+        exact energyIntegrand_add_apply A B b d c e U V
+      map_smul' := by
+        rintro r ⟨A, b, c⟩
+        apply ContinuousLinearMap.ext
+        intro U
+        apply ContinuousLinearMap.ext
+        intro V
+        exact energyIntegrand_smul_apply A b c r U V }
+
+/-- Applying `energyIntegrandLinear` recovers `energyIntegrand` for the coefficient triple. -/
+@[simp]
+lemma energyIntegrandLinear_apply (A : Matrix n n ℝ) (b : EuclideanSpace ℝ n) (c : ℝ) :
+    energyIntegrandLinear (n := n) (A, b, c) = energyIntegrand A b c :=
+  rfl
+
+/-- The principal coefficient-to-bilinear-form map is continuous. -/
+lemma continuous_matrixBilinearForm :
+    Continuous (fun A : Matrix n n ℝ => matrixBilinearForm A) :=
+  (matrixBilinearFormLinear (n := n)).continuous
+
+omit [DecidableEq n] in
+/-- The drift coefficient-to-form map is continuous. -/
+lemma continuous_driftForm :
+    Continuous (fun b : EuclideanSpace ℝ n => driftForm b) :=
+  (driftFormLinear (n := n)).continuous.congr fun b => (driftFormLinear_apply b)
+
+/-- The mass coefficient-to-form map is continuous. -/
+lemma continuous_massForm : Continuous (fun c : ℝ => massForm c) :=
+  massFormLinear.continuous.congr fun c => massFormLinear_apply c
+
+/-- The full coefficient triple-to-energy-integrand map is continuous. -/
+lemma continuous_energyIntegrand :
+    Continuous (fun p : Matrix n n ℝ × EuclideanSpace ℝ n × ℝ =>
+      energyIntegrand p.1 p.2.1 p.2.2) :=
+  (energyIntegrandLinear (n := n)).continuous.congr fun p =>
+    energyIntegrandLinear_apply p.1 p.2.1 p.2.2
+
+variable [TopologicalSpace X]
+
+namespace Continuous
+
+/-- A continuous principal coefficient field gives a continuous field of principal bilinear
+forms. -/
+lemma matrixBilinearForm {a : X → Matrix n n ℝ} (ha : Continuous a) :
+    Continuous (fun x => PDE.matrixBilinearForm (a x)) :=
+  continuous_matrixBilinearForm.comp ha
+
+omit [DecidableEq n] in
+/-- A continuous drift coefficient field gives a continuous field of drift forms. -/
+lemma driftForm {b : X → EuclideanSpace ℝ n} (hb : Continuous b) :
+    Continuous (fun x => PDE.driftForm (b x)) :=
+  continuous_driftForm.comp hb
+
+/-- A continuous mass coefficient field gives a continuous field of mass forms. -/
+lemma massForm {c : X → ℝ} (hc : Continuous c) :
+    Continuous (fun x => PDE.massForm (c x)) :=
+  continuous_massForm.comp hc
+
+/-- Continuous coefficient fields give a continuous field of full pointwise energy
+integrands. -/
+lemma energyIntegrand {a : X → Matrix n n ℝ} {b : X → EuclideanSpace ℝ n} {c : X → ℝ}
+    (ha : Continuous a) (hb : Continuous b) (hc : Continuous c) :
+    Continuous (fun x => PDE.energyIntegrand (a x) (b x) (c x)) :=
+  continuous_energyIntegrand.comp (ha.prodMk (hb.prodMk hc))
+
+end Continuous
+
+namespace ContinuousOn
+
+/-- A continuous principal coefficient field on a set gives a continuous field of principal
+bilinear forms on that set. -/
+lemma matrixBilinearForm {s : Set X} {a : X → Matrix n n ℝ} (ha : ContinuousOn a s) :
+    ContinuousOn (fun x => PDE.matrixBilinearForm (a x)) s :=
+  continuous_matrixBilinearForm.comp_continuousOn ha
+
+omit [DecidableEq n] in
+/-- A continuous drift coefficient field on a set gives a continuous field of drift forms on
+that set. -/
+lemma driftForm {s : Set X} {b : X → EuclideanSpace ℝ n} (hb : ContinuousOn b s) :
+    ContinuousOn (fun x => PDE.driftForm (b x)) s :=
+  continuous_driftForm.comp_continuousOn hb
+
+/-- A continuous mass coefficient field on a set gives a continuous field of mass forms on
+that set. -/
+lemma massForm {s : Set X} {c : X → ℝ} (hc : ContinuousOn c s) :
+    ContinuousOn (fun x => PDE.massForm (c x)) s :=
+  continuous_massForm.comp_continuousOn hc
+
+/-- Continuous coefficient fields on a set give a continuous field of full pointwise energy
+integrands on that set. -/
+lemma energyIntegrand {s : Set X} {a : X → Matrix n n ℝ} {b : X → EuclideanSpace ℝ n}
+    {c : X → ℝ} (ha : ContinuousOn a s) (hb : ContinuousOn b s) (hc : ContinuousOn c s) :
+    ContinuousOn (fun x => PDE.energyIntegrand (a x) (b x) (c x)) s :=
+  continuous_energyIntegrand.comp_continuousOn (ha.prodMk (hb.prodMk hc))
+
+end ContinuousOn
+
+end PDE
+
+end TauCeti

--- a/TauCeti/Analysis/PDE/EnergyFormContinuity.lean
+++ b/TauCeti/Analysis/PDE/EnergyFormContinuity.lean
@@ -21,15 +21,11 @@ families without unfolding the jet form.
 
 ## Main declarations
 
-* `TauCeti.PDE.matrixBilinearFormLinear`, `TauCeti.PDE.driftFormLinear`, and
-  `TauCeti.PDE.massFormLinear`: the coefficient-to-form maps as continuous linear maps.
 * `TauCeti.PDE.energyIntegrandLinear`: the full coefficient triple-to-integrand map as a
   continuous linear map.
-* `TauCeti.PDE.continuous_matrixBilinearForm`, `TauCeti.PDE.continuous_driftForm`,
-  `TauCeti.PDE.continuous_massForm`, and `TauCeti.PDE.continuous_energyIntegrand`: continuity
-  of the corresponding unbundled maps.
-* `Continuous.energyIntegrand`, `ContinuousOn.energyIntegrand`, and the lower-order analogues:
-  composition lemmas for coefficient fields.
+* `TauCeti.PDE.continuous_energyIntegrand`: continuity of the unbundled full integrand map.
+* `Continuous.energyIntegrand` and `ContinuousOn.energyIntegrand`: composition lemmas for
+  coefficient fields.
 -/
 
 public section
@@ -43,86 +39,7 @@ open scoped InnerProductSpace
 
 variable {X n : Type*} [Fintype n] [DecidableEq n]
 
-/-- The principal coefficient matrix-to-bilinear-form map as a continuous linear map. -/
-@[expose]
-noncomputable def matrixBilinearFormLinear :
-    Matrix n n ℝ →L[ℝ] EuclideanSpace ℝ n →L[ℝ] EuclideanSpace ℝ n →L[ℝ] ℝ :=
-  LinearMap.toContinuousLinearMap
-    { toFun := matrixBilinearForm
-      map_add' := by
-        intro A B
-        ext η ξ
-        exact matrixBilinearForm_add_apply A B η ξ
-      map_smul' := by
-        intro r A
-        ext η ξ
-        exact matrixBilinearForm_smul_apply r A η ξ }
-
-/-- Applying `matrixBilinearFormLinear` recovers `matrixBilinearForm`. -/
-@[simp]
-lemma matrixBilinearFormLinear_apply (A : Matrix n n ℝ) :
-    matrixBilinearFormLinear (n := n) A = matrixBilinearForm A :=
-  rfl
-
-/-- The drift coefficient-to-form map as a continuous linear map. -/
-@[expose]
-noncomputable def driftFormLinear :
-    EuclideanSpace ℝ n →L[ℝ] ℝ →L[ℝ] EuclideanSpace ℝ n →L[ℝ] ℝ :=
-  LinearMap.toContinuousLinearMap
-    { toFun := driftForm
-      map_add' := by
-        intro b d
-        apply ContinuousLinearMap.ext
-        intro u
-        apply ContinuousLinearMap.ext
-        intro ξ
-        simp [driftForm_apply, inner_add_left]
-        ring
-      map_smul' := by
-        intro r b
-        apply ContinuousLinearMap.ext
-        intro u
-        apply ContinuousLinearMap.ext
-        intro ξ
-        simp [driftForm_apply, inner_smul_left, smul_eq_mul]
-        ring }
-
-omit [DecidableEq n] in
-/-- Applying `driftFormLinear` recovers `driftForm`. -/
-@[simp]
-lemma driftFormLinear_apply (b : EuclideanSpace ℝ n) :
-    driftFormLinear (n := n) b = driftForm b :=
-  rfl
-
-/-- The mass coefficient-to-form map as a continuous linear map. -/
-@[expose]
-noncomputable def massFormLinear : ℝ →L[ℝ] ℝ →L[ℝ] ℝ →L[ℝ] ℝ :=
-  LinearMap.toContinuousLinearMap
-    { toFun := massForm
-      map_add' := by
-        intro c e
-        apply ContinuousLinearMap.ext
-        intro u
-        apply ContinuousLinearMap.ext
-        intro v
-        simp [massForm_apply]
-        ring
-      map_smul' := by
-        intro r c
-        apply ContinuousLinearMap.ext
-        intro u
-        apply ContinuousLinearMap.ext
-        intro v
-        simp [massForm_apply, smul_eq_mul]
-        ring }
-
-/-- Applying `massFormLinear` recovers `massForm`. -/
-@[simp]
-lemma massFormLinear_apply (c : ℝ) : massFormLinear c = massForm c :=
-  rfl
-
 /-- The coefficient triple-to-energy-integrand map as a continuous linear map. -/
-@[expose]
 noncomputable def energyIntegrandLinear :
     (Matrix n n ℝ × EuclideanSpace ℝ n × ℝ) →L[ℝ]
       (ℝ × EuclideanSpace ℝ n) →L[ℝ] (ℝ × EuclideanSpace ℝ n) →L[ℝ] ℝ :=
@@ -147,22 +64,12 @@ noncomputable def energyIntegrandLinear :
 @[simp]
 lemma energyIntegrandLinear_apply (A : Matrix n n ℝ) (b : EuclideanSpace ℝ n) (c : ℝ) :
     energyIntegrandLinear (n := n) (A, b, c) = energyIntegrand A b c :=
-  rfl
-
-/-- The principal coefficient-to-bilinear-form map is continuous. -/
-lemma continuous_matrixBilinearForm :
-    Continuous (fun A : Matrix n n ℝ => matrixBilinearForm A) :=
-  (matrixBilinearFormLinear (n := n)).continuous
-
-omit [DecidableEq n] in
-/-- The drift coefficient-to-form map is continuous. -/
-lemma continuous_driftForm :
-    Continuous (fun b : EuclideanSpace ℝ n => driftForm b) :=
-  (driftFormLinear (n := n)).continuous.congr fun b => (driftFormLinear_apply b)
-
-/-- The mass coefficient-to-form map is continuous. -/
-lemma continuous_massForm : Continuous (fun c : ℝ => massForm c) :=
-  massFormLinear.continuous.congr fun c => massFormLinear_apply c
+  by
+    apply ContinuousLinearMap.ext
+    rintro ⟨u, η⟩
+    apply ContinuousLinearMap.ext
+    rintro ⟨v, ξ⟩
+    simp [energyIntegrandLinear]
 
 /-- The full coefficient triple-to-energy-integrand map is continuous. -/
 lemma continuous_energyIntegrand :
@@ -175,23 +82,6 @@ variable [TopologicalSpace X]
 
 namespace Continuous
 
-/-- A continuous principal coefficient field gives a continuous field of principal bilinear
-forms. -/
-lemma matrixBilinearForm {a : X → Matrix n n ℝ} (ha : Continuous a) :
-    Continuous (fun x => PDE.matrixBilinearForm (a x)) :=
-  continuous_matrixBilinearForm.comp ha
-
-omit [DecidableEq n] in
-/-- A continuous drift coefficient field gives a continuous field of drift forms. -/
-lemma driftForm {b : X → EuclideanSpace ℝ n} (hb : Continuous b) :
-    Continuous (fun x => PDE.driftForm (b x)) :=
-  continuous_driftForm.comp hb
-
-/-- A continuous mass coefficient field gives a continuous field of mass forms. -/
-lemma massForm {c : X → ℝ} (hc : Continuous c) :
-    Continuous (fun x => PDE.massForm (c x)) :=
-  continuous_massForm.comp hc
-
 /-- Continuous coefficient fields give a continuous field of full pointwise energy
 integrands. -/
 lemma energyIntegrand {a : X → Matrix n n ℝ} {b : X → EuclideanSpace ℝ n} {c : X → ℝ}
@@ -202,25 +92,6 @@ lemma energyIntegrand {a : X → Matrix n n ℝ} {b : X → EuclideanSpace ℝ n
 end Continuous
 
 namespace ContinuousOn
-
-/-- A continuous principal coefficient field on a set gives a continuous field of principal
-bilinear forms on that set. -/
-lemma matrixBilinearForm {s : Set X} {a : X → Matrix n n ℝ} (ha : ContinuousOn a s) :
-    ContinuousOn (fun x => PDE.matrixBilinearForm (a x)) s :=
-  continuous_matrixBilinearForm.comp_continuousOn ha
-
-omit [DecidableEq n] in
-/-- A continuous drift coefficient field on a set gives a continuous field of drift forms on
-that set. -/
-lemma driftForm {s : Set X} {b : X → EuclideanSpace ℝ n} (hb : ContinuousOn b s) :
-    ContinuousOn (fun x => PDE.driftForm (b x)) s :=
-  continuous_driftForm.comp_continuousOn hb
-
-/-- A continuous mass coefficient field on a set gives a continuous field of mass forms on
-that set. -/
-lemma massForm {s : Set X} {c : X → ℝ} (hc : ContinuousOn c s) :
-    ContinuousOn (fun x => PDE.massForm (c x)) s :=
-  continuous_massForm.comp_continuousOn hc
 
 /-- Continuous coefficient fields on a set give a continuous field of full pointwise energy
 integrands on that set. -/

--- a/TauCeti/Analysis/PDE/EnergyFormLinearity.lean
+++ b/TauCeti/Analysis/PDE/EnergyFormLinearity.lean
@@ -38,7 +38,7 @@ namespace PDE
 
 open Matrix
 
-variable {n : Type*} [Fintype n] [DecidableEq n]
+variable {n : Type*} [Fintype n]
 
 variable (A B : Matrix n n ℝ) (b d : EuclideanSpace ℝ n) (c e m r : ℝ)
 variable (U V : ℝ × EuclideanSpace ℝ n)
@@ -157,6 +157,8 @@ lemma energyIntegrand_principal_drift_mass_apply :
         energyIntegrand 0 0 c U V := by
   rw [energyIntegrand_principal_drift_mass]
   rfl
+
+variable [DecidableEq n]
 
 /-- The full energy integrand is the sum of a shifted Laplacian model with chosen base mass
 and the residual perturbation of the coefficient triple. -/

--- a/TauCeti/Analysis/PDE/LowerOrder.lean
+++ b/TauCeti/Analysis/PDE/LowerOrder.lean
@@ -27,6 +27,8 @@ in that shape.
 ## Main declarations
 
 * `TauCeti.PDE.driftForm`, `TauCeti.PDE.massForm`: the pointwise lower-order forms.
+* `TauCeti.PDE.driftFormLinear`, `TauCeti.PDE.massFormLinear`: coefficient-to-form maps as
+  continuous linear maps.
 * `TauCeti.PDE.norm_driftForm_apply_le` and `TauCeti.PDE.opNorm_driftForm_le`.
 * `TauCeti.PDE.norm_massForm_apply_le` and `TauCeti.PDE.opNorm_massForm_le`.
 * Bound-by-a-constant and radius-restricted variants for both forms.
@@ -65,6 +67,83 @@ lemma massForm_apply (c u v : ℝ) :
   rw [massForm, smul_apply, smul_apply,
     ContinuousLinearMap.mul_apply', smul_eq_mul]
   ring
+
+/-! ## Continuity in lower-order coefficients -/
+
+/-- The drift coefficient-to-form map as a continuous linear map. -/
+noncomputable def driftFormLinear :
+    EuclideanSpace ℝ n →L[ℝ] ℝ →L[ℝ] EuclideanSpace ℝ n →L[ℝ] ℝ :=
+  (ContinuousLinearMap.smulRightL ℝ (EuclideanSpace ℝ n) ℝ).comp (innerSL ℝ)
+
+/-- Applying `driftFormLinear` recovers `driftForm`. -/
+@[simp]
+lemma driftFormLinear_apply (b : EuclideanSpace ℝ n) :
+    driftFormLinear (n := n) b = driftForm b :=
+  by
+    apply ContinuousLinearMap.ext
+    intro u
+    apply ContinuousLinearMap.ext
+    intro ξ
+    simp [driftFormLinear, driftForm]
+
+/-- The mass coefficient-to-form map as a continuous linear map. -/
+noncomputable def massFormLinear : ℝ →L[ℝ] ℝ →L[ℝ] ℝ →L[ℝ] ℝ :=
+  ContinuousLinearMap.toSpanSingleton ℝ (ContinuousLinearMap.mul ℝ ℝ)
+
+/-- Applying `massFormLinear` recovers `massForm`. -/
+@[simp]
+lemma massFormLinear_apply (c : ℝ) : massFormLinear c = massForm c :=
+  by
+    apply ContinuousLinearMap.ext
+    intro u
+    apply ContinuousLinearMap.ext
+    intro v
+    simp [massFormLinear, massForm]
+
+/-- The drift coefficient-to-form map is continuous. -/
+lemma continuous_driftForm :
+    Continuous (fun b : EuclideanSpace ℝ n => driftForm b) :=
+  (driftFormLinear (n := n)).continuous.congr fun b => (driftFormLinear_apply b)
+
+/-- The mass coefficient-to-form map is continuous. -/
+lemma continuous_massForm : Continuous (fun c : ℝ => massForm c) :=
+  massFormLinear.continuous.congr fun c => massFormLinear_apply c
+
+section Continuity
+
+variable {X : Type*} [TopologicalSpace X]
+
+namespace Continuous
+
+/-- A continuous drift coefficient field gives a continuous field of drift forms. -/
+lemma driftForm {b : X → EuclideanSpace ℝ n} (hb : Continuous b) :
+    Continuous (fun x => PDE.driftForm (b x)) :=
+  continuous_driftForm.comp hb
+
+/-- A continuous mass coefficient field gives a continuous field of mass forms. -/
+lemma massForm {c : X → ℝ} (hc : Continuous c) :
+    Continuous (fun x => PDE.massForm (c x)) :=
+  continuous_massForm.comp hc
+
+end Continuous
+
+namespace ContinuousOn
+
+/-- A continuous drift coefficient field on a set gives a continuous field of drift forms on
+that set. -/
+lemma driftForm {s : Set X} {b : X → EuclideanSpace ℝ n} (hb : ContinuousOn b s) :
+    ContinuousOn (fun x => PDE.driftForm (b x)) s :=
+  continuous_driftForm.comp_continuousOn hb
+
+/-- A continuous mass coefficient field on a set gives a continuous field of mass forms on
+that set. -/
+lemma massForm {s : Set X} {c : X → ℝ} (hc : ContinuousOn c s) :
+    ContinuousOn (fun x => PDE.massForm (c x)) s :=
+  continuous_massForm.comp_continuousOn hc
+
+end ContinuousOn
+
+end Continuity
 
 /-! ## Drift form bounds -/
 

--- a/TauCeti/Analysis/PDE/LowerOrder.lean
+++ b/TauCeti/Analysis/PDE/LowerOrder.lean
@@ -27,8 +27,7 @@ in that shape.
 ## Main declarations
 
 * `TauCeti.PDE.driftForm`, `TauCeti.PDE.massForm`: the pointwise lower-order forms.
-* `TauCeti.PDE.driftFormLinear`, `TauCeti.PDE.massFormLinear`: coefficient-to-form maps as
-  continuous linear maps.
+* `TauCeti.PDE.driftFormLinear`: the drift coefficient-to-form map as a continuous linear map.
 * `TauCeti.PDE.norm_driftForm_apply_le` and `TauCeti.PDE.opNorm_driftForm_le`.
 * `TauCeti.PDE.norm_massForm_apply_le` and `TauCeti.PDE.opNorm_massForm_le`.
 * Bound-by-a-constant and radius-restricted variants for both forms.
@@ -86,20 +85,6 @@ lemma driftFormLinear_apply (b : EuclideanSpace ℝ n) :
     intro ξ
     simp [driftFormLinear, driftForm]
 
-/-- The mass coefficient-to-form map as a continuous linear map. -/
-noncomputable def massFormLinear : ℝ →L[ℝ] ℝ →L[ℝ] ℝ →L[ℝ] ℝ :=
-  ContinuousLinearMap.toSpanSingleton ℝ (ContinuousLinearMap.mul ℝ ℝ)
-
-/-- Applying `massFormLinear` recovers `massForm`. -/
-@[simp]
-lemma massFormLinear_apply (c : ℝ) : massFormLinear c = massForm c :=
-  by
-    apply ContinuousLinearMap.ext
-    intro u
-    apply ContinuousLinearMap.ext
-    intro v
-    simp [massFormLinear, massForm]
-
 /-- The drift coefficient-to-form map is continuous. -/
 lemma continuous_driftForm :
     Continuous (fun b : EuclideanSpace ℝ n => driftForm b) :=
@@ -107,7 +92,13 @@ lemma continuous_driftForm :
 
 /-- The mass coefficient-to-form map is continuous. -/
 lemma continuous_massForm : Continuous (fun c : ℝ => massForm c) :=
-  massFormLinear.continuous.congr fun c => massFormLinear_apply c
+  (ContinuousLinearMap.toSpanSingleton ℝ (ContinuousLinearMap.mul ℝ ℝ)).continuous.congr fun c =>
+    by
+      apply ContinuousLinearMap.ext
+      intro u
+      apply ContinuousLinearMap.ext
+      intro v
+      simp [massForm]
 
 section Continuity
 

--- a/TauCeti/Analysis/PDE/LowerOrder.lean
+++ b/TauCeti/Analysis/PDE/LowerOrder.lean
@@ -28,6 +28,7 @@ in that shape.
 
 * `TauCeti.PDE.driftForm`, `TauCeti.PDE.massForm`: the pointwise lower-order forms.
 * `TauCeti.PDE.driftFormLinear`: the drift coefficient-to-form map as a continuous linear map.
+* `TauCeti.PDE.massFormLinear`: the mass coefficient-to-form map as a continuous linear map.
 * `TauCeti.PDE.norm_driftForm_apply_le` and `TauCeti.PDE.opNorm_driftForm_le`.
 * `TauCeti.PDE.norm_massForm_apply_le` and `TauCeti.PDE.opNorm_massForm_le`.
 * Bound-by-a-constant and radius-restricted variants for both forms.
@@ -90,15 +91,24 @@ lemma continuous_driftForm :
     Continuous (fun b : EuclideanSpace ℝ n => driftForm b) :=
   (driftFormLinear (n := n)).continuous.congr fun b => (driftFormLinear_apply b)
 
+/-- The mass coefficient-to-form map as a continuous linear map. -/
+noncomputable def massFormLinear : ℝ →L[ℝ] ℝ →L[ℝ] ℝ →L[ℝ] ℝ :=
+  ContinuousLinearMap.toSpanSingleton ℝ (ContinuousLinearMap.mul ℝ ℝ)
+
+/-- Applying `massFormLinear` recovers `massForm`. -/
+@[simp]
+lemma massFormLinear_apply (c : ℝ) :
+    massFormLinear c = massForm c :=
+  by
+    apply ContinuousLinearMap.ext
+    intro u
+    apply ContinuousLinearMap.ext
+    intro v
+    simp [massFormLinear, massForm]
+
 /-- The mass coefficient-to-form map is continuous. -/
 lemma continuous_massForm : Continuous (fun c : ℝ => massForm c) :=
-  (ContinuousLinearMap.toSpanSingleton ℝ (ContinuousLinearMap.mul ℝ ℝ)).continuous.congr fun c =>
-    by
-      apply ContinuousLinearMap.ext
-      intro u
-      apply ContinuousLinearMap.ext
-      intro v
-      simp [massForm]
+  massFormLinear.continuous.congr fun c => massFormLinear_apply c
 
 section Continuity
 

--- a/TauCeti/Analysis/PDE/SymmetricEnergy.lean
+++ b/TauCeti/Analysis/PDE/SymmetricEnergy.lean
@@ -46,6 +46,7 @@ open Matrix
 
 variable {X n : Type*} [Fintype n] [DecidableEq n]
 
+omit [DecidableEq n] in
 /-- With zero drift, transposing the principal coefficient swaps the two jet arguments. -/
 lemma energyIntegrand_zero_drift_transpose_apply (A : Matrix n n ℝ) (c : ℝ)
     (U V : ℝ × EuclideanSpace ℝ n) :
@@ -53,6 +54,7 @@ lemma energyIntegrand_zero_drift_transpose_apply (A : Matrix n n ℝ) (c : ℝ)
   rw [energyIntegrand_apply, energyIntegrand_apply, matrixBilinearForm_transpose_apply]
   simp [driftForm_apply, massForm_apply, mul_comm, mul_left_comm]
 
+omit [DecidableEq n] in
 /-- A symmetric principal coefficient gives a symmetric zero-drift jet form. -/
 lemma energyIntegrand_zero_drift_comm_of_isSymm {A : Matrix n n ℝ} (hA : A.IsSymm)
     (c : ℝ) (U V : ℝ × EuclideanSpace ℝ n) :
@@ -61,6 +63,7 @@ lemma energyIntegrand_zero_drift_comm_of_isSymm {A : Matrix n n ℝ} (hA : A.IsS
     energyIntegrand A 0 c U V = energyIntegrand Aᵀ 0 c U V := by rw [hA.eq]
     _ = energyIntegrand A 0 c V U := energyIntegrand_zero_drift_transpose_apply A c U V
 
+omit [DecidableEq n] in
 /-- Bundled-map form of symmetry for the zero-drift jet integrand.
 
 Downstream energy forms that need the same integrand to be both symmetric and coercive pair
@@ -84,6 +87,7 @@ lemma energyIntegrand_one_zero_drift_comm (c : ℝ) (U V : ℝ × EuclideanSpace
       energyIntegrand (1 : Matrix n n ℝ) 0 c V U :=
   energyIntegrand_zero_drift_comm_of_isSymm isSymm_one c U V
 
+omit [DecidableEq n] in
 /-- The symmetric part's zero-drift jet form is the average of the original form and its
 transpose. -/
 lemma energyIntegrand_coefficientSymmetricPart_zero_drift_apply (A : Matrix n n ℝ)
@@ -95,14 +99,17 @@ lemma energyIntegrand_coefficientSymmetricPart_zero_drift_apply (A : Matrix n n 
   simp [driftForm_apply, massForm_apply, mul_comm, mul_left_comm]
   ring
 
+omit [DecidableEq n] in
 /-- Replacing the principal coefficient by its symmetric part does not change the diagonal
 energy density. -/
 lemma energyIntegrand_coefficientSymmetricPart_self (A : Matrix n n ℝ)
     (b : EuclideanSpace ℝ n) (c : ℝ) (U : ℝ × EuclideanSpace ℝ n) :
     energyIntegrand (coefficientSymmetricPart A) b c U U =
       energyIntegrand A b c U U := by
+  classical
   rw [energyIntegrand_self, energyIntegrand_self, toQuadraticForm'_coefficientSymmetricPart]
 
+omit [DecidableEq n] in
 /-- The symmetric part always gives a symmetric zero-drift jet form. -/
 lemma energyIntegrand_coefficientSymmetricPart_zero_drift_comm (A : Matrix n n ℝ)
     (c : ℝ) (U V : ℝ × EuclideanSpace ℝ n) :
@@ -110,6 +117,7 @@ lemma energyIntegrand_coefficientSymmetricPart_zero_drift_comm (A : Matrix n n �
       energyIntegrand (coefficientSymmetricPart A) 0 c V U :=
   energyIntegrand_zero_drift_comm_of_isSymm (coefficientSymmetricPart_isSymm A) c U V
 
+omit [DecidableEq n] in
 /-- Bundled-map form of symmetry for the symmetric-part zero-drift jet integrand. -/
 @[simp]
 lemma energyIntegrand_coefficientSymmetricPart_zero_drift_flip_eq (A : Matrix n n ℝ)
@@ -118,6 +126,7 @@ lemma energyIntegrand_coefficientSymmetricPart_zero_drift_flip_eq (A : Matrix n 
       energyIntegrand (coefficientSymmetricPart A) 0 c :=
   energyIntegrand_zero_drift_flip_eq_of_isSymm (coefficientSymmetricPart_isSymm A) c
 
+omit [DecidableEq n] in
 /-- A pointwise symmetric coefficient field gives symmetric zero-drift jet forms at every
 point of the domain. -/
 lemma energyIntegrand_zero_drift_comm_on {Ω : Set X} {a : X → Matrix n n ℝ}
@@ -126,6 +135,7 @@ lemma energyIntegrand_zero_drift_comm_on {Ω : Set X} {a : X → Matrix n n ℝ}
     energyIntegrand (a x) 0 (c x) U V = energyIntegrand (a x) 0 (c x) V U :=
   energyIntegrand_zero_drift_comm_of_isSymm (ha hx) (c x) U V
 
+omit [DecidableEq n] in
 /-- A pointwise symmetric coefficient field gives a bundled symmetric zero-drift jet form at
 each point of the domain. -/
 lemma energyIntegrand_zero_drift_flip_eq_on {Ω : Set X} {a : X → Matrix n n ℝ}

--- a/TauCeti/Analysis/PDE/UniformEllipticity.lean
+++ b/TauCeti/Analysis/PDE/UniformEllipticity.lean
@@ -105,15 +105,30 @@ Mathlib's bounded-bilinear-form and Lax--Milgram APIs once the corresponding Sob
 are available. -/
 noncomputable def matrixBilinearForm (A : Matrix n n ℝ) :
     EuclideanSpace ℝ n →L[ℝ] EuclideanSpace ℝ n →L[ℝ] ℝ :=
-  (A.toBilin'.comp (EuclideanSpace.equiv n ℝ).toLinearMap
-    (EuclideanSpace.equiv n ℝ).toLinearMap).toContinuousBilinearMap
+  LinearMap.toContinuousBilinearMap
+    { toFun := fun η =>
+        { toFun := fun ξ => ∑ i, η i * ∑ j, A i j * ξ j
+          map_add' := by
+            intro ξ ζ
+            simp [mul_add, Finset.sum_add_distrib]
+          map_smul' := by
+            intro r ξ
+            simp [mul_left_comm, Finset.mul_sum] }
+      map_add' := by
+        intro η θ
+        ext ξ
+        simp [add_mul, Finset.sum_add_distrib]
+      map_smul' := by
+        intro r η
+        ext ξ
+        simp [mul_assoc, mul_left_comm, Finset.mul_sum] }
 
+omit [DecidableEq n] in
 /-- The matrix bilinear form is the dot-product expression `ηᵀ A ξ`. -/
 @[simp]
 lemma matrixBilinearForm_apply (A : Matrix n n ℝ) (η ξ : EuclideanSpace ℝ n) :
     matrixBilinearForm A η ξ = η ⬝ᵥ (A *ᵥ ξ) := by
-  rw [matrixBilinearForm, LinearMap.toContinuousBilinearMap_apply,
-    LinearMap.BilinForm.comp_apply, Matrix.toBilin'_apply']
+  rw [matrixBilinearForm, LinearMap.toContinuousBilinearMap_apply]
   rfl
 
 /-- The matrix bilinear form associated to the identity matrix is the Euclidean dot product. -/
@@ -141,6 +156,7 @@ lemma toQuadraticForm'_add (A B : Matrix n n ℝ) (ξ : EuclideanSpace ℝ n) :
   rw [toQuadraticForm'_eq_dotProduct, toQuadraticForm'_eq_dotProduct,
     toQuadraticForm'_eq_dotProduct, add_mulVec, dotProduct_add]
 
+omit [DecidableEq n] in
 /-- Matrix bilinear forms are linear in scalar multiplication of the coefficient matrix. -/
 lemma matrixBilinearForm_smul_apply (c : ℝ) (A : Matrix n n ℝ)
     (η ξ : EuclideanSpace ℝ n) :
@@ -148,6 +164,7 @@ lemma matrixBilinearForm_smul_apply (c : ℝ) (A : Matrix n n ℝ)
   rw [matrixBilinearForm_apply, matrixBilinearForm_apply, smul_mulVec, dotProduct_smul]
   simp [smul_eq_mul]
 
+omit [DecidableEq n] in
 /-- Matrix bilinear forms are additive in the coefficient matrix. -/
 lemma matrixBilinearForm_add_apply (A B : Matrix n n ℝ) (η ξ : EuclideanSpace ℝ n) :
     matrixBilinearForm (A + B) η ξ = matrixBilinearForm A η ξ + matrixBilinearForm B η ξ := by
@@ -161,6 +178,7 @@ lemma toQuadraticForm'_transpose (A : Matrix n n ℝ) (ξ : EuclideanSpace ℝ n
   rw [toQuadraticForm'_eq_dotProduct, toQuadraticForm'_eq_dotProduct,
     Matrix.dotProduct_transpose_mulVec]
 
+omit [DecidableEq n] in
 /-- Transposing the coefficient matrix swaps the arguments of the bundled matrix bilinear
 form. -/
 lemma matrixBilinearForm_transpose_apply (A : Matrix n n ℝ) (η ξ : EuclideanSpace ℝ n) :
@@ -177,34 +195,37 @@ lemma matrixBilinearForm_self (A : Matrix n n ℝ) (ξ : EuclideanSpace ℝ n) :
     matrixBilinearForm A ξ ξ = A.toQuadraticForm' ξ := by
   rw [matrixBilinearForm_apply, toQuadraticForm'_eq_dotProduct]
 
+omit [DecidableEq n] in
 /-- The principal coefficient matrix-to-bilinear-form map as a continuous linear map. -/
 noncomputable def matrixBilinearFormLinear :
     Matrix n n ℝ →L[ℝ] EuclideanSpace ℝ n →L[ℝ] EuclideanSpace ℝ n →L[ℝ] ℝ :=
   LinearMap.toContinuousLinearMap
     { toFun := fun A =>
-        ((Matrix.toBilin' A).compl₁₂ (EuclideanSpace.equiv n ℝ).toLinearMap
-          (EuclideanSpace.equiv n ℝ).toLinearMap).toContinuousBilinearMap
+        matrixBilinearForm A
       map_add' := by
         intro A B
         ext η ξ
-        simp
+        exact matrixBilinearForm_add_apply A B η ξ
       map_smul' := by
         intro r A
         ext η ξ
-        simp }
+        exact matrixBilinearForm_smul_apply r A η ξ }
 
+omit [DecidableEq n] in
 /-- Applying `matrixBilinearFormLinear` recovers `matrixBilinearForm`. -/
 @[simp]
 lemma matrixBilinearFormLinear_apply (A : Matrix n n ℝ) :
     matrixBilinearFormLinear (n := n) A = matrixBilinearForm A :=
   by
     ext η ξ
-    simp [matrixBilinearFormLinear, matrixBilinearForm, Matrix.toBilin'_apply']
+    simp [matrixBilinearFormLinear]
 
+omit [DecidableEq n] in
 /-- The principal coefficient-to-bilinear-form map is continuous. -/
 lemma continuous_matrixBilinearForm :
     Continuous (fun A : Matrix n n ℝ => matrixBilinearForm A) :=
-  (matrixBilinearFormLinear (n := n)).continuous
+  (matrixBilinearFormLinear (n := n)).continuous.congr fun A =>
+    matrixBilinearFormLinear_apply A
 
 section Continuity
 
@@ -212,6 +233,7 @@ variable [TopologicalSpace X]
 
 namespace Continuous
 
+omit [DecidableEq n] in
 /-- A continuous principal coefficient field gives a continuous field of principal bilinear
 forms. -/
 lemma matrixBilinearForm {a : X → Matrix n n ℝ} (ha : Continuous a) :
@@ -222,6 +244,7 @@ end Continuous
 
 namespace ContinuousOn
 
+omit [DecidableEq n] in
 /-- A continuous principal coefficient field on a set gives a continuous field of principal
 bilinear forms on that set. -/
 lemma matrixBilinearForm {s : Set X} {a : X → Matrix n n ℝ} (ha : ContinuousOn a s) :
@@ -263,6 +286,7 @@ lemma toQuadraticForm'_coefficientSymmetricPart (A : Matrix n n ℝ)
     toQuadraticForm'_transpose]
   ring
 
+omit [DecidableEq n] in
 /-- The bundled bilinear form of the symmetric part is the average of the original bilinear
 form and its transpose. -/
 lemma matrixBilinearForm_coefficientSymmetricPart_apply (A : Matrix n n ℝ)
@@ -273,6 +297,7 @@ lemma matrixBilinearForm_coefficientSymmetricPart_apply (A : Matrix n n ℝ)
     matrixBilinearForm_transpose_apply]
   ring
 
+omit [DecidableEq n] in
 /-- A pointwise bilinear upper bound gives the corresponding norm estimate for the bundled
 continuous bilinear form. -/
 lemma norm_matrixBilinearForm_le_of_upper_bound (A : Matrix n n ℝ) {Lam : ℝ}
@@ -281,6 +306,7 @@ lemma norm_matrixBilinearForm_le_of_upper_bound (A : Matrix n n ℝ) {Lam : ℝ}
     ‖matrixBilinearForm A η ξ‖ ≤ Lam * ‖η‖ * ‖ξ‖ := by
   simpa [Real.norm_eq_abs] using hA η ξ
 
+omit [DecidableEq n] in
 /-- A pointwise bilinear upper bound controls the operator norm of the bundled matrix
 bilinear form.
 
@@ -294,6 +320,7 @@ lemma matrixBilinearForm_opNorm_le_of_upper_bound (A : Matrix n n ℝ) {Lam : �
   intro η ξ
   exact norm_matrixBilinearForm_le_of_upper_bound A hA η ξ
 
+omit [DecidableEq n] in
 /-- A pointwise bilinear upper bound gives a radius-restricted estimate for the bundled
 matrix bilinear form. -/
 lemma matrixBilinearForm_apply_norm_le_of_upper_bound {A : Matrix n n ℝ} {Lam R S : ℝ}

--- a/TauCeti/Analysis/PDE/UniformEllipticity.lean
+++ b/TauCeti/Analysis/PDE/UniformEllipticity.lean
@@ -46,6 +46,8 @@ and Lax--Milgram arguments: constants are parameters, not hidden existential dat
 * `TauCeti.PDE.UniformlyEllipticOn.biUnion`: patch over a union indexed by points of a set.
 * `TauCeti.PDE.matrixBilinearForm`: the bounded bilinear form `η, ξ ↦ ηᵀ A ξ` attached to
   a coefficient matrix.
+* `TauCeti.PDE.matrixBilinearFormLinear`: the coefficient matrix-to-bilinear-form map as a
+  continuous linear map.
 * `TauCeti.PDE.matrixBilinearForm_opNorm_le_of_upper_bound`: a pointwise bilinear upper
   bound controls the operator norm of the attached matrix bilinear form.
 * `TauCeti.PDE.UniformlyEllipticOn.isCoercive_matrixBilinearForm`: pointwise coercivity of
@@ -174,6 +176,61 @@ lemma matrixBilinearForm_smul_one_apply (c : ℝ) (η ξ : EuclideanSpace ℝ n)
 lemma matrixBilinearForm_self (A : Matrix n n ℝ) (ξ : EuclideanSpace ℝ n) :
     matrixBilinearForm A ξ ξ = A.toQuadraticForm' ξ := by
   rw [matrixBilinearForm_apply, toQuadraticForm'_eq_dotProduct]
+
+/-- The principal coefficient matrix-to-bilinear-form map as a continuous linear map. -/
+noncomputable def matrixBilinearFormLinear :
+    Matrix n n ℝ →L[ℝ] EuclideanSpace ℝ n →L[ℝ] EuclideanSpace ℝ n →L[ℝ] ℝ :=
+  LinearMap.toContinuousLinearMap
+    { toFun := fun A =>
+        ((Matrix.toBilin' A).compl₁₂ (EuclideanSpace.equiv n ℝ).toLinearMap
+          (EuclideanSpace.equiv n ℝ).toLinearMap).toContinuousBilinearMap
+      map_add' := by
+        intro A B
+        ext η ξ
+        simp
+      map_smul' := by
+        intro r A
+        ext η ξ
+        simp }
+
+/-- Applying `matrixBilinearFormLinear` recovers `matrixBilinearForm`. -/
+@[simp]
+lemma matrixBilinearFormLinear_apply (A : Matrix n n ℝ) :
+    matrixBilinearFormLinear (n := n) A = matrixBilinearForm A :=
+  by
+    ext η ξ
+    simp [matrixBilinearFormLinear, matrixBilinearForm, Matrix.toBilin'_apply']
+
+/-- The principal coefficient-to-bilinear-form map is continuous. -/
+lemma continuous_matrixBilinearForm :
+    Continuous (fun A : Matrix n n ℝ => matrixBilinearForm A) :=
+  (matrixBilinearFormLinear (n := n)).continuous
+
+section Continuity
+
+variable [TopologicalSpace X]
+
+namespace Continuous
+
+/-- A continuous principal coefficient field gives a continuous field of principal bilinear
+forms. -/
+lemma matrixBilinearForm {a : X → Matrix n n ℝ} (ha : Continuous a) :
+    Continuous (fun x => PDE.matrixBilinearForm (a x)) :=
+  continuous_matrixBilinearForm.comp ha
+
+end Continuous
+
+namespace ContinuousOn
+
+/-- A continuous principal coefficient field on a set gives a continuous field of principal
+bilinear forms on that set. -/
+lemma matrixBilinearForm {s : Set X} {a : X → Matrix n n ℝ} (ha : ContinuousOn a s) :
+    ContinuousOn (fun x => PDE.matrixBilinearForm (a x)) s :=
+  continuous_matrixBilinearForm.comp_continuousOn ha
+
+end ContinuousOn
+
+end Continuity
 
 /-- The symmetric part `(A + Aᵀ) / 2` of a coefficient matrix.
 

--- a/TauCeti/Analysis/PDE/UniformEllipticity.lean
+++ b/TauCeti/Analysis/PDE/UniformEllipticity.lean
@@ -106,30 +106,17 @@ are available. -/
 noncomputable def matrixBilinearForm (A : Matrix n n ℝ) :
     EuclideanSpace ℝ n →L[ℝ] EuclideanSpace ℝ n →L[ℝ] ℝ :=
   LinearMap.toContinuousBilinearMap
-    { toFun := fun η =>
-        { toFun := fun ξ => ∑ i, η i * ∑ j, A i j * ξ j
-          map_add' := by
-            intro ξ ζ
-            simp [mul_add, Finset.sum_add_distrib]
-          map_smul' := by
-            intro r ξ
-            simp [mul_left_comm, Finset.mul_sum] }
-      map_add' := by
-        intro η θ
-        ext ξ
-        simp [add_mul, Finset.sum_add_distrib]
-      map_smul' := by
-        intro r η
-        ext ξ
-        simp [mul_assoc, mul_left_comm, Finset.mul_sum] }
+    ((Matrix.toBilin'Aux A).comp (EuclideanSpace.equiv n ℝ).toLinearEquiv.toLinearMap
+      (EuclideanSpace.equiv n ℝ).toLinearEquiv.toLinearMap)
 
 omit [DecidableEq n] in
 /-- The matrix bilinear form is the dot-product expression `ηᵀ A ξ`. -/
 @[simp]
 lemma matrixBilinearForm_apply (A : Matrix n n ℝ) (η ξ : EuclideanSpace ℝ n) :
     matrixBilinearForm A η ξ = η ⬝ᵥ (A *ᵥ ξ) := by
-  rw [matrixBilinearForm, LinearMap.toContinuousBilinearMap_apply]
-  rfl
+  rw [matrixBilinearForm, LinearMap.toContinuousBilinearMap_apply, LinearMap.BilinForm.comp_apply]
+  simp [Matrix.toBilin'Aux, Matrix.toLinearMap₂'Aux, Matrix.mulVec, dotProduct, Finset.mul_sum,
+    mul_left_comm, mul_comm]
 
 /-- The matrix bilinear form associated to the identity matrix is the Euclidean dot product. -/
 lemma matrixBilinearForm_one_apply (η ξ : EuclideanSpace ℝ n) :


### PR DESCRIPTION
This PR package coefficient-linearity of the pointwise divergence-form weak integrand as continuous linear maps: the principal matrix form, drift form, mass form, and full `energyIntegrand` now have bundled coefficient-to-form maps, together with unbundled continuity and `Continuous`/`ContinuousOn` composition lemmas for coefficient fields. It advances `TauCetiRoadmap/PDE/README.md`, Lane D item 16, “Weak formulation,” as the coefficient-regularity prerequisite for forming later integrated weak energy forms from `x ↦ energyIntegrand (a x) (b x) (c x)` without unfolding the jet integrand.

I chose this as the lowest-hanging distinct PDE target after checking open and recently merged PRs: open PDE work covers symmetric/coercive zero-drift energy integrands, and recent merged PDE work covers harmonic ball normalization and local Laplacian extrema, while the existing pointwise energy layer had boundedness, Gårding, coercivity, symmetry, and coefficient algebra but not continuity of the coefficient-to-integrand maps.

No Mathlib infrastructure is vendored. The implementation reuses Tau Ceti’s existing `matrixBilinearForm`, `driftForm`, `massForm`, `energyIntegrand`, and `energyIntegrand_*` coefficient-linearity lemmas, together with Mathlib’s `LinearMap.toContinuousLinearMap` for finite-dimensional coefficient spaces.

`lake exe cache get` completed with `No files to download` and `Already decompressed 8609 file(s)`. `lake build` completed with `Build completed successfully (4506 jobs).` `lake exe axioms` completed with `axioms: audited 7762 TauCeti declaration(s); all within the allowlist [propext, Classical.choice, Quot.sound].`

<!--tauceti-target:v1 {"focus":"PDE","id":"energy-integrand-coefficient-continuity"}-->

🤖 Prepared with Codex
