### PR TITLE
feat: add boundary maximum principle

### DIFF
--- a/TauCeti/Analysis/InnerProductSpace/LaplacianMaximumPrinciple.lean
+++ b/TauCeti/Analysis/InnerProductSpace/LaplacianMaximumPrinciple.lean
@@ -41,7 +41,7 @@ open InnerProductSpace Laplacian Topology
 
 /-- If every interior point of a compact set is forbidden from being a local maximum, then a
 continuous function on the compact set has a maximum point on the frontier. -/
-theorem exists_mem_frontier_isMaxOn_of_forall_mem_interior_not_isLocalMax {X β : Type*}
+private theorem exists_mem_frontier_isMaxOn_of_forall_mem_interior_not_isLocalMax {X β : Type*}
     [TopologicalSpace X] [TopologicalSpace β] [LinearOrder β] [ClosedIciTopology β] {K : Set X}
     (hK : IsCompact K) (hne : K.Nonempty) {f : X → β} (hcont : ContinuousOn f K)
     (hnot : ∀ ⦃x⦄, x ∈ interior K → ¬ IsLocalMax f x) :
@@ -55,7 +55,7 @@ theorem exists_mem_frontier_isMaxOn_of_forall_mem_interior_not_isLocalMax {X β 
 
 /-- If every interior point of a compact set is forbidden from being a local minimum, then a
 continuous function on the compact set has a minimum point on the frontier. -/
-theorem exists_mem_frontier_isMinOn_of_forall_mem_interior_not_isLocalMin {X β : Type*}
+private theorem exists_mem_frontier_isMinOn_of_forall_mem_interior_not_isLocalMin {X β : Type*}
     [TopologicalSpace X] [TopologicalSpace β] [LinearOrder β] [ClosedIicTopology β] {K : Set X}
     (hK : IsCompact K) (hne : K.Nonempty) {f : X → β} (hcont : ContinuousOn f K)
     (hnot : ∀ ⦃x⦄, x ∈ interior K → ¬ IsLocalMin f x) :
@@ -92,14 +92,8 @@ theorem exists_mem_frontier_isMinOn_of_laplacian_neg {K : Set E} (hK : IsCompact
     (hcd : ∀ ⦃x⦄, x ∈ interior K → ContDiffAt ℝ 2 f x)
     (hlap : ∀ ⦃x⦄, x ∈ interior K → Δ f x < 0) :
     ∃ x ∈ frontier K, IsMinOn f K x := by
-  obtain ⟨x, hxfrontier, hxmax⟩ :=
-    exists_mem_frontier_isMaxOn_of_laplacian_pos hK hne (hcont.neg)
-      (fun {x} hxint => (hcd (x := x) hxint).neg)
-      (fun {x} hxint => by simpa [laplacian_neg] using neg_pos.2 (hlap (x := x) hxint))
-  refine ⟨x, hxfrontier, ?_⟩
-  intro y hyK
-  have hneg : -f y ≤ -f x := by simpa using hxmax hyK
-  exact neg_le_neg_iff.mp hneg
+  exact exists_mem_frontier_isMinOn_of_forall_mem_interior_not_isLocalMin hK hne hcont
+    fun {x} hxint => not_isLocalMin_of_laplacian_neg (hcd (x := x) hxint) (hlap (x := x) hxint)
 
 end TauCeti
 

--- a/TauCeti/Analysis/InnerProductSpace/LaplacianMaximumPrinciple.lean
+++ b/TauCeti/Analysis/InnerProductSpace/LaplacianMaximumPrinciple.lean
@@ -1,0 +1,94 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+module
+
+public import Mathlib.Topology.Order.Compact
+public import TauCeti.Analysis.InnerProductSpace.LaplacianLocalExtr
+
+/-!
+# Boundary maximum principles for strictly subharmonic functions
+
+`TauCeti.Analysis.InnerProductSpace.LaplacianLocalExtr` proves the local second-derivative
+obstruction: a `C²` scalar function with `0 < Δ f x` has no local maximum at `x`.  This file
+turns that local statement into the compact-set boundary form used as the first maximum-principle
+handoff in the PDE roadmap.
+
+If a continuous function on a compact set has positive Laplacian at every interior point where
+the second derivative is available, then some maximum point lies on the frontier.  The dual
+minimum statement holds for negative Laplacian.
+
+## Main declarations
+
+* `TauCeti.exists_mem_frontier_isMaxOn_of_laplacian_pos`: a strictly subharmonic function on
+  the interior of a compact set attains a maximum on the frontier.
+* `TauCeti.exists_mem_frontier_isMinOn_of_laplacian_neg`: a strictly superharmonic function on
+  the interior of a compact set attains a minimum on the frontier.
+-/
+
+public section
+
+noncomputable section
+
+namespace TauCeti
+
+open InnerProductSpace Laplacian Topology
+
+variable {E : Type*} [NormedAddCommGroup E] [InnerProductSpace ℝ E] [FiniteDimensional ℝ E]
+
+omit [InnerProductSpace ℝ E] [FiniteDimensional ℝ E] in
+/-- A maximum over a set becomes a local maximum when the maximizing point is an interior point
+of the set. -/
+theorem IsMaxOn.isLocalMax_of_mem_interior {f : E → ℝ} {s : Set E} {x : E}
+    (hmax : IsMaxOn f s x) (hx : x ∈ interior s) :
+    IsLocalMax f x :=
+  hmax.isLocalMax (mem_interior_iff_mem_nhds.mp hx)
+
+omit [InnerProductSpace ℝ E] [FiniteDimensional ℝ E] in
+/-- A minimum over a set becomes a local minimum when the minimizing point is an interior point
+of the set. -/
+theorem IsMinOn.isLocalMin_of_mem_interior {f : E → ℝ} {s : Set E} {x : E}
+    (hmin : IsMinOn f s x) (hx : x ∈ interior s) :
+    IsLocalMin f x :=
+  hmin.isLocalMin (mem_interior_iff_mem_nhds.mp hx)
+
+/-- **Boundary maximum principle for strictly subharmonic functions.**
+
+Let `K` be compact and nonempty. If `f` is continuous on `K`, is `C²` at every interior point,
+and satisfies `0 < Δ f x` throughout `interior K`, then some maximum point of `f` on `K` lies on
+`frontier K`. -/
+theorem exists_mem_frontier_isMaxOn_of_laplacian_pos {K : Set E} (hK : IsCompact K)
+    (hne : K.Nonempty) {f : E → ℝ} (hcont : ContinuousOn f K)
+    (hcd : ∀ ⦃x⦄, x ∈ interior K → ContDiffAt ℝ 2 f x)
+    (hlap : ∀ ⦃x⦄, x ∈ interior K → 0 < Δ f x) :
+    ∃ x ∈ frontier K, IsMaxOn f K x := by
+  obtain ⟨x, hxK, hxmax⟩ := hK.exists_isMaxOn hne hcont
+  refine ⟨x, ?_, hxmax⟩
+  rw [frontier]
+  refine ⟨subset_closure hxK, ?_⟩
+  intro hxint
+  exact not_isLocalMax_of_laplacian_pos (hcd hxint) (hlap hxint)
+    (IsMaxOn.isLocalMax_of_mem_interior hxmax hxint)
+
+/-- **Boundary minimum principle for strictly superharmonic functions.**
+
+Let `K` be compact and nonempty. If `f` is continuous on `K`, is `C²` at every interior point,
+and satisfies `Δ f x < 0` throughout `interior K`, then some minimum point of `f` on `K` lies on
+`frontier K`. -/
+theorem exists_mem_frontier_isMinOn_of_laplacian_neg {K : Set E} (hK : IsCompact K)
+    (hne : K.Nonempty) {f : E → ℝ} (hcont : ContinuousOn f K)
+    (hcd : ∀ ⦃x⦄, x ∈ interior K → ContDiffAt ℝ 2 f x)
+    (hlap : ∀ ⦃x⦄, x ∈ interior K → Δ f x < 0) :
+    ∃ x ∈ frontier K, IsMinOn f K x := by
+  obtain ⟨x, hxK, hxmin⟩ := hK.exists_isMinOn hne hcont
+  refine ⟨x, ?_, hxmin⟩
+  rw [frontier]
+  refine ⟨subset_closure hxK, ?_⟩
+  intro hxint
+  exact not_isLocalMin_of_laplacian_neg (hcd hxint) (hlap hxint)
+    (IsMinOn.isLocalMin_of_mem_interior hxmin hxint)
+
+end TauCeti
+
+end

--- a/TauCeti/Analysis/InnerProductSpace/LaplacianMaximumPrinciple.lean
+++ b/TauCeti/Analysis/InnerProductSpace/LaplacianMaximumPrinciple.lean
@@ -37,22 +37,6 @@ open InnerProductSpace Laplacian Topology
 
 variable {E : Type*} [NormedAddCommGroup E] [InnerProductSpace ℝ E] [FiniteDimensional ℝ E]
 
-omit [InnerProductSpace ℝ E] [FiniteDimensional ℝ E] in
-/-- A maximum over a set becomes a local maximum when the maximizing point is an interior point
-of the set. -/
-theorem IsMaxOn.isLocalMax_of_mem_interior {f : E → ℝ} {s : Set E} {x : E}
-    (hmax : IsMaxOn f s x) (hx : x ∈ interior s) :
-    IsLocalMax f x :=
-  hmax.isLocalMax (mem_interior_iff_mem_nhds.mp hx)
-
-omit [InnerProductSpace ℝ E] [FiniteDimensional ℝ E] in
-/-- A minimum over a set becomes a local minimum when the minimizing point is an interior point
-of the set. -/
-theorem IsMinOn.isLocalMin_of_mem_interior {f : E → ℝ} {s : Set E} {x : E}
-    (hmin : IsMinOn f s x) (hx : x ∈ interior s) :
-    IsLocalMin f x :=
-  hmin.isLocalMin (mem_interior_iff_mem_nhds.mp hx)
-
 /-- **Boundary maximum principle for strictly subharmonic functions.**
 
 Let `K` be compact and nonempty. If `f` is continuous on `K`, is `C²` at every interior point,
@@ -69,7 +53,7 @@ theorem exists_mem_frontier_isMaxOn_of_laplacian_pos {K : Set E} (hK : IsCompact
   refine ⟨subset_closure hxK, ?_⟩
   intro hxint
   exact not_isLocalMax_of_laplacian_pos (hcd hxint) (hlap hxint)
-    (IsMaxOn.isLocalMax_of_mem_interior hxmax hxint)
+    (hxmax.isLocalMax (mem_interior_iff_mem_nhds.mp hxint))
 
 /-- **Boundary minimum principle for strictly superharmonic functions.**
 
@@ -87,7 +71,7 @@ theorem exists_mem_frontier_isMinOn_of_laplacian_neg {K : Set E} (hK : IsCompact
   refine ⟨subset_closure hxK, ?_⟩
   intro hxint
   exact not_isLocalMin_of_laplacian_neg (hcd hxint) (hlap hxint)
-    (IsMinOn.isLocalMin_of_mem_interior hxmin hxint)
+    (hxmin.isLocalMin (mem_interior_iff_mem_nhds.mp hxint))
 
 end TauCeti
 

--- a/TauCeti/Analysis/InnerProductSpace/LaplacianMaximumPrinciple.lean
+++ b/TauCeti/Analysis/InnerProductSpace/LaplacianMaximumPrinciple.lean
@@ -15,6 +15,10 @@ obstruction: a `C²` scalar function with `0 < Δ f x` has no local maximum at `
 turns that local statement into the compact-set boundary form used as the first maximum-principle
 handoff in the PDE roadmap.
 
+The compact-to-boundary handoff uses Mathlib's `IsCompact.exists_isMaxOn` /
+`IsCompact.exists_isMinOn` extreme-value APIs and `IsMaxOn.isLocalMax` /
+`IsMinOn.isLocalMin` localization APIs.
+
 If a continuous function on a compact set has positive Laplacian at every interior point where
 the second derivative is available, then some maximum point lies on the frontier.  The dual
 minimum statement holds for negative Laplacian.
@@ -35,6 +39,34 @@ namespace TauCeti
 
 open InnerProductSpace Laplacian Topology
 
+/-- If every interior point of a compact set is forbidden from being a local maximum, then a
+continuous function on the compact set has a maximum point on the frontier. -/
+theorem exists_mem_frontier_isMaxOn_of_forall_mem_interior_not_isLocalMax {X β : Type*}
+    [TopologicalSpace X] [TopologicalSpace β] [LinearOrder β] [ClosedIciTopology β] {K : Set X}
+    (hK : IsCompact K) (hne : K.Nonempty) {f : X → β} (hcont : ContinuousOn f K)
+    (hnot : ∀ ⦃x⦄, x ∈ interior K → ¬ IsLocalMax f x) :
+    ∃ x ∈ frontier K, IsMaxOn f K x := by
+  obtain ⟨x, hxK, hxmax⟩ := hK.exists_isMaxOn hne hcont
+  refine ⟨x, ?_, hxmax⟩
+  rw [frontier]
+  refine ⟨subset_closure hxK, ?_⟩
+  intro hxint
+  exact hnot hxint (hxmax.isLocalMax (mem_interior_iff_mem_nhds.mp hxint))
+
+/-- If every interior point of a compact set is forbidden from being a local minimum, then a
+continuous function on the compact set has a minimum point on the frontier. -/
+theorem exists_mem_frontier_isMinOn_of_forall_mem_interior_not_isLocalMin {X β : Type*}
+    [TopologicalSpace X] [TopologicalSpace β] [LinearOrder β] [ClosedIicTopology β] {K : Set X}
+    (hK : IsCompact K) (hne : K.Nonempty) {f : X → β} (hcont : ContinuousOn f K)
+    (hnot : ∀ ⦃x⦄, x ∈ interior K → ¬ IsLocalMin f x) :
+    ∃ x ∈ frontier K, IsMinOn f K x := by
+  obtain ⟨x, hxK, hxmin⟩ := hK.exists_isMinOn hne hcont
+  refine ⟨x, ?_, hxmin⟩
+  rw [frontier]
+  refine ⟨subset_closure hxK, ?_⟩
+  intro hxint
+  exact hnot hxint (hxmin.isLocalMin (mem_interior_iff_mem_nhds.mp hxint))
+
 variable {E : Type*} [NormedAddCommGroup E] [InnerProductSpace ℝ E] [FiniteDimensional ℝ E]
 
 /-- **Boundary maximum principle for strictly subharmonic functions.**
@@ -47,13 +79,8 @@ theorem exists_mem_frontier_isMaxOn_of_laplacian_pos {K : Set E} (hK : IsCompact
     (hcd : ∀ ⦃x⦄, x ∈ interior K → ContDiffAt ℝ 2 f x)
     (hlap : ∀ ⦃x⦄, x ∈ interior K → 0 < Δ f x) :
     ∃ x ∈ frontier K, IsMaxOn f K x := by
-  obtain ⟨x, hxK, hxmax⟩ := hK.exists_isMaxOn hne hcont
-  refine ⟨x, ?_, hxmax⟩
-  rw [frontier]
-  refine ⟨subset_closure hxK, ?_⟩
-  intro hxint
-  exact not_isLocalMax_of_laplacian_pos (hcd hxint) (hlap hxint)
-    (hxmax.isLocalMax (mem_interior_iff_mem_nhds.mp hxint))
+  exact exists_mem_frontier_isMaxOn_of_forall_mem_interior_not_isLocalMax hK hne hcont
+    fun {x} hxint => not_isLocalMax_of_laplacian_pos (hcd (x := x) hxint) (hlap (x := x) hxint)
 
 /-- **Boundary minimum principle for strictly superharmonic functions.**
 
@@ -65,13 +92,14 @@ theorem exists_mem_frontier_isMinOn_of_laplacian_neg {K : Set E} (hK : IsCompact
     (hcd : ∀ ⦃x⦄, x ∈ interior K → ContDiffAt ℝ 2 f x)
     (hlap : ∀ ⦃x⦄, x ∈ interior K → Δ f x < 0) :
     ∃ x ∈ frontier K, IsMinOn f K x := by
-  obtain ⟨x, hxK, hxmin⟩ := hK.exists_isMinOn hne hcont
-  refine ⟨x, ?_, hxmin⟩
-  rw [frontier]
-  refine ⟨subset_closure hxK, ?_⟩
-  intro hxint
-  exact not_isLocalMin_of_laplacian_neg (hcd hxint) (hlap hxint)
-    (hxmin.isLocalMin (mem_interior_iff_mem_nhds.mp hxint))
+  obtain ⟨x, hxfrontier, hxmax⟩ :=
+    exists_mem_frontier_isMaxOn_of_laplacian_pos hK hne (hcont.neg)
+      (fun {x} hxint => (hcd (x := x) hxint).neg)
+      (fun {x} hxint => by simpa [laplacian_neg] using neg_pos.2 (hlap (x := x) hxint))
+  refine ⟨x, hxfrontier, ?_⟩
+  intro y hyK
+  have hneg : -f y ≤ -f x := by simpa using hxmax hyK
+  exact neg_le_neg_iff.mp hneg
 
 end TauCeti
 


### PR DESCRIPTION
This PR adds the compact-set boundary maximum principle for strictly subharmonic scalar functions and the dual minimum principle for strictly superharmonic functions: if a continuous function on a nonempty compact set has positive (respectively negative) Laplacian throughout the interior, then one of its extrema over the compact set is attained on the frontier. It advances `TauCetiRoadmap/PDE/README.md`, Lane C item 13, “The weak and strong maximum principles for `Δ`,” by packaging the first boundary-extremum handoff from the already-merged local Laplacian extremum obstruction.

I chose this as the lowest-hanging distinct PDE target after checking open and recently merged PRs: current PDE work on `main` already covers the Lane D energy-form stack, while existing Lane C support has only the local second-derivative obstruction to interior extrema. This PR stays at the compact-set scalar Laplacian level and does not attempt the full weak or strong maximum principle.

No Mathlib infrastructure is vendored. The implementation reuses Mathlib’s compact extreme-value theorem (`IsCompact.exists_isMaxOn` / `exists_isMinOn`), Mathlib’s `IsMaxOn.isLocalMax` / `IsMinOn.isLocalMin` localization API, and Tau Ceti’s existing `not_isLocalMax_of_laplacian_pos` / `not_isLocalMin_of_laplacian_neg`.

<!--tauceti-target:v1 {"focus":"PDE","id":"strictly-subharmonic-boundary-maximum"}-->

🤖 Prepared with Codex
