### PR TITLE
feat: add null-homologous contour API

### DIFF
--- a/TauCeti/Analysis/Contour/NullHomologous.lean
+++ b/TauCeti/Analysis/Contour/NullHomologous.lean
@@ -1,0 +1,150 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Chris Birkbeck
+-/
+module
+
+public import TauCeti.Analysis.Contour.WindingNumber
+
+/-!
+# Basic API for null-homologous contours
+
+The contour-integration roadmap uses `Contour.IsNullHomologous γ a b Ω` as the hypothesis that a
+curve has zero generalized winding number about every point outside the domain `Ω`. This file
+records the elementary set-theoretic API for that predicate: monotonicity in the ambient domain,
+the universal and empty-domain boundary cases, intersections, unions, and replacement by another
+curve with the same winding numbers off the domain.
+
+These lemmas are prerequisites for the homology Cauchy theorem and for the Hungerbühler--Wasem
+generalized residue theorem, where the same cycle is repeatedly viewed inside larger or smaller
+domains and the proof only needs the vanishing of the winding number on the complement.
+
+## Main results
+
+* `Contour.IsNullHomologous.mono` — enlarge the ambient domain.
+* `Contour.IsNullHomologous.inter`, `Contour.isNullHomologous_iInter` — combine null-homology
+  hypotheses by intersecting domains.
+* `Contour.IsNullHomologous.union_left`, `Contour.IsNullHomologous.union_right` — a null-homologous
+  curve remains null-homologous after adjoining any extra part of the domain.
+* `Contour.isNullHomologous_empty_iff`, `Contour.isNullHomologous_univ` — the two boundary cases.
+* `Contour.IsNullHomologous.congr_windingNumber` — replace a curve by another with the same winding
+  numbers outside the domain.
+
+## Provenance
+
+This is routine API around the Hungerbühler--Wasem null-homology condition from the contour
+integration roadmap; no formal source is vendored.
+-/
+
+public section
+
+noncomputable section
+
+namespace TauCeti.Contour
+
+open Set
+
+variable {γ η : ℝ → ℂ} {a b c d : ℝ} {Ω Ω' Ω'' : Set ℂ}
+
+/-- A curve is null-homologous in the whole plane, since there are no exterior points. -/
+theorem isNullHomologous_univ (γ : ℝ → ℂ) (a b : ℝ) :
+    IsNullHomologous γ a b (Set.univ : Set ℂ) := by
+  rw [isNullHomologous_iff]
+  intro w hw
+  simp at hw
+
+/-- Null-homology in the empty set is exactly vanishing of the winding number about every point. -/
+theorem isNullHomologous_empty_iff :
+    IsNullHomologous γ a b (∅ : Set ℂ) ↔ ∀ w, windingNumber γ a b w = 0 := by
+  rw [isNullHomologous_iff]
+  simp
+
+/-- If every winding number vanishes, then the curve is null-homologous in the empty set. -/
+theorem isNullHomologous_empty_of_forall_windingNumber_eq_zero
+    (h : ∀ w, windingNumber γ a b w = 0) :
+    IsNullHomologous γ a b (∅ : Set ℂ) :=
+  isNullHomologous_empty_iff.2 h
+
+/-- A curve null-homologous in the empty set is null-homologous in every set. -/
+theorem IsNullHomologous.of_empty (h : IsNullHomologous γ a b (∅ : Set ℂ)) :
+    IsNullHomologous γ a b Ω := by
+  rw [isNullHomologous_iff] at h ⊢
+  intro w hw
+  exact h w (by simp)
+
+/-- Null-homology is monotone in the ambient domain: enlarging the domain shrinks its complement. -/
+theorem IsNullHomologous.mono (h : IsNullHomologous γ a b Ω) (hΩ : Ω ⊆ Ω') :
+    IsNullHomologous γ a b Ω' := by
+  rw [isNullHomologous_iff] at h ⊢
+  intro w hw
+  exact h w (fun hwΩ => hw (hΩ hwΩ))
+
+/-- A complement-subset form of `Contour.IsNullHomologous.mono`. -/
+theorem IsNullHomologous.mono_compl (h : IsNullHomologous γ a b Ω) (hΩ : Ω'ᶜ ⊆ Ωᶜ) :
+    IsNullHomologous γ a b Ω' := by
+  rw [isNullHomologous_iff] at h ⊢
+  intro w hw
+  exact h w (hΩ hw)
+
+/-- It suffices to prove winding-number vanishing on any set containing the complement of `Ω`. -/
+theorem isNullHomologous_of_compl_subset {E : Set ℂ} (hE : Ωᶜ ⊆ E)
+    (h : ∀ w ∈ E, windingNumber γ a b w = 0) :
+    IsNullHomologous γ a b Ω := by
+  rw [isNullHomologous_iff]
+  intro w hw
+  exact h w (hE hw)
+
+/-- If two curves have the same winding numbers outside `Ω`, null-homology transfers from one to
+the other. This is the replacement principle used by homotopy or decomposition arguments before the
+homology Cauchy theorem. -/
+theorem IsNullHomologous.congr_windingNumber (h : IsNullHomologous γ a b Ω)
+    (hwind : ∀ w ∉ Ω, windingNumber η c d w = windingNumber γ a b w) :
+    IsNullHomologous η c d Ω := by
+  rw [isNullHomologous_iff] at h ⊢
+  intro w hw
+  rw [hwind w hw]
+  exact h w hw
+
+/-- If a curve is null-homologous in `Ω`, then it is null-homologous in `Ω ∪ Ω'`. -/
+theorem IsNullHomologous.union_left (h : IsNullHomologous γ a b Ω) :
+    IsNullHomologous γ a b (Ω ∪ Ω') :=
+  h.mono (subset_union_left)
+
+/-- If a curve is null-homologous in `Ω'`, then it is null-homologous in `Ω ∪ Ω'`. -/
+theorem IsNullHomologous.union_right (h : IsNullHomologous γ a b Ω') :
+    IsNullHomologous γ a b (Ω ∪ Ω') :=
+  h.mono (subset_union_right)
+
+/-- Null-homology in a domain implies null-homology after adjoining two extra pieces. -/
+theorem IsNullHomologous.union_union (h : IsNullHomologous γ a b Ω) :
+    IsNullHomologous γ a b (Ω ∪ Ω' ∪ Ω'') := by
+  exact h.mono (by intro w hw; exact Or.inl (Or.inl hw))
+
+/-- If a curve is null-homologous in each of two domains, it is null-homologous in their
+intersection. -/
+theorem IsNullHomologous.inter (hΩ : IsNullHomologous γ a b Ω)
+    (hΩ' : IsNullHomologous γ a b Ω') :
+    IsNullHomologous γ a b (Ω ∩ Ω') := by
+  rw [isNullHomologous_iff] at hΩ hΩ' ⊢
+  intro w hw
+  by_cases hwΩ : w ∈ Ω
+  · exact hΩ' w (fun hwΩ' => hw ⟨hwΩ, hwΩ'⟩)
+  · exact hΩ w hwΩ
+
+/-- If a curve is null-homologous in every member of an indexed family, then it is
+null-homologous in the intersection of the family. -/
+theorem isNullHomologous_iInter {ι : Sort*} {Ω : ι → Set ℂ}
+    (h : ∀ i, IsNullHomologous γ a b (Ω i)) :
+    IsNullHomologous γ a b (⋂ i, Ω i) := by
+  classical
+  rw [isNullHomologous_iff]
+  intro w hw
+  rw [mem_iInter] at hw
+  push Not at hw
+  obtain ⟨i, hi⟩ := hw
+  exact (isNullHomologous_iff.mp (h i)) w hi
+
+end TauCeti.Contour
+
+end

--- a/TauCeti/Analysis/Contour/NullHomologous.lean
+++ b/TauCeti/Analysis/Contour/NullHomologous.lean
@@ -26,7 +26,7 @@ domains and the proof only needs the vanishing of the winding number on the comp
 * `Contour.IsNullHomologous.inter`, `Contour.isNullHomologous_iInter` — combine null-homology
   hypotheses by intersecting domains.
 * `Contour.IsNullHomologous.union_left`, `Contour.IsNullHomologous.union_right` — a null-homologous
-  curve remains null-homologous after adjoining any extra part of the domain.
+  curve remains null-homologous after adjoining an extra part of the domain.
 * `Contour.isNullHomologous_empty_iff`, `Contour.isNullHomologous_univ` — the two boundary cases.
 * `Contour.IsNullHomologous.congr_windingNumber` — replace a curve by another with the same winding
   numbers outside the domain.
@@ -45,9 +45,10 @@ namespace TauCeti.Contour
 
 open Set
 
-variable {γ η : ℝ → ℂ} {a b c d : ℝ} {Ω Ω' Ω'' : Set ℂ}
+variable {γ η : ℝ → ℂ} {a b c d : ℝ} {Ω Ω' : Set ℂ}
 
 /-- A curve is null-homologous in the whole plane, since there are no exterior points. -/
+@[simp]
 theorem isNullHomologous_univ (γ : ℝ → ℂ) (a b : ℝ) :
     IsNullHomologous γ a b (Set.univ : Set ℂ) := by
   rw [isNullHomologous_iff]
@@ -55,6 +56,7 @@ theorem isNullHomologous_univ (γ : ℝ → ℂ) (a b : ℝ) :
   simp at hw
 
 /-- Null-homology in the empty set is exactly vanishing of the winding number about every point. -/
+@[simp]
 theorem isNullHomologous_empty_iff :
     IsNullHomologous γ a b (∅ : Set ℂ) ↔ ∀ w, windingNumber γ a b w = 0 := by
   rw [isNullHomologous_iff]
@@ -115,11 +117,6 @@ theorem IsNullHomologous.union_left (h : IsNullHomologous γ a b Ω) :
 theorem IsNullHomologous.union_right (h : IsNullHomologous γ a b Ω') :
     IsNullHomologous γ a b (Ω ∪ Ω') :=
   h.mono (subset_union_right)
-
-/-- Null-homology in a domain implies null-homology after adjoining two extra pieces. -/
-theorem IsNullHomologous.union_union (h : IsNullHomologous γ a b Ω) :
-    IsNullHomologous γ a b (Ω ∪ Ω' ∪ Ω'') := by
-  exact h.mono (by intro w hw; exact Or.inl (Or.inl hw))
 
 /-- If a curve is null-homologous in each of two domains, it is null-homologous in their
 intersection. -/

--- a/TauCeti/Analysis/Contour/NullHomologous.lean
+++ b/TauCeti/Analysis/Contour/NullHomologous.lean
@@ -68,13 +68,6 @@ theorem isNullHomologous_empty_of_forall_windingNumber_eq_zero
     IsNullHomologous γ a b (∅ : Set ℂ) :=
   isNullHomologous_empty_iff.2 h
 
-/-- A curve null-homologous in the empty set is null-homologous in every set. -/
-theorem IsNullHomologous.of_empty (h : IsNullHomologous γ a b (∅ : Set ℂ)) :
-    IsNullHomologous γ a b Ω := by
-  rw [isNullHomologous_iff] at h ⊢
-  intro w hw
-  exact h w (by simp)
-
 /-- Null-homology is monotone in the ambient domain: enlarging the domain shrinks its complement. -/
 theorem IsNullHomologous.mono (h : IsNullHomologous γ a b Ω) (hΩ : Ω ⊆ Ω') :
     IsNullHomologous γ a b Ω' := by
@@ -82,12 +75,15 @@ theorem IsNullHomologous.mono (h : IsNullHomologous γ a b Ω) (hΩ : Ω ⊆ Ω'
   intro w hw
   exact h w (fun hwΩ => hw (hΩ hwΩ))
 
+/-- A curve null-homologous in the empty set is null-homologous in every set. -/
+theorem IsNullHomologous.of_empty (h : IsNullHomologous γ a b (∅ : Set ℂ)) :
+    IsNullHomologous γ a b Ω :=
+  h.mono (empty_subset Ω)
+
 /-- A complement-subset form of `Contour.IsNullHomologous.mono`. -/
 theorem IsNullHomologous.mono_compl (h : IsNullHomologous γ a b Ω) (hΩ : Ω'ᶜ ⊆ Ωᶜ) :
-    IsNullHomologous γ a b Ω' := by
-  rw [isNullHomologous_iff] at h ⊢
-  intro w hw
-  exact h w (hΩ hw)
+    IsNullHomologous γ a b Ω' :=
+  h.mono (Set.compl_subset_compl.mp hΩ)
 
 /-- It suffices to prove winding-number vanishing on any set containing the complement of `Ω`. -/
 theorem isNullHomologous_of_compl_subset {E : Set ℂ} (hE : Ωᶜ ⊆ E)


### PR DESCRIPTION
This PR adds the basic set-theoretic API for `TauCeti.Contour.IsNullHomologous`: monotonicity under enlarging the ambient domain, empty and universal domain boundary cases, complement-subset introduction, union and intersection lemmas, indexed intersections, and transfer across curves with the same winding numbers outside the domain. It advances `TauCetiRoadmap/ContourIntegration/README.md`, Layer 0, “The classical case `z₀ ∉ C` … homotopy-invariant in `ℂ ∖ C`, and `0` on the unbounded component,” together with Layer 3, “The homology form of Cauchy's theorem,” where null-homology is the named hypothesis `n_w(C) = 0` for every `w ∉ Ω`.

I chose this as the lowest-hanging distinct ContourIntegration prerequisite after checking open and recently merged PRs: the pointwise Cauchy principal value and generalized winding number are already on `main`, while two open ContourIntegration PRs cover the model-sector winding computations. This PR stays below those computations and supplies the small reusable API needed to move the same null-homology hypothesis across larger domains, intersections, and curve replacements in the later homology Cauchy and Hungerbühler--Wasem residue theorem proofs.

No Mathlib infrastructure is vendored. The implementation reuses the existing Tau Ceti `TauCeti.Contour.IsNullHomologous`, `isNullHomologous_iff`, and `windingNumber` API; the proofs are elementary set/complement reasoning.

`lake exe cache get` completed with `No files to download` and `Already decompressed 8609 file(s)`. `lake build` completed with `Build completed successfully (4513 jobs).` `lake exe axioms` completed with `axioms: audited 7865 TauCeti declaration(s); all within the allowlist [propext, Classical.choice, Quot.sound].`

<!--tauceti-target:v1 {"focus":"ContourIntegration","id":"is-null-homologous-basic-api"}-->

🤖 Prepared with Codex
