### PR TITLE
feat: add the Wirtinger energy inequality for the standard complex line

### DIFF
--- a/TauCeti/Geometry/Symplectic/CompatibleMetric.lean
+++ b/TauCeti/Geometry/Symplectic/CompatibleMetric.lean
@@ -34,6 +34,8 @@ against exactly this metric.
   `g(J v, J w) = g(v, w)`.
 * `TauCeti.SymplecticForm.Invariant.associatedBilinForm_skewAdjoint`: `J` is `g`-skew-adjoint,
   `g(J v, w) = -g(v, J w)`.
+* `TauCeti.SymplecticForm.Invariant.associatedBilinForm_add_apply_self`: the symmetric
+  polarization identity for `g(a + J b, a + J b)`.
 * `TauCeti.SymplecticForm.Compatible.associatedBilinForm_nondegenerate`: the metric is
   nondegenerate.
 * `TauCeti.SymplecticForm.Compatible.innerProductCore`: the metric of a compatible pair as an
@@ -86,6 +88,19 @@ lemma associatedBilinForm_invariant (hinv : ω.Invariant J) (v w : V) :
 lemma associatedBilinForm_skewAdjoint (hinv : ω.Invariant J) (v w : V) :
     ω.associatedBilinForm J (J v) w = -ω.associatedBilinForm J v (J w) := by
   rw [hinv.associatedBilinForm_apply_left_apply, associatedBilinForm_apply_right_apply, neg_neg]
+
+/-- The polarization identity for the associated metric of a `J`-invariant form:
+`g(a + J b, a + J b) = g(a, a) + g(b, b) - 2 ω(a, b)`, where
+`g = ω.associatedBilinForm J`. -/
+lemma associatedBilinForm_add_apply_self (hinv : ω.Invariant J) (a b : V) :
+    ω.associatedBilinForm J (a + J b) (a + J b) =
+      ω.associatedBilinForm J a a + ω.associatedBilinForm J b b - 2 * ω a b := by
+  have hpol := hinv.associatedBilinForm_isSymm.polarization a (J b)
+  have hcross : ω.associatedBilinForm J a (J b) = -ω a b :=
+    associatedBilinForm_apply_right_apply a b
+  have hself : ω.associatedBilinForm J (J b) (J b) = ω.associatedBilinForm J b b :=
+    ω.associatedBilinForm_apply_apply_self_eq J b
+  linarith
 
 end Invariant
 

--- a/TauCeti/Geometry/Symplectic/JHolomorphicEnergy.lean
+++ b/TauCeti/Geometry/Symplectic/JHolomorphicEnergy.lean
@@ -392,29 +392,6 @@ namespace SymplecticForm
 variable {V : Type*} [AddCommGroup V] [Module ℝ V]
 variable {J : AlmostComplexStructure V} {ω : SymplecticForm V}
 
-/-- The polarization identity behind the Wirtinger inequality: for a `J`-invariant form,
-`g(a + J b, a + J b) = g(a, a) + g(b, b) - 2 ω(a, b)`, where `g = ω.associatedBilinForm J`.
-
-Only invariance is used; taming is needed for the sign of the left side, not for the identity. -/
-lemma Invariant.associatedBilinForm_add_apply_self (hinv : ω.Invariant J) (a b : V) :
-    ω.associatedBilinForm J (a + J b) (a + J b) =
-      ω.associatedBilinForm J a a + ω.associatedBilinForm J b b - 2 * ω a b := by
-  have hcross : ω.associatedBilinForm J a (J b) = -(ω a b) := by
-    rw [associatedBilinForm_apply, AlmostComplexStructure.apply_apply]
-    exact map_neg (ω.toBilinForm a) b
-  have hswap : ω.associatedBilinForm J (J b) a = ω.associatedBilinForm J a (J b) := by
-    rw [associatedBilinForm_apply, associatedBilinForm_apply]
-    exact hinv.associatedBilinForm_apply_swap (J b) a
-  have hself : ω.associatedBilinForm J (J b) (J b) = ω.associatedBilinForm J b b :=
-    ω.associatedBilinForm_apply_apply_self_eq J b
-  have hexpand : ω.associatedBilinForm J (a + J b) (a + J b) =
-      ω.associatedBilinForm J a a + ω.associatedBilinForm J a (J b) +
-        ω.associatedBilinForm J (J b) a + ω.associatedBilinForm J (J b) (J b) := by
-    simp only [map_add, LinearMap.add_apply]
-    ring
-  rw [hexpand, hswap, hcross, hself]
-  ring
-
 /-- The Wirtinger identity out of the standard complex line: the standard energy density minus
 twice the symplectic area density is the Cauchy--Riemann defect square
 `g(F ∂s + J (F ∂t), F ∂s + J (F ∂t))`. Needs only `J`-invariance of `ω`. -/
@@ -436,11 +413,8 @@ lemma two_mul_symplecticForm_le_stdComplexLineEnergyDensity (hcompat : ω.Compat
       ω.stdComplexLineEnergyDensity J F := by
   have hid := stdComplexLineEnergyDensity_sub_two_mul_symplecticForm hcompat.invariant F
   have hnn : 0 ≤ ω.associatedBilinForm J (F stdComplexLineReal + J (F stdComplexLineImag))
-      (F stdComplexLineReal + J (F stdComplexLineImag)) := by
-    rw [associatedBilinForm_apply]
-    rcases eq_or_ne (F stdComplexLineReal + J (F stdComplexLineImag)) 0 with h | h
-    · rw [h]; simp
-    · exact (hcompat.tames _ h).le
+      (F stdComplexLineReal + J (F stdComplexLineImag)) :=
+    hcompat.associatedBilinForm_self_nonneg _
   linarith
 
 /-- The Wirtinger inequality is an equality exactly when the map is complex linear, that is,
@@ -456,11 +430,8 @@ lemma stdComplexLineEnergyDensity_eq_two_mul_symplecticForm_iff (hcompat : ω.Co
   have hz : ω.associatedBilinForm J (F stdComplexLineReal + J (F stdComplexLineImag))
       (F stdComplexLineReal + J (F stdComplexLineImag)) = 0 := by
     rw [← hid, heq]; ring
-  have hw : F stdComplexLineReal + J (F stdComplexLineImag) = 0 := by
-    by_contra h
-    have hpos := hcompat.tames _ h
-    rw [associatedBilinForm_apply] at hz
-    linarith
+  have hw : F stdComplexLineReal + J (F stdComplexLineImag) = 0 :=
+    (hcompat.associatedBilinForm_self_eq_zero).mp hz
   have key : J (F stdComplexLineReal) = F stdComplexLineImag := by
     simpa using congrArg (fun x => J x) (add_eq_zero_iff_eq_neg.mp hw)
   rw [isComplexLinearMap_stdComplexLine_iff]

--- a/TauCeti/Geometry/Symplectic/JHolomorphicEnergy.lean
+++ b/TauCeti/Geometry/Symplectic/JHolomorphicEnergy.lean
@@ -22,6 +22,13 @@ Under a taming symplectic form the density is moreover nondegenerate: it is nonn
 real-linear map, vanishes exactly for the zero map, and is positive otherwise. The
 Frechet-derivative versions specialize this to pointwise and within-set `J`-holomorphic maps.
 
+For an *arbitrary* real-linear map the density obeys the **Wirtinger inequality**
+`2 ω(F ∂s, F ∂t) ≤ g(F ∂s, F ∂s) + g(F ∂t, F ∂t)`, the pointwise form of `E(u) ≥ ∫ u^*ω`: the
+difference is the Cauchy--Riemann defect square `g(F ∂s + J (F ∂t), F ∂s + J (F ∂t))`, which
+vanishes exactly when `F` is complex linear, so the inequality is an equality precisely for
+`J`-holomorphic maps. This is the linear-algebra content behind "`J`-holomorphic curves minimize
+energy in their homology class".
+
 The statements here are still pointwise linear algebra and Frechet-derivative calculus. They are
 the local identities that the later holomorphic-curve energy theory will integrate over strips
 or disks.
@@ -41,6 +48,15 @@ or disks.
   Frechet-derivative versions.
 * `TauCeti.SymplecticForm.prod_stdComplexLineEnergyDensity`: product-target energy density is
   the sum of the factor energy densities.
+* `TauCeti.SymplecticForm.stdComplexLineEnergyDensity_sub_two_mul_symplecticForm`: the Wirtinger
+  identity `energyDensity F - 2 ω(F ∂s, F ∂t) = g(F ∂s + J (F ∂t), F ∂s + J (F ∂t))`.
+* `TauCeti.SymplecticForm.two_mul_symplecticForm_le_stdComplexLineEnergyDensity`: the Wirtinger
+  inequality `2 ω(F ∂s, F ∂t) ≤ energyDensity F` for a compatible pair, with the
+  Frechet-derivative corollaries
+  `TauCeti.SymplecticForm.two_mul_symplecticForm_fderiv_le_stdComplexLineEnergyDensity` and
+  `TauCeti.SymplecticForm.two_mul_symplecticForm_fderivWithin_le_stdComplexLineEnergyDensity`.
+* `TauCeti.SymplecticForm.stdComplexLineEnergyDensity_eq_two_mul_symplecticForm_iff`: equality
+  holds exactly for complex-linear (`J`-holomorphic) maps.
 
 The convention follows McDuff--Salamon, *J-holomorphic Curves and Symplectic Topology*,
 Section 2.1: for a compatible pair, `g(·, ·) = ω(·, J ·)` and `du(∂t) = J du(∂s)`.
@@ -370,5 +386,112 @@ lemma fderivWithin_stdComplexLineEnergyDensity_pos (hω : ω.Tames J)
     (ω := ω) (J := J) (f := f) (s := s) (x := x) hω).mpr hfderiv
 
 end IsJHolomorphicWithinAt
+
+namespace SymplecticForm
+
+variable {V : Type*} [AddCommGroup V] [Module ℝ V]
+variable {J : AlmostComplexStructure V} {ω : SymplecticForm V}
+
+/-- The polarization identity behind the Wirtinger inequality: for a `J`-invariant form,
+`g(a + J b, a + J b) = g(a, a) + g(b, b) - 2 ω(a, b)`, where `g = ω.associatedBilinForm J`.
+
+Only invariance is used; taming is needed for the sign of the left side, not for the identity. -/
+lemma Invariant.associatedBilinForm_add_apply_self (hinv : ω.Invariant J) (a b : V) :
+    ω.associatedBilinForm J (a + J b) (a + J b) =
+      ω.associatedBilinForm J a a + ω.associatedBilinForm J b b - 2 * ω a b := by
+  have hcross : ω.associatedBilinForm J a (J b) = -(ω a b) := by
+    rw [associatedBilinForm_apply, AlmostComplexStructure.apply_apply]
+    exact map_neg (ω.toBilinForm a) b
+  have hswap : ω.associatedBilinForm J (J b) a = ω.associatedBilinForm J a (J b) := by
+    rw [associatedBilinForm_apply, associatedBilinForm_apply]
+    exact hinv.associatedBilinForm_apply_swap (J b) a
+  have hself : ω.associatedBilinForm J (J b) (J b) = ω.associatedBilinForm J b b :=
+    ω.associatedBilinForm_apply_apply_self_eq J b
+  have hexpand : ω.associatedBilinForm J (a + J b) (a + J b) =
+      ω.associatedBilinForm J a a + ω.associatedBilinForm J a (J b) +
+        ω.associatedBilinForm J (J b) a + ω.associatedBilinForm J (J b) (J b) := by
+    simp only [map_add, LinearMap.add_apply]
+    ring
+  rw [hexpand, hswap, hcross, hself]
+  ring
+
+/-- The Wirtinger identity out of the standard complex line: the standard energy density minus
+twice the symplectic area density is the Cauchy--Riemann defect square
+`g(F ∂s + J (F ∂t), F ∂s + J (F ∂t))`. Needs only `J`-invariance of `ω`. -/
+lemma stdComplexLineEnergyDensity_sub_two_mul_symplecticForm (hinv : ω.Invariant J)
+    (F : (ℝ × ℝ) →ₗ[ℝ] V) :
+    ω.stdComplexLineEnergyDensity J F -
+        2 * ω (F stdComplexLineReal) (F stdComplexLineImag) =
+      ω.associatedBilinForm J (F stdComplexLineReal + J (F stdComplexLineImag))
+        (F stdComplexLineReal + J (F stdComplexLineImag)) := by
+  rw [stdComplexLineEnergyDensity_def]
+  linarith [hinv.associatedBilinForm_add_apply_self (F stdComplexLineReal) (F stdComplexLineImag)]
+
+/-- **Wirtinger inequality.** For a compatible pair `(ω, J)` and any real-linear map out of the
+standard complex line, twice the symplectic area density of the ordered coordinate pair is at
+most the standard energy density: the local form of `E(u) ≥ ∫ u^*ω`. -/
+lemma two_mul_symplecticForm_le_stdComplexLineEnergyDensity (hcompat : ω.Compatible J)
+    (F : (ℝ × ℝ) →ₗ[ℝ] V) :
+    2 * ω (F stdComplexLineReal) (F stdComplexLineImag) ≤
+      ω.stdComplexLineEnergyDensity J F := by
+  have hid := stdComplexLineEnergyDensity_sub_two_mul_symplecticForm hcompat.invariant F
+  have hnn : 0 ≤ ω.associatedBilinForm J (F stdComplexLineReal + J (F stdComplexLineImag))
+      (F stdComplexLineReal + J (F stdComplexLineImag)) := by
+    rw [associatedBilinForm_apply]
+    rcases eq_or_ne (F stdComplexLineReal + J (F stdComplexLineImag)) 0 with h | h
+    · rw [h]; simp
+    · exact (hcompat.tames _ h).le
+  linarith
+
+/-- The Wirtinger inequality is an equality exactly when the map is complex linear, that is,
+`J`-holomorphic out of the standard complex line: the energy density then equals twice the
+symplectic area density. -/
+lemma stdComplexLineEnergyDensity_eq_two_mul_symplecticForm_iff (hcompat : ω.Compatible J)
+    (F : (ℝ × ℝ) →ₗ[ℝ] V) :
+    ω.stdComplexLineEnergyDensity J F =
+        2 * ω (F stdComplexLineReal) (F stdComplexLineImag) ↔
+      IsComplexLinearMap (AlmostComplexStructure.product ℝ) J F := by
+  refine ⟨fun heq => ?_, fun hF => hF.stdComplexLineEnergyDensity_eq_two_mul_symplecticForm⟩
+  have hid := stdComplexLineEnergyDensity_sub_two_mul_symplecticForm hcompat.invariant F
+  have hz : ω.associatedBilinForm J (F stdComplexLineReal + J (F stdComplexLineImag))
+      (F stdComplexLineReal + J (F stdComplexLineImag)) = 0 := by
+    rw [← hid, heq]; ring
+  have hw : F stdComplexLineReal + J (F stdComplexLineImag) = 0 := by
+    by_contra h
+    have hpos := hcompat.tames _ h
+    rw [associatedBilinForm_apply] at hz
+    linarith
+  have key : J (F stdComplexLineReal) = F stdComplexLineImag := by
+    simpa using congrArg (fun x => J x) (add_eq_zero_iff_eq_neg.mp hw)
+  rw [isComplexLinearMap_stdComplexLine_iff]
+  exact key.symm
+
+section Fderiv
+
+variable {W : Type*} [NormedAddCommGroup W] [NormedSpace ℝ W]
+variable {J : AlmostComplexStructure W} {ω : SymplecticForm W}
+variable {f : ℝ × ℝ → W}
+
+/-- The Wirtinger inequality for the Frechet derivative of any map from the standard complex
+line: twice the symplectic area density of the derivative's coordinate pair is at most its
+standard energy density. -/
+lemma two_mul_symplecticForm_fderiv_le_stdComplexLineEnergyDensity (hcompat : ω.Compatible J)
+    (x : ℝ × ℝ) :
+    2 * ω (fderiv ℝ f x stdComplexLineReal) (fderiv ℝ f x stdComplexLineImag) ≤
+      ω.stdComplexLineEnergyDensity J (fderiv ℝ f x).toLinearMap :=
+  two_mul_symplecticForm_le_stdComplexLineEnergyDensity hcompat (fderiv ℝ f x).toLinearMap
+
+/-- The Wirtinger inequality for the within-set Frechet derivative of any map from the standard
+complex line. -/
+lemma two_mul_symplecticForm_fderivWithin_le_stdComplexLineEnergyDensity
+    (hcompat : ω.Compatible J) (s : Set (ℝ × ℝ)) (x : ℝ × ℝ) :
+    2 * ω (fderivWithin ℝ f s x stdComplexLineReal)
+        (fderivWithin ℝ f s x stdComplexLineImag) ≤
+      ω.stdComplexLineEnergyDensity J (fderivWithin ℝ f s x).toLinearMap :=
+  two_mul_symplecticForm_le_stdComplexLineEnergyDensity hcompat (fderivWithin ℝ f s x).toLinearMap
+
+end Fderiv
+
+end SymplecticForm
 
 end TauCeti


### PR DESCRIPTION
This PR adds the Wirtinger energy inequality for real-linear maps out of the standard complex line, extending the pointwise standard-line energy density of `TauCeti/Geometry/Symplectic/JHolomorphicEnergy.lean`. Where that file already proves the *equality* `energyDensity F = 2 ω(F ∂s, F ∂t)` for complex-linear maps, this PR proves the accompanying identity for an *arbitrary* real-linear map, `energyDensity F − 2 ω(F ∂s, F ∂t) = g(F ∂s + J (F ∂t), F ∂s + J (F ∂t))`, whose right side is the Cauchy--Riemann defect square; under a compatible pair it is nonnegative, giving `2 ω(F ∂s, F ∂t) ≤ energyDensity F` (the local form of `E(u) ≥ ∫ u^*ω`), and it vanishes exactly when `F` is complex linear, so the inequality is an equality precisely for `J`-holomorphic maps. Frechet-derivative corollaries specialize the inequality to the derivative of any map, pointwise and within a set.

The added declarations are `SymplecticForm.Invariant.associatedBilinForm_add_apply_self` (the polarization identity, needing only `J`-invariance), `SymplecticForm.stdComplexLineEnergyDensity_sub_two_mul_symplecticForm`, `SymplecticForm.two_mul_symplecticForm_le_stdComplexLineEnergyDensity`, `SymplecticForm.stdComplexLineEnergyDensity_eq_two_mul_symplecticForm_iff`, and the `fderiv`/`fderivWithin` corollaries. They live in the same file as `stdComplexLineEnergyDensity` because that definition is a sealed `irreducible_def` whose value is only accessible in its own module; the Wirtinger identity is the natural companion property of that density, so this is its correct home.

This advances `TauCetiRoadmap/HeegaardFloer/README.md`, Lane F2.1, "Definitions land immediately: almost complex structures, tame/compatible `J`, symplectic manifolds, `J`-holomorphic maps, energy," supplying the pointwise energy inequality that the later holomorphic-curve energy theory (Lane F2.3 compactness and the exact-Floer energy estimates of Lane F3) integrates over strips and disks. I chose it as the lowest-hanging distinct target after scanning open and merged PRs: `main` already has the almost-complex, J-holomorphic, standard-line, area-density, and complex-linear energy API, and PR #740 covered source rotation, but the energy *inequality* itself was still absent.

No Mathlib infrastructure is vendored. The proofs reuse Tau Ceti's existing `SymplecticForm.associatedBilinForm`, `Invariant.associatedBilinForm_apply_swap`, `associatedBilinForm_apply_apply_self_eq`, `Compatible.tames`, `stdComplexLineReal`/`stdComplexLineImag`, and `isComplexLinearMap_stdComplexLine_iff`; the sign and normalization conventions follow McDuff--Salamon, *J-holomorphic Curves and Symplectic Topology*, Section 2.1.

`lake build` completed with `Build completed successfully (4548 jobs).` `lake exe axioms` completed with `axioms: audited 8268 TauCeti declaration(s); all within the allowlist [propext, Classical.choice, Quot.sound].`

<!--tauceti-target:v1 {"focus":"HeegaardFloer","id":"stdcomplexline-energy-wirtinger-inequality"}-->

🤖 Prepared with Claude Code
