### PR TITLE
feat(Analysis/Contour): winding number of a closed curve is an integer

### DIFF
--- a/TauCeti/Analysis/Contour/WindingInteger.lean
+++ b/TauCeti/Analysis/Contour/WindingInteger.lean
@@ -1,37 +1,28 @@
 module
 
-public import Mathlib.Analysis.Calculus.Deriv.Basic
-public import Mathlib.Analysis.SpecialFunctions.Complex.Log
-public import Mathlib.Analysis.SpecialFunctions.Log.Basic
-public import Mathlib.MeasureTheory.Integral.IntervalIntegral.Basic
 public import TauCeti.Analysis.Contour.WindingNumber
-import Mathlib.Data.Complex.BigOperators
+import Mathlib.Analysis.SpecialFunctions.Complex.Log
 import TauCeti.Analysis.Contour.WindingSegmentSum
 import TauCeti.Analysis.Contour.ArgumentLift
 
 /-!
 # The winding number of a closed curve is an integer
 
-For a closed curve `γ` on `[a, b]` (with `γ a = γ b`) that avoids `w`, the generalized winding
-number `windingNumber γ a b w` is an integer. The index integral is evaluated over a continuous
-argument-lift partition (`exists_continuousOn_arg_lift_with_partition`): it splits into a real
-logarithm-of-modulus increment plus `I` times the imaginary part of the segment logarithm sum
-(`contourIntegral_inv_re_im_decomp`). For a closed curve the modulus increment telescopes to zero,
-so the integral is `I` times the total argument change `θ b - θ a`; closedness makes
-`exp (I * (θ b - θ a)) = 1`, whence `θ b - θ a` is an integer multiple of `2π` and the winding
-number is that integer.
+For a curve `γ` on an interval that returns to its start (`γ a = γ b`) and avoids a point `w`, its
+generalized winding number about `w` is an integer. This is the integrality step on the
+Hungerbühler–Wasem path (HW Thm 3.3): combined with continuity of the winding number in the point,
+it makes the winding number locally constant on the complement of the curve — the input to the
+homology form of Cauchy's theorem.
 
 ## Main results
 
-* `TauCeti.Contour.contourIntegral_inv_re_im_decomp` — real/imaginary decomposition of the index
-  integral over a slit-compatible monotone partition.
 * `TauCeti.Contour.exists_int_windingNumber_of_closed` — the generalized winding number of a closed
   curve is an integer.
 
 ## Provenance
 
-Adapted from `hasGeneralizedWindingNumber_integer_of_closed` in `WindingInteger.lean` of the
-AINTLIB `LeanModularForms` development, restated for a raw `γ : ℝ → ℂ` on `[a, b]`.
+Adapted from `hasGeneralizedWindingNumber_integer_of_closed` in `WindingInteger.lean` of the AINTLIB
+`LeanModularForms` development, restated for a raw `γ : ℝ → ℂ` on an oriented interval.
 -/
 
 public section
@@ -42,52 +33,12 @@ open scoped Interval
 
 namespace TauCeti.Contour
 
-/-- **Real/imaginary decomposition of the index integral.** Over a slit-compatible monotone
-partition, the index integral splits into a real logarithm-of-modulus increment plus `I` times the
-imaginary part of the segment logarithm sum. For a closed curve the real part vanishes. -/
-theorem contourIntegral_inv_re_im_decomp {γ : ℝ → ℂ} {w : ℂ} {a b : ℝ} {P : Set ℝ}
-    {N : ℕ} {s : ℕ → ℝ} (hP : P.Countable)
-    (hs_zero : s 0 = a) (hs_N : s N = b) (hs_mono : Monotone s)
-    (hγ_cont : ContinuousOn γ (Icc a b))
-    (hγ_diff : ∀ t ∈ Ioo a b \ P, DifferentiableAt ℝ γ t)
-    (h_slit : ∀ j, j < N → ∀ t ∈ Icc (s j) (s (j + 1)),
-      (γ t - w) / (γ (s j) - w) ∈ slitPlane)
-    (h_int : IntervalIntegrable (fun t ↦ (γ t - w)⁻¹ * deriv γ t) volume a b) :
-    ∫ t in a..b, (γ t - w)⁻¹ * deriv γ t
-      = ((Real.log ‖γ b - w‖ - Real.log ‖γ a - w‖ : ℝ) : ℂ)
-        + Complex.I * ((∑ j ∈ Finset.range N,
-            (Complex.log ((γ (s (j + 1)) - w) / (γ (s j) - w))).im : ℝ) : ℂ) := by
-  rw [integral_inv_sub_mul_deriv_eq_sum_log hP hs_zero hs_N hs_mono hγ_cont hγ_diff h_slit h_int]
-  have hmono_seg : ∀ j, s j ≤ s (j + 1) := fun j ↦ hs_mono (Nat.le_succ j)
-  have hne : ∀ j, j < N → γ (s j) - w ≠ 0 ∧ γ (s (j + 1)) - w ≠ 0 := fun j hj ↦
-    ⟨(div_ne_zero_iff.mp (slitPlane_ne_zero
-        (h_slit j hj (s j) (left_mem_Icc.mpr (hmono_seg j))))).1,
-      (div_ne_zero_iff.mp (slitPlane_ne_zero
-        (h_slit j hj (s (j + 1)) (right_mem_Icc.mpr (hmono_seg j))))).1⟩
-  apply Complex.ext
-  · simp only [Complex.add_re, Complex.ofReal_re, Complex.mul_re, Complex.I_re, Complex.I_im,
-      Complex.ofReal_im, zero_mul, mul_zero, sub_zero, add_zero]
-    rw [Complex.re_sum]
-    calc ∑ j ∈ Finset.range N, (Complex.log ((γ (s (j + 1)) - w) / (γ (s j) - w))).re
-        = ∑ j ∈ Finset.range N, (Real.log ‖γ (s (j + 1)) - w‖ - Real.log ‖γ (s j) - w‖) := by
-          refine Finset.sum_congr rfl fun j hj ↦ ?_
-          rw [Finset.mem_range] at hj
-          rw [Complex.log_re, norm_div,
-            Real.log_div (norm_ne_zero_iff.mpr (hne j hj).2) (norm_ne_zero_iff.mpr (hne j hj).1)]
-      _ = Real.log ‖γ (s N) - w‖ - Real.log ‖γ (s 0) - w‖ :=
-          Finset.sum_range_sub (fun j ↦ Real.log ‖γ (s j) - w‖) N
-      _ = Real.log ‖γ b - w‖ - Real.log ‖γ a - w‖ := by rw [hs_N, hs_zero]
-  · simp only [Complex.add_im, Complex.ofReal_im, Complex.mul_im, Complex.I_re, Complex.I_im,
-      Complex.ofReal_re, zero_mul, zero_add, one_mul]
-    exact Complex.im_sum _ _
-
-/-- **The winding number of a closed curve is an integer.** For a closed curve `γ` (with
-`γ a = γ b`) that is continuous on `[a, b]`, differentiable off a countable set `P`, avoids `w`
-throughout, and has an interval-integrable index integrand, the generalized winding number
-`windingNumber γ a b w` is an integer. Along a continuous argument lift the index integral equals
-`I` times the total argument change; closedness forces the modulus increment to vanish and the
-argument change to be an integer multiple of `2π`. -/
-theorem exists_int_windingNumber_of_closed {γ : ℝ → ℂ} {w : ℂ} {a b : ℝ} {P : Set ℝ}
+/-- The `a ≤ b` case of `exists_int_windingNumber_of_closed`. The index integral is evaluated over a
+continuous argument-lift partition and split into a real logarithm-of-modulus increment plus `I`
+times the total argument change; closedness kills the modulus increment and forces the argument
+change to be an integer multiple of `2π`. The general oriented-interval statement reduces to this by
+orientation reversal. -/
+private theorem exists_int_windingNumber_of_closed_of_le {γ : ℝ → ℂ} {w : ℂ} {a b : ℝ} {P : Set ℝ}
     (hab : a ≤ b) (hclosed : γ a = γ b) (hP : P.Countable)
     (hγ_cont : ContinuousOn γ (Icc a b))
     (hγ_diff : ∀ t ∈ Ioo a b \ P, DifferentiableAt ℝ γ t)
@@ -98,8 +49,8 @@ theorem exists_int_windingNumber_of_closed {γ : ℝ → ℂ} {w : ℂ} {a b : �
     exists_continuousOn_arg_lift_with_partition hab hγ_cont h_avoid
   have hla := h_lift a (left_mem_Icc.mpr hab)
   have hlb := h_lift b (right_mem_Icc.mpr hab)
-  have hint :=
-    contourIntegral_inv_re_im_decomp hP hs_zero hs_N hs_mono hγ_cont hγ_diff h_slit h_int
+  have hint := integral_inv_sub_mul_deriv_eq_log_norm_add_I_mul_sum_log_im hP hs_zero hs_N hs_mono
+    hγ_cont hγ_diff h_slit h_int
   have hnorm_ne : (‖γ a - w‖ : ℂ) ≠ 0 := by
     rw [ne_eq, Complex.ofReal_eq_zero, norm_eq_zero, sub_eq_zero]
     exact h_avoid a (left_mem_Icc.mpr hab)
@@ -138,9 +89,9 @@ theorem exists_int_windingNumber_of_closed {γ : ℝ → ℂ} {w : ℂ} {a b : �
       rw [← mul_sub, ← Complex.ofReal_sub, hEdiff]
     rw [h1, Complex.exp_sub, hEab, div_self (Complex.exp_ne_zero _)]
   obtain ⟨n, hn⟩ := Complex.exp_eq_one_iff.mp hexp_one
+  have hlog_zero : Real.log ‖γ b - w‖ - Real.log ‖γ a - w‖ = 0 := by rw [hclosed, sub_self]
   have hint' : (∫ t in a..b, (γ t - w)⁻¹ * deriv γ t) = Complex.I * (Se : ℂ) := by
-    rw [hint, show Real.log ‖γ b - w‖ - Real.log ‖γ a - w‖ = 0 by rw [hclosed, sub_self],
-      Complex.ofReal_zero, zero_add]
+    rw [hint, hlog_zero, Complex.ofReal_zero, zero_add]
   refine ⟨n, ?_⟩
   have hcont_u : ContinuousOn γ (Set.uIcc a b) := by rw [Set.uIcc_of_le hab]; exact hγ_cont
   have havoid_u : ∀ t ∈ Set.uIcc a b, γ t ≠ w := by rw [Set.uIcc_of_le hab]; exact h_avoid
@@ -150,5 +101,36 @@ theorem exists_int_windingNumber_of_closed {γ : ℝ → ℂ} {w : ℂ} {a b : �
   rw [windingNumber_eq_integral_of_avoidance hcont_u havoid_u h_int, hint', hn,
     mul_comm (n : ℂ) (2 * (Real.pi : ℂ) * Complex.I), ← mul_assoc,
     inv_mul_cancel₀ h2πI_ne, one_mul]
+
+/-- **The winding number of a closed curve is an integer.** For a curve `γ` on the oriented interval
+with endpoints `a`, `b` that returns to its start (`γ a = γ b`), is continuous on `Set.uIcc a b`,
+differentiable off a countable set `P`, avoids `w` throughout `Set.uIcc a b`, and has an
+interval-integrable index integrand `(γ · - w)⁻¹ * deriv γ`, the generalized winding number
+`windingNumber γ a b w` is an integer. -/
+theorem exists_int_windingNumber_of_closed {γ : ℝ → ℂ} {w : ℂ} {a b : ℝ} {P : Set ℝ}
+    (hclosed : γ a = γ b) (hP : P.Countable)
+    (hγ_cont : ContinuousOn γ (Set.uIcc a b))
+    (hγ_diff : ∀ t ∈ Ioo (min a b) (max a b) \ P, DifferentiableAt ℝ γ t)
+    (h_avoid : ∀ t ∈ Set.uIcc a b, γ t ≠ w)
+    (h_int : IntervalIntegrable (fun t ↦ (γ t - w)⁻¹ * deriv γ t) volume a b) :
+    ∃ n : ℤ, windingNumber γ a b w = n := by
+  rcases le_total a b with hab | hba
+  · rw [Set.uIcc_of_le hab] at hγ_cont h_avoid
+    rw [min_eq_left hab, max_eq_right hab] at hγ_diff
+    exact exists_int_windingNumber_of_closed_of_le hab hclosed hP hγ_cont hγ_diff h_avoid h_int
+  · have hcont_ba : ContinuousOn γ (Icc b a) := by rw [← Set.uIcc_of_ge hba]; exact hγ_cont
+    have havoid_ba : ∀ t ∈ Icc b a, γ t ≠ w := fun t ht ↦
+      h_avoid t (by rw [Set.uIcc_of_ge hba]; exact ht)
+    rw [min_eq_right hba, max_eq_left hba] at hγ_diff
+    obtain ⟨m, hm⟩ := exists_int_windingNumber_of_closed_of_le hba hclosed.symm hP hcont_ba
+      hγ_diff havoid_ba h_int.symm
+    refine ⟨-m, ?_⟩
+    have hrev : windingNumber γ a b w = -windingNumber γ b a w := by
+      rw [windingNumber_eq_integral_of_avoidance hγ_cont h_avoid h_int,
+        windingNumber_eq_integral_of_avoidance (by rw [Set.uIcc_comm]; exact hγ_cont)
+          (fun t ht ↦ h_avoid t (by rw [Set.uIcc_comm] at ht; exact ht)) h_int.symm,
+        intervalIntegral.integral_symm a b]
+      ring
+    rw [hrev, hm]; push_cast; ring
 
 end TauCeti.Contour

--- a/TauCeti/Analysis/Contour/WindingInteger.lean
+++ b/TauCeti/Analysis/Contour/WindingInteger.lean
@@ -1,0 +1,154 @@
+module
+
+public import Mathlib.Analysis.Calculus.Deriv.Basic
+public import Mathlib.Analysis.SpecialFunctions.Complex.Log
+public import Mathlib.Analysis.SpecialFunctions.Log.Basic
+public import Mathlib.MeasureTheory.Integral.IntervalIntegral.Basic
+public import TauCeti.Analysis.Contour.WindingNumber
+import Mathlib.Data.Complex.BigOperators
+import TauCeti.Analysis.Contour.WindingSegmentSum
+import TauCeti.Analysis.Contour.ArgumentLift
+
+/-!
+# The winding number of a closed curve is an integer
+
+For a closed curve `γ` on `[a, b]` (with `γ a = γ b`) that avoids `w`, the generalized winding
+number `windingNumber γ a b w` is an integer. The index integral is evaluated over a continuous
+argument-lift partition (`exists_continuousOn_arg_lift_with_partition`): it splits into a real
+logarithm-of-modulus increment plus `I` times the imaginary part of the segment logarithm sum
+(`contourIntegral_inv_re_im_decomp`). For a closed curve the modulus increment telescopes to zero,
+so the integral is `I` times the total argument change `θ b - θ a`; closedness makes
+`exp (I * (θ b - θ a)) = 1`, whence `θ b - θ a` is an integer multiple of `2π` and the winding
+number is that integer.
+
+## Main results
+
+* `TauCeti.Contour.contourIntegral_inv_re_im_decomp` — real/imaginary decomposition of the index
+  integral over a slit-compatible monotone partition.
+* `TauCeti.Contour.exists_int_windingNumber_of_closed` — the generalized winding number of a closed
+  curve is an integer.
+
+## Provenance
+
+Adapted from `hasGeneralizedWindingNumber_integer_of_closed` in `WindingInteger.lean` of the
+AINTLIB `LeanModularForms` development, restated for a raw `γ : ℝ → ℂ` on `[a, b]`.
+-/
+
+public section
+
+open Complex MeasureTheory Set intervalIntegral
+
+open scoped Interval
+
+namespace TauCeti.Contour
+
+/-- **Real/imaginary decomposition of the index integral.** Over a slit-compatible monotone
+partition, the index integral splits into a real logarithm-of-modulus increment plus `I` times the
+imaginary part of the segment logarithm sum. For a closed curve the real part vanishes. -/
+theorem contourIntegral_inv_re_im_decomp {γ : ℝ → ℂ} {w : ℂ} {a b : ℝ} {P : Set ℝ}
+    {N : ℕ} {s : ℕ → ℝ} (hP : P.Countable)
+    (hs_zero : s 0 = a) (hs_N : s N = b) (hs_mono : Monotone s)
+    (hγ_cont : ContinuousOn γ (Icc a b))
+    (hγ_diff : ∀ t ∈ Ioo a b \ P, DifferentiableAt ℝ γ t)
+    (h_slit : ∀ j, j < N → ∀ t ∈ Icc (s j) (s (j + 1)),
+      (γ t - w) / (γ (s j) - w) ∈ slitPlane)
+    (h_int : IntervalIntegrable (fun t ↦ (γ t - w)⁻¹ * deriv γ t) volume a b) :
+    ∫ t in a..b, (γ t - w)⁻¹ * deriv γ t
+      = ((Real.log ‖γ b - w‖ - Real.log ‖γ a - w‖ : ℝ) : ℂ)
+        + Complex.I * ((∑ j ∈ Finset.range N,
+            (Complex.log ((γ (s (j + 1)) - w) / (γ (s j) - w))).im : ℝ) : ℂ) := by
+  rw [integral_inv_sub_mul_deriv_eq_sum_log hP hs_zero hs_N hs_mono hγ_cont hγ_diff h_slit h_int]
+  have hmono_seg : ∀ j, s j ≤ s (j + 1) := fun j ↦ hs_mono (Nat.le_succ j)
+  have hne : ∀ j, j < N → γ (s j) - w ≠ 0 ∧ γ (s (j + 1)) - w ≠ 0 := fun j hj ↦
+    ⟨(div_ne_zero_iff.mp (slitPlane_ne_zero
+        (h_slit j hj (s j) (left_mem_Icc.mpr (hmono_seg j))))).1,
+      (div_ne_zero_iff.mp (slitPlane_ne_zero
+        (h_slit j hj (s (j + 1)) (right_mem_Icc.mpr (hmono_seg j))))).1⟩
+  apply Complex.ext
+  · simp only [Complex.add_re, Complex.ofReal_re, Complex.mul_re, Complex.I_re, Complex.I_im,
+      Complex.ofReal_im, zero_mul, mul_zero, sub_zero, add_zero]
+    rw [Complex.re_sum]
+    calc ∑ j ∈ Finset.range N, (Complex.log ((γ (s (j + 1)) - w) / (γ (s j) - w))).re
+        = ∑ j ∈ Finset.range N, (Real.log ‖γ (s (j + 1)) - w‖ - Real.log ‖γ (s j) - w‖) := by
+          refine Finset.sum_congr rfl fun j hj ↦ ?_
+          rw [Finset.mem_range] at hj
+          rw [Complex.log_re, norm_div,
+            Real.log_div (norm_ne_zero_iff.mpr (hne j hj).2) (norm_ne_zero_iff.mpr (hne j hj).1)]
+      _ = Real.log ‖γ (s N) - w‖ - Real.log ‖γ (s 0) - w‖ :=
+          Finset.sum_range_sub (fun j ↦ Real.log ‖γ (s j) - w‖) N
+      _ = Real.log ‖γ b - w‖ - Real.log ‖γ a - w‖ := by rw [hs_N, hs_zero]
+  · simp only [Complex.add_im, Complex.ofReal_im, Complex.mul_im, Complex.I_re, Complex.I_im,
+      Complex.ofReal_re, zero_mul, zero_add, one_mul]
+    exact Complex.im_sum _ _
+
+/-- **The winding number of a closed curve is an integer.** For a closed curve `γ` (with
+`γ a = γ b`) that is continuous on `[a, b]`, differentiable off a countable set `P`, avoids `w`
+throughout, and has an interval-integrable index integrand, the generalized winding number
+`windingNumber γ a b w` is an integer. Along a continuous argument lift the index integral equals
+`I` times the total argument change; closedness forces the modulus increment to vanish and the
+argument change to be an integer multiple of `2π`. -/
+theorem exists_int_windingNumber_of_closed {γ : ℝ → ℂ} {w : ℂ} {a b : ℝ} {P : Set ℝ}
+    (hab : a ≤ b) (hclosed : γ a = γ b) (hP : P.Countable)
+    (hγ_cont : ContinuousOn γ (Icc a b))
+    (hγ_diff : ∀ t ∈ Ioo a b \ P, DifferentiableAt ℝ γ t)
+    (h_avoid : ∀ t ∈ Icc a b, γ t ≠ w)
+    (h_int : IntervalIntegrable (fun t ↦ (γ t - w)⁻¹ * deriv γ t) volume a b) :
+    ∃ n : ℤ, windingNumber γ a b w = n := by
+  obtain ⟨N, s, _, hs_zero, hs_N, hs_mono, _, hs_avoid, h_slit, _, h_lift⟩ :=
+    exists_continuousOn_arg_lift_with_partition hab hγ_cont h_avoid
+  have hla := h_lift a (left_mem_Icc.mpr hab)
+  have hlb := h_lift b (right_mem_Icc.mpr hab)
+  have hint :=
+    contourIntegral_inv_re_im_decomp hP hs_zero hs_N hs_mono hγ_cont hγ_diff h_slit h_int
+  have hnorm_ne : (‖γ a - w‖ : ℂ) ≠ 0 := by
+    rw [ne_eq, Complex.ofReal_eq_zero, norm_eq_zero, sub_eq_zero]
+    exact h_avoid a (left_mem_Icc.mpr hab)
+  have hsa : (∑ j ∈ Finset.range N,
+      (Complex.log (segRatio γ w (s j) (s (j + 1)) a)).im) = 0 := by
+    refine Finset.sum_eq_zero fun j hj ↦ ?_
+    rw [Finset.mem_range] at hj
+    have ha_le : a ≤ s j := by rw [← hs_zero]; exact hs_mono (Nat.zero_le j)
+    rw [segRatio_eq_one_of_le ha_le (hs_avoid j hj.le), Complex.log_one, Complex.zero_im]
+  have hsb_eq : (∑ j ∈ Finset.range N,
+        (Complex.log (segRatio γ w (s j) (s (j + 1)) b)).im)
+      = ∑ j ∈ Finset.range N,
+        (Complex.log ((γ (s (j + 1)) - w) / (γ (s j) - w))).im := by
+    refine Finset.sum_congr rfl fun j hj ↦ ?_
+    rw [Finset.mem_range] at hj
+    have hb_ge : s (j + 1) ≤ b := by rw [← hs_N]; exact hs_mono hj
+    rw [segRatio_eq_endpoint_div_of_le (hs_mono (Nat.le_succ j)) hb_ge]
+  set Se : ℝ := ∑ j ∈ Finset.range N,
+    (Complex.log ((γ (s (j + 1)) - w) / (γ (s j) - w))).im with hSe_def
+  set Sa : ℝ := ∑ j ∈ Finset.range N,
+    (Complex.log (segRatio γ w (s j) (s (j + 1)) a)).im with hSa_def
+  set Sb : ℝ := ∑ j ∈ Finset.range N,
+    (Complex.log (segRatio γ w (s j) (s (j + 1)) b)).im with hSb_def
+  set Ea : ℝ := Complex.arg (γ a - w) + Sa with hEa_def
+  set Eb : ℝ := Complex.arg (γ a - w) + Sb with hEb_def
+  have hEab : Complex.exp (Complex.I * (Ea : ℂ)) = Complex.exp (Complex.I * (Eb : ℂ)) := by
+    refine mul_left_cancel₀ hnorm_ne ?_
+    calc (‖γ a - w‖ : ℂ) * Complex.exp (Complex.I * (Ea : ℂ))
+        = γ a - w := hla.symm
+      _ = γ b - w := by rw [hclosed]
+      _ = (‖γ b - w‖ : ℂ) * Complex.exp (Complex.I * (Eb : ℂ)) := hlb
+      _ = (‖γ a - w‖ : ℂ) * Complex.exp (Complex.I * (Eb : ℂ)) := by rw [← hclosed]
+  have hEdiff : Eb - Ea = Se := by rw [hEb_def, hEa_def, hsb_eq, hsa]; ring
+  have hexp_one : Complex.exp (Complex.I * (Se : ℂ)) = 1 := by
+    have h1 : Complex.I * (Se : ℂ) = Complex.I * (Eb : ℂ) - Complex.I * (Ea : ℂ) := by
+      rw [← mul_sub, ← Complex.ofReal_sub, hEdiff]
+    rw [h1, Complex.exp_sub, hEab, div_self (Complex.exp_ne_zero _)]
+  obtain ⟨n, hn⟩ := Complex.exp_eq_one_iff.mp hexp_one
+  have hint' : (∫ t in a..b, (γ t - w)⁻¹ * deriv γ t) = Complex.I * (Se : ℂ) := by
+    rw [hint, show Real.log ‖γ b - w‖ - Real.log ‖γ a - w‖ = 0 by rw [hclosed, sub_self],
+      Complex.ofReal_zero, zero_add]
+  refine ⟨n, ?_⟩
+  have hcont_u : ContinuousOn γ (Set.uIcc a b) := by rw [Set.uIcc_of_le hab]; exact hγ_cont
+  have havoid_u : ∀ t ∈ Set.uIcc a b, γ t ≠ w := by rw [Set.uIcc_of_le hab]; exact h_avoid
+  have h2πI_ne : (2 * (Real.pi : ℂ) * Complex.I) ≠ 0 :=
+    mul_ne_zero (mul_ne_zero (by norm_num) (Complex.ofReal_ne_zero.mpr Real.pi_ne_zero))
+      Complex.I_ne_zero
+  rw [windingNumber_eq_integral_of_avoidance hcont_u havoid_u h_int, hint', hn,
+    mul_comm (n : ℂ) (2 * (Real.pi : ℂ) * Complex.I), ← mul_assoc,
+    inv_mul_cancel₀ h2πI_ne, one_mul]
+
+end TauCeti.Contour

--- a/TauCeti/Analysis/Contour/WindingInteger.lean
+++ b/TauCeti/Analysis/Contour/WindingInteger.lean
@@ -8,8 +8,10 @@ import TauCeti.Analysis.Contour.ArgumentLift
 /-!
 # The winding number of a closed curve is an integer
 
-For a curve `γ` on an interval that returns to its start (`γ a = γ b`) and avoids a point `w`, its
-generalized winding number about `w` is an integer. This is the integrality step on the
+For a curve `γ` on an interval that returns to its start (`γ a = γ b`), avoids a point `w`, and is
+regular enough — continuous, differentiable off a countable set, with an interval-integrable index
+integrand — its generalized winding number about `w` is an integer (see
+`exists_int_windingNumber_of_closed` for the exact hypotheses). This is the integrality step on the
 Hungerbühler–Wasem path (HW Thm 3.3): combined with continuity of the winding number in the point,
 it makes the winding number locally constant on the complement of the curve — the input to the
 homology form of Cauchy's theorem.
@@ -33,11 +35,10 @@ open scoped Interval
 
 namespace TauCeti.Contour
 
-/-- The `a ≤ b` case of `exists_int_windingNumber_of_closed`. The index integral is evaluated over a
-continuous argument-lift partition and split into a real logarithm-of-modulus increment plus `I`
-times the total argument change; closedness kills the modulus increment and forces the argument
-change to be an integer multiple of `2π`. The general oriented-interval statement reduces to this by
-orientation reversal. -/
+/-- The nonnegative-orientation (`a ≤ b`) case of `exists_int_windingNumber_of_closed`: under the
+same continuity, differentiability-off-a-countable-set, avoidance, and interval-integrability
+assumptions on `[a, b]`, the winding number of the closed curve `γ` about `w` is an integer. The
+general oriented-interval statement reduces to this case by orientation reversal. -/
 private theorem exists_int_windingNumber_of_closed_of_le {γ : ℝ → ℂ} {w : ℂ} {a b : ℝ} {P : Set ℝ}
     (hab : a ≤ b) (hclosed : γ a = γ b) (hP : P.Countable)
     (hγ_cont : ContinuousOn γ (Icc a b))
@@ -45,15 +46,20 @@ private theorem exists_int_windingNumber_of_closed_of_le {γ : ℝ → ℂ} {w :
     (h_avoid : ∀ t ∈ Icc a b, γ t ≠ w)
     (h_int : IntervalIntegrable (fun t ↦ (γ t - w)⁻¹ * deriv γ t) volume a b) :
     ∃ n : ℤ, windingNumber γ a b w = n := by
+  -- The argument lift gives a monotone partition with per-segment slit-plane bounds and, at each
+  -- `t`, the polar form `γ t - w = ‖γ t - w‖ · exp (I · θ t)` with `θ t = arg (γ a - w) + (sum)`.
   obtain ⟨N, s, _, hs_zero, hs_N, hs_mono, _, hs_avoid, h_slit, _, h_lift⟩ :=
     exists_continuousOn_arg_lift_with_partition hab hγ_cont h_avoid
   have hla := h_lift a (left_mem_Icc.mpr hab)
   have hlb := h_lift b (right_mem_Icc.mpr hab)
+  -- Split the index integral into a modulus increment plus `I` times the argument-sum.
   have hint := integral_inv_sub_mul_deriv_eq_log_norm_add_I_mul_sum_log_im hP hs_zero hs_N hs_mono
     hγ_cont hγ_diff h_slit h_int
   have hnorm_ne : (‖γ a - w‖ : ℂ) ≠ 0 := by
     rw [ne_eq, Complex.ofReal_eq_zero, norm_eq_zero, sub_eq_zero]
     exact h_avoid a (left_mem_Icc.mpr hab)
+  -- Endpoint values of the argument sum: at `a` every segment ratio is `1` (sum `= 0`), and at `b`
+  -- every segment ratio is the full endpoint ratio (sum `=` the decomposition's sum).
   have hsa : (∑ j ∈ Finset.range N,
       (Complex.log (segRatio γ w (s j) (s (j + 1)) a)).im) = 0 := by
     refine Finset.sum_eq_zero fun j hj ↦ ?_
@@ -68,6 +74,7 @@ private theorem exists_int_windingNumber_of_closed_of_le {γ : ℝ → ℂ} {w :
     rw [Finset.mem_range] at hj
     have hb_ge : s (j + 1) ≤ b := by rw [← hs_N]; exact hs_mono hj
     rw [segRatio_eq_endpoint_div_of_le (hs_mono (Nat.le_succ j)) hb_ge]
+  -- Abbreviate the segment sums and the lifted endpoint arguments `θ a = Ea`, `θ b = Eb`.
   set Se : ℝ := ∑ j ∈ Finset.range N,
     (Complex.log ((γ (s (j + 1)) - w) / (γ (s j) - w))).im with hSe_def
   set Sa : ℝ := ∑ j ∈ Finset.range N,
@@ -76,6 +83,8 @@ private theorem exists_int_windingNumber_of_closed_of_le {γ : ℝ → ℂ} {w :
     (Complex.log (segRatio γ w (s j) (s (j + 1)) b)).im with hSb_def
   set Ea : ℝ := Complex.arg (γ a - w) + Sa with hEa_def
   set Eb : ℝ := Complex.arg (γ a - w) + Sb with hEb_def
+  -- Closedness `γ a = γ b` equates the two polar forms, so the lifted exponentials agree; hence,
+  -- since `Eb - Ea = Se`, exponential periodicity gives `exp (I · Se) = 1`.
   have hEab : Complex.exp (Complex.I * (Ea : ℂ)) = Complex.exp (Complex.I * (Eb : ℂ)) := by
     refine mul_left_cancel₀ hnorm_ne ?_
     calc (‖γ a - w‖ : ℂ) * Complex.exp (Complex.I * (Ea : ℂ))
@@ -88,6 +97,8 @@ private theorem exists_int_windingNumber_of_closed_of_le {γ : ℝ → ℂ} {w :
     have h1 : Complex.I * (Se : ℂ) = Complex.I * (Eb : ℂ) - Complex.I * (Ea : ℂ) := by
       rw [← mul_sub, ← Complex.ofReal_sub, hEdiff]
     rw [h1, Complex.exp_sub, hEab, div_self (Complex.exp_ne_zero _)]
+  -- So `I · Se = n · (2π i)` for some integer `n`, and closedness kills the modulus increment,
+  -- leaving `∫ = I · Se`. Converting through the avoidance form of `windingNumber` reads off `n`.
   obtain ⟨n, hn⟩ := Complex.exp_eq_one_iff.mp hexp_one
   have hlog_zero : Real.log ‖γ b - w‖ - Real.log ‖γ a - w‖ = 0 := by rw [hclosed, sub_self]
   have hint' : (∫ t in a..b, (γ t - w)⁻¹ * deriv γ t) = Complex.I * (Se : ℂ) := by
@@ -115,10 +126,13 @@ theorem exists_int_windingNumber_of_closed {γ : ℝ → ℂ} {w : ℂ} {a b : �
     (h_int : IntervalIntegrable (fun t ↦ (γ t - w)⁻¹ * deriv γ t) volume a b) :
     ∃ n : ℤ, windingNumber γ a b w = n := by
   rcases le_total a b with hab | hba
-  · rw [Set.uIcc_of_le hab] at hγ_cont h_avoid
+  · -- Forward orientation: apply the core directly on `[a, b] = uIcc a b`.
+    rw [Set.uIcc_of_le hab] at hγ_cont h_avoid
     rw [min_eq_left hab, max_eq_right hab] at hγ_diff
     exact exists_int_windingNumber_of_closed_of_le hab hclosed hP hγ_cont hγ_diff h_avoid h_int
-  · have hcont_ba : ContinuousOn γ (Icc b a) := by rw [← Set.uIcc_of_ge hba]; exact hγ_cont
+  · -- Reversed orientation: the core on `[b, a]` gives `windingNumber γ b a w = m`, and
+    -- `windingNumber γ a b w = -windingNumber γ b a w` by `integral_symm`, so `n = -m`.
+    have hcont_ba : ContinuousOn γ (Icc b a) := by rw [← Set.uIcc_of_ge hba]; exact hγ_cont
     have havoid_ba : ∀ t ∈ Icc b a, γ t ≠ w := fun t ht ↦
       h_avoid t (by rw [Set.uIcc_of_ge hba]; exact ht)
     rw [min_eq_right hba, max_eq_left hba] at hγ_diff

--- a/TauCeti/Analysis/Contour/WindingSegmentSum.lean
+++ b/TauCeti/Analysis/Contour/WindingSegmentSum.lean
@@ -3,6 +3,7 @@ module
 public import Mathlib.Analysis.Calculus.Deriv.Basic
 public import Mathlib.Analysis.SpecialFunctions.Complex.Log
 public import Mathlib.MeasureTheory.Integral.IntervalIntegral.Basic
+import Mathlib.Data.Complex.BigOperators
 import TauCeti.Analysis.Contour.LogDerivFTC
 
 /-!
@@ -27,6 +28,11 @@ increments telescope away and the imaginary parts sum to the total argument chan
   `γ' t / (γ t - w)` form with an explicit derivative witness.
 * `TauCeti.Contour.integral_inv_sub_mul_deriv_eq_sum_log` — its `deriv γ` specialization with the
   winding integrand `(γ t - w)⁻¹ * deriv γ t`.
+* `TauCeti.Contour.integral_deriv_div_sub_eq_log_norm_add_I_mul_sum_log_im` — the real/imaginary
+  refinement of the partition sum: a real logarithm-of-modulus increment plus `I` times the
+  imaginary segment logarithm sum.
+* `TauCeti.Contour.integral_inv_sub_mul_deriv_eq_log_norm_add_I_mul_sum_log_im` — its `deriv γ`
+  specialization with the winding integrand.
 
 ## Provenance
 
@@ -98,5 +104,69 @@ theorem integral_inv_sub_mul_deriv_eq_sum_log {γ : ℝ → ℂ} {w : ℂ} {a b 
   rw [hfun]
   exact integral_deriv_div_sub_eq_sum_log (γ' := deriv γ) hP hs_zero hs_N hs_mono hγ_cont
     (fun t ht ↦ (hγ_diff t ht).hasDerivAt) h_slit (hfun ▸ h_int)
+
+/-- **Real/imaginary decomposition of the index integral (explicit velocity).** Refining
+`integral_deriv_div_sub_eq_sum_log`, over the same slit-compatible monotone partition the integral
+of `γ' t / (γ t - w)` splits into a real logarithm-of-modulus increment
+`Real.log ‖γ b - w‖ - Real.log ‖γ a - w‖` plus `I` times the imaginary part of the segment
+logarithm sum. For a closed curve the real increment vanishes, isolating the total argument
+change. -/
+theorem integral_deriv_div_sub_eq_log_norm_add_I_mul_sum_log_im {γ γ' : ℝ → ℂ} {w : ℂ}
+    {a b : ℝ} {P : Set ℝ} {N : ℕ} {s : ℕ → ℝ} (hP : P.Countable)
+    (hs_zero : s 0 = a) (hs_N : s N = b) (hs_mono : Monotone s)
+    (hγ_cont : ContinuousOn γ (Icc a b))
+    (hγ_diff : ∀ t ∈ Ioo a b \ P, HasDerivAt γ (γ' t) t)
+    (h_slit : ∀ j, j < N → ∀ t ∈ Icc (s j) (s (j + 1)),
+      (γ t - w) / (γ (s j) - w) ∈ slitPlane)
+    (h_int : IntervalIntegrable (fun t ↦ γ' t / (γ t - w)) volume a b) :
+    ∫ t in a..b, γ' t / (γ t - w)
+      = ((Real.log ‖γ b - w‖ - Real.log ‖γ a - w‖ : ℝ) : ℂ)
+        + Complex.I * ((∑ j ∈ Finset.range N,
+            (Complex.log ((γ (s (j + 1)) - w) / (γ (s j) - w))).im : ℝ) : ℂ) := by
+  rw [integral_deriv_div_sub_eq_sum_log hP hs_zero hs_N hs_mono hγ_cont hγ_diff h_slit h_int]
+  have hmono_seg : ∀ j, s j ≤ s (j + 1) := fun j ↦ hs_mono (Nat.le_succ j)
+  have hne : ∀ j, j < N → γ (s j) - w ≠ 0 ∧ γ (s (j + 1)) - w ≠ 0 := fun j hj ↦
+    ⟨(div_ne_zero_iff.mp (slitPlane_ne_zero
+        (h_slit j hj (s j) (left_mem_Icc.mpr (hmono_seg j))))).1,
+      (div_ne_zero_iff.mp (slitPlane_ne_zero
+        (h_slit j hj (s (j + 1)) (right_mem_Icc.mpr (hmono_seg j))))).1⟩
+  apply Complex.ext
+  · simp only [Complex.add_re, Complex.ofReal_re, Complex.mul_re, Complex.I_re, Complex.I_im,
+      Complex.ofReal_im, zero_mul, mul_zero, sub_zero, add_zero]
+    rw [Complex.re_sum]
+    calc ∑ j ∈ Finset.range N, (Complex.log ((γ (s (j + 1)) - w) / (γ (s j) - w))).re
+        = ∑ j ∈ Finset.range N, (Real.log ‖γ (s (j + 1)) - w‖ - Real.log ‖γ (s j) - w‖) := by
+          refine Finset.sum_congr rfl fun j hj ↦ ?_
+          rw [Finset.mem_range] at hj
+          rw [Complex.log_re, norm_div,
+            Real.log_div (norm_ne_zero_iff.mpr (hne j hj).2) (norm_ne_zero_iff.mpr (hne j hj).1)]
+      _ = Real.log ‖γ (s N) - w‖ - Real.log ‖γ (s 0) - w‖ :=
+          Finset.sum_range_sub (fun j ↦ Real.log ‖γ (s j) - w‖) N
+      _ = Real.log ‖γ b - w‖ - Real.log ‖γ a - w‖ := by rw [hs_N, hs_zero]
+  · simp only [Complex.add_im, Complex.ofReal_im, Complex.mul_im, Complex.I_re, Complex.I_im,
+      Complex.ofReal_re, zero_mul, zero_add, one_mul]
+    exact Complex.im_sum _ _
+
+/-- **Winding-integrand form of the index-integral decomposition.** The `γ' = deriv γ`
+specialization of `integral_deriv_div_sub_eq_log_norm_add_I_mul_sum_log_im`, stated with the
+winding integrand `(γ t - w)⁻¹ * deriv γ t`, as consumed by the closed-curve winding-number
+computation. -/
+theorem integral_inv_sub_mul_deriv_eq_log_norm_add_I_mul_sum_log_im {γ : ℝ → ℂ} {w : ℂ}
+    {a b : ℝ} {P : Set ℝ} {N : ℕ} {s : ℕ → ℝ} (hP : P.Countable)
+    (hs_zero : s 0 = a) (hs_N : s N = b) (hs_mono : Monotone s)
+    (hγ_cont : ContinuousOn γ (Icc a b))
+    (hγ_diff : ∀ t ∈ Ioo a b \ P, DifferentiableAt ℝ γ t)
+    (h_slit : ∀ j, j < N → ∀ t ∈ Icc (s j) (s (j + 1)),
+      (γ t - w) / (γ (s j) - w) ∈ slitPlane)
+    (h_int : IntervalIntegrable (fun t ↦ (γ t - w)⁻¹ * deriv γ t) volume a b) :
+    ∫ t in a..b, (γ t - w)⁻¹ * deriv γ t
+      = ((Real.log ‖γ b - w‖ - Real.log ‖γ a - w‖ : ℝ) : ℂ)
+        + Complex.I * ((∑ j ∈ Finset.range N,
+            (Complex.log ((γ (s (j + 1)) - w) / (γ (s j) - w))).im : ℝ) : ℂ) := by
+  have hfun : (fun t ↦ (γ t - w)⁻¹ * deriv γ t) = fun t ↦ deriv γ t / (γ t - w) := by
+    funext t; rw [div_eq_mul_inv, mul_comm]
+  rw [hfun]
+  exact integral_deriv_div_sub_eq_log_norm_add_I_mul_sum_log_im (γ' := deriv γ) hP hs_zero hs_N
+    hs_mono hγ_cont (fun t ht ↦ (hγ_diff t ht).hasDerivAt) h_slit (hfun ▸ h_int)
 
 end TauCeti.Contour


### PR DESCRIPTION
## Contents

* `contourIntegral_inv_re_im_decomp` — over a slit-compatible monotone partition
  `a = s 0 ≤ ⋯ ≤ s N = b`, the index integral splits into a real logarithm-of-modulus increment
  plus `I` times the imaginary part of the segment logarithm sum:
  `∫ t in a..b, (γ t - w)⁻¹ * deriv γ t = ↑(Real.log ‖γ b - w‖ - Real.log ‖γ a - w‖) + I * ↑(∑ j < N, (Complex.log ((γ (s (j+1)) - w) / (γ (s j) - w))).im)`.
* `exists_int_windingNumber_of_closed` — for a closed curve `γ` (with `γ a = γ b`) continuous on
  `[a, b]`, differentiable off a countable set `P`, avoiding `w`, with an interval-integrable index
  integrand, the generalized winding number `windingNumber γ a b w` is an integer.

## Why

Integer-valuedness of the winding number of a closed curve is the P1 prerequisite on the
ContourIntegration roadmap path toward the generalized residue theorem (Hungerbühler–Wasem 3.3):
it is used for the null-homology bookkeeping in Dixon's proof of the homology form of Cauchy's
theorem. It combines the per-segment logarithm sum (#823) with the continuous argument lift (#759).

## Design

* The decomposition rewrites the segment logarithm sum (#823) via `Complex.log_re`/`Complex.log_im`:
  the real parts telescope to `Real.log ‖γ b - w‖ - Real.log ‖γ a - w‖` (`Finset.sum_range_sub`) and
  the imaginary parts are carried along by `Complex.im_sum`.
* For the integer conclusion, the argument-lift partition (#759) supplies both the per-segment
  slit-plane hypothesis the decomposition needs and the polar identity
  `γ t - w = ‖γ t - w‖ · exp (I · θ t)`. Evaluating `segRatio` at the endpoints (`= 1` at `a`,
  `= full endpoint ratio` at `b`) identifies `θ b - θ a` with the imaginary segment sum. Closedness
  makes the modulus increment vanish and `exp (I · (θ b - θ a)) = 1`, so `Complex.exp_eq_one_iff`
  gives the integer, and `windingNumber_eq_integral_of_avoidance` converts back to the winding number.

## Provenance

Adapted from `hasGeneralizedWindingNumber_integer_of_closed` in `WindingInteger.lean` of the AINTLIB
`LeanModularForms` development, restated for a raw `γ : ℝ → ℂ` on `[a, b]`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)