### PR TITLE
feat: general conditional-expectation / a.e.-limit helper API

### DIFF
--- a/TauCeti/MeasureTheory/Function/AEStronglyMeasurable.lean
+++ b/TauCeti/MeasureTheory/Function/AEStronglyMeasurable.lean
@@ -11,9 +11,14 @@ sequence of σ-algebras, used when working with tail σ-algebras and reverse mar
 
 ## Main results
 
+- `aestronglyMeasurable_of_tendsto_ae'`: an a.e. pointwise limit of `AEStronglyMeasurable[m]`
+  functions is `AEStronglyMeasurable[m]`, for a sub-σ-algebra `m` unrelated to the measure's ambient
+  σ-algebra `m₀` (Mathlib's `aestronglyMeasurable_of_tendsto_ae` covers only the `m = m₀` case).
 - `aestronglyMeasurable_iInf_of_antitone`: if a function is `AEStronglyMeasurable` with respect to
   each σ-algebra in an antitone sequence, then it is `AEStronglyMeasurable` with respect to their
   infimum.
+- `aestronglyMeasurable_iInf_of_tendsto_ae_antitone`: an a.e. limit of a sequence adapted to an
+  antitone family `𝔽` is `AEStronglyMeasurable[⨅ n, 𝔽 n]`.
 
 The result holds for a codomain in any second-countable conditionally complete linear order with the
 order topology and Borel σ-algebra (`ℝ` qualifies). The witness σ-algebras `m N` need not be related
@@ -29,6 +34,8 @@ public section
 noncomputable section
 
 open MeasureTheory Filter
+
+open scoped Topology
 
 namespace TauCeti
 
@@ -88,6 +95,69 @@ lemma aestronglyMeasurable_iInf_of_antitone
     exact h_meas.stronglyMeasurable
   -- Step 6: Conclude AEStronglyMeasurable
   exact ⟨h, h_sm, h_ae_eq⟩
+
+/-- A.e. pointwise limit of `AEStronglyMeasurable[m]` functions is `AEStronglyMeasurable[m]`, for a
+sub-σ-algebra `m` with no assumed relation to the measure's ambient σ-algebra `m₀`. Mathlib's
+`aestronglyMeasurable_of_tendsto_ae` covers only the `m = m₀` case. -/
+-- The witness is the pointwise `limsup` of the strongly measurable representatives of the `f n`.
+-- The order-codomain assumptions are inherited from `Measurable.limsup` (`BorelSpace.Order`):
+-- unlike the ambient case, Mathlib has no pseudo-metrizable a.e.-limit lemma for a sub-σ-algebra,
+-- so the `limsup` witness is the only route. This lemma and the two below are consumed by the
+-- reverse-martingale Lévy-downward theorem `MeasureTheory.tendsto_ae_condExp_iInf`.
+lemma aestronglyMeasurable_of_tendsto_ae'
+    {α : Type*} {m₀ : MeasurableSpace α} {μ : @MeasureTheory.Measure α m₀}
+    {m : MeasurableSpace α}
+    {f : ℕ → α → β} {g : α → β}
+    (hf : ∀ n, @MeasureTheory.AEStronglyMeasurable α β _ m m₀ (f n) μ)
+    (hlim : ∀ᵐ x ∂μ, Filter.Tendsto (fun n => f n x) Filter.atTop (nhds (g x))) :
+    @MeasureTheory.AEStronglyMeasurable α β _ m m₀ g μ := by
+  -- Strongly measurable representatives of the `f n`.
+  let f' : ℕ → α → β := fun n => (hf n).mk (f n)
+  have hf'_sm : ∀ n, @MeasureTheory.StronglyMeasurable α β _ m (f' n) :=
+    fun n => (hf n).stronglyMeasurable_mk
+  have hf'_meas : ∀ n, @Measurable α β m _ (f' n) := fun n => (hf'_sm n).measurable
+  have hf'_ae : ∀ n, f n =ᵐ[μ] f' n := fun n => (hf n).ae_eq_mk
+  -- Use the `limsup` of the representatives as the witness.
+  let h := fun x => Filter.atTop.limsup (fun n => f' n x)
+  have h_meas : @Measurable α β m _ h := by
+    haveI : MeasurableSpace α := m
+    exact Measurable.limsup hf'_meas
+  -- `h = g` a.e.: on the set where `f n = f' n` for all `n` and `f n → g`, `limsup (f' ·) = g`.
+  have h_ae_eq : h =ᵐ[μ] g := by
+    have h_all_eq : ∀ᵐ x ∂μ, ∀ n, f n x = f' n x := MeasureTheory.ae_all_iff.mpr hf'_ae
+    filter_upwards [h_all_eq, hlim] with x hx hxlim
+    have hlim' : Filter.Tendsto (fun n => f' n x) Filter.atTop (nhds (g x)) := by
+      simpa only [fun n => (hx n)] using hxlim
+    exact Filter.Tendsto.limsup_eq hlim'
+  have h_sm : @MeasureTheory.StronglyMeasurable α β _ m h := by
+    haveI : MeasurableSpace α := m
+    exact h_meas.stronglyMeasurable
+  exact ⟨h, h_sm, h_ae_eq.symm⟩
+
+/-- A.e. limit of an adapted antitone sequence is `⨅ n, 𝔽 n`-`AEStronglyMeasurable`.
+
+For antitone `𝔽`, if each `g n` is `𝔽 n`-a.e.-strongly-measurable and `g n → Xlim` a.e., then `Xlim`
+is `AEStronglyMeasurable[⨅ n, 𝔽 n]`. Codomain `β` at the same order level as the rest of this
+section (`ℝ` qualifies). -/
+lemma aestronglyMeasurable_iInf_of_tendsto_ae_antitone
+    {Ω : Type*} [MeasurableSpace Ω] {μ : Measure Ω}
+    {𝔽 : ℕ → MeasurableSpace Ω} (h_antitone : Antitone 𝔽)
+    {g : ℕ → Ω → β} {Xlim : Ω → β}
+    (hg_meas : ∀ n, AEStronglyMeasurable[𝔽 n] (g n) μ)
+    (h_tendsto : ∀ᵐ ω ∂μ, Tendsto (fun n => g n ω) atTop (𝓝 (Xlim ω))) :
+    AEStronglyMeasurable[⨅ n, 𝔽 n] Xlim μ := by
+  -- Compose the two `AEStronglyMeasurable` helper lemmas: first show
+  -- `AEStronglyMeasurable[𝔽 N] Xlim` for each `N` by feeding the shifted sequence `g (n + N)` into
+  -- `aestronglyMeasurable_of_tendsto_ae'` (each shifted term is `𝔽 N`-`AEStronglyMeasurable` by
+  -- antitonicity — take its `𝔽 (n+N)`-measurable representative, `mono` it up to `𝔽 N`); then
+  -- combine over `N` via `aestronglyMeasurable_iInf_of_antitone`.
+  refine aestronglyMeasurable_iInf_of_antitone (μ := μ) h_antitone Xlim (fun N => ?_)
+  refine aestronglyMeasurable_of_tendsto_ae' (μ := μ) (f := fun n => g (n + N))
+    (fun n => (((hg_meas (n + N)).stronglyMeasurable_mk.mono
+      (h_antitone (Nat.le_add_left N n))).aestronglyMeasurable).congr
+      (hg_meas (n + N)).ae_eq_mk.symm) ?_
+  filter_upwards [h_tendsto] with ω hω
+  exact hω.comp (Filter.tendsto_add_atTop_nat N)
 
 end MeasureTheory
 

--- a/TauCeti/MeasureTheory/Function/AEStronglyMeasurable.lean
+++ b/TauCeti/MeasureTheory/Function/AEStronglyMeasurable.lean
@@ -12,8 +12,9 @@ sequence of σ-algebras, used when working with tail σ-algebras and reverse mar
 ## Main results
 
 - `aestronglyMeasurable_of_tendsto_ae'`: an a.e. pointwise limit of `AEStronglyMeasurable[m]`
-  functions is `AEStronglyMeasurable[m]`, for a sub-σ-algebra `m` unrelated to the measure's ambient
-  σ-algebra `m₀` (Mathlib's `aestronglyMeasurable_of_tendsto_ae` covers only the `m = m₀` case).
+  functions is `AEStronglyMeasurable[m]`, for an arbitrary measurable space `m` on `α`, unrelated to
+  the measure's ambient σ-algebra `m₀` (Mathlib's `aestronglyMeasurable_of_tendsto_ae` covers only
+  the `m = m₀` case).
 - `aestronglyMeasurable_iInf_of_antitone`: if a function is `AEStronglyMeasurable` with respect to
   each σ-algebra in an antitone sequence, then it is `AEStronglyMeasurable` with respect to their
   infimum.
@@ -25,7 +26,9 @@ order topology and Borel σ-algebra (`ℝ` qualifies). The witness σ-algebras `
 to the measure's ambient σ-algebra `m₀`.
 
 Adapted from `cameronfreer/exchangeability` (`Probability/SigmaAlgebraHelpers.lean`, pin
-`e0532e59ceff23edab44dda9ab0655debbc9cc22`). This sub-σ-algebra statement has no Mathlib equivalent.
+`e0532e59ceff23edab44dda9ab0655debbc9cc22`); the two a.e.-limit lemmas
+(`aestronglyMeasurable_of_tendsto_ae'`, `aestronglyMeasurable_iInf_of_tendsto_ae_antitone`) are
+adapted from the same source. These general-`m` / antitone statements have no Mathlib equivalent.
 Written Mathlib-shaped for eventual upstreaming.
 -/
 
@@ -96,12 +99,12 @@ lemma aestronglyMeasurable_iInf_of_antitone
   -- Step 6: Conclude AEStronglyMeasurable
   exact ⟨h, h_sm, h_ae_eq⟩
 
-/-- A.e. pointwise limit of `AEStronglyMeasurable[m]` functions is `AEStronglyMeasurable[m]`, for a
-sub-σ-algebra `m` with no assumed relation to the measure's ambient σ-algebra `m₀`. Mathlib's
-`aestronglyMeasurable_of_tendsto_ae` covers only the `m = m₀` case. -/
+/-- A.e. pointwise limit of `AEStronglyMeasurable[m]` functions is `AEStronglyMeasurable[m]`, for an
+arbitrary measurable space `m` on `α` (no assumed relation to the measure's ambient σ-algebra `m₀`).
+Mathlib's `aestronglyMeasurable_of_tendsto_ae` covers only the `m = m₀` case. -/
 -- The witness is the pointwise `limsup` of the strongly measurable representatives of the `f n`.
 -- The order-codomain assumptions are inherited from `Measurable.limsup` (`BorelSpace.Order`):
--- unlike the ambient case, Mathlib has no pseudo-metrizable a.e.-limit lemma for a sub-σ-algebra,
+-- unlike the ambient case, Mathlib has no pseudo-metrizable a.e.-limit lemma for a non-ambient `m`,
 -- so the `limsup` witness is the only route. This lemma and the two below are consumed by the
 -- reverse-martingale Lévy-downward theorem `MeasureTheory.tendsto_ae_condExp_iInf`.
 lemma aestronglyMeasurable_of_tendsto_ae'

--- a/TauCeti/MeasureTheory/Function/ConditionalExpectation.lean
+++ b/TauCeti/MeasureTheory/Function/ConditionalExpectation.lean
@@ -2,7 +2,7 @@ module
 
 public import Mathlib.MeasureTheory.Function.ConditionalExpectation.Basic
 -- Non-public: `eLpNorm_one_condExp_le_eLpNorm` (the L¹ contraction of conditional expectation) is
--- used only inside the proof of `condExp_ae_eq_of_tendsto_eLpNorm`, not in any public signature.
+-- used only inside the proof of the L¹-continuity lemma below, not in any public signature.
 import Mathlib.MeasureTheory.Function.ConditionalExpectation.Real
 
 /-!
@@ -10,9 +10,9 @@ import Mathlib.MeasureTheory.Function.ConditionalExpectation.Real
 
 - `condExp_indicator_eq_of_pair_law_eq`: if `(Y, Z)` and `(Y', Z)` have the same law, then for
   measurable `B` the conditional expectations of `𝟙_B ∘ Y` and `𝟙_B ∘ Y'` given `σ(Z)` agree a.e.
-- `condExp_ae_eq_of_tendsto_eLpNorm`: L¹-continuity of conditional expectation — if `Xn → Xlim` in
-  L¹ (in `eLpNorm`) and each `μ[Xn n | F]` agrees a.e. with a fixed `Y`, then `μ[Xlim | F]` agrees
-  a.e. with `Y`.
+- `condExp_ae_eq_of_forall_condExp_ae_eq_of_tendsto_eLpNorm`: L¹-continuity of conditional
+  expectation — if `Xn → Xlim` in L¹ (in `eLpNorm`) and each `μ[Xn n | F]` agrees a.e. with a fixed
+  `Y`, then `μ[Xlim | F]` agrees a.e. with `Y`.
 
 Both are generic conditional-expectation facts (no exchangeability/tail/directing-measure
 hypotheses), each the bridge for a downstream construction.
@@ -87,7 +87,7 @@ theorem condExp_indicator_eq_of_pair_law_eq {Ω α β : Type*} [mΩ : Measurable
 -- bound `‖μ[Xlim|F] - Y‖₁` by `‖Xlim - Xn n‖₁` (triangle + `condExp_sub` + the contraction + the
 -- vanishing `μ[Xn n|F] - Y` term), then let `n → ∞`. Consumed by the reverse-martingale
 -- Lévy-downward theorem `MeasureTheory.tendsto_ae_condExp_iInf`.
-lemma condExp_ae_eq_of_tendsto_eLpNorm
+lemma condExp_ae_eq_of_forall_condExp_ae_eq_of_tendsto_eLpNorm
     {Ω : Type*} [MeasurableSpace Ω] {μ : Measure Ω}
     {F : MeasurableSpace Ω} {Xlim Y : Ω → ℝ} {Xn : ℕ → Ω → ℝ}
     (hXlimint : Integrable Xlim μ) (hXn_int : ∀ n, Integrable (Xn n) μ)

--- a/TauCeti/MeasureTheory/Function/ConditionalExpectation.lean
+++ b/TauCeti/MeasureTheory/Function/ConditionalExpectation.lean
@@ -1,27 +1,33 @@
 module
 
 public import Mathlib.MeasureTheory.Function.ConditionalExpectation.Basic
+-- Non-public: `eLpNorm_one_condExp_le_eLpNorm` (the L¹ contraction of conditional expectation) is
+-- used only inside the proof of `condExp_ae_eq_of_tendsto_eLpNorm`, not in any public signature.
+import Mathlib.MeasureTheory.Function.ConditionalExpectation.Real
 
 /-!
-# Conditional expectation of an indicator under pair-law equality
+# Generic conditional-expectation facts
 
-`condExp_indicator_eq_of_pair_law_eq`: if the pairs `(Y, Z)` and `(Y', Z)` have the same law, then
-for every measurable `B` the conditional expectations of `𝟙_B ∘ Y` and `𝟙_B ∘ Y'` given `σ(Z)` agree
-almost everywhere.
+- `condExp_indicator_eq_of_pair_law_eq`: if `(Y, Z)` and `(Y', Z)` have the same law, then for
+  measurable `B` the conditional expectations of `𝟙_B ∘ Y` and `𝟙_B ∘ Y'` given `σ(Z)` agree a.e.
+- `condExp_ae_eq_of_tendsto_eLpNorm`: L¹-continuity of conditional expectation — if `Xn → Xlim` in
+  L¹ (in `eLpNorm`) and each `μ[Xn n | F]` agrees a.e. with a fixed `Y`, then `μ[Xlim | F]` agrees
+  a.e. with `Y`.
 
-This is a generic conditional-expectation fact (no exchangeability/tail/directing-measure
-hypotheses); it is the bridge that turns a pair-law (distributional) equality into a
-conditional-expectation identity, consumed by the de Finetti block-product factorisation.
+Both are generic conditional-expectation facts (no exchangeability/tail/directing-measure
+hypotheses), each the bridge for a downstream construction.
 
-Adapted from `cameronfreer/exchangeability` (`Probability/CondExp.lean`, pin
-`e0532e59ceff23edab44dda9ab0655debbc9cc22`).
+Adapted from `cameronfreer/exchangeability` (`Probability/CondExp.lean` and
+`Probability/Martingale/Convergence.lean`, pin `e0532e59ceff23edab44dda9ab0655debbc9cc22`).
 -/
 
 public section
 
 noncomputable section
 
-open MeasureTheory
+open MeasureTheory Filter
+
+open scoped Topology
 
 namespace TauCeti
 
@@ -72,6 +78,54 @@ theorem condExp_indicator_eq_of_pair_law_eq {Ω α β : Type*} [mΩ : Measurable
       ext ω; simp only [hf'_def, Function.comp_apply, Set.indicator, Set.mem_preimage]
     rw [hf'_eq]; exact hint Y' hY'
   simp_rw [h_lhs, h_rhs_ce, h_rhs, h_meas_eq]
+
+/-- **L¹-continuity of conditional expectation.** If `Xn → Xlim` in `L¹` (in `eLpNorm`) and each
+`μ[Xn n | F]` agrees a.e. with a fixed `Y`, then `μ[Xlim | F]` agrees a.e. with `Y`. -/
+-- Stated for an arbitrary conditioning σ-algebra `F` (no `F ≤ m₀`, no `[SigmaFinite (μ.trim)]`):
+-- the bound goes through Mathlib's L¹ contraction `eLpNorm_one_condExp_le_eLpNorm`, which holds at
+-- every `F` via the `condExp = 0` convention — whereas `condExpL1CLM` would require both. Proof:
+-- bound `‖μ[Xlim|F] - Y‖₁` by `‖Xlim - Xn n‖₁` (triangle + `condExp_sub` + the contraction + the
+-- vanishing `μ[Xn n|F] - Y` term), then let `n → ∞`. Consumed by the reverse-martingale
+-- Lévy-downward theorem `MeasureTheory.tendsto_ae_condExp_iInf`.
+lemma condExp_ae_eq_of_tendsto_eLpNorm
+    {Ω : Type*} [MeasurableSpace Ω] {μ : Measure Ω}
+    {F : MeasurableSpace Ω} {Xlim Y : Ω → ℝ} {Xn : ℕ → Ω → ℝ}
+    (hXlimint : Integrable Xlim μ) (hXn_int : ∀ n, Integrable (Xn n) μ)
+    (h_condExp : ∀ n, μ[Xn n | F] =ᵐ[μ] Y)
+    (hL1 : Tendsto (fun n => eLpNorm (Xlim - Xn n) 1 μ) atTop (𝓝 0)) :
+    μ[Xlim | F] =ᵐ[μ] Y := by
+  have hY_meas := integrable_condExp.aestronglyMeasurable.congr (h_condExp 0)
+  have h_bound (n : ℕ) : eLpNorm (μ[Xlim | F] - Y) 1 μ ≤ eLpNorm (Xlim - Xn n) 1 μ := by
+    have htri : eLpNorm (μ[Xlim | F] - Y) 1 μ
+                ≤ eLpNorm (μ[Xlim | F] - μ[Xn n | F]) 1 μ
+                  + eLpNorm (μ[Xn n | F] - Y) 1 μ := by
+      have : μ[Xlim | F] - Y = (μ[Xlim | F] - μ[Xn n | F]) + (μ[Xn n | F] - Y) := by ring
+      rw [this]
+      refine eLpNorm_add_le ?_ ?_ ?_
+      · exact (integrable_condExp.sub integrable_condExp).aestronglyMeasurable
+      · exact integrable_condExp.aestronglyMeasurable.sub hY_meas
+      · norm_num
+    have hzero : eLpNorm (μ[Xn n | F] - Y) 1 μ = 0 := by
+      have h0 : μ[Xn n | F] - Y =ᵐ[μ] 0 := by
+        filter_upwards [h_condExp n] with ω hω; simp [hω]
+      rw [eLpNorm_congr_ae h0]; simp
+    have hfirst : eLpNorm (μ[Xlim | F] - μ[Xn n | F]) 1 μ ≤ eLpNorm (Xlim - Xn n) 1 μ := by
+      have hsub : μ[Xlim | F] - μ[Xn n | F] =ᵐ[μ] μ[Xlim - Xn n | F] :=
+        (condExp_sub hXlimint (hXn_int n) F).symm
+      rw [eLpNorm_congr_ae hsub]
+      exact eLpNorm_one_condExp_le_eLpNorm _
+    calc eLpNorm (μ[Xlim | F] - Y) 1 μ
+        ≤ eLpNorm (μ[Xlim | F] - μ[Xn n | F]) 1 μ + eLpNorm (μ[Xn n | F] - Y) 1 μ := htri
+      _ = eLpNorm (μ[Xlim | F] - μ[Xn n | F]) 1 μ := by rw [hzero]; ring
+      _ ≤ eLpNorm (Xlim - Xn n) 1 μ := hfirst
+  have h_norm_zero : eLpNorm (μ[Xlim | F] - Y) 1 μ = 0 :=
+    le_antisymm
+      (le_of_tendsto_of_tendsto tendsto_const_nhds hL1 (Eventually.of_forall h_bound)) bot_le
+  rw [eLpNorm_eq_zero_iff (integrable_condExp.aestronglyMeasurable.sub hY_meas)
+    one_ne_zero] at h_norm_zero
+  filter_upwards [h_norm_zero] with ω hω
+  simp only [Pi.zero_apply] at hω
+  exact sub_eq_zero.mp hω
 
 end MeasureTheory
 


### PR DESCRIPTION
<!--tauceti-target:v1 {"focus":"Exchangeability","id":"condexp-ae-limit-helpers"}-->

## Summary

Adds three **general** `MeasureTheory` lemmas as public API in their canonical sibling files —
measurability of a.e. limits with respect to a sub-σ-algebra, and L¹-continuity of conditional
expectation:

- `TauCeti/MeasureTheory/Function/AEStronglyMeasurable.lean`
  - `aestronglyMeasurable_of_tendsto_ae'` — an a.e. pointwise limit of `AEStronglyMeasurable[m]`
    functions is `AEStronglyMeasurable[m]`, for a sub-σ-algebra `m` **unrelated** to the ambient
    `m₀`. Mathlib's `aestronglyMeasurable_of_tendsto_ae` covers only the `m = m₀` case.
  - `aestronglyMeasurable_iInf_of_tendsto_ae_antitone` — an a.e. limit adapted to an antitone
    family `𝔽` is `AEStronglyMeasurable[⨅ n, 𝔽 n]`.
- `TauCeti/MeasureTheory/Function/ConditionalExpectation.lean`
  - `condExp_ae_eq_of_tendsto_eLpNorm` — L¹-continuity of conditional expectation.

## Why these are general API (not proof scaffolding)

Each fills a genuine Mathlib gap and stands alone as reusable measure theory:

- The **sub-σ-algebra** a.e.-limit lemmas have no Mathlib analogue — Mathlib's a.e.-limit
  measurability (`aestronglyMeasurable_of_tendsto_ae`, `exists_stronglyMeasurable_limit_of_tendsto_ae`)
  is only w.r.t. the measure's own σ-algebra. For a sub-σ-algebra the only route is the order-based
  `Measurable.limsup`/`liminf` (`BorelSpace.Order`), used here.
- `condExp_ae_eq_of_tendsto_eLpNorm` is stated for an **arbitrary** conditioning σ-algebra `F` (no
  `F ≤ m₀`, no `[SigmaFinite (μ.trim)]`), via Mathlib's L¹ contraction `eLpNorm_one_condExp_le_eLpNorm`
  — strictly more general than the `condExpL1CLM` map, which needs both.

They are the reusable infrastructure consumed by the reverse-martingale **Lévy-downward theorem**
`tendsto_ae_condExp_iInf` (PR under review); factoring them out here keeps that convergence PR free
of helper surface and lets this API be reviewed/reused on its own terms. Design rationale is in
inline comments (docstrings kept result-level).

## Generality

- `aestronglyMeasurable_iInf_of_tendsto_ae_antitone` is **β-polymorphic** (order-level codomain, `ℝ`
  qualifies) and takes **`AEStronglyMeasurable`** input (not `StronglyMeasurable`).
- `condExp_ae_eq_of_tendsto_eLpNorm` imposes no sub-σ-algebra / σ-finite hypotheses.

## Placement / reuse

- Each lemma sits in its canonical general file next to its siblings
  (`aestronglyMeasurable_iInf_of_antitone`, `condExp_indicator_eq_of_pair_law_eq`).
- `condExp_ae_eq_of_tendsto_eLpNorm` uses Mathlib's L¹ contraction directly; it does not re-prove
  the `condExpL1CLM` operator's continuity.

## Test plan
```bash
lake build && lake exe axioms && lake exe module-system && bash scripts/lint-env.sh
```
All pass; sorry-free; the three new lemmas' axioms ⊆ {`propext`, `Classical.choice`, `Quot.sound`};
lines ≤100; module-system opts in.

## Attribution
Adapted from `cameronfreer/exchangeability` (`Probability/SigmaAlgebraHelpers.lean`,
`Probability/Martingale/Convergence.lean`, pin `e0532e59ceff23edab44dda9ab0655debbc9cc22`). Written
Mathlib-shaped for eventual upstreaming. Drafted with Claude (Opus 4.8), human-directed.
