### PR TITLE
feat: uniform upcrossing bound for the reversed conditional-expectation process

### DIFF
--- a/TauCeti/Probability/Martingale/Crossings/Bounds.lean
+++ b/TauCeti/Probability/Martingale/Crossings/Bounds.lean
@@ -12,9 +12,10 @@ top of `Pathwise.lean` and `Reverse.lean`.
 
 ## Main results
 
-- `upcrossings_bdd_uniform`: uniform-in-`N` bound on the
-  expected number of upcrossings for the reversed conditional-expectation process along an antitone
-  filtration.
+- `upcrossings_bdd_uniform`: a uniform crossing bound for the antitone conditional-expectation
+  sequence `n ↦ μ[f | 𝔽 n]` along an antitone filtration, for integrable `f`. Proved by transferring
+  a per-horizon reversed-surrogate bound (`lintegral_upcrossings_revCEFinite_bdd`, kept private) to
+  the antitone sequence via the pathwise time-reversal comparison.
 
 Adapted from `cameronfreer/exchangeability` (`Probability/Martingale/Crossings/Bounds.lean`, pin
 `e0532e59ceff23edab44dda9ab0655debbc9cc22`). Written Mathlib-shaped for eventual upstreaming.
@@ -108,13 +109,15 @@ private lemma upcrossings_zero_eq {a b : ℝ} (hab : a < b) (ω : Ω) :
           linarith
   simp [MeasureTheory.upcrossings, hub]
 
-/-- Uniform (in `N`) bound on upcrossings for the reversed conditional-expectation process.
+/-- Surrogate bound (kept private): uniform (in `N`) bound on upcrossings for the reversed
+conditional-expectation process.
 
 For the process obtained by reversing an antitone filtration, the expected number of upcrossings is
 uniformly bounded, independent of the time horizon `N`. No integrability hypothesis is needed: when
 `f` is not integrable the reversed conditional expectations all vanish, so the bound holds with
-`C = 0`. -/
-lemma upcrossings_bdd_uniform
+`C = 0`. The public `upcrossings_bdd_uniform` transfers this surrogate bound to the genuine antitone
+sequence `n ↦ μ[f | 𝔽 n]`. -/
+private lemma lintegral_upcrossings_revCEFinite_bdd
     [IsFiniteMeasure μ]
     (h_antitone : Antitone 𝔽) (h_le : ∀ n, 𝔽 n ≤ (inferInstance : MeasurableSpace Ω))
     (f : Ω → ℝ) (a b : ℝ) (hab : a < b) :
@@ -163,5 +166,126 @@ lemma upcrossings_bdd_uniform
       funext n; rw [revCEFinite_apply]; exact condExp_of_not_integrable hf
     rw [hzero]
     simp only [upcrossings_zero_eq hab, lintegral_zero, le_refl]
+
+/-- Pathwise comparison: the upcrossings of `n ↦ μ[f | 𝔽 n]` on `[a, b]` before time `N` are
+bounded by the total upcrossings on `[-b, -a]` of the negated finite-horizon reverse process. -/
+private lemma upcrossingsBefore_condExp_le_upcrossings_neg_revCEFinite
+    (f : Ω → ℝ) {a b : ℝ} (hab : a < b) (N : ℕ) (ω : Ω) :
+    ↑(upcrossingsBefore a b (fun n => μ[f | 𝔽 n]) N ω)
+      ≤ upcrossings (-b) (-a) (-(fun n => revCEFinite (μ := μ) f 𝔽 N n)) ω := by
+  -- `revProcess (μ[f|𝔽·]) N` and `revCEFinite f 𝔽 N` agree on `[0, N]` (below the horizon,
+  -- `Polynomial.revAt N` is genuine subtraction). The `N + 1` reversed horizon lets crossings
+  -- completing exactly at `N` count, but the extra index `N + 1` is a *free boundary*: it never
+  -- affects the crossing count (`upcrossingsBefore_succ_congr`), so we may swap the two processes
+  -- there even though they differ at `N + 1`.
+  have h_agree : ∀ n ≤ N, (-(revProcess (fun n => μ[f | 𝔽 n]) N)) n ω
+      = (-(fun n => revCEFinite (μ := μ) f 𝔽 N n)) n ω := by
+    intro n hn
+    simp only [Pi.neg_apply, revProcess_apply_of_le _ hn, revCEFinite_apply]
+  have hle : upcrossingsBefore a b (fun n => μ[f | 𝔽 n]) N ω
+      ≤ upcrossingsBefore (-b) (-a) (-(fun n => revCEFinite (μ := μ) f 𝔽 N n)) (N + 1) ω :=
+    calc upcrossingsBefore a b (fun n => μ[f | 𝔽 n]) N ω
+        ≤ upcrossingsBefore (-b) (-a) (-(revProcess (fun n => μ[f | 𝔽 n]) N)) (N + 1) ω :=
+          upcrossingsBefore_le_upcrossingsBefore_neg_revProcess_succ _ a b hab N ω
+      _ = upcrossingsBefore (-b) (-a) (-(fun n => revCEFinite (μ := μ) f 𝔽 N n)) (N + 1) ω :=
+          upcrossingsBefore_succ_congr h_agree
+  calc ↑(upcrossingsBefore a b (fun n => μ[f | 𝔽 n]) N ω)
+      ≤ ↑(upcrossingsBefore (-b) (-a)
+            (-(fun n => revCEFinite (μ := μ) f 𝔽 N n)) (N + 1) ω) := Nat.cast_le.mpr hle
+    _ ≤ upcrossings (-b) (-a) (-(fun n => revCEFinite (μ := μ) f 𝔽 N n)) ω := by
+        simp only [MeasureTheory.upcrossings]
+        exact le_iSup (fun M => (upcrossingsBefore (-b) (-a)
+          (-(fun n => revCEFinite (μ := μ) f 𝔽 N n)) M ω : ℝ≥0∞)) (N + 1)
+
+/-- Finite-horizon integral step: negating commutes a.e. with the reverse conditional-expectation
+process (via `condExp_neg`), so the upcrossing integrals of the negated process and of the reverse
+process of `-f` agree. -/
+private lemma lintegral_upcrossings_neg_revCEFinite_eq
+    (f : Ω → ℝ) (a b : ℝ) (N : ℕ) :
+    ∫⁻ ω, upcrossings (-b) (-a)
+        (-(fun n => revCEFinite (μ := μ) f 𝔽 N n)) ω ∂μ
+      = ∫⁻ ω, upcrossings (-b) (-a)
+          (fun n => revCEFinite (μ := μ) (fun x => -f x) 𝔽 N n) ω ∂μ := by
+  apply lintegral_congr_ae
+  -- The two processes agree a.e. at every time index (countable intersection via `ae_all_iff`).
+  have h_ae_eq : ∀ᵐ ω ∂μ, ∀ n,
+      (-(fun m => revCEFinite (μ := μ) f 𝔽 N m)) n ω =
+      revCEFinite (μ := μ) (fun x => -f x) 𝔽 N n ω := by
+    rw [ae_all_iff]
+    intro n
+    simp only [Pi.neg_apply, revCEFinite_apply]
+    exact (condExp_neg f (𝔽 (N - n))).symm
+  filter_upwards [h_ae_eq] with ω hω
+  simp only [MeasureTheory.upcrossings]
+  refine iSup_congr fun M => ?_
+  rw [upcrossingsBefore_congr (fun k _ => hω k)]
+
+/-- Upgrade a uniform-in-`N` bound on the per-horizon `upcrossingsBefore` integrals to a bound on
+the total `upcrossings` integral, by monotone convergence in the horizon `N`. The adapted process
+`g` supplies the measurability of each `upcrossingsBefore` count. -/
+private lemma lintegral_upcrossings_le_of_forall_lintegral_upcrossingsBefore_le
+    {g : ℕ → Ω → ℝ} {a b : ℝ} {C : ℝ≥0∞}
+    {ℱ : Filtration ℕ (inferInstance : MeasurableSpace Ω)}
+    (h_adapted : StronglyAdapted ℱ g) (hab : a < b)
+    (h_N_bound : ∀ N, ∫⁻ ω, ↑(upcrossingsBefore a b g N ω) ∂μ ≤ C) :
+    ∫⁻ ω, upcrossings a b g ω ∂μ ≤ C := by
+  -- Set `U N ω := upcrossingsBefore` (as `ℝ≥0∞`) for the process `g`.
+  set U : ℕ → Ω → ℝ≥0∞ := fun N ω => (upcrossingsBefore a b g N ω : ℝ≥0∞) with hU
+  -- Monotonicity in `N` (pathwise): more time allows more completed crossings.
+  have hU_mono : Monotone U := by
+    intro m n hmn ω
+    simp only [hU]
+    exact Nat.cast_le.2 (upcrossingsBefore_mono (f := g) hab hmn ω)
+  -- Measurability of each `U N` via the adaptedness hypothesis.
+  have hU_meas : ∀ N, Measurable (U N) := fun _ =>
+    measurable_from_top.comp (h_adapted.measurable_upcrossingsBefore hab)
+  -- Monotone convergence, then bound the supremum of integrals by `C`.
+  have h_iSup : ∫⁻ ω, (⨆ N, U N ω) ∂μ = ⨆ N, ∫⁻ ω, U N ω ∂μ := lintegral_iSup hU_meas hU_mono
+  have hbound : (⨆ N, ∫⁻ ω, U N ω ∂μ) ≤ C := iSup_le h_N_bound
+  -- Conclude via `upcrossings = ⨆ N, upcrossingsBefore N`.
+  simpa [MeasureTheory.upcrossings, hU] using h_iSup.le.trans hbound
+
+-- `hf` is intentionally not consumed: the transfer is pathwise, so the bound holds for all `f`.
+-- The hypothesis fixes the genuine (integrable) regime this bound targets and is the precondition
+-- the antitone-limit consumer relies on to read `n ↦ μ[f | 𝔽 n]` as the honest condExp process.
+set_option linter.unusedVariables false in
+/-- Uniform crossing bound for the antitone conditional-expectation sequence.
+
+For an antitone filtration `𝔽` and integrable `f`, the expected number of upcrossings of the genuine
+conditional-expectation process `n ↦ μ[f | 𝔽 n]` on any interval `[a, b]` is finite. This is the
+roadmap-shape bound used by the antitone-limit (Lévy downward) argument; it is obtained by
+transferring the per-horizon reversed-surrogate bound `lintegral_upcrossings_revCEFinite_bdd`
+through the pathwise time-reversal comparison. -/
+theorem upcrossings_bdd_uniform [IsFiniteMeasure μ] (h_antitone : Antitone 𝔽)
+    (h_le : ∀ n, 𝔽 n ≤ (inferInstance : MeasurableSpace Ω)) (f : Ω → ℝ) (hf : Integrable f μ)
+    (a b : ℝ) (hab : a < b) :
+    ∃ C : ENNReal, C < ⊤ ∧ ∫⁻ ω, upcrossings (↑a) (↑b) (fun n => μ[f | 𝔽 n]) ω ∂μ ≤ C := by
+  -- Downcrossings-side surrogate bound: apply the (private) reversed-process bound to `-f` on the
+  -- reflected interval `[-b, -a]`. This yields the constant `C_down` used throughout.
+  obtain ⟨C_down, h_C_down_finite, hC_down⟩ :=
+    lintegral_upcrossings_revCEFinite_bdd (μ := μ) h_antitone h_le
+      (fun ω => -f ω) (-b) (-a) (by linarith)
+  refine ⟨C_down, h_C_down_finite, ?_⟩
+  -- Per-horizon `L¹` bound: compose the pathwise comparison with the negation-commutes step, then
+  -- discharge with the surrogate bound `hC_down`.
+  have h_N_bound : ∀ N,
+      ∫⁻ ω, ↑(upcrossingsBefore a b (fun n => μ[f | 𝔽 n]) N ω) ∂μ ≤ C_down := fun N =>
+    calc ∫⁻ ω, ↑(upcrossingsBefore a b (fun n => μ[f | 𝔽 n]) N ω) ∂μ
+        ≤ ∫⁻ ω, upcrossings (-b) (-a)
+              (-(fun n => revCEFinite (μ := μ) f 𝔽 N n)) ω ∂μ :=
+          lintegral_mono
+            (upcrossingsBefore_condExp_le_upcrossings_neg_revCEFinite f hab N)
+      _ = ∫⁻ ω, upcrossings (-b) (-a)
+            (fun n => revCEFinite (μ := μ) (fun x => -f x) 𝔽 N n) ω ∂μ :=
+          lintegral_upcrossings_neg_revCEFinite_eq f a b N
+      _ ≤ C_down := hC_down N
+  -- The sequence `μ[f | 𝔽 n]` is adapted to the constant ambient filtration, supplying the
+  -- measurability needed for the monotone-convergence upgrade.
+  let ℱ : Filtration ℕ (inferInstance : MeasurableSpace Ω) :=
+    Filtration.const ℕ (inferInstance : MeasurableSpace Ω) le_rfl
+  have h_adapted : StronglyAdapted ℱ (fun n => μ[f | 𝔽 n]) :=
+    fun n => stronglyMeasurable_condExp.mono (h_le n)
+  -- Upgrade the per-horizon bound to the total upcrossings integral (monotone convergence in `N`).
+  exact lintegral_upcrossings_le_of_forall_lintegral_upcrossingsBefore_le h_adapted hab h_N_bound
 
 end MeasureTheory

--- a/TauCeti/Probability/Martingale/Crossings/Bounds.lean
+++ b/TauCeti/Probability/Martingale/Crossings/Bounds.lean
@@ -1,7 +1,8 @@
 module
 
-public import TauCeti.Probability.Martingale.Reverse
-public import TauCeti.Probability.Martingale.Crossings.Pathwise
+public import Mathlib.Probability.Martingale.Upcrossing
+import TauCeti.Probability.Martingale.Reverse
+import TauCeti.Probability.Martingale.Crossings.Pathwise
 import Mathlib.MeasureTheory.Function.LpSeminorm.Basic
 
 /-!
@@ -245,17 +246,13 @@ private lemma lintegral_upcrossings_le_of_forall_lintegral_upcrossingsBefore_le
   -- Conclude via `upcrossings = ⨆ N, upcrossingsBefore N`.
   simpa [MeasureTheory.upcrossings, hU] using h_iSup.le.trans hbound
 
--- `hf` is intentionally not consumed: the transfer is pathwise, so the bound holds for all `f`.
--- The hypothesis fixes the genuine (integrable) regime this bound targets and is the precondition
--- the antitone-limit consumer relies on to read `n ↦ μ[f | 𝔽 n]` as the honest condExp process.
-set_option linter.unusedVariables false in
 /-- Uniform crossing bound for the antitone conditional-expectation sequence.
 
-For an antitone filtration `𝔽` and integrable `f`, the expected number of upcrossings of the
-conditional-expectation process `n ↦ μ[f | 𝔽 n]` on any interval `[a, b]` is finite. This is the
-crossing bound consumed by the antitone-limit (Lévy downward) argument. -/
+For an antitone filtration `𝔽`, the expected number of upcrossings of the conditional-expectation
+process `n ↦ μ[f | 𝔽 n]` on any interval `[a, b]` is finite. This is the crossing bound consumed by
+the antitone-limit (Lévy downward) argument. -/
 theorem upcrossings_bdd_uniform [IsFiniteMeasure μ] (h_antitone : Antitone 𝔽)
-    (h_le : ∀ n, 𝔽 n ≤ (inferInstance : MeasurableSpace Ω)) (f : Ω → ℝ) (hf : Integrable f μ)
+    (h_le : ∀ n, 𝔽 n ≤ (inferInstance : MeasurableSpace Ω)) (f : Ω → ℝ)
     (a b : ℝ) (hab : a < b) :
     ∃ C : ENNReal, C < ⊤ ∧ ∫⁻ ω, upcrossings (↑a) (↑b) (fun n => μ[f | 𝔽 n]) ω ∂μ ≤ C := by
   -- Downcrossings-side surrogate bound: apply the (private) reversed-process bound to `-f` on the

--- a/TauCeti/Probability/Martingale/Crossings/Bounds.lean
+++ b/TauCeti/Probability/Martingale/Crossings/Bounds.lean
@@ -13,10 +13,9 @@ top of `Pathwise.lean` and `Reverse.lean`.
 
 ## Main results
 
-- `upcrossings_bdd_uniform`: a uniform crossing bound for the antitone conditional-expectation
-  sequence `n ↦ μ[f | 𝔽 n]` along an antitone filtration, for integrable `f`. Proved by transferring
-  a per-horizon reversed-surrogate bound (`lintegral_upcrossings_revCEFinite_bdd`, kept private) to
-  the antitone sequence via the pathwise time-reversal comparison.
+- `exists_lintegral_upcrossings_condExp_le` (roadmap alias `upcrossings_bdd_uniform`): a uniform
+  crossing bound for the antitone conditional-expectation sequence `n ↦ μ[f | 𝔽 n]`, for integrable
+  `f`.
 
 Adapted from `cameronfreer/exchangeability` (`Probability/Martingale/Crossings/Bounds.lean`, pin
 `e0532e59ceff23edab44dda9ab0655debbc9cc22`). Written Mathlib-shaped for eventual upstreaming.
@@ -209,7 +208,7 @@ For an antitone filtration `𝔽` and integrable `f`, the expected number of upc
 conditional-expectation process `n ↦ μ[f | 𝔽 n]` on any interval `[a, b]` is finite — the L¹
 reverse-martingale upcrossing bound. This is the crossing bound consumed by the antitone-limit
 (Lévy downward) argument. -/
-theorem upcrossings_bdd_uniform [IsFiniteMeasure μ] (h_antitone : Antitone 𝔽)
+theorem exists_lintegral_upcrossings_condExp_le [IsFiniteMeasure μ] (h_antitone : Antitone 𝔽)
     (h_le : ∀ n, 𝔽 n ≤ (inferInstance : MeasurableSpace Ω)) (f : Ω → ℝ) (hf : Integrable f μ)
     (a b : ℝ) (hab : a < b) :
     ∃ C : ENNReal, C < ⊤ ∧ ∫⁻ ω, upcrossings (↑a) (↑b) (fun n => μ[f | 𝔽 n]) ω ∂μ ≤ C := by
@@ -240,5 +239,9 @@ theorem upcrossings_bdd_uniform [IsFiniteMeasure μ] (h_antitone : Antitone 𝔽
     fun n => stronglyMeasurable_condExp.mono (h_le n)
   -- Upgrade the per-horizon bound to the total upcrossings integral (monotone convergence in `N`).
   exact lintegral_upcrossings_le_of_forall_lintegral_upcrossingsBefore_le h_adapted hab h_N_bound
+
+/-- Roadmap Layer 4 target name (`TauCetiRoadmap/Exchangeability`) for the uniform upcrossing bound
+`exists_lintegral_upcrossings_condExp_le`. -/
+alias upcrossings_bdd_uniform := exists_lintegral_upcrossings_condExp_le
 
 end MeasureTheory

--- a/TauCeti/Probability/Martingale/Crossings/Bounds.lean
+++ b/TauCeti/Probability/Martingale/Crossings/Bounds.lean
@@ -76,97 +76,54 @@ private lemma lintegral_pos_part_revCEFinite_le
               rw [ENNReal.ofReal_toReal]
               exact (memLp_one_iff_integrable.mpr hf).eLpNorm_ne_top
 
-omit [MeasurableSpace Ω] in
-/-- A process constant in time has no upcrossings: for `a < b`, the identically-zero process has
-zero upcrossings of `[a, b]`. This makes the reverse-martingale bound hold trivially when `f` is not
-integrable, since the reversed conditional expectations then all vanish. -/
-private lemma upcrossings_zero_eq {a b : ℝ} (hab : a < b) (ω : Ω) :
-    upcrossings a b (fun (_ : ℕ) => (0 : Ω → ℝ)) ω = 0 := by
-  have hub : ∀ N, upcrossingsBefore a b (fun (_ : ℕ) => (0 : Ω → ℝ)) N ω = 0 := by
-    intro N
-    rcases Nat.eq_zero_or_pos N with hN | hN
-    · rw [hN]; exact upcrossingsBefore_zero
-    · refine Nat.eq_zero_of_le_zero (csSup_le ⟨0, ?_⟩ ?_)
-      · simp only [Set.mem_setOf_eq, upperCrossingTime_zero, Pi.bot_apply, bot_eq_zero']
-        exact hN
-      · rintro n hn
-        rcases n with _ | m
-        · exact le_refl 0
-        · exfalso
-          rw [Set.mem_setOf_eq] at hn
-          have huc_ne : upperCrossingTime a b (fun (_ : ℕ) => (0 : Ω → ℝ)) N (m + 1) ω ≠ N :=
-            ne_of_lt hn
-          have hb : b ≤ (0 : ℝ) := by
-            have := stoppedValue_upperCrossingTime huc_ne
-            simpa [stoppedValue] using this
-          have hlt : lowerCrossingTime a b (fun (_ : ℕ) => (0 : Ω → ℝ)) N m ω
-              < upperCrossingTime a b (fun (_ : ℕ) => (0 : Ω → ℝ)) N (m + 1) ω :=
-            lowerCrossingTime_lt_upperCrossingTime hab huc_ne
-          have hlow_ne : lowerCrossingTime a b (fun (_ : ℕ) => (0 : Ω → ℝ)) N m ω ≠ N :=
-            ne_of_lt (lt_trans hlt hn)
-          have ha : (0 : ℝ) ≤ a := by
-            have := stoppedValue_lowerCrossingTime hlow_ne
-            simpa [stoppedValue] using this
-          linarith
-  simp [MeasureTheory.upcrossings, hub]
-
 /-- Surrogate bound (kept private): uniform (in `N`) bound on upcrossings for the reversed
 conditional-expectation process.
 
-For the process obtained by reversing an antitone filtration, the expected number of upcrossings is
-uniformly bounded, independent of the time horizon `N`. No integrability hypothesis is needed: when
-`f` is not integrable the reversed conditional expectations all vanish, so the bound holds with
-`C = 0`. The public `upcrossings_bdd_uniform` transfers this surrogate bound to the genuine antitone
-sequence `n ↦ μ[f | 𝔽 n]`. -/
+For an integrable `f` and the process obtained by reversing an antitone filtration, the expected
+number of upcrossings is uniformly bounded, independent of the time horizon `N`, by Doob's
+upcrossing inequality. The public `upcrossings_bdd_uniform` transfers this surrogate bound to the
+genuine antitone sequence `n ↦ μ[f | 𝔽 n]`. -/
 private lemma lintegral_upcrossings_revCEFinite_bdd
     [IsFiniteMeasure μ]
     (h_antitone : Antitone 𝔽) (h_le : ∀ n, 𝔽 n ≤ (inferInstance : MeasurableSpace Ω))
-    (f : Ω → ℝ) (a b : ℝ) (hab : a < b) :
+    (f : Ω → ℝ) (hf : Integrable f μ) (a b : ℝ) (hab : a < b) :
     ∃ C : ENNReal, C < ⊤ ∧ ∀ N,
       ∫⁻ ω, (upcrossings (↑a) (↑b) (fun n => revCEFinite (μ := μ) f 𝔽 N n) ω) ∂μ ≤ C := by
-  by_cases hf : Integrable f μ
-  · -- Integrable `f`: `C = (‖f‖₁ + |a| · μ(univ)) / (b - a)` via Doob's upcrossing inequality.
-    set C := (ENNReal.ofReal (eLpNorm f 1 μ).toReal + ENNReal.ofReal |a| * μ Set.univ)
-        / ENNReal.ofReal (b - a)
-    have hC_finite : C < ⊤ := by
-      refine ENNReal.div_lt_top ?h1 ?h2
-      · -- Numerator ≠ ⊤ (finite measure keeps `μ Set.univ < ⊤`)
-        refine (ENNReal.add_lt_top.2 ⟨?_, ?_⟩).ne
-        · rw [ENNReal.ofReal_toReal]
-          · exact (memLp_one_iff_integrable.mpr hf).eLpNorm_lt_top
-          · exact (memLp_one_iff_integrable.mpr hf).eLpNorm_ne_top
-        · exact ENNReal.mul_lt_top ENNReal.ofReal_lt_top (measure_lt_top μ Set.univ)
-      · -- Denominator ≠ 0
-        exact (ENNReal.ofReal_pos.2 (sub_pos.2 hab)).ne'
-    refine ⟨C, hC_finite, fun N => ?_⟩
-    -- Doob's upcrossing inequality for the reversed submartingale, then bound the supremum with
-    -- the positive-part L¹ estimate.
-    have hsub := (revCEFinite_martingale (μ := μ) h_antitone h_le f N).submartingale
-    have key := hsub.mul_lintegral_upcrossings_le_lintegral_pos_part a b
-    have sup_bdd : ⨆ M, ∫⁻ ω, ENNReal.ofReal ((revCEFinite (μ := μ) f 𝔽 N M ω - a)⁺) ∂μ
-        ≤ ENNReal.ofReal (eLpNorm f 1 μ).toReal + ENNReal.ofReal |a| * μ Set.univ :=
-      iSup_le fun M => lintegral_pos_part_revCEFinite_le f hf a N M
-    have step1 : (∫⁻ ω, upcrossings (↑a) (↑b) (fun n => revCEFinite (μ := μ) f 𝔽 N n) ω ∂μ)
-        * ENNReal.ofReal (b - a)
-        ≤ ⨆ M, ∫⁻ ω, ENNReal.ofReal ((revCEFinite (μ := μ) f 𝔽 N M ω - a)⁺) ∂μ := by
-      rw [mul_comm]; exact key
-    calc ∫⁻ ω, upcrossings (↑a) (↑b) (fun n => revCEFinite (μ := μ) f 𝔽 N n) ω ∂μ
-        ≤ (⨆ M, ∫⁻ ω, ENNReal.ofReal ((revCEFinite (μ := μ) f 𝔽 N M ω - a)⁺) ∂μ)
-            / ENNReal.ofReal (b - a) := by
-          refine (ENNReal.le_div_iff_mul_le ?_ ?_).2 step1
-          · left; exact (ENNReal.ofReal_pos.2 (sub_pos.2 hab)).ne'
-          · left; exact ENNReal.ofReal_ne_top
-      _ ≤ (ENNReal.ofReal (eLpNorm f 1 μ).toReal + ENNReal.ofReal |a| * μ Set.univ)
-            / ENNReal.ofReal (b - a) := by
-          gcongr
-      _ = C := rfl
-  · -- Non-integrable `f`: `revCEFinite f 𝔽 N n = μ[f | 𝔽 (N - n)] = 0`, so the reversed
-    -- process is identically `0` and has no upcrossings; the bound holds with `C = 0`.
-    refine ⟨0, ENNReal.zero_lt_top, fun N => ?_⟩
-    have hzero : (fun n => revCEFinite (μ := μ) f 𝔽 N n) = fun _ => (0 : Ω → ℝ) := by
-      funext n; rw [revCEFinite_apply]; exact condExp_of_not_integrable hf
-    rw [hzero]
-    simp only [upcrossings_zero_eq hab, lintegral_zero, le_refl]
+  -- `C = (‖f‖₁ + |a| · μ(univ)) / (b - a)` via Doob's upcrossing inequality.
+  set C := (ENNReal.ofReal (eLpNorm f 1 μ).toReal + ENNReal.ofReal |a| * μ Set.univ)
+      / ENNReal.ofReal (b - a)
+  have hC_finite : C < ⊤ := by
+    refine ENNReal.div_lt_top ?h1 ?h2
+    · -- Numerator ≠ ⊤ (finite measure keeps `μ Set.univ < ⊤`)
+      refine (ENNReal.add_lt_top.2 ⟨?_, ?_⟩).ne
+      · rw [ENNReal.ofReal_toReal]
+        · exact (memLp_one_iff_integrable.mpr hf).eLpNorm_lt_top
+        · exact (memLp_one_iff_integrable.mpr hf).eLpNorm_ne_top
+      · exact ENNReal.mul_lt_top ENNReal.ofReal_lt_top (measure_lt_top μ Set.univ)
+    · -- Denominator ≠ 0
+      exact (ENNReal.ofReal_pos.2 (sub_pos.2 hab)).ne'
+  refine ⟨C, hC_finite, fun N => ?_⟩
+  -- Doob's upcrossing inequality for the reversed submartingale, then bound the supremum with
+  -- the positive-part L¹ estimate.
+  have hsub := (revCEFinite_martingale (μ := μ) h_antitone h_le f N).submartingale
+  have key := hsub.mul_lintegral_upcrossings_le_lintegral_pos_part a b
+  have sup_bdd : ⨆ M, ∫⁻ ω, ENNReal.ofReal ((revCEFinite (μ := μ) f 𝔽 N M ω - a)⁺) ∂μ
+      ≤ ENNReal.ofReal (eLpNorm f 1 μ).toReal + ENNReal.ofReal |a| * μ Set.univ :=
+    iSup_le fun M => lintegral_pos_part_revCEFinite_le f hf a N M
+  have step1 : (∫⁻ ω, upcrossings (↑a) (↑b) (fun n => revCEFinite (μ := μ) f 𝔽 N n) ω ∂μ)
+      * ENNReal.ofReal (b - a)
+      ≤ ⨆ M, ∫⁻ ω, ENNReal.ofReal ((revCEFinite (μ := μ) f 𝔽 N M ω - a)⁺) ∂μ := by
+    rw [mul_comm]; exact key
+  calc ∫⁻ ω, upcrossings (↑a) (↑b) (fun n => revCEFinite (μ := μ) f 𝔽 N n) ω ∂μ
+      ≤ (⨆ M, ∫⁻ ω, ENNReal.ofReal ((revCEFinite (μ := μ) f 𝔽 N M ω - a)⁺) ∂μ)
+          / ENNReal.ofReal (b - a) := by
+        refine (ENNReal.le_div_iff_mul_le ?_ ?_).2 step1
+        · left; exact (ENNReal.ofReal_pos.2 (sub_pos.2 hab)).ne'
+        · left; exact ENNReal.ofReal_ne_top
+    _ ≤ (ENNReal.ofReal (eLpNorm f 1 μ).toReal + ENNReal.ofReal |a| * μ Set.univ)
+          / ENNReal.ofReal (b - a) := by
+        gcongr
+    _ = C := rfl
 
 /-- Pathwise comparison: the upcrossings of `n ↦ μ[f | 𝔽 n]` on `[a, b]` before time `N` are
 bounded by the total upcrossings on `[-b, -a]` of the negated finite-horizon reverse process. -/
@@ -248,18 +205,19 @@ private lemma lintegral_upcrossings_le_of_forall_lintegral_upcrossingsBefore_le
 
 /-- Uniform crossing bound for the antitone conditional-expectation sequence.
 
-For an antitone filtration `𝔽`, the expected number of upcrossings of the conditional-expectation
-process `n ↦ μ[f | 𝔽 n]` on any interval `[a, b]` is finite. This is the crossing bound consumed by
-the antitone-limit (Lévy downward) argument. -/
+For an antitone filtration `𝔽` and integrable `f`, the expected number of upcrossings of the
+conditional-expectation process `n ↦ μ[f | 𝔽 n]` on any interval `[a, b]` is finite — the L¹
+reverse-martingale upcrossing bound. This is the crossing bound consumed by the antitone-limit
+(Lévy downward) argument. -/
 theorem upcrossings_bdd_uniform [IsFiniteMeasure μ] (h_antitone : Antitone 𝔽)
-    (h_le : ∀ n, 𝔽 n ≤ (inferInstance : MeasurableSpace Ω)) (f : Ω → ℝ)
+    (h_le : ∀ n, 𝔽 n ≤ (inferInstance : MeasurableSpace Ω)) (f : Ω → ℝ) (hf : Integrable f μ)
     (a b : ℝ) (hab : a < b) :
     ∃ C : ENNReal, C < ⊤ ∧ ∫⁻ ω, upcrossings (↑a) (↑b) (fun n => μ[f | 𝔽 n]) ω ∂μ ≤ C := by
   -- Downcrossings-side surrogate bound: apply the (private) reversed-process bound to `-f` on the
   -- reflected interval `[-b, -a]`. This yields the constant `C_down` used throughout.
   obtain ⟨C_down, h_C_down_finite, hC_down⟩ :=
     lintegral_upcrossings_revCEFinite_bdd (μ := μ) h_antitone h_le
-      (fun ω => -f ω) (-b) (-a) (by linarith)
+      (fun ω => -f ω) hf.neg (-b) (-a) (by linarith)
   refine ⟨C_down, h_C_down_finite, ?_⟩
   -- Per-horizon `L¹` bound: compose the pathwise comparison with the negation-commutes step, then
   -- discharge with the surrogate bound `hC_down`.

--- a/TauCeti/Probability/Martingale/Crossings/Bounds.lean
+++ b/TauCeti/Probability/Martingale/Crossings/Bounds.lean
@@ -251,11 +251,9 @@ private lemma lintegral_upcrossings_le_of_forall_lintegral_upcrossingsBefore_le
 set_option linter.unusedVariables false in
 /-- Uniform crossing bound for the antitone conditional-expectation sequence.
 
-For an antitone filtration `𝔽` and integrable `f`, the expected number of upcrossings of the genuine
+For an antitone filtration `𝔽` and integrable `f`, the expected number of upcrossings of the
 conditional-expectation process `n ↦ μ[f | 𝔽 n]` on any interval `[a, b]` is finite. This is the
-roadmap-shape bound used by the antitone-limit (Lévy downward) argument; it is obtained by
-transferring the per-horizon reversed-surrogate bound `lintegral_upcrossings_revCEFinite_bdd`
-through the pathwise time-reversal comparison. -/
+crossing bound consumed by the antitone-limit (Lévy downward) argument. -/
 theorem upcrossings_bdd_uniform [IsFiniteMeasure μ] (h_antitone : Antitone 𝔽)
     (h_le : ∀ n, 𝔽 n ≤ (inferInstance : MeasurableSpace Ω)) (f : Ω → ℝ) (hf : Integrable f μ)
     (a b : ℝ) (hab : a < b) :

--- a/TauCeti/Probability/Martingale/Crossings/Bounds.lean
+++ b/TauCeti/Probability/Martingale/Crossings/Bounds.lean
@@ -1,0 +1,167 @@
+module
+
+public import TauCeti.Probability.Martingale.Reverse
+public import TauCeti.Probability.Martingale.Crossings.Pathwise
+import Mathlib.MeasureTheory.Function.LpSeminorm.Basic
+
+/-!
+# Crossings: uniform upcrossing bound for reverse martingales
+
+The L¹-uniform upcrossing bound used in the reverse-martingale antitone-limit argument. Built on
+top of `Pathwise.lean` and `Reverse.lean`.
+
+## Main results
+
+- `upcrossings_bdd_uniform`: uniform-in-`N` bound on the
+  expected number of upcrossings for the reversed conditional-expectation process along an antitone
+  filtration.
+
+Adapted from `cameronfreer/exchangeability` (`Probability/Martingale/Crossings/Bounds.lean`, pin
+`e0532e59ceff23edab44dda9ab0655debbc9cc22`). Written Mathlib-shaped for eventual upstreaming.
+-/
+
+public section
+
+noncomputable section
+
+open MeasureTheory
+
+open scoped ENNReal
+
+namespace MeasureTheory
+
+variable {Ω : Type*} [MeasurableSpace Ω] {μ : Measure Ω}
+variable {𝔽 : ℕ → MeasurableSpace Ω}
+
+/-- Positive-part L¹ bound for the reversed conditional-expectation process: for integrable `f`,
+the integral of `(revCEFinite f 𝔽 N M · - a)⁺` is bounded by `‖f‖₁ + |a| · μ(univ)`,
+uniformly in the horizon `N` and the time `M`. -/
+private lemma lintegral_pos_part_revCEFinite_le
+    (f : Ω → ℝ) (hf : Integrable f μ) (a : ℝ) (N M : ℕ) :
+    ∫⁻ ω, ENNReal.ofReal ((revCEFinite (μ := μ) f 𝔽 N M ω - a)⁺) ∂μ
+      ≤ ENNReal.ofReal (eLpNorm f 1 μ).toReal + ENNReal.ofReal |a| * μ Set.univ := by
+  -- Use (x - a)⁺ ≤ |x - a| ≤ |x| + |a|, integrate, then convert to `eLpNorm` and apply the
+  -- L¹ contraction of conditional expectation.
+  calc ∫⁻ ω, ENNReal.ofReal ((revCEFinite (μ := μ) f 𝔽 N M ω - a)⁺) ∂μ
+      ≤ ∫⁻ ω, ENNReal.ofReal (|revCEFinite (μ := μ) f 𝔽 N M ω| + |a|) ∂μ := by
+        apply lintegral_mono
+        intro ω
+        apply ENNReal.ofReal_le_ofReal
+        calc (revCEFinite (μ := μ) f 𝔽 N M ω - a)⁺
+            = max (revCEFinite (μ := μ) f 𝔽 N M ω - a) 0 := rfl
+          _ ≤ |revCEFinite (μ := μ) f 𝔽 N M ω - a| := by
+              simp only [le_abs_self, max_le_iff, abs_nonneg, and_self]
+          _ ≤ |revCEFinite (μ := μ) f 𝔽 N M ω| + |a| := by
+              rw [sub_eq_add_neg]
+              simpa using abs_add_le (revCEFinite (μ := μ) f 𝔽 N M ω) (-a)
+    _ = ∫⁻ ω, (ENNReal.ofReal |revCEFinite (μ := μ) f 𝔽 N M ω| + ENNReal.ofReal |a|) ∂μ := by
+        simp [ENNReal.ofReal_add]
+    _ = ∫⁻ ω, ENNReal.ofReal |revCEFinite (μ := μ) f 𝔽 N M ω| ∂μ
+          + ENNReal.ofReal |a| * μ Set.univ := by
+        rw [lintegral_add_right _ measurable_const, lintegral_const]
+    _ ≤ ENNReal.ofReal (eLpNorm f 1 μ).toReal + ENNReal.ofReal |a| * μ Set.univ := by
+        gcongr
+        have hconv : ∫⁻ ω, ENNReal.ofReal |revCEFinite (μ := μ) f 𝔽 N M ω| ∂μ =
+            eLpNorm (revCEFinite (μ := μ) f 𝔽 N M) 1 μ := by
+          rw [eLpNorm_one_eq_lintegral_enorm]
+          congr 1; ext ω
+          exact (Real.enorm_eq_ofReal_abs _).symm
+        rw [hconv]
+        calc eLpNorm (revCEFinite (μ := μ) f 𝔽 N M) 1 μ
+            ≤ eLpNorm f 1 μ := by
+                rw [revCEFinite_apply]; exact eLpNorm_one_condExp_le_eLpNorm f
+          _ = ENNReal.ofReal (eLpNorm f 1 μ).toReal := by
+              rw [ENNReal.ofReal_toReal]
+              exact (memLp_one_iff_integrable.mpr hf).eLpNorm_ne_top
+
+omit [MeasurableSpace Ω] in
+/-- A process constant in time has no upcrossings: for `a < b`, the identically-zero process has
+zero upcrossings of `[a, b]`. This makes the reverse-martingale bound hold trivially when `f` is not
+integrable, since the reversed conditional expectations then all vanish. -/
+private lemma upcrossings_zero_eq {a b : ℝ} (hab : a < b) (ω : Ω) :
+    upcrossings a b (fun (_ : ℕ) => (0 : Ω → ℝ)) ω = 0 := by
+  have hub : ∀ N, upcrossingsBefore a b (fun (_ : ℕ) => (0 : Ω → ℝ)) N ω = 0 := by
+    intro N
+    rcases Nat.eq_zero_or_pos N with hN | hN
+    · rw [hN]; exact upcrossingsBefore_zero
+    · refine Nat.eq_zero_of_le_zero (csSup_le ⟨0, ?_⟩ ?_)
+      · simp only [Set.mem_setOf_eq, upperCrossingTime_zero, Pi.bot_apply, bot_eq_zero']
+        exact hN
+      · rintro n hn
+        rcases n with _ | m
+        · exact le_refl 0
+        · exfalso
+          rw [Set.mem_setOf_eq] at hn
+          have huc_ne : upperCrossingTime a b (fun (_ : ℕ) => (0 : Ω → ℝ)) N (m + 1) ω ≠ N :=
+            ne_of_lt hn
+          have hb : b ≤ (0 : ℝ) := by
+            have := stoppedValue_upperCrossingTime huc_ne
+            simpa [stoppedValue] using this
+          have hlt : lowerCrossingTime a b (fun (_ : ℕ) => (0 : Ω → ℝ)) N m ω
+              < upperCrossingTime a b (fun (_ : ℕ) => (0 : Ω → ℝ)) N (m + 1) ω :=
+            lowerCrossingTime_lt_upperCrossingTime hab huc_ne
+          have hlow_ne : lowerCrossingTime a b (fun (_ : ℕ) => (0 : Ω → ℝ)) N m ω ≠ N :=
+            ne_of_lt (lt_trans hlt hn)
+          have ha : (0 : ℝ) ≤ a := by
+            have := stoppedValue_lowerCrossingTime hlow_ne
+            simpa [stoppedValue] using this
+          linarith
+  simp [MeasureTheory.upcrossings, hub]
+
+/-- Uniform (in `N`) bound on upcrossings for the reversed conditional-expectation process.
+
+For the process obtained by reversing an antitone filtration, the expected number of upcrossings is
+uniformly bounded, independent of the time horizon `N`. No integrability hypothesis is needed: when
+`f` is not integrable the reversed conditional expectations all vanish, so the bound holds with
+`C = 0`. -/
+lemma upcrossings_bdd_uniform
+    [IsFiniteMeasure μ]
+    (h_antitone : Antitone 𝔽) (h_le : ∀ n, 𝔽 n ≤ (inferInstance : MeasurableSpace Ω))
+    (f : Ω → ℝ) (a b : ℝ) (hab : a < b) :
+    ∃ C : ENNReal, C < ⊤ ∧ ∀ N,
+      ∫⁻ ω, (upcrossings (↑a) (↑b) (fun n => revCEFinite (μ := μ) f 𝔽 N n) ω) ∂μ ≤ C := by
+  by_cases hf : Integrable f μ
+  · -- Integrable `f`: `C = (‖f‖₁ + |a| · μ(univ)) / (b - a)` via Doob's upcrossing inequality.
+    set C := (ENNReal.ofReal (eLpNorm f 1 μ).toReal + ENNReal.ofReal |a| * μ Set.univ)
+        / ENNReal.ofReal (b - a)
+    have hC_finite : C < ⊤ := by
+      refine ENNReal.div_lt_top ?h1 ?h2
+      · -- Numerator ≠ ⊤ (finite measure keeps `μ Set.univ < ⊤`)
+        refine (ENNReal.add_lt_top.2 ⟨?_, ?_⟩).ne
+        · rw [ENNReal.ofReal_toReal]
+          · exact (memLp_one_iff_integrable.mpr hf).eLpNorm_lt_top
+          · exact (memLp_one_iff_integrable.mpr hf).eLpNorm_ne_top
+        · exact ENNReal.mul_lt_top ENNReal.ofReal_lt_top (measure_lt_top μ Set.univ)
+      · -- Denominator ≠ 0
+        exact (ENNReal.ofReal_pos.2 (sub_pos.2 hab)).ne'
+    refine ⟨C, hC_finite, fun N => ?_⟩
+    -- Doob's upcrossing inequality for the reversed submartingale, then bound the supremum with
+    -- the positive-part L¹ estimate.
+    have hsub := (revCEFinite_martingale (μ := μ) h_antitone h_le f N).submartingale
+    have key := hsub.mul_lintegral_upcrossings_le_lintegral_pos_part a b
+    have sup_bdd : ⨆ M, ∫⁻ ω, ENNReal.ofReal ((revCEFinite (μ := μ) f 𝔽 N M ω - a)⁺) ∂μ
+        ≤ ENNReal.ofReal (eLpNorm f 1 μ).toReal + ENNReal.ofReal |a| * μ Set.univ :=
+      iSup_le fun M => lintegral_pos_part_revCEFinite_le f hf a N M
+    have step1 : (∫⁻ ω, upcrossings (↑a) (↑b) (fun n => revCEFinite (μ := μ) f 𝔽 N n) ω ∂μ)
+        * ENNReal.ofReal (b - a)
+        ≤ ⨆ M, ∫⁻ ω, ENNReal.ofReal ((revCEFinite (μ := μ) f 𝔽 N M ω - a)⁺) ∂μ := by
+      rw [mul_comm]; exact key
+    calc ∫⁻ ω, upcrossings (↑a) (↑b) (fun n => revCEFinite (μ := μ) f 𝔽 N n) ω ∂μ
+        ≤ (⨆ M, ∫⁻ ω, ENNReal.ofReal ((revCEFinite (μ := μ) f 𝔽 N M ω - a)⁺) ∂μ)
+            / ENNReal.ofReal (b - a) := by
+          refine (ENNReal.le_div_iff_mul_le ?_ ?_).2 step1
+          · left; exact (ENNReal.ofReal_pos.2 (sub_pos.2 hab)).ne'
+          · left; exact ENNReal.ofReal_ne_top
+      _ ≤ (ENNReal.ofReal (eLpNorm f 1 μ).toReal + ENNReal.ofReal |a| * μ Set.univ)
+            / ENNReal.ofReal (b - a) := by
+          gcongr
+      _ = C := rfl
+  · -- Non-integrable `f`: `revCEFinite f 𝔽 N n = μ[f | 𝔽 (N - n)] = 0`, so the reversed
+    -- process is identically `0` and has no upcrossings; the bound holds with `C = 0`.
+    refine ⟨0, ENNReal.zero_lt_top, fun N => ?_⟩
+    have hzero : (fun n => revCEFinite (μ := μ) f 𝔽 N n) = fun _ => (0 : Ω → ℝ) := by
+      funext n; rw [revCEFinite_apply]; exact condExp_of_not_integrable hf
+    rw [hzero]
+    simp only [upcrossings_zero_eq hab, lintegral_zero, le_refl]
+
+end MeasureTheory


### PR DESCRIPTION
<!--tauceti-target:v1 {"focus":"Exchangeability","id":"upcrossings-bdd-uniform"}-->

## Summary

Adds `TauCeti/Probability/Martingale/Crossings/Bounds.lean` — the **uniform upcrossing bound** for the
antitone conditional-expectation sequence (`namespace MeasureTheory`):

- `upcrossings_bdd_uniform` — for an antitone filtration `𝔽` and **integrable** `f`, the total
  `∫⁻`-upcrossings of the genuine conditional-expectation process `n ↦ μ[f | 𝔽 n]` on any interval
  `[a, b]` are bounded by a single finite `C < ⊤`. This is the crossing bound the Lévy-downward
  antitone-limit argument (`condExp_exists_ae_limit_antitone` → `condExp_tendsto_iInf`, forthcoming)
  consumes.

## Roadmap

Advances `TauCetiRoadmap/Exchangeability/README.md` **Layer 4 (reverse martingales and
conditional-expectation limits)** — the antitone-upcrossing bound (roadmap `upcrossings_bdd_uniform`)
stated on `n ↦ μ[f | 𝔽 n]`, exactly the sequence the downward limit consumes. Peeled off as a
standalone one-topic PR.

## How it's proved (reuse / Mathlib-backing)

The genuine bound is transferred from a per-horizon reversed-surrogate bound through the pathwise
time-reversal comparison:

- The **private** surrogate `lintegral_upcrossings_revCEFinite_bdd` bounds `∫⁻`-upcrossings of the
  reversed conditional-expectation process `revCEFinite f 𝔽 N`, uniformly in the horizon `N`, via
  Mathlib's submartingale upcrossing inequality (`Submartingale.mul_lintegral_upcrossings_le_lintegral_pos_part`)
  applied to `(revCEFinite_martingale …).submartingale`, with the uniform constant from condExp
  L¹-contractivity (`eLpNorm_one_condExp_le_eLpNorm`).
- Three **private** transfer lemmas move the surrogate bound to the genuine sequence: a pathwise
  comparison (`upcrossingsBefore_condExp_le_upcrossings_neg_revCEFinite`, built on the merged #724
  reversal API), the negation-commutes step (`condExp_neg`), and a monotone-convergence-in-`N` upgrade
  from per-horizon `upcrossingsBefore` to total `upcrossings`.

No new martingale theory. The remaining private helper (`upcrossings_zero_eq`) is assembly over
Mathlib (no "upcrossings of a constant = 0" lemma exists, `leanfinder`-checked).

## Correctness fix

An earlier revision stated the public bound on the reversed **surrogate** process `revCEFinite f 𝔽 N`
rather than the genuine antitone sequence `n ↦ μ[f | 𝔽 n]` that the roadmap and the downward-limit
consumer require, and omitted the `Integrable f` precondition. This revision restates the public
theorem on `n ↦ μ[f | 𝔽 n]` with `Integrable f`, keeping the surrogate + reversal machinery as private
support (folded in from the antitone-limit file, which will shed its copies when peeled).

## Review notes
- **api-design:** public surface is the single roadmap target `upcrossings_bdd_uniform`; the surrogate
  bound and the three transfer lemmas are `private`.
- **placement:** `Probability/Martingale/Crossings/`, `namespace MeasureTheory` (matching Mathlib's
  upcrossing/martingale API and the merged reverse-martingale leaves). The `LpSeminorm` import is
  **non-public** (`eLpNorm` appears only in the private surrogate's statement + proofs, not the public
  theorem).
- **reuse:** Mathlib's submartingale upcrossing bound + `eLpNorm_one_condExp_le_eLpNorm` + the #724
  pathwise reversal API.

## Dependency

Builds on `revCEFinite`/`revCEFinite_martingale` (#685) and the pathwise crossing infrastructure
(#724, merged); off current `main`.

## Test plan
```bash
lake build && lake exe axioms && lake exe module-system && bash scripts/lint-env.sh
```
All pass; sorry-free; `upcrossings_bdd_uniform` axioms ⊆ {`propext`, `Classical.choice`, `Quot.sound`};
lines ≤100; module-system opts in.

## Attribution
Adapted from `cameronfreer/exchangeability`, reworked into TauCeti's module system and to the merged
Mathlib-shaped reverse-martingale API. Drafted with Claude (Opus 4.8), human-directed.
