### PR TITLE
feat: add winding number scaling API

### DIFF
--- a/TauCeti/Analysis/Contour/CauchyPrincipalValue.lean
+++ b/TauCeti/Analysis/Contour/CauchyPrincipalValue.lean
@@ -8,6 +8,7 @@ module
 public import Mathlib.MeasureTheory.Integral.IntervalIntegral.Basic
 public import Mathlib.Analysis.Calculus.Deriv.Basic
 import Mathlib.Analysis.Calculus.Deriv.Add
+import Mathlib.Analysis.Calculus.Deriv.Mul
 public import Mathlib.Analysis.Complex.Basic
 import Mathlib.Topology.Order.Compact
 
@@ -62,6 +63,9 @@ versus `MeromorphicOn` (on a set).
   existence form).
 * `HasCauchyPVAt.translate`, `CauchyPVExistsAt.translate`, `cauchyPVAt_translate` — simultaneous
   translation of the curve, point, and integrand preserves the principal value.
+* `HasCauchyPVAt.const_mul_curve`, `CauchyPVExistsAt.const_mul_curve` — simultaneous nonzero scaling
+  of the curve and point, with the integrand rescaled by `z ↦ c⁻¹ * f (c⁻¹ * z)`, preserves the
+  principal value.
 * `HasCauchyPVAt.symm`, `CauchyPVExistsAt.symm`, `cauchyPVAt_symm` — reversing the interval
   orientation negates the single-point principal value.
 * `HasCauchyPVAt.concat` — the principal values on `[a, b]` and `[b, c]` add
@@ -403,6 +407,57 @@ theorem cauchyPVAt_translate {γ : ℝ → ℂ} {a b : ℝ} {f : ℂ → ℂ} {z
   ext ε
   refine intervalIntegral.integral_congr fun t _ => ?_
   simp [add_sub_add_right_eq_sub, add_sub_cancel_right, deriv_add_const]
+
+/-- Simultaneously scaling the curve and the excision point by a nonzero complex number `c`
+preserves a single-point Cauchy principal value, provided the integrand is rescaled by
+`z ↦ c⁻¹ * f (c⁻¹ * z)`: the excision radius rescales by `‖c‖` and, after this rescaling, the two
+truncated integrands agree along the scaled curve. -/
+theorem HasCauchyPVAt.const_mul_curve {γ : ℝ → ℂ} {a b : ℝ} {f : ℂ → ℂ} {z₀ L : ℂ}
+    (h : HasCauchyPVAt γ a b f z₀ L) {c : ℂ} (hc : c ≠ 0) :
+    HasCauchyPVAt (fun t => c * γ t) a b (fun z => c⁻¹ * f (c⁻¹ * z)) (c * z₀) L := by
+  have hscale : Tendsto (fun ε : ℝ => ε / ‖c‖) (𝓝[>] (0 : ℝ)) (𝓝[>] (0 : ℝ)) := by
+    simpa [div_eq_mul_inv] using
+      Filter.TendstoNhdsWithinIoi.mul_const (b := ‖c‖⁻¹) (c := 0)
+        (inv_pos.mpr (norm_pos_iff.mpr hc)) (tendsto_id (x := 𝓝[>] (0 : ℝ)))
+  -- The scaled excision at radius `ε` reproduces the original excision at radius `ε / ‖c‖`, and the
+  -- rescaling factor `c⁻¹` cancels the derivative factor `c`, so the two truncated integrands agree
+  -- pointwise.
+  have hbody : ∀ (ε t : ℝ),
+      (if ‖c * γ t - c * z₀‖ > ε then
+          (fun z => c⁻¹ * f (c⁻¹ * z)) (c * γ t) * deriv (fun t => c * γ t) t else 0)
+        = if ‖γ t - z₀‖ > ε / ‖c‖ then f (γ t) * deriv γ t else 0 := by
+    intro ε t
+    by_cases hεt : ‖γ t - z₀‖ > ε / ‖c‖
+    · have hscaled : ‖c * γ t - c * z₀‖ > ε := by
+        rw [← mul_sub, norm_mul]
+        have hmul := mul_lt_mul_of_pos_right hεt (norm_pos_iff.mpr hc)
+        have hmul' : ε < ‖γ t - z₀‖ * ‖c‖ := by
+          simpa [div_mul_cancel₀ _ (norm_ne_zero_iff.mpr hc)] using hmul
+        simpa [mul_comm] using hmul'
+      rw [if_pos hscaled, if_pos hεt, deriv_const_mul_field]
+      simp only [inv_mul_cancel_left₀ hc]
+      rw [show c⁻¹ * f (γ t) * (c * deriv γ t) = c⁻¹ * c * (f (γ t) * deriv γ t) by ring,
+        inv_mul_cancel₀ hc, one_mul]
+    · have hscaled : ¬ ‖c * γ t - c * z₀‖ > ε := by
+        rw [← mul_sub, norm_mul, not_lt]
+        rw [not_lt] at hεt
+        have hmul := mul_le_mul_of_nonneg_right hεt (norm_nonneg c)
+        rwa [div_mul_cancel₀ _ (norm_ne_zero_iff.mpr hc), mul_comm] at hmul
+      rw [if_neg hscaled, if_neg hεt]
+  refine HasCauchyPVAt.intro ?_ ?_
+  · filter_upwards [hscale.eventually h.eventually_intervalIntegrable] with ε hε
+    exact (intervalIntegrable_congr fun t _ => hbody ε t).mpr hε
+  · refine h.tendsto.comp hscale |>.congr' ?_
+    filter_upwards with ε
+    exact intervalIntegral.integral_congr fun t _ => (hbody ε t).symm
+
+/-- Existence form of `HasCauchyPVAt.const_mul_curve`: nonzero scaling of the curve and excision
+point preserves existence of a single-point Cauchy principal value. -/
+theorem CauchyPVExistsAt.const_mul_curve {γ : ℝ → ℂ} {a b : ℝ} {f : ℂ → ℂ} {z₀ : ℂ}
+    (h : CauchyPVExistsAt γ a b f z₀) {c : ℂ} (hc : c ≠ 0) :
+    CauchyPVExistsAt (fun t => c * γ t) a b (fun z => c⁻¹ * f (c⁻¹ * z)) (c * z₀) :=
+  let ⟨_, hL⟩ := cauchyPVExistsAt_iff.mp h
+  CauchyPVExistsAt.intro (hL.const_mul_curve hc)
 
 /-- Reversing the interval orientation negates a single-point Cauchy principal value. -/
 theorem HasCauchyPVAt.symm {γ : ℝ → ℂ} {a b : ℝ} {f : ℂ → ℂ} {z₀ L : ℂ}

--- a/TauCeti/Analysis/Contour/CauchyPrincipalValue.lean
+++ b/TauCeti/Analysis/Contour/CauchyPrincipalValue.lean
@@ -63,9 +63,10 @@ versus `MeromorphicOn` (on a set).
   existence form).
 * `HasCauchyPVAt.translate`, `CauchyPVExistsAt.translate`, `cauchyPVAt_translate` — simultaneous
   translation of the curve, point, and integrand preserves the principal value.
-* `HasCauchyPVAt.const_mul_curve`, `CauchyPVExistsAt.const_mul_curve` — simultaneous nonzero scaling
-  of the curve and point, with the integrand rescaled by `z ↦ c⁻¹ * f (c⁻¹ * z)`, preserves the
-  principal value.
+* `HasCauchyPVAt.const_mul_curve`, `CauchyPVExistsAt.const_mul_curve`,
+  `cauchyPVAt_const_mul_curve` — simultaneous nonzero scaling of the curve and point, with the
+  integrand rescaled by `z ↦ c⁻¹ * f (c⁻¹ * z)`, preserves the principal value; the value form
+  needs no existence hypothesis.
 * `HasCauchyPVAt.symm`, `CauchyPVExistsAt.symm`, `cauchyPVAt_symm` — reversing the interval
   orientation negates the single-point principal value.
 * `HasCauchyPVAt.concat` — the principal values on `[a, b]` and `[b, c]` add
@@ -408,6 +409,34 @@ theorem cauchyPVAt_translate {γ : ℝ → ℂ} {a b : ℝ} {f : ℂ → ℂ} {z
   refine intervalIntegral.integral_congr fun t _ => ?_
   simp [add_sub_add_right_eq_sub, add_sub_cancel_right, deriv_add_const]
 
+/-- Pointwise identity behind the scaling lemmas: multiplying the curve and excision point by a
+nonzero `c` and rescaling the integrand by `z ↦ c⁻¹ * f (c⁻¹ * z)` turns the scaled truncated
+integrand at radius `ε` into the original truncated integrand at radius `ε / ‖c‖`. The rescaling
+factor `c⁻¹` cancels the derivative factor `c`, and the excision radius rescales by `‖c‖`. Shared by
+`HasCauchyPVAt.const_mul_curve` and `cauchyPVAt_const_mul_curve`. -/
+private theorem truncated_const_mul_curve_eq {γ : ℝ → ℂ} {f : ℂ → ℂ} {z₀ c : ℂ} (hc : c ≠ 0)
+    (ε t : ℝ) :
+    (if ‖c * γ t - c * z₀‖ > ε then
+        (fun z => c⁻¹ * f (c⁻¹ * z)) (c * γ t) * deriv (fun t => c * γ t) t else 0)
+      = if ‖γ t - z₀‖ > ε / ‖c‖ then f (γ t) * deriv γ t else 0 := by
+  by_cases hεt : ‖γ t - z₀‖ > ε / ‖c‖
+  · have hscaled : ‖c * γ t - c * z₀‖ > ε := by
+      rw [← mul_sub, norm_mul]
+      have hmul := mul_lt_mul_of_pos_right hεt (norm_pos_iff.mpr hc)
+      have hmul' : ε < ‖γ t - z₀‖ * ‖c‖ := by
+        simpa [div_mul_cancel₀ _ (norm_ne_zero_iff.mpr hc)] using hmul
+      simpa [mul_comm] using hmul'
+    rw [if_pos hscaled, if_pos hεt, deriv_const_mul_field]
+    simp only [inv_mul_cancel_left₀ hc]
+    rw [show c⁻¹ * f (γ t) * (c * deriv γ t) = c⁻¹ * c * (f (γ t) * deriv γ t) by ring,
+      inv_mul_cancel₀ hc, one_mul]
+  · have hscaled : ¬ ‖c * γ t - c * z₀‖ > ε := by
+      rw [← mul_sub, norm_mul, not_lt]
+      rw [not_lt] at hεt
+      have hmul := mul_le_mul_of_nonneg_right hεt (norm_nonneg c)
+      rwa [div_mul_cancel₀ _ (norm_ne_zero_iff.mpr hc), mul_comm] at hmul
+    rw [if_neg hscaled, if_neg hεt]
+
 /-- Simultaneously scaling the curve and the excision point by a nonzero complex number `c`
 preserves a single-point Cauchy principal value, provided the integrand is rescaled by
 `z ↦ c⁻¹ * f (c⁻¹ * z)`: the excision radius rescales by `‖c‖` and, after this rescaling, the two
@@ -419,37 +448,12 @@ theorem HasCauchyPVAt.const_mul_curve {γ : ℝ → ℂ} {a b : ℝ} {f : ℂ �
     simpa [div_eq_mul_inv] using
       Filter.TendstoNhdsWithinIoi.mul_const (b := ‖c‖⁻¹) (c := 0)
         (inv_pos.mpr (norm_pos_iff.mpr hc)) (tendsto_id (x := 𝓝[>] (0 : ℝ)))
-  -- The scaled excision at radius `ε` reproduces the original excision at radius `ε / ‖c‖`, and the
-  -- rescaling factor `c⁻¹` cancels the derivative factor `c`, so the two truncated integrands agree
-  -- pointwise.
-  have hbody : ∀ (ε t : ℝ),
-      (if ‖c * γ t - c * z₀‖ > ε then
-          (fun z => c⁻¹ * f (c⁻¹ * z)) (c * γ t) * deriv (fun t => c * γ t) t else 0)
-        = if ‖γ t - z₀‖ > ε / ‖c‖ then f (γ t) * deriv γ t else 0 := by
-    intro ε t
-    by_cases hεt : ‖γ t - z₀‖ > ε / ‖c‖
-    · have hscaled : ‖c * γ t - c * z₀‖ > ε := by
-        rw [← mul_sub, norm_mul]
-        have hmul := mul_lt_mul_of_pos_right hεt (norm_pos_iff.mpr hc)
-        have hmul' : ε < ‖γ t - z₀‖ * ‖c‖ := by
-          simpa [div_mul_cancel₀ _ (norm_ne_zero_iff.mpr hc)] using hmul
-        simpa [mul_comm] using hmul'
-      rw [if_pos hscaled, if_pos hεt, deriv_const_mul_field]
-      simp only [inv_mul_cancel_left₀ hc]
-      rw [show c⁻¹ * f (γ t) * (c * deriv γ t) = c⁻¹ * c * (f (γ t) * deriv γ t) by ring,
-        inv_mul_cancel₀ hc, one_mul]
-    · have hscaled : ¬ ‖c * γ t - c * z₀‖ > ε := by
-        rw [← mul_sub, norm_mul, not_lt]
-        rw [not_lt] at hεt
-        have hmul := mul_le_mul_of_nonneg_right hεt (norm_nonneg c)
-        rwa [div_mul_cancel₀ _ (norm_ne_zero_iff.mpr hc), mul_comm] at hmul
-      rw [if_neg hscaled, if_neg hεt]
   refine HasCauchyPVAt.intro ?_ ?_
   · filter_upwards [hscale.eventually h.eventually_intervalIntegrable] with ε hε
-    exact (intervalIntegrable_congr fun t _ => hbody ε t).mpr hε
+    exact (intervalIntegrable_congr fun t _ => truncated_const_mul_curve_eq hc ε t).mpr hε
   · refine h.tendsto.comp hscale |>.congr' ?_
     filter_upwards with ε
-    exact intervalIntegral.integral_congr fun t _ => (hbody ε t).symm
+    exact intervalIntegral.integral_congr fun t _ => (truncated_const_mul_curve_eq hc ε t).symm
 
 /-- Existence form of `HasCauchyPVAt.const_mul_curve`: nonzero scaling of the curve and excision
 point preserves existence of a single-point Cauchy principal value. -/
@@ -458,6 +462,47 @@ theorem CauchyPVExistsAt.const_mul_curve {γ : ℝ → ℂ} {a b : ℝ} {f : ℂ
     CauchyPVExistsAt (fun t => c * γ t) a b (fun z => c⁻¹ * f (c⁻¹ * z)) (c * z₀) :=
   let ⟨_, hL⟩ := cauchyPVExistsAt_iff.mp h
   CauchyPVExistsAt.intro (hL.const_mul_curve hc)
+
+/-- Reindexing a `limUnder` by a self-map of the source filter that fixes it leaves the value
+unchanged: if `Filter.map φ F = F`, then `limUnder F (g ∘ φ) = limUnder F g`, even when the limit
+does not exist. -/
+private theorem limUnder_comp_of_map_eq {α : Type*} {β : Type*} [TopologicalSpace β] [Nonempty β]
+    {F : Filter α} {φ : α → α} (hφ : Filter.map φ F = F) (g : α → β) :
+    Filter.limUnder F (g ∘ φ) = Filter.limUnder F g := by
+  unfold Filter.limUnder
+  rw [← Filter.map_map, hφ]
+
+/-- Value form of `HasCauchyPVAt.const_mul_curve`: simultaneous nonzero scaling of the curve and the
+excision point preserves the raw single-point Cauchy principal *value*, with no existence
+hypothesis. Scaling only reindexes the excision radius by the order-isomorphism `ε ↦ ε / ‖c‖`, which
+fixes the filter `𝓝[>] 0`, so the underlying `limUnder` is unchanged even when it does not
+converge. -/
+theorem cauchyPVAt_const_mul_curve {γ : ℝ → ℂ} {a b : ℝ} {f : ℂ → ℂ} {z₀ c : ℂ} (hc : c ≠ 0) :
+    cauchyPVAt (fun t => c * γ t) a b (fun z => c⁻¹ * f (c⁻¹ * z)) (c * z₀)
+      = cauchyPVAt γ a b f z₀ := by
+  have hmap : Filter.map (fun ε : ℝ => ε / ‖c‖) (𝓝[>] (0 : ℝ)) = 𝓝[>] (0 : ℝ) := by
+    have hx : (0 : ℝ) < ‖c‖⁻¹ := inv_pos.mpr (norm_pos_iff.mpr hc)
+    have hcne : ‖c‖ ≠ 0 := norm_ne_zero_iff.mpr hc
+    have hsurj : Function.Surjective (fun x : ℝ => ‖c‖⁻¹ * x) := fun y =>
+      ⟨‖c‖ * y, by simpa using inv_mul_cancel_left₀ hcne y⟩
+    have hfun : (fun ε : ℝ => ε / ‖c‖) = fun ε => ‖c‖⁻¹ * ε := funext fun ε => div_eq_inv_mul ε ‖c‖
+    rw [hfun]
+    conv_lhs => rw [← comap_mulLeft_nhdsGT_zero hx]
+    exact Filter.map_comap_of_surjective hsurj _
+  have hbodyeq : (fun ε : ℝ => ∫ t in a..b, if ‖c * γ t - c * z₀‖ > ε then
+        (fun z => c⁻¹ * f (c⁻¹ * z)) (c * γ t) * deriv (fun t => c * γ t) t else 0)
+      = (fun ε' : ℝ => ∫ t in a..b, if ‖γ t - z₀‖ > ε' then f (γ t) * deriv γ t else 0)
+          ∘ (fun ε => ε / ‖c‖) :=
+    funext fun ε =>
+      intervalIntegral.integral_congr fun t _ => truncated_const_mul_curve_eq hc ε t
+  calc cauchyPVAt (fun t => c * γ t) a b (fun z => c⁻¹ * f (c⁻¹ * z)) (c * z₀)
+      = Filter.limUnder (𝓝[>] (0 : ℝ))
+          ((fun ε' : ℝ => ∫ t in a..b, if ‖γ t - z₀‖ > ε' then f (γ t) * deriv γ t else 0)
+            ∘ (fun ε => ε / ‖c‖)) := congrArg (Filter.limUnder (𝓝[>] (0 : ℝ))) hbodyeq
+    _ = Filter.limUnder (𝓝[>] (0 : ℝ))
+          (fun ε' : ℝ => ∫ t in a..b, if ‖γ t - z₀‖ > ε' then f (γ t) * deriv γ t else 0) :=
+        limUnder_comp_of_map_eq hmap _
+    _ = cauchyPVAt γ a b f z₀ := rfl
 
 /-- Reversing the interval orientation negates a single-point Cauchy principal value. -/
 theorem HasCauchyPVAt.symm {γ : ℝ → ℂ} {a b : ℝ} {f : ℂ → ℂ} {z₀ L : ℂ}

--- a/TauCeti/Analysis/Contour/CauchyPrincipalValue.lean
+++ b/TauCeti/Analysis/Contour/CauchyPrincipalValue.lean
@@ -428,8 +428,7 @@ private theorem truncated_const_mul_curve_eq {γ : ℝ → ℂ} {f : ℂ → ℂ
       simpa [mul_comm] using hmul'
     rw [if_pos hscaled, if_pos hεt, deriv_const_mul_field]
     simp only [inv_mul_cancel_left₀ hc]
-    rw [show c⁻¹ * f (γ t) * (c * deriv γ t) = c⁻¹ * c * (f (γ t) * deriv γ t) by ring,
-      inv_mul_cancel₀ hc, one_mul]
+    rw [mul_mul_mul_comm, inv_mul_cancel₀ hc, one_mul]
   · have hscaled : ¬ ‖c * γ t - c * z₀‖ > ε := by
       rw [← mul_sub, norm_mul, not_lt]
       rw [not_lt] at hεt

--- a/TauCeti/Analysis/Contour/WindingNumberScale.lean
+++ b/TauCeti/Analysis/Contour/WindingNumberScale.lean
@@ -1,0 +1,153 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Chris Birkbeck
+-/
+module
+
+public import TauCeti.Analysis.Contour.NullHomologous
+import Mathlib.Analysis.Calculus.Deriv.Mul
+
+/-!
+# Scaling invariance for contour winding numbers
+
+This file records the basic nonzero-scaling API for the generalized winding number. Multiplying
+both the curve and the distinguished point by the same nonzero complex number leaves the index
+principal value unchanged, so the winding number and null-homology are invariant.
+
+These lemmas are bookkeeping for the roadmap's curve and cycle layer. The geometry of the
+generalized winding number is local at a crossing or sector; after translating the crossing point
+to the origin, finite-decomposition arguments also rescale the local model before applying the
+sector computation.
+
+## Main results
+
+* `Contour.windingNumber_const_mul` — multiplying the curve and base point by the same nonzero
+  complex number preserves the generalized winding number, under the principal-value existence
+  hypothesis for the original kernel.
+* `Contour.IsNullHomologous.const_mul` — null-homology is preserved by nonzero complex scaling of
+  both the curve and the ambient set.
+
+## Provenance
+
+This is routine API around the Hungerbühler--Wasem generalized winding number from the contour
+integration roadmap; no formal source is vendored.
+-/
+
+public section
+
+noncomputable section
+
+open Filter Topology
+
+namespace TauCeti.Contour
+
+variable {γ : ℝ → ℂ} {a b : ℝ} {z₀ c : ℂ} {Ω : Set ℂ}
+
+/-- The kernel integrand used to define the generalized winding number about `z₀`. This local
+abbreviation keeps the scaling statements readable. -/
+local notation "κ[" z "]" => (fun w : ℂ => (w - z)⁻¹)
+
+private theorem tendsto_div_nhdsWithin_pos (hc : c ≠ 0) :
+    Tendsto (fun ε : ℝ => ε / ‖c‖) (𝓝[>] (0 : ℝ)) (𝓝[>] (0 : ℝ)) := by
+  have hnorm : 0 < ‖c‖ := norm_pos_iff.mpr hc
+  have hnhds : Tendsto (fun ε : ℝ => ε / ‖c‖) (𝓝 (0 : ℝ)) (𝓝 (0 : ℝ)) := by
+    simpa using (tendsto_id (x := 𝓝 (0 : ℝ))).div_const ‖c‖
+  have hpos : Tendsto (fun ε : ℝ => ε / ‖c‖) (𝓟 (Set.Ioi (0 : ℝ))) (𝓟 (Set.Ioi (0 : ℝ))) := by
+    refine tendsto_principal_principal.mpr ?_
+    intro ε hε
+    exact div_pos hε hnorm
+  exact Tendsto.inf hnhds hpos
+
+private theorem windingKernel_const_mul_hasCauchyPVAt
+    (h : HasCauchyPVAt γ a b κ[z₀] z₀ L) (hc : c ≠ 0) :
+    HasCauchyPVAt (fun t => c * γ t) a b κ[c * z₀] (c * z₀) L := by
+  have hscale : Tendsto (fun ε : ℝ => ε / ‖c‖) (𝓝[>] (0 : ℝ)) (𝓝[>] (0 : ℝ)) :=
+    tendsto_div_nhdsWithin_pos (c := c) hc
+  refine HasCauchyPVAt.intro ?_ ?_
+  · filter_upwards [hscale.eventually h.eventually_intervalIntegrable] with ε hε
+    refine (intervalIntegrable_congr fun t _ => ?_).mpr hε
+    by_cases hεt : ‖γ t - z₀‖ > ε / ‖c‖
+    · have hscaled : ‖c * γ t - c * z₀‖ > ε := by
+        rw [← mul_sub, norm_mul]
+        have hmul := mul_lt_mul_of_pos_right hεt (norm_pos_iff.mpr hc)
+        have hmul' : ε < ‖γ t - z₀‖ * ‖c‖ := by
+          simpa [div_mul_cancel₀ _ (norm_ne_zero_iff.mpr hc)] using hmul
+        simpa [mul_comm] using hmul'
+      rw [if_pos hscaled, if_pos hεt, deriv_const_mul_field]
+      field_simp [hc, sub_eq_add_neg, mul_add, add_mul, mul_assoc, mul_left_comm, mul_comm]
+    · have hscaled : ¬ ‖c * γ t - c * z₀‖ > ε := by
+        rw [← mul_sub, norm_mul, not_lt]
+        rw [not_lt] at hεt
+        have hmul := mul_le_mul_of_nonneg_right hεt (norm_nonneg c)
+        rwa [div_mul_cancel₀ _ (norm_ne_zero_iff.mpr hc), mul_comm] at hmul
+      rw [if_neg hscaled, if_neg hεt]
+  · refine h.tendsto.comp hscale |>.congr' ?_
+    filter_upwards with ε
+    refine intervalIntegral.integral_congr fun t _ => ?_
+    by_cases hεt : ‖γ t - z₀‖ > ε / ‖c‖
+    · have hscaled : ‖c * γ t - c * z₀‖ > ε := by
+        rw [← mul_sub, norm_mul]
+        have hmul := mul_lt_mul_of_pos_right hεt (norm_pos_iff.mpr hc)
+        have hmul' : ε < ‖γ t - z₀‖ * ‖c‖ := by
+          simpa [div_mul_cancel₀ _ (norm_ne_zero_iff.mpr hc)] using hmul
+        simpa [mul_comm] using hmul'
+      rw [if_pos hscaled, if_pos hεt, deriv_const_mul_field]
+      field_simp [hc, sub_eq_add_neg, mul_add, add_mul, mul_assoc, mul_left_comm, mul_comm]
+    · have hscaled : ¬ ‖c * γ t - c * z₀‖ > ε := by
+        rw [← mul_sub, norm_mul, not_lt]
+        rw [not_lt] at hεt
+        have hmul := mul_le_mul_of_nonneg_right hεt (norm_nonneg c)
+        rwa [div_mul_cancel₀ _ (norm_ne_zero_iff.mpr hc), mul_comm] at hmul
+      rw [if_neg hscaled, if_neg hεt]
+
+/-- The generalized winding number is invariant under simultaneous multiplication of the curve
+and the base point by a nonzero complex number, provided the original principal value exists. -/
+theorem windingNumber_const_mul (h : CauchyPVExistsAt γ a b κ[z₀] z₀) (hc : c ≠ 0) :
+    windingNumber (fun t => c * γ t) a b (c * z₀) = windingNumber γ a b z₀ := by
+  rw [windingNumber_eq_of_hasCauchyPVAt
+      (windingKernel_const_mul_hasCauchyPVAt h.hasCauchyPVAt_cauchyPVAt hc),
+    windingNumber_eq_of_hasCauchyPVAt h.hasCauchyPVAt_cauchyPVAt]
+
+/-- Pointwise vanishing of a winding number is preserved by simultaneous multiplication of the
+curve and base point by a nonzero complex number, under the original principal-value existence
+hypothesis. -/
+theorem windingNumber_eq_zero_const_mul (hzero : windingNumber γ a b z₀ = 0)
+    (hpv : CauchyPVExistsAt γ a b κ[z₀] z₀) (hc : c ≠ 0) :
+    windingNumber (fun t => c * γ t) a b (c * z₀) = 0 := by
+  rw [windingNumber_const_mul hpv hc, hzero]
+
+/-- Null-homology is preserved by nonzero complex scaling, provided the pointwise principal values
+defining the original exterior winding numbers exist. -/
+theorem IsNullHomologous.const_mul (h : IsNullHomologous γ a b Ω)
+    (hpv : ∀ z ∉ Ω, CauchyPVExistsAt γ a b κ[z] z) (hc : c ≠ 0) :
+    IsNullHomologous (fun t => c * γ t) a b ((fun z => c * z) '' Ω) := by
+  rw [isNullHomologous_iff] at h ⊢
+  intro z hz
+  have hpre_not_mem : c⁻¹ * z ∉ Ω := by
+    intro hzΩ
+    exact hz ⟨c⁻¹ * z, hzΩ, by field_simp [hc]⟩
+  have hz_eq : z = c * (c⁻¹ * z) := by field_simp [hc]
+  rw [hz_eq]
+  exact windingNumber_eq_zero_const_mul (h (c⁻¹ * z) hpre_not_mem)
+    (hpv (c⁻¹ * z) hpre_not_mem) hc
+
+/-- Null-homology is preserved by nonzero complex scaling in the ordinary avoided-pole case. If the
+curve lies in `Ω`, every exterior point of the scaled ambient set is avoided by the scaled curve, so
+the required original principal values are ordinary integrals. -/
+theorem IsNullHomologous.const_mul_of_avoidance (h : IsNullHomologous γ a b Ω)
+    (hγ : ∀ t ∈ Set.uIcc a b, γ t ∈ Ω)
+    (hcont : ContinuousOn γ (Set.uIcc a b))
+    (hint : ∀ z ∉ Ω,
+      IntervalIntegrable (fun t => (γ t - z)⁻¹ * deriv γ t) MeasureTheory.volume a b)
+    (hc : c ≠ 0) :
+    IsNullHomologous (fun t => c * γ t) a b ((fun z => c * z) '' Ω) := by
+  refine h.const_mul ?_ hc
+  intro z hz
+  refine cauchyPVExistsAt_of_avoidance hcont ?_ (hint z hz)
+  intro t ht htz
+  exact hz (htz ▸ hγ t ht)
+
+end TauCeti.Contour
+
+end

--- a/TauCeti/Analysis/Contour/WindingNumberScale.lean
+++ b/TauCeti/Analysis/Contour/WindingNumberScale.lean
@@ -22,6 +22,11 @@ sector computation.
 
 ## Main results
 
+* `Contour.hasCauchyPVAt_windingKernel_const_mul` /
+  `Contour.cauchyPVExistsAt_windingKernel_const_mul` — the index principal value transports under
+  nonzero scaling of the curve and base point; these are exposed so downstream normalization steps
+  can obtain the scaled `HasCauchyPVAt` / `CauchyPVExistsAt` fact and chain further
+  principal-value APIs.
 * `Contour.windingNumber_const_mul` — multiplying the curve and base point by the same nonzero
   complex number preserves the generalized winding number, under the principal-value existence
   hypothesis for the original kernel.
@@ -48,65 +53,60 @@ variable {γ : ℝ → ℂ} {a b : ℝ} {z₀ c : ℂ} {Ω : Set ℂ}
 abbreviation keeps the scaling statements readable. -/
 local notation "κ[" z "]" => (fun w : ℂ => (w - z)⁻¹)
 
-private theorem tendsto_div_nhdsWithin_pos (hc : c ≠ 0) :
-    Tendsto (fun ε : ℝ => ε / ‖c‖) (𝓝[>] (0 : ℝ)) (𝓝[>] (0 : ℝ)) := by
-  have hnorm : 0 < ‖c‖ := norm_pos_iff.mpr hc
-  have hnhds : Tendsto (fun ε : ℝ => ε / ‖c‖) (𝓝 (0 : ℝ)) (𝓝 (0 : ℝ)) := by
-    simpa using (tendsto_id (x := 𝓝 (0 : ℝ))).div_const ‖c‖
-  have hpos : Tendsto (fun ε : ℝ => ε / ‖c‖) (𝓟 (Set.Ioi (0 : ℝ))) (𝓟 (Set.Ioi (0 : ℝ))) := by
-    refine tendsto_principal_principal.mpr ?_
-    intro ε hε
-    exact div_pos hε hnorm
-  exact Tendsto.inf hnhds hpos
-
-private theorem windingKernel_const_mul_hasCauchyPVAt
+/-- **Index principal value under nonzero scaling.** Multiplying the curve and the base point by a
+nonzero complex number `c` transports the single-point Cauchy principal value of the winding kernel
+`κ[z₀]` about `z₀` to that of `κ[c * z₀]` about `c * z₀`, with the same value: the excision radius
+rescales by `‖c‖` and the kernel and derivative factors cancel. Exposed so downstream normalization
+steps can chain further principal-value APIs from the scaled fact. -/
+theorem hasCauchyPVAt_windingKernel_const_mul
     (h : HasCauchyPVAt γ a b κ[z₀] z₀ L) (hc : c ≠ 0) :
     HasCauchyPVAt (fun t => c * γ t) a b κ[c * z₀] (c * z₀) L := by
-  have hscale : Tendsto (fun ε : ℝ => ε / ‖c‖) (𝓝[>] (0 : ℝ)) (𝓝[>] (0 : ℝ)) :=
-    tendsto_div_nhdsWithin_pos (c := c) hc
+  have hscale : Tendsto (fun ε : ℝ => ε / ‖c‖) (𝓝[>] (0 : ℝ)) (𝓝[>] (0 : ℝ)) := by
+    simpa [div_eq_mul_inv] using
+      Filter.TendstoNhdsWithinIoi.mul_const (b := ‖c‖⁻¹) (c := 0)
+        (inv_pos.mpr (norm_pos_iff.mpr hc)) (tendsto_id (x := 𝓝[>] (0 : ℝ)))
+  -- The scaled excision at radius `ε` reproduces the original excision at radius `ε / ‖c‖`, and the
+  -- kernel and derivative factors cancel, so the two truncated integrands agree pointwise.
+  have hbody : ∀ (ε t : ℝ),
+      (if ‖c * γ t - c * z₀‖ > ε then κ[c * z₀] (c * γ t) * deriv (fun t => c * γ t) t else 0)
+        = if ‖γ t - z₀‖ > ε / ‖c‖ then κ[z₀] (γ t) * deriv γ t else 0 := by
+    intro ε t
+    by_cases hεt : ‖γ t - z₀‖ > ε / ‖c‖
+    · have hscaled : ‖c * γ t - c * z₀‖ > ε := by
+        rw [← mul_sub, norm_mul]
+        have hmul := mul_lt_mul_of_pos_right hεt (norm_pos_iff.mpr hc)
+        have hmul' : ε < ‖γ t - z₀‖ * ‖c‖ := by
+          simpa [div_mul_cancel₀ _ (norm_ne_zero_iff.mpr hc)] using hmul
+        simpa [mul_comm] using hmul'
+      rw [if_pos hscaled, if_pos hεt, deriv_const_mul_field]
+      field_simp [hc, sub_eq_add_neg, mul_add, add_mul, mul_assoc, mul_left_comm, mul_comm]
+    · have hscaled : ¬ ‖c * γ t - c * z₀‖ > ε := by
+        rw [← mul_sub, norm_mul, not_lt]
+        rw [not_lt] at hεt
+        have hmul := mul_le_mul_of_nonneg_right hεt (norm_nonneg c)
+        rwa [div_mul_cancel₀ _ (norm_ne_zero_iff.mpr hc), mul_comm] at hmul
+      rw [if_neg hscaled, if_neg hεt]
   refine HasCauchyPVAt.intro ?_ ?_
   · filter_upwards [hscale.eventually h.eventually_intervalIntegrable] with ε hε
-    refine (intervalIntegrable_congr fun t _ => ?_).mpr hε
-    by_cases hεt : ‖γ t - z₀‖ > ε / ‖c‖
-    · have hscaled : ‖c * γ t - c * z₀‖ > ε := by
-        rw [← mul_sub, norm_mul]
-        have hmul := mul_lt_mul_of_pos_right hεt (norm_pos_iff.mpr hc)
-        have hmul' : ε < ‖γ t - z₀‖ * ‖c‖ := by
-          simpa [div_mul_cancel₀ _ (norm_ne_zero_iff.mpr hc)] using hmul
-        simpa [mul_comm] using hmul'
-      rw [if_pos hscaled, if_pos hεt, deriv_const_mul_field]
-      field_simp [hc, sub_eq_add_neg, mul_add, add_mul, mul_assoc, mul_left_comm, mul_comm]
-    · have hscaled : ¬ ‖c * γ t - c * z₀‖ > ε := by
-        rw [← mul_sub, norm_mul, not_lt]
-        rw [not_lt] at hεt
-        have hmul := mul_le_mul_of_nonneg_right hεt (norm_nonneg c)
-        rwa [div_mul_cancel₀ _ (norm_ne_zero_iff.mpr hc), mul_comm] at hmul
-      rw [if_neg hscaled, if_neg hεt]
+    exact (intervalIntegrable_congr fun t _ => hbody ε t).mpr hε
   · refine h.tendsto.comp hscale |>.congr' ?_
     filter_upwards with ε
-    refine intervalIntegral.integral_congr fun t _ => ?_
-    by_cases hεt : ‖γ t - z₀‖ > ε / ‖c‖
-    · have hscaled : ‖c * γ t - c * z₀‖ > ε := by
-        rw [← mul_sub, norm_mul]
-        have hmul := mul_lt_mul_of_pos_right hεt (norm_pos_iff.mpr hc)
-        have hmul' : ε < ‖γ t - z₀‖ * ‖c‖ := by
-          simpa [div_mul_cancel₀ _ (norm_ne_zero_iff.mpr hc)] using hmul
-        simpa [mul_comm] using hmul'
-      rw [if_pos hscaled, if_pos hεt, deriv_const_mul_field]
-      field_simp [hc, sub_eq_add_neg, mul_add, add_mul, mul_assoc, mul_left_comm, mul_comm]
-    · have hscaled : ¬ ‖c * γ t - c * z₀‖ > ε := by
-        rw [← mul_sub, norm_mul, not_lt]
-        rw [not_lt] at hεt
-        have hmul := mul_le_mul_of_nonneg_right hεt (norm_nonneg c)
-        rwa [div_mul_cancel₀ _ (norm_ne_zero_iff.mpr hc), mul_comm] at hmul
-      rw [if_neg hscaled, if_neg hεt]
+    exact intervalIntegral.integral_congr fun t _ => (hbody ε t).symm
+
+/-- Existence form of `hasCauchyPVAt_windingKernel_const_mul`: nonzero scaling of the curve and base
+point preserves existence of the index principal value, exposed for the same downstream chaining. -/
+theorem cauchyPVExistsAt_windingKernel_const_mul
+    (h : CauchyPVExistsAt γ a b κ[z₀] z₀) (hc : c ≠ 0) :
+    CauchyPVExistsAt (fun t => c * γ t) a b κ[c * z₀] (c * z₀) :=
+  let ⟨_, hL⟩ := cauchyPVExistsAt_iff.mp h
+  CauchyPVExistsAt.intro (hasCauchyPVAt_windingKernel_const_mul hL hc)
 
 /-- The generalized winding number is invariant under simultaneous multiplication of the curve
 and the base point by a nonzero complex number, provided the original principal value exists. -/
 theorem windingNumber_const_mul (h : CauchyPVExistsAt γ a b κ[z₀] z₀) (hc : c ≠ 0) :
     windingNumber (fun t => c * γ t) a b (c * z₀) = windingNumber γ a b z₀ := by
   rw [windingNumber_eq_of_hasCauchyPVAt
-      (windingKernel_const_mul_hasCauchyPVAt h.hasCauchyPVAt_cauchyPVAt hc),
+      (hasCauchyPVAt_windingKernel_const_mul h.hasCauchyPVAt_cauchyPVAt hc),
     windingNumber_eq_of_hasCauchyPVAt h.hasCauchyPVAt_cauchyPVAt]
 
 /-- Pointwise vanishing of a winding number is preserved by simultaneous multiplication of the

--- a/TauCeti/Analysis/Contour/WindingNumberScale.lean
+++ b/TauCeti/Analysis/Contour/WindingNumberScale.lean
@@ -51,6 +51,11 @@ variable {γ : ℝ → ℂ} {a b : ℝ} {z₀ c : ℂ} {Ω : Set ℂ}
 abbreviation keeps the scaling statements readable. -/
 local notation "κ[" z "]" => (fun w : ℂ => (w - z)⁻¹)
 
+private lemma windingKernel_const_mul_eq (hc : c ≠ 0) (w : ℂ) :
+    c⁻¹ * (c⁻¹ * (c * w) - z₀)⁻¹ = (c * w - c * z₀)⁻¹ := by
+  simp only [inv_mul_cancel_left₀ hc]
+  rw [← mul_sub, mul_inv]
+
 /-- **Index principal value under nonzero scaling.** Multiplying the curve and the base point by a
 nonzero complex number `c` transports the single-point Cauchy principal value of the winding kernel
 `κ[z₀]` about `z₀` to that of `κ[c * z₀]` about `c * z₀`, with the same value. This specializes the
@@ -61,9 +66,7 @@ theorem hasCauchyPVAt_windingKernel_const_mul
     (h : HasCauchyPVAt γ a b κ[z₀] z₀ L) (hc : c ≠ 0) :
     HasCauchyPVAt (fun t => c * γ t) a b κ[c * z₀] (c * z₀) L := by
   refine (h.const_mul_curve hc).congr_along_curve fun t _ => ?_
-  -- The rescaled winding kernel `z ↦ c⁻¹ * (c⁻¹ * z - z₀)⁻¹` agrees with `κ[c * z₀]` at `c * γ t`.
-  simp only [inv_mul_cancel_left₀ hc]
-  rw [← mul_sub, mul_inv]
+  exact windingKernel_const_mul_eq (z₀ := z₀) hc (γ t)
 
 /-- Existence form of `hasCauchyPVAt_windingKernel_const_mul`: nonzero scaling of the curve and base
 point preserves existence of the index principal value, exposed for the same downstream chaining. -/
@@ -83,13 +86,11 @@ theorem windingNumber_const_mul (hc : c ≠ 0) :
     (f := κ[c * z₀]) (g := fun z => c⁻¹ * κ[z₀] (c⁻¹ * z)) (z₀ := c * z₀)]
   · exact cauchyPVAt_const_mul_curve (γ := γ) (a := a) (b := b) (f := κ[z₀]) (z₀ := z₀) hc
   · intro t _
-    -- `κ[c * z₀] (c * γ t)` agrees with the rescaled kernel `c⁻¹ * κ[z₀] (c⁻¹ * (c * γ t))`.
-    simp only [inv_mul_cancel_left₀ hc]
-    rw [← mul_sub, mul_inv]
+    exact (windingKernel_const_mul_eq (z₀ := z₀) hc (γ t)).symm
 
 /-- Pointwise vanishing of a winding number is preserved by simultaneous multiplication of the
 curve and base point by a nonzero complex number. -/
-theorem windingNumber_eq_zero_const_mul (hzero : windingNumber γ a b z₀ = 0) (hc : c ≠ 0) :
+private theorem windingNumber_eq_zero_const_mul (hzero : windingNumber γ a b z₀ = 0) (hc : c ≠ 0) :
     windingNumber (fun t => c * γ t) a b (c * z₀) = 0 := by
   rw [windingNumber_const_mul hc, hzero]
 

--- a/TauCeti/Analysis/Contour/WindingNumberScale.lean
+++ b/TauCeti/Analysis/Contour/WindingNumberScale.lean
@@ -23,8 +23,8 @@ sector computation.
 
 ## Main results
 
-* `Contour.hasCauchyPVAt_windingKernel_const_mul` /
-  `Contour.cauchyPVExistsAt_windingKernel_const_mul` — the index principal value transports under
+* `Contour.hasCauchyPVAt_inv_sub_const_mul` /
+  `Contour.cauchyPVExistsAt_inv_sub_const_mul` — the index principal value transports under
   nonzero scaling of the curve and base point; these are exposed so downstream normalization steps
   can obtain the scaled `HasCauchyPVAt` / `CauchyPVExistsAt` fact and chain further
   principal-value APIs.
@@ -51,7 +51,7 @@ variable {γ : ℝ → ℂ} {a b : ℝ} {z₀ c : ℂ} {Ω : Set ℂ}
 abbreviation keeps the scaling statements readable. -/
 local notation "κ[" z "]" => (fun w : ℂ => (w - z)⁻¹)
 
-private lemma windingKernel_const_mul_eq (hc : c ≠ 0) (w : ℂ) :
+private lemma inv_sub_const_mul_eq (hc : c ≠ 0) (w : ℂ) :
     c⁻¹ * (c⁻¹ * (c * w) - z₀)⁻¹ = (c * w - c * z₀)⁻¹ := by
   simp only [inv_mul_cancel_left₀ hc]
   rw [← mul_sub, mul_inv]
@@ -62,19 +62,19 @@ nonzero complex number `c` transports the single-point Cauchy principal value of
 general `HasCauchyPVAt.const_mul_curve` to the winding kernel, where the rescaled integrand
 `z ↦ c⁻¹ * κ[z₀] (c⁻¹ * z)` agrees with `κ[c * z₀]` along the scaled curve. Exposed so downstream
 normalization steps can chain further principal-value APIs from the scaled fact. -/
-theorem hasCauchyPVAt_windingKernel_const_mul
+theorem hasCauchyPVAt_inv_sub_const_mul
     (h : HasCauchyPVAt γ a b κ[z₀] z₀ L) (hc : c ≠ 0) :
     HasCauchyPVAt (fun t => c * γ t) a b κ[c * z₀] (c * z₀) L := by
   refine (h.const_mul_curve hc).congr_along_curve fun t _ => ?_
-  exact windingKernel_const_mul_eq (z₀ := z₀) hc (γ t)
+  exact inv_sub_const_mul_eq (z₀ := z₀) hc (γ t)
 
-/-- Existence form of `hasCauchyPVAt_windingKernel_const_mul`: nonzero scaling of the curve and base
+/-- Existence form of `hasCauchyPVAt_inv_sub_const_mul`: nonzero scaling of the curve and base
 point preserves existence of the index principal value, exposed for the same downstream chaining. -/
-theorem cauchyPVExistsAt_windingKernel_const_mul
+theorem cauchyPVExistsAt_inv_sub_const_mul
     (h : CauchyPVExistsAt γ a b κ[z₀] z₀) (hc : c ≠ 0) :
     CauchyPVExistsAt (fun t => c * γ t) a b κ[c * z₀] (c * z₀) :=
   let ⟨_, hL⟩ := cauchyPVExistsAt_iff.mp h
-  CauchyPVExistsAt.intro (hasCauchyPVAt_windingKernel_const_mul hL hc)
+  CauchyPVExistsAt.intro (hasCauchyPVAt_inv_sub_const_mul hL hc)
 
 /-- The generalized winding number is invariant under simultaneous multiplication of the curve
 and the base point by a nonzero complex number. -/
@@ -86,7 +86,7 @@ theorem windingNumber_const_mul (hc : c ≠ 0) :
     (f := κ[c * z₀]) (g := fun z => c⁻¹ * κ[z₀] (c⁻¹ * z)) (z₀ := c * z₀)]
   · exact cauchyPVAt_const_mul_curve (γ := γ) (a := a) (b := b) (f := κ[z₀]) (z₀ := z₀) hc
   · intro t _
-    exact (windingKernel_const_mul_eq (z₀ := z₀) hc (γ t)).symm
+    exact (inv_sub_const_mul_eq (z₀ := z₀) hc (γ t)).symm
 
 /-- Pointwise vanishing of a winding number is preserved by simultaneous multiplication of the
 curve and base point by a nonzero complex number. -/

--- a/TauCeti/Analysis/Contour/WindingNumberScale.lean
+++ b/TauCeti/Analysis/Contour/WindingNumberScale.lean
@@ -12,9 +12,9 @@ public import TauCeti.Analysis.Contour.NullHomologous
 
 This file records the basic nonzero-scaling API for the generalized winding number. Multiplying
 both the curve and the distinguished point by the same nonzero complex number leaves the index
-principal value unchanged, so the winding number is invariant. Null-homology is likewise preserved,
-but only under the pointwise `CauchyPVExistsAt` hypothesis for the exterior points (supplied
-outright in the avoided-pole wrapper).
+principal value unchanged, so the winding number and null-homology are invariant. Scaling only
+reindexes the excision radius by the order-isomorphism `ε ↦ ε / ‖c‖`, so no principal-value
+existence hypothesis is needed.
 
 These lemmas are bookkeeping for the roadmap's curve and cycle layer. The geometry of the
 generalized winding number is local at a crossing or sector; after translating the crossing point
@@ -29,12 +29,9 @@ sector computation.
   can obtain the scaled `HasCauchyPVAt` / `CauchyPVExistsAt` fact and chain further
   principal-value APIs.
 * `Contour.windingNumber_const_mul` — multiplying the curve and base point by the same nonzero
-  complex number preserves the generalized winding number, under the principal-value existence
-  hypothesis for the original kernel.
+  complex number preserves the generalized winding number.
 * `Contour.IsNullHomologous.const_mul` — null-homology is preserved by nonzero complex scaling of
-  both the curve and the ambient set, provided the pointwise principal values defining the original
-  exterior winding numbers exist (`Contour.IsNullHomologous.const_mul_of_avoidance` supplies this
-  hypothesis in the avoided-pole case).
+  both the curve and the ambient set.
 
 ## Provenance
 
@@ -77,25 +74,27 @@ theorem cauchyPVExistsAt_windingKernel_const_mul
   CauchyPVExistsAt.intro (hasCauchyPVAt_windingKernel_const_mul hL hc)
 
 /-- The generalized winding number is invariant under simultaneous multiplication of the curve
-and the base point by a nonzero complex number, provided the original principal value exists. -/
-theorem windingNumber_const_mul (h : CauchyPVExistsAt γ a b κ[z₀] z₀) (hc : c ≠ 0) :
+and the base point by a nonzero complex number. -/
+theorem windingNumber_const_mul (hc : c ≠ 0) :
     windingNumber (fun t => c * γ t) a b (c * z₀) = windingNumber γ a b z₀ := by
-  rw [windingNumber_eq_of_hasCauchyPVAt
-      (hasCauchyPVAt_windingKernel_const_mul h.hasCauchyPVAt_cauchyPVAt hc),
-    windingNumber_eq_of_hasCauchyPVAt h.hasCauchyPVAt_cauchyPVAt]
+  rw [windingNumber_eq_cauchyPVAt, windingNumber_eq_cauchyPVAt]
+  congr 1
+  rw [cauchyPVAt_congr_along_curve (γ := fun t => c * γ t)
+    (f := κ[c * z₀]) (g := fun z => c⁻¹ * κ[z₀] (c⁻¹ * z)) (z₀ := c * z₀)]
+  · exact cauchyPVAt_const_mul_curve (γ := γ) (a := a) (b := b) (f := κ[z₀]) (z₀ := z₀) hc
+  · intro t _
+    -- `κ[c * z₀] (c * γ t)` agrees with the rescaled kernel `c⁻¹ * κ[z₀] (c⁻¹ * (c * γ t))`.
+    simp only [inv_mul_cancel_left₀ hc]
+    rw [← mul_sub, mul_inv]
 
 /-- Pointwise vanishing of a winding number is preserved by simultaneous multiplication of the
-curve and base point by a nonzero complex number, under the original principal-value existence
-hypothesis. -/
-theorem windingNumber_eq_zero_const_mul (hzero : windingNumber γ a b z₀ = 0)
-    (hpv : CauchyPVExistsAt γ a b κ[z₀] z₀) (hc : c ≠ 0) :
+curve and base point by a nonzero complex number. -/
+theorem windingNumber_eq_zero_const_mul (hzero : windingNumber γ a b z₀ = 0) (hc : c ≠ 0) :
     windingNumber (fun t => c * γ t) a b (c * z₀) = 0 := by
-  rw [windingNumber_const_mul hpv hc, hzero]
+  rw [windingNumber_const_mul hc, hzero]
 
-/-- Null-homology is preserved by nonzero complex scaling, provided the pointwise principal values
-defining the original exterior winding numbers exist. -/
-theorem IsNullHomologous.const_mul (h : IsNullHomologous γ a b Ω)
-    (hpv : ∀ z ∉ Ω, CauchyPVExistsAt γ a b κ[z] z) (hc : c ≠ 0) :
+/-- Null-homology is preserved by nonzero complex scaling of both the curve and the ambient set. -/
+theorem IsNullHomologous.const_mul (h : IsNullHomologous γ a b Ω) (hc : c ≠ 0) :
     IsNullHomologous (fun t => c * γ t) a b ((fun z => c * z) '' Ω) := by
   rw [isNullHomologous_iff] at h ⊢
   intro z hz
@@ -104,24 +103,7 @@ theorem IsNullHomologous.const_mul (h : IsNullHomologous γ a b Ω)
     exact hz ⟨c⁻¹ * z, hzΩ, by field_simp [hc]⟩
   have hz_eq : z = c * (c⁻¹ * z) := by field_simp [hc]
   rw [hz_eq]
-  exact windingNumber_eq_zero_const_mul (h (c⁻¹ * z) hpre_not_mem)
-    (hpv (c⁻¹ * z) hpre_not_mem) hc
-
-/-- Null-homology is preserved by nonzero complex scaling in the ordinary avoided-pole case. If the
-curve lies in `Ω`, every exterior point of the scaled ambient set is avoided by the scaled curve, so
-the required original principal values are ordinary integrals. -/
-theorem IsNullHomologous.const_mul_of_avoidance (h : IsNullHomologous γ a b Ω)
-    (hγ : ∀ t ∈ Set.uIcc a b, γ t ∈ Ω)
-    (hcont : ContinuousOn γ (Set.uIcc a b))
-    (hint : ∀ z ∉ Ω,
-      IntervalIntegrable (fun t => (γ t - z)⁻¹ * deriv γ t) MeasureTheory.volume a b)
-    (hc : c ≠ 0) :
-    IsNullHomologous (fun t => c * γ t) a b ((fun z => c * z) '' Ω) := by
-  refine h.const_mul ?_ hc
-  intro z hz
-  refine cauchyPVExistsAt_of_avoidance hcont ?_ (hint z hz)
-  intro t ht htz
-  exact hz (htz ▸ hγ t ht)
+  exact windingNumber_eq_zero_const_mul (h (c⁻¹ * z) hpre_not_mem) hc
 
 end TauCeti.Contour
 

--- a/TauCeti/Analysis/Contour/WindingNumberScale.lean
+++ b/TauCeti/Analysis/Contour/WindingNumberScale.lean
@@ -6,14 +6,15 @@ Authors: Chris Birkbeck
 module
 
 public import TauCeti.Analysis.Contour.NullHomologous
-import Mathlib.Analysis.Calculus.Deriv.Mul
 
 /-!
 # Scaling invariance for contour winding numbers
 
 This file records the basic nonzero-scaling API for the generalized winding number. Multiplying
 both the curve and the distinguished point by the same nonzero complex number leaves the index
-principal value unchanged, so the winding number and null-homology are invariant.
+principal value unchanged, so the winding number is invariant. Null-homology is likewise preserved,
+but only under the pointwise `CauchyPVExistsAt` hypothesis for the exterior points (supplied
+outright in the avoided-pole wrapper).
 
 These lemmas are bookkeeping for the roadmap's curve and cycle layer. The geometry of the
 generalized winding number is local at a crossing or sector; after translating the crossing point
@@ -31,7 +32,9 @@ sector computation.
   complex number preserves the generalized winding number, under the principal-value existence
   hypothesis for the original kernel.
 * `Contour.IsNullHomologous.const_mul` — null-homology is preserved by nonzero complex scaling of
-  both the curve and the ambient set.
+  both the curve and the ambient set, provided the pointwise principal values defining the original
+  exterior winding numbers exist (`Contour.IsNullHomologous.const_mul_of_avoidance` supplies this
+  hypothesis in the avoided-pole case).
 
 ## Provenance
 
@@ -43,8 +46,6 @@ public section
 
 noncomputable section
 
-open Filter Topology
-
 namespace TauCeti.Contour
 
 variable {γ : ℝ → ℂ} {a b : ℝ} {z₀ c : ℂ} {Ω : Set ℂ}
@@ -55,43 +56,17 @@ local notation "κ[" z "]" => (fun w : ℂ => (w - z)⁻¹)
 
 /-- **Index principal value under nonzero scaling.** Multiplying the curve and the base point by a
 nonzero complex number `c` transports the single-point Cauchy principal value of the winding kernel
-`κ[z₀]` about `z₀` to that of `κ[c * z₀]` about `c * z₀`, with the same value: the excision radius
-rescales by `‖c‖` and the kernel and derivative factors cancel. Exposed so downstream normalization
-steps can chain further principal-value APIs from the scaled fact. -/
+`κ[z₀]` about `z₀` to that of `κ[c * z₀]` about `c * z₀`, with the same value. This specializes the
+general `HasCauchyPVAt.const_mul_curve` to the winding kernel, where the rescaled integrand
+`z ↦ c⁻¹ * κ[z₀] (c⁻¹ * z)` agrees with `κ[c * z₀]` along the scaled curve. Exposed so downstream
+normalization steps can chain further principal-value APIs from the scaled fact. -/
 theorem hasCauchyPVAt_windingKernel_const_mul
     (h : HasCauchyPVAt γ a b κ[z₀] z₀ L) (hc : c ≠ 0) :
     HasCauchyPVAt (fun t => c * γ t) a b κ[c * z₀] (c * z₀) L := by
-  have hscale : Tendsto (fun ε : ℝ => ε / ‖c‖) (𝓝[>] (0 : ℝ)) (𝓝[>] (0 : ℝ)) := by
-    simpa [div_eq_mul_inv] using
-      Filter.TendstoNhdsWithinIoi.mul_const (b := ‖c‖⁻¹) (c := 0)
-        (inv_pos.mpr (norm_pos_iff.mpr hc)) (tendsto_id (x := 𝓝[>] (0 : ℝ)))
-  -- The scaled excision at radius `ε` reproduces the original excision at radius `ε / ‖c‖`, and the
-  -- kernel and derivative factors cancel, so the two truncated integrands agree pointwise.
-  have hbody : ∀ (ε t : ℝ),
-      (if ‖c * γ t - c * z₀‖ > ε then κ[c * z₀] (c * γ t) * deriv (fun t => c * γ t) t else 0)
-        = if ‖γ t - z₀‖ > ε / ‖c‖ then κ[z₀] (γ t) * deriv γ t else 0 := by
-    intro ε t
-    by_cases hεt : ‖γ t - z₀‖ > ε / ‖c‖
-    · have hscaled : ‖c * γ t - c * z₀‖ > ε := by
-        rw [← mul_sub, norm_mul]
-        have hmul := mul_lt_mul_of_pos_right hεt (norm_pos_iff.mpr hc)
-        have hmul' : ε < ‖γ t - z₀‖ * ‖c‖ := by
-          simpa [div_mul_cancel₀ _ (norm_ne_zero_iff.mpr hc)] using hmul
-        simpa [mul_comm] using hmul'
-      rw [if_pos hscaled, if_pos hεt, deriv_const_mul_field]
-      field_simp [hc, sub_eq_add_neg, mul_add, add_mul, mul_assoc, mul_left_comm, mul_comm]
-    · have hscaled : ¬ ‖c * γ t - c * z₀‖ > ε := by
-        rw [← mul_sub, norm_mul, not_lt]
-        rw [not_lt] at hεt
-        have hmul := mul_le_mul_of_nonneg_right hεt (norm_nonneg c)
-        rwa [div_mul_cancel₀ _ (norm_ne_zero_iff.mpr hc), mul_comm] at hmul
-      rw [if_neg hscaled, if_neg hεt]
-  refine HasCauchyPVAt.intro ?_ ?_
-  · filter_upwards [hscale.eventually h.eventually_intervalIntegrable] with ε hε
-    exact (intervalIntegrable_congr fun t _ => hbody ε t).mpr hε
-  · refine h.tendsto.comp hscale |>.congr' ?_
-    filter_upwards with ε
-    exact intervalIntegral.integral_congr fun t _ => (hbody ε t).symm
+  refine (h.const_mul_curve hc).congr_along_curve fun t _ => ?_
+  -- The rescaled winding kernel `z ↦ c⁻¹ * (c⁻¹ * z - z₀)⁻¹` agrees with `κ[c * z₀]` at `c * γ t`.
+  simp only [inv_mul_cancel_left₀ hc]
+  rw [← mul_sub, mul_inv]
 
 /-- Existence form of `hasCauchyPVAt_windingKernel_const_mul`: nonzero scaling of the curve and base
 point preserves existence of the index principal value, exposed for the same downstream chaining. -/


### PR DESCRIPTION
This PR adds nonzero complex scaling invariance for the ContourIntegration generalized winding-number API: `windingNumber_const_mul`, pointwise vanishing under scaling, and null-homology preservation under simultaneous scaling of the curve and ambient set. It advances `TauCetiRoadmap/ContourIntegration/README.md`, Layer 0, specifically “Curves, immersions, cycles, and the generalized winding number,” and supplies a clean prerequisite for Layer 1 “the geometry of the generalized winding number,” where finite-crossing and model-sector arguments normalize local crossing or sector models after translating the distinguished point to the origin.

<!--tauceti-target:v1 {"focus":"ContourIntegration","id":"winding-number-scale"}-->

I chose this as the lowest-hanging distinct ContourIntegration prerequisite after checking open and recently merged PRs: translation invariance has landed, orientation reversal and concatenation are present, and the open ContourIntegration PRs are Dixon analyticity and decay steps. Scaling is the remaining small affine-normalization companion for local winding-number geometry and does not overlap with the open Dixon work.

No Mathlib infrastructure is vendored. The proof reuses Tau Ceti's `HasCauchyPVAt`, `windingNumber`, and `IsNullHomologous` APIs, plus Mathlib's derivative simplification for multiplication by a constant and standard filter/tendsto lemmas for the positive-radius rescaling `ε ↦ ε / ‖c‖`.

`lake exe cache get` completed with `No files to download` and `Already decompressed 8619 file(s)`. `lake build` reported `Build completed successfully (4635 jobs).` `lake exe axioms` reported `axioms: audited 8722 TauCeti declaration(s); all within the allowlist [propext, Classical.choice, Quot.sound].`

🤖 Prepared with Codex
