### PR TITLE
feat: add winding number reversal

### DIFF
--- a/TauCeti/Analysis/Contour/CauchyPrincipalValue.lean
+++ b/TauCeti/Analysis/Contour/CauchyPrincipalValue.lean
@@ -58,6 +58,8 @@ versus `MeromorphicOn` (on a set).
 * `HasCauchyPVAt.of_avoidance` — if `γ` avoids `z₀` on `[a, b]` and the integrand is integrable
   there, the principal value is the ordinary integral (`cauchyPVExistsAt_of_avoidance` is the
   existence form).
+* `HasCauchyPVAt.symm`, `CauchyPVExistsAt.symm`, `cauchyPVAt_symm` — reversing the interval
+  orientation negates the single-point principal value.
 * `HasCauchyPVAt.concat` — the principal values on `[a, b]` and `[b, c]` add
   (`CauchyPVExistsAt.concat` is the existence form).
 
@@ -317,6 +319,32 @@ theorem CauchyPVExistsAt.sum {ι : Type*} {γ : ℝ → ℂ} {a b : ℝ} {z₀ :
     obtain ⟨Lj, hLj⟩ := h j (Finset.mem_insert_self j s)
     obtain ⟨Ls, hLs⟩ := ih fun i hi => h i (Finset.mem_insert_of_mem hi)
     exact ⟨Lj + Ls, by simpa only [Finset.sum_insert hj] using hLj.add hLs⟩
+
+/-- Reversing the interval orientation negates a single-point Cauchy principal value. -/
+theorem HasCauchyPVAt.symm {γ : ℝ → ℂ} {a b : ℝ} {f : ℂ → ℂ} {z₀ L : ℂ}
+    (h : HasCauchyPVAt γ a b f z₀ L) :
+    HasCauchyPVAt γ b a f z₀ (-L) := by
+  refine HasCauchyPVAt.intro ?_ ?_
+  · filter_upwards [h.eventually_intervalIntegrable] with ε hε
+    exact hε.symm
+  · refine Filter.Tendsto.congr (fun ε => ?_) h.tendsto.neg
+    exact (intervalIntegral.integral_symm (f :=
+      fun t => if ‖γ t - z₀‖ > ε then f (γ t) * deriv γ t else 0) a b).symm
+
+/-- Existence of a single-point Cauchy principal value is invariant under reversing the interval
+orientation. -/
+theorem CauchyPVExistsAt.symm {γ : ℝ → ℂ} {a b : ℝ} {f : ℂ → ℂ} {z₀ : ℂ}
+    (h : CauchyPVExistsAt γ a b f z₀) :
+    CauchyPVExistsAt γ b a f z₀ :=
+  let ⟨_, hL⟩ := cauchyPVExistsAt_iff.mp h
+  cauchyPVExistsAt_iff.mpr ⟨_, hL.symm⟩
+
+/-- Value form of `HasCauchyPVAt.symm`: if the single-point principal value exists on `[a, b]`,
+then the value on `[b, a]` is its negative. -/
+theorem cauchyPVAt_symm {γ : ℝ → ℂ} {a b : ℝ} {f : ℂ → ℂ} {z₀ : ℂ}
+    (h : CauchyPVExistsAt γ a b f z₀) :
+    cauchyPVAt γ b a f z₀ = -cauchyPVAt γ a b f z₀ :=
+  h.hasCauchyPVAt_cauchyPVAt.symm.cauchyPVAt_eq
 
 /-- Existence form of `HasCauchyPVAt.concat`. -/
 theorem CauchyPVExistsAt.concat {γ : ℝ → ℂ} {a b c : ℝ} {f : ℂ → ℂ} {z₀ : ℂ}

--- a/TauCeti/Analysis/Contour/CauchyPrincipalValueOn.lean
+++ b/TauCeti/Analysis/Contour/CauchyPrincipalValueOn.lean
@@ -60,6 +60,8 @@ of `f` (which fails at an on-curve singularity), never silently identifying the 
 * `HasCauchyPV.unique`, `cauchyPV`, `HasCauchyPV.cauchyPV_eq`, `cauchyPV_zero`,
   `CauchyPVExists.hasCauchyPV_cauchyPV` — the value is well-defined (independent of the witnessing
   set), so `cauchyPV γ a b f` names it (junk value `0` when none exists).
+* `HasCauchyPV.symm`, `CauchyPVExists.symm`, `cauchyPV_symm` — reversing the interval orientation
+  negates the set-level principal value.
 * `HasCauchyPV.add`, `HasCauchyPV.sum` (and their `CauchyPVExists` forms) — additivity in `f`;
   reconciling the summands' *different* excision sets on their union needs a `Measurable γ`
   hypothesis, unlike the excision-set-preserving operations above.
@@ -469,6 +471,33 @@ theorem CauchyPVExists.hasCauchyPV_cauchyPV {γ : ℝ → ℂ} {a b : ℝ} {f : 
   obtain ⟨v, hv⟩ := h
   rw [hv.cauchyPV_eq]
   exact hv
+
+/-- Reversing the interval orientation negates a set-level Cauchy principal value. -/
+theorem HasCauchyPV.symm {γ : ℝ → ℂ} {a b : ℝ} {f : ℂ → ℂ} {v : ℂ}
+    (h : HasCauchyPV γ a b f v) :
+    HasCauchyPV γ b a f (-v) := by
+  obtain ⟨S, hint, htend⟩ := hasCauchyPV_iff.mp h
+  refine HasCauchyPV.intro S ?_ ?_
+  · filter_upwards [hint] with ε hε
+    exact hε.symm
+  · refine Filter.Tendsto.congr (fun ε => ?_) htend.neg
+    exact (intervalIntegral.integral_symm (f :=
+      fun t => if ∃ s ∈ S, ‖γ t - s‖ ≤ ε then 0 else f (γ t) * deriv γ t) a b).symm
+
+/-- Existence of a set-level Cauchy principal value is invariant under reversing the interval
+orientation. -/
+theorem CauchyPVExists.symm {γ : ℝ → ℂ} {a b : ℝ} {f : ℂ → ℂ}
+    (h : CauchyPVExists γ a b f) :
+    CauchyPVExists γ b a f :=
+  let ⟨_, hv⟩ := cauchyPVExists_iff.mp h
+  cauchyPVExists_iff.mpr ⟨_, hv.symm⟩
+
+/-- Value form of `HasCauchyPV.symm`: if the set-level principal value exists on `[a, b]`, then
+the value on `[b, a]` is its negative. -/
+theorem cauchyPV_symm {γ : ℝ → ℂ} {a b : ℝ} {f : ℂ → ℂ}
+    (h : CauchyPVExists γ a b f) :
+    cauchyPV γ b a f = -cauchyPV γ a b f :=
+  h.hasCauchyPV_cauchyPV.symm.cauchyPV_eq
 
 /-- Enlarging the excision set preserves interval-integrability of the truncated integrand: the
 extra excision at `S'` only zeroes the integrand on the measurable set `γ ⁻¹' ⋃ s ∈ S', closedBall

--- a/TauCeti/Analysis/Contour/WindingNumberReverse.lean
+++ b/TauCeti/Analysis/Contour/WindingNumberReverse.lean
@@ -5,7 +5,6 @@ Authors: Chris Birkbeck
 -/
 module
 
-public import TauCeti.Analysis.Contour.CauchyPrincipalValueOn
 public import TauCeti.Analysis.Contour.NullHomologous
 
 /-!

--- a/TauCeti/Analysis/Contour/WindingNumberReverse.lean
+++ b/TauCeti/Analysis/Contour/WindingNumberReverse.lean
@@ -1,0 +1,143 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Chris Birkbeck
+-/
+module
+
+public import TauCeti.Analysis.Contour.CauchyPrincipalValueOn
+public import TauCeti.Analysis.Contour.NullHomologous
+
+/-!
+# Orientation reversal for contour principal values and winding numbers
+
+This file records the basic orientation-reversal API for the Cauchy principal values used by the
+contour-integration roadmap and for the generalized winding number. Reversing the interval
+orientation sends each truncated contour integral to its negative, so both the single-point and
+set-level principal values change sign; the same is therefore true for
+`Contour.windingNumber`.
+
+These lemmas are bookkeeping for the roadmap's curve and cycle layer. Cycles are oriented formal
+combinations of curves, and finite decompositions of curves into avoiding pieces and model sectors
+need both concatenation and orientation reversal.
+
+## Main results
+
+* `Contour.HasCauchyPVAt.symm`, `Contour.cauchyPVAt_symm` — reversal for the pointwise principal
+  value.
+* `Contour.HasCauchyPV.symm`, `Contour.cauchyPV_symm` — reversal for the set-level principal value.
+* `Contour.windingNumber_symm` — the generalized winding number changes sign when the interval is
+  reversed.
+* `Contour.IsNullHomologous.symm`, `Contour.IsNullHomologous.symm_of_avoidance` — null-homology is
+  preserved by reversing orientation, under the same honest principal-value existence hypotheses
+  used elsewhere in the winding-number API.
+
+## Provenance
+
+This is routine API around the Hungerbühler--Wasem generalized winding number from the contour
+integration roadmap; no formal source is vendored.
+-/
+
+public section
+
+noncomputable section
+
+open Filter Topology
+
+namespace TauCeti.Contour
+
+variable {γ : ℝ → ℂ} {a b : ℝ} {f : ℂ → ℂ} {z₀ L v : ℂ} {Ω : Set ℂ}
+
+/-- Reversing the interval orientation negates a single-point Cauchy principal value. -/
+theorem HasCauchyPVAt.symm (h : HasCauchyPVAt γ a b f z₀ L) :
+    HasCauchyPVAt γ b a f z₀ (-L) := by
+  refine HasCauchyPVAt.intro ?_ ?_
+  · filter_upwards [h.eventually_intervalIntegrable] with ε hε
+    exact hε.symm
+  · refine Filter.Tendsto.congr (fun ε => ?_) h.tendsto.neg
+    exact (intervalIntegral.integral_symm (f :=
+      fun t => if ‖γ t - z₀‖ > ε then f (γ t) * deriv γ t else 0) a b).symm
+
+/-- Existence of a single-point Cauchy principal value is invariant under reversing the interval
+orientation. -/
+theorem CauchyPVExistsAt.symm (h : CauchyPVExistsAt γ a b f z₀) :
+    CauchyPVExistsAt γ b a f z₀ :=
+  let ⟨_, hL⟩ := cauchyPVExistsAt_iff.mp h
+  cauchyPVExistsAt_iff.mpr ⟨_, hL.symm⟩
+
+/-- Value form of `HasCauchyPVAt.symm`: if the single-point principal value exists on `[a, b]`,
+then the value on `[b, a]` is its negative. -/
+theorem cauchyPVAt_symm (h : CauchyPVExistsAt γ a b f z₀) :
+    cauchyPVAt γ b a f z₀ = -cauchyPVAt γ a b f z₀ :=
+  h.hasCauchyPVAt_cauchyPVAt.symm.cauchyPVAt_eq
+
+/-- Reversing the interval orientation negates a set-level Cauchy principal value. -/
+theorem HasCauchyPV.symm (h : HasCauchyPV γ a b f v) :
+    HasCauchyPV γ b a f (-v) := by
+  obtain ⟨S, hint, htend⟩ := hasCauchyPV_iff.mp h
+  refine HasCauchyPV.intro S ?_ ?_
+  · filter_upwards [hint] with ε hε
+    exact hε.symm
+  · refine Filter.Tendsto.congr (fun ε => ?_) htend.neg
+    exact (intervalIntegral.integral_symm (f :=
+      fun t => if ∃ s ∈ S, ‖γ t - s‖ ≤ ε then 0 else f (γ t) * deriv γ t) a b).symm
+
+/-- Existence of a set-level Cauchy principal value is invariant under reversing the interval
+orientation. -/
+theorem CauchyPVExists.symm (h : CauchyPVExists γ a b f) :
+    CauchyPVExists γ b a f :=
+  let ⟨_, hv⟩ := cauchyPVExists_iff.mp h
+  cauchyPVExists_iff.mpr ⟨_, hv.symm⟩
+
+/-- Value form of `HasCauchyPV.symm`: if the set-level principal value exists on `[a, b]`, then
+the value on `[b, a]` is its negative. -/
+theorem cauchyPV_symm (h : CauchyPVExists γ a b f) :
+    cauchyPV γ b a f = -cauchyPV γ a b f :=
+  h.hasCauchyPV_cauchyPV.symm.cauchyPV_eq
+
+/-- The kernel integrand used to define the generalized winding number about `z₀`. This local
+abbreviation keeps the orientation-reversal statements readable. -/
+local notation "κ[" z "]" => (fun w : ℂ => (w - z)⁻¹)
+
+/-- The generalized winding number changes sign when the interval orientation is reversed,
+provided the principal value defining the original winding number exists. -/
+theorem windingNumber_symm (h : CauchyPVExistsAt γ a b κ[z₀] z₀) :
+    windingNumber γ b a z₀ = -windingNumber γ a b z₀ := by
+  rw [windingNumber_eq_of_hasCauchyPVAt h.hasCauchyPVAt_cauchyPVAt.symm,
+    windingNumber_eq_of_hasCauchyPVAt h.hasCauchyPVAt_cauchyPVAt]
+  ring
+
+/-- Pointwise vanishing of a winding number is preserved by reversing the interval orientation,
+under the principal-value existence hypothesis that makes the two winding-number values honest. -/
+theorem windingNumber_eq_zero_symm (hzero : windingNumber γ a b z₀ = 0)
+    (hpv : CauchyPVExistsAt γ a b κ[z₀] z₀) :
+    windingNumber γ b a z₀ = 0 := by
+  rw [windingNumber_symm hpv, hzero, neg_zero]
+
+/-- Null-homology is preserved by reversing orientation, provided the pointwise principal values
+defining the exterior winding numbers exist. -/
+theorem IsNullHomologous.symm (h : IsNullHomologous γ a b Ω)
+    (hpv : ∀ z ∉ Ω, CauchyPVExistsAt γ a b κ[z] z) :
+    IsNullHomologous γ b a Ω := by
+  rw [isNullHomologous_iff] at h ⊢
+  intro z hz
+  exact windingNumber_eq_zero_symm (h z hz) (hpv z hz)
+
+/-- Null-homology is preserved by reversing orientation in the ordinary avoided-pole case. If the
+curve lies in `Ω`, every exterior point is avoided, so the required principal values are ordinary
+integrals. -/
+theorem IsNullHomologous.symm_of_avoidance (h : IsNullHomologous γ a b Ω)
+    (hγ : ∀ t ∈ Set.uIcc a b, γ t ∈ Ω)
+    (hcont : ContinuousOn γ (Set.uIcc a b))
+    (hint : ∀ z ∉ Ω,
+      IntervalIntegrable (fun t => (γ t - z)⁻¹ * deriv γ t) MeasureTheory.volume a b) :
+    IsNullHomologous γ b a Ω := by
+  refine h.symm ?_
+  intro z hz
+  refine cauchyPVExistsAt_of_avoidance hcont ?_ (hint z hz)
+  intro t ht htz
+  exact hz (htz ▸ hγ t ht)
+
+end TauCeti.Contour
+
+end

--- a/TauCeti/Analysis/Contour/WindingNumberReverse.lean
+++ b/TauCeti/Analysis/Contour/WindingNumberReverse.lean
@@ -9,13 +9,11 @@ public import TauCeti.Analysis.Contour.CauchyPrincipalValueOn
 public import TauCeti.Analysis.Contour.NullHomologous
 
 /-!
-# Orientation reversal for contour principal values and winding numbers
+# Orientation reversal for contour winding numbers
 
-This file records the basic orientation-reversal API for the Cauchy principal values used by the
-contour-integration roadmap and for the generalized winding number. Reversing the interval
-orientation sends each truncated contour integral to its negative, so both the single-point and
-set-level principal values change sign; the same is therefore true for
-`Contour.windingNumber`.
+This file records the basic orientation-reversal API for the generalized winding number.
+Reversing the interval orientation negates the single-point Cauchy principal value defining
+`Contour.windingNumber`, so the winding number itself changes sign.
 
 These lemmas are bookkeeping for the roadmap's curve and cycle layer. Cycles are oriented formal
 combinations of curves, and finite decompositions of curves into avoiding pieces and model sectors
@@ -23,9 +21,6 @@ need both concatenation and orientation reversal.
 
 ## Main results
 
-* `Contour.HasCauchyPVAt.symm`, `Contour.cauchyPVAt_symm` — reversal for the pointwise principal
-  value.
-* `Contour.HasCauchyPV.symm`, `Contour.cauchyPV_symm` — reversal for the set-level principal value.
 * `Contour.windingNumber_symm` — the generalized winding number changes sign when the interval is
   reversed.
 * `Contour.IsNullHomologous.symm`, `Contour.IsNullHomologous.symm_of_avoidance` — null-homology is
@@ -46,54 +41,7 @@ open Filter Topology
 
 namespace TauCeti.Contour
 
-variable {γ : ℝ → ℂ} {a b : ℝ} {f : ℂ → ℂ} {z₀ L v : ℂ} {Ω : Set ℂ}
-
-/-- Reversing the interval orientation negates a single-point Cauchy principal value. -/
-theorem HasCauchyPVAt.symm (h : HasCauchyPVAt γ a b f z₀ L) :
-    HasCauchyPVAt γ b a f z₀ (-L) := by
-  refine HasCauchyPVAt.intro ?_ ?_
-  · filter_upwards [h.eventually_intervalIntegrable] with ε hε
-    exact hε.symm
-  · refine Filter.Tendsto.congr (fun ε => ?_) h.tendsto.neg
-    exact (intervalIntegral.integral_symm (f :=
-      fun t => if ‖γ t - z₀‖ > ε then f (γ t) * deriv γ t else 0) a b).symm
-
-/-- Existence of a single-point Cauchy principal value is invariant under reversing the interval
-orientation. -/
-theorem CauchyPVExistsAt.symm (h : CauchyPVExistsAt γ a b f z₀) :
-    CauchyPVExistsAt γ b a f z₀ :=
-  let ⟨_, hL⟩ := cauchyPVExistsAt_iff.mp h
-  cauchyPVExistsAt_iff.mpr ⟨_, hL.symm⟩
-
-/-- Value form of `HasCauchyPVAt.symm`: if the single-point principal value exists on `[a, b]`,
-then the value on `[b, a]` is its negative. -/
-theorem cauchyPVAt_symm (h : CauchyPVExistsAt γ a b f z₀) :
-    cauchyPVAt γ b a f z₀ = -cauchyPVAt γ a b f z₀ :=
-  h.hasCauchyPVAt_cauchyPVAt.symm.cauchyPVAt_eq
-
-/-- Reversing the interval orientation negates a set-level Cauchy principal value. -/
-theorem HasCauchyPV.symm (h : HasCauchyPV γ a b f v) :
-    HasCauchyPV γ b a f (-v) := by
-  obtain ⟨S, hint, htend⟩ := hasCauchyPV_iff.mp h
-  refine HasCauchyPV.intro S ?_ ?_
-  · filter_upwards [hint] with ε hε
-    exact hε.symm
-  · refine Filter.Tendsto.congr (fun ε => ?_) htend.neg
-    exact (intervalIntegral.integral_symm (f :=
-      fun t => if ∃ s ∈ S, ‖γ t - s‖ ≤ ε then 0 else f (γ t) * deriv γ t) a b).symm
-
-/-- Existence of a set-level Cauchy principal value is invariant under reversing the interval
-orientation. -/
-theorem CauchyPVExists.symm (h : CauchyPVExists γ a b f) :
-    CauchyPVExists γ b a f :=
-  let ⟨_, hv⟩ := cauchyPVExists_iff.mp h
-  cauchyPVExists_iff.mpr ⟨_, hv.symm⟩
-
-/-- Value form of `HasCauchyPV.symm`: if the set-level principal value exists on `[a, b]`, then
-the value on `[b, a]` is its negative. -/
-theorem cauchyPV_symm (h : CauchyPVExists γ a b f) :
-    cauchyPV γ b a f = -cauchyPV γ a b f :=
-  h.hasCauchyPV_cauchyPV.symm.cauchyPV_eq
+variable {γ : ℝ → ℂ} {a b : ℝ} {z₀ : ℂ} {Ω : Set ℂ}
 
 /-- The kernel integrand used to define the generalized winding number about `z₀`. This local
 abbreviation keeps the orientation-reversal statements readable. -/


### PR DESCRIPTION
This PR adds orientation-reversal API for ContourIntegration principal values and generalized winding numbers: reversing `[a, b]` to `[b, a]` negates both `HasCauchyPVAt` and set-level `HasCauchyPV` values, negates `windingNumber`, and preserves `IsNullHomologous` under the same pointwise principal-value existence hypotheses used by the existing concatenation API. It advances `TauCetiRoadmap/ContourIntegration/README.md`, Layer 0, specifically “Curves, immersions, cycles” where cycles are finite formal `ℤ`-combinations of closed curves, and supplies a clean prerequisite for Layer 1 HW Proposition 2.2 finite-decomposition bookkeeping alongside the already-merged winding-number concatenation API.

I chose this as the lowest-hanging distinct ContourIntegration prerequisite after checking open and recently merged PRs: `main` already has the principal-value predicates, generalized winding number, null-homology API, model-sector computations, arc FTC, residue, circle residue theorem, argument principle, piecewise-`C¹` curves, and winding-number concatenation, while the only open ContourIntegration PR covers continuous argument lifts. This PR stays at the orientation bookkeeping layer and does not attempt integer-valuedness, homotopy invariance, HW Proposition 2.2, or any new residue theorem.

No Mathlib infrastructure is vendored. The implementation reuses Mathlib’s `IntervalIntegrable.symm` and `intervalIntegral.integral_symm`, plus Tau Ceti’s existing `HasCauchyPVAt` / `HasCauchyPV` intro and value APIs, `windingNumber_eq_of_hasCauchyPVAt`, `cauchyPVExistsAt_of_avoidance`, and `IsNullHomologous` API.

`lake exe cache get` completed with `No files to download` and `Already decompressed 8609 file(s)`. `lake build` completed with `Build completed successfully (4590 jobs).` `lake exe axioms` completed with `axioms: audited 8625 TauCeti declaration(s); all within the allowlist [propext, Classical.choice, Quot.sound].`

<!--tauceti-target:v1 {"focus":"ContourIntegration","id":"winding-number-reverse"}-->

🤖 Prepared with Codex
