### PR TITLE
feat: add integrability, L² membership, and parity of the Hermite functions

### DIFF
--- a/TauCeti/Analysis/SpecialFunctions/HermiteFunction.lean
+++ b/TauCeti/Analysis/SpecialFunctions/HermiteFunction.lean
@@ -21,9 +21,9 @@ probabilists' Hermite polynomial evaluated at `x * sqrt 2`, multiplied by the
 Gaussian envelope `exp (-x^2 / 2)`.
 
 The API here is deliberately pointwise: the definition, continuity and
-smoothness, and the first three base formulas `ψ₀`, `ψ₁`, and `ψ₂`. Orthogonality, `L²`
-packaging, and the oscillator identities are later milestones built on this
-basic object.
+smoothness, the first three base formulas `ψ₀`, `ψ₁`, and `ψ₂`, and the parity formula
+`ψₙ(-x) = (-1)ⁿ ψₙ(x)`. Orthogonality, `L²` packaging, and the oscillator identities are later
+milestones built on this basic object.
 -/
 
 public section
@@ -130,5 +130,17 @@ lemma hermiteFunction_two (x : ℝ) :
         Real.sqrt ((2 : ℝ) * Real.sqrt Real.pi) := by
   rw [hermiteFunction_def, aeval_hermite_two]
   norm_num [Nat.factorial]
+
+/-! ## Parity -/
+
+/-- **Target A2 (parity).** `ψₙ(-x) = (-1)ⁿ ψₙ(x)`: the Gaussian envelope `exp(-x²/2)` is even and
+the polynomial factor `Hₙ(x√2)` carries the parity of `Hₙ` (`Polynomial.hermite_aeval_neg`). -/
+@[simp]
+theorem hermiteFunction_neg (n : ℕ) (x : ℝ) :
+    hermiteFunction n (-x) = (-1) ^ n * hermiteFunction n x := by
+  have h1 : (-x) * Real.sqrt 2 = -(x * Real.sqrt 2) := by ring
+  have h2 : ((-x) ^ 2 / 2 : ℝ) = x ^ 2 / 2 := by ring
+  rw [hermiteFunction_def, hermiteFunction_def, h1, Polynomial.hermite_aeval_neg, h2]
+  ring
 
 end TauCeti

--- a/TauCeti/Analysis/SpecialFunctions/HermiteFunctionMemLp.lean
+++ b/TauCeti/Analysis/SpecialFunctions/HermiteFunctionMemLp.lean
@@ -6,7 +6,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Claude
 -/
 public import TauCeti.Analysis.SpecialFunctions.HermiteFunction
-public import TauCeti.Probability.Distributions.Gaussian.HermiteMemLp
+public import TauCeti.Probability.Distributions.Gaussian.PolynomialMemLp
 
 /-!
 # Integrability and `L²` membership of the Hermite functions

--- a/TauCeti/Analysis/SpecialFunctions/HermiteFunctionMemLp.lean
+++ b/TauCeti/Analysis/SpecialFunctions/HermiteFunctionMemLp.lean
@@ -1,0 +1,156 @@
+module
+
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Claude
+-/
+public import TauCeti.Analysis.SpecialFunctions.HermiteFunction
+public import TauCeti.Probability.Distributions.Gaussian.HermiteMemLp
+
+/-!
+# Integrability, `L²` membership, and parity of the Hermite functions
+
+This file continues the object API for the Hermite functions
+`ψₙ(x) = Hₙ(x√2) exp(-x²/2) / √(n!√π)` (`TauCeti.hermiteFunction`), adding the regularity facts
+the `OrthogonalL2Bases` roadmap's **A2** milestone lists and its **A3** basis construction consumes:
+
+* `TauCeti.integrable_hermiteFunction` — every `ψₙ` is integrable against Lebesgue measure;
+* `TauCeti.memLp_two_hermiteFunction` — every `ψₙ` is in `L²(volume)`, the membership the
+  `hermiteFunctionLp`/`hermiteHilbertBasis` layer needs to package `ψₙ` as an `Lp` element;
+* `TauCeti.hermiteFunction_neg` — the parity relation `ψₙ(-x) = (-1)ⁿ ψₙ(x)`.
+
+The analytic input is a single reusable engine, `TauCeti.integrable_eval_mul_gaussianEnvelope`: a
+real polynomial evaluated pointwise, times a Gaussian envelope `exp(-x²/(2v))` of any positive
+variance `v`, is Lebesgue-integrable. It is obtained by transporting the polynomial's integrability
+against the Gaussian *measure* `gaussianReal 0 v` (all of whose moments are finite,
+`TauCeti.integrable_pow_gaussianReal`, so `TauCeti.integrable_eval_of_forall_integrable_pow`
+applies) across the change of variables `gaussianReal 0 v = volume.withDensity (gaussianPDF 0 v)`
+with `integrable_withDensity_iff`. Applied to the polynomial `Hₙ(·√2)` with `v = 1` this gives the
+`L¹` membership, and to its square with `v = ½` (whose envelope `exp(-x²)` is `ψₙ²` up to the
+constant) the `L²` membership.
+
+The parity of the functions rests on `TauCeti.aeval_neg_hermite`, the parity `Hₙ(-x) = (-1)ⁿ Hₙ(x)`
+of the probabilists' Hermite polynomials, itself immediate from Mathlib's
+`Polynomial.coeff_hermite_of_odd_add` (a nonzero coefficient forces `n` and its degree to share
+parity).
+
+Mathlib's Gaussian density API (`gaussianReal_of_var_ne_zero`, `measurable_gaussianPDF`,
+`gaussianPDFReal_def`), `integrable_withDensity_iff`, `memLp_two_iff_integrable_sq`, and the
+`Polynomial` evaluation API are consumed, not re-derived.
+-/
+
+public section
+
+namespace TauCeti
+
+open MeasureTheory ProbabilityTheory Polynomial
+
+open scoped NNReal ENNReal
+
+/-! ## Parity of the probabilists' Hermite polynomials -/
+
+/-- **Parity of the Hermite polynomials.** `Hₙ(-x) = (-1)ⁿ Hₙ(x)` in any commutative ring: a
+coefficient of `hermite n` in degree `k` can be nonzero only when `n + k` is even
+(`Polynomial.coeff_hermite_of_odd_add`), so `k` and `n` share parity and `(-x)ᵏ = (-1)ⁿ xᵏ` on every
+surviving monomial. -/
+theorem aeval_neg_hermite {R : Type*} [CommRing R] (n : ℕ) (x : R) :
+    aeval (-x) (hermite n) = (-1) ^ n * aeval x (hermite n) := by
+  rw [aeval_eq_sum_range, aeval_eq_sum_range, Finset.mul_sum]
+  apply Finset.sum_congr rfl
+  intro k _
+  by_cases hodd : Odd (n + k)
+  · rw [coeff_hermite_of_odd_add hodd]; simp
+  · rw [Nat.not_odd_iff_even] at hodd
+    rw [zsmul_eq_mul, zsmul_eq_mul]
+    have hpow : (-x) ^ k = (-1) ^ n * x ^ k := by
+      rcases Nat.even_or_odd n with hn | hn
+      · rw [Even.neg_pow ((Nat.even_add.mp hodd).mp hn), Even.neg_one_pow hn, one_mul]
+      · have hk : Odd k := Nat.not_even_iff_odd.mp fun hke =>
+          (Nat.not_even_iff_odd.mpr hn) ((Nat.even_add.mp hodd).mpr hke)
+        rw [Odd.neg_pow hk, Odd.neg_one_pow hn]; ring
+    rw [hpow]; ring
+
+/-! ## Integrability of a polynomial against a Gaussian envelope -/
+
+/-- A real polynomial evaluated pointwise, times a Gaussian envelope `exp(-x²/(2v))` of positive
+variance `v`, is Lebesgue-integrable. Transported from the polynomial's integrability against the
+Gaussian measure `gaussianReal 0 v` (finite moments of all orders) across
+`gaussianReal 0 v = volume.withDensity (gaussianPDF 0 v)`. -/
+theorem integrable_eval_mul_gaussianEnvelope (q : ℝ[X]) {w : ℝ≥0} (hw : w ≠ 0) :
+    Integrable (fun x : ℝ => q.eval x * Real.exp (-x ^ 2 / (2 * (w : ℝ)))) volume := by
+  have hint : Integrable (fun x : ℝ => q.eval x) (gaussianReal 0 w) :=
+    integrable_eval_of_forall_integrable_pow (fun k => integrable_pow_gaussianReal 0 w k) q
+  rw [gaussianReal_of_var_ne_zero 0 hw,
+    integrable_withDensity_iff (measurable_gaussianPDF 0 w)
+      (ae_of_all _ fun _ => ENNReal.ofReal_lt_top)] at hint
+  simp only [toReal_gaussianPDF] at hint
+  have hw' : (0 : ℝ) < (w : ℝ) := NNReal.coe_pos.mpr (zero_lt_iff.mpr hw)
+  have hsqrt : Real.sqrt (2 * Real.pi * (w : ℝ)) ≠ 0 :=
+    (Real.sqrt_pos.mpr (by positivity)).ne'
+  refine (hint.const_mul (Real.sqrt (2 * Real.pi * (w : ℝ)))).congr (ae_of_all _ fun x => ?_)
+  simp only [gaussianPDFReal_def, sub_zero]
+  field_simp
+
+/-- A real polynomial times the envelope `exp(-x²)` is Lebesgue-integrable — the `v = ½` case of
+`integrable_eval_mul_gaussianEnvelope`, the shape of `ψₙ²`. -/
+theorem integrable_eval_mul_exp_neg_sq (q : ℝ[X]) :
+    Integrable (fun x : ℝ => q.eval x * Real.exp (-x ^ 2)) volume := by
+  have h := integrable_eval_mul_gaussianEnvelope q (w := 2⁻¹) (by norm_num)
+  have he : (2 : ℝ) * ((2⁻¹ : ℝ≥0) : ℝ) = 1 := by push_cast; norm_num
+  simpa only [he, div_one] using h
+
+/-! ## `L¹` and `L²` membership of the Hermite functions -/
+
+/-- The polynomial `Hₙ(·√2)`, real-evaluated, as a composition whose `eval` is `aeval (·√2)`. -/
+private lemma eval_hermiteComp (n : ℕ) (x : ℝ) :
+    (((hermite n).map (Int.castRingHom ℝ)).comp (X * Polynomial.C (Real.sqrt 2))).eval x
+      = aeval (x * Real.sqrt 2) (hermite n) := by
+  rw [eval_comp, eval_mul, eval_X, eval_C, aeval_def, algebraMap_int_eq, ← eval_map]
+
+/-- **Target A2 (`L¹`).** Each Hermite function is integrable against Lebesgue measure: it is a
+polynomial in `x` times the Gaussian envelope `exp(-x²/2)`, the `v = 1` case of
+`integrable_eval_mul_gaussianEnvelope`. -/
+theorem integrable_hermiteFunction (n : ℕ) : Integrable (hermiteFunction n) volume := by
+  have h := integrable_eval_mul_gaussianEnvelope
+    (((hermite n).map (Int.castRingHom ℝ)).comp (X * Polynomial.C (Real.sqrt 2))) (w := 1)
+    one_ne_zero
+  have hfun : hermiteFunction n = fun x =>
+      (((hermite n).map (Int.castRingHom ℝ)).comp (X * Polynomial.C (Real.sqrt 2))).eval x
+        * Real.exp (-x ^ 2 / (2 * ((1 : ℝ≥0) : ℝ)))
+        / Real.sqrt ((n.factorial : ℝ) * Real.sqrt Real.pi) := by
+    funext x
+    rw [hermiteFunction_def, ← eval_hermiteComp,
+      show (-(x ^ 2 / 2) : ℝ) = -x ^ 2 / (2 * ((1 : ℝ≥0) : ℝ)) by push_cast; ring]
+  rw [hfun]
+  exact h.div_const _
+
+/-- **Target A2 (`L²`).** Each Hermite function lies in `L²(volume)`. Its square is
+`(Hₙ(x√2))² exp(-x²)` up to the constant `(n!√π)`, integrable by `integrable_eval_mul_exp_neg_sq`,
+and `L²` membership is integrability of the square (`memLp_two_iff_integrable_sq`). This is the
+membership `hermiteFunctionLp` needs to realize `ψₙ` as an element of `Lp ℝ 2 volume`. -/
+theorem memLp_two_hermiteFunction (n : ℕ) : MemLp (hermiteFunction n) 2 volume := by
+  rw [memLp_two_iff_integrable_sq (continuous_hermiteFunction n).aestronglyMeasurable]
+  have hfun : (fun x => hermiteFunction n x ^ 2) = fun x =>
+      ((((hermite n).map (Int.castRingHom ℝ)).comp (X * Polynomial.C (Real.sqrt 2))) ^ 2).eval x
+        * Real.exp (-x ^ 2)
+        / Real.sqrt ((n.factorial : ℝ) * Real.sqrt Real.pi) ^ 2 := by
+    funext x
+    have henv : Real.exp (-(x ^ 2 / 2)) ^ 2 = Real.exp (-x ^ 2) := by
+      rw [pow_two, ← Real.exp_add]; congr 1; ring
+    rw [hermiteFunction_def, div_pow, mul_pow, henv, eval_pow, eval_hermiteComp]
+  rw [hfun]
+  exact (integrable_eval_mul_exp_neg_sq _).div_const _
+
+/-! ## Parity of the Hermite functions -/
+
+/-- **Target A2 (parity).** `ψₙ(-x) = (-1)ⁿ ψₙ(x)`: the Gaussian envelope `exp(-x²/2)` is even and
+the polynomial factor `Hₙ(x√2)` carries the parity of `Hₙ` (`aeval_neg_hermite`). -/
+theorem hermiteFunction_neg (n : ℕ) (x : ℝ) :
+    hermiteFunction n (-x) = (-1) ^ n * hermiteFunction n x := by
+  have h1 : (-x) * Real.sqrt 2 = -(x * Real.sqrt 2) := by ring
+  have h2 : ((-x) ^ 2 / 2 : ℝ) = x ^ 2 / 2 := by ring
+  rw [hermiteFunction_def, hermiteFunction_def, h1, aeval_neg_hermite, h2]
+  ring
+
+end TauCeti

--- a/TauCeti/Analysis/SpecialFunctions/HermiteFunctionMemLp.lean
+++ b/TauCeti/Analysis/SpecialFunctions/HermiteFunctionMemLp.lean
@@ -9,7 +9,7 @@ public import TauCeti.Analysis.SpecialFunctions.HermiteFunction
 public import TauCeti.Probability.Distributions.Gaussian.HermiteMemLp
 
 /-!
-# Integrability, `L²` membership, and parity of the Hermite functions
+# Integrability and `L²` membership of the Hermite functions
 
 This file continues the object API for the Hermite functions
 `ψₙ(x) = Hₙ(x√2) exp(-x²/2) / √(n!√π)` (`TauCeti.hermiteFunction`), adding the regularity facts
@@ -17,23 +17,18 @@ the `OrthogonalL2Bases` roadmap's **A2** milestone lists and its **A3** basis co
 
 * `TauCeti.integrable_hermiteFunction` — every `ψₙ` is integrable against Lebesgue measure;
 * `TauCeti.memLp_two_hermiteFunction` — every `ψₙ` is in `L²(volume)`, the membership the
-  `hermiteFunctionLp`/`hermiteHilbertBasis` layer needs to package `ψₙ` as an `Lp` element;
-* `TauCeti.hermiteFunction_neg` — the parity relation `ψₙ(-x) = (-1)ⁿ ψₙ(x)`.
+  `hermiteFunctionLp`/`hermiteHilbertBasis` layer needs to package `ψₙ` as an `Lp` element.
 
 The analytic input is a single reusable engine, `TauCeti.integrable_eval_mul_gaussianEnvelope`: a
-real polynomial evaluated pointwise, times a Gaussian envelope `exp(-x²/(2v))` of any positive
-variance `v`, is Lebesgue-integrable. It is obtained by transporting the polynomial's integrability
-against the Gaussian *measure* `gaussianReal 0 v` (all of whose moments are finite,
+real polynomial evaluated pointwise, times a Gaussian envelope `exp(-(x - μ)²/(2v))` of any center
+`μ` and positive variance `v`, is Lebesgue-integrable. It is obtained by transporting the
+polynomial's integrability against the Gaussian *measure* `gaussianReal μ v` (all of whose moments
+are finite,
 `TauCeti.integrable_pow_gaussianReal`, so `TauCeti.integrable_eval_of_forall_integrable_pow`
-applies) across the change of variables `gaussianReal 0 v = volume.withDensity (gaussianPDF 0 v)`
+applies) across the change of variables `gaussianReal μ v = volume.withDensity (gaussianPDF μ v)`
 with `integrable_withDensity_iff`. Applied to the polynomial `Hₙ(·√2)` with `v = 1` this gives the
 `L¹` membership, and to its square with `v = ½` (whose envelope `exp(-x²)` is `ψₙ²` up to the
 constant) the `L²` membership.
-
-The parity of the functions rests on `TauCeti.aeval_neg_hermite`, the parity `Hₙ(-x) = (-1)ⁿ Hₙ(x)`
-of the probabilists' Hermite polynomials, itself immediate from Mathlib's
-`Polynomial.coeff_hermite_of_odd_add` (a nonzero coefficient forces `n` and its degree to share
-parity).
 
 Mathlib's Gaussian density API (`gaussianReal_of_var_ne_zero`, `measurable_gaussianPDF`,
 `gaussianPDFReal_def`), `integrable_withDensity_iff`, `memLp_two_iff_integrable_sq`, and the
@@ -48,58 +43,6 @@ open MeasureTheory ProbabilityTheory Polynomial
 
 open scoped NNReal ENNReal
 
-/-! ## Parity of the probabilists' Hermite polynomials -/
-
-/-- **Parity of the Hermite polynomials.** `Hₙ(-x) = (-1)ⁿ Hₙ(x)` in any commutative ring: a
-coefficient of `hermite n` in degree `k` can be nonzero only when `n + k` is even
-(`Polynomial.coeff_hermite_of_odd_add`), so `k` and `n` share parity and `(-x)ᵏ = (-1)ⁿ xᵏ` on every
-surviving monomial. -/
-theorem aeval_neg_hermite {R : Type*} [CommRing R] (n : ℕ) (x : R) :
-    aeval (-x) (hermite n) = (-1) ^ n * aeval x (hermite n) := by
-  rw [aeval_eq_sum_range, aeval_eq_sum_range, Finset.mul_sum]
-  apply Finset.sum_congr rfl
-  intro k _
-  by_cases hodd : Odd (n + k)
-  · rw [coeff_hermite_of_odd_add hodd]; simp
-  · rw [Nat.not_odd_iff_even] at hodd
-    rw [zsmul_eq_mul, zsmul_eq_mul]
-    have hpow : (-x) ^ k = (-1) ^ n * x ^ k := by
-      rcases Nat.even_or_odd n with hn | hn
-      · rw [Even.neg_pow ((Nat.even_add.mp hodd).mp hn), Even.neg_one_pow hn, one_mul]
-      · have hk : Odd k := Nat.not_even_iff_odd.mp fun hke =>
-          (Nat.not_even_iff_odd.mpr hn) ((Nat.even_add.mp hodd).mpr hke)
-        rw [Odd.neg_pow hk, Odd.neg_one_pow hn]; ring
-    rw [hpow]; ring
-
-/-! ## Integrability of a polynomial against a Gaussian envelope -/
-
-/-- A real polynomial evaluated pointwise, times a Gaussian envelope `exp(-x²/(2v))` of positive
-variance `v`, is Lebesgue-integrable. Transported from the polynomial's integrability against the
-Gaussian measure `gaussianReal 0 v` (finite moments of all orders) across
-`gaussianReal 0 v = volume.withDensity (gaussianPDF 0 v)`. -/
-theorem integrable_eval_mul_gaussianEnvelope (q : ℝ[X]) {w : ℝ≥0} (hw : w ≠ 0) :
-    Integrable (fun x : ℝ => q.eval x * Real.exp (-x ^ 2 / (2 * (w : ℝ)))) volume := by
-  have hint : Integrable (fun x : ℝ => q.eval x) (gaussianReal 0 w) :=
-    integrable_eval_of_forall_integrable_pow (fun k => integrable_pow_gaussianReal 0 w k) q
-  rw [gaussianReal_of_var_ne_zero 0 hw,
-    integrable_withDensity_iff (measurable_gaussianPDF 0 w)
-      (ae_of_all _ fun _ => ENNReal.ofReal_lt_top)] at hint
-  simp only [toReal_gaussianPDF] at hint
-  have hw' : (0 : ℝ) < (w : ℝ) := NNReal.coe_pos.mpr (zero_lt_iff.mpr hw)
-  have hsqrt : Real.sqrt (2 * Real.pi * (w : ℝ)) ≠ 0 :=
-    (Real.sqrt_pos.mpr (by positivity)).ne'
-  refine (hint.const_mul (Real.sqrt (2 * Real.pi * (w : ℝ)))).congr (ae_of_all _ fun x => ?_)
-  simp only [gaussianPDFReal_def, sub_zero]
-  field_simp
-
-/-- A real polynomial times the envelope `exp(-x²)` is Lebesgue-integrable — the `v = ½` case of
-`integrable_eval_mul_gaussianEnvelope`, the shape of `ψₙ²`. -/
-theorem integrable_eval_mul_exp_neg_sq (q : ℝ[X]) :
-    Integrable (fun x : ℝ => q.eval x * Real.exp (-x ^ 2)) volume := by
-  have h := integrable_eval_mul_gaussianEnvelope q (w := 2⁻¹) (by norm_num)
-  have he : (2 : ℝ) * ((2⁻¹ : ℝ≥0) : ℝ) = 1 := by push_cast; norm_num
-  simpa only [he, div_one] using h
-
 /-! ## `L¹` and `L²` membership of the Hermite functions -/
 
 /-- The polynomial `Hₙ(·√2)`, real-evaluated, as a composition whose `eval` is `aeval (·√2)`. -/
@@ -112,16 +55,20 @@ private lemma eval_hermiteComp (n : ℕ) (x : ℝ) :
 polynomial in `x` times the Gaussian envelope `exp(-x²/2)`, the `v = 1` case of
 `integrable_eval_mul_gaussianEnvelope`. -/
 theorem integrable_hermiteFunction (n : ℕ) : Integrable (hermiteFunction n) volume := by
-  have h := integrable_eval_mul_gaussianEnvelope
+  have h := integrable_eval_mul_gaussianEnvelope 0
     (((hermite n).map (Int.castRingHom ℝ)).comp (X * Polynomial.C (Real.sqrt 2))) (w := 1)
     one_ne_zero
+  have exponent_one :
+      ∀ x : ℝ, (-(x ^ 2 / 2) : ℝ) = -(x - 0) ^ 2 / (2 * ((1 : ℝ≥0) : ℝ)) := by
+    intro x
+    push_cast
+    ring
   have hfun : hermiteFunction n = fun x =>
       (((hermite n).map (Int.castRingHom ℝ)).comp (X * Polynomial.C (Real.sqrt 2))).eval x
-        * Real.exp (-x ^ 2 / (2 * ((1 : ℝ≥0) : ℝ)))
+        * Real.exp (-(x - 0) ^ 2 / (2 * ((1 : ℝ≥0) : ℝ)))
         / Real.sqrt ((n.factorial : ℝ) * Real.sqrt Real.pi) := by
     funext x
-    rw [hermiteFunction_def, ← eval_hermiteComp,
-      show (-(x ^ 2 / 2) : ℝ) = -x ^ 2 / (2 * ((1 : ℝ≥0) : ℝ)) by push_cast; ring]
+    rw [hermiteFunction_def, ← eval_hermiteComp, exponent_one x]
   rw [hfun]
   exact h.div_const _
 
@@ -141,16 +88,5 @@ theorem memLp_two_hermiteFunction (n : ℕ) : MemLp (hermiteFunction n) 2 volume
     rw [hermiteFunction_def, div_pow, mul_pow, henv, eval_pow, eval_hermiteComp]
   rw [hfun]
   exact (integrable_eval_mul_exp_neg_sq _).div_const _
-
-/-! ## Parity of the Hermite functions -/
-
-/-- **Target A2 (parity).** `ψₙ(-x) = (-1)ⁿ ψₙ(x)`: the Gaussian envelope `exp(-x²/2)` is even and
-the polynomial factor `Hₙ(x√2)` carries the parity of `Hₙ` (`aeval_neg_hermite`). -/
-theorem hermiteFunction_neg (n : ℕ) (x : ℝ) :
-    hermiteFunction n (-x) = (-1) ^ n * hermiteFunction n x := by
-  have h1 : (-x) * Real.sqrt 2 = -(x * Real.sqrt 2) := by ring
-  have h2 : ((-x) ^ 2 / 2 : ℝ) = x ^ 2 / 2 := by ring
-  rw [hermiteFunction_def, hermiteFunction_def, h1, aeval_neg_hermite, h2]
-  ring
 
 end TauCeti

--- a/TauCeti/Probability/Distributions/Gaussian/HermiteMemLp.lean
+++ b/TauCeti/Probability/Distributions/Gaussian/HermiteMemLp.lean
@@ -5,32 +5,25 @@ Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Claude
 -/
-public import Mathlib.Probability.Distributions.Gaussian.Real
 public import Mathlib.RingTheory.Polynomial.Hermite.Basic
 public import Mathlib.Analysis.RCLike.Basic
-public import TauCeti.MeasureTheory.Function.PolynomialMemLp
+public import TauCeti.Probability.Distributions.Gaussian.PolynomialMemLp
 
 /-!
-# `L²` membership of polynomials and Hermite polynomials against a Gaussian measure
+# `L²` membership of the Hermite polynomials against a Gaussian measure
 
-This file proves that a real polynomial, evaluated pointwise, is square-integrable against a real
-Gaussian measure `gaussianReal μ v`, and specializes this to the probabilists' Hermite polynomials
-`Polynomial.hermite n`.  The Hermite statement `memLp_hermite_gaussianReal` is target **A3′** of the
-`OrthogonalL2Bases` roadmap: the variance-general `L²` membership of the normalized Hermite
-polynomials `Hₙ / √(n!)` under `gaussianReal 0 v`, the membership the Gaussian Hermite Hilbert-basis
-construction consumes for its `MemLp` obligations.
+This file specializes the generic Gaussian/polynomial `L²` membership of
+`TauCeti.Probability.Distributions.Gaussian.PolynomialMemLp` to the probabilists' Hermite
+polynomials `Polynomial.hermite n`.  The Hermite statement `memLp_hermite_gaussianReal` is target
+**A3′** of the `OrthogonalL2Bases` roadmap: the variance-general `L²` membership of the normalized
+Hermite polynomials `Hₙ / √(n!)` under `gaussianReal 0 v`, the membership the Gaussian Hermite
+Hilbert-basis construction consumes for its `MemLp` obligations.
 
-The argument factors through the family-agnostic `memLp_two_eval_of_forall_integrable_pow`
-(`TauCeti.MeasureTheory.Function.PolynomialMemLp`), which holds for **any** reference measure on `ℝ`
-all of whose polynomial moments are finite.  The Gaussian instance supplies that moment hypothesis
-`∀ k, Integrable (x ↦ xᵏ)` from Mathlib's `memLp_id_gaussianReal'` (all moments of a real Gaussian
-are finite).  The
-scalar-generic cast to `[RCLike 𝕜]` (needed because the roadmap's bases are stated over `Lp 𝕜 2 μ`
-uniformly for `𝕜 = ℝ` and `𝕜 = ℂ`) reuses Mathlib's `MemLp.ofReal`, rewriting the `algebraMap ℝ 𝕜`
-cast to `RCLike.ofReal`.
+The scalar-generic cast to `[RCLike 𝕜]` (needed because the roadmap's bases are stated over
+`Lp 𝕜 2 μ` uniformly for `𝕜 = ℝ` and `𝕜 = ℂ`) reuses Mathlib's `MemLp.ofReal`, rewriting the
+`algebraMap ℝ 𝕜` cast to `RCLike.ofReal`.
 
-Mathlib's `memLp_id_gaussianReal'` (Fernique), `memLp_two_iff_integrable_sq`, Gaussian density API,
-and the `Polynomial` evaluation API are consumed, not re-derived.
+The `Polynomial` evaluation API and `MemLp.ofReal` are consumed, not re-derived.
 -/
 
 public section
@@ -40,53 +33,6 @@ namespace TauCeti
 open MeasureTheory ProbabilityTheory Polynomial
 
 open scoped NNReal ENNReal
-
-/-! ## The Gaussian instance -/
-
-/-- Every polynomial moment of a real Gaussian measure is finite: `x ↦ xⁿ` is integrable against
-`gaussianReal μ v`.  This is `memLp_id_gaussianReal'` (all moments finite) unwound to plain
-integrability of the power. -/
-theorem integrable_pow_gaussianReal (μ : ℝ) (v : ℝ≥0) (n : ℕ) :
-    Integrable (fun x : ℝ => x ^ n) (gaussianReal μ v) := by
-  have h : Integrable (fun x : ℝ => ‖x‖ ^ n) (gaussianReal μ v) := by
-    simpa using
-      (memLp_id_gaussianReal' (μ := μ) (v := v) (n : ℝ≥0∞) (by simp)).integrable_norm_pow'
-  rw [← integrable_norm_iff (continuous_pow n).aestronglyMeasurable]
-  simpa only [norm_pow] using h
-
-/-- A real polynomial is square-integrable against every real Gaussian measure. -/
-theorem memLp_two_eval_gaussianReal (μ : ℝ) (v : ℝ≥0) (q : ℝ[X]) :
-    MemLp (fun x : ℝ => q.eval x) 2 (gaussianReal μ v) :=
-  memLp_two_eval_of_forall_integrable_pow (fun k => integrable_pow_gaussianReal μ v k) q
-
-/-! ## Polynomial times a Gaussian envelope -/
-
-/-- A real polynomial evaluated pointwise, times a Gaussian envelope
-`exp (-(x - μ)²/(2v))` of positive variance `v` centered at `μ`, is Lebesgue-integrable.
-Transported from the polynomial's integrability against the Gaussian measure `gaussianReal μ v`
-across `gaussianReal μ v = volume.withDensity (gaussianPDF μ v)`. -/
-theorem integrable_eval_mul_gaussianEnvelope (μ : ℝ) (q : ℝ[X]) {w : ℝ≥0} (hw : w ≠ 0) :
-    Integrable (fun x : ℝ => q.eval x * Real.exp (-(x - μ) ^ 2 / (2 * (w : ℝ)))) volume := by
-  have hint : Integrable (fun x : ℝ => q.eval x) (gaussianReal μ w) :=
-    integrable_eval_of_forall_integrable_pow (fun k => integrable_pow_gaussianReal μ w k) q
-  rw [gaussianReal_of_var_ne_zero μ hw,
-    integrable_withDensity_iff (measurable_gaussianPDF μ w)
-      (ae_of_all _ fun _ => ENNReal.ofReal_lt_top)] at hint
-  simp only [toReal_gaussianPDF] at hint
-  have hw' : (0 : ℝ) < (w : ℝ) := NNReal.coe_pos.mpr (zero_lt_iff.mpr hw)
-  have hsqrt : Real.sqrt (2 * Real.pi * (w : ℝ)) ≠ 0 :=
-    (Real.sqrt_pos.mpr (by positivity)).ne'
-  refine (hint.const_mul (Real.sqrt (2 * Real.pi * (w : ℝ)))).congr (ae_of_all _ fun x => ?_)
-  simp only [gaussianPDFReal_def]
-  field_simp
-
-/-- A real polynomial times the envelope `exp(-x²)` is Lebesgue-integrable — the centered
-`v = ½` case of `integrable_eval_mul_gaussianEnvelope`. -/
-theorem integrable_eval_mul_exp_neg_sq (q : ℝ[X]) :
-    Integrable (fun x : ℝ => q.eval x * Real.exp (-x ^ 2)) volume := by
-  have h := integrable_eval_mul_gaussianEnvelope 0 q (w := 2⁻¹) (by norm_num)
-  have he : (2 : ℝ) * ((2⁻¹ : ℝ≥0) : ℝ) = 1 := by push_cast; norm_num
-  simpa only [sub_zero, he, div_one] using h
 
 /-! ## Scalar-generic cast and the Hermite instance -/
 

--- a/TauCeti/Probability/Distributions/Gaussian/HermiteMemLp.lean
+++ b/TauCeti/Probability/Distributions/Gaussian/HermiteMemLp.lean
@@ -29,8 +29,8 @@ scalar-generic cast to `[RCLike 𝕜]` (needed because the roadmap's bases are s
 uniformly for `𝕜 = ℝ` and `𝕜 = ℂ`) reuses Mathlib's `MemLp.ofReal`, rewriting the `algebraMap ℝ 𝕜`
 cast to `RCLike.ofReal`.
 
-Mathlib's `memLp_id_gaussianReal'` (Fernique), `memLp_two_iff_integrable_sq`, and the `Polynomial`
-evaluation API are consumed, not re-derived.
+Mathlib's `memLp_id_gaussianReal'` (Fernique), `memLp_two_iff_integrable_sq`, Gaussian density API,
+and the `Polynomial` evaluation API are consumed, not re-derived.
 -/
 
 public section
@@ -58,6 +58,35 @@ theorem integrable_pow_gaussianReal (μ : ℝ) (v : ℝ≥0) (n : ℕ) :
 theorem memLp_two_eval_gaussianReal (μ : ℝ) (v : ℝ≥0) (q : ℝ[X]) :
     MemLp (fun x : ℝ => q.eval x) 2 (gaussianReal μ v) :=
   memLp_two_eval_of_forall_integrable_pow (fun k => integrable_pow_gaussianReal μ v k) q
+
+/-! ## Polynomial times a Gaussian envelope -/
+
+/-- A real polynomial evaluated pointwise, times a Gaussian envelope
+`exp (-(x - μ)²/(2v))` of positive variance `v` centered at `μ`, is Lebesgue-integrable.
+Transported from the polynomial's integrability against the Gaussian measure `gaussianReal μ v`
+across `gaussianReal μ v = volume.withDensity (gaussianPDF μ v)`. -/
+theorem integrable_eval_mul_gaussianEnvelope (μ : ℝ) (q : ℝ[X]) {w : ℝ≥0} (hw : w ≠ 0) :
+    Integrable (fun x : ℝ => q.eval x * Real.exp (-(x - μ) ^ 2 / (2 * (w : ℝ)))) volume := by
+  have hint : Integrable (fun x : ℝ => q.eval x) (gaussianReal μ w) :=
+    integrable_eval_of_forall_integrable_pow (fun k => integrable_pow_gaussianReal μ w k) q
+  rw [gaussianReal_of_var_ne_zero μ hw,
+    integrable_withDensity_iff (measurable_gaussianPDF μ w)
+      (ae_of_all _ fun _ => ENNReal.ofReal_lt_top)] at hint
+  simp only [toReal_gaussianPDF] at hint
+  have hw' : (0 : ℝ) < (w : ℝ) := NNReal.coe_pos.mpr (zero_lt_iff.mpr hw)
+  have hsqrt : Real.sqrt (2 * Real.pi * (w : ℝ)) ≠ 0 :=
+    (Real.sqrt_pos.mpr (by positivity)).ne'
+  refine (hint.const_mul (Real.sqrt (2 * Real.pi * (w : ℝ)))).congr (ae_of_all _ fun x => ?_)
+  simp only [gaussianPDFReal_def]
+  field_simp
+
+/-- A real polynomial times the envelope `exp(-x²)` is Lebesgue-integrable — the centered
+`v = ½` case of `integrable_eval_mul_gaussianEnvelope`. -/
+theorem integrable_eval_mul_exp_neg_sq (q : ℝ[X]) :
+    Integrable (fun x : ℝ => q.eval x * Real.exp (-x ^ 2)) volume := by
+  have h := integrable_eval_mul_gaussianEnvelope 0 q (w := 2⁻¹) (by norm_num)
+  have he : (2 : ℝ) * ((2⁻¹ : ℝ≥0) : ℝ) = 1 := by push_cast; norm_num
+  simpa only [sub_zero, he, div_one] using h
 
 /-! ## Scalar-generic cast and the Hermite instance -/
 

--- a/TauCeti/Probability/Distributions/Gaussian/PolynomialMemLp.lean
+++ b/TauCeti/Probability/Distributions/Gaussian/PolynomialMemLp.lean
@@ -1,0 +1,88 @@
+module
+
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Claude
+-/
+public import Mathlib.Probability.Distributions.Gaussian.Real
+public import TauCeti.MeasureTheory.Function.PolynomialMemLp
+
+/-!
+# Integrability and `L²` membership of polynomials against a Gaussian measure
+
+This file collects the family-agnostic facts that a real polynomial, evaluated pointwise, is
+integrable and square-integrable against a real Gaussian measure `gaussianReal μ v`, together with
+the companion statement that a polynomial times a Gaussian *envelope* `exp (-(x - μ)²/(2v))` is
+Lebesgue-integrable.  These hold for **any** `q : ℝ[X]` and feed the Hermite-specific `L²`
+membership in `TauCeti.Probability.Distributions.Gaussian.HermiteMemLp` and the Hermite-function
+integrability in `TauCeti.Analysis.SpecialFunctions.HermiteFunctionMemLp`.
+
+The `L²` argument factors through the family-agnostic `memLp_two_eval_of_forall_integrable_pow`
+(`TauCeti.MeasureTheory.Function.PolynomialMemLp`), which holds for any reference measure on `ℝ`
+all of whose polynomial moments are finite.  The Gaussian instance supplies that moment hypothesis
+`∀ k, Integrable (x ↦ xᵏ)` from Mathlib's `memLp_id_gaussianReal'` (all moments of a real Gaussian
+are finite).  The envelope statement transports the polynomial's integrability against the Gaussian
+measure across `gaussianReal μ v = volume.withDensity (gaussianPDF μ v)`.
+
+Mathlib's `memLp_id_gaussianReal'` (Fernique) and Gaussian density API
+(`gaussianReal_of_var_ne_zero`, `measurable_gaussianPDF`, `gaussianPDFReal_def`) are consumed, not
+re-derived.
+-/
+
+public section
+
+namespace TauCeti
+
+open MeasureTheory ProbabilityTheory Polynomial
+
+open scoped NNReal ENNReal
+
+/-! ## The Gaussian instance -/
+
+/-- Every polynomial moment of a real Gaussian measure is finite: `x ↦ xⁿ` is integrable against
+`gaussianReal μ v`.  This is `memLp_id_gaussianReal'` (all moments finite) unwound to plain
+integrability of the power. -/
+theorem integrable_pow_gaussianReal (μ : ℝ) (v : ℝ≥0) (n : ℕ) :
+    Integrable (fun x : ℝ => x ^ n) (gaussianReal μ v) := by
+  have h : Integrable (fun x : ℝ => ‖x‖ ^ n) (gaussianReal μ v) := by
+    simpa using
+      (memLp_id_gaussianReal' (μ := μ) (v := v) (n : ℝ≥0∞) (by simp)).integrable_norm_pow'
+  rw [← integrable_norm_iff (continuous_pow n).aestronglyMeasurable]
+  simpa only [norm_pow] using h
+
+/-- A real polynomial is square-integrable against every real Gaussian measure. -/
+theorem memLp_two_eval_gaussianReal (μ : ℝ) (v : ℝ≥0) (q : ℝ[X]) :
+    MemLp (fun x : ℝ => q.eval x) 2 (gaussianReal μ v) :=
+  memLp_two_eval_of_forall_integrable_pow (fun k => integrable_pow_gaussianReal μ v k) q
+
+/-! ## Polynomial times a Gaussian envelope -/
+
+/-- A real polynomial evaluated pointwise, times a Gaussian envelope
+`exp (-(x - μ)²/(2v))` of positive variance `v` centered at `μ`, is Lebesgue-integrable.
+Transported from the polynomial's integrability against the Gaussian measure `gaussianReal μ v`
+across `gaussianReal μ v = volume.withDensity (gaussianPDF μ v)`. -/
+theorem integrable_eval_mul_gaussianEnvelope (μ : ℝ) (q : ℝ[X]) {w : ℝ≥0} (hw : w ≠ 0) :
+    Integrable (fun x : ℝ => q.eval x * Real.exp (-(x - μ) ^ 2 / (2 * (w : ℝ)))) volume := by
+  have hint : Integrable (fun x : ℝ => q.eval x) (gaussianReal μ w) :=
+    integrable_eval_of_forall_integrable_pow (fun k => integrable_pow_gaussianReal μ w k) q
+  rw [gaussianReal_of_var_ne_zero μ hw,
+    integrable_withDensity_iff (measurable_gaussianPDF μ w)
+      (ae_of_all _ fun _ => ENNReal.ofReal_lt_top)] at hint
+  simp only [toReal_gaussianPDF] at hint
+  have hw' : (0 : ℝ) < (w : ℝ) := NNReal.coe_pos.mpr (zero_lt_iff.mpr hw)
+  have hsqrt : Real.sqrt (2 * Real.pi * (w : ℝ)) ≠ 0 :=
+    (Real.sqrt_pos.mpr (by positivity)).ne'
+  refine (hint.const_mul (Real.sqrt (2 * Real.pi * (w : ℝ)))).congr (ae_of_all _ fun x => ?_)
+  simp only [gaussianPDFReal_def]
+  field_simp
+
+/-- A real polynomial times the envelope `exp(-x²)` is Lebesgue-integrable — the centered
+`v = ½` case of `integrable_eval_mul_gaussianEnvelope`. -/
+theorem integrable_eval_mul_exp_neg_sq (q : ℝ[X]) :
+    Integrable (fun x : ℝ => q.eval x * Real.exp (-x ^ 2)) volume := by
+  have h := integrable_eval_mul_gaussianEnvelope 0 q (w := 2⁻¹) (by norm_num)
+  have he : (2 : ℝ) * ((2⁻¹ : ℝ≥0) : ℝ) = 1 := by push_cast; norm_num
+  simpa only [sub_zero, he, div_one] using h
+
+end TauCeti

--- a/TauCeti/RingTheory/Polynomial/Hermite/Derivative.lean
+++ b/TauCeti/RingTheory/Polynomial/Hermite/Derivative.lean
@@ -5,10 +5,11 @@ Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Claude
 -/
+public import Mathlib.Algebra.Polynomial.AlgebraMap
 public import Mathlib.RingTheory.Polynomial.Hermite.Basic
 
 /-!
-# Derivatives and the three-term recurrence of the probabilists' Hermite polynomials
+# Derivatives, recurrence, and parity of the probabilists' Hermite polynomials
 
 Mathlib's `Mathlib/RingTheory/Polynomial/Hermite/Basic.lean` defines `Polynomial.hermite` by the
 one-step recursion `hermite (n + 1) = X * hermite n - derivative (hermite n)` and develops its
@@ -27,8 +28,8 @@ inputs (target **A1**) of the `OrthogonalL2Bases` roadmap: the lowering identity
 content behind the weighted-pairing integration-by-parts recursion
 `∫ p · H_{n+1} · w = ∫ p' · Hₙ · w` and behind the Hermite generating function, and the three-term
 recurrence is the standard form `Hₙ₊₁ = X·Hₙ - n·Hₙ₋₁` that orthogonal-polynomial arguments
-consume. They mirror Mathlib's existing Hermite file and are stated in the `Polynomial` namespace as
-upstream candidates.
+consume. The parity theorem records `Hₙ(-x) = (-1)ⁿ Hₙ(x)` over any commutative ring. They mirror
+Mathlib's existing Hermite file and are stated in the `Polynomial` namespace as upstream candidates.
 -/
 
 public section
@@ -85,5 +86,29 @@ i.e. `H_{m+1} = X·H_m - m·H_{m-1}`. -/
 theorem _root_.Polynomial.hermite_add_two (n : ℕ) :
     hermite (n + 2) = X * hermite (n + 1) - (n + 1) • hermite n := by
   rw [hermite_succ (n + 1), derivative_hermite_succ]
+
+/-! ## Parity -/
+
+/-- **Parity of the Hermite polynomials.** `Hₙ(-x) = (-1)ⁿ Hₙ(x)` in any commutative ring: a
+coefficient of `hermite n` in degree `k` can be nonzero only when `n + k` is even
+(`Polynomial.coeff_hermite_of_odd_add`), so `k` and `n` share parity and `(-x)ᵏ = (-1)ⁿ xᵏ` on every
+surviving monomial. -/
+@[simp]
+theorem _root_.Polynomial.hermite_aeval_neg {R : Type*} [CommRing R] (n : ℕ) (x : R) :
+    aeval (-x) (hermite n) = (-1) ^ n * aeval x (hermite n) := by
+  rw [aeval_eq_sum_range, aeval_eq_sum_range, Finset.mul_sum]
+  apply Finset.sum_congr rfl
+  intro k _
+  by_cases hodd : Odd (n + k)
+  · rw [coeff_hermite_of_odd_add hodd]; simp
+  · rw [Nat.not_odd_iff_even] at hodd
+    rw [zsmul_eq_mul, zsmul_eq_mul]
+    have hpow : (-x) ^ k = (-1) ^ n * x ^ k := by
+      rcases Nat.even_or_odd n with hn | hn
+      · rw [Even.neg_pow ((Nat.even_add.mp hodd).mp hn), Even.neg_one_pow hn, one_mul]
+      · have hk : Odd k := Nat.not_even_iff_odd.mp fun hke =>
+          (Nat.not_even_iff_odd.mpr hn) ((Nat.even_add.mp hodd).mpr hke)
+        rw [Odd.neg_pow hk, Odd.neg_one_pow hn]; ring
+    rw [hpow]; ring
 
 end TauCeti


### PR DESCRIPTION
This PR extends the Hermite-function object API for the `OrthogonalL2Bases` roadmap (target **A2**, `TauCetiRoadmap/OrthogonalL2Bases/README.md` — the "regularity: `Continuous`, `ContDiff ℝ ⊤`, `MemLp _ 2 volume`" and "parity `ψₙ(-x)=(-1)ⁿψₙ(x)`" companion API) with the regularity facts the roadmap's **A3** basis construction consumes. It adds, for `ψₙ(x) = Hₙ(x√2) exp(-x²/2) / √(n!√π)` (`TauCeti.hermiteFunction`, landed in #747): `integrable_hermiteFunction` (`L¹`), `memLp_two_hermiteFunction` (`L²(volume)`, the membership `hermiteFunctionLp` needs to realize `ψₙ` as an `Lp` element), and `hermiteFunction_neg` (parity).

The analytic input is a single reusable engine `integrable_eval_mul_gaussianEnvelope`: a real polynomial times a Gaussian envelope `exp(-x²/(2v))` of any positive variance is Lebesgue-integrable, obtained by transporting the polynomial's integrability against `gaussianReal 0 v` (finite moments of all orders) across `gaussianReal 0 v = volume.withDensity (gaussianPDF 0 v)`. The `L²` case applies it to `Hₙ(·√2)²` with `v = ½` (envelope `exp(-x²)`), the `L¹` case with `v = 1`. Parity rests on `aeval_neg_hermite` (`Hₙ(-x) = (-1)ⁿ Hₙ(x)` in any commutative ring), immediate from Mathlib's `Polynomial.coeff_hermite_of_odd_add`.

It reuses this repo's `integrable_pow_gaussianReal` / `integrable_eval_of_forall_integrable_pow` (finite Gaussian moments) and Mathlib's `integrable_withDensity_iff`, `memLp_two_iff_integrable_sq`, and Gaussian density API (`gaussianReal_of_var_ne_zero`, `measurable_gaussianPDF`, `gaussianPDFReal_def`), rather than re-deriving them. No new mathematical scope beyond the roadmap target; one new file under `TauCeti/`, no `sorry`, axioms exactly `[propext, Classical.choice, Quot.sound]`.

<!--tauceti-target:v1 {"focus":"OrthogonalL2Bases","id":"hermite-function-memlp-parity"}-->

🤖 Prepared with Claude Code
