### PR TITLE
feat: the de Finetti–Ryll-Nardzewski equivalences (roadmap summit wrappers)

### DIFF
--- a/TauCeti/Probability/DeFinetti/Theorem.lean
+++ b/TauCeti/Probability/DeFinetti/Theorem.lean
@@ -1,0 +1,90 @@
+module
+
+public import TauCeti.Probability.DeFinetti.BlockFactorization
+-- Non-public: used only inside proofs — the Layer-0 bridge from conditional i.i.d. back to
+-- exchangeability.
+import TauCeti.Probability.Exchangeability.ConditionallyIIDImplications
+
+/-!
+# The de Finetti–Ryll-Nardzewski equivalences
+
+The equivalence forms of the de Finetti summit: for a process with measurable coordinates, valued
+in a nonempty standard Borel space, under a finite measure,
+
+* exchangeable **iff** conditionally i.i.d. (`exchangeable_iff_conditionallyIID`), and
+* contractable **iff** exchangeable and conditionally i.i.d.
+  (`contractable_iff_exchangeable_and_conditionallyIID`)
+
+— Kallenberg, *Probabilistic Symmetries and Invariance Principles*, Theorem 1.1 (pp. 26–28). The
+hard direction is the merged reverse-martingale de Finetti chain
+(`conditionallyIID_of_contractable`); the converse directions are the Layer-0 bridges
+(`ConditionallyIID.exchangeable`, `contractable_of_exchangeable`). This file assembles the
+equivalences and provides the roadmap target handles (`TauCetiRoadmap`, Exchangeability
+Layers 6–7): `deFinetti`, `deFinetti_equivalence`, and `deFinetti_RyllNardzewski_equivalence`.
+
+Both equivalences hold on an arbitrary measurable sample space `Ω` under `[IsFiniteMeasure μ]`;
+the standard-Borel hypothesis sits only on the state space `α`, where the directing measure lives.
+
+Adapted from `cameronfreer/exchangeability` (`DeFinetti/TheoremViaMartingale.lean`, pin
+`e0532e59ceff23edab44dda9ab0655debbc9cc22`); the statements here are the source's final wrappers,
+generalized from `[StandardBorelSpace Ω]` + probability measures to arbitrary measurable `Ω` +
+finite measures.
+
+## Main results
+
+* `exchangeable_iff_conditionallyIID` — de Finetti's theorem as an equivalence.
+* `contractable_iff_exchangeable_and_conditionallyIID` — the Ryll-Nardzewski equivalence.
+* `deFinetti`, `deFinetti_equivalence`, `deFinetti_RyllNardzewski_equivalence` — roadmap target
+  handles (aliases).
+-/
+
+public section
+
+noncomputable section
+
+open MeasureTheory
+
+namespace TauCeti
+
+namespace Probability
+
+variable {Ω α : Type*} {mΩ : MeasurableSpace Ω} [MeasurableSpace α]
+
+/-- **De Finetti's theorem, equivalence form** (Kallenberg, Theorem 1.1). A process with
+measurable coordinates, valued in a nonempty standard Borel space, under a finite measure, is
+exchangeable iff it is conditionally i.i.d. The forward direction is the reverse-martingale
+de Finetti chain (`conditionallyIID_of_exchangeable`); the converse is the mixture computation
+`ConditionallyIID.exchangeable`, which needs no side hypotheses. -/
+theorem exchangeable_iff_conditionallyIID [StandardBorelSpace α] [Nonempty α] {μ : Measure Ω}
+    [IsFiniteMeasure μ] {X : ℕ → Ω → α} (hX_meas : ∀ n, Measurable (X n)) :
+    Exchangeable μ X ↔ ConditionallyIID μ X :=
+  ⟨fun hX => conditionallyIID_of_exchangeable hX hX_meas, fun hX => hX.exchangeable⟩
+
+/-- **The de Finetti–Ryll-Nardzewski equivalence** (Kallenberg, Theorem 1.1). A process with
+measurable coordinates, valued in a nonempty standard Borel space, under a finite measure, is
+contractable iff it is exchangeable and conditionally i.i.d. Forward: the reverse-martingale
+de Finetti chain (`conditionallyIID_of_contractable`), with exchangeability read off the mixture
+representation; converse: `contractable_of_exchangeable`. -/
+theorem contractable_iff_exchangeable_and_conditionallyIID [StandardBorelSpace α] [Nonempty α]
+    {μ : Measure Ω} [IsFiniteMeasure μ] {X : ℕ → Ω → α} (hX_meas : ∀ n, Measurable (X n)) :
+    Contractable μ X ↔ Exchangeable μ X ∧ ConditionallyIID μ X := by
+  refine ⟨fun hX => ?_, fun hX =>
+    contractable_of_exchangeable hX.1 fun i => (hX_meas i).aemeasurable⟩
+  have hiid : ConditionallyIID μ X := conditionallyIID_of_contractable hX hX_meas
+  exact ⟨hiid.exchangeable, hiid⟩
+
+/-- Roadmap Layer 6 target name (`TauCetiRoadmap/Exchangeability`) for de Finetti's theorem,
+`conditionallyIID_of_exchangeable`. -/
+alias deFinetti := conditionallyIID_of_exchangeable
+
+/-- Roadmap Layer 7 target name (`TauCetiRoadmap/Exchangeability`) for the de Finetti equivalence
+`exchangeable_iff_conditionallyIID`. -/
+alias deFinetti_equivalence := exchangeable_iff_conditionallyIID
+
+/-- Roadmap Layer 6 target name (`TauCetiRoadmap/Exchangeability`) for the Ryll-Nardzewski
+equivalence `contractable_iff_exchangeable_and_conditionallyIID`. -/
+alias deFinetti_RyllNardzewski_equivalence := contractable_iff_exchangeable_and_conditionallyIID
+
+end Probability
+
+end TauCeti

--- a/TauCeti/Probability/DeFinetti/Theorem.lean
+++ b/TauCeti/Probability/DeFinetti/Theorem.lean
@@ -1,8 +1,8 @@
 module
 
 public import TauCeti.Probability.DeFinetti.BlockFactorization
--- Non-public: used only inside proofs — the Layer-0 bridge from conditional i.i.d. back to
--- exchangeability.
+-- Non-public: used only inside proofs — the Layer-0 bridges from conditional i.i.d. back to
+-- exchangeability and contractability.
 import TauCeti.Probability.Exchangeability.ConditionallyIIDImplications
 
 /-!
@@ -11,14 +11,17 @@ import TauCeti.Probability.Exchangeability.ConditionallyIIDImplications
 The equivalence forms of the de Finetti summit: for a process with measurable coordinates, valued
 in a nonempty standard Borel space, under a finite measure,
 
-* exchangeable **iff** conditionally i.i.d. (`exchangeable_iff_conditionallyIID`), and
+* exchangeable **iff** conditionally i.i.d. (`exchangeable_iff_conditionallyIID`),
+* contractable **iff** conditionally i.i.d. (`contractable_iff_conditionallyIID`, the two-way
+  form), and
 * contractable **iff** exchangeable and conditionally i.i.d.
-  (`contractable_iff_exchangeable_and_conditionallyIID`)
+  (`contractable_iff_exchangeable_and_conditionallyIID`, the roadmap's conjunction form, derived
+  from the two-way form)
 
 — Kallenberg, *Probabilistic Symmetries and Invariance Principles*, Theorem 1.1 (pp. 26–28). The
 hard direction is the merged reverse-martingale de Finetti chain
 (`conditionallyIID_of_contractable`); the converse directions are the Layer-0 bridges
-(`ConditionallyIID.exchangeable`, `contractable_of_exchangeable`). This file assembles the
+(`ConditionallyIID.exchangeable`, `ConditionallyIID.contractable`). This file assembles the
 equivalences and provides the roadmap target handles (`TauCetiRoadmap`, Exchangeability
 Layers 6–7): `deFinetti`, `deFinetti_equivalence`, and `deFinetti_RyllNardzewski_equivalence`.
 
@@ -33,7 +36,8 @@ finite measures.
 ## Main results
 
 * `exchangeable_iff_conditionallyIID` — de Finetti's theorem as an equivalence.
-* `contractable_iff_exchangeable_and_conditionallyIID` — the Ryll-Nardzewski equivalence.
+* `contractable_iff_conditionallyIID` — the two-way Ryll-Nardzewski equivalence.
+* `contractable_iff_exchangeable_and_conditionallyIID` — the roadmap's conjunction form.
 * `deFinetti`, `deFinetti_equivalence`, `deFinetti_RyllNardzewski_equivalence` — roadmap target
   handles (aliases).
 -/
@@ -60,18 +64,25 @@ theorem exchangeable_iff_conditionallyIID [StandardBorelSpace α] [Nonempty α] 
     Exchangeable μ X ↔ ConditionallyIID μ X :=
   ⟨fun hX => conditionallyIID_of_exchangeable hX hX_meas, fun hX => hX.exchangeable⟩
 
-/-- **The de Finetti–Ryll-Nardzewski equivalence** (Kallenberg, Theorem 1.1). A process with
-measurable coordinates, valued in a nonempty standard Borel space, under a finite measure, is
-contractable iff it is exchangeable and conditionally i.i.d. Forward: the reverse-martingale
-de Finetti chain (`conditionallyIID_of_contractable`), with exchangeability read off the mixture
-representation; converse: `contractable_of_exchangeable`. -/
+/-- **De Finetti–Ryll-Nardzewski, two-way form.** A process with measurable coordinates, valued
+in a nonempty standard Borel space, under a finite measure, is contractable iff it is conditionally
+i.i.d. Forward: the reverse-martingale de Finetti chain (`conditionallyIID_of_contractable`);
+converse: `ConditionallyIID.contractable`, which needs no side hypotheses. -/
+theorem contractable_iff_conditionallyIID [StandardBorelSpace α] [Nonempty α]
+    {μ : Measure Ω} [IsFiniteMeasure μ] {X : ℕ → Ω → α} (hX_meas : ∀ n, Measurable (X n)) :
+    Contractable μ X ↔ ConditionallyIID μ X :=
+  ⟨fun hX => conditionallyIID_of_contractable hX hX_meas, fun hX => hX.contractable⟩
+
+/-- **The de Finetti–Ryll-Nardzewski equivalence** (Kallenberg, Theorem 1.1), in the roadmap's
+conjunction form: contractable iff exchangeable and conditionally i.i.d. Derived from the two-way
+`contractable_iff_conditionallyIID`, with the exchangeability conjunct supplied by
+`ConditionallyIID.exchangeable` (the conjunct is redundant given conditional i.i.d., but this is
+the equivalence the roadmap names). -/
 theorem contractable_iff_exchangeable_and_conditionallyIID [StandardBorelSpace α] [Nonempty α]
     {μ : Measure Ω} [IsFiniteMeasure μ] {X : ℕ → Ω → α} (hX_meas : ∀ n, Measurable (X n)) :
-    Contractable μ X ↔ Exchangeable μ X ∧ ConditionallyIID μ X := by
-  refine ⟨fun hX => ?_, fun hX =>
-    contractable_of_exchangeable hX.1 fun i => (hX_meas i).aemeasurable⟩
-  have hiid : ConditionallyIID μ X := conditionallyIID_of_contractable hX hX_meas
-  exact ⟨hiid.exchangeable, hiid⟩
+    Contractable μ X ↔ Exchangeable μ X ∧ ConditionallyIID μ X :=
+  (contractable_iff_conditionallyIID hX_meas).trans
+    ⟨fun hX => ⟨hX.exchangeable, hX⟩, And.right⟩
 
 /-- Roadmap Layer 6 target name (`TauCetiRoadmap/Exchangeability`) for de Finetti's theorem,
 `conditionallyIID_of_exchangeable`. -/


### PR DESCRIPTION
<!--tauceti-target:v1 {"focus":"Exchangeability","id":"de-finetti-ryll-nardzewski-equivalence"}-->

## Summary

Adds `TauCeti/Probability/DeFinetti/Theorem.lean` — the **equivalence forms of the de Finetti
summit** (`namespace TauCeti.Probability`), assembling the merged reverse-martingale chain into the
Exchangeability roadmap's final wrappers:

- `exchangeable_iff_conditionallyIID` — de Finetti's theorem as an equivalence:
  exchangeable ↔ conditionally i.i.d.;
- `contractable_iff_exchangeable_and_conditionallyIID` — the **Ryll-Nardzewski equivalence**
  (Kallenberg, *Probabilistic Symmetries and Invariance Principles*, Theorem 1.1):
  contractable ↔ exchangeable ∧ conditionally i.i.d.;
- roadmap target handles as aliases (the merged `upcrossings_bdd_uniform` pattern): `deFinetti`,
  `deFinetti_equivalence`, `deFinetti_RyllNardzewski_equivalence`.

## How it's proved (reuse)

Pure assembly of merged theorems — no new analytic content:

- hard directions: `conditionallyIID_of_contractable` / `conditionallyIID_of_exchangeable` (the
  merged de Finetti chain, `BlockFactorization.lean`);
- converses: `ConditionallyIID.exchangeable` (the mixture computation, no side hypotheses) and
  `contractable_of_exchangeable`.

The one non-public import (`ConditionallyIIDImplications`) is proof-only.

## Roadmap

Completes the `TauCetiRoadmap/Exchangeability` **Layer 6 summit** shapes (both `Suggested.lean`
summit forms) and the Layer 7 public names, in the roadmap's suggested home
(`DeFinetti/Theorem.lean`).

Closes TauCetiProject/TauCetiRoadmap#54 — the reverse-martingale intention (Layer-4 engine + the
conditional-independence chain + the summit): everything in its scope is on `main` once this
merges.

Checked open PRs: none touch `TauCeti/Probability/DeFinetti/`.

## Generality

Both equivalences hold on an **arbitrary measurable sample space `Ω`** at `[IsFiniteMeasure μ]`;
`[StandardBorelSpace α] [Nonempty α]` sit only on the state space, where the directing measure
lives — matching the merged summit implications and exceeding the roadmap's probability-measure
target.

## Test plan

```bash
lake build && lake exe axioms && lake exe module-system && bash scripts/lint-env.sh
```

`lake build TauCeti.Probability.DeFinetti.Theorem` green locally (post-cache, current `main`
merge-base); sorry-free; axioms of all five declarations exactly
{`propext`, `Classical.choice`, `Quot.sound`}; lines ≤100.

## Attribution

Adapted from `cameronfreer/exchangeability` (`DeFinetti/TheoremViaMartingale.lean`, pin
`e0532e59ceff23edab44dda9ab0655debbc9cc22`), generalized from `[StandardBorelSpace Ω]` +
probability measures to arbitrary measurable `Ω` + finite measures. Written by Claude (Fable 5),
human-directed.
