### PR TITLE
feat: add Chebyshev measure polynomial moments

### DIFF
--- a/TauCeti/Analysis/SpecialFunctions/Trigonometric/Chebyshev/Moments.lean
+++ b/TauCeti/Analysis/SpecialFunctions/Trigonometric/Chebyshev/Moments.lean
@@ -5,8 +5,8 @@ Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Codex
 -/
-public import TauCeti.Analysis.SpecialFunctions.Trigonometric.Chebyshev.Measure
-public import TauCeti.MeasureTheory.Function.PolynomialMemLp
+public import Mathlib.Analysis.SpecialFunctions.Trigonometric.Chebyshev.Orthogonality
+import TauCeti.MeasureTheory.Function.PolynomialMemLp
 
 /-!
 # Polynomial moments for the Chebyshev `T` measure

--- a/TauCeti/Analysis/SpecialFunctions/Trigonometric/Chebyshev/Moments.lean
+++ b/TauCeti/Analysis/SpecialFunctions/Trigonometric/Chebyshev/Moments.lean
@@ -11,15 +11,14 @@ public import TauCeti.MeasureTheory.Function.PolynomialMemLp
 /-!
 # Polynomial moments for the Chebyshev `T` measure
 
-This file records the bare-polynomial `L¹` and `L²` consequences of compact support for
-Mathlib's Chebyshev orthogonality measure `Polynomial.Chebyshev.measureT`.
+This file records the bare-polynomial `L²` consequences of compact support for Mathlib's
+Chebyshev orthogonality measure `Polynomial.Chebyshev.measureT`.
 
 The normalized Chebyshev modes and their orthonormality live in
 `TauCeti.Analysis.SpecialFunctions.Trigonometric.Chebyshev.Measure`.  The lemmas here are the
 un-normalized consumer forms needed on the way to the roadmap's Chebyshev Hilbert-basis target:
-all monomial moments are finite, every real polynomial evaluation is integrable and square
-integrable, and these statements are available after casting real-valued functions to any
-`[RCLike 𝕜]` scalar field.
+every real polynomial evaluation is square integrable, and this statement is available after
+casting real-valued functions to any `[RCLike 𝕜]` scalar field.
 -/
 
 public section
@@ -28,27 +27,10 @@ namespace TauCeti
 
 open MeasureTheory Polynomial.Chebyshev
 
-/-- Every monomial has a finite moment with respect to the Chebyshev `T` measure. -/
-lemma integrable_pow_measureT (k : ℕ) :
-    Integrable (fun x : ℝ => x ^ k) Polynomial.Chebyshev.measureT :=
-  integrable_measureT (by fun_prop)
-
-/-- A real polynomial evaluation is integrable with respect to the Chebyshev `T` measure. -/
-lemma integrable_eval_measureT (q : Polynomial ℝ) :
-    Integrable (fun x : ℝ => q.eval x) Polynomial.Chebyshev.measureT :=
-  integrable_eval_of_forall_integrable_pow integrable_pow_measureT q
-
-/-- A real polynomial evaluation, cast to any `RCLike` scalar field, is integrable with respect
-to the Chebyshev `T` measure. -/
-lemma integrable_algebraMap_eval_measureT {𝕜 : Type*} [RCLike 𝕜] (q : Polynomial ℝ) :
-    Integrable (fun x : ℝ => (algebraMap ℝ 𝕜) (q.eval x))
-      Polynomial.Chebyshev.measureT := by
-  simpa only [RCLike.algebraMap_eq_ofReal] using (integrable_eval_measureT q).ofReal (𝕜 := 𝕜)
-
 /-- A real polynomial evaluation lies in `L²` with respect to the Chebyshev `T` measure. -/
 lemma memLp_two_eval_measureT (q : Polynomial ℝ) :
     MemLp (fun x : ℝ => q.eval x) 2 Polynomial.Chebyshev.measureT :=
-  memLp_two_eval_of_forall_integrable_pow integrable_pow_measureT q
+  memLp_two_eval_of_forall_integrable_pow (fun _ => integrable_measureT (by fun_prop)) q
 
 /-- A real polynomial evaluation, cast to any `RCLike` scalar field, lies in `L²` with respect
 to the Chebyshev `T` measure. -/
@@ -57,28 +39,5 @@ lemma memLp_two_algebraMap_eval_measureT {𝕜 : Type*} [RCLike 𝕜] (q : Polyn
       Polynomial.Chebyshev.measureT := by
   simpa only [RCLike.algebraMap_eq_ofReal] using
     (memLp_two_eval_measureT q).ofReal (K := 𝕜)
-
-/-- The `n`th Chebyshev `T` polynomial evaluation is integrable with respect to `measureT`. -/
-lemma integrable_eval_T_real_measureT (n : ℕ) :
-    Integrable (fun x : ℝ => (T ℝ n).eval x) Polynomial.Chebyshev.measureT :=
-  integrable_eval_measureT (T ℝ n)
-
-/-- The scalar-cast `n`th Chebyshev `T` polynomial evaluation is integrable with respect to
-`measureT`. -/
-lemma integrable_algebraMap_eval_T_real_measureT {𝕜 : Type*} [RCLike 𝕜] (n : ℕ) :
-    Integrable (fun x : ℝ => (algebraMap ℝ 𝕜) ((T ℝ n).eval x))
-      Polynomial.Chebyshev.measureT :=
-  integrable_algebraMap_eval_measureT (𝕜 := 𝕜) (T ℝ n)
-
-/-- The `n`th Chebyshev `T` polynomial evaluation lies in `L²(measureT)`. -/
-lemma memLp_two_eval_T_real_measureT (n : ℕ) :
-    MemLp (fun x : ℝ => (T ℝ n).eval x) 2 Polynomial.Chebyshev.measureT :=
-  memLp_two_eval_measureT (T ℝ n)
-
-/-- The scalar-cast `n`th Chebyshev `T` polynomial evaluation lies in `L²(measureT)`. -/
-lemma memLp_two_algebraMap_eval_T_real_measureT {𝕜 : Type*} [RCLike 𝕜] (n : ℕ) :
-    MemLp (fun x : ℝ => (algebraMap ℝ 𝕜) ((T ℝ n).eval x)) 2
-      Polynomial.Chebyshev.measureT :=
-  memLp_two_algebraMap_eval_measureT (𝕜 := 𝕜) (T ℝ n)
 
 end TauCeti

--- a/TauCeti/Analysis/SpecialFunctions/Trigonometric/Chebyshev/Moments.lean
+++ b/TauCeti/Analysis/SpecialFunctions/Trigonometric/Chebyshev/Moments.lean
@@ -11,14 +11,15 @@ public import TauCeti.MeasureTheory.Function.PolynomialMemLp
 /-!
 # Polynomial moments for the Chebyshev `T` measure
 
-This file records the bare-polynomial `L²` consequences of compact support for Mathlib's
-Chebyshev orthogonality measure `Polynomial.Chebyshev.measureT`.
+This file records bare-polynomial moment, `L¹`, and `L²` consequences of compact support for
+Mathlib's Chebyshev orthogonality measure `Polynomial.Chebyshev.measureT`.
 
 The normalized Chebyshev modes and their orthonormality live in
 `TauCeti.Analysis.SpecialFunctions.Trigonometric.Chebyshev.Measure`.  The lemmas here are the
 un-normalized consumer forms needed on the way to the roadmap's Chebyshev Hilbert-basis target:
-every real polynomial evaluation is square integrable, and this statement is available after
-casting real-valued functions to any `[RCLike 𝕜]` scalar field.
+every real polynomial moment is finite, every real polynomial evaluation is integrable and square
+integrable, and these statements are available after casting real-valued functions to any
+`[RCLike 𝕜]` scalar field.
 -/
 
 public section
@@ -27,10 +28,28 @@ namespace TauCeti
 
 open MeasureTheory Polynomial.Chebyshev
 
+/-- Every real monomial has finite `L¹` moment with respect to the Chebyshev `T` measure. -/
+lemma integrable_pow_measureT (k : ℕ) :
+    Integrable (fun x : ℝ => x ^ k) Polynomial.Chebyshev.measureT :=
+  integrable_measureT (by fun_prop)
+
+/-- A real polynomial evaluation is integrable with respect to the Chebyshev `T` measure. -/
+lemma integrable_eval_measureT (q : Polynomial ℝ) :
+    Integrable (fun x : ℝ => q.eval x) Polynomial.Chebyshev.measureT :=
+  integrable_eval_of_forall_integrable_pow integrable_pow_measureT q
+
+/-- A real polynomial evaluation, cast to any `RCLike` scalar field, is integrable with respect
+to the Chebyshev `T` measure. -/
+lemma integrable_algebraMap_eval_measureT {𝕜 : Type*} [RCLike 𝕜] (q : Polynomial ℝ) :
+    Integrable (fun x : ℝ => (algebraMap ℝ 𝕜) (q.eval x))
+      Polynomial.Chebyshev.measureT := by
+  simpa only [RCLike.algebraMap_eq_ofReal] using
+    (integrable_eval_measureT q).ofReal (𝕜 := 𝕜)
+
 /-- A real polynomial evaluation lies in `L²` with respect to the Chebyshev `T` measure. -/
 lemma memLp_two_eval_measureT (q : Polynomial ℝ) :
     MemLp (fun x : ℝ => q.eval x) 2 Polynomial.Chebyshev.measureT :=
-  memLp_two_eval_of_forall_integrable_pow (fun _ => integrable_measureT (by fun_prop)) q
+  memLp_two_eval_of_forall_integrable_pow integrable_pow_measureT q
 
 /-- A real polynomial evaluation, cast to any `RCLike` scalar field, lies in `L²` with respect
 to the Chebyshev `T` measure. -/

--- a/TauCeti/Analysis/SpecialFunctions/Trigonometric/Chebyshev/Moments.lean
+++ b/TauCeti/Analysis/SpecialFunctions/Trigonometric/Chebyshev/Moments.lean
@@ -1,0 +1,84 @@
+module
+
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Codex
+-/
+public import TauCeti.Analysis.SpecialFunctions.Trigonometric.Chebyshev.Measure
+public import TauCeti.MeasureTheory.Function.PolynomialMemLp
+
+/-!
+# Polynomial moments for the Chebyshev `T` measure
+
+This file records the bare-polynomial `L¹` and `L²` consequences of compact support for
+Mathlib's Chebyshev orthogonality measure `Polynomial.Chebyshev.measureT`.
+
+The normalized Chebyshev modes and their orthonormality live in
+`TauCeti.Analysis.SpecialFunctions.Trigonometric.Chebyshev.Measure`.  The lemmas here are the
+un-normalized consumer forms needed on the way to the roadmap's Chebyshev Hilbert-basis target:
+all monomial moments are finite, every real polynomial evaluation is integrable and square
+integrable, and these statements are available after casting real-valued functions to any
+`[RCLike 𝕜]` scalar field.
+-/
+
+public section
+
+namespace TauCeti
+
+open MeasureTheory Polynomial.Chebyshev
+
+/-- Every monomial has a finite moment with respect to the Chebyshev `T` measure. -/
+lemma integrable_pow_measureT (k : ℕ) :
+    Integrable (fun x : ℝ => x ^ k) Polynomial.Chebyshev.measureT :=
+  integrable_measureT (by fun_prop)
+
+/-- A real polynomial evaluation is integrable with respect to the Chebyshev `T` measure. -/
+lemma integrable_eval_measureT (q : Polynomial ℝ) :
+    Integrable (fun x : ℝ => q.eval x) Polynomial.Chebyshev.measureT :=
+  integrable_eval_of_forall_integrable_pow integrable_pow_measureT q
+
+/-- A real polynomial evaluation, cast to any `RCLike` scalar field, is integrable with respect
+to the Chebyshev `T` measure. -/
+lemma integrable_algebraMap_eval_measureT {𝕜 : Type*} [RCLike 𝕜] (q : Polynomial ℝ) :
+    Integrable (fun x : ℝ => (algebraMap ℝ 𝕜) (q.eval x))
+      Polynomial.Chebyshev.measureT := by
+  simpa only [RCLike.algebraMap_eq_ofReal] using (integrable_eval_measureT q).ofReal (𝕜 := 𝕜)
+
+/-- A real polynomial evaluation lies in `L²` with respect to the Chebyshev `T` measure. -/
+lemma memLp_two_eval_measureT (q : Polynomial ℝ) :
+    MemLp (fun x : ℝ => q.eval x) 2 Polynomial.Chebyshev.measureT :=
+  memLp_two_eval_of_forall_integrable_pow integrable_pow_measureT q
+
+/-- A real polynomial evaluation, cast to any `RCLike` scalar field, lies in `L²` with respect
+to the Chebyshev `T` measure. -/
+lemma memLp_two_algebraMap_eval_measureT {𝕜 : Type*} [RCLike 𝕜] (q : Polynomial ℝ) :
+    MemLp (fun x : ℝ => (algebraMap ℝ 𝕜) (q.eval x)) 2
+      Polynomial.Chebyshev.measureT := by
+  simpa only [RCLike.algebraMap_eq_ofReal] using
+    (memLp_two_eval_measureT q).ofReal (K := 𝕜)
+
+/-- The `n`th Chebyshev `T` polynomial evaluation is integrable with respect to `measureT`. -/
+lemma integrable_eval_T_real_measureT (n : ℕ) :
+    Integrable (fun x : ℝ => (T ℝ n).eval x) Polynomial.Chebyshev.measureT :=
+  integrable_eval_measureT (T ℝ n)
+
+/-- The scalar-cast `n`th Chebyshev `T` polynomial evaluation is integrable with respect to
+`measureT`. -/
+lemma integrable_algebraMap_eval_T_real_measureT {𝕜 : Type*} [RCLike 𝕜] (n : ℕ) :
+    Integrable (fun x : ℝ => (algebraMap ℝ 𝕜) ((T ℝ n).eval x))
+      Polynomial.Chebyshev.measureT :=
+  integrable_algebraMap_eval_measureT (𝕜 := 𝕜) (T ℝ n)
+
+/-- The `n`th Chebyshev `T` polynomial evaluation lies in `L²(measureT)`. -/
+lemma memLp_two_eval_T_real_measureT (n : ℕ) :
+    MemLp (fun x : ℝ => (T ℝ n).eval x) 2 Polynomial.Chebyshev.measureT :=
+  memLp_two_eval_measureT (T ℝ n)
+
+/-- The scalar-cast `n`th Chebyshev `T` polynomial evaluation lies in `L²(measureT)`. -/
+lemma memLp_two_algebraMap_eval_T_real_measureT {𝕜 : Type*} [RCLike 𝕜] (n : ℕ) :
+    MemLp (fun x : ℝ => (algebraMap ℝ 𝕜) ((T ℝ n).eval x)) 2
+      Polynomial.Chebyshev.measureT :=
+  memLp_two_algebraMap_eval_measureT (𝕜 := 𝕜) (T ℝ n)
+
+end TauCeti


### PR DESCRIPTION
This PR records finite polynomial moments and bare-polynomial `L¹`/`L²` consumer forms for Mathlib's Chebyshev orthogonality measure `Polynomial.Chebyshev.measureT`, including the scalar-cast `RCLike` forms needed by the Chebyshev Hilbert-basis path. It advances `TauCetiRoadmap/OrthogonalL2Bases/README.md`, Part C, “Open targets this entails,” specifically the compactly-supported instance of B1's moment lemma and the real-to-`[RCLike 𝕜]` cast of the Chebyshev completeness input, as a small prerequisite before `chebyshevHilbertBasis`.

I chose this as the lowest-hanging distinct OrthogonalL2Bases target after checking open and recently merged PRs: open PR #499 covers A1 Hermite orthogonality, while `main` already has `measureT` finiteness, normalized Chebyshev `Lp` modes, their orthonormality, cosine-transfer lemmas, and `HilbertBasis.mapₗᵢ`; the remaining Chebyshev polynomial-moment and bare-`Tₙ` `L²` forms were still absent.

No Mathlib infrastructure is vendored. The implementation reuses Mathlib's `integrable_measureT` for compact-support integrability, Tau Ceti's `integrable_eval_of_forall_integrable_pow` and `memLp_two_eval_of_forall_integrable_pow`, and Mathlib's `Integrable.ofReal` / `MemLp.ofReal` scalar-cast APIs.

`lake exe cache get` completed with `No files to download` and `Already decompressed 8609 file(s)`. `lake build` completed with `Build completed successfully (4551 jobs).` `lake exe axioms` completed with `axioms: audited 8348 TauCeti declaration(s); all within the allowlist [propext, Classical.choice, Quot.sound].`

<!--tauceti-target:v1 {"focus":"OrthogonalL2Bases","id":"chebyshev-polynomial-moments-measuret"}-->

🤖 Prepared with Codex
