### PR TITLE
refactor: remove dead generator-domain predicate

### DIFF
--- a/TauCeti/Analysis/Semigroups/Generator.lean
+++ b/TauCeti/Analysis/Semigroups/Generator.lean
@@ -84,14 +84,6 @@ exists) is the generator value at `x`. -/
 private def StronglyContinuousSemigroup.genQuot (S : StronglyContinuousSemigroup X)
     (x : X) (t : ℝ) : X := (1 / t) • (S.realOperator t x - x)
 
-/-- Membership predicate for the generator's domain: the difference quotient
-`(S t x - x)/t` converges as `t → 0⁺` ([EN] Def. II.1.2, [Linares] Def. 2).
-Equivalently `x ∈ S.domain`; the generator itself is the `LinearPMap`
-`StronglyContinuousSemigroup.generator`. -/
-private def StronglyContinuousSemigroup.IsInGeneratorDomain (S : StronglyContinuousSemigroup X)
-    (x : X) : Prop :=
-  ∃ Ax : X, Filter.Tendsto (S.genQuot x) (nhdsWithin 0 (Set.Ioi 0)) (nhds Ax)
-
 omit [CompleteSpace X] in
 /-- The generator difference quotient is additive in the limit. -/
 private theorem StronglyContinuousSemigroup.genQuot_tendsto_add


### PR DESCRIPTION
This PR removes the unused private definition `StronglyContinuousSemigroup.IsInGeneratorDomain` from `Analysis/Semigroups/Generator.lean`. The predicate is referenced nowhere in the repository: the generator's domain is carried by the `Submodule` `StronglyContinuousSemigroup.domain`, whose membership condition is spelled out inline and exposed through `mem_domain_iff_tendsto`, while the difference-quotient limit facts go through `genQuot` and the `genQuot_tendsto_*` lemmas. Per `AGENTS.md`, improving code that already exists is always in scope; this PR adds no new mathematical scope. `lake build`, `lake exe axioms` (audited 8741 declarations; all within the allowlist [propext, Classical.choice, Quot.sound]), and `lake exe module-system` (all 441 modules opt in) pass.

🤖 Prepared with Claude Code