### PR TITLE
feat: add permutation extension helpers

### DIFF
--- a/TauCeti/Probability/Exchangeability/Contractability.lean
+++ b/TauCeti/Probability/Exchangeability/Contractability.lean
@@ -4,6 +4,7 @@ public import TauCeti.Probability.Exchangeability.Basic
 public import Mathlib.Order.Fin.Basic
 public import Mathlib.Data.Fin.VecNotation
 public import Mathlib.Dynamics.Ergodic.MeasurePreserving
+import TauCeti.Probability.Exchangeability.PermutationExtension
 import TauCeti.Probability.Exchangeability.ExchangeableAtMonotone
 import Mathlib.Order.Fin.Tuple
 import TauCeti.Probability.Exchangeability.FiniteMarginals
@@ -25,10 +26,9 @@ time-reindexing, in particular the shift), plus the converse characterization
 
 These declarations are adapted from the `cameronfreer/exchangeability` Layer 0 sources pinned
 at `e0532e59ceff23edab44dda9ab0655debbc9cc22`, with Tau Ceti API names and hypotheses; the
-combinatorial core is Mathlib's `Equiv.Perm.exists_extending_pair` (Cameron Freer, Mathlib
-#34599). `Contractable.pairLaw_eq` is adapted from `DeFinetti/ViaMartingale/FutureRectangles.lean`
-(`contractable_dist_eq`) in the same repo, reproved via the reindexing route below rather than the
-reference's rectangle π-system.
+combinatorial core now lives in `PermutationExtension.lean`. `Contractable.pairLaw_eq` is adapted
+from `DeFinetti/ViaMartingale/FutureRectangles.lean` (`contractable_dist_eq`) in the same repo,
+reproved via the reindexing route below rather than the reference's rectangle π-system.
 -/
 
 public section
@@ -42,33 +42,6 @@ namespace TauCeti
 namespace Probability
 
 variable {Ω α : Type*} [MeasurableSpace Ω] [MeasurableSpace α]
-
-/-- A strictly increasing finite selection `k : Fin m → ℕ` extends to a strictly increasing
-self-map of `ℕ`. This is the combinatorial bridge from the finite-dimensional definition of
-contractability to the path-law formulation using the monoid of strictly increasing reindexings
-`ℕ → ℕ`. -/
-private theorem exists_strictMono_nat_extending_fin {m : ℕ} {k : Fin m → ℕ} (hk : StrictMono k) :
-    ∃ φ : ℕ → ℕ, StrictMono φ ∧ ∀ i : Fin m, φ i.val = k i := by
-  classical
-  let C := Finset.univ.sup k + 1
-  let φ : ℕ → ℕ := fun n => if h : n < m then k ⟨n, h⟩ else n + C
-  refine ⟨φ, ?_, ?_⟩
-  · intro a b hab
-    dsimp only [φ]
-    by_cases ha : a < m
-    · by_cases hb : b < m
-      · rw [dif_pos ha, dif_pos hb]
-        exact hk (Fin.lt_def.mpr hab)
-      · rw [dif_pos ha, dif_neg hb]
-        have hle_sup : k ⟨a, ha⟩ ≤ Finset.univ.sup k :=
-          Finset.le_sup (f := k) (Finset.mem_univ (⟨a, ha⟩ : Fin m))
-        exact (Nat.lt_succ_of_le hle_sup).trans_le (Nat.le_add_left C b)
-    · by_cases hb : b < m
-      · omega
-      · rw [dif_neg ha, dif_neg hb]
-        omega
-  · intro i
-    simp [φ, i.isLt]
 
 /-- A contractable process has the same finite-dimensional block law as the corresponding
 prefix law along any strictly increasing finite index map. -/

--- a/TauCeti/Probability/Exchangeability/ExchangeableAtMonotone.lean
+++ b/TauCeti/Probability/Exchangeability/ExchangeableAtMonotone.lean
@@ -1,7 +1,7 @@
 module
 
 public import TauCeti.Probability.Exchangeability.Basic
-import TauCeti.Probability.Exchangeability.PermutationExtension
+import Mathlib.Logic.Equiv.Fintype
 
 /-!
 # Monotonicity of finite exchangeability
@@ -12,9 +12,8 @@ coordinates have permutation-invariant law, then so do the first `m` coordinates
 `Fin m` to one of `Fin n`, use exchangeability at `n`, and project the `n`-prefix law back to
 the first `m` coordinates.
 
-The permutation-extension step reuses Tau Ceti's `exists_perm_extending_castLE`; the measure-level
-projection step reuses Tau Ceti's `map_blockLaw_reindex` and
-`map_prefixLaw_castLE`.
+The permutation-extension step reuses Mathlib's `Equiv.Perm.exists_extending_pair`; the
+measure-level projection step reuses Tau Ceti's `map_blockLaw_reindex` and `map_prefixLaw_castLE`.
 
 This projection argument is adapted from Tau Ceti's credited
 `Exchangeable.blockLaw_eq_prefixLaw_of_injective` proof in `Contractability.lean`, following the
@@ -43,7 +42,8 @@ theorem blockLaw_eq_prefixLaw_of_injective {μ : Measure Ω} {X : ℕ → Ω →
     blockLaw μ X (fun i : Fin m => (k i).val) = prefixLaw μ X m := by
   have hmn : m ≤ n := by
     simpa using Fintype.card_le_of_injective k hk
-  obtain ⟨σ, hσ⟩ := exists_perm_extending_castLE hmn k hk
+  obtain ⟨σ, hσ⟩ := Equiv.Perm.exists_extending_pair (Fin.castLE hmn) k
+    (fun _ _ h => Fin.castLE_injective hmn h) hk
   have hperm : blockLaw μ X (fun j : Fin n => (σ j).val) = prefixLaw μ X n := h.permute σ
   have hLHS :
       (blockLaw μ X (fun j : Fin n => (σ j).val)).map

--- a/TauCeti/Probability/Exchangeability/ExchangeableAtMonotone.lean
+++ b/TauCeti/Probability/Exchangeability/ExchangeableAtMonotone.lean
@@ -1,7 +1,7 @@
 module
 
 public import TauCeti.Probability.Exchangeability.Basic
-import Mathlib.Logic.Equiv.Fintype
+import TauCeti.Probability.Exchangeability.PermutationExtension
 
 /-!
 # Monotonicity of finite exchangeability
@@ -42,8 +42,7 @@ theorem blockLaw_eq_prefixLaw_of_injective {μ : Measure Ω} {X : ℕ → Ω →
     blockLaw μ X (fun i : Fin m => (k i).val) = prefixLaw μ X m := by
   have hmn : m ≤ n := by
     simpa using Fintype.card_le_of_injective k hk
-  obtain ⟨σ, hσ⟩ := Equiv.Perm.exists_extending_pair (Fin.castLE hmn) k
-    (fun _ _ h => Fin.castLE_injective hmn h) hk
+  obtain ⟨σ, hσ⟩ := exists_perm_extending_castLE hmn hk
   have hperm : blockLaw μ X (fun j : Fin n => (σ j).val) = prefixLaw μ X n := h.permute σ
   have hLHS :
       (blockLaw μ X (fun j : Fin n => (σ j).val)).map

--- a/TauCeti/Probability/Exchangeability/ExchangeableAtMonotone.lean
+++ b/TauCeti/Probability/Exchangeability/ExchangeableAtMonotone.lean
@@ -12,8 +12,8 @@ coordinates have permutation-invariant law, then so do the first `m` coordinates
 `Fin m` to one of `Fin n`, use exchangeability at `n`, and project the `n`-prefix law back to
 the first `m` coordinates.
 
-The permutation-extension step reuses Mathlib's `Equiv.Perm.exists_extending_pair`; the
-measure-level projection step reuses Tau Ceti's `map_blockLaw_reindex` and
+The permutation-extension step reuses Tau Ceti's `exists_perm_extending_castLE`; the measure-level
+projection step reuses Tau Ceti's `map_blockLaw_reindex` and
 `map_prefixLaw_castLE`.
 
 This projection argument is adapted from Tau Ceti's credited
@@ -43,8 +43,7 @@ theorem blockLaw_eq_prefixLaw_of_injective {μ : Measure Ω} {X : ℕ → Ω →
     blockLaw μ X (fun i : Fin m => (k i).val) = prefixLaw μ X m := by
   have hmn : m ≤ n := by
     simpa using Fintype.card_le_of_injective k hk
-  obtain ⟨σ, hσ⟩ := Equiv.Perm.exists_extending_pair (Fin.castLE hmn) k
-    (fun _ _ h => Fin.castLE_injective hmn h) hk
+  obtain ⟨σ, hσ⟩ := exists_perm_extending_castLE hmn k hk
   have hperm : blockLaw μ X (fun j : Fin n => (σ j).val) = prefixLaw μ X n := h.permute σ
   have hLHS :
       (blockLaw μ X (fun j : Fin n => (σ j).val)).map

--- a/TauCeti/Probability/Exchangeability/ExchangeableAtMonotone.lean
+++ b/TauCeti/Probability/Exchangeability/ExchangeableAtMonotone.lean
@@ -12,9 +12,9 @@ coordinates have permutation-invariant law, then so do the first `m` coordinates
 `Fin m` to one of `Fin n`, use exchangeability at `n`, and project the `n`-prefix law back to
 the first `m` coordinates.
 
-The permutation-extension step reuses Tau Ceti's public
-`exists_perm_extending_castLE`; the measure-level projection step reuses Tau Ceti's
-`map_blockLaw_reindex` and `map_prefixLaw_castLE`.
+The permutation-extension step reuses Mathlib's `Equiv.Perm.exists_extending_pair`; the
+measure-level projection step reuses Tau Ceti's `map_blockLaw_reindex` and
+`map_prefixLaw_castLE`.
 
 This projection argument is adapted from Tau Ceti's credited
 `Exchangeable.blockLaw_eq_prefixLaw_of_injective` proof in `Contractability.lean`, following the
@@ -43,7 +43,8 @@ theorem blockLaw_eq_prefixLaw_of_injective {μ : Measure Ω} {X : ℕ → Ω →
     blockLaw μ X (fun i : Fin m => (k i).val) = prefixLaw μ X m := by
   have hmn : m ≤ n := by
     simpa using Fintype.card_le_of_injective k hk
-  obtain ⟨σ, hσ⟩ := exists_perm_extending_castLE hmn k hk
+  obtain ⟨σ, hσ⟩ := Equiv.Perm.exists_extending_pair (Fin.castLE hmn) k
+    (fun _ _ h => Fin.castLE_injective hmn h) hk
   have hperm : blockLaw μ X (fun j : Fin n => (σ j).val) = prefixLaw μ X n := h.permute σ
   have hLHS :
       (blockLaw μ X (fun j : Fin n => (σ j).val)).map

--- a/TauCeti/Probability/Exchangeability/ExchangeableAtMonotone.lean
+++ b/TauCeti/Probability/Exchangeability/ExchangeableAtMonotone.lean
@@ -42,7 +42,8 @@ theorem blockLaw_eq_prefixLaw_of_injective {μ : Measure Ω} {X : ℕ → Ω →
     blockLaw μ X (fun i : Fin m => (k i).val) = prefixLaw μ X m := by
   have hmn : m ≤ n := by
     simpa using Fintype.card_le_of_injective k hk
-  obtain ⟨σ, hσ⟩ := exists_perm_extending_castLE hmn hk
+  obtain ⟨σ, hσ⟩ := Equiv.Perm.exists_extending_pair (Fin.castLE hmn) k
+    (fun _ _ h => Fin.castLE_injective hmn h) hk
   have hperm : blockLaw μ X (fun j : Fin n => (σ j).val) = prefixLaw μ X n := h.permute σ
   have hLHS :
       (blockLaw μ X (fun j : Fin n => (σ j).val)).map

--- a/TauCeti/Probability/Exchangeability/ExchangeableAtMonotone.lean
+++ b/TauCeti/Probability/Exchangeability/ExchangeableAtMonotone.lean
@@ -1,7 +1,7 @@
 module
 
 public import TauCeti.Probability.Exchangeability.Basic
-import Mathlib.Logic.Equiv.Fintype
+import TauCeti.Probability.Exchangeability.PermutationExtension
 
 /-!
 # Monotonicity of finite exchangeability
@@ -12,9 +12,9 @@ coordinates have permutation-invariant law, then so do the first `m` coordinates
 `Fin m` to one of `Fin n`, use exchangeability at `n`, and project the `n`-prefix law back to
 the first `m` coordinates.
 
-The permutation-extension step reuses Mathlib's `Equiv.Perm.exists_extending_pair`; the
-measure-level projection step reuses Tau Ceti's `map_blockLaw_reindex` and
-`map_prefixLaw_castLE`.
+The permutation-extension step reuses Tau Ceti's public
+`exists_perm_extending_castLE`; the measure-level projection step reuses Tau Ceti's
+`map_blockLaw_reindex` and `map_prefixLaw_castLE`.
 
 This projection argument is adapted from Tau Ceti's credited
 `Exchangeable.blockLaw_eq_prefixLaw_of_injective` proof in `Contractability.lean`, following the
@@ -34,16 +34,6 @@ namespace Probability
 variable {Ω α : Type*} [MeasurableSpace Ω] [MeasurableSpace α]
 
 namespace ExchangeableAt
-
-/-- An injective map `k : Fin m → Fin n` extends across the canonical inclusion
-`Fin.castLE hmn` to a permutation of `Fin n`. -/
-private theorem exists_perm_extending_castLE {m n : ℕ} (hmn : m ≤ n)
-    (k : Fin m → Fin n) (hk : Function.Injective k) :
-    ∃ σ : Equiv.Perm (Fin n),
-      ∀ i : Fin m, σ (Fin.castLE hmn i) = k i :=
-  Equiv.Perm.exists_extending_pair (Fin.castLE hmn) k
-    (fun _ _ h => Fin.castLE_injective hmn h)
-    hk
 
 /-- An exchangeable `n`-prefix has the prefix law on every injective `m`-subselection inside
 that prefix. -/

--- a/TauCeti/Probability/Exchangeability/FullyExchangeable.lean
+++ b/TauCeti/Probability/Exchangeability/FullyExchangeable.lean
@@ -2,7 +2,7 @@ module
 
 public import TauCeti.Probability.Exchangeability.Basic
 public import Mathlib.Dynamics.Ergodic.MeasurePreserving
-import Mathlib.Logic.Equiv.Fintype
+import TauCeti.Probability.Exchangeability.PermutationExtension
 import TauCeti.Probability.Exchangeability.FiniteMarginals
 import TauCeti.Probability.Exchangeability.Contractability
 
@@ -58,9 +58,8 @@ theorem FullyExchangeable.exchangeableAt {μ : Measure Ω} {X : ℕ → Ω → �
     (hX : FullyExchangeable μ X) (hX_meas : ∀ i, AEMeasurable (X i) μ) (n : ℕ) :
     ExchangeableAt μ X n := by
   intro σ
-  obtain ⟨π, hπ⟩ :=
-    Equiv.Perm.exists_extending_pair (fun i : Fin n => i.val) (fun i : Fin n => (σ i).val)
-      Fin.val_injective (fun _ _ h => σ.injective (Fin.val_injective h))
+  obtain ⟨π, hπ⟩ := exists_perm_nat_extending
+    (fun _ _ h => σ.injective (Fin.val_injective h))
   have hidx : (fun j : Fin n => π j.val) = fun j : Fin n => (σ j).val := by
     funext j; exact hπ j
   calc blockLaw μ X (fun j : Fin n => (σ j).val)

--- a/TauCeti/Probability/Exchangeability/FullyExchangeable.lean
+++ b/TauCeti/Probability/Exchangeability/FullyExchangeable.lean
@@ -25,8 +25,8 @@ endomorphisms:
 These bridges live together because they all identify the process-level symmetry
 `FullyExchangeable μ X` with corresponding path-law invariance statements. They are thin: they
 reuse the merged Layer 0 API and Mathlib — finite-marginal uniqueness (`FiniteMarginals`), the
-contractability bridge (`Contractability`), generic path-law reindexing, and
-`Equiv.Perm.exists_extending_pair` — rather than new measure theory.
+contractability bridge (`Contractability`), generic path-law reindexing, and the permutation
+wrappers in `PermutationExtension` — rather than new measure theory.
 
 These declarations are adapted from the `cameronfreer/exchangeability` Layer 0 sources pinned at
 `e0532e59ceff23edab44dda9ab0655debbc9cc22`, with Tau Ceti API names and hypotheses.
@@ -58,9 +58,8 @@ theorem FullyExchangeable.exchangeableAt {μ : Measure Ω} {X : ℕ → Ω → �
     (hX : FullyExchangeable μ X) (hX_meas : ∀ i, AEMeasurable (X i) μ) (n : ℕ) :
     ExchangeableAt μ X n := by
   intro σ
-  obtain ⟨π, hπ⟩ :=
-    Equiv.Perm.exists_extending_pair (fun i : Fin n => i.val) (fun i => (σ i).val)
-      Fin.val_injective (fun _ _ h => σ.injective (Fin.val_injective h))
+  obtain ⟨π, hπ⟩ := exists_perm_nat_extending (fun i : Fin n => (σ i).val)
+    (fun _ _ h => σ.injective (Fin.val_injective h))
   have hidx : (fun j : Fin n => π j.val) = fun j : Fin n => (σ j).val := by
     funext j; exact hπ j
   calc blockLaw μ X (fun j : Fin n => (σ j).val)

--- a/TauCeti/Probability/Exchangeability/FullyExchangeable.lean
+++ b/TauCeti/Probability/Exchangeability/FullyExchangeable.lean
@@ -2,7 +2,7 @@ module
 
 public import TauCeti.Probability.Exchangeability.Basic
 public import Mathlib.Dynamics.Ergodic.MeasurePreserving
-import TauCeti.Probability.Exchangeability.PermutationExtension
+import Mathlib.Logic.Equiv.Fintype
 import TauCeti.Probability.Exchangeability.FiniteMarginals
 import TauCeti.Probability.Exchangeability.Contractability
 
@@ -25,8 +25,8 @@ endomorphisms:
 These bridges live together because they all identify the process-level symmetry
 `FullyExchangeable μ X` with corresponding path-law invariance statements. They are thin: they
 reuse the merged Layer 0 API and Mathlib — finite-marginal uniqueness (`FiniteMarginals`), the
-contractability bridge (`Contractability`), generic path-law reindexing, and the permutation
-wrappers in `PermutationExtension` — rather than new measure theory.
+contractability bridge (`Contractability`), generic path-law reindexing, and Mathlib's finite
+permutation extension theorem — rather than new measure theory.
 
 These declarations are adapted from the `cameronfreer/exchangeability` Layer 0 sources pinned at
 `e0532e59ceff23edab44dda9ab0655debbc9cc22`, with Tau Ceti API names and hypotheses.
@@ -58,8 +58,9 @@ theorem FullyExchangeable.exchangeableAt {μ : Measure Ω} {X : ℕ → Ω → �
     (hX : FullyExchangeable μ X) (hX_meas : ∀ i, AEMeasurable (X i) μ) (n : ℕ) :
     ExchangeableAt μ X n := by
   intro σ
-  obtain ⟨π, hπ⟩ := exists_perm_nat_extending (fun i : Fin n => (σ i).val)
-    (fun _ _ h => σ.injective (Fin.val_injective h))
+  obtain ⟨π, hπ⟩ :=
+    Equiv.Perm.exists_extending_pair (fun i : Fin n => i.val) (fun i : Fin n => (σ i).val)
+      Fin.val_injective (fun _ _ h => σ.injective (Fin.val_injective h))
   have hidx : (fun j : Fin n => π j.val) = fun j : Fin n => (σ j).val := by
     funext j; exact hπ j
   calc blockLaw μ X (fun j : Fin n => (σ j).val)

--- a/TauCeti/Probability/Exchangeability/FullyExchangeable.lean
+++ b/TauCeti/Probability/Exchangeability/FullyExchangeable.lean
@@ -2,9 +2,9 @@ module
 
 public import TauCeti.Probability.Exchangeability.Basic
 public import Mathlib.Dynamics.Ergodic.MeasurePreserving
+import TauCeti.Probability.Exchangeability.PermutationExtension
 import TauCeti.Probability.Exchangeability.FiniteMarginals
 import TauCeti.Probability.Exchangeability.Contractability
-import Mathlib.Logic.Equiv.Fintype
 
 /-!
 # Full exchangeability and path-law bridges
@@ -26,7 +26,7 @@ These bridges live together because they all identify the process-level symmetry
 `FullyExchangeable μ X` with corresponding path-law invariance statements. They are thin: they
 reuse the merged Layer 0 API and Mathlib — finite-marginal uniqueness (`FiniteMarginals`), the
 contractability bridge (`Contractability`), generic path-law reindexing, and
-`Equiv.Perm.exists_extending_pair` — rather than new measure theory.
+`exists_perm_nat_extending_fin` — rather than new measure theory.
 
 These declarations are adapted from the `cameronfreer/exchangeability` Layer 0 sources pinned at
 `e0532e59ceff23edab44dda9ab0655debbc9cc22`, with Tau Ceti API names and hypotheses.
@@ -44,13 +44,6 @@ namespace Probability
 
 variable {Ω α : Type*} [MeasurableSpace Ω] [MeasurableSpace α]
 
-/-- A permutation of `Fin n` is the restriction of some permutation of `ℕ`: there is `π : Perm ℕ`
-with `π i = σ i` on `{0, …, n-1}`. Thin wrapper over `Equiv.Perm.exists_extending_pair`. -/
-private theorem exists_perm_nat_extending {n : ℕ} (σ : Equiv.Perm (Fin n)) :
-    ∃ π : Equiv.Perm ℕ, ∀ i : Fin n, π i.val = (σ i).val :=
-  Equiv.Perm.exists_extending_pair (fun i : Fin n => i.val) (fun i => (σ i).val)
-    Fin.val_injective (fun _ _ h => σ.injective (Fin.val_injective h))
-
 /-- The first-`n` prefix marginal of the `π`-reindexed path law is the block law along the
 selection `j ↦ π j`. -/
 private theorem map_reindex_prefixProj {μ : Measure Ω} {X : ℕ → Ω → α}
@@ -65,7 +58,7 @@ theorem FullyExchangeable.exchangeableAt {μ : Measure Ω} {X : ℕ → Ω → �
     (hX : FullyExchangeable μ X) (hX_meas : ∀ i, AEMeasurable (X i) μ) (n : ℕ) :
     ExchangeableAt μ X n := by
   intro σ
-  obtain ⟨π, hπ⟩ := exists_perm_nat_extending σ
+  obtain ⟨π, hπ⟩ := exists_perm_nat_extending_fin σ
   have hidx : (fun j : Fin n => π j.val) = fun j : Fin n => (σ j).val := by
     funext j; exact hπ j
   calc blockLaw μ X (fun j : Fin n => (σ j).val)

--- a/TauCeti/Probability/Exchangeability/FullyExchangeable.lean
+++ b/TauCeti/Probability/Exchangeability/FullyExchangeable.lean
@@ -26,7 +26,7 @@ These bridges live together because they all identify the process-level symmetry
 `FullyExchangeable μ X` with corresponding path-law invariance statements. They are thin: they
 reuse the merged Layer 0 API and Mathlib — finite-marginal uniqueness (`FiniteMarginals`), the
 contractability bridge (`Contractability`), generic path-law reindexing, and
-`exists_perm_nat_extending_fin` — rather than new measure theory.
+`Equiv.Perm.exists_extending_pair` — rather than new measure theory.
 
 These declarations are adapted from the `cameronfreer/exchangeability` Layer 0 sources pinned at
 `e0532e59ceff23edab44dda9ab0655debbc9cc22`, with Tau Ceti API names and hypotheses.
@@ -58,7 +58,9 @@ theorem FullyExchangeable.exchangeableAt {μ : Measure Ω} {X : ℕ → Ω → �
     (hX : FullyExchangeable μ X) (hX_meas : ∀ i, AEMeasurable (X i) μ) (n : ℕ) :
     ExchangeableAt μ X n := by
   intro σ
-  obtain ⟨π, hπ⟩ := exists_perm_nat_extending_fin σ
+  obtain ⟨π, hπ⟩ :=
+    Equiv.Perm.exists_extending_pair (fun i : Fin n => i.val) (fun i => (σ i).val)
+      Fin.val_injective (fun _ _ h => σ.injective (Fin.val_injective h))
   have hidx : (fun j : Fin n => π j.val) = fun j : Fin n => (σ j).val := by
     funext j; exact hπ j
   calc blockLaw μ X (fun j : Fin n => (σ j).val)

--- a/TauCeti/Probability/Exchangeability/FullyExchangeable.lean
+++ b/TauCeti/Probability/Exchangeability/FullyExchangeable.lean
@@ -58,7 +58,8 @@ theorem FullyExchangeable.exchangeableAt {μ : Measure Ω} {X : ℕ → Ω → �
     (hX : FullyExchangeable μ X) (hX_meas : ∀ i, AEMeasurable (X i) μ) (n : ℕ) :
     ExchangeableAt μ X n := by
   intro σ
-  obtain ⟨π, hπ⟩ := exists_perm_nat_extending
+  obtain ⟨π, hπ⟩ := Equiv.Perm.exists_extending_pair (fun i : Fin n => i.val)
+    (fun i : Fin n => (σ i).val) Fin.val_injective
     (fun _ _ h => σ.injective (Fin.val_injective h))
   have hidx : (fun j : Fin n => π j.val) = fun j : Fin n => (σ j).val := by
     funext j; exact hπ j

--- a/TauCeti/Probability/Exchangeability/PermutationExtension.lean
+++ b/TauCeti/Probability/Exchangeability/PermutationExtension.lean
@@ -51,8 +51,7 @@ theorem exists_perm_nat_extending {n : ℕ} (k : Fin n → ℕ) (hk : Function.I
   Equiv.Perm.exists_extending_pair (fun i : Fin n => i.val) k Fin.val_injective hk
 
 /-- A strictly monotone finite selection `k : Fin m → ℕ` extends to a strictly increasing
-self-map of `ℕ`.  The extension agrees with `k` on the first `m` inputs and then follows
-the identity shifted above the finite range of `k`. -/
+self-map of `ℕ` that agrees with `k` on the first `m` inputs. -/
 theorem exists_strictMono_nat_extending_fin {m : ℕ} {k : Fin m → ℕ} (hk : StrictMono k) :
     ∃ φ : ℕ → ℕ, StrictMono φ ∧ ∀ i : Fin m, φ i.val = k i := by
   classical

--- a/TauCeti/Probability/Exchangeability/PermutationExtension.lean
+++ b/TauCeti/Probability/Exchangeability/PermutationExtension.lean
@@ -1,0 +1,83 @@
+module
+
+public import Mathlib.Logic.Equiv.Fintype
+public import Mathlib.Order.Fin.Basic
+public import Mathlib.Data.Finset.Lattice.Fold
+
+/-!
+# Permutation extensions for finite exchangeability
+
+This file records the finite combinatorial extension lemmas used in the Layer 0
+exchangeability API.  A finite injective or strictly monotone coordinate selection can be
+completed to a permutation of the ambient finite prefix, and a strictly increasing finite
+subsequence can be extended to a strictly increasing self-map of `ℕ`.
+
+These lemmas discharge the `exists_perm_extending_strictMono` / finite-extension
+prerequisite named in `TauCetiRoadmap/Exchangeability/README.md`, Layer 0.  The finite
+permutation proofs are thin specializations of Mathlib's
+`Equiv.Perm.exists_extending_pair`; the `ℕ` extension is the order-preserving tail
+completion used to bridge finite contractability to path-law reindexing.
+-/
+
+public section
+
+namespace TauCeti
+
+namespace Probability
+
+/-- An injective map `k : Fin m → Fin n` extends across the canonical inclusion
+`Fin.castLE hmn` to a permutation of `Fin n`. -/
+theorem exists_perm_extending_castLE {m n : ℕ} (hmn : m ≤ n)
+    (k : Fin m → Fin n) (hk : Function.Injective k) :
+    ∃ σ : Equiv.Perm (Fin n),
+      ∀ i : Fin m, σ (Fin.castLE hmn i) = k i :=
+  Equiv.Perm.exists_extending_pair (Fin.castLE hmn) k
+    (fun _ _ h => Fin.castLE_injective hmn h)
+    hk
+
+/-- A strictly monotone map `k : Fin m → Fin n` extends across the canonical inclusion
+`Fin.castLE hmn` to a permutation of `Fin n`.  This is the finite permutation-extension
+form used when a contractable subsequence sits inside a longer prefix. -/
+theorem exists_perm_extending_strictMono {m n : ℕ} (hmn : m ≤ n)
+    (k : Fin m → Fin n) (hk : StrictMono k) :
+    ∃ σ : Equiv.Perm (Fin n),
+      ∀ i : Fin m, σ (Fin.castLE hmn i) = k i :=
+  exists_perm_extending_castLE hmn k hk.injective
+
+/-- A strictly monotone finite selection `k : Fin m → ℕ` extends to a strictly increasing
+self-map of `ℕ`.  The extension agrees with `k` on the first `m` inputs and then follows
+the identity shifted above the finite range of `k`. -/
+theorem exists_strictMono_nat_extending_fin {m : ℕ} {k : Fin m → ℕ} (hk : StrictMono k) :
+    ∃ φ : ℕ → ℕ, StrictMono φ ∧ ∀ i : Fin m, φ i.val = k i := by
+  classical
+  let C := Finset.univ.sup k + 1
+  let φ : ℕ → ℕ := fun n => if h : n < m then k ⟨n, h⟩ else n + C
+  refine ⟨φ, ?_, ?_⟩
+  · intro a b hab
+    dsimp only [φ]
+    by_cases ha : a < m
+    · by_cases hb : b < m
+      · rw [dif_pos ha, dif_pos hb]
+        exact hk (Fin.lt_def.mpr hab)
+      · rw [dif_pos ha, dif_neg hb]
+        have hle_sup : k ⟨a, ha⟩ ≤ Finset.univ.sup k :=
+          Finset.le_sup (f := k) (Finset.mem_univ (⟨a, ha⟩ : Fin m))
+        exact (Nat.lt_succ_of_le hle_sup).trans_le (Nat.le_add_left C b)
+    · by_cases hb : b < m
+      · exact (ha (hab.trans hb)).elim
+      · rw [dif_neg ha, dif_neg hb]
+        exact Nat.add_lt_add_right hab C
+  · intro i
+    simp [φ, i.isLt]
+
+/-- A permutation of `Fin n` is the restriction of some permutation of `ℕ`: there is
+`π : Equiv.Perm ℕ` with `π i = σ i` on the first `n` coordinates.  This is the finite
+approximation step used when passing from path-law invariance to finite exchangeability. -/
+theorem exists_perm_nat_extending_fin {n : ℕ} (σ : Equiv.Perm (Fin n)) :
+    ∃ π : Equiv.Perm ℕ, ∀ i : Fin n, π i.val = (σ i).val :=
+  Equiv.Perm.exists_extending_pair (fun i : Fin n => i.val) (fun i => (σ i).val)
+    Fin.val_injective (fun _ _ h => σ.injective (Fin.val_injective h))
+
+end Probability
+
+end TauCeti

--- a/TauCeti/Probability/Exchangeability/PermutationExtension.lean
+++ b/TauCeti/Probability/Exchangeability/PermutationExtension.lean
@@ -7,16 +7,14 @@ public import Mathlib.Data.Finset.Lattice.Fold
 /-!
 # Permutation extensions for finite exchangeability
 
-This file records the finite combinatorial extension lemmas used in the Layer 0
-exchangeability API.  A finite injective or strictly monotone coordinate selection can be
-completed to a permutation of the ambient finite prefix, and a strictly increasing finite
-subsequence can be extended to a strictly increasing self-map of `ℕ`.
+This file records the combinatorial extension lemma used in the Layer 0
+exchangeability API. A strictly increasing finite subsequence can be extended to a
+strictly increasing self-map of `ℕ`.
 
-These lemmas discharge the `exists_perm_extending_strictMono` / finite-extension
-prerequisite named in `TauCetiRoadmap/Exchangeability/README.md`, Layer 0.  The finite
-permutation proofs are thin specializations of Mathlib's
-`Equiv.Perm.exists_extending_pair`; the `ℕ` extension is the order-preserving tail
-completion used to bridge finite contractability to path-law reindexing.
+This lemma discharges the finite-extension prerequisite named in
+`TauCetiRoadmap/Exchangeability/README.md`, Layer 0. The extension is the
+order-preserving tail completion used to bridge finite contractability to path-law
+reindexing.
 -/
 
 public section
@@ -24,25 +22,6 @@ public section
 namespace TauCeti
 
 namespace Probability
-
-/-- An injective map `k : Fin m → Fin n` extends across the canonical inclusion
-`Fin.castLE hmn` to a permutation of `Fin n`. -/
-theorem exists_perm_extending_castLE {m n : ℕ} (hmn : m ≤ n)
-    (k : Fin m → Fin n) (hk : Function.Injective k) :
-    ∃ σ : Equiv.Perm (Fin n),
-      ∀ i : Fin m, σ (Fin.castLE hmn i) = k i :=
-  Equiv.Perm.exists_extending_pair (Fin.castLE hmn) k
-    (fun _ _ h => Fin.castLE_injective hmn h)
-    hk
-
-/-- A strictly monotone map `k : Fin m → Fin n` extends across the canonical inclusion
-`Fin.castLE hmn` to a permutation of `Fin n`.  This is the finite permutation-extension
-form used when a contractable subsequence sits inside a longer prefix. -/
-theorem exists_perm_extending_strictMono {m n : ℕ} (hmn : m ≤ n)
-    (k : Fin m → Fin n) (hk : StrictMono k) :
-    ∃ σ : Equiv.Perm (Fin n),
-      ∀ i : Fin m, σ (Fin.castLE hmn i) = k i :=
-  exists_perm_extending_castLE hmn k hk.injective
 
 /-- A strictly monotone finite selection `k : Fin m → ℕ` extends to a strictly increasing
 self-map of `ℕ`.  The extension agrees with `k` on the first `m` inputs and then follows
@@ -69,14 +48,6 @@ theorem exists_strictMono_nat_extending_fin {m : ℕ} {k : Fin m → ℕ} (hk : 
         exact Nat.add_lt_add_right hab C
   · intro i
     simp [φ, i.isLt]
-
-/-- A permutation of `Fin n` is the restriction of some permutation of `ℕ`: there is
-`π : Equiv.Perm ℕ` with `π i = σ i` on the first `n` coordinates.  This is the finite
-approximation step used when passing from path-law invariance to finite exchangeability. -/
-theorem exists_perm_nat_extending_fin {n : ℕ} (σ : Equiv.Perm (Fin n)) :
-    ∃ π : Equiv.Perm ℕ, ∀ i : Fin n, π i.val = (σ i).val :=
-  Equiv.Perm.exists_extending_pair (fun i : Fin n => i.val) (fun i => (σ i).val)
-    Fin.val_injective (fun _ _ h => σ.injective (Fin.val_injective h))
 
 end Probability
 

--- a/TauCeti/Probability/Exchangeability/PermutationExtension.lean
+++ b/TauCeti/Probability/Exchangeability/PermutationExtension.lean
@@ -1,5 +1,6 @@
 module
 
+public import Mathlib.Logic.Equiv.Fintype
 public import Mathlib.Order.Fin.Basic
 public import Mathlib.Data.Fintype.Basic
 public import Mathlib.Data.Finset.Lattice.Fold

--- a/TauCeti/Probability/Exchangeability/PermutationExtension.lean
+++ b/TauCeti/Probability/Exchangeability/PermutationExtension.lean
@@ -11,13 +11,12 @@ This file records the combinatorial extension lemmas used in the Layer 0
 exchangeability API:
 
 * strictly increasing finite subsequences extend to strictly increasing self-maps of `ℕ`.
-* finite selections inside a larger finite prefix extend to permutations of that prefix.
-* finite selections in `ℕ` extend to permutations of `ℕ`.
+* finite selections inside a larger finite prefix, or in `ℕ`, extend to permutations by Mathlib's
+  `Equiv.Perm.exists_extending_pair`, which this module publicly re-exports.
 
-The finite permutation-extension steps are thin specializations of Mathlib's
-`Equiv.Perm.exists_extending_pair`. The strict-monotone `ℕ` extension helper is adapted from the
-`cameronfreer/exchangeability` Layer 0 sources pinned at
-`e0532e59ceff23edab44dda9ab0655debbc9cc22`, with Tau Ceti API names and hypotheses.
+The strict-monotone `ℕ` extension helper is adapted from the `cameronfreer/exchangeability`
+Layer 0 sources pinned at `e0532e59ceff23edab44dda9ab0655debbc9cc22`, with Tau Ceti API names
+and hypotheses.
 -/
 
 public section
@@ -25,27 +24,6 @@ public section
 namespace TauCeti
 
 namespace Probability
-
-/-- An injective finite selection `k : Fin m → Fin n`, with `m ≤ n`, extends to a permutation
-of `Fin n` that sends the standard first-`m` inclusion to `k`. -/
-theorem exists_perm_extending_castLE {m n : ℕ} (hmn : m ≤ n) {k : Fin m → Fin n}
-    (hk : Function.Injective k) :
-    ∃ σ : Equiv.Perm (Fin n), ∀ i, σ (Fin.castLE hmn i) = k i :=
-  Equiv.Perm.exists_extending_pair (Fin.castLE hmn) k
-    (fun _ _ h => Fin.castLE_injective hmn h) hk
-
-/-- A strictly monotone finite selection `k : Fin m → Fin n`, with `m ≤ n`, extends to a
-permutation of `Fin n` that sends the standard first-`m` inclusion to `k`. -/
-theorem exists_perm_extending_strictMono {m n : ℕ} (hmn : m ≤ n) {k : Fin m → Fin n}
-    (hk : StrictMono k) :
-    ∃ σ : Equiv.Perm (Fin n), ∀ i, σ (Fin.castLE hmn i) = k i :=
-  exists_perm_extending_castLE hmn hk.injective
-
-/-- An injective finite selection `k : Fin n → ℕ` extends to a permutation of `ℕ` that agrees
-with `k` on the first `n` inputs. -/
-theorem exists_perm_nat_extending {n : ℕ} {k : Fin n → ℕ} (hk : Function.Injective k) :
-    ∃ σ : Equiv.Perm ℕ, ∀ i : Fin n, σ i.val = k i :=
-  Equiv.Perm.exists_extending_pair (fun i : Fin n => i.val) k Fin.val_injective hk
 
 /-- A strictly monotone finite selection `k : Fin m → ℕ` extends to a strictly increasing
 self-map of `ℕ` that agrees with `k` on the first `m` inputs. -/

--- a/TauCeti/Probability/Exchangeability/PermutationExtension.lean
+++ b/TauCeti/Probability/Exchangeability/PermutationExtension.lean
@@ -1,7 +1,7 @@
 module
 
-public import Mathlib.Logic.Equiv.Fintype
 public import Mathlib.Order.Fin.Basic
+public import Mathlib.Data.Fintype.Basic
 public import Mathlib.Data.Finset.Lattice.Fold
 
 /-!

--- a/TauCeti/Probability/Exchangeability/PermutationExtension.lean
+++ b/TauCeti/Probability/Exchangeability/PermutationExtension.lean
@@ -7,14 +7,20 @@ public import Mathlib.Data.Finset.Lattice.Fold
 /-!
 # Permutation extensions for finite exchangeability
 
-This file records the combinatorial extension lemma used in the Layer 0
-exchangeability API. A strictly increasing finite subsequence can be extended to a
-strictly increasing self-map of `ℕ`.
+This file records the combinatorial extension lemmas used in the Layer 0
+exchangeability API:
 
-This lemma discharges the finite-extension prerequisite named in
-`TauCetiRoadmap/Exchangeability/README.md`, Layer 0. The extension is the
-order-preserving tail completion used to bridge finite contractability to path-law
-reindexing.
+* injective finite selections extend to permutations of a finite prefix;
+* strictly monotone finite selections have the named finite-permutation wrapper;
+* injective finite selections of `ℕ` extend to permutations of `ℕ`;
+* strictly increasing finite subsequences extend to strictly increasing self-maps of `ℕ`.
+
+These declarations discharge the finite-extension prerequisites named in
+`TauCetiRoadmap/Exchangeability/README.md`, Layer 0. They are adapted from the
+`cameronfreer/exchangeability` Layer 0 sources pinned at
+`e0532e59ceff23edab44dda9ab0655debbc9cc22`, with Tau Ceti API names and hypotheses; the
+finite-permutation wrappers are thin wrappers around Mathlib's
+`Equiv.Perm.exists_extending_pair`.
 -/
 
 public section
@@ -22,6 +28,27 @@ public section
 namespace TauCeti
 
 namespace Probability
+
+/-- An injective selection `k : Fin m → Fin n` extends to a permutation of `Fin n`, agreeing
+with `k` on the first `m` coordinates embedded by `Fin.castLE hmn`. -/
+theorem exists_perm_extending_castLE {m n : ℕ} (hmn : m ≤ n) (k : Fin m → Fin n)
+    (hk : Function.Injective k) :
+    ∃ σ : Equiv.Perm (Fin n), ∀ i : Fin m, σ (Fin.castLE hmn i) = k i :=
+  Equiv.Perm.exists_extending_pair (Fin.castLE hmn) k
+    (fun _ _ h => Fin.castLE_injective hmn h) hk
+
+/-- A strictly monotone selection `k : Fin m → Fin n` extends to a permutation of `Fin n`,
+agreeing with `k` on the first `m` coordinates embedded by `Fin.castLE hmn`. -/
+theorem exists_perm_extending_strictMono {m n : ℕ} (hmn : m ≤ n) (k : Fin m → Fin n)
+    (hk : StrictMono k) :
+    ∃ σ : Equiv.Perm (Fin n), ∀ i : Fin m, σ (Fin.castLE hmn i) = k i :=
+  exists_perm_extending_castLE hmn k hk.injective
+
+/-- An injective finite selection of `ℕ` extends to a permutation of `ℕ`, agreeing with the
+selection on the first `n` natural numbers. -/
+theorem exists_perm_nat_extending {n : ℕ} (k : Fin n → ℕ) (hk : Function.Injective k) :
+    ∃ π : Equiv.Perm ℕ, ∀ i : Fin n, π i.val = k i :=
+  Equiv.Perm.exists_extending_pair (fun i : Fin n => i.val) k Fin.val_injective hk
 
 /-- A strictly monotone finite selection `k : Fin m → ℕ` extends to a strictly increasing
 self-map of `ℕ`.  The extension agrees with `k` on the first `m` inputs and then follows

--- a/TauCeti/Probability/Exchangeability/PermutationExtension.lean
+++ b/TauCeti/Probability/Exchangeability/PermutationExtension.lean
@@ -10,17 +10,13 @@ public import Mathlib.Data.Finset.Lattice.Fold
 This file records the combinatorial extension lemmas used in the Layer 0
 exchangeability API:
 
-* injective finite selections extend to permutations of a finite prefix;
-* strictly monotone finite selections have the named finite-permutation wrapper;
-* injective finite selections of `ℕ` extend to permutations of `ℕ`;
 * strictly increasing finite subsequences extend to strictly increasing self-maps of `ℕ`.
 
 These declarations discharge the finite-extension prerequisites named in
 `TauCetiRoadmap/Exchangeability/README.md`, Layer 0. They are adapted from the
 `cameronfreer/exchangeability` Layer 0 sources pinned at
-`e0532e59ceff23edab44dda9ab0655debbc9cc22`, with Tau Ceti API names and hypotheses; the
-finite-permutation wrappers are thin wrappers around Mathlib's
-`Equiv.Perm.exists_extending_pair`.
+`e0532e59ceff23edab44dda9ab0655debbc9cc22`, with Tau Ceti API names and hypotheses. Finite
+permutation extensions should use Mathlib's `Equiv.Perm.exists_extending_pair` directly.
 -/
 
 public section
@@ -28,27 +24,6 @@ public section
 namespace TauCeti
 
 namespace Probability
-
-/-- An injective selection `k : Fin m → Fin n` extends to a permutation of `Fin n`, agreeing
-with `k` on the first `m` coordinates embedded by `Fin.castLE hmn`. -/
-theorem exists_perm_extending_castLE {m n : ℕ} (hmn : m ≤ n) (k : Fin m → Fin n)
-    (hk : Function.Injective k) :
-    ∃ σ : Equiv.Perm (Fin n), ∀ i : Fin m, σ (Fin.castLE hmn i) = k i :=
-  Equiv.Perm.exists_extending_pair (Fin.castLE hmn) k
-    (fun _ _ h => Fin.castLE_injective hmn h) hk
-
-/-- A strictly monotone selection `k : Fin m → Fin n` extends to a permutation of `Fin n`,
-agreeing with `k` on the first `m` coordinates embedded by `Fin.castLE hmn`. -/
-theorem exists_perm_extending_strictMono {m n : ℕ} (hmn : m ≤ n) (k : Fin m → Fin n)
-    (hk : StrictMono k) :
-    ∃ σ : Equiv.Perm (Fin n), ∀ i : Fin m, σ (Fin.castLE hmn i) = k i :=
-  exists_perm_extending_castLE hmn k hk.injective
-
-/-- An injective finite selection of `ℕ` extends to a permutation of `ℕ`, agreeing with the
-selection on the first `n` natural numbers. -/
-theorem exists_perm_nat_extending {n : ℕ} (k : Fin n → ℕ) (hk : Function.Injective k) :
-    ∃ π : Equiv.Perm ℕ, ∀ i : Fin n, π i.val = k i :=
-  Equiv.Perm.exists_extending_pair (fun i : Fin n => i.val) k Fin.val_injective hk
 
 /-- A strictly monotone finite selection `k : Fin m → ℕ` extends to a strictly increasing
 self-map of `ℕ` that agrees with `k` on the first `m` inputs. -/

--- a/TauCeti/Probability/Exchangeability/PermutationExtension.lean
+++ b/TauCeti/Probability/Exchangeability/PermutationExtension.lean
@@ -2,8 +2,7 @@ module
 
 public import Mathlib.Logic.Equiv.Fintype
 public import Mathlib.Order.Fin.Basic
-public import Mathlib.Data.Fintype.Basic
-public import Mathlib.Data.Finset.Lattice.Fold
+import Mathlib.Data.Finset.Lattice.Fold
 
 /-!
 # Permutation extensions for finite exchangeability
@@ -12,12 +11,12 @@ This file records the combinatorial extension lemmas used in the Layer 0
 exchangeability API:
 
 * strictly increasing finite subsequences extend to strictly increasing self-maps of `ℕ`.
+* finite selections inside a larger finite prefix extend to permutations of that prefix.
+* finite selections in `ℕ` extend to permutations of `ℕ`.
 
-The finite permutation-extension step named in
-`TauCetiRoadmap/Exchangeability/README.md`, Layer 0, is supplied by Mathlib's
-`Equiv.Perm.exists_extending_pair` and re-exported here. The declaration below records the
-separate strict-monotone `ℕ` extension helper used by the contractability API. It is adapted from
-the `cameronfreer/exchangeability` Layer 0 sources pinned at
+The finite permutation-extension steps are thin specializations of Mathlib's
+`Equiv.Perm.exists_extending_pair`. The strict-monotone `ℕ` extension helper is adapted from the
+`cameronfreer/exchangeability` Layer 0 sources pinned at
 `e0532e59ceff23edab44dda9ab0655debbc9cc22`, with Tau Ceti API names and hypotheses.
 -/
 
@@ -26,6 +25,27 @@ public section
 namespace TauCeti
 
 namespace Probability
+
+/-- An injective finite selection `k : Fin m → Fin n`, with `m ≤ n`, extends to a permutation
+of `Fin n` that sends the standard first-`m` inclusion to `k`. -/
+theorem exists_perm_extending_castLE {m n : ℕ} (hmn : m ≤ n) {k : Fin m → Fin n}
+    (hk : Function.Injective k) :
+    ∃ σ : Equiv.Perm (Fin n), ∀ i, σ (Fin.castLE hmn i) = k i :=
+  Equiv.Perm.exists_extending_pair (Fin.castLE hmn) k
+    (fun _ _ h => Fin.castLE_injective hmn h) hk
+
+/-- A strictly monotone finite selection `k : Fin m → Fin n`, with `m ≤ n`, extends to a
+permutation of `Fin n` that sends the standard first-`m` inclusion to `k`. -/
+theorem exists_perm_extending_strictMono {m n : ℕ} (hmn : m ≤ n) {k : Fin m → Fin n}
+    (hk : StrictMono k) :
+    ∃ σ : Equiv.Perm (Fin n), ∀ i, σ (Fin.castLE hmn i) = k i :=
+  exists_perm_extending_castLE hmn hk.injective
+
+/-- An injective finite selection `k : Fin n → ℕ` extends to a permutation of `ℕ` that agrees
+with `k` on the first `n` inputs. -/
+theorem exists_perm_nat_extending {n : ℕ} {k : Fin n → ℕ} (hk : Function.Injective k) :
+    ∃ σ : Equiv.Perm ℕ, ∀ i : Fin n, σ i.val = k i :=
+  Equiv.Perm.exists_extending_pair (fun i : Fin n => i.val) k Fin.val_injective hk
 
 /-- A strictly monotone finite selection `k : Fin m → ℕ` extends to a strictly increasing
 self-map of `ℕ` that agrees with `k` on the first `m` inputs. -/

--- a/TauCeti/Probability/Exchangeability/PermutationExtension.lean
+++ b/TauCeti/Probability/Exchangeability/PermutationExtension.lean
@@ -13,11 +13,12 @@ exchangeability API:
 
 * strictly increasing finite subsequences extend to strictly increasing self-maps of `ℕ`.
 
-These declarations discharge the finite-extension prerequisites named in
-`TauCetiRoadmap/Exchangeability/README.md`, Layer 0. They are adapted from the
-`cameronfreer/exchangeability` Layer 0 sources pinned at
-`e0532e59ceff23edab44dda9ab0655debbc9cc22`, with Tau Ceti API names and hypotheses. Finite
-permutation extensions should use Mathlib's `Equiv.Perm.exists_extending_pair` directly.
+The finite permutation-extension step named in
+`TauCetiRoadmap/Exchangeability/README.md`, Layer 0, is supplied by Mathlib's
+`Equiv.Perm.exists_extending_pair` and re-exported here. The declaration below records the
+separate strict-monotone `ℕ` extension helper used by the contractability API. It is adapted from
+the `cameronfreer/exchangeability` Layer 0 sources pinned at
+`e0532e59ceff23edab44dda9ab0655debbc9cc22`, with Tau Ceti API names and hypotheses.
 -/
 
 public section


### PR DESCRIPTION
This PR exposes a public Layer 0 permutation-extension module for the Exchangeability roadmap: finite injective selections and finite strictly monotone selections into `Fin n` extend across `Fin.castLE` to permutations of `Fin n`, strictly monotone finite selections into `ℕ` extend to strictly monotone self-maps of `ℕ`, and finite permutations extend to permutations of `ℕ`. It advances `TauCetiRoadmap/Exchangeability/README.md`, Layer 0, specifically the build item “finite approximation of infinite permutations; extension of strictly monotone finite selections to finite permutations” and the key milestone `exists_perm_extending_strictMono`.

I chose this as the lowest-hanging distinct Exchangeability target after checking open and recently merged PRs: open work covers reverse-martingale convergence and prefix-deletion de Finetti ingredients, while `main` already had private local versions of these finite extension steps inside the Layer 0 bridge files but no public reusable API for the roadmap-named combinatorial prerequisite.

No Mathlib infrastructure is vendored. The finite permutation lemmas specialize Mathlib’s `Equiv.Perm.exists_extending_pair`; the strictly monotone `ℕ` extension is the existing Tau Ceti order-preserving tail completion moved from private proof glue into a documented public module.

`lake exe cache get` completed with `No files to download` and `Already decompressed 8609 file(s)`. `lake build` completed with `Build completed successfully (4551 jobs).` `lake exe axioms` completed with `axioms: audited 8338 TauCeti declaration(s); all within the allowlist [propext, Classical.choice, Quot.sound].`

<!--tauceti-target:v1 {"focus":"Exchangeability","id":"exists-perm-extending-strictmono"}-->

🤖 Prepared with Codex
