### PR TITLE
refactor: simplify expShift_realOperator_of_nonneg via realOperator_coe

### DIFF
--- a/TauCeti/Analysis/Semigroups/ExponentialShift.lean
+++ b/TauCeti/Analysis/Semigroups/ExponentialShift.lean
@@ -97,18 +97,7 @@ theorem expShift_realOperator_of_nonneg (S : StronglyContinuousSemigroup X)
     (lambda t : ℝ) (ht : 0 ≤ t) :
     (S.expShift lambda).realOperator t = Real.exp (-(lambda * t)) • S.realOperator t := by
   have ht_coe : ((t.toNNReal : ℝ) = t) := Real.coe_toNNReal t ht
-  calc
-    (S.expShift lambda).realOperator t
-        = (S.expShift lambda).realOperator (t.toNNReal : ℝ) := by rw [ht_coe]
-    _ = (S.expShift lambda) t.toNNReal := by rw [realOperator_coe]
-    _ = Real.exp (-(lambda * (t.toNNReal : ℝ))) • S t.toNNReal := by
-        rw [expShift_apply]
-    _ = Real.exp (-(lambda * t)) • S.realOperator t := by
-        have hS : S.realOperator t = S t.toNNReal := by
-          calc
-            S.realOperator t = S.realOperator (t.toNNReal : ℝ) := by rw [ht_coe]
-            _ = S t.toNNReal := by rw [realOperator_coe]
-        rw [ht_coe, hS]
+  rw [← ht_coe, realOperator_coe, realOperator_coe, expShift_apply]
 
 omit [CompleteSpace X] in
 /-- Pointwise real-time form of the shifted operator at nonnegative times. -/


### PR DESCRIPTION
This PR collapses the four-step calc proof of `expShift_realOperator_of_nonneg` in `Analysis/Semigroups/ExponentialShift.lean` to a single `rw` chain through `realOperator_coe` and `expShift_apply`, deleting the redundant inner `hS` sub-block that re-derived `S.realOperator t = S t.toNNReal` a second time. The new proof reuses the same `rw [← ht_coe, realOperator_coe]` coercion idiom already used elsewhere in `Analysis/Semigroups/Basic.lean`. Per `AGENTS.md`, improving code that already exists is always in scope; this PR adds no new mathematical scope.

Build evidence: `lake build` completes (4614 jobs); `lake exe axioms` reports all 8707 declarations within the allowlist [propext, Classical.choice, Quot.sound]; `lake exe module-system` reports all 437 modules opt into the module system.

🤖 Prepared with Claude Code