### PR TITLE
feat: add integrated zero-drift symmetry

### DIFF
--- a/TauCeti/Analysis/PDE/CoercivePerturbation.lean
+++ b/TauCeti/Analysis/PDE/CoercivePerturbation.lean
@@ -46,7 +46,10 @@ namespace PDE
 open Matrix
 open scoped InnerProductSpace
 
-variable {X n : Type*} [Fintype n] [DecidableEq n]
+variable {X n : Type*} [Fintype n]
+
+noncomputable local instance coercivePerturbationDecidableEq : DecidableEq n :=
+  Classical.decEq n
 
 variable {A B : Matrix n n ℝ} {b₀ : EuclideanSpace ℝ n} {c₀ d lam mu beta : ℝ}
 

--- a/TauCeti/Analysis/PDE/CoercivePerturbation.lean
+++ b/TauCeti/Analysis/PDE/CoercivePerturbation.lean
@@ -48,6 +48,7 @@ open scoped InnerProductSpace
 
 variable {X n : Type*} [Fintype n]
 
+/-- Local classical decidable equality for finite coordinate indices in perturbation proofs. -/
 noncomputable local instance coercivePerturbationDecidableEq : DecidableEq n :=
   Classical.decEq n
 

--- a/TauCeti/Analysis/PDE/EnergyForm.lean
+++ b/TauCeti/Analysis/PDE/EnergyForm.lean
@@ -72,6 +72,7 @@ open scoped InnerProductSpace
 
 variable {X n : Type*} [Fintype n]
 
+/-- Local classical decidable equality for finite coordinate indices in energy-form proofs. -/
 noncomputable local instance energyFormDecidableEq : DecidableEq n := Classical.decEq n
 
 /-- The pointwise weak-form (energy) integrand of a divergence-form operator

--- a/TauCeti/Analysis/PDE/EnergyForm.lean
+++ b/TauCeti/Analysis/PDE/EnergyForm.lean
@@ -70,7 +70,7 @@ namespace PDE
 open Matrix
 open scoped InnerProductSpace
 
-variable {X n : Type*} [Fintype n] [DecidableEq n]
+variable {X n : Type*} [Fintype n]
 
 /-- The pointwise weak-form (energy) integrand of a divergence-form operator
 `L u = -∂ⱼ(aⁱʲ ∂ᵢu) + bⁱ ∂ᵢu + c u`, as a bundled continuous bilinear form on jets
@@ -82,6 +82,7 @@ On jets `U = (u, ∇u)` and `V = (v, ∇v)` it evaluates to
 once the energy form is integrated over the Sobolev space. -/
 noncomputable def energyIntegrand (A : Matrix n n ℝ) (b : EuclideanSpace ℝ n) (c : ℝ) :
     (ℝ × EuclideanSpace ℝ n) →L[ℝ] (ℝ × EuclideanSpace ℝ n) →L[ℝ] ℝ :=
+  letI := Classical.decEq n
   (matrixBilinearForm A).flip.bilinearComp
       (ContinuousLinearMap.snd ℝ ℝ (EuclideanSpace ℝ n))
       (ContinuousLinearMap.snd ℝ ℝ (EuclideanSpace ℝ n))
@@ -92,7 +93,6 @@ noncomputable def energyIntegrand (A : Matrix n n ℝ) (b : EuclideanSpace ℝ n
         (ContinuousLinearMap.fst ℝ ℝ (EuclideanSpace ℝ n))
         (ContinuousLinearMap.fst ℝ ℝ (EuclideanSpace ℝ n))
 
-omit [DecidableEq n] in
 /-- The jet form evaluates to `⟨a ∇u, ∇v⟩ + ⟪b, ∇u⟫ v + c u v` on jets `U`, `V`. -/
 @[simp]
 lemma energyIntegrand_apply (A : Matrix n n ℝ) (b : EuclideanSpace ℝ n) (c : ℝ)
@@ -102,8 +102,8 @@ lemma energyIntegrand_apply (A : Matrix n n ℝ) (b : EuclideanSpace ℝ n) (c :
   simp [energyIntegrand]
 
 /-- The diagonal of the jet form, the energy density `⟨a ∇u, ∇u⟩ + ⟪b, ∇u⟫ u + c u²`. -/
-lemma energyIntegrand_self (A : Matrix n n ℝ) (b : EuclideanSpace ℝ n) (c : ℝ)
-    (U : ℝ × EuclideanSpace ℝ n) :
+lemma energyIntegrand_self [DecidableEq n] (A : Matrix n n ℝ) (b : EuclideanSpace ℝ n)
+    (c : ℝ) (U : ℝ × EuclideanSpace ℝ n) :
     energyIntegrand A b c U U
       = A.toQuadraticForm' U.2 + ⟪b, U.2⟫_ℝ * U.1 + c * U.1 ^ 2 := by
   rw [energyIntegrand_apply, matrixBilinearForm_self, driftForm_apply, massForm_apply]
@@ -111,25 +111,27 @@ lemma energyIntegrand_self (A : Matrix n n ℝ) (b : EuclideanSpace ℝ n) (c : 
 
 /-- The Laplacian model `−Δ` (`a = 1`, no drift, no mass) has jet form the Dirichlet
 integrand `⟨∇u, ∇v⟩`. -/
-lemma energyIntegrand_one_zero_zero_apply (U V : ℝ × EuclideanSpace ℝ n) :
+lemma energyIntegrand_one_zero_zero_apply [DecidableEq n] (U V : ℝ × EuclideanSpace ℝ n) :
     energyIntegrand (1 : Matrix n n ℝ) 0 0 U V = V.2 ⬝ᵥ U.2 := by
   simp [energyIntegrand_apply]
 
 /-- The diagonal of the Laplacian model's jet form is the Dirichlet energy density `‖∇u‖²`. -/
-lemma energyIntegrand_one_zero_zero_self (U : ℝ × EuclideanSpace ℝ n) :
+lemma energyIntegrand_one_zero_zero_self [DecidableEq n] (U : ℝ × EuclideanSpace ℝ n) :
     energyIntegrand (1 : Matrix n n ℝ) 0 0 U U = ‖U.2‖ ^ 2 := by
   rw [energyIntegrand_self, toQuadraticForm'_one]
   simp
 
 /-- The shifted Laplacian model `-Δ + c` has jet form
 `(U, V) ↦ ∇u · ∇v + c u v`. -/
-lemma energyIntegrand_one_zero_mass_apply (c : ℝ) (U V : ℝ × EuclideanSpace ℝ n) :
+lemma energyIntegrand_one_zero_mass_apply [DecidableEq n] (c : ℝ)
+    (U V : ℝ × EuclideanSpace ℝ n) :
     energyIntegrand (1 : Matrix n n ℝ) 0 c U V = V.2 ⬝ᵥ U.2 + c * U.1 * V.1 := by
   simp [energyIntegrand_apply, massForm_apply]
 
 /-- The shifted Laplacian model `-Δ + c` has diagonal jet density
 `‖∇u‖² + c u²`. -/
-lemma energyIntegrand_one_zero_mass_self (c : ℝ) (U : ℝ × EuclideanSpace ℝ n) :
+lemma energyIntegrand_one_zero_mass_self [DecidableEq n] (c : ℝ)
+    (U : ℝ × EuclideanSpace ℝ n) :
     energyIntegrand (1 : Matrix n n ℝ) 0 c U U = ‖U.2‖ ^ 2 + c * U.1 ^ 2 := by
   rw [energyIntegrand_self, toQuadraticForm'_one]
   simp
@@ -153,13 +155,12 @@ private lemma mul_norm_abs_le_half_mul_sq_add (hlam : 0 < lam) (beta u : ℝ) (r
   apply div_nonneg _ h2lam.le
   nlinarith [hkey]
 
-private lemma abs_dotProduct_one_mulVec_le (η ξ : EuclideanSpace ℝ n) :
+private lemma abs_dotProduct_one_mulVec_le [DecidableEq n] (η ξ : EuclideanSpace ℝ n) :
     |η ⬝ᵥ ((1 : Matrix n n ℝ) *ᵥ ξ)| ≤ 1 * ‖η‖ * ‖ξ‖ := by
   rw [one_mulVec, one_mul]
   simpa [EuclideanSpace.inner_eq_star_dotProduct, dotProduct_comm] using
     abs_real_inner_le_norm η ξ
 
-omit [DecidableEq n] in
 /-- Pointwise boundedness of the jet form with explicit constant `Λ + β + γ`: the principal,
 drift, and mass contributions are each controlled by the corresponding constant times the jet
 norms. -/
@@ -211,7 +212,6 @@ lemma norm_energyIntegrand_apply_le_of_bounds (hLam : 0 ≤ Lam)
         add_le_add (add_le_add hmat hdrift) hmass
     _ = (Lam + beta + gamma) * ‖U‖ * ‖V‖ := by ring
 
-omit [DecidableEq n] in
 /-- Pointwise boundedness on a domain, obtained by applying
 `norm_energyIntegrand_apply_le_of_bounds` at `x`. -/
 lemma norm_energyIntegrand_apply_le_of_bounds_on (hLam : 0 ≤ Lam)
@@ -223,7 +223,6 @@ lemma norm_energyIntegrand_apply_le_of_bounds_on (hLam : 0 ≤ Lam)
     ‖energyIntegrand (a x) (b x) (c x) U V‖ ≤ (Lam + beta + gamma) * ‖U‖ * ‖V‖ :=
   norm_energyIntegrand_apply_le_of_bounds hLam (ha hx) (hb hx) (hc hx) U V
 
-omit [DecidableEq n] in
 /-- The operator norm of the jet form is at most `Λ + β + γ`. This is the boundedness
 hypothesis of Lax--Milgram, with the constant explicit in the ellipticity, drift, and mass
 bounds. -/
@@ -240,7 +239,7 @@ lemma opNorm_energyIntegrand_le_of_bounds (hLam : 0 ≤ Lam)
   exact norm_energyIntegrand_apply_le_of_bounds hLam ha hb hc U V
 
 /-- Pointwise boundedness of the shifted Laplacian jet form with constant `1 + ‖c‖`. -/
-lemma norm_energyIntegrand_one_zero_mass_apply_le (c : ℝ)
+lemma norm_energyIntegrand_one_zero_mass_apply_le [DecidableEq n] (c : ℝ)
     (U V : ℝ × EuclideanSpace ℝ n) :
     ‖energyIntegrand (1 : Matrix n n ℝ) 0 c U V‖ ≤
       (1 + ‖c‖) * ‖U‖ * ‖V‖ := by
@@ -250,14 +249,13 @@ lemma norm_energyIntegrand_one_zero_mass_apply_le (c : ℝ)
       (fun η ξ => abs_dotProduct_one_mulVec_le η ξ) (by simp) le_rfl U V
 
 /-- Operator-norm boundedness of the shifted Laplacian jet form with constant `1 + ‖c‖`. -/
-lemma opNorm_energyIntegrand_one_zero_mass_le (c : ℝ) :
+lemma opNorm_energyIntegrand_one_zero_mass_le [DecidableEq n] (c : ℝ) :
     ‖energyIntegrand (1 : Matrix n n ℝ) 0 c‖ ≤ 1 + ‖c‖ := by
   simpa using
     opNorm_energyIntegrand_le_of_bounds (n := n) (Lam := 1) (beta := 0) (b₀ := 0)
       (gamma := ‖c‖) zero_le_one
       (fun η ξ => abs_dotProduct_one_mulVec_le η ξ) (by simp) le_rfl
 
-omit [DecidableEq n] in
 /-- Operator-norm boundedness on a domain, obtained by applying
 `opNorm_energyIntegrand_le_of_bounds` at `x`. -/
 lemma opNorm_energyIntegrand_le_of_bounds_on (hLam : 0 ≤ Lam)
@@ -273,7 +271,7 @@ diagonal of the jet form is bounded below by `(λ/2)‖∇u‖² − (β²/2λ)|
 floor `λ‖∇u‖²` pays for the drift term via Young's inequality, leaving half the floor and a
 mass defect proportional to `β²/λ`. Integrating over `Ω` this is Gårding's inequality
 `a(u, u) ≥ (λ/2)‖∇u‖²_{L²} − (β²/2λ)‖u‖²_{L²}`. -/
-lemma garding_energyIntegrand_self_of_bounds (hlam : 0 < lam)
+lemma garding_energyIntegrand_self_of_bounds [DecidableEq n] (hlam : 0 < lam)
     {A : Matrix n n ℝ} {b₀ : EuclideanSpace ℝ n} {c₀ : ℝ}
     (hQ : ∀ ξ : EuclideanSpace ℝ n, lam * ‖ξ‖ ^ 2 ≤ A.toQuadraticForm' ξ)
     (hb : ‖b₀‖ ≤ beta) (hc : 0 ≤ c₀)
@@ -299,7 +297,7 @@ lemma garding_energyIntegrand_self_of_bounds (hlam : 0 < lam)
 
 /-- Pointwise Gårding inequality on a domain, obtained by applying
 `garding_energyIntegrand_self_of_bounds` at `x`. -/
-lemma garding_energyIntegrand_self_of_bounds_on (hlam : 0 < lam)
+lemma garding_energyIntegrand_self_of_bounds_on [DecidableEq n] (hlam : 0 < lam)
     (hQ : ∀ ⦃x⦄, x ∈ Ω → ∀ ξ : EuclideanSpace ℝ n,
       lam * ‖ξ‖ ^ 2 ≤ (a x).toQuadraticForm' ξ)
     (hb : ∀ ⦃x⦄, x ∈ Ω → ‖b x‖ ≤ beta)

--- a/TauCeti/Analysis/PDE/EnergyForm.lean
+++ b/TauCeti/Analysis/PDE/EnergyForm.lean
@@ -72,6 +72,8 @@ open scoped InnerProductSpace
 
 variable {X n : Type*} [Fintype n]
 
+noncomputable local instance energyFormDecidableEq : DecidableEq n := Classical.decEq n
+
 /-- The pointwise weak-form (energy) integrand of a divergence-form operator
 `L u = -∂ⱼ(aⁱʲ ∂ᵢu) + bⁱ ∂ᵢu + c u`, as a bundled continuous bilinear form on jets
 `(value, gradient) ∈ ℝ × EuclideanSpace ℝ n`.
@@ -102,7 +104,7 @@ lemma energyIntegrand_apply (A : Matrix n n ℝ) (b : EuclideanSpace ℝ n) (c :
   simp [energyIntegrand]
 
 /-- The diagonal of the jet form, the energy density `⟨a ∇u, ∇u⟩ + ⟪b, ∇u⟫ u + c u²`. -/
-lemma energyIntegrand_self [DecidableEq n] (A : Matrix n n ℝ) (b : EuclideanSpace ℝ n)
+lemma energyIntegrand_self (A : Matrix n n ℝ) (b : EuclideanSpace ℝ n)
     (c : ℝ) (U : ℝ × EuclideanSpace ℝ n) :
     energyIntegrand A b c U U
       = A.toQuadraticForm' U.2 + ⟪b, U.2⟫_ℝ * U.1 + c * U.1 ^ 2 := by
@@ -111,26 +113,26 @@ lemma energyIntegrand_self [DecidableEq n] (A : Matrix n n ℝ) (b : EuclideanSp
 
 /-- The Laplacian model `−Δ` (`a = 1`, no drift, no mass) has jet form the Dirichlet
 integrand `⟨∇u, ∇v⟩`. -/
-lemma energyIntegrand_one_zero_zero_apply [DecidableEq n] (U V : ℝ × EuclideanSpace ℝ n) :
+lemma energyIntegrand_one_zero_zero_apply (U V : ℝ × EuclideanSpace ℝ n) :
     energyIntegrand (1 : Matrix n n ℝ) 0 0 U V = V.2 ⬝ᵥ U.2 := by
   simp [energyIntegrand_apply]
 
 /-- The diagonal of the Laplacian model's jet form is the Dirichlet energy density `‖∇u‖²`. -/
-lemma energyIntegrand_one_zero_zero_self [DecidableEq n] (U : ℝ × EuclideanSpace ℝ n) :
+lemma energyIntegrand_one_zero_zero_self (U : ℝ × EuclideanSpace ℝ n) :
     energyIntegrand (1 : Matrix n n ℝ) 0 0 U U = ‖U.2‖ ^ 2 := by
   rw [energyIntegrand_self, toQuadraticForm'_one]
   simp
 
 /-- The shifted Laplacian model `-Δ + c` has jet form
 `(U, V) ↦ ∇u · ∇v + c u v`. -/
-lemma energyIntegrand_one_zero_mass_apply [DecidableEq n] (c : ℝ)
+lemma energyIntegrand_one_zero_mass_apply (c : ℝ)
     (U V : ℝ × EuclideanSpace ℝ n) :
     energyIntegrand (1 : Matrix n n ℝ) 0 c U V = V.2 ⬝ᵥ U.2 + c * U.1 * V.1 := by
   simp [energyIntegrand_apply, massForm_apply]
 
 /-- The shifted Laplacian model `-Δ + c` has diagonal jet density
 `‖∇u‖² + c u²`. -/
-lemma energyIntegrand_one_zero_mass_self [DecidableEq n] (c : ℝ)
+lemma energyIntegrand_one_zero_mass_self (c : ℝ)
     (U : ℝ × EuclideanSpace ℝ n) :
     energyIntegrand (1 : Matrix n n ℝ) 0 c U U = ‖U.2‖ ^ 2 + c * U.1 ^ 2 := by
   rw [energyIntegrand_self, toQuadraticForm'_one]
@@ -155,7 +157,7 @@ private lemma mul_norm_abs_le_half_mul_sq_add (hlam : 0 < lam) (beta u : ℝ) (r
   apply div_nonneg _ h2lam.le
   nlinarith [hkey]
 
-private lemma abs_dotProduct_one_mulVec_le [DecidableEq n] (η ξ : EuclideanSpace ℝ n) :
+private lemma abs_dotProduct_one_mulVec_le (η ξ : EuclideanSpace ℝ n) :
     |η ⬝ᵥ ((1 : Matrix n n ℝ) *ᵥ ξ)| ≤ 1 * ‖η‖ * ‖ξ‖ := by
   rw [one_mulVec, one_mul]
   simpa [EuclideanSpace.inner_eq_star_dotProduct, dotProduct_comm] using
@@ -239,7 +241,7 @@ lemma opNorm_energyIntegrand_le_of_bounds (hLam : 0 ≤ Lam)
   exact norm_energyIntegrand_apply_le_of_bounds hLam ha hb hc U V
 
 /-- Pointwise boundedness of the shifted Laplacian jet form with constant `1 + ‖c‖`. -/
-lemma norm_energyIntegrand_one_zero_mass_apply_le [DecidableEq n] (c : ℝ)
+lemma norm_energyIntegrand_one_zero_mass_apply_le (c : ℝ)
     (U V : ℝ × EuclideanSpace ℝ n) :
     ‖energyIntegrand (1 : Matrix n n ℝ) 0 c U V‖ ≤
       (1 + ‖c‖) * ‖U‖ * ‖V‖ := by
@@ -249,7 +251,7 @@ lemma norm_energyIntegrand_one_zero_mass_apply_le [DecidableEq n] (c : ℝ)
       (fun η ξ => abs_dotProduct_one_mulVec_le η ξ) (by simp) le_rfl U V
 
 /-- Operator-norm boundedness of the shifted Laplacian jet form with constant `1 + ‖c‖`. -/
-lemma opNorm_energyIntegrand_one_zero_mass_le [DecidableEq n] (c : ℝ) :
+lemma opNorm_energyIntegrand_one_zero_mass_le (c : ℝ) :
     ‖energyIntegrand (1 : Matrix n n ℝ) 0 c‖ ≤ 1 + ‖c‖ := by
   simpa using
     opNorm_energyIntegrand_le_of_bounds (n := n) (Lam := 1) (beta := 0) (b₀ := 0)
@@ -271,7 +273,7 @@ diagonal of the jet form is bounded below by `(λ/2)‖∇u‖² − (β²/2λ)|
 floor `λ‖∇u‖²` pays for the drift term via Young's inequality, leaving half the floor and a
 mass defect proportional to `β²/λ`. Integrating over `Ω` this is Gårding's inequality
 `a(u, u) ≥ (λ/2)‖∇u‖²_{L²} − (β²/2λ)‖u‖²_{L²}`. -/
-lemma garding_energyIntegrand_self_of_bounds [DecidableEq n] (hlam : 0 < lam)
+lemma garding_energyIntegrand_self_of_bounds (hlam : 0 < lam)
     {A : Matrix n n ℝ} {b₀ : EuclideanSpace ℝ n} {c₀ : ℝ}
     (hQ : ∀ ξ : EuclideanSpace ℝ n, lam * ‖ξ‖ ^ 2 ≤ A.toQuadraticForm' ξ)
     (hb : ‖b₀‖ ≤ beta) (hc : 0 ≤ c₀)
@@ -297,7 +299,7 @@ lemma garding_energyIntegrand_self_of_bounds [DecidableEq n] (hlam : 0 < lam)
 
 /-- Pointwise Gårding inequality on a domain, obtained by applying
 `garding_energyIntegrand_self_of_bounds` at `x`. -/
-lemma garding_energyIntegrand_self_of_bounds_on [DecidableEq n] (hlam : 0 < lam)
+lemma garding_energyIntegrand_self_of_bounds_on (hlam : 0 < lam)
     (hQ : ∀ ⦃x⦄, x ∈ Ω → ∀ ξ : EuclideanSpace ℝ n,
       lam * ‖ξ‖ ^ 2 ≤ (a x).toQuadraticForm' ξ)
     (hb : ∀ ⦃x⦄, x ∈ Ω → ‖b x‖ ≤ beta)

--- a/TauCeti/Analysis/PDE/IntegratedEnergyForm.lean
+++ b/TauCeti/Analysis/PDE/IntegratedEnergyForm.lean
@@ -47,6 +47,7 @@ open scoped InnerProductSpace
 
 variable {X n : Type*} [MeasurableSpace X] [Fintype n]
 
+/-- Local classical decidable equality for finite coordinate indices in integrated energy proofs. -/
 noncomputable local instance integratedEnergyFormDecidableEq : DecidableEq n := Classical.decEq n
 
 /-- The scalar energy form obtained by integrating the divergence-form pointwise jet

--- a/TauCeti/Analysis/PDE/IntegratedEnergyForm.lean
+++ b/TauCeti/Analysis/PDE/IntegratedEnergyForm.lean
@@ -329,6 +329,8 @@ lemma energyFormIntegral_eq_one_zero_baseMass_add_perturbation
     funext x
     exact energyIntegrand_eq_one_zero_baseMass_add_perturbation_apply
       (a x) (b x) (c x) (m x) (U x) (V x)
+  -- After unfolding all three forms, expose the left integrand as a function application so
+  -- the pointwise function equality `hpoint` rewrites the integral before `integral_add`.
   change ∫ x, (fun x => energyIntegrand (a x) (b x) (c x) (U x) (V x)) x ∂μ =
       energyFormIntegral μ (fun _ => (1 : Matrix n n ℝ)) (fun _ => 0) m U V +
         energyFormIntegral μ (fun x => a x - 1) b (fun x => c x - m x) U V

--- a/TauCeti/Analysis/PDE/IntegratedEnergyForm.lean
+++ b/TauCeti/Analysis/PDE/IntegratedEnergyForm.lean
@@ -47,6 +47,8 @@ open scoped InnerProductSpace
 
 variable {X n : Type*} [MeasurableSpace X] [Fintype n]
 
+noncomputable local instance integratedEnergyFormDecidableEq : DecidableEq n := Classical.decEq n
+
 /-- The scalar energy form obtained by integrating the divergence-form pointwise jet
 integrand against a measure.
 
@@ -310,7 +312,7 @@ lemma energyFormIntegral_principal_drift_mass
 
 /-- The integrated full energy form is a shifted-Laplacian model plus the residual
 coefficient perturbation. -/
-lemma energyFormIntegral_eq_one_zero_baseMass_add_perturbation [DecidableEq n]
+lemma energyFormIntegral_eq_one_zero_baseMass_add_perturbation
     (hmodel : Integrable
       (fun x => energyIntegrand (1 : Matrix n n ℝ) 0 (m x) (U x) (V x)) μ)
     (hpert : Integrable
@@ -326,12 +328,15 @@ lemma energyFormIntegral_eq_one_zero_baseMass_add_perturbation [DecidableEq n]
     funext x
     exact energyIntegrand_eq_one_zero_baseMass_add_perturbation_apply
       (a x) (b x) (c x) (m x) (U x) (V x)
+  change ∫ x, (fun x => energyIntegrand (a x) (b x) (c x) (U x) (V x)) x ∂μ =
+      energyFormIntegral μ (fun _ => (1 : Matrix n n ℝ)) (fun _ => 0) m U V +
+        energyFormIntegral μ (fun x => a x - 1) b (fun x => c x - m x) U V
   rw [hpoint]
   exact integral_add hmodel hpert
 
 /-- The integrated full energy form is the shifted-Laplacian form with the same mass plus the
 principal-and-drift perturbation. -/
-lemma energyFormIntegral_eq_one_zero_mass_add_perturbation [DecidableEq n]
+lemma energyFormIntegral_eq_one_zero_mass_add_perturbation
     (hmodel : Integrable
       (fun x => energyIntegrand (1 : Matrix n n ℝ) 0 (c x) (U x) (V x)) μ)
     (hpert : Integrable
@@ -345,33 +350,33 @@ lemma energyFormIntegral_eq_one_zero_mass_add_perturbation [DecidableEq n]
 
 /-- The integrated `−Δ` model form is the integral of the dot product of the two gradient
 components of the jet fields. -/
-lemma energyFormIntegral_one_zero_zero [DecidableEq n] :
+lemma energyFormIntegral_one_zero_zero :
     energyFormIntegral μ (fun _ => (1 : Matrix n n ℝ)) (fun _ => 0) (fun _ => 0) U V =
       ∫ x, ((V x).2 ⬝ᵥ (U x).2) ∂μ := by
   rw [energyFormIntegral_def]
   apply MeasureTheory.integral_congr_ae
   exact Filter.Eventually.of_forall fun x =>
-    energyIntegrand_one_zero_zero_apply (U x) (V x)
+    by simp
 
 /-- The integrated shifted Laplacian model form `−Δ + c` is the sum of the Dirichlet density
 and the mass density. -/
-lemma energyFormIntegral_one_zero_mass [DecidableEq n] (m : X → ℝ) :
+lemma energyFormIntegral_one_zero_mass (m : X → ℝ) :
     energyFormIntegral μ (fun _ => (1 : Matrix n n ℝ)) (fun _ => 0) m U V =
       ∫ x, ((V x).2 ⬝ᵥ (U x).2 + m x * (U x).1 * (V x).1) ∂μ := by
   rw [energyFormIntegral_def]
   apply MeasureTheory.integral_congr_ae
   exact Filter.Eventually.of_forall fun x =>
-    energyIntegrand_one_zero_mass_apply (m x) (U x) (V x)
+    by simp
 
 /-- The diagonal of the integrated shifted Laplacian model is the integral of
 `‖∇u‖² + c u²` at the jet level. -/
-lemma energyFormIntegral_one_zero_mass_self [DecidableEq n] (m : X → ℝ) :
+lemma energyFormIntegral_one_zero_mass_self (m : X → ℝ) :
     energyFormIntegral μ (fun _ => (1 : Matrix n n ℝ)) (fun _ => 0) m U U =
       ∫ x, (‖(U x).2‖ ^ 2 + m x * (U x).1 ^ 2) ∂μ := by
   rw [energyFormIntegral_def]
   apply MeasureTheory.integral_congr_ae
   exact Filter.Eventually.of_forall fun x =>
-    energyIntegrand_one_zero_mass_self (m x) (U x)
+    by simpa using energyIntegrand_one_zero_mass_self (m x) (U x)
 
 variable {Lam beta gamma : ℝ}
 
@@ -407,7 +412,6 @@ lemma garding_energyFormIntegral_self_of_bounds (hlam : 0 < lam)
   rw [energyFormIntegral_def]
   refine integral_mono_ae hlower henergy ?_
   filter_upwards [ha, hb, hc] with x hax hbx hcx
-  letI := Classical.decEq n
   exact garding_energyIntegrand_self_of_bounds hlam
     (fun ξ => by simpa [toQuadraticForm'_eq_dotProduct] using hax ξ) hbx hcx (U x)
 
@@ -427,7 +431,6 @@ lemma garding_energyFormIntegral_self_of_mass_lower_bound_of_bounds (hlam : 0 < 
   rw [energyFormIntegral_def]
   refine integral_mono_ae hlower henergy ?_
   filter_upwards [ha, hb, hc] with x hax hbx hcx
-  letI := Classical.decEq n
   exact garding_energyIntegrand_self_of_mass_lower_bound_of_bounds hlam
     (fun ξ => by simpa [toQuadraticForm'_eq_dotProduct] using hax ξ) hbx hcx (U x)
 
@@ -447,13 +450,11 @@ lemma integral_min_coercivityConstant_mul_norm_sq_le_energyFormIntegral_self_of_
   rw [energyFormIntegral_def]
   refine integral_mono_ae hlower henergy ?_
   filter_upwards [ha, hb, hc] with x hax hbx hcx
-  letI := Classical.decEq n
   exact min_coercivityConstant_mul_norm_sq_le_energyIntegrand_self hlam
     (fun ξ => by simpa [toQuadraticForm'_eq_dotProduct] using hax ξ) hbx hcx hmu (U x)
 
 namespace UniformlyEllipticOn
 
-variable [DecidableEq n]
 variable {Ω : Set X} {lam Lam beta gamma mu : ℝ}
 variable {a : X → Matrix n n ℝ} {b : X → EuclideanSpace ℝ n} {c : X → ℝ}
 variable {U V : X → ℝ × EuclideanSpace ℝ n}

--- a/TauCeti/Analysis/PDE/IntegratedSymmetricEnergy.lean
+++ b/TauCeti/Analysis/PDE/IntegratedSymmetricEnergy.lean
@@ -24,15 +24,15 @@ integrand.
 
 * `TauCeti.PDE.energyFormIntegral_zero_drift_comm_of_isSymm_ae`: a.e. symmetric principal
   coefficients make the zero-drift integrated form symmetric.
-* `TauCeti.PDE.energyFormIntegral_coefficientSymmetricPart_zero_drift_comm`: replacing the
-  principal coefficient by its symmetric part gives a symmetric zero-drift integrated form.
+* `TauCeti.PDE.energyFormIntegral_zero_drift_flip_eq_of_isSymm_ae`: bundled symmetry of the
+  zero-drift integrated form under a.e. symmetric principal coefficients.
 * `TauCeti.PDE.energyFormIntegral_coefficientSymmetricPart_self`: the diagonal integrated
   energy is unchanged by replacing the principal coefficient by its symmetric part.
 * `TauCeti.PDE.energyFormIntegral_coefficientSymmetricPart_zero_drift_apply`: the
   symmetric-part zero-drift form is the average of the original form and its transpose, under the
   natural integrability hypotheses.
-* `TauCeti.PDE.energyFormIntegral_one_zero_mass_comm`: the shifted-Laplacian model form is
-  symmetric.
+* `TauCeti.PDE.energyFormIntegral_one_zero_mass_flip_eq`: bundled symmetry of the
+  shifted-Laplacian model form.
 -/
 
 public section
@@ -59,28 +59,40 @@ lemma energyFormIntegral_zero_drift_comm_of_isSymm_ae
   filter_upwards [ha] with x hx
   exact energyIntegrand_zero_drift_comm_of_isSymm hx (c x) (U x) (V x)
 
-/-- Pointwise symmetric principal coefficients on a domain make the zero-drift integrated
-energy form symmetric when the measure is a.e. supported on that domain. -/
-lemma energyFormIntegral_zero_drift_comm_on {Ω : Set X}
+/-- Bundled-map form of symmetry for a zero-drift integrated energy form with a.e. symmetric
+principal coefficients. -/
+@[simp]
+lemma energyFormIntegral_zero_drift_flip_eq_of_isSymm_ae
+    (ha : ∀ᵐ x ∂μ, (a x).IsSymm) :
+    Function.swap (energyFormIntegral μ a (fun _ => 0) c) =
+      energyFormIntegral μ a (fun _ => 0) c := by
+  funext U V
+  exact energyFormIntegral_zero_drift_comm_of_isSymm_ae (a := a) (c := c) (U := V) (V := U) ha
+
+/-- Bundled-map symmetry on a domain when the measure is a.e. supported there and the
+principal coefficients are pointwise symmetric on that domain. -/
+lemma energyFormIntegral_zero_drift_flip_eq_on {Ω : Set X}
     (hΩ : ∀ᵐ x ∂μ, x ∈ Ω) (ha : ∀ ⦃x⦄, x ∈ Ω → (a x).IsSymm) :
-    energyFormIntegral μ a (fun _ => 0) c U V =
-      energyFormIntegral μ a (fun _ => 0) c V U :=
-  energyFormIntegral_zero_drift_comm_of_isSymm_ae
+    Function.swap (energyFormIntegral μ a (fun _ => 0) c) =
+      energyFormIntegral μ a (fun _ => 0) c :=
+  energyFormIntegral_zero_drift_flip_eq_of_isSymm_ae
     (hΩ.mono fun _ hx => ha hx)
 
-/-- The symmetric part of any principal coefficient field gives a symmetric zero-drift
-integrated energy form. -/
-lemma energyFormIntegral_coefficientSymmetricPart_zero_drift_comm :
-    energyFormIntegral μ (fun x => coefficientSymmetricPart (a x)) (fun _ => 0) c U V =
-      energyFormIntegral μ (fun x => coefficientSymmetricPart (a x)) (fun _ => 0) c V U :=
-  energyFormIntegral_zero_drift_comm_of_isSymm_ae
+/-- Bundled-map symmetry for the symmetric-part zero-drift integrated energy form. -/
+@[simp]
+lemma energyFormIntegral_coefficientSymmetricPart_zero_drift_flip_eq :
+    Function.swap
+        (energyFormIntegral μ (fun x => coefficientSymmetricPart (a x)) (fun _ => 0) c) =
+      energyFormIntegral μ (fun x => coefficientSymmetricPart (a x)) (fun _ => 0) c :=
+  energyFormIntegral_zero_drift_flip_eq_of_isSymm_ae
     (Filter.Eventually.of_forall fun _ => coefficientSymmetricPart_isSymm _)
 
-/-- The shifted-Laplacian model integrated form `-Δ + c` is symmetric. -/
-lemma energyFormIntegral_one_zero_mass_comm [DecidableEq n] :
-    energyFormIntegral μ (fun _ => (1 : Matrix n n ℝ)) (fun _ => 0) c U V =
-      energyFormIntegral μ (fun _ => (1 : Matrix n n ℝ)) (fun _ => 0) c V U :=
-  energyFormIntegral_zero_drift_comm_of_isSymm_ae
+/-- Bundled symmetry of the shifted-Laplacian model integrated form `-Δ + c`. -/
+@[simp]
+lemma energyFormIntegral_one_zero_mass_flip_eq [DecidableEq n] :
+    Function.swap (energyFormIntegral μ (fun _ => (1 : Matrix n n ℝ)) (fun _ => 0) c) =
+      energyFormIntegral μ (fun _ => (1 : Matrix n n ℝ)) (fun _ => 0) c :=
+  energyFormIntegral_zero_drift_flip_eq_of_isSymm_ae
     (Filter.Eventually.of_forall fun _ => isSymm_one)
 
 /-- Replacing the principal coefficient by its symmetric part does not change the diagonal
@@ -94,13 +106,6 @@ lemma energyFormIntegral_coefficientSymmetricPart_self {b : X → EuclideanSpace
   refine integral_congr_ae ?_
   exact Filter.Eventually.of_forall fun x =>
     energyIntegrand_coefficientSymmetricPart_self (a x) (b x) (c x) (U x)
-
-/-- Replacing a coefficient field by its symmetric part does not change the diagonal
-zero-drift integrated energy. -/
-lemma energyFormIntegral_coefficientSymmetricPart_zero_drift_self :
-    energyFormIntegral μ (fun x => coefficientSymmetricPart (a x)) (fun _ => 0) c U U =
-      energyFormIntegral μ a (fun _ => 0) c U U :=
-  energyFormIntegral_coefficientSymmetricPart_self
 
 /-- The symmetric-part zero-drift integrated form is the average of the original zero-drift
 form and its transpose, assuming the two original scalar densities are integrable. -/
@@ -129,22 +134,7 @@ lemma energyFormIntegral_coefficientSymmetricPart_eq_of_isSymm_ae {b : X → Euc
   rw [energyFormIntegral_def, energyFormIntegral_def]
   refine integral_congr_ae ?_
   filter_upwards [ha] with x hx
-  have hcoeff : coefficientSymmetricPart (a x) = a x := by
-    ext i j
-    have hji : a x j i = a x i j := by
-      simpa [Matrix.transpose_apply] using congrFun (congrFun hx.eq i) j
-    rw [coefficientSymmetricPart_apply, hji]
-    ring
-  simp [hcoeff]
-
-/-- Domain-supported version of
-`energyFormIntegral_coefficientSymmetricPart_eq_of_isSymm_ae`. -/
-lemma energyFormIntegral_coefficientSymmetricPart_eq_on {b : X → EuclideanSpace ℝ n} {Ω : Set X}
-    (hΩ : ∀ᵐ x ∂μ, x ∈ Ω) (ha : ∀ ⦃x⦄, x ∈ Ω → (a x).IsSymm) :
-    energyFormIntegral μ (fun x => coefficientSymmetricPart (a x)) b c U V =
-      energyFormIntegral μ a b c U V :=
-  energyFormIntegral_coefficientSymmetricPart_eq_of_isSymm_ae
-    (hΩ.mono fun _ hx => ha hx)
+  simp [coefficientSymmetricPart_eq_self_of_isSymm hx]
 
 end PDE
 

--- a/TauCeti/Analysis/PDE/IntegratedSymmetricEnergy.lean
+++ b/TauCeti/Analysis/PDE/IntegratedSymmetricEnergy.lean
@@ -22,6 +22,8 @@ integrand.
 
 ## Main declarations
 
+* `TauCeti.PDE.energyFormIntegral_zero_drift_transpose_apply`: transposing the principal
+  coefficient swaps the two jet fields under the integral.
 * `TauCeti.PDE.energyFormIntegral_zero_drift_comm_of_isSymm_ae`: a.e. symmetric principal
   coefficients make the zero-drift integrated form symmetric.
 * `TauCeti.PDE.energyFormIntegral_zero_drift_swap_eq_of_isSymm_ae`: bundled symmetry of the
@@ -44,9 +46,24 @@ namespace PDE
 open MeasureTheory Matrix
 
 variable {X n : Type*} [MeasurableSpace X] [Fintype n]
+
+noncomputable local instance integratedSymmetricEnergyDecidableEq : DecidableEq n :=
+  Classical.decEq n
+
 variable {μ : Measure X}
 variable {a : X → Matrix n n ℝ} {c : X → ℝ}
 variable {U V : X → ℝ × EuclideanSpace ℝ n}
+
+/-- With zero drift, transposing the principal coefficient swaps the two jet fields under the
+integral. -/
+lemma energyFormIntegral_zero_drift_transpose_apply :
+    energyFormIntegral μ (fun x => (a x)ᵀ) (fun _ => 0) c U V =
+      energyFormIntegral μ a (fun _ => 0) c V U := by
+  classical
+  rw [energyFormIntegral_def, energyFormIntegral_def]
+  refine integral_congr_ae ?_
+  exact Filter.Eventually.of_forall fun x =>
+    energyIntegrand_zero_drift_transpose_apply (a x) (c x) (U x) (V x)
 
 /-- A.e. symmetric principal coefficients make the zero-drift integrated energy form
 symmetric. -/
@@ -54,10 +71,20 @@ lemma energyFormIntegral_zero_drift_comm_of_isSymm_ae
     (ha : ∀ᵐ x ∂μ, (a x).IsSymm) :
     energyFormIntegral μ a (fun _ => 0) c U V =
       energyFormIntegral μ a (fun _ => 0) c V U := by
-  rw [energyFormIntegral_def, energyFormIntegral_def]
-  refine integral_congr_ae ?_
-  filter_upwards [ha] with x hx
-  exact energyIntegrand_zero_drift_comm_of_isSymm hx (c x) (U x) (V x)
+  calc
+    energyFormIntegral μ a (fun _ => 0) c U V =
+        energyFormIntegral μ (fun x => (a x)ᵀ) (fun _ => 0) c U V := by
+      refine energyFormIntegral_congr_ae (μ := μ) (a := a) (b := fun _ => 0) (c := c)
+        (U := U) (V := V) (a' := fun x => (a x)ᵀ) (b' := fun _ => 0) (c' := c)
+        (U' := U) (V' := V) ?_ ?_ ?_ ?_ ?_
+      · filter_upwards [ha] with x hx
+        exact hx.eq.symm
+      · rfl
+      · rfl
+      · rfl
+      · rfl
+    _ = energyFormIntegral μ a (fun _ => 0) c V U :=
+      energyFormIntegral_zero_drift_transpose_apply
 
 /-- Bundled-map form of symmetry for a zero-drift integrated energy form with a.e. symmetric
 principal coefficients. -/
@@ -69,14 +96,24 @@ lemma energyFormIntegral_zero_drift_swap_eq_of_isSymm_ae
   funext U V
   exact energyFormIntegral_zero_drift_comm_of_isSymm_ae (a := a) (c := c) (U := V) (V := U) ha
 
+/-- Symmetry on a domain when the measure is a.e. supported there and the principal
+coefficients are pointwise symmetric on that domain. -/
+lemma energyFormIntegral_zero_drift_comm_on {Ω : Set X}
+    (hΩ : ∀ᵐ x ∂μ, x ∈ Ω) (ha : ∀ ⦃x⦄, x ∈ Ω → (a x).IsSymm) :
+    energyFormIntegral μ a (fun _ => 0) c U V =
+      energyFormIntegral μ a (fun _ => 0) c V U :=
+  energyFormIntegral_zero_drift_comm_of_isSymm_ae
+    (hΩ.mono fun _ hx => ha hx)
+
 /-- Bundled-map symmetry on a domain when the measure is a.e. supported there and the
 principal coefficients are pointwise symmetric on that domain. -/
 lemma energyFormIntegral_zero_drift_swap_eq_on {Ω : Set X}
     (hΩ : ∀ᵐ x ∂μ, x ∈ Ω) (ha : ∀ ⦃x⦄, x ∈ Ω → (a x).IsSymm) :
     Function.swap (energyFormIntegral μ a (fun _ => 0) c) =
-      energyFormIntegral μ a (fun _ => 0) c :=
-  energyFormIntegral_zero_drift_swap_eq_of_isSymm_ae
-    (hΩ.mono fun _ hx => ha hx)
+      energyFormIntegral μ a (fun _ => 0) c := by
+  funext U V
+  exact energyFormIntegral_zero_drift_comm_on
+    (a := a) (c := c) (U := V) (V := U) hΩ ha
 
 /-- The symmetric-part zero-drift integrated energy form is symmetric. -/
 lemma energyFormIntegral_coefficientSymmetricPart_zero_drift_comm :
@@ -95,14 +132,14 @@ lemma energyFormIntegral_coefficientSymmetricPart_zero_drift_swap_eq :
     (Filter.Eventually.of_forall fun _ => coefficientSymmetricPart_isSymm _)
 
 /-- The shifted-Laplacian model integrated form `-Δ + c` is symmetric. -/
-lemma energyFormIntegral_one_zero_mass_comm [DecidableEq n] :
+lemma energyFormIntegral_one_zero_mass_comm :
     energyFormIntegral μ (fun _ => (1 : Matrix n n ℝ)) (fun _ => 0) c U V =
       energyFormIntegral μ (fun _ => (1 : Matrix n n ℝ)) (fun _ => 0) c V U :=
   energyFormIntegral_zero_drift_comm_of_isSymm_ae
     (Filter.Eventually.of_forall fun _ => isSymm_one)
 
 /-- Bundled symmetry of the shifted-Laplacian model integrated form `-Δ + c`. -/
-lemma energyFormIntegral_one_zero_mass_swap_eq [DecidableEq n] :
+lemma energyFormIntegral_one_zero_mass_swap_eq :
     Function.swap (energyFormIntegral μ (fun _ => (1 : Matrix n n ℝ)) (fun _ => 0) c) =
       energyFormIntegral μ (fun _ => (1 : Matrix n n ℝ)) (fun _ => 0) c :=
   energyFormIntegral_zero_drift_swap_eq_of_isSymm_ae
@@ -115,6 +152,7 @@ principal quadratic form is unchanged pointwise. -/
 lemma energyFormIntegral_coefficientSymmetricPart_self {b : X → EuclideanSpace ℝ n} :
     energyFormIntegral μ (fun x => coefficientSymmetricPart (a x)) b c U U =
       energyFormIntegral μ a b c U U := by
+  classical
   rw [energyFormIntegral_def, energyFormIntegral_def]
   refine integral_congr_ae ?_
   exact Filter.Eventually.of_forall fun x =>
@@ -128,6 +166,7 @@ lemma energyFormIntegral_coefficientSymmetricPart_zero_drift_apply
     energyFormIntegral μ (fun x => coefficientSymmetricPart (a x)) (fun _ => 0) c U V =
       (energyFormIntegral μ a (fun _ => 0) c U V +
         energyFormIntegral μ a (fun _ => 0) c V U) / 2 := by
+  classical
   rw [energyFormIntegral_def, energyFormIntegral_def, energyFormIntegral_def]
   have hpoint :
       (fun x => energyIntegrand (coefficientSymmetricPart (a x)) 0 (c x) (U x) (V x)) =
@@ -144,6 +183,7 @@ lemma energyFormIntegral_coefficientSymmetricPart_eq_of_isSymm_ae {b : X → Euc
     (ha : ∀ᵐ x ∂μ, (a x).IsSymm) :
     energyFormIntegral μ (fun x => coefficientSymmetricPart (a x)) b c U V =
       energyFormIntegral μ a b c U V := by
+  classical
   rw [energyFormIntegral_def, energyFormIntegral_def]
   refine integral_congr_ae ?_
   filter_upwards [ha] with x hx

--- a/TauCeti/Analysis/PDE/IntegratedSymmetricEnergy.lean
+++ b/TauCeti/Analysis/PDE/IntegratedSymmetricEnergy.lean
@@ -88,7 +88,6 @@ lemma energyFormIntegral_coefficientSymmetricPart_zero_drift_flip_eq :
     (Filter.Eventually.of_forall fun _ => coefficientSymmetricPart_isSymm _)
 
 /-- Bundled symmetry of the shifted-Laplacian model integrated form `-Δ + c`. -/
-@[simp]
 lemma energyFormIntegral_one_zero_mass_flip_eq [DecidableEq n] :
     Function.swap (energyFormIntegral μ (fun _ => (1 : Matrix n n ℝ)) (fun _ => 0) c) =
       energyFormIntegral μ (fun _ => (1 : Matrix n n ℝ)) (fun _ => 0) c :=

--- a/TauCeti/Analysis/PDE/IntegratedSymmetricEnergy.lean
+++ b/TauCeti/Analysis/PDE/IntegratedSymmetricEnergy.lean
@@ -47,6 +47,8 @@ open MeasureTheory Matrix
 
 variable {X n : Type*} [MeasurableSpace X] [Fintype n]
 
+/-- Local classical decidable equality for finite coordinate indices in integrated symmetry
+proofs. -/
 noncomputable local instance integratedSymmetricEnergyDecidableEq : DecidableEq n :=
   Classical.decEq n
 

--- a/TauCeti/Analysis/PDE/IntegratedSymmetricEnergy.lean
+++ b/TauCeti/Analysis/PDE/IntegratedSymmetricEnergy.lean
@@ -28,9 +28,9 @@ integrand.
   principal coefficient by its symmetric part gives a symmetric zero-drift integrated form.
 * `TauCeti.PDE.energyFormIntegral_coefficientSymmetricPart_self`: the diagonal integrated
   energy is unchanged by replacing the principal coefficient by its symmetric part.
-* `TauCeti.PDE.energyFormIntegral_coefficientSymmetricPart_zero_drift`: the symmetric-part
-  zero-drift form is the average of the original form and its transpose, under the natural
-  integrability hypotheses.
+* `TauCeti.PDE.energyFormIntegral_coefficientSymmetricPart_zero_drift_apply`: the
+  symmetric-part zero-drift form is the average of the original form and its transpose, under the
+  natural integrability hypotheses.
 * `TauCeti.PDE.energyFormIntegral_one_zero_mass_comm`: the shifted-Laplacian model form is
   symmetric.
 -/
@@ -86,6 +86,7 @@ lemma energyFormIntegral_one_zero_mass_comm [DecidableEq n] :
 /-- Replacing the principal coefficient by its symmetric part does not change the diagonal
 integrated energy.  The drift and mass coefficients are arbitrary, since the diagonal
 principal quadratic form is unchanged pointwise. -/
+@[simp]
 lemma energyFormIntegral_coefficientSymmetricPart_self {b : X → EuclideanSpace ℝ n} :
     energyFormIntegral μ (fun x => coefficientSymmetricPart (a x)) b c U U =
       energyFormIntegral μ a b c U U := by
@@ -103,7 +104,7 @@ lemma energyFormIntegral_coefficientSymmetricPart_zero_drift_self :
 
 /-- The symmetric-part zero-drift integrated form is the average of the original zero-drift
 form and its transpose, assuming the two original scalar densities are integrable. -/
-lemma energyFormIntegral_coefficientSymmetricPart_zero_drift
+lemma energyFormIntegral_coefficientSymmetricPart_zero_drift_apply
     (hUV : Integrable (fun x => energyIntegrand (a x) 0 (c x) (U x) (V x)) μ)
     (hVU : Integrable (fun x => energyIntegrand (a x) 0 (c x) (V x) (U x)) μ) :
     energyFormIntegral μ (fun x => coefficientSymmetricPart (a x)) (fun _ => 0) c U V =
@@ -119,12 +120,12 @@ lemma energyFormIntegral_coefficientSymmetricPart_zero_drift
   rw [hpoint]
   rw [integral_div, integral_add hUV hVU]
 
-/-- For symmetric principal coefficients, replacing by the symmetric part leaves the
-zero-drift integrated form unchanged. -/
-lemma energyFormIntegral_coefficientSymmetricPart_zero_drift_eq_of_isSymm_ae
+/-- For symmetric principal coefficients, replacing by the symmetric part leaves the integrated
+form unchanged. -/
+lemma energyFormIntegral_coefficientSymmetricPart_eq_of_isSymm_ae {b : X → EuclideanSpace ℝ n}
     (ha : ∀ᵐ x ∂μ, (a x).IsSymm) :
-    energyFormIntegral μ (fun x => coefficientSymmetricPart (a x)) (fun _ => 0) c U V =
-      energyFormIntegral μ a (fun _ => 0) c U V := by
+    energyFormIntegral μ (fun x => coefficientSymmetricPart (a x)) b c U V =
+      energyFormIntegral μ a b c U V := by
   rw [energyFormIntegral_def, energyFormIntegral_def]
   refine integral_congr_ae ?_
   filter_upwards [ha] with x hx
@@ -137,12 +138,12 @@ lemma energyFormIntegral_coefficientSymmetricPart_zero_drift_eq_of_isSymm_ae
   simp [hcoeff]
 
 /-- Domain-supported version of
-`energyFormIntegral_coefficientSymmetricPart_zero_drift_eq_of_isSymm_ae`. -/
-lemma energyFormIntegral_coefficientSymmetricPart_zero_drift_eq_on {Ω : Set X}
+`energyFormIntegral_coefficientSymmetricPart_eq_of_isSymm_ae`. -/
+lemma energyFormIntegral_coefficientSymmetricPart_eq_on {b : X → EuclideanSpace ℝ n} {Ω : Set X}
     (hΩ : ∀ᵐ x ∂μ, x ∈ Ω) (ha : ∀ ⦃x⦄, x ∈ Ω → (a x).IsSymm) :
-    energyFormIntegral μ (fun x => coefficientSymmetricPart (a x)) (fun _ => 0) c U V =
-      energyFormIntegral μ a (fun _ => 0) c U V :=
-  energyFormIntegral_coefficientSymmetricPart_zero_drift_eq_of_isSymm_ae
+    energyFormIntegral μ (fun x => coefficientSymmetricPart (a x)) b c U V =
+      energyFormIntegral μ a b c U V :=
+  energyFormIntegral_coefficientSymmetricPart_eq_of_isSymm_ae
     (hΩ.mono fun _ hx => ha hx)
 
 end PDE

--- a/TauCeti/Analysis/PDE/IntegratedSymmetricEnergy.lean
+++ b/TauCeti/Analysis/PDE/IntegratedSymmetricEnergy.lean
@@ -1,0 +1,150 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+module
+
+public import TauCeti.Analysis.PDE.IntegratedEnergyForm
+public import TauCeti.Analysis.PDE.SymmetricEnergy
+
+/-!
+# Symmetry of integrated zero-drift energy forms
+
+Lane D of the PDE roadmap needs symmetric bilinear forms for the energy method and the
+Dirichlet spectrum.  `TauCeti.Analysis.PDE.SymmetricEnergy` proves the corresponding
+finite-dimensional facts for the pointwise jet integrand.  This file passes those facts
+through the Bochner integral for raw jet fields.
+
+The statements remain below the weak-derivative Sobolev-space layer: the inputs are coefficient
+fields and raw value-gradient jets `U V : X → ℝ × EuclideanSpace ℝ n`.  Once Lane A supplies
+Sobolev jets, these lemmas give the symmetric part of the weak form without unfolding the
+integrand.
+
+## Main declarations
+
+* `TauCeti.PDE.energyFormIntegral_zero_drift_comm_of_isSymm_ae`: a.e. symmetric principal
+  coefficients make the zero-drift integrated form symmetric.
+* `TauCeti.PDE.energyFormIntegral_coefficientSymmetricPart_zero_drift_comm`: replacing the
+  principal coefficient by its symmetric part gives a symmetric zero-drift integrated form.
+* `TauCeti.PDE.energyFormIntegral_coefficientSymmetricPart_self`: the diagonal integrated
+  energy is unchanged by replacing the principal coefficient by its symmetric part.
+* `TauCeti.PDE.energyFormIntegral_coefficientSymmetricPart_zero_drift`: the symmetric-part
+  zero-drift form is the average of the original form and its transpose, under the natural
+  integrability hypotheses.
+* `TauCeti.PDE.energyFormIntegral_one_zero_mass_comm`: the shifted-Laplacian model form is
+  symmetric.
+-/
+
+public section
+
+namespace TauCeti
+
+namespace PDE
+
+open MeasureTheory Matrix
+
+variable {X n : Type*} [MeasurableSpace X] [Fintype n]
+variable {μ : Measure X}
+variable {a : X → Matrix n n ℝ} {c : X → ℝ}
+variable {U V : X → ℝ × EuclideanSpace ℝ n}
+
+/-- A.e. symmetric principal coefficients make the zero-drift integrated energy form
+symmetric. -/
+lemma energyFormIntegral_zero_drift_comm_of_isSymm_ae
+    (ha : ∀ᵐ x ∂μ, (a x).IsSymm) :
+    energyFormIntegral μ a (fun _ => 0) c U V =
+      energyFormIntegral μ a (fun _ => 0) c V U := by
+  rw [energyFormIntegral_def, energyFormIntegral_def]
+  refine integral_congr_ae ?_
+  filter_upwards [ha] with x hx
+  exact energyIntegrand_zero_drift_comm_of_isSymm hx (c x) (U x) (V x)
+
+/-- Pointwise symmetric principal coefficients on a domain make the zero-drift integrated
+energy form symmetric when the measure is a.e. supported on that domain. -/
+lemma energyFormIntegral_zero_drift_comm_on {Ω : Set X}
+    (hΩ : ∀ᵐ x ∂μ, x ∈ Ω) (ha : ∀ ⦃x⦄, x ∈ Ω → (a x).IsSymm) :
+    energyFormIntegral μ a (fun _ => 0) c U V =
+      energyFormIntegral μ a (fun _ => 0) c V U :=
+  energyFormIntegral_zero_drift_comm_of_isSymm_ae
+    (hΩ.mono fun _ hx => ha hx)
+
+/-- The symmetric part of any principal coefficient field gives a symmetric zero-drift
+integrated energy form. -/
+lemma energyFormIntegral_coefficientSymmetricPart_zero_drift_comm :
+    energyFormIntegral μ (fun x => coefficientSymmetricPart (a x)) (fun _ => 0) c U V =
+      energyFormIntegral μ (fun x => coefficientSymmetricPart (a x)) (fun _ => 0) c V U :=
+  energyFormIntegral_zero_drift_comm_of_isSymm_ae
+    (Filter.Eventually.of_forall fun _ => coefficientSymmetricPart_isSymm _)
+
+/-- The shifted-Laplacian model integrated form `-Δ + c` is symmetric. -/
+lemma energyFormIntegral_one_zero_mass_comm [DecidableEq n] :
+    energyFormIntegral μ (fun _ => (1 : Matrix n n ℝ)) (fun _ => 0) c U V =
+      energyFormIntegral μ (fun _ => (1 : Matrix n n ℝ)) (fun _ => 0) c V U :=
+  energyFormIntegral_zero_drift_comm_of_isSymm_ae
+    (Filter.Eventually.of_forall fun _ => isSymm_one)
+
+/-- Replacing the principal coefficient by its symmetric part does not change the diagonal
+integrated energy.  The drift and mass coefficients are arbitrary, since the diagonal
+principal quadratic form is unchanged pointwise. -/
+lemma energyFormIntegral_coefficientSymmetricPart_self {b : X → EuclideanSpace ℝ n} :
+    energyFormIntegral μ (fun x => coefficientSymmetricPart (a x)) b c U U =
+      energyFormIntegral μ a b c U U := by
+  rw [energyFormIntegral_def, energyFormIntegral_def]
+  refine integral_congr_ae ?_
+  exact Filter.Eventually.of_forall fun x =>
+    energyIntegrand_coefficientSymmetricPart_self (a x) (b x) (c x) (U x)
+
+/-- Replacing a coefficient field by its symmetric part does not change the diagonal
+zero-drift integrated energy. -/
+lemma energyFormIntegral_coefficientSymmetricPart_zero_drift_self :
+    energyFormIntegral μ (fun x => coefficientSymmetricPart (a x)) (fun _ => 0) c U U =
+      energyFormIntegral μ a (fun _ => 0) c U U :=
+  energyFormIntegral_coefficientSymmetricPart_self
+
+/-- The symmetric-part zero-drift integrated form is the average of the original zero-drift
+form and its transpose, assuming the two original scalar densities are integrable. -/
+lemma energyFormIntegral_coefficientSymmetricPart_zero_drift
+    (hUV : Integrable (fun x => energyIntegrand (a x) 0 (c x) (U x) (V x)) μ)
+    (hVU : Integrable (fun x => energyIntegrand (a x) 0 (c x) (V x) (U x)) μ) :
+    energyFormIntegral μ (fun x => coefficientSymmetricPart (a x)) (fun _ => 0) c U V =
+      (energyFormIntegral μ a (fun _ => 0) c U V +
+        energyFormIntegral μ a (fun _ => 0) c V U) / 2 := by
+  rw [energyFormIntegral_def, energyFormIntegral_def, energyFormIntegral_def]
+  have hpoint :
+      (fun x => energyIntegrand (coefficientSymmetricPart (a x)) 0 (c x) (U x) (V x)) =
+        fun x => (energyIntegrand (a x) 0 (c x) (U x) (V x) +
+          energyIntegrand (a x) 0 (c x) (V x) (U x)) / 2 := by
+    funext x
+    exact energyIntegrand_coefficientSymmetricPart_zero_drift_apply (a x) (c x) (U x) (V x)
+  rw [hpoint]
+  rw [integral_div, integral_add hUV hVU]
+
+/-- For symmetric principal coefficients, replacing by the symmetric part leaves the
+zero-drift integrated form unchanged. -/
+lemma energyFormIntegral_coefficientSymmetricPart_zero_drift_eq_of_isSymm_ae
+    (ha : ∀ᵐ x ∂μ, (a x).IsSymm) :
+    energyFormIntegral μ (fun x => coefficientSymmetricPart (a x)) (fun _ => 0) c U V =
+      energyFormIntegral μ a (fun _ => 0) c U V := by
+  rw [energyFormIntegral_def, energyFormIntegral_def]
+  refine integral_congr_ae ?_
+  filter_upwards [ha] with x hx
+  have hcoeff : coefficientSymmetricPart (a x) = a x := by
+    ext i j
+    have hji : a x j i = a x i j := by
+      simpa [Matrix.transpose_apply] using congrFun (congrFun hx.eq i) j
+    rw [coefficientSymmetricPart_apply, hji]
+    ring
+  simp [hcoeff]
+
+/-- Domain-supported version of
+`energyFormIntegral_coefficientSymmetricPart_zero_drift_eq_of_isSymm_ae`. -/
+lemma energyFormIntegral_coefficientSymmetricPart_zero_drift_eq_on {Ω : Set X}
+    (hΩ : ∀ᵐ x ∂μ, x ∈ Ω) (ha : ∀ ⦃x⦄, x ∈ Ω → (a x).IsSymm) :
+    energyFormIntegral μ (fun x => coefficientSymmetricPart (a x)) (fun _ => 0) c U V =
+      energyFormIntegral μ a (fun _ => 0) c U V :=
+  energyFormIntegral_coefficientSymmetricPart_zero_drift_eq_of_isSymm_ae
+    (hΩ.mono fun _ hx => ha hx)
+
+end PDE
+
+end TauCeti

--- a/TauCeti/Analysis/PDE/IntegratedSymmetricEnergy.lean
+++ b/TauCeti/Analysis/PDE/IntegratedSymmetricEnergy.lean
@@ -24,14 +24,14 @@ integrand.
 
 * `TauCeti.PDE.energyFormIntegral_zero_drift_comm_of_isSymm_ae`: a.e. symmetric principal
   coefficients make the zero-drift integrated form symmetric.
-* `TauCeti.PDE.energyFormIntegral_zero_drift_flip_eq_of_isSymm_ae`: bundled symmetry of the
+* `TauCeti.PDE.energyFormIntegral_zero_drift_swap_eq_of_isSymm_ae`: bundled symmetry of the
   zero-drift integrated form under a.e. symmetric principal coefficients.
 * `TauCeti.PDE.energyFormIntegral_coefficientSymmetricPart_self`: the diagonal integrated
   energy is unchanged by replacing the principal coefficient by its symmetric part.
 * `TauCeti.PDE.energyFormIntegral_coefficientSymmetricPart_zero_drift_apply`: the
   symmetric-part zero-drift form is the average of the original form and its transpose, under the
   natural integrability hypotheses.
-* `TauCeti.PDE.energyFormIntegral_one_zero_mass_flip_eq`: bundled symmetry of the
+* `TauCeti.PDE.energyFormIntegral_one_zero_mass_swap_eq`: bundled symmetry of the
   shifted-Laplacian model form.
 -/
 
@@ -62,7 +62,7 @@ lemma energyFormIntegral_zero_drift_comm_of_isSymm_ae
 /-- Bundled-map form of symmetry for a zero-drift integrated energy form with a.e. symmetric
 principal coefficients. -/
 @[simp]
-lemma energyFormIntegral_zero_drift_flip_eq_of_isSymm_ae
+lemma energyFormIntegral_zero_drift_swap_eq_of_isSymm_ae
     (ha : ∀ᵐ x ∂μ, (a x).IsSymm) :
     Function.swap (energyFormIntegral μ a (fun _ => 0) c) =
       energyFormIntegral μ a (fun _ => 0) c := by
@@ -71,27 +71,41 @@ lemma energyFormIntegral_zero_drift_flip_eq_of_isSymm_ae
 
 /-- Bundled-map symmetry on a domain when the measure is a.e. supported there and the
 principal coefficients are pointwise symmetric on that domain. -/
-lemma energyFormIntegral_zero_drift_flip_eq_on {Ω : Set X}
+lemma energyFormIntegral_zero_drift_swap_eq_on {Ω : Set X}
     (hΩ : ∀ᵐ x ∂μ, x ∈ Ω) (ha : ∀ ⦃x⦄, x ∈ Ω → (a x).IsSymm) :
     Function.swap (energyFormIntegral μ a (fun _ => 0) c) =
       energyFormIntegral μ a (fun _ => 0) c :=
-  energyFormIntegral_zero_drift_flip_eq_of_isSymm_ae
+  energyFormIntegral_zero_drift_swap_eq_of_isSymm_ae
     (hΩ.mono fun _ hx => ha hx)
+
+/-- The symmetric-part zero-drift integrated energy form is symmetric. -/
+lemma energyFormIntegral_coefficientSymmetricPart_zero_drift_comm :
+    energyFormIntegral μ (fun x => coefficientSymmetricPart (a x)) (fun _ => 0) c U V =
+      energyFormIntegral μ (fun x => coefficientSymmetricPart (a x)) (fun _ => 0) c V U :=
+  energyFormIntegral_zero_drift_comm_of_isSymm_ae
+    (Filter.Eventually.of_forall fun _ => coefficientSymmetricPart_isSymm _)
 
 /-- Bundled-map symmetry for the symmetric-part zero-drift integrated energy form. -/
 @[simp]
-lemma energyFormIntegral_coefficientSymmetricPart_zero_drift_flip_eq :
+lemma energyFormIntegral_coefficientSymmetricPart_zero_drift_swap_eq :
     Function.swap
         (energyFormIntegral μ (fun x => coefficientSymmetricPart (a x)) (fun _ => 0) c) =
       energyFormIntegral μ (fun x => coefficientSymmetricPart (a x)) (fun _ => 0) c :=
-  energyFormIntegral_zero_drift_flip_eq_of_isSymm_ae
+  energyFormIntegral_zero_drift_swap_eq_of_isSymm_ae
     (Filter.Eventually.of_forall fun _ => coefficientSymmetricPart_isSymm _)
 
+/-- The shifted-Laplacian model integrated form `-Δ + c` is symmetric. -/
+lemma energyFormIntegral_one_zero_mass_comm [DecidableEq n] :
+    energyFormIntegral μ (fun _ => (1 : Matrix n n ℝ)) (fun _ => 0) c U V =
+      energyFormIntegral μ (fun _ => (1 : Matrix n n ℝ)) (fun _ => 0) c V U :=
+  energyFormIntegral_zero_drift_comm_of_isSymm_ae
+    (Filter.Eventually.of_forall fun _ => isSymm_one)
+
 /-- Bundled symmetry of the shifted-Laplacian model integrated form `-Δ + c`. -/
-lemma energyFormIntegral_one_zero_mass_flip_eq [DecidableEq n] :
+lemma energyFormIntegral_one_zero_mass_swap_eq [DecidableEq n] :
     Function.swap (energyFormIntegral μ (fun _ => (1 : Matrix n n ℝ)) (fun _ => 0) c) =
       energyFormIntegral μ (fun _ => (1 : Matrix n n ℝ)) (fun _ => 0) c :=
-  energyFormIntegral_zero_drift_flip_eq_of_isSymm_ae
+  energyFormIntegral_zero_drift_swap_eq_of_isSymm_ae
     (Filter.Eventually.of_forall fun _ => isSymm_one)
 
 /-- Replacing the principal coefficient by its symmetric part does not change the diagonal

--- a/TauCeti/Analysis/PDE/SymmetricEnergy.lean
+++ b/TauCeti/Analysis/PDE/SymmetricEnergy.lean
@@ -53,14 +53,6 @@ open Matrix
 
 variable {X n : Type*} [Fintype n]
 
-omit [Fintype n] in
-/-- A symmetric coefficient matrix is unchanged by taking its symmetric part. -/
-lemma coefficientSymmetricPart_eq_self_of_isSymm {A : Matrix n n ℝ} (hA : A.IsSymm) :
-    coefficientSymmetricPart A = A := by
-  ext i j
-  rw [coefficientSymmetricPart_apply, hA.apply i j]
-  ring
-
 /-- With zero drift, transposing the principal coefficient swaps the two jet arguments. -/
 lemma energyIntegrand_zero_drift_transpose_apply (A : Matrix n n ℝ) (c : ℝ)
     (U V : ℝ × EuclideanSpace ℝ n) :

--- a/TauCeti/Analysis/PDE/SymmetricEnergy.lean
+++ b/TauCeti/Analysis/PDE/SymmetricEnergy.lean
@@ -53,6 +53,8 @@ open Matrix
 
 variable {X n : Type*} [Fintype n]
 
+noncomputable local instance symmetricEnergyDecidableEq : DecidableEq n := Classical.decEq n
+
 /-- With zero drift, transposing the principal coefficient swaps the two jet arguments. -/
 lemma energyIntegrand_zero_drift_transpose_apply (A : Matrix n n ℝ) (c : ℝ)
     (U V : ℝ × EuclideanSpace ℝ n) :
@@ -86,7 +88,7 @@ lemma energyIntegrand_zero_drift_flip_eq_of_isSymm {A : Matrix n n ℝ} (hA : A.
   exact energyIntegrand_zero_drift_comm_of_isSymm hA c V U
 
 /-- The identity principal coefficient gives a symmetric zero-drift jet form. -/
-lemma energyIntegrand_one_zero_drift_comm [DecidableEq n] (c : ℝ)
+lemma energyIntegrand_one_zero_drift_comm (c : ℝ)
     (U V : ℝ × EuclideanSpace ℝ n) :
     energyIntegrand (1 : Matrix n n ℝ) 0 c U V =
       energyIntegrand (1 : Matrix n n ℝ) 0 c V U :=
@@ -143,7 +145,7 @@ lemma energyIntegrand_zero_drift_flip_eq_on {Ω : Set X} {a : X → Matrix n n �
   energyIntegrand_zero_drift_flip_eq_of_isSymm (ha hx) (c x)
 
 /-- Bundled symmetry of the shifted Laplacian jet form. -/
-lemma energyIntegrand_one_zero_mass_flip_eq [DecidableEq n] (c : ℝ) :
+lemma energyIntegrand_one_zero_mass_flip_eq (c : ℝ) :
     (energyIntegrand (1 : Matrix n n ℝ) 0 c).flip =
       energyIntegrand (1 : Matrix n n ℝ) 0 c :=
   energyIntegrand_zero_drift_flip_eq_of_isSymm isSymm_one c

--- a/TauCeti/Analysis/PDE/SymmetricEnergy.lean
+++ b/TauCeti/Analysis/PDE/SymmetricEnergy.lean
@@ -53,6 +53,7 @@ open Matrix
 
 variable {X n : Type*} [Fintype n]
 
+/-- Local classical decidable equality for finite coordinate indices in symmetry proofs. -/
 noncomputable local instance symmetricEnergyDecidableEq : DecidableEq n := Classical.decEq n
 
 /-- With zero drift, transposing the principal coefficient swaps the two jet arguments. -/

--- a/TauCeti/Analysis/PDE/SymmetricEnergy.lean
+++ b/TauCeti/Analysis/PDE/SymmetricEnergy.lean
@@ -51,9 +51,16 @@ namespace PDE
 
 open Matrix
 
-variable {X n : Type*} [Fintype n] [DecidableEq n]
+variable {X n : Type*} [Fintype n]
 
-omit [DecidableEq n] in
+omit [Fintype n] in
+/-- A symmetric coefficient matrix is unchanged by taking its symmetric part. -/
+lemma coefficientSymmetricPart_eq_self_of_isSymm {A : Matrix n n ℝ} (hA : A.IsSymm) :
+    coefficientSymmetricPart A = A := by
+  ext i j
+  rw [coefficientSymmetricPart_apply, hA.apply i j]
+  ring
+
 /-- With zero drift, transposing the principal coefficient swaps the two jet arguments. -/
 lemma energyIntegrand_zero_drift_transpose_apply (A : Matrix n n ℝ) (c : ℝ)
     (U V : ℝ × EuclideanSpace ℝ n) :
@@ -61,7 +68,6 @@ lemma energyIntegrand_zero_drift_transpose_apply (A : Matrix n n ℝ) (c : ℝ)
   rw [energyIntegrand_apply, energyIntegrand_apply, matrixBilinearForm_transpose_apply]
   simp [driftForm_apply, massForm_apply, mul_comm, mul_left_comm]
 
-omit [DecidableEq n] in
 /-- A symmetric principal coefficient gives a symmetric zero-drift jet form. -/
 lemma energyIntegrand_zero_drift_comm_of_isSymm {A : Matrix n n ℝ} (hA : A.IsSymm)
     (c : ℝ) (U V : ℝ × EuclideanSpace ℝ n) :
@@ -70,7 +76,6 @@ lemma energyIntegrand_zero_drift_comm_of_isSymm {A : Matrix n n ℝ} (hA : A.IsS
     energyIntegrand A 0 c U V = energyIntegrand Aᵀ 0 c U V := by rw [hA.eq]
     _ = energyIntegrand A 0 c V U := energyIntegrand_zero_drift_transpose_apply A c U V
 
-omit [DecidableEq n] in
 /-- Bundled-map form of symmetry for the zero-drift jet integrand.
 
 Downstream energy forms that need the same integrand to be both symmetric and coercive pair
@@ -89,12 +94,12 @@ lemma energyIntegrand_zero_drift_flip_eq_of_isSymm {A : Matrix n n ℝ} (hA : A.
   exact energyIntegrand_zero_drift_comm_of_isSymm hA c V U
 
 /-- The identity principal coefficient gives a symmetric zero-drift jet form. -/
-lemma energyIntegrand_one_zero_drift_comm (c : ℝ) (U V : ℝ × EuclideanSpace ℝ n) :
+lemma energyIntegrand_one_zero_drift_comm [DecidableEq n] (c : ℝ)
+    (U V : ℝ × EuclideanSpace ℝ n) :
     energyIntegrand (1 : Matrix n n ℝ) 0 c U V =
       energyIntegrand (1 : Matrix n n ℝ) 0 c V U :=
   energyIntegrand_zero_drift_comm_of_isSymm isSymm_one c U V
 
-omit [DecidableEq n] in
 /-- The symmetric part's zero-drift jet form is the average of the original form and its
 transpose. -/
 lemma energyIntegrand_coefficientSymmetricPart_zero_drift_apply (A : Matrix n n ℝ)
@@ -106,7 +111,6 @@ lemma energyIntegrand_coefficientSymmetricPart_zero_drift_apply (A : Matrix n n 
   simp [driftForm_apply, massForm_apply, mul_comm, mul_left_comm]
   ring
 
-omit [DecidableEq n] in
 /-- Replacing the principal coefficient by its symmetric part does not change the diagonal
 energy density. -/
 lemma energyIntegrand_coefficientSymmetricPart_self (A : Matrix n n ℝ)
@@ -116,7 +120,6 @@ lemma energyIntegrand_coefficientSymmetricPart_self (A : Matrix n n ℝ)
   classical
   rw [energyIntegrand_self, energyIntegrand_self, toQuadraticForm'_coefficientSymmetricPart]
 
-omit [DecidableEq n] in
 /-- The symmetric part always gives a symmetric zero-drift jet form. -/
 lemma energyIntegrand_coefficientSymmetricPart_zero_drift_comm (A : Matrix n n ℝ)
     (c : ℝ) (U V : ℝ × EuclideanSpace ℝ n) :
@@ -124,7 +127,6 @@ lemma energyIntegrand_coefficientSymmetricPart_zero_drift_comm (A : Matrix n n �
       energyIntegrand (coefficientSymmetricPart A) 0 c V U :=
   energyIntegrand_zero_drift_comm_of_isSymm (coefficientSymmetricPart_isSymm A) c U V
 
-omit [DecidableEq n] in
 /-- Bundled-map form of symmetry for the symmetric-part zero-drift jet integrand. -/
 @[simp]
 lemma energyIntegrand_coefficientSymmetricPart_zero_drift_flip_eq (A : Matrix n n ℝ)
@@ -133,7 +135,6 @@ lemma energyIntegrand_coefficientSymmetricPart_zero_drift_flip_eq (A : Matrix n 
       energyIntegrand (coefficientSymmetricPart A) 0 c :=
   energyIntegrand_zero_drift_flip_eq_of_isSymm (coefficientSymmetricPart_isSymm A) c
 
-omit [DecidableEq n] in
 /-- A pointwise symmetric coefficient field gives symmetric zero-drift jet forms at every
 point of the domain. -/
 lemma energyIntegrand_zero_drift_comm_on {Ω : Set X} {a : X → Matrix n n ℝ}
@@ -142,7 +143,6 @@ lemma energyIntegrand_zero_drift_comm_on {Ω : Set X} {a : X → Matrix n n ℝ}
     energyIntegrand (a x) 0 (c x) U V = energyIntegrand (a x) 0 (c x) V U :=
   energyIntegrand_zero_drift_comm_of_isSymm (ha hx) (c x) U V
 
-omit [DecidableEq n] in
 /-- A pointwise symmetric coefficient field gives a bundled symmetric zero-drift jet form at
 each point of the domain. -/
 lemma energyIntegrand_zero_drift_flip_eq_on {Ω : Set X} {a : X → Matrix n n ℝ}
@@ -151,7 +151,7 @@ lemma energyIntegrand_zero_drift_flip_eq_on {Ω : Set X} {a : X → Matrix n n �
   energyIntegrand_zero_drift_flip_eq_of_isSymm (ha hx) (c x)
 
 /-- Bundled symmetry of the shifted Laplacian jet form. -/
-lemma energyIntegrand_one_zero_mass_flip_eq (c : ℝ) :
+lemma energyIntegrand_one_zero_mass_flip_eq [DecidableEq n] (c : ℝ) :
     (energyIntegrand (1 : Matrix n n ℝ) 0 c).flip =
       energyIntegrand (1 : Matrix n n ℝ) 0 c :=
   energyIntegrand_zero_drift_flip_eq_of_isSymm isSymm_one c

--- a/TauCeti/Analysis/PDE/UniformEllipticity.lean
+++ b/TauCeti/Analysis/PDE/UniformEllipticity.lean
@@ -266,6 +266,7 @@ lemma coefficientSymmetricPart_apply (A : Matrix n n ℝ) (i j : n) :
 
 omit [Fintype n] [DecidableEq n] in
 /-- A symmetric coefficient matrix is unchanged by taking its symmetric part. -/
+@[simp]
 lemma coefficientSymmetricPart_eq_self_of_isSymm {A : Matrix n n ℝ} (hA : A.IsSymm) :
     coefficientSymmetricPart A = A := by
   ext i j

--- a/TauCeti/Analysis/PDE/UniformEllipticity.lean
+++ b/TauCeti/Analysis/PDE/UniformEllipticity.lean
@@ -264,6 +264,14 @@ lemma coefficientSymmetricPart_apply (A : Matrix n n ℝ) (i j : n) :
     coefficientSymmetricPart A i j = (A i j + A j i) / 2 := by
   simp [coefficientSymmetricPart, div_eq_mul_inv, mul_comm]
 
+omit [Fintype n] [DecidableEq n] in
+/-- A symmetric coefficient matrix is unchanged by taking its symmetric part. -/
+lemma coefficientSymmetricPart_eq_self_of_isSymm {A : Matrix n n ℝ} (hA : A.IsSymm) :
+    coefficientSymmetricPart A = A := by
+  ext i j
+  rw [coefficientSymmetricPart_apply, hA.apply i j]
+  ring
+
 /-- The symmetric part has the same quadratic form as the original coefficient matrix. -/
 @[simp]
 lemma toQuadraticForm'_coefficientSymmetricPart (A : Matrix n n ℝ)


### PR DESCRIPTION
This PR records integrated symmetry facts for the zero-drift divergence-form energy integrand on raw value-gradient jets: a.e. symmetric principal coefficients make the integrated form symmetric, the coefficient symmetric part gives a symmetric form, the diagonal integrated energy is unchanged by replacing the principal coefficient by its symmetric part, and the shifted-Laplacian model is symmetric. It advances `TauCetiRoadmap/PDE/README.md`, Lane D.16, “Weak formulation,” specifically the energy bilinear form and boundedness/Gårding infrastructure needed before Lax-Milgram can consume the weak form.

I chose this as the lowest-hanging distinct PDE prerequisite after checking open and recently merged PRs: `main` already has `UniformlyEllipticOn`, pointwise symmetry of `energyIntegrand`, integrated boundedness, integrated Gårding lower bounds, and Lax-Milgram wrappers, while the integrated symmetry handoff from the pointwise zero-drift API was still absent. This PR stays below the missing Sobolev-space layer and does not introduce placeholders for `W^{k,p}(Ω)`.

No Mathlib infrastructure is vendored. The implementation reuses Tau Ceti’s existing `energyIntegrand_zero_drift_comm_of_isSymm`, `energyIntegrand_coefficientSymmetricPart_zero_drift_apply`, `energyIntegrand_coefficientSymmetricPart_self`, and `energyFormIntegral`, together with Mathlib’s standard Bochner integral congruence and additivity lemmas.

`lake exe cache get` completed with `No files to download` and `Already decompressed 8609 file(s)`. `lake build` completed with `Build completed successfully (4534 jobs).` `lake exe axioms` completed with `axioms: audited 8049 TauCeti declaration(s); all within the allowlist [propext, Classical.choice, Quot.sound].`

<!--tauceti-target:v1 {"focus":"PDE","id":"integrated-zero-drift-symmetry"}-->

🤖 Prepared with Codex
