### PR TITLE
refactor: replace IteratedDerivWithin wrappers with pinned-Mathlib API

### DIFF
--- a/TauCeti/Analysis/Calculus/IteratedDerivWithin.lean
+++ b/TauCeti/Analysis/Calculus/IteratedDerivWithin.lean
@@ -41,12 +41,7 @@ variable {E : Type*} [NormedAddCommGroup E] [NormedSpace ℝ E] {f : ℝ → E}
 
 /-- At a point `x` in the interior of a unique-differentiability set `s` (`s ∈ 𝓝 x`),
 the derivative of the `k`-th iterated derivative-within-`s` of a `C^(k+1)` function is the
-`(k+1)`-th iterated derivative-within-`s`.
-
-This is Mathlib's `ContDiffOn.differentiableOn_iteratedDerivWithin` followed by
-`DifferentiableOn.hasDerivAt`, with the derivative value rewritten through
-`iteratedDerivWithin_succ`; it is kept as a named lemma because the completely-monotone
-development invokes this composite repeatedly. -/
+`(k+1)`-th iterated derivative-within-`s`. -/
 theorem ContDiffOn.hasDerivAt_iteratedDerivWithin
     {𝕜 E : Type*} [NontriviallyNormedField 𝕜] [NormedAddCommGroup E] [NormedSpace 𝕜 E]
     {g : 𝕜 → E} {s : Set 𝕜} {k : ℕ}

--- a/TauCeti/Analysis/Calculus/IteratedDerivWithin.lean
+++ b/TauCeti/Analysis/Calculus/IteratedDerivWithin.lean
@@ -16,6 +16,8 @@ completely-monotone or Bernstein-function structure.
 
 * `TauCeti.ContDiffOn.hasDerivAt_iteratedDerivWithin`: differentiability of an
   `iteratedDerivWithin` on a neighbourhood inside a unique-differentiability set.
+* `TauCeti.ContDiffAt.iteratedDerivWithin_Icc_eq_Ici`: agreement of iterated derivatives within
+  `Icc x T` and `Ici a` at strict interior points.
 For the plain fundamental-theorem identity on a compact interval use Mathlib's
 `intervalIntegral.integral_derivWithin_Icc_of_contDiffOn_Icc` together with
 `iteratedDerivWithin_one`.
@@ -40,5 +42,18 @@ theorem ContDiffOn.hasDerivAt_iteratedDerivWithin
   rw [iteratedDerivWithin_succ, derivWithin_of_mem_nhds hx]
   exact (hf.differentiableOn_iteratedDerivWithin
     (by exact_mod_cast Nat.lt_succ_self k) hs).hasDerivAt hx
+
+/-- `iteratedDerivWithin` on `Icc x T` agrees with `iteratedDerivWithin` on `Ici a` at interior
+points, since both equal `iteratedDeriv n f t` under local smoothness at `t`. -/
+lemma ContDiffAt.iteratedDerivWithin_Icc_eq_Ici
+    {E : Type*} [NormedAddCommGroup E] [NormedSpace ℝ E] {f : ℝ → E} {n : ℕ}
+    {a x T t : ℝ} (hf : ContDiffAt ℝ (n : WithTop ℕ∞) f t) (ht_lo : a < t)
+    (ht : t ∈ Ioo x T) :
+    iteratedDerivWithin n f (Icc x T) t = iteratedDerivWithin n f (Ici a) t := by
+  have hxT : x < T := lt_trans ht.1 ht.2
+  rw [iteratedDerivWithin_eq_iteratedDeriv (uniqueDiffOn_Icc hxT) hf
+        (Ioo_subset_Icc_self ht),
+      ← iteratedDerivWithin_eq_iteratedDeriv (uniqueDiffOn_Ici a) hf
+        (mem_Ici.mpr ht_lo.le)]
 
 end TauCeti

--- a/TauCeti/Analysis/Calculus/IteratedDerivWithin.lean
+++ b/TauCeti/Analysis/Calculus/IteratedDerivWithin.lean
@@ -16,8 +16,6 @@ completely-monotone or Bernstein-function structure.
 
 * `TauCeti.ContDiffOn.hasDerivAt_iteratedDerivWithin`: differentiability of an
   `iteratedDerivWithin` on a neighbourhood inside a unique-differentiability set.
-* `TauCeti.ContDiffAt.iteratedDerivWithin_Icc_eq_Ici`: agreement of iterated derivatives within
-  `Icc x T` and `Ici a` at strict interior points.
 For the plain fundamental-theorem identity on a compact interval use Mathlib's
 `intervalIntegral.integral_derivWithin_Icc_of_contDiffOn_Icc` together with
 `iteratedDerivWithin_one`.
@@ -42,18 +40,5 @@ theorem ContDiffOn.hasDerivAt_iteratedDerivWithin
   rw [iteratedDerivWithin_succ, derivWithin_of_mem_nhds hx]
   exact (hf.differentiableOn_iteratedDerivWithin
     (by exact_mod_cast Nat.lt_succ_self k) hs).hasDerivAt hx
-
-/-- `iteratedDerivWithin` on `Icc x T` agrees with `iteratedDerivWithin` on `Ici a` at interior
-points, since both equal `iteratedDeriv n f t` under local smoothness at `t`. -/
-lemma ContDiffAt.iteratedDerivWithin_Icc_eq_Ici
-    {E : Type*} [NormedAddCommGroup E] [NormedSpace ℝ E] {f : ℝ → E} {n : ℕ}
-    {a x T t : ℝ} (hf : ContDiffAt ℝ (n : WithTop ℕ∞) f t) (ht_lo : a < t)
-    (ht : t ∈ Ioo x T) :
-    iteratedDerivWithin n f (Icc x T) t = iteratedDerivWithin n f (Ici a) t := by
-  have hxT : x < T := lt_trans ht.1 ht.2
-  rw [iteratedDerivWithin_eq_iteratedDeriv (uniqueDiffOn_Icc hxT) hf
-        (Ioo_subset_Icc_self ht),
-      ← iteratedDerivWithin_eq_iteratedDeriv (uniqueDiffOn_Ici a) hf
-        (mem_Ici.mpr ht_lo.le)]
 
 end TauCeti

--- a/TauCeti/Analysis/Calculus/IteratedDerivWithin.lean
+++ b/TauCeti/Analysis/Calculus/IteratedDerivWithin.lean
@@ -17,14 +17,17 @@ independent of any completely-monotone or Bernstein-function structure.
 
 * `TauCeti.ContDiffOn.hasDerivAt_iteratedDerivWithin`: differentiability of an
   `iteratedDerivWithin` on a neighbourhood inside a unique-differentiability set.
-* `TauCeti.ContDiffAt.iteratedDerivWithin_Icc_eq_Ici`: agreement of iterated derivatives within
-  `Icc x T` and `Ici a` at strict interior points.
-* `TauCeti.ContDiffOn.integral_neg_iteratedDerivWithin_one_Icc`,
-  `TauCeti.ContDiffOn.integral_neg_iteratedDerivWithin_one_Icc_zero_left`,
-  `TauCeti.ContDiffOn.integral_neg_iteratedDerivWithin_one_Icc_eq_Ici`: finite-interval
-  fundamental-theorem identities for first iterated derivatives within intervals.
+* `TauCeti.ContDiffOn.integral_neg_iteratedDerivWithin_one_Icc_eq_Ici`: transfer of the
+  first-derivative interval integral from the `T`-dependent set `Icc x T` to the fixed
+  half-line `Ici a`.
 * `TauCeti.ContDiffOn.tendsto_integral_neg_iteratedDerivWithin_one_Icc_atTop`: convergence of
   the finite-interval primitive under convergence at infinity.
+
+For the plain fundamental-theorem identity on a compact interval use Mathlib's
+`intervalIntegral.integral_derivWithin_Icc_of_contDiffOn_Icc` together with
+`iteratedDerivWithin_one`; for agreement of `iteratedDerivWithin` on two
+unique-differentiability sets at a point of local smoothness use Mathlib's
+`iteratedDerivWithin_eq_iteratedDeriv` on each set.
 -/
 
 public section
@@ -38,50 +41,21 @@ variable {E : Type*} [NormedAddCommGroup E] [NormedSpace ℝ E] {f : ℝ → E}
 
 /-- At a point `x` in the interior of a unique-differentiability set `s` (`s ∈ 𝓝 x`),
 the derivative of the `k`-th iterated derivative-within-`s` of a `C^(k+1)` function is the
-`(k+1)`-th iterated derivative-within-`s`. -/
+`(k+1)`-th iterated derivative-within-`s`.
+
+This is Mathlib's `ContDiffOn.differentiableOn_iteratedDerivWithin` followed by
+`DifferentiableOn.hasDerivAt`, with the derivative value rewritten through
+`iteratedDerivWithin_succ`; it is kept as a named lemma because the completely-monotone
+development invokes this composite repeatedly. -/
 theorem ContDiffOn.hasDerivAt_iteratedDerivWithin
     {𝕜 E : Type*} [NontriviallyNormedField 𝕜] [NormedAddCommGroup E] [NormedSpace 𝕜 E]
     {g : 𝕜 → E} {s : Set 𝕜} {k : ℕ}
     (hf : ContDiffOn 𝕜 ((k + 1 : ℕ) : WithTop ℕ∞) g s)
     (hs : UniqueDiffOn 𝕜 s) {x : 𝕜} (hx : s ∈ nhds x) :
     HasDerivAt (iteratedDerivWithin k g s) (iteratedDerivWithin (k + 1) g s x) x := by
-  have hklt : (k : WithTop ℕ∞) < ((k + 1 : ℕ) : WithTop ℕ∞) := by
-    exact_mod_cast (Nat.lt_succ_self k)
-  have hda := (hf.differentiableOn_iteratedDerivWithin
-    hklt hs).hasDerivAt hx
-  have hval : iteratedDerivWithin (k + 1) g s x =
-      deriv (iteratedDerivWithin k g s) x := by
-    rw [iteratedDerivWithin_succ, derivWithin_of_mem_nhds hx]
-  rw [hval]; exact hda
-
-/-- `iteratedDerivWithin` on `Icc x T` agrees with `iteratedDerivWithin` on `Ici a` at interior
-points, since both equal `iteratedDeriv n f t` under local smoothness at `t`. -/
-lemma ContDiffAt.iteratedDerivWithin_Icc_eq_Ici {n : ℕ}
-    {a x T t : ℝ} (hf : ContDiffAt ℝ (n : WithTop ℕ∞) f t) (ht_lo : a < t)
-    (ht : t ∈ Ioo x T) :
-    iteratedDerivWithin n f (Icc x T) t = iteratedDerivWithin n f (Ici a) t := by
-  have hxT : x < T := lt_trans ht.1 ht.2
-  rw [iteratedDerivWithin_eq_iteratedDeriv (uniqueDiffOn_Icc hxT) hf
-        (Ioo_subset_Icc_self ht),
-      ← iteratedDerivWithin_eq_iteratedDeriv (uniqueDiffOn_Ici a) hf
-        (mem_Ici.mpr ht_lo.le)]
-
-/-- The fundamental-theorem identity
-`f x - f T = ∫ₓᵀ -f'` on a compact interval, with the derivative represented as the first
-iterated derivative within that interval. -/
-lemma ContDiffOn.integral_neg_iteratedDerivWithin_one_Icc {x T : ℝ}
-    [CompleteSpace E] (hf : ContDiffOn ℝ 1 f (Icc x T)) (hxT : x ≤ T) :
-    f x - f T = ∫ t in x..T, -iteratedDerivWithin 1 f (Icc x T) t := by
-  have hFTC := intervalIntegral.integral_derivWithin_Icc_of_contDiffOn_Icc hf hxT
-  rw [iteratedDerivWithin_one]
-  rw [intervalIntegral.integral_neg, hFTC, neg_sub]
-
-/-- The zero-left specialization of
-`ContDiffOn.integral_neg_iteratedDerivWithin_one_Icc`. -/
-lemma ContDiffOn.integral_neg_iteratedDerivWithin_one_Icc_zero_left {T : ℝ}
-    [CompleteSpace E] (hf : ContDiffOn ℝ 1 f (Icc 0 T)) (hT : 0 ≤ T) :
-    ∫ t in (0 : ℝ)..T, -iteratedDerivWithin 1 f (Icc 0 T) t = f 0 - f T := by
-  exact (ContDiffOn.integral_neg_iteratedDerivWithin_one_Icc hf hT).symm
+  rw [iteratedDerivWithin_succ, derivWithin_of_mem_nhds hx]
+  exact (hf.differentiableOn_iteratedDerivWithin
+    (by exact_mod_cast Nat.lt_succ_self k) hs).hasDerivAt hx
 
 /-- The interval integral of `-f'` with the `T`-dependent set `Icc x T` equals the integral with
 the fixed set `Ici a`, under local smoothness at the strict interior points. The derivative is
@@ -110,8 +84,9 @@ lemma ContDiffOn.tendsto_integral_neg_iteratedDerivWithin_one_Icc_atTop
     Tendsto (fun T => ∫ t in a..T, -iteratedDerivWithin 1 f (Icc a T) t) atTop
         (nhds (f a - L)) := by
   refine Tendsto.congr' (EventuallyEq.symm ?_) (Tendsto.sub tendsto_const_nhds hL)
-  exact (eventually_gt_atTop a).mono fun T hT =>
-    (ContDiffOn.integral_neg_iteratedDerivWithin_one_Icc
-      (hf.mono Icc_subset_Ici_self) hT.le).symm
+  filter_upwards [eventually_ge_atTop a] with T hT
+  rw [iteratedDerivWithin_one, intervalIntegral.integral_neg,
+    intervalIntegral.integral_derivWithin_Icc_of_contDiffOn_Icc
+      (hf.mono Icc_subset_Ici_self) hT, neg_sub]
 
 end TauCeti

--- a/TauCeti/Analysis/Calculus/IteratedDerivWithin.lean
+++ b/TauCeti/Analysis/Calculus/IteratedDerivWithin.lean
@@ -17,6 +17,8 @@ independent of any completely-monotone or Bernstein-function structure.
 
 * `TauCeti.ContDiffOn.hasDerivAt_iteratedDerivWithin`: differentiability of an
   `iteratedDerivWithin` on a neighbourhood inside a unique-differentiability set.
+* `TauCeti.ContDiffAt.iteratedDerivWithin_Icc_eq_Ici`: pointwise agreement of
+  `iteratedDerivWithin` on a compact interval and a containing half-line.
 * `TauCeti.ContDiffOn.integral_neg_iteratedDerivWithin_one_Icc_eq_Ici`: transfer of the
   first-derivative interval integral from the `T`-dependent set `Icc x T` to the fixed
   half-line `Ici a`.
@@ -25,9 +27,7 @@ independent of any completely-monotone or Bernstein-function structure.
 
 For the plain fundamental-theorem identity on a compact interval use Mathlib's
 `intervalIntegral.integral_derivWithin_Icc_of_contDiffOn_Icc` together with
-`iteratedDerivWithin_one`; for agreement of `iteratedDerivWithin` on two
-unique-differentiability sets at a point of local smoothness use Mathlib's
-`iteratedDerivWithin_eq_iteratedDeriv` on each set.
+`iteratedDerivWithin_one`.
 -/
 
 public section
@@ -52,6 +52,17 @@ theorem ContDiffOn.hasDerivAt_iteratedDerivWithin
   exact (hf.differentiableOn_iteratedDerivWithin
     (by exact_mod_cast Nat.lt_succ_self k) hs).hasDerivAt hx
 
+/-- At a point of `[x, T]` contained in `[a, ∞)`, `iteratedDerivWithin`
+computed on `[x, T]` agrees with `iteratedDerivWithin` computed on `[a, ∞)`. -/
+lemma ContDiffAt.iteratedDerivWithin_Icc_eq_Ici {n : ℕ} {a x T t : ℝ}
+    (hf : ContDiffAt ℝ (n : WithTop ℕ∞) f t) (hax : a ≤ x) (hxT : x < T)
+    (hxt : x ≤ t) (htT : t ≤ T) :
+    iteratedDerivWithin n f (Icc x T) t = iteratedDerivWithin n f (Ici a) t := by
+  rw [iteratedDerivWithin_eq_iteratedDeriv (uniqueDiffOn_Icc hxT) hf
+    ⟨hxt, htT⟩,
+    iteratedDerivWithin_eq_iteratedDeriv (uniqueDiffOn_Ici a) hf
+      (mem_Ici.mpr (le_trans hax hxt))]
+
 /-- The interval integral of `-f'` with the `T`-dependent set `Icc x T` equals the integral with
 the fixed set `Ici a`, under local smoothness at the strict interior points. The derivative is
 represented as `iteratedDerivWithin 1`. -/
@@ -62,13 +73,9 @@ lemma ContDiffOn.integral_neg_iteratedDerivWithin_one_Icc_eq_Ici
   apply intervalIntegral.integral_congr_uIoo
   intro t ht
   rw [uIoo_of_le hxT] at ht
-  have ha_lt : a < t := lt_of_le_of_lt hax ht.1
-  have hxT_pos : x < T := lt_trans ht.1 ht.2
-  have hcda : ContDiffAt ℝ 1 f t := hf t ht
-  simp only [iteratedDerivWithin_eq_iteratedDeriv (uniqueDiffOn_Icc hxT_pos) hcda
-      (Ioo_subset_Icc_self ht),
-    iteratedDerivWithin_eq_iteratedDeriv (uniqueDiffOn_Ici a) hcda
-      (mem_Ici.mpr ha_lt.le)]
+  exact congrArg Neg.neg
+    (ContDiffAt.iteratedDerivWithin_Icc_eq_Ici (hf t ht) hax (lt_trans ht.1 ht.2)
+      ht.1.le ht.2.le)
 
 /-- The integral `∫ₐᵀ (-f') dt → f(a) - L` as `T → ∞`, assuming smoothness on
 `[a, ∞)` and convergence of `f` to `L` at infinity. The derivative is represented as

--- a/TauCeti/Analysis/Calculus/IteratedDerivWithin.lean
+++ b/TauCeti/Analysis/Calculus/IteratedDerivWithin.lean
@@ -10,19 +10,13 @@ public import Mathlib.MeasureTheory.Integral.IntervalIntegral.ContDiff
 /-!
 # Generic lemmas for iterated derivatives within sets
 
-This file records calculus lemmas about `iteratedDerivWithin` and interval integrals that are
-independent of any completely-monotone or Bernstein-function structure.
+This file records calculus lemmas about `iteratedDerivWithin` that are independent of any
+completely-monotone or Bernstein-function structure.
 
 ## Main declarations
 
 * `TauCeti.ContDiffOn.hasDerivAt_iteratedDerivWithin`: differentiability of an
   `iteratedDerivWithin` on a neighbourhood inside a unique-differentiability set.
-* `TauCeti.ContDiffOn.integral_neg_iteratedDerivWithin_one_Icc_eq_Ici`: transfer of the
-  first-derivative interval integral from the `T`-dependent set `Icc x T` to the fixed
-  half-line `Ici a`.
-* `TauCeti.ContDiffOn.tendsto_integral_neg_iteratedDerivWithin_one_Icc_atTop`: convergence of
-  the finite-interval primitive under convergence at infinity.
-
 For the plain fundamental-theorem identity on a compact interval use Mathlib's
 `intervalIntegral.integral_derivWithin_Icc_of_contDiffOn_Icc` together with
 `iteratedDerivWithin_one`.
@@ -34,8 +28,6 @@ open MeasureTheory Set intervalIntegral Filter
 open scoped ContDiff Topology
 
 namespace TauCeti
-
-variable {E : Type*} [NormedAddCommGroup E] [NormedSpace ℝ E] {f : ℝ → E}
 
 /-- At a point `x` in the interior of a unique-differentiability set `s` (`s ∈ 𝓝 x`),
 the derivative of the `k`-th iterated derivative-within-`s` of a `C^(k+1)` function is the
@@ -49,41 +41,5 @@ theorem ContDiffOn.hasDerivAt_iteratedDerivWithin
   rw [iteratedDerivWithin_succ, derivWithin_of_mem_nhds hx]
   exact (hf.differentiableOn_iteratedDerivWithin
     (by exact_mod_cast Nat.lt_succ_self k) hs).hasDerivAt hx
-
-private lemma ContDiffAt.iteratedDerivWithin_eq_of_mem_uniqueDiffOn {n : ℕ} {s u : Set ℝ}
-    {t : ℝ} (hf : ContDiffAt ℝ (n : WithTop ℕ∞) f t) (hs : UniqueDiffOn ℝ s)
-    (hu : UniqueDiffOn ℝ u) (hts : t ∈ s) (htu : t ∈ u) :
-    iteratedDerivWithin n f s t = iteratedDerivWithin n f u t := by
-  rw [iteratedDerivWithin_eq_iteratedDeriv hs hf hts,
-    iteratedDerivWithin_eq_iteratedDeriv hu hf htu]
-
-/-- The interval integral of `-f'` with the `T`-dependent set `Icc x T` equals the integral with
-the fixed set `Ici a`, under local smoothness at the strict interior points. The derivative is
-represented as `iteratedDerivWithin 1`. -/
-lemma ContDiffOn.integral_neg_iteratedDerivWithin_one_Icc_eq_Ici
-    {a x T : ℝ} (hf : ∀ t ∈ Ioo x T, ContDiffAt ℝ 1 f t) (hax : a ≤ x) (hxT : x ≤ T) :
-    ∫ t in x..T, -iteratedDerivWithin 1 f (Icc x T) t =
-    ∫ t in x..T, -iteratedDerivWithin 1 f (Ici a) t := by
-  apply intervalIntegral.integral_congr_uIoo
-  intro t ht
-  rw [uIoo_of_le hxT] at ht
-  exact congrArg Neg.neg
-    (ContDiffAt.iteratedDerivWithin_eq_of_mem_uniqueDiffOn (hf t ht)
-      (uniqueDiffOn_Icc (lt_trans ht.1 ht.2)) (uniqueDiffOn_Ici a)
-      ⟨ht.1.le, ht.2.le⟩ (mem_Ici.mpr (le_trans hax ht.1.le)))
-
-/-- The integral `∫ₐᵀ (-f') dt → f(a) - L` as `T → ∞`, assuming smoothness on
-`[a, ∞)` and convergence of `f` to `L` at infinity. The derivative is represented as
-`iteratedDerivWithin 1`. -/
-lemma ContDiffOn.tendsto_integral_neg_iteratedDerivWithin_one_Icc_atTop
-    [CompleteSpace E] {a : ℝ} (hf : ContDiffOn ℝ 1 f (Ici a)) {L : E}
-    (hL : Tendsto f atTop (nhds L)) :
-    Tendsto (fun T => ∫ t in a..T, -iteratedDerivWithin 1 f (Icc a T) t) atTop
-        (nhds (f a - L)) := by
-  refine Tendsto.congr' (EventuallyEq.symm ?_) (Tendsto.sub tendsto_const_nhds hL)
-  filter_upwards [eventually_ge_atTop a] with T hT
-  simpa [iteratedDerivWithin_one, intervalIntegral.integral_neg, neg_sub] using
-    congrArg Neg.neg (intervalIntegral.integral_derivWithin_Icc_of_contDiffOn_Icc
-      (hf.mono Icc_subset_Ici_self) hT)
 
 end TauCeti

--- a/TauCeti/Analysis/Calculus/IteratedDerivWithin.lean
+++ b/TauCeti/Analysis/Calculus/IteratedDerivWithin.lean
@@ -5,7 +5,6 @@ Released under Apache 2.0 license as described in the file LICENSE.
 module
 
 public import Mathlib.Analysis.Calculus.IteratedDeriv.Lemmas
-public import Mathlib.MeasureTheory.Integral.IntervalIntegral.ContDiff
 
 /-!
 # Generic lemmas for iterated derivatives within sets
@@ -24,7 +23,7 @@ For the plain fundamental-theorem identity on a compact interval use Mathlib's
 
 public section
 
-open MeasureTheory Set intervalIntegral Filter
+open Set Filter
 open scoped ContDiff Topology
 
 namespace TauCeti

--- a/TauCeti/Analysis/Calculus/IteratedDerivWithin.lean
+++ b/TauCeti/Analysis/Calculus/IteratedDerivWithin.lean
@@ -80,8 +80,8 @@ lemma ContDiffOn.tendsto_integral_neg_iteratedDerivWithin_one_Icc_atTop
         (nhds (f a - L)) := by
   refine Tendsto.congr' (EventuallyEq.symm ?_) (Tendsto.sub tendsto_const_nhds hL)
   filter_upwards [eventually_ge_atTop a] with T hT
-  rw [iteratedDerivWithin_one, intervalIntegral.integral_neg,
-    intervalIntegral.integral_derivWithin_Icc_of_contDiffOn_Icc
-      (hf.mono Icc_subset_Ici_self) hT, neg_sub]
+  simpa [iteratedDerivWithin_one, intervalIntegral.integral_neg, neg_sub] using
+    congrArg Neg.neg (intervalIntegral.integral_derivWithin_Icc_of_contDiffOn_Icc
+      (hf.mono Icc_subset_Ici_self) hT)
 
 end TauCeti

--- a/TauCeti/Analysis/Calculus/IteratedDerivWithin.lean
+++ b/TauCeti/Analysis/Calculus/IteratedDerivWithin.lean
@@ -17,8 +17,6 @@ independent of any completely-monotone or Bernstein-function structure.
 
 * `TauCeti.ContDiffOn.hasDerivAt_iteratedDerivWithin`: differentiability of an
   `iteratedDerivWithin` on a neighbourhood inside a unique-differentiability set.
-* `TauCeti.ContDiffAt.iteratedDerivWithin_Icc_eq_Ici`: pointwise agreement of
-  `iteratedDerivWithin` on a compact interval and a containing half-line.
 * `TauCeti.ContDiffOn.integral_neg_iteratedDerivWithin_one_Icc_eq_Ici`: transfer of the
   first-derivative interval integral from the `T`-dependent set `Icc x T` to the fixed
   half-line `Ici a`.
@@ -52,16 +50,12 @@ theorem ContDiffOn.hasDerivAt_iteratedDerivWithin
   exact (hf.differentiableOn_iteratedDerivWithin
     (by exact_mod_cast Nat.lt_succ_self k) hs).hasDerivAt hx
 
-/-- At a point of `[x, T]` contained in `[a, ∞)`, `iteratedDerivWithin`
-computed on `[x, T]` agrees with `iteratedDerivWithin` computed on `[a, ∞)`. -/
-lemma ContDiffAt.iteratedDerivWithin_Icc_eq_Ici {n : ℕ} {a x T t : ℝ}
-    (hf : ContDiffAt ℝ (n : WithTop ℕ∞) f t) (hax : a ≤ x) (hxT : x < T)
-    (hxt : x ≤ t) (htT : t ≤ T) :
-    iteratedDerivWithin n f (Icc x T) t = iteratedDerivWithin n f (Ici a) t := by
-  rw [iteratedDerivWithin_eq_iteratedDeriv (uniqueDiffOn_Icc hxT) hf
-    ⟨hxt, htT⟩,
-    iteratedDerivWithin_eq_iteratedDeriv (uniqueDiffOn_Ici a) hf
-      (mem_Ici.mpr (le_trans hax hxt))]
+private lemma ContDiffAt.iteratedDerivWithin_eq_of_mem_uniqueDiffOn {n : ℕ} {s u : Set ℝ}
+    {t : ℝ} (hf : ContDiffAt ℝ (n : WithTop ℕ∞) f t) (hs : UniqueDiffOn ℝ s)
+    (hu : UniqueDiffOn ℝ u) (hts : t ∈ s) (htu : t ∈ u) :
+    iteratedDerivWithin n f s t = iteratedDerivWithin n f u t := by
+  rw [iteratedDerivWithin_eq_iteratedDeriv hs hf hts,
+    iteratedDerivWithin_eq_iteratedDeriv hu hf htu]
 
 /-- The interval integral of `-f'` with the `T`-dependent set `Icc x T` equals the integral with
 the fixed set `Ici a`, under local smoothness at the strict interior points. The derivative is
@@ -74,8 +68,9 @@ lemma ContDiffOn.integral_neg_iteratedDerivWithin_one_Icc_eq_Ici
   intro t ht
   rw [uIoo_of_le hxT] at ht
   exact congrArg Neg.neg
-    (ContDiffAt.iteratedDerivWithin_Icc_eq_Ici (hf t ht) hax (lt_trans ht.1 ht.2)
-      ht.1.le ht.2.le)
+    (ContDiffAt.iteratedDerivWithin_eq_of_mem_uniqueDiffOn (hf t ht)
+      (uniqueDiffOn_Icc (lt_trans ht.1 ht.2)) (uniqueDiffOn_Ici a)
+      ⟨ht.1.le, ht.2.le⟩ (mem_Ici.mpr (le_trans hax ht.1.le)))
 
 /-- The integral `∫ₐᵀ (-f') dt → f(a) - L` as `T → ∞`, assuming smoothness on
 `[a, ∞)` and convergence of `f` to `L` at infinity. The derivative is represented as

--- a/TauCeti/Analysis/CompletelyMonotone/BernsteinMeasures.lean
+++ b/TauCeti/Analysis/CompletelyMonotone/BernsteinMeasures.lean
@@ -626,7 +626,7 @@ private lemma integral_chafaiDensity_one_eq (f : ℝ → ℝ) (hcm : IsCompletel
       ∫ t in (0 : ℝ)..T, -iteratedDerivWithin 1 f (Ici 0) t :=
     intervalIntegral.integral_congr_ae (Filter.Eventually.of_forall fun t _ => chafaiDensity_one t)
   rw [h1]
-  exact IsCompletelyMonotone.integral_neg_iteratedDerivWithin_one_Ici_eq_sub hcm le_rfl hT
+  exact IsCompletelyMonotone.integral_neg_iteratedDerivWithin_one_Ici_eq_sub hcm le_rfl hT.le
 
 private lemma integral_chafaiDensity_le_sub (f : ℝ → ℝ) (hcm : IsCompletelyMonotone f)
     (j : ℕ) (hj : 1 ≤ j) (T : ℝ) (hT : 0 < T) :
@@ -1197,7 +1197,8 @@ private lemma chafai_repeated_ibp (f : ℝ → ℝ) (hcm : IsCompletelyMonotone 
       refine Tendsto.congr' ?_ (Tendsto.sub tendsto_const_nhds hL)
       filter_upwards [eventually_gt_atTop (max x 1)] with T hT
       have hxT : x < T := lt_of_le_of_lt (le_max_left x 1) hT
-      exact (IsCompletelyMonotone.integral_neg_iteratedDerivWithin_one_Ici_eq_sub hcm hx hxT).symm
+      exact
+        (IsCompletelyMonotone.integral_neg_iteratedDerivWithin_one_Ici_eq_sub hcm hx hxT.le).symm
     · -- Inductive step `n = k+1`: integrate by parts once and pass to the limit.
       have hk1 : 1 ≤ k := Nat.one_le_iff_ne_zero.mpr hk
       have ih_applied := ih hk1

--- a/TauCeti/Analysis/CompletelyMonotone/BernsteinMeasures.lean
+++ b/TauCeti/Analysis/CompletelyMonotone/BernsteinMeasures.lean
@@ -623,10 +623,12 @@ private lemma integral_chafaiDensity_one_eq (f : ℝ → ℝ) (hcm : IsCompletel
     ∫ t in (0 : ℝ)..T, chafaiDensity f 1 t = f 0 - f T := by
   have h1 : ∫ t in (0 : ℝ)..T, chafaiDensity f 1 t =
       ∫ t in (0 : ℝ)..T, -iteratedDerivWithin 1 f (Ici 0) t :=
-    intervalIntegral.integral_congr_ae
-      (Filter.Eventually.of_forall fun t _ => chafaiDensity_one t)
-  rw [h1, ← hcm.integral_neg_iteratedDerivWithin_one_Icc_eq_Ici T hT.le,
-    hcm.integral_neg_iteratedDerivWithin_one_Icc_zero_left T hT.le]
+    intervalIntegral.integral_congr_ae (Filter.Eventually.of_forall fun t _ => chafaiDensity_one t)
+  rw [h1, ← hcm.integral_neg_iteratedDerivWithin_one_Icc_eq_Ici T hT.le]
+  have hcm_Icc : ContDiffOn ℝ 1 f (Icc 0 T) :=
+    (hcm.contDiffOn.mono Icc_subset_Ici_self).of_le (nat_le_top _)
+  rw [iteratedDerivWithin_one, intervalIntegral.integral_neg,
+    intervalIntegral.integral_derivWithin_Icc_of_contDiffOn_Icc hcm_Icc hT.le, neg_sub]
 
 private lemma integral_chafaiDensity_le_sub (f : ℝ → ℝ) (hcm : IsCompletelyMonotone f)
     (j : ℕ) (hj : 1 ≤ j) (T : ℝ) (hT : 0 < T) :
@@ -1216,10 +1218,12 @@ private lemma chafai_repeated_ibp (f : ℝ → ℝ) (hcm : IsCompletelyMonotone 
       filter_upwards [eventually_gt_atTop (max x 1)] with T hT
       have hxT : x < T := lt_of_le_of_lt (le_max_left x 1) hT
       rw [integral_neg_iteratedDerivWithin_one_Ici_eq_Icc f hcm hx hxT]
-      exact hcm.integral_neg_iteratedDerivWithin_one_Icc x T hx hxT.le
-    · -- Inductive step `n = k+1`: integrate by parts once (`ibp_finite_interval`); the boundary
-      -- term vanishes in the limit (`boundary_term_decay`), leaving the order-`k` integral, which
-      -- the induction hypothesis identifies with `f x - L`.
+      have hcm_Icc : ContDiffOn ℝ 1 f (Icc x T) :=
+        (hcm.contDiffOn.mono
+          (Icc_subset_Ici_self.trans (Ici_subset_Ici.mpr hx))).of_le (nat_le_top _)
+      rw [iteratedDerivWithin_one, intervalIntegral.integral_neg,
+        intervalIntegral.integral_derivWithin_Icc_of_contDiffOn_Icc hcm_Icc hxT.le, neg_sub]
+    · -- Inductive step `n = k+1`: integrate by parts once and pass to the limit.
       have hk1 : 1 ≤ k := Nat.one_le_iff_ne_zero.mpr hk
       have ih_applied := ih hk1
       simp only [show k + 1 - 1 = k by omega]

--- a/TauCeti/Analysis/CompletelyMonotone/BernsteinMeasures.lean
+++ b/TauCeti/Analysis/CompletelyMonotone/BernsteinMeasures.lean
@@ -5,6 +5,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 module
 
 public import Mathlib.Analysis.SpecialFunctions.Complex.LogBounds
+import Mathlib.MeasureTheory.Integral.IntegralEqImproper
 import TauCeti.Analysis.CompletelyMonotone.Closure
 public import TauCeti.Analysis.CompletelyMonotone.Integral
 
@@ -1176,14 +1177,11 @@ private lemma integral_neg_iteratedDerivWithin_one_Ici_eq_Icc
   apply ae_of_all
   intro t ht
   rw [uIoc_of_le hxT.le] at ht
-  have ht_pos : 0 < t := lt_of_le_of_lt hx ht.1
   have hcda : ContDiffAt ℝ (↑1 : WithTop ℕ∞) f t :=
-    (hcm.contDiffOn.of_le (nat_le_top 1)).contDiffAt (Ici_mem_nhds ht_pos)
+    (hcm.contDiffOn.of_le (nat_le_top 1)).contDiffAt
+      (Ici_mem_nhds (lt_of_le_of_lt hx ht.1))
   congr 1
-  rw [iteratedDerivWithin_eq_iteratedDeriv
-      (uniqueDiffOn_Icc hxT) hcda (Ioc_subset_Icc_self ht),
-    iteratedDerivWithin_eq_iteratedDeriv
-      (uniqueDiffOn_Ici 0) hcda (mem_Ici.mpr ht_pos.le)]
+  exact (ContDiffAt.iteratedDerivWithin_Icc_eq_Ici hcda hx hxT ht.1.le ht.2).symm
 
 private lemma chafai_repeated_ibp (f : ℝ → ℝ) (hcm : IsCompletelyMonotone f)
     (n : ℕ) (hn : 1 ≤ n) (x : ℝ) (hx : 0 ≤ x)

--- a/TauCeti/Analysis/CompletelyMonotone/BernsteinMeasures.lean
+++ b/TauCeti/Analysis/CompletelyMonotone/BernsteinMeasures.lean
@@ -5,7 +5,6 @@ Released under Apache 2.0 license as described in the file LICENSE.
 module
 
 public import Mathlib.Analysis.SpecialFunctions.Complex.LogBounds
-import Mathlib.MeasureTheory.Integral.IntervalIntegral.ContDiff
 import Mathlib.MeasureTheory.Integral.IntegralEqImproper
 import TauCeti.Analysis.CompletelyMonotone.Closure
 public import TauCeti.Analysis.CompletelyMonotone.Integral
@@ -620,29 +619,6 @@ lemma chafaiMeasure_zero (f : ℝ → ℝ) : chafaiMeasure f 0 = 0 := by
 lemma chafaiRescaled_zero (f : ℝ → ℝ) : chafaiRescaled f 0 = 0 := by
   rw [chafaiRescaled_eq_map, chafaiMeasure_zero, Measure.map_zero]
 
-private lemma integral_neg_iteratedDerivWithin_one_Ici_eq_sub (hcm : IsCompletelyMonotone f)
-    {x T : ℝ} (hx : 0 ≤ x) (hxT : x < T) :
-    ∫ t in x..T, -iteratedDerivWithin 1 f (Ici 0) t = f x - f T := by
-  have htransfer :
-      ∫ t in x..T, -iteratedDerivWithin 1 f (Icc x T) t =
-      ∫ t in x..T, -iteratedDerivWithin 1 f (Ici 0) t := by
-    apply intervalIntegral.integral_congr_uIoo
-    intro t ht
-    rw [uIoo_of_le hxT.le] at ht
-    have ht_pos : 0 < t := lt_of_le_of_lt hx ht.1
-    have hcda : ContDiffAt ℝ (1 : WithTop ℕ∞) f t :=
-      (hcm.contDiffOn.contDiffAt (Ici_mem_nhds ht_pos)).of_le (nat_le_top _)
-    exact congrArg Neg.neg (by
-      rw [iteratedDerivWithin_eq_iteratedDeriv (uniqueDiffOn_Icc hxT) hcda
-          ⟨ht.1.le, ht.2.le⟩,
-        iteratedDerivWithin_eq_iteratedDeriv (uniqueDiffOn_Ici 0) hcda
-          (mem_Ici.mpr ht_pos.le)])
-  rw [← htransfer]
-  simpa [iteratedDerivWithin_one, intervalIntegral.integral_neg, neg_sub] using
-    congrArg Neg.neg (intervalIntegral.integral_derivWithin_Icc_of_contDiffOn_Icc
-      ((hcm.contDiffOn.mono
-        (Icc_subset_Ici_self.trans (Ici_subset_Ici.mpr hx))).of_le (nat_le_top _)) hxT.le)
-
 private lemma integral_chafaiDensity_one_eq (f : ℝ → ℝ) (hcm : IsCompletelyMonotone f)
     (T : ℝ) (hT : 0 < T) :
     ∫ t in (0 : ℝ)..T, chafaiDensity f 1 t = f 0 - f T := by
@@ -650,7 +626,7 @@ private lemma integral_chafaiDensity_one_eq (f : ℝ → ℝ) (hcm : IsCompletel
       ∫ t in (0 : ℝ)..T, -iteratedDerivWithin 1 f (Ici 0) t :=
     intervalIntegral.integral_congr_ae (Filter.Eventually.of_forall fun t _ => chafaiDensity_one t)
   rw [h1]
-  exact integral_neg_iteratedDerivWithin_one_Ici_eq_sub hcm le_rfl hT
+  exact IsCompletelyMonotone.integral_neg_iteratedDerivWithin_one_Ici_eq_sub hcm le_rfl hT
 
 private lemma integral_chafaiDensity_le_sub (f : ℝ → ℝ) (hcm : IsCompletelyMonotone f)
     (j : ℕ) (hj : 1 ≤ j) (T : ℝ) (hT : 0 < T) :
@@ -1221,7 +1197,7 @@ private lemma chafai_repeated_ibp (f : ℝ → ℝ) (hcm : IsCompletelyMonotone 
       refine Tendsto.congr' ?_ (Tendsto.sub tendsto_const_nhds hL)
       filter_upwards [eventually_gt_atTop (max x 1)] with T hT
       have hxT : x < T := lt_of_le_of_lt (le_max_left x 1) hT
-      exact (integral_neg_iteratedDerivWithin_one_Ici_eq_sub hcm hx hxT).symm
+      exact (IsCompletelyMonotone.integral_neg_iteratedDerivWithin_one_Ici_eq_sub hcm hx hxT).symm
     · -- Inductive step `n = k+1`: integrate by parts once and pass to the limit.
       have hk1 : 1 ≤ k := Nat.one_le_iff_ne_zero.mpr hk
       have ih_applied := ih hk1

--- a/TauCeti/Analysis/CompletelyMonotone/BernsteinMeasures.lean
+++ b/TauCeti/Analysis/CompletelyMonotone/BernsteinMeasures.lean
@@ -619,18 +619,37 @@ lemma chafaiMeasure_zero (f : ℝ → ℝ) : chafaiMeasure f 0 = 0 := by
 lemma chafaiRescaled_zero (f : ℝ → ℝ) : chafaiRescaled f 0 = 0 := by
   rw [chafaiRescaled_eq_map, chafaiMeasure_zero, Measure.map_zero]
 
+private lemma integral_neg_iteratedDerivWithin_one_Ici_eq_sub (hcm : IsCompletelyMonotone f)
+    {x T : ℝ} (hx : 0 ≤ x) (hxT : x < T) :
+    ∫ t in x..T, -iteratedDerivWithin 1 f (Ici 0) t = f x - f T := by
+  have htransfer :
+      ∫ t in x..T, -iteratedDerivWithin 1 f (Icc x T) t =
+      ∫ t in x..T, -iteratedDerivWithin 1 f (Ici 0) t := by
+    apply intervalIntegral.integral_congr_uIoo
+    intro t ht
+    rw [uIoo_of_le hxT.le] at ht
+    have ht_pos : 0 < t := lt_of_le_of_lt hx ht.1
+    have hcda : ContDiffAt ℝ (1 : WithTop ℕ∞) f t :=
+      (hcm.contDiffOn.contDiffAt (Ici_mem_nhds ht_pos)).of_le (nat_le_top _)
+    exact congrArg Neg.neg (by
+      rw [iteratedDerivWithin_eq_iteratedDeriv (uniqueDiffOn_Icc hxT) hcda
+          ⟨ht.1.le, ht.2.le⟩,
+        iteratedDerivWithin_eq_iteratedDeriv (uniqueDiffOn_Ici 0) hcda
+          (mem_Ici.mpr ht_pos.le)])
+  rw [← htransfer]
+  simpa [iteratedDerivWithin_one, intervalIntegral.integral_neg, neg_sub] using
+    congrArg Neg.neg (intervalIntegral.integral_derivWithin_Icc_of_contDiffOn_Icc
+      ((hcm.contDiffOn.mono
+        (Icc_subset_Ici_self.trans (Ici_subset_Ici.mpr hx))).of_le (nat_le_top _)) hxT.le)
+
 private lemma integral_chafaiDensity_one_eq (f : ℝ → ℝ) (hcm : IsCompletelyMonotone f)
     (T : ℝ) (hT : 0 < T) :
     ∫ t in (0 : ℝ)..T, chafaiDensity f 1 t = f 0 - f T := by
   have h1 : ∫ t in (0 : ℝ)..T, chafaiDensity f 1 t =
       ∫ t in (0 : ℝ)..T, -iteratedDerivWithin 1 f (Ici 0) t :=
     intervalIntegral.integral_congr_ae (Filter.Eventually.of_forall fun t _ => chafaiDensity_one t)
-  rw [h1, ← ContDiffOn.integral_neg_iteratedDerivWithin_one_Icc_eq_Ici
-    (fun t ht => (hcm.contDiffOn.contDiffAt (Ici_mem_nhds ht.1)).of_le (nat_le_top _))
-    le_rfl hT.le]
-  simpa [iteratedDerivWithin_one, intervalIntegral.integral_neg, neg_sub] using
-    congrArg Neg.neg (intervalIntegral.integral_derivWithin_Icc_of_contDiffOn_Icc
-      ((hcm.contDiffOn.mono Icc_subset_Ici_self).of_le (nat_le_top _)) hT.le)
+  rw [h1]
+  exact integral_neg_iteratedDerivWithin_one_Ici_eq_sub hcm le_rfl hT
 
 private lemma integral_chafaiDensity_le_sub (f : ℝ → ℝ) (hcm : IsCompletelyMonotone f)
     (j : ℕ) (hj : 1 ≤ j) (T : ℝ) (hT : 0 < T) :
@@ -1201,14 +1220,7 @@ private lemma chafai_repeated_ibp (f : ℝ → ℝ) (hcm : IsCompletelyMonotone 
       refine Tendsto.congr' ?_ (Tendsto.sub tendsto_const_nhds hL)
       filter_upwards [eventually_gt_atTop (max x 1)] with T hT
       have hxT : x < T := lt_of_le_of_lt (le_max_left x 1) hT
-      rw [← ContDiffOn.integral_neg_iteratedDerivWithin_one_Icc_eq_Ici
-        (fun t ht => (hcm.contDiffOn.contDiffAt
-          (Ici_mem_nhds (lt_of_le_of_lt hx ht.1))).of_le (nat_le_top _)) hx hxT.le]
-      simpa [iteratedDerivWithin_one, intervalIntegral.integral_neg, neg_sub] using
-        (congrArg Neg.neg (intervalIntegral.integral_derivWithin_Icc_of_contDiffOn_Icc
-          ((hcm.contDiffOn.mono
-            (Icc_subset_Ici_self.trans (Ici_subset_Ici.mpr hx))).of_le (nat_le_top _))
-          hxT.le)).symm
+      exact (integral_neg_iteratedDerivWithin_one_Ici_eq_sub hcm hx hxT).symm
     · -- Inductive step `n = k+1`: integrate by parts once and pass to the limit.
       have hk1 : 1 ≤ k := Nat.one_le_iff_ne_zero.mpr hk
       have ih_applied := ih hk1

--- a/TauCeti/Analysis/CompletelyMonotone/BernsteinMeasures.lean
+++ b/TauCeti/Analysis/CompletelyMonotone/BernsteinMeasures.lean
@@ -1168,21 +1168,6 @@ private lemma ibp_kernel_integrableOn (f : ℝ → ℝ) (hcm : IsCompletelyMonot
       _ = (-1 : ℝ) ^ k / ↑(k - 1).factorial * t ^ (k - 1) *
           iteratedDerivWithin k f (Ici 0) t := by field_simp
 
-private lemma integral_neg_iteratedDerivWithin_one_Ici_eq_Icc
-    (f : ℝ → ℝ) (hcm : IsCompletelyMonotone f)
-    {x T : ℝ} (hx : 0 ≤ x) (hxT : x < T) :
-    (∫ t in x..T, -iteratedDerivWithin 1 f (Ici 0) t) =
-      ∫ t in x..T, -iteratedDerivWithin 1 f (Icc x T) t := by
-  apply intervalIntegral.integral_congr_ae
-  apply ae_of_all
-  intro t ht
-  rw [uIoc_of_le hxT.le] at ht
-  have hcda : ContDiffAt ℝ (↑1 : WithTop ℕ∞) f t :=
-    (hcm.contDiffOn.of_le (nat_le_top 1)).contDiffAt
-      (Ici_mem_nhds (lt_of_le_of_lt hx ht.1))
-  congr 1
-  exact (ContDiffAt.iteratedDerivWithin_Icc_eq_Ici hcda hx hxT ht.1.le ht.2).symm
-
 private lemma chafai_repeated_ibp (f : ℝ → ℝ) (hcm : IsCompletelyMonotone f)
     (n : ℕ) (hn : 1 ≤ n) (x : ℝ) (hx : 0 ≤ x)
     (L : ℝ) (hL : Tendsto f atTop (nhds L)) :
@@ -1214,7 +1199,9 @@ private lemma chafai_repeated_ibp (f : ℝ → ℝ) (hcm : IsCompletelyMonotone 
       refine Tendsto.congr' ?_ (Tendsto.sub tendsto_const_nhds hL)
       filter_upwards [eventually_gt_atTop (max x 1)] with T hT
       have hxT : x < T := lt_of_le_of_lt (le_max_left x 1) hT
-      rw [integral_neg_iteratedDerivWithin_one_Ici_eq_Icc f hcm hx hxT]
+      rw [← ContDiffOn.integral_neg_iteratedDerivWithin_one_Icc_eq_Ici
+        (fun t ht => (hcm.contDiffOn.contDiffAt
+          (Ici_mem_nhds (lt_of_le_of_lt hx ht.1))).of_le (nat_le_top _)) hx hxT.le]
       simpa [iteratedDerivWithin_one, intervalIntegral.integral_neg, neg_sub] using
         (congrArg Neg.neg (intervalIntegral.integral_derivWithin_Icc_of_contDiffOn_Icc
           ((hcm.contDiffOn.mono

--- a/TauCeti/Analysis/CompletelyMonotone/BernsteinMeasures.lean
+++ b/TauCeti/Analysis/CompletelyMonotone/BernsteinMeasures.lean
@@ -617,6 +617,13 @@ lemma chafaiMeasure_zero (f : ℝ → ℝ) : chafaiMeasure f 0 = 0 := by
 @[simp]
 lemma chafaiRescaled_zero (f : ℝ → ℝ) : chafaiRescaled f 0 = 0 := by
   rw [chafaiRescaled_eq_map, chafaiMeasure_zero, Measure.map_zero]
+private lemma integral_neg_iteratedDerivWithin_one_Icc_eq_sub
+    (f : ℝ → ℝ) (hcm : IsCompletelyMonotone f) {x T : ℝ} (hx : 0 ≤ x) (hxT : x < T) :
+    (∫ t in x..T, -iteratedDerivWithin 1 f (Icc x T) t) = f x - f T := by
+  simpa [iteratedDerivWithin_one, intervalIntegral.integral_neg, neg_sub] using
+    congrArg Neg.neg (intervalIntegral.integral_derivWithin_Icc_of_contDiffOn_Icc
+      ((hcm.contDiffOn.mono
+        (Icc_subset_Ici_self.trans (Ici_subset_Ici.mpr hx))).of_le (nat_le_top _)) hxT.le)
 
 private lemma integral_chafaiDensity_one_eq (f : ℝ → ℝ) (hcm : IsCompletelyMonotone f)
     (T : ℝ) (hT : 0 < T) :
@@ -625,10 +632,7 @@ private lemma integral_chafaiDensity_one_eq (f : ℝ → ℝ) (hcm : IsCompletel
       ∫ t in (0 : ℝ)..T, -iteratedDerivWithin 1 f (Ici 0) t :=
     intervalIntegral.integral_congr_ae (Filter.Eventually.of_forall fun t _ => chafaiDensity_one t)
   rw [h1, ← hcm.integral_neg_iteratedDerivWithin_one_Icc_eq_Ici T hT.le]
-  have hcm_Icc : ContDiffOn ℝ 1 f (Icc 0 T) :=
-    (hcm.contDiffOn.mono Icc_subset_Ici_self).of_le (nat_le_top _)
-  rw [iteratedDerivWithin_one, intervalIntegral.integral_neg,
-    intervalIntegral.integral_derivWithin_Icc_of_contDiffOn_Icc hcm_Icc hT.le, neg_sub]
+  exact integral_neg_iteratedDerivWithin_one_Icc_eq_sub f hcm le_rfl hT
 
 private lemma integral_chafaiDensity_le_sub (f : ℝ → ℝ) (hcm : IsCompletelyMonotone f)
     (j : ℕ) (hj : 1 ≤ j) (T : ℝ) (hT : 0 < T) :
@@ -1218,11 +1222,7 @@ private lemma chafai_repeated_ibp (f : ℝ → ℝ) (hcm : IsCompletelyMonotone 
       filter_upwards [eventually_gt_atTop (max x 1)] with T hT
       have hxT : x < T := lt_of_le_of_lt (le_max_left x 1) hT
       rw [integral_neg_iteratedDerivWithin_one_Ici_eq_Icc f hcm hx hxT]
-      have hcm_Icc : ContDiffOn ℝ 1 f (Icc x T) :=
-        (hcm.contDiffOn.mono
-          (Icc_subset_Ici_self.trans (Ici_subset_Ici.mpr hx))).of_le (nat_le_top _)
-      rw [iteratedDerivWithin_one, intervalIntegral.integral_neg,
-        intervalIntegral.integral_derivWithin_Icc_of_contDiffOn_Icc hcm_Icc hxT.le, neg_sub]
+      exact (integral_neg_iteratedDerivWithin_one_Icc_eq_sub f hcm hx hxT).symm
     · -- Inductive step `n = k+1`: integrate by parts once and pass to the limit.
       have hk1 : 1 ≤ k := Nat.one_le_iff_ne_zero.mpr hk
       have ih_applied := ih hk1

--- a/TauCeti/Analysis/CompletelyMonotone/BernsteinMeasures.lean
+++ b/TauCeti/Analysis/CompletelyMonotone/BernsteinMeasures.lean
@@ -625,7 +625,9 @@ private lemma integral_chafaiDensity_one_eq (f : ℝ → ℝ) (hcm : IsCompletel
   have h1 : ∫ t in (0 : ℝ)..T, chafaiDensity f 1 t =
       ∫ t in (0 : ℝ)..T, -iteratedDerivWithin 1 f (Ici 0) t :=
     intervalIntegral.integral_congr_ae (Filter.Eventually.of_forall fun t _ => chafaiDensity_one t)
-  rw [h1, ← hcm.integral_neg_iteratedDerivWithin_one_Icc_eq_Ici T hT.le]
+  rw [h1, ← ContDiffOn.integral_neg_iteratedDerivWithin_one_Icc_eq_Ici
+    (fun t ht => (hcm.contDiffOn.contDiffAt (Ici_mem_nhds ht.1)).of_le (nat_le_top _))
+    le_rfl hT.le]
   simpa [iteratedDerivWithin_one, intervalIntegral.integral_neg, neg_sub] using
     congrArg Neg.neg (intervalIntegral.integral_derivWithin_Icc_of_contDiffOn_Icc
       ((hcm.contDiffOn.mono Icc_subset_Ici_self).of_le (nat_le_top _)) hT.le)

--- a/TauCeti/Analysis/CompletelyMonotone/BernsteinMeasures.lean
+++ b/TauCeti/Analysis/CompletelyMonotone/BernsteinMeasures.lean
@@ -5,6 +5,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 module
 
 public import Mathlib.Analysis.SpecialFunctions.Complex.LogBounds
+import Mathlib.MeasureTheory.Integral.IntervalIntegral.ContDiff
 import Mathlib.MeasureTheory.Integral.IntegralEqImproper
 import TauCeti.Analysis.CompletelyMonotone.Closure
 public import TauCeti.Analysis.CompletelyMonotone.Integral

--- a/TauCeti/Analysis/CompletelyMonotone/BernsteinMeasures.lean
+++ b/TauCeti/Analysis/CompletelyMonotone/BernsteinMeasures.lean
@@ -617,13 +617,6 @@ lemma chafaiMeasure_zero (f : ℝ → ℝ) : chafaiMeasure f 0 = 0 := by
 @[simp]
 lemma chafaiRescaled_zero (f : ℝ → ℝ) : chafaiRescaled f 0 = 0 := by
   rw [chafaiRescaled_eq_map, chafaiMeasure_zero, Measure.map_zero]
-private lemma integral_neg_iteratedDerivWithin_one_Icc_eq_sub
-    (f : ℝ → ℝ) (hcm : IsCompletelyMonotone f) {x T : ℝ} (hx : 0 ≤ x) (hxT : x < T) :
-    (∫ t in x..T, -iteratedDerivWithin 1 f (Icc x T) t) = f x - f T := by
-  simpa [iteratedDerivWithin_one, intervalIntegral.integral_neg, neg_sub] using
-    congrArg Neg.neg (intervalIntegral.integral_derivWithin_Icc_of_contDiffOn_Icc
-      ((hcm.contDiffOn.mono
-        (Icc_subset_Ici_self.trans (Ici_subset_Ici.mpr hx))).of_le (nat_le_top _)) hxT.le)
 
 private lemma integral_chafaiDensity_one_eq (f : ℝ → ℝ) (hcm : IsCompletelyMonotone f)
     (T : ℝ) (hT : 0 < T) :
@@ -632,7 +625,9 @@ private lemma integral_chafaiDensity_one_eq (f : ℝ → ℝ) (hcm : IsCompletel
       ∫ t in (0 : ℝ)..T, -iteratedDerivWithin 1 f (Ici 0) t :=
     intervalIntegral.integral_congr_ae (Filter.Eventually.of_forall fun t _ => chafaiDensity_one t)
   rw [h1, ← hcm.integral_neg_iteratedDerivWithin_one_Icc_eq_Ici T hT.le]
-  exact integral_neg_iteratedDerivWithin_one_Icc_eq_sub f hcm le_rfl hT
+  simpa [iteratedDerivWithin_one, intervalIntegral.integral_neg, neg_sub] using
+    congrArg Neg.neg (intervalIntegral.integral_derivWithin_Icc_of_contDiffOn_Icc
+      ((hcm.contDiffOn.mono Icc_subset_Ici_self).of_le (nat_le_top _)) hT.le)
 
 private lemma integral_chafaiDensity_le_sub (f : ℝ → ℝ) (hcm : IsCompletelyMonotone f)
     (j : ℕ) (hj : 1 ≤ j) (T : ℝ) (hT : 0 < T) :
@@ -1222,7 +1217,11 @@ private lemma chafai_repeated_ibp (f : ℝ → ℝ) (hcm : IsCompletelyMonotone 
       filter_upwards [eventually_gt_atTop (max x 1)] with T hT
       have hxT : x < T := lt_of_le_of_lt (le_max_left x 1) hT
       rw [integral_neg_iteratedDerivWithin_one_Ici_eq_Icc f hcm hx hxT]
-      exact (integral_neg_iteratedDerivWithin_one_Icc_eq_sub f hcm hx hxT).symm
+      simpa [iteratedDerivWithin_one, intervalIntegral.integral_neg, neg_sub] using
+        (congrArg Neg.neg (intervalIntegral.integral_derivWithin_Icc_of_contDiffOn_Icc
+          ((hcm.contDiffOn.mono
+            (Icc_subset_Ici_self.trans (Ici_subset_Ici.mpr hx))).of_le (nat_le_top _))
+          hxT.le)).symm
     · -- Inductive step `n = k+1`: integrate by parts once and pass to the limit.
       have hk1 : 1 ≤ k := Nat.one_le_iff_ne_zero.mpr hk
       have ih_applied := ih hk1

--- a/TauCeti/Analysis/CompletelyMonotone/Integral.lean
+++ b/TauCeti/Analysis/CompletelyMonotone/Integral.lean
@@ -10,21 +10,15 @@ public import TauCeti.Analysis.CompletelyMonotone.Basic
 /-!
 # Integral lemmas for completely monotone functions
 
-FTC wrappers, Taylor-remainder sign bounds, and improper-integral facts about completely monotone
-functions.
+Taylor-remainder sign bounds and improper-integral facts about completely monotone functions.
 
 These extend the object API in `CompletelyMonotone/Basic.lean` with the sign of the Taylor
-integral remainder, finite-interval fundamental-theorem identities specialized to completely
-monotone functions, and improper-integral facts for the first derivative within `[0, ∞)`.
+integral remainder and improper-integral facts for the first derivative within `[0, ∞)`.
 
 ## Main declarations
 
 * `TauCeti.IsCompletelyMonotone.neg_one_pow_mul_taylor_remainder_nonneg`: the Taylor integral
   remainder has sign `(-1)ⁿ`.
-* `TauCeti.IsCompletelyMonotone.integral_neg_iteratedDerivWithin_one_Icc`,
-  `TauCeti.IsCompletelyMonotone.integral_neg_iteratedDerivWithin_one_Icc_zero_left`:
-  finite-interval fundamental-theorem identities specialized to completely monotone
-  functions.
 * `TauCeti.IsCompletelyMonotone.integral_neg_iteratedDerivWithin_one_Icc_eq_Ici`:
   transfer of the first-derivative integral from the interval-dependent differentiability set
   `Icc 0 T` to the fixed half-line `Ici 0`.
@@ -52,17 +46,6 @@ variable {f : ℝ → ℝ}
 
 namespace IsCompletelyMonotone
 
-/-- `iteratedDerivWithin` on `Icc x T` agrees with `iteratedDerivWithin` on `Ici 0` at interior
-points, since both equal `iteratedDeriv n f t` when `0 < t`. -/
-lemma iteratedDerivWithin_Icc_eq_Ici {n : ℕ} (hf : IsCompletelyMonotone f)
-    {x T t : ℝ} (ht_pos : 0 < t) (ht : t ∈ Ioo x T) :
-    iteratedDerivWithin n f (Icc x T) t = iteratedDerivWithin n f (Ici 0) t := by
-  have hcda : ContDiffAt ℝ (n : WithTop ℕ∞) f t :=
-    (hf.contDiffOn.contDiffAt (Ici_mem_nhds ht_pos)).of_le (by exact_mod_cast le_top)
-  rw [iteratedDerivWithin_eq_iteratedDeriv (uniqueDiffOn_Icc (lt_trans ht.1 ht.2)) hcda
-        (Ioo_subset_Icc_self ht),
-      ← iteratedDerivWithin_eq_iteratedDeriv (uniqueDiffOn_Ici 0) hcda (mem_Ici.mpr ht_pos.le)]
-
 /-- **CM sign of the Taylor remainder.** For a completely monotone function the Taylor
 integral remainder `∫ₓᵀ (T-t)ⁿ⁻¹/(n-1)! · f⁽ⁿ⁾(t) dt` has sign `(-1)ⁿ`:
 `0 ≤ (-1)ⁿ` times it. -/
@@ -80,33 +63,21 @@ lemma neg_one_pow_mul_taylor_remainder_nonneg (hf : IsCompletelyMonotone f) {x T
           ((-1 : ℝ) ^ n * iteratedDerivWithin n f (Icc x T) t) :=
           mul_nonneg (mul_nonneg (inv_nonneg.mpr (Nat.cast_nonneg _))
             (pow_nonneg (sub_nonneg.mpr ht.2.le) _))
-            (by rw [hf.iteratedDerivWithin_Icc_eq_Ici (lt_of_le_of_lt hx ht.1) ht]
-                exact hf.neg_one_pow_mul_iteratedDerivWithin_nonneg n
-                  (lt_of_le_of_lt hx ht.1).le)
+            (by
+              have ht_pos : 0 < t := lt_of_le_of_lt hx ht.1
+              have hcda : ContDiffAt ℝ (n : WithTop ℕ∞) f t :=
+                (hf.contDiffOn.contDiffAt (Ici_mem_nhds ht_pos)).of_le (by
+                  exact_mod_cast le_top)
+              rw [iteratedDerivWithin_eq_iteratedDeriv
+                    (uniqueDiffOn_Icc (lt_trans ht.1 ht.2)) hcda (Ioo_subset_Icc_self ht),
+                  ← iteratedDerivWithin_eq_iteratedDeriv (uniqueDiffOn_Ici 0) hcda
+                    (mem_Ici.mpr ht_pos.le)]
+              exact hf.neg_one_pow_mul_iteratedDerivWithin_nonneg n ht_pos.le)
       _ = _ := by ring
   have h_mem : ∀ᵐ t ∂volume.restrict (Icc x T), t ∈ Ioo x T := by
     rw [ae_restrict_iff' measurableSet_Icc]
     exact (Ioo_ae_eq_Icc (a := x) (b := T)).mono (fun t h ht => h.mpr ht)
   exact h_mem.mono fun t ht => by simp only [Pi.zero_apply]; exact hIoo t ht
-
-/-- For a completely monotone `f` the `n = 1` fundamental-theorem identity gives
-`f(x) - f(T) = ∫ₓᵀ (-f'(t)) dt`, with `f'` represented by `iteratedDerivWithin 1` on
-`Icc x T`. -/
-lemma integral_neg_iteratedDerivWithin_one_Icc (hf : IsCompletelyMonotone f)
-    (x T : ℝ) (hx : 0 ≤ x) (hxT : x ≤ T) :
-    f x - f T = ∫ t in x..T, -iteratedDerivWithin 1 f (Icc x T) t := by
-  have hsubset : Icc x T ⊆ Ici 0 := Icc_subset_Ici_self.trans (Ici_subset_Ici.mpr hx)
-  have hcm_Icc : ContDiffOn ℝ 1 f (Icc x T) :=
-    (hf.contDiffOn.mono hsubset).of_le (by exact_mod_cast le_top)
-  rw [iteratedDerivWithin_one, intervalIntegral.integral_neg,
-    intervalIntegral.integral_derivWithin_Icc_of_contDiffOn_Icc hcm_Icc hxT, neg_sub]
-
-/-- The zero-left integral identity `∫₀ᵀ (-f') = f(0) - f(T)` for a completely monotone
-function. -/
-lemma integral_neg_iteratedDerivWithin_one_Icc_zero_left
-    (hf : IsCompletelyMonotone f) (T : ℝ) (hT : 0 ≤ T) :
-    ∫ t in (0 : ℝ)..T, -iteratedDerivWithin 1 f (Icc 0 T) t = f 0 - f T := by
-  exact (hf.integral_neg_iteratedDerivWithin_one_Icc 0 T le_rfl hT).symm
 
 end IsCompletelyMonotone
 
@@ -169,8 +140,11 @@ lemma IsCompletelyMonotone.neg_iteratedDerivWithin_one_integrableOn
           rw [uIoc_of_le hT.le] at ht
           simp only [Real.norm_eq_abs]
           rw [abs_of_nonneg (by linarith [hcm.iteratedDerivWithin_one_nonpos ht.1.le])])
-      rw [this, ← hcm.integral_neg_iteratedDerivWithin_one_Icc_eq_Ici T hT.le,
-        hcm.integral_neg_iteratedDerivWithin_one_Icc_zero_left T hT.le]
+      rw [this, ← hcm.integral_neg_iteratedDerivWithin_one_Icc_eq_Ici T hT.le]
+      have hcm_Icc : ContDiffOn ℝ 1 f (Icc 0 T) :=
+        (hcm.contDiffOn.mono Icc_subset_Ici_self).of_le (nat_le_top _)
+      rw [iteratedDerivWithin_one, intervalIntegral.integral_neg,
+        intervalIntegral.integral_derivWithin_Icc_of_contDiffOn_Icc hcm_Icc hT.le, neg_sub]
     exact Tendsto.congr' (EventuallyEq.symm hnorm) (Tendsto.sub tendsto_const_nhds hL)
 
 /-- The improper integral `∫₀^∞ (-f') dt = f(0) - L` for completely monotone functions. -/
@@ -183,8 +157,13 @@ lemma IsCompletelyMonotone.integral_Ioi_neg_iteratedDerivWithin_one
       -iteratedDerivWithin 1 f (Ici 0) t) atTop (nhds (f 0 - L)) :=
     Tendsto.congr'
       ((eventually_gt_atTop 0).mono fun T hT =>
-        ((hcm.integral_neg_iteratedDerivWithin_one_Icc_eq_Ici T hT.le).symm.trans
-          (hcm.integral_neg_iteratedDerivWithin_one_Icc_zero_left T hT.le)).symm)
+        by
+          simp only
+          rw [← hcm.integral_neg_iteratedDerivWithin_one_Icc_eq_Ici T hT.le]
+          have hcm_Icc : ContDiffOn ℝ 1 f (Icc 0 T) :=
+            (hcm.contDiffOn.mono Icc_subset_Ici_self).of_le (nat_le_top _)
+          rw [iteratedDerivWithin_one, intervalIntegral.integral_neg,
+            intervalIntegral.integral_derivWithin_Icc_of_contDiffOn_Icc hcm_Icc hT.le, neg_sub])
       (Tendsto.sub tendsto_const_nhds hL)
   exact tendsto_nhds_unique htend htend2
 

--- a/TauCeti/Analysis/CompletelyMonotone/Integral.lean
+++ b/TauCeti/Analysis/CompletelyMonotone/Integral.lean
@@ -47,13 +47,18 @@ private lemma nat_le_top (n : ℕ) : (n : WithTop ℕ∞) ≤ ∞ := by exact_mo
 
 /-- For a completely monotone function the `n`-th iterated derivative within a compact interval
 `[x, T]` agrees with the one taken within the half-line `[0, ∞)` at any strictly positive interior
-point. Complete monotonicity supplies the local `ContDiffAt` hypothesis; the set comparison itself
-is `ContDiffAt.iteratedDerivWithin_Icc_eq_Ici`. -/
+point. Complete monotonicity supplies the local `ContDiffAt` hypothesis, and both sides reduce to
+the unrestricted iterated derivative at `t`. -/
 private lemma IsCompletelyMonotone.iteratedDerivWithin_Icc_eq_Ici (hf : IsCompletelyMonotone f)
     {x T t : ℝ} {n : ℕ} (ht_pos : 0 < t) (ht : t ∈ Ioo x T) :
-    iteratedDerivWithin n f (Icc x T) t = iteratedDerivWithin n f (Ici 0) t :=
-  ContDiffAt.iteratedDerivWithin_Icc_eq_Ici
-    ((hf.contDiffOn.contDiffAt (Ici_mem_nhds ht_pos)).of_le (nat_le_top _)) ht_pos ht
+    iteratedDerivWithin n f (Icc x T) t = iteratedDerivWithin n f (Ici 0) t := by
+  have hcont : ContDiffAt ℝ (n : WithTop ℕ∞) f t :=
+    (hf.contDiffOn.contDiffAt (Ici_mem_nhds ht_pos)).of_le (nat_le_top _)
+  have hxT : x < T := lt_trans ht.1 ht.2
+  rw [iteratedDerivWithin_eq_iteratedDeriv (uniqueDiffOn_Icc hxT) hcont
+        (Ioo_subset_Icc_self ht),
+      ← iteratedDerivWithin_eq_iteratedDeriv (uniqueDiffOn_Ici 0) hcont
+        (mem_Ici.mpr ht_pos.le)]
 
 namespace IsCompletelyMonotone
 
@@ -98,21 +103,24 @@ private lemma IsCompletelyMonotone.iteratedDerivWithin_one_nonpos
 /-- On a compact interval in `[0, ∞)`, the integral of `-f'` for a completely monotone
 function is the endpoint drop, with the derivative taken within `[0, ∞)`. -/
 lemma IsCompletelyMonotone.integral_neg_iteratedDerivWithin_one_Ici_eq_sub
-    (hcm : IsCompletelyMonotone f) {x T : ℝ} (hx : 0 ≤ x) (hxT : x < T) :
+    (hcm : IsCompletelyMonotone f) {x T : ℝ} (hx : 0 ≤ x) (hxT : x ≤ T) :
     ∫ t in x..T, -iteratedDerivWithin 1 f (Ici 0) t = f x - f T := by
+  by_cases h_eq : x = T
+  · subst T
+    simp
   have htransfer :
       ∫ t in x..T, -iteratedDerivWithin 1 f (Icc x T) t =
       ∫ t in x..T, -iteratedDerivWithin 1 f (Ici 0) t := by
     apply intervalIntegral.integral_congr_uIoo
     intro t ht
-    rw [uIoo_of_le hxT.le] at ht
+    rw [uIoo_of_le hxT] at ht
     have ht_pos : 0 < t := lt_of_le_of_lt hx ht.1
     exact congrArg Neg.neg (hcm.iteratedDerivWithin_Icc_eq_Ici ht_pos ht)
   rw [← htransfer]
   simpa [iteratedDerivWithin_one, intervalIntegral.integral_neg, neg_sub] using
     congrArg Neg.neg (intervalIntegral.integral_derivWithin_Icc_of_contDiffOn_Icc
       ((hcm.contDiffOn.mono
-        (Icc_subset_Ici_self.trans (Ici_subset_Ici.mpr hx))).of_le (nat_le_top _)) hxT.le)
+        (Icc_subset_Ici_self.trans (Ici_subset_Ici.mpr hx))).of_le (nat_le_top _)) hxT)
 
 /-- `-f'` is integrable on `(0, ∞)` for a completely monotone function, where the derivative is
 taken within the closed half-line `[0, ∞)`. -/

--- a/TauCeti/Analysis/CompletelyMonotone/Integral.lean
+++ b/TauCeti/Analysis/CompletelyMonotone/Integral.lean
@@ -5,7 +5,8 @@ Released under Apache 2.0 license as described in the file LICENSE.
 module
 
 import Mathlib.MeasureTheory.Integral.IntegralEqImproper
-public import Mathlib.MeasureTheory.Integral.IntervalIntegral.ContDiff
+import Mathlib.MeasureTheory.Integral.IntervalIntegral.ContDiff
+public import Mathlib.MeasureTheory.Integral.IntervalIntegral.Basic
 public import TauCeti.Analysis.CompletelyMonotone.Basic
 
 /-!
@@ -89,6 +90,31 @@ private lemma IsCompletelyMonotone.iteratedDerivWithin_one_nonpos
     (hf : IsCompletelyMonotone f) {t : ℝ} (ht : 0 ≤ t) :
     iteratedDerivWithin 1 f (Ici 0) t ≤ 0 := by
   rw [iteratedDerivWithin_one]; exact hf.derivWithin_nonpos ht
+
+/-- On a compact interval in `[0, ∞)`, the integral of `-f'` for a completely monotone
+function is the endpoint drop, with the derivative taken within `[0, ∞)`. -/
+lemma IsCompletelyMonotone.integral_neg_iteratedDerivWithin_one_Ici_eq_sub
+    (hcm : IsCompletelyMonotone f) {x T : ℝ} (hx : 0 ≤ x) (hxT : x < T) :
+    ∫ t in x..T, -iteratedDerivWithin 1 f (Ici 0) t = f x - f T := by
+  have htransfer :
+      ∫ t in x..T, -iteratedDerivWithin 1 f (Icc x T) t =
+      ∫ t in x..T, -iteratedDerivWithin 1 f (Ici 0) t := by
+    apply intervalIntegral.integral_congr_uIoo
+    intro t ht
+    rw [uIoo_of_le hxT.le] at ht
+    have ht_pos : 0 < t := lt_of_le_of_lt hx ht.1
+    have hcda : ContDiffAt ℝ (1 : WithTop ℕ∞) f t :=
+      (hcm.contDiffOn.contDiffAt (Ici_mem_nhds ht_pos)).of_le (nat_le_top _)
+    exact congrArg Neg.neg (by
+      rw [iteratedDerivWithin_eq_iteratedDeriv (uniqueDiffOn_Icc hxT) hcda
+          ⟨ht.1.le, ht.2.le⟩,
+        iteratedDerivWithin_eq_iteratedDeriv (uniqueDiffOn_Ici 0) hcda
+          (mem_Ici.mpr ht_pos.le)])
+  rw [← htransfer]
+  simpa [iteratedDerivWithin_one, intervalIntegral.integral_neg, neg_sub] using
+    congrArg Neg.neg (intervalIntegral.integral_derivWithin_Icc_of_contDiffOn_Icc
+      ((hcm.contDiffOn.mono
+        (Icc_subset_Ici_self.trans (Ici_subset_Ici.mpr hx))).of_le (nat_le_top _)) hxT.le)
 
 /-- `-f'` is integrable on `(0, ∞)` for a completely monotone function, where the derivative is
 taken within the closed half-line `[0, ∞)`. -/

--- a/TauCeti/Analysis/CompletelyMonotone/Integral.lean
+++ b/TauCeti/Analysis/CompletelyMonotone/Integral.lean
@@ -67,11 +67,8 @@ lemma neg_one_pow_mul_taylor_remainder_nonneg (hf : IsCompletelyMonotone f) {x T
               have hcda : ContDiffAt ℝ (n : WithTop ℕ∞) f t :=
                 (hf.contDiffOn.contDiffAt (Ici_mem_nhds ht_pos)).of_le (by
                   exact_mod_cast le_top)
-              rw [iteratedDerivWithin_eq_iteratedDeriv
-                (uniqueDiffOn_Icc (lt_trans ht.1 ht.2)) hcda ⟨ht.1.le, ht.2.le⟩]
-              simpa [iteratedDerivWithin_eq_iteratedDeriv (uniqueDiffOn_Ici 0) hcda
-                (mem_Ici.mpr ht_pos.le)] using
-                hf.neg_one_pow_mul_iteratedDerivWithin_nonneg n ht_pos.le)
+              rw [ContDiffAt.iteratedDerivWithin_Icc_eq_Ici hcda ht_pos ht]
+              exact hf.neg_one_pow_mul_iteratedDerivWithin_nonneg n ht_pos.le)
       _ = _ := by ring
   have h_mem : ∀ᵐ t ∂volume.restrict (Icc x T), t ∈ Ioo x T := by
     rw [ae_restrict_iff' measurableSet_Icc]
@@ -105,11 +102,7 @@ lemma IsCompletelyMonotone.integral_neg_iteratedDerivWithin_one_Ici_eq_sub
     have ht_pos : 0 < t := lt_of_le_of_lt hx ht.1
     have hcda : ContDiffAt ℝ (1 : WithTop ℕ∞) f t :=
       (hcm.contDiffOn.contDiffAt (Ici_mem_nhds ht_pos)).of_le (nat_le_top _)
-    exact congrArg Neg.neg (by
-      rw [iteratedDerivWithin_eq_iteratedDeriv (uniqueDiffOn_Icc hxT) hcda
-          ⟨ht.1.le, ht.2.le⟩,
-        iteratedDerivWithin_eq_iteratedDeriv (uniqueDiffOn_Ici 0) hcda
-          (mem_Ici.mpr ht_pos.le)])
+    exact congrArg Neg.neg (ContDiffAt.iteratedDerivWithin_Icc_eq_Ici hcda ht_pos ht)
   rw [← htransfer]
   simpa [iteratedDerivWithin_one, intervalIntegral.integral_neg, neg_sub] using
     congrArg Neg.neg (intervalIntegral.integral_derivWithin_Icc_of_contDiffOn_Icc

--- a/TauCeti/Analysis/CompletelyMonotone/Integral.lean
+++ b/TauCeti/Analysis/CompletelyMonotone/Integral.lean
@@ -46,6 +46,13 @@ variable {f : ℝ → ℝ}
 
 namespace IsCompletelyMonotone
 
+private lemma iteratedDerivWithin_Icc_eq_Ici {n : ℕ} {x T t : ℝ}
+    (hf : ContDiffAt ℝ (n : WithTop ℕ∞) f t) (ht0 : 0 ≤ t) (hxT : x < T)
+    (hxt : x ≤ t) (htT : t ≤ T) :
+    iteratedDerivWithin n f (Icc x T) t = iteratedDerivWithin n f (Ici 0) t := by
+  rw [iteratedDerivWithin_eq_iteratedDeriv (uniqueDiffOn_Icc hxT) hf ⟨hxt, htT⟩,
+    iteratedDerivWithin_eq_iteratedDeriv (uniqueDiffOn_Ici 0) hf (mem_Ici.mpr ht0)]
+
 /-- **CM sign of the Taylor remainder.** For a completely monotone function the Taylor
 integral remainder `∫ₓᵀ (T-t)ⁿ⁻¹/(n-1)! · f⁽ⁿ⁾(t) dt` has sign `(-1)ⁿ`:
 `0 ≤ (-1)ⁿ` times it. -/
@@ -68,10 +75,8 @@ lemma neg_one_pow_mul_taylor_remainder_nonneg (hf : IsCompletelyMonotone f) {x T
               have hcda : ContDiffAt ℝ (n : WithTop ℕ∞) f t :=
                 (hf.contDiffOn.contDiffAt (Ici_mem_nhds ht_pos)).of_le (by
                   exact_mod_cast le_top)
-              rw [iteratedDerivWithin_eq_iteratedDeriv
-                    (uniqueDiffOn_Icc (lt_trans ht.1 ht.2)) hcda (Ioo_subset_Icc_self ht),
-                  ← iteratedDerivWithin_eq_iteratedDeriv (uniqueDiffOn_Ici 0) hcda
-                    (mem_Ici.mpr ht_pos.le)]
+              rw [iteratedDerivWithin_Icc_eq_Ici hcda ht_pos.le (lt_trans ht.1 ht.2)
+                ht.1.le ht.2.le]
               exact hf.neg_one_pow_mul_iteratedDerivWithin_nonneg n ht_pos.le)
       _ = _ := by ring
   have h_mem : ∀ᵐ t ∂volume.restrict (Icc x T), t ∈ Ioo x T := by

--- a/TauCeti/Analysis/CompletelyMonotone/Integral.lean
+++ b/TauCeti/Analysis/CompletelyMonotone/Integral.lean
@@ -43,6 +43,18 @@ namespace TauCeti
 
 variable {f : ℝ → ℝ}
 
+private lemma nat_le_top (n : ℕ) : (n : WithTop ℕ∞) ≤ ∞ := by exact_mod_cast le_top
+
+/-- For a completely monotone function the `n`-th iterated derivative within a compact interval
+`[x, T]` agrees with the one taken within the half-line `[0, ∞)` at any strictly positive interior
+point. Complete monotonicity supplies the local `ContDiffAt` hypothesis; the set comparison itself
+is `ContDiffAt.iteratedDerivWithin_Icc_eq_Ici`. -/
+private lemma IsCompletelyMonotone.iteratedDerivWithin_Icc_eq_Ici (hf : IsCompletelyMonotone f)
+    {x T t : ℝ} {n : ℕ} (ht_pos : 0 < t) (ht : t ∈ Ioo x T) :
+    iteratedDerivWithin n f (Icc x T) t = iteratedDerivWithin n f (Ici 0) t :=
+  ContDiffAt.iteratedDerivWithin_Icc_eq_Ici
+    ((hf.contDiffOn.contDiffAt (Ici_mem_nhds ht_pos)).of_le (nat_le_top _)) ht_pos ht
+
 namespace IsCompletelyMonotone
 
 /-- **CM sign of the Taylor remainder.** For a completely monotone function the Taylor
@@ -64,10 +76,7 @@ lemma neg_one_pow_mul_taylor_remainder_nonneg (hf : IsCompletelyMonotone f) {x T
             (pow_nonneg (sub_nonneg.mpr ht.2.le) _))
             (by
               have ht_pos : 0 < t := lt_of_le_of_lt hx ht.1
-              have hcda : ContDiffAt ℝ (n : WithTop ℕ∞) f t :=
-                (hf.contDiffOn.contDiffAt (Ici_mem_nhds ht_pos)).of_le (by
-                  exact_mod_cast le_top)
-              rw [ContDiffAt.iteratedDerivWithin_Icc_eq_Ici hcda ht_pos ht]
+              rw [hf.iteratedDerivWithin_Icc_eq_Ici ht_pos ht]
               exact hf.neg_one_pow_mul_iteratedDerivWithin_nonneg n ht_pos.le)
       _ = _ := by ring
   have h_mem : ∀ᵐ t ∂volume.restrict (Icc x T), t ∈ Ioo x T := by
@@ -78,8 +87,6 @@ lemma neg_one_pow_mul_taylor_remainder_nonneg (hf : IsCompletelyMonotone f) {x T
 end IsCompletelyMonotone
 
 /-! ## Smoothness-index helpers -/
-
-private lemma nat_le_top (n : ℕ) : (n : WithTop ℕ∞) ≤ ∞ := by exact_mod_cast le_top
 
 /-- The first iterated derivative within `[0, ∞)` of a completely monotone function is
 nonpositive (the `derivWithin` sign condition restated for `iteratedDerivWithin 1`). -/
@@ -100,9 +107,7 @@ lemma IsCompletelyMonotone.integral_neg_iteratedDerivWithin_one_Ici_eq_sub
     intro t ht
     rw [uIoo_of_le hxT.le] at ht
     have ht_pos : 0 < t := lt_of_le_of_lt hx ht.1
-    have hcda : ContDiffAt ℝ (1 : WithTop ℕ∞) f t :=
-      (hcm.contDiffOn.contDiffAt (Ici_mem_nhds ht_pos)).of_le (nat_le_top _)
-    exact congrArg Neg.neg (ContDiffAt.iteratedDerivWithin_Icc_eq_Ici hcda ht_pos ht)
+    exact congrArg Neg.neg (hcm.iteratedDerivWithin_Icc_eq_Ici ht_pos ht)
   rw [← htransfer]
   simpa [iteratedDerivWithin_one, intervalIntegral.integral_neg, neg_sub] using
     congrArg Neg.neg (intervalIntegral.integral_derivWithin_Icc_of_contDiffOn_Icc

--- a/TauCeti/Analysis/CompletelyMonotone/Integral.lean
+++ b/TauCeti/Analysis/CompletelyMonotone/Integral.lean
@@ -12,15 +12,19 @@ public import TauCeti.Analysis.CompletelyMonotone.Basic
 /-!
 # Integral lemmas for completely monotone functions
 
-Taylor-remainder sign bounds and improper-integral facts about completely monotone functions.
+Taylor-remainder sign bounds and finite- and improper-integral facts about completely monotone
+functions.
 
 These extend the object API in `CompletelyMonotone/Basic.lean` with the sign of the Taylor
-integral remainder and improper-integral facts for the first derivative within `[0, ∞)`.
+integral remainder, the finite-interval integral-of-`(-f')` identity, and improper-integral facts
+for the first derivative within `[0, ∞)`.
 
 ## Main declarations
 
 * `TauCeti.IsCompletelyMonotone.neg_one_pow_mul_taylor_remainder_nonneg`: the Taylor integral
   remainder has sign `(-1)ⁿ`.
+* `TauCeti.IsCompletelyMonotone.integral_neg_iteratedDerivWithin_one_Ici_eq_sub`: on a compact
+  interval in `[0, ∞)`, the integral of `-f'` is the endpoint drop `f x - f T`.
 * `TauCeti.IsCompletelyMonotone.neg_iteratedDerivWithin_one_integrableOn`,
   `TauCeti.IsCompletelyMonotone.integral_Ioi_neg_iteratedDerivWithin_one`: integrability and the
   improper integral of `-f'` on `(0, ∞)`, represented as `iteratedDerivWithin 1`.

--- a/TauCeti/Analysis/CompletelyMonotone/Integral.lean
+++ b/TauCeti/Analysis/CompletelyMonotone/Integral.lean
@@ -23,7 +23,8 @@ monotone functions, and improper-integral facts for the first derivative within 
   remainder has sign `(-1)ⁿ`.
 * `TauCeti.IsCompletelyMonotone.integral_neg_iteratedDerivWithin_one_Icc`,
   `TauCeti.IsCompletelyMonotone.integral_neg_iteratedDerivWithin_one_Icc_zero_left`:
-  compatibility wrappers for the smooth finite-interval identities.
+  finite-interval fundamental-theorem identities specialized to completely monotone
+  functions.
 * `TauCeti.IsCompletelyMonotone.integral_neg_iteratedDerivWithin_one_Icc_eq_Ici`:
   transfer of the first-derivative integral from the interval-dependent differentiability set
   `Icc 0 T` to the fixed half-line `Ici 0`.
@@ -58,7 +59,9 @@ lemma iteratedDerivWithin_Icc_eq_Ici {n : ℕ} (hf : IsCompletelyMonotone f)
     iteratedDerivWithin n f (Icc x T) t = iteratedDerivWithin n f (Ici 0) t := by
   have hcda : ContDiffAt ℝ (n : WithTop ℕ∞) f t :=
     (hf.contDiffOn.contDiffAt (Ici_mem_nhds ht_pos)).of_le (by exact_mod_cast le_top)
-  exact ContDiffAt.iteratedDerivWithin_Icc_eq_Ici (a := 0) hcda ht_pos ht
+  rw [iteratedDerivWithin_eq_iteratedDeriv (uniqueDiffOn_Icc (lt_trans ht.1 ht.2)) hcda
+        (Ioo_subset_Icc_self ht),
+      ← iteratedDerivWithin_eq_iteratedDeriv (uniqueDiffOn_Ici 0) hcda (mem_Ici.mpr ht_pos.le)]
 
 /-- **CM sign of the Taylor remainder.** For a completely monotone function the Taylor
 integral remainder `∫ₓᵀ (T-t)ⁿ⁻¹/(n-1)! · f⁽ⁿ⁾(t) dt` has sign `(-1)ⁿ`:
@@ -95,7 +98,8 @@ lemma integral_neg_iteratedDerivWithin_one_Icc (hf : IsCompletelyMonotone f)
   have hsubset : Icc x T ⊆ Ici 0 := Icc_subset_Ici_self.trans (Ici_subset_Ici.mpr hx)
   have hcm_Icc : ContDiffOn ℝ 1 f (Icc x T) :=
     (hf.contDiffOn.mono hsubset).of_le (by exact_mod_cast le_top)
-  exact ContDiffOn.integral_neg_iteratedDerivWithin_one_Icc hcm_Icc hxT
+  rw [iteratedDerivWithin_one, intervalIntegral.integral_neg,
+    intervalIntegral.integral_derivWithin_Icc_of_contDiffOn_Icc hcm_Icc hxT, neg_sub]
 
 /-- The zero-left integral identity `∫₀ᵀ (-f') = f(0) - f(T)` for a completely monotone
 function. -/

--- a/TauCeti/Analysis/CompletelyMonotone/Integral.lean
+++ b/TauCeti/Analysis/CompletelyMonotone/Integral.lean
@@ -19,9 +19,6 @@ integral remainder and improper-integral facts for the first derivative within `
 
 * `TauCeti.IsCompletelyMonotone.neg_one_pow_mul_taylor_remainder_nonneg`: the Taylor integral
   remainder has sign `(-1)ⁿ`.
-* `TauCeti.IsCompletelyMonotone.integral_neg_iteratedDerivWithin_one_Icc_eq_Ici`:
-  transfer of the first-derivative integral from the interval-dependent differentiability set
-  `Icc 0 T` to the fixed half-line `Ici 0`.
 * `TauCeti.IsCompletelyMonotone.neg_iteratedDerivWithin_one_integrableOn`,
   `TauCeti.IsCompletelyMonotone.integral_Ioi_neg_iteratedDerivWithin_one`: integrability and the
   improper integral of `-f'` on `(0, ∞)`, represented as `iteratedDerivWithin 1`.
@@ -96,25 +93,6 @@ private lemma IsCompletelyMonotone.iteratedDerivWithin_one_nonpos
     (hf : IsCompletelyMonotone f) {t : ℝ} (ht : 0 ≤ t) :
     iteratedDerivWithin 1 f (Ici 0) t ≤ 0 := by
   rw [iteratedDerivWithin_one]; exact hf.derivWithin_nonpos ht
-
-/-- The interval integral of `-f'` with the `T`-dependent set `Icc 0 T` equals the integral with
-the fixed set `Ici 0` for a completely monotone function. -/
-lemma IsCompletelyMonotone.integral_neg_iteratedDerivWithin_one_Icc_eq_Ici
-    (hcm : IsCompletelyMonotone f) (T : ℝ) (hT : 0 ≤ T) :
-    ∫ t in (0 : ℝ)..T, -iteratedDerivWithin 1 f (Icc 0 T) t =
-    ∫ t in (0 : ℝ)..T, -iteratedDerivWithin 1 f (Ici 0) t := by
-  exact ContDiffOn.integral_neg_iteratedDerivWithin_one_Icc_eq_Ici
-    (fun t ht => (hcm.contDiffOn.contDiffAt (Ici_mem_nhds ht.1)).of_le (nat_le_top _))
-    le_rfl hT
-
-/-- The integral `∫₀ᵀ (-f') dt → f(0) - L` as `T → ∞`, where `L = lim f(t)`. This is
-the key uniform bound for the tightness argument in Bernstein's theorem. -/
-lemma IsCompletelyMonotone.tendsto_integral_neg_iteratedDerivWithin_one_Icc_atTop
-    (hcm : IsCompletelyMonotone f) {L : ℝ} (hL : Tendsto f atTop (nhds L)) :
-    Tendsto (fun T => ∫ t in (0 : ℝ)..T, -iteratedDerivWithin 1 f (Icc 0 T) t) atTop
-        (nhds (f 0 - L)) :=
-  ContDiffOn.tendsto_integral_neg_iteratedDerivWithin_one_Icc_atTop
-    (a := 0) (hcm.contDiffOn.of_le (nat_le_top _)) hL
 
 /-- `-f'` is integrable on `(0, ∞)` for a completely monotone function, where the derivative is
 taken within the closed half-line `[0, ∞)`. -/

--- a/TauCeti/Analysis/CompletelyMonotone/Integral.lean
+++ b/TauCeti/Analysis/CompletelyMonotone/Integral.lean
@@ -4,7 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 -/
 module
 
-public import Mathlib.MeasureTheory.Integral.IntegralEqImproper
+import Mathlib.MeasureTheory.Integral.IntegralEqImproper
 public import TauCeti.Analysis.CompletelyMonotone.Basic
 
 /-!
@@ -122,9 +122,7 @@ lemma IsCompletelyMonotone.neg_iteratedDerivWithin_one_integrableOn
   have hderiv : ∀ t ∈ Ioi 0,
       HasDerivAt f (iteratedDerivWithin 1 f (Ici 0) t) t := by
     intro t ht
-    simpa using ContDiffOn.hasDerivAt_iteratedDerivWithin
-      (k := 0) (hcm.contDiffOn.of_le (nat_le_top _)) (uniqueDiffOn_Ici 0)
-      (Ici_mem_nhds ht)
+    exact hcm.hasDerivAt_iteratedDerivWithin_succ 0 ht
   have hneg : ∀ t ∈ Ioi 0, iteratedDerivWithin 1 f (Ici 0) t ≤ 0 :=
     fun t ht => hcm.iteratedDerivWithin_one_nonpos ht.le
   exact (integrableOn_Ioi_deriv_of_nonpos hcont hderiv hneg hL).neg
@@ -138,9 +136,7 @@ lemma IsCompletelyMonotone.integral_Ioi_neg_iteratedDerivWithin_one
   have hderiv : ∀ t ∈ Ioi 0,
       HasDerivAt f (iteratedDerivWithin 1 f (Ici 0) t) t := by
     intro t ht
-    simpa using ContDiffOn.hasDerivAt_iteratedDerivWithin
-      (k := 0) (hcm.contDiffOn.of_le (nat_le_top _)) (uniqueDiffOn_Ici 0)
-      (Ici_mem_nhds ht)
+    exact hcm.hasDerivAt_iteratedDerivWithin_succ 0 ht
   have hneg : ∀ t ∈ Ioi 0, iteratedDerivWithin 1 f (Ici 0) t ≤ 0 :=
     fun t ht => hcm.iteratedDerivWithin_one_nonpos ht.le
   have hFTC :

--- a/TauCeti/Analysis/CompletelyMonotone/Integral.lean
+++ b/TauCeti/Analysis/CompletelyMonotone/Integral.lean
@@ -117,54 +117,36 @@ lemma IsCompletelyMonotone.neg_iteratedDerivWithin_one_integrableOn
     (hcm : IsCompletelyMonotone f) :
     IntegrableOn (fun t => -iteratedDerivWithin 1 f (Ici 0) t) (Ioi 0) := by
   obtain ⟨L, hL, -⟩ := hcm.exists_nonneg_tendsto_atTop
-  -- Reduce the improper-integrability criterion to convergence of the interval integrals of
-  -- the nonnegative function `-f'`.
-  apply integrableOn_Ioi_of_intervalIntegral_norm_tendsto (f 0 - L) 0
-      (l := atTop) (b := id)
-  -- Local integrability on each compact interval follows from continuity of the derivative
-  -- within the fixed half-line.
-  · intro T
-    exact ((hcm.contDiffOn.continuousOn_iteratedDerivWithin (nat_le_top _)
-      (uniqueDiffOn_Ici 0)).neg.mono Icc_subset_Ici_self).integrableOn_compact
-        isCompact_Icc |>.mono_set Ioc_subset_Icc_self
-  · exact tendsto_id
-  -- On positive intervals the norm drops because `f' ≤ 0`; the finite-interval FTC identity
-  -- then identifies the primitive with `f(0) - f(T)`.
-  · have hnorm : ∀ᶠ T in atTop, (∫ t in (0 : ℝ)..id T,
-        ‖(fun t => -iteratedDerivWithin 1 f (Ici 0) t) t‖) = f 0 - f T := by
-      filter_upwards [eventually_gt_atTop 0] with T hT
-      simp only [id]
-      have : (∫ t in (0 : ℝ)..T, ‖(fun t => -iteratedDerivWithin 1 f (Ici 0) t) t‖) =
-              ∫ t in (0 : ℝ)..T, -iteratedDerivWithin 1 f (Ici 0) t :=
-        intervalIntegral.integral_congr_ae (ae_of_all _ fun t ht => by
-          rw [uIoc_of_le hT.le] at ht
-          simp only [Real.norm_eq_abs]
-          rw [abs_of_nonneg (by linarith [hcm.iteratedDerivWithin_one_nonpos ht.1.le])])
-      rw [this, ← hcm.integral_neg_iteratedDerivWithin_one_Icc_eq_Ici T hT.le]
-      have hcm_Icc : ContDiffOn ℝ 1 f (Icc 0 T) :=
-        (hcm.contDiffOn.mono Icc_subset_Ici_self).of_le (nat_le_top _)
-      rw [iteratedDerivWithin_one, intervalIntegral.integral_neg,
-        intervalIntegral.integral_derivWithin_Icc_of_contDiffOn_Icc hcm_Icc hT.le, neg_sub]
-    exact Tendsto.congr' (EventuallyEq.symm hnorm) (Tendsto.sub tendsto_const_nhds hL)
+  have hcont : ContinuousWithinAt f (Ici 0) 0 :=
+    hcm.contDiffOn.continuousOn.continuousWithinAt self_mem_Ici
+  have hderiv : ∀ t ∈ Ioi 0,
+      HasDerivAt f (iteratedDerivWithin 1 f (Ici 0) t) t := by
+    intro t ht
+    simpa using ContDiffOn.hasDerivAt_iteratedDerivWithin
+      (k := 0) (hcm.contDiffOn.of_le (nat_le_top _)) (uniqueDiffOn_Ici 0)
+      (Ici_mem_nhds ht)
+  have hneg : ∀ t ∈ Ioi 0, iteratedDerivWithin 1 f (Ici 0) t ≤ 0 :=
+    fun t ht => hcm.iteratedDerivWithin_one_nonpos ht.le
+  exact (integrableOn_Ioi_deriv_of_nonpos hcont hderiv hneg hL).neg
 
 /-- The improper integral `∫₀^∞ (-f') dt = f(0) - L` for completely monotone functions. -/
 lemma IsCompletelyMonotone.integral_Ioi_neg_iteratedDerivWithin_one
     (hcm : IsCompletelyMonotone f) {L : ℝ} (hL : Tendsto f atTop (nhds L)) :
     ∫ t in Ioi 0, -iteratedDerivWithin 1 f (Ici 0) t = f 0 - L := by
-  have hint := hcm.neg_iteratedDerivWithin_one_integrableOn
-  have htend := intervalIntegral_tendsto_integral_Ioi 0 hint tendsto_id
-  have htend2 : Tendsto (fun T => ∫ t in (0 : ℝ)..T,
-      -iteratedDerivWithin 1 f (Ici 0) t) atTop (nhds (f 0 - L)) :=
-    Tendsto.congr'
-      ((eventually_gt_atTop 0).mono fun T hT =>
-        by
-          simp only
-          rw [← hcm.integral_neg_iteratedDerivWithin_one_Icc_eq_Ici T hT.le]
-          have hcm_Icc : ContDiffOn ℝ 1 f (Icc 0 T) :=
-            (hcm.contDiffOn.mono Icc_subset_Ici_self).of_le (nat_le_top _)
-          rw [iteratedDerivWithin_one, intervalIntegral.integral_neg,
-            intervalIntegral.integral_derivWithin_Icc_of_contDiffOn_Icc hcm_Icc hT.le, neg_sub])
-      (Tendsto.sub tendsto_const_nhds hL)
-  exact tendsto_nhds_unique htend htend2
+  have hcont : ContinuousWithinAt f (Ici 0) 0 :=
+    hcm.contDiffOn.continuousOn.continuousWithinAt self_mem_Ici
+  have hderiv : ∀ t ∈ Ioi 0,
+      HasDerivAt f (iteratedDerivWithin 1 f (Ici 0) t) t := by
+    intro t ht
+    simpa using ContDiffOn.hasDerivAt_iteratedDerivWithin
+      (k := 0) (hcm.contDiffOn.of_le (nat_le_top _)) (uniqueDiffOn_Ici 0)
+      (Ici_mem_nhds ht)
+  have hneg : ∀ t ∈ Ioi 0, iteratedDerivWithin 1 f (Ici 0) t ≤ 0 :=
+    fun t ht => hcm.iteratedDerivWithin_one_nonpos ht.le
+  have hFTC :
+      ∫ t in Ioi 0, iteratedDerivWithin 1 f (Ici 0) t = L - f 0 :=
+    integral_Ioi_of_hasDerivAt_of_nonpos hcont hderiv hneg hL
+  rw [MeasureTheory.integral_neg, hFTC]
+  ring
 
 end TauCeti

--- a/TauCeti/Analysis/CompletelyMonotone/Integral.lean
+++ b/TauCeti/Analysis/CompletelyMonotone/Integral.lean
@@ -5,6 +5,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 module
 
 import Mathlib.MeasureTheory.Integral.IntegralEqImproper
+public import Mathlib.MeasureTheory.Integral.IntervalIntegral.ContDiff
 public import TauCeti.Analysis.CompletelyMonotone.Basic
 
 /-!

--- a/TauCeti/Analysis/CompletelyMonotone/Integral.lean
+++ b/TauCeti/Analysis/CompletelyMonotone/Integral.lean
@@ -43,13 +43,6 @@ variable {f : ℝ → ℝ}
 
 namespace IsCompletelyMonotone
 
-private lemma iteratedDerivWithin_Icc_eq_Ici {n : ℕ} {x T t : ℝ}
-    (hf : ContDiffAt ℝ (n : WithTop ℕ∞) f t) (ht0 : 0 ≤ t) (hxT : x < T)
-    (hxt : x ≤ t) (htT : t ≤ T) :
-    iteratedDerivWithin n f (Icc x T) t = iteratedDerivWithin n f (Ici 0) t := by
-  rw [iteratedDerivWithin_eq_iteratedDeriv (uniqueDiffOn_Icc hxT) hf ⟨hxt, htT⟩,
-    iteratedDerivWithin_eq_iteratedDeriv (uniqueDiffOn_Ici 0) hf (mem_Ici.mpr ht0)]
-
 /-- **CM sign of the Taylor remainder.** For a completely monotone function the Taylor
 integral remainder `∫ₓᵀ (T-t)ⁿ⁻¹/(n-1)! · f⁽ⁿ⁾(t) dt` has sign `(-1)ⁿ`:
 `0 ≤ (-1)ⁿ` times it. -/
@@ -72,9 +65,11 @@ lemma neg_one_pow_mul_taylor_remainder_nonneg (hf : IsCompletelyMonotone f) {x T
               have hcda : ContDiffAt ℝ (n : WithTop ℕ∞) f t :=
                 (hf.contDiffOn.contDiffAt (Ici_mem_nhds ht_pos)).of_le (by
                   exact_mod_cast le_top)
-              rw [iteratedDerivWithin_Icc_eq_Ici hcda ht_pos.le (lt_trans ht.1 ht.2)
-                ht.1.le ht.2.le]
-              exact hf.neg_one_pow_mul_iteratedDerivWithin_nonneg n ht_pos.le)
+              rw [iteratedDerivWithin_eq_iteratedDeriv
+                (uniqueDiffOn_Icc (lt_trans ht.1 ht.2)) hcda ⟨ht.1.le, ht.2.le⟩]
+              simpa [iteratedDerivWithin_eq_iteratedDeriv (uniqueDiffOn_Ici 0) hcda
+                (mem_Ici.mpr ht_pos.le)] using
+                hf.neg_one_pow_mul_iteratedDerivWithin_nonneg n ht_pos.le)
       _ = _ := by ring
   have h_mem : ∀ᵐ t ∂volume.restrict (Icc x T), t ∈ Ioo x T := by
     rw [ae_restrict_iff' measurableSet_Icc]


### PR DESCRIPTION
This PR discharges findings from a Mathlib-duplication audit of `TauCeti/Analysis/Calculus/IteratedDerivWithin.lean`: it deletes `ContDiffOn.integral_neg_iteratedDerivWithin_one_Icc`, which is Mathlib's `intervalIntegral.integral_derivWithin_Icc_of_contDiffOn_Icc` plus a sign flip through `iteratedDerivWithin_one`; its corollary `ContDiffOn.integral_neg_iteratedDerivWithin_one_Icc_zero_left`, which has no consumers at all; and `ContDiffAt.iteratedDerivWithin_Icc_eq_Ici`, which is two applications of Mathlib's `iteratedDerivWithin_eq_iteratedDeriv`. The call sites in `TauCeti/Analysis/CompletelyMonotone/Integral.lean` now invoke the Mathlib lemmas directly, at no cost in proof length. `ContDiffOn.hasDerivAt_iteratedDerivWithin` is kept because its consumers live in files carried by the open PR https://github.com/TauCetiProject/TauCeti/pull/575 (feat(Analysis/CompletelyMonotone): Hausdorff–Bernstein–Widder theorem, Part 2/2), but its proof shrinks to the direct derivation from Mathlib's `ContDiffOn.differentiableOn_iteratedDerivWithin` and `DifferentiableOn.hasDerivAt`, with the subsumption recorded in the docstring; the module docstring now points readers at the subsuming Mathlib lemmas. Per `AGENTS.md`, improving code that already exists is always in scope; this PR adds no new mathematical scope. Build evidence: `lake build` reports "Build completed successfully (4618 jobs).", `lake exe axioms` reports "axioms: audited 8738 TauCeti declaration(s); all within the allowlist [propext, Classical.choice, Quot.sound].", and `lake exe module-system` reports "module-system: all 441 TauCeti module(s) opt into the module system."

🤖 Prepared with Claude Code