### PR TITLE
feat: add Hopf ideal point subgroup order API

### DIFF
--- a/TauCeti/Algebra/AlgebraicGroup/HopfIdealPointsOrder.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/HopfIdealPointsOrder.lean
@@ -73,7 +73,6 @@ theorem mem_quotientPointsSubgroup_of_le (H : _root_.CommHopfAlgCat.{v} R)
   quotientPointsSubgroup_le_of_le H hIJ A hg
 
 /-- If `I = J`, then the point subgroups cut out by `I` and `J` are equal. -/
-@[simp]
 theorem quotientPointsSubgroup_eq_of_eq (H : _root_.CommHopfAlgCat.{v} R)
     {I J : HopfIdeal R H} (hIJ : I = J) (A : CommAlgCat.{w} R) :
     quotientPointsSubgroup H I A = quotientPointsSubgroup H J A := by

--- a/TauCeti/Algebra/AlgebraicGroup/HopfIdealPointsOrder.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/HopfIdealPointsOrder.lean
@@ -23,7 +23,9 @@ value algebra.
 
 * `CommHopfAlgCat.quotientPointsSubgroup_antitone`: the cut-out point subgroup is antitone in
   the Hopf ideal.
-* `CommHopfAlgCat.mapQuotientPointsSubgroup_inclusion`: these inclusions commute with
+* `CommHopfAlgCat.quotientPointsSubgroupInclusion`: the bundled natural inclusion between
+  subgroup functors induced by `I ≤ J`.
+* `CommHopfAlgCat.mapQuotientPointsSubgroup_inclusion_apply`: these inclusions commute with
   post-composition in the value algebra.
 
 ## References
@@ -91,8 +93,39 @@ theorem quotientPointsSubgroup_bot (H : _root_.CommHopfAlgCat.{v} R)
     intro h hh
     rw [HopfIdeal.mem_bot.mp hh, map_zero]
 
+/-- The natural inclusion of subgroup functors associated to `I ≤ J`. -/
+@[expose] noncomputable def quotientPointsSubgroupInclusion
+    (H : _root_.CommHopfAlgCat.{v} R) {I J : HopfIdeal R H} (hIJ : I ≤ J) :
+    quotientPointsSubgroupFunctor (R := R) H J ⟶
+      quotientPointsSubgroupFunctor (R := R) H I where
+  app A := GrpCat.ofHom (Subgroup.inclusion (quotientPointsSubgroup_le_of_le H hIJ A))
+  naturality {A B} χ := by
+    simp only [quotientPointsSubgroupFunctor_obj, quotientPointsSubgroupFunctor_map]
+    rw [← GrpCat.ofHom_comp, ← GrpCat.ofHom_comp]
+    apply GrpCat.hom_ext
+    apply MonoidHom.ext
+    intro g
+    apply Subtype.ext
+    change (Subgroup.inclusion (quotientPointsSubgroup_le_of_le H hIJ B)
+        (mapQuotientPointsSubgroup H J χ g) :
+          HopfAlgebra.points (R := R) (H := H) B) =
+      (mapQuotientPointsSubgroup H I χ
+        (Subgroup.inclusion (quotientPointsSubgroup_le_of_le H hIJ A) g) :
+          HopfAlgebra.points (R := R) (H := H) B)
+    rw [coe_mapQuotientPointsSubgroup_apply, Subgroup.coe_inclusion,
+      Subgroup.coe_inclusion, coe_mapQuotientPointsSubgroup_apply]
+
+/-- The component of `quotientPointsSubgroupInclusion` is the subgroup inclusion. -/
+@[simp]
+lemma quotientPointsSubgroupInclusion_app
+    (H : _root_.CommHopfAlgCat.{v} R) {I J : HopfIdeal R H} (hIJ : I ≤ J)
+    (A : CommAlgCat.{w} R) :
+    (quotientPointsSubgroupInclusion (R := R) H hIJ).app A =
+      GrpCat.ofHom (Subgroup.inclusion (quotientPointsSubgroup_le_of_le H hIJ A)) :=
+  rfl
+
 /-- The subgroup inclusions associated to `I ≤ J` commute with maps of value algebras. -/
-theorem mapQuotientPointsSubgroup_inclusion
+theorem mapQuotientPointsSubgroup_inclusion_apply
     (H : _root_.CommHopfAlgCat.{v} R) {I J : HopfIdeal R H} (hIJ : I ≤ J)
     {A B : CommAlgCat.{w} R} (χ : A ⟶ B) (g : quotientPointsSubgroup H J A) :
     mapQuotientPointsSubgroup H I χ

--- a/TauCeti/Algebra/AlgebraicGroup/HopfIdealPointsOrder.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/HopfIdealPointsOrder.lean
@@ -1,0 +1,166 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+module
+
+public import TauCeti.Algebra.AlgebraicGroup.HopfIdealPointsNaturality
+
+/-!
+# Order of Hopf-ideal quotient point subgroups
+
+A Hopf ideal `I` cuts out, on every value algebra `A`, the subgroup of ambient points
+`H(A)` which vanish on `I`. This file records the elementary order behavior of this
+construction: if `I ≤ J`, then every point which kills `J` also kills `I`, so the subgroup
+cut out by `J` is contained in the subgroup cut out by `I`.
+
+This is the point-level order bookkeeping for the Layer 3 ReductiveGroups roadmap item
+"Hopf ideals ↔ closed subgroup schemes". Larger Hopf ideals correspond contravariantly to
+smaller closed subgroup functors, and the inclusion is compatible with functoriality in the
+value algebra.
+
+## Main declarations
+
+* `CommHopfAlgCat.quotientPointsSubgroup_antitone`: the cut-out point subgroup is antitone in
+  the Hopf ideal.
+* `CommHopfAlgCat.quotientPointsSubgroupInclusion`: the inclusion hom
+  `G_J(A) →* G_I(A)` for `I ≤ J`.
+* `CommHopfAlgCat.mapQuotientPointsSubgroup_inclusion`: these inclusions commute with
+  post-composition in the value algebra.
+
+## References
+
+This uses the vanishing characterization of quotient points from
+`TauCeti.Algebra.AlgebraicGroup.HopfIdealPoints` and the naturality API from
+`TauCeti.Algebra.AlgebraicGroup.HopfIdealPointsNaturality`.
+-/
+
+public section
+
+open CategoryTheory WithConv
+
+namespace TauCeti
+
+universe u v w
+
+namespace CommHopfAlgCat
+
+variable {R : Type u} [CommRing R]
+
+/-- The point subgroup cut out by a Hopf ideal is antitone in the Hopf ideal:
+larger ideals impose more vanishing equations. -/
+theorem quotientPointsSubgroup_antitone (H : _root_.CommHopfAlgCat.{v} R)
+    (A : CommAlgCat.{w} R) :
+    Antitone fun I : HopfIdeal R H => quotientPointsSubgroup H I A := by
+  intro I J hIJ g hg
+  rw [mem_quotientPointsSubgroup_iff] at hg ⊢
+  intro h hh
+  exact hg h (hIJ hh)
+
+/-- If `I ≤ J`, then the point subgroup cut out by `J` is contained in the point subgroup
+cut out by `I`. -/
+theorem quotientPointsSubgroup_le_of_le (H : _root_.CommHopfAlgCat.{v} R)
+    {I J : HopfIdeal R H} (hIJ : I ≤ J) (A : CommAlgCat.{w} R) :
+    quotientPointsSubgroup H J A ≤ quotientPointsSubgroup H I A :=
+  quotientPointsSubgroup_antitone H A hIJ
+
+/-- Rewriting form of `quotientPointsSubgroup_le_of_le` as a membership implication. -/
+theorem mem_quotientPointsSubgroup_of_le (H : _root_.CommHopfAlgCat.{v} R)
+    {I J : HopfIdeal R H} (hIJ : I ≤ J) (A : CommAlgCat.{w} R)
+    {g : HopfAlgebra.points (R := R) (H := H) A}
+    (hg : g ∈ quotientPointsSubgroup H J A) :
+    g ∈ quotientPointsSubgroup H I A :=
+  quotientPointsSubgroup_le_of_le H hIJ A hg
+
+/-- If `I = J`, then the point subgroups cut out by `I` and `J` are equal. -/
+@[simp]
+theorem quotientPointsSubgroup_eq_of_eq (H : _root_.CommHopfAlgCat.{v} R)
+    {I J : HopfIdeal R H} (hIJ : I = J) (A : CommAlgCat.{w} R) :
+    quotientPointsSubgroup H I A = quotientPointsSubgroup H J A := by
+  subst hIJ
+  rfl
+
+/-- The point subgroup cut out by the zero Hopf ideal is the full ambient point group. -/
+@[simp]
+theorem quotientPointsSubgroup_bot (H : _root_.CommHopfAlgCat.{v} R)
+    (A : CommAlgCat.{w} R) :
+    quotientPointsSubgroup H (⊥ : HopfIdeal R H) A = ⊤ := by
+  ext g
+  constructor
+  · intro _
+    exact Subgroup.mem_top g
+  · intro _
+    rw [mem_quotientPointsSubgroup_iff]
+    intro h hh
+    rw [HopfIdeal.mem_bot.mp hh, map_zero]
+
+/-- For `I ≤ J`, the inclusion of point subgroups cut out by Hopf ideals,
+`G_J(A) →* G_I(A)`. -/
+@[expose] noncomputable def quotientPointsSubgroupInclusion
+    (H : _root_.CommHopfAlgCat.{v} R) {I J : HopfIdeal R H} (hIJ : I ≤ J)
+    (A : CommAlgCat.{w} R) :
+    quotientPointsSubgroup H J A →* quotientPointsSubgroup H I A :=
+  Subgroup.inclusion (quotientPointsSubgroup_le_of_le H hIJ A)
+
+/-- The inclusion between cut-out point subgroups is the identity on ambient points. -/
+@[simp]
+theorem quotientPointsSubgroupInclusion_apply
+    (H : _root_.CommHopfAlgCat.{v} R) {I J : HopfIdeal R H} (hIJ : I ≤ J)
+    (A : CommAlgCat.{w} R) (g : quotientPointsSubgroup H J A) :
+    quotientPointsSubgroupInclusion H hIJ A g =
+      ⟨g, mem_quotientPointsSubgroup_of_le H hIJ A g.property⟩ :=
+  rfl
+
+/-- Coercing the inclusion between cut-out point subgroups gives the same ambient point. -/
+@[simp]
+theorem coe_quotientPointsSubgroupInclusion_apply
+    (H : _root_.CommHopfAlgCat.{v} R) {I J : HopfIdeal R H} (hIJ : I ≤ J)
+    (A : CommAlgCat.{w} R) (g : quotientPointsSubgroup H J A) :
+    (quotientPointsSubgroupInclusion H hIJ A g :
+      HopfAlgebra.points (R := R) (H := H) A) = g :=
+  rfl
+
+/-- Pointwise form of the inclusion between cut-out point subgroups. -/
+@[simp]
+theorem quotientPointsSubgroupInclusion_apply_apply
+    (H : _root_.CommHopfAlgCat.{v} R) {I J : HopfIdeal R H} (hIJ : I ≤ J)
+    (A : CommAlgCat.{w} R) (g : quotientPointsSubgroup H J A) (h : H) :
+    ((quotientPointsSubgroupInclusion H hIJ A g :
+      HopfAlgebra.points (R := R) (H := H) A).ofConv) h = g.val.ofConv h :=
+  rfl
+
+/-- Inclusions of cut-out point subgroups compose along chains of Hopf ideals. -/
+@[simp]
+theorem quotientPointsSubgroupInclusion_comp
+    (H : _root_.CommHopfAlgCat.{v} R) {I J K : HopfIdeal R H}
+    (hIJ : I ≤ J) (hJK : J ≤ K) (A : CommAlgCat.{w} R) :
+    (quotientPointsSubgroupInclusion H hIJ A).comp
+        (quotientPointsSubgroupInclusion H hJK A) =
+      quotientPointsSubgroupInclusion H (hIJ.trans hJK) A := by
+  ext g
+  rfl
+
+/-- The inclusion for `I ≤ I` is the identity homomorphism. -/
+@[simp]
+theorem quotientPointsSubgroupInclusion_refl
+    (H : _root_.CommHopfAlgCat.{v} R) (I : HopfIdeal R H) (A : CommAlgCat.{w} R) :
+    quotientPointsSubgroupInclusion H (le_refl I) A =
+      MonoidHom.id (quotientPointsSubgroup H I A) := by
+  ext g
+  rfl
+
+/-- The subgroup inclusions associated to `I ≤ J` commute with maps of value algebras. -/
+theorem mapQuotientPointsSubgroup_inclusion
+    (H : _root_.CommHopfAlgCat.{v} R) {I J : HopfIdeal R H} (hIJ : I ≤ J)
+    {A B : CommAlgCat.{w} R} (χ : A ⟶ B) (g : quotientPointsSubgroup H J A) :
+    mapQuotientPointsSubgroup H I χ
+        (quotientPointsSubgroupInclusion H hIJ A g) =
+      quotientPointsSubgroupInclusion H hIJ B
+        (mapQuotientPointsSubgroup H J χ g) := by
+  apply Subtype.ext
+  rw [coe_mapQuotientPointsSubgroup_apply, coe_quotientPointsSubgroupInclusion_apply,
+    coe_quotientPointsSubgroupInclusion_apply, coe_mapQuotientPointsSubgroup_apply]
+
+end CommHopfAlgCat
+
+end TauCeti

--- a/TauCeti/Algebra/AlgebraicGroup/HopfIdealPointsOrder.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/HopfIdealPointsOrder.lean
@@ -107,7 +107,7 @@ theorem mapQuotientPointsSubgroup_inclusion_apply
     coe_mapQuotientPointsSubgroup_apply]
 
 /-- The natural inclusion of subgroup functors associated to `I ≤ J`. -/
-noncomputable abbrev quotientPointsSubgroupInclusion
+@[expose] noncomputable def quotientPointsSubgroupInclusion
     (H : _root_.CommHopfAlgCat.{v} R) {I J : HopfIdeal R H} (hIJ : I ≤ J) :
     quotientPointsSubgroupFunctor (R := R) H J ⟶
       quotientPointsSubgroupFunctor (R := R) H I where
@@ -128,6 +128,28 @@ lemma quotientPointsSubgroupInclusion_app
     (quotientPointsSubgroupInclusion (R := R) H hIJ).app A =
       GrpCat.ofHom (Subgroup.inclusion (quotientPointsSubgroup_le_of_le H hIJ A)) :=
   rfl
+
+/-- The inclusion associated to reflexivity is the identity natural transformation. -/
+@[simp]
+lemma quotientPointsSubgroupInclusion_refl
+    (H : _root_.CommHopfAlgCat.{v} R) (I : HopfIdeal R H) :
+    quotientPointsSubgroupInclusion (R := R) H (le_refl I) =
+      𝟙 (quotientPointsSubgroupFunctor (R := R) H I) := by
+  ext A g
+  exact SubgroupClass.inclusion_self g
+
+/-- Inclusions of quotient point subgroup functors compose along transitive ideal inclusions. -/
+@[simp]
+lemma quotientPointsSubgroupInclusion_comp
+    (H : _root_.CommHopfAlgCat.{v} R) {I J K : HopfIdeal R H}
+    (hIJ : I ≤ J) (hJK : J ≤ K) :
+    quotientPointsSubgroupInclusion (R := R) H hJK ≫
+        quotientPointsSubgroupInclusion (R := R) H hIJ =
+      quotientPointsSubgroupInclusion (R := R) H (hIJ.trans hJK) := by
+  ext A g
+  exact SubgroupClass.inclusion_inclusion
+    (quotientPointsSubgroup_le_of_le H hJK A)
+    (quotientPointsSubgroup_le_of_le H hIJ A) g
 
 end CommHopfAlgCat
 

--- a/TauCeti/Algebra/AlgebraicGroup/HopfIdealPointsOrder.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/HopfIdealPointsOrder.lean
@@ -93,38 +93,8 @@ theorem quotientPointsSubgroup_bot (H : _root_.CommHopfAlgCat.{v} R)
     intro h hh
     rw [HopfIdeal.mem_bot.mp hh, map_zero]
 
-/-- The natural inclusion of subgroup functors associated to `I ≤ J`. -/
-@[expose] noncomputable def quotientPointsSubgroupInclusion
-    (H : _root_.CommHopfAlgCat.{v} R) {I J : HopfIdeal R H} (hIJ : I ≤ J) :
-    quotientPointsSubgroupFunctor (R := R) H J ⟶
-      quotientPointsSubgroupFunctor (R := R) H I where
-  app A := GrpCat.ofHom (Subgroup.inclusion (quotientPointsSubgroup_le_of_le H hIJ A))
-  naturality {A B} χ := by
-    simp only [quotientPointsSubgroupFunctor_obj, quotientPointsSubgroupFunctor_map]
-    rw [← GrpCat.ofHom_comp, ← GrpCat.ofHom_comp]
-    apply GrpCat.hom_ext
-    apply MonoidHom.ext
-    intro g
-    apply Subtype.ext
-    change (Subgroup.inclusion (quotientPointsSubgroup_le_of_le H hIJ B)
-        (mapQuotientPointsSubgroup H J χ g) :
-          HopfAlgebra.points (R := R) (H := H) B) =
-      (mapQuotientPointsSubgroup H I χ
-        (Subgroup.inclusion (quotientPointsSubgroup_le_of_le H hIJ A) g) :
-          HopfAlgebra.points (R := R) (H := H) B)
-    rw [coe_mapQuotientPointsSubgroup_apply, Subgroup.coe_inclusion,
-      Subgroup.coe_inclusion, coe_mapQuotientPointsSubgroup_apply]
-
-/-- The component of `quotientPointsSubgroupInclusion` is the subgroup inclusion. -/
-@[simp]
-lemma quotientPointsSubgroupInclusion_app
-    (H : _root_.CommHopfAlgCat.{v} R) {I J : HopfIdeal R H} (hIJ : I ≤ J)
-    (A : CommAlgCat.{w} R) :
-    (quotientPointsSubgroupInclusion (R := R) H hIJ).app A =
-      GrpCat.ofHom (Subgroup.inclusion (quotientPointsSubgroup_le_of_le H hIJ A)) :=
-  rfl
-
 /-- The subgroup inclusions associated to `I ≤ J` commute with maps of value algebras. -/
+@[simp]
 theorem mapQuotientPointsSubgroup_inclusion_apply
     (H : _root_.CommHopfAlgCat.{v} R) {I J : HopfIdeal R H} (hIJ : I ≤ J)
     {A B : CommAlgCat.{w} R} (χ : A ⟶ B) (g : quotientPointsSubgroup H J A) :
@@ -135,6 +105,29 @@ theorem mapQuotientPointsSubgroup_inclusion_apply
   apply Subtype.ext
   rw [coe_mapQuotientPointsSubgroup_apply, Subgroup.coe_inclusion, Subgroup.coe_inclusion,
     coe_mapQuotientPointsSubgroup_apply]
+
+/-- The natural inclusion of subgroup functors associated to `I ≤ J`. -/
+noncomputable abbrev quotientPointsSubgroupInclusion
+    (H : _root_.CommHopfAlgCat.{v} R) {I J : HopfIdeal R H} (hIJ : I ≤ J) :
+    quotientPointsSubgroupFunctor (R := R) H J ⟶
+      quotientPointsSubgroupFunctor (R := R) H I where
+  app A := GrpCat.ofHom (Subgroup.inclusion (quotientPointsSubgroup_le_of_le H hIJ A))
+  naturality {A B} χ := by
+    simp only [quotientPointsSubgroupFunctor_obj, quotientPointsSubgroupFunctor_map]
+    rw [← GrpCat.ofHom_comp, ← GrpCat.ofHom_comp]
+    apply GrpCat.hom_ext
+    apply MonoidHom.ext
+    intro g
+    exact mapQuotientPointsSubgroup_inclusion_apply H hIJ χ g
+
+/-- The component of `quotientPointsSubgroupInclusion` is the subgroup inclusion. -/
+@[simp]
+lemma quotientPointsSubgroupInclusion_app
+    (H : _root_.CommHopfAlgCat.{v} R) {I J : HopfIdeal R H} (hIJ : I ≤ J)
+    (A : CommAlgCat.{w} R) :
+    (quotientPointsSubgroupInclusion (R := R) H hIJ).app A =
+      GrpCat.ofHom (Subgroup.inclusion (quotientPointsSubgroup_le_of_le H hIJ A)) :=
+  rfl
 
 end CommHopfAlgCat
 

--- a/TauCeti/Algebra/AlgebraicGroup/HopfIdealPointsOrder.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/HopfIdealPointsOrder.lean
@@ -23,8 +23,6 @@ value algebra.
 
 * `CommHopfAlgCat.quotientPointsSubgroup_antitone`: the cut-out point subgroup is antitone in
   the Hopf ideal.
-* `CommHopfAlgCat.quotientPointsSubgroupInclusion`: the inclusion hom
-  `G_J(A) →* G_I(A)` for `I ≤ J`.
 * `CommHopfAlgCat.mapQuotientPointsSubgroup_inclusion`: these inclusions commute with
   post-composition in the value algebra.
 
@@ -93,72 +91,17 @@ theorem quotientPointsSubgroup_bot (H : _root_.CommHopfAlgCat.{v} R)
     intro h hh
     rw [HopfIdeal.mem_bot.mp hh, map_zero]
 
-/-- For `I ≤ J`, the inclusion of point subgroups cut out by Hopf ideals,
-`G_J(A) →* G_I(A)`. -/
-@[expose] noncomputable def quotientPointsSubgroupInclusion
-    (H : _root_.CommHopfAlgCat.{v} R) {I J : HopfIdeal R H} (hIJ : I ≤ J)
-    (A : CommAlgCat.{w} R) :
-    quotientPointsSubgroup H J A →* quotientPointsSubgroup H I A :=
-  Subgroup.inclusion (quotientPointsSubgroup_le_of_le H hIJ A)
-
-/-- The inclusion between cut-out point subgroups is the identity on ambient points. -/
-@[simp]
-theorem quotientPointsSubgroupInclusion_apply
-    (H : _root_.CommHopfAlgCat.{v} R) {I J : HopfIdeal R H} (hIJ : I ≤ J)
-    (A : CommAlgCat.{w} R) (g : quotientPointsSubgroup H J A) :
-    quotientPointsSubgroupInclusion H hIJ A g =
-      ⟨g, mem_quotientPointsSubgroup_of_le H hIJ A g.property⟩ :=
-  rfl
-
-/-- Coercing the inclusion between cut-out point subgroups gives the same ambient point. -/
-@[simp]
-theorem coe_quotientPointsSubgroupInclusion_apply
-    (H : _root_.CommHopfAlgCat.{v} R) {I J : HopfIdeal R H} (hIJ : I ≤ J)
-    (A : CommAlgCat.{w} R) (g : quotientPointsSubgroup H J A) :
-    (quotientPointsSubgroupInclusion H hIJ A g :
-      HopfAlgebra.points (R := R) (H := H) A) = g :=
-  rfl
-
-/-- Pointwise form of the inclusion between cut-out point subgroups. -/
-@[simp]
-theorem quotientPointsSubgroupInclusion_apply_apply
-    (H : _root_.CommHopfAlgCat.{v} R) {I J : HopfIdeal R H} (hIJ : I ≤ J)
-    (A : CommAlgCat.{w} R) (g : quotientPointsSubgroup H J A) (h : H) :
-    ((quotientPointsSubgroupInclusion H hIJ A g :
-      HopfAlgebra.points (R := R) (H := H) A).ofConv) h = g.val.ofConv h :=
-  rfl
-
-/-- Inclusions of cut-out point subgroups compose along chains of Hopf ideals. -/
-@[simp]
-theorem quotientPointsSubgroupInclusion_comp
-    (H : _root_.CommHopfAlgCat.{v} R) {I J K : HopfIdeal R H}
-    (hIJ : I ≤ J) (hJK : J ≤ K) (A : CommAlgCat.{w} R) :
-    (quotientPointsSubgroupInclusion H hIJ A).comp
-        (quotientPointsSubgroupInclusion H hJK A) =
-      quotientPointsSubgroupInclusion H (hIJ.trans hJK) A := by
-  ext g
-  rfl
-
-/-- The inclusion for `I ≤ I` is the identity homomorphism. -/
-@[simp]
-theorem quotientPointsSubgroupInclusion_refl
-    (H : _root_.CommHopfAlgCat.{v} R) (I : HopfIdeal R H) (A : CommAlgCat.{w} R) :
-    quotientPointsSubgroupInclusion H (le_refl I) A =
-      MonoidHom.id (quotientPointsSubgroup H I A) := by
-  ext g
-  rfl
-
 /-- The subgroup inclusions associated to `I ≤ J` commute with maps of value algebras. -/
 theorem mapQuotientPointsSubgroup_inclusion
     (H : _root_.CommHopfAlgCat.{v} R) {I J : HopfIdeal R H} (hIJ : I ≤ J)
     {A B : CommAlgCat.{w} R} (χ : A ⟶ B) (g : quotientPointsSubgroup H J A) :
     mapQuotientPointsSubgroup H I χ
-        (quotientPointsSubgroupInclusion H hIJ A g) =
-      quotientPointsSubgroupInclusion H hIJ B
+        (Subgroup.inclusion (quotientPointsSubgroup_le_of_le H hIJ A) g) =
+      Subgroup.inclusion (quotientPointsSubgroup_le_of_le H hIJ B)
         (mapQuotientPointsSubgroup H J χ g) := by
   apply Subtype.ext
-  rw [coe_mapQuotientPointsSubgroup_apply, coe_quotientPointsSubgroupInclusion_apply,
-    coe_quotientPointsSubgroupInclusion_apply, coe_mapQuotientPointsSubgroup_apply]
+  rw [coe_mapQuotientPointsSubgroup_apply, Subgroup.coe_inclusion, Subgroup.coe_inclusion,
+    coe_mapQuotientPointsSubgroup_apply]
 
 end CommHopfAlgCat
 


### PR DESCRIPTION
This PR records the antitone order behavior of Hopf-ideal cut-out point subgroups: if `I ≤ J`, then the `A`-points vanishing on `J` include into the `A`-points vanishing on `I`, and those inclusions commute with maps of value algebras. It advances `TauCetiRoadmap/ReductiveGroups/README.md`, Layer 3, “Hopf ideals ↔ closed subgroup schemes,” specifically the closed-subgroup dictionary and quotient bookkeeping after Hopf ideals cut out point subgroups.

I chose this as the lowest-hanging distinct ReductiveGroups target after checking open and recently merged PRs: open ReductiveGroups work covers finite-type trivial coordinate objects and kernel quotient point equivalences, while `main` already has quotient point subgroups and their value-algebra naturality but not the order/inclusion API saying larger Hopf ideals cut out smaller point subgroups.

No Mathlib infrastructure is vendored. The implementation reuses Tau Ceti’s existing `CommHopfAlgCat.mem_quotientPointsSubgroup_iff`, `mapQuotientPointsSubgroup`, and Mathlib’s standard `Subgroup.inclusion` API.

`lake exe cache get` completed with `No files to download` and `Already decompressed 8609 file(s)`. `lake build` completed with `Build completed successfully (4552 jobs).` `lake exe axioms` completed with `axioms: audited 8366 TauCeti declaration(s); all within the allowlist [propext, Classical.choice, Quot.sound].`

<!--tauceti-target:v1 {"focus":"ReductiveGroups","id":"hopf-ideal-points-order"}-->

🤖 Prepared with Codex
