### PR TITLE
refactor(Contour): share the off-curve index-integrand integrability lemma

### DIFF
--- a/TauCeti/Analysis/Contour/WindingContinuity.lean
+++ b/TauCeti/Analysis/Contour/WindingContinuity.lean
@@ -35,19 +35,16 @@ open scoped Interval
 
 namespace TauCeti.Contour
 
-/-- **Integrability of the index integrand for a point off the curve.** If `w` stays a positive
-distance `ε` from `γ` on `[a, b]` (so `γ · - w` is nowhere zero and `(γ · - w)⁻¹` is continuous)
-and `deriv γ` is interval-integrable, then `(γ t - w)⁻¹ * deriv γ t` is interval-integrable, being
-a continuous factor times an integrable one. -/
-private theorem intervalIntegrable_inv_sub_mul_deriv {γ : ℝ → ℂ} {w : ℂ} {a b ε : ℝ} (hab : a ≤ b)
-    (hε_pos : 0 < ε) (h_dist : ∀ t ∈ Icc a b, ε ≤ ‖γ t - w‖) (hγ_cont : ContinuousOn γ (Icc a b))
+/-- **Integrability of the index integrand for a point off the curve.** If `γ` is continuous on
+`Set.uIcc a b` and avoids `w` there (so `(γ · - w)⁻¹` is continuous) and `deriv γ` is
+interval-integrable, then `(γ t - w)⁻¹ * deriv γ t` is interval-integrable, being a continuous
+factor times an integrable one. -/
+theorem intervalIntegrable_inv_sub_mul_deriv {γ : ℝ → ℂ} {w : ℂ} {a b : ℝ}
+    (hγ_cont : ContinuousOn γ (Set.uIcc a b)) (hoff : ∀ t ∈ Set.uIcc a b, γ t ≠ w)
     (hderiv_int : IntervalIntegrable (fun t ↦ deriv γ t) volume a b) :
-    IntervalIntegrable (fun t ↦ (γ t - w)⁻¹ * deriv γ t) volume a b := by
-  have h_ne : ∀ t ∈ Icc a b, γ t - w ≠ 0 := fun t ht ↦
-    norm_pos_iff.mp (lt_of_lt_of_le hε_pos (h_dist t ht))
-  have hcont : ContinuousOn (fun t ↦ (γ t - w)⁻¹) (Set.uIcc a b) := by
-    rw [Set.uIcc_of_le hab]; exact (hγ_cont.sub continuousOn_const).inv₀ h_ne
-  exact hderiv_int.continuousOn_mul hcont
+    IntervalIntegrable (fun t ↦ (γ t - w)⁻¹ * deriv γ t) volume a b :=
+  hderiv_int.continuousOn_mul ((hγ_cont.sub continuousOn_const).inv₀
+    fun t ht ↦ sub_ne_zero.mpr (hoff t ht))
 
 /-- The `a ≤ b` case of `continuousAt_windingNumber_of_avoidance`. -/
 private theorem continuousAt_windingNumber_of_avoidance_of_le {γ : ℝ → ℂ} {w₀ : ℂ} {a b : ℝ}
@@ -74,10 +71,11 @@ private theorem continuousAt_windingNumber_of_avoidance_of_le {γ : ℝ → ℂ}
   have h_eq_nbhd : (fun w ↦ windingNumber γ a b w) =ᶠ[nhds w₀]
       fun w ↦ (2 * (Real.pi : ℂ) * Complex.I)⁻¹ * ∫ t in a..b, F w t := by
     filter_upwards [Metric.ball_mem_nhds w₀ hε_pos] with w hw
-    refine windingNumber_eq_integral_of_avoidance ?_ ?_
-      (intervalIntegrable_inv_sub_mul_deriv hab hε_pos (h_dist_lb w hw) hγ_cont hderiv_int)
-    · rw [Set.uIcc_of_le hab]; exact hγ_cont
-    · rw [Set.uIcc_of_le hab]; exact fun t ht ↦ sub_ne_zero.mp (h_ne w hw t ht)
+    have hcont' : ContinuousOn γ (Set.uIcc a b) := by rw [Set.uIcc_of_le hab]; exact hγ_cont
+    have hoff' : ∀ t ∈ Set.uIcc a b, γ t ≠ w := by
+      rw [Set.uIcc_of_le hab]; exact fun t ht ↦ sub_ne_zero.mp (h_ne w hw t ht)
+    exact windingNumber_eq_integral_of_avoidance hcont' hoff'
+      (intervalIntegrable_inv_sub_mul_deriv hcont' hoff' hderiv_int)
   refine ContinuousAt.congr ?_ h_eq_nbhd.symm
   refine ContinuousAt.mul continuousAt_const ?_
   refine intervalIntegral.continuousAt_of_dominated_interval (bound := fun t ↦ ε⁻¹ * ‖deriv γ t‖)
@@ -125,8 +123,7 @@ theorem continuousAt_windingNumber_of_avoidance {γ : ℝ → ℂ} {w₀ : ℂ} 
       have hcont_u : ContinuousOn γ (Set.uIcc b a) := by rw [Set.uIcc_of_le hba]; exact hγ_cont
       have havoid_u : ∀ t ∈ Set.uIcc b a, γ t ≠ w := by
         rw [Set.uIcc_of_le hba]; exact fun t ht ↦ sub_ne_zero.mp (h_ne t ht)
-      have hintg := intervalIntegrable_inv_sub_mul_deriv hba hε_pos (h_dist_lb w hw) hγ_cont
-        hderiv_int.symm
+      have hintg := intervalIntegrable_inv_sub_mul_deriv hcont_u havoid_u hderiv_int.symm
       exact windingNumber_symm (cauchyPVExistsAt_of_avoidance hcont_u havoid_u hintg)
     exact hcore.neg.congr h_eq.symm
 

--- a/TauCeti/Analysis/Contour/WindingContinuity.lean
+++ b/TauCeti/Analysis/Contour/WindingContinuity.lean
@@ -35,17 +35,6 @@ open scoped Interval
 
 namespace TauCeti.Contour
 
-/-- **Integrability of the index integrand for a point off the curve.** If `γ` is continuous on
-`Set.uIcc a b` and avoids `w` there (so `(γ · - w)⁻¹` is continuous) and `deriv γ` is
-interval-integrable, then `(γ t - w)⁻¹ * deriv γ t` is interval-integrable, being a continuous
-factor times an integrable one. -/
-theorem intervalIntegrable_inv_sub_mul_deriv {γ : ℝ → ℂ} {w : ℂ} {a b : ℝ}
-    (hγ_cont : ContinuousOn γ (Set.uIcc a b)) (hoff : ∀ t ∈ Set.uIcc a b, γ t ≠ w)
-    (hderiv_int : IntervalIntegrable (fun t ↦ deriv γ t) volume a b) :
-    IntervalIntegrable (fun t ↦ (γ t - w)⁻¹ * deriv γ t) volume a b :=
-  hderiv_int.continuousOn_mul ((hγ_cont.sub continuousOn_const).inv₀
-    fun t ht ↦ sub_ne_zero.mpr (hoff t ht))
-
 /-- The `a ≤ b` case of `continuousAt_windingNumber_of_avoidance`. -/
 private theorem continuousAt_windingNumber_of_avoidance_of_le {γ : ℝ → ℂ} {w₀ : ℂ} {a b : ℝ}
     (hab : a ≤ b) (hγ_cont : ContinuousOn γ (Icc a b)) (h_avoid : ∀ t ∈ Icc a b, γ t ≠ w₀)

--- a/TauCeti/Analysis/Contour/WindingLocallyConstant.lean
+++ b/TauCeti/Analysis/Contour/WindingLocallyConstant.lean
@@ -54,8 +54,7 @@ theorem isLocallyConstant_windingNumber_of_closed {γ : ℝ → ℂ} {a b : ℝ}
   -- `(γ · - w)⁻¹` times the integrable derivative.
   have hII : ∀ w : ℂ, (∀ t ∈ uIcc a b, γ t ≠ w) →
       IntervalIntegrable (fun t ↦ (γ t - w)⁻¹ * deriv γ t) volume a b := fun w hw ↦
-    hderiv_int.continuousOn_mul
-      ((hγ_cont.sub continuousOn_const).inv₀ fun t ht ↦ sub_ne_zero.mpr (hw t ht))
+    intervalIntegrable_inv_sub_mul_deriv hγ_cont hw hderiv_int
   rw [IsLocallyConstant.iff_eventually_eq]
   rintro ⟨w₀, hw₀⟩
   -- A uniform lower bound `ρ ≤ ‖γ t - w₀‖`; on `ball w₀ (ρ / 2)` every point stays off `γ`, so the

--- a/TauCeti/Analysis/Contour/WindingNumber.lean
+++ b/TauCeti/Analysis/Contour/WindingNumber.lean
@@ -106,6 +106,17 @@ theorem isNullHomologous_iff {γ : ℝ → ℂ} {a b : ℝ} {Ω : Set ℂ} :
     IsNullHomologous γ a b Ω ↔ ∀ w ∉ Ω, windingNumber γ a b w = 0 :=
   Iff.rfl
 
+/-- **Integrability of the index integrand for a point off the curve.** If `γ` is continuous on
+`Set.uIcc a b` and avoids `w` there (so `(γ · - w)⁻¹` is continuous) and `deriv γ` is
+interval-integrable, then `(γ t - w)⁻¹ * deriv γ t` is interval-integrable, being a continuous
+factor times an integrable one. -/
+theorem intervalIntegrable_inv_sub_mul_deriv {γ : ℝ → ℂ} {w : ℂ} {a b : ℝ}
+    (hγ_cont : ContinuousOn γ (Set.uIcc a b)) (hoff : ∀ t ∈ Set.uIcc a b, γ t ≠ w)
+    (hderiv_int : IntervalIntegrable (fun t ↦ deriv γ t) MeasureTheory.volume a b) :
+    IntervalIntegrable (fun t ↦ (γ t - w)⁻¹ * deriv γ t) MeasureTheory.volume a b :=
+  hderiv_int.continuousOn_mul ((hγ_cont.sub continuousOn_const).inv₀
+    fun t ht ↦ sub_ne_zero.mpr (hoff t ht))
+
 /-- If `γ` is continuous on `[a, b]`, avoids `z₀` there, and the index integrand is
 interval-integrable, the generalized winding number is the ordinary index integral: the principal
 value collapses to `(2πi)⁻¹ · ∮_γ dz/(z − z₀)`. -/


### PR DESCRIPTION
Generalizes `intervalIntegrable_inv_sub_mul_deriv` (WindingContinuity.lean) from the private
`a ≤ b`/distance-bound variant to a **public** lemma with cleaner hypotheses — `ContinuousOn γ
(uIcc a b)` and off-curve `∀ t ∈ uIcc a b, γ t ≠ w` — and routes all existing consumers through it:

* both orientation branches of `continuousAt_windingNumber_of_avoidance` (they derive the
  off-curve hypothesis from their distance lower bounds);
* the inline `hII` in `isLocallyConstant_windingNumber_of_closed` (WindingLocallyConstant.lean),
  which was a byte-for-byte copy of the proof term.

This is the single shared statement of "the index integrand `(γ · - w)⁻¹ · deriv γ` is
interval-integrable off the curve", so downstream Dixon code (`differentiable_dixonFunction`,
the `dixonH1 = dixonH2 - …` identity) reuses it rather than re-proving it. Behavior-preserving;
same consolidation pattern as #858.

No new axioms; all four local gates (build, axioms, module-system, lint) green.