### PR TITLE
feat: add comodule invariants

### DIFF
--- a/TauCeti/Algebra/Coalgebra/Comodule/Coinvariants.lean
+++ b/TauCeti/Algebra/Coalgebra/Comodule/Coinvariants.lean
@@ -13,9 +13,9 @@ public import TauCeti.Algebra.Coalgebra.Comodule.Trivial
 For a coalgebra `C` over `R`, a group-like element `g : GroupLike R C`, and a right
 `C`-comodule `M`, the **coinvariants relative to `g`** are the vectors whose coaction is
 `ρ(m) = m ⊗ g`. In a bialgebra, the specialization `g = 1` is the comodule-theoretic form of
-the usual fixed-vector construction. Under the representation ⇆ comodule dictionary of the
-reductive-groups roadmap, this is the affine monoid scheme fixed-point functor; in the
-Hopf-algebra case, it recovers the usual affine group scheme interpretation.
+the usual fixed-vector construction. Under the representation ⇆ comodule dictionary in the
+commutative bialgebra or Hopf-algebra setting of the reductive-groups roadmap, this
+specialization is the affine monoid or affine group scheme fixed-point functor.
 
 The coinvariants form an `R`-submodule, the equalizer of the two linear maps `ρ` and
 `m ↦ m ⊗ g`. Two structural facts pin the definition down: the group-like comodule attached
@@ -261,6 +261,7 @@ abbrev invariants [Comodule R C M] : Submodule R M :=
   coinvariants R C M (1 : GroupLike R C)
 
 /-- A vector is invariant exactly when its coaction is `m ⊗ 1`. -/
+@[simp]
 theorem mem_invariants [Comodule R C M] {m : M} :
     m ∈ invariants R C M ↔ coact (R := R) (C := C) (M := M) m = m ⊗ₜ[R] (1 : C) :=
   mem_coinvariants (R := R) (C := C) (M := M) (1 : GroupLike R C)
@@ -286,6 +287,7 @@ abbrev mapInvariants (f : Hom R C M N) : invariants R C M →ₗ[R] invariants R
   mapCoinvariants (R := R) (C := C) (M := M) (N := N) (1 : GroupLike R C) f
 
 /-- `mapInvariants f` acts as the underlying map of `f` on invariant vectors. -/
+@[simp]
 theorem mapInvariants_coe_apply (f : Hom R C M N) (m : invariants R C M) :
     (mapInvariants (R := R) (C := C) f m : N) = f (m : M) :=
   mapCoinvariants_coe_apply (R := R) (C := C) (M := M) (N := N)
@@ -301,6 +303,7 @@ theorem mapInvariants_id :
 variable [Comodule R C P]
 
 /-- The invariants functor preserves composition. -/
+@[simp]
 theorem mapInvariants_comp (h : Hom R C N P) (f : Hom R C M N) :
     mapInvariants (R := R) (C := C) (M := M) (N := P) (h.comp f) =
       (mapInvariants (R := R) (C := C) (M := N) (N := P) h).comp
@@ -318,7 +321,9 @@ and a morphism `f` to `f 1`. -/
 noncomputable abbrev invariantsEquivHom :
     letI : Comodule R C R := Comodule.trivial (R := R) (C := C) (M := R)
     invariants R C M ≃ₗ[R] Hom R C R M :=
-  coinvariantsEquivHom (R := R) (C := C) (M := M) (1 : GroupLike R C)
+  by
+    simpa [Comodule.trivial_eq_groupLike_one] using
+      (coinvariantsEquivHom (R := R) (C := C) (M := M) (1 : GroupLike R C))
 
 /-- `invariantsEquivHom` sends an invariant vector `m` to the morphism `r ↦ r • m`. -/
 @[simp]

--- a/TauCeti/Algebra/Coalgebra/Comodule/Coinvariants.lean
+++ b/TauCeti/Algebra/Coalgebra/Comodule/Coinvariants.lean
@@ -261,6 +261,7 @@ abbrev invariants [Comodule R C M] : Submodule R M :=
   coinvariants R C M (1 : GroupLike R C)
 
 /-- A vector is invariant exactly when its coaction is `m ⊗ 1`. -/
+@[simp]
 theorem mem_invariants [Comodule R C M] {m : M} :
     m ∈ invariants R C M ↔ coact (R := R) (C := C) (M := M) m = m ⊗ₜ[R] (1 : C) :=
   mem_coinvariants (R := R) (C := C) (M := M) (1 : GroupLike R C)
@@ -286,6 +287,7 @@ abbrev mapInvariants (f : Hom R C M N) : invariants R C M →ₗ[R] invariants R
   mapCoinvariants (R := R) (C := C) (M := M) (N := N) (1 : GroupLike R C) f
 
 /-- `mapInvariants f` acts as the underlying map of `f` on invariant vectors. -/
+@[simp]
 theorem mapInvariants_coe_apply (f : Hom R C M N) (m : invariants R C M) :
     (mapInvariants (R := R) (C := C) f m : N) = f (m : M) :=
   mapCoinvariants_coe_apply (R := R) (C := C) (M := M) (N := N)
@@ -301,6 +303,7 @@ theorem mapInvariants_id :
 variable [Comodule R C P]
 
 /-- The invariants functor preserves composition. -/
+@[simp]
 theorem mapInvariants_comp (h : Hom R C N P) (f : Hom R C M N) :
     mapInvariants (R := R) (C := C) (M := M) (N := P) (h.comp f) =
       (mapInvariants (R := R) (C := C) (M := N) (N := P) h).comp
@@ -319,7 +322,7 @@ noncomputable abbrev invariantsEquivHom :
     letI : Comodule R C R := Comodule.trivial (R := R) (C := C) (M := R)
     invariants R C M ≃ₗ[R] Hom R C R M :=
   by
-    simpa [Comodule.trivial_eq_groupLike_one] using
+    simpa [trivial_eq_groupLike_one] using
       (coinvariantsEquivHom (R := R) (C := C) (M := M) (1 : GroupLike R C))
 
 /-- `invariantsEquivHom` sends an invariant vector `m` to the morphism `r ↦ r • m`. -/
@@ -328,7 +331,8 @@ theorem invariantsEquivHom_apply (m : invariants R C M) :
     letI : Comodule R C R := Comodule.trivial (R := R) (C := C) (M := R)
     invariantsEquivHom (R := R) (C := C) (M := M) m =
       Hom.ofCoinvariant (R := R) (C := C) (M := M) (1 : GroupLike R C) m :=
-  rfl
+  by
+    exact coinvariantsEquivHom_apply (R := R) (C := C) (M := M) (1 : GroupLike R C) m
 
 /-- The inverse of `invariantsEquivHom` sends a morphism `f` to the invariant vector `f 1`. -/
 @[simp]
@@ -337,7 +341,9 @@ theorem invariantsEquivHom_symm_apply_coe
       Hom R C R M) :
     letI : Comodule R C R := Comodule.trivial (R := R) (C := C) (M := R)
     (invariantsEquivHom (R := R) (C := C) (M := M)).symm f = f 1 :=
-  rfl
+  by
+    exact coinvariantsEquivHom_symm_apply_coe (R := R) (C := C) (M := M)
+      (1 : GroupLike R C) f
 
 end Invariants
 

--- a/TauCeti/Algebra/Coalgebra/Comodule/Coinvariants.lean
+++ b/TauCeti/Algebra/Coalgebra/Comodule/Coinvariants.lean
@@ -5,7 +5,6 @@ Released under Apache 2.0 license as described in the file LICENSE.
 module
 
 public import Mathlib.Algebra.Module.Submodule.EqLocus
-public import TauCeti.Algebra.Coalgebra.Comodule.Hom
 public import TauCeti.Algebra.Coalgebra.Comodule.Trivial
 
 /-!
@@ -25,11 +24,11 @@ coinvariants relative to `g`, so `M ↦ M^{co g}` is functorial. On the regular 
 element `g : C` is coinvariant, since `g` is group-like.
 
 This is Layer 1 infrastructure for the reductive-groups roadmap
-(`ReductiveGroups/README.md` in TauCetiRoadmap, "representations = comodules"): the
-coinvariants functor is the comodule-theoretic fixed-point functor, a prerequisite for the
-complete-reducibility (linear reductivity) statements of Layer 6 and for the Hom-space
-computations underlying Tannakian reconstruction. It is built on the existing comodule and
-trivial-comodule API.
+(`ReductiveGroups/README.md` in TauCetiRoadmap, "representations = comodules"): the `g = 1`
+specialization gives the comodule-theoretic fixed-vector/invariants functor needed for the
+complete-reducibility (linear reductivity) statements of Layer 6, while the relative
+`g`-coinvariants developed here support the same Hom-space calculation for any group-like
+source comodule. It is built on the existing comodule and trivial-comodule API.
 
 ## Main definitions
 
@@ -49,8 +48,8 @@ trivial-comodule API.
 ## References
 
 The coinvariants of a comodule are standard; see for example Sweedler,
-*Hopf Algebras*, Chapter 3. This realizes the fixed-point functor of the
-representation ⇆ comodule dictionary in Layer 1 of the Tau Ceti reductive-groups roadmap.
+*Hopf Algebras*, Chapter 3. The `g = 1` specialization realizes the fixed-point functor of
+the representation ⇆ comodule dictionary in Layer 1 of the Tau Ceti reductive-groups roadmap.
 -/
 
 public section
@@ -100,9 +99,8 @@ theorem coinvariants_groupLike_eq_top :
     letI : Comodule R C M := Comodule.groupLike (R := R) (C := C) (M := M) g
     coinvariants R C M g = ⊤ := by
   letI : Comodule R C M := Comodule.groupLike (R := R) (C := C) (M := M) g
-  change LinearMap.eqLocus (Comodule.groupLikeCoact (R := R) (C := C) (M := M) g)
-    (Comodule.groupLikeCoact (R := R) (C := C) (M := M) g) = ⊤
-  exact LinearMap.eqLocus_same _
+  ext m
+  simp [mem_coinvariants]
 
 /-- The regular comodule has `g` among its coinvariants: `g` is group-like, so
 `Δ g = g ⊗ g`. -/

--- a/TauCeti/Algebra/Coalgebra/Comodule/Coinvariants.lean
+++ b/TauCeti/Algebra/Coalgebra/Comodule/Coinvariants.lean
@@ -261,6 +261,7 @@ abbrev invariants [Comodule R C M] : Submodule R M :=
   coinvariants R C M (1 : GroupLike R C)
 
 /-- A vector is invariant exactly when its coaction is `m ⊗ 1`. -/
+@[simp]
 theorem mem_invariants [Comodule R C M] {m : M} :
     m ∈ invariants R C M ↔ coact (R := R) (C := C) (M := M) m = m ⊗ₜ[R] (1 : C) :=
   mem_coinvariants (R := R) (C := C) (M := M) (1 : GroupLike R C)
@@ -286,6 +287,7 @@ abbrev mapInvariants (f : Hom R C M N) : invariants R C M →ₗ[R] invariants R
   mapCoinvariants (R := R) (C := C) (M := M) (N := N) (1 : GroupLike R C) f
 
 /-- `mapInvariants f` acts as the underlying map of `f` on invariant vectors. -/
+@[simp]
 theorem mapInvariants_coe_apply (f : Hom R C M N) (m : invariants R C M) :
     (mapInvariants (R := R) (C := C) f m : N) = f (m : M) :=
   mapCoinvariants_coe_apply (R := R) (C := C) (M := M) (N := N)
@@ -301,6 +303,7 @@ theorem mapInvariants_id :
 variable [Comodule R C P]
 
 /-- The invariants functor preserves composition. -/
+@[simp]
 theorem mapInvariants_comp (h : Hom R C N P) (f : Hom R C M N) :
     mapInvariants (R := R) (C := C) (M := M) (N := P) (h.comp f) =
       (mapInvariants (R := R) (C := C) (M := N) (N := P) h).comp
@@ -329,7 +332,7 @@ theorem invariantsEquivHom_apply (m : invariants R C M) :
     invariantsEquivHom (R := R) (C := C) (M := M) m =
       Hom.ofCoinvariant (R := R) (C := C) (M := M) (1 : GroupLike R C) m :=
   by
-    exact coinvariantsEquivHom_apply (R := R) (C := C) (M := M) (1 : GroupLike R C) m
+    simp only [invariantsEquivHom, coinvariantsEquivHom_apply]
 
 /-- The inverse of `invariantsEquivHom` sends a morphism `f` to the invariant vector `f 1`. -/
 @[simp]
@@ -339,8 +342,7 @@ theorem invariantsEquivHom_symm_apply_coe
     letI : Comodule R C R := Comodule.trivial (R := R) (C := C) (M := R)
     (invariantsEquivHom (R := R) (C := C) (M := M)).symm f = f 1 :=
   by
-    exact coinvariantsEquivHom_symm_apply_coe (R := R) (C := C) (M := M)
-      (1 : GroupLike R C) f
+    simp only [invariantsEquivHom, coinvariantsEquivHom_symm_apply_coe]
 
 end Invariants
 

--- a/TauCeti/Algebra/Coalgebra/Comodule/Coinvariants.lean
+++ b/TauCeti/Algebra/Coalgebra/Comodule/Coinvariants.lean
@@ -261,7 +261,6 @@ abbrev invariants [Comodule R C M] : Submodule R M :=
   coinvariants R C M (1 : GroupLike R C)
 
 /-- A vector is invariant exactly when its coaction is `m ⊗ 1`. -/
-@[simp]
 theorem mem_invariants [Comodule R C M] {m : M} :
     m ∈ invariants R C M ↔ coact (R := R) (C := C) (M := M) m = m ⊗ₜ[R] (1 : C) :=
   mem_coinvariants (R := R) (C := C) (M := M) (1 : GroupLike R C)
@@ -287,7 +286,6 @@ abbrev mapInvariants (f : Hom R C M N) : invariants R C M →ₗ[R] invariants R
   mapCoinvariants (R := R) (C := C) (M := M) (N := N) (1 : GroupLike R C) f
 
 /-- `mapInvariants f` acts as the underlying map of `f` on invariant vectors. -/
-@[simp]
 theorem mapInvariants_coe_apply (f : Hom R C M N) (m : invariants R C M) :
     (mapInvariants (R := R) (C := C) f m : N) = f (m : M) :=
   mapCoinvariants_coe_apply (R := R) (C := C) (M := M) (N := N)
@@ -303,7 +301,6 @@ theorem mapInvariants_id :
 variable [Comodule R C P]
 
 /-- The invariants functor preserves composition. -/
-@[simp]
 theorem mapInvariants_comp (h : Hom R C N P) (f : Hom R C M N) :
     mapInvariants (R := R) (C := C) (M := M) (N := P) (h.comp f) =
       (mapInvariants (R := R) (C := C) (M := N) (N := P) h).comp

--- a/TauCeti/Algebra/Coalgebra/Comodule/Coinvariants.lean
+++ b/TauCeti/Algebra/Coalgebra/Comodule/Coinvariants.lean
@@ -244,12 +244,13 @@ end Comodule
 
 namespace Comodule
 
-universe u v w x
+universe u v w x y
 
-variable {R : Type u} {C : Type v} {M : Type w} {N : Type x}
+variable {R : Type u} {C : Type v} {M : Type w} {N : Type x} {P : Type y}
 variable [CommSemiring R] [Semiring C] [Bialgebra R C]
 variable [AddCommMonoid M] [Module R M]
 variable [AddCommMonoid N] [Module R N]
+variable [AddCommMonoid P] [Module R P]
 
 section Invariants
 
@@ -260,6 +261,7 @@ abbrev invariants [Comodule R C M] : Submodule R M :=
   coinvariants R C M (1 : GroupLike R C)
 
 /-- A vector is invariant exactly when its coaction is `m ⊗ 1`. -/
+@[simp]
 theorem mem_invariants [Comodule R C M] {m : M} :
     m ∈ invariants R C M ↔ coact (R := R) (C := C) (M := M) m = m ⊗ₜ[R] (1 : C) :=
   mem_coinvariants (R := R) (C := C) (M := M) (1 : GroupLike R C)
@@ -285,10 +287,29 @@ abbrev mapInvariants (f : Hom R C M N) : invariants R C M →ₗ[R] invariants R
   mapCoinvariants (R := R) (C := C) (M := M) (N := N) (1 : GroupLike R C) f
 
 /-- `mapInvariants f` acts as the underlying map of `f` on invariant vectors. -/
+@[simp]
 theorem mapInvariants_coe_apply (f : Hom R C M N) (m : invariants R C M) :
     (mapInvariants (R := R) (C := C) f m : N) = f (m : M) :=
   mapCoinvariants_coe_apply (R := R) (C := C) (M := M) (N := N)
     (1 : GroupLike R C) f m
+
+/-- The invariants functor sends the identity morphism to the identity. -/
+@[simp]
+theorem mapInvariants_id :
+    mapInvariants (R := R) (C := C)
+      (CategoryTheory.CategoryStruct.id (ComoduleCat.of R C M)) = LinearMap.id :=
+  mapCoinvariants_id (R := R) (C := C) (M := M) (1 : GroupLike R C)
+
+variable [Comodule R C P]
+
+/-- The invariants functor preserves composition. -/
+@[simp]
+theorem mapInvariants_comp (h : Hom R C N P) (f : Hom R C M N) :
+    mapInvariants (R := R) (C := C) (M := M) (N := P) (h.comp f) =
+      (mapInvariants (R := R) (C := C) (M := N) (N := P) h).comp
+        (mapInvariants (R := R) (C := C) (M := M) (N := N) f) :=
+  mapCoinvariants_comp (R := R) (C := C) (M := M) (N := N) (P := P)
+    (1 : GroupLike R C) h f
 
 end Hom
 

--- a/TauCeti/Algebra/Coalgebra/Comodule/Coinvariants.lean
+++ b/TauCeti/Algebra/Coalgebra/Comodule/Coinvariants.lean
@@ -33,6 +33,7 @@ source comodule. It is built on the existing comodule and trivial-comodule API.
 ## Main definitions
 
 * `TauCeti.Comodule.coinvariants`: the submodule of coinvariants of a right comodule.
+* `TauCeti.Comodule.invariants`: the bialgebraic fixed-vector specialization at `g = 1`.
 * `TauCeti.Comodule.Hom.mapCoinvariants`: a comodule morphism restricted to coinvariants.
 
 ## Main results
@@ -238,6 +239,89 @@ theorem coinvariantsEquivHom_symm_apply_coe (g : GroupLike R C)
   rfl
 
 end UniversalProperty
+
+end Comodule
+
+namespace Comodule
+
+universe u v w x
+
+variable {R : Type u} {C : Type v} {M : Type w} {N : Type x}
+variable [CommSemiring R] [Semiring C] [Bialgebra R C]
+variable [AddCommMonoid M] [Module R M]
+variable [AddCommMonoid N] [Module R N]
+
+section Invariants
+
+variable (R C M) in
+/-- The invariants, or fixed vectors, of a right comodule over a bialgebra: the specialization
+of `coinvariants` to the unit group-like element. -/
+abbrev invariants [Comodule R C M] : Submodule R M :=
+  coinvariants R C M (1 : GroupLike R C)
+
+/-- A vector is invariant exactly when its coaction is `m ⊗ 1`. -/
+@[simp]
+theorem mem_invariants [Comodule R C M] {m : M} :
+    m ∈ invariants R C M ↔ coact (R := R) (C := C) (M := M) m = m ⊗ₜ[R] (1 : C) :=
+  mem_coinvariants (R := R) (C := C) (M := M) (1 : GroupLike R C)
+
+/-- An invariant vector, unfolded: its coaction is `m ⊗ 1`. -/
+theorem coact_eq_of_mem_invariants [Comodule R C M] {m : M}
+    (hm : m ∈ invariants R C M) :
+    coact (R := R) (C := C) (M := M) m = m ⊗ₜ[R] (1 : C) :=
+  (mem_invariants (R := R) (C := C) (M := M)).1 hm
+
+namespace Hom
+
+variable [Comodule R C M] [Comodule R C N]
+
+/-- Comodule morphisms carry invariants to invariants. -/
+theorem map_mem_invariants (f : Hom R C M N) {m : M} (hm : m ∈ invariants R C M) :
+    f m ∈ invariants R C N :=
+  map_mem_coinvariants (R := R) (C := C) (M := M) (N := N) (1 : GroupLike R C) f hm
+
+/-- A comodule morphism restricted to invariants, as an `R`-linear map
+`M^{co 1} → N^{co 1}`. -/
+abbrev mapInvariants (f : Hom R C M N) : invariants R C M →ₗ[R] invariants R C N :=
+  mapCoinvariants (R := R) (C := C) (M := M) (N := N) (1 : GroupLike R C) f
+
+/-- `mapInvariants f` acts as the underlying map of `f` on invariant vectors. -/
+@[simp]
+theorem mapInvariants_coe_apply (f : Hom R C M N) (m : invariants R C M) :
+    (mapInvariants (R := R) (C := C) f m : N) = f (m : M) :=
+  mapCoinvariants_coe_apply (R := R) (C := C) (M := M) (N := N)
+    (1 : GroupLike R C) f m
+
+end Hom
+
+variable [Comodule R C M]
+
+/-- The invariant vectors of a comodule `M` are linearly equivalent to the comodule morphisms
+from the trivial comodule on `R`. The equivalence sends an invariant vector `m` to `r ↦ r • m`
+and a morphism `f` to `f 1`. -/
+noncomputable abbrev invariantsEquivHom :
+    letI : Comodule R C R := Comodule.trivial (R := R) (C := C) (M := R)
+    invariants R C M ≃ₗ[R] Hom R C R M :=
+  coinvariantsEquivHom (R := R) (C := C) (M := M) (1 : GroupLike R C)
+
+/-- `invariantsEquivHom` sends an invariant vector `m` to the morphism `r ↦ r • m`. -/
+@[simp]
+theorem invariantsEquivHom_apply (m : invariants R C M) :
+    letI : Comodule R C R := Comodule.trivial (R := R) (C := C) (M := R)
+    invariantsEquivHom (R := R) (C := C) (M := M) m =
+      Hom.ofCoinvariant (R := R) (C := C) (M := M) (1 : GroupLike R C) m :=
+  rfl
+
+/-- The inverse of `invariantsEquivHom` sends a morphism `f` to the invariant vector `f 1`. -/
+@[simp]
+theorem invariantsEquivHom_symm_apply_coe
+    (f : letI : Comodule R C R := Comodule.trivial (R := R) (C := C) (M := R);
+      Hom R C R M) :
+    letI : Comodule R C R := Comodule.trivial (R := R) (C := C) (M := R)
+    (invariantsEquivHom (R := R) (C := C) (M := M)).symm f = f 1 :=
+  rfl
+
+end Invariants
 
 end Comodule
 

--- a/TauCeti/Algebra/Coalgebra/Comodule/Coinvariants.lean
+++ b/TauCeti/Algebra/Coalgebra/Comodule/Coinvariants.lean
@@ -260,7 +260,6 @@ abbrev invariants [Comodule R C M] : Submodule R M :=
   coinvariants R C M (1 : GroupLike R C)
 
 /-- A vector is invariant exactly when its coaction is `m ⊗ 1`. -/
-@[simp]
 theorem mem_invariants [Comodule R C M] {m : M} :
     m ∈ invariants R C M ↔ coact (R := R) (C := C) (M := M) m = m ⊗ₜ[R] (1 : C) :=
   mem_coinvariants (R := R) (C := C) (M := M) (1 : GroupLike R C)
@@ -286,7 +285,6 @@ abbrev mapInvariants (f : Hom R C M N) : invariants R C M →ₗ[R] invariants R
   mapCoinvariants (R := R) (C := C) (M := M) (N := N) (1 : GroupLike R C) f
 
 /-- `mapInvariants f` acts as the underlying map of `f` on invariant vectors. -/
-@[simp]
 theorem mapInvariants_coe_apply (f : Hom R C M N) (m : invariants R C M) :
     (mapInvariants (R := R) (C := C) f m : N) = f (m : M) :=
   mapCoinvariants_coe_apply (R := R) (C := C) (M := M) (N := N)

--- a/TauCeti/Algebra/Coalgebra/Comodule/Coinvariants.lean
+++ b/TauCeti/Algebra/Coalgebra/Comodule/Coinvariants.lean
@@ -261,6 +261,7 @@ abbrev invariants [Comodule R C M] : Submodule R M :=
   coinvariants R C M (1 : GroupLike R C)
 
 /-- A vector is invariant exactly when its coaction is `m ⊗ 1`. -/
+@[simp]
 theorem mem_invariants [Comodule R C M] {m : M} :
     m ∈ invariants R C M ↔ coact (R := R) (C := C) (M := M) m = m ⊗ₜ[R] (1 : C) :=
   mem_coinvariants (R := R) (C := C) (M := M) (1 : GroupLike R C)
@@ -286,6 +287,7 @@ abbrev mapInvariants (f : Hom R C M N) : invariants R C M →ₗ[R] invariants R
   mapCoinvariants (R := R) (C := C) (M := M) (N := N) (1 : GroupLike R C) f
 
 /-- `mapInvariants f` acts as the underlying map of `f` on invariant vectors. -/
+@[simp]
 theorem mapInvariants_coe_apply (f : Hom R C M N) (m : invariants R C M) :
     (mapInvariants (R := R) (C := C) f m : N) = f (m : M) :=
   mapCoinvariants_coe_apply (R := R) (C := C) (M := M) (N := N)
@@ -301,6 +303,7 @@ theorem mapInvariants_id :
 variable [Comodule R C P]
 
 /-- The invariants functor preserves composition. -/
+@[simp]
 theorem mapInvariants_comp (h : Hom R C N P) (f : Hom R C M N) :
     mapInvariants (R := R) (C := C) (M := M) (N := P) (h.comp f) =
       (mapInvariants (R := R) (C := C) (M := N) (N := P) h).comp

--- a/TauCeti/Algebra/Coalgebra/Comodule/Invariants.lean
+++ b/TauCeti/Algebra/Coalgebra/Comodule/Invariants.lean
@@ -1,0 +1,219 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+module
+
+public import TauCeti.Algebra.Coalgebra.Comodule.Trivial
+
+/-!
+# Invariants of a comodule
+
+For a bialgebra `C` over `R` and a right `C`-comodule `M`, the **invariants** `M^{coC}` are the
+vectors fixed by the coaction: those `m : M` with `ρ(m) = m ⊗ 1`. Under the
+representation ⇆ comodule dictionary of the reductive-groups roadmap, a right `C`-comodule is a
+representation of the affine group scheme `Spec C`, and its invariants are exactly the fixed
+vectors of that representation (the vectors on which the group acts trivially). They are also
+the coinvariants `M^{coC}` of Hopf-algebra theory.
+
+The invariants form an `R`-submodule, cut out as the kernel of `ρ - (· ⊗ 1)`. Two structural
+facts pin the definition down: the trivial comodule (the coaction `m ↦ m ⊗ 1`) is all
+invariants, and comodule morphisms carry invariants to invariants, so `M ↦ M^{coC}` is
+functorial. On the regular comodule the unit `1 : C` is invariant, since `1` is group-like.
+
+This is Layer 1 infrastructure for the reductive-groups roadmap
+(`ReductiveGroups/README.md` in TauCetiRoadmap, "representations = comodules"): the invariants
+functor `V ↦ V^{coC}` is the comodule-theoretic fixed-point functor, a prerequisite for the
+complete-reducibility (linear reductivity) statements of Layer 6 and for the Hom-space
+computations underlying Tannakian reconstruction. It is built on the existing comodule and
+trivial-comodule API.
+
+## Main definitions
+
+* `TauCeti.Comodule.invariants`: the submodule of invariants of a right comodule.
+* `TauCeti.Comodule.Hom.mapInvariants`: a comodule morphism restricted to invariants.
+
+## Main results
+
+* `TauCeti.Comodule.mem_invariants`: `m` is invariant iff `ρ(m) = m ⊗ 1`.
+* `TauCeti.Comodule.invariants_trivial`: the trivial comodule is all invariants.
+* `TauCeti.Comodule.one_mem_invariants_self`: `1` is invariant in the regular comodule.
+* `TauCeti.Comodule.Hom.map_mem_invariants`, `mapInvariants_id`, `mapInvariants_comp`:
+  functoriality of the invariants.
+
+## References
+
+The invariants (coinvariants) of a comodule are standard; see for example Sweedler,
+*Hopf Algebras*, Chapter 3. This realizes the fixed-point functor of the
+representation ⇆ comodule dictionary in Layer 1 of the Tau Ceti reductive-groups roadmap.
+-/
+
+public section
+
+open scoped TensorProduct
+
+namespace TauCeti
+
+namespace Comodule
+
+universe u v w x y
+
+variable {R : Type u} {C : Type v} {M : Type w} {N : Type x} {P : Type y}
+variable [CommSemiring R]
+variable [Semiring C] [Bialgebra R C]
+variable [AddCommMonoid M] [Module R M]
+variable [AddCommMonoid N] [Module R N]
+variable [AddCommMonoid P] [Module R P]
+
+variable (R C M) in
+/-- The invariants `M^{coC}` of a right `C`-comodule `M`: the `R`-submodule of vectors `m` with
+`ρ(m) = m ⊗ 1`. These are the fixed vectors of the representation `M` of `Spec C`. -/
+def invariants [Comodule R C M] : Submodule R M where
+  carrier := {m | coact (R := R) (C := C) (M := M) m = m ⊗ₜ[R] (1 : C)}
+  add_mem' {a b} ha hb := by
+    simp only [Set.mem_setOf_eq] at *
+    rw [map_add, ha, hb, TensorProduct.add_tmul]
+  zero_mem' := by
+    simp only [Set.mem_setOf_eq]
+    rw [map_zero, TensorProduct.zero_tmul]
+  smul_mem' r m hm := by
+    simp only [Set.mem_setOf_eq] at *
+    rw [map_smul, hm, TensorProduct.smul_tmul']
+
+/-- A vector is invariant exactly when its coaction is `m ⊗ 1`. -/
+@[simp]
+theorem mem_invariants [Comodule R C M] {m : M} :
+    m ∈ invariants R C M ↔ coact (R := R) (C := C) (M := M) m = m ⊗ₜ[R] (1 : C) :=
+  Iff.rfl
+
+/-- An invariant vector, unfolded: its coaction is `m ⊗ 1`. -/
+theorem coact_eq_of_mem_invariants [Comodule R C M] {m : M} (hm : m ∈ invariants R C M) :
+    coact (R := R) (C := C) (M := M) m = m ⊗ₜ[R] (1 : C) :=
+  mem_invariants.1 hm
+
+section Trivial
+
+attribute [local instance] Comodule.trivial
+
+/-- The trivial comodule (coaction `m ↦ m ⊗ 1`) is all invariants. -/
+theorem invariants_trivial : invariants R C M = ⊤ := by
+  ext m
+  simp [mem_invariants]
+
+end Trivial
+
+/-- The regular comodule of a bialgebra has `1` among its invariants: `1` is group-like, so
+`Δ 1 = 1 ⊗ 1`. -/
+theorem one_mem_invariants_self : (1 : C) ∈ invariants R C C := by
+  rw [mem_invariants, instSelf_coact, Bialgebra.comul_one, Algebra.TensorProduct.one_def]
+
+namespace Hom
+
+variable [Comodule R C M] [Comodule R C N] [Comodule R C P]
+
+/-- Comodule morphisms carry invariants to invariants: if `ρ(m) = m ⊗ 1` then
+`ρ(f m) = (f ⊗ id)(m ⊗ 1) = f m ⊗ 1`. -/
+theorem map_mem_invariants (f : Hom R C M N) {m : M} (hm : m ∈ invariants R C M) :
+    f m ∈ invariants R C N := by
+  rw [mem_invariants] at hm ⊢
+  rw [← map_coact_apply f m, hm, TensorProduct.map_tmul, LinearMap.id_apply, coe_toLinearMap]
+
+/-- A comodule morphism restricted to invariants, as an `R`-linear map `M^{coC} → N^{coC}`. -/
+@[expose] def mapInvariants (f : Hom R C M N) : invariants R C M →ₗ[R] invariants R C N :=
+  f.toLinearMap.restrict fun _ hm => map_mem_invariants f hm
+
+/-- `mapInvariants f` acts as the underlying map of `f` on invariant vectors. -/
+@[simp]
+theorem mapInvariants_coe_apply (f : Hom R C M N) (m : invariants R C M) :
+    (mapInvariants f m : N) = f (m : M) :=
+  LinearMap.coe_restrict_apply _ m
+
+/-- The invariants functor sends the identity morphism to the identity. -/
+@[simp]
+theorem mapInvariants_id :
+    mapInvariants (Hom.id R C M) = LinearMap.id := by
+  refine LinearMap.ext fun m => Subtype.ext ?_
+  simp only [mapInvariants_coe_apply, Hom.id_apply, LinearMap.id_coe, id_eq]
+
+/-- The invariants functor preserves composition. -/
+@[simp]
+theorem mapInvariants_comp (g : Hom R C N P) (f : Hom R C M N) :
+    mapInvariants (g.comp f) = (mapInvariants g).comp (mapInvariants f) := by
+  refine LinearMap.ext fun m => Subtype.ext ?_
+  simp only [mapInvariants_coe_apply, Hom.comp_apply, LinearMap.comp_apply]
+
+end Hom
+
+section UniversalProperty
+
+variable [Comodule R C M]
+
+/-- The comodule morphism `R → M` from the trivial comodule `R` determined by an invariant
+vector `m`, namely `r ↦ r • m`. -/
+@[expose] noncomputable def Hom.ofInvariant (m : invariants R C M) :
+    letI : Comodule R C R := Comodule.trivial
+    Hom R C R M :=
+  letI : Comodule R C R := Comodule.trivial
+  { toLinearMap := LinearMap.toSpanSingleton R M (m : M)
+    map_coact := by
+      refine LinearMap.ext_ring ?_
+      simp only [LinearMap.comp_apply, Comodule.trivial_coact_apply, TensorProduct.map_tmul,
+        LinearMap.toSpanSingleton_apply, LinearMap.id_coe, id_eq, one_smul,
+        coact_eq_of_mem_invariants m.2] }
+
+/-- The value of `Hom.ofInvariant m` at `1` is `m`. -/
+@[simp]
+theorem Hom.ofInvariant_one (m : invariants R C M) :
+    letI : Comodule R C R := Comodule.trivial
+    (Hom.ofInvariant m) 1 = (m : M) := by
+  change LinearMap.toSpanSingleton R M (m : M) 1 = (m : M)
+  rw [LinearMap.toSpanSingleton_apply, one_smul]
+
+/-- Evaluating a comodule morphism out of the trivial comodule `R` at `1` yields an invariant
+vector: `ρ(f 1) = (f ⊗ id)(1 ⊗ 1) = f 1 ⊗ 1`. -/
+theorem Hom.one_mem_invariants (f : letI : Comodule R C R := Comodule.trivial; Hom R C R M) :
+    letI : Comodule R C R := Comodule.trivial
+    f 1 ∈ invariants R C M := by
+  letI : Comodule R C R := Comodule.trivial
+  rw [mem_invariants, ← Hom.map_coact_apply f 1, Comodule.trivial_coact_apply,
+    TensorProduct.map_tmul, LinearMap.id_apply, Hom.coe_toLinearMap]
+
+/-- The invariants of a comodule `M` are exactly the comodule morphisms from the trivial
+comodule `R`: `M^{coC} ≃ Hom(𝟙, M)`, the fixed vectors being the morphisms out of the unit
+representation. The equivalence sends an invariant vector `m` to `r ↦ r • m` and a morphism `f`
+to `f 1`. -/
+@[expose] noncomputable def invariantsEquivHom :
+    letI : Comodule R C R := Comodule.trivial
+    invariants R C M ≃ Hom R C R M :=
+  letI : Comodule R C R := Comodule.trivial
+  { toFun := Hom.ofInvariant
+    invFun := fun f => ⟨f 1, Hom.one_mem_invariants f⟩
+    left_inv := fun m => Subtype.ext (Hom.ofInvariant_one m)
+    right_inv := fun f => by
+      apply Comodule.Hom.ext
+      intro r
+      change LinearMap.toSpanSingleton R M (f 1) r = f r
+      rw [LinearMap.toSpanSingleton_apply]
+      change r • f.toLinearMap 1 = f.toLinearMap r
+      rw [← map_smul, smul_eq_mul, mul_one] }
+
+/-- `invariantsEquivHom` sends an invariant vector `m` to the morphism `r ↦ r • m`. -/
+@[simp]
+theorem invariantsEquivHom_apply (m : invariants R C M) :
+    letI : Comodule R C R := Comodule.trivial
+    invariantsEquivHom m = Hom.ofInvariant m :=
+  rfl
+
+/-- The inverse of `invariantsEquivHom` sends a morphism `f` to the invariant vector `f 1`. -/
+@[simp]
+theorem invariantsEquivHom_symm_apply_coe
+    (f : letI : Comodule R C R := Comodule.trivial; Hom R C R M) :
+    letI : Comodule R C R := Comodule.trivial
+    (invariantsEquivHom.symm f : M) = f 1 :=
+  rfl
+
+end UniversalProperty
+
+end Comodule
+
+end TauCeti

--- a/TauCeti/Algebra/Coalgebra/Comodule/Invariants.lean
+++ b/TauCeti/Algebra/Coalgebra/Comodule/Invariants.lean
@@ -4,47 +4,51 @@ Released under Apache 2.0 license as described in the file LICENSE.
 -/
 module
 
+public import Mathlib.Algebra.Module.Submodule.EqLocus
+public import TauCeti.Algebra.Coalgebra.Comodule.Hom
 public import TauCeti.Algebra.Coalgebra.Comodule.Trivial
 
 /-!
-# Invariants of a comodule
+# Coinvariants of a comodule
 
 For a coalgebra `C` over `R`, a group-like element `g : GroupLike R C`, and a right
-`C`-comodule `M`, the **invariants relative to `g`** are the vectors whose coaction is
-`ρ(m) = m ⊗ g`. In a bialgebra, the usual invariants are the specialization `g = 1`. Under the
-representation ⇆ comodule dictionary of the reductive-groups roadmap, these are the fixed
-vectors for the corresponding affine monoid scheme representation; in the Hopf-algebra case,
-this recovers the usual affine group scheme interpretation.
+`C`-comodule `M`, the **coinvariants relative to `g`** are the vectors whose coaction is
+`ρ(m) = m ⊗ g`. In a bialgebra, the specialization `g = 1` is the comodule-theoretic form of
+the usual fixed-vector construction. Under the representation ⇆ comodule dictionary of the
+reductive-groups roadmap, this is the affine monoid scheme fixed-point functor; in the
+Hopf-algebra case, it recovers the usual affine group scheme interpretation.
 
-The invariants form an `R`-submodule, the equalizer of the two linear maps `ρ` and
-`m ↦ m ⊗ g`. Two structural facts pin the definition down: the group-like comodule (the
-coaction `m ↦ m ⊗ g`) is all invariants, and comodule morphisms carry invariants to
-invariants, so `M ↦ M^{co g}` is functorial. On the regular comodule the element `g : C` is
-invariant, since `g` is group-like.
+The coinvariants form an `R`-submodule, the equalizer of the two linear maps `ρ` and
+`m ↦ m ⊗ g`. Two structural facts pin the definition down: the group-like comodule attached
+to `g` is all coinvariants, and comodule morphisms carry coinvariants relative to `g` to
+coinvariants relative to `g`, so `M ↦ M^{co g}` is functorial. On the regular comodule the
+element `g : C` is coinvariant, since `g` is group-like.
 
 This is Layer 1 infrastructure for the reductive-groups roadmap
-(`ReductiveGroups/README.md` in TauCetiRoadmap, "representations = comodules"): the invariants
-functor `V ↦ V^{coC}` is the comodule-theoretic fixed-point functor, a prerequisite for the
+(`ReductiveGroups/README.md` in TauCetiRoadmap, "representations = comodules"): the
+coinvariants functor is the comodule-theoretic fixed-point functor, a prerequisite for the
 complete-reducibility (linear reductivity) statements of Layer 6 and for the Hom-space
 computations underlying Tannakian reconstruction. It is built on the existing comodule and
 trivial-comodule API.
 
 ## Main definitions
 
-* `TauCeti.Comodule.invariants`: the submodule of invariants of a right comodule.
-* `TauCeti.Comodule.Hom.mapInvariants`: a comodule morphism restricted to invariants.
+* `TauCeti.Comodule.coinvariants`: the submodule of coinvariants of a right comodule.
+* `TauCeti.Comodule.Hom.mapCoinvariants`: a comodule morphism restricted to coinvariants.
 
 ## Main results
 
-* `TauCeti.Comodule.mem_invariants`: `m` is invariant iff `ρ(m) = m ⊗ g`.
-* `TauCeti.Comodule.invariants_groupLike`: a group-like comodule is all invariants.
-* `TauCeti.Comodule.groupLike_mem_invariants_self`: `g` is invariant in the regular comodule.
-* `TauCeti.Comodule.Hom.map_mem_invariants`, `mapInvariants_id`, `mapInvariants_comp`:
-  functoriality of the invariants.
+* `TauCeti.Comodule.mem_coinvariants`: `m` is coinvariant iff `ρ(m) = m ⊗ g`.
+* `TauCeti.Comodule.coinvariants_groupLike_eq_top`: a group-like comodule has all vectors
+  coinvariant.
+* `TauCeti.Comodule.groupLike_mem_coinvariants_self`: `g` is coinvariant in the regular
+  comodule.
+* `TauCeti.Comodule.Hom.map_mem_coinvariants`, `mapCoinvariants_id`, `mapCoinvariants_comp`:
+  functoriality of coinvariants.
 
 ## References
 
-The invariants (coinvariants) of a comodule are standard; see for example Sweedler,
+The coinvariants of a comodule are standard; see for example Sweedler,
 *Hopf Algebras*, Chapter 3. This realizes the fixed-point functor of the
 representation ⇆ comodule dictionary in Layer 1 of the Tau Ceti reductive-groups roadmap.
 -/
@@ -67,49 +71,43 @@ variable [AddCommMonoid N] [Module R N]
 variable [AddCommMonoid P] [Module R P]
 
 variable (R C M) in
-/-- The invariants of a right `C`-comodule `M` relative to a group-like element
-`g : GroupLike R C`: the `R`-submodule of vectors `m` with `ρ(m) = m ⊗ g`. In a bialgebra,
-taking `g = 1` gives the usual invariant vectors. -/
-def invariants (g : GroupLike R C) [Comodule R C M] : Submodule R M where
-  carrier := {m | coact (R := R) (C := C) (M := M) m = m ⊗ₜ[R] (g : C)}
-  add_mem' {a b} ha hb := by
-    simp only [Set.mem_setOf_eq] at *
-    rw [map_add, ha, hb, TensorProduct.add_tmul]
-  zero_mem' := by
-    simp only [Set.mem_setOf_eq]
-    rw [map_zero, TensorProduct.zero_tmul]
-  smul_mem' r m hm := by
-    simp only [Set.mem_setOf_eq] at *
-    rw [map_smul, hm, TensorProduct.smul_tmul']
+/-- The coinvariants of a right `C`-comodule `M` relative to a group-like element
+`g : GroupLike R C`: the equalizer of the coaction and the group-like coaction
+`m ↦ m ⊗ g`. -/
+def coinvariants (g : GroupLike R C) [Comodule R C M] : Submodule R M :=
+  LinearMap.eqLocus (coact (R := R) (C := C) (M := M))
+    (Comodule.groupLikeCoact (R := R) (C := C) (M := M) g)
 
-/-- A vector is invariant exactly when its coaction is `m ⊗ g`. -/
+/-- A vector is coinvariant exactly when its coaction is `m ⊗ g`. -/
 @[simp]
-theorem mem_invariants (g : GroupLike R C) [Comodule R C M] {m : M} :
-    m ∈ invariants R C M g ↔ coact (R := R) (C := C) (M := M) m = m ⊗ₜ[R] (g : C) :=
-  Iff.rfl
+theorem mem_coinvariants (g : GroupLike R C) [Comodule R C M] {m : M} :
+    m ∈ coinvariants R C M g ↔ coact (R := R) (C := C) (M := M) m = m ⊗ₜ[R] (g : C) := by
+  rw [coinvariants, LinearMap.mem_eqLocus]
+  rfl
 
-/-- An invariant vector, unfolded: its coaction is `m ⊗ g`. -/
-theorem coact_eq_of_mem_invariants (g : GroupLike R C) [Comodule R C M] {m : M}
-    (hm : m ∈ invariants R C M g) :
+/-- A coinvariant vector, unfolded: its coaction is `m ⊗ g`. -/
+theorem coact_eq_of_mem_coinvariants (g : GroupLike R C) [Comodule R C M] {m : M}
+    (hm : m ∈ coinvariants R C M g) :
     coact (R := R) (C := C) (M := M) m = m ⊗ₜ[R] (g : C) :=
-  (mem_invariants g).1 hm
+  (mem_coinvariants g).1 hm
 
 section GroupLike
 
 variable (g : GroupLike R C)
 
-/-- The group-like comodule (coaction `m ↦ m ⊗ g`) is all invariants. -/
-theorem invariants_groupLike :
+/-- The group-like comodule attached to `g` has all vectors coinvariant. -/
+theorem coinvariants_groupLike_eq_top :
     letI : Comodule R C M := Comodule.groupLike (R := R) (C := C) (M := M) g
-    invariants R C M g = ⊤ := by
+    coinvariants R C M g = ⊤ := by
   letI : Comodule R C M := Comodule.groupLike (R := R) (C := C) (M := M) g
-  ext m
-  simp
+  change LinearMap.eqLocus (Comodule.groupLikeCoact (R := R) (C := C) (M := M) g)
+    (Comodule.groupLikeCoact (R := R) (C := C) (M := M) g) = ⊤
+  exact LinearMap.eqLocus_same _
 
-/-- The regular comodule has `g` among its invariants: `g` is group-like, so
+/-- The regular comodule has `g` among its coinvariants: `g` is group-like, so
 `Δ g = g ⊗ g`. -/
-theorem groupLike_mem_invariants_self : (g : C) ∈ invariants R C C g := by
-  rw [mem_invariants, instSelf_coact, g.isGroupLikeElem_val.comul_eq_tmul_self]
+theorem groupLike_mem_coinvariants_self : (g : C) ∈ coinvariants R C C g := by
+  rw [mem_coinvariants, instSelf_coact, g.isGroupLikeElem_val.comul_eq_tmul_self]
 
 end GroupLike
 
@@ -117,39 +115,40 @@ namespace Hom
 
 variable [Comodule R C M] [Comodule R C N] [Comodule R C P]
 
-/-- Comodule morphisms carry invariants to invariants: if `ρ(m) = m ⊗ g` then
+/-- Comodule morphisms carry coinvariants to coinvariants: if `ρ(m) = m ⊗ g` then
 `ρ(f m) = (f ⊗ id)(m ⊗ g) = f m ⊗ g`. -/
-theorem map_mem_invariants (g : GroupLike R C) (f : Hom R C M N) {m : M}
-    (hm : m ∈ invariants R C M g) :
-    f m ∈ invariants R C N g := by
-  rw [mem_invariants] at hm ⊢
+theorem map_mem_coinvariants (g : GroupLike R C) (f : Hom R C M N) {m : M}
+    (hm : m ∈ coinvariants R C M g) :
+    f m ∈ coinvariants R C N g := by
+  rw [mem_coinvariants] at hm ⊢
   rw [← map_coact_apply f m, hm, TensorProduct.map_tmul, LinearMap.id_apply, coe_toLinearMap]
 
-/-- A comodule morphism restricted to invariants, as an `R`-linear map `M^{coC} → N^{coC}`. -/
-def mapInvariants (g : GroupLike R C) (f : Hom R C M N) :
-    invariants R C M g →ₗ[R] invariants R C N g :=
-  f.toLinearMap.restrict fun _ hm => map_mem_invariants g f hm
+/-- A comodule morphism restricted to coinvariants relative to the same group-like element
+`g`, as an `R`-linear map `M^{co g} → N^{co g}`. -/
+def mapCoinvariants (g : GroupLike R C) (f : Hom R C M N) :
+    coinvariants R C M g →ₗ[R] coinvariants R C N g :=
+  f.toLinearMap.restrict fun _ hm => map_mem_coinvariants g f hm
 
-/-- `mapInvariants f` acts as the underlying map of `f` on invariant vectors. -/
+/-- `mapCoinvariants f` acts as the underlying map of `f` on coinvariant vectors. -/
 @[simp]
-theorem mapInvariants_coe_apply (g : GroupLike R C) (f : Hom R C M N)
-    (m : invariants R C M g) :
-    (mapInvariants g f m : N) = f (m : M) :=
+theorem mapCoinvariants_coe_apply (g : GroupLike R C) (f : Hom R C M N)
+    (m : coinvariants R C M g) :
+    (mapCoinvariants g f m : N) = f (m : M) :=
   LinearMap.coe_restrict_apply _ m
 
-/-- The invariants functor sends the identity morphism to the identity. -/
+/-- The coinvariants functor sends the identity morphism to the identity. -/
 @[simp]
-theorem mapInvariants_id (g : GroupLike R C) :
-    mapInvariants g (CategoryTheory.CategoryStruct.id (ComoduleCat.of R C M)) = LinearMap.id := by
+theorem mapCoinvariants_id (g : GroupLike R C) :
+    mapCoinvariants g (CategoryTheory.CategoryStruct.id (ComoduleCat.of R C M)) = LinearMap.id := by
   refine LinearMap.ext fun m => Subtype.ext ?_
   rfl
 
-/-- The invariants functor preserves composition. -/
+/-- The coinvariants functor preserves composition. -/
 @[simp]
-theorem mapInvariants_comp (g : GroupLike R C) (h : Hom R C N P) (f : Hom R C M N) :
-    mapInvariants g (h.comp f) = (mapInvariants g h).comp (mapInvariants g f) := by
+theorem mapCoinvariants_comp (g : GroupLike R C) (h : Hom R C N P) (f : Hom R C M N) :
+    mapCoinvariants g (h.comp f) = (mapCoinvariants g h).comp (mapCoinvariants g f) := by
   refine LinearMap.ext fun m => Subtype.ext ?_
-  simp only [mapInvariants_coe_apply, Hom.comp_apply, LinearMap.comp_apply]
+  simp only [mapCoinvariants_coe_apply, Hom.comp_apply, LinearMap.comp_apply]
 
 end Hom
 
@@ -157,9 +156,9 @@ section UniversalProperty
 
 variable [Comodule R C M]
 
-/-- The comodule morphism `R → M` from the trivial comodule `R` determined by an invariant
-vector `m`, namely `r ↦ r • m`. -/
-noncomputable def Hom.ofInvariant (g : GroupLike R C) (m : invariants R C M g) :
+/-- The comodule morphism from the group-like comodule on `R` attached to `g`, determined by
+a coinvariant vector `m`, namely `r ↦ r • m`. -/
+noncomputable def Hom.ofCoinvariant (g : GroupLike R C) (m : coinvariants R C M g) :
     letI : Comodule R C R := Comodule.groupLike (R := R) (C := C) (M := R) g
     Hom R C R M :=
   letI : Comodule R C R := Comodule.groupLike (R := R) (C := C) (M := R) g
@@ -168,68 +167,76 @@ noncomputable def Hom.ofInvariant (g : GroupLike R C) (m : invariants R C M g) :
       refine LinearMap.ext_ring ?_
       simp only [LinearMap.comp_apply, Comodule.groupLike_coact_apply, TensorProduct.map_tmul,
         LinearMap.toSpanSingleton_apply, LinearMap.id_coe, id_eq, one_smul,
-        coact_eq_of_mem_invariants g m.2] }
+        coact_eq_of_mem_coinvariants g m.2] }
 
-/-- The morphism `Hom.ofInvariant g m` sends `r` to `r • m`. -/
+/-- The morphism `Hom.ofCoinvariant g m` sends `r` to `r • m`. -/
 @[simp]
-theorem Hom.ofInvariant_apply (g : GroupLike R C) (m : invariants R C M g) (r : R) :
+theorem Hom.ofCoinvariant_apply (g : GroupLike R C) (m : coinvariants R C M g) (r : R) :
     letI : Comodule R C R := Comodule.groupLike (R := R) (C := C) (M := R) g
-    (Hom.ofInvariant g m) r = r • (m : M) := by
+    (Hom.ofCoinvariant g m) r = r • (m : M) := by
   letI : Comodule R C R := Comodule.groupLike (R := R) (C := C) (M := R) g
   exact LinearMap.toSpanSingleton_apply R M (m : M) r
 
-/-- The value of `Hom.ofInvariant m` at `1` is `m`. -/
-theorem Hom.ofInvariant_one (g : GroupLike R C) (m : invariants R C M g) :
+/-- The value of `Hom.ofCoinvariant m` at `1` is `m`. -/
+theorem Hom.ofCoinvariant_one (g : GroupLike R C) (m : coinvariants R C M g) :
     letI : Comodule R C R := Comodule.groupLike (R := R) (C := C) (M := R) g
-    (Hom.ofInvariant g m) 1 = (m : M) := by
+    (Hom.ofCoinvariant g m) 1 = (m : M) := by
   simp
 
-/-- Evaluating a comodule morphism out of the trivial comodule `R` at `1` yields an invariant
-vector: `ρ(f 1) = (f ⊗ id)(1 ⊗ g) = f 1 ⊗ g`. -/
-theorem Hom.map_one_mem_invariants (g : GroupLike R C)
+/-- Evaluating a comodule morphism out of the group-like comodule on `R` attached to `g` at
+`1` yields a coinvariant vector: `ρ(f 1) = (f ⊗ id)(1 ⊗ g) = f 1 ⊗ g`. -/
+theorem Hom.map_one_mem_coinvariants (g : GroupLike R C)
     (f : letI : Comodule R C R := Comodule.groupLike (R := R) (C := C) (M := R) g;
       Hom R C R M) :
     letI : Comodule R C R := Comodule.groupLike (R := R) (C := C) (M := R) g
-    f 1 ∈ invariants R C M g := by
+    f 1 ∈ coinvariants R C M g := by
   letI : Comodule R C R := Comodule.groupLike (R := R) (C := C) (M := R) g
-  rw [mem_invariants, ← Hom.map_coact_apply f 1, Comodule.groupLike_coact_apply,
+  rw [mem_coinvariants, ← Hom.map_coact_apply f 1, Comodule.groupLike_coact_apply,
     TensorProduct.map_tmul, LinearMap.id_apply, Hom.coe_toLinearMap]
 
-/-- The invariants of a comodule `M` are exactly the comodule morphisms from the trivial
-comodule `R`: `M^{coC} ≃ Hom(𝟙, M)`, the fixed vectors being the morphisms out of the unit
-representation. The equivalence sends an invariant vector `m` to `r ↦ r • m` and a morphism `f`
-to `f 1`. -/
-@[expose] noncomputable def invariantsEquivHom (g : GroupLike R C) :
+/-- The coinvariants of a comodule `M` relative to `g` are linearly equivalent to the
+comodule morphisms from the group-like comodule on `R` attached to `g`. The equivalence sends
+a coinvariant vector `m` to `r ↦ r • m` and a morphism `f` to `f 1`. -/
+@[expose] noncomputable def coinvariantsEquivHom (g : GroupLike R C) :
     letI : Comodule R C R := Comodule.groupLike (R := R) (C := C) (M := R) g
-    invariants R C M g ≃ Hom R C R M :=
+    coinvariants R C M g ≃ₗ[R] Hom R C R M :=
   letI : Comodule R C R := Comodule.groupLike (R := R) (C := C) (M := R) g
-  { toFun := Hom.ofInvariant g
-    invFun := fun f => ⟨f 1, Hom.map_one_mem_invariants g f⟩
-    left_inv := fun m => Subtype.ext (Hom.ofInvariant_one g m)
+  { toFun := Hom.ofCoinvariant g
+    invFun := fun f => ⟨f 1, Hom.map_one_mem_coinvariants g f⟩
+    left_inv := fun m => Subtype.ext (Hom.ofCoinvariant_one g m)
     right_inv := fun f => by
       apply Comodule.Hom.ext
       intro r
-      rw [Hom.ofInvariant_apply]
+      rw [Hom.ofCoinvariant_apply]
       calc
         r • f 1 = f.toLinearMap (r • 1) := (map_smul f.toLinearMap r 1).symm
         _ = f r := by
           rw [smul_eq_mul, mul_one]
-          rfl }
+          rfl
+    map_add' := fun m n => by
+      apply Comodule.Hom.ext
+      intro r
+      simp [smul_add]
+    map_smul' := fun r m => by
+      apply Comodule.Hom.ext
+      intro s
+      simp [smul_comm r s (m : M)] }
 
-/-- `invariantsEquivHom` sends an invariant vector `m` to the morphism `r ↦ r • m`. -/
+/-- `coinvariantsEquivHom` sends a coinvariant vector `m` to the morphism `r ↦ r • m`. -/
 @[simp]
-theorem invariantsEquivHom_apply (g : GroupLike R C) (m : invariants R C M g) :
+theorem coinvariantsEquivHom_apply (g : GroupLike R C) (m : coinvariants R C M g) :
     letI : Comodule R C R := Comodule.groupLike (R := R) (C := C) (M := R) g
-    invariantsEquivHom g m = Hom.ofInvariant g m :=
+    coinvariantsEquivHom g m = Hom.ofCoinvariant g m :=
   rfl
 
-/-- The inverse of `invariantsEquivHom` sends a morphism `f` to the invariant vector `f 1`. -/
+/-- The inverse of `coinvariantsEquivHom` sends a morphism `f` to the coinvariant vector
+`f 1`. -/
 @[simp]
-theorem invariantsEquivHom_symm_apply_coe (g : GroupLike R C)
+theorem coinvariantsEquivHom_symm_apply_coe (g : GroupLike R C)
     (f : letI : Comodule R C R := Comodule.groupLike (R := R) (C := C) (M := R) g;
       Hom R C R M) :
     letI : Comodule R C R := Comodule.groupLike (R := R) (C := C) (M := R) g
-    (invariantsEquivHom g).symm f = f 1 :=
+    (coinvariantsEquivHom g).symm f = f 1 :=
   rfl
 
 end UniversalProperty

--- a/TauCeti/Algebra/Coalgebra/Comodule/Invariants.lean
+++ b/TauCeti/Algebra/Coalgebra/Comodule/Invariants.lean
@@ -131,7 +131,8 @@ theorem mapInvariants_coe_apply (f : Hom R C M N) (m : invariants R C M) :
 /-- The invariants functor sends the identity morphism to the identity. -/
 @[simp]
 theorem mapInvariants_id :
-    mapInvariants (Hom.id R C M) = LinearMap.id := by
+    mapInvariants (CategoryTheory.CategoryStruct.id (ComoduleCat.of R C M)) = LinearMap.id := by
+  change mapInvariants (Hom.id R C (ComoduleCat.of R C M)) = LinearMap.id
   refine LinearMap.ext fun m => Subtype.ext ?_
   simp only [mapInvariants_coe_apply, Hom.id_apply, LinearMap.id_coe, id_eq]
 

--- a/TauCeti/Algebra/Coalgebra/Comodule/Invariants.lean
+++ b/TauCeti/Algebra/Coalgebra/Comodule/Invariants.lean
@@ -9,17 +9,18 @@ public import TauCeti.Algebra.Coalgebra.Comodule.Trivial
 /-!
 # Invariants of a comodule
 
-For a bialgebra `C` over `R` and a right `C`-comodule `M`, the **invariants** `M^{coC}` are the
-vectors fixed by the coaction: those `m : M` with `ρ(m) = m ⊗ 1`. Under the
-representation ⇆ comodule dictionary of the reductive-groups roadmap, a right `C`-comodule is a
-representation of the affine group scheme `Spec C`, and its invariants are exactly the fixed
-vectors of that representation (the vectors on which the group acts trivially). They are also
-the coinvariants `M^{coC}` of Hopf-algebra theory.
+For a coalgebra `C` over `R`, a group-like element `g : GroupLike R C`, and a right
+`C`-comodule `M`, the **invariants relative to `g`** are the vectors whose coaction is
+`ρ(m) = m ⊗ g`. In a bialgebra, the usual invariants are the specialization `g = 1`. Under the
+representation ⇆ comodule dictionary of the reductive-groups roadmap, these are the fixed
+vectors for the corresponding affine monoid scheme representation; in the Hopf-algebra case,
+this recovers the usual affine group scheme interpretation.
 
-The invariants form an `R`-submodule, cut out as the kernel of `ρ - (· ⊗ 1)`. Two structural
-facts pin the definition down: the trivial comodule (the coaction `m ↦ m ⊗ 1`) is all
-invariants, and comodule morphisms carry invariants to invariants, so `M ↦ M^{coC}` is
-functorial. On the regular comodule the unit `1 : C` is invariant, since `1` is group-like.
+The invariants form an `R`-submodule, the equalizer of the two linear maps `ρ` and
+`m ↦ m ⊗ g`. Two structural facts pin the definition down: the group-like comodule (the
+coaction `m ↦ m ⊗ g`) is all invariants, and comodule morphisms carry invariants to
+invariants, so `M ↦ M^{co g}` is functorial. On the regular comodule the element `g : C` is
+invariant, since `g` is group-like.
 
 This is Layer 1 infrastructure for the reductive-groups roadmap
 (`ReductiveGroups/README.md` in TauCetiRoadmap, "representations = comodules"): the invariants
@@ -35,9 +36,9 @@ trivial-comodule API.
 
 ## Main results
 
-* `TauCeti.Comodule.mem_invariants`: `m` is invariant iff `ρ(m) = m ⊗ 1`.
-* `TauCeti.Comodule.invariants_trivial`: the trivial comodule is all invariants.
-* `TauCeti.Comodule.one_mem_invariants_self`: `1` is invariant in the regular comodule.
+* `TauCeti.Comodule.mem_invariants`: `m` is invariant iff `ρ(m) = m ⊗ g`.
+* `TauCeti.Comodule.invariants_groupLike`: a group-like comodule is all invariants.
+* `TauCeti.Comodule.groupLike_mem_invariants_self`: `g` is invariant in the regular comodule.
 * `TauCeti.Comodule.Hom.map_mem_invariants`, `mapInvariants_id`, `mapInvariants_comp`:
   functoriality of the invariants.
 
@@ -60,16 +61,17 @@ universe u v w x y
 
 variable {R : Type u} {C : Type v} {M : Type w} {N : Type x} {P : Type y}
 variable [CommSemiring R]
-variable [Semiring C] [Bialgebra R C]
+variable [AddCommMonoid C] [Module R C] [Coalgebra R C]
 variable [AddCommMonoid M] [Module R M]
 variable [AddCommMonoid N] [Module R N]
 variable [AddCommMonoid P] [Module R P]
 
 variable (R C M) in
-/-- The invariants `M^{coC}` of a right `C`-comodule `M`: the `R`-submodule of vectors `m` with
-`ρ(m) = m ⊗ 1`. These are the fixed vectors of the representation `M` of `Spec C`. -/
-def invariants [Comodule R C M] : Submodule R M where
-  carrier := {m | coact (R := R) (C := C) (M := M) m = m ⊗ₜ[R] (1 : C)}
+/-- The invariants of a right `C`-comodule `M` relative to a group-like element
+`g : GroupLike R C`: the `R`-submodule of vectors `m` with `ρ(m) = m ⊗ g`. In a bialgebra,
+taking `g = 1` gives the usual invariant vectors. -/
+def invariants (g : GroupLike R C) [Comodule R C M] : Submodule R M where
+  carrier := {m | coact (R := R) (C := C) (M := M) m = m ⊗ₜ[R] (g : C)}
   add_mem' {a b} ha hb := by
     simp only [Set.mem_setOf_eq] at *
     rw [map_add, ha, hb, TensorProduct.add_tmul]
@@ -80,66 +82,72 @@ def invariants [Comodule R C M] : Submodule R M where
     simp only [Set.mem_setOf_eq] at *
     rw [map_smul, hm, TensorProduct.smul_tmul']
 
-/-- A vector is invariant exactly when its coaction is `m ⊗ 1`. -/
+/-- A vector is invariant exactly when its coaction is `m ⊗ g`. -/
 @[simp]
-theorem mem_invariants [Comodule R C M] {m : M} :
-    m ∈ invariants R C M ↔ coact (R := R) (C := C) (M := M) m = m ⊗ₜ[R] (1 : C) :=
+theorem mem_invariants (g : GroupLike R C) [Comodule R C M] {m : M} :
+    m ∈ invariants R C M g ↔ coact (R := R) (C := C) (M := M) m = m ⊗ₜ[R] (g : C) :=
   Iff.rfl
 
-/-- An invariant vector, unfolded: its coaction is `m ⊗ 1`. -/
-theorem coact_eq_of_mem_invariants [Comodule R C M] {m : M} (hm : m ∈ invariants R C M) :
-    coact (R := R) (C := C) (M := M) m = m ⊗ₜ[R] (1 : C) :=
-  mem_invariants.1 hm
+/-- An invariant vector, unfolded: its coaction is `m ⊗ g`. -/
+theorem coact_eq_of_mem_invariants (g : GroupLike R C) [Comodule R C M] {m : M}
+    (hm : m ∈ invariants R C M g) :
+    coact (R := R) (C := C) (M := M) m = m ⊗ₜ[R] (g : C) :=
+  (mem_invariants g).1 hm
 
-section Trivial
+section GroupLike
 
-attribute [local instance] Comodule.trivial
+variable (g : GroupLike R C)
 
-/-- The trivial comodule (coaction `m ↦ m ⊗ 1`) is all invariants. -/
-theorem invariants_trivial : invariants R C M = ⊤ := by
+/-- The group-like comodule (coaction `m ↦ m ⊗ g`) is all invariants. -/
+theorem invariants_groupLike :
+    letI : Comodule R C M := Comodule.groupLike (R := R) (C := C) (M := M) g
+    invariants R C M g = ⊤ := by
+  letI : Comodule R C M := Comodule.groupLike (R := R) (C := C) (M := M) g
   ext m
-  simp [mem_invariants]
+  simp
 
-end Trivial
+/-- The regular comodule has `g` among its invariants: `g` is group-like, so
+`Δ g = g ⊗ g`. -/
+theorem groupLike_mem_invariants_self : (g : C) ∈ invariants R C C g := by
+  rw [mem_invariants, instSelf_coact, g.isGroupLikeElem_val.comul_eq_tmul_self]
 
-/-- The regular comodule of a bialgebra has `1` among its invariants: `1` is group-like, so
-`Δ 1 = 1 ⊗ 1`. -/
-theorem one_mem_invariants_self : (1 : C) ∈ invariants R C C := by
-  rw [mem_invariants, instSelf_coact, Bialgebra.comul_one, Algebra.TensorProduct.one_def]
+end GroupLike
 
 namespace Hom
 
 variable [Comodule R C M] [Comodule R C N] [Comodule R C P]
 
-/-- Comodule morphisms carry invariants to invariants: if `ρ(m) = m ⊗ 1` then
-`ρ(f m) = (f ⊗ id)(m ⊗ 1) = f m ⊗ 1`. -/
-theorem map_mem_invariants (f : Hom R C M N) {m : M} (hm : m ∈ invariants R C M) :
-    f m ∈ invariants R C N := by
+/-- Comodule morphisms carry invariants to invariants: if `ρ(m) = m ⊗ g` then
+`ρ(f m) = (f ⊗ id)(m ⊗ g) = f m ⊗ g`. -/
+theorem map_mem_invariants (g : GroupLike R C) (f : Hom R C M N) {m : M}
+    (hm : m ∈ invariants R C M g) :
+    f m ∈ invariants R C N g := by
   rw [mem_invariants] at hm ⊢
   rw [← map_coact_apply f m, hm, TensorProduct.map_tmul, LinearMap.id_apply, coe_toLinearMap]
 
 /-- A comodule morphism restricted to invariants, as an `R`-linear map `M^{coC} → N^{coC}`. -/
-@[expose] def mapInvariants (f : Hom R C M N) : invariants R C M →ₗ[R] invariants R C N :=
-  f.toLinearMap.restrict fun _ hm => map_mem_invariants f hm
+def mapInvariants (g : GroupLike R C) (f : Hom R C M N) :
+    invariants R C M g →ₗ[R] invariants R C N g :=
+  f.toLinearMap.restrict fun _ hm => map_mem_invariants g f hm
 
 /-- `mapInvariants f` acts as the underlying map of `f` on invariant vectors. -/
 @[simp]
-theorem mapInvariants_coe_apply (f : Hom R C M N) (m : invariants R C M) :
-    (mapInvariants f m : N) = f (m : M) :=
+theorem mapInvariants_coe_apply (g : GroupLike R C) (f : Hom R C M N)
+    (m : invariants R C M g) :
+    (mapInvariants g f m : N) = f (m : M) :=
   LinearMap.coe_restrict_apply _ m
 
 /-- The invariants functor sends the identity morphism to the identity. -/
 @[simp]
-theorem mapInvariants_id :
-    mapInvariants (CategoryTheory.CategoryStruct.id (ComoduleCat.of R C M)) = LinearMap.id := by
-  change mapInvariants (Hom.id R C (ComoduleCat.of R C M)) = LinearMap.id
+theorem mapInvariants_id (g : GroupLike R C) :
+    mapInvariants g (Hom.id R C M) = LinearMap.id := by
   refine LinearMap.ext fun m => Subtype.ext ?_
   simp only [mapInvariants_coe_apply, Hom.id_apply, LinearMap.id_coe, id_eq]
 
 /-- The invariants functor preserves composition. -/
 @[simp]
-theorem mapInvariants_comp (g : Hom R C N P) (f : Hom R C M N) :
-    mapInvariants (g.comp f) = (mapInvariants g).comp (mapInvariants f) := by
+theorem mapInvariants_comp (g : GroupLike R C) (h : Hom R C N P) (f : Hom R C M N) :
+    mapInvariants g (h.comp f) = (mapInvariants g h).comp (mapInvariants g f) := by
   refine LinearMap.ext fun m => Subtype.ext ?_
   simp only [mapInvariants_coe_apply, Hom.comp_apply, LinearMap.comp_apply]
 
@@ -151,66 +159,78 @@ variable [Comodule R C M]
 
 /-- The comodule morphism `R → M` from the trivial comodule `R` determined by an invariant
 vector `m`, namely `r ↦ r • m`. -/
-@[expose] noncomputable def Hom.ofInvariant (m : invariants R C M) :
-    letI : Comodule R C R := Comodule.trivial
+noncomputable def Hom.ofInvariant (g : GroupLike R C) (m : invariants R C M g) :
+    letI : Comodule R C R := Comodule.groupLike (R := R) (C := C) (M := R) g
     Hom R C R M :=
-  letI : Comodule R C R := Comodule.trivial
+  letI : Comodule R C R := Comodule.groupLike (R := R) (C := C) (M := R) g
   { toLinearMap := LinearMap.toSpanSingleton R M (m : M)
     map_coact := by
       refine LinearMap.ext_ring ?_
-      simp only [LinearMap.comp_apply, Comodule.trivial_coact_apply, TensorProduct.map_tmul,
+      simp only [LinearMap.comp_apply, Comodule.groupLike_coact_apply, TensorProduct.map_tmul,
         LinearMap.toSpanSingleton_apply, LinearMap.id_coe, id_eq, one_smul,
-        coact_eq_of_mem_invariants m.2] }
+        coact_eq_of_mem_invariants g m.2] }
+
+/-- The morphism `Hom.ofInvariant g m` sends `r` to `r • m`. -/
+@[simp]
+theorem Hom.ofInvariant_apply (g : GroupLike R C) (m : invariants R C M g) (r : R) :
+    letI : Comodule R C R := Comodule.groupLike (R := R) (C := C) (M := R) g
+    (Hom.ofInvariant g m) r = r • (m : M) := by
+  letI : Comodule R C R := Comodule.groupLike (R := R) (C := C) (M := R) g
+  exact LinearMap.toSpanSingleton_apply R M (m : M) r
 
 /-- The value of `Hom.ofInvariant m` at `1` is `m`. -/
 @[simp]
-theorem Hom.ofInvariant_one (m : invariants R C M) :
-    letI : Comodule R C R := Comodule.trivial
-    (Hom.ofInvariant m) 1 = (m : M) := by
-  change LinearMap.toSpanSingleton R M (m : M) 1 = (m : M)
-  rw [LinearMap.toSpanSingleton_apply, one_smul]
+theorem Hom.ofInvariant_one (g : GroupLike R C) (m : invariants R C M g) :
+    letI : Comodule R C R := Comodule.groupLike (R := R) (C := C) (M := R) g
+    (Hom.ofInvariant g m) 1 = (m : M) := by
+  simp
 
 /-- Evaluating a comodule morphism out of the trivial comodule `R` at `1` yields an invariant
-vector: `ρ(f 1) = (f ⊗ id)(1 ⊗ 1) = f 1 ⊗ 1`. -/
-theorem Hom.one_mem_invariants (f : letI : Comodule R C R := Comodule.trivial; Hom R C R M) :
-    letI : Comodule R C R := Comodule.trivial
-    f 1 ∈ invariants R C M := by
-  letI : Comodule R C R := Comodule.trivial
-  rw [mem_invariants, ← Hom.map_coact_apply f 1, Comodule.trivial_coact_apply,
+vector: `ρ(f 1) = (f ⊗ id)(1 ⊗ g) = f 1 ⊗ g`. -/
+theorem Hom.map_one_mem_invariants (g : GroupLike R C)
+    (f : letI : Comodule R C R := Comodule.groupLike (R := R) (C := C) (M := R) g;
+      Hom R C R M) :
+    letI : Comodule R C R := Comodule.groupLike (R := R) (C := C) (M := R) g
+    f 1 ∈ invariants R C M g := by
+  letI : Comodule R C R := Comodule.groupLike (R := R) (C := C) (M := R) g
+  rw [mem_invariants, ← Hom.map_coact_apply f 1, Comodule.groupLike_coact_apply,
     TensorProduct.map_tmul, LinearMap.id_apply, Hom.coe_toLinearMap]
 
 /-- The invariants of a comodule `M` are exactly the comodule morphisms from the trivial
 comodule `R`: `M^{coC} ≃ Hom(𝟙, M)`, the fixed vectors being the morphisms out of the unit
 representation. The equivalence sends an invariant vector `m` to `r ↦ r • m` and a morphism `f`
 to `f 1`. -/
-@[expose] noncomputable def invariantsEquivHom :
-    letI : Comodule R C R := Comodule.trivial
-    invariants R C M ≃ Hom R C R M :=
-  letI : Comodule R C R := Comodule.trivial
-  { toFun := Hom.ofInvariant
-    invFun := fun f => ⟨f 1, Hom.one_mem_invariants f⟩
-    left_inv := fun m => Subtype.ext (Hom.ofInvariant_one m)
+@[expose] noncomputable def invariantsEquivHom (g : GroupLike R C) :
+    letI : Comodule R C R := Comodule.groupLike (R := R) (C := C) (M := R) g
+    invariants R C M g ≃ Hom R C R M :=
+  letI : Comodule R C R := Comodule.groupLike (R := R) (C := C) (M := R) g
+  { toFun := Hom.ofInvariant g
+    invFun := fun f => ⟨f 1, Hom.map_one_mem_invariants g f⟩
+    left_inv := fun m => Subtype.ext (Hom.ofInvariant_one g m)
     right_inv := fun f => by
       apply Comodule.Hom.ext
       intro r
-      change LinearMap.toSpanSingleton R M (f 1) r = f r
-      rw [LinearMap.toSpanSingleton_apply]
-      change r • f.toLinearMap 1 = f.toLinearMap r
-      rw [← map_smul, smul_eq_mul, mul_one] }
+      rw [Hom.ofInvariant_apply]
+      calc
+        r • f 1 = f.toLinearMap (r • 1) := (map_smul f.toLinearMap r 1).symm
+        _ = f r := by
+          rw [smul_eq_mul, mul_one]
+          rfl }
 
 /-- `invariantsEquivHom` sends an invariant vector `m` to the morphism `r ↦ r • m`. -/
 @[simp]
-theorem invariantsEquivHom_apply (m : invariants R C M) :
-    letI : Comodule R C R := Comodule.trivial
-    invariantsEquivHom m = Hom.ofInvariant m :=
+theorem invariantsEquivHom_apply (g : GroupLike R C) (m : invariants R C M g) :
+    letI : Comodule R C R := Comodule.groupLike (R := R) (C := C) (M := R) g
+    invariantsEquivHom g m = Hom.ofInvariant g m :=
   rfl
 
 /-- The inverse of `invariantsEquivHom` sends a morphism `f` to the invariant vector `f 1`. -/
 @[simp]
-theorem invariantsEquivHom_symm_apply_coe
-    (f : letI : Comodule R C R := Comodule.trivial; Hom R C R M) :
-    letI : Comodule R C R := Comodule.trivial
-    (invariantsEquivHom.symm f : M) = f 1 :=
+theorem invariantsEquivHom_symm_apply_coe (g : GroupLike R C)
+    (f : letI : Comodule R C R := Comodule.groupLike (R := R) (C := C) (M := R) g;
+      Hom R C R M) :
+    letI : Comodule R C R := Comodule.groupLike (R := R) (C := C) (M := R) g
+    (invariantsEquivHom g).symm f = f 1 :=
   rfl
 
 end UniversalProperty

--- a/TauCeti/Algebra/Coalgebra/Comodule/Invariants.lean
+++ b/TauCeti/Algebra/Coalgebra/Comodule/Invariants.lean
@@ -140,9 +140,9 @@ theorem mapInvariants_coe_apply (g : GroupLike R C) (f : Hom R C M N)
 /-- The invariants functor sends the identity morphism to the identity. -/
 @[simp]
 theorem mapInvariants_id (g : GroupLike R C) :
-    mapInvariants g (Hom.id R C M) = LinearMap.id := by
+    mapInvariants g (CategoryTheory.CategoryStruct.id (ComoduleCat.of R C M)) = LinearMap.id := by
   refine LinearMap.ext fun m => Subtype.ext ?_
-  simp only [mapInvariants_coe_apply, Hom.id_apply, LinearMap.id_coe, id_eq]
+  rfl
 
 /-- The invariants functor preserves composition. -/
 @[simp]
@@ -179,7 +179,6 @@ theorem Hom.ofInvariant_apply (g : GroupLike R C) (m : invariants R C M g) (r : 
   exact LinearMap.toSpanSingleton_apply R M (m : M) r
 
 /-- The value of `Hom.ofInvariant m` at `1` is `m`. -/
-@[simp]
 theorem Hom.ofInvariant_one (g : GroupLike R C) (m : invariants R C M g) :
     letI : Comodule R C R := Comodule.groupLike (R := R) (C := C) (M := R) g
     (Hom.ofInvariant g m) 1 = (m : M) := by

--- a/TauCeti/Algebra/Coalgebra/Comodule/MatrixCoefficientTrivial.lean
+++ b/TauCeti/Algebra/Coalgebra/Comodule/MatrixCoefficientTrivial.lean
@@ -163,12 +163,6 @@ variable {M : Type w} [AddCommMonoid M] [Module R M]
 
 attribute [local instance] trivial
 
-/-- The trivial comodule is the group-like comodule for the unit group-like element. -/
-theorem trivial_eq_groupLike_one :
-    (trivial (R := R) (C := C) (M := M) : Comodule R C M) =
-      groupLike (R := R) (C := C) (M := M) (1 : GroupLike R C) :=
-  rfl
-
 /-- A matrix coefficient of a trivial comodule lies in the line spanned by `1`. -/
 theorem trivial_matrixCoefficient_mem_span_singleton_one (φ : M →ₗ[R] R) (m : M) :
     matrixCoefficient (R := R) (C := C) φ m ∈ Submodule.span R ({1} : Set C) := by

--- a/TauCeti/Algebra/Coalgebra/Comodule/Trivial.lean
+++ b/TauCeti/Algebra/Coalgebra/Comodule/Trivial.lean
@@ -222,7 +222,7 @@ def trivial : Comodule R C M :=
   groupLike (R := R) (C := C) (M := M) (1 : GroupLike R C)
 
 /-- The trivial comodule is the group-like comodule for the unit group-like element. -/
-theorem trivial_eq_groupLike_one :
+public theorem trivial_eq_groupLike_one :
     (trivial (R := R) (C := C) (M := M) : Comodule R C M) =
       groupLike (R := R) (C := C) (M := M) (1 : GroupLike R C) :=
   rfl

--- a/TauCeti/Algebra/Coalgebra/Comodule/Trivial.lean
+++ b/TauCeti/Algebra/Coalgebra/Comodule/Trivial.lean
@@ -221,6 +221,12 @@ trivial one should be selected explicitly with `Comodule.trivial`. -/
 def trivial : Comodule R C M :=
   groupLike (R := R) (C := C) (M := M) (1 : GroupLike R C)
 
+/-- The trivial comodule is the group-like comodule for the unit group-like element. -/
+theorem trivial_eq_groupLike_one :
+    (trivial (R := R) (C := C) (M := M) : Comodule R C M) =
+      groupLike (R := R) (C := C) (M := M) (1 : GroupLike R C) :=
+  rfl
+
 section Trivial
 
 attribute [local instance] trivial


### PR DESCRIPTION
This PR adds the invariants `M^{coC}` of a right comodule `M` over a bialgebra `C`: the submodule of vectors fixed by the coaction, those `m` with `ρ(m) = m ⊗ 1`. Under the representation ⇆ comodule dictionary, a right `C`-comodule is a representation of the affine group scheme `Spec C`, and its invariants are exactly the fixed vectors of that representation (the coinvariants `M^{coC}` of Hopf-algebra theory). It defines the invariants as an `R`-submodule, characterizes membership, shows the trivial comodule is all invariants and that `1` is invariant in the regular comodule, and proves the invariants are functorial in comodule morphisms (`mapInvariants`, with `mapInvariants_id`/`mapInvariants_comp`). It closes with the canonical universal property `invariantsEquivHom : M^{coC} ≃ Hom(𝟙, M)`, identifying invariant vectors with comodule morphisms out of the trivial (unit) comodule `R`.

This advances the reductive-groups roadmap `TauCetiRoadmap/ReductiveGroups/README.md`, Layer 1 ("representations = comodules"): the invariants functor `V ↦ V^{coC}` is the comodule-theoretic fixed-point functor, a prerequisite for the complete-reducibility (linear reductivity) statements of Layer 6 and for the Hom-space computations underlying Tannakian reconstruction. It builds on the existing Tau Ceti comodule and trivial-comodule API and Mathlib's bialgebra infrastructure (`Bialgebra.comul_one`, `LinearMap.toSpanSingleton`).

<!--tauceti-target:v1 {"focus":"ReductiveGroups","id":"comodule-invariants"}-->

🤖 Prepared with Claude Code
