### PR TITLE
refactor: trim dead relative-diffeomorphism fixing-subgroup variants

### DIFF
--- a/TauCeti/Geometry/Diffeomorphism/RelativeCongr.lean
+++ b/TauCeti/Geometry/Diffeomorphism/RelativeCongr.lean
@@ -108,22 +108,6 @@ theorem diffCongr_mem_fixingSubgroup_image (e : M ≃ₘ^n⟮I, J⟯ N) {s : Set
   rw [← map_fixingSubgroup_diffCongr e s]
   exact ⟨φ, hφ, rfl⟩
 
-/-- Conjugating by `e` sends diffeomorphisms fixing `s` pointwise to diffeomorphisms fixing any
-subset of the image of `s`. -/
-theorem diffCongr_mem_fixingSubgroup_of_subset_image (e : M ≃ₘ^n⟮I, J⟯ N) {s : Set M}
-    {t : Set N} (ht : t ⊆ e '' s) {φ : M ≃ₘ^n⟮I, I⟯ M}
-    (hφ : φ ∈ fixingSubgroup (I := I) (n := n) s) :
-    diffCongr e φ ∈ fixingSubgroup (I := J) (n := n) t := by
-  exact fixingSubgroup_antitone ht (diffCongr_mem_fixingSubgroup_image e hφ)
-
-/-- Conjugating by `e` sends diffeomorphisms fixing `s` pointwise to diffeomorphisms fixing a
-named target `t` pointwise, when `t` is the image of `s`. -/
-theorem diffCongr_mem_fixingSubgroup_of_image_eq (e : M ≃ₘ^n⟮I, J⟯ N) {s : Set M} {t : Set N}
-    (hst : e '' s = t) {φ : M ≃ₘ^n⟮I, I⟯ M}
-    (hφ : φ ∈ fixingSubgroup (I := I) (n := n) s) :
-    diffCongr e φ ∈ fixingSubgroup (I := J) (n := n) t := by
-  exact diffCongr_mem_fixingSubgroup_of_subset_image e hst.ge hφ
-
 /-- Conjugating by `e.symm` sends diffeomorphisms fixing `e '' s` pointwise back to
 diffeomorphisms fixing `s` pointwise. -/
 theorem diffCongr_symm_mem_fixingSubgroup (e : M ≃ₘ^n⟮I, J⟯ N) {s : Set M}
@@ -134,22 +118,6 @@ theorem diffCongr_symm_mem_fixingSubgroup (e : M ≃ₘ^n⟮I, J⟯ N) {s : Set 
     exact hψ
   rcases hmap with ⟨φ, hφ, rfl⟩
   simpa [diffCongr_symm] using hφ
-
-/-- Conjugating by `e.symm` sends diffeomorphisms fixing a superset of `e '' s` pointwise back to
-diffeomorphisms fixing `s` pointwise. -/
-theorem diffCongr_symm_mem_fixingSubgroup_of_image_subset (e : M ≃ₘ^n⟮I, J⟯ N) {s : Set M}
-    {t : Set N} (ht : e '' s ⊆ t) {ψ : N ≃ₘ^n⟮J, J⟯ N}
-    (hψ : ψ ∈ fixingSubgroup (I := J) (n := n) t) :
-    diffCongr e.symm ψ ∈ fixingSubgroup (I := I) (n := n) s := by
-  exact diffCongr_symm_mem_fixingSubgroup e (fixingSubgroup_antitone ht hψ)
-
-/-- Conjugating by `e.symm` sends diffeomorphisms fixing a named target `t` pointwise back to
-diffeomorphisms fixing `s` pointwise, when `t` is the image of `s`. -/
-theorem diffCongr_symm_mem_fixingSubgroup_of_image_eq (e : M ≃ₘ^n⟮I, J⟯ N) {s : Set M}
-    {t : Set N} (hst : e '' s = t) {ψ : N ≃ₘ^n⟮J, J⟯ N}
-    (hψ : ψ ∈ fixingSubgroup (I := J) (n := n) t) :
-    diffCongr e.symm ψ ∈ fixingSubgroup (I := I) (n := n) s := by
-  exact diffCongr_symm_mem_fixingSubgroup_of_image_subset e hst.le hψ
 
 /-- Conjugation by a diffeomorphism identifies the relative diffeomorphism group fixing `s`
 pointwise with the relative diffeomorphism group fixing a named target `t` pointwise, when `t` is


### PR DESCRIPTION
This PR trims four zero-consumer micro-variants from the relative-diffeomorphism fixing-subgroup API in `TauCeti/Geometry/Diffeomorphism/RelativeCongr.lean`: the antitone weakenings `diffCongr_mem_fixingSubgroup_of_subset_image` and `diffCongr_symm_mem_fixingSubgroup_of_image_subset`, together with the hypothesis-rewrite restatements `diffCongr_mem_fixingSubgroup_of_image_eq` and `diffCongr_symm_mem_fixingSubgroup_of_image_eq`. None of the four is used anywhere in the repository, and none has a role named by the geometric-topology roadmap (`TauCetiRoadmap/GeometricTopology/README.md`, layer 3): they only relax the image `e '' s` to an arbitrary subset or superset, recoverable on demand from `fixingSubgroup_antitone`, or re-state a membership fact after rewriting `e '' s = t`, a one-line `rw`. The constructions layer 3's relative diffeomorphism groups such as `Diff(M, ∂M)` plausibly consume are all kept: the subgroup-map theorem `map_fixingSubgroup_diffCongr` and its named-target form, the element-level membership lemmas `diffCongr_mem_fixingSubgroup_image` and `diffCongr_symm_mem_fixingSubgroup`, and the relative-transport equivalences `relativeDiffCongr` and `relativeDiffCongrOfImageEq` with their full computation API, since transporting a relative group along a diffeomorphism `e` with `e '' ∂M = ∂N` is exactly the named-target `OfImageEq` form that layer will reach for.

Per `AGENTS.md`, improving code that already exists is always in scope; this PR adds no new mathematical scope. Against the pinned Mathlib, `lake build` completes all 4614 jobs, `lake exe axioms` audits 8703 declarations as within the allowlist [propext, Classical.choice, Quot.sound], and `lake exe module-system` reports all 437 modules opt into the module system.

Roadmap: GeometricTopology

🤖 Prepared with Claude Code
