### PR TITLE
feat: tail-level factorization via reverse-martingale limit (CI-5)

### DIFF
--- a/TauCeti/Probability/DeFinetti/TailFactorization.lean
+++ b/TauCeti/Probability/DeFinetti/TailFactorization.lean
@@ -44,7 +44,7 @@ given the tail σ-algebra `tailProcess X` factors:
 This passes the finite-level future factorization to the tail using reverse-martingale (Lévy
 downward) convergence along the antitone future family `tailFamily X`. -/
 lemma condExp_blockIndicatorProd_tail_factor
-    [StandardBorelSpace Ω] [StandardBorelSpace α]
+    [StandardBorelSpace Ω]
     {μ : Measure Ω} [IsFiniteMeasure μ]
     (X : ℕ → Ω → α) (hX : Contractable μ X) (hX_meas : ∀ n, Measurable (X n))
     (r : ℕ) (C : Fin r → Set α) (hC : ∀ i, MeasurableSet (C i)) :

--- a/TauCeti/Probability/DeFinetti/TailFactorization.lean
+++ b/TauCeti/Probability/DeFinetti/TailFactorization.lean
@@ -1,8 +1,15 @@
 module
 
-public import TauCeti.Probability.DeFinetti.FutureFactorization
--- Non-public: `tendsto_ae_condExp_iInf` (Lévy's downward theorem) is used only inside the proof
--- below, not in the exported statement of `condExp_blockIndicatorProd_tailProcess_ae_eq_prod`.
+-- Public: the modules whose symbols appear in the exported statement.
+public import Mathlib.MeasureTheory.Function.ConditionalExpectation.Basic
+public import Mathlib.MeasureTheory.Constructions.Polish.Basic
+public import TauCeti.Probability.Process.Tail
+public import TauCeti.Probability.Exchangeability.Cylinder
+public import TauCeti.Probability.Exchangeability.Contractability
+-- Non-public: used only inside the proof, absent from the exported statement —
+-- `condExp_blockIndicatorProd_future_ae_eq_prod` (finite-level factorization) and
+-- `tendsto_ae_condExp_iInf` (Lévy's downward theorem).
+import TauCeti.Probability.DeFinetti.FutureFactorization
 import TauCeti.Probability.Martingale.Convergence
 
 /-!

--- a/TauCeti/Probability/DeFinetti/TailFactorization.lean
+++ b/TauCeti/Probability/DeFinetti/TailFactorization.lean
@@ -1,0 +1,106 @@
+module
+
+public import TauCeti.Probability.DeFinetti.FutureFactorization
+public import TauCeti.Probability.Martingale.Convergence
+
+/-!
+# Tail-level factorization for the de Finetti martingale route
+
+For a contractable process `X`, this file passes the finite-level future factorization
+(`condExp_blockIndicatorProd_future_ae_eq_prod`, at `tailFamily X (m+1)`) to the **tail** σ-algebra
+`tailProcess X`, by Lévy's downward theorem (`tendsto_ae_condExp_iInf`) along the
+antitone future family.
+
+## Main result
+
+* `condExp_blockIndicatorProd_tail_factor` — for a contractable process, the conditional expectation
+  of the length-`r` prefix indicator product given the tail σ-algebra factors as the product of the
+  single-coordinate (all replaced by `X 0`) tail conditional expectations.
+
+Adapted from `cameronfreer/exchangeability`
+(`DeFinetti/ViaMartingale/Factorization.lean`: `tail_factorization_from_future`).
+-/
+
+public section
+
+noncomputable section
+
+open MeasureTheory ProbabilityTheory Filter
+open scoped MeasureTheory Topology
+
+namespace TauCeti
+
+namespace Probability
+
+variable {Ω α : Type*} [MeasurableSpace Ω] [MeasurableSpace α]
+
+/-- **Tail-level factorization.**
+
+For a contractable process, the conditional expectation of the length-`r` prefix indicator product
+given the tail σ-algebra `tailProcess X` factors:
+```
+μ[∏ i<r 𝟙_{X i ∈ C i} | 𝒯_X] = ∏ i<r μ[𝟙_{X 0 ∈ C i} | 𝒯_X]   a.e.
+```
+This passes the finite-level future factorization to the tail using reverse-martingale (Lévy
+downward) convergence along the antitone future family `tailFamily X`. -/
+lemma condExp_blockIndicatorProd_tail_factor
+    [StandardBorelSpace Ω] [StandardBorelSpace α]
+    {μ : Measure Ω} [IsFiniteMeasure μ]
+    (X : ℕ → Ω → α) (hX : Contractable μ X) (hX_meas : ∀ n, Measurable (X n))
+    (r : ℕ) (C : Fin r → Set α) (hC : ∀ i, MeasurableSet (C i)) :
+    μ[blockIndicatorProd X (fun i : Fin r => (i : ℕ)) C | tailProcess X]
+      =ᵐ[μ]
+    (fun ω => ∏ i : Fin r,
+      μ[Set.indicator (C i) (fun _ => (1 : ℝ)) ∘ X 0 | tailProcess X] ω) := by
+  classical
+  -- Reverse-martingale convergence: `μ[f | tailFamily X (m+1)] → μ[f | tailProcess X]` a.e.
+  have hconv : ∀ f : Ω → ℝ, Integrable f μ → ∀ᵐ ω ∂μ,
+      Tendsto (fun m => μ[f | tailFamily X (m + 1)] ω) atTop
+        (𝓝 (μ[f | tailProcess X] ω)) := by
+    intro f hf
+    -- `tendsto_ae_condExp_iInf` takes the index-0 bound `𝔽 0 ≤ m₀` (antitonicity supplies the rest)
+    -- and the integrability of `f`.
+    have h := tendsto_ae_condExp_iInf (μ := μ) (tailFamily_antitone X)
+      (tailFamily_le_ambient 0 fun k _ => hX_meas k) f hf
+    rw [← tailProcess_eq_iInf_tailFamily X] at h
+    filter_upwards [h] with ω hω using hω.comp (tendsto_add_atTop_nat 1)
+  -- The integrands are bounded indicators, hence integrable under the finite measure.
+  have hint_coord : ∀ i : Fin r, Integrable (Set.indicator (C i) (fun _ => (1 : ℝ)) ∘ X 0) μ := by
+    intro i
+    have heq : (Set.indicator (C i) (fun _ => (1 : ℝ)) ∘ X 0)
+        = (X 0 ⁻¹' C i).indicator (fun _ => (1 : ℝ)) := by
+      ext ω; simp only [Function.comp_apply, Set.indicator, Set.mem_preimage]
+    rw [heq]; exact (integrable_const (1 : ℝ)).indicator ((hX_meas 0) (hC i))
+  -- LHS converges to the tail conditional expectation of the block.
+  have h_lhs := hconv (blockIndicatorProd X (fun i : Fin r => (i : ℕ)) C)
+    (integrable_blockIndicatorProd (fun i => (hX_meas _).aemeasurable) hC)
+  -- RHS: the finite product of the convergent single-coordinate factors converges.
+  have h_rhs : ∀ᵐ ω ∂μ,
+      Tendsto (fun m => ∏ i : Fin r,
+          μ[Set.indicator (C i) (fun _ => (1 : ℝ)) ∘ X 0 | tailFamily X (m + 1)] ω) atTop
+        (𝓝 (∏ i : Fin r,
+          μ[Set.indicator (C i) (fun _ => (1 : ℝ)) ∘ X 0 | tailProcess X] ω)) := by
+    have hfac : ∀ᵐ ω ∂μ, ∀ i : Fin r,
+        Tendsto (fun m => μ[Set.indicator (C i) (fun _ => (1 : ℝ)) ∘ X 0
+            | tailFamily X (m + 1)] ω) atTop
+          (𝓝 (μ[Set.indicator (C i) (fun _ => (1 : ℝ)) ∘ X 0 | tailProcess X] ω)) :=
+      ae_all_iff.mpr fun i => hconv _ (hint_coord i)
+    filter_upwards [hfac] with ω hω using tendsto_finsetProd _ fun i _ => hω i
+  -- Equality of the two sequences at each finite level `m ≥ r`.
+  have h_fact : ∀ᵐ ω ∂μ, ∀ m, r ≤ m →
+      μ[blockIndicatorProd X (fun i : Fin r => (i : ℕ)) C | tailFamily X (m + 1)] ω
+        = ∏ i : Fin r,
+            μ[Set.indicator (C i) (fun _ => (1 : ℝ)) ∘ X 0 | tailFamily X (m + 1)] ω := by
+    rw [ae_all_iff]
+    intro m
+    by_cases hm : r ≤ m
+    · filter_upwards [condExp_blockIndicatorProd_future_ae_eq_prod X hX hX_meas m r C hC (by omega)]
+        with ω hω _ using hω
+    · exact ae_of_all _ fun ω h => absurd h hm
+  filter_upwards [h_lhs, h_rhs, h_fact] with ω hl hr hf
+  refine tendsto_nhds_unique hl (hr.congr' ?_)
+  filter_upwards [eventually_ge_atTop r] with m hm using (hf m hm).symm
+
+end Probability
+
+end TauCeti

--- a/TauCeti/Probability/DeFinetti/TailFactorization.lean
+++ b/TauCeti/Probability/DeFinetti/TailFactorization.lean
@@ -1,21 +1,22 @@
 module
 
 public import TauCeti.Probability.DeFinetti.FutureFactorization
-public import TauCeti.Probability.Martingale.Convergence
+-- Non-public: `tendsto_ae_condExp_iInf` (Lévy's downward theorem) is used only inside the proof
+-- below, not in the exported statement of `condExp_blockIndicatorProd_tailProcess_ae_eq_prod`.
+import TauCeti.Probability.Martingale.Convergence
 
 /-!
 # Tail-level factorization for the de Finetti martingale route
 
-For a contractable process `X`, this file passes the finite-level future factorization
-(`condExp_blockIndicatorProd_future_ae_eq_prod`, at `tailFamily X (m+1)`) to the **tail** σ-algebra
-`tailProcess X`, by Lévy's downward theorem (`tendsto_ae_condExp_iInf`) along the
-antitone future family.
+For a contractable process `X`, this file factors the conditional expectation of a prefix indicator
+product given the **tail** σ-algebra `tailProcess X` into a product of single-coordinate tail
+conditional expectations — the tail-level input to the de Finetti martingale route.
 
 ## Main result
 
-* `condExp_blockIndicatorProd_tail_factor` — for a contractable process, the conditional expectation
-  of the length-`r` prefix indicator product given the tail σ-algebra factors as the product of the
-  single-coordinate (all replaced by `X 0`) tail conditional expectations.
+* `condExp_blockIndicatorProd_tailProcess_ae_eq_prod` — for a contractable process, the conditional
+  expectation of the length-`r` prefix indicator product given the tail σ-algebra factors as the
+  product of the single-coordinate (all replaced by `X 0`) tail conditional expectations.
 
 Adapted from `cameronfreer/exchangeability`
 (`DeFinetti/ViaMartingale/Factorization.lean`: `tail_factorization_from_future`).
@@ -40,10 +41,8 @@ For a contractable process, the conditional expectation of the length-`r` prefix
 given the tail σ-algebra `tailProcess X` factors:
 ```
 μ[∏ i<r 𝟙_{X i ∈ C i} | 𝒯_X] = ∏ i<r μ[𝟙_{X 0 ∈ C i} | 𝒯_X]   a.e.
-```
-This passes the finite-level future factorization to the tail using reverse-martingale (Lévy
-downward) convergence along the antitone future family `tailFamily X`. -/
-lemma condExp_blockIndicatorProd_tail_factor
+``` -/
+lemma condExp_blockIndicatorProd_tailProcess_ae_eq_prod
     [StandardBorelSpace Ω]
     {μ : Measure Ω} [IsFiniteMeasure μ]
     (X : ℕ → Ω → α) (hX : Contractable μ X) (hX_meas : ∀ n, Measurable (X n))


### PR DESCRIPTION
<!--tauceti-target:v1 {"focus":"Exchangeability","id":"tail-factorization"}-->

## Summary

Adds `TauCeti/Probability/DeFinetti/TailFactorization.lean` — the **tail-level factorization** for
the de Finetti martingale route (`namespace TauCeti.Probability`):

- `condExp_blockIndicatorProd_tailProcess_ae_eq_prod` — for a contractable process `X`, the conditional
  expectation of the length-`r` prefix indicator product given the **tail** σ-algebra
  `tailProcess X` factors as the product of single-coordinate tail conditional expectations (every
  coordinate replaced by `X 0`):
  ```
  μ[∏ i<r 𝟙_{X i ∈ C i} | 𝒯_X] =ᵐ ∏ i<r μ[𝟙_{X 0 ∈ C i} | 𝒯_X].
  ```

## How it's proved (reuse)

Passes the **finite-level future factorization** to the tail by a reverse-martingale limit:
- the merged finite factorization `condExp_blockIndicatorProd_future_ae_eq_prod` holds at each
  future level `tailFamily X (m+1)` (for `r ≤ m`);
- Lévy's downward theorem `tendsto_ae_condExp_iInf` (merged) gives
  `μ[f | tailFamily X (m+1)] → μ[f | tailProcess X]` a.e. along the antitone future family
  (`tailFamily_antitone`, `tailProcess_eq_iInf_tailFamily`);
- both sides converge (the RHS finite product via `tendsto_finsetProd`), agree at every level
  `m ≥ r`, so uniqueness of a.e. limits (`tendsto_nhds_unique`) identifies the tail-level equality.

Integrability of the bounded indicator integrands (needed by `tendsto_ae_condExp_iInf`) is supplied
by `integrable_blockIndicatorProd` + `Integrable.indicator` under the finite measure.

## Roadmap

Advances `TauCetiRoadmap/Exchangeability` toward **Layer 6** (directing measure → de Finetti): the
tail-conditional factorization consumed by the directing-measure construction (CI-6).

## Generality

`[StandardBorelSpace Ω] [IsFiniteMeasure μ]` — finite measure (strict generalization of the source
probability measure); `[StandardBorelSpace Ω]` is the *sole* standard-Borel hypothesis, internal to
the reverse-martingale route via the merged `condExp_blockIndicatorProd_future_ae_eq_prod` (discharged
at the summit by path-space transfer). **No** standard-Borel assumption on the value space `α`: the
statement is about real indicator conditional expectations and its inputs don't require it.

## Dependency

Consumes the merged reverse-martingale foundation: `condExp_blockIndicatorProd_future_ae_eq_prod`
(future factorization), `tendsto_ae_condExp_iInf` (Lévy downward), `blockIndicatorProd` /
`integrable_blockIndicatorProd` (cylinder API), `tailProcess` / `tailFamily_antitone` /
`tailProcess_eq_iInf_tailFamily` (tail σ-algebras). Off current `main`.

## Test plan
```bash
lake build && lake exe axioms && lake exe module-system && bash scripts/lint-env.sh
```
All pass; sorry-free; `condExp_blockIndicatorProd_tailProcess_ae_eq_prod` axioms ⊆
{`propext`, `Classical.choice`, `Quot.sound`}; lines ≤100.

## Attribution
Adapted from `cameronfreer/exchangeability` (`DeFinetti/ViaMartingale/Factorization.lean`,
`tail_factorization_from_future`), pin `e0532e59ceff23edab44dda9ab0655debbc9cc22`. Drafted with
Claude (Opus 4.8), human-directed.
