### PR TITLE
feat: identify Abel-map fibers with linear systems

### DIFF
--- a/TauCeti/AlgebraicGeometry/WeilDivisor/AbelJacobiLinearSystem.lean
+++ b/TauCeti/AlgebraicGeometry/WeilDivisor/AbelJacobiLinearSystem.lean
@@ -50,7 +50,7 @@ variable {d : ℕ}
 
 /-- For effective divisors of the same fixed degree, equality of normalized Abel-Jacobi
 classes is exactly linear equivalence of the underlying divisors. -/
-lemma weightedAbelJacobiDivisorClass_effectiveDivisorOfDegree_eq_iff_linearlyEquivalent
+lemma weightedAbelJacobiDivisorClass_one_effectiveDivisorOfDegree_eq_iff_linearlyEquivalent
     (h : S.IsUnweightedDegreeZero) (x₀ : X)
     (D E : EffectiveDivisorOfDegree X d) :
     S.weightedAbelJacobiDivisorClass (fun _ : X => (1 : ℤ)) h (x₀ := x₀) rfl
@@ -64,7 +64,7 @@ lemma weightedAbelJacobiDivisorClass_effectiveDivisorOfDegree_eq_iff_linearlyEqu
 
 /-- The fixed-degree Abel-Jacobi fiber through `D` is the complete linear system `|D|`, restricted
 to effective divisors of the same degree. -/
-lemma weightedAbelJacobiDivisorClass_effectiveDivisorOfDegree_eq_iff_mem_completeLinearSystem
+lemma weightedAbelJacobiDivisorClass_one_effectiveDivisorOfDegree_eq_iff_mem_completeLinearSystem
     (h : S.IsUnweightedDegreeZero) (x₀ : X)
     (D E : EffectiveDivisorOfDegree X d) :
     S.weightedAbelJacobiDivisorClass (fun _ : X => (1 : ℤ)) h (x₀ := x₀) rfl
@@ -72,7 +72,7 @@ lemma weightedAbelJacobiDivisorClass_effectiveDivisorOfDegree_eq_iff_mem_complet
         S.weightedAbelJacobiDivisorClass (fun _ : X => (1 : ℤ)) h (x₀ := x₀) rfl
           (D : WeilDivisor X) ↔
       (E : WeilDivisor X) ∈ S.completeLinearSystem (D : WeilDivisor X) := by
-  rw [S.weightedAbelJacobiDivisorClass_effectiveDivisorOfDegree_eq_iff_linearlyEquivalent
+  rw [S.weightedAbelJacobiDivisorClass_one_effectiveDivisorOfDegree_eq_iff_linearlyEquivalent
     h x₀ E D, S.mem_completeLinearSystem]
   constructor
   · intro hlin
@@ -81,7 +81,7 @@ lemma weightedAbelJacobiDivisorClass_effectiveDivisorOfDegree_eq_iff_mem_complet
 
 /-- As a set of fixed-degree effective divisors, the Abel-Jacobi fiber through `D` is the
 restriction of the complete linear system `|D|`. -/
-lemma setOf_weightedAbelJacobiDivisorClass_effectiveDivisorOfDegree_eq
+lemma setOf_weightedAbelJacobiDivisorClass_one_effectiveDivisorOfDegree_eq
     (h : S.IsUnweightedDegreeZero) (x₀ : X)
     (D : EffectiveDivisorOfDegree X d) :
     {E : EffectiveDivisorOfDegree X d |
@@ -92,14 +92,15 @@ lemma setOf_weightedAbelJacobiDivisorClass_effectiveDivisorOfDegree_eq
       {E : EffectiveDivisorOfDegree X d |
         (E : WeilDivisor X) ∈ S.completeLinearSystem (D : WeilDivisor X)} := by
   ext E
-  exact S.weightedAbelJacobiDivisorClass_effectiveDivisorOfDegree_eq_iff_mem_completeLinearSystem
-    h x₀ D E
+  exact
+    S.weightedAbelJacobiDivisorClass_one_effectiveDivisorOfDegree_eq_iff_mem_completeLinearSystem
+      h x₀ D E
 
 /-! ### Symmetric powers -/
 
 /-- On symmetric powers, equality of normalized Abel-Jacobi classes is exactly membership of the
 corresponding divisor in the complete linear system. -/
-lemma weightedAbelJacobiDivisorClass_ofSym_eq_iff_mem_completeLinearSystem
+lemma weightedAbelJacobiDivisorClass_one_ofSym_eq_iff_mem_completeLinearSystem
     (h : S.IsUnweightedDegreeZero) (x₀ : X) (s t : Sym X d) :
     S.weightedAbelJacobiDivisorClass (fun _ : X => (1 : ℤ)) h (x₀ := x₀) rfl
         (EffectiveDivisorOfDegree.ofSym t : WeilDivisor X) =
@@ -107,12 +108,12 @@ lemma weightedAbelJacobiDivisorClass_ofSym_eq_iff_mem_completeLinearSystem
           (EffectiveDivisorOfDegree.ofSym s : WeilDivisor X) ↔
       (EffectiveDivisorOfDegree.ofSym t : WeilDivisor X) ∈
         S.completeLinearSystem (EffectiveDivisorOfDegree.ofSym s : WeilDivisor X) :=
-  S.weightedAbelJacobiDivisorClass_effectiveDivisorOfDegree_eq_iff_mem_completeLinearSystem
+  S.weightedAbelJacobiDivisorClass_one_effectiveDivisorOfDegree_eq_iff_mem_completeLinearSystem
     h x₀ (EffectiveDivisorOfDegree.ofSym s) (EffectiveDivisorOfDegree.ofSym t)
 
 /-- As a set of symmetric-power points, the Abel-Jacobi fiber through `s` is the preimage of the
 complete linear system `|ofSym s|`. -/
-lemma setOf_weightedAbelJacobiDivisorClass_ofSym_eq
+lemma setOf_weightedAbelJacobiDivisorClass_one_ofSym_eq
     (h : S.IsUnweightedDegreeZero) (x₀ : X) (s : Sym X d) :
     {t : Sym X d |
         S.weightedAbelJacobiDivisorClass (fun _ : X => (1 : ℤ)) h (x₀ := x₀) rfl
@@ -123,7 +124,7 @@ lemma setOf_weightedAbelJacobiDivisorClass_ofSym_eq
         (EffectiveDivisorOfDegree.ofSym t : WeilDivisor X) ∈
           S.completeLinearSystem (EffectiveDivisorOfDegree.ofSym s : WeilDivisor X)} := by
   ext t
-  exact S.weightedAbelJacobiDivisorClass_ofSym_eq_iff_mem_completeLinearSystem h x₀ s t
+  exact S.weightedAbelJacobiDivisorClass_one_ofSym_eq_iff_mem_completeLinearSystem h x₀ s t
 
 end
 

--- a/TauCeti/AlgebraicGeometry/WeilDivisor/AbelJacobiLinearSystem.lean
+++ b/TauCeti/AlgebraicGeometry/WeilDivisor/AbelJacobiLinearSystem.lean
@@ -44,42 +44,6 @@ variable (S : OrderSystem X G)
 
 noncomputable section
 
-/-! ### Equal-degree Abel-Jacobi classes -/
-
-/-- If two divisors have the same weighted degree, equality of their weighted Abel-Jacobi
-classes is exactly linear equivalence of the original divisors.
-
-The equal-degree hypothesis is essential: the Abel-Jacobi class only records the `Pic⁰`
-component of the divisor class after subtracting the same degree from the chosen base point. -/
-lemma weightedAbelJacobiDivisorClass_eq_iff_linearlyEquivalent_of_weightedDegree_eq
-    (w : X → ℤ) (h : S.IsWeightedDegreeZero w) {x₀ : X} (hx₀ : w x₀ = 1)
-    {D E : WeilDivisor X} (hDE : weightedDegree w D = weightedDegree w E) :
-    S.weightedAbelJacobiDivisorClass w h hx₀ D =
-        S.weightedAbelJacobiDivisorClass w h hx₀ E ↔
-      S.LinearlyEquivalent D E := by
-  rw [S.weightedAbelJacobiDivisorClass_eq_iff_linearlyEquivalent w h hx₀, hDE]
-  constructor
-  · intro hlin
-    have hlin' :=
-      LinearlyEquivalent.add_right (S := S) hlin (weightedDegree w E • ofPoint x₀)
-    simpa only [sub_add_cancel] using hlin'
-  · intro hlin
-    have hlin' :=
-      LinearlyEquivalent.add_right (S := S) hlin (-(weightedDegree w E • ofPoint x₀))
-    simpa only [sub_eq_add_neg] using hlin'
-
-/-- In the unweighted theory, equal-degree divisors have the same Abel-Jacobi class exactly when
-they are linearly equivalent. -/
-lemma weightedAbelJacobiDivisorClass_one_eq_iff_linearlyEquivalent_of_degree_eq
-    (h : S.IsUnweightedDegreeZero) (x₀ : X) {D E : WeilDivisor X}
-    (hDE : degree D = degree E) :
-    S.weightedAbelJacobiDivisorClass (fun _ : X => (1 : ℤ)) h (x₀ := x₀) rfl D =
-        S.weightedAbelJacobiDivisorClass (fun _ : X => (1 : ℤ)) h (x₀ := x₀) rfl E ↔
-      S.LinearlyEquivalent D E := by
-  refine S.weightedAbelJacobiDivisorClass_eq_iff_linearlyEquivalent_of_weightedDegree_eq
-    (fun _ : X => (1 : ℤ)) h (x₀ := x₀) rfl ?_
-  simpa only [weightedDegree_one_eq_degree] using hDE
-
 /-! ### Fixed-degree effective divisors -/
 
 variable {d : ℕ}

--- a/TauCeti/AlgebraicGeometry/WeilDivisor/AbelJacobiLinearSystem.lean
+++ b/TauCeti/AlgebraicGeometry/WeilDivisor/AbelJacobiLinearSystem.lean
@@ -1,0 +1,172 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+module
+
+public import TauCeti.AlgebraicGeometry.WeilDivisor.AbelJacobiFixedDegree
+public import TauCeti.AlgebraicGeometry.WeilDivisor.LinearSystem
+
+/-!
+# Abel-Jacobi fibers and complete linear systems
+
+This file records the formal fixed-degree fiber statement for the divisor-class shadow of the
+Abel-Jacobi map.  The existing map
+
+`D ↦ [D - deg(D) • [x₀]] ∈ Pic⁰`
+
+is defined on all Weil divisors as `OrderSystem.weightedAbelJacobiDivisorClass`.  On effective
+divisors of a fixed degree, two divisors have the same normalized Abel-Jacobi class exactly when
+they are linearly equivalent; equivalently, one lies in the complete linear system of the other.
+The same statement is restated for Mathlib's symmetric powers through the existing equivalence
+between `Sym X d` and effective divisors of degree `d`.
+
+This is the formal-divisor version of the classical fact that the fibers of the Abel map
+`Symᵈ X → Pic⁰ X`, `D ↦ 𝒪_X(D - d·x₀)`, are complete linear systems.  It advances
+`TauCetiRoadmap/JacobianChallenge/README.md`, Layer C/D, the symmetric-power Abel-map lane
+`D ↦ 𝒪_X(D - d·x₀)`, using the abstract divisor class group available before line bundles,
+the Picard scheme, or the Jacobian variety exist.  No external mathematics is vendored.
+-/
+
+public section
+
+namespace TauCeti
+
+namespace AlgebraicGeometry
+
+namespace WeilDivisor
+
+variable {X G : Type*} [AddCommGroup G]
+
+namespace OrderSystem
+
+variable (S : OrderSystem X G)
+
+noncomputable section
+
+/-! ### Equal-degree Abel-Jacobi classes -/
+
+/-- If two divisors have the same weighted degree, equality of their weighted Abel-Jacobi
+classes is exactly linear equivalence of the original divisors.
+
+The equal-degree hypothesis is essential: the Abel-Jacobi class only records the `Pic⁰`
+component of the divisor class after subtracting the same degree from the chosen base point. -/
+lemma weightedAbelJacobiDivisorClass_eq_iff_linearlyEquivalent_of_weightedDegree_eq
+    (w : X → ℤ) (h : S.IsWeightedDegreeZero w) {x₀ : X} (hx₀ : w x₀ = 1)
+    {D E : WeilDivisor X} (hDE : weightedDegree w D = weightedDegree w E) :
+    S.weightedAbelJacobiDivisorClass w h hx₀ D =
+        S.weightedAbelJacobiDivisorClass w h hx₀ E ↔
+      S.LinearlyEquivalent D E := by
+  rw [S.weightedAbelJacobiDivisorClass_eq_iff_linearlyEquivalent w h hx₀, hDE]
+  constructor
+  · intro hlin
+    have hlin' :=
+      LinearlyEquivalent.add_right (S := S) hlin (weightedDegree w E • ofPoint x₀)
+    simpa only [sub_add_cancel] using hlin'
+  · intro hlin
+    have hlin' :=
+      LinearlyEquivalent.add_right (S := S) hlin (-(weightedDegree w E • ofPoint x₀))
+    simpa only [sub_eq_add_neg] using hlin'
+
+/-- In the unweighted theory, equal-degree divisors have the same Abel-Jacobi class exactly when
+they are linearly equivalent. -/
+lemma weightedAbelJacobiDivisorClass_one_eq_iff_linearlyEquivalent_of_degree_eq
+    (h : S.IsUnweightedDegreeZero) (x₀ : X) {D E : WeilDivisor X}
+    (hDE : degree D = degree E) :
+    S.weightedAbelJacobiDivisorClass (fun _ : X => (1 : ℤ)) h (x₀ := x₀) rfl D =
+        S.weightedAbelJacobiDivisorClass (fun _ : X => (1 : ℤ)) h (x₀ := x₀) rfl E ↔
+      S.LinearlyEquivalent D E := by
+  refine S.weightedAbelJacobiDivisorClass_eq_iff_linearlyEquivalent_of_weightedDegree_eq
+    (fun _ : X => (1 : ℤ)) h (x₀ := x₀) rfl ?_
+  simpa only [weightedDegree_one_eq_degree] using hDE
+
+/-! ### Fixed-degree effective divisors -/
+
+variable {d : ℕ}
+
+/-- For effective divisors of the same fixed degree, equality of normalized Abel-Jacobi
+classes is exactly linear equivalence of the underlying divisors. -/
+lemma weightedAbelJacobiDivisorClass_effectiveDivisorOfDegree_eq_iff_linearlyEquivalent
+    (h : S.IsUnweightedDegreeZero) (x₀ : X)
+    (D E : EffectiveDivisorOfDegree X d) :
+    S.weightedAbelJacobiDivisorClass (fun _ : X => (1 : ℤ)) h (x₀ := x₀) rfl
+        (D : WeilDivisor X) =
+        S.weightedAbelJacobiDivisorClass (fun _ : X => (1 : ℤ)) h (x₀ := x₀) rfl
+          (E : WeilDivisor X) ↔
+      S.LinearlyEquivalent (D : WeilDivisor X) E := by
+  refine S.weightedAbelJacobiDivisorClass_one_eq_iff_linearlyEquivalent_of_degree_eq
+    h x₀ ?_
+  rw [D.degree_eq, E.degree_eq]
+
+/-- The fixed-degree Abel-Jacobi fiber through `D` is the complete linear system `|D|`, restricted
+to effective divisors of the same degree. -/
+lemma weightedAbelJacobiDivisorClass_effectiveDivisorOfDegree_eq_iff_mem_completeLinearSystem
+    (h : S.IsUnweightedDegreeZero) (x₀ : X)
+    (D E : EffectiveDivisorOfDegree X d) :
+    S.weightedAbelJacobiDivisorClass (fun _ : X => (1 : ℤ)) h (x₀ := x₀) rfl
+        (E : WeilDivisor X) =
+        S.weightedAbelJacobiDivisorClass (fun _ : X => (1 : ℤ)) h (x₀ := x₀) rfl
+          (D : WeilDivisor X) ↔
+      (E : WeilDivisor X) ∈ S.completeLinearSystem (D : WeilDivisor X) := by
+  rw [S.weightedAbelJacobiDivisorClass_effectiveDivisorOfDegree_eq_iff_linearlyEquivalent
+    h x₀ E D, S.mem_completeLinearSystem]
+  constructor
+  · intro hlin
+    exact ⟨E.isEffective, hlin.symm⟩
+  · exact fun hE => hE.2.symm
+
+/-- As a set of fixed-degree effective divisors, the Abel-Jacobi fiber through `D` is the
+restriction of the complete linear system `|D|`. -/
+lemma setOf_weightedAbelJacobiDivisorClass_effectiveDivisorOfDegree_eq
+    (h : S.IsUnweightedDegreeZero) (x₀ : X)
+    (D : EffectiveDivisorOfDegree X d) :
+    {E : EffectiveDivisorOfDegree X d |
+        S.weightedAbelJacobiDivisorClass (fun _ : X => (1 : ℤ)) h (x₀ := x₀) rfl
+          (E : WeilDivisor X) =
+        S.weightedAbelJacobiDivisorClass (fun _ : X => (1 : ℤ)) h (x₀ := x₀) rfl
+          (D : WeilDivisor X)} =
+      {E : EffectiveDivisorOfDegree X d |
+        (E : WeilDivisor X) ∈ S.completeLinearSystem (D : WeilDivisor X)} := by
+  ext E
+  exact S.weightedAbelJacobiDivisorClass_effectiveDivisorOfDegree_eq_iff_mem_completeLinearSystem
+    h x₀ D E
+
+/-! ### Symmetric powers -/
+
+/-- On symmetric powers, equality of normalized Abel-Jacobi classes is exactly membership of the
+corresponding divisor in the complete linear system. -/
+lemma weightedAbelJacobiDivisorClass_ofSym_eq_iff_mem_completeLinearSystem
+    (h : S.IsUnweightedDegreeZero) (x₀ : X) (s t : Sym X d) :
+    S.weightedAbelJacobiDivisorClass (fun _ : X => (1 : ℤ)) h (x₀ := x₀) rfl
+        (EffectiveDivisorOfDegree.ofSym t : WeilDivisor X) =
+        S.weightedAbelJacobiDivisorClass (fun _ : X => (1 : ℤ)) h (x₀ := x₀) rfl
+          (EffectiveDivisorOfDegree.ofSym s : WeilDivisor X) ↔
+      (EffectiveDivisorOfDegree.ofSym t : WeilDivisor X) ∈
+        S.completeLinearSystem (EffectiveDivisorOfDegree.ofSym s : WeilDivisor X) :=
+  S.weightedAbelJacobiDivisorClass_effectiveDivisorOfDegree_eq_iff_mem_completeLinearSystem
+    h x₀ (EffectiveDivisorOfDegree.ofSym s) (EffectiveDivisorOfDegree.ofSym t)
+
+/-- As a set of symmetric-power points, the Abel-Jacobi fiber through `s` is the preimage of the
+complete linear system `|ofSym s|`. -/
+lemma setOf_weightedAbelJacobiDivisorClass_ofSym_eq
+    (h : S.IsUnweightedDegreeZero) (x₀ : X) (s : Sym X d) :
+    {t : Sym X d |
+        S.weightedAbelJacobiDivisorClass (fun _ : X => (1 : ℤ)) h (x₀ := x₀) rfl
+          (EffectiveDivisorOfDegree.ofSym t : WeilDivisor X) =
+        S.weightedAbelJacobiDivisorClass (fun _ : X => (1 : ℤ)) h (x₀ := x₀) rfl
+          (EffectiveDivisorOfDegree.ofSym s : WeilDivisor X)} =
+      {t : Sym X d |
+        (EffectiveDivisorOfDegree.ofSym t : WeilDivisor X) ∈
+          S.completeLinearSystem (EffectiveDivisorOfDegree.ofSym s : WeilDivisor X)} := by
+  ext t
+  exact S.weightedAbelJacobiDivisorClass_ofSym_eq_iff_mem_completeLinearSystem h x₀ s t
+
+end
+
+end OrderSystem
+
+end WeilDivisor
+
+end AlgebraicGeometry
+
+end TauCeti

--- a/TauCeti/AlgebraicGeometry/WeilDivisor/AbelJacobiSum.lean
+++ b/TauCeti/AlgebraicGeometry/WeilDivisor/AbelJacobiSum.lean
@@ -157,6 +157,40 @@ lemma weightedAbelJacobiDivisorClass_eq_iff_linearlyEquivalent
         (E - weightedDegree w E • ofPoint x₀) := by
   rw [S.weightedAbelJacobiDivisorClass_eq_iff_divisorClass w h hx₀, S.divisorClass_eq_iff]
 
+/-- If two divisors have the same weighted degree, equality of their weighted Abel-Jacobi
+classes is exactly linear equivalence of the original divisors.
+
+The equal-degree hypothesis is essential: the Abel-Jacobi class only records the `Pic⁰`
+component of the divisor class after subtracting the same degree from the chosen base point. -/
+lemma weightedAbelJacobiDivisorClass_eq_iff_linearlyEquivalent_of_weightedDegree_eq
+    (w : X → ℤ) (h : S.IsWeightedDegreeZero w) {x₀ : X} (hx₀ : w x₀ = 1)
+    {D E : WeilDivisor X} (hDE : weightedDegree w D = weightedDegree w E) :
+    S.weightedAbelJacobiDivisorClass w h hx₀ D =
+        S.weightedAbelJacobiDivisorClass w h hx₀ E ↔
+      S.LinearlyEquivalent D E := by
+  rw [S.weightedAbelJacobiDivisorClass_eq_iff_linearlyEquivalent w h hx₀, hDE]
+  constructor
+  · intro hlin
+    have hlin' :=
+      LinearlyEquivalent.add_right (S := S) hlin (weightedDegree w E • ofPoint x₀)
+    simpa only [sub_add_cancel] using hlin'
+  · intro hlin
+    have hlin' :=
+      LinearlyEquivalent.add_right (S := S) hlin (-(weightedDegree w E • ofPoint x₀))
+    simpa only [sub_eq_add_neg] using hlin'
+
+/-- In the unweighted theory, equal-degree divisors have the same Abel-Jacobi class exactly when
+they are linearly equivalent. -/
+lemma weightedAbelJacobiDivisorClass_one_eq_iff_linearlyEquivalent_of_degree_eq
+    (h : S.IsUnweightedDegreeZero) (x₀ : X) {D E : WeilDivisor X}
+    (hDE : degree D = degree E) :
+    S.weightedAbelJacobiDivisorClass (fun _ : X => (1 : ℤ)) h (x₀ := x₀) rfl D =
+        S.weightedAbelJacobiDivisorClass (fun _ : X => (1 : ℤ)) h (x₀ := x₀) rfl E ↔
+      S.LinearlyEquivalent D E := by
+  refine S.weightedAbelJacobiDivisorClass_eq_iff_linearlyEquivalent_of_weightedDegree_eq
+    (fun _ : X => (1 : ℤ)) h (x₀ := x₀) rfl ?_
+  simpa only [weightedDegree_one_eq_degree] using hDE
+
 /-- The Abel-Jacobi sum is invariant under linear equivalence of divisors with the same
 weighted degree. -/
 lemma weightedAbelJacobiDivisorClass_eq_of_linearlyEquivalent


### PR DESCRIPTION
This PR identifies the formal fixed-degree fibers of the divisor-level Abel-Jacobi map with complete linear systems. It adds `OrderSystem.weightedAbelJacobiDivisorClass_eq_iff_linearlyEquivalent_of_weightedDegree_eq`, then specializes it to equal ordinary degree, fixed-degree effective divisors, and symmetric powers: for `D E : EffectiveDivisorOfDegree X d`, the normalized classes `[E - d·x₀]` and `[D - d·x₀]` in abstract `Pic⁰` agree exactly when `E ∈ |D|`. This is the formal-divisor version of the classical fiber statement for `Symᵈ X → Pic⁰ X`.

The target is `TauCetiRoadmap/JacobianChallenge/README.md`, Layer C/D, "Relative effective Cartier divisors and symmetric powers `Symᵈ X`" and the Abel-map lane "`AJ_d : Symᵈ X → Pic^d`, `D ↦ 𝒪_X(D)`, normalized to `Pic⁰` by `D ↦ 𝒪_X(D − d·x₀)`". I chose it as the lowest-hanging distinct JacobianChallenge prerequisite after checking open PRs and the recently merged degree-zero-generator PR: it uses the already-landed formal Weil-divisor, complete-linear-system, fixed-degree, and Abel-Jacobi APIs without starting the missing scheme-level Picard or symmetric-power geometry.

No Mathlib infrastructure is vendored. The proof reuses Tau Ceti's `OrderSystem.weightedAbelJacobiDivisorClass_eq_iff_linearlyEquivalent`, `OrderSystem.completeLinearSystem`, and `EffectiveDivisorOfDegree.ofSym` API, plus Mathlib's quotient-group equality already wrapped by Tau Ceti's divisor-class layer.

`lake exe cache get` completed with `No files to download` and `Already decompressed 8619 file(s)`. `lake build` reported `Build completed successfully (4698 jobs).` `lake exe axioms` reported `axioms: audited 8859 TauCeti declaration(s); all within the allowlist [propext, Classical.choice, Quot.sound].`

<!--tauceti-target:v1 {"focus":"JacobianChallenge","id":"abel-map-fibers-complete-linear-systems"}-->

🤖 Prepared with Codex
