### PR TITLE
refactor: correct PiecewiseC1On docstring on ArcFTC

### DIFF
--- a/TauCeti/Analysis/Contour/PiecewiseC1On.lean
+++ b/TauCeti/Analysis/Contour/PiecewiseC1On.lean
@@ -18,8 +18,11 @@ there, and `C¹` on each piece between finitely many breakpoints. This file intr
 that regularity as a predicate `Contour.IsPiecewiseC1On γ a b` on the raw function `γ` itself —
 following the roadmap's function-based design, with no bundled path type — together with its API.
 
-The predicate is the hypothesis a "regularity package" supplies to the raw contour-integral lemmas
-(for example the fundamental theorem of calculus along a contour in `Contour.ArcFTC`), and it is a
+The predicate is the regularity a "regularity package" will use to *discharge* the integrand-level
+hypotheses — continuity, pointwise differentiability, and integrability — that the raw
+contour-integral lemmas take directly. Those lemmas do not consume the predicate themselves: the
+fundamental theorem of calculus along a contour in `Contour.ArcFTC`, for instance, is stated on the
+integrand so it works with any regularity package that supplies these hypotheses. The predicate is a
 prerequisite for the homology Cauchy theorem and the generalized residue theorem.
 
 ## Main definitions


### PR DESCRIPTION
This PR corrects the module docstring of `Analysis/Contour/PiecewiseC1On.lean`, which claimed that the raw contour-integral lemmas — "for example the fundamental theorem of calculus along a contour in `Contour.ArcFTC`" — consume `IsPiecewiseC1On` as the hypothesis a regularity package supplies. That is false: `ArcFTC` is deliberately stated on the integrand (continuity, pointwise `HasDerivAt`, and integrability hypotheses), takes no such predicate, and its own docstring notes it "can be used with any regularity package that supplies it"; nothing in the repository currently consumes `IsPiecewiseC1On`. The revised text says instead that the predicate is the regularity a package will use to discharge those integrand-level hypotheses, and that the raw lemmas do not consume the predicate themselves. This discharges the refactor lead in task 3 of https://github.com/TauCetiProject/TauCeti/issues/804 (Analysis/Contour: make the on-curve winding-number layer real).

Per `AGENTS.md`, improving code that already exists is always in scope; this PR adds no new mathematical scope. `lake build` completes all 4618 jobs, `lake exe axioms` reports all 8741 declarations within the allowlist [propext, Classical.choice, Quot.sound], and `lake exe module-system` confirms all 441 modules opt into the module system.

🤖 Prepared with Claude Code
