### PR TITLE
feat: add energy integrand measurability

### DIFF
--- a/TauCeti/Analysis/PDE/EnergyFormMeasurability.lean
+++ b/TauCeti/Analysis/PDE/EnergyFormMeasurability.lean
@@ -1,0 +1,103 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+module
+
+public import TauCeti.Analysis.PDE.EnergyFormContinuity
+public import Mathlib.MeasureTheory.Function.StronglyMeasurable.Lemmas
+
+/-!
+# Measurability of pointwise PDE energy integrands
+
+The weak-form lane of the PDE roadmap is stated for bounded measurable coefficients.  Before the
+pointwise jet integrand
+`x ↦ energyIntegrand (a x) (b x) (c x)` can be integrated over a domain, it must be available as a
+strongly measurable field of continuous bilinear forms, and its scalar evaluations on measurable
+jet fields must be a.e. strongly measurable.
+
+This file supplies that finite-dimensional bookkeeping.  It does not introduce a bundled
+bounded-measurable-coefficient predicate; coefficient regularity remains stated inline,
+following the roadmap and Mathlib style.
+
+## Main declarations
+
+* `stronglyMeasurable_energyIntegrand` and `aestronglyMeasurable_energyIntegrand`: measurable
+  coefficient fields give a measurable field of pointwise energy integrands.
+* `stronglyMeasurable_energyIntegrand_apply` and `aestronglyMeasurable_energyIntegrand_apply`:
+  fixed-jet scalar evaluations are measurable.
+* `aestronglyMeasurable_energyIntegrand_apply₂`: a.e. strongly measurable coefficient fields and
+  a.e. strongly measurable jet fields give an a.e. strongly measurable scalar energy density.
+-/
+
+public section
+
+namespace TauCeti
+
+namespace PDE
+
+open MeasureTheory
+
+variable {α n : Type*} [MeasurableSpace α] [Fintype n]
+
+/-- Strongly measurable coefficient fields give a strongly measurable field of pointwise energy
+integrands. -/
+lemma stronglyMeasurable_energyIntegrand {a : α → Matrix n n ℝ} {b : α → EuclideanSpace ℝ n}
+    {c : α → ℝ}
+    (ha : StronglyMeasurable a) (hb : StronglyMeasurable b) (hc : StronglyMeasurable c) :
+    StronglyMeasurable (fun x => PDE.energyIntegrand (a x) (b x) (c x)) :=
+  continuous_energyIntegrand.comp_stronglyMeasurable (ha.prodMk (hb.prodMk hc))
+
+/-- Strongly measurable coefficient fields give strongly measurable scalar evaluations of the
+pointwise energy integrand on fixed jets. -/
+lemma stronglyMeasurable_energyIntegrand_apply {a : α → Matrix n n ℝ}
+    {b : α → EuclideanSpace ℝ n} {c : α → ℝ}
+    (ha : StronglyMeasurable a) (hb : StronglyMeasurable b) (hc : StronglyMeasurable c)
+    (U V : ℝ × EuclideanSpace ℝ n) :
+    StronglyMeasurable (fun x => PDE.energyIntegrand (a x) (b x) (c x) U V) :=
+  StronglyMeasurable.apply_continuousLinearMap
+    (StronglyMeasurable.apply_continuousLinearMap
+      (stronglyMeasurable_energyIntegrand ha hb hc) U) V
+
+variable {μ : MeasureTheory.Measure α}
+
+/-- A.e. strongly measurable coefficient fields give an a.e. strongly measurable field of
+pointwise energy integrands. -/
+lemma aestronglyMeasurable_energyIntegrand {a : α → Matrix n n ℝ}
+    {b : α → EuclideanSpace ℝ n} {c : α → ℝ}
+    (ha : MeasureTheory.AEStronglyMeasurable a μ) (hb : MeasureTheory.AEStronglyMeasurable b μ)
+    (hc : MeasureTheory.AEStronglyMeasurable c μ) :
+    AEStronglyMeasurable (fun x => PDE.energyIntegrand (a x) (b x) (c x)) μ :=
+  continuous_energyIntegrand.comp_aestronglyMeasurable (ha.prodMk (hb.prodMk hc))
+
+/-- A.e. strongly measurable coefficient fields give a.e. strongly measurable scalar evaluations of
+the pointwise energy integrand on fixed jets. -/
+lemma aestronglyMeasurable_energyIntegrand_apply {a : α → Matrix n n ℝ}
+    {b : α → EuclideanSpace ℝ n} {c : α → ℝ}
+    (ha : MeasureTheory.AEStronglyMeasurable a μ) (hb : MeasureTheory.AEStronglyMeasurable b μ)
+    (hc : MeasureTheory.AEStronglyMeasurable c μ) (U V : ℝ × EuclideanSpace ℝ n) :
+    AEStronglyMeasurable (fun x => PDE.energyIntegrand (a x) (b x) (c x) U V) μ :=
+  MeasureTheory.AEStronglyMeasurable.apply_continuousLinearMap
+    (MeasureTheory.AEStronglyMeasurable.apply_continuousLinearMap
+      (aestronglyMeasurable_energyIntegrand ha hb hc) U) V
+
+/-- A.e. strongly measurable coefficient fields and a.e. strongly measurable jet fields give an
+a.e. strongly measurable scalar energy density. -/
+lemma aestronglyMeasurable_energyIntegrand_apply₂ {a : α → Matrix n n ℝ}
+    {b : α → EuclideanSpace ℝ n} {c : α → ℝ} {U V : α → ℝ × EuclideanSpace ℝ n}
+    (ha : MeasureTheory.AEStronglyMeasurable a μ) (hb : MeasureTheory.AEStronglyMeasurable b μ)
+    (hc : MeasureTheory.AEStronglyMeasurable c μ) (hU : MeasureTheory.AEStronglyMeasurable U μ)
+    (hV : MeasureTheory.AEStronglyMeasurable V μ) :
+    AEStronglyMeasurable (fun x => PDE.energyIntegrand (a x) (b x) (c x) (U x) (V x)) μ := by
+  let Jet := ℝ × EuclideanSpace ℝ n
+  have hform : AEStronglyMeasurable (fun x => PDE.energyIntegrand (a x) (b x) (c x)) μ :=
+    aestronglyMeasurable_energyIntegrand ha hb hc
+  have hcont : Continuous (fun p : (Jet →L[ℝ] Jet →L[ℝ] ℝ) × Jet × Jet =>
+      p.1 p.2.1 p.2.2) := by
+    exact (continuous_fst.clm_apply (continuous_fst.comp continuous_snd)).clm_apply
+      (continuous_snd.comp continuous_snd)
+  exact hcont.comp_aestronglyMeasurable (hform.prodMk (hU.prodMk hV))
+
+end PDE
+
+end TauCeti

--- a/TauCeti/Analysis/PDE/EnergyFormMeasurability.lean
+++ b/TauCeti/Analysis/PDE/EnergyFormMeasurability.lean
@@ -24,10 +24,10 @@ following the roadmap and Mathlib style.
 
 * `stronglyMeasurable_energyIntegrand` and `aestronglyMeasurable_energyIntegrand`: measurable
   coefficient fields give a measurable field of pointwise energy integrands.
-* `stronglyMeasurable_energyIntegrand_apply` and `aestronglyMeasurable_energyIntegrand_apply`:
-  fixed-jet scalar evaluations are measurable.
-* `aestronglyMeasurable_energyIntegrand_apply₂`: a.e. strongly measurable coefficient fields and
-  a.e. strongly measurable jet fields give an a.e. strongly measurable scalar energy density.
+* `stronglyMeasurable_energyIntegrand_apply`, `stronglyMeasurable_energyIntegrand_apply₂`,
+  `aestronglyMeasurable_energyIntegrand_apply`, and
+  `aestronglyMeasurable_energyIntegrand_apply₂`: scalar evaluations on fixed or measurable jet
+  fields are measurable.
 -/
 
 public section
@@ -48,6 +48,22 @@ lemma stronglyMeasurable_energyIntegrand {a : α → Matrix n n ℝ} {b : α →
     StronglyMeasurable (fun x => PDE.energyIntegrand (a x) (b x) (c x)) :=
   continuous_energyIntegrand.comp_stronglyMeasurable (ha.prodMk (hb.prodMk hc))
 
+/-- Strongly measurable coefficient fields and strongly measurable jet fields give a strongly
+measurable scalar energy density. -/
+lemma stronglyMeasurable_energyIntegrand_apply₂ {a : α → Matrix n n ℝ}
+    {b : α → EuclideanSpace ℝ n} {c : α → ℝ} {U V : α → ℝ × EuclideanSpace ℝ n}
+    (ha : StronglyMeasurable a) (hb : StronglyMeasurable b) (hc : StronglyMeasurable c)
+    (hU : StronglyMeasurable U) (hV : StronglyMeasurable V) :
+    StronglyMeasurable (fun x => PDE.energyIntegrand (a x) (b x) (c x) (U x) (V x)) := by
+  let Jet := ℝ × EuclideanSpace ℝ n
+  have hform : StronglyMeasurable (fun x => PDE.energyIntegrand (a x) (b x) (c x)) :=
+    stronglyMeasurable_energyIntegrand ha hb hc
+  have hcont : Continuous (fun p : (Jet →L[ℝ] Jet →L[ℝ] ℝ) × Jet × Jet =>
+      p.1 p.2.1 p.2.2) := by
+    exact (continuous_fst.clm_apply (continuous_fst.comp continuous_snd)).clm_apply
+      (continuous_snd.comp continuous_snd)
+  exact hcont.comp_stronglyMeasurable (hform.prodMk (hU.prodMk hV))
+
 /-- Strongly measurable coefficient fields give strongly measurable scalar evaluations of the
 pointwise energy integrand on fixed jets. -/
 lemma stronglyMeasurable_energyIntegrand_apply {a : α → Matrix n n ℝ}
@@ -55,9 +71,8 @@ lemma stronglyMeasurable_energyIntegrand_apply {a : α → Matrix n n ℝ}
     (ha : StronglyMeasurable a) (hb : StronglyMeasurable b) (hc : StronglyMeasurable c)
     (U V : ℝ × EuclideanSpace ℝ n) :
     StronglyMeasurable (fun x => PDE.energyIntegrand (a x) (b x) (c x) U V) :=
-  StronglyMeasurable.apply_continuousLinearMap
-    (StronglyMeasurable.apply_continuousLinearMap
-      (stronglyMeasurable_energyIntegrand ha hb hc) U) V
+  stronglyMeasurable_energyIntegrand_apply₂ ha hb hc stronglyMeasurable_const
+    stronglyMeasurable_const
 
 variable {μ : MeasureTheory.Measure α}
 


### PR DESCRIPTION
This PR adds strong and a.e. strong measurability API for the pointwise divergence-form energy integrand, so measurable coefficient fields produce measurable fields of continuous bilinear jet forms and measurable scalar energy densities after applying measurable jet fields. It advances `TauCetiRoadmap/PDE/README.md`, Lane D item 16, “Weak formulation,” specifically the bounded-measurable-coefficient prerequisite for forming the integrated weak energy form from `x ↦ energyIntegrand (a x) (b x) (c x)`.

I chose this as the lowest-hanging distinct PDE target after checking open and recently merged PRs: the current open PDE work covers coefficient continuity for energy integrands, while existing merged PDE files already define uniform ellipticity, lower-order pointwise forms, energy-integrand linearity, continuity, boundedness, symmetry, and coercivity. This PR supplies the parallel measurable-coefficient handoff required by the roadmap’s bounded measurable Lane D hypotheses, without starting the still-missing domain Sobolev-space or integrated weak-form construction.

No Mathlib infrastructure is vendored. The implementation reuses Tau Ceti’s existing `energyIntegrandLinear` / `continuous_energyIntegrand` API and Mathlib’s `StronglyMeasurable`, `AEStronglyMeasurable`, product, continuous-composition, and continuous-linear-map application lemmas.

`lake exe cache get` completed with `No files to download` and `Already decompressed 8609 file(s)`. `lake build` completed with `Build completed successfully (4513 jobs).` `lake exe axioms` completed with `axioms: audited 7861 TauCeti declaration(s); all within the allowlist [propext, Classical.choice, Quot.sound].`

<!--tauceti-target:v1 {"focus":"PDE","id":"energy-integrand-measurability"}-->

🤖 Prepared with Codex
