### PR TITLE
refactor: factor out submultiplicativity of the semigroup operator norm

### DIFF
--- a/TauCeti/Analysis/Semigroups/Basic.lean
+++ b/TauCeti/Analysis/Semigroups/Basic.lean
@@ -95,6 +95,13 @@ theorem map_add_apply (S : StronglyContinuousSemigroup X) (s t : ℝ≥0) (x : X
   rfl
 
 omit [CompleteSpace X] in
+/-- Submultiplicativity of the native nonnegative-time operator norm. -/
+theorem norm_map_add_le (S : StronglyContinuousSemigroup X) (s t : ℝ≥0) :
+    ‖S (s + t)‖ ≤ ‖S s‖ * ‖S t‖ := by
+  rw [S.map_add]
+  exact ContinuousLinearMap.opNorm_comp_le _ _
+
+omit [CompleteSpace X] in
 /-- Strong continuity at zero for the native nonnegative-time action. -/
 theorem continuousAt_zero (S : StronglyContinuousSemigroup X) (x : X) :
     ContinuousAt (fun t : ℝ≥0 => S t x) 0 :=
@@ -139,8 +146,8 @@ by the product of the norms. -/
 theorem norm_realOperator_add_le (S : StronglyContinuousSemigroup X) (s t : ℝ)
     (hs : 0 ≤ s) (ht : 0 ≤ t) :
     ‖S.realOperator (s + t)‖ ≤ ‖S.realOperator s‖ * ‖S.realOperator t‖ := by
-  rw [S.realOperator_add s t hs ht]
-  exact ContinuousLinearMap.opNorm_comp_le _ _
+  rw [realOperator, realOperator, realOperator, Real.toNNReal_add hs ht]
+  exact S.norm_map_add_le s.toNNReal t.toNNReal
 
 omit [CompleteSpace X] in
 /-- Strong continuity at zero of `t ↦ S.realOperator t x` along `0 ≤ t`. -/
@@ -325,7 +332,7 @@ private theorem StronglyContinuousSemigroup.normBoundedOnInterval
       have hk_nn : (0 : ℝ) ≤ ↑k := Nat.cast_nonneg k
       calc ‖S.realOperator t‖
           = ‖S.realOperator ((t - ↑k) + ↑k)‖ := by
-            rw [show (t - ↑k) + ↑k = t from by ring]
+            rw [sub_add_cancel]
         _ ≤ ‖S.realOperator (t - ↑k)‖ * ‖S.realOperator ↑k‖ :=
             S.norm_realOperator_add_le _ _ htk_nn hk_nn
         _ ≤ M * C_k :=

--- a/TauCeti/Analysis/Semigroups/Basic.lean
+++ b/TauCeti/Analysis/Semigroups/Basic.lean
@@ -133,6 +133,16 @@ theorem realOperator_add (S : StronglyContinuousSemigroup X) (s t : ℝ) (hs : 0
   exact S.map_add' s.toNNReal t.toNNReal
 
 omit [CompleteSpace X] in
+/-- Submultiplicativity of the real-time operator norm at nonnegative times: the semigroup law
+`S.realOperator (s + t) = S.realOperator s ∘ S.realOperator t` bounds the norm of the composite
+by the product of the norms. -/
+theorem norm_realOperator_add_le (S : StronglyContinuousSemigroup X) (s t : ℝ)
+    (hs : 0 ≤ s) (ht : 0 ≤ t) :
+    ‖S.realOperator (s + t)‖ ≤ ‖S.realOperator s‖ * ‖S.realOperator t‖ := by
+  rw [S.realOperator_add s t hs ht]
+  exact ContinuousLinearMap.opNorm_comp_le _ _
+
+omit [CompleteSpace X] in
 /-- Strong continuity at zero of `t ↦ S.realOperator t x` along `0 ≤ t`. -/
 theorem realOperator_continuousWithinAt_zero (S : StronglyContinuousSemigroup X) (x : X) :
     ContinuousWithinAt (fun t => S.realOperator t x) (Set.Ici 0) 0 := by
@@ -313,13 +323,11 @@ private theorem StronglyContinuousSemigroup.normBoundedOnInterval
       have htk_le : t - ↑k ≤ 1 := by
         push_cast [Nat.succ_eq_add_one] at htn; linarith
       have hk_nn : (0 : ℝ) ≤ ↑k := Nat.cast_nonneg k
-      have h_eq : t = (t - ↑k) + ↑k := by ring
-      have h_sg := S.realOperator_add (t - ↑k) ↑k htk_nn hk_nn
-      rw [← h_eq] at h_sg
-      rw [h_sg]
-      calc ‖(S.realOperator (t - ↑k)).comp (S.realOperator ↑k)‖
-          ≤ ‖S.realOperator (t - ↑k)‖ * ‖S.realOperator ↑k‖ :=
-            ContinuousLinearMap.opNorm_comp_le _ _
+      calc ‖S.realOperator t‖
+          = ‖S.realOperator ((t - ↑k) + ↑k)‖ := by
+            rw [show (t - ↑k) + ↑k = t from by ring]
+        _ ≤ ‖S.realOperator (t - ↑k)‖ * ‖S.realOperator ↑k‖ :=
+            S.norm_realOperator_add_le _ _ htk_nn hk_nn
         _ ≤ M * C_k :=
             mul_le_mul (hMbound _ htk_nn htk_le) (hC_k_bound ↑k hk_nn le_rfl)
               (norm_nonneg _) (le_of_lt hM_pos)

--- a/TauCeti/Analysis/Semigroups/GrowthBound.lean
+++ b/TauCeti/Analysis/Semigroups/GrowthBound.lean
@@ -136,9 +136,10 @@ theorem StronglyContinuousSemigroup.existsGrowthBound
       simp only [Nat.cast_zero, S.realOperator_zero]
       exact ContinuousLinearMap.norm_id_le
     | succ k ih =>
-      rw [show (↑(k + 1) : ℝ) = 1 + ↑k from by push_cast; ring]
-      calc ‖S.realOperator (1 + ↑k)‖
-          ≤ ‖S.realOperator 1‖ * ‖S.realOperator ↑k‖ :=
+      calc ‖S.realOperator (↑(k + 1) : ℝ)‖
+          = ‖S.realOperator (1 + ↑k)‖ := by
+            rw [Nat.cast_add, Nat.cast_one, add_comm]
+        _ ≤ ‖S.realOperator 1‖ * ‖S.realOperator ↑k‖ :=
             S.norm_realOperator_add_le 1 ↑k (by linarith) (Nat.cast_nonneg k)
         _ ≤ M * M ^ k :=
             mul_le_mul (hMbound 1 (by linarith) le_rfl) ih (norm_nonneg _) (by linarith)
@@ -150,7 +151,7 @@ theorem StronglyContinuousSemigroup.existsGrowthBound
     have := Nat.lt_floor_add_one t; linarith
   calc ‖S.realOperator t‖
       = ‖S.realOperator ((t - ↑n) + ↑n)‖ := by
-        rw [show (t - ↑n) + ↑n = t from by ring]
+        rw [sub_add_cancel]
     _ ≤ ‖S.realOperator (t - ↑n)‖ * ‖S.realOperator ↑n‖ :=
         S.norm_realOperator_add_le _ _ hfrac_nn (Nat.cast_nonneg n)
     _ ≤ M * M ^ n :=

--- a/TauCeti/Analysis/Semigroups/GrowthBound.lean
+++ b/TauCeti/Analysis/Semigroups/GrowthBound.lean
@@ -136,11 +136,10 @@ theorem StronglyContinuousSemigroup.existsGrowthBound
       simp only [Nat.cast_zero, S.realOperator_zero]
       exact ContinuousLinearMap.norm_id_le
     | succ k ih =>
-      have : (↑(k + 1) : ℝ) = 1 + ↑k := by push_cast; ring
-      rw [this, S.realOperator_add 1 ↑k (by linarith) (Nat.cast_nonneg k)]
-      calc ‖(S.realOperator 1).comp (S.realOperator ↑k)‖
+      rw [show (↑(k + 1) : ℝ) = 1 + ↑k from by push_cast; ring]
+      calc ‖S.realOperator (1 + ↑k)‖
           ≤ ‖S.realOperator 1‖ * ‖S.realOperator ↑k‖ :=
-            ContinuousLinearMap.opNorm_comp_le _ _
+            S.norm_realOperator_add_le 1 ↑k (by linarith) (Nat.cast_nonneg k)
         _ ≤ M * M ^ k :=
             mul_le_mul (hMbound 1 (by linarith) le_rfl) ih (norm_nonneg _) (by linarith)
         _ = M ^ (k + 1) := by ring
@@ -149,13 +148,11 @@ theorem StronglyContinuousSemigroup.existsGrowthBound
   have hfrac_nn : 0 ≤ t - ↑n := sub_nonneg.mpr hn_le
   have hfrac_le1 : t - ↑n ≤ 1 := by
     have := Nat.lt_floor_add_one t; linarith
-  have h_eq : (t - ↑n) + ↑n = t := by ring
-  have h_sg := S.realOperator_add (t - ↑n) ↑n hfrac_nn (Nat.cast_nonneg n)
-  rw [h_eq] at h_sg
-  rw [h_sg]
-  calc ‖(S.realOperator (t - ↑n)).comp (S.realOperator ↑n)‖
-      ≤ ‖S.realOperator (t - ↑n)‖ * ‖S.realOperator ↑n‖ :=
-        ContinuousLinearMap.opNorm_comp_le _ _
+  calc ‖S.realOperator t‖
+      = ‖S.realOperator ((t - ↑n) + ↑n)‖ := by
+        rw [show (t - ↑n) + ↑n = t from by ring]
+    _ ≤ ‖S.realOperator (t - ↑n)‖ * ‖S.realOperator ↑n‖ :=
+        S.norm_realOperator_add_le _ _ hfrac_nn (Nat.cast_nonneg n)
     _ ≤ M * M ^ n :=
         mul_le_mul (hMbound _ hfrac_nn hfrac_le1) (h_int_bound n) (norm_nonneg _) (by linarith)
     _ ≤ M * Real.exp (Real.log M * t) := by


### PR DESCRIPTION
This PR extracts the recurring "apply the real-time semigroup law, then bound the operator norm of the composite by the product of the factor norms" step into a single reusable lemma `StronglyContinuousSemigroup.norm_realOperator_add_le` in `Analysis/Semigroups/Basic.lean`, and rewrites the three call sites that previously spelled it out by hand (`normBoundedOnInterval` in `Basic.lean`, and both the integer-time induction and the fractional-part decomposition inside `existsGrowthBound` in `GrowthBound.lean`) to use it. Per `AGENTS.md`, improving code that already exists is always in scope; this PR adds no new mathematical scope. `lake build`, `lake exe axioms` (audited 8741 declarations; all within the allowlist [propext, Classical.choice, Quot.sound]), and `lake exe module-system` (all 441 modules opt in) pass.

🤖 Prepared with Claude Code