### PR TITLE
feat: add semigroup exponential shifts

### DIFF
--- a/TauCeti/Analysis/Semigroups/ExponentialShift.lean
+++ b/TauCeti/Analysis/Semigroups/ExponentialShift.lean
@@ -1,0 +1,175 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+module
+
+public import TauCeti.Analysis.Semigroups.GrowthBound
+
+/-!
+# Exponential shifts of strongly continuous semigroups
+
+This file defines the exponentially shifted C₀-semigroup
+`t ↦ exp (-lambda t) • S(t)`.  Shifting is the standard way to move a growth bound
+`(ω, M)` to `(ω - lambda, M)`, and in particular to turn a semigroup with bound
+`(lambda, 1)` into a contraction semigroup.
+
+## References
+The construction is standard in the Hille--Yosida theory of C₀-semigroups; see
+Engel--Nagel, *One-Parameter Semigroups for Linear Evolution Equations*, Ch. II.
+-/
+
+public section
+
+noncomputable section
+
+open scoped NNReal
+
+namespace TauCeti.Semigroups
+
+variable {X : Type*} [NormedAddCommGroup X] [NormedSpace ℝ X] [CompleteSpace X]
+
+namespace StronglyContinuousSemigroup
+
+/-- The exponential shift of a C₀-semigroup by `lambda`.
+
+At nonnegative time `t`, this is the semigroup `exp (-lambda t) • S(t)`.  It shifts
+growth exponents by subtracting `lambda`; see `HasGrowthBound.expShift`. -/
+@[expose] def expShift (S : StronglyContinuousSemigroup X) (lambda : ℝ) :
+    StronglyContinuousSemigroup X where
+  toFun t := Real.exp (-(lambda * (t : ℝ))) • S t
+  map_zero' := by
+    rw [NNReal.coe_zero, mul_zero, neg_zero, Real.exp_zero, one_smul, S.map_zero]
+  map_add' s t := by
+    ext x
+    simp only [NNReal.coe_add, ContinuousLinearMap.comp_apply, smul_apply]
+    rw [S.map_add_apply, map_smul, smul_smul]
+    congr 1
+    rw [← Real.exp_add]
+    congr 1
+    ring_nf
+  continuousAt_zero' x := by
+    have h_exp : Filter.Tendsto (fun t : ℝ≥0 => Real.exp (-(lambda * (t : ℝ))))
+        (nhds 0) (nhds 1) := by
+      have h_cont : ContinuousAt (fun t : ℝ≥0 => Real.exp (-(lambda * (t : ℝ)))) 0 :=
+        (Real.continuous_exp.comp ((continuous_const.mul continuous_subtype_val).neg)).continuousAt
+      simpa using h_cont.tendsto
+    have h_orbit := S.continuousAt_zero_tendsto x
+    simpa [ContinuousAt, S.map_zero_apply] using h_exp.smul h_orbit
+
+omit [CompleteSpace X] in
+/-- The native nonnegative-time operator of the exponential shift. -/
+@[simp]
+theorem expShift_apply (S : StronglyContinuousSemigroup X) (lambda : ℝ) (t : ℝ≥0) :
+    S.expShift lambda t = Real.exp (-(lambda * (t : ℝ))) • S t :=
+  rfl
+
+omit [CompleteSpace X] in
+/-- Pointwise form of `StronglyContinuousSemigroup.expShift_apply`. -/
+theorem expShift_apply_apply (S : StronglyContinuousSemigroup X) (lambda : ℝ)
+    (t : ℝ≥0) (x : X) :
+    S.expShift lambda t x = Real.exp (-(lambda * (t : ℝ))) • S t x :=
+  rfl
+
+omit [CompleteSpace X] in
+/-- The zero exponential shift is the original semigroup. -/
+@[simp]
+theorem expShift_zero (S : StronglyContinuousSemigroup X) :
+    S.expShift 0 = S := by
+  ext t x
+  simp
+
+omit [CompleteSpace X] in
+/-- Successive exponential shifts add their parameters. -/
+theorem expShift_expShift (S : StronglyContinuousSemigroup X) (lambda μ : ℝ) :
+    (S.expShift lambda).expShift μ = S.expShift (lambda + μ) := by
+  ext t x
+  simp only [expShift_apply_apply]
+  rw [smul_smul, ← Real.exp_add]
+  congr 1
+  ring_nf
+
+omit [CompleteSpace X] in
+/-- Real-time form of the shifted operator at nonnegative times. -/
+theorem expShift_realOperator_of_nonneg (S : StronglyContinuousSemigroup X)
+    (lambda t : ℝ) (ht : 0 ≤ t) :
+    (S.expShift lambda).realOperator t = Real.exp (-(lambda * t)) • S.realOperator t := by
+  have ht_coe : ((t.toNNReal : ℝ) = t) := Real.coe_toNNReal t ht
+  calc
+    (S.expShift lambda).realOperator t
+        = (S.expShift lambda).realOperator (t.toNNReal : ℝ) := by rw [ht_coe]
+    _ = (S.expShift lambda) t.toNNReal := by rw [realOperator_coe]
+    _ = Real.exp (-(lambda * (t.toNNReal : ℝ))) • S t.toNNReal := rfl
+    _ = Real.exp (-(lambda * t)) • S.realOperator t := by
+        have hS : S.realOperator t = S t.toNNReal := by
+          calc
+            S.realOperator t = S.realOperator (t.toNNReal : ℝ) := by rw [ht_coe]
+            _ = S t.toNNReal := by rw [realOperator_coe]
+        rw [ht_coe, hS]
+
+omit [CompleteSpace X] in
+/-- Pointwise real-time form of the shifted operator at nonnegative times. -/
+theorem expShift_realOperator_apply_of_nonneg (S : StronglyContinuousSemigroup X)
+    (lambda t : ℝ) (ht : 0 ≤ t) (x : X) :
+    (S.expShift lambda).realOperator t x =
+      Real.exp (-(lambda * t)) • S.realOperator t x := by
+  rw [S.expShift_realOperator_of_nonneg lambda t ht]
+  rfl
+
+namespace HasGrowthBound
+
+omit [CompleteSpace X] in
+/-- Exponential shifting subtracts the shift parameter from the growth exponent. -/
+theorem expShift {S : StronglyContinuousSemigroup X} {ω M lambda : ℝ}
+    (hb : S.HasGrowthBound ω M) : (S.expShift lambda).HasGrowthBound (ω - lambda) M := by
+  refine StronglyContinuousSemigroup.hasGrowthBound_of_bound hb.one_le (fun t ht => ?_)
+  rw [S.expShift_realOperator_of_nonneg lambda t ht]
+  calc ‖Real.exp (-(lambda * t)) • S.realOperator t‖
+      ≤ ‖Real.exp (-(lambda * t))‖ * ‖S.realOperator t‖ :=
+        ContinuousLinearMap.opNorm_smul_le _ _
+    _ = Real.exp (-(lambda * t)) * ‖S.realOperator t‖ := by
+        rw [Real.norm_eq_abs, abs_of_nonneg (Real.exp_nonneg _)]
+    _ ≤ Real.exp (-(lambda * t)) * (M * Real.exp (ω * t)) :=
+        mul_le_mul_of_nonneg_left (hb.bound t ht) (Real.exp_nonneg _)
+    _ = M * Real.exp ((ω - lambda) * t) := by
+        rw [show Real.exp (-(lambda * t)) * (M * Real.exp (ω * t)) =
+            M * (Real.exp (-(lambda * t)) * Real.exp (ω * t)) by ring]
+        rw [← Real.exp_add]
+        congr 1
+        ring_nf
+
+end HasGrowthBound
+
+/-- A semigroup with growth bound `(lambda, 1)` becomes a contraction semigroup after
+exponential shifting by `lambda`. -/
+@[expose] def expShiftContraction (S : StronglyContinuousSemigroup X) (lambda : ℝ)
+    (hb : S.HasGrowthBound lambda 1) : ContractionSemigroup X where
+  toStronglyContinuousSemigroup := S.expShift lambda
+  contracting t := by
+    have h := hb.expShift (lambda := lambda)
+    have hbound := h.bound (t : ℝ) (by exact_mod_cast t.2)
+    rw [realOperator_coe] at hbound
+    rw [sub_self, zero_mul, Real.exp_zero, mul_one] at hbound
+    exact hbound
+
+omit [CompleteSpace X] in
+/-- The C₀-semigroup underlying `expShiftContraction` is the exponential shift. -/
+@[simp]
+theorem expShiftContraction_toStronglyContinuousSemigroup
+    (S : StronglyContinuousSemigroup X) (lambda : ℝ) (hb : S.HasGrowthBound lambda 1) :
+    (S.expShiftContraction lambda hb).toStronglyContinuousSemigroup = S.expShift lambda :=
+  rfl
+
+omit [CompleteSpace X] in
+/-- Native operator formula for `expShiftContraction`. -/
+@[simp]
+theorem expShiftContraction_apply (S : StronglyContinuousSemigroup X) (lambda : ℝ)
+    (hb : S.HasGrowthBound lambda 1) (t : ℝ≥0) :
+    S.expShiftContraction lambda hb t = Real.exp (-(lambda * (t : ℝ))) • S t :=
+  rfl
+
+end StronglyContinuousSemigroup
+
+end TauCeti.Semigroups
+
+end

--- a/TauCeti/Analysis/Semigroups/ExponentialShift.lean
+++ b/TauCeti/Analysis/Semigroups/ExponentialShift.lean
@@ -36,7 +36,7 @@ omit [CompleteSpace X] in
 
 At nonnegative time `t`, this is the semigroup `exp (-lambda t) • S(t)`.  It shifts
 growth exponents by subtracting `lambda`; see `HasGrowthBound.expShift`. -/
-@[expose] def expShift (S : StronglyContinuousSemigroup X) (lambda : ℝ) :
+irreducible_def expShift (S : StronglyContinuousSemigroup X) (lambda : ℝ) :
     StronglyContinuousSemigroup X where
   toFun t := Real.exp (-(lambda * (t : ℝ))) • S t
   map_zero' := by
@@ -64,6 +64,7 @@ omit [CompleteSpace X] in
 theorem expShift_apply (S : StronglyContinuousSemigroup X) (lambda : ℝ) (t : ℝ≥0) :
     S.expShift lambda t = Real.exp (-(lambda * (t : ℝ))) • S t :=
   by
+    rw [expShift_def]
     rfl
 
 omit [CompleteSpace X] in
@@ -146,7 +147,7 @@ end HasGrowthBound
 omit [CompleteSpace X] in
 /-- A semigroup with growth bound `(lambda, 1)` becomes a contraction semigroup after
 exponential shifting by `lambda`. -/
-@[expose] def expShiftContraction (S : StronglyContinuousSemigroup X) (lambda : ℝ)
+irreducible_def expShiftContraction (S : StronglyContinuousSemigroup X) (lambda : ℝ)
     (hb : S.HasGrowthBound lambda 1) : ContractionSemigroup X where
   toStronglyContinuousSemigroup := S.expShift lambda
   contracting t := by
@@ -162,7 +163,8 @@ omit [CompleteSpace X] in
 theorem expShiftContraction_toStronglyContinuousSemigroup
     (S : StronglyContinuousSemigroup X) (lambda : ℝ) (hb : S.HasGrowthBound lambda 1) :
     (S.expShiftContraction lambda hb).toStronglyContinuousSemigroup = S.expShift lambda :=
-  rfl
+  by
+    rw [expShiftContraction_def]
 
 omit [CompleteSpace X] in
 /-- Native operator formula for `expShiftContraction`. -/

--- a/TauCeti/Analysis/Semigroups/ExponentialShift.lean
+++ b/TauCeti/Analysis/Semigroups/ExponentialShift.lean
@@ -36,7 +36,6 @@ omit [CompleteSpace X] in
 
 At nonnegative time `t`, this is the semigroup `exp (-lambda t) • S(t)`.  It shifts
 growth exponents by subtracting `lambda`; see `HasGrowthBound.expShift`. -/
-@[expose]
 def expShift (S : StronglyContinuousSemigroup X) (lambda : ℝ) :
     StronglyContinuousSemigroup X where
   toFun t := Real.exp (-(lambda * (t : ℝ))) • S t
@@ -63,8 +62,8 @@ omit [CompleteSpace X] in
 /-- The native nonnegative-time operator of the exponential shift. -/
 @[simp]
 theorem expShift_apply (S : StronglyContinuousSemigroup X) (lambda : ℝ) (t : ℝ≥0) :
-    S.expShift lambda t = Real.exp (-(lambda * (t : ℝ))) • S t :=
-  rfl
+    S.expShift lambda t = Real.exp (-(lambda * (t : ℝ))) • S t := by
+  rw [expShift]; rfl
 
 omit [CompleteSpace X] in
 /-- Pointwise form of `StronglyContinuousSemigroup.expShift_apply`. -/
@@ -146,7 +145,6 @@ end HasGrowthBound
 omit [CompleteSpace X] in
 /-- A semigroup with growth bound `(lambda, 1)` becomes a contraction semigroup after
 exponential shifting by `lambda`. -/
-@[expose]
 def expShiftContraction (S : StronglyContinuousSemigroup X) (lambda : ℝ)
     (hb : S.HasGrowthBound lambda 1) : ContractionSemigroup X where
   toStronglyContinuousSemigroup := S.expShift lambda
@@ -162,8 +160,8 @@ omit [CompleteSpace X] in
 @[simp]
 theorem expShiftContraction_toStronglyContinuousSemigroup
     (S : StronglyContinuousSemigroup X) (lambda : ℝ) (hb : S.HasGrowthBound lambda 1) :
-    (S.expShiftContraction lambda hb).toStronglyContinuousSemigroup = S.expShift lambda :=
-  rfl
+    (S.expShiftContraction lambda hb).toStronglyContinuousSemigroup = S.expShift lambda := by
+  rw [expShiftContraction]
 
 omit [CompleteSpace X] in
 /-- Native operator formula for `expShiftContraction`. -/

--- a/TauCeti/Analysis/Semigroups/ExponentialShift.lean
+++ b/TauCeti/Analysis/Semigroups/ExponentialShift.lean
@@ -31,6 +31,11 @@ variable {X : Type*} [NormedAddCommGroup X] [NormedSpace ℝ X] [CompleteSpace X
 
 namespace StronglyContinuousSemigroup
 
+-- `expShift`'s body is exposed (`@[expose] section`) so that its `irreducible_def`
+-- unfolding lemma `expShift_def` type-checks at the module interface; the definition
+-- stays irreducible for tactics, only its body becomes visible across modules.
+@[expose] section
+
 /-- The exponential shift of a C₀-semigroup by `lambda`.
 
 At nonnegative time `t`, this is the semigroup `exp (-lambda t) • S(t)`.  It shifts
@@ -56,6 +61,8 @@ irreducible_def expShift (S : StronglyContinuousSemigroup X) (lambda : ℝ) :
       simpa using h_cont.tendsto
     have h_orbit := S.continuousAt_zero_tendsto x
     simpa [ContinuousAt, S.map_zero_apply] using h_exp.smul h_orbit
+
+end
 
 omit [CompleteSpace X] in
 /-- The native nonnegative-time operator of the exponential shift. -/
@@ -142,6 +149,10 @@ theorem expShift {S : StronglyContinuousSemigroup X} {ω M lambda : ℝ}
 
 end HasGrowthBound
 
+-- Exposed for the same reason as `expShift`: keeps `expShiftContraction_def` type-checking
+-- at the module interface while the definition stays irreducible for tactics.
+@[expose] section
+
 /-- A semigroup with growth bound `(lambda, 1)` becomes a contraction semigroup after
 exponential shifting by `lambda`. -/
 irreducible_def expShiftContraction (S : StronglyContinuousSemigroup X) (lambda : ℝ)
@@ -153,6 +164,8 @@ irreducible_def expShiftContraction (S : StronglyContinuousSemigroup X) (lambda 
     rw [realOperator_coe] at hbound
     rw [sub_self, zero_mul, Real.exp_zero, mul_one] at hbound
     exact hbound
+
+end
 
 omit [CompleteSpace X] in
 /-- The C₀-semigroup underlying `expShiftContraction` is the exponential shift. -/

--- a/TauCeti/Analysis/Semigroups/ExponentialShift.lean
+++ b/TauCeti/Analysis/Semigroups/ExponentialShift.lean
@@ -31,11 +31,12 @@ variable {X : Type*} [NormedAddCommGroup X] [NormedSpace ℝ X] [CompleteSpace X
 
 namespace StronglyContinuousSemigroup
 
+omit [CompleteSpace X] in
 /-- The exponential shift of a C₀-semigroup by `lambda`.
 
 At nonnegative time `t`, this is the semigroup `exp (-lambda t) • S(t)`.  It shifts
 growth exponents by subtracting `lambda`; see `HasGrowthBound.expShift`. -/
-@[expose] def expShift (S : StronglyContinuousSemigroup X) (lambda : ℝ) :
+irreducible_def expShift (S : StronglyContinuousSemigroup X) (lambda : ℝ) :
     StronglyContinuousSemigroup X where
   toFun t := Real.exp (-(lambda * (t : ℝ))) • S t
   map_zero' := by
@@ -62,7 +63,9 @@ omit [CompleteSpace X] in
 @[simp]
 theorem expShift_apply (S : StronglyContinuousSemigroup X) (lambda : ℝ) (t : ℝ≥0) :
     S.expShift lambda t = Real.exp (-(lambda * (t : ℝ))) • S t :=
-  rfl
+  by
+    rw [expShift_def]
+    rfl
 
 omit [CompleteSpace X] in
 /-- Pointwise form of `StronglyContinuousSemigroup.expShift_apply`. -/
@@ -81,6 +84,7 @@ theorem expShift_zero (S : StronglyContinuousSemigroup X) :
 
 omit [CompleteSpace X] in
 /-- Successive exponential shifts add their parameters. -/
+@[simp]
 theorem expShift_expShift (S : StronglyContinuousSemigroup X) (lambda μ : ℝ) :
     (S.expShift lambda).expShift μ = S.expShift (lambda + μ) := by
   ext t x
@@ -123,7 +127,7 @@ omit [CompleteSpace X] in
 /-- Exponential shifting subtracts the shift parameter from the growth exponent. -/
 theorem expShift {S : StronglyContinuousSemigroup X} {ω M lambda : ℝ}
     (hb : S.HasGrowthBound ω M) : (S.expShift lambda).HasGrowthBound (ω - lambda) M := by
-  refine hasGrowthBound_of_bound hb.one_le (fun t ht => ?_)
+  refine StronglyContinuousSemigroup.hasGrowthBound_of_bound hb.one_le (fun t ht => ?_)
   rw [S.expShift_realOperator_of_nonneg lambda t ht]
   calc ‖Real.exp (-(lambda * t)) • S.realOperator t‖
       ≤ ‖Real.exp (-(lambda * t))‖ * ‖S.realOperator t‖ :=
@@ -140,9 +144,10 @@ theorem expShift {S : StronglyContinuousSemigroup X} {ω M lambda : ℝ}
 
 end HasGrowthBound
 
+omit [CompleteSpace X] in
 /-- A semigroup with growth bound `(lambda, 1)` becomes a contraction semigroup after
 exponential shifting by `lambda`. -/
-@[expose] def expShiftContraction (S : StronglyContinuousSemigroup X) (lambda : ℝ)
+irreducible_def expShiftContraction (S : StronglyContinuousSemigroup X) (lambda : ℝ)
     (hb : S.HasGrowthBound lambda 1) : ContractionSemigroup X where
   toStronglyContinuousSemigroup := S.expShift lambda
   contracting t := by
@@ -158,7 +163,7 @@ omit [CompleteSpace X] in
 theorem expShiftContraction_toStronglyContinuousSemigroup
     (S : StronglyContinuousSemigroup X) (lambda : ℝ) (hb : S.HasGrowthBound lambda 1) :
     (S.expShiftContraction lambda hb).toStronglyContinuousSemigroup = S.expShift lambda :=
-  rfl
+  by rw [expShiftContraction_def]
 
 omit [CompleteSpace X] in
 /-- Native operator formula for `expShiftContraction`. -/

--- a/TauCeti/Analysis/Semigroups/ExponentialShift.lean
+++ b/TauCeti/Analysis/Semigroups/ExponentialShift.lean
@@ -35,7 +35,7 @@ namespace StronglyContinuousSemigroup
 
 At nonnegative time `t`, this is the semigroup `exp (-lambda t) • S(t)`.  It shifts
 growth exponents by subtracting `lambda`; see `HasGrowthBound.expShift`. -/
-irreducible_def expShift (S : StronglyContinuousSemigroup X) (lambda : ℝ) :
+@[expose] def expShift (S : StronglyContinuousSemigroup X) (lambda : ℝ) :
     StronglyContinuousSemigroup X where
   toFun t := Real.exp (-(lambda * (t : ℝ))) • S t
   map_zero' := by
@@ -62,9 +62,7 @@ omit [CompleteSpace X] in
 @[simp]
 theorem expShift_apply (S : StronglyContinuousSemigroup X) (lambda : ℝ) (t : ℝ≥0) :
     S.expShift lambda t = Real.exp (-(lambda * (t : ℝ))) • S t :=
-  by
-    rw [expShift_def]
-    rfl
+  rfl
 
 omit [CompleteSpace X] in
 /-- Pointwise form of `StronglyContinuousSemigroup.expShift_apply`. -/
@@ -144,7 +142,7 @@ end HasGrowthBound
 
 /-- A semigroup with growth bound `(lambda, 1)` becomes a contraction semigroup after
 exponential shifting by `lambda`. -/
-irreducible_def expShiftContraction (S : StronglyContinuousSemigroup X) (lambda : ℝ)
+@[expose] def expShiftContraction (S : StronglyContinuousSemigroup X) (lambda : ℝ)
     (hb : S.HasGrowthBound lambda 1) : ContractionSemigroup X where
   toStronglyContinuousSemigroup := S.expShift lambda
   contracting t := by
@@ -160,7 +158,7 @@ omit [CompleteSpace X] in
 theorem expShiftContraction_toStronglyContinuousSemigroup
     (S : StronglyContinuousSemigroup X) (lambda : ℝ) (hb : S.HasGrowthBound lambda 1) :
     (S.expShiftContraction lambda hb).toStronglyContinuousSemigroup = S.expShift lambda :=
-  by simp [expShiftContraction_def]
+  rfl
 
 omit [CompleteSpace X] in
 /-- Native operator formula for `expShiftContraction`. -/

--- a/TauCeti/Analysis/Semigroups/ExponentialShift.lean
+++ b/TauCeti/Analysis/Semigroups/ExponentialShift.lean
@@ -35,7 +35,7 @@ namespace StronglyContinuousSemigroup
 
 At nonnegative time `t`, this is the semigroup `exp (-lambda t) • S(t)`.  It shifts
 growth exponents by subtracting `lambda`; see `HasGrowthBound.expShift`. -/
-irreducible_def expShift (S : StronglyContinuousSemigroup X) (lambda : ℝ) :
+public abbrev expShift (S : StronglyContinuousSemigroup X) (lambda : ℝ) :
     StronglyContinuousSemigroup X where
   toFun t := Real.exp (-(lambda * (t : ℝ))) • S t
   map_zero' := by
@@ -62,9 +62,7 @@ omit [CompleteSpace X] in
 @[simp]
 theorem expShift_apply (S : StronglyContinuousSemigroup X) (lambda : ℝ) (t : ℝ≥0) :
     S.expShift lambda t = Real.exp (-(lambda * (t : ℝ))) • S t :=
-  by
-    rw [expShift_def]
-    rfl
+  rfl
 
 omit [CompleteSpace X] in
 /-- Pointwise form of `StronglyContinuousSemigroup.expShift_apply`. -/
@@ -89,7 +87,7 @@ theorem expShift_expShift (S : StronglyContinuousSemigroup X) (lambda μ : ℝ) 
   simp only [expShift_apply_apply]
   rw [smul_smul, ← Real.exp_add]
   congr 1
-  ring
+  ring_nf
 
 omit [CompleteSpace X] in
 /-- Real-time form of the shifted operator at nonnegative times. -/
@@ -138,13 +136,13 @@ theorem expShift {S : StronglyContinuousSemigroup X} {ω M lambda : ℝ}
     _ = M * Real.exp ((ω - lambda) * t) := by
         rw [← Real.exp_add]
         congr 1
-        ring
+        ring_nf
 
 end HasGrowthBound
 
 /-- A semigroup with growth bound `(lambda, 1)` becomes a contraction semigroup after
 exponential shifting by `lambda`. -/
-irreducible_def expShiftContraction (S : StronglyContinuousSemigroup X) (lambda : ℝ)
+public abbrev expShiftContraction (S : StronglyContinuousSemigroup X) (lambda : ℝ)
     (hb : S.HasGrowthBound lambda 1) : ContractionSemigroup X where
   toStronglyContinuousSemigroup := S.expShift lambda
   contracting t := by
@@ -160,7 +158,7 @@ omit [CompleteSpace X] in
 theorem expShiftContraction_toStronglyContinuousSemigroup
     (S : StronglyContinuousSemigroup X) (lambda : ℝ) (hb : S.HasGrowthBound lambda 1) :
     (S.expShiftContraction lambda hb).toStronglyContinuousSemigroup = S.expShift lambda :=
-  by rw [expShiftContraction_def]
+  rfl
 
 omit [CompleteSpace X] in
 /-- Native operator formula for `expShiftContraction`. -/

--- a/TauCeti/Analysis/Semigroups/ExponentialShift.lean
+++ b/TauCeti/Analysis/Semigroups/ExponentialShift.lean
@@ -36,7 +36,7 @@ omit [CompleteSpace X] in
 
 At nonnegative time `t`, this is the semigroup `exp (-lambda t) • S(t)`.  It shifts
 growth exponents by subtracting `lambda`; see `HasGrowthBound.expShift`. -/
-irreducible_def expShift (S : StronglyContinuousSemigroup X) (lambda : ℝ) :
+@[expose] def expShift (S : StronglyContinuousSemigroup X) (lambda : ℝ) :
     StronglyContinuousSemigroup X where
   toFun t := Real.exp (-(lambda * (t : ℝ))) • S t
   map_zero' := by
@@ -64,7 +64,6 @@ omit [CompleteSpace X] in
 theorem expShift_apply (S : StronglyContinuousSemigroup X) (lambda : ℝ) (t : ℝ≥0) :
     S.expShift lambda t = Real.exp (-(lambda * (t : ℝ))) • S t :=
   by
-    rw [expShift_def]
     rfl
 
 omit [CompleteSpace X] in
@@ -147,7 +146,7 @@ end HasGrowthBound
 omit [CompleteSpace X] in
 /-- A semigroup with growth bound `(lambda, 1)` becomes a contraction semigroup after
 exponential shifting by `lambda`. -/
-irreducible_def expShiftContraction (S : StronglyContinuousSemigroup X) (lambda : ℝ)
+@[expose] def expShiftContraction (S : StronglyContinuousSemigroup X) (lambda : ℝ)
     (hb : S.HasGrowthBound lambda 1) : ContractionSemigroup X where
   toStronglyContinuousSemigroup := S.expShift lambda
   contracting t := by
@@ -163,7 +162,7 @@ omit [CompleteSpace X] in
 theorem expShiftContraction_toStronglyContinuousSemigroup
     (S : StronglyContinuousSemigroup X) (lambda : ℝ) (hb : S.HasGrowthBound lambda 1) :
     (S.expShiftContraction lambda hb).toStronglyContinuousSemigroup = S.expShift lambda :=
-  by rw [expShiftContraction_def]
+  rfl
 
 omit [CompleteSpace X] in
 /-- Native operator formula for `expShiftContraction`. -/

--- a/TauCeti/Analysis/Semigroups/ExponentialShift.lean
+++ b/TauCeti/Analysis/Semigroups/ExponentialShift.lean
@@ -31,6 +31,11 @@ variable {X : Type*} [NormedAddCommGroup X] [NormedSpace ℝ X] [CompleteSpace X
 
 namespace StronglyContinuousSemigroup
 
+-- `expShift`'s body is exposed (`@[expose] section`) so that its `irreducible_def`
+-- unfolding lemma `expShift_def` type-checks at the module interface; the definition
+-- stays irreducible for tactics, only its body becomes visible across modules.
+@[expose] section
+
 omit [CompleteSpace X] in
 /-- The exponential shift of a C₀-semigroup by `lambda`.
 
@@ -57,6 +62,8 @@ irreducible_def expShift (S : StronglyContinuousSemigroup X) (lambda : ℝ) :
       simpa using h_cont.tendsto
     have h_orbit := S.continuousAt_zero_tendsto x
     simpa [ContinuousAt, S.map_zero_apply] using h_exp.smul h_orbit
+
+end
 
 omit [CompleteSpace X] in
 /-- The native nonnegative-time operator of the exponential shift. -/
@@ -144,6 +151,10 @@ theorem expShift {S : StronglyContinuousSemigroup X} {ω M lambda : ℝ}
 
 end HasGrowthBound
 
+-- Exposed for the same reason as `expShift`: keeps `expShiftContraction_def` type-checking
+-- at the module interface while the definition stays irreducible for tactics.
+@[expose] section
+
 omit [CompleteSpace X] in
 /-- A semigroup with growth bound `(lambda, 1)` becomes a contraction semigroup after
 exponential shifting by `lambda`. -/
@@ -156,6 +167,8 @@ irreducible_def expShiftContraction (S : StronglyContinuousSemigroup X) (lambda 
     rw [realOperator_coe] at hbound
     rw [sub_self, zero_mul, Real.exp_zero, mul_one] at hbound
     exact hbound
+
+end
 
 omit [CompleteSpace X] in
 /-- The C₀-semigroup underlying `expShiftContraction` is the exponential shift. -/

--- a/TauCeti/Analysis/Semigroups/ExponentialShift.lean
+++ b/TauCeti/Analysis/Semigroups/ExponentialShift.lean
@@ -31,11 +31,6 @@ variable {X : Type*} [NormedAddCommGroup X] [NormedSpace ℝ X] [CompleteSpace X
 
 namespace StronglyContinuousSemigroup
 
--- `expShift`'s body is exposed (`@[expose] section`) so that its `irreducible_def`
--- unfolding lemma `expShift_def` type-checks at the module interface; the definition
--- stays irreducible for tactics, only its body becomes visible across modules.
-@[expose] section
-
 /-- The exponential shift of a C₀-semigroup by `lambda`.
 
 At nonnegative time `t`, this is the semigroup `exp (-lambda t) • S(t)`.  It shifts
@@ -52,7 +47,7 @@ irreducible_def expShift (S : StronglyContinuousSemigroup X) (lambda : ℝ) :
     congr 1
     rw [← Real.exp_add]
     congr 1
-    ring_nf
+    ring
   continuousAt_zero' x := by
     have h_exp : Filter.Tendsto (fun t : ℝ≥0 => Real.exp (-(lambda * (t : ℝ))))
         (nhds 0) (nhds 1) := by
@@ -61,8 +56,6 @@ irreducible_def expShift (S : StronglyContinuousSemigroup X) (lambda : ℝ) :
       simpa using h_cont.tendsto
     have h_orbit := S.continuousAt_zero_tendsto x
     simpa [ContinuousAt, S.map_zero_apply] using h_exp.smul h_orbit
-
-end
 
 omit [CompleteSpace X] in
 /-- The native nonnegative-time operator of the exponential shift. -/
@@ -96,7 +89,7 @@ theorem expShift_expShift (S : StronglyContinuousSemigroup X) (lambda μ : ℝ) 
   simp only [expShift_apply_apply]
   rw [smul_smul, ← Real.exp_add]
   congr 1
-  ring_nf
+  ring
 
 omit [CompleteSpace X] in
 /-- Real-time form of the shifted operator at nonnegative times. -/
@@ -124,7 +117,7 @@ theorem expShift_realOperator_apply_of_nonneg (S : StronglyContinuousSemigroup X
     (S.expShift lambda).realOperator t x =
       Real.exp (-(lambda * t)) • S.realOperator t x := by
   rw [S.expShift_realOperator_of_nonneg lambda t ht]
-  rfl
+  rw [smul_apply]
 
 namespace HasGrowthBound
 
@@ -145,13 +138,9 @@ theorem expShift {S : StronglyContinuousSemigroup X} {ω M lambda : ℝ}
     _ = M * Real.exp ((ω - lambda) * t) := by
         rw [← Real.exp_add]
         congr 1
-        ring_nf
+        ring
 
 end HasGrowthBound
-
--- Exposed for the same reason as `expShift`: keeps `expShiftContraction_def` type-checking
--- at the module interface while the definition stays irreducible for tactics.
-@[expose] section
 
 /-- A semigroup with growth bound `(lambda, 1)` becomes a contraction semigroup after
 exponential shifting by `lambda`. -/
@@ -164,8 +153,6 @@ irreducible_def expShiftContraction (S : StronglyContinuousSemigroup X) (lambda 
     rw [realOperator_coe] at hbound
     rw [sub_self, zero_mul, Real.exp_zero, mul_one] at hbound
     exact hbound
-
-end
 
 omit [CompleteSpace X] in
 /-- The C₀-semigroup underlying `expShiftContraction` is the exponential shift. -/

--- a/TauCeti/Analysis/Semigroups/ExponentialShift.lean
+++ b/TauCeti/Analysis/Semigroups/ExponentialShift.lean
@@ -35,7 +35,7 @@ namespace StronglyContinuousSemigroup
 
 At nonnegative time `t`, this is the semigroup `exp (-lambda t) • S(t)`.  It shifts
 growth exponents by subtracting `lambda`; see `HasGrowthBound.expShift`. -/
-public abbrev expShift (S : StronglyContinuousSemigroup X) (lambda : ℝ) :
+irreducible_def expShift (S : StronglyContinuousSemigroup X) (lambda : ℝ) :
     StronglyContinuousSemigroup X where
   toFun t := Real.exp (-(lambda * (t : ℝ))) • S t
   map_zero' := by
@@ -62,7 +62,9 @@ omit [CompleteSpace X] in
 @[simp]
 theorem expShift_apply (S : StronglyContinuousSemigroup X) (lambda : ℝ) (t : ℝ≥0) :
     S.expShift lambda t = Real.exp (-(lambda * (t : ℝ))) • S t :=
-  rfl
+  by
+    rw [expShift_def]
+    rfl
 
 omit [CompleteSpace X] in
 /-- Pointwise form of `StronglyContinuousSemigroup.expShift_apply`. -/
@@ -123,7 +125,7 @@ omit [CompleteSpace X] in
 /-- Exponential shifting subtracts the shift parameter from the growth exponent. -/
 theorem expShift {S : StronglyContinuousSemigroup X} {ω M lambda : ℝ}
     (hb : S.HasGrowthBound ω M) : (S.expShift lambda).HasGrowthBound (ω - lambda) M := by
-  refine StronglyContinuousSemigroup.hasGrowthBound_of_bound hb.one_le (fun t ht => ?_)
+  refine hasGrowthBound_of_bound hb.one_le (fun t ht => ?_)
   rw [S.expShift_realOperator_of_nonneg lambda t ht]
   calc ‖Real.exp (-(lambda * t)) • S.realOperator t‖
       ≤ ‖Real.exp (-(lambda * t))‖ * ‖S.realOperator t‖ :=
@@ -142,7 +144,7 @@ end HasGrowthBound
 
 /-- A semigroup with growth bound `(lambda, 1)` becomes a contraction semigroup after
 exponential shifting by `lambda`. -/
-public abbrev expShiftContraction (S : StronglyContinuousSemigroup X) (lambda : ℝ)
+irreducible_def expShiftContraction (S : StronglyContinuousSemigroup X) (lambda : ℝ)
     (hb : S.HasGrowthBound lambda 1) : ContractionSemigroup X where
   toStronglyContinuousSemigroup := S.expShift lambda
   contracting t := by
@@ -158,7 +160,7 @@ omit [CompleteSpace X] in
 theorem expShiftContraction_toStronglyContinuousSemigroup
     (S : StronglyContinuousSemigroup X) (lambda : ℝ) (hb : S.HasGrowthBound lambda 1) :
     (S.expShiftContraction lambda hb).toStronglyContinuousSemigroup = S.expShift lambda :=
-  rfl
+  by simp [expShiftContraction_def]
 
 omit [CompleteSpace X] in
 /-- Native operator formula for `expShiftContraction`. -/

--- a/TauCeti/Analysis/Semigroups/ExponentialShift.lean
+++ b/TauCeti/Analysis/Semigroups/ExponentialShift.lean
@@ -36,7 +36,8 @@ omit [CompleteSpace X] in
 
 At nonnegative time `t`, this is the semigroup `exp (-lambda t) • S(t)`.  It shifts
 growth exponents by subtracting `lambda`; see `HasGrowthBound.expShift`. -/
-irreducible_def expShift (S : StronglyContinuousSemigroup X) (lambda : ℝ) :
+@[expose]
+def expShift (S : StronglyContinuousSemigroup X) (lambda : ℝ) :
     StronglyContinuousSemigroup X where
   toFun t := Real.exp (-(lambda * (t : ℝ))) • S t
   map_zero' := by
@@ -63,9 +64,7 @@ omit [CompleteSpace X] in
 @[simp]
 theorem expShift_apply (S : StronglyContinuousSemigroup X) (lambda : ℝ) (t : ℝ≥0) :
     S.expShift lambda t = Real.exp (-(lambda * (t : ℝ))) • S t :=
-  by
-    rw [expShift_def]
-    rfl
+  rfl
 
 omit [CompleteSpace X] in
 /-- Pointwise form of `StronglyContinuousSemigroup.expShift_apply`. -/
@@ -147,7 +146,8 @@ end HasGrowthBound
 omit [CompleteSpace X] in
 /-- A semigroup with growth bound `(lambda, 1)` becomes a contraction semigroup after
 exponential shifting by `lambda`. -/
-irreducible_def expShiftContraction (S : StronglyContinuousSemigroup X) (lambda : ℝ)
+@[expose]
+def expShiftContraction (S : StronglyContinuousSemigroup X) (lambda : ℝ)
     (hb : S.HasGrowthBound lambda 1) : ContractionSemigroup X where
   toStronglyContinuousSemigroup := S.expShift lambda
   contracting t := by
@@ -163,8 +163,7 @@ omit [CompleteSpace X] in
 theorem expShiftContraction_toStronglyContinuousSemigroup
     (S : StronglyContinuousSemigroup X) (lambda : ℝ) (hb : S.HasGrowthBound lambda 1) :
     (S.expShiftContraction lambda hb).toStronglyContinuousSemigroup = S.expShift lambda :=
-  by
-    rw [expShiftContraction_def]
+  rfl
 
 omit [CompleteSpace X] in
 /-- Native operator formula for `expShiftContraction`. -/

--- a/TauCeti/Analysis/Semigroups/ExponentialShift.lean
+++ b/TauCeti/Analysis/Semigroups/ExponentialShift.lean
@@ -31,11 +31,6 @@ variable {X : Type*} [NormedAddCommGroup X] [NormedSpace ℝ X] [CompleteSpace X
 
 namespace StronglyContinuousSemigroup
 
--- `expShift`'s body is exposed (`@[expose] section`) so that its `irreducible_def`
--- unfolding lemma `expShift_def` type-checks at the module interface; the definition
--- stays irreducible for tactics, only its body becomes visible across modules.
-@[expose] section
-
 omit [CompleteSpace X] in
 /-- The exponential shift of a C₀-semigroup by `lambda`.
 
@@ -62,8 +57,6 @@ irreducible_def expShift (S : StronglyContinuousSemigroup X) (lambda : ℝ) :
       simpa using h_cont.tendsto
     have h_orbit := S.continuousAt_zero_tendsto x
     simpa [ContinuousAt, S.map_zero_apply] using h_exp.smul h_orbit
-
-end
 
 omit [CompleteSpace X] in
 /-- The native nonnegative-time operator of the exponential shift. -/
@@ -151,10 +144,6 @@ theorem expShift {S : StronglyContinuousSemigroup X} {ω M lambda : ℝ}
 
 end HasGrowthBound
 
--- Exposed for the same reason as `expShift`: keeps `expShiftContraction_def` type-checking
--- at the module interface while the definition stays irreducible for tactics.
-@[expose] section
-
 omit [CompleteSpace X] in
 /-- A semigroup with growth bound `(lambda, 1)` becomes a contraction semigroup after
 exponential shifting by `lambda`. -/
@@ -167,8 +156,6 @@ irreducible_def expShiftContraction (S : StronglyContinuousSemigroup X) (lambda 
     rw [realOperator_coe] at hbound
     rw [sub_self, zero_mul, Real.exp_zero, mul_one] at hbound
     exact hbound
-
-end
 
 omit [CompleteSpace X] in
 /-- The C₀-semigroup underlying `expShiftContraction` is the exponential shift. -/

--- a/TauCeti/Analysis/Semigroups/ExponentialShift.lean
+++ b/TauCeti/Analysis/Semigroups/ExponentialShift.lean
@@ -35,7 +35,7 @@ namespace StronglyContinuousSemigroup
 
 At nonnegative time `t`, this is the semigroup `exp (-lambda t) • S(t)`.  It shifts
 growth exponents by subtracting `lambda`; see `HasGrowthBound.expShift`. -/
-@[expose] def expShift (S : StronglyContinuousSemigroup X) (lambda : ℝ) :
+irreducible_def expShift (S : StronglyContinuousSemigroup X) (lambda : ℝ) :
     StronglyContinuousSemigroup X where
   toFun t := Real.exp (-(lambda * (t : ℝ))) • S t
   map_zero' := by
@@ -62,14 +62,16 @@ omit [CompleteSpace X] in
 @[simp]
 theorem expShift_apply (S : StronglyContinuousSemigroup X) (lambda : ℝ) (t : ℝ≥0) :
     S.expShift lambda t = Real.exp (-(lambda * (t : ℝ))) • S t :=
-  rfl
+  by
+    rw [expShift_def]
+    rfl
 
 omit [CompleteSpace X] in
 /-- Pointwise form of `StronglyContinuousSemigroup.expShift_apply`. -/
 theorem expShift_apply_apply (S : StronglyContinuousSemigroup X) (lambda : ℝ)
     (t : ℝ≥0) (x : X) :
     S.expShift lambda t x = Real.exp (-(lambda * (t : ℝ))) • S t x :=
-  rfl
+  by rw [expShift_apply, smul_apply]
 
 omit [CompleteSpace X] in
 /-- The zero exponential shift is the original semigroup. -/
@@ -99,7 +101,8 @@ theorem expShift_realOperator_of_nonneg (S : StronglyContinuousSemigroup X)
     (S.expShift lambda).realOperator t
         = (S.expShift lambda).realOperator (t.toNNReal : ℝ) := by rw [ht_coe]
     _ = (S.expShift lambda) t.toNNReal := by rw [realOperator_coe]
-    _ = Real.exp (-(lambda * (t.toNNReal : ℝ))) • S t.toNNReal := rfl
+    _ = Real.exp (-(lambda * (t.toNNReal : ℝ))) • S t.toNNReal := by
+        rw [expShift_apply]
     _ = Real.exp (-(lambda * t)) • S.realOperator t := by
         have hS : S.realOperator t = S t.toNNReal := by
           calc
@@ -131,9 +134,8 @@ theorem expShift {S : StronglyContinuousSemigroup X} {ω M lambda : ℝ}
         rw [Real.norm_eq_abs, abs_of_nonneg (Real.exp_nonneg _)]
     _ ≤ Real.exp (-(lambda * t)) * (M * Real.exp (ω * t)) :=
         mul_le_mul_of_nonneg_left (hb.bound t ht) (Real.exp_nonneg _)
+    _ = M * (Real.exp (-(lambda * t)) * Real.exp (ω * t)) := by ring
     _ = M * Real.exp ((ω - lambda) * t) := by
-        rw [show Real.exp (-(lambda * t)) * (M * Real.exp (ω * t)) =
-            M * (Real.exp (-(lambda * t)) * Real.exp (ω * t)) by ring]
         rw [← Real.exp_add]
         congr 1
         ring_nf
@@ -142,7 +144,7 @@ end HasGrowthBound
 
 /-- A semigroup with growth bound `(lambda, 1)` becomes a contraction semigroup after
 exponential shifting by `lambda`. -/
-@[expose] def expShiftContraction (S : StronglyContinuousSemigroup X) (lambda : ℝ)
+irreducible_def expShiftContraction (S : StronglyContinuousSemigroup X) (lambda : ℝ)
     (hb : S.HasGrowthBound lambda 1) : ContractionSemigroup X where
   toStronglyContinuousSemigroup := S.expShift lambda
   contracting t := by
@@ -158,7 +160,7 @@ omit [CompleteSpace X] in
 theorem expShiftContraction_toStronglyContinuousSemigroup
     (S : StronglyContinuousSemigroup X) (lambda : ℝ) (hb : S.HasGrowthBound lambda 1) :
     (S.expShiftContraction lambda hb).toStronglyContinuousSemigroup = S.expShift lambda :=
-  rfl
+  by rw [expShiftContraction_def]
 
 omit [CompleteSpace X] in
 /-- Native operator formula for `expShiftContraction`. -/
@@ -166,7 +168,12 @@ omit [CompleteSpace X] in
 theorem expShiftContraction_apply (S : StronglyContinuousSemigroup X) (lambda : ℝ)
     (hb : S.HasGrowthBound lambda 1) (t : ℝ≥0) :
     S.expShiftContraction lambda hb t = Real.exp (-(lambda * (t : ℝ))) • S t :=
-  rfl
+  by
+    calc
+      S.expShiftContraction lambda hb t =
+          (S.expShiftContraction lambda hb).toStronglyContinuousSemigroup t := rfl
+      _ = Real.exp (-(lambda * (t : ℝ))) • S t := by
+          rw [expShiftContraction_toStronglyContinuousSemigroup, expShift_apply]
 
 end StronglyContinuousSemigroup
 

--- a/TauCeti/Analysis/Semigroups/GrowthBound.lean
+++ b/TauCeti/Analysis/Semigroups/GrowthBound.lean
@@ -52,6 +52,16 @@ theorem StronglyContinuousSemigroup.HasGrowthBound.bound
   exact hb.2 t ht
 
 omit [CompleteSpace X] in
+/-- Constructor for a growth bound from the multiplicative lower bound and operator-norm
+estimate. -/
+theorem StronglyContinuousSemigroup.hasGrowthBound_of_bound
+    {S : StronglyContinuousSemigroup X} {ω M : ℝ} (hM : 1 ≤ M)
+    (hbound : ∀ (t : ℝ), 0 ≤ t → ‖S.realOperator t‖ ≤ M * Real.exp (ω * t)) :
+    S.HasGrowthBound ω M := by
+  unfold StronglyContinuousSemigroup.HasGrowthBound
+  exact ⟨hM, hbound⟩
+
+omit [CompleteSpace X] in
 /-- A growth bound can be weakened by increasing both the exponential rate and the multiplicative
 constant. -/
 theorem StronglyContinuousSemigroup.HasGrowthBound.mono

--- a/TauCeti/Analysis/Semigroups/GrowthBound.lean
+++ b/TauCeti/Analysis/Semigroups/GrowthBound.lean
@@ -54,7 +54,7 @@ theorem StronglyContinuousSemigroup.HasGrowthBound.bound
 omit [CompleteSpace X] in
 /-- Constructor for a growth bound from the multiplicative lower bound and operator-norm
 estimate. -/
-theorem StronglyContinuousSemigroup.hasGrowthBound_of_bound
+public theorem StronglyContinuousSemigroup.hasGrowthBound_of_bound
     {S : StronglyContinuousSemigroup X} {ω M : ℝ} (hM : 1 ≤ M)
     (hbound : ∀ (t : ℝ), 0 ≤ t → ‖S.realOperator t‖ ≤ M * Real.exp (ω * t)) :
     S.HasGrowthBound ω M := by

--- a/TauCeti/Analysis/Semigroups/Resolvent.lean
+++ b/TauCeti/Analysis/Semigroups/Resolvent.lean
@@ -5,7 +5,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 module
 
 public import TauCeti.Analysis.Semigroups.Generator
-public import TauCeti.Analysis.Semigroups.GrowthBound
+public import TauCeti.Analysis.Semigroups.ExponentialShift
 public import Mathlib.Analysis.SpecialFunctions.ExpDeriv
 public import Mathlib.MeasureTheory.Integral.ExpDecay
 public import Mathlib.MeasureTheory.Integral.IntervalIntegral.FundThmCalculus
@@ -200,28 +200,6 @@ private theorem StronglyContinuousSemigroup.resolvent_shift_identity
   simp only [smul_sub, sub_smul, one_smul]
   abel
 
-private def StronglyContinuousSemigroup.expScaled
-    (S : StronglyContinuousSemigroup X) (lambda : ℝ) : StronglyContinuousSemigroup X where
-  toFun t := Real.exp (-(lambda * (t : ℝ))) • S t
-  map_zero' := by
-    rw [NNReal.coe_zero, mul_zero, neg_zero, Real.exp_zero, one_smul, S.map_zero]
-  map_add' s t := by
-    ext x
-    simp only [NNReal.coe_add, ContinuousLinearMap.comp_apply, smul_apply]
-    rw [S.map_add_apply, map_smul, smul_smul]
-    congr 1
-    rw [← Real.exp_add]
-    congr 1
-    ring
-  continuousAt_zero' x := by
-    have h_exp : Filter.Tendsto (fun t : ℝ≥0 => Real.exp (-(lambda * (t : ℝ))))
-        (nhds 0) (nhds 1) := by
-      have h_cont : ContinuousAt (fun t : ℝ≥0 => Real.exp (-(lambda * (t : ℝ)))) 0 :=
-        (Real.continuous_exp.comp ((continuous_const.mul continuous_subtype_val).neg)).continuousAt
-      simpa using h_cont.tendsto
-    have h := h_exp.smul (S.continuousAt_zero_tendsto x)
-    simpa [ContinuousAt, S.map_zero_apply] using h
-
 /-- The integral average `(1/t) • ∫_{(0,t]} e^{-λu} S(u)x du` of the resolvent integrand
 tends to `x` as `t → 0⁺`. -/
 private theorem StronglyContinuousSemigroup.tendsto_average_resolvent_integrand
@@ -229,7 +207,7 @@ private theorem StronglyContinuousSemigroup.tendsto_average_resolvent_integrand
     Filter.Tendsto
       (fun t => (1 / t) • ∫ u in Set.Ioc 0 t, Real.exp (-(lambda * u)) • S.realOperator u x)
       (nhdsWithin 0 (Set.Ioi 0)) (nhds x) := by
-  let T := S.expScaled lambda
+  let T := S.expShift lambda
   have h := T.tendsto_average_orbit_zero x
   refine h.congr' ?_
   filter_upwards [self_mem_nhdsWithin] with t (ht : 0 < t)
@@ -237,14 +215,7 @@ private theorem StronglyContinuousSemigroup.tendsto_average_resolvent_integrand
   apply MeasureTheory.setIntegral_congr_fun measurableSet_Ioc
   intro u hu
   have hu_nonneg : 0 ≤ u := hu.1.le
-  have hu_toNN : ((u.toNNReal : ℝ) = u) := Real.coe_toNNReal u hu_nonneg
-  calc
-    (T.realOperator u) x = (T.realOperator (u.toNNReal : ℝ)) x := by rw [hu_toNN]
-    _ = T u.toNNReal x := by rw [T.realOperator_coe u.toNNReal]
-    _ = (Real.exp (-(lambda * (u.toNNReal : ℝ))) • S u.toNNReal) x := by rfl
-    _ = Real.exp (-(lambda * (u.toNNReal : ℝ))) • S u.toNNReal x := by rw [smul_apply]
-    _ = Real.exp (-(lambda * u)) • (S.realOperator u) x := by
-        rw [← S.realOperator_coe u.toNNReal, hu_toNN]
+  exact S.expShift_realOperator_apply_of_nonneg lambda u hu_nonneg x
 
 
 /-- The generator difference quotient for `R(λ)x` converges to `λ R(λ)x - x`. -/


### PR DESCRIPTION
This PR adds public exponential-shift API for C0 semigroups: `S.expShift lambda` packages `t ↦ exp (-lambda t) • S(t)`, records native and real-time formulas, transports growth bounds from `(omega, M)` to `(omega - lambda, M)`, and packages a `(lambda, 1)`-bounded semigroup as a contraction after shifting.

It advances `TauCetiRoadmap/OneParameterSemigroups/README.md`, Part A, “Strongly continuous semigroups,” specifically the API around “the semigroup laws, strong continuity, and the growth bound `‖S t‖ ≤ M e^{omega t}` (`existsGrowthBound`),” together with the roadmap’s instruction that general C0 semigroups with growth bounds come before contraction semigroups. I chose this as the lowest-hanging distinct OneParameterSemigroups target after checking open and recently merged PRs: Bernstein representation work is claimed/open, the C0 semigroup object and growth-bound weakening API already exist on `main`, and the exponential shift was only available as private proof machinery inside the resolvent file rather than reusable public API.

No Mathlib infrastructure is vendored. The construction follows the standard Hille-Yosida exponential shift from Engel-Nagel, *One-Parameter Semigroups for Linear Evolution Equations*, and reuses Tau Ceti’s existing `StronglyContinuousSemigroup`, `ContractionSemigroup`, `realOperator`, and `HasGrowthBound` APIs together with Mathlib’s operator-norm scalar bound.

`lake exe cache get` completed with `No files to download` and `Already decompressed 8609 file(s)`. `lake build` completed with `Build completed successfully (4595 jobs).` `lake exe axioms` completed with `axioms: audited 8661 TauCeti declaration(s); all within the allowlist [propext, Classical.choice, Quot.sound].`

<!--tauceti-target:v1 {"focus":"OneParameterSemigroups","id":"exponential-shift-semigroup"}-->

🤖 Prepared with Codex
