### PR TITLE
refactor: use nsmulRec for comodule morphism nsmul

### DIFF
--- a/TauCeti/Algebra/Coalgebra/Comodule/Hom.lean
+++ b/TauCeti/Algebra/Coalgebra/Comodule/Hom.lean
@@ -95,17 +95,12 @@ theorem add_apply (f g : Hom R C M N) (m : M) : (f + g) m = f m + g m :=
 theorem smul_apply (r : R) (f : Hom R C M N) (m : M) : (r • f) m = r • f m :=
   rfl
 
-/-- Natural-number scalar multiplication of comodule morphisms, defined by repeated
-pointwise addition. -/
-instance instNSMul : SMul ℕ (Hom R C M N) where
-  smul n f := n.rec 0 fun _ g => f + g
-
-/-- Comodule morphisms form an additive commutative monoid under pointwise zero, addition,
-and natural-number scalar multiplication. -/
+/-- Comodule morphisms form an additive commutative monoid under pointwise zero and
+addition, with the default natural-number scalar multiplication `nsmulRec`. -/
 instance instAddCommMonoid : AddCommMonoid (Hom R C M N) where
   zero := 0
   add := (· + ·)
-  nsmul := (· • ·)
+  nsmul := nsmulRec
   zero_add f := by
     ext m
     simp
@@ -118,16 +113,6 @@ instance instAddCommMonoid : AddCommMonoid (Hom R C M N) where
   add_comm f g := by
     ext m
     simp [add_comm]
-  -- These fields verify that the custom primitive `SMul ℕ` instance agrees with the
-  -- `AddCommMonoid` nsmul convention. Unfolding it exposes definitional equalities, after
-  -- which the successor case only differs by commutativity of pointwise addition.
-  nsmul_zero f := by
-    ext m
-    rw [show ((0 : ℕ) • f : Hom R C M N) = 0 from rfl]
-  nsmul_succ n f := by
-    ext m
-    rw [show (Nat.succ n • f : Hom R C M N) = f + n • f from rfl]
-    rw [add_apply, add_apply, add_comm]
 
 /-- The map sending a comodule morphism to its underlying linear map, bundled as an
 additive monoid homomorphism. -/


### PR DESCRIPTION
This PR replaces the hand-rolled `SMul ℕ` instance on comodule morphisms in `TauCeti/Algebra/Coalgebra/Comodule/Hom.lean` with the standard `nsmulRec` idiom. The previous code defined natural-number scalar multiplication as `n.rec 0 fun _ g => f + g` in a dedicated `instNSMul` instance and then wired it into the `AddCommMonoid` through explicit `nsmul_zero` and `nsmul_succ` fields discharged by `rfl` plus a commutativity fix-up. That bespoke recursor is the successor-flipped `nsmulRec` already, so setting `nsmul := nsmulRec` on the `AddCommMonoid` instance and dropping the separate `SMul ℕ` instance and its two manual compatibility proofs removes the redundancy without changing behaviour. The downstream `Module` instance and the `nsmul_apply`, `nsmul_toLinearMap`, and finite-sum simp lemmas are untouched and continue to build, confirming the `nsmul` convention they depend on is preserved.

Per `AGENTS.md`, improving code that already exists is always in scope; this PR adds no new mathematical scope. Against the pinned Mathlib, `lake build` completes all 4614 jobs, `lake exe axioms` audits 8706 declarations as within the allowlist [propext, Classical.choice, Quot.sound], and `lake exe module-system` reports all 437 modules opt into the module system.

🤖 Prepared with Claude Code
