### PR TITLE
feat: add tensor-product comodule coaction map

### DIFF
--- a/TauCeti/Algebra/Coalgebra/Comodule/TensorProduct.lean
+++ b/TauCeti/Algebra/Coalgebra/Comodule/TensorProduct.lean
@@ -6,7 +6,6 @@ module
 
 public import Mathlib.RingTheory.Bialgebra.Basic
 public import TauCeti.Algebra.Coalgebra.Comodule
-import Mathlib.Tactic.IrreducibleDef
 
 /-!
 # The tensor-product coaction map for comodules over a bialgebra
@@ -60,10 +59,19 @@ variable [AddCommMonoid N] [Module R N]
 the two `C`-components.
 
 On pure tensors it sends `(m ⊗ c) ⊗ (n ⊗ d)` to `(m ⊗ n) ⊗ cd`. -/
-noncomputable irreducible_def tensorCombine :
+noncomputable def tensorCombine :
     (M ⊗[R] C) ⊗[R] (N ⊗[R] C) →ₗ[R] (M ⊗[R] N) ⊗[R] C :=
   TensorProduct.map (LinearMap.id : M ⊗[R] N →ₗ[R] M ⊗[R] N) (LinearMap.mul' R C) ∘ₗ
     (TensorProduct.tensorTensorTensorComm R M C N C).toLinearMap
+
+/-- Unfold `tensorCombine` to its defining composition. Kept `private`: the map's body is
+deliberately not exposed to downstream modules (the module system hides non-`@[expose]`d
+definition bodies), so this equation is an in-file helper for the lemmas below. -/
+private theorem tensorCombine_def :
+    tensorCombine (R := R) (C := C) (M := M) (N := N) =
+      TensorProduct.map (LinearMap.id : M ⊗[R] N →ₗ[R] M ⊗[R] N) (LinearMap.mul' R C) ∘ₗ
+        (TensorProduct.tensorTensorTensorComm R M C N C).toLinearMap :=
+  rfl
 
 /-- `tensorCombine` sends `(m ⊗ c) ⊗ (n ⊗ d)` to `(m ⊗ n) ⊗ cd`. -/
 @[simp]
@@ -128,13 +136,25 @@ section Coact
 /-- The diagonal coaction map on the tensor product of two right comodules over a bialgebra.
 
 The later full tensor-product comodule structure uses this map as its coaction. -/
-noncomputable irreducible_def tensorCoact [Semiring C] [Bialgebra R C]
+noncomputable def tensorCoact [Semiring C] [Bialgebra R C]
     [AddCommMonoid M] [Module R M] [Comodule R C M]
     [AddCommMonoid N] [Module R N] [Comodule R C N] :
     M ⊗[R] N →ₗ[R] (M ⊗[R] N) ⊗[R] C :=
   tensorCombine (R := R) (C := C) (M := M) (N := N) ∘ₗ
     TensorProduct.map (coact (R := R) (C := C) (M := M))
       (coact (R := R) (C := C) (M := N))
+
+/-- Unfold `tensorCoact` to the combining map applied to the two component coactions. Kept
+`private` for the same reason as `tensorCombine_def`: the coaction's body is not exposed
+downstream, so this equation only serves the lemmas in this file. -/
+private theorem tensorCoact_def [Semiring C] [Bialgebra R C]
+    [AddCommMonoid M] [Module R M] [Comodule R C M]
+    [AddCommMonoid N] [Module R N] [Comodule R C N] :
+    tensorCoact (R := R) (C := C) (M := M) (N := N) =
+      tensorCombine (R := R) (C := C) (M := M) (N := N) ∘ₗ
+        TensorProduct.map (coact (R := R) (C := C) (M := M))
+          (coact (R := R) (C := C) (M := N)) :=
+  rfl
 
 /-- The tensor-product coaction, before expanding the two component coactions. -/
 @[simp]

--- a/TauCeti/Algebra/Coalgebra/Comodule/TensorProduct.lean
+++ b/TauCeti/Algebra/Coalgebra/Comodule/TensorProduct.lean
@@ -5,7 +5,6 @@ Released under Apache 2.0 license as described in the file LICENSE.
 module
 
 public import Mathlib.RingTheory.Bialgebra.Basic
-public import Mathlib.Tactic.IrreducibleDef
 public import TauCeti.Algebra.Coalgebra.Comodule
 
 /-!
@@ -60,10 +59,17 @@ variable [AddCommMonoid N] [Module R N]
 the two `C`-components.
 
 On pure tensors it sends `(m ⊗ c) ⊗ (n ⊗ d)` to `(m ⊗ n) ⊗ cd`. -/
-irreducible_def tensorCombine :
+@[expose] def tensorCombine :
     (M ⊗[R] C) ⊗[R] (N ⊗[R] C) →ₗ[R] (M ⊗[R] N) ⊗[R] C :=
   TensorProduct.map (LinearMap.id : M ⊗[R] N →ₗ[R] M ⊗[R] N) (LinearMap.mul' R C) ∘ₗ
     (TensorProduct.tensorTensorTensorComm R M C N C).toLinearMap
+
+/-- The definition of `tensorCombine`. -/
+theorem tensorCombine_def :
+    tensorCombine (R := R) (C := C) (M := M) (N := N) =
+      TensorProduct.map (LinearMap.id : M ⊗[R] N →ₗ[R] M ⊗[R] N) (LinearMap.mul' R C) ∘ₗ
+        (TensorProduct.tensorTensorTensorComm R M C N C).toLinearMap :=
+  rfl
 
 /-- `tensorCombine` sends `(m ⊗ c) ⊗ (n ⊗ d)` to `(m ⊗ n) ⊗ cd`. -/
 @[simp]
@@ -128,13 +134,23 @@ section Coact
 /-- The diagonal coaction map on the tensor product of two right comodules over a bialgebra.
 
 The later full tensor-product comodule structure uses this as its coaction. -/
-irreducible_def tensorCoact [Semiring C] [Bialgebra R C]
+@[expose] def tensorCoact [Semiring C] [Bialgebra R C]
     [AddCommMonoid M] [Module R M] [Comodule R C M]
     [AddCommMonoid N] [Module R N] [Comodule R C N] :
     M ⊗[R] N →ₗ[R] (M ⊗[R] N) ⊗[R] C :=
   tensorCombine (R := R) (C := C) (M := M) (N := N) ∘ₗ
     TensorProduct.map (coact (R := R) (C := C) (M := M))
       (coact (R := R) (C := C) (M := N))
+
+/-- The definition of `tensorCoact`. -/
+theorem tensorCoact_def [Semiring C] [Bialgebra R C]
+    [AddCommMonoid M] [Module R M] [Comodule R C M]
+    [AddCommMonoid N] [Module R N] [Comodule R C N] :
+    tensorCoact (R := R) (C := C) (M := M) (N := N) =
+      tensorCombine (R := R) (C := C) (M := M) (N := N) ∘ₗ
+        TensorProduct.map (coact (R := R) (C := C) (M := M))
+          (coact (R := R) (C := C) (M := N)) :=
+  rfl
 
 /-- The tensor-product coaction, before expanding the two component coactions. -/
 @[simp]

--- a/TauCeti/Algebra/Coalgebra/Comodule/TensorProduct.lean
+++ b/TauCeti/Algebra/Coalgebra/Comodule/TensorProduct.lean
@@ -59,17 +59,10 @@ variable [AddCommMonoid N] [Module R N]
 the two `C`-components.
 
 On pure tensors it sends `(m ⊗ c) ⊗ (n ⊗ d)` to `(m ⊗ n) ⊗ cd`. -/
-@[expose] def tensorCombine :
+irreducible_def tensorCombine :
     (M ⊗[R] C) ⊗[R] (N ⊗[R] C) →ₗ[R] (M ⊗[R] N) ⊗[R] C :=
   TensorProduct.map (LinearMap.id : M ⊗[R] N →ₗ[R] M ⊗[R] N) (LinearMap.mul' R C) ∘ₗ
     (TensorProduct.tensorTensorTensorComm R M C N C).toLinearMap
-
-/-- The definition of `tensorCombine`. -/
-theorem tensorCombine_def :
-    tensorCombine (R := R) (C := C) (M := M) (N := N) =
-      TensorProduct.map (LinearMap.id : M ⊗[R] N →ₗ[R] M ⊗[R] N) (LinearMap.mul' R C) ∘ₗ
-        (TensorProduct.tensorTensorTensorComm R M C N C).toLinearMap :=
-  rfl
 
 /-- `tensorCombine` sends `(m ⊗ c) ⊗ (n ⊗ d)` to `(m ⊗ n) ⊗ cd`. -/
 @[simp]
@@ -134,23 +127,13 @@ section Coact
 /-- The diagonal coaction map on the tensor product of two right comodules over a bialgebra.
 
 The later full tensor-product comodule structure uses this as its coaction. -/
-@[expose] def tensorCoact [Semiring C] [Bialgebra R C]
+irreducible_def tensorCoact [Semiring C] [Bialgebra R C]
     [AddCommMonoid M] [Module R M] [Comodule R C M]
     [AddCommMonoid N] [Module R N] [Comodule R C N] :
     M ⊗[R] N →ₗ[R] (M ⊗[R] N) ⊗[R] C :=
   tensorCombine (R := R) (C := C) (M := M) (N := N) ∘ₗ
     TensorProduct.map (coact (R := R) (C := C) (M := M))
       (coact (R := R) (C := C) (M := N))
-
-/-- The definition of `tensorCoact`. -/
-theorem tensorCoact_def [Semiring C] [Bialgebra R C]
-    [AddCommMonoid M] [Module R M] [Comodule R C M]
-    [AddCommMonoid N] [Module R N] [Comodule R C N] :
-    tensorCoact (R := R) (C := C) (M := M) (N := N) =
-      tensorCombine (R := R) (C := C) (M := M) (N := N) ∘ₗ
-        TensorProduct.map (coact (R := R) (C := C) (M := M))
-          (coact (R := R) (C := C) (M := N)) :=
-  rfl
 
 /-- The tensor-product coaction, before expanding the two component coactions. -/
 @[simp]

--- a/TauCeti/Algebra/Coalgebra/Comodule/TensorProduct.lean
+++ b/TauCeti/Algebra/Coalgebra/Comodule/TensorProduct.lean
@@ -4,7 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 -/
 module
 
-public import Mathlib.Algebra.Algebra.Bilinear
+public import Mathlib.RingTheory.Bialgebra.Basic
 public import TauCeti.Algebra.Coalgebra.Comodule
 
 /-!
@@ -48,6 +48,9 @@ universe u v w x y z
 
 variable {R : Type u} {C : Type v} {M : Type w} {N : Type x}
 variable [CommSemiring R]
+
+section Combine
+
 variable [NonUnitalNonAssocSemiring C] [Module R C] [SMulCommClass R C C] [IsScalarTower R C C]
 variable [AddCommMonoid M] [Module R M]
 variable [AddCommMonoid N] [Module R N]
@@ -56,7 +59,7 @@ variable [AddCommMonoid N] [Module R N]
 the two `C`-components.
 
 On pure tensors it sends `(m ⊗ c) ⊗ (n ⊗ d)` to `(m ⊗ n) ⊗ cd`. -/
-def tensorCombine :
+irreducible_def tensorCombine :
     (M ⊗[R] C) ⊗[R] (N ⊗[R] C) →ₗ[R] (M ⊗[R] N) ⊗[R] C :=
   TensorProduct.map (LinearMap.id : M ⊗[R] N →ₗ[R] M ⊗[R] N) (LinearMap.mul' R C) ∘ₗ
     (TensorProduct.tensorTensorTensorComm R M C N C).toLinearMap
@@ -67,7 +70,7 @@ theorem tensorCombine_tmul_tmul (m : M) (c : C) (n : N) (d : C) :
     tensorCombine (R := R) (C := C) (M := M) (N := N)
         ((m ⊗ₜ[R] c) ⊗ₜ[R] (n ⊗ₜ[R] d)) =
       (m ⊗ₜ[R] n) ⊗ₜ[R] (c * d) := by
-  simp [tensorCombine]
+  simp [tensorCombine_def]
 
 variable {M' : Type y} {N' : Type z}
 variable [AddCommMonoid M'] [Module R M']
@@ -80,7 +83,7 @@ theorem tensorCombine_natural (f : M →ₗ[R] M') (g : N →ₗ[R] N') :
       tensorCombine (R := R) (C := C) (M := M') (N := N') ∘ₗ
         TensorProduct.map (TensorProduct.map f (LinearMap.id : C →ₗ[R] C))
           (TensorProduct.map g (LinearMap.id : C →ₗ[R] C)) := by
-  rw [tensorCombine, tensorCombine]
+  rw [tensorCombine_def, tensorCombine_def]
   have h := TensorProduct.tensorTensorTensorComm_comp_map (R := R) (M := M) (N := C)
     (P := N) (Q := C) (S := M') (T := C) (V := N') (W := C) f
     (LinearMap.id : C →ₗ[R] C) g (LinearMap.id : C →ₗ[R] C)
@@ -117,38 +120,55 @@ theorem tensorCombine_natural (f : M →ₗ[R] M') (g : N →ₗ[R] N') :
             (TensorProduct.map g (LinearMap.id : C →ₗ[R] C)) := by
       rw [LinearMap.comp_assoc]
 
-variable [Coalgebra R C] [Comodule R C M] [Comodule R C N]
+end Combine
+
+section Coact
 
 /-- The diagonal coaction map on the tensor product of two right comodules over a bialgebra.
 
 The later full tensor-product comodule structure uses this as its coaction. -/
-def tensorCoact : M ⊗[R] N →ₗ[R] (M ⊗[R] N) ⊗[R] C :=
+irreducible_def tensorCoact [Semiring C] [Bialgebra R C]
+    [AddCommMonoid M] [Module R M] [Comodule R C M]
+    [AddCommMonoid N] [Module R N] [Comodule R C N] :
+    M ⊗[R] N →ₗ[R] (M ⊗[R] N) ⊗[R] C :=
   tensorCombine (R := R) (C := C) (M := M) (N := N) ∘ₗ
     TensorProduct.map (coact (R := R) (C := C) (M := M))
       (coact (R := R) (C := C) (M := N))
 
 /-- The tensor-product coaction, before expanding the two component coactions. -/
 @[simp]
-theorem tensorCoact_tmul (m : M) (n : N) :
+theorem tensorCoact_tmul [Semiring C] [Bialgebra R C]
+    [AddCommMonoid M] [Module R M] [Comodule R C M]
+    [AddCommMonoid N] [Module R N] [Comodule R C N] (m : M) (n : N) :
     tensorCoact (R := R) (C := C) (M := M) (N := N) (m ⊗ₜ[R] n) =
       tensorCombine (R := R) (C := C) (M := M) (N := N)
         (coact (R := R) (C := C) (M := M) m ⊗ₜ[R]
           coact (R := R) (C := C) (M := N) n) := by
-  simp [tensorCoact]
+  rw [tensorCoact_def (R := R) (C := C) (M := M) (N := N)]
+  rfl
 
-variable [Comodule R C M'] [Comodule R C N']
+variable {M' : Type y} {N' : Type z}
 
 /-- The diagonal tensor coaction is natural under tensor products of comodule morphisms. -/
-theorem tensorCoact_natural (f : Hom R C M M') (g : Hom R C N N') :
+theorem tensorCoact_natural [Semiring C] [Bialgebra R C]
+    [AddCommMonoid M] [Module R M] [Comodule R C M]
+    [AddCommMonoid N] [Module R N] [Comodule R C N]
+    [AddCommMonoid M'] [Module R M'] [Comodule R C M']
+    [AddCommMonoid N'] [Module R N'] [Comodule R C N']
+    (f : Hom R C M M') (g : Hom R C N N') :
     TensorProduct.map (TensorProduct.map f.toLinearMap g.toLinearMap)
         (LinearMap.id : C →ₗ[R] C) ∘ₗ
         tensorCoact (R := R) (C := C) (M := M) (N := N) =
-      tensorCoact (R := R) (C := C) (M := M') (N := N') ∘ₗ
+        tensorCoact (R := R) (C := C) (M := M') (N := N') ∘ₗ
         TensorProduct.map f.toLinearMap g.toLinearMap := by
-  rw [tensorCoact, tensorCoact, ← LinearMap.comp_assoc, tensorCombine_natural,
+  rw [tensorCoact_def (R := R) (C := C) (M := M) (N := N),
+    tensorCoact_def (R := R) (C := C) (M := M') (N := N'), ← LinearMap.comp_assoc,
+    tensorCombine_natural,
     LinearMap.comp_assoc, LinearMap.comp_assoc]
   congr 1
   rw [← TensorProduct.map_comp, ← TensorProduct.map_comp, Hom.map_coact_eq, Hom.map_coact_eq]
+
+end Coact
 
 end Comodule
 

--- a/TauCeti/Algebra/Coalgebra/Comodule/TensorProduct.lean
+++ b/TauCeti/Algebra/Coalgebra/Comodule/TensorProduct.lean
@@ -59,10 +59,17 @@ variable [AddCommMonoid N] [Module R N]
 the two `C`-components.
 
 On pure tensors it sends `(m ⊗ c) ⊗ (n ⊗ d)` to `(m ⊗ n) ⊗ cd`. -/
-irreducible_def tensorCombine :
+abbrev tensorCombine :
     (M ⊗[R] C) ⊗[R] (N ⊗[R] C) →ₗ[R] (M ⊗[R] N) ⊗[R] C :=
   TensorProduct.map (LinearMap.id : M ⊗[R] N →ₗ[R] M ⊗[R] N) (LinearMap.mul' R C) ∘ₗ
     (TensorProduct.tensorTensorTensorComm R M C N C).toLinearMap
+
+/-- The definition of `tensorCombine`. -/
+theorem tensorCombine_def :
+    tensorCombine (R := R) (C := C) (M := M) (N := N) =
+      TensorProduct.map (LinearMap.id : M ⊗[R] N →ₗ[R] M ⊗[R] N) (LinearMap.mul' R C) ∘ₗ
+        (TensorProduct.tensorTensorTensorComm R M C N C).toLinearMap :=
+  rfl
 
 /-- `tensorCombine` sends `(m ⊗ c) ⊗ (n ⊗ d)` to `(m ⊗ n) ⊗ cd`. -/
 @[simp]
@@ -127,13 +134,23 @@ section Coact
 /-- The diagonal coaction map on the tensor product of two right comodules over a bialgebra.
 
 The later full tensor-product comodule structure uses this as its coaction. -/
-irreducible_def tensorCoact [Semiring C] [Bialgebra R C]
+abbrev tensorCoact [Semiring C] [Bialgebra R C]
     [AddCommMonoid M] [Module R M] [Comodule R C M]
     [AddCommMonoid N] [Module R N] [Comodule R C N] :
     M ⊗[R] N →ₗ[R] (M ⊗[R] N) ⊗[R] C :=
   tensorCombine (R := R) (C := C) (M := M) (N := N) ∘ₗ
     TensorProduct.map (coact (R := R) (C := C) (M := M))
       (coact (R := R) (C := C) (M := N))
+
+/-- The definition of `tensorCoact`. -/
+theorem tensorCoact_def [Semiring C] [Bialgebra R C]
+    [AddCommMonoid M] [Module R M] [Comodule R C M]
+    [AddCommMonoid N] [Module R N] [Comodule R C N] :
+    tensorCoact (R := R) (C := C) (M := M) (N := N) =
+      tensorCombine (R := R) (C := C) (M := M) (N := N) ∘ₗ
+        TensorProduct.map (coact (R := R) (C := C) (M := M))
+          (coact (R := R) (C := C) (M := N)) :=
+  rfl
 
 /-- The tensor-product coaction, before expanding the two component coactions. -/
 @[simp]
@@ -165,8 +182,11 @@ theorem tensorCoact_natural [Semiring C] [Bialgebra R C]
     tensorCoact_def (R := R) (C := C) (M := M') (N := N'), ← LinearMap.comp_assoc,
     tensorCombine_natural,
     LinearMap.comp_assoc, LinearMap.comp_assoc]
-  congr 1
-  rw [← TensorProduct.map_comp, ← TensorProduct.map_comp, Hom.map_coact_eq, Hom.map_coact_eq]
+  rw [tensorCombine_def (R := R) (C := C) (M := M') (N := N')]
+  rw [LinearMap.comp_assoc]
+  rw [← TensorProduct.map_comp, Hom.map_coact_eq, Hom.map_coact_eq]
+  rw [← TensorProduct.map_comp]
+  rw [← LinearMap.comp_assoc]
 
 end Coact
 

--- a/TauCeti/Algebra/Coalgebra/Comodule/TensorProduct.lean
+++ b/TauCeti/Algebra/Coalgebra/Comodule/TensorProduct.lean
@@ -4,7 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 -/
 module
 
-public import Mathlib.RingTheory.Bialgebra.Basic
+public import Mathlib.Algebra.Algebra.Bilinear
 public import TauCeti.Algebra.Coalgebra.Comodule
 
 /-!
@@ -48,7 +48,7 @@ universe u v w x y z
 
 variable {R : Type u} {C : Type v} {M : Type w} {N : Type x}
 variable [CommSemiring R]
-variable [Semiring C] [Algebra R C]
+variable [NonUnitalNonAssocSemiring C] [Module R C] [SMulCommClass R C C] [IsScalarTower R C C]
 variable [AddCommMonoid M] [Module R M]
 variable [AddCommMonoid N] [Module R N]
 
@@ -56,19 +56,10 @@ variable [AddCommMonoid N] [Module R N]
 the two `C`-components.
 
 On pure tensors it sends `(m ⊗ c) ⊗ (n ⊗ d)` to `(m ⊗ n) ⊗ cd`. -/
-@[expose] def tensorCombine :
+irreducible_def tensorCombine :
     (M ⊗[R] C) ⊗[R] (N ⊗[R] C) →ₗ[R] (M ⊗[R] N) ⊗[R] C :=
   TensorProduct.map (LinearMap.id : M ⊗[R] N →ₗ[R] M ⊗[R] N) (LinearMap.mul' R C) ∘ₗ
     (TensorProduct.tensorTensorTensorComm R M C N C).toLinearMap
-
-/-- The definition of `tensorCombine` as a shuffle followed by multiplication on the
-`C`-components. -/
-theorem tensorCombine_def :
-    tensorCombine (R := R) (C := C) (M := M) (N := N) =
-      TensorProduct.map (LinearMap.id : M ⊗[R] N →ₗ[R] M ⊗[R] N)
-          (LinearMap.mul' R C) ∘ₗ
-        (TensorProduct.tensorTensorTensorComm R M C N C).toLinearMap :=
-  rfl
 
 /-- `tensorCombine` sends `(m ⊗ c) ⊗ (n ⊗ d)` to `(m ⊗ n) ⊗ cd`. -/
 @[simp]
@@ -76,7 +67,7 @@ theorem tensorCombine_tmul_tmul (m : M) (c : C) (n : N) (d : C) :
     tensorCombine (R := R) (C := C) (M := M) (N := N)
         ((m ⊗ₜ[R] c) ⊗ₜ[R] (n ⊗ₜ[R] d)) =
       (m ⊗ₜ[R] n) ⊗ₜ[R] (c * d) := by
-  simp [tensorCombine]
+  simp [tensorCombine_def]
 
 variable {M' : Type y} {N' : Type z}
 variable [AddCommMonoid M'] [Module R M']
@@ -131,19 +122,10 @@ variable [Coalgebra R C] [Comodule R C M] [Comodule R C N]
 /-- The diagonal coaction map on the tensor product of two right comodules over a bialgebra.
 
 The later full tensor-product comodule structure uses this as its coaction. -/
-@[expose] def tensorCoact : M ⊗[R] N →ₗ[R] (M ⊗[R] N) ⊗[R] C :=
+irreducible_def tensorCoact : M ⊗[R] N →ₗ[R] (M ⊗[R] N) ⊗[R] C :=
   tensorCombine (R := R) (C := C) (M := M) (N := N) ∘ₗ
     TensorProduct.map (coact (R := R) (C := C) (M := M))
       (coact (R := R) (C := C) (M := N))
-
-/-- The definition of `tensorCoact` as the tensor product of the two component coactions,
-followed by `tensorCombine`. -/
-theorem tensorCoact_def :
-    tensorCoact (R := R) (C := C) (M := M) (N := N) =
-      tensorCombine (R := R) (C := C) (M := M) (N := N) ∘ₗ
-        TensorProduct.map (coact (R := R) (C := C) (M := M))
-          (coact (R := R) (C := C) (M := N)) :=
-  rfl
 
 /-- The tensor-product coaction, before expanding the two component coactions. -/
 @[simp]
@@ -152,7 +134,7 @@ theorem tensorCoact_tmul (m : M) (n : N) :
       tensorCombine (R := R) (C := C) (M := M) (N := N)
         (coact (R := R) (C := C) (M := M) m ⊗ₜ[R]
           coact (R := R) (C := C) (M := N) n) := by
-  simp [tensorCoact]
+  simp [tensorCoact_def]
 
 variable [Comodule R C M'] [Comodule R C N']
 
@@ -163,9 +145,10 @@ theorem tensorCoact_natural (f : Hom R C M M') (g : Hom R C N N') :
         tensorCoact (R := R) (C := C) (M := M) (N := N) =
       tensorCoact (R := R) (C := C) (M := M') (N := N') ∘ₗ
         TensorProduct.map f.toLinearMap g.toLinearMap := by
-  rw [tensorCoact, tensorCoact, ← LinearMap.comp_assoc, tensorCombine_natural]
-  ext m n
-  simp [Hom.map_coact_apply]
+  rw [tensorCoact_def, tensorCoact_def, ← LinearMap.comp_assoc, tensorCombine_natural,
+    LinearMap.comp_assoc, LinearMap.comp_assoc]
+  congr 1
+  rw [← TensorProduct.map_comp, ← TensorProduct.map_comp, Hom.map_coact_eq, Hom.map_coact_eq]
 
 end Comodule
 

--- a/TauCeti/Algebra/Coalgebra/Comodule/TensorProduct.lean
+++ b/TauCeti/Algebra/Coalgebra/Comodule/TensorProduct.lean
@@ -60,13 +60,22 @@ the two `C`-components.
 
 On pure tensors it sends `(m ⊗ c) ⊗ (n ⊗ d)` to `(m ⊗ n) ⊗ cd`.
 
-This is `irreducible_def`, exposing the public `tensorCombine_def` equation lemma while keeping
-the shuffle/multiplication body opaque so downstream code depends only on the characteristic
-lemmas below. -/
-noncomputable irreducible_def tensorCombine :
+The body is exposed through the `tensorCombine_def` equation lemma and the definition is then
+marked `irreducible`, so downstream code depends only on `tensorCombine_def` and the
+characteristic lemmas below rather than on the shuffle/multiplication body by reduction. -/
+@[expose] noncomputable def tensorCombine :
     (M ⊗[R] C) ⊗[R] (N ⊗[R] C) →ₗ[R] (M ⊗[R] N) ⊗[R] C :=
   TensorProduct.map (LinearMap.id : M ⊗[R] N →ₗ[R] M ⊗[R] N) (LinearMap.mul' R C) ∘ₗ
     (TensorProduct.tensorTensorTensorComm R M C N C).toLinearMap
+
+/-- The defining equation of `tensorCombine`, kept as the sole handle on its opaque body. -/
+theorem tensorCombine_def :
+    tensorCombine (R := R) (C := C) (M := M) (N := N) =
+      TensorProduct.map (LinearMap.id : M ⊗[R] N →ₗ[R] M ⊗[R] N) (LinearMap.mul' R C) ∘ₗ
+        (TensorProduct.tensorTensorTensorComm R M C N C).toLinearMap :=
+  rfl
+
+attribute [irreducible] tensorCombine
 
 /-- `tensorCombine` sends `(m ⊗ c) ⊗ (n ⊗ d)` to `(m ⊗ n) ⊗ cd`. -/
 @[simp]
@@ -132,16 +141,28 @@ section Coact
 
 The later full tensor-product comodule structure uses this as its coaction.
 
-This is `irreducible_def`, exposing the public `tensorCoact_def` equation lemma while keeping the
-composition body opaque so downstream code depends only on the characteristic coaction lemmas
+The body is exposed through the `tensorCoact_def` equation lemma and the definition is then
+marked `irreducible`, so downstream code depends only on the characteristic coaction lemmas
 `tensorCoact_tmul` and `tensorCoact_natural` rather than on this composition by reduction. -/
-noncomputable irreducible_def tensorCoact [Semiring C] [Bialgebra R C]
+@[expose] noncomputable def tensorCoact [Semiring C] [Bialgebra R C]
     [AddCommMonoid M] [Module R M] [Comodule R C M]
     [AddCommMonoid N] [Module R N] [Comodule R C N] :
     M ⊗[R] N →ₗ[R] (M ⊗[R] N) ⊗[R] C :=
   tensorCombine (R := R) (C := C) (M := M) (N := N) ∘ₗ
     TensorProduct.map (coact (R := R) (C := C) (M := M))
       (coact (R := R) (C := C) (M := N))
+
+/-- The defining equation of `tensorCoact`, kept as the sole handle on its opaque body. -/
+theorem tensorCoact_def [Semiring C] [Bialgebra R C]
+    [AddCommMonoid M] [Module R M] [Comodule R C M]
+    [AddCommMonoid N] [Module R N] [Comodule R C N] :
+    tensorCoact (R := R) (C := C) (M := M) (N := N) =
+      tensorCombine (R := R) (C := C) (M := M) (N := N) ∘ₗ
+        TensorProduct.map (coact (R := R) (C := C) (M := M))
+          (coact (R := R) (C := C) (M := N)) :=
+  rfl
+
+attribute [irreducible] tensorCoact
 
 /-- The tensor-product coaction, before expanding the two component coactions. -/
 @[simp]

--- a/TauCeti/Algebra/Coalgebra/Comodule/TensorProduct.lean
+++ b/TauCeti/Algebra/Coalgebra/Comodule/TensorProduct.lean
@@ -58,17 +58,13 @@ variable [AddCommMonoid N] [Module R N]
 /-- Combine two coacted tensor factors by shuffling the middle factors together and multiplying
 the two `C`-components.
 
-On pure tensors it sends `(m ⊗ c) ⊗ (n ⊗ d)` to `(m ⊗ n) ⊗ cd`. -/
-@[expose] def tensorCombine :
+On pure tensors it sends `(m ⊗ c) ⊗ (n ⊗ d)` to `(m ⊗ n) ⊗ cd`. The body is kept unexposed;
+the public API is the generated `tensorCombine_def` equation together with the simp and
+naturality lemmas below. -/
+irreducible_def tensorCombine :
     (M ⊗[R] C) ⊗[R] (N ⊗[R] C) →ₗ[R] (M ⊗[R] N) ⊗[R] C :=
   TensorProduct.map (LinearMap.id : M ⊗[R] N →ₗ[R] M ⊗[R] N) (LinearMap.mul' R C) ∘ₗ
     (TensorProduct.tensorTensorTensorComm R M C N C).toLinearMap
-
-/-- The combining map is the tensor shuffling map followed by multiplication on `C`. -/
-theorem tensorCombine_def :
-    tensorCombine (R := R) (C := C) (M := M) (N := N) =
-      TensorProduct.map (LinearMap.id : M ⊗[R] N →ₗ[R] M ⊗[R] N) (LinearMap.mul' R C) ∘ₗ
-        (TensorProduct.tensorTensorTensorComm R M C N C).toLinearMap := rfl
 
 /-- `tensorCombine` sends `(m ⊗ c) ⊗ (n ⊗ d)` to `(m ⊗ n) ⊗ cd`. -/
 @[simp]
@@ -132,23 +128,16 @@ section Coact
 
 /-- The diagonal coaction map on the tensor product of two right comodules over a bialgebra.
 
-The later full tensor-product comodule structure uses this as its coaction. -/
-@[expose] def tensorCoact [Semiring C] [Bialgebra R C]
+The later full tensor-product comodule structure uses this as its coaction. The body is kept
+unexposed; the public API is the generated `tensorCoact_def` equation together with the simp
+and naturality lemmas below. -/
+irreducible_def tensorCoact [Semiring C] [Bialgebra R C]
     [AddCommMonoid M] [Module R M] [Comodule R C M]
     [AddCommMonoid N] [Module R N] [Comodule R C N] :
     M ⊗[R] N →ₗ[R] (M ⊗[R] N) ⊗[R] C :=
   tensorCombine (R := R) (C := C) (M := M) (N := N) ∘ₗ
     TensorProduct.map (coact (R := R) (C := C) (M := M))
       (coact (R := R) (C := C) (M := N))
-
-/-- The tensor-product coaction combines the two component coactions. -/
-theorem tensorCoact_def [Semiring C] [Bialgebra R C]
-    [AddCommMonoid M] [Module R M] [Comodule R C M]
-    [AddCommMonoid N] [Module R N] [Comodule R C N] :
-    tensorCoact (R := R) (C := C) (M := M) (N := N) =
-      tensorCombine (R := R) (C := C) (M := M) (N := N) ∘ₗ
-        TensorProduct.map (coact (R := R) (C := C) (M := M))
-          (coact (R := R) (C := C) (M := N)) := rfl
 
 /-- The tensor-product coaction, before expanding the two component coactions. -/
 @[simp]

--- a/TauCeti/Algebra/Coalgebra/Comodule/TensorProduct.lean
+++ b/TauCeti/Algebra/Coalgebra/Comodule/TensorProduct.lean
@@ -6,6 +6,7 @@ module
 
 public import Mathlib.RingTheory.Bialgebra.Basic
 public import TauCeti.Algebra.Coalgebra.Comodule
+import Mathlib.Tactic.IrreducibleDef
 
 /-!
 # The tensor-product coaction map for comodules over a bialgebra
@@ -58,24 +59,11 @@ variable [AddCommMonoid N] [Module R N]
 /-- Combine two coacted tensor factors by shuffling the middle factors together and multiplying
 the two `C`-components.
 
-On pure tensors it sends `(m ⊗ c) ⊗ (n ⊗ d)` to `(m ⊗ n) ⊗ cd`.
-
-The body is exposed through the `tensorCombine_def` equation lemma and the definition is then
-marked `irreducible`, so downstream code depends only on `tensorCombine_def` and the
-characteristic lemmas below rather than on the shuffle/multiplication body by reduction. -/
-@[expose] noncomputable def tensorCombine :
+On pure tensors it sends `(m ⊗ c) ⊗ (n ⊗ d)` to `(m ⊗ n) ⊗ cd`. -/
+noncomputable irreducible_def tensorCombine :
     (M ⊗[R] C) ⊗[R] (N ⊗[R] C) →ₗ[R] (M ⊗[R] N) ⊗[R] C :=
   TensorProduct.map (LinearMap.id : M ⊗[R] N →ₗ[R] M ⊗[R] N) (LinearMap.mul' R C) ∘ₗ
     (TensorProduct.tensorTensorTensorComm R M C N C).toLinearMap
-
-/-- The defining equation of `tensorCombine`, kept as the sole handle on its opaque body. -/
-theorem tensorCombine_def :
-    tensorCombine (R := R) (C := C) (M := M) (N := N) =
-      TensorProduct.map (LinearMap.id : M ⊗[R] N →ₗ[R] M ⊗[R] N) (LinearMap.mul' R C) ∘ₗ
-        (TensorProduct.tensorTensorTensorComm R M C N C).toLinearMap :=
-  rfl
-
-attribute [irreducible] tensorCombine
 
 /-- `tensorCombine` sends `(m ⊗ c) ⊗ (n ⊗ d)` to `(m ⊗ n) ⊗ cd`. -/
 @[simp]
@@ -139,30 +127,14 @@ section Coact
 
 /-- The diagonal coaction map on the tensor product of two right comodules over a bialgebra.
 
-The later full tensor-product comodule structure uses this as its coaction.
-
-The body is exposed through the `tensorCoact_def` equation lemma and the definition is then
-marked `irreducible`, so downstream code depends only on the characteristic coaction lemmas
-`tensorCoact_tmul` and `tensorCoact_natural` rather than on this composition by reduction. -/
-@[expose] noncomputable def tensorCoact [Semiring C] [Bialgebra R C]
+The later full tensor-product comodule structure uses this map as its coaction. -/
+noncomputable irreducible_def tensorCoact [Semiring C] [Bialgebra R C]
     [AddCommMonoid M] [Module R M] [Comodule R C M]
     [AddCommMonoid N] [Module R N] [Comodule R C N] :
     M ⊗[R] N →ₗ[R] (M ⊗[R] N) ⊗[R] C :=
   tensorCombine (R := R) (C := C) (M := M) (N := N) ∘ₗ
     TensorProduct.map (coact (R := R) (C := C) (M := M))
       (coact (R := R) (C := C) (M := N))
-
-/-- The defining equation of `tensorCoact`, kept as the sole handle on its opaque body. -/
-theorem tensorCoact_def [Semiring C] [Bialgebra R C]
-    [AddCommMonoid M] [Module R M] [Comodule R C M]
-    [AddCommMonoid N] [Module R N] [Comodule R C N] :
-    tensorCoact (R := R) (C := C) (M := M) (N := N) =
-      tensorCombine (R := R) (C := C) (M := M) (N := N) ∘ₗ
-        TensorProduct.map (coact (R := R) (C := C) (M := M))
-          (coact (R := R) (C := C) (M := N)) :=
-  rfl
-
-attribute [irreducible] tensorCoact
 
 /-- The tensor-product coaction, before expanding the two component coactions. -/
 @[simp]
@@ -173,8 +145,7 @@ theorem tensorCoact_tmul [Semiring C] [Bialgebra R C]
       tensorCombine (R := R) (C := C) (M := M) (N := N)
         (coact (R := R) (C := C) (M := M) m ⊗ₜ[R]
           coact (R := R) (C := C) (M := N) n) := by
-  rw [tensorCoact_def (R := R) (C := C) (M := M) (N := N)]
-  rfl
+  simp [tensorCoact_def (R := R) (C := C) (M := M) (N := N)]
 
 variable {M' : Type y} {N' : Type z}
 
@@ -190,15 +161,13 @@ theorem tensorCoact_natural [Semiring C] [Bialgebra R C]
         tensorCoact (R := R) (C := C) (M := M) (N := N) =
         tensorCoact (R := R) (C := C) (M := M') (N := N') ∘ₗ
         TensorProduct.map f.toLinearMap g.toLinearMap := by
-  rw [tensorCoact_def (R := R) (C := C) (M := M) (N := N),
-    tensorCoact_def (R := R) (C := C) (M := M') (N := N'), ← LinearMap.comp_assoc,
-    tensorCombine_natural,
-    LinearMap.comp_assoc, LinearMap.comp_assoc]
-  rw [tensorCombine_def (R := R) (C := C) (M := M') (N := N')]
-  rw [LinearMap.comp_assoc]
-  rw [← TensorProduct.map_comp, Hom.map_coact_eq, Hom.map_coact_eq]
-  rw [← TensorProduct.map_comp]
-  rw [← LinearMap.comp_assoc]
+  apply TensorProduct.ext'
+  intro m n
+  have hcombine := LinearMap.congr_fun
+    (tensorCombine_natural (R := R) (C := C) (M := M) (N := N)
+      (M' := M') (N' := N') f.toLinearMap g.toLinearMap)
+    (coact (R := R) (C := C) (M := M) m ⊗ₜ[R] coact (R := R) (C := C) (M := N) n)
+  simpa [tensorCoact_tmul, Hom.map_coact_apply] using hcombine
 
 end Coact
 

--- a/TauCeti/Algebra/Coalgebra/Comodule/TensorProduct.lean
+++ b/TauCeti/Algebra/Coalgebra/Comodule/TensorProduct.lean
@@ -4,8 +4,8 @@ Released under Apache 2.0 license as described in the file LICENSE.
 -/
 module
 
-public import Mathlib.RingTheory.Bialgebra.TensorProduct
-public import TauCeti.Algebra.Coalgebra.ComoduleCat
+public import Mathlib.RingTheory.Bialgebra.Basic
+public import TauCeti.Algebra.Coalgebra.Comodule
 
 /-!
 # The tensor-product coaction map for comodules over a bialgebra
@@ -48,7 +48,7 @@ universe u v w x y z
 
 variable {R : Type u} {C : Type v} {M : Type w} {N : Type x}
 variable [CommSemiring R]
-variable [Semiring C] [Bialgebra R C]
+variable [Semiring C] [Algebra R C]
 variable [AddCommMonoid M] [Module R M]
 variable [AddCommMonoid N] [Module R N]
 
@@ -60,6 +60,15 @@ On pure tensors it sends `(m ⊗ c) ⊗ (n ⊗ d)` to `(m ⊗ n) ⊗ cd`. -/
     (M ⊗[R] C) ⊗[R] (N ⊗[R] C) →ₗ[R] (M ⊗[R] N) ⊗[R] C :=
   TensorProduct.map (LinearMap.id : M ⊗[R] N →ₗ[R] M ⊗[R] N) (LinearMap.mul' R C) ∘ₗ
     (TensorProduct.tensorTensorTensorComm R M C N C).toLinearMap
+
+/-- The definition of `tensorCombine` as a shuffle followed by multiplication on the
+`C`-components. -/
+theorem tensorCombine_def :
+    tensorCombine (R := R) (C := C) (M := M) (N := N) =
+      TensorProduct.map (LinearMap.id : M ⊗[R] N →ₗ[R] M ⊗[R] N)
+          (LinearMap.mul' R C) ∘ₗ
+        (TensorProduct.tensorTensorTensorComm R M C N C).toLinearMap :=
+  rfl
 
 /-- `tensorCombine` sends `(m ⊗ c) ⊗ (n ⊗ d)` to `(m ⊗ n) ⊗ cd`. -/
 @[simp]
@@ -80,20 +89,44 @@ theorem tensorCombine_natural (f : M →ₗ[R] M') (g : N →ₗ[R] N') :
       tensorCombine (R := R) (C := C) (M := M') (N := N') ∘ₗ
         TensorProduct.map (TensorProduct.map f (LinearMap.id : C →ₗ[R] C))
           (TensorProduct.map g (LinearMap.id : C →ₗ[R] C)) := by
-  apply TensorProduct.ext'
-  intro x y
-  induction x using TensorProduct.induction_on with
-  | zero => simp
-  | tmul m c =>
-      induction y using TensorProduct.induction_on with
-      | zero => simp
-      | tmul n d => simp [tensorCombine]
-      | add y z hy hz =>
-          rw [TensorProduct.tmul_add, LinearMap.map_add, LinearMap.map_add, hy, hz]
-  | add x y hx hy =>
-      rw [TensorProduct.add_tmul, LinearMap.map_add, LinearMap.map_add, hx, hy]
+  rw [tensorCombine_def, tensorCombine_def]
+  have h := TensorProduct.tensorTensorTensorComm_comp_map (R := R) (M := M) (N := C)
+    (P := N) (Q := C) (S := M') (T := C) (V := N') (W := C) f
+    (LinearMap.id : C →ₗ[R] C) g (LinearMap.id : C →ₗ[R] C)
+  calc
+    TensorProduct.map (TensorProduct.map f g) (LinearMap.id : C →ₗ[R] C) ∘ₗ
+        (TensorProduct.map (LinearMap.id : M ⊗[R] N →ₗ[R] M ⊗[R] N)
+          (LinearMap.mul' R C) ∘ₗ
+        (TensorProduct.tensorTensorTensorComm R M C N C).toLinearMap) =
+        (TensorProduct.map (LinearMap.id : M' ⊗[R] N' →ₗ[R] M' ⊗[R] N')
+            (LinearMap.mul' R C) ∘ₗ
+          TensorProduct.map (TensorProduct.map f g)
+            (TensorProduct.map (LinearMap.id : C →ₗ[R] C) LinearMap.id)) ∘ₗ
+          (TensorProduct.tensorTensorTensorComm R M C N C).toLinearMap := by
+      rw [LinearMap.comp_assoc]
+      apply TensorProduct.ext'
+      intro x y
+      simp [TensorProduct.map_map]
+    _ = TensorProduct.map (LinearMap.id : M' ⊗[R] N' →ₗ[R] M' ⊗[R] N')
+          (LinearMap.mul' R C) ∘ₗ
+        (TensorProduct.map (TensorProduct.map f g)
+            (TensorProduct.map (LinearMap.id : C →ₗ[R] C) LinearMap.id) ∘ₗ
+          (TensorProduct.tensorTensorTensorComm R M C N C).toLinearMap) := by
+      rw [LinearMap.comp_assoc]
+    _ = TensorProduct.map (LinearMap.id : M' ⊗[R] N' →ₗ[R] M' ⊗[R] N')
+          (LinearMap.mul' R C) ∘ₗ
+        ((TensorProduct.tensorTensorTensorComm R M' C N' C).toLinearMap ∘ₗ
+          TensorProduct.map (TensorProduct.map f (LinearMap.id : C →ₗ[R] C))
+            (TensorProduct.map g (LinearMap.id : C →ₗ[R] C))) := by
+      rw [← h]
+    _ = (TensorProduct.map (LinearMap.id : M' ⊗[R] N' →ₗ[R] M' ⊗[R] N')
+          (LinearMap.mul' R C) ∘ₗ
+        (TensorProduct.tensorTensorTensorComm R M' C N' C).toLinearMap) ∘ₗ
+          TensorProduct.map (TensorProduct.map f (LinearMap.id : C →ₗ[R] C))
+            (TensorProduct.map g (LinearMap.id : C →ₗ[R] C)) := by
+      rw [LinearMap.comp_assoc]
 
-variable [Comodule R C M] [Comodule R C N]
+variable [Coalgebra R C] [Comodule R C M] [Comodule R C N]
 
 /-- The diagonal coaction map on the tensor product of two right comodules over a bialgebra.
 
@@ -102,6 +135,15 @@ The later full tensor-product comodule structure uses this as its coaction. -/
   tensorCombine (R := R) (C := C) (M := M) (N := N) ∘ₗ
     TensorProduct.map (coact (R := R) (C := C) (M := M))
       (coact (R := R) (C := C) (M := N))
+
+/-- The definition of `tensorCoact` as the tensor product of the two component coactions,
+followed by `tensorCombine`. -/
+theorem tensorCoact_def :
+    tensorCoact (R := R) (C := C) (M := M) (N := N) =
+      tensorCombine (R := R) (C := C) (M := M) (N := N) ∘ₗ
+        TensorProduct.map (coact (R := R) (C := C) (M := M))
+          (coact (R := R) (C := C) (M := N)) :=
+  rfl
 
 /-- The tensor-product coaction, before expanding the two component coactions. -/
 @[simp]

--- a/TauCeti/Algebra/Coalgebra/Comodule/TensorProduct.lean
+++ b/TauCeti/Algebra/Coalgebra/Comodule/TensorProduct.lean
@@ -59,10 +59,16 @@ variable [AddCommMonoid N] [Module R N]
 the two `C`-components.
 
 On pure tensors it sends `(m ⊗ c) ⊗ (n ⊗ d)` to `(m ⊗ n) ⊗ cd`. -/
-irreducible_def tensorCombine :
+@[expose] def tensorCombine :
     (M ⊗[R] C) ⊗[R] (N ⊗[R] C) →ₗ[R] (M ⊗[R] N) ⊗[R] C :=
   TensorProduct.map (LinearMap.id : M ⊗[R] N →ₗ[R] M ⊗[R] N) (LinearMap.mul' R C) ∘ₗ
     (TensorProduct.tensorTensorTensorComm R M C N C).toLinearMap
+
+/-- The combining map is the tensor shuffling map followed by multiplication on `C`. -/
+theorem tensorCombine_def :
+    tensorCombine (R := R) (C := C) (M := M) (N := N) =
+      TensorProduct.map (LinearMap.id : M ⊗[R] N →ₗ[R] M ⊗[R] N) (LinearMap.mul' R C) ∘ₗ
+        (TensorProduct.tensorTensorTensorComm R M C N C).toLinearMap := rfl
 
 /-- `tensorCombine` sends `(m ⊗ c) ⊗ (n ⊗ d)` to `(m ⊗ n) ⊗ cd`. -/
 @[simp]
@@ -127,13 +133,22 @@ section Coact
 /-- The diagonal coaction map on the tensor product of two right comodules over a bialgebra.
 
 The later full tensor-product comodule structure uses this as its coaction. -/
-irreducible_def tensorCoact [Semiring C] [Bialgebra R C]
+@[expose] def tensorCoact [Semiring C] [Bialgebra R C]
     [AddCommMonoid M] [Module R M] [Comodule R C M]
     [AddCommMonoid N] [Module R N] [Comodule R C N] :
     M ⊗[R] N →ₗ[R] (M ⊗[R] N) ⊗[R] C :=
   tensorCombine (R := R) (C := C) (M := M) (N := N) ∘ₗ
     TensorProduct.map (coact (R := R) (C := C) (M := M))
       (coact (R := R) (C := C) (M := N))
+
+/-- The tensor-product coaction combines the two component coactions. -/
+theorem tensorCoact_def [Semiring C] [Bialgebra R C]
+    [AddCommMonoid M] [Module R M] [Comodule R C M]
+    [AddCommMonoid N] [Module R N] [Comodule R C N] :
+    tensorCoact (R := R) (C := C) (M := M) (N := N) =
+      tensorCombine (R := R) (C := C) (M := M) (N := N) ∘ₗ
+        TensorProduct.map (coact (R := R) (C := C) (M := M))
+          (coact (R := R) (C := C) (M := N)) := rfl
 
 /-- The tensor-product coaction, before expanding the two component coactions. -/
 @[simp]

--- a/TauCeti/Algebra/Coalgebra/Comodule/TensorProduct.lean
+++ b/TauCeti/Algebra/Coalgebra/Comodule/TensorProduct.lean
@@ -5,6 +5,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 module
 
 public import Mathlib.RingTheory.Bialgebra.Basic
+public import Mathlib.Tactic.IrreducibleDef
 public import TauCeti.Algebra.Coalgebra.Comodule
 
 /-!
@@ -59,16 +60,10 @@ variable [AddCommMonoid N] [Module R N]
 the two `C`-components.
 
 On pure tensors it sends `(m ⊗ c) ⊗ (n ⊗ d)` to `(m ⊗ n) ⊗ cd`. -/
-@[expose] def tensorCombine :
+irreducible_def tensorCombine :
     (M ⊗[R] C) ⊗[R] (N ⊗[R] C) →ₗ[R] (M ⊗[R] N) ⊗[R] C :=
   TensorProduct.map (LinearMap.id : M ⊗[R] N →ₗ[R] M ⊗[R] N) (LinearMap.mul' R C) ∘ₗ
     (TensorProduct.tensorTensorTensorComm R M C N C).toLinearMap
-
-/-- The combining map is the tensor shuffling map followed by multiplication on `C`. -/
-theorem tensorCombine_def :
-    tensorCombine (R := R) (C := C) (M := M) (N := N) =
-      TensorProduct.map (LinearMap.id : M ⊗[R] N →ₗ[R] M ⊗[R] N) (LinearMap.mul' R C) ∘ₗ
-        (TensorProduct.tensorTensorTensorComm R M C N C).toLinearMap := rfl
 
 /-- `tensorCombine` sends `(m ⊗ c) ⊗ (n ⊗ d)` to `(m ⊗ n) ⊗ cd`. -/
 @[simp]
@@ -133,22 +128,13 @@ section Coact
 /-- The diagonal coaction map on the tensor product of two right comodules over a bialgebra.
 
 The later full tensor-product comodule structure uses this as its coaction. -/
-@[expose] def tensorCoact [Semiring C] [Bialgebra R C]
+irreducible_def tensorCoact [Semiring C] [Bialgebra R C]
     [AddCommMonoid M] [Module R M] [Comodule R C M]
     [AddCommMonoid N] [Module R N] [Comodule R C N] :
     M ⊗[R] N →ₗ[R] (M ⊗[R] N) ⊗[R] C :=
   tensorCombine (R := R) (C := C) (M := M) (N := N) ∘ₗ
     TensorProduct.map (coact (R := R) (C := C) (M := M))
       (coact (R := R) (C := C) (M := N))
-
-/-- The tensor-product coaction combines the two component coactions. -/
-theorem tensorCoact_def [Semiring C] [Bialgebra R C]
-    [AddCommMonoid M] [Module R M] [Comodule R C M]
-    [AddCommMonoid N] [Module R N] [Comodule R C N] :
-    tensorCoact (R := R) (C := C) (M := M) (N := N) =
-      tensorCombine (R := R) (C := C) (M := M) (N := N) ∘ₗ
-        TensorProduct.map (coact (R := R) (C := C) (M := M))
-          (coact (R := R) (C := C) (M := N)) := rfl
 
 /-- The tensor-product coaction, before expanding the two component coactions. -/
 @[simp]

--- a/TauCeti/Algebra/Coalgebra/Comodule/TensorProduct.lean
+++ b/TauCeti/Algebra/Coalgebra/Comodule/TensorProduct.lean
@@ -1,0 +1,130 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+module
+
+public import Mathlib.RingTheory.Bialgebra.TensorProduct
+public import TauCeti.Algebra.Coalgebra.ComoduleCat
+
+/-!
+# The tensor-product coaction map for comodules over a bialgebra
+
+This file constructs the diagonal coaction map used in the tensor product of two right
+comodules over a bialgebra. If `M` and `N` are right comodules over `C`, the map on
+`M ⊗ N` is the usual formula
+
+`m ⊗ n ↦ m₀ ⊗ n₀ ⊗ m₁ n₁`.
+
+This is the concrete linear-map prerequisite for the full tensor-product comodule structure:
+the counit and coassociativity laws can be proved against this map, and the naturality lemma
+here is the morphism-level compatibility needed for the later categorical tensor product.
+
+## Main declarations
+
+* `TauCeti.Comodule.tensorCombine`: combines two coacted tensor factors.
+* `TauCeti.Comodule.tensorCoact`: the diagonal coaction on `M ⊗ N`.
+* `TauCeti.Comodule.tensorCombine_natural`: naturality of the combining map in the two
+  comodule carriers.
+* `TauCeti.Comodule.tensorCoact_natural`: the diagonal coaction commutes with tensoring
+  comodule morphisms.
+
+## References
+
+This is the standard diagonal map for the tensor product of right comodules over a bialgebra;
+see Sweedler, *Hopf Algebras*, Chapter 2.
+-/
+
+public section
+
+open scoped TensorProduct
+open TensorProduct
+
+namespace TauCeti
+
+namespace Comodule
+
+universe u v w x y z
+
+variable {R : Type u} {C : Type v} {M : Type w} {N : Type x}
+variable [CommSemiring R]
+variable [Semiring C] [Bialgebra R C]
+variable [AddCommMonoid M] [Module R M]
+variable [AddCommMonoid N] [Module R N]
+
+/-- Combine two coacted tensor factors by shuffling the middle factors together and multiplying
+the two `C`-components.
+
+On pure tensors it sends `(m ⊗ c) ⊗ (n ⊗ d)` to `(m ⊗ n) ⊗ cd`. -/
+@[expose] def tensorCombine :
+    (M ⊗[R] C) ⊗[R] (N ⊗[R] C) →ₗ[R] (M ⊗[R] N) ⊗[R] C :=
+  TensorProduct.map (LinearMap.id : M ⊗[R] N →ₗ[R] M ⊗[R] N) (LinearMap.mul' R C) ∘ₗ
+    (TensorProduct.tensorTensorTensorComm R M C N C).toLinearMap
+
+/-- `tensorCombine` sends `(m ⊗ c) ⊗ (n ⊗ d)` to `(m ⊗ n) ⊗ cd`. -/
+@[simp]
+theorem tensorCombine_tmul_tmul (m : M) (c : C) (n : N) (d : C) :
+    tensorCombine (R := R) (C := C) (M := M) (N := N)
+        ((m ⊗ₜ[R] c) ⊗ₜ[R] (n ⊗ₜ[R] d)) =
+      (m ⊗ₜ[R] n) ⊗ₜ[R] (c * d) := by
+  simp [tensorCombine]
+
+variable {M' : Type y} {N' : Type z}
+variable [AddCommMonoid M'] [Module R M']
+variable [AddCommMonoid N'] [Module R N']
+
+/-- The combining map is natural in the two comodule carriers. -/
+theorem tensorCombine_natural (f : M →ₗ[R] M') (g : N →ₗ[R] N') :
+    TensorProduct.map (TensorProduct.map f g) (LinearMap.id : C →ₗ[R] C) ∘ₗ
+        tensorCombine (R := R) (C := C) (M := M) (N := N) =
+      tensorCombine (R := R) (C := C) (M := M') (N := N') ∘ₗ
+        TensorProduct.map (TensorProduct.map f (LinearMap.id : C →ₗ[R] C))
+          (TensorProduct.map g (LinearMap.id : C →ₗ[R] C)) := by
+  apply TensorProduct.ext'
+  intro x y
+  induction x using TensorProduct.induction_on with
+  | zero => simp
+  | tmul m c =>
+      induction y using TensorProduct.induction_on with
+      | zero => simp
+      | tmul n d => simp [tensorCombine]
+      | add y z hy hz =>
+          rw [TensorProduct.tmul_add, LinearMap.map_add, LinearMap.map_add, hy, hz]
+  | add x y hx hy =>
+      rw [TensorProduct.add_tmul, LinearMap.map_add, LinearMap.map_add, hx, hy]
+
+variable [Comodule R C M] [Comodule R C N]
+
+/-- The diagonal coaction map on the tensor product of two right comodules over a bialgebra.
+
+The later full tensor-product comodule structure uses this as its coaction. -/
+@[expose] def tensorCoact : M ⊗[R] N →ₗ[R] (M ⊗[R] N) ⊗[R] C :=
+  tensorCombine (R := R) (C := C) (M := M) (N := N) ∘ₗ
+    TensorProduct.map (coact (R := R) (C := C) (M := M))
+      (coact (R := R) (C := C) (M := N))
+
+/-- The tensor-product coaction, before expanding the two component coactions. -/
+@[simp]
+theorem tensorCoact_tmul (m : M) (n : N) :
+    tensorCoact (R := R) (C := C) (M := M) (N := N) (m ⊗ₜ[R] n) =
+      tensorCombine (R := R) (C := C) (M := M) (N := N)
+        (coact (R := R) (C := C) (M := M) m ⊗ₜ[R]
+          coact (R := R) (C := C) (M := N) n) := by
+  simp [tensorCoact]
+
+variable [Comodule R C M'] [Comodule R C N']
+
+/-- The diagonal tensor coaction is natural under tensor products of comodule morphisms. -/
+theorem tensorCoact_natural (f : Hom R C M M') (g : Hom R C N N') :
+    TensorProduct.map (TensorProduct.map f.toLinearMap g.toLinearMap)
+        (LinearMap.id : C →ₗ[R] C) ∘ₗ
+        tensorCoact (R := R) (C := C) (M := M) (N := N) =
+      tensorCoact (R := R) (C := C) (M := M') (N := N') ∘ₗ
+        TensorProduct.map f.toLinearMap g.toLinearMap := by
+  rw [tensorCoact, tensorCoact, ← LinearMap.comp_assoc, tensorCombine_natural]
+  ext m n
+  simp [Hom.map_coact_apply]
+
+end Comodule
+
+end TauCeti

--- a/TauCeti/Algebra/Coalgebra/Comodule/TensorProduct.lean
+++ b/TauCeti/Algebra/Coalgebra/Comodule/TensorProduct.lean
@@ -58,13 +58,17 @@ variable [AddCommMonoid N] [Module R N]
 /-- Combine two coacted tensor factors by shuffling the middle factors together and multiplying
 the two `C`-components.
 
-On pure tensors it sends `(m ⊗ c) ⊗ (n ⊗ d)` to `(m ⊗ n) ⊗ cd`. The body is kept unexposed;
-the public API is the generated `tensorCombine_def` equation together with the simp and
-naturality lemmas below. -/
-irreducible_def tensorCombine :
+On pure tensors it sends `(m ⊗ c) ⊗ (n ⊗ d)` to `(m ⊗ n) ⊗ cd`. -/
+@[expose] def tensorCombine :
     (M ⊗[R] C) ⊗[R] (N ⊗[R] C) →ₗ[R] (M ⊗[R] N) ⊗[R] C :=
   TensorProduct.map (LinearMap.id : M ⊗[R] N →ₗ[R] M ⊗[R] N) (LinearMap.mul' R C) ∘ₗ
     (TensorProduct.tensorTensorTensorComm R M C N C).toLinearMap
+
+/-- The combining map is the tensor shuffling map followed by multiplication on `C`. -/
+theorem tensorCombine_def :
+    tensorCombine (R := R) (C := C) (M := M) (N := N) =
+      TensorProduct.map (LinearMap.id : M ⊗[R] N →ₗ[R] M ⊗[R] N) (LinearMap.mul' R C) ∘ₗ
+        (TensorProduct.tensorTensorTensorComm R M C N C).toLinearMap := rfl
 
 /-- `tensorCombine` sends `(m ⊗ c) ⊗ (n ⊗ d)` to `(m ⊗ n) ⊗ cd`. -/
 @[simp]
@@ -128,16 +132,23 @@ section Coact
 
 /-- The diagonal coaction map on the tensor product of two right comodules over a bialgebra.
 
-The later full tensor-product comodule structure uses this as its coaction. The body is kept
-unexposed; the public API is the generated `tensorCoact_def` equation together with the simp
-and naturality lemmas below. -/
-irreducible_def tensorCoact [Semiring C] [Bialgebra R C]
+The later full tensor-product comodule structure uses this as its coaction. -/
+@[expose] def tensorCoact [Semiring C] [Bialgebra R C]
     [AddCommMonoid M] [Module R M] [Comodule R C M]
     [AddCommMonoid N] [Module R N] [Comodule R C N] :
     M ⊗[R] N →ₗ[R] (M ⊗[R] N) ⊗[R] C :=
   tensorCombine (R := R) (C := C) (M := M) (N := N) ∘ₗ
     TensorProduct.map (coact (R := R) (C := C) (M := M))
       (coact (R := R) (C := C) (M := N))
+
+/-- The tensor-product coaction combines the two component coactions. -/
+theorem tensorCoact_def [Semiring C] [Bialgebra R C]
+    [AddCommMonoid M] [Module R M] [Comodule R C M]
+    [AddCommMonoid N] [Module R N] [Comodule R C N] :
+    tensorCoact (R := R) (C := C) (M := M) (N := N) =
+      tensorCombine (R := R) (C := C) (M := M) (N := N) ∘ₗ
+        TensorProduct.map (coact (R := R) (C := C) (M := M))
+          (coact (R := R) (C := C) (M := N)) := rfl
 
 /-- The tensor-product coaction, before expanding the two component coactions. -/
 @[simp]

--- a/TauCeti/Algebra/Coalgebra/Comodule/TensorProduct.lean
+++ b/TauCeti/Algebra/Coalgebra/Comodule/TensorProduct.lean
@@ -56,7 +56,7 @@ variable [AddCommMonoid N] [Module R N]
 the two `C`-components.
 
 On pure tensors it sends `(m ⊗ c) ⊗ (n ⊗ d)` to `(m ⊗ n) ⊗ cd`. -/
-irreducible_def tensorCombine :
+def tensorCombine :
     (M ⊗[R] C) ⊗[R] (N ⊗[R] C) →ₗ[R] (M ⊗[R] N) ⊗[R] C :=
   TensorProduct.map (LinearMap.id : M ⊗[R] N →ₗ[R] M ⊗[R] N) (LinearMap.mul' R C) ∘ₗ
     (TensorProduct.tensorTensorTensorComm R M C N C).toLinearMap
@@ -67,7 +67,7 @@ theorem tensorCombine_tmul_tmul (m : M) (c : C) (n : N) (d : C) :
     tensorCombine (R := R) (C := C) (M := M) (N := N)
         ((m ⊗ₜ[R] c) ⊗ₜ[R] (n ⊗ₜ[R] d)) =
       (m ⊗ₜ[R] n) ⊗ₜ[R] (c * d) := by
-  simp [tensorCombine_def]
+  simp [tensorCombine]
 
 variable {M' : Type y} {N' : Type z}
 variable [AddCommMonoid M'] [Module R M']
@@ -80,7 +80,7 @@ theorem tensorCombine_natural (f : M →ₗ[R] M') (g : N →ₗ[R] N') :
       tensorCombine (R := R) (C := C) (M := M') (N := N') ∘ₗ
         TensorProduct.map (TensorProduct.map f (LinearMap.id : C →ₗ[R] C))
           (TensorProduct.map g (LinearMap.id : C →ₗ[R] C)) := by
-  rw [tensorCombine_def, tensorCombine_def]
+  rw [tensorCombine, tensorCombine]
   have h := TensorProduct.tensorTensorTensorComm_comp_map (R := R) (M := M) (N := C)
     (P := N) (Q := C) (S := M') (T := C) (V := N') (W := C) f
     (LinearMap.id : C →ₗ[R] C) g (LinearMap.id : C →ₗ[R] C)
@@ -122,7 +122,7 @@ variable [Coalgebra R C] [Comodule R C M] [Comodule R C N]
 /-- The diagonal coaction map on the tensor product of two right comodules over a bialgebra.
 
 The later full tensor-product comodule structure uses this as its coaction. -/
-irreducible_def tensorCoact : M ⊗[R] N →ₗ[R] (M ⊗[R] N) ⊗[R] C :=
+def tensorCoact : M ⊗[R] N →ₗ[R] (M ⊗[R] N) ⊗[R] C :=
   tensorCombine (R := R) (C := C) (M := M) (N := N) ∘ₗ
     TensorProduct.map (coact (R := R) (C := C) (M := M))
       (coact (R := R) (C := C) (M := N))
@@ -134,7 +134,7 @@ theorem tensorCoact_tmul (m : M) (n : N) :
       tensorCombine (R := R) (C := C) (M := M) (N := N)
         (coact (R := R) (C := C) (M := M) m ⊗ₜ[R]
           coact (R := R) (C := C) (M := N) n) := by
-  simp [tensorCoact_def]
+  simp [tensorCoact]
 
 variable [Comodule R C M'] [Comodule R C N']
 
@@ -145,7 +145,7 @@ theorem tensorCoact_natural (f : Hom R C M M') (g : Hom R C N N') :
         tensorCoact (R := R) (C := C) (M := M) (N := N) =
       tensorCoact (R := R) (C := C) (M := M') (N := N') ∘ₗ
         TensorProduct.map f.toLinearMap g.toLinearMap := by
-  rw [tensorCoact_def, tensorCoact_def, ← LinearMap.comp_assoc, tensorCombine_natural,
+  rw [tensorCoact, tensorCoact, ← LinearMap.comp_assoc, tensorCombine_natural,
     LinearMap.comp_assoc, LinearMap.comp_assoc]
   congr 1
   rw [← TensorProduct.map_comp, ← TensorProduct.map_comp, Hom.map_coact_eq, Hom.map_coact_eq]

--- a/TauCeti/Algebra/Coalgebra/Comodule/TensorProduct.lean
+++ b/TauCeti/Algebra/Coalgebra/Comodule/TensorProduct.lean
@@ -58,18 +58,15 @@ variable [AddCommMonoid N] [Module R N]
 /-- Combine two coacted tensor factors by shuffling the middle factors together and multiplying
 the two `C`-components.
 
-On pure tensors it sends `(m ⊗ c) ⊗ (n ⊗ d)` to `(m ⊗ n) ⊗ cd`. -/
-abbrev tensorCombine :
+On pure tensors it sends `(m ⊗ c) ⊗ (n ⊗ d)` to `(m ⊗ n) ⊗ cd`.
+
+This is `irreducible_def`, exposing the public `tensorCombine_def` equation lemma while keeping
+the shuffle/multiplication body opaque so downstream code depends only on the characteristic
+lemmas below. -/
+noncomputable irreducible_def tensorCombine :
     (M ⊗[R] C) ⊗[R] (N ⊗[R] C) →ₗ[R] (M ⊗[R] N) ⊗[R] C :=
   TensorProduct.map (LinearMap.id : M ⊗[R] N →ₗ[R] M ⊗[R] N) (LinearMap.mul' R C) ∘ₗ
     (TensorProduct.tensorTensorTensorComm R M C N C).toLinearMap
-
-/-- The definition of `tensorCombine`. -/
-theorem tensorCombine_def :
-    tensorCombine (R := R) (C := C) (M := M) (N := N) =
-      TensorProduct.map (LinearMap.id : M ⊗[R] N →ₗ[R] M ⊗[R] N) (LinearMap.mul' R C) ∘ₗ
-        (TensorProduct.tensorTensorTensorComm R M C N C).toLinearMap :=
-  rfl
 
 /-- `tensorCombine` sends `(m ⊗ c) ⊗ (n ⊗ d)` to `(m ⊗ n) ⊗ cd`. -/
 @[simp]
@@ -133,24 +130,18 @@ section Coact
 
 /-- The diagonal coaction map on the tensor product of two right comodules over a bialgebra.
 
-The later full tensor-product comodule structure uses this as its coaction. -/
-abbrev tensorCoact [Semiring C] [Bialgebra R C]
+The later full tensor-product comodule structure uses this as its coaction.
+
+This is `irreducible_def`, exposing the public `tensorCoact_def` equation lemma while keeping the
+composition body opaque so downstream code depends only on the characteristic coaction lemmas
+`tensorCoact_tmul` and `tensorCoact_natural` rather than on this composition by reduction. -/
+noncomputable irreducible_def tensorCoact [Semiring C] [Bialgebra R C]
     [AddCommMonoid M] [Module R M] [Comodule R C M]
     [AddCommMonoid N] [Module R N] [Comodule R C N] :
     M ⊗[R] N →ₗ[R] (M ⊗[R] N) ⊗[R] C :=
   tensorCombine (R := R) (C := C) (M := M) (N := N) ∘ₗ
     TensorProduct.map (coact (R := R) (C := C) (M := M))
       (coact (R := R) (C := C) (M := N))
-
-/-- The definition of `tensorCoact`. -/
-theorem tensorCoact_def [Semiring C] [Bialgebra R C]
-    [AddCommMonoid M] [Module R M] [Comodule R C M]
-    [AddCommMonoid N] [Module R N] [Comodule R C N] :
-    tensorCoact (R := R) (C := C) (M := M) (N := N) =
-      tensorCombine (R := R) (C := C) (M := M) (N := N) ∘ₗ
-        TensorProduct.map (coact (R := R) (C := C) (M := M))
-          (coact (R := R) (C := C) (M := N)) :=
-  rfl
 
 /-- The tensor-product coaction, before expanding the two component coactions. -/
 @[simp]


### PR DESCRIPTION
This PR adds the diagonal tensor-product coaction map for right comodules over a bialgebra: the combining map sends `(m ⊗ c) ⊗ (n ⊗ d)` to `(m ⊗ n) ⊗ cd`, and `tensorCoact` applies this after the two component coactions, giving the usual formula `m ⊗ n ↦ m₀ ⊗ n₀ ⊗ m₁n₁`. It also proves the combining map is natural in the two carrier modules and that the diagonal coaction map is natural under comodule morphisms, so the later tensor-product comodule structure has its concrete linear map and morphism compatibility already packaged.

This advances `TauCetiRoadmap/ReductiveGroups/README.md`, Layer 1, “Comodules over a coalgebra/Hopf algebra,” specifically the requested tensor-products part of the finite-dimensional comodule category. I chose it as the lowest-hanging distinct ReductiveGroups prerequisite after checking open and recently merged PRs: Layer 0 convolution points and base change are already present, the subcomodule image/comap/quotient and finite bookkeeping APIs have landed, and the open ReductiveGroups PR covers comodule invariants, while the tensor-product coaction map itself was still absent. This PR deliberately stops at the stable linear-map prerequisite and naturality lemma rather than asserting the full comodule instance before its counit and coassociativity proof layer is in place.

No Mathlib infrastructure is vendored. The implementation reuses Mathlib’s tensor shuffle `TensorProduct.tensorTensorTensorComm`, multiplication as a linear map `LinearMap.mul'`, and the existing Tau Ceti `Comodule.Hom.map_coact_apply` API.

`lake exe cache get` completed with `No files to download` and `Already decompressed 8619 file(s)`. `lake build` reported `Build completed successfully (4703 jobs).` `lake exe axioms` reported `axioms: audited 8929 TauCeti declaration(s); all within the allowlist [propext, Classical.choice, Quot.sound].`

<!--tauceti-target:v1 {"focus":"ReductiveGroups","id":"comodule-tensor-product"}-->

🤖 Prepared with Codex
