### PR TITLE
feat: add plumbing face exponent squares

### DIFF
--- a/TauCeti/LowDimTopology/Plumbing/CubeFaceExponent.lean
+++ b/TauCeti/LowDimTopology/Plumbing/CubeFaceExponent.lean
@@ -46,7 +46,16 @@ variable {V : Type*} [DecidableEq V] [Fintype V]
 variable (P : PlumbingGraph V) (k : P.characteristicVectors)
 variable (C : PlumbingCube V) {v w : V}
 
+private theorem characteristicLowerFaceExponent_natCast_lowerFace
+    (hv : v ∈ C.directions) :
+    (characteristicLowerFaceExponent P k C v : ℤ) =
+      characteristicWeight P k C - characteristicWeight P k (C.lowerFace v hv) := by
+  rw [characteristicLowerFaceExponent_natCast]
+  congr
+  rw [lowerFace_def]
+
 /-- The lower-lower codimension-two square has the same total `U`-exponent along either path. -/
+@[simp]
 theorem characteristicLowerFaceExponent_add_lowerFace_comm
     (hv : v ∈ C.directions) (hw : w ∈ C.directions) (hne : v ≠ w) :
     characteristicLowerFaceExponent P k C v +
@@ -55,16 +64,17 @@ theorem characteristicLowerFaceExponent_add_lowerFace_comm
         characteristicLowerFaceExponent P k (C.lowerFace w hw) v := by
   apply Nat.cast_injective (R := ℤ)
   rw [Int.natCast_add, Int.natCast_add]
-  rw [characteristicLowerFaceExponent_natCast, characteristicLowerFaceExponent_natCast,
-    characteristicLowerFaceExponent_natCast, characteristicLowerFaceExponent_natCast]
-  simp only [lowerFace_def]
-  have hcorner :
-      (C.eraseDirection v).eraseDirection w = (C.eraseDirection w).eraseDirection v := by
-    simpa [lowerFace_def] using C.lowerFace_lowerFace_comm hv hw hne
-  rw [hcorner]
+  rw [characteristicLowerFaceExponent_natCast_lowerFace P k C hv,
+    characteristicLowerFaceExponent_natCast_lowerFace P k (C.lowerFace v hv)
+      (by rw [lowerFace_directions]; exact Finset.mem_erase_of_ne_of_mem hne.symm hw),
+    characteristicLowerFaceExponent_natCast_lowerFace P k C hw,
+    characteristicLowerFaceExponent_natCast_lowerFace P k (C.lowerFace w hw)
+      (by rw [lowerFace_directions]; exact Finset.mem_erase_of_ne_of_mem hne hv)]
+  rw [C.lowerFace_lowerFace_comm hv hw hne]
   omega
 
 /-- The upper-upper codimension-two square has the same total `U`-exponent along either path. -/
+@[simp]
 theorem characteristicUpperFaceExponent_add_upperFace_comm
     (hv : v ∈ C.directions) (hw : w ∈ C.directions) (hne : v ≠ w) :
     characteristicUpperFaceExponent P k C (v := v) hv +
@@ -84,6 +94,7 @@ theorem characteristicUpperFaceExponent_add_upperFace_comm
 
 /-- The lower-then-upper mixed codimension-two square has the same total `U`-exponent as the
 upper-then-lower path to the same corner. -/
+@[simp]
 theorem characteristicLowerFaceExponent_add_upperFace_comm
     (hv : v ∈ C.directions) (hw : w ∈ C.directions) (hne : v ≠ w) :
     characteristicLowerFaceExponent P k C v +
@@ -94,20 +105,16 @@ theorem characteristicLowerFaceExponent_add_upperFace_comm
         characteristicLowerFaceExponent P k (C.upperFace w hw) v := by
   apply Nat.cast_injective (R := ℤ)
   rw [Int.natCast_add, Int.natCast_add]
-  rw [characteristicLowerFaceExponent_natCast P k C v,
+  rw [characteristicLowerFaceExponent_natCast_lowerFace P k C hv,
     characteristicUpperFaceExponent_natCast, characteristicUpperFaceExponent_natCast,
-    characteristicLowerFaceExponent_natCast P k (C.upperFace w hw) v]
-  simp only [lowerFace_def]
-  have hcorner :
-      (C.eraseDirection v).upperFace w
-          (by rw [eraseDirection_directions]; exact Finset.mem_erase_of_ne_of_mem hne.symm hw) =
-        (C.upperFace w hw).eraseDirection v := by
-    simpa [lowerFace_def] using C.lowerFace_upperFace_comm hv hw hne
-  rw [hcorner]
+    characteristicLowerFaceExponent_natCast_lowerFace P k (C.upperFace w hw)
+      (by rw [upperFace_directions]; exact Finset.mem_erase_of_ne_of_mem hne hv)]
+  rw [C.lowerFace_upperFace_comm hv hw hne]
   omega
 
 /-- The upper-then-lower mixed codimension-two square has the same total `U`-exponent as the
 lower-then-upper path to the same corner. -/
+@[simp]
 theorem characteristicUpperFaceExponent_add_lowerFace_comm
     (hv : v ∈ C.directions) (hw : w ∈ C.directions) (hne : v ≠ w) :
     characteristicUpperFaceExponent P k C (v := v) hv +

--- a/TauCeti/LowDimTopology/Plumbing/CubeFaceExponent.lean
+++ b/TauCeti/LowDimTopology/Plumbing/CubeFaceExponent.lean
@@ -92,7 +92,6 @@ theorem characteristicUpperFaceExponent_add_upperFace_comm
 
 /-- The lower-then-upper mixed codimension-two square has the same total `U`-exponent as the
 upper-then-lower path to the same corner. -/
-@[simp]
 theorem characteristicLowerFaceExponent_add_upperFace_comm
     (hv : v ∈ C.directions) (hw : w ∈ C.directions) (hne : v ≠ w) :
     characteristicLowerFaceExponent P k C v +
@@ -112,7 +111,6 @@ theorem characteristicLowerFaceExponent_add_upperFace_comm
 
 /-- The upper-then-lower mixed codimension-two square has the same total `U`-exponent as the
 lower-then-upper path to the same corner. -/
-@[simp]
 theorem characteristicUpperFaceExponent_add_lowerFace_comm
     (hv : v ∈ C.directions) (hw : w ∈ C.directions) (hne : v ≠ w) :
     characteristicUpperFaceExponent P k C (v := v) hv +

--- a/TauCeti/LowDimTopology/Plumbing/CubeFaceExponent.lean
+++ b/TauCeti/LowDimTopology/Plumbing/CubeFaceExponent.lean
@@ -55,7 +55,6 @@ private theorem characteristicLowerFaceExponent_natCast_lowerFace
   rw [lowerFace_def]
 
 /-- The lower-lower codimension-two square has the same total `U`-exponent along either path. -/
-@[simp]
 theorem characteristicLowerFaceExponent_add_lowerFace_comm
     (hv : v ∈ C.directions) (hw : w ∈ C.directions) (hne : v ≠ w) :
     characteristicLowerFaceExponent P k C v +
@@ -74,7 +73,6 @@ theorem characteristicLowerFaceExponent_add_lowerFace_comm
   omega
 
 /-- The upper-upper codimension-two square has the same total `U`-exponent along either path. -/
-@[simp]
 theorem characteristicUpperFaceExponent_add_upperFace_comm
     (hv : v ∈ C.directions) (hw : w ∈ C.directions) (hne : v ≠ w) :
     characteristicUpperFaceExponent P k C (v := v) hv +

--- a/TauCeti/LowDimTopology/Plumbing/CubeFaceExponent.lean
+++ b/TauCeti/LowDimTopology/Plumbing/CubeFaceExponent.lean
@@ -26,6 +26,8 @@ the same codimension-two generator; the lemmas here add that they also carry the
 * `TauCeti.PlumbingCube.characteristicUpperFaceExponent_add_upperFace_comm`: upper-upper square.
 * `TauCeti.PlumbingCube.characteristicLowerFaceExponent_add_upperFace_comm`: lower-then-upper
   equals upper-then-lower.
+* `TauCeti.PlumbingCube.characteristicUpperFaceExponent_add_lowerFace_comm`: upper-then-lower
+  equals lower-then-upper.
 
 ## References
 
@@ -103,6 +105,19 @@ theorem characteristicLowerFaceExponent_add_upperFace_comm
     simpa [lowerFace_def] using C.lowerFace_upperFace_comm hv hw hne
   rw [hcorner]
   omega
+
+/-- The upper-then-lower mixed codimension-two square has the same total `U`-exponent as the
+lower-then-upper path to the same corner. -/
+theorem characteristicUpperFaceExponent_add_lowerFace_comm
+    (hv : v ∈ C.directions) (hw : w ∈ C.directions) (hne : v ≠ w) :
+    characteristicUpperFaceExponent P k C (v := v) hv +
+        characteristicLowerFaceExponent P k (C.upperFace v hv) w =
+      characteristicLowerFaceExponent P k C w +
+        characteristicUpperFaceExponent P k (C.lowerFace w hw)
+          (v := v)
+          (by rw [lowerFace_directions]; exact Finset.mem_erase_of_ne_of_mem hne hv) := by
+  simpa [add_comm] using (characteristicLowerFaceExponent_add_upperFace_comm
+    (P := P) (k := k) (C := C) (v := w) (w := v) hw hv hne.symm).symm
 
 end PlumbingCube
 

--- a/TauCeti/LowDimTopology/Plumbing/CubeFaceExponent.lean
+++ b/TauCeti/LowDimTopology/Plumbing/CubeFaceExponent.lean
@@ -53,13 +53,13 @@ theorem characteristicLowerFaceExponent_add_lowerFace_comm
         characteristicLowerFaceExponent P k (C.lowerFace w hw) v := by
   apply Nat.cast_injective (R := ℤ)
   rw [Int.natCast_add, Int.natCast_add]
-  rw [characteristicLowerFaceExponent_natCast_lowerFace P k C hv,
-    characteristicLowerFaceExponent_natCast_lowerFace P k (C.lowerFace v hv)
-      (by rw [lowerFace_directions]; exact Finset.mem_erase_of_ne_of_mem hne.symm hw),
-    characteristicLowerFaceExponent_natCast_lowerFace P k C hw,
-    characteristicLowerFaceExponent_natCast_lowerFace P k (C.lowerFace w hw)
-      (by rw [lowerFace_directions]; exact Finset.mem_erase_of_ne_of_mem hne hv)]
-  rw [C.lowerFace_lowerFace_comm hv hw hne]
+  rw [characteristicLowerFaceExponent_natCast, characteristicLowerFaceExponent_natCast,
+    characteristicLowerFaceExponent_natCast, characteristicLowerFaceExponent_natCast]
+  simp only [lowerFace_def]
+  have hcorner :
+      (C.eraseDirection v).eraseDirection w = (C.eraseDirection w).eraseDirection v := by
+    simpa [lowerFace_def] using C.lowerFace_lowerFace_comm hv hw hne
+  rw [hcorner]
   omega
 
 /-- The upper-upper codimension-two square has the same total `U`-exponent along either path. -/
@@ -92,11 +92,16 @@ theorem characteristicLowerFaceExponent_add_upperFace_comm
         characteristicLowerFaceExponent P k (C.upperFace w hw) v := by
   apply Nat.cast_injective (R := ℤ)
   rw [Int.natCast_add, Int.natCast_add]
-  rw [characteristicLowerFaceExponent_natCast_lowerFace P k C hv,
+  rw [characteristicLowerFaceExponent_natCast P k C v,
     characteristicUpperFaceExponent_natCast, characteristicUpperFaceExponent_natCast,
-    characteristicLowerFaceExponent_natCast_lowerFace P k (C.upperFace w hw)
-      (by rw [upperFace_directions]; exact Finset.mem_erase_of_ne_of_mem hne hv)]
-  rw [C.lowerFace_upperFace_comm hv hw hne]
+    characteristicLowerFaceExponent_natCast P k (C.upperFace w hw) v]
+  simp only [lowerFace_def]
+  have hcorner :
+      (C.eraseDirection v).upperFace w
+          (by rw [eraseDirection_directions]; exact Finset.mem_erase_of_ne_of_mem hne.symm hw) =
+        (C.upperFace w hw).eraseDirection v := by
+    simpa [lowerFace_def] using C.lowerFace_upperFace_comm hv hw hne
+  rw [hcorner]
   omega
 
 end PlumbingCube

--- a/TauCeti/LowDimTopology/Plumbing/CubeFaceExponent.lean
+++ b/TauCeti/LowDimTopology/Plumbing/CubeFaceExponent.lean
@@ -42,7 +42,7 @@ namespace TauCeti
 
 namespace PlumbingCube
 
-variable {V : Type*} [DecidableEq V] [DecidableEq (V → ℤ)] [Fintype V]
+variable {V : Type*} [DecidableEq V] [Fintype V]
 variable (P : PlumbingGraph V) (k : P.characteristicVectors)
 variable (C : PlumbingCube V) {v w : V}
 

--- a/TauCeti/LowDimTopology/Plumbing/CubeFaceExponent.lean
+++ b/TauCeti/LowDimTopology/Plumbing/CubeFaceExponent.lean
@@ -1,0 +1,128 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+module
+
+public import TauCeti.LowDimTopology.Plumbing.CubeGenerator
+
+/-!
+# Exponent sums around plumbing-lattice face squares
+
+The cubical generators for lattice homology have two codimension-one faces in each direction:
+a lower face and an upper face. The `U`-exponents attached to these faces are differences between
+the cube weight and the face weight. This file records the corresponding codimension-two
+bookkeeping: in a square determined by two distinct directions, the sum of the two exponents along
+one path equals the sum along the other path.
+
+These identities are the weight part of the standard `∂² = 0` cubical cancellation in Némethi's
+lattice homology. `CubeGenerator.lean` already proves that the two paths around each square reach
+the same codimension-two generator; the lemmas here add that they also carry the same total
+`U`-power.
+
+## Main results
+
+* `TauCeti.PlumbingCube.characteristicLowerFaceExponent_add_lowerFace_comm`: lower-lower square.
+* `TauCeti.PlumbingCube.characteristicUpperFaceExponent_add_upperFace_comm`: upper-upper square.
+* `TauCeti.PlumbingCube.characteristicLowerFaceExponent_add_upperFace_comm`: lower-then-upper
+  equals upper-then-lower.
+* `TauCeti.PlumbingCube.characteristicUpperFaceExponent_add_lowerFace_comm`: upper-then-lower
+  equals lower-then-upper.
+
+## References
+
+This supplies a prerequisite for `TauCetiRoadmap/CombinatorialHeegaardFloer/README.md`, Lane L
+("lattice homology"), whose differential is built from cubical face weights of a plumbing lattice.
+The face-exponent convention follows Némethi, [arXiv:0709.0841](https://arxiv.org/abs/0709.0841).
+-/
+
+public section
+
+namespace TauCeti
+
+namespace PlumbingCube
+
+variable {V : Type*} [DecidableEq V] [DecidableEq (V → ℤ)] [Fintype V]
+variable (P : PlumbingGraph V) (k : P.characteristicVectors)
+variable (C : PlumbingCube V) {v w : V}
+
+private theorem characteristicLowerFaceExponent_natCast_lowerFace
+    {C : PlumbingCube V} {v : V} (hv : v ∈ C.directions) :
+    (characteristicLowerFaceExponent P k C v : ℤ) =
+      characteristicWeight P k C - characteristicWeight P k (C.lowerFace v hv) := by
+  simp [lowerFace_def]
+
+/-- The lower-lower codimension-two square has the same total `U`-exponent along either path.
+Both sides telescope to the ambient cube weight minus the common lower-lower corner weight. -/
+theorem characteristicLowerFaceExponent_add_lowerFace_comm
+    (hv : v ∈ C.directions) (hw : w ∈ C.directions) (hne : v ≠ w) :
+    characteristicLowerFaceExponent P k C v +
+        characteristicLowerFaceExponent P k (C.lowerFace v hv) w =
+      characteristicLowerFaceExponent P k C w +
+        characteristicLowerFaceExponent P k (C.lowerFace w hw) v := by
+  apply Nat.cast_injective (R := ℤ)
+  rw [Int.natCast_add, Int.natCast_add]
+  rw [characteristicLowerFaceExponent_natCast_lowerFace P k hv,
+    characteristicLowerFaceExponent_natCast_lowerFace P k
+      (by rw [lowerFace_directions]; exact Finset.mem_erase_of_ne_of_mem hne.symm hw),
+    characteristicLowerFaceExponent_natCast_lowerFace P k hw,
+    characteristicLowerFaceExponent_natCast_lowerFace P k
+      (by rw [lowerFace_directions]; exact Finset.mem_erase_of_ne_of_mem hne hv)]
+  rw [C.lowerFace_lowerFace_comm hv hw hne]
+  omega
+
+/-- The upper-upper codimension-two square has the same total `U`-exponent along either path.
+Both sides telescope to the ambient cube weight minus the common upper-upper corner weight. -/
+theorem characteristicUpperFaceExponent_add_upperFace_comm
+    (hv : v ∈ C.directions) (hw : w ∈ C.directions) (hne : v ≠ w) :
+    characteristicUpperFaceExponent P k C (v := v) hv +
+        characteristicUpperFaceExponent P k (C.upperFace v hv)
+          (v := w)
+          (by rw [upperFace_directions]; exact Finset.mem_erase_of_ne_of_mem hne.symm hw) =
+      characteristicUpperFaceExponent P k C (v := w) hw +
+        characteristicUpperFaceExponent P k (C.upperFace w hw)
+          (v := v)
+          (by rw [upperFace_directions]; exact Finset.mem_erase_of_ne_of_mem hne hv) := by
+  apply Nat.cast_injective (R := ℤ)
+  rw [Int.natCast_add, Int.natCast_add]
+  rw [characteristicUpperFaceExponent_natCast, characteristicUpperFaceExponent_natCast,
+    characteristicUpperFaceExponent_natCast, characteristicUpperFaceExponent_natCast]
+  rw [C.upperFace_upperFace_comm hv hw hne]
+  omega
+
+/-- The lower-then-upper mixed codimension-two square has the same total `U`-exponent as the
+upper-then-lower path to the same corner. -/
+theorem characteristicLowerFaceExponent_add_upperFace_comm
+    (hv : v ∈ C.directions) (hw : w ∈ C.directions) (hne : v ≠ w) :
+    characteristicLowerFaceExponent P k C v +
+        characteristicUpperFaceExponent P k (C.lowerFace v hv)
+          (v := w)
+          (by rw [lowerFace_directions]; exact Finset.mem_erase_of_ne_of_mem hne.symm hw) =
+      characteristicUpperFaceExponent P k C (v := w) hw +
+        characteristicLowerFaceExponent P k (C.upperFace w hw) v := by
+  apply Nat.cast_injective (R := ℤ)
+  rw [Int.natCast_add, Int.natCast_add]
+  rw [characteristicLowerFaceExponent_natCast_lowerFace P k hv,
+    characteristicUpperFaceExponent_natCast, characteristicUpperFaceExponent_natCast,
+    characteristicLowerFaceExponent_natCast_lowerFace P k
+      (by rw [upperFace_directions]; exact Finset.mem_erase_of_ne_of_mem hne hv)]
+  rw [C.lowerFace_upperFace_comm hv hw hne]
+  omega
+
+/-- The upper-then-lower mixed codimension-two square has the same total `U`-exponent as the
+lower-then-upper path to the same corner. This is the symmetric mixed-face form convenient when a
+calculation starts with the upper face in the first direction. -/
+theorem characteristicUpperFaceExponent_add_lowerFace_comm
+    (hv : v ∈ C.directions) (hw : w ∈ C.directions) (hne : v ≠ w) :
+    characteristicUpperFaceExponent P k C (v := v) hv +
+        characteristicLowerFaceExponent P k (C.upperFace v hv) w =
+      characteristicLowerFaceExponent P k C w +
+        characteristicUpperFaceExponent P k (C.lowerFace w hw)
+          (v := v)
+          (by rw [lowerFace_directions]; exact Finset.mem_erase_of_ne_of_mem hne hv) := by
+  rw [add_comm, characteristicLowerFaceExponent_add_upperFace_comm P k C hw hv hne.symm]
+  rw [add_comm]
+
+end PlumbingCube
+
+end TauCeti

--- a/TauCeti/LowDimTopology/Plumbing/CubeFaceExponent.lean
+++ b/TauCeti/LowDimTopology/Plumbing/CubeFaceExponent.lean
@@ -26,8 +26,6 @@ the same codimension-two generator; the lemmas here add that they also carry the
 * `TauCeti.PlumbingCube.characteristicUpperFaceExponent_add_upperFace_comm`: upper-upper square.
 * `TauCeti.PlumbingCube.characteristicLowerFaceExponent_add_upperFace_comm`: lower-then-upper
   equals upper-then-lower.
-* `TauCeti.PlumbingCube.characteristicUpperFaceExponent_add_lowerFace_comm`: upper-then-lower
-  equals lower-then-upper.
 
 ## References
 
@@ -46,14 +44,7 @@ variable {V : Type*} [DecidableEq V] [DecidableEq (V → ℤ)] [Fintype V]
 variable (P : PlumbingGraph V) (k : P.characteristicVectors)
 variable (C : PlumbingCube V) {v w : V}
 
-private theorem characteristicLowerFaceExponent_natCast_lowerFace
-    {C : PlumbingCube V} {v : V} (hv : v ∈ C.directions) :
-    (characteristicLowerFaceExponent P k C v : ℤ) =
-      characteristicWeight P k C - characteristicWeight P k (C.lowerFace v hv) := by
-  simp [lowerFace_def]
-
-/-- The lower-lower codimension-two square has the same total `U`-exponent along either path.
-Both sides telescope to the ambient cube weight minus the common lower-lower corner weight. -/
+/-- The lower-lower codimension-two square has the same total `U`-exponent along either path. -/
 theorem characteristicLowerFaceExponent_add_lowerFace_comm
     (hv : v ∈ C.directions) (hw : w ∈ C.directions) (hne : v ≠ w) :
     characteristicLowerFaceExponent P k C v +
@@ -62,17 +53,16 @@ theorem characteristicLowerFaceExponent_add_lowerFace_comm
         characteristicLowerFaceExponent P k (C.lowerFace w hw) v := by
   apply Nat.cast_injective (R := ℤ)
   rw [Int.natCast_add, Int.natCast_add]
-  rw [characteristicLowerFaceExponent_natCast_lowerFace P k hv,
-    characteristicLowerFaceExponent_natCast_lowerFace P k
+  rw [characteristicLowerFaceExponent_natCast_lowerFace P k C hv,
+    characteristicLowerFaceExponent_natCast_lowerFace P k (C.lowerFace v hv)
       (by rw [lowerFace_directions]; exact Finset.mem_erase_of_ne_of_mem hne.symm hw),
-    characteristicLowerFaceExponent_natCast_lowerFace P k hw,
-    characteristicLowerFaceExponent_natCast_lowerFace P k
+    characteristicLowerFaceExponent_natCast_lowerFace P k C hw,
+    characteristicLowerFaceExponent_natCast_lowerFace P k (C.lowerFace w hw)
       (by rw [lowerFace_directions]; exact Finset.mem_erase_of_ne_of_mem hne hv)]
   rw [C.lowerFace_lowerFace_comm hv hw hne]
   omega
 
-/-- The upper-upper codimension-two square has the same total `U`-exponent along either path.
-Both sides telescope to the ambient cube weight minus the common upper-upper corner weight. -/
+/-- The upper-upper codimension-two square has the same total `U`-exponent along either path. -/
 theorem characteristicUpperFaceExponent_add_upperFace_comm
     (hv : v ∈ C.directions) (hw : w ∈ C.directions) (hne : v ≠ w) :
     characteristicUpperFaceExponent P k C (v := v) hv +
@@ -102,26 +92,12 @@ theorem characteristicLowerFaceExponent_add_upperFace_comm
         characteristicLowerFaceExponent P k (C.upperFace w hw) v := by
   apply Nat.cast_injective (R := ℤ)
   rw [Int.natCast_add, Int.natCast_add]
-  rw [characteristicLowerFaceExponent_natCast_lowerFace P k hv,
+  rw [characteristicLowerFaceExponent_natCast_lowerFace P k C hv,
     characteristicUpperFaceExponent_natCast, characteristicUpperFaceExponent_natCast,
-    characteristicLowerFaceExponent_natCast_lowerFace P k
+    characteristicLowerFaceExponent_natCast_lowerFace P k (C.upperFace w hw)
       (by rw [upperFace_directions]; exact Finset.mem_erase_of_ne_of_mem hne hv)]
   rw [C.lowerFace_upperFace_comm hv hw hne]
   omega
-
-/-- The upper-then-lower mixed codimension-two square has the same total `U`-exponent as the
-lower-then-upper path to the same corner. This is the symmetric mixed-face form convenient when a
-calculation starts with the upper face in the first direction. -/
-theorem characteristicUpperFaceExponent_add_lowerFace_comm
-    (hv : v ∈ C.directions) (hw : w ∈ C.directions) (hne : v ≠ w) :
-    characteristicUpperFaceExponent P k C (v := v) hv +
-        characteristicLowerFaceExponent P k (C.upperFace v hv) w =
-      characteristicLowerFaceExponent P k C w +
-        characteristicUpperFaceExponent P k (C.lowerFace w hw)
-          (v := v)
-          (by rw [lowerFace_directions]; exact Finset.mem_erase_of_ne_of_mem hne hv) := by
-  rw [add_comm, characteristicLowerFaceExponent_add_upperFace_comm P k C hw hv hne.symm]
-  rw [add_comm]
 
 end PlumbingCube
 

--- a/TauCeti/LowDimTopology/Plumbing/CubeFaceExponent.lean
+++ b/TauCeti/LowDimTopology/Plumbing/CubeFaceExponent.lean
@@ -46,13 +46,18 @@ variable {V : Type*} [DecidableEq V] [Fintype V]
 variable (P : PlumbingGraph V) (k : P.characteristicVectors)
 variable (C : PlumbingCube V) {v w : V}
 
-private theorem characteristicLowerFaceExponent_natCast_lowerFace
+/-- The lower-face exponent, cast back to `ℤ`, is the difference between the bundled cube weight
+and the lower face weight. -/
+theorem characteristicLowerFaceExponent_natCast_lowerFace
     (hv : v ∈ C.directions) :
     (characteristicLowerFaceExponent P k C v : ℤ) =
       characteristicWeight P k C - characteristicWeight P k (C.lowerFace v hv) := by
   rw [characteristicLowerFaceExponent_natCast]
-  congr
-  rw [lowerFace_def]
+  have hface : C.eraseDirection v = C.lowerFace v hv := by
+    apply PlumbingCube.ext
+    · simp
+    · simp
+  rw [hface]
 
 /-- The lower-lower codimension-two square has the same total `U`-exponent along either path. -/
 theorem characteristicLowerFaceExponent_add_lowerFace_comm

--- a/TauCeti/LowDimTopology/Plumbing/CubeGenerator.lean
+++ b/TauCeti/LowDimTopology/Plumbing/CubeGenerator.lean
@@ -266,14 +266,6 @@ theorem characteristicLowerFaceExponent_natCast [Fintype V] (P : PlumbingGraph V
     simp [characteristicLowerFaceExponent_def, characteristicWeight_def, eraseDirection_base,
       eraseDirection_directions]
 
-/-- The lower-face exponent, cast back to `ℤ`, is the difference between the bundled cube weight
-and the lower face weight. -/
-theorem characteristicLowerFaceExponent_natCast_lowerFace [Fintype V] (P : PlumbingGraph V)
-    (k : P.characteristicVectors) (C : PlumbingCube V) {v : V} (hv : v ∈ C.directions) :
-    (characteristicLowerFaceExponent P k C v : ℤ) =
-      characteristicWeight P k C - characteristicWeight P k (C.lowerFace v hv) := by
-  simp [lowerFace_def]
-
 /-- The upper-face exponent, cast back to `ℤ`, is the difference between the bundled cube weight
 and the upper face weight. -/
 @[simp]

--- a/TauCeti/LowDimTopology/Plumbing/CubeGenerator.lean
+++ b/TauCeti/LowDimTopology/Plumbing/CubeGenerator.lean
@@ -266,6 +266,14 @@ theorem characteristicLowerFaceExponent_natCast [Fintype V] (P : PlumbingGraph V
     simp [characteristicLowerFaceExponent_def, characteristicWeight_def, eraseDirection_base,
       eraseDirection_directions]
 
+/-- The lower-face exponent, cast back to `ℤ`, is the difference between the bundled cube weight
+and the lower face weight. -/
+theorem characteristicLowerFaceExponent_natCast_lowerFace [Fintype V] (P : PlumbingGraph V)
+    (k : P.characteristicVectors) (C : PlumbingCube V) {v : V} (hv : v ∈ C.directions) :
+    (characteristicLowerFaceExponent P k C v : ℤ) =
+      characteristicWeight P k C - characteristicWeight P k (C.lowerFace v hv) := by
+  simp [lowerFace_def]
+
 /-- The upper-face exponent, cast back to `ℤ`, is the difference between the bundled cube weight
 and the upper face weight. -/
 @[simp]


### PR DESCRIPTION
This PR records equality of total `U`-exponents around codimension-two plumbing-cube face squares: lower-lower, upper-upper, and the two mixed lower/upper paths. It advances `TauCetiRoadmap/CombinatorialHeegaardFloer/README.md`, Lane L, specifically the lattice-homology target for Némethi cube weights and the cubical differential built from face weights, by supplying the exponent bookkeeping paired with the already-merged codimension-two face commutation API.

I chose this as the lowest-hanging distinct CombinatorialHeegaardFloer target after checking open and recently merged PRs and the existing grid/plumbing files: the grid differential coefficient and small-grid computations are already landed, while Lane L already has plumbing lattices, characteristic weights, cube weights, face exponents, and codimension-two face equality. This PR stays at the next small cubical bookkeeping step and does not define the lattice-homology chain complex or assert `∂² = 0`.

No Mathlib infrastructure is vendored. The implementation reuses Tau Ceti’s existing `PlumbingCube.lowerFace_*_comm` / `upperFace_*_comm` codimension-two face identities and the bundled `characteristicLowerFaceExponent_natCast` / `characteristicUpperFaceExponent_natCast` weight-difference API; the proofs are telescoping equalities after casting the natural exponents to integers.

`lake exe cache get` completed with `No files to download` and `Already decompressed 8609 file(s)`. `lake build` completed with `Build completed successfully (4592 jobs).` `lake exe axioms` completed with `axioms: audited 8634 TauCeti declaration(s); all within the allowlist [propext, Classical.choice, Quot.sound].`

<!--tauceti-target:v1 {"focus":"CombinatorialHeegaardFloer","id":"cube-face-exponent-squares"}-->

🤖 Prepared with Codex
