### PR TITLE
refactor(Analysis/Contour): share exists_ball_dist_curve_lower_bound across contour consumers

### DIFF
--- a/TauCeti/Analysis/Contour/CurveDistance.lean
+++ b/TauCeti/Analysis/Contour/CurveDistance.lean
@@ -19,11 +19,13 @@ a uniform positive lower bound `ρ` on `‖γ t - w‖` over `[a, b]`.
 ## Main results
 
 * `TauCeti.Contour.exists_curve_dist_lower_bound` — the uniform positive distance lower bound.
+* `TauCeti.Contour.exists_ball_dist_curve_lower_bound` — the same lower bound made uniform over a
+  whole ball of points around the avoided point.
 
-This small support lemma is shared by the argument-lift partition
+These small support lemmas are shared by the argument-lift partition
 (`exists_uniform_modulus_avoiding`, feeding the integer-valuedness of the winding number) and by the
-continuity of the winding number in the point (`exists_ball_dist_curve_lb`) — both prerequisites for
-the homology form of Cauchy's theorem (roadmap `homologyCauchyTheorem`).
+continuity of the winding number in the point (`continuousAt_windingNumber_of_avoidance`) — both
+prerequisites for the homology form of Cauchy's theorem (roadmap `homologyCauchyTheorem`).
 -/
 
 public section
@@ -47,5 +49,22 @@ theorem exists_curve_dist_lower_bound {γ : ℝ → ℂ} {w : ℂ} {a b : ℝ}
     fun t ht ↦ ?_⟩
   have h1 := Metric.infDist_le_dist_of_mem (x := w) (mem_image_of_mem γ ht)
   rwa [Complex.dist_eq, norm_sub_rev] at h1
+
+/-- **Uniform distance to the curve on a neighbourhood of an avoided point.** If `γ` is continuous
+on the interval with endpoints `a`, `b` and avoids `w₀` there, then there is a radius `ε > 0` such
+that every `w` within `ε` of `w₀` stays at distance at least `ε` from the whole curve: for all
+`t ∈ Set.uIcc a b`, `ε ≤ ‖γ t - w‖`. Take `ε = ρ / 2` for the uniform distance `ρ` to `w₀` of
+`exists_curve_dist_lower_bound`; a point `w` within `ρ / 2` of `w₀` then stays `ρ / 2` from `γ` by
+the triangle inequality. Stated on the oriented interval `Set.uIcc a b`. -/
+theorem exists_ball_dist_curve_lower_bound {γ : ℝ → ℂ} {w₀ : ℂ} {a b : ℝ}
+    (hγ : ContinuousOn γ (uIcc a b)) (h_avoid : ∀ t ∈ uIcc a b, γ t ≠ w₀) :
+    ∃ ε > 0, ∀ w ∈ Metric.ball w₀ ε, ∀ t ∈ uIcc a b, ε ≤ ‖γ t - w‖ := by
+  obtain ⟨ρ, hρ_pos, h_dist_lb⟩ := exists_curve_dist_lower_bound hγ h_avoid
+  refine ⟨ρ / 2, half_pos hρ_pos, fun w hw t ht ↦ ?_⟩
+  rw [Metric.mem_ball, Complex.dist_eq] at hw
+  have htri : ‖γ t - w₀‖ - ‖w - w₀‖ ≤ ‖γ t - w‖ := by
+    have h := norm_sub_norm_le (γ t - w₀) (w - w₀)
+    rwa [sub_sub_sub_cancel_right] at h
+  linarith [h_dist_lb t ht]
 
 end TauCeti.Contour

--- a/TauCeti/Analysis/Contour/CurveDistance.lean
+++ b/TauCeti/Analysis/Contour/CurveDistance.lean
@@ -53,9 +53,7 @@ theorem exists_curve_dist_lower_bound {γ : ℝ → ℂ} {w : ℂ} {a b : ℝ}
 /-- **Uniform distance to the curve on a neighbourhood of an avoided point.** If `γ` is continuous
 on the interval with endpoints `a`, `b` and avoids `w₀` there, then there is a radius `ε > 0` such
 that every `w` within `ε` of `w₀` stays at distance at least `ε` from the whole curve: for all
-`t ∈ Set.uIcc a b`, `ε ≤ ‖γ t - w‖`. Take `ε = ρ / 2` for the uniform distance `ρ` to `w₀` of
-`exists_curve_dist_lower_bound`; a point `w` within `ρ / 2` of `w₀` then stays `ρ / 2` from `γ` by
-the triangle inequality. Stated on the oriented interval `Set.uIcc a b`. -/
+`t ∈ Set.uIcc a b`, `ε ≤ ‖γ t - w‖`. Stated on the oriented interval `Set.uIcc a b`. -/
 theorem exists_ball_dist_curve_lower_bound {γ : ℝ → ℂ} {w₀ : ℂ} {a b : ℝ}
     (hγ : ContinuousOn γ (uIcc a b)) (h_avoid : ∀ t ∈ uIcc a b, γ t ≠ w₀) :
     ∃ ε > 0, ∀ w ∈ Metric.ball w₀ ε, ∀ t ∈ uIcc a b, ε ≤ ‖γ t - w‖ := by

--- a/TauCeti/Analysis/Contour/DixonH2Diff.lean
+++ b/TauCeti/Analysis/Contour/DixonH2Diff.lean
@@ -69,22 +69,6 @@ private theorem h2_factor_mul_num_aestronglyMeasurable {g : ℝ → ℂ}
     AEStronglyMeasurable (fun t ↦ g t * (f (γ t) * deriv γ t)) (volume.restrict (Ι a b)) :=
   ((hg.mono Set.uIoc_subset_uIcc).aestronglyMeasurable measurableSet_uIoc).mul hnum
 
-/-- Points in the `ρ/2`-ball about an off-curve `w` stay `ρ/2` away from the curve. -/
-private theorem h2_ball_dist {ρ : ℝ} (hρ_dist : ∀ t ∈ uIcc a b, ρ ≤ ‖γ t - w‖)
-    {w' : ℂ} (hw' : w' ∈ Metric.ball w (ρ / 2)) (t : ℝ) (ht : t ∈ uIcc a b) :
-    ρ / 2 ≤ ‖γ t - w'‖ := by
-  rw [Metric.mem_ball, Complex.dist_eq] at hw'
-  have h := norm_sub_norm_le (γ t - w) (w' - w)
-  rw [sub_sub_sub_cancel_right] at h
-  linarith [hρ_dist t ht]
-
-/-- On the `ρ/2`-ball, every point stays off the curve. -/
-private theorem h2_ball_avoids {ρ : ℝ} (hρ_pos : 0 < ρ) (hρ_dist : ∀ t ∈ uIcc a b, ρ ≤ ‖γ t - w‖)
-    {w' : ℂ} (hw' : w' ∈ Metric.ball w (ρ / 2)) : ∀ t ∈ uIcc a b, γ t ≠ w' := fun t ht heq ↦ by
-  have hd := h2_ball_dist hρ_dist hw' t ht
-  rw [heq, sub_self, norm_zero] at hd
-  linarith
-
 /-- On a ball of radius `ε` about the off-curve point, the squared-pole derivative integrand is
 bounded by `ε⁻² · ‖numerator‖`. -/
 private theorem h2_deriv_bound {ε : ℝ} (hε_pos : 0 < ε) {w' : ℂ}
@@ -101,8 +85,9 @@ theorem differentiableAt_dixonH2 (hγ_cont : ContinuousOn γ (uIcc a b))
     (hoff : ∀ t ∈ uIcc a b, γ t ≠ w)
     (h_cauchy_int : IntervalIntegrable (fun t ↦ f (γ t) / (γ t - w) * deriv γ t) volume a b) :
     DifferentiableAt ℂ (dixonH2 f γ a b) w := by
-  obtain ⟨ρ, hρ_pos, hρ_dist⟩ := exists_curve_dist_lower_bound hγ_cont hoff
-  have hε_pos : 0 < ρ / 2 := half_pos hρ_pos
+  obtain ⟨ε, hε_pos, h_dist_lb⟩ := exists_ball_dist_curve_lower_bound hγ_cont hoff
+  have avoid : ∀ w' ∈ Metric.ball w ε, ∀ t ∈ uIcc a b, γ t ≠ w' := fun w' hw' t ht ↦
+    sub_ne_zero.mp (norm_pos_iff.mp (lt_of_lt_of_le hε_pos (h_dist_lb w' hw' t ht)))
   -- Multiplying the Cauchy integrand by the continuous factor `γ · - w` recovers the numerator.
   have h_factor_cont : ContinuousOn (fun t ↦ γ t - w) (uIcc a b) := hγ_cont.sub continuousOn_const
   have h_num_int : IntervalIntegrable (fun t ↦ f (γ t) * deriv γ t) volume a b := by
@@ -120,19 +105,19 @@ theorem differentiableAt_dixonH2 (hγ_cont : ContinuousOn γ (uIcc a b))
   refine ((intervalIntegral.hasDerivAt_integral_of_dominated_loc_of_deriv_le (𝕜 := ℂ)
     (F := fun w' t ↦ (γ t - w')⁻¹ * (f (γ t) * deriv γ t))
     (F' := fun w' t ↦ (γ t - w')⁻¹ ^ 2 * (f (γ t) * deriv γ t))
-    (bound := fun t ↦ (ρ / 2)⁻¹ ^ 2 * ‖f (γ t) * deriv γ t‖)
+    (bound := fun t ↦ ε⁻¹ ^ 2 * ‖f (γ t) * deriv γ t‖)
     (Metric.ball_mem_nhds w hε_pos) ?_
     (h_num_int.continuousOn_mul (h2_kernel_continuousOn hγ_cont hoff))
     (h2_factor_mul_num_aestronglyMeasurable ((h2_kernel_continuousOn hγ_cont hoff).pow 2) hnum)
     (Filter.Eventually.of_forall fun t ht w' hw' ↦ h2_deriv_bound hε_pos
-      (fun s hs ↦ h2_ball_dist hρ_dist hw' s hs) (Set.uIoc_subset_uIcc ht))
-    (h_num_int.norm.const_mul ((ρ / 2)⁻¹ ^ 2))
+      (h_dist_lb w' hw') (Set.uIoc_subset_uIcc ht))
+    (h_num_int.norm.const_mul (ε⁻¹ ^ 2))
     (Filter.Eventually.of_forall fun t ht w' hw' ↦ h2_pole_hasDerivAt (f (γ t) * deriv γ t) (γ t)
-      w' (sub_ne_zero.mpr (h2_ball_avoids hρ_pos hρ_dist hw' t (Set.uIoc_subset_uIcc ht))))).2
+      w' (sub_ne_zero.mpr (avoid w' hw' t (Set.uIoc_subset_uIcc ht))))).2
     ).differentiableAt
   · filter_upwards [Metric.ball_mem_nhds w hε_pos] with w' hw'
     exact h2_factor_mul_num_aestronglyMeasurable
-      (h2_kernel_continuousOn hγ_cont (h2_ball_avoids hρ_pos hρ_dist hw')) hnum
+      (h2_kernel_continuousOn hγ_cont (avoid w' hw')) hnum
 
 end
 

--- a/TauCeti/Analysis/Contour/WindingContinuity.lean
+++ b/TauCeti/Analysis/Contour/WindingContinuity.lean
@@ -35,23 +35,6 @@ open scoped Interval
 
 namespace TauCeti.Contour
 
-/-- **Uniform distance to the curve near an avoided point.** If `γ` is continuous on the compact
-interval `[a, b]` and avoids `w₀` there, then there is a radius `ε > 0` such that every `w` within
-`ε` of `w₀` stays at distance at least `ε` from the whole curve `γ '' [a, b]`. Uses the distance to
-the compact image `Metric.infDist w₀ (γ '' Icc a b)`. -/
-private theorem exists_ball_dist_curve_lower_bound {γ : ℝ → ℂ} {w₀ : ℂ} {a b : ℝ} (hab : a ≤ b)
-    (hγ_cont : ContinuousOn γ (Icc a b)) (h_avoid : ∀ t ∈ Icc a b, γ t ≠ w₀) :
-    ∃ ε > 0, ∀ w ∈ Metric.ball w₀ ε, ∀ t ∈ Icc a b, ε ≤ ‖γ t - w‖ := by
-  obtain ⟨ρ, hρ_pos, h_dist_lb⟩ := exists_curve_dist_lower_bound
-    (by rw [Set.uIcc_of_le hab]; exact hγ_cont) (by rw [Set.uIcc_of_le hab]; exact h_avoid)
-  rw [Set.uIcc_of_le hab] at h_dist_lb
-  refine ⟨ρ / 2, half_pos hρ_pos, fun w hw t ht ↦ ?_⟩
-  rw [Metric.mem_ball, Complex.dist_eq] at hw
-  have h2 : ‖γ t - w₀‖ - ‖w - w₀‖ ≤ ‖γ t - w‖ := by
-    have h := norm_sub_norm_le (γ t - w₀) (w - w₀)
-    rwa [sub_sub_sub_cancel_right] at h
-  linarith [h_dist_lb t ht]
-
 /-- **Integrability of the index integrand for a point off the curve.** If `w` stays a positive
 distance `ε` from `γ` on `[a, b]` (so `γ · - w` is nowhere zero and `(γ · - w)⁻¹` is continuous)
 and `deriv γ` is interval-integrable, then `(γ t - w)⁻¹ * deriv γ t` is interval-integrable, being
@@ -71,7 +54,9 @@ private theorem continuousAt_windingNumber_of_avoidance_of_le {γ : ℝ → ℂ}
     (hab : a ≤ b) (hγ_cont : ContinuousOn γ (Icc a b)) (h_avoid : ∀ t ∈ Icc a b, γ t ≠ w₀)
     (hderiv_int : IntervalIntegrable (fun t ↦ deriv γ t) volume a b) :
     ContinuousAt (fun w ↦ windingNumber γ a b w) w₀ := by
-  obtain ⟨ε, hε_pos, h_dist_lb⟩ := exists_ball_dist_curve_lower_bound hab hγ_cont h_avoid
+  obtain ⟨ε, hε_pos, h_dist_lb⟩ := exists_ball_dist_curve_lower_bound
+    (by rw [Set.uIcc_of_le hab]; exact hγ_cont) (by rw [Set.uIcc_of_le hab]; exact h_avoid)
+  rw [Set.uIcc_of_le hab] at h_dist_lb
   set F : ℂ → ℝ → ℂ := fun w t ↦ (γ t - w)⁻¹ * deriv γ t with hF_def
   have h_ne : ∀ w ∈ Metric.ball w₀ ε, ∀ t ∈ Icc a b, γ t - w ≠ 0 := fun w hw t ht ↦
     norm_pos_iff.mp (lt_of_lt_of_le hε_pos (h_dist_lb w hw t ht))
@@ -130,7 +115,9 @@ theorem continuousAt_windingNumber_of_avoidance {γ : ℝ → ℂ} {w₀ : ℂ} 
   · rw [Set.uIcc_of_ge hba] at hγ_cont h_avoid
     have hcore :=
       continuousAt_windingNumber_of_avoidance_of_le hba hγ_cont h_avoid hderiv_int.symm
-    obtain ⟨ε, hε_pos, h_dist_lb⟩ := exists_ball_dist_curve_lower_bound hba hγ_cont h_avoid
+    obtain ⟨ε, hε_pos, h_dist_lb⟩ := exists_ball_dist_curve_lower_bound
+      (by rw [Set.uIcc_of_le hba]; exact hγ_cont) (by rw [Set.uIcc_of_le hba]; exact h_avoid)
+    rw [Set.uIcc_of_le hba] at h_dist_lb
     have h_eq : (fun w ↦ windingNumber γ a b w) =ᶠ[nhds w₀] fun w ↦ -windingNumber γ b a w := by
       filter_upwards [Metric.ball_mem_nhds w₀ hε_pos] with w hw
       have h_ne : ∀ t ∈ Icc b a, γ t - w ≠ 0 := fun t ht ↦


### PR DESCRIPTION
Consolidates the "neighbourhood off-curve distance bound" into the shared `CurveDistance` API and routes every current consumer through it.

## What this does

* Adds `exists_ball_dist_curve_lower_bound` to `CurveDistance.lean` — public, on the oriented interval `uIcc a b`: for `γ` continuous on `uIcc a b` and avoiding `w₀`, there is a radius `ε > 0` such that every `w` within `ε` of `w₀` stays at distance `≥ ε` from the whole curve. Proof: take `ε = ρ/2` for the uniform distance `ρ` of `exists_curve_dist_lower_bound`, then a triangle inequality.
* Removes the private `Icc`-specific copy from `WindingContinuity.lean` and rewires its two call sites to the shared `uIcc` lemma.
* Removes the local `h2_ball_dist`/`h2_ball_avoids` scaffolding from `DixonH2Diff.lean` (just merged in #857) and routes it through the same shared lemma, deriving off-curve avoidance inline via a compact `avoid` local.

Net: `WindingContinuity` and `DixonH2Diff` both shrink; `CurveDistance` gains one general, reusable sibling to `exists_curve_dist_lower_bound` that all off-curve neighbourhood arguments share.

## Why

`CurveDistance.lean` is the designated public home for uniform curve-distance lemmas (it already hosts `exists_curve_dist_lower_bound`, whose module docstring anticipated this neighbourhood consumer). The `ρ/2`-ball construction is needed by winding-number continuity, Dixon `h₂` holomorphy, and every downstream contour holomorphy result that differentiates a Cauchy kernel under the integral off the curve; factoring it here gives a single source of truth instead of re-deriving the scaffolding in each file.

No new mathematics: this only relocates and generalises an existing lemma from `Icc` to `uIcc` and reuses it in place across the three current consumers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
