### PR TITLE
feat: add fully blocked cycle submodules

### DIFF
--- a/TauCeti/KnotTheory/Grid/BasicCycles.lean
+++ b/TauCeti/KnotTheory/Grid/BasicCycles.lean
@@ -61,26 +61,6 @@ theorem mem_fullyBlockedBoundaries (c : GridChain (ZMod 2) n) :
     rw [fullyBlockedBoundaries]
     exact LinearMap.mem_range
 
-/-- The zero chain is a fully blocked cycle. -/
-theorem zero_mem_fullyBlockedCycles : (0 : GridChain (ZMod 2) n) ∈ G.fullyBlockedCycles := by
-  simp [fullyBlockedCycles]
-
-/-- The zero chain is a fully blocked boundary. -/
-theorem zero_mem_fullyBlockedBoundaries :
-    (0 : GridChain (ZMod 2) n) ∈ G.fullyBlockedBoundaries := by
-  exact Submodule.zero_mem G.fullyBlockedBoundaries
-
-/-- The differential of a cycle is zero, as an element of the chain module. -/
-theorem fullyBlockedDifferential_eq_zero_of_mem_cycles
-    {c : GridChain (ZMod 2) n} (hc : c ∈ G.fullyBlockedCycles) :
-    G.fullyBlockedDifferential c = 0 :=
-  (G.mem_fullyBlockedCycles c).mp hc
-
-/-- The differential of a chain is always a boundary. -/
-theorem fullyBlockedDifferential_mem_boundaries (c : GridChain (ZMod 2) n) :
-    G.fullyBlockedDifferential c ∈ G.fullyBlockedBoundaries :=
-  (G.mem_fullyBlockedBoundaries (G.fullyBlockedDifferential c)).mpr ⟨c, rfl⟩
-
 /-- Boundaries lie in cycles once the fully blocked differential is square-zero. -/
 theorem fullyBlockedBoundaries_le_cycles
     (hsq : G.fullyBlockedDifferential.comp G.fullyBlockedDifferential = 0) :

--- a/TauCeti/KnotTheory/Grid/BasicCycles.lean
+++ b/TauCeti/KnotTheory/Grid/BasicCycles.lean
@@ -1,0 +1,109 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+module
+
+public import TauCeti.KnotTheory.Grid.Complex
+public import Mathlib.Algebra.Module.Submodule.Range
+
+/-!
+# Cycles and boundaries for the fully blocked grid differential
+
+This file packages the kernel and range of the fully blocked grid differential as the cycle
+and boundary submodules of the finite free grid chain module. It does not assert the global
+square-zero theorem; instead it records the exact condition under which boundaries are cycles.
+
+## Main results
+
+* `TauCeti.GridDiagram.fullyBlockedCycles`: the kernel of the fully blocked differential.
+* `TauCeti.GridDiagram.fullyBlockedBoundaries`: the range of the fully blocked differential.
+* `TauCeti.GridDiagram.fullyBlockedBoundaries_le_cycles`: boundaries lie in cycles whenever the
+  fully blocked differential squares to zero.
+
+## References
+
+This supplies a prerequisite for `TauCetiRoadmap/CombinatorialHeegaardFloer/README.md`,
+Lane G.3, "The complexes and `∂² = 0`". The terminology follows Ozsváth--Stipsicz--Szabó,
+*Grid Homology for Knots and Links*, Chapter 3.
+-/
+
+public section
+
+namespace TauCeti
+
+namespace GridDiagram
+
+variable {n : ℕ} (G : GridDiagram n)
+
+/-- The cycles of the fully blocked grid differential: chains killed by `∂`. -/
+noncomputable def fullyBlockedCycles : Submodule (ZMod 2) (GridChain (ZMod 2) n) :=
+  LinearMap.ker G.fullyBlockedDifferential
+
+/-- The boundaries of the fully blocked grid differential: chains hit by `∂`. -/
+noncomputable def fullyBlockedBoundaries : Submodule (ZMod 2) (GridChain (ZMod 2) n) :=
+  LinearMap.range G.fullyBlockedDifferential
+
+/-- A chain is a fully blocked cycle exactly when its differential vanishes. -/
+@[simp]
+theorem mem_fullyBlockedCycles (c : GridChain (ZMod 2) n) :
+    c ∈ G.fullyBlockedCycles ↔ G.fullyBlockedDifferential c = 0 :=
+  by
+    rw [fullyBlockedCycles]
+    exact LinearMap.mem_ker
+
+/-- A chain is a fully blocked boundary exactly when it is the differential of some chain. -/
+@[simp]
+theorem mem_fullyBlockedBoundaries (c : GridChain (ZMod 2) n) :
+    c ∈ G.fullyBlockedBoundaries ↔
+      ∃ b : GridChain (ZMod 2) n, G.fullyBlockedDifferential b = c :=
+  by
+    rw [fullyBlockedBoundaries]
+    exact LinearMap.mem_range
+
+/-- The zero chain is a fully blocked cycle. -/
+theorem zero_mem_fullyBlockedCycles : (0 : GridChain (ZMod 2) n) ∈ G.fullyBlockedCycles := by
+  simp [fullyBlockedCycles]
+
+/-- The zero chain is a fully blocked boundary. -/
+theorem zero_mem_fullyBlockedBoundaries :
+    (0 : GridChain (ZMod 2) n) ∈ G.fullyBlockedBoundaries := by
+  exact Submodule.zero_mem G.fullyBlockedBoundaries
+
+/-- The differential of a cycle is zero, as an element of the chain module. -/
+theorem fullyBlockedDifferential_eq_zero_of_mem_cycles
+    {c : GridChain (ZMod 2) n} (hc : c ∈ G.fullyBlockedCycles) :
+    G.fullyBlockedDifferential c = 0 :=
+  (G.mem_fullyBlockedCycles c).mp hc
+
+/-- The differential of a chain is always a boundary. -/
+theorem fullyBlockedDifferential_mem_boundaries (c : GridChain (ZMod 2) n) :
+    G.fullyBlockedDifferential c ∈ G.fullyBlockedBoundaries :=
+  (G.mem_fullyBlockedBoundaries (G.fullyBlockedDifferential c)).mpr ⟨c, rfl⟩
+
+/-- Boundaries lie in cycles once the fully blocked differential is square-zero. -/
+theorem fullyBlockedBoundaries_le_cycles
+    (hsq : G.fullyBlockedDifferential.comp G.fullyBlockedDifferential = 0) :
+    G.fullyBlockedBoundaries ≤ G.fullyBlockedCycles := by
+  rw [fullyBlockedBoundaries, fullyBlockedCycles]
+  exact LinearMap.range_le_ker_iff.mpr hsq
+
+/-- The fully blocked cycle submodule is top when the differential is the zero map. -/
+theorem fullyBlockedCycles_eq_top_of_fullyBlockedDifferential_eq_zero
+    (h : G.fullyBlockedDifferential =
+      (0 : GridChain (ZMod 2) n →ₗ[ZMod 2] GridChain (ZMod 2) n)) :
+    G.fullyBlockedCycles = ⊤ := by
+  rw [fullyBlockedCycles]
+  exact LinearMap.ker_eq_top.mpr h
+
+/-- The fully blocked boundary submodule is bottom when the differential is the zero map. -/
+theorem fullyBlockedBoundaries_eq_bot_of_fullyBlockedDifferential_eq_zero
+    (h : G.fullyBlockedDifferential =
+      (0 : GridChain (ZMod 2) n →ₗ[ZMod 2] GridChain (ZMod 2) n)) :
+    G.fullyBlockedBoundaries = ⊥ := by
+  rw [fullyBlockedBoundaries]
+  exact LinearMap.range_eq_bot.mpr h
+
+end GridDiagram
+
+end TauCeti

--- a/TauCeti/KnotTheory/Grid/Cycles.lean
+++ b/TauCeti/KnotTheory/Grid/Cycles.lean
@@ -5,7 +5,6 @@ Released under Apache 2.0 license as described in the file LICENSE.
 module
 
 public import TauCeti.KnotTheory.Grid.SmallGridDifferential
-public import TauCeti.KnotTheory.Grid.SmallGridGradings
 public import TauCeti.KnotTheory.Grid.ChainCardinality
 public import Mathlib.Algebra.Module.Submodule.Range
 
@@ -52,15 +51,21 @@ noncomputable def fullyBlockedBoundaries : Submodule (ZMod 2) (GridChain (ZMod 2
   LinearMap.range G.fullyBlockedDifferential
 
 /-- A chain is a fully blocked cycle exactly when its differential vanishes. -/
+@[simp]
 theorem mem_fullyBlockedCycles (c : GridChain (ZMod 2) n) :
     c ∈ G.fullyBlockedCycles ↔ G.fullyBlockedDifferential c = 0 :=
-  Iff.rfl
+  by
+    rw [fullyBlockedCycles]
+    exact LinearMap.mem_ker
 
 /-- A chain is a fully blocked boundary exactly when it is the differential of some chain. -/
+@[simp]
 theorem mem_fullyBlockedBoundaries (c : GridChain (ZMod 2) n) :
     c ∈ G.fullyBlockedBoundaries ↔
       ∃ b : GridChain (ZMod 2) n, G.fullyBlockedDifferential b = c :=
-  Iff.rfl
+  by
+    rw [fullyBlockedBoundaries]
+    exact LinearMap.mem_range
 
 /-- The zero chain is a fully blocked cycle. -/
 theorem zero_mem_fullyBlockedCycles : (0 : GridChain (ZMod 2) n) ∈ G.fullyBlockedCycles := by
@@ -75,33 +80,35 @@ theorem zero_mem_fullyBlockedBoundaries :
 theorem fullyBlockedDifferential_eq_zero_of_mem_cycles
     {c : GridChain (ZMod 2) n} (hc : c ∈ G.fullyBlockedCycles) :
     G.fullyBlockedDifferential c = 0 :=
-  hc
+  (G.mem_fullyBlockedCycles c).mp hc
 
 /-- The differential of a chain is always a boundary. -/
 theorem fullyBlockedDifferential_mem_boundaries (c : GridChain (ZMod 2) n) :
     G.fullyBlockedDifferential c ∈ G.fullyBlockedBoundaries :=
-  ⟨c, rfl⟩
+  (G.mem_fullyBlockedBoundaries (G.fullyBlockedDifferential c)).mpr ⟨c, rfl⟩
 
 /-- Boundaries lie in cycles once the fully blocked differential is square-zero. -/
 theorem fullyBlockedBoundaries_le_cycles
     (hsq : G.fullyBlockedDifferential.comp G.fullyBlockedDifferential = 0) :
     G.fullyBlockedBoundaries ≤ G.fullyBlockedCycles := by
-  rintro c ⟨b, rfl⟩
-  exact LinearMap.congr_fun hsq b
+  change LinearMap.range G.fullyBlockedDifferential ≤ LinearMap.ker G.fullyBlockedDifferential
+  exact LinearMap.range_le_ker_iff.mpr hsq
 
 /-- The fully blocked cycle submodule is top when the differential is the zero map. -/
 theorem fullyBlockedCycles_eq_top_of_fullyBlockedDifferential_eq_zero
     (h : G.fullyBlockedDifferential =
       (0 : GridChain (ZMod 2) n →ₗ[ZMod 2] GridChain (ZMod 2) n)) :
     G.fullyBlockedCycles = ⊤ := by
-  rw [fullyBlockedCycles, h, LinearMap.ker_zero]
+  unfold fullyBlockedCycles
+  exact LinearMap.ker_eq_top.mpr h
 
 /-- The fully blocked boundary submodule is bottom when the differential is the zero map. -/
 theorem fullyBlockedBoundaries_eq_bot_of_fullyBlockedDifferential_eq_zero
     (h : G.fullyBlockedDifferential =
       (0 : GridChain (ZMod 2) n →ₗ[ZMod 2] GridChain (ZMod 2) n)) :
     G.fullyBlockedBoundaries = ⊥ := by
-  rw [fullyBlockedBoundaries, h, LinearMap.range_zero]
+  unfold fullyBlockedBoundaries
+  exact LinearMap.range_eq_bot.mpr h
 
 /-- In grid size at most two, every chain is a cycle for the fully blocked differential. -/
 theorem fullyBlockedCycles_eq_top_of_le_two (hn : n ≤ 2) :
@@ -151,16 +158,16 @@ theorem mem_fullyBlockedBoundaries_iff_eq_zero_of_two
     c ∈ G.fullyBlockedBoundaries ↔ c = 0 :=
   G.mem_fullyBlockedBoundaries_iff_eq_zero_of_le_two le_rfl c
 
-/-- The standard two-by-two grid has four fully blocked cycles. -/
-theorem natCard_fullyBlockedCycles_twoByTwo :
-  Nat.card (fullyBlockedCycles GridDiagram.twoByTwo) = 4 := by
+/-- Every `2 × 2` grid has four fully blocked cycles. -/
+theorem natCard_fullyBlockedCycles_of_two (G : GridDiagram 2) :
+  Nat.card G.fullyBlockedCycles = 4 := by
   classical
   rw [fullyBlockedCycles_eq_top_of_two]
   simp
 
-/-- The standard two-by-two grid has one fully blocked boundary. -/
-theorem natCard_fullyBlockedBoundaries_twoByTwo :
-    Nat.card (fullyBlockedBoundaries GridDiagram.twoByTwo) = 1 := by
+/-- Every `2 × 2` grid has one fully blocked boundary. -/
+theorem natCard_fullyBlockedBoundaries_of_two (G : GridDiagram 2) :
+    Nat.card G.fullyBlockedBoundaries = 1 := by
   classical
   rw [fullyBlockedBoundaries_eq_bot_of_two]
   simp

--- a/TauCeti/KnotTheory/Grid/Cycles.lean
+++ b/TauCeti/KnotTheory/Grid/Cycles.lean
@@ -63,12 +63,10 @@ theorem mem_fullyBlockedBoundaries (c : GridChain (ZMod 2) n) :
   Iff.rfl
 
 /-- The zero chain is a fully blocked cycle. -/
-@[simp]
 theorem zero_mem_fullyBlockedCycles : (0 : GridChain (ZMod 2) n) ∈ G.fullyBlockedCycles := by
   simp [fullyBlockedCycles]
 
 /-- The zero chain is a fully blocked boundary. -/
-@[simp]
 theorem zero_mem_fullyBlockedBoundaries :
     (0 : GridChain (ZMod 2) n) ∈ G.fullyBlockedBoundaries := by
   exact Submodule.zero_mem G.fullyBlockedBoundaries

--- a/TauCeti/KnotTheory/Grid/Cycles.lean
+++ b/TauCeti/KnotTheory/Grid/Cycles.lean
@@ -4,34 +4,28 @@ Released under Apache 2.0 license as described in the file LICENSE.
 -/
 module
 
+public import TauCeti.KnotTheory.Grid.BasicCycles
 public import TauCeti.KnotTheory.Grid.SmallGridDifferential
 public import TauCeti.KnotTheory.Grid.ChainCardinality
-public import Mathlib.Algebra.Module.Submodule.Range
 
 /-!
-# Cycles and boundaries for the fully blocked grid differential
+# Small-grid cycles and boundaries for the fully blocked grid differential
 
-This file packages the kernel and range of the fully blocked grid differential as the cycle
-and boundary submodules of the finite free grid chain module. It does not assert the global
-square-zero theorem; instead it records the exact condition under which boundaries are cycles,
-and computes the cycle and boundary submodules in the already-proved zero-differential small-grid
-case.
+This file computes the cycle and boundary submodules of the fully blocked grid differential in
+the already-proved zero-differential small-grid case.
 
 ## Main results
 
-* `TauCeti.GridDiagram.fullyBlockedCycles`: the kernel of the fully blocked differential.
-* `TauCeti.GridDiagram.fullyBlockedBoundaries`: the range of the fully blocked differential.
-* `TauCeti.GridDiagram.fullyBlockedBoundaries_le_cycles`: boundaries lie in cycles whenever the
-  fully blocked differential squares to zero.
 * `TauCeti.GridDiagram.fullyBlockedCycles_eq_top_of_le_two` and
   `TauCeti.GridDiagram.fullyBlockedBoundaries_eq_bot_of_le_two`: the small-grid computation.
+* `TauCeti.GridDiagram.natCard_fullyBlockedCycles_of_le_two` and
+  `TauCeti.GridDiagram.natCard_fullyBlockedBoundaries_of_le_two`: the small-grid cardinalities.
 
 ## References
 
 This supplies a prerequisite for `TauCetiRoadmap/CombinatorialHeegaardFloer/README.md`,
-Lane G.3, "The complexes and `∂² = 0`", and for the acceptance criterion that the `2 × 2`
-unknot grid complex be explicitly computable with its bigradings. The terminology follows
-Ozsváth--Stipsicz--Szabó, *Grid Homology for Knots and Links*, Chapter 3.
+Lane G.3, "The complexes and `∂² = 0`", and for the standing convention that grid complexes
+compute on explicit small grids.
 -/
 
 public section
@@ -41,74 +35,6 @@ namespace TauCeti
 namespace GridDiagram
 
 variable {n : ℕ} (G : GridDiagram n)
-
-/-- The cycles of the fully blocked grid differential: chains killed by `∂`. -/
-noncomputable def fullyBlockedCycles : Submodule (ZMod 2) (GridChain (ZMod 2) n) :=
-  LinearMap.ker G.fullyBlockedDifferential
-
-/-- The boundaries of the fully blocked grid differential: chains hit by `∂`. -/
-noncomputable def fullyBlockedBoundaries : Submodule (ZMod 2) (GridChain (ZMod 2) n) :=
-  LinearMap.range G.fullyBlockedDifferential
-
-/-- A chain is a fully blocked cycle exactly when its differential vanishes. -/
-@[simp]
-theorem mem_fullyBlockedCycles (c : GridChain (ZMod 2) n) :
-    c ∈ G.fullyBlockedCycles ↔ G.fullyBlockedDifferential c = 0 :=
-  by
-    rw [fullyBlockedCycles]
-    exact LinearMap.mem_ker
-
-/-- A chain is a fully blocked boundary exactly when it is the differential of some chain. -/
-@[simp]
-theorem mem_fullyBlockedBoundaries (c : GridChain (ZMod 2) n) :
-    c ∈ G.fullyBlockedBoundaries ↔
-      ∃ b : GridChain (ZMod 2) n, G.fullyBlockedDifferential b = c :=
-  by
-    rw [fullyBlockedBoundaries]
-    exact LinearMap.mem_range
-
-/-- The zero chain is a fully blocked cycle. -/
-theorem zero_mem_fullyBlockedCycles : (0 : GridChain (ZMod 2) n) ∈ G.fullyBlockedCycles := by
-  simp [fullyBlockedCycles]
-
-/-- The zero chain is a fully blocked boundary. -/
-theorem zero_mem_fullyBlockedBoundaries :
-    (0 : GridChain (ZMod 2) n) ∈ G.fullyBlockedBoundaries := by
-  exact Submodule.zero_mem G.fullyBlockedBoundaries
-
-/-- The differential of a cycle is zero, as an element of the chain module. -/
-theorem fullyBlockedDifferential_eq_zero_of_mem_cycles
-    {c : GridChain (ZMod 2) n} (hc : c ∈ G.fullyBlockedCycles) :
-    G.fullyBlockedDifferential c = 0 :=
-  (G.mem_fullyBlockedCycles c).mp hc
-
-/-- The differential of a chain is always a boundary. -/
-theorem fullyBlockedDifferential_mem_boundaries (c : GridChain (ZMod 2) n) :
-    G.fullyBlockedDifferential c ∈ G.fullyBlockedBoundaries :=
-  (G.mem_fullyBlockedBoundaries (G.fullyBlockedDifferential c)).mpr ⟨c, rfl⟩
-
-/-- Boundaries lie in cycles once the fully blocked differential is square-zero. -/
-theorem fullyBlockedBoundaries_le_cycles
-    (hsq : G.fullyBlockedDifferential.comp G.fullyBlockedDifferential = 0) :
-    G.fullyBlockedBoundaries ≤ G.fullyBlockedCycles := by
-  change LinearMap.range G.fullyBlockedDifferential ≤ LinearMap.ker G.fullyBlockedDifferential
-  exact LinearMap.range_le_ker_iff.mpr hsq
-
-/-- The fully blocked cycle submodule is top when the differential is the zero map. -/
-theorem fullyBlockedCycles_eq_top_of_fullyBlockedDifferential_eq_zero
-    (h : G.fullyBlockedDifferential =
-      (0 : GridChain (ZMod 2) n →ₗ[ZMod 2] GridChain (ZMod 2) n)) :
-    G.fullyBlockedCycles = ⊤ := by
-  unfold fullyBlockedCycles
-  exact LinearMap.ker_eq_top.mpr h
-
-/-- The fully blocked boundary submodule is bottom when the differential is the zero map. -/
-theorem fullyBlockedBoundaries_eq_bot_of_fullyBlockedDifferential_eq_zero
-    (h : G.fullyBlockedDifferential =
-      (0 : GridChain (ZMod 2) n →ₗ[ZMod 2] GridChain (ZMod 2) n)) :
-    G.fullyBlockedBoundaries = ⊥ := by
-  unfold fullyBlockedBoundaries
-  exact LinearMap.range_eq_bot.mpr h
 
 /-- In grid size at most two, every chain is a cycle for the fully blocked differential. -/
 theorem fullyBlockedCycles_eq_top_of_le_two (hn : n ≤ 2) :
@@ -158,19 +84,33 @@ theorem mem_fullyBlockedBoundaries_iff_eq_zero_of_two
     c ∈ G.fullyBlockedBoundaries ↔ c = 0 :=
   G.mem_fullyBlockedBoundaries_iff_eq_zero_of_le_two le_rfl c
 
+/-- In grid size at most two, there are `2 ^ n!` fully blocked cycles. -/
+theorem natCard_fullyBlockedCycles_of_le_two (hn : n ≤ 2) :
+    Nat.card G.fullyBlockedCycles = 2 ^ n.factorial := by
+  classical
+  rw [G.fullyBlockedCycles_eq_top_of_le_two hn]
+  rw [← GridChain.natCard_zmod_two n]
+  exact Nat.card_congr
+    (Submodule.topEquiv : (⊤ : Submodule (ZMod 2) (GridChain (ZMod 2) n)) ≃ₗ[ZMod 2]
+      GridChain (ZMod 2) n).toEquiv
+
+/-- In grid size at most two, there is one fully blocked boundary. -/
+theorem natCard_fullyBlockedBoundaries_of_le_two (hn : n ≤ 2) :
+    Nat.card G.fullyBlockedBoundaries = 1 := by
+  classical
+  rw [G.fullyBlockedBoundaries_eq_bot_of_le_two hn]
+  simp
+
 /-- Every `2 × 2` grid has four fully blocked cycles. -/
 theorem natCard_fullyBlockedCycles_of_two (G : GridDiagram 2) :
-  Nat.card G.fullyBlockedCycles = 4 := by
-  classical
-  rw [fullyBlockedCycles_eq_top_of_two]
+    Nat.card G.fullyBlockedCycles = 4 := by
+  rw [G.natCard_fullyBlockedCycles_of_le_two le_rfl]
   simp
 
 /-- Every `2 × 2` grid has one fully blocked boundary. -/
 theorem natCard_fullyBlockedBoundaries_of_two (G : GridDiagram 2) :
-    Nat.card G.fullyBlockedBoundaries = 1 := by
-  classical
-  rw [fullyBlockedBoundaries_eq_bot_of_two]
-  simp
+    Nat.card G.fullyBlockedBoundaries = 1 :=
+  G.natCard_fullyBlockedBoundaries_of_le_two le_rfl
 
 end GridDiagram
 

--- a/TauCeti/KnotTheory/Grid/Cycles.lean
+++ b/TauCeti/KnotTheory/Grid/Cycles.lean
@@ -1,0 +1,172 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+module
+
+public import TauCeti.KnotTheory.Grid.SmallGridDifferential
+public import TauCeti.KnotTheory.Grid.SmallGridGradings
+public import TauCeti.KnotTheory.Grid.ChainCardinality
+public import Mathlib.Algebra.Module.Submodule.Range
+
+/-!
+# Cycles and boundaries for the fully blocked grid differential
+
+This file packages the kernel and range of the fully blocked grid differential as the cycle
+and boundary submodules of the finite free grid chain module. It does not assert the global
+square-zero theorem; instead it records the exact condition under which boundaries are cycles,
+and computes the cycle and boundary submodules in the already-proved zero-differential small-grid
+case.
+
+## Main results
+
+* `TauCeti.GridDiagram.fullyBlockedCycles`: the kernel of the fully blocked differential.
+* `TauCeti.GridDiagram.fullyBlockedBoundaries`: the range of the fully blocked differential.
+* `TauCeti.GridDiagram.fullyBlockedBoundaries_le_cycles`: boundaries lie in cycles whenever the
+  fully blocked differential squares to zero.
+* `TauCeti.GridDiagram.fullyBlockedCycles_eq_top_of_le_two` and
+  `TauCeti.GridDiagram.fullyBlockedBoundaries_eq_bot_of_le_two`: the small-grid computation.
+
+## References
+
+This supplies a prerequisite for `TauCetiRoadmap/CombinatorialHeegaardFloer/README.md`,
+Lane G.3, "The complexes and `∂² = 0`", and for the acceptance criterion that the `2 × 2`
+unknot grid complex be explicitly computable with its bigradings. The terminology follows
+Ozsváth--Stipsicz--Szabó, *Grid Homology for Knots and Links*, Chapter 3.
+-/
+
+public section
+
+namespace TauCeti
+
+namespace GridDiagram
+
+variable {n : ℕ} (G : GridDiagram n)
+
+/-- The cycles of the fully blocked grid differential: chains killed by `∂`. -/
+noncomputable def fullyBlockedCycles : Submodule (ZMod 2) (GridChain (ZMod 2) n) :=
+  LinearMap.ker G.fullyBlockedDifferential
+
+/-- The boundaries of the fully blocked grid differential: chains hit by `∂`. -/
+noncomputable def fullyBlockedBoundaries : Submodule (ZMod 2) (GridChain (ZMod 2) n) :=
+  LinearMap.range G.fullyBlockedDifferential
+
+/-- A chain is a fully blocked cycle exactly when its differential vanishes. -/
+theorem mem_fullyBlockedCycles (c : GridChain (ZMod 2) n) :
+    c ∈ G.fullyBlockedCycles ↔ G.fullyBlockedDifferential c = 0 :=
+  Iff.rfl
+
+/-- A chain is a fully blocked boundary exactly when it is the differential of some chain. -/
+theorem mem_fullyBlockedBoundaries (c : GridChain (ZMod 2) n) :
+    c ∈ G.fullyBlockedBoundaries ↔
+      ∃ b : GridChain (ZMod 2) n, G.fullyBlockedDifferential b = c :=
+  Iff.rfl
+
+/-- The zero chain is a fully blocked cycle. -/
+@[simp]
+theorem zero_mem_fullyBlockedCycles : (0 : GridChain (ZMod 2) n) ∈ G.fullyBlockedCycles := by
+  simp [fullyBlockedCycles]
+
+/-- The zero chain is a fully blocked boundary. -/
+@[simp]
+theorem zero_mem_fullyBlockedBoundaries :
+    (0 : GridChain (ZMod 2) n) ∈ G.fullyBlockedBoundaries := by
+  exact Submodule.zero_mem G.fullyBlockedBoundaries
+
+/-- The differential of a cycle is zero, as an element of the chain module. -/
+theorem fullyBlockedDifferential_eq_zero_of_mem_cycles
+    {c : GridChain (ZMod 2) n} (hc : c ∈ G.fullyBlockedCycles) :
+    G.fullyBlockedDifferential c = 0 :=
+  hc
+
+/-- The differential of a chain is always a boundary. -/
+theorem fullyBlockedDifferential_mem_boundaries (c : GridChain (ZMod 2) n) :
+    G.fullyBlockedDifferential c ∈ G.fullyBlockedBoundaries :=
+  ⟨c, rfl⟩
+
+/-- Boundaries lie in cycles once the fully blocked differential is square-zero. -/
+theorem fullyBlockedBoundaries_le_cycles
+    (hsq : G.fullyBlockedDifferential.comp G.fullyBlockedDifferential = 0) :
+    G.fullyBlockedBoundaries ≤ G.fullyBlockedCycles := by
+  rintro c ⟨b, rfl⟩
+  exact LinearMap.congr_fun hsq b
+
+/-- The fully blocked cycle submodule is top when the differential is the zero map. -/
+theorem fullyBlockedCycles_eq_top_of_fullyBlockedDifferential_eq_zero
+    (h : G.fullyBlockedDifferential =
+      (0 : GridChain (ZMod 2) n →ₗ[ZMod 2] GridChain (ZMod 2) n)) :
+    G.fullyBlockedCycles = ⊤ := by
+  rw [fullyBlockedCycles, h, LinearMap.ker_zero]
+
+/-- The fully blocked boundary submodule is bottom when the differential is the zero map. -/
+theorem fullyBlockedBoundaries_eq_bot_of_fullyBlockedDifferential_eq_zero
+    (h : G.fullyBlockedDifferential =
+      (0 : GridChain (ZMod 2) n →ₗ[ZMod 2] GridChain (ZMod 2) n)) :
+    G.fullyBlockedBoundaries = ⊥ := by
+  rw [fullyBlockedBoundaries, h, LinearMap.range_zero]
+
+/-- In grid size at most two, every chain is a cycle for the fully blocked differential. -/
+theorem fullyBlockedCycles_eq_top_of_le_two (hn : n ≤ 2) :
+    G.fullyBlockedCycles = ⊤ :=
+  G.fullyBlockedCycles_eq_top_of_fullyBlockedDifferential_eq_zero
+    (G.fullyBlockedDifferential_eq_zero_of_le_two hn)
+
+/-- In grid size at most two, the only boundary for the fully blocked differential is zero. -/
+theorem fullyBlockedBoundaries_eq_bot_of_le_two (hn : n ≤ 2) :
+    G.fullyBlockedBoundaries = ⊥ :=
+  G.fullyBlockedBoundaries_eq_bot_of_fullyBlockedDifferential_eq_zero
+    (G.fullyBlockedDifferential_eq_zero_of_le_two hn)
+
+/-- On every `2 × 2` grid, every chain is a cycle for the fully blocked differential. -/
+@[simp]
+theorem fullyBlockedCycles_eq_top_of_two (G : GridDiagram 2) :
+    G.fullyBlockedCycles = ⊤ :=
+  G.fullyBlockedCycles_eq_top_of_le_two le_rfl
+
+/-- On every `2 × 2` grid, the only boundary for the fully blocked differential is zero. -/
+@[simp]
+theorem fullyBlockedBoundaries_eq_bot_of_two (G : GridDiagram 2) :
+    G.fullyBlockedBoundaries = ⊥ :=
+  G.fullyBlockedBoundaries_eq_bot_of_le_two le_rfl
+
+/-- In grid size at most two, every chain is a fully blocked cycle. -/
+theorem mem_fullyBlockedCycles_of_le_two (hn : n ≤ 2) (c : GridChain (ZMod 2) n) :
+    c ∈ G.fullyBlockedCycles := by
+  rw [G.fullyBlockedCycles_eq_top_of_le_two hn]
+  exact Submodule.mem_top
+
+/-- In grid size at most two, a fully blocked boundary is exactly the zero chain. -/
+theorem mem_fullyBlockedBoundaries_iff_eq_zero_of_le_two
+    (hn : n ≤ 2) (c : GridChain (ZMod 2) n) :
+    c ∈ G.fullyBlockedBoundaries ↔ c = 0 := by
+  rw [G.fullyBlockedBoundaries_eq_bot_of_le_two hn]
+  exact Submodule.mem_bot (R := ZMod 2)
+
+/-- On every `2 × 2` grid, every chain is a fully blocked cycle. -/
+theorem mem_fullyBlockedCycles_of_two (G : GridDiagram 2) (c : GridChain (ZMod 2) 2) :
+    c ∈ G.fullyBlockedCycles :=
+  G.mem_fullyBlockedCycles_of_le_two le_rfl c
+
+/-- On every `2 × 2` grid, a fully blocked boundary is exactly the zero chain. -/
+theorem mem_fullyBlockedBoundaries_iff_eq_zero_of_two
+    (G : GridDiagram 2) (c : GridChain (ZMod 2) 2) :
+    c ∈ G.fullyBlockedBoundaries ↔ c = 0 :=
+  G.mem_fullyBlockedBoundaries_iff_eq_zero_of_le_two le_rfl c
+
+/-- The standard two-by-two grid has four fully blocked cycles. -/
+theorem natCard_fullyBlockedCycles_twoByTwo :
+  Nat.card (fullyBlockedCycles GridDiagram.twoByTwo) = 4 := by
+  classical
+  rw [fullyBlockedCycles_eq_top_of_two]
+  simp
+
+/-- The standard two-by-two grid has one fully blocked boundary. -/
+theorem natCard_fullyBlockedBoundaries_twoByTwo :
+    Nat.card (fullyBlockedBoundaries GridDiagram.twoByTwo) = 1 := by
+  classical
+  rw [fullyBlockedBoundaries_eq_bot_of_two]
+  simp
+
+end GridDiagram
+
+end TauCeti


### PR DESCRIPTION
This PR packages the kernel and range of the fully blocked grid differential as the cycle and boundary submodules, records the square-zero handoff saying boundaries lie in cycles whenever `∂² = 0`, and computes those submodules in grid size at most two: all chains are cycles and the only boundary is zero. It advances `TauCetiRoadmap/CombinatorialHeegaardFloer/README.md`, Lane G.3, “The complexes and `∂² = 0`,” together with the acceptance criterion that the `2 × 2` unknot grid complex be explicitly computable with its bigradings.

I chose this as the lowest-hanging distinct CombinatorialHeegaardFloer target after checking open and recently merged PRs: `main` already has grid diagrams/states, rectangle counts, the fully blocked differential, chain cardinalities, the zero-differential theorem for grids of size at most two, and the named `2 × 2` grading computation, while the cycle/boundary submodule API needed before packaging the homology quotient was still absent.

No Mathlib infrastructure is vendored. The implementation reuses Mathlib’s `LinearMap.ker` and `LinearMap.range` submodule API, plus Tau Ceti’s existing `GridDiagram.fullyBlockedDifferential_eq_zero_of_le_two`, `GridDiagram.twoByTwo`, and `GridChain.natCard_zmod_two` APIs.

`lake exe cache get` completed with `No files to download` and `Already decompressed 8609 file(s)`. `lake build` completed with `Build completed successfully (4554 jobs).` `lake exe axioms` completed with `axioms: audited 8404 TauCeti declaration(s); all within the allowlist [propext, Classical.choice, Quot.sound].`

<!--tauceti-target:v1 {"focus":"CombinatorialHeegaardFloer","id":"fully-blocked-cycles-boundaries"}-->

🤖 Prepared with Codex
