### PR TITLE
feat: comap_processCons_eq_sup — σ of a cons is the join of σs

### DIFF
--- a/TauCeti/Probability/Process/Tail.lean
+++ b/TauCeti/Probability/Process/Tail.lean
@@ -286,29 +286,18 @@ theorem comap_le_comap_processCons (x : Ω → α) (t : Ω → ℕ → α) :
 omit [MeasurableSpace Ω] in
 /-- Consing a head onto a sequence-valued random variable joins their σ-algebras:
 `σ(processCons x t) = σ(x) ⊔ σ(t)`. -/
+@[simp]
 theorem comap_processCons_eq_sup (x : Ω → α) (t : Ω → ℕ → α) :
     MeasurableSpace.comap (processCons x t) inferInstance
       = MeasurableSpace.comap x inferInstance ⊔ MeasurableSpace.comap t inferInstance := by
-  apply le_antisymm
-  · -- `σ(processCons x t) ≤ σ(x) ⊔ σ(t)`, by factoring through the measurable pair `(x, t)`.
-    rintro s ⟨S, hS, rfl⟩
-    have hx : @Measurable Ω α (MeasurableSpace.comap x inferInstance) inferInstance x :=
-      Measurable.of_comap_le le_rfl
-    have ht : @Measurable Ω (ℕ → α) (MeasurableSpace.comap t inferInstance) inferInstance t :=
-      Measurable.of_comap_le le_rfl
-    have hpair : @Measurable Ω (α × (ℕ → α))
-        (MeasurableSpace.comap x inferInstance ⊔ MeasurableSpace.comap t inferInstance)
-        inferInstance (fun ω => (x ω, t ω)) :=
-      (hx.mono le_sup_left le_rfl).prodMk (ht.mono le_sup_right le_rfl)
-    have hcons : Measurable (processCons (Prod.fst : α × (ℕ → α) → α) Prod.snd) :=
-      measurable_processCons measurable_fst fun n => (measurable_pi_apply n).comp measurable_snd
-    have hfactor : processCons x t
-        = processCons (Prod.fst : α × (ℕ → α) → α) Prod.snd ∘ fun ω => (x ω, t ω) := rfl
-    rw [hfactor, Set.preimage_comp]
-    exact hpair (hcons hS)
-  · refine sup_le ?_ (comap_le_comap_processCons x t)
-    rintro s ⟨S, hS, rfl⟩
-    exact ⟨{f | f 0 ∈ S}, measurable_pi_apply 0 hS, by ext ω; simp [processCons_zero]⟩
+  -- `σ` of a sequence is the join of its coordinate `σ`s; split off the head coordinate.
+  rw [MeasurableSpace.comap_process_pi (fun n ω => processCons x t ω n), ← sup_iSup_nat_succ]
+  refine congr_arg₂ _ ?_ ?_
+  · -- Head: coordinate `0` of the cons is `x`.
+    simp only [processCons_zero]
+  · -- Tail: coordinates `n + 1` of the cons reassemble `t`.
+    simp only [processCons_succ]
+    rw [← MeasurableSpace.comap_process_pi (fun n ω => t ω n)]
 
 end Probability
 

--- a/TauCeti/Probability/Process/Tail.lean
+++ b/TauCeti/Probability/Process/Tail.lean
@@ -283,6 +283,33 @@ theorem comap_le_comap_processCons (x : Ω → α) (t : Ω → ℕ → α) :
         rw [processTail_processCons]
     _ ≤ MeasurableSpace.comap (processCons x t) inferInstance := comap_processTail_le
 
+omit [MeasurableSpace Ω] in
+/-- Consing a head onto a sequence-valued random variable joins their σ-algebras:
+`σ(processCons x t) = σ(x) ⊔ σ(t)`. -/
+theorem comap_processCons_eq_sup (x : Ω → α) (t : Ω → ℕ → α) :
+    MeasurableSpace.comap (processCons x t) inferInstance
+      = MeasurableSpace.comap x inferInstance ⊔ MeasurableSpace.comap t inferInstance := by
+  apply le_antisymm
+  · -- `σ(processCons x t) ≤ σ(x) ⊔ σ(t)`, by factoring through the measurable pair `(x, t)`.
+    rintro s ⟨S, hS, rfl⟩
+    have hx : @Measurable Ω α (MeasurableSpace.comap x inferInstance) inferInstance x :=
+      Measurable.of_comap_le le_rfl
+    have ht : @Measurable Ω (ℕ → α) (MeasurableSpace.comap t inferInstance) inferInstance t :=
+      Measurable.of_comap_le le_rfl
+    have hpair : @Measurable Ω (α × (ℕ → α))
+        (MeasurableSpace.comap x inferInstance ⊔ MeasurableSpace.comap t inferInstance)
+        inferInstance (fun ω => (x ω, t ω)) :=
+      (hx.mono le_sup_left le_rfl).prodMk (ht.mono le_sup_right le_rfl)
+    have hcons : Measurable (processCons (Prod.fst : α × (ℕ → α) → α) Prod.snd) :=
+      measurable_processCons measurable_fst fun n => (measurable_pi_apply n).comp measurable_snd
+    have hfactor : processCons x t
+        = processCons (Prod.fst : α × (ℕ → α) → α) Prod.snd ∘ fun ω => (x ω, t ω) := rfl
+    rw [hfactor, Set.preimage_comp]
+    exact hpair (hcons hS)
+  · refine sup_le ?_ (comap_le_comap_processCons x t)
+    rintro s ⟨S, hS, rfl⟩
+    exact ⟨{f | f 0 ∈ S}, measurable_pi_apply 0 hS, by ext ω; simp [processCons_zero]⟩
+
 end Probability
 
 end TauCeti


### PR DESCRIPTION
<!--tauceti-target:v1 {"focus":"Exchangeability","id":"process-cons-comap-sup"}-->

## Summary

Adds one generic process-σ-algebra lemma to `TauCeti/Probability/Process/Tail.lean`:

- `comap_processCons_eq_sup` — consing a head `x` onto a sequence-valued `t` joins their σ-algebras:
  `σ(processCons x t) = σ(x) ⊔ σ(t)`.

## Roadmap

Process-layer infrastructure for `TauCetiRoadmap/Exchangeability`: a process-tail / path-space
σ-algebra fact (roadmap **Layer 2**, process tails / path-space dynamics). It is consumed downstream
by the **Layer 6 de Finetti** prefix-deletion step, which conditions on "past block ⊔ tail"
σ-algebras built by consing a coordinate onto a tail process and needs this decomposition. Peeled off
as a standalone one-topic lemma so it can land independently.

## How it's proved (reuse)

Mathlib-first: `MeasurableSpace.comap_process_pi` rewrites `σ(processCons x t)` as the join of its
coordinate σ-algebras `⨆ n, σ(coord n)`; `sup_iSup_nat_succ` splits off the head; `processCons_zero`
/ `processCons_succ` identify coordinate `0` with `x` and coordinates `n+1` with `t` (the latter via
`comap_process_pi` again). No hand-rolled σ-algebra derivation.

## Review notes
- **placement:** next to the other `processCons`/`comap` lemmas in `Process/Tail.lean`
  (`comap_le_comap_processCons` sits directly above).
- **naming:** `comap_processCons_eq_sup` states the conclusion (`comap … = … ⊔ …`).
- **api-design:** `@[simp]` (the orientation strictly removes `processCons`; simpNF-clean).
- **generality:** arbitrary `x : Ω → α`, `t : Ω → ℕ → α`; no measure/finiteness assumptions
  (`omit [MeasurableSpace Ω]`).
- **reuse:** built on Mathlib's `comap_process_pi` / `sup_iSup_nat_succ`; `processCons` is TauCeti's,
  so only the cons-specific `⊔` shape is new.

## Test plan
```bash
lake build && lake exe axioms && lake exe module-system && bash scripts/lint-env.sh
```
All pass; sorry-free; `comap_processCons_eq_sup` axioms ⊆ {`propext`, `Classical.choice`,
`Quot.sound`}; lines ≤100; module-system opts in.

## Attribution
Drafted with Claude (Opus 4.8), human-directed.
