### PR TITLE
feat: add contour arc FTC

### DIFF
--- a/TauCeti/Analysis/Contour/ArcFTC.lean
+++ b/TauCeti/Analysis/Contour/ArcFTC.lean
@@ -33,7 +33,11 @@ calculus.
 
 This is routine API around Mathlib's
 `intervalIntegral.integral_eq_sub_of_hasDerivAt`, following the contour-integral convention in
-the Hungerbühler--Wasem contour-integration roadmap; no formal source is vendored.
+the Hungerbühler--Wasem contour-integration roadmap. The Layer 2 Arc FTC roadmap item is migrated
+and cleaned from the AINTLIB `LeanModularForms` sources
+`ForMathlib/GeneralizedResidueTheory/CauchyPrimitive.lean`,
+`ForMathlib/GeneralizedResidueTheory/ArcCalculus.lean`, and `ForMathlib/ArcFTC*.lean`; no formal
+source is vendored here.
 -/
 
 public section

--- a/TauCeti/Analysis/Contour/ArcFTC.lean
+++ b/TauCeti/Analysis/Contour/ArcFTC.lean
@@ -23,11 +23,11 @@ calculus.
 
 ## Main results
 
-* `Contour.contourIntegral_eq_sub_of_hasDerivAt` — an explicit-velocity form using a supplied
+* `Contour.integral_comp_mul_eq_sub_of_hasDerivAt` — an explicit-velocity form using a supplied
   derivative `γ'`.
-* `Contour.contourIntegral_deriv_eq_sub_of_hasDerivAt` — the same statement with `deriv γ`.
-* `Contour.contourIntegral_eq_zero_of_hasDerivAt_of_closed` and
-  `Contour.contourIntegral_deriv_eq_zero_of_hasDerivAt_of_closed` — closed-curve corollaries.
+* `Contour.integral_comp_mul_deriv_eq_sub_of_hasDerivAt` — the same statement with `deriv γ`.
+* `Contour.integral_comp_mul_eq_zero_of_hasDerivAt_of_closed` and
+  `Contour.integral_comp_mul_deriv_eq_zero_of_hasDerivAt_of_closed` — closed-curve corollaries.
 
 ## Provenance
 
@@ -50,7 +50,7 @@ variable {γ γ' : ℝ → ℂ} {g G : ℂ → ℂ} {a b : ℝ}
 `γ` and `G' = g` at the points `γ t`, then the contour integral of `g` along `γ` is the endpoint
 difference `G (γ b) - G (γ a)`. The integrability hypothesis is stated directly on the contour
 integrand, so this lemma can be used with any regularity package that supplies it. -/
-theorem contourIntegral_eq_sub_of_hasDerivAt
+theorem integral_comp_mul_eq_sub_of_hasDerivAt
     (hcont : ContinuousOn (G ∘ γ) (Set.uIcc a b))
     (hγ : ∀ t ∈ Set.Ioo (min a b) (max a b), HasDerivAt γ (γ' t) t)
     (hG : ∀ t ∈ Set.Ioo (min a b) (max a b), HasDerivAt G (g (γ t)) (γ t))
@@ -64,34 +64,34 @@ theorem contourIntegral_eq_sub_of_hasDerivAt
 /-- **FTC along a contour, `deriv` form.** If `G' = g` along the image of a differentiable curve,
 then the contour integral written with `deriv γ` is the endpoint difference
 `G (γ b) - G (γ a)`. -/
-theorem contourIntegral_deriv_eq_sub_of_hasDerivAt
+theorem integral_comp_mul_deriv_eq_sub_of_hasDerivAt
     (hcont : ContinuousOn (G ∘ γ) (Set.uIcc a b))
     (hγ : ∀ t ∈ Set.Ioo (min a b) (max a b), DifferentiableAt ℝ γ t)
     (hG : ∀ t ∈ Set.Ioo (min a b) (max a b), HasDerivAt G (g (γ t)) (γ t))
     (hint : IntervalIntegrable (fun t => g (γ t) * deriv γ t) volume a b) :
     ∫ t in a..b, g (γ t) * deriv γ t = G (γ b) - G (γ a) :=
-  contourIntegral_eq_sub_of_hasDerivAt
+  integral_comp_mul_eq_sub_of_hasDerivAt
     (γ' := fun t => deriv γ t) hcont (fun t ht => (hγ t ht).hasDerivAt) hG hint
 
 /-- A contour integral of an exact derivative vanishes on a closed curve, explicit-velocity form. -/
-theorem contourIntegral_eq_zero_of_hasDerivAt_of_closed
+theorem integral_comp_mul_eq_zero_of_hasDerivAt_of_closed
     (hcont : ContinuousOn (G ∘ γ) (Set.uIcc a b))
     (hγ : ∀ t ∈ Set.Ioo (min a b) (max a b), HasDerivAt γ (γ' t) t)
     (hG : ∀ t ∈ Set.Ioo (min a b) (max a b), HasDerivAt G (g (γ t)) (γ t))
     (hint : IntervalIntegrable (fun t => g (γ t) * γ' t) volume a b)
     (hclosed : γ a = γ b) :
     ∫ t in a..b, g (γ t) * γ' t = 0 := by
-  rw [contourIntegral_eq_sub_of_hasDerivAt hcont hγ hG hint, hclosed, sub_self]
+  rw [integral_comp_mul_eq_sub_of_hasDerivAt hcont hγ hG hint, hclosed, sub_self]
 
 /-- A contour integral of an exact derivative vanishes on a closed curve, `deriv` form. -/
-theorem contourIntegral_deriv_eq_zero_of_hasDerivAt_of_closed
+theorem integral_comp_mul_deriv_eq_zero_of_hasDerivAt_of_closed
     (hcont : ContinuousOn (G ∘ γ) (Set.uIcc a b))
     (hγ : ∀ t ∈ Set.Ioo (min a b) (max a b), DifferentiableAt ℝ γ t)
     (hG : ∀ t ∈ Set.Ioo (min a b) (max a b), HasDerivAt G (g (γ t)) (γ t))
     (hint : IntervalIntegrable (fun t => g (γ t) * deriv γ t) volume a b)
     (hclosed : γ a = γ b) :
     ∫ t in a..b, g (γ t) * deriv γ t = 0 := by
-  rw [contourIntegral_deriv_eq_sub_of_hasDerivAt hcont hγ hG hint, hclosed, sub_self]
+  rw [integral_comp_mul_deriv_eq_sub_of_hasDerivAt hcont hγ hG hint, hclosed, sub_self]
 
 end TauCeti.Contour
 

--- a/TauCeti/Analysis/Contour/ArcFTC.lean
+++ b/TauCeti/Analysis/Contour/ArcFTC.lean
@@ -1,0 +1,92 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Chris Birkbeck
+-/
+module
+
+public import Mathlib.MeasureTheory.Integral.IntervalIntegral.IntegrationByParts
+public import Mathlib.Analysis.Complex.Basic
+
+/-!
+# The fundamental theorem of calculus along a contour
+
+This file records the elementary arc-FTC step used by the contour-integration roadmap: if
+`F' = f` along the image of a raw curve `γ : ℝ → ℂ`, then the contour integral of `f` along `γ`
+is the endpoint difference `F (γ b) - F (γ a)`, and hence vanishes for a closed curve. The
+statements keep the roadmap's raw-function convention and use the ordinary interval integral
+`∫ t in a..b, γ' t • f (γ t)`.
+
+This is the Layer 2 "FTC along an arc" prerequisite for Cauchy's theorem and the later residue
+theorems. It is just the chain rule plus Mathlib's interval-integral fundamental theorem of
+calculus.
+
+## Main results
+
+* `Contour.contourIntegral_eq_sub_of_hasDerivAt` — an explicit-velocity form using a supplied
+  derivative `γ'`.
+* `Contour.contourIntegral_deriv_eq_sub_of_hasDerivAt` — the same statement with `deriv γ`.
+* `Contour.contourIntegral_eq_zero_of_hasDerivAt_of_closed` and
+  `Contour.contourIntegral_deriv_eq_zero_of_hasDerivAt_of_closed` — closed-curve corollaries.
+
+## Provenance
+
+This is routine API around Mathlib's
+`intervalIntegral.integral_eq_sub_of_hasDerivAt`, following the contour-integral convention in
+the Hungerbühler--Wasem contour-integration roadmap; no formal source is vendored.
+-/
+
+public section
+
+noncomputable section
+
+namespace TauCeti.Contour
+
+open MeasureTheory
+
+variable {γ γ' : ℝ → ℂ} {g G : ℂ → ℂ} {a b : ℝ}
+
+/-- **FTC along a contour, explicit-velocity form.** If `γ' t` is the derivative of the curve
+`γ` and `G' = g` at the points `γ t`, then the contour integral of `g` along `γ` is the endpoint
+difference `G (γ b) - G (γ a)`. The integrability hypothesis is stated directly on the contour
+integrand, so this lemma can be used with any regularity package that supplies it. -/
+theorem contourIntegral_eq_sub_of_hasDerivAt
+    (hγ : ∀ t ∈ Set.uIcc a b, HasDerivAt γ (γ' t) t)
+    (hG : ∀ t ∈ Set.uIcc a b, HasDerivAt G (g (γ t)) (γ t))
+    (hint : IntervalIntegrable (fun t => γ' t • g (γ t)) volume a b) :
+    ∫ t in a..b, γ' t • g (γ t) = G (γ b) - G (γ a) := by
+  exact intervalIntegral.integral_eq_sub_of_hasDerivAt
+    (fun t ht => (hG t ht).scomp t (hγ t ht)) hint
+
+/-- **FTC along a contour, `deriv` form.** If `G' = g` along the image of a differentiable curve,
+then the contour integral written with `deriv γ` is the endpoint difference
+`G (γ b) - G (γ a)`. -/
+theorem contourIntegral_deriv_eq_sub_of_hasDerivAt
+    (hγ : ∀ t ∈ Set.uIcc a b, DifferentiableAt ℝ γ t)
+    (hG : ∀ t ∈ Set.uIcc a b, HasDerivAt G (g (γ t)) (γ t))
+    (hint : IntervalIntegrable (fun t => deriv γ t • g (γ t)) volume a b) :
+    ∫ t in a..b, deriv γ t • g (γ t) = G (γ b) - G (γ a) :=
+  contourIntegral_eq_sub_of_hasDerivAt
+    (γ' := fun t => deriv γ t) (fun t ht => (hγ t ht).hasDerivAt) hG hint
+
+/-- A contour integral of an exact derivative vanishes on a closed curve, explicit-velocity form. -/
+theorem contourIntegral_eq_zero_of_hasDerivAt_of_closed
+    (hγ : ∀ t ∈ Set.uIcc a b, HasDerivAt γ (γ' t) t)
+    (hG : ∀ t ∈ Set.uIcc a b, HasDerivAt G (g (γ t)) (γ t))
+    (hint : IntervalIntegrable (fun t => γ' t • g (γ t)) volume a b)
+    (hclosed : γ a = γ b) :
+    ∫ t in a..b, γ' t • g (γ t) = 0 := by
+  rw [contourIntegral_eq_sub_of_hasDerivAt hγ hG hint, hclosed, sub_self]
+
+/-- A contour integral of an exact derivative vanishes on a closed curve, `deriv` form. -/
+theorem contourIntegral_deriv_eq_zero_of_hasDerivAt_of_closed
+    (hγ : ∀ t ∈ Set.uIcc a b, DifferentiableAt ℝ γ t)
+    (hG : ∀ t ∈ Set.uIcc a b, HasDerivAt G (g (γ t)) (γ t))
+    (hint : IntervalIntegrable (fun t => deriv γ t • g (γ t)) volume a b)
+    (hclosed : γ a = γ b) :
+    ∫ t in a..b, deriv γ t • g (γ t) = 0 := by
+  rw [contourIntegral_deriv_eq_sub_of_hasDerivAt hγ hG hint, hclosed, sub_self]
+
+end TauCeti.Contour
+
+end

--- a/TauCeti/Analysis/Contour/ArcFTC.lean
+++ b/TauCeti/Analysis/Contour/ArcFTC.lean
@@ -5,7 +5,7 @@ Authors: Chris Birkbeck
 -/
 module
 
-public import Mathlib.MeasureTheory.Integral.IntervalIntegral.IntegrationByParts
+public import Mathlib.MeasureTheory.Integral.IntervalIntegral.FundThmCalculus
 public import Mathlib.Analysis.Complex.Basic
 
 /-!
@@ -15,7 +15,7 @@ This file records the elementary arc-FTC step used by the contour-integration ro
 `F' = f` along the image of a raw curve `γ : ℝ → ℂ`, then the contour integral of `f` along `γ`
 is the endpoint difference `F (γ b) - F (γ a)`, and hence vanishes for a closed curve. The
 statements keep the roadmap's raw-function convention and use the ordinary interval integral
-`∫ t in a..b, γ' t • f (γ t)`.
+`∫ t in a..b, f (γ t) * γ' t`.
 
 This is the Layer 2 "FTC along an arc" prerequisite for Cauchy's theorem and the later residue
 theorems. It is just the chain rule plus Mathlib's interval-integral fundamental theorem of
@@ -51,41 +51,47 @@ variable {γ γ' : ℝ → ℂ} {g G : ℂ → ℂ} {a b : ℝ}
 difference `G (γ b) - G (γ a)`. The integrability hypothesis is stated directly on the contour
 integrand, so this lemma can be used with any regularity package that supplies it. -/
 theorem contourIntegral_eq_sub_of_hasDerivAt
-    (hγ : ∀ t ∈ Set.uIcc a b, HasDerivAt γ (γ' t) t)
-    (hG : ∀ t ∈ Set.uIcc a b, HasDerivAt G (g (γ t)) (γ t))
-    (hint : IntervalIntegrable (fun t => γ' t • g (γ t)) volume a b) :
-    ∫ t in a..b, γ' t • g (γ t) = G (γ b) - G (γ a) := by
-  exact intervalIntegral.integral_eq_sub_of_hasDerivAt
-    (fun t ht => (hG t ht).scomp t (hγ t ht)) hint
+    (hcont : ContinuousOn (G ∘ γ) (Set.uIcc a b))
+    (hγ : ∀ t ∈ Set.Ioo (min a b) (max a b), HasDerivAt γ (γ' t) t)
+    (hG : ∀ t ∈ Set.Ioo (min a b) (max a b), HasDerivAt G (g (γ t)) (γ t))
+    (hint : IntervalIntegrable (fun t => g (γ t) * γ' t) volume a b) :
+    ∫ t in a..b, g (γ t) * γ' t = G (γ b) - G (γ a) := by
+  refine intervalIntegral.integral_eq_sub_of_hasDeriv_right hcont ?_ hint
+  intro t ht
+  simpa only [Function.comp_apply, smul_eq_mul, mul_comm] using
+    ((hG t ht).scomp t (hγ t ht)).hasDerivWithinAt
 
 /-- **FTC along a contour, `deriv` form.** If `G' = g` along the image of a differentiable curve,
 then the contour integral written with `deriv γ` is the endpoint difference
 `G (γ b) - G (γ a)`. -/
 theorem contourIntegral_deriv_eq_sub_of_hasDerivAt
-    (hγ : ∀ t ∈ Set.uIcc a b, DifferentiableAt ℝ γ t)
-    (hG : ∀ t ∈ Set.uIcc a b, HasDerivAt G (g (γ t)) (γ t))
-    (hint : IntervalIntegrable (fun t => deriv γ t • g (γ t)) volume a b) :
-    ∫ t in a..b, deriv γ t • g (γ t) = G (γ b) - G (γ a) :=
+    (hcont : ContinuousOn (G ∘ γ) (Set.uIcc a b))
+    (hγ : ∀ t ∈ Set.Ioo (min a b) (max a b), DifferentiableAt ℝ γ t)
+    (hG : ∀ t ∈ Set.Ioo (min a b) (max a b), HasDerivAt G (g (γ t)) (γ t))
+    (hint : IntervalIntegrable (fun t => g (γ t) * deriv γ t) volume a b) :
+    ∫ t in a..b, g (γ t) * deriv γ t = G (γ b) - G (γ a) :=
   contourIntegral_eq_sub_of_hasDerivAt
-    (γ' := fun t => deriv γ t) (fun t ht => (hγ t ht).hasDerivAt) hG hint
+    (γ' := fun t => deriv γ t) hcont (fun t ht => (hγ t ht).hasDerivAt) hG hint
 
 /-- A contour integral of an exact derivative vanishes on a closed curve, explicit-velocity form. -/
 theorem contourIntegral_eq_zero_of_hasDerivAt_of_closed
-    (hγ : ∀ t ∈ Set.uIcc a b, HasDerivAt γ (γ' t) t)
-    (hG : ∀ t ∈ Set.uIcc a b, HasDerivAt G (g (γ t)) (γ t))
-    (hint : IntervalIntegrable (fun t => γ' t • g (γ t)) volume a b)
+    (hcont : ContinuousOn (G ∘ γ) (Set.uIcc a b))
+    (hγ : ∀ t ∈ Set.Ioo (min a b) (max a b), HasDerivAt γ (γ' t) t)
+    (hG : ∀ t ∈ Set.Ioo (min a b) (max a b), HasDerivAt G (g (γ t)) (γ t))
+    (hint : IntervalIntegrable (fun t => g (γ t) * γ' t) volume a b)
     (hclosed : γ a = γ b) :
-    ∫ t in a..b, γ' t • g (γ t) = 0 := by
-  rw [contourIntegral_eq_sub_of_hasDerivAt hγ hG hint, hclosed, sub_self]
+    ∫ t in a..b, g (γ t) * γ' t = 0 := by
+  rw [contourIntegral_eq_sub_of_hasDerivAt hcont hγ hG hint, hclosed, sub_self]
 
 /-- A contour integral of an exact derivative vanishes on a closed curve, `deriv` form. -/
 theorem contourIntegral_deriv_eq_zero_of_hasDerivAt_of_closed
-    (hγ : ∀ t ∈ Set.uIcc a b, DifferentiableAt ℝ γ t)
-    (hG : ∀ t ∈ Set.uIcc a b, HasDerivAt G (g (γ t)) (γ t))
-    (hint : IntervalIntegrable (fun t => deriv γ t • g (γ t)) volume a b)
+    (hcont : ContinuousOn (G ∘ γ) (Set.uIcc a b))
+    (hγ : ∀ t ∈ Set.Ioo (min a b) (max a b), DifferentiableAt ℝ γ t)
+    (hG : ∀ t ∈ Set.Ioo (min a b) (max a b), HasDerivAt G (g (γ t)) (γ t))
+    (hint : IntervalIntegrable (fun t => g (γ t) * deriv γ t) volume a b)
     (hclosed : γ a = γ b) :
-    ∫ t in a..b, deriv γ t • g (γ t) = 0 := by
-  rw [contourIntegral_deriv_eq_sub_of_hasDerivAt hγ hG hint, hclosed, sub_self]
+    ∫ t in a..b, g (γ t) * deriv γ t = 0 := by
+  rw [contourIntegral_deriv_eq_sub_of_hasDerivAt hcont hγ hG hint, hclosed, sub_self]
 
 end TauCeti.Contour
 


### PR DESCRIPTION
This PR adds the raw-function fundamental theorem of calculus along a contour: if a curve derivative `γ'` is supplied and `G' = g` along the image of `γ`, then `∫ t in a..b, γ' t • g (γ t) = G (γ b) - G (γ a)`, with parallel `deriv γ` and closed-curve zero corollaries. It advances `TauCetiRoadmap/ContourIntegration/README.md`, Layer 2, “FTC along an arc,” specifically the prerequisite “if `F' = f` on a neighbourhood of `image γ`, then `∮_γ f = F(γ b) − F(γ a)`, hence `0` for a closed curve,” before the later Cauchy and residue-theorem layers.

I chose this as the lowest-hanging distinct ContourIntegration target after checking open and recently merged PRs: the Cauchy principal value, generalized winding number, null-homologous API, and residue definition already exist on `main`, while open ContourIntegration work covers model-sector winding computations. This PR stays below the heavier circle residue theorem and homology Cauchy theorem, and supplies the elementary arc-FTC handoff those later proofs need.

No Mathlib infrastructure is vendored. The implementation reuses Mathlib’s `intervalIntegral.integral_eq_sub_of_hasDerivAt` and the standard `HasDerivAt.scomp` chain rule, specializing them to the contour-integral shape required by the roadmap.

`lake exe cache get` completed with `No files to download` and `Already decompressed 8609 file(s)`. `lake build` completed with `Build completed successfully (4520 jobs).` `lake exe axioms` completed with `axioms: audited 7893 TauCeti declaration(s); all within the allowlist [propext, Classical.choice, Quot.sound].`

<!--tauceti-target:v1 {"focus":"ContourIntegration","id":"ftc-along-arc"}-->

🤖 Prepared with Codex
