### PR TITLE
feat(Analysis/Contour): share Cauchy-integral decay bound; dixonH2 L¹ decay

### DIFF
--- a/TauCeti/Analysis/Contour/CurveIntegralBound.lean
+++ b/TauCeti/Analysis/Contour/CurveIntegralBound.lean
@@ -18,14 +18,11 @@ bounded by `(∫ ‖g‖) / (‖w‖ - R)`: the distance lower bound `‖w‖ - 
 the common decay estimate behind the vanishing at infinity of both the generalized winding number
 (weight `g = deriv γ`) and Dixon's `dixonH2` (weight `g = f (γ ·) * deriv γ`); using the `L¹` norm
 rather than a uniform bound on `g` keeps it applicable to raw curves whose derivative is only
-interval-integrable. A companion lemma turns any such `C / (‖w‖ - R)` bound (for `R < ‖w‖`) into
-decay along `cocompact ℂ`, which is the shared vanishing-at-infinity step.
+interval-integrable.
 
 ## Main results
 
 * `TauCeti.Contour.norm_integral_inv_sub_mul_le` — the `(∫ ‖g‖) / (‖w‖ - R)` decay bound.
-* `TauCeti.Contour.tendsto_zero_cocompact_of_norm_le_div` — a `C / (‖w‖ - R)` bound on `‖F w‖`
-  for `R < ‖w‖` forces `F → 0` along `cocompact ℂ`.
 
 ## Provenance
 
@@ -38,9 +35,9 @@ oriented interval with an arbitrary interval-integrable weight `g`, and bounding
 
 public section
 
-open Complex MeasureTheory Set Filter
+open Complex MeasureTheory Set
 
-open scoped Interval Topology
+open scoped Interval
 
 namespace TauCeti.Contour
 
@@ -72,28 +69,5 @@ theorem norm_integral_inv_sub_mul_le {γ g : ℝ → ℂ} {a b R : ℝ} {w : ℂ
           (hg.norm.const_mul _).def' h_ae
     _ = (‖w‖ - R)⁻¹ * ∫ t in Ι a b, ‖g t‖ := integral_const_mul _ _
     _ = (∫ t in Ι a b, ‖g t‖) / (‖w‖ - R) := inv_mul_eq_div _ _
-
-/-- **A `C / (‖w‖ - R)` bound forces decay along `cocompact`.** If `‖F w‖ ≤ C / (‖w‖ - R)` for every
-`w` with `R < ‖w‖`, then `F` tends to `0` along `cocompact ℂ`: outside a large closed ball the bound
-drops below any `ε > 0`. This is the shared vanishing-at-infinity step behind the decay of the
-generalized winding number and Dixon's `dixonH2`. -/
-theorem tendsto_zero_cocompact_of_norm_le_div {F : ℂ → ℂ} {R C : ℝ}
-    (hbound : ∀ w : ℂ, R < ‖w‖ → ‖F w‖ ≤ C / (‖w‖ - R)) :
-    Tendsto F (cocompact ℂ) (nhds 0) := by
-  rw [Metric.tendsto_nhds]
-  intro ε hε
-  simp only [dist_zero_right]
-  filter_upwards [(isCompact_closedBall (0 : ℂ)
-      (max R (R + C / ε))).compl_mem_cocompact] with w hw
-  rw [Set.mem_compl_iff, Metric.mem_closedBall, dist_zero_right, not_le] at hw
-  have hRw : R < ‖w‖ := lt_of_le_of_lt (le_max_left _ _) hw
-  have hpos : 0 < ‖w‖ - R := by linarith
-  calc ‖F w‖ ≤ C / (‖w‖ - R) := hbound w hRw
-    _ < ε := by
-        rw [div_lt_iff₀ hpos]
-        have h2 : C / ε < ‖w‖ - R := by
-          linarith [lt_of_le_of_lt (le_max_right _ _) hw]
-        rw [div_lt_iff₀ hε] at h2
-        linarith [mul_comm ε (‖w‖ - R)]
 
 end TauCeti.Contour

--- a/TauCeti/Analysis/Contour/CurveIntegralBound.lean
+++ b/TauCeti/Analysis/Contour/CurveIntegralBound.lean
@@ -1,0 +1,64 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Chris Birkbeck
+-/
+module
+
+public import Mathlib.MeasureTheory.Integral.IntervalIntegral.Basic
+public import Mathlib.Analysis.Complex.Basic
+
+/-!
+# A decay bound for `∫ (γ - w)⁻¹ · g` when `w` is far from the curve
+
+For a curve `γ : ℝ → ℂ` contained in the closed ball of radius `R` and a point `w` with
+`R < ‖w‖`, the integral `∫ t in a..b, (γ t - w)⁻¹ * g t` of an interval-integrable weight `g` is
+bounded by `(∫ ‖g‖) / (‖w‖ - R)`: pointwise `‖(γ t - w)⁻¹‖ ≤ (‖w‖ - R)⁻¹`, so the estimate reduces
+to the `L¹` norm of `g`. This is the common decay estimate behind the vanishing at infinity of both
+the generalized winding number (weight `g = deriv γ`) and Dixon's `dixonH2` (weight
+`g = f (γ ·) * deriv γ`); using the `L¹` norm rather than a uniform bound on `g` keeps it applicable
+to raw curves whose derivative is only interval-integrable.
+
+## Main results
+
+* `TauCeti.Contour.norm_integral_inv_sub_mul_le` — the `(∫ ‖g‖) / (‖w‖ - R)` decay bound.
+-/
+
+public section
+
+open Complex MeasureTheory Set
+
+open scoped Interval
+
+namespace TauCeti.Contour
+
+/-- **Decay bound for a Cauchy-type integral far from the curve.** If `‖γ t‖ ≤ R` on `uIcc a b`,
+`g` is interval-integrable, and `R < ‖w‖`, then
+`‖∫ t in a..b, (γ t - w)⁻¹ * g t‖ ≤ (∫ t in Ι a b, ‖g t‖) / (‖w‖ - R)`. The distance lower bound
+`‖w‖ - R ≤ ‖γ t - w‖` makes `‖(γ t - w)⁻¹‖ ≤ (‖w‖ - R)⁻¹` pointwise, and the weight contributes its
+`L¹` norm. -/
+theorem norm_integral_inv_sub_mul_le {γ g : ℝ → ℂ} {a b R : ℝ} {w : ℂ}
+    (hg : IntervalIntegrable g volume a b)
+    (hR : ∀ t ∈ uIcc a b, ‖γ t‖ ≤ R) (hw : R < ‖w‖) :
+    ‖∫ t in a..b, (γ t - w)⁻¹ * g t‖ ≤ (∫ t in Ι a b, ‖g t‖) / (‖w‖ - R) := by
+  have hpos : 0 < ‖w‖ - R := by linarith
+  have h_dist_lb : ∀ t ∈ uIcc a b, ‖w‖ - R ≤ ‖γ t - w‖ := fun t ht => by
+    have h := norm_sub_norm_le w (γ t)
+    rw [norm_sub_rev] at h
+    linarith [hR t ht]
+  have h_ae : ∀ᵐ t ∂volume.restrict (Ι a b),
+      ‖(γ t - w)⁻¹ * g t‖ ≤ (‖w‖ - R)⁻¹ * ‖g t‖ := by
+    refine ae_restrict_of_forall_mem measurableSet_uIoc fun t ht => ?_
+    rw [norm_mul, norm_inv]
+    exact mul_le_mul_of_nonneg_right (inv_anti₀ hpos (h_dist_lb t (uIoc_subset_uIcc ht)))
+      (norm_nonneg _)
+  calc ‖∫ t in a..b, (γ t - w)⁻¹ * g t‖
+      ≤ ∫ t in Ι a b, ‖(γ t - w)⁻¹ * g t‖ :=
+        intervalIntegral.norm_integral_le_integral_norm_uIoc
+    _ ≤ ∫ t in Ι a b, (‖w‖ - R)⁻¹ * ‖g t‖ :=
+        integral_mono_of_nonneg (ae_of_all _ fun _ ↦ norm_nonneg _)
+          (hg.norm.const_mul _).def' h_ae
+    _ = (‖w‖ - R)⁻¹ * ∫ t in Ι a b, ‖g t‖ := integral_const_mul _ _
+    _ = (∫ t in Ι a b, ‖g t‖) / (‖w‖ - R) := inv_mul_eq_div _ _
+
+end TauCeti.Contour

--- a/TauCeti/Analysis/Contour/CurveIntegralBound.lean
+++ b/TauCeti/Analysis/Contour/CurveIntegralBound.lean
@@ -18,11 +18,14 @@ bounded by `(∫ ‖g‖) / (‖w‖ - R)`: the distance lower bound `‖w‖ - 
 the common decay estimate behind the vanishing at infinity of both the generalized winding number
 (weight `g = deriv γ`) and Dixon's `dixonH2` (weight `g = f (γ ·) * deriv γ`); using the `L¹` norm
 rather than a uniform bound on `g` keeps it applicable to raw curves whose derivative is only
-interval-integrable.
+interval-integrable. A companion lemma turns any such `C / (‖w‖ - R)` bound (for `R < ‖w‖`) into
+decay along `cocompact ℂ`, which is the shared vanishing-at-infinity step.
 
 ## Main results
 
 * `TauCeti.Contour.norm_integral_inv_sub_mul_le` — the `(∫ ‖g‖) / (‖w‖ - R)` decay bound.
+* `TauCeti.Contour.tendsto_zero_cocompact_of_norm_le_div` — a `C / (‖w‖ - R)` bound on `‖F w‖`
+  for `R < ‖w‖` forces `F → 0` along `cocompact ℂ`.
 
 ## Provenance
 
@@ -35,9 +38,9 @@ oriented interval with an arbitrary interval-integrable weight `g`, and bounding
 
 public section
 
-open Complex MeasureTheory Set
+open Complex MeasureTheory Set Filter
 
-open scoped Interval
+open scoped Interval Topology
 
 namespace TauCeti.Contour
 
@@ -69,5 +72,28 @@ theorem norm_integral_inv_sub_mul_le {γ g : ℝ → ℂ} {a b R : ℝ} {w : ℂ
           (hg.norm.const_mul _).def' h_ae
     _ = (‖w‖ - R)⁻¹ * ∫ t in Ι a b, ‖g t‖ := integral_const_mul _ _
     _ = (∫ t in Ι a b, ‖g t‖) / (‖w‖ - R) := inv_mul_eq_div _ _
+
+/-- **A `C / (‖w‖ - R)` bound forces decay along `cocompact`.** If `‖F w‖ ≤ C / (‖w‖ - R)` for every
+`w` with `R < ‖w‖`, then `F` tends to `0` along `cocompact ℂ`: outside a large closed ball the bound
+drops below any `ε > 0`. This is the shared vanishing-at-infinity step behind the decay of the
+generalized winding number and Dixon's `dixonH2`. -/
+theorem tendsto_zero_cocompact_of_norm_le_div {F : ℂ → ℂ} {R C : ℝ}
+    (hbound : ∀ w : ℂ, R < ‖w‖ → ‖F w‖ ≤ C / (‖w‖ - R)) :
+    Tendsto F (cocompact ℂ) (nhds 0) := by
+  rw [Metric.tendsto_nhds]
+  intro ε hε
+  simp only [dist_zero_right]
+  filter_upwards [(isCompact_closedBall (0 : ℂ)
+      (max R (R + C / ε))).compl_mem_cocompact] with w hw
+  rw [Set.mem_compl_iff, Metric.mem_closedBall, dist_zero_right, not_le] at hw
+  have hRw : R < ‖w‖ := lt_of_le_of_lt (le_max_left _ _) hw
+  have hpos : 0 < ‖w‖ - R := by linarith
+  calc ‖F w‖ ≤ C / (‖w‖ - R) := hbound w hRw
+    _ < ε := by
+        rw [div_lt_iff₀ hpos]
+        have h2 : C / ε < ‖w‖ - R := by
+          linarith [lt_of_le_of_lt (le_max_right _ _) hw]
+        rw [div_lt_iff₀ hε] at h2
+        linarith [mul_comm ε (‖w‖ - R)]
 
 end TauCeti.Contour

--- a/TauCeti/Analysis/Contour/CurveIntegralBound.lean
+++ b/TauCeti/Analysis/Contour/CurveIntegralBound.lean
@@ -11,17 +11,26 @@ public import Mathlib.Analysis.Complex.Basic
 /-!
 # A decay bound for `∫ (γ - w)⁻¹ · g` when `w` is far from the curve
 
-For a curve `γ : ℝ → ℂ` contained in the closed ball of radius `R` and a point `w` with
+For a curve `γ : ℝ → ℂ` with `‖γ t‖ ≤ R` on the integrating interval and a point `w` with
 `R < ‖w‖`, the integral `∫ t in a..b, (γ t - w)⁻¹ * g t` of an interval-integrable weight `g` is
-bounded by `(∫ ‖g‖) / (‖w‖ - R)`: pointwise `‖(γ t - w)⁻¹‖ ≤ (‖w‖ - R)⁻¹`, so the estimate reduces
-to the `L¹` norm of `g`. This is the common decay estimate behind the vanishing at infinity of both
-the generalized winding number (weight `g = deriv γ`) and Dixon's `dixonH2` (weight
-`g = f (γ ·) * deriv γ`); using the `L¹` norm rather than a uniform bound on `g` keeps it applicable
-to raw curves whose derivative is only interval-integrable.
+bounded by `(∫ ‖g‖) / (‖w‖ - R)`: the distance lower bound `‖w‖ - R ≤ ‖γ t - w‖` gives
+`‖(γ t - w)⁻¹‖ ≤ (‖w‖ - R)⁻¹` pointwise, so the estimate reduces to the `L¹` norm of `g`. This is
+the common decay estimate behind the vanishing at infinity of both the generalized winding number
+(weight `g = deriv γ`) and Dixon's `dixonH2` (weight `g = f (γ ·) * deriv γ`); using the `L¹` norm
+rather than a uniform bound on `g` keeps it applicable to raw curves whose derivative is only
+interval-integrable.
 
 ## Main results
 
 * `TauCeti.Contour.norm_integral_inv_sub_mul_le` — the `(∫ ‖g‖) / (‖w‖ - R)` decay bound.
+
+## Provenance
+
+Factored from the far-field estimates in the AINTLIB `LeanModularForms` development —
+`contourIntegral_inv_norm_le_of_far` in `NullHomologous.lean` (the winding case, weight `deriv γ`)
+and `dixonH2_norm_le` in `DixonTheorem.lean` (the Dixon case) — restated for a raw `γ : ℝ → ℂ` on an
+oriented interval with an arbitrary interval-integrable weight `g`, and bounding by the `L¹` norm of
+`g` rather than a Lipschitz or uniform bound.
 -/
 
 public section
@@ -32,17 +41,18 @@ open scoped Interval
 
 namespace TauCeti.Contour
 
-/-- **Decay bound for a Cauchy-type integral far from the curve.** If `‖γ t‖ ≤ R` on `uIcc a b`,
+/-- **Decay bound for a Cauchy-type integral far from the curve.** If `‖γ t‖ ≤ R` on `Ι a b`,
 `g` is interval-integrable, and `R < ‖w‖`, then
 `‖∫ t in a..b, (γ t - w)⁻¹ * g t‖ ≤ (∫ t in Ι a b, ‖g t‖) / (‖w‖ - R)`. The distance lower bound
 `‖w‖ - R ≤ ‖γ t - w‖` makes `‖(γ t - w)⁻¹‖ ≤ (‖w‖ - R)⁻¹` pointwise, and the weight contributes its
-`L¹` norm. -/
+`L¹` norm. Only the bound on the half-open interval `Ι a b` matters; the endpoints do not affect the
+integral. -/
 theorem norm_integral_inv_sub_mul_le {γ g : ℝ → ℂ} {a b R : ℝ} {w : ℂ}
     (hg : IntervalIntegrable g volume a b)
-    (hR : ∀ t ∈ uIcc a b, ‖γ t‖ ≤ R) (hw : R < ‖w‖) :
+    (hR : ∀ t ∈ Ι a b, ‖γ t‖ ≤ R) (hw : R < ‖w‖) :
     ‖∫ t in a..b, (γ t - w)⁻¹ * g t‖ ≤ (∫ t in Ι a b, ‖g t‖) / (‖w‖ - R) := by
   have hpos : 0 < ‖w‖ - R := by linarith
-  have h_dist_lb : ∀ t ∈ uIcc a b, ‖w‖ - R ≤ ‖γ t - w‖ := fun t ht => by
+  have h_dist_lb : ∀ t ∈ Ι a b, ‖w‖ - R ≤ ‖γ t - w‖ := fun t ht => by
     have h := norm_sub_norm_le w (γ t)
     rw [norm_sub_rev] at h
     linarith [hR t ht]
@@ -50,8 +60,7 @@ theorem norm_integral_inv_sub_mul_le {γ g : ℝ → ℂ} {a b R : ℝ} {w : ℂ
       ‖(γ t - w)⁻¹ * g t‖ ≤ (‖w‖ - R)⁻¹ * ‖g t‖ := by
     refine ae_restrict_of_forall_mem measurableSet_uIoc fun t ht => ?_
     rw [norm_mul, norm_inv]
-    exact mul_le_mul_of_nonneg_right (inv_anti₀ hpos (h_dist_lb t (uIoc_subset_uIcc ht)))
-      (norm_nonneg _)
+    exact mul_le_mul_of_nonneg_right (inv_anti₀ hpos (h_dist_lb t ht)) (norm_nonneg _)
   calc ‖∫ t in a..b, (γ t - w)⁻¹ * g t‖
       ≤ ∫ t in Ι a b, ‖(γ t - w)⁻¹ * g t‖ :=
         intervalIntegral.norm_integral_le_integral_norm_uIoc

--- a/TauCeti/Analysis/Contour/DixonH2Bound.lean
+++ b/TauCeti/Analysis/Contour/DixonH2Bound.lean
@@ -6,30 +6,36 @@ Authors: Chris Birkbeck
 module
 
 public import TauCeti.Analysis.Contour.DixonDef
+import TauCeti.Analysis.Contour.CurveIntegralBound
 
 /-!
 # Norm bound and decay at infinity of Dixon's `dixonH2`
 
 For `w` outside a ball containing the curve, Dixon's Cauchy-type integral
-`dixonH2 f γ a b w = ∫ t in a..b, f (γ t) / (γ t - w) * deriv γ t` is small: its integrand is
-bounded by `M / (‖w‖ - R)`, where `M` bounds the numerator product `‖f (γ ·) * deriv γ‖`, so the
-integral is bounded by `M · |b - a| / (‖w‖ - R)`, which tends to `0` as `‖w‖ → ∞`.
+`dixonH2 f γ a b w = ∫ t in a..b, f (γ t) / (γ t - w) * deriv γ t` is small: rewriting the integrand
+as `(γ t - w)⁻¹ * (f (γ t) * deriv γ t)`, the distance lower bound `‖w‖ - R ≤ ‖γ t - w‖` gives
+`‖dixonH2 f γ a b w‖ ≤ (∫ ‖f (γ ·) * deriv γ‖) / (‖w‖ - R)`, which tends to `0` as `‖w‖ → ∞`.
+Bounding by the `L¹` norm of the weight `f (γ ·) * deriv γ` rather than a uniform bound keeps the
+estimate applicable to raw curves whose derivative is only interval-integrable.
 
 ## Main results
 
-* `TauCeti.Contour.dixonH2_norm_le` — the quantitative bound `‖dixonH2 f γ a b w‖ ≤
-  M / (‖w‖ - R) · |b - a|` for `R < ‖w‖`.
+* `TauCeti.Contour.dixonH2_norm_le` — the decay bound `‖dixonH2 f γ a b w‖ ≤
+  (∫ ‖f (γ ·) * deriv γ‖) / (‖w‖ - R)` for `R < ‖w‖`.
 * `TauCeti.Contour.dixonH2_tendsto_zero` — `dixonH2 f γ a b` tends to `0` along `cocompact ℂ`.
 
 The decay of `dixonH2` (hence of Dixon's glued function, which agrees with it far out) is the input
 to the Liouville step of Dixon's proof of the homology form of Cauchy's theorem
-(`homologyCauchyTheorem`, `TauCetiRoadmap/ContourIntegration/Suggested.lean`).
+(`homologyCauchyTheorem`, `TauCetiRoadmap/ContourIntegration/Suggested.lean`). It shares the
+underlying Cauchy-integral decay estimate `norm_integral_inv_sub_mul_le` with the vanishing at
+infinity of the generalized winding number.
 
 ## Provenance
 
 Adapted from `dixonH2_norm_le` and `dixonH2_tendsto_zero` in `DixonTheorem.lean` of the AINTLIB
-`LeanModularForms` development, restated for a raw `γ : ℝ → ℂ` on an oriented interval. The
-`|b - a|` factor is the length of that interval (invisible in the `[0, 1]`-parametrised original).
+`LeanModularForms` development, restated for a raw `γ : ℝ → ℂ` on an oriented interval. The original
+uses a uniform bound on the integrand (valid for its `C¹`, `[0, 1]`-parametrised curve); the
+raw-`γ` port bounds by the `L¹` norm `∫ ‖f (γ ·) * deriv γ‖`, shedding the boundedness hypothesis.
 -/
 
 public section
@@ -42,45 +48,38 @@ namespace TauCeti.Contour
 
 variable {f : ℂ → ℂ} {γ : ℝ → ℂ} {a b : ℝ}
 
-/-- **Norm bound for `dixonH2`.** When `‖w‖ > R`, `R` bounds `‖γ‖`, and `M` bounds the numerator
-product `‖f (γ ·) * deriv γ‖` on `uIcc a b`, the Cauchy-type integral is bounded by
-`M / (‖w‖ - R) · |b - a|`. -/
-theorem dixonH2_norm_le {R M : ℝ}
-    (hR : ∀ t ∈ uIcc a b, ‖γ t‖ ≤ R) (hM : ∀ t ∈ uIcc a b, ‖f (γ t) * deriv γ t‖ ≤ M)
-    {w : ℂ} (hw : R < ‖w‖) :
-    ‖dixonH2 f γ a b w‖ ≤ M / (‖w‖ - R) * |b - a| := by
-  rw [dixonH2_def]
-  have hM_nn : 0 ≤ M := (norm_nonneg _).trans (hM a Set.left_mem_uIcc)
-  have hpos : 0 < ‖w‖ - R := by linarith
-  have h_ptwise : ∀ t ∈ Set.uIoc a b,
-      ‖f (γ t) / (γ t - w) * deriv γ t‖ ≤ M / (‖w‖ - R) := by
-    intro t ht_ui
-    have ht : t ∈ uIcc a b := Set.uIoc_subset_uIcc ht_ui
-    have h_dist_lb : ‖w‖ - R ≤ ‖γ t - w‖ := by
-      linarith [norm_sub_norm_le w (γ t), norm_sub_rev w (γ t), hR t ht]
-    rw [show f (γ t) / (γ t - w) * deriv γ t = f (γ t) * deriv γ t / (γ t - w) by ring, norm_div]
-    gcongr
-    exact hM t ht
-  exact intervalIntegral.norm_integral_le_of_norm_le_const h_ptwise
+/-- **Norm bound for `dixonH2`.** When `‖w‖ > R`, `R` bounds `‖γ‖` on `uIcc a b`, and the weight
+`f (γ ·) * deriv γ` is interval-integrable, the Cauchy-type integral is bounded by its `L¹` norm
+divided by `‖w‖ - R`: rewrite the integrand as `(γ t - w)⁻¹ * (f (γ t) * deriv γ t)` and apply the
+shared decay estimate `norm_integral_inv_sub_mul_le`. -/
+theorem dixonH2_norm_le {R : ℝ} (hR : ∀ t ∈ uIcc a b, ‖γ t‖ ≤ R)
+    (hg : IntervalIntegrable (fun t ↦ f (γ t) * deriv γ t) volume a b) {w : ℂ} (hw : R < ‖w‖) :
+    ‖dixonH2 f γ a b w‖ ≤ (∫ t in Ι a b, ‖f (γ t) * deriv γ t‖) / (‖w‖ - R) := by
+  have hcongr : (∫ t in a..b, f (γ t) / (γ t - w) * deriv γ t)
+      = ∫ t in a..b, (γ t - w)⁻¹ * (f (γ t) * deriv γ t) :=
+    intervalIntegral.integral_congr fun t _ ↦ by ring
+  rw [dixonH2_def, hcongr]
+  exact norm_integral_inv_sub_mul_le hg hR hw
 
 /-- **`dixonH2 f γ a b` tends to `0` along `cocompact ℂ`.** For `‖w‖` large the norm bound
-`M · |b - a| / (‖w‖ - R)` is below any `ε > 0`. -/
-theorem dixonH2_tendsto_zero {R M : ℝ}
-    (hR : ∀ t ∈ uIcc a b, ‖γ t‖ ≤ R) (hM : ∀ t ∈ uIcc a b, ‖f (γ t) * deriv γ t‖ ≤ M) :
+`(∫ ‖f (γ ·) * deriv γ‖) / (‖w‖ - R)` is below any `ε > 0`. -/
+theorem dixonH2_tendsto_zero {R : ℝ} (hR : ∀ t ∈ uIcc a b, ‖γ t‖ ≤ R)
+    (hg : IntervalIntegrable (fun t ↦ f (γ t) * deriv γ t) volume a b) :
     Tendsto (dixonH2 f γ a b) (cocompact ℂ) (nhds 0) := by
   rw [Metric.tendsto_nhds]
   intro ε hε
   simp only [dist_zero_right]
+  set D := ∫ t in Ι a b, ‖f (γ t) * deriv γ t‖
   filter_upwards [(isCompact_closedBall (0 : ℂ)
-      (max R (R + M * |b - a| / ε))).compl_mem_cocompact] with w hw
+      (max R (R + D / ε))).compl_mem_cocompact] with w hw
   rw [Set.mem_compl_iff, Metric.mem_closedBall, dist_zero_right, not_le] at hw
   have hRw : R < ‖w‖ := lt_of_le_of_lt (le_max_left _ _) hw
   have hpos : 0 < ‖w‖ - R := by linarith
   calc ‖dixonH2 f γ a b w‖
-      ≤ M / (‖w‖ - R) * |b - a| := dixonH2_norm_le hR hM hRw
+      ≤ D / (‖w‖ - R) := dixonH2_norm_le hR hg hRw
     _ < ε := by
-        rw [div_mul_eq_mul_div, div_lt_iff₀ hpos]
-        have h2 : M * |b - a| / ε < ‖w‖ - R := by
+        rw [div_lt_iff₀ hpos]
+        have h2 : D / ε < ‖w‖ - R := by
           linarith [lt_of_le_of_lt (le_max_right _ _) hw]
         rw [div_lt_iff₀ hε] at h2
         linarith [mul_comm ε (‖w‖ - R)]

--- a/TauCeti/Analysis/Contour/DixonH2Bound.lean
+++ b/TauCeti/Analysis/Contour/DixonH2Bound.lean
@@ -75,27 +75,14 @@ theorem dixonH2_norm_le {R M : ℝ}
     exact hM t ht
   exact intervalIntegral.norm_integral_le_of_norm_le_const h_ptwise
 
-/-- **`dixonH2 f γ a b` tends to `0` along `cocompact ℂ`.** For `‖w‖` large the norm bound
-`M · |b - a| / (‖w‖ - R)` is below any `ε > 0`. -/
+/-- **`dixonH2 f γ a b` tends to `0` along `cocompact ℂ`.** The norm bound `dixonH2_norm_le` has the
+form `C / (‖w‖ - R)` with `C = M * |b - a|`, so `tendsto_zero_cocompact_of_norm_le_div` applies. -/
 theorem dixonH2_tendsto_zero {R M : ℝ}
     (hR : ∀ t ∈ uIcc a b, ‖γ t‖ ≤ R) (hM : ∀ t ∈ uIcc a b, ‖f (γ t) * deriv γ t‖ ≤ M) :
     Tendsto (dixonH2 f γ a b) (cocompact ℂ) (nhds 0) := by
-  rw [Metric.tendsto_nhds]
-  intro ε hε
-  simp only [dist_zero_right]
-  filter_upwards [(isCompact_closedBall (0 : ℂ)
-      (max R (R + M * |b - a| / ε))).compl_mem_cocompact] with w hw
-  rw [Set.mem_compl_iff, Metric.mem_closedBall, dist_zero_right, not_le] at hw
-  have hRw : R < ‖w‖ := lt_of_le_of_lt (le_max_left _ _) hw
-  have hpos : 0 < ‖w‖ - R := by linarith
-  calc ‖dixonH2 f γ a b w‖
-      ≤ M / (‖w‖ - R) * |b - a| := dixonH2_norm_le hR hM hRw
-    _ < ε := by
-        rw [div_mul_eq_mul_div, div_lt_iff₀ hpos]
-        have h2 : M * |b - a| / ε < ‖w‖ - R := by
-          linarith [lt_of_le_of_lt (le_max_right _ _) hw]
-        rw [div_lt_iff₀ hε] at h2
-        linarith [mul_comm ε (‖w‖ - R)]
+  refine tendsto_zero_cocompact_of_norm_le_div (R := R) (C := M * |b - a|) fun w hw ↦ ?_
+  rw [← div_mul_eq_mul_div]
+  exact dixonH2_norm_le hR hM hw
 
 /-- **`L¹` norm bound for `dixonH2`.** When `‖w‖ > R`, `R` bounds `‖γ‖` on `uIcc a b`, and the
 weight `f (γ ·) * deriv γ` is interval-integrable, `dixonH2` is bounded by that weight's `L¹` norm
@@ -111,28 +98,13 @@ theorem dixonH2_norm_le_of_integrable {R : ℝ} (hR : ∀ t ∈ uIcc a b, ‖γ 
   rw [dixonH2_def, hcongr]
   exact norm_integral_inv_sub_mul_le hg (fun t ht ↦ hR t (uIoc_subset_uIcc ht)) hw
 
-/-- **`dixonH2 f γ a b` tends to `0` along `cocompact ℂ` (`L¹` form).** For `‖w‖` large the bound
-`(∫ ‖f (γ ·) * deriv γ‖) / (‖w‖ - R)` is below any `ε > 0`; the interval-integrable weight replaces
-the uniform bound of `dixonH2_tendsto_zero`. -/
+/-- **`dixonH2 f γ a b` tends to `0` along `cocompact ℂ` (`L¹` form).** The `L¹` norm bound
+`dixonH2_norm_le_of_integrable` is already of the form `C / (‖w‖ - R)`, so
+`tendsto_zero_cocompact_of_norm_le_div` applies; the interval-integrable weight replaces the uniform
+bound of `dixonH2_tendsto_zero`. -/
 theorem dixonH2_tendsto_zero_of_integrable {R : ℝ} (hR : ∀ t ∈ uIcc a b, ‖γ t‖ ≤ R)
     (hg : IntervalIntegrable (fun t ↦ f (γ t) * deriv γ t) volume a b) :
-    Tendsto (dixonH2 f γ a b) (cocompact ℂ) (nhds 0) := by
-  rw [Metric.tendsto_nhds]
-  intro ε hε
-  simp only [dist_zero_right]
-  set D := ∫ t in Ι a b, ‖f (γ t) * deriv γ t‖
-  filter_upwards [(isCompact_closedBall (0 : ℂ)
-      (max R (R + D / ε))).compl_mem_cocompact] with w hw
-  rw [Set.mem_compl_iff, Metric.mem_closedBall, dist_zero_right, not_le] at hw
-  have hRw : R < ‖w‖ := lt_of_le_of_lt (le_max_left _ _) hw
-  have hpos : 0 < ‖w‖ - R := by linarith
-  calc ‖dixonH2 f γ a b w‖
-      ≤ D / (‖w‖ - R) := dixonH2_norm_le_of_integrable hR hg hRw
-    _ < ε := by
-        rw [div_lt_iff₀ hpos]
-        have h2 : D / ε < ‖w‖ - R := by
-          linarith [lt_of_le_of_lt (le_max_right _ _) hw]
-        rw [div_lt_iff₀ hε] at h2
-        linarith [mul_comm ε (‖w‖ - R)]
+    Tendsto (dixonH2 f γ a b) (cocompact ℂ) (nhds 0) :=
+  tendsto_zero_cocompact_of_norm_le_div fun _ hw ↦ dixonH2_norm_le_of_integrable hR hg hw
 
 end TauCeti.Contour

--- a/TauCeti/Analysis/Contour/DixonH2Bound.lean
+++ b/TauCeti/Analysis/Contour/DixonH2Bound.lean
@@ -12,30 +12,36 @@ import TauCeti.Analysis.Contour.CurveIntegralBound
 # Norm bound and decay at infinity of Dixon's `dixonH2`
 
 For `w` outside a ball containing the curve, Dixon's Cauchy-type integral
-`dixonH2 f γ a b w = ∫ t in a..b, f (γ t) / (γ t - w) * deriv γ t` is small: rewriting the integrand
-as `(γ t - w)⁻¹ * (f (γ t) * deriv γ t)`, the distance lower bound `‖w‖ - R ≤ ‖γ t - w‖` gives
-`‖dixonH2 f γ a b w‖ ≤ (∫ ‖f (γ ·) * deriv γ‖) / (‖w‖ - R)`, which tends to `0` as `‖w‖ → ∞`.
-Bounding by the `L¹` norm of the weight `f (γ ·) * deriv γ` rather than a uniform bound keeps the
-estimate applicable to raw curves whose derivative is only interval-integrable.
+`dixonH2 f γ a b w = ∫ t in a..b, f (γ t) / (γ t - w) * deriv γ t` is small and tends to `0` as
+`‖w‖ → ∞`. The distance lower bound `‖w‖ - R ≤ ‖γ t - w‖` (for `‖γ‖ ≤ R < ‖w‖`) controls the Cauchy
+kernel; the numerator `f (γ ·) * deriv γ` is then bounded either uniformly or in `L¹`:
+
+* with a uniform bound `M` on the integrand, `‖dixonH2 f γ a b w‖ ≤ M / (‖w‖ - R) · |b - a|`;
+* using only interval-integrability of the weight (rewrite the integrand as
+  `(γ t - w)⁻¹ * (f (γ t) * deriv γ t)`),
+  `‖dixonH2 f γ a b w‖ ≤ (∫ ‖f (γ ·) * deriv γ‖) / (‖w‖ - R)`.
+
+The two hypotheses are incomparable — the uniform bound needs no integrability, the `L¹` bound needs
+no uniform bound — so both are kept. The `L¹` form is what applies to raw curves whose derivative is
+only interval-integrable.
 
 ## Main results
 
-* `TauCeti.Contour.dixonH2_norm_le` — the decay bound `‖dixonH2 f γ a b w‖ ≤
-  (∫ ‖f (γ ·) * deriv γ‖) / (‖w‖ - R)` for `R < ‖w‖`.
-* `TauCeti.Contour.dixonH2_tendsto_zero` — `dixonH2 f γ a b` tends to `0` along `cocompact ℂ`.
+* `TauCeti.Contour.dixonH2_norm_le` / `dixonH2_tendsto_zero` — the uniform-bound norm estimate and
+  its decay at infinity.
+* `TauCeti.Contour.dixonH2_norm_le_of_integrable` / `dixonH2_tendsto_zero_of_integrable` — the `L¹`
+  versions, via the shared estimate `norm_integral_inv_sub_mul_le`.
 
 The decay of `dixonH2` (hence of Dixon's glued function, which agrees with it far out) is the input
 to the Liouville step of Dixon's proof of the homology form of Cauchy's theorem
-(`homologyCauchyTheorem`, `TauCetiRoadmap/ContourIntegration/Suggested.lean`). It shares the
-underlying Cauchy-integral decay estimate `norm_integral_inv_sub_mul_le` with the vanishing at
-infinity of the generalized winding number.
+(`homologyCauchyTheorem`, `TauCetiRoadmap/ContourIntegration/Suggested.lean`).
 
 ## Provenance
 
 Adapted from `dixonH2_norm_le` and `dixonH2_tendsto_zero` in `DixonTheorem.lean` of the AINTLIB
-`LeanModularForms` development, restated for a raw `γ : ℝ → ℂ` on an oriented interval. The original
-uses a uniform bound on the integrand (valid for its `C¹`, `[0, 1]`-parametrised curve); the
-raw-`γ` port bounds by the `L¹` norm `∫ ‖f (γ ·) * deriv γ‖`, shedding the boundedness hypothesis.
+`LeanModularForms` development, restated for a raw `γ : ℝ → ℂ` on an oriented interval (the
+`|b - a|` factor is the interval length, invisible in the `[0, 1]`-parametrised original). The `L¹`
+variants additionally shed the boundedness hypothesis, bounding by `∫ ‖f (γ ·) * deriv γ‖` instead.
 -/
 
 public section
@@ -48,22 +54,67 @@ namespace TauCeti.Contour
 
 variable {f : ℂ → ℂ} {γ : ℝ → ℂ} {a b : ℝ}
 
-/-- **Norm bound for `dixonH2`.** When `‖w‖ > R`, `R` bounds `‖γ‖` on `uIcc a b`, and the weight
-`f (γ ·) * deriv γ` is interval-integrable, the Cauchy-type integral is bounded by its `L¹` norm
-divided by `‖w‖ - R`: rewrite the integrand as `(γ t - w)⁻¹ * (f (γ t) * deriv γ t)` and apply the
-shared decay estimate `norm_integral_inv_sub_mul_le`. -/
-theorem dixonH2_norm_le {R : ℝ} (hR : ∀ t ∈ uIcc a b, ‖γ t‖ ≤ R)
+/-- **Norm bound for `dixonH2`.** When `‖w‖ > R`, `R` bounds `‖γ‖`, and `M` bounds the numerator
+product `‖f (γ ·) * deriv γ‖` on `uIcc a b`, the Cauchy-type integral is bounded by
+`M / (‖w‖ - R) · |b - a|`. -/
+theorem dixonH2_norm_le {R M : ℝ}
+    (hR : ∀ t ∈ uIcc a b, ‖γ t‖ ≤ R) (hM : ∀ t ∈ uIcc a b, ‖f (γ t) * deriv γ t‖ ≤ M)
+    {w : ℂ} (hw : R < ‖w‖) :
+    ‖dixonH2 f γ a b w‖ ≤ M / (‖w‖ - R) * |b - a| := by
+  rw [dixonH2_def]
+  have hM_nn : 0 ≤ M := (norm_nonneg _).trans (hM a Set.left_mem_uIcc)
+  have hpos : 0 < ‖w‖ - R := by linarith
+  have h_ptwise : ∀ t ∈ Set.uIoc a b,
+      ‖f (γ t) / (γ t - w) * deriv γ t‖ ≤ M / (‖w‖ - R) := by
+    intro t ht_ui
+    have ht : t ∈ uIcc a b := Set.uIoc_subset_uIcc ht_ui
+    have h_dist_lb : ‖w‖ - R ≤ ‖γ t - w‖ := by
+      linarith [norm_sub_norm_le w (γ t), norm_sub_rev w (γ t), hR t ht]
+    rw [show f (γ t) / (γ t - w) * deriv γ t = f (γ t) * deriv γ t / (γ t - w) by ring, norm_div]
+    gcongr
+    exact hM t ht
+  exact intervalIntegral.norm_integral_le_of_norm_le_const h_ptwise
+
+/-- **`dixonH2 f γ a b` tends to `0` along `cocompact ℂ`.** For `‖w‖` large the norm bound
+`M · |b - a| / (‖w‖ - R)` is below any `ε > 0`. -/
+theorem dixonH2_tendsto_zero {R M : ℝ}
+    (hR : ∀ t ∈ uIcc a b, ‖γ t‖ ≤ R) (hM : ∀ t ∈ uIcc a b, ‖f (γ t) * deriv γ t‖ ≤ M) :
+    Tendsto (dixonH2 f γ a b) (cocompact ℂ) (nhds 0) := by
+  rw [Metric.tendsto_nhds]
+  intro ε hε
+  simp only [dist_zero_right]
+  filter_upwards [(isCompact_closedBall (0 : ℂ)
+      (max R (R + M * |b - a| / ε))).compl_mem_cocompact] with w hw
+  rw [Set.mem_compl_iff, Metric.mem_closedBall, dist_zero_right, not_le] at hw
+  have hRw : R < ‖w‖ := lt_of_le_of_lt (le_max_left _ _) hw
+  have hpos : 0 < ‖w‖ - R := by linarith
+  calc ‖dixonH2 f γ a b w‖
+      ≤ M / (‖w‖ - R) * |b - a| := dixonH2_norm_le hR hM hRw
+    _ < ε := by
+        rw [div_mul_eq_mul_div, div_lt_iff₀ hpos]
+        have h2 : M * |b - a| / ε < ‖w‖ - R := by
+          linarith [lt_of_le_of_lt (le_max_right _ _) hw]
+        rw [div_lt_iff₀ hε] at h2
+        linarith [mul_comm ε (‖w‖ - R)]
+
+/-- **`L¹` norm bound for `dixonH2`.** When `‖w‖ > R`, `R` bounds `‖γ‖` on `uIcc a b`, and the
+weight `f (γ ·) * deriv γ` is interval-integrable, `dixonH2` is bounded by that weight's `L¹` norm
+divided by `‖w‖ - R`. Unlike `dixonH2_norm_le` this needs no uniform bound on the integrand, so it
+applies to raw curves whose derivative is only interval-integrable: rewrite the integrand as
+`(γ t - w)⁻¹ * (f (γ t) * deriv γ t)` and apply `norm_integral_inv_sub_mul_le`. -/
+theorem dixonH2_norm_le_of_integrable {R : ℝ} (hR : ∀ t ∈ uIcc a b, ‖γ t‖ ≤ R)
     (hg : IntervalIntegrable (fun t ↦ f (γ t) * deriv γ t) volume a b) {w : ℂ} (hw : R < ‖w‖) :
     ‖dixonH2 f γ a b w‖ ≤ (∫ t in Ι a b, ‖f (γ t) * deriv γ t‖) / (‖w‖ - R) := by
   have hcongr : (∫ t in a..b, f (γ t) / (γ t - w) * deriv γ t)
       = ∫ t in a..b, (γ t - w)⁻¹ * (f (γ t) * deriv γ t) :=
     intervalIntegral.integral_congr fun t _ ↦ by ring
   rw [dixonH2_def, hcongr]
-  exact norm_integral_inv_sub_mul_le hg hR hw
+  exact norm_integral_inv_sub_mul_le hg (fun t ht ↦ hR t (uIoc_subset_uIcc ht)) hw
 
-/-- **`dixonH2 f γ a b` tends to `0` along `cocompact ℂ`.** For `‖w‖` large the norm bound
-`(∫ ‖f (γ ·) * deriv γ‖) / (‖w‖ - R)` is below any `ε > 0`. -/
-theorem dixonH2_tendsto_zero {R : ℝ} (hR : ∀ t ∈ uIcc a b, ‖γ t‖ ≤ R)
+/-- **`dixonH2 f γ a b` tends to `0` along `cocompact ℂ` (`L¹` form).** For `‖w‖` large the bound
+`(∫ ‖f (γ ·) * deriv γ‖) / (‖w‖ - R)` is below any `ε > 0`; the interval-integrable weight replaces
+the uniform bound of `dixonH2_tendsto_zero`. -/
+theorem dixonH2_tendsto_zero_of_integrable {R : ℝ} (hR : ∀ t ∈ uIcc a b, ‖γ t‖ ≤ R)
     (hg : IntervalIntegrable (fun t ↦ f (γ t) * deriv γ t) volume a b) :
     Tendsto (dixonH2 f γ a b) (cocompact ℂ) (nhds 0) := by
   rw [Metric.tendsto_nhds]
@@ -76,7 +127,7 @@ theorem dixonH2_tendsto_zero {R : ℝ} (hR : ∀ t ∈ uIcc a b, ‖γ t‖ ≤ 
   have hRw : R < ‖w‖ := lt_of_le_of_lt (le_max_left _ _) hw
   have hpos : 0 < ‖w‖ - R := by linarith
   calc ‖dixonH2 f γ a b w‖
-      ≤ D / (‖w‖ - R) := dixonH2_norm_le hR hg hRw
+      ≤ D / (‖w‖ - R) := dixonH2_norm_le_of_integrable hR hg hRw
     _ < ε := by
         rw [div_lt_iff₀ hpos]
         have h2 : D / ε < ‖w‖ - R := by

--- a/TauCeti/Analysis/Contour/DixonH2Bound.lean
+++ b/TauCeti/Analysis/Contour/DixonH2Bound.lean
@@ -75,6 +75,28 @@ theorem dixonH2_norm_le {R M : ℝ}
     exact hM t ht
   exact intervalIntegral.norm_integral_le_of_norm_le_const h_ptwise
 
+/-- **A `C / (‖w‖ - R)` bound forces decay along `cocompact`.** If `‖F w‖ ≤ C / (‖w‖ - R)` for every
+`w` with `R < ‖w‖`, then `F` tends to `0` along `cocompact ℂ`: outside a large closed ball the bound
+drops below any `ε > 0`. Shared scaffolding for the uniform and `L¹` decay lemmas below. -/
+private theorem tendsto_zero_cocompact_of_norm_le_div {F : ℂ → ℂ} {R C : ℝ}
+    (hbound : ∀ w : ℂ, R < ‖w‖ → ‖F w‖ ≤ C / (‖w‖ - R)) :
+    Tendsto F (cocompact ℂ) (nhds 0) := by
+  rw [Metric.tendsto_nhds]
+  intro ε hε
+  simp only [dist_zero_right]
+  filter_upwards [(isCompact_closedBall (0 : ℂ)
+      (max R (R + C / ε))).compl_mem_cocompact] with w hw
+  rw [Set.mem_compl_iff, Metric.mem_closedBall, dist_zero_right, not_le] at hw
+  have hRw : R < ‖w‖ := lt_of_le_of_lt (le_max_left _ _) hw
+  have hpos : 0 < ‖w‖ - R := by linarith
+  calc ‖F w‖ ≤ C / (‖w‖ - R) := hbound w hRw
+    _ < ε := by
+        rw [div_lt_iff₀ hpos]
+        have h2 : C / ε < ‖w‖ - R := by
+          linarith [lt_of_le_of_lt (le_max_right _ _) hw]
+        rw [div_lt_iff₀ hε] at h2
+        linarith [mul_comm ε (‖w‖ - R)]
+
 /-- **`dixonH2 f γ a b` tends to `0` along `cocompact ℂ`.** The norm bound `dixonH2_norm_le` has the
 form `C / (‖w‖ - R)` with `C = M * |b - a|`, so `tendsto_zero_cocompact_of_norm_le_div` applies. -/
 theorem dixonH2_tendsto_zero {R M : ℝ}
@@ -84,25 +106,26 @@ theorem dixonH2_tendsto_zero {R M : ℝ}
   rw [← div_mul_eq_mul_div]
   exact dixonH2_norm_le hR hM hw
 
-/-- **`L¹` norm bound for `dixonH2`.** When `‖w‖ > R`, `R` bounds `‖γ‖` on `uIcc a b`, and the
-weight `f (γ ·) * deriv γ` is interval-integrable, `dixonH2` is bounded by that weight's `L¹` norm
-divided by `‖w‖ - R`. Unlike `dixonH2_norm_le` this needs no uniform bound on the integrand, so it
-applies to raw curves whose derivative is only interval-integrable: rewrite the integrand as
-`(γ t - w)⁻¹ * (f (γ t) * deriv γ t)` and apply `norm_integral_inv_sub_mul_le`. -/
-theorem dixonH2_norm_le_of_integrable {R : ℝ} (hR : ∀ t ∈ uIcc a b, ‖γ t‖ ≤ R)
+/-- **`L¹` norm bound for `dixonH2`.** When `‖w‖ > R`, `R` bounds `‖γ‖` on `Ι a b`, and the weight
+`f (γ ·) * deriv γ` is interval-integrable, `dixonH2` is bounded by that weight's `L¹` norm divided
+by `‖w‖ - R`. Unlike `dixonH2_norm_le` this needs no uniform bound on the integrand, so it applies
+to raw curves whose derivative is only interval-integrable: rewrite the integrand as
+`(γ t - w)⁻¹ * (f (γ t) * deriv γ t)` and apply `norm_integral_inv_sub_mul_le`. Only the bound on
+the half-open interval `Ι a b` is needed. -/
+theorem dixonH2_norm_le_of_integrable {R : ℝ} (hR : ∀ t ∈ Ι a b, ‖γ t‖ ≤ R)
     (hg : IntervalIntegrable (fun t ↦ f (γ t) * deriv γ t) volume a b) {w : ℂ} (hw : R < ‖w‖) :
     ‖dixonH2 f γ a b w‖ ≤ (∫ t in Ι a b, ‖f (γ t) * deriv γ t‖) / (‖w‖ - R) := by
   have hcongr : (∫ t in a..b, f (γ t) / (γ t - w) * deriv γ t)
       = ∫ t in a..b, (γ t - w)⁻¹ * (f (γ t) * deriv γ t) :=
     intervalIntegral.integral_congr fun t _ ↦ by ring
   rw [dixonH2_def, hcongr]
-  exact norm_integral_inv_sub_mul_le hg (fun t ht ↦ hR t (uIoc_subset_uIcc ht)) hw
+  exact norm_integral_inv_sub_mul_le hg hR hw
 
 /-- **`dixonH2 f γ a b` tends to `0` along `cocompact ℂ` (`L¹` form).** The `L¹` norm bound
 `dixonH2_norm_le_of_integrable` is already of the form `C / (‖w‖ - R)`, so
 `tendsto_zero_cocompact_of_norm_le_div` applies; the interval-integrable weight replaces the uniform
 bound of `dixonH2_tendsto_zero`. -/
-theorem dixonH2_tendsto_zero_of_integrable {R : ℝ} (hR : ∀ t ∈ uIcc a b, ‖γ t‖ ≤ R)
+theorem dixonH2_tendsto_zero_of_integrable {R : ℝ} (hR : ∀ t ∈ Ι a b, ‖γ t‖ ≤ R)
     (hg : IntervalIntegrable (fun t ↦ f (γ t) * deriv γ t) volume a b) :
     Tendsto (dixonH2 f γ a b) (cocompact ℂ) (nhds 0) :=
   tendsto_zero_cocompact_of_norm_le_div fun _ hw ↦ dixonH2_norm_le_of_integrable hR hg hw

--- a/TauCeti/Analysis/Contour/WindingVanishing.lean
+++ b/TauCeti/Analysis/Contour/WindingVanishing.lean
@@ -7,6 +7,7 @@ module
 
 public import TauCeti.Analysis.Contour.WindingNumber
 import TauCeti.Analysis.Contour.WindingInteger
+import TauCeti.Analysis.Contour.CurveIntegralBound
 
 /-!
 # The winding number vanishes far from a bounded closed curve
@@ -46,34 +47,6 @@ private theorem norm_inv_two_pi_I : ‖(2 * (Real.pi : ℂ) * Complex.I)⁻¹‖
       by push_cast; ring, norm_mul, Complex.norm_I, mul_one, Complex.norm_real, Real.norm_eq_abs,
     abs_of_pos (by positivity)]
 
-/-- **Index-integral decay bound.** For a curve contained in the closed ball of radius `R` and a
-point `w` with `R < ‖w‖`, the index integral `∮_γ dz/(z - w)` is bounded by
-`(∫ ‖deriv γ‖) / (‖w‖ - R)`: pointwise `‖(γ t - w)⁻¹‖ ≤ (‖w‖ - R)⁻¹`, and the `L¹` norm of the
-derivative is finite. -/
-private theorem norm_index_integral_le_of_far {γ : ℝ → ℂ} {a b R : ℝ} {w : ℂ}
-    (hderiv_int : IntervalIntegrable (fun t ↦ deriv γ t) volume a b)
-    (hR : ∀ t ∈ uIcc a b, ‖γ t‖ ≤ R) (hw : R < ‖w‖) :
-    ‖∫ t in a..b, (γ t - w)⁻¹ * deriv γ t‖ ≤ (∫ t in Ι a b, ‖deriv γ t‖) / (‖w‖ - R) := by
-  have hpos : 0 < ‖w‖ - R := by linarith
-  have h_dist_lb : ∀ t ∈ uIcc a b, ‖w‖ - R ≤ ‖γ t - w‖ := fun t ht => by
-    have h := norm_sub_norm_le w (γ t)
-    rw [norm_sub_rev] at h
-    linarith [hR t ht]
-  have h_ae : ∀ᵐ t ∂volume.restrict (Ι a b),
-      ‖(γ t - w)⁻¹ * deriv γ t‖ ≤ (‖w‖ - R)⁻¹ * ‖deriv γ t‖ := by
-    refine ae_restrict_of_forall_mem measurableSet_uIoc fun t ht => ?_
-    rw [norm_mul, norm_inv]
-    exact mul_le_mul_of_nonneg_right (inv_anti₀ hpos (h_dist_lb t (uIoc_subset_uIcc ht)))
-      (norm_nonneg _)
-  calc ‖∫ t in a..b, (γ t - w)⁻¹ * deriv γ t‖
-      ≤ ∫ t in Ι a b, ‖(γ t - w)⁻¹ * deriv γ t‖ :=
-        intervalIntegral.norm_integral_le_integral_norm_uIoc
-    _ ≤ ∫ t in Ι a b, (‖w‖ - R)⁻¹ * ‖deriv γ t‖ :=
-        integral_mono_of_nonneg (ae_of_all _ fun _ ↦ norm_nonneg _)
-          (hderiv_int.norm.const_mul _).def' h_ae
-    _ = (‖w‖ - R)⁻¹ * ∫ t in Ι a b, ‖deriv γ t‖ := integral_const_mul _ _
-    _ = (∫ t in Ι a b, ‖deriv γ t‖) / (‖w‖ - R) := inv_mul_eq_div _ _
-
 /-- **The winding number vanishes for a point far from a bounded closed curve.** If the closed curve
 `γ` lies in the closed ball of radius `R` and `‖w‖` exceeds `R + (∫ ‖deriv γ‖) / (2π)`, then the
 integer-valued winding number about `w` has absolute value below `1`, hence is `0`. -/
@@ -98,7 +71,7 @@ private theorem windingNumber_eq_zero_of_far {γ : ℝ → ℂ} {a b R : ℝ} {P
     rw [windingNumber_eq_integral_of_avoidance hγ_cont h_off
         (intervalIntegrable_inv_sub_mul_deriv hγ_cont h_off hderiv_int),
       norm_mul, norm_inv_two_pi_I]
-    exact mul_le_mul_of_nonneg_left (norm_index_integral_le_of_far hderiv_int hR hwR)
+    exact mul_le_mul_of_nonneg_left (norm_integral_inv_sub_mul_le hderiv_int hR hwR)
       (by positivity)
   have h_lt_one : (2 * Real.pi)⁻¹ * ((∫ t in Ι a b, ‖deriv γ t‖) / (‖w‖ - R)) < 1 := by
     have key : (∫ t in Ι a b, ‖deriv γ t‖) / (2 * Real.pi) < ‖w‖ - R := by

--- a/TauCeti/Analysis/Contour/WindingVanishing.lean
+++ b/TauCeti/Analysis/Contour/WindingVanishing.lean
@@ -71,7 +71,8 @@ private theorem windingNumber_eq_zero_of_far {γ : ℝ → ℂ} {a b R : ℝ} {P
     rw [windingNumber_eq_integral_of_avoidance hγ_cont h_off
         (intervalIntegrable_inv_sub_mul_deriv hγ_cont h_off hderiv_int),
       norm_mul, norm_inv_two_pi_I]
-    exact mul_le_mul_of_nonneg_left (norm_integral_inv_sub_mul_le hderiv_int hR hwR)
+    exact mul_le_mul_of_nonneg_left
+      (norm_integral_inv_sub_mul_le hderiv_int (fun t ht ↦ hR t (uIoc_subset_uIcc ht)) hwR)
       (by positivity)
   have h_lt_one : (2 * Real.pi)⁻¹ * ((∫ t in Ι a b, ‖deriv γ t‖) / (‖w‖ - R)) < 1 := by
     have key : (∫ t in Ι a b, ‖deriv γ t‖) / (2 * Real.pi) < ‖w‖ - R := by


### PR DESCRIPTION
## Summary

One topic: factor the common **far-field Cauchy-integral decay estimate** out of the winding and Dixon developments into a single shared lemma, and use it to generalize `dixonH2`'s decay from a uniform bound to an `L¹` bound.

The shared estimate is
$$\left\lVert \int_a^b (\gamma(t)-w)^{-1}\,g(t)\,dt \right\rVert \le \frac{\int_{\mathrm{I}(a,b)} \lVert g \rVert}{\lVert w \rVert - R}$$
for an interval-integrable weight `g`, a curve with `‖γ‖ ≤ R` on `uIcc a b`, and `R < ‖w‖`. The distance lower bound `‖w‖ - R ≤ ‖γ t - w‖` makes `‖(γ t - w)⁻¹‖ ≤ (‖w‖ - R)⁻¹` pointwise, so the estimate reduces to the `L¹` norm of `g`.

## Changes

- **New** `TauCeti/Analysis/Contour/CurveIntegralBound.lean` (Mathlib-only imports): public `norm_integral_inv_sub_mul_le`, the estimate above.
- **`WindingVanishing`**: delete the private `norm_index_integral_le_of_far` (its `g = deriv γ` special case) and call the shared lemma at its one use site. No change to any public signature.
- **`DixonH2Bound`**: generalize `dixonH2_norm_le` / `dixonH2_tendsto_zero` from a *uniform* bound `M` on the integrand `‖f (γ ·) * deriv γ‖` to the `L¹` norm `∫ ‖f (γ ·) * deriv γ‖`, obtained by rewriting the integrand as `(γ t - w)⁻¹ * (f (γ t) * deriv γ t)` and applying the shared lemma with `g = f (γ ·) * deriv γ`.

## Why L¹

For a raw curve `γ : ℝ → ℂ` whose derivative is only interval-integrable, a uniform bound on `f (γ ·) * deriv γ` need not exist. The `L¹` form drops that boundedness hypothesis, so the decay result applies to exactly the curves the rest of the Dixon development handles. This is a strict generalization — the previous uniform-`M` statement is the special case `∫ ‖·‖ ≤ M · |b - a|` — and no downstream result is weakened (there are no in-repo callers of the old signatures yet).

## Context

The decay of `dixonH2` (hence of Dixon's glued function, which agrees with it far out) is the input to the Liouville step of Dixon's proof of the homology form of Cauchy's theorem (roadmap `homologyCauchyTheorem`). Both that step and the vanishing at infinity of the generalized winding number now share one estimate.

Local gates green: full `lake build` (4639 jobs), `lake exe axioms` (allowlist only), `lake exe module-system` (all opt in), `scripts/lint-env.sh` (no new violations).

🤖 Generated with [Claude Code](https://claude.com/claude-code)