### PR TITLE
docs(Martingale/Convergence): update stale references to the renamed Lévy-downward theorem

### DIFF
--- a/TauCeti/Probability/Martingale/Convergence.lean
+++ b/TauCeti/Probability/Martingale/Convergence.lean
@@ -16,14 +16,14 @@ Lévy's downward theorem for conditional expectations along a decreasing filtrat
 This is the flagship of the reverse-martingale infrastructure: the finite-horizon reversal
 (`Martingale/Reverse.lean`), the pathwise crossing adapters (`Martingale/Crossings/`), the
 reverse-martingale upcrossing bound (`Crossings/Bounds.lean`), and the antitone-limit existence
-result (`Martingale/AntitoneLimit.lean`) all feed into `condExp_tendsto_iInf`.
+result (`Martingale/AntitoneLimit.lean`) all feed into `tendsto_ae_condExp_iInf`.
 
 ## Main results
 
 - `tendsto_ae_condExp_iInf`: Lévy's downward theorem — for antitone `𝔽` and integrable `f`, the
   sequence `μ[f | 𝔽 n]` converges a.e. to `μ[f | ⨅ n, 𝔽 n]` (the reverse-martingale limit). This is
-  the roadmap Layer-4 target (roadmap README name `condExp_tendsto_iInf`), spelled in the Mathlib
-  convergence-API grammar (conclusion-first) required by the naming convention.
+  the roadmap Layer-4 target, spelled in the Mathlib convergence-API grammar (conclusion-first)
+  required by the naming convention.
 
 ## References
 


### PR DESCRIPTION
<!--tauceti-target:v1 {"focus":"docs","id":"convergence-condexp-iinf-rename"}-->

## Summary

The module docstring of `TauCeti/Probability/Martingale/Convergence.lean` referred to Lévy's downward theorem by its old roadmap name `condExp_tendsto_iInf` in two places (the "feed into" summary and the Main-results note), although the theorem itself is named `tendsto_ae_condExp_iInf` — the Mathlib convergence-API grammar name settled in #755.

This updates both references to the actual name and drops the now-obsolete parenthetical that explained the roadmap-name/theorem-name mismatch — the Exchangeability roadmap README adopts the same `tendsto_ae_condExp_iInf` spelling.

Comment-only (module docstring); no declaration, signature, or proof changes.

## Files changed

```text
TauCeti/Probability/Martingale/Convergence.lean
```

Checked open PRs: #575 (Hausdorff–Bernstein–Widder) and #822 (remove dead `futureFiltration` API) do not conflict with this docstring update.
