### PR TITLE
feat: the weight ↔ measure isometry L²(w·μ) ≃ₗᵢ L²(μ)

### DIFF
--- a/TauCeti/MeasureTheory/Function/WeightL2Isometry.lean
+++ b/TauCeti/MeasureTheory/Function/WeightL2Isometry.lean
@@ -1,0 +1,168 @@
+module
+
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Claude
+-/
+public import Mathlib.MeasureTheory.Function.L2Space
+public import Mathlib.MeasureTheory.Measure.WithDensity
+import Mathlib.MeasureTheory.Function.SpecialFunctions.Basic
+
+/-!
+# The weight ↔ measure isometry `L²(w·μ) ≃ₗᵢ L²(μ)`
+
+For an almost-everywhere-positive real weight `w` on an arbitrary measurable space, multiplication
+by `√w` is a linear isometric equivalence from the weighted `L²` space `L²(w·μ)` onto `L²(μ)`, where
+`w·μ := μ.withDensity (ENNReal.ofReal ∘ w)`. It is an *equivalence* precisely because `w > 0`
+almost everywhere: the inverse is multiplication by `(√w)⁻¹`.
+
+This is the Part 0 primitive `weightL2Isometry` from the `OrthogonalL2Bases` roadmap, the single
+map converting a weight-in-the-measure normalization to a weight-in-the-function normalization. Once
+combined with `HilbertBasis.mapₗᵢ` (transport of a Hilbert basis across a `≃ₗᵢ`, already in
+`TauCeti.Analysis.InnerProductSpace.HilbertBasisMap`), it moves an orthogonal-polynomial basis of a
+weighted measure to the `√w`-envelope basis of the reference measure and back.
+
+The construction is purely measure-theoretic, so it is stated over an arbitrary `MeasurableSpace`;
+only the later polynomial-facing layers specialize to `Measure ℝ`.
+
+## Main definitions
+
+* `TauCeti.weightL2Isometry` — the isometric equivalence `L²(w·μ) ≃ₗᵢ[𝕜] L²(μ)`.
+
+## Main statements
+
+* `TauCeti.weightL2Isometry_apply` — the forward map is multiplication by `√w`.
+* `TauCeti.weightL2Isometry_symm_apply` — the inverse map is multiplication by `(√w)⁻¹`.
+
+The load-bearing analytic fact is `eLpNorm_sqrt_smul_withDensity`: the `L²(μ)` seminorm of `√w · g`
+equals the `L²(w·μ)` seminorm of `g`, proved from the `withDensity` change-of-variables for
+`lintegral`.
+-/
+
+public section
+
+namespace TauCeti
+
+open MeasureTheory
+
+open scoped ENNReal NNReal
+
+variable {𝕜 : Type*} [RCLike 𝕜] {α : Type*} [MeasurableSpace α] (μ : Measure α) (w : α → ℝ)
+
+/-- **Core seminorm identity.** The `L²(μ)` seminorm of `√w · g` equals the `L²(w·μ)` seminorm of
+`g`, where `w·μ = μ.withDensity (ENNReal.ofReal ∘ w)`. Only `0 ≤ w` almost everywhere is used (via
+`hwpos`); the exponent `2` is handled through the `lintegral`-of-`rpow` description of `eLpNorm`. -/
+theorem eLpNorm_sqrt_smul_withDensity (hwm : AEMeasurable w μ) (hwpos : ∀ᵐ x ∂μ, 0 < w x)
+    (g : α → 𝕜) :
+    eLpNorm (fun x => Real.sqrt (w x) • g x) 2 μ
+      = eLpNorm g 2 (μ.withDensity fun x => ENNReal.ofReal (w x)) := by
+  have h2z : (2 : ℝ≥0∞) ≠ 0 := by norm_num
+  have h2t : (2 : ℝ≥0∞) ≠ ∞ := by norm_num
+  have ht : (2 : ℝ≥0∞).toReal = 2 := by norm_num
+  rw [eLpNorm_eq_lintegral_rpow_enorm_toReal h2z h2t,
+    eLpNorm_eq_lintegral_rpow_enorm_toReal h2z h2t, ht]
+  congr 1
+  rw [lintegral_withDensity_eq_lintegral_mul_non_measurable₀ μ hwm.ennreal_ofReal
+    (Filter.Eventually.of_forall fun x => ENNReal.ofReal_lt_top)]
+  refine lintegral_congr_ae ?_
+  filter_upwards [hwpos] with x hx
+  have hsqnn : (0 : ℝ) ≤ Real.sqrt (w x) := Real.sqrt_nonneg _
+  simp only [Pi.mul_apply]
+  rw [enorm_smul, Real.enorm_of_nonneg hsqnn,
+    ENNReal.mul_rpow_of_nonneg _ _ (by norm_num : (0 : ℝ) ≤ 2)]
+  congr 1
+  rw [ENNReal.ofReal_rpow_of_nonneg hsqnn (by norm_num : (0 : ℝ) ≤ 2),
+    show (2 : ℝ) = ((2 : ℕ) : ℝ) by norm_num, Real.rpow_natCast, Real.sq_sqrt hx.le]
+
+/-- `w · μ` is absolutely continuous with respect to `μ` (always holds). -/
+private theorem withDensity_ac :
+    (μ.withDensity fun x => ENNReal.ofReal (w x)) ≪ μ := withDensity_absolutelyContinuous _ _
+
+/-- `μ` is absolutely continuous with respect to `w · μ` (uses `w > 0` a.e.). -/
+private theorem ac_withDensity (hwpos : ∀ᵐ x ∂μ, 0 < w x) (hwm : AEMeasurable w μ) :
+    μ ≪ μ.withDensity fun x => ENNReal.ofReal (w x) :=
+  withDensity_absolutelyContinuous' hwm.ennreal_ofReal (by
+    filter_upwards [hwpos] with x hx
+    simp only [ne_eq, ENNReal.ofReal_eq_zero, not_le]
+    exact hx)
+
+/-- The forward direction `√w · f` of a class in `L²(w·μ)` is in `L²(μ)`. -/
+private theorem memLp_sqrt_smul (hwpos : ∀ᵐ x ∂μ, 0 < w x) (hwm : AEMeasurable w μ)
+    (f : Lp 𝕜 2 (μ.withDensity fun x => ENNReal.ofReal (w x))) :
+    MemLp (fun x => Real.sqrt (w x) • (f : α → 𝕜) x) 2 μ := by
+  refine ⟨(hwm.sqrt.aestronglyMeasurable).smul
+    ((Lp.aestronglyMeasurable f).mono_ac (ac_withDensity μ w hwpos hwm)), ?_⟩
+  rw [eLpNorm_sqrt_smul_withDensity μ w hwm hwpos]
+  exact Lp.eLpNorm_lt_top f
+
+/-- The inverse direction `(√w)⁻¹ · g` of a class in `L²(μ)` is in `L²(w·μ)`. -/
+private theorem memLp_inv_sqrt_smul (hwpos : ∀ᵐ x ∂μ, 0 < w x) (hwm : AEMeasurable w μ)
+    (g : Lp 𝕜 2 μ) :
+    MemLp (fun x => (Real.sqrt (w x))⁻¹ • (g : α → 𝕜) x) 2
+      (μ.withDensity fun x => ENNReal.ofReal (w x)) := by
+  have hasm : AEStronglyMeasurable (fun x => (Real.sqrt (w x))⁻¹ • (g : α → 𝕜) x) μ :=
+    (hwm.sqrt.inv.aestronglyMeasurable).smul (Lp.aestronglyMeasurable g)
+  refine ⟨hasm.mono_ac (withDensity_ac μ w), ?_⟩
+  rw [← eLpNorm_sqrt_smul_withDensity μ w hwm hwpos]
+  refine (eLpNorm_congr_ae ?_).trans_lt (Lp.eLpNorm_lt_top g)
+  filter_upwards [hwpos] with x hx
+  rw [smul_smul, mul_inv_cancel₀ (Real.sqrt_pos.2 hx).ne', one_smul]
+
+/-- **The weight ↔ measure isometry.** For an almost-everywhere-positive weight `w`, multiplication
+by `√w` is a linear isometric equivalence `L²(w·μ) ≃ₗᵢ[𝕜] L²(μ)`. -/
+noncomputable def weightL2Isometry (hwpos : ∀ᵐ x ∂μ, 0 < w x) (hwm : AEMeasurable w μ) :
+    Lp 𝕜 2 (μ.withDensity fun x => ENNReal.ofReal (w x)) ≃ₗᵢ[𝕜] Lp 𝕜 2 μ where
+  toLinearEquiv :=
+    { toFun := fun f => (memLp_sqrt_smul μ w hwpos hwm f).toLp _
+      invFun := fun g => (memLp_inv_sqrt_smul μ w hwpos hwm g).toLp _
+      map_add' := fun f₁ f₂ => by
+        rw [← MemLp.toLp_add, MemLp.toLp_eq_toLp_iff]
+        filter_upwards [(Lp.coeFn_add f₁ f₂).filter_mono (ac_withDensity μ w hwpos hwm).ae_le]
+          with x hx
+        simp only [Pi.add_apply, hx, smul_add]
+      map_smul' := fun c f => by
+        simp only [RingHom.id_apply]
+        rw [← MemLp.toLp_const_smul, MemLp.toLp_eq_toLp_iff]
+        filter_upwards [(Lp.coeFn_smul c f).filter_mono (ac_withDensity μ w hwpos hwm).ae_le]
+          with x hx
+        simp only [Pi.smul_apply, hx]
+        rw [smul_comm]
+      left_inv := fun f => by
+        refine Lp.ext ?_
+        have e2 : (⇑((memLp_sqrt_smul μ w hwpos hwm f).toLp _) : α → 𝕜)
+            =ᵐ[μ.withDensity fun x => ENNReal.ofReal (w x)]
+              fun x => Real.sqrt (w x) • (f : α → 𝕜) x :=
+          (MemLp.coeFn_toLp _).filter_mono (withDensity_ac μ w).ae_le
+        filter_upwards [MemLp.coeFn_toLp
+          (memLp_inv_sqrt_smul μ w hwpos hwm ((memLp_sqrt_smul μ w hwpos hwm f).toLp _)),
+          e2, hwpos.filter_mono (withDensity_ac μ w).ae_le] with x h1 h2 hx
+        rw [h1, h2, smul_smul, inv_mul_cancel₀ (Real.sqrt_pos.2 hx).ne', one_smul]
+      right_inv := fun g => by
+        refine Lp.ext ?_
+        filter_upwards [MemLp.coeFn_toLp
+          (memLp_sqrt_smul μ w hwpos hwm ((memLp_inv_sqrt_smul μ w hwpos hwm g).toLp _)),
+          (MemLp.coeFn_toLp (memLp_inv_sqrt_smul μ w hwpos hwm g)).filter_mono
+            (ac_withDensity μ w hwpos hwm).ae_le,
+          hwpos] with x h1 h2 hx
+        rw [h1, h2, smul_smul, mul_inv_cancel₀ (Real.sqrt_pos.2 hx).ne', one_smul] }
+  norm_map' := fun f => by
+    change ‖MemLp.toLp (fun x => Real.sqrt (w x) • (f : α → 𝕜) x)
+      (memLp_sqrt_smul μ w hwpos hwm f)‖ = ‖f‖
+    rw [Lp.norm_toLp, Lp.norm_def, eLpNorm_sqrt_smul_withDensity μ w hwm hwpos]
+
+/-- The forward isometry is multiplication by `√w`. -/
+theorem weightL2Isometry_apply (hwpos : ∀ᵐ x ∂μ, 0 < w x) (hwm : AEMeasurable w μ)
+    (f : Lp 𝕜 2 (μ.withDensity fun x => ENNReal.ofReal (w x))) :
+    weightL2Isometry μ w hwpos hwm f =ᵐ[μ] fun x => Real.sqrt (w x) • (f : α → 𝕜) x :=
+  MemLp.coeFn_toLp (memLp_sqrt_smul μ w hwpos hwm f)
+
+/-- The inverse isometry is multiplication by `(√w)⁻¹`. -/
+theorem weightL2Isometry_symm_apply (hwpos : ∀ᵐ x ∂μ, 0 < w x) (hwm : AEMeasurable w μ)
+    (g : Lp 𝕜 2 μ) :
+    (weightL2Isometry μ w hwpos hwm).symm g
+      =ᵐ[μ] fun x => (Real.sqrt (w x))⁻¹ • (g : α → 𝕜) x :=
+  (MemLp.coeFn_toLp (memLp_inv_sqrt_smul μ w hwpos hwm g)).filter_mono
+    (ac_withDensity μ w hwpos hwm).ae_le
+
+end TauCeti

--- a/TauCeti/MeasureTheory/Function/WeightL2Isometry.lean
+++ b/TauCeti/MeasureTheory/Function/WeightL2Isometry.lean
@@ -35,9 +35,8 @@ only the later polynomial-facing layers specialize to `Measure ℝ`.
 * `TauCeti.weightL2Isometry_apply` — the forward map is multiplication by `√w`.
 * `TauCeti.weightL2Isometry_symm_apply` — the inverse map is multiplication by `(√w)⁻¹`.
 
-The load-bearing analytic fact is `eLpNorm_sqrt_smul_withDensity`: the `L²(μ)` seminorm of `√w · g`
-equals the `L²(w·μ)` seminorm of `g`, proved from the `withDensity` change-of-variables for
-`lintegral`.
+The file also provides the underlying `L²` seminorm identity: the `L²(μ)` seminorm of `√w · g`
+equals the `L²(w·μ)` seminorm of `g`.
 -/
 
 public section
@@ -51,10 +50,10 @@ open scoped ENNReal NNReal
 variable {𝕜 : Type*} [RCLike 𝕜] {α : Type*} [MeasurableSpace α] (μ : Measure α) (w : α → ℝ)
 
 /-- **Core seminorm identity.** The `L²(μ)` seminorm of `√w · g` equals the `L²(w·μ)` seminorm of
-`g`, where `w·μ = μ.withDensity (ENNReal.ofReal ∘ w)`. Only `0 ≤ w` almost everywhere is used (via
-`hwpos`); the exponent `2` is handled through the `lintegral`-of-`rpow` description of `eLpNorm`. -/
-theorem eLpNorm_sqrt_smul_withDensity (hwm : AEMeasurable w μ) (hwpos : ∀ᵐ x ∂μ, 0 < w x)
-    (g : α → 𝕜) :
+`g`, where `w·μ = μ.withDensity (ENNReal.ofReal ∘ w)`. Only nonnegativity of `w` almost everywhere
+is needed. -/
+private theorem eLpNorm_sqrt_smul_withDensity (hwm : AEMeasurable w μ)
+    (hw_nonneg : ∀ᵐ x ∂μ, 0 ≤ w x) (g : α → 𝕜) :
     eLpNorm (fun x => Real.sqrt (w x) • g x) 2 μ
       = eLpNorm g 2 (μ.withDensity fun x => ENNReal.ofReal (w x)) := by
   have h2z : (2 : ℝ≥0∞) ≠ 0 := by norm_num
@@ -66,14 +65,14 @@ theorem eLpNorm_sqrt_smul_withDensity (hwm : AEMeasurable w μ) (hwpos : ∀ᵐ 
   rw [lintegral_withDensity_eq_lintegral_mul_non_measurable₀ μ hwm.ennreal_ofReal
     (Filter.Eventually.of_forall fun x => ENNReal.ofReal_lt_top)]
   refine lintegral_congr_ae ?_
-  filter_upwards [hwpos] with x hx
+  filter_upwards [hw_nonneg] with x hx
   have hsqnn : (0 : ℝ) ≤ Real.sqrt (w x) := Real.sqrt_nonneg _
   simp only [Pi.mul_apply]
   rw [enorm_smul, Real.enorm_of_nonneg hsqnn,
     ENNReal.mul_rpow_of_nonneg _ _ (by norm_num : (0 : ℝ) ≤ 2)]
   congr 1
   rw [ENNReal.ofReal_rpow_of_nonneg hsqnn (by norm_num : (0 : ℝ) ≤ 2),
-    show (2 : ℝ) = ((2 : ℕ) : ℝ) by norm_num, Real.rpow_natCast, Real.sq_sqrt hx.le]
+    Real.rpow_two, Real.sq_sqrt hx]
 
 /-- `w · μ` is absolutely continuous with respect to `μ` (always holds). -/
 private theorem withDensity_ac :
@@ -93,7 +92,7 @@ private theorem memLp_sqrt_smul (hwpos : ∀ᵐ x ∂μ, 0 < w x) (hwm : AEMeasu
     MemLp (fun x => Real.sqrt (w x) • (f : α → 𝕜) x) 2 μ := by
   refine ⟨(hwm.sqrt.aestronglyMeasurable).smul
     ((Lp.aestronglyMeasurable f).mono_ac (ac_withDensity μ w hwpos hwm)), ?_⟩
-  rw [eLpNorm_sqrt_smul_withDensity μ w hwm hwpos]
+  rw [eLpNorm_sqrt_smul_withDensity μ w hwm (hwpos.mono fun _ h => h.le)]
   exact Lp.eLpNorm_lt_top f
 
 /-- The inverse direction `(√w)⁻¹ · g` of a class in `L²(μ)` is in `L²(w·μ)`. -/
@@ -104,7 +103,7 @@ private theorem memLp_inv_sqrt_smul (hwpos : ∀ᵐ x ∂μ, 0 < w x) (hwm : AEM
   have hasm : AEStronglyMeasurable (fun x => (Real.sqrt (w x))⁻¹ • (g : α → 𝕜) x) μ :=
     (hwm.sqrt.inv.aestronglyMeasurable).smul (Lp.aestronglyMeasurable g)
   refine ⟨hasm.mono_ac (withDensity_ac μ w), ?_⟩
-  rw [← eLpNorm_sqrt_smul_withDensity μ w hwm hwpos]
+  rw [← eLpNorm_sqrt_smul_withDensity μ w hwm (hwpos.mono fun _ h => h.le)]
   refine (eLpNorm_congr_ae ?_).trans_lt (Lp.eLpNorm_lt_top g)
   filter_upwards [hwpos] with x hx
   rw [smul_smul, mul_inv_cancel₀ (Real.sqrt_pos.2 hx).ne', one_smul]
@@ -147,9 +146,12 @@ noncomputable def weightL2Isometry (hwpos : ∀ᵐ x ∂μ, 0 < w x) (hwm : AEMe
           hwpos] with x h1 h2 hx
         rw [h1, h2, smul_smul, mul_inv_cancel₀ (Real.sqrt_pos.2 hx).ne', one_smul] }
   norm_map' := fun f => by
+    -- The forward map is definitionally `MemLp.toLp (√w • f)`; expose that representative so that
+    -- `Lp.norm_toLp` fires, then discharge the norm through the core seminorm identity.
     change ‖MemLp.toLp (fun x => Real.sqrt (w x) • (f : α → 𝕜) x)
       (memLp_sqrt_smul μ w hwpos hwm f)‖ = ‖f‖
-    rw [Lp.norm_toLp, Lp.norm_def, eLpNorm_sqrt_smul_withDensity μ w hwm hwpos]
+    rw [Lp.norm_toLp, Lp.norm_def,
+      eLpNorm_sqrt_smul_withDensity μ w hwm (hwpos.mono fun _ h => h.le)]
 
 /-- The forward isometry is multiplication by `√w`. -/
 theorem weightL2Isometry_apply (hwpos : ∀ᵐ x ∂μ, 0 < w x) (hwm : AEMeasurable w μ)


### PR DESCRIPTION
This PR adds the Part 0 primitive `weightL2Isometry` of the `OrthogonalL2Bases` roadmap: for an almost-everywhere-positive real weight `w` on an arbitrary measurable space, multiplication by `√w` is a linear isometric equivalence `L²(w·μ) ≃ₗᵢ[𝕜] L²(μ)`, where `w·μ = μ.withDensity (ENNReal.ofReal ∘ w)`. It is an equivalence precisely because `w > 0` almost everywhere, so the inverse is multiplication by `(√w)⁻¹`. This is the single map converting a weight-in-the-measure normalization to a weight-in-the-function normalization, and once composed with the already-landed `HilbertBasis.mapₗᵢ` it will move an orthogonal-polynomial basis of a weighted measure to the `√w`-envelope basis of the reference measure and back.

The target is `TauCetiRoadmap/OrthogonalL2Bases/README.md`, Part B2 ("**`weightL2Isometry (μ : Measure α) (w) (hwpos) (hwm) : L²(w·μ) ≃ₗᵢ[𝕜] L²(μ)`**, multiplication by `√w` ... an *equivalence* exactly because `0 < w` a.e. ... The isometry is purely measure-theoretic, so stated over an **arbitrary** measurable `α` ... it ships the element-level `weightL2Isometry_apply` (a.e. `= √w · f`) as its anti-vacuity pin"), matching the representative signature in that area's `Suggested.lean`. The construction is stated over a generic `MeasurableSpace` since only the later polynomial-facing layers need `Measure ℝ`.

The load-bearing analytic content is `eLpNorm_sqrt_smul_withDensity`, the seminorm identity `eLpNorm (√w · g) 2 μ = eLpNorm g 2 (w·μ)`, proved from the `withDensity` change of variables for `lintegral` (`lintegral_withDensity_eq_lintegral_mul_non_measurable₀`) via the `rpow`-of-`enorm` description of `eLpNorm`. From it the forward/inverse `MemLp` obligations, the two mutual absolute continuities (`μ ≪ w·μ` needs `w > 0` a.e., `w·μ ≪ μ` is automatic), and the `LinearIsometryEquiv` structure follow. The element-level `weightL2Isometry_apply` and `weightL2Isometry_symm_apply` are exported as the anti-vacuity pins the downstream basis targets consume.

Mathlib infrastructure consumed (not re-derived): `MeasureTheory.withDensity_absolutelyContinuous`, `withDensity_absolutelyContinuous'`, `lintegral_withDensity_eq_lintegral_mul_non_measurable₀`, `eLpNorm_eq_lintegral_rpow_enorm_toReal`, `MemLp.toLp` with `coeFn_toLp` / `toLp_add` / `toLp_const_smul` / `toLp_eq_toLp_iff`, `Lp.norm_toLp` / `Lp.norm_def` / `Lp.ext`, `ENNReal.ofReal_rpow_of_nonneg`, and the `Real.sqrt` API. Builds green against the pin; `lake exe axioms` reports all declarations within `[propext, Classical.choice, Quot.sound]`.

<!--tauceti-target:v1 {"focus":"OrthogonalL2Bases","id":"weightl2isometry"}-->

🤖 Prepared with Claude Code
