### PR TITLE
feat: define abelian varieties and their commutativity

### DIFF
--- a/TauCeti/AlgebraicGeometry/AbelianVariety/Basic.lean
+++ b/TauCeti/AlgebraicGeometry/AbelianVariety/Basic.lean
@@ -1,0 +1,133 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+module
+
+public import Mathlib.AlgebraicGeometry.Group.Abelian
+
+/-!
+# Abelian varieties
+
+This file opens the Jacobian roadmap's Layer E by defining an **abelian variety** over a field
+`K` and recording its first structural property, commutativity of the group law.
+
+Following Milne, an abelian variety is a *proper, geometrically integral group scheme* over `K`.
+Geometric integrality is the robust "variety" condition (it is the standing hypothesis of
+Mathlib's commutativity theorem and is stable under base change and insensitive to imperfect
+base fields); for a group scheme over a field it is equivalent to the more familiar
+smooth-plus-geometrically-connected packaging, which needs the harder "reduced connected group
+scheme is irreducible" input not yet in Mathlib. We therefore take geometric integrality as the
+definition and leave the smooth/connected reconciliation as later work.
+
+We bundle the data as a structure `AbelianVariety K`, so that later roadmap targets can write
+`JacobianVariety X x₀ : AbelianVariety k` and refer to `(JacobianVariety X x₀).toScheme` and
+its base changes, matching `TauCetiRoadmap/JacobianChallenge/Suggested.lean`. From the bundled
+hypotheses we derive:
+
+* `AbelianVariety.isCommMonObj`: the group law is commutative, straight from Mathlib's rigidity
+  theorem `AlgebraicGeometry.isCommMonObj_of_isProper_of_geometricallyIntegral`
+  (a proper geometrically integral group scheme over a field is commutative);
+* `AbelianVariety.isIntegral`: the underlying scheme is integral (hence nonempty, irreducible,
+  and reduced), since geometric integrality over the one-point base `Spec K` descends to
+  absolute integrality;
+* `AbelianVariety.baseChange`: the base change of an abelian variety along a field extension
+  `K → L` is again an abelian variety, since properness and geometric integrality are stable
+  under base change and the monoidal pullback functor carries the group-object structure.
+
+This advances `TauCetiRoadmap/JacobianChallenge/README.md`, Layer E, "Abelian variety = smooth,
+proper, geometrically connected group scheme over `k`; basic API ... Commutativity is automatic
+(rigidity, `Group/Abelian.lean`)", and the roadmap's base-change compatibility. No external
+mathematics is vendored; the proofs reuse Mathlib's `Over`/`GrpObj` monoidal API, the
+`GeometricallyIntegral`/`IsProper` morphism-property instances, and the commutativity theorem in
+`Mathlib.AlgebraicGeometry.Group.Abelian`.
+-/
+
+public section
+
+open CategoryTheory Limits MonoidalCategory CartesianMonoidalCategory AlgebraicGeometry
+
+namespace TauCeti
+
+namespace AlgebraicGeometry
+
+universe u
+
+/-- An **abelian variety** over a field `K`: a proper, geometrically integral group scheme over
+`Spec K`.
+
+The group-object structure lives on `toOver : Over (Spec (.of K))`; the underlying scheme is
+`toScheme = toOver.left`. The fields are the standing hypotheses of the theory: `grpObj` is the
+group law, `isProper` says the structure morphism to `Spec K` is proper, and
+`geometricallyIntegral` is the "variety" condition. -/
+structure AbelianVariety (K : Type u) [Field K] where
+  /-- The underlying group scheme over `Spec K`. -/
+  toOver : Over (Spec (.of K))
+  /-- The group-object structure on `toOver`. -/
+  grpObj : GrpObj toOver
+  /-- The structure morphism to `Spec K` is proper. -/
+  isProper : IsProper toOver.hom
+  /-- `toOver` is geometrically integral over `Spec K`: the "variety" condition. -/
+  geometricallyIntegral : GeometricallyIntegral toOver.hom
+
+namespace AbelianVariety
+
+variable {K : Type u} [Field K]
+
+attribute [instance] AbelianVariety.grpObj AbelianVariety.isProper
+  AbelianVariety.geometricallyIntegral
+
+/-- The underlying scheme of an abelian variety. -/
+noncomputable abbrev toScheme (A : AbelianVariety K) : Scheme.{u} :=
+  A.toOver.left
+
+/-- The group law of an abelian variety is commutative: a proper geometrically integral group
+scheme over a field is a commutative group object. This is the abstract rigidity theorem
+`AlgebraicGeometry.isCommMonObj_of_isProper_of_geometricallyIntegral`, packaged for the bundled
+`AbelianVariety`. -/
+instance isCommMonObj (A : AbelianVariety K) : IsCommMonObj A.toOver :=
+  isCommMonObj_of_isProper_of_geometricallyIntegral A.toOver
+
+/-- The underlying scheme of an abelian variety is integral: geometric integrality over the
+one-point base `Spec K` descends to absolute integrality. In particular the underlying space is
+nonempty, irreducible, and reduced. -/
+instance isIntegral (A : AbelianVariety K) : IsIntegral A.toScheme :=
+  GeometricallyIntegral.isIntegral_of_subsingleton A.toOver.hom
+
+/-! ### Base change along a field extension -/
+
+/-- The base change of an abelian variety along a field extension `K → L`, obtained by pulling
+back the group scheme along `Spec L → Spec K`.
+
+Properness and geometric integrality are stable under base change, and the monoidal pullback
+functor carries the group-object structure (`Functor.grpObjObj`), so the result is again an
+abelian variety. This realizes the roadmap's base-change compatibility of the Jacobian at the
+level of abelian varieties. -/
+@[expose] noncomputable def baseChange (A : AbelianVariety K) (L : Type u) [Field L]
+    [Algebra K L] : AbelianVariety L where
+  toOver := (Over.pullback (Spec.map (CommRingCat.ofHom (algebraMap K L)))).obj A.toOver
+  grpObj := Functor.grpObjObj
+  isProper := inferInstanceAs
+    (IsProper (Limits.pullback.snd A.toOver.hom (Spec.map (CommRingCat.ofHom (algebraMap K L)))))
+  geometricallyIntegral := inferInstanceAs
+    (GeometricallyIntegral (Limits.pullback.snd A.toOver.hom
+      (Spec.map (CommRingCat.ofHom (algebraMap K L)))))
+
+@[simp]
+lemma baseChange_toOver (A : AbelianVariety K) (L : Type u) [Field L] [Algebra K L] :
+    (A.baseChange L).toOver =
+      (Over.pullback (Spec.map (CommRingCat.ofHom (algebraMap K L)))).obj A.toOver :=
+  rfl
+
+/-- The underlying scheme of a base change is the fibre product of the abelian variety with
+`Spec L` over `Spec K`. -/
+lemma baseChange_toScheme (A : AbelianVariety K) (L : Type u) [Field L] [Algebra K L] :
+    (A.baseChange L).toScheme =
+      Limits.pullback A.toOver.hom (Spec.map (CommRingCat.ofHom (algebraMap K L))) :=
+  rfl
+
+end AbelianVariety
+
+end AlgebraicGeometry
+
+end TauCeti

--- a/TauCeti/AlgebraicGeometry/AbelianVariety/Basic.lean
+++ b/TauCeti/AlgebraicGeometry/AbelianVariety/Basic.lean
@@ -55,8 +55,10 @@ namespace AlgebraicGeometry
 
 universe u
 
-/-- A geometrically irreducible morphism is geometrically connected. -/
-lemma GeometricallyConnected.of_geometricallyIrreducible {X S : Scheme.{u}} {f : X ⟶ S}
+/-- A geometrically irreducible morphism is geometrically connected. Kept `private` as an
+implementation helper for `AbelianVariety.geometricallyConnected`; it is not part of the
+abelian-variety public interface. -/
+private lemma GeometricallyConnected.of_geometricallyIrreducible {X S : Scheme.{u}} {f : X ⟶ S}
     [GeometricallyIrreducible f] : GeometricallyConnected f := by
   refine ⟨?_⟩
   have h : geometrically (IrreducibleSpace ·) f :=

--- a/TauCeti/AlgebraicGeometry/AbelianVariety/Basic.lean
+++ b/TauCeti/AlgebraicGeometry/AbelianVariety/Basic.lean
@@ -5,6 +5,8 @@ Released under Apache 2.0 license as described in the file LICENSE.
 module
 
 public import Mathlib.AlgebraicGeometry.Group.Abelian
+public import Mathlib.AlgebraicGeometry.Group.Smooth
+public import Mathlib.AlgebraicGeometry.Geometrically.Connected
 
 /-!
 # Abelian varieties
@@ -16,9 +18,11 @@ Following Milne, an abelian variety is a *proper, geometrically integral group s
 Geometric integrality is the robust "variety" condition (it is the standing hypothesis of
 Mathlib's commutativity theorem and is stable under base change and insensitive to imperfect
 base fields); for a group scheme over a field it is equivalent to the more familiar
-smooth-plus-geometrically-connected packaging, which needs the harder "reduced connected group
-scheme is irreducible" input not yet in Mathlib. We therefore take geometric integrality as the
-definition and leave the smooth/connected reconciliation as later work.
+smooth-plus-geometrically-connected packaging. One direction of that equivalence is available and
+recorded below (`AbelianVariety.smooth`, `AbelianVariety.geometricallyConnected`), so the
+roadmap's smooth/connected interface is exposed; the reverse reconciliation needs the harder
+"reduced connected group scheme is irreducible" input not yet in Mathlib and is left as later
+work. We therefore take geometric integrality as the definition.
 
 We bundle the data as a structure `AbelianVariety K`, so that later roadmap targets can write
 `JacobianVariety X x₀ : AbelianVariety k` and refer to `(JacobianVariety X x₀).toScheme` and
@@ -31,6 +35,10 @@ hypotheses we derive:
 * `AbelianVariety.isIntegral`: the underlying scheme is integral (hence nonempty, irreducible,
   and reduced), since geometric integrality over the one-point base `Spec K` descends to
   absolute integrality;
+* `AbelianVariety.smooth` and `AbelianVariety.geometricallyConnected`: the structure morphism is
+  smooth (a geometrically reduced group scheme of finite type over a field is smooth) and
+  geometrically connected (geometric irreducibility gives connectedness), recovering the
+  roadmap's smooth/connected clauses from geometric integrality;
 * `AbelianVariety.baseChange`: the base change of an abelian variety along a field extension
   `K → L` is again an abelian variety, since properness and geometric integrality are stable
   under base change and the monoidal pullback functor carries the group-object structure.
@@ -94,6 +102,27 @@ nonempty, irreducible, and reduced. -/
 instance isIntegral (A : AbelianVariety K) : IsIntegral A.toScheme :=
   GeometricallyIntegral.isIntegral_of_subsingleton A.toOver.hom
 
+/-- An abelian variety is smooth over `Spec K`. This recovers the roadmap's "smooth" clause:
+a geometrically reduced group scheme locally of finite type over a field is smooth
+(`AlgebraicGeometry.smooth_of_grpObj`), and geometric integrality supplies geometric reducedness
+while properness supplies local finiteness of type. -/
+instance smooth (A : AbelianVariety K) : Smooth A.toOver.hom :=
+  haveI : GrpObj (Over.mk A.toOver.hom) := A.grpObj
+  smooth_of_grpObj A.toOver.hom
+
+/-- An abelian variety is geometrically connected over `Spec K`. This recovers the roadmap's
+"geometrically connected" clause: geometric integrality gives geometric irreducibility, and an
+irreducible space is connected. -/
+instance geometricallyConnected (A : AbelianVariety K) :
+    GeometricallyConnected A.toOver.hom where
+  geometrically_connectedSpace := by
+    have h : geometrically (IrreducibleSpace ·) A.toOver.hom :=
+      GeometricallyIrreducible.geometrically_irreducibleSpace ..
+    rw [geometrically_eq_universally] at h ⊢
+    refine MorphismProperty.universally_mono (fun {X Y} f hf hint hsub ↦ ?_) _ h
+    have := hf hint hsub
+    infer_instance
+
 /-! ### Base change along a field extension -/
 
 /-- The base change of an abelian variety along a field extension `K → L`, obtained by pulling
@@ -121,10 +150,11 @@ lemma baseChange_toOver (A : AbelianVariety K) (L : Type u) [Field L] [Algebra K
 
 /-- The underlying scheme of a base change is the fibre product of the abelian variety with
 `Spec L` over `Spec K`. -/
+@[simp]
 lemma baseChange_toScheme (A : AbelianVariety K) (L : Type u) [Field L] [Algebra K L] :
     (A.baseChange L).toScheme =
-      Limits.pullback A.toOver.hom (Spec.map (CommRingCat.ofHom (algebraMap K L))) :=
-  (rfl)
+      Limits.pullback A.toOver.hom (Spec.map (CommRingCat.ofHom (algebraMap K L))) := by
+  simp only [toScheme, baseChange_toOver, Over.pullback_obj_left]
 
 end AbelianVariety
 

--- a/TauCeti/AlgebraicGeometry/AbelianVariety/Basic.lean
+++ b/TauCeti/AlgebraicGeometry/AbelianVariety/Basic.lean
@@ -12,36 +12,31 @@ public import Mathlib.AlgebraicGeometry.Geometrically.Connected
 # Abelian varieties
 
 This file opens the Jacobian roadmap's Layer E by defining an **abelian variety** over a field
-`K` and recording its first structural property, commutativity of the group law.
+`K`.
 
-Following Milne, an abelian variety is a *proper, geometrically integral group scheme* over `K`.
-Geometric integrality is the robust "variety" condition (it is the standing hypothesis of
-Mathlib's commutativity theorem and is stable under base change and insensitive to imperfect
-base fields); for a group scheme over a field it is equivalent to the more familiar
-smooth-plus-geometrically-connected packaging. One direction of that equivalence is available and
-recorded below (`AbelianVariety.smooth`, `AbelianVariety.geometricallyConnected`), so the
-roadmap's smooth/connected interface is exposed; the reverse reconciliation needs the harder
-"reduced connected group scheme is irreducible" input not yet in Mathlib and is left as later
-work. We therefore take geometric integrality as the definition.
+Following the roadmap, an abelian variety is bundled as a smooth, proper, geometrically connected
+group scheme over `K`. Mathlib's current commutativity theorem assumes the stronger
+`GeometricallyIntegral` condition, so commutativity and absolute integrality are exposed below as
+conditional API under that hypothesis, together with a constructor from the geometrically integral
+package.
 
 We bundle the data as a structure `AbelianVariety K`, so that later roadmap targets can write
 `JacobianVariety X x₀ : AbelianVariety k` and refer to `(JacobianVariety X x₀).toScheme` and
 its base changes, matching `TauCetiRoadmap/JacobianChallenge/Suggested.lean`. From the bundled
 hypotheses we derive:
 
-* `AbelianVariety.isCommMonObj`: the group law is commutative, straight from Mathlib's rigidity
-  theorem `AlgebraicGeometry.isCommMonObj_of_isProper_of_geometricallyIntegral`
-  (a proper geometrically integral group scheme over a field is commutative);
-* `AbelianVariety.isIntegral`: the underlying scheme is integral (hence nonempty, irreducible,
-  and reduced), since geometric integrality over the one-point base `Spec K` descends to
-  absolute integrality;
-* `AbelianVariety.smooth` and `AbelianVariety.geometricallyConnected`: the structure morphism is
-  smooth (a geometrically reduced group scheme of finite type over a field is smooth) and
-  geometrically connected (geometric irreducibility gives connectedness), recovering the
-  roadmap's smooth/connected clauses from geometric integrality;
+* `AbelianVariety.isCommMonObj_of_geometricallyIntegral`: the group law is commutative, straight
+  from Mathlib's rigidity theorem
+  `AlgebraicGeometry.isCommMonObj_of_isProper_of_geometricallyIntegral` under the extra hypothesis
+  `GeometricallyIntegral A.toOver.hom`;
+* `AbelianVariety.isIntegral_of_geometricallyIntegral`: the underlying scheme is integral under
+  the same extra hypothesis;
+* `AbelianVariety.ofGeometricallyIntegral`: a constructor from the geometrically integral package
+  used by Mathlib's rigidity theorem;
 * `AbelianVariety.baseChange`: the base change of an abelian variety along a field extension
-  `K → L` is again an abelian variety, since properness and geometric integrality are stable
-  under base change and the monoidal pullback functor carries the group-object structure.
+  `K → L` is again an abelian variety, since properness, smoothness, and geometric connectedness
+  are stable under base change and the monoidal pullback functor carries the group-object
+  structure.
 
 This advances `TauCetiRoadmap/JacobianChallenge/README.md`, Layer E, "Abelian variety = smooth,
 proper, geometrically connected group scheme over `k`; basic API ... Commutativity is automatic
@@ -61,13 +56,13 @@ namespace AlgebraicGeometry
 
 universe u
 
-/-- An **abelian variety** over a field `K`: a proper, geometrically integral group scheme over
-`Spec K`.
+/-- An **abelian variety** over a field `K`: a smooth, proper, geometrically connected group
+scheme over `Spec K`.
 
 The group-object structure lives on `toOver : Over (Spec (.of K))`; the underlying scheme is
 `toScheme = toOver.left`. The fields are the standing hypotheses of the theory: `grpObj` is the
 group law, `isProper` says the structure morphism to `Spec K` is proper, and
-`geometricallyIntegral` is the "variety" condition. -/
+`smooth` and `geometricallyConnected` record the roadmap's geometric hypotheses. -/
 structure AbelianVariety (K : Type u) [Field K] where
   /-- The underlying group scheme over `Spec K`. -/
   toOver : Over (Spec (.of K))
@@ -75,48 +70,51 @@ structure AbelianVariety (K : Type u) [Field K] where
   grpObj : GrpObj toOver
   /-- The structure morphism to `Spec K` is proper. -/
   isProper : IsProper toOver.hom
-  /-- `toOver` is geometrically integral over `Spec K`: the "variety" condition. -/
-  geometricallyIntegral : GeometricallyIntegral toOver.hom
+  /-- The structure morphism to `Spec K` is smooth. -/
+  smooth : Smooth toOver.hom
+  /-- The structure morphism to `Spec K` is geometrically connected. -/
+  geometricallyConnected : GeometricallyConnected toOver.hom
 
 namespace AbelianVariety
 
 variable {K : Type u} [Field K]
 
-attribute [instance] AbelianVariety.grpObj AbelianVariety.isProper
-  AbelianVariety.geometricallyIntegral
+attribute [instance] AbelianVariety.grpObj AbelianVariety.isProper AbelianVariety.smooth
+  AbelianVariety.geometricallyConnected
 
 /-- The underlying scheme of an abelian variety. -/
 noncomputable abbrev toScheme (A : AbelianVariety K) : Scheme.{u} :=
   A.toOver.left
 
-/-- The group law of an abelian variety is commutative: a proper geometrically integral group
-scheme over a field is a commutative group object. This is the abstract rigidity theorem
-`AlgebraicGeometry.isCommMonObj_of_isProper_of_geometricallyIntegral`, packaged for the bundled
-`AbelianVariety`. -/
-instance isCommMonObj (A : AbelianVariety K) : IsCommMonObj A.toOver :=
+/-- The group law of a geometrically integral abelian variety is commutative: a proper
+geometrically integral group scheme over a field is a commutative group object. This is the
+abstract rigidity theorem `AlgebraicGeometry.isCommMonObj_of_isProper_of_geometricallyIntegral`,
+packaged for the bundled `AbelianVariety`. -/
+instance isCommMonObj_of_geometricallyIntegral (A : AbelianVariety K)
+    [GeometricallyIntegral A.toOver.hom] : IsCommMonObj A.toOver :=
   isCommMonObj_of_isProper_of_geometricallyIntegral A.toOver
 
-/-- The underlying scheme of an abelian variety is integral: geometric integrality over the
-one-point base `Spec K` descends to absolute integrality. In particular the underlying space is
-nonempty, irreducible, and reduced. -/
-instance isIntegral (A : AbelianVariety K) : IsIntegral A.toScheme :=
+/-- The underlying scheme of a geometrically integral abelian variety is integral: geometric
+integrality over the one-point base `Spec K` descends to absolute integrality. In particular the
+underlying space is nonempty, irreducible, and reduced. -/
+instance isIntegral_of_geometricallyIntegral (A : AbelianVariety K)
+    [GeometricallyIntegral A.toOver.hom] : IsIntegral A.toScheme :=
   GeometricallyIntegral.isIntegral_of_subsingleton A.toOver.hom
 
-/-- An abelian variety is smooth over `Spec K`. This recovers the roadmap's "smooth" clause:
-a geometrically reduced group scheme locally of finite type over a field is smooth
-(`AlgebraicGeometry.smooth_of_grpObj`), and geometric integrality supplies geometric reducedness
-while properness supplies local finiteness of type. -/
-instance smooth (A : AbelianVariety K) : Smooth A.toOver.hom :=
-  haveI : GrpObj (Over.mk A.toOver.hom) := A.grpObj
-  smooth_of_grpObj A.toOver.hom
-
-/-- An abelian variety is geometrically connected over `Spec K`. This recovers the roadmap's
-"geometrically connected" clause: geometric integrality gives geometric irreducibility, and an
-irreducible space is connected. -/
-instance geometricallyConnected (A : AbelianVariety K) :
-    GeometricallyConnected A.toOver.hom where
-  geometrically_connectedSpace := by
-    have h : geometrically (IrreducibleSpace ·) A.toOver.hom :=
+/-- A constructor for abelian varieties from Mathlib's geometrically integral package. For a group
+scheme locally of finite type over a field, geometric integrality supplies the smoothness and
+geometric connectedness hypotheses of `AbelianVariety`. -/
+noncomputable def ofGeometricallyIntegral (G : Over (Spec (.of K))) [GrpObj G]
+    [IsProper G.hom] [GeometricallyIntegral G.hom] : AbelianVariety K where
+  toOver := G
+  grpObj := inferInstance
+  isProper := inferInstance
+  smooth := by
+    haveI : GrpObj (Over.mk G.hom) := inferInstanceAs (GrpObj G)
+    exact smooth_of_grpObj G.hom
+  geometricallyConnected := by
+    refine ⟨?_⟩
+    have h : geometrically (IrreducibleSpace ·) G.hom :=
       GeometricallyIrreducible.geometrically_irreducibleSpace ..
     rw [geometrically_eq_universally] at h ⊢
     refine MorphismProperty.universally_mono (fun {X Y} f hf hint hsub ↦ ?_) _ h
@@ -128,18 +126,20 @@ instance geometricallyConnected (A : AbelianVariety K) :
 /-- The base change of an abelian variety along a field extension `K → L`, obtained by pulling
 back the group scheme along `Spec L → Spec K`.
 
-Properness and geometric integrality are stable under base change, and the monoidal pullback
-functor carries the group-object structure (`Functor.grpObjObj`), so the result is again an
-abelian variety. This realizes the roadmap's base-change compatibility of the Jacobian at the
-level of abelian varieties. -/
+Properness, smoothness, and geometric connectedness are stable under base change, and the
+monoidal pullback functor carries the group-object structure (`Functor.grpObjObj`), so the result
+is again an abelian variety. This realizes the roadmap's base-change compatibility of the Jacobian
+at the level of abelian varieties. -/
 noncomputable def baseChange (A : AbelianVariety K) (L : Type u) [Field L]
     [Algebra K L] : AbelianVariety L where
   toOver := (Over.pullback (Spec.map (CommRingCat.ofHom (algebraMap K L)))).obj A.toOver
   grpObj := Functor.grpObjObj
   isProper := inferInstanceAs
     (IsProper (Limits.pullback.snd A.toOver.hom (Spec.map (CommRingCat.ofHom (algebraMap K L)))))
-  geometricallyIntegral := inferInstanceAs
-    (GeometricallyIntegral (Limits.pullback.snd A.toOver.hom
+  smooth := inferInstanceAs
+    (Smooth (Limits.pullback.snd A.toOver.hom (Spec.map (CommRingCat.ofHom (algebraMap K L)))))
+  geometricallyConnected := inferInstanceAs
+    (GeometricallyConnected (Limits.pullback.snd A.toOver.hom
       (Spec.map (CommRingCat.ofHom (algebraMap K L)))))
 
 @[simp]

--- a/TauCeti/AlgebraicGeometry/AbelianVariety/Basic.lean
+++ b/TauCeti/AlgebraicGeometry/AbelianVariety/Basic.lean
@@ -45,7 +45,7 @@ mathematics is vendored; the proofs reuse Mathlib's `Over`/`GrpObj` monoidal API
 
 public section
 
-open CategoryTheory Limits MonoidalCategory CartesianMonoidalCategory AlgebraicGeometry
+open CategoryTheory Limits MonoidalCategory CartesianMonoidalCategory AlgebraicGeometry MonObj
 
 namespace TauCeti
 
@@ -130,6 +130,36 @@ lemma ofGeometricallyIntegral_toOver (G : Over (Spec (.of K))) [GrpObj G]
     (ofGeometricallyIntegral G).toOver = G :=
   (rfl)
 
+/-- The unit of `ofGeometricallyIntegral G` is the unit of `G`. -/
+@[simp]
+lemma ofGeometricallyIntegral_one (G : Over (Spec (.of K))) [GrpObj G]
+    [IsProper G.hom] [GeometricallyIntegral G.hom] :
+    η[(ofGeometricallyIntegral G).toOver] ≫
+        eqToHom (ofGeometricallyIntegral_toOver G) = η[G] := by
+  unfold ofGeometricallyIntegral
+  simp
+
+/-- The multiplication of `ofGeometricallyIntegral G` is the multiplication of `G`. -/
+@[simp]
+lemma ofGeometricallyIntegral_mul (G : Over (Spec (.of K))) [GrpObj G]
+    [IsProper G.hom] [GeometricallyIntegral G.hom] :
+    μ[(ofGeometricallyIntegral G).toOver] ≫
+        eqToHom (ofGeometricallyIntegral_toOver G) =
+      (eqToHom (ofGeometricallyIntegral_toOver G) ⊗ₘ
+          eqToHom (ofGeometricallyIntegral_toOver G)) ≫ μ[G] := by
+  unfold ofGeometricallyIntegral
+  simp
+
+/-- The inverse of `ofGeometricallyIntegral G` is the inverse of `G`. -/
+@[simp]
+lemma ofGeometricallyIntegral_inv (G : Over (Spec (.of K))) [GrpObj G]
+    [IsProper G.hom] [GeometricallyIntegral G.hom] :
+    ι[(ofGeometricallyIntegral G).toOver] ≫
+        eqToHom (ofGeometricallyIntegral_toOver G) =
+      eqToHom (ofGeometricallyIntegral_toOver G) ≫ ι[G] := by
+  unfold ofGeometricallyIntegral
+  simp
+
 /-! ### Base change along a field extension -/
 
 /-- The base change of an abelian variety along a field extension `K → L`, obtained by pulling
@@ -154,6 +184,41 @@ lemma baseChange_toOver (A : AbelianVariety K) (L : Type u) [Field L] [Algebra K
     (A.baseChange L).toOver =
       (Over.pullback (Spec.map (CommRingCat.ofHom (algebraMap K L)))).obj A.toOver :=
   (rfl)
+
+/-- The unit of a base-changed abelian variety is the pullback of the original unit, with the
+monoidal comparison for `Over.pullback`. -/
+@[simp]
+lemma baseChange_one (A : AbelianVariety K) (L : Type u) [Field L] [Algebra K L] :
+    η[(A.baseChange L).toOver] ≫ eqToHom (baseChange_toOver A L) =
+      Functor.LaxMonoidal.ε
+        (Over.pullback (Spec.map (CommRingCat.ofHom (algebraMap K L)))) ≫
+        (Over.pullback (Spec.map (CommRingCat.ofHom (algebraMap K L)))).map η[A.toOver] :=
+  by
+    unfold baseChange
+    simp
+
+/-- The multiplication of a base-changed abelian variety is the pullback of the original
+multiplication, with the monoidal comparison for `Over.pullback`. -/
+@[simp]
+lemma baseChange_mul (A : AbelianVariety K) (L : Type u) [Field L] [Algebra K L] :
+    μ[(A.baseChange L).toOver] ≫ eqToHom (baseChange_toOver A L) =
+      (eqToHom (baseChange_toOver A L) ⊗ₘ eqToHom (baseChange_toOver A L)) ≫
+        Functor.LaxMonoidal.μ
+        (Over.pullback (Spec.map (CommRingCat.ofHom (algebraMap K L)))) A.toOver A.toOver ≫
+        (Over.pullback (Spec.map (CommRingCat.ofHom (algebraMap K L)))).map μ[A.toOver] :=
+  by
+    unfold baseChange
+    simp
+
+/-- The inverse of a base-changed abelian variety is the pullback of the original inverse. -/
+@[simp]
+lemma baseChange_inv (A : AbelianVariety K) (L : Type u) [Field L] [Algebra K L] :
+    ι[(A.baseChange L).toOver] ≫ eqToHom (baseChange_toOver A L) =
+      eqToHom (baseChange_toOver A L) ≫
+      (Over.pullback (Spec.map (CommRingCat.ofHom (algebraMap K L)))).map ι[A.toOver] :=
+  by
+    unfold baseChange
+    simp
 
 /-- The underlying scheme of a base change is the fibre product of the abelian variety with
 `Spec L` over `Spec K`. -/

--- a/TauCeti/AlgebraicGeometry/AbelianVariety/Basic.lean
+++ b/TauCeti/AlgebraicGeometry/AbelianVariety/Basic.lean
@@ -103,7 +103,7 @@ Properness and geometric integrality are stable under base change, and the monoi
 functor carries the group-object structure (`Functor.grpObjObj`), so the result is again an
 abelian variety. This realizes the roadmap's base-change compatibility of the Jacobian at the
 level of abelian varieties. -/
-@[expose] noncomputable def baseChange (A : AbelianVariety K) (L : Type u) [Field L]
+noncomputable def baseChange (A : AbelianVariety K) (L : Type u) [Field L]
     [Algebra K L] : AbelianVariety L where
   toOver := (Over.pullback (Spec.map (CommRingCat.ofHom (algebraMap K L)))).obj A.toOver
   grpObj := Functor.grpObjObj
@@ -117,14 +117,14 @@ level of abelian varieties. -/
 lemma baseChange_toOver (A : AbelianVariety K) (L : Type u) [Field L] [Algebra K L] :
     (A.baseChange L).toOver =
       (Over.pullback (Spec.map (CommRingCat.ofHom (algebraMap K L)))).obj A.toOver :=
-  rfl
+  (rfl)
 
 /-- The underlying scheme of a base change is the fibre product of the abelian variety with
 `Spec L` over `Spec K`. -/
 lemma baseChange_toScheme (A : AbelianVariety K) (L : Type u) [Field L] [Algebra K L] :
     (A.baseChange L).toScheme =
       Limits.pullback A.toOver.hom (Spec.map (CommRingCat.ofHom (algebraMap K L))) :=
-  rfl
+  (rfl)
 
 end AbelianVariety
 

--- a/TauCeti/AlgebraicGeometry/AbelianVariety/Basic.lean
+++ b/TauCeti/AlgebraicGeometry/AbelianVariety/Basic.lean
@@ -14,29 +14,26 @@ public import Mathlib.AlgebraicGeometry.Geometrically.Connected
 This file opens the Jacobian roadmap's Layer E by defining an **abelian variety** over a field
 `K`.
 
-Following the roadmap, an abelian variety is bundled as a smooth, proper, geometrically connected
-group scheme over `K`. Mathlib's current commutativity theorem assumes the stronger
-`GeometricallyIntegral` condition, so commutativity and absolute integrality are exposed below as
-conditional API under that hypothesis, together with a constructor from the geometrically integral
-package.
+Following the roadmap, an abelian variety is bundled as a proper geometrically integral group
+scheme over `K`. From geometric integrality and the group-scheme smoothness theorem we derive the
+roadmap's smooth and geometrically connected interface, while Mathlib's rigidity theorem gives
+commutativity.
 
 We bundle the data as a structure `AbelianVariety K`, so that later roadmap targets can write
 `JacobianVariety X x₀ : AbelianVariety k` and refer to `(JacobianVariety X x₀).toScheme` and
 its base changes, matching `TauCetiRoadmap/JacobianChallenge/Suggested.lean`. From the bundled
 hypotheses we derive:
 
-* `AbelianVariety.isCommMonObj_of_geometricallyIntegral`: the group law is commutative, straight
-  from Mathlib's rigidity theorem
-  `AlgebraicGeometry.isCommMonObj_of_isProper_of_geometricallyIntegral` under the extra hypothesis
-  `GeometricallyIntegral A.toOver.hom`;
-* `AbelianVariety.isIntegral_of_geometricallyIntegral`: the underlying scheme is integral under
-  the same extra hypothesis;
+* `AbelianVariety.isCommMonObj`: the group law is commutative, straight from Mathlib's rigidity
+  theorem `AlgebraicGeometry.isCommMonObj_of_isProper_of_geometricallyIntegral`;
+* `AbelianVariety.isIntegral`: the underlying scheme is integral;
+* `AbelianVariety.smooth` and `AbelianVariety.geometricallyConnected`: the roadmap's geometric
+  hypotheses derived from geometric integrality;
 * `AbelianVariety.ofGeometricallyIntegral`: a constructor from the geometrically integral package
   used by Mathlib's rigidity theorem;
 * `AbelianVariety.baseChange`: the base change of an abelian variety along a field extension
-  `K → L` is again an abelian variety, since properness, smoothness, and geometric connectedness
-  are stable under base change and the monoidal pullback functor carries the group-object
-  structure.
+  `K → L` is again an abelian variety, since properness and geometric integrality are stable under
+  base change and the monoidal pullback functor carries the group-object structure.
 
 This advances `TauCetiRoadmap/JacobianChallenge/README.md`, Layer E, "Abelian variety = smooth,
 proper, geometrically connected group scheme over `k`; basic API ... Commutativity is automatic
@@ -56,13 +53,25 @@ namespace AlgebraicGeometry
 
 universe u
 
-/-- An **abelian variety** over a field `K`: a smooth, proper, geometrically connected group
-scheme over `Spec K`.
+/-- A geometrically irreducible morphism is geometrically connected. -/
+lemma GeometricallyConnected.of_geometricallyIrreducible {X S : Scheme.{u}} {f : X ⟶ S}
+    [GeometricallyIrreducible f] : GeometricallyConnected f := by
+  refine ⟨?_⟩
+  have h : geometrically (IrreducibleSpace ·) f :=
+    GeometricallyIrreducible.geometrically_irreducibleSpace ..
+  rw [geometrically_eq_universally] at h ⊢
+  refine MorphismProperty.universally_mono (fun {X Y} f hf hint hsub ↦ ?_) _ h
+  have := hf hint hsub
+  infer_instance
+
+/-- An **abelian variety** over a field `K`: a proper geometrically integral group scheme over
+`Spec K`.
 
 The group-object structure lives on `toOver : Over (Spec (.of K))`; the underlying scheme is
 `toScheme = toOver.left`. The fields are the standing hypotheses of the theory: `grpObj` is the
 group law, `isProper` says the structure morphism to `Spec K` is proper, and
-`smooth` and `geometricallyConnected` record the roadmap's geometric hypotheses. -/
+`geometricallyIntegral` records the geometric hypothesis from which smoothness, geometric
+connectedness, absolute integrality, and commutativity are derived. -/
 structure AbelianVariety (K : Type u) [Field K] where
   /-- The underlying group scheme over `Spec K`. -/
   toOver : Over (Spec (.of K))
@@ -70,76 +79,74 @@ structure AbelianVariety (K : Type u) [Field K] where
   grpObj : GrpObj toOver
   /-- The structure morphism to `Spec K` is proper. -/
   isProper : IsProper toOver.hom
-  /-- The structure morphism to `Spec K` is smooth. -/
-  smooth : Smooth toOver.hom
-  /-- The structure morphism to `Spec K` is geometrically connected. -/
-  geometricallyConnected : GeometricallyConnected toOver.hom
+  /-- The structure morphism to `Spec K` is geometrically integral. -/
+  geometricallyIntegral : GeometricallyIntegral toOver.hom
 
 namespace AbelianVariety
 
 variable {K : Type u} [Field K]
 
-attribute [instance] AbelianVariety.grpObj AbelianVariety.isProper AbelianVariety.smooth
-  AbelianVariety.geometricallyConnected
+attribute [instance] AbelianVariety.grpObj AbelianVariety.isProper
+  AbelianVariety.geometricallyIntegral
 
 /-- The underlying scheme of an abelian variety. -/
 noncomputable abbrev toScheme (A : AbelianVariety K) : Scheme.{u} :=
   A.toOver.left
 
-/-- The group law of a geometrically integral abelian variety is commutative: a proper
-geometrically integral group scheme over a field is a commutative group object. This is the
-abstract rigidity theorem `AlgebraicGeometry.isCommMonObj_of_isProper_of_geometricallyIntegral`,
-packaged for the bundled `AbelianVariety`. -/
-instance isCommMonObj_of_geometricallyIntegral (A : AbelianVariety K)
-    [GeometricallyIntegral A.toOver.hom] : IsCommMonObj A.toOver :=
+/-- An abelian variety is smooth over the base field. -/
+instance smooth (A : AbelianVariety K) : Smooth A.toOver.hom := by
+  haveI : GrpObj (Over.mk A.toOver.hom) := inferInstanceAs (GrpObj A.toOver)
+  exact smooth_of_grpObj A.toOver.hom
+
+/-- An abelian variety is geometrically connected over the base field. -/
+instance geometricallyConnected (A : AbelianVariety K) :
+    GeometricallyConnected A.toOver.hom :=
+  GeometricallyConnected.of_geometricallyIrreducible
+
+/-- The group law of an abelian variety is commutative: a proper geometrically integral group
+scheme over a field is a commutative group object. This is the abstract rigidity theorem
+`AlgebraicGeometry.isCommMonObj_of_isProper_of_geometricallyIntegral`, packaged for the bundled
+`AbelianVariety`. -/
+instance isCommMonObj (A : AbelianVariety K) : IsCommMonObj A.toOver :=
   isCommMonObj_of_isProper_of_geometricallyIntegral A.toOver
 
-/-- The underlying scheme of a geometrically integral abelian variety is integral: geometric
-integrality over the one-point base `Spec K` descends to absolute integrality. In particular the
-underlying space is nonempty, irreducible, and reduced. -/
-instance isIntegral_of_geometricallyIntegral (A : AbelianVariety K)
-    [GeometricallyIntegral A.toOver.hom] : IsIntegral A.toScheme :=
+/-- The underlying scheme of an abelian variety is integral: geometric integrality over the
+one-point base `Spec K` descends to absolute integrality. In particular the underlying space is
+nonempty, irreducible, and reduced. -/
+instance isIntegral (A : AbelianVariety K) : IsIntegral A.toScheme :=
   GeometricallyIntegral.isIntegral_of_subsingleton A.toOver.hom
 
-/-- A constructor for abelian varieties from Mathlib's geometrically integral package. For a group
-scheme locally of finite type over a field, geometric integrality supplies the smoothness and
-geometric connectedness hypotheses of `AbelianVariety`. -/
+/-- A constructor for abelian varieties from Mathlib's geometrically integral package. -/
 noncomputable def ofGeometricallyIntegral (G : Over (Spec (.of K))) [GrpObj G]
     [IsProper G.hom] [GeometricallyIntegral G.hom] : AbelianVariety K where
   toOver := G
   grpObj := inferInstance
   isProper := inferInstance
-  smooth := by
-    haveI : GrpObj (Over.mk G.hom) := inferInstanceAs (GrpObj G)
-    exact smooth_of_grpObj G.hom
-  geometricallyConnected := by
-    refine ⟨?_⟩
-    have h : geometrically (IrreducibleSpace ·) G.hom :=
-      GeometricallyIrreducible.geometrically_irreducibleSpace ..
-    rw [geometrically_eq_universally] at h ⊢
-    refine MorphismProperty.universally_mono (fun {X Y} f hf hint hsub ↦ ?_) _ h
-    have := hf hint hsub
-    infer_instance
+  geometricallyIntegral := inferInstance
+
+@[simp]
+lemma ofGeometricallyIntegral_toOver (G : Over (Spec (.of K))) [GrpObj G]
+    [IsProper G.hom] [GeometricallyIntegral G.hom] :
+    (ofGeometricallyIntegral G).toOver = G :=
+  (rfl)
 
 /-! ### Base change along a field extension -/
 
 /-- The base change of an abelian variety along a field extension `K → L`, obtained by pulling
 back the group scheme along `Spec L → Spec K`.
 
-Properness, smoothness, and geometric connectedness are stable under base change, and the
-monoidal pullback functor carries the group-object structure (`Functor.grpObjObj`), so the result
-is again an abelian variety. This realizes the roadmap's base-change compatibility of the Jacobian
-at the level of abelian varieties. -/
+Properness and geometric integrality are stable under base change, and the monoidal pullback
+functor carries the group-object structure (`Functor.grpObjObj`), so the result is again an
+abelian variety. This realizes the roadmap's base-change compatibility of the Jacobian at the
+level of abelian varieties. -/
 noncomputable def baseChange (A : AbelianVariety K) (L : Type u) [Field L]
     [Algebra K L] : AbelianVariety L where
   toOver := (Over.pullback (Spec.map (CommRingCat.ofHom (algebraMap K L)))).obj A.toOver
   grpObj := Functor.grpObjObj
   isProper := inferInstanceAs
     (IsProper (Limits.pullback.snd A.toOver.hom (Spec.map (CommRingCat.ofHom (algebraMap K L)))))
-  smooth := inferInstanceAs
-    (Smooth (Limits.pullback.snd A.toOver.hom (Spec.map (CommRingCat.ofHom (algebraMap K L)))))
-  geometricallyConnected := inferInstanceAs
-    (GeometricallyConnected (Limits.pullback.snd A.toOver.hom
+  geometricallyIntegral := inferInstanceAs
+    (GeometricallyIntegral (Limits.pullback.snd A.toOver.hom
       (Spec.map (CommRingCat.ofHom (algebraMap K L)))))
 
 @[simp]

--- a/TauCeti/AlgebraicGeometry/AbelianVariety/Basic.lean
+++ b/TauCeti/AlgebraicGeometry/AbelianVariety/Basic.lean
@@ -7,6 +7,7 @@ module
 public import Mathlib.AlgebraicGeometry.Group.Abelian
 public import Mathlib.AlgebraicGeometry.Group.Smooth
 public import Mathlib.AlgebraicGeometry.Geometrically.Connected
+public import Mathlib.Topology.KrullDimension
 
 /-!
 # Abelian varieties
@@ -29,6 +30,7 @@ hypotheses we derive:
 * `AbelianVariety.isIntegral`: the underlying scheme is integral;
 * `AbelianVariety.smooth` and `AbelianVariety.geometricallyConnected`: the roadmap's geometric
   hypotheses derived from geometric integrality;
+* `AbelianVariety.dim`: the topological Krull dimension of the underlying scheme;
 * `AbelianVariety.ofGeometricallyIntegral`: a constructor from the geometrically integral package
   used by Mathlib's rigidity theorem;
 * `AbelianVariety.baseChange`: the base change of an abelian variety along a field extension
@@ -92,6 +94,16 @@ attribute [instance] AbelianVariety.grpObj AbelianVariety.isProper
 /-- The underlying scheme of an abelian variety. -/
 noncomputable abbrev toScheme (A : AbelianVariety K) : Scheme.{u} :=
   A.toOver.left
+
+/-- The dimension of an abelian variety, defined as the topological Krull dimension of its
+underlying scheme. -/
+noncomputable abbrev dim (A : AbelianVariety K) : WithBot ℕ∞ :=
+  topologicalKrullDim A.toScheme
+
+@[simp]
+lemma dim_def (A : AbelianVariety K) :
+    A.dim = topologicalKrullDim A.toScheme :=
+  rfl
 
 /-- An abelian variety is smooth over the base field. -/
 instance smooth (A : AbelianVariety K) : Smooth A.toOver.hom := by
@@ -227,6 +239,14 @@ lemma baseChange_toScheme (A : AbelianVariety K) (L : Type u) [Field L] [Algebra
     (A.baseChange L).toScheme =
       Limits.pullback A.toOver.hom (Spec.map (CommRingCat.ofHom (algebraMap K L))) := by
   simp only [toScheme, baseChange_toOver, Over.pullback_obj_left]
+
+@[simp]
+lemma baseChange_dim (A : AbelianVariety K) (L : Type u) [Field L] [Algebra K L] :
+    (A.baseChange L).dim =
+      topologicalKrullDim
+        (Limits.pullback A.toOver.hom
+          (Spec.map (CommRingCat.ofHom (algebraMap K L))) : Scheme.{u}) := by
+  rw [dim, baseChange_toScheme]
 
 end AbelianVariety
 


### PR DESCRIPTION
This PR opens Layer E of the Jacobian challenge roadmap by defining an abelian variety over a field and recording its first structural property. Following Milne, `TauCeti.AlgebraicGeometry.AbelianVariety K` bundles a proper, geometrically integral group scheme over `Spec K`: geometric integrality is the robust "variety" condition (stable under base change and insensitive to imperfect base fields), and it is the exact hypothesis of Mathlib's rigidity theorem, so it is taken as the definition, with the smooth-plus-geometrically-connected reconciliation (which needs the harder "reduced connected group scheme is irreducible" input, not yet in Mathlib) left as later work. From the bundled data the file derives commutativity of the group law (`AbelianVariety.isCommMonObj`, straight from `AlgebraicGeometry.isCommMonObj_of_isProper_of_geometricallyIntegral`), integrality of the underlying scheme (`AbelianVariety.isIntegral`, since geometric integrality over the one-point base `Spec K` descends to absolute integrality), and base change along a field extension `K → L` (`AbelianVariety.baseChange`, assembling the base-change stability of properness and geometric integrality with the monoidal pullback functor's transport of the group-object structure). The structure is shaped so later targets can write `JacobianVariety X x₀ : AbelianVariety k` with `.toScheme` and `.baseChange`, matching `TauCetiRoadmap/JacobianChallenge/Suggested.lean`.

The target is `TauCetiRoadmap/JacobianChallenge/README.md`, Layer E, "Abelian variety = smooth, proper, geometrically connected group scheme over `k`; basic API ... Commutativity is automatic (rigidity, `Group/Abelian.lean`)", together with the roadmap's base-change compatibility. I chose it as a lowest-hanging Layer E prerequisite that is cleanly distinct from the crowded Layer A `WeilDivisor`/`OrderSystem` lane (no existing TauCeti file or open PR touches abelian varieties, group schemes, or `GrpObj`), and it directly consumes the recently added `Mathlib.AlgebraicGeometry.Group.Abelian`.

No external mathematics is vendored. The proofs reuse Mathlib's `Over`/`GrpObj` monoidal API (`Functor.grpObjObj`), the `GeometricallyIntegral`/`IsProper` morphism-property instances and their base-change stability, and the commutativity theorem `AlgebraicGeometry.isCommMonObj_of_isProper_of_geometricallyIntegral` (Andrew Yang, Christian Merten).

`lake build` reported `Build completed successfully (5053 jobs).` and `lake exe axioms` reported `axioms: audited 8933 TauCeti declaration(s); all within the allowlist [propext, Classical.choice, Quot.sound].`

<!--tauceti-target:v1 {"focus":"JacobianChallenge","id":"abelian-variety-basic"}-->

🤖 Prepared with Claude Code
