### PR TITLE
feat: add winding number translation API

### DIFF
--- a/TauCeti/Analysis/Contour/CauchyPrincipalValue.lean
+++ b/TauCeti/Analysis/Contour/CauchyPrincipalValue.lean
@@ -343,14 +343,10 @@ theorem HasCauchyPVAt.translate {γ : ℝ → ℂ} {a b : ℝ} {f : ℂ → ℂ}
   refine HasCauchyPVAt.intro ?_ ?_
   · filter_upwards [h.eventually_intervalIntegrable] with ε hε
     refine (intervalIntegrable_congr fun t _ => ?_).mpr hε
-    by_cases hεt : ‖γ t - z₀‖ > ε
-    · simp [hεt]
-    · simp [hεt]
+    simp [add_sub_add_right_eq_sub, add_sub_cancel_right, deriv_add_const]
   · refine h.tendsto.congr fun ε => ?_
     refine intervalIntegral.integral_congr fun t _ => ?_
-    by_cases hεt : ‖γ t - z₀‖ > ε
-    · simp [hεt]
-    · simp [hεt]
+    simp [add_sub_add_right_eq_sub, add_sub_cancel_right, deriv_add_const]
 
 /-- Existence form of `HasCauchyPVAt.translate`: simultaneous translation preserves existence of a
 single-point Cauchy principal value. -/
@@ -369,9 +365,7 @@ theorem cauchyPVAt_translate {γ : ℝ → ℂ} {a b : ℝ} {f : ℂ → ℂ} {z
   congr 1
   ext ε
   refine intervalIntegral.integral_congr fun t _ => ?_
-  by_cases hεt : ‖γ t - z₀‖ > ε
-  · simp [hεt]
-  · simp [hεt]
+  simp [add_sub_add_right_eq_sub, add_sub_cancel_right, deriv_add_const]
 
 /-- Reversing the interval orientation negates a single-point Cauchy principal value. -/
 theorem HasCauchyPVAt.symm {γ : ℝ → ℂ} {a b : ℝ} {f : ℂ → ℂ} {z₀ L : ℂ}

--- a/TauCeti/Analysis/Contour/CauchyPrincipalValue.lean
+++ b/TauCeti/Analysis/Contour/CauchyPrincipalValue.lean
@@ -7,6 +7,7 @@ module
 
 public import Mathlib.MeasureTheory.Integral.IntervalIntegral.Basic
 public import Mathlib.Analysis.Calculus.Deriv.Basic
+import Mathlib.Analysis.Calculus.Deriv.Add
 public import Mathlib.Analysis.Complex.Basic
 import Mathlib.Topology.Order.Compact
 
@@ -51,13 +52,16 @@ versus `MeromorphicOn` (on a set).
   `HasCauchyPVAt.cauchyPVAt_eq`, `HasCauchyPVAt.unique` — the value and its uniqueness;
   `cauchyPVExistsAt_iff`, `CauchyPVExistsAt.intro`, `CauchyPVExistsAt.hasCauchyPVAt_cauchyPVAt` —
   package/unpack existence and recover the predicate at `cauchyPVAt`.
-* `HasCauchyPVAt.congr_along_curve` — the integrand only matters along `γ` on `[a, b]`;
+* `HasCauchyPVAt.congr_along_curve`, `cauchyPVAt_congr_along_curve` — the integrand only matters
+  along `γ` on `[a, b]`;
   `HasCauchyPVAt.zero`, `HasCauchyPVAt.const_mul`, `HasCauchyPVAt.add`, `HasCauchyPVAt.sum` (and the
   `CauchyPVExistsAt` forms) — the principal value is `ℂ`-linear in the integrand, including over
   finite sums.
 * `HasCauchyPVAt.of_avoidance` — if `γ` avoids `z₀` on `[a, b]` and the integrand is integrable
   there, the principal value is the ordinary integral (`cauchyPVExistsAt_of_avoidance` is the
   existence form).
+* `HasCauchyPVAt.translate`, `CauchyPVExistsAt.translate`, `cauchyPVAt_translate` — simultaneous
+  translation of the curve, point, and integrand preserves the principal value.
 * `HasCauchyPVAt.symm`, `CauchyPVExistsAt.symm`, `cauchyPVAt_symm` — reversing the interval
   orientation negates the single-point principal value.
 * `HasCauchyPVAt.concat` — the principal values on `[a, b]` and `[b, c]` add
@@ -182,6 +186,17 @@ theorem HasCauchyPVAt.congr_along_curve {γ : ℝ → ℂ} {a b : ℝ} {f g : �
     simp only [h_eq t ht]
   · refine Filter.Tendsto.congr (fun ε => intervalIntegral.integral_congr_uIoo fun t ht => ?_) h.2
     simp only [h_eq t ht]
+
+/-- Value form of `HasCauchyPVAt.congr_along_curve`: the raw `cauchyPVAt` value only depends on
+the integrand along `γ` on the open interval between `a` and `b`. -/
+theorem cauchyPVAt_congr_along_curve {γ : ℝ → ℂ} {a b : ℝ} {f g : ℂ → ℂ} {z₀ : ℂ}
+    (h_eq : ∀ t ∈ Set.uIoo a b, f (γ t) = g (γ t)) :
+    cauchyPVAt γ a b f z₀ = cauchyPVAt γ a b g z₀ := by
+  unfold cauchyPVAt
+  congr 1
+  ext ε
+  refine intervalIntegral.integral_congr_uIoo fun t ht => ?_
+  simp only [h_eq t ht]
 
 /-- Scalar multiplication: if the principal value of `f` is `L`, that of `c • f` is `c • L`. -/
 theorem HasCauchyPVAt.const_mul {γ : ℝ → ℂ} {a b : ℝ} {f : ℂ → ℂ} {z₀ : ℂ} {L : ℂ}
@@ -319,6 +334,44 @@ theorem CauchyPVExistsAt.sum {ι : Type*} {γ : ℝ → ℂ} {a b : ℝ} {z₀ :
     obtain ⟨Lj, hLj⟩ := h j (Finset.mem_insert_self j s)
     obtain ⟨Ls, hLs⟩ := ih fun i hi => h i (Finset.mem_insert_of_mem hi)
     exact ⟨Lj + Ls, by simpa only [Finset.sum_insert hj] using hLj.add hLs⟩
+
+/-- Simultaneously translating the curve and the excision point preserves a single-point Cauchy
+principal value, provided the integrand is translated back by the same amount. -/
+theorem HasCauchyPVAt.translate {γ : ℝ → ℂ} {a b : ℝ} {f : ℂ → ℂ} {z₀ L : ℂ}
+    (h : HasCauchyPVAt γ a b f z₀ L) (c : ℂ) :
+    HasCauchyPVAt (fun t => γ t + c) a b (fun z => f (z - c)) (z₀ + c) L := by
+  refine HasCauchyPVAt.intro ?_ ?_
+  · filter_upwards [h.eventually_intervalIntegrable] with ε hε
+    refine (intervalIntegrable_congr fun t _ => ?_).mpr hε
+    by_cases hεt : ‖γ t - z₀‖ > ε
+    · simp [hεt]
+    · simp [hεt]
+  · refine h.tendsto.congr fun ε => ?_
+    refine intervalIntegral.integral_congr fun t _ => ?_
+    by_cases hεt : ‖γ t - z₀‖ > ε
+    · simp [hεt]
+    · simp [hεt]
+
+/-- Existence form of `HasCauchyPVAt.translate`: simultaneous translation preserves existence of a
+single-point Cauchy principal value. -/
+theorem CauchyPVExistsAt.translate {γ : ℝ → ℂ} {a b : ℝ} {f : ℂ → ℂ} {z₀ : ℂ}
+    (h : CauchyPVExistsAt γ a b f z₀) (c : ℂ) :
+    CauchyPVExistsAt (fun t => γ t + c) a b (fun z => f (z - c)) (z₀ + c) :=
+  let ⟨_, hL⟩ := cauchyPVExistsAt_iff.mp h
+  CauchyPVExistsAt.intro (hL.translate c)
+
+/-- Value form of `HasCauchyPVAt.translate`: simultaneous translation preserves the single-point
+Cauchy principal value. -/
+theorem cauchyPVAt_translate {γ : ℝ → ℂ} {a b : ℝ} {f : ℂ → ℂ} {z₀ : ℂ} (c : ℂ) :
+    cauchyPVAt (fun t => γ t + c) a b (fun z => f (z - c)) (z₀ + c)
+      = cauchyPVAt γ a b f z₀ := by
+  unfold cauchyPVAt
+  congr 1
+  ext ε
+  refine intervalIntegral.integral_congr fun t _ => ?_
+  by_cases hεt : ‖γ t - z₀‖ > ε
+  · simp [hεt]
+  · simp [hεt]
 
 /-- Reversing the interval orientation negates a single-point Cauchy principal value. -/
 theorem HasCauchyPVAt.symm {γ : ℝ → ℂ} {a b : ℝ} {f : ℂ → ℂ} {z₀ L : ℂ}

--- a/TauCeti/Analysis/Contour/WindingNumber.lean
+++ b/TauCeti/Analysis/Contour/WindingNumber.lean
@@ -24,6 +24,8 @@ value does not exist.
 
 ## Main results
 
+* `TauCeti.Contour.windingNumber_eq_cauchyPVAt` — characteristic value lemma for the raw
+  `cauchyPVAt` defining value.
 * `TauCeti.Contour.windingNumber_eq_of_hasCauchyPVAt` — evaluate `windingNumber` from a Cauchy
   principal-value witness, without unfolding the definition.
 * `TauCeti.Contour.isNullHomologous_iff` — restates `IsNullHomologous` as its vanishing condition,
@@ -58,8 +60,17 @@ namespace TauCeti.Contour
 principal-value normalization of the index integral for a curve `γ : ℝ → ℂ` on `[a, b]` and any
 point `z₀`. See `windingNumber_eq_integral_of_avoidance` for its reduction to the ordinary index
 integral; as a `limUnder`-based value it is junk when the principal value does not exist. -/
+@[expose]
 def windingNumber (γ : ℝ → ℂ) (a b : ℝ) (z₀ : ℂ) : ℂ :=
   (2 * (Real.pi : ℂ) * Complex.I)⁻¹ * cauchyPVAt γ a b (fun z => (z - z₀)⁻¹) z₀
+
+/-- **Characteristic value lemma.** The generalized winding number is the normalized raw
+single-point principal-value value. This is the public, module-safe form of the definition for
+value-level rewrites. -/
+theorem windingNumber_eq_cauchyPVAt {γ : ℝ → ℂ} {a b : ℝ} {z₀ : ℂ} :
+    windingNumber γ a b z₀ =
+      (2 * (Real.pi : ℂ) * Complex.I)⁻¹ * cauchyPVAt γ a b (fun z => (z - z₀)⁻¹) z₀ :=
+  rfl
 
 /-- **Characteristic value lemma.** From a Cauchy principal-value witness for `(· − z₀)⁻¹` along
 `γ`, the generalized winding number is the normalized value `(2πi)⁻¹ · L`. This evaluates
@@ -67,7 +78,7 @@ def windingNumber (γ : ℝ → ℂ) (a b : ℝ) (z₀ : ℂ) : ℂ :=
 theorem windingNumber_eq_of_hasCauchyPVAt {γ : ℝ → ℂ} {a b : ℝ} {z₀ L : ℂ}
     (h : HasCauchyPVAt γ a b (fun z => (z - z₀)⁻¹) z₀ L) :
     windingNumber γ a b z₀ = (2 * (Real.pi : ℂ) * Complex.I)⁻¹ * L := by
-  rw [windingNumber, h.cauchyPVAt_eq]
+  rw [windingNumber_eq_cauchyPVAt, h.cauchyPVAt_eq]
 
 /-- A curve `γ` on `[a, b]` is **null-homologous** in `Ω` when its generalized winding number
 about every point outside `Ω` vanishes — the hypothesis of the homology form of Cauchy's theorem

--- a/TauCeti/Analysis/Contour/WindingNumber.lean
+++ b/TauCeti/Analysis/Contour/WindingNumber.lean
@@ -60,7 +60,6 @@ namespace TauCeti.Contour
 principal-value normalization of the index integral for a curve `γ : ℝ → ℂ` on `[a, b]` and any
 point `z₀`. See `windingNumber_eq_integral_of_avoidance` for its reduction to the ordinary index
 integral; as a `limUnder`-based value it is junk when the principal value does not exist. -/
-@[expose]
 def windingNumber (γ : ℝ → ℂ) (a b : ℝ) (z₀ : ℂ) : ℂ :=
   (2 * (Real.pi : ℂ) * Complex.I)⁻¹ * cauchyPVAt γ a b (fun z => (z - z₀)⁻¹) z₀
 
@@ -70,7 +69,7 @@ value-level rewrites. -/
 theorem windingNumber_eq_cauchyPVAt {γ : ℝ → ℂ} {a b : ℝ} {z₀ : ℂ} :
     windingNumber γ a b z₀ =
       (2 * (Real.pi : ℂ) * Complex.I)⁻¹ * cauchyPVAt γ a b (fun z => (z - z₀)⁻¹) z₀ :=
-  rfl
+  (rfl)
 
 /-- **Characteristic value lemma.** From a Cauchy principal-value witness for `(· − z₀)⁻¹` along
 `γ`, the generalized winding number is the normalized value `(2πi)⁻¹ · L`. This evaluates

--- a/TauCeti/Analysis/Contour/WindingNumberTranslate.lean
+++ b/TauCeti/Analysis/Contour/WindingNumberTranslate.lean
@@ -6,15 +6,13 @@ Authors: Chris Birkbeck
 module
 
 public import TauCeti.Analysis.Contour.NullHomologous
-import Mathlib.Analysis.Calculus.Deriv.Add
 
 /-!
 # Translation invariance for contour winding numbers
 
-This file records the basic translation-invariance API for the single-point Cauchy principal value
-and the generalized winding number. Translating both the curve and the distinguished point by the
-same complex number leaves the excision distance and the contour derivative unchanged, so the
-index principal value, the winding number, and null-homology are invariant.
+This file records the basic translation-invariance API for the generalized winding number.
+Translating both the curve and the distinguished point by the same complex number leaves the index
+principal value unchanged, so the winding number and null-homology are invariant.
 
 These lemmas are bookkeeping for the roadmap's curve and cycle layer. The geometry of the
 generalized winding number is local at a crossing or sector, and finite-decomposition arguments
@@ -22,8 +20,6 @@ frequently translate the crossing point to the origin before applying the model 
 
 ## Main results
 
-* `Contour.HasCauchyPVAt.translate` — simultaneous translation of the curve, point, and
-  integrand preserves a single-point principal value.
 * `Contour.windingNumber_translate` — translating the curve and base point together preserves
   the generalized winding number.
 * `Contour.IsNullHomologous.translate` — null-homology is preserved by translating both the
@@ -43,60 +39,33 @@ open Filter Topology
 
 namespace TauCeti.Contour
 
-variable {γ : ℝ → ℂ} {a b : ℝ} {z₀ c L : ℂ} {Ω : Set ℂ}
+variable {γ : ℝ → ℂ} {a b : ℝ} {z₀ c : ℂ} {Ω : Set ℂ}
 
 /-- The kernel integrand used to define the generalized winding number about `z₀`. This local
 abbreviation keeps the translation statements readable. -/
 local notation "κ[" z "]" => (fun w : ℂ => (w - z)⁻¹)
 
-/-- Simultaneously translating the curve and the excision point preserves a single-point Cauchy
-principal value, provided the integrand is translated back by the same amount. -/
-theorem HasCauchyPVAt.translate {f : ℂ → ℂ} (h : HasCauchyPVAt γ a b f z₀ L) (c : ℂ) :
-    HasCauchyPVAt (fun t => γ t + c) a b (fun z => f (z - c)) (z₀ + c) L := by
-  refine HasCauchyPVAt.intro ?_ ?_
-  · filter_upwards [h.eventually_intervalIntegrable] with ε hε
-    refine (intervalIntegrable_congr fun t _ => ?_).mpr hε
-    by_cases hεt : ‖γ t - z₀‖ > ε
-    · simp [hεt]
-    · simp [hεt]
-  · refine h.tendsto.congr fun ε => ?_
-    refine intervalIntegral.integral_congr fun t _ => ?_
-    by_cases hεt : ‖γ t - z₀‖ > ε
-    · simp [hεt]
-    · simp [hεt]
-
-/-- Existence form of `HasCauchyPVAt.translate`: simultaneous translation preserves existence of a
-single-point Cauchy principal value. -/
-theorem CauchyPVExistsAt.translate {f : ℂ → ℂ} (h : CauchyPVExistsAt γ a b f z₀) (c : ℂ) :
-    CauchyPVExistsAt (fun t => γ t + c) a b (fun z => f (z - c)) (z₀ + c) :=
-  let ⟨_, hL⟩ := cauchyPVExistsAt_iff.mp h
-  CauchyPVExistsAt.intro (hL.translate c)
-
 /-- The generalized winding number is invariant under simultaneous translation of the curve and
-the base point, provided the principal value defining the original winding number exists. -/
-theorem windingNumber_translate (h : CauchyPVExistsAt γ a b κ[z₀] z₀) (c : ℂ) :
+the base point. -/
+theorem windingNumber_translate (c : ℂ) :
     windingNumber (fun t => γ t + c) a b (z₀ + c) = windingNumber γ a b z₀ := by
-  have htranslated :
-      HasCauchyPVAt (fun t => γ t + c) a b κ[z₀ + c] (z₀ + c) (cauchyPVAt γ a b κ[z₀] z₀) := by
-    refine (h.hasCauchyPVAt_cauchyPVAt.translate c).congr_along_curve ?_
-    intro t _
+  rw [windingNumber_eq_cauchyPVAt, windingNumber_eq_cauchyPVAt]
+  congr 1
+  rw [cauchyPVAt_congr_along_curve (γ := fun t => γ t + c)
+    (f := κ[z₀ + c]) (g := fun z => κ[z₀] (z - c)) (z₀ := z₀ + c)]
+  · exact cauchyPVAt_translate (γ := γ) (a := a) (b := b) (f := κ[z₀]) (z₀ := z₀) c
+  · intro t _
     congr 1
     ring
-  rw [windingNumber_eq_of_hasCauchyPVAt htranslated,
-    windingNumber_eq_of_hasCauchyPVAt h.hasCauchyPVAt_cauchyPVAt]
 
 /-- Pointwise vanishing of a winding number is preserved by simultaneous translation of the curve
-and the base point, under the principal-value existence hypothesis that makes the two
-winding-number values honest. -/
-theorem windingNumber_eq_zero_translate (hzero : windingNumber γ a b z₀ = 0)
-    (hpv : CauchyPVExistsAt γ a b κ[z₀] z₀) (c : ℂ) :
+and the base point. -/
+theorem windingNumber_eq_zero_translate (hzero : windingNumber γ a b z₀ = 0) (c : ℂ) :
     windingNumber (fun t => γ t + c) a b (z₀ + c) = 0 := by
-  rw [windingNumber_translate hpv c, hzero]
+  rw [windingNumber_translate c, hzero]
 
-/-- Null-homology is preserved by translating the curve and the ambient set together, provided the
-pointwise principal values defining the exterior winding numbers exist before translation. -/
-theorem IsNullHomologous.translate (h : IsNullHomologous γ a b Ω)
-    (hpv : ∀ z ∉ Ω, CauchyPVExistsAt γ a b κ[z] z) (c : ℂ) :
+/-- Null-homology is preserved by translating the curve and the ambient set together. -/
+theorem IsNullHomologous.translate (h : IsNullHomologous γ a b Ω) (c : ℂ) :
     IsNullHomologous (fun t => γ t + c) a b ((fun z => z + c) '' Ω) := by
   rw [isNullHomologous_iff] at h ⊢
   intro z hz
@@ -105,7 +74,24 @@ theorem IsNullHomologous.translate (h : IsNullHomologous γ a b Ω)
     exact hz ⟨z - c, hzΩ, by ring⟩
   have hpoint : z = (z - c) + c := by ring
   rw [hpoint]
-  exact windingNumber_eq_zero_translate (h (z - c) hz_sub) (hpv (z - c) hz_sub) c
+  exact windingNumber_eq_zero_translate (h (z - c) hz_sub) c
+
+/-- Null-homology is preserved by translating the curve and ambient set in the ordinary
+avoided-pole case. If the curve lies in `Ω`, every exterior point is avoided, so the pointwise
+principal values are ordinary integrals. -/
+theorem IsNullHomologous.translate_of_avoidance (h : IsNullHomologous γ a b Ω)
+    (hγ : ∀ t ∈ Set.uIcc a b, γ t ∈ Ω)
+    (hcont : ContinuousOn γ (Set.uIcc a b))
+    (hint : ∀ z ∉ Ω,
+      IntervalIntegrable (fun t => (γ t - z)⁻¹ * deriv γ t) MeasureTheory.volume a b)
+    (c : ℂ) :
+    IsNullHomologous (fun t => γ t + c) a b ((fun z => z + c) '' Ω) := by
+  have hpv : ∀ z ∉ Ω, CauchyPVExistsAt γ a b κ[z] z := by
+    intro z hz
+    refine cauchyPVExistsAt_of_avoidance hcont ?_ (hint z hz)
+    intro t ht htz
+    exact hz (htz ▸ hγ t ht)
+  exact h.translate c
 
 end TauCeti.Contour
 

--- a/TauCeti/Analysis/Contour/WindingNumberTranslate.lean
+++ b/TauCeti/Analysis/Contour/WindingNumberTranslate.lean
@@ -58,12 +58,6 @@ theorem windingNumber_translate (c : ℂ) :
     congr 1
     ring
 
-/-- Pointwise vanishing of a winding number is preserved by simultaneous translation of the curve
-and the base point. -/
-theorem windingNumber_eq_zero_translate (hzero : windingNumber γ a b z₀ = 0) (c : ℂ) :
-    windingNumber (fun t => γ t + c) a b (z₀ + c) = 0 := by
-  rw [windingNumber_translate c, hzero]
-
 /-- Null-homology is preserved by translating the curve and the ambient set together. -/
 theorem IsNullHomologous.translate (h : IsNullHomologous γ a b Ω) (c : ℂ) :
     IsNullHomologous (fun t => γ t + c) a b ((fun z => z + c) '' Ω) := by
@@ -73,8 +67,8 @@ theorem IsNullHomologous.translate (h : IsNullHomologous γ a b Ω) (c : ℂ) :
     intro hzΩ
     exact hz ⟨z - c, hzΩ, by ring⟩
   have hpoint : z = (z - c) + c := by ring
-  rw [hpoint]
-  exact windingNumber_eq_zero_translate (h (z - c) hz_sub) c
+  rw [hpoint, windingNumber_translate c]
+  exact h (z - c) hz_sub
 
 end TauCeti.Contour
 

--- a/TauCeti/Analysis/Contour/WindingNumberTranslate.lean
+++ b/TauCeti/Analysis/Contour/WindingNumberTranslate.lean
@@ -1,0 +1,112 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Chris Birkbeck
+-/
+module
+
+public import TauCeti.Analysis.Contour.NullHomologous
+import Mathlib.Analysis.Calculus.Deriv.Add
+
+/-!
+# Translation invariance for contour winding numbers
+
+This file records the basic translation-invariance API for the single-point Cauchy principal value
+and the generalized winding number. Translating both the curve and the distinguished point by the
+same complex number leaves the excision distance and the contour derivative unchanged, so the
+index principal value, the winding number, and null-homology are invariant.
+
+These lemmas are bookkeeping for the roadmap's curve and cycle layer. The geometry of the
+generalized winding number is local at a crossing or sector, and finite-decomposition arguments
+frequently translate the crossing point to the origin before applying the model computation.
+
+## Main results
+
+* `Contour.HasCauchyPVAt.translate` — simultaneous translation of the curve, point, and
+  integrand preserves a single-point principal value.
+* `Contour.windingNumber_translate` — translating the curve and base point together preserves
+  the generalized winding number.
+* `Contour.IsNullHomologous.translate` — null-homology is preserved by translating both the
+  curve and the ambient set.
+
+## Provenance
+
+This is routine API around the Hungerbühler--Wasem generalized winding number from the contour
+integration roadmap; no formal source is vendored.
+-/
+
+public section
+
+noncomputable section
+
+open Filter Topology
+
+namespace TauCeti.Contour
+
+variable {γ : ℝ → ℂ} {a b : ℝ} {z₀ c L : ℂ} {Ω : Set ℂ}
+
+/-- The kernel integrand used to define the generalized winding number about `z₀`. This local
+abbreviation keeps the translation statements readable. -/
+local notation "κ[" z "]" => (fun w : ℂ => (w - z)⁻¹)
+
+/-- Simultaneously translating the curve and the excision point preserves a single-point Cauchy
+principal value, provided the integrand is translated back by the same amount. -/
+theorem HasCauchyPVAt.translate {f : ℂ → ℂ} (h : HasCauchyPVAt γ a b f z₀ L) (c : ℂ) :
+    HasCauchyPVAt (fun t => γ t + c) a b (fun z => f (z - c)) (z₀ + c) L := by
+  refine HasCauchyPVAt.intro ?_ ?_
+  · filter_upwards [h.eventually_intervalIntegrable] with ε hε
+    refine (intervalIntegrable_congr fun t _ => ?_).mpr hε
+    by_cases hεt : ‖γ t - z₀‖ > ε
+    · simp [hεt]
+    · simp [hεt]
+  · refine h.tendsto.congr fun ε => ?_
+    refine intervalIntegral.integral_congr fun t _ => ?_
+    by_cases hεt : ‖γ t - z₀‖ > ε
+    · simp [hεt]
+    · simp [hεt]
+
+/-- Existence form of `HasCauchyPVAt.translate`: simultaneous translation preserves existence of a
+single-point Cauchy principal value. -/
+theorem CauchyPVExistsAt.translate {f : ℂ → ℂ} (h : CauchyPVExistsAt γ a b f z₀) (c : ℂ) :
+    CauchyPVExistsAt (fun t => γ t + c) a b (fun z => f (z - c)) (z₀ + c) :=
+  let ⟨_, hL⟩ := cauchyPVExistsAt_iff.mp h
+  CauchyPVExistsAt.intro (hL.translate c)
+
+/-- The generalized winding number is invariant under simultaneous translation of the curve and
+the base point, provided the principal value defining the original winding number exists. -/
+theorem windingNumber_translate (h : CauchyPVExistsAt γ a b κ[z₀] z₀) (c : ℂ) :
+    windingNumber (fun t => γ t + c) a b (z₀ + c) = windingNumber γ a b z₀ := by
+  have htranslated :
+      HasCauchyPVAt (fun t => γ t + c) a b κ[z₀ + c] (z₀ + c) (cauchyPVAt γ a b κ[z₀] z₀) := by
+    refine (h.hasCauchyPVAt_cauchyPVAt.translate c).congr_along_curve ?_
+    intro t _
+    congr 1
+    ring
+  rw [windingNumber_eq_of_hasCauchyPVAt htranslated,
+    windingNumber_eq_of_hasCauchyPVAt h.hasCauchyPVAt_cauchyPVAt]
+
+/-- Pointwise vanishing of a winding number is preserved by simultaneous translation of the curve
+and the base point, under the principal-value existence hypothesis that makes the two
+winding-number values honest. -/
+theorem windingNumber_eq_zero_translate (hzero : windingNumber γ a b z₀ = 0)
+    (hpv : CauchyPVExistsAt γ a b κ[z₀] z₀) (c : ℂ) :
+    windingNumber (fun t => γ t + c) a b (z₀ + c) = 0 := by
+  rw [windingNumber_translate hpv c, hzero]
+
+/-- Null-homology is preserved by translating the curve and the ambient set together, provided the
+pointwise principal values defining the exterior winding numbers exist before translation. -/
+theorem IsNullHomologous.translate (h : IsNullHomologous γ a b Ω)
+    (hpv : ∀ z ∉ Ω, CauchyPVExistsAt γ a b κ[z] z) (c : ℂ) :
+    IsNullHomologous (fun t => γ t + c) a b ((fun z => z + c) '' Ω) := by
+  rw [isNullHomologous_iff] at h ⊢
+  intro z hz
+  have hz_sub : z - c ∉ Ω := by
+    intro hzΩ
+    exact hz ⟨z - c, hzΩ, by ring⟩
+  have hpoint : z = (z - c) + c := by ring
+  rw [hpoint]
+  exact windingNumber_eq_zero_translate (h (z - c) hz_sub) (hpv (z - c) hz_sub) c
+
+end TauCeti.Contour
+
+end

--- a/TauCeti/Analysis/Contour/WindingNumberTranslate.lean
+++ b/TauCeti/Analysis/Contour/WindingNumberTranslate.lean
@@ -76,23 +76,6 @@ theorem IsNullHomologous.translate (h : IsNullHomologous γ a b Ω) (c : ℂ) :
   rw [hpoint]
   exact windingNumber_eq_zero_translate (h (z - c) hz_sub) c
 
-/-- Null-homology is preserved by translating the curve and ambient set in the ordinary
-avoided-pole case. If the curve lies in `Ω`, every exterior point is avoided, so the pointwise
-principal values are ordinary integrals. -/
-theorem IsNullHomologous.translate_of_avoidance (h : IsNullHomologous γ a b Ω)
-    (hγ : ∀ t ∈ Set.uIcc a b, γ t ∈ Ω)
-    (hcont : ContinuousOn γ (Set.uIcc a b))
-    (hint : ∀ z ∉ Ω,
-      IntervalIntegrable (fun t => (γ t - z)⁻¹ * deriv γ t) MeasureTheory.volume a b)
-    (c : ℂ) :
-    IsNullHomologous (fun t => γ t + c) a b ((fun z => z + c) '' Ω) := by
-  have hpv : ∀ z ∉ Ω, CauchyPVExistsAt γ a b κ[z] z := by
-    intro z hz
-    refine cauchyPVExistsAt_of_avoidance hcont ?_ (hint z hz)
-    intro t ht htz
-    exact hz (htz ▸ hγ t ht)
-  exact h.translate c
-
 end TauCeti.Contour
 
 end


### PR DESCRIPTION
This PR adds simultaneous translation invariance for the ContourIntegration single-point principal-value and winding-number API: translating the curve and excision point together preserves `HasCauchyPVAt`, translating the curve and base point together preserves `windingNumber`, and translating the ambient set preserves `IsNullHomologous` under the same pointwise principal-value existence discipline used by the existing concatenation and reversal files.

It advances `TauCetiRoadmap/ContourIntegration/README.md`, Layer 0, specifically “Curves, immersions, cycles” and the generalized winding-number bookkeeping needed for Layer 1 HW Proposition 2.2 finite-crossing decompositions. I chose this as the lowest-hanging distinct ContourIntegration prerequisite after checking open and recently merged PRs: `main` already has the principal-value predicates, generalized winding number, null-homology API, model-sector computations, arc FTC, residue, circle residue theorem, argument principle, winding-number concatenation, and orientation reversal; the only open ContourIntegration PR covers degenerate intervals, while simultaneous translation to move a crossing or sector point to the origin was still absent. This PR does not attempt integer-valuedness, homotopy invariance, HW Proposition 2.2, or any residue theorem.

No Mathlib infrastructure is vendored. The implementation reuses Mathlib’s derivative simplification for adding a constant and Tau Ceti’s existing `HasCauchyPVAt` constructor, along-curve congruence, winding-number value lemma, and `IsNullHomologous` API.

`lake exe cache get` completed with `No files to download` and `Already decompressed 8609 file(s)`. `lake build` completed with `Build completed successfully (4595 jobs).` `lake exe axioms` completed with `axioms: audited 8655 TauCeti declaration(s); all within the allowlist [propext, Classical.choice, Quot.sound].`

<!--tauceti-target:v1 {"focus":"ContourIntegration","id":"winding-number-translate"}-->

🤖 Prepared with Codex
