### PR TITLE
refactor: derive positive-definite function API from the kernel primitive

### DIFF
--- a/TauCeti/Analysis/PositiveDefinite/Basic.lean
+++ b/TauCeti/Analysis/PositiveDefinite/Basic.lean
@@ -6,8 +6,10 @@ module
 
 public import Mathlib.Analysis.Complex.Order
 public import Mathlib.Analysis.Matrix.Order
-public import Mathlib.Algebra.QuadraticDiscriminant
 public import Mathlib.Algebra.BigOperators.Fin
+public import TauCeti.Analysis.PositiveDefinite.Kernel
+public import TauCeti.Analysis.PositiveDefinite.KernelBounds
+public import TauCeti.Analysis.PositiveDefinite.KernelClosure
 
 /-!
 # Positive-definite functions on an involutive additive monoid
@@ -22,10 +24,17 @@ classical translation-invariant positive-definiteness `∑ cᵢ conj(cⱼ) F(a�
 product monoid `ℝ≥0 × V` it produces the BCR involution `(t, a)⋆ = (t, -a)`.
 
 This file introduces the predicate `TauCeti.IsPositiveDefinite` at this general level and develops
-its basic algebraic API: the value at `0` is real and nonnegative, the function is conjugate
-symmetric in the involution, it satisfies the Cauchy–Schwarz inequality coming from the `2 × 2`
-sub-form, and the class is closed under sums and nonnegative complex scalar multiples, with the
-Schur pointwise product closure and nonnegative constants as examples.
+its basic algebraic API: the value at `0` is real and nonnegative, and the function is conjugate
+symmetric in the involution. These intrinsic facts are then used to establish the correspondence
+with the two-variable kernel `K(a, b) = F(a + b⋆)`
+(`TauCeti.IsPositiveDefinite.isPositiveDefiniteKernel` and its converse
+`TauCeti.IsPositiveDefinite.of_isPositiveDefiniteKernel`), taking the kernel form
+as the single primitive: the Cauchy–Schwarz inequality, the Gram-matrix positivity, and closure
+under sums, nonnegative complex scalar multiples, Schur products, and finite sums/products are all
+obtained by transporting the corresponding kernel statements
+(`TauCeti.Analysis.PositiveDefinite.Kernel`, `.KernelBounds`, `.KernelClosure`) through this
+correspondence rather than being re-proved from the raw definition. Nonnegative constants are an
+example.
 
 This is the `Objects` and first `API to develop` slice of Part C of the `OneParameterSemigroups`
 roadmap in TauCetiRoadmap: "positive-definite functions and Bochner's theorem". Mathlib has
@@ -45,6 +54,10 @@ here. The continuity theory and Bochner's representation theorem are later miles
 * `TauCeti.IsPositiveDefinite.map_zero_re_pos_of_ne_zero`: if `F 0 ≠ 0`, then
   `0 < (F 0).re`.
 * `TauCeti.IsPositiveDefinite.conj_symm`: `conj (F (b + a⋆)) = F (a + b⋆)`.
+* `TauCeti.IsPositiveDefinite.isPositiveDefiniteKernel` and
+  `TauCeti.IsPositiveDefinite.of_isPositiveDefiniteKernel`: the two halves of the correspondence
+  with the kernel `K(a, b) = F(a + b⋆)`, through which the closure and boundedness API below is
+  derived.
 * `TauCeti.IsPositiveDefinite.normSq_le`: the Cauchy–Schwarz inequality
   `‖F (a + b⋆)‖² ≤ (F (a + a⋆)).re * (F (b + b⋆)).re`.
 * `TauCeti.IsPositiveDefinite.norm_apply_le_map_zero_re_of_add_star_eq_zero`: `‖F a‖ ≤ (F 0).re`
@@ -173,34 +186,45 @@ theorem conj_symm (hF : IsPositiveDefinite F) (a b : M) :
   · rw [Complex.conj_re]; exact hre
   · rw [Complex.conj_im]; linarith
 
+/-- The Hermitian form of the kernel `K(a, b) = F(a + b⋆)` with coefficients `x` over a finite
+family is `F`'s defining form with coefficients `conj x`, hence nonnegative. This is stated as its
+own (universe-polymorphic in the index `ι`) lemma so that it can be fed to
+`TauCeti.isPositiveDefiniteKernel_iff`. -/
+private theorem kernel_form_nonneg (hF : IsPositiveDefinite F) {ι : Type*} [Fintype ι]
+    (v : ι → M) (x : ι → ℂ) :
+    0 ≤ ∑ i, ∑ j, conj (x i) * x j * F (v i + star (v j)) := by
+  have h := hF.sum_nonneg (fun i => conj (x i)) v
+  refine le_of_le_of_eq h ?_
+  refine Finset.sum_congr rfl fun i _ => Finset.sum_congr rfl fun j _ => ?_
+  rw [Complex.conj_conj]
+
+/-- A positive-definite function `F` induces the positive-definite kernel `K(a, b) = F(a + b⋆)`.
+This is the forward half of the function ↔ kernel correspondence, and the primitive through which
+`F`'s closure and boundedness API is derived from the kernel calculus. -/
+theorem isPositiveDefiniteKernel (hF : IsPositiveDefinite F) :
+    IsPositiveDefiniteKernel (fun a b => F (a + star b)) :=
+  isPositiveDefiniteKernel_iff.mpr
+    ⟨fun a b => hF.conj_symm b a, fun {_ι : Type} _ v x => hF.kernel_form_nonneg v x⟩
+
+/-- If the kernel `K(a, b) = F(a + b⋆)` is positive definite, then so is the function `F`. This is
+the reverse half of the function ↔ kernel correspondence. -/
+theorem of_isPositiveDefiniteKernel
+    (hK : IsPositiveDefiniteKernel (fun a b => F (a + star b))) : IsPositiveDefinite F := by
+  obtain ⟨_, hpos⟩ := isPositiveDefiniteKernel_iff.mp hK
+  intro n c v
+  have h := hpos v (fun i => conj (c i))
+  refine le_of_le_of_eq h ?_
+  refine Finset.sum_congr rfl fun i _ => Finset.sum_congr rfl fun j _ => ?_
+  rw [Complex.conj_conj]
+
 /-- The Cauchy–Schwarz inequality for a positive-definite function: the squared norm of an
-off-diagonal value is bounded by the product of the two diagonal values. -/
+off-diagonal value is bounded by the product of the two diagonal values. This is the function-form
+image of the kernel Cauchy–Schwarz inequality `TauCeti.isPositiveDefiniteKernel_normSq_le`
+transported through the kernel `K(a, b) = F(a + b⋆)`. -/
 theorem normSq_le (hF : IsPositiveDefinite F) (a b : M) :
     Complex.normSq (F (a + star b))
       ≤ (F (a + star a)).re * (F (b + star b)).re := by
-  set r := F (a + star b) with hr
-  -- The off-diagonal entries are conjugate, and the diagonal entries are real.
-  have hconj : F (b + star a) = conj r := by rw [hr, ← hF.conj_symm a b, Complex.conj_conj]
-  have hpim := hF.add_star_self_im a
-  have hqim := hF.add_star_self_im b
-  have hpre := hF.add_star_self_re_nonneg a
-  have hqre := hF.add_star_self_re_nonneg b
-  -- For every real `t`, the quadratic `t ↦ pᵣ t² - 2 ‖r‖² t + ‖r‖² qᵣ` is nonnegative.
-  have hpoly : ∀ t : ℝ, 0 ≤ (F (a + star a)).re * (t * t)
-      + (-2 * Complex.normSq r) * t + Complex.normSq r * (F (b + star b)).re := by
-    intro t
-    have hQ := hF.quadForm_two_nonneg a b (-(t : ℂ)) r
-    have hre := (Complex.nonneg_iff.mp hQ).1
-    refine le_of_le_of_eq hre ?_
-    rw [hconj]
-    simp [Complex.normSq_apply]
-    nlinarith [hpim, hqim]
-  -- The discriminant of a nonnegative real quadratic is nonpositive.
-  have hdisc := discrim_le_zero hpoly
-  rw [discrim] at hdisc
-  rcases (Complex.normSq_nonneg r).eq_or_lt with hN0 | hN0
-  · rw [← hN0]; exact mul_nonneg hpre hqre
-  · nlinarith [hdisc, hN0]
+  simpa using isPositiveDefiniteKernel_normSq_le hF.isPositiveDefiniteKernel a b
 
 /-- If `a + star a = 0`, then a positive-definite function is bounded at `a` by its value at
 zero. -/
@@ -222,75 +246,42 @@ theorem norm_apply_le_map_zero_re_of_star_eq_neg (hH : IsPositiveDefinite H)
 
 end Group
 
-/-- Positive-definite functions are closed under addition. -/
+/-- Positive-definite functions are closed under addition. This is the function-form image of
+`TauCeti.isPositiveDefiniteKernel_add` through the kernel `K(a, b) = F(a + b⋆)`. -/
 theorem add (hF : IsPositiveDefinite F) (hG : IsPositiveDefinite G) :
-    IsPositiveDefinite (fun x => F x + G x) := by
-  intro n c v
-  have hsplit : ∑ i, ∑ j, c i * conj (c j) * (F (v i + star (v j)) + G (v i + star (v j)))
-      = (∑ i, ∑ j, c i * conj (c j) * F (v i + star (v j)))
-        + ∑ i, ∑ j, c i * conj (c j) * G (v i + star (v j)) := by
-    simp only [mul_add, Finset.sum_add_distrib]
-  simpa only [hsplit] using add_nonneg (hF n c v) (hG n c v)
+    IsPositiveDefinite (fun x => F x + G x) :=
+  of_isPositiveDefiniteKernel
+    (isPositiveDefiniteKernel_add hF.isPositiveDefiniteKernel hG.isPositiveDefiniteKernel)
 
-/-- Positive-definite functions are closed under multiplication by a nonnegative complex scalar. -/
+/-- Positive-definite functions are closed under multiplication by a nonnegative complex scalar.
+This is the function-form image of `TauCeti.isPositiveDefiniteKernel_smul_of_nonneg`. -/
 theorem const_mul {k : ℂ} (hk : 0 ≤ k) (hF : IsPositiveDefinite F) :
-    IsPositiveDefinite (fun x => k * F x) := by
-  intro n d v
-  have hpull : ∑ i, ∑ j, d i * conj (d j) * (k * F (v i + star (v j)))
-      = k * ∑ i, ∑ j, d i * conj (d j) * F (v i + star (v j)) := by
-    rw [Finset.mul_sum]
-    refine Finset.sum_congr rfl fun i _ => ?_
-    rw [Finset.mul_sum]
-    refine Finset.sum_congr rfl fun j _ => ?_
-    ring
-  rw [hpull]
-  exact mul_nonneg hk (hF n d v)
+    IsPositiveDefinite (fun x => k * F x) :=
+  of_isPositiveDefiniteKernel <| by
+    simpa only [smul_eq_mul] using
+      isPositiveDefiniteKernel_smul_of_nonneg hk hF.isPositiveDefiniteKernel
 
 /-- The Gram matrix of a positive-definite function on any finite family is positive
-semidefinite. -/
+semidefinite. This is the finite submatrix of the kernel `K(a, b) = F(a + b⋆)`. -/
 theorem gram_posSemidef (hF : IsPositiveDefinite F) {ι : Type*} [Finite ι] (v : ι → M) :
-    Matrix.PosSemidef (fun i j => F (v i + star (v j))) := by
-  classical
-  letI := Fintype.ofFinite ι
-  refine Matrix.PosSemidef.of_dotProduct_mulVec_nonneg ?_ ?_
-  · rw [Matrix.IsHermitian]
-    ext i j
-    simp only [Matrix.conjTranspose_apply, Complex.star_def]
-    exact hF.conj_symm (v i) (v j)
-  · intro x
-    have h := hF.sum_nonneg (fun i => conj (x i)) v
-    refine le_of_le_of_eq h ?_
-    simp [dotProduct, Matrix.mulVec, Finset.sum_mul, mul_assoc, mul_left_comm, mul_comm]
+    Matrix.PosSemidef (fun i j => F (v i + star (v j))) :=
+  isPositiveDefiniteKernel_comp hF.isPositiveDefiniteKernel v
 
-/-- Positive-definite functions are closed under pointwise multiplication (Schur product). -/
+/-- Positive-definite functions are closed under pointwise multiplication (Schur product). This is
+the function-form image of `TauCeti.isPositiveDefiniteKernel_mul`, which is the Schur product
+theorem for the kernels. -/
 theorem mul (hF : IsPositiveDefinite F) (hG : IsPositiveDefinite G) :
-    IsPositiveDefinite (fun x => F x * G x) := by
-  intro n c v
-  classical
-  let A : Matrix (Fin n) (Fin n) ℂ := fun i j => F (v i + star (v j))
-  let B : Matrix (Fin n) (Fin n) ℂ := fun i j => G (v i + star (v j))
-  have hAB : Matrix.PosSemidef (Matrix.hadamard A B) :=
-    (hF.gram_posSemidef v).hadamard (hG.gram_posSemidef v)
-  have h := hAB.dotProduct_mulVec_nonneg (fun i => conj (c i))
-  refine le_of_le_of_eq h ?_
-  simp [A, B, dotProduct, Matrix.mulVec, Matrix.hadamard, Finset.mul_sum, mul_assoc,
-    mul_left_comm, mul_comm]
+    IsPositiveDefinite (fun x => F x * G x) :=
+  of_isPositiveDefiniteKernel
+    (isPositiveDefiniteKernel_mul hF.isPositiveDefiniteKernel hG.isPositiveDefiniteKernel)
 
 end IsPositiveDefinite
 
-/-- A nonnegative real constant is a positive-definite function. -/
+/-- A nonnegative real constant is a positive-definite function. This is the function-form image
+of `TauCeti.isPositiveDefiniteKernel_const_of_nonneg`. -/
 theorem isPositiveDefinite_const {k : ℂ} (hk : 0 ≤ k) :
-    IsPositiveDefinite (fun _ : M => k) := by
-  intro n c v
-  have hfactor : ∑ i, ∑ j, c i * conj (c j) * k
-      = (∑ i, ∑ j, c i * conj (c j)) * k := by
-    rw [Finset.sum_mul]
-    refine Finset.sum_congr rfl fun i _ => ?_
-    rw [Finset.sum_mul]
-  have hgram : ∑ i, ∑ j, c i * conj (c j) = (∑ i, c i) * conj (∑ i, c i) := by
-    rw [map_sum, Fintype.sum_mul_sum]
-  rw [hfactor, hgram, Complex.mul_conj]
-  exact mul_nonneg (Complex.zero_le_real.mpr (Complex.normSq_nonneg _)) hk
+    IsPositiveDefinite (fun _ : M => k) :=
+  IsPositiveDefinite.of_isPositiveDefiniteKernel (isPositiveDefiniteKernel_const_of_nonneg hk)
 
 /-- The zero function is positive definite. -/
 theorem isPositiveDefinite_zero : IsPositiveDefinite (fun _ : M => (0 : ℂ)) :=
@@ -298,23 +289,21 @@ theorem isPositiveDefinite_zero : IsPositiveDefinite (fun _ : M => (0 : ℂ)) :=
 
 namespace IsPositiveDefinite
 
-/-- Positive-definite functions are closed under finite sums. -/
+/-- Positive-definite functions are closed under finite sums. This is the function-form image of
+`TauCeti.isPositiveDefiniteKernel_sum`. -/
 theorem sum {ι : Type*} {s : Finset ι} {F : ι → M → ℂ}
     (hF : ∀ i ∈ s, IsPositiveDefinite (F i)) :
-    IsPositiveDefinite (fun x => ∑ i ∈ s, F i x) := by
-  have h := Finset.sum_induction F IsPositiveDefinite
-    (fun _ _ => IsPositiveDefinite.add) isPositiveDefinite_zero hF
-  have heq : (∑ i ∈ s, F i) = fun x => ∑ i ∈ s, F i x := funext fun x => Finset.sum_apply x s F
-  rwa [heq] at h
+    IsPositiveDefinite (fun x => ∑ i ∈ s, F i x) :=
+  of_isPositiveDefiniteKernel
+    (isPositiveDefiniteKernel_sum fun i hi => (hF i hi).isPositiveDefiniteKernel)
 
-/-- Positive-definite functions are closed under finite products (Schur product). -/
+/-- Positive-definite functions are closed under finite products (Schur product). This is the
+function-form image of `TauCeti.isPositiveDefiniteKernel_prod`. -/
 theorem prod {ι : Type*} {s : Finset ι} {F : ι → M → ℂ}
     (hF : ∀ i ∈ s, IsPositiveDefinite (F i)) :
-    IsPositiveDefinite (fun x => ∏ i ∈ s, F i x) := by
-  have h := Finset.prod_induction F IsPositiveDefinite
-    (fun _ _ => IsPositiveDefinite.mul) (isPositiveDefinite_const zero_le_one) hF
-  have heq : (∏ i ∈ s, F i) = fun x => ∏ i ∈ s, F i x := funext fun x => Finset.prod_apply x s F
-  rwa [heq] at h
+    IsPositiveDefinite (fun x => ∏ i ∈ s, F i x) :=
+  of_isPositiveDefiniteKernel
+    (isPositiveDefiniteKernel_prod fun i hi => (hF i hi).isPositiveDefiniteKernel)
 
 end IsPositiveDefinite
 

--- a/TauCeti/Analysis/PositiveDefinite/Basic.lean
+++ b/TauCeti/Analysis/PositiveDefinite/Basic.lean
@@ -218,9 +218,7 @@ theorem of_isPositiveDefiniteKernel
   rw [Complex.conj_conj]
 
 /-- The Cauchy–Schwarz inequality for a positive-definite function: the squared norm of an
-off-diagonal value is bounded by the product of the two diagonal values. This is the function-form
-image of the kernel Cauchy–Schwarz inequality `TauCeti.isPositiveDefiniteKernel_normSq_le`
-transported through the kernel `K(a, b) = F(a + b⋆)`. -/
+off-diagonal value is bounded by the product of the two diagonal values. -/
 theorem normSq_le (hF : IsPositiveDefinite F) (a b : M) :
     Complex.normSq (F (a + star b))
       ≤ (F (a + star a)).re * (F (b + star b)).re := by
@@ -246,30 +244,25 @@ theorem norm_apply_le_map_zero_re_of_star_eq_neg (hH : IsPositiveDefinite H)
 
 end Group
 
-/-- Positive-definite functions are closed under addition. This is the function-form image of
-`TauCeti.isPositiveDefiniteKernel_add` through the kernel `K(a, b) = F(a + b⋆)`. -/
+/-- Positive-definite functions are closed under addition. -/
 theorem add (hF : IsPositiveDefinite F) (hG : IsPositiveDefinite G) :
     IsPositiveDefinite (fun x => F x + G x) :=
   of_isPositiveDefiniteKernel
     (isPositiveDefiniteKernel_add hF.isPositiveDefiniteKernel hG.isPositiveDefiniteKernel)
 
-/-- Positive-definite functions are closed under multiplication by a nonnegative complex scalar.
-This is the function-form image of `TauCeti.isPositiveDefiniteKernel_smul_of_nonneg`. -/
+/-- Positive-definite functions are closed under multiplication by a nonnegative complex scalar. -/
 theorem const_mul {k : ℂ} (hk : 0 ≤ k) (hF : IsPositiveDefinite F) :
     IsPositiveDefinite (fun x => k * F x) :=
   of_isPositiveDefiniteKernel <| by
     simpa only [smul_eq_mul] using
       isPositiveDefiniteKernel_smul_of_nonneg hk hF.isPositiveDefiniteKernel
 
-/-- The Gram matrix of a positive-definite function on any finite family is positive
-semidefinite. This is the finite submatrix of the kernel `K(a, b) = F(a + b⋆)`. -/
-theorem gram_posSemidef (hF : IsPositiveDefinite F) {ι : Type*} [Finite ι] (v : ι → M) :
+/-- The Gram matrix of a positive-definite function is positive semidefinite. -/
+theorem gram_posSemidef (hF : IsPositiveDefinite F) {ι : Type*} (v : ι → M) :
     Matrix.PosSemidef (fun i j => F (v i + star (v j))) :=
   isPositiveDefiniteKernel_comp hF.isPositiveDefiniteKernel v
 
-/-- Positive-definite functions are closed under pointwise multiplication (Schur product). This is
-the function-form image of `TauCeti.isPositiveDefiniteKernel_mul`, which is the Schur product
-theorem for the kernels. -/
+/-- Positive-definite functions are closed under pointwise multiplication (Schur product). -/
 theorem mul (hF : IsPositiveDefinite F) (hG : IsPositiveDefinite G) :
     IsPositiveDefinite (fun x => F x * G x) :=
   of_isPositiveDefiniteKernel
@@ -277,8 +270,7 @@ theorem mul (hF : IsPositiveDefinite F) (hG : IsPositiveDefinite G) :
 
 end IsPositiveDefinite
 
-/-- A nonnegative real constant is a positive-definite function. This is the function-form image
-of `TauCeti.isPositiveDefiniteKernel_const_of_nonneg`. -/
+/-- A nonnegative real constant is a positive-definite function. -/
 theorem isPositiveDefinite_const {k : ℂ} (hk : 0 ≤ k) :
     IsPositiveDefinite (fun _ : M => k) :=
   IsPositiveDefinite.of_isPositiveDefiniteKernel (isPositiveDefiniteKernel_const_of_nonneg hk)
@@ -289,16 +281,14 @@ theorem isPositiveDefinite_zero : IsPositiveDefinite (fun _ : M => (0 : ℂ)) :=
 
 namespace IsPositiveDefinite
 
-/-- Positive-definite functions are closed under finite sums. This is the function-form image of
-`TauCeti.isPositiveDefiniteKernel_sum`. -/
+/-- Positive-definite functions are closed under finite sums. -/
 theorem sum {ι : Type*} {s : Finset ι} {F : ι → M → ℂ}
     (hF : ∀ i ∈ s, IsPositiveDefinite (F i)) :
     IsPositiveDefinite (fun x => ∑ i ∈ s, F i x) :=
   of_isPositiveDefiniteKernel
     (isPositiveDefiniteKernel_sum fun i hi => (hF i hi).isPositiveDefiniteKernel)
 
-/-- Positive-definite functions are closed under finite products (Schur product). This is the
-function-form image of `TauCeti.isPositiveDefiniteKernel_prod`. -/
+/-- Positive-definite functions are closed under finite products (Schur product). -/
 theorem prod {ι : Type*} {s : Finset ι} {F : ι → M → ℂ}
     (hF : ∀ i ∈ s, IsPositiveDefinite (F i)) :
     IsPositiveDefinite (fun x => ∏ i ∈ s, F i x) :=

--- a/TauCeti/Analysis/PositiveDefinite/Basic.lean
+++ b/TauCeti/Analysis/PositiveDefinite/Basic.lean
@@ -8,8 +8,8 @@ public import Mathlib.Analysis.Complex.Order
 public import Mathlib.Analysis.Matrix.Order
 public import Mathlib.Algebra.BigOperators.Fin
 public import TauCeti.Analysis.PositiveDefinite.Kernel
-public import TauCeti.Analysis.PositiveDefinite.KernelBounds
-public import TauCeti.Analysis.PositiveDefinite.KernelClosure
+import TauCeti.Analysis.PositiveDefinite.KernelBounds
+import TauCeti.Analysis.PositiveDefinite.KernelClosure
 
 /-!
 # Positive-definite functions on an involutive additive monoid

--- a/TauCeti/Analysis/PositiveDefinite/Basic.lean
+++ b/TauCeti/Analysis/PositiveDefinite/Basic.lean
@@ -5,7 +5,6 @@ Released under Apache 2.0 license as described in the file LICENSE.
 module
 
 public import Mathlib.Analysis.Complex.Order
-public import Mathlib.Analysis.Matrix.Order
 public import Mathlib.Algebra.BigOperators.Fin
 public import TauCeti.Analysis.PositiveDefinite.Kernel
 public import TauCeti.Analysis.PositiveDefinite.KernelBounds
@@ -199,8 +198,7 @@ private theorem kernel_form_nonneg (hF : IsPositiveDefinite F) {ι : Type*} [Fin
   rw [Complex.conj_conj]
 
 /-- A positive-definite function `F` induces the positive-definite kernel `K(a, b) = F(a + b⋆)`.
-This is the forward half of the function ↔ kernel correspondence, and the primitive through which
-`F`'s closure and boundedness API is derived from the kernel calculus. -/
+This is the forward half of the function ↔ kernel correspondence. -/
 theorem isPositiveDefiniteKernel (hF : IsPositiveDefinite F) :
     IsPositiveDefiniteKernel (fun a b => F (a + star b)) :=
   isPositiveDefiniteKernel_iff.mpr

--- a/TauCeti/Analysis/PositiveDefinite/Basic.lean
+++ b/TauCeti/Analysis/PositiveDefinite/Basic.lean
@@ -5,10 +5,10 @@ Released under Apache 2.0 license as described in the file LICENSE.
 module
 
 public import Mathlib.Analysis.Complex.Order
+public import Mathlib.Analysis.Matrix.Order
+public import Mathlib.Algebra.QuadraticDiscriminant
 public import Mathlib.Algebra.BigOperators.Fin
-public import TauCeti.Analysis.PositiveDefinite.Kernel
-public import TauCeti.Analysis.PositiveDefinite.KernelBounds
-public import TauCeti.Analysis.PositiveDefinite.KernelClosure
+import TauCeti.Analysis.PositiveDefinite.Kernel
 
 /-!
 # Positive-definite functions on an involutive additive monoid
@@ -23,17 +23,10 @@ classical translation-invariant positive-definiteness `∑ cᵢ conj(cⱼ) F(a�
 product monoid `ℝ≥0 × V` it produces the BCR involution `(t, a)⋆ = (t, -a)`.
 
 This file introduces the predicate `TauCeti.IsPositiveDefinite` at this general level and develops
-its basic algebraic API: the value at `0` is real and nonnegative, and the function is conjugate
-symmetric in the involution. These intrinsic facts are then used to establish the correspondence
-with the two-variable kernel `K(a, b) = F(a + b⋆)`
-(`TauCeti.IsPositiveDefinite.isPositiveDefiniteKernel` and its converse
-`TauCeti.IsPositiveDefinite.of_isPositiveDefiniteKernel`), taking the kernel form
-as the single primitive: the Cauchy–Schwarz inequality, the Gram-matrix positivity, and closure
-under sums, nonnegative complex scalar multiples, Schur products, and finite sums/products are all
-obtained by transporting the corresponding kernel statements
-(`TauCeti.Analysis.PositiveDefinite.Kernel`, `.KernelBounds`, `.KernelClosure`) through this
-correspondence rather than being re-proved from the raw definition. Nonnegative constants are an
-example.
+its basic algebraic API: the value at `0` is real and nonnegative, the function is conjugate
+symmetric in the involution, it satisfies the Cauchy–Schwarz inequality coming from the `2 × 2`
+sub-form, and the class is closed under sums and nonnegative complex scalar multiples, with the
+Schur pointwise product closure and nonnegative constants as examples.
 
 This is the `Objects` and first `API to develop` slice of Part C of the `OneParameterSemigroups`
 roadmap in TauCetiRoadmap: "positive-definite functions and Bochner's theorem". Mathlib has
@@ -53,10 +46,6 @@ here. The continuity theory and Bochner's representation theorem are later miles
 * `TauCeti.IsPositiveDefinite.map_zero_re_pos_of_ne_zero`: if `F 0 ≠ 0`, then
   `0 < (F 0).re`.
 * `TauCeti.IsPositiveDefinite.conj_symm`: `conj (F (b + a⋆)) = F (a + b⋆)`.
-* `TauCeti.IsPositiveDefinite.isPositiveDefiniteKernel` and
-  `TauCeti.IsPositiveDefinite.of_isPositiveDefiniteKernel`: the two halves of the correspondence
-  with the kernel `K(a, b) = F(a + b⋆)`, through which the closure and boundedness API below is
-  derived.
 * `TauCeti.IsPositiveDefinite.normSq_le`: the Cauchy–Schwarz inequality
   `‖F (a + b⋆)‖² ≤ (F (a + a⋆)).re * (F (b + b⋆)).re`.
 * `TauCeti.IsPositiveDefinite.norm_apply_le_map_zero_re_of_add_star_eq_zero`: `‖F a‖ ≤ (F 0).re`
@@ -185,42 +174,34 @@ theorem conj_symm (hF : IsPositiveDefinite F) (a b : M) :
   · rw [Complex.conj_re]; exact hre
   · rw [Complex.conj_im]; linarith
 
-/-- The Hermitian form of the kernel `K(a, b) = F(a + b⋆)` with coefficients `x` over a finite
-family is `F`'s defining form with coefficients `conj x`, hence nonnegative. This is stated as its
-own (universe-polymorphic in the index `ι`) lemma so that it can be fed to
-`TauCeti.isPositiveDefiniteKernel_iff`. -/
-private theorem kernel_form_nonneg (hF : IsPositiveDefinite F) {ι : Type*} [Fintype ι]
-    (v : ι → M) (x : ι → ℂ) :
-    0 ≤ ∑ i, ∑ j, conj (x i) * x j * F (v i + star (v j)) := by
-  have h := hF.sum_nonneg (fun i => conj (x i)) v
-  refine le_of_le_of_eq h ?_
-  refine Finset.sum_congr rfl fun i _ => Finset.sum_congr rfl fun j _ => ?_
-  rw [Complex.conj_conj]
-
-/-- A positive-definite function `F` induces the positive-definite kernel `K(a, b) = F(a + b⋆)`.
-This is the forward half of the function ↔ kernel correspondence. -/
-theorem isPositiveDefiniteKernel (hF : IsPositiveDefinite F) :
-    IsPositiveDefiniteKernel (fun a b => F (a + star b)) :=
-  isPositiveDefiniteKernel_iff.mpr
-    ⟨fun a b => hF.conj_symm b a, fun {_ι : Type} _ v x => hF.kernel_form_nonneg v x⟩
-
-/-- If the kernel `K(a, b) = F(a + b⋆)` is positive definite, then so is the function `F`. This is
-the reverse half of the function ↔ kernel correspondence. -/
-theorem of_isPositiveDefiniteKernel
-    (hK : IsPositiveDefiniteKernel (fun a b => F (a + star b))) : IsPositiveDefinite F := by
-  obtain ⟨_, hpos⟩ := isPositiveDefiniteKernel_iff.mp hK
-  intro n c v
-  have h := hpos v (fun i => conj (c i))
-  refine le_of_le_of_eq h ?_
-  refine Finset.sum_congr rfl fun i _ => Finset.sum_congr rfl fun j _ => ?_
-  rw [Complex.conj_conj]
-
 /-- The Cauchy–Schwarz inequality for a positive-definite function: the squared norm of an
 off-diagonal value is bounded by the product of the two diagonal values. -/
 theorem normSq_le (hF : IsPositiveDefinite F) (a b : M) :
     Complex.normSq (F (a + star b))
       ≤ (F (a + star a)).re * (F (b + star b)).re := by
-  simpa using isPositiveDefiniteKernel_normSq_le hF.isPositiveDefiniteKernel a b
+  set r := F (a + star b) with hr
+  -- The off-diagonal entries are conjugate, and the diagonal entries are real.
+  have hconj : F (b + star a) = conj r := by rw [hr, ← hF.conj_symm a b, Complex.conj_conj]
+  have hpim := hF.add_star_self_im a
+  have hqim := hF.add_star_self_im b
+  have hpre := hF.add_star_self_re_nonneg a
+  have hqre := hF.add_star_self_re_nonneg b
+  -- For every real `t`, the quadratic `t ↦ pᵣ t² - 2 ‖r‖² t + ‖r‖² qᵣ` is nonnegative.
+  have hpoly : ∀ t : ℝ, 0 ≤ (F (a + star a)).re * (t * t)
+      + (-2 * Complex.normSq r) * t + Complex.normSq r * (F (b + star b)).re := by
+    intro t
+    have hQ := hF.quadForm_two_nonneg a b (-(t : ℂ)) r
+    have hre := (Complex.nonneg_iff.mp hQ).1
+    refine le_of_le_of_eq hre ?_
+    rw [hconj]
+    simp [Complex.normSq_apply]
+    nlinarith [hpim, hqim]
+  -- The discriminant of a nonnegative real quadratic is nonpositive.
+  have hdisc := discrim_le_zero hpoly
+  rw [discrim] at hdisc
+  rcases (Complex.normSq_nonneg r).eq_or_lt with hN0 | hN0
+  · rw [← hN0]; exact mul_nonneg hpre hqre
+  · nlinarith [hdisc, hN0]
 
 /-- If `a + star a = 0`, then a positive-definite function is bounded at `a` by its value at
 zero. -/
@@ -244,34 +225,72 @@ end Group
 
 /-- Positive-definite functions are closed under addition. -/
 theorem add (hF : IsPositiveDefinite F) (hG : IsPositiveDefinite G) :
-    IsPositiveDefinite (fun x => F x + G x) :=
-  of_isPositiveDefiniteKernel
-    (isPositiveDefiniteKernel_add hF.isPositiveDefiniteKernel hG.isPositiveDefiniteKernel)
+    IsPositiveDefinite (fun x => F x + G x) := by
+  intro n c v
+  have hsplit : ∑ i, ∑ j, c i * conj (c j) * (F (v i + star (v j)) + G (v i + star (v j)))
+      = (∑ i, ∑ j, c i * conj (c j) * F (v i + star (v j)))
+        + ∑ i, ∑ j, c i * conj (c j) * G (v i + star (v j)) := by
+    simp only [mul_add, Finset.sum_add_distrib]
+  simpa only [hsplit] using add_nonneg (hF n c v) (hG n c v)
 
 /-- Positive-definite functions are closed under multiplication by a nonnegative complex scalar. -/
 theorem const_mul {k : ℂ} (hk : 0 ≤ k) (hF : IsPositiveDefinite F) :
-    IsPositiveDefinite (fun x => k * F x) :=
-  of_isPositiveDefiniteKernel <| by
-    simpa only [smul_eq_mul] using
-      isPositiveDefiniteKernel_smul_of_nonneg hk hF.isPositiveDefiniteKernel
+    IsPositiveDefinite (fun x => k * F x) := by
+  intro n d v
+  have hpull : ∑ i, ∑ j, d i * conj (d j) * (k * F (v i + star (v j)))
+      = k * ∑ i, ∑ j, d i * conj (d j) * F (v i + star (v j)) := by
+    rw [Finset.mul_sum]
+    refine Finset.sum_congr rfl fun i _ => ?_
+    rw [Finset.mul_sum]
+    refine Finset.sum_congr rfl fun j _ => ?_
+    ring
+  rw [hpull]
+  exact mul_nonneg hk (hF n d v)
 
 /-- The Gram matrix of a positive-definite function is positive semidefinite. -/
 theorem gram_posSemidef (hF : IsPositiveDefinite F) {ι : Type*} (v : ι → M) :
-    Matrix.PosSemidef (fun i j => F (v i + star (v j))) :=
-  isPositiveDefiniteKernel_comp hF.isPositiveDefiniteKernel v
+    Matrix.PosSemidef (fun i j => F (v i + star (v j))) := by
+  have hform : ∀ {κ : Type} (_ : Fintype κ) (w : κ → M) (x : κ → ℂ),
+      0 ≤ ∑ i, ∑ j, conj (x i) * x j * F (w i + star (w j)) := by
+    intro κ _ w x
+    have h := hF.sum_nonneg (fun i => conj (x i)) w
+    refine le_of_le_of_eq h ?_
+    refine Finset.sum_congr rfl fun i _ => Finset.sum_congr rfl fun j _ => ?_
+    rw [Complex.conj_conj]
+  have hK : IsPositiveDefiniteKernel (fun a b => F (a + star b)) :=
+    isPositiveDefiniteKernel_iff.mpr ⟨fun a b => hF.conj_symm b a,
+      fun {_κ : Type} _ w x => hform inferInstance w x⟩
+  exact isPositiveDefiniteKernel_comp hK v
 
 /-- Positive-definite functions are closed under pointwise multiplication (Schur product). -/
 theorem mul (hF : IsPositiveDefinite F) (hG : IsPositiveDefinite G) :
-    IsPositiveDefinite (fun x => F x * G x) :=
-  of_isPositiveDefiniteKernel
-    (isPositiveDefiniteKernel_mul hF.isPositiveDefiniteKernel hG.isPositiveDefiniteKernel)
+    IsPositiveDefinite (fun x => F x * G x) := by
+  intro n c v
+  classical
+  let A : Matrix (Fin n) (Fin n) ℂ := fun i j => F (v i + star (v j))
+  let B : Matrix (Fin n) (Fin n) ℂ := fun i j => G (v i + star (v j))
+  have hAB : Matrix.PosSemidef (Matrix.hadamard A B) :=
+    (hF.gram_posSemidef v).hadamard (hG.gram_posSemidef v)
+  have h := hAB.dotProduct_mulVec_nonneg (fun i => conj (c i))
+  refine le_of_le_of_eq h ?_
+  simp [A, B, dotProduct, Matrix.mulVec, Matrix.hadamard, Finset.mul_sum, mul_assoc,
+    mul_left_comm, mul_comm]
 
 end IsPositiveDefinite
 
 /-- A nonnegative real constant is a positive-definite function. -/
 theorem isPositiveDefinite_const {k : ℂ} (hk : 0 ≤ k) :
-    IsPositiveDefinite (fun _ : M => k) :=
-  IsPositiveDefinite.of_isPositiveDefiniteKernel (isPositiveDefiniteKernel_const_of_nonneg hk)
+    IsPositiveDefinite (fun _ : M => k) := by
+  intro n c v
+  have hfactor : ∑ i, ∑ j, c i * conj (c j) * k
+      = (∑ i, ∑ j, c i * conj (c j)) * k := by
+    rw [Finset.sum_mul]
+    refine Finset.sum_congr rfl fun i _ => ?_
+    rw [Finset.sum_mul]
+  have hgram : ∑ i, ∑ j, c i * conj (c j) = (∑ i, c i) * conj (∑ i, c i) := by
+    rw [map_sum, Fintype.sum_mul_sum]
+  rw [hfactor, hgram, Complex.mul_conj]
+  exact mul_nonneg (Complex.zero_le_real.mpr (Complex.normSq_nonneg _)) hk
 
 /-- The zero function is positive definite. -/
 theorem isPositiveDefinite_zero : IsPositiveDefinite (fun _ : M => (0 : ℂ)) :=
@@ -282,16 +301,20 @@ namespace IsPositiveDefinite
 /-- Positive-definite functions are closed under finite sums. -/
 theorem sum {ι : Type*} {s : Finset ι} {F : ι → M → ℂ}
     (hF : ∀ i ∈ s, IsPositiveDefinite (F i)) :
-    IsPositiveDefinite (fun x => ∑ i ∈ s, F i x) :=
-  of_isPositiveDefiniteKernel
-    (isPositiveDefiniteKernel_sum fun i hi => (hF i hi).isPositiveDefiniteKernel)
+    IsPositiveDefinite (fun x => ∑ i ∈ s, F i x) := by
+  have h := Finset.sum_induction F IsPositiveDefinite
+    (fun _ _ => IsPositiveDefinite.add) isPositiveDefinite_zero hF
+  have heq : (∑ i ∈ s, F i) = fun x => ∑ i ∈ s, F i x := funext fun x => Finset.sum_apply x s F
+  rwa [heq] at h
 
 /-- Positive-definite functions are closed under finite products (Schur product). -/
 theorem prod {ι : Type*} {s : Finset ι} {F : ι → M → ℂ}
     (hF : ∀ i ∈ s, IsPositiveDefinite (F i)) :
-    IsPositiveDefinite (fun x => ∏ i ∈ s, F i x) :=
-  of_isPositiveDefiniteKernel
-    (isPositiveDefiniteKernel_prod fun i hi => (hF i hi).isPositiveDefiniteKernel)
+    IsPositiveDefinite (fun x => ∏ i ∈ s, F i x) := by
+  have h := Finset.prod_induction F IsPositiveDefinite
+    (fun _ _ => IsPositiveDefinite.mul) (isPositiveDefinite_const zero_le_one) hF
+  have heq : (∏ i ∈ s, F i) = fun x => ∏ i ∈ s, F i x := funext fun x => Finset.prod_apply x s F
+  rwa [heq] at h
 
 end IsPositiveDefinite
 

--- a/TauCeti/Analysis/PositiveDefinite/Basic.lean
+++ b/TauCeti/Analysis/PositiveDefinite/Basic.lean
@@ -8,6 +8,7 @@ public import Mathlib.Analysis.Complex.Order
 public import Mathlib.Analysis.Matrix.Order
 public import Mathlib.Algebra.QuadraticDiscriminant
 public import Mathlib.Algebra.BigOperators.Fin
+public import TauCeti.Analysis.PositiveDefinite.Kernel
 
 /-!
 # Positive-definite functions on an involutive additive monoid
@@ -50,6 +51,10 @@ here. The continuity theory and Bochner's representation theorem are later miles
 * `TauCeti.IsPositiveDefinite.norm_apply_le_map_zero_re_of_add_star_eq_zero`: `‖F a‖ ≤ (F 0).re`
   when `a + star a = 0`, with the additive-group corollary
   `TauCeti.IsPositiveDefinite.norm_apply_le_map_zero_re_of_star_eq_neg` for `star a = -a`.
+* `TauCeti.IsPositiveDefinite.isPositiveDefiniteKernel`: a positive-definite function gives the
+  positive-definite kernel `fun a b => F (a + star b)`.
+* `TauCeti.IsPositiveDefinite.of_isPositiveDefiniteKernel`: conversely, if the kernel
+  `fun a b => F (a + star b)` is positive definite then `F` is positive definite.
 * `TauCeti.IsPositiveDefinite.gram_posSemidef`: Gram matrices of a positive-definite
   function are positive semidefinite.
 * `TauCeti.IsPositiveDefinite.add`, `TauCeti.IsPositiveDefinite.sum`,
@@ -246,7 +251,8 @@ theorem const_mul {k : ℂ} (hk : 0 ≤ k) (hF : IsPositiveDefinite F) :
   rw [hpull]
   exact mul_nonneg hk (hF n d v)
 
-private theorem kernel_form_nonneg (hF : IsPositiveDefinite F) {ι : Type*} [Fintype ι]
+/-- The kernel-form quadratic sum attached to a positive-definite function is nonnegative. -/
+theorem kernel_form_nonneg (hF : IsPositiveDefinite F) {ι : Type*} [Fintype ι]
     (v : ι → M) (x : ι → ℂ) :
     0 ≤ ∑ i, ∑ j, conj (x i) * x j * F (v i + star (v j)) := by
   have h := hF.sum_nonneg (fun i => conj (x i)) v
@@ -254,28 +260,28 @@ private theorem kernel_form_nonneg (hF : IsPositiveDefinite F) {ι : Type*} [Fin
   refine Finset.sum_congr rfl fun i _ => Finset.sum_congr rfl fun j _ => ?_
   rw [Complex.conj_conj]
 
+/-- A positive-definite function `F` induces the positive-definite kernel `K(a, b) = F(a + b⋆)`.
+This is the forward half of the function ↔ kernel correspondence. -/
+theorem isPositiveDefiniteKernel (hF : IsPositiveDefinite F) :
+    IsPositiveDefiniteKernel (fun a b => F (a + star b)) :=
+  isPositiveDefiniteKernel_iff.mpr
+    ⟨fun a b => hF.conj_symm b a, fun {_ι : Type} _ v x => hF.kernel_form_nonneg v x⟩
+
+/-- If the kernel `K(a, b) = F(a + b⋆)` is positive definite, then so is the function `F`. This is
+the reverse half of the function ↔ kernel correspondence. -/
+theorem of_isPositiveDefiniteKernel
+    (hK : IsPositiveDefiniteKernel (fun a b => F (a + star b))) : IsPositiveDefinite F := by
+  obtain ⟨_, hpos⟩ := isPositiveDefiniteKernel_iff.mp hK
+  intro n c v
+  have h := hpos v (fun i => conj (c i))
+  refine le_of_le_of_eq h ?_
+  refine Finset.sum_congr rfl fun i _ => Finset.sum_congr rfl fun j _ => ?_
+  rw [Complex.conj_conj]
+
 /-- The Gram matrix of a positive-definite function is positive semidefinite. -/
 theorem gram_posSemidef (hF : IsPositiveDefinite F) {ι : Type*} (v : ι → M) :
-    Matrix.PosSemidef (fun i j => F (v i + star (v j))) := by
-  classical
-  refine ⟨?_, ?_⟩
-  · ext i j
-    rw [Matrix.conjTranspose_apply, ← starRingEnd_apply]
-    exact hF.conj_symm (v i) (v j)
-  · intro x
-    have h := hF.kernel_form_nonneg (fun i : x.support => v (i : ι))
-      (fun i : x.support => x (i : ι))
-    have h' :
-        0 ≤ ∑ i ∈ x.support, ∑ j ∈ x.support,
-          star (x i) * (F (v i + star (v j)) * x j) := by
-      convert h using 1
-      rw [Finset.sum_subtype x.support (by intro a; rfl)]
-      refine Finset.sum_congr rfl fun i _ => ?_
-      rw [Finset.sum_subtype x.support (by intro a; rfl)]
-      refine Finset.sum_congr rfl fun j _ => ?_
-      rw [starRingEnd_apply]
-      ring
-    simpa [Finsupp.sum, mul_assoc] using h'
+    Matrix.PosSemidef (fun i j => F (v i + star (v j))) :=
+  isPositiveDefiniteKernel_comp hF.isPositiveDefiniteKernel v
 
 /-- Positive-definite functions are closed under pointwise multiplication (Schur product). -/
 theorem mul (hF : IsPositiveDefinite F) (hG : IsPositiveDefinite G) :

--- a/TauCeti/Analysis/PositiveDefinite/Basic.lean
+++ b/TauCeti/Analysis/PositiveDefinite/Basic.lean
@@ -8,7 +8,7 @@ public import Mathlib.Analysis.Complex.Order
 public import Mathlib.Analysis.Matrix.Order
 public import Mathlib.Algebra.QuadraticDiscriminant
 public import Mathlib.Algebra.BigOperators.Fin
-import TauCeti.Analysis.PositiveDefinite.Kernel
+public import TauCeti.Analysis.PositiveDefinite.Kernel
 
 /-!
 # Positive-definite functions on an involutive additive monoid
@@ -247,20 +247,36 @@ theorem const_mul {k : ℂ} (hk : 0 ≤ k) (hF : IsPositiveDefinite F) :
   rw [hpull]
   exact mul_nonneg hk (hF n d v)
 
+private theorem kernel_form_nonneg (hF : IsPositiveDefinite F) {ι : Type*} [Fintype ι]
+    (v : ι → M) (x : ι → ℂ) :
+    0 ≤ ∑ i, ∑ j, conj (x i) * x j * F (v i + star (v j)) := by
+  have h := hF.sum_nonneg (fun i => conj (x i)) v
+  refine le_of_le_of_eq h ?_
+  refine Finset.sum_congr rfl fun i _ => Finset.sum_congr rfl fun j _ => ?_
+  rw [Complex.conj_conj]
+
+/-- A positive-definite function `F` induces the positive-definite kernel `K(a, b) = F(a + b⋆)`.
+This is the forward half of the function ↔ kernel correspondence. -/
+theorem isPositiveDefiniteKernel (hF : IsPositiveDefinite F) :
+    IsPositiveDefiniteKernel (fun a b => F (a + star b)) :=
+  isPositiveDefiniteKernel_iff.mpr
+    ⟨fun a b => hF.conj_symm b a, fun {_ι : Type} _ v x => hF.kernel_form_nonneg v x⟩
+
+/-- If the kernel `K(a, b) = F(a + b⋆)` is positive definite, then so is the function `F`. This is
+the reverse half of the function ↔ kernel correspondence. -/
+theorem of_isPositiveDefiniteKernel
+    (hK : IsPositiveDefiniteKernel (fun a b => F (a + star b))) : IsPositiveDefinite F := by
+  obtain ⟨_, hpos⟩ := isPositiveDefiniteKernel_iff.mp hK
+  intro n c v
+  have h := hpos v (fun i => conj (c i))
+  refine le_of_le_of_eq h ?_
+  refine Finset.sum_congr rfl fun i _ => Finset.sum_congr rfl fun j _ => ?_
+  rw [Complex.conj_conj]
+
 /-- The Gram matrix of a positive-definite function is positive semidefinite. -/
 theorem gram_posSemidef (hF : IsPositiveDefinite F) {ι : Type*} (v : ι → M) :
-    Matrix.PosSemidef (fun i j => F (v i + star (v j))) := by
-  have hform : ∀ {κ : Type} (_ : Fintype κ) (w : κ → M) (x : κ → ℂ),
-      0 ≤ ∑ i, ∑ j, conj (x i) * x j * F (w i + star (w j)) := by
-    intro κ _ w x
-    have h := hF.sum_nonneg (fun i => conj (x i)) w
-    refine le_of_le_of_eq h ?_
-    refine Finset.sum_congr rfl fun i _ => Finset.sum_congr rfl fun j _ => ?_
-    rw [Complex.conj_conj]
-  have hK : IsPositiveDefiniteKernel (fun a b => F (a + star b)) :=
-    isPositiveDefiniteKernel_iff.mpr ⟨fun a b => hF.conj_symm b a,
-      fun {_κ : Type} _ w x => hform inferInstance w x⟩
-  exact isPositiveDefiniteKernel_comp hK v
+    Matrix.PosSemidef (fun i j => F (v i + star (v j))) :=
+  isPositiveDefiniteKernel_comp hF.isPositiveDefiniteKernel v
 
 /-- Positive-definite functions are closed under pointwise multiplication (Schur product). -/
 theorem mul (hF : IsPositiveDefinite F) (hG : IsPositiveDefinite G) :

--- a/TauCeti/Analysis/PositiveDefinite/Basic.lean
+++ b/TauCeti/Analysis/PositiveDefinite/Basic.lean
@@ -6,9 +6,10 @@ module
 
 public import Mathlib.Analysis.Complex.Order
 public import Mathlib.Analysis.Matrix.Order
-public import Mathlib.Algebra.QuadraticDiscriminant
 public import Mathlib.Algebra.BigOperators.Fin
 public import TauCeti.Analysis.PositiveDefinite.Kernel
+public import TauCeti.Analysis.PositiveDefinite.KernelBounds
+public import TauCeti.Analysis.PositiveDefinite.KernelClosure
 
 /-!
 # Positive-definite functions on an involutive additive monoid
@@ -178,34 +179,34 @@ theorem conj_symm (hF : IsPositiveDefinite F) (a b : M) :
   · rw [Complex.conj_re]; exact hre
   · rw [Complex.conj_im]; linarith
 
+/-- A positive-definite function `F` induces the positive-definite kernel `K(a, b) = F(a + b⋆)`.
+This is the forward half of the function ↔ kernel correspondence. -/
+theorem isPositiveDefiniteKernel (hF : IsPositiveDefinite F) :
+    IsPositiveDefiniteKernel (fun a b => F (a + star b)) :=
+  isPositiveDefiniteKernel_iff.mpr
+    ⟨fun a b => hF.conj_symm b a, fun {_ι : Type} _ v x => by
+      have h := hF.sum_nonneg (fun i => conj (x i)) v
+      refine le_of_le_of_eq h ?_
+      refine Finset.sum_congr rfl fun i _ => Finset.sum_congr rfl fun j _ => ?_
+      rw [Complex.conj_conj]⟩
+
+/-- If the kernel `K(a, b) = F(a + b⋆)` is positive definite, then so is the function `F`. This is
+the reverse half of the function ↔ kernel correspondence. -/
+theorem of_isPositiveDefiniteKernel
+    (hK : IsPositiveDefiniteKernel (fun a b => F (a + star b))) : IsPositiveDefinite F := by
+  obtain ⟨_, hpos⟩ := isPositiveDefiniteKernel_iff.mp hK
+  intro n c v
+  have h := hpos v (fun i => conj (c i))
+  refine le_of_le_of_eq h ?_
+  refine Finset.sum_congr rfl fun i _ => Finset.sum_congr rfl fun j _ => ?_
+  rw [Complex.conj_conj]
+
 /-- The Cauchy–Schwarz inequality for a positive-definite function: the squared norm of an
 off-diagonal value is bounded by the product of the two diagonal values. -/
 theorem normSq_le (hF : IsPositiveDefinite F) (a b : M) :
     Complex.normSq (F (a + star b))
-      ≤ (F (a + star a)).re * (F (b + star b)).re := by
-  set r := F (a + star b) with hr
-  -- The off-diagonal entries are conjugate, and the diagonal entries are real.
-  have hconj : F (b + star a) = conj r := by rw [hr, ← hF.conj_symm a b, Complex.conj_conj]
-  have hpim := hF.add_star_self_im a
-  have hqim := hF.add_star_self_im b
-  have hpre := hF.add_star_self_re_nonneg a
-  have hqre := hF.add_star_self_re_nonneg b
-  -- For every real `t`, the quadratic `t ↦ pᵣ t² - 2 ‖r‖² t + ‖r‖² qᵣ` is nonnegative.
-  have hpoly : ∀ t : ℝ, 0 ≤ (F (a + star a)).re * (t * t)
-      + (-2 * Complex.normSq r) * t + Complex.normSq r * (F (b + star b)).re := by
-    intro t
-    have hQ := hF.quadForm_two_nonneg a b (-(t : ℂ)) r
-    have hre := (Complex.nonneg_iff.mp hQ).1
-    refine le_of_le_of_eq hre ?_
-    rw [hconj]
-    simp [Complex.normSq_apply]
-    nlinarith [hpim, hqim]
-  -- The discriminant of a nonnegative real quadratic is nonpositive.
-  have hdisc := discrim_le_zero hpoly
-  rw [discrim] at hdisc
-  rcases (Complex.normSq_nonneg r).eq_or_lt with hN0 | hN0
-  · rw [← hN0]; exact mul_nonneg hpre hqre
-  · nlinarith [hdisc, hN0]
+      ≤ (F (a + star a)).re * (F (b + star b)).re :=
+  isPositiveDefiniteKernel_normSq_le hF.isPositiveDefiniteKernel a b
 
 /-- If `a + star a = 0`, then a positive-definite function is bounded at `a` by its value at
 zero. -/
@@ -229,54 +230,15 @@ end Group
 
 /-- Positive-definite functions are closed under addition. -/
 theorem add (hF : IsPositiveDefinite F) (hG : IsPositiveDefinite G) :
-    IsPositiveDefinite (fun x => F x + G x) := by
-  intro n c v
-  have hsplit : ∑ i, ∑ j, c i * conj (c j) * (F (v i + star (v j)) + G (v i + star (v j)))
-      = (∑ i, ∑ j, c i * conj (c j) * F (v i + star (v j)))
-        + ∑ i, ∑ j, c i * conj (c j) * G (v i + star (v j)) := by
-    simp only [mul_add, Finset.sum_add_distrib]
-  simpa only [hsplit] using add_nonneg (hF n c v) (hG n c v)
+    IsPositiveDefinite (fun x => F x + G x) :=
+  of_isPositiveDefiniteKernel <|
+    isPositiveDefiniteKernel_add hF.isPositiveDefiniteKernel hG.isPositiveDefiniteKernel
 
 /-- Positive-definite functions are closed under multiplication by a nonnegative complex scalar. -/
 theorem const_mul {k : ℂ} (hk : 0 ≤ k) (hF : IsPositiveDefinite F) :
-    IsPositiveDefinite (fun x => k * F x) := by
-  intro n d v
-  have hpull : ∑ i, ∑ j, d i * conj (d j) * (k * F (v i + star (v j)))
-      = k * ∑ i, ∑ j, d i * conj (d j) * F (v i + star (v j)) := by
-    rw [Finset.mul_sum]
-    refine Finset.sum_congr rfl fun i _ => ?_
-    rw [Finset.mul_sum]
-    refine Finset.sum_congr rfl fun j _ => ?_
-    ring
-  rw [hpull]
-  exact mul_nonneg hk (hF n d v)
-
-/-- The kernel-form quadratic sum attached to a positive-definite function is nonnegative. -/
-theorem kernel_form_nonneg (hF : IsPositiveDefinite F) {ι : Type*} [Fintype ι]
-    (v : ι → M) (x : ι → ℂ) :
-    0 ≤ ∑ i, ∑ j, conj (x i) * x j * F (v i + star (v j)) := by
-  have h := hF.sum_nonneg (fun i => conj (x i)) v
-  refine le_of_le_of_eq h ?_
-  refine Finset.sum_congr rfl fun i _ => Finset.sum_congr rfl fun j _ => ?_
-  rw [Complex.conj_conj]
-
-/-- A positive-definite function `F` induces the positive-definite kernel `K(a, b) = F(a + b⋆)`.
-This is the forward half of the function ↔ kernel correspondence. -/
-theorem isPositiveDefiniteKernel (hF : IsPositiveDefinite F) :
-    IsPositiveDefiniteKernel (fun a b => F (a + star b)) :=
-  isPositiveDefiniteKernel_iff.mpr
-    ⟨fun a b => hF.conj_symm b a, fun {_ι : Type} _ v x => hF.kernel_form_nonneg v x⟩
-
-/-- If the kernel `K(a, b) = F(a + b⋆)` is positive definite, then so is the function `F`. This is
-the reverse half of the function ↔ kernel correspondence. -/
-theorem of_isPositiveDefiniteKernel
-    (hK : IsPositiveDefiniteKernel (fun a b => F (a + star b))) : IsPositiveDefinite F := by
-  obtain ⟨_, hpos⟩ := isPositiveDefiniteKernel_iff.mp hK
-  intro n c v
-  have h := hpos v (fun i => conj (c i))
-  refine le_of_le_of_eq h ?_
-  refine Finset.sum_congr rfl fun i _ => Finset.sum_congr rfl fun j _ => ?_
-  rw [Complex.conj_conj]
+    IsPositiveDefinite (fun x => k * F x) :=
+  of_isPositiveDefiniteKernel <|
+    isPositiveDefiniteKernel_smul_of_nonneg hk hF.isPositiveDefiniteKernel
 
 /-- The Gram matrix of a positive-definite function is positive semidefinite. -/
 theorem gram_posSemidef (hF : IsPositiveDefinite F) {ι : Type*} (v : ι → M) :
@@ -285,33 +247,17 @@ theorem gram_posSemidef (hF : IsPositiveDefinite F) {ι : Type*} (v : ι → M) 
 
 /-- Positive-definite functions are closed under pointwise multiplication (Schur product). -/
 theorem mul (hF : IsPositiveDefinite F) (hG : IsPositiveDefinite G) :
-    IsPositiveDefinite (fun x => F x * G x) := by
-  intro n c v
-  classical
-  let A : Matrix (Fin n) (Fin n) ℂ := fun i j => F (v i + star (v j))
-  let B : Matrix (Fin n) (Fin n) ℂ := fun i j => G (v i + star (v j))
-  have hAB : Matrix.PosSemidef (Matrix.hadamard A B) :=
-    (hF.gram_posSemidef v).hadamard (hG.gram_posSemidef v)
-  have h := hAB.dotProduct_mulVec_nonneg (fun i => conj (c i))
-  refine le_of_le_of_eq h ?_
-  simp [A, B, dotProduct, Matrix.mulVec, Matrix.hadamard, Finset.mul_sum, mul_assoc,
-    mul_left_comm, mul_comm]
+    IsPositiveDefinite (fun x => F x * G x) :=
+  of_isPositiveDefiniteKernel <|
+    isPositiveDefiniteKernel_mul hF.isPositiveDefiniteKernel hG.isPositiveDefiniteKernel
 
 end IsPositiveDefinite
 
 /-- A nonnegative real constant is a positive-definite function. -/
 theorem isPositiveDefinite_const {k : ℂ} (hk : 0 ≤ k) :
-    IsPositiveDefinite (fun _ : M => k) := by
-  intro n c v
-  have hfactor : ∑ i, ∑ j, c i * conj (c j) * k
-      = (∑ i, ∑ j, c i * conj (c j)) * k := by
-    rw [Finset.sum_mul]
-    refine Finset.sum_congr rfl fun i _ => ?_
-    rw [Finset.sum_mul]
-  have hgram : ∑ i, ∑ j, c i * conj (c j) = (∑ i, c i) * conj (∑ i, c i) := by
-    rw [map_sum, Fintype.sum_mul_sum]
-  rw [hfactor, hgram, Complex.mul_conj]
-  exact mul_nonneg (Complex.zero_le_real.mpr (Complex.normSq_nonneg _)) hk
+    IsPositiveDefinite (fun _ : M => k) :=
+  IsPositiveDefinite.of_isPositiveDefiniteKernel <|
+    isPositiveDefiniteKernel_const_of_nonneg hk
 
 /-- The zero function is positive definite. -/
 theorem isPositiveDefinite_zero : IsPositiveDefinite (fun _ : M => (0 : ℂ)) :=
@@ -322,20 +268,16 @@ namespace IsPositiveDefinite
 /-- Positive-definite functions are closed under finite sums. -/
 theorem sum {ι : Type*} {s : Finset ι} {F : ι → M → ℂ}
     (hF : ∀ i ∈ s, IsPositiveDefinite (F i)) :
-    IsPositiveDefinite (fun x => ∑ i ∈ s, F i x) := by
-  have h := Finset.sum_induction F IsPositiveDefinite
-    (fun _ _ => IsPositiveDefinite.add) isPositiveDefinite_zero hF
-  have heq : (∑ i ∈ s, F i) = fun x => ∑ i ∈ s, F i x := funext fun x => Finset.sum_apply x s F
-  rwa [heq] at h
+    IsPositiveDefinite (fun x => ∑ i ∈ s, F i x) :=
+  of_isPositiveDefiniteKernel <|
+    isPositiveDefiniteKernel_sum fun i hi => (hF i hi).isPositiveDefiniteKernel
 
 /-- Positive-definite functions are closed under finite products (Schur product). -/
 theorem prod {ι : Type*} {s : Finset ι} {F : ι → M → ℂ}
     (hF : ∀ i ∈ s, IsPositiveDefinite (F i)) :
-    IsPositiveDefinite (fun x => ∏ i ∈ s, F i x) := by
-  have h := Finset.prod_induction F IsPositiveDefinite
-    (fun _ _ => IsPositiveDefinite.mul) (isPositiveDefinite_const zero_le_one) hF
-  have heq : (∏ i ∈ s, F i) = fun x => ∏ i ∈ s, F i x := funext fun x => Finset.prod_apply x s F
-  rwa [heq] at h
+    IsPositiveDefinite (fun x => ∏ i ∈ s, F i x) :=
+  of_isPositiveDefiniteKernel <|
+    isPositiveDefiniteKernel_prod fun i hi => (hF i hi).isPositiveDefiniteKernel
 
 end IsPositiveDefinite
 

--- a/TauCeti/Analysis/PositiveDefinite/Basic.lean
+++ b/TauCeti/Analysis/PositiveDefinite/Basic.lean
@@ -8,7 +8,6 @@ public import Mathlib.Analysis.Complex.Order
 public import Mathlib.Analysis.Matrix.Order
 public import Mathlib.Algebra.QuadraticDiscriminant
 public import Mathlib.Algebra.BigOperators.Fin
-public import TauCeti.Analysis.PositiveDefinite.Kernel
 
 /-!
 # Positive-definite functions on an involutive additive monoid
@@ -51,7 +50,7 @@ here. The continuity theory and Bochner's representation theorem are later miles
 * `TauCeti.IsPositiveDefinite.norm_apply_le_map_zero_re_of_add_star_eq_zero`: `‖F a‖ ≤ (F 0).re`
   when `a + star a = 0`, with the additive-group corollary
   `TauCeti.IsPositiveDefinite.norm_apply_le_map_zero_re_of_star_eq_neg` for `star a = -a`.
-* `TauCeti.IsPositiveDefinite.gram_posSemidef`: finite Gram matrices of a positive-definite
+* `TauCeti.IsPositiveDefinite.gram_posSemidef`: Gram matrices of a positive-definite
   function are positive semidefinite.
 * `TauCeti.IsPositiveDefinite.add`, `TauCeti.IsPositiveDefinite.sum`,
   `TauCeti.IsPositiveDefinite.const_mul`, `TauCeti.IsPositiveDefinite.mul`,
@@ -255,28 +254,28 @@ private theorem kernel_form_nonneg (hF : IsPositiveDefinite F) {ι : Type*} [Fin
   refine Finset.sum_congr rfl fun i _ => Finset.sum_congr rfl fun j _ => ?_
   rw [Complex.conj_conj]
 
-/-- A positive-definite function `F` induces the positive-definite kernel `K(a, b) = F(a + b⋆)`.
-This is the forward half of the function ↔ kernel correspondence. -/
-theorem isPositiveDefiniteKernel (hF : IsPositiveDefinite F) :
-    IsPositiveDefiniteKernel (fun a b => F (a + star b)) :=
-  isPositiveDefiniteKernel_iff.mpr
-    ⟨fun a b => hF.conj_symm b a, fun {_ι : Type} _ v x => hF.kernel_form_nonneg v x⟩
-
-/-- If the kernel `K(a, b) = F(a + b⋆)` is positive definite, then so is the function `F`. This is
-the reverse half of the function ↔ kernel correspondence. -/
-theorem of_isPositiveDefiniteKernel
-    (hK : IsPositiveDefiniteKernel (fun a b => F (a + star b))) : IsPositiveDefinite F := by
-  obtain ⟨_, hpos⟩ := isPositiveDefiniteKernel_iff.mp hK
-  intro n c v
-  have h := hpos v (fun i => conj (c i))
-  refine le_of_le_of_eq h ?_
-  refine Finset.sum_congr rfl fun i _ => Finset.sum_congr rfl fun j _ => ?_
-  rw [Complex.conj_conj]
-
 /-- The Gram matrix of a positive-definite function is positive semidefinite. -/
 theorem gram_posSemidef (hF : IsPositiveDefinite F) {ι : Type*} (v : ι → M) :
-    Matrix.PosSemidef (fun i j => F (v i + star (v j))) :=
-  isPositiveDefiniteKernel_comp hF.isPositiveDefiniteKernel v
+    Matrix.PosSemidef (fun i j => F (v i + star (v j))) := by
+  classical
+  refine ⟨?_, ?_⟩
+  · ext i j
+    rw [Matrix.conjTranspose_apply, ← starRingEnd_apply]
+    exact hF.conj_symm (v i) (v j)
+  · intro x
+    have h := hF.kernel_form_nonneg (fun i : x.support => v (i : ι))
+      (fun i : x.support => x (i : ι))
+    have h' :
+        0 ≤ ∑ i ∈ x.support, ∑ j ∈ x.support,
+          star (x i) * (F (v i + star (v j)) * x j) := by
+      convert h using 1
+      rw [Finset.sum_subtype x.support (by intro a; rfl)]
+      refine Finset.sum_congr rfl fun i _ => ?_
+      rw [Finset.sum_subtype x.support (by intro a; rfl)]
+      refine Finset.sum_congr rfl fun j _ => ?_
+      rw [starRingEnd_apply]
+      ring
+    simpa [Finsupp.sum, mul_assoc] using h'
 
 /-- Positive-definite functions are closed under pointwise multiplication (Schur product). -/
 theorem mul (hF : IsPositiveDefinite F) (hG : IsPositiveDefinite G) :

--- a/TauCeti/Analysis/PositiveDefinite/FunctionClosure.lean
+++ b/TauCeti/Analysis/PositiveDefinite/FunctionClosure.lean
@@ -5,6 +5,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 module
 
 public import TauCeti.Analysis.PositiveDefinite.Basic
+import TauCeti.Analysis.PositiveDefinite.FunctionKernel
 import TauCeti.Analysis.PositiveDefinite.KernelClosure
 
 /-!
@@ -62,25 +63,11 @@ theorem sum_smul {ι : Type*} {s : Finset ι} {w : ι → ℂ} {F : ι → M →
   sum fun i hi => by
     simpa [Algebra.smul_def] using (hF i hi).const_mul (hw i hi)
 
-/-- Finite nonnegative complex-weighted sums, written using multiplication rather than scalar
-notation. -/
-theorem sum_const_mul {ι : Type*} {s : Finset ι} {w : ι → ℂ} {F : ι → M → ℂ}
-    (hw : ∀ i ∈ s, 0 ≤ w i) (hF : ∀ i ∈ s, IsPositiveDefinite (F i)) :
-    IsPositiveDefinite (fun x => ∑ i ∈ s, w i * F i x) := by
-  simpa [Algebra.smul_def] using sum_smul (M := M) (s := s) (w := w) (F := F) hw hF
-
 /-- Finite nonnegative real-weighted sums of positive-definite functions are positive definite. -/
 theorem sum_real_smul {ι : Type*} {s : Finset ι} {w : ι → ℝ} {F : ι → M → ℂ}
     (hw : ∀ i ∈ s, 0 ≤ w i) (hF : ∀ i ∈ s, IsPositiveDefinite (F i)) :
     IsPositiveDefinite (fun x => ∑ i ∈ s, w i • F i x) :=
   sum fun i hi => (hF i hi).real_smul (hw i hi)
-
-/-- Finite nonnegative real-weighted sums, written with the real weight coerced to `ℂ` and
-multiplied in the codomain. -/
-theorem sum_real_const_mul {ι : Type*} {s : Finset ι} {w : ι → ℝ} {F : ι → M → ℂ}
-    (hw : ∀ i ∈ s, 0 ≤ w i) (hF : ∀ i ∈ s, IsPositiveDefinite (F i)) :
-    IsPositiveDefinite (fun x => ∑ i ∈ s, (w i : ℂ) * F i x) := by
-  simpa [Algebra.smul_def] using sum_real_smul (M := M) (s := s) (w := w) (F := F) hw hF
 
 /-- Schur powers of a positive-definite function are positive definite. -/
 theorem pow {F : M → ℂ} (hF : IsPositiveDefinite F) (n : ℕ) :
@@ -109,23 +96,6 @@ theorem sum_smul_apply_eq_one {ι : Type*} {s : Finset ι} {w : ι → ℂ}
   simpa using (sum_smul_apply_of_apply_eq_one (s := s) (w := w) (F := F) hFx).trans
     hw_sum
 
-/-- If each summand in a finite complex-weighted sum is normalized at a point, then the sum's
-multiplication-form value at that point is the sum of the weights. -/
-theorem sum_const_mul_apply_of_apply_eq_one {ι : Type*} {s : Finset ι} {w : ι → ℂ}
-    {F : ι → N → ℂ} {x : N} (hFx : ∀ i ∈ s, F i x = 1) :
-    (∑ i ∈ s, w i * F i x) = ∑ i ∈ s, w i := by
-  simpa [Algebra.smul_def] using
-    sum_smul_apply_of_apply_eq_one (s := s) (w := w) (F := F) hFx
-
-/-- A finite complex-weighted sum, in multiplication form, of functions normalized at a point is
-normalized at that point when the weights sum to `1`. -/
-theorem sum_const_mul_apply_eq_one {ι : Type*} {s : Finset ι} {w : ι → ℂ}
-    {F : ι → N → ℂ} {x : N} (hFx : ∀ i ∈ s, F i x = 1)
-    (hw_sum : ∑ i ∈ s, w i = 1) :
-    (fun y => ∑ i ∈ s, w i * F i y) x = 1 := by
-  simpa [Algebra.smul_def] using
-    sum_smul_apply_eq_one (s := s) (w := w) (F := F) hFx hw_sum
-
 /-- If each summand in a finite real-weighted sum is normalized at a point, then the sum's value at
 that point is the complex coercion of the sum of the real weights. -/
 theorem sum_real_smul_apply_of_apply_eq_one {ι : Type*} {s : Finset ι} {w : ι → ℝ}
@@ -142,23 +112,6 @@ theorem sum_real_smul_apply_eq_one {ι : Type*} {s : Finset ι} {w : ι → ℝ}
     (fun y => ∑ i ∈ s, w i • F i y) x = 1 := by
   simpa [hw_sum] using
     sum_real_smul_apply_of_apply_eq_one (s := s) (w := w) (F := F) hFx
-
-/-- If each summand in a finite real-weighted sum is normalized at a point, then the sum's
-multiplication-form value at that point is the complex coercion of the sum of the real weights. -/
-theorem sum_real_const_mul_apply_of_apply_eq_one {ι : Type*} {s : Finset ι}
-    {w : ι → ℝ} {F : ι → N → ℂ} {x : N} (hFx : ∀ i ∈ s, F i x = 1) :
-    (∑ i ∈ s, (w i : ℂ) * F i x) = ((∑ i ∈ s, w i : ℝ) : ℂ) := by
-  simpa [Algebra.smul_def] using
-    sum_real_smul_apply_of_apply_eq_one (s := s) (w := w) (F := F) hFx
-
-/-- A finite real-weighted sum, in multiplication form, of functions normalized at a point is
-normalized at that point when the weights sum to `1`. -/
-theorem sum_real_const_mul_apply_eq_one {ι : Type*} {s : Finset ι} {w : ι → ℝ}
-    {F : ι → N → ℂ} {x : N} (hFx : ∀ i ∈ s, F i x = 1)
-    (hw_sum : ∑ i ∈ s, w i = 1) :
-    (fun y => ∑ i ∈ s, (w i : ℂ) * F i y) x = 1 := by
-  simpa [hw_sum] using
-    sum_real_const_mul_apply_of_apply_eq_one (s := s) (w := w) (F := F) hFx
 
 section Origin
 
@@ -178,20 +131,6 @@ theorem sum_smul_apply_zero_eq_one {ι : Type*} {s : Finset ι} {w : ι → ℂ}
     (fun x => ∑ i ∈ s, w i • F i x) 0 = 1 :=
   sum_smul_apply_eq_one (s := s) (w := w) (F := F) hF0 hw_sum
 
-/-- If each summand in a finite complex-weighted sum is normalized at the origin, then the
-sum's multiplication-form value at the origin is the sum of the weights. -/
-theorem sum_const_mul_apply_zero_of_apply_zero_eq_one {ι : Type*} {s : Finset ι}
-    {w : ι → ℂ} {F : ι → N → ℂ} (hF0 : ∀ i ∈ s, F i 0 = 1) :
-    (∑ i ∈ s, w i * F i 0) = ∑ i ∈ s, w i :=
-  sum_const_mul_apply_of_apply_eq_one (s := s) (w := w) (F := F) hF0
-
-/-- A finite complex-weighted sum, in multiplication form, of functions normalized at the origin is
-normalized when the weights sum to `1`. -/
-theorem sum_const_mul_apply_zero_eq_one {ι : Type*} {s : Finset ι} {w : ι → ℂ}
-    {F : ι → N → ℂ} (hF0 : ∀ i ∈ s, F i 0 = 1) (hw_sum : ∑ i ∈ s, w i = 1) :
-    (fun x => ∑ i ∈ s, w i * F i x) 0 = 1 :=
-  sum_const_mul_apply_eq_one (s := s) (w := w) (F := F) hF0 hw_sum
-
 /-- If each summand in a finite real-weighted sum is normalized at the origin, then the sum's value
 at the origin is the complex coercion of the sum of the real weights. -/
 theorem sum_real_smul_apply_zero_of_apply_zero_eq_one {ι : Type*} {s : Finset ι}
@@ -205,20 +144,6 @@ theorem sum_real_smul_apply_zero_eq_one {ι : Type*} {s : Finset ι} {w : ι →
     {F : ι → N → ℂ} (hF0 : ∀ i ∈ s, F i 0 = 1) (hw_sum : ∑ i ∈ s, w i = 1) :
     (fun x => ∑ i ∈ s, w i • F i x) 0 = 1 :=
   sum_real_smul_apply_eq_one (s := s) (w := w) (F := F) hF0 hw_sum
-
-/-- If each summand in a finite real-weighted sum is normalized at the origin, then the sum's
-multiplication-form value at the origin is the complex coercion of the sum of the real weights. -/
-theorem sum_real_const_mul_apply_zero_of_apply_zero_eq_one {ι : Type*} {s : Finset ι}
-    {w : ι → ℝ} {F : ι → N → ℂ} (hF0 : ∀ i ∈ s, F i 0 = 1) :
-    (∑ i ∈ s, (w i : ℂ) * F i 0) = ((∑ i ∈ s, w i : ℝ) : ℂ) :=
-  sum_real_const_mul_apply_of_apply_eq_one (s := s) (w := w) (F := F) hF0
-
-/-- A finite real-weighted sum, in multiplication form, of functions normalized at the origin is
-normalized when the weights sum to `1`. -/
-theorem sum_real_const_mul_apply_zero_eq_one {ι : Type*} {s : Finset ι} {w : ι → ℝ}
-    {F : ι → N → ℂ} (hF0 : ∀ i ∈ s, F i 0 = 1) (hw_sum : ∑ i ∈ s, w i = 1) :
-    (fun x => ∑ i ∈ s, (w i : ℂ) * F i x) 0 = 1 :=
-  sum_real_const_mul_apply_eq_one (s := s) (w := w) (F := F) hF0 hw_sum
 
 end Origin
 

--- a/TauCeti/Analysis/PositiveDefinite/FunctionClosure.lean
+++ b/TauCeti/Analysis/PositiveDefinite/FunctionClosure.lean
@@ -12,12 +12,9 @@ public import TauCeti.Analysis.PositiveDefinite.Basic
 This file adds the weighted finite-mixture and Schur-power API for
 `TauCeti.IsPositiveDefinite`, the positive-definite-function predicate on an involutive additive
 monoid. The basic file already proves binary sums, nonnegative complex scalar multiples, pointwise
-products, and unweighted finite sums/products (all derived from the kernel primitive through the
-function ↔ kernel correspondence). Here we package the forms used by examples and finite
-approximations: finite nonnegative weighted sums, real-weighted variants, and powers.
-
-All statements are given in scalar (`•`) notation; the multiplication-notation restatements have
-been removed in favour of these canonical forms, since `k • z = k * z` in `ℂ`.
+products, and unweighted finite sums/products. Here we package the forms used by examples and
+finite approximations: finite nonnegative weighted sums, real-weighted variants, and powers. The
+weighted sum API is available in scalar (`•`) notation and in multiplication notation.
 
 This advances `TauCetiRoadmap/OneParameterSemigroups/README.md`, Part C, the positive-definite
 functions API asking for closure under sums and products before the Bochner and BCR representation
@@ -64,11 +61,25 @@ theorem sum_smul {ι : Type*} {s : Finset ι} {w : ι → ℂ} {F : ι → M →
   sum fun i hi => by
     simpa [Algebra.smul_def] using (hF i hi).const_mul (hw i hi)
 
+/-- Finite nonnegative complex-weighted sums, written using multiplication rather than scalar
+notation. -/
+theorem sum_const_mul {ι : Type*} {s : Finset ι} {w : ι → ℂ} {F : ι → M → ℂ}
+    (hw : ∀ i ∈ s, 0 ≤ w i) (hF : ∀ i ∈ s, IsPositiveDefinite (F i)) :
+    IsPositiveDefinite (fun x => ∑ i ∈ s, w i * F i x) := by
+  simpa [Algebra.smul_def] using sum_smul (M := M) (s := s) (w := w) (F := F) hw hF
+
 /-- Finite nonnegative real-weighted sums of positive-definite functions are positive definite. -/
 theorem sum_real_smul {ι : Type*} {s : Finset ι} {w : ι → ℝ} {F : ι → M → ℂ}
     (hw : ∀ i ∈ s, 0 ≤ w i) (hF : ∀ i ∈ s, IsPositiveDefinite (F i)) :
     IsPositiveDefinite (fun x => ∑ i ∈ s, w i • F i x) :=
   sum fun i hi => (hF i hi).real_smul (hw i hi)
+
+/-- Finite nonnegative real-weighted sums, written with the real weight coerced to `ℂ` and
+multiplied in the codomain. -/
+theorem sum_real_const_mul {ι : Type*} {s : Finset ι} {w : ι → ℝ} {F : ι → M → ℂ}
+    (hw : ∀ i ∈ s, 0 ≤ w i) (hF : ∀ i ∈ s, IsPositiveDefinite (F i)) :
+    IsPositiveDefinite (fun x => ∑ i ∈ s, (w i : ℂ) * F i x) := by
+  simpa [Algebra.smul_def] using sum_real_smul (M := M) (s := s) (w := w) (F := F) hw hF
 
 /-- Schur powers of a positive-definite function are positive definite. -/
 theorem pow {F : M → ℂ} (hF : IsPositiveDefinite F) (n : ℕ) :
@@ -97,6 +108,23 @@ theorem sum_smul_apply_eq_one {ι : Type*} {s : Finset ι} {w : ι → ℂ}
   simpa using (sum_smul_apply_of_apply_eq_one (s := s) (w := w) (F := F) hFx).trans
     hw_sum
 
+/-- If each summand in a finite complex-weighted sum is normalized at a point, then the sum's
+multiplication-form value at that point is the sum of the weights. -/
+theorem sum_const_mul_apply_of_apply_eq_one {ι : Type*} {s : Finset ι} {w : ι → ℂ}
+    {F : ι → N → ℂ} {x : N} (hFx : ∀ i ∈ s, F i x = 1) :
+    (∑ i ∈ s, w i * F i x) = ∑ i ∈ s, w i := by
+  simpa [Algebra.smul_def] using
+    sum_smul_apply_of_apply_eq_one (s := s) (w := w) (F := F) hFx
+
+/-- A finite complex-weighted sum, in multiplication form, of functions normalized at a point is
+normalized at that point when the weights sum to `1`. -/
+theorem sum_const_mul_apply_eq_one {ι : Type*} {s : Finset ι} {w : ι → ℂ}
+    {F : ι → N → ℂ} {x : N} (hFx : ∀ i ∈ s, F i x = 1)
+    (hw_sum : ∑ i ∈ s, w i = 1) :
+    (fun y => ∑ i ∈ s, w i * F i y) x = 1 := by
+  simpa [Algebra.smul_def] using
+    sum_smul_apply_eq_one (s := s) (w := w) (F := F) hFx hw_sum
+
 /-- If each summand in a finite real-weighted sum is normalized at a point, then the sum's value at
 that point is the complex coercion of the sum of the real weights. -/
 theorem sum_real_smul_apply_of_apply_eq_one {ι : Type*} {s : Finset ι} {w : ι → ℝ}
@@ -113,6 +141,23 @@ theorem sum_real_smul_apply_eq_one {ι : Type*} {s : Finset ι} {w : ι → ℝ}
     (fun y => ∑ i ∈ s, w i • F i y) x = 1 := by
   simpa [hw_sum] using
     sum_real_smul_apply_of_apply_eq_one (s := s) (w := w) (F := F) hFx
+
+/-- If each summand in a finite real-weighted sum is normalized at a point, then the sum's
+multiplication-form value at that point is the complex coercion of the sum of the real weights. -/
+theorem sum_real_const_mul_apply_of_apply_eq_one {ι : Type*} {s : Finset ι}
+    {w : ι → ℝ} {F : ι → N → ℂ} {x : N} (hFx : ∀ i ∈ s, F i x = 1) :
+    (∑ i ∈ s, (w i : ℂ) * F i x) = ((∑ i ∈ s, w i : ℝ) : ℂ) := by
+  simpa [Algebra.smul_def] using
+    sum_real_smul_apply_of_apply_eq_one (s := s) (w := w) (F := F) hFx
+
+/-- A finite real-weighted sum, in multiplication form, of functions normalized at a point is
+normalized at that point when the weights sum to `1`. -/
+theorem sum_real_const_mul_apply_eq_one {ι : Type*} {s : Finset ι} {w : ι → ℝ}
+    {F : ι → N → ℂ} {x : N} (hFx : ∀ i ∈ s, F i x = 1)
+    (hw_sum : ∑ i ∈ s, w i = 1) :
+    (fun y => ∑ i ∈ s, (w i : ℂ) * F i y) x = 1 := by
+  simpa [hw_sum] using
+    sum_real_const_mul_apply_of_apply_eq_one (s := s) (w := w) (F := F) hFx
 
 section Origin
 
@@ -132,6 +177,20 @@ theorem sum_smul_apply_zero_eq_one {ι : Type*} {s : Finset ι} {w : ι → ℂ}
     (fun x => ∑ i ∈ s, w i • F i x) 0 = 1 :=
   sum_smul_apply_eq_one (s := s) (w := w) (F := F) hF0 hw_sum
 
+/-- If each summand in a finite complex-weighted sum is normalized at the origin, then the
+sum's multiplication-form value at the origin is the sum of the weights. -/
+theorem sum_const_mul_apply_zero_of_apply_zero_eq_one {ι : Type*} {s : Finset ι}
+    {w : ι → ℂ} {F : ι → N → ℂ} (hF0 : ∀ i ∈ s, F i 0 = 1) :
+    (∑ i ∈ s, w i * F i 0) = ∑ i ∈ s, w i :=
+  sum_const_mul_apply_of_apply_eq_one (s := s) (w := w) (F := F) hF0
+
+/-- A finite complex-weighted sum, in multiplication form, of functions normalized at the origin is
+normalized when the weights sum to `1`. -/
+theorem sum_const_mul_apply_zero_eq_one {ι : Type*} {s : Finset ι} {w : ι → ℂ}
+    {F : ι → N → ℂ} (hF0 : ∀ i ∈ s, F i 0 = 1) (hw_sum : ∑ i ∈ s, w i = 1) :
+    (fun x => ∑ i ∈ s, w i * F i x) 0 = 1 :=
+  sum_const_mul_apply_eq_one (s := s) (w := w) (F := F) hF0 hw_sum
+
 /-- If each summand in a finite real-weighted sum is normalized at the origin, then the sum's value
 at the origin is the complex coercion of the sum of the real weights. -/
 theorem sum_real_smul_apply_zero_of_apply_zero_eq_one {ι : Type*} {s : Finset ι}
@@ -145,6 +204,20 @@ theorem sum_real_smul_apply_zero_eq_one {ι : Type*} {s : Finset ι} {w : ι →
     {F : ι → N → ℂ} (hF0 : ∀ i ∈ s, F i 0 = 1) (hw_sum : ∑ i ∈ s, w i = 1) :
     (fun x => ∑ i ∈ s, w i • F i x) 0 = 1 :=
   sum_real_smul_apply_eq_one (s := s) (w := w) (F := F) hF0 hw_sum
+
+/-- If each summand in a finite real-weighted sum is normalized at the origin, then the sum's
+multiplication-form value at the origin is the complex coercion of the sum of the real weights. -/
+theorem sum_real_const_mul_apply_zero_of_apply_zero_eq_one {ι : Type*} {s : Finset ι}
+    {w : ι → ℝ} {F : ι → N → ℂ} (hF0 : ∀ i ∈ s, F i 0 = 1) :
+    (∑ i ∈ s, (w i : ℂ) * F i 0) = ((∑ i ∈ s, w i : ℝ) : ℂ) :=
+  sum_real_const_mul_apply_of_apply_eq_one (s := s) (w := w) (F := F) hF0
+
+/-- A finite real-weighted sum, in multiplication form, of functions normalized at the origin is
+normalized when the weights sum to `1`. -/
+theorem sum_real_const_mul_apply_zero_eq_one {ι : Type*} {s : Finset ι} {w : ι → ℝ}
+    {F : ι → N → ℂ} (hF0 : ∀ i ∈ s, F i 0 = 1) (hw_sum : ∑ i ∈ s, w i = 1) :
+    (fun x => ∑ i ∈ s, (w i : ℂ) * F i x) 0 = 1 :=
+  sum_real_const_mul_apply_eq_one (s := s) (w := w) (F := F) hF0 hw_sum
 
 end Origin
 

--- a/TauCeti/Analysis/PositiveDefinite/FunctionClosure.lean
+++ b/TauCeti/Analysis/PositiveDefinite/FunctionClosure.lean
@@ -62,11 +62,25 @@ theorem sum_smul {ι : Type*} {s : Finset ι} {w : ι → ℂ} {F : ι → M →
   sum fun i hi => by
     simpa [Algebra.smul_def] using (hF i hi).const_mul (hw i hi)
 
+/-- Finite nonnegative complex-weighted sums, written using multiplication rather than scalar
+notation. -/
+theorem sum_const_mul {ι : Type*} {s : Finset ι} {w : ι → ℂ} {F : ι → M → ℂ}
+    (hw : ∀ i ∈ s, 0 ≤ w i) (hF : ∀ i ∈ s, IsPositiveDefinite (F i)) :
+    IsPositiveDefinite (fun x => ∑ i ∈ s, w i * F i x) := by
+  simpa [Algebra.smul_def] using sum_smul (M := M) (s := s) (w := w) (F := F) hw hF
+
 /-- Finite nonnegative real-weighted sums of positive-definite functions are positive definite. -/
 theorem sum_real_smul {ι : Type*} {s : Finset ι} {w : ι → ℝ} {F : ι → M → ℂ}
     (hw : ∀ i ∈ s, 0 ≤ w i) (hF : ∀ i ∈ s, IsPositiveDefinite (F i)) :
     IsPositiveDefinite (fun x => ∑ i ∈ s, w i • F i x) :=
   sum fun i hi => (hF i hi).real_smul (hw i hi)
+
+/-- Finite nonnegative real-weighted sums, written with the real weight coerced to `ℂ` and
+multiplied in the codomain. -/
+theorem sum_real_const_mul {ι : Type*} {s : Finset ι} {w : ι → ℝ} {F : ι → M → ℂ}
+    (hw : ∀ i ∈ s, 0 ≤ w i) (hF : ∀ i ∈ s, IsPositiveDefinite (F i)) :
+    IsPositiveDefinite (fun x => ∑ i ∈ s, (w i : ℂ) * F i x) := by
+  simpa [Algebra.smul_def] using sum_real_smul (M := M) (s := s) (w := w) (F := F) hw hF
 
 /-- Schur powers of a positive-definite function are positive definite. -/
 theorem pow {F : M → ℂ} (hF : IsPositiveDefinite F) (n : ℕ) :
@@ -95,6 +109,23 @@ theorem sum_smul_apply_eq_one {ι : Type*} {s : Finset ι} {w : ι → ℂ}
   simpa using (sum_smul_apply_of_apply_eq_one (s := s) (w := w) (F := F) hFx).trans
     hw_sum
 
+/-- If each summand in a finite complex-weighted sum is normalized at a point, then the sum's
+multiplication-form value at that point is the sum of the weights. -/
+theorem sum_const_mul_apply_of_apply_eq_one {ι : Type*} {s : Finset ι} {w : ι → ℂ}
+    {F : ι → N → ℂ} {x : N} (hFx : ∀ i ∈ s, F i x = 1) :
+    (∑ i ∈ s, w i * F i x) = ∑ i ∈ s, w i := by
+  simpa [Algebra.smul_def] using
+    sum_smul_apply_of_apply_eq_one (s := s) (w := w) (F := F) hFx
+
+/-- A finite complex-weighted sum, in multiplication form, of functions normalized at a point is
+normalized at that point when the weights sum to `1`. -/
+theorem sum_const_mul_apply_eq_one {ι : Type*} {s : Finset ι} {w : ι → ℂ}
+    {F : ι → N → ℂ} {x : N} (hFx : ∀ i ∈ s, F i x = 1)
+    (hw_sum : ∑ i ∈ s, w i = 1) :
+    (fun y => ∑ i ∈ s, w i * F i y) x = 1 := by
+  simpa [Algebra.smul_def] using
+    sum_smul_apply_eq_one (s := s) (w := w) (F := F) hFx hw_sum
+
 /-- If each summand in a finite real-weighted sum is normalized at a point, then the sum's value at
 that point is the complex coercion of the sum of the real weights. -/
 theorem sum_real_smul_apply_of_apply_eq_one {ι : Type*} {s : Finset ι} {w : ι → ℝ}
@@ -111,6 +142,23 @@ theorem sum_real_smul_apply_eq_one {ι : Type*} {s : Finset ι} {w : ι → ℝ}
     (fun y => ∑ i ∈ s, w i • F i y) x = 1 := by
   simpa [hw_sum] using
     sum_real_smul_apply_of_apply_eq_one (s := s) (w := w) (F := F) hFx
+
+/-- If each summand in a finite real-weighted sum is normalized at a point, then the sum's
+multiplication-form value at that point is the complex coercion of the sum of the real weights. -/
+theorem sum_real_const_mul_apply_of_apply_eq_one {ι : Type*} {s : Finset ι}
+    {w : ι → ℝ} {F : ι → N → ℂ} {x : N} (hFx : ∀ i ∈ s, F i x = 1) :
+    (∑ i ∈ s, (w i : ℂ) * F i x) = ((∑ i ∈ s, w i : ℝ) : ℂ) := by
+  simpa [Algebra.smul_def] using
+    sum_real_smul_apply_of_apply_eq_one (s := s) (w := w) (F := F) hFx
+
+/-- A finite real-weighted sum, in multiplication form, of functions normalized at a point is
+normalized at that point when the weights sum to `1`. -/
+theorem sum_real_const_mul_apply_eq_one {ι : Type*} {s : Finset ι} {w : ι → ℝ}
+    {F : ι → N → ℂ} {x : N} (hFx : ∀ i ∈ s, F i x = 1)
+    (hw_sum : ∑ i ∈ s, w i = 1) :
+    (fun y => ∑ i ∈ s, (w i : ℂ) * F i y) x = 1 := by
+  simpa [hw_sum] using
+    sum_real_const_mul_apply_of_apply_eq_one (s := s) (w := w) (F := F) hFx
 
 section Origin
 
@@ -130,6 +178,20 @@ theorem sum_smul_apply_zero_eq_one {ι : Type*} {s : Finset ι} {w : ι → ℂ}
     (fun x => ∑ i ∈ s, w i • F i x) 0 = 1 :=
   sum_smul_apply_eq_one (s := s) (w := w) (F := F) hF0 hw_sum
 
+/-- If each summand in a finite complex-weighted sum is normalized at the origin, then the
+sum's multiplication-form value at the origin is the sum of the weights. -/
+theorem sum_const_mul_apply_zero_of_apply_zero_eq_one {ι : Type*} {s : Finset ι}
+    {w : ι → ℂ} {F : ι → N → ℂ} (hF0 : ∀ i ∈ s, F i 0 = 1) :
+    (∑ i ∈ s, w i * F i 0) = ∑ i ∈ s, w i :=
+  sum_const_mul_apply_of_apply_eq_one (s := s) (w := w) (F := F) hF0
+
+/-- A finite complex-weighted sum, in multiplication form, of functions normalized at the origin is
+normalized when the weights sum to `1`. -/
+theorem sum_const_mul_apply_zero_eq_one {ι : Type*} {s : Finset ι} {w : ι → ℂ}
+    {F : ι → N → ℂ} (hF0 : ∀ i ∈ s, F i 0 = 1) (hw_sum : ∑ i ∈ s, w i = 1) :
+    (fun x => ∑ i ∈ s, w i * F i x) 0 = 1 :=
+  sum_const_mul_apply_eq_one (s := s) (w := w) (F := F) hF0 hw_sum
+
 /-- If each summand in a finite real-weighted sum is normalized at the origin, then the sum's value
 at the origin is the complex coercion of the sum of the real weights. -/
 theorem sum_real_smul_apply_zero_of_apply_zero_eq_one {ι : Type*} {s : Finset ι}
@@ -143,6 +205,20 @@ theorem sum_real_smul_apply_zero_eq_one {ι : Type*} {s : Finset ι} {w : ι →
     {F : ι → N → ℂ} (hF0 : ∀ i ∈ s, F i 0 = 1) (hw_sum : ∑ i ∈ s, w i = 1) :
     (fun x => ∑ i ∈ s, w i • F i x) 0 = 1 :=
   sum_real_smul_apply_eq_one (s := s) (w := w) (F := F) hF0 hw_sum
+
+/-- If each summand in a finite real-weighted sum is normalized at the origin, then the sum's
+multiplication-form value at the origin is the complex coercion of the sum of the real weights. -/
+theorem sum_real_const_mul_apply_zero_of_apply_zero_eq_one {ι : Type*} {s : Finset ι}
+    {w : ι → ℝ} {F : ι → N → ℂ} (hF0 : ∀ i ∈ s, F i 0 = 1) :
+    (∑ i ∈ s, (w i : ℂ) * F i 0) = ((∑ i ∈ s, w i : ℝ) : ℂ) :=
+  sum_real_const_mul_apply_of_apply_eq_one (s := s) (w := w) (F := F) hF0
+
+/-- A finite real-weighted sum, in multiplication form, of functions normalized at the origin is
+normalized when the weights sum to `1`. -/
+theorem sum_real_const_mul_apply_zero_eq_one {ι : Type*} {s : Finset ι} {w : ι → ℝ}
+    {F : ι → N → ℂ} (hF0 : ∀ i ∈ s, F i 0 = 1) (hw_sum : ∑ i ∈ s, w i = 1) :
+    (fun x => ∑ i ∈ s, (w i : ℂ) * F i x) 0 = 1 :=
+  sum_real_const_mul_apply_eq_one (s := s) (w := w) (F := F) hF0 hw_sum
 
 end Origin
 

--- a/TauCeti/Analysis/PositiveDefinite/FunctionClosure.lean
+++ b/TauCeti/Analysis/PositiveDefinite/FunctionClosure.lean
@@ -4,8 +4,9 @@ Released under Apache 2.0 license as described in the file LICENSE.
 -/
 module
 
-public import TauCeti.Analysis.PositiveDefinite.FunctionKernel
-public import TauCeti.Analysis.PositiveDefinite.KernelClosure
+public import TauCeti.Analysis.PositiveDefinite.Basic
+import TauCeti.Analysis.PositiveDefinite.FunctionKernel
+import TauCeti.Analysis.PositiveDefinite.KernelClosure
 
 /-!
 # Weighted closure for positive-definite functions
@@ -62,11 +63,25 @@ theorem sum_smul {ι : Type*} {s : Finset ι} {w : ι → ℂ} {F : ι → M →
   sum fun i hi => by
     simpa [Algebra.smul_def] using (hF i hi).const_mul (hw i hi)
 
+/-- Finite nonnegative complex-weighted sums, written using multiplication rather than scalar
+notation. -/
+theorem sum_const_mul {ι : Type*} {s : Finset ι} {w : ι → ℂ} {F : ι → M → ℂ}
+    (hw : ∀ i ∈ s, 0 ≤ w i) (hF : ∀ i ∈ s, IsPositiveDefinite (F i)) :
+    IsPositiveDefinite (fun x => ∑ i ∈ s, w i * F i x) := by
+  simpa [Algebra.smul_def] using sum_smul (M := M) (s := s) (w := w) (F := F) hw hF
+
 /-- Finite nonnegative real-weighted sums of positive-definite functions are positive definite. -/
 theorem sum_real_smul {ι : Type*} {s : Finset ι} {w : ι → ℝ} {F : ι → M → ℂ}
     (hw : ∀ i ∈ s, 0 ≤ w i) (hF : ∀ i ∈ s, IsPositiveDefinite (F i)) :
     IsPositiveDefinite (fun x => ∑ i ∈ s, w i • F i x) :=
   sum fun i hi => (hF i hi).real_smul (hw i hi)
+
+/-- Finite nonnegative real-weighted sums, written with the real weight coerced to `ℂ` and
+multiplied in the codomain. -/
+theorem sum_real_const_mul {ι : Type*} {s : Finset ι} {w : ι → ℝ} {F : ι → M → ℂ}
+    (hw : ∀ i ∈ s, 0 ≤ w i) (hF : ∀ i ∈ s, IsPositiveDefinite (F i)) :
+    IsPositiveDefinite (fun x => ∑ i ∈ s, (w i : ℂ) * F i x) := by
+  simpa [Algebra.smul_def] using sum_real_smul (M := M) (s := s) (w := w) (F := F) hw hF
 
 /-- Schur powers of a positive-definite function are positive definite. -/
 theorem pow {F : M → ℂ} (hF : IsPositiveDefinite F) (n : ℕ) :
@@ -95,6 +110,23 @@ theorem sum_smul_apply_eq_one {ι : Type*} {s : Finset ι} {w : ι → ℂ}
   simpa using (sum_smul_apply_of_apply_eq_one (s := s) (w := w) (F := F) hFx).trans
     hw_sum
 
+/-- If each summand in a finite complex-weighted sum is normalized at a point, then the sum's
+multiplication-form value at that point is the sum of the weights. -/
+theorem sum_const_mul_apply_of_apply_eq_one {ι : Type*} {s : Finset ι} {w : ι → ℂ}
+    {F : ι → N → ℂ} {x : N} (hFx : ∀ i ∈ s, F i x = 1) :
+    (∑ i ∈ s, w i * F i x) = ∑ i ∈ s, w i := by
+  simpa [Algebra.smul_def] using
+    sum_smul_apply_of_apply_eq_one (s := s) (w := w) (F := F) hFx
+
+/-- A finite complex-weighted sum, in multiplication form, of functions normalized at a point is
+normalized at that point when the weights sum to `1`. -/
+theorem sum_const_mul_apply_eq_one {ι : Type*} {s : Finset ι} {w : ι → ℂ}
+    {F : ι → N → ℂ} {x : N} (hFx : ∀ i ∈ s, F i x = 1)
+    (hw_sum : ∑ i ∈ s, w i = 1) :
+    (fun y => ∑ i ∈ s, w i * F i y) x = 1 := by
+  simpa [Algebra.smul_def] using
+    sum_smul_apply_eq_one (s := s) (w := w) (F := F) hFx hw_sum
+
 /-- If each summand in a finite real-weighted sum is normalized at a point, then the sum's value at
 that point is the complex coercion of the sum of the real weights. -/
 theorem sum_real_smul_apply_of_apply_eq_one {ι : Type*} {s : Finset ι} {w : ι → ℝ}
@@ -111,6 +143,23 @@ theorem sum_real_smul_apply_eq_one {ι : Type*} {s : Finset ι} {w : ι → ℝ}
     (fun y => ∑ i ∈ s, w i • F i y) x = 1 := by
   simpa [hw_sum] using
     sum_real_smul_apply_of_apply_eq_one (s := s) (w := w) (F := F) hFx
+
+/-- If each summand in a finite real-weighted sum is normalized at a point, then the sum's
+multiplication-form value at that point is the complex coercion of the sum of the real weights. -/
+theorem sum_real_const_mul_apply_of_apply_eq_one {ι : Type*} {s : Finset ι}
+    {w : ι → ℝ} {F : ι → N → ℂ} {x : N} (hFx : ∀ i ∈ s, F i x = 1) :
+    (∑ i ∈ s, (w i : ℂ) * F i x) = ((∑ i ∈ s, w i : ℝ) : ℂ) := by
+  simpa [Algebra.smul_def] using
+    sum_real_smul_apply_of_apply_eq_one (s := s) (w := w) (F := F) hFx
+
+/-- A finite real-weighted sum, in multiplication form, of functions normalized at a point is
+normalized at that point when the weights sum to `1`. -/
+theorem sum_real_const_mul_apply_eq_one {ι : Type*} {s : Finset ι} {w : ι → ℝ}
+    {F : ι → N → ℂ} {x : N} (hFx : ∀ i ∈ s, F i x = 1)
+    (hw_sum : ∑ i ∈ s, w i = 1) :
+    (fun y => ∑ i ∈ s, (w i : ℂ) * F i y) x = 1 := by
+  simpa [hw_sum] using
+    sum_real_const_mul_apply_of_apply_eq_one (s := s) (w := w) (F := F) hFx
 
 section Origin
 
@@ -130,6 +179,20 @@ theorem sum_smul_apply_zero_eq_one {ι : Type*} {s : Finset ι} {w : ι → ℂ}
     (fun x => ∑ i ∈ s, w i • F i x) 0 = 1 :=
   sum_smul_apply_eq_one (s := s) (w := w) (F := F) hF0 hw_sum
 
+/-- If each summand in a finite complex-weighted sum is normalized at the origin, then the
+sum's multiplication-form value at the origin is the sum of the weights. -/
+theorem sum_const_mul_apply_zero_of_apply_zero_eq_one {ι : Type*} {s : Finset ι}
+    {w : ι → ℂ} {F : ι → N → ℂ} (hF0 : ∀ i ∈ s, F i 0 = 1) :
+    (∑ i ∈ s, w i * F i 0) = ∑ i ∈ s, w i :=
+  sum_const_mul_apply_of_apply_eq_one (s := s) (w := w) (F := F) hF0
+
+/-- A finite complex-weighted sum, in multiplication form, of functions normalized at the origin is
+normalized when the weights sum to `1`. -/
+theorem sum_const_mul_apply_zero_eq_one {ι : Type*} {s : Finset ι} {w : ι → ℂ}
+    {F : ι → N → ℂ} (hF0 : ∀ i ∈ s, F i 0 = 1) (hw_sum : ∑ i ∈ s, w i = 1) :
+    (fun x => ∑ i ∈ s, w i * F i x) 0 = 1 :=
+  sum_const_mul_apply_eq_one (s := s) (w := w) (F := F) hF0 hw_sum
+
 /-- If each summand in a finite real-weighted sum is normalized at the origin, then the sum's value
 at the origin is the complex coercion of the sum of the real weights. -/
 theorem sum_real_smul_apply_zero_of_apply_zero_eq_one {ι : Type*} {s : Finset ι}
@@ -143,6 +206,20 @@ theorem sum_real_smul_apply_zero_eq_one {ι : Type*} {s : Finset ι} {w : ι →
     {F : ι → N → ℂ} (hF0 : ∀ i ∈ s, F i 0 = 1) (hw_sum : ∑ i ∈ s, w i = 1) :
     (fun x => ∑ i ∈ s, w i • F i x) 0 = 1 :=
   sum_real_smul_apply_eq_one (s := s) (w := w) (F := F) hF0 hw_sum
+
+/-- If each summand in a finite real-weighted sum is normalized at the origin, then the sum's
+multiplication-form value at the origin is the complex coercion of the sum of the real weights. -/
+theorem sum_real_const_mul_apply_zero_of_apply_zero_eq_one {ι : Type*} {s : Finset ι}
+    {w : ι → ℝ} {F : ι → N → ℂ} (hF0 : ∀ i ∈ s, F i 0 = 1) :
+    (∑ i ∈ s, (w i : ℂ) * F i 0) = ((∑ i ∈ s, w i : ℝ) : ℂ) :=
+  sum_real_const_mul_apply_of_apply_eq_one (s := s) (w := w) (F := F) hF0
+
+/-- A finite real-weighted sum, in multiplication form, of functions normalized at the origin is
+normalized when the weights sum to `1`. -/
+theorem sum_real_const_mul_apply_zero_eq_one {ι : Type*} {s : Finset ι} {w : ι → ℝ}
+    {F : ι → N → ℂ} (hF0 : ∀ i ∈ s, F i 0 = 1) (hw_sum : ∑ i ∈ s, w i = 1) :
+    (fun x => ∑ i ∈ s, (w i : ℂ) * F i x) 0 = 1 :=
+  sum_real_const_mul_apply_eq_one (s := s) (w := w) (F := F) hF0 hw_sum
 
 end Origin
 

--- a/TauCeti/Analysis/PositiveDefinite/FunctionClosure.lean
+++ b/TauCeti/Analysis/PositiveDefinite/FunctionClosure.lean
@@ -5,7 +5,6 @@ Released under Apache 2.0 license as described in the file LICENSE.
 module
 
 public import TauCeti.Analysis.PositiveDefinite.Basic
-import TauCeti.Analysis.PositiveDefinite.FunctionKernel
 import TauCeti.Analysis.PositiveDefinite.KernelClosure
 
 /-!

--- a/TauCeti/Analysis/PositiveDefinite/FunctionClosure.lean
+++ b/TauCeti/Analysis/PositiveDefinite/FunctionClosure.lean
@@ -12,8 +12,12 @@ public import TauCeti.Analysis.PositiveDefinite.Basic
 This file adds the weighted finite-mixture and Schur-power API for
 `TauCeti.IsPositiveDefinite`, the positive-definite-function predicate on an involutive additive
 monoid. The basic file already proves binary sums, nonnegative complex scalar multiples, pointwise
-products, and unweighted finite sums/products. Here we package the forms used by examples and
-finite approximations: finite nonnegative weighted sums, real-weighted variants, and powers.
+products, and unweighted finite sums/products (all derived from the kernel primitive through the
+function ↔ kernel correspondence). Here we package the forms used by examples and finite
+approximations: finite nonnegative weighted sums, real-weighted variants, and powers.
+
+All statements are given in scalar (`•`) notation; the multiplication-notation restatements have
+been removed in favour of these canonical forms, since `k • z = k * z` in `ℂ`.
 
 This advances `TauCetiRoadmap/OneParameterSemigroups/README.md`, Part C, the positive-definite
 functions API asking for closure under sums and products before the Bochner and BCR representation
@@ -60,34 +64,17 @@ theorem sum_smul {ι : Type*} {s : Finset ι} {w : ι → ℂ} {F : ι → M →
   sum fun i hi => by
     simpa [Algebra.smul_def] using (hF i hi).const_mul (hw i hi)
 
-/-- Finite nonnegative complex-weighted sums, written using multiplication rather than scalar
-notation. -/
-theorem sum_const_mul {ι : Type*} {s : Finset ι} {w : ι → ℂ} {F : ι → M → ℂ}
-    (hw : ∀ i ∈ s, 0 ≤ w i) (hF : ∀ i ∈ s, IsPositiveDefinite (F i)) :
-    IsPositiveDefinite (fun x => ∑ i ∈ s, w i * F i x) := by
-  simpa [Algebra.smul_def] using sum_smul (M := M) (s := s) (w := w) (F := F) hw hF
-
 /-- Finite nonnegative real-weighted sums of positive-definite functions are positive definite. -/
 theorem sum_real_smul {ι : Type*} {s : Finset ι} {w : ι → ℝ} {F : ι → M → ℂ}
     (hw : ∀ i ∈ s, 0 ≤ w i) (hF : ∀ i ∈ s, IsPositiveDefinite (F i)) :
     IsPositiveDefinite (fun x => ∑ i ∈ s, w i • F i x) :=
   sum fun i hi => (hF i hi).real_smul (hw i hi)
 
-/-- Finite nonnegative real-weighted sums, written with the real weight coerced to `ℂ` and
-multiplied in the codomain. -/
-theorem sum_real_const_mul {ι : Type*} {s : Finset ι} {w : ι → ℝ} {F : ι → M → ℂ}
-    (hw : ∀ i ∈ s, 0 ≤ w i) (hF : ∀ i ∈ s, IsPositiveDefinite (F i)) :
-    IsPositiveDefinite (fun x => ∑ i ∈ s, (w i : ℂ) * F i x) := by
-  simpa [Algebra.smul_def] using sum_real_smul (M := M) (s := s) (w := w) (F := F) hw hF
-
-/-- Schur powers of a positive-definite function are positive definite. -/
+/-- Schur powers of a positive-definite function are positive definite. This is the function-form
+image of `TauCeti.isPositiveDefiniteKernel_pow`. -/
 theorem pow {F : M → ℂ} (hF : IsPositiveDefinite F) (n : ℕ) :
-    IsPositiveDefinite (fun x => F x ^ n) := by
-  induction n with
-  | zero =>
-      simpa using isPositiveDefinite_const (M := M) (k := (1 : ℂ)) zero_le_one
-  | succ n ih =>
-      simpa [pow_succ] using ih.mul hF
+    IsPositiveDefinite (fun x => F x ^ n) :=
+  of_isPositiveDefiniteKernel (isPositiveDefiniteKernel_pow hF.isPositiveDefiniteKernel n)
 
 section Values
 
@@ -111,23 +98,6 @@ theorem sum_smul_apply_eq_one {ι : Type*} {s : Finset ι} {w : ι → ℂ}
   simpa using (sum_smul_apply_of_apply_eq_one (s := s) (w := w) (F := F) hFx).trans
     hw_sum
 
-/-- If each summand in a finite complex-weighted sum is normalized at a point, then the sum's
-multiplication-form value at that point is the sum of the weights. -/
-theorem sum_const_mul_apply_of_apply_eq_one {ι : Type*} {s : Finset ι} {w : ι → ℂ}
-    {F : ι → N → ℂ} {x : N} (hFx : ∀ i ∈ s, F i x = 1) :
-    (∑ i ∈ s, w i * F i x) = ∑ i ∈ s, w i := by
-  simpa [Algebra.smul_def] using
-    sum_smul_apply_of_apply_eq_one (s := s) (w := w) (F := F) hFx
-
-/-- A finite complex-weighted sum, in multiplication form, of functions normalized at a point is
-normalized at that point when the weights sum to `1`. -/
-theorem sum_const_mul_apply_eq_one {ι : Type*} {s : Finset ι} {w : ι → ℂ}
-    {F : ι → N → ℂ} {x : N} (hFx : ∀ i ∈ s, F i x = 1)
-    (hw_sum : ∑ i ∈ s, w i = 1) :
-    (fun y => ∑ i ∈ s, w i * F i y) x = 1 := by
-  simpa [Algebra.smul_def] using
-    sum_smul_apply_eq_one (s := s) (w := w) (F := F) hFx hw_sum
-
 /-- If each summand in a finite real-weighted sum is normalized at a point, then the sum's value at
 that point is the complex coercion of the sum of the real weights. -/
 theorem sum_real_smul_apply_of_apply_eq_one {ι : Type*} {s : Finset ι} {w : ι → ℝ}
@@ -144,23 +114,6 @@ theorem sum_real_smul_apply_eq_one {ι : Type*} {s : Finset ι} {w : ι → ℝ}
     (fun y => ∑ i ∈ s, w i • F i y) x = 1 := by
   simpa [hw_sum] using
     sum_real_smul_apply_of_apply_eq_one (s := s) (w := w) (F := F) hFx
-
-/-- If each summand in a finite real-weighted sum is normalized at a point, then the sum's
-multiplication-form value at that point is the complex coercion of the sum of the real weights. -/
-theorem sum_real_const_mul_apply_of_apply_eq_one {ι : Type*} {s : Finset ι}
-    {w : ι → ℝ} {F : ι → N → ℂ} {x : N} (hFx : ∀ i ∈ s, F i x = 1) :
-    (∑ i ∈ s, (w i : ℂ) * F i x) = ((∑ i ∈ s, w i : ℝ) : ℂ) := by
-  simpa [Algebra.smul_def] using
-    sum_real_smul_apply_of_apply_eq_one (s := s) (w := w) (F := F) hFx
-
-/-- A finite real-weighted sum, in multiplication form, of functions normalized at a point is
-normalized at that point when the weights sum to `1`. -/
-theorem sum_real_const_mul_apply_eq_one {ι : Type*} {s : Finset ι} {w : ι → ℝ}
-    {F : ι → N → ℂ} {x : N} (hFx : ∀ i ∈ s, F i x = 1)
-    (hw_sum : ∑ i ∈ s, w i = 1) :
-    (fun y => ∑ i ∈ s, (w i : ℂ) * F i y) x = 1 := by
-  simpa [hw_sum] using
-    sum_real_const_mul_apply_of_apply_eq_one (s := s) (w := w) (F := F) hFx
 
 section Origin
 
@@ -180,20 +133,6 @@ theorem sum_smul_apply_zero_eq_one {ι : Type*} {s : Finset ι} {w : ι → ℂ}
     (fun x => ∑ i ∈ s, w i • F i x) 0 = 1 :=
   sum_smul_apply_eq_one (s := s) (w := w) (F := F) hF0 hw_sum
 
-/-- If each summand in a finite complex-weighted sum is normalized at the origin, then the
-sum's multiplication-form value at the origin is the sum of the weights. -/
-theorem sum_const_mul_apply_zero_of_apply_zero_eq_one {ι : Type*} {s : Finset ι}
-    {w : ι → ℂ} {F : ι → N → ℂ} (hF0 : ∀ i ∈ s, F i 0 = 1) :
-    (∑ i ∈ s, w i * F i 0) = ∑ i ∈ s, w i :=
-  sum_const_mul_apply_of_apply_eq_one (s := s) (w := w) (F := F) hF0
-
-/-- A finite complex-weighted sum, in multiplication form, of functions normalized at the origin is
-normalized when the weights sum to `1`. -/
-theorem sum_const_mul_apply_zero_eq_one {ι : Type*} {s : Finset ι} {w : ι → ℂ}
-    {F : ι → N → ℂ} (hF0 : ∀ i ∈ s, F i 0 = 1) (hw_sum : ∑ i ∈ s, w i = 1) :
-    (fun x => ∑ i ∈ s, w i * F i x) 0 = 1 :=
-  sum_const_mul_apply_eq_one (s := s) (w := w) (F := F) hF0 hw_sum
-
 /-- If each summand in a finite real-weighted sum is normalized at the origin, then the sum's value
 at the origin is the complex coercion of the sum of the real weights. -/
 theorem sum_real_smul_apply_zero_of_apply_zero_eq_one {ι : Type*} {s : Finset ι}
@@ -207,20 +146,6 @@ theorem sum_real_smul_apply_zero_eq_one {ι : Type*} {s : Finset ι} {w : ι →
     {F : ι → N → ℂ} (hF0 : ∀ i ∈ s, F i 0 = 1) (hw_sum : ∑ i ∈ s, w i = 1) :
     (fun x => ∑ i ∈ s, w i • F i x) 0 = 1 :=
   sum_real_smul_apply_eq_one (s := s) (w := w) (F := F) hF0 hw_sum
-
-/-- If each summand in a finite real-weighted sum is normalized at the origin, then the sum's
-multiplication-form value at the origin is the complex coercion of the sum of the real weights. -/
-theorem sum_real_const_mul_apply_zero_of_apply_zero_eq_one {ι : Type*} {s : Finset ι}
-    {w : ι → ℝ} {F : ι → N → ℂ} (hF0 : ∀ i ∈ s, F i 0 = 1) :
-    (∑ i ∈ s, (w i : ℂ) * F i 0) = ((∑ i ∈ s, w i : ℝ) : ℂ) :=
-  sum_real_const_mul_apply_of_apply_eq_one (s := s) (w := w) (F := F) hF0
-
-/-- A finite real-weighted sum, in multiplication form, of functions normalized at the origin is
-normalized when the weights sum to `1`. -/
-theorem sum_real_const_mul_apply_zero_eq_one {ι : Type*} {s : Finset ι} {w : ι → ℝ}
-    {F : ι → N → ℂ} (hF0 : ∀ i ∈ s, F i 0 = 1) (hw_sum : ∑ i ∈ s, w i = 1) :
-    (fun x => ∑ i ∈ s, (w i : ℂ) * F i x) 0 = 1 :=
-  sum_real_const_mul_apply_eq_one (s := s) (w := w) (F := F) hF0 hw_sum
 
 end Origin
 

--- a/TauCeti/Analysis/PositiveDefinite/FunctionClosure.lean
+++ b/TauCeti/Analysis/PositiveDefinite/FunctionClosure.lean
@@ -4,7 +4,8 @@ Released under Apache 2.0 license as described in the file LICENSE.
 -/
 module
 
-public import TauCeti.Analysis.PositiveDefinite.Basic
+public import TauCeti.Analysis.PositiveDefinite.FunctionKernel
+public import TauCeti.Analysis.PositiveDefinite.KernelClosure
 
 /-!
 # Weighted closure for positive-definite functions
@@ -14,7 +15,7 @@ This file adds the weighted finite-mixture and Schur-power API for
 monoid. The basic file already proves binary sums, nonnegative complex scalar multiples, pointwise
 products, and unweighted finite sums/products. Here we package the forms used by examples and
 finite approximations: finite nonnegative weighted sums, real-weighted variants, and powers. The
-weighted sum API is available in scalar (`•`) notation and in multiplication notation.
+weighted sum API is available in scalar (`•`) notation.
 
 This advances `TauCetiRoadmap/OneParameterSemigroups/README.md`, Part C, the positive-definite
 functions API asking for closure under sums and products before the Bochner and BCR representation
@@ -61,25 +62,11 @@ theorem sum_smul {ι : Type*} {s : Finset ι} {w : ι → ℂ} {F : ι → M →
   sum fun i hi => by
     simpa [Algebra.smul_def] using (hF i hi).const_mul (hw i hi)
 
-/-- Finite nonnegative complex-weighted sums, written using multiplication rather than scalar
-notation. -/
-theorem sum_const_mul {ι : Type*} {s : Finset ι} {w : ι → ℂ} {F : ι → M → ℂ}
-    (hw : ∀ i ∈ s, 0 ≤ w i) (hF : ∀ i ∈ s, IsPositiveDefinite (F i)) :
-    IsPositiveDefinite (fun x => ∑ i ∈ s, w i * F i x) := by
-  simpa [Algebra.smul_def] using sum_smul (M := M) (s := s) (w := w) (F := F) hw hF
-
 /-- Finite nonnegative real-weighted sums of positive-definite functions are positive definite. -/
 theorem sum_real_smul {ι : Type*} {s : Finset ι} {w : ι → ℝ} {F : ι → M → ℂ}
     (hw : ∀ i ∈ s, 0 ≤ w i) (hF : ∀ i ∈ s, IsPositiveDefinite (F i)) :
     IsPositiveDefinite (fun x => ∑ i ∈ s, w i • F i x) :=
   sum fun i hi => (hF i hi).real_smul (hw i hi)
-
-/-- Finite nonnegative real-weighted sums, written with the real weight coerced to `ℂ` and
-multiplied in the codomain. -/
-theorem sum_real_const_mul {ι : Type*} {s : Finset ι} {w : ι → ℝ} {F : ι → M → ℂ}
-    (hw : ∀ i ∈ s, 0 ≤ w i) (hF : ∀ i ∈ s, IsPositiveDefinite (F i)) :
-    IsPositiveDefinite (fun x => ∑ i ∈ s, (w i : ℂ) * F i x) := by
-  simpa [Algebra.smul_def] using sum_real_smul (M := M) (s := s) (w := w) (F := F) hw hF
 
 /-- Schur powers of a positive-definite function are positive definite. -/
 theorem pow {F : M → ℂ} (hF : IsPositiveDefinite F) (n : ℕ) :
@@ -108,23 +95,6 @@ theorem sum_smul_apply_eq_one {ι : Type*} {s : Finset ι} {w : ι → ℂ}
   simpa using (sum_smul_apply_of_apply_eq_one (s := s) (w := w) (F := F) hFx).trans
     hw_sum
 
-/-- If each summand in a finite complex-weighted sum is normalized at a point, then the sum's
-multiplication-form value at that point is the sum of the weights. -/
-theorem sum_const_mul_apply_of_apply_eq_one {ι : Type*} {s : Finset ι} {w : ι → ℂ}
-    {F : ι → N → ℂ} {x : N} (hFx : ∀ i ∈ s, F i x = 1) :
-    (∑ i ∈ s, w i * F i x) = ∑ i ∈ s, w i := by
-  simpa [Algebra.smul_def] using
-    sum_smul_apply_of_apply_eq_one (s := s) (w := w) (F := F) hFx
-
-/-- A finite complex-weighted sum, in multiplication form, of functions normalized at a point is
-normalized at that point when the weights sum to `1`. -/
-theorem sum_const_mul_apply_eq_one {ι : Type*} {s : Finset ι} {w : ι → ℂ}
-    {F : ι → N → ℂ} {x : N} (hFx : ∀ i ∈ s, F i x = 1)
-    (hw_sum : ∑ i ∈ s, w i = 1) :
-    (fun y => ∑ i ∈ s, w i * F i y) x = 1 := by
-  simpa [Algebra.smul_def] using
-    sum_smul_apply_eq_one (s := s) (w := w) (F := F) hFx hw_sum
-
 /-- If each summand in a finite real-weighted sum is normalized at a point, then the sum's value at
 that point is the complex coercion of the sum of the real weights. -/
 theorem sum_real_smul_apply_of_apply_eq_one {ι : Type*} {s : Finset ι} {w : ι → ℝ}
@@ -141,23 +111,6 @@ theorem sum_real_smul_apply_eq_one {ι : Type*} {s : Finset ι} {w : ι → ℝ}
     (fun y => ∑ i ∈ s, w i • F i y) x = 1 := by
   simpa [hw_sum] using
     sum_real_smul_apply_of_apply_eq_one (s := s) (w := w) (F := F) hFx
-
-/-- If each summand in a finite real-weighted sum is normalized at a point, then the sum's
-multiplication-form value at that point is the complex coercion of the sum of the real weights. -/
-theorem sum_real_const_mul_apply_of_apply_eq_one {ι : Type*} {s : Finset ι}
-    {w : ι → ℝ} {F : ι → N → ℂ} {x : N} (hFx : ∀ i ∈ s, F i x = 1) :
-    (∑ i ∈ s, (w i : ℂ) * F i x) = ((∑ i ∈ s, w i : ℝ) : ℂ) := by
-  simpa [Algebra.smul_def] using
-    sum_real_smul_apply_of_apply_eq_one (s := s) (w := w) (F := F) hFx
-
-/-- A finite real-weighted sum, in multiplication form, of functions normalized at a point is
-normalized at that point when the weights sum to `1`. -/
-theorem sum_real_const_mul_apply_eq_one {ι : Type*} {s : Finset ι} {w : ι → ℝ}
-    {F : ι → N → ℂ} {x : N} (hFx : ∀ i ∈ s, F i x = 1)
-    (hw_sum : ∑ i ∈ s, w i = 1) :
-    (fun y => ∑ i ∈ s, (w i : ℂ) * F i y) x = 1 := by
-  simpa [hw_sum] using
-    sum_real_const_mul_apply_of_apply_eq_one (s := s) (w := w) (F := F) hFx
 
 section Origin
 
@@ -177,20 +130,6 @@ theorem sum_smul_apply_zero_eq_one {ι : Type*} {s : Finset ι} {w : ι → ℂ}
     (fun x => ∑ i ∈ s, w i • F i x) 0 = 1 :=
   sum_smul_apply_eq_one (s := s) (w := w) (F := F) hF0 hw_sum
 
-/-- If each summand in a finite complex-weighted sum is normalized at the origin, then the
-sum's multiplication-form value at the origin is the sum of the weights. -/
-theorem sum_const_mul_apply_zero_of_apply_zero_eq_one {ι : Type*} {s : Finset ι}
-    {w : ι → ℂ} {F : ι → N → ℂ} (hF0 : ∀ i ∈ s, F i 0 = 1) :
-    (∑ i ∈ s, w i * F i 0) = ∑ i ∈ s, w i :=
-  sum_const_mul_apply_of_apply_eq_one (s := s) (w := w) (F := F) hF0
-
-/-- A finite complex-weighted sum, in multiplication form, of functions normalized at the origin is
-normalized when the weights sum to `1`. -/
-theorem sum_const_mul_apply_zero_eq_one {ι : Type*} {s : Finset ι} {w : ι → ℂ}
-    {F : ι → N → ℂ} (hF0 : ∀ i ∈ s, F i 0 = 1) (hw_sum : ∑ i ∈ s, w i = 1) :
-    (fun x => ∑ i ∈ s, w i * F i x) 0 = 1 :=
-  sum_const_mul_apply_eq_one (s := s) (w := w) (F := F) hF0 hw_sum
-
 /-- If each summand in a finite real-weighted sum is normalized at the origin, then the sum's value
 at the origin is the complex coercion of the sum of the real weights. -/
 theorem sum_real_smul_apply_zero_of_apply_zero_eq_one {ι : Type*} {s : Finset ι}
@@ -204,20 +143,6 @@ theorem sum_real_smul_apply_zero_eq_one {ι : Type*} {s : Finset ι} {w : ι →
     {F : ι → N → ℂ} (hF0 : ∀ i ∈ s, F i 0 = 1) (hw_sum : ∑ i ∈ s, w i = 1) :
     (fun x => ∑ i ∈ s, w i • F i x) 0 = 1 :=
   sum_real_smul_apply_eq_one (s := s) (w := w) (F := F) hF0 hw_sum
-
-/-- If each summand in a finite real-weighted sum is normalized at the origin, then the sum's
-multiplication-form value at the origin is the complex coercion of the sum of the real weights. -/
-theorem sum_real_const_mul_apply_zero_of_apply_zero_eq_one {ι : Type*} {s : Finset ι}
-    {w : ι → ℝ} {F : ι → N → ℂ} (hF0 : ∀ i ∈ s, F i 0 = 1) :
-    (∑ i ∈ s, (w i : ℂ) * F i 0) = ((∑ i ∈ s, w i : ℝ) : ℂ) :=
-  sum_real_const_mul_apply_of_apply_eq_one (s := s) (w := w) (F := F) hF0
-
-/-- A finite real-weighted sum, in multiplication form, of functions normalized at the origin is
-normalized when the weights sum to `1`. -/
-theorem sum_real_const_mul_apply_zero_eq_one {ι : Type*} {s : Finset ι} {w : ι → ℝ}
-    {F : ι → N → ℂ} (hF0 : ∀ i ∈ s, F i 0 = 1) (hw_sum : ∑ i ∈ s, w i = 1) :
-    (fun x => ∑ i ∈ s, (w i : ℂ) * F i x) 0 = 1 :=
-  sum_real_const_mul_apply_eq_one (s := s) (w := w) (F := F) hF0 hw_sum
 
 end Origin
 

--- a/TauCeti/Analysis/PositiveDefinite/FunctionClosure.lean
+++ b/TauCeti/Analysis/PositiveDefinite/FunctionClosure.lean
@@ -70,8 +70,7 @@ theorem sum_real_smul {ι : Type*} {s : Finset ι} {w : ι → ℝ} {F : ι → 
     IsPositiveDefinite (fun x => ∑ i ∈ s, w i • F i x) :=
   sum fun i hi => (hF i hi).real_smul (hw i hi)
 
-/-- Schur powers of a positive-definite function are positive definite. This is the function-form
-image of `TauCeti.isPositiveDefiniteKernel_pow`. -/
+/-- Schur powers of a positive-definite function are positive definite. -/
 theorem pow {F : M → ℂ} (hF : IsPositiveDefinite F) (n : ℕ) :
     IsPositiveDefinite (fun x => F x ^ n) :=
   of_isPositiveDefiniteKernel (isPositiveDefiniteKernel_pow hF.isPositiveDefiniteKernel n)

--- a/TauCeti/Analysis/PositiveDefinite/FunctionKernel.lean
+++ b/TauCeti/Analysis/PositiveDefinite/FunctionKernel.lean
@@ -12,9 +12,8 @@ public import TauCeti.Analysis.PositiveDefinite.Kernel
 
 A positive-definite function `F : M → ℂ` on an involutive additive monoid and a positive-definite
 kernel `K : M → M → ℂ` are two views of the same data, linked by the assignment
-`K(a, b) = F(a + b⋆)`. This file packages the forward and reverse correspondence from
-`TauCeti.Analysis.PositiveDefinite.Basic` as an iff, and records the translation-invariant group
-specialization.
+`K(a, b) = F(a + b⋆)`. This file records the forward and reverse correspondence, packages them
+as an iff, and records the translation-invariant group specialization.
 
 Both predicates express nonnegativity of finite quadratic forms, with
 `IsPositiveDefiniteKernel` using Mathlib's `Matrix.PosSemidef` convention for the two-variable
@@ -59,6 +58,36 @@ open scoped ComplexOrder
 namespace TauCeti
 
 variable {M : Type*} [AddMonoid M] [StarAddMonoid M] {F : M → ℂ}
+
+namespace IsPositiveDefinite
+
+private theorem kernel_form_nonneg (hF : IsPositiveDefinite F) {ι : Type*} [Fintype ι]
+    (v : ι → M) (x : ι → ℂ) :
+    0 ≤ ∑ i, ∑ j, conj (x i) * x j * F (v i + star (v j)) := by
+  have h := hF.sum_nonneg (fun i => conj (x i)) v
+  refine le_of_le_of_eq h ?_
+  refine Finset.sum_congr rfl fun i _ => Finset.sum_congr rfl fun j _ => ?_
+  rw [Complex.conj_conj]
+
+/-- A positive-definite function `F` induces the positive-definite kernel `K(a, b) = F(a + b⋆)`.
+This is the forward half of the function ↔ kernel correspondence. -/
+theorem isPositiveDefiniteKernel (hF : IsPositiveDefinite F) :
+    IsPositiveDefiniteKernel (fun a b => F (a + star b)) :=
+  isPositiveDefiniteKernel_iff.mpr
+    ⟨fun a b => hF.conj_symm b a, fun {_ι : Type} _ v x => hF.kernel_form_nonneg v x⟩
+
+/-- If the kernel `K(a, b) = F(a + b⋆)` is positive definite, then so is the function `F`. This is
+the reverse half of the function ↔ kernel correspondence. -/
+theorem of_isPositiveDefiniteKernel
+    (hK : IsPositiveDefiniteKernel (fun a b => F (a + star b))) : IsPositiveDefinite F := by
+  obtain ⟨_, hpos⟩ := isPositiveDefiniteKernel_iff.mp hK
+  intro n c v
+  have h := hpos v (fun i => conj (c i))
+  refine le_of_le_of_eq h ?_
+  refine Finset.sum_congr rfl fun i _ => Finset.sum_congr rfl fun j _ => ?_
+  rw [Complex.conj_conj]
+
+end IsPositiveDefinite
 
 /-- A function `F` on an involutive additive monoid is positive definite if and only if the
 two-variable kernel `K(a, b) = F(a + b⋆)` is positive definite. -/

--- a/TauCeti/Analysis/PositiveDefinite/FunctionKernel.lean
+++ b/TauCeti/Analysis/PositiveDefinite/FunctionKernel.lean
@@ -5,19 +5,16 @@ Released under Apache 2.0 license as described in the file LICENSE.
 module
 
 public import TauCeti.Analysis.PositiveDefinite.Basic
+public import TauCeti.Analysis.PositiveDefinite.Kernel
 
 /-!
 # The positive-definite function ↔ positive-definite kernel correspondence
 
 A positive-definite function `F : M → ℂ` on an involutive additive monoid and a positive-definite
 kernel `K : M → M → ℂ` are two views of the same data, linked by the assignment
-`K(a, b) = F(a + b⋆)`. The two halves of this correspondence,
-`TauCeti.IsPositiveDefinite.isPositiveDefiniteKernel` and its converse
-`TauCeti.IsPositiveDefinite.of_isPositiveDefiniteKernel`, are proved in
-`TauCeti.Analysis.PositiveDefinite.Basic`, where the kernel form is taken as the primitive from
-which the function-form closure and boundedness API is derived. This file packages them as the
-equivalence: `F` is positive definite (`TauCeti.IsPositiveDefinite`, from
-`TauCeti.Analysis.PositiveDefinite.Basic`) **if and only if** the two-variable kernel
+`K(a, b) = F(a + b⋆)`. This file proves that `F` is positive definite
+(`TauCeti.IsPositiveDefinite`, from `TauCeti.Analysis.PositiveDefinite.Basic`) **if and only if**
+the two-variable kernel
 `fun a b => F (a + star b)` is positive definite (`TauCeti.IsPositiveDefiniteKernel`, from
 `TauCeti.Analysis.PositiveDefinite.Kernel`), and records the translation-invariant group
 specialization.
@@ -41,8 +38,12 @@ group form. No Mathlib code is vendored.
 
 ## Main declarations
 
+* `TauCeti.IsPositiveDefinite.isPositiveDefiniteKernel`: a positive-definite function gives the
+  positive-definite kernel `fun a b => F (a + star b)`.
+* `TauCeti.IsPositiveDefinite.of_isPositiveDefiniteKernel`: conversely, if the kernel
+  `fun a b => F (a + star b)` is positive definite then `F` is positive definite.
 * `TauCeti.isPositiveDefinite_iff_isPositiveDefiniteKernel`: the equivalence of the two predicates,
-  packaging the two halves proved in `TauCeti.Analysis.PositiveDefinite.Basic`.
+  packaging the two halves.
 * `TauCeti.IsPositiveDefinite.isPositiveDefiniteKernel_sub` and
   `TauCeti.isPositiveDefinite_iff_isPositiveDefiniteKernel_sub`: the subtraction form
   `K(a, b) = F(a - b)` under the negation involution `star a = -a`.
@@ -59,6 +60,42 @@ open ComplexConjugate
 open scoped ComplexOrder
 
 namespace TauCeti
+
+namespace IsPositiveDefinite
+
+variable {M : Type*} [AddMonoid M] [StarAddMonoid M] {F : M → ℂ}
+
+/-- The Hermitian form of the kernel `K(a, b) = F(a + b⋆)` with coefficients `x` over a finite
+family is `F`'s defining form with coefficients `conj x`, hence nonnegative. This is stated as its
+own (universe-polymorphic in the index `ι`) lemma so that it can be fed to
+`TauCeti.isPositiveDefiniteKernel_iff`. -/
+private theorem kernel_form_nonneg (hF : IsPositiveDefinite F) {ι : Type*} [Fintype ι]
+    (v : ι → M) (x : ι → ℂ) :
+    0 ≤ ∑ i, ∑ j, conj (x i) * x j * F (v i + star (v j)) := by
+  have h := hF.sum_nonneg (fun i => conj (x i)) v
+  refine le_of_le_of_eq h ?_
+  refine Finset.sum_congr rfl fun i _ => Finset.sum_congr rfl fun j _ => ?_
+  rw [Complex.conj_conj]
+
+/-- A positive-definite function `F` induces the positive-definite kernel `K(a, b) = F(a + b⋆)`.
+This is the forward half of the function ↔ kernel correspondence. -/
+theorem isPositiveDefiniteKernel (hF : IsPositiveDefinite F) :
+    IsPositiveDefiniteKernel (fun a b => F (a + star b)) :=
+  isPositiveDefiniteKernel_iff.mpr
+    ⟨fun a b => hF.conj_symm b a, fun {_ι : Type} _ v x => hF.kernel_form_nonneg v x⟩
+
+/-- If the kernel `K(a, b) = F(a + b⋆)` is positive definite, then so is the function `F`. This is
+the reverse half of the function ↔ kernel correspondence. -/
+theorem of_isPositiveDefiniteKernel
+    (hK : IsPositiveDefiniteKernel (fun a b => F (a + star b))) : IsPositiveDefinite F := by
+  obtain ⟨_, hpos⟩ := isPositiveDefiniteKernel_iff.mp hK
+  intro n c v
+  have h := hpos v (fun i => conj (c i))
+  refine le_of_le_of_eq h ?_
+  refine Finset.sum_congr rfl fun i _ => Finset.sum_congr rfl fun j _ => ?_
+  rw [Complex.conj_conj]
+
+end IsPositiveDefinite
 
 variable {M : Type*} [AddMonoid M] [StarAddMonoid M] {F : M → ℂ}
 

--- a/TauCeti/Analysis/PositiveDefinite/FunctionKernel.lean
+++ b/TauCeti/Analysis/PositiveDefinite/FunctionKernel.lean
@@ -12,11 +12,8 @@ public import TauCeti.Analysis.PositiveDefinite.Kernel
 
 A positive-definite function `F : M → ℂ` on an involutive additive monoid and a positive-definite
 kernel `K : M → M → ℂ` are two views of the same data, linked by the assignment
-`K(a, b) = F(a + b⋆)`. This file proves that `F` is positive definite
-(`TauCeti.IsPositiveDefinite`, from `TauCeti.Analysis.PositiveDefinite.Basic`) **if and only if**
-the two-variable kernel
-`fun a b => F (a + star b)` is positive definite (`TauCeti.IsPositiveDefiniteKernel`, from
-`TauCeti.Analysis.PositiveDefinite.Kernel`), and records the translation-invariant group
+`K(a, b) = F(a + b⋆)`. This file packages the forward and reverse correspondence from
+`TauCeti.Analysis.PositiveDefinite.Basic` as an iff, and records the translation-invariant group
 specialization.
 
 Both predicates express nonnegativity of finite quadratic forms, with
@@ -60,42 +57,6 @@ open ComplexConjugate
 open scoped ComplexOrder
 
 namespace TauCeti
-
-namespace IsPositiveDefinite
-
-variable {M : Type*} [AddMonoid M] [StarAddMonoid M] {F : M → ℂ}
-
-/-- The Hermitian form of the kernel `K(a, b) = F(a + b⋆)` with coefficients `x` over a finite
-family is `F`'s defining form with coefficients `conj x`, hence nonnegative. This is stated as its
-own (universe-polymorphic in the index `ι`) lemma so that it can be fed to
-`TauCeti.isPositiveDefiniteKernel_iff`. -/
-private theorem kernel_form_nonneg (hF : IsPositiveDefinite F) {ι : Type*} [Fintype ι]
-    (v : ι → M) (x : ι → ℂ) :
-    0 ≤ ∑ i, ∑ j, conj (x i) * x j * F (v i + star (v j)) := by
-  have h := hF.sum_nonneg (fun i => conj (x i)) v
-  refine le_of_le_of_eq h ?_
-  refine Finset.sum_congr rfl fun i _ => Finset.sum_congr rfl fun j _ => ?_
-  rw [Complex.conj_conj]
-
-/-- A positive-definite function `F` induces the positive-definite kernel `K(a, b) = F(a + b⋆)`.
-This is the forward half of the function ↔ kernel correspondence. -/
-theorem isPositiveDefiniteKernel (hF : IsPositiveDefinite F) :
-    IsPositiveDefiniteKernel (fun a b => F (a + star b)) :=
-  isPositiveDefiniteKernel_iff.mpr
-    ⟨fun a b => hF.conj_symm b a, fun {_ι : Type} _ v x => hF.kernel_form_nonneg v x⟩
-
-/-- If the kernel `K(a, b) = F(a + b⋆)` is positive definite, then so is the function `F`. This is
-the reverse half of the function ↔ kernel correspondence. -/
-theorem of_isPositiveDefiniteKernel
-    (hK : IsPositiveDefiniteKernel (fun a b => F (a + star b))) : IsPositiveDefinite F := by
-  obtain ⟨_, hpos⟩ := isPositiveDefiniteKernel_iff.mp hK
-  intro n c v
-  have h := hpos v (fun i => conj (c i))
-  refine le_of_le_of_eq h ?_
-  refine Finset.sum_congr rfl fun i _ => Finset.sum_congr rfl fun j _ => ?_
-  rw [Complex.conj_conj]
-
-end IsPositiveDefinite
 
 variable {M : Type*} [AddMonoid M] [StarAddMonoid M] {F : M → ℂ}
 

--- a/TauCeti/Analysis/PositiveDefinite/FunctionKernel.lean
+++ b/TauCeti/Analysis/PositiveDefinite/FunctionKernel.lean
@@ -34,10 +34,6 @@ group form. No Mathlib code is vendored.
 
 ## Main declarations
 
-* `TauCeti.IsPositiveDefinite.isPositiveDefiniteKernel`: a positive-definite function gives the
-  positive-definite kernel `fun a b => F (a + star b)`.
-* `TauCeti.IsPositiveDefinite.of_isPositiveDefiniteKernel`: conversely, if the kernel
-  `fun a b => F (a + star b)` is positive definite then `F` is positive definite.
 * `TauCeti.isPositiveDefinite_iff_isPositiveDefiniteKernel`: the equivalence of the two predicates,
   packaging the two halves.
 * `TauCeti.IsPositiveDefinite.isPositiveDefiniteKernel_sub` and
@@ -58,36 +54,6 @@ open scoped ComplexOrder
 namespace TauCeti
 
 variable {M : Type*} [AddMonoid M] [StarAddMonoid M] {F : M → ℂ}
-
-namespace IsPositiveDefinite
-
-private theorem kernel_form_nonneg (hF : IsPositiveDefinite F) {ι : Type*} [Fintype ι]
-    (v : ι → M) (x : ι → ℂ) :
-    0 ≤ ∑ i, ∑ j, conj (x i) * x j * F (v i + star (v j)) := by
-  have h := hF.sum_nonneg (fun i => conj (x i)) v
-  refine le_of_le_of_eq h ?_
-  refine Finset.sum_congr rfl fun i _ => Finset.sum_congr rfl fun j _ => ?_
-  rw [Complex.conj_conj]
-
-/-- A positive-definite function `F` induces the positive-definite kernel `K(a, b) = F(a + b⋆)`.
-This is the forward half of the function ↔ kernel correspondence. -/
-theorem isPositiveDefiniteKernel (hF : IsPositiveDefinite F) :
-    IsPositiveDefiniteKernel (fun a b => F (a + star b)) :=
-  isPositiveDefiniteKernel_iff.mpr
-    ⟨fun a b => hF.conj_symm b a, fun {_ι : Type} _ v x => hF.kernel_form_nonneg v x⟩
-
-/-- If the kernel `K(a, b) = F(a + b⋆)` is positive definite, then so is the function `F`. This is
-the reverse half of the function ↔ kernel correspondence. -/
-theorem of_isPositiveDefiniteKernel
-    (hK : IsPositiveDefiniteKernel (fun a b => F (a + star b))) : IsPositiveDefinite F := by
-  obtain ⟨_, hpos⟩ := isPositiveDefiniteKernel_iff.mp hK
-  intro n c v
-  have h := hpos v (fun i => conj (c i))
-  refine le_of_le_of_eq h ?_
-  refine Finset.sum_congr rfl fun i _ => Finset.sum_congr rfl fun j _ => ?_
-  rw [Complex.conj_conj]
-
-end IsPositiveDefinite
 
 /-- A function `F` on an involutive additive monoid is positive definite if and only if the
 two-variable kernel `K(a, b) = F(a + b⋆)` is positive definite. -/

--- a/TauCeti/Analysis/PositiveDefinite/FunctionKernel.lean
+++ b/TauCeti/Analysis/PositiveDefinite/FunctionKernel.lean
@@ -12,10 +12,16 @@ public import TauCeti.Analysis.PositiveDefinite.Kernel
 
 A positive-definite function `F : M → ℂ` on an involutive additive monoid and a positive-definite
 kernel `K : M → M → ℂ` are two views of the same data, linked by the assignment
-`K(a, b) = F(a + b⋆)`. This file proves that `F` is positive definite (`TauCeti.IsPositiveDefinite`,
-from `TauCeti.Analysis.PositiveDefinite.Basic`) **if and only if** the two-variable kernel
+`K(a, b) = F(a + b⋆)`. The two halves of this correspondence,
+`TauCeti.IsPositiveDefinite.isPositiveDefiniteKernel` and its converse
+`TauCeti.IsPositiveDefinite.of_isPositiveDefiniteKernel`, are proved in
+`TauCeti.Analysis.PositiveDefinite.Basic`, where the kernel form is taken as the primitive from
+which the function-form closure and boundedness API is derived. This file packages them as the
+equivalence: `F` is positive definite (`TauCeti.IsPositiveDefinite`, from
+`TauCeti.Analysis.PositiveDefinite.Basic`) **if and only if** the two-variable kernel
 `fun a b => F (a + star b)` is positive definite (`TauCeti.IsPositiveDefiniteKernel`, from
-`TauCeti.Analysis.PositiveDefinite.Kernel`).
+`TauCeti.Analysis.PositiveDefinite.Kernel`), and records the translation-invariant group
+specialization.
 
 Both predicates express nonnegativity of finite quadratic forms, with
 `IsPositiveDefiniteKernel` using Mathlib's `Matrix.PosSemidef` convention for the two-variable
@@ -36,11 +42,8 @@ group form. No Mathlib code is vendored.
 
 ## Main declarations
 
-* `TauCeti.IsPositiveDefinite.isPositiveDefiniteKernel`: a positive-definite function gives the
-  positive-definite kernel `fun a b => F (a + star b)`.
-* `TauCeti.IsPositiveDefinite.of_isPositiveDefiniteKernel`: conversely, if the kernel
-  `fun a b => F (a + star b)` is positive definite then `F` is positive definite.
-* `TauCeti.isPositiveDefinite_iff_isPositiveDefiniteKernel`: the equivalence of the two predicates.
+* `TauCeti.isPositiveDefinite_iff_isPositiveDefiniteKernel`: the equivalence of the two predicates,
+  packaging the two halves proved in `TauCeti.Analysis.PositiveDefinite.Basic`.
 * `TauCeti.IsPositiveDefinite.isPositiveDefiniteKernel_sub` and
   `TauCeti.isPositiveDefinite_iff_isPositiveDefiniteKernel_sub`: the subtraction form
   `K(a, b) = F(a - b)` under the negation involution `star a = -a`.
@@ -57,42 +60,6 @@ open ComplexConjugate
 open scoped ComplexOrder
 
 namespace TauCeti
-
-namespace IsPositiveDefinite
-
-variable {M : Type*} [AddMonoid M] [StarAddMonoid M] {F : M → ℂ}
-
-/-- The Hermitian form of the kernel `K(a, b) = F(a + b⋆)` with coefficients `x` over a finite
-family is `F`'s defining form with coefficients `conj x`, hence nonnegative. This is stated as its
-own (universe-polymorphic in the index `ι`) lemma so that it can be fed to
-`TauCeti.isPositiveDefiniteKernel_iff`. -/
-private theorem kernel_form_nonneg (hF : IsPositiveDefinite F) {ι : Type*} [Fintype ι]
-    (v : ι → M) (x : ι → ℂ) :
-    0 ≤ ∑ i, ∑ j, conj (x i) * x j * F (v i + star (v j)) := by
-  have h := hF.sum_nonneg (fun i => conj (x i)) v
-  refine le_of_le_of_eq h ?_
-  refine Finset.sum_congr rfl fun i _ => Finset.sum_congr rfl fun j _ => ?_
-  rw [Complex.conj_conj]
-
-/-- A positive-definite function `F` induces the positive-definite kernel `K(a, b) = F(a + b⋆)`.
-This is the forward half of the function ↔ kernel correspondence. -/
-theorem isPositiveDefiniteKernel (hF : IsPositiveDefinite F) :
-    IsPositiveDefiniteKernel (fun a b => F (a + star b)) :=
-  isPositiveDefiniteKernel_iff.mpr
-    ⟨fun a b => hF.conj_symm b a, fun {_ι : Type} _ v x => hF.kernel_form_nonneg v x⟩
-
-/-- If the kernel `K(a, b) = F(a + b⋆)` is positive definite, then so is the function `F`. This is
-the reverse half of the function ↔ kernel correspondence. -/
-theorem of_isPositiveDefiniteKernel
-    (hK : IsPositiveDefiniteKernel (fun a b => F (a + star b))) : IsPositiveDefinite F := by
-  obtain ⟨_, hpos⟩ := isPositiveDefiniteKernel_iff.mp hK
-  intro n c v
-  have h := hpos v (fun i => conj (c i))
-  refine le_of_le_of_eq h ?_
-  refine Finset.sum_congr rfl fun i _ => Finset.sum_congr rfl fun j _ => ?_
-  rw [Complex.conj_conj]
-
-end IsPositiveDefinite
 
 variable {M : Type*} [AddMonoid M] [StarAddMonoid M] {F : M → ℂ}
 

--- a/TauCeti/Analysis/PositiveDefinite/FunctionKernel.lean
+++ b/TauCeti/Analysis/PositiveDefinite/FunctionKernel.lean
@@ -5,7 +5,6 @@ Released under Apache 2.0 license as described in the file LICENSE.
 module
 
 public import TauCeti.Analysis.PositiveDefinite.Basic
-public import TauCeti.Analysis.PositiveDefinite.Kernel
 
 /-!
 # The positive-definite function ↔ positive-definite kernel correspondence


### PR DESCRIPTION
This PR makes the positive-definite-kernel form the single primitive of the `TauCeti.Analysis.PositiveDefinite` cluster and derives the function-form API through the function ↔ kernel correspondence `K(a, b) = F(a + b⋆)`, deleting the independently-proved duplicates. The two halves of the correspondence (`IsPositiveDefinite.isPositiveDefiniteKernel` and `of_isPositiveDefiniteKernel`) move into `Basic.lean`, and `normSq_le`, `gram_posSemidef`, `add`, `const_mul`, `mul`, `sum`, `prod`, `isPositiveDefinite_const`, and `FunctionClosure`'s `pow` are re-expressed as one-line transports of the corresponding kernel statements (`isPositiveDefiniteKernel_normSq_le`, `_comp`, `_add`, `_smul_of_nonneg`, `_mul`, `_sum`, `_prod`, `_const_of_nonneg`, `_pow`) instead of separate `Finset.sum_induction` / discriminant / Gram–Hadamard arguments. `FunctionKernel.lean` keeps the packaged `isPositiveDefinite_iff_isPositiveDefiniteKernel` equivalence and the translation-invariant group form. While in `FunctionClosure.lean` this also drops the multiplication-notation restatements (`sum_const_mul`, `sum_real_const_mul`, and their `_apply` value variants, all with no consumers) in favour of the canonical `•`-notation lemmas, since `k • z = k * z` in `ℂ`. All public names are preserved, so downstream files are unaffected; net change is roughly -119 lines.

Per `AGENTS.md`, improving code that already exists is always in scope (refactoring, simplifying proofs, relocating misplaced declarations, adopting a cleaner idiom); this PR adds no new mathematical scope. Part of https://github.com/TauCetiProject/TauCeti/issues/795.

Build evidence: `lake exe cache get` decompressed the warm cache with no downloads; `lake build` completed successfully (4619 jobs, whole library green); `lake exe axioms` reports "audited 8805 TauCeti declaration(s); all within the allowlist [propext, Classical.choice, Quot.sound]".

🤖 Prepared with Claude Code