### PR TITLE
feat: the residue of the logarithmic derivative is the meromorphic order

### DIFF
--- a/TauCeti/Analysis/Contour/ArgumentPrinciple.lean
+++ b/TauCeti/Analysis/Contour/ArgumentPrinciple.lean
@@ -96,8 +96,9 @@ private lemma logDeriv_zpow_sub_mul {g : ℂ → ℂ} {c z : ℂ} {n : ℤ} (hz 
 meromorphic of order `n`, the logarithmic derivative equals its simple-pole principal part
 `n · (· - s)⁻¹` plus an analytic term: there is `g` analytic and non-vanishing at `s` (the local
 factor of `F = (· - s) ^ n • g`) with `logDeriv F = n · (· - s)⁻¹ + logDeriv g` on a punctured
-neighbourhood of `s`. -/
-private lemma logDeriv_eventuallyEq_principalPart {F : ℂ → ℂ} {s : ℂ} {n : ℤ}
+neighbourhood of `s`. Exposed for the residue-form of the argument principle
+(`TauCeti.Contour.residue_logDeriv`). -/
+theorem logDeriv_eventuallyEq_principalPart {F : ℂ → ℂ} {s : ℂ} {n : ℤ}
     (hF : MeromorphicAt F s) (hn : meromorphicOrderAt F s = (n : WithTop ℤ)) :
     ∃ g : ℂ → ℂ, AnalyticAt ℂ g s ∧ g s ≠ 0 ∧
       logDeriv F =ᶠ[𝓝[≠] s] fun z => (n : ℂ) * (z - s)⁻¹ + logDeriv g z := by

--- a/TauCeti/Analysis/Contour/ArgumentPrinciple.lean
+++ b/TauCeti/Analysis/Contour/ArgumentPrinciple.lean
@@ -65,8 +65,9 @@ open scoped Real
 namespace TauCeti.Contour
 
 /-- At a point where a function is analytic and non-vanishing, its logarithmic derivative
-`logDeriv f = deriv f / f` is analytic. -/
-private lemma analyticAt_logDeriv_of_analyticAt {f : ℂ → ℂ} {z : ℂ} (hf : AnalyticAt ℂ f z)
+`logDeriv f = deriv f / f` is analytic. Exposed for the residue-form of the argument principle
+(`TauCeti.Contour.residue_logDeriv_eq_meromorphicOrderAt`). -/
+lemma analyticAt_logDeriv_of_analyticAt {f : ℂ → ℂ} {z : ℂ} (hf : AnalyticAt ℂ f z)
     (hz : f z ≠ 0) : AnalyticAt ℂ (logDeriv f) z := by
   rw [logDeriv]
   exact hf.deriv.div hf hz
@@ -97,7 +98,7 @@ meromorphic of order `n`, the logarithmic derivative equals its simple-pole prin
 `n · (· - s)⁻¹` plus an analytic term: there is `g` analytic and non-vanishing at `s` (the local
 factor of `F = (· - s) ^ n • g`) with `logDeriv F = n · (· - s)⁻¹ + logDeriv g` on a punctured
 neighbourhood of `s`. Exposed for the residue-form of the argument principle
-(`TauCeti.Contour.residue_logDeriv`). -/
+(`TauCeti.Contour.residue_logDeriv_eq_meromorphicOrderAt`). -/
 theorem logDeriv_eventuallyEq_principalPart {F : ℂ → ℂ} {s : ℂ} {n : ℤ}
     (hF : MeromorphicAt F s) (hn : meromorphicOrderAt F s = (n : WithTop ℤ)) :
     ∃ g : ℂ → ℂ, AnalyticAt ℂ g s ∧ g s ≠ 0 ∧

--- a/TauCeti/Analysis/Contour/ResidueLogDeriv.lean
+++ b/TauCeti/Analysis/Contour/ResidueLogDeriv.lean
@@ -70,7 +70,9 @@ theorem residue_logDeriv_eq_meromorphicOrderAt {f : ℂ → ℂ} {z₀ : ℂ} {n
   have hA : MeromorphicAt (fun z => (n : ℂ) * (z - z₀)⁻¹) z₀ :=
     analyticAt_const.meromorphicAt.mul (meromorphicAt_sub_inv z₀)
   have hB : MeromorphicAt (logDeriv g) z₀ := hlogg_an.meromorphicAt
-  -- The residue only sees the germ, so pass to the split form and add residues.
+  -- The residue only sees the germ, so pass to the split form and add residues. The `show`
+  -- unfolds `Pi.add`, putting the pointwise sum into the function-sum form expected by
+  -- `residue_add`.
   rw [residue_congr_nhdsNE hgerm,
     show (fun z => (n : ℂ) * (z - z₀)⁻¹ + logDeriv g z)
         = (fun z => (n : ℂ) * (z - z₀)⁻¹) + logDeriv g from rfl,

--- a/TauCeti/Analysis/Contour/ResidueLogDeriv.lean
+++ b/TauCeti/Analysis/Contour/ResidueLogDeriv.lean
@@ -22,16 +22,13 @@ The mechanism is the simple-pole splitting of the logarithmic derivative
 (`TauCeti.Contour.logDeriv_eventuallyEq_principalPart`): near `z₀` there is `g` analytic and
 non-vanishing with `logDeriv f = n · (· − z₀)⁻¹ + logDeriv g` on a punctured neighbourhood. The
 analytic tail `logDeriv g` contributes no residue, so only the simple-pole principal part
-`n · (· − z₀)⁻¹` survives, and `residue (fun z => (z − z₀)⁻¹) z₀ = 1`.
-
-The two elementary simple-pole residues used along the way are recorded as reusable lemmas: the
-residue of `(· − z₀)⁻¹` is `1`, and the residue of `c · (· − z₀)⁻¹` is `c`.
+`n · (· − z₀)⁻¹` survives, whose residue is `n` by
+`TauCeti.Contour.residue_const_mul_sub_inv` (the elementary simple-pole residues live in
+`TauCeti.Analysis.Contour.ResidueSimplePole`).
 
 ## Main results
 
-* `TauCeti.Contour.residue_sub_inv` — `residue (fun z => (z − z₀)⁻¹) z₀ = 1`.
-* `TauCeti.Contour.residue_const_mul_sub_inv` — `residue (fun z => c · (z − z₀)⁻¹) z₀ = c`.
-* `TauCeti.Contour.residue_logDeriv` — `residue (logDeriv f) z₀ = n` when
+* `TauCeti.Contour.residue_logDeriv_eq_meromorphicOrderAt` — `residue (logDeriv f) z₀ = n` when
   `meromorphicOrderAt f z₀ = n`: the residue of `f'/f` is the order of `f` at `z₀`.
 
 These are Layer 2 targets of the contour-integration roadmap, feeding the argument principle and,
@@ -58,40 +55,20 @@ open Filter Topology Complex
 
 namespace TauCeti.Contour
 
-/-- The residue of the elementary simple pole `(· − z₀)⁻¹` at `z₀` is `1`: since
-`(z − z₀) · (z − z₀)⁻¹ → 1` as `z → z₀`, the simple-pole limit formula gives the residue. -/
-theorem residue_sub_inv (z₀ : ℂ) : residue (fun z => (z - z₀)⁻¹) z₀ = 1 := by
-  have hmero : MeromorphicAt (fun z => (z - z₀)⁻¹) z₀ :=
-    ((analyticAt_id.sub analyticAt_const).meromorphicAt).inv
-  refine residue_eq_of_tendsto_sub_mul hmero (tendsto_const_nhds.congr' ?_)
-  filter_upwards [self_mem_nhdsWithin] with z hz
-  exact (mul_inv_cancel₀ (sub_ne_zero.2 hz)).symm
-
-/-- The residue of `c · (· − z₀)⁻¹` at `z₀` is `c`: scaling the elementary simple pole scales its
-residue. -/
-theorem residue_const_mul_sub_inv (c z₀ : ℂ) :
-    residue (fun z => c * (z - z₀)⁻¹) z₀ = c := by
-  have hmero : MeromorphicAt (fun z => (z - z₀)⁻¹) z₀ :=
-    ((analyticAt_id.sub analyticAt_const).meromorphicAt).inv
-  rw [residue_const_mul c hmero, residue_sub_inv, mul_one]
-
 /-- **The residue of the logarithmic derivative is the meromorphic order.** If `f` is meromorphic at
 `z₀` of order `n` (`meromorphicOrderAt f z₀ = n`), then `residue (logDeriv f) z₀ = n`: the residue
 of `f'/f` counts the order of `f` at `z₀` — positive at a zero, negative at a pole. This is the
 local, residue-form of the argument principle `TauCeti.Contour.argumentPrinciple`, the identity
 `Res_{z₀}(f'/f) = ord_{z₀} f`. -/
-theorem residue_logDeriv {f : ℂ → ℂ} {z₀ : ℂ} {n : ℤ} (hf : MeromorphicAt f z₀)
-    (hn : meromorphicOrderAt f z₀ = (n : WithTop ℤ)) :
+theorem residue_logDeriv_eq_meromorphicOrderAt {f : ℂ → ℂ} {z₀ : ℂ} {n : ℤ}
+    (hf : MeromorphicAt f z₀) (hn : meromorphicOrderAt f z₀ = (n : WithTop ℤ)) :
     residue (logDeriv f) z₀ = (n : ℂ) := by
   -- Near `z₀`, `logDeriv f` splits into its simple-pole principal part `n · (· − z₀)⁻¹` plus the
   -- analytic tail `logDeriv g` (with `g` the analytic non-vanishing local factor of `f`).
   obtain ⟨g, hg_an, hg_ne, hgerm⟩ := logDeriv_eventuallyEq_principalPart hf hn
-  have hlogg_an : AnalyticAt ℂ (logDeriv g) z₀ := by
-    rw [logDeriv]; exact hg_an.deriv.div hg_an hg_ne
-  have hmero_inv : MeromorphicAt (fun z => (z - z₀)⁻¹) z₀ :=
-    ((analyticAt_id.sub analyticAt_const).meromorphicAt).inv
+  have hlogg_an : AnalyticAt ℂ (logDeriv g) z₀ := analyticAt_logDeriv_of_analyticAt hg_an hg_ne
   have hA : MeromorphicAt (fun z => (n : ℂ) * (z - z₀)⁻¹) z₀ :=
-    analyticAt_const.meromorphicAt.mul hmero_inv
+    analyticAt_const.meromorphicAt.mul (meromorphicAt_sub_inv z₀)
   have hB : MeromorphicAt (logDeriv g) z₀ := hlogg_an.meromorphicAt
   -- The residue only sees the germ, so pass to the split form and add residues.
   rw [residue_congr_nhdsNE hgerm,

--- a/TauCeti/Analysis/Contour/ResidueLogDeriv.lean
+++ b/TauCeti/Analysis/Contour/ResidueLogDeriv.lean
@@ -1,0 +1,104 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Chris Birkbeck
+-/
+module
+
+public import TauCeti.Analysis.Contour.ArgumentPrinciple
+public import TauCeti.Analysis.Contour.ResidueSimplePole
+
+/-!
+# The residue of the logarithmic derivative is the meromorphic order
+
+For `f : ℂ → ℂ` meromorphic at `z₀` of order `n = meromorphicOrderAt f z₀`, the residue of the
+logarithmic derivative there is exactly that order:
+`TauCeti.Contour.residue (logDeriv f) z₀ = n`. This is the residue-form of the argument principle,
+the identity `Res_{z₀}(f'/f) = ord_{z₀} f` that the roadmap names as the local statement its
+contour form (`TauCeti.Contour.argumentPrinciple`) integrates: a zero of order `k` contributes
+`+k` and a pole of order `k` contributes `−k`.
+
+The mechanism is the simple-pole splitting of the logarithmic derivative
+(`TauCeti.Contour.logDeriv_eventuallyEq_principalPart`): near `z₀` there is `g` analytic and
+non-vanishing with `logDeriv f = n · (· − z₀)⁻¹ + logDeriv g` on a punctured neighbourhood. The
+analytic tail `logDeriv g` contributes no residue, so only the simple-pole principal part
+`n · (· − z₀)⁻¹` survives, and `residue (fun z => (z − z₀)⁻¹) z₀ = 1`.
+
+The two elementary simple-pole residues used along the way are recorded as reusable lemmas: the
+residue of `(· − z₀)⁻¹` is `1`, and the residue of `c · (· − z₀)⁻¹` is `c`.
+
+## Main results
+
+* `TauCeti.Contour.residue_sub_inv` — `residue (fun z => (z − z₀)⁻¹) z₀ = 1`.
+* `TauCeti.Contour.residue_const_mul_sub_inv` — `residue (fun z => c · (z − z₀)⁻¹) z₀ = c`.
+* `TauCeti.Contour.residue_logDeriv` — `residue (logDeriv f) z₀ = n` when
+  `meromorphicOrderAt f z₀ = n`: the residue of `f'/f` is the order of `f` at `z₀`.
+
+These are Layer 2 targets of the contour-integration roadmap, feeding the argument principle and,
+ultimately, the valence formula's interior-orbit sum.
+
+## Provenance
+
+The simple-pole splitting `logDeriv_eventuallyEq_principalPart` and the residue API are adapted from
+the AINTLIB `LeanModularForms` project (the argument-principle and residue material of
+`ForMathlib/GeneralizedResidueTheory/Residue.lean` and
+`.../Residue/GeneralizedTheoremBase.lean`, where the residue theorem is applied to `logDeriv f`),
+here specialised to Mathlib's `meromorphicOrderAt` API and the raw-function design of the
+contour-integration roadmap.
+
+## References
+
+* N. Hungerbühler, M. Wasem, *Non-integer valued winding numbers and a generalized Residue
+  Theorem*, arXiv:1808.00997.
+-/
+
+public section
+
+open Filter Topology Complex
+
+namespace TauCeti.Contour
+
+/-- The residue of the elementary simple pole `(· − z₀)⁻¹` at `z₀` is `1`: since
+`(z − z₀) · (z − z₀)⁻¹ → 1` as `z → z₀`, the simple-pole limit formula gives the residue. -/
+theorem residue_sub_inv (z₀ : ℂ) : residue (fun z => (z - z₀)⁻¹) z₀ = 1 := by
+  have hmero : MeromorphicAt (fun z => (z - z₀)⁻¹) z₀ :=
+    ((analyticAt_id.sub analyticAt_const).meromorphicAt).inv
+  refine residue_eq_of_tendsto_sub_mul hmero (tendsto_const_nhds.congr' ?_)
+  filter_upwards [self_mem_nhdsWithin] with z hz
+  exact (mul_inv_cancel₀ (sub_ne_zero.2 hz)).symm
+
+/-- The residue of `c · (· − z₀)⁻¹` at `z₀` is `c`: scaling the elementary simple pole scales its
+residue. -/
+theorem residue_const_mul_sub_inv (c z₀ : ℂ) :
+    residue (fun z => c * (z - z₀)⁻¹) z₀ = c := by
+  have hmero : MeromorphicAt (fun z => (z - z₀)⁻¹) z₀ :=
+    ((analyticAt_id.sub analyticAt_const).meromorphicAt).inv
+  rw [residue_const_mul c hmero, residue_sub_inv, mul_one]
+
+/-- **The residue of the logarithmic derivative is the meromorphic order.** If `f` is meromorphic at
+`z₀` of order `n` (`meromorphicOrderAt f z₀ = n`), then `residue (logDeriv f) z₀ = n`: the residue
+of `f'/f` counts the order of `f` at `z₀` — positive at a zero, negative at a pole. This is the
+local, residue-form of the argument principle `TauCeti.Contour.argumentPrinciple`, the identity
+`Res_{z₀}(f'/f) = ord_{z₀} f`. -/
+theorem residue_logDeriv {f : ℂ → ℂ} {z₀ : ℂ} {n : ℤ} (hf : MeromorphicAt f z₀)
+    (hn : meromorphicOrderAt f z₀ = (n : WithTop ℤ)) :
+    residue (logDeriv f) z₀ = (n : ℂ) := by
+  -- Near `z₀`, `logDeriv f` splits into its simple-pole principal part `n · (· − z₀)⁻¹` plus the
+  -- analytic tail `logDeriv g` (with `g` the analytic non-vanishing local factor of `f`).
+  obtain ⟨g, hg_an, hg_ne, hgerm⟩ := logDeriv_eventuallyEq_principalPart hf hn
+  have hlogg_an : AnalyticAt ℂ (logDeriv g) z₀ := by
+    rw [logDeriv]; exact hg_an.deriv.div hg_an hg_ne
+  have hmero_inv : MeromorphicAt (fun z => (z - z₀)⁻¹) z₀ :=
+    ((analyticAt_id.sub analyticAt_const).meromorphicAt).inv
+  have hA : MeromorphicAt (fun z => (n : ℂ) * (z - z₀)⁻¹) z₀ :=
+    analyticAt_const.meromorphicAt.mul hmero_inv
+  have hB : MeromorphicAt (logDeriv g) z₀ := hlogg_an.meromorphicAt
+  -- The residue only sees the germ, so pass to the split form and add residues.
+  rw [residue_congr_nhdsNE hgerm,
+    show (fun z => (n : ℂ) * (z - z₀)⁻¹ + logDeriv g z)
+        = (fun z => (n : ℂ) * (z - z₀)⁻¹) + logDeriv g from rfl,
+    residue_add hA hB, residue_const_mul_sub_inv, residue_eq_zero_of_analyticAt hlogg_an, add_zero]
+
+end TauCeti.Contour
+
+end

--- a/TauCeti/Analysis/Contour/ResidueSimplePole.lean
+++ b/TauCeti/Analysis/Contour/ResidueSimplePole.lean
@@ -37,6 +37,9 @@ direction one uses in practice to read off a residue.
   f z₀` (at most a simple pole); the analytic case gives the limit `0 = residue f z₀`.
 * `TauCeti.Contour.residue_eq_of_tendsto_sub_mul` — the converse: if `f` is meromorphic at `z₀` and
   `(z − z₀) · f z` converges to `L`, then `residue f z₀ = L`.
+* `TauCeti.Contour.residue_sub_inv` — `residue (fun z => (z − z₀)⁻¹) z₀ = 1`, and
+  `TauCeti.Contour.residue_const_mul_sub_inv` — `residue (fun z => c · (z − z₀)⁻¹) z₀ = c`: the
+  elementary simple-pole residues, read off from the converse rule.
 
 ## Provenance
 
@@ -133,6 +136,25 @@ theorem residue_eq_of_tendsto_sub_mul {L : ℂ} (hf : MeromorphicAt f z₀)
     (tendsto_nhds_iff_meromorphicOrderAt_nonneg hg).1 ⟨L, h⟩
   rw [meromorphicOrderAt_sub_mul hf] at hgnn
   exact tendsto_nhds_unique (tendsto_sub_mul_nhds_residue hf (neg_one_le_of_zero_le_one_add hgnn)) h
+
+/-- The reciprocal `(· − z₀)⁻¹` of the simple factor `(· − z₀)` is meromorphic at `z₀`. -/
+theorem meromorphicAt_sub_inv (z₀ : ℂ) : MeromorphicAt (fun z => (z - z₀)⁻¹) z₀ :=
+  ((analyticAt_id.sub analyticAt_const).meromorphicAt).inv
+
+/-- The residue of the elementary simple pole `(· − z₀)⁻¹` at `z₀` is `1`: since
+`(z − z₀) · (z − z₀)⁻¹ → 1` as `z → z₀`, the simple-pole limit formula gives the residue. -/
+@[simp]
+theorem residue_sub_inv (z₀ : ℂ) : residue (fun z => (z - z₀)⁻¹) z₀ = 1 := by
+  refine residue_eq_of_tendsto_sub_mul (meromorphicAt_sub_inv z₀) (tendsto_const_nhds.congr' ?_)
+  filter_upwards [self_mem_nhdsWithin] with z hz
+  exact (mul_inv_cancel₀ (sub_ne_zero.2 hz)).symm
+
+/-- The residue of `c · (· − z₀)⁻¹` at `z₀` is `c`: scaling the elementary simple pole scales its
+residue. -/
+@[simp]
+theorem residue_const_mul_sub_inv (c z₀ : ℂ) :
+    residue (fun z => c * (z - z₀)⁻¹) z₀ = c := by
+  rw [residue_const_mul c (meromorphicAt_sub_inv z₀), residue_sub_inv, mul_one]
 
 end TauCeti.Contour
 


### PR DESCRIPTION
This PR adds `residue_logDeriv`, the local residue-form of the argument principle: for `f` meromorphic at `z₀` of order `n` (`meromorphicOrderAt f z₀ = n`), the residue of the logarithmic derivative there is exactly that order, `residue (logDeriv f) z₀ = n`. This is the identity `Res_{z₀}(f'/f) = ord_{z₀} f` that `TauCetiRoadmap/ContourIntegration/README.md` names as the pointwise statement its contour form integrates ("the argument principle ... `Res_z (f'/f) = ord_z f`", Layer 2), and which `TauCeti/Analysis/Contour/ArgumentPrinciple.lean` already refers to in prose without stating. A zero of order `k` contributes `+k`, a pole of order `k` contributes `−k`. Along the way it records the two elementary simple-pole residues it rests on, `residue (fun z => (z − z₀)⁻¹) z₀ = 1` and `residue (fun z => c · (z − z₀)⁻¹) z₀ = c`, as reusable lemmas.

The proof reuses the simple-pole splitting `logDeriv_eventuallyEq_principalPart` in `ArgumentPrinciple.lean` (`logDeriv f = n · (· − z₀)⁻¹ + logDeriv g` near `z₀`, with `g` analytic and non-vanishing), which is exposed from `private` to support the new theorem; the analytic tail `logDeriv g` carries no residue, so only the simple-pole principal part survives. The splitting lemma and the residue API are adapted from the AINTLIB `LeanModularForms` project (the argument-principle and residue material of `ForMathlib/GeneralizedResidueTheory/Residue.lean` and `.../Residue/GeneralizedTheoremBase.lean`), stated here against Mathlib's `meromorphicOrderAt` API.

<!--tauceti-target:v1 {"focus":"ContourIntegration","id":"residue-logderiv-eq-order"}-->

🤖 Prepared with Claude Code
