### PR TITLE
feat: add unit disc automorphism homeomorphisms

### DIFF
--- a/TauCeti/Analysis/Complex/Conformal/Moebius.lean
+++ b/TauCeti/Analysis/Complex/Conformal/Moebius.lean
@@ -15,7 +15,8 @@ This file packages the standard Moebius factor
 the elementary automorphism API used by the Schwarz--Pick and disc-automorphism layer of
 the conformal-mapping roadmap: the map sends `a` to `0`, its norm is the
 pseudo-hyperbolic expression from `z` to `a`, and the inverse is the factor with center
-`-a`.
+`-a`.  The same map is also bundled as an equivalence and as a homeomorphism of the
+unit disc.
 
 This L2 material is coordinated with the upstream Mathlib RMT effort in
 leanprover-community/mathlib4#33505.  Mathlib already contains the preceding human-curated
@@ -177,5 +178,72 @@ lemma unitDiscMoebiusEquiv_apply (a z : Complex.UnitDisc) :
 lemma unitDiscMoebiusEquiv_symm (a : Complex.UnitDisc) :
     (unitDiscMoebiusEquiv a).symm = unitDiscMoebiusEquiv (-a) :=
   Equiv.ext fun _ => rfl
+
+/-- The unit-disc Moebius factor is continuous as a map of the bundled open disc. -/
+lemma continuous_unitDiscMoebius (a : Complex.UnitDisc) :
+    Continuous (unitDiscMoebius a) := by
+  rw [Complex.UnitDisc.isEmbedding_coe.continuous_iff]
+  simpa only [Function.comp_def, coe_unitDiscMoebius] using
+    (differentiableOn_unitDiscMoebiusFormula a).continuousOn.comp_continuous
+      Complex.UnitDisc.continuous_coe
+      (fun z => by simpa [mem_ball_zero_iff] using Complex.UnitDisc.norm_lt_one z)
+
+/-- The standard Moebius self-map of the unit disc, bundled as a homeomorphism. -/
+noncomputable def unitDiscMoebiusHomeomorph (a : Complex.UnitDisc) :
+    Complex.UnitDisc ≃ₜ Complex.UnitDisc where
+  toEquiv := unitDiscMoebiusEquiv a
+  continuous_toFun := by
+    exact (continuous_unitDiscMoebius a).congr fun z => by
+      calc
+        unitDiscMoebius a z = unitDiscMoebiusEquiv a z :=
+          (unitDiscMoebiusEquiv_apply a z).symm
+        _ = (unitDiscMoebiusEquiv a).toFun z := rfl
+  continuous_invFun := by
+    exact (continuous_unitDiscMoebius (-a)).congr fun z => by
+      calc
+        unitDiscMoebius (-a) z = unitDiscMoebiusEquiv (-a) z :=
+          (unitDiscMoebiusEquiv_apply (-a) z).symm
+        _ = (unitDiscMoebiusEquiv a).symm z := by
+          rw [unitDiscMoebiusEquiv_symm]
+        _ = (unitDiscMoebiusEquiv a).invFun z := rfl
+
+/-- The Moebius homeomorphism applies by the existing Moebius factor. -/
+@[simp]
+lemma unitDiscMoebiusHomeomorph_apply (a z : Complex.UnitDisc) :
+    unitDiscMoebiusHomeomorph a z = unitDiscMoebius a z :=
+  unitDiscMoebiusEquiv_apply a z
+
+/-- The underlying equivalence of the Moebius homeomorphism is the existing equivalence. -/
+@[simp]
+lemma unitDiscMoebiusHomeomorph_toEquiv (a : Complex.UnitDisc) :
+    (unitDiscMoebiusHomeomorph a).toEquiv = unitDiscMoebiusEquiv a :=
+  by
+    ext z
+    calc
+      ((unitDiscMoebiusHomeomorph a).toEquiv z : ℂ)
+          = (unitDiscMoebiusHomeomorph a z : ℂ) := rfl
+      _ = (unitDiscMoebiusEquiv a z : ℂ) := by
+        rw [unitDiscMoebiusHomeomorph_apply, unitDiscMoebiusEquiv_apply]
+
+/-- The inverse Moebius homeomorphism is the Moebius homeomorphism centered at `-a`. -/
+@[simp]
+lemma unitDiscMoebiusHomeomorph_symm (a : Complex.UnitDisc) :
+    (unitDiscMoebiusHomeomorph a).symm = unitDiscMoebiusHomeomorph (-a) := by
+  ext z
+  calc
+    ((unitDiscMoebiusHomeomorph a).symm z : ℂ)
+        = ((unitDiscMoebiusEquiv a).symm z : ℂ) := rfl
+    _ = (unitDiscMoebiusHomeomorph (-a) z : ℂ) := by
+      rw [unitDiscMoebiusEquiv_symm, unitDiscMoebiusEquiv_apply,
+        unitDiscMoebiusHomeomorph_apply]
+
+/-- The scalar formula for the Moebius homeomorphism. -/
+@[norm_cast]
+lemma coe_unitDiscMoebiusHomeomorph_apply (a z : Complex.UnitDisc) :
+    (unitDiscMoebiusHomeomorph a z : ℂ) =
+      ((z : ℂ) - (a : ℂ)) / (1 - (starRingEnd ℂ) (a : ℂ) * (z : ℂ)) :=
+  by
+    rw [unitDiscMoebiusHomeomorph_apply]
+    exact coe_unitDiscMoebius a z
 
 end TauCeti

--- a/TauCeti/Analysis/Complex/Conformal/UnitDiscHomeomorph.lean
+++ b/TauCeti/Analysis/Complex/Conformal/UnitDiscHomeomorph.lean
@@ -11,10 +11,10 @@ public import TauCeti.Analysis.Complex.Conformal.UnitDiscAutomorphism
 
 This file packages the standard unit-disc automorphisms from
 `TauCeti.Analysis.Complex.Conformal.UnitDiscAutomorphism` as homeomorphisms of
-`Complex.UnitDisc`.  The underlying maps are the existing equivalences
-`unitDiscMoebiusEquiv` and `unitDiscStandardAutomorphismEquiv`; this file adds the
-continuity API needed before treating the disc automorphisms as a topological automorphism
-group in the Schwarz--Pick layer of the conformal-mapping roadmap.
+`Complex.UnitDisc`.  The underlying map is the existing equivalence
+`unitDiscStandardAutomorphismEquiv`; this file adds the continuity API needed before treating
+the disc automorphisms as a topological automorphism group in the Schwarz--Pick layer of the
+conformal-mapping roadmap.
 
 This L2 material is coordinated with the upstream Mathlib RMT effort in
 leanprover-community/mathlib4#33505.  Mathlib already contains the preceding human-curated
@@ -28,73 +28,6 @@ namespace TauCeti
 
 open Complex
 open scoped ComplexConjugate
-
-/-- The unit-disc Moebius factor is continuous as a map of the bundled open disc. -/
-lemma continuous_unitDiscMoebius (a : Complex.UnitDisc) :
-    Continuous (unitDiscMoebius a) := by
-  rw [Complex.UnitDisc.isEmbedding_coe.continuous_iff]
-  simpa only [Function.comp_def, coe_unitDiscMoebius] using
-    (differentiableOn_unitDiscMoebiusFormula a).continuousOn.comp_continuous
-      Complex.UnitDisc.continuous_coe
-      (fun z => by simpa [mem_ball_zero_iff] using Complex.UnitDisc.norm_lt_one z)
-
-/-- The standard Moebius self-map of the unit disc, bundled as a homeomorphism. -/
-noncomputable def unitDiscMoebiusHomeomorph (a : Complex.UnitDisc) :
-    Complex.UnitDisc ≃ₜ Complex.UnitDisc where
-  toEquiv := unitDiscMoebiusEquiv a
-  continuous_toFun := by
-    exact (continuous_unitDiscMoebius a).congr fun z => by
-      calc
-        unitDiscMoebius a z = unitDiscMoebiusEquiv a z :=
-          (unitDiscMoebiusEquiv_apply a z).symm
-        _ = (unitDiscMoebiusEquiv a).toFun z := rfl
-  continuous_invFun := by
-    exact (continuous_unitDiscMoebius (-a)).congr fun z => by
-      calc
-        unitDiscMoebius (-a) z = unitDiscMoebiusEquiv (-a) z :=
-          (unitDiscMoebiusEquiv_apply (-a) z).symm
-        _ = (unitDiscMoebiusEquiv a).symm z := by
-          rw [unitDiscMoebiusEquiv_symm]
-        _ = (unitDiscMoebiusEquiv a).invFun z := rfl
-
-/-- The Moebius homeomorphism applies by the existing Moebius factor. -/
-@[simp]
-lemma unitDiscMoebiusHomeomorph_apply (a z : Complex.UnitDisc) :
-    unitDiscMoebiusHomeomorph a z = unitDiscMoebius a z :=
-  unitDiscMoebiusEquiv_apply a z
-
-/-- The underlying equivalence of the Moebius homeomorphism is the existing equivalence. -/
-@[simp]
-lemma unitDiscMoebiusHomeomorph_toEquiv (a : Complex.UnitDisc) :
-    (unitDiscMoebiusHomeomorph a).toEquiv = unitDiscMoebiusEquiv a :=
-  by
-    ext z
-    calc
-      ((unitDiscMoebiusHomeomorph a).toEquiv z : ℂ)
-          = (unitDiscMoebiusHomeomorph a z : ℂ) := rfl
-      _ = (unitDiscMoebiusEquiv a z : ℂ) := by
-        rw [unitDiscMoebiusHomeomorph_apply, unitDiscMoebiusEquiv_apply]
-
-/-- The inverse Moebius homeomorphism is the Moebius homeomorphism centered at `-a`. -/
-@[simp]
-lemma unitDiscMoebiusHomeomorph_symm (a : Complex.UnitDisc) :
-    (unitDiscMoebiusHomeomorph a).symm = unitDiscMoebiusHomeomorph (-a) := by
-  ext z
-  calc
-    ((unitDiscMoebiusHomeomorph a).symm z : ℂ)
-        = ((unitDiscMoebiusEquiv a).symm z : ℂ) := rfl
-    _ = (unitDiscMoebiusHomeomorph (-a) z : ℂ) := by
-      rw [unitDiscMoebiusEquiv_symm, unitDiscMoebiusEquiv_apply,
-        unitDiscMoebiusHomeomorph_apply]
-
-/-- The scalar formula for the Moebius homeomorphism. -/
-@[norm_cast]
-lemma coe_unitDiscMoebiusHomeomorph_apply (a z : Complex.UnitDisc) :
-    (unitDiscMoebiusHomeomorph a z : ℂ) =
-      ((z : ℂ) - (a : ℂ)) / (1 - (starRingEnd ℂ) (a : ℂ) * (z : ℂ)) :=
-  by
-    rw [unitDiscMoebiusHomeomorph_apply]
-    exact coe_unitDiscMoebius a z
 
 /--
 The standard automorphism of the complex unit disc, bundled as a homeomorphism.

--- a/TauCeti/Analysis/Complex/Conformal/UnitDiscHomeomorph.lean
+++ b/TauCeti/Analysis/Complex/Conformal/UnitDiscHomeomorph.lean
@@ -33,12 +33,7 @@ open scoped ComplexConjugate
 lemma continuous_unitDiscMoebius (a : Complex.UnitDisc) :
     Continuous (unitDiscMoebius a) := by
   rw [Complex.UnitDisc.isEmbedding_coe.continuous_iff]
-  -- `isEmbedding_coe.continuous_iff` transports continuity through the fixed subtype
-  -- embedding `Complex.UnitDisc → ℂ`; the remaining defeq is the standard coercion of a
-  -- bundled disc-valued function to its scalar coordinate.
-  change Continuous fun z : Complex.UnitDisc => (unitDiscMoebius a z : ℂ)
-  simp only [coe_unitDiscMoebius]
-  simpa only [Function.comp_def] using
+  simpa only [Function.comp_def, coe_unitDiscMoebius] using
     (differentiableOn_unitDiscMoebiusFormula a).continuousOn.comp_continuous
       Complex.UnitDisc.continuous_coe
       (fun z => by simpa [mem_ball_zero_iff] using Complex.UnitDisc.norm_lt_one z)
@@ -48,15 +43,19 @@ noncomputable def unitDiscMoebiusHomeomorph (a : Complex.UnitDisc) :
     Complex.UnitDisc ≃ₜ Complex.UnitDisc where
   toEquiv := unitDiscMoebiusEquiv a
   continuous_toFun := by
-    -- `Homeomorph` extends `Equiv`, so the forward continuity field is definitionally the
-    -- function of the supplied `toEquiv`; this is the canonical projection used by Mathlib.
-    change Continuous fun z : Complex.UnitDisc => unitDiscMoebiusEquiv a z
-    simpa only [unitDiscMoebiusEquiv_apply] using continuous_unitDiscMoebius a
+    exact (continuous_unitDiscMoebius a).congr fun z => by
+      calc
+        unitDiscMoebius a z = unitDiscMoebiusEquiv a z :=
+          (unitDiscMoebiusEquiv_apply a z).symm
+        _ = (unitDiscMoebiusEquiv a).toFun z := rfl
   continuous_invFun := by
-    -- As above, the inverse continuity field projects to the inverse function of `toEquiv`.
-    change Continuous fun z : Complex.UnitDisc => (unitDiscMoebiusEquiv a).symm z
-    rw [unitDiscMoebiusEquiv_symm]
-    simpa only [unitDiscMoebiusEquiv_apply] using continuous_unitDiscMoebius (-a)
+    exact (continuous_unitDiscMoebius (-a)).congr fun z => by
+      calc
+        unitDiscMoebius (-a) z = unitDiscMoebiusEquiv (-a) z :=
+          (unitDiscMoebiusEquiv_apply (-a) z).symm
+        _ = (unitDiscMoebiusEquiv a).symm z := by
+          rw [unitDiscMoebiusEquiv_symm]
+        _ = (unitDiscMoebiusEquiv a).invFun z := rfl
 
 /-- The Moebius homeomorphism applies by the existing Moebius factor. -/
 @[simp]
@@ -69,22 +68,24 @@ lemma unitDiscMoebiusHomeomorph_apply (a z : Complex.UnitDisc) :
 lemma unitDiscMoebiusHomeomorph_toEquiv (a : Complex.UnitDisc) :
     (unitDiscMoebiusHomeomorph a).toEquiv = unitDiscMoebiusEquiv a :=
   by
-    apply Equiv.ext
-    intro z
-    -- Extensionality reduces equality of the projected equivalences to equality of their
-    -- applications; `Homeomorph` stores this application in the inherited `Equiv.toFun`.
-    change unitDiscMoebiusHomeomorph a z = unitDiscMoebiusEquiv a z
-    rw [unitDiscMoebiusHomeomorph_apply, unitDiscMoebiusEquiv_apply]
+    ext z
+    calc
+      ((unitDiscMoebiusHomeomorph a).toEquiv z : ℂ)
+          = (unitDiscMoebiusHomeomorph a z : ℂ) := rfl
+      _ = (unitDiscMoebiusEquiv a z : ℂ) := by
+        rw [unitDiscMoebiusHomeomorph_apply, unitDiscMoebiusEquiv_apply]
 
 /-- The inverse Moebius homeomorphism is the Moebius homeomorphism centered at `-a`. -/
 @[simp]
 lemma unitDiscMoebiusHomeomorph_symm (a : Complex.UnitDisc) :
     (unitDiscMoebiusHomeomorph a).symm = unitDiscMoebiusHomeomorph (-a) := by
   ext z
-  -- `Homeomorph.symm` is defined in Mathlib by replacing `toEquiv` with `toEquiv.symm`;
-  -- after extensionality this stable projection is exactly the inverse equivalence formula.
-  change ((unitDiscMoebiusEquiv a).symm z : ℂ) = (unitDiscMoebiusHomeomorph (-a) z : ℂ)
-  rw [unitDiscMoebiusEquiv_symm, unitDiscMoebiusEquiv_apply, unitDiscMoebiusHomeomorph_apply]
+  calc
+    ((unitDiscMoebiusHomeomorph a).symm z : ℂ)
+        = ((unitDiscMoebiusEquiv a).symm z : ℂ) := rfl
+    _ = (unitDiscMoebiusHomeomorph (-a) z : ℂ) := by
+      rw [unitDiscMoebiusEquiv_symm, unitDiscMoebiusEquiv_apply,
+        unitDiscMoebiusHomeomorph_apply]
 
 /-- The scalar formula for the Moebius homeomorphism. -/
 @[norm_cast]
@@ -113,13 +114,11 @@ lemma unitDiscStandardAutomorphismHomeomorph_apply
       unitDiscStandardAutomorphismEquiv u a z :=
   by
   rw [unitDiscStandardAutomorphismEquiv_apply]
-  -- The homeomorphism is defined as `Homeomorph.trans` with Mathlib's `Homeomorph.smul`;
-  -- unfolding the application aligns that structure-level composition with the existing
-  -- equivalence formula, whose last step is written with ordinary scalar action notation.
-  change Homeomorph.smul u (unitDiscMoebiusHomeomorph a z) =
-    u • unitDiscMoebius a z
-  rw [unitDiscMoebiusHomeomorph_apply]
-  rfl
+  calc
+    unitDiscStandardAutomorphismHomeomorph u a z
+        = Homeomorph.smul u (unitDiscMoebiusHomeomorph a z) := rfl
+    _ = u • unitDiscMoebius a z := by
+      rw [Homeomorph.smul_apply, unitDiscMoebiusHomeomorph_apply]
 
 /-- The underlying equivalence of the standard automorphism homeomorphism is the existing one. -/
 @[simp]
@@ -141,20 +140,17 @@ lemma unitDiscStandardAutomorphismHomeomorph_symm
       (Homeomorph.smul u⁻¹).trans (unitDiscMoebiusHomeomorph (-a)) := by
   apply Homeomorph.ext
   intro z
-  -- `Homeomorph.symm` is specified through the inverse of `toEquiv`; exposing that
-  -- projection lets us reuse the already-proved inverse formula for the underlying
-  -- standard automorphism equivalence.
-  change ((unitDiscStandardAutomorphismHomeomorph u a).toEquiv).symm z =
-    unitDiscMoebiusHomeomorph (-a) ((Homeomorph.smul u⁻¹) z)
-  rw [congrArg Equiv.symm (unitDiscStandardAutomorphismHomeomorph_toEquiv u a),
-    unitDiscStandardAutomorphismEquiv_symm]
-  -- The equivalence-side inverse is expressed with `MulAction.toPerm`; the homeomorphism
-  -- side uses `Homeomorph.smul`. Their named application lemmas reduce both to the same
-  -- scalar action, so the remaining projection is only this wrapper comparison.
-  change unitDiscMoebiusEquiv (-a) ((MulAction.toPerm u⁻¹ : Equiv.Perm Complex.UnitDisc) z) =
-    unitDiscMoebiusHomeomorph (-a) ((Homeomorph.smul u⁻¹) z)
-  rw [unitDiscMoebiusEquiv_apply, unitDiscMoebiusHomeomorph_apply, Homeomorph.smul_apply,
-    MulAction.toPerm_apply]
+  calc
+    (unitDiscStandardAutomorphismHomeomorph u a).symm z
+        = ((unitDiscStandardAutomorphismHomeomorph u a).toEquiv).symm z := rfl
+    _ = unitDiscMoebiusHomeomorph (-a) ((Homeomorph.smul u⁻¹) z) := by
+      rw [congrArg Equiv.symm (unitDiscStandardAutomorphismHomeomorph_toEquiv u a),
+        unitDiscStandardAutomorphismEquiv_symm]
+      calc
+        unitDiscMoebiusEquiv (-a) ((MulAction.toPerm u⁻¹ : Equiv.Perm Complex.UnitDisc) z)
+            = unitDiscMoebiusHomeomorph (-a) ((Homeomorph.smul u⁻¹) z) := by
+          rw [unitDiscMoebiusEquiv_apply, unitDiscMoebiusHomeomorph_apply,
+            Homeomorph.smul_apply, MulAction.toPerm_apply]
 
 /-- The scalar formula for the standard disc-automorphism homeomorphism. -/
 @[norm_cast]

--- a/TauCeti/Analysis/Complex/Conformal/UnitDiscHomeomorph.lean
+++ b/TauCeti/Analysis/Complex/Conformal/UnitDiscHomeomorph.lean
@@ -4,7 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 -/
 module
 
-public import Mathlib.Topology.Homeomorph.Defs
+public import Mathlib.Topology.Algebra.ConstMulAction
 public import TauCeti.Analysis.Complex.Conformal.UnitDiscAutomorphism
 
 /-!
@@ -36,12 +36,10 @@ lemma continuous_unitDiscMoebius (a : Complex.UnitDisc) :
   rw [Complex.UnitDisc.isEmbedding_coe.continuous_iff]
   change Continuous fun z : Complex.UnitDisc => (unitDiscMoebius a z : ℂ)
   simp only [coe_unitDiscMoebius]
-  exact
-    (Complex.UnitDisc.continuous_coe.sub continuous_const).div
-      (continuous_const.sub
-        ((continuous_const : Continuous fun _ : Complex.UnitDisc => (starRingEnd ℂ) (a : ℂ)).mul
-          Complex.UnitDisc.continuous_coe))
-      (fun z => one_sub_conj_mul_ne_zero_unitDisc z a)
+  simpa only [Function.comp_def] using
+    (differentiableOn_unitDiscMoebiusFormula a).continuousOn.comp_continuous
+      Complex.UnitDisc.continuous_coe
+      (fun z => by simpa [mem_ball_zero_iff] using Complex.UnitDisc.norm_lt_one z)
 
 /-- A fixed circle rotation is continuous on the bundled open disc. -/
 lemma continuous_circle_smul_unitDisc (u : Circle) :
@@ -50,6 +48,11 @@ lemma continuous_circle_smul_unitDisc (u : Circle) :
   change Continuous fun z : Complex.UnitDisc => ((u • z : Complex.UnitDisc) : ℂ)
   simp only [Complex.UnitDisc.coe_circle_smul]
   exact continuous_const.mul Complex.UnitDisc.continuous_coe
+
+/-- Circle rotations act continuously on the bundled open unit disc. -/
+instance instContinuousConstSMulCircleUnitDisc :
+    ContinuousConstSMul Circle Complex.UnitDisc where
+  continuous_const_smul := continuous_circle_smul_unitDisc
 
 /-- The standard Moebius self-map of the unit disc, bundled as a homeomorphism. -/
 @[expose] noncomputable def unitDiscMoebiusHomeomorph (a : Complex.UnitDisc) :
@@ -92,35 +95,6 @@ lemma coe_unitDiscMoebiusHomeomorph_apply (a z : Complex.UnitDisc) :
     rw [unitDiscMoebiusHomeomorph_apply]
     exact coe_unitDiscMoebius a z
 
-/-- A fixed circle rotation of the open unit disc, bundled as a homeomorphism. -/
-@[expose] noncomputable def circleSmulUnitDiscHomeomorph (u : Circle) :
-    Complex.UnitDisc ≃ₜ Complex.UnitDisc where
-  toEquiv := MulAction.toPerm u
-  continuous_toFun := continuous_circle_smul_unitDisc u
-  continuous_invFun := by
-    change Continuous fun z : Complex.UnitDisc => u⁻¹ • z
-    exact continuous_circle_smul_unitDisc u⁻¹
-
-/-- The circle-rotation homeomorphism applies by scalar multiplication. -/
-@[simp]
-lemma circleSmulUnitDiscHomeomorph_apply (u : Circle) (z : Complex.UnitDisc) :
-    circleSmulUnitDiscHomeomorph u z = u • z :=
-  rfl
-
-/-- The underlying equivalence of the circle-rotation homeomorphism is the action permutation. -/
-@[simp]
-lemma circleSmulUnitDiscHomeomorph_toEquiv (u : Circle) :
-    (circleSmulUnitDiscHomeomorph u).toEquiv =
-      (MulAction.toPerm u : Equiv.Perm Complex.UnitDisc) :=
-  rfl
-
-/-- The inverse circle-rotation homeomorphism is rotation by the inverse circle element. -/
-@[simp]
-lemma circleSmulUnitDiscHomeomorph_symm (u : Circle) :
-    (circleSmulUnitDiscHomeomorph u).symm = circleSmulUnitDiscHomeomorph u⁻¹ := by
-  ext z
-  rfl
-
 /--
 The standard automorphism of the complex unit disc, bundled as a homeomorphism.
 
@@ -129,7 +103,7 @@ circle rotation by `u`.
 -/
 @[expose] noncomputable def unitDiscStandardAutomorphismHomeomorph
     (u : Circle) (a : Complex.UnitDisc) : Complex.UnitDisc ≃ₜ Complex.UnitDisc :=
-  (unitDiscMoebiusHomeomorph a).trans (circleSmulUnitDiscHomeomorph u)
+  (unitDiscMoebiusHomeomorph a).trans (Homeomorph.smul u)
 
 /-- The standard automorphism homeomorphism applies by the existing equivalence formula. -/
 @[simp]
@@ -139,9 +113,10 @@ lemma unitDiscStandardAutomorphismHomeomorph_apply
       unitDiscStandardAutomorphismEquiv u a z :=
   by
   rw [unitDiscStandardAutomorphismEquiv_apply]
-  change circleSmulUnitDiscHomeomorph u (unitDiscMoebiusHomeomorph a z) =
+  change Homeomorph.smul u (unitDiscMoebiusHomeomorph a z) =
     u • unitDiscMoebius a z
-  rw [circleSmulUnitDiscHomeomorph_apply, unitDiscMoebiusHomeomorph_apply]
+  rw [unitDiscMoebiusHomeomorph_apply]
+  rfl
 
 /-- The underlying equivalence of the standard automorphism homeomorphism is the existing one. -/
 @[simp]
@@ -169,7 +144,7 @@ lemma coe_unitDiscStandardAutomorphismHomeomorph_apply
 @[simp]
 lemma unitDiscStandardAutomorphismHomeomorph_zero (u : Circle) :
     unitDiscStandardAutomorphismHomeomorph u 0 =
-      circleSmulUnitDiscHomeomorph u := by
+      Homeomorph.smul u := by
   ext z
   simp [unitDiscStandardAutomorphismHomeomorph]
 

--- a/TauCeti/Analysis/Complex/Conformal/UnitDiscHomeomorph.lean
+++ b/TauCeti/Analysis/Complex/Conformal/UnitDiscHomeomorph.lean
@@ -4,7 +4,6 @@ Released under Apache 2.0 license as described in the file LICENSE.
 -/
 module
 
-public import Mathlib.Topology.Algebra.ConstMulAction
 public import TauCeti.Analysis.Complex.Conformal.UnitDiscAutomorphism
 
 /-!
@@ -34,6 +33,7 @@ open scoped ComplexConjugate
 lemma continuous_unitDiscMoebius (a : Complex.UnitDisc) :
     Continuous (unitDiscMoebius a) := by
   rw [Complex.UnitDisc.isEmbedding_coe.continuous_iff]
+  -- The embedding criterion reduces continuity to the scalar coercion of the bundled disc.
   change Continuous fun z : Complex.UnitDisc => (unitDiscMoebius a z : ℂ)
   simp only [coe_unitDiscMoebius]
   simpa only [Function.comp_def] using
@@ -41,27 +41,16 @@ lemma continuous_unitDiscMoebius (a : Complex.UnitDisc) :
       Complex.UnitDisc.continuous_coe
       (fun z => by simpa [mem_ball_zero_iff] using Complex.UnitDisc.norm_lt_one z)
 
-/-- A fixed circle rotation is continuous on the bundled open disc. -/
-lemma continuous_circle_smul_unitDisc (u : Circle) :
-    Continuous fun z : Complex.UnitDisc => u • z := by
-  rw [Complex.UnitDisc.isEmbedding_coe.continuous_iff]
-  change Continuous fun z : Complex.UnitDisc => ((u • z : Complex.UnitDisc) : ℂ)
-  simp only [Complex.UnitDisc.coe_circle_smul]
-  exact continuous_const.mul Complex.UnitDisc.continuous_coe
-
-/-- Circle rotations act continuously on the bundled open unit disc. -/
-instance instContinuousConstSMulCircleUnitDisc :
-    ContinuousConstSMul Circle Complex.UnitDisc where
-  continuous_const_smul := continuous_circle_smul_unitDisc
-
 /-- The standard Moebius self-map of the unit disc, bundled as a homeomorphism. -/
-@[expose] noncomputable def unitDiscMoebiusHomeomorph (a : Complex.UnitDisc) :
+noncomputable def unitDiscMoebiusHomeomorph (a : Complex.UnitDisc) :
     Complex.UnitDisc ≃ₜ Complex.UnitDisc where
   toEquiv := unitDiscMoebiusEquiv a
   continuous_toFun := by
+    -- The homeomorphism field is the bundled equivalence function.
     change Continuous fun z : Complex.UnitDisc => unitDiscMoebiusEquiv a z
     simpa only [unitDiscMoebiusEquiv_apply] using continuous_unitDiscMoebius a
   continuous_invFun := by
+    -- The inverse field is the bundled equivalence inverse function.
     change Continuous fun z : Complex.UnitDisc => (unitDiscMoebiusEquiv a).symm z
     rw [unitDiscMoebiusEquiv_symm]
     simpa only [unitDiscMoebiusEquiv_apply] using continuous_unitDiscMoebius (-a)
@@ -76,13 +65,19 @@ lemma unitDiscMoebiusHomeomorph_apply (a z : Complex.UnitDisc) :
 @[simp]
 lemma unitDiscMoebiusHomeomorph_toEquiv (a : Complex.UnitDisc) :
     (unitDiscMoebiusHomeomorph a).toEquiv = unitDiscMoebiusEquiv a :=
-  rfl
+  by
+    apply Equiv.ext
+    intro z
+    -- `Homeomorph.toEquiv` is the bundled homeomorphism function.
+    change unitDiscMoebiusHomeomorph a z = unitDiscMoebiusEquiv a z
+    rw [unitDiscMoebiusHomeomorph_apply, unitDiscMoebiusEquiv_apply]
 
 /-- The inverse Moebius homeomorphism is the Moebius homeomorphism centered at `-a`. -/
 @[simp]
 lemma unitDiscMoebiusHomeomorph_symm (a : Complex.UnitDisc) :
     (unitDiscMoebiusHomeomorph a).symm = unitDiscMoebiusHomeomorph (-a) := by
   ext z
+  -- `Homeomorph.symm` exposes the inverse function through the bundled `Equiv`.
   change ((unitDiscMoebiusEquiv a).symm z : ℂ) = (unitDiscMoebiusHomeomorph (-a) z : ℂ)
   rw [unitDiscMoebiusEquiv_symm, unitDiscMoebiusEquiv_apply, unitDiscMoebiusHomeomorph_apply]
 
@@ -101,7 +96,7 @@ The standard automorphism of the complex unit disc, bundled as a homeomorphism.
 It is the composition of the Moebius homeomorphism sending `a` to `0` with the fixed
 circle rotation by `u`.
 -/
-@[expose] noncomputable def unitDiscStandardAutomorphismHomeomorph
+noncomputable def unitDiscStandardAutomorphismHomeomorph
     (u : Circle) (a : Complex.UnitDisc) : Complex.UnitDisc ≃ₜ Complex.UnitDisc :=
   (unitDiscMoebiusHomeomorph a).trans (Homeomorph.smul u)
 
@@ -113,6 +108,7 @@ lemma unitDiscStandardAutomorphismHomeomorph_apply
       unitDiscStandardAutomorphismEquiv u a z :=
   by
   rw [unitDiscStandardAutomorphismEquiv_apply]
+  -- The left side is the bundled homeomorphism composition, while the right side is smul notation.
   change Homeomorph.smul u (unitDiscMoebiusHomeomorph a z) =
     u • unitDiscMoebius a z
   rw [unitDiscMoebiusHomeomorph_apply]
@@ -128,6 +124,26 @@ lemma unitDiscStandardAutomorphismHomeomorph_toEquiv
     ext z
     exact congrArg (fun w : Complex.UnitDisc => (w : ℂ))
       (unitDiscStandardAutomorphismHomeomorph_apply u a z)
+
+/-- The inverse standard automorphism homeomorphism is inverse rotation followed by the
+inverse Moebius homeomorphism. -/
+@[simp]
+lemma unitDiscStandardAutomorphismHomeomorph_symm
+    (u : Circle) (a : Complex.UnitDisc) :
+    (unitDiscStandardAutomorphismHomeomorph u a).symm =
+      (Homeomorph.smul u⁻¹).trans (unitDiscMoebiusHomeomorph (-a)) := by
+  apply Homeomorph.ext
+  intro z
+  -- `Homeomorph.symm` applies through the inverse of the underlying equivalence.
+  change ((unitDiscStandardAutomorphismHomeomorph u a).toEquiv).symm z =
+    unitDiscMoebiusHomeomorph (-a) ((Homeomorph.smul u⁻¹) z)
+  rw [congrArg Equiv.symm (unitDiscStandardAutomorphismHomeomorph_toEquiv u a),
+    unitDiscStandardAutomorphismEquiv_symm]
+  -- The equivalence formula uses `MulAction.toPerm`, while the homeomorphism formula uses `smul`.
+  change unitDiscMoebiusEquiv (-a) ((MulAction.toPerm u⁻¹ : Equiv.Perm Complex.UnitDisc) z) =
+    unitDiscMoebiusHomeomorph (-a) ((Homeomorph.smul u⁻¹) z)
+  rw [unitDiscMoebiusEquiv_apply, unitDiscMoebiusHomeomorph_apply, Homeomorph.smul_apply,
+    MulAction.toPerm_apply]
 
 /-- The scalar formula for the standard disc-automorphism homeomorphism. -/
 @[norm_cast]

--- a/TauCeti/Analysis/Complex/Conformal/UnitDiscHomeomorph.lean
+++ b/TauCeti/Analysis/Complex/Conformal/UnitDiscHomeomorph.lean
@@ -1,0 +1,183 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+module
+
+public import Mathlib.Topology.Homeomorph.Defs
+public import TauCeti.Analysis.Complex.Conformal.UnitDiscAutomorphism
+
+/-!
+# Unit-disc automorphisms as homeomorphisms
+
+This file packages the standard unit-disc automorphisms from
+`TauCeti.Analysis.Complex.Conformal.UnitDiscAutomorphism` as homeomorphisms of
+`Complex.UnitDisc`.  The underlying maps are the existing equivalences
+`unitDiscMoebiusEquiv` and `unitDiscStandardAutomorphismEquiv`; this file adds the
+continuity API needed before treating the disc automorphisms as a topological automorphism
+group in the Schwarz--Pick layer of the conformal-mapping roadmap.
+
+This L2 material is coordinated with the upstream Mathlib RMT effort in
+leanprover-community/mathlib4#33505.  Mathlib already contains the preceding human-curated
+work in `Analysis/Complex/RiemannMapping.lean` and `Analysis/Complex/BranchLogRoot.lean`;
+this file only packages Tau Ceti's existing unit-disc automorphism formulas topologically.
+-/
+
+public section
+
+namespace TauCeti
+
+open Complex
+open scoped ComplexConjugate
+
+/-- The unit-disc Moebius factor is continuous as a map of the bundled open disc. -/
+lemma continuous_unitDiscMoebius (a : Complex.UnitDisc) :
+    Continuous (unitDiscMoebius a) := by
+  rw [Complex.UnitDisc.isEmbedding_coe.continuous_iff]
+  change Continuous fun z : Complex.UnitDisc => (unitDiscMoebius a z : ℂ)
+  simp only [coe_unitDiscMoebius]
+  exact
+    (Complex.UnitDisc.continuous_coe.sub continuous_const).div
+      (continuous_const.sub
+        ((continuous_const : Continuous fun _ : Complex.UnitDisc => (starRingEnd ℂ) (a : ℂ)).mul
+          Complex.UnitDisc.continuous_coe))
+      (fun z => one_sub_conj_mul_ne_zero_unitDisc z a)
+
+/-- A fixed circle rotation is continuous on the bundled open disc. -/
+lemma continuous_circle_smul_unitDisc (u : Circle) :
+    Continuous fun z : Complex.UnitDisc => u • z := by
+  rw [Complex.UnitDisc.isEmbedding_coe.continuous_iff]
+  change Continuous fun z : Complex.UnitDisc => ((u • z : Complex.UnitDisc) : ℂ)
+  simp only [Complex.UnitDisc.coe_circle_smul]
+  exact continuous_const.mul Complex.UnitDisc.continuous_coe
+
+/-- The standard Moebius self-map of the unit disc, bundled as a homeomorphism. -/
+@[expose] noncomputable def unitDiscMoebiusHomeomorph (a : Complex.UnitDisc) :
+    Complex.UnitDisc ≃ₜ Complex.UnitDisc where
+  toEquiv := unitDiscMoebiusEquiv a
+  continuous_toFun := by
+    change Continuous fun z : Complex.UnitDisc => unitDiscMoebiusEquiv a z
+    simpa only [unitDiscMoebiusEquiv_apply] using continuous_unitDiscMoebius a
+  continuous_invFun := by
+    change Continuous fun z : Complex.UnitDisc => (unitDiscMoebiusEquiv a).symm z
+    rw [unitDiscMoebiusEquiv_symm]
+    simpa only [unitDiscMoebiusEquiv_apply] using continuous_unitDiscMoebius (-a)
+
+/-- The Moebius homeomorphism applies by the existing Moebius factor. -/
+@[simp]
+lemma unitDiscMoebiusHomeomorph_apply (a z : Complex.UnitDisc) :
+    unitDiscMoebiusHomeomorph a z = unitDiscMoebius a z :=
+  unitDiscMoebiusEquiv_apply a z
+
+/-- The underlying equivalence of the Moebius homeomorphism is the existing equivalence. -/
+@[simp]
+lemma unitDiscMoebiusHomeomorph_toEquiv (a : Complex.UnitDisc) :
+    (unitDiscMoebiusHomeomorph a).toEquiv = unitDiscMoebiusEquiv a :=
+  rfl
+
+/-- The inverse Moebius homeomorphism is the Moebius homeomorphism centered at `-a`. -/
+@[simp]
+lemma unitDiscMoebiusHomeomorph_symm (a : Complex.UnitDisc) :
+    (unitDiscMoebiusHomeomorph a).symm = unitDiscMoebiusHomeomorph (-a) := by
+  ext z
+  change ((unitDiscMoebiusEquiv a).symm z : ℂ) = (unitDiscMoebiusHomeomorph (-a) z : ℂ)
+  rw [unitDiscMoebiusEquiv_symm, unitDiscMoebiusEquiv_apply, unitDiscMoebiusHomeomorph_apply]
+
+/-- The scalar formula for the Moebius homeomorphism. -/
+@[norm_cast]
+lemma coe_unitDiscMoebiusHomeomorph_apply (a z : Complex.UnitDisc) :
+    (unitDiscMoebiusHomeomorph a z : ℂ) =
+      ((z : ℂ) - (a : ℂ)) / (1 - (starRingEnd ℂ) (a : ℂ) * (z : ℂ)) :=
+  by
+    rw [unitDiscMoebiusHomeomorph_apply]
+    exact coe_unitDiscMoebius a z
+
+/-- A fixed circle rotation of the open unit disc, bundled as a homeomorphism. -/
+@[expose] noncomputable def circleSmulUnitDiscHomeomorph (u : Circle) :
+    Complex.UnitDisc ≃ₜ Complex.UnitDisc where
+  toEquiv := MulAction.toPerm u
+  continuous_toFun := continuous_circle_smul_unitDisc u
+  continuous_invFun := by
+    change Continuous fun z : Complex.UnitDisc => u⁻¹ • z
+    exact continuous_circle_smul_unitDisc u⁻¹
+
+/-- The circle-rotation homeomorphism applies by scalar multiplication. -/
+@[simp]
+lemma circleSmulUnitDiscHomeomorph_apply (u : Circle) (z : Complex.UnitDisc) :
+    circleSmulUnitDiscHomeomorph u z = u • z :=
+  rfl
+
+/-- The underlying equivalence of the circle-rotation homeomorphism is the action permutation. -/
+@[simp]
+lemma circleSmulUnitDiscHomeomorph_toEquiv (u : Circle) :
+    (circleSmulUnitDiscHomeomorph u).toEquiv =
+      (MulAction.toPerm u : Equiv.Perm Complex.UnitDisc) :=
+  rfl
+
+/-- The inverse circle-rotation homeomorphism is rotation by the inverse circle element. -/
+@[simp]
+lemma circleSmulUnitDiscHomeomorph_symm (u : Circle) :
+    (circleSmulUnitDiscHomeomorph u).symm = circleSmulUnitDiscHomeomorph u⁻¹ := by
+  ext z
+  rfl
+
+/--
+The standard automorphism of the complex unit disc, bundled as a homeomorphism.
+
+It is the composition of the Moebius homeomorphism sending `a` to `0` with the fixed
+circle rotation by `u`.
+-/
+@[expose] noncomputable def unitDiscStandardAutomorphismHomeomorph
+    (u : Circle) (a : Complex.UnitDisc) : Complex.UnitDisc ≃ₜ Complex.UnitDisc :=
+  (unitDiscMoebiusHomeomorph a).trans (circleSmulUnitDiscHomeomorph u)
+
+/-- The standard automorphism homeomorphism applies by the existing equivalence formula. -/
+@[simp]
+lemma unitDiscStandardAutomorphismHomeomorph_apply
+    (u : Circle) (a z : Complex.UnitDisc) :
+    unitDiscStandardAutomorphismHomeomorph u a z =
+      unitDiscStandardAutomorphismEquiv u a z :=
+  by
+  rw [unitDiscStandardAutomorphismEquiv_apply]
+  change circleSmulUnitDiscHomeomorph u (unitDiscMoebiusHomeomorph a z) =
+    u • unitDiscMoebius a z
+  rw [circleSmulUnitDiscHomeomorph_apply, unitDiscMoebiusHomeomorph_apply]
+
+/-- The underlying equivalence of the standard automorphism homeomorphism is the existing one. -/
+@[simp]
+lemma unitDiscStandardAutomorphismHomeomorph_toEquiv
+    (u : Circle) (a : Complex.UnitDisc) :
+    (unitDiscStandardAutomorphismHomeomorph u a).toEquiv =
+      unitDiscStandardAutomorphismEquiv u a :=
+  by
+    ext z
+    exact congrArg (fun w : Complex.UnitDisc => (w : ℂ))
+      (unitDiscStandardAutomorphismHomeomorph_apply u a z)
+
+/-- The scalar formula for the standard disc-automorphism homeomorphism. -/
+@[norm_cast]
+lemma coe_unitDiscStandardAutomorphismHomeomorph_apply
+    (u : Circle) (a z : Complex.UnitDisc) :
+    (unitDiscStandardAutomorphismHomeomorph u a z : ℂ) =
+      (u : ℂ) *
+        (((z : ℂ) - (a : ℂ)) / (1 - (starRingEnd ℂ) (a : ℂ) * (z : ℂ))) :=
+  by
+    rw [unitDiscStandardAutomorphismHomeomorph_apply]
+    exact coe_unitDiscStandardAutomorphismEquiv_apply u a z
+
+/-- With zero center, the standard automorphism homeomorphism is just rotation. -/
+@[simp]
+lemma unitDiscStandardAutomorphismHomeomorph_zero (u : Circle) :
+    unitDiscStandardAutomorphismHomeomorph u 0 =
+      circleSmulUnitDiscHomeomorph u := by
+  ext z
+  simp [unitDiscStandardAutomorphismHomeomorph]
+
+/-- With unit rotation factor, the standard automorphism homeomorphism is the Moebius one. -/
+@[simp]
+lemma unitDiscStandardAutomorphismHomeomorph_one (a : Complex.UnitDisc) :
+    unitDiscStandardAutomorphismHomeomorph 1 a = unitDiscMoebiusHomeomorph a := by
+  ext z
+  simp [unitDiscStandardAutomorphismHomeomorph]
+
+end TauCeti

--- a/TauCeti/Analysis/Complex/Conformal/UnitDiscHomeomorph.lean
+++ b/TauCeti/Analysis/Complex/Conformal/UnitDiscHomeomorph.lean
@@ -33,7 +33,9 @@ open scoped ComplexConjugate
 lemma continuous_unitDiscMoebius (a : Complex.UnitDisc) :
     Continuous (unitDiscMoebius a) := by
   rw [Complex.UnitDisc.isEmbedding_coe.continuous_iff]
-  -- The embedding criterion reduces continuity to the scalar coercion of the bundled disc.
+  -- `isEmbedding_coe.continuous_iff` transports continuity through the fixed subtype
+  -- embedding `Complex.UnitDisc → ℂ`; the remaining defeq is the standard coercion of a
+  -- bundled disc-valued function to its scalar coordinate.
   change Continuous fun z : Complex.UnitDisc => (unitDiscMoebius a z : ℂ)
   simp only [coe_unitDiscMoebius]
   simpa only [Function.comp_def] using
@@ -46,11 +48,12 @@ noncomputable def unitDiscMoebiusHomeomorph (a : Complex.UnitDisc) :
     Complex.UnitDisc ≃ₜ Complex.UnitDisc where
   toEquiv := unitDiscMoebiusEquiv a
   continuous_toFun := by
-    -- The homeomorphism field is the bundled equivalence function.
+    -- `Homeomorph` extends `Equiv`, so the forward continuity field is definitionally the
+    -- function of the supplied `toEquiv`; this is the canonical projection used by Mathlib.
     change Continuous fun z : Complex.UnitDisc => unitDiscMoebiusEquiv a z
     simpa only [unitDiscMoebiusEquiv_apply] using continuous_unitDiscMoebius a
   continuous_invFun := by
-    -- The inverse field is the bundled equivalence inverse function.
+    -- As above, the inverse continuity field projects to the inverse function of `toEquiv`.
     change Continuous fun z : Complex.UnitDisc => (unitDiscMoebiusEquiv a).symm z
     rw [unitDiscMoebiusEquiv_symm]
     simpa only [unitDiscMoebiusEquiv_apply] using continuous_unitDiscMoebius (-a)
@@ -68,7 +71,8 @@ lemma unitDiscMoebiusHomeomorph_toEquiv (a : Complex.UnitDisc) :
   by
     apply Equiv.ext
     intro z
-    -- `Homeomorph.toEquiv` is the bundled homeomorphism function.
+    -- Extensionality reduces equality of the projected equivalences to equality of their
+    -- applications; `Homeomorph` stores this application in the inherited `Equiv.toFun`.
     change unitDiscMoebiusHomeomorph a z = unitDiscMoebiusEquiv a z
     rw [unitDiscMoebiusHomeomorph_apply, unitDiscMoebiusEquiv_apply]
 
@@ -77,7 +81,8 @@ lemma unitDiscMoebiusHomeomorph_toEquiv (a : Complex.UnitDisc) :
 lemma unitDiscMoebiusHomeomorph_symm (a : Complex.UnitDisc) :
     (unitDiscMoebiusHomeomorph a).symm = unitDiscMoebiusHomeomorph (-a) := by
   ext z
-  -- `Homeomorph.symm` exposes the inverse function through the bundled `Equiv`.
+  -- `Homeomorph.symm` is defined in Mathlib by replacing `toEquiv` with `toEquiv.symm`;
+  -- after extensionality this stable projection is exactly the inverse equivalence formula.
   change ((unitDiscMoebiusEquiv a).symm z : ℂ) = (unitDiscMoebiusHomeomorph (-a) z : ℂ)
   rw [unitDiscMoebiusEquiv_symm, unitDiscMoebiusEquiv_apply, unitDiscMoebiusHomeomorph_apply]
 
@@ -108,7 +113,9 @@ lemma unitDiscStandardAutomorphismHomeomorph_apply
       unitDiscStandardAutomorphismEquiv u a z :=
   by
   rw [unitDiscStandardAutomorphismEquiv_apply]
-  -- The left side is the bundled homeomorphism composition, while the right side is smul notation.
+  -- The homeomorphism is defined as `Homeomorph.trans` with Mathlib's `Homeomorph.smul`;
+  -- unfolding the application aligns that structure-level composition with the existing
+  -- equivalence formula, whose last step is written with ordinary scalar action notation.
   change Homeomorph.smul u (unitDiscMoebiusHomeomorph a z) =
     u • unitDiscMoebius a z
   rw [unitDiscMoebiusHomeomorph_apply]
@@ -134,12 +141,16 @@ lemma unitDiscStandardAutomorphismHomeomorph_symm
       (Homeomorph.smul u⁻¹).trans (unitDiscMoebiusHomeomorph (-a)) := by
   apply Homeomorph.ext
   intro z
-  -- `Homeomorph.symm` applies through the inverse of the underlying equivalence.
+  -- `Homeomorph.symm` is specified through the inverse of `toEquiv`; exposing that
+  -- projection lets us reuse the already-proved inverse formula for the underlying
+  -- standard automorphism equivalence.
   change ((unitDiscStandardAutomorphismHomeomorph u a).toEquiv).symm z =
     unitDiscMoebiusHomeomorph (-a) ((Homeomorph.smul u⁻¹) z)
   rw [congrArg Equiv.symm (unitDiscStandardAutomorphismHomeomorph_toEquiv u a),
     unitDiscStandardAutomorphismEquiv_symm]
-  -- The equivalence formula uses `MulAction.toPerm`, while the homeomorphism formula uses `smul`.
+  -- The equivalence-side inverse is expressed with `MulAction.toPerm`; the homeomorphism
+  -- side uses `Homeomorph.smul`. Their named application lemmas reduce both to the same
+  -- scalar action, so the remaining projection is only this wrapper comparison.
   change unitDiscMoebiusEquiv (-a) ((MulAction.toPerm u⁻¹ : Equiv.Perm Complex.UnitDisc) z) =
     unitDiscMoebiusHomeomorph (-a) ((Homeomorph.smul u⁻¹) z)
   rw [unitDiscMoebiusEquiv_apply, unitDiscMoebiusHomeomorph_apply, Homeomorph.smul_apply,

--- a/TauCeti/Analysis/Complex/UnitDisc/Basic.lean
+++ b/TauCeti/Analysis/Complex/UnitDisc/Basic.lean
@@ -43,12 +43,8 @@ end Complex.UnitDisc
 lemma continuous_circle_smul_unitDisc (u : Circle) :
     Continuous fun z : Complex.UnitDisc => u • z := by
   rw [Complex.UnitDisc.isEmbedding_coe.continuous_iff]
-  -- `isEmbedding_coe.continuous_iff` intentionally transports the goal through the
-  -- subtype embedding `Complex.UnitDisc → ℂ`.  There is no separate coercion lemma for an
-  -- arbitrary bundled target function, so this stable subtype defeq exposes the scalar map.
-  change Continuous fun z : Complex.UnitDisc => ((u • z : Complex.UnitDisc) : ℂ)
-  simp only [Complex.UnitDisc.coe_circle_smul]
-  exact continuous_const.mul Complex.UnitDisc.continuous_coe
+  exact ((continuous_const (y := (u : ℂ))).mul Complex.UnitDisc.continuous_coe).congr fun z => by
+    simp only [Function.comp_def, Complex.UnitDisc.coe_circle_smul, Pi.mul_apply]
 
 /-- Circle rotations act continuously on the bundled open unit disc. -/
 instance instContinuousConstSMulCircleUnitDisc :

--- a/TauCeti/Analysis/Complex/UnitDisc/Basic.lean
+++ b/TauCeti/Analysis/Complex/UnitDisc/Basic.lean
@@ -43,7 +43,9 @@ end Complex.UnitDisc
 lemma continuous_circle_smul_unitDisc (u : Circle) :
     Continuous fun z : Complex.UnitDisc => u • z := by
   rw [Complex.UnitDisc.isEmbedding_coe.continuous_iff]
-  -- The embedding criterion reduces continuity to the scalar coercion of the bundled disc.
+  -- `isEmbedding_coe.continuous_iff` intentionally transports the goal through the
+  -- subtype embedding `Complex.UnitDisc → ℂ`.  There is no separate coercion lemma for an
+  -- arbitrary bundled target function, so this stable subtype defeq exposes the scalar map.
   change Continuous fun z : Complex.UnitDisc => ((u • z : Complex.UnitDisc) : ℂ)
   simp only [Complex.UnitDisc.coe_circle_smul]
   exact continuous_const.mul Complex.UnitDisc.continuous_coe

--- a/TauCeti/Analysis/Complex/UnitDisc/Basic.lean
+++ b/TauCeti/Analysis/Complex/UnitDisc/Basic.lean
@@ -5,6 +5,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 module
 
 public import Mathlib.Analysis.Complex.UnitDisc.Basic
+public import Mathlib.Topology.Algebra.ConstMulAction
 
 /-!
 # Basic API for the complex unit disc
@@ -37,5 +38,19 @@ lemma circle_smul_eq_zero_iff (u : Circle) {z : _root_.Complex.UnitDisc} :
   simp
 
 end Complex.UnitDisc
+
+/-- A fixed circle rotation is continuous on the bundled open disc. -/
+lemma continuous_circle_smul_unitDisc (u : Circle) :
+    Continuous fun z : Complex.UnitDisc => u • z := by
+  rw [Complex.UnitDisc.isEmbedding_coe.continuous_iff]
+  -- The embedding criterion reduces continuity to the scalar coercion of the bundled disc.
+  change Continuous fun z : Complex.UnitDisc => ((u • z : Complex.UnitDisc) : ℂ)
+  simp only [Complex.UnitDisc.coe_circle_smul]
+  exact continuous_const.mul Complex.UnitDisc.continuous_coe
+
+/-- Circle rotations act continuously on the bundled open unit disc. -/
+instance instContinuousConstSMulCircleUnitDisc :
+    ContinuousConstSMul Circle Complex.UnitDisc where
+  continuous_const_smul := continuous_circle_smul_unitDisc
 
 end TauCeti


### PR DESCRIPTION
This PR packages the existing unit-disc Moebius and standard automorphism equivalences as homeomorphisms of `Complex.UnitDisc`, adding continuity lemmas for the Moebius factor and fixed circle rotations plus the scalar coercion API for the bundled `≃ₜ` maps. It advances `TauCetiRoadmap/ConformalMapping/README.md`, Layer L2, “Schwarz lemma extensions,” specifically the disc automorphism group `Aut(𝔻) = {e^{iθ}(z−a)/(1−āz)}` and the companion packaged automorphism API needed before Schwarz--Pick and the hyperbolic-disc layer consume these maps topologically.

I chose this as the lowest-hanging distinct ConformalMapping target after checking open and recently merged PRs: `main` already has the pseudo-hyperbolic expression, the center-removing Moebius equivalence, the standard disc automorphism equivalence, and L4 reflection branch prerequisites, while the L2 automorphisms were still only plain equivalences rather than homeomorphisms. This stays below the heavier Schwarz--Pick theorem and does not duplicate the upstream RMT work.

No Mathlib infrastructure is vendored. The implementation reuses Mathlib’s `Complex.UnitDisc.isEmbedding_coe`, `Complex.UnitDisc.coe_circle_smul`, and `Homeomorph`, together with Tau Ceti’s existing `unitDiscMoebiusEquiv`, `unitDiscStandardAutomorphismEquiv`, scalar formula lemmas, and denominator nonvanishing API. As with the existing L2 files, the overlap with the human-curated RMT effort is coordinated with leanprover-community/mathlib4#33505 and should be refactored to upstream API if matching disc-automorphism packaging lands there.

`lake exe cache get` completed with `No files to download` and `Already decompressed 8609 file(s)`. `lake build` completed with `Build completed successfully (4554 jobs).` `lake exe axioms` completed with `axioms: audited 8399 TauCeti declaration(s); all within the allowlist [propext, Classical.choice, Quot.sound].`

<!--tauceti-target:v1 {"focus":"ConformalMapping","id":"unit-disc-automorphism-homeomorph"}-->

🤖 Prepared with Codex
