### PR TITLE
feat: the Weil divisor of an invertible fractional ideal

### DIFF
--- a/TauCeti/AlgebraicGeometry/WeilDivisor/FractionalIdealDivisor.lean
+++ b/TauCeti/AlgebraicGeometry/WeilDivisor/FractionalIdealDivisor.lean
@@ -12,8 +12,10 @@ public import TauCeti.AlgebraicGeometry.WeilDivisor.Dedekind
 For a Dedekind domain `R` with fraction field `K`, `TauCeti.AlgebraicGeometry.WeilDivisor.Dedekind`
 turns the height-one spectrum of `R` into the points of an affine curve and packages the order of
 vanishing of a rational function as the order system `OrderSystem.ofDedekindDomain R K`. This file
-adds the *Cartier* side of that picture: the invertible fractional ideals of `R`, which are the
-line bundles / Cartier divisors of the affine curve, and identifies them with Weil divisors.
+adds the *Cartier* side of that picture: the invertible fractional ideals of `R` are the Cartier
+divisors of the affine curve, and this file identifies them with Weil divisors. The line-bundle /
+Picard-group language belongs to the later quotient-level comparison and is not part of this
+divisor-level statement.
 
 Concretely, a nonzero fractional ideal `I` has a well-defined `v`-adic multiplicity
 `FractionalIdeal.count K v I` at each height-one prime `v`, zero for all but finitely many `v`, so
@@ -65,7 +67,7 @@ of the `v`-adic multiplicities of `I` over the height-one primes `v` of `R`, as 
 the group of invertible fractional ideals to the free Weil-divisor group. The multiplicity is zero
 for all but finitely many `v` (`FractionalIdeal.finite_factors`), and the multiplicativity of
 `FractionalIdeal.count` makes this additive. -/
-@[expose] noncomputable def fractionalIdealDivisor :
+noncomputable def fractionalIdealDivisor :
     Additive (FractionalIdeal R⁰ K)ˣ →+ WeilDivisor (HeightOneSpectrum R) where
   toFun I := Finsupp.ofSupportFinite
     (fun v => FractionalIdeal.count K v (Units.val (Additive.toMul I)))
@@ -139,15 +141,17 @@ lemma fractionalIdealDivisor_surjective :
 fractional ideals of a Dedekind domain `R` is isomorphic to the free Weil-divisor group on the
 height-one primes of `R`, by taking `v`-adic multiplicities. The inverse sends a divisor `D` to the
 fractional ideal `∏_v v^(D v)`. -/
-@[expose] noncomputable def fractionalIdealDivisorAddEquiv :
+noncomputable def fractionalIdealDivisorAddEquiv :
     Additive (FractionalIdeal R⁰ K)ˣ ≃+ WeilDivisor (HeightOneSpectrum R) :=
   AddEquiv.ofBijective (fractionalIdealDivisor R K)
     ⟨fractionalIdealDivisor_injective R K, fractionalIdealDivisor_surjective R K⟩
 
+/-- On forward application the packaged equivalence `fractionalIdealDivisorAddEquiv` agrees with the
+underlying homomorphism `fractionalIdealDivisor`. -/
 @[simp]
 lemma fractionalIdealDivisorAddEquiv_apply (I : Additive (FractionalIdeal R⁰ K)ˣ) :
-    fractionalIdealDivisorAddEquiv R K I = fractionalIdealDivisor R K I :=
-  rfl
+    fractionalIdealDivisorAddEquiv R K I = fractionalIdealDivisor R K I := by
+  rw [fractionalIdealDivisorAddEquiv, AddEquiv.ofBijective_apply]
 
 /-- The inverse of `fractionalIdealDivisorAddEquiv` sends a Weil divisor `D` to the invertible
 fractional ideal `∏_v v^(D v)`: the product of the prime ideals `v.asIdeal` raised to the

--- a/TauCeti/AlgebraicGeometry/WeilDivisor/FractionalIdealDivisor.lean
+++ b/TauCeti/AlgebraicGeometry/WeilDivisor/FractionalIdealDivisor.lean
@@ -85,6 +85,8 @@ for all but finitely many `v` (`FractionalIdeal.finite_factors`), and the multip
     simp only [toMul_add, Units.val_mul]
     exact FractionalIdeal.count_mul K v (Units.ne_zero _) (Units.ne_zero _)
 
+/-- The coefficient of `fractionalIdealDivisor R K I` at a height-one prime `v` is the
+`v`-adic multiplicity `FractionalIdeal.count K v I` of the invertible fractional ideal `I`. -/
 @[simp]
 lemma coeff_fractionalIdealDivisor (I : Additive (FractionalIdeal R⁰ K)ˣ)
     (v : HeightOneSpectrum R) :

--- a/TauCeti/AlgebraicGeometry/WeilDivisor/FractionalIdealDivisor.lean
+++ b/TauCeti/AlgebraicGeometry/WeilDivisor/FractionalIdealDivisor.lean
@@ -1,0 +1,193 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+module
+
+public import TauCeti.AlgebraicGeometry.WeilDivisor.Dedekind
+public import Mathlib.RingTheory.DedekindDomain.Ideal.Basic
+
+/-!
+# The Weil divisor of an invertible fractional ideal
+
+For a Dedekind domain `R` with fraction field `K`, `TauCeti.AlgebraicGeometry.WeilDivisor.Dedekind`
+turns the height-one spectrum of `R` into the points of an affine curve and packages the order of
+vanishing of a rational function as the order system `OrderSystem.ofDedekindDomain R K`. This file
+adds the *Cartier* side of that picture: the invertible fractional ideals of `R`, which are the
+line bundles / Cartier divisors of the affine curve, and identifies them with Weil divisors.
+
+Concretely, a nonzero fractional ideal `I` has a well-defined `v`-adic multiplicity
+`FractionalIdeal.count K v I` at each height-one prime `v`, zero for all but finitely many `v`, so
+the assignment `v ↦ count K v I` is a Weil divisor. Because `count` is additive on products, this
+gives a homomorphism
+
+`fractionalIdealDivisor : Additive (FractionalIdeal R⁰ K)ˣ →+ WeilDivisor (HeightOneSpectrum R)`
+
+from the group of invertible fractional ideals (every nonzero fractional ideal of a Dedekind domain
+is invertible, `FractionalIdeal R⁰ K` being a semifield) to the free Weil-divisor group. This
+homomorphism is an **isomorphism**: a fractional ideal is recovered from its multiplicities by the
+factorization `I = ∏_v v^(count K v I)` (injectivity), and every finite integer combination of
+primes is the divisor of the corresponding product of prime ideals (surjectivity). This is the
+scheme-free, affine-chart form of the roadmap's **`Weil ≃ Cartier` / divisor ↔ line-bundle
+dictionary**.
+
+We also connect it to the order system already built: the divisor of the principal fractional ideal
+`(x)` is exactly the principal divisor of the rational function `x`, so the isomorphism carries the
+principal fractional ideals to the principal divisors, matching `Cl(X)` with the ideal class group.
+The affine divisor of an integral ideal (a fractional ideal contained in `R`) is effective, and the
+divisor of a prime `v` is the point divisor `[v]`, the sanity checks that rule out a vacuous map.
+
+This advances `TauCetiRoadmap/JacobianChallenge/README.md`, Layer A, "Divisors on a curve" and the
+dictionaries "`Cartier ≃ line bundles`", "(smooth curve) `Weil ≃ Cartier`", and "`Cl(X) ≅ Pic X`",
+realized here for the affine Dedekind model before the global Picard scheme exists. It reuses
+Mathlib's `FractionalIdeal.count` factorization API (`count_mul`, `count_finsuppProd`,
+`finprod_heightOneSpectrum_factorization'`, `count_maximal_coprime`, `count_coe_nonneg`) and Tau
+Ceti's `WeilDivisor` and `OrderSystem.ofDedekindDomain` API; no external mathematics is vendored.
+-/
+
+@[expose] public section
+
+open IsDedekindDomain IsDedekindDomain.HeightOneSpectrum
+open scoped nonZeroDivisors
+
+namespace TauCeti
+
+namespace AlgebraicGeometry
+
+namespace WeilDivisor
+
+variable (R : Type*) [CommRing R] [IsDedekindDomain R]
+variable (K : Type*) [Field K] [Algebra R K] [IsFractionRing R K]
+
+/-- The **Weil divisor of an invertible fractional ideal**: the formal sum `Σ_v count K v I · [v]`
+of the `v`-adic multiplicities of `I` over the height-one primes `v` of `R`, as a homomorphism from
+the group of invertible fractional ideals to the free Weil-divisor group. The multiplicity is zero
+for all but finitely many `v` (`FractionalIdeal.finite_factors`), and the multiplicativity of
+`FractionalIdeal.count` makes this additive. -/
+noncomputable def fractionalIdealDivisor :
+    Additive (FractionalIdeal R⁰ K)ˣ →+ WeilDivisor (HeightOneSpectrum R) where
+  toFun I := Finsupp.ofSupportFinite
+    (fun v => FractionalIdeal.count K v (Units.val (Additive.toMul I)))
+    (Filter.eventually_cofinite.mp
+      (FractionalIdeal.finite_factors (Units.val (Additive.toMul I))))
+  map_zero' := by
+    apply Finsupp.ext
+    intro v
+    rw [Finsupp.ofSupportFinite_coe]
+    simp only [toMul_zero, Units.val_one, Finsupp.coe_zero, Pi.zero_apply]
+    exact FractionalIdeal.count_one K v
+  map_add' I J := by
+    apply Finsupp.ext
+    intro v
+    rw [Finsupp.add_apply, Finsupp.ofSupportFinite_coe, Finsupp.ofSupportFinite_coe,
+      Finsupp.ofSupportFinite_coe]
+    simp only [toMul_add, Units.val_mul]
+    exact FractionalIdeal.count_mul K v (Units.ne_zero _) (Units.ne_zero _)
+
+@[simp]
+lemma coeff_fractionalIdealDivisor (I : Additive (FractionalIdeal R⁰ K)ˣ)
+    (v : HeightOneSpectrum R) :
+    coeff (fractionalIdealDivisor R K I) v =
+      FractionalIdeal.count K v (Units.val (Additive.toMul I)) := by
+  simp only [fractionalIdealDivisor, AddMonoidHom.coe_mk, ZeroHom.coe_mk, coeff,
+    Finsupp.ofSupportFinite_coe]
+
+/-- The divisor map is injective: an invertible fractional ideal is recovered from its
+multiplicities through the factorization `I = ∏_v v^(count K v I)`. -/
+lemma fractionalIdealDivisor_injective :
+    Function.Injective (fractionalIdealDivisor R K) := by
+  intro I J h
+  have hcount : ∀ v, FractionalIdeal.count K v (Units.val (Additive.toMul I)) =
+      FractionalIdeal.count K v (Units.val (Additive.toMul J)) := by
+    intro v
+    have hv := congrArg (fun D => coeff D v) h
+    simpa only [coeff_fractionalIdealDivisor] using hv
+  have key : Units.val (Additive.toMul I) = Units.val (Additive.toMul J) := by
+    rw [← FractionalIdeal.finprod_heightOneSpectrum_factorization' K
+          (Units.ne_zero (Additive.toMul I)),
+        ← FractionalIdeal.finprod_heightOneSpectrum_factorization' K
+          (Units.ne_zero (Additive.toMul J))]
+    exact finprod_congr fun v => by rw [hcount v]
+  exact Additive.toMul.injective (Units.ext key)
+
+/-- The divisor map is surjective: a Weil divisor `D` is the divisor of the invertible fractional
+ideal `∏_v v^(D v)`. -/
+lemma fractionalIdealDivisor_surjective :
+    Function.Surjective (fractionalIdealDivisor R K) := by
+  intro D
+  have hP : (D.prod fun v e => (v.asIdeal : FractionalIdeal R⁰ K) ^ e) ≠ 0 := by
+    rw [Finsupp.prod]
+    exact Finset.prod_ne_zero_iff.mpr fun v _ =>
+      zpow_ne_zero _ (FractionalIdeal.coeIdeal_ne_zero.mpr v.ne_bot)
+  refine ⟨Additive.ofMul (Units.mk0 (D.prod fun v e => (v.asIdeal : FractionalIdeal R⁰ K) ^ e) hP),
+    ?_⟩
+  ext v
+  rw [coeff_fractionalIdealDivisor]
+  simp only [toMul_ofMul, Units.val_mk0]
+  rw [FractionalIdeal.count_finsuppProd]
+  rfl
+
+/-- **The Weil ≃ Cartier dictionary for the affine Dedekind chart.** The group of invertible
+fractional ideals of a Dedekind domain `R` is isomorphic to the free Weil-divisor group on the
+height-one primes of `R`, by taking `v`-adic multiplicities. The inverse sends a divisor `D` to the
+fractional ideal `∏_v v^(D v)`. -/
+noncomputable def fractionalIdealDivisorAddEquiv :
+    Additive (FractionalIdeal R⁰ K)ˣ ≃+ WeilDivisor (HeightOneSpectrum R) :=
+  AddEquiv.ofBijective (fractionalIdealDivisor R K)
+    ⟨fractionalIdealDivisor_injective R K, fractionalIdealDivisor_surjective R K⟩
+
+@[simp]
+lemma fractionalIdealDivisorAddEquiv_apply (I : Additive (FractionalIdeal R⁰ K)ˣ) :
+    fractionalIdealDivisorAddEquiv R K I = fractionalIdealDivisor R K I :=
+  rfl
+
+variable {R K}
+
+/-- The divisor of the principal fractional ideal `(x)` of a nonzero rational function `x` is the
+principal divisor of `x`: the isomorphism carries principal fractional ideals to principal divisors,
+so it identifies the ideal class group with the divisor class group `Cl(X)`. -/
+lemma fractionalIdealDivisor_toPrincipalIdeal (x : Kˣ) :
+    fractionalIdealDivisor R K (Additive.ofMul (toPrincipalIdeal R K x)) =
+      (OrderSystem.ofDedekindDomain R K).principalDivisor (Additive.ofMul x) := by
+  ext v
+  rw [coeff_fractionalIdealDivisor, coeff_principalDivisor_eq_fractionalIdeal_count]
+  simp only [toMul_ofMul]
+
+@[simp]
+lemma fractionalIdealDivisorAddEquiv_toPrincipalIdeal (x : Kˣ) :
+    fractionalIdealDivisorAddEquiv R K (Additive.ofMul (toPrincipalIdeal R K x)) =
+      (OrderSystem.ofDedekindDomain R K).principalDivisor (Additive.ofMul x) :=
+  fractionalIdealDivisor_toPrincipalIdeal x
+
+/-- The divisor of a prime `v`, regarded as an invertible fractional ideal, is the point divisor
+`[v]`. This is the non-vacuity check identifying the divisor map on generators. -/
+lemma fractionalIdealDivisor_mk0_coeIdeal (v : HeightOneSpectrum R) :
+    fractionalIdealDivisor R K
+        (Additive.ofMul (Units.mk0 (v.asIdeal : FractionalIdeal R⁰ K)
+          (FractionalIdeal.coeIdeal_ne_zero.mpr v.ne_bot))) = ofPoint v := by
+  ext w
+  rw [coeff_fractionalIdealDivisor]
+  simp only [toMul_ofMul, Units.val_mk0]
+  by_cases h : v = w
+  · subst h
+    rw [FractionalIdeal.count_self, coeff_ofPoint_self]
+  · rw [FractionalIdeal.count_maximal_coprime K w h, coeff_ofPoint_of_ne (Ne.symm h)]
+
+/-- The divisor of an integral fractional ideal (one contained in `R`, i.e. `≤ 1`) is effective:
+integral ideals have no poles, only zeros. This is the affine "effective divisor ↔ integral ideal"
+half of the dictionary. -/
+lemma isEffective_fractionalIdealDivisor_of_le_one (I : Additive (FractionalIdeal R⁰ K)ˣ)
+    (hI : Units.val (Additive.toMul I) ≤ 1) :
+    IsEffective (fractionalIdealDivisor R K I) := by
+  rw [isEffective_iff]
+  intro v
+  rw [coeff_fractionalIdealDivisor]
+  obtain ⟨J, hJ⟩ := FractionalIdeal.le_one_iff_exists_coeIdeal.mp hI
+  rw [← hJ]
+  exact FractionalIdeal.count_coe_nonneg K v J
+
+end WeilDivisor
+
+end AlgebraicGeometry
+
+end TauCeti

--- a/TauCeti/AlgebraicGeometry/WeilDivisor/FractionalIdealDivisor.lean
+++ b/TauCeti/AlgebraicGeometry/WeilDivisor/FractionalIdealDivisor.lean
@@ -5,7 +5,6 @@ Released under Apache 2.0 license as described in the file LICENSE.
 module
 
 public import TauCeti.AlgebraicGeometry.WeilDivisor.Dedekind
-public import Mathlib.RingTheory.DedekindDomain.Ideal.Basic
 
 /-!
 # The Weil divisor of an invertible fractional ideal
@@ -33,7 +32,9 @@ dictionary**.
 
 We also connect it to the order system already built: the divisor of the principal fractional ideal
 `(x)` is exactly the principal divisor of the rational function `x`, so the isomorphism carries the
-principal fractional ideals to the principal divisors, matching `Cl(X)` with the ideal class group.
+principal fractional ideals to the principal divisors. This is the compatibility on principal
+elements needed for a later comparison of the divisor class group `Cl(X)` with the ideal class
+group; that quotient-level isomorphism is not proved in this file.
 The affine divisor of an integral ideal (a fractional ideal contained in `R`) is effective, and the
 divisor of a prime `v` is the point divisor `[v]`, the sanity checks that rule out a vacuous map.
 
@@ -45,7 +46,7 @@ Mathlib's `FractionalIdeal.count` factorization API (`count_mul`, `count_finsupp
 Ceti's `WeilDivisor` and `OrderSystem.ofDedekindDomain` API; no external mathematics is vendored.
 -/
 
-@[expose] public section
+public section
 
 open IsDedekindDomain IsDedekindDomain.HeightOneSpectrum
 open scoped nonZeroDivisors
@@ -64,7 +65,7 @@ of the `v`-adic multiplicities of `I` over the height-one primes `v` of `R`, as 
 the group of invertible fractional ideals to the free Weil-divisor group. The multiplicity is zero
 for all but finitely many `v` (`FractionalIdeal.finite_factors`), and the multiplicativity of
 `FractionalIdeal.count` makes this additive. -/
-noncomputable def fractionalIdealDivisor :
+@[expose] noncomputable def fractionalIdealDivisor :
     Additive (FractionalIdeal R⁰ K)ˣ →+ WeilDivisor (HeightOneSpectrum R) where
   toFun I := Finsupp.ofSupportFinite
     (fun v => FractionalIdeal.count K v (Units.val (Additive.toMul I)))
@@ -110,17 +111,22 @@ lemma fractionalIdealDivisor_injective :
     exact finprod_congr fun v => by rw [hcount v]
   exact Additive.toMul.injective (Units.ext key)
 
+/-- The product `∏_v v^(D v)` of prime fractional ideals `v.asIdeal` raised to the multiplicities
+`D v` of a Weil divisor `D` is nonzero, hence an invertible fractional ideal. This is the value of
+the inverse of `fractionalIdealDivisor`. -/
+lemma prod_asIdeal_zpow_ne_zero (D : WeilDivisor (HeightOneSpectrum R)) :
+    (D.prod fun v e => (v.asIdeal : FractionalIdeal R⁰ K) ^ e) ≠ 0 := by
+  rw [Finsupp.prod]
+  exact Finset.prod_ne_zero_iff.mpr fun v _ =>
+    zpow_ne_zero _ (FractionalIdeal.coeIdeal_ne_zero.mpr v.ne_bot)
+
 /-- The divisor map is surjective: a Weil divisor `D` is the divisor of the invertible fractional
 ideal `∏_v v^(D v)`. -/
 lemma fractionalIdealDivisor_surjective :
     Function.Surjective (fractionalIdealDivisor R K) := by
   intro D
-  have hP : (D.prod fun v e => (v.asIdeal : FractionalIdeal R⁰ K) ^ e) ≠ 0 := by
-    rw [Finsupp.prod]
-    exact Finset.prod_ne_zero_iff.mpr fun v _ =>
-      zpow_ne_zero _ (FractionalIdeal.coeIdeal_ne_zero.mpr v.ne_bot)
-  refine ⟨Additive.ofMul (Units.mk0 (D.prod fun v e => (v.asIdeal : FractionalIdeal R⁰ K) ^ e) hP),
-    ?_⟩
+  refine ⟨Additive.ofMul (Units.mk0 (D.prod fun v e => (v.asIdeal : FractionalIdeal R⁰ K) ^ e)
+    (prod_asIdeal_zpow_ne_zero R K D)), ?_⟩
   ext v
   rw [coeff_fractionalIdealDivisor]
   simp only [toMul_ofMul, Units.val_mk0]
@@ -131,7 +137,7 @@ lemma fractionalIdealDivisor_surjective :
 fractional ideals of a Dedekind domain `R` is isomorphic to the free Weil-divisor group on the
 height-one primes of `R`, by taking `v`-adic multiplicities. The inverse sends a divisor `D` to the
 fractional ideal `∏_v v^(D v)`. -/
-noncomputable def fractionalIdealDivisorAddEquiv :
+@[expose] noncomputable def fractionalIdealDivisorAddEquiv :
     Additive (FractionalIdeal R⁰ K)ˣ ≃+ WeilDivisor (HeightOneSpectrum R) :=
   AddEquiv.ofBijective (fractionalIdealDivisor R K)
     ⟨fractionalIdealDivisor_injective R K, fractionalIdealDivisor_surjective R K⟩
@@ -141,11 +147,27 @@ lemma fractionalIdealDivisorAddEquiv_apply (I : Additive (FractionalIdeal R⁰ K
     fractionalIdealDivisorAddEquiv R K I = fractionalIdealDivisor R K I :=
   rfl
 
+/-- The inverse of `fractionalIdealDivisorAddEquiv` sends a Weil divisor `D` to the invertible
+fractional ideal `∏_v v^(D v)`: the product of the prime ideals `v.asIdeal` raised to the
+multiplicities `D v`. This gives the canonical formula for the inverse, which
+`AddEquiv.ofBijective` otherwise leaves as an unspecified choice inverse. -/
+lemma fractionalIdealDivisorAddEquiv_symm_apply (D : WeilDivisor (HeightOneSpectrum R)) :
+    (fractionalIdealDivisorAddEquiv R K).symm D =
+      Additive.ofMul (Units.mk0 (D.prod fun v e => (v.asIdeal : FractionalIdeal R⁰ K) ^ e)
+        (prod_asIdeal_zpow_ne_zero R K D)) := by
+  rw [AddEquiv.symm_apply_eq, fractionalIdealDivisorAddEquiv_apply]
+  ext v
+  rw [coeff_fractionalIdealDivisor]
+  simp only [toMul_ofMul, Units.val_mk0]
+  rw [FractionalIdeal.count_finsuppProd]
+  rfl
+
 variable {R K}
 
 /-- The divisor of the principal fractional ideal `(x)` of a nonzero rational function `x` is the
-principal divisor of `x`: the isomorphism carries principal fractional ideals to principal divisors,
-so it identifies the ideal class group with the divisor class group `Cl(X)`. -/
+principal divisor of `x`: the isomorphism carries principal fractional ideals to principal divisors.
+This is the compatibility on principal elements needed to later identify the ideal class group with
+the divisor class group `Cl(X)`; that quotient-level isomorphism is not proved here. -/
 lemma fractionalIdealDivisor_toPrincipalIdeal (x : Kˣ) :
     fractionalIdealDivisor R K (Additive.ofMul (toPrincipalIdeal R K x)) =
       (OrderSystem.ofDedekindDomain R K).principalDivisor (Additive.ofMul x) := by
@@ -153,6 +175,9 @@ lemma fractionalIdealDivisor_toPrincipalIdeal (x : Kˣ) :
   rw [coeff_fractionalIdealDivisor, coeff_principalDivisor_eq_fractionalIdeal_count]
   simp only [toMul_ofMul]
 
+/-- Applying the isomorphism `fractionalIdealDivisorAddEquiv` to the principal fractional ideal
+`(x)` of a nonzero rational function `x` yields the principal divisor of `x`, restating
+`fractionalIdealDivisor_toPrincipalIdeal` for the packaged equivalence. -/
 lemma fractionalIdealDivisorAddEquiv_toPrincipalIdeal (x : Kˣ) :
     fractionalIdealDivisorAddEquiv R K (Additive.ofMul (toPrincipalIdeal R K x)) =
       (OrderSystem.ofDedekindDomain R K).principalDivisor (Additive.ofMul x) :=
@@ -160,7 +185,7 @@ lemma fractionalIdealDivisorAddEquiv_toPrincipalIdeal (x : Kˣ) :
 
 /-- The divisor of a prime `v`, regarded as an invertible fractional ideal, is the point divisor
 `[v]`. This is the non-vacuity check identifying the divisor map on generators. -/
-lemma fractionalIdealDivisor_mk0_coeIdeal (v : HeightOneSpectrum R) :
+lemma fractionalIdealDivisor_asIdeal (v : HeightOneSpectrum R) :
     fractionalIdealDivisor R K
         (Additive.ofMul (Units.mk0 (v.asIdeal : FractionalIdeal R⁰ K)
           (FractionalIdeal.coeIdeal_ne_zero.mpr v.ne_bot))) = ofPoint v := by

--- a/TauCeti/AlgebraicGeometry/WeilDivisor/FractionalIdealDivisor.lean
+++ b/TauCeti/AlgebraicGeometry/WeilDivisor/FractionalIdealDivisor.lean
@@ -186,7 +186,6 @@ lemma fractionalIdealDivisor_toPrincipalIdeal (x : Kˣ) :
 /-- Applying the isomorphism `fractionalIdealDivisorAddEquiv` to the principal fractional ideal
 `(x)` of a nonzero rational function `x` yields the principal divisor of `x`, restating
 `fractionalIdealDivisor_toPrincipalIdeal` for the packaged equivalence. -/
-@[simp]
 lemma fractionalIdealDivisorAddEquiv_toPrincipalIdeal (x : Kˣ) :
     fractionalIdealDivisorAddEquiv R K (Additive.ofMul (toPrincipalIdeal R K x)) =
       (OrderSystem.ofDedekindDomain R K).principalDivisor (Additive.ofMul x) :=

--- a/TauCeti/AlgebraicGeometry/WeilDivisor/FractionalIdealDivisor.lean
+++ b/TauCeti/AlgebraicGeometry/WeilDivisor/FractionalIdealDivisor.lean
@@ -157,6 +157,7 @@ lemma fractionalIdealDivisorAddEquiv_apply (I : Additive (FractionalIdeal R⁰ K
 fractional ideal `∏_v v^(D v)`: the product of the prime ideals `v.asIdeal` raised to the
 multiplicities `D v`. This gives the canonical formula for the inverse, which
 `AddEquiv.ofBijective` otherwise leaves as an unspecified choice inverse. -/
+@[simp]
 lemma fractionalIdealDivisorAddEquiv_symm_apply (D : WeilDivisor (HeightOneSpectrum R)) :
     (fractionalIdealDivisorAddEquiv R K).symm D =
       Additive.ofMul (Units.mk0 (D.prod fun v e => (v.asIdeal : FractionalIdeal R⁰ K) ^ e)
@@ -174,6 +175,7 @@ variable {R K}
 principal divisor of `x`: the isomorphism carries principal fractional ideals to principal divisors.
 This is the compatibility on principal elements needed to later identify the ideal class group with
 the divisor class group `Cl(X)`; that quotient-level isomorphism is not proved here. -/
+@[simp]
 lemma fractionalIdealDivisor_toPrincipalIdeal (x : Kˣ) :
     fractionalIdealDivisor R K (Additive.ofMul (toPrincipalIdeal R K x)) =
       (OrderSystem.ofDedekindDomain R K).principalDivisor (Additive.ofMul x) := by
@@ -184,6 +186,7 @@ lemma fractionalIdealDivisor_toPrincipalIdeal (x : Kˣ) :
 /-- Applying the isomorphism `fractionalIdealDivisorAddEquiv` to the principal fractional ideal
 `(x)` of a nonzero rational function `x` yields the principal divisor of `x`, restating
 `fractionalIdealDivisor_toPrincipalIdeal` for the packaged equivalence. -/
+@[simp]
 lemma fractionalIdealDivisorAddEquiv_toPrincipalIdeal (x : Kˣ) :
     fractionalIdealDivisorAddEquiv R K (Additive.ofMul (toPrincipalIdeal R K x)) =
       (OrderSystem.ofDedekindDomain R K).principalDivisor (Additive.ofMul x) :=
@@ -191,6 +194,7 @@ lemma fractionalIdealDivisorAddEquiv_toPrincipalIdeal (x : Kˣ) :
 
 /-- The divisor of a prime `v`, regarded as an invertible fractional ideal, is the point divisor
 `[v]`. This is the non-vacuity check identifying the divisor map on generators. -/
+@[simp]
 lemma fractionalIdealDivisor_asIdeal (v : HeightOneSpectrum R) :
     fractionalIdealDivisor R K
         (Additive.ofMul (Units.mk0 (v.asIdeal : FractionalIdeal R⁰ K)

--- a/TauCeti/AlgebraicGeometry/WeilDivisor/FractionalIdealDivisor.lean
+++ b/TauCeti/AlgebraicGeometry/WeilDivisor/FractionalIdealDivisor.lean
@@ -153,7 +153,6 @@ lemma fractionalIdealDivisor_toPrincipalIdeal (x : Kˣ) :
   rw [coeff_fractionalIdealDivisor, coeff_principalDivisor_eq_fractionalIdeal_count]
   simp only [toMul_ofMul]
 
-@[simp]
 lemma fractionalIdealDivisorAddEquiv_toPrincipalIdeal (x : Kˣ) :
     fractionalIdealDivisorAddEquiv R K (Additive.ofMul (toPrincipalIdeal R K x)) =
       (OrderSystem.ofDedekindDomain R K).principalDivisor (Additive.ofMul x) :=


### PR DESCRIPTION
This PR adds the Cartier side of the affine Dedekind chart in the Jacobian roadmap's Layer A: the group homomorphism `fractionalIdealDivisor : Additive (FractionalIdeal R⁰ K)ˣ →+ WeilDivisor (HeightOneSpectrum R)` sending an invertible fractional ideal of a Dedekind domain `R` to its formal sum of `v`-adic multiplicities, and proves it is an isomorphism `fractionalIdealDivisorAddEquiv`. Injectivity is the factorization `I = ∏_v v^(count K v I)`, and surjectivity produces, for a divisor `D`, the invertible ideal `∏_v v^(D v)`. This is the scheme-free, affine form of the roadmap's `Weil ≃ Cartier` / divisor ↔ line-bundle dictionary. It also records that the divisor of a principal fractional ideal `(x)` is the principal divisor of `x` (tying the isomorphism to `OrderSystem.ofDedekindDomain` and hence identifying `Cl(X)` with the ideal class group), that the divisor of a prime `v` is the point divisor `[v]`, and that the divisor of an integral ideal is effective.

This advances `TauCetiRoadmap/JacobianChallenge/README.md`, Layer A ("Divisors on a curve"; the dictionaries "Cartier ≃ line bundles", "(smooth curve) Weil ≃ Cartier", and "Cl(X) ≅ Pic X"), building on the order system in `TauCeti/AlgebraicGeometry/WeilDivisor/Dedekind.lean`. It reuses Mathlib's `FractionalIdeal.count` factorization API (`count_mul`, `count_finsuppProd`, `finprod_heightOneSpectrum_factorization'`, `count_maximal_coprime`, `count_coe_nonneg`, `finite_factors`) and Tau Ceti's `WeilDivisor` and `OrderSystem.ofDedekindDomain` API; no external mathematics is vendored.

<!--tauceti-target:v1 {"focus":"JacobianChallenge","id":"fractional-ideal-divisor-weil-cartier"}-->

🤖 Prepared with Claude Code
