### PR TITLE
feat: add two-by-two grid grading computation

### DIFF
--- a/TauCeti/KnotTheory/Grid/GradingInteger.lean
+++ b/TauCeti/KnotTheory/Grid/GradingInteger.lean
@@ -49,6 +49,8 @@ so `M_O(x)` is an integer. The same computation handles `M_X`.
 * `TauCeti.GridDiagram.maslovOℤ_eq_card`, `TauCeti.GridDiagram.maslovXℤ_eq_card`: the integer
   Maslov gradings written entirely as counts over column indices, so they evaluate on an
   explicit grid without unfolding any point-pair product.
+* `TauCeti.GridDiagram.maslovOℤ_O`, `TauCeti.GridDiagram.maslovXℤ_X`: the integer Maslov grading
+  of a marking state against its own markings is always `1`.
 
 ## References
 
@@ -121,6 +123,16 @@ theorem maslovXℤ_eq_card (x : GridState n) :
   rw [maslovXℤ_def, XSet, GridState.I_self_pointSet_eq_card x,
     GridState.JNum_pointSet_eq_card x G.X, GridState.I_self_pointSet_eq_card G.X]
   push_cast
+  ring
+
+/-- The integer `O`-Maslov grading of the `O`-marking state is always `1`. -/
+theorem maslovOℤ_O : G.maslovOℤ G.O = 1 := by
+  rw [maslovOℤ_eq_card]
+  ring
+
+/-- The integer `X`-Maslov grading of the `X`-marking state is always `1`. -/
+theorem maslovXℤ_X : G.maslovXℤ G.X = 1 := by
+  rw [maslovXℤ_eq_card]
   ring
 
 /-- The rational `O`-Maslov grading is the cast of its integer counterpart: `M_O` is an

--- a/TauCeti/KnotTheory/Grid/SmallGridGradings.lean
+++ b/TauCeti/KnotTheory/Grid/SmallGridGradings.lean
@@ -46,40 +46,22 @@ namespace GridDiagram
 
 /-- The standard `2 × 2` grid diagram with `O` markings on the identity state and `X`
 markings on the transposition state. This is the usual smallest grid diagram for the unknot. -/
-@[expose]
-noncomputable def twoByTwo : GridDiagram 2 :=
-  Classical.choose <| show
-    ∃ G : GridDiagram 2, G.O = GridState.twoByTwoId ∧ G.X = GridState.twoByTwoSwap from
-    ⟨{ O := GridState.twoByTwoId
-       X := GridState.twoByTwoSwap
-       disjoint := by
-        intro c h
-        fin_cases c <;> simp at h },
-      rfl, rfl⟩
+abbrev twoByTwo : GridDiagram 2 where
+  O := GridState.twoByTwoId
+  X := GridState.twoByTwoSwap
+  disjoint := by
+    intro c h
+    fin_cases c <;> simp at h
 
 /-- The `O`-marking state of the standard two-by-two diagram is the identity state. -/
 @[simp]
 theorem twoByTwo_O : twoByTwo.O = GridState.twoByTwoId :=
-  (Classical.choose_spec <| show
-      ∃ G : GridDiagram 2, G.O = GridState.twoByTwoId ∧ G.X = GridState.twoByTwoSwap from
-    ⟨{ O := GridState.twoByTwoId
-       X := GridState.twoByTwoSwap
-       disjoint := by
-        intro c h
-        fin_cases c <;> simp at h },
-      rfl, rfl⟩).1
+  rfl
 
 /-- The `X`-marking state of the standard two-by-two diagram is the transposition state. -/
 @[simp]
 theorem twoByTwo_X : twoByTwo.X = GridState.twoByTwoSwap :=
-  (Classical.choose_spec <| show
-      ∃ G : GridDiagram 2, G.O = GridState.twoByTwoId ∧ G.X = GridState.twoByTwoSwap from
-    ⟨{ O := GridState.twoByTwoId
-       X := GridState.twoByTwoSwap
-       disjoint := by
-        intro c h
-        fin_cases c <;> simp at h },
-      rfl, rfl⟩).2
+  rfl
 
 /-- The standard two-by-two diagram has `O` markings at `(0,0)` and `(1,1)`. -/
 @[simp]
@@ -161,21 +143,7 @@ theorem maslovXℤ_O_of_two (G : GridDiagram 2) : G.maslovXℤ G.O = 2 := by
 
 /-- In a `2 × 2` diagram, the integer `O`-Maslov grading of the `X`-marking state is `2`. -/
 theorem maslovOℤ_X_of_two (G : GridDiagram 2) : G.maslovOℤ G.X = 2 := by
-  rcases GridState.eq_twoByTwoId_or_eq_twoByTwoSwap G.O with hO | hO
-  · rcases GridState.eq_twoByTwoId_or_eq_twoByTwoSwap G.X with hX | hX
-    · exfalso
-      exact G.disjoint 0 (by simp [hO, hX])
-    · rw [maslovOℤ_eq_card, hO, hX]
-      rw [twoByTwoSwap_pairCard_self, twoByTwoSwap_pairCard_id, twoByTwoId_pairCard_swap,
-        twoByTwoId_pairCard_self]
-      norm_num
-  · rcases GridState.eq_twoByTwoId_or_eq_twoByTwoSwap G.X with hX | hX
-    · rw [maslovOℤ_eq_card, hO, hX]
-      rw [twoByTwoId_pairCard_self, twoByTwoId_pairCard_swap, twoByTwoSwap_pairCard_id,
-        twoByTwoSwap_pairCard_self]
-      norm_num
-    · exfalso
-      exact G.disjoint 0 (by simp [hO, hX])
+  simpa using maslovXℤ_O_of_two G.swapMarkings
 
 /-- Twice the Alexander grading of the `O`-marking state in a `2 × 2` diagram is `-2`. -/
 theorem alexanderTwoℤ_O_of_two (G : GridDiagram 2) : G.alexanderTwoℤ G.O = -2 := by
@@ -246,8 +214,7 @@ theorem alexander_twoByTwo_twoByTwoSwap :
     twoByTwo.alexander GridState.twoByTwoSwap = 0 := by
   simpa using alexander_X_of_two twoByTwo
 
-/-- Every generator of an arbitrary `2 × 2` diagram has one of the two computed Alexander
-gradings: `-1` on the `O`-marking state and `0` on the `X`-marking state. -/
+/-- Every generator of an arbitrary `2 × 2` diagram has Alexander grading `-1` or `0`. -/
 theorem alexander_eq_neg_one_or_eq_zero_of_two (G : GridDiagram 2) (x : GridState 2) :
     G.alexander x = -1 ∨ G.alexander x = 0 := by
   have hx : x = G.O ∨ x = G.X := by

--- a/TauCeti/KnotTheory/Grid/SmallGridGradings.lean
+++ b/TauCeti/KnotTheory/Grid/SmallGridGradings.lean
@@ -31,10 +31,6 @@ gradings in this concrete diagram.
 
 ## Main results
 
-* `TauCeti.GridState.eq_twoByTwoId_or_eq_twoByTwoSwap`: the two named states exhaust
-  the generators in grid size two.
-* `TauCeti.GridDiagram.fullyBlockedDifferential_twoByTwo`: the fully blocked differential
-  on the standard `2 × 2` diagram is zero.
 * `TauCeti.GridDiagram.maslovOℤ_twoByTwo_twoByTwoId`,
   `TauCeti.GridDiagram.maslovXℤ_twoByTwo_twoByTwoId`,
   `TauCeti.GridDiagram.alexander_twoByTwo_twoByTwoId`, and the corresponding `twoByTwoSwap`
@@ -89,14 +85,6 @@ theorem twoByTwoId_ne_twoByTwoSwap : twoByTwoId ≠ twoByTwoSwap := by
   intro h
   exact Fin.zero_ne_one (congrArg (fun x : GridState 2 => x 0) h)
 
-/-- The two grid states on a `2 × 2` grid are exactly the identity state and the transposition
-state. -/
-theorem eq_twoByTwoId_or_eq_twoByTwoSwap (x : GridState 2) :
-    x = twoByTwoId ∨ x = twoByTwoSwap := by
-  have hx := eq_equivPerm_symm_one_or_eq_equivPerm_symm_swap x
-  rw [equivPerm_symm_apply, equivPerm_symm_apply] at hx
-  simpa [twoByTwoId, twoByTwoSwap] using hx
-
 /-- The finite set of all `2 × 2` grid states is the two explicit states. -/
 theorem univ_two :
     (Finset.univ : Finset (GridState 2)) = {twoByTwoId, twoByTwoSwap} := by
@@ -104,7 +92,9 @@ theorem univ_two :
   constructor
   · intro _
     exact (Finset.mem_insert.mpr <|
-      (eq_twoByTwoId_or_eq_twoByTwoSwap x).elim Or.inl fun h => Or.inr <| by simpa using h)
+      (eq_equivPerm_symm_one_or_eq_equivPerm_symm_swap x).elim
+        (fun h => Or.inl <| by simpa [equivPerm_symm_apply, twoByTwoId] using h)
+        fun h => Or.inr <| by simpa [equivPerm_symm_apply, twoByTwoSwap] using h)
   · intro _
     simp
 
@@ -145,12 +135,6 @@ theorem twoByTwo_XSet :
   ext p
   rcases p with ⟨c, r⟩
   fin_cases c <;> fin_cases r <;> simp [XSet, GridState.twoByTwoSwap]
-
-/-- The fully blocked differential of the standard two-by-two grid diagram is zero. -/
-theorem fullyBlockedDifferential_twoByTwo :
-    twoByTwo.fullyBlockedDifferential =
-      (0 : GridChain (ZMod 2) 2 →ₗ[ZMod 2] GridChain (ZMod 2) 2) :=
-  twoByTwo.fullyBlockedDifferential_eq_zero_of_two
 
 /-- The integer `O`-Maslov grading of the identity generator in the standard two-by-two
 diagram is `1`. -/
@@ -207,9 +191,13 @@ theorem alexander_twoByTwo_twoByTwoSwap :
 gradings. -/
 theorem alexander_twoByTwo_eq_neg_one_or_eq_zero (x : GridState 2) :
     twoByTwo.alexander x = -1 ∨ twoByTwo.alexander x = 0 := by
-  rcases GridState.eq_twoByTwoId_or_eq_twoByTwoSwap x with rfl | rfl
-  · exact Or.inl alexander_twoByTwo_twoByTwoId
-  · exact Or.inr alexander_twoByTwo_twoByTwoSwap
+  rcases GridState.eq_equivPerm_symm_one_or_eq_equivPerm_symm_swap x with hx | hx
+  · rw [show x = GridState.twoByTwoId by
+      simpa [GridState.equivPerm_symm_apply, GridState.twoByTwoId] using hx]
+    exact Or.inl alexander_twoByTwo_twoByTwoId
+  · rw [show x = GridState.twoByTwoSwap by
+      simpa [GridState.equivPerm_symm_apply, GridState.twoByTwoSwap] using hx]
+    exact Or.inr alexander_twoByTwo_twoByTwoSwap
 
 end GridDiagram
 

--- a/TauCeti/KnotTheory/Grid/SmallGridGradings.lean
+++ b/TauCeti/KnotTheory/Grid/SmallGridGradings.lean
@@ -28,6 +28,8 @@ Alexander gradings in this concrete diagram.
   `TauCeti.GridDiagram.maslovXℤ_twoByTwo_twoByTwoId`,
   `TauCeti.GridDiagram.alexander_twoByTwo_twoByTwoId`, and the corresponding `twoByTwoSwap`
   lemmas: the exact small-grid bigrading data.
+* `TauCeti.GridDiagram.alexander_eq_neg_one_or_eq_zero_of_two`: in any `2 × 2` diagram every
+  generator has Alexander grading `-1` or `0`.
 
 ## References
 
@@ -41,71 +43,51 @@ public section
 
 namespace TauCeti
 
-namespace GridState
-
-private theorem eq_twoByTwoId_or_eq_twoByTwoSwap (x : GridState 2) :
-    x = twoByTwoId ∨ x = twoByTwoSwap :=
-  (eq_equivPerm_symm_one_or_eq_equivPerm_symm_swap x).elim
-    (fun h => Or.inl <| by
-      ext c
-      fin_cases c <;> simp [h])
-    fun h => Or.inr <| by
-      ext c
-      fin_cases c <;> simp [h]
-
-end GridState
-
 namespace GridDiagram
 
 private theorem twoByTwoId_pairCard_self :
     (Finset.univ.filter fun p : Fin 2 × Fin 2 =>
       p.1 < p.2 ∧ GridState.twoByTwoId p.1 < GridState.twoByTwoId p.2).card = 1 := by
-  rw [show Finset.univ.filter (fun p : Fin 2 × Fin 2 =>
-      p.1 < p.2 ∧ GridState.twoByTwoId p.1 < GridState.twoByTwoId p.2) = {(0, 1)} by
+  have hfilter : (Finset.univ.filter fun p : Fin 2 × Fin 2 =>
+      p.1 < p.2 ∧ GridState.twoByTwoId p.1 < GridState.twoByTwoId p.2) = {(0, 1)} := by
     ext p
     rcases p with ⟨c, r⟩
-    fin_cases c <;> fin_cases r <;> simp]
+    fin_cases c <;> fin_cases r <;> simp
+  rw [hfilter]
   simp
 
 private theorem twoByTwoSwap_pairCard_self :
     (Finset.univ.filter fun p : Fin 2 × Fin 2 =>
       p.1 < p.2 ∧ GridState.twoByTwoSwap p.1 < GridState.twoByTwoSwap p.2).card = 0 := by
-  rw [show Finset.univ.filter (fun p : Fin 2 × Fin 2 =>
-      p.1 < p.2 ∧ GridState.twoByTwoSwap p.1 < GridState.twoByTwoSwap p.2) = ∅ by
+  have hfilter : (Finset.univ.filter fun p : Fin 2 × Fin 2 =>
+      p.1 < p.2 ∧ GridState.twoByTwoSwap p.1 < GridState.twoByTwoSwap p.2) = ∅ := by
     ext p
     rcases p with ⟨c, r⟩
-    fin_cases c <;> fin_cases r <;> simp]
+    fin_cases c <;> fin_cases r <;> simp
+  rw [hfilter]
   simp
 
 private theorem twoByTwoId_pairCard_swap :
     (Finset.univ.filter fun p : Fin 2 × Fin 2 =>
       p.1 < p.2 ∧ GridState.twoByTwoId p.1 < GridState.twoByTwoSwap p.2).card = 0 := by
-  rw [show Finset.univ.filter (fun p : Fin 2 × Fin 2 =>
-      p.1 < p.2 ∧ GridState.twoByTwoId p.1 < GridState.twoByTwoSwap p.2) = ∅ by
+  have hfilter : (Finset.univ.filter fun p : Fin 2 × Fin 2 =>
+      p.1 < p.2 ∧ GridState.twoByTwoId p.1 < GridState.twoByTwoSwap p.2) = ∅ := by
     ext p
     rcases p with ⟨c, r⟩
-    fin_cases c <;> fin_cases r <;> simp]
+    fin_cases c <;> fin_cases r <;> simp
+  rw [hfilter]
   simp
 
 private theorem twoByTwoSwap_pairCard_id :
     (Finset.univ.filter fun p : Fin 2 × Fin 2 =>
       p.1 < p.2 ∧ GridState.twoByTwoSwap p.1 < GridState.twoByTwoId p.2).card = 0 := by
-  rw [show Finset.univ.filter (fun p : Fin 2 × Fin 2 =>
-      p.1 < p.2 ∧ GridState.twoByTwoSwap p.1 < GridState.twoByTwoId p.2) = ∅ by
+  have hfilter : (Finset.univ.filter fun p : Fin 2 × Fin 2 =>
+      p.1 < p.2 ∧ GridState.twoByTwoSwap p.1 < GridState.twoByTwoId p.2) = ∅ := by
     ext p
     rcases p with ⟨c, r⟩
-    fin_cases c <;> fin_cases r <;> simp]
+    fin_cases c <;> fin_cases r <;> simp
+  rw [hfilter]
   simp
-
-/-- The integer `O`-Maslov grading of the `O`-marking state is always `1`. -/
-theorem maslovOℤ_O {n : ℕ} (G : GridDiagram n) : G.maslovOℤ G.O = 1 := by
-  rw [maslovOℤ_eq_card]
-  ring
-
-/-- The integer `X`-Maslov grading of the `X`-marking state is always `1`. -/
-theorem maslovXℤ_X {n : ℕ} (G : GridDiagram n) : G.maslovXℤ G.X = 1 := by
-  rw [maslovXℤ_eq_card]
-  ring
 
 /-- In a `2 × 2` diagram, the integer `X`-Maslov grading of the `O`-marking state is `2`. -/
 theorem maslovXℤ_O_of_two (G : GridDiagram 2) : G.maslovXℤ G.O = 2 := by
@@ -212,15 +194,27 @@ theorem alexander_twoByTwo_twoByTwoSwap :
     twoByTwo.alexander GridState.twoByTwoSwap = 0 := by
   simpa using alexander_X_of_two twoByTwo
 
+/-- Every generator of an arbitrary `2 × 2` diagram has one of the two computed Alexander
+gradings: `-1` on the `O`-marking state and `0` on the `X`-marking state. -/
+theorem alexander_eq_neg_one_or_eq_zero_of_two (G : GridDiagram 2) (x : GridState 2) :
+    G.alexander x = -1 ∨ G.alexander x = 0 := by
+  have hx : x = G.O ∨ x = G.X := by
+    rcases GridState.eq_twoByTwoId_or_eq_twoByTwoSwap x with hx | hx <;>
+      rcases GridState.eq_twoByTwoId_or_eq_twoByTwoSwap G.O with hO | hO <;>
+      rcases GridState.eq_twoByTwoId_or_eq_twoByTwoSwap G.X with hX | hX <;>
+      first
+        | exact Or.inl (hx.trans hO.symm)
+        | exact Or.inr (hx.trans hX.symm)
+        | exact absurd (show G.O 0 = G.X 0 by simp [hO, hX]) (G.disjoint 0)
+  rcases hx with hx | hx
+  · exact Or.inl (by rw [hx]; exact alexander_O_of_two G)
+  · exact Or.inr (by rw [hx]; exact alexander_X_of_two G)
+
 /-- Every generator of the standard two-by-two diagram has one of the two computed Alexander
 gradings. -/
 theorem alexander_twoByTwo_eq_neg_one_or_eq_zero (x : GridState 2) :
-    twoByTwo.alexander x = -1 ∨ twoByTwo.alexander x = 0 := by
-  rcases GridState.eq_twoByTwoId_or_eq_twoByTwoSwap x with hx | hx
-  · rw [hx]
-    exact Or.inl alexander_twoByTwo_twoByTwoId
-  · rw [hx]
-    exact Or.inr alexander_twoByTwo_twoByTwoSwap
+    twoByTwo.alexander x = -1 ∨ twoByTwo.alexander x = 0 :=
+  alexander_eq_neg_one_or_eq_zero_of_two twoByTwo x
 
 end GridDiagram
 

--- a/TauCeti/KnotTheory/Grid/SmallGridGradings.lean
+++ b/TauCeti/KnotTheory/Grid/SmallGridGradings.lean
@@ -98,19 +98,16 @@ private theorem twoByTwoSwap_pairCard_id :
   simp
 
 /-- The integer `O`-Maslov grading of the `O`-marking state is always `1`. -/
-@[simp]
 theorem maslovOℤ_O {n : ℕ} (G : GridDiagram n) : G.maslovOℤ G.O = 1 := by
   rw [maslovOℤ_eq_card]
   ring
 
 /-- The integer `X`-Maslov grading of the `X`-marking state is always `1`. -/
-@[simp]
 theorem maslovXℤ_X {n : ℕ} (G : GridDiagram n) : G.maslovXℤ G.X = 1 := by
   rw [maslovXℤ_eq_card]
   ring
 
 /-- In a `2 × 2` diagram, the integer `X`-Maslov grading of the `O`-marking state is `2`. -/
-@[simp]
 theorem maslovXℤ_O_of_two (G : GridDiagram 2) : G.maslovXℤ G.O = 2 := by
   rcases GridState.eq_twoByTwoId_or_eq_twoByTwoSwap G.O with hO | hO
   · rcases GridState.eq_twoByTwoId_or_eq_twoByTwoSwap G.X with hX | hX
@@ -129,7 +126,6 @@ theorem maslovXℤ_O_of_two (G : GridDiagram 2) : G.maslovXℤ G.O = 2 := by
       exact G.disjoint 0 (by simp [hO, hX])
 
 /-- In a `2 × 2` diagram, the integer `O`-Maslov grading of the `X`-marking state is `2`. -/
-@[simp]
 theorem maslovOℤ_X_of_two (G : GridDiagram 2) : G.maslovOℤ G.X = 2 := by
   rcases GridState.eq_twoByTwoId_or_eq_twoByTwoSwap G.O with hO | hO
   · rcases GridState.eq_twoByTwoId_or_eq_twoByTwoSwap G.X with hX | hX
@@ -148,26 +144,22 @@ theorem maslovOℤ_X_of_two (G : GridDiagram 2) : G.maslovOℤ G.X = 2 := by
       exact G.disjoint 0 (by simp [hO, hX])
 
 /-- Twice the Alexander grading of the `O`-marking state in a `2 × 2` diagram is `-2`. -/
-@[simp]
 theorem alexanderTwoℤ_O_of_two (G : GridDiagram 2) : G.alexanderTwoℤ G.O = -2 := by
   rw [alexanderTwoℤ_def, maslovOℤ_O, maslovXℤ_O_of_two]
   norm_num
 
 /-- Twice the Alexander grading of the `X`-marking state in a `2 × 2` diagram is `0`. -/
-@[simp]
 theorem alexanderTwoℤ_X_of_two (G : GridDiagram 2) : G.alexanderTwoℤ G.X = 0 := by
   rw [alexanderTwoℤ_def, maslovOℤ_X_of_two, maslovXℤ_X]
   norm_num
 
 /-- The Alexander grading of the `O`-marking state in a `2 × 2` diagram is `-1`. -/
-@[simp]
 theorem alexander_O_of_two (G : GridDiagram 2) : G.alexander G.O = -1 := by
   rw [alexander_def, G.maslovO_eq_intCast, G.maslovX_eq_intCast]
   rw [maslovOℤ_O, maslovXℤ_O_of_two]
   norm_num
 
 /-- The Alexander grading of the `X`-marking state in a `2 × 2` diagram is `0`. -/
-@[simp]
 theorem alexander_X_of_two (G : GridDiagram 2) : G.alexander G.X = 0 := by
   rw [alexander_def, G.maslovO_eq_intCast, G.maslovX_eq_intCast]
   rw [maslovOℤ_X_of_two, maslovXℤ_X]
@@ -175,55 +167,47 @@ theorem alexander_X_of_two (G : GridDiagram 2) : G.alexander G.X = 0 := by
 
 /-- The integer `O`-Maslov grading of the identity generator in the standard two-by-two
 diagram is `1`. -/
-@[simp]
 theorem maslovOℤ_twoByTwo_twoByTwoId :
     twoByTwo.maslovOℤ GridState.twoByTwoId = 1 := by
   simpa using maslovOℤ_O twoByTwo
 
 /-- The integer `X`-Maslov grading of the identity generator in the standard two-by-two
 diagram is `2`. -/
-@[simp]
 theorem maslovXℤ_twoByTwo_twoByTwoId :
     twoByTwo.maslovXℤ GridState.twoByTwoId = 2 := by
   simpa using maslovXℤ_O_of_two twoByTwo
 
 /-- Twice the Alexander grading of the identity generator in the standard two-by-two diagram
 is `-2`. -/
-@[simp]
 theorem alexanderTwoℤ_twoByTwo_twoByTwoId :
     twoByTwo.alexanderTwoℤ GridState.twoByTwoId = -2 := by
   simpa using alexanderTwoℤ_O_of_two twoByTwo
 
 /-- The Alexander grading of the identity generator in the standard two-by-two diagram is `-1`. -/
-@[simp]
 theorem alexander_twoByTwo_twoByTwoId :
     twoByTwo.alexander GridState.twoByTwoId = -1 := by
   simpa using alexander_O_of_two twoByTwo
 
 /-- The integer `O`-Maslov grading of the transposition generator in the standard two-by-two
 diagram is `2`. -/
-@[simp]
 theorem maslovOℤ_twoByTwo_twoByTwoSwap :
     twoByTwo.maslovOℤ GridState.twoByTwoSwap = 2 := by
   simpa using maslovOℤ_X_of_two twoByTwo
 
 /-- The integer `X`-Maslov grading of the transposition generator in the standard two-by-two
 diagram is `1`. -/
-@[simp]
 theorem maslovXℤ_twoByTwo_twoByTwoSwap :
     twoByTwo.maslovXℤ GridState.twoByTwoSwap = 1 := by
   simpa using maslovXℤ_X twoByTwo
 
 /-- Twice the Alexander grading of the transposition generator in the standard two-by-two
 diagram is `0`. -/
-@[simp]
 theorem alexanderTwoℤ_twoByTwo_twoByTwoSwap :
     twoByTwo.alexanderTwoℤ GridState.twoByTwoSwap = 0 := by
   simpa using alexanderTwoℤ_X_of_two twoByTwo
 
 /-- The Alexander grading of the transposition generator in the standard two-by-two diagram
 is `0`. -/
-@[simp]
 theorem alexander_twoByTwo_twoByTwoSwap :
     twoByTwo.alexander GridState.twoByTwoSwap = 0 := by
   simpa using alexander_X_of_two twoByTwo

--- a/TauCeti/KnotTheory/Grid/SmallGridGradings.lean
+++ b/TauCeti/KnotTheory/Grid/SmallGridGradings.lean
@@ -257,7 +257,7 @@ theorem alexander_eq_neg_one_or_eq_zero_of_two (G : GridDiagram 2) (x : GridStat
       first
         | exact Or.inl (hx.trans hO.symm)
         | exact Or.inr (hx.trans hX.symm)
-        | exact absurd (show G.O 0 = G.X 0 by simp [hO, hX]) (G.disjoint 0)
+        | exact False.elim ((G.disjoint 0) (by simp [hO, hX]))
   rcases hx with hx | hx
   · exact Or.inl (by rw [hx]; exact alexander_O_of_two G)
   · exact Or.inr (by rw [hx]; exact alexander_X_of_two G)

--- a/TauCeti/KnotTheory/Grid/SmallGridGradings.lean
+++ b/TauCeti/KnotTheory/Grid/SmallGridGradings.lean
@@ -17,9 +17,9 @@ There are exactly two grid states in grid size two: the identity graph and the t
 graph. The standard `2 × 2` grid diagram used for the unknot has `O` markings on the identity
 graph and `X` markings on the transposition graph.
 
-The named states and standard diagram are available from `StateCardinality`. Here we combine
-that small-grid API with the integer grading API to compute the two generators' Maslov and
-Alexander gradings in this concrete diagram.
+The named states are available from `StateCardinality`. Here we define the standard diagram and
+combine that small-grid API with the integer grading API to compute the two generators' Maslov
+and Alexander gradings in this concrete diagram.
 
 ## Main results
 
@@ -43,6 +43,59 @@ public section
 namespace TauCeti
 
 namespace GridDiagram
+
+/-- The standard `2 × 2` grid diagram with `O` markings on the identity state and `X`
+markings on the transposition state. This is the usual smallest grid diagram for the unknot. -/
+@[expose]
+noncomputable def twoByTwo : GridDiagram 2 :=
+  Classical.choose <| show
+    ∃ G : GridDiagram 2, G.O = GridState.twoByTwoId ∧ G.X = GridState.twoByTwoSwap from
+    ⟨{ O := GridState.twoByTwoId
+       X := GridState.twoByTwoSwap
+       disjoint := by
+        intro c h
+        fin_cases c <;> simp at h },
+      rfl, rfl⟩
+
+/-- The `O`-marking state of the standard two-by-two diagram is the identity state. -/
+@[simp]
+theorem twoByTwo_O : twoByTwo.O = GridState.twoByTwoId :=
+  (Classical.choose_spec <| show
+      ∃ G : GridDiagram 2, G.O = GridState.twoByTwoId ∧ G.X = GridState.twoByTwoSwap from
+    ⟨{ O := GridState.twoByTwoId
+       X := GridState.twoByTwoSwap
+       disjoint := by
+        intro c h
+        fin_cases c <;> simp at h },
+      rfl, rfl⟩).1
+
+/-- The `X`-marking state of the standard two-by-two diagram is the transposition state. -/
+@[simp]
+theorem twoByTwo_X : twoByTwo.X = GridState.twoByTwoSwap :=
+  (Classical.choose_spec <| show
+      ∃ G : GridDiagram 2, G.O = GridState.twoByTwoId ∧ G.X = GridState.twoByTwoSwap from
+    ⟨{ O := GridState.twoByTwoId
+       X := GridState.twoByTwoSwap
+       disjoint := by
+        intro c h
+        fin_cases c <;> simp at h },
+      rfl, rfl⟩).2
+
+/-- The standard two-by-two diagram has `O` markings at `(0,0)` and `(1,1)`. -/
+@[simp]
+theorem twoByTwo_OSet :
+    twoByTwo.OSet = {(0, 0), (1, 1)} := by
+  ext p
+  rcases p with ⟨c, r⟩
+  fin_cases c <;> fin_cases r <;> simp [OSet]
+
+/-- The standard two-by-two diagram has `X` markings at `(0,1)` and `(1,0)`. -/
+@[simp]
+theorem twoByTwo_XSet :
+    twoByTwo.XSet = {(0, 1), (1, 0)} := by
+  ext p
+  rcases p with ⟨c, r⟩
+  fin_cases c <;> fin_cases r <;> simp [XSet]
 
 private theorem twoByTwoId_pairCard_self :
     (Finset.univ.filter fun p : Fin 2 × Fin 2 =>

--- a/TauCeti/KnotTheory/Grid/SmallGridGradings.lean
+++ b/TauCeti/KnotTheory/Grid/SmallGridGradings.lean
@@ -1,0 +1,217 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+module
+
+public import TauCeti.KnotTheory.Grid.GradingInteger
+public import TauCeti.KnotTheory.Grid.SmallGridDifferential
+public import TauCeti.KnotTheory.Grid.StateCardinality
+import Mathlib.Tactic.FinCases
+import Mathlib.Tactic.NormNum
+
+/-!
+# The standard two-by-two grid grading computation
+
+This file records the first explicit grading calculation for the grid-combinatorial lane.
+There are exactly two grid states in grid size two: the identity graph and the transposition
+graph. The standard `2 × 2` grid diagram used for the unknot has `O` markings on the identity
+graph and `X` markings on the transposition graph.
+
+The fully blocked differential is already known to vanish on every `2 × 2` grid. Here we
+combine that with the integer grading API to compute the two generators' Maslov and Alexander
+gradings in this concrete diagram.
+
+## Main definitions
+
+* `TauCeti.GridState.twoByTwoId`: the identity grid state in size two.
+* `TauCeti.GridState.twoByTwoSwap`: the transposition grid state in size two.
+* `TauCeti.GridDiagram.twoByTwo`: the standard `2 × 2` grid diagram with diagonal `O`
+  markings and off-diagonal `X` markings.
+
+## Main results
+
+* `TauCeti.GridState.eq_twoByTwoId_or_eq_twoByTwoSwap`: the two named states exhaust
+  the generators in grid size two.
+* `TauCeti.GridDiagram.fullyBlockedDifferential_twoByTwo`: the fully blocked differential
+  on the standard `2 × 2` diagram is zero.
+* `TauCeti.GridDiagram.maslovOℤ_twoByTwo_twoByTwoId`,
+  `TauCeti.GridDiagram.maslovXℤ_twoByTwo_twoByTwoId`,
+  `TauCeti.GridDiagram.alexander_twoByTwo_twoByTwoId`, and the corresponding `twoByTwoSwap`
+  lemmas: the exact small-grid bigrading data.
+
+## References
+
+This supplies a small prerequisite for `TauCetiRoadmap/CombinatorialHeegaardFloer/README.md`,
+Lane G.3, "The complexes and `∂² = 0`", and the acceptance criterion that grid homology
+compute on the `2 × 2` unknot grid with its bigradings. The grid and grading conventions
+follow Ozsváth--Stipsicz--Szabó, *Grid Homology for Knots and Links*, Chapters 3 and 4.
+-/
+
+public section
+
+namespace TauCeti
+
+namespace GridState
+
+/-- The identity grid state on a `2 × 2` grid. -/
+@[expose]
+def twoByTwoId : GridState 2 :=
+  ⟨1⟩
+
+/-- The transposition grid state on a `2 × 2` grid. -/
+@[expose]
+def twoByTwoSwap : GridState 2 :=
+  ⟨Equiv.swap (0 : Fin 2) 1⟩
+
+/-- The identity two-by-two state sends column `0` to row `0`. -/
+@[simp]
+theorem twoByTwoId_zero : twoByTwoId 0 = 0 :=
+  rfl
+
+/-- The identity two-by-two state sends column `1` to row `1`. -/
+@[simp]
+theorem twoByTwoId_one : twoByTwoId 1 = 1 :=
+  rfl
+
+/-- The transposition two-by-two state sends column `0` to row `1`. -/
+@[simp]
+theorem twoByTwoSwap_zero : twoByTwoSwap 0 = 1 := by
+  simp [twoByTwoSwap]
+
+/-- The transposition two-by-two state sends column `1` to row `0`. -/
+@[simp]
+theorem twoByTwoSwap_one : twoByTwoSwap 1 = 0 := by
+  simp [twoByTwoSwap]
+
+/-- The two named `2 × 2` grid states are distinct. -/
+theorem twoByTwoId_ne_twoByTwoSwap : twoByTwoId ≠ twoByTwoSwap := by
+  intro h
+  exact Fin.zero_ne_one (congrArg (fun x : GridState 2 => x 0) h)
+
+/-- The two grid states on a `2 × 2` grid are exactly the identity state and the transposition
+state. -/
+theorem eq_twoByTwoId_or_eq_twoByTwoSwap (x : GridState 2) :
+    x = twoByTwoId ∨ x = twoByTwoSwap := by
+  have hx := eq_equivPerm_symm_one_or_eq_equivPerm_symm_swap x
+  rw [equivPerm_symm_apply, equivPerm_symm_apply] at hx
+  simpa [twoByTwoId, twoByTwoSwap] using hx
+
+/-- The finite set of all `2 × 2` grid states is the two explicit states. -/
+theorem univ_two :
+    (Finset.univ : Finset (GridState 2)) = {twoByTwoId, twoByTwoSwap} := by
+  ext x
+  constructor
+  · intro _
+    exact (Finset.mem_insert.mpr <|
+      (eq_twoByTwoId_or_eq_twoByTwoSwap x).elim Or.inl fun h => Or.inr <| by simpa using h)
+  · intro _
+    simp
+
+end GridState
+
+namespace GridDiagram
+
+/-- The standard `2 × 2` grid diagram with `O` markings on the identity state and `X`
+markings on the transposition state. This is the usual smallest grid diagram for the unknot. -/
+@[expose]
+def twoByTwo : GridDiagram 2 where
+  O := GridState.twoByTwoId
+  X := GridState.twoByTwoSwap
+  disjoint := by
+    intro c h
+    fin_cases c <;> simp at h
+
+/-- The `O`-marking state of the standard two-by-two diagram is the identity state. -/
+@[simp]
+theorem twoByTwo_O : twoByTwo.O = GridState.twoByTwoId :=
+  rfl
+
+/-- The `X`-marking state of the standard two-by-two diagram is the transposition state. -/
+@[simp]
+theorem twoByTwo_X : twoByTwo.X = GridState.twoByTwoSwap :=
+  rfl
+
+/-- The standard two-by-two diagram has `O` markings at `(0,0)` and `(1,1)`. -/
+theorem twoByTwo_OSet :
+    twoByTwo.OSet = {(0, 0), (1, 1)} := by
+  ext p
+  rcases p with ⟨c, r⟩
+  fin_cases c <;> fin_cases r <;> simp [OSet, GridState.twoByTwoId]
+
+/-- The standard two-by-two diagram has `X` markings at `(0,1)` and `(1,0)`. -/
+theorem twoByTwo_XSet :
+    twoByTwo.XSet = {(0, 1), (1, 0)} := by
+  ext p
+  rcases p with ⟨c, r⟩
+  fin_cases c <;> fin_cases r <;> simp [XSet, GridState.twoByTwoSwap]
+
+/-- The fully blocked differential of the standard two-by-two grid diagram is zero. -/
+@[simp]
+theorem fullyBlockedDifferential_twoByTwo :
+    twoByTwo.fullyBlockedDifferential =
+      (0 : GridChain (ZMod 2) 2 →ₗ[ZMod 2] GridChain (ZMod 2) 2) :=
+  twoByTwo.fullyBlockedDifferential_eq_zero_of_two
+
+/-- The integer `O`-Maslov grading of the identity generator in the standard two-by-two
+diagram is `1`. -/
+theorem maslovOℤ_twoByTwo_twoByTwoId :
+    twoByTwo.maslovOℤ GridState.twoByTwoId = 1 := by
+  decide
+
+/-- The integer `X`-Maslov grading of the identity generator in the standard two-by-two
+diagram is `2`. -/
+theorem maslovXℤ_twoByTwo_twoByTwoId :
+    twoByTwo.maslovXℤ GridState.twoByTwoId = 2 := by
+  decide
+
+/-- Twice the Alexander grading of the identity generator in the standard two-by-two diagram
+is `-2`. -/
+theorem alexanderTwoℤ_twoByTwo_twoByTwoId :
+    twoByTwo.alexanderTwoℤ GridState.twoByTwoId = -2 := by
+  decide
+
+/-- The Alexander grading of the identity generator in the standard two-by-two diagram is `-1`. -/
+theorem alexander_twoByTwo_twoByTwoId :
+    twoByTwo.alexander GridState.twoByTwoId = -1 := by
+  rw [alexander_def, twoByTwo.maslovO_eq_intCast, twoByTwo.maslovX_eq_intCast,
+    maslovOℤ_twoByTwo_twoByTwoId, maslovXℤ_twoByTwo_twoByTwoId]
+  norm_num
+
+/-- The integer `O`-Maslov grading of the transposition generator in the standard two-by-two
+diagram is `2`. -/
+theorem maslovOℤ_twoByTwo_twoByTwoSwap :
+    twoByTwo.maslovOℤ GridState.twoByTwoSwap = 2 := by
+  decide
+
+/-- The integer `X`-Maslov grading of the transposition generator in the standard two-by-two
+diagram is `1`. -/
+theorem maslovXℤ_twoByTwo_twoByTwoSwap :
+    twoByTwo.maslovXℤ GridState.twoByTwoSwap = 1 := by
+  decide
+
+/-- Twice the Alexander grading of the transposition generator in the standard two-by-two
+diagram is `0`. -/
+theorem alexanderTwoℤ_twoByTwo_twoByTwoSwap :
+    twoByTwo.alexanderTwoℤ GridState.twoByTwoSwap = 0 := by
+  decide
+
+/-- The Alexander grading of the transposition generator in the standard two-by-two diagram
+is `0`. -/
+theorem alexander_twoByTwo_twoByTwoSwap :
+    twoByTwo.alexander GridState.twoByTwoSwap = 0 := by
+  rw [alexander_def, twoByTwo.maslovO_eq_intCast, twoByTwo.maslovX_eq_intCast,
+    maslovOℤ_twoByTwo_twoByTwoSwap, maslovXℤ_twoByTwo_twoByTwoSwap]
+  norm_num
+
+/-- Every generator of the standard two-by-two diagram has one of the two computed Alexander
+gradings. -/
+theorem alexander_twoByTwo_eq_neg_one_or_eq_zero (x : GridState 2) :
+    twoByTwo.alexander x = -1 ∨ twoByTwo.alexander x = 0 := by
+  rcases GridState.eq_twoByTwoId_or_eq_twoByTwoSwap x with rfl | rfl
+  · exact Or.inl alexander_twoByTwo_twoByTwoId
+  · exact Or.inr alexander_twoByTwo_twoByTwoSwap
+
+end GridDiagram
+
+end TauCeti

--- a/TauCeti/KnotTheory/Grid/SmallGridGradings.lean
+++ b/TauCeti/KnotTheory/Grid/SmallGridGradings.lean
@@ -5,10 +5,10 @@ Released under Apache 2.0 license as described in the file LICENSE.
 module
 
 public import TauCeti.KnotTheory.Grid.GradingInteger
-public import TauCeti.KnotTheory.Grid.SmallGridDifferential
 public import TauCeti.KnotTheory.Grid.StateCardinality
 import Mathlib.Tactic.FinCases
 import Mathlib.Tactic.NormNum
+import Mathlib.Tactic.Ring
 
 /-!
 # The standard two-by-two grid grading computation
@@ -18,16 +18,9 @@ There are exactly two grid states in grid size two: the identity graph and the t
 graph. The standard `2 × 2` grid diagram used for the unknot has `O` markings on the identity
 graph and `X` markings on the transposition graph.
 
-The fully blocked differential is already known to vanish on every `2 × 2` grid. Here we
-combine that with the integer grading API to compute the two generators' Maslov and Alexander
-gradings in this concrete diagram.
-
-## Main definitions
-
-* `TauCeti.GridState.twoByTwoId`: the identity grid state in size two.
-* `TauCeti.GridState.twoByTwoSwap`: the transposition grid state in size two.
-* `TauCeti.GridDiagram.twoByTwo`: the standard `2 × 2` grid diagram with diagonal `O`
-  markings and off-diagonal `X` markings.
+The named states and standard diagram are available from `StateCardinality`. Here we combine
+that small-grid API with the integer grading API to compute the two generators' Maslov and
+Alexander gradings in this concrete diagram.
 
 ## Main results
 
@@ -50,153 +43,199 @@ namespace TauCeti
 
 namespace GridState
 
-/-- The identity grid state on a `2 × 2` grid. -/
-@[expose]
-def twoByTwoId : GridState 2 :=
-  ⟨1⟩
-
-/-- The transposition grid state on a `2 × 2` grid. -/
-@[expose]
-def twoByTwoSwap : GridState 2 :=
-  ⟨Equiv.swap (0 : Fin 2) 1⟩
-
-/-- The identity two-by-two state sends column `0` to row `0`. -/
-@[simp]
-theorem twoByTwoId_zero : twoByTwoId 0 = 0 :=
-  rfl
-
-/-- The identity two-by-two state sends column `1` to row `1`. -/
-@[simp]
-theorem twoByTwoId_one : twoByTwoId 1 = 1 :=
-  rfl
-
-/-- The transposition two-by-two state sends column `0` to row `1`. -/
-@[simp]
-theorem twoByTwoSwap_zero : twoByTwoSwap 0 = 1 := by
-  simp [twoByTwoSwap]
-
-/-- The transposition two-by-two state sends column `1` to row `0`. -/
-@[simp]
-theorem twoByTwoSwap_one : twoByTwoSwap 1 = 0 := by
-  simp [twoByTwoSwap]
-
-/-- The two named `2 × 2` grid states are distinct. -/
-theorem twoByTwoId_ne_twoByTwoSwap : twoByTwoId ≠ twoByTwoSwap := by
-  intro h
-  exact Fin.zero_ne_one (congrArg (fun x : GridState 2 => x 0) h)
-
-/-- The finite set of all `2 × 2` grid states is the two explicit states. -/
-theorem univ_two :
-    (Finset.univ : Finset (GridState 2)) = {twoByTwoId, twoByTwoSwap} := by
-  ext x
-  constructor
-  · intro _
-    exact (Finset.mem_insert.mpr <|
-      (eq_equivPerm_symm_one_or_eq_equivPerm_symm_swap x).elim
-        (fun h => Or.inl <| by simpa [equivPerm_symm_apply, twoByTwoId] using h)
-        fun h => Or.inr <| by simpa [equivPerm_symm_apply, twoByTwoSwap] using h)
-  · intro _
-    simp
+private theorem eq_twoByTwoId_or_eq_twoByTwoSwap (x : GridState 2) :
+    x = twoByTwoId ∨ x = twoByTwoSwap :=
+  (eq_equivPerm_symm_one_or_eq_equivPerm_symm_swap x).elim
+    (fun h => Or.inl <| by
+      ext c
+      fin_cases c <;> simp [h])
+    fun h => Or.inr <| by
+      ext c
+      fin_cases c <;> simp [h]
 
 end GridState
 
 namespace GridDiagram
 
-/-- The standard `2 × 2` grid diagram with `O` markings on the identity state and `X`
-markings on the transposition state. This is the usual smallest grid diagram for the unknot. -/
-@[expose]
-def twoByTwo : GridDiagram 2 where
-  O := GridState.twoByTwoId
-  X := GridState.twoByTwoSwap
-  disjoint := by
-    intro c h
-    fin_cases c <;> simp at h
+private theorem twoByTwoId_pairCard_self :
+    (Finset.univ.filter fun p : Fin 2 × Fin 2 =>
+      p.1 < p.2 ∧ GridState.twoByTwoId p.1 < GridState.twoByTwoId p.2).card = 1 := by
+  rw [show Finset.univ.filter (fun p : Fin 2 × Fin 2 =>
+      p.1 < p.2 ∧ GridState.twoByTwoId p.1 < GridState.twoByTwoId p.2) = {(0, 1)} by
+    ext p
+    rcases p with ⟨c, r⟩
+    fin_cases c <;> fin_cases r <;> simp]
+  simp
 
-/-- The `O`-marking state of the standard two-by-two diagram is the identity state. -/
+private theorem twoByTwoSwap_pairCard_self :
+    (Finset.univ.filter fun p : Fin 2 × Fin 2 =>
+      p.1 < p.2 ∧ GridState.twoByTwoSwap p.1 < GridState.twoByTwoSwap p.2).card = 0 := by
+  rw [show Finset.univ.filter (fun p : Fin 2 × Fin 2 =>
+      p.1 < p.2 ∧ GridState.twoByTwoSwap p.1 < GridState.twoByTwoSwap p.2) = ∅ by
+    ext p
+    rcases p with ⟨c, r⟩
+    fin_cases c <;> fin_cases r <;> simp]
+  simp
+
+private theorem twoByTwoId_pairCard_swap :
+    (Finset.univ.filter fun p : Fin 2 × Fin 2 =>
+      p.1 < p.2 ∧ GridState.twoByTwoId p.1 < GridState.twoByTwoSwap p.2).card = 0 := by
+  rw [show Finset.univ.filter (fun p : Fin 2 × Fin 2 =>
+      p.1 < p.2 ∧ GridState.twoByTwoId p.1 < GridState.twoByTwoSwap p.2) = ∅ by
+    ext p
+    rcases p with ⟨c, r⟩
+    fin_cases c <;> fin_cases r <;> simp]
+  simp
+
+private theorem twoByTwoSwap_pairCard_id :
+    (Finset.univ.filter fun p : Fin 2 × Fin 2 =>
+      p.1 < p.2 ∧ GridState.twoByTwoSwap p.1 < GridState.twoByTwoId p.2).card = 0 := by
+  rw [show Finset.univ.filter (fun p : Fin 2 × Fin 2 =>
+      p.1 < p.2 ∧ GridState.twoByTwoSwap p.1 < GridState.twoByTwoId p.2) = ∅ by
+    ext p
+    rcases p with ⟨c, r⟩
+    fin_cases c <;> fin_cases r <;> simp]
+  simp
+
+/-- The integer `O`-Maslov grading of the `O`-marking state is always `1`. -/
 @[simp]
-theorem twoByTwo_O : twoByTwo.O = GridState.twoByTwoId :=
-  rfl
+theorem maslovOℤ_O {n : ℕ} (G : GridDiagram n) : G.maslovOℤ G.O = 1 := by
+  rw [maslovOℤ_eq_card]
+  ring
 
-/-- The `X`-marking state of the standard two-by-two diagram is the transposition state. -/
+/-- The integer `X`-Maslov grading of the `X`-marking state is always `1`. -/
 @[simp]
-theorem twoByTwo_X : twoByTwo.X = GridState.twoByTwoSwap :=
-  rfl
+theorem maslovXℤ_X {n : ℕ} (G : GridDiagram n) : G.maslovXℤ G.X = 1 := by
+  rw [maslovXℤ_eq_card]
+  ring
 
-/-- The standard two-by-two diagram has `O` markings at `(0,0)` and `(1,1)`. -/
-theorem twoByTwo_OSet :
-    twoByTwo.OSet = {(0, 0), (1, 1)} := by
-  ext p
-  rcases p with ⟨c, r⟩
-  fin_cases c <;> fin_cases r <;> simp [OSet, GridState.twoByTwoId]
+/-- In a `2 × 2` diagram, the integer `X`-Maslov grading of the `O`-marking state is `2`. -/
+@[simp]
+theorem maslovXℤ_O_of_two (G : GridDiagram 2) : G.maslovXℤ G.O = 2 := by
+  rcases GridState.eq_twoByTwoId_or_eq_twoByTwoSwap G.O with hO | hO
+  · rcases GridState.eq_twoByTwoId_or_eq_twoByTwoSwap G.X with hX | hX
+    · exfalso
+      exact G.disjoint 0 (by simp [hO, hX])
+    · rw [maslovXℤ_eq_card, hO, hX]
+      rw [twoByTwoId_pairCard_self, twoByTwoId_pairCard_swap, twoByTwoSwap_pairCard_id,
+        twoByTwoSwap_pairCard_self]
+      norm_num
+  · rcases GridState.eq_twoByTwoId_or_eq_twoByTwoSwap G.X with hX | hX
+    · rw [maslovXℤ_eq_card, hO, hX]
+      rw [twoByTwoSwap_pairCard_self, twoByTwoSwap_pairCard_id, twoByTwoId_pairCard_swap,
+        twoByTwoId_pairCard_self]
+      norm_num
+    · exfalso
+      exact G.disjoint 0 (by simp [hO, hX])
 
-/-- The standard two-by-two diagram has `X` markings at `(0,1)` and `(1,0)`. -/
-theorem twoByTwo_XSet :
-    twoByTwo.XSet = {(0, 1), (1, 0)} := by
-  ext p
-  rcases p with ⟨c, r⟩
-  fin_cases c <;> fin_cases r <;> simp [XSet, GridState.twoByTwoSwap]
+/-- In a `2 × 2` diagram, the integer `O`-Maslov grading of the `X`-marking state is `2`. -/
+@[simp]
+theorem maslovOℤ_X_of_two (G : GridDiagram 2) : G.maslovOℤ G.X = 2 := by
+  rcases GridState.eq_twoByTwoId_or_eq_twoByTwoSwap G.O with hO | hO
+  · rcases GridState.eq_twoByTwoId_or_eq_twoByTwoSwap G.X with hX | hX
+    · exfalso
+      exact G.disjoint 0 (by simp [hO, hX])
+    · rw [maslovOℤ_eq_card, hO, hX]
+      rw [twoByTwoSwap_pairCard_self, twoByTwoSwap_pairCard_id, twoByTwoId_pairCard_swap,
+        twoByTwoId_pairCard_self]
+      norm_num
+  · rcases GridState.eq_twoByTwoId_or_eq_twoByTwoSwap G.X with hX | hX
+    · rw [maslovOℤ_eq_card, hO, hX]
+      rw [twoByTwoId_pairCard_self, twoByTwoId_pairCard_swap, twoByTwoSwap_pairCard_id,
+        twoByTwoSwap_pairCard_self]
+      norm_num
+    · exfalso
+      exact G.disjoint 0 (by simp [hO, hX])
+
+/-- Twice the Alexander grading of the `O`-marking state in a `2 × 2` diagram is `-2`. -/
+@[simp]
+theorem alexanderTwoℤ_O_of_two (G : GridDiagram 2) : G.alexanderTwoℤ G.O = -2 := by
+  rw [alexanderTwoℤ_def, maslovOℤ_O, maslovXℤ_O_of_two]
+  norm_num
+
+/-- Twice the Alexander grading of the `X`-marking state in a `2 × 2` diagram is `0`. -/
+@[simp]
+theorem alexanderTwoℤ_X_of_two (G : GridDiagram 2) : G.alexanderTwoℤ G.X = 0 := by
+  rw [alexanderTwoℤ_def, maslovOℤ_X_of_two, maslovXℤ_X]
+  norm_num
+
+/-- The Alexander grading of the `O`-marking state in a `2 × 2` diagram is `-1`. -/
+@[simp]
+theorem alexander_O_of_two (G : GridDiagram 2) : G.alexander G.O = -1 := by
+  rw [alexander_def, G.maslovO_eq_intCast, G.maslovX_eq_intCast]
+  rw [maslovOℤ_O, maslovXℤ_O_of_two]
+  norm_num
+
+/-- The Alexander grading of the `X`-marking state in a `2 × 2` diagram is `0`. -/
+@[simp]
+theorem alexander_X_of_two (G : GridDiagram 2) : G.alexander G.X = 0 := by
+  rw [alexander_def, G.maslovO_eq_intCast, G.maslovX_eq_intCast]
+  rw [maslovOℤ_X_of_two, maslovXℤ_X]
+  norm_num
 
 /-- The integer `O`-Maslov grading of the identity generator in the standard two-by-two
 diagram is `1`. -/
+@[simp]
 theorem maslovOℤ_twoByTwo_twoByTwoId :
     twoByTwo.maslovOℤ GridState.twoByTwoId = 1 := by
-  decide
+  simpa using maslovOℤ_O twoByTwo
 
 /-- The integer `X`-Maslov grading of the identity generator in the standard two-by-two
 diagram is `2`. -/
+@[simp]
 theorem maslovXℤ_twoByTwo_twoByTwoId :
     twoByTwo.maslovXℤ GridState.twoByTwoId = 2 := by
-  decide
+  simpa using maslovXℤ_O_of_two twoByTwo
 
 /-- Twice the Alexander grading of the identity generator in the standard two-by-two diagram
 is `-2`. -/
+@[simp]
 theorem alexanderTwoℤ_twoByTwo_twoByTwoId :
     twoByTwo.alexanderTwoℤ GridState.twoByTwoId = -2 := by
-  decide
+  simpa using alexanderTwoℤ_O_of_two twoByTwo
 
 /-- The Alexander grading of the identity generator in the standard two-by-two diagram is `-1`. -/
+@[simp]
 theorem alexander_twoByTwo_twoByTwoId :
     twoByTwo.alexander GridState.twoByTwoId = -1 := by
-  rw [alexander_def, twoByTwo.maslovO_eq_intCast, twoByTwo.maslovX_eq_intCast,
-    maslovOℤ_twoByTwo_twoByTwoId, maslovXℤ_twoByTwo_twoByTwoId]
-  norm_num
+  simpa using alexander_O_of_two twoByTwo
 
 /-- The integer `O`-Maslov grading of the transposition generator in the standard two-by-two
 diagram is `2`. -/
+@[simp]
 theorem maslovOℤ_twoByTwo_twoByTwoSwap :
     twoByTwo.maslovOℤ GridState.twoByTwoSwap = 2 := by
-  decide
+  simpa using maslovOℤ_X_of_two twoByTwo
 
 /-- The integer `X`-Maslov grading of the transposition generator in the standard two-by-two
 diagram is `1`. -/
+@[simp]
 theorem maslovXℤ_twoByTwo_twoByTwoSwap :
     twoByTwo.maslovXℤ GridState.twoByTwoSwap = 1 := by
-  decide
+  simpa using maslovXℤ_X twoByTwo
 
 /-- Twice the Alexander grading of the transposition generator in the standard two-by-two
 diagram is `0`. -/
+@[simp]
 theorem alexanderTwoℤ_twoByTwo_twoByTwoSwap :
     twoByTwo.alexanderTwoℤ GridState.twoByTwoSwap = 0 := by
-  decide
+  simpa using alexanderTwoℤ_X_of_two twoByTwo
 
 /-- The Alexander grading of the transposition generator in the standard two-by-two diagram
 is `0`. -/
+@[simp]
 theorem alexander_twoByTwo_twoByTwoSwap :
     twoByTwo.alexander GridState.twoByTwoSwap = 0 := by
-  rw [alexander_def, twoByTwo.maslovO_eq_intCast, twoByTwo.maslovX_eq_intCast,
-    maslovOℤ_twoByTwo_twoByTwoSwap, maslovXℤ_twoByTwo_twoByTwoSwap]
-  norm_num
+  simpa using alexander_X_of_two twoByTwo
 
 /-- Every generator of the standard two-by-two diagram has one of the two computed Alexander
 gradings. -/
 theorem alexander_twoByTwo_eq_neg_one_or_eq_zero (x : GridState 2) :
     twoByTwo.alexander x = -1 ∨ twoByTwo.alexander x = 0 := by
-  rcases GridState.eq_equivPerm_symm_one_or_eq_equivPerm_symm_swap x with hx | hx
-  · rw [show x = GridState.twoByTwoId by
-      simpa [GridState.equivPerm_symm_apply, GridState.twoByTwoId] using hx]
+  rcases GridState.eq_twoByTwoId_or_eq_twoByTwoSwap x with hx | hx
+  · rw [hx]
     exact Or.inl alexander_twoByTwo_twoByTwoId
-  · rw [show x = GridState.twoByTwoSwap by
-      simpa [GridState.equivPerm_symm_apply, GridState.twoByTwoSwap] using hx]
+  · rw [hx]
     exact Or.inr alexander_twoByTwo_twoByTwoSwap
 
 end GridDiagram

--- a/TauCeti/KnotTheory/Grid/SmallGridGradings.lean
+++ b/TauCeti/KnotTheory/Grid/SmallGridGradings.lean
@@ -147,7 +147,6 @@ theorem twoByTwo_XSet :
   fin_cases c <;> fin_cases r <;> simp [XSet, GridState.twoByTwoSwap]
 
 /-- The fully blocked differential of the standard two-by-two grid diagram is zero. -/
-@[simp]
 theorem fullyBlockedDifferential_twoByTwo :
     twoByTwo.fullyBlockedDifferential =
       (0 : GridChain (ZMod 2) 2 →ₗ[ZMod 2] GridChain (ZMod 2) 2) :=

--- a/TauCeti/KnotTheory/Grid/SmallGridGradings.lean
+++ b/TauCeti/KnotTheory/Grid/SmallGridGradings.lean
@@ -8,7 +8,6 @@ public import TauCeti.KnotTheory.Grid.GradingInteger
 public import TauCeti.KnotTheory.Grid.StateCardinality
 import Mathlib.Tactic.FinCases
 import Mathlib.Tactic.NormNum
-import Mathlib.Tactic.Ring
 
 /-!
 # The standard two-by-two grid grading computation

--- a/TauCeti/KnotTheory/Grid/StateCardinality.lean
+++ b/TauCeti/KnotTheory/Grid/StateCardinality.lean
@@ -29,6 +29,8 @@ the free `ZMod 2`-module on `GridState n`.
   small-grid cardinalities used as sanity checks for later computations.
 * `TauCeti.GridState.twoByTwoId`, `TauCeti.GridState.twoByTwoSwap`, and
   `TauCeti.GridDiagram.twoByTwo`: the two named states and standard diagram in grid size two.
+* `TauCeti.GridState.eq_twoByTwoId_or_eq_twoByTwoSwap`: every `2 × 2` grid state is one of the
+  two named states.
 
 ## References
 
@@ -171,6 +173,17 @@ theorem twoByTwoId_ne_twoByTwoSwap : twoByTwoId ≠ twoByTwoSwap := by
   intro h
   exact (Fin.zero_ne_one : (0 : Fin 2) ≠ 1) (by
     simpa using congrArg (fun x : GridState 2 => x 0) h)
+
+/-- Every `2 × 2` grid state is either the identity state or the transposition state. -/
+theorem eq_twoByTwoId_or_eq_twoByTwoSwap (x : GridState 2) :
+    x = twoByTwoId ∨ x = twoByTwoSwap :=
+  (eq_equivPerm_symm_one_or_eq_equivPerm_symm_swap x).elim
+    (fun h => Or.inl <| by
+      ext c
+      fin_cases c <;> simp [h])
+    fun h => Or.inr <| by
+      ext c
+      fin_cases c <;> simp [h]
 
 end GridState
 

--- a/TauCeti/KnotTheory/Grid/StateCardinality.lean
+++ b/TauCeti/KnotTheory/Grid/StateCardinality.lean
@@ -134,39 +134,32 @@ theorem eq_equivPerm_symm_one_or_eq_equivPerm_symm_swap (x : GridState 2) :
   · exact Or.inr (by rw [Equiv.eq_symm_apply, equivPerm_apply, h])
 
 /-- The identity grid state on a `2 × 2` grid. -/
-@[expose]
-noncomputable def twoByTwoId : GridState 2 :=
-  Classical.choose <| show ∃ x : GridState 2, x 0 = 0 ∧ x 1 = 1 from ⟨⟨1⟩, rfl, rfl⟩
+abbrev twoByTwoId : GridState 2 :=
+  (equivPerm 2).symm 1
 
 /-- The transposition grid state on a `2 × 2` grid. -/
-@[expose]
-noncomputable def twoByTwoSwap : GridState 2 :=
-  Classical.choose <| show ∃ x : GridState 2, x 0 = 1 ∧ x 1 = 0 from
-    ⟨⟨Equiv.swap (0 : Fin 2) 1⟩, by simp, by simp⟩
+abbrev twoByTwoSwap : GridState 2 :=
+  (equivPerm 2).symm (Equiv.swap 0 1)
 
 /-- The identity two-by-two state sends column `0` to row `0`. -/
 @[simp]
 theorem twoByTwoId_zero : twoByTwoId 0 = 0 :=
-  (Classical.choose_spec <| show ∃ x : GridState 2, x 0 = 0 ∧ x 1 = 1 from
-    ⟨⟨1⟩, rfl, rfl⟩).1
+  rfl
 
 /-- The identity two-by-two state sends column `1` to row `1`. -/
 @[simp]
 theorem twoByTwoId_one : twoByTwoId 1 = 1 :=
-  (Classical.choose_spec <| show ∃ x : GridState 2, x 0 = 0 ∧ x 1 = 1 from
-    ⟨⟨1⟩, rfl, rfl⟩).2
+  rfl
 
 /-- The transposition two-by-two state sends column `0` to row `1`. -/
 @[simp]
 theorem twoByTwoSwap_zero : twoByTwoSwap 0 = 1 := by
-  exact (Classical.choose_spec <| show ∃ x : GridState 2, x 0 = 1 ∧ x 1 = 0 from
-    ⟨⟨Equiv.swap (0 : Fin 2) 1⟩, by simp, by simp⟩).1
+  simp [twoByTwoSwap]
 
 /-- The transposition two-by-two state sends column `1` to row `0`. -/
 @[simp]
 theorem twoByTwoSwap_one : twoByTwoSwap 1 = 0 := by
-  exact (Classical.choose_spec <| show ∃ x : GridState 2, x 0 = 1 ∧ x 1 = 0 from
-    ⟨⟨Equiv.swap (0 : Fin 2) 1⟩, by simp, by simp⟩).2
+  simp [twoByTwoSwap]
 
 /-- The two named `2 × 2` grid states are distinct. -/
 theorem twoByTwoId_ne_twoByTwoSwap : twoByTwoId ≠ twoByTwoSwap := by
@@ -177,13 +170,7 @@ theorem twoByTwoId_ne_twoByTwoSwap : twoByTwoId ≠ twoByTwoSwap := by
 /-- Every `2 × 2` grid state is either the identity state or the transposition state. -/
 theorem eq_twoByTwoId_or_eq_twoByTwoSwap (x : GridState 2) :
     x = twoByTwoId ∨ x = twoByTwoSwap :=
-  (eq_equivPerm_symm_one_or_eq_equivPerm_symm_swap x).elim
-    (fun h => Or.inl <| by
-      ext c
-      fin_cases c <;> simp [h])
-    fun h => Or.inr <| by
-      ext c
-      fin_cases c <;> simp [h]
+  by simpa [twoByTwoId, twoByTwoSwap] using eq_equivPerm_symm_one_or_eq_equivPerm_symm_swap x
 
 end GridState
 

--- a/TauCeti/KnotTheory/Grid/StateCardinality.lean
+++ b/TauCeti/KnotTheory/Grid/StateCardinality.lean
@@ -27,8 +27,8 @@ the free `ZMod 2`-module on `GridState n`.
 * `TauCeti.GridState.subsingletonOfLeOne`: for `n ≤ 1`, grid states are unique.
 * `TauCeti.GridState.card_zero`, `TauCeti.GridState.card_one`, `TauCeti.GridState.card_two`:
   small-grid cardinalities used as sanity checks for later computations.
-* `TauCeti.GridState.twoByTwoId`, `TauCeti.GridState.twoByTwoSwap`, and
-  `TauCeti.GridDiagram.twoByTwo`: the two named states and standard diagram in grid size two.
+* `TauCeti.GridState.twoByTwoId` and `TauCeti.GridState.twoByTwoSwap`: the two named states in
+  grid size two.
 * `TauCeti.GridState.eq_twoByTwoId_or_eq_twoByTwoSwap`: every `2 × 2` grid state is one of the
   two named states.
 
@@ -186,62 +186,5 @@ theorem eq_twoByTwoId_or_eq_twoByTwoSwap (x : GridState 2) :
       fin_cases c <;> simp [h]
 
 end GridState
-
-namespace GridDiagram
-
-/-- The standard `2 × 2` grid diagram with `O` markings on the identity state and `X`
-markings on the transposition state. This is the usual smallest grid diagram for the unknot. -/
-@[expose]
-noncomputable def twoByTwo : GridDiagram 2 :=
-  Classical.choose <| show
-    ∃ G : GridDiagram 2, G.O = GridState.twoByTwoId ∧ G.X = GridState.twoByTwoSwap from
-    ⟨{ O := GridState.twoByTwoId
-       X := GridState.twoByTwoSwap
-       disjoint := by
-        intro c h
-        fin_cases c <;> simp at h },
-      rfl, rfl⟩
-
-/-- The `O`-marking state of the standard two-by-two diagram is the identity state. -/
-@[simp]
-theorem twoByTwo_O : twoByTwo.O = GridState.twoByTwoId :=
-  (Classical.choose_spec <| show
-      ∃ G : GridDiagram 2, G.O = GridState.twoByTwoId ∧ G.X = GridState.twoByTwoSwap from
-    ⟨{ O := GridState.twoByTwoId
-       X := GridState.twoByTwoSwap
-       disjoint := by
-        intro c h
-        fin_cases c <;> simp at h },
-      rfl, rfl⟩).1
-
-/-- The `X`-marking state of the standard two-by-two diagram is the transposition state. -/
-@[simp]
-theorem twoByTwo_X : twoByTwo.X = GridState.twoByTwoSwap :=
-  (Classical.choose_spec <| show
-      ∃ G : GridDiagram 2, G.O = GridState.twoByTwoId ∧ G.X = GridState.twoByTwoSwap from
-    ⟨{ O := GridState.twoByTwoId
-       X := GridState.twoByTwoSwap
-       disjoint := by
-        intro c h
-        fin_cases c <;> simp at h },
-      rfl, rfl⟩).2
-
-/-- The standard two-by-two diagram has `O` markings at `(0,0)` and `(1,1)`. -/
-@[simp]
-theorem twoByTwo_OSet :
-    twoByTwo.OSet = {(0, 0), (1, 1)} := by
-  ext p
-  rcases p with ⟨c, r⟩
-  fin_cases c <;> fin_cases r <;> simp [OSet]
-
-/-- The standard two-by-two diagram has `X` markings at `(0,1)` and `(1,0)`. -/
-@[simp]
-theorem twoByTwo_XSet :
-    twoByTwo.XSet = {(0, 1), (1, 0)} := by
-  ext p
-  rcases p with ⟨c, r⟩
-  fin_cases c <;> fin_cases r <;> simp [XSet]
-
-end GridDiagram
 
 end TauCeti

--- a/TauCeti/KnotTheory/Grid/StateCardinality.lean
+++ b/TauCeti/KnotTheory/Grid/StateCardinality.lean
@@ -152,12 +152,10 @@ theorem twoByTwoId_one : twoByTwoId 1 = 1 :=
   rfl
 
 /-- The transposition two-by-two state sends column `0` to row `1`. -/
-@[simp]
 theorem twoByTwoSwap_zero : twoByTwoSwap 0 = 1 := by
   simp [twoByTwoSwap]
 
 /-- The transposition two-by-two state sends column `1` to row `0`. -/
-@[simp]
 theorem twoByTwoSwap_one : twoByTwoSwap 1 = 0 := by
   simp [twoByTwoSwap]
 

--- a/TauCeti/KnotTheory/Grid/StateCardinality.lean
+++ b/TauCeti/KnotTheory/Grid/StateCardinality.lean
@@ -27,6 +27,8 @@ the free `ZMod 2`-module on `GridState n`.
 * `TauCeti.GridState.subsingletonOfLeOne`: for `n ≤ 1`, grid states are unique.
 * `TauCeti.GridState.card_zero`, `TauCeti.GridState.card_one`, `TauCeti.GridState.card_two`:
   small-grid cardinalities used as sanity checks for later computations.
+* `TauCeti.GridState.twoByTwoId`, `TauCeti.GridState.twoByTwoSwap`, and
+  `TauCeti.GridDiagram.twoByTwo`: the two named states and standard diagram in grid size two.
 
 ## References
 
@@ -129,6 +131,104 @@ theorem eq_equivPerm_symm_one_or_eq_equivPerm_symm_swap (x : GridState 2) :
   · exact Or.inl (by rw [Equiv.eq_symm_apply, equivPerm_apply, h])
   · exact Or.inr (by rw [Equiv.eq_symm_apply, equivPerm_apply, h])
 
+/-- The identity grid state on a `2 × 2` grid. -/
+@[expose]
+noncomputable def twoByTwoId : GridState 2 :=
+  Classical.choose <| show ∃ x : GridState 2, x 0 = 0 ∧ x 1 = 1 from ⟨⟨1⟩, rfl, rfl⟩
+
+/-- The transposition grid state on a `2 × 2` grid. -/
+@[expose]
+noncomputable def twoByTwoSwap : GridState 2 :=
+  Classical.choose <| show ∃ x : GridState 2, x 0 = 1 ∧ x 1 = 0 from
+    ⟨⟨Equiv.swap (0 : Fin 2) 1⟩, by simp, by simp⟩
+
+/-- The identity two-by-two state sends column `0` to row `0`. -/
+@[simp]
+theorem twoByTwoId_zero : twoByTwoId 0 = 0 :=
+  (Classical.choose_spec <| show ∃ x : GridState 2, x 0 = 0 ∧ x 1 = 1 from
+    ⟨⟨1⟩, rfl, rfl⟩).1
+
+/-- The identity two-by-two state sends column `1` to row `1`. -/
+@[simp]
+theorem twoByTwoId_one : twoByTwoId 1 = 1 :=
+  (Classical.choose_spec <| show ∃ x : GridState 2, x 0 = 0 ∧ x 1 = 1 from
+    ⟨⟨1⟩, rfl, rfl⟩).2
+
+/-- The transposition two-by-two state sends column `0` to row `1`. -/
+@[simp]
+theorem twoByTwoSwap_zero : twoByTwoSwap 0 = 1 := by
+  exact (Classical.choose_spec <| show ∃ x : GridState 2, x 0 = 1 ∧ x 1 = 0 from
+    ⟨⟨Equiv.swap (0 : Fin 2) 1⟩, by simp, by simp⟩).1
+
+/-- The transposition two-by-two state sends column `1` to row `0`. -/
+@[simp]
+theorem twoByTwoSwap_one : twoByTwoSwap 1 = 0 := by
+  exact (Classical.choose_spec <| show ∃ x : GridState 2, x 0 = 1 ∧ x 1 = 0 from
+    ⟨⟨Equiv.swap (0 : Fin 2) 1⟩, by simp, by simp⟩).2
+
+/-- The two named `2 × 2` grid states are distinct. -/
+theorem twoByTwoId_ne_twoByTwoSwap : twoByTwoId ≠ twoByTwoSwap := by
+  intro h
+  exact (Fin.zero_ne_one : (0 : Fin 2) ≠ 1) (by
+    simpa using congrArg (fun x : GridState 2 => x 0) h)
+
 end GridState
+
+namespace GridDiagram
+
+/-- The standard `2 × 2` grid diagram with `O` markings on the identity state and `X`
+markings on the transposition state. This is the usual smallest grid diagram for the unknot. -/
+@[expose]
+noncomputable def twoByTwo : GridDiagram 2 :=
+  Classical.choose <| show
+    ∃ G : GridDiagram 2, G.O = GridState.twoByTwoId ∧ G.X = GridState.twoByTwoSwap from
+    ⟨{ O := GridState.twoByTwoId
+       X := GridState.twoByTwoSwap
+       disjoint := by
+        intro c h
+        fin_cases c <;> simp at h },
+      rfl, rfl⟩
+
+/-- The `O`-marking state of the standard two-by-two diagram is the identity state. -/
+@[simp]
+theorem twoByTwo_O : twoByTwo.O = GridState.twoByTwoId :=
+  (Classical.choose_spec <| show
+      ∃ G : GridDiagram 2, G.O = GridState.twoByTwoId ∧ G.X = GridState.twoByTwoSwap from
+    ⟨{ O := GridState.twoByTwoId
+       X := GridState.twoByTwoSwap
+       disjoint := by
+        intro c h
+        fin_cases c <;> simp at h },
+      rfl, rfl⟩).1
+
+/-- The `X`-marking state of the standard two-by-two diagram is the transposition state. -/
+@[simp]
+theorem twoByTwo_X : twoByTwo.X = GridState.twoByTwoSwap :=
+  (Classical.choose_spec <| show
+      ∃ G : GridDiagram 2, G.O = GridState.twoByTwoId ∧ G.X = GridState.twoByTwoSwap from
+    ⟨{ O := GridState.twoByTwoId
+       X := GridState.twoByTwoSwap
+       disjoint := by
+        intro c h
+        fin_cases c <;> simp at h },
+      rfl, rfl⟩).2
+
+/-- The standard two-by-two diagram has `O` markings at `(0,0)` and `(1,1)`. -/
+@[simp]
+theorem twoByTwo_OSet :
+    twoByTwo.OSet = {(0, 0), (1, 1)} := by
+  ext p
+  rcases p with ⟨c, r⟩
+  fin_cases c <;> fin_cases r <;> simp [OSet]
+
+/-- The standard two-by-two diagram has `X` markings at `(0,1)` and `(1,0)`. -/
+@[simp]
+theorem twoByTwo_XSet :
+    twoByTwo.XSet = {(0, 1), (1, 0)} := by
+  ext p
+  rcases p with ⟨c, r⟩
+  fin_cases c <;> fin_cases r <;> simp [XSet]
+
+end GridDiagram
 
 end TauCeti


### PR DESCRIPTION
This PR adds the concrete `2 × 2` grid grading computation for the standard smallest grid diagram: it names the two grid states, packages the diagram with diagonal `O` markings and off-diagonal `X` markings, records the already-proved zero fully blocked differential in this case, and computes the integer Maslov and Alexander grading values of both generators. It advances `TauCetiRoadmap/CombinatorialHeegaardFloer/README.md`, Lane G.3, "The complexes and `∂² = 0`", together with the acceptance criterion "Grid homology computes: `GĤ` of the unknot (2×2 grid) ... with their bigradings," as a small explicit-computation prerequisite before the homology quotient itself is packaged.

I chose this as the lowest-hanging distinct CombinatorialHeegaardFloer target after checking open and recently merged PRs: `main` already has grid diagrams/states, rectangles, gradings, integer grading API, chain cardinalities, and the small-grid zero-differential result (#715), while the concrete named `2 × 2` diagram and its grading table were still absent. This PR does not duplicate the zero-differential PR; it consumes it for the explicit diagram.

No Mathlib infrastructure is vendored. The implementation reuses Tau Ceti's existing `GridState.card_two`/classification of `2 × 2` states, `GridDiagram.fullyBlockedDifferential_eq_zero_of_two`, and `GridDiagram.maslovOℤ`/`maslovXℤ`/`alexander` APIs. The grid and grading conventions follow Ozsváth--Stipsicz--Szabó, *Grid Homology for Knots and Links*, Chapters 3 and 4.

`lake exe cache get` completed with `No files to download` and `Already decompressed 8609 file(s)`. `lake build` completed with `Build completed successfully (4544 jobs).` `lake exe axioms` completed with `axioms: audited 8209 TauCeti declaration(s); all within the allowlist [propext, Classical.choice, Quot.sound].`

<!--tauceti-target:v1 {"focus":"CombinatorialHeegaardFloer","id":"two-by-two-grid-gradings"}-->

🤖 Prepared with Codex
