### PR TITLE
feat: the circle is not simply connected

### DIFF
--- a/TauCeti/AlgebraicTopology/UniversalCover/CircleNotSimplyConnected.lean
+++ b/TauCeti/AlgebraicTopology/UniversalCover/CircleNotSimplyConnected.lean
@@ -52,14 +52,14 @@ namespace AddCircle
 variable (p : ℝ)
 
 /-- The fundamental group of the circle `AddCircle p` (`p ≠ 0`), based at any point `x`, is
-nontrivial: it contains loops of every winding number. -/
+nontrivial. See `fundamentalGroupMulEquiv` for the full winding-number classification. -/
 theorem nontrivial_fundamentalGroup (hp : p ≠ 0) (x : AddCircle p) :
     Nontrivial (FundamentalGroup (AddCircle p) x) := by
   obtain ⟨e, rfl⟩ := QuotientAddGroup.mk_surjective x
   exact (fundamentalGroupMulEquiv p hp ⟨e, rfl⟩).toEquiv.nontrivial
 
 /-- The fundamental group of the circle `AddCircle p` (`p ≠ 0`), based at any point `x`, is
-infinite: distinct winding numbers give distinct loop classes. -/
+infinite. See `fundamentalGroupMulEquiv` for the full winding-number classification. -/
 theorem infinite_fundamentalGroup (hp : p ≠ 0) (x : AddCircle p) :
     Infinite (FundamentalGroup (AddCircle p) x) := by
   obtain ⟨e, rfl⟩ := QuotientAddGroup.mk_surjective x

--- a/TauCeti/AlgebraicTopology/UniversalCover/CircleNotSimplyConnected.lean
+++ b/TauCeti/AlgebraicTopology/UniversalCover/CircleNotSimplyConnected.lean
@@ -40,9 +40,9 @@ contractibility of a real topological vector space
 * `TauCeti.AddCircle.not_simplyConnectedSpace`: `AddCircle p` is not simply connected.
 * `TauCeti.AddCircle.not_contractibleSpace`: `AddCircle p` is not contractible.
 * `TauCeti.AddCircle.isEmpty_homeomorph_of_simplyConnectedSpace`,
-  `TauCeti.AddCircle.isEmpty_homeomorph_normedSpace`,
+  `TauCeti.AddCircle.isEmpty_homeomorph_realTopologicalVectorSpace`,
   `TauCeti.AddCircle.isEmpty_homeomorph_real`: `AddCircle p` is not homeomorphic to a simply
-  connected space, to a real normed space, or to `ℝ`.
+  connected space, to a real topological vector space, or to `ℝ`.
 * `TauCeti.UnitAddCircle.*`: the specialisations to the unit circle `S¹ = ℝ ⧸ ℤ`.
 -/
 
@@ -54,29 +54,29 @@ namespace AddCircle
 
 variable (p : ℝ)
 
-/-- The fundamental group of the circle `AddCircle p` (`p ≠ 0`), based at any point `x` with a
-chosen lift `e`, is nontrivial: it contains loops of every winding number. -/
-theorem nontrivial_fundamentalGroup (hp : p ≠ 0) {x : AddCircle p}
-    (e : ((↑) : ℝ → AddCircle p) ⁻¹' {x}) :
-    Nontrivial (FundamentalGroup (AddCircle p) x) :=
-  (fundamentalGroupMulEquiv p hp e).toEquiv.nontrivial
+/-- The fundamental group of the circle `AddCircle p` (`p ≠ 0`), based at any point `x`, is
+nontrivial: it contains loops of every winding number. -/
+theorem nontrivial_fundamentalGroup (hp : p ≠ 0) (x : AddCircle p) :
+    Nontrivial (FundamentalGroup (AddCircle p) x) := by
+  obtain ⟨e, rfl⟩ := QuotientAddGroup.mk_surjective x
+  exact (fundamentalGroupMulEquiv p hp ⟨e, rfl⟩).toEquiv.nontrivial
 
-/-- The fundamental group of the circle `AddCircle p` (`p ≠ 0`), based at any point `x` with a
-chosen lift `e`, is infinite: distinct winding numbers give distinct loop classes. -/
-theorem infinite_fundamentalGroup (hp : p ≠ 0) {x : AddCircle p}
-    (e : ((↑) : ℝ → AddCircle p) ⁻¹' {x}) :
-    Infinite (FundamentalGroup (AddCircle p) x) :=
-  Infinite.of_injective _ (fundamentalGroupMulEquiv p hp e).symm.injective
+/-- The fundamental group of the circle `AddCircle p` (`p ≠ 0`), based at any point `x`, is
+infinite: distinct winding numbers give distinct loop classes. -/
+theorem infinite_fundamentalGroup (hp : p ≠ 0) (x : AddCircle p) :
+    Infinite (FundamentalGroup (AddCircle p) x) := by
+  obtain ⟨e, rfl⟩ := QuotientAddGroup.mk_surjective x
+  exact Infinite.of_injective _ (fundamentalGroupMulEquiv p hp ⟨e, rfl⟩).symm.injective
 
 /-- The fundamental group of the circle `AddCircle p` (`p ≠ 0`), based at `0`, is nontrivial. -/
 theorem nontrivial_fundamentalGroup_zero (hp : p ≠ 0) :
     Nontrivial (FundamentalGroup (AddCircle p) 0) :=
-  nontrivial_fundamentalGroup p hp ⟨0, by simp⟩
+  nontrivial_fundamentalGroup p hp 0
 
 /-- The fundamental group of the circle `AddCircle p` (`p ≠ 0`), based at `0`, is infinite. -/
 theorem infinite_fundamentalGroup_zero (hp : p ≠ 0) :
     Infinite (FundamentalGroup (AddCircle p) 0) :=
-  infinite_fundamentalGroup p hp ⟨0, by simp⟩
+  infinite_fundamentalGroup p hp 0
 
 /-- The circle `AddCircle p` (`p ≠ 0`) is **not simply connected**: its fundamental group is
 nontrivial, whereas a simply connected space has a subsingleton fundamental group. -/
@@ -103,17 +103,18 @@ theorem isEmpty_homeomorph_of_simplyConnectedSpace (hp : p ≠ 0)
   have : SimplyConnectedSpace (AddCircle p) := e.toHomotopyEquiv.simplyConnectedSpace
   exact not_simplyConnectedSpace p hp this
 
-/-- The circle `AddCircle p` (`p ≠ 0`) is not homeomorphic to any real normed space, since such
-a space is contractible, hence simply connected. -/
-theorem isEmpty_homeomorph_normedSpace (hp : p ≠ 0)
-    (E : Type*) [NormedAddCommGroup E] [NormedSpace ℝ E] :
+/-- The circle `AddCircle p` (`p ≠ 0`) is not homeomorphic to any real topological vector space
+(in particular, to any real normed space), since such a space is contractible, hence simply
+connected. -/
+theorem isEmpty_homeomorph_realTopologicalVectorSpace (hp : p ≠ 0) (E : Type*)
+    [AddCommGroup E] [Module ℝ E] [TopologicalSpace E] [ContinuousAdd E] [ContinuousSMul ℝ E] :
     IsEmpty (AddCircle p ≃ₜ E) :=
   isEmpty_homeomorph_of_simplyConnectedSpace p hp E
 
 /-- The circle `AddCircle p` (`p ≠ 0`) is not homeomorphic to the real line: the circle is not
 simply connected but `ℝ` is contractible. -/
 theorem isEmpty_homeomorph_real (hp : p ≠ 0) : IsEmpty (AddCircle p ≃ₜ ℝ) :=
-  isEmpty_homeomorph_normedSpace p hp ℝ
+  isEmpty_homeomorph_realTopologicalVectorSpace p hp ℝ
 
 end AddCircle
 

--- a/TauCeti/AlgebraicTopology/UniversalCover/CircleNotSimplyConnected.lean
+++ b/TauCeti/AlgebraicTopology/UniversalCover/CircleNotSimplyConnected.lean
@@ -4,9 +4,6 @@ Released under Apache 2.0 license as described in the file LICENSE.
 -/
 module
 
-public import Mathlib.Topology.Homotopy.Equiv
-public import Mathlib.Analysis.Convex.Contractible
-public import Mathlib.Analysis.Normed.Module.Basic
 public import TauCeti.AlgebraicTopology.UniversalCover.CircleFundamentalGroup
 
 /-!

--- a/TauCeti/AlgebraicTopology/UniversalCover/CircleNotSimplyConnected.lean
+++ b/TauCeti/AlgebraicTopology/UniversalCover/CircleNotSimplyConnected.lean
@@ -1,0 +1,144 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+module
+
+public import Mathlib.Topology.Homotopy.Equiv
+public import Mathlib.Analysis.Convex.Contractible
+public import Mathlib.Analysis.Normed.Module.Basic
+public import TauCeti.AlgebraicTopology.UniversalCover.CircleFundamentalGroup
+
+/-!
+# The circle is not simply connected
+
+The circle computation `π₁(AddCircle p) ≃* Multiplicative ℤ`
+(`TauCeti.AddCircle.fundamentalGroupMulEquiv`) has an immediate qualitative payoff: since
+`Multiplicative ℤ` is nontrivial and infinite, so is the fundamental group of the circle, and
+therefore the circle is **not simply connected**. Being non-simply-connected, it is not
+contractible, and it is not homeomorphic to any simply connected space; in particular the
+circle is not homeomorphic to the real line nor to any real normed space.
+
+These are the standard topological consequences of `π₁(S¹) ≅ ℤ`, and they realise the
+universal-covers roadmap Stage 4 "applications" (`TauCetiRoadmap/UniversalCovers/README.md`),
+extending the circle computation (item 12, `π₁(S¹) ≅ ℤ`) to the classical fact that the
+circle and the line are topologically distinct.
+
+The nontriviality and infinitude of the fundamental group are transported from
+`Multiplicative ℤ` along the circle equivalence. Non-simple-connectivity then follows because
+a simply connected space has a subsingleton fundamental group. The homeomorphism statements
+consume Mathlib's transfer of `SimplyConnectedSpace` along a homotopy equivalence
+(`ContinuousMap.HomotopyEquiv.simplyConnectedSpace`, via `Homeomorph.toHomotopyEquiv`) and the
+contractibility of a real topological vector space
+(`RealTopologicalVectorSpace.contractibleSpace`). No Mathlib code is vendored.
+
+## Main declarations
+
+* `TauCeti.AddCircle.nontrivial_fundamentalGroup`,
+  `TauCeti.AddCircle.infinite_fundamentalGroup`: the fundamental group of `AddCircle p`
+  (`p ≠ 0`), at any basepoint, is nontrivial and infinite.
+* `TauCeti.AddCircle.not_simplyConnectedSpace`: `AddCircle p` is not simply connected.
+* `TauCeti.AddCircle.not_contractibleSpace`: `AddCircle p` is not contractible.
+* `TauCeti.AddCircle.isEmpty_homeomorph_of_simplyConnectedSpace`,
+  `TauCeti.AddCircle.isEmpty_homeomorph_normedSpace`,
+  `TauCeti.AddCircle.isEmpty_homeomorph_real`: `AddCircle p` is not homeomorphic to a simply
+  connected space, to a real normed space, or to `ℝ`.
+* `TauCeti.UnitAddCircle.*`: the specialisations to the unit circle `S¹ = ℝ ⧸ ℤ`.
+-/
+
+public section
+
+namespace TauCeti
+
+namespace AddCircle
+
+variable (p : ℝ)
+
+/-- The fundamental group of the circle `AddCircle p` (`p ≠ 0`), based at any point `x` with a
+chosen lift `e`, is nontrivial: it contains loops of every winding number. -/
+theorem nontrivial_fundamentalGroup (hp : p ≠ 0) {x : AddCircle p}
+    (e : ((↑) : ℝ → AddCircle p) ⁻¹' {x}) :
+    Nontrivial (FundamentalGroup (AddCircle p) x) :=
+  (fundamentalGroupMulEquiv p hp e).toEquiv.nontrivial
+
+/-- The fundamental group of the circle `AddCircle p` (`p ≠ 0`), based at any point `x` with a
+chosen lift `e`, is infinite: distinct winding numbers give distinct loop classes. -/
+theorem infinite_fundamentalGroup (hp : p ≠ 0) {x : AddCircle p}
+    (e : ((↑) : ℝ → AddCircle p) ⁻¹' {x}) :
+    Infinite (FundamentalGroup (AddCircle p) x) :=
+  Infinite.of_injective _ (fundamentalGroupMulEquiv p hp e).symm.injective
+
+/-- The fundamental group of the circle `AddCircle p` (`p ≠ 0`), based at `0`, is nontrivial. -/
+theorem nontrivial_fundamentalGroup_zero (hp : p ≠ 0) :
+    Nontrivial (FundamentalGroup (AddCircle p) 0) :=
+  nontrivial_fundamentalGroup p hp ⟨0, by simp⟩
+
+/-- The fundamental group of the circle `AddCircle p` (`p ≠ 0`), based at `0`, is infinite. -/
+theorem infinite_fundamentalGroup_zero (hp : p ≠ 0) :
+    Infinite (FundamentalGroup (AddCircle p) 0) :=
+  infinite_fundamentalGroup p hp ⟨0, by simp⟩
+
+/-- The circle `AddCircle p` (`p ≠ 0`) is **not simply connected**: its fundamental group is
+nontrivial, whereas a simply connected space has a subsingleton fundamental group. -/
+theorem not_simplyConnectedSpace (hp : p ≠ 0) : ¬ SimplyConnectedSpace (AddCircle p) := by
+  intro h
+  haveI := h
+  haveI := nontrivial_fundamentalGroup_zero p hp
+  exact false_of_nontrivial_of_subsingleton (FundamentalGroup (AddCircle p) 0)
+
+/-- The circle `AddCircle p` (`p ≠ 0`) is **not contractible**: a contractible space is simply
+connected, and the circle is not. -/
+theorem not_contractibleSpace (hp : p ≠ 0) : ¬ ContractibleSpace (AddCircle p) := by
+  intro h
+  haveI := h
+  exact not_simplyConnectedSpace p hp inferInstance
+
+/-- The circle `AddCircle p` (`p ≠ 0`) is not homeomorphic to any simply connected space: a
+homeomorphism is in particular a homotopy equivalence, and simple connectivity transfers along
+homotopy equivalences, which the circle does not enjoy. -/
+theorem isEmpty_homeomorph_of_simplyConnectedSpace (hp : p ≠ 0)
+    (Y : Type*) [TopologicalSpace Y] [SimplyConnectedSpace Y] :
+    IsEmpty (AddCircle p ≃ₜ Y) := by
+  refine ⟨fun e => ?_⟩
+  have : SimplyConnectedSpace (AddCircle p) := e.toHomotopyEquiv.simplyConnectedSpace
+  exact not_simplyConnectedSpace p hp this
+
+/-- The circle `AddCircle p` (`p ≠ 0`) is not homeomorphic to any real normed space, since such
+a space is contractible, hence simply connected. -/
+theorem isEmpty_homeomorph_normedSpace (hp : p ≠ 0)
+    (E : Type*) [NormedAddCommGroup E] [NormedSpace ℝ E] :
+    IsEmpty (AddCircle p ≃ₜ E) :=
+  isEmpty_homeomorph_of_simplyConnectedSpace p hp E
+
+/-- The circle `AddCircle p` (`p ≠ 0`) is not homeomorphic to the real line: the circle is not
+simply connected but `ℝ` is contractible. -/
+theorem isEmpty_homeomorph_real (hp : p ≠ 0) : IsEmpty (AddCircle p ≃ₜ ℝ) :=
+  isEmpty_homeomorph_normedSpace p hp ℝ
+
+end AddCircle
+
+namespace UnitAddCircle
+
+/-- The fundamental group of the unit circle `S¹ = ℝ ⧸ ℤ`, based at `0`, is nontrivial. -/
+theorem nontrivial_fundamentalGroup_zero : Nontrivial (FundamentalGroup UnitAddCircle 0) :=
+  AddCircle.nontrivial_fundamentalGroup_zero 1 one_ne_zero
+
+/-- The fundamental group of the unit circle `S¹ = ℝ ⧸ ℤ`, based at `0`, is infinite. -/
+theorem infinite_fundamentalGroup_zero : Infinite (FundamentalGroup UnitAddCircle 0) :=
+  AddCircle.infinite_fundamentalGroup_zero 1 one_ne_zero
+
+/-- The unit circle `S¹ = ℝ ⧸ ℤ` is not simply connected. -/
+theorem not_simplyConnectedSpace : ¬ SimplyConnectedSpace UnitAddCircle :=
+  AddCircle.not_simplyConnectedSpace 1 one_ne_zero
+
+/-- The unit circle `S¹ = ℝ ⧸ ℤ` is not contractible. -/
+theorem not_contractibleSpace : ¬ ContractibleSpace UnitAddCircle :=
+  AddCircle.not_contractibleSpace 1 one_ne_zero
+
+/-- The unit circle `S¹ = ℝ ⧸ ℤ` is not homeomorphic to the real line. -/
+theorem isEmpty_homeomorph_real : IsEmpty (UnitAddCircle ≃ₜ ℝ) :=
+  AddCircle.isEmpty_homeomorph_real 1 one_ne_zero
+
+end UnitAddCircle
+
+end TauCeti


### PR DESCRIPTION
This PR derives the standard topological consequences of the circle computation `π₁(AddCircle p) ≃* Multiplicative ℤ` (`TauCeti.AddCircle.fundamentalGroupMulEquiv`): since `Multiplicative ℤ` is nontrivial and infinite, so is the fundamental group of `AddCircle p` (`p ≠ 0`) at any basepoint, hence the circle is not simply connected, not contractible, and not homeomorphic to any simply connected space -- in particular not to a real normed space nor to the line `ℝ`. It specialises each statement to the unit circle `S¹ = ℝ ⧸ ℤ`.

This advances `TauCetiRoadmap/UniversalCovers/README.md`, Stage 4 "applications", extending the circle computation (item 12, `π₁(S¹) ≅ ℤ`) to the classical fact that the circle and the line are topologically distinct. The new file is `TauCeti/AlgebraicTopology/UniversalCover/CircleNotSimplyConnected.lean` (144 lines). It builds on `TauCeti.AddCircle.fundamentalGroupMulEquiv` (from `.../UniversalCover/CircleFundamentalGroup.lean`) and consumes Mathlib's transfer of `SimplyConnectedSpace` along a homotopy equivalence (`ContinuousMap.HomotopyEquiv.simplyConnectedSpace`, via `Homeomorph.toHomotopyEquiv`), the subsingleton fundamental group of a simply connected space, `SimplyConnectedSpace.ofContractible`, and the contractibility of a real topological vector space (`RealTopologicalVectorSpace.contractibleSpace`); no Mathlib code is vendored.

`lake build` completed with `Build completed successfully (4684 jobs).` `lake exe axioms` reported `audited 8765 TauCeti declaration(s); all within the allowlist [propext, Classical.choice, Quot.sound].` `lake exe module-system` reported `all 458 TauCeti module(s) opt into the module system.`

<!--tauceti-target:v1 {"focus":"UniversalCovers","id":"circle-not-simply-connected"}-->

🤖 Prepared with Claude Code
