### PR TITLE
feat(Analysis/Contour): Dixon h₁/h₂ functions and their identity

### DIFF
--- a/TauCeti/Analysis/Contour/DixonDef.lean
+++ b/TauCeti/Analysis/Contour/DixonDef.lean
@@ -1,0 +1,116 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Chris Birkbeck
+-/
+module
+
+public import TauCeti.Analysis.Contour.WindingNumber
+public import Mathlib.Analysis.Calculus.DSlope
+
+/-!
+# Dixon's `h₁` and `h₂` functions and their defining identity
+
+Dixon's proof of the homology form of Cauchy's theorem hinges on a single auxiliary function that
+is analytic on all of `ℂ`. This file records its two constituent integrals and the algebraic
+identity relating them; the analyticity, boundedness, and Liouville steps are developed downstream.
+
+For a curve `γ : ℝ → ℂ` on the oriented interval with endpoints `a`, `b` and a holomorphic `f`:
+
+* `dixonH1 f γ a b w = ∫ t in a..b, dslope f w (γ t) * deriv γ t` — built from the *difference
+  quotient* `dslope f w (γ t) = (f (γ t) - f w) / (γ t - w)` (which extends continuously through
+  `γ t = w`, where it is `deriv f w`), so it is defined for **every** `w`, including points on `γ`.
+* `dixonH2 f γ a b w = ∫ t in a..b, f (γ t) / (γ t - w) * deriv γ t` — the Cauchy-type integral,
+  defined for `w` off the curve.
+* `dixonFunction f U γ a b w` — glues the two: `dixonH1` on `U`, `dixonH2` on its complement.
+
+## Main results
+
+* `TauCeti.Contour.dixonH1_eq_dixonH2_sub_winding` — for `w` off the curve,
+  `dixonH1 f γ a b w = dixonH2 f γ a b w - 2πi · n(γ, w) · f w`, where `n(γ, w)` is the generalized
+  `windingNumber`. This is what makes `dixonFunction` well-glued across `∂U`.
+
+These are the building blocks of the `homologyCauchyTheorem` roadmap target
+(`TauCetiRoadmap/ContourIntegration/Suggested.lean`, Layer 3, proved by Dixon's argument).
+
+## Provenance
+
+Adapted from `dixonH1`, `dixonH2`, `dixonFunction`, and `dixonH1_eq_dixonH2_sub_winding_f` in
+`DixonDef.lean` of the AINTLIB `LeanModularForms` development, restated for a raw `γ : ℝ → ℂ` on an
+oriented interval with endpoints `a` and `b`. See J. D. Dixon, *A brief proof of Cauchy's integral
+theorem*, Proc. Amer. Math. Soc. 29 (1971), and K. Hungerbühler, J. Wasem, *A generalized notion of
+winding numbers*.
+-/
+
+public section
+
+open Complex MeasureTheory Set
+
+open scoped Real Interval
+
+namespace TauCeti.Contour
+
+/-- **Dixon's `h₁` integral** `∫ t in a..b, dslope f w (γ t) * deriv γ t`. Because the difference
+quotient `dslope f w z = (f z - f w) / (z - w)` extends continuously through `z = w` (taking the
+value `deriv f w`), this integral is defined for *every* `w`, including points on the curve `γ`. -/
+noncomputable def dixonH1 (f : ℂ → ℂ) (γ : ℝ → ℂ) (a b : ℝ) (w : ℂ) : ℂ :=
+  ∫ t in a..b, dslope f w (γ t) * deriv γ t
+
+/-- **Dixon's `h₂` integral** `∫ t in a..b, f (γ t) / (γ t - w) * deriv γ t`. This is the ordinary
+Cauchy-type integral, defined for `w` off the curve. -/
+noncomputable def dixonH2 (f : ℂ → ℂ) (γ : ℝ → ℂ) (a b : ℝ) (w : ℂ) : ℂ :=
+  ∫ t in a..b, f (γ t) / (γ t - w) * deriv γ t
+
+open Classical in
+/-- **Dixon's glued function** `dixonH1` on `U`, `dixonH2` on its complement. The two pieces agree
+on the overlap by `dixonH1_eq_dixonH2_sub_winding` together with null-homology, which is what makes
+the glued function analytic on all of `ℂ`. -/
+noncomputable def dixonFunction (f : ℂ → ℂ) (U : Set ℂ) (γ : ℝ → ℂ) (a b : ℝ) (w : ℂ) : ℂ :=
+  if w ∈ U then dixonH1 f γ a b w else dixonH2 f γ a b w
+
+/-- Off the curve, the `dslope` integrand splits into the Cauchy-type integrand minus the
+winding-number integrand scaled by `f w`. -/
+private theorem dslope_integrand_eq {f : ℂ → ℂ} {γ : ℝ → ℂ} {a b : ℝ} {w : ℂ}
+    (hoff : ∀ t ∈ uIcc a b, γ t ≠ w) :
+    ∀ t ∈ uIcc a b, dslope f w (γ t) * deriv γ t =
+      f (γ t) / (γ t - w) * deriv γ t - f w / (γ t - w) * deriv γ t := fun t ht ↦ by
+  rw [dslope_of_ne _ (hoff t ht), slope_def_field]; ring
+
+/-- The `f w`-weighted term of the split integrand as a constant times the index integrand. -/
+private theorem fw_div_eq (f : ℂ → ℂ) (γ : ℝ → ℂ) (w : ℂ) :
+    (fun t ↦ f w / (γ t - w) * deriv γ t) = fun t ↦ f w * ((γ t - w)⁻¹ * deriv γ t) := by
+  funext t; rw [div_eq_mul_inv, mul_assoc]
+
+/-- **The `h₁`/`h₂` identity.** For `w` off the curve, `dixonH1 f γ a b w` differs from
+`dixonH2 f γ a b w` by exactly `2πi · n(γ, w) · f w`, the generalized winding number scaled by
+`f w`. The proof expands `dslope f w (γ t) = (f (γ t) - f w) / (γ t - w)`, splits the integral, and
+identifies the second piece with `f w · ∫ (γ · - w)⁻¹ · deriv γ = 2πi · n(γ, w) · f w`. -/
+theorem dixonH1_eq_dixonH2_sub_winding {f : ℂ → ℂ} {γ : ℝ → ℂ} {a b : ℝ} {w : ℂ}
+    (h_cont : ContinuousOn γ (uIcc a b)) (hoff : ∀ t ∈ uIcc a b, γ t ≠ w)
+    (h_cauchy_int : IntervalIntegrable (fun t ↦ f (γ t) / (γ t - w) * deriv γ t) volume a b)
+    (h_base_int : IntervalIntegrable (fun t ↦ (γ t - w)⁻¹ * deriv γ t) volume a b) :
+    dixonH1 f γ a b w =
+      dixonH2 f γ a b w - 2 * (Real.pi : ℂ) * Complex.I * windingNumber γ a b w * f w := by
+  have hw_int : ∫ t in a..b, (γ t - w)⁻¹ * deriv γ t =
+      2 * (Real.pi : ℂ) * Complex.I * windingNumber γ a b w := by
+    rw [windingNumber_eq_integral_of_avoidance h_cont hoff h_base_int, ← mul_assoc,
+      mul_inv_cancel₀ Complex.two_pi_I_ne_zero, one_mul]
+  have h_fw_div_int : IntervalIntegrable (fun t ↦ f w / (γ t - w) * deriv γ t) volume a b :=
+    (fw_div_eq f γ w) ▸ (h_base_int.const_mul (f w))
+  simp only [dixonH1, dixonH2]
+  rw [intervalIntegral.integral_congr (dslope_integrand_eq hoff),
+    intervalIntegral.integral_sub h_cauchy_int h_fw_div_int, fw_div_eq,
+    intervalIntegral.integral_const_mul, hw_int]
+  ring
+
+/-- On `U`, the glued Dixon function is `dixonH1`. -/
+theorem dixonFunction_eq_dixonH1 {f : ℂ → ℂ} {U : Set ℂ} {γ : ℝ → ℂ} {a b : ℝ} {w : ℂ}
+    (hw : w ∈ U) : dixonFunction f U γ a b w = dixonH1 f γ a b w := by
+  rw [dixonFunction, if_pos hw]
+
+/-- Off `U`, the glued Dixon function is `dixonH2`. -/
+theorem dixonFunction_eq_dixonH2 {f : ℂ → ℂ} {U : Set ℂ} {γ : ℝ → ℂ} {a b : ℝ} {w : ℂ}
+    (hw : w ∉ U) : dixonFunction f U γ a b w = dixonH2 f γ a b w := by
+  rw [dixonFunction, if_neg hw]
+
+end TauCeti.Contour

--- a/TauCeti/Analysis/Contour/DixonDef.lean
+++ b/TauCeti/Analysis/Contour/DixonDef.lean
@@ -15,18 +15,21 @@ Dixon's proof of the homology form of Cauchy's theorem hinges on a single auxili
 is analytic on all of `ℂ`. This file records its two constituent integrals and the algebraic
 identity relating them; the analyticity, boundedness, and Liouville steps are developed downstream.
 
-For a curve `γ : ℝ → ℂ` on the oriented interval with endpoints `a`, `b` and a holomorphic `f`:
+For a curve `γ : ℝ → ℂ` on the oriented interval with endpoints `a`, `b` and a function `f`:
 
 * `dixonH1 f γ a b w = ∫ t in a..b, dslope f w (γ t) * deriv γ t` — built from the *difference
-  quotient* `dslope f w (γ t) = (f (γ t) - f w) / (γ t - w)` (which extends continuously through
-  `γ t = w`, where it is `deriv f w`), so it is defined for **every** `w`, including points on `γ`.
+  quotient* `dslope f w z`, which equals `(f z - f w) / (z - w)` for `z ≠ w` and `deriv f w` at
+  `z = w`, so the integrand is defined for **every** `w`, including points on `γ`.
 * `dixonH2 f γ a b w = ∫ t in a..b, f (γ t) / (γ t - w) * deriv γ t` — the Cauchy-type integral,
   defined for `w` off the curve.
-* `dixonFunction f U γ a b w` — glues the two: `dixonH1` on `U`, `dixonH2` on its complement.
+* `dixonFunction f U γ a b w` — selects `dixonH1` on `U` and `dixonH2` on its complement.
+
+Each definition is `irreducible_def`, exposing a public `*_def` equation lemma while keeping the
+body opaque.
 
 ## Main results
 
-* `TauCeti.Contour.dixonH1_eq_dixonH2_sub_winding` — for `w` off the curve,
+* `TauCeti.Contour.dixonH1_eq_dixonH2_sub_windingNumber_mul_f` — for `w` off the curve,
   `dixonH1 f γ a b w = dixonH2 f γ a b w - 2πi · n(γ, w) · f w`, where `n(γ, w)` is the generalized
   `windingNumber`. This is what makes `dixonFunction` well-glued across `∂U`.
 
@@ -50,22 +53,23 @@ open scoped Real Interval
 
 namespace TauCeti.Contour
 
-/-- **Dixon's `h₁` integral** `∫ t in a..b, dslope f w (γ t) * deriv γ t`. Because the difference
-quotient `dslope f w z = (f z - f w) / (z - w)` extends continuously through `z = w` (taking the
-value `deriv f w`), this integral is defined for *every* `w`, including points on the curve `γ`. -/
-noncomputable def dixonH1 (f : ℂ → ℂ) (γ : ℝ → ℂ) (a b : ℝ) (w : ℂ) : ℂ :=
+/-- **Dixon's `h₁` integral** `∫ t in a..b, dslope f w (γ t) * deriv γ t`. The difference quotient
+`dslope f w z` equals `(f z - f w) / (z - w)` for `z ≠ w` and `deriv f w` at `z = w`, so the
+integrand is defined for *every* `w`, including points on the curve `γ`. -/
+noncomputable irreducible_def dixonH1 (f : ℂ → ℂ) (γ : ℝ → ℂ) (a b : ℝ) (w : ℂ) : ℂ :=
   ∫ t in a..b, dslope f w (γ t) * deriv γ t
 
-/-- **Dixon's `h₂` integral** `∫ t in a..b, f (γ t) / (γ t - w) * deriv γ t`. This is the ordinary
+/-- **Dixon's `h₂` integral** `∫ t in a..b, f (γ t) / (γ t - w) * deriv γ t`, the ordinary
 Cauchy-type integral, defined for `w` off the curve. -/
-noncomputable def dixonH2 (f : ℂ → ℂ) (γ : ℝ → ℂ) (a b : ℝ) (w : ℂ) : ℂ :=
+noncomputable irreducible_def dixonH2 (f : ℂ → ℂ) (γ : ℝ → ℂ) (a b : ℝ) (w : ℂ) : ℂ :=
   ∫ t in a..b, f (γ t) / (γ t - w) * deriv γ t
 
 open Classical in
-/-- **Dixon's glued function** `dixonH1` on `U`, `dixonH2` on its complement. The two pieces agree
-on the overlap by `dixonH1_eq_dixonH2_sub_winding` together with null-homology, which is what makes
-the glued function analytic on all of `ℂ`. -/
-noncomputable def dixonFunction (f : ℂ → ℂ) (U : Set ℂ) (γ : ℝ → ℂ) (a b : ℝ) (w : ℂ) : ℂ :=
+/-- **Dixon's glued function**: `dixonH1` on `U`, `dixonH2` on its complement. That these two pieces
+glue, under null-homology, into a function analytic on all of `ℂ` is the downstream content of
+Dixon's argument, established in later results; here the function is only defined. -/
+noncomputable irreducible_def dixonFunction (f : ℂ → ℂ) (U : Set ℂ) (γ : ℝ → ℂ) (a b : ℝ)
+    (w : ℂ) : ℂ :=
   if w ∈ U then dixonH1 f γ a b w else dixonH2 f γ a b w
 
 /-- Off the curve, the `dslope` integrand splits into the Cauchy-type integrand minus the
@@ -82,10 +86,9 @@ private theorem fw_div_eq (f : ℂ → ℂ) (γ : ℝ → ℂ) (w : ℂ) :
   funext t; rw [div_eq_mul_inv, mul_assoc]
 
 /-- **The `h₁`/`h₂` identity.** For `w` off the curve, `dixonH1 f γ a b w` differs from
-`dixonH2 f γ a b w` by exactly `2πi · n(γ, w) · f w`, the generalized winding number scaled by
-`f w`. The proof expands `dslope f w (γ t) = (f (γ t) - f w) / (γ t - w)`, splits the integral, and
-identifies the second piece with `f w · ∫ (γ · - w)⁻¹ · deriv γ = 2πi · n(γ, w) · f w`. -/
-theorem dixonH1_eq_dixonH2_sub_winding {f : ℂ → ℂ} {γ : ℝ → ℂ} {a b : ℝ} {w : ℂ}
+`dixonH2 f γ a b w` by exactly `2πi · n(γ, w) · f w`, the generalized winding number of `γ` about
+`w` scaled by `f w`. -/
+theorem dixonH1_eq_dixonH2_sub_windingNumber_mul_f {f : ℂ → ℂ} {γ : ℝ → ℂ} {a b : ℝ} {w : ℂ}
     (h_cont : ContinuousOn γ (uIcc a b)) (hoff : ∀ t ∈ uIcc a b, γ t ≠ w)
     (h_cauchy_int : IntervalIntegrable (fun t ↦ f (γ t) / (γ t - w) * deriv γ t) volume a b)
     (h_base_int : IntervalIntegrable (fun t ↦ (γ t - w)⁻¹ * deriv γ t) volume a b) :
@@ -97,20 +100,21 @@ theorem dixonH1_eq_dixonH2_sub_winding {f : ℂ → ℂ} {γ : ℝ → ℂ} {a b
       mul_inv_cancel₀ Complex.two_pi_I_ne_zero, one_mul]
   have h_fw_div_int : IntervalIntegrable (fun t ↦ f w / (γ t - w) * deriv γ t) volume a b :=
     (fw_div_eq f γ w) ▸ (h_base_int.const_mul (f w))
-  simp only [dixonH1, dixonH2]
-  rw [intervalIntegral.integral_congr (dslope_integrand_eq hoff),
+  rw [dixonH1_def, dixonH2_def, intervalIntegral.integral_congr (dslope_integrand_eq hoff),
     intervalIntegral.integral_sub h_cauchy_int h_fw_div_int, fw_div_eq,
     intervalIntegral.integral_const_mul, hw_int]
   ring
 
 /-- On `U`, the glued Dixon function is `dixonH1`. -/
+@[simp]
 theorem dixonFunction_eq_dixonH1 {f : ℂ → ℂ} {U : Set ℂ} {γ : ℝ → ℂ} {a b : ℝ} {w : ℂ}
     (hw : w ∈ U) : dixonFunction f U γ a b w = dixonH1 f γ a b w := by
-  rw [dixonFunction, if_pos hw]
+  rw [dixonFunction_def, if_pos hw]
 
 /-- Off `U`, the glued Dixon function is `dixonH2`. -/
+@[simp]
 theorem dixonFunction_eq_dixonH2 {f : ℂ → ℂ} {U : Set ℂ} {γ : ℝ → ℂ} {a b : ℝ} {w : ℂ}
     (hw : w ∉ U) : dixonFunction f U γ a b w = dixonH2 f γ a b w := by
-  rw [dixonFunction, if_neg hw]
+  rw [dixonFunction_def, if_neg hw]
 
 end TauCeti.Contour

--- a/TauCeti/Analysis/Contour/DixonDef.lean
+++ b/TauCeti/Analysis/Contour/DixonDef.lean
@@ -29,7 +29,8 @@ body opaque.
 
 ## Main results
 
-* `TauCeti.Contour.dixonH1_eq_dixonH2_sub_windingNumber_mul_f` — for `w` off the curve,
+* `TauCeti.Contour.dixonH1_eq_dixonH2_sub_windingNumber_mul_f` — for `γ` continuous on `uIcc a b`
+  and `w` off the curve, with the index and Cauchy-type integrands interval-integrable,
   `dixonH1 f γ a b w = dixonH2 f γ a b w - 2πi · n(γ, w) · f w`, where `n(γ, w)` is the generalized
   `windingNumber`. This is what makes `dixonFunction` well-glued across `∂U`.
 
@@ -85,7 +86,8 @@ private theorem fw_div_eq (f : ℂ → ℂ) (γ : ℝ → ℂ) (w : ℂ) :
     (fun t ↦ f w / (γ t - w) * deriv γ t) = fun t ↦ f w * ((γ t - w)⁻¹ * deriv γ t) := by
   funext t; rw [div_eq_mul_inv, mul_assoc]
 
-/-- **The `h₁`/`h₂` identity.** For `w` off the curve, `dixonH1 f γ a b w` differs from
+/-- **The `h₁`/`h₂` identity.** For `γ` continuous on `uIcc a b` and `w` off the curve, with the
+index and Cauchy-type integrands interval-integrable, `dixonH1 f γ a b w` differs from
 `dixonH2 f γ a b w` by exactly `2πi · n(γ, w) · f w`, the generalized winding number of `γ` about
 `w` scaled by `f w`. -/
 theorem dixonH1_eq_dixonH2_sub_windingNumber_mul_f {f : ℂ → ℂ} {γ : ℝ → ℂ} {a b : ℝ} {w : ℂ}


### PR DESCRIPTION
Adds `TauCeti/Analysis/Contour/DixonDef.lean`: the definitional foundation of **Dixon's argument** for the homology Cauchy theorem.

## What this adds

Three definitions and the algebraic identity that binds them, all for a raw `γ : ℝ → ℂ` on the oriented interval with endpoints `a`, `b`:

* `dixonH1 f γ a b w = ∫ t in a..b, dslope f w (γ t) * deriv γ t` — the difference-quotient integral. Since `dslope f w z = (f z − f w)/(z − w)` extends continuously through `z = w` (to `deriv f w`), this is defined for **every** `w`, including points on `γ`.
* `dixonH2 f γ a b w = ∫ t in a..b, f (γ t)/(γ t − w) * deriv γ t` — the Cauchy-type integral, defined off the curve.
* `dixonFunction f U γ a b w` — glues `dixonH1` on `U` to `dixonH2` on its complement.
* `dixonH1_eq_dixonH2_sub_winding` — the key identity: for `w` off the curve,
  `dixonH1 f γ a b w = dixonH2 f γ a b w − 2πi · n(γ, w) · f w`,
  with `n(γ, w) = windingNumber γ a b w` the generalized winding number. This is what makes `dixonFunction` agree across `∂U` once null-homology is imposed.
* `dixonFunction_eq_dixonH1` / `dixonFunction_eq_dixonH2` — the two branch equations.

## Roadmap

First step of the dependency-ordered chain toward the `homologyCauchyTheorem` target (`TauCetiRoadmap/ContourIntegration/Suggested.lean`, Layer 3 — the homology form of Cauchy's theorem, proved by Dixon's argument). Dixon's function is the object whose analyticity, boundedness, and vanishing-at-infinity (via Liouville) give `∮_γ f = 0`; this PR introduces it and the identity, with the analyticity and Liouville steps to follow in subsequent PRs. The three winding-number ingredients Dixon's argument relies on — continuity (#829), integer-valuedness (#828), local constancy (#854) — are already merged.

The identity reuses `windingNumber_eq_integral_of_avoidance` (the definition's reduction to the index integral), so the port is smaller than the source: no bespoke distance bound is needed.

## Provenance

Adapted from `dixonH1`, `dixonH2`, `dixonFunction`, and `dixonH1_eq_dixonH2_sub_winding_f` in `DixonDef.lean` of the AINTLIB `LeanModularForms` development, restated for a raw `γ : ℝ → ℂ` on an oriented interval. References: J. D. Dixon, *A brief proof of Cauchy's integral theorem* (1971); K. Hungerbühler, J. Wasem, *A generalized notion of winding numbers*.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
