### PR TITLE
doc: repoint the roadmap reference from Targets.lean to Suggested.lean

### DIFF
--- a/TauCeti/Analysis/Contour/ModelSectorWinding.lean
+++ b/TauCeti/Analysis/Contour/ModelSectorWinding.lean
@@ -41,7 +41,7 @@ normalization; its value also follows from Mathlib's `circleIntegral.integral_su
 
 The `windingNumber_modelSector`, `windingNumber_at_i`, `windingNumber_at_rho`, and
 `windingNumber_circle` corollaries are the named Layer 1 targets of
-`ContourIntegration/Targets.lean`, derived from the general arbitrary-interval statement.
+`ContourIntegration/Suggested.lean`, derived from the general arbitrary-interval statement.
 
 ## Provenance
 

--- a/TauCeti/Probability/Exchangeability/Basic.lean
+++ b/TauCeti/Probability/Exchangeability/Basic.lean
@@ -15,7 +15,7 @@ hypotheses enter only in lemmas that compose `Measure.map`s.
 
 These declarations follow the roadmap signatures in
 `TauCetiRoadmap/Exchangeability/README.md` and
-`TauCetiRoadmap/Exchangeability/Targets.lean`, Layer 0. They are adapted from the
+`TauCetiRoadmap/Exchangeability/Suggested.lean`, Layer 0. They are adapted from the
 `cameronfreer/exchangeability` Layer 0 sources pinned at
 `e0532e59ceff23edab44dda9ab0655debbc9cc22`, with Tau Ceti API names and hypotheses.
 -/

--- a/TauCeti/Probability/Exchangeability/ConditionallyIID.lean
+++ b/TauCeti/Probability/Exchangeability/ConditionallyIID.lean
@@ -19,7 +19,7 @@ exchangeability implications from conditionally i.i.d. processes live in
 
 These declarations follow the roadmap signatures in
 `TauCetiRoadmap/Exchangeability/README.md` and
-`TauCetiRoadmap/Exchangeability/Targets.lean`, Layer 0, refining the existential
+`TauCetiRoadmap/Exchangeability/Suggested.lean`, Layer 0, refining the existential
 `ConditionallyIID` of the roadmap into a named-directing-measure relation
 (`ConditionallyIIDWith`) plus its existential wrapper. They are adapted from the
 `cameronfreer/exchangeability` Layer 0 sources pinned at

--- a/TauCeti/Probability/Exchangeability/ConditionallyIIDImplications.lean
+++ b/TauCeti/Probability/Exchangeability/ConditionallyIIDImplications.lean
@@ -12,7 +12,7 @@ has the same product-mixture law, so the exchangeability proof is just the speci
 the permuted and identity selections of `Fin n`.
 
 The resulting exchangeability theorem is one of the Layer 0 bridges listed in
-`TauCetiRoadmap/Exchangeability/Targets.lean`; the contractability corollaries use the same
+`TauCetiRoadmap/Exchangeability/Suggested.lean`; the contractability corollaries use the same
 injective-block identity, since strictly increasing finite selections are injective.
 
 These declarations follow the `cameronfreer/exchangeability` Layer 0 implication lattice

--- a/formalization.yaml
+++ b/formalization.yaml
@@ -87,6 +87,6 @@ alignment:
   note: >
     The human-authored roadmaps in the TauCetiRoadmap repo are the closest thing to a
     blueprint. Each roadmap (e.g. UniversalCovers, JacobianChallenge, ReductiveGroups)
-    states its goals as sorry-allowed signatures in its Targets.lean; the matching
+    states its goals as sorry-allowed signatures in its Suggested.lean; the matching
     sorry-free development lives (or will live) under TauCeti/.
   roadmaps: "https://github.com/TauCetiProject/TauCetiRoadmap"


### PR DESCRIPTION
This PR repoints TauCeti's references to the roadmap's suggested-signatures file from `Targets.lean` to `Suggested.lean`, matching the roadmap-side rename in https://github.com/TauCetiProject/TauCetiRoadmap/pull/55. It updates `formalization.yaml` and four in-source module docstrings (`Analysis/Contour/ModelSectorWinding.lean` and the three `Probability/Exchangeability/` files). Merge the roadmap PR first. (The lakefile `defaultTargets` are unrelated Lake targets and are untouched.)

🤖 Prepared with Claude Code