### PR TITLE
feat: add integrated PDE energy form

### DIFF
--- a/TauCeti/Analysis/PDE/IntegratedEnergyForm.lean
+++ b/TauCeti/Analysis/PDE/IntegratedEnergyForm.lean
@@ -32,6 +32,8 @@ derivative: once Lane A supplies `W^{k,p}(Ω)`, its value-gradient jets can feed
   Bochner-integrability hypotheses.
 * `TauCeti.PDE.norm_energyFormIntegral_le_of_bounds`: the integrated boundedness estimate
   obtained from the pointwise coefficient bounds.
+* `TauCeti.PDE.UniformlyEllipticOn.norm_energyFormIntegral_le_on`: the corresponding
+  boundedness estimate from uniform ellipticity on an a.e. domain.
 -/
 
 public section
@@ -395,9 +397,22 @@ lemma integral_min_coercivityConstant_mul_norm_sq_le_energyFormIntegral_self_of_
 
 namespace UniformlyEllipticOn
 
-variable {Ω : Set X} {lam Lam beta mu : ℝ}
+variable {Ω : Set X} {lam Lam beta gamma mu : ℝ}
 variable {a : X → Matrix n n ℝ} {b : X → EuclideanSpace ℝ n} {c : X → ℝ}
-variable {U : X → ℝ × EuclideanSpace ℝ n}
+variable {U V : X → ℝ × EuclideanSpace ℝ n}
+
+/-- Integrated boundedness of the energy form from uniform ellipticity and a.e. lower-order
+coefficient bounds. -/
+lemma norm_energyFormIntegral_le_on (h : UniformlyEllipticOn Ω a lam Lam)
+    (hΩ : ∀ᵐ x ∂μ, x ∈ Ω) (hb : ∀ᵐ x ∂μ, ‖b x‖ ≤ beta)
+    (hc : ∀ᵐ x ∂μ, ‖c x‖ ≤ gamma)
+    (hUV : Integrable (fun x => (Lam + beta + gamma) * (‖U x‖ * ‖V x‖)) μ) :
+    ‖energyFormIntegral μ a b c U V‖ ≤
+      ∫ x, ((Lam + beta + gamma) * (‖U x‖ * ‖V x‖)) ∂μ := by
+  refine PDE.norm_energyFormIntegral_le_of_bounds (μ := μ) (a := a) (b := b) (c := c)
+    (U := U) (V := V) h.upper_nonneg ?_ hb hc hUV
+  filter_upwards [hΩ] with x hx
+  exact h.upper_bound hx
 
 /-- Integrated Gårding lower bound from uniform ellipticity and a.e. lower-order
 coefficient hypotheses. -/

--- a/TauCeti/Analysis/PDE/IntegratedEnergyForm.lean
+++ b/TauCeti/Analysis/PDE/IntegratedEnergyForm.lean
@@ -50,11 +50,18 @@ integrand against a measure.
 For a Sobolev function `u`, the intended jet field is `x ↦ (u x, ∇u x)`.  This definition stays
 at the raw-jet level because the roadmap's weak-derivative Sobolev spaces are a separate
 prerequisite. -/
--- `irreducible_def` supplies the public `_def` lemma while keeping this body unexposed.
-noncomputable irreducible_def energyFormIntegral (μ : Measure X) (a : X → Matrix n n ℝ)
+public noncomputable def energyFormIntegral (μ : Measure X) (a : X → Matrix n n ℝ)
     (b : X → EuclideanSpace ℝ n) (c : X → ℝ)
     (U V : X → ℝ × EuclideanSpace ℝ n) : ℝ :=
   ∫ x, (energyIntegrand (a x) (b x) (c x) (U x) (V x)) ∂μ
+
+/-- Unfolding rule for the integrated energy form. -/
+theorem energyFormIntegral_def (μ : Measure X) (a : X → Matrix n n ℝ)
+    (b : X → EuclideanSpace ℝ n) (c : X → ℝ)
+    (U V : X → ℝ × EuclideanSpace ℝ n) :
+    energyFormIntegral μ a b c U V =
+      ∫ x, (energyIntegrand (a x) (b x) (c x) (U x) (V x)) ∂μ :=
+  by simp [energyFormIntegral]
 
 variable (μ : Measure X) (a : X → Matrix n n ℝ)
 variable (b : X → EuclideanSpace ℝ n) (c : X → ℝ)

--- a/TauCeti/Analysis/PDE/IntegratedEnergyForm.lean
+++ b/TauCeti/Analysis/PDE/IntegratedEnergyForm.lean
@@ -1,0 +1,181 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+module
+
+public import TauCeti.Analysis.PDE.EnergyFormIntegrability
+public import Mathlib.MeasureTheory.Integral.Bochner.Basic
+
+/-!
+# Integrated divergence-form energy forms
+
+Lane D of the PDE roadmap asks for the weak energy form
+
+`a(u, v) = ∫ aⁱʲ ∂ᵢu ∂ⱼv + bⁱ ∂ᵢu v + c u v`.
+
+The preceding PDE files build the pointwise jet integrand
+`energyIntegrand (a x) (b x) (c x)` and prove the measurability and integrability estimates
+needed to integrate it.  This file performs that integration for raw jet fields
+`U V : X → ℝ × EuclideanSpace ℝ n`.  It deliberately does not define a Sobolev space or weak
+derivative: once Lane A supplies `W^{k,p}(Ω)`, its value-gradient jets can feed this definition.
+
+## Main declarations
+
+* `TauCeti.PDE.energyFormIntegral`: the integrated scalar energy form on two jet fields.
+* `TauCeti.PDE.energyFormIntegral_one_zero_zero` and
+  `TauCeti.PDE.energyFormIntegral_one_zero_mass`: the `−Δ` and shifted-`−Δ + c` model forms.
+* `TauCeti.PDE.energyFormIntegral_add_left`, `TauCeti.PDE.energyFormIntegral_add_right`,
+  `TauCeti.PDE.energyFormIntegral_smul_left`, and
+  `TauCeti.PDE.energyFormIntegral_smul_right`: bilinearity identities under the usual
+  Bochner-integrability hypotheses.
+* `TauCeti.PDE.norm_energyFormIntegral_le_of_bound`: the integrated boundedness estimate
+  obtained from the pointwise coefficient bounds.
+-/
+
+public section
+
+namespace TauCeti
+
+namespace PDE
+
+open MeasureTheory Matrix
+open scoped InnerProductSpace
+
+variable {X n : Type*} [MeasurableSpace X] [Fintype n]
+
+/-- The scalar energy form obtained by integrating the divergence-form pointwise jet
+integrand against a measure.
+
+For a Sobolev function `u`, the intended jet field is `x ↦ (u x, ∇u x)`.  This definition stays
+at the raw-jet level because the roadmap's weak-derivative Sobolev spaces are a separate
+prerequisite. -/
+-- `irreducible_def` supplies the public `_def` lemma while keeping this body unexposed.
+noncomputable irreducible_def energyFormIntegral (μ : Measure X) (a : X → Matrix n n ℝ)
+    (b : X → EuclideanSpace ℝ n) (c : X → ℝ)
+    (U V : X → ℝ × EuclideanSpace ℝ n) : ℝ :=
+  ∫ x, (energyIntegrand (a x) (b x) (c x) (U x) (V x)) ∂μ
+
+variable (μ : Measure X) (a : X → Matrix n n ℝ)
+variable (b : X → EuclideanSpace ℝ n) (c : X → ℝ)
+variable (U V W : X → ℝ × EuclideanSpace ℝ n)
+
+/-- The integrated energy form respects almost-everywhere equality of all coefficient and jet
+fields. -/
+lemma energyFormIntegral_congr_ae {a' : X → Matrix n n ℝ} {b' : X → EuclideanSpace ℝ n}
+    {c' : X → ℝ} {U' V' : X → ℝ × EuclideanSpace ℝ n}
+    (ha : a =ᵐ[μ] a') (hb : b =ᵐ[μ] b') (hc : c =ᵐ[μ] c')
+    (hU : U =ᵐ[μ] U') (hV : V =ᵐ[μ] V') :
+    energyFormIntegral μ a b c U V = energyFormIntegral μ a' b' c' U' V' := by
+  rw [energyFormIntegral_def, energyFormIntegral_def]
+  apply MeasureTheory.integral_congr_ae
+  filter_upwards [ha, hb, hc, hU, hV] with x hax hbx hcx hUx hVx
+  simp [hax, hbx, hcx, hUx, hVx]
+
+/-- Additivity in the left jet field, assuming the two summand energy densities are
+integrable. -/
+lemma energyFormIntegral_add_left
+    (hU : Integrable (fun x => energyIntegrand (a x) (b x) (c x) (U x) (V x)) μ)
+    (hW : Integrable (fun x => energyIntegrand (a x) (b x) (c x) (W x) (V x)) μ) :
+    energyFormIntegral μ a b c (fun x => U x + W x) V =
+      energyFormIntegral μ a b c U V + energyFormIntegral μ a b c W V := by
+  rw [energyFormIntegral_def, energyFormIntegral_def, energyFormIntegral_def]
+  rw [show (∫ x, (energyIntegrand (a x) (b x) (c x) ((fun y => U y + W y) x) (V x)) ∂μ)
+      = ∫ x, (energyIntegrand (a x) (b x) (c x) (U x) (V x) +
+          energyIntegrand (a x) (b x) (c x) (W x) (V x)) ∂μ by
+    apply MeasureTheory.integral_congr_ae
+    exact Filter.Eventually.of_forall fun x => by simp]
+  exact integral_add hU hW
+
+/-- Additivity in the right jet field, assuming the two summand energy densities are
+integrable. -/
+lemma energyFormIntegral_add_right
+    (hV : Integrable (fun x => energyIntegrand (a x) (b x) (c x) (U x) (V x)) μ)
+    (hW : Integrable (fun x => energyIntegrand (a x) (b x) (c x) (U x) (W x)) μ) :
+    energyFormIntegral μ a b c U (fun x => V x + W x) =
+      energyFormIntegral μ a b c U V + energyFormIntegral μ a b c U W := by
+  rw [energyFormIntegral_def, energyFormIntegral_def, energyFormIntegral_def]
+  rw [show (∫ x, (energyIntegrand (a x) (b x) (c x) (U x) ((fun y => V y + W y) x)) ∂μ)
+      = ∫ x, (energyIntegrand (a x) (b x) (c x) (U x) (V x) +
+          energyIntegrand (a x) (b x) (c x) (U x) (W x)) ∂μ by
+    apply MeasureTheory.integral_congr_ae
+    exact Filter.Eventually.of_forall fun x =>
+      map_add (energyIntegrand (a x) (b x) (c x) (U x)) (V x) (W x)]
+  exact integral_add hV hW
+
+/-- Homogeneity in the left jet field. -/
+lemma energyFormIntegral_smul_left (r : ℝ) :
+    energyFormIntegral μ a b c (fun x => r • U x) V =
+      r * energyFormIntegral μ a b c U V := by
+  rw [energyFormIntegral_def, energyFormIntegral_def]
+  rw [show (∫ x, (energyIntegrand (a x) (b x) (c x) ((fun y => r • U y) x) (V x)) ∂μ)
+      = ∫ x, (r • energyIntegrand (a x) (b x) (c x) (U x) (V x)) ∂μ by
+    apply MeasureTheory.integral_congr_ae
+    exact Filter.Eventually.of_forall fun x => by simp]
+  rw [MeasureTheory.integral_smul]
+  rfl
+
+/-- Homogeneity in the right jet field. -/
+lemma energyFormIntegral_smul_right (r : ℝ) :
+    energyFormIntegral μ a b c U (fun x => r • V x) =
+      r * energyFormIntegral μ a b c U V := by
+  rw [energyFormIntegral_def, energyFormIntegral_def]
+  rw [show (∫ x, (energyIntegrand (a x) (b x) (c x) (U x) ((fun y => r • V y) x)) ∂μ)
+      = ∫ x, (r • energyIntegrand (a x) (b x) (c x) (U x) (V x)) ∂μ by
+    apply MeasureTheory.integral_congr_ae
+    exact Filter.Eventually.of_forall fun x => by simp]
+  rw [MeasureTheory.integral_smul]
+  rfl
+
+variable [DecidableEq n]
+
+/-- The integrated `−Δ` model form is the integral of the dot product of the two gradient
+components of the jet fields. -/
+lemma energyFormIntegral_one_zero_zero :
+    energyFormIntegral μ (fun _ => (1 : Matrix n n ℝ)) (fun _ => 0) (fun _ => 0) U V =
+      ∫ x, ((V x).2 ⬝ᵥ (U x).2) ∂μ := by
+  simp [energyFormIntegral_def]
+
+/-- The integrated shifted Laplacian model form `−Δ + c` is the sum of the Dirichlet density
+and the mass density. -/
+lemma energyFormIntegral_one_zero_mass (m : X → ℝ) :
+    energyFormIntegral μ (fun _ => (1 : Matrix n n ℝ)) (fun _ => 0) m U V =
+      ∫ x, ((V x).2 ⬝ᵥ (U x).2 + m x * (U x).1 * (V x).1) ∂μ := by
+  rw [energyFormIntegral_def]
+  apply MeasureTheory.integral_congr_ae
+  exact Filter.Eventually.of_forall fun x =>
+    energyIntegrand_one_zero_mass_apply (m x) (U x) (V x)
+
+/-- The diagonal of the integrated shifted Laplacian model is the integral of
+`‖∇u‖² + c u²` at the jet level. -/
+lemma energyFormIntegral_one_zero_mass_self (m : X → ℝ) :
+    energyFormIntegral μ (fun _ => (1 : Matrix n n ℝ)) (fun _ => 0) m U U =
+      ∫ x, (‖(U x).2‖ ^ 2 + m x * (U x).1 ^ 2) ∂μ := by
+  rw [energyFormIntegral_def]
+  apply MeasureTheory.integral_congr_ae
+  exact Filter.Eventually.of_forall fun x =>
+    energyIntegrand_one_zero_mass_self (m x) (U x)
+
+variable {Lam beta gamma : ℝ}
+
+omit [DecidableEq n] in
+/-- Integrated boundedness of the raw-jet energy form from pointwise coefficient bounds.
+
+This is the scalar integral version of `norm_energyIntegrand_apply_le_of_bounds`: if the
+pointwise jet product `‖U x‖ * ‖V x‖` is integrable, the absolute value of the integrated form
+is bounded by `(Λ + β + γ)` times its integral. -/
+lemma norm_energyFormIntegral_le_of_bound (hLam : 0 ≤ Lam)
+    (ha : ∀ x, ∀ η ξ : EuclideanSpace ℝ n,
+      |η ⬝ᵥ (a x *ᵥ ξ)| ≤ Lam * ‖η‖ * ‖ξ‖)
+    (hb : ∀ x, ‖b x‖ ≤ beta) (hc : ∀ x, ‖c x‖ ≤ gamma)
+    (hUV : Integrable (fun x => (Lam + beta + gamma) * (‖U x‖ * ‖V x‖)) μ) :
+    ‖energyFormIntegral μ a b c U V‖ ≤
+      ∫ x, ((Lam + beta + gamma) * (‖U x‖ * ‖V x‖)) ∂μ := by
+  rw [energyFormIntegral_def]
+  refine norm_integral_le_of_norm_le hUV (Filter.Eventually.of_forall fun x => ?_)
+  simpa [mul_assoc] using
+    norm_energyIntegrand_apply_le_of_bounds hLam (ha x) (hb x) (hc x) (U x) (V x)
+
+end PDE
+
+end TauCeti

--- a/TauCeti/Analysis/PDE/IntegratedEnergyForm.lean
+++ b/TauCeti/Analysis/PDE/IntegratedEnergyForm.lean
@@ -375,82 +375,6 @@ lemma energyFormIntegral_one_zero_mass_self [DecidableEq n] (m : X → ℝ) :
 
 variable {Lam beta gamma : ℝ}
 
-/-- Weighted Young inequality used to absorb the first-order drift term. -/
-private lemma mul_norm_abs_le_half_mul_sq_add (hlam : 0 < lam) (beta u r : ℝ) :
-    beta * r * |u| ≤ lam / 2 * r ^ 2 + beta ^ 2 / (2 * lam) * u ^ 2 := by
-  have hkey := two_mul_le_add_sq (lam * r) (beta * |u|)
-  rw [mul_pow, mul_pow, sq_abs] at hkey
-  have h2lam : (0 : ℝ) < 2 * lam := mul_pos two_pos hlam
-  rw [← sub_nonneg]
-  have expand : lam / 2 * r ^ 2 + beta ^ 2 / (2 * lam) * u ^ 2 - beta * r * |u|
-      = (lam ^ 2 * r ^ 2 + beta ^ 2 * u ^ 2 - 2 * lam * beta * r * |u|)
-          / (2 * lam) := by
-    field_simp
-  rw [expand]
-  apply div_nonneg _ h2lam.le
-  nlinarith [hkey]
-
-/-- Pointwise Gårding inequality from a dot-product lower bound, avoiding the
-`Matrix.toQuadraticForm'` API. -/
-private lemma garding_energyIntegrand_self_of_dotProduct_lower_bound {A : Matrix n n ℝ}
-    {b₀ : EuclideanSpace ℝ n} {c₀ : ℝ} (hlam : 0 < lam)
-    (ha : ∀ ξ : EuclideanSpace ℝ n, lam * ‖ξ‖ ^ 2 ≤ ξ ⬝ᵥ (A *ᵥ ξ))
-    (hb : ‖b₀‖ ≤ beta) (hc : 0 ≤ c₀) (U : ℝ × EuclideanSpace ℝ n) :
-    lam / 2 * ‖U.2‖ ^ 2 - beta ^ 2 / (2 * lam) * U.1 ^ 2
-      ≤ energyIntegrand A b₀ c₀ U U := by
-  rw [energyIntegrand_apply, matrixBilinearForm_apply, driftForm_apply, massForm_apply]
-  have hA : lam * ‖U.2‖ ^ 2 ≤ U.2 ⬝ᵥ (A *ᵥ U.2) := ha U.2
-  have hM : 0 ≤ c₀ * U.1 ^ 2 := mul_nonneg hc (sq_nonneg _)
-  have hbip : |⟪b₀, U.2⟫_ℝ| ≤ beta * ‖U.2‖ :=
-    (abs_real_inner_le_norm b₀ U.2).trans
-      (mul_le_mul_of_nonneg_right hb (norm_nonneg _))
-  have hD : -(beta * ‖U.2‖ * |U.1|) ≤ ⟪b₀, U.2⟫_ℝ * U.1 := by
-    have habs : |⟪b₀, U.2⟫_ℝ * U.1| ≤ beta * ‖U.2‖ * |U.1| := by
-      rw [abs_mul]
-      exact mul_le_mul_of_nonneg_right hbip (abs_nonneg _)
-    have := neg_abs_le (⟪b₀, U.2⟫_ℝ * U.1)
-    linarith
-  have hYoung : beta * ‖U.2‖ * |U.1| ≤
-      lam / 2 * ‖U.2‖ ^ 2 + beta ^ 2 / (2 * lam) * U.1 ^ 2 :=
-    mul_norm_abs_le_half_mul_sq_add hlam beta U.1 ‖U.2‖
-  nlinarith [hA, hM, hD, hYoung]
-
-/-- Pointwise mass-floor Gårding inequality from a dot-product lower bound. -/
-private lemma garding_energyIntegrand_self_of_mass_lower_bound_of_dotProduct_lower_bound
-    {A : Matrix n n ℝ} {b₀ : EuclideanSpace ℝ n} {c₀ : ℝ} (hlam : 0 < lam)
-    (ha : ∀ ξ : EuclideanSpace ℝ n, lam * ‖ξ‖ ^ 2 ≤ ξ ⬝ᵥ (A *ᵥ ξ))
-    (hb : ‖b₀‖ ≤ beta) (hc : mu ≤ c₀) (U : ℝ × EuclideanSpace ℝ n) :
-    lam / 2 * ‖U.2‖ ^ 2 + (mu - beta ^ 2 / (2 * lam)) * U.1 ^ 2
-      ≤ energyIntegrand A b₀ c₀ U U := by
-  have hdecomp : energyIntegrand A b₀ c₀ U U
-      = energyIntegrand A b₀ (c₀ - mu) U U + mu * U.1 ^ 2 := by
-    rw [energyIntegrand_apply, energyIntegrand_apply, massForm_apply, massForm_apply]
-    ring
-  have hgard := garding_energyIntegrand_self_of_dotProduct_lower_bound
-    (beta := beta) hlam ha hb (sub_nonneg.mpr hc) U
-  rw [hdecomp]
-  have hrw : lam / 2 * ‖U.2‖ ^ 2 + (mu - beta ^ 2 / (2 * lam)) * U.1 ^ 2
-      = lam / 2 * ‖U.2‖ ^ 2 - beta ^ 2 / (2 * lam) * U.1 ^ 2 + mu * U.1 ^ 2 := by
-    ring
-  rw [hrw]
-  linarith [hgard]
-
-/-- Explicit coercive diagonal lower bound from a dot-product lower bound. -/
-private lemma min_coercivityConstant_mul_norm_sq_le_energyIntegrand_self_of_dotProduct_lower_bound
-    {A : Matrix n n ℝ} {b₀ : EuclideanSpace ℝ n} {c₀ : ℝ} (hlam : 0 < lam)
-    (ha : ∀ ξ : EuclideanSpace ℝ n, lam * ‖ξ‖ ^ 2 ≤ ξ ⬝ᵥ (A *ᵥ ξ))
-    (hb : ‖b₀‖ ≤ beta) (hc : mu ≤ c₀) (hmu : beta ^ 2 / (2 * lam) < mu)
-    (U : ℝ × EuclideanSpace ℝ n) :
-    min (lam / 2) (mu - beta ^ 2 / (2 * lam)) * ‖U‖ ^ 2
-      ≤ energyIntegrand A b₀ c₀ U U := by
-  have hhalf : 0 < lam / 2 := half_pos hlam
-  have hdef : 0 < mu - beta ^ 2 / (2 * lam) := sub_pos.mpr hmu
-  have hnorm := min_mul_prod_norm_sq_le_add hhalf.le hdef.le U
-  rw [Real.norm_eq_abs, sq_abs] at hnorm
-  exact hnorm.trans
-    (garding_energyIntegrand_self_of_mass_lower_bound_of_dotProduct_lower_bound
-      (beta := beta) (mu := mu) hlam ha hb hc U)
-
 /-- Integrated boundedness of the raw-jet energy form from a.e. coefficient bounds.
 
 This is the scalar integral version of `norm_energyIntegrand_apply_le_of_bounds`: if the
@@ -483,7 +407,9 @@ lemma garding_energyFormIntegral_self_of_bounds (hlam : 0 < lam)
   rw [energyFormIntegral_def]
   refine integral_mono_ae hlower henergy ?_
   filter_upwards [ha, hb, hc] with x hax hbx hcx
-  exact garding_energyIntegrand_self_of_dotProduct_lower_bound hlam hax hbx hcx (U x)
+  letI := Classical.decEq n
+  exact garding_energyIntegrand_self_of_bounds hlam
+    (fun ξ => by simpa [toQuadraticForm'_eq_dotProduct] using hax ξ) hbx hcx (U x)
 
 /-- Integrated Gårding lower bound with a mass floor from a.e. lower ellipticity and a.e.
 lower-order coefficient hypotheses. -/
@@ -501,8 +427,9 @@ lemma garding_energyFormIntegral_self_of_mass_lower_bound_of_bounds (hlam : 0 < 
   rw [energyFormIntegral_def]
   refine integral_mono_ae hlower henergy ?_
   filter_upwards [ha, hb, hc] with x hax hbx hcx
-  exact garding_energyIntegrand_self_of_mass_lower_bound_of_dotProduct_lower_bound
-    hlam hax hbx hcx (U x)
+  letI := Classical.decEq n
+  exact garding_energyIntegrand_self_of_mass_lower_bound_of_bounds hlam
+    (fun ξ => by simpa [toQuadraticForm'_eq_dotProduct] using hax ξ) hbx hcx (U x)
 
 /-- Integrated explicit coercive diagonal lower bound from a.e. lower ellipticity, a.e.
 lower-order coefficient hypotheses, and a mass floor that dominates the drift defect. -/
@@ -520,8 +447,9 @@ lemma integral_min_coercivityConstant_mul_norm_sq_le_energyFormIntegral_self_of_
   rw [energyFormIntegral_def]
   refine integral_mono_ae hlower henergy ?_
   filter_upwards [ha, hb, hc] with x hax hbx hcx
-  exact min_coercivityConstant_mul_norm_sq_le_energyIntegrand_self_of_dotProduct_lower_bound
-    hlam hax hbx hcx hmu (U x)
+  letI := Classical.decEq n
+  exact min_coercivityConstant_mul_norm_sq_le_energyIntegrand_self hlam
+    (fun ξ => by simpa [toQuadraticForm'_eq_dotProduct] using hax ξ) hbx hcx hmu (U x)
 
 namespace UniformlyEllipticOn
 

--- a/TauCeti/Analysis/PDE/IntegratedEnergyForm.lean
+++ b/TauCeti/Analysis/PDE/IntegratedEnergyForm.lean
@@ -82,6 +82,61 @@ lemma energyFormIntegral_congr_ae {a' : X → Matrix n n ℝ} {b' : X → Euclid
   filter_upwards [ha, hb, hc, hU, hV] with x hax hbx hcx hUx hVx
   simp [hax, hbx, hcx, hUx, hVx]
 
+/-- The integrated energy form vanishes when the left jet field is zero. -/
+@[simp]
+lemma energyFormIntegral_zero_left :
+    energyFormIntegral μ a b c (fun _ => 0) V = 0 := by
+  simp [energyFormIntegral_def]
+
+/-- The integrated energy form vanishes when the right jet field is zero. -/
+@[simp]
+lemma energyFormIntegral_zero_right :
+    energyFormIntegral μ a b c U (fun _ => 0) = 0 := by
+  simp [energyFormIntegral_def]
+
+/-- The zero coefficient triple gives the zero integrated energy form. -/
+@[simp]
+lemma energyFormIntegral_zero_coefficients :
+    energyFormIntegral μ (fun _ => 0) (fun _ => 0) (fun _ => 0) U V = 0 := by
+  simp [energyFormIntegral_def]
+
+/-- Negating the left jet field negates the integrated energy form. -/
+@[simp]
+lemma energyFormIntegral_neg_left :
+    energyFormIntegral μ a b c (fun x => -U x) V = -energyFormIntegral μ a b c U V := by
+  rw [energyFormIntegral_def, energyFormIntegral_def]
+  have hpoint :
+      (fun x => energyIntegrand (a x) (b x) (c x) (-U x) (V x))
+        = fun x => -energyIntegrand (a x) (b x) (c x) (U x) (V x) := by
+    funext x
+    simp
+  rw [hpoint, MeasureTheory.integral_neg]
+
+/-- Negating the right jet field negates the integrated energy form. -/
+@[simp]
+lemma energyFormIntegral_neg_right :
+    energyFormIntegral μ a b c U (fun x => -V x) = -energyFormIntegral μ a b c U V := by
+  rw [energyFormIntegral_def, energyFormIntegral_def]
+  have hpoint :
+      (fun x => energyIntegrand (a x) (b x) (c x) (U x) (-V x))
+        = fun x => -energyIntegrand (a x) (b x) (c x) (U x) (V x) := by
+    funext x
+    exact map_neg (energyIntegrand (a x) (b x) (c x) (U x)) (V x)
+  rw [hpoint, MeasureTheory.integral_neg]
+
+/-- Negating the coefficient triple negates the integrated energy form. -/
+@[simp]
+lemma energyFormIntegral_neg_coefficients :
+    energyFormIntegral μ (fun x => -a x) (fun x => -b x) (fun x => -c x) U V =
+      -energyFormIntegral μ a b c U V := by
+  rw [energyFormIntegral_def, energyFormIntegral_def]
+  have hpoint :
+      (fun x => energyIntegrand (-a x) (-b x) (-c x) (U x) (V x))
+        = fun x => -energyIntegrand (a x) (b x) (c x) (U x) (V x) := by
+    funext x
+    exact energyIntegrand_neg_apply (a x) (b x) (c x) (U x) (V x)
+  rw [hpoint, MeasureTheory.integral_neg]
+
 /-- Additivity in the left jet field, assuming the two summand energy densities are
 integrable. -/
 lemma energyFormIntegral_add_left
@@ -128,7 +183,7 @@ lemma energyFormIntegral_smul_left (r : ℝ) :
     simp
   rw [hpoint]
   rw [MeasureTheory.integral_smul]
-  rfl
+  simp [smul_eq_mul]
 
 /-- Homogeneity in the right jet field. -/
 lemma energyFormIntegral_smul_right (r : ℝ) :
@@ -142,7 +197,7 @@ lemma energyFormIntegral_smul_right (r : ℝ) :
     simp
   rw [hpoint]
   rw [MeasureTheory.integral_smul]
-  rfl
+  simp [smul_eq_mul]
 
 variable (a' : X → Matrix n n ℝ) (b' : X → EuclideanSpace ℝ n) (c' : X → ℝ)
 variable (m : X → ℝ) (r : ℝ)
@@ -195,7 +250,7 @@ lemma energyFormIntegral_smul :
     simp
   rw [hpoint]
   rw [MeasureTheory.integral_smul]
-  rfl
+  simp [smul_eq_mul]
 
 /-- The integrated full energy form splits into its principal and lower-order parts. -/
 lemma energyFormIntegral_principal_add_lowerOrder
@@ -253,11 +308,9 @@ lemma energyFormIntegral_principal_drift_mass
             energyFormIntegral μ (fun _ => 0) (fun _ => 0) c U V := by
       rw [add_assoc]
 
-variable [DecidableEq n]
-
 /-- The integrated full energy form is a shifted-Laplacian model plus the residual
 coefficient perturbation. -/
-lemma energyFormIntegral_eq_one_zero_baseMass_add_perturbation
+lemma energyFormIntegral_eq_one_zero_baseMass_add_perturbation [DecidableEq n]
     (hmodel : Integrable
       (fun x => energyIntegrand (1 : Matrix n n ℝ) 0 (m x) (U x) (V x)) μ)
     (hpert : Integrable
@@ -278,7 +331,7 @@ lemma energyFormIntegral_eq_one_zero_baseMass_add_perturbation
 
 /-- The integrated full energy form is the shifted-Laplacian form with the same mass plus the
 principal-and-drift perturbation. -/
-lemma energyFormIntegral_eq_one_zero_mass_add_perturbation
+lemma energyFormIntegral_eq_one_zero_mass_add_perturbation [DecidableEq n]
     (hmodel : Integrable
       (fun x => energyIntegrand (1 : Matrix n n ℝ) 0 (c x) (U x) (V x)) μ)
     (hpert : Integrable
@@ -292,14 +345,17 @@ lemma energyFormIntegral_eq_one_zero_mass_add_perturbation
 
 /-- The integrated `−Δ` model form is the integral of the dot product of the two gradient
 components of the jet fields. -/
-lemma energyFormIntegral_one_zero_zero :
+lemma energyFormIntegral_one_zero_zero [DecidableEq n] :
     energyFormIntegral μ (fun _ => (1 : Matrix n n ℝ)) (fun _ => 0) (fun _ => 0) U V =
       ∫ x, ((V x).2 ⬝ᵥ (U x).2) ∂μ := by
-  simp [energyFormIntegral_def]
+  rw [energyFormIntegral_def]
+  apply MeasureTheory.integral_congr_ae
+  exact Filter.Eventually.of_forall fun x =>
+    energyIntegrand_one_zero_zero_apply (U x) (V x)
 
 /-- The integrated shifted Laplacian model form `−Δ + c` is the sum of the Dirichlet density
 and the mass density. -/
-lemma energyFormIntegral_one_zero_mass (m : X → ℝ) :
+lemma energyFormIntegral_one_zero_mass [DecidableEq n] (m : X → ℝ) :
     energyFormIntegral μ (fun _ => (1 : Matrix n n ℝ)) (fun _ => 0) m U V =
       ∫ x, ((V x).2 ⬝ᵥ (U x).2 + m x * (U x).1 * (V x).1) ∂μ := by
   rw [energyFormIntegral_def]
@@ -309,7 +365,7 @@ lemma energyFormIntegral_one_zero_mass (m : X → ℝ) :
 
 /-- The diagonal of the integrated shifted Laplacian model is the integral of
 `‖∇u‖² + c u²` at the jet level. -/
-lemma energyFormIntegral_one_zero_mass_self (m : X → ℝ) :
+lemma energyFormIntegral_one_zero_mass_self [DecidableEq n] (m : X → ℝ) :
     energyFormIntegral μ (fun _ => (1 : Matrix n n ℝ)) (fun _ => 0) m U U =
       ∫ x, (‖(U x).2‖ ^ 2 + m x * (U x).1 ^ 2) ∂μ := by
   rw [energyFormIntegral_def]
@@ -319,7 +375,82 @@ lemma energyFormIntegral_one_zero_mass_self (m : X → ℝ) :
 
 variable {Lam beta gamma : ℝ}
 
-omit [DecidableEq n] in
+/-- Weighted Young inequality used to absorb the first-order drift term. -/
+private lemma mul_norm_abs_le_half_mul_sq_add (hlam : 0 < lam) (beta u r : ℝ) :
+    beta * r * |u| ≤ lam / 2 * r ^ 2 + beta ^ 2 / (2 * lam) * u ^ 2 := by
+  have hkey := two_mul_le_add_sq (lam * r) (beta * |u|)
+  rw [mul_pow, mul_pow, sq_abs] at hkey
+  have h2lam : (0 : ℝ) < 2 * lam := mul_pos two_pos hlam
+  rw [← sub_nonneg]
+  have expand : lam / 2 * r ^ 2 + beta ^ 2 / (2 * lam) * u ^ 2 - beta * r * |u|
+      = (lam ^ 2 * r ^ 2 + beta ^ 2 * u ^ 2 - 2 * lam * beta * r * |u|)
+          / (2 * lam) := by
+    field_simp
+  rw [expand]
+  apply div_nonneg _ h2lam.le
+  nlinarith [hkey]
+
+/-- Pointwise Gårding inequality from a dot-product lower bound, avoiding the
+`Matrix.toQuadraticForm'` API. -/
+private lemma garding_energyIntegrand_self_of_dotProduct_lower_bound {A : Matrix n n ℝ}
+    {b₀ : EuclideanSpace ℝ n} {c₀ : ℝ} (hlam : 0 < lam)
+    (ha : ∀ ξ : EuclideanSpace ℝ n, lam * ‖ξ‖ ^ 2 ≤ ξ ⬝ᵥ (A *ᵥ ξ))
+    (hb : ‖b₀‖ ≤ beta) (hc : 0 ≤ c₀) (U : ℝ × EuclideanSpace ℝ n) :
+    lam / 2 * ‖U.2‖ ^ 2 - beta ^ 2 / (2 * lam) * U.1 ^ 2
+      ≤ energyIntegrand A b₀ c₀ U U := by
+  rw [energyIntegrand_apply, matrixBilinearForm_apply, driftForm_apply, massForm_apply]
+  have hA : lam * ‖U.2‖ ^ 2 ≤ U.2 ⬝ᵥ (A *ᵥ U.2) := ha U.2
+  have hM : 0 ≤ c₀ * U.1 ^ 2 := mul_nonneg hc (sq_nonneg _)
+  have hbip : |⟪b₀, U.2⟫_ℝ| ≤ beta * ‖U.2‖ :=
+    (abs_real_inner_le_norm b₀ U.2).trans
+      (mul_le_mul_of_nonneg_right hb (norm_nonneg _))
+  have hD : -(beta * ‖U.2‖ * |U.1|) ≤ ⟪b₀, U.2⟫_ℝ * U.1 := by
+    have habs : |⟪b₀, U.2⟫_ℝ * U.1| ≤ beta * ‖U.2‖ * |U.1| := by
+      rw [abs_mul]
+      exact mul_le_mul_of_nonneg_right hbip (abs_nonneg _)
+    have := neg_abs_le (⟪b₀, U.2⟫_ℝ * U.1)
+    linarith
+  have hYoung : beta * ‖U.2‖ * |U.1| ≤
+      lam / 2 * ‖U.2‖ ^ 2 + beta ^ 2 / (2 * lam) * U.1 ^ 2 :=
+    mul_norm_abs_le_half_mul_sq_add hlam beta U.1 ‖U.2‖
+  nlinarith [hA, hM, hD, hYoung]
+
+/-- Pointwise mass-floor Gårding inequality from a dot-product lower bound. -/
+private lemma garding_energyIntegrand_self_of_mass_lower_bound_of_dotProduct_lower_bound
+    {A : Matrix n n ℝ} {b₀ : EuclideanSpace ℝ n} {c₀ : ℝ} (hlam : 0 < lam)
+    (ha : ∀ ξ : EuclideanSpace ℝ n, lam * ‖ξ‖ ^ 2 ≤ ξ ⬝ᵥ (A *ᵥ ξ))
+    (hb : ‖b₀‖ ≤ beta) (hc : mu ≤ c₀) (U : ℝ × EuclideanSpace ℝ n) :
+    lam / 2 * ‖U.2‖ ^ 2 + (mu - beta ^ 2 / (2 * lam)) * U.1 ^ 2
+      ≤ energyIntegrand A b₀ c₀ U U := by
+  have hdecomp : energyIntegrand A b₀ c₀ U U
+      = energyIntegrand A b₀ (c₀ - mu) U U + mu * U.1 ^ 2 := by
+    rw [energyIntegrand_apply, energyIntegrand_apply, massForm_apply, massForm_apply]
+    ring
+  have hgard := garding_energyIntegrand_self_of_dotProduct_lower_bound
+    (beta := beta) hlam ha hb (sub_nonneg.mpr hc) U
+  rw [hdecomp]
+  have hrw : lam / 2 * ‖U.2‖ ^ 2 + (mu - beta ^ 2 / (2 * lam)) * U.1 ^ 2
+      = lam / 2 * ‖U.2‖ ^ 2 - beta ^ 2 / (2 * lam) * U.1 ^ 2 + mu * U.1 ^ 2 := by
+    ring
+  rw [hrw]
+  linarith [hgard]
+
+/-- Explicit coercive diagonal lower bound from a dot-product lower bound. -/
+private lemma min_coercivityConstant_mul_norm_sq_le_energyIntegrand_self_of_dotProduct_lower_bound
+    {A : Matrix n n ℝ} {b₀ : EuclideanSpace ℝ n} {c₀ : ℝ} (hlam : 0 < lam)
+    (ha : ∀ ξ : EuclideanSpace ℝ n, lam * ‖ξ‖ ^ 2 ≤ ξ ⬝ᵥ (A *ᵥ ξ))
+    (hb : ‖b₀‖ ≤ beta) (hc : mu ≤ c₀) (hmu : beta ^ 2 / (2 * lam) < mu)
+    (U : ℝ × EuclideanSpace ℝ n) :
+    min (lam / 2) (mu - beta ^ 2 / (2 * lam)) * ‖U‖ ^ 2
+      ≤ energyIntegrand A b₀ c₀ U U := by
+  have hhalf : 0 < lam / 2 := half_pos hlam
+  have hdef : 0 < mu - beta ^ 2 / (2 * lam) := sub_pos.mpr hmu
+  have hnorm := min_mul_prod_norm_sq_le_add hhalf.le hdef.le U
+  rw [Real.norm_eq_abs, sq_abs] at hnorm
+  exact hnorm.trans
+    (garding_energyIntegrand_self_of_mass_lower_bound_of_dotProduct_lower_bound
+      (beta := beta) (mu := mu) hlam ha hb hc U)
+
 /-- Integrated boundedness of the raw-jet energy form from a.e. coefficient bounds.
 
 This is the scalar integral version of `norm_energyIntegrand_apply_le_of_bounds`: if the
@@ -342,7 +473,7 @@ lemma norm_energyFormIntegral_le_of_bounds (hLam : 0 ≤ Lam)
 coefficient hypotheses. -/
 lemma garding_energyFormIntegral_self_of_bounds (hlam : 0 < lam)
     (ha : ∀ᵐ x ∂μ, ∀ ξ : EuclideanSpace ℝ n,
-      lam * ‖ξ‖ ^ 2 ≤ (a x).toQuadraticForm' ξ)
+      lam * ‖ξ‖ ^ 2 ≤ ξ ⬝ᵥ (a x *ᵥ ξ))
     (hb : ∀ᵐ x ∂μ, ‖b x‖ ≤ beta) (hc : ∀ᵐ x ∂μ, 0 ≤ c x)
     (hlower : Integrable
       (fun x => lam / 2 * ‖(U x).2‖ ^ 2 - beta ^ 2 / (2 * lam) * (U x).1 ^ 2) μ)
@@ -352,13 +483,13 @@ lemma garding_energyFormIntegral_self_of_bounds (hlam : 0 < lam)
   rw [energyFormIntegral_def]
   refine integral_mono_ae hlower henergy ?_
   filter_upwards [ha, hb, hc] with x hax hbx hcx
-  exact garding_energyIntegrand_self_of_bounds hlam hax hbx hcx (U x)
+  exact garding_energyIntegrand_self_of_dotProduct_lower_bound hlam hax hbx hcx (U x)
 
 /-- Integrated Gårding lower bound with a mass floor from a.e. lower ellipticity and a.e.
 lower-order coefficient hypotheses. -/
 lemma garding_energyFormIntegral_self_of_mass_lower_bound_of_bounds (hlam : 0 < lam)
     (ha : ∀ᵐ x ∂μ, ∀ ξ : EuclideanSpace ℝ n,
-      lam * ‖ξ‖ ^ 2 ≤ (a x).toQuadraticForm' ξ)
+      lam * ‖ξ‖ ^ 2 ≤ ξ ⬝ᵥ (a x *ᵥ ξ))
     (hb : ∀ᵐ x ∂μ, ‖b x‖ ≤ beta) (hc : ∀ᵐ x ∂μ, mu ≤ c x)
     (hlower : Integrable
       (fun x => lam / 2 * ‖(U x).2‖ ^ 2 +
@@ -370,14 +501,15 @@ lemma garding_energyFormIntegral_self_of_mass_lower_bound_of_bounds (hlam : 0 < 
   rw [energyFormIntegral_def]
   refine integral_mono_ae hlower henergy ?_
   filter_upwards [ha, hb, hc] with x hax hbx hcx
-  exact garding_energyIntegrand_self_of_mass_lower_bound_of_bounds hlam hax hbx hcx (U x)
+  exact garding_energyIntegrand_self_of_mass_lower_bound_of_dotProduct_lower_bound
+    hlam hax hbx hcx (U x)
 
 /-- Integrated explicit coercive diagonal lower bound from a.e. lower ellipticity, a.e.
 lower-order coefficient hypotheses, and a mass floor that dominates the drift defect. -/
 lemma integral_min_coercivityConstant_mul_norm_sq_le_energyFormIntegral_self_of_bounds
     (hlam : 0 < lam)
     (ha : ∀ᵐ x ∂μ, ∀ ξ : EuclideanSpace ℝ n,
-      lam * ‖ξ‖ ^ 2 ≤ (a x).toQuadraticForm' ξ)
+      lam * ‖ξ‖ ^ 2 ≤ ξ ⬝ᵥ (a x *ᵥ ξ))
     (hb : ∀ᵐ x ∂μ, ‖b x‖ ≤ beta) (hc : ∀ᵐ x ∂μ, mu ≤ c x)
     (hmu : beta ^ 2 / (2 * lam) < mu)
     (hlower : Integrable
@@ -388,11 +520,12 @@ lemma integral_min_coercivityConstant_mul_norm_sq_le_energyFormIntegral_self_of_
   rw [energyFormIntegral_def]
   refine integral_mono_ae hlower henergy ?_
   filter_upwards [ha, hb, hc] with x hax hbx hcx
-  exact min_coercivityConstant_mul_norm_sq_le_energyIntegrand_self
+  exact min_coercivityConstant_mul_norm_sq_le_energyIntegrand_self_of_dotProduct_lower_bound
     hlam hax hbx hcx hmu (U x)
 
 namespace UniformlyEllipticOn
 
+variable [DecidableEq n]
 variable {Ω : Set X} {lam Lam beta gamma mu : ℝ}
 variable {a : X → Matrix n n ℝ} {b : X → EuclideanSpace ℝ n} {c : X → ℝ}
 variable {U V : X → ℝ × EuclideanSpace ℝ n}
@@ -423,7 +556,8 @@ lemma garding_energyFormIntegral_self_on (h : UniformlyEllipticOn Ω a lam Lam)
   refine PDE.garding_energyFormIntegral_self_of_bounds (μ := μ) (a := a) (b := b) (c := c)
     (U := U) h.pos ?_ hb hc hlower henergy
   filter_upwards [hΩ] with x hx
-  exact h.lower_bound hx
+  intro ξ
+  simpa [toQuadraticForm'_eq_dotProduct] using h.lower_bound hx ξ
 
 /-- Integrated Gårding lower bound with a mass floor from uniform ellipticity and a.e.
 coefficient hypotheses. -/
@@ -440,7 +574,8 @@ lemma garding_energyFormIntegral_self_of_mass_lower_bound_on
   refine PDE.garding_energyFormIntegral_self_of_mass_lower_bound_of_bounds (μ := μ) (a := a)
     (b := b) (c := c) (U := U) h.pos ?_ hb hc hlower henergy
   filter_upwards [hΩ] with x hx
-  exact h.lower_bound hx
+  intro ξ
+  simpa [toQuadraticForm'_eq_dotProduct] using h.lower_bound hx ξ
 
 /-- Integrated explicit coercive diagonal lower bound from uniform ellipticity, a.e.
 coefficient hypotheses, and a mass floor that dominates the drift defect. -/
@@ -456,7 +591,8 @@ lemma integral_min_coercivityConstant_mul_norm_sq_le_energyFormIntegral_self_on
   refine PDE.integral_min_coercivityConstant_mul_norm_sq_le_energyFormIntegral_self_of_bounds
     (μ := μ) (a := a) (b := b) (c := c) (U := U) h.pos ?_ hb hc hmu hlower henergy
   filter_upwards [hΩ] with x hx
-  exact h.lower_bound hx
+  intro ξ
+  simpa [toQuadraticForm'_eq_dotProduct] using h.lower_bound hx ξ
 
 end UniformlyEllipticOn
 

--- a/TauCeti/Analysis/PDE/IntegratedEnergyForm.lean
+++ b/TauCeti/Analysis/PDE/IntegratedEnergyForm.lean
@@ -4,7 +4,8 @@ Released under Apache 2.0 license as described in the file LICENSE.
 -/
 module
 
-public import TauCeti.Analysis.PDE.EnergyFormIntegrability
+public import TauCeti.Analysis.PDE.EnergyFormLinearity
+public import TauCeti.Analysis.PDE.UniformEllipticEnergy
 public import Mathlib.MeasureTheory.Integral.Bochner.Basic
 
 /-!
@@ -29,7 +30,7 @@ derivative: once Lane A supplies `W^{k,p}(Ω)`, its value-gradient jets can feed
   `TauCeti.PDE.energyFormIntegral_smul_left`, and
   `TauCeti.PDE.energyFormIntegral_smul_right`: bilinearity identities under the usual
   Bochner-integrability hypotheses.
-* `TauCeti.PDE.norm_energyFormIntegral_le_of_bound`: the integrated boundedness estimate
+* `TauCeti.PDE.norm_energyFormIntegral_le_of_bounds`: the integrated boundedness estimate
   obtained from the pointwise coefficient bounds.
 -/
 
@@ -87,11 +88,13 @@ lemma energyFormIntegral_add_left
     energyFormIntegral μ a b c (fun x => U x + W x) V =
       energyFormIntegral μ a b c U V + energyFormIntegral μ a b c W V := by
   rw [energyFormIntegral_def, energyFormIntegral_def, energyFormIntegral_def]
-  rw [show (∫ x, (energyIntegrand (a x) (b x) (c x) ((fun y => U y + W y) x) (V x)) ∂μ)
-      = ∫ x, (energyIntegrand (a x) (b x) (c x) (U x) (V x) +
-          energyIntegrand (a x) (b x) (c x) (W x) (V x)) ∂μ by
-    apply MeasureTheory.integral_congr_ae
-    exact Filter.Eventually.of_forall fun x => by simp]
+  have hpoint :
+      (fun x => energyIntegrand (a x) (b x) (c x) (U x + W x) (V x))
+        = fun x => energyIntegrand (a x) (b x) (c x) (U x) (V x) +
+            energyIntegrand (a x) (b x) (c x) (W x) (V x) := by
+    funext x
+    simp
+  rw [hpoint]
   exact integral_add hU hW
 
 /-- Additivity in the right jet field, assuming the two summand energy densities are
@@ -102,12 +105,13 @@ lemma energyFormIntegral_add_right
     energyFormIntegral μ a b c U (fun x => V x + W x) =
       energyFormIntegral μ a b c U V + energyFormIntegral μ a b c U W := by
   rw [energyFormIntegral_def, energyFormIntegral_def, energyFormIntegral_def]
-  rw [show (∫ x, (energyIntegrand (a x) (b x) (c x) (U x) ((fun y => V y + W y) x)) ∂μ)
-      = ∫ x, (energyIntegrand (a x) (b x) (c x) (U x) (V x) +
-          energyIntegrand (a x) (b x) (c x) (U x) (W x)) ∂μ by
-    apply MeasureTheory.integral_congr_ae
-    exact Filter.Eventually.of_forall fun x =>
-      map_add (energyIntegrand (a x) (b x) (c x) (U x)) (V x) (W x)]
+  have hpoint :
+      (fun x => energyIntegrand (a x) (b x) (c x) (U x) (V x + W x))
+        = fun x => energyIntegrand (a x) (b x) (c x) (U x) (V x) +
+            energyIntegrand (a x) (b x) (c x) (U x) (W x) := by
+    funext x
+    exact map_add (energyIntegrand (a x) (b x) (c x) (U x)) (V x) (W x)
+  rw [hpoint]
   exact integral_add hV hW
 
 /-- Homogeneity in the left jet field. -/
@@ -115,10 +119,12 @@ lemma energyFormIntegral_smul_left (r : ℝ) :
     energyFormIntegral μ a b c (fun x => r • U x) V =
       r * energyFormIntegral μ a b c U V := by
   rw [energyFormIntegral_def, energyFormIntegral_def]
-  rw [show (∫ x, (energyIntegrand (a x) (b x) (c x) ((fun y => r • U y) x) (V x)) ∂μ)
-      = ∫ x, (r • energyIntegrand (a x) (b x) (c x) (U x) (V x)) ∂μ by
-    apply MeasureTheory.integral_congr_ae
-    exact Filter.Eventually.of_forall fun x => by simp]
+  have hpoint :
+      (fun x => energyIntegrand (a x) (b x) (c x) (r • U x) (V x))
+        = fun x => r • energyIntegrand (a x) (b x) (c x) (U x) (V x) := by
+    funext x
+    simp
+  rw [hpoint]
   rw [MeasureTheory.integral_smul]
   rfl
 
@@ -127,14 +133,159 @@ lemma energyFormIntegral_smul_right (r : ℝ) :
     energyFormIntegral μ a b c U (fun x => r • V x) =
       r * energyFormIntegral μ a b c U V := by
   rw [energyFormIntegral_def, energyFormIntegral_def]
-  rw [show (∫ x, (energyIntegrand (a x) (b x) (c x) (U x) ((fun y => r • V y) x)) ∂μ)
-      = ∫ x, (r • energyIntegrand (a x) (b x) (c x) (U x) (V x)) ∂μ by
-    apply MeasureTheory.integral_congr_ae
-    exact Filter.Eventually.of_forall fun x => by simp]
+  have hpoint :
+      (fun x => energyIntegrand (a x) (b x) (c x) (U x) (r • V x))
+        = fun x => r • energyIntegrand (a x) (b x) (c x) (U x) (V x) := by
+    funext x
+    simp
+  rw [hpoint]
   rw [MeasureTheory.integral_smul]
   rfl
 
+variable (a' : X → Matrix n n ℝ) (b' : X → EuclideanSpace ℝ n) (c' : X → ℝ)
+variable (m : X → ℝ) (r : ℝ)
+
+/-- The integrated energy form is additive in the coefficient triple, under the corresponding
+integrability assumptions for the two summand densities. -/
+lemma energyFormIntegral_add
+    (h : Integrable (fun x => energyIntegrand (a x) (b x) (c x) (U x) (V x)) μ)
+    (h' : Integrable (fun x => energyIntegrand (a' x) (b' x) (c' x) (U x) (V x)) μ) :
+    energyFormIntegral μ (fun x => a x + a' x) (fun x => b x + b' x) (fun x => c x + c' x)
+        U V =
+      energyFormIntegral μ a b c U V + energyFormIntegral μ a' b' c' U V := by
+  rw [energyFormIntegral_def, energyFormIntegral_def, energyFormIntegral_def]
+  have hpoint :
+      (fun x => energyIntegrand (a x + a' x) (b x + b' x) (c x + c' x) (U x) (V x))
+        = fun x => energyIntegrand (a x) (b x) (c x) (U x) (V x) +
+            energyIntegrand (a' x) (b' x) (c' x) (U x) (V x) := by
+    funext x
+    exact energyIntegrand_add_apply (a x) (a' x) (b x) (b' x) (c x) (c' x) (U x) (V x)
+  rw [hpoint]
+  exact integral_add h h'
+
+/-- The integrated energy form is subtractive in the coefficient triple, under the
+corresponding integrability assumptions for the two densities. -/
+lemma energyFormIntegral_sub
+    (h : Integrable (fun x => energyIntegrand (a x) (b x) (c x) (U x) (V x)) μ)
+    (h' : Integrable (fun x => energyIntegrand (a' x) (b' x) (c' x) (U x) (V x)) μ) :
+    energyFormIntegral μ (fun x => a x - a' x) (fun x => b x - b' x) (fun x => c x - c' x)
+        U V =
+      energyFormIntegral μ a b c U V - energyFormIntegral μ a' b' c' U V := by
+  rw [energyFormIntegral_def, energyFormIntegral_def, energyFormIntegral_def]
+  have hpoint :
+      (fun x => energyIntegrand (a x - a' x) (b x - b' x) (c x - c' x) (U x) (V x))
+        = fun x => energyIntegrand (a x) (b x) (c x) (U x) (V x) -
+            energyIntegrand (a' x) (b' x) (c' x) (U x) (V x) := by
+    funext x
+    exact energyIntegrand_sub_apply (a x) (a' x) (b x) (b' x) (c x) (c' x) (U x) (V x)
+  rw [hpoint]
+  exact integral_sub h h'
+
+/-- The integrated energy form is homogeneous in the coefficient triple. -/
+lemma energyFormIntegral_smul :
+    energyFormIntegral μ (fun x => r • a x) (fun x => r • b x) (fun x => r * c x) U V =
+      r * energyFormIntegral μ a b c U V := by
+  rw [energyFormIntegral_def, energyFormIntegral_def]
+  have hpoint :
+      (fun x => energyIntegrand (r • a x) (r • b x) (r * c x) (U x) (V x))
+        = fun x => r • energyIntegrand (a x) (b x) (c x) (U x) (V x) := by
+    funext x
+    simp
+  rw [hpoint]
+  rw [MeasureTheory.integral_smul]
+  rfl
+
+/-- The integrated full energy form splits into its principal and lower-order parts. -/
+lemma energyFormIntegral_principal_add_lowerOrder
+    (hprincipal : Integrable (fun x => energyIntegrand (a x) 0 0 (U x) (V x)) μ)
+    (hlower : Integrable (fun x => energyIntegrand 0 (b x) (c x) (U x) (V x)) μ) :
+    energyFormIntegral μ a b c U V =
+      energyFormIntegral μ a (fun _ => 0) (fun _ => 0) U V +
+        energyFormIntegral μ (fun _ => 0) b c U V := by
+  rw [energyFormIntegral_def, energyFormIntegral_def, energyFormIntegral_def]
+  have hpoint :
+      (fun x => energyIntegrand (a x) (b x) (c x) (U x) (V x))
+        = fun x => energyIntegrand (a x) 0 0 (U x) (V x) +
+            energyIntegrand 0 (b x) (c x) (U x) (V x) := by
+    funext x
+    exact energyIntegrand_principal_add_lowerOrder_apply (a x) (b x) (c x) (U x) (V x)
+  rw [hpoint]
+  exact integral_add hprincipal hlower
+
+/-- The integrated full energy form splits into its principal, drift, and mass pieces. -/
+lemma energyFormIntegral_principal_drift_mass
+    (hprincipal : Integrable (fun x => energyIntegrand (a x) 0 0 (U x) (V x)) μ)
+    (hdrift : Integrable (fun x => energyIntegrand 0 (b x) 0 (U x) (V x)) μ)
+    (hmass : Integrable (fun x => energyIntegrand 0 0 (c x) (U x) (V x)) μ) :
+    energyFormIntegral μ a b c U V =
+      energyFormIntegral μ a (fun _ => 0) (fun _ => 0) U V +
+        energyFormIntegral μ (fun _ => 0) b (fun _ => 0) U V +
+          energyFormIntegral μ (fun _ => 0) (fun _ => 0) c U V := by
+  rw [energyFormIntegral_def, energyFormIntegral_def, energyFormIntegral_def,
+    energyFormIntegral_def]
+  have hpoint :
+      (fun x => energyIntegrand (a x) (b x) (c x) (U x) (V x))
+        = fun x => energyIntegrand (a x) 0 0 (U x) (V x) +
+            energyIntegrand 0 (b x) 0 (U x) (V x) +
+              energyIntegrand 0 0 (c x) (U x) (V x) := by
+    funext x
+    exact energyIntegrand_principal_drift_mass_apply (a x) (b x) (c x) (U x) (V x)
+  rw [hpoint]
+  let f := fun x => energyIntegrand (a x) 0 0 (U x) (V x)
+  let g := fun x => energyIntegrand 0 (b x) 0 (U x) (V x)
+  let k := fun x => energyIntegrand 0 0 (c x) (U x) (V x)
+  change (∫ x, f x + g x + k x ∂μ) =
+    (∫ x, f x ∂μ) + (∫ x, g x ∂μ) + ∫ x, k x ∂μ
+  calc
+    ∫ x, f x + g x + k x ∂μ = ∫ x, (f x + g x) + k x ∂μ := by rfl
+    _ = (∫ x, f x + g x ∂μ) + ∫ x, k x ∂μ :=
+      integral_add (hprincipal.add hdrift) hmass
+    _ = (∫ x, f x ∂μ) + (∫ x, g x ∂μ) + ∫ x, k x ∂μ := by
+      rw [integral_add hprincipal hdrift]
+
 variable [DecidableEq n]
+
+/-- The integrated full energy form is a shifted-Laplacian model plus the residual
+coefficient perturbation. -/
+lemma energyFormIntegral_eq_one_zero_baseMass_add_perturbation
+    (hmodel : Integrable
+      (fun x => energyIntegrand (1 : Matrix n n ℝ) 0 (m x) (U x) (V x)) μ)
+    (hpert : Integrable
+      (fun x => energyIntegrand (a x - 1) (b x) (c x - m x) (U x) (V x)) μ) :
+    energyFormIntegral μ a b c U V =
+      energyFormIntegral μ (fun _ => (1 : Matrix n n ℝ)) (fun _ => 0) m U V +
+        energyFormIntegral μ (fun x => a x - 1) b (fun x => c x - m x) U V := by
+  rw [energyFormIntegral_def, energyFormIntegral_def, energyFormIntegral_def]
+  have hpoint :
+      (fun x => energyIntegrand (a x) (b x) (c x) (U x) (V x))
+        = fun x => energyIntegrand (1 : Matrix n n ℝ) 0 (m x) (U x) (V x) +
+            energyIntegrand (a x - 1) (b x) (c x - m x) (U x) (V x) := by
+    funext x
+    exact energyIntegrand_eq_one_zero_baseMass_add_perturbation_apply
+      (a x) (b x) (c x) (m x) (U x) (V x)
+  rw [hpoint]
+  exact integral_add hmodel hpert
+
+/-- The integrated full energy form is the shifted-Laplacian form with the same mass plus the
+principal-and-drift perturbation. -/
+lemma energyFormIntegral_eq_one_zero_mass_add_perturbation
+    (hmodel : Integrable
+      (fun x => energyIntegrand (1 : Matrix n n ℝ) 0 (c x) (U x) (V x)) μ)
+    (hpert : Integrable
+      (fun x => energyIntegrand (a x - 1) (b x) 0 (U x) (V x)) μ) :
+    energyFormIntegral μ a b c U V =
+      energyFormIntegral μ (fun _ => (1 : Matrix n n ℝ)) (fun _ => 0) c U V +
+        energyFormIntegral μ (fun x => a x - 1) b (fun _ => 0) U V := by
+  rw [energyFormIntegral_def, energyFormIntegral_def, energyFormIntegral_def]
+  have hpoint :
+      (fun x => energyIntegrand (a x) (b x) (c x) (U x) (V x))
+        = fun x => energyIntegrand (1 : Matrix n n ℝ) 0 (c x) (U x) (V x) +
+            energyIntegrand (a x - 1) (b x) 0 (U x) (V x) := by
+    funext x
+    exact energyIntegrand_eq_one_zero_mass_add_perturbation_apply
+      (a x) (b x) (c x) (U x) (V x)
+  rw [hpoint]
+  exact integral_add hmodel hpert
 
 /-- The integrated `−Δ` model form is the integral of the dot product of the two gradient
 components of the jet fields. -/
@@ -166,22 +317,79 @@ lemma energyFormIntegral_one_zero_mass_self (m : X → ℝ) :
 variable {Lam beta gamma : ℝ}
 
 omit [DecidableEq n] in
-/-- Integrated boundedness of the raw-jet energy form from pointwise coefficient bounds.
+/-- Integrated boundedness of the raw-jet energy form from a.e. coefficient bounds.
 
 This is the scalar integral version of `norm_energyIntegrand_apply_le_of_bounds`: if the
 pointwise jet product `‖U x‖ * ‖V x‖` is integrable, the absolute value of the integrated form
 is bounded by `(Λ + β + γ)` times its integral. -/
-lemma norm_energyFormIntegral_le_of_bound (hLam : 0 ≤ Lam)
-    (ha : ∀ x, ∀ η ξ : EuclideanSpace ℝ n,
+lemma norm_energyFormIntegral_le_of_bounds (hLam : 0 ≤ Lam)
+    (ha : ∀ᵐ x ∂μ, ∀ η ξ : EuclideanSpace ℝ n,
       |η ⬝ᵥ (a x *ᵥ ξ)| ≤ Lam * ‖η‖ * ‖ξ‖)
-    (hb : ∀ x, ‖b x‖ ≤ beta) (hc : ∀ x, ‖c x‖ ≤ gamma)
+    (hb : ∀ᵐ x ∂μ, ‖b x‖ ≤ beta) (hc : ∀ᵐ x ∂μ, ‖c x‖ ≤ gamma)
     (hUV : Integrable (fun x => (Lam + beta + gamma) * (‖U x‖ * ‖V x‖)) μ) :
     ‖energyFormIntegral μ a b c U V‖ ≤
       ∫ x, ((Lam + beta + gamma) * (‖U x‖ * ‖V x‖)) ∂μ := by
   rw [energyFormIntegral_def]
-  refine norm_integral_le_of_norm_le hUV (Filter.Eventually.of_forall fun x => ?_)
+  refine norm_integral_le_of_norm_le hUV ?_
+  filter_upwards [ha, hb, hc] with x hax hbx hcx
   simpa [mul_assoc] using
-    norm_energyIntegrand_apply_le_of_bounds hLam (ha x) (hb x) (hc x) (U x) (V x)
+    norm_energyIntegrand_apply_le_of_bounds hLam hax hbx hcx (U x) (V x)
+
+namespace UniformlyEllipticOn
+
+variable {Ω : Set X} {lam Lam beta mu : ℝ}
+variable {a : X → Matrix n n ℝ} {b : X → EuclideanSpace ℝ n} {c : X → ℝ}
+variable {U : X → ℝ × EuclideanSpace ℝ n}
+
+/-- Integrated Gårding lower bound from uniform ellipticity and a.e. lower-order
+coefficient hypotheses. -/
+lemma garding_energyFormIntegral_self_on (h : UniformlyEllipticOn Ω a lam Lam)
+    (hΩ : ∀ᵐ x ∂μ, x ∈ Ω) (hb : ∀ᵐ x ∂μ, ‖b x‖ ≤ beta)
+    (hc : ∀ᵐ x ∂μ, 0 ≤ c x)
+    (hlower : Integrable
+      (fun x => lam / 2 * ‖(U x).2‖ ^ 2 - beta ^ 2 / (2 * lam) * (U x).1 ^ 2) μ)
+    (henergy : Integrable (fun x => energyIntegrand (a x) (b x) (c x) (U x) (U x)) μ) :
+    ∫ x, (lam / 2 * ‖(U x).2‖ ^ 2 - beta ^ 2 / (2 * lam) * (U x).1 ^ 2) ∂μ
+      ≤ energyFormIntegral μ a b c U U := by
+  rw [energyFormIntegral_def]
+  refine integral_mono_ae hlower henergy ?_
+  filter_upwards [hΩ, hb, hc] with x hx hbx hcx
+  exact h.garding_energyIntegrand_self hx hbx hcx (U x)
+
+/-- Integrated Gårding lower bound with a mass floor from uniform ellipticity and a.e.
+coefficient hypotheses. -/
+lemma garding_energyFormIntegral_self_of_mass_lower_bound_on
+    (h : UniformlyEllipticOn Ω a lam Lam) (hΩ : ∀ᵐ x ∂μ, x ∈ Ω)
+    (hb : ∀ᵐ x ∂μ, ‖b x‖ ≤ beta) (hc : ∀ᵐ x ∂μ, mu ≤ c x)
+    (hlower : Integrable
+      (fun x => lam / 2 * ‖(U x).2‖ ^ 2 +
+        (mu - beta ^ 2 / (2 * lam)) * (U x).1 ^ 2) μ)
+    (henergy : Integrable (fun x => energyIntegrand (a x) (b x) (c x) (U x) (U x)) μ) :
+    ∫ x, (lam / 2 * ‖(U x).2‖ ^ 2 +
+        (mu - beta ^ 2 / (2 * lam)) * (U x).1 ^ 2) ∂μ
+      ≤ energyFormIntegral μ a b c U U := by
+  rw [energyFormIntegral_def]
+  refine integral_mono_ae hlower henergy ?_
+  filter_upwards [hΩ, hb, hc] with x hx hbx hcx
+  exact h.garding_energyIntegrand_self_of_mass_lower_bound hx hbx hcx (U x)
+
+/-- Integrated explicit coercive diagonal lower bound from uniform ellipticity, a.e.
+coefficient hypotheses, and a mass floor that dominates the drift defect. -/
+lemma min_coercivityConstant_mul_integral_norm_sq_le_energyFormIntegral_self_on
+    (h : UniformlyEllipticOn Ω a lam Lam) (hΩ : ∀ᵐ x ∂μ, x ∈ Ω)
+    (hb : ∀ᵐ x ∂μ, ‖b x‖ ≤ beta) (hc : ∀ᵐ x ∂μ, mu ≤ c x)
+    (hmu : beta ^ 2 / (2 * lam) < mu)
+    (hlower : Integrable
+      (fun x => min (lam / 2) (mu - beta ^ 2 / (2 * lam)) * ‖U x‖ ^ 2) μ)
+    (henergy : Integrable (fun x => energyIntegrand (a x) (b x) (c x) (U x) (U x)) μ) :
+    ∫ x, (min (lam / 2) (mu - beta ^ 2 / (2 * lam)) * ‖U x‖ ^ 2) ∂μ
+      ≤ energyFormIntegral μ a b c U U := by
+  rw [energyFormIntegral_def]
+  refine integral_mono_ae hlower henergy ?_
+  filter_upwards [hΩ, hb, hc] with x hx hbx hcx
+  exact h.min_coercivityConstant_mul_norm_sq_le_energyIntegrand_self hx hbx hcx hmu (U x)
+
+end UniformlyEllipticOn
 
 end PDE
 

--- a/TauCeti/Analysis/PDE/IntegratedEnergyForm.lean
+++ b/TauCeti/Analysis/PDE/IntegratedEnergyForm.lean
@@ -231,16 +231,21 @@ lemma energyFormIntegral_principal_drift_mass
     funext x
     exact energyIntegrand_principal_drift_mass_apply (a x) (b x) (c x) (U x) (V x)
   rw [hpoint]
-  let f := fun x => energyIntegrand (a x) 0 0 (U x) (V x)
-  let g := fun x => energyIntegrand 0 (b x) 0 (U x) (V x)
-  let k := fun x => energyIntegrand 0 0 (c x) (U x) (V x)
-  change (∫ x, f x + g x + k x ∂μ) =
-    (∫ x, f x ∂μ) + (∫ x, g x ∂μ) + ∫ x, k x ∂μ
   calc
-    ∫ x, f x + g x + k x ∂μ = ∫ x, (f x + g x) + k x ∂μ := by rfl
-    _ = (∫ x, f x + g x ∂μ) + ∫ x, k x ∂μ :=
+    ∫ x, energyIntegrand (a x) 0 0 (U x) (V x) +
+        energyIntegrand 0 (b x) 0 (U x) (V x) +
+          energyIntegrand 0 0 (c x) (U x) (V x) ∂μ
+        =
+        ∫ x, (energyIntegrand (a x) 0 0 (U x) (V x) +
+          energyIntegrand 0 (b x) 0 (U x) (V x)) +
+            energyIntegrand 0 0 (c x) (U x) (V x) ∂μ := by rfl
+    _ = (∫ x, energyIntegrand (a x) 0 0 (U x) (V x) +
+          energyIntegrand 0 (b x) 0 (U x) (V x) ∂μ) +
+          ∫ x, energyIntegrand 0 0 (c x) (U x) (V x) ∂μ :=
       integral_add (hprincipal.add hdrift) hmass
-    _ = (∫ x, f x ∂μ) + (∫ x, g x ∂μ) + ∫ x, k x ∂μ := by
+    _ = (∫ x, energyIntegrand (a x) 0 0 (U x) (V x) ∂μ) +
+          (∫ x, energyIntegrand 0 (b x) 0 (U x) (V x) ∂μ) +
+            ∫ x, energyIntegrand 0 0 (c x) (U x) (V x) ∂μ := by
       rw [integral_add hprincipal hdrift]
 
 variable [DecidableEq n]
@@ -335,6 +340,59 @@ lemma norm_energyFormIntegral_le_of_bounds (hLam : 0 ≤ Lam)
   simpa [mul_assoc] using
     norm_energyIntegrand_apply_le_of_bounds hLam hax hbx hcx (U x) (V x)
 
+/-- Integrated Gårding lower bound from a.e. lower ellipticity and a.e. lower-order
+coefficient hypotheses. -/
+lemma garding_energyFormIntegral_self_of_bounds (hlam : 0 < lam)
+    (ha : ∀ᵐ x ∂μ, ∀ ξ : EuclideanSpace ℝ n,
+      lam * ‖ξ‖ ^ 2 ≤ (a x).toQuadraticForm' ξ)
+    (hb : ∀ᵐ x ∂μ, ‖b x‖ ≤ beta) (hc : ∀ᵐ x ∂μ, 0 ≤ c x)
+    (hlower : Integrable
+      (fun x => lam / 2 * ‖(U x).2‖ ^ 2 - beta ^ 2 / (2 * lam) * (U x).1 ^ 2) μ)
+    (henergy : Integrable (fun x => energyIntegrand (a x) (b x) (c x) (U x) (U x)) μ) :
+    ∫ x, (lam / 2 * ‖(U x).2‖ ^ 2 - beta ^ 2 / (2 * lam) * (U x).1 ^ 2) ∂μ
+      ≤ energyFormIntegral μ a b c U U := by
+  rw [energyFormIntegral_def]
+  refine integral_mono_ae hlower henergy ?_
+  filter_upwards [ha, hb, hc] with x hax hbx hcx
+  exact garding_energyIntegrand_self_of_bounds hlam hax hbx hcx (U x)
+
+/-- Integrated Gårding lower bound with a mass floor from a.e. lower ellipticity and a.e.
+lower-order coefficient hypotheses. -/
+lemma garding_energyFormIntegral_self_of_mass_lower_bound_of_bounds (hlam : 0 < lam)
+    (ha : ∀ᵐ x ∂μ, ∀ ξ : EuclideanSpace ℝ n,
+      lam * ‖ξ‖ ^ 2 ≤ (a x).toQuadraticForm' ξ)
+    (hb : ∀ᵐ x ∂μ, ‖b x‖ ≤ beta) (hc : ∀ᵐ x ∂μ, mu ≤ c x)
+    (hlower : Integrable
+      (fun x => lam / 2 * ‖(U x).2‖ ^ 2 +
+        (mu - beta ^ 2 / (2 * lam)) * (U x).1 ^ 2) μ)
+    (henergy : Integrable (fun x => energyIntegrand (a x) (b x) (c x) (U x) (U x)) μ) :
+    ∫ x, (lam / 2 * ‖(U x).2‖ ^ 2 +
+        (mu - beta ^ 2 / (2 * lam)) * (U x).1 ^ 2) ∂μ
+      ≤ energyFormIntegral μ a b c U U := by
+  rw [energyFormIntegral_def]
+  refine integral_mono_ae hlower henergy ?_
+  filter_upwards [ha, hb, hc] with x hax hbx hcx
+  exact garding_energyIntegrand_self_of_mass_lower_bound_of_bounds hlam hax hbx hcx (U x)
+
+/-- Integrated explicit coercive diagonal lower bound from a.e. lower ellipticity, a.e.
+lower-order coefficient hypotheses, and a mass floor that dominates the drift defect. -/
+lemma integral_min_coercivityConstant_mul_norm_sq_le_energyFormIntegral_self_of_bounds
+    (hlam : 0 < lam)
+    (ha : ∀ᵐ x ∂μ, ∀ ξ : EuclideanSpace ℝ n,
+      lam * ‖ξ‖ ^ 2 ≤ (a x).toQuadraticForm' ξ)
+    (hb : ∀ᵐ x ∂μ, ‖b x‖ ≤ beta) (hc : ∀ᵐ x ∂μ, mu ≤ c x)
+    (hmu : beta ^ 2 / (2 * lam) < mu)
+    (hlower : Integrable
+      (fun x => min (lam / 2) (mu - beta ^ 2 / (2 * lam)) * ‖U x‖ ^ 2) μ)
+    (henergy : Integrable (fun x => energyIntegrand (a x) (b x) (c x) (U x) (U x)) μ) :
+    ∫ x, (min (lam / 2) (mu - beta ^ 2 / (2 * lam)) * ‖U x‖ ^ 2) ∂μ
+      ≤ energyFormIntegral μ a b c U U := by
+  rw [energyFormIntegral_def]
+  refine integral_mono_ae hlower henergy ?_
+  filter_upwards [ha, hb, hc] with x hax hbx hcx
+  exact min_coercivityConstant_mul_norm_sq_le_energyIntegrand_self
+    hlam hax hbx hcx hmu (U x)
+
 namespace UniformlyEllipticOn
 
 variable {Ω : Set X} {lam Lam beta mu : ℝ}
@@ -351,10 +409,10 @@ lemma garding_energyFormIntegral_self_on (h : UniformlyEllipticOn Ω a lam Lam)
     (henergy : Integrable (fun x => energyIntegrand (a x) (b x) (c x) (U x) (U x)) μ) :
     ∫ x, (lam / 2 * ‖(U x).2‖ ^ 2 - beta ^ 2 / (2 * lam) * (U x).1 ^ 2) ∂μ
       ≤ energyFormIntegral μ a b c U U := by
-  rw [energyFormIntegral_def]
-  refine integral_mono_ae hlower henergy ?_
-  filter_upwards [hΩ, hb, hc] with x hx hbx hcx
-  exact h.garding_energyIntegrand_self hx hbx hcx (U x)
+  refine PDE.garding_energyFormIntegral_self_of_bounds (μ := μ) (a := a) (b := b) (c := c)
+    (U := U) h.pos ?_ hb hc hlower henergy
+  filter_upwards [hΩ] with x hx
+  exact h.lower_bound hx
 
 /-- Integrated Gårding lower bound with a mass floor from uniform ellipticity and a.e.
 coefficient hypotheses. -/
@@ -368,14 +426,14 @@ lemma garding_energyFormIntegral_self_of_mass_lower_bound_on
     ∫ x, (lam / 2 * ‖(U x).2‖ ^ 2 +
         (mu - beta ^ 2 / (2 * lam)) * (U x).1 ^ 2) ∂μ
       ≤ energyFormIntegral μ a b c U U := by
-  rw [energyFormIntegral_def]
-  refine integral_mono_ae hlower henergy ?_
-  filter_upwards [hΩ, hb, hc] with x hx hbx hcx
-  exact h.garding_energyIntegrand_self_of_mass_lower_bound hx hbx hcx (U x)
+  refine PDE.garding_energyFormIntegral_self_of_mass_lower_bound_of_bounds (μ := μ) (a := a)
+    (b := b) (c := c) (U := U) h.pos ?_ hb hc hlower henergy
+  filter_upwards [hΩ] with x hx
+  exact h.lower_bound hx
 
 /-- Integrated explicit coercive diagonal lower bound from uniform ellipticity, a.e.
 coefficient hypotheses, and a mass floor that dominates the drift defect. -/
-lemma min_coercivityConstant_mul_integral_norm_sq_le_energyFormIntegral_self_on
+lemma integral_min_coercivityConstant_mul_norm_sq_le_energyFormIntegral_self_on
     (h : UniformlyEllipticOn Ω a lam Lam) (hΩ : ∀ᵐ x ∂μ, x ∈ Ω)
     (hb : ∀ᵐ x ∂μ, ‖b x‖ ≤ beta) (hc : ∀ᵐ x ∂μ, mu ≤ c x)
     (hmu : beta ^ 2 / (2 * lam) < mu)
@@ -384,10 +442,10 @@ lemma min_coercivityConstant_mul_integral_norm_sq_le_energyFormIntegral_self_on
     (henergy : Integrable (fun x => energyIntegrand (a x) (b x) (c x) (U x) (U x)) μ) :
     ∫ x, (min (lam / 2) (mu - beta ^ 2 / (2 * lam)) * ‖U x‖ ^ 2) ∂μ
       ≤ energyFormIntegral μ a b c U U := by
-  rw [energyFormIntegral_def]
-  refine integral_mono_ae hlower henergy ?_
-  filter_upwards [hΩ, hb, hc] with x hx hbx hcx
-  exact h.min_coercivityConstant_mul_norm_sq_le_energyIntegrand_self hx hbx hcx hmu (U x)
+  refine PDE.integral_min_coercivityConstant_mul_norm_sq_le_energyFormIntegral_self_of_bounds
+    (μ := μ) (a := a) (b := b) (c := c) (U := U) h.pos ?_ hb hc hmu hlower henergy
+  filter_upwards [hΩ] with x hx
+  exact h.lower_bound hx
 
 end UniformlyEllipticOn
 

--- a/TauCeti/Analysis/PDE/IntegratedEnergyForm.lean
+++ b/TauCeti/Analysis/PDE/IntegratedEnergyForm.lean
@@ -204,15 +204,9 @@ lemma energyFormIntegral_principal_add_lowerOrder
     energyFormIntegral μ a b c U V =
       energyFormIntegral μ a (fun _ => 0) (fun _ => 0) U V +
         energyFormIntegral μ (fun _ => 0) b c U V := by
-  rw [energyFormIntegral_def, energyFormIntegral_def, energyFormIntegral_def]
-  have hpoint :
-      (fun x => energyIntegrand (a x) (b x) (c x) (U x) (V x))
-        = fun x => energyIntegrand (a x) 0 0 (U x) (V x) +
-            energyIntegrand 0 (b x) (c x) (U x) (V x) := by
-    funext x
-    exact energyIntegrand_principal_add_lowerOrder_apply (a x) (b x) (c x) (U x) (V x)
-  rw [hpoint]
-  exact integral_add hprincipal hlower
+  simpa using
+    energyFormIntegral_add μ a (fun _ => 0) (fun _ => 0) U V
+      (fun _ => 0) b c hprincipal hlower
 
 /-- The integrated full energy form splits into its principal, drift, and mass pieces. -/
 lemma energyFormIntegral_principal_drift_mass
@@ -223,32 +217,41 @@ lemma energyFormIntegral_principal_drift_mass
       energyFormIntegral μ a (fun _ => 0) (fun _ => 0) U V +
         energyFormIntegral μ (fun _ => 0) b (fun _ => 0) U V +
           energyFormIntegral μ (fun _ => 0) (fun _ => 0) c U V := by
-  rw [energyFormIntegral_def, energyFormIntegral_def, energyFormIntegral_def,
-    energyFormIntegral_def]
-  have hpoint :
-      (fun x => energyIntegrand (a x) (b x) (c x) (U x) (V x))
-        = fun x => energyIntegrand (a x) 0 0 (U x) (V x) +
-            energyIntegrand 0 (b x) 0 (U x) (V x) +
+  have hlower :
+      Integrable (fun x => energyIntegrand 0 (b x) (c x) (U x) (V x)) μ := by
+    have hpoint :
+        (fun x => energyIntegrand 0 (b x) (c x) (U x) (V x))
+          = fun x => energyIntegrand 0 (b x) 0 (U x) (V x) +
               energyIntegrand 0 0 (c x) (U x) (V x) := by
-    funext x
-    exact energyIntegrand_principal_drift_mass_apply (a x) (b x) (c x) (U x) (V x)
-  rw [hpoint]
+      funext x
+      conv_lhs =>
+        rw [← zero_add (0 : Matrix n n ℝ), ← add_zero (b x), ← zero_add (c x)]
+      exact energyIntegrand_add_apply (0 : Matrix n n ℝ) 0 (b x) 0 0 (c x) (U x) (V x)
+    have hsum : Integrable
+        (fun x => energyIntegrand 0 (b x) 0 (U x) (V x) +
+          energyIntegrand 0 0 (c x) (U x) (V x)) μ := by
+      exact (hdrift.add hmass).congr (Filter.Eventually.of_forall fun _ => rfl)
+    exact hsum.congr (Filter.Eventually.of_forall fun x => congrFun hpoint.symm x)
+  have hlower_eq :
+      energyFormIntegral μ (fun _ => 0) b c U V =
+        energyFormIntegral μ (fun _ => 0) b (fun _ => 0) U V +
+          energyFormIntegral μ (fun _ => 0) (fun _ => 0) c U V := by
+    simpa using
+      energyFormIntegral_add μ (fun _ => 0) b (fun _ => 0) U V
+        (fun _ => 0) (fun _ => 0) c hdrift hmass
   calc
-    ∫ x, energyIntegrand (a x) 0 0 (U x) (V x) +
-        energyIntegrand 0 (b x) 0 (U x) (V x) +
-          energyIntegrand 0 0 (c x) (U x) (V x) ∂μ
-        =
-        ∫ x, (energyIntegrand (a x) 0 0 (U x) (V x) +
-          energyIntegrand 0 (b x) 0 (U x) (V x)) +
-            energyIntegrand 0 0 (c x) (U x) (V x) ∂μ := by rfl
-    _ = (∫ x, energyIntegrand (a x) 0 0 (U x) (V x) +
-          energyIntegrand 0 (b x) 0 (U x) (V x) ∂μ) +
-          ∫ x, energyIntegrand 0 0 (c x) (U x) (V x) ∂μ :=
-      integral_add (hprincipal.add hdrift) hmass
-    _ = (∫ x, energyIntegrand (a x) 0 0 (U x) (V x) ∂μ) +
-          (∫ x, energyIntegrand 0 (b x) 0 (U x) (V x) ∂μ) +
-            ∫ x, energyIntegrand 0 0 (c x) (U x) (V x) ∂μ := by
-      rw [integral_add hprincipal hdrift]
+    energyFormIntegral μ a b c U V =
+        energyFormIntegral μ a (fun _ => 0) (fun _ => 0) U V +
+          energyFormIntegral μ (fun _ => 0) b c U V :=
+      energyFormIntegral_principal_add_lowerOrder μ a b c U V hprincipal hlower
+    _ = energyFormIntegral μ a (fun _ => 0) (fun _ => 0) U V +
+          (energyFormIntegral μ (fun _ => 0) b (fun _ => 0) U V +
+            energyFormIntegral μ (fun _ => 0) (fun _ => 0) c U V) := by
+      rw [hlower_eq]
+    _ = energyFormIntegral μ a (fun _ => 0) (fun _ => 0) U V +
+          energyFormIntegral μ (fun _ => 0) b (fun _ => 0) U V +
+            energyFormIntegral μ (fun _ => 0) (fun _ => 0) c U V := by
+      rw [add_assoc]
 
 variable [DecidableEq n]
 
@@ -283,16 +286,9 @@ lemma energyFormIntegral_eq_one_zero_mass_add_perturbation
     energyFormIntegral μ a b c U V =
       energyFormIntegral μ (fun _ => (1 : Matrix n n ℝ)) (fun _ => 0) c U V +
         energyFormIntegral μ (fun x => a x - 1) b (fun _ => 0) U V := by
-  rw [energyFormIntegral_def, energyFormIntegral_def, energyFormIntegral_def]
-  have hpoint :
-      (fun x => energyIntegrand (a x) (b x) (c x) (U x) (V x))
-        = fun x => energyIntegrand (1 : Matrix n n ℝ) 0 (c x) (U x) (V x) +
-            energyIntegrand (a x - 1) (b x) 0 (U x) (V x) := by
-    funext x
-    exact energyIntegrand_eq_one_zero_mass_add_perturbation_apply
-      (a x) (b x) (c x) (U x) (V x)
-  rw [hpoint]
-  exact integral_add hmodel hpert
+  simpa using
+    energyFormIntegral_eq_one_zero_baseMass_add_perturbation μ a b c U V c hmodel
+      (by simpa using hpert)
 
 /-- The integrated `−Δ` model form is the integral of the dot product of the two gradient
 components of the jet fields. -/


### PR DESCRIPTION
This PR adds the raw-jet integrated divergence-form energy form `PDE.energyFormIntegral`, together with a.e. congruence, bilinearity in the two jet fields under Bochner-integrability hypotheses, shifted-Laplacian model formulas, and the integrated boundedness estimate inherited from the pointwise coefficient bounds. It advances `TauCetiRoadmap/PDE/README.md`, Lane D item 16, “Weak formulation,” specifically the energy bilinear form `a(u,v) = ∫ aⁱʲ ∂ᵢu ∂ⱼv + …` before the later Sobolev-space specialization supplies jets `x ↦ (u x, ∇u x)`.

I chose this as the lowest-hanging distinct PDE target after checking open and recently merged PRs: the pointwise integrand stack, coefficient continuity, measurability, integrability, boundedness, and Gårding/coercivity estimates are already on `main`, while the actual integrated scalar form over a measure was still absent. This PR stays below the still-missing weak-derivative Sobolev spaces and Lax--Milgram weak-solution theorem, and only packages the integral that those later layers consume.

No Mathlib infrastructure is vendored. The implementation reuses Tau Ceti’s existing `energyIntegrand`, `energyIntegrand_one_zero_mass_*`, `norm_energyIntegrand_apply_le_of_bounds`, and integrability API, together with Mathlib’s Bochner integral congruence, linearity, and `norm_integral_le_of_norm_le` lemmas.

`lake exe cache get` completed with `No files to download` and `Already decompressed 8609 file(s)`. `lake build` completed with `Build completed successfully (4522 jobs).` `lake exe axioms` completed with `axioms: audited 7928 TauCeti declaration(s); all within the allowlist [propext, Classical.choice, Quot.sound].`

<!--tauceti-target:v1 {"focus":"PDE","id":"integrated-energy-form"}-->

🤖 Prepared with Codex
