### PR TITLE
feat: add contractable L² covariance structure

### DIFF
--- a/TauCeti/Probability/Exchangeability/Contractability.lean
+++ b/TauCeti/Probability/Exchangeability/Contractability.lean
@@ -4,6 +4,7 @@ public import TauCeti.Probability.Exchangeability.Basic
 public import Mathlib.Order.Fin.Basic
 public import Mathlib.Data.Fin.VecNotation
 public import Mathlib.Dynamics.Ergodic.MeasurePreserving
+public import Mathlib.Probability.IdentDistrib
 import TauCeti.Probability.Exchangeability.PermutationExtension
 import TauCeti.Probability.Exchangeability.ExchangeableAtMonotone
 import Mathlib.Order.Fin.Tuple
@@ -35,7 +36,7 @@ public section
 
 noncomputable section
 
-open MeasureTheory
+open MeasureTheory ProbabilityTheory
 
 namespace TauCeti
 
@@ -61,6 +62,52 @@ theorem Contractable.map_pair {μ : Measure Ω} {X : ℕ → Ω → α} (h : Con
     {i j : ℕ} (hij : i < j) :
     blockLaw μ X ![i, j] = prefixLaw μ X 2 :=
   h.map (strictMono_vecEmpty.vecCons hij)
+
+/-- Evaluating the one-coordinate block law `blockLaw μ X (fun _ => i)` at its single
+coordinate recovers the law of `X i`. -/
+private theorem map_coordEval_blockLaw {μ : Measure Ω} {X : ℕ → Ω → α}
+    (i : ℕ) (hX_meas : ∀ n, AEMeasurable (X n) μ) :
+    (blockLaw μ X (fun _ : Fin 1 => i)).map (fun v : Fin 1 → α => v 0) = μ.map (X i) := by
+  rw [blockLaw_def, AEMeasurable.map_map_of_aemeasurable (measurable_pi_apply 0).aemeasurable
+    (aemeasurable_pi_lambda _ fun _ => hX_meas i)]
+  rfl
+
+/-- Evaluating the two-coordinate block law `blockLaw μ X ![i, j]` at its two coordinates
+recovers the joint law of `(X i, X j)`. -/
+private theorem map_pairEval_blockLaw {μ : Measure Ω} {X : ℕ → Ω → α}
+    (i j : ℕ) (hX_meas : ∀ n, AEMeasurable (X n) μ) :
+    (blockLaw μ X ![i, j]).map (fun v : Fin 2 → α => (v 0, v 1))
+      = μ.map (fun ω => (X i ω, X j ω)) := by
+  have hcomp : ((fun v : Fin 2 → α => (v 0, v 1)) ∘ fun ω (l : Fin 2) => X (![i, j] l) ω)
+      = fun ω => (X i ω, X j ω) := by
+    funext ω
+    simp [Function.comp, Matrix.cons_val_zero, Matrix.cons_val_one]
+  rw [blockLaw_def, AEMeasurable.map_map_of_aemeasurable
+    ((measurable_pi_apply 0).prodMk (measurable_pi_apply 1)).aemeasurable
+    (aemeasurable_pi_lambda _ fun l => hX_meas (![i, j] l)), hcomp]
+
+/-- **Coordinates of a contractable process are identically distributed.** For a contractable
+process `X` with a.e. measurable coordinates, `X i` and `X j` have the same law. -/
+theorem Contractable.identDistrib_coord {μ : Measure Ω} {X : ℕ → Ω → α} (hX : Contractable μ X)
+    (hX_meas : ∀ n, AEMeasurable (X n) μ) (i j : ℕ) :
+    IdentDistrib (X i) (X j) μ μ where
+  aemeasurable_fst := hX_meas i
+  aemeasurable_snd := hX_meas j
+  map_eq := by
+    rw [← map_coordEval_blockLaw i hX_meas, ← map_coordEval_blockLaw j hX_meas,
+      hX.map_single (fun _ => i), hX.map_single (fun _ => j)]
+
+/-- **Increasing pairs of a contractable process are identically distributed.** For a
+contractable process `X` with a.e. measurable coordinates and `i < j`, `k < l`, the pair
+`(X i, X j)` has the same joint law as `(X k, X l)`. -/
+theorem Contractable.identDistrib_pair {μ : Measure Ω} {X : ℕ → Ω → α} (hX : Contractable μ X)
+    (hX_meas : ∀ n, AEMeasurable (X n) μ) {i j k l : ℕ} (hij : i < j) (hkl : k < l) :
+    IdentDistrib (fun ω => (X i ω, X j ω)) (fun ω => (X k ω, X l ω)) μ μ where
+  aemeasurable_fst := (hX_meas i).prodMk (hX_meas j)
+  aemeasurable_snd := (hX_meas k).prodMk (hX_meas l)
+  map_eq := by
+    rw [← map_pairEval_blockLaw i j hX_meas, ← map_pairEval_blockLaw k l hX_meas,
+      hX.map_pair hij, hX.map_pair hkl]
 
 /-- Contractability is preserved by passing to a strictly increasing subsequence. -/
 theorem Contractable.comp {μ : Measure Ω} {X : ℕ → Ω → α} (h : Contractable μ X)

--- a/TauCeti/Probability/Exchangeability/Contractability.lean
+++ b/TauCeti/Probability/Exchangeability/Contractability.lean
@@ -79,24 +79,12 @@ theorem Contractable.identDistrib_block {μ : Measure Ω} {X : ℕ → Ω → α
 process `X`, any two a.e. measurable coordinates `X i` and `X j` have the same law. -/
 theorem Contractable.identDistrib_coord {μ : Measure Ω} {X : ℕ → Ω → α} (hX : Contractable μ X)
     {i j : ℕ} (hi_meas : AEMeasurable (X i) μ) (hj_meas : AEMeasurable (X j) μ) :
-    IdentDistrib (X i) (X j) μ μ where
-  aemeasurable_fst := hi_meas
-  aemeasurable_snd := hj_meas
-  map_eq := by
-    let eval : (Fin 1 → α) → α := fun v => v 0
-    have heval : AEMeasurable eval
-        (μ.map fun (ω : Ω) (r : Fin 1) => X ((fun _ : Fin 1 => i) r) ω) :=
-      (measurable_pi_apply (0 : Fin 1)).aemeasurable
-    have hblock := hX.identDistrib_block
-      (Subsingleton.strictMono (fun _ : Fin 1 => i))
-      (Subsingleton.strictMono (fun _ : Fin 1 => j)) (fun _ => hi_meas) (fun _ => hj_meas)
-    have hmap := congrArg (fun ν : Measure (Fin 1 → α) => ν.map eval) hblock.map_eq
-    rw [AEMeasurable.map_map_of_aemeasurable heval hblock.aemeasurable_fst,
-      AEMeasurable.map_map_of_aemeasurable (by rwa [hblock.map_eq] at heval)
-        hblock.aemeasurable_snd] at hmap
-    change μ.map (eval ∘ (fun (ω : Ω) (r : Fin 1) => X ((fun _ : Fin 1 => i) r) ω)) =
-      μ.map (eval ∘ (fun (ω : Ω) (r : Fin 1) => X ((fun _ : Fin 1 => j) r) ω))
-    simpa [eval, Function.comp] using hmap
+    IdentDistrib (X i) (X j) μ μ := by
+  have hblock := hX.identDistrib_block
+    (Subsingleton.strictMono (fun _ : Fin 1 => i))
+    (Subsingleton.strictMono (fun _ : Fin 1 => j)) (fun _ => hi_meas) (fun _ => hj_meas)
+  have hcomp := hblock.comp (measurable_pi_apply (0 : Fin 1))
+  convert hcomp using 1 <;> funext ω <;> simp [Function.comp]
 
 /-- **Increasing pairs of a contractable process are identically distributed.** For a
 contractable process `X`, if the four selected coordinates are a.e. measurable and `i < j`,
@@ -105,32 +93,21 @@ theorem Contractable.identDistrib_pair {μ : Measure Ω} {X : ℕ → Ω → α}
     {i j k l : ℕ} (hi_meas : AEMeasurable (X i) μ) (hj_meas : AEMeasurable (X j) μ)
     (hk_meas : AEMeasurable (X k) μ) (hl_meas : AEMeasurable (X l) μ)
     (hij : i < j) (hkl : k < l) :
-    IdentDistrib (fun ω => (X i ω, X j ω)) (fun ω => (X k ω, X l ω)) μ μ where
-  aemeasurable_fst := hi_meas.prodMk hj_meas
-  aemeasurable_snd := hk_meas.prodMk hl_meas
-  map_eq := by
-    let eval : (Fin 2 → α) → α × α := fun v => (v 0, v 1)
-    have hblock := hX.identDistrib_block (strictMono_vecEmpty.vecCons hij)
-      (strictMono_vecEmpty.vecCons hkl)
-      (fun r => by
-        fin_cases r
-        · simpa [Matrix.cons_val_zero] using hi_meas
-        · simpa [Matrix.cons_val_one] using hj_meas)
-      (fun r => by
-        fin_cases r
-        · simpa [Matrix.cons_val_zero] using hk_meas
-        · simpa [Matrix.cons_val_one] using hl_meas)
-    have heval : AEMeasurable eval
-        (μ.map fun (ω : Ω) (r : Fin 2) => X (![i, j] r) ω) :=
-      ((measurable_pi_apply (0 : Fin 2)).prodMk
-        (measurable_pi_apply (1 : Fin 2))).aemeasurable
-    have hmap := congrArg (fun ν : Measure (Fin 2 → α) => ν.map eval) hblock.map_eq
-    rw [AEMeasurable.map_map_of_aemeasurable heval hblock.aemeasurable_fst,
-      AEMeasurable.map_map_of_aemeasurable (by rwa [hblock.map_eq] at heval)
-        hblock.aemeasurable_snd] at hmap
-    change μ.map (eval ∘ (fun (ω : Ω) (r : Fin 2) => X (![i, j] r) ω)) =
-      μ.map (eval ∘ (fun (ω : Ω) (r : Fin 2) => X (![k, l] r) ω))
-    simpa [eval, Function.comp, Matrix.cons_val_zero, Matrix.cons_val_one] using hmap
+    IdentDistrib (fun ω => (X i ω, X j ω)) (fun ω => (X k ω, X l ω)) μ μ := by
+  have hblock := hX.identDistrib_block (strictMono_vecEmpty.vecCons hij)
+    (strictMono_vecEmpty.vecCons hkl)
+    (fun r => by
+      fin_cases r
+      · simpa [Matrix.cons_val_zero] using hi_meas
+      · simpa [Matrix.cons_val_one] using hj_meas)
+    (fun r => by
+      fin_cases r
+      · simpa [Matrix.cons_val_zero] using hk_meas
+      · simpa [Matrix.cons_val_one] using hl_meas)
+  have hcomp := hblock.comp
+    ((measurable_pi_apply (0 : Fin 2)).prodMk (measurable_pi_apply (1 : Fin 2)))
+  convert hcomp using 1 <;> funext ω <;>
+    simp [Function.comp, Matrix.cons_val_zero, Matrix.cons_val_one]
 
 /-- Contractability is preserved by passing to a strictly increasing subsequence. -/
 theorem Contractable.comp {μ : Measure Ω} {X : ℕ → Ω → α} (h : Contractable μ X)

--- a/TauCeti/Probability/Exchangeability/Contractability.lean
+++ b/TauCeti/Probability/Exchangeability/Contractability.lean
@@ -63,51 +63,74 @@ theorem Contractable.map_pair {μ : Measure Ω} {X : ℕ → Ω → α} (h : Con
     blockLaw μ X ![i, j] = prefixLaw μ X 2 :=
   h.map (strictMono_vecEmpty.vecCons hij)
 
-/-- Evaluating the one-coordinate block law `blockLaw μ X (fun _ => i)` at its single
-coordinate recovers the law of `X i`. -/
-private theorem map_coordEval_blockLaw {μ : Measure Ω} {X : ℕ → Ω → α}
-    (i : ℕ) (hX_meas : ∀ n, AEMeasurable (X n) μ) :
-    (blockLaw μ X (fun _ : Fin 1 => i)).map (fun v : Fin 1 → α => v 0) = μ.map (X i) := by
-  rw [blockLaw_def, AEMeasurable.map_map_of_aemeasurable (measurable_pi_apply 0).aemeasurable
-    (aemeasurable_pi_lambda _ fun _ => hX_meas i)]
-  rfl
-
-/-- Evaluating the two-coordinate block law `blockLaw μ X ![i, j]` at its two coordinates
-recovers the joint law of `(X i, X j)`. -/
-private theorem map_pairEval_blockLaw {μ : Measure Ω} {X : ℕ → Ω → α}
-    (i j : ℕ) (hX_meas : ∀ n, AEMeasurable (X n) μ) :
-    (blockLaw μ X ![i, j]).map (fun v : Fin 2 → α => (v 0, v 1))
-      = μ.map (fun ω => (X i ω, X j ω)) := by
-  have hcomp : ((fun v : Fin 2 → α => (v 0, v 1)) ∘ fun ω (l : Fin 2) => X (![i, j] l) ω)
-      = fun ω => (X i ω, X j ω) := by
-    funext ω
-    simp [Function.comp, Matrix.cons_val_zero, Matrix.cons_val_one]
-  rw [blockLaw_def, AEMeasurable.map_map_of_aemeasurable
-    ((measurable_pi_apply 0).prodMk (measurable_pi_apply 1)).aemeasurable
-    (aemeasurable_pi_lambda _ fun l => hX_meas (![i, j] l)), hcomp]
+/-- **Finite blocks of a contractable process are identically distributed.** For a contractable
+process `X`, any two strictly increasing finite coordinate selections have the same joint law. -/
+theorem Contractable.identDistrib_block {μ : Measure Ω} {X : ℕ → Ω → α}
+    (hX : Contractable μ X) {m : ℕ} {k l : Fin m → ℕ} (hk : StrictMono k) (hl : StrictMono l)
+    (hk_meas : ∀ r, AEMeasurable (X (k r)) μ)
+    (hl_meas : ∀ r, AEMeasurable (X (l r)) μ) :
+    IdentDistrib (fun ω r => X (k r) ω) (fun ω r => X (l r) ω) μ μ where
+  aemeasurable_fst := aemeasurable_pi_lambda _ hk_meas
+  aemeasurable_snd := aemeasurable_pi_lambda _ hl_meas
+  map_eq := by
+    simpa [blockLaw_def] using (hX.map hk).trans (hX.map hl).symm
 
 /-- **Coordinates of a contractable process are identically distributed.** For a contractable
-process `X` with a.e. measurable coordinates, `X i` and `X j` have the same law. -/
+process `X`, any two a.e. measurable coordinates `X i` and `X j` have the same law. -/
 theorem Contractable.identDistrib_coord {μ : Measure Ω} {X : ℕ → Ω → α} (hX : Contractable μ X)
-    (hX_meas : ∀ n, AEMeasurable (X n) μ) (i j : ℕ) :
+    {i j : ℕ} (hi_meas : AEMeasurable (X i) μ) (hj_meas : AEMeasurable (X j) μ) :
     IdentDistrib (X i) (X j) μ μ where
-  aemeasurable_fst := hX_meas i
-  aemeasurable_snd := hX_meas j
+  aemeasurable_fst := hi_meas
+  aemeasurable_snd := hj_meas
   map_eq := by
-    rw [← map_coordEval_blockLaw i hX_meas, ← map_coordEval_blockLaw j hX_meas,
-      hX.map_single (fun _ => i), hX.map_single (fun _ => j)]
+    let eval : (Fin 1 → α) → α := fun v => v 0
+    have heval : AEMeasurable eval
+        (μ.map fun (ω : Ω) (r : Fin 1) => X ((fun _ : Fin 1 => i) r) ω) :=
+      (measurable_pi_apply (0 : Fin 1)).aemeasurable
+    have hblock := hX.identDistrib_block
+      (Subsingleton.strictMono (fun _ : Fin 1 => i))
+      (Subsingleton.strictMono (fun _ : Fin 1 => j)) (fun _ => hi_meas) (fun _ => hj_meas)
+    have hmap := congrArg (fun ν : Measure (Fin 1 → α) => ν.map eval) hblock.map_eq
+    rw [AEMeasurable.map_map_of_aemeasurable heval hblock.aemeasurable_fst,
+      AEMeasurable.map_map_of_aemeasurable (by rwa [hblock.map_eq] at heval)
+        hblock.aemeasurable_snd] at hmap
+    change μ.map (eval ∘ (fun (ω : Ω) (r : Fin 1) => X ((fun _ : Fin 1 => i) r) ω)) =
+      μ.map (eval ∘ (fun (ω : Ω) (r : Fin 1) => X ((fun _ : Fin 1 => j) r) ω))
+    simpa [eval, Function.comp] using hmap
 
 /-- **Increasing pairs of a contractable process are identically distributed.** For a
-contractable process `X` with a.e. measurable coordinates and `i < j`, `k < l`, the pair
-`(X i, X j)` has the same joint law as `(X k, X l)`. -/
+contractable process `X`, if the four selected coordinates are a.e. measurable and `i < j`,
+`k < l`, then `(X i, X j)` has the same joint law as `(X k, X l)`. -/
 theorem Contractable.identDistrib_pair {μ : Measure Ω} {X : ℕ → Ω → α} (hX : Contractable μ X)
-    (hX_meas : ∀ n, AEMeasurable (X n) μ) {i j k l : ℕ} (hij : i < j) (hkl : k < l) :
+    {i j k l : ℕ} (hi_meas : AEMeasurable (X i) μ) (hj_meas : AEMeasurable (X j) μ)
+    (hk_meas : AEMeasurable (X k) μ) (hl_meas : AEMeasurable (X l) μ)
+    (hij : i < j) (hkl : k < l) :
     IdentDistrib (fun ω => (X i ω, X j ω)) (fun ω => (X k ω, X l ω)) μ μ where
-  aemeasurable_fst := (hX_meas i).prodMk (hX_meas j)
-  aemeasurable_snd := (hX_meas k).prodMk (hX_meas l)
+  aemeasurable_fst := hi_meas.prodMk hj_meas
+  aemeasurable_snd := hk_meas.prodMk hl_meas
   map_eq := by
-    rw [← map_pairEval_blockLaw i j hX_meas, ← map_pairEval_blockLaw k l hX_meas,
-      hX.map_pair hij, hX.map_pair hkl]
+    let eval : (Fin 2 → α) → α × α := fun v => (v 0, v 1)
+    have hblock := hX.identDistrib_block (strictMono_vecEmpty.vecCons hij)
+      (strictMono_vecEmpty.vecCons hkl)
+      (fun r => by
+        fin_cases r
+        · simpa [Matrix.cons_val_zero] using hi_meas
+        · simpa [Matrix.cons_val_one] using hj_meas)
+      (fun r => by
+        fin_cases r
+        · simpa [Matrix.cons_val_zero] using hk_meas
+        · simpa [Matrix.cons_val_one] using hl_meas)
+    have heval : AEMeasurable eval
+        (μ.map fun (ω : Ω) (r : Fin 2) => X (![i, j] r) ω) :=
+      ((measurable_pi_apply (0 : Fin 2)).prodMk
+        (measurable_pi_apply (1 : Fin 2))).aemeasurable
+    have hmap := congrArg (fun ν : Measure (Fin 2 → α) => ν.map eval) hblock.map_eq
+    rw [AEMeasurable.map_map_of_aemeasurable heval hblock.aemeasurable_fst,
+      AEMeasurable.map_map_of_aemeasurable (by rwa [hblock.map_eq] at heval)
+        hblock.aemeasurable_snd] at hmap
+    change μ.map (eval ∘ (fun (ω : Ω) (r : Fin 2) => X (![i, j] r) ω)) =
+      μ.map (eval ∘ (fun (ω : Ω) (r : Fin 2) => X (![k, l] r) ω))
+    simpa [eval, Function.comp, Matrix.cons_val_zero, Matrix.cons_val_one] using hmap
 
 /-- Contractability is preserved by passing to a strictly increasing subsequence. -/
 theorem Contractable.comp {μ : Measure Ω} {X : ℕ → Ω → α} (h : Contractable μ X)

--- a/TauCeti/Probability/Exchangeability/L2/Covariance.lean
+++ b/TauCeti/Probability/Exchangeability/L2/Covariance.lean
@@ -11,7 +11,8 @@ standard-Borel de Finetti route"), whose first analytic input is the *uniform co
 structure of a contractable L² sequence* (`contractable_covariance_structure`). It also
 supplies the two Layer 3 preliminaries listed before it — "equality of means and integrals
 from equal one-dimensional laws" and "equality of pair covariances from equal
-two-dimensional laws" — specialized to a contractable process.
+two-dimensional laws". The latter appears first in the reusable form
+`covariance_eq_of_identDistrib_pair`, then specializes to contractable processes.
 
 For a real-valued contractable sequence, the one- and two-coordinate `IdentDistrib` facts in
 `TauCeti.Probability.Exchangeability.Contractability` give the uniform first- and second-moment
@@ -46,6 +47,25 @@ section Real
 
 variable {X : ℕ → Ω → ℝ}
 
+/-- **Equal covariance from equal pair laws.** If the two-dimensional laws of `(X, Y)` under
+`μ` and `(X', Y')` under `ν` agree, then their covariances agree. -/
+theorem covariance_eq_of_identDistrib_pair {Ω' : Type*} [MeasurableSpace Ω']
+    {ν : Measure Ω'} {X Y : Ω → ℝ} {X' Y' : Ω' → ℝ} [IsProbabilityMeasure μ]
+    [IsProbabilityMeasure ν]
+    (h : IdentDistrib (fun ω => (X ω, Y ω)) (fun ω => (X' ω, Y' ω)) μ ν)
+    (hX : MemLp X 2 μ) (hY : MemLp Y 2 μ) (hX' : MemLp X' 2 ν) (hY' : MemLp Y' 2 ν) :
+    cov[X, Y; μ] = cov[X', Y'; ν] := by
+  have hmul : μ[X * Y] = ν[X' * Y'] := by
+    have h' := h.comp (measurable_fst.mul measurable_snd)
+    simpa [Function.comp, Pi.mul_apply] using h'.integral_eq
+  have hfst : μ[X] = ν[X'] := by
+    have h' := h.comp measurable_fst
+    simpa [Function.comp] using h'.integral_eq
+  have hsnd : μ[Y] = ν[Y'] := by
+    have h' := h.comp measurable_snd
+    simpa [Function.comp] using h'.integral_eq
+  rw [covariance_eq_sub hX hY, covariance_eq_sub hX' hY', hmul, hfst, hsnd]
+
 /-- **Equal means from contractability.** For a contractable real-valued process, all
 coordinate expectations agree. -/
 theorem Contractable.integral_coord_eq (hX : Contractable μ X)
@@ -67,12 +87,8 @@ theorem Contractable.covariance_eq_of_lt [IsProbabilityMeasure μ] (hX : Contrac
     (hX_L2 : ∀ n, MemLp (X n) 2 μ) {i j k l : ℕ} (hij : i < j) (hkl : k < l) :
     cov[X i, X j; μ] = cov[X k, X l; μ] := by
   have hmeas : ∀ n, AEMeasurable (X n) μ := fun n => (hX_L2 n).aestronglyMeasurable.aemeasurable
-  have hmul : μ[X i * X j] = μ[X k * X l] := by
-    have h := (hX.identDistrib_pair hmeas hij hkl).comp (measurable_fst.mul measurable_snd)
-    simpa [Function.comp, Pi.mul_apply] using h.integral_eq
-  rw [covariance_eq_sub (hX_L2 i) (hX_L2 j), covariance_eq_sub (hX_L2 k) (hX_L2 l), hmul]
-  simp only [hX.integral_coord_eq hmeas i 0, hX.integral_coord_eq hmeas j 0,
-    hX.integral_coord_eq hmeas k 0, hX.integral_coord_eq hmeas l 0]
+  exact covariance_eq_of_identDistrib_pair (hX.identDistrib_pair hmeas hij hkl)
+    (hX_L2 i) (hX_L2 j) (hX_L2 k) (hX_L2 l)
 
 /-- **Uniform off-diagonal covariances from contractability.** For a contractable real-valued
 process with `L²` coordinates, any two off-diagonal covariances agree:

--- a/TauCeti/Probability/Exchangeability/L2/Covariance.lean
+++ b/TauCeti/Probability/Exchangeability/L2/Covariance.lean
@@ -10,9 +10,8 @@ This file opens the Layer 3 (L²) lane of the Exchangeability roadmap
 standard-Borel de Finetti route"), whose first analytic input is the *uniform covariance
 structure of a contractable L² sequence* (`contractable_covariance_structure`). It also
 supplies the two Layer 3 preliminaries listed before it — "equality of means and integrals
-from equal one-dimensional laws" and "equality of pair covariances from equal
-two-dimensional laws". The latter appears first in the reusable form
-`covariance_eq_of_identDistrib_pair`, then specializes to contractable processes.
+from equal one-dimensional laws" and "equality of pair covariances from equal two-dimensional
+laws".
 
 For a real-valued contractable sequence, the one- and two-coordinate `IdentDistrib` facts in
 `TauCeti.Probability.Exchangeability.Contractability` give the uniform first- and second-moment
@@ -43,35 +42,19 @@ namespace Probability
 
 variable {Ω : Type*} [MeasurableSpace Ω] {μ : Measure Ω}
 
+variable {γ : Type*} [MeasurableSpace γ] [NormedAddCommGroup γ] [NormedSpace ℝ γ]
+  [BorelSpace γ] {Z : ℕ → Ω → γ}
+
+/-- **Equal means from contractability.** For a contractable process with values in a normed
+real vector space, all coordinate expectations agree. -/
+theorem Contractable.integral_coord_eq (hZ : Contractable μ Z)
+    (hZ_meas : ∀ n, AEMeasurable (Z n) μ) (i j : ℕ) :
+    μ[Z i] = μ[Z j] :=
+  (hZ.identDistrib_coord hZ_meas i j).integral_eq
+
 section Real
 
 variable {X : ℕ → Ω → ℝ}
-
-/-- **Equal covariance from equal pair laws.** If the two-dimensional laws of `(X, Y)` under
-`μ` and `(X', Y')` under `ν` agree, then their covariances agree. -/
-theorem covariance_eq_of_identDistrib_pair {Ω' : Type*} [MeasurableSpace Ω']
-    {ν : Measure Ω'} {X Y : Ω → ℝ} {X' Y' : Ω' → ℝ}
-    (h : IdentDistrib (fun ω => (X ω, Y ω)) (fun ω => (X' ω, Y' ω)) μ ν) :
-    cov[X, Y; μ] = cov[X', Y'; ν] := by
-  let F : Ω → ℝ × ℝ := fun ω => (X ω, Y ω)
-  let G : Ω' → ℝ × ℝ := fun ω => (X' ω, Y' ω)
-  calc
-    cov[X, Y; μ] = cov[Prod.fst, Prod.snd; μ.map F] := by
-      rw [covariance_map measurable_fst.aestronglyMeasurable measurable_snd.aestronglyMeasurable
-        h.aemeasurable_fst]
-      rfl
-    _ = cov[Prod.fst, Prod.snd; ν.map G] := by rw [h.map_eq]
-    _ = cov[X', Y'; ν] := by
-      rw [covariance_map measurable_fst.aestronglyMeasurable measurable_snd.aestronglyMeasurable
-        h.aemeasurable_snd]
-      rfl
-
-/-- **Equal means from contractability.** For a contractable real-valued process, all
-coordinate expectations agree. -/
-theorem Contractable.integral_coord_eq (hX : Contractable μ X)
-    (hX_meas : ∀ n, AEMeasurable (X n) μ) (i j : ℕ) :
-    μ[X i] = μ[X j] :=
-  (hX.identDistrib_coord hX_meas i j).integral_eq
 
 /-- **Equal variances from contractability.** For a contractable real-valued process, all
 coordinate variances agree. -/
@@ -86,7 +69,19 @@ a.e. measurable coordinates, any two off-diagonal covariances agree:
 theorem Contractable.covariance_eq_of_lt (hX : Contractable μ X)
     (hX_meas : ∀ n, AEMeasurable (X n) μ) {i j k l : ℕ} (hij : i < j) (hkl : k < l) :
     cov[X i, X j; μ] = cov[X k, X l; μ] := by
-  exact covariance_eq_of_identDistrib_pair (hX.identDistrib_pair hX_meas hij hkl)
+  let F : Ω → ℝ × ℝ := fun ω => (X i ω, X j ω)
+  let G : Ω → ℝ × ℝ := fun ω => (X k ω, X l ω)
+  have hpair : IdentDistrib F G μ μ := hX.identDistrib_pair hX_meas hij hkl
+  have hF : HasLaw F (μ.map F) μ := ⟨hpair.aemeasurable_fst, rfl⟩
+  have hG : HasLaw G (μ.map F) μ := hpair.hasLaw hF
+  calc
+    cov[X i, X j; μ] = cov[Prod.fst, Prod.snd; μ.map F] := by
+      simpa [F] using
+        hF.covariance_fun_comp measurable_fst.aemeasurable measurable_snd.aemeasurable
+    _ = cov[X k, X l; μ] := by
+      symm
+      simpa [G] using
+        hG.covariance_fun_comp measurable_fst.aemeasurable measurable_snd.aemeasurable
 
 /-- **Uniform off-diagonal covariances from contractability.** For a contractable real-valued
 process with a.e. measurable coordinates, any two off-diagonal covariances agree:
@@ -109,8 +104,7 @@ theorem Contractable.covariance_eq_of_ne (hX : Contractable μ X)
 real-valued process with `L²` coordinates has constant coordinate means and variances, and a
 single common off-diagonal covariance: any two unequal-index pairs have equal covariance. This
 is the seed of the Layer 3 L² route to de Finetti. -/
-theorem contractable_covariance_structure [IsProbabilityMeasure μ] (hX : Contractable μ X)
-    (hX_L2 : ∀ n, MemLp (X n) 2 μ) :
+theorem contractable_covariance_structure (hX : Contractable μ X) (hX_L2 : ∀ n, MemLp (X n) 2 μ) :
     (∀ i j, μ[X i] = μ[X j]) ∧ (∀ i j, Var[X i; μ] = Var[X j; μ]) ∧
       (∀ i j k l, i ≠ j → k ≠ l → cov[X i, X j; μ] = cov[X k, X l; μ]) := by
   have hmeas : ∀ n, AEMeasurable (X n) μ := fun n => (hX_L2 n).aestronglyMeasurable.aemeasurable

--- a/TauCeti/Probability/Exchangeability/L2/Covariance.lean
+++ b/TauCeti/Probability/Exchangeability/L2/Covariance.lean
@@ -50,21 +50,21 @@ variable {X : ℕ → Ω → ℝ}
 /-- **Equal covariance from equal pair laws.** If the two-dimensional laws of `(X, Y)` under
 `μ` and `(X', Y')` under `ν` agree, then their covariances agree. -/
 theorem covariance_eq_of_identDistrib_pair {Ω' : Type*} [MeasurableSpace Ω']
-    {ν : Measure Ω'} {X Y : Ω → ℝ} {X' Y' : Ω' → ℝ} [IsProbabilityMeasure μ]
-    [IsProbabilityMeasure ν]
-    (h : IdentDistrib (fun ω => (X ω, Y ω)) (fun ω => (X' ω, Y' ω)) μ ν)
-    (hX : MemLp X 2 μ) (hY : MemLp Y 2 μ) (hX' : MemLp X' 2 ν) (hY' : MemLp Y' 2 ν) :
+    {ν : Measure Ω'} {X Y : Ω → ℝ} {X' Y' : Ω' → ℝ}
+    (h : IdentDistrib (fun ω => (X ω, Y ω)) (fun ω => (X' ω, Y' ω)) μ ν) :
     cov[X, Y; μ] = cov[X', Y'; ν] := by
-  have hmul : μ[X * Y] = ν[X' * Y'] := by
-    have h' := h.comp (measurable_fst.mul measurable_snd)
-    simpa [Function.comp, Pi.mul_apply] using h'.integral_eq
-  have hfst : μ[X] = ν[X'] := by
-    have h' := h.comp measurable_fst
-    simpa [Function.comp] using h'.integral_eq
-  have hsnd : μ[Y] = ν[Y'] := by
-    have h' := h.comp measurable_snd
-    simpa [Function.comp] using h'.integral_eq
-  rw [covariance_eq_sub hX hY, covariance_eq_sub hX' hY', hmul, hfst, hsnd]
+  let F : Ω → ℝ × ℝ := fun ω => (X ω, Y ω)
+  let G : Ω' → ℝ × ℝ := fun ω => (X' ω, Y' ω)
+  calc
+    cov[X, Y; μ] = cov[Prod.fst, Prod.snd; μ.map F] := by
+      rw [covariance_map measurable_fst.aestronglyMeasurable measurable_snd.aestronglyMeasurable
+        h.aemeasurable_fst]
+      rfl
+    _ = cov[Prod.fst, Prod.snd; ν.map G] := by rw [h.map_eq]
+    _ = cov[X', Y'; ν] := by
+      rw [covariance_map measurable_fst.aestronglyMeasurable measurable_snd.aestronglyMeasurable
+        h.aemeasurable_snd]
+      rfl
 
 /-- **Equal means from contractability.** For a contractable real-valued process, all
 coordinate expectations agree. -/
@@ -81,31 +81,29 @@ theorem Contractable.variance_coord_eq (hX : Contractable μ X)
   (hX.identDistrib_coord hX_meas i j).variance_eq
 
 /-- **Uniform covariances from contractability.** For a contractable real-valued process with
-`L²` coordinates, any two off-diagonal covariances agree: `cov[X i, X j; μ] = cov[X k, X l; μ]`
-whenever `i < j` and `k < l`. -/
-theorem Contractable.covariance_eq_of_lt [IsProbabilityMeasure μ] (hX : Contractable μ X)
-    (hX_L2 : ∀ n, MemLp (X n) 2 μ) {i j k l : ℕ} (hij : i < j) (hkl : k < l) :
+a.e. measurable coordinates, any two off-diagonal covariances agree:
+`cov[X i, X j; μ] = cov[X k, X l; μ]` whenever `i < j` and `k < l`. -/
+theorem Contractable.covariance_eq_of_lt (hX : Contractable μ X)
+    (hX_meas : ∀ n, AEMeasurable (X n) μ) {i j k l : ℕ} (hij : i < j) (hkl : k < l) :
     cov[X i, X j; μ] = cov[X k, X l; μ] := by
-  have hmeas : ∀ n, AEMeasurable (X n) μ := fun n => (hX_L2 n).aestronglyMeasurable.aemeasurable
-  exact covariance_eq_of_identDistrib_pair (hX.identDistrib_pair hmeas hij hkl)
-    (hX_L2 i) (hX_L2 j) (hX_L2 k) (hX_L2 l)
+  exact covariance_eq_of_identDistrib_pair (hX.identDistrib_pair hX_meas hij hkl)
 
 /-- **Uniform off-diagonal covariances from contractability.** For a contractable real-valued
-process with `L²` coordinates, any two off-diagonal covariances agree:
+process with a.e. measurable coordinates, any two off-diagonal covariances agree:
 `cov[X i, X j; μ] = cov[X k, X l; μ]` whenever `i ≠ j` and `k ≠ l`. -/
-theorem Contractable.covariance_eq_of_ne [IsProbabilityMeasure μ] (hX : Contractable μ X)
-    (hX_L2 : ∀ n, MemLp (X n) 2 μ) {i j k l : ℕ} (hij : i ≠ j) (hkl : k ≠ l) :
+theorem Contractable.covariance_eq_of_ne (hX : Contractable μ X)
+    (hX_meas : ∀ n, AEMeasurable (X n) μ) {i j k l : ℕ} (hij : i ≠ j) (hkl : k ≠ l) :
     cov[X i, X j; μ] = cov[X k, X l; μ] := by
   rcases lt_or_gt_of_ne hij with hij_lt | hji_lt
   · rcases lt_or_gt_of_ne hkl with hkl_lt | hlk_lt
-    · exact hX.covariance_eq_of_lt hX_L2 hij_lt hkl_lt
+    · exact hX.covariance_eq_of_lt hX_meas hij_lt hkl_lt
     · rw [covariance_comm (X k) (X l)]
-      exact hX.covariance_eq_of_lt hX_L2 hij_lt hlk_lt
+      exact hX.covariance_eq_of_lt hX_meas hij_lt hlk_lt
   · rw [covariance_comm (X i) (X j)]
     rcases lt_or_gt_of_ne hkl with hkl_lt | hlk_lt
-    · exact hX.covariance_eq_of_lt hX_L2 hji_lt hkl_lt
+    · exact hX.covariance_eq_of_lt hX_meas hji_lt hkl_lt
     · rw [covariance_comm (X k) (X l)]
-      exact hX.covariance_eq_of_lt hX_L2 hji_lt hlk_lt
+      exact hX.covariance_eq_of_lt hX_meas hji_lt hlk_lt
 
 /-- **The uniform covariance structure of a contractable L² sequence.** A contractable
 real-valued process with `L²` coordinates has constant coordinate means and variances, and a
@@ -117,7 +115,7 @@ theorem contractable_covariance_structure [IsProbabilityMeasure μ] (hX : Contra
       (∀ i j k l, i ≠ j → k ≠ l → cov[X i, X j; μ] = cov[X k, X l; μ]) := by
   have hmeas : ∀ n, AEMeasurable (X n) μ := fun n => (hX_L2 n).aestronglyMeasurable.aemeasurable
   exact ⟨fun i j => hX.integral_coord_eq hmeas i j, fun i j => hX.variance_coord_eq hmeas i j,
-    fun _ _ _ _ hij hkl => hX.covariance_eq_of_ne hX_L2 hij hkl⟩
+    fun _ _ _ _ hij hkl => hX.covariance_eq_of_ne hmeas hij hkl⟩
 
 end Real
 

--- a/TauCeti/Probability/Exchangeability/L2/Covariance.lean
+++ b/TauCeti/Probability/Exchangeability/L2/Covariance.lean
@@ -48,9 +48,9 @@ variable {γ : Type*} [MeasurableSpace γ] [NormedAddCommGroup γ] [NormedSpace 
 /-- **Equal means from contractability.** For a contractable process with values in a normed
 real vector space, all coordinate expectations agree. -/
 theorem Contractable.integral_coord_eq (hZ : Contractable μ Z)
-    (hZ_meas : ∀ n, AEMeasurable (Z n) μ) (i j : ℕ) :
+    {i j : ℕ} (hi_meas : AEMeasurable (Z i) μ) (hj_meas : AEMeasurable (Z j) μ) :
     μ[Z i] = μ[Z j] :=
-  (hZ.identDistrib_coord hZ_meas i j).integral_eq
+  (hZ.identDistrib_coord hi_meas hj_meas).integral_eq
 
 section Real
 
@@ -59,19 +59,22 @@ variable {X : ℕ → Ω → ℝ}
 /-- **Equal variances from contractability.** For a contractable real-valued process, all
 coordinate variances agree. -/
 theorem Contractable.variance_coord_eq (hX : Contractable μ X)
-    (hX_meas : ∀ n, AEMeasurable (X n) μ) (i j : ℕ) :
+    {i j : ℕ} (hi_meas : AEMeasurable (X i) μ) (hj_meas : AEMeasurable (X j) μ) :
     Var[X i; μ] = Var[X j; μ] :=
-  (hX.identDistrib_coord hX_meas i j).variance_eq
+  (hX.identDistrib_coord hi_meas hj_meas).variance_eq
 
 /-- **Uniform covariances from contractability.** For a contractable real-valued process with
 a.e. measurable coordinates, any two off-diagonal covariances agree:
 `cov[X i, X j; μ] = cov[X k, X l; μ]` whenever `i < j` and `k < l`. -/
 theorem Contractable.covariance_eq_of_lt (hX : Contractable μ X)
-    (hX_meas : ∀ n, AEMeasurable (X n) μ) {i j k l : ℕ} (hij : i < j) (hkl : k < l) :
+    {i j k l : ℕ} (hi_meas : AEMeasurable (X i) μ) (hj_meas : AEMeasurable (X j) μ)
+    (hk_meas : AEMeasurable (X k) μ) (hl_meas : AEMeasurable (X l) μ)
+    (hij : i < j) (hkl : k < l) :
     cov[X i, X j; μ] = cov[X k, X l; μ] := by
   let F : Ω → ℝ × ℝ := fun ω => (X i ω, X j ω)
   let G : Ω → ℝ × ℝ := fun ω => (X k ω, X l ω)
-  have hpair : IdentDistrib F G μ μ := hX.identDistrib_pair hX_meas hij hkl
+  have hpair : IdentDistrib F G μ μ :=
+    hX.identDistrib_pair hi_meas hj_meas hk_meas hl_meas hij hkl
   have hF : HasLaw F (μ.map F) μ := ⟨hpair.aemeasurable_fst, rfl⟩
   have hG : HasLaw G (μ.map F) μ := hpair.hasLaw hF
   calc
@@ -87,18 +90,20 @@ theorem Contractable.covariance_eq_of_lt (hX : Contractable μ X)
 process with a.e. measurable coordinates, any two off-diagonal covariances agree:
 `cov[X i, X j; μ] = cov[X k, X l; μ]` whenever `i ≠ j` and `k ≠ l`. -/
 theorem Contractable.covariance_eq_of_ne (hX : Contractable μ X)
-    (hX_meas : ∀ n, AEMeasurable (X n) μ) {i j k l : ℕ} (hij : i ≠ j) (hkl : k ≠ l) :
+    {i j k l : ℕ} (hi_meas : AEMeasurable (X i) μ) (hj_meas : AEMeasurable (X j) μ)
+    (hk_meas : AEMeasurable (X k) μ) (hl_meas : AEMeasurable (X l) μ)
+    (hij : i ≠ j) (hkl : k ≠ l) :
     cov[X i, X j; μ] = cov[X k, X l; μ] := by
   rcases lt_or_gt_of_ne hij with hij_lt | hji_lt
   · rcases lt_or_gt_of_ne hkl with hkl_lt | hlk_lt
-    · exact hX.covariance_eq_of_lt hX_meas hij_lt hkl_lt
+    · exact hX.covariance_eq_of_lt hi_meas hj_meas hk_meas hl_meas hij_lt hkl_lt
     · rw [covariance_comm (X k) (X l)]
-      exact hX.covariance_eq_of_lt hX_meas hij_lt hlk_lt
+      exact hX.covariance_eq_of_lt hi_meas hj_meas hl_meas hk_meas hij_lt hlk_lt
   · rw [covariance_comm (X i) (X j)]
     rcases lt_or_gt_of_ne hkl with hkl_lt | hlk_lt
-    · exact hX.covariance_eq_of_lt hX_meas hji_lt hkl_lt
+    · exact hX.covariance_eq_of_lt hj_meas hi_meas hk_meas hl_meas hji_lt hkl_lt
     · rw [covariance_comm (X k) (X l)]
-      exact hX.covariance_eq_of_lt hX_meas hji_lt hlk_lt
+      exact hX.covariance_eq_of_lt hj_meas hi_meas hl_meas hk_meas hji_lt hlk_lt
 
 /-- **The uniform covariance structure of a contractable L² sequence.** A contractable
 real-valued process with `L²` coordinates has constant coordinate means and variances, and a
@@ -108,8 +113,10 @@ theorem contractable_covariance_structure (hX : Contractable μ X) (hX_L2 : ∀ 
     (∀ i j, μ[X i] = μ[X j]) ∧ (∀ i j, Var[X i; μ] = Var[X j; μ]) ∧
       (∀ i j k l, i ≠ j → k ≠ l → cov[X i, X j; μ] = cov[X k, X l; μ]) := by
   have hmeas : ∀ n, AEMeasurable (X n) μ := fun n => (hX_L2 n).aestronglyMeasurable.aemeasurable
-  exact ⟨fun i j => hX.integral_coord_eq hmeas i j, fun i j => hX.variance_coord_eq hmeas i j,
-    fun _ _ _ _ hij hkl => hX.covariance_eq_of_ne hmeas hij hkl⟩
+  exact ⟨fun i j => hX.integral_coord_eq (hmeas i) (hmeas j),
+    fun i j => hX.variance_coord_eq (hmeas i) (hmeas j),
+    fun i j k l hij hkl => hX.covariance_eq_of_ne (hmeas i) (hmeas j) (hmeas k) (hmeas l)
+      hij hkl⟩
 
 end Real
 

--- a/TauCeti/Probability/Exchangeability/L2/Covariance.lean
+++ b/TauCeti/Probability/Exchangeability/L2/Covariance.lean
@@ -22,15 +22,15 @@ here as `IdentDistrib` facts:
 
 * `Contractable.identDistrib_coord`: every coordinate `X i` is identically distributed to
   every other coordinate `X j`;
-* `Contractable.identDistrib_pair`: for `i < j` the pair `(X i, X j)` is identically
-  distributed to `(X 0, X 1)`.
+* `Contractable.identDistrib_pair`: for `i < j` and `k < l` the pair `(X i, X j)` is
+  identically distributed to `(X k, X l)`.
 
 For a real-valued sequence these give the uniform first- and second-moment structure:
 
 * `Contractable.integral_coord_eq`: all coordinate means agree;
 * `Contractable.variance_coord_eq`: all coordinate variances agree;
-* `Contractable.covariance_eq_of_lt`: every off-diagonal covariance `cov[X i, X j; μ]`
-  (`i < j`) equals `cov[X 0, X 1; μ]`.
+* `Contractable.covariance_eq_of_lt`: any two off-diagonal covariances agree,
+  `cov[X i, X j; μ] = cov[X k, X l; μ]` for `i < j` and `k < l`.
 
 The `IdentDistrib` and moment machinery is Mathlib's (`ProbabilityTheory.IdentDistrib`,
 `ProbabilityTheory.covariance`, `ProbabilityTheory.variance`); the contractability input is
@@ -89,16 +89,16 @@ theorem Contractable.identDistrib_coord (hX : Contractable μ X)
       hX.map_single (fun _ => i), hX.map_single (fun _ => j)]
 
 /-- **Increasing pairs of a contractable process are identically distributed.** For a
-contractable process `X` with a.e. measurable coordinates and `i < j`, the pair `(X i, X j)`
-has the same joint law as `(X 0, X 1)`. -/
+contractable process `X` with a.e. measurable coordinates and `i < j`, `k < l`, the pair
+`(X i, X j)` has the same joint law as `(X k, X l)`. -/
 theorem Contractable.identDistrib_pair (hX : Contractable μ X)
-    (hX_meas : ∀ n, AEMeasurable (X n) μ) {i j : ℕ} (hij : i < j) :
-    IdentDistrib (fun ω => (X i ω, X j ω)) (fun ω => (X 0 ω, X 1 ω)) μ μ where
+    (hX_meas : ∀ n, AEMeasurable (X n) μ) {i j k l : ℕ} (hij : i < j) (hkl : k < l) :
+    IdentDistrib (fun ω => (X i ω, X j ω)) (fun ω => (X k ω, X l ω)) μ μ where
   aemeasurable_fst := (hX_meas i).prodMk (hX_meas j)
-  aemeasurable_snd := (hX_meas 0).prodMk (hX_meas 1)
+  aemeasurable_snd := (hX_meas k).prodMk (hX_meas l)
   map_eq := by
-    rw [← map_pairEval_blockLaw i j hX_meas, ← map_pairEval_blockLaw 0 1 hX_meas,
-      hX.map_pair hij, hX.map_pair Nat.zero_lt_one]
+    rw [← map_pairEval_blockLaw i j hX_meas, ← map_pairEval_blockLaw k l hX_meas,
+      hX.map_pair hij, hX.map_pair hkl]
 
 end IdentDistrib
 
@@ -121,30 +121,30 @@ theorem Contractable.variance_coord_eq (hX : Contractable μ X)
   (hX.identDistrib_coord hX_meas i j).variance_eq
 
 /-- **Uniform covariances from contractability.** For a contractable real-valued process with
-`L²` coordinates, every off-diagonal covariance `cov[X i, X j; μ]` with `i < j` equals the
-single covariance `cov[X 0, X 1; μ]`. -/
+`L²` coordinates, any two off-diagonal covariances agree: `cov[X i, X j; μ] = cov[X k, X l; μ]`
+whenever `i < j` and `k < l`. -/
 theorem Contractable.covariance_eq_of_lt [IsProbabilityMeasure μ] (hX : Contractable μ X)
-    (hX_L2 : ∀ n, MemLp (X n) 2 μ) {i j : ℕ} (hij : i < j) :
-    cov[X i, X j; μ] = cov[X 0, X 1; μ] := by
+    (hX_L2 : ∀ n, MemLp (X n) 2 μ) {i j k l : ℕ} (hij : i < j) (hkl : k < l) :
+    cov[X i, X j; μ] = cov[X k, X l; μ] := by
   have hmeas : ∀ n, AEMeasurable (X n) μ := fun n => (hX_L2 n).aestronglyMeasurable.aemeasurable
-  have hmul : μ[X i * X j] = μ[X 0 * X 1] := by
-    have h := (hX.identDistrib_pair hmeas hij).comp (measurable_fst.mul measurable_snd)
+  have hmul : μ[X i * X j] = μ[X k * X l] := by
+    have h := (hX.identDistrib_pair hmeas hij hkl).comp (measurable_fst.mul measurable_snd)
     simpa [Function.comp, Pi.mul_apply] using h.integral_eq
-  rw [covariance_eq_sub (hX_L2 i) (hX_L2 j), covariance_eq_sub (hX_L2 0) (hX_L2 1), hmul]
+  rw [covariance_eq_sub (hX_L2 i) (hX_L2 j), covariance_eq_sub (hX_L2 k) (hX_L2 l), hmul]
   simp only [hX.integral_coord_eq hmeas i 0, hX.integral_coord_eq hmeas j 0,
-    hX.integral_coord_eq hmeas 1 0]
+    hX.integral_coord_eq hmeas k 0, hX.integral_coord_eq hmeas l 0]
 
 /-- **The uniform covariance structure of a contractable L² sequence.** A contractable
 real-valued process with `L²` coordinates has constant coordinate means and variances, and a
-single common off-diagonal covariance `cov[X 0, X 1; μ]`. This is the seed of the Layer 3 L²
-route to de Finetti. -/
+single common off-diagonal covariance: any two increasing pairs have equal covariance. This is
+the seed of the Layer 3 L² route to de Finetti. -/
 theorem contractable_covariance_structure [IsProbabilityMeasure μ] (hX : Contractable μ X)
     (hX_L2 : ∀ n, MemLp (X n) 2 μ) :
     (∀ i j, μ[X i] = μ[X j]) ∧ (∀ i j, Var[X i; μ] = Var[X j; μ]) ∧
-      (∀ i j, i < j → cov[X i, X j; μ] = cov[X 0, X 1; μ]) := by
+      (∀ i j k l, i < j → k < l → cov[X i, X j; μ] = cov[X k, X l; μ]) := by
   have hmeas : ∀ n, AEMeasurable (X n) μ := fun n => (hX_L2 n).aestronglyMeasurable.aemeasurable
   exact ⟨fun i j => hX.integral_coord_eq hmeas i j, fun i j => hX.variance_coord_eq hmeas i j,
-    fun _ _ hij => hX.covariance_eq_of_lt hX_L2 hij⟩
+    fun _ _ _ _ hij hkl => hX.covariance_eq_of_lt hX_L2 hij hkl⟩
 
 end Real
 

--- a/TauCeti/Probability/Exchangeability/L2/Covariance.lean
+++ b/TauCeti/Probability/Exchangeability/L2/Covariance.lean
@@ -1,8 +1,6 @@
 module
 
 public import TauCeti.Probability.Exchangeability.Contractability
-public import Mathlib.Probability.IdentDistrib
-public import Mathlib.Probability.Moments.Covariance
 public import Mathlib.Probability.Moments.Variance
 
 /-!
@@ -16,21 +14,14 @@ supplies the two Layer 3 preliminaries listed before it — "equality of means a
 from equal one-dimensional laws" and "equality of pair covariances from equal
 two-dimensional laws" — specialized to a contractable process.
 
-For a contractable process the one- and two-coordinate laws are constant along strictly
-increasing selections (`Contractable.map_single`, `Contractable.map_pair`). This is packaged
-here as `IdentDistrib` facts:
-
-* `Contractable.identDistrib_coord`: every coordinate `X i` is identically distributed to
-  every other coordinate `X j`;
-* `Contractable.identDistrib_pair`: for `i < j` and `k < l` the pair `(X i, X j)` is
-  identically distributed to `(X k, X l)`.
-
-For a real-valued sequence these give the uniform first- and second-moment structure:
+For a real-valued contractable sequence, the one- and two-coordinate `IdentDistrib` facts in
+`TauCeti.Probability.Exchangeability.Contractability` give the uniform first- and second-moment
+structure:
 
 * `Contractable.integral_coord_eq`: all coordinate means agree;
 * `Contractable.variance_coord_eq`: all coordinate variances agree;
-* `Contractable.covariance_eq_of_lt`: any two off-diagonal covariances agree,
-  `cov[X i, X j; μ] = cov[X k, X l; μ]` for `i < j` and `k < l`.
+* `Contractable.covariance_eq_of_ne`: any two off-diagonal covariances agree,
+  `cov[X i, X j; μ] = cov[X k, X l; μ]` for `i ≠ j` and `k ≠ l`.
 
 The `IdentDistrib` and moment machinery is Mathlib's (`ProbabilityTheory.IdentDistrib`,
 `ProbabilityTheory.covariance`, `ProbabilityTheory.variance`); the contractability input is
@@ -51,56 +42,6 @@ namespace TauCeti
 namespace Probability
 
 variable {Ω : Type*} [MeasurableSpace Ω] {μ : Measure Ω}
-
-section IdentDistrib
-
-variable {α : Type*} [MeasurableSpace α] {X : ℕ → Ω → α}
-
-/-- Evaluating the one-coordinate block law `blockLaw μ X (fun _ => i)` at its single
-coordinate recovers the law of `X i`. -/
-private theorem map_coordEval_blockLaw (i : ℕ) (hX_meas : ∀ n, AEMeasurable (X n) μ) :
-    (blockLaw μ X (fun _ : Fin 1 => i)).map (fun v : Fin 1 → α => v 0) = μ.map (X i) := by
-  rw [blockLaw_def, AEMeasurable.map_map_of_aemeasurable (measurable_pi_apply 0).aemeasurable
-    (aemeasurable_pi_lambda _ fun _ => hX_meas i)]
-  rfl
-
-/-- Evaluating the two-coordinate block law `blockLaw μ X ![i, j]` at its two coordinates
-recovers the joint law of `(X i, X j)`. -/
-private theorem map_pairEval_blockLaw (i j : ℕ) (hX_meas : ∀ n, AEMeasurable (X n) μ) :
-    (blockLaw μ X ![i, j]).map (fun v : Fin 2 → α => (v 0, v 1))
-      = μ.map (fun ω => (X i ω, X j ω)) := by
-  have hcomp : ((fun v : Fin 2 → α => (v 0, v 1)) ∘ fun ω (l : Fin 2) => X (![i, j] l) ω)
-      = fun ω => (X i ω, X j ω) := by
-    funext ω
-    simp [Function.comp, Matrix.cons_val_zero, Matrix.cons_val_one]
-  rw [blockLaw_def, AEMeasurable.map_map_of_aemeasurable
-    ((measurable_pi_apply 0).prodMk (measurable_pi_apply 1)).aemeasurable
-    (aemeasurable_pi_lambda _ fun l => hX_meas (![i, j] l)), hcomp]
-
-/-- **Coordinates of a contractable process are identically distributed.** For a contractable
-process `X` with a.e. measurable coordinates, `X i` and `X j` have the same law. -/
-theorem Contractable.identDistrib_coord (hX : Contractable μ X)
-    (hX_meas : ∀ n, AEMeasurable (X n) μ) (i j : ℕ) :
-    IdentDistrib (X i) (X j) μ μ where
-  aemeasurable_fst := hX_meas i
-  aemeasurable_snd := hX_meas j
-  map_eq := by
-    rw [← map_coordEval_blockLaw i hX_meas, ← map_coordEval_blockLaw j hX_meas,
-      hX.map_single (fun _ => i), hX.map_single (fun _ => j)]
-
-/-- **Increasing pairs of a contractable process are identically distributed.** For a
-contractable process `X` with a.e. measurable coordinates and `i < j`, `k < l`, the pair
-`(X i, X j)` has the same joint law as `(X k, X l)`. -/
-theorem Contractable.identDistrib_pair (hX : Contractable μ X)
-    (hX_meas : ∀ n, AEMeasurable (X n) μ) {i j k l : ℕ} (hij : i < j) (hkl : k < l) :
-    IdentDistrib (fun ω => (X i ω, X j ω)) (fun ω => (X k ω, X l ω)) μ μ where
-  aemeasurable_fst := (hX_meas i).prodMk (hX_meas j)
-  aemeasurable_snd := (hX_meas k).prodMk (hX_meas l)
-  map_eq := by
-    rw [← map_pairEval_blockLaw i j hX_meas, ← map_pairEval_blockLaw k l hX_meas,
-      hX.map_pair hij, hX.map_pair hkl]
-
-end IdentDistrib
 
 section Real
 
@@ -134,17 +75,34 @@ theorem Contractable.covariance_eq_of_lt [IsProbabilityMeasure μ] (hX : Contrac
   simp only [hX.integral_coord_eq hmeas i 0, hX.integral_coord_eq hmeas j 0,
     hX.integral_coord_eq hmeas k 0, hX.integral_coord_eq hmeas l 0]
 
+/-- **Uniform off-diagonal covariances from contractability.** For a contractable real-valued
+process with `L²` coordinates, any two off-diagonal covariances agree:
+`cov[X i, X j; μ] = cov[X k, X l; μ]` whenever `i ≠ j` and `k ≠ l`. -/
+theorem Contractable.covariance_eq_of_ne [IsProbabilityMeasure μ] (hX : Contractable μ X)
+    (hX_L2 : ∀ n, MemLp (X n) 2 μ) {i j k l : ℕ} (hij : i ≠ j) (hkl : k ≠ l) :
+    cov[X i, X j; μ] = cov[X k, X l; μ] := by
+  rcases lt_or_gt_of_ne hij with hij_lt | hji_lt
+  · rcases lt_or_gt_of_ne hkl with hkl_lt | hlk_lt
+    · exact hX.covariance_eq_of_lt hX_L2 hij_lt hkl_lt
+    · rw [covariance_comm (X k) (X l)]
+      exact hX.covariance_eq_of_lt hX_L2 hij_lt hlk_lt
+  · rw [covariance_comm (X i) (X j)]
+    rcases lt_or_gt_of_ne hkl with hkl_lt | hlk_lt
+    · exact hX.covariance_eq_of_lt hX_L2 hji_lt hkl_lt
+    · rw [covariance_comm (X k) (X l)]
+      exact hX.covariance_eq_of_lt hX_L2 hji_lt hlk_lt
+
 /-- **The uniform covariance structure of a contractable L² sequence.** A contractable
 real-valued process with `L²` coordinates has constant coordinate means and variances, and a
-single common off-diagonal covariance: any two increasing pairs have equal covariance. This is
-the seed of the Layer 3 L² route to de Finetti. -/
+single common off-diagonal covariance: any two unequal-index pairs have equal covariance. This
+is the seed of the Layer 3 L² route to de Finetti. -/
 theorem contractable_covariance_structure [IsProbabilityMeasure μ] (hX : Contractable μ X)
     (hX_L2 : ∀ n, MemLp (X n) 2 μ) :
     (∀ i j, μ[X i] = μ[X j]) ∧ (∀ i j, Var[X i; μ] = Var[X j; μ]) ∧
-      (∀ i j k l, i < j → k < l → cov[X i, X j; μ] = cov[X k, X l; μ]) := by
+      (∀ i j k l, i ≠ j → k ≠ l → cov[X i, X j; μ] = cov[X k, X l; μ]) := by
   have hmeas : ∀ n, AEMeasurable (X n) μ := fun n => (hX_L2 n).aestronglyMeasurable.aemeasurable
   exact ⟨fun i j => hX.integral_coord_eq hmeas i j, fun i j => hX.variance_coord_eq hmeas i j,
-    fun _ _ _ _ hij hkl => hX.covariance_eq_of_lt hX_L2 hij hkl⟩
+    fun _ _ _ _ hij hkl => hX.covariance_eq_of_ne hX_L2 hij hkl⟩
 
 end Real
 

--- a/TauCeti/Probability/Exchangeability/L2/Covariance.lean
+++ b/TauCeti/Probability/Exchangeability/L2/Covariance.lean
@@ -1,7 +1,6 @@
 module
 
 public import TauCeti.Probability.Exchangeability.Contractability
-public import Mathlib.Probability.Moments.Variance
 
 /-!
 # The covariance structure of a contractable L² sequence

--- a/TauCeti/Probability/Exchangeability/L2/Covariance.lean
+++ b/TauCeti/Probability/Exchangeability/L2/Covariance.lean
@@ -1,0 +1,153 @@
+module
+
+public import TauCeti.Probability.Exchangeability.Contractability
+public import Mathlib.Probability.IdentDistrib
+public import Mathlib.Probability.Moments.Covariance
+public import Mathlib.Probability.Moments.Variance
+
+/-!
+# The covariance structure of a contractable L² sequence
+
+This file opens the Layer 3 (L²) lane of the Exchangeability roadmap
+(`TauCetiRoadmap/Exchangeability/README.md`, "Layer 3: L² averaging library and the
+standard-Borel de Finetti route"), whose first analytic input is the *uniform covariance
+structure of a contractable L² sequence* (`contractable_covariance_structure`). It also
+supplies the two Layer 3 preliminaries listed before it — "equality of means and integrals
+from equal one-dimensional laws" and "equality of pair covariances from equal
+two-dimensional laws" — specialized to a contractable process.
+
+For a contractable process the one- and two-coordinate laws are constant along strictly
+increasing selections (`Contractable.map_single`, `Contractable.map_pair`). This is packaged
+here as `IdentDistrib` facts:
+
+* `Contractable.identDistrib_coord`: every coordinate `X i` is identically distributed to
+  every other coordinate `X j`;
+* `Contractable.identDistrib_pair`: for `i < j` the pair `(X i, X j)` is identically
+  distributed to `(X 0, X 1)`.
+
+For a real-valued sequence these give the uniform first- and second-moment structure:
+
+* `Contractable.integral_coord_eq`: all coordinate means agree;
+* `Contractable.variance_coord_eq`: all coordinate variances agree;
+* `Contractable.covariance_eq_of_lt`: every off-diagonal covariance `cov[X i, X j; μ]`
+  (`i < j`) equals `cov[X 0, X 1; μ]`.
+
+The `IdentDistrib` and moment machinery is Mathlib's (`ProbabilityTheory.IdentDistrib`,
+`ProbabilityTheory.covariance`, `ProbabilityTheory.variance`); the contractability input is
+the Layer 0 API in `TauCeti.Probability.Exchangeability.Contractability`. No material from
+`cameronfreer/exchangeability` is used: the source's L² lane carries the real-valued
+statement through block averages, whereas this file records only the elementary
+moment-uniformity that seeds it.
+-/
+
+public section
+
+noncomputable section
+
+open MeasureTheory ProbabilityTheory
+
+namespace TauCeti
+
+namespace Probability
+
+variable {Ω : Type*} [MeasurableSpace Ω] {μ : Measure Ω}
+
+section IdentDistrib
+
+variable {α : Type*} [MeasurableSpace α] {X : ℕ → Ω → α}
+
+/-- Evaluating the one-coordinate block law `blockLaw μ X (fun _ => i)` at its single
+coordinate recovers the law of `X i`. -/
+private theorem map_coordEval_blockLaw (i : ℕ) (hX_meas : ∀ n, AEMeasurable (X n) μ) :
+    (blockLaw μ X (fun _ : Fin 1 => i)).map (fun v : Fin 1 → α => v 0) = μ.map (X i) := by
+  rw [blockLaw_def, AEMeasurable.map_map_of_aemeasurable (measurable_pi_apply 0).aemeasurable
+    (aemeasurable_pi_lambda _ fun _ => hX_meas i)]
+  rfl
+
+/-- Evaluating the two-coordinate block law `blockLaw μ X ![i, j]` at its two coordinates
+recovers the joint law of `(X i, X j)`. -/
+private theorem map_pairEval_blockLaw (i j : ℕ) (hX_meas : ∀ n, AEMeasurable (X n) μ) :
+    (blockLaw μ X ![i, j]).map (fun v : Fin 2 → α => (v 0, v 1))
+      = μ.map (fun ω => (X i ω, X j ω)) := by
+  have hcomp : ((fun v : Fin 2 → α => (v 0, v 1)) ∘ fun ω (l : Fin 2) => X (![i, j] l) ω)
+      = fun ω => (X i ω, X j ω) := by
+    funext ω
+    simp [Function.comp, Matrix.cons_val_zero, Matrix.cons_val_one]
+  rw [blockLaw_def, AEMeasurable.map_map_of_aemeasurable
+    ((measurable_pi_apply 0).prodMk (measurable_pi_apply 1)).aemeasurable
+    (aemeasurable_pi_lambda _ fun l => hX_meas (![i, j] l)), hcomp]
+
+/-- **Coordinates of a contractable process are identically distributed.** For a contractable
+process `X` with a.e. measurable coordinates, `X i` and `X j` have the same law. -/
+theorem Contractable.identDistrib_coord (hX : Contractable μ X)
+    (hX_meas : ∀ n, AEMeasurable (X n) μ) (i j : ℕ) :
+    IdentDistrib (X i) (X j) μ μ where
+  aemeasurable_fst := hX_meas i
+  aemeasurable_snd := hX_meas j
+  map_eq := by
+    rw [← map_coordEval_blockLaw i hX_meas, ← map_coordEval_blockLaw j hX_meas,
+      hX.map_single (fun _ => i), hX.map_single (fun _ => j)]
+
+/-- **Increasing pairs of a contractable process are identically distributed.** For a
+contractable process `X` with a.e. measurable coordinates and `i < j`, the pair `(X i, X j)`
+has the same joint law as `(X 0, X 1)`. -/
+theorem Contractable.identDistrib_pair (hX : Contractable μ X)
+    (hX_meas : ∀ n, AEMeasurable (X n) μ) {i j : ℕ} (hij : i < j) :
+    IdentDistrib (fun ω => (X i ω, X j ω)) (fun ω => (X 0 ω, X 1 ω)) μ μ where
+  aemeasurable_fst := (hX_meas i).prodMk (hX_meas j)
+  aemeasurable_snd := (hX_meas 0).prodMk (hX_meas 1)
+  map_eq := by
+    rw [← map_pairEval_blockLaw i j hX_meas, ← map_pairEval_blockLaw 0 1 hX_meas,
+      hX.map_pair hij, hX.map_pair Nat.zero_lt_one]
+
+end IdentDistrib
+
+section Real
+
+variable {X : ℕ → Ω → ℝ}
+
+/-- **Equal means from contractability.** For a contractable real-valued process, all
+coordinate expectations agree. -/
+theorem Contractable.integral_coord_eq (hX : Contractable μ X)
+    (hX_meas : ∀ n, AEMeasurable (X n) μ) (i j : ℕ) :
+    μ[X i] = μ[X j] :=
+  (hX.identDistrib_coord hX_meas i j).integral_eq
+
+/-- **Equal variances from contractability.** For a contractable real-valued process, all
+coordinate variances agree. -/
+theorem Contractable.variance_coord_eq (hX : Contractable μ X)
+    (hX_meas : ∀ n, AEMeasurable (X n) μ) (i j : ℕ) :
+    Var[X i; μ] = Var[X j; μ] :=
+  (hX.identDistrib_coord hX_meas i j).variance_eq
+
+/-- **Uniform covariances from contractability.** For a contractable real-valued process with
+`L²` coordinates, every off-diagonal covariance `cov[X i, X j; μ]` with `i < j` equals the
+single covariance `cov[X 0, X 1; μ]`. -/
+theorem Contractable.covariance_eq_of_lt [IsProbabilityMeasure μ] (hX : Contractable μ X)
+    (hX_L2 : ∀ n, MemLp (X n) 2 μ) {i j : ℕ} (hij : i < j) :
+    cov[X i, X j; μ] = cov[X 0, X 1; μ] := by
+  have hmeas : ∀ n, AEMeasurable (X n) μ := fun n => (hX_L2 n).aestronglyMeasurable.aemeasurable
+  have hmul : μ[X i * X j] = μ[X 0 * X 1] := by
+    have h := (hX.identDistrib_pair hmeas hij).comp (measurable_fst.mul measurable_snd)
+    simpa [Function.comp, Pi.mul_apply] using h.integral_eq
+  rw [covariance_eq_sub (hX_L2 i) (hX_L2 j), covariance_eq_sub (hX_L2 0) (hX_L2 1), hmul]
+  simp only [hX.integral_coord_eq hmeas i 0, hX.integral_coord_eq hmeas j 0,
+    hX.integral_coord_eq hmeas 1 0]
+
+/-- **The uniform covariance structure of a contractable L² sequence.** A contractable
+real-valued process with `L²` coordinates has constant coordinate means and variances, and a
+single common off-diagonal covariance `cov[X 0, X 1; μ]`. This is the seed of the Layer 3 L²
+route to de Finetti. -/
+theorem contractable_covariance_structure [IsProbabilityMeasure μ] (hX : Contractable μ X)
+    (hX_L2 : ∀ n, MemLp (X n) 2 μ) :
+    (∀ i j, μ[X i] = μ[X j]) ∧ (∀ i j, Var[X i; μ] = Var[X j; μ]) ∧
+      (∀ i j, i < j → cov[X i, X j; μ] = cov[X 0, X 1; μ]) := by
+  have hmeas : ∀ n, AEMeasurable (X n) μ := fun n => (hX_L2 n).aestronglyMeasurable.aemeasurable
+  exact ⟨fun i j => hX.integral_coord_eq hmeas i j, fun i j => hX.variance_coord_eq hmeas i j,
+    fun _ _ hij => hX.covariance_eq_of_lt hX_L2 hij⟩
+
+end Real
+
+end Probability
+
+end TauCeti


### PR DESCRIPTION
This PR opens the Layer 3 (L²) lane of the Exchangeability roadmap by recording the uniform covariance structure of a contractable L² sequence, the roadmap's first analytic input toward the L² route to de Finetti (`TauCetiRoadmap/Exchangeability/README.md`, "Layer 3: L² averaging library and the standard-Borel de Finetti route", milestone `contractable_covariance_structure`). It also supplies the two Layer 3 preliminaries listed before it, "equality of means and integrals from equal one-dimensional laws" and "equality of pair covariances from equal two-dimensional laws", specialized to a contractable process.

The elementary content is that a contractable process has constant one- and two-coordinate laws along strictly increasing selections. This is packaged as `IdentDistrib` facts over Mathlib's `ProbabilityTheory.IdentDistrib`: `Contractable.identDistrib_coord` (every coordinate `X i` is identically distributed to `X j`) and `Contractable.identDistrib_pair` (for `i < j` the pair `(X i, X j)` is identically distributed to `(X 0, X 1)`), obtained by evaluating the Layer 0 block laws `Contractable.map_single` / `Contractable.map_pair`. For a real-valued sequence these give the uniform first- and second-moment structure through Mathlib's `covariance`/`variance` API: `Contractable.integral_coord_eq` (all means agree), `Contractable.variance_coord_eq` (all variances agree), and `Contractable.covariance_eq_of_lt` (every off-diagonal covariance `cov[X i, X j; μ]` with `i < j` equals `cov[X 0, X 1; μ]`), assembled into the headline `contractable_covariance_structure`.

The `IdentDistrib` and moment machinery is Mathlib's; the contractability input is the existing Layer 0 API. No material from `cameronfreer/exchangeability` is used: the source's L² lane carries the real-valued statement through block averages, whereas this file records only the moment uniformity that seeds it.

<!--tauceti-target:v1 {"focus":"Exchangeability","id":"contractable-covariance-structure"}-->

🤖 Prepared with Claude Code
