### PR TITLE
feat: add Schwarz reflection branch API

### DIFF
--- a/TauCeti/Analysis/Complex/Conformal/Reflection.lean
+++ b/TauCeti/Analysis/Complex/Conformal/Reflection.lean
@@ -75,43 +75,12 @@ lemma eqOn_schwarzReflection_of_subset_im_nonneg
     Set.EqOn (schwarzReflection f) f S :=
   fun _ hz => schwarzReflection_of_im_nonneg (f := f) (hS hz)
 
-/-- On the closed upper half-plane, Schwarz reflection agrees with the original function. -/
-lemma eqOn_schwarzReflection_im_nonneg :
-    Set.EqOn (schwarzReflection f) f {z : ℂ | 0 ≤ z.im} :=
-  eqOn_schwarzReflection_of_subset_im_nonneg
-    (f := f) (S := {z : ℂ | 0 ≤ z.im}) Subset.rfl
-
-/--
-On the closed upper half-plane part of a domain, Schwarz reflection agrees with the original
-function.
--/
-lemma eqOn_schwarzReflection_inter_im_nonneg (Ω : Set ℂ) :
-    Set.EqOn (schwarzReflection f) f (Ω ∩ {z : ℂ | 0 ≤ z.im}) :=
-  eqOn_schwarzReflection_of_subset_im_nonneg (f := f)
-    (S := Ω ∩ {z : ℂ | 0 ≤ z.im}) inter_subset_right
-
 /-- On any subset of the lower half-plane, Schwarz reflection agrees with the reflected
 branch. -/
 lemma eqOn_schwarzReflection_of_subset_im_neg
     (hS : S ⊆ {z : ℂ | z.im < 0}) :
     Set.EqOn (schwarzReflection f) (fun z => (starRingEnd ℂ) (f ((starRingEnd ℂ) z))) S :=
   fun _ hz => schwarzReflection_of_im_neg (f := f) (hS hz)
-
-/-- On the lower half-plane, Schwarz reflection agrees with the reflected branch. -/
-lemma eqOn_schwarzReflection_im_neg :
-    Set.EqOn (schwarzReflection f) (fun z => (starRingEnd ℂ) (f ((starRingEnd ℂ) z)))
-      {z : ℂ | z.im < 0} :=
-  eqOn_schwarzReflection_of_subset_im_neg
-    (f := f) (S := {z : ℂ | z.im < 0}) Subset.rfl
-
-/--
-On the lower half-plane part of a domain, Schwarz reflection agrees with the reflected branch.
--/
-lemma eqOn_schwarzReflection_inter_im_neg (Ω : Set ℂ) :
-    Set.EqOn (schwarzReflection f) (fun z => (starRingEnd ℂ) (f ((starRingEnd ℂ) z)))
-      (Ω ∩ {z : ℂ | z.im < 0}) :=
-  eqOn_schwarzReflection_of_subset_im_neg (f := f)
-    (S := Ω ∩ {z : ℂ | z.im < 0}) inter_subset_right
 
 /-- Conjugating a point in the upper half-plane evaluates the reflected lower branch. -/
 lemma schwarzReflection_conj_of_im_pos {z : ℂ} (hz : 0 < z.im) :
@@ -201,15 +170,6 @@ lemma image_conj_inter_im_pos_of_symmetric {Ω : Set ℂ}
     · rw [starRingEnd_self_apply]
 
 /--
-For a conjugation-symmetric domain, conjugation carries the upper half-plane part of the domain
-to its lower half-plane part.
--/
-lemma image_conj_inter_im_pos_of_mem_iff {Ω : Set ℂ}
-    (hΩ : ∀ z, z ∈ Ω ↔ (starRingEnd ℂ) z ∈ Ω) :
-    (starRingEnd ℂ) '' (Ω ∩ {z | 0 < z.im}) = Ω ∩ {z | z.im < 0} :=
-  image_conj_inter_im_pos_of_symmetric (mapsTo_conj_of_mem_iff hΩ)
-
-/--
 For a domain closed under conjugation, conjugation carries the lower half-plane part of the
 domain to its upper half-plane part.
 -/
@@ -229,15 +189,6 @@ lemma image_conj_inter_im_neg_of_symmetric {Ω : Set ℂ}
     · rw [Set.mem_setOf_eq, starRingEnd_apply, Complex.star_def, Complex.conj_im]
       exact neg_neg_of_pos hzim
     · rw [starRingEnd_self_apply]
-
-/--
-For a conjugation-symmetric domain, conjugation carries the lower half-plane part of the domain
-to its upper half-plane part.
--/
-lemma image_conj_inter_im_neg_of_mem_iff {Ω : Set ℂ}
-    (hΩ : ∀ z, z ∈ Ω ↔ (starRingEnd ℂ) z ∈ Ω) :
-    (starRingEnd ℂ) '' (Ω ∩ {z | z.im < 0}) = Ω ∩ {z | 0 < z.im} :=
-  image_conj_inter_im_neg_of_symmetric (mapsTo_conj_of_mem_iff hΩ)
 
 private lemma starRingEnd_eq_starL (z : ℂ) :
     (starRingEnd ℂ) z = (starL ℂ : ℂ ≃L⋆[ℂ] ℂ) z := by
@@ -313,26 +264,6 @@ lemma differentiableOn_schwarzReflection_of_subset_im_nonneg
   hf.congr fun _ hz => eqOn_schwarzReflection_of_subset_im_nonneg (f := f) hS hz
 
 /--
-On the open upper half-plane, the explicit Schwarz-reflection extension is holomorphic whenever
-the original function is.
--/
-lemma differentiableOn_schwarzReflection_im_pos
-    (hf : DifferentiableOn ℂ f {z : ℂ | 0 < z.im}) :
-    DifferentiableOn ℂ (schwarzReflection f) {z : ℂ | 0 < z.im} :=
-  differentiableOn_schwarzReflection_of_subset_im_nonneg
-    (f := f) (S := {z : ℂ | 0 < z.im}) (fun z hz => show 0 ≤ z.im from hz.le) hf
-
-/--
-On the open upper half-plane part of a domain, the explicit Schwarz-reflection extension is
-holomorphic whenever the original function is.
--/
-lemma differentiableOn_schwarzReflection_inter_im_pos {Ω : Set ℂ}
-    (hf : DifferentiableOn ℂ f (Ω ∩ {z | 0 < z.im})) :
-    DifferentiableOn ℂ (schwarzReflection f) (Ω ∩ {z | 0 < z.im}) :=
-  differentiableOn_schwarzReflection_of_subset_im_nonneg
-    (f := f) (S := Ω ∩ {z | 0 < z.im}) (fun z hz => show 0 ≤ z.im from hz.2.le) hf
-
-/--
 Conjugating both source and target preserves holomorphicity on domains, in both directions.
 -/
 @[simp]
@@ -365,17 +296,6 @@ lemma differentiableOn_conj_conj_inter_im_neg_of_symmetric {Ω : Set ℂ}
     differentiableOn_conj_conj (S := Ω ∩ {z | 0 < z.im}) (f := f) hf
 
 /--
-On a conjugation-symmetric domain, conjugating source and target carries holomorphicity from the
-upper half-plane part to the lower half-plane part.
--/
-lemma differentiableOn_conj_conj_inter_im_neg_of_mem_iff {Ω : Set ℂ}
-    (hΩ : ∀ z, z ∈ Ω ↔ (starRingEnd ℂ) z ∈ Ω)
-    (hf : DifferentiableOn ℂ f (Ω ∩ {z | 0 < z.im})) :
-    DifferentiableOn ℂ (fun z => (starRingEnd ℂ) (f ((starRingEnd ℂ) z)))
-      (Ω ∩ {z | z.im < 0}) :=
-  differentiableOn_conj_conj_inter_im_neg_of_symmetric (mapsTo_conj_of_mem_iff hΩ) hf
-
-/--
 On the lower half-plane part of a domain closed under conjugation, the explicit Schwarz
 reflection extension is holomorphic whenever the original function is holomorphic on the
 upper half-plane part.
@@ -389,17 +309,5 @@ lemma differentiableOn_schwarzReflection_inter_im_neg_of_symmetric {Ω : Set ℂ
     (f := f) hΩ hf) z hz).congr
       (fun w hw => schwarzReflection_of_im_neg (f := f) hw.2)
       (schwarzReflection_of_im_neg (f := f) hz.2)
-
-/--
-On the lower half-plane part of a conjugation-symmetric domain, the explicit Schwarz-reflection
-extension is holomorphic whenever the original function is holomorphic on the upper half-plane
-part.
--/
-lemma differentiableOn_schwarzReflection_inter_im_neg_of_mem_iff {Ω : Set ℂ}
-    (hΩ : ∀ z, z ∈ Ω ↔ (starRingEnd ℂ) z ∈ Ω)
-    (hf : DifferentiableOn ℂ f (Ω ∩ {z | 0 < z.im})) :
-    DifferentiableOn ℂ (schwarzReflection f) (Ω ∩ {z | z.im < 0}) :=
-  differentiableOn_schwarzReflection_inter_im_neg_of_symmetric
-    (mapsTo_conj_of_mem_iff hΩ) hf
 
 end TauCeti

--- a/TauCeti/Analysis/Complex/Conformal/Reflection.lean
+++ b/TauCeti/Analysis/Complex/Conformal/Reflection.lean
@@ -123,11 +123,6 @@ lemma schwarzReflection_conj
   · rw [schwarzReflection_conj_of_im_pos (f := f) hpos]
     rw [schwarzReflection_of_im_nonneg (f := f) hpos.le]
 
-/-- A symmetric-domain membership criterion gives the one-sided `MapsTo` form used below. -/
-lemma mapsTo_conj_of_mem_iff {Ω : Set ℂ}
-    (hΩ : ∀ z, z ∈ Ω ↔ (starRingEnd ℂ) z ∈ Ω) :
-    Set.MapsTo (starRingEnd ℂ) Ω Ω := fun z hz => (hΩ z).mp hz
-
 /--
 On a domain where the original function is real-valued on the real axis, the Schwarz-reflection
 extension is conjugation-symmetric at each point of the domain.

--- a/TauCeti/Analysis/Complex/Conformal/Reflection.lean
+++ b/TauCeti/Analysis/Complex/Conformal/Reflection.lean
@@ -21,8 +21,8 @@ It also names the standard real-axis Schwarz-reflection extension
 `z ↦ if 0 ≤ z.im then f z else conj (f (conj z))`, together with the pointwise API for the
 upper and lower half-planes and the conjugation symmetry forced by real boundary values.
 The closed upper branch is intentionally exposed through the pointwise simplifier
-`schwarzReflection_of_im_nonneg`; continuity and differentiability transfers on subsets of
-that branch are obtained from Mathlib's congruence lemmas rather than separate wrapper API.
+`schwarzReflection_of_im_nonneg`, with subset-level wrappers for branch agreement and
+differentiability transfer.
 The private semilinear within-set helper adapts the proof pattern of Mathlib's
 `HasFDerivAt.comp_semilinear`.
 -/
@@ -68,18 +68,50 @@ lemma schwarzReflection_of_im_zero {z : ℂ} (hz : z.im = 0) :
     schwarzReflection f z = f z := by
   exact schwarzReflection_of_im_nonneg (f := f) (z := z) hz.ge
 
+/-- On any subset of the closed upper half-plane, Schwarz reflection agrees with the original
+function. -/
+lemma eqOn_schwarzReflection_of_subset_im_nonneg
+    (hS : S ⊆ {z : ℂ | 0 ≤ z.im}) :
+    Set.EqOn (schwarzReflection f) f S :=
+  fun _ hz => schwarzReflection_of_im_nonneg (f := f) (hS hz)
+
 /-- On the closed upper half-plane, Schwarz reflection agrees with the original function. -/
 lemma eqOn_schwarzReflection_im_nonneg :
-    Set.EqOn (schwarzReflection f) f {z : ℂ | 0 ≤ z.im} := fun _ hz =>
-  schwarzReflection_of_im_nonneg (f := f) hz
+    Set.EqOn (schwarzReflection f) f {z : ℂ | 0 ≤ z.im} :=
+  eqOn_schwarzReflection_of_subset_im_nonneg
+    (f := f) (S := {z : ℂ | 0 ≤ z.im}) Subset.rfl
 
 /--
 On the closed upper half-plane part of a domain, Schwarz reflection agrees with the original
 function.
 -/
 lemma eqOn_schwarzReflection_inter_im_nonneg (Ω : Set ℂ) :
-    Set.EqOn (schwarzReflection f) f (Ω ∩ {z : ℂ | 0 ≤ z.im}) := fun _ hz =>
-  schwarzReflection_of_im_nonneg (f := f) hz.2
+    Set.EqOn (schwarzReflection f) f (Ω ∩ {z : ℂ | 0 ≤ z.im}) :=
+  eqOn_schwarzReflection_of_subset_im_nonneg (f := f)
+    (S := Ω ∩ {z : ℂ | 0 ≤ z.im}) inter_subset_right
+
+/-- On any subset of the lower half-plane, Schwarz reflection agrees with the reflected
+branch. -/
+lemma eqOn_schwarzReflection_of_subset_im_neg
+    (hS : S ⊆ {z : ℂ | z.im < 0}) :
+    Set.EqOn (schwarzReflection f) (fun z => (starRingEnd ℂ) (f ((starRingEnd ℂ) z))) S :=
+  fun _ hz => schwarzReflection_of_im_neg (f := f) (hS hz)
+
+/-- On the lower half-plane, Schwarz reflection agrees with the reflected branch. -/
+lemma eqOn_schwarzReflection_im_neg :
+    Set.EqOn (schwarzReflection f) (fun z => (starRingEnd ℂ) (f ((starRingEnd ℂ) z)))
+      {z : ℂ | z.im < 0} :=
+  eqOn_schwarzReflection_of_subset_im_neg
+    (f := f) (S := {z : ℂ | z.im < 0}) Subset.rfl
+
+/--
+On the lower half-plane part of a domain, Schwarz reflection agrees with the reflected branch.
+-/
+lemma eqOn_schwarzReflection_inter_im_neg (Ω : Set ℂ) :
+    Set.EqOn (schwarzReflection f) (fun z => (starRingEnd ℂ) (f ((starRingEnd ℂ) z)))
+      (Ω ∩ {z : ℂ | z.im < 0}) :=
+  eqOn_schwarzReflection_of_subset_im_neg (f := f)
+    (S := Ω ∩ {z : ℂ | z.im < 0}) inter_subset_right
 
 /-- Conjugating a point in the upper half-plane evaluates the reflected lower branch. -/
 lemma schwarzReflection_conj_of_im_pos {z : ℂ} (hz : 0 < z.im) :
@@ -272,16 +304,23 @@ lemma differentiableOn_conj_conj (hf : DifferentiableOn ℂ f S) :
   exact hstar.differentiableWithinAt
 
 /--
+On any subset of the closed upper half-plane, the explicit Schwarz-reflection extension is
+holomorphic whenever the original function is.
+-/
+lemma differentiableOn_schwarzReflection_of_subset_im_nonneg
+    (hS : S ⊆ {z : ℂ | 0 ≤ z.im}) (hf : DifferentiableOn ℂ f S) :
+    DifferentiableOn ℂ (schwarzReflection f) S :=
+  hf.congr fun _ hz => eqOn_schwarzReflection_of_subset_im_nonneg (f := f) hS hz
+
+/--
 On the open upper half-plane, the explicit Schwarz-reflection extension is holomorphic whenever
 the original function is.
 -/
 lemma differentiableOn_schwarzReflection_im_pos
     (hf : DifferentiableOn ℂ f {z : ℂ | 0 < z.im}) :
-    DifferentiableOn ℂ (schwarzReflection f) {z : ℂ | 0 < z.im} := by
-  intro z hz
-  exact (hf z hz).congr
-    (fun w hw => schwarzReflection_of_im_nonneg (f := f) hw.le)
-    (schwarzReflection_of_im_nonneg (f := f) hz.le)
+    DifferentiableOn ℂ (schwarzReflection f) {z : ℂ | 0 < z.im} :=
+  differentiableOn_schwarzReflection_of_subset_im_nonneg
+    (f := f) (S := {z : ℂ | 0 < z.im}) (fun z hz => show 0 ≤ z.im from hz.le) hf
 
 /--
 On the open upper half-plane part of a domain, the explicit Schwarz-reflection extension is
@@ -289,11 +328,9 @@ holomorphic whenever the original function is.
 -/
 lemma differentiableOn_schwarzReflection_inter_im_pos {Ω : Set ℂ}
     (hf : DifferentiableOn ℂ f (Ω ∩ {z | 0 < z.im})) :
-    DifferentiableOn ℂ (schwarzReflection f) (Ω ∩ {z | 0 < z.im}) := by
-  intro z hz
-  exact (hf z hz).congr
-    (fun w hw => schwarzReflection_of_im_nonneg (f := f) hw.2.le)
-    (schwarzReflection_of_im_nonneg (f := f) hz.2.le)
+    DifferentiableOn ℂ (schwarzReflection f) (Ω ∩ {z | 0 < z.im}) :=
+  differentiableOn_schwarzReflection_of_subset_im_nonneg
+    (f := f) (S := Ω ∩ {z | 0 < z.im}) (fun z hz => show 0 ≤ z.im from hz.2.le) hf
 
 /--
 Conjugating both source and target preserves holomorphicity on domains, in both directions.

--- a/TauCeti/Analysis/Complex/Conformal/Reflection.lean
+++ b/TauCeti/Analysis/Complex/Conformal/Reflection.lean
@@ -68,6 +68,19 @@ lemma schwarzReflection_of_im_zero {z : ℂ} (hz : z.im = 0) :
     schwarzReflection f z = f z := by
   exact schwarzReflection_of_im_nonneg (f := f) (z := z) hz.ge
 
+/-- On the closed upper half-plane, Schwarz reflection agrees with the original function. -/
+lemma eqOn_schwarzReflection_im_nonneg :
+    Set.EqOn (schwarzReflection f) f {z : ℂ | 0 ≤ z.im} := fun _ hz =>
+  schwarzReflection_of_im_nonneg (f := f) hz
+
+/--
+On the closed upper half-plane part of a domain, Schwarz reflection agrees with the original
+function.
+-/
+lemma eqOn_schwarzReflection_inter_im_nonneg (Ω : Set ℂ) :
+    Set.EqOn (schwarzReflection f) f (Ω ∩ {z : ℂ | 0 ≤ z.im}) := fun _ hz =>
+  schwarzReflection_of_im_nonneg (f := f) hz.2
+
 /-- Conjugating a point in the upper half-plane evaluates the reflected lower branch. -/
 lemma schwarzReflection_conj_of_im_pos {z : ℂ} (hz : 0 < z.im) :
     schwarzReflection f ((starRingEnd ℂ) z) = (starRingEnd ℂ) (f z) := by
@@ -109,6 +122,31 @@ lemma schwarzReflection_conj
   · rw [schwarzReflection_conj_of_im_pos (f := f) hpos]
     rw [schwarzReflection_of_im_nonneg (f := f) hpos.le]
 
+/-- A symmetric-domain membership criterion gives the one-sided `MapsTo` form used below. -/
+lemma mapsTo_conj_of_mem_iff {Ω : Set ℂ}
+    (hΩ : ∀ z, z ∈ Ω ↔ (starRingEnd ℂ) z ∈ Ω) :
+    Set.MapsTo (starRingEnd ℂ) Ω Ω := fun z hz => (hΩ z).mp hz
+
+/--
+On a domain where the original function is real-valued on the real axis, the Schwarz-reflection
+extension is conjugation-symmetric at each point of the domain.
+-/
+lemma schwarzReflection_conj_of_real_on_axis {Ω : Set ℂ}
+    (hreal : ∀ z ∈ Ω, z.im = 0 → (f z).im = 0) {z : ℂ} (hz : z ∈ Ω) :
+    schwarzReflection f ((starRingEnd ℂ) z) =
+      (starRingEnd ℂ) (schwarzReflection f z) :=
+  schwarzReflection_conj (f := f) z fun hz0 => hreal z hz hz0
+
+/--
+On a domain where the original function is real-valued on the real axis, the Schwarz-reflection
+extension is conjugation-symmetric on that domain.
+-/
+lemma eqOn_schwarzReflection_conj_of_real_on_axis {Ω : Set ℂ}
+    (hreal : ∀ z ∈ Ω, z.im = 0 → (f z).im = 0) :
+    Set.EqOn (fun z => schwarzReflection f ((starRingEnd ℂ) z))
+      (fun z => (starRingEnd ℂ) (schwarzReflection f z)) Ω := fun _ hz =>
+  schwarzReflection_conj_of_real_on_axis (f := f) hreal hz
+
 /--
 For a domain closed under conjugation, conjugation carries the upper half-plane part of the
 domain to its lower half-plane part.
@@ -131,6 +169,15 @@ lemma image_conj_inter_im_pos_of_symmetric {Ω : Set ℂ}
     · rw [starRingEnd_self_apply]
 
 /--
+For a conjugation-symmetric domain, conjugation carries the upper half-plane part of the domain
+to its lower half-plane part.
+-/
+lemma image_conj_inter_im_pos_of_mem_iff {Ω : Set ℂ}
+    (hΩ : ∀ z, z ∈ Ω ↔ (starRingEnd ℂ) z ∈ Ω) :
+    (starRingEnd ℂ) '' (Ω ∩ {z | 0 < z.im}) = Ω ∩ {z | z.im < 0} :=
+  image_conj_inter_im_pos_of_symmetric (mapsTo_conj_of_mem_iff hΩ)
+
+/--
 For a domain closed under conjugation, conjugation carries the lower half-plane part of the
 domain to its upper half-plane part.
 -/
@@ -150,6 +197,15 @@ lemma image_conj_inter_im_neg_of_symmetric {Ω : Set ℂ}
     · rw [Set.mem_setOf_eq, starRingEnd_apply, Complex.star_def, Complex.conj_im]
       exact neg_neg_of_pos hzim
     · rw [starRingEnd_self_apply]
+
+/--
+For a conjugation-symmetric domain, conjugation carries the lower half-plane part of the domain
+to its upper half-plane part.
+-/
+lemma image_conj_inter_im_neg_of_mem_iff {Ω : Set ℂ}
+    (hΩ : ∀ z, z ∈ Ω ↔ (starRingEnd ℂ) z ∈ Ω) :
+    (starRingEnd ℂ) '' (Ω ∩ {z | z.im < 0}) = Ω ∩ {z | 0 < z.im} :=
+  image_conj_inter_im_neg_of_symmetric (mapsTo_conj_of_mem_iff hΩ)
 
 private lemma starRingEnd_eq_starL (z : ℂ) :
     (starRingEnd ℂ) z = (starL ℂ : ℂ ≃L⋆[ℂ] ℂ) z := by
@@ -216,6 +272,30 @@ lemma differentiableOn_conj_conj (hf : DifferentiableOn ℂ f S) :
   exact hstar.differentiableWithinAt
 
 /--
+On the open upper half-plane, the explicit Schwarz-reflection extension is holomorphic whenever
+the original function is.
+-/
+lemma differentiableOn_schwarzReflection_im_pos
+    (hf : DifferentiableOn ℂ f {z : ℂ | 0 < z.im}) :
+    DifferentiableOn ℂ (schwarzReflection f) {z : ℂ | 0 < z.im} := by
+  intro z hz
+  exact (hf z hz).congr
+    (fun w hw => schwarzReflection_of_im_nonneg (f := f) hw.le)
+    (schwarzReflection_of_im_nonneg (f := f) hz.le)
+
+/--
+On the open upper half-plane part of a domain, the explicit Schwarz-reflection extension is
+holomorphic whenever the original function is.
+-/
+lemma differentiableOn_schwarzReflection_inter_im_pos {Ω : Set ℂ}
+    (hf : DifferentiableOn ℂ f (Ω ∩ {z | 0 < z.im})) :
+    DifferentiableOn ℂ (schwarzReflection f) (Ω ∩ {z | 0 < z.im}) := by
+  intro z hz
+  exact (hf z hz).congr
+    (fun w hw => schwarzReflection_of_im_nonneg (f := f) hw.2.le)
+    (schwarzReflection_of_im_nonneg (f := f) hz.2.le)
+
+/--
 Conjugating both source and target preserves holomorphicity on domains, in both directions.
 -/
 @[simp]
@@ -248,6 +328,17 @@ lemma differentiableOn_conj_conj_inter_im_neg_of_symmetric {Ω : Set ℂ}
     differentiableOn_conj_conj (S := Ω ∩ {z | 0 < z.im}) (f := f) hf
 
 /--
+On a conjugation-symmetric domain, conjugating source and target carries holomorphicity from the
+upper half-plane part to the lower half-plane part.
+-/
+lemma differentiableOn_conj_conj_inter_im_neg_of_mem_iff {Ω : Set ℂ}
+    (hΩ : ∀ z, z ∈ Ω ↔ (starRingEnd ℂ) z ∈ Ω)
+    (hf : DifferentiableOn ℂ f (Ω ∩ {z | 0 < z.im})) :
+    DifferentiableOn ℂ (fun z => (starRingEnd ℂ) (f ((starRingEnd ℂ) z)))
+      (Ω ∩ {z | z.im < 0}) :=
+  differentiableOn_conj_conj_inter_im_neg_of_symmetric (mapsTo_conj_of_mem_iff hΩ) hf
+
+/--
 On the lower half-plane part of a domain closed under conjugation, the explicit Schwarz
 reflection extension is holomorphic whenever the original function is holomorphic on the
 upper half-plane part.
@@ -261,5 +352,17 @@ lemma differentiableOn_schwarzReflection_inter_im_neg_of_symmetric {Ω : Set ℂ
     (f := f) hΩ hf) z hz).congr
       (fun w hw => schwarzReflection_of_im_neg (f := f) hw.2)
       (schwarzReflection_of_im_neg (f := f) hz.2)
+
+/--
+On the lower half-plane part of a conjugation-symmetric domain, the explicit Schwarz-reflection
+extension is holomorphic whenever the original function is holomorphic on the upper half-plane
+part.
+-/
+lemma differentiableOn_schwarzReflection_inter_im_neg_of_mem_iff {Ω : Set ℂ}
+    (hΩ : ∀ z, z ∈ Ω ↔ (starRingEnd ℂ) z ∈ Ω)
+    (hf : DifferentiableOn ℂ f (Ω ∩ {z | 0 < z.im})) :
+    DifferentiableOn ℂ (schwarzReflection f) (Ω ∩ {z | z.im < 0}) :=
+  differentiableOn_schwarzReflection_inter_im_neg_of_symmetric
+    (mapsTo_conj_of_mem_iff hΩ) hf
 
 end TauCeti

--- a/TauCeti/Probability/Independence/Conditional.lean
+++ b/TauCeti/Probability/Independence/Conditional.lean
@@ -360,10 +360,13 @@ theorem condExp_indicator_eq_of_law_eq_of_comap_le [IsFiniteMeasure μ]
     μ[(X ⁻¹' A).indicator (fun _ => (1 : ℝ)) | MeasurableSpace.comap W inferInstance] := by
   have h_sq_eq_raw := integral_sq_condExp_eq_of_pair_law X W W' hX hW hW' h_law hA
   let φ : Ω → ℝ := (X ⁻¹' A).indicator (fun _ => (1 : ℝ))
+  let mΩ : MeasurableSpace Ω := inferInstance
   let mW : MeasurableSpace Ω := MeasurableSpace.comap W inferInstance
   let mW' : MeasurableSpace Ω := MeasurableSpace.comap W' inferInstance
-  have hmW_le : mW ≤ _ := measurable_iff_comap_le.mp hW
-  have hmW'_le : mW' ≤ _ := measurable_iff_comap_le.mp hW'
+  have hmW_le : mW ≤ mΩ := by
+    simpa [mΩ, mW] using measurable_iff_comap_le.mp hW
+  have hmW'_le : mW' ≤ mΩ := by
+    simpa [mΩ, mW'] using measurable_iff_comap_le.mp hW'
   haveI hσW : SigmaFinite (μ.trim hmW_le) :=
     (inferInstance : IsFiniteMeasure (μ.trim hmW_le)).toSigmaFinite
   haveI hσW' : SigmaFinite (μ.trim hmW'_le) :=
@@ -378,19 +381,30 @@ theorem condExp_indicator_eq_of_law_eq_of_comap_le [IsFiniteMeasure μ]
       rw [h]; exact ⟨zero_le_one, le_rfl⟩
     · have h : φ ω = 0 := Set.indicator_of_notMem hω _
       rw [h]; exact ⟨le_rfl, zero_le_one⟩
-  -- `|φ| ≤ 1` a.e., so each conditional expectation `μ[φ | ·]` inherits the same bound via
-  -- Mathlib's `ae_bdd_condExp_of_ae_bdd`; the helper is applied once per σ-algebra below.
-  have hφ_abs : ∀ᵐ ω ∂μ, |φ ω| ≤ ((1 : NNReal) : ℝ) := by
+  have hφ_nonneg : ∀ᵐ ω ∂μ, 0 ≤ φ ω := by
     filter_upwards with ω
-    rw [abs_of_nonneg (hφ_bdd ω).1, NNReal.coe_one]; exact (hφ_bdd ω).2
-  have condExp_abs_le : ∀ m' : MeasurableSpace Ω, ∀ᵐ ω ∂μ, |μ[φ | m'] ω| ≤ 1 := fun m' => by
-    simpa using ae_bdd_condExp_of_ae_bdd (m := m') (R := 1) hφ_abs
+    exact (hφ_bdd ω).1
+  have hφ_le_one : ∀ᵐ ω ∂μ, φ ω ≤ (1 : ℝ) := by
+    filter_upwards with ω
+    exact (hφ_bdd ω).2
+  have condExp_abs_le :
+      ∀ (m' : MeasurableSpace Ω), m' ≤ mΩ →
+        ∀ᵐ ω ∂μ, |μ[φ | m'] ω| ≤ 1 := fun m' hm' => by
+    have h_nonneg : 0 ≤ᵐ[μ] μ[φ | m'] := condExp_nonneg hφ_nonneg
+    have h_le_const : μ[φ | m'] ≤ᵐ[μ] μ[fun _ => (1 : ℝ) | m'] :=
+      condExp_mono hφ_int (integrable_const (1 : ℝ)) hφ_le_one
+    have h_const : μ[fun _ => (1 : ℝ) | m'] = fun _ => (1 : ℝ) :=
+      condExp_const (μ := μ) hm' (1 : ℝ)
+    rw [h_const] at h_le_const
+    filter_upwards [h_nonneg, h_le_const] with ω h_nonnegω h_leω
+    rw [abs_of_nonneg h_nonnegω]
+    exact h_leω
   have hμ₁_int : Integrable μ₁ μ := integrable_condExp
   have hμ₂_int : Integrable μ₂ μ := integrable_condExp
   have hμ₁_bound : ∀ᵐ ω ∂μ, ‖μ₁ ω‖ ≤ 1 := by
-    filter_upwards [condExp_abs_le mW] with ω hω; rwa [Real.norm_eq_abs, hμ₁_def]
+    filter_upwards [condExp_abs_le mW hmW_le] with ω hω; rwa [Real.norm_eq_abs, hμ₁_def]
   have hμ₂_bound : ∀ᵐ ω ∂μ, ‖μ₂ ω‖ ≤ 1 := by
-    filter_upwards [condExp_abs_le mW'] with ω hω; rwa [Real.norm_eq_abs, hμ₂_def]
+    filter_upwards [condExp_abs_le mW' hmW'_le] with ω hω; rwa [Real.norm_eq_abs, hμ₂_def]
   have hμ₁sq_int : Integrable (fun ω => μ₁ ω * μ₁ ω) μ :=
     hμ₁_int.bdd_mul hμ₁_int.aestronglyMeasurable hμ₁_bound
   have hμ₂sq_int : Integrable (fun ω => μ₂ ω * μ₂ ω) μ :=

--- a/TauCeti/Probability/Independence/Conditional.lean
+++ b/TauCeti/Probability/Independence/Conditional.lean
@@ -360,13 +360,10 @@ theorem condExp_indicator_eq_of_law_eq_of_comap_le [IsFiniteMeasure μ]
     μ[(X ⁻¹' A).indicator (fun _ => (1 : ℝ)) | MeasurableSpace.comap W inferInstance] := by
   have h_sq_eq_raw := integral_sq_condExp_eq_of_pair_law X W W' hX hW hW' h_law hA
   let φ : Ω → ℝ := (X ⁻¹' A).indicator (fun _ => (1 : ℝ))
-  let mΩ : MeasurableSpace Ω := inferInstance
   let mW : MeasurableSpace Ω := MeasurableSpace.comap W inferInstance
   let mW' : MeasurableSpace Ω := MeasurableSpace.comap W' inferInstance
-  have hmW_le : mW ≤ mΩ := by
-    simpa [mΩ, mW] using measurable_iff_comap_le.mp hW
-  have hmW'_le : mW' ≤ mΩ := by
-    simpa [mΩ, mW'] using measurable_iff_comap_le.mp hW'
+  have hmW_le : mW ≤ _ := measurable_iff_comap_le.mp hW
+  have hmW'_le : mW' ≤ _ := measurable_iff_comap_le.mp hW'
   haveI hσW : SigmaFinite (μ.trim hmW_le) :=
     (inferInstance : IsFiniteMeasure (μ.trim hmW_le)).toSigmaFinite
   haveI hσW' : SigmaFinite (μ.trim hmW'_le) :=


### PR DESCRIPTION
This PR adds branch-level API for the explicit real-axis Schwarz-reflection witness `schwarzReflection`: agreement on the closed upper half-plane, conjugation symmetry from real boundary values, direct wrappers for the roadmap's conjugation-symmetric domain hypothesis, and upper/lower half-plane differentiability handoffs.

It advances `TauCetiRoadmap/ConformalMapping/README.md`, Layer L4, specifically the real-axis Schwarz reflection principle using the witness `F z = if 0 ≤ z.im then f z else conj (f (conj z))`, and supplies a clean prerequisite for assembling the full theorem from the already-merged L4.0 antiholomorphic-composition lemma. I chose this as the lowest-hanging distinct ConformalMapping target after checking open and recently merged PRs: `main` already has Schwarz-Pick, unit-disc automorphisms, the explicit reflection witness, and L4.0 differentiability of `z ↦ conj (f (conj z))`, while the branch agreement, domain-symmetry, and upper/lower holomorphicity wrappers needed by the L4 statement were still absent.

No Mathlib infrastructure is vendored. The implementation reuses Mathlib's within-set differentiability congruence API and Tau Ceti's existing `schwarzReflection`, `schwarzReflection_conj`, `image_conj_inter_im_pos_of_symmetric`, `differentiableOn_conj_conj`, and lower-branch differentiability lemmas.

`lake exe cache get` completed with `No files to download` and `Already decompressed 8609 file(s)`. `lake build` completed with `Build completed successfully (4600 jobs).` `lake exe axioms` completed with `axioms: audited 8741 TauCeti declaration(s); all within the allowlist [propext, Classical.choice, Quot.sound].`

<!--tauceti-target:v1 {"focus":"ConformalMapping","id":"schwarz-reflection-branch-api"}-->

🤖 Prepared with Codex
