### PR TITLE
feat: based-path space and discreteness of homotopy-class fibres

### DIFF
--- a/TauCeti/AlgebraicTopology/SemilocallySimplyConnectedOn.lean
+++ b/TauCeti/AlgebraicTopology/SemilocallySimplyConnectedOn.lean
@@ -1,0 +1,1018 @@
+/-
+Copyright (c) 2026 Lean FRO, LLC. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Kim Morrison
+-/
+module
+
+public import TauCeti.AlgebraicTopology.SemilocallySimplyConnected
+public import TauCeti.AlgebraicTopology.UniversalCover.Prelude
+public import Mathlib.AlgebraicTopology.FundamentalGroupoid.FundamentalGroup
+public import Mathlib.AlgebraicTopology.FundamentalGroupoid.SimplyConnected
+public import Mathlib.Topology.Path
+public import Mathlib.Topology.Homotopy.Path
+public import Mathlib.Topology.Constructions
+public import Mathlib.Topology.Order
+public import Mathlib.Topology.Defs.Induced
+public import Mathlib.Topology.Connected.LocallyPathConnected
+public import Mathlib.Topology.UnitInterval
+
+/-!
+# Semilocally simple connectivity at a point and on a set; discreteness of homotopy fibres
+
+This file develops the *unbased, pointwise* form of semilocal simple connectivity and the tube
+machinery it powers, culminating in the discreteness of homotopy-class fibres. It is the
+companion of `TauCeti.AlgebraicTopology.SemilocallySimplyConnected`, which defines the *based*
+class `TauCeti.SemilocallySimplyConnectedSpace`.
+
+`SemilocallySimplyConnectedAt x` is Brazas' *unbased* notion (Definition 2.2 in
+https://arxiv.org/abs/1102.0993): `x` has a neighbourhood `U` in which every loop, based at any
+point of `U`, is null-homotopic in the ambient space. It is strictly stronger than the based
+class, but the two coincide on locally path-connected spaces
+(`SemilocallySimplyConnectedAt.of_semilocallySimplyConnectedSpace`), which is the setting for
+covering-space theory.
+
+This file is adapted from the Mathlib drafts
+[#31449](https://github.com/leanprover-community/mathlib4/pull/31449) and
+[#31576](https://github.com/leanprover-community/mathlib4/pull/31576) by Kim Morrison; it
+advances Stage 0.1 of the `TauCetiRoadmap/UniversalCovers` roadmap.
+
+## Main definitions
+
+* `SemilocallySimplyConnectedAt x` - The unbased property at a single point.
+* `SemilocallySimplyConnectedOn s` - The unbased property at every point of `s`.
+* `IsPathHomotopyTrivial U` - Any two paths in `U` with matching endpoints are homotopic in `X`.
+* `IntervalPartition`, `TubeData`, `PathInTube` - the tube data around a path.
+
+## Main theorems
+
+* `semilocallySimplyConnectedAt_iff` - Characterization in terms of loops being nullhomotopic.
+* `semilocallySimplyConnectedAt_iff_paths` - Characterization: there exists a neighbourhood `U`
+  such that any two paths in `U` between the same endpoints are homotopic.
+* `SemilocallySimplyConnectedAt.of_semilocallySimplyConnectedSpace` - on a locally
+  path-connected space, the based class `TauCeti.SemilocallySimplyConnectedSpace` implies the
+  unbased pointwise predicate.
+* `Path.Homotopic.Quotient.instDiscreteTopology` - In a semilocally simply connected,
+  locally path-connected space, the quotient of paths by homotopy has the discrete topology.
+-/
+
+noncomputable section
+
+open CategoryTheory Filter FundamentalGroupoid Set Topology TauCeti
+
+variable {X : Type*} [TopologicalSpace X]
+
+/-! ### SemilocallySimplyConnectedAt -/
+
+/-- A space is semilocally simply connected at `x` if `x` has a neighborhood `U` such that
+the map from `π₁(U, base)` to `π₁(X, base)` induced by the inclusion is trivial for all
+basepoints in `U`. Equivalently, every loop in `U` is nullhomotopic in `X`. -/
+public def SemilocallySimplyConnectedAt (x : X) : Prop :=
+  ∃ U ∈ 𝓝 x, ∀ (base : U),
+    (FundamentalGroup.map (⟨Subtype.val, continuous_subtype_val⟩ : C(U, X)) base).range = ⊥
+
+/-- Simply connected spaces are semilocally simply connected at every point. -/
+public theorem SemilocallySimplyConnectedAt.of_simplyConnected [SimplyConnectedSpace X] (x : X) :
+    SemilocallySimplyConnectedAt x :=
+  ⟨univ, univ_mem, fun base ↦ by
+    simp only [MonoidHom.range_eq_bot_iff]
+    ext
+    exact Subsingleton.elim (α := Path.Homotopic.Quotient base.val base.val) _ _⟩
+
+/-- Characterization of `SemilocallySimplyConnectedAt x` by open neighborhoods whose loops are
+nullhomotopic in the ambient space. -/
+public theorem semilocallySimplyConnectedAt_iff {x : X} :
+    SemilocallySimplyConnectedAt x ↔
+    ∃ U : Set X, IsOpen U ∧ x ∈ U ∧
+      ∀ {u : X} (γ : Path u u) (_ : range γ ⊆ U),
+        Path.Homotopic γ (Path.refl u) := by
+  constructor
+  · -- Forward direction: SemilocallySimplyConnectedAt implies small loops are null
+    intro ⟨U, hU_nhd, hU_loops⟩
+    obtain ⟨V, hVU, hV_open, hx_in_V⟩ := mem_nhds_iff.mp hU_nhd
+    refine ⟨V, hV_open, hx_in_V, ?_⟩
+    intro u γ hγ_range
+    -- Since range γ ⊆ V ⊆ U, γ takes values in U
+    have hγ_mem : ∀ t, γ t ∈ U := fun t ↦ hVU (hγ_range ⟨t, rfl⟩)
+    -- Restrict γ to a path in the subspace U
+    let γ_U : Path (⟨u, γ.source ▸ hγ_mem 0⟩ : U) ⟨u, γ.target ▸ hγ_mem 1⟩ := γ.codRestrict hγ_mem
+    -- The basepoint u' : U
+    let u' : U := ⟨u, γ.source ▸ hγ_mem 0⟩
+    -- The map from π₁(U, u') to π₁(X, u) has trivial range
+    have h_range := hU_loops u'
+    rw [MonoidHom.range_eq_bot_iff] at h_range
+    have h_map_eq : FundamentalGroup.map ⟨Subtype.val, continuous_subtype_val⟩ u'
+        (FundamentalGroup.fromPath ⟦γ_U⟧) =
+      FundamentalGroup.fromPath ⟦γ_U.map continuous_subtype_val⟧ := rfl
+    have h_map : FundamentalGroup.fromPath ⟦γ_U.map continuous_subtype_val⟧ =
+        FundamentalGroup.fromPath ⟦Path.refl u⟧ := by
+      rw [← h_map_eq, h_range]; rfl
+    rw [Path.map_codRestrict] at h_map
+    exact Quotient.eq.mp h_map
+  · -- Backward direction: small loops null implies SemilocallySimplyConnectedAt
+    intro ⟨U, hU_open, hx_in_U, hU_loops_null⟩
+    refine ⟨U, hU_open.mem_nhds hx_in_U, ?_⟩; intro base
+    simp only [MonoidHom.range_eq_bot_iff]; ext p
+    obtain ⟨γ', rfl⟩ := Quotient.exists_rep (FundamentalGroup.toPath p)
+    have hrange : range (γ'.map continuous_subtype_val) ⊆ U := by
+      rintro _ ⟨t, rfl⟩
+      exact (γ' t).property
+    have hhom := hU_loops_null (γ'.map continuous_subtype_val) hrange
+    have h_map_eq : FundamentalGroup.map ⟨Subtype.val, continuous_subtype_val⟩ base
+        (FundamentalGroup.fromPath ⟦γ'⟧) =
+      FundamentalGroup.fromPath ⟦γ'.map continuous_subtype_val⟧ := rfl
+    rw [h_map_eq, Quotient.sound hhom]
+    rfl
+
+/-- Characterization of semilocally simply connected at a point: any two paths in U between
+the same endpoints are homotopic. -/
+public theorem semilocallySimplyConnectedAt_iff_paths {x : X} :
+    SemilocallySimplyConnectedAt x ↔
+    ∃ U : Set X, IsOpen U ∧ x ∈ U ∧
+      ∀ {u u' : X} (γ γ' : Path u u'),
+        range γ ⊆ U → range γ' ⊆ U → γ.Homotopic γ' := by
+  rw [semilocallySimplyConnectedAt_iff]
+  constructor
+  · intro ⟨U, hU_open, hx_in_U, hU_loops⟩
+    refine ⟨U, hU_open, hx_in_U, ?_⟩
+    intro u u' γ γ' hγ hγ'
+    -- γ.trans γ'.symm is a loop in U, hence nullhomotopic
+    have hloop : range (γ.trans γ'.symm) ⊆ U := by
+      intro y hy
+      simp only [Path.trans_range, Path.symm_range] at hy
+      exact hy.elim (fun h ↦ hγ h) (fun h ↦ hγ' h)
+    have hnull := hU_loops (γ.trans γ'.symm) hloop
+    exact Path.Homotopic.of_trans_symm hnull
+  · intro ⟨U, hU_open, hx_in_U, hU_paths⟩
+    refine ⟨U, hU_open, hx_in_U, ?_⟩
+    intro u γ hγ
+    have hrefl : range (Path.refl u) ⊆ U := by
+      simp only [Path.refl_range, singleton_subset_iff]
+      exact hγ ⟨0, γ.source⟩
+    exact hU_paths γ (Path.refl u) hγ hrefl
+
+/-! ### SemilocallySimplyConnectedOn -/
+
+variable {s t : Set X} {x : X}
+
+/-- A space is semilocally simply connected on `s` if it is semilocally simply connected
+at every point of `s`. -/
+public def SemilocallySimplyConnectedOn (s : Set X) : Prop :=
+  ∀ x ∈ s, SemilocallySimplyConnectedAt x
+
+public theorem SemilocallySimplyConnectedOn.at (h : SemilocallySimplyConnectedOn s) (hx : x ∈ s) :
+    SemilocallySimplyConnectedAt x :=
+  h x hx
+
+public theorem SemilocallySimplyConnectedOn.mono (h : SemilocallySimplyConnectedOn t)
+    (hst : s ⊆ t) : SemilocallySimplyConnectedOn s :=
+  fun x hx ↦ h x (hst hx)
+
+/-- A subset `U` of a topological space `X` is *path-homotopy-trivial* if any two paths
+in `X` whose images lie in `U` and which share endpoints are homotopic in `X`.
+This is the form of "`U` is simply connected" used in the universal-cover
+construction: it is weaker than `IsSimplyConnected U` because the homotopy is not required
+to lie inside `U`. -/
+public def IsPathHomotopyTrivial (U : Set X) : Prop :=
+  ∀ ⦃a b : X⦄ (p q : Path a b), range p ⊆ U → range q ⊆ U → Path.Homotopic p q
+
+public theorem isPathHomotopyTrivial_iff {U : Set X} :
+    IsPathHomotopyTrivial U ↔
+      ∀ ⦃a b : X⦄ (p q : Path a b), range p ⊆ U → range q ⊆ U → Path.Homotopic p q :=
+  Iff.rfl
+
+public theorem IsPathHomotopyTrivial.apply {U : Set X} (hU : IsPathHomotopyTrivial U)
+    ⦃a b : X⦄ (p q : Path a b) (hp : range p ⊆ U) (hq : range q ⊆ U) :
+    Path.Homotopic p q :=
+  hU p q hp hq
+public theorem IsPathHomotopyTrivial.mk {U : Set X}
+    (hU : ∀ ⦃a b : X⦄ (p q : Path a b), range p ⊆ U → range q ⊆ U →
+      Path.Homotopic p q) :
+    IsPathHomotopyTrivial U :=
+  hU
+
+public theorem semilocallySimplyConnectedOn_iff :
+    SemilocallySimplyConnectedOn s ↔
+    ∀ x ∈ s, ∃ U : Set X, IsOpen U ∧ x ∈ U ∧
+      ∀ {u : X} (γ : Path u u) (_ : range γ ⊆ U),
+        Path.Homotopic γ (Path.refl u) :=
+  forall₂_congr fun _ _ ↦ semilocallySimplyConnectedAt_iff
+
+public theorem semilocallySimplyConnectedOn_iff_paths :
+    SemilocallySimplyConnectedOn s ↔
+    ∀ x ∈ s, ∃ U : Set X, IsOpen U ∧ x ∈ U ∧
+      ∀ {u u' : X} (γ γ' : Path u u'),
+        range γ ⊆ U → range γ' ⊆ U → γ.Homotopic γ' :=
+  forall₂_congr fun _ _ ↦ semilocallySimplyConnectedAt_iff_paths
+
+/-! ### Bridging to `TauCeti.SemilocallySimplyConnectedSpace`
+
+The class `TauCeti.SemilocallySimplyConnectedSpace` (see
+`TauCeti.AlgebraicTopology.SemilocallySimplyConnected`) records the *based* form of semilocal
+simple connectivity (Brazas, Definition 2.1): every point `x` has a neighbourhood in which every
+loop *based at `x`* is null-homotopic in `X`. The `SemilocallySimplyConnectedAt` predicate above
+is the *unbased* form (Brazas, Definition 2.2), asking the same of loops based at *any* point of
+the neighbourhood. The two coincide on locally path-connected spaces, which is the setting for
+covering-space theory, so the bridge below is stated under `[LocallyPathConnectedSpace X]`. -/
+
+/-- On a locally path-connected space, the based class
+`TauCeti.SemilocallySimplyConnectedSpace` implies the unbased pointwise predicate
+`SemilocallySimplyConnectedAt` at every point.
+
+Given a based neighbourhood `U` of `x` in which every loop at `x` is null-homotopic, the path
+component `U'` of `x` in `U` is open (local path-connectedness), path-connected, and contained in
+`U`. Any loop `γ` based at `u ∈ U'` is conjugated by a path `δ : x ⤳ u` inside `U'` to a loop at
+`x` with range in `U`, which is null-homotopic; conjugating back kills `γ`. -/
+public theorem SemilocallySimplyConnectedAt.of_semilocallySimplyConnectedSpace
+    [LocallyPathConnectedSpace X] [SemilocallySimplyConnectedSpace X] (x : X) :
+    SemilocallySimplyConnectedAt x := by
+  obtain ⟨U, hUopen, hxU, hloop⟩ :=
+    SemilocallySimplyConnectedSpace.exists_isOpen_mem_nhds_loops_nullhomotopic x
+  refine semilocallySimplyConnectedAt_iff.mpr
+    ⟨pathComponentIn U x, hUopen.pathComponentIn x, mem_pathComponentIn_self hxU, ?_⟩
+  intro u γ hγ
+  -- `γ` is a loop at `u` with range in the path component `U'` of `x`.
+  have hu : u ∈ pathComponentIn U x := hγ ⟨0, γ.source⟩
+  -- Join `x` to `u` inside `U'`.
+  obtain ⟨δ, hδ⟩ :=
+    (isPathConnected_pathComponentIn hxU).exists_path (mem_pathComponentIn_self hxU) hu
+  -- The conjugated loop `(δ.trans γ).trans δ.symm` is based at `x` and has range in `U`.
+  have hδU : ∀ s, δ s ∈ pathComponentIn U x := fun s ↦ hδ ⟨s, rfl⟩
+  have hsub : Set.range ((δ.trans γ).trans δ.symm) ⊆ pathComponentIn U x := by
+    rw [Path.trans_range, Path.trans_range, Path.symm_range]
+    exact Set.union_subset (Set.union_subset (fun _ ⟨s, hs⟩ ↦ hs ▸ hδU s) hγ)
+      (fun _ ⟨s, hs⟩ ↦ hs ▸ hδU s)
+  have hconj : ((δ.trans γ).trans δ.symm).Homotopic (Path.refl x) :=
+    hloop _ fun t ↦ pathComponentIn_subset (hsub ⟨t, rfl⟩)
+  -- Recover `γ ≃ refl u` from the conjugation.
+  -- `of_trans_symm` on `p = δ.trans γ`, `q = δ`: `δ.trans γ ≃ δ`.
+  have hδγ : (δ.trans γ).Homotopic δ := Path.Homotopic.of_trans_symm hconj
+  -- Left-cancel `δ`.
+  have hcancel : (δ.symm.trans (δ.trans γ)).Homotopic (δ.symm.trans δ) :=
+    Path.Homotopic.hcomp (.refl δ.symm) hδγ
+  have hleft : (δ.symm.trans (δ.trans γ)).Homotopic γ :=
+    (Path.Homotopic.trans_assoc δ.symm δ γ).symm.trans <|
+      ((Path.Homotopic.hcomp (Path.Homotopic.symm_trans δ) (.refl γ)).trans
+        (Path.Homotopic.refl_trans γ))
+  exact hleft.symm.trans (hcancel.trans (Path.Homotopic.symm_trans δ))
+
+public theorem SemilocallySimplyConnectedOn.of_semilocallySimplyConnectedSpace
+    [LocallyPathConnectedSpace X] [SemilocallySimplyConnectedSpace X] (s : Set X) :
+    SemilocallySimplyConnectedOn s :=
+  fun x _ ↦ .of_semilocallySimplyConnectedSpace x
+
+/-! ### Helper lemmas for discreteness of path homotopy quotients -/
+
+/-- In an SLSC space, every point has an open neighborhood `U` with the
+`IsPathHomotopyTrivial U` property: any two paths in `U` with the same endpoints are
+homotopic (so path homotopy classes are determined by endpoints).
+
+This is `semilocallySimplyConnectedAt_iff_paths.mp` repackaged with the
+`IsPathHomotopyTrivial` abstraction, which is the form most downstream users consume. -/
+public theorem SemilocallySimplyConnectedAt.exists_pathHomotopyTrivial_neighborhood {x : X}
+    (h : SemilocallySimplyConnectedAt x) :
+    ∃ U : Set X, IsOpen U ∧ x ∈ U ∧ IsPathHomotopyTrivial U :=
+  semilocallySimplyConnectedAt_iff_paths.mp h
+
+public theorem exists_pathHomotopyTrivial_neighborhood
+    [LocallyPathConnectedSpace X] [SemilocallySimplyConnectedSpace X] (x : X) :
+    ∃ U : Set X, IsOpen U ∧ x ∈ U ∧ IsPathHomotopyTrivial U := by
+  have hx := SemilocallySimplyConnectedAt.of_semilocallySimplyConnectedSpace x
+  exact hx.exists_pathHomotopyTrivial_neighborhood
+
+/-- An SLSC neighborhood can be chosen to be path-connected. In a locally path-connected space,
+we can use the path component of x in an SLSC neighborhood V to get a neighborhood that is both
+open, path-connected, and has the SLSC property (paths with same endpoints in U are homotopic). -/
+public theorem SemilocallySimplyConnectedAt.exists_pathConnected_pathHomotopyTrivial_neighborhood
+    [LocallyPathConnectedSpace X] {x : X} (h : SemilocallySimplyConnectedAt x) :
+    ∃ U : Set X, IsOpen U ∧ x ∈ U ∧ IsPathConnected U ∧ IsPathHomotopyTrivial U := by
+  -- Take the path component of `x` in any SLSC neighborhood `V`. It is open by local
+  -- path-connectedness, path-connected by construction, and inherits SLSC from `V` by
+  -- composing the range subsets through `pathComponentIn_subset : pathComponentIn V x ⊆ V`.
+  obtain ⟨V, hV_open, hx_in_V, hV_slsc⟩ := h.exists_pathHomotopyTrivial_neighborhood
+  refine ⟨pathComponentIn V x, hV_open.pathComponentIn x, mem_pathComponentIn_self hx_in_V,
+    isPathConnected_pathComponentIn hx_in_V, fun _ _ p q hp hq ↦ ?_⟩
+  exact hV_slsc.apply p q (hp.trans pathComponentIn_subset) (hq.trans pathComponentIn_subset)
+
+public theorem exists_pathConnected_pathHomotopyTrivial_neighborhood
+    [SemilocallySimplyConnectedSpace X] [LocallyPathConnectedSpace X] (x : X) :
+    ∃ U : Set X, IsOpen U ∧ x ∈ U ∧ IsPathConnected U ∧ IsPathHomotopyTrivial U := by
+  have hx := SemilocallySimplyConnectedAt.of_semilocallySimplyConnectedSpace x
+  exact hx.exists_pathConnected_pathHomotopyTrivial_neighborhood
+
+/-! ### Tube data structures -/
+
+/-- A partition of the unit interval [0,1] into n segments.
+This bundles a monotone sequence 0 = t₀ ≤ t₁ ≤ ... ≤ tₙ = 1. -/
+-- If this proves more generally useful, we should move it to `UnitInterval.lean`
+-- and provide further API (e.g. compositions, induction principles, ...)
+public structure IntervalPartition (n : ℕ) where
+  /-- Partition points 0 = t₀ ≤ t₁ ≤ ... ≤ tₙ = 1 -/
+  t : Fin (n + 1) → unitInterval
+  /-- t is monotone -/
+  mono : Monotone t
+  /-- t starts at 0 -/
+  t_zero : t 0 = 0
+  /-- t ends at 1 -/
+  t_last : t (Fin.last n) = 1
+
+namespace IntervalPartition
+
+attribute [simp, grind =] t_zero t_last
+
+/-- `IntervalPartition 0` is empty: a single partition point cannot be simultaneously
+`0` (by `t_zero`) and `1` (by `t_last`). -/
+public instance : IsEmpty (IntervalPartition 0) where
+  false part := by
+    have h0 : part.t 0 = 0 := part.t_zero
+    have h1 : part.t 0 = 1 := part.t_last
+    exact zero_ne_one (h0.symm.trans h1)
+
+end IntervalPartition
+
+/-- Data for a tubular neighborhood in an SLSC space: segment neighborhoods, point
+neighborhoods at all partition points, and the openness/path-connectedness/SLSC subset data. -/
+public structure TubeData (X : Type*) [TopologicalSpace X] (n : ℕ) where
+  /-- Segment neighborhoods -/
+  U : Fin n → Set X
+  /-- Point neighborhoods at ALL partition points (including endpoints) -/
+  V : Fin (n + 1) → Set X
+  /-- Each U[i] is open -/
+  U_open : ∀ i, IsOpen (U i)
+  /-- SLSC property: paths in U[i] with same endpoints are homotopic -/
+  U_slsc : ∀ i, IsPathHomotopyTrivial (U i)
+  /-- Each V[j] is open -/
+  V_open : ∀ j, IsOpen (V j)
+  /-- Each V[j] is path-connected -/
+  V_pathConn : ∀ j, IsPathConnected (V j)
+  /-- For each segment i, the left endpoint neighborhood V[i.castSucc] is in U[i] -/
+  V_left_subset : ∀ i : Fin n, V i.castSucc ⊆ U i
+  /-- For each segment i, the right endpoint neighborhood V[i.succ] is in U[i] -/
+  V_right_subset : ∀ i : Fin n, V i.succ ⊆ U i
+
+/-- A path γ is in the tube defined by partition `part` and tube data T.
+This means:
+1. γ stays in the segment neighborhoods U[i] on each interval [t[i], t[i+1]]
+2. γ passes through the point neighborhoods V[j] at ALL partition points -/
+public structure PathInTube {X : Type*} [TopologicalSpace X] {x y : X} {n : ℕ}
+    (γ : Path x y) (part : IntervalPartition n) (T : TubeData X n) : Prop where
+  /-- γ stays in the segment neighborhoods U[i] on each interval [t[i], t[i+1]] -/
+  stays_in_U : ∀ i (s : unitInterval),
+    (part.t i.castSucc : ℝ) ≤ s ∧ s ≤ (part.t i.succ : ℝ) → γ s ∈ T.U i
+  /-- γ passes through the point neighborhoods V[j] at ALL partition points -/
+  passes_through_V : ∀ j, γ (part.t j) ∈ T.V j
+
+/-- If γ is in a tube, then its subpath on segment i has range in U[i]. -/
+public lemma PathInTube.subpath_range_subset {X : Type*} [TopologicalSpace X] {x y : X} {n : ℕ}
+    {γ : Path x y} {part : IntervalPartition n} {T : TubeData X n}
+    (hγ : PathInTube γ part T) (i : Fin n) :
+    Set.range (γ.subpath (part.t i.castSucc) (part.t i.succ)) ⊆ T.U i := by
+  intro z hz
+  obtain ⟨t, rfl⟩ := hz
+  have h_mono : (part.t i.castSucc : ℝ) ≤ part.t i.succ :=
+    part.mono i.castSucc_lt_succ.le
+  simpa [Path.subpath] using
+    hγ.stays_in_U i (Set.Icc.convexComb (part.t i.castSucc) (part.t i.succ) t)
+      ⟨Set.Icc.le_convexComb h_mono t, Set.Icc.convexComb_le h_mono t⟩
+
+/-- Convert TubeData with partition to the set of paths in the tube -/
+@[expose] public def TubeData.toSet {X : Type*} [TopologicalSpace X] {x y : X} {n : ℕ}
+    (part : IntervalPartition n) (T : TubeData X n) : Set (Path x y) :=
+  {γ | PathInTube γ part T}
+
+@[simp] public theorem TubeData.mem_toSet_iff {X : Type*} [TopologicalSpace X] {x y : X} {n : ℕ}
+    (part : IntervalPartition n) (T : TubeData X n) (γ : Path x y) :
+    γ ∈ T.toSet part ↔ PathInTube γ part T :=
+  Iff.rfl
+
+/-- Given segment neighborhoods covering each subpath of `γ`, construct the vertex neighborhoods
+as path components of the finite intersections of adjacent segment neighborhoods. -/
+private theorem Path.exists_vertexNeighborhood_family [LocallyPathConnectedSpace X]
+    {x y : X} {γ : Path x y} {n : ℕ}
+    {t : Fin (n + 1) → unitInterval} {U : Fin n → Set X}
+    (h_mono : Monotone t) (hU_open : ∀ i, IsOpen (U i))
+    (hU_contains : ∀ i : Fin n, ∀ s : unitInterval,
+      (t i.castSucc : ℝ) ≤ s ∧ s ≤ (t i.succ : ℝ) → γ s ∈ U i) :
+    ∃ V : Fin (n + 1) → Set X,
+      (∀ j, IsOpen (V j)) ∧
+      (∀ j, IsPathConnected (V j)) ∧
+      (∀ j, γ (t j) ∈ V j) ∧
+      (∀ i : Fin n, V i.castSucc ⊆ U i) ∧
+      (∀ i : Fin n, V i.succ ⊆ U i) := by
+  have V_data : ∀ j : Fin (n + 1),
+      ∃ V : Set X, IsOpen V ∧ IsPathConnected V ∧ γ (t j) ∈ V ∧
+        (∀ i : Fin n, j = i.castSucc → V ⊆ U i) ∧
+        (∀ i : Fin n, j = i.succ → V ⊆ U i) := by
+    intro j
+    let U_inter := ⋂ i : Fin n, ⋂ (_ : j = i.castSucc ∨ j = i.succ), U i
+    have hγ_in_inter : γ (t j) ∈ U_inter := by
+      simp only [U_inter, Set.mem_iInter]
+      intro i hi
+      exact hU_contains i (t j) <| by
+        cases hi with
+        | inl h =>
+            constructor <;> apply h_mono <;> simp [h, Fin.le_def]
+        | inr h =>
+            constructor <;> apply h_mono <;> simp [h, Fin.le_def, Fin.succ]
+    refine ⟨pathComponentIn U_inter (γ (t j)), ?_, isPathConnected_pathComponentIn hγ_in_inter,
+      mem_pathComponentIn_self hγ_in_inter, ?_, ?_⟩
+    · apply IsOpen.pathComponentIn
+      apply isOpen_iInter_of_finite
+      intro i
+      apply isOpen_iInter_of_finite
+      intro _
+      exact hU_open i
+    · intro i hi
+      trans U_inter
+      · exact pathComponentIn_subset
+      · exact Set.iInter_subset_of_subset i <| Set.iInter_subset_of_subset (Or.inl hi) <| subset_rfl
+    · intro i hi
+      trans U_inter
+      · exact pathComponentIn_subset
+      · exact Set.iInter_subset_of_subset i <| Set.iInter_subset_of_subset (Or.inr hi) <| subset_rfl
+  choose V hV_open hV_pathConn hγ_in_V hV_left hV_right using V_data
+  refine ⟨V, hV_open, hV_pathConn, hγ_in_V, ?_, ?_⟩
+  · intro i
+    exact hV_left i.castSucc i rfl
+  · intro i
+    exact hV_right i.succ i rfl
+
+/-- If `X` is SLSC along the range of `γ`, then `γ` has tube data around it. -/
+public theorem Path.exists_partition_in_pathHomotopyTrivial_neighborhoods
+    [LocallyPathConnectedSpace X] {x y : X}
+    (γ : Path x y) (hslsc : SemilocallySimplyConnectedOn (Set.range γ)) :
+    ∃ (n : ℕ) (part : IntervalPartition n) (T : TubeData X n), PathInTube γ part T := by
+  obtain ⟨n, t, h_mono, h_start, h_end, h_partition⟩ := γ.exists_partition_with_property
+    (fun U ↦ IsPathConnected U ∧ IsPathHomotopyTrivial U)
+    (fun z hz ↦ (hslsc.at hz).exists_pathConnected_pathHomotopyTrivial_neighborhood)
+  choose U hU_open hU_prop hU_contains using h_partition
+  obtain ⟨V, hV_open, hV_pathConn, hγ_in_V, hV_left, hV_right⟩ :=
+    Path.exists_vertexNeighborhood_family h_mono hU_open hU_contains
+  let part : IntervalPartition n := {
+    t := t
+    mono := h_mono
+    t_zero := h_start
+    t_last := h_end
+  }
+  let T : TubeData X n := {
+    U := U
+    V := V
+    U_open := hU_open
+    U_slsc := fun i ↦ (hU_prop i).2
+    V_open := hV_open
+    V_pathConn := hV_pathConn
+    V_left_subset := hV_left
+    V_right_subset := hV_right
+  }
+  refine ⟨n, part, T, ?_⟩
+  exact { stays_in_U := hU_contains, passes_through_V := hγ_in_V }
+
+/-- Given open segment and vertex families, the corresponding raw tube set is open in the path
+space. This compact-open statement only uses openness of the two families, not the full SLSC tube
+data carried by `TubeData`. -/
+public theorem isOpen_pathTube {x y : X} {n : ℕ}
+    (part : IntervalPartition n) (U : Fin n → Set X) (V : Fin (n + 1) → Set X)
+    (hU_open : ∀ i, IsOpen (U i)) (hV_open : ∀ j, IsOpen (V j)) :
+    IsOpen {γ' : Path x y |
+      (∀ i (s : unitInterval),
+        (part.t i.castSucc : ℝ) ≤ s ∧ s ≤ (part.t i.succ : ℝ) → γ' s ∈ U i) ∧
+      ∀ j, γ' (part.t j) ∈ V j} := by
+  let A : Set (Path x y) := {γ' | ∀ i (s : unitInterval),
+    (part.t i.castSucc : ℝ) ≤ s ∧ s ≤ (part.t i.succ : ℝ) → γ' s ∈ U i}
+  let B : Set (Path x y) := {γ' | ∀ j, γ' (part.t j) ∈ V j}
+  have hA : IsOpen A := by
+    have : A =
+      ⋂ i : Fin n, {γ' : Path x y | ∀ s : unitInterval,
+        (part.t i.castSucc : ℝ) ≤ s ∧ s ≤ (part.t i.succ : ℝ) → γ' s ∈ U i} := by
+      ext γ'
+      simp only [A, Set.mem_setOf_eq, Set.mem_iInter]
+    rw [this]
+    apply isOpen_iInter_of_finite
+    intro i
+    let K_i : Set unitInterval := Set.Icc (part.t i.castSucc) (part.t i.succ)
+    have h_compact_K : IsCompact K_i := isCompact_Icc
+    have h_eq : {γ' : Path x y | ∀ s : unitInterval,
+        (part.t i.castSucc : ℝ) ≤ s ∧ s ≤ (part.t i.succ : ℝ) → γ' s ∈ U i} =
+      {γ' : Path x y | Set.MapsTo γ' K_i (U i)} := by
+      ext γ'
+      simp only [Set.mem_setOf_eq, Set.MapsTo, K_i, Set.mem_Icc]
+      refine forall_congr' fun s ↦ ?_
+      constructor
+      · intro h hs; exact h hs
+      · intro h hs; exact h hs
+    rw [h_eq]
+    have : {γ' : Path x y | Set.MapsTo γ' K_i (U i)} =
+        (↑) ⁻¹' {f : C(unitInterval, X) | Set.MapsTo f K_i (U i)} := by
+      rfl
+    rw [this]
+    exact (ContinuousMap.isOpen_setOf_mapsTo h_compact_K (hU_open i)).preimage
+      continuous_induced_dom
+  have hB : IsOpen B := by
+    have : B = ⋂ j : Fin (n + 1), {γ' : Path x y | γ' (part.t j) ∈ V j} := by
+      ext γ'
+      simp only [B, Set.mem_setOf_eq, Set.mem_iInter]
+    rw [this]
+    apply isOpen_iInter_of_finite
+    intro j
+    exact (hV_open j).preimage <|
+      (continuous_eval_const (part.t j)).comp continuous_induced_dom
+  have hAB :
+      {γ' : Path x y |
+        (∀ i (s : unitInterval),
+          (part.t i.castSucc : ℝ) ≤ s ∧ s ≤ (part.t i.succ : ℝ) → γ' s ∈ U i) ∧
+        ∀ j, γ' (part.t j) ∈ V j} = A ∩ B := by
+    ext γ'
+    simp only [A, B, Set.mem_setOf_eq, Set.mem_inter_iff]
+  rw [hAB]
+  exact hA.inter hB
+
+/-- Given a partition and tube data, the set of paths in the tube is open in the path space. -/
+public theorem TubeData.isOpen {x y : X} {n : ℕ}
+    (part : IntervalPartition n) (T : TubeData X n) :
+    IsOpen (T.toSet (x := x) (y := y) part) := by
+  have : T.toSet (x := x) (y := y) part =
+      {γ' : Path x y |
+        (∀ i (s : unitInterval),
+          (part.t i.castSucc : ℝ) ≤ s ∧ s ≤ (part.t i.succ : ℝ) → γ' s ∈ T.U i) ∧
+        ∀ j, γ' (part.t j) ∈ T.V j} := by
+    ext γ'
+    simp only [TubeData.mem_toSet_iff, Set.mem_setOf_eq]
+    constructor
+    · intro h
+      exact ⟨h.stays_in_U, h.passes_through_V⟩
+    · intro ⟨h1, h2⟩
+      exact ⟨h1, h2⟩
+  rw [this]
+  exact isOpen_pathTube part T.U T.V T.U_open T.V_open
+
+/-! ### Proof strategy for discrete topology on Path.Homotopic.Quotient
+
+The main theorem `Path.Homotopic.Quotient.instDiscreteTopology` states that in a semilocally
+simply connected space, the quotient `Path.Homotopic.Quotient x y` carries the discrete topology.
+This is proved by showing that every homotopy class (singleton in the quotient) is open.
+
+**Overall proof strategy:**
+
+Given a path `p : Path x y`, we show that its homotopy class `{p' | Path.Homotopic p' p}` is open.
+
+1. **Partition construction** (`exists_partition_in_pathHomotopyTrivial_neighborhoods`):
+   Use compactness of `p`'s image and the Lebesgue number lemma to find a finite partition
+   `0 = t₀ < t₁ < ... < tₙ = 1` such that each segment `p([tᵢ, tᵢ₊₁])` lies in an open,
+   path-connected neighborhood `Uᵢ` where all paths with the same endpoints are homotopic.
+
+   **Crucially**, we also obtain **overlap neighborhoods** `Vⱼ` at each interior partition
+   point `tⱼ`:
+   - Each `Vⱼ` is open and path-connected
+   - `p(tⱼ) ∈ Vⱼ ⊆ Uⱼ₋₁ ∩ Uⱼ`
+   - These overlaps are obtained using **local path-connectedness**: at each `tⱼ`, the
+     intersection `Uⱼ₋₁ ∩ Uⱼ` is an open neighborhood of `p(tⱼ)`, so it contains a
+     path-connected neighborhood `Vⱼ`.
+
+   This ensures rungs can be constructed at interior points (where we need paths in the
+   intersection).
+
+2. **The tube is open** (`TubeData.isOpen`):
+   The set of paths `p'` such that `p'([tᵢ, tᵢ₊₁]) ⊆ Uᵢ` for all `i` is open in the
+   compact-open topology on `Path x y`. This follows because each segment `[tᵢ, tᵢ₊₁]` is
+   compact and each `Uᵢ` is open, so the tube is a finite intersection of sets of the form
+   `{f | MapsTo f K U}` which are open by definition of the compact-open topology.
+
+3. **Ladder homotopy construction** (`tube_subset_homotopy_class`):
+   Any path `p'` in the tube is homotopic to `p` via a "ladder homotopy":
+
+   - **Rungs** (`exists_rung_paths`): For each partition point `tᵢ`, construct a path `αᵢ`
+     from `p(tᵢ)` to `p'(tᵢ)`:
+     * At interior points: use path-connectedness of the overlap neighborhood `Vⱼ` to connect
+       `p(tⱼ)` to `p'(tⱼ)`. Since `Vⱼ ⊆ Uⱼ₋₁ ∩ Uⱼ`, the rung lies in both adjacent segments'
+       neighborhoods as required.
+     * At endpoints: use constant paths since `p` and `p'` share endpoints.
+
+   - **Rectangle homotopies** (`segment_rung_homotopy`): For each segment `i`, we have
+     a rectangle with:
+     * Bottom edge: segment `pᵢ` of `p` from `p(tᵢ)` to `p(tᵢ₊₁)`
+     * Top edge: segment `p'ᵢ` of `p'` from `p'(tᵢ)` to `p'(tᵢ₊₁)`
+     * Left edge: rung `αᵢ` from `p(tᵢ)` to `p'(tᵢ)`
+     * Right edge: rung `αᵢ₊₁` from `p(tᵢ₊₁)` to `p'(tᵢ₊₁)`
+
+     Both `pᵢ` and `p'ᵢ` lie in the SLSC neighborhood `Uᵢ`, as do the rungs (by construction).
+     By the SLSC property, `pᵢ · αᵢ₊₁ ≃ αᵢ · p'ᵢ` (both are paths from `p(tᵢ)` to `p'(tᵢ₊₁)`
+     with ranges in `Uᵢ`).
+
+   - **Pasting via telescoping** (`paste_segment_homotopies`): Compose the segment homotopies:
+     ```
+     p = p₀ · p₁ · ... · pₙ₋₁
+       ≃ (α₀ · p'₀ · α₁⁻¹) · (α₁ · p'₁ · α₂⁻¹) · ... · (αₙ₋₁ · p'ₙ₋₁ · αₙ⁻¹)
+       ≃ α₀ · (p'₀ · p'₁ · ... · p'ₙ₋₁) · αₙ⁻¹  (telescoping cancellation)
+       ≃ α₀ · p' · αₙ⁻¹
+     ```
+
+     The theorem `paste_segment_homotopies` keeps the final rung `αₙ`, so it applies equally
+     well when the endpoint is allowed to move. The fixed-endpoint theorem is then recovered in
+     two steps:
+     * `paste_segment_homotopies_pathHomotopyTrivial_source` kills the initial loop `α₀`
+     * `paste_segment_homotopies_pathHomotopyTrivial` also kills the final loop `αₙ`
+
+4. **Tubular neighborhoods** (`exists_open_tubular_neighborhood_in_homotopy_class`):
+   Combining steps 1-3, we have shown that for any path `p`:
+   - Step 1 gives a partition `tᵢ` and SLSC neighborhoods `Uᵢ` for `p`
+   - Step 2 shows the tube `T = {p' | ∀i, p'([tᵢ, tᵢ₊₁]) ⊆ Uᵢ}` is open
+   - Step 3 shows `T ⊆ {p' | Homotopic p' p}` (the tube is contained in `p`'s homotopy class)
+
+   **Therefore: Every path `p` has an open neighborhood contained in its homotopy class.**
+   This is the key fact that bridges the local SLSC property to the global topological result.
+
+5. **Homotopy classes are open** (`isOpen_setOf_homotopic`):
+   Let `H(p) = {p' | Homotopic p' p}` be the homotopy class of `p`. To show `H(p)` is open:
+   - Take any `q ∈ H(p)` (so `q` is homotopic to `p`)
+   - By step 4, `q` has an open neighborhood `T_q` with `T_q ⊆ H(q)`
+   - Since homotopy is an equivalence relation, `H(q) = H(p)`
+   - Therefore `q ∈ T_q ⊆ H(p)`, so `q` has an open neighborhood in `H(p)`
+
+   Since every point in `H(p)` has an open neighborhood contained in `H(p)`, the set `H(p)`
+   is open.
+
+6. **Discrete topology** (`Path.Homotopic.Quotient.instDiscreteTopology`):
+   In the quotient `Path.Homotopic.Quotient x y`, singletons `{⟦p⟧}` correspond to homotopy
+   classes `H(p)` under the quotient map. By step 5, `H(p)` is open, so its image `{⟦p⟧}` is
+   open in the quotient topology. Since every singleton is open, the quotient has discrete
+   topology.
+
+This proof strategy shows that SLSC spaces have "locally unique" path homotopy classes,
+which is the key to constructing universal covers.
+-/
+
+/-! ### Construction of "rung" paths for the ladder homotopy -/
+
+/-- Given two paths γ and γ' in a tube with partition points t_i, we can construct connecting
+"rung" paths α_i from γ(t_i) to γ'(t_i), where each rung αᵢ lies in neighborhoods Uᵢ₋₁ and Uᵢ
+(the neighborhoods of the adjacent segments). In the variable-endpoint case, the final rung
+connects the possibly different endpoints. -/
+theorem Path.exists_rung_paths {x y y' : X} {n : ℕ} (γ : Path x y) (γ' : Path x y')
+    (part : IntervalPartition n) (T : TubeData X n)
+    (hγ : PathInTube γ part T) (hγ' : PathInTube γ' part T) :
+    ∃ α : (i : Fin (n + 1)) → Path (γ (part.t i)) (γ' (part.t i)),
+      (∀ j, Set.range (α j) ⊆ T.V j) ∧
+      (∀ (i : Fin n), Set.range (α i.castSucc) ⊆ T.U i ∧ Set.range (α i.succ) ⊆ T.U i) := by
+  -- For each point j, construct a rung path α_j from γ(t_j) to γ'(t_j)
+  -- using the path-connected neighborhood V[j]
+  have rung_exists : ∀ j, ∃ α_j : Path (γ (part.t j)) (γ' (part.t j)),
+      Set.range α_j ⊆ T.V j := fun j ↦
+    IsPathConnected.exists_path (T.V_pathConn j) (hγ.passes_through_V j) (hγ'.passes_through_V j)
+  choose α hα_range using rung_exists
+  -- Prove the range conditions using the subset properties
+  refine ⟨α, hα_range, fun i ↦ ?_⟩
+  constructor
+  · calc Set.range (α i.castSucc) ⊆ T.V i.castSucc := hα_range i.castSucc
+      _ ⊆ T.U i := T.V_left_subset i
+  · calc Set.range (α i.succ) ⊆ T.V i.succ := hα_range i.succ
+      _ ⊆ T.U i := T.V_right_subset i
+
+/-! ### Single segment homotopy: the key step in the ladder construction -/
+
+/-- For a single segment i, the path γ_i · α_{i+1} (along γ then down the next rung) is
+homotopic to α_i · γ'_i (down the current rung then along γ'). Both paths lie entirely in
+the SLSC neighborhood U_i, and since they share endpoints, the SLSC property implies they
+are homotopic. This is the crucial "rectangle" homotopy for each segment. -/
+theorem Path.segment_rung_homotopy {a b c d : X} (U : Set X)
+    (hU : IsPathHomotopyTrivial U)
+    (γ : Path a b) (γ' : Path c d) (α_start : Path a c) (α_end : Path b d)
+    (hγ : Set.range γ ⊆ U) (hγ' : Set.range γ' ⊆ U)
+    (hα_start : Set.range α_start ⊆ U) (hα_end : Set.range α_end ⊆ U) :
+    Path.Homotopic (γ.trans α_end) (α_start.trans γ') := by
+  apply hU
+  · rw [Path.trans_range]; exact Set.union_subset hγ hα_end
+  · rw [Path.trans_range]; exact Set.union_subset hα_start hγ'
+
+/-! ### Pasting lemma: telescoping cancellation of rungs -/
+
+/-- The cast'd quotient class of `p.subpath` over the endpoints of an `IntervalPartition`
+equals the class of `p` itself. This packages `Path.Homotopic.Quotient.subpath_zero_one`
+together with `part.t_zero` / `part.t_last`, sidestepping the dependent-type "motive"
+obstruction one hits when rewriting `part.t 0 = 0` / `part.t (Fin.last n) = 1` directly
+through `subpath`. -/
+private theorem Path.Homotopic.Quotient.cast_mk_subpath_part_endpoints
+    {x y : X} (p : Path x y) {n : ℕ} (part : IntervalPartition n)
+    (h₁ : x = p (part.t 0)) (h₂ : y = p (part.t (Fin.last n))) :
+    (Path.Homotopic.Quotient.mk (p.subpath (part.t 0) (part.t (Fin.last n)))).cast h₁ h₂ =
+      Path.Homotopic.Quotient.mk p := by
+  convert congrArg (fun q ↦ q.cast p.source.symm p.target.symm)
+    (Path.Homotopic.Quotient.subpath_zero_one p)
+  · simp [part.t_zero]
+  · simp [part.t_last]
+  · simp
+
+/-- The pasting lemma for segment homotopies. Works directly with path restrictions.
+
+Given:
+- γ is a path from x to y and γ' is a path from x to y' with a partition
+- α : (i : Fin (n+1)) → Path (γ (t i)) (γ' (t i)) are rung paths connecting partition points
+- For each segment i, the rectangle homotopy: γ|[t_i,t_{i+1}] · α_{i+1} ≃ α_i · γ'|[t_i,t_{i+1}]
+
+Then by telescoping, we get: γ · αₙ ≃ α₀ · γ'
+
+Since part.t 0 = 0 and part.t (Fin.last n) = 1:
+- α₀ : Path (γ 0) (γ' 0) = Path x x (loop at x)
+- αₙ : Path (γ 1) (γ' 1) = Path y y'
+
+When the initial loop is null-homotopic, this identifies `γ'` with `γ` followed by the final
+rung. If the final rung is also null-homotopic, we recover γ ≃ γ'. -/
+theorem Path.paste_segment_homotopies {x y y' : X} {n : ℕ}
+    (γ : Path x y) (γ' : Path x y') (part : IntervalPartition n)
+    (α : (i : Fin (n + 1)) → Path (γ (part.t i)) (γ' (part.t i)))
+    (h_rectangles : ∀ (i : Fin n),
+        Path.Homotopic
+          ((γ.subpath (part.t i.castSucc) (part.t i.succ)).trans (α i.succ))
+          ((α i.castSucc).trans (γ'.subpath (part.t i.castSucc) (part.t i.succ)))) :
+    Path.Homotopic
+      (γ.trans ((α (Fin.last n)).cast
+        (show y = γ (part.t (Fin.last n)) by rw [part.t_last, γ.target])
+        (show y' = γ' (part.t (Fin.last n)) by rw [part.t_last, γ'.target])))
+      (((α 0).cast (show x = γ (part.t 0) by rw [part.t_zero, γ.source])
+                   (show x = γ' (part.t 0) by rw [part.t_zero, γ'.source])).trans γ') := by
+  open Path.Homotopic.Quotient in
+  -- Define intermediate paths: γ_aux i follows γ up to t_i, crosses via α_i, then follows γ'
+  let γ_aux : (i : Fin (n + 1)) → Path x y' := fun i ↦
+    (((γ.subpath (part.t 0) (part.t i)).trans (α i)).trans
+      (γ'.subpath (part.t i) (part.t (Fin.last n)))).cast
+      (by rw [part.t_zero, γ.source])
+      (by rw [part.t_last, γ'.target])
+  -- Base case: γ_aux 0 ≃ α_0 · γ'
+  -- At i=0, γ|[0,0] is constant, and γ'|[0,1] is all of γ', so this simplifies to α_0 · γ'
+  have h_base : Path.Homotopic (γ_aux 0)
+      (((α 0).cast (show x = γ (part.t 0) by rw [part.t_zero, γ.source])
+                   (show x = γ' (part.t 0) by rw [part.t_zero, γ'.source])).trans γ') := by
+    apply Path.Homotopic.Quotient.exact
+    dsimp [γ_aux]
+    rw [Path.Homotopic.Quotient.subpath_self,
+        Path.Homotopic.Quotient.cast_mk_subpath_part_endpoints γ' part]
+    simp
+  -- Final case: γ_aux (Fin.last n) ≃ γ · α_n
+  -- At i=n, γ|[0,1] is all of γ, and γ'|[1,1] is constant, so this simplifies to γ · α_n
+  have h_final : Path.Homotopic (γ_aux (Fin.last n))
+      (γ.trans ((α (Fin.last n)).cast
+        (show y = γ (part.t (Fin.last n)) by rw [part.t_last, γ.target])
+        (show y' = γ' (part.t (Fin.last n)) by rw [part.t_last, γ'.target]))) := by
+    apply Path.Homotopic.Quotient.exact
+    dsimp [γ_aux]
+    rw [Path.Homotopic.Quotient.subpath_self,
+        Path.Homotopic.Quotient.cast_mk_subpath_part_endpoints γ part]
+    simp
+  -- Lift h_rectangles to the quotient with an arbitrary suffix
+  -- This allows simp to apply the rectangle homotopy in context
+  have rectangle_with_suffix : ∀ (i : Fin n) {w : X}
+      (suffix : Path.Homotopic.Quotient (γ' (part.t i.succ)) w),
+      (Path.Homotopic.Quotient.mk (γ.subpath (part.t i.castSucc) (part.t i.succ))).trans
+        ((Path.Homotopic.Quotient.mk (α i.succ)).trans suffix) =
+      (Path.Homotopic.Quotient.mk (α i.castSucc)).trans
+        ((Path.Homotopic.Quotient.mk
+          (γ'.subpath (part.t i.castSucc) (part.t i.succ))).trans suffix) := by
+    intro i w suffix
+    induction suffix using Path.Homotopic.Quotient.ind with | mk suffix =>
+    simp only [← mk_trans, eq]
+    -- Chain homotopies: reassociate, apply rectangle, reassociate back
+    exact ((Path.Homotopic.trans_assoc _ _ _).symm.trans
+      (Path.Homotopic.hcomp (h_rectangles i) (Path.Homotopic.refl suffix))).trans
+      (Path.Homotopic.trans_assoc _ _ _)
+  -- Consecutive paths are homotopic: γ_aux i.succ ≃ γ_aux i.castSucc
+  -- This follows from decomposing using subpath_trans and applying h_rectangles i
+  have h_step : ∀ (i : Fin n), Path.Homotopic (γ_aux i.succ) (γ_aux i.castSucc) := by
+    intro i
+    apply exact
+    simp only [γ_aux, mk_trans, mk_cast]
+    -- Decompose γ|[0, i+1] = γ|[0, i] · γ|[i, i+1]
+    rw [← Path.Homotopic.Quotient.subpath_trans γ
+      (part.t 0) (part.t i.castSucc) (part.t i.succ)
+      (part.mono (Fin.zero_le i.castSucc))
+      (part.mono i.castSucc_lt_succ.le)]
+    -- Decompose γ'|[i, last n] = γ'|[i, i+1] · γ'|[i+1, last n]
+    rw [← Path.Homotopic.Quotient.subpath_trans γ'
+      (part.t i.castSucc) (part.t i.succ) (part.t (Fin.last n))
+      (part.mono i.castSucc_lt_succ.le)
+      (part.mono (Fin.le_last i.succ))]
+    -- Right-associate everything so rectangle_with_suffix can fire
+    simp only [trans_assoc]
+    -- Now apply the rectangle homotopy with suffix
+    rw [rectangle_with_suffix]
+  -- Chain all homotopies together
+  -- γ · α_n ≃ γ_aux n ≃ γ_aux (n-1) ≃ ... ≃ γ_aux 0 ≃ α_0 · γ'
+  -- Build a chain from any γ_aux i down to γ_aux 0 using h_step
+  have h_chain : ∀ i : Fin (n + 1), Path.Homotopic (γ_aux i) (γ_aux 0) := by
+    intro i
+    induction i using Fin.induction with
+    | zero => exact Path.Homotopic.refl _
+    | succ i ih => exact (h_step i).trans ih
+  -- Now combine everything: γ · α_n ≃ γ_aux n ≃ γ_aux 0 ≃ α_0 · γ'
+  exact h_final.symm.trans ((h_chain (Fin.last n)).trans h_base)
+
+/-- A loop in an SLSC neighborhood is null-homotopic if its range lies in that neighborhood. -/
+public theorem Path.nullhomotopic_of_range_subset_pathHomotopyTrivial {x : X} (γ : Path x x)
+    (U : Set X) (hU : IsPathHomotopyTrivial U)
+    (hγU : Set.range γ ⊆ U) :
+    Path.Homotopic γ (Path.refl x) :=
+  hU.apply γ (Path.refl x) hγU <| by
+    rintro _ ⟨_, rfl⟩
+    simpa [γ.source] using hγU ⟨0, rfl⟩
+
+private theorem Path.first_rung_nullhomotopic_of_range_subset_pathHomotopyTrivial
+    {x y y' : X} {n : ℕ}
+    (γ : Path x y) (γ' : Path x y')
+    (part : IntervalPartition n)
+    (α : (i : Fin (n + 1)) → Path (γ (part.t i)) (γ' (part.t i)))
+    (U₀ : Set X) (hU₀ : IsPathHomotopyTrivial U₀)
+    (h_α₀_in_U₀ : Set.range (α 0) ⊆ U₀) :
+    let α₀ := (α 0).cast (show x = γ (part.t 0) by rw [part.t_zero, γ.source])
+      (show x = γ' (part.t 0) by rw [part.t_zero, γ'.source])
+    Path.Homotopic α₀ (Path.refl x) := by
+  intro α₀
+  apply Path.nullhomotopic_of_range_subset_pathHomotopyTrivial α₀ U₀ hU₀
+  simpa only [α₀, Path.cast_coe] using h_α₀_in_U₀
+
+private theorem Path.last_rung_nullhomotopic_of_range_subset_pathHomotopyTrivial
+    {x y : X} {n : ℕ}
+    (γ γ' : Path x y) (part : IntervalPartition n)
+    (α : (i : Fin (n + 1)) → Path (γ (part.t i)) (γ' (part.t i)))
+    (Uₙ : Set X) (hUₙ : IsPathHomotopyTrivial Uₙ)
+    (h_αₙ_in_Uₙ : Set.range (α (Fin.last n)) ⊆ Uₙ) :
+    let αₙ := (α (Fin.last n)).cast
+      (show y = γ (part.t (Fin.last n)) by rw [part.t_last, γ.target])
+      (show y = γ' (part.t (Fin.last n)) by rw [part.t_last, γ'.target])
+    Path.Homotopic αₙ (Path.refl y) := by
+  intro αₙ
+  apply Path.nullhomotopic_of_range_subset_pathHomotopyTrivial αₙ Uₙ hUₙ
+  simpa only [αₙ, Path.cast_coe] using h_αₙ_in_Uₙ
+
+/-- One-sided specialization of `paste_segment_homotopies` that kills the source loop.
+
+Given the same rectangle homotopies, plus:
+- U₀ is an SLSC neighborhood containing the range of α 0
+
+Then `γ'` is homotopic to `γ` followed by the final rung. -/
+theorem Path.paste_segment_homotopies_pathHomotopyTrivial_source {x y y' : X} {n : ℕ}
+    (γ : Path x y) (γ' : Path x y')
+    (part : IntervalPartition n)
+    (α : (i : Fin (n + 1)) → Path (γ (part.t i)) (γ' (part.t i)))
+    (h_rectangles : ∀ (i : Fin n),
+        Path.Homotopic
+          ((γ.subpath (part.t i.castSucc) (part.t i.succ)).trans (α i.succ))
+          ((α i.castSucc).trans (γ'.subpath (part.t i.castSucc) (part.t i.succ))))
+    (U₀ : Set X) (hU₀ : IsPathHomotopyTrivial U₀)
+    (h_α₀_in_U₀ : Set.range (α 0) ⊆ U₀) :
+    Path.Homotopic
+      (γ.trans ((α (Fin.last n)).cast
+        (show y = γ (part.t (Fin.last n)) by rw [part.t_last, γ.target])
+        (show y' = γ' (part.t (Fin.last n)) by rw [part.t_last, γ'.target])))
+      γ' := by
+  have h_paste := paste_segment_homotopies γ γ' part α h_rectangles
+  let α₀ := (α 0).cast (show x = γ (part.t 0) by rw [part.t_zero, γ.source])
+                       (show x = γ' (part.t 0) by rw [part.t_zero, γ'.source])
+  have h_α₀_null : Path.Homotopic α₀ (Path.refl x) := by
+    simpa [α₀] using
+      Path.first_rung_nullhomotopic_of_range_subset_pathHomotopyTrivial γ γ' part α
+        U₀ hU₀ h_α₀_in_U₀
+  exact h_paste.trans <| Path.Homotopic.trans_left_of_nullhomotopic h_α₀_null
+
+/-- Variable-endpoint tube theorem: paths in the same tube as `γ` are homotopic to `γ`
+followed by the final endpoint rung. -/
+public theorem Path.tube_subset_homotopy_class_source {x y y' : X} {n : ℕ}
+    (γ : Path x y) (part : IntervalPartition n) (T : TubeData X n)
+    (hγ : PathInTube γ part T)
+    (γ' : Path x y') (hγ' : PathInTube γ' part T) :
+    ∃ ρ : Path y y', Set.range ρ ⊆ T.V (Fin.last n) ∧ Path.Homotopic (γ.trans ρ) γ' := by
+  cases n with
+  | zero => exact isEmptyElim part
+  | succ n' =>
+    obtain ⟨α, hα_V_ranges, hα_ranges⟩ := Path.exists_rung_paths γ γ' part T hγ hγ'
+    have h_rectangles : ∀ (i : Fin (n' + 1)),
+        Path.Homotopic
+          ((γ.subpath (part.t i.castSucc) (part.t i.succ)).trans (α i.succ))
+          ((α i.castSucc).trans (γ'.subpath (part.t i.castSucc) (part.t i.succ))) := by
+      intro i
+      apply segment_rung_homotopy (T.U i) (T.U_slsc i)
+      · exact hγ.subpath_range_subset i
+      · exact hγ'.subpath_range_subset i
+      · exact (hα_ranges i).1
+      · exact (hα_ranges i).2
+    let ρ : Path y y' := (α (Fin.last (n' + 1))).cast
+      (show y = γ (part.t (Fin.last (n' + 1))) by rw [part.t_last, γ.target])
+      (show y' = γ' (part.t (Fin.last (n' + 1))) by rw [part.t_last, γ'.target])
+    refine ⟨ρ, ?_, ?_⟩
+    · simpa only [ρ, Path.cast_coe] using hα_V_ranges (Fin.last (n' + 1))
+    · simpa only [ρ] using
+        paste_segment_homotopies_pathHomotopyTrivial_source γ γ' part α h_rectangles
+          (T.U ⟨0, Nat.succ_pos n'⟩) (T.U_slsc ⟨0, Nat.succ_pos n'⟩)
+          (hα_ranges ⟨0, Nat.succ_pos n'⟩).1
+
+/-- Two-sided specialization of `paste_segment_homotopies` killing both endpoint loops. -/
+theorem Path.paste_segment_homotopies_pathHomotopyTrivial {x y : X} {n : ℕ} (γ γ' : Path x y)
+    (part : IntervalPartition n)
+    (α : (i : Fin (n + 1)) → Path (γ (part.t i)) (γ' (part.t i)))
+    (h_rectangles : ∀ (i : Fin n),
+        Path.Homotopic
+          ((γ.subpath (part.t i.castSucc) (part.t i.succ)).trans (α i.succ))
+          ((α i.castSucc).trans (γ'.subpath (part.t i.castSucc) (part.t i.succ))))
+    (U₀ : Set X) (hU₀ : IsPathHomotopyTrivial U₀)
+    (h_α₀_in_U₀ : Set.range (α 0) ⊆ U₀)
+    (Uₙ : Set X) (hUₙ : IsPathHomotopyTrivial Uₙ)
+    (h_αₙ_in_Uₙ : Set.range (α (Fin.last n)) ⊆ Uₙ) :
+    Path.Homotopic γ γ' := by
+  let αₙ := (α (Fin.last n)).cast
+              (show y = γ (part.t (Fin.last n)) by rw [part.t_last, γ.target])
+              (show y = γ' (part.t (Fin.last n)) by rw [part.t_last, γ'.target])
+  have h_source : Path.Homotopic (γ.trans αₙ) γ' := by
+    simpa only [αₙ] using
+      paste_segment_homotopies_pathHomotopyTrivial_source γ γ' part α h_rectangles U₀ hU₀ h_α₀_in_U₀
+  have h_αₙ_null : Path.Homotopic αₙ (Path.refl y) := by
+    simpa [αₙ] using
+      Path.last_rung_nullhomotopic_of_range_subset_pathHomotopyTrivial γ γ' part α Uₙ hUₙ h_αₙ_in_Uₙ
+  exact (Path.Homotopic.trans_right_of_nullhomotopic h_αₙ_null).symm.trans h_source
+
+/-- Given a path γ in an SLSC space, paths in the tube around γ are homotopic to γ.
+This is the main result that combines all the previous lemmas:
+1. Construct rung paths α_i using path-connectedness of V neighborhoods
+2. For each segment, apply segment_rung_homotopy to get γ_i·α_{i+1} ≃ α_i·γ'_i
+3. Use paste_segment_homotopies to get γ ≃ γ' by telescoping cancellation -/
+public theorem Path.tube_subset_homotopy_class {x y : X} {n : ℕ}
+    (γ : Path x y) (part : IntervalPartition n) (T : TubeData X n)
+    (hγ : PathInTube γ part T)
+    (γ' : Path x y) (hγ' : PathInTube γ' part T) :
+    Path.Homotopic γ' γ := by
+  cases n with
+  | zero => exact isEmptyElim part
+  | succ n' =>
+    let i_last : Fin (n' + 1) := ⟨n', Nat.lt_succ_self n'⟩
+    obtain ⟨ρ, hρ_V, hρ⟩ := Path.tube_subset_homotopy_class_source γ part T hγ γ' hγ'
+    have hρ_null : Path.Homotopic ρ (Path.refl y) := by
+      apply Path.nullhomotopic_of_range_subset_pathHomotopyTrivial ρ (T.U i_last) (T.U_slsc i_last)
+      exact hρ_V.trans (T.V_right_subset i_last)
+    have hdrop : Path.Homotopic (γ.trans ρ) γ :=
+      Path.Homotopic.trans_right_of_nullhomotopic (γ₀ := γ) hρ_null
+    exact hρ.symm.trans hdrop
+
+/--
+If semilocal simple connectivity holds along `p` in a locally path-connected space, then `p`
+has an open tubular neighborhood contained in its homotopy class.
+
+This shows that the SLSC property gives us not just any open set around p, but specifically
+an open set where ALL paths are homotopic to p. This is what makes homotopy classes open.
+-/
+public theorem Path.exists_open_tubular_neighborhood_in_homotopy_class
+    [LocallyPathConnectedSpace X] {x y : X} (p : Path x y)
+    (hslsc : SemilocallySimplyConnectedOn (Set.range p)) :
+    ∃ (T : Set (Path x y)), IsOpen T ∧ p ∈ T ∧ T ⊆ {p' | Path.Homotopic p' p} := by
+  -- Step 1: Get partition and SLSC neighborhoods
+  obtain ⟨n, part, T_data, hp_in_tube⟩ :=
+    p.exists_partition_in_pathHomotopyTrivial_neighborhoods hslsc
+  refine ⟨T_data.toSet part, ?_, ?_, ?_⟩
+  · -- Show `T` is open.
+    exact T_data.isOpen part
+  · -- Show p ∈ T
+    exact hp_in_tube
+  · -- Show T ⊆ {p' | Homotopic p' p} using tube_subset_homotopy_class
+    intro p' hp'
+    apply Path.tube_subset_homotopy_class p part T_data
+    · exact hp_in_tube
+    · exact hp'
+
+/-- In an SLSC locally path-connected space, for any path `p`, the set of paths homotopic to `p`
+is open. -/
+public theorem Path.isOpen_setOf_homotopic [SemilocallySimplyConnectedSpace X]
+    [LocallyPathConnectedSpace X] {x y : X} (p : Path x y) :
+    IsOpen {p' : Path x y | Path.Homotopic p' p} := by
+  apply isOpen_iff_mem_nhds.mpr
+  intro q hq
+  obtain ⟨T, hT_open, hqT, hT_subset⟩ :=
+    exists_open_tubular_neighborhood_in_homotopy_class q
+      (SemilocallySimplyConnectedOn.of_semilocallySimplyConnectedSpace (Set.range q))
+  rw [mem_nhds_iff]
+  refine ⟨T, fun p' hp' ↦ (hT_subset hp').trans hq, hT_open, hqT⟩
+
+/-- The quotient topology on `Path.Homotopic.Quotient x₀ x`. This instance is load-bearing:
+`Path.Homotopic.Quotient` is a `def` over `Quotient`, and instance search does not unfold it to
+find the generic `TopologicalSpace (Quotient _)` (removing this breaks `instDiscreteTopology`). -/
+public instance Path.Homotopic.Quotient.instTopologicalSpace (x₀ x : X) :
+    TopologicalSpace (Path.Homotopic.Quotient x₀ x) :=
+  inferInstanceAs (TopologicalSpace (Quotient _))
+
+/--
+In a semilocally simply connected, locally path-connected space, the quotient of paths by
+homotopy has discrete topology.
+-/
+public instance Path.Homotopic.Quotient.instDiscreteTopology
+    [SemilocallySimplyConnectedSpace X] [LocallyPathConnectedSpace X] {x y : X} :
+    DiscreteTopology (Path.Homotopic.Quotient x y) := by
+  rw [discreteTopology_iff_isOpen_singleton]
+  intro a
+  induction a using Quotient.inductionOn with
+  | h p =>
+    -- Reframe through the quotient/coinduced topology: opens in the quotient are preimages
+    -- under `Path.Homotopic.Quotient.mk`.
+    change IsOpen ((Path.Homotopic.Quotient.mk : Path x y → Path.Homotopic.Quotient x y) ⁻¹'
+      ({⟦p⟧} : Set (Path.Homotopic.Quotient x y)))
+    have heq :
+        (Path.Homotopic.Quotient.mk : Path x y → Path.Homotopic.Quotient x y) ⁻¹' {⟦p⟧} =
+          {p' : Path x y | Path.Homotopic p' p} :=
+      Set.ext fun _ ↦ Path.Homotopic.Quotient.eq
+    rw [heq]
+    exact isOpen_setOf_homotopic p
+
+end

--- a/TauCeti/AlgebraicTopology/SemilocallySimplyConnectedOn.lean
+++ b/TauCeti/AlgebraicTopology/SemilocallySimplyConnectedOn.lean
@@ -18,42 +18,13 @@ public import Mathlib.Topology.Connected.LocallyPathConnected
 public import Mathlib.Topology.UnitInterval
 
 /-!
-# Semilocally simple connectivity at a point and on a set; discreteness of homotopy fibres
+# Semilocally simple connectivity on sets
 
-This file develops the *unbased, pointwise* form of semilocal simple connectivity and the tube
-machinery it powers, culminating in the discreteness of homotopy-class fibres. It is the
-companion of `TauCeti.AlgebraicTopology.SemilocallySimplyConnected`, which defines the *based*
-class `TauCeti.SemilocallySimplyConnectedSpace`.
-
-`SemilocallySimplyConnectedAt x` is Brazas' *unbased* notion (Definition 2.2 in
-https://arxiv.org/abs/1102.0993): `x` has a neighbourhood `U` in which every loop, based at any
-point of `U`, is null-homotopic in the ambient space. It is strictly stronger than the based
-class, but the two coincide on locally path-connected spaces
-(`SemilocallySimplyConnectedAt.of_semilocallySimplyConnectedSpace`), which is the setting for
-covering-space theory.
-
-This file is adapted from the Mathlib drafts
-[#31449](https://github.com/leanprover-community/mathlib4/pull/31449) and
-[#31576](https://github.com/leanprover-community/mathlib4/pull/31576) by Kim Morrison; it
-advances Stage 0.1 of the `TauCetiRoadmap/UniversalCovers` roadmap.
-
-## Main definitions
-
-* `SemilocallySimplyConnectedAt x` - The unbased property at a single point.
-* `SemilocallySimplyConnectedOn s` - The unbased property at every point of `s`.
-* `IsPathHomotopyTrivial U` - Any two paths in `U` with matching endpoints are homotopic in `X`.
-* `IntervalPartition`, `TubeData`, `PathInTube` - the tube data around a path.
-
-## Main theorems
-
-* `semilocallySimplyConnectedAt_iff` - Characterization in terms of loops being nullhomotopic.
-* `semilocallySimplyConnectedAt_iff_paths` - Characterization: there exists a neighbourhood `U`
-  such that any two paths in `U` between the same endpoints are homotopic.
-* `SemilocallySimplyConnectedAt.of_semilocallySimplyConnectedSpace` - on a locally
-  path-connected space, the based class `TauCeti.SemilocallySimplyConnectedSpace` implies the
-  unbased pointwise predicate.
-* `Path.Homotopic.Quotient.instDiscreteTopology` - In a semilocally simply connected,
-  locally path-connected space, the quotient of paths by homotopy has the discrete topology.
+This file develops the unbased, pointwise form of semilocal simple connectivity and the tube
+machinery used to prove discreteness of path-homotopy fibres. It is adapted from the Mathlib
+drafts [#31449](https://github.com/leanprover-community/mathlib4/pull/31449) and
+[#31576](https://github.com/leanprover-community/mathlib4/pull/31576) by Kim Morrison, for
+Stage 0.1 of the `TauCetiRoadmap/UniversalCovers` roadmap.
 -/
 
 noncomputable section
@@ -544,102 +515,6 @@ public theorem TubeData.isOpen {x y : X} {n : ℕ}
       exact ⟨h1, h2⟩
   rw [this]
   exact isOpen_pathTube part T.U T.V T.U_open T.V_open
-
-/-! ### Proof strategy for discrete topology on Path.Homotopic.Quotient
-
-The main theorem `Path.Homotopic.Quotient.instDiscreteTopology` states that in a semilocally
-simply connected space, the quotient `Path.Homotopic.Quotient x y` carries the discrete topology.
-This is proved by showing that every homotopy class (singleton in the quotient) is open.
-
-**Overall proof strategy:**
-
-Given a path `p : Path x y`, we show that its homotopy class `{p' | Path.Homotopic p' p}` is open.
-
-1. **Partition construction** (`exists_partition_in_pathHomotopyTrivial_neighborhoods`):
-   Use compactness of `p`'s image and the Lebesgue number lemma to find a finite partition
-   `0 = t₀ < t₁ < ... < tₙ = 1` such that each segment `p([tᵢ, tᵢ₊₁])` lies in an open,
-   path-connected neighborhood `Uᵢ` where all paths with the same endpoints are homotopic.
-
-   **Crucially**, we also obtain **overlap neighborhoods** `Vⱼ` at each interior partition
-   point `tⱼ`:
-   - Each `Vⱼ` is open and path-connected
-   - `p(tⱼ) ∈ Vⱼ ⊆ Uⱼ₋₁ ∩ Uⱼ`
-   - These overlaps are obtained using **local path-connectedness**: at each `tⱼ`, the
-     intersection `Uⱼ₋₁ ∩ Uⱼ` is an open neighborhood of `p(tⱼ)`, so it contains a
-     path-connected neighborhood `Vⱼ`.
-
-   This ensures rungs can be constructed at interior points (where we need paths in the
-   intersection).
-
-2. **The tube is open** (`TubeData.isOpen`):
-   The set of paths `p'` such that `p'([tᵢ, tᵢ₊₁]) ⊆ Uᵢ` for all `i` is open in the
-   compact-open topology on `Path x y`. This follows because each segment `[tᵢ, tᵢ₊₁]` is
-   compact and each `Uᵢ` is open, so the tube is a finite intersection of sets of the form
-   `{f | MapsTo f K U}` which are open by definition of the compact-open topology.
-
-3. **Ladder homotopy construction** (`tube_subset_homotopy_class`):
-   Any path `p'` in the tube is homotopic to `p` via a "ladder homotopy":
-
-   - **Rungs** (`exists_rung_paths`): For each partition point `tᵢ`, construct a path `αᵢ`
-     from `p(tᵢ)` to `p'(tᵢ)`:
-     * At interior points: use path-connectedness of the overlap neighborhood `Vⱼ` to connect
-       `p(tⱼ)` to `p'(tⱼ)`. Since `Vⱼ ⊆ Uⱼ₋₁ ∩ Uⱼ`, the rung lies in both adjacent segments'
-       neighborhoods as required.
-     * At endpoints: use constant paths since `p` and `p'` share endpoints.
-
-   - **Rectangle homotopies** (`segment_rung_homotopy`): For each segment `i`, we have
-     a rectangle with:
-     * Bottom edge: segment `pᵢ` of `p` from `p(tᵢ)` to `p(tᵢ₊₁)`
-     * Top edge: segment `p'ᵢ` of `p'` from `p'(tᵢ)` to `p'(tᵢ₊₁)`
-     * Left edge: rung `αᵢ` from `p(tᵢ)` to `p'(tᵢ)`
-     * Right edge: rung `αᵢ₊₁` from `p(tᵢ₊₁)` to `p'(tᵢ₊₁)`
-
-     Both `pᵢ` and `p'ᵢ` lie in the SLSC neighborhood `Uᵢ`, as do the rungs (by construction).
-     By the SLSC property, `pᵢ · αᵢ₊₁ ≃ αᵢ · p'ᵢ` (both are paths from `p(tᵢ)` to `p'(tᵢ₊₁)`
-     with ranges in `Uᵢ`).
-
-   - **Pasting via telescoping** (`paste_segment_homotopies`): Compose the segment homotopies:
-     ```
-     p = p₀ · p₁ · ... · pₙ₋₁
-       ≃ (α₀ · p'₀ · α₁⁻¹) · (α₁ · p'₁ · α₂⁻¹) · ... · (αₙ₋₁ · p'ₙ₋₁ · αₙ⁻¹)
-       ≃ α₀ · (p'₀ · p'₁ · ... · p'ₙ₋₁) · αₙ⁻¹  (telescoping cancellation)
-       ≃ α₀ · p' · αₙ⁻¹
-     ```
-
-     The theorem `paste_segment_homotopies` keeps the final rung `αₙ`, so it applies equally
-     well when the endpoint is allowed to move. The fixed-endpoint theorem is then recovered in
-     two steps:
-     * `paste_segment_homotopies_pathHomotopyTrivial_source` kills the initial loop `α₀`
-     * `paste_segment_homotopies_pathHomotopyTrivial` also kills the final loop `αₙ`
-
-4. **Tubular neighborhoods** (`exists_open_tubular_neighborhood_in_homotopy_class`):
-   Combining steps 1-3, we have shown that for any path `p`:
-   - Step 1 gives a partition `tᵢ` and SLSC neighborhoods `Uᵢ` for `p`
-   - Step 2 shows the tube `T = {p' | ∀i, p'([tᵢ, tᵢ₊₁]) ⊆ Uᵢ}` is open
-   - Step 3 shows `T ⊆ {p' | Homotopic p' p}` (the tube is contained in `p`'s homotopy class)
-
-   **Therefore: Every path `p` has an open neighborhood contained in its homotopy class.**
-   This is the key fact that bridges the local SLSC property to the global topological result.
-
-5. **Homotopy classes are open** (`isOpen_setOf_homotopic`):
-   Let `H(p) = {p' | Homotopic p' p}` be the homotopy class of `p`. To show `H(p)` is open:
-   - Take any `q ∈ H(p)` (so `q` is homotopic to `p`)
-   - By step 4, `q` has an open neighborhood `T_q` with `T_q ⊆ H(q)`
-   - Since homotopy is an equivalence relation, `H(q) = H(p)`
-   - Therefore `q ∈ T_q ⊆ H(p)`, so `q` has an open neighborhood in `H(p)`
-
-   Since every point in `H(p)` has an open neighborhood contained in `H(p)`, the set `H(p)`
-   is open.
-
-6. **Discrete topology** (`Path.Homotopic.Quotient.instDiscreteTopology`):
-   In the quotient `Path.Homotopic.Quotient x y`, singletons `{⟦p⟧}` correspond to homotopy
-   classes `H(p)` under the quotient map. By step 5, `H(p)` is open, so its image `{⟦p⟧}` is
-   open in the quotient topology. Since every singleton is open, the quotient has discrete
-   topology.
-
-This proof strategy shows that SLSC spaces have "locally unique" path homotopy classes,
-which is the key to constructing universal covers.
--/
 
 /-! ### Construction of "rung" paths for the ladder homotopy -/
 

--- a/TauCeti/AlgebraicTopology/UniversalCover/BasedPath.lean
+++ b/TauCeti/AlgebraicTopology/UniversalCover/BasedPath.lean
@@ -1,0 +1,930 @@
+/-
+Copyright (c) 2026 Lean FRO, LLC. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Kim Morrison
+-/
+module
+
+public import TauCeti.AlgebraicTopology.SemilocallySimplyConnectedOn
+public import Mathlib.Topology.CompactOpen
+public import Mathlib.Topology.Constructions
+public import Mathlib.Topology.Order.Basic
+
+/-!
+# Based paths
+
+For a topological space `X` and basepoint `x₀ : X`, this file introduces the space
+`BasedPath x₀` of continuous maps `γ : C(I, X)` with `γ 0 = x₀`, topologised as a subspace
+of the compact-open topology on `C(I, X)`. It then develops the path-component machinery of
+`endpoint ⁻¹' U` that feeds the universal-cover construction.
+
+This file is adapted from the Mathlib draft
+[#38292](https://github.com/leanprover-community/mathlib4/pull/38292) by Kim Morrison.
+
+## Main definitions
+
+* `BasedPath x₀`: the compact-open space of based paths out of `x₀`.
+* `BasedPath.endpoint`, `BasedPath.toPath`, `BasedPath.ofPath`, `BasedPath.append`:
+  basic API for operating on based paths.
+* `Path.initialSegmentFamily`: the family `t ↦ γ|_[0, t]` of initial segments of a path.
+
+## Main results
+
+* `BasedPath.isOpenMap_endpoint`: the endpoint map `BasedPath x₀ → X` is open when `X` is
+  locally path-connected.
+* `BasedPath.joinedIn_preimage_of_append`: appending a path inside `U` moves a based path
+  within the same path component of `endpoint ⁻¹' U`.
+* `BasedPath.exists_open_nhd_pathComponent_preimage`: when semilocal simple connectivity holds
+  along a based path, every based path landing in an open set `U` has an open
+  neighbourhood of based paths joined to it inside `endpoint ⁻¹' U`.
+* `BasedPath.isOpen_pathComponent_preimage`: in a semilocally simply connected, locally
+  path-connected space, path components of `endpoint ⁻¹' U` (for good `U`) are open.
+* `BasedPath.pathComponent_preimage_saturated`: path components of `endpoint ⁻¹' U` are
+  invariant under endpoint-preserving homotopy.
+-/
+
+open scoped unitInterval
+open Topology TauCeti
+
+variable {X : Type*} [TopologicalSpace X]
+
+/-- The compact-open based-path space out of `x₀`. -/
+@[expose] public def BasedPath (x₀ : X) :=
+  { γ : C(I, X) // γ 0 = x₀ }
+
+namespace BasedPath
+
+variable {x₀ : X}
+
+public instance : TopologicalSpace (BasedPath x₀) :=
+  inferInstanceAs (TopologicalSpace { γ : C(I, X) // γ 0 = x₀ })
+
+/-- The endpoint of a based path. -/
+@[expose] public def endpoint (γ : BasedPath x₀) : X := γ.1 1
+
+/-- The endpoint map from based paths to their terminal point is continuous. -/
+public theorem continuous_endpoint : Continuous (endpoint (x₀ := x₀)) :=
+  (continuous_eval_const (1 : I)).comp continuous_induced_dom
+
+/-- View a based path as a path to its endpoint. -/
+@[expose] public def toPath (γ : BasedPath x₀) : Path x₀ (endpoint γ) where
+  toContinuousMap := γ.1
+  source' := γ.2
+  target' := rfl
+
+/-- Definitional unfolding of `endpoint`. Not a global simp lemma: it overlaps with
+`endpoint_refl` (and other `endpoint_…` lemmas) on the simp normal form, so we instead include it
+explicitly in `simp [endpoint_def, …]` at each site that wants to bridge between the named
+`endpoint γ = u` API and the underlying `γ.1 1` evaluation. -/
+public theorem endpoint_def (γ : BasedPath x₀) : endpoint γ = γ.1 1 := rfl
+@[simp] public theorem toPath_apply (γ : BasedPath x₀) (t : I) : toPath γ t = γ.1 t := rfl
+public theorem toPath_source (γ : BasedPath x₀) : toPath γ 0 = x₀ := γ.2
+public theorem toPath_target (γ : BasedPath x₀) : toPath γ 1 = endpoint γ := rfl
+
+@[ext] public theorem ext {γ γ' : BasedPath x₀} (h : ∀ t, γ.1 t = γ'.1 t) : γ = γ' := by
+  cases γ with
+  | mk γ hγ =>
+    cases γ' with
+    | mk γ' hγ' =>
+      simp only at h
+      have hfun : γ = γ' := by
+        ext t
+        exact h t
+      subst hfun
+      simp
+
+/-- The canonical inclusion `Path x₀ y → BasedPath x₀`: package an ordinary path out of `x₀` as a
+based path, forgetting `y` at the type level. The endpoint is recovered as
+`endpoint (ofPath γ) = y` via `endpoint_ofPath`. The map `toPath` is a partial inverse:
+`ofPath γ.toPath = γ` (`ofPath_toPath_self`), and conversely `(ofPath γ).toPath` is `γ` with its
+right endpoint cast to `endpoint (ofPath γ)` (`toPath_ofPath`). -/
+@[expose] public def ofPath {y : X} (γ : Path x₀ y) : BasedPath x₀ :=
+  ⟨γ.toContinuousMap, γ.source⟩
+
+@[simp] public theorem toPath_ofPath {y : X} (γ : Path x₀ y) :
+    (ofPath γ).toPath = γ.cast rfl γ.target := by
+  ext t
+  rfl
+
+@[simp] public theorem endpoint_ofPath {y : X} (γ : Path x₀ y) : endpoint (ofPath γ) = y :=
+  γ.target
+
+/-- The round-trip `ofPath ∘ toPath` is the identity on `BasedPath x₀`. -/
+@[simp] public theorem ofPath_toPath_self (γ : BasedPath x₀) : ofPath γ.toPath = γ := rfl
+
+/-- `ofPath` is invariant under reindexing the right endpoint via `Path.cast`. -/
+@[simp] public theorem ofPath_cast {y y' : X} (γ : Path x₀ y) (h : y' = y) :
+    ofPath (γ.cast rfl h) = ofPath γ := rfl
+
+/-- The constant based path at `x₀`. -/
+@[expose] public def refl (x₀ : X) : BasedPath x₀ :=
+  ofPath (Path.refl x₀)
+
+@[simp] public theorem endpoint_refl (x₀ : X) : endpoint (refl x₀) = x₀ :=
+  endpoint_ofPath _
+
+@[simp] public theorem toPath_refl (x₀ : X) :
+    (refl x₀).toPath = Path.refl x₀ := by
+  apply Path.ext; funext t; rfl
+
+@[simp] public theorem ofPath_refl (x₀ : X) :
+    ofPath (Path.refl x₀) = refl x₀ := rfl
+
+/-- Append a path `δ` at the endpoint of a based path `γ`, defined as
+`ofPath (γ.toPath.trans δ)`: the half `s ∈ [0, ½]` traverses `γ` at double speed and the half
+`s ∈ [½, 1]` traverses `δ` at double speed (`Path.trans_apply`). The new endpoint is the endpoint
+of `δ` (`endpoint_append`). This is the move used by `joinedIn_preimage_of_append` to slide a
+based path within a path component of `endpoint ⁻¹' U`. -/
+-- `append` is exposed so the exported endpoint and `toPath` normal-form lemmas can typecheck
+-- across the module boundary; their result types identify endpoints by unfolding this wrapper.
+@[expose] public noncomputable def append {y : X} (γ : BasedPath x₀)
+    (δ : Path (endpoint γ) y) : BasedPath x₀ :=
+  ofPath (γ.toPath.trans δ)
+
+@[simp] public theorem toPath_append {y : X} (γ : BasedPath x₀) (δ : Path (endpoint γ) y) :
+    (append γ δ).toPath = (γ.toPath.trans δ).cast rfl (γ.toPath.trans δ).target := by
+  simp [append, toPath_ofPath]
+
+@[simp] public theorem endpoint_append {y : X} (γ : BasedPath x₀) (δ : Path (endpoint γ) y) :
+    endpoint (append γ δ) = y := endpoint_ofPath _
+
+/-- The tail of a based path past time `a`, viewed as a `Path (γ.toPath.extend a) u` where
+`u = endpoint γ`. Concretely it is `γ.toPath.truncateOfLE` between `a` and `1`, cast on the right
+to land at `u`; the only hypothesis required is `a ≤ 1` (for `a < 0` the source is clamped
+through `Path.extend`). This is the "compressed tail" piece used by `deformTerminal` to splice
+a new endpoint path onto `γ` while preserving its image on `[0, a]`. -/
+private noncomputable def terminalTail {u : X} (γ : BasedPath x₀)
+    (hu : endpoint γ = u) (a : ℝ) (ha1 : a ≤ 1) :
+    Path (γ.toPath.extend a) u :=
+  (γ.toPath.truncateOfLE (t₀ := a) (t₁ := 1) ha1).cast rfl
+    (by simpa using! hu.symm)
+
+/-- Replace the terminal interval of a based path by first traversing a compressed tail of the
+original path and then a new endpoint path. -/
+private noncomputable def deformTerminal {u v : X} (γ : BasedPath x₀)
+    (hu : endpoint γ = u)
+    (δ : Path u v) {a b : ℝ} (ha : 0 ≤ a) (hab : a < b) (hb : b < 1) : BasedPath x₀ := by
+  let tail : Path (γ.toPath.extend a) u := terminalTail γ hu a (by linarith)
+  let f : ℝ → X := fun t ↦
+    if hta : t ≤ a then γ.toPath.extend t else
+      if htb : t ≤ b then tail.extend ((t - a) / (b - a)) else δ.extend ((t - b) / (1 - b))
+  have hf_cont : Continuous f := by
+    refine Continuous.if_le γ.toPath.continuous_extend ?_ continuous_id continuous_const ?_
+    · refine Continuous.if_le
+        (tail.continuous_extend.comp (by fun_prop))
+        (δ.continuous_extend.comp (by fun_prop))
+        continuous_id continuous_const ?_
+      · intro t htb
+        have hba : b - a ≠ 0 := sub_ne_zero.mpr hab.ne.symm
+        subst t
+        simp [tail, hba]
+    · intro t hta
+      subst t
+      simp [tail, hab.le]
+  refine ⟨ContinuousMap.mk
+    (fun t : I ↦ f t)
+    (hf_cont.comp continuous_subtype_val), ?_⟩
+  simpa [f, ha, endpoint_def] using! γ.toPath.source
+
+private theorem deformTerminal_apply_of_le {u v : X} (γ : BasedPath x₀) (hu : endpoint γ = u)
+    (δ : Path u v) {a b : ℝ} (ha : 0 ≤ a) (hab : a < b) (hb : b < 1)
+    (t : I) (ht : (t : ℝ) ≤ a) :
+    (deformTerminal γ hu δ ha hab hb).1 t = γ.toPath.extend t := by
+  simp [deformTerminal, endpoint_def, ht]
+
+private theorem deformTerminal_apply_of_lt_of_le {u v : X} (γ : BasedPath x₀)
+    (hu : endpoint γ = u) (δ : Path u v) {a b : ℝ} (ha : 0 ≤ a) (hab : a < b) (hb : b < 1)
+    (t : I) (hta : a < (t : ℝ)) (htb : (t : ℝ) ≤ b) :
+    (deformTerminal γ hu δ ha hab hb).1 t =
+      (terminalTail γ hu a (by linarith)).extend (((t : ℝ) - a) / (b - a)) := by
+  simp [deformTerminal, endpoint_def, not_le_of_gt hta, htb]
+
+private theorem deformTerminal_apply_of_lt {u v : X} (γ : BasedPath x₀) (hu : endpoint γ = u)
+    (δ : Path u v) {a b : ℝ} (ha : 0 ≤ a) (hab : a < b) (hb : b < 1)
+    (t : I) (ht : b < (t : ℝ)) :
+    (deformTerminal γ hu δ ha hab hb).1 t = δ.extend (((t : ℝ) - b) / (1 - b)) := by
+  simp [deformTerminal, endpoint_def, not_le_of_gt (lt_trans hab ht), not_le_of_gt ht]
+
+/-- The endpoint of `deformTerminal γ hu δ ha hab hb` is the endpoint of `δ`. -/
+private theorem endpoint_deformTerminal {u v : X} (γ : BasedPath x₀) (hu : endpoint γ = u)
+    (δ : Path u v) {a b : ℝ} (ha : 0 ≤ a) (hab : a < b) (hb : b < 1) :
+    endpoint (deformTerminal γ hu δ ha hab hb) = v := by
+  simp only [endpoint_def]
+  rw [deformTerminal_apply_of_lt γ hu δ ha hab hb 1 hb]
+  have hbne : (1 : ℝ) - b ≠ 0 := sub_ne_zero.mpr hb.ne'
+  have hone : (((1 : I) : ℝ) - b) / (1 - b) = 1 := by
+    have : ((1 : I) : ℝ) = 1 := rfl
+    rw [this]; field_simp
+  rw [hone]
+  simp [δ.extend_one]
+
+end BasedPath
+
+namespace Path
+
+public theorem truncateOfLE_range_subset_preimage {a b : X} (γ : Path a b) {t₀ t₁ : ℝ}
+    (h : t₀ ≤ t₁) {U : Set X} (hU : Set.Icc t₀ t₁ ⊆ γ.extend ⁻¹' U) :
+    Set.range (γ.truncateOfLE h) ⊆ U := by
+  rintro _ ⟨s, rfl⟩
+  dsimp [truncateOfLE, truncate]
+  apply hU
+  constructor
+  · exact le_min (le_max_right _ _) h
+  · exact min_le_right _ _
+
+/-- The family of initial segments of `γ : Path a b`: at parameter `t : I`, the path
+`s ↦ γ.extend (min s t)` from `a` to `γ t` (`initialSegmentFamily_apply`). At `t = 0` this is
+the constant path at `a` (`initialSegmentFamily_zero`); at `t = 1` it is `γ` itself, up to a
+trivial right-endpoint cast (`initialSegmentFamily_one`). The property consumers actually need
+is joint continuity in `(t, s)`, recorded as `continuous_initialSegmentFamily_uncurry` and used
+to build the rung homotopy in `joinedIn_preimage_of_append`. -/
+public noncomputable def initialSegmentFamily {a b : X} (γ : Path a b) (t : I) :
+    Path a (γ t) :=
+  (γ.truncate 0 t).cast (by rw [min_eq_left t.2.1, γ.extend_zero]) (γ.extend_apply t.2).symm
+
+public theorem continuous_initialSegmentFamily_uncurry {a b : X} (γ : Path a b) :
+    Continuous ↿(initialSegmentFamily γ) := by
+  have htrunc : Continuous (fun ts : I × I ↦ γ.truncate 0 ts.1 ts.2 : I × I → X) := by
+    let key : I × I → ℝ × ℝ × I := fun ts ↦ (0, ts.1, ts.2)
+    have hkey : Continuous key := by fun_prop
+    simpa [key] using! γ.truncate_continuous_family.comp hkey
+  simpa [initialSegmentFamily] using! htrunc
+
+@[simp] public theorem initialSegmentFamily_apply {a b : X} (γ : Path a b) (t s : I) :
+    initialSegmentFamily γ t s = γ.extend (min (s : ℝ) t) := by
+  simp [initialSegmentFamily, Path.truncate, max_eq_left s.2.1]
+
+@[simp] public theorem initialSegmentFamily_zero {a b : X} (γ : Path a b) :
+    initialSegmentFamily γ 0 = (Path.refl a).cast rfl (by simp) := by
+  ext s
+  simp [initialSegmentFamily_apply, γ.extend_zero, Path.refl, min_eq_right s.2.1]
+
+@[simp] public theorem initialSegmentFamily_one {a b : X} (γ : Path a b) :
+    initialSegmentFamily γ 1 = γ.cast rfl (by simp) := by
+  ext s
+  simp [initialSegmentFamily_apply, min_eq_left s.2.2, γ.extend_apply s.2]
+
+end Path
+
+namespace BasedPath
+
+/-- The family of initial segments of a based path, defined as
+`ofPath (γ.toPath.initialSegmentFamily t)`. At `t = 0` this is the constant based path at `x₀`;
+at `t = 1` it is `γ` itself. Joint continuity in `t` is `continuous_initialSegmentFamily`. -/
+-- This wrapper is exposed for the same reason as `append`: exported endpoint and `toPath`
+-- normal forms need its body to align the endpoint-indexed path types.
+@[expose] public noncomputable def initialSegmentFamily {x₀ : X} (γ : BasedPath x₀) (t : I) :
+    BasedPath x₀ :=
+  ofPath (γ.toPath.initialSegmentFamily t)
+
+@[simp] public theorem initialSegmentFamily_zero {x₀ : X} (γ : BasedPath x₀) :
+    γ.initialSegmentFamily 0 = ofPath (Path.refl x₀) := by
+  simp [initialSegmentFamily, Path.initialSegmentFamily_zero]
+
+@[simp] public theorem initialSegmentFamily_one {x₀ : X} (γ : BasedPath x₀) :
+    γ.initialSegmentFamily 1 = γ := by
+  rw [initialSegmentFamily, Path.initialSegmentFamily_one, ofPath_cast, ofPath_toPath_self]
+
+@[simp] public theorem toPath_initialSegmentFamily {x₀ : X} (γ : BasedPath x₀) (t : I) :
+    (γ.initialSegmentFamily t).toPath =
+      (γ.toPath.initialSegmentFamily t).cast rfl (γ.toPath.initialSegmentFamily t).target := by
+  -- The wrapper is endpoint-indexed, so expose its definitional `ofPath` value before using
+  -- the public `toPath_ofPath` normal form.
+  change (ofPath (γ.toPath.initialSegmentFamily t)).toPath =
+    (γ.toPath.initialSegmentFamily t).cast rfl (γ.toPath.initialSegmentFamily t).target
+  exact toPath_ofPath (γ.toPath.initialSegmentFamily t)
+
+@[simp] public theorem endpoint_initialSegmentFamily {x₀ : X} (γ : BasedPath x₀) (t : I) :
+    endpoint (γ.initialSegmentFamily t) = γ.1 t := by
+  simp [initialSegmentFamily]
+
+public theorem continuous_initialSegmentFamily {x₀ : X} (γ : BasedPath x₀) :
+    Continuous γ.initialSegmentFamily := by
+  refine Continuous.subtype_mk ?_ _
+  refine ContinuousMap.continuous_of_continuous_uncurry _ ?_
+  simpa only using! γ.toPath.continuous_initialSegmentFamily_uncurry
+
+/-- Appending a fixed terminal path's initial-segment family to a fixed based path is jointly
+continuous in the family parameter. This packages the boilerplate for using
+`Path.trans_continuous_family` to lift `append γ ∘ Path.initialSegmentFamily δ` to a continuous
+map `I → BasedPath x₀`. -/
+public theorem continuous_append_initialSegmentFamily {x₀ z : X}
+    (γ : BasedPath x₀) (δ : Path (endpoint γ) z) :
+    Continuous fun t : I ↦ γ.append (Path.initialSegmentFamily δ t) := by
+  apply Continuous.subtype_mk
+  refine ContinuousMap.continuous_of_continuous_uncurry _ ?_
+  simpa using!
+    Path.trans_continuous_family (fun _ : I ↦ γ.toPath)
+      (Path.continuous_uncurry_iff.mpr continuous_const) (Path.initialSegmentFamily δ)
+      (Path.continuous_initialSegmentFamily_uncurry δ)
+
+/-- Extract an open path-connected endpoint neighborhood and a terminal interval avoiding the
+subbasic compact sets that do not contain `1`. -/
+theorem exists_endpointNeighborhood_of_basicNeighborhood [LocallyPathConnectedSpace X]
+    {x₀ : X} (γ : BasedPath x₀) (Tgood Tbad : Finset (Set I × Set X))
+    (hTgood_open_mem : ∀ KU ∈ Tgood, IsOpen KU.2 ∧ endpoint γ ∈ KU.2)
+    (hTbad_closed : ∀ KU ∈ Tbad, IsClosed KU.1)
+    (hTbad_not_mem : ∀ KU ∈ Tbad, (1 : I) ∉ KU.1) :
+    ∃ (W : Set X) (a₀ : I) (a b : ℝ),
+      IsOpen W ∧ endpoint γ ∈ W ∧ IsPathConnected W ∧
+      (∀ KU ∈ Tgood, W ⊆ KU.2) ∧
+      Set.Ioc a₀ 1 ⊆ γ.toPath ⁻¹' W ∩ ⋂ KU ∈ Tbad, KU.1ᶜ ∧
+      ((a₀ : I) : ℝ) < a ∧ 0 ≤ a ∧ a ≤ 1 ∧ a < b ∧ b < 1 := by
+  let O : Set X := ⋂ KU ∈ Tgood, KU.2
+  have hOopen : IsOpen O :=
+    isOpen_biInter_finset fun KU hKU ↦ (hTgood_open_mem KU hKU).1
+  have huO : endpoint γ ∈ O := by
+    simp only [O, Set.mem_iInter]
+    exact fun KU hKU ↦ (hTgood_open_mem KU hKU).2
+  rcases (isOpen_isPathConnected_basis (x := endpoint γ)).mem_iff.mp
+      (hOopen.mem_nhds huO) with ⟨W, ⟨hWopen, huW, hWpath⟩, hWO⟩
+  let N : Set I := γ.toPath ⁻¹' W ∩ ⋂ KU ∈ Tbad, KU.1ᶜ
+  have hNnhds : N ∈ 𝓝 (1 : I) := by
+    refine Filter.inter_mem
+      ((hWopen.preimage γ.toPath.continuous).mem_nhds (by simpa using! huW)) ?_
+    refine (isOpen_biInter_finset ?_).mem_nhds ?_
+    · exact fun KU hKU ↦ (hTbad_closed KU hKU).isOpen_compl
+    · simp only [Set.mem_iInter]
+      intro KU hKU
+      exact hTbad_not_mem KU hKU
+  rcases exists_Ioc_subset_of_mem_nhds' hNnhds (show (0 : I) < 1 by simp) with ⟨a₀, ha₀, hIoc⟩
+  let a : ℝ := (((a₀ : I) : ℝ) + 1) / 2
+  let b : ℝ := (a + 1) / 2
+  have ha₀_nonneg : 0 ≤ ((a₀ : I) : ℝ) := a₀.2.1
+  have ha₀_lt_one : ((a₀ : I) : ℝ) < 1 := ha₀.2
+  have ha₀_lt_a : ((a₀ : I) : ℝ) < a := by dsimp [a]; nlinarith
+  have ha0 : 0 ≤ a := by dsimp [a]; nlinarith
+  have ha1 : a ≤ 1 := by dsimp [a]; nlinarith
+  have hab : a < b := by dsimp [a, b]; nlinarith
+  have hb1 : b < 1 := by dsimp [a, b]; nlinarith
+  refine ⟨W, a₀, a, b, hWopen, huW, hWpath, ?_, hIoc, ha₀_lt_a, ha0, ha1, hab, hb1⟩
+  intro KU hKU z hz
+  have hz' : ∀ KU ∈ Tgood, z ∈ KU.2 := by simpa [O] using! hWO hz
+  exact hz' KU hKU
+
+/-- Any point in the chosen path-connected endpoint neighborhood is realized by a deformed based
+path that still lies in the original compact-open basic neighborhood. -/
+theorem exists_deformTerminal_mem_basicNeighborhood
+    {x₀ : X} (γ : BasedPath x₀) {V : Set (C(I, X))} {S : Set (Set I × Set X)}
+    {T Tgood Tbad : Finset (Set I × Set X)}
+    (hSdata : ∀ K U, (K, U) ∈ S → IsCompact K ∧ IsOpen U ∧ Set.MapsTo γ.1 K U)
+    (hT_of_S : ∀ KU, KU ∈ S → KU ∈ T)
+    (hSV : {g : C(I, X) | ∀ K U, (K, U) ∈ S → Set.MapsTo g K U} ⊆ V)
+    (hTgood_iff : ∀ KU, KU ∈ Tgood ↔ KU ∈ T ∧ (1 : I) ∈ KU.1)
+    (hTbad_iff : ∀ KU, KU ∈ Tbad ↔ KU ∈ T ∧ (1 : I) ∉ KU.1)
+    {W : Set X} (huW : endpoint γ ∈ W) (hWpath : IsPathConnected W)
+    (hW_good : ∀ KU ∈ Tgood, W ⊆ KU.2)
+    {a₀ : I} {a b : ℝ}
+    (hIoc : Set.Ioc a₀ 1 ⊆ γ.toPath ⁻¹' W ∩ ⋂ KU ∈ Tbad, KU.1ᶜ)
+    (ha₀_lt_a : ((a₀ : I) : ℝ) < a) (ha0 : 0 ≤ a) (ha1 : a ≤ 1) (hab : a < b) (hb1 : b < 1) :
+    ∀ v ∈ W, ∃ η : BasedPath x₀, η.1 ∈ V ∧ endpoint η = v := by
+  classical
+  intro v hvW
+  obtain ⟨δ, hδW⟩ := hWpath.exists_path huW hvW
+  refine ⟨deformTerminal γ rfl δ ha0 hab hb1, ?_,
+    endpoint_deformTerminal γ rfl δ ha0 hab hb1⟩
+  apply hSV
+  intro K U hKU
+  have hKUT : (K, U) ∈ T := hT_of_S (K, U) hKU
+  intro t ht
+  by_cases h1K : (1 : I) ∈ K
+  · have hKUgood : (K, U) ∈ Tgood := (hTgood_iff (K, U)).2 ⟨hKUT, h1K⟩
+    by_cases hta : (t : ℝ) ≤ a
+    · rw [BasedPath.deformTerminal_apply_of_le γ rfl δ ha0 hab hb1 t hta,
+          Path.extend_apply _ t.2]
+      exact (hSdata K U hKU).2.2 ht
+    · have hat : a < (t : ℝ) := lt_of_not_ge hta
+      by_cases htb : (t : ℝ) ≤ b
+      · have hrange : Set.range (terminalTail γ rfl a (by linarith)) ⊆ W := by
+          apply Path.truncateOfLE_range_subset_preimage (h := ha1)
+          intro s hs
+          have hs01 : s ∈ (Set.Icc 0 1 : Set ℝ) := ⟨le_trans ha0 hs.1, hs.2⟩
+          simp only [Set.mem_preimage]
+          rw [Path.extend_apply _ hs01]
+          refine (hIoc ?_).1
+          refine ⟨?_, ?_⟩
+          · -- No interval-order lemma matches this mixed subtype/real goal directly.
+            change ((a₀ : I) : ℝ) < s
+            exact lt_of_lt_of_le ha₀_lt_a hs.1
+          · -- No interval-order lemma matches this mixed subtype/real goal directly.
+            change s ≤ 1
+            exact hs.2
+        have hparam : (((t : ℝ) - a) / (b - a)) ∈ (Set.Icc 0 1 : Set ℝ) := by
+          have hba : 0 < b - a := sub_pos.mpr hab
+          exact ⟨div_nonneg (sub_nonneg.mpr hat.le) hba.le,
+            (div_le_one hba).2 <| sub_le_sub_right htb a⟩
+        have htailW :
+            (terminalTail γ rfl a (by linarith)).extend (((t : ℝ) - a) / (b - a)) ∈ W := by
+          rw [Path.extend_apply _ hparam]
+          exact hrange ⟨⟨((t : ℝ) - a) / (b - a), hparam⟩, rfl⟩
+        rw [BasedPath.deformTerminal_apply_of_lt_of_le γ rfl δ ha0 hab hb1 t hat htb]
+        exact hW_good (K, U) hKUgood htailW
+      · have hbt : b < (t : ℝ) := lt_of_not_ge htb
+        have hparam : (((t : ℝ) - b) / (1 - b)) ∈ (Set.Icc 0 1 : Set ℝ) := by
+          have hb : 0 < 1 - b := sub_pos.mpr hb1
+          exact ⟨div_nonneg (sub_nonneg.mpr hbt.le) hb.le,
+            (div_le_one hb).2 <| sub_le_sub_right t.2.2 b⟩
+        have hδt : δ.extend (((t : ℝ) - b) / (1 - b)) ∈ W := by
+          rw [Path.extend_apply _ hparam]
+          exact hδW ⟨⟨((t : ℝ) - b) / (1 - b), hparam⟩, rfl⟩
+        rw [BasedPath.deformTerminal_apply_of_lt γ rfl δ ha0 hab hb1 t hbt]
+        exact hW_good (K, U) hKUgood hδt
+  · have hKUbad : (K, U) ∈ Tbad := (hTbad_iff (K, U)).2 ⟨hKUT, h1K⟩
+    have ht_not_Ioc : t ∉ Set.Ioc a₀ 1 := fun htIoc ↦ by
+      have htN : t ∈ γ.toPath ⁻¹' W ∩ ⋂ KU ∈ Tbad, KU.1ᶜ := hIoc htIoc
+      have htN' : ∀ KU ∈ Tbad, t ∉ KU.1 := by simpa using! htN.2
+      exact htN' (K, U) hKUbad ht
+    have htle : (t : ℝ) ≤ a := by
+      by_contra hgt
+      have hat : a < (t : ℝ) := lt_of_not_ge hgt
+      have hat₀ : ((a₀ : I) : ℝ) < t := lt_trans ha₀_lt_a hat
+      exact ht_not_Ioc ⟨hat₀, t.2.2⟩
+    rw [BasedPath.deformTerminal_apply_of_le γ rfl δ ha0 hab hb1 t htle,
+        Path.extend_apply _ t.2]
+    exact (hSdata K U hKU).2.2 ht
+
+/-- The endpoint map `BasedPath x₀ → X` is an open map when `X` is locally path-connected. -/
+public theorem isOpenMap_endpoint [LocallyPathConnectedSpace X] (x₀ : X) :
+    IsOpenMap (endpoint (x₀ := x₀)) := by
+  classical
+  refine IsOpenMap.of_nhds_le ?_
+  intro γ
+  rw [Filter.le_def]
+  intro s hs
+  rw [Filter.mem_map'] at hs
+  have hsub := mem_nhds_subtype (s := {γ : C(I, X) | γ 0 = x₀}) γ
+    ({η : BasedPath x₀ | endpoint η ∈ s})
+  rcases hsub.mp hs with ⟨V, hVγ, hVs⟩
+  rcases ContinuousMap.mem_nhds_iff.1 hVγ with ⟨S, hSfin, hSdata, hSV⟩
+  let T : Finset (Set I × Set X) := hSfin.toFinset
+  let Tgood : Finset (Set I × Set X) := T.filter fun KU ↦ (1 : I) ∈ KU.1
+  let Tbad : Finset (Set I × Set X) := T.filter fun KU ↦ (1 : I) ∉ KU.1
+  have hS_of_T : ∀ KU, KU ∈ T → KU ∈ S := fun _ ↦ hSfin.mem_toFinset.mp
+  have hT_of_S : ∀ KU, KU ∈ S → KU ∈ T := fun _ ↦ hSfin.mem_toFinset.mpr
+  have hgood : ∀ KU ∈ Tgood, KU ∈ S ∧ (1 : I) ∈ KU.1 := fun KU hKU ↦
+    let ⟨hT, h1⟩ := Finset.mem_filter.mp hKU
+    ⟨hS_of_T KU hT, h1⟩
+  have hbad : ∀ KU ∈ Tbad, KU ∈ S ∧ (1 : I) ∉ KU.1 := fun KU hKU ↦
+    let ⟨hT, h1⟩ := Finset.mem_filter.mp hKU
+    ⟨hS_of_T KU hT, h1⟩
+  obtain ⟨W, a₀, a, b, hWopen, huW, hWpath, hW_good, hIoc, ha₀_lt_a, ha0, ha1, hab, hb1⟩ :=
+    exists_endpointNeighborhood_of_basicNeighborhood γ Tgood Tbad
+      (fun KU hKU ↦ ⟨(hSdata KU.1 KU.2 (hgood KU hKU).1).2.1,
+        (hSdata KU.1 KU.2 (hgood KU hKU).1).2.2 (hgood KU hKU).2⟩)
+      (fun KU hKU ↦ (hSdata KU.1 KU.2 (hbad KU hKU).1).1.isClosed)
+      (fun KU hKU ↦ (hbad KU hKU).2)
+  refine mem_nhds_iff.mpr ⟨W, ?_, hWopen, huW⟩
+  intro v hvW
+  obtain ⟨η, hηV, hend⟩ :=
+    exists_deformTerminal_mem_basicNeighborhood γ hSdata hT_of_S hSV
+      (fun KU ↦ by simp [Tgood])
+      (fun KU ↦ by simp [Tbad])
+      huW hWpath hW_good hIoc ha₀_lt_a ha0 ha1 hab hb1 v hvW
+  have hηs : endpoint η ∈ s := hVs hηV
+  rw [hend] at hηs
+  exact hηs
+
+variable {x₀ : X}
+
+/-- Endpoint-preserving homotopic paths to a point `y ∈ U` give joined based paths inside the
+endpoint preimage of `U`. -/
+public theorem joinedIn_endpoint_preimage_of_homotopic (x₀ : X) {y : X} {U : Set X}
+    (hy : y ∈ U) {p q : Path x₀ y} (h : Path.Homotopic p q) :
+    JoinedIn (endpoint (x₀ := x₀) ⁻¹' U) (ofPath p) (ofPath q) := by
+  rcases h with ⟨H⟩
+  let γ : Path (ofPath p) (ofPath q) :=
+    { toFun := fun t ↦ ofPath (H.eval t)
+      continuous_toFun := by
+        apply Continuous.subtype_mk
+        exact continuous_induced_dom.comp <| (Path.continuous_uncurry_iff.mp <| by
+          -- `Path.continuous_uncurry_iff` leaves the homotopy as its coercion; name that
+          -- defeq form so `H.continuous` applies.
+          change Continuous fun ts : I × I ↦ H ts
+          exact H.continuous)
+      source' := by
+        ext s
+        simp
+      target' := by
+        ext s
+        simp }
+  refine ⟨γ, fun t ↦ ?_⟩
+  -- `γ` is a let-bound path, so expose its definitional value before using endpoint API.
+  change endpoint (ofPath (H.eval t)) ∈ U
+  rw [endpoint_ofPath]
+  exact hy
+
+/-- Appending a path that stays inside `U` moves a based path within the same path component of
+the endpoint preimage of `U`. -/
+public theorem joinedIn_preimage_of_append {U : Set X} {z : X} (γ : BasedPath x₀)
+    (δ : Path (endpoint γ) z) (hδU : Set.range δ ⊆ U) :
+    JoinedIn (endpoint (x₀ := x₀) ⁻¹' U) γ (append γ δ) := by
+  have hγU : endpoint γ ∈ U := by
+    simpa [δ.source] using hδU ⟨0, rfl⟩
+  let γrefl : Path (endpoint γ) (endpoint γ) := Path.refl (endpoint γ)
+  have h_start :
+      JoinedIn (endpoint (x₀ := x₀) ⁻¹' U) γ (append γ γrefl) := by
+    simpa [γrefl] using!
+      (joinedIn_endpoint_preimage_of_homotopic (x₀ := x₀) (U := U) hγU
+        (p := γ.toPath.trans (Path.refl (endpoint γ))) (q := γ.toPath)
+        (Path.Homotopic.trans_refl γ.toPath)).symm
+  have h_move :
+      JoinedIn (endpoint (x₀ := x₀) ⁻¹' U) (append γ γrefl) (append γ δ) := by
+    let η : Path (append γ γrefl) (append γ δ) := {
+      toFun := fun t ↦ append γ (Path.initialSegmentFamily δ t)
+      continuous_toFun := continuous_append_initialSegmentFamily γ δ
+      source' := by
+        rw [Path.initialSegmentFamily_zero]
+        ext s
+        -- The endpoint casts come from `Path.initialSegmentFamily_zero`; expose the appended
+        -- path values so `Path.cast_coe` can remove them pointwise.
+        change (γ.toPath.trans ((Path.refl (endpoint γ)).cast _ _)) s =
+          (γ.toPath.trans γrefl) s
+        rw [Path.trans_apply, Path.trans_apply]
+        split_ifs <;> simp only [γrefl, Path.cast_coe]
+      target' := by
+        rw [Path.initialSegmentFamily_one]
+        ext s
+        -- As above, the final segment differs only by endpoint casts introduced by the
+        -- initial-segment normal form.
+        change (γ.toPath.trans (δ.cast _ _)) s = (γ.toPath.trans δ) s
+        rw [Path.trans_apply, Path.trans_apply]
+        split_ifs <;> simp only [Path.cast_coe] }
+    refine ⟨η, fun t ↦ ?_⟩
+    -- `η` is a let-bound path, so expose its definitional value before using endpoint API.
+    change endpoint (append γ (Path.initialSegmentFamily δ t)) ∈ U
+    rw [BasedPath.endpoint_append]
+    exact hδU ⟨t, rfl⟩
+  exact h_start.trans h_move
+
+theorem exists_refined_terminal_vertex
+    [LocallyPathConnectedSpace X]
+    {x₀ : X} {n' : ℕ} {U : Set X} (hU_open : IsOpen U)
+    (α : BasedPath x₀) (hα : endpoint α ∈ U)
+    (part : IntervalPartition (n' + 1)) (T : TubeData X (n' + 1))
+    (hα_tube : PathInTube α.toPath part T) :
+    ∃ V_last' : Set X,
+      IsOpen V_last' ∧ IsPathConnected V_last' ∧ endpoint α ∈ V_last' ∧
+      V_last' ⊆ T.V (Fin.last (n' + 1)) ∧ V_last' ⊆ U := by
+  have hα_at_last : α.toPath (part.t (Fin.last (n' + 1))) = endpoint α := by
+    rw [part.t_last]
+    exact α.toPath.target
+  let V_last := T.V (Fin.last (n' + 1))
+  have hα_V_last : endpoint α ∈ V_last := hα_at_last ▸ hα_tube.passes_through_V _
+  let W : Set X := V_last ∩ U
+  have hW_open : IsOpen W := (T.V_open _).inter hU_open
+  have hα_W : endpoint α ∈ W := ⟨hα_V_last, hα⟩
+  refine ⟨pathComponentIn W (endpoint α), hW_open.pathComponentIn _,
+    isPathConnected_pathComponentIn hα_W, mem_pathComponentIn_self hα_W, ?_, ?_⟩
+  · exact pathComponentIn_subset.trans Set.inter_subset_left
+  · exact pathComponentIn_subset.trans Set.inter_subset_right
+
+theorem isOpen_refined_tubeNeighborhood
+    {x₀ : X} {n' : ℕ} (part : IntervalPartition (n' + 1))
+    {U : Fin (n' + 1) → Set X} {V : Fin (n' + 2) → Set X}
+    (hU_open : ∀ i, IsOpen (U i)) (hV_open : ∀ j, IsOpen (V j)) :
+    IsOpen {β : BasedPath x₀ |
+      (∀ (i : Fin (n' + 1)) (s : I),
+          (part.t i.castSucc : ℝ) ≤ s ∧ s ≤ (part.t i.succ : ℝ) → β.1 s ∈ U i) ∧
+      (∀ j, β.1 (part.t j) ∈ V j)} := by
+  have h_split : {β : BasedPath x₀ |
+        (∀ (i : Fin (n' + 1)) (s : I),
+            (part.t i.castSucc : ℝ) ≤ s ∧ s ≤ (part.t i.succ : ℝ) → β.1 s ∈ U i) ∧
+        (∀ j, β.1 (part.t j) ∈ V j)} =
+      {β : BasedPath x₀ | ∀ (i : Fin (n' + 1)) (s : I),
+          (part.t i.castSucc : ℝ) ≤ s ∧ s ≤ (part.t i.succ : ℝ) → β.1 s ∈ U i} ∩
+      {β : BasedPath x₀ | ∀ j, β.1 (part.t j) ∈ V j} := by ext β; simp
+  rw [h_split]
+  refine IsOpen.inter ?_ ?_
+  · have h_U_iInter : {β : BasedPath x₀ | ∀ (i : Fin (n' + 1)) (s : I),
+          (part.t i.castSucc : ℝ) ≤ s ∧ s ≤ (part.t i.succ : ℝ) → β.1 s ∈ U i} =
+        ⋂ i : Fin (n' + 1), {β : BasedPath x₀ | ∀ s : I,
+            (part.t i.castSucc : ℝ) ≤ s ∧ s ≤ (part.t i.succ : ℝ) → β.1 s ∈ U i} := by
+      ext β; simp
+    rw [h_U_iInter]
+    refine isOpen_iInter_of_finite fun i ↦ ?_
+    have h_U_preimage : {β : BasedPath x₀ | ∀ s : I,
+          (part.t i.castSucc : ℝ) ≤ s ∧ s ≤ (part.t i.succ : ℝ) → β.1 s ∈ U i} =
+        (fun β : BasedPath x₀ ↦ (β.1 : C(I, X))) ⁻¹'
+          {f : C(I, X) | Set.MapsTo f
+            (Set.Icc (part.t i.castSucc) (part.t i.succ) : Set I) (U i)} := by
+      ext β; simp [Set.MapsTo, Set.mem_Icc]
+    rw [h_U_preimage]
+    exact (ContinuousMap.isOpen_setOf_mapsTo isCompact_Icc (hU_open i)).preimage
+      continuous_subtype_val
+  · have h_V_iInter : {β : BasedPath x₀ | ∀ j, β.1 (part.t j) ∈ V j} =
+        ⋂ j : Fin (n' + 2), {β : BasedPath x₀ | β.1 (part.t j) ∈ V j} := by ext β; simp
+    rw [h_V_iInter]
+    exact isOpen_iInter_of_finite fun j ↦
+      (hV_open j).preimage ((continuous_eval_const (part.t j)).comp continuous_subtype_val)
+
+/-- Variable-endpoint tube/component theorem.
+
+In a locally path-connected space, if semilocal simple connectivity holds along `α.toPath` and
+`α : BasedPath x₀` has endpoint in an open set `U`, then `α` has an open neighborhood `N` in
+`BasedPath x₀` such that every element of `N` has endpoint in `U` and lies in the same path
+component of `endpoint ⁻¹' U` as `α`. -/
+public theorem exists_open_nhd_pathComponent_preimage
+    [LocallyPathConnectedSpace X] {U : Set X} (hU_open : IsOpen U)
+    (α : BasedPath x₀) (hslsc : SemilocallySimplyConnectedOn (Set.range α.toPath))
+    (hα : endpoint α ∈ U) :
+    ∃ N : Set (BasedPath x₀), IsOpen N ∧ α ∈ N ∧
+      N ⊆ endpoint (x₀ := x₀) ⁻¹' U ∧
+      ∀ β ∈ N, JoinedIn (endpoint (x₀ := x₀) ⁻¹' U) α β := by
+  classical
+  obtain ⟨n, part, T, hα_tube⟩ :=
+    α.toPath.exists_partition_in_pathHomotopyTrivial_neighborhoods hslsc
+  -- Rule out `n = 0`; the rest of the proof assumes `n = n' + 1`.
+  match n, part, T, hα_tube with
+  | 0, part, _, _ => exact isEmptyElim part
+  | n' + 1, part, T, hα_tube =>
+  -- Endpoint of α at the last partition point equals `endpoint α`.
+  have hα_at_last : α.toPath (part.t (Fin.last (n' + 1))) = endpoint α := by
+    rw [part.t_last]; exact α.toPath.target
+  obtain ⟨V_last', hV'_open, hV'_pathConn, hα_V', hV'_sub_V, hV'_sub_U⟩ :=
+    exists_refined_terminal_vertex hU_open α hα part T hα_tube
+  -- Refined V function: `V_last'` at the last partition point, `T.V` elsewhere.
+  set V' : Fin (n' + 2) → Set X :=
+    Fin.snoc (fun j : Fin (n' + 1) ↦ T.V j.castSucc) V_last' with hV'_def
+  have hV'_last_eq : V' (Fin.last (n' + 1)) = V_last' := Fin.snoc_last ..
+  have hV'_castSucc_eq : ∀ j : Fin (n' + 1), V' j.castSucc = T.V j.castSucc := fun j ↦
+    Fin.snoc_castSucc ..
+  have hV'_sub_TV : ∀ j : Fin (n' + 2), V' j ⊆ T.V j := by
+    intro j
+    induction j using Fin.lastCases with
+    | last => rw [hV'_last_eq]; exact hV'_sub_V
+    | cast k => rw [hV'_castSucc_eq]
+  have hV'_open_all : ∀ j, IsOpen (V' j) := by
+    intro j
+    induction j using Fin.lastCases with
+    | last => rw [hV'_last_eq]; exact hV'_open
+    | cast k => rw [hV'_castSucc_eq]; exact T.V_open _
+  have hV'_pathConn_all : ∀ j, IsPathConnected (V' j) := by
+    intro j
+    induction j using Fin.lastCases with
+    | last => rw [hV'_last_eq]; exact hV'_pathConn
+    | cast k => rw [hV'_castSucc_eq]; exact T.V_pathConn _
+  have hα_passes_V' : ∀ j, α.toPath (part.t j) ∈ V' j := by
+    intro j
+    induction j using Fin.lastCases with
+    | last => rw [hV'_last_eq, hα_at_last]; exact hα_V'
+    | cast k => rw [hV'_castSucc_eq]; exact hα_tube.passes_through_V _
+  let T' : TubeData X (n' + 1) := {
+    U := T.U
+    V := V'
+    U_open := T.U_open
+    U_slsc := T.U_slsc
+    V_open := hV'_open_all
+    V_pathConn := hV'_pathConn_all
+    V_left_subset := fun i ↦ (hV'_sub_TV i.castSucc).trans (T.V_left_subset i)
+    V_right_subset := fun i ↦ (hV'_sub_TV i.succ).trans (T.V_right_subset i)
+  }
+  -- The neighborhood `N` of `α`: based paths satisfying the refined tube conditions.
+  set N : Set (BasedPath x₀) := {β : BasedPath x₀ |
+      (∀ (i : Fin (n' + 1)) (s : I),
+          (part.t i.castSucc : ℝ) ≤ s ∧ s ≤ (part.t i.succ : ℝ) → β.1 s ∈ T.U i) ∧
+      (∀ j, β.1 (part.t j) ∈ V' j)} with hN_def
+  refine ⟨N, ?_, ?_, ?_, ?_⟩
+  · simpa [hN_def] using! isOpen_refined_tubeNeighborhood part T.U_open hV'_open_all
+  · -- `α ∈ N`.
+    exact ⟨hα_tube.stays_in_U, hα_passes_V'⟩
+  · -- `N ⊆ endpoint ⁻¹' U`.
+    intro β hβ
+    have h1 : β.1 (part.t (Fin.last (n' + 1))) ∈ V' (Fin.last (n' + 1)) := hβ.2 _
+    rw [hV'_last_eq] at h1
+    exact hV'_sub_U (by simpa [part.t_last] using! h1)
+  · -- Every `β ∈ N` is `JoinedIn (endpoint ⁻¹' U)` to `α`.
+    intro β hβ
+    obtain ⟨hβ_stays, hβ_passes⟩ := hβ
+    -- Endpoint of `β` lies in `U`.
+    have hβ_end_U : endpoint β ∈ U := by
+      have h1 : β.1 (part.t (Fin.last (n' + 1))) ∈ V' (Fin.last (n' + 1)) := hβ_passes _
+      rw [hV'_last_eq] at h1
+      exact hV'_sub_U (by simpa [part.t_last] using! h1)
+    have hβ_tube : PathInTube β.toPath part T' :=
+      ⟨hβ_stays, hβ_passes⟩
+    have hα_tube' : PathInTube α.toPath part T' :=
+      ⟨hα_tube.stays_in_U, hα_passes_V'⟩
+    obtain ⟨ρ_final, hρ_final_range_V, h_paste⟩ :=
+      Path.tube_subset_homotopy_class_source α.toPath part T' hα_tube' β.toPath hβ_tube
+    have hρ_final_range : Set.range ρ_final ⊆ U :=
+      hρ_final_range_V.trans (by
+        -- `T'.V` is defeq to the local family `V'`; expose it so `hV'_last_eq` rewrites.
+        change V' (Fin.last (n' + 1)) ⊆ U
+        rw [hV'_last_eq]
+        exact hV'_sub_U)
+    -- Join `α` to `append α ρ_final`, then deform `append α ρ_final` to `β` via `h_paste`.
+    refine (joinedIn_preimage_of_append α ρ_final hρ_final_range).trans ?_
+    obtain ⟨γ, hγ⟩ :=
+      (joinedIn_endpoint_preimage_of_homotopic (x₀ := x₀) (U := ({endpoint β} : Set X))
+        (show endpoint β ∈ ({endpoint β} : Set X) from rfl)
+        (show Path.Homotopic (α.toPath.trans ρ_final) β.toPath from h_paste)).mono
+        (Set.preimage_mono (Set.singleton_subset_iff.mpr hβ_end_U))
+    exact ⟨γ.cast rfl (by ext t; rfl), hγ⟩
+
+/-- For an open neighborhood `U`, path components of `endpoint ⁻¹' U` are open. -/
+public theorem isOpen_pathComponent_preimage
+    [SemilocallySimplyConnectedSpace X] [LocallyPathConnectedSpace X]
+    {U : Set X} (hU_open : IsOpen U) (α : BasedPath x₀) :
+    IsOpen (pathComponentIn (endpoint (x₀ := x₀) ⁻¹' U) α) := by
+  apply isOpen_iff_mem_nhds.mpr
+  intro β hβ
+  have hβ_end_U : endpoint β ∈ U := hβ.target_mem
+  obtain ⟨N, hN_open, hβ_N, _, hN_joined⟩ :=
+    exists_open_nhd_pathComponent_preimage hU_open
+      β
+      (SemilocallySimplyConnectedOn.of_semilocallySimplyConnectedSpace (Set.range β.toPath))
+      hβ_end_U
+  refine mem_nhds_iff.mpr ⟨N, ?_, hN_open, hβ_N⟩
+  intro γ hγ_N
+  exact hβ.trans (hN_joined γ hγ_N)
+
+section joinedInSLSC
+
+/-! Reparametrisation helpers for
+`toPath_homotopic_of_joinedIn_pathHomotopyTrivial` (private to this section). -/
+
+private def joinedInSLSC_uReal (ts : ℝ × ℝ) : ℝ :=
+  ts.1 + max 0 (2 * ts.2 - 1) * (1 - ts.1)
+
+private def joinedInSLSC_vReal (ts : ℝ × ℝ) : ℝ :=
+  min (2 * ts.2) 1
+
+private theorem joinedInSLSC_uReal_mem (t s : I) :
+    joinedInSLSC_uReal ((t : ℝ), (s : ℝ)) ∈ I := by
+  simp only [joinedInSLSC_uReal]
+  have hm_nn : (0 : ℝ) ≤ max 0 (2 * (s : ℝ) - 1) := le_max_left _ _
+  have hm_le : max 0 (2 * (s : ℝ) - 1) ≤ 1 := max_le zero_le_one (by linarith [s.2.2])
+  refine ⟨?_, ?_⟩
+  · have h0 : 0 ≤ max 0 (2 * (s : ℝ) - 1) * (1 - (t : ℝ)) :=
+      mul_nonneg hm_nn (by linarith [t.2.2])
+    linarith [t.2.1]
+  · nlinarith [t.2.1, t.2.2]
+
+private theorem joinedInSLSC_vReal_mem (t s : I) :
+    joinedInSLSC_vReal ((t : ℝ), (s : ℝ)) ∈ I := by
+  refine ⟨le_min (by linarith [s.2.1]) zero_le_one, min_le_right _ _⟩
+
+private def joinedInSLSC_uFn : I × I → I := fun ts ↦
+  ⟨joinedInSLSC_uReal ((ts.1 : ℝ), (ts.2 : ℝ)), joinedInSLSC_uReal_mem ts.1 ts.2⟩
+
+private def joinedInSLSC_vFn : I × I → I := fun ts ↦
+  ⟨joinedInSLSC_vReal ((ts.1 : ℝ), (ts.2 : ℝ)), joinedInSLSC_vReal_mem ts.1 ts.2⟩
+
+private theorem joinedInSLSC_uFn_zero_left (s : I) :
+    (joinedInSLSC_uFn (0, s) : ℝ) = max 0 (2 * (s : ℝ) - 1) := by
+  simp [joinedInSLSC_uFn, joinedInSLSC_uReal]
+
+private theorem joinedInSLSC_uFn_one_left (s : I) : joinedInSLSC_uFn (1, s) = 1 :=
+  Subtype.ext (by simp [joinedInSLSC_uFn, joinedInSLSC_uReal])
+
+private theorem joinedInSLSC_uFn_one_right (t : I) : joinedInSLSC_uFn (t, 1) = 1 :=
+  Subtype.ext (by simp [joinedInSLSC_uFn, joinedInSLSC_uReal]; ring)
+
+private theorem joinedInSLSC_vFn_left (t s : I) :
+    (joinedInSLSC_vFn (t, s) : ℝ) = min (2 * (s : ℝ)) 1 := by
+  simp [joinedInSLSC_vFn, joinedInSLSC_vReal]
+
+private theorem joinedInSLSC_vFn_zero_right (t : I) : joinedInSLSC_vFn (t, 0) = 0 :=
+  Subtype.ext (by simp [joinedInSLSC_vFn, joinedInSLSC_vReal])
+
+private theorem joinedInSLSC_vFn_one_right (t : I) : joinedInSLSC_vFn (t, 1) = 1 :=
+  Subtype.ext (by simp [joinedInSLSC_vFn, joinedInSLSC_vReal])
+
+private theorem joinedInSLSC_uFn_zero_left_eq_zero_of_le_half {s : I}
+    (hs : (s : ℝ) ≤ 1 / 2) : joinedInSLSC_uFn (0, s) = 0 :=
+  Subtype.ext <| by
+    rw [joinedInSLSC_uFn_zero_left, max_eq_left (by linarith)]; rfl
+
+private theorem joinedInSLSC_uFn_zero_left_eq_two_mul_sub_one_of_half_le
+    {s : I} (hs : 1 / 2 ≤ (s : ℝ)) :
+    joinedInSLSC_uFn (0, s) =
+      ⟨2 * (s : ℝ) - 1,
+        unitInterval.two_mul_sub_one_mem_iff.2 ⟨hs, s.2.2⟩⟩ :=
+  Subtype.ext <| by
+    rw [joinedInSLSC_uFn_zero_left, max_eq_right (by linarith)]
+
+private theorem joinedInSLSC_vFn_eq_two_mul_of_le_half {t s : I}
+    (hs : (s : ℝ) ≤ 1 / 2) :
+    joinedInSLSC_vFn (t, s) =
+      ⟨2 * (s : ℝ),
+        (unitInterval.mul_pos_mem_iff zero_lt_two).2 ⟨s.2.1, hs⟩⟩ :=
+  Subtype.ext <| by rw [joinedInSLSC_vFn_left, min_eq_left (by linarith)]
+
+private theorem joinedInSLSC_vFn_eq_one_of_half_le {t s : I}
+    (hs : 1 / 2 ≤ (s : ℝ)) : joinedInSLSC_vFn (t, s) = 1 :=
+  Subtype.ext <| by
+    rw [joinedInSLSC_vFn_left, min_eq_right (by linarith)]; rfl
+
+end joinedInSLSC
+
+/-- If `α` and `β` are based paths with the same endpoint `v ∈ U`, joined inside
+`endpoint ⁻¹' U`, and `U` has the SLSC uniqueness property, then their associated paths
+`α.toPath` and `β.toPath` are homotopic (after casting to a common endpoint).
+
+This is the heart of the sheet-injectivity argument: a path in the based-path space descends
+to a free homotopy of paths in `X` whose endpoint trace is a loop in `U`, which is killed by
+the SLSC hypothesis. -/
+public theorem toPath_homotopic_of_joinedIn_pathHomotopyTrivial
+    {U : Set X} (hU_slsc : IsPathHomotopyTrivial U)
+    {α β : BasedPath x₀}
+    (heq : endpoint α = endpoint β)
+    (hAB : JoinedIn (endpoint (x₀ := x₀) ⁻¹' U) α β) :
+    Path.Homotopic (α.toPath.cast rfl heq.symm) β.toPath := by
+  obtain ⟨F, hF_U⟩ := hAB
+  set v : X := endpoint β with hv_def
+  -- Uncurry F to get a continuous map (t, s) ↦ (F t).1 s.
+  have hFv_cont : Continuous (fun ts : I × I ↦ (F ts.1).1 ts.2) := by
+    have h1 : Continuous (fun t : I ↦ ((F t).1 : C(I, X))) :=
+      continuous_subtype_val.comp F.continuous
+    exact ContinuousMap.continuous_uncurry_of_continuous ⟨_, h1⟩
+  -- The endpoint-trace loop `L : Path v v`.
+  have hF0_eq : (F (0 : I)).1 = α.1 := congrArg Subtype.val F.source
+  have hF1_eq : (F (1 : I)).1 = β.1 := congrArg Subtype.val F.target
+  have hv : v ∈ U := by
+    simpa [v, hv_def, endpoint_def, hF1_eq] using hF_U 1
+  let L : Path v v :=
+    { toFun := fun t ↦ (F t).1 1
+      continuous_toFun := by
+        simpa using! hFv_cont.comp (continuous_id.prodMk (continuous_const (y := (1 : I))))
+      source' := by rw [hF0_eq]; exact heq
+      target' := by rw [hF1_eq]; rfl }
+  have hL_refl : L.Homotopic (Path.refl v) :=
+    hU_slsc.apply L (Path.refl v) (by rintro _ ⟨t, rfl⟩; exact hF_U t) (by
+      rintro _ ⟨_, rfl⟩; simpa using! hv)
+  -- Cast α.toPath to target `v`.
+  let α' : Path x₀ v := α.toPath.cast rfl heq.symm
+  have hu_cont : Continuous joinedInSLSC_uReal :=
+    (continuous_fst).add <|
+      (Continuous.max continuous_const (by fun_prop)).mul (by fun_prop)
+  have hv_cont_real : Continuous joinedInSLSC_vReal :=
+    Continuous.min (by fun_prop) continuous_const
+  have hu_fn_cont : Continuous joinedInSLSC_uFn :=
+    Continuous.subtype_mk (hu_cont.comp (by fun_prop)) _
+  have hv_fn_cont : Continuous joinedInSLSC_vFn :=
+    Continuous.subtype_mk (hv_cont_real.comp (by fun_prop)) _
+  -- The rectangle homotopy.
+  let K_fn : I × I → X := fun ts ↦ (F (joinedInSLSC_uFn ts)).1 (joinedInSLSC_vFn ts)
+  have K_fn_apply : ∀ ts : I × I, K_fn ts = (F (joinedInSLSC_uFn ts)).1 (joinedInSLSC_vFn ts) :=
+    fun _ ↦ rfl
+  have hK_cont : Continuous K_fn :=
+    hFv_cont.comp (hu_fn_cont.prodMk hv_fn_cont)
+  -- Auxiliary identities evaluating K at corners/edges.
+  have hK_zero : ∀ s : I, K_fn (0, s) = (α'.trans L) s := by
+    intro s
+    rw [K_fn_apply, Path.trans_apply]
+    by_cases hs : (s : ℝ) ≤ 1 / 2
+    · rw [dif_pos hs,
+        joinedInSLSC_uFn_zero_left_eq_zero_of_le_half hs,
+        joinedInSLSC_vFn_eq_two_mul_of_le_half hs, hF0_eq]; rfl
+    · rw [dif_neg hs,
+        joinedInSLSC_uFn_zero_left_eq_two_mul_sub_one_of_half_le (not_le.mp hs).le,
+        joinedInSLSC_vFn_eq_one_of_half_le (not_le.mp hs).le]; rfl
+  have hK_one : ∀ s : I, K_fn (1, s) = (β.toPath.trans (Path.refl v)) s := by
+    intro s
+    rw [K_fn_apply, Path.trans_apply, joinedInSLSC_uFn_one_left]
+    by_cases hs : (s : ℝ) ≤ 1 / 2
+    · rw [dif_pos hs, joinedInSLSC_vFn_eq_two_mul_of_le_half hs, hF1_eq]; rfl
+    · rw [dif_neg hs,
+        joinedInSLSC_vFn_eq_one_of_half_le (not_le.mp hs).le, hF1_eq]; rfl
+  have hK_at_zero : ∀ t : I, K_fn (t, 0) = x₀ := fun t ↦ by
+    rw [K_fn_apply, joinedInSLSC_vFn_zero_right]
+    exact (F (joinedInSLSC_uFn (t, 0))).2
+  have hK_at_one : ∀ t : I, K_fn (t, 1) = v := fun t ↦ by
+    rw [K_fn_apply, joinedInSLSC_uFn_one_right, joinedInSLSC_vFn_one_right, hF1_eq]
+    rfl
+  let K : Path.Homotopy (α'.trans L) (β.toPath.trans (Path.refl v)) :=
+    { toFun := K_fn
+      continuous_toFun := hK_cont
+      map_zero_left := hK_zero
+      map_one_left := hK_one
+      prop' := by
+        intro t s hs
+        rcases hs with rfl | hs
+        -- `prop'` only exposes an edge evaluation goal; name the let-bound `K_fn` form.
+        · change K_fn (t, (0 : I)) = (α'.trans L) 0
+          rw [hK_at_zero, (α'.trans L).source]
+        · rw [Set.mem_singleton_iff] at hs
+          subst hs
+          -- `prop'` only exposes an edge evaluation goal; name the let-bound `K_fn` form.
+          change K_fn (t, (1 : I)) = (α'.trans L) 1
+          rw [hK_at_one, (α'.trans L).target] }
+  have h_rect : (α'.trans L).Homotopic (β.toPath.trans (Path.refl v)) := ⟨K⟩
+  -- Combine: α' ≃ α'.trans (refl v) ≃ α'.trans L ≃ β.trans (refl v) ≃ β.
+  have h_α_trans_refl : (α'.trans (Path.refl v)).Homotopic α' := Path.Homotopic.trans_refl α'
+  have h_α_L_refl : (α'.trans (Path.refl v)).Homotopic (α'.trans L) :=
+    Path.Homotopic.hcomp (Path.Homotopic.refl α') hL_refl.symm
+  have h_β_trans_refl : (β.toPath.trans (Path.refl v)).Homotopic β.toPath :=
+    Path.Homotopic.trans_refl β.toPath
+  exact h_α_trans_refl.symm.trans <| h_α_L_refl.trans <| h_rect.trans h_β_trans_refl
+
+/-- Path components of `endpoint ⁻¹' U` are invariant under endpoint-preserving homotopy:
+if `p ≃ q` are homotopic paths from `x₀` to `y ∈ U`, then the based paths `ofPath p` and
+`ofPath q` lie in the same path component of `endpoint ⁻¹' U`. -/
+public theorem pathComponent_preimage_saturated
+    {U : Set X} {y : X} (hy : y ∈ U)
+    {p q : Path x₀ y} (h : Path.Homotopic p q) :
+    pathComponentIn (endpoint (x₀ := x₀) ⁻¹' U) (ofPath p) =
+      pathComponentIn (endpoint (x₀ := x₀) ⁻¹' U) (ofPath q) :=
+  pathComponentIn_congr (joinedIn_endpoint_preimage_of_homotopic x₀ hy h).symm
+
+end BasedPath

--- a/TauCeti/AlgebraicTopology/UniversalCover/BasedPath.lean
+++ b/TauCeti/AlgebraicTopology/UniversalCover/BasedPath.lean
@@ -13,34 +13,9 @@ public import Mathlib.Topology.Order.Basic
 /-!
 # Based paths
 
-For a topological space `X` and basepoint `x₀ : X`, this file introduces the space
-`BasedPath x₀` of continuous maps `γ : C(I, X)` with `γ 0 = x₀`, topologised as a subspace
-of the compact-open topology on `C(I, X)`. It then develops the path-component machinery of
-`endpoint ⁻¹' U` that feeds the universal-cover construction.
-
-This file is adapted from the Mathlib draft
+This file introduces the compact-open based-path space `BasedPath x₀` and the path-component
+machinery of `endpoint ⁻¹' U` used in the universal-cover construction. It is adapted from
 [#38292](https://github.com/leanprover-community/mathlib4/pull/38292) by Kim Morrison.
-
-## Main definitions
-
-* `BasedPath x₀`: the compact-open space of based paths out of `x₀`.
-* `BasedPath.endpoint`, `BasedPath.toPath`, `BasedPath.ofPath`, `BasedPath.append`:
-  basic API for operating on based paths.
-* `Path.initialSegmentFamily`: the family `t ↦ γ|_[0, t]` of initial segments of a path.
-
-## Main results
-
-* `BasedPath.isOpenMap_endpoint`: the endpoint map `BasedPath x₀ → X` is open when `X` is
-  locally path-connected.
-* `BasedPath.joinedIn_preimage_of_append`: appending a path inside `U` moves a based path
-  within the same path component of `endpoint ⁻¹' U`.
-* `BasedPath.exists_open_nhd_pathComponent_preimage`: when semilocal simple connectivity holds
-  along a based path, every based path landing in an open set `U` has an open
-  neighbourhood of based paths joined to it inside `endpoint ⁻¹' U`.
-* `BasedPath.isOpen_pathComponent_preimage`: in a semilocally simply connected, locally
-  path-connected space, path components of `endpoint ⁻¹' U` (for good `U`) are open.
-* `BasedPath.pathComponent_preimage_saturated`: path components of `endpoint ⁻¹' U` are
-  invariant under endpoint-preserving homotopy.
 -/
 
 open scoped unitInterval

--- a/TauCeti/AlgebraicTopology/UniversalCover/Prelude.lean
+++ b/TauCeti/AlgebraicTopology/UniversalCover/Prelude.lean
@@ -1,0 +1,206 @@
+/-
+Copyright (c) 2026 Lean FRO, LLC. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Kim Morrison
+-/
+module
+
+public import Mathlib.Topology.UnitInterval
+public import Mathlib.Topology.Path
+public import Mathlib.Topology.Subpath
+public import Mathlib.Topology.Homotopy.Path
+public import Mathlib.Topology.Connected.PathConnected
+public import Mathlib.AlgebraicTopology.FundamentalGroupoid.Basic
+
+/-!
+# Universal-cover prelude
+
+Declarations from the universal-cover work in
+[mathlib4#38292](https://github.com/leanprover-community/mathlib4/pull/38292) (Kim Morrison) that
+are not yet in the pinned Mathlib. Several supporting declarations also come from
+[mathlib4#31449](https://github.com/leanprover-community/mathlib4/pull/31449) (Kim Morrison).
+
+When the pinned Mathlib advances past these upstream declarations, this shim should be removed
+declaration-by-declaration in the same bump PR that switches downstream imports to Mathlib's
+versions.
+-/
+
+public section
+
+open scoped unitInterval
+open Topology Set
+
+namespace unitInterval
+/-- The midpoint of the unit interval. -/
+@[expose]
+noncomputable def half : I := ⟨1 / 2, by constructor <;> linarith⟩
+
+@[simp]
+theorem coe_half : (half : ℝ) = 1 / 2 := rfl
+
+end unitInterval
+
+/-- Finite-`Fin` partition variant: Any open cover of `[a, b]` can be refined to a monotone
+partition indexed by `Fin (n + 1)`. -/
+lemma exists_monotone_partition_Icc {ι} {a b : ℝ} (h : a ≤ b) {c : ι → Set (Icc a b)}
+    (hc₁ : ∀ i, IsOpen (c i)) (hc₂ : univ ⊆ ⋃ i, c i) :
+    ∃ (n : ℕ) (t : Fin (n + 1) → Icc a b),
+      Monotone t ∧ t 0 = a ∧ t (Fin.last n) = b ∧
+      ∀ i : Fin n, ∃ j : ι, Icc (t i.castSucc) (t i.succ) ⊆ c j := by
+  obtain ⟨t, ht0, ht_mono, ⟨N, hN⟩, ht_cover⟩ :=
+    exists_monotone_Icc_subset_open_cover_Icc h hc₁ hc₂
+  refine ⟨N, fun k ↦ t (k : ℕ), fun _ _ hij ↦ ht_mono hij, ?_, ?_, fun i ↦ ?_⟩
+  · simpa using ht0
+  · simpa using hN N le_rfl
+  · obtain ⟨j, hj⟩ := ht_cover i
+    exact ⟨j, by simpa [Fin.val_succ, Fin.val_castSucc] using hj⟩
+
+/-- Finite-`Fin` partition variant for the unit interval. -/
+lemma exists_monotone_partition_unitInterval {ι} {c : ι → Set I}
+    (hc₁ : ∀ i, IsOpen (c i)) (hc₂ : univ ⊆ ⋃ i, c i) :
+    ∃ (n : ℕ) (t : Fin (n + 1) → I),
+      Monotone t ∧ t 0 = 0 ∧ t (Fin.last n) = 1 ∧
+      ∀ i : Fin n, ∃ j : ι, Icc (t i.castSucc) (t i.succ) ⊆ c j := by
+  obtain ⟨N, t, ht_mono, ht0, htN, ht_cover⟩ :=
+    exists_monotone_partition_Icc zero_le_one hc₁ hc₂
+  exact ⟨N, t, ht_mono, Subtype.ext ht0, Subtype.ext htN, ht_cover⟩
+
+
+/-- In a path-connected set `U`, two points of `U` are joined by a path with range in `U`. -/
+theorem IsPathConnected.exists_path {X : Type*} [TopologicalSpace X] {a b : X} {U : Set X}
+    (hU : IsPathConnected U) (ha : a ∈ U) (hb : b ∈ U) : ∃ p : Path a b, Set.range p ⊆ U :=
+  let hab : JoinedIn U a b := hU.joinedIn _ ha _ hb
+  ⟨hab.somePath, Set.range_subset_iff.mpr hab.somePath_mem⟩
+
+namespace Path
+variable {X : Type*} [TopologicalSpace X]
+
+/-- Restrict a path whose image lies in a subset to a path in the corresponding subtype.
+The source and target are the given subtype endpoints, and coercing the restricted path back to
+`X` recovers the original path pointwise. -/
+@[expose]
+def codRestrict {s : Set X} {x y : s} (γ : Path x.val y.val) (hmem : ∀ t, γ t ∈ s) :
+    Path x y where
+  toFun := s.codRestrict γ hmem
+  continuous_toFun := γ.continuous.codRestrict hmem
+  source' := Subtype.ext γ.source
+  target' := Subtype.ext γ.target
+
+@[simp]
+theorem codRestrict_coe {s : Set X} {x y : s} (γ : Path x.val y.val) (hmem : ∀ t, γ t ∈ s) (t : I) :
+    (γ.codRestrict hmem t : X) = γ t := rfl
+
+@[simp]
+theorem map_codRestrict {s : Set X} {x y : s} (γ : Path x.val y.val) (hmem : ∀ t, γ t ∈ s) :
+    (γ.codRestrict hmem).map continuous_subtype_val = γ := rfl
+
+
+/-- Generic Lebesgue partition lemma for paths: Given an open cover of a path's range,
+there exists a finite partition of [0,1] such that each segment lies entirely in one set
+from the cover. -/
+theorem exists_partition_in_cover
+    {ι : Type*} (U : ι → Set X) (hU_open : ∀ i, IsOpen (U i))
+    {x y : X} (γ : Path x y) (hU_cover : ∀ s : unitInterval, ∃ i, γ s ∈ U i) :
+    ∃ (n : ℕ) (t : Fin (n + 1) → unitInterval),
+      Monotone t ∧ t 0 = 0 ∧ t (Fin.last n) = 1 ∧
+      (∀ i : Fin n, ∃ j : ι,
+        ∀ s : unitInterval, (t i.castSucc : ℝ) ≤ s ∧ s ≤ (t i.succ : ℝ) → γ s ∈ U j) := by
+  -- Pull back the cover along `γ`; the result is an open cover of `unitInterval`.
+  obtain ⟨n, t, ht_mono, ht0, htn, ht_cover⟩ :=
+    exists_monotone_partition_unitInterval
+      (fun i ↦ (hU_open i).preimage γ.continuous)
+      (fun s _ ↦ by
+        obtain ⟨i, hi⟩ := hU_cover s
+        exact Set.mem_iUnion.2 ⟨i, hi⟩)
+  refine ⟨n, t, ht_mono, ht0, htn, fun i ↦ ?_⟩
+  obtain ⟨j, hj⟩ := ht_cover i
+  exact ⟨j, fun s hs ↦ hj ⟨hs.1, hs.2⟩⟩
+
+/-- Generic Lebesgue partition lemma for paths, neighborhood version: If every point on a path
+has a neighborhood with property P, then there exists a partition such that each segment lies
+in an open set with property P. This follows immediately from the cover version. -/
+theorem exists_partition_with_property {x y : X} (γ : Path x y) (P : Set X → Prop)
+    (h : ∀ z ∈ Set.range γ, ∃ U : Set X, IsOpen U ∧ z ∈ U ∧ P U) :
+    ∃ (n : ℕ) (t : Fin (n + 1) → unitInterval),
+      Monotone t ∧ t 0 = 0 ∧ t (Fin.last n) = 1 ∧
+      (∀ i : Fin n, ∃ U : Set X, IsOpen U ∧ P U ∧
+        ∀ s : unitInterval, (t i.castSucc : ℝ) ≤ s ∧ s ≤ (t i.succ : ℝ) → γ s ∈ U) := by
+  choose U hU_open hU_mem hU_P using h
+  obtain ⟨n, t, h_mono, h_start, h_end, h_segments⟩ :=
+    exists_partition_in_cover (fun z : Set.range γ ↦ U z.val z.property)
+      (fun z ↦ hU_open z.val z.property) γ fun s ↦
+        ⟨⟨γ s, ⟨s, rfl⟩⟩, hU_mem (γ s) ⟨s, rfl⟩⟩
+  refine ⟨n, t, h_mono, h_start, h_end, fun i ↦ ?_⟩
+  obtain ⟨⟨z, hz⟩, h_seg⟩ := h_segments i
+  exact ⟨U z hz, hU_open z hz, hU_P z hz, h_seg⟩
+
+end Path
+
+namespace Path
+variable {X : Type*} [TopologicalSpace X] {x y : X}
+
+namespace Homotopic.Quotient
+
+@[simp]
+theorem subpath_trans {x y : X} (p : Path x y)
+    (a b c : unitInterval) (_hab : a ≤ b) (_hbc : b ≤ c) :
+    trans (mk (p.subpath a b)) (mk (p.subpath b c)) =
+      mk (p.subpath a c) := by
+  simp only [← mk_trans, eq]
+  exact ⟨Path.Homotopy.subpathTransSubpath p a b c⟩
+
+@[simp]
+theorem subpath_self {x y : X} (p : Path x y) (a : unitInterval) :
+    mk (p.subpath a a) = refl (p a) := by
+  simp only [← mk_refl, eq]
+  rw [Path.subpath_self]
+
+@[simp]
+theorem subpath_zero_one {x y : X} (p : Path x y) :
+    mk (p.subpath 0 1) = (mk p).cast (by simp) (by simp) := by
+  simp only [← mk_cast, eq]
+  rw [Path.subpath_zero_one]
+
+end Homotopic.Quotient
+
+end Path
+
+namespace Path.Homotopic
+variable {X : Type*} [TopologicalSpace X] {x₀ x₁ : X}
+
+/-- Composing on the left with a null-homotopic loop does not change the homotopy class. -/
+theorem trans_left_of_nullhomotopic {γ₀ : Path x₀ x₀} {γ₁ : Path x₀ x₁}
+    (hγ₀ : γ₀.Homotopic (Path.refl x₀)) : (γ₀.trans γ₁).Homotopic γ₁ :=
+  (hcomp hγ₀ (.refl γ₁)).trans (refl_trans γ₁)
+
+/-- Composing on the right with a null-homotopic loop does not change the homotopy class. -/
+theorem trans_right_of_nullhomotopic {γ₀ : Path x₀ x₁} {γ₁ : Path x₁ x₁}
+    (hγ₁ : γ₁.Homotopic (Path.refl x₁)) : (γ₀.trans γ₁).Homotopic γ₀ :=
+  (hcomp (.refl γ₀) hγ₁).trans (trans_refl γ₀)
+
+/-- If `γ.trans γ'.symm` is nullhomotopic, then `γ` and `γ'` are homotopic.
+This is the path-homotopy analogue of `a * b⁻¹ = 1 → a = b`. -/
+theorem of_trans_symm {γ γ' : Path x₀ x₁}
+    (h : (γ.trans γ'.symm).Homotopic (Path.refl x₀)) : γ.Homotopic γ' :=
+  (trans_refl γ).symm |>.trans <|
+  (hcomp (.refl γ) (symm_trans γ').symm) |>.trans <|
+  (trans_assoc γ γ'.symm γ').symm |>.trans <|
+  (hcomp h (.refl γ')) |>.trans <|
+  refl_trans γ'
+namespace Quotient
+variable {x₀ x₁ : X}
+
+@[simp, grind =]
+theorem refl_cast {x y : X} (h : y = x) : (refl x).cast h h = refl y := by
+  cases h; rfl
+/-- If `trans γ (symm γ') = refl`, then `γ = γ'`.
+This is the quotient analogue of `a * b⁻¹ = 1 → a = b`. -/
+theorem of_trans_symm {γ γ' : Homotopic.Quotient x₀ x₁}
+    (h : trans γ (symm γ') = refl x₀) : γ = γ' := by
+  induction γ using Quotient.ind with | mk γ =>
+  induction γ' using Quotient.ind with | mk γ' =>
+  simp only [← mk_trans, ← mk_symm, ← mk_refl] at h
+  exact Quotient.sound (Homotopic.of_trans_symm (Quotient.exact h))
+
+end Quotient
+end Path.Homotopic

--- a/TauCeti/AlgebraicTopology/UniversalCover/Prelude.lean
+++ b/TauCeti/AlgebraicTopology/UniversalCover/Prelude.lean
@@ -15,14 +15,7 @@ public import Mathlib.AlgebraicTopology.FundamentalGroupoid.Basic
 /-!
 # Universal-cover prelude
 
-Declarations from the universal-cover work in
-[mathlib4#38292](https://github.com/leanprover-community/mathlib4/pull/38292) (Kim Morrison) that
-are not yet in the pinned Mathlib. Several supporting declarations also come from
-[mathlib4#31449](https://github.com/leanprover-community/mathlib4/pull/31449) (Kim Morrison).
-
-When the pinned Mathlib advances past these upstream declarations, this shim should be removed
-declaration-by-declaration in the same bump PR that switches downstream imports to Mathlib's
-versions.
+Shim declarations from upstream universal-cover work not yet in the pinned Mathlib.
 -/
 
 public section

--- a/TauCeti/AlgebraicTopology/UniversalCover/Prelude.lean
+++ b/TauCeti/AlgebraicTopology/UniversalCover/Prelude.lean
@@ -142,13 +142,11 @@ theorem subpath_trans {x y : X} (p : Path x y)
   simp only [← mk_trans, eq]
   exact ⟨Path.Homotopy.subpathTransSubpath p a b c⟩
 
-@[simp]
 theorem subpath_self {x y : X} (p : Path x y) (a : unitInterval) :
     mk (p.subpath a a) = refl (p a) := by
   simp only [← mk_refl, eq]
   rw [Path.subpath_self]
 
-@[simp]
 theorem subpath_zero_one {x y : X} (p : Path x y) :
     mk (p.subpath 0 1) = (mk p).cast (by simp) (by simp) := by
   simp only [← mk_cast, eq]


### PR DESCRIPTION
This PR ports the foundations of the universal-cover construction into `TauCeti`: the unbased, pointwise form of semilocal simple connectivity together with the tube machinery it powers, the discreteness of homotopy-class fibres, and the based-path space `BasedPath x₀` with its endpoint and path-component API. It resurrects the sorry-free, human-written material from the closed https://github.com/TauCetiProject/TauCeti/pull/42 ("port the based-path space toward the universal cover"), updated to current `main` and the pinned Mathlib, and reconciled with the based `SemilocallySimplyConnectedSpace` class that has since landed.

`SemilocallySimplyConnectedOn.lean` adds `SemilocallySimplyConnectedAt`, `SemilocallySimplyConnectedOn`, and `IsPathHomotopyTrivial` (Brazas' *unbased* notion, Definition 2.2), characterises them in terms of null-homotopic loops and of paths with matching endpoints, and bridges them to the existing based class `TauCeti.SemilocallySimplyConnectedSpace` under local path-connectedness via `SemilocallySimplyConnectedAt.of_semilocallySimplyConnectedSpace` (the two notions coincide there, which is the covering-space setting). It then builds the `IntervalPartition` / `TubeData` / `PathInTube` tube covering of a path and the ladder-homotopy argument, culminating in `Path.Homotopic.Quotient.instDiscreteTopology`: in a semilocally simply connected, locally path-connected space the homotopy-class fibres are discrete. `UniversalCover/BasedPath.lean` develops the compact-open based-path space `BasedPath x₀`, its `endpoint` / `toPath` / `append` / initial-segment API, and the openness and homotopy-invariance of path components of `endpoint ⁻¹' U`. `UniversalCover/Prelude.lean` is a small shim of upstreamable Path/subpath lemmas, to be removed declaration-by-declaration as the pinned Mathlib advances.

It advances `TauCetiRoadmap/UniversalCovers/README.md`, Stage 0, specifically Stage 0.1 (discreteness of homotopy-class fibres, from mathlib4#31576) and the based-path half of Stage 0.2 (`BasedPath x₀` and the path-component machinery of `endpoint ⁻¹' U`, from mathlib4#38292). The remaining Stage 0.2 pieces — the `UniversalCover x₀` quotient, `proj`, `IsCoveringMap proj`, and simple connectivity of the total space — are a follow-up building on this foundation; they were not present in PR #42 and are left for a subsequent PR. Part of https://github.com/TauCetiProject/TauCeti/issues/794.

<!--tauceti-target:v1 {"focus":"UniversalCovers","id":"stage0-universal-cover"}-->

Build evidence: `lake exe cache get` decompressed the warm shared cache (no downloads); `lake build` completes the whole library (`Build completed successfully (4624 jobs)`); `lake exe axioms` reports `audited 9073 TauCeti declaration(s); all within the allowlist [propext, Classical.choice, Quot.sound]`; `lake exe module-system` reports all modules opt in.

🤖 Prepared with Claude Code