### PR TITLE
feat(Analysis/Contour): Dixon function vanishes (Liouville step)

### DIFF
--- a/TauCeti/Analysis/Contour/DixonFunctionDiff.lean
+++ b/TauCeti/Analysis/Contour/DixonFunctionDiff.lean
@@ -26,8 +26,8 @@ there, so the `h₁`/`h₂` identity collapses.
 * `TauCeti.Contour.differentiable_dixonFunction` — `dixonFunction f U γ a b` is entire for a
   null-homologous closed curve. It is built from a private gluing core that takes the off-`U`
   winding-vanishing hypothesis directly, which the null-homologous case then discharges.
-* `TauCeti.Contour.cauchy_integrand_intervalIntegrable` — the `dixonH2` integrand
-  `f (γ ·) / (γ · - w) · deriv γ` is interval-integrable for `w` off the curve.
+* `TauCeti.Contour.dixonFunction_eq_dixonH2_of_windingNumber_zero` — off the curve with winding
+  number `0`, `dixonFunction` equals `dixonH2` (the pointwise gluing fact used here and downstream).
 
 This is the analyticity input to the Liouville step of Dixon's proof of the homology form of
 Cauchy's theorem (`homologyCauchyTheorem`, `TauCetiRoadmap/ContourIntegration/Suggested.lean`).
@@ -56,13 +56,30 @@ interval-integrable for `w` off the curve: a continuous factor (using `f` contin
 `γ` continuous, and `γ` avoiding `w`) times the interval-integrable derivative. This is the
 integrand of `dixonH2 f γ a b w`, and supplies the `h_cauchy_int` hypothesis of
 `dixonH1_eq_dixonH2_sub_windingNumber_mul_f`. -/
-theorem cauchy_integrand_intervalIntegrable (hf : DifferentiableOn ℂ f U)
+private theorem cauchy_integrand_intervalIntegrable (hf : DifferentiableOn ℂ f U)
     (hγ_cont : ContinuousOn γ (uIcc a b)) (hγU : ∀ t ∈ uIcc a b, γ t ∈ U)
     (hderiv_int : IntervalIntegrable (fun t ↦ deriv γ t) volume a b)
     (hoff : ∀ t ∈ uIcc a b, γ t ≠ w) :
     IntervalIntegrable (fun t ↦ f (γ t) / (γ t - w) * deriv γ t) volume a b :=
   hderiv_int.continuousOn_mul (((hf.continuousOn.comp hγ_cont hγU).div
     (hγ_cont.sub continuousOn_const) fun t ht ↦ sub_ne_zero.mpr (hoff t ht)))
+
+/-- **Off the curve with vanishing winding number, `dixonFunction` equals `dixonH2`.** For `w` off
+the curve with `windingNumber γ a b w = 0`, the two branches of `dixonFunction` agree: on `U` the
+`h₁`/`h₂` identity collapses because the winding term vanishes, and off `U` it is `dixonH2` by
+definition. This is the pointwise gluing fact shared by the analyticity of `dixonFunction` (across
+`∂U`) and its vanishing at infinity. -/
+theorem dixonFunction_eq_dixonH2_of_windingNumber_zero (hf : DifferentiableOn ℂ f U)
+    (hγ_cont : ContinuousOn γ (uIcc a b)) (hγU : ∀ t ∈ uIcc a b, γ t ∈ U)
+    (hderiv_int : IntervalIntegrable (fun t ↦ deriv γ t) volume a b)
+    (hoff : ∀ t ∈ uIcc a b, γ t ≠ w) (hwn : windingNumber γ a b w = 0) :
+    dixonFunction f U γ a b w = dixonH2 f γ a b w := by
+  by_cases hw : w ∈ U
+  · rw [dixonFunction_eq_dixonH1 hw, dixonH1_eq_dixonH2_sub_windingNumber_mul_f hγ_cont hoff
+      (cauchy_integrand_intervalIntegrable hf hγ_cont hγU hderiv_int hoff)
+      (intervalIntegrable_inv_sub_mul_deriv hγ_cont hoff hderiv_int), hwn]
+    ring
+  · rw [dixonFunction_eq_dixonH2 hw]
 
 /-- **Analytic gluing of the Dixon function.** If `f` is differentiable on the open set `U`, the
 curve `γ` is continuous on `uIcc a b` with image in `U` and interval-integrable derivative, and
@@ -90,12 +107,7 @@ private theorem differentiable_dixonFunction_of_windingNumber_zero_near (hU : Is
       (cauchy_integrand_intervalIntegrable hf hγ_cont hγU hderiv_int hoff)).congr_of_eventuallyEq ?_
     filter_upwards [Metric.ball_mem_nhds w hε_pos] with w' hw'
     obtain ⟨hoff', hwz'⟩ := h_ball w' hw'
-    by_cases hw'U : w' ∈ U
-    · rw [dixonFunction_eq_dixonH1 hw'U, dixonH1_eq_dixonH2_sub_windingNumber_mul_f hγ_cont hoff'
-        (cauchy_integrand_intervalIntegrable hf hγ_cont hγU hderiv_int hoff')
-        (intervalIntegrable_inv_sub_mul_deriv hγ_cont hoff' hderiv_int), hwz']
-      ring
-    · rw [dixonFunction_eq_dixonH2 hw'U]
+    exact dixonFunction_eq_dixonH2_of_windingNumber_zero hf hγ_cont hγU hderiv_int hoff' hwz'
 
 /-- **The Dixon function is entire.** For `f` differentiable on the open set `U`, a closed curve `γ`
 that is continuous on `uIcc a b`, differentiable off a countable subset, with interval-integrable

--- a/TauCeti/Analysis/Contour/DixonFunctionDiff.lean
+++ b/TauCeti/Analysis/Contour/DixonFunctionDiff.lean
@@ -31,7 +31,7 @@ there, so the `h₁`/`h₂` identity collapses.
   gluing fact used here and downstream).
 * `TauCeti.Contour.cauchy_integrand_intervalIntegrable` — the `dixonH2` integrand
   `f (γ ·) / (γ · - w) · deriv γ` is interval-integrable for `w` off the curve (discharges the
-  integrand hypothesis above when `f` is differentiable on `U`).
+  integrand hypothesis above, needing only `f` continuous on `U`).
 
 This is the analyticity input to the Liouville step of Dixon's proof of the homology form of
 Cauchy's theorem (`homologyCauchyTheorem`, `TauCetiRoadmap/ContourIntegration/Suggested.lean`).
@@ -60,13 +60,14 @@ interval-integrable for `w` off the curve: a continuous factor (using `f` contin
 `γ` continuous, and `γ` avoiding `w`) times the interval-integrable derivative. This is the
 integrand of `dixonH2 f γ a b w`, and supplies the `h_cauchy_int` hypothesis of
 `dixonH1_eq_dixonH2_sub_windingNumber_mul_f` and of
-`dixonFunction_eq_dixonH2_of_windingNumber_zero` when `f` is differentiable on `U`. -/
-theorem cauchy_integrand_intervalIntegrable (hf : DifferentiableOn ℂ f U)
+`dixonFunction_eq_dixonH2_of_windingNumber_zero`; in Dixon's application `f` is holomorphic on `U`,
+but only continuity is used here. -/
+theorem cauchy_integrand_intervalIntegrable (hf : ContinuousOn f U)
     (hγ_cont : ContinuousOn γ (uIcc a b)) (hγU : ∀ t ∈ uIcc a b, γ t ∈ U)
     (hderiv_int : IntervalIntegrable (fun t ↦ deriv γ t) volume a b)
     (hoff : ∀ t ∈ uIcc a b, γ t ≠ w) :
     IntervalIntegrable (fun t ↦ f (γ t) / (γ t - w) * deriv γ t) volume a b :=
-  hderiv_int.continuousOn_mul (((hf.continuousOn.comp hγ_cont hγU).div
+  hderiv_int.continuousOn_mul (((hf.comp hγ_cont hγU).div
     (hγ_cont.sub continuousOn_const) fun t ht ↦ sub_ne_zero.mpr (hoff t ht)))
 
 /-- **Off the curve with vanishing winding number, `dixonFunction` equals `dixonH2`.** For `w` off
@@ -110,11 +111,12 @@ private theorem differentiable_dixonFunction_of_windingNumber_zero_near (hU : Is
   · have hoff : ∀ t ∈ uIcc a b, γ t ≠ w := fun t ht heq ↦ hw (heq ▸ hγU t ht)
     obtain ⟨ε, hε_pos, h_ball⟩ := h_local w hw
     refine (differentiableAt_dixonH2 hγ_cont hoff
-      (cauchy_integrand_intervalIntegrable hf hγ_cont hγU hderiv_int hoff)).congr_of_eventuallyEq ?_
+      (cauchy_integrand_intervalIntegrable hf.continuousOn hγ_cont hγU hderiv_int
+        hoff)).congr_of_eventuallyEq ?_
     filter_upwards [Metric.ball_mem_nhds w hε_pos] with w' hw'
     obtain ⟨hoff', hwz'⟩ := h_ball w' hw'
     exact dixonFunction_eq_dixonH2_of_windingNumber_zero hγ_cont hderiv_int
-      (cauchy_integrand_intervalIntegrable hf hγ_cont hγU hderiv_int hoff') hoff' hwz'
+      (cauchy_integrand_intervalIntegrable hf.continuousOn hγ_cont hγU hderiv_int hoff') hoff' hwz'
 
 /-- **The Dixon function is entire.** For `f` differentiable on the open set `U`, a closed curve `γ`
 that is continuous on `uIcc a b`, differentiable off a countable subset, with interval-integrable

--- a/TauCeti/Analysis/Contour/DixonFunctionDiff.lean
+++ b/TauCeti/Analysis/Contour/DixonFunctionDiff.lean
@@ -27,7 +27,11 @@ there, so the `h₁`/`h₂` identity collapses.
   null-homologous closed curve. It is built from a private gluing core that takes the off-`U`
   winding-vanishing hypothesis directly, which the null-homologous case then discharges.
 * `TauCeti.Contour.dixonFunction_eq_dixonH2_of_windingNumber_zero` — off the curve with winding
-  number `0`, `dixonFunction` equals `dixonH2` (the pointwise gluing fact used here and downstream).
+  number `0` and the Cauchy integrand integrable, `dixonFunction` equals `dixonH2` (the pointwise
+  gluing fact used here and downstream).
+* `TauCeti.Contour.cauchy_integrand_intervalIntegrable` — the `dixonH2` integrand
+  `f (γ ·) / (γ · - w) · deriv γ` is interval-integrable for `w` off the curve (discharges the
+  integrand hypothesis above when `f` is differentiable on `U`).
 
 This is the analyticity input to the Liouville step of Dixon's proof of the homology form of
 Cauchy's theorem (`homologyCauchyTheorem`, `TauCetiRoadmap/ContourIntegration/Suggested.lean`).
@@ -55,8 +59,9 @@ variable {f : ℂ → ℂ} {U : Set ℂ} {γ : ℝ → ℂ} {a b : ℝ} {P : Set
 interval-integrable for `w` off the curve: a continuous factor (using `f` continuous on `U ⊇ γ`,
 `γ` continuous, and `γ` avoiding `w`) times the interval-integrable derivative. This is the
 integrand of `dixonH2 f γ a b w`, and supplies the `h_cauchy_int` hypothesis of
-`dixonH1_eq_dixonH2_sub_windingNumber_mul_f`. -/
-private theorem cauchy_integrand_intervalIntegrable (hf : DifferentiableOn ℂ f U)
+`dixonH1_eq_dixonH2_sub_windingNumber_mul_f` and of
+`dixonFunction_eq_dixonH2_of_windingNumber_zero` when `f` is differentiable on `U`. -/
+theorem cauchy_integrand_intervalIntegrable (hf : DifferentiableOn ℂ f U)
     (hγ_cont : ContinuousOn γ (uIcc a b)) (hγU : ∀ t ∈ uIcc a b, γ t ∈ U)
     (hderiv_int : IntervalIntegrable (fun t ↦ deriv γ t) volume a b)
     (hoff : ∀ t ∈ uIcc a b, γ t ≠ w) :
@@ -65,19 +70,20 @@ private theorem cauchy_integrand_intervalIntegrable (hf : DifferentiableOn ℂ f
     (hγ_cont.sub continuousOn_const) fun t ht ↦ sub_ne_zero.mpr (hoff t ht)))
 
 /-- **Off the curve with vanishing winding number, `dixonFunction` equals `dixonH2`.** For `w` off
-the curve with `windingNumber γ a b w = 0`, the two branches of `dixonFunction` agree: on `U` the
-`h₁`/`h₂` identity collapses because the winding term vanishes, and off `U` it is `dixonH2` by
-definition. This is the pointwise gluing fact shared by the analyticity of `dixonFunction` (across
-`∂U`) and its vanishing at infinity. -/
-theorem dixonFunction_eq_dixonH2_of_windingNumber_zero (hf : DifferentiableOn ℂ f U)
-    (hγ_cont : ContinuousOn γ (uIcc a b)) (hγU : ∀ t ∈ uIcc a b, γ t ∈ U)
+the curve with `windingNumber γ a b w = 0` and the Cauchy integrand `f (γ ·) / (γ · - w) · deriv γ`
+interval-integrable, the two branches of `dixonFunction` agree: on `U` the `h₁`/`h₂` identity
+collapses because the winding term vanishes, and off `U` it is `dixonH2` by definition. Only
+integrability is needed, not holomorphy of `f`; when `f` is differentiable on `U ⊇ γ` the integrand
+hypothesis is discharged by `cauchy_integrand_intervalIntegrable`. This is the pointwise gluing fact
+shared by the analyticity of `dixonFunction` and its vanishing at infinity. -/
+theorem dixonFunction_eq_dixonH2_of_windingNumber_zero (hγ_cont : ContinuousOn γ (uIcc a b))
     (hderiv_int : IntervalIntegrable (fun t ↦ deriv γ t) volume a b)
+    (h_cauchy_int : IntervalIntegrable (fun t ↦ f (γ t) / (γ t - w) * deriv γ t) volume a b)
     (hoff : ∀ t ∈ uIcc a b, γ t ≠ w) (hwn : windingNumber γ a b w = 0) :
     dixonFunction f U γ a b w = dixonH2 f γ a b w := by
   by_cases hw : w ∈ U
   · rw [dixonFunction_eq_dixonH1 hw, dixonH1_eq_dixonH2_sub_windingNumber_mul_f hγ_cont hoff
-      (cauchy_integrand_intervalIntegrable hf hγ_cont hγU hderiv_int hoff)
-      (intervalIntegrable_inv_sub_mul_deriv hγ_cont hoff hderiv_int), hwn]
+      h_cauchy_int (intervalIntegrable_inv_sub_mul_deriv hγ_cont hoff hderiv_int), hwn]
     ring
   · rw [dixonFunction_eq_dixonH2 hw]
 
@@ -107,7 +113,8 @@ private theorem differentiable_dixonFunction_of_windingNumber_zero_near (hU : Is
       (cauchy_integrand_intervalIntegrable hf hγ_cont hγU hderiv_int hoff)).congr_of_eventuallyEq ?_
     filter_upwards [Metric.ball_mem_nhds w hε_pos] with w' hw'
     obtain ⟨hoff', hwz'⟩ := h_ball w' hw'
-    exact dixonFunction_eq_dixonH2_of_windingNumber_zero hf hγ_cont hγU hderiv_int hoff' hwz'
+    exact dixonFunction_eq_dixonH2_of_windingNumber_zero hγ_cont hderiv_int
+      (cauchy_integrand_intervalIntegrable hf hγ_cont hγU hderiv_int hoff') hoff' hwz'
 
 /-- **The Dixon function is entire.** For `f` differentiable on the open set `U`, a closed curve `γ`
 that is continuous on `uIcc a b`, differentiable off a countable subset, with interval-integrable

--- a/TauCeti/Analysis/Contour/DixonFunctionDiff.lean
+++ b/TauCeti/Analysis/Contour/DixonFunctionDiff.lean
@@ -26,6 +26,8 @@ there, so the `h₁`/`h₂` identity collapses.
 * `TauCeti.Contour.differentiable_dixonFunction` — `dixonFunction f U γ a b` is entire for a
   null-homologous closed curve. It is built from a private gluing core that takes the off-`U`
   winding-vanishing hypothesis directly, which the null-homologous case then discharges.
+* `TauCeti.Contour.cauchy_integrand_intervalIntegrable` — the `dixonH2` integrand
+  `f (γ ·) / (γ · - w) · deriv γ` is interval-integrable for `w` off the curve.
 
 This is the analyticity input to the Liouville step of Dixon's proof of the homology form of
 Cauchy's theorem (`homologyCauchyTheorem`, `TauCetiRoadmap/ContourIntegration/Suggested.lean`).
@@ -49,9 +51,12 @@ section
 
 variable {f : ℂ → ℂ} {U : Set ℂ} {γ : ℝ → ℂ} {a b : ℝ} {P : Set ℝ} {w : ℂ}
 
-/-- The Cauchy-type integrand `f (γ ·) / (γ · - w) · deriv γ` is interval-integrable for `w` off the
-curve: a continuous factor (using `f` continuous on `U ⊇ γ`) times the integrable derivative. -/
-private theorem cauchy_integrand_intervalIntegrable (hf : DifferentiableOn ℂ f U)
+/-- **The Cauchy-type integrand is interval-integrable.** `f (γ ·) / (γ · - w) · deriv γ` is
+interval-integrable for `w` off the curve: a continuous factor (using `f` continuous on `U ⊇ γ`,
+`γ` continuous, and `γ` avoiding `w`) times the interval-integrable derivative. This is the
+integrand of `dixonH2 f γ a b w`, and supplies the `h_cauchy_int` hypothesis of
+`dixonH1_eq_dixonH2_sub_windingNumber_mul_f`. -/
+theorem cauchy_integrand_intervalIntegrable (hf : DifferentiableOn ℂ f U)
     (hγ_cont : ContinuousOn γ (uIcc a b)) (hγU : ∀ t ∈ uIcc a b, γ t ∈ U)
     (hderiv_int : IntervalIntegrable (fun t ↦ deriv γ t) volume a b)
     (hoff : ∀ t ∈ uIcc a b, γ t ≠ w) :

--- a/TauCeti/Analysis/Contour/DixonLiouville.lean
+++ b/TauCeti/Analysis/Contour/DixonLiouville.lean
@@ -59,12 +59,7 @@ private theorem dixonFunction_eventually_eq_dixonH2 (hf : DifferentiableOn ℂ f
     ∀ᶠ w in cocompact ℂ, dixonFunction f U γ a b w = dixonH2 f γ a b w := by
   filter_upwards [windingNumber_eventually_zero_cocompact hclosed hP hγ_cont hγ_diff hderiv_int]
     with w ⟨hoff, hwn⟩
-  by_cases hw : w ∈ U
-  · rw [dixonFunction_eq_dixonH1 hw, dixonH1_eq_dixonH2_sub_windingNumber_mul_f hγ_cont hoff
-      (cauchy_integrand_intervalIntegrable hf hγ_cont hγU hderiv_int hoff)
-      (intervalIntegrable_inv_sub_mul_deriv hγ_cont hoff hderiv_int), hwn]
-    ring
-  · rw [dixonFunction_eq_dixonH2 hw]
+  exact dixonFunction_eq_dixonH2_of_windingNumber_zero hf hγ_cont hγU hderiv_int hoff hwn
 
 /-- **The Dixon function tends to `0` along `cocompact ℂ`.** It eventually agrees with `dixonH2`,
 which tends to `0` by the `L¹` decay bound: the image of the compact interval `uIcc a b` is bounded

--- a/TauCeti/Analysis/Contour/DixonLiouville.lean
+++ b/TauCeti/Analysis/Contour/DixonLiouville.lean
@@ -59,7 +59,8 @@ private theorem dixonFunction_eventually_eq_dixonH2 (hf : DifferentiableOn ℂ f
     ∀ᶠ w in cocompact ℂ, dixonFunction f U γ a b w = dixonH2 f γ a b w := by
   filter_upwards [windingNumber_eventually_zero_cocompact hclosed hP hγ_cont hγ_diff hderiv_int]
     with w ⟨hoff, hwn⟩
-  exact dixonFunction_eq_dixonH2_of_windingNumber_zero hf hγ_cont hγU hderiv_int hoff hwn
+  exact dixonFunction_eq_dixonH2_of_windingNumber_zero hγ_cont hderiv_int
+    (cauchy_integrand_intervalIntegrable hf hγ_cont hγU hderiv_int hoff) hoff hwn
 
 /-- **The Dixon function tends to `0` along `cocompact ℂ`.** It eventually agrees with `dixonH2`,
 which tends to `0` by the `L¹` decay bound: the image of the compact interval `uIcc a b` is bounded

--- a/TauCeti/Analysis/Contour/DixonLiouville.lean
+++ b/TauCeti/Analysis/Contour/DixonLiouville.lean
@@ -60,7 +60,7 @@ private theorem dixonFunction_eventually_eq_dixonH2 (hf : DifferentiableOn ℂ f
   filter_upwards [windingNumber_eventually_zero_cocompact hclosed hP hγ_cont hγ_diff hderiv_int]
     with w ⟨hoff, hwn⟩
   exact dixonFunction_eq_dixonH2_of_windingNumber_zero hγ_cont hderiv_int
-    (cauchy_integrand_intervalIntegrable hf hγ_cont hγU hderiv_int hoff) hoff hwn
+    (cauchy_integrand_intervalIntegrable hf.continuousOn hγ_cont hγU hderiv_int hoff) hoff hwn
 
 /-- **The Dixon function tends to `0` along `cocompact ℂ`.** It eventually agrees with `dixonH2`,
 which tends to `0` by the `L¹` decay bound: the image of the compact interval `uIcc a b` is bounded

--- a/TauCeti/Analysis/Contour/DixonLiouville.lean
+++ b/TauCeti/Analysis/Contour/DixonLiouville.lean
@@ -1,0 +1,100 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Chris Birkbeck
+-/
+module
+
+public import TauCeti.Analysis.Contour.DixonDef
+import TauCeti.Analysis.Contour.DixonFunctionDiff
+import TauCeti.Analysis.Contour.DixonH2Bound
+import TauCeti.Analysis.Contour.WindingVanishing
+import Mathlib.Analysis.Complex.Liouville
+
+/-!
+# The Dixon function vanishes (Liouville step)
+
+Dixon's glued function `dixonFunction f U γ a b` is entire (`differentiable_dixonFunction`) and,
+for a closed null-homologous curve, tends to `0` at infinity, so Liouville's theorem forces it to
+vanish identically. The decay comes from the eventual agreement `dixonFunction = dixonH2` far from
+the origin — off `U` by definition, and on `U` because the winding number is eventually `0`, which
+collapses the `h₁`/`h₂` identity — combined with the `L¹` decay of `dixonH2`.
+
+## Main results
+
+* `TauCeti.Contour.dixonFunction_eq_zero` — `dixonFunction f U γ a b w = 0` for every `w`, for a
+  closed null-homologous curve in `U` with `f` differentiable on the open set `U`.
+
+This pointwise vanishing is the hinge of Dixon's proof of the homology form of Cauchy's theorem
+(`homologyCauchyTheorem`, `TauCetiRoadmap/ContourIntegration/Suggested.lean`): applying it to
+`(· - w₀) * f` yields the Cauchy integral formula and thence `∮_γ f = 0`.
+
+## Provenance
+
+Adapted from `dixonFunction_eventually_eq_dixonH2`, `dixonFunction_tendsto_zero` and
+`dixonFunction_eq_zero` in `DixonTheorem.lean` of the AINTLIB `LeanModularForms` development,
+restated for a raw `γ : ℝ → ℂ` on an oriented interval. See J. D. Dixon, *A brief proof of Cauchy's
+integral theorem* (1971).
+-/
+
+public section
+
+open Complex MeasureTheory Set Filter
+
+open scoped Real Interval Topology
+
+namespace TauCeti.Contour
+
+variable {f : ℂ → ℂ} {U : Set ℂ} {γ : ℝ → ℂ} {a b : ℝ} {P : Set ℝ}
+
+/-- **The Dixon function eventually agrees with `dixonH2` along `cocompact ℂ`.** For a closed curve
+`γ` continuous on `uIcc a b`, differentiable off a countable set, with interval-integrable
+derivative and image in `U`, every `w` far from the origin lies off the curve with winding number
+`0` (`windingNumber_eventually_zero_cocompact`). There `dixonFunction = dixonH2`: off `U` by
+definition, and on `U` because the vanishing winding number collapses the `h₁`/`h₂` identity. -/
+private theorem dixonFunction_eventually_eq_dixonH2 (hf : DifferentiableOn ℂ f U)
+    (hγ_cont : ContinuousOn γ (uIcc a b)) (hγU : ∀ t ∈ uIcc a b, γ t ∈ U)
+    (hderiv_int : IntervalIntegrable (fun t ↦ deriv γ t) volume a b) (hclosed : γ a = γ b)
+    (hP : P.Countable) (hγ_diff : ∀ t ∈ Ioo (min a b) (max a b) \ P, DifferentiableAt ℝ γ t) :
+    ∀ᶠ w in cocompact ℂ, dixonFunction f U γ a b w = dixonH2 f γ a b w := by
+  filter_upwards [windingNumber_eventually_zero_cocompact hclosed hP hγ_cont hγ_diff hderiv_int]
+    with w ⟨hoff, hwn⟩
+  by_cases hw : w ∈ U
+  · rw [dixonFunction_eq_dixonH1 hw, dixonH1_eq_dixonH2_sub_windingNumber_mul_f hγ_cont hoff
+      (cauchy_integrand_intervalIntegrable hf hγ_cont hγU hderiv_int hoff)
+      (intervalIntegrable_inv_sub_mul_deriv hγ_cont hoff hderiv_int), hwn]
+    ring
+  · rw [dixonFunction_eq_dixonH2 hw]
+
+/-- **The Dixon function tends to `0` along `cocompact ℂ`.** It eventually agrees with `dixonH2`,
+which tends to `0` by the `L¹` decay bound: the image of the compact interval `uIcc a b` is bounded
+(`IsCompact.exists_bound_of_continuousOn`), and the weight `f (γ ·) * deriv γ` is
+interval-integrable (continuous `f ∘ γ` times the interval-integrable derivative). -/
+private theorem dixonFunction_tendsto_zero (hf : DifferentiableOn ℂ f U)
+    (hγ_cont : ContinuousOn γ (uIcc a b)) (hγU : ∀ t ∈ uIcc a b, γ t ∈ U)
+    (hderiv_int : IntervalIntegrable (fun t ↦ deriv γ t) volume a b) (hclosed : γ a = γ b)
+    (hP : P.Countable) (hγ_diff : ∀ t ∈ Ioo (min a b) (max a b) \ P, DifferentiableAt ℝ γ t) :
+    Tendsto (dixonFunction f U γ a b) (cocompact ℂ) (nhds 0) := by
+  obtain ⟨R, hR⟩ := isCompact_uIcc.exists_bound_of_continuousOn hγ_cont
+  have hg : IntervalIntegrable (fun t ↦ f (γ t) * deriv γ t) volume a b :=
+    hderiv_int.continuousOn_mul (hf.continuousOn.comp hγ_cont hγU)
+  exact (dixonH2_tendsto_zero_of_integrable (fun t ht ↦ hR t (uIoc_subset_uIcc ht)) hg).congr'
+    (Filter.EventuallyEq.symm
+      (dixonFunction_eventually_eq_dixonH2 hf hγ_cont hγU hderiv_int hclosed hP hγ_diff))
+
+/-- **The Dixon function is identically zero (Liouville).** For a closed curve `γ`, null-homologous
+in an open set `U` (continuous on `uIcc a b`, differentiable off a countable set, with
+interval-integrable derivative and image in `U`) and `f` differentiable on `U`, the entire function
+`dixonFunction f U γ a b` tends to `0` at infinity, so Liouville's theorem forces it to vanish at
+every point. -/
+theorem dixonFunction_eq_zero (hU : IsOpen U) (hf : DifferentiableOn ℂ f U)
+    (hγ_cont : ContinuousOn γ (uIcc a b)) (hγU : ∀ t ∈ uIcc a b, γ t ∈ U)
+    (hderiv_int : IntervalIntegrable (fun t ↦ deriv γ t) volume a b) (hclosed : γ a = γ b)
+    (hP : P.Countable) (hγ_diff : ∀ t ∈ Ioo (min a b) (max a b) \ P, DifferentiableAt ℝ γ t)
+    (h_null : IsNullHomologous γ a b U) (w : ℂ) : dixonFunction f U γ a b w = 0 := by
+  have h_entire :=
+    differentiable_dixonFunction hU hf hγ_cont hγU hderiv_int hclosed hP hγ_diff h_null
+  exact Differentiable.apply_eq_of_tendsto_cocompact h_entire w
+    (dixonFunction_tendsto_zero hf hγ_cont hγU hderiv_int hclosed hP hγ_diff)
+
+end TauCeti.Contour


### PR DESCRIPTION
## Summary

The Liouville step of Dixon's proof of the homology form of Cauchy's theorem: **Dixon's glued function `dixonFunction f U γ a b` is identically zero** for a closed null-homologous curve `γ` in an open set `U` with `f` differentiable on `U`.

`dixonFunction` is entire (`differentiable_dixonFunction`, already on `main`). Far from the origin it agrees with `dixonH2`:
- off `U`, `dixonFunction = dixonH2` by definition;
- on `U`, the winding number is eventually `0` (`windingNumber_eventually_zero_cocompact`), which collapses the `h₁`/`h₂` identity `dixonH1 = dixonH2 - 2πi·n·f`.

Since `dixonH2` has `L¹` decay (`dixonH2_tendsto_zero_of_integrable`), `dixonFunction → 0` along `cocompact ℂ`, and Liouville's theorem (`Differentiable.apply_eq_of_tendsto_cocompact`) forces it to vanish everywhere.

## Changes

- **New** `TauCeti/Analysis/Contour/DixonLiouville.lean`:
  - `dixonFunction_eventually_eq_dixonH2` (private) — eventual agreement far out.
  - `dixonFunction_tendsto_zero` (private) — decay via the `L¹` bound.
  - `dixonFunction_eq_zero` (public) — `dixonFunction f U γ a b w = 0` at every `w`.
- **`DixonFunctionDiff`**: expose `cauchy_integrand_intervalIntegrable` (drop `private`) — the `dixonH2` integrand's interval-integrability. It supplies the `h_cauchy_int` hypothesis of the `h₁`/`h₂` identity in the eventual-agreement step, and now has two consumers (`differentiable_dixonFunction` and `DixonLiouville`).

## Notes

All hypotheses match `differentiable_dixonFunction`'s bundle (closed, continuous on `uIcc a b`, differentiable off a countable set, interval-integrable derivative, image in `U`, null-homologous) — no new curve-regularity is introduced. This is the last Liouville-intermediate before the Cauchy integral formula and `∮_γ f = 0`.

Local gates green: full `lake build` (4687 jobs), `lake exe axioms` (allowlist only), `lake exe module-system` (all opt in), `scripts/lint-env.sh` (no new violations).

🤖 Generated with [Claude Code](https://claude.com/claude-code)