### PR TITLE
feat: add Hopf ideal quotient order maps

### DIFF
--- a/TauCeti/Algebra/AlgebraicGroup/HopfIdealQuotient.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/HopfIdealQuotient.lean
@@ -30,6 +30,8 @@ the finite-type coordinate-Hopf-algebra category.
 * `TauCeti.FiniteTypeCommHopfAlgCat.mkQuotient`: the quotient morphism.
 * `TauCeti.FiniteTypeCommHopfAlgCat.mkQuotient_ker`: its kernel characterization.
 * `TauCeti.FiniteTypeCommHopfAlgCat.liftQuotient`: the induced morphism out of a quotient.
+* `TauCeti.CommHopfAlgCat.quotientMapOfLe`: the morphism `H ⧸ I ⟶ H ⧸ J` induced by
+  `I ≤ J`.
 
 ## References
 
@@ -130,6 +132,58 @@ lemma liftQuotient_unique (I : HopfIdeal R H) (f : H ⟶ K)
     _ = (liftQuotient I f hf).hom (Ideal.Quotient.mkₐ R I.toIdeal h) :=
       (liftQuotient_mk I f hf h).symm
 
+/-- If `I ≤ J`, then the quotient map by `J` kills every element of `I`. -/
+lemma toIdeal_le_ker_mkQuotient_of_le
+    (H : _root_.CommHopfAlgCat.{v} R) {I J : HopfIdeal R H} (hIJ : I ≤ J) :
+    I.toIdeal ≤ RingHom.ker (mkQuotient H J).hom.toAlgHom.toRingHom := by
+  rw [mkQuotient_ker]
+  exact HopfIdeal.toIdeal_le_toIdeal.mpr hIJ
+
+/-- The coordinate morphism `H ⧸ I ⟶ H ⧸ J` induced by an inclusion `I ≤ J` of Hopf
+ideals.
+
+It is the unique morphism out of `H ⧸ I` whose composite with `H ⟶ H ⧸ I` is the quotient
+map `H ⟶ H ⧸ J`. -/
+noncomputable abbrev quotientMapOfLe (H : _root_.CommHopfAlgCat.{v} R)
+    {I J : HopfIdeal R H} (hIJ : I ≤ J) : quotient H I ⟶ quotient H J :=
+  liftQuotient I (mkQuotient H J) (toIdeal_le_ker_mkQuotient_of_le H hIJ)
+
+/-- The quotient-to-quotient morphism sends the class of `h` modulo `I` to its class
+modulo `J`. -/
+lemma quotientMapOfLe_mk (H : _root_.CommHopfAlgCat.{v} R) {I J : HopfIdeal R H}
+    (hIJ : I ≤ J) (h : H) :
+    (quotientMapOfLe H hIJ).hom (Ideal.Quotient.mkₐ R I.toIdeal h) =
+      Ideal.Quotient.mkₐ R J.toIdeal h := by
+  rw [quotientMapOfLe, liftQuotient_mk, mkQuotient_apply]
+
+/-- Composing the quotient map `H ⟶ H ⧸ I` with the quotient-to-quotient morphism for
+`I ≤ J` gives the quotient map `H ⟶ H ⧸ J`. -/
+lemma mkQuotient_comp_quotientMapOfLe (H : _root_.CommHopfAlgCat.{v} R)
+    {I J : HopfIdeal R H} (hIJ : I ≤ J) :
+    mkQuotient H I ≫ quotientMapOfLe H hIJ = mkQuotient H J :=
+  mkQuotient_comp_liftQuotient I (mkQuotient H J)
+    (toIdeal_le_ker_mkQuotient_of_le H hIJ)
+
+/-- The quotient-to-quotient morphism for `I ≤ I` is the identity morphism. -/
+@[simp]
+lemma quotientMapOfLe_refl (H : _root_.CommHopfAlgCat.{v} R) (I : HopfIdeal R H) :
+    quotientMapOfLe H (le_refl I) = 𝟙 (quotient H I) := by
+  ext q
+  obtain ⟨h, rfl⟩ := Ideal.Quotient.mkₐ_surjective R I.toIdeal q
+  rw [quotientMapOfLe_mk]
+  rfl
+
+/-- Quotient-to-quotient morphisms compose along inclusions of Hopf ideals. -/
+@[simp]
+lemma quotientMapOfLe_comp (H : _root_.CommHopfAlgCat.{v} R)
+    {I J K : HopfIdeal R H} (hIJ : I ≤ J) (hJK : J ≤ K) :
+    quotientMapOfLe H hIJ ≫ quotientMapOfLe H hJK =
+      quotientMapOfLe H (hIJ.trans hJK) := by
+  ext q
+  obtain ⟨h, rfl⟩ := Ideal.Quotient.mkₐ_surjective R I.toIdeal q
+  rw [_root_.CommHopfAlgCat.comp_apply, quotientMapOfLe_mk, quotientMapOfLe_mk,
+    quotientMapOfLe_mk]
+
 end CommHopfAlgCat
 
 namespace FiniteTypeCommHopfAlgCat
@@ -205,6 +259,57 @@ lemma liftQuotient_unique (I : HopfIdeal R H) (f : H ⟶ K)
         (_root_.CommHopfAlgCat.{v} R)).map φ) hg
   exact CommHopfAlgCat.liftQuotient_unique (H := _root_.CommHopfAlgCat.of R H) I f.hom hf
     g.hom hg'
+
+/-- The finite-type coordinate morphism `H ⧸ I ⟶ H ⧸ J` induced by an inclusion `I ≤ J` of
+Hopf ideals. -/
+noncomputable abbrev quotientMapOfLe (H : FiniteTypeCommHopfAlgCat.{u, v} R)
+    {I J : HopfIdeal R H} (hIJ : I ≤ J) : quotient H I ⟶ quotient H J :=
+  ObjectProperty.homMk (CommHopfAlgCat.quotientMapOfLe H.obj hIJ)
+
+/-- The finite-type quotient-to-quotient morphism forgets to the `CommHopfAlgCat`
+quotient-to-quotient morphism. -/
+lemma forget₂_commHopfAlgCat_map_quotientMapOfLe
+    (H : FiniteTypeCommHopfAlgCat.{u, v} R) {I J : HopfIdeal R H} (hIJ : I ≤ J) :
+    (forget₂ (FiniteTypeCommHopfAlgCat.{u, v} R) (_root_.CommHopfAlgCat.{v} R)).map
+        (quotientMapOfLe H hIJ) =
+      CommHopfAlgCat.quotientMapOfLe H.obj hIJ :=
+  rfl
+
+/-- The finite-type quotient-to-quotient morphism sends the class of `h` modulo `I` to its
+class modulo `J`. -/
+lemma quotientMapOfLe_mk (H : FiniteTypeCommHopfAlgCat.{u, v} R)
+    {I J : HopfIdeal R H} (hIJ : I ≤ J) (h : H) :
+    (toBialgHom (quotientMapOfLe H hIJ)) (Ideal.Quotient.mkₐ R I.toIdeal h) =
+      Ideal.Quotient.mkₐ R J.toIdeal h :=
+  CommHopfAlgCat.quotientMapOfLe_mk H.obj hIJ h
+
+/-- Composing the finite-type quotient map `H ⟶ H ⧸ I` with the quotient-to-quotient
+morphism for `I ≤ J` gives the quotient map `H ⟶ H ⧸ J`. -/
+@[simp]
+lemma mkQuotient_comp_quotientMapOfLe (H : FiniteTypeCommHopfAlgCat.{u, v} R)
+    {I J : HopfIdeal R H} (hIJ : I ≤ J) :
+    mkQuotient H I ≫ quotientMapOfLe H hIJ = mkQuotient H J := by
+  apply (forget₂ (FiniteTypeCommHopfAlgCat.{u, v} R)
+    (_root_.CommHopfAlgCat.{v} R)).map_injective
+  exact CommHopfAlgCat.mkQuotient_comp_quotientMapOfLe H.obj hIJ
+
+/-- The finite-type quotient-to-quotient morphism for `I ≤ I` is the identity morphism. -/
+@[simp]
+lemma quotientMapOfLe_refl (H : FiniteTypeCommHopfAlgCat.{u, v} R) (I : HopfIdeal R H) :
+    quotientMapOfLe H (le_refl I) = 𝟙 (quotient H I) := by
+  apply (forget₂ (FiniteTypeCommHopfAlgCat.{u, v} R)
+    (_root_.CommHopfAlgCat.{v} R)).map_injective
+  exact CommHopfAlgCat.quotientMapOfLe_refl H.obj I
+
+/-- Finite-type quotient-to-quotient morphisms compose along inclusions of Hopf ideals. -/
+@[simp]
+lemma quotientMapOfLe_comp (H : FiniteTypeCommHopfAlgCat.{u, v} R)
+    {I J K : HopfIdeal R H} (hIJ : I ≤ J) (hJK : J ≤ K) :
+    quotientMapOfLe H hIJ ≫ quotientMapOfLe H hJK =
+      quotientMapOfLe H (hIJ.trans hJK) := by
+  apply (forget₂ (FiniteTypeCommHopfAlgCat.{u, v} R)
+    (_root_.CommHopfAlgCat.{v} R)).map_injective
+  exact CommHopfAlgCat.quotientMapOfLe_comp H.obj hIJ hJK
 
 end FiniteTypeCommHopfAlgCat
 

--- a/TauCeti/Algebra/AlgebraicGroup/HopfIdealQuotient.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/HopfIdealQuotient.lean
@@ -158,7 +158,6 @@ lemma quotientMapOfLe_mk (H : _root_.CommHopfAlgCat.{v} R) {I J : HopfIdeal R H}
 
 /-- Composing the quotient map `H ⟶ H ⧸ I` with the quotient-to-quotient morphism for
 `I ≤ J` gives the quotient map `H ⟶ H ⧸ J`. -/
-@[simp]
 lemma mkQuotient_comp_quotientMapOfLe (H : _root_.CommHopfAlgCat.{v} R)
     {I J : HopfIdeal R H} (hIJ : I ≤ J) :
     mkQuotient H I ≫ quotientMapOfLe H hIJ = mkQuotient H J :=

--- a/TauCeti/Algebra/AlgebraicGroup/HopfIdealQuotient.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/HopfIdealQuotient.lean
@@ -158,6 +158,7 @@ lemma quotientMapOfLe_mk (H : _root_.CommHopfAlgCat.{v} R) {I J : HopfIdeal R H}
 
 /-- Composing the quotient map `H ⟶ H ⧸ I` with the quotient-to-quotient morphism for
 `I ≤ J` gives the quotient map `H ⟶ H ⧸ J`. -/
+@[simp]
 lemma mkQuotient_comp_quotientMapOfLe (H : _root_.CommHopfAlgCat.{v} R)
     {I J : HopfIdeal R H} (hIJ : I ≤ J) :
     mkQuotient H I ≫ quotientMapOfLe H hIJ = mkQuotient H J :=

--- a/TauCeti/Algebra/AlgebraicGroup/HopfIdealQuotientOrder.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/HopfIdealQuotientOrder.lean
@@ -7,33 +7,29 @@ module
 public import TauCeti.Algebra.AlgebraicGroup.HopfIdealPointsOrder
 
 /-!
-# Order maps between Hopf-ideal quotients
+# Point compatibility for order maps between Hopf-ideal quotients
 
 If `I ≤ J` are Hopf ideals in a commutative Hopf algebra `H`, then the quotient map
 `H ⟶ H ⧸ J` kills `I`, so it factors through a coordinate morphism
 `H ⧸ I ⟶ H ⧸ J`. Contravariantly, this is the map on closed-subgroup functors induced by
 the inclusion of the subgroup cut out by `J` into the subgroup cut out by `I`.
 
-This file records that quotient-to-quotient morphism in `CommHopfAlgCat` and in the
-finite-type wrapper, together with its compatibility with the already-defined point subgroup
-inclusions.
+This file records the compatibility of that quotient-to-quotient morphism with the
+already-defined point subgroup inclusions. The coordinate-level morphism itself is defined in
+`TauCeti.Algebra.AlgebraicGroup.HopfIdealQuotient`.
 
 ## Main declarations
 
-* `CommHopfAlgCat.quotientMapOfLe`: the coordinate morphism `H ⧸ I ⟶ H ⧸ J` induced by
-  `I ≤ J`.
 * `CommHopfAlgCat.quotientPointsHom_mapPointsFunctor_quotientMapOfLe_app`: on points,
   precomposition with `quotientMapOfLe` is compatible with the ambient quotient-points
   inclusions.
-* `FiniteTypeCommHopfAlgCat.quotientMapOfLe`: the same morphism for finite-type
-  commutative Hopf algebras.
 
 ## References
 
-This is point-level and coordinate-ring bookkeeping for the ReductiveGroups roadmap,
-Layer 3, "Hopf ideals ↔ closed subgroup schemes". It uses the quotient universal property
-from `TauCeti.Algebra.AlgebraicGroup.HopfIdealQuotient` and the cut-out subgroup order API
-from `TauCeti.Algebra.AlgebraicGroup.HopfIdealPointsOrder`.
+This is point-level bookkeeping for the ReductiveGroups roadmap, Layer 3,
+"Hopf ideals ↔ closed subgroup schemes". It uses the quotient universal property from
+`TauCeti.Algebra.AlgebraicGroup.HopfIdealQuotient` and the cut-out subgroup order API from
+`TauCeti.Algebra.AlgebraicGroup.HopfIdealPointsOrder`.
 -/
 
 public section
@@ -47,62 +43,6 @@ universe u v w
 namespace CommHopfAlgCat
 
 variable {R : Type u} [CommRing R]
-
-/-- If `I ≤ J`, then the quotient map by `J` kills every element of `I`. -/
-lemma toIdeal_le_ker_mkQuotient_of_le
-    (H : _root_.CommHopfAlgCat.{v} R) {I J : HopfIdeal R H} (hIJ : I ≤ J) :
-    I.toIdeal ≤ RingHom.ker (mkQuotient H J).hom.toAlgHom.toRingHom := by
-  intro h hh
-  rw [RingHom.mem_ker]
-  change (mkQuotient H J).hom h = 0
-  rw [mkQuotient_eq_zero_iff]
-  exact (HopfIdeal.mem_toIdeal (I := J)).mpr
-    (hIJ ((HopfIdeal.mem_toIdeal (I := I)).mp hh))
-
-/-- The coordinate morphism `H ⧸ I ⟶ H ⧸ J` induced by an inclusion `I ≤ J` of Hopf
-ideals.
-
-It is the unique morphism out of `H ⧸ I` whose composite with `H ⟶ H ⧸ I` is the quotient
-map `H ⟶ H ⧸ J`. -/
-noncomputable abbrev quotientMapOfLe (H : _root_.CommHopfAlgCat.{v} R)
-    {I J : HopfIdeal R H} (hIJ : I ≤ J) : quotient H I ⟶ quotient H J :=
-  liftQuotient I (mkQuotient H J) (toIdeal_le_ker_mkQuotient_of_le H hIJ)
-
-/-- The quotient-to-quotient morphism sends the class of `h` modulo `I` to its class
-modulo `J`. -/
-lemma quotientMapOfLe_mk (H : _root_.CommHopfAlgCat.{v} R) {I J : HopfIdeal R H}
-    (hIJ : I ≤ J) (h : H) :
-    (quotientMapOfLe H hIJ).hom (Ideal.Quotient.mkₐ R I.toIdeal h) =
-      Ideal.Quotient.mkₐ R J.toIdeal h := by
-  rw [quotientMapOfLe, liftQuotient_mk, mkQuotient_apply]
-
-/-- Composing the quotient map `H ⟶ H ⧸ I` with the quotient-to-quotient morphism for
-`I ≤ J` gives the quotient map `H ⟶ H ⧸ J`. -/
-lemma mkQuotient_comp_quotientMapOfLe (H : _root_.CommHopfAlgCat.{v} R)
-    {I J : HopfIdeal R H} (hIJ : I ≤ J) :
-    mkQuotient H I ≫ quotientMapOfLe H hIJ = mkQuotient H J :=
-  mkQuotient_comp_liftQuotient I (mkQuotient H J)
-    (toIdeal_le_ker_mkQuotient_of_le H hIJ)
-
-/-- The quotient-to-quotient morphism for `I ≤ I` is the identity morphism. -/
-@[simp]
-lemma quotientMapOfLe_refl (H : _root_.CommHopfAlgCat.{v} R) (I : HopfIdeal R H) :
-    quotientMapOfLe H (le_refl I) = 𝟙 (quotient H I) := by
-  ext q
-  obtain ⟨h, rfl⟩ := Ideal.Quotient.mkₐ_surjective R I.toIdeal q
-  rw [quotientMapOfLe_mk]
-  rfl
-
-/-- Quotient-to-quotient morphisms compose along inclusions of Hopf ideals. -/
-@[simp]
-lemma quotientMapOfLe_comp (H : _root_.CommHopfAlgCat.{v} R)
-    {I J K : HopfIdeal R H} (hIJ : I ≤ J) (hJK : J ≤ K) :
-    quotientMapOfLe H hIJ ≫ quotientMapOfLe H hJK =
-      quotientMapOfLe H (hIJ.trans hJK) := by
-  ext q
-  obtain ⟨h, rfl⟩ := Ideal.Quotient.mkₐ_surjective R I.toIdeal q
-  rw [_root_.CommHopfAlgCat.comp_apply, quotientMapOfLe_mk, quotientMapOfLe_mk,
-    quotientMapOfLe_mk]
 
 /-- On points, precomposition with `quotientMapOfLe` is compatible with the ambient
 quotient-points inclusions.
@@ -134,6 +74,7 @@ lemma quotientPointsHom_mapPointsFunctor_quotientMapOfLe_app_apply
 
 /-- Under the quotient-point subgroup isomorphisms, the points map induced by
 `quotientMapOfLe` is exactly the subgroup inclusion attached to `I ≤ J`. -/
+@[simp]
 lemma quotientPointsSubgroupIso_hom_mapPointsFunctor_quotientMapOfLe_app
     (H : _root_.CommHopfAlgCat.{v} R) {I J : HopfIdeal R H} (hIJ : I ≤ J)
     (A : CommAlgCat.{w} R)
@@ -146,62 +87,5 @@ lemma quotientPointsSubgroupIso_hom_mapPointsFunctor_quotientMapOfLe_app
   exact quotientPointsHom_mapPointsFunctor_quotientMapOfLe_app H hIJ A f
 
 end CommHopfAlgCat
-
-namespace FiniteTypeCommHopfAlgCat
-
-variable {R : Type u} [CommRing R]
-
-/-- The finite-type coordinate morphism `H ⧸ I ⟶ H ⧸ J` induced by an inclusion `I ≤ J` of
-Hopf ideals. -/
-noncomputable abbrev quotientMapOfLe (H : FiniteTypeCommHopfAlgCat.{u, v} R)
-    {I J : HopfIdeal R H} (hIJ : I ≤ J) : quotient H I ⟶ quotient H J :=
-  ObjectProperty.homMk (CommHopfAlgCat.quotientMapOfLe H.obj hIJ)
-
-/-- The finite-type quotient-to-quotient morphism forgets to the `CommHopfAlgCat`
-quotient-to-quotient morphism. -/
-lemma forget₂_commHopfAlgCat_map_quotientMapOfLe
-    (H : FiniteTypeCommHopfAlgCat.{u, v} R) {I J : HopfIdeal R H} (hIJ : I ≤ J) :
-    (forget₂ (FiniteTypeCommHopfAlgCat.{u, v} R) (_root_.CommHopfAlgCat.{v} R)).map
-        (quotientMapOfLe H hIJ) =
-      CommHopfAlgCat.quotientMapOfLe H.obj hIJ :=
-  rfl
-
-/-- The finite-type quotient-to-quotient morphism sends the class of `h` modulo `I` to its
-class modulo `J`. -/
-lemma quotientMapOfLe_mk (H : FiniteTypeCommHopfAlgCat.{u, v} R)
-    {I J : HopfIdeal R H} (hIJ : I ≤ J) (h : H) :
-    (toBialgHom (quotientMapOfLe H hIJ)) (Ideal.Quotient.mkₐ R I.toIdeal h) =
-      Ideal.Quotient.mkₐ R J.toIdeal h :=
-  CommHopfAlgCat.quotientMapOfLe_mk H.obj hIJ h
-
-/-- Composing the finite-type quotient map `H ⟶ H ⧸ I` with the quotient-to-quotient
-morphism for `I ≤ J` gives the quotient map `H ⟶ H ⧸ J`. -/
-@[simp]
-lemma mkQuotient_comp_quotientMapOfLe (H : FiniteTypeCommHopfAlgCat.{u, v} R)
-    {I J : HopfIdeal R H} (hIJ : I ≤ J) :
-    mkQuotient H I ≫ quotientMapOfLe H hIJ = mkQuotient H J := by
-  apply (forget₂ (FiniteTypeCommHopfAlgCat.{u, v} R)
-    (_root_.CommHopfAlgCat.{v} R)).map_injective
-  exact CommHopfAlgCat.mkQuotient_comp_quotientMapOfLe H.obj hIJ
-
-/-- The finite-type quotient-to-quotient morphism for `I ≤ I` is the identity morphism. -/
-@[simp]
-lemma quotientMapOfLe_refl (H : FiniteTypeCommHopfAlgCat.{u, v} R) (I : HopfIdeal R H) :
-    quotientMapOfLe H (le_refl I) = 𝟙 (quotient H I) := by
-  apply (forget₂ (FiniteTypeCommHopfAlgCat.{u, v} R)
-    (_root_.CommHopfAlgCat.{v} R)).map_injective
-  exact CommHopfAlgCat.quotientMapOfLe_refl H.obj I
-
-/-- Finite-type quotient-to-quotient morphisms compose along inclusions of Hopf ideals. -/
-@[simp]
-lemma quotientMapOfLe_comp (H : FiniteTypeCommHopfAlgCat.{u, v} R)
-    {I J K : HopfIdeal R H} (hIJ : I ≤ J) (hJK : J ≤ K) :
-    quotientMapOfLe H hIJ ≫ quotientMapOfLe H hJK =
-      quotientMapOfLe H (hIJ.trans hJK) := by
-  apply (forget₂ (FiniteTypeCommHopfAlgCat.{u, v} R)
-    (_root_.CommHopfAlgCat.{v} R)).map_injective
-  exact CommHopfAlgCat.quotientMapOfLe_comp H.obj hIJ hJK
-
-end FiniteTypeCommHopfAlgCat
 
 end TauCeti

--- a/TauCeti/Algebra/AlgebraicGroup/HopfIdealQuotientOrder.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/HopfIdealQuotientOrder.lean
@@ -70,7 +70,6 @@ noncomputable abbrev quotientMapOfLe (H : _root_.CommHopfAlgCat.{v} R)
 
 /-- The quotient-to-quotient morphism sends the class of `h` modulo `I` to its class
 modulo `J`. -/
-@[simp]
 lemma quotientMapOfLe_mk (H : _root_.CommHopfAlgCat.{v} R) {I J : HopfIdeal R H}
     (hIJ : I ≤ J) (h : H) :
     (quotientMapOfLe H hIJ).hom (Ideal.Quotient.mkₐ R I.toIdeal h) =
@@ -79,7 +78,6 @@ lemma quotientMapOfLe_mk (H : _root_.CommHopfAlgCat.{v} R) {I J : HopfIdeal R H}
 
 /-- Composing the quotient map `H ⟶ H ⧸ I` with the quotient-to-quotient morphism for
 `I ≤ J` gives the quotient map `H ⟶ H ⧸ J`. -/
-@[simp]
 lemma mkQuotient_comp_quotientMapOfLe (H : _root_.CommHopfAlgCat.{v} R)
     {I J : HopfIdeal R H} (hIJ : I ≤ J) :
     mkQuotient H I ≫ quotientMapOfLe H hIJ = mkQuotient H J :=
@@ -170,7 +168,6 @@ lemma forget₂_commHopfAlgCat_map_quotientMapOfLe
 
 /-- The finite-type quotient-to-quotient morphism sends the class of `h` modulo `I` to its
 class modulo `J`. -/
-@[simp]
 lemma quotientMapOfLe_mk (H : FiniteTypeCommHopfAlgCat.{u, v} R)
     {I J : HopfIdeal R H} (hIJ : I ≤ J) (h : H) :
     (toBialgHom (quotientMapOfLe H hIJ)) (Ideal.Quotient.mkₐ R I.toIdeal h) =

--- a/TauCeti/Algebra/AlgebraicGroup/HopfIdealQuotientOrder.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/HopfIdealQuotientOrder.lean
@@ -1,0 +1,210 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+module
+
+public import TauCeti.Algebra.AlgebraicGroup.HopfIdealPointsOrder
+
+/-!
+# Order maps between Hopf-ideal quotients
+
+If `I ≤ J` are Hopf ideals in a commutative Hopf algebra `H`, then the quotient map
+`H ⟶ H ⧸ J` kills `I`, so it factors through a coordinate morphism
+`H ⧸ I ⟶ H ⧸ J`. Contravariantly, this is the map on closed-subgroup functors induced by
+the inclusion of the subgroup cut out by `J` into the subgroup cut out by `I`.
+
+This file records that quotient-to-quotient morphism in `CommHopfAlgCat` and in the
+finite-type wrapper, together with its compatibility with the already-defined point subgroup
+inclusions.
+
+## Main declarations
+
+* `CommHopfAlgCat.quotientMapOfLe`: the coordinate morphism `H ⧸ I ⟶ H ⧸ J` induced by
+  `I ≤ J`.
+* `CommHopfAlgCat.quotientPointsHom_mapPointsFunctor_quotientMapOfLe_app`: on points,
+  precomposition with `quotientMapOfLe` is compatible with the ambient quotient-points
+  inclusions.
+* `FiniteTypeCommHopfAlgCat.quotientMapOfLe`: the same morphism for finite-type
+  commutative Hopf algebras.
+
+## References
+
+This is point-level and coordinate-ring bookkeeping for the ReductiveGroups roadmap,
+Layer 3, "Hopf ideals ↔ closed subgroup schemes". It uses the quotient universal property
+from `TauCeti.Algebra.AlgebraicGroup.HopfIdealQuotient` and the cut-out subgroup order API
+from `TauCeti.Algebra.AlgebraicGroup.HopfIdealPointsOrder`.
+-/
+
+public section
+
+open CategoryTheory WithConv
+
+namespace TauCeti
+
+universe u v w
+
+namespace CommHopfAlgCat
+
+variable {R : Type u} [CommRing R]
+
+/-- If `I ≤ J`, then the quotient map by `J` kills every element of `I`. -/
+lemma toIdeal_le_ker_mkQuotient_of_le
+    (H : _root_.CommHopfAlgCat.{v} R) {I J : HopfIdeal R H} (hIJ : I ≤ J) :
+    I.toIdeal ≤ RingHom.ker (mkQuotient H J).hom.toAlgHom.toRingHom := by
+  intro h hh
+  rw [RingHom.mem_ker]
+  change (mkQuotient H J).hom h = 0
+  rw [mkQuotient_eq_zero_iff]
+  exact (HopfIdeal.mem_toIdeal (I := J)).mpr
+    (hIJ ((HopfIdeal.mem_toIdeal (I := I)).mp hh))
+
+/-- The coordinate morphism `H ⧸ I ⟶ H ⧸ J` induced by an inclusion `I ≤ J` of Hopf
+ideals.
+
+It is the unique morphism out of `H ⧸ I` whose composite with `H ⟶ H ⧸ I` is the quotient
+map `H ⟶ H ⧸ J`. -/
+noncomputable abbrev quotientMapOfLe (H : _root_.CommHopfAlgCat.{v} R)
+    {I J : HopfIdeal R H} (hIJ : I ≤ J) : quotient H I ⟶ quotient H J :=
+  liftQuotient I (mkQuotient H J) (toIdeal_le_ker_mkQuotient_of_le H hIJ)
+
+/-- The quotient-to-quotient morphism sends the class of `h` modulo `I` to its class
+modulo `J`. -/
+@[simp]
+lemma quotientMapOfLe_mk (H : _root_.CommHopfAlgCat.{v} R) {I J : HopfIdeal R H}
+    (hIJ : I ≤ J) (h : H) :
+    (quotientMapOfLe H hIJ).hom (Ideal.Quotient.mkₐ R I.toIdeal h) =
+      Ideal.Quotient.mkₐ R J.toIdeal h := by
+  rw [quotientMapOfLe, liftQuotient_mk, mkQuotient_apply]
+
+/-- Composing the quotient map `H ⟶ H ⧸ I` with the quotient-to-quotient morphism for
+`I ≤ J` gives the quotient map `H ⟶ H ⧸ J`. -/
+@[simp]
+lemma mkQuotient_comp_quotientMapOfLe (H : _root_.CommHopfAlgCat.{v} R)
+    {I J : HopfIdeal R H} (hIJ : I ≤ J) :
+    mkQuotient H I ≫ quotientMapOfLe H hIJ = mkQuotient H J :=
+  mkQuotient_comp_liftQuotient I (mkQuotient H J)
+    (toIdeal_le_ker_mkQuotient_of_le H hIJ)
+
+/-- The quotient-to-quotient morphism for `I ≤ I` is the identity morphism. -/
+@[simp]
+lemma quotientMapOfLe_refl (H : _root_.CommHopfAlgCat.{v} R) (I : HopfIdeal R H) :
+    quotientMapOfLe H (le_refl I) = 𝟙 (quotient H I) := by
+  ext q
+  obtain ⟨h, rfl⟩ := Ideal.Quotient.mkₐ_surjective R I.toIdeal q
+  rw [quotientMapOfLe_mk]
+  rfl
+
+/-- Quotient-to-quotient morphisms compose along inclusions of Hopf ideals. -/
+@[simp]
+lemma quotientMapOfLe_comp (H : _root_.CommHopfAlgCat.{v} R)
+    {I J K : HopfIdeal R H} (hIJ : I ≤ J) (hJK : J ≤ K) :
+    quotientMapOfLe H hIJ ≫ quotientMapOfLe H hJK =
+      quotientMapOfLe H (hIJ.trans hJK) := by
+  ext q
+  obtain ⟨h, rfl⟩ := Ideal.Quotient.mkₐ_surjective R I.toIdeal q
+  rw [_root_.CommHopfAlgCat.comp_apply, quotientMapOfLe_mk, quotientMapOfLe_mk,
+    quotientMapOfLe_mk]
+
+/-- On points, precomposition with `quotientMapOfLe` is compatible with the ambient
+quotient-points inclusions.
+
+Starting with a point of `H ⧸ J`, mapping it to a point of `H ⧸ I` and then including into
+ambient `H`-points gives the same ambient point as the direct inclusion from `H ⧸ J`. -/
+@[simp]
+lemma quotientPointsHom_mapPointsFunctor_quotientMapOfLe_app
+    (H : _root_.CommHopfAlgCat.{v} R) {I J : HopfIdeal R H} (hIJ : I ≤ J)
+    (A : CommAlgCat.{w} R)
+    (f : HopfAlgebra.points (R := R) (H := quotient H J) A) :
+    quotientPointsHom H I A ((mapPointsFunctor (quotientMapOfLe H hIJ)).app A f) =
+      quotientPointsHom H J A f := by
+  apply WithConv.ofConv_injective
+  ext h
+  rw [quotientPointsHom_apply_apply, mapPointsFunctor_app_apply_apply,
+    quotientMapOfLe_mk, quotientPointsHom_apply_apply]
+
+/-- The pointwise form of
+`CommHopfAlgCat.quotientPointsHom_mapPointsFunctor_quotientMapOfLe_app`. -/
+@[simp]
+lemma quotientPointsHom_mapPointsFunctor_quotientMapOfLe_app_apply
+    (H : _root_.CommHopfAlgCat.{v} R) {I J : HopfIdeal R H} (hIJ : I ≤ J)
+    (A : CommAlgCat.{w} R)
+    (f : HopfAlgebra.points (R := R) (H := quotient H J) A) (h : H) :
+    (quotientPointsHom H I A ((mapPointsFunctor (quotientMapOfLe H hIJ)).app A f)).ofConv h =
+      f.ofConv (Ideal.Quotient.mkₐ R J.toIdeal h) := by
+  rw [quotientPointsHom_mapPointsFunctor_quotientMapOfLe_app, quotientPointsHom_apply_apply]
+
+/-- Under the quotient-point subgroup isomorphisms, the points map induced by
+`quotientMapOfLe` is exactly the subgroup inclusion attached to `I ≤ J`. -/
+lemma quotientPointsSubgroupIso_hom_mapPointsFunctor_quotientMapOfLe_app
+    (H : _root_.CommHopfAlgCat.{v} R) {I J : HopfIdeal R H} (hIJ : I ≤ J)
+    (A : CommAlgCat.{w} R)
+    (f : HopfAlgebra.points (R := R) (H := quotient H J) A) :
+    (quotientPointsSubgroupIso H I A).hom
+        ((mapPointsFunctor (quotientMapOfLe H hIJ)).app A f) =
+      Subgroup.inclusion (quotientPointsSubgroup_le_of_le H hIJ A)
+        ((quotientPointsSubgroupIso H J A).hom f) := by
+  apply Subtype.ext
+  exact quotientPointsHom_mapPointsFunctor_quotientMapOfLe_app H hIJ A f
+
+end CommHopfAlgCat
+
+namespace FiniteTypeCommHopfAlgCat
+
+variable {R : Type u} [CommRing R]
+
+/-- The finite-type coordinate morphism `H ⧸ I ⟶ H ⧸ J` induced by an inclusion `I ≤ J` of
+Hopf ideals. -/
+noncomputable abbrev quotientMapOfLe (H : FiniteTypeCommHopfAlgCat.{u, v} R)
+    {I J : HopfIdeal R H} (hIJ : I ≤ J) : quotient H I ⟶ quotient H J :=
+  ObjectProperty.homMk (CommHopfAlgCat.quotientMapOfLe H.obj hIJ)
+
+/-- The finite-type quotient-to-quotient morphism forgets to the `CommHopfAlgCat`
+quotient-to-quotient morphism. -/
+lemma forget₂_commHopfAlgCat_map_quotientMapOfLe
+    (H : FiniteTypeCommHopfAlgCat.{u, v} R) {I J : HopfIdeal R H} (hIJ : I ≤ J) :
+    (forget₂ (FiniteTypeCommHopfAlgCat.{u, v} R) (_root_.CommHopfAlgCat.{v} R)).map
+        (quotientMapOfLe H hIJ) =
+      CommHopfAlgCat.quotientMapOfLe H.obj hIJ :=
+  rfl
+
+/-- The finite-type quotient-to-quotient morphism sends the class of `h` modulo `I` to its
+class modulo `J`. -/
+@[simp]
+lemma quotientMapOfLe_mk (H : FiniteTypeCommHopfAlgCat.{u, v} R)
+    {I J : HopfIdeal R H} (hIJ : I ≤ J) (h : H) :
+    (toBialgHom (quotientMapOfLe H hIJ)) (Ideal.Quotient.mkₐ R I.toIdeal h) =
+      Ideal.Quotient.mkₐ R J.toIdeal h :=
+  CommHopfAlgCat.quotientMapOfLe_mk H.obj hIJ h
+
+/-- Composing the finite-type quotient map `H ⟶ H ⧸ I` with the quotient-to-quotient
+morphism for `I ≤ J` gives the quotient map `H ⟶ H ⧸ J`. -/
+@[simp]
+lemma mkQuotient_comp_quotientMapOfLe (H : FiniteTypeCommHopfAlgCat.{u, v} R)
+    {I J : HopfIdeal R H} (hIJ : I ≤ J) :
+    mkQuotient H I ≫ quotientMapOfLe H hIJ = mkQuotient H J := by
+  apply (forget₂ (FiniteTypeCommHopfAlgCat.{u, v} R)
+    (_root_.CommHopfAlgCat.{v} R)).map_injective
+  exact CommHopfAlgCat.mkQuotient_comp_quotientMapOfLe H.obj hIJ
+
+/-- The finite-type quotient-to-quotient morphism for `I ≤ I` is the identity morphism. -/
+@[simp]
+lemma quotientMapOfLe_refl (H : FiniteTypeCommHopfAlgCat.{u, v} R) (I : HopfIdeal R H) :
+    quotientMapOfLe H (le_refl I) = 𝟙 (quotient H I) := by
+  apply (forget₂ (FiniteTypeCommHopfAlgCat.{u, v} R)
+    (_root_.CommHopfAlgCat.{v} R)).map_injective
+  exact CommHopfAlgCat.quotientMapOfLe_refl H.obj I
+
+/-- Finite-type quotient-to-quotient morphisms compose along inclusions of Hopf ideals. -/
+@[simp]
+lemma quotientMapOfLe_comp (H : FiniteTypeCommHopfAlgCat.{u, v} R)
+    {I J K : HopfIdeal R H} (hIJ : I ≤ J) (hJK : J ≤ K) :
+    quotientMapOfLe H hIJ ≫ quotientMapOfLe H hJK =
+      quotientMapOfLe H (hIJ.trans hJK) := by
+  apply (forget₂ (FiniteTypeCommHopfAlgCat.{u, v} R)
+    (_root_.CommHopfAlgCat.{v} R)).map_injective
+  exact CommHopfAlgCat.quotientMapOfLe_comp H.obj hIJ hJK
+
+end FiniteTypeCommHopfAlgCat
+
+end TauCeti


### PR DESCRIPTION
This PR adds the coordinate morphism `H ⧸ I ⟶ H ⧸ J` induced by an inclusion `I ≤ J` of Hopf ideals, with the quotient-class formula, identity and composition laws, finite-type wrappers, and the compatibility saying that the induced map on points matches the existing inclusion of cut-out point subgroups. It advances `TauCetiRoadmap/ReductiveGroups/README.md`, Layer 3, “Hopf ideals ↔ closed subgroup schemes,” specifically the Hopf-ideal/closed-subgroup dictionary and quotient bookkeeping for comparable Hopf ideals.

I chose this as the lowest-hanging distinct ReductiveGroups target after checking open and recently merged PRs: open ReductiveGroups work covers finite-type trivial coordinate objects, and merged work already has quotient point subgroups, their value-algebra naturality, and the antitone subgroup inclusion for `I ≤ J`, while the corresponding coordinate quotient map `H ⧸ I ⟶ H ⧸ J` and its point-level compatibility were still absent.

No Mathlib infrastructure is vendored. The implementation reuses Tau Ceti’s existing `CommHopfAlgCat.liftQuotient`, `mkQuotient`, `mapPointsFunctor`, `quotientPointsHom`, `quotientPointsSubgroupIso`, and `quotientPointsSubgroup_le_of_le` APIs, together with Mathlib’s `Ideal.Quotient.mkₐ_surjective` quotient-class induction.

`lake exe cache get` completed with `No files to download` and `Already decompressed 8609 file(s)`. `lake build` completed with `Build completed successfully (4573 jobs).` `lake exe axioms` completed with `axioms: audited 8517 TauCeti declaration(s); all within the allowlist [propext, Classical.choice, Quot.sound].`

<!--tauceti-target:v1 {"focus":"ReductiveGroups","id":"hopf-ideal-quotient-order-map"}-->

🤖 Prepared with Codex
