### PR TITLE
refactor: move the sandboxed build body into a trusted scripts/sandbox-build.sh

### DIFF
--- a/.github/workflows/pr-build.yml
+++ b/.github/workflows/pr-build.yml
@@ -371,29 +371,17 @@ jobs:
           LAKE_NO_CACHE: "true"
         run: |
           export PATH="$HOME/.local/bin:$HOME/.elan/bin:$PATH"
+          # The sandboxed build/audit/lint body lives in the TRUSTED base script
+          # scripts/sandbox-build.sh (scripts/ routes to a human, so a PR cannot edit it
+          # here). Keeping the landrun `bash -c` payload a fixed, comment-free one-liner
+          # is deliberate: a comment's apostrophe once closed this single-quoted string
+          # early and reddened every PR build (#694). All prose now lives in the script.
           landrun --rox /usr --rox /etc \
             --rw /dev/null --rox /dev/zero --rox /dev/urandom --rox /dev/random \
             --rox "$HOME/.elan" --rox "$PWD/base" --rw "$PWD/base/.lake" \
             --env PATH --env HOME --env CI \
             --env LAKE_NO_CACHE --env LAKE_ARTIFACT_CACHE --env LAKE_RESTORE_ARTIFACTS --env LAKE_CACHE_DIR \
-            -- bash -euxo pipefail -c '
-              cd base
-              export TMPDIR="$PWD/.lake/tmp"
-              lake build
-              lake exe axioms
-              lake exe module-system
-              # Environment lint (the Mathlib default `#lint` set minus docBlame, plus
-              # a module-system-reliable docstring scan; see the script header)
-              # against the grandfathered baseline in scripts/lint-baseline.txt.
-              # Script, baseline, and the @[nolint <linter>] allowlist
-              # (scripts/lint-nolints-allowlist.txt) are the TRUSTED base copies
-              # (scripts/ routes to a human, so a PR cannot edit them here); it
-              # elaborates the PR code, which is why it runs inside this landrun
-              # sandbox, and its report parsing is fail-closed (see the SECURITY
-              # MODEL in the script). Fails on new violations or unaccounted nolints;
-              # fixed baseline entries are printed as a ratchet reminder only.
-              bash scripts/lint-env.sh
-            '
+            -- bash -euxo pipefail -c 'cd base && exec bash scripts/sandbox-build.sh'
 
       - name: Report build and bump-guard statuses to the PR head commit
         if: always()

--- a/scripts/sandbox-build.sh
+++ b/scripts/sandbox-build.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+# sandbox-build.sh — the offline, landrun-sandboxed build + audits + environment lint of
+# the overlaid TauCeti/ sources, factored out of .github/workflows/pr-build.yml.
+#
+# pr-build.yml invokes this inside landrun with a fixed, comment-free one-liner
+# (`cd base && exec bash scripts/sandbox-build.sh`), so the workflow's `bash -c` payload
+# can no longer be broken by an apostrophe or a stray quote in a comment: all the prose
+# and its punctuation live here, in a file the shell reads as a script rather than as a
+# single-quoted `-c` argument. (A comment reading "Mathlib's default" once closed that
+# single-quoted argument early and reddened every PR build; see #694.)
+#
+# This is a TRUSTED base copy. Only the PR's TauCeti/ is overlaid into the sandbox;
+# scripts/ is not, and a PR that edits scripts/ is routed to a human by the scope guard —
+# so this script cannot be swapped out to escape the sandbox, even though it elaborates
+# the PR's (untrusted) TauCeti/ code, which is the whole reason it runs under landrun.
+#
+# cwd on entry is the trusted `base` checkout, with the PR's TauCeti/ already overlaid.
+set -euxo pipefail
+
+export TMPDIR="$PWD/.lake/tmp"
+
+# Build the overlaid TauCeti/ against the trusted base config. landrun keeps this
+# offline and confines writes to base/.lake.
+lake build
+
+# Axiom audit: inspect the built environment and reject any axiom outside
+# {propext, Classical.choice, Quot.sound} — catching sorry, native_decide, and
+# home-rolled axioms, including ones reaching in through imports.
+lake exe axioms
+
+# Module-system audit: every TauCeti/ module must opt into the Lean module system
+# (read from each compiled module's isModule flag, not a textual grep).
+lake exe module-system
+
+# Environment lint: Mathlib's default `#lint` set minus docBlame, plus a
+# module-system-reliable docstring scan, compared against the grandfathered baseline in
+# scripts/lint-baseline.txt. Script, baseline, and the @[nolint <linter>] allowlist
+# (scripts/lint-nolints-allowlist.txt) are trusted base copies, and its report parsing
+# is fail-closed (see the SECURITY MODEL in the script). Fails on new violations or
+# unaccounted nolints; fixed baseline entries print a ratchet reminder only.
+bash scripts/lint-env.sh


### PR DESCRIPTION
This PR moves the landrun-sandboxed build, audit, and environment-lint commands out of pr-build.yml's inline `bash -c` payload into a trusted base script, scripts/sandbox-build.sh, and reduces the payload to a fixed, comment-free one-liner (`cd base && exec bash scripts/sandbox-build.sh`). The inline payload was a single-quoted string with prose comments inside it, so an apostrophe in one comment ("Mathlib's default") closed the string early and reddened every PR build until #694; keeping the prose in a file the shell reads as a script removes that whole class of fragility. The script stays a trusted base copy — only TauCeti/ is overlaid into the sandbox and scripts/ changes route to a human — so the sandbox trust boundary is unchanged.

🤖 Prepared with Claude Code