### PR TITLE
feat(Analysis/Contour): winding number vanishes far from a bounded closed curve

### DIFF
--- a/TauCeti/Analysis/Contour/WindingVanishing.lean
+++ b/TauCeti/Analysis/Contour/WindingVanishing.lean
@@ -1,0 +1,140 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Chris Birkbeck
+-/
+module
+
+public import TauCeti.Analysis.Contour.WindingNumber
+import TauCeti.Analysis.Contour.WindingInteger
+
+/-!
+# The winding number vanishes far from a bounded closed curve
+
+For a closed curve `γ` continuous on the compact interval `Set.uIcc a b` (so its image is bounded),
+differentiable off a countable set, with interval-integrable derivative, the generalized winding
+number `fun w ↦ windingNumber γ a b w` vanishes for every `w` sufficiently far from the origin:
+`windingNumber_eventually_zero_cocompact` states this as an eventual property along the cocompact
+filter, together with the fact that such `w` lie off the curve. This is the input to the Liouville
+step of Dixon's proof of the homology form of Cauchy's theorem (roadmap `homologyCauchyTheorem`):
+the Dixon function agrees with `dixonH2` wherever the winding number is zero.
+
+## Main results
+
+* `TauCeti.Contour.windingNumber_eventually_zero_cocompact` — off the curve, the winding number is
+  eventually `0` along `cocompact ℂ`.
+
+## Provenance
+
+Adapted from `winding_eventually_zero_cocompact_of_lipschitz` in `NullHomologous.lean` of the
+AINTLIB `LeanModularForms` development. The raw-function port replaces the Lipschitz derivative
+bound with the `L¹` norm `∫ ‖deriv γ‖`, so continuity on the compact interval (which bounds the
+image) and interval-integrability of the derivative suffice — no Lipschitz hypothesis.
+-/
+
+public section
+
+open Complex MeasureTheory Set
+
+open scoped Real Topology Interval
+
+namespace TauCeti.Contour
+
+/-- The value `‖(2πi)⁻¹‖ = (2π)⁻¹` normalizing the index integral to the winding number. -/
+private theorem norm_inv_two_pi_I : ‖(2 * (Real.pi : ℂ) * Complex.I)⁻¹‖ = (2 * Real.pi)⁻¹ := by
+  rw [norm_inv, show (2 : ℂ) * (Real.pi : ℂ) * Complex.I = ((2 * Real.pi : ℝ) : ℂ) * Complex.I from
+      by push_cast; ring, norm_mul, Complex.norm_I, mul_one, Complex.norm_real, Real.norm_eq_abs,
+    abs_of_pos (by positivity)]
+
+/-- **Index-integral decay bound.** For a curve contained in the closed ball of radius `R` and a
+point `w` with `R < ‖w‖`, the index integral `∮_γ dz/(z - w)` is bounded by
+`(∫ ‖deriv γ‖) / (‖w‖ - R)`: pointwise `‖(γ t - w)⁻¹‖ ≤ (‖w‖ - R)⁻¹`, and the `L¹` norm of the
+derivative is finite. -/
+private theorem norm_index_integral_le_of_far {γ : ℝ → ℂ} {a b R : ℝ} {w : ℂ}
+    (hderiv_int : IntervalIntegrable (fun t ↦ deriv γ t) volume a b)
+    (hR : ∀ t ∈ uIcc a b, ‖γ t‖ ≤ R) (hw : R < ‖w‖) :
+    ‖∫ t in a..b, (γ t - w)⁻¹ * deriv γ t‖ ≤ (∫ t in Ι a b, ‖deriv γ t‖) / (‖w‖ - R) := by
+  have hpos : 0 < ‖w‖ - R := by linarith
+  have h_dist_lb : ∀ t ∈ uIcc a b, ‖w‖ - R ≤ ‖γ t - w‖ := fun t ht => by
+    have h := norm_sub_norm_le w (γ t)
+    rw [norm_sub_rev] at h
+    linarith [hR t ht]
+  have h_ae : ∀ᵐ t ∂volume.restrict (Ι a b),
+      ‖(γ t - w)⁻¹ * deriv γ t‖ ≤ (‖w‖ - R)⁻¹ * ‖deriv γ t‖ := by
+    refine ae_restrict_of_forall_mem measurableSet_uIoc fun t ht => ?_
+    rw [norm_mul, norm_inv]
+    exact mul_le_mul_of_nonneg_right (inv_anti₀ hpos (h_dist_lb t (uIoc_subset_uIcc ht)))
+      (norm_nonneg _)
+  calc ‖∫ t in a..b, (γ t - w)⁻¹ * deriv γ t‖
+      ≤ ∫ t in Ι a b, ‖(γ t - w)⁻¹ * deriv γ t‖ :=
+        intervalIntegral.norm_integral_le_integral_norm_uIoc
+    _ ≤ ∫ t in Ι a b, (‖w‖ - R)⁻¹ * ‖deriv γ t‖ :=
+        integral_mono_of_nonneg (ae_of_all _ fun _ ↦ norm_nonneg _)
+          (hderiv_int.norm.const_mul _).def' h_ae
+    _ = (‖w‖ - R)⁻¹ * ∫ t in Ι a b, ‖deriv γ t‖ := integral_const_mul _ _
+    _ = (∫ t in Ι a b, ‖deriv γ t‖) / (‖w‖ - R) := inv_mul_eq_div _ _
+
+/-- **The winding number vanishes for a point far from a bounded closed curve.** If the closed curve
+`γ` lies in the closed ball of radius `R` and `‖w‖` exceeds `R + (∫ ‖deriv γ‖) / (2π)`, then the
+integer-valued winding number about `w` has absolute value below `1`, hence is `0`. -/
+private theorem windingNumber_eq_zero_of_far {γ : ℝ → ℂ} {a b R : ℝ} {P : Set ℝ} {w : ℂ}
+    (hclosed : γ a = γ b) (hP : P.Countable) (hγ_cont : ContinuousOn γ (uIcc a b))
+    (hγ_diff : ∀ t ∈ Ioo (min a b) (max a b) \ P, DifferentiableAt ℝ γ t)
+    (hderiv_int : IntervalIntegrable (fun t ↦ deriv γ t) volume a b)
+    (hR : ∀ t ∈ uIcc a b, ‖γ t‖ ≤ R)
+    (hw : R + (∫ t in Ι a b, ‖deriv γ t‖) / (2 * Real.pi) < ‖w‖) :
+    windingNumber γ a b w = 0 := by
+  have h2pi_pos : (0 : ℝ) < 2 * Real.pi := by positivity
+  have hD_nonneg : 0 ≤ ∫ t in Ι a b, ‖deriv γ t‖ := integral_nonneg fun _ => norm_nonneg _
+  have hwR : R < ‖w‖ :=
+    lt_of_le_of_lt (le_add_of_nonneg_right (div_nonneg hD_nonneg h2pi_pos.le)) hw
+  have hpos : 0 < ‖w‖ - R := by linarith
+  have h_off : ∀ t ∈ uIcc a b, γ t ≠ w := fun t ht heq => by
+    have h := hR t ht; rw [heq] at h; linarith
+  obtain ⟨n, hn⟩ := exists_int_windingNumber_of_closed hclosed hP hγ_cont hγ_diff h_off
+    (intervalIntegrable_inv_sub_mul_deriv hγ_cont h_off hderiv_int)
+  have h_norm_wind : ‖windingNumber γ a b w‖
+      ≤ (2 * Real.pi)⁻¹ * ((∫ t in Ι a b, ‖deriv γ t‖) / (‖w‖ - R)) := by
+    rw [windingNumber_eq_integral_of_avoidance hγ_cont h_off
+        (intervalIntegrable_inv_sub_mul_deriv hγ_cont h_off hderiv_int),
+      norm_mul, norm_inv_two_pi_I]
+    exact mul_le_mul_of_nonneg_left (norm_index_integral_le_of_far hderiv_int hR hwR)
+      (by positivity)
+  have h_lt_one : (2 * Real.pi)⁻¹ * ((∫ t in Ι a b, ‖deriv γ t‖) / (‖w‖ - R)) < 1 := by
+    have key : (∫ t in Ι a b, ‖deriv γ t‖) / (2 * Real.pi) < ‖w‖ - R := by
+      rw [lt_sub_iff_add_lt]; linarith
+    rw [inv_mul_eq_div, div_div, div_lt_one (mul_pos hpos h2pi_pos)]
+    exact (div_lt_iff₀ h2pi_pos).mp key
+  have h_abs : |(n : ℝ)| < 1 := by
+    have h := lt_of_le_of_lt h_norm_wind h_lt_one
+    rwa [hn, Complex.norm_intCast] at h
+  rw [hn, show n = 0 from Int.abs_lt_one_iff.mp (by exact_mod_cast h_abs), Int.cast_zero]
+
+/-- **The winding number is eventually zero far from a bounded closed curve.** For a closed curve
+`γ` (`γ a = γ b`) continuous on `Set.uIcc a b`, differentiable off a countable set `P`, with
+interval-integrable derivative, every point `w` far enough from the origin lies off the curve and
+has winding number `0`; equivalently, `fun w ↦ (γ avoids w) ∧ windingNumber γ a b w = 0` holds
+eventually along `cocompact ℂ`. The bounded image (continuity on the compact interval) and the
+integer-valuedness of the winding number for a closed curve force the small far-field value to be
+exactly `0`. -/
+theorem windingNumber_eventually_zero_cocompact {γ : ℝ → ℂ} {a b : ℝ} {P : Set ℝ}
+    (hclosed : γ a = γ b) (hP : P.Countable) (hγ_cont : ContinuousOn γ (uIcc a b))
+    (hγ_diff : ∀ t ∈ Ioo (min a b) (max a b) \ P, DifferentiableAt ℝ γ t)
+    (hderiv_int : IntervalIntegrable (fun t ↦ deriv γ t) volume a b) :
+    ∀ᶠ w in Filter.cocompact ℂ,
+      (∀ t ∈ uIcc a b, γ t ≠ w) ∧ windingNumber γ a b w = 0 := by
+  obtain ⟨R, hR⟩ := isCompact_uIcc.exists_bound_of_continuousOn hγ_cont
+  have hD_nonneg : 0 ≤ ∫ t in Ι a b, ‖deriv γ t‖ := integral_nonneg fun _ => norm_nonneg _
+  set RR : ℝ := R + (∫ t in Ι a b, ‖deriv γ t‖) / (2 * Real.pi) with hRR_def
+  have hR_le_RR : R ≤ RR := le_add_of_nonneg_right (div_nonneg hD_nonneg (by positivity))
+  have h_mem : {w : ℂ | RR < ‖w‖} ∈ Filter.cocompact ℂ := by
+    rw [Filter.mem_cocompact]
+    exact ⟨Metric.closedBall 0 RR, isCompact_closedBall 0 RR, fun w hw => by
+      simpa [mem_compl_iff, Metric.mem_closedBall, dist_zero_right, not_le] using hw⟩
+  filter_upwards [h_mem] with w (hw : RR < ‖w‖)
+  refine ⟨fun t ht heq => ?_, windingNumber_eq_zero_of_far hclosed hP hγ_cont hγ_diff hderiv_int hR
+    (hRR_def ▸ hw)⟩
+  have h := hR t ht; rw [heq] at h
+  linarith [lt_of_le_of_lt hR_le_RR hw]
+
+end TauCeti.Contour


### PR DESCRIPTION
## What

Adds `TauCeti.Contour.windingNumber_eventually_zero_cocompact`: for a closed curve `γ` (`γ a = γ b`) continuous on the compact interval `Set.uIcc a b`, differentiable off a countable set, with interval-integrable derivative, the pair "`γ` avoids `w` **and** `windingNumber γ a b w = 0`" holds **eventually along `cocompact ℂ`** — i.e. the winding number vanishes for every point far enough from the origin.

## Why

This is the local-matching input to the **Liouville step** of Dixon's proof of the homology form of Cauchy's theorem (`homologyCauchyTheorem`, `TauCetiRoadmap/ContourIntegration/Suggested.lean`): the Dixon function agrees with `dixonH2` wherever the winding number is zero, and `dixonH2 → 0` at infinity, so the entire Dixon function tends to `0` and is therefore constant `0`. It is a prerequisite that target needs; it adds no new roadmap scope.

## How / raw-function novelty

Ported from `winding_eventually_zero_cocompact_of_lipschitz` in AINTLIB `LeanModularForms` (`NullHomologous.lean`), restated for a raw `γ : ℝ → ℂ` on an oriented interval. The port **weakens** the AINTLIB hypotheses:

- **No Lipschitz assumption.** Continuity on the *compact* interval already bounds the image (`IsCompact.exists_bound_of_continuousOn`), and the index integral is controlled by the **L¹ norm** `∫ ‖deriv γ‖` (via `norm_integral_le_integral_norm_uIoc` + `integral_mono_of_nonneg`) rather than a pointwise derivative bound. So continuity + interval-integrability of the derivative suffice.

The far-field value is an integer (`exists_int_windingNumber_of_closed`) of absolute value `< 1`, hence exactly `0`.

Three `private` helpers (`norm_inv_two_pi_I`, `norm_index_integral_le_of_far`, `windingNumber_eq_zero_of_far`) keep each proof small; the public surface is the single cocompact statement.

Depends only on already-merged API (`WindingNumber`, `WindingInteger`); independent of the in-flight Dixon-function PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
