### PR TITLE
feat(Analysis/Contour): HW condition (A′) and curve flatness

### DIFF
--- a/TauCeti/Analysis/Contour/RegularityConditions.lean
+++ b/TauCeti/Analysis/Contour/RegularityConditions.lean
@@ -40,10 +40,10 @@ sector-cancellation identity; simple poles need no sector condition.
   Order `1` is a transversal crossing; larger `n` hugs the line more tightly.
 * `FlatOfOrderBasepoint γ a b n` — the analogue at the join `γ a = γ b` of a closed curve, for the
   outgoing branch at `a` (from the right) and the incoming branch at `b` (from the left).
-* `ConditionAprime γ a b f S` — HW condition (A′), a structure requiring `γ` to be flat of order `n`
-  wherever it meets a prescribed singularity `s ∈ S` at which `f` has a pole of order `n`: at each
-  interior crossing (`ConditionAprime.interior`) and at the basepoint (`ConditionAprime.basepoint`).
-  The pole orders are read from `f` via `meromorphicOrderAt`; `S` selects the singularities.
+* `ConditionAprime γ a b f S` — HW condition (A′), a structure requiring `γ` to meet each `s ∈ S`
+  finitely often (`finite_crossings`) and be flat of order `n` wherever `f` has a pole of order `n`
+  there (`interior`, `basepoint`). Pole orders come from `f` via `meromorphicOrderAt`; `S` selects
+  the singularities.
 * `SectorCompatible f z₀ θ` — the one-crossing Hungerbühler–Wasem sector condition, a structure with
   fields `angle_rational` (`θ` is a rational multiple of `π`) and `laurent_compatible` (the Laurent
   principal part of `f` at `z₀` resonates with `θ`).
@@ -200,15 +200,18 @@ def FlatOfOrderBasepoint (γ : ℝ → ℂ) (a b : ℝ) (n : ℕ) : Prop :=
     (fun t => |((γ t - γ b) * star v_minus).im| / ‖v_minus‖) =o[𝓝[<] b] (fun t => ‖γ t - γ b‖ ^ n)
 
 /-- **Hungerbühler–Wasem condition (A′)** for `γ` along `[a, b]`, at the prescribed singular set `S`
-of the integrand `f`: at each singularity `γ` is **flat of order equal to the order of `f`'s
-pole there**. Wherever `γ` meets a point of `S` at which `f` has a pole of order `n`, the curve is
-flat of order `n` — transversal at a simple pole, flatter at a higher-order pole — so it meets the
-singularity as a finite union of model sectors. Together with condition (B) it is a regularity
-hypothesis of the generalized residue theorem (HW Thm 3.3). Imposed at each *interior* crossing
-`t₀ ∈ (a, b)` and the *basepoint* `γ a` (`= γ b` for a closed curve), so a join singularity is not
-left free. The pole orders are read from `f` via `meromorphicOrderAt`; `S` selects the singularities
-to constrain. -/
+of the integrand `f`: `γ` meets each singularity only **finitely often** and is **flat** to the
+order of `f`'s pole there. Wherever `γ` meets a point of `S` at which `f` has a pole of order `n`,
+the curve is flat of order `n` — transversal at a simple pole, flatter at a higher-order pole; the
+crossings being finite, the singularity is met as a *finite* union of model sectors. Together with
+condition (B) it is a regularity hypothesis of the generalized residue theorem (HW Thm 3.3). It is
+imposed at each *interior* crossing `t₀ ∈ (a, b)` and the *basepoint* `γ a` (`= γ b` for a closed
+curve), so a join singularity is not left free. Pole orders are read from `f` via
+`meromorphicOrderAt`; `S` selects the singularities to constrain. -/
 structure ConditionAprime (γ : ℝ → ℂ) (a b : ℝ) (f : ℂ → ℂ) (S : Finset ℂ) : Prop where
+  /-- Each prescribed singularity is met only **finitely often** on `[a, b]`, so the indentation
+  around it is a *finite* union of model sectors. -/
+  finite_crossings : ∀ s ∈ S, (Set.Icc a b ∩ γ ⁻¹' {s}).Finite
   /-- At each interior crossing of a prescribed singularity where `f` has a pole of order `n`, the
   curve `γ` is flat of order `n`. -/
   interior : ∀ t₀ ∈ Set.Ioo a b, γ t₀ ∈ S → ∀ n : ℕ, 1 ≤ n →
@@ -218,15 +221,17 @@ structure ConditionAprime (γ : ℝ → ℂ) (a b : ℝ) (f : ℂ → ℂ) (S : 
   basepoint : γ a ∈ S → ∀ n : ℕ, 1 ≤ n →
     meromorphicOrderAt f (γ a) = (-(n : ℤ) : WithTop ℤ) → FlatOfOrderBasepoint γ a b n
 
-/-- Characterization of `ConditionAprime` by its two clauses, for rewriting the hypothesis into the
-`interior ∧ basepoint` conjunction (and back via the anonymous constructor). -/
+/-- Characterization of `ConditionAprime` by its three clauses, for rewriting the hypothesis into
+the `finite_crossings ∧ interior ∧ basepoint` conjunction (and back via the anonymous constructor).
+-/
 theorem conditionAprime_iff {γ : ℝ → ℂ} {a b : ℝ} {f : ℂ → ℂ} {S : Finset ℂ} :
     ConditionAprime γ a b f S ↔
+      (∀ s ∈ S, (Set.Icc a b ∩ γ ⁻¹' {s}).Finite) ∧
       (∀ t₀ ∈ Set.Ioo a b, γ t₀ ∈ S → ∀ n : ℕ, 1 ≤ n →
           meromorphicOrderAt f (γ t₀) = (-(n : ℤ) : WithTop ℤ) → FlatOfOrder γ t₀ n) ∧
         (γ a ∈ S → ∀ n : ℕ, 1 ≤ n →
           meromorphicOrderAt f (γ a) = (-(n : ℤ) : WithTop ℤ) → FlatOfOrderBasepoint γ a b n) :=
-  ⟨fun h => ⟨h.interior, h.basepoint⟩, fun h => ⟨h.1, h.2⟩⟩
+  ⟨fun h => ⟨h.finite_crossings, h.interior, h.basepoint⟩, fun h => ⟨h.1, h.2.1, h.2.2⟩⟩
 
 /-- **Sector compatibility** of `f` at an on-curve singularity `z₀` whose sector opens at angle `θ`
 (the Hungerbühler–Wasem condition at one crossing): the angle is a rational multiple of `π` and the

--- a/TauCeti/Analysis/Contour/RegularityConditions.lean
+++ b/TauCeti/Analysis/Contour/RegularityConditions.lean
@@ -16,14 +16,17 @@ public import Mathlib.Algebra.Order.ToIntervalMod
 # The Hungerbühler–Wasem crossing angle and regularity conditions (A′) and (B)
 
 For a curve `γ : ℝ → ℂ` on `[a, b]` and an integrand `f : ℂ → ℂ`, this file defines the **crossing
-angle** and the **flatness** of `γ` at a time, and the two Hungerbühler–Wasem regularity conditions
-at its on-curve singularities: the geometric transversal-approach condition **(A′)** and the
-analytic sector-cancellation condition **(B)**. Together they are the two regularity hypotheses of
-the generalized residue theorem (HW Thm 3.3), evaluating the Cauchy principal value `PV ∮_γ f`.
-Condition (A′) asks that `γ` approach each prescribed on-curve singularity transversally (flat of
-order `1`), so it is met as a finite union of model sectors. Condition (B) governs poles of order
-`> 1`, coupling the Laurent principal part of `f` at each such pole with the entry/exit tangents of
-`γ` there, through a sector-cancellation identity; simple poles need no sector condition.
+angle** and the **flatness** of `γ` at a time, and the roadmap's two Hungerbühler–Wasem regularity
+conditions at its on-curve singularities: the geometric transversal-approach condition **(A′)** and
+the analytic sector-cancellation condition **(B)**, the two regularity hypotheses of the generalized
+residue theorem (HW Thm 3.3), which evaluates the Cauchy principal value `PV ∮_γ f`. Condition (A′)
+asks that `γ` approach each prescribed on-curve singularity transversally (flat of order `1`) — its
+order-`1` form, exact for simple poles (the reach of this development, whose valence-formula
+target uses `f′/f`); the full higher-order (A′), matching flatness to pole order, needs order data
+absent from the f-free roadmap signature and is left as a roadmap-signature question. Condition (B)
+governs poles of order `> 1`, coupling the Laurent principal part of `f` at each such pole with the
+entry/exit tangents of `γ` there, via a sector-cancellation identity; simple poles need no sector
+condition.
 
 ## Main definitions
 
@@ -34,15 +37,16 @@ order `1`), so it is met as a finite union of model sectors. Condition (B) gover
   piecewise-`C¹` curve.
 * `basepointAngle γ a b` — the analogous opening angle at the join `γ a = γ b` of a closed curve,
   from the reversed incoming tangent at `b` to the outgoing tangent at `a`.
-* `FlatOfOrder γ t₀ n` — `γ` is **flat of order `n`** at `t₀`: from each side, `γ` deviates from a
-  one-sided tangent line by `o(‖γ t − γ t₀‖ⁿ)`. Order `1` is a transversal crossing; larger `n`
-  forces the approach to hug the tangent ever more tightly.
+* `FlatOfOrder γ t₀ n` — `γ` is **flat of order `n`** at `t₀` (parametrized-tangent form): from each
+  side, `γ` deviates from a one-sided tangent line by `o(‖γ t − γ t₀‖ⁿ)`. Order `1` is a transversal
+  crossing (HW's flatness for immersions); see its docstring for the `n ≥ 2` caveat vs HW Def. 3.2.
 * `FlatOfOrderBasepoint γ a b n` — the analogue at the join `γ a = γ b` of a closed curve, matching
   the outgoing tangent at `a` (from the right) with the incoming tangent at `b` (from the left).
-* `ConditionAprime γ a b S` — HW condition (A′), a structure asking that `γ` be flat of order `1` at
-  every crossing of every prescribed singularity `s ∈ S`: at each interior crossing
-  (`ConditionAprime.interior`) and at the basepoint (`ConditionAprime.basepoint`). It is purely
-  geometric — it does not refer to `f`; the matching to pole orders is carried by condition (B).
+* `ConditionAprime γ a b S` — the roadmap's condition (A′) target in transversal (order-`1`) form: a
+  structure asking `γ` be flat of order `1` at every crossing of every singularity `s ∈ S`,
+  at each interior crossing (`ConditionAprime.interior`) and at the basepoint
+  (`ConditionAprime.basepoint`). Purely geometric (f-free), exact for simple poles; its docstring
+  explains why the full higher-order HW (A′) is a roadmap-signature question.
 * `SectorCompatible f z₀ θ` — the one-crossing Hungerbühler–Wasem sector condition, a structure with
   fields `angle_rational` (`θ` is a rational multiple of `π`) and `laurent_compatible` (the Laurent
   principal part of `f` at `z₀` resonates with `θ`).
@@ -172,11 +176,14 @@ theorem basepointAngle_eq_pi {γ : ℝ → ℂ} {a b : ℝ}
   rw [basepointAngle, h]
   exact toIcoMod_arg_sub_arg_neg hL
 
-/-- **Flatness of order `n`** of `γ : ℝ → ℂ` at a time `t₀` (HW §3): from each side, `γ` agrees with
-a one-sided tangent line up to `o(‖γ t − γ t₀‖ⁿ)`. There are one-sided velocities `t_plus` (right)
-and `t_minus` (left) with `‖γ t − (γ t₀ + (t − t₀) • t_plus)‖ = o(‖γ t − γ t₀‖ⁿ)` as `t → t₀⁺`, and
-symmetrically as `t → t₀⁻`. Order `1` is a transversal crossing (a one-sided tangent exists); larger
-`n` forces the approach to hug the tangent ever more tightly. -/
+/-- **Flatness of order `n`** of `γ : ℝ → ℂ` at a time `t₀`, in *parametrized-tangent* form: from
+each side there is a one-sided velocity (`t_plus` right, `t_minus` left) with
+`‖γ t − (γ t₀ + (t − t₀) • t_plus)‖ = o(‖γ t − γ t₀‖ⁿ)` as `t → t₀⁺`, symmetrically as `t → t₀⁻`
+(migrated from AINTLIB). At order `1` for an immersion (nonzero one-sided velocity — any genuine
+contour crossing) this is HW's flatness: `γ` has a one-sided tangent. For `n ≥ 2` it is *stricter*
+than HW Def. 3.2, measuring deviation from the tangent *line* (orthogonal projection) rather than
+the parametrized tangent *point*; the two coincide when the along-tangent speed is linear. Only the
+order-`1` case is used below (by `ConditionAprime`). -/
 def FlatOfOrder (γ : ℝ → ℂ) (t₀ : ℝ) (n : ℕ) : Prop :=
   ∃ t_plus t_minus : ℂ,
     (fun t => ‖γ t - (γ t₀ + (t - t₀) • t_plus)‖) =o[𝓝[>] t₀] (fun t => ‖γ t - γ t₀‖ ^ n) ∧
@@ -192,13 +199,19 @@ def FlatOfOrderBasepoint (γ : ℝ → ℂ) (a b : ℝ) (n : ℕ) : Prop :=
     (fun t => ‖γ t - (γ a + (t - a) • t_plus)‖) =o[𝓝[>] a] (fun t => ‖γ t - γ a‖ ^ n) ∧
     (fun t => ‖γ t - (γ b + (t - b) • t_minus)‖) =o[𝓝[<] b] (fun t => ‖γ t - γ b‖ ^ n)
 
-/-- **Hungerbühler–Wasem condition (A′)** for `γ` along `[a, b]` at the prescribed singular set `S`:
-`γ` approaches each `s ∈ S` transversally, i.e. is **flat of order `1`** at every time it meets `s`,
-so it meets `s` as a finite union of model sectors. Together with condition (B) it is one of the two
-regularity hypotheses of the generalized residue theorem (HW Thm 3.3). Imposed at each *interior*
-crossing `t₀ ∈ (a, b)` and at the *basepoint* `γ a` (`= γ b` for a closed curve), so a join
-singularity is not left free. This is the purely geometric condition — it does not refer to `f`; the
-matching to the pole orders of `f` at higher-order poles is carried by condition (B). -/
+/-- The roadmap's **condition (A′)** target, in transversal (order-`1`) form: `γ` approaches each
+prescribed singularity `s ∈ S` **transversally** — flat of order `1` at every time it meets `s` — so
+it meets `s` as finitely many model sectors, at each *interior* crossing `t₀ ∈ (a, b)` and at the
+*basepoint* `γ a` (`= γ b` for a closed curve), leaving no join singularity free. It is the purely
+geometric half of the roadmap's A′/B split (A′ on the set `S`; the analytic data in condition (B)),
+and does not refer to `f`.
+
+This order-`1` form is **exact for simple poles**, this development's reach (the valence formula
+applies the residue theorem to `f′/f`, whose poles are all simple). It is **not** the full
+higher-order HW condition (A′): faithful HW (A) demands flatness of order equal to the *pole
+order*, which needs the pole orders of `f`. The roadmap signature `ConditionAprime (γ)(a b)(S)` is
+f-free and `S` carries no order data, so that matching cannot be expressed here; supplying it is
+a roadmap-signature decision, not settled in this file. -/
 structure ConditionAprime (γ : ℝ → ℂ) (a b : ℝ) (S : Finset ℂ) : Prop where
   /-- At each interior time where `γ` meets a prescribed singularity, `γ` crosses transversally,
   i.e. is flat of order `1`. -/

--- a/TauCeti/Analysis/Contour/RegularityConditions.lean
+++ b/TauCeti/Analysis/Contour/RegularityConditions.lean
@@ -9,18 +9,21 @@ public import Mathlib.Analysis.SpecialFunctions.Complex.Arg
 public import Mathlib.Analysis.Calculus.Deriv.Basic
 public import Mathlib.Analysis.Analytic.Basic
 public import Mathlib.Analysis.Meromorphic.Order
+public import Mathlib.Analysis.Asymptotics.Defs
 public import Mathlib.Algebra.Order.ToIntervalMod
 
 /-!
-# The Hungerbühler–Wasem crossing angle and regularity condition (B)
+# The Hungerbühler–Wasem crossing angle and regularity conditions (A′) and (B)
 
 For a curve `γ : ℝ → ℂ` on `[a, b]` and an integrand `f : ℂ → ℂ`, this file defines the **crossing
-angle** of `γ` at a time and the Hungerbühler–Wasem regularity **condition (B)** at the higher-order
-on-curve poles of `f`. Condition (B) is one of the two regularity hypotheses (with condition (A′),
-the transversal-approach/flatness condition) of the generalized residue theorem (HW Thm 3.3), the
-theorem that evaluates the Cauchy principal value `PV ∮_γ f`. It governs poles of order `> 1`,
-coupling the Laurent principal part of `f` at each such pole with the entry/exit tangents of `γ`
-there, through a sector-cancellation identity; simple poles need no sector condition.
+angle** and the **flatness** of `γ` at a time, and the two Hungerbühler–Wasem regularity conditions
+at its on-curve singularities: the geometric transversal-approach condition **(A′)** and the
+analytic sector-cancellation condition **(B)**. Together they are the two regularity hypotheses of
+the generalized residue theorem (HW Thm 3.3), evaluating the Cauchy principal value `PV ∮_γ f`.
+Condition (A′) asks that `γ` approach each prescribed on-curve singularity transversally (flat of
+order `1`), so it is met as a finite union of model sectors. Condition (B) governs poles of order
+`> 1`, coupling the Laurent principal part of `f` at each such pole with the entry/exit tangents of
+`γ` there, through a sector-cancellation identity; simple poles need no sector condition.
 
 ## Main definitions
 
@@ -31,6 +34,15 @@ there, through a sector-cancellation identity; simple poles need no sector condi
   piecewise-`C¹` curve.
 * `basepointAngle γ a b` — the analogous opening angle at the join `γ a = γ b` of a closed curve,
   from the reversed incoming tangent at `b` to the outgoing tangent at `a`.
+* `FlatOfOrder γ t₀ n` — `γ` is **flat of order `n`** at `t₀`: from each side, `γ` deviates from a
+  one-sided tangent line by `o(‖γ t − γ t₀‖ⁿ)`. Order `1` is a transversal crossing; larger `n`
+  forces the approach to hug the tangent ever more tightly.
+* `FlatOfOrderBasepoint γ a b n` — the analogue at the join `γ a = γ b` of a closed curve, matching
+  the outgoing tangent at `a` (from the right) with the incoming tangent at `b` (from the left).
+* `ConditionAprime γ a b S` — HW condition (A′), a structure asking that `γ` be flat of order `1` at
+  every crossing of every prescribed singularity `s ∈ S`: at each interior crossing
+  (`ConditionAprime.interior`) and at the basepoint (`ConditionAprime.basepoint`). It is purely
+  geometric — it does not refer to `f`; the matching to pole orders is carried by condition (B).
 * `SectorCompatible f z₀ θ` — the one-crossing Hungerbühler–Wasem sector condition, a structure with
   fields `angle_rational` (`θ` is a rational multiple of `π`) and `laurent_compatible` (the Laurent
   principal part of `f` at `z₀` resonates with `θ`).
@@ -38,16 +50,18 @@ there, through a sector-cancellation identity; simple poles need no sector condi
   higher-order (order `> 1`) on-curve pole of `f`: at each interior crossing (`ConditionB.interior`)
   and at the basepoint (`ConditionB.basepoint`).
 
-Higher-order on-curve poles are detected **intrinsically** as the times `t₀` where
-`meromorphicOrderAt f (γ t₀) < -1` (a pole of order `> 1`), so the predicate is `S`-free and depends
-only on `(γ, f)`, matching the roadmap signature and the way the generalized residue theorem
-consumes it.
+Higher-order on-curve poles (for condition (B)) are detected **intrinsically** as the times `t₀`
+where `meromorphicOrderAt f (γ t₀) < -1` (a pole of order `> 1`), so `ConditionB` is `S`-free and
+depends only on `(γ, f)`. Condition (A′), the geometric condition, is imposed on the prescribed
+singular set `S`. Both match the roadmap signatures and the way the generalized residue theorem
+consumes them.
 
 ## Provenance
 
-Migrated and adapted from the AINTLIB `LeanModularForms` project (`angleAtCrossing` and
-`SatisfiesConditionB`), specialised to the raw-function (`γ : ℝ → ℂ` on `[a, b]`) design of the
-contour-integration roadmap, with the singular set detected intrinsically rather than prescribed.
+Migrated and adapted from the AINTLIB `LeanModularForms` project (`angleAtCrossing`, `FlatOfOrder`,
+and `SatisfiesConditionB`), specialised to the raw-function (`γ : ℝ → ℂ` on `[a, b]`) design of the
+contour-integration roadmap. Condition (A′) is imposed on the prescribed singular set `S`; condition
+(B) detects the higher-order poles of `f` intrinsically via `meromorphicOrderAt`.
 
 ## References
 
@@ -157,6 +171,49 @@ theorem basepointAngle_eq_pi {γ : ℝ → ℂ} {a b : ℝ}
     basepointAngle γ a b = Real.pi := by
   rw [basepointAngle, h]
   exact toIcoMod_arg_sub_arg_neg hL
+
+/-- **Flatness of order `n`** of `γ : ℝ → ℂ` at a time `t₀` (HW §3): from each side, `γ` agrees with
+a one-sided tangent line up to `o(‖γ t − γ t₀‖ⁿ)`. There are one-sided velocities `t_plus` (right)
+and `t_minus` (left) with `‖γ t − (γ t₀ + (t − t₀) • t_plus)‖ = o(‖γ t − γ t₀‖ⁿ)` as `t → t₀⁺`, and
+symmetrically as `t → t₀⁻`. Order `1` is a transversal crossing (a one-sided tangent exists); larger
+`n` forces the approach to hug the tangent ever more tightly. -/
+def FlatOfOrder (γ : ℝ → ℂ) (t₀ : ℝ) (n : ℕ) : Prop :=
+  ∃ t_plus t_minus : ℂ,
+    (fun t => ‖γ t - (γ t₀ + (t - t₀) • t_plus)‖) =o[𝓝[>] t₀] (fun t => ‖γ t - γ t₀‖ ^ n) ∧
+    (fun t => ‖γ t - (γ t₀ + (t - t₀) • t_minus)‖) =o[𝓝[<] t₀] (fun t => ‖γ t - γ t₀‖ ^ n)
+
+/-- **Flatness of order `n` at the basepoint** of a closed curve `γ` on `[a, b]`, at the join
+`γ a = γ b`: the outgoing branch at `a` (from the right) and the incoming branch at `b` (from the
+left) each agree with a one-sided tangent line, up to `o(‖γ t − γ a‖ⁿ)` and `o(‖γ t − γ b‖ⁿ)`
+respectively. This is `FlatOfOrder`'s analogue at the basepoint, where the two branches come from
+opposite ends of `[a, b]`. -/
+def FlatOfOrderBasepoint (γ : ℝ → ℂ) (a b : ℝ) (n : ℕ) : Prop :=
+  ∃ t_plus t_minus : ℂ,
+    (fun t => ‖γ t - (γ a + (t - a) • t_plus)‖) =o[𝓝[>] a] (fun t => ‖γ t - γ a‖ ^ n) ∧
+    (fun t => ‖γ t - (γ b + (t - b) • t_minus)‖) =o[𝓝[<] b] (fun t => ‖γ t - γ b‖ ^ n)
+
+/-- **Hungerbühler–Wasem condition (A′)** for `γ` along `[a, b]` at the prescribed singular set `S`:
+`γ` approaches each `s ∈ S` transversally, i.e. is **flat of order `1`** at every time it meets `s`,
+so it meets `s` as a finite union of model sectors. Together with condition (B) it is one of the two
+regularity hypotheses of the generalized residue theorem (HW Thm 3.3). Imposed at each *interior*
+crossing `t₀ ∈ (a, b)` and at the *basepoint* `γ a` (`= γ b` for a closed curve), so a join
+singularity is not left free. This is the purely geometric condition — it does not refer to `f`; the
+matching to the pole orders of `f` at higher-order poles is carried by condition (B). -/
+structure ConditionAprime (γ : ℝ → ℂ) (a b : ℝ) (S : Finset ℂ) : Prop where
+  /-- At each interior time where `γ` meets a prescribed singularity, `γ` crosses transversally,
+  i.e. is flat of order `1`. -/
+  interior : ∀ t₀ ∈ Set.Ioo a b, γ t₀ ∈ S → FlatOfOrder γ t₀ 1
+  /-- If the basepoint `γ a` (`= γ b` for a closed curve) is a prescribed singularity, `γ` meets it
+  transversally across the join — the endpoint case the `interior` clause cannot reach. -/
+  basepoint : γ a ∈ S → FlatOfOrderBasepoint γ a b 1
+
+/-- Characterization of `ConditionAprime` by its two clauses, for rewriting the hypothesis into the
+`interior ∧ basepoint` conjunction (and back via the anonymous constructor). -/
+theorem conditionAprime_iff {γ : ℝ → ℂ} {a b : ℝ} {S : Finset ℂ} :
+    ConditionAprime γ a b S ↔
+      (∀ t₀ ∈ Set.Ioo a b, γ t₀ ∈ S → FlatOfOrder γ t₀ 1) ∧
+        (γ a ∈ S → FlatOfOrderBasepoint γ a b 1) :=
+  ⟨fun h => ⟨h.interior, h.basepoint⟩, fun h => ⟨h.1, h.2⟩⟩
 
 /-- **Sector compatibility** of `f` at an on-curve singularity `z₀` whose sector opens at angle `θ`
 (the Hungerbühler–Wasem condition at one crossing): the angle is a rational multiple of `π` and the

--- a/TauCeti/Analysis/Contour/RegularityConditions.lean
+++ b/TauCeti/Analysis/Contour/RegularityConditions.lean
@@ -21,7 +21,7 @@ sector-cancellation condition **(B)**, the two regularity hypotheses of the gene
 theorem (HW Thm 3.3), evaluating the Cauchy principal value `PV ∮_γ f`. Condition (A′) asks that
 at each prescribed singularity `s ∈ S` the curve `γ` be **flat of order equal to the order of `f`'s
 pole there** — with a one-sided tangent line at a simple pole, hugged ever tighter at a higher-order
-pole — so it meets `s` as a finite union of model sectors. Condition (B) governs poles of order
+pole — and that it meet each `s` only finitely often. Condition (B) governs poles of order
 `> 1`, coupling the Laurent principal part of `f` at each such pole with the entry/exit tangents of
 `γ` there, via a sector-cancellation identity; simple poles need no sector condition.
 
@@ -223,15 +223,15 @@ theorem flatOfOrderBasepoint_iff {γ : ℝ → ℂ} {a b : ℝ} {n : ℕ} :
 /-- **Hungerbühler–Wasem condition (A′)** for `γ` along `[a, b]`, at the prescribed singular set `S`
 of the integrand `f`: `γ` meets each singularity only **finitely often** and is **flat** to the
 order of `f`'s pole there. Wherever `γ` meets a point of `S` at which `f` has a pole of order `n`,
-the curve is flat of order `n` — tangent to a line at a simple pole, flatter at a higher pole; the
-crossings being finite, the singularity is met as a *finite* union of model sectors. Together with
+the curve is flat of order `n` — tangent to a line at a simple pole, flatter at a higher pole — and
+each such `s` is met only finitely often. Together with
 condition (B) it is a regularity hypothesis of the generalized residue theorem (HW Thm 3.3). It is
 imposed at each *interior* crossing `t₀ ∈ (a, b)` and the *basepoint* `γ a` (`= γ b` for a closed
 curve), so a join singularity is not left free. Pole orders are read from `f` via
 `meromorphicOrderAt`; `S` selects the singularities to constrain. -/
 structure ConditionAprime (γ : ℝ → ℂ) (a b : ℝ) (f : ℂ → ℂ) (S : Finset ℂ) : Prop where
-  /-- Each prescribed singularity is met only **finitely often** on `[a, b]`, so the indentation
-  around it is a *finite* union of model sectors. -/
+  /-- Each prescribed singularity `s ∈ S` is met only **finitely often** on `[a, b]`: the crossing
+  set `[a, b] ∩ γ ⁻¹' {s}` is finite. -/
   finite_crossings : ∀ s ∈ S, (Set.Icc a b ∩ γ ⁻¹' {s}).Finite
   /-- At each interior crossing of a prescribed singularity where `f` has a pole of order `n`, the
   curve `γ` is flat of order `n`. -/

--- a/TauCeti/Analysis/Contour/RegularityConditions.lean
+++ b/TauCeti/Analysis/Contour/RegularityConditions.lean
@@ -17,16 +17,14 @@ public import Mathlib.Algebra.Order.ToIntervalMod
 
 For a curve `γ : ℝ → ℂ` on `[a, b]` and an integrand `f : ℂ → ℂ`, this file defines the **crossing
 angle** and the **flatness** of `γ` at a time, and the roadmap's two Hungerbühler–Wasem regularity
-conditions at its on-curve singularities: the geometric transversal-approach condition **(A′)** and
-the analytic sector-cancellation condition **(B)**, the two regularity hypotheses of the generalized
-residue theorem (HW Thm 3.3), which evaluates the Cauchy principal value `PV ∮_γ f`. Condition (A′)
-asks that `γ` approach each prescribed on-curve singularity transversally (flat of order `1`) — its
-order-`1` form, exact for simple poles (the reach of this development, whose valence-formula
-target uses `f′/f`); the full higher-order (A′), matching flatness to pole order, needs order data
-absent from the f-free roadmap signature and is left as a roadmap-signature question. Condition (B)
-governs poles of order `> 1`, coupling the Laurent principal part of `f` at each such pole with the
-entry/exit tangents of `γ` there, via a sector-cancellation identity; simple poles need no sector
-condition.
+conditions at its on-curve singularities: the geometric flatness condition **(A′)** and the analytic
+sector-cancellation condition **(B)**, the two regularity hypotheses of the generalized residue
+theorem (HW Thm 3.3), evaluating the Cauchy principal value `PV ∮_γ f`. Condition (A′) asks that
+at each prescribed singularity `s ∈ S` the curve `γ` be **flat of order equal to the order of `f`'s
+pole there** — transversal at a simple pole, flatter at a higher-order pole — so it meets `s` as a
+finite union of model sectors. Condition (B) governs poles of order `> 1`, coupling the Laurent
+principal part of `f` at each such pole with the entry/exit tangents of `γ` there, via a
+sector-cancellation identity; simple poles need no sector condition.
 
 ## Main definitions
 
@@ -37,16 +35,15 @@ condition.
   piecewise-`C¹` curve.
 * `basepointAngle γ a b` — the analogous opening angle at the join `γ a = γ b` of a closed curve,
   from the reversed incoming tangent at `b` to the outgoing tangent at `a`.
-* `FlatOfOrder γ t₀ n` — `γ` is **flat of order `n`** at `t₀` (parametrized-tangent form): from each
-  side, `γ` deviates from a one-sided tangent line by `o(‖γ t − γ t₀‖ⁿ)`. Order `1` is a transversal
-  crossing (HW's flatness for immersions); see its docstring for the `n ≥ 2` caveat vs HW Def. 3.2.
-* `FlatOfOrderBasepoint γ a b n` — the analogue at the join `γ a = γ b` of a closed curve, matching
-  the outgoing tangent at `a` (from the right) with the incoming tangent at `b` (from the left).
-* `ConditionAprime γ a b S` — the roadmap's condition (A′) target in transversal (order-`1`) form: a
-  structure asking `γ` be flat of order `1` at every crossing of every singularity `s ∈ S`,
-  at each interior crossing (`ConditionAprime.interior`) and at the basepoint
-  (`ConditionAprime.basepoint`). Purely geometric (f-free), exact for simple poles; its docstring
-  explains why the full higher-order HW (A′) is a roadmap-signature question.
+* `FlatOfOrder γ t₀ n` — `γ` is **flat of order `n`** at `t₀` (HW Def. 3.2): from each side the
+  perpendicular distance from `γ t` to a one-sided tangent line at `γ t₀` is `o(‖γ t − γ t₀‖ⁿ)`.
+  Order `1` is a transversal crossing; larger `n` hugs the line more tightly.
+* `FlatOfOrderBasepoint γ a b n` — the analogue at the join `γ a = γ b` of a closed curve, for the
+  outgoing branch at `a` (from the right) and the incoming branch at `b` (from the left).
+* `ConditionAprime γ a b f S` — HW condition (A′), a structure requiring `γ` to be flat of order `n`
+  wherever it meets a prescribed singularity `s ∈ S` at which `f` has a pole of order `n`: at each
+  interior crossing (`ConditionAprime.interior`) and at the basepoint (`ConditionAprime.basepoint`).
+  The pole orders are read from `f` via `meromorphicOrderAt`; `S` selects the singularities.
 * `SectorCompatible f z₀ θ` — the one-crossing Hungerbühler–Wasem sector condition, a structure with
   fields `angle_rational` (`θ` is a rational multiple of `π`) and `laurent_compatible` (the Laurent
   principal part of `f` at `z₀` resonates with `θ`).
@@ -54,18 +51,20 @@ condition.
   higher-order (order `> 1`) on-curve pole of `f`: at each interior crossing (`ConditionB.interior`)
   and at the basepoint (`ConditionB.basepoint`).
 
-Higher-order on-curve poles (for condition (B)) are detected **intrinsically** as the times `t₀`
-where `meromorphicOrderAt f (γ t₀) < -1` (a pole of order `> 1`), so `ConditionB` is `S`-free and
-depends only on `(γ, f)`. Condition (A′), the geometric condition, is imposed on the prescribed
-singular set `S`. Both match the roadmap signatures and the way the generalized residue theorem
-consumes them.
+Both conditions read the on-curve pole orders of `f` from `meromorphicOrderAt`. Condition (B) needs
+no explicit singular set — it fires **intrinsically** at the times `t₀` where
+`meromorphicOrderAt f (γ t₀) < -1` (a pole of order `> 1`), so it is `S`-free. Condition (A′) is
+imposed at the prescribed set `S` (selecting the singularities), with the required flatness order
+taken from `f`. Both match the roadmap signatures and the way the residue theorem consumes them.
 
 ## Provenance
 
 Migrated and adapted from the AINTLIB `LeanModularForms` project (`angleAtCrossing`, `FlatOfOrder`,
 and `SatisfiesConditionB`), specialised to the raw-function (`γ : ℝ → ℂ` on `[a, b]`) design of the
-contour-integration roadmap. Condition (A′) is imposed on the prescribed singular set `S`; condition
-(B) detects the higher-order poles of `f` intrinsically via `meromorphicOrderAt`.
+contour-integration roadmap. `FlatOfOrder` here uses HW Def. 3.2's tangent-*line* (orthogonal
+projection) distance, so it is speed-independent at every order. Condition (A′) matches the flatness
+order to `f`'s pole order at each `s ∈ S`; condition (B) detects the higher-order poles of
+`f` intrinsically via `meromorphicOrderAt`.
 
 ## References
 
@@ -176,56 +175,57 @@ theorem basepointAngle_eq_pi {γ : ℝ → ℂ} {a b : ℝ}
   rw [basepointAngle, h]
   exact toIcoMod_arg_sub_arg_neg hL
 
-/-- **Flatness of order `n`** of `γ : ℝ → ℂ` at a time `t₀`, in *parametrized-tangent* form: from
-each side there is a one-sided velocity (`t_plus` right, `t_minus` left) with
-`‖γ t − (γ t₀ + (t − t₀) • t_plus)‖ = o(‖γ t − γ t₀‖ⁿ)` as `t → t₀⁺`, symmetrically as `t → t₀⁻`
-(migrated from AINTLIB). At order `1` for an immersion (nonzero one-sided velocity — any genuine
-contour crossing) this is HW's flatness: `γ` has a one-sided tangent. For `n ≥ 2` it is *stricter*
-than HW Def. 3.2, measuring deviation from the tangent *line* (orthogonal projection) rather than
-the parametrized tangent *point*; the two coincide when the along-tangent speed is linear. Only the
-order-`1` case is used below (by `ConditionAprime`). -/
+/-- **Flatness of order `n`** of `γ : ℝ → ℂ` at `t₀` (HW Def. 3.2): from each side, `γ` hugs a
+one-sided **tangent line** through `γ t₀`, its perpendicular distance to that line vanishing faster
+than `‖γ t − γ t₀‖ⁿ`. There are nonzero one-sided directions `v_plus` (right) and `v_minus` (left)
+for which the component of `γ t − γ t₀` orthogonal to `v` — of length
+`|((γ t − γ t₀) · conj v).im| / ‖v‖`, the distance from `γ t` to the line `γ t₀ + ℝ • v` — is
+`o(‖γ t − γ t₀‖ⁿ)` as `t → t₀⁺`, symmetrically as `t → t₀⁻`. Order `1` is a transversal crossing;
+larger `n` forces it to hug the line ever more tightly. Distance is measured to the tangent
+*line*, not to a moving point on it, so flatness ignores the along-tangent speed, as in HW. -/
 def FlatOfOrder (γ : ℝ → ℂ) (t₀ : ℝ) (n : ℕ) : Prop :=
-  ∃ t_plus t_minus : ℂ,
-    (fun t => ‖γ t - (γ t₀ + (t - t₀) • t_plus)‖) =o[𝓝[>] t₀] (fun t => ‖γ t - γ t₀‖ ^ n) ∧
-    (fun t => ‖γ t - (γ t₀ + (t - t₀) • t_minus)‖) =o[𝓝[<] t₀] (fun t => ‖γ t - γ t₀‖ ^ n)
+  ∃ v_plus v_minus : ℂ, v_plus ≠ 0 ∧ v_minus ≠ 0 ∧
+    (fun t => |((γ t - γ t₀) * star v_plus).im| / ‖v_plus‖)
+        =o[𝓝[>] t₀] (fun t => ‖γ t - γ t₀‖ ^ n) ∧
+    (fun t => |((γ t - γ t₀) * star v_minus).im| / ‖v_minus‖)
+        =o[𝓝[<] t₀] (fun t => ‖γ t - γ t₀‖ ^ n)
 
 /-- **Flatness of order `n` at the basepoint** of a closed curve `γ` on `[a, b]`, at the join
 `γ a = γ b`: the outgoing branch at `a` (from the right) and the incoming branch at `b` (from the
-left) each agree with a one-sided tangent line, up to `o(‖γ t − γ a‖ⁿ)` and `o(‖γ t − γ b‖ⁿ)`
-respectively. This is `FlatOfOrder`'s analogue at the basepoint, where the two branches come from
-opposite ends of `[a, b]`. -/
+left) each hug their one-sided tangent line in the perpendicular sense of `FlatOfOrder`, to order
+`n`. The two branches come from opposite ends of `[a, b]`. -/
 def FlatOfOrderBasepoint (γ : ℝ → ℂ) (a b : ℝ) (n : ℕ) : Prop :=
-  ∃ t_plus t_minus : ℂ,
-    (fun t => ‖γ t - (γ a + (t - a) • t_plus)‖) =o[𝓝[>] a] (fun t => ‖γ t - γ a‖ ^ n) ∧
-    (fun t => ‖γ t - (γ b + (t - b) • t_minus)‖) =o[𝓝[<] b] (fun t => ‖γ t - γ b‖ ^ n)
+  ∃ v_plus v_minus : ℂ, v_plus ≠ 0 ∧ v_minus ≠ 0 ∧
+    (fun t => |((γ t - γ a) * star v_plus).im| / ‖v_plus‖) =o[𝓝[>] a] (fun t => ‖γ t - γ a‖ ^ n) ∧
+    (fun t => |((γ t - γ b) * star v_minus).im| / ‖v_minus‖) =o[𝓝[<] b] (fun t => ‖γ t - γ b‖ ^ n)
 
-/-- The roadmap's **condition (A′)** target, in transversal (order-`1`) form: `γ` approaches each
-prescribed singularity `s ∈ S` **transversally** — flat of order `1` at every time it meets `s` — so
-it meets `s` as finitely many model sectors, at each *interior* crossing `t₀ ∈ (a, b)` and at the
-*basepoint* `γ a` (`= γ b` for a closed curve), leaving no join singularity free. It is the purely
-geometric half of the roadmap's A′/B split (A′ on the set `S`; the analytic data in condition (B)),
-and does not refer to `f`.
-
-This order-`1` form is **exact for simple poles**, this development's reach (the valence formula
-applies the residue theorem to `f′/f`, whose poles are all simple). It is **not** the full
-higher-order HW condition (A′): faithful HW (A) demands flatness of order equal to the *pole
-order*, which needs the pole orders of `f`. The roadmap signature `ConditionAprime (γ)(a b)(S)` is
-f-free and `S` carries no order data, so that matching cannot be expressed here; supplying it is
-a roadmap-signature decision, not settled in this file. -/
-structure ConditionAprime (γ : ℝ → ℂ) (a b : ℝ) (S : Finset ℂ) : Prop where
-  /-- At each interior time where `γ` meets a prescribed singularity, `γ` crosses transversally,
-  i.e. is flat of order `1`. -/
-  interior : ∀ t₀ ∈ Set.Ioo a b, γ t₀ ∈ S → FlatOfOrder γ t₀ 1
-  /-- If the basepoint `γ a` (`= γ b` for a closed curve) is a prescribed singularity, `γ` meets it
-  transversally across the join — the endpoint case the `interior` clause cannot reach. -/
-  basepoint : γ a ∈ S → FlatOfOrderBasepoint γ a b 1
+/-- **Hungerbühler–Wasem condition (A′)** for `γ` along `[a, b]`, at the prescribed singular set `S`
+of the integrand `f`: at each singularity `γ` is **flat of order equal to the order of `f`'s
+pole there**. Wherever `γ` meets a point of `S` at which `f` has a pole of order `n`, the curve is
+flat of order `n` — transversal at a simple pole, flatter at a higher-order pole — so it meets the
+singularity as a finite union of model sectors. Together with condition (B) it is a regularity
+hypothesis of the generalized residue theorem (HW Thm 3.3). Imposed at each *interior* crossing
+`t₀ ∈ (a, b)` and the *basepoint* `γ a` (`= γ b` for a closed curve), so a join singularity is not
+left free. The pole orders are read from `f` via `meromorphicOrderAt`; `S` selects the singularities
+to constrain. -/
+structure ConditionAprime (γ : ℝ → ℂ) (a b : ℝ) (f : ℂ → ℂ) (S : Finset ℂ) : Prop where
+  /-- At each interior crossing of a prescribed singularity where `f` has a pole of order `n`, the
+  curve `γ` is flat of order `n`. -/
+  interior : ∀ t₀ ∈ Set.Ioo a b, γ t₀ ∈ S → ∀ n : ℕ, 1 ≤ n →
+    meromorphicOrderAt f (γ t₀) = (-(n : ℤ) : WithTop ℤ) → FlatOfOrder γ t₀ n
+  /-- If the basepoint `γ a` (`= γ b`) is a prescribed singularity where `f` has a
+  pole of order `n`, then `γ` is flat of order `n` across the join. -/
+  basepoint : γ a ∈ S → ∀ n : ℕ, 1 ≤ n →
+    meromorphicOrderAt f (γ a) = (-(n : ℤ) : WithTop ℤ) → FlatOfOrderBasepoint γ a b n
 
 /-- Characterization of `ConditionAprime` by its two clauses, for rewriting the hypothesis into the
 `interior ∧ basepoint` conjunction (and back via the anonymous constructor). -/
-theorem conditionAprime_iff {γ : ℝ → ℂ} {a b : ℝ} {S : Finset ℂ} :
-    ConditionAprime γ a b S ↔
-      (∀ t₀ ∈ Set.Ioo a b, γ t₀ ∈ S → FlatOfOrder γ t₀ 1) ∧
-        (γ a ∈ S → FlatOfOrderBasepoint γ a b 1) :=
+theorem conditionAprime_iff {γ : ℝ → ℂ} {a b : ℝ} {f : ℂ → ℂ} {S : Finset ℂ} :
+    ConditionAprime γ a b f S ↔
+      (∀ t₀ ∈ Set.Ioo a b, γ t₀ ∈ S → ∀ n : ℕ, 1 ≤ n →
+          meromorphicOrderAt f (γ t₀) = (-(n : ℤ) : WithTop ℤ) → FlatOfOrder γ t₀ n) ∧
+        (γ a ∈ S → ∀ n : ℕ, 1 ≤ n →
+          meromorphicOrderAt f (γ a) = (-(n : ℤ) : WithTop ℤ) → FlatOfOrderBasepoint γ a b n) :=
   ⟨fun h => ⟨h.interior, h.basepoint⟩, fun h => ⟨h.1, h.2⟩⟩
 
 /-- **Sector compatibility** of `f` at an on-curve singularity `z₀` whose sector opens at angle `θ`

--- a/TauCeti/Analysis/Contour/RegularityConditions.lean
+++ b/TauCeti/Analysis/Contour/RegularityConditions.lean
@@ -9,7 +9,6 @@ public import Mathlib.Analysis.SpecialFunctions.Complex.Arg
 public import Mathlib.Analysis.Calculus.Deriv.Basic
 public import Mathlib.Analysis.Analytic.Basic
 public import Mathlib.Analysis.Meromorphic.Order
-public import Mathlib.Analysis.Asymptotics.Defs
 public import Mathlib.Algebra.Order.ToIntervalMod
 
 /-!
@@ -21,10 +20,10 @@ conditions at its on-curve singularities: the geometric flatness condition **(A�
 sector-cancellation condition **(B)**, the two regularity hypotheses of the generalized residue
 theorem (HW Thm 3.3), evaluating the Cauchy principal value `PV ∮_γ f`. Condition (A′) asks that
 at each prescribed singularity `s ∈ S` the curve `γ` be **flat of order equal to the order of `f`'s
-pole there** — transversal at a simple pole, flatter at a higher-order pole — so it meets `s` as a
-finite union of model sectors. Condition (B) governs poles of order `> 1`, coupling the Laurent
-principal part of `f` at each such pole with the entry/exit tangents of `γ` there, via a
-sector-cancellation identity; simple poles need no sector condition.
+pole there** — with a one-sided tangent line at a simple pole, hugged ever tighter at a higher-order
+pole — so it meets `s` as a finite union of model sectors. Condition (B) governs poles of order
+`> 1`, coupling the Laurent principal part of `f` at each such pole with the entry/exit tangents of
+`γ` there, via a sector-cancellation identity; simple poles need no sector condition.
 
 ## Main definitions
 
@@ -37,7 +36,7 @@ sector-cancellation identity; simple poles need no sector condition.
   from the reversed incoming tangent at `b` to the outgoing tangent at `a`.
 * `FlatOfOrder γ t₀ n` — `γ` is **flat of order `n`** at `t₀` (HW Def. 3.2): from each side the
   perpendicular distance from `γ t` to a one-sided tangent line at `γ t₀` is `o(‖γ t − γ t₀‖ⁿ)`.
-  Order `1` is a transversal crossing; larger `n` hugs the line more tightly.
+  Order `1` gives a one-sided tangent line; larger `n` hugs the line more tightly.
 * `FlatOfOrderBasepoint γ a b n` — the analogue at the join `γ a = γ b` of a closed curve, for the
   outgoing branch at `a` (from the right) and the incoming branch at `b` (from the left).
 * `ConditionAprime γ a b f S` — HW condition (A′), a structure requiring `γ` to meet each `s ∈ S`
@@ -180,8 +179,8 @@ one-sided **tangent line** through `γ t₀`, its perpendicular distance to that
 than `‖γ t − γ t₀‖ⁿ`. There are nonzero one-sided directions `v_plus` (right) and `v_minus` (left)
 for which the component of `γ t − γ t₀` orthogonal to `v` — of length
 `|((γ t − γ t₀) · conj v).im| / ‖v‖`, the distance from `γ t` to the line `γ t₀ + ℝ • v` — is
-`o(‖γ t − γ t₀‖ⁿ)` as `t → t₀⁺`, symmetrically as `t → t₀⁻`. Order `1` is a transversal crossing;
-larger `n` forces it to hug the line ever more tightly. Distance is measured to the tangent
+`o(‖γ t − γ t₀‖ⁿ)` as `t → t₀⁺`, symmetrically as `t → t₀⁻`. Order `1` is first-order tangency to a
+line; larger `n` forces it to hug the line ever more tightly. Distance is measured to the tangent
 *line*, not to a moving point on it, so flatness ignores the along-tangent speed, as in HW. -/
 def FlatOfOrder (γ : ℝ → ℂ) (t₀ : ℝ) (n : ℕ) : Prop :=
   ∃ v_plus v_minus : ℂ, v_plus ≠ 0 ∧ v_minus ≠ 0 ∧
@@ -199,10 +198,32 @@ def FlatOfOrderBasepoint (γ : ℝ → ℂ) (a b : ℝ) (n : ℕ) : Prop :=
     (fun t => |((γ t - γ a) * star v_plus).im| / ‖v_plus‖) =o[𝓝[>] a] (fun t => ‖γ t - γ a‖ ^ n) ∧
     (fun t => |((γ t - γ b) * star v_minus).im| / ‖v_minus‖) =o[𝓝[<] b] (fun t => ‖γ t - γ b‖ ^ n)
 
+/-- `FlatOfOrder` unfolded: the one-sided little-o clauses that build the flatness hypothesis, so
+downstream code can construct or destruct it without unfolding the definition. -/
+theorem flatOfOrder_iff {γ : ℝ → ℂ} {t₀ : ℝ} {n : ℕ} :
+    FlatOfOrder γ t₀ n ↔
+      ∃ v_plus v_minus : ℂ, v_plus ≠ 0 ∧ v_minus ≠ 0 ∧
+        (fun t => |((γ t - γ t₀) * star v_plus).im| / ‖v_plus‖)
+            =o[𝓝[>] t₀] (fun t => ‖γ t - γ t₀‖ ^ n) ∧
+        (fun t => |((γ t - γ t₀) * star v_minus).im| / ‖v_minus‖)
+            =o[𝓝[<] t₀] (fun t => ‖γ t - γ t₀‖ ^ n) :=
+  Iff.rfl
+
+/-- `FlatOfOrderBasepoint` unfolded: the two one-sided little-o clauses (outgoing at `a`, incoming
+at `b`) that build the basepoint flatness hypothesis, exposed without unfolding the definition. -/
+theorem flatOfOrderBasepoint_iff {γ : ℝ → ℂ} {a b : ℝ} {n : ℕ} :
+    FlatOfOrderBasepoint γ a b n ↔
+      ∃ v_plus v_minus : ℂ, v_plus ≠ 0 ∧ v_minus ≠ 0 ∧
+        (fun t => |((γ t - γ a) * star v_plus).im| / ‖v_plus‖)
+            =o[𝓝[>] a] (fun t => ‖γ t - γ a‖ ^ n) ∧
+        (fun t => |((γ t - γ b) * star v_minus).im| / ‖v_minus‖)
+            =o[𝓝[<] b] (fun t => ‖γ t - γ b‖ ^ n) :=
+  Iff.rfl
+
 /-- **Hungerbühler–Wasem condition (A′)** for `γ` along `[a, b]`, at the prescribed singular set `S`
 of the integrand `f`: `γ` meets each singularity only **finitely often** and is **flat** to the
 order of `f`'s pole there. Wherever `γ` meets a point of `S` at which `f` has a pole of order `n`,
-the curve is flat of order `n` — transversal at a simple pole, flatter at a higher-order pole; the
+the curve is flat of order `n` — tangent to a line at a simple pole, flatter at a higher pole; the
 crossings being finite, the singularity is met as a *finite* union of model sectors. Together with
 condition (B) it is a regularity hypothesis of the generalized residue theorem (HW Thm 3.3). It is
 imposed at each *interior* crossing `t₀ ∈ (a, b)` and the *basepoint* `γ a` (`= γ b` for a closed


### PR DESCRIPTION
Adds the Hungerbühler–Wasem regularity **condition (A′)** — the geometric
flatness hypothesis of the generalized residue theorem (HW Thm 3.3) — to
`RegularityConditions.lean`, completing the (A′)/(B) pair (condition (B) landed
in #735).

### What's added
- `FlatOfOrder γ t₀ n` — `γ` is flat of order `n` at `t₀` in HW Def. 3.2's
  sense: the **perpendicular distance** from `γ t` to a one-sided tangent *line*
  at `γ t₀` is `o(‖γ t − γ t₀‖ⁿ)` (orthogonal projection, so it is
  speed-independent at every order).
- `FlatOfOrderBasepoint γ a b n` — the join analogue for a closed curve
  (outgoing branch at `a`, incoming branch at `b`).
- `ConditionAprime γ a b f S` — a structure requiring `γ` to be flat of order
  `n` wherever it meets a prescribed singularity `s ∈ S` at which `f` has a pole
  of order `n` (interior + basepoint clauses), plus `conditionAprime_iff`.

### On the signature
`ConditionAprime` carries `f` because HW condition (A) matches the flatness order
to `f`'s pole order at each on-curve singularity (read via `meromorphicOrderAt`).
The roadmap's `ConditionAprime` signature was updated to match in
FormalFrontier/TauCetiRoadmap#61; this PR realises it. An earlier revision tried
an f-free order-1 form, which correctness correctly flagged as too weak for
higher-order poles — hence the roadmap fix and this order-aware version.

### Checks (all green locally)
`lake build`, `lake exe axioms`, `lake exe module-system`, `bash scripts/lint-env.sh`
(no new violations).

🤖 Generated with [Claude Code](https://claude.com/claude-code)