### PR TITLE
feat: add normal quotient fibre transitivity

### DIFF
--- a/TauCeti/Algebra/GroupAction/OrbitRelQuotient.lean
+++ b/TauCeti/Algebra/GroupAction/OrbitRelQuotient.lean
@@ -5,6 +5,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 module
 
 public import Mathlib.GroupTheory.GroupAction.Quotient
+public import Mathlib.GroupTheory.GroupAction.Transitive
 public import TauCeti.Algebra.Group.NormalizerQuotient
 
 /-!
@@ -349,19 +350,14 @@ theorem normalizerQuotientOrbitRelQuotientIsPretransitive
     MulAction.IsPretransitive
       (Subgroup.normalizerQuotient H) (_root_.MulAction.orbitRel.Quotient H X) := by
   letI := normalizerQuotientOrbitRelQuotientMulAction (X := X) H
-  refine MulAction.IsPretransitive.mk ?_
-  intro xq yq
-  refine Quotient.inductionOn' xq ?_
-  intro x
-  refine Quotient.inductionOn' yq ?_
-  intro y
-  obtain ⟨g, hg⟩ :=
-    MulAction.exists_smul_eq (_root_.Subgroup.normalizer (H : Set G)) x y
-  refine ⟨Subgroup.normalizerQuotientMk H g, ?_⟩
-  rw [normalizerQuotientOrbitRelQuotient_smul_mk]
-  exact congrArg Quotient.mk'' (show (g : G) • x = y by
-    change (g : G) • x = y at hg
-    exact hg)
+  let φ : _root_.Subgroup.normalizer (H : Set G) → Subgroup.normalizerQuotient H :=
+    Subgroup.normalizerQuotientMk H
+  let f : X →ₑ[φ] _root_.MulAction.orbitRel.Quotient H X := {
+    toFun := Quotient.mk''
+    map_smul' g x := by
+      exact (normalizerQuotientOrbitRelQuotient_smul_mk (X := X) H g x).symm }
+  exact MulAction.IsPretransitive.of_surjective_map
+    (f := f) Quotient.mk''_surjective inferInstance
 
 /-- If `H` is normal and `G` acts transitively on `X`, then the descended `N(H) / H` action
 on the quotient by `H`-orbits is transitive. -/
@@ -374,8 +370,7 @@ theorem normalizerQuotientOrbitRelQuotientIsPretransitiveOfNormal
     MulAction.IsPretransitive.mk fun x y => by
       obtain ⟨g, hg⟩ := MulAction.exists_smul_eq G x y
       refine ⟨⟨g, by simp [_root_.Subgroup.normalizer_eq_top (H := H)]⟩, ?_⟩
-      change g • x = y
-      exact hg
+      simpa using hg
   exact normalizerQuotientOrbitRelQuotientIsPretransitive (X := X) H
 
 /-- Equality after the descended `N(H) / H` action on an `H`-orbit quotient is equality of

--- a/TauCeti/Algebra/GroupAction/OrbitRelQuotient.lean
+++ b/TauCeti/Algebra/GroupAction/OrbitRelQuotient.lean
@@ -31,9 +31,9 @@ This file records small generic additions to Mathlib's `MulAction.orbitRel.Quoti
   quotient by `H`-orbits.
 * `TauCeti.MulAction.normalizerQuotientOrbitRelQuotientPermHom`: the descended action of
   `N(H) / H` on the quotient by `H`-orbits.
-* `TauCeti.MulAction.normalizerQuotientOrbitRelQuotientIsPretransitiveOfNormal`: if `H` is
-  normal and the original action is transitive, then the descended `N(H) / H` action on the
-  `H`-orbit quotient is transitive.
+* `TauCeti.MulAction.normalizerQuotientOrbitRelQuotientIsPretransitive`: if the normalizer
+  acts transitively, then the descended `N(H) / H` action on the `H`-orbit quotient is
+  transitive.
 * `TauCeti.MulAction.normalizerQuotientOrbitRelQuotient_smul_eq_smul_iff`: if the original
   action is free, then the descended `N(H) / H` action on the `H`-orbit quotient is free.
 -/
@@ -340,12 +340,11 @@ lemma normalizerQuotientOrbitRelQuotient_smul_mk (H : Subgroup G)
       Quotient.mk'' ((g : G) • x)
     exact normalizerQuotientOrbitRelQuotientPermHom_mk_apply (X := X) H g x
 
-/-- If `H` is normal and `G` acts transitively on `X`, then the descended `N(H) / H` action
-on the quotient by `H`-orbits is transitive. Under normality the normalizer is all of `G`,
-so a group element carrying one representative to another supplies the required normalizer
-quotient element. -/
-theorem normalizerQuotientOrbitRelQuotientIsPretransitiveOfNormal
-    [MulAction.IsPretransitive G X] (H : Subgroup G) [H.Normal] :
+/-- If the normalizer of `H` acts transitively on `X`, then the descended `N(H) / H` action on
+the quotient by `H`-orbits is transitive. -/
+theorem normalizerQuotientOrbitRelQuotientIsPretransitive
+    (H : Subgroup G)
+    [MulAction.IsPretransitive (_root_.Subgroup.normalizer (H : Set G)) X] :
     letI := normalizerQuotientOrbitRelQuotientMulAction (X := X) H
     MulAction.IsPretransitive
       (Subgroup.normalizerQuotient H) (_root_.MulAction.orbitRel.Quotient H X) := by
@@ -356,12 +355,28 @@ theorem normalizerQuotientOrbitRelQuotientIsPretransitiveOfNormal
   intro x
   refine Quotient.inductionOn' yq ?_
   intro y
-  obtain ⟨g, hg⟩ := MulAction.exists_smul_eq G x y
-  let g' : _root_.Subgroup.normalizer (H : Set G) :=
-    ⟨g, by simp [_root_.Subgroup.normalizer_eq_top (H := H)]⟩
-  refine ⟨Subgroup.normalizerQuotientMk H g', ?_⟩
+  obtain ⟨g, hg⟩ :=
+    MulAction.exists_smul_eq (_root_.Subgroup.normalizer (H : Set G)) x y
+  refine ⟨Subgroup.normalizerQuotientMk H g, ?_⟩
   rw [normalizerQuotientOrbitRelQuotient_smul_mk]
-  exact congrArg Quotient.mk'' hg
+  exact congrArg Quotient.mk'' (show (g : G) • x = y by
+    change (g : G) • x = y at hg
+    exact hg)
+
+/-- If `H` is normal and `G` acts transitively on `X`, then the descended `N(H) / H` action
+on the quotient by `H`-orbits is transitive. -/
+theorem normalizerQuotientOrbitRelQuotientIsPretransitiveOfNormal
+    [MulAction.IsPretransitive G X] (H : Subgroup G) [H.Normal] :
+    letI := normalizerQuotientOrbitRelQuotientMulAction (X := X) H
+    MulAction.IsPretransitive
+      (Subgroup.normalizerQuotient H) (_root_.MulAction.orbitRel.Quotient H X) := by
+  letI : MulAction.IsPretransitive (_root_.Subgroup.normalizer (H : Set G)) X :=
+    MulAction.IsPretransitive.mk fun x y => by
+      obtain ⟨g, hg⟩ := MulAction.exists_smul_eq G x y
+      refine ⟨⟨g, by simp [_root_.Subgroup.normalizer_eq_top (H := H)]⟩, ?_⟩
+      change g • x = y
+      exact hg
+  exact normalizerQuotientOrbitRelQuotientIsPretransitive (X := X) H
 
 /-- Equality after the descended `N(H) / H` action on an `H`-orbit quotient is equality of
 normalizer-quotient elements, provided the original action is free. -/

--- a/TauCeti/Algebra/GroupAction/OrbitRelQuotient.lean
+++ b/TauCeti/Algebra/GroupAction/OrbitRelQuotient.lean
@@ -31,6 +31,9 @@ This file records small generic additions to Mathlib's `MulAction.orbitRel.Quoti
   quotient by `H`-orbits.
 * `TauCeti.MulAction.normalizerQuotientOrbitRelQuotientPermHom`: the descended action of
   `N(H) / H` on the quotient by `H`-orbits.
+* `TauCeti.MulAction.normalizerQuotientOrbitRelQuotientIsPretransitiveOfNormal`: if `H` is
+  normal and the original action is transitive, then the descended `N(H) / H` action on the
+  `H`-orbit quotient is transitive.
 * `TauCeti.MulAction.normalizerQuotientOrbitRelQuotient_smul_eq_smul_iff`: if the original
   action is free, then the descended `N(H) / H` action on the `H`-orbit quotient is free.
 -/
@@ -336,6 +339,29 @@ lemma normalizerQuotientOrbitRelQuotient_smul_mk (H : Subgroup G)
         (Quotient.mk'' x : _root_.MulAction.orbitRel.Quotient H X) =
       Quotient.mk'' ((g : G) • x)
     exact normalizerQuotientOrbitRelQuotientPermHom_mk_apply (X := X) H g x
+
+/-- If `H` is normal and `G` acts transitively on `X`, then the descended `N(H) / H` action
+on the quotient by `H`-orbits is transitive. Under normality the normalizer is all of `G`,
+so a group element carrying one representative to another supplies the required normalizer
+quotient element. -/
+theorem normalizerQuotientOrbitRelQuotientIsPretransitiveOfNormal
+    [MulAction.IsPretransitive G X] (H : Subgroup G) [H.Normal] :
+    letI := normalizerQuotientOrbitRelQuotientMulAction (X := X) H
+    MulAction.IsPretransitive
+      (Subgroup.normalizerQuotient H) (_root_.MulAction.orbitRel.Quotient H X) := by
+  letI := normalizerQuotientOrbitRelQuotientMulAction (X := X) H
+  refine MulAction.IsPretransitive.mk ?_
+  intro xq yq
+  refine Quotient.inductionOn' xq ?_
+  intro x
+  refine Quotient.inductionOn' yq ?_
+  intro y
+  obtain ⟨g, hg⟩ := MulAction.exists_smul_eq G x y
+  let g' : _root_.Subgroup.normalizer (H : Set G) :=
+    ⟨g, by simp [_root_.Subgroup.normalizer_eq_top (H := H)]⟩
+  refine ⟨Subgroup.normalizerQuotientMk H g', ?_⟩
+  rw [normalizerQuotientOrbitRelQuotient_smul_mk]
+  exact congrArg Quotient.mk'' hg
 
 /-- Equality after the descended `N(H) / H` action on an `H`-orbit quotient is equality of
 normalizer-quotient elements, provided the original action is free. -/

--- a/TauCeti/AlgebraicTopology/UniversalCover/Deck/NormalizerQuotientFiberAction.lean
+++ b/TauCeti/AlgebraicTopology/UniversalCover/Deck/NormalizerQuotientFiberAction.lean
@@ -27,8 +27,10 @@ identify the deck group of the cover attached to `H` with `N(H) / H`.
   from `N(H) / H`.
 * `TauCeti.Deck.instNormalizerQuotientSubgroupFiberOrbitMulAction`: the resulting action of
   `N(H) / H` on `SubgroupFiberOrbitQuotient H b`.
-* `TauCeti.Deck.normalizerQuotientSubgroupFiberOrbitIsPretransitiveOfNormal`: transitivity
-  of this descended action when `H` is normal and the deck action on the fibre is transitive.
+* `TauCeti.Deck.normalizerQuotientSubgroupFiberOrbitIsPretransitive`: transitivity of this
+  descended action when the normalizer action on the fibre is transitive.
+* `TauCeti.Deck.instNormalizerQuotientSubgroupFiberOrbitIsPretransitiveOfNormal`: the
+  normal-subgroup instance for this descended action.
 * `TauCeti.Deck.instNormalizerQuotientSubgroupFiberOrbitIsCancelSMul`: freeness of this
   descended action when the deck action on the fibre is free.
 
@@ -180,6 +182,16 @@ lemma normalizerQuotient_mk_of_mem_smul_subgroupFiberOrbitClass
   rw [normalizerQuotient_smul_subgroupFiberOrbitClass]
   exact (subgroupFiberOrbitClass_eq_iff H (φ • e) e).2 ⟨⟨φ, hφ⟩, rfl⟩
 
+/-- If the normalizer of `H` acts transitively on the chosen fibre, then the descended
+`N(H) / H` action on the quotient of that fibre by `H`-orbits is transitive. -/
+theorem normalizerQuotientSubgroupFiberOrbitIsPretransitive
+    (H : Subgroup (Deck p))
+    [MulAction.IsPretransitive (_root_.Subgroup.normalizer (H : Set (Deck p))) (p ⁻¹' {b})] :
+    MulAction.IsPretransitive
+      (Subgroup.normalizerQuotient H) (SubgroupFiberOrbitQuotient H b) :=
+  TauCeti.MulAction.normalizerQuotientOrbitRelQuotientIsPretransitive
+    (X := p ⁻¹' {b}) H
+
 /-- If `H` is normal and the deck action on the chosen fibre is transitive, then the
 descended `N(H) / H` action on the quotient of that fibre by `H`-orbits is transitive. -/
 theorem normalizerQuotientSubgroupFiberOrbitIsPretransitiveOfNormal
@@ -189,6 +201,15 @@ theorem normalizerQuotientSubgroupFiberOrbitIsPretransitiveOfNormal
       (Subgroup.normalizerQuotient H) (SubgroupFiberOrbitQuotient H b) :=
   TauCeti.MulAction.normalizerQuotientOrbitRelQuotientIsPretransitiveOfNormal
     (X := p ⁻¹' {b}) H
+
+/-- The normalizer quotient acts transitively on a normal subgroup fibre quotient whenever the
+deck action on the fibre is transitive. -/
+noncomputable instance instNormalizerQuotientSubgroupFiberOrbitIsPretransitiveOfNormal
+    [MulAction.IsPretransitive (Deck p) (p ⁻¹' {b})]
+    (H : Subgroup (Deck p)) [H.Normal] :
+    MulAction.IsPretransitive
+      (Subgroup.normalizerQuotient H) (SubgroupFiberOrbitQuotient H b) :=
+  normalizerQuotientSubgroupFiberOrbitIsPretransitiveOfNormal H
 
 /-- For a regular map and a normal deck subgroup, the descended `N(H) / H` action on each
 subgroup fibre quotient is transitive. This is the fibre-action half of the regular-cover

--- a/TauCeti/AlgebraicTopology/UniversalCover/Deck/NormalizerQuotientFiberAction.lean
+++ b/TauCeti/AlgebraicTopology/UniversalCover/Deck/NormalizerQuotientFiberAction.lean
@@ -193,7 +193,7 @@ theorem normalizerQuotientSubgroupFiberOrbitIsPretransitiveOfNormal
 /-- For a regular map and a normal deck subgroup, the descended `N(H) / H` action on each
 subgroup fibre quotient is transitive. This is the fibre-action half of the regular-cover
 specialization from the normalizer quotient to an ordinary quotient by a normal subgroup. -/
-theorem regularNormalizerQuotientSubgroupFiberOrbitIsPretransitiveOfNormal
+theorem normalizerQuotientSubgroupFiberOrbitIsPretransitiveOfNormal_of_isRegular
     (hreg : IsRegular p) (H : Subgroup (Deck p)) [H.Normal] :
     MulAction.IsPretransitive
       (Subgroup.normalizerQuotient H) (SubgroupFiberOrbitQuotient H b) := by

--- a/TauCeti/AlgebraicTopology/UniversalCover/Deck/NormalizerQuotientFiberAction.lean
+++ b/TauCeti/AlgebraicTopology/UniversalCover/Deck/NormalizerQuotientFiberAction.lean
@@ -27,6 +27,8 @@ identify the deck group of the cover attached to `H` with `N(H) / H`.
   from `N(H) / H`.
 * `TauCeti.Deck.instNormalizerQuotientSubgroupFiberOrbitMulAction`: the resulting action of
   `N(H) / H` on `SubgroupFiberOrbitQuotient H b`.
+* `TauCeti.Deck.normalizerQuotientSubgroupFiberOrbitIsPretransitiveOfNormal`: transitivity
+  of this descended action when `H` is normal and the deck action on the fibre is transitive.
 * `TauCeti.Deck.instNormalizerQuotientSubgroupFiberOrbitIsCancelSMul`: freeness of this
   descended action when the deck action on the fibre is free.
 
@@ -177,6 +179,26 @@ lemma normalizerQuotient_mk_of_mem_smul_subgroupFiberOrbitClass
       subgroupFiberOrbitClass H e := by
   rw [normalizerQuotient_smul_subgroupFiberOrbitClass]
   exact (subgroupFiberOrbitClass_eq_iff H (φ • e) e).2 ⟨⟨φ, hφ⟩, rfl⟩
+
+/-- If `H` is normal and the deck action on the chosen fibre is transitive, then the
+descended `N(H) / H` action on the quotient of that fibre by `H`-orbits is transitive. -/
+theorem normalizerQuotientSubgroupFiberOrbitIsPretransitiveOfNormal
+    [MulAction.IsPretransitive (Deck p) (p ⁻¹' {b})]
+    (H : Subgroup (Deck p)) [H.Normal] :
+    MulAction.IsPretransitive
+      (Subgroup.normalizerQuotient H) (SubgroupFiberOrbitQuotient H b) :=
+  TauCeti.MulAction.normalizerQuotientOrbitRelQuotientIsPretransitiveOfNormal
+    (X := p ⁻¹' {b}) H
+
+/-- For a regular map and a normal deck subgroup, the descended `N(H) / H` action on each
+subgroup fibre quotient is transitive. This is the fibre-action half of the regular-cover
+specialization from the normalizer quotient to an ordinary quotient by a normal subgroup. -/
+theorem regularNormalizerQuotientSubgroupFiberOrbitIsPretransitiveOfNormal
+    (hreg : IsRegular p) (H : Subgroup (Deck p)) [H.Normal] :
+    MulAction.IsPretransitive
+      (Subgroup.normalizerQuotient H) (SubgroupFiberOrbitQuotient H b) := by
+  letI := hreg.fiber_isPretransitive b
+  exact normalizerQuotientSubgroupFiberOrbitIsPretransitiveOfNormal H
 
 /-- Equality after the `N(H) / H` action on an `H`-fibre quotient is equality of
 normalizer-quotient elements, provided the deck action on that fibre is free. -/


### PR DESCRIPTION
This PR records transitivity of the descended normalizer-quotient action in the normal-subgroup case: if a group acts transitively on `X` and `H` is normal, then the action of `N(H)/H` on the quotient of `X` by `H`-orbits is transitive, and the same fact is exposed for deck actions on subgroup fibre quotients. It advances `TauCetiRoadmap/UniversalCovers/README.md`, Stage 2, item 8, specifically the normalizer quotient and regular-cover milestone: “For the cover attached to `H`, the deck group is `N(H)/H`; it is a regular (normal/Galois) cover iff `H ◁ π₁(X, x₀)`, and then the deck group is `π₁(X, x₀)/H`.”

I chose this as the lowest-hanging distinct UniversalCovers prerequisite after checking open and recently merged PRs: `main` already has the normalizer-quotient fibre action, the normal-subgroup quotient comparison, and the freeness half of the descended action, while the transitivity half for normal subgroups was still absent. This PR does not attempt the full cover-classification theorem or the deck-group computation for quotient covers; it only supplies the small action-theoretic handoff those results consume.

No Mathlib infrastructure is vendored. The proof reuses Tau Ceti’s existing `normalizerQuotientOrbitRelQuotientMulAction` and representative formula, together with Mathlib’s `MulAction.IsPretransitive` API and `Subgroup.normalizer_eq_top` for normal subgroups.

`lake exe cache get` completed with `No files to download` and `Already decompressed 8609 file(s)`. `lake build` completed with `Build completed successfully (4526 jobs).` `lake exe axioms` completed with `axioms: audited 7992 TauCeti declaration(s); all within the allowlist [propext, Classical.choice, Quot.sound].`

<!--tauceti-target:v1 {"focus":"UniversalCovers","id":"normalizer-quotient-fiber-action-transitive"}-->

🤖 Prepared with Codex
