### PR TITLE
feat(Analysis/Contour): index integral as a sum of segment log increments

### DIFF
--- a/TauCeti/Analysis/Contour/WindingSegmentSum.lean
+++ b/TauCeti/Analysis/Contour/WindingSegmentSum.lean
@@ -1,0 +1,74 @@
+module
+
+public import Mathlib.Analysis.Calculus.Deriv.Basic
+public import Mathlib.Analysis.SpecialFunctions.Complex.Log
+public import Mathlib.MeasureTheory.Integral.IntervalIntegral.Basic
+import TauCeti.Analysis.Contour.LogDerivFTC
+
+/-!
+# The index integral as a sum of segment logarithm increments
+
+Given a monotone partition `a = s 0 ≤ ⋯ ≤ s N = b` fine enough that on each segment the normalized
+ratio `(γ t - w) / (γ (s j) - w)` stays in `Complex.slitPlane`, the index integral splits into a sum
+of per-segment logarithm increments:
+
+`∫ t in a..b, (γ t - w)⁻¹ * deriv γ t = ∑ j < N, Complex.log ((γ (s (j+1)) - w) / (γ (s j) - w))`.
+
+The proof splits the integral over the partition with `sum_integral_adjacent_intervals` and
+evaluates each segment with the per-segment logarithmic-derivative FTC
+`integral_inv_sub_mul_deriv_eq_log`; the slit-plane hypothesis on each segment is exactly what the
+argument-lift partition supplies. This is the first half of showing the winding number of a closed
+curve is an integer: for a closed curve the real parts of these increments telescope away and the
+imaginary parts sum to the total argument change.
+
+## Provenance
+
+Adapted from `contourIntegral_inv_eq_sum_log_segRatio` in `WindingArgDiff.lean` of the AINTLIB
+`LeanModularForms` development.
+-/
+
+public section
+
+open Complex MeasureTheory Set intervalIntegral
+
+open scoped Interval
+
+namespace TauCeti.Contour
+
+/-- **Index integral as a sum of segment logarithm increments.** For a monotone partition
+`a = s 0 ≤ ⋯ ≤ s N = b` of `[a, b]` with `γ` continuous there, differentiable off a countable set
+`P`, avoiding `w` at each node, and with the normalized segment ratio `(γ t - w) / (γ (s j) - w)` in
+`Complex.slitPlane` on each `[s j, s (j+1)]`, the index integral of `(γ t - w)⁻¹ * deriv γ t` equals
+the sum of the per-segment `Complex.log` increments. -/
+theorem integral_inv_sub_mul_deriv_eq_sum_log {γ : ℝ → ℂ} {w : ℂ} {a b : ℝ} {P : Set ℝ}
+    {N : ℕ} {s : ℕ → ℝ} (hP : P.Countable)
+    (hs_zero : s 0 = a) (hs_N : s N = b) (hs_mono : Monotone s)
+    (hs_in : ∀ j ≤ N, s j ∈ Icc a b) (hγ_cont : ContinuousOn γ (Icc a b))
+    (hγ_diff : ∀ t ∈ Ioo a b \ P, DifferentiableAt ℝ γ t)
+    (h_slit : ∀ j, j < N → ∀ t ∈ Icc (s j) (s (j + 1)),
+      (γ t - w) / (γ (s j) - w) ∈ slitPlane)
+    (h_int : IntervalIntegrable (fun t ↦ (γ t - w)⁻¹ * deriv γ t) volume a b) :
+    ∫ t in a..b, (γ t - w)⁻¹ * deriv γ t
+      = ∑ j ∈ Finset.range N, Complex.log ((γ (s (j + 1)) - w) / (γ (s j) - w)) := by
+  have hab : a ≤ b := by have := hs_mono (Nat.zero_le N); rwa [hs_zero, hs_N] at this
+  have hmono_seg : ∀ j, s j ≤ s (j + 1) := fun j ↦ hs_mono (Nat.le_succ j)
+  have h_int_seg : ∀ k < N,
+      IntervalIntegrable (fun t ↦ (γ t - w)⁻¹ * deriv γ t) volume (s k) (s (k + 1)) := by
+    intro k hk
+    refine h_int.mono_set ?_
+    rw [uIcc_of_le (hmono_seg k), uIcc_of_le hab]
+    exact Icc_subset_Icc (hs_in k hk.le).1 (hs_in (k + 1) hk).2
+  rw [← hs_zero, ← hs_N, ← sum_integral_adjacent_intervals h_int_seg]
+  refine Finset.sum_congr rfl fun j hj ↦ ?_
+  rw [Finset.mem_range] at hj
+  refine integral_inv_sub_mul_deriv_eq_log hP ?_ ?_ ?_ (h_int_seg j hj)
+  · rw [uIcc_of_le (hmono_seg j)]
+    exact hγ_cont.mono (Icc_subset_Icc (hs_in j hj.le).1 (hs_in (j + 1) hj).2)
+  · intro t ht
+    rw [min_eq_left (hmono_seg j), max_eq_right (hmono_seg j)] at ht
+    refine hγ_diff t ⟨⟨(hs_in j hj.le).1.trans_lt ht.1.1, ?_⟩, ht.2⟩
+    exact ht.1.2.trans_le (hs_in (j + 1) hj).2
+  · rw [uIcc_of_le (hmono_seg j)]
+    exact h_slit j hj
+
+end TauCeti.Contour

--- a/TauCeti/Analysis/Contour/WindingSegmentSum.lean
+++ b/TauCeti/Analysis/Contour/WindingSegmentSum.lean
@@ -9,21 +9,29 @@ import TauCeti.Analysis.Contour.LogDerivFTC
 # The index integral as a sum of segment logarithm increments
 
 Given a monotone partition `a = s 0 ≤ ⋯ ≤ s N = b` fine enough that on each segment the normalized
-ratio `(γ t - w) / (γ (s j) - w)` stays in `Complex.slitPlane`, the index integral splits into a sum
-of per-segment logarithm increments:
+ratio `(γ t - w) / (γ (s j) - w)` stays in `Complex.slitPlane`, the logarithmic-derivative integral
+splits into a sum of per-segment logarithm increments:
 
-`∫ t in a..b, (γ t - w)⁻¹ * deriv γ t = ∑ j < N, Complex.log ((γ (s (j+1)) - w) / (γ (s j) - w))`.
+`∫ t in a..b, γ' t / (γ t - w) = ∑ j < N, Complex.log ((γ (s (j+1)) - w) / (γ (s j) - w))`.
 
-The per-segment slit-plane hypothesis is exactly the data the continuous argument-lift partition
-supplies, so this evaluation bridges that partition to the winding-number computation. It is the
-first half of showing the winding number of a closed curve is an integer: for a closed curve the
-real parts of these increments telescope away and the imaginary parts sum to the total argument
-change.
+Specializing `γ' = deriv γ` and rewriting `γ' t / (γ t - w)` as the winding integrand
+`(γ t - w)⁻¹ * deriv γ t` gives the form consumed by the winding-number computation. The per-segment
+slit-plane hypothesis is exactly the data the continuous argument-lift partition supplies, so this
+evaluation bridges that partition to the winding-number computation: it is the first half of showing
+the winding number of a closed curve is an integer, since for a closed curve the real parts of these
+increments telescope away and the imaginary parts sum to the total argument change.
+
+## Main results
+
+* `TauCeti.Contour.integral_deriv_div_sub_eq_sum_log` — the partition sum in general
+  `γ' t / (γ t - w)` form with an explicit derivative witness.
+* `TauCeti.Contour.integral_inv_sub_mul_deriv_eq_sum_log` — its `deriv γ` specialization with the
+  winding integrand `(γ t - w)⁻¹ * deriv γ t`.
 
 ## Provenance
 
 Adapted from `contourIntegral_inv_eq_sum_log_segRatio` in `WindingArgDiff.lean` of the AINTLIB
-`LeanModularForms` development.
+`LeanModularForms` development, restated for a raw `γ : ℝ → ℂ` on `[a, b]`.
 -/
 
 public section
@@ -35,10 +43,46 @@ open scoped Interval
 namespace TauCeti.Contour
 
 /-- **Index integral as a sum of segment logarithm increments.** For a monotone partition
-`a = s 0 ≤ ⋯ ≤ s N = b` of `[a, b]` with `γ` continuous there, differentiable off a countable set
-`P`, and with the normalized segment ratio `(γ t - w) / (γ (s j) - w)` in `Complex.slitPlane` on
-each `[s j, s (j+1)]`, the index integral of `(γ t - w)⁻¹ * deriv γ t` equals the sum of the
-per-segment `Complex.log` increments. -/
+`a = s 0 ≤ ⋯ ≤ s N = b` of `[a, b]` with `γ` continuous there, differentiable with derivative `γ'`
+off a countable set `P`, and with the normalized segment ratio `(γ t - w) / (γ (s j) - w)` in
+`Complex.slitPlane` on each `[s j, s (j+1)]`, the integral of `γ' t / (γ t - w)` equals the sum of
+the per-segment `Complex.log` increments. -/
+theorem integral_deriv_div_sub_eq_sum_log {γ γ' : ℝ → ℂ} {w : ℂ} {a b : ℝ} {P : Set ℝ}
+    {N : ℕ} {s : ℕ → ℝ} (hP : P.Countable)
+    (hs_zero : s 0 = a) (hs_N : s N = b) (hs_mono : Monotone s)
+    (hγ_cont : ContinuousOn γ (Icc a b))
+    (hγ_diff : ∀ t ∈ Ioo a b \ P, HasDerivAt γ (γ' t) t)
+    (h_slit : ∀ j, j < N → ∀ t ∈ Icc (s j) (s (j + 1)),
+      (γ t - w) / (γ (s j) - w) ∈ slitPlane)
+    (h_int : IntervalIntegrable (fun t ↦ γ' t / (γ t - w)) volume a b) :
+    ∫ t in a..b, γ' t / (γ t - w)
+      = ∑ j ∈ Finset.range N, Complex.log ((γ (s (j + 1)) - w) / (γ (s j) - w)) := by
+  have hab : a ≤ b := by have := hs_mono (Nat.zero_le N); rwa [hs_zero, hs_N] at this
+  have hs_in : ∀ j ≤ N, s j ∈ Icc a b := fun j hj ↦
+    ⟨by rw [← hs_zero]; exact hs_mono (Nat.zero_le j), by rw [← hs_N]; exact hs_mono hj⟩
+  have hmono_seg : ∀ j, s j ≤ s (j + 1) := fun j ↦ hs_mono (Nat.le_succ j)
+  have h_int_seg : ∀ k < N,
+      IntervalIntegrable (fun t ↦ γ' t / (γ t - w)) volume (s k) (s (k + 1)) := by
+    intro k hk
+    refine h_int.mono_set ?_
+    rw [uIcc_of_le (hmono_seg k), uIcc_of_le hab]
+    exact Icc_subset_Icc (hs_in k hk.le).1 (hs_in (k + 1) hk).2
+  rw [← hs_zero, ← hs_N, ← sum_integral_adjacent_intervals h_int_seg]
+  refine Finset.sum_congr rfl fun j hj ↦ ?_
+  rw [Finset.mem_range] at hj
+  refine integral_deriv_div_sub_eq_log hP ?_ ?_ ?_ (h_int_seg j hj)
+  · rw [uIcc_of_le (hmono_seg j)]
+    exact hγ_cont.mono (Icc_subset_Icc (hs_in j hj.le).1 (hs_in (j + 1) hj).2)
+  · intro t ht
+    rw [min_eq_left (hmono_seg j), max_eq_right (hmono_seg j)] at ht
+    refine hγ_diff t ⟨⟨(hs_in j hj.le).1.trans_lt ht.1.1, ?_⟩, ht.2⟩
+    exact ht.1.2.trans_le (hs_in (j + 1) hj).2
+  · rw [uIcc_of_le (hmono_seg j)]
+    exact h_slit j hj
+
+/-- **Winding-integrand form.** The `γ' = deriv γ` specialization of
+`integral_deriv_div_sub_eq_sum_log` with the winding integrand `(γ t - w)⁻¹ * deriv γ t`, as
+consumed by the winding-number computation. -/
 theorem integral_inv_sub_mul_deriv_eq_sum_log {γ : ℝ → ℂ} {w : ℂ} {a b : ℝ} {P : Set ℝ}
     {N : ℕ} {s : ℕ → ℝ} (hP : P.Countable)
     (hs_zero : s 0 = a) (hs_N : s N = b) (hs_mono : Monotone s)
@@ -49,27 +93,10 @@ theorem integral_inv_sub_mul_deriv_eq_sum_log {γ : ℝ → ℂ} {w : ℂ} {a b 
     (h_int : IntervalIntegrable (fun t ↦ (γ t - w)⁻¹ * deriv γ t) volume a b) :
     ∫ t in a..b, (γ t - w)⁻¹ * deriv γ t
       = ∑ j ∈ Finset.range N, Complex.log ((γ (s (j + 1)) - w) / (γ (s j) - w)) := by
-  have hab : a ≤ b := by have := hs_mono (Nat.zero_le N); rwa [hs_zero, hs_N] at this
-  have hs_in : ∀ j ≤ N, s j ∈ Icc a b := fun j hj ↦
-    ⟨by rw [← hs_zero]; exact hs_mono (Nat.zero_le j), by rw [← hs_N]; exact hs_mono hj⟩
-  have hmono_seg : ∀ j, s j ≤ s (j + 1) := fun j ↦ hs_mono (Nat.le_succ j)
-  have h_int_seg : ∀ k < N,
-      IntervalIntegrable (fun t ↦ (γ t - w)⁻¹ * deriv γ t) volume (s k) (s (k + 1)) := by
-    intro k hk
-    refine h_int.mono_set ?_
-    rw [uIcc_of_le (hmono_seg k), uIcc_of_le hab]
-    exact Icc_subset_Icc (hs_in k hk.le).1 (hs_in (k + 1) hk).2
-  rw [← hs_zero, ← hs_N, ← sum_integral_adjacent_intervals h_int_seg]
-  refine Finset.sum_congr rfl fun j hj ↦ ?_
-  rw [Finset.mem_range] at hj
-  refine integral_inv_sub_mul_deriv_eq_log hP ?_ ?_ ?_ (h_int_seg j hj)
-  · rw [uIcc_of_le (hmono_seg j)]
-    exact hγ_cont.mono (Icc_subset_Icc (hs_in j hj.le).1 (hs_in (j + 1) hj).2)
-  · intro t ht
-    rw [min_eq_left (hmono_seg j), max_eq_right (hmono_seg j)] at ht
-    refine hγ_diff t ⟨⟨(hs_in j hj.le).1.trans_lt ht.1.1, ?_⟩, ht.2⟩
-    exact ht.1.2.trans_le (hs_in (j + 1) hj).2
-  · rw [uIcc_of_le (hmono_seg j)]
-    exact h_slit j hj
+  have hfun : (fun t ↦ (γ t - w)⁻¹ * deriv γ t) = fun t ↦ deriv γ t / (γ t - w) := by
+    funext t; rw [div_eq_mul_inv, mul_comm]
+  rw [hfun]
+  exact integral_deriv_div_sub_eq_sum_log (γ' := deriv γ) hP hs_zero hs_N hs_mono hγ_cont
+    (fun t ht ↦ (hγ_diff t ht).hasDerivAt) h_slit (hfun ▸ h_int)
 
 end TauCeti.Contour

--- a/TauCeti/Analysis/Contour/WindingSegmentSum.lean
+++ b/TauCeti/Analysis/Contour/WindingSegmentSum.lean
@@ -14,12 +14,11 @@ of per-segment logarithm increments:
 
 `∫ t in a..b, (γ t - w)⁻¹ * deriv γ t = ∑ j < N, Complex.log ((γ (s (j+1)) - w) / (γ (s j) - w))`.
 
-The proof splits the integral over the partition with `sum_integral_adjacent_intervals` and
-evaluates each segment with the per-segment logarithmic-derivative FTC
-`integral_inv_sub_mul_deriv_eq_log`; the slit-plane hypothesis on each segment is exactly what the
-argument-lift partition supplies. This is the first half of showing the winding number of a closed
-curve is an integer: for a closed curve the real parts of these increments telescope away and the
-imaginary parts sum to the total argument change.
+The per-segment slit-plane hypothesis is exactly the data the continuous argument-lift partition
+supplies, so this evaluation bridges that partition to the winding-number computation. It is the
+first half of showing the winding number of a closed curve is an integer: for a closed curve the
+real parts of these increments telescope away and the imaginary parts sum to the total argument
+change.
 
 ## Provenance
 

--- a/TauCeti/Analysis/Contour/WindingSegmentSum.lean
+++ b/TauCeti/Analysis/Contour/WindingSegmentSum.lean
@@ -37,13 +37,13 @@ namespace TauCeti.Contour
 
 /-- **Index integral as a sum of segment logarithm increments.** For a monotone partition
 `a = s 0 ≤ ⋯ ≤ s N = b` of `[a, b]` with `γ` continuous there, differentiable off a countable set
-`P`, avoiding `w` at each node, and with the normalized segment ratio `(γ t - w) / (γ (s j) - w)` in
-`Complex.slitPlane` on each `[s j, s (j+1)]`, the index integral of `(γ t - w)⁻¹ * deriv γ t` equals
-the sum of the per-segment `Complex.log` increments. -/
+`P`, and with the normalized segment ratio `(γ t - w) / (γ (s j) - w)` in `Complex.slitPlane` on
+each `[s j, s (j+1)]`, the index integral of `(γ t - w)⁻¹ * deriv γ t` equals the sum of the
+per-segment `Complex.log` increments. -/
 theorem integral_inv_sub_mul_deriv_eq_sum_log {γ : ℝ → ℂ} {w : ℂ} {a b : ℝ} {P : Set ℝ}
     {N : ℕ} {s : ℕ → ℝ} (hP : P.Countable)
     (hs_zero : s 0 = a) (hs_N : s N = b) (hs_mono : Monotone s)
-    (hs_in : ∀ j ≤ N, s j ∈ Icc a b) (hγ_cont : ContinuousOn γ (Icc a b))
+    (hγ_cont : ContinuousOn γ (Icc a b))
     (hγ_diff : ∀ t ∈ Ioo a b \ P, DifferentiableAt ℝ γ t)
     (h_slit : ∀ j, j < N → ∀ t ∈ Icc (s j) (s (j + 1)),
       (γ t - w) / (γ (s j) - w) ∈ slitPlane)
@@ -51,6 +51,8 @@ theorem integral_inv_sub_mul_deriv_eq_sum_log {γ : ℝ → ℂ} {w : ℂ} {a b 
     ∫ t in a..b, (γ t - w)⁻¹ * deriv γ t
       = ∑ j ∈ Finset.range N, Complex.log ((γ (s (j + 1)) - w) / (γ (s j) - w)) := by
   have hab : a ≤ b := by have := hs_mono (Nat.zero_le N); rwa [hs_zero, hs_N] at this
+  have hs_in : ∀ j ≤ N, s j ∈ Icc a b := fun j hj ↦
+    ⟨by rw [← hs_zero]; exact hs_mono (Nat.zero_le j), by rw [← hs_N]; exact hs_mono hj⟩
   have hmono_seg : ∀ j, s j ≤ s (j + 1) := fun j ↦ hs_mono (Nat.le_succ j)
   have h_int_seg : ∀ k < N,
       IntervalIntegrable (fun t ↦ (γ t - w)⁻¹ * deriv γ t) volume (s k) (s (k + 1)) := by


### PR DESCRIPTION
## Contents

* `integral_deriv_div_sub_eq_sum_log` — the general explicit-derivative form: over the same
  partition, `∫ t in a..b, γ' t / (γ t - w) = ∑ j < N, Complex.log ((γ (s (j+1)) - w) / (γ (s j) - w))`
  from `HasDerivAt γ (γ' t) t` off `P`.
* `integral_inv_sub_mul_deriv_eq_sum_log` — its `deriv γ` winding-integrand specialization, for a monotone partition `a = s 0 ≤ ⋯ ≤ s N = b` of
  `[a, b]` with `γ` continuous there, differentiable off a countable set `P`, avoiding `w` at each
  node, and with `(γ t - w) / (γ (s j) - w) ∈ Complex.slitPlane` on each segment:
  `∫ t in a..b, (γ t - w)⁻¹ * deriv γ t = ∑ j < N, Complex.log ((γ (s (j+1)) - w) / (γ (s j) - w))`.

## Why

Evaluating the index (winding) integral segment by segment is the first half of the P1 "winding
number is an integer for a closed curve" prerequisite on the ContourIntegration roadmap path toward
the generalized residue theorem (Hungerbühler–Wasem 3.3). For a closed curve the real parts of these
`Complex.log` increments telescope to zero and the imaginary parts sum to the total argument change
of the argument lift (#759), giving the integer winding number in a follow-up.

## Design

* Splits `∫ a..b` into `∑ ∫ (s j)..(s (j+1))` via `sum_integral_adjacent_intervals`, restricting
  integrability to each segment with `IntervalIntegrable.mono_set`.
* Evaluates each segment with `integral_inv_sub_mul_deriv_eq_log` (#818), whose winding-form
  integrand `(γ t - w)⁻¹ * deriv γ t` matches directly — no algebraic rearrangement needed.
* The per-segment slit-plane hypothesis is exactly what the argument-lift partition (#759) supplies.

## Provenance

Adapted from `contourIntegral_inv_eq_sum_log_segRatio` in `WindingArgDiff.lean` of the AINTLIB
`LeanModularForms` development, restated for a raw `γ : ℝ → ℂ` on `[a, b]`.

