### PR TITLE
feat: add energy density integrability

### DIFF
--- a/TauCeti/Analysis/PDE/EnergyFormIntegrability.lean
+++ b/TauCeti/Analysis/PDE/EnergyFormIntegrability.lean
@@ -14,16 +14,24 @@ The weak-form lane of the PDE roadmap will define the energy bilinear form by in
 pointwise scalar density
 `x ↦ energyIntegrand (a x) (b x) (c x) (U x) (V x)`.  The preceding finite-dimensional files
 give the measurability of this density and the pointwise bound with explicit coefficient
-constants.  This file packages the next handoff: on a finite-measure domain, bounded measurable
-coefficient fields and bounded measurable jet fields produce integrable scalar energy densities.
+constants.  This file packages the next handoff: bounded measurable coefficient fields and
+measurable jet fields whose norm product is integrable produce integrable scalar energy
+densities.  In particular, this applies to square-integrable jet fields, and specializes on
+finite-measure domains to bounded jet fields.
 
 This remains below the Sobolev-space construction.  The coefficient bounds are stated inline,
 matching the roadmap's bounded-measurable-coefficient hypotheses.
 
 ## Main declarations
 
-* `TauCeti.PDE.integrable_energyIntegrand_apply₂_of_bounds`: coefficient bounds and bounded jet
-  fields give scalar-density integrability.
+* `TauCeti.PDE.integrable_energyIntegrand_apply₂_of_integrable_norm_mul`: coefficient bounds and
+  an integrable product of jet norms give scalar-density integrability.
+* `TauCeti.PDE.integrable_norm_mul_of_memLp_two`: square-integrable jet fields have integrable
+  product of norms.
+* `TauCeti.PDE.integrable_energyIntegrand_apply₂_of_memLp_two`: coefficient bounds and
+  square-integrable jet fields give scalar-density integrability.
+* `TauCeti.PDE.integrable_energyIntegrand_apply₂_of_bounds`: the bounded finite-measure
+  specialization.
 * `TauCeti.PDE.integrable_energyIntegrand_apply_of_bounds`: the fixed-jet specialization.
 -/
 
@@ -38,6 +46,63 @@ open scoped InnerProductSpace
 
 variable {α n : Type*} [MeasurableSpace α] [Fintype n]
 variable {μ : Measure α}
+
+/-- Bounded measurable coefficient fields and an integrable product of jet norms give an
+integrable scalar energy density. -/
+lemma integrable_energyIntegrand_apply₂_of_integrable_norm_mul
+    {a : α → Matrix n n ℝ} {b : α → EuclideanSpace ℝ n} {c : α → ℝ}
+    {U V : α → ℝ × EuclideanSpace ℝ n} {Lam beta gamma : ℝ}
+    (hLam : 0 ≤ Lam)
+    (ha : AEStronglyMeasurable a μ) (hb : AEStronglyMeasurable b μ)
+    (hc : AEStronglyMeasurable c μ) (hU : AEStronglyMeasurable U μ)
+    (hV : AEStronglyMeasurable V μ)
+    (ha_bound : ∀ᵐ x ∂μ, ∀ η ξ : EuclideanSpace ℝ n,
+      |η ⬝ᵥ (a x *ᵥ ξ)| ≤ Lam * ‖η‖ * ‖ξ‖)
+    (hb_bound : ∀ᵐ x ∂μ, ‖b x‖ ≤ beta)
+    (hc_bound : ∀ᵐ x ∂μ, ‖c x‖ ≤ gamma)
+    (hUV : Integrable (fun x => ‖U x‖ * ‖V x‖) μ) :
+    Integrable (fun x => energyIntegrand (a x) (b x) (c x) (U x) (V x)) μ := by
+  refine (hUV.const_mul (Lam + beta + gamma)).mono'
+    (aestronglyMeasurable_energyIntegrand_apply₂ ha hb hc hU hV) ?_
+  filter_upwards [ha_bound, hb_bound, hc_bound] with x hA hb₀ hc₀
+  simpa [mul_assoc] using norm_energyIntegrand_apply_le_of_bounds hLam hA hb₀ hc₀ (U x) (V x)
+
+/-- Square-integrable jet fields have integrable product of norms. -/
+lemma integrable_norm_mul_of_memLp_two
+    {U V : α → ℝ × EuclideanSpace ℝ n} (hU : MemLp U 2 μ) (hV : MemLp V 2 μ) :
+    Integrable (fun x => ‖U x‖ * ‖V x‖) μ := by
+  have hU₂ : Integrable (fun x => ‖U x‖ ^ 2) μ := by
+    simpa [ENNReal.toReal_ofNat] using
+      hU.integrable_norm_rpow (by norm_num : (2 : ENNReal) ≠ 0)
+        (by norm_num : (2 : ENNReal) ≠ ⊤)
+  have hV₂ : Integrable (fun x => ‖V x‖ ^ 2) μ := by
+    simpa [ENNReal.toReal_ofNat] using
+      hV.integrable_norm_rpow (by norm_num : (2 : ENNReal) ≠ 0)
+        (by norm_num : (2 : ENNReal) ≠ ⊤)
+  refine ((hU₂.add hV₂).const_mul (1 / 2)).mono' (hU.aestronglyMeasurable.norm.mul
+    hV.aestronglyMeasurable.norm) ?_
+  filter_upwards with x
+  rw [Real.norm_of_nonneg (mul_nonneg (norm_nonneg _) (norm_nonneg _))]
+  change ‖U x‖ * ‖V x‖ ≤ (1 / 2) * (‖U x‖ ^ 2 + ‖V x‖ ^ 2)
+  have htwo := two_mul_le_add_sq ‖U x‖ ‖V x‖
+  nlinarith
+
+/-- Bounded measurable coefficient fields and square-integrable jet fields give an integrable
+scalar energy density. -/
+lemma integrable_energyIntegrand_apply₂_of_memLp_two
+    {a : α → Matrix n n ℝ} {b : α → EuclideanSpace ℝ n} {c : α → ℝ}
+    {U V : α → ℝ × EuclideanSpace ℝ n} {Lam beta gamma : ℝ}
+    (hLam : 0 ≤ Lam)
+    (ha : AEStronglyMeasurable a μ) (hb : AEStronglyMeasurable b μ)
+    (hc : AEStronglyMeasurable c μ) (hU : MemLp U 2 μ) (hV : MemLp V 2 μ)
+    (ha_bound : ∀ᵐ x ∂μ, ∀ η ξ : EuclideanSpace ℝ n,
+      |η ⬝ᵥ (a x *ᵥ ξ)| ≤ Lam * ‖η‖ * ‖ξ‖)
+    (hb_bound : ∀ᵐ x ∂μ, ‖b x‖ ≤ beta)
+    (hc_bound : ∀ᵐ x ∂μ, ‖c x‖ ≤ gamma) :
+    Integrable (fun x => energyIntegrand (a x) (b x) (c x) (U x) (V x)) μ :=
+  integrable_energyIntegrand_apply₂_of_integrable_norm_mul hLam ha hb hc
+    hU.aestronglyMeasurable hV.aestronglyMeasurable ha_bound hb_bound hc_bound
+    (integrable_norm_mul_of_memLp_two hU hV)
 
 /-- Bounded measurable coefficient fields and bounded measurable jet fields give an integrable
 scalar energy density on a finite-measure space. -/
@@ -55,22 +120,13 @@ lemma integrable_energyIntegrand_apply₂_of_bounds [IsFiniteMeasure μ]
     (hU_bound : ∀ᵐ x ∂μ, ‖U x‖ ≤ R)
     (hV_bound : ∀ᵐ x ∂μ, ‖V x‖ ≤ S) :
     Integrable (fun x => energyIntegrand (a x) (b x) (c x) (U x) (V x)) μ := by
-  refine Integrable.of_bound (aestronglyMeasurable_energyIntegrand_apply₂ ha hb hc hU hV)
-    ((Lam + beta + gamma) * R * S) ?_
-  filter_upwards [ha_bound, hb_bound, hc_bound, hU_bound, hV_bound] with x hA hb₀ hc₀ hUx hVx
-  have hbase := norm_energyIntegrand_apply_le_of_bounds hLam hA hb₀ hc₀ (U x) (V x)
-  have hbeta : 0 ≤ beta := (norm_nonneg (b x)).trans hb₀
-  have hgamma : 0 ≤ gamma := (norm_nonneg (c x)).trans hc₀
-  have hK : 0 ≤ Lam + beta + gamma := add_nonneg (add_nonneg hLam hbeta) hgamma
+  refine integrable_energyIntegrand_apply₂_of_integrable_norm_mul hLam ha hb hc hU hV ha_bound
+    hb_bound hc_bound ?_
+  refine Integrable.of_bound (hU.norm.mul hV.norm) (R * S) ?_
+  filter_upwards [hU_bound, hV_bound] with x hUx hVx
+  rw [Real.norm_of_nonneg (mul_nonneg (norm_nonneg _) (norm_nonneg _))]
   have hR : 0 ≤ R := (norm_nonneg (U x)).trans hUx
-  calc
-    ‖energyIntegrand (a x) (b x) (c x) (U x) (V x)‖
-        ≤ (Lam + beta + gamma) * ‖U x‖ * ‖V x‖ := hbase
-    _ ≤ (Lam + beta + gamma) * R * S :=
-      by
-        simpa [mul_assoc] using
-          mul_le_mul_of_nonneg_left
-            (mul_le_mul hUx hVx (norm_nonneg (V x)) hR) hK
+  exact mul_le_mul hUx hVx (norm_nonneg (V x)) hR
 
 /-- Fixed-jet specialization of `integrable_energyIntegrand_apply₂_of_bounds`. -/
 lemma integrable_energyIntegrand_apply_of_bounds [IsFiniteMeasure μ]

--- a/TauCeti/Analysis/PDE/EnergyFormIntegrability.lean
+++ b/TauCeti/Analysis/PDE/EnergyFormIntegrability.lean
@@ -22,8 +22,6 @@ matching the roadmap's bounded-measurable-coefficient hypotheses.
 
 ## Main declarations
 
-* `TauCeti.PDE.integrable_energyIntegrand_apply₂_of_bound`: a scalar energy density is integrable
-  when it is a.e. bounded.
 * `TauCeti.PDE.integrable_energyIntegrand_apply₂_of_bounds`: coefficient bounds and bounded jet
   fields give scalar-density integrability.
 * `TauCeti.PDE.integrable_energyIntegrand_apply_of_bounds`: the fixed-jet specialization.
@@ -41,17 +39,6 @@ open scoped InnerProductSpace
 variable {α n : Type*} [MeasurableSpace α] [Fintype n]
 variable {μ : Measure α}
 
-/-- A measurable scalar energy density is integrable on a finite-measure space when it is a.e.
-bounded. -/
-lemma integrable_energyIntegrand_apply₂_of_bound [IsFiniteMeasure μ] {a : α → Matrix n n ℝ}
-    {b : α → EuclideanSpace ℝ n} {c : α → ℝ} {U V : α → ℝ × EuclideanSpace ℝ n}
-    (ha : AEStronglyMeasurable a μ) (hb : AEStronglyMeasurable b μ)
-    (hc : AEStronglyMeasurable c μ) (hU : AEStronglyMeasurable U μ)
-    (hV : AEStronglyMeasurable V μ) (C : ℝ)
-    (hC : ∀ᵐ x ∂μ, ‖energyIntegrand (a x) (b x) (c x) (U x) (V x)‖ ≤ C) :
-    Integrable (fun x => energyIntegrand (a x) (b x) (c x) (U x) (V x)) μ :=
-  Integrable.of_bound (aestronglyMeasurable_energyIntegrand_apply₂ ha hb hc hU hV) C hC
-
 /-- Bounded measurable coefficient fields and bounded measurable jet fields give an integrable
 scalar energy density on a finite-measure space. -/
 lemma integrable_energyIntegrand_apply₂_of_bounds [IsFiniteMeasure μ]
@@ -68,7 +55,7 @@ lemma integrable_energyIntegrand_apply₂_of_bounds [IsFiniteMeasure μ]
     (hU_bound : ∀ᵐ x ∂μ, ‖U x‖ ≤ R)
     (hV_bound : ∀ᵐ x ∂μ, ‖V x‖ ≤ S) :
     Integrable (fun x => energyIntegrand (a x) (b x) (c x) (U x) (V x)) μ := by
-  refine integrable_energyIntegrand_apply₂_of_bound ha hb hc hU hV
+  refine Integrable.of_bound (aestronglyMeasurable_energyIntegrand_apply₂ ha hb hc hU hV)
     ((Lam + beta + gamma) * R * S) ?_
   filter_upwards [ha_bound, hb_bound, hc_bound, hU_bound, hV_bound] with x hA hb₀ hc₀ hUx hVx
   have hbase := norm_energyIntegrand_apply_le_of_bounds hLam hA hb₀ hc₀ (U x) (V x)

--- a/TauCeti/Analysis/PDE/EnergyFormIntegrability.lean
+++ b/TauCeti/Analysis/PDE/EnergyFormIntegrability.lean
@@ -1,0 +1,108 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+module
+
+public import TauCeti.Analysis.PDE.EnergyFormMeasurability
+public import Mathlib.MeasureTheory.Integral.IntegrableOn
+
+/-!
+# Integrability of pointwise PDE energy densities
+
+The weak-form lane of the PDE roadmap will define the energy bilinear form by integrating the
+pointwise scalar density
+`x ↦ energyIntegrand (a x) (b x) (c x) (U x) (V x)`.  The preceding finite-dimensional files
+give the measurability of this density and the pointwise bound with explicit coefficient
+constants.  This file packages the next handoff: on a finite-measure domain, bounded measurable
+coefficient fields and bounded measurable jet fields produce integrable scalar energy densities.
+
+This remains below the Sobolev-space construction.  The coefficient bounds are stated inline,
+matching the roadmap's bounded-measurable-coefficient hypotheses.
+
+## Main declarations
+
+* `TauCeti.PDE.integrable_energyIntegrand_apply₂_of_bound`: a scalar energy density is integrable
+  when it is a.e. bounded.
+* `TauCeti.PDE.integrable_energyIntegrand_apply₂_of_bounds`: coefficient bounds and bounded jet
+  fields give scalar-density integrability.
+* `TauCeti.PDE.integrable_energyIntegrand_apply_of_bounds`: the fixed-jet specialization.
+-/
+
+public section
+
+namespace TauCeti
+
+namespace PDE
+
+open Matrix MeasureTheory
+open scoped InnerProductSpace
+
+variable {α n : Type*} [MeasurableSpace α] [Fintype n]
+variable {μ : Measure α}
+
+/-- A measurable scalar energy density is integrable on a finite-measure space when it is a.e.
+bounded. -/
+lemma integrable_energyIntegrand_apply₂_of_bound [IsFiniteMeasure μ] {a : α → Matrix n n ℝ}
+    {b : α → EuclideanSpace ℝ n} {c : α → ℝ} {U V : α → ℝ × EuclideanSpace ℝ n}
+    (ha : AEStronglyMeasurable a μ) (hb : AEStronglyMeasurable b μ)
+    (hc : AEStronglyMeasurable c μ) (hU : AEStronglyMeasurable U μ)
+    (hV : AEStronglyMeasurable V μ) (C : ℝ)
+    (hC : ∀ᵐ x ∂μ, ‖energyIntegrand (a x) (b x) (c x) (U x) (V x)‖ ≤ C) :
+    Integrable (fun x => energyIntegrand (a x) (b x) (c x) (U x) (V x)) μ :=
+  Integrable.of_bound (aestronglyMeasurable_energyIntegrand_apply₂ ha hb hc hU hV) C hC
+
+/-- Bounded measurable coefficient fields and bounded measurable jet fields give an integrable
+scalar energy density on a finite-measure space. -/
+lemma integrable_energyIntegrand_apply₂_of_bounds [IsFiniteMeasure μ]
+    {a : α → Matrix n n ℝ} {b : α → EuclideanSpace ℝ n} {c : α → ℝ}
+    {U V : α → ℝ × EuclideanSpace ℝ n} {Lam beta gamma R S : ℝ}
+    (hLam : 0 ≤ Lam)
+    (ha : AEStronglyMeasurable a μ) (hb : AEStronglyMeasurable b μ)
+    (hc : AEStronglyMeasurable c μ) (hU : AEStronglyMeasurable U μ)
+    (hV : AEStronglyMeasurable V μ)
+    (ha_bound : ∀ᵐ x ∂μ, ∀ η ξ : EuclideanSpace ℝ n,
+      |η ⬝ᵥ (a x *ᵥ ξ)| ≤ Lam * ‖η‖ * ‖ξ‖)
+    (hb_bound : ∀ᵐ x ∂μ, ‖b x‖ ≤ beta)
+    (hc_bound : ∀ᵐ x ∂μ, ‖c x‖ ≤ gamma)
+    (hU_bound : ∀ᵐ x ∂μ, ‖U x‖ ≤ R)
+    (hV_bound : ∀ᵐ x ∂μ, ‖V x‖ ≤ S) :
+    Integrable (fun x => energyIntegrand (a x) (b x) (c x) (U x) (V x)) μ := by
+  refine integrable_energyIntegrand_apply₂_of_bound ha hb hc hU hV
+    ((Lam + beta + gamma) * R * S) ?_
+  filter_upwards [ha_bound, hb_bound, hc_bound, hU_bound, hV_bound] with x hA hb₀ hc₀ hUx hVx
+  have hbase := norm_energyIntegrand_apply_le_of_bounds hLam hA hb₀ hc₀ (U x) (V x)
+  have hbeta : 0 ≤ beta := (norm_nonneg (b x)).trans hb₀
+  have hgamma : 0 ≤ gamma := (norm_nonneg (c x)).trans hc₀
+  have hK : 0 ≤ Lam + beta + gamma := add_nonneg (add_nonneg hLam hbeta) hgamma
+  have hR : 0 ≤ R := (norm_nonneg (U x)).trans hUx
+  calc
+    ‖energyIntegrand (a x) (b x) (c x) (U x) (V x)‖
+        ≤ (Lam + beta + gamma) * ‖U x‖ * ‖V x‖ := hbase
+    _ ≤ (Lam + beta + gamma) * R * S :=
+      by
+        simpa [mul_assoc] using
+          mul_le_mul_of_nonneg_left
+            (mul_le_mul hUx hVx (norm_nonneg (V x)) hR) hK
+
+/-- Fixed-jet specialization of `integrable_energyIntegrand_apply₂_of_bounds`. -/
+lemma integrable_energyIntegrand_apply_of_bounds [IsFiniteMeasure μ]
+    {a : α → Matrix n n ℝ} {b : α → EuclideanSpace ℝ n} {c : α → ℝ}
+    {Lam beta gamma : ℝ}
+    (hLam : 0 ≤ Lam)
+    (ha : AEStronglyMeasurable a μ) (hb : AEStronglyMeasurable b μ)
+    (hc : AEStronglyMeasurable c μ)
+    (ha_bound : ∀ᵐ x ∂μ, ∀ η ξ : EuclideanSpace ℝ n,
+      |η ⬝ᵥ (a x *ᵥ ξ)| ≤ Lam * ‖η‖ * ‖ξ‖)
+    (hb_bound : ∀ᵐ x ∂μ, ‖b x‖ ≤ beta)
+    (hc_bound : ∀ᵐ x ∂μ, ‖c x‖ ≤ gamma)
+    (U V : ℝ × EuclideanSpace ℝ n) :
+    Integrable (fun x => energyIntegrand (a x) (b x) (c x) U V) μ :=
+  integrable_energyIntegrand_apply₂_of_bounds (U := fun _ => U) (V := fun _ => V)
+    hLam ha hb hc aestronglyMeasurable_const aestronglyMeasurable_const
+    ha_bound hb_bound hc_bound (Filter.Eventually.of_forall fun _ => le_rfl)
+    (Filter.Eventually.of_forall fun _ => le_rfl)
+
+end PDE
+
+end TauCeti

--- a/TauCeti/Analysis/PDE/EnergyFormIntegrability.lean
+++ b/TauCeti/Analysis/PDE/EnergyFormIntegrability.lean
@@ -26,8 +26,6 @@ matching the roadmap's bounded-measurable-coefficient hypotheses.
 
 * `TauCeti.PDE.integrable_energyIntegrand_apply₂_of_integrable_norm_mul`: coefficient bounds and
   an integrable product of jet norms give scalar-density integrability.
-* `TauCeti.PDE.integrable_norm_mul_of_memLp_two`: square-integrable jet fields have integrable
-  product of norms.
 * `TauCeti.PDE.integrable_energyIntegrand_apply₂_of_memLp_two`: coefficient bounds and
   square-integrable jet fields give scalar-density integrability.
 * `TauCeti.PDE.integrable_energyIntegrand_apply₂_of_bounds`: the bounded finite-measure
@@ -67,26 +65,6 @@ lemma integrable_energyIntegrand_apply₂_of_integrable_norm_mul
   filter_upwards [ha_bound, hb_bound, hc_bound] with x hA hb₀ hc₀
   simpa [mul_assoc] using norm_energyIntegrand_apply_le_of_bounds hLam hA hb₀ hc₀ (U x) (V x)
 
-/-- Square-integrable jet fields have integrable product of norms. -/
-lemma integrable_norm_mul_of_memLp_two
-    {U V : α → ℝ × EuclideanSpace ℝ n} (hU : MemLp U 2 μ) (hV : MemLp V 2 μ) :
-    Integrable (fun x => ‖U x‖ * ‖V x‖) μ := by
-  have hU₂ : Integrable (fun x => ‖U x‖ ^ 2) μ := by
-    simpa [ENNReal.toReal_ofNat] using
-      hU.integrable_norm_rpow (by norm_num : (2 : ENNReal) ≠ 0)
-        (by norm_num : (2 : ENNReal) ≠ ⊤)
-  have hV₂ : Integrable (fun x => ‖V x‖ ^ 2) μ := by
-    simpa [ENNReal.toReal_ofNat] using
-      hV.integrable_norm_rpow (by norm_num : (2 : ENNReal) ≠ 0)
-        (by norm_num : (2 : ENNReal) ≠ ⊤)
-  refine ((hU₂.add hV₂).const_mul (1 / 2)).mono' (hU.aestronglyMeasurable.norm.mul
-    hV.aestronglyMeasurable.norm) ?_
-  filter_upwards with x
-  rw [Real.norm_of_nonneg (mul_nonneg (norm_nonneg _) (norm_nonneg _))]
-  change ‖U x‖ * ‖V x‖ ≤ (1 / 2) * (‖U x‖ ^ 2 + ‖V x‖ ^ 2)
-  have htwo := two_mul_le_add_sq ‖U x‖ ‖V x‖
-  nlinarith
-
 /-- Bounded measurable coefficient fields and square-integrable jet fields give an integrable
 scalar energy density. -/
 lemma integrable_energyIntegrand_apply₂_of_memLp_two
@@ -102,7 +80,12 @@ lemma integrable_energyIntegrand_apply₂_of_memLp_two
     Integrable (fun x => energyIntegrand (a x) (b x) (c x) (U x) (V x)) μ :=
   integrable_energyIntegrand_apply₂_of_integrable_norm_mul hLam ha hb hc
     hU.aestronglyMeasurable hV.aestronglyMeasurable ha_bound hb_bound hc_bound
-    (integrable_norm_mul_of_memLp_two hU hV)
+    (by
+      convert
+        (hU.norm.integrable_mul hV.norm :
+          Integrable ((fun x => ‖U x‖) * fun x => ‖V x‖) μ) using 1
+      ext x
+      rw [Pi.mul_apply])
 
 /-- Bounded measurable coefficient fields and bounded measurable jet fields give an integrable
 scalar energy density on a finite-measure space. -/


### PR DESCRIPTION
This PR packages finite-measure integrability for the pointwise scalar PDE energy density: if the coefficient fields are a.e. strongly measurable and satisfy the standard explicit bounds, and the two jet fields are a.e. strongly measurable and a.e. bounded, then `x ↦ energyIntegrand (a x) (b x) (c x) (U x) (V x)` is integrable. It advances `TauCetiRoadmap/PDE/README.md`, Lane D item 16, “Weak formulation,” as the bounded-measurable-coefficient handoff needed before the integrated weak energy form `a(u,v) = ∫ energyIntegrand ...` can be defined on the later Sobolev space.

I chose this as the lowest-hanging distinct PDE target after checking open and recently merged PRs: uniform ellipticity, pointwise energy integrands, pointwise boundedness and Gårding estimates, continuity, and a.e. strong measurability are already on `main`, while this PR supplies the next scalar integrability step without starting the still-missing domain Sobolev-space construction or the integrated bilinear form.

No Mathlib infrastructure is vendored. The implementation reuses Tau Ceti’s existing `aestronglyMeasurable_energyIntegrand_apply₂` and `norm_energyIntegrand_apply_le_of_bounds` APIs, together with Mathlib’s `Integrable.of_bound` for a.e. bounded functions on finite-measure spaces.

`lake exe cache get` completed with `No files to download` and `Already decompressed 8609 file(s)`. `lake build` completed with `Build completed successfully (4515 jobs).` `lake exe axioms` completed with `axioms: audited 7879 TauCeti declaration(s); all within the allowlist [propext, Classical.choice, Quot.sound].`

<!--tauceti-target:v1 {"focus":"PDE","id":"energy-integrand-integrability"}-->

🤖 Prepared with Codex
