### PR TITLE
feat: add contractable path laws

### DIFF
--- a/TauCeti/Probability/Exchangeability/PathSpace/ContractableLaw.lean
+++ b/TauCeti/Probability/Exchangeability/PathSpace/ContractableLaw.lean
@@ -51,8 +51,9 @@ theorem contractableLaw_iff {ρ : Measure (ℕ → α)} :
   Iff.rfl
 
 /-- The defining invariance of a contractable path law. -/
-@[simp]
-theorem ContractableLaw.map_reindex {ρ : Measure (ℕ → α)} (hρ : ContractableLaw ρ)
+theorem ContractableLaw.map_reindex {ρ : Measure (ℕ → α)}
+    (hρ : ∀ φ : ℕ → ℕ, StrictMono φ →
+      ρ.map (fun x : ℕ → α => fun k => x (φ k)) = ρ)
     {φ : ℕ → ℕ} (hφ : StrictMono φ) :
     ρ.map (fun x : ℕ → α => fun k => x (φ k)) = ρ :=
   hρ φ hφ
@@ -61,7 +62,7 @@ theorem ContractableLaw.map_reindex {ρ : Measure (ℕ → α)} (hρ : Contracta
 theorem ContractableLaw.measurePreserving_reindex {ρ : Measure (ℕ → α)}
     (hρ : ContractableLaw ρ) {φ : ℕ → ℕ} (hφ : StrictMono φ) :
     MeasurePreserving (fun x : ℕ → α => fun k => x (φ k)) ρ ρ :=
-  ⟨measurable_reindex φ, hρ.map_reindex hφ⟩
+  ⟨measurable_reindex φ, ContractableLaw.map_reindex hρ hφ⟩
 
 /-- Path-law contractability is equivalently measure preservation by every strictly increasing
 time reindexing. -/
@@ -89,16 +90,19 @@ theorem ContractableLaw.measurePreserving_shift_iterate {ρ : Measure (ℕ → �
 
 /-- The one-sided shift leaves a contractable path law unchanged. -/
 @[simp]
-theorem ContractableLaw.map_shift {ρ : Measure (ℕ → α)} (hρ : ContractableLaw ρ) :
+theorem ContractableLaw.map_shift {ρ : Measure (ℕ → α)}
+    (hρ : ∀ φ : ℕ → ℕ, StrictMono φ →
+      ρ.map (fun x : ℕ → α => fun k => x (φ k)) = ρ) :
     ρ.map (shift α) = ρ :=
-  hρ.measurePreserving_shift.map_eq
+  (ContractableLaw.measurePreserving_shift hρ).map_eq
 
 /-- Iterating the one-sided shift leaves a contractable path law unchanged. -/
 @[simp]
 theorem ContractableLaw.map_shift_iterate {ρ : Measure (ℕ → α)}
-    (hρ : ContractableLaw ρ) (n : ℕ) :
+    (hρ : ∀ φ : ℕ → ℕ, StrictMono φ →
+      ρ.map (fun x : ℕ → α => fun k => x (φ k)) = ρ) (n : ℕ) :
     ρ.map ((shift α)^[n]) = ρ :=
-  (hρ.measurePreserving_shift_iterate n).map_eq
+  (ContractableLaw.measurePreserving_shift_iterate hρ n).map_eq
 
 /-- A contractable process has a contractable path law. -/
 theorem Contractable.contractableLaw_pathLaw {μ : Measure Ω} {X : ℕ → Ω → α}

--- a/TauCeti/Probability/Exchangeability/PathSpace/ContractableLaw.lean
+++ b/TauCeti/Probability/Exchangeability/PathSpace/ContractableLaw.lean
@@ -52,7 +52,6 @@ theorem contractableLaw_iff {ρ : Measure (ℕ → α)} :
   Iff.rfl
 
 /-- The defining invariance of a contractable path law. -/
-@[simp]
 theorem ContractableLaw.map_reindex {ρ : Measure (ℕ → α)}
     (hρ : ContractableLaw ρ)
     {φ : ℕ → ℕ} (hφ : StrictMono φ) :
@@ -128,14 +127,12 @@ theorem ContractableLaw.measurePreserving_shift_iterate {ρ : Measure (ℕ → �
   (hρ.measurePreserving_shift).iterate n
 
 /-- The one-sided shift leaves a contractable path law unchanged. -/
-@[simp]
 theorem ContractableLaw.map_shift {ρ : Measure (ℕ → α)}
     (hρ : ContractableLaw ρ) :
     ρ.map (shift α) = ρ :=
   (ContractableLaw.measurePreserving_shift hρ).map_eq
 
 /-- Iterating the one-sided shift leaves a contractable path law unchanged. -/
-@[simp]
 theorem ContractableLaw.map_shift_iterate {ρ : Measure (ℕ → α)}
     (hρ : ContractableLaw ρ) (n : ℕ) :
     ρ.map ((shift α)^[n]) = ρ :=

--- a/TauCeti/Probability/Exchangeability/PathSpace/ContractableLaw.lean
+++ b/TauCeti/Probability/Exchangeability/PathSpace/ContractableLaw.lean
@@ -51,6 +51,7 @@ theorem contractableLaw_iff {ρ : Measure (ℕ → α)} :
   Iff.rfl
 
 /-- The defining invariance of a contractable path law. -/
+@[simp]
 theorem ContractableLaw.map_reindex {ρ : Measure (ℕ → α)} (hρ : ContractableLaw ρ)
     {φ : ℕ → ℕ} (hφ : StrictMono φ) :
     ρ.map (fun x : ℕ → α => fun k => x (φ k)) = ρ :=
@@ -86,7 +87,14 @@ theorem ContractableLaw.measurePreserving_shift_iterate {ρ : Measure (ℕ → �
     MeasurePreserving ((shift α)^[n]) ρ ρ :=
   (hρ.measurePreserving_shift).iterate n
 
+/-- The one-sided shift leaves a contractable path law unchanged. -/
+@[simp]
+theorem ContractableLaw.map_shift {ρ : Measure (ℕ → α)} (hρ : ContractableLaw ρ) :
+    ρ.map (shift α) = ρ :=
+  hρ.measurePreserving_shift.map_eq
+
 /-- Iterating the one-sided shift leaves a contractable path law unchanged. -/
+@[simp]
 theorem ContractableLaw.map_shift_iterate {ρ : Measure (ℕ → α)}
     (hρ : ContractableLaw ρ) (n : ℕ) :
     ρ.map ((shift α)^[n]) = ρ :=

--- a/TauCeti/Probability/Exchangeability/PathSpace/ContractableLaw.lean
+++ b/TauCeti/Probability/Exchangeability/PathSpace/ContractableLaw.lean
@@ -1,7 +1,7 @@
 module
 
-public import TauCeti.Probability.Exchangeability.Contractability
-public import TauCeti.Probability.Exchangeability.PathSpace.Shift
+public import TauCeti.Probability.Exchangeability.FiniteMarginals
+public import TauCeti.Probability.Exchangeability.PathSpace.Law
 
 /-!
 # Contractable laws on path space
@@ -13,9 +13,10 @@ The process-level predicate `Contractable μ X` remains the main stochastic-proc
 factorization and path-space dynamics.
 
 This is the contractability analogue of `ExchangeableLaw`. It realizes the Exchangeability
-roadmap's Layer 0 request for process-level ↔ path-law bridges and for the characterization
-of contractability by strictly increasing maps `ℕ → ℕ`. It reuses the existing Tau Ceti
-bridge `contractable_iff_forall_map_reindex_pathLaw`; no Mathlib infrastructure is vendored.
+roadmap's Layer 0 request for the characterization of contractability by strictly increasing
+maps `ℕ → ℕ`, with finite-dimensional marginal consequences. The process-level ↔ path-law
+bridges live in `TauCeti.Probability.Exchangeability.PathSpace.LawBridge`, which imports this
+file and `Contractability`; no Mathlib infrastructure is vendored.
 -/
 
 public section
@@ -51,9 +52,9 @@ theorem contractableLaw_iff {ρ : Measure (ℕ → α)} :
   Iff.rfl
 
 /-- The defining invariance of a contractable path law. -/
+@[simp]
 theorem ContractableLaw.map_reindex {ρ : Measure (ℕ → α)}
-    (hρ : ∀ φ : ℕ → ℕ, StrictMono φ →
-      ρ.map (fun x : ℕ → α => fun k => x (φ k)) = ρ)
+    (hρ : ContractableLaw ρ)
     {φ : ℕ → ℕ} (hφ : StrictMono φ) :
     ρ.map (fun x : ℕ → α => fun k => x (φ k)) = ρ :=
   hρ φ hφ
@@ -76,6 +77,44 @@ theorem contractableLaw_iff_forall_measurePreserving_reindex {ρ : Measure (ℕ 
   · intro hρ φ hφ
     exact (hρ φ hφ).map_eq
 
+/-- The finite marginal of a contractable path law along any strictly increasing selection
+`k : Fin n → ℕ` equals its first-`n` prefix marginal. -/
+theorem ContractableLaw.map_prefixProj_of_strictMono {ρ : Measure (ℕ → α)}
+    (hρ : ContractableLaw ρ) {n : ℕ} {k : Fin n → ℕ} (hk : StrictMono k) :
+    ρ.map (fun x : ℕ → α => fun i : Fin n => x (k i)) =
+      ρ.map (prefixProj α n) := by
+  obtain ⟨φ, hφ, hφ_eq⟩ := exists_strictMono_nat_extending_fin hk
+  have hmap := congrArg (fun ν : Measure (ℕ → α) => ν.map (prefixProj α n))
+    (hρ.map_reindex hφ)
+  rw [map_reindex_prefixProj] at hmap
+  have hidx :
+      (fun x : ℕ → α => fun i : Fin n => x (φ i.val)) =
+        fun x : ℕ → α => fun i : Fin n => x (k i) := by
+    funext x i
+    rw [hφ_eq i]
+  simpa [hidx] using hmap
+
+/-- For finite path laws, contractability is equivalently invariance of every finite-dimensional
+marginal under strictly increasing finite selections. -/
+theorem contractableLaw_iff_forall_map_prefixProj_of_strictMono {ρ : Measure (ℕ → α)}
+    [IsFiniteMeasure ρ] :
+    ContractableLaw ρ ↔
+      ∀ n (k : Fin n → ℕ), StrictMono k →
+        ρ.map (fun x : ℕ → α => fun i : Fin n => x (k i)) =
+          ρ.map (prefixProj α n) := by
+  constructor
+  · intro hρ n k hk
+    exact hρ.map_prefixProj_of_strictMono hk
+  · intro hρ
+    refine ContractableLaw.intro ?_
+    intro φ hφ
+    haveI : IsFiniteMeasure (ρ.map (fun x : ℕ → α => fun k => x (φ k))) := by
+      infer_instance
+    refine measure_eq_of_prefixProj_map_eq ?_
+    intro n
+    rw [map_reindex_prefixProj]
+    exact hρ n (fun i : Fin n => φ i.val) (hφ.comp Fin.val_strictMono)
+
 /-- A contractable path law is preserved by the one-sided shift. -/
 theorem ContractableLaw.measurePreserving_shift {ρ : Measure (ℕ → α)}
     (hρ : ContractableLaw ρ) :
@@ -91,37 +130,16 @@ theorem ContractableLaw.measurePreserving_shift_iterate {ρ : Measure (ℕ → �
 /-- The one-sided shift leaves a contractable path law unchanged. -/
 @[simp]
 theorem ContractableLaw.map_shift {ρ : Measure (ℕ → α)}
-    (hρ : ∀ φ : ℕ → ℕ, StrictMono φ →
-      ρ.map (fun x : ℕ → α => fun k => x (φ k)) = ρ) :
+    (hρ : ContractableLaw ρ) :
     ρ.map (shift α) = ρ :=
   (ContractableLaw.measurePreserving_shift hρ).map_eq
 
 /-- Iterating the one-sided shift leaves a contractable path law unchanged. -/
 @[simp]
 theorem ContractableLaw.map_shift_iterate {ρ : Measure (ℕ → α)}
-    (hρ : ∀ φ : ℕ → ℕ, StrictMono φ →
-      ρ.map (fun x : ℕ → α => fun k => x (φ k)) = ρ) (n : ℕ) :
+    (hρ : ContractableLaw ρ) (n : ℕ) :
     ρ.map ((shift α)^[n]) = ρ :=
   (ContractableLaw.measurePreserving_shift_iterate hρ n).map_eq
-
-/-- A contractable process has a contractable path law. -/
-theorem Contractable.contractableLaw_pathLaw {μ : Measure Ω} {X : ℕ → Ω → α}
-    [IsFiniteMeasure μ] (hX : Contractable μ X) (hX_meas : ∀ i, AEMeasurable (X i) μ) :
-    ContractableLaw (pathLaw μ X) :=
-  ContractableLaw.intro fun _ hφ => (hX.measurePreserving_reindex hX_meas hφ).map_eq
-
-/-- Contractability of a process is equivalent to contractability of its path law. -/
-theorem contractable_iff_contractableLaw_pathLaw {μ : Measure Ω} {X : ℕ → Ω → α}
-    [IsFiniteMeasure μ] (hX_meas : ∀ i, AEMeasurable (X i) μ) :
-    Contractable μ X ↔ ContractableLaw (pathLaw μ X) := by
-  rw [contractable_iff_forall_map_reindex_pathLaw hX_meas, contractableLaw_iff]
-
-/-- If a process has a contractable path law, then the process is contractable. -/
-theorem contractable_of_contractableLaw_pathLaw {μ : Measure Ω} {X : ℕ → Ω → α}
-    [IsFiniteMeasure μ] (hX_meas : ∀ i, AEMeasurable (X i) μ)
-    (hρ : ContractableLaw (pathLaw μ X)) :
-    Contractable μ X :=
-  (contractable_iff_contractableLaw_pathLaw hX_meas).2 hρ
 
 end Probability
 

--- a/TauCeti/Probability/Exchangeability/PathSpace/ContractableLaw.lean
+++ b/TauCeti/Probability/Exchangeability/PathSpace/ContractableLaw.lean
@@ -1,0 +1,116 @@
+module
+
+public import TauCeti.Probability.Exchangeability.Contractability
+public import TauCeti.Probability.Exchangeability.PathSpace.Shift
+
+/-!
+# Contractable laws on path space
+
+This file adds the path-law formulation of contractability, also called spreadability:
+a measure on `ℕ → α` is invariant under every strictly increasing reindexing of time.
+The process-level predicate `Contractable μ X` remains the main stochastic-process API;
+`ContractableLaw` names the equivalent path-space viewpoint needed by the de Finetti
+factorization and path-space dynamics.
+
+This is the contractability analogue of `ExchangeableLaw`. It realizes the Exchangeability
+roadmap's Layer 0 request for process-level ↔ path-law bridges and for the characterization
+of contractability by strictly increasing maps `ℕ → ℕ`. It reuses the existing Tau Ceti
+bridge `contractable_iff_forall_map_reindex_pathLaw`; no Mathlib infrastructure is vendored.
+-/
+
+public section
+
+noncomputable section
+
+open MeasureTheory
+
+namespace TauCeti
+
+namespace Probability
+
+variable {Ω α : Type*} [MeasurableSpace Ω] [MeasurableSpace α]
+
+/-- A measure on one-sided path space is contractable, or spreadable, if it is invariant under
+every strictly increasing reindexing of the time coordinate. -/
+def ContractableLaw (ρ : Measure (ℕ → α)) : Prop :=
+  ∀ φ : ℕ → ℕ, StrictMono φ → ρ.map (fun x : ℕ → α => fun k => x (φ k)) = ρ
+
+/-- Constructor for `ContractableLaw` from the defining map invariance. -/
+theorem ContractableLaw.intro {ρ : Measure (ℕ → α)}
+    (h : ∀ φ : ℕ → ℕ, StrictMono φ →
+      ρ.map (fun x : ℕ → α => fun k => x (φ k)) = ρ) :
+    ContractableLaw ρ :=
+  h
+
+/-- Simp normal form for `ContractableLaw`. -/
+@[simp]
+theorem contractableLaw_iff {ρ : Measure (ℕ → α)} :
+    ContractableLaw ρ ↔
+      ∀ φ : ℕ → ℕ, StrictMono φ →
+        ρ.map (fun x : ℕ → α => fun k => x (φ k)) = ρ :=
+  Iff.rfl
+
+/-- The defining invariance of a contractable path law. -/
+theorem ContractableLaw.map_reindex {ρ : Measure (ℕ → α)} (hρ : ContractableLaw ρ)
+    {φ : ℕ → ℕ} (hφ : StrictMono φ) :
+    ρ.map (fun x : ℕ → α => fun k => x (φ k)) = ρ :=
+  hρ φ hφ
+
+/-- A strictly increasing time reindexing preserves a contractable path law. -/
+theorem ContractableLaw.measurePreserving_reindex {ρ : Measure (ℕ → α)}
+    (hρ : ContractableLaw ρ) {φ : ℕ → ℕ} (hφ : StrictMono φ) :
+    MeasurePreserving (fun x : ℕ → α => fun k => x (φ k)) ρ ρ :=
+  ⟨measurable_reindex φ, hρ.map_reindex hφ⟩
+
+/-- Path-law contractability is equivalently measure preservation by every strictly increasing
+time reindexing. -/
+theorem contractableLaw_iff_forall_measurePreserving_reindex {ρ : Measure (ℕ → α)} :
+    ContractableLaw ρ ↔
+      ∀ φ : ℕ → ℕ, StrictMono φ →
+        MeasurePreserving (fun x : ℕ → α => fun k => x (φ k)) ρ ρ := by
+  constructor
+  · intro hρ φ hφ
+    exact hρ.measurePreserving_reindex hφ
+  · intro hρ φ hφ
+    exact (hρ φ hφ).map_eq
+
+/-- A contractable path law is preserved by the one-sided shift. -/
+theorem ContractableLaw.measurePreserving_shift {ρ : Measure (ℕ → α)}
+    (hρ : ContractableLaw ρ) :
+    MeasurePreserving (shift α) ρ ρ :=
+  hρ.measurePreserving_reindex (φ := fun k => k + 1) fun _ _ h => Nat.add_lt_add_right h 1
+
+/-- Every iterate of the one-sided shift preserves a contractable path law. -/
+theorem ContractableLaw.measurePreserving_shift_iterate {ρ : Measure (ℕ → α)}
+    (hρ : ContractableLaw ρ) (n : ℕ) :
+    MeasurePreserving ((shift α)^[n]) ρ ρ :=
+  (hρ.measurePreserving_shift).iterate n
+
+/-- Iterating the one-sided shift leaves a contractable path law unchanged. -/
+theorem ContractableLaw.map_shift_iterate {ρ : Measure (ℕ → α)}
+    (hρ : ContractableLaw ρ) (n : ℕ) :
+    ρ.map ((shift α)^[n]) = ρ :=
+  (hρ.measurePreserving_shift_iterate n).map_eq
+
+/-- A contractable process has a contractable path law. -/
+theorem Contractable.contractableLaw_pathLaw {μ : Measure Ω} {X : ℕ → Ω → α}
+    [IsFiniteMeasure μ] (hX : Contractable μ X) (hX_meas : ∀ i, AEMeasurable (X i) μ) :
+    ContractableLaw (pathLaw μ X) :=
+  ContractableLaw.intro fun _ hφ => (hX.measurePreserving_reindex hX_meas hφ).map_eq
+
+/-- Contractability of a process is equivalent to contractability of its path law. -/
+theorem contractable_iff_contractableLaw_pathLaw {μ : Measure Ω} {X : ℕ → Ω → α}
+    [IsFiniteMeasure μ] (hX_meas : ∀ i, AEMeasurable (X i) μ) :
+    Contractable μ X ↔ ContractableLaw (pathLaw μ X) := by
+  rw [contractable_iff_forall_map_reindex_pathLaw hX_meas, contractableLaw_iff]
+
+/-- If a process has a contractable path law, then the process is contractable. -/
+theorem contractable_of_contractableLaw_pathLaw {μ : Measure Ω} {X : ℕ → Ω → α}
+    [IsFiniteMeasure μ] (hX_meas : ∀ i, AEMeasurable (X i) μ)
+    (hρ : ContractableLaw (pathLaw μ X)) :
+    Contractable μ X :=
+  (contractable_iff_contractableLaw_pathLaw hX_meas).2 hρ
+
+end Probability
+
+end TauCeti

--- a/TauCeti/Probability/Exchangeability/PathSpace/LawBridge.lean
+++ b/TauCeti/Probability/Exchangeability/PathSpace/LawBridge.lean
@@ -1,6 +1,8 @@
 module
 
+public import TauCeti.Probability.Exchangeability.Contractability
 public import TauCeti.Probability.Exchangeability.FullyExchangeable
+public import TauCeti.Probability.Exchangeability.PathSpace.ContractableLaw
 public import TauCeti.Probability.Exchangeability.PathSpace.Law
 
 /-!
@@ -9,11 +11,13 @@ public import TauCeti.Probability.Exchangeability.PathSpace.Law
 This file connects the process-level `FullyExchangeable`/`Exchangeable` predicates with the
 path-space `ExchangeableLaw` predicate: a process is fully exchangeable exactly when its
 `pathLaw` is an exchangeable path-space law, and (under a finite base law) finite exchangeability
-is the same statement.
+is the same statement. It also connects process-level contractability with the path-space
+`ContractableLaw` predicate.
 
 The bridges realize the Layer 0 roadmap item asking for process-level ↔ path-law bridges in both
 directions. They reuse the existing `FullyExchangeable` path-law bridge from
-`FullyExchangeable.lean`; no measure-theoretic infrastructure is vendored.
+`FullyExchangeable.lean` and the contractability bridge from `Contractability.lean`; no
+measure-theoretic infrastructure is vendored.
 -/
 
 public section
@@ -60,6 +64,25 @@ theorem exchangeable_of_exchangeableLaw_pathLaw {μ : Measure Ω} {X : ℕ → �
     (hρ : ExchangeableLaw (pathLaw μ X)) :
     Exchangeable μ X :=
   (exchangeable_iff_exchangeableLaw_pathLaw hX_meas).2 hρ
+
+/-- A contractable process has a contractable path law. -/
+theorem Contractable.contractableLaw_pathLaw {μ : Measure Ω} {X : ℕ → Ω → α}
+    [IsFiniteMeasure μ] (hX : Contractable μ X) (hX_meas : ∀ i, AEMeasurable (X i) μ) :
+    ContractableLaw (pathLaw μ X) :=
+  ContractableLaw.intro fun _ hφ => (hX.measurePreserving_reindex hX_meas hφ).map_eq
+
+/-- Contractability of a process is equivalent to contractability of its path law. -/
+theorem contractable_iff_contractableLaw_pathLaw {μ : Measure Ω} {X : ℕ → Ω → α}
+    [IsFiniteMeasure μ] (hX_meas : ∀ i, AEMeasurable (X i) μ) :
+    Contractable μ X ↔ ContractableLaw (pathLaw μ X) := by
+  rw [contractable_iff_forall_map_reindex_pathLaw hX_meas, contractableLaw_iff]
+
+/-- If a process has a contractable path law, then the process is contractable. -/
+theorem contractable_of_contractableLaw_pathLaw {μ : Measure Ω} {X : ℕ → Ω → α}
+    [IsFiniteMeasure μ] (hX_meas : ∀ i, AEMeasurable (X i) μ)
+    (hρ : ContractableLaw (pathLaw μ X)) :
+    Contractable μ X :=
+  (contractable_iff_contractableLaw_pathLaw hX_meas).2 hρ
 
 end Probability
 


### PR DESCRIPTION
This PR adds the path-space `ContractableLaw` predicate for measures on `ℕ → α`, with the defining strictly increasing reindexing invariance, measure-preserving form, shift and shift-iterate corollaries, and the bridge `Contractable μ X ↔ ContractableLaw (pathLaw μ X)` for finite base laws.

It advances `TauCetiRoadmap/Exchangeability/README.md`, Layer 0, specifically the items “contractability/spreadability via the monoid of strictly increasing maps `ℕ → ℕ`” and “the process-level ↔ path-law bridges in both directions.” I chose this as the lowest-hanging distinct Exchangeability target after checking open and recently merged PRs: the reverse-martingale capstone is open, and `main` already has process-level contractability plus the theorem-shaped path-law bridge, but it had no named path-space predicate parallel to `ExchangeableLaw`.

No Mathlib infrastructure is vendored. The implementation reuses Tau Ceti’s existing `contractable_iff_forall_map_reindex_pathLaw`, `Contractable.measurePreserving_reindex`, `measurable_reindex`, and path-space shift API.

`lake exe cache get` completed with `No files to download` and `Already decompressed 8609 file(s)`. `lake build` completed with `Build completed successfully (4598 jobs).` `lake exe axioms` completed with `axioms: audited 8683 TauCeti declaration(s); all within the allowlist [propext, Classical.choice, Quot.sound].`

<!--tauceti-target:v1 {"focus":"Exchangeability","id":"contractable-law"}-->

🤖 Prepared with Codex
