### PR TITLE
feat: add Chebyshev exponential moments

### DIFF
--- a/TauCeti/Analysis/SpecialFunctions/Trigonometric/Chebyshev/Measure.lean
+++ b/TauCeti/Analysis/SpecialFunctions/Trigonometric/Chebyshev/Measure.lean
@@ -158,19 +158,6 @@ lemma integrable_exp_mul_abs_smul_measureT {𝕜 β : Type*} [RCLike 𝕜] [Norm
     filter_upwards [ae_mem_Icc_measureT] with x hx
     exact abs_le.mpr hx)
 
-/-- The Chebyshev `T` orthogonality measure has every exponential absolute moment finite. -/
-lemma integrable_exp_abs_measureT (a : ℝ) :
-    Integrable (fun x : ℝ => Real.exp (a * |x|)) Polynomial.Chebyshev.measureT := by
-  simpa using integrable_exp_mul_abs_smul_measureT (𝕜 := ℝ) (β := ℝ) (g := fun _ : ℝ => 1) a
-    (integrable_const (1 : ℝ))
-
-/-- The scalar-cast exponential absolute moments of the Chebyshev `T` measure are finite. -/
-lemma integrable_algebraMap_exp_abs_measureT {𝕜 : Type*} [RCLike 𝕜] (a : ℝ) :
-    Integrable (fun x : ℝ => (algebraMap ℝ 𝕜) (Real.exp (a * |x|)))
-      Polynomial.Chebyshev.measureT := by
-  simpa only [RCLike.algebraMap_eq_ofReal] using
-    (integrable_exp_abs_measureT a).ofReal (𝕜 := 𝕜)
-
 /-! ### `L²` consumer forms -/
 
 /-- The real normalized Chebyshev `T` mode, with squared norm one in `L²(measureT)`. -/

--- a/TauCeti/Analysis/SpecialFunctions/Trigonometric/Chebyshev/Measure.lean
+++ b/TauCeti/Analysis/SpecialFunctions/Trigonometric/Chebyshev/Measure.lean
@@ -112,7 +112,8 @@ lemma integral_eval_T_real_mul_eval_T_real_measureT_eq_ite (m n : ℕ) :
 
 /-! ### Exponential-moment consumer forms -/
 
-private lemma ae_mem_Icc_measureT :
+/-- The Chebyshev `T` orthogonality measure is supported on `[-1, 1]`. -/
+lemma ae_mem_Icc_measureT :
     ∀ᵐ x ∂Polynomial.Chebyshev.measureT, x ∈ Set.Icc (-1 : ℝ) 1 := by
   -- Across the `module` boundary, `measureT`'s restricted-measure definition is not
   -- unfoldable here.  Recover the support fact through the public `integral_measureT`
@@ -156,6 +157,19 @@ lemma integrable_exp_mul_abs_smul_measureT {𝕜 β : Type*} [RCLike 𝕜] [Norm
   exact Integrable.exp_abs_smul_of_ae_abs_le hg a 1 (by
     filter_upwards [ae_mem_Icc_measureT] with x hx
     exact abs_le.mpr hx)
+
+/-- The Chebyshev `T` orthogonality measure has every exponential absolute moment finite. -/
+lemma integrable_exp_abs_measureT (a : ℝ) :
+    Integrable (fun x : ℝ => Real.exp (a * |x|)) Polynomial.Chebyshev.measureT := by
+  simpa using integrable_exp_mul_abs_smul_measureT (𝕜 := ℝ) (β := ℝ) (g := fun _ : ℝ => 1) a
+    (integrable_const (1 : ℝ))
+
+/-- The scalar-cast exponential absolute moments of the Chebyshev `T` measure are finite. -/
+lemma integrable_algebraMap_exp_abs_measureT {𝕜 : Type*} [RCLike 𝕜] (a : ℝ) :
+    Integrable (fun x : ℝ => (algebraMap ℝ 𝕜) (Real.exp (a * |x|)))
+      Polynomial.Chebyshev.measureT := by
+  simpa only [RCLike.algebraMap_eq_ofReal] using
+    (integrable_exp_abs_measureT a).ofReal (𝕜 := 𝕜)
 
 /-! ### `L²` consumer forms -/
 


### PR DESCRIPTION
This PR exposes the compact-support bookkeeping for Mathlib's Chebyshev `T` orthogonality measure and records the finite exponential moments that the later completeness proof can consume. It makes the existing `measureT` support fact public as `ae_mem_Icc_measureT`, then specializes the bounded-support integrability lemma to `integrable_exp_abs_measureT` and its `RCLike` scalar-cast form `integrable_algebraMap_exp_abs_measureT`.

This advances `TauCetiRoadmap/OrthogonalL2Bases/README.md`, Part C, "A second family: the Chebyshev basis of `L²([-1,1])`", specifically the open target that Chebyshev completeness reuses B1 because "`measureT` is compactly supported" and needs the finite exponential moments for B1's moment-determinacy hypothesis. It is the small prerequisite immediately below the full `chebyshevHilbertBasis` construction, not the basis construction itself.

<!--tauceti-target:v1 {"focus":"OrthogonalL2Bases","id":"chebyshev-measuret-exponential-moments"}-->

No Mathlib infrastructure is vendored. The proof reuses Mathlib's Chebyshev measure API (`measureT`, `integral_measureT`) and Tau Ceti's existing bounded-support integrability lemma `Integrable.exp_abs_smul_of_ae_abs_le`.

`lake exe cache get` completed with `No files to download` and `Already decompressed 8619 file(s)`. `lake build` reported `Build completed successfully (4686 jobs).` `lake exe axioms` reported `axioms: audited 8798 TauCeti declaration(s); all within the allowlist [propext, Classical.choice, Quot.sound].`

🤖 Prepared with Codex
