### PR TITLE
feat: add Schwarz reflection lower branch API

### DIFF
--- a/TauCeti/Analysis/Complex/Conformal/Reflection.lean
+++ b/TauCeti/Analysis/Complex/Conformal/Reflection.lean
@@ -107,49 +107,49 @@ lemma schwarzReflection_conj
     rw [schwarzReflection_of_im_nonneg (f := f) hpos.le]
 
 /--
-For a conjugation-symmetric domain, conjugation carries the upper half-plane part of the
+For a domain closed under conjugation, conjugation carries the upper half-plane part of the
 domain to its lower half-plane part.
 -/
 lemma image_conj_inter_im_pos_of_symmetric {Ω : Set ℂ}
-    (hsymm : ∀ z, z ∈ Ω ↔ (starRingEnd ℂ) z ∈ Ω) :
+    (hΩ : Set.MapsTo (starRingEnd ℂ) Ω Ω) :
     (starRingEnd ℂ) '' (Ω ∩ {z | 0 < z.im}) = Ω ∩ {z | z.im < 0} := by
   ext z
   constructor
   · rintro ⟨w, ⟨hwΩ, hwim⟩, rfl⟩
     constructor
-    · exact (hsymm w).mp hwΩ
-    · change ((starRingEnd ℂ) w).im < 0
-      rw [starRingEnd_apply, Complex.star_def, Complex.conj_im]
-      exact neg_neg_of_pos hwim
+    · exact hΩ hwΩ
+    · exact show ((starRingEnd ℂ) w).im < 0 from by
+        rw [starRingEnd_apply, Complex.star_def, Complex.conj_im]
+        exact neg_neg_of_pos hwim
   · rintro ⟨hzΩ, hzim⟩
     refine ⟨(starRingEnd ℂ) z, ⟨?_, ?_⟩, ?_⟩
-    · exact (hsymm z).mp hzΩ
-    · change 0 < ((starRingEnd ℂ) z).im
-      rw [starRingEnd_apply, Complex.star_def, Complex.conj_im]
-      exact neg_pos.mpr hzim
+    · exact hΩ hzΩ
+    · exact show 0 < ((starRingEnd ℂ) z).im from by
+        rw [starRingEnd_apply, Complex.star_def, Complex.conj_im]
+        exact neg_pos.mpr hzim
     · rw [starRingEnd_self_apply]
 
 /--
-For a conjugation-symmetric domain, conjugation carries the lower half-plane part of the
+For a domain closed under conjugation, conjugation carries the lower half-plane part of the
 domain to its upper half-plane part.
 -/
 lemma image_conj_inter_im_neg_of_symmetric {Ω : Set ℂ}
-    (hsymm : ∀ z, z ∈ Ω ↔ (starRingEnd ℂ) z ∈ Ω) :
+    (hΩ : Set.MapsTo (starRingEnd ℂ) Ω Ω) :
     (starRingEnd ℂ) '' (Ω ∩ {z | z.im < 0}) = Ω ∩ {z | 0 < z.im} := by
   ext z
   constructor
   · rintro ⟨w, ⟨hwΩ, hwim⟩, rfl⟩
     constructor
-    · exact (hsymm w).mp hwΩ
-    · change 0 < ((starRingEnd ℂ) w).im
-      rw [starRingEnd_apply, Complex.star_def, Complex.conj_im]
-      exact neg_pos.mpr hwim
+    · exact hΩ hwΩ
+    · exact show 0 < ((starRingEnd ℂ) w).im from by
+        rw [starRingEnd_apply, Complex.star_def, Complex.conj_im]
+        exact neg_pos.mpr hwim
   · rintro ⟨hzΩ, hzim⟩
     refine ⟨(starRingEnd ℂ) z, ⟨?_, ?_⟩, ?_⟩
-    · exact (hsymm z).mp hzΩ
-    · change ((starRingEnd ℂ) z).im < 0
-      rw [starRingEnd_apply, Complex.star_def, Complex.conj_im]
-      exact neg_neg_of_pos hzim
+    · exact hΩ hzΩ
+    · exact show ((starRingEnd ℂ) z).im < 0 from by
+        rw [starRingEnd_apply, Complex.star_def, Complex.conj_im]
+        exact neg_neg_of_pos hzim
     · rw [starRingEnd_self_apply]
 
 private lemma starRingEnd_eq_starL (z : ℂ) :
@@ -236,30 +236,30 @@ lemma differentiableOn_conj_conj_iff :
   · exact differentiableOn_conj_conj
 
 /--
-If a domain is symmetric under conjugation and `f` is holomorphic on its upper half-plane
+If a domain is closed under conjugation and `f` is holomorphic on its upper half-plane
 part, then the reflected branch `z ↦ conj (f (conj z))` is holomorphic on the lower
 half-plane part.
 -/
 lemma differentiableOn_conj_conj_inter_im_neg_of_symmetric {Ω : Set ℂ}
-    (hsymm : ∀ z, z ∈ Ω ↔ (starRingEnd ℂ) z ∈ Ω)
+    (hΩ : Set.MapsTo (starRingEnd ℂ) Ω Ω)
     (hf : DifferentiableOn ℂ f (Ω ∩ {z | 0 < z.im})) :
     DifferentiableOn ℂ (fun z => (starRingEnd ℂ) (f ((starRingEnd ℂ) z)))
       (Ω ∩ {z | z.im < 0}) := by
-  simpa [image_conj_inter_im_pos_of_symmetric hsymm] using
+  simpa [image_conj_inter_im_pos_of_symmetric hΩ] using
     differentiableOn_conj_conj (S := Ω ∩ {z | 0 < z.im}) (f := f) hf
 
 /--
-On the lower half-plane part of a conjugation-symmetric domain, the explicit Schwarz
+On the lower half-plane part of a domain closed under conjugation, the explicit Schwarz
 reflection extension is holomorphic whenever the original function is holomorphic on the
 upper half-plane part.
 -/
 lemma differentiableOn_schwarzReflection_inter_im_neg_of_symmetric {Ω : Set ℂ}
-    (hsymm : ∀ z, z ∈ Ω ↔ (starRingEnd ℂ) z ∈ Ω)
+    (hΩ : Set.MapsTo (starRingEnd ℂ) Ω Ω)
     (hf : DifferentiableOn ℂ f (Ω ∩ {z | 0 < z.im})) :
     DifferentiableOn ℂ (schwarzReflection f) (Ω ∩ {z | z.im < 0}) := by
   intro z hz
   exact ((differentiableOn_conj_conj_inter_im_neg_of_symmetric
-    (f := f) hsymm hf) z hz).congr
+    (f := f) hΩ hf) z hz).congr
       (fun w hw => schwarzReflection_of_im_neg (f := f) hw.2)
       (schwarzReflection_of_im_neg (f := f) hz.2)
 

--- a/TauCeti/Analysis/Complex/Conformal/Reflection.lean
+++ b/TauCeti/Analysis/Complex/Conformal/Reflection.lean
@@ -118,15 +118,13 @@ lemma image_conj_inter_im_pos_of_symmetric {Ω : Set ℂ}
   · rintro ⟨w, ⟨hwΩ, hwim⟩, rfl⟩
     constructor
     · exact hΩ hwΩ
-    · exact show ((starRingEnd ℂ) w).im < 0 from by
-        rw [starRingEnd_apply, Complex.star_def, Complex.conj_im]
-        exact neg_neg_of_pos hwim
+    · rw [Set.mem_setOf_eq, starRingEnd_apply, Complex.star_def, Complex.conj_im]
+      exact neg_neg_of_pos hwim
   · rintro ⟨hzΩ, hzim⟩
     refine ⟨(starRingEnd ℂ) z, ⟨?_, ?_⟩, ?_⟩
     · exact hΩ hzΩ
-    · exact show 0 < ((starRingEnd ℂ) z).im from by
-        rw [starRingEnd_apply, Complex.star_def, Complex.conj_im]
-        exact neg_pos.mpr hzim
+    · rw [Set.mem_setOf_eq, starRingEnd_apply, Complex.star_def, Complex.conj_im]
+      exact neg_pos.mpr hzim
     · rw [starRingEnd_self_apply]
 
 /--
@@ -141,15 +139,13 @@ lemma image_conj_inter_im_neg_of_symmetric {Ω : Set ℂ}
   · rintro ⟨w, ⟨hwΩ, hwim⟩, rfl⟩
     constructor
     · exact hΩ hwΩ
-    · exact show 0 < ((starRingEnd ℂ) w).im from by
-        rw [starRingEnd_apply, Complex.star_def, Complex.conj_im]
-        exact neg_pos.mpr hwim
+    · rw [Set.mem_setOf_eq, starRingEnd_apply, Complex.star_def, Complex.conj_im]
+      exact neg_pos.mpr hwim
   · rintro ⟨hzΩ, hzim⟩
     refine ⟨(starRingEnd ℂ) z, ⟨?_, ?_⟩, ?_⟩
     · exact hΩ hzΩ
-    · exact show ((starRingEnd ℂ) z).im < 0 from by
-        rw [starRingEnd_apply, Complex.star_def, Complex.conj_im]
-        exact neg_neg_of_pos hzim
+    · rw [Set.mem_setOf_eq, starRingEnd_apply, Complex.star_def, Complex.conj_im]
+      exact neg_neg_of_pos hzim
     · rw [starRingEnd_self_apply]
 
 private lemma starRingEnd_eq_starL (z : ℂ) :

--- a/TauCeti/Analysis/Complex/Conformal/Reflection.lean
+++ b/TauCeti/Analysis/Complex/Conformal/Reflection.lean
@@ -106,6 +106,52 @@ lemma schwarzReflection_conj
   · rw [schwarzReflection_conj_of_im_pos (f := f) hpos]
     rw [schwarzReflection_of_im_nonneg (f := f) hpos.le]
 
+/--
+For a conjugation-symmetric domain, conjugation carries the upper half-plane part of the
+domain to its lower half-plane part.
+-/
+lemma image_conj_inter_im_pos_of_symmetric {Ω : Set ℂ}
+    (hsymm : ∀ z, z ∈ Ω ↔ (starRingEnd ℂ) z ∈ Ω) :
+    (starRingEnd ℂ) '' (Ω ∩ {z | 0 < z.im}) = Ω ∩ {z | z.im < 0} := by
+  ext z
+  constructor
+  · rintro ⟨w, ⟨hwΩ, hwim⟩, rfl⟩
+    constructor
+    · exact (hsymm w).mp hwΩ
+    · change ((starRingEnd ℂ) w).im < 0
+      rw [starRingEnd_apply, Complex.star_def, Complex.conj_im]
+      exact neg_neg_of_pos hwim
+  · rintro ⟨hzΩ, hzim⟩
+    refine ⟨(starRingEnd ℂ) z, ⟨?_, ?_⟩, ?_⟩
+    · exact (hsymm z).mp hzΩ
+    · change 0 < ((starRingEnd ℂ) z).im
+      rw [starRingEnd_apply, Complex.star_def, Complex.conj_im]
+      exact neg_pos.mpr hzim
+    · rw [starRingEnd_self_apply]
+
+/--
+For a conjugation-symmetric domain, conjugation carries the lower half-plane part of the
+domain to its upper half-plane part.
+-/
+lemma image_conj_inter_im_neg_of_symmetric {Ω : Set ℂ}
+    (hsymm : ∀ z, z ∈ Ω ↔ (starRingEnd ℂ) z ∈ Ω) :
+    (starRingEnd ℂ) '' (Ω ∩ {z | z.im < 0}) = Ω ∩ {z | 0 < z.im} := by
+  ext z
+  constructor
+  · rintro ⟨w, ⟨hwΩ, hwim⟩, rfl⟩
+    constructor
+    · exact (hsymm w).mp hwΩ
+    · change 0 < ((starRingEnd ℂ) w).im
+      rw [starRingEnd_apply, Complex.star_def, Complex.conj_im]
+      exact neg_pos.mpr hwim
+  · rintro ⟨hzΩ, hzim⟩
+    refine ⟨(starRingEnd ℂ) z, ⟨?_, ?_⟩, ?_⟩
+    · exact (hsymm z).mp hzΩ
+    · change ((starRingEnd ℂ) z).im < 0
+      rw [starRingEnd_apply, Complex.star_def, Complex.conj_im]
+      exact neg_neg_of_pos hzim
+    · rw [starRingEnd_self_apply]
+
 private lemma starRingEnd_eq_starL (z : ℂ) :
     (starRingEnd ℂ) z = (starL ℂ : ℂ ≃L⋆[ℂ] ℂ) z := by
   rw [starL_apply, starRingEnd_apply]
@@ -188,5 +234,33 @@ lemma differentiableOn_conj_conj_iff :
       (starRingEnd_self_apply : Function.Involutive (starRingEnd ℂ)), Set.preimage_preimage,
       Function.comp_def] using htwice
   · exact differentiableOn_conj_conj
+
+/--
+If a domain is symmetric under conjugation and `f` is holomorphic on its upper half-plane
+part, then the reflected branch `z ↦ conj (f (conj z))` is holomorphic on the lower
+half-plane part.
+-/
+lemma differentiableOn_conj_conj_inter_im_neg_of_symmetric {Ω : Set ℂ}
+    (hsymm : ∀ z, z ∈ Ω ↔ (starRingEnd ℂ) z ∈ Ω)
+    (hf : DifferentiableOn ℂ f (Ω ∩ {z | 0 < z.im})) :
+    DifferentiableOn ℂ (fun z => (starRingEnd ℂ) (f ((starRingEnd ℂ) z)))
+      (Ω ∩ {z | z.im < 0}) := by
+  simpa [image_conj_inter_im_pos_of_symmetric hsymm] using
+    differentiableOn_conj_conj (S := Ω ∩ {z | 0 < z.im}) (f := f) hf
+
+/--
+On the lower half-plane part of a conjugation-symmetric domain, the explicit Schwarz
+reflection extension is holomorphic whenever the original function is holomorphic on the
+upper half-plane part.
+-/
+lemma differentiableOn_schwarzReflection_inter_im_neg_of_symmetric {Ω : Set ℂ}
+    (hsymm : ∀ z, z ∈ Ω ↔ (starRingEnd ℂ) z ∈ Ω)
+    (hf : DifferentiableOn ℂ f (Ω ∩ {z | 0 < z.im})) :
+    DifferentiableOn ℂ (schwarzReflection f) (Ω ∩ {z | z.im < 0}) := by
+  intro z hz
+  exact ((differentiableOn_conj_conj_inter_im_neg_of_symmetric
+    (f := f) hsymm hf) z hz).congr
+      (fun w hw => schwarzReflection_of_im_neg (f := f) hw.2)
+      (schwarzReflection_of_im_neg (f := f) hz.2)
 
 end TauCeti


### PR DESCRIPTION
This PR adds the lower-branch Schwarz reflection API needed for the real-axis reflection witness: conjugation carries the upper half-plane part of a symmetric domain to its lower half-plane part, and the branch `z ↦ conj (f (conj z))` is holomorphic there when `f` is holomorphic on the upper part.

It advances `TauCetiRoadmap/ConformalMapping/README.md`, Layer L4, “analytic continuation & the reflection principle,” specifically the real-axis Schwarz reflection witness `F z = if 0 ≤ z.im then f z else conj (f (conj z))`, as the clean prerequisite that proves the reflected lower branch of this explicit witness is holomorphic away from the boundary. It builds directly on the already-landed L4.0 antiholomorphic-composition lemma in `TauCeti.Analysis.Complex.Conformal.Reflection`.

I chose this as the lowest-hanging distinct ConformalMapping target after checking open and recently merged PRs: L2 unit-disc automorphism API and L4.0 antiholomorphic composition already exist on `main`, while the domain-specific lower-branch differentiability step needed by the full Schwarz reflection theorem was still absent. This avoids duplicating the in-progress Mathlib RMT/Hurwitz/Montel work and stays inside the genuinely new L4 reflection layer.

No Mathlib infrastructure is vendored. The implementation reuses Tau Ceti’s existing `differentiableOn_conj_conj` and `schwarzReflection_of_im_neg`, plus Mathlib’s standard complex conjugation API via `starRingEnd ℂ`.

`lake exe cache get` completed with `No files to download` and `Already decompressed 8609 file(s)`. `lake build` completed with `Build completed successfully (4507 jobs).` `lake exe axioms` completed with `axioms: audited 7773 TauCeti declaration(s); all within the allowlist [propext, Classical.choice, Quot.sound].`

<!--tauceti-target:v1 {"focus":"ConformalMapping","id":"schwarz-reflection-lower-branch"}-->

🤖 Prepared with Codex
