### PR TITLE
feat: add exchangeable path laws

### DIFF
--- a/TauCeti/Probability/Exchangeability/PathSpace/Law.lean
+++ b/TauCeti/Probability/Exchangeability/PathSpace/Law.lean
@@ -1,0 +1,141 @@
+module
+
+public import TauCeti.Probability.Exchangeability.FullyExchangeable
+import TauCeti.Probability.Exchangeability.PermutationExtension
+
+/-!
+# Exchangeable laws on path space
+
+This file adds the path-law formulation of full exchangeability for measures on `ℕ → α`.
+The process-level definitions in `TauCeti.Probability.Exchangeability.Basic` remain the main
+user-facing API for stochastic processes; `ExchangeableLaw` names the equivalent path-space
+viewpoint needed by π-system, invariant-σ-algebra, and shift arguments.
+
+The bridges here realize the Layer 0 roadmap item asking for process-level ↔ path-law bridges
+in both directions. They reuse the existing `FullyExchangeable` path-law bridge from
+`FullyExchangeable.lean`; no measure-theoretic infrastructure is vendored.
+-/
+
+public section
+
+noncomputable section
+
+open MeasureTheory
+
+namespace TauCeti
+
+namespace Probability
+
+variable {Ω α : Type*} [MeasurableSpace Ω] [MeasurableSpace α]
+
+/-- A measure on one-sided path space is exchangeable if it is invariant under every
+permutation of the time coordinate. -/
+def ExchangeableLaw (ρ : Measure (ℕ → α)) : Prop :=
+  ∀ π : Equiv.Perm ℕ, ρ.map (permReindex (α := α) π) = ρ
+
+/-- Constructor for `ExchangeableLaw` from the defining map invariance. -/
+theorem ExchangeableLaw.intro {ρ : Measure (ℕ → α)}
+    (h : ∀ π : Equiv.Perm ℕ, ρ.map (permReindex (α := α) π) = ρ) :
+    ExchangeableLaw ρ :=
+  h
+
+/-- Simp normal form for `ExchangeableLaw`. -/
+@[simp]
+theorem exchangeableLaw_iff {ρ : Measure (ℕ → α)} :
+    ExchangeableLaw ρ ↔ ∀ π : Equiv.Perm ℕ, ρ.map (permReindex (α := α) π) = ρ :=
+  Iff.rfl
+
+/-- The defining invariance of an exchangeable path law. -/
+theorem ExchangeableLaw.map_permReindex {ρ : Measure (ℕ → α)} (hρ : ExchangeableLaw ρ)
+    (π : Equiv.Perm ℕ) :
+    ρ.map (permReindex (α := α) π) = ρ :=
+  hρ π
+
+/-- Reindexing by a time permutation preserves an exchangeable path law. -/
+theorem ExchangeableLaw.measurePreserving_permReindex {ρ : Measure (ℕ → α)}
+    (hρ : ExchangeableLaw ρ) (π : Equiv.Perm ℕ) :
+    MeasurePreserving (permReindex (α := α) π) ρ ρ :=
+  ⟨measurable_reindex π, hρ.map_permReindex π⟩
+
+/-- Path-law exchangeability is equivalently measure preservation by every time permutation. -/
+theorem exchangeableLaw_iff_forall_measurePreserving_permReindex {ρ : Measure (ℕ → α)} :
+    ExchangeableLaw ρ ↔
+      ∀ π : Equiv.Perm ℕ, MeasurePreserving (permReindex (α := α) π) ρ ρ := by
+  constructor
+  · intro hρ π
+    exact hρ.measurePreserving_permReindex π
+  · intro hρ π
+    exact (hρ π).map_eq
+
+/-- The prefix marginal after a path-space permutation is the corresponding finite-dimensional
+coordinate marginal. -/
+theorem map_permReindex_prefixProj (ρ : Measure (ℕ → α)) (π : Equiv.Perm ℕ) (n : ℕ) :
+    (ρ.map (permReindex (α := α) π)).map (prefixProj α n) =
+      ρ.map (fun x : ℕ → α => fun i : Fin n => x (π i.val)) := by
+  have hperm :
+      permReindex (α := α) π = (fun x : ℕ → α => fun k => x (π k)) := by
+    funext x k
+    rw [permReindex_apply]
+  rw [hperm, Measure.map_map (measurable_prefixProj n) (measurable_reindex π)]
+  rfl
+
+/-- The prefix marginal of an exchangeable path law is invariant under permutations of the
+finite prefix. -/
+theorem ExchangeableLaw.map_prefixProj_perm {ρ : Measure (ℕ → α)} (hρ : ExchangeableLaw ρ)
+    (n : ℕ) (σ : Equiv.Perm (Fin n)) :
+    ρ.map (fun x : ℕ → α => fun i : Fin n => x (σ i).val) =
+      ρ.map (prefixProj α n) := by
+  obtain ⟨π, hπ⟩ := Equiv.Perm.exists_extending_pair (fun i : Fin n => i.val)
+    (fun i : Fin n => (σ i).val) Fin.val_injective
+    (fun _ _ h => σ.injective (Fin.val_injective h))
+  have hidx :
+      (fun x : ℕ → α => fun i : Fin n => x (π i.val)) =
+        fun x : ℕ → α => fun i : Fin n => x (σ i).val := by
+    funext x i
+    rw [hπ i]
+  calc
+    ρ.map (fun x : ℕ → α => fun i : Fin n => x (σ i).val)
+        = ρ.map (fun x : ℕ → α => fun i : Fin n => x (π i.val)) := by
+          rw [← hidx]
+    _ = (ρ.map (permReindex (α := α) π)).map (prefixProj α n) := by
+          rw [map_permReindex_prefixProj]
+    _ = ρ.map (prefixProj α n) := by rw [hρ.map_permReindex π]
+
+/-- A fully exchangeable process has an exchangeable path law. -/
+theorem FullyExchangeable.exchangeableLaw_pathLaw {μ : Measure Ω} {X : ℕ → Ω → α}
+    (hX : FullyExchangeable μ X) (hX_meas : ∀ i, AEMeasurable (X i) μ) :
+    ExchangeableLaw (pathLaw μ X) := by
+  intro π
+  exact hX.map_permReindex_pathLaw hX_meas π
+
+/-- A process is fully exchangeable iff its path law is an exchangeable path-space measure. -/
+theorem fullyExchangeable_iff_exchangeableLaw_pathLaw (μ : Measure Ω) {X : ℕ → Ω → α}
+    (hX_meas : ∀ i, AEMeasurable (X i) μ) :
+    FullyExchangeable μ X ↔ ExchangeableLaw (pathLaw μ X) := by
+  rw [fullyExchangeable_iff_forall_map_permReindex_pathLaw μ hX_meas]
+  rfl
+
+/-- For finite laws, finite exchangeability of a process is equivalent to exchangeability of
+its path law. -/
+theorem exchangeable_iff_exchangeableLaw_pathLaw {μ : Measure Ω} {X : ℕ → Ω → α}
+    [IsFiniteMeasure μ] (hX_meas : ∀ i, AEMeasurable (X i) μ) :
+    Exchangeable μ X ↔ ExchangeableLaw (pathLaw μ X) := by
+  rw [exchangeable_iff_fullyExchangeable hX_meas,
+    fullyExchangeable_iff_exchangeableLaw_pathLaw μ hX_meas]
+
+/-- A process whose path law is exchangeable is fully exchangeable. -/
+theorem fullyExchangeable_of_exchangeableLaw_pathLaw {μ : Measure Ω} {X : ℕ → Ω → α}
+    (hX_meas : ∀ i, AEMeasurable (X i) μ) (hρ : ExchangeableLaw (pathLaw μ X)) :
+    FullyExchangeable μ X :=
+  (fullyExchangeable_iff_exchangeableLaw_pathLaw μ hX_meas).2 hρ
+
+/-- A process whose path law is exchangeable is finitely exchangeable under a finite base law. -/
+theorem exchangeable_of_exchangeableLaw_pathLaw {μ : Measure Ω} {X : ℕ → Ω → α}
+    [IsFiniteMeasure μ] (hX_meas : ∀ i, AEMeasurable (X i) μ)
+    (hρ : ExchangeableLaw (pathLaw μ X)) :
+    Exchangeable μ X :=
+  (exchangeable_iff_exchangeableLaw_pathLaw hX_meas).2 hρ
+
+end Probability
+
+end TauCeti

--- a/TauCeti/Probability/Exchangeability/PathSpace/Law.lean
+++ b/TauCeti/Probability/Exchangeability/PathSpace/Law.lean
@@ -1,7 +1,8 @@
 module
 
-public import TauCeti.Probability.Exchangeability.FullyExchangeable
-import TauCeti.Probability.Exchangeability.PermutationExtension
+public import TauCeti.Probability.Exchangeability.Basic
+public import TauCeti.Probability.Exchangeability.PermutationExtension
+public import Mathlib.Dynamics.Ergodic.MeasurePreserving
 
 /-!
 # Exchangeable laws on path space
@@ -11,9 +12,11 @@ The process-level definitions in `TauCeti.Probability.Exchangeability.Basic` rem
 user-facing API for stochastic processes; `ExchangeableLaw` names the equivalent path-space
 viewpoint needed by π-system, invariant-σ-algebra, and shift arguments.
 
-The bridges here realize the Layer 0 roadmap item asking for process-level ↔ path-law bridges
-in both directions. They reuse the existing `FullyExchangeable` path-law bridge from
-`FullyExchangeable.lean`; no measure-theoretic infrastructure is vendored.
+Everything here is pure path space: it depends only on the coordinate-reindexing and prefix
+machinery of `Basic` and the finite permutation extension of `PermutationExtension`. The
+process-level ↔ path-law bridges live in
+`TauCeti.Probability.Exchangeability.PathSpace.LawBridge`, which imports both this file and
+`FullyExchangeable`. No measure-theoretic infrastructure is vendored.
 -/
 
 public section
@@ -26,7 +29,7 @@ namespace TauCeti
 
 namespace Probability
 
-variable {Ω α : Type*} [MeasurableSpace Ω] [MeasurableSpace α]
+variable {α : Type*} [MeasurableSpace α]
 
 /-- A measure on one-sided path space is exchangeable if it is invariant under every
 permutation of the time coordinate. -/
@@ -67,74 +70,48 @@ theorem exchangeableLaw_iff_forall_measurePreserving_permReindex {ρ : Measure (
   · intro hρ π
     exact (hρ π).map_eq
 
-/-- The prefix marginal after a path-space permutation is the corresponding finite-dimensional
-coordinate marginal. -/
-theorem map_permReindex_prefixProj (ρ : Measure (ℕ → α)) (π : Equiv.Perm ℕ) (n : ℕ) :
-    (ρ.map (permReindex (α := α) π)).map (prefixProj α n) =
-      ρ.map (fun x : ℕ → α => fun i : Fin n => x (π i.val)) := by
-  have hperm :
-      permReindex (α := α) π = (fun x : ℕ → α => fun k => x (π k)) := by
-    funext x k
-    rw [permReindex_apply]
-  rw [hperm, Measure.map_map (measurable_prefixProj n) (measurable_reindex π)]
+/-- The first-`n` prefix marginal of a path-space measure reindexed by `φ : ℕ → ℕ` is its
+finite coordinate marginal along `i ↦ φ i`. This only uses coordinate reindexing, so it holds
+for an arbitrary function `φ`, not just a permutation. -/
+theorem map_reindex_prefixProj (ρ : Measure (ℕ → α)) (φ : ℕ → ℕ) (n : ℕ) :
+    (ρ.map (fun x : ℕ → α => fun k => x (φ k))).map (prefixProj α n) =
+      ρ.map (fun x : ℕ → α => fun i : Fin n => x (φ i.val)) := by
+  rw [Measure.map_map (measurable_prefixProj n) (measurable_reindex φ)]
   rfl
 
+/-- The finite marginal of an exchangeable path law along any injective selection
+`k : Fin n → ℕ` equals its first-`n` prefix marginal: an exchangeable law has the same
+finite-dimensional distribution along every injective finite selection of coordinates. -/
+theorem ExchangeableLaw.map_prefixProj_of_injective {ρ : Measure (ℕ → α)}
+    (hρ : ExchangeableLaw ρ) {n : ℕ} (k : Fin n → ℕ) (hk : Function.Injective k) :
+    ρ.map (fun x : ℕ → α => fun i : Fin n => x (k i)) =
+      ρ.map (prefixProj α n) := by
+  obtain ⟨π, hπ⟩ := Equiv.Perm.exists_extending_pair (fun i : Fin n => i.val) k
+    Fin.val_injective hk
+  have hidx :
+      (fun x : ℕ → α => fun i : Fin n => x (π i.val)) =
+        fun x : ℕ → α => fun i : Fin n => x (k i) := by
+    funext x i
+    rw [hπ i]
+  have hperm : (permReindex (α := α) π) = (fun x : ℕ → α => fun k => x (π k)) := by
+    funext x k
+    rw [permReindex_apply]
+  calc
+    ρ.map (fun x : ℕ → α => fun i : Fin n => x (k i))
+        = ρ.map (fun x : ℕ → α => fun i : Fin n => x (π i.val)) := by rw [← hidx]
+    _ = (ρ.map (permReindex (α := α) π)).map (prefixProj α n) := by
+          rw [hperm, map_reindex_prefixProj]
+    _ = ρ.map (prefixProj α n) := by rw [hρ.map_permReindex π]
+
 /-- The prefix marginal of an exchangeable path law is invariant under permutations of the
-finite prefix. -/
+finite prefix, the special case of `ExchangeableLaw.map_prefixProj_of_injective` along the
+injective selection `i ↦ (σ i).val`. -/
 theorem ExchangeableLaw.map_prefixProj_perm {ρ : Measure (ℕ → α)} (hρ : ExchangeableLaw ρ)
     (n : ℕ) (σ : Equiv.Perm (Fin n)) :
     ρ.map (fun x : ℕ → α => fun i : Fin n => x (σ i).val) =
-      ρ.map (prefixProj α n) := by
-  obtain ⟨π, hπ⟩ := Equiv.Perm.exists_extending_pair (fun i : Fin n => i.val)
-    (fun i : Fin n => (σ i).val) Fin.val_injective
+      ρ.map (prefixProj α n) :=
+  hρ.map_prefixProj_of_injective (fun i : Fin n => (σ i).val)
     (fun _ _ h => σ.injective (Fin.val_injective h))
-  have hidx :
-      (fun x : ℕ → α => fun i : Fin n => x (π i.val)) =
-        fun x : ℕ → α => fun i : Fin n => x (σ i).val := by
-    funext x i
-    rw [hπ i]
-  calc
-    ρ.map (fun x : ℕ → α => fun i : Fin n => x (σ i).val)
-        = ρ.map (fun x : ℕ → α => fun i : Fin n => x (π i.val)) := by
-          rw [← hidx]
-    _ = (ρ.map (permReindex (α := α) π)).map (prefixProj α n) := by
-          rw [map_permReindex_prefixProj]
-    _ = ρ.map (prefixProj α n) := by rw [hρ.map_permReindex π]
-
-/-- A fully exchangeable process has an exchangeable path law. -/
-theorem FullyExchangeable.exchangeableLaw_pathLaw {μ : Measure Ω} {X : ℕ → Ω → α}
-    (hX : FullyExchangeable μ X) (hX_meas : ∀ i, AEMeasurable (X i) μ) :
-    ExchangeableLaw (pathLaw μ X) := by
-  intro π
-  exact hX.map_permReindex_pathLaw hX_meas π
-
-/-- A process is fully exchangeable iff its path law is an exchangeable path-space measure. -/
-theorem fullyExchangeable_iff_exchangeableLaw_pathLaw (μ : Measure Ω) {X : ℕ → Ω → α}
-    (hX_meas : ∀ i, AEMeasurable (X i) μ) :
-    FullyExchangeable μ X ↔ ExchangeableLaw (pathLaw μ X) := by
-  rw [fullyExchangeable_iff_forall_map_permReindex_pathLaw μ hX_meas]
-  rfl
-
-/-- For finite laws, finite exchangeability of a process is equivalent to exchangeability of
-its path law. -/
-theorem exchangeable_iff_exchangeableLaw_pathLaw {μ : Measure Ω} {X : ℕ → Ω → α}
-    [IsFiniteMeasure μ] (hX_meas : ∀ i, AEMeasurable (X i) μ) :
-    Exchangeable μ X ↔ ExchangeableLaw (pathLaw μ X) := by
-  rw [exchangeable_iff_fullyExchangeable hX_meas,
-    fullyExchangeable_iff_exchangeableLaw_pathLaw μ hX_meas]
-
-/-- A process whose path law is exchangeable is fully exchangeable. -/
-theorem fullyExchangeable_of_exchangeableLaw_pathLaw {μ : Measure Ω} {X : ℕ → Ω → α}
-    (hX_meas : ∀ i, AEMeasurable (X i) μ) (hρ : ExchangeableLaw (pathLaw μ X)) :
-    FullyExchangeable μ X :=
-  (fullyExchangeable_iff_exchangeableLaw_pathLaw μ hX_meas).2 hρ
-
-/-- A process whose path law is exchangeable is finitely exchangeable under a finite base law. -/
-theorem exchangeable_of_exchangeableLaw_pathLaw {μ : Measure Ω} {X : ℕ → Ω → α}
-    [IsFiniteMeasure μ] (hX_meas : ∀ i, AEMeasurable (X i) μ)
-    (hρ : ExchangeableLaw (pathLaw μ X)) :
-    Exchangeable μ X :=
-  (exchangeable_iff_exchangeableLaw_pathLaw hX_meas).2 hρ
 
 end Probability
 

--- a/TauCeti/Probability/Exchangeability/PathSpace/LawBridge.lean
+++ b/TauCeti/Probability/Exchangeability/PathSpace/LawBridge.lean
@@ -1,0 +1,66 @@
+module
+
+public import TauCeti.Probability.Exchangeability.FullyExchangeable
+public import TauCeti.Probability.Exchangeability.PathSpace.Law
+
+/-!
+# Process-level ↔ path-law bridges for exchangeability
+
+This file connects the process-level `FullyExchangeable`/`Exchangeable` predicates with the
+path-space `ExchangeableLaw` predicate: a process is fully exchangeable exactly when its
+`pathLaw` is an exchangeable path-space law, and (under a finite base law) finite exchangeability
+is the same statement.
+
+The bridges realize the Layer 0 roadmap item asking for process-level ↔ path-law bridges in both
+directions. They reuse the existing `FullyExchangeable` path-law bridge from
+`FullyExchangeable.lean`; no measure-theoretic infrastructure is vendored.
+-/
+
+public section
+
+noncomputable section
+
+open MeasureTheory
+
+namespace TauCeti
+
+namespace Probability
+
+variable {Ω α : Type*} [MeasurableSpace Ω] [MeasurableSpace α]
+
+/-- A fully exchangeable process has an exchangeable path law. -/
+theorem FullyExchangeable.exchangeableLaw_pathLaw {μ : Measure Ω} {X : ℕ → Ω → α}
+    (hX : FullyExchangeable μ X) (hX_meas : ∀ i, AEMeasurable (X i) μ) :
+    ExchangeableLaw (pathLaw μ X) :=
+  ExchangeableLaw.intro fun π => hX.map_permReindex_pathLaw hX_meas π
+
+/-- A process is fully exchangeable iff its path law is an exchangeable path-space measure. -/
+theorem fullyExchangeable_iff_exchangeableLaw_pathLaw (μ : Measure Ω) {X : ℕ → Ω → α}
+    (hX_meas : ∀ i, AEMeasurable (X i) μ) :
+    FullyExchangeable μ X ↔ ExchangeableLaw (pathLaw μ X) := by
+  rw [fullyExchangeable_iff_forall_map_permReindex_pathLaw μ hX_meas, exchangeableLaw_iff]
+
+/-- For finite laws, finite exchangeability of a process is equivalent to exchangeability of
+its path law. -/
+theorem exchangeable_iff_exchangeableLaw_pathLaw {μ : Measure Ω} {X : ℕ → Ω → α}
+    [IsFiniteMeasure μ] (hX_meas : ∀ i, AEMeasurable (X i) μ) :
+    Exchangeable μ X ↔ ExchangeableLaw (pathLaw μ X) := by
+  rw [exchangeable_iff_fullyExchangeable hX_meas,
+    fullyExchangeable_iff_exchangeableLaw_pathLaw μ hX_meas]
+
+/-- A process whose path law is exchangeable is fully exchangeable. -/
+theorem fullyExchangeable_of_exchangeableLaw_pathLaw {μ : Measure Ω} {X : ℕ → Ω → α}
+    (hX_meas : ∀ i, AEMeasurable (X i) μ) (hρ : ExchangeableLaw (pathLaw μ X)) :
+    FullyExchangeable μ X :=
+  (fullyExchangeable_iff_exchangeableLaw_pathLaw μ hX_meas).2 hρ
+
+/-- A process whose path law is exchangeable is finitely exchangeable under a finite base law. -/
+theorem exchangeable_of_exchangeableLaw_pathLaw {μ : Measure Ω} {X : ℕ → Ω → α}
+    [IsFiniteMeasure μ] (hX_meas : ∀ i, AEMeasurable (X i) μ)
+    (hρ : ExchangeableLaw (pathLaw μ X)) :
+    Exchangeable μ X :=
+  (exchangeable_iff_exchangeableLaw_pathLaw hX_meas).2 hρ
+
+end Probability
+
+end TauCeti


### PR DESCRIPTION
This PR adds `ExchangeableLaw`, the named path-space formulation of full exchangeability for measures on `ℕ → α`, with map and measure-preserving characterizations, finite-prefix marginal invariance, and bridges saying a process is fully exchangeable exactly when its `pathLaw` is an exchangeable path-space law. It advances `TauCetiRoadmap/Exchangeability/README.md`, Layer 0, specifically the API warning and build item requiring “process-level ↔ path-law bridges in both directions” so users can move between stochastic-process statements and path-law/invariant-σ-algebra arguments.

I chose this as the lowest-hanging distinct Exchangeability target after checking open and recently merged PRs: the current library already has `Exchangeable`, `FullyExchangeable`, `Contractable`, finite-marginal uniqueness, coordinatewise pushforward closure, shift stationarity, `exchangeableSigma`, product-kernel adapters, and several de Finetti-route lemmas, while the path-space law viewpoint itself was still unnamed. This PR stays at that small bridge layer and does not start a new proof route.

No Mathlib infrastructure is vendored. The implementation reuses Tau Ceti’s existing `permReindex`, `pathLaw`, `prefixProj`, `fullyExchangeable_iff_forall_map_permReindex_pathLaw`, and `exchangeable_iff_fullyExchangeable`, plus Mathlib’s `Measure.map_map`, `MeasurePreserving`, and `Equiv.Perm.exists_extending_pair`.

`lake exe cache get` completed with `No files to download` and `Already decompressed 8609 file(s)`. `lake build` completed with `Build completed successfully (4581 jobs).` `lake exe axioms` completed with `axioms: audited 8547 TauCeti declaration(s); all within the allowlist [propext, Classical.choice, Quot.sound].`

<!--tauceti-target:v1 {"focus":"Exchangeability","id":"exchangeable-law"}-->

🤖 Prepared with Codex
