### PR TITLE
feat: the infinitesimal Schwarz--Pick inequality

### DIFF
--- a/TauCeti/Analysis/Complex/Conformal/Moebius.lean
+++ b/TauCeti/Analysis/Complex/Conformal/Moebius.lean
@@ -6,7 +6,6 @@ module
 
 public import Mathlib.Analysis.Calculus.Deriv.Inv
 import Mathlib.Analysis.Calculus.Deriv.Add
-import Mathlib.Analysis.Calculus.Deriv.Mul
 public import TauCeti.Analysis.Complex.Conformal.PseudoHyperbolic
 
 /-!
@@ -148,6 +147,45 @@ lemma differentiableOn_unitDiscMoebiusFormula (a : Complex.UnitDisc) :
       (fun z : ℂ => (z - (a : ℂ)) / (1 - (starRingEnd ℂ) (a : ℂ) * z))
       (ball (0 : ℂ) 1) :=
   differentiableOn_unitDiscMoebiusFormula_of_norm_lt_one a.norm_lt_one
+
+/-- **Schwarz--Pick conjugation scaffold.** For a holomorphic self-map `f` of the open unit
+disc and a disc point `a`, conjugating `f` by the Moebius automorphisms centred at `a` (on the
+source) and at `f a` (on the target) yields a holomorphic self-map of the disc that fixes the
+origin.  This is the common scaffold of the finite and infinitesimal Schwarz--Pick estimates:
+applying Schwarz's lemma at `0` to the conjugate `g` unwinds to the contraction estimate for
+`f`. -/
+lemma schwarzPickConjugate {f : ℂ → ℂ}
+    (hf : DifferentiableOn ℂ f (ball (0 : ℂ) 1))
+    (hmaps : MapsTo f (ball (0 : ℂ) 1) (ball (0 : ℂ) 1)) {a : ℂ} (ha : ‖a‖ < 1) :
+    DifferentiableOn ℂ
+        ((fun η => (η - f a) / (1 - (starRingEnd ℂ) (f a) * η)) ∘ f ∘
+          fun ξ => (ξ - (-a)) / (1 - (starRingEnd ℂ) (-a) * ξ)) (ball (0 : ℂ) 1) ∧
+      MapsTo
+        ((fun η => (η - f a) / (1 - (starRingEnd ℂ) (f a) * η)) ∘ f ∘
+          fun ξ => (ξ - (-a)) / (1 - (starRingEnd ℂ) (-a) * ξ)) (ball (0 : ℂ) 1) (ball (0 : ℂ) 1) ∧
+      ((fun η => (η - f a) / (1 - (starRingEnd ℂ) (f a) * η)) ∘ f ∘
+          fun ξ => (ξ - (-a)) / (1 - (starRingEnd ℂ) (-a) * ξ)) 0 = 0 := by
+  have ha_mem : a ∈ ball (0 : ℂ) 1 := by simpa [mem_ball_zero_iff] using ha
+  have hfa_norm : ‖f a‖ < 1 := by simpa [mem_ball_zero_iff] using hmaps ha_mem
+  have hsource_maps :
+      MapsTo (fun ξ : ℂ => (ξ - (-a)) / (1 - (starRingEnd ℂ) (-a) * ξ))
+        (ball (0 : ℂ) 1) (ball (0 : ℂ) 1) :=
+    mapsTo_ball_unitDiscMoebiusFormula_of_norm_lt_one (a := -a) (by simpa using ha)
+  have htarget_maps :
+      MapsTo (fun η : ℂ => (η - f a) / (1 - (starRingEnd ℂ) (f a) * η))
+        (ball (0 : ℂ) 1) (ball (0 : ℂ) 1) :=
+    mapsTo_ball_unitDiscMoebiusFormula_of_norm_lt_one (a := f a) hfa_norm
+  have hsource_diff :
+      DifferentiableOn ℂ (fun ξ : ℂ => (ξ - (-a)) / (1 - (starRingEnd ℂ) (-a) * ξ))
+        (ball (0 : ℂ) 1) :=
+    differentiableOn_unitDiscMoebiusFormula_of_norm_lt_one (a := -a) (by simpa using ha)
+  have htarget_diff :
+      DifferentiableOn ℂ (fun η : ℂ => (η - f a) / (1 - (starRingEnd ℂ) (f a) * η))
+        (ball (0 : ℂ) 1) :=
+    differentiableOn_unitDiscMoebiusFormula_of_norm_lt_one (a := f a) hfa_norm
+  refine ⟨htarget_diff.comp (hf.comp hsource_diff hsource_maps) (hmaps.comp hsource_maps),
+    fun ξ hξ => htarget_maps (hmaps (hsource_maps hξ)), ?_⟩
+  simp
 
 private lemma unitDiscMoebius_neg_apply_unitDiscMoebius_apply_scalar {a z : ℂ}
     (hden : 1 - (starRingEnd ℂ) a * z ≠ 0)

--- a/TauCeti/Analysis/Complex/Conformal/Moebius.lean
+++ b/TauCeti/Analysis/Complex/Conformal/Moebius.lean
@@ -154,7 +154,7 @@ source) and at `f a` (on the target) yields a holomorphic self-map of the disc t
 origin.  This is the common scaffold of the finite and infinitesimal Schwarz--Pick estimates:
 applying Schwarz's lemma at `0` to the conjugate `g` unwinds to the contraction estimate for
 `f`. -/
-lemma schwarzPickConjugate {f : ℂ → ℂ}
+lemma differentiableOn_and_mapsTo_ball_and_apply_zero_schwarzPickConjugate {f : ℂ → ℂ}
     (hf : DifferentiableOn ℂ f (ball (0 : ℂ) 1))
     (hmaps : MapsTo f (ball (0 : ℂ) 1) (ball (0 : ℂ) 1)) {a : ℂ} (ha : ‖a‖ < 1) :
     DifferentiableOn ℂ

--- a/TauCeti/Analysis/Complex/Conformal/Moebius.lean
+++ b/TauCeti/Analysis/Complex/Conformal/Moebius.lean
@@ -5,6 +5,8 @@ Released under Apache 2.0 license as described in the file LICENSE.
 module
 
 public import Mathlib.Analysis.Calculus.Deriv.Inv
+import Mathlib.Analysis.Calculus.Deriv.Add
+import Mathlib.Analysis.Calculus.Deriv.Mul
 public import TauCeti.Analysis.Complex.Conformal.PseudoHyperbolic
 
 /-!
@@ -119,6 +121,26 @@ lemma differentiableOn_unitDiscMoebiusFormula_of_norm_lt_one {a : ℂ} (ha : ‖
       ((differentiableWithinAt_const (c := (starRingEnd ℂ) a)).mul
         differentiableWithinAt_id)
   exact hnum.div hden_diff hden
+
+/-- The complex derivative of the scalar unit-disc Moebius factor
+`z ↦ (z - a) / (1 - conj a * z)` at a point `p` where the denominator is nonzero.  Its value at
+`p = 0` (with center `-z`) is `1 - ‖z‖ ^ 2`, and at `p = a` it is `1 / (1 - ‖a‖ ^ 2)`, the two
+factors that appear in the infinitesimal Schwarz--Pick estimate. -/
+lemma hasDerivAt_unitDiscMoebiusFormula (a p : ℂ)
+    (hp : 1 - (starRingEnd ℂ) a * p ≠ 0) :
+    HasDerivAt (fun z : ℂ => (z - a) / (1 - (starRingEnd ℂ) a * z))
+      ((1 - (starRingEnd ℂ) a * a) / (1 - (starRingEnd ℂ) a * p) ^ 2) p := by
+  have hn : HasDerivAt (fun z : ℂ => z - a) 1 p := (hasDerivAt_id p).sub_const a
+  have hd : HasDerivAt (fun z : ℂ => 1 - (starRingEnd ℂ) a * z) (-(starRingEnd ℂ) a) p := by
+    simpa using ((hasDerivAt_id p).const_mul ((starRingEnd ℂ) a)).const_sub 1
+  have hq := hn.div hd hp
+  have hval : (1 - (starRingEnd ℂ) a * a) / (1 - (starRingEnd ℂ) a * p) ^ 2
+      = (1 * (1 - (starRingEnd ℂ) a * p) - (p - a) * -(starRingEnd ℂ) a)
+        / (1 - (starRingEnd ℂ) a * p) ^ 2 := by
+    congr 1
+    ring
+  rw [hval]
+  exact hq
 
 /-- The scalar formula of the unit-disc Moebius factor is holomorphic on the unit disc. -/
 lemma differentiableOn_unitDiscMoebiusFormula (a : Complex.UnitDisc) :

--- a/TauCeti/Analysis/Complex/Conformal/PseudoHyperbolic.lean
+++ b/TauCeti/Analysis/Complex/Conformal/PseudoHyperbolic.lean
@@ -132,9 +132,9 @@ lemma one_sub_conj_mul_ne_zero_unitDisc (z w : Complex.UnitDisc) :
     1 - (starRingEnd ℂ) (w : ℂ) * (z : ℂ) ≠ 0 :=
   one_sub_conj_mul_ne_zero_of_norm_lt_one z.norm_lt_one w.norm_lt_one
 
-/-- For a point of norm less than one, the denominator of the Moebius factor evaluated at the
+/-- For a point of norm at most one, the denominator of the Moebius factor evaluated at the
 factor's own center has norm `1 - ‖w‖ ^ 2`. -/
-lemma norm_one_sub_conj_mul_self_of_norm_lt_one {w : ℂ} (hw : ‖w‖ < 1) :
+lemma norm_one_sub_conj_mul_self_of_norm_le_one {w : ℂ} (hw : ‖w‖ ≤ 1) :
     ‖(1 : ℂ) - (starRingEnd ℂ) w * w‖ = 1 - ‖w‖ ^ 2 := by
   have hconj : (starRingEnd ℂ) w * w = ((‖w‖ ^ 2 : ℝ) : ℂ) := by
     rw [mul_comm, Complex.mul_conj, Complex.normSq_eq_norm_sq]

--- a/TauCeti/Analysis/Complex/Conformal/PseudoHyperbolic.lean
+++ b/TauCeti/Analysis/Complex/Conformal/PseudoHyperbolic.lean
@@ -132,6 +132,15 @@ lemma one_sub_conj_mul_ne_zero_unitDisc (z w : Complex.UnitDisc) :
     1 - (starRingEnd ℂ) (w : ℂ) * (z : ℂ) ≠ 0 :=
   one_sub_conj_mul_ne_zero_of_norm_lt_one z.norm_lt_one w.norm_lt_one
 
+/-- For a point of norm less than one, the denominator of the Moebius factor evaluated at the
+factor's own center has norm `1 - ‖w‖ ^ 2`. -/
+lemma norm_one_sub_conj_mul_self_of_norm_lt_one {w : ℂ} (hw : ‖w‖ < 1) :
+    ‖(1 : ℂ) - (starRingEnd ℂ) w * w‖ = 1 - ‖w‖ ^ 2 := by
+  have hconj : (starRingEnd ℂ) w * w = ((‖w‖ ^ 2 : ℝ) : ℂ) := by
+    rw [mul_comm, Complex.mul_conj, Complex.normSq_eq_norm_sq]
+  rw [hconj, ← Complex.ofReal_one, ← Complex.ofReal_sub, Complex.norm_real, Real.norm_eq_abs,
+    abs_of_nonneg (by nlinarith [norm_nonneg w])]
+
 /-- On the open unit disc, zero pseudo-hyperbolic expression characterizes equality. -/
 lemma pseudoHyperbolicExpr_eq_zero_iff_of_norm_lt_one {z w : ℂ}
     (hz : ‖z‖ < 1) (hw : ‖w‖ < 1) :

--- a/TauCeti/Analysis/Complex/Conformal/SchwarzPick.lean
+++ b/TauCeti/Analysis/Complex/Conformal/SchwarzPick.lean
@@ -54,7 +54,8 @@ theorem pseudoHyperbolicExpr_map_le {f : ℂ → ℂ}
   have hw_norm : ‖w‖ < 1 := by
     simpa [mem_ball_zero_iff] using hw
   -- The conjugate `g` is a holomorphic self-map of the disc fixing the origin (shared scaffold).
-  obtain ⟨hg_diff, hg_maps_ball, hg_zero⟩ := schwarzPickConjugate hf hmaps hw_norm
+  obtain ⟨hg_diff, hg_maps_ball, hg_zero⟩ :=
+    differentiableOn_and_mapsTo_ball_and_apply_zero_schwarzPickConjugate hf hmaps hw_norm
   have hg_maps_closed : MapsTo g (ball (0 : ℂ) 1) (closedBall (0 : ℂ) 1) := by
     intro ξ hξ
     exact ball_subset_closedBall (hg_maps_ball hξ)

--- a/TauCeti/Analysis/Complex/Conformal/SchwarzPick.lean
+++ b/TauCeti/Analysis/Complex/Conformal/SchwarzPick.lean
@@ -53,33 +53,11 @@ theorem pseudoHyperbolicExpr_map_le {f : ℂ → ℂ}
   let g : ℂ → ℂ := target ∘ f ∘ source
   have hw_norm : ‖w‖ < 1 := by
     simpa [mem_ball_zero_iff] using hw
-  have hfw : f w ∈ ball (0 : ℂ) 1 := hmaps hw
-  have hfw_norm : ‖f w‖ < 1 := by
-    simpa [mem_ball_zero_iff] using hfw
-  have hsource_maps : MapsTo source (ball (0 : ℂ) 1) (ball (0 : ℂ) 1) := by
-    simpa [source] using mapsTo_ball_unitDiscMoebiusFormula_of_norm_lt_one
-      (a := -(w : ℂ)) (by simpa using hw_norm)
-  have htarget_maps : MapsTo target (ball (0 : ℂ) 1) (ball (0 : ℂ) 1) := by
-    simpa [target] using mapsTo_ball_unitDiscMoebiusFormula_of_norm_lt_one
-      (a := f w) hfw_norm
-  have hg_maps_ball : MapsTo g (ball (0 : ℂ) 1) (ball (0 : ℂ) 1) := by
-    intro ξ hξ
-    exact htarget_maps (hmaps (hsource_maps hξ))
+  -- The conjugate `g` is a holomorphic self-map of the disc fixing the origin (shared scaffold).
+  obtain ⟨hg_diff, hg_maps_ball, hg_zero⟩ := schwarzPickConjugate hf hmaps hw_norm
   have hg_maps_closed : MapsTo g (ball (0 : ℂ) 1) (closedBall (0 : ℂ) 1) := by
     intro ξ hξ
     exact ball_subset_closedBall (hg_maps_ball hξ)
-  have hsource_diff : DifferentiableOn ℂ source (ball (0 : ℂ) 1) := by
-    simpa [source] using differentiableOn_unitDiscMoebiusFormula_of_norm_lt_one
-      (a := -(w : ℂ)) (by simpa using hw_norm)
-  have htarget_diff : DifferentiableOn ℂ target (ball (0 : ℂ) 1) := by
-    simpa [target] using differentiableOn_unitDiscMoebiusFormula_of_norm_lt_one
-      (a := f w) hfw_norm
-  have hg_diff : DifferentiableOn ℂ g (ball (0 : ℂ) 1) :=
-    htarget_diff.comp (hf.comp hsource_diff hsource_maps) (hmaps.comp hsource_maps)
-  have hg_zero : g 0 = 0 := by
-    have hsource_zero : source 0 = w := by
-      simp [source]
-    simp [g, target, hsource_zero]
   let ξ : ℂ := (z - w) / (1 - (starRingEnd ℂ) w * z)
   have hξ_mem : ξ ∈ ball (0 : ℂ) 1 := by
     simpa [ξ] using mapsTo_ball_unitDiscMoebiusFormula_of_norm_lt_one

--- a/TauCeti/Analysis/Complex/Conformal/SchwarzPickDerivative.lean
+++ b/TauCeti/Analysis/Complex/Conformal/SchwarzPickDerivative.lean
@@ -8,11 +8,8 @@ public import Mathlib.Analysis.Calculus.Deriv.Basic
 public import Mathlib.Analysis.Complex.Basic
 public import Mathlib.Data.Set.Function
 import Mathlib.Analysis.Complex.Schwarz
-import Mathlib.Analysis.Calculus.Deriv.Add
-import Mathlib.Analysis.Calculus.Deriv.Mul
-import Mathlib.Analysis.Calculus.Deriv.Inv
 import Mathlib.Analysis.Calculus.Deriv.Comp
-import TauCeti.Analysis.Complex.Conformal.Moebius
+public import TauCeti.Analysis.Complex.Conformal.Moebius
 
 /-!
 # The infinitesimal Schwarz--Pick inequality
@@ -21,13 +18,8 @@ This file proves the differential (infinitesimal) form of the Schwarz--Pick lemm
 holomorphic self-maps of the complex unit disc: if `f` is holomorphic on `ball 0 1` and maps
 it into itself, then at every point `z` of the disc
 `‖deriv f z‖ / (1 - ‖f z‖ ^ 2) ≤ 1 / (1 - ‖z‖ ^ 2)`, i.e. `f` contracts the Poincaré
-(hyperbolic) metric `|dz| / (1 - |z| ^ 2)`.
-
-The proof conjugates `f` by the disc automorphisms `source` (sending `0 ↦ z`) and `target`
-(sending `f z ↦ 0`), so that `g = target ∘ f ∘ source` is a self-map of the disc fixing `0`.
-Mathlib's Schwarz lemma bounds `‖deriv g 0‖ ≤ 1`, and the chain rule evaluates `deriv g 0` in
-terms of `deriv f z` together with the derivatives of the two Moebius factors
-(`hasDerivAt_moebiusFactor`), which unwinds to the stated contraction.
+(hyperbolic) metric `|dz| / (1 - |z| ^ 2)`.  The bundled `Complex.UnitDisc` form is
+`norm_deriv_div_one_sub_norm_sq_le_unitDisc`.
 
 This advances the conformal-mapping roadmap's **L2 Schwarz--Pick** target
 (`TauCetiRoadmap/ConformalMapping/README.md`, the L2 hyperbolic/Poincaré-metric contraction),
@@ -44,25 +36,6 @@ namespace TauCeti
 
 open Complex Metric Set
 open scoped ComplexConjugate
-
-/-- The complex derivative of the Moebius factor `ξ ↦ (ξ - a) / (1 - conj a * ξ)` at a point
-`p` where the denominator is nonzero.  The value simplifies to `1 - ‖z‖ ^ 2` at `p = 0`
-(with `a = -z`) and to `1 / (1 - ‖a‖ ^ 2)` at `p = a`. -/
-private lemma hasDerivAt_moebiusFactor (a p : ℂ)
-    (hp : 1 - (starRingEnd ℂ) a * p ≠ 0) :
-    HasDerivAt (fun ξ : ℂ => (ξ - a) / (1 - (starRingEnd ℂ) a * ξ))
-      ((1 - (starRingEnd ℂ) a * a) / (1 - (starRingEnd ℂ) a * p) ^ 2) p := by
-  have hn : HasDerivAt (fun ξ : ℂ => ξ - a) 1 p := (hasDerivAt_id p).sub_const a
-  have hd : HasDerivAt (fun ξ : ℂ => 1 - (starRingEnd ℂ) a * ξ) (-(starRingEnd ℂ) a) p := by
-    simpa using ((hasDerivAt_id p).const_mul ((starRingEnd ℂ) a)).const_sub 1
-  have hq := hn.div hd hp
-  have hval : (1 - (starRingEnd ℂ) a * a) / (1 - (starRingEnd ℂ) a * p) ^ 2
-      = (1 * (1 - (starRingEnd ℂ) a * p) - (p - a) * -(starRingEnd ℂ) a)
-        / (1 - (starRingEnd ℂ) a * p) ^ 2 := by
-    congr 1
-    ring
-  rw [hval]
-  exact hq
 
 /-- **The infinitesimal Schwarz--Pick inequality.** A holomorphic self-map `f` of the open
 unit disc contracts the Poincaré metric: at every point `z` of the disc,
@@ -98,13 +71,9 @@ theorem norm_deriv_div_one_sub_norm_sq_le {f : ℂ → ℂ}
     htarget_diff.comp (hf.comp hsource_diff hsource_maps) (hmaps.comp hsource_maps)
   -- The conjugate `g` fixes the origin.
   have hsource_zero : source 0 = z := by
-    change (0 - (-z)) / (1 - (starRingEnd ℂ) (-z) * 0) = z
-    simp
+    simp [source]
   have hg_zero : g 0 = 0 := by
-    change target (f (source 0)) = 0
-    rw [hsource_zero]
-    change (f z - f z) / (1 - (starRingEnd ℂ) (f z) * f z) = 0
-    rw [sub_self, zero_div]
+    simp [g, target, hsource_zero]
   -- Schwarz's lemma at `0` for `g`.
   have hg_maps_closed : MapsTo g (ball (0 : ℂ) 1) (closedBall (0 : ℂ) 1) :=
     fun ξ hξ => ball_subset_closedBall (hg_maps hξ)
@@ -117,13 +86,13 @@ theorem norm_deriv_div_one_sub_norm_sq_le {f : ℂ → ℂ}
   have hp_outer : (1 : ℂ) - (starRingEnd ℂ) (f z) * f z ≠ 0 :=
     one_sub_conj_mul_ne_zero_of_norm_lt_one hfz1 hfz1
   have hd_inner : HasDerivAt source (1 - (starRingEnd ℂ) z * z) 0 := by
-    have h := hasDerivAt_moebiusFactor (-z) 0 hp_inner
+    have h := hasDerivAt_unitDiscMoebiusFormula (-z) 0 hp_inner
     have hval : (1 - (starRingEnd ℂ) (-z) * (-z)) / (1 - (starRingEnd ℂ) (-z) * 0) ^ 2
         = 1 - (starRingEnd ℂ) z * z := by simp [map_neg]
     rw [hval] at h
     exact h
   have hd_outer : HasDerivAt target (1 / (1 - (starRingEnd ℂ) (f z) * f z)) (f z) := by
-    have h := hasDerivAt_moebiusFactor (f z) (f z) hp_outer
+    have h := hasDerivAt_unitDiscMoebiusFormula (f z) (f z) hp_outer
     have hval : (1 - (starRingEnd ℂ) (f z) * f z) / (1 - (starRingEnd ℂ) (f z) * f z) ^ 2
         = 1 / (1 - (starRingEnd ℂ) (f z) * f z) := by
       rw [sq, ← div_div, div_self hp_outer]
@@ -143,14 +112,8 @@ theorem norm_deriv_div_one_sub_norm_sq_le {f : ℂ → ℂ}
       = (1 / (1 - (starRingEnd ℂ) (f z) * f z)) * (deriv f z * (1 - (starRingEnd ℂ) z * z)) :=
     hcompg.deriv
   -- The norms of the two Moebius derivative factors.
-  have hnorm : ∀ w : ℂ, ‖w‖ < 1 → ‖(1 : ℂ) - (starRingEnd ℂ) w * w‖ = 1 - ‖w‖ ^ 2 := by
-    intro w hw
-    have hconj : (starRingEnd ℂ) w * w = ((‖w‖ ^ 2 : ℝ) : ℂ) := by
-      rw [mul_comm, Complex.mul_conj, Complex.normSq_eq_norm_sq]
-    rw [hconj, ← Complex.ofReal_one, ← Complex.ofReal_sub, Complex.norm_real, Real.norm_eq_abs,
-      abs_of_nonneg (by nlinarith [norm_nonneg w])]
-  have hnorm_z := hnorm z hz1
-  have hnorm_fz := hnorm (f z) hfz1
+  have hnorm_z := norm_one_sub_conj_mul_self_of_norm_lt_one hz1
+  have hnorm_fz := norm_one_sub_conj_mul_self_of_norm_lt_one hfz1
   -- Assemble the norm of `deriv g 0` and conclude via Schwarz.
   have hnorm_dg : ‖deriv g 0‖ = ‖deriv f z‖ * (1 - ‖z‖ ^ 2) / (1 - ‖f z‖ ^ 2) := by
     rw [hderiv_g, norm_mul, norm_mul, norm_div, norm_one, hnorm_z, hnorm_fz]
@@ -159,5 +122,14 @@ theorem norm_deriv_div_one_sub_norm_sq_le {f : ℂ → ℂ}
   rw [div_le_one hden_fz] at hkey
   rw [div_le_div_iff₀ hden_fz hden_z, one_mul]
   exact hkey
+
+/-- Bundled unit-disc form of the infinitesimal Schwarz--Pick inequality: a holomorphic
+self-map `f` of the open unit disc contracts the Poincaré metric at every disc point `z`. -/
+theorem norm_deriv_div_one_sub_norm_sq_le_unitDisc {f : ℂ → ℂ}
+    (hf : DifferentiableOn ℂ f (ball (0 : ℂ) 1))
+    (hmaps : MapsTo f (ball (0 : ℂ) 1) (ball (0 : ℂ) 1))
+    (z : Complex.UnitDisc) :
+    ‖deriv f (z : ℂ)‖ / (1 - ‖f (z : ℂ)‖ ^ 2) ≤ 1 / (1 - ‖(z : ℂ)‖ ^ 2) :=
+  norm_deriv_div_one_sub_norm_sq_le hf hmaps z.property
 
 end TauCeti

--- a/TauCeti/Analysis/Complex/Conformal/SchwarzPickDerivative.lean
+++ b/TauCeti/Analysis/Complex/Conformal/SchwarzPickDerivative.lean
@@ -54,7 +54,8 @@ theorem norm_deriv_div_one_sub_norm_sq_le {f : ℂ → ℂ}
   let target : ℂ → ℂ := fun η => (η - f z) / (1 - (starRingEnd ℂ) (f z) * η)
   let g : ℂ → ℂ := target ∘ f ∘ source
   -- The conjugate `g` is a holomorphic self-map of the disc fixing the origin (shared scaffold).
-  obtain ⟨hg_diff, hg_maps, hg_zero'⟩ := schwarzPickConjugate hf hmaps hz1
+  obtain ⟨hg_diff, hg_maps, hg_zero'⟩ :=
+    differentiableOn_and_mapsTo_ball_and_apply_zero_schwarzPickConjugate hf hmaps hz1
   have hg_zero : g 0 = 0 := hg_zero'
   have hsource_zero : source 0 = z := by
     simp [source]

--- a/TauCeti/Analysis/Complex/Conformal/SchwarzPickDerivative.lean
+++ b/TauCeti/Analysis/Complex/Conformal/SchwarzPickDerivative.lean
@@ -6,10 +6,10 @@ module
 
 public import Mathlib.Analysis.Calculus.Deriv.Basic
 public import Mathlib.Analysis.Complex.Basic
+public import Mathlib.Analysis.Complex.UnitDisc.Basic
 public import Mathlib.Data.Set.Function
 import Mathlib.Analysis.Complex.Schwarz
-import Mathlib.Analysis.Calculus.Deriv.Comp
-public import TauCeti.Analysis.Complex.Conformal.Moebius
+import TauCeti.Analysis.Complex.Conformal.Moebius
 
 /-!
 # The infinitesimal Schwarz--Pick inequality
@@ -54,26 +54,11 @@ theorem norm_deriv_div_one_sub_norm_sq_le {f : ℂ → ℂ}
   let source : ℂ → ℂ := fun ξ => (ξ - (-z)) / (1 - (starRingEnd ℂ) (-z) * ξ)
   let target : ℂ → ℂ := fun η => (η - f z) / (1 - (starRingEnd ℂ) (f z) * η)
   let g : ℂ → ℂ := target ∘ f ∘ source
-  -- `source` and `target` map the disc into itself and are holomorphic there.
-  have hsource_maps : MapsTo source (ball (0 : ℂ) 1) (ball (0 : ℂ) 1) := by
-    simpa [source] using mapsTo_ball_unitDiscMoebiusFormula_of_norm_lt_one
-      (a := -z) (by simpa using hz1)
-  have htarget_maps : MapsTo target (ball (0 : ℂ) 1) (ball (0 : ℂ) 1) := by
-    simpa [target] using mapsTo_ball_unitDiscMoebiusFormula_of_norm_lt_one (a := f z) hfz1
-  have hsource_diff : DifferentiableOn ℂ source (ball (0 : ℂ) 1) := by
-    simpa [source] using differentiableOn_unitDiscMoebiusFormula_of_norm_lt_one
-      (a := -z) (by simpa using hz1)
-  have htarget_diff : DifferentiableOn ℂ target (ball (0 : ℂ) 1) := by
-    simpa [target] using differentiableOn_unitDiscMoebiusFormula_of_norm_lt_one (a := f z) hfz1
-  have hg_maps : MapsTo g (ball (0 : ℂ) 1) (ball (0 : ℂ) 1) :=
-    fun ξ hξ => htarget_maps (hmaps (hsource_maps hξ))
-  have hg_diff : DifferentiableOn ℂ g (ball (0 : ℂ) 1) :=
-    htarget_diff.comp (hf.comp hsource_diff hsource_maps) (hmaps.comp hsource_maps)
-  -- The conjugate `g` fixes the origin.
+  -- The conjugate `g` is a holomorphic self-map of the disc fixing the origin (shared scaffold).
+  obtain ⟨hg_diff, hg_maps, hg_zero'⟩ := schwarzPickConjugate hf hmaps hz1
+  have hg_zero : g 0 = 0 := hg_zero'
   have hsource_zero : source 0 = z := by
     simp [source]
-  have hg_zero : g 0 = 0 := by
-    simp [g, target, hsource_zero]
   -- Schwarz's lemma at `0` for `g`.
   have hg_maps_closed : MapsTo g (ball (0 : ℂ) 1) (closedBall (0 : ℂ) 1) :=
     fun ξ hξ => ball_subset_closedBall (hg_maps hξ)
@@ -112,8 +97,8 @@ theorem norm_deriv_div_one_sub_norm_sq_le {f : ℂ → ℂ}
       = (1 / (1 - (starRingEnd ℂ) (f z) * f z)) * (deriv f z * (1 - (starRingEnd ℂ) z * z)) :=
     hcompg.deriv
   -- The norms of the two Moebius derivative factors.
-  have hnorm_z := norm_one_sub_conj_mul_self_of_norm_lt_one hz1
-  have hnorm_fz := norm_one_sub_conj_mul_self_of_norm_lt_one hfz1
+  have hnorm_z := norm_one_sub_conj_mul_self_of_norm_le_one hz1.le
+  have hnorm_fz := norm_one_sub_conj_mul_self_of_norm_le_one hfz1.le
   -- Assemble the norm of `deriv g 0` and conclude via Schwarz.
   have hnorm_dg : ‖deriv g 0‖ = ‖deriv f z‖ * (1 - ‖z‖ ^ 2) / (1 - ‖f z‖ ^ 2) := by
     rw [hderiv_g, norm_mul, norm_mul, norm_div, norm_one, hnorm_z, hnorm_fz]

--- a/TauCeti/Analysis/Complex/Conformal/SchwarzPickDerivative.lean
+++ b/TauCeti/Analysis/Complex/Conformal/SchwarzPickDerivative.lean
@@ -5,7 +5,6 @@ Released under Apache 2.0 license as described in the file LICENSE.
 module
 
 public import Mathlib.Analysis.Calculus.Deriv.Basic
-public import Mathlib.Analysis.Complex.Basic
 public import Mathlib.Analysis.Complex.UnitDisc.Basic
 public import Mathlib.Data.Set.Function
 import Mathlib.Analysis.Complex.Schwarz

--- a/TauCeti/Analysis/Complex/Conformal/SchwarzPickDerivative.lean
+++ b/TauCeti/Analysis/Complex/Conformal/SchwarzPickDerivative.lean
@@ -1,0 +1,163 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+module
+
+public import Mathlib.Analysis.Calculus.Deriv.Basic
+public import Mathlib.Analysis.Complex.Basic
+public import Mathlib.Data.Set.Function
+import Mathlib.Analysis.Complex.Schwarz
+import Mathlib.Analysis.Calculus.Deriv.Add
+import Mathlib.Analysis.Calculus.Deriv.Mul
+import Mathlib.Analysis.Calculus.Deriv.Inv
+import Mathlib.Analysis.Calculus.Deriv.Comp
+import TauCeti.Analysis.Complex.Conformal.Moebius
+
+/-!
+# The infinitesimal Schwarz--Pick inequality
+
+This file proves the differential (infinitesimal) form of the Schwarz--Pick lemma for
+holomorphic self-maps of the complex unit disc: if `f` is holomorphic on `ball 0 1` and maps
+it into itself, then at every point `z` of the disc
+`‖deriv f z‖ / (1 - ‖f z‖ ^ 2) ≤ 1 / (1 - ‖z‖ ^ 2)`, i.e. `f` contracts the Poincaré
+(hyperbolic) metric `|dz| / (1 - |z| ^ 2)`.
+
+The proof conjugates `f` by the disc automorphisms `source` (sending `0 ↦ z`) and `target`
+(sending `f z ↦ 0`), so that `g = target ∘ f ∘ source` is a self-map of the disc fixing `0`.
+Mathlib's Schwarz lemma bounds `‖deriv g 0‖ ≤ 1`, and the chain rule evaluates `deriv g 0` in
+terms of `deriv f z` together with the derivatives of the two Moebius factors
+(`hasDerivAt_moebiusFactor`), which unwinds to the stated contraction.
+
+This advances the conformal-mapping roadmap's **L2 Schwarz--Pick** target
+(`TauCetiRoadmap/ConformalMapping/README.md`, the L2 hyperbolic/Poincaré-metric contraction),
+complementing Tau Ceti's finite Schwarz--Pick estimate `pseudoHyperbolicExpr_map_le`.  It
+reuses Mathlib's Schwarz lemma (`Complex.norm_deriv_le_one_of_mapsTo_ball`) and Tau Ceti's
+unit-disc Moebius API.  As with the rest of the L0--L3 conformal-mapping material, it is
+coordinated with the upstream Mathlib RMT effort leanprover-community/mathlib4#33505 and
+should be refactored to upstream API if that work lands a human-curated Schwarz--Pick theorem.
+-/
+
+public section
+
+namespace TauCeti
+
+open Complex Metric Set
+open scoped ComplexConjugate
+
+/-- The complex derivative of the Moebius factor `ξ ↦ (ξ - a) / (1 - conj a * ξ)` at a point
+`p` where the denominator is nonzero.  The value simplifies to `1 - ‖z‖ ^ 2` at `p = 0`
+(with `a = -z`) and to `1 / (1 - ‖a‖ ^ 2)` at `p = a`. -/
+private lemma hasDerivAt_moebiusFactor (a p : ℂ)
+    (hp : 1 - (starRingEnd ℂ) a * p ≠ 0) :
+    HasDerivAt (fun ξ : ℂ => (ξ - a) / (1 - (starRingEnd ℂ) a * ξ))
+      ((1 - (starRingEnd ℂ) a * a) / (1 - (starRingEnd ℂ) a * p) ^ 2) p := by
+  have hn : HasDerivAt (fun ξ : ℂ => ξ - a) 1 p := (hasDerivAt_id p).sub_const a
+  have hd : HasDerivAt (fun ξ : ℂ => 1 - (starRingEnd ℂ) a * ξ) (-(starRingEnd ℂ) a) p := by
+    simpa using ((hasDerivAt_id p).const_mul ((starRingEnd ℂ) a)).const_sub 1
+  have hq := hn.div hd hp
+  have hval : (1 - (starRingEnd ℂ) a * a) / (1 - (starRingEnd ℂ) a * p) ^ 2
+      = (1 * (1 - (starRingEnd ℂ) a * p) - (p - a) * -(starRingEnd ℂ) a)
+        / (1 - (starRingEnd ℂ) a * p) ^ 2 := by
+    congr 1
+    ring
+  rw [hval]
+  exact hq
+
+/-- **The infinitesimal Schwarz--Pick inequality.** A holomorphic self-map `f` of the open
+unit disc contracts the Poincaré metric: at every point `z` of the disc,
+`‖deriv f z‖ / (1 - ‖f z‖ ^ 2) ≤ 1 / (1 - ‖z‖ ^ 2)`. -/
+theorem norm_deriv_div_one_sub_norm_sq_le {f : ℂ → ℂ}
+    (hf : DifferentiableOn ℂ f (ball (0 : ℂ) 1))
+    (hmaps : MapsTo f (ball (0 : ℂ) 1) (ball (0 : ℂ) 1))
+    {z : ℂ} (hz : z ∈ ball (0 : ℂ) 1) :
+    ‖deriv f z‖ / (1 - ‖f z‖ ^ 2) ≤ 1 / (1 - ‖z‖ ^ 2) := by
+  have hz1 : ‖z‖ < 1 := by simpa [mem_ball_zero_iff] using hz
+  have hfz_mem : f z ∈ ball (0 : ℂ) 1 := hmaps hz
+  have hfz1 : ‖f z‖ < 1 := by simpa [mem_ball_zero_iff] using hfz_mem
+  have hden_z : (0 : ℝ) < 1 - ‖z‖ ^ 2 := by nlinarith [norm_nonneg z]
+  have hden_fz : (0 : ℝ) < 1 - ‖f z‖ ^ 2 := by nlinarith [norm_nonneg (f z)]
+  -- The disc automorphisms conjugating `f` so that the conjugate fixes `0`.
+  let source : ℂ → ℂ := fun ξ => (ξ - (-z)) / (1 - (starRingEnd ℂ) (-z) * ξ)
+  let target : ℂ → ℂ := fun η => (η - f z) / (1 - (starRingEnd ℂ) (f z) * η)
+  let g : ℂ → ℂ := target ∘ f ∘ source
+  -- `source` and `target` map the disc into itself and are holomorphic there.
+  have hsource_maps : MapsTo source (ball (0 : ℂ) 1) (ball (0 : ℂ) 1) := by
+    simpa [source] using mapsTo_ball_unitDiscMoebiusFormula_of_norm_lt_one
+      (a := -z) (by simpa using hz1)
+  have htarget_maps : MapsTo target (ball (0 : ℂ) 1) (ball (0 : ℂ) 1) := by
+    simpa [target] using mapsTo_ball_unitDiscMoebiusFormula_of_norm_lt_one (a := f z) hfz1
+  have hsource_diff : DifferentiableOn ℂ source (ball (0 : ℂ) 1) := by
+    simpa [source] using differentiableOn_unitDiscMoebiusFormula_of_norm_lt_one
+      (a := -z) (by simpa using hz1)
+  have htarget_diff : DifferentiableOn ℂ target (ball (0 : ℂ) 1) := by
+    simpa [target] using differentiableOn_unitDiscMoebiusFormula_of_norm_lt_one (a := f z) hfz1
+  have hg_maps : MapsTo g (ball (0 : ℂ) 1) (ball (0 : ℂ) 1) :=
+    fun ξ hξ => htarget_maps (hmaps (hsource_maps hξ))
+  have hg_diff : DifferentiableOn ℂ g (ball (0 : ℂ) 1) :=
+    htarget_diff.comp (hf.comp hsource_diff hsource_maps) (hmaps.comp hsource_maps)
+  -- The conjugate `g` fixes the origin.
+  have hsource_zero : source 0 = z := by
+    change (0 - (-z)) / (1 - (starRingEnd ℂ) (-z) * 0) = z
+    simp
+  have hg_zero : g 0 = 0 := by
+    change target (f (source 0)) = 0
+    rw [hsource_zero]
+    change (f z - f z) / (1 - (starRingEnd ℂ) (f z) * f z) = 0
+    rw [sub_self, zero_div]
+  -- Schwarz's lemma at `0` for `g`.
+  have hg_maps_closed : MapsTo g (ball (0 : ℂ) 1) (closedBall (0 : ℂ) 1) :=
+    fun ξ hξ => ball_subset_closedBall (hg_maps hξ)
+  have hschwarz : ‖deriv g 0‖ ≤ 1 := by
+    have hmaps' : MapsTo g (ball (0 : ℂ) 1) (closedBall (g 0) 1) := by
+      rw [hg_zero]; exact hg_maps_closed
+    exact Complex.norm_deriv_le_one_of_mapsTo_ball hg_diff hmaps' (by norm_num)
+  -- The chain rule for `deriv g 0`.
+  have hp_inner : (1 : ℂ) - (starRingEnd ℂ) (-z) * 0 ≠ 0 := by simp
+  have hp_outer : (1 : ℂ) - (starRingEnd ℂ) (f z) * f z ≠ 0 :=
+    one_sub_conj_mul_ne_zero_of_norm_lt_one hfz1 hfz1
+  have hd_inner : HasDerivAt source (1 - (starRingEnd ℂ) z * z) 0 := by
+    have h := hasDerivAt_moebiusFactor (-z) 0 hp_inner
+    have hval : (1 - (starRingEnd ℂ) (-z) * (-z)) / (1 - (starRingEnd ℂ) (-z) * 0) ^ 2
+        = 1 - (starRingEnd ℂ) z * z := by simp [map_neg]
+    rw [hval] at h
+    exact h
+  have hd_outer : HasDerivAt target (1 / (1 - (starRingEnd ℂ) (f z) * f z)) (f z) := by
+    have h := hasDerivAt_moebiusFactor (f z) (f z) hp_outer
+    have hval : (1 - (starRingEnd ℂ) (f z) * f z) / (1 - (starRingEnd ℂ) (f z) * f z) ^ 2
+        = 1 / (1 - (starRingEnd ℂ) (f z) * f z) := by
+      rw [sq, ← div_div, div_self hp_outer]
+    rw [hval] at h
+    exact h
+  have hf_at : HasDerivAt f (deriv f z) z :=
+    (hf.differentiableAt (isOpen_ball.mem_nhds hz)).hasDerivAt
+  have hf_at' : HasDerivAt f (deriv f z) (source 0) := by rw [hsource_zero]; exact hf_at
+  have hcomp1 : HasDerivAt (f ∘ source) (deriv f z * (1 - (starRingEnd ℂ) z * z)) 0 :=
+    hf_at'.comp (0 : ℂ) hd_inner
+  have hd_outer' : HasDerivAt target (1 / (1 - (starRingEnd ℂ) (f z) * f z)) ((f ∘ source) 0) := by
+    rw [Function.comp_apply, hsource_zero]; exact hd_outer
+  have hcompg : HasDerivAt g
+      ((1 / (1 - (starRingEnd ℂ) (f z) * f z)) * (deriv f z * (1 - (starRingEnd ℂ) z * z))) 0 :=
+    hd_outer'.comp (0 : ℂ) hcomp1
+  have hderiv_g : deriv g 0
+      = (1 / (1 - (starRingEnd ℂ) (f z) * f z)) * (deriv f z * (1 - (starRingEnd ℂ) z * z)) :=
+    hcompg.deriv
+  -- The norms of the two Moebius derivative factors.
+  have hnorm : ∀ w : ℂ, ‖w‖ < 1 → ‖(1 : ℂ) - (starRingEnd ℂ) w * w‖ = 1 - ‖w‖ ^ 2 := by
+    intro w hw
+    have hconj : (starRingEnd ℂ) w * w = ((‖w‖ ^ 2 : ℝ) : ℂ) := by
+      rw [mul_comm, Complex.mul_conj, Complex.normSq_eq_norm_sq]
+    rw [hconj, ← Complex.ofReal_one, ← Complex.ofReal_sub, Complex.norm_real, Real.norm_eq_abs,
+      abs_of_nonneg (by nlinarith [norm_nonneg w])]
+  have hnorm_z := hnorm z hz1
+  have hnorm_fz := hnorm (f z) hfz1
+  -- Assemble the norm of `deriv g 0` and conclude via Schwarz.
+  have hnorm_dg : ‖deriv g 0‖ = ‖deriv f z‖ * (1 - ‖z‖ ^ 2) / (1 - ‖f z‖ ^ 2) := by
+    rw [hderiv_g, norm_mul, norm_mul, norm_div, norm_one, hnorm_z, hnorm_fz]
+    ring
+  have hkey : ‖deriv f z‖ * (1 - ‖z‖ ^ 2) / (1 - ‖f z‖ ^ 2) ≤ 1 := hnorm_dg ▸ hschwarz
+  rw [div_le_one hden_fz] at hkey
+  rw [div_le_div_iff₀ hden_fz hden_z, one_mul]
+  exact hkey
+
+end TauCeti


### PR DESCRIPTION
This PR proves the infinitesimal (differential) form of the Schwarz--Pick lemma for holomorphic self-maps of the complex unit disc: if `f` is holomorphic on `Metric.ball 0 1` and maps it into itself, then at every point `z` of the disc `‖deriv f z‖ / (1 - ‖f z‖ ^ 2) ≤ 1 / (1 - ‖z‖ ^ 2)`, i.e. `f` contracts the Poincaré (hyperbolic) metric `|dz| / (1 - |z| ^ 2)`. The proof conjugates `f` by the disc automorphisms sending `0 ↦ z` and `f z ↦ 0`, so the conjugate `g` fixes the origin; Mathlib's Schwarz lemma bounds `‖deriv g 0‖ ≤ 1`, and the chain rule evaluates `deriv g 0` in terms of `deriv f z` and the derivatives of the two Moebius factors, which unwinds to the stated contraction.

This advances the conformal-mapping roadmap's L2 Schwarz--Pick target (`TauCetiRoadmap/ConformalMapping/README.md`, "L2 — Schwarz lemma extensions", the hyperbolic/Poincaré-metric contraction), complementing Tau Ceti's existing finite Schwarz--Pick estimate `pseudoHyperbolicExpr_map_le`. It reuses Mathlib's Schwarz lemma (`Complex.norm_deriv_le_one_of_mapsTo_ball`) and Tau Ceti's unit-disc Moebius API. As with the rest of the L0--L3 conformal-mapping material, it is coordinated with the upstream Mathlib RMT effort leanprover-community/mathlib4#33505 (per the roadmap's "Coordination with upstream Mathlib" clause) and should be refactored to upstream API should that work land a human-curated Schwarz--Pick theorem.

<!--tauceti-target:v1 {"focus":"ConformalMapping","id":"infinitesimal-schwarz-pick"}-->

🤖 Prepared with Claude Code
