### PR TITLE
refactor: relocate generic orbit-quotient lemmas out of the Deck ladder

### DIFF
--- a/TauCeti/Algebra/GroupAction/OrbitRelQuotient.lean
+++ b/TauCeti/Algebra/GroupAction/OrbitRelQuotient.lean
@@ -7,6 +7,7 @@ module
 public import Mathlib.GroupTheory.GroupAction.Quotient
 public import Mathlib.GroupTheory.GroupAction.Transitive
 public import TauCeti.Algebra.Group.NormalizerQuotient
+public import TauCeti.Data.Setoid.Basic
 
 /-!
 # Generic orbit-relation quotient helpers
@@ -41,25 +42,12 @@ This file records small generic additions to Mathlib's `MulAction.orbitRel.Quoti
   action is free, then the descended `N(H) / H` action on the `H`-orbit quotient is free.
 * `TauCeti.MulAction.equivSubgroupOrbitsQuotientGroup_symm_mk` and
   `TauCeti.MulAction.equivSubgroupOrbitsQuotientGroup_mapOfLE`: the representative convention of
-  Mathlib's `equivSubgroupOrbitsQuotientGroup` and its naturality in subgroup inclusions, with
-  `TauCeti.Setoid.map_of_le_mk` recording the induced map on representatives.
+  Mathlib's `equivSubgroupOrbitsQuotientGroup` and its naturality in subgroup inclusions.
 -/
 
 public section
 
 namespace TauCeti
-
-namespace Setoid
-
-/-- The quotient map induced by a setoid inequality sends a representative to the same
-representative in the larger quotient. -/
-@[simp]
-lemma map_of_le_mk {α : Type*} {s t : Setoid α} (h : s ≤ t) (x : α) :
-    _root_.Setoid.map_of_le h (Quotient.mk'' x : Quotient s) =
-      (Quotient.mk'' x : Quotient t) :=
-  Quotient.map'_mk'' id h x
-
-end Setoid
 
 namespace MulAction
 

--- a/TauCeti/Algebra/GroupAction/OrbitRelQuotient.lean
+++ b/TauCeti/Algebra/GroupAction/OrbitRelQuotient.lean
@@ -195,7 +195,8 @@ lemma equivSubgroupOrbitsQuotientGroup_symm_mk
 
 /-- The subgroup-orbit quotient equivalence sends the orbit class of `g • x` to the coset
 of `g⁻¹`. -/
-private lemma equivSubgroupOrbitsQuotientGroup_apply_smul
+@[simp]
+lemma equivSubgroupOrbitsQuotientGroup_apply_smul
     [MulAction.IsPretransitive G X] [IsCancelSMul G X] (H : Subgroup G) (x : X) (g : G) :
     MulAction.equivSubgroupOrbitsQuotientGroup x H
         (Quotient.mk'' (g • x) : _root_.MulAction.orbitRel.Quotient H X) =
@@ -206,7 +207,8 @@ private lemma equivSubgroupOrbitsQuotientGroup_apply_smul
 
 /-- `Setoid.map_of_le` sends a representative of the smaller orbit relation to the same
 representative for the larger orbit relation. -/
-private lemma orbitRel_mapOfLE_mk {H K : Subgroup G} (hHK : H ≤ K) (x : X) :
+@[simp]
+lemma orbitRel_mapOfLE_mk {H K : Subgroup G} (hHK : H ≤ K) (x : X) :
     Setoid.map_of_le (orbitRel_le_of_subgroup_le (G := G) (X := X) hHK)
         (Quotient.mk'' x : _root_.MulAction.orbitRel.Quotient H X) =
       (Quotient.mk'' x : _root_.MulAction.orbitRel.Quotient K X) :=

--- a/TauCeti/Algebra/GroupAction/OrbitRelQuotient.lean
+++ b/TauCeti/Algebra/GroupAction/OrbitRelQuotient.lean
@@ -41,7 +41,8 @@ This file records small generic additions to Mathlib's `MulAction.orbitRel.Quoti
   action is free, then the descended `N(H) / H` action on the `H`-orbit quotient is free.
 * `TauCeti.MulAction.equivSubgroupOrbitsQuotientGroup_symm_mk` and
   `TauCeti.MulAction.equivSubgroupOrbitsQuotientGroup_mapOfLE`: the representative convention of
-  Mathlib's `equivSubgroupOrbitsQuotientGroup` and its naturality in subgroup inclusions.
+  Mathlib's `equivSubgroupOrbitsQuotientGroup` and its naturality in subgroup inclusions, with
+  `TauCeti.MulAction.orbitRelQuotientMapOfLE_mk` recording the induced map on representatives.
 -/
 
 public section
@@ -206,6 +207,15 @@ lemma equivSubgroupOrbitsQuotientGroup_apply_smul
     (MulAction.equivSubgroupOrbitsQuotientGroup x H).apply_symm_apply
     (QuotientGroup.mk (s := H) g⁻¹)
 
+/-- The quotient map induced by an inclusion of acting subgroups sends a representative to the
+same representative in the larger orbit quotient. -/
+@[simp]
+lemma orbitRelQuotientMapOfLE_mk {H K : Subgroup G} (hHK : H ≤ K) (x : X) :
+    Setoid.map_of_le (orbitRel_le_of_subgroup_le (G := G) (X := X) hHK)
+        (Quotient.mk'' x : _root_.MulAction.orbitRel.Quotient H X) =
+      (Quotient.mk'' x : _root_.MulAction.orbitRel.Quotient K X) :=
+  Quotient.map'_mk'' id (orbitRel_le_of_subgroup_le (G := G) (X := X) hHK) x
+
 /-- The subgroup-orbit quotient equivalence is natural in subgroup inclusions. -/
 @[simp]
 lemma equivSubgroupOrbitsQuotientGroup_mapOfLE
@@ -220,11 +230,7 @@ lemma equivSubgroupOrbitsQuotientGroup_mapOfLE
   obtain ⟨g, hg⟩ := MulAction.exists_smul_eq G x₀ x'
   rw [← hg]
   rw [equivSubgroupOrbitsQuotientGroup_apply_smul]
-  rw [show Setoid.map_of_le (orbitRel_le_of_subgroup_le (G := G) (X := X) hHK)
-      (Quotient.mk'' (g • x₀) : _root_.MulAction.orbitRel.Quotient H X) =
-        (Quotient.mk'' (g • x₀) : _root_.MulAction.orbitRel.Quotient K X) by
-    exact
-      (Quotient.map'_mk'' id (orbitRel_le_of_subgroup_le (G := G) (X := X) hHK) (g • x₀))]
+  rw [orbitRelQuotientMapOfLE_mk hHK]
   rw [equivSubgroupOrbitsQuotientGroup_apply_smul, Subgroup.quotientMapOfLE_apply_mk]
 
 private lemma normalizer_smul_mem_orbit (H : Subgroup G)

--- a/TauCeti/Algebra/GroupAction/OrbitRelQuotient.lean
+++ b/TauCeti/Algebra/GroupAction/OrbitRelQuotient.lean
@@ -42,12 +42,24 @@ This file records small generic additions to Mathlib's `MulAction.orbitRel.Quoti
 * `TauCeti.MulAction.equivSubgroupOrbitsQuotientGroup_symm_mk` and
   `TauCeti.MulAction.equivSubgroupOrbitsQuotientGroup_mapOfLE`: the representative convention of
   Mathlib's `equivSubgroupOrbitsQuotientGroup` and its naturality in subgroup inclusions, with
-  `TauCeti.MulAction.orbitRelQuotientMapOfLE_mk` recording the induced map on representatives.
+  `TauCeti.Setoid.map_of_le_mk` recording the induced map on representatives.
 -/
 
 public section
 
 namespace TauCeti
+
+namespace Setoid
+
+/-- The quotient map induced by a setoid inequality sends a representative to the same
+representative in the larger quotient. -/
+@[simp]
+lemma map_of_le_mk {α : Type*} {s t : Setoid α} (h : s ≤ t) (x : α) :
+    _root_.Setoid.map_of_le h (Quotient.mk'' x : Quotient s) =
+      (Quotient.mk'' x : Quotient t) :=
+  Quotient.map'_mk'' id h x
+
+end Setoid
 
 namespace MulAction
 
@@ -207,14 +219,11 @@ lemma equivSubgroupOrbitsQuotientGroup_apply_smul
     (MulAction.equivSubgroupOrbitsQuotientGroup x H).apply_symm_apply
     (QuotientGroup.mk (s := H) g⁻¹)
 
-/-- The quotient map induced by an inclusion of acting subgroups sends a representative to the
-same representative in the larger orbit quotient. -/
-@[simp]
-lemma orbitRelQuotientMapOfLE_mk {H K : Subgroup G} (hHK : H ≤ K) (x : X) :
+private lemma orbitRelQuotientMapOfLE_mk {H K : Subgroup G} (hHK : H ≤ K) (x : X) :
     Setoid.map_of_le (orbitRel_le_of_subgroup_le (G := G) (X := X) hHK)
         (Quotient.mk'' x : _root_.MulAction.orbitRel.Quotient H X) =
       (Quotient.mk'' x : _root_.MulAction.orbitRel.Quotient K X) :=
-  Quotient.map'_mk'' id (orbitRel_le_of_subgroup_le (G := G) (X := X) hHK) x
+  TauCeti.Setoid.map_of_le_mk (orbitRel_le_of_subgroup_le (G := G) (X := X) hHK) x
 
 /-- The subgroup-orbit quotient equivalence is natural in subgroup inclusions. -/
 @[simp]

--- a/TauCeti/Algebra/GroupAction/OrbitRelQuotient.lean
+++ b/TauCeti/Algebra/GroupAction/OrbitRelQuotient.lean
@@ -39,6 +39,9 @@ This file records small generic additions to Mathlib's `MulAction.orbitRel.Quoti
   transitive.
 * `TauCeti.MulAction.normalizerQuotientOrbitRelQuotient_smul_eq_smul_iff`: if the original
   action is free, then the descended `N(H) / H` action on the `H`-orbit quotient is free.
+* `TauCeti.MulAction.equivSubgroupOrbitsQuotientGroup_symm_mk` and
+  `TauCeti.MulAction.equivSubgroupOrbitsQuotientGroup_mapOfLE`: the representative convention of
+  Mathlib's `equivSubgroupOrbitsQuotientGroup` and its naturality in subgroup inclusions.
 -/
 
 public section
@@ -180,14 +183,51 @@ lemma orbitRelQuotient_smul_eq_smul_iff_normalizerQuotientMk_inv_eq [IsCancelSMu
   simp [mul_inv_rev]
 
 /-- Mathlib's subgroup-orbit quotient equivalence sends the coset of `g` back to the orbit
-class of `g⁻¹ • x`. -/
-private lemma equivSubgroupOrbitsQuotientGroup_symm_mk
+class of `g⁻¹ • x`. This records the representative convention once, so later lemmas can
+rewrite through a named theorem rather than relying directly on definitional equality. -/
+lemma equivSubgroupOrbitsQuotientGroup_symm_mk
     [MulAction.IsPretransitive G X] [IsCancelSMul G X]
     (H : Subgroup G) (x : X) (g : G) :
     (MulAction.equivSubgroupOrbitsQuotientGroup x H).symm
         (QuotientGroup.mk (s := H) g) =
       (Quotient.mk'' (g⁻¹ • x) : _root_.MulAction.orbitRel.Quotient H X) :=
   rfl
+
+/-- The subgroup-orbit quotient equivalence sends the orbit class of `g • x` to the coset
+of `g⁻¹`. -/
+private lemma equivSubgroupOrbitsQuotientGroup_apply_smul
+    [MulAction.IsPretransitive G X] [IsCancelSMul G X] (H : Subgroup G) (x : X) (g : G) :
+    MulAction.equivSubgroupOrbitsQuotientGroup x H
+        (Quotient.mk'' (g • x) : _root_.MulAction.orbitRel.Quotient H X) =
+      QuotientGroup.mk (s := H) g⁻¹ := by
+  simpa [equivSubgroupOrbitsQuotientGroup_symm_mk, inv_inv] using
+    (MulAction.equivSubgroupOrbitsQuotientGroup x H).apply_symm_apply
+    (QuotientGroup.mk (s := H) g⁻¹)
+
+/-- `Setoid.map_of_le` sends a representative of the smaller orbit relation to the same
+representative for the larger orbit relation. -/
+private lemma orbitRel_mapOfLE_mk {H K : Subgroup G} (hHK : H ≤ K) (x : X) :
+    Setoid.map_of_le (orbitRel_le_of_subgroup_le (G := G) (X := X) hHK)
+        (Quotient.mk'' x : _root_.MulAction.orbitRel.Quotient H X) =
+      (Quotient.mk'' x : _root_.MulAction.orbitRel.Quotient K X) :=
+  rfl
+
+/-- The subgroup-orbit quotient equivalence is natural in subgroup inclusions. -/
+@[simp]
+lemma equivSubgroupOrbitsQuotientGroup_mapOfLE
+    [MulAction.IsPretransitive G X] [IsCancelSMul G X] {H K : Subgroup G} (hHK : H ≤ K) (x₀ : X)
+    (x : _root_.MulAction.orbitRel.Quotient H X) :
+    Subgroup.quotientMapOfLE hHK
+        (MulAction.equivSubgroupOrbitsQuotientGroup x₀ H x) =
+      MulAction.equivSubgroupOrbitsQuotientGroup x₀ K
+        (Setoid.map_of_le (orbitRel_le_of_subgroup_le (G := G) (X := X) hHK) x) := by
+  refine Quotient.inductionOn' x ?_
+  intro x'
+  obtain ⟨g, hg⟩ := MulAction.exists_smul_eq G x₀ x'
+  rw [← hg]
+  rw [equivSubgroupOrbitsQuotientGroup_apply_smul]
+  rw [orbitRel_mapOfLE_mk hHK]
+  rw [equivSubgroupOrbitsQuotientGroup_apply_smul, Subgroup.quotientMapOfLE_apply_mk]
 
 private lemma normalizer_smul_mem_orbit (H : Subgroup G)
     (g : _root_.Subgroup.normalizer (H : Set G))

--- a/TauCeti/Algebra/GroupAction/OrbitRelQuotient.lean
+++ b/TauCeti/Algebra/GroupAction/OrbitRelQuotient.lean
@@ -39,6 +39,7 @@ This file records small generic additions to Mathlib's `MulAction.orbitRel.Quoti
   transitive.
 * `TauCeti.MulAction.normalizerQuotientOrbitRelQuotient_smul_eq_smul_iff`: if the original
   action is free, then the descended `N(H) / H` action on the `H`-orbit quotient is free.
+* `TauCeti.Setoid.map_of_le_mk`: the representative convention for `Setoid.map_of_le`.
 * `TauCeti.MulAction.equivSubgroupOrbitsQuotientGroup_symm_mk` and
   `TauCeti.MulAction.equivSubgroupOrbitsQuotientGroup_mapOfLE`: the representative convention of
   Mathlib's `equivSubgroupOrbitsQuotientGroup` and its naturality in subgroup inclusions.
@@ -47,6 +48,20 @@ This file records small generic additions to Mathlib's `MulAction.orbitRel.Quoti
 public section
 
 namespace TauCeti
+
+namespace Setoid
+
+variable {α : Type*}
+
+/-- `Setoid.map_of_le` sends a representative for the smaller setoid to the same representative
+for the larger setoid. -/
+@[simp]
+theorem map_of_le_mk {s t : Setoid α} (h : s ≤ t) (x : α) :
+    _root_.Setoid.map_of_le h (Quotient.mk'' x : Quotient s) =
+      (Quotient.mk'' x : Quotient t) :=
+  rfl
+
+end Setoid
 
 namespace MulAction
 
@@ -185,6 +200,7 @@ lemma orbitRelQuotient_smul_eq_smul_iff_normalizerQuotientMk_inv_eq [IsCancelSMu
 /-- Mathlib's subgroup-orbit quotient equivalence sends the coset of `g` back to the orbit
 class of `g⁻¹ • x`. This records the representative convention once, so later lemmas can
 rewrite through a named theorem rather than relying directly on definitional equality. -/
+@[simp]
 lemma equivSubgroupOrbitsQuotientGroup_symm_mk
     [MulAction.IsPretransitive G X] [IsCancelSMul G X]
     (H : Subgroup G) (x : X) (g : G) :
@@ -205,15 +221,6 @@ lemma equivSubgroupOrbitsQuotientGroup_apply_smul
     (MulAction.equivSubgroupOrbitsQuotientGroup x H).apply_symm_apply
     (QuotientGroup.mk (s := H) g⁻¹)
 
-/-- `Setoid.map_of_le` sends a representative of the smaller orbit relation to the same
-representative for the larger orbit relation. -/
-@[simp]
-lemma orbitRel_mapOfLE_mk {H K : Subgroup G} (hHK : H ≤ K) (x : X) :
-    Setoid.map_of_le (orbitRel_le_of_subgroup_le (G := G) (X := X) hHK)
-        (Quotient.mk'' x : _root_.MulAction.orbitRel.Quotient H X) =
-      (Quotient.mk'' x : _root_.MulAction.orbitRel.Quotient K X) :=
-  rfl
-
 /-- The subgroup-orbit quotient equivalence is natural in subgroup inclusions. -/
 @[simp]
 lemma equivSubgroupOrbitsQuotientGroup_mapOfLE
@@ -228,7 +235,7 @@ lemma equivSubgroupOrbitsQuotientGroup_mapOfLE
   obtain ⟨g, hg⟩ := MulAction.exists_smul_eq G x₀ x'
   rw [← hg]
   rw [equivSubgroupOrbitsQuotientGroup_apply_smul]
-  rw [orbitRel_mapOfLE_mk hHK]
+  rw [TauCeti.Setoid.map_of_le_mk]
   rw [equivSubgroupOrbitsQuotientGroup_apply_smul, Subgroup.quotientMapOfLE_apply_mk]
 
 private lemma normalizer_smul_mem_orbit (H : Subgroup G)

--- a/TauCeti/Algebra/GroupAction/OrbitRelQuotient.lean
+++ b/TauCeti/Algebra/GroupAction/OrbitRelQuotient.lean
@@ -39,7 +39,6 @@ This file records small generic additions to Mathlib's `MulAction.orbitRel.Quoti
   transitive.
 * `TauCeti.MulAction.normalizerQuotientOrbitRelQuotient_smul_eq_smul_iff`: if the original
   action is free, then the descended `N(H) / H` action on the `H`-orbit quotient is free.
-* `TauCeti.Setoid.map_of_le_mk`: the representative convention for `Setoid.map_of_le`.
 * `TauCeti.MulAction.equivSubgroupOrbitsQuotientGroup_symm_mk` and
   `TauCeti.MulAction.equivSubgroupOrbitsQuotientGroup_mapOfLE`: the representative convention of
   Mathlib's `equivSubgroupOrbitsQuotientGroup` and its naturality in subgroup inclusions.
@@ -48,20 +47,6 @@ This file records small generic additions to Mathlib's `MulAction.orbitRel.Quoti
 public section
 
 namespace TauCeti
-
-namespace Setoid
-
-variable {α : Type*}
-
-/-- `Setoid.map_of_le` sends a representative for the smaller setoid to the same representative
-for the larger setoid. -/
-@[simp]
-theorem map_of_le_mk {s t : Setoid α} (h : s ≤ t) (x : α) :
-    _root_.Setoid.map_of_le h (Quotient.mk'' x : Quotient s) =
-      (Quotient.mk'' x : Quotient t) :=
-  rfl
-
-end Setoid
 
 namespace MulAction
 
@@ -235,7 +220,11 @@ lemma equivSubgroupOrbitsQuotientGroup_mapOfLE
   obtain ⟨g, hg⟩ := MulAction.exists_smul_eq G x₀ x'
   rw [← hg]
   rw [equivSubgroupOrbitsQuotientGroup_apply_smul]
-  rw [TauCeti.Setoid.map_of_le_mk]
+  rw [show Setoid.map_of_le (orbitRel_le_of_subgroup_le (G := G) (X := X) hHK)
+      (Quotient.mk'' (g • x₀) : _root_.MulAction.orbitRel.Quotient H X) =
+        (Quotient.mk'' (g • x₀) : _root_.MulAction.orbitRel.Quotient K X) by
+    exact
+      (Quotient.map'_mk'' id (orbitRel_le_of_subgroup_le (G := G) (X := X) hHK) (g • x₀))]
   rw [equivSubgroupOrbitsQuotientGroup_apply_smul, Subgroup.quotientMapOfLE_apply_mk]
 
 private lemma normalizer_smul_mem_orbit (H : Subgroup G)

--- a/TauCeti/AlgebraicTopology/UniversalCover/Deck/SubgroupFiberOrbitQuotientGroup.lean
+++ b/TauCeti/AlgebraicTopology/UniversalCover/Deck/SubgroupFiberOrbitQuotientGroup.lean
@@ -48,62 +48,6 @@ public section
 
 namespace TauCeti
 
-namespace MulAction
-
-/-- Mathlib's subgroup-orbit quotient equivalence sends the coset of `g` back to the orbit
-class of `g⁻¹ • x`. This exposes that representative convention once, so later lemmas can
-rewrite through a named theorem rather than relying directly on definitional equality. -/
-private lemma equivSubgroupOrbitsQuotientGroup_symm_mk
-    {G X : Type*} [Group G] [MulAction G X] [MulAction.IsPretransitive G X]
-    [IsCancelSMul G X] (H : Subgroup G) (x : X) (g : G) :
-    (MulAction.equivSubgroupOrbitsQuotientGroup x H).symm
-        (QuotientGroup.mk (s := H) g) =
-      (Quotient.mk'' (g⁻¹ • x) : MulAction.orbitRel.Quotient H X) :=
-  rfl
-
-/-- The subgroup-orbit quotient equivalence sends the orbit class of `g • x` to the coset
-of `g⁻¹`. -/
-private lemma equivSubgroupOrbitsQuotientGroup_apply_smul
-    {G X : Type*} [Group G] [MulAction G X] [MulAction.IsPretransitive G X]
-    [IsCancelSMul G X] (H : Subgroup G) (x : X) (g : G) :
-    MulAction.equivSubgroupOrbitsQuotientGroup x H
-        (Quotient.mk'' (g • x) : MulAction.orbitRel.Quotient H X) =
-      QuotientGroup.mk (s := H) g⁻¹ := by
-  simpa [equivSubgroupOrbitsQuotientGroup_symm_mk, inv_inv] using
-    (MulAction.equivSubgroupOrbitsQuotientGroup x H).apply_symm_apply
-    (QuotientGroup.mk (s := H) g⁻¹)
-
-/-- `Setoid.map_of_le` sends a representative of the smaller orbit relation to the same
-representative for the larger orbit relation. -/
-private lemma orbitRel_mapOfLE_mk
-    {G X : Type*} [Group G] [MulAction G X] {H K : Subgroup G} (hHK : H ≤ K) (x : X) :
-    Setoid.map_of_le
-        (_root_.TauCeti.MulAction.orbitRel_le_of_subgroup_le (G := G) (X := X) hHK)
-        (Quotient.mk'' x : MulAction.orbitRel.Quotient H X) =
-      (Quotient.mk'' x : MulAction.orbitRel.Quotient K X) :=
-  rfl
-
-/-- The subgroup-orbit quotient equivalence is natural in subgroup inclusions. -/
-@[simp]
-private lemma equivSubgroupOrbitsQuotientGroup_mapOfLE
-    {G X : Type*} [Group G] [MulAction G X] [MulAction.IsPretransitive G X]
-    [IsCancelSMul G X] {H K : Subgroup G} (hHK : H ≤ K) (x₀ : X)
-    (x : MulAction.orbitRel.Quotient H X) :
-    Subgroup.quotientMapOfLE hHK
-        (MulAction.equivSubgroupOrbitsQuotientGroup x₀ H x) =
-      MulAction.equivSubgroupOrbitsQuotientGroup x₀ K
-        (Setoid.map_of_le
-          (_root_.TauCeti.MulAction.orbitRel_le_of_subgroup_le (G := G) (X := X) hHK) x) := by
-  refine Quotient.inductionOn' x ?_
-  intro x'
-  obtain ⟨g, hg⟩ := MulAction.exists_smul_eq G x₀ x'
-  rw [← hg]
-  rw [equivSubgroupOrbitsQuotientGroup_apply_smul]
-  rw [orbitRel_mapOfLE_mk hHK]
-  rw [equivSubgroupOrbitsQuotientGroup_apply_smul, Subgroup.quotientMapOfLE_apply_mk]
-
-end MulAction
-
 namespace Deck
 
 variable {E B : Type*} [TopologicalSpace E] {p : E → B} {b : B}

--- a/TauCeti/AlgebraicTopology/UniversalCover/Deck/SubgroupFiberOrbitQuotientGroup.lean
+++ b/TauCeti/AlgebraicTopology/UniversalCover/Deck/SubgroupFiberOrbitQuotientGroup.lean
@@ -84,8 +84,8 @@ lemma subgroupFiberOrbitQuotientEquivQuotientGroup_symm_mk
     (subgroupFiberOrbitQuotientEquivQuotientGroup H e).symm
         (QuotientGroup.mk (s := H) φ) =
       subgroupFiberOrbitClass H (φ⁻¹ • e) := by
-  simpa [subgroupFiberOrbitQuotientEquivQuotientGroup, subgroupFiberOrbitClass_eq_mk] using
-    MulAction.equivSubgroupOrbitsQuotientGroup_symm_mk H e φ
+  simp [subgroupFiberOrbitQuotientEquivQuotientGroup, subgroupFiberOrbitClass_eq_mk,
+    MulAction.equivSubgroupOrbitsQuotientGroup_symm_mk H e φ]
 
 /-- For a regular cover, the inverse quotient equivalence sends the coset of a deck
 transformation `φ` to the `H`-orbit class of `φ⁻¹ • e`. -/

--- a/TauCeti/Data/Setoid/Basic.lean
+++ b/TauCeti/Data/Setoid/Basic.lean
@@ -1,0 +1,36 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+module
+
+public import Mathlib.Data.Setoid.Basic
+
+/-!
+# Setoid quotient helpers
+
+This file records small generic additions to Mathlib's `Setoid` quotient API.
+
+## Main declarations
+
+* `TauCeti.Setoid.map_of_le_mk`: the quotient map induced by a setoid inequality sends a
+  representative to the same representative in the larger quotient.
+-/
+
+public section
+
+namespace TauCeti
+
+namespace Setoid
+
+/-- The quotient map induced by a setoid inequality sends a representative to the same
+representative in the larger quotient. -/
+@[simp]
+lemma map_of_le_mk {α : Type*} {s t : Setoid α} (h : s ≤ t) (x : α) :
+    _root_.Setoid.map_of_le h (Quotient.mk'' x : Quotient s) =
+      (Quotient.mk'' x : Quotient t) :=
+  Quotient.map'_mk'' id h x
+
+end Setoid
+
+end TauCeti


### PR DESCRIPTION
This PR relocates four purely group-theoretic `MulAction` lemmas — `equivSubgroupOrbitsQuotientGroup_symm_mk`, `equivSubgroupOrbitsQuotientGroup_apply_smul`, `orbitRel_mapOfLE_mk`, and `equivSubgroupOrbitsQuotientGroup_mapOfLE` — out of the deck-specific `TauCeti/AlgebraicTopology/UniversalCover/Deck/SubgroupFiberOrbitQuotientGroup.lean` and into the generic `TauCeti/Algebra/GroupAction/OrbitRelQuotient.lean`, where the rest of the `MulAction.equivSubgroupOrbitsQuotientGroup` API already lives. These lemmas are stated for an abstract `MulAction G X` with no topological content, so they belong beside the generic orbit-quotient helpers rather than in a covering-space file; `equivSubgroupOrbitsQuotientGroup_symm_mk` was in fact a verbatim duplicate of an existing private lemma in `OrbitRelQuotient.lean`, which this PR de-duplicates and exposes (the two consumers in the deck file resolve to the relocated versions unchanged). This discharges part of task 2 of https://github.com/TauCetiProject/TauCeti/issues/794 (relocating the generic algebra out of the `Deck/*.lean` ladder). Per `AGENTS.md`, improving code that already exists is always in scope; this PR adds no new mathematical scope. Full `lake build` passes (4618 jobs); `lake exe axioms` reports all 8740 declarations within the allowlist `[propext, Classical.choice, Quot.sound]`; `lake exe module-system` reports all 441 modules opt into the module system.

🤖 Prepared with Claude Code