### PR TITLE
feat: add compact-support exponential moments

### DIFF
--- a/TauCeti/Analysis/SpecialFunctions/Trigonometric/Chebyshev/Measure.lean
+++ b/TauCeti/Analysis/SpecialFunctions/Trigonometric/Chebyshev/Measure.lean
@@ -148,7 +148,8 @@ private lemma ae_mem_Icc_measureT :
 
 This is the compact-support consumer form used by the Chebyshev completeness
 argument. -/
-lemma integrable_exp_mul_abs_smul_measureT {𝕜 : Type*} [RCLike 𝕜] {g : ℝ → 𝕜} (a : ℝ)
+lemma integrable_exp_mul_abs_smul_measureT {𝕜 β : Type*} [RCLike 𝕜] [NormedAddCommGroup β]
+    [NormedSpace 𝕜 β] {g : ℝ → β} (a : ℝ)
     (hg : Integrable g Polynomial.Chebyshev.measureT) :
     Integrable (fun x : ℝ => (Real.exp (a * |x|) : 𝕜) • g x)
       Polynomial.Chebyshev.measureT := by

--- a/TauCeti/Analysis/SpecialFunctions/Trigonometric/Chebyshev/Measure.lean
+++ b/TauCeti/Analysis/SpecialFunctions/Trigonometric/Chebyshev/Measure.lean
@@ -3,7 +3,7 @@ module
 public import Mathlib.Analysis.SpecialFunctions.Trigonometric.Chebyshev.Orthogonality
 public import Mathlib.MeasureTheory.Function.L2Space
 public import Mathlib.MeasureTheory.Measure.Real
-import TauCeti.MeasureTheory.Function.CompactSupportExponential
+import TauCeti.MeasureTheory.Function.BoundedSupportExponential
 import Mathlib.Topology.Algebra.Polynomial
 
 /-!

--- a/TauCeti/Analysis/SpecialFunctions/Trigonometric/Chebyshev/Measure.lean
+++ b/TauCeti/Analysis/SpecialFunctions/Trigonometric/Chebyshev/Measure.lean
@@ -3,6 +3,7 @@ module
 public import Mathlib.Analysis.SpecialFunctions.Trigonometric.Chebyshev.Orthogonality
 public import Mathlib.MeasureTheory.Function.L2Space
 public import Mathlib.MeasureTheory.Measure.Real
+import TauCeti.MeasureTheory.Function.CompactSupportExponential
 import Mathlib.Topology.Algebra.Polynomial
 
 /-!
@@ -151,20 +152,9 @@ lemma integrable_exp_mul_abs_smul_measureT {𝕜 : Type*} [RCLike 𝕜] {g : ℝ
     (hg : Integrable g Polynomial.Chebyshev.measureT) :
     Integrable (fun x : ℝ => (Real.exp (a * |x|) : 𝕜) • g x)
       Polynomial.Chebyshev.measureT := by
-  have h_exp : AEStronglyMeasurable (fun x : ℝ => (Real.exp (a * |x|) : 𝕜))
-      Polynomial.Chebyshev.measureT := by
-    exact (RCLike.continuous_ofReal.comp (by fun_prop)).aestronglyMeasurable
-  refine hg.bdd_smul (Real.exp |a|) h_exp ?_
-  filter_upwards [ae_mem_Icc_measureT] with x hx
-  have hx_abs : |x| ≤ 1 := abs_le.mpr hx
-  have hmul : a * |x| ≤ |a| := by
-    calc
-      a * |x| ≤ |a| * |x| := by
-        exact mul_le_mul_of_nonneg_right (le_abs_self a) (abs_nonneg x)
-      _ ≤ |a| * 1 := by
-        exact mul_le_mul_of_nonneg_left hx_abs (abs_nonneg a)
-      _ = |a| := mul_one _
-  simpa [RCLike.norm_ofReal] using Real.exp_le_exp.mpr hmul
+  exact Integrable.exp_abs_smul_of_ae_abs_le hg a 1 (by
+    filter_upwards [ae_mem_Icc_measureT] with x hx
+    exact abs_le.mpr hx)
 
 /-! ### `L²` consumer forms -/
 

--- a/TauCeti/MeasureTheory/Function/BoundedSupportExponential.lean
+++ b/TauCeti/MeasureTheory/Function/BoundedSupportExponential.lean
@@ -28,7 +28,7 @@ namespace TauCeti
 
 open MeasureTheory
 
-variable {α 𝕜 β : Type*} [NormedAddCommGroup α] [MeasurableSpace α] [BorelSpace α]
+variable {α 𝕜 β : Type*} [NormedAddCommGroup α] [MeasurableSpace α] [OpensMeasurableSpace α]
 variable [RCLike 𝕜] [SecondCountableTopologyEither α 𝕜] [NormedAddCommGroup β]
 variable [NormedSpace 𝕜 β] {μ : Measure α} {g : α → β}
 

--- a/TauCeti/MeasureTheory/Function/BoundedSupportExponential.lean
+++ b/TauCeti/MeasureTheory/Function/BoundedSupportExponential.lean
@@ -12,7 +12,7 @@ public import Mathlib.MeasureTheory.Function.L1Space.Integrable
 /-!
 # Exponential moments from bounded support
 
-This file records a small compact-support integrability principle used by the
+This file records a small bounded-support integrability principle used by the
 `OrthogonalL2Bases` roadmap's moment-determinacy route.  If a measure is supported where the
 argument norm is essentially bounded, multiplying an integrable function by any exponential
 weight `exp (a * ‖x‖)` preserves integrability.  On `ℝ`, this gives the corresponding
@@ -28,8 +28,9 @@ namespace TauCeti
 
 open MeasureTheory
 
-variable {α 𝕜 : Type*} [NormedAddCommGroup α] [MeasurableSpace α] [BorelSpace α]
-variable [RCLike 𝕜] [SecondCountableTopologyEither α 𝕜] {μ : Measure α} {g : α → 𝕜}
+variable {α 𝕜 β : Type*} [NormedAddCommGroup α] [MeasurableSpace α] [BorelSpace α]
+variable [RCLike 𝕜] [SecondCountableTopologyEither α 𝕜] [NormedAddCommGroup β]
+variable [NormedSpace 𝕜 β] {μ : Measure α} {g : α → β}
 
 /-- Multiplication by `exp (a * ‖x‖)` preserves integrability on a measure whose support is
 essentially contained in a closed ball. -/
@@ -51,7 +52,7 @@ protected theorem Integrable.exp_norm_smul_of_ae_norm_le (hg : Integrable g μ) 
     Real.exp_le_exp.mpr (hmul_left.trans hmul_right)
 
 /-- Real-line version of `Integrable.exp_norm_smul_of_ae_norm_le`, stated with `|x|`. -/
-protected theorem Integrable.exp_abs_smul_of_ae_abs_le {μ : Measure ℝ} {g : ℝ → 𝕜}
+protected theorem Integrable.exp_abs_smul_of_ae_abs_le {μ : Measure ℝ} {g : ℝ → β}
     (hg : Integrable g μ) (a R : ℝ) (hR : ∀ᵐ x ∂μ, |x| ≤ R) :
     Integrable (fun x : ℝ => (Real.exp (a * |x|) : 𝕜) • g x) μ := by
   simpa [Real.norm_eq_abs] using

--- a/TauCeti/MeasureTheory/Function/CompactSupportExponential.lean
+++ b/TauCeti/MeasureTheory/Function/CompactSupportExponential.lean
@@ -1,0 +1,61 @@
+module
+
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Codex
+-/
+public import Mathlib.Analysis.RCLike.Basic
+public import Mathlib.Analysis.SpecialFunctions.Exp
+public import Mathlib.MeasureTheory.Function.L1Space.Integrable
+
+/-!
+# Exponential moments from bounded support
+
+This file records a small compact-support integrability principle used by the
+`OrthogonalL2Bases` roadmap's moment-determinacy route.  If a measure is supported where the
+argument norm is essentially bounded, multiplying an integrable function by any exponential
+weight `exp (a * ‖x‖)` preserves integrability.  On `ℝ`, this gives the corresponding
+`exp (a * |x|)` form.
+
+The Chebyshev `T` measure is supported on `[-1, 1]`, so this is the reusable bookkeeping behind
+the finite exponential moments needed before the Chebyshev Hilbert-basis construction.
+-/
+
+public section
+
+namespace TauCeti
+
+open MeasureTheory
+
+variable {α 𝕜 : Type*} [NormedAddCommGroup α] [MeasurableSpace α] [BorelSpace α]
+variable [RCLike 𝕜] [SecondCountableTopologyEither α 𝕜] {μ : Measure α} {g : α → 𝕜}
+
+/-- Multiplication by `exp (a * ‖x‖)` preserves integrability on a measure whose support is
+essentially contained in a closed ball. -/
+protected theorem Integrable.exp_norm_smul_of_ae_norm_le (hg : Integrable g μ) (a R : ℝ)
+    (hR : ∀ᵐ x ∂μ, ‖x‖ ≤ R) :
+    Integrable (fun x : α => (Real.exp (a * ‖x‖) : 𝕜) • g x) μ := by
+  have h_exp : AEStronglyMeasurable (fun x : α => (Real.exp (a * ‖x‖) : 𝕜)) μ := by
+    exact (RCLike.continuous_ofReal.comp
+      (Real.continuous_exp.comp (continuous_const.mul continuous_norm))).aestronglyMeasurable
+  refine hg.bdd_smul (Real.exp (|a| * max R 0)) h_exp ?_
+  filter_upwards [hR] with x hx
+  have hx_nonneg : 0 ≤ ‖x‖ := norm_nonneg x
+  have hx_bound : ‖x‖ ≤ max R 0 := hx.trans (le_max_left R 0)
+  have hmul_left : a * ‖x‖ ≤ |a| * ‖x‖ :=
+    mul_le_mul_of_nonneg_right (le_abs_self a) hx_nonneg
+  have hmul_right : |a| * ‖x‖ ≤ |a| * max R 0 :=
+    mul_le_mul_of_nonneg_left hx_bound (abs_nonneg a)
+  simpa [RCLike.norm_ofReal] using
+    Real.exp_le_exp.mpr (hmul_left.trans hmul_right)
+
+/-- Real-line version of `Integrable.exp_norm_smul_of_ae_norm_le`, stated with `|x|`. -/
+protected theorem Integrable.exp_abs_smul_of_ae_abs_le {μ : Measure ℝ} {g : ℝ → 𝕜}
+    (hg : Integrable g μ) (a R : ℝ) (hR : ∀ᵐ x ∂μ, |x| ≤ R) :
+    Integrable (fun x : ℝ => (Real.exp (a * |x|) : 𝕜) • g x) μ := by
+  simpa [Real.norm_eq_abs] using
+    (Integrable.exp_norm_smul_of_ae_norm_le (α := ℝ) hg a R
+      (by simpa [Real.norm_eq_abs] using hR))
+
+end TauCeti


### PR DESCRIPTION
This PR adds a reusable compact-support exponential-moment lemma and uses it to keep the Chebyshev `measureT` exponential-moment consumer form tied to a general bounded-support principle. It advances `TauCetiRoadmap/OrthogonalL2Bases/README.md`, Part C, specifically the open target that compact support supplies the finite exponential moments needed for B1's moment-determinacy completeness input before `chebyshevHilbertBasis`.

I chose this as the lowest-hanging distinct OrthogonalL2Bases target after checking open and recently merged PRs: open PR #499 covers Hermite A1 orthogonality, open PR #777 covers `hermiteFunctionLp`, and recent merged work already added Chebyshev measure finiteness, normalized modes, cosine transfer, polynomial moments, and `HilbertBasis.mapₗᵢ`. The remaining small gap was to factor the compact-support exponential-moment bookkeeping into a reusable lemma while preserving the existing Chebyshev consumer API; this PR does not attempt B1 uniqueness, the full B2 bridge, or `chebyshevHilbertBasis`.

No Mathlib infrastructure is vendored. The implementation reuses Mathlib's `Integrable.bdd_smul`, `Real.exp_le_exp`, and continuity/a.e.-measurability APIs, together with Tau Ceti's existing `ae_mem_Icc_measureT` support fact for the Chebyshev specialization.

`lake exe cache get` completed with `No files to download` and `Already decompressed 8609 file(s)`. `lake build` completed with `Build completed successfully (4595 jobs).` `lake exe axioms` completed with `axioms: audited 8645 TauCeti declaration(s); all within the allowlist [propext, Classical.choice, Quot.sound].`

<!--tauceti-target:v1 {"focus":"OrthogonalL2Bases","id":"compact-support-exponential-moments"}-->

🤖 Prepared with Codex
