### PR TITLE
feat: add normal fibre quotient equivariance

### DIFF
--- a/TauCeti/Algebra/GroupAction/OrbitRelQuotient.lean
+++ b/TauCeti/Algebra/GroupAction/OrbitRelQuotient.lean
@@ -357,7 +357,7 @@ lemma normalizerQuotientOrbitRelQuotient_smul_mk (H : Subgroup G)
 `H`-orbit quotient with the normalizer quotient `N(H) / H`. The representative convention is
 the same as Mathlib's `equivSubgroupOrbitsQuotientGroup`: the class of `g • x` corresponds to
 the class of `g⁻¹`. -/
-@[expose] noncomputable def orbitRelQuotientEquivNormalizerQuotientOfNormal
+noncomputable def orbitRelQuotientEquivNormalizerQuotientOfNormal
     [MulAction.IsPretransitive G X] [IsCancelSMul G X]
     (H : Subgroup G) [H.Normal] (x : X) :
     _root_.MulAction.orbitRel.Quotient H X ≃ Subgroup.normalizerQuotient H :=

--- a/TauCeti/Algebra/GroupAction/OrbitRelQuotient.lean
+++ b/TauCeti/Algebra/GroupAction/OrbitRelQuotient.lean
@@ -385,7 +385,7 @@ lemma orbitRelQuotientEquivNormalizerQuotientOfNormal_symm_mk
     (H : Subgroup G) [H.Normal] (x : X)
     (g : _root_.Subgroup.normalizer (H : Set G)) :
     (orbitRelQuotientEquivNormalizerQuotientOfNormal H x).symm
-        (Subgroup.normalizerQuotientMk H g) =
+        (g : Subgroup.normalizerQuotient H) =
       (Quotient.mk'' ((g : G)⁻¹ • x) : _root_.MulAction.orbitRel.Quotient H X) := by
   change (MulAction.equivSubgroupOrbitsQuotientGroup x H).symm
       (Subgroup.normalizerQuotientEquivQuotientOfNormal H
@@ -405,6 +405,7 @@ lemma orbitRelQuotientEquivNormalizerQuotientOfNormal_apply_smul
       Subgroup.normalizerQuotientMk H
         ⟨g⁻¹, by simp [_root_.Subgroup.normalizer_eq_top (H := H)]⟩ := by
   rw [(orbitRelQuotientEquivNormalizerQuotientOfNormal H x).apply_eq_iff_eq_symm_apply]
+  rw [Subgroup.normalizerQuotientMk_apply]
   rw [orbitRelQuotientEquivNormalizerQuotientOfNormal_symm_mk]
   simp
 

--- a/TauCeti/Algebra/GroupAction/OrbitRelQuotient.lean
+++ b/TauCeti/Algebra/GroupAction/OrbitRelQuotient.lean
@@ -387,6 +387,8 @@ lemma orbitRelQuotientEquivNormalizerQuotientOfNormal_symm_mk
     (orbitRelQuotientEquivNormalizerQuotientOfNormal H x).symm
         (g : Subgroup.normalizerQuotient H) =
       (Quotient.mk'' ((g : G)⁻¹ • x) : _root_.MulAction.orbitRel.Quotient H X) := by
+  -- The new equivalence is definitionally Mathlib's orbit-quotient equivalence transposed
+  -- across the normal-subgroup comparison `N(H) / H ≃ G ⧸ H`.
   change (MulAction.equivSubgroupOrbitsQuotientGroup x H).symm
       (Subgroup.normalizerQuotientEquivQuotientOfNormal H
         (Subgroup.normalizerQuotientMk H g)) =

--- a/TauCeti/Algebra/GroupAction/OrbitRelQuotient.lean
+++ b/TauCeti/Algebra/GroupAction/OrbitRelQuotient.lean
@@ -28,6 +28,8 @@ This file records small generic additions to Mathlib's `MulAction.orbitRel.Quoti
 * `TauCeti.MulAction.orbitRelQuotient_smul_eq_smul_iff_normalizerQuotientMk_inv_eq`: for a
   normal subgroup, equality of two translates in the `H`-orbit quotient is equality of the
   corresponding inverse representatives in `N(H) / H`.
+* `TauCeti.MulAction.orbitRelQuotientEquivNormalizerQuotientOfNormal`: in a free transitive
+  action, the quotient by a normal subgroup is the normalizer quotient `N(H) / H`.
 * `TauCeti.MulAction.normalizerOrbitRelQuotientPermHom`: the normalizer action on the
   quotient by `H`-orbits.
 * `TauCeti.MulAction.normalizerQuotientOrbitRelQuotientPermHom`: the descended action of
@@ -176,6 +178,16 @@ lemma orbitRelQuotient_smul_eq_smul_iff_normalizerQuotientMk_inv_eq [IsCancelSMu
     Subgroup.normalizerQuotientMk_eq_iff_div_mem, div_eq_mul_inv, inv_inv,
     (inferInstance : H.Normal).mem_comm_iff, ← inv_mem_iff]
   simp [mul_inv_rev]
+
+/-- Mathlib's subgroup-orbit quotient equivalence sends the coset of `g` back to the orbit
+class of `g⁻¹ • x`. -/
+private lemma equivSubgroupOrbitsQuotientGroup_symm_mk
+    [MulAction.IsPretransitive G X] [IsCancelSMul G X]
+    (H : Subgroup G) (x : X) (g : G) :
+    (MulAction.equivSubgroupOrbitsQuotientGroup x H).symm
+        (QuotientGroup.mk (s := H) g) =
+      (Quotient.mk'' (g⁻¹ • x) : _root_.MulAction.orbitRel.Quotient H X) :=
+  rfl
 
 private lemma normalizer_smul_mem_orbit (H : Subgroup G)
     (g : _root_.Subgroup.normalizer (H : Set G))
@@ -340,6 +352,98 @@ lemma normalizerQuotientOrbitRelQuotient_smul_mk (H : Subgroup G)
         (Quotient.mk'' x : _root_.MulAction.orbitRel.Quotient H X) =
       Quotient.mk'' ((g : G) • x)
     exact normalizerQuotientOrbitRelQuotientPermHom_mk_apply (X := X) H g x
+
+/-- In a free transitive action, quotienting by a normal subgroup `H` identifies the
+`H`-orbit quotient with the normalizer quotient `N(H) / H`. The representative convention is
+the same as Mathlib's `equivSubgroupOrbitsQuotientGroup`: the class of `g • x` corresponds to
+the class of `g⁻¹`. -/
+@[expose] noncomputable def orbitRelQuotientEquivNormalizerQuotientOfNormal
+    [MulAction.IsPretransitive G X] [IsCancelSMul G X]
+    (H : Subgroup G) [H.Normal] (x : X) :
+    _root_.MulAction.orbitRel.Quotient H X ≃ Subgroup.normalizerQuotient H :=
+  (MulAction.equivSubgroupOrbitsQuotientGroup x H).trans
+    (Subgroup.normalizerQuotientEquivQuotientOfNormal H).toEquiv.symm
+
+/-- The normal-subgroup orbit quotient equivalence, followed by the normalizer quotient's
+normal-case comparison, is Mathlib's equivalence to `G ⧸ H`. -/
+@[simp]
+lemma normalizerQuotientEquivQuotientOfNormal_orbitRelQuotientEquivNormalizerQuotientOfNormal
+    [MulAction.IsPretransitive G X] [IsCancelSMul G X]
+    (H : Subgroup G) [H.Normal] (x₀ : X)
+    (x : _root_.MulAction.orbitRel.Quotient H X) :
+    Subgroup.normalizerQuotientEquivQuotientOfNormal H
+        (orbitRelQuotientEquivNormalizerQuotientOfNormal H x₀ x) =
+      MulAction.equivSubgroupOrbitsQuotientGroup x₀ H x :=
+  (Subgroup.normalizerQuotientEquivQuotientOfNormal H).toEquiv.apply_symm_apply
+    (MulAction.equivSubgroupOrbitsQuotientGroup x₀ H x)
+
+/-- The inverse normal-subgroup orbit-quotient equivalence sends a normalizer representative
+to the orbit class of its inverse acting on the base point. -/
+@[simp]
+lemma orbitRelQuotientEquivNormalizerQuotientOfNormal_symm_mk
+    [MulAction.IsPretransitive G X] [IsCancelSMul G X]
+    (H : Subgroup G) [H.Normal] (x : X)
+    (g : _root_.Subgroup.normalizer (H : Set G)) :
+    (orbitRelQuotientEquivNormalizerQuotientOfNormal H x).symm
+        (Subgroup.normalizerQuotientMk H g) =
+      (Quotient.mk'' ((g : G)⁻¹ • x) : _root_.MulAction.orbitRel.Quotient H X) := by
+  change (MulAction.equivSubgroupOrbitsQuotientGroup x H).symm
+      (Subgroup.normalizerQuotientEquivQuotientOfNormal H
+        (Subgroup.normalizerQuotientMk H g)) =
+    (Quotient.mk'' ((g : G)⁻¹ • x) : _root_.MulAction.orbitRel.Quotient H X)
+  rw [Subgroup.normalizerQuotientEquivQuotientOfNormal_mk]
+  exact equivSubgroupOrbitsQuotientGroup_symm_mk H x (g : G)
+
+/-- The normal-subgroup orbit-quotient equivalence sends the class of `g • x` to the
+normalizer-quotient class of `g⁻¹`. -/
+@[simp]
+lemma orbitRelQuotientEquivNormalizerQuotientOfNormal_apply_smul
+    [MulAction.IsPretransitive G X] [IsCancelSMul G X]
+    (H : Subgroup G) [H.Normal] (x : X) (g : G) :
+    orbitRelQuotientEquivNormalizerQuotientOfNormal H x
+        (Quotient.mk'' (g • x) : _root_.MulAction.orbitRel.Quotient H X) =
+      Subgroup.normalizerQuotientMk H
+        ⟨g⁻¹, by simp [_root_.Subgroup.normalizer_eq_top (H := H)]⟩ := by
+  rw [(orbitRelQuotientEquivNormalizerQuotientOfNormal H x).apply_eq_iff_eq_symm_apply]
+  rw [orbitRelQuotientEquivNormalizerQuotientOfNormal_symm_mk]
+  simp
+
+/-- Under the normal-subgroup orbit-quotient equivalence, the descended normalizer-quotient
+action is right multiplication by the inverse. -/
+@[simp]
+lemma orbitRelQuotientEquivNormalizerQuotientOfNormal_map_smul_eq_mul_inv
+    [MulAction.IsPretransitive G X] [IsCancelSMul G X]
+    (H : Subgroup G) [H.Normal] (x₀ : X)
+    (a : Subgroup.normalizerQuotient H)
+    (x : _root_.MulAction.orbitRel.Quotient H X) :
+    letI := normalizerQuotientOrbitRelQuotientMulAction (X := X) H
+    orbitRelQuotientEquivNormalizerQuotientOfNormal H x₀ (a • x) =
+      orbitRelQuotientEquivNormalizerQuotientOfNormal H x₀ x * a⁻¹ := by
+  letI := normalizerQuotientOrbitRelQuotientMulAction (X := X) H
+  obtain ⟨g, rfl⟩ := Subgroup.normalizerQuotientMk_surjective H a
+  refine Quotient.inductionOn' x ?_
+  intro x
+  obtain ⟨k, hk⟩ := MulAction.exists_smul_eq G x₀ x
+  rw [← hk]
+  rw [normalizerQuotientOrbitRelQuotient_smul_mk, ← mul_smul,
+    orbitRelQuotientEquivNormalizerQuotientOfNormal_apply_smul,
+    orbitRelQuotientEquivNormalizerQuotientOfNormal_apply_smul]
+  apply (Subgroup.normalizerQuotientEquivQuotientOfNormal H).injective
+  simp [mul_inv_rev]
+
+/-- Applying the inverse normal-subgroup orbit-quotient equivalence after right
+multiplication by `a⁻¹` is the same as acting by `a` on the orbit quotient. -/
+lemma orbitRelQuotientEquivNormalizerQuotientOfNormal_symm_mul_inv
+    [MulAction.IsPretransitive G X] [IsCancelSMul G X]
+    (H : Subgroup G) [H.Normal] (x₀ : X) (a y : Subgroup.normalizerQuotient H) :
+    letI := normalizerQuotientOrbitRelQuotientMulAction (X := X) H
+    (orbitRelQuotientEquivNormalizerQuotientOfNormal H x₀).symm (y * a⁻¹) =
+      a • (orbitRelQuotientEquivNormalizerQuotientOfNormal H x₀).symm y := by
+  letI := normalizerQuotientOrbitRelQuotientMulAction (X := X) H
+  apply (orbitRelQuotientEquivNormalizerQuotientOfNormal H x₀).injective
+  rw [Equiv.apply_symm_apply,
+    orbitRelQuotientEquivNormalizerQuotientOfNormal_map_smul_eq_mul_inv,
+    Equiv.apply_symm_apply]
 
 /-- If the normalizer of `H` acts transitively on `X`, then the descended `N(H) / H` action on
 the quotient by `H`-orbits is transitive. -/

--- a/TauCeti/AlgebraicTopology/UniversalCover/Deck/NormalSubgroupFiberQuotient.lean
+++ b/TauCeti/AlgebraicTopology/UniversalCover/Deck/NormalSubgroupFiberQuotient.lean
@@ -168,6 +168,25 @@ lemma subgroupFiberOrbitQuotientEquivNormalizerQuotientOfNormal_apply_smul
     Subgroup.normalizerQuotientEquivQuotientOfNormal_mk]
   rfl
 
+/-- The normal-subgroup fibre quotient equivalence is the generic normal-subgroup
+orbit-quotient equivalence applied to the deck action on the fibre. This bridge lets deck-level
+consumers reuse the generic orbit-quotient API without depending on the (opaque) wrapper
+definition. -/
+lemma subgroupFiberOrbitQuotientEquivNormalizerQuotientOfNormal_eq
+    [MulAction.IsPretransitive (Deck p) (p ⁻¹' {b})] [IsCancelSMul (Deck p) (p ⁻¹' {b})]
+    (H : Subgroup (Deck p)) [H.Normal] (e : p ⁻¹' {b}) :
+    subgroupFiberOrbitQuotientEquivNormalizerQuotientOfNormal H e =
+      TauCeti.MulAction.orbitRelQuotientEquivNormalizerQuotientOfNormal
+        (G := Deck p) (X := p ⁻¹' {b}) H e := by
+  ext x
+  refine Quotient.inductionOn' x ?_
+  intro e'
+  obtain ⟨φ, hφ⟩ := MulAction.exists_smul_eq (Deck p) e e'
+  rw [← hφ, ← subgroupFiberOrbitClass_eq_mk H (φ • e),
+    subgroupFiberOrbitQuotientEquivNormalizerQuotientOfNormal_apply_smul,
+    subgroupFiberOrbitClass_eq_mk,
+    TauCeti.MulAction.orbitRelQuotientEquivNormalizerQuotientOfNormal_apply_smul]
+
 /-- For a regular cover, the normal-subgroup fibre quotient equivalence sends the class of
 `φ • e` to the normalizer-quotient class of `φ⁻¹`. -/
 @[simp]

--- a/TauCeti/AlgebraicTopology/UniversalCover/Deck/NormalSubgroupFiberQuotient.lean
+++ b/TauCeti/AlgebraicTopology/UniversalCover/Deck/NormalSubgroupFiberQuotient.lean
@@ -49,12 +49,12 @@ transitive.
 
 Under normality, `N(H) = Deck p`, so this is the fibre-level version of the regular-cover
 specialization from `N(H) / H` to `Deck p / H`. -/
-noncomputable def subgroupFiberOrbitQuotientEquivNormalizerQuotientOfNormal
+@[expose] noncomputable def subgroupFiberOrbitQuotientEquivNormalizerQuotientOfNormal
     [MulAction.IsPretransitive (Deck p) (p ⁻¹' {b})] [IsCancelSMul (Deck p) (p ⁻¹' {b})]
     (H : Subgroup (Deck p)) [H.Normal] (e : p ⁻¹' {b}) :
     SubgroupFiberOrbitQuotient H b ≃ Subgroup.normalizerQuotient H :=
-  (subgroupFiberOrbitQuotientEquivQuotientGroup H e).trans
-    (Subgroup.normalizerQuotientEquivQuotientOfNormal H).toEquiv.symm
+  TauCeti.MulAction.orbitRelQuotientEquivNormalizerQuotientOfNormal
+    (G := Deck p) (X := p ⁻¹' {b}) H e
 
 /-- For a regular preconnected covering and a normal subgroup `H ≤ Deck p`, the quotient of a
 fibre by the restricted `H`-action is the normalizer quotient `N(H) / H`. -/
@@ -178,6 +178,8 @@ lemma subgroupFiberOrbitQuotientEquivNormalizerQuotientOfNormal_apply_inv_smul
         (subgroupFiberOrbitClass H (φ⁻¹ • e)) =
       Subgroup.normalizerQuotientMk H
         ⟨φ, by simp [_root_.Subgroup.normalizer_eq_top (H := H)]⟩ := by
+  rw [subgroupFiberOrbitClass_eq_mk]
+  rw [subgroupFiberOrbitQuotientEquivNormalizerQuotientOfNormal]
   simp
 
 /-- For a regular cover, the normal-subgroup fibre quotient equivalence sends the class of

--- a/TauCeti/AlgebraicTopology/UniversalCover/Deck/NormalSubgroupFiberQuotient.lean
+++ b/TauCeti/AlgebraicTopology/UniversalCover/Deck/NormalSubgroupFiberQuotient.lean
@@ -168,25 +168,6 @@ lemma subgroupFiberOrbitQuotientEquivNormalizerQuotientOfNormal_apply_smul
     Subgroup.normalizerQuotientEquivQuotientOfNormal_mk]
   rfl
 
-/-- The normal-subgroup fibre quotient equivalence is the generic normal-subgroup
-orbit-quotient equivalence applied to the deck action on the fibre. This bridge lets deck-level
-consumers reuse the generic orbit-quotient API without depending on the (opaque) wrapper
-definition. -/
-lemma subgroupFiberOrbitQuotientEquivNormalizerQuotientOfNormal_eq
-    [MulAction.IsPretransitive (Deck p) (p ⁻¹' {b})] [IsCancelSMul (Deck p) (p ⁻¹' {b})]
-    (H : Subgroup (Deck p)) [H.Normal] (e : p ⁻¹' {b}) :
-    subgroupFiberOrbitQuotientEquivNormalizerQuotientOfNormal H e =
-      TauCeti.MulAction.orbitRelQuotientEquivNormalizerQuotientOfNormal
-        (G := Deck p) (X := p ⁻¹' {b}) H e := by
-  ext x
-  refine Quotient.inductionOn' x ?_
-  intro e'
-  obtain ⟨φ, hφ⟩ := MulAction.exists_smul_eq (Deck p) e e'
-  rw [← hφ, ← subgroupFiberOrbitClass_eq_mk H (φ • e),
-    subgroupFiberOrbitQuotientEquivNormalizerQuotientOfNormal_apply_smul,
-    subgroupFiberOrbitClass_eq_mk,
-    TauCeti.MulAction.orbitRelQuotientEquivNormalizerQuotientOfNormal_apply_smul]
-
 /-- For a regular cover, the normal-subgroup fibre quotient equivalence sends the class of
 `φ • e` to the normalizer-quotient class of `φ⁻¹`. -/
 @[simp]

--- a/TauCeti/AlgebraicTopology/UniversalCover/Deck/NormalSubgroupFiberQuotient.lean
+++ b/TauCeti/AlgebraicTopology/UniversalCover/Deck/NormalSubgroupFiberQuotient.lean
@@ -49,7 +49,7 @@ transitive.
 
 Under normality, `N(H) = Deck p`, so this is the fibre-level version of the regular-cover
 specialization from `N(H) / H` to `Deck p / H`. -/
-@[expose] noncomputable def subgroupFiberOrbitQuotientEquivNormalizerQuotientOfNormal
+noncomputable def subgroupFiberOrbitQuotientEquivNormalizerQuotientOfNormal
     [MulAction.IsPretransitive (Deck p) (p ⁻¹' {b})] [IsCancelSMul (Deck p) (p ⁻¹' {b})]
     (H : Subgroup (Deck p)) [H.Normal] (e : p ⁻¹' {b}) :
     SubgroupFiberOrbitQuotient H b ≃ Subgroup.normalizerQuotient H :=
@@ -76,8 +76,23 @@ lemma normalizerQuotientEquivQuotientOfNormal_subgroupFiberOrbitQuotientEquiv
     Subgroup.normalizerQuotientEquivQuotientOfNormal H
         (subgroupFiberOrbitQuotientEquivNormalizerQuotientOfNormal H e x) =
       subgroupFiberOrbitQuotientEquivQuotientGroup H e x := by
-  exact (Subgroup.normalizerQuotientEquivQuotientOfNormal H).toEquiv.apply_symm_apply
-    (subgroupFiberOrbitQuotientEquivQuotientGroup H e x)
+  refine Quotient.inductionOn' x ?_
+  intro e'
+  obtain ⟨φ, hφ⟩ := MulAction.exists_smul_eq (Deck p) e e'
+  rw [← hφ]
+  -- The deck-specific normalizer quotient equivalence is a wrapper around the generic
+  -- orbit-relation equivalence; the quotient-group equivalence is kept opaque.
+  change
+    Subgroup.normalizerQuotientEquivQuotientOfNormal H
+        (TauCeti.MulAction.orbitRelQuotientEquivNormalizerQuotientOfNormal
+          (G := Deck p) (X := p ⁻¹' {b}) H e
+          (Quotient.mk'' (φ • e) : _root_.MulAction.orbitRel.Quotient H (p ⁻¹' {b}))) =
+      subgroupFiberOrbitQuotientEquivQuotientGroup H e
+        (subgroupFiberOrbitClass H (φ • e))
+  rw [TauCeti.MulAction.orbitRelQuotientEquivNormalizerQuotientOfNormal_apply_smul,
+    subgroupFiberOrbitQuotientEquivQuotientGroup_apply_smul,
+    Subgroup.normalizerQuotientEquivQuotientOfNormal_mk]
+  rfl
 
 /-- For a regular cover, the normal-subgroup fibre quotient equivalence, followed by the
 normalizer quotient's normal-case comparison, is the existing equivalence to `Deck p ⧸ H`. -/
@@ -178,9 +193,8 @@ lemma subgroupFiberOrbitQuotientEquivNormalizerQuotientOfNormal_apply_inv_smul
         (subgroupFiberOrbitClass H (φ⁻¹ • e)) =
       Subgroup.normalizerQuotientMk H
         ⟨φ, by simp [_root_.Subgroup.normalizer_eq_top (H := H)]⟩ := by
-  rw [subgroupFiberOrbitClass_eq_mk]
-  rw [subgroupFiberOrbitQuotientEquivNormalizerQuotientOfNormal]
-  simp
+  simpa only [inv_inv] using
+    subgroupFiberOrbitQuotientEquivNormalizerQuotientOfNormal_apply_smul H e φ⁻¹
 
 /-- For a regular cover, the normal-subgroup fibre quotient equivalence sends the class of
 `φ⁻¹ • e` to the normalizer-quotient class of `φ`. -/

--- a/TauCeti/AlgebraicTopology/UniversalCover/Deck/NormalSubgroupFiberQuotientEquivariance.lean
+++ b/TauCeti/AlgebraicTopology/UniversalCover/Deck/NormalSubgroupFiberQuotientEquivariance.lean
@@ -86,17 +86,9 @@ lemma subgroupFiberOrbitQuotientEquivNormalizerQuotientOfNormal_map_smul_eq_mul_
     (a : Subgroup.normalizerQuotient H) (x : SubgroupFiberOrbitQuotient H b) :
     subgroupFiberOrbitQuotientEquivNormalizerQuotientOfNormal H e (a • x) =
       subgroupFiberOrbitQuotientEquivNormalizerQuotientOfNormal H e x * a⁻¹ := by
-  obtain ⟨φ, rfl⟩ := Subgroup.normalizerQuotientMk_surjective H a
-  refine Quotient.inductionOn' x ?_
-  intro e'
-  obtain ⟨ψ, hψ⟩ := MulAction.exists_smul_eq (Deck p) e e'
-  rw [← hψ, ← subgroupFiberOrbitClass_eq_mk H (ψ • e),
-    Subgroup.normalizerQuotientMk_apply,
-    normalizerQuotient_smul_subgroupFiberOrbitClass, ← mul_smul,
-    subgroupFiberOrbitQuotientEquivNormalizerQuotientOfNormal_apply_smul,
-    subgroupFiberOrbitQuotientEquivNormalizerQuotientOfNormal_apply_smul]
-  apply (Subgroup.normalizerQuotientEquivQuotientOfNormal H).injective
-  simp [mul_inv_rev]
+  rw [subgroupFiberOrbitQuotientEquivNormalizerQuotientOfNormal_eq]
+  exact TauCeti.MulAction.orbitRelQuotientEquivNormalizerQuotientOfNormal_map_smul_eq_mul_inv
+    (G := Deck p) (X := p ⁻¹' {b}) H e a x
 
 /-- For a regular preconnected covering map, the normal-subgroup fibre quotient equivalence
 turns the descended normalizer-quotient action into right multiplication by the inverse. -/
@@ -121,10 +113,9 @@ lemma subgroupFiberOrbitQuotientEquivNormalizerQuotientOfNormal_symm_mul_inv
     (a y : Subgroup.normalizerQuotient H) :
     (subgroupFiberOrbitQuotientEquivNormalizerQuotientOfNormal H e).symm (y * a⁻¹) =
       a • (subgroupFiberOrbitQuotientEquivNormalizerQuotientOfNormal H e).symm y := by
-  apply (subgroupFiberOrbitQuotientEquivNormalizerQuotientOfNormal H e).injective
-  rw [Equiv.apply_symm_apply,
-    subgroupFiberOrbitQuotientEquivNormalizerQuotientOfNormal_map_smul_eq_mul_inv,
-    Equiv.apply_symm_apply]
+  rw [subgroupFiberOrbitQuotientEquivNormalizerQuotientOfNormal_eq]
+  exact TauCeti.MulAction.orbitRelQuotientEquivNormalizerQuotientOfNormal_symm_mul_inv
+    (G := Deck p) (X := p ⁻¹' {b}) H e a y
 
 /-- For a regular preconnected covering map, applying the inverse normal-subgroup fibre
 quotient equivalence after right multiplication by `a⁻¹` is the same as acting by `a` on the

--- a/TauCeti/AlgebraicTopology/UniversalCover/Deck/NormalSubgroupFiberQuotientEquivariance.lean
+++ b/TauCeti/AlgebraicTopology/UniversalCover/Deck/NormalSubgroupFiberQuotientEquivariance.lean
@@ -1,0 +1,138 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+module
+
+public import TauCeti.AlgebraicTopology.UniversalCover.Deck.NormalSubgroupFiberQuotient
+public import TauCeti.AlgebraicTopology.UniversalCover.Deck.NormalizerQuotientFiberAction
+
+/-!
+# Equivariance for normal deck-subgroup fibre quotients
+
+For a normal subgroup `H ≤ Deck p`, the quotient of a fibre by `H` is already identified
+with the normalizer quotient `N(H) / H`. This file records how that identification interacts
+with the descended `N(H) / H` action on the fibre quotient.
+
+The orientation is important: the existing fibre-quotient equivalence sends the orbit class
+of `φ • e` to the normalizer-quotient class of `φ⁻¹`. Consequently, acting on the fibre
+quotient by a normalizer-quotient element `a` corresponds, under this equivalence, to right
+multiplication by `a⁻¹`.
+
+## Main declarations
+
+* `TauCeti.Deck.subgroupFiberOrbitQuotientEquivNormalizerQuotientOfNormal_map_smul`:
+  the `N(H) / H` action becomes right multiplication by the inverse.
+* `TauCeti.Deck.regularSubgroupFiberOrbitQuotientEquivNormalizerQuotientOfNormal_map_smul`:
+  the same statement for a regular preconnected covering map.
+* Inverse-form lemmas for applying the inverse equivalence after right multiplication.
+
+## References
+
+This supplies a small bookkeeping prerequisite for
+`TauCetiRoadmap/UniversalCovers/README.md`, Stage 2, item 8: the deck group of the cover
+attached to `H` is `N(H) / H`, with the normal case specializing to a quotient by `H`.
+-/
+
+public section
+
+namespace TauCeti
+
+namespace Deck
+
+variable {E B : Type*} [TopologicalSpace E] {p : E → B} {b : B}
+
+/-- Under the normal-subgroup fibre quotient equivalence, the descended normalizer-quotient
+action is right multiplication by the inverse. This is the representative-free form of the
+convention that `φ • e` maps to the class of `φ⁻¹`. -/
+lemma subgroupFiberOrbitQuotientEquivNormalizerQuotientOfNormal_map_smul
+    [MulAction.IsPretransitive (Deck p) (p ⁻¹' {b})] [IsCancelSMul (Deck p) (p ⁻¹' {b})]
+    (H : Subgroup (Deck p)) [H.Normal] (e : p ⁻¹' {b})
+    (a : Subgroup.normalizerQuotient H) (x : SubgroupFiberOrbitQuotient H b) :
+    subgroupFiberOrbitQuotientEquivNormalizerQuotientOfNormal H e (a • x) =
+      subgroupFiberOrbitQuotientEquivNormalizerQuotientOfNormal H e x * a⁻¹ := by
+  obtain ⟨α, rfl⟩ := Subgroup.normalizerQuotientMk_surjective H a
+  refine Quotient.inductionOn' x ?_
+  intro e'
+  obtain ⟨φ, hφ⟩ := MulAction.exists_smul_eq (Deck p) e e'
+  rw [← hφ]
+  change subgroupFiberOrbitQuotientEquivNormalizerQuotientOfNormal H e
+        ((Subgroup.normalizerQuotientMk H α) • subgroupFiberOrbitClass H (φ • e)) =
+      subgroupFiberOrbitQuotientEquivNormalizerQuotientOfNormal H e
+          (subgroupFiberOrbitClass H (φ • e)) *
+        (Subgroup.normalizerQuotientMk H α)⁻¹
+  rw [Subgroup.normalizerQuotientMk_apply, normalizerQuotient_smul_subgroupFiberOrbitClass,
+    subgroupFiberOrbitQuotientEquivNormalizerQuotientOfNormal_apply_smul]
+  change subgroupFiberOrbitQuotientEquivNormalizerQuotientOfNormal H e
+        (subgroupFiberOrbitClass H (((α : Deck p) * φ) • e)) =
+      Subgroup.normalizerQuotientMk H
+          ⟨φ⁻¹, by simp [_root_.Subgroup.normalizer_eq_top (H := H)]⟩ *
+        (α : Subgroup.normalizerQuotient H)⁻¹
+  rw [subgroupFiberOrbitQuotientEquivNormalizerQuotientOfNormal_apply_smul]
+  apply (Subgroup.normalizerQuotientEquivQuotientOfNormal H).injective
+  simp [mul_inv_rev]
+
+/-- For a regular preconnected covering map, the normal-subgroup fibre quotient equivalence
+turns the descended normalizer-quotient action into right multiplication by the inverse. -/
+lemma regularSubgroupFiberOrbitQuotientEquivNormalizerQuotientOfNormal_map_smul
+    [TopologicalSpace B] [PreconnectedSpace E] (hp : IsCoveringMap p) (hreg : IsRegular p)
+    (H : Subgroup (Deck p)) [H.Normal] (e : p ⁻¹' {b})
+    (a : Subgroup.normalizerQuotient H) (x : SubgroupFiberOrbitQuotient H b) :
+    regularSubgroupFiberOrbitQuotientEquivNormalizerQuotientOfNormal hp hreg H e (a • x) =
+      regularSubgroupFiberOrbitQuotientEquivNormalizerQuotientOfNormal hp hreg H e x * a⁻¹ := by
+  letI := hreg.fiber_isPretransitive b
+  letI := fiber_isCancelSMul (b := b) hp
+  obtain ⟨α, rfl⟩ := Subgroup.normalizerQuotientMk_surjective H a
+  refine Quotient.inductionOn' x ?_
+  intro e'
+  obtain ⟨φ, hφ⟩ := MulAction.exists_smul_eq (Deck p) e e'
+  rw [← hφ]
+  change regularSubgroupFiberOrbitQuotientEquivNormalizerQuotientOfNormal hp hreg H e
+        ((Subgroup.normalizerQuotientMk H α) • subgroupFiberOrbitClass H (φ • e)) =
+      regularSubgroupFiberOrbitQuotientEquivNormalizerQuotientOfNormal hp hreg H e
+          (subgroupFiberOrbitClass H (φ • e)) *
+        (Subgroup.normalizerQuotientMk H α)⁻¹
+  rw [Subgroup.normalizerQuotientMk_apply, normalizerQuotient_smul_subgroupFiberOrbitClass,
+    regularSubgroupFiberOrbitQuotientEquivNormalizerQuotientOfNormal_apply_smul]
+  change regularSubgroupFiberOrbitQuotientEquivNormalizerQuotientOfNormal hp hreg H e
+        (subgroupFiberOrbitClass H (((α : Deck p) * φ) • e)) =
+      Subgroup.normalizerQuotientMk H
+          ⟨φ⁻¹, by simp [_root_.Subgroup.normalizer_eq_top (H := H)]⟩ *
+        (α : Subgroup.normalizerQuotient H)⁻¹
+  rw [regularSubgroupFiberOrbitQuotientEquivNormalizerQuotientOfNormal_apply_smul]
+  apply (Subgroup.normalizerQuotientEquivQuotientOfNormal H).injective
+  simp [mul_inv_rev]
+
+/-- Applying the inverse normal-subgroup fibre quotient equivalence after right multiplication
+by `a⁻¹` is the same as acting by `a` on the fibre quotient. -/
+lemma subgroupFiberOrbitQuotientEquivNormalizerQuotientOfNormal_symm_mul_inv
+    [MulAction.IsPretransitive (Deck p) (p ⁻¹' {b})] [IsCancelSMul (Deck p) (p ⁻¹' {b})]
+    (H : Subgroup (Deck p)) [H.Normal] (e : p ⁻¹' {b})
+    (a y : Subgroup.normalizerQuotient H) :
+    (subgroupFiberOrbitQuotientEquivNormalizerQuotientOfNormal H e).symm (y * a⁻¹) =
+      a • (subgroupFiberOrbitQuotientEquivNormalizerQuotientOfNormal H e).symm y := by
+  apply (subgroupFiberOrbitQuotientEquivNormalizerQuotientOfNormal H e).injective
+  rw [Equiv.apply_symm_apply, subgroupFiberOrbitQuotientEquivNormalizerQuotientOfNormal_map_smul,
+    Equiv.apply_symm_apply]
+
+/-- For a regular preconnected covering map, applying the inverse normal-subgroup fibre
+quotient equivalence after right multiplication by `a⁻¹` is the same as acting by `a` on the
+fibre quotient. -/
+lemma regularSubgroupFiberOrbitQuotientEquivNormalizerQuotientOfNormal_symm_mul_inv
+    [TopologicalSpace B] [PreconnectedSpace E] (hp : IsCoveringMap p) (hreg : IsRegular p)
+    (H : Subgroup (Deck p)) [H.Normal] (e : p ⁻¹' {b})
+    (a y : Subgroup.normalizerQuotient H) :
+    (regularSubgroupFiberOrbitQuotientEquivNormalizerQuotientOfNormal hp hreg H e).symm
+        (y * a⁻¹) =
+      a • (regularSubgroupFiberOrbitQuotientEquivNormalizerQuotientOfNormal hp hreg H e).symm
+        y := by
+  letI := hreg.fiber_isPretransitive b
+  letI := fiber_isCancelSMul (b := b) hp
+  apply (regularSubgroupFiberOrbitQuotientEquivNormalizerQuotientOfNormal hp hreg H e).injective
+  rw [Equiv.apply_symm_apply,
+    regularSubgroupFiberOrbitQuotientEquivNormalizerQuotientOfNormal_map_smul,
+    Equiv.apply_symm_apply]
+
+end Deck
+
+end TauCeti

--- a/TauCeti/AlgebraicTopology/UniversalCover/Deck/NormalSubgroupFiberQuotientEquivariance.lean
+++ b/TauCeti/AlgebraicTopology/UniversalCover/Deck/NormalSubgroupFiberQuotientEquivariance.lean
@@ -10,8 +10,9 @@ public import TauCeti.AlgebraicTopology.UniversalCover.Deck.NormalizerQuotientFi
 /-!
 # Equivariance for normal deck-subgroup fibre quotients
 
-For a normal subgroup `H ≤ Deck p`, the quotient of a fibre by `H` is already identified
-with the normalizer quotient `N(H) / H`. This file records how that identification interacts
+For a normal subgroup `H ≤ Deck p`, the existing free-transitive fibre-action equivalence
+identifies the quotient of a fibre by `H` with the normalizer quotient `N(H) / H`. This file
+records how that identification, and its regular preconnected-cover specialization, interacts
 with the descended `N(H) / H` action on the fibre quotient.
 
 The orientation is important: the existing fibre-quotient equivalence sends the orbit class
@@ -85,8 +86,17 @@ lemma subgroupFiberOrbitQuotientEquivNormalizerQuotientOfNormal_map_smul_eq_mul_
     (a : Subgroup.normalizerQuotient H) (x : SubgroupFiberOrbitQuotient H b) :
     subgroupFiberOrbitQuotientEquivNormalizerQuotientOfNormal H e (a • x) =
       subgroupFiberOrbitQuotientEquivNormalizerQuotientOfNormal H e x * a⁻¹ := by
-  exact TauCeti.MulAction.orbitRelQuotientEquivNormalizerQuotientOfNormal_map_smul_eq_mul_inv
-    (G := Deck p) (X := p ⁻¹' {b}) H e a x
+  obtain ⟨φ, rfl⟩ := Subgroup.normalizerQuotientMk_surjective H a
+  refine Quotient.inductionOn' x ?_
+  intro e'
+  obtain ⟨ψ, hψ⟩ := MulAction.exists_smul_eq (Deck p) e e'
+  rw [← hψ, ← subgroupFiberOrbitClass_eq_mk H (ψ • e),
+    Subgroup.normalizerQuotientMk_apply,
+    normalizerQuotient_smul_subgroupFiberOrbitClass, ← mul_smul,
+    subgroupFiberOrbitQuotientEquivNormalizerQuotientOfNormal_apply_smul,
+    subgroupFiberOrbitQuotientEquivNormalizerQuotientOfNormal_apply_smul]
+  apply (Subgroup.normalizerQuotientEquivQuotientOfNormal H).injective
+  simp [mul_inv_rev]
 
 /-- For a regular preconnected covering map, the normal-subgroup fibre quotient equivalence
 turns the descended normalizer-quotient action into right multiplication by the inverse. -/

--- a/TauCeti/AlgebraicTopology/UniversalCover/Deck/NormalSubgroupFiberQuotientEquivariance.lean
+++ b/TauCeti/AlgebraicTopology/UniversalCover/Deck/NormalSubgroupFiberQuotientEquivariance.lean
@@ -76,6 +76,21 @@ private lemma regularSubgroupFiberOrbitQuotientEquivNormalizerQuotientOfNormal_s
     regularSubgroupFiberOrbitQuotientEquivNormalizerQuotientOfNormal_apply_eq,
     Equiv.apply_symm_apply]
 
+private lemma subgroupFiberOrbitQuotientEquivNormalizerQuotientOfNormal_eq
+    [MulAction.IsPretransitive (Deck p) (p ⁻¹' {b})] [IsCancelSMul (Deck p) (p ⁻¹' {b})]
+    (H : Subgroup (Deck p)) [H.Normal] (e : p ⁻¹' {b}) :
+    subgroupFiberOrbitQuotientEquivNormalizerQuotientOfNormal H e =
+      TauCeti.MulAction.orbitRelQuotientEquivNormalizerQuotientOfNormal
+        (G := Deck p) (X := p ⁻¹' {b}) H e := by
+  ext x
+  refine Quotient.inductionOn' x ?_
+  intro e'
+  obtain ⟨φ, hφ⟩ := MulAction.exists_smul_eq (Deck p) e e'
+  rw [← hφ, ← subgroupFiberOrbitClass_eq_mk H (φ • e),
+    subgroupFiberOrbitQuotientEquivNormalizerQuotientOfNormal_apply_smul,
+    subgroupFiberOrbitClass_eq_mk,
+    TauCeti.MulAction.orbitRelQuotientEquivNormalizerQuotientOfNormal_apply_smul]
+
 /-- Under the normal-subgroup fibre quotient equivalence, the descended normalizer-quotient
 action is right multiplication by the inverse. This is the representative-free form of the
 convention that `φ • e` maps to the class of `φ⁻¹`. -/

--- a/TauCeti/AlgebraicTopology/UniversalCover/Deck/NormalSubgroupFiberQuotientEquivariance.lean
+++ b/TauCeti/AlgebraicTopology/UniversalCover/Deck/NormalSubgroupFiberQuotientEquivariance.lean
@@ -42,9 +42,46 @@ namespace Deck
 
 variable {E B : Type*} [TopologicalSpace E] {p : E → B} {b : B}
 
+private lemma regularSubgroupFiberOrbitQuotientEquivNormalizerQuotientOfNormal_apply_eq
+    [TopologicalSpace B] [PreconnectedSpace E] (hp : IsCoveringMap p) (hreg : IsRegular p)
+    (H : Subgroup (Deck p)) [H.Normal] (e : p ⁻¹' {b})
+    (x : SubgroupFiberOrbitQuotient H b) :
+    regularSubgroupFiberOrbitQuotientEquivNormalizerQuotientOfNormal hp hreg H e x =
+      @subgroupFiberOrbitQuotientEquivNormalizerQuotientOfNormal E B _ p b
+        (hreg.fiber_isPretransitive b) (fiber_isCancelSMul (b := b) hp) H _ e x := by
+  letI := hreg.fiber_isPretransitive b
+  letI := fiber_isCancelSMul (b := b) hp
+  refine Quotient.inductionOn' x ?_
+  intro e'
+  obtain ⟨φ, hφ⟩ := MulAction.exists_smul_eq (Deck p) e e'
+  rw [← hφ]
+  -- Quotient induction exposes the raw quotient representative; the public API uses the
+  -- deck-specific `subgroupFiberOrbitClass` notation for the same representative.
+  change regularSubgroupFiberOrbitQuotientEquivNormalizerQuotientOfNormal hp hreg H e
+        (subgroupFiberOrbitClass H (φ • e)) =
+      subgroupFiberOrbitQuotientEquivNormalizerQuotientOfNormal H e
+        (subgroupFiberOrbitClass H (φ • e))
+  rw [regularSubgroupFiberOrbitQuotientEquivNormalizerQuotientOfNormal_apply_smul,
+    subgroupFiberOrbitQuotientEquivNormalizerQuotientOfNormal_apply_smul]
+
+private lemma regularSubgroupFiberOrbitQuotientEquivNormalizerQuotientOfNormal_symm_apply_eq
+    [TopologicalSpace B] [PreconnectedSpace E] (hp : IsCoveringMap p) (hreg : IsRegular p)
+    (H : Subgroup (Deck p)) [H.Normal] (e : p ⁻¹' {b})
+    (y : Subgroup.normalizerQuotient H) :
+    (regularSubgroupFiberOrbitQuotientEquivNormalizerQuotientOfNormal hp hreg H e).symm y =
+      (@subgroupFiberOrbitQuotientEquivNormalizerQuotientOfNormal E B _ p b
+        (hreg.fiber_isPretransitive b) (fiber_isCancelSMul (b := b) hp) H _ e).symm y := by
+  letI := hreg.fiber_isPretransitive b
+  letI := fiber_isCancelSMul (b := b) hp
+  apply (regularSubgroupFiberOrbitQuotientEquivNormalizerQuotientOfNormal hp hreg H e).injective
+  rw [Equiv.apply_symm_apply,
+    regularSubgroupFiberOrbitQuotientEquivNormalizerQuotientOfNormal_apply_eq,
+    Equiv.apply_symm_apply]
+
 /-- Under the normal-subgroup fibre quotient equivalence, the descended normalizer-quotient
 action is right multiplication by the inverse. This is the representative-free form of the
 convention that `φ • e` maps to the class of `φ⁻¹`. -/
+@[simp]
 lemma subgroupFiberOrbitQuotientEquivNormalizerQuotientOfNormal_map_smul
     [MulAction.IsPretransitive (Deck p) (p ⁻¹' {b})] [IsCancelSMul (Deck p) (p ⁻¹' {b})]
     (H : Subgroup (Deck p)) [H.Normal] (e : p ⁻¹' {b})
@@ -56,6 +93,7 @@ lemma subgroupFiberOrbitQuotientEquivNormalizerQuotientOfNormal_map_smul
   intro e'
   obtain ⟨φ, hφ⟩ := MulAction.exists_smul_eq (Deck p) e e'
   rw [← hφ]
+  -- Expose the representative of `a` so the descended action can rewrite on orbit classes.
   change subgroupFiberOrbitQuotientEquivNormalizerQuotientOfNormal H e
         ((Subgroup.normalizerQuotientMk H α) • subgroupFiberOrbitClass H (φ • e)) =
       subgroupFiberOrbitQuotientEquivNormalizerQuotientOfNormal H e
@@ -63,6 +101,7 @@ lemma subgroupFiberOrbitQuotientEquivNormalizerQuotientOfNormal_map_smul
         (Subgroup.normalizerQuotientMk H α)⁻¹
   rw [Subgroup.normalizerQuotientMk_apply, normalizerQuotient_smul_subgroupFiberOrbitClass,
     subgroupFiberOrbitQuotientEquivNormalizerQuotientOfNormal_apply_smul]
+  -- After rewriting the action, unfold the equivalence on the translated representative.
   change subgroupFiberOrbitQuotientEquivNormalizerQuotientOfNormal H e
         (subgroupFiberOrbitClass H (((α : Deck p) * φ) • e)) =
       Subgroup.normalizerQuotientMk H
@@ -74,6 +113,7 @@ lemma subgroupFiberOrbitQuotientEquivNormalizerQuotientOfNormal_map_smul
 
 /-- For a regular preconnected covering map, the normal-subgroup fibre quotient equivalence
 turns the descended normalizer-quotient action into right multiplication by the inverse. -/
+@[simp]
 lemma regularSubgroupFiberOrbitQuotientEquivNormalizerQuotientOfNormal_map_smul
     [TopologicalSpace B] [PreconnectedSpace E] (hp : IsCoveringMap p) (hreg : IsRegular p)
     (H : Subgroup (Deck p)) [H.Normal] (e : p ⁻¹' {b})
@@ -82,26 +122,9 @@ lemma regularSubgroupFiberOrbitQuotientEquivNormalizerQuotientOfNormal_map_smul
       regularSubgroupFiberOrbitQuotientEquivNormalizerQuotientOfNormal hp hreg H e x * a⁻¹ := by
   letI := hreg.fiber_isPretransitive b
   letI := fiber_isCancelSMul (b := b) hp
-  obtain ⟨α, rfl⟩ := Subgroup.normalizerQuotientMk_surjective H a
-  refine Quotient.inductionOn' x ?_
-  intro e'
-  obtain ⟨φ, hφ⟩ := MulAction.exists_smul_eq (Deck p) e e'
-  rw [← hφ]
-  change regularSubgroupFiberOrbitQuotientEquivNormalizerQuotientOfNormal hp hreg H e
-        ((Subgroup.normalizerQuotientMk H α) • subgroupFiberOrbitClass H (φ • e)) =
-      regularSubgroupFiberOrbitQuotientEquivNormalizerQuotientOfNormal hp hreg H e
-          (subgroupFiberOrbitClass H (φ • e)) *
-        (Subgroup.normalizerQuotientMk H α)⁻¹
-  rw [Subgroup.normalizerQuotientMk_apply, normalizerQuotient_smul_subgroupFiberOrbitClass,
-    regularSubgroupFiberOrbitQuotientEquivNormalizerQuotientOfNormal_apply_smul]
-  change regularSubgroupFiberOrbitQuotientEquivNormalizerQuotientOfNormal hp hreg H e
-        (subgroupFiberOrbitClass H (((α : Deck p) * φ) • e)) =
-      Subgroup.normalizerQuotientMk H
-          ⟨φ⁻¹, by simp [_root_.Subgroup.normalizer_eq_top (H := H)]⟩ *
-        (α : Subgroup.normalizerQuotient H)⁻¹
-  rw [regularSubgroupFiberOrbitQuotientEquivNormalizerQuotientOfNormal_apply_smul]
-  apply (Subgroup.normalizerQuotientEquivQuotientOfNormal H).injective
-  simp [mul_inv_rev]
+  rw [regularSubgroupFiberOrbitQuotientEquivNormalizerQuotientOfNormal_apply_eq,
+    regularSubgroupFiberOrbitQuotientEquivNormalizerQuotientOfNormal_apply_eq]
+  exact subgroupFiberOrbitQuotientEquivNormalizerQuotientOfNormal_map_smul H e a x
 
 /-- Applying the inverse normal-subgroup fibre quotient equivalence after right multiplication
 by `a⁻¹` is the same as acting by `a` on the fibre quotient. -/
@@ -128,10 +151,9 @@ lemma regularSubgroupFiberOrbitQuotientEquivNormalizerQuotientOfNormal_symm_mul_
         y := by
   letI := hreg.fiber_isPretransitive b
   letI := fiber_isCancelSMul (b := b) hp
-  apply (regularSubgroupFiberOrbitQuotientEquivNormalizerQuotientOfNormal hp hreg H e).injective
-  rw [Equiv.apply_symm_apply,
-    regularSubgroupFiberOrbitQuotientEquivNormalizerQuotientOfNormal_map_smul,
-    Equiv.apply_symm_apply]
+  rw [regularSubgroupFiberOrbitQuotientEquivNormalizerQuotientOfNormal_symm_apply_eq,
+    regularSubgroupFiberOrbitQuotientEquivNormalizerQuotientOfNormal_symm_apply_eq]
+  exact subgroupFiberOrbitQuotientEquivNormalizerQuotientOfNormal_symm_mul_inv H e a y
 
 end Deck
 

--- a/TauCeti/AlgebraicTopology/UniversalCover/Deck/NormalSubgroupFiberQuotientEquivariance.lean
+++ b/TauCeti/AlgebraicTopology/UniversalCover/Deck/NormalSubgroupFiberQuotientEquivariance.lean
@@ -21,9 +21,9 @@ multiplication by `a⁻¹`.
 
 ## Main declarations
 
-* `TauCeti.Deck.subgroupFiberOrbitQuotientEquivNormalizerQuotientOfNormal_map_smul`:
+* `TauCeti.Deck.subgroupFiberOrbitQuotientEquivNormalizerQuotientOfNormal_map_smul_eq_mul_inv`:
   the `N(H) / H` action becomes right multiplication by the inverse.
-* `TauCeti.Deck.regularSubgroupFiberOrbitQuotientEquivNormalizerQuotientOfNormal_map_smul`:
+* the regular `..._map_smul_eq_mul_inv` wrapper:
   the same statement for a regular preconnected covering map.
 * Inverse-form lemmas for applying the inverse equivalence after right multiplication.
 
@@ -51,18 +51,15 @@ private lemma regularSubgroupFiberOrbitQuotientEquivNormalizerQuotientOfNormal_a
         (hreg.fiber_isPretransitive b) (fiber_isCancelSMul (b := b) hp) H _ e x := by
   letI := hreg.fiber_isPretransitive b
   letI := fiber_isCancelSMul (b := b) hp
+  apply (Subgroup.normalizerQuotientEquivQuotientOfNormal H).injective
   refine Quotient.inductionOn' x ?_
   intro e'
   obtain ⟨φ, hφ⟩ := MulAction.exists_smul_eq (Deck p) e e'
-  rw [← hφ]
-  -- Quotient induction exposes the raw quotient representative; the public API uses the
-  -- deck-specific `subgroupFiberOrbitClass` notation for the same representative.
-  change regularSubgroupFiberOrbitQuotientEquivNormalizerQuotientOfNormal hp hreg H e
-        (subgroupFiberOrbitClass H (φ • e)) =
-      subgroupFiberOrbitQuotientEquivNormalizerQuotientOfNormal H e
-        (subgroupFiberOrbitClass H (φ • e))
-  rw [regularSubgroupFiberOrbitQuotientEquivNormalizerQuotientOfNormal_apply_smul,
-    subgroupFiberOrbitQuotientEquivNormalizerQuotientOfNormal_apply_smul]
+  rw [← hφ, ← subgroupFiberOrbitClass_eq_mk H (φ • e),
+    normalizerQuotientEquivQuotientOfNormal_regularSubgroupFiberOrbitQuotientEquiv,
+    normalizerQuotientEquivQuotientOfNormal_subgroupFiberOrbitQuotientEquiv,
+    regularSubgroupFiberOrbitQuotientEquivQuotientGroup_apply_smul,
+    subgroupFiberOrbitQuotientEquivQuotientGroup_apply_smul]
 
 private lemma regularSubgroupFiberOrbitQuotientEquivNormalizerQuotientOfNormal_symm_apply_eq
     [TopologicalSpace B] [PreconnectedSpace E] (hp : IsCoveringMap p) (hreg : IsRegular p)
@@ -82,39 +79,19 @@ private lemma regularSubgroupFiberOrbitQuotientEquivNormalizerQuotientOfNormal_s
 action is right multiplication by the inverse. This is the representative-free form of the
 convention that `φ • e` maps to the class of `φ⁻¹`. -/
 @[simp]
-lemma subgroupFiberOrbitQuotientEquivNormalizerQuotientOfNormal_map_smul
+lemma subgroupFiberOrbitQuotientEquivNormalizerQuotientOfNormal_map_smul_eq_mul_inv
     [MulAction.IsPretransitive (Deck p) (p ⁻¹' {b})] [IsCancelSMul (Deck p) (p ⁻¹' {b})]
     (H : Subgroup (Deck p)) [H.Normal] (e : p ⁻¹' {b})
     (a : Subgroup.normalizerQuotient H) (x : SubgroupFiberOrbitQuotient H b) :
     subgroupFiberOrbitQuotientEquivNormalizerQuotientOfNormal H e (a • x) =
       subgroupFiberOrbitQuotientEquivNormalizerQuotientOfNormal H e x * a⁻¹ := by
-  obtain ⟨α, rfl⟩ := Subgroup.normalizerQuotientMk_surjective H a
-  refine Quotient.inductionOn' x ?_
-  intro e'
-  obtain ⟨φ, hφ⟩ := MulAction.exists_smul_eq (Deck p) e e'
-  rw [← hφ]
-  -- Expose the representative of `a` so the descended action can rewrite on orbit classes.
-  change subgroupFiberOrbitQuotientEquivNormalizerQuotientOfNormal H e
-        ((Subgroup.normalizerQuotientMk H α) • subgroupFiberOrbitClass H (φ • e)) =
-      subgroupFiberOrbitQuotientEquivNormalizerQuotientOfNormal H e
-          (subgroupFiberOrbitClass H (φ • e)) *
-        (Subgroup.normalizerQuotientMk H α)⁻¹
-  rw [Subgroup.normalizerQuotientMk_apply, normalizerQuotient_smul_subgroupFiberOrbitClass,
-    subgroupFiberOrbitQuotientEquivNormalizerQuotientOfNormal_apply_smul]
-  -- After rewriting the action, unfold the equivalence on the translated representative.
-  change subgroupFiberOrbitQuotientEquivNormalizerQuotientOfNormal H e
-        (subgroupFiberOrbitClass H (((α : Deck p) * φ) • e)) =
-      Subgroup.normalizerQuotientMk H
-          ⟨φ⁻¹, by simp [_root_.Subgroup.normalizer_eq_top (H := H)]⟩ *
-        (α : Subgroup.normalizerQuotient H)⁻¹
-  rw [subgroupFiberOrbitQuotientEquivNormalizerQuotientOfNormal_apply_smul]
-  apply (Subgroup.normalizerQuotientEquivQuotientOfNormal H).injective
-  simp [mul_inv_rev]
+  exact TauCeti.MulAction.orbitRelQuotientEquivNormalizerQuotientOfNormal_map_smul_eq_mul_inv
+    (G := Deck p) (X := p ⁻¹' {b}) H e a x
 
 /-- For a regular preconnected covering map, the normal-subgroup fibre quotient equivalence
 turns the descended normalizer-quotient action into right multiplication by the inverse. -/
 @[simp]
-lemma regularSubgroupFiberOrbitQuotientEquivNormalizerQuotientOfNormal_map_smul
+lemma regularSubgroupFiberOrbitQuotientEquivNormalizerQuotientOfNormal_map_smul_eq_mul_inv
     [TopologicalSpace B] [PreconnectedSpace E] (hp : IsCoveringMap p) (hreg : IsRegular p)
     (H : Subgroup (Deck p)) [H.Normal] (e : p ⁻¹' {b})
     (a : Subgroup.normalizerQuotient H) (x : SubgroupFiberOrbitQuotient H b) :
@@ -124,7 +101,7 @@ lemma regularSubgroupFiberOrbitQuotientEquivNormalizerQuotientOfNormal_map_smul
   letI := fiber_isCancelSMul (b := b) hp
   rw [regularSubgroupFiberOrbitQuotientEquivNormalizerQuotientOfNormal_apply_eq,
     regularSubgroupFiberOrbitQuotientEquivNormalizerQuotientOfNormal_apply_eq]
-  exact subgroupFiberOrbitQuotientEquivNormalizerQuotientOfNormal_map_smul H e a x
+  exact subgroupFiberOrbitQuotientEquivNormalizerQuotientOfNormal_map_smul_eq_mul_inv H e a x
 
 /-- Applying the inverse normal-subgroup fibre quotient equivalence after right multiplication
 by `a⁻¹` is the same as acting by `a` on the fibre quotient. -/
@@ -135,7 +112,8 @@ lemma subgroupFiberOrbitQuotientEquivNormalizerQuotientOfNormal_symm_mul_inv
     (subgroupFiberOrbitQuotientEquivNormalizerQuotientOfNormal H e).symm (y * a⁻¹) =
       a • (subgroupFiberOrbitQuotientEquivNormalizerQuotientOfNormal H e).symm y := by
   apply (subgroupFiberOrbitQuotientEquivNormalizerQuotientOfNormal H e).injective
-  rw [Equiv.apply_symm_apply, subgroupFiberOrbitQuotientEquivNormalizerQuotientOfNormal_map_smul,
+  rw [Equiv.apply_symm_apply,
+    subgroupFiberOrbitQuotientEquivNormalizerQuotientOfNormal_map_smul_eq_mul_inv,
     Equiv.apply_symm_apply]
 
 /-- For a regular preconnected covering map, applying the inverse normal-subgroup fibre

--- a/TauCeti/AlgebraicTopology/UniversalCover/Deck/SubgroupFiberOrbitQuotientGroup.lean
+++ b/TauCeti/AlgebraicTopology/UniversalCover/Deck/SubgroupFiberOrbitQuotientGroup.lean
@@ -116,7 +116,7 @@ private lemma quotientGroup_quotientBot_mk (φ : Deck p) :
 
 /-- The subgroup-fibre orbit quotient is equivalent to the quotient of the deck group by the
 subgroup, once the deck action on the chosen fibre is free and transitive. -/
-@[expose] noncomputable def subgroupFiberOrbitQuotientEquivQuotientGroup
+noncomputable def subgroupFiberOrbitQuotientEquivQuotientGroup
     [MulAction.IsPretransitive (Deck p) (p ⁻¹' {b})] [IsCancelSMul (Deck p) (p ⁻¹' {b})]
     (H : Subgroup (Deck p)) (e : p ⁻¹' {b}) :
     SubgroupFiberOrbitQuotient H b ≃ Deck p ⧸ H :=

--- a/TauCeti/AlgebraicTopology/UniversalCover/Deck/SubgroupFiberOrbitQuotientGroup.lean
+++ b/TauCeti/AlgebraicTopology/UniversalCover/Deck/SubgroupFiberOrbitQuotientGroup.lean
@@ -116,7 +116,7 @@ private lemma quotientGroup_quotientBot_mk (φ : Deck p) :
 
 /-- The subgroup-fibre orbit quotient is equivalent to the quotient of the deck group by the
 subgroup, once the deck action on the chosen fibre is free and transitive. -/
-noncomputable def subgroupFiberOrbitQuotientEquivQuotientGroup
+@[expose] noncomputable def subgroupFiberOrbitQuotientEquivQuotientGroup
     [MulAction.IsPretransitive (Deck p) (p ⁻¹' {b})] [IsCancelSMul (Deck p) (p ⁻¹' {b})]
     (H : Subgroup (Deck p)) (e : p ⁻¹' {b}) :
     SubgroupFiberOrbitQuotient H b ≃ Deck p ⧸ H :=


### PR DESCRIPTION
This PR records the equivariance convention for the normal-subgroup fibre quotient equivalence: under the existing identification of an `H`-fibre quotient with `N(H) / H`, the descended normalizer-quotient action corresponds to right multiplication by the inverse element, with regular-cover wrappers for the preconnected regular case. It advances `TauCetiRoadmap/UniversalCovers/README.md`, Stage 2, item 8, specifically the normalizer quotient milestone: “For the cover attached to `H`, the deck group is `N(H)/H`; it is a regular (normal/Galois) cover iff `H ◁ π₁(X, x₀)`, and then the deck group is `π₁(X, x₀)/H`.”

I chose this as the lowest-hanging distinct UniversalCovers target after checking open and recently merged PRs: `main` already has subgroup fibre quotients, the normalizer-quotient action, freeness of that action, and the normal-subgroup equivalence to `N(H) / H`, while the action/equivalence compatibility and its inverse form were still absent. The orientation matters because the existing equivalence sends the class of `φ • e` to the class of `φ⁻¹`.

No Mathlib infrastructure is vendored. The implementation reuses Tau Ceti’s existing `subgroupFiberOrbitQuotientEquivNormalizerQuotientOfNormal`, `regularSubgroupFiberOrbitQuotientEquivNormalizerQuotientOfNormal`, `normalizerQuotient_smul_subgroupFiberOrbitClass`, and `Subgroup.normalizerQuotientEquivQuotientOfNormal` APIs, plus Mathlib’s standard quotient-group multiplication and inverse simp lemmas.

`lake exe cache get` completed with `No files to download` and `Already decompressed 8609 file(s)`. `lake build` completed with `Build completed successfully (4552 jobs).` `lake exe axioms` completed with `axioms: audited 8358 TauCeti declaration(s); all within the allowlist [propext, Classical.choice, Quot.sound].`

<!--tauceti-target:v1 {"focus":"UniversalCovers","id":"normal-subgroup-fiber-quotient-equivariance"}-->

🤖 Prepared with Codex
