### PR TITLE
feat: add relative diffeomorphism conjugation

### DIFF
--- a/TauCeti/Geometry/Diffeomorphism/RelativeCongr.lean
+++ b/TauCeti/Geometry/Diffeomorphism/RelativeCongr.lean
@@ -11,8 +11,9 @@ public import TauCeti.Geometry.Diffeomorphism.FixingSubgroup
 # Transporting relative diffeomorphism groups
 
 A diffeomorphism `e : M ≃ₘ^n⟮I, J⟯ N` identifies the relative diffeomorphism group fixing a
-subset `s : Set M` pointwise with the relative diffeomorphism group fixing `e '' s` pointwise.
-This file records that restriction of `Diffeomorph.diffCongr` to pointwise fixing subgroups.
+subset `s : Set M` pointwise with the relative diffeomorphism group fixing any named target
+subset `t : Set N` known to be `e '' s`. This file records that restriction of
+`Diffeomorph.diffCongr` to pointwise fixing subgroups.
 
 This is a small algebraic prerequisite for the geometric-topology roadmap
 (`TauCetiRoadmap/GeometricTopology/README.md`, layer 3, "diffeomorphism groups with the C^∞
@@ -28,11 +29,15 @@ analogues of Mathlib's pointwise-fixer conjugation API
 
 ## Main definitions
 
-* `TauCeti.Diffeomorph.relativeDiffCongr e s`: the group isomorphism
+* `TauCeti.Diffeomorph.relativeDiffCongrOfImageEq e hst`: the group isomorphism
+  `Diff(M, s) ≃* Diff(N, t)` induced by conjugation with `e`, when `hst : e '' s = t`.
+* `TauCeti.Diffeomorph.relativeDiffCongr e s`: the specialization
   `Diff(M, s) ≃* Diff(N, e '' s)` induced by conjugation with `e`.
 
 ## Main results
 
+* `TauCeti.Diffeomorph.map_fixingSubgroup_diffCongr_of_image_eq`: conjugation maps the pointwise
+  fixer of `s` onto the pointwise fixer of `t`, when `e '' s = t`.
 * `TauCeti.Diffeomorph.map_fixingSubgroup_diffCongr`: conjugation maps the pointwise fixer of
   `s` onto the pointwise fixer of `e '' s`.
 * `TauCeti.Diffeomorph.diffCongr_mem_fixingSubgroup_image`: conjugating a diffeomorphism fixing
@@ -86,12 +91,30 @@ theorem map_fixingSubgroup_diffCongr (e : M ≃ₘ^n⟮I, J⟯ N) (s : Set M) :
     · ext y
       simp [diffCongr_apply_apply]
 
+/-- Conjugation by `e` maps the subgroup fixing `s` pointwise onto the subgroup fixing a named
+target `t` pointwise, when `t` is the image of `s`. -/
+theorem map_fixingSubgroup_diffCongr_of_image_eq (e : M ≃ₘ^n⟮I, J⟯ N) {s : Set M} {t : Set N}
+    (hst : e '' s = t) :
+    (fixingSubgroup (I := I) (n := n) s).map (diffCongr e).toMonoidHom =
+      fixingSubgroup (I := J) (n := n) t := by
+  rw [← hst]
+  exact map_fixingSubgroup_diffCongr e s
+
 /-- Conjugating by `e` sends diffeomorphisms fixing `s` pointwise to diffeomorphisms fixing
 `e '' s` pointwise. -/
 theorem diffCongr_mem_fixingSubgroup_image (e : M ≃ₘ^n⟮I, J⟯ N) {s : Set M}
     {φ : M ≃ₘ^n⟮I, I⟯ M} (hφ : φ ∈ fixingSubgroup (I := I) (n := n) s) :
     diffCongr e φ ∈ fixingSubgroup (I := J) (n := n) (e '' s) := by
   rw [← map_fixingSubgroup_diffCongr e s]
+  exact ⟨φ, hφ, rfl⟩
+
+/-- Conjugating by `e` sends diffeomorphisms fixing `s` pointwise to diffeomorphisms fixing a
+named target `t` pointwise, when `t` is the image of `s`. -/
+theorem diffCongr_mem_fixingSubgroup_of_image_eq (e : M ≃ₘ^n⟮I, J⟯ N) {s : Set M} {t : Set N}
+    (hst : e '' s = t) {φ : M ≃ₘ^n⟮I, I⟯ M}
+    (hφ : φ ∈ fixingSubgroup (I := I) (n := n) s) :
+    diffCongr e φ ∈ fixingSubgroup (I := J) (n := n) t := by
+  rw [← map_fixingSubgroup_diffCongr_of_image_eq e hst]
   exact ⟨φ, hφ, rfl⟩
 
 /-- Conjugating by `e.symm` sends diffeomorphisms fixing `e '' s` pointwise back to
@@ -105,20 +128,58 @@ theorem diffCongr_symm_mem_fixingSubgroup (e : M ≃ₘ^n⟮I, J⟯ N) {s : Set 
   rcases hmap with ⟨φ, hφ, rfl⟩
   simpa [diffCongr_symm] using hφ
 
+/-- Conjugating by `e.symm` sends diffeomorphisms fixing a named target `t` pointwise back to
+diffeomorphisms fixing `s` pointwise, when `t` is the image of `s`. -/
+theorem diffCongr_symm_mem_fixingSubgroup_of_image_eq (e : M ≃ₘ^n⟮I, J⟯ N) {s : Set M}
+    {t : Set N} (hst : e '' s = t) {ψ : N ≃ₘ^n⟮J, J⟯ N}
+    (hψ : ψ ∈ fixingSubgroup (I := J) (n := n) t) :
+    diffCongr e.symm ψ ∈ fixingSubgroup (I := I) (n := n) s := by
+  have hmap :
+      ψ ∈ (fixingSubgroup (I := I) (n := n) s).map (diffCongr e).toMonoidHom := by
+    rw [map_fixingSubgroup_diffCongr_of_image_eq e hst]
+    exact hψ
+  rcases hmap with ⟨φ, hφ, rfl⟩
+  simpa [diffCongr_symm] using hφ
+
+/-- Conjugation by a diffeomorphism identifies the relative diffeomorphism group fixing `s`
+pointwise with the relative diffeomorphism group fixing a named target `t` pointwise, when `t` is
+the image of `s`. -/
+def relativeDiffCongrOfImageEq (e : M ≃ₘ^n⟮I, J⟯ N) {s : Set M} {t : Set N}
+    (hst : e '' s = t) :
+    fixingSubgroup (I := I) (n := n) s ≃*
+      fixingSubgroup (I := J) (n := n) t :=
+  ((diffCongr e).subgroupMap (fixingSubgroup (I := I) (n := n) s)).trans
+    (MulEquiv.subgroupCongr (map_fixingSubgroup_diffCongr_of_image_eq e hst))
+
 /-- Conjugation by a diffeomorphism identifies the relative diffeomorphism group fixing `s`
 pointwise with the relative diffeomorphism group fixing the image subset `e '' s` pointwise. -/
 def relativeDiffCongr (e : M ≃ₘ^n⟮I, J⟯ N) (s : Set M) :
     fixingSubgroup (I := I) (n := n) s ≃*
       fixingSubgroup (I := J) (n := n) (e '' s) :=
-  ((diffCongr e).subgroupMap (fixingSubgroup (I := I) (n := n) s)).trans
-    (MulEquiv.subgroupCongr (map_fixingSubgroup_diffCongr e s))
+  relativeDiffCongrOfImageEq e (s := s) rfl
+
+/-- Applying `relativeDiffCongrOfImageEq` and then forgetting the subgroup is
+`Diffeomorph.diffCongr`. -/
+theorem relativeDiffCongrOfImageEq_apply (e : M ≃ₘ^n⟮I, J⟯ N) {s : Set M} {t : Set N}
+    (hst : e '' s = t) (φ : fixingSubgroup (I := I) (n := n) s) :
+    (relativeDiffCongrOfImageEq e hst φ : N ≃ₘ^n⟮J, J⟯ N) = diffCongr e φ := by
+  ext y
+  rfl
 
 /-- Applying `relativeDiffCongr` and then forgetting the subgroup is `Diffeomorph.diffCongr`. -/
 theorem relativeDiffCongr_apply (e : M ≃ₘ^n⟮I, J⟯ N) (s : Set M)
     (φ : fixingSubgroup (I := I) (n := n) s) :
     (relativeDiffCongr e s φ : N ≃ₘ^n⟮J, J⟯ N) = diffCongr e φ := by
-  ext y
-  rfl
+  exact relativeDiffCongrOfImageEq_apply e rfl φ
+
+/-- Pointwise formula for the named-target relative conjugation equivalence. -/
+@[simp, grind =]
+theorem relativeDiffCongrOfImageEq_apply_apply (e : M ≃ₘ^n⟮I, J⟯ N) {s : Set M} {t : Set N}
+    (hst : e '' s = t) (φ : fixingSubgroup (I := I) (n := n) s) (y : N) :
+    ((relativeDiffCongrOfImageEq e hst φ : N ≃ₘ^n⟮J, J⟯ N) y) =
+      e ((φ : M ≃ₘ^n⟮I, I⟯ M) (e.symm y)) := by
+  rw [relativeDiffCongrOfImageEq_apply]
+  exact diffCongr_apply_apply e φ y
 
 /-- Pointwise formula for the relative conjugation equivalence. -/
 @[simp, grind =]
@@ -129,13 +190,30 @@ theorem relativeDiffCongr_apply_apply (e : M ≃ₘ^n⟮I, J⟯ N) (s : Set M)
   rw [relativeDiffCongr_apply]
   exact diffCongr_apply_apply e φ y
 
+/-- Applying the inverse of `relativeDiffCongrOfImageEq` and then forgetting the subgroup is
+conjugation by `e.symm`. -/
+theorem relativeDiffCongrOfImageEq_symm_apply (e : M ≃ₘ^n⟮I, J⟯ N) {s : Set M} {t : Set N}
+    (hst : e '' s = t) (ψ : fixingSubgroup (I := J) (n := n) t) :
+    ((relativeDiffCongrOfImageEq e hst).symm ψ : M ≃ₘ^n⟮I, I⟯ M) = diffCongr e.symm ψ := by
+  ext x
+  rfl
+
 /-- Applying the inverse of `relativeDiffCongr` and then forgetting the subgroup is conjugation by
 `e.symm`. -/
 theorem relativeDiffCongr_symm_apply (e : M ≃ₘ^n⟮I, J⟯ N) (s : Set M)
     (ψ : fixingSubgroup (I := J) (n := n) (e '' s)) :
     ((relativeDiffCongr e s).symm ψ : M ≃ₘ^n⟮I, I⟯ M) = diffCongr e.symm ψ := by
-  ext x
-  rfl
+  exact relativeDiffCongrOfImageEq_symm_apply e rfl ψ
+
+/-- Pointwise formula for the inverse named-target relative conjugation equivalence. -/
+@[simp, grind =]
+theorem relativeDiffCongrOfImageEq_symm_apply_apply (e : M ≃ₘ^n⟮I, J⟯ N)
+    {s : Set M} {t : Set N} (hst : e '' s = t)
+    (ψ : fixingSubgroup (I := J) (n := n) t) (x : M) :
+    (((relativeDiffCongrOfImageEq e hst).symm ψ : M ≃ₘ^n⟮I, I⟯ M) x) =
+      e.symm ((ψ : N ≃ₘ^n⟮J, J⟯ N) (e x)) := by
+  rw [relativeDiffCongrOfImageEq_symm_apply]
+  exact diffCongr_apply_apply e.symm ψ x
 
 /-- Pointwise formula for the inverse relative conjugation equivalence. -/
 @[simp, grind =]

--- a/TauCeti/Geometry/Diffeomorphism/RelativeCongr.lean
+++ b/TauCeti/Geometry/Diffeomorphism/RelativeCongr.lean
@@ -19,6 +19,13 @@ This is a small algebraic prerequisite for the geometric-topology roadmap
 topology"), where relative groups such as `Diff(M, ∂M)` are pointwise fixing subgroups. The
 `C^∞` topology and closed-subgroup statements remain later layer-3 work.
 
+The main subgroup-map statement and relative equivalence are the diffeomorphism-specialized
+analogues of Mathlib's pointwise-fixer conjugation API
+`Set.conj_mem_fixingSubgroup`, `fixingSubgroup_map_conj_eq`, and
+`fixingSubgroupEquivFixingSubgroup` from
+`Mathlib/GroupTheory/GroupAction/SubMulAction/OfFixingSubgroup.lean`, using
+`Diffeomorph.diffCongr` for conjugation by a diffeomorphism.
+
 ## Main definitions
 
 * `TauCeti.Diffeomorph.relativeDiffCongr e s`: the group isomorphism
@@ -66,8 +73,7 @@ theorem map_fixingSubgroup_diffCongr (e : M ≃ₘ^n⟮I, J⟯ N) (s : Set M) :
     simp [diffCongr_apply_apply, apply_eq_of_mem_fixingSubgroup hφ hx]
   · intro hψ
     refine ⟨diffCongr e.symm ψ, ?_, ?_⟩
-    · change diffCongr e.symm ψ ∈ fixingSubgroup (I := I) (n := n) s
-      rw [mem_fixingSubgroup_iff]
+    · apply mem_fixingSubgroup_of_forall
       intro x hx
       have hfix : ψ (e x) = e x :=
         apply_eq_of_mem_fixingSubgroup hψ (Set.mem_image_of_mem e hx)

--- a/TauCeti/Geometry/Diffeomorphism/RelativeCongr.lean
+++ b/TauCeti/Geometry/Diffeomorphism/RelativeCongr.lean
@@ -1,0 +1,124 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+module
+
+public import TauCeti.Geometry.Diffeomorphism.Congr
+public import TauCeti.Geometry.Diffeomorphism.FixingSubgroup
+
+/-!
+# Transporting relative diffeomorphism groups
+
+A diffeomorphism `e : M ≃ₘ^n⟮I, J⟯ N` identifies the relative diffeomorphism group fixing a
+subset `s : Set M` pointwise with the relative diffeomorphism group fixing `e '' s` pointwise.
+This file records that restriction of `Diffeomorph.diffCongr` to pointwise fixing subgroups.
+
+This is a small algebraic prerequisite for the geometric-topology roadmap
+(`TauCetiRoadmap/GeometricTopology/README.md`, layer 3, "diffeomorphism groups with the C^∞
+topology"), where relative groups such as `Diff(M, ∂M)` are pointwise fixing subgroups. The
+`C^∞` topology and closed-subgroup statements remain later layer-3 work.
+
+## Main definitions
+
+* `TauCeti.Diffeomorph.relativeDiffCongr e s`: the group isomorphism
+  `Diff(M, s) ≃* Diff(N, e '' s)` induced by conjugation with `e`.
+
+## Main results
+
+* `TauCeti.Diffeomorph.diffCongr_mem_fixingSubgroup_image`: conjugating a diffeomorphism fixing
+  `s` gives one fixing `e '' s`.
+* `TauCeti.Diffeomorph.relativeDiffCongr_apply`: the underlying diffeomorphism is
+  `Diffeomorph.diffCongr e`.
+* `TauCeti.Diffeomorph.relativeDiffCongr_apply_apply`: pointwise,
+  `relativeDiffCongr e s φ y = e (φ (e.symm y))`.
+-/
+
+public section
+
+namespace TauCeti
+
+open scoped Manifold ContDiff
+
+variable {𝕜 : Type*} [NontriviallyNormedField 𝕜]
+  {E : Type*} [NormedAddCommGroup E] [NormedSpace 𝕜 E]
+  {E' : Type*} [NormedAddCommGroup E'] [NormedSpace 𝕜 E']
+  {H : Type*} [TopologicalSpace H] {I : ModelWithCorners 𝕜 E H}
+  {H' : Type*} [TopologicalSpace H'] {J : ModelWithCorners 𝕜 E' H'}
+  {M : Type*} [TopologicalSpace M] [ChartedSpace H M]
+  {N : Type*} [TopologicalSpace N] [ChartedSpace H' N]
+  {n : ℕ∞ω}
+
+namespace Diffeomorph
+
+/-- Conjugating by `e` sends diffeomorphisms fixing `s` pointwise to diffeomorphisms fixing
+`e '' s` pointwise. -/
+theorem diffCongr_mem_fixingSubgroup_image (e : M ≃ₘ^n⟮I, J⟯ N) {s : Set M}
+    {φ : M ≃ₘ^n⟮I, I⟯ M} (hφ : φ ∈ fixingSubgroup (I := I) (n := n) s) :
+    diffCongr e φ ∈ fixingSubgroup (I := J) (n := n) (e '' s) := by
+  rw [mem_fixingSubgroup_iff]
+  rintro y ⟨x, hx, rfl⟩
+  simp [diffCongr_apply_apply, apply_eq_of_mem_fixingSubgroup hφ hx]
+
+/-- Conjugating by `e.symm` sends diffeomorphisms fixing `e '' s` pointwise back to
+diffeomorphisms fixing `s` pointwise. -/
+theorem diffCongr_symm_mem_fixingSubgroup (e : M ≃ₘ^n⟮I, J⟯ N) {s : Set M}
+    {ψ : N ≃ₘ^n⟮J, J⟯ N} (hψ : ψ ∈ fixingSubgroup (I := J) (n := n) (e '' s)) :
+    diffCongr e.symm ψ ∈ fixingSubgroup (I := I) (n := n) s := by
+  rw [mem_fixingSubgroup_iff]
+  intro x hx
+  have hfix : ψ (e x) = e x :=
+    apply_eq_of_mem_fixingSubgroup hψ (Set.mem_image_of_mem e hx)
+  calc
+    diffCongr e.symm ψ x = e.symm (ψ (e.symm.symm x)) := by
+      rw [diffCongr_apply_apply]
+    _ = e.symm (ψ (e x)) :=
+      congrArg (fun y => e.symm (ψ y)) (e.toEquiv.symm_symm_apply x)
+    _ = x := by simpa using congrArg e.symm hfix
+
+/-- Conjugation by a diffeomorphism identifies the relative diffeomorphism group fixing `s`
+pointwise with the relative diffeomorphism group fixing the image subset `e '' s` pointwise. -/
+def relativeDiffCongr (e : M ≃ₘ^n⟮I, J⟯ N) (s : Set M) :
+    fixingSubgroup (I := I) (n := n) s ≃*
+      fixingSubgroup (I := J) (n := n) (e '' s) where
+  toFun φ := ⟨diffCongr e φ, diffCongr_mem_fixingSubgroup_image e φ.property⟩
+  invFun ψ := ⟨diffCongr e.symm ψ, diffCongr_symm_mem_fixingSubgroup e ψ.property⟩
+  left_inv φ := by
+    ext x
+    simp [diffCongr_apply_apply]
+  right_inv ψ := by
+    ext y
+    simp [diffCongr_apply_apply]
+  map_mul' φ ψ := by
+    ext y
+    simp [diffCongr_apply_apply]
+
+/-- Applying `relativeDiffCongr` and then forgetting the subgroup is `Diffeomorph.diffCongr`. -/
+@[simp]
+theorem relativeDiffCongr_apply (e : M ≃ₘ^n⟮I, J⟯ N) (s : Set M)
+    (φ : fixingSubgroup (I := I) (n := n) s) :
+    (relativeDiffCongr e s φ : N ≃ₘ^n⟮J, J⟯ N) = diffCongr e φ := by
+  ext y
+  rfl
+
+/-- Pointwise formula for the relative conjugation equivalence. -/
+@[simp]
+theorem relativeDiffCongr_apply_apply (e : M ≃ₘ^n⟮I, J⟯ N) (s : Set M)
+    (φ : fixingSubgroup (I := I) (n := n) s) (y : N) :
+    ((relativeDiffCongr e s φ : N ≃ₘ^n⟮J, J⟯ N) y) =
+      e ((φ : M ≃ₘ^n⟮I, I⟯ M) (e.symm y)) := by
+  rw [relativeDiffCongr_apply]
+  exact diffCongr_apply_apply e φ y
+
+/-- Applying the inverse of `relativeDiffCongr` and then forgetting the subgroup is conjugation by
+`e.symm`. -/
+@[simp]
+theorem relativeDiffCongr_symm_apply (e : M ≃ₘ^n⟮I, J⟯ N) (s : Set M)
+    (ψ : fixingSubgroup (I := J) (n := n) (e '' s)) :
+    ((relativeDiffCongr e s).symm ψ : M ≃ₘ^n⟮I, I⟯ M) = diffCongr e.symm ψ := by
+  ext x
+  rfl
+
+end Diffeomorph
+
+end TauCeti

--- a/TauCeti/Geometry/Diffeomorphism/RelativeCongr.lean
+++ b/TauCeti/Geometry/Diffeomorphism/RelativeCongr.lean
@@ -108,14 +108,24 @@ theorem diffCongr_mem_fixingSubgroup_image (e : M ≃ₘ^n⟮I, J⟯ N) {s : Set
   rw [← map_fixingSubgroup_diffCongr e s]
   exact ⟨φ, hφ, rfl⟩
 
+/-- Conjugating by `e` sends diffeomorphisms fixing `s` pointwise to diffeomorphisms fixing any
+subset of the image of `s`. -/
+theorem diffCongr_mem_fixingSubgroup_of_subset_image (e : M ≃ₘ^n⟮I, J⟯ N) {s : Set M}
+    {t : Set N} (ht : t ⊆ e '' s) {φ : M ≃ₘ^n⟮I, I⟯ M}
+    (hφ : φ ∈ fixingSubgroup (I := I) (n := n) s) :
+    diffCongr e φ ∈ fixingSubgroup (I := J) (n := n) t := by
+  apply mem_fixingSubgroup_of_forall
+  rintro y hy
+  rcases ht hy with ⟨x, hx, rfl⟩
+  simp [diffCongr_apply_apply, apply_eq_of_mem_fixingSubgroup hφ hx]
+
 /-- Conjugating by `e` sends diffeomorphisms fixing `s` pointwise to diffeomorphisms fixing a
 named target `t` pointwise, when `t` is the image of `s`. -/
 theorem diffCongr_mem_fixingSubgroup_of_image_eq (e : M ≃ₘ^n⟮I, J⟯ N) {s : Set M} {t : Set N}
     (hst : e '' s = t) {φ : M ≃ₘ^n⟮I, I⟯ M}
     (hφ : φ ∈ fixingSubgroup (I := I) (n := n) s) :
     diffCongr e φ ∈ fixingSubgroup (I := J) (n := n) t := by
-  rw [← map_fixingSubgroup_diffCongr_of_image_eq e hst]
-  exact ⟨φ, hφ, rfl⟩
+  exact diffCongr_mem_fixingSubgroup_of_subset_image e hst.ge hφ
 
 /-- Conjugating by `e.symm` sends diffeomorphisms fixing `e '' s` pointwise back to
 diffeomorphisms fixing `s` pointwise. -/
@@ -128,18 +138,30 @@ theorem diffCongr_symm_mem_fixingSubgroup (e : M ≃ₘ^n⟮I, J⟯ N) {s : Set 
   rcases hmap with ⟨φ, hφ, rfl⟩
   simpa [diffCongr_symm] using hφ
 
+/-- Conjugating by `e.symm` sends diffeomorphisms fixing a superset of `e '' s` pointwise back to
+diffeomorphisms fixing `s` pointwise. -/
+theorem diffCongr_symm_mem_fixingSubgroup_of_image_subset (e : M ≃ₘ^n⟮I, J⟯ N) {s : Set M}
+    {t : Set N} (ht : e '' s ⊆ t) {ψ : N ≃ₘ^n⟮J, J⟯ N}
+    (hψ : ψ ∈ fixingSubgroup (I := J) (n := n) t) :
+    diffCongr e.symm ψ ∈ fixingSubgroup (I := I) (n := n) s := by
+  apply mem_fixingSubgroup_of_forall
+  intro x hx
+  have hfix : ψ (e x) = e x :=
+    apply_eq_of_mem_fixingSubgroup hψ (ht (Set.mem_image_of_mem e hx))
+  calc
+    diffCongr e.symm ψ x = e.symm (ψ (e.symm.symm x)) := by
+      rw [diffCongr_apply_apply]
+    _ = e.symm (ψ (e x)) :=
+      congrArg (fun y => e.symm (ψ y)) (e.toEquiv.symm_symm_apply x)
+    _ = x := by simpa using congrArg e.symm hfix
+
 /-- Conjugating by `e.symm` sends diffeomorphisms fixing a named target `t` pointwise back to
 diffeomorphisms fixing `s` pointwise, when `t` is the image of `s`. -/
 theorem diffCongr_symm_mem_fixingSubgroup_of_image_eq (e : M ≃ₘ^n⟮I, J⟯ N) {s : Set M}
     {t : Set N} (hst : e '' s = t) {ψ : N ≃ₘ^n⟮J, J⟯ N}
     (hψ : ψ ∈ fixingSubgroup (I := J) (n := n) t) :
     diffCongr e.symm ψ ∈ fixingSubgroup (I := I) (n := n) s := by
-  have hmap :
-      ψ ∈ (fixingSubgroup (I := I) (n := n) s).map (diffCongr e).toMonoidHom := by
-    rw [map_fixingSubgroup_diffCongr_of_image_eq e hst]
-    exact hψ
-  rcases hmap with ⟨φ, hφ, rfl⟩
-  simpa [diffCongr_symm] using hφ
+  exact diffCongr_symm_mem_fixingSubgroup_of_image_subset e hst.le hψ
 
 /-- Conjugation by a diffeomorphism identifies the relative diffeomorphism group fixing `s`
 pointwise with the relative diffeomorphism group fixing a named target `t` pointwise, when `t` is

--- a/TauCeti/Geometry/Diffeomorphism/RelativeCongr.lean
+++ b/TauCeti/Geometry/Diffeomorphism/RelativeCongr.lean
@@ -102,7 +102,6 @@ theorem relativeDiffCongr_apply (e : M ≃ₘ^n⟮I, J⟯ N) (s : Set M)
   rfl
 
 /-- Pointwise formula for the relative conjugation equivalence. -/
-@[simp]
 theorem relativeDiffCongr_apply_apply (e : M ≃ₘ^n⟮I, J⟯ N) (s : Set M)
     (φ : fixingSubgroup (I := I) (n := n) s) (y : N) :
     ((relativeDiffCongr e s φ : N ≃ₘ^n⟮J, J⟯ N) y) =

--- a/TauCeti/Geometry/Diffeomorphism/RelativeCongr.lean
+++ b/TauCeti/Geometry/Diffeomorphism/RelativeCongr.lean
@@ -108,7 +108,6 @@ def relativeDiffCongr (e : M ≃ₘ^n⟮I, J⟯ N) (s : Set M) :
     (MulEquiv.subgroupCongr (map_fixingSubgroup_diffCongr e s))
 
 /-- Applying `relativeDiffCongr` and then forgetting the subgroup is `Diffeomorph.diffCongr`. -/
-@[simp]
 theorem relativeDiffCongr_apply (e : M ≃ₘ^n⟮I, J⟯ N) (s : Set M)
     (φ : fixingSubgroup (I := I) (n := n) s) :
     (relativeDiffCongr e s φ : N ≃ₘ^n⟮J, J⟯ N) = diffCongr e φ := by
@@ -126,7 +125,6 @@ theorem relativeDiffCongr_apply_apply (e : M ≃ₘ^n⟮I, J⟯ N) (s : Set M)
 
 /-- Applying the inverse of `relativeDiffCongr` and then forgetting the subgroup is conjugation by
 `e.symm`. -/
-@[simp]
 theorem relativeDiffCongr_symm_apply (e : M ≃ₘ^n⟮I, J⟯ N) (s : Set M)
     (ψ : fixingSubgroup (I := J) (n := n) (e '' s)) :
     ((relativeDiffCongr e s).symm ψ : M ≃ₘ^n⟮I, I⟯ M) = diffCongr e.symm ψ := by

--- a/TauCeti/Geometry/Diffeomorphism/RelativeCongr.lean
+++ b/TauCeti/Geometry/Diffeomorphism/RelativeCongr.lean
@@ -114,10 +114,7 @@ theorem diffCongr_mem_fixingSubgroup_of_subset_image (e : M ≃ₘ^n⟮I, J⟯ N
     {t : Set N} (ht : t ⊆ e '' s) {φ : M ≃ₘ^n⟮I, I⟯ M}
     (hφ : φ ∈ fixingSubgroup (I := I) (n := n) s) :
     diffCongr e φ ∈ fixingSubgroup (I := J) (n := n) t := by
-  apply mem_fixingSubgroup_of_forall
-  rintro y hy
-  rcases ht hy with ⟨x, hx, rfl⟩
-  simp [diffCongr_apply_apply, apply_eq_of_mem_fixingSubgroup hφ hx]
+  exact fixingSubgroup_antitone ht (diffCongr_mem_fixingSubgroup_image e hφ)
 
 /-- Conjugating by `e` sends diffeomorphisms fixing `s` pointwise to diffeomorphisms fixing a
 named target `t` pointwise, when `t` is the image of `s`. -/
@@ -144,16 +141,7 @@ theorem diffCongr_symm_mem_fixingSubgroup_of_image_subset (e : M ≃ₘ^n⟮I, J
     {t : Set N} (ht : e '' s ⊆ t) {ψ : N ≃ₘ^n⟮J, J⟯ N}
     (hψ : ψ ∈ fixingSubgroup (I := J) (n := n) t) :
     diffCongr e.symm ψ ∈ fixingSubgroup (I := I) (n := n) s := by
-  apply mem_fixingSubgroup_of_forall
-  intro x hx
-  have hfix : ψ (e x) = e x :=
-    apply_eq_of_mem_fixingSubgroup hψ (ht (Set.mem_image_of_mem e hx))
-  calc
-    diffCongr e.symm ψ x = e.symm (ψ (e.symm.symm x)) := by
-      rw [diffCongr_apply_apply]
-    _ = e.symm (ψ (e x)) :=
-      congrArg (fun y => e.symm (ψ y)) (e.toEquiv.symm_symm_apply x)
-    _ = x := by simpa using congrArg e.symm hfix
+  exact diffCongr_symm_mem_fixingSubgroup e (fixingSubgroup_antitone ht hψ)
 
 /-- Conjugating by `e.symm` sends diffeomorphisms fixing a named target `t` pointwise back to
 diffeomorphisms fixing `s` pointwise, when `t` is the image of `s`. -/

--- a/TauCeti/Geometry/Diffeomorphism/RelativeCongr.lean
+++ b/TauCeti/Geometry/Diffeomorphism/RelativeCongr.lean
@@ -197,7 +197,7 @@ theorem relativeDiffCongr_apply (e : M ≃ₘ^n⟮I, J⟯ N) (s : Set M)
   exact relativeDiffCongrOfImageEq_apply e rfl φ
 
 /-- Pointwise formula for the named-target relative conjugation equivalence. -/
-@[simp, grind =]
+@[grind =]
 theorem relativeDiffCongrOfImageEq_apply_apply (e : M ≃ₘ^n⟮I, J⟯ N) {s : Set M} {t : Set N}
     (hst : e '' s = t) (φ : fixingSubgroup (I := I) (n := n) s) (y : N) :
     ((relativeDiffCongrOfImageEq e hst φ : N ≃ₘ^n⟮J, J⟯ N) y) =
@@ -206,7 +206,7 @@ theorem relativeDiffCongrOfImageEq_apply_apply (e : M ≃ₘ^n⟮I, J⟯ N) {s :
   exact diffCongr_apply_apply e φ y
 
 /-- Pointwise formula for the relative conjugation equivalence. -/
-@[simp, grind =]
+@[grind =]
 theorem relativeDiffCongr_apply_apply (e : M ≃ₘ^n⟮I, J⟯ N) (s : Set M)
     (φ : fixingSubgroup (I := I) (n := n) s) (y : N) :
     ((relativeDiffCongr e s φ : N ≃ₘ^n⟮J, J⟯ N) y) =
@@ -232,7 +232,7 @@ theorem relativeDiffCongr_symm_apply (e : M ≃ₘ^n⟮I, J⟯ N) (s : Set M)
   exact relativeDiffCongrOfImageEq_symm_apply e rfl ψ
 
 /-- Pointwise formula for the inverse named-target relative conjugation equivalence. -/
-@[simp, grind =]
+@[grind =]
 theorem relativeDiffCongrOfImageEq_symm_apply_apply (e : M ≃ₘ^n⟮I, J⟯ N)
     {s : Set M} {t : Set N} (hst : e '' s = t)
     (ψ : fixingSubgroup (I := J) (n := n) t) (x : M) :
@@ -242,7 +242,7 @@ theorem relativeDiffCongrOfImageEq_symm_apply_apply (e : M ≃ₘ^n⟮I, J⟯ N)
   exact diffCongr_apply_apply e.symm ψ x
 
 /-- Pointwise formula for the inverse relative conjugation equivalence. -/
-@[simp, grind =]
+@[grind =]
 theorem relativeDiffCongr_symm_apply_apply (e : M ≃ₘ^n⟮I, J⟯ N) (s : Set M)
     (ψ : fixingSubgroup (I := J) (n := n) (e '' s)) (x : M) :
     (((relativeDiffCongr e s).symm ψ : M ≃ₘ^n⟮I, I⟯ M) x) =

--- a/TauCeti/Geometry/Diffeomorphism/RelativeCongr.lean
+++ b/TauCeti/Geometry/Diffeomorphism/RelativeCongr.lean
@@ -182,6 +182,7 @@ def relativeDiffCongr (e : M ≃ₘ^n⟮I, J⟯ N) (s : Set M) :
 
 /-- Applying `relativeDiffCongrOfImageEq` and then forgetting the subgroup is
 `Diffeomorph.diffCongr`. -/
+@[simp]
 theorem relativeDiffCongrOfImageEq_apply (e : M ≃ₘ^n⟮I, J⟯ N) {s : Set M} {t : Set N}
     (hst : e '' s = t) (φ : fixingSubgroup (I := I) (n := n) s) :
     (relativeDiffCongrOfImageEq e hst φ : N ≃ₘ^n⟮J, J⟯ N) = diffCongr e φ := by
@@ -189,6 +190,7 @@ theorem relativeDiffCongrOfImageEq_apply (e : M ≃ₘ^n⟮I, J⟯ N) {s : Set M
   rfl
 
 /-- Applying `relativeDiffCongr` and then forgetting the subgroup is `Diffeomorph.diffCongr`. -/
+@[simp]
 theorem relativeDiffCongr_apply (e : M ≃ₘ^n⟮I, J⟯ N) (s : Set M)
     (φ : fixingSubgroup (I := I) (n := n) s) :
     (relativeDiffCongr e s φ : N ≃ₘ^n⟮J, J⟯ N) = diffCongr e φ := by
@@ -214,6 +216,7 @@ theorem relativeDiffCongr_apply_apply (e : M ≃ₘ^n⟮I, J⟯ N) (s : Set M)
 
 /-- Applying the inverse of `relativeDiffCongrOfImageEq` and then forgetting the subgroup is
 conjugation by `e.symm`. -/
+@[simp]
 theorem relativeDiffCongrOfImageEq_symm_apply (e : M ≃ₘ^n⟮I, J⟯ N) {s : Set M} {t : Set N}
     (hst : e '' s = t) (ψ : fixingSubgroup (I := J) (n := n) t) :
     ((relativeDiffCongrOfImageEq e hst).symm ψ : M ≃ₘ^n⟮I, I⟯ M) = diffCongr e.symm ψ := by
@@ -222,6 +225,7 @@ theorem relativeDiffCongrOfImageEq_symm_apply (e : M ≃ₘ^n⟮I, J⟯ N) {s : 
 
 /-- Applying the inverse of `relativeDiffCongr` and then forgetting the subgroup is conjugation by
 `e.symm`. -/
+@[simp]
 theorem relativeDiffCongr_symm_apply (e : M ≃ₘ^n⟮I, J⟯ N) (s : Set M)
     (ψ : fixingSubgroup (I := J) (n := n) (e '' s)) :
     ((relativeDiffCongr e s).symm ψ : M ≃ₘ^n⟮I, I⟯ M) = diffCongr e.symm ψ := by

--- a/TauCeti/Geometry/Diffeomorphism/RelativeCongr.lean
+++ b/TauCeti/Geometry/Diffeomorphism/RelativeCongr.lean
@@ -26,6 +26,8 @@ topology"), where relative groups such as `Diff(M, ∂M)` are pointwise fixing s
 
 ## Main results
 
+* `TauCeti.Diffeomorph.map_fixingSubgroup_diffCongr`: conjugation maps the pointwise fixer of
+  `s` onto the pointwise fixer of `e '' s`.
 * `TauCeti.Diffeomorph.diffCongr_mem_fixingSubgroup_image`: conjugating a diffeomorphism fixing
   `s` gives one fixing `e '' s`.
 * `TauCeti.Diffeomorph.relativeDiffCongr_apply`: the underlying diffeomorphism is
@@ -51,47 +53,59 @@ variable {𝕜 : Type*} [NontriviallyNormedField 𝕜]
 
 namespace Diffeomorph
 
+/-- Conjugation by `e` maps the subgroup fixing `s` pointwise onto the subgroup fixing `e '' s`
+pointwise. -/
+theorem map_fixingSubgroup_diffCongr (e : M ≃ₘ^n⟮I, J⟯ N) (s : Set M) :
+    (fixingSubgroup (I := I) (n := n) s).map (diffCongr e).toMonoidHom =
+      fixingSubgroup (I := J) (n := n) (e '' s) := by
+  ext ψ
+  constructor
+  · rintro ⟨φ, hφ, rfl⟩
+    rw [mem_fixingSubgroup_iff]
+    rintro y ⟨x, hx, rfl⟩
+    simp [diffCongr_apply_apply, apply_eq_of_mem_fixingSubgroup hφ hx]
+  · intro hψ
+    refine ⟨diffCongr e.symm ψ, ?_, ?_⟩
+    · change diffCongr e.symm ψ ∈ fixingSubgroup (I := I) (n := n) s
+      rw [mem_fixingSubgroup_iff]
+      intro x hx
+      have hfix : ψ (e x) = e x :=
+        apply_eq_of_mem_fixingSubgroup hψ (Set.mem_image_of_mem e hx)
+      calc
+        diffCongr e.symm ψ x = e.symm (ψ (e.symm.symm x)) := by
+          rw [diffCongr_apply_apply]
+        _ = e.symm (ψ (e x)) :=
+          congrArg (fun y => e.symm (ψ y)) (e.toEquiv.symm_symm_apply x)
+        _ = x := by simpa using congrArg e.symm hfix
+    · ext y
+      simp [diffCongr_apply_apply]
+
 /-- Conjugating by `e` sends diffeomorphisms fixing `s` pointwise to diffeomorphisms fixing
 `e '' s` pointwise. -/
 theorem diffCongr_mem_fixingSubgroup_image (e : M ≃ₘ^n⟮I, J⟯ N) {s : Set M}
     {φ : M ≃ₘ^n⟮I, I⟯ M} (hφ : φ ∈ fixingSubgroup (I := I) (n := n) s) :
     diffCongr e φ ∈ fixingSubgroup (I := J) (n := n) (e '' s) := by
-  rw [mem_fixingSubgroup_iff]
-  rintro y ⟨x, hx, rfl⟩
-  simp [diffCongr_apply_apply, apply_eq_of_mem_fixingSubgroup hφ hx]
+  rw [← map_fixingSubgroup_diffCongr e s]
+  exact ⟨φ, hφ, rfl⟩
 
 /-- Conjugating by `e.symm` sends diffeomorphisms fixing `e '' s` pointwise back to
 diffeomorphisms fixing `s` pointwise. -/
 theorem diffCongr_symm_mem_fixingSubgroup (e : M ≃ₘ^n⟮I, J⟯ N) {s : Set M}
     {ψ : N ≃ₘ^n⟮J, J⟯ N} (hψ : ψ ∈ fixingSubgroup (I := J) (n := n) (e '' s)) :
     diffCongr e.symm ψ ∈ fixingSubgroup (I := I) (n := n) s := by
-  rw [mem_fixingSubgroup_iff]
-  intro x hx
-  have hfix : ψ (e x) = e x :=
-    apply_eq_of_mem_fixingSubgroup hψ (Set.mem_image_of_mem e hx)
-  calc
-    diffCongr e.symm ψ x = e.symm (ψ (e.symm.symm x)) := by
-      rw [diffCongr_apply_apply]
-    _ = e.symm (ψ (e x)) :=
-      congrArg (fun y => e.symm (ψ y)) (e.toEquiv.symm_symm_apply x)
-    _ = x := by simpa using congrArg e.symm hfix
+  have hmap : ψ ∈ (fixingSubgroup (I := I) (n := n) s).map (diffCongr e).toMonoidHom := by
+    rw [map_fixingSubgroup_diffCongr e s]
+    exact hψ
+  rcases hmap with ⟨φ, hφ, rfl⟩
+  simpa [diffCongr_symm] using hφ
 
 /-- Conjugation by a diffeomorphism identifies the relative diffeomorphism group fixing `s`
 pointwise with the relative diffeomorphism group fixing the image subset `e '' s` pointwise. -/
 def relativeDiffCongr (e : M ≃ₘ^n⟮I, J⟯ N) (s : Set M) :
     fixingSubgroup (I := I) (n := n) s ≃*
-      fixingSubgroup (I := J) (n := n) (e '' s) where
-  toFun φ := ⟨diffCongr e φ, diffCongr_mem_fixingSubgroup_image e φ.property⟩
-  invFun ψ := ⟨diffCongr e.symm ψ, diffCongr_symm_mem_fixingSubgroup e ψ.property⟩
-  left_inv φ := by
-    ext x
-    simp [diffCongr_apply_apply]
-  right_inv ψ := by
-    ext y
-    simp [diffCongr_apply_apply]
-  map_mul' φ ψ := by
-    ext y
-    simp [diffCongr_apply_apply]
+      fixingSubgroup (I := J) (n := n) (e '' s) :=
+  ((diffCongr e).subgroupMap (fixingSubgroup (I := I) (n := n) s)).trans
+    (MulEquiv.subgroupCongr (map_fixingSubgroup_diffCongr e s))
 
 /-- Applying `relativeDiffCongr` and then forgetting the subgroup is `Diffeomorph.diffCongr`. -/
 @[simp]
@@ -102,6 +116,7 @@ theorem relativeDiffCongr_apply (e : M ≃ₘ^n⟮I, J⟯ N) (s : Set M)
   rfl
 
 /-- Pointwise formula for the relative conjugation equivalence. -/
+@[simp, grind =]
 theorem relativeDiffCongr_apply_apply (e : M ≃ₘ^n⟮I, J⟯ N) (s : Set M)
     (φ : fixingSubgroup (I := I) (n := n) s) (y : N) :
     ((relativeDiffCongr e s φ : N ≃ₘ^n⟮J, J⟯ N) y) =
@@ -117,6 +132,15 @@ theorem relativeDiffCongr_symm_apply (e : M ≃ₘ^n⟮I, J⟯ N) (s : Set M)
     ((relativeDiffCongr e s).symm ψ : M ≃ₘ^n⟮I, I⟯ M) = diffCongr e.symm ψ := by
   ext x
   rfl
+
+/-- Pointwise formula for the inverse relative conjugation equivalence. -/
+@[simp, grind =]
+theorem relativeDiffCongr_symm_apply_apply (e : M ≃ₘ^n⟮I, J⟯ N) (s : Set M)
+    (ψ : fixingSubgroup (I := J) (n := n) (e '' s)) (x : M) :
+    (((relativeDiffCongr e s).symm ψ : M ≃ₘ^n⟮I, I⟯ M) x) =
+      e.symm ((ψ : N ≃ₘ^n⟮J, J⟯ N) (e x)) := by
+  rw [relativeDiffCongr_symm_apply]
+  exact diffCongr_apply_apply e.symm ψ x
 
 end Diffeomorph
 


### PR DESCRIPTION
This PR adds the algebraic relative-conjugation API for diffeomorphism groups: conjugation by a diffeomorphism `e : M ≃ₘ^n⟮I, J⟯ N` restricts to a group isomorphism from the pointwise fixer of `s : Set M` to the pointwise fixer of `e '' s`. It advances `TauCetiRoadmap/GeometricTopology/README.md`, Layer 3, “diffeomorphism groups with the C^∞ topology,” specifically the relative-group setup where `Diff(M, ∂M)` is the subgroup fixing `∂M` pointwise, by supplying the diffeomorphism-invariance bookkeeping for these relative subgroups before the later `C^∞` topology and closed-subgroup work.

I chose this as the lowest-hanging distinct GeometricTopology target after checking open and recently merged PRs: the basic self-diffeomorphism group, its tautological action, conjugation equivalence, and pointwise fixing subgroups already exist on `main`, while the restriction of conjugation to relative pointwise-fixing subgroups was still absent. This PR stays in that algebraic layer and does not start the heavier Whitney-topology construction.

No Mathlib infrastructure is vendored. The implementation reuses Tau Ceti’s existing `Diffeomorph.diffCongr`, `Diffeomorph.fixingSubgroup`, and pointwise membership API, together with Mathlib’s standard subgroup and equivalence infrastructure.

`lake exe cache get` completed with `No files to download` and `Already decompressed 8609 file(s)`. `lake build` completed with `Build completed successfully (4519 jobs).` `lake exe axioms` completed with `axioms: audited 7899 TauCeti declaration(s); all within the allowlist [propext, Classical.choice, Quot.sound].`

<!--tauceti-target:v1 {"focus":"GeometricTopology","id":"relative-diffeomorphism-conjugation"}-->

🤖 Prepared with Codex
