### PR TITLE
fix: unbreak the sandboxed lint step's shell quoting in pr-build

### DIFF
--- a/.github/workflows/pr-build.yml
+++ b/.github/workflows/pr-build.yml
@@ -382,7 +382,7 @@ jobs:
               lake build
               lake exe axioms
               lake exe module-system
-              # Environment lint (Mathlib's default `#lint` set minus docBlame, plus
+              # Environment lint (the Mathlib default `#lint` set minus docBlame, plus
               # a module-system-reliable docstring scan; see the script header)
               # against the grandfathered baseline in scripts/lint-baseline.txt.
               # Script, baseline, and the @[nolint <linter>] allowlist


### PR DESCRIPTION
This PR removes an apostrophe from a comment inside the landrun build step of pr-build.yml so the sandboxed `bash -c` script parses correctly again. The comment reworded in #683 read "Mathlib's default", and that apostrophe closed the single-quoted `-c` string early, dropping `bash scripts/lint-env.sh` out of the sandboxed script. The mangled parse then ran the lint invocation in the wrong context and exited 127 with "scripts/lint-env.sh: No such file or directory", reddening every PR build since #683 merged and wedging the merge queue. The lint script itself is present and correct; only the quoting was broken.

🤖 Prepared with Claude Code