### PR TITLE
feat: add fixed-degree divisor addition

### DIFF
--- a/TauCeti/AlgebraicGeometry/WeilDivisor/FixedDegree.lean
+++ b/TauCeti/AlgebraicGeometry/WeilDivisor/FixedDegree.lean
@@ -48,6 +48,34 @@ namespace EffectiveDivisorOfDegree
 lemma ext {D E : EffectiveDivisorOfDegree X d} (h : (D : WeilDivisor X) = E) : D = E :=
   Subtype.ext h
 
+/-- The zero effective divisor, regarded as the unique effective divisor of degree `0`. -/
+abbrev zero (X : Type*) : EffectiveDivisorOfDegree X 0 :=
+  ⟨0, isEffective_zero, degree_zero⟩
+
+/-- The underlying Weil divisor of the degree-zero effective divisor is zero. -/
+@[simp]
+lemma coe_zero : (zero X : WeilDivisor X) = 0 :=
+  rfl
+
+/-- Change the degree index of a fixed-degree effective divisor along an equality. -/
+@[expose]
+protected def cast {d e : ℕ} (h : d = e) :
+    EffectiveDivisorOfDegree X d ≃ EffectiveDivisorOfDegree X e where
+  toFun D := ⟨D, D.property.1, D.property.2.trans (by exact_mod_cast h)⟩
+  invFun D := ⟨D, D.property.1, D.property.2.trans (by exact_mod_cast h.symm)⟩
+
+/-- Changing the degree index along `rfl` leaves a fixed-degree divisor unchanged. -/
+@[simp]
+lemma cast_rfl (D : EffectiveDivisorOfDegree X d) :
+    EffectiveDivisorOfDegree.cast rfl D = D :=
+  rfl
+
+/-- Changing the degree index does not change the underlying Weil divisor. -/
+@[simp]
+lemma coe_cast {d e : ℕ} (h : d = e) (D : EffectiveDivisorOfDegree X d) :
+    (EffectiveDivisorOfDegree.cast h D : WeilDivisor X) = D :=
+  rfl
+
 @[simp]
 lemma isEffective (D : EffectiveDivisorOfDegree X d) : IsEffective (D : WeilDivisor X) :=
   D.property.1

--- a/TauCeti/AlgebraicGeometry/WeilDivisor/FixedDegree.lean
+++ b/TauCeti/AlgebraicGeometry/WeilDivisor/FixedDegree.lean
@@ -58,7 +58,6 @@ lemma coe_zero : (zero X : WeilDivisor X) = 0 :=
   rfl
 
 /-- Change the degree index of a fixed-degree effective divisor along an equality. -/
-@[expose]
 protected def cast {d e : ℕ} (h : d = e) :
     EffectiveDivisorOfDegree X d ≃ EffectiveDivisorOfDegree X e where
   toFun D := ⟨D, D.property.1, D.property.2.trans (by exact_mod_cast h)⟩
@@ -68,13 +67,14 @@ protected def cast {d e : ℕ} (h : d = e) :
 @[simp]
 lemma cast_rfl (D : EffectiveDivisorOfDegree X d) :
     EffectiveDivisorOfDegree.cast rfl D = D :=
-  rfl
+  Subtype.ext rfl
 
 /-- Changing the degree index does not change the underlying Weil divisor. -/
 @[simp]
 lemma coe_cast {d e : ℕ} (h : d = e) (D : EffectiveDivisorOfDegree X d) :
-    (EffectiveDivisorOfDegree.cast h D : WeilDivisor X) = D :=
-  rfl
+    (EffectiveDivisorOfDegree.cast h D : WeilDivisor X) = D := by
+  subst e
+  simp
 
 @[simp]
 lemma isEffective (D : EffectiveDivisorOfDegree X d) : IsEffective (D : WeilDivisor X) :=

--- a/TauCeti/AlgebraicGeometry/WeilDivisor/FixedDegreeAddition.lean
+++ b/TauCeti/AlgebraicGeometry/WeilDivisor/FixedDegreeAddition.lean
@@ -141,8 +141,10 @@ lemma add_ofSym (s : Sym X d) (t : Sym X e) :
 fixed-degree divisors. -/
 @[simp]
 lemma coe_ofSym_append (s : Sym X d) (t : Sym X e) :
-    (ofSym (s.append t) : WeilDivisor X) = (ofSym s : WeilDivisor X) + ofSym t := by
-  rw [← coe_add, add_ofSym]
+    WeilDivisor.ofFinsupp
+        (letI := Classical.decEq X; ((Sym.equivNatSum X (d + e)) (s.append t)).1) =
+      (ofSym s : WeilDivisor X) + (ofSym t : WeilDivisor X) := by
+  rw [← coe_ofSym, ← coe_add, add_ofSym]
 
 /-- Pushforward commutes with addition of fixed-degree effective divisors. -/
 @[simp]

--- a/TauCeti/AlgebraicGeometry/WeilDivisor/FixedDegreeAddition.lean
+++ b/TauCeti/AlgebraicGeometry/WeilDivisor/FixedDegreeAddition.lean
@@ -1,0 +1,157 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+module
+
+public import TauCeti.AlgebraicGeometry.WeilDivisor.FixedDegree
+
+/-!
+# Addition of fixed-degree effective Weil divisors
+
+This file records the degree-indexed addition operation on effective Weil divisors of fixed
+degree.  Adding an effective divisor of degree `d` to one of degree `e` gives an effective
+divisor of degree `d + e`; under the equivalence with Mathlib's symmetric powers, this is
+exactly `Sym.append`.
+
+This is formal divisor bookkeeping for the Jacobian challenge roadmap's Layer C symmetric-power
+lane (`TauCetiRoadmap/JacobianChallenge/README.md`, "Relative effective Cartier divisors and
+symmetric powers `Symᵈ X`").  It supplies the additive compatibility between unordered
+collections of points and the effective-divisor model used by Abel-map statements.  No external
+mathematics is vendored.
+-/
+
+public section
+
+namespace TauCeti
+
+namespace AlgebraicGeometry
+
+namespace WeilDivisor
+
+namespace EffectiveDivisorOfDegree
+
+variable {X Y : Type*} {d e : ℕ}
+
+noncomputable section
+
+/-- The zero effective divisor, regarded as the unique effective divisor of degree `0`. -/
+abbrev zero (X : Type*) : EffectiveDivisorOfDegree X 0 :=
+  ⟨0, isEffective_zero, degree_zero⟩
+
+@[simp]
+lemma coe_zero : (zero X : WeilDivisor X) = 0 :=
+  rfl
+
+/-- Add fixed-degree effective divisors.  The degree index records additivity of degree. -/
+abbrev add (D : EffectiveDivisorOfDegree X d) (E : EffectiveDivisorOfDegree X e) :
+    EffectiveDivisorOfDegree X (d + e) :=
+  ⟨(D : WeilDivisor X) + E, D.isEffective.add E.isEffective, by
+    simp [degree_add, D.degree_eq, E.degree_eq]⟩
+
+@[simp]
+lemma coe_add (D : EffectiveDivisorOfDegree X d) (E : EffectiveDivisorOfDegree X e) :
+    (add D E : WeilDivisor X) = (D : WeilDivisor X) + E :=
+  rfl
+
+@[simp]
+lemma coeff_add (D : EffectiveDivisorOfDegree X d) (E : EffectiveDivisorOfDegree X e) (x : X) :
+    coeff (add D E : WeilDivisor X) x = coeff (D : WeilDivisor X) x + coeff E x := by
+  rw [coe_add, WeilDivisor.coeff_add]
+
+/-- Adding divisors built from finitely supported multiplicities corresponds to adding their
+multiplicity functions. -/
+@[simp]
+lemma add_ofFinsupp (m n : X →₀ ℕ) (hm : m.sum (fun _ k => k) = d)
+    (hn : n.sum (fun _ k => k) = e) :
+    add (ofFinsupp m hm) (ofFinsupp n hn) =
+      ofFinsupp (m + n) (by
+        rw [Finsupp.sum_add_index']
+        · simp [hm, hn]
+        · simp
+        · simp) := by
+  apply Subtype.ext
+  ext x
+  rw [coe_add, coe_ofFinsupp, coe_ofFinsupp, coe_ofFinsupp, WeilDivisor.coeff_add]
+  simp
+
+/-- The multiplicity function of a sum is the sum of the multiplicity functions. -/
+@[simp]
+lemma multiplicityFinsupp_add (D : EffectiveDivisorOfDegree X d)
+    (E : EffectiveDivisorOfDegree X e) :
+    (add D E).multiplicityFinsupp = D.multiplicityFinsupp + E.multiplicityFinsupp := by
+  have h := add_ofFinsupp D.multiplicityFinsupp E.multiplicityFinsupp
+    D.sum_multiplicityFinsupp E.sum_multiplicityFinsupp
+  rw [ofFinsupp_multiplicityFinsupp_eq D, ofFinsupp_multiplicityFinsupp_eq E] at h
+  rw [h, multiplicityFinsupp_ofFinsupp]
+
+/-- Addition of fixed-degree effective divisors is commutative on underlying Weil divisors. -/
+lemma coe_add_comm (D : EffectiveDivisorOfDegree X d) (E : EffectiveDivisorOfDegree X e) :
+    (add D E : WeilDivisor X) = (add E D : WeilDivisor X) := by
+  simp [add_comm]
+
+/-- Addition of fixed-degree effective divisors is associative on underlying Weil divisors. -/
+lemma coe_add_assoc {f : ℕ} (D : EffectiveDivisorOfDegree X d)
+    (E : EffectiveDivisorOfDegree X e) (F : EffectiveDivisorOfDegree X f) :
+    (add (add D E) F : WeilDivisor X) = (add D (add E F) : WeilDivisor X) := by
+  simp [add_assoc]
+
+/-- Adding the degree-zero effective divisor on the right preserves the underlying divisor. -/
+lemma coe_add_zero (D : EffectiveDivisorOfDegree X d) :
+    (add D (zero X) : WeilDivisor X) = D := by
+  simp
+
+/-- Adding the degree-zero effective divisor on the left preserves the underlying divisor. -/
+lemma coe_zero_add (D : EffectiveDivisorOfDegree X d) :
+    (add (zero X) D : WeilDivisor X) = D := by
+  simp
+
+/-- The symmetric-power equivalence sends fixed-degree divisor addition to `Sym.append`. -/
+@[simp]
+lemma equivSym_add (D : EffectiveDivisorOfDegree X d) (E : EffectiveDivisorOfDegree X e) :
+    equivSym (add D E) = (equivSym D).append (equivSym E) := by
+  classical
+  apply (Sym.equivNatSum X (d + e)).injective
+  ext x
+  simp [equivSym_apply]
+
+/-- Adding the divisors associated to symmetric-power points is the divisor associated to
+their appended unordered collection. -/
+@[simp]
+lemma add_ofSym (s : Sym X d) (t : Sym X e) :
+    add (ofSym s) (ofSym t) = ofSym (s.append t) := by
+  classical
+  apply equivSym.injective
+  simp
+
+/-- The divisor associated to an appended symmetric-power point is the sum of the associated
+fixed-degree divisors. -/
+lemma coe_ofSym_append (s : Sym X d) (t : Sym X e) :
+    (ofSym (s.append t) : WeilDivisor X) = (ofSym s : WeilDivisor X) + ofSym t := by
+  rw [← coe_add, add_ofSym]
+
+/-- Pushforward commutes with addition of fixed-degree effective divisors. -/
+@[simp]
+lemma pushforward_add (f : X → Y) (D : EffectiveDivisorOfDegree X d)
+    (E : EffectiveDivisorOfDegree X e) :
+    (add D E).pushforward f = add (D.pushforward f) (E.pushforward f) := by
+  ext
+  rw [coe_pushforward, coe_add, coe_add, coe_pushforward, coe_pushforward, map_add]
+
+/-- On symmetric powers, pushforward compatibility for fixed-degree divisor addition is the
+usual compatibility of `Sym.map` with `Sym.append`. -/
+lemma equivSym_pushforward_add (f : X → Y) (D : EffectiveDivisorOfDegree X d)
+    (E : EffectiveDivisorOfDegree X e) :
+    equivSym ((add D E).pushforward f) =
+      (Sym.map f (equivSym D)).append (Sym.map f (equivSym E)) := by
+  rw [pushforward_add, equivSym_add, equivSym_pushforward, equivSym_pushforward]
+
+end
+
+end EffectiveDivisorOfDegree
+
+end WeilDivisor
+
+end AlgebraicGeometry
+
+end TauCeti

--- a/TauCeti/AlgebraicGeometry/WeilDivisor/FixedDegreeAddition.lean
+++ b/TauCeti/AlgebraicGeometry/WeilDivisor/FixedDegreeAddition.lean
@@ -4,6 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 -/
 module
 
+public import TauCeti.Data.Sym.Basic
 public import TauCeti.AlgebraicGeometry.WeilDivisor.FixedDegree
 
 /-!
@@ -22,19 +23,6 @@ mathematics is vendored.
 -/
 
 public section
-
-namespace Sym
-
-variable {X Y : Type*} {d e : ℕ}
-
-/-- Mapping a function over an appended symmetric-power point is the append of the mapped
-symmetric-power points. -/
-@[simp]
-theorem map_append (f : X → Y) (s : Sym X d) (t : Sym X e) :
-    Sym.map f (s.append t) = (Sym.map f s).append (Sym.map f t) :=
-  Subtype.ext <| by simp [Multiset.map_add]
-
-end Sym
 
 namespace TauCeti
 

--- a/TauCeti/AlgebraicGeometry/WeilDivisor/FixedDegreeAddition.lean
+++ b/TauCeti/AlgebraicGeometry/WeilDivisor/FixedDegreeAddition.lean
@@ -23,8 +23,6 @@ mathematics is vendored.
 
 public section
 
-namespace TauCeti
-
 namespace Sym
 
 variable {X Y : Type*} {d e : ℕ}
@@ -34,9 +32,11 @@ symmetric-power points. -/
 @[simp]
 theorem map_append (f : X → Y) (s : Sym X d) (t : Sym X e) :
     Sym.map f (s.append t) = (Sym.map f s).append (Sym.map f t) :=
-  Subtype.ext <| by simp [Sym.map, Sym.append]
+  Subtype.ext <| by simp [Multiset.map_add]
 
 end Sym
+
+namespace TauCeti
 
 namespace AlgebraicGeometry
 
@@ -47,15 +47,6 @@ namespace EffectiveDivisorOfDegree
 variable {X Y : Type*} {d e : ℕ}
 
 noncomputable section
-
-/-- The zero effective divisor, regarded as the unique effective divisor of degree `0`. -/
-abbrev zero (X : Type*) : EffectiveDivisorOfDegree X 0 :=
-  ⟨0, isEffective_zero, degree_zero⟩
-
-/-- The underlying Weil divisor of the degree-zero effective divisor is zero. -/
-@[simp]
-lemma coe_zero : (zero X : WeilDivisor X) = 0 :=
-  rfl
 
 /-- Add fixed-degree effective divisors.  The degree index records additivity of degree. -/
 abbrev add (D : EffectiveDivisorOfDegree X d) (E : EffectiveDivisorOfDegree X e) :
@@ -75,6 +66,34 @@ lemma coeff_add (D : EffectiveDivisorOfDegree X d) (E : EffectiveDivisorOfDegree
     coeff (add D E : WeilDivisor X) x = coeff (D : WeilDivisor X) x + coeff E x := by
   rw [coe_add, WeilDivisor.coeff_add]
 
+/-- Zero is a left identity for fixed-degree effective-divisor addition. -/
+@[simp]
+lemma zero_add (D : EffectiveDivisorOfDegree X d) :
+    add (zero X) D = EffectiveDivisorOfDegree.cast (Nat.zero_add d).symm D := by
+  ext
+  simp
+
+/-- Zero is a right identity for fixed-degree effective-divisor addition. -/
+@[simp]
+lemma add_zero (D : EffectiveDivisorOfDegree X d) :
+    add D (zero X) = EffectiveDivisorOfDegree.cast (Nat.add_zero d).symm D := by
+  ext
+  simp
+
+/-- Fixed-degree effective-divisor addition is commutative, up to the degree-index cast. -/
+lemma add_comm (D : EffectiveDivisorOfDegree X d) (E : EffectiveDivisorOfDegree X e) :
+    add D E = EffectiveDivisorOfDegree.cast (Nat.add_comm e d) (add E D) := by
+  ext
+  simp [Int.add_comm]
+
+/-- Fixed-degree effective-divisor addition is associative, up to the degree-index cast. -/
+lemma add_assoc {n : ℕ} (D : EffectiveDivisorOfDegree X d)
+    (E : EffectiveDivisorOfDegree X e) (F : EffectiveDivisorOfDegree X n) :
+    add (add D E) F =
+      EffectiveDivisorOfDegree.cast (Nat.add_assoc d e n).symm (add D (add E F)) := by
+  ext
+  simp [Int.add_assoc]
+
 /-- Adding divisors built from finitely supported multiplicities corresponds to adding their
 multiplicity functions. -/
 @[simp]
@@ -88,7 +107,6 @@ lemma add_ofFinsupp (m n : X →₀ ℕ) (hm : m.sum (fun _ k => k) = d)
         · simp) := by
   apply Subtype.ext
   ext x
-  rw [coe_add, coe_ofFinsupp, coe_ofFinsupp, coe_ofFinsupp, WeilDivisor.coeff_add]
   simp
 
 /-- The multiplicity function of a sum is the sum of the multiplicity functions. -/
@@ -121,6 +139,7 @@ lemma add_ofSym (s : Sym X d) (t : Sym X e) :
 
 /-- The divisor associated to an appended symmetric-power point is the sum of the associated
 fixed-degree divisors. -/
+@[simp]
 lemma coe_ofSym_append (s : Sym X d) (t : Sym X e) :
     (ofSym (s.append t) : WeilDivisor X) = (ofSym s : WeilDivisor X) + ofSym t := by
   rw [← coe_add, add_ofSym]
@@ -131,7 +150,7 @@ lemma pushforward_add (f : X → Y) (D : EffectiveDivisorOfDegree X d)
     (E : EffectiveDivisorOfDegree X e) :
     (add D E).pushforward f = add (D.pushforward f) (E.pushforward f) := by
   ext
-  rw [coe_pushforward, coe_add, coe_add, coe_pushforward, coe_pushforward, map_add]
+  simp [WeilDivisor.pushforward_add]
 
 /-- On symmetric powers, pushforward compatibility for fixed-degree divisor addition is the
 usual compatibility of `Sym.map` with `Sym.append`. -/

--- a/TauCeti/AlgebraicGeometry/WeilDivisor/FixedDegreeAddition.lean
+++ b/TauCeti/AlgebraicGeometry/WeilDivisor/FixedDegreeAddition.lean
@@ -25,6 +25,19 @@ public section
 
 namespace TauCeti
 
+namespace Sym
+
+variable {X Y : Type*} {d e : ℕ}
+
+/-- Mapping a function over an appended symmetric-power point is the append of the mapped
+symmetric-power points. -/
+@[simp]
+theorem map_append (f : X → Y) (s : Sym X d) (t : Sym X e) :
+    Sym.map f (s.append t) = (Sym.map f s).append (Sym.map f t) :=
+  Subtype.ext <| by simp [Sym.map, Sym.append]
+
+end Sym
+
 namespace AlgebraicGeometry
 
 namespace WeilDivisor
@@ -39,6 +52,7 @@ noncomputable section
 abbrev zero (X : Type*) : EffectiveDivisorOfDegree X 0 :=
   ⟨0, isEffective_zero, degree_zero⟩
 
+/-- The underlying Weil divisor of the degree-zero effective divisor is zero. -/
 @[simp]
 lemma coe_zero : (zero X : WeilDivisor X) = 0 :=
   rfl
@@ -49,11 +63,13 @@ abbrev add (D : EffectiveDivisorOfDegree X d) (E : EffectiveDivisorOfDegree X e)
   ⟨(D : WeilDivisor X) + E, D.isEffective.add E.isEffective, by
     simp [degree_add, D.degree_eq, E.degree_eq]⟩
 
+/-- The underlying Weil divisor of a fixed-degree sum is the sum of the underlying divisors. -/
 @[simp]
 lemma coe_add (D : EffectiveDivisorOfDegree X d) (E : EffectiveDivisorOfDegree X e) :
     (add D E : WeilDivisor X) = (D : WeilDivisor X) + E :=
   rfl
 
+/-- The coefficient of a fixed-degree sum is the sum of the coefficients. -/
 @[simp]
 lemma coeff_add (D : EffectiveDivisorOfDegree X d) (E : EffectiveDivisorOfDegree X e) (x : X) :
     coeff (add D E : WeilDivisor X) x = coeff (D : WeilDivisor X) x + coeff E x := by
@@ -84,27 +100,6 @@ lemma multiplicityFinsupp_add (D : EffectiveDivisorOfDegree X d)
     D.sum_multiplicityFinsupp E.sum_multiplicityFinsupp
   rw [ofFinsupp_multiplicityFinsupp_eq D, ofFinsupp_multiplicityFinsupp_eq E] at h
   rw [h, multiplicityFinsupp_ofFinsupp]
-
-/-- Addition of fixed-degree effective divisors is commutative on underlying Weil divisors. -/
-lemma coe_add_comm (D : EffectiveDivisorOfDegree X d) (E : EffectiveDivisorOfDegree X e) :
-    (add D E : WeilDivisor X) = (add E D : WeilDivisor X) := by
-  simp [add_comm]
-
-/-- Addition of fixed-degree effective divisors is associative on underlying Weil divisors. -/
-lemma coe_add_assoc {f : ℕ} (D : EffectiveDivisorOfDegree X d)
-    (E : EffectiveDivisorOfDegree X e) (F : EffectiveDivisorOfDegree X f) :
-    (add (add D E) F : WeilDivisor X) = (add D (add E F) : WeilDivisor X) := by
-  simp [add_assoc]
-
-/-- Adding the degree-zero effective divisor on the right preserves the underlying divisor. -/
-lemma coe_add_zero (D : EffectiveDivisorOfDegree X d) :
-    (add D (zero X) : WeilDivisor X) = D := by
-  simp
-
-/-- Adding the degree-zero effective divisor on the left preserves the underlying divisor. -/
-lemma coe_zero_add (D : EffectiveDivisorOfDegree X d) :
-    (add (zero X) D : WeilDivisor X) = D := by
-  simp
 
 /-- The symmetric-power equivalence sends fixed-degree divisor addition to `Sym.append`. -/
 @[simp]
@@ -144,7 +139,7 @@ lemma equivSym_pushforward_add (f : X → Y) (D : EffectiveDivisorOfDegree X d)
     (E : EffectiveDivisorOfDegree X e) :
     equivSym ((add D E).pushforward f) =
       (Sym.map f (equivSym D)).append (Sym.map f (equivSym E)) := by
-  rw [pushforward_add, equivSym_add, equivSym_pushforward, equivSym_pushforward]
+  rw [equivSym_pushforward, equivSym_add, Sym.map_append]
 
 end
 

--- a/TauCeti/Data/Sym/Basic.lean
+++ b/TauCeti/Data/Sym/Basic.lean
@@ -1,0 +1,28 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+module
+
+public import Mathlib.Data.Sym.Basic
+
+/-!
+# Basic lemmas for symmetric powers
+
+This file records small API extensions for Mathlib's symmetric powers.
+-/
+
+public section
+
+namespace Sym
+
+variable {X Y : Type*} {d e : ℕ}
+
+/-- Mapping a function over an appended symmetric-power point is the append of the mapped
+symmetric-power points. -/
+@[simp]
+theorem map_append (f : X → Y) (s : Sym X d) (t : Sym X e) :
+    Sym.map f (s.append t) = (Sym.map f s).append (Sym.map f t) :=
+  Subtype.ext <| by simp [Multiset.map_add]
+
+end Sym


### PR DESCRIPTION
This PR adds indexed addition for fixed-degree effective Weil divisors: an effective divisor of degree `d` plus one of degree `e` gives an effective divisor of degree `d + e`, with characterizing lemmas for coefficients, multiplicity functions, symmetric-power append, and pushforward. It advances `TauCetiRoadmap/JacobianChallenge/README.md`, Layer C, the item “Relative effective Cartier divisors and symmetric powers `Symᵈ X`,” as the formal divisor bookkeeping prerequisite that makes addition of unordered point collections agree with addition of the effective-divisor model consumed by later Abel-map statements.

I chose this as the lowest-hanging distinct JacobianChallenge target after checking open and recently merged PRs: the fixed-degree effective-divisor model and its equivalence with `Sym X d` already exist on `main`, while the additive compatibility with `Sym.append` and pushforward was still absent. This stays below the missing scheme-level geometry and only records the honest formal-divisor API already supported by the existing Layer A/C infrastructure.

No Mathlib infrastructure is vendored. The implementation reuses Tau Ceti’s existing `EffectiveDivisorOfDegree`, `multiplicityFinsupp`, `equivSym`, `pushforward`, and formal Weil-divisor degree/effectivity API, together with Mathlib’s `Sym.append` and `Finsupp` additive lemmas.

`lake exe cache get` completed with `No files to download` and `Already decompressed 8609 file(s)`. `lake build` completed with `Build completed successfully (4507 jobs).` `lake exe axioms` completed with `axioms: audited 7777 TauCeti declaration(s); all within the allowlist [propext, Classical.choice, Quot.sound].`

<!--tauceti-target:v1 {"focus":"JacobianChallenge","id":"fixed-degree-effective-divisor-addition"}-->

🤖 Prepared with Codex
