### PR TITLE
feat: add exchangeable stationarity API

### DIFF
--- a/TauCeti/Probability/Exchangeability/Stationary.lean
+++ b/TauCeti/Probability/Exchangeability/Stationary.lean
@@ -58,11 +58,11 @@ theorem Contractable.map_processShift_eq_pathLaw {μ : Measure Ω} {X : ℕ → 
 
 /-- Prefix laws are unchanged after shifting a contractable process by any finite amount. -/
 theorem Contractable.map_prefixProj_shift_iterate_pathLaw_eq_prefixLaw {μ : Measure Ω}
-    {X : ℕ → Ω → α} [IsFiniteMeasure μ] (hX : Contractable μ X)
+    {X : ℕ → Ω → α} (hX : Contractable μ X)
     (hX_meas : ∀ i, AEMeasurable (X i) μ) (n m : ℕ) :
     ((pathLaw μ X).map ((shift α)^[n])).map (prefixProj α m) = prefixLaw μ X m := by
-  rw [hX.map_shift_iterate_pathLaw hX_meas n,
-    map_prefixProj_pathLaw μ (aemeasurable_pi_lambda _ hX_meas) m]
+  rw [map_prefixProj_shift_iterate_pathLaw μ hX_meas n m]
+  exact hX m (fun i : Fin m => i.val + n) (fun _ _ h => Nat.add_lt_add_right h n)
 
 /-- **An exchangeable process has a shift-invariant path law.** -/
 theorem Exchangeable.measurePreserving_shift {μ : Measure Ω} {X : ℕ → Ω → α}
@@ -100,7 +100,7 @@ theorem Exchangeable.map_processShift_eq_pathLaw {μ : Measure Ω} {X : ℕ → 
 
 /-- Prefix laws are unchanged after shifting an exchangeable process by any finite amount. -/
 theorem Exchangeable.map_prefixProj_shift_iterate_pathLaw_eq_prefixLaw {μ : Measure Ω}
-    {X : ℕ → Ω → α} [IsFiniteMeasure μ] (hX : Exchangeable μ X)
+    {X : ℕ → Ω → α} (hX : Exchangeable μ X)
     (hX_meas : ∀ i, AEMeasurable (X i) μ) (n m : ℕ) :
     ((pathLaw μ X).map ((shift α)^[n])).map (prefixProj α m) = prefixLaw μ X m :=
   (hX.contractable hX_meas).map_prefixProj_shift_iterate_pathLaw_eq_prefixLaw hX_meas n m

--- a/TauCeti/Probability/Exchangeability/Stationary.lean
+++ b/TauCeti/Probability/Exchangeability/Stationary.lean
@@ -2,6 +2,7 @@ module
 
 public import TauCeti.Probability.Exchangeability.Contractability
 public import TauCeti.Probability.Exchangeability.PathSpace.ProcessShift
+import TauCeti.Probability.Exchangeability.FiniteMarginals
 
 /-!
 # Exchangeable laws are stationary
@@ -12,8 +13,8 @@ exchangeable process has a shift-invariant path law.  The existing implication
 `Exchangeable`-named API that downstream shift, tail, and ergodic arguments can use without
 manually detouring through contractability.
 
-The bridge is stated for all strictly monotone time reindexings first, then specialized to the
-one-sided shift and its iterates.  The final `processShift` form packages the same invariance at
+The bridge is stated for all injective time reindexings first, then specialized to the one-sided
+shift and its iterates.  The final `processShift` form packages the same invariance at
 the process-law level.
 -/
 
@@ -29,20 +30,27 @@ namespace Probability
 
 variable {Ω α : Type*} [MeasurableSpace Ω] [MeasurableSpace α]
 
-/-- **Exchangeable laws are invariant under strictly monotone reindexing.**  If `X` is
+/-- **Exchangeable laws are invariant under injective reindexing.**  If `X` is
 exchangeable and its coordinates are a.e.-measurable, then the path-law reindexing
-`x ↦ x ∘ φ` preserves `pathLaw μ X` for every strictly monotone `φ : ℕ → ℕ`. -/
+`x ↦ x ∘ φ` preserves `pathLaw μ X` for every injective `φ : ℕ → ℕ`. -/
 theorem Exchangeable.measurePreserving_reindex {μ : Measure Ω} {X : ℕ → Ω → α}
     [IsFiniteMeasure μ] (hX : Exchangeable μ X) (hX_meas : ∀ i, AEMeasurable (X i) μ)
-    {φ : ℕ → ℕ} (hφ : StrictMono φ) :
-    MeasurePreserving (fun x : ℕ → α => fun k => x (φ k)) (pathLaw μ X) (pathLaw μ X) :=
-  (hX.contractable hX_meas).measurePreserving_reindex hX_meas hφ
+    {φ : ℕ → ℕ} (hφ : Function.Injective φ) :
+    MeasurePreserving (fun x : ℕ → α => fun k => x (φ k)) (pathLaw μ X) (pathLaw μ X) := by
+  refine ⟨measurable_reindex φ, ?_⟩
+  haveI : IsFiniteMeasure (pathLaw μ X) := by rw [pathLaw_def]; infer_instance
+  refine measure_eq_of_prefixProj_map_eq ?_
+  intro n
+  rw [map_reindex_prefixProj_pathLaw μ hX_meas φ n,
+    map_prefixProj_pathLaw μ (aemeasurable_pi_lambda _ hX_meas) n]
+  exact hX.blockLaw_eq_prefixLaw_of_injective hX_meas (fun i : Fin n => φ i.val)
+    (fun _ _ h => Fin.ext (hφ h))
 
-/-- Reindexing the path law of an exchangeable process by a strictly monotone map leaves it
+/-- Reindexing the path law of an exchangeable process by an injective map leaves it
 unchanged. -/
 theorem Exchangeable.map_reindex_pathLaw {μ : Measure Ω} {X : ℕ → Ω → α}
     [IsFiniteMeasure μ] (hX : Exchangeable μ X) (hX_meas : ∀ i, AEMeasurable (X i) μ)
-    {φ : ℕ → ℕ} (hφ : StrictMono φ) :
+    {φ : ℕ → ℕ} (hφ : Function.Injective φ) :
     (pathLaw μ X).map (fun x : ℕ → α => fun k => x (φ k)) = pathLaw μ X :=
   (hX.measurePreserving_reindex hX_meas hφ).map_eq
 
@@ -51,12 +59,6 @@ theorem Exchangeable.measurePreserving_shift {μ : Measure Ω} {X : ℕ → Ω �
     [IsFiniteMeasure μ] (hX : Exchangeable μ X) (hX_meas : ∀ i, AEMeasurable (X i) μ) :
     MeasurePreserving (shift α) (pathLaw μ X) (pathLaw μ X) :=
   (hX.contractable hX_meas).measurePreserving_shift hX_meas
-
-/-- Shifting the path law of an exchangeable process leaves it unchanged. -/
-theorem Exchangeable.map_shift_pathLaw {μ : Measure Ω} {X : ℕ → Ω → α}
-    [IsFiniteMeasure μ] (hX : Exchangeable μ X) (hX_meas : ∀ i, AEMeasurable (X i) μ) :
-    (pathLaw μ X).map (shift α) = pathLaw μ X :=
-  (hX.measurePreserving_shift hX_meas).map_eq
 
 /-- Every iterate of the one-sided shift preserves the path law of an exchangeable process. -/
 theorem Exchangeable.measurePreserving_shift_iterate {μ : Measure Ω} {X : ℕ → Ω → α}
@@ -72,20 +74,12 @@ theorem Exchangeable.map_shift_iterate_pathLaw {μ : Measure Ω} {X : ℕ → Ω
     (pathLaw μ X).map ((shift α)^[n]) = pathLaw μ X :=
   (hX.measurePreserving_shift_iterate hX_meas n).map_eq
 
-/-- Setwise stationarity: a shift preimage has the same path-law mass as the original measurable
-set. -/
-theorem Exchangeable.pathLaw_preimage_shift {μ : Measure Ω} {X : ℕ → Ω → α}
-    [IsFiniteMeasure μ] (hX : Exchangeable μ X) (hX_meas : ∀ i, AEMeasurable (X i) μ)
-    {s : Set (ℕ → α)} (hs : MeasurableSet s) :
-    pathLaw μ X (shift α ⁻¹' s) = pathLaw μ X s :=
-  (hX.measurePreserving_shift hX_meas).measure_preimage hs.nullMeasurableSet
-
 /-- Setwise stationarity for every shift iterate. -/
 theorem Exchangeable.pathLaw_preimage_shift_iterate {μ : Measure Ω} {X : ℕ → Ω → α}
     [IsFiniteMeasure μ] (hX : Exchangeable μ X) (hX_meas : ∀ i, AEMeasurable (X i) μ)
-    (n : ℕ) {s : Set (ℕ → α)} (hs : MeasurableSet s) :
+    (n : ℕ) {s : Set (ℕ → α)} (hs : NullMeasurableSet s (pathLaw μ X)) :
     pathLaw μ X (((shift α)^[n]) ⁻¹' s) = pathLaw μ X s :=
-  (hX.measurePreserving_shift_iterate hX_meas n).measure_preimage hs.nullMeasurableSet
+  (hX.measurePreserving_shift_iterate hX_meas n).measure_preimage hs
 
 /-- The law of the `n`-step shifted process of an exchangeable process is the original path law. -/
 theorem Exchangeable.map_processShift_eq_pathLaw {μ : Measure Ω} {X : ℕ → Ω → α}
@@ -94,13 +88,6 @@ theorem Exchangeable.map_processShift_eq_pathLaw {μ : Measure Ω} {X : ℕ → 
     μ.map (processShift X n) = pathLaw μ X := by
   rw [map_processShift μ hX_meas n, hX.map_shift_iterate_pathLaw hX_meas n]
 
-/-- The one-step shifted process of an exchangeable process has the same law as the original
-path. -/
-theorem Exchangeable.map_processShift_one_eq_pathLaw {μ : Measure Ω} {X : ℕ → Ω → α}
-    [IsFiniteMeasure μ] (hX : Exchangeable μ X) (hX_meas : ∀ i, AEMeasurable (X i) μ) :
-    μ.map (processShift X 1) = pathLaw μ X :=
-  hX.map_processShift_eq_pathLaw hX_meas 1
-
 /-- Prefix laws are unchanged after shifting an exchangeable process by any finite amount. -/
 theorem Exchangeable.map_prefixProj_shift_iterate_pathLaw_eq_prefixLaw {μ : Measure Ω}
     {X : ℕ → Ω → α} [IsFiniteMeasure μ] (hX : Exchangeable μ X)
@@ -108,13 +95,6 @@ theorem Exchangeable.map_prefixProj_shift_iterate_pathLaw_eq_prefixLaw {μ : Mea
     ((pathLaw μ X).map ((shift α)^[n])).map (prefixProj α m) = prefixLaw μ X m := by
   rw [hX.map_shift_iterate_pathLaw hX_meas n,
     map_prefixProj_pathLaw μ (aemeasurable_pi_lambda _ hX_meas) m]
-
-/-- Setwise prefix-law form of exchangeable stationarity after a finite shift. -/
-theorem Exchangeable.map_prefixProj_shift_iterate_pathLaw_apply {μ : Measure Ω}
-    {X : ℕ → Ω → α} [IsFiniteMeasure μ] (hX : Exchangeable μ X)
-    (hX_meas : ∀ i, AEMeasurable (X i) μ) (n m : ℕ) (s : Set (Fin m → α)) :
-    ((pathLaw μ X).map ((shift α)^[n])).map (prefixProj α m) s = prefixLaw μ X m s := by
-  rw [hX.map_prefixProj_shift_iterate_pathLaw_eq_prefixLaw hX_meas n m]
 
 end Probability
 

--- a/TauCeti/Probability/Exchangeability/Stationary.lean
+++ b/TauCeti/Probability/Exchangeability/Stationary.lean
@@ -2,20 +2,18 @@ module
 
 public import TauCeti.Probability.Exchangeability.Contractability
 public import TauCeti.Probability.Exchangeability.PathSpace.ProcessShift
-import TauCeti.Probability.Exchangeability.FiniteMarginals
 
 /-!
 # Exchangeable laws are stationary
 
 This file records the Layer 0 stationarity bridge from the Exchangeability roadmap: a finitely
 exchangeable process has a shift-invariant path law.  The existing implication
-`Exchangeable.contractable` gives the mathematical content; the lemmas here provide the direct
-`Exchangeable`-named API that downstream shift, tail, and ergodic arguments can use without
-manually detouring through contractability.
+`Exchangeable.contractable` gives the exchangeability-to-contractability bridge.  The lemmas here
+first expose the shift-stationarity consequences at the natural `Contractable` level, then provide
+thin `Exchangeable`-named wrappers for downstream code that starts from exchangeability.
 
-The bridge is stated for all injective time reindexings first, then specialized to the one-sided
-shift and its iterates.  The final `processShift` form packages the same invariance at
-the process-law level.
+The bridge is stated for the one-sided shift and its iterates.  The final `processShift` form
+packages the same invariance at the process-law level.
 -/
 
 public section
@@ -30,29 +28,41 @@ namespace Probability
 
 variable {Ω α : Type*} [MeasurableSpace Ω] [MeasurableSpace α]
 
-/-- **Exchangeable laws are invariant under injective reindexing.**  If `X` is
-exchangeable and its coordinates are a.e.-measurable, then the path-law reindexing
-`x ↦ x ∘ φ` preserves `pathLaw μ X` for every injective `φ : ℕ → ℕ`. -/
-theorem Exchangeable.measurePreserving_reindex {μ : Measure Ω} {X : ℕ → Ω → α}
-    [IsFiniteMeasure μ] (hX : Exchangeable μ X) (hX_meas : ∀ i, AEMeasurable (X i) μ)
-    {φ : ℕ → ℕ} (hφ : Function.Injective φ) :
-    MeasurePreserving (fun x : ℕ → α => fun k => x (φ k)) (pathLaw μ X) (pathLaw μ X) := by
-  refine ⟨measurable_reindex φ, ?_⟩
-  haveI : IsFiniteMeasure (pathLaw μ X) := by rw [pathLaw_def]; infer_instance
-  refine measure_eq_of_prefixProj_map_eq ?_
-  intro n
-  rw [map_reindex_prefixProj_pathLaw μ hX_meas φ n,
-    map_prefixProj_pathLaw μ (aemeasurable_pi_lambda _ hX_meas) n]
-  exact hX.blockLaw_eq_prefixLaw_of_injective hX_meas (fun i : Fin n => φ i.val)
-    (fun _ _ h => Fin.ext (hφ h))
+/-- Every iterate of the one-sided shift preserves the path law of a contractable process. -/
+theorem Contractable.measurePreserving_shift_iterate {μ : Measure Ω} {X : ℕ → Ω → α}
+    [IsFiniteMeasure μ] (hX : Contractable μ X) (hX_meas : ∀ i, AEMeasurable (X i) μ)
+    (n : ℕ) :
+    MeasurePreserving ((shift α)^[n]) (pathLaw μ X) (pathLaw μ X) :=
+  (hX.measurePreserving_shift hX_meas).iterate n
 
-/-- Reindexing the path law of an exchangeable process by an injective map leaves it
-unchanged. -/
-theorem Exchangeable.map_reindex_pathLaw {μ : Measure Ω} {X : ℕ → Ω → α}
-    [IsFiniteMeasure μ] (hX : Exchangeable μ X) (hX_meas : ∀ i, AEMeasurable (X i) μ)
-    {φ : ℕ → ℕ} (hφ : Function.Injective φ) :
-    (pathLaw μ X).map (fun x : ℕ → α => fun k => x (φ k)) = pathLaw μ X :=
-  (hX.measurePreserving_reindex hX_meas hφ).map_eq
+/-- Iterating the one-sided shift leaves the path law of a contractable process unchanged. -/
+theorem Contractable.map_shift_iterate_pathLaw {μ : Measure Ω} {X : ℕ → Ω → α}
+    [IsFiniteMeasure μ] (hX : Contractable μ X) (hX_meas : ∀ i, AEMeasurable (X i) μ)
+    (n : ℕ) :
+    (pathLaw μ X).map ((shift α)^[n]) = pathLaw μ X :=
+  (hX.measurePreserving_shift_iterate hX_meas n).map_eq
+
+/-- Setwise stationarity for every shift iterate of a contractable process. -/
+theorem Contractable.pathLaw_preimage_shift_iterate {μ : Measure Ω} {X : ℕ → Ω → α}
+    [IsFiniteMeasure μ] (hX : Contractable μ X) (hX_meas : ∀ i, AEMeasurable (X i) μ)
+    (n : ℕ) {s : Set (ℕ → α)} (hs : NullMeasurableSet s (pathLaw μ X)) :
+    pathLaw μ X (((shift α)^[n]) ⁻¹' s) = pathLaw μ X s :=
+  (hX.measurePreserving_shift_iterate hX_meas n).measure_preimage hs
+
+/-- The law of the `n`-step shifted process of a contractable process is the original path law. -/
+theorem Contractable.map_processShift_eq_pathLaw {μ : Measure Ω} {X : ℕ → Ω → α}
+    [IsFiniteMeasure μ] (hX : Contractable μ X) (hX_meas : ∀ i, AEMeasurable (X i) μ)
+    (n : ℕ) :
+    μ.map (processShift X n) = pathLaw μ X := by
+  rw [map_processShift μ hX_meas n, hX.map_shift_iterate_pathLaw hX_meas n]
+
+/-- Prefix laws are unchanged after shifting a contractable process by any finite amount. -/
+theorem Contractable.map_prefixProj_shift_iterate_pathLaw_eq_prefixLaw {μ : Measure Ω}
+    {X : ℕ → Ω → α} [IsFiniteMeasure μ] (hX : Contractable μ X)
+    (hX_meas : ∀ i, AEMeasurable (X i) μ) (n m : ℕ) :
+    ((pathLaw μ X).map ((shift α)^[n])).map (prefixProj α m) = prefixLaw μ X m := by
+  rw [hX.map_shift_iterate_pathLaw hX_meas n,
+    map_prefixProj_pathLaw μ (aemeasurable_pi_lambda _ hX_meas) m]
 
 /-- **An exchangeable process has a shift-invariant path law.** -/
 theorem Exchangeable.measurePreserving_shift {μ : Measure Ω} {X : ℕ → Ω → α}
@@ -65,36 +75,35 @@ theorem Exchangeable.measurePreserving_shift_iterate {μ : Measure Ω} {X : ℕ 
     [IsFiniteMeasure μ] (hX : Exchangeable μ X) (hX_meas : ∀ i, AEMeasurable (X i) μ)
     (n : ℕ) :
     MeasurePreserving ((shift α)^[n]) (pathLaw μ X) (pathLaw μ X) :=
-  (hX.measurePreserving_shift hX_meas).iterate n
+  (hX.contractable hX_meas).measurePreserving_shift_iterate hX_meas n
 
 /-- Iterating the one-sided shift leaves the path law of an exchangeable process unchanged. -/
 theorem Exchangeable.map_shift_iterate_pathLaw {μ : Measure Ω} {X : ℕ → Ω → α}
     [IsFiniteMeasure μ] (hX : Exchangeable μ X) (hX_meas : ∀ i, AEMeasurable (X i) μ)
     (n : ℕ) :
     (pathLaw μ X).map ((shift α)^[n]) = pathLaw μ X :=
-  (hX.measurePreserving_shift_iterate hX_meas n).map_eq
+  (hX.contractable hX_meas).map_shift_iterate_pathLaw hX_meas n
 
 /-- Setwise stationarity for every shift iterate. -/
 theorem Exchangeable.pathLaw_preimage_shift_iterate {μ : Measure Ω} {X : ℕ → Ω → α}
     [IsFiniteMeasure μ] (hX : Exchangeable μ X) (hX_meas : ∀ i, AEMeasurable (X i) μ)
     (n : ℕ) {s : Set (ℕ → α)} (hs : NullMeasurableSet s (pathLaw μ X)) :
     pathLaw μ X (((shift α)^[n]) ⁻¹' s) = pathLaw μ X s :=
-  (hX.measurePreserving_shift_iterate hX_meas n).measure_preimage hs
+  (hX.contractable hX_meas).pathLaw_preimage_shift_iterate hX_meas n hs
 
 /-- The law of the `n`-step shifted process of an exchangeable process is the original path law. -/
 theorem Exchangeable.map_processShift_eq_pathLaw {μ : Measure Ω} {X : ℕ → Ω → α}
     [IsFiniteMeasure μ] (hX : Exchangeable μ X) (hX_meas : ∀ i, AEMeasurable (X i) μ)
     (n : ℕ) :
-    μ.map (processShift X n) = pathLaw μ X := by
-  rw [map_processShift μ hX_meas n, hX.map_shift_iterate_pathLaw hX_meas n]
+    μ.map (processShift X n) = pathLaw μ X :=
+  (hX.contractable hX_meas).map_processShift_eq_pathLaw hX_meas n
 
 /-- Prefix laws are unchanged after shifting an exchangeable process by any finite amount. -/
 theorem Exchangeable.map_prefixProj_shift_iterate_pathLaw_eq_prefixLaw {μ : Measure Ω}
     {X : ℕ → Ω → α} [IsFiniteMeasure μ] (hX : Exchangeable μ X)
     (hX_meas : ∀ i, AEMeasurable (X i) μ) (n m : ℕ) :
-    ((pathLaw μ X).map ((shift α)^[n])).map (prefixProj α m) = prefixLaw μ X m := by
-  rw [hX.map_shift_iterate_pathLaw hX_meas n,
-    map_prefixProj_pathLaw μ (aemeasurable_pi_lambda _ hX_meas) m]
+    ((pathLaw μ X).map ((shift α)^[n])).map (prefixProj α m) = prefixLaw μ X m :=
+  (hX.contractable hX_meas).map_prefixProj_shift_iterate_pathLaw_eq_prefixLaw hX_meas n m
 
 end Probability
 

--- a/TauCeti/Probability/Exchangeability/Stationary.lean
+++ b/TauCeti/Probability/Exchangeability/Stationary.lean
@@ -1,0 +1,121 @@
+module
+
+public import TauCeti.Probability.Exchangeability.Contractability
+public import TauCeti.Probability.Exchangeability.PathSpace.ProcessShift
+
+/-!
+# Exchangeable laws are stationary
+
+This file records the Layer 0 stationarity bridge from the Exchangeability roadmap: a finitely
+exchangeable process has a shift-invariant path law.  The existing implication
+`Exchangeable.contractable` gives the mathematical content; the lemmas here provide the direct
+`Exchangeable`-named API that downstream shift, tail, and ergodic arguments can use without
+manually detouring through contractability.
+
+The bridge is stated for all strictly monotone time reindexings first, then specialized to the
+one-sided shift and its iterates.  The final `processShift` form packages the same invariance at
+the process-law level.
+-/
+
+public section
+
+noncomputable section
+
+open MeasureTheory
+
+namespace TauCeti
+
+namespace Probability
+
+variable {Ω α : Type*} [MeasurableSpace Ω] [MeasurableSpace α]
+
+/-- **Exchangeable laws are invariant under strictly monotone reindexing.**  If `X` is
+exchangeable and its coordinates are a.e.-measurable, then the path-law reindexing
+`x ↦ x ∘ φ` preserves `pathLaw μ X` for every strictly monotone `φ : ℕ → ℕ`. -/
+theorem Exchangeable.measurePreserving_reindex {μ : Measure Ω} {X : ℕ → Ω → α}
+    [IsFiniteMeasure μ] (hX : Exchangeable μ X) (hX_meas : ∀ i, AEMeasurable (X i) μ)
+    {φ : ℕ → ℕ} (hφ : StrictMono φ) :
+    MeasurePreserving (fun x : ℕ → α => fun k => x (φ k)) (pathLaw μ X) (pathLaw μ X) :=
+  (hX.contractable hX_meas).measurePreserving_reindex hX_meas hφ
+
+/-- Reindexing the path law of an exchangeable process by a strictly monotone map leaves it
+unchanged. -/
+theorem Exchangeable.map_reindex_pathLaw {μ : Measure Ω} {X : ℕ → Ω → α}
+    [IsFiniteMeasure μ] (hX : Exchangeable μ X) (hX_meas : ∀ i, AEMeasurable (X i) μ)
+    {φ : ℕ → ℕ} (hφ : StrictMono φ) :
+    (pathLaw μ X).map (fun x : ℕ → α => fun k => x (φ k)) = pathLaw μ X :=
+  (hX.measurePreserving_reindex hX_meas hφ).map_eq
+
+/-- **An exchangeable process has a shift-invariant path law.** -/
+theorem Exchangeable.measurePreserving_shift {μ : Measure Ω} {X : ℕ → Ω → α}
+    [IsFiniteMeasure μ] (hX : Exchangeable μ X) (hX_meas : ∀ i, AEMeasurable (X i) μ) :
+    MeasurePreserving (shift α) (pathLaw μ X) (pathLaw μ X) :=
+  (hX.contractable hX_meas).measurePreserving_shift hX_meas
+
+/-- Shifting the path law of an exchangeable process leaves it unchanged. -/
+theorem Exchangeable.map_shift_pathLaw {μ : Measure Ω} {X : ℕ → Ω → α}
+    [IsFiniteMeasure μ] (hX : Exchangeable μ X) (hX_meas : ∀ i, AEMeasurable (X i) μ) :
+    (pathLaw μ X).map (shift α) = pathLaw μ X :=
+  (hX.measurePreserving_shift hX_meas).map_eq
+
+/-- Every iterate of the one-sided shift preserves the path law of an exchangeable process. -/
+theorem Exchangeable.measurePreserving_shift_iterate {μ : Measure Ω} {X : ℕ → Ω → α}
+    [IsFiniteMeasure μ] (hX : Exchangeable μ X) (hX_meas : ∀ i, AEMeasurable (X i) μ)
+    (n : ℕ) :
+    MeasurePreserving ((shift α)^[n]) (pathLaw μ X) (pathLaw μ X) :=
+  (hX.measurePreserving_shift hX_meas).iterate n
+
+/-- Iterating the one-sided shift leaves the path law of an exchangeable process unchanged. -/
+theorem Exchangeable.map_shift_iterate_pathLaw {μ : Measure Ω} {X : ℕ → Ω → α}
+    [IsFiniteMeasure μ] (hX : Exchangeable μ X) (hX_meas : ∀ i, AEMeasurable (X i) μ)
+    (n : ℕ) :
+    (pathLaw μ X).map ((shift α)^[n]) = pathLaw μ X :=
+  (hX.measurePreserving_shift_iterate hX_meas n).map_eq
+
+/-- Setwise stationarity: a shift preimage has the same path-law mass as the original measurable
+set. -/
+theorem Exchangeable.pathLaw_preimage_shift {μ : Measure Ω} {X : ℕ → Ω → α}
+    [IsFiniteMeasure μ] (hX : Exchangeable μ X) (hX_meas : ∀ i, AEMeasurable (X i) μ)
+    {s : Set (ℕ → α)} (hs : MeasurableSet s) :
+    pathLaw μ X (shift α ⁻¹' s) = pathLaw μ X s :=
+  (hX.measurePreserving_shift hX_meas).measure_preimage hs.nullMeasurableSet
+
+/-- Setwise stationarity for every shift iterate. -/
+theorem Exchangeable.pathLaw_preimage_shift_iterate {μ : Measure Ω} {X : ℕ → Ω → α}
+    [IsFiniteMeasure μ] (hX : Exchangeable μ X) (hX_meas : ∀ i, AEMeasurable (X i) μ)
+    (n : ℕ) {s : Set (ℕ → α)} (hs : MeasurableSet s) :
+    pathLaw μ X (((shift α)^[n]) ⁻¹' s) = pathLaw μ X s :=
+  (hX.measurePreserving_shift_iterate hX_meas n).measure_preimage hs.nullMeasurableSet
+
+/-- The law of the `n`-step shifted process of an exchangeable process is the original path law. -/
+theorem Exchangeable.map_processShift_eq_pathLaw {μ : Measure Ω} {X : ℕ → Ω → α}
+    [IsFiniteMeasure μ] (hX : Exchangeable μ X) (hX_meas : ∀ i, AEMeasurable (X i) μ)
+    (n : ℕ) :
+    μ.map (processShift X n) = pathLaw μ X := by
+  rw [map_processShift μ hX_meas n, hX.map_shift_iterate_pathLaw hX_meas n]
+
+/-- The one-step shifted process of an exchangeable process has the same law as the original
+path. -/
+theorem Exchangeable.map_processShift_one_eq_pathLaw {μ : Measure Ω} {X : ℕ → Ω → α}
+    [IsFiniteMeasure μ] (hX : Exchangeable μ X) (hX_meas : ∀ i, AEMeasurable (X i) μ) :
+    μ.map (processShift X 1) = pathLaw μ X :=
+  hX.map_processShift_eq_pathLaw hX_meas 1
+
+/-- Prefix laws are unchanged after shifting an exchangeable process by any finite amount. -/
+theorem Exchangeable.map_prefixProj_shift_iterate_pathLaw_eq_prefixLaw {μ : Measure Ω}
+    {X : ℕ → Ω → α} [IsFiniteMeasure μ] (hX : Exchangeable μ X)
+    (hX_meas : ∀ i, AEMeasurable (X i) μ) (n m : ℕ) :
+    ((pathLaw μ X).map ((shift α)^[n])).map (prefixProj α m) = prefixLaw μ X m := by
+  rw [hX.map_shift_iterate_pathLaw hX_meas n,
+    map_prefixProj_pathLaw μ (aemeasurable_pi_lambda _ hX_meas) m]
+
+/-- Setwise prefix-law form of exchangeable stationarity after a finite shift. -/
+theorem Exchangeable.map_prefixProj_shift_iterate_pathLaw_apply {μ : Measure Ω}
+    {X : ℕ → Ω → α} [IsFiniteMeasure μ] (hX : Exchangeable μ X)
+    (hX_meas : ∀ i, AEMeasurable (X i) μ) (n m : ℕ) (s : Set (Fin m → α)) :
+    ((pathLaw μ X).map ((shift α)^[n])).map (prefixProj α m) s = prefixLaw μ X m s := by
+  rw [hX.map_prefixProj_shift_iterate_pathLaw_eq_prefixLaw hX_meas n m]
+
+end Probability
+
+end TauCeti


### PR DESCRIPTION
This PR exposes the direct stationarity API for finitely exchangeable processes: an `Exchangeable` process with a finite base law and a.e.-measurable coordinates preserves its path law under the one-sided shift, every shift iterate, and the corresponding finite shifted-process laws. It advances `TauCetiRoadmap/Exchangeability/README.md`, Layer 0, specifically the item “exchangeable laws are stationary,” together with the process-level/path-law bridge API around shift arguments.

I chose this as the lowest-hanging distinct Exchangeability target after checking open and recently merged PRs: the reverse-martingale convergence stack and related prerequisites are already open, while `main` had the stationarity theorem only through `Contractable.measurePreserving_shift` and `FullyExchangeable.measurePreserving_shift`, not as the direct `Exchangeable`-named arrow promised by the roadmap. The new module keeps the proof surface small by reusing the existing `Exchangeable.contractable` bridge and `Contractable.measurePreserving_shift`/`measurePreserving_reindex` infrastructure.

No Mathlib infrastructure is vendored. The implementation reuses Tau Ceti’s existing finite-dimensional exchangeability-to-contractability theorem, path-space shift API, `processShift`, and Mathlib’s `MeasurePreserving.iterate` and `measure_preimage` API.

`lake exe cache get` completed with `No files to download` and `Already decompressed 8609 file(s)`. `lake build` completed with `Build completed successfully (4510 jobs).` `lake exe axioms` completed with `axioms: audited 7812 TauCeti declaration(s); all within the allowlist [propext, Classical.choice, Quot.sound].`

<!--tauceti-target:v1 {"focus":"Exchangeability","id":"exchangeable-laws-stationary"}-->

🤖 Prepared with Codex
