### PR TITLE
feat: add fixed-degree divisor subtraction

### DIFF
--- a/TauCeti/AlgebraicGeometry/WeilDivisor/DegreeOrder.lean
+++ b/TauCeti/AlgebraicGeometry/WeilDivisor/DegreeOrder.lean
@@ -5,6 +5,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 module
 
 public import TauCeti.AlgebraicGeometry.WeilDivisor.Order
+public import TauCeti.AlgebraicGeometry.WeilDivisor.FixedDegree
 public import Mathlib.Algebra.Order.Hom.Monoid
 
 /-!
@@ -154,6 +155,22 @@ lemma eq_of_le_of_degree_eq {D E : WeilDivisor X} (hDE : D ≤ E) (hdeg : degree
 lemma strictMono_degree : StrictMono (degree : WeilDivisor X → ℤ) := by
   intro D E hDE
   exact degree_lt_of_le_of_ne hDE.le hDE.ne'.symm
+
+namespace EffectiveDivisorOfDegree
+
+variable {d e : ℕ}
+
+/-- If a fixed-degree effective divisor is coefficientwise below another, its degree index is
+also bounded above. -/
+lemma degree_le_of_le {D : EffectiveDivisorOfDegree X d} {E : EffectiveDivisorOfDegree X e}
+    (hDE : (D : WeilDivisor X) ≤ E) : d ≤ e := by
+  have hdeg : degree (D : WeilDivisor X) ≤ degree (E : WeilDivisor X) :=
+    WeilDivisor.degree_le_of_le hDE
+  have hde : (d : ℤ) ≤ e := by
+    simpa [D.degree_eq, E.degree_eq] using hdeg
+  exact_mod_cast hde
+
+end EffectiveDivisorOfDegree
 
 end WeilDivisor
 

--- a/TauCeti/AlgebraicGeometry/WeilDivisor/FixedDegreeSubtraction.lean
+++ b/TauCeti/AlgebraicGeometry/WeilDivisor/FixedDegreeSubtraction.lean
@@ -93,6 +93,7 @@ lemma equivFinsupp_subOfLe_coe (D : EffectiveDivisorOfDegree X e)
 
 /-- Under the symmetric-power equivalence, a residual divisor is represented by the truncated
 difference of multiplicity functions. -/
+@[simp]
 lemma equivSym_subOfLe (D : EffectiveDivisorOfDegree X e) (E : EffectiveDivisorOfDegree X d)
     (hED : (E : WeilDivisor X) ≤ D) :
     equivSym (subOfLe D E hED) =

--- a/TauCeti/AlgebraicGeometry/WeilDivisor/FixedDegreeSubtraction.lean
+++ b/TauCeti/AlgebraicGeometry/WeilDivisor/FixedDegreeSubtraction.lean
@@ -13,9 +13,8 @@ public import TauCeti.AlgebraicGeometry.WeilDivisor.FixedDegreeAddition
 This file records the residual effective divisor obtained by subtracting an effective
 sub-divisor from a fixed-degree effective Weil divisor. If `E ≤ D`, with `D` of degree `e`
 and `E` of degree `d`, then `D - E` is effective of degree `e - d`. The cancellation lemmas
-show that this operation is inverse to the degree-indexed addition operation from
-`TauCeti.AlgebraicGeometry.WeilDivisor.FixedDegreeAddition`, up to the unavoidable casts in
-the natural-number degree index.
+show that adding the residual back recovers the original divisor, up to the unavoidable casts
+in the natural-number degree index.
 
 This is formal divisor bookkeeping for the Jacobian challenge roadmap's Layer C symmetric-power
 lane (`TauCetiRoadmap/JacobianChallenge/README.md`, "Relative effective Cartier divisors and
@@ -38,23 +37,13 @@ variable {X : Type*} {d e : ℕ}
 
 noncomputable section
 
-/-- If a fixed-degree effective divisor is coefficientwise below another, its degree index is
-also bounded above. -/
-lemma degree_le_of_le {D : EffectiveDivisorOfDegree X d} {E : EffectiveDivisorOfDegree X e}
-    (hDE : (D : WeilDivisor X) ≤ E) : d ≤ e := by
-  have hdeg : degree (D : WeilDivisor X) ≤ degree (E : WeilDivisor X) :=
-    WeilDivisor.degree_le_of_le hDE
-  have hde : (d : ℤ) ≤ e := by
-    simpa [D.degree_eq, E.degree_eq] using hdeg
-  exact_mod_cast hde
-
 /-- The residual fixed-degree effective divisor `D - E`, defined when `E ≤ D`.
 
 If `D` has degree `e` and `E` has degree `d`, the residual has degree `e - d`. -/
 abbrev subOfLE (D : EffectiveDivisorOfDegree X e) (E : EffectiveDivisorOfDegree X d)
     (hED : (E : WeilDivisor X) ≤ D) : EffectiveDivisorOfDegree X (e - d) :=
   ⟨(D : WeilDivisor X) - E, le_iff_isEffective_sub.mp hED, by
-    have hde : d ≤ e := degree_le_of_le hED
+    have hde : d ≤ e := EffectiveDivisorOfDegree.degree_le_of_le hED
     rw [degree_sub, D.degree_eq, E.degree_eq]
     exact (Int.ofNat_sub hde).symm⟩
 
@@ -74,6 +63,51 @@ lemma coeff_subOfLE (D : EffectiveDivisorOfDegree X e) (E : EffectiveDivisorOfDe
       coeff (D : WeilDivisor X) x - coeff (E : WeilDivisor X) x := by
   rw [coe_subOfLE, WeilDivisor.coeff_sub]
 
+/-- The multiplicity function of a residual divisor is the truncated difference of the
+multiplicity functions. -/
+@[simp]
+lemma multiplicityFinsupp_subOfLE (D : EffectiveDivisorOfDegree X e)
+    (E : EffectiveDivisorOfDegree X d) (hED : (E : WeilDivisor X) ≤ D) :
+    (subOfLE D E hED).multiplicityFinsupp =
+      D.multiplicityFinsupp - E.multiplicityFinsupp := by
+  ext x
+  simp only [multiplicityFinsupp_apply, WeilDivisor.coeff_sub]
+  change ((coeff (D : WeilDivisor X) x - coeff (E : WeilDivisor X) x).toNat) =
+    (coeff (D : WeilDivisor X) x).toNat - (coeff (E : WeilDivisor X) x).toNat
+  have hcoeff : coeff (E : WeilDivisor X) x ≤ coeff (D : WeilDivisor X) x :=
+    WeilDivisor.coeff_le_coeff hED x
+  have hnat : (coeff (E : WeilDivisor X) x).toNat ≤ (coeff (D : WeilDivisor X) x).toNat :=
+    Int.toNat_le_toNat hcoeff
+  apply Nat.cast_injective (R := ℤ)
+  rw [Int.toNat_sub_of_le hcoeff, Nat.cast_sub hnat]
+  rw [Int.toNat_of_nonneg ((isEffective_iff (D : WeilDivisor X)).mp D.isEffective x),
+    Int.toNat_of_nonneg ((isEffective_iff (E : WeilDivisor X)).mp E.isEffective x)]
+
+/-- The finitely supported multiplicity representation of a residual divisor is the
+truncated difference of the representations of the original divisors. -/
+@[simp]
+lemma equivFinsupp_subOfLE_coe (D : EffectiveDivisorOfDegree X e)
+    (E : EffectiveDivisorOfDegree X d) (hED : (E : WeilDivisor X) ≤ D) :
+    (equivFinsupp (subOfLE D E hED) : X →₀ ℕ) =
+      (equivFinsupp D : X →₀ ℕ) - (equivFinsupp E : X →₀ ℕ) := by
+  simp
+
+/-- Under the symmetric-power equivalence, a residual divisor is represented by the truncated
+difference of multiplicity functions. -/
+lemma equivSym_subOfLE (D : EffectiveDivisorOfDegree X e) (E : EffectiveDivisorOfDegree X d)
+    (hED : (E : WeilDivisor X) ≤ D) :
+    equivSym (subOfLE D E hED) =
+      (letI := Classical.decEq X;
+        (Sym.equivNatSum X (e - d)).symm
+          ⟨D.multiplicityFinsupp - E.multiplicityFinsupp, by
+            rw [← multiplicityFinsupp_subOfLE D E hED]
+            exact (subOfLE D E hED).sum_multiplicityFinsupp⟩) := by
+  classical
+  rw [equivSym_apply]
+  congr 1
+  ext x
+  simp
+
 /-- The degree of the residual divisor is the difference of the degree indices. -/
 lemma degree_subOfLE (D : EffectiveDivisorOfDegree X e) (E : EffectiveDivisorOfDegree X d)
     (hED : (E : WeilDivisor X) ≤ D) :
@@ -86,7 +120,8 @@ identifying `d + (e - d)` with `e`. -/
 lemma add_subOfLE (D : EffectiveDivisorOfDegree X e) (E : EffectiveDivisorOfDegree X d)
     (hED : (E : WeilDivisor X) ≤ D) :
     add E (subOfLE D E hED) =
-      EffectiveDivisorOfDegree.cast (Nat.add_sub_of_le (degree_le_of_le hED)).symm D := by
+      EffectiveDivisorOfDegree.cast
+        (Nat.add_sub_of_le (EffectiveDivisorOfDegree.degree_le_of_le hED)).symm D := by
   ext
   simp
 
@@ -96,7 +131,8 @@ identifying `(e - d) + d` with `e`. -/
 lemma subOfLE_add (D : EffectiveDivisorOfDegree X e) (E : EffectiveDivisorOfDegree X d)
     (hED : (E : WeilDivisor X) ≤ D) :
     add (subOfLE D E hED) E =
-      EffectiveDivisorOfDegree.cast (Nat.sub_add_cancel (degree_le_of_le hED)).symm D := by
+      EffectiveDivisorOfDegree.cast
+        (Nat.sub_add_cancel (EffectiveDivisorOfDegree.degree_le_of_le hED)).symm D := by
   ext
   simp [sub_add_cancel]
 

--- a/TauCeti/AlgebraicGeometry/WeilDivisor/FixedDegreeSubtraction.lean
+++ b/TauCeti/AlgebraicGeometry/WeilDivisor/FixedDegreeSubtraction.lean
@@ -40,7 +40,8 @@ noncomputable section
 /-- The residual fixed-degree effective divisor `D - E`, defined when `E ≤ D`.
 
 If `D` has degree `e` and `E` has degree `d`, the residual has degree `e - d`. -/
-abbrev subOfLE (D : EffectiveDivisorOfDegree X e) (E : EffectiveDivisorOfDegree X d)
+@[expose]
+def subOfLe (D : EffectiveDivisorOfDegree X e) (E : EffectiveDivisorOfDegree X d)
     (hED : (E : WeilDivisor X) ≤ D) : EffectiveDivisorOfDegree X (e - d) :=
   ⟨(D : WeilDivisor X) - E, le_iff_isEffective_sub.mp hED, by
     have hde : d ≤ e := EffectiveDivisorOfDegree.degree_le_of_le hED
@@ -50,30 +51,29 @@ abbrev subOfLE (D : EffectiveDivisorOfDegree X e) (E : EffectiveDivisorOfDegree 
 /-- The underlying Weil divisor of a residual fixed-degree divisor is the difference of the
 underlying Weil divisors. -/
 @[simp]
-lemma coe_subOfLE (D : EffectiveDivisorOfDegree X e) (E : EffectiveDivisorOfDegree X d)
+lemma coe_subOfLe (D : EffectiveDivisorOfDegree X e) (E : EffectiveDivisorOfDegree X d)
     (hED : (E : WeilDivisor X) ≤ D) :
-    (subOfLE D E hED : WeilDivisor X) = (D : WeilDivisor X) - E :=
+    (subOfLe D E hED : WeilDivisor X) = (D : WeilDivisor X) - E :=
   rfl
 
 /-- The coefficient of a residual fixed-degree divisor is the difference of coefficients. -/
 @[simp]
-lemma coeff_subOfLE (D : EffectiveDivisorOfDegree X e) (E : EffectiveDivisorOfDegree X d)
+lemma coeff_subOfLe (D : EffectiveDivisorOfDegree X e) (E : EffectiveDivisorOfDegree X d)
     (hED : (E : WeilDivisor X) ≤ D) (x : X) :
-    coeff (subOfLE D E hED : WeilDivisor X) x =
+    coeff (subOfLe D E hED : WeilDivisor X) x =
       coeff (D : WeilDivisor X) x - coeff (E : WeilDivisor X) x := by
-  rw [coe_subOfLE, WeilDivisor.coeff_sub]
+  rw [coe_subOfLe, WeilDivisor.coeff_sub]
 
 /-- The multiplicity function of a residual divisor is the truncated difference of the
 multiplicity functions. -/
 @[simp]
-lemma multiplicityFinsupp_subOfLE (D : EffectiveDivisorOfDegree X e)
+lemma multiplicityFinsupp_subOfLe (D : EffectiveDivisorOfDegree X e)
     (E : EffectiveDivisorOfDegree X d) (hED : (E : WeilDivisor X) ≤ D) :
-    (subOfLE D E hED).multiplicityFinsupp =
+    (subOfLe D E hED).multiplicityFinsupp =
       D.multiplicityFinsupp - E.multiplicityFinsupp := by
   ext x
-  simp only [multiplicityFinsupp_apply, WeilDivisor.coeff_sub]
-  change ((coeff (D : WeilDivisor X) x - coeff (E : WeilDivisor X) x).toNat) =
-    (coeff (D : WeilDivisor X) x).toNat - (coeff (E : WeilDivisor X) x).toNat
+  rw [multiplicityFinsupp_apply, coe_subOfLe, WeilDivisor.coeff_sub, Finsupp.tsub_apply,
+    multiplicityFinsupp_apply, multiplicityFinsupp_apply]
   have hcoeff : coeff (E : WeilDivisor X) x ≤ coeff (D : WeilDivisor X) x :=
     WeilDivisor.coeff_le_coeff hED x
   have hnat : (coeff (E : WeilDivisor X) x).toNat ≤ (coeff (D : WeilDivisor X) x).toNat :=
@@ -85,22 +85,22 @@ lemma multiplicityFinsupp_subOfLE (D : EffectiveDivisorOfDegree X e)
 
 /-- The finitely supported multiplicity representation of a residual divisor is the
 truncated difference of the representations of the original divisors. -/
-lemma equivFinsupp_subOfLE_coe (D : EffectiveDivisorOfDegree X e)
+lemma equivFinsupp_subOfLe_coe (D : EffectiveDivisorOfDegree X e)
     (E : EffectiveDivisorOfDegree X d) (hED : (E : WeilDivisor X) ≤ D) :
-    (equivFinsupp (subOfLE D E hED) : X →₀ ℕ) =
+    (equivFinsupp (subOfLe D E hED) : X →₀ ℕ) =
       (equivFinsupp D : X →₀ ℕ) - (equivFinsupp E : X →₀ ℕ) := by
   simp
 
 /-- Under the symmetric-power equivalence, a residual divisor is represented by the truncated
 difference of multiplicity functions. -/
-lemma equivSym_subOfLE (D : EffectiveDivisorOfDegree X e) (E : EffectiveDivisorOfDegree X d)
+lemma equivSym_subOfLe (D : EffectiveDivisorOfDegree X e) (E : EffectiveDivisorOfDegree X d)
     (hED : (E : WeilDivisor X) ≤ D) :
-    equivSym (subOfLE D E hED) =
+    equivSym (subOfLe D E hED) =
       (letI := Classical.decEq X;
         (Sym.equivNatSum X (e - d)).symm
           ⟨D.multiplicityFinsupp - E.multiplicityFinsupp, by
-            rw [← multiplicityFinsupp_subOfLE D E hED]
-            exact (subOfLE D E hED).sum_multiplicityFinsupp⟩) := by
+            rw [← multiplicityFinsupp_subOfLe D E hED]
+            exact (subOfLe D E hED).sum_multiplicityFinsupp⟩) := by
   classical
   rw [equivSym_apply]
   congr 1
@@ -108,17 +108,17 @@ lemma equivSym_subOfLE (D : EffectiveDivisorOfDegree X e) (E : EffectiveDivisorO
   simp
 
 /-- The degree of the residual divisor is the difference of the degree indices. -/
-lemma degree_subOfLE (D : EffectiveDivisorOfDegree X e) (E : EffectiveDivisorOfDegree X d)
+lemma degree_subOfLe (D : EffectiveDivisorOfDegree X e) (E : EffectiveDivisorOfDegree X d)
     (hED : (E : WeilDivisor X) ≤ D) :
-    degree (subOfLE D E hED : WeilDivisor X) = ((e - d : ℕ) : ℤ) :=
-  (subOfLE D E hED).degree_eq
+    degree (subOfLe D E hED : WeilDivisor X) = ((e - d : ℕ) : ℤ) :=
+  (subOfLe D E hED).degree_eq
 
 /-- Adding a sub-divisor back to its residual recovers the original divisor, up to the cast
 identifying `d + (e - d)` with `e`. -/
 @[simp]
-lemma add_subOfLE (D : EffectiveDivisorOfDegree X e) (E : EffectiveDivisorOfDegree X d)
+lemma add_subOfLe (D : EffectiveDivisorOfDegree X e) (E : EffectiveDivisorOfDegree X d)
     (hED : (E : WeilDivisor X) ≤ D) :
-    add E (subOfLE D E hED) =
+    add E (subOfLe D E hED) =
       EffectiveDivisorOfDegree.cast
         (Nat.add_sub_of_le (EffectiveDivisorOfDegree.degree_le_of_le hED)).symm D := by
   ext
@@ -127,9 +127,9 @@ lemma add_subOfLE (D : EffectiveDivisorOfDegree X e) (E : EffectiveDivisorOfDegr
 /-- Adding the residual on the left also recovers the original divisor, up to the cast
 identifying `(e - d) + d` with `e`. -/
 @[simp]
-lemma subOfLE_add (D : EffectiveDivisorOfDegree X e) (E : EffectiveDivisorOfDegree X d)
+lemma subOfLe_add (D : EffectiveDivisorOfDegree X e) (E : EffectiveDivisorOfDegree X d)
     (hED : (E : WeilDivisor X) ≤ D) :
-    add (subOfLE D E hED) E =
+    add (subOfLe D E hED) E =
       EffectiveDivisorOfDegree.cast
         (Nat.sub_add_cancel (EffectiveDivisorOfDegree.degree_le_of_le hED)).symm D := by
   ext
@@ -138,8 +138,8 @@ lemma subOfLE_add (D : EffectiveDivisorOfDegree X e) (E : EffectiveDivisorOfDegr
 /-- Subtracting the zero fixed-degree divisor leaves the original divisor, up to the cast
 identifying `d - 0` with `d`. -/
 @[simp]
-lemma subOfLE_zero (D : EffectiveDivisorOfDegree X d) :
-    subOfLE D (zero X) (by
+lemma subOfLe_zero (D : EffectiveDivisorOfDegree X d) :
+    subOfLe D (zero X) (by
       rw [← WeilDivisor.isEffective_iff_zero_le]
       exact D.isEffective) =
       EffectiveDivisorOfDegree.cast (Nat.sub_zero d).symm D := by
@@ -148,8 +148,8 @@ lemma subOfLE_zero (D : EffectiveDivisorOfDegree X d) :
 
 /-- Subtracting a fixed-degree divisor from itself gives the zero residual divisor. -/
 @[simp]
-lemma subOfLE_self (D : EffectiveDivisorOfDegree X d) :
-    subOfLE D D le_rfl = EffectiveDivisorOfDegree.cast (Nat.sub_self d).symm (zero X) := by
+lemma subOfLe_self (D : EffectiveDivisorOfDegree X d) :
+    subOfLe D D le_rfl = EffectiveDivisorOfDegree.cast (Nat.sub_self d).symm (zero X) := by
   ext
   simp
 

--- a/TauCeti/AlgebraicGeometry/WeilDivisor/FixedDegreeSubtraction.lean
+++ b/TauCeti/AlgebraicGeometry/WeilDivisor/FixedDegreeSubtraction.lean
@@ -75,7 +75,6 @@ lemma coeff_subOfLE (D : EffectiveDivisorOfDegree X e) (E : EffectiveDivisorOfDe
   rw [coe_subOfLE, WeilDivisor.coeff_sub]
 
 /-- The degree of the residual divisor is the difference of the degree indices. -/
-@[simp]
 lemma degree_subOfLE (D : EffectiveDivisorOfDegree X e) (E : EffectiveDivisorOfDegree X d)
     (hED : (E : WeilDivisor X) ≤ D) :
     degree (subOfLE D E hED : WeilDivisor X) = ((e - d : ℕ) : ℤ) :=

--- a/TauCeti/AlgebraicGeometry/WeilDivisor/FixedDegreeSubtraction.lean
+++ b/TauCeti/AlgebraicGeometry/WeilDivisor/FixedDegreeSubtraction.lean
@@ -85,7 +85,6 @@ lemma multiplicityFinsupp_subOfLE (D : EffectiveDivisorOfDegree X e)
 
 /-- The finitely supported multiplicity representation of a residual divisor is the
 truncated difference of the representations of the original divisors. -/
-@[simp]
 lemma equivFinsupp_subOfLE_coe (D : EffectiveDivisorOfDegree X e)
     (E : EffectiveDivisorOfDegree X d) (hED : (E : WeilDivisor X) ≤ D) :
     (equivFinsupp (subOfLE D E hED) : X →₀ ℕ) =

--- a/TauCeti/AlgebraicGeometry/WeilDivisor/FixedDegreeSubtraction.lean
+++ b/TauCeti/AlgebraicGeometry/WeilDivisor/FixedDegreeSubtraction.lean
@@ -1,0 +1,130 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+module
+
+public import TauCeti.AlgebraicGeometry.WeilDivisor.DegreeOrder
+public import TauCeti.AlgebraicGeometry.WeilDivisor.FixedDegreeAddition
+
+/-!
+# Subtraction of fixed-degree effective Weil divisors
+
+This file records the residual effective divisor obtained by subtracting an effective
+sub-divisor from a fixed-degree effective Weil divisor. If `E ≤ D`, with `D` of degree `e`
+and `E` of degree `d`, then `D - E` is effective of degree `e - d`. The cancellation lemmas
+show that this operation is inverse to the degree-indexed addition operation from
+`TauCeti.AlgebraicGeometry.WeilDivisor.FixedDegreeAddition`, up to the unavoidable casts in
+the natural-number degree index.
+
+This is formal divisor bookkeeping for the Jacobian challenge roadmap's Layer C symmetric-power
+lane (`TauCetiRoadmap/JacobianChallenge/README.md`, "Relative effective Cartier divisors and
+symmetric powers `Symᵈ X`"). The scheme-level construction is later geometry; this file supplies
+the elementary residual-divisor API used when separating a fixed effective base divisor from an
+unordered collection of points. No external mathematics is vendored.
+-/
+
+public section
+
+namespace TauCeti
+
+namespace AlgebraicGeometry
+
+namespace WeilDivisor
+
+namespace EffectiveDivisorOfDegree
+
+variable {X : Type*} {d e : ℕ}
+
+noncomputable section
+
+/-- If a fixed-degree effective divisor is coefficientwise below another, its degree index is
+also bounded above. -/
+lemma degree_le_of_le {D : EffectiveDivisorOfDegree X d} {E : EffectiveDivisorOfDegree X e}
+    (hDE : (D : WeilDivisor X) ≤ E) : d ≤ e := by
+  have hdeg : degree (D : WeilDivisor X) ≤ degree (E : WeilDivisor X) :=
+    WeilDivisor.degree_le_of_le hDE
+  have hde : (d : ℤ) ≤ e := by
+    simpa [D.degree_eq, E.degree_eq] using hdeg
+  exact_mod_cast hde
+
+/-- The residual fixed-degree effective divisor `D - E`, defined when `E ≤ D`.
+
+If `D` has degree `e` and `E` has degree `d`, the residual has degree `e - d`. -/
+abbrev subOfLE (D : EffectiveDivisorOfDegree X e) (E : EffectiveDivisorOfDegree X d)
+    (hED : (E : WeilDivisor X) ≤ D) : EffectiveDivisorOfDegree X (e - d) :=
+  ⟨(D : WeilDivisor X) - E, le_iff_isEffective_sub.mp hED, by
+    have hde : d ≤ e := degree_le_of_le hED
+    rw [degree_sub, D.degree_eq, E.degree_eq]
+    exact (Int.ofNat_sub hde).symm⟩
+
+/-- The underlying Weil divisor of a residual fixed-degree divisor is the difference of the
+underlying Weil divisors. -/
+@[simp]
+lemma coe_subOfLE (D : EffectiveDivisorOfDegree X e) (E : EffectiveDivisorOfDegree X d)
+    (hED : (E : WeilDivisor X) ≤ D) :
+    (subOfLE D E hED : WeilDivisor X) = (D : WeilDivisor X) - E :=
+  rfl
+
+/-- The coefficient of a residual fixed-degree divisor is the difference of coefficients. -/
+@[simp]
+lemma coeff_subOfLE (D : EffectiveDivisorOfDegree X e) (E : EffectiveDivisorOfDegree X d)
+    (hED : (E : WeilDivisor X) ≤ D) (x : X) :
+    coeff (subOfLE D E hED : WeilDivisor X) x =
+      coeff (D : WeilDivisor X) x - coeff (E : WeilDivisor X) x := by
+  rw [coe_subOfLE, WeilDivisor.coeff_sub]
+
+/-- The degree of the residual divisor is the difference of the degree indices. -/
+@[simp]
+lemma degree_subOfLE (D : EffectiveDivisorOfDegree X e) (E : EffectiveDivisorOfDegree X d)
+    (hED : (E : WeilDivisor X) ≤ D) :
+    degree (subOfLE D E hED : WeilDivisor X) = ((e - d : ℕ) : ℤ) :=
+  (subOfLE D E hED).degree_eq
+
+/-- Adding a sub-divisor back to its residual recovers the original divisor, up to the cast
+identifying `d + (e - d)` with `e`. -/
+@[simp]
+lemma add_subOfLE (D : EffectiveDivisorOfDegree X e) (E : EffectiveDivisorOfDegree X d)
+    (hED : (E : WeilDivisor X) ≤ D) :
+    add E (subOfLE D E hED) =
+      EffectiveDivisorOfDegree.cast (Nat.add_sub_of_le (degree_le_of_le hED)).symm D := by
+  ext
+  simp
+
+/-- Adding the residual on the left also recovers the original divisor, up to the cast
+identifying `(e - d) + d` with `e`. -/
+@[simp]
+lemma subOfLE_add (D : EffectiveDivisorOfDegree X e) (E : EffectiveDivisorOfDegree X d)
+    (hED : (E : WeilDivisor X) ≤ D) :
+    add (subOfLE D E hED) E =
+      EffectiveDivisorOfDegree.cast (Nat.sub_add_cancel (degree_le_of_le hED)).symm D := by
+  ext
+  simp [sub_add_cancel]
+
+/-- Subtracting the zero fixed-degree divisor leaves the original divisor, up to the cast
+identifying `d - 0` with `d`. -/
+@[simp]
+lemma subOfLE_zero (D : EffectiveDivisorOfDegree X d) :
+    subOfLE D (zero X) (by
+      rw [← WeilDivisor.isEffective_iff_zero_le]
+      exact D.isEffective) =
+      EffectiveDivisorOfDegree.cast (Nat.sub_zero d).symm D := by
+  ext
+  simp
+
+/-- Subtracting a fixed-degree divisor from itself gives the zero residual divisor. -/
+@[simp]
+lemma subOfLE_self (D : EffectiveDivisorOfDegree X d) :
+    subOfLE D D le_rfl = EffectiveDivisorOfDegree.cast (Nat.sub_self d).symm (zero X) := by
+  ext
+  simp
+
+end
+
+end EffectiveDivisorOfDegree
+
+end WeilDivisor
+
+end AlgebraicGeometry
+
+end TauCeti


### PR DESCRIPTION
This PR adds residual fixed-degree effective Weil divisors: if `E ≤ D`, with `D` of degree `e` and `E` of degree `d`, it packages the effective divisor `D - E` as degree `e - d` and proves the cancellation lemmas showing that adding the residual back recovers `D` up to the natural degree-index casts. It advances `TauCetiRoadmap/JacobianChallenge/README.md`, Layer C, the item “Relative effective Cartier divisors and symmetric powers `Symᵈ X`,” as formal divisor bookkeeping for separating a fixed effective base divisor from an unordered degree-`e` collection of points before the scheme-level symmetric powers exist.

I chose this as the lowest-hanging distinct JacobianChallenge prerequisite after checking open and recently merged PRs: existing work already provides fixed-degree effective divisors, their equivalence with `Sym X d`, addition, pushforward, divisor order, and degree monotonicity, while the residual sub-divisor operation was still absent. The open JacobianChallenge-adjacent work is contour/residue material outside this roadmap, and the recent JacobianChallenge PR covers degree monotonicity rather than fixed-degree subtraction.

No Mathlib infrastructure is vendored. The implementation reuses Tau Ceti’s `EffectiveDivisorOfDegree`, degree-indexed `add`, coefficientwise divisor order, and `degree_le_of_le`, together with Mathlib’s standard integer/natural cast lemma `Int.ofNat_sub`.

`lake exe cache get` completed with `No files to download` and `Already decompressed 8609 file(s)`. `lake build` completed with `Build completed successfully (4534 jobs).` `lake exe axioms` completed with `axioms: audited 8052 TauCeti declaration(s); all within the allowlist [propext, Classical.choice, Quot.sound].`

<!--tauceti-target:v1 {"focus":"JacobianChallenge","id":"fixed-degree-subdivisor"}-->

🤖 Prepared with Codex
