### PR TITLE
feat: disc automorphisms are infinitesimal Poincaré isometries

### DIFF
--- a/TauCeti/Analysis/Complex/Conformal/PseudoHyperbolic.lean
+++ b/TauCeti/Analysis/Complex/Conformal/PseudoHyperbolic.lean
@@ -173,6 +173,13 @@ private lemma normSq_one_sub_conj_mul_sub_normSq_sub (z w : ℂ) :
   rw [hre]
   ring_nf
 
+/-- **Poincaré defect identity (norm form).** The difference of the squared norms of the Moebius
+denominator and numerator factors is the product of the two hyperbolic defects:
+`‖1 - conj w * z‖ ^ 2 - ‖z - w‖ ^ 2 = (1 - ‖z‖ ^ 2) * (1 - ‖w‖ ^ 2)`. -/
+lemma norm_sq_one_sub_conj_mul_sub_norm_sq_sub (z w : ℂ) :
+    ‖(1 : ℂ) - (starRingEnd ℂ) w * z‖ ^ 2 - ‖z - w‖ ^ 2 = (1 - ‖z‖ ^ 2) * (1 - ‖w‖ ^ 2) := by
+  simpa only [Complex.normSq_eq_norm_sq] using normSq_one_sub_conj_mul_sub_normSq_sub z w
+
 /-- For two points of norm less than one, the numerator norm is smaller than the denominator
 norm in the pseudo-hyperbolic expression. -/
 lemma norm_sub_lt_norm_one_sub_conj_mul_of_norm_lt_one {z w : ℂ}

--- a/TauCeti/Analysis/Complex/Conformal/SchwarzPickAutomorphismIsometry.lean
+++ b/TauCeti/Analysis/Complex/Conformal/SchwarzPickAutomorphismIsometry.lean
@@ -5,7 +5,6 @@ Released under Apache 2.0 license as described in the file LICENSE.
 module
 
 public import TauCeti.Analysis.Complex.Conformal.UnitDiscAutomorphism
-public import TauCeti.Analysis.Complex.Conformal.SchwarzPickDerivative
 
 /-!
 # Disc automorphisms are infinitesimal isometries of the Poincaré metric
@@ -39,20 +38,6 @@ namespace TauCeti
 open Complex Metric Set
 open scoped ComplexConjugate
 
-/-- **Poincaré defect identity.** The difference of squared norms of the Moebius denominator and
-numerator factors is the product of the two hyperbolic defects, so the metric factors cancel:
-`‖1 - conj a * z‖ ^ 2 - ‖z - a‖ ^ 2 = (1 - ‖z‖ ^ 2) * (1 - ‖a‖ ^ 2)`. -/
-private lemma norm_sq_one_sub_conj_mul_sub_norm_sq_sub (a z : ℂ) :
-    ‖(1 : ℂ) - (starRingEnd ℂ) a * z‖ ^ 2 - ‖z - a‖ ^ 2
-      = (1 - ‖z‖ ^ 2) * (1 - ‖a‖ ^ 2) := by
-  rw [← Complex.normSq_eq_norm_sq, ← Complex.normSq_eq_norm_sq, ← Complex.normSq_eq_norm_sq,
-    ← Complex.normSq_eq_norm_sq, Complex.normSq_sub, Complex.normSq_sub, Complex.normSq_mul,
-    Complex.normSq_conj, Complex.normSq_one]
-  have hre : (1 * (starRingEnd ℂ) ((starRingEnd ℂ) a * z)).re = (z * (starRingEnd ℂ) a).re := by
-    simp [mul_comm]
-  rw [hre]
-  ring_nf
-
 /-- **Value-level equality case of the infinitesimal Schwarz--Pick lemma.** The quotient built
 from the Moebius derivative value `(1 - conj a * a) / (1 - conj a * z) ^ 2` and the Moebius
 image `(z - a) / (1 - conj a * z)` collapses to the reciprocal Poincaré factor `1 / (1 - ‖z‖ ^ 2)`.
@@ -75,7 +60,7 @@ private lemma poincare_defect_quotient {a : ℂ} (ha : ‖a‖ < 1) {z : ℂ} (h
   -- Squared norm of the Moebius image.
   have hM : 1 - ‖(z - a) / (1 - (starRingEnd ℂ) a * z)‖ ^ 2
       = (1 - ‖z‖ ^ 2) * (1 - ‖a‖ ^ 2) / ‖(1 : ℂ) - (starRingEnd ℂ) a * z‖ ^ 2 := by
-    rw [norm_div, div_pow, ← norm_sq_one_sub_conj_mul_sub_norm_sq_sub a z, sub_div,
+    rw [norm_div, div_pow, ← norm_sq_one_sub_conj_mul_sub_norm_sq_sub z a, sub_div,
       div_self hD_pos.ne']
   rw [hnum, hM]
   field_simp
@@ -84,8 +69,8 @@ private lemma poincare_defect_quotient {a : ℂ} (ha : ‖a‖ < 1) {z : ℂ} (h
 the disc automorphism `z ↦ (z - a) / (1 - conj a * z)` attains equality in the infinitesimal
 Schwarz--Pick inequality `norm_deriv_div_one_sub_norm_sq_le`: at every point of the open unit
 disc its Poincaré metric distortion is exactly `1`. -/
-theorem norm_deriv_div_one_sub_norm_sq_unitDiscMoebiusFormula {a : ℂ} (ha : ‖a‖ < 1)
-    {z : ℂ} (hz : ‖z‖ < 1) :
+theorem norm_deriv_div_one_sub_norm_sq_unitDiscMoebiusFormula_of_norm_lt_one {a : ℂ}
+    (ha : ‖a‖ < 1) {z : ℂ} (hz : ‖z‖ < 1) :
     ‖deriv (fun ξ : ℂ => (ξ - a) / (1 - (starRingEnd ℂ) a * ξ)) z‖
         / (1 - ‖(z - a) / (1 - (starRingEnd ℂ) a * z)‖ ^ 2)
       = 1 / (1 - ‖z‖ ^ 2) := by
@@ -94,20 +79,19 @@ theorem norm_deriv_div_one_sub_norm_sq_unitDiscMoebiusFormula {a : ℂ} (ha : �
   rw [(hasDerivAt_unitDiscMoebiusFormula a z hden).deriv]
   exact poincare_defect_quotient ha hz
 
-/-- **The standard disc automorphism is an infinitesimal isometry of the Poincaré metric.** For
-`u` on the unit circle and `‖a‖ < 1` the automorphism `z ↦ u * (z - a) / (1 - conj a * z)`
+/-- **The standard disc automorphism is an infinitesimal isometry of the Poincaré metric.** For a
+rotation factor `u` of norm `1` and `‖a‖ < 1` the automorphism `z ↦ u * (z - a) / (1 - conj a * z)`
 attains equality in the infinitesimal Schwarz--Pick inequality at every disc point: its Poincaré
-metric distortion is exactly `1`.  The rotation factor `u` does not change the distortion, so the
-whole group `Aut(𝔻)` acts by Poincaré isometries. -/
-theorem norm_deriv_div_one_sub_norm_sq_unitDiscStandardAutomorphismFormula (u : Circle)
-    {a : ℂ} (ha : ‖a‖ < 1) {z : ℂ} (hz : ‖z‖ < 1) :
-    ‖deriv (fun ξ : ℂ => (u : ℂ) * ((ξ - a) / (1 - (starRingEnd ℂ) a * ξ))) z‖
-        / (1 - ‖(u : ℂ) * ((z - a) / (1 - (starRingEnd ℂ) a * z))‖ ^ 2)
+metric distortion is exactly `1`.  The rotation factor `u` does not change the distortion. -/
+theorem norm_deriv_div_one_sub_norm_sq_unitDiscStandardAutomorphismFormula_of_norm_lt_one
+    {u : ℂ} (hu : ‖u‖ = 1) {a : ℂ} (ha : ‖a‖ < 1) {z : ℂ} (hz : ‖z‖ < 1) :
+    ‖deriv (fun ξ : ℂ => u * ((ξ - a) / (1 - (starRingEnd ℂ) a * ξ))) z‖
+        / (1 - ‖u * ((z - a) / (1 - (starRingEnd ℂ) a * z))‖ ^ 2)
       = 1 / (1 - ‖z‖ ^ 2) := by
   have hden : (1 : ℂ) - (starRingEnd ℂ) a * z ≠ 0 :=
     one_sub_conj_mul_ne_zero_of_norm_lt_one hz ha
-  have hA := (hasDerivAt_unitDiscMoebiusFormula a z hden).const_mul (u : ℂ)
-  rw [hA.deriv, norm_mul, norm_mul, Circle.norm_coe, one_mul, one_mul]
+  have hA := (hasDerivAt_unitDiscMoebiusFormula a z hden).const_mul u
+  rw [hA.deriv, norm_mul, norm_mul, hu, one_mul, one_mul]
   exact poincare_defect_quotient ha hz
 
 /-- Bundled unit-disc form of the automorphism Poincaré-isometry: for disc points `a z` the
@@ -119,6 +103,7 @@ theorem norm_deriv_div_one_sub_norm_sq_unitDiscStandardAutomorphismFormula_unitD
         / (1 - ‖(u : ℂ) * (((z : ℂ) - (a : ℂ)) /
           (1 - (starRingEnd ℂ) (a : ℂ) * (z : ℂ)))‖ ^ 2)
       = 1 / (1 - ‖(z : ℂ)‖ ^ 2) :=
-  norm_deriv_div_one_sub_norm_sq_unitDiscStandardAutomorphismFormula u a.norm_lt_one z.norm_lt_one
+  norm_deriv_div_one_sub_norm_sq_unitDiscStandardAutomorphismFormula_of_norm_lt_one
+    (Circle.norm_coe u) a.norm_lt_one z.norm_lt_one
 
 end TauCeti

--- a/TauCeti/Analysis/Complex/Conformal/SchwarzPickAutomorphismIsometry.lean
+++ b/TauCeti/Analysis/Complex/Conformal/SchwarzPickAutomorphismIsometry.lean
@@ -1,0 +1,124 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+module
+
+public import TauCeti.Analysis.Complex.Conformal.UnitDiscAutomorphism
+public import TauCeti.Analysis.Complex.Conformal.SchwarzPickDerivative
+
+/-!
+# Disc automorphisms are infinitesimal isometries of the Poincaré metric
+
+The infinitesimal Schwarz--Pick inequality `norm_deriv_div_one_sub_norm_sq_le` shows that
+every holomorphic self-map of the open unit disc contracts the Poincaré (hyperbolic) metric
+`|dz| / (1 - |z| ^ 2)`.  This file proves that the **disc automorphisms attain equality**: for
+the standard automorphism formula `z ↦ u * (z - a) / (1 - conj a * z)` (with `u` on the unit
+circle and `‖a‖ < 1`),
+`‖deriv f z‖ / (1 - ‖f z‖ ^ 2) = 1 / (1 - ‖z‖ ^ 2)` at every disc point `z`.  In other words
+the standard automorphisms act as isometries of the Poincaré metric — the equality case of the
+infinitesimal Schwarz--Pick lemma and the differential counterpart of the finite Moebius
+invariance `pseudoHyperbolicExpr_unitDiscMoebius`.
+
+The proof is a direct computation from Tau Ceti's Moebius derivative
+`hasDerivAt_unitDiscMoebiusFormula` and the Pythagorean identity
+`‖1 - conj a * z‖ ^ 2 - ‖z - a‖ ^ 2 = (1 - ‖z‖ ^ 2) * (1 - ‖a‖ ^ 2)`, which forces the metric
+factors to cancel exactly rather than merely bound one another.
+
+This advances the conformal-mapping roadmap's **L2 Schwarz--Pick / disc-automorphism** target
+(`TauCetiRoadmap/ConformalMapping/README.md`: the hyperbolic/Poincaré metric on `𝔻` and the
+automorphism group `Aut(𝔻)`).  As with the rest of the L0--L3 conformal-mapping material it is
+coordinated with the upstream Mathlib RMT effort leanprover-community/mathlib4#33505 and should
+be refactored to upstream API if that work lands a human-curated Schwarz--Pick theorem.
+-/
+
+public section
+
+namespace TauCeti
+
+open Complex Metric Set
+open scoped ComplexConjugate
+
+/-- **Poincaré defect identity.** The difference of squared norms of the Moebius denominator and
+numerator factors is the product of the two hyperbolic defects, so the metric factors cancel:
+`‖1 - conj a * z‖ ^ 2 - ‖z - a‖ ^ 2 = (1 - ‖z‖ ^ 2) * (1 - ‖a‖ ^ 2)`. -/
+private lemma norm_sq_one_sub_conj_mul_sub_norm_sq_sub (a z : ℂ) :
+    ‖(1 : ℂ) - (starRingEnd ℂ) a * z‖ ^ 2 - ‖z - a‖ ^ 2
+      = (1 - ‖z‖ ^ 2) * (1 - ‖a‖ ^ 2) := by
+  rw [← Complex.normSq_eq_norm_sq, ← Complex.normSq_eq_norm_sq, ← Complex.normSq_eq_norm_sq,
+    ← Complex.normSq_eq_norm_sq, Complex.normSq_sub, Complex.normSq_sub, Complex.normSq_mul,
+    Complex.normSq_conj, Complex.normSq_one]
+  have hre : (1 * (starRingEnd ℂ) ((starRingEnd ℂ) a * z)).re = (z * (starRingEnd ℂ) a).re := by
+    simp [mul_comm]
+  rw [hre]
+  ring_nf
+
+/-- **Value-level equality case of the infinitesimal Schwarz--Pick lemma.** The quotient built
+from the Moebius derivative value `(1 - conj a * a) / (1 - conj a * z) ^ 2` and the Moebius
+image `(z - a) / (1 - conj a * z)` collapses to the reciprocal Poincaré factor `1 / (1 - ‖z‖ ^ 2)`.
+Both public isometry theorems below rewrite their derivative to this value and apply this
+computation. -/
+private lemma poincare_defect_quotient {a : ℂ} (ha : ‖a‖ < 1) {z : ℂ} (hz : ‖z‖ < 1) :
+    ‖(1 - (starRingEnd ℂ) a * a) / (1 - (starRingEnd ℂ) a * z) ^ 2‖
+        / (1 - ‖(z - a) / (1 - (starRingEnd ℂ) a * z)‖ ^ 2)
+      = 1 / (1 - ‖z‖ ^ 2) := by
+  have hden : (1 : ℂ) - (starRingEnd ℂ) a * z ≠ 0 :=
+    one_sub_conj_mul_ne_zero_of_norm_lt_one hz ha
+  have hD_pos : (0 : ℝ) < ‖(1 : ℂ) - (starRingEnd ℂ) a * z‖ ^ 2 :=
+    pow_pos (norm_pos_iff.mpr hden) 2
+  have hz_pos : (0 : ℝ) < 1 - ‖z‖ ^ 2 := by nlinarith [norm_nonneg z]
+  have ha_pos : (0 : ℝ) < 1 - ‖a‖ ^ 2 := by nlinarith [norm_nonneg a]
+  -- Norm of the derivative factor: `(1 - ‖a‖ ^ 2) / ‖1 - conj a * z‖ ^ 2`.
+  have hnum : ‖(1 - (starRingEnd ℂ) a * a) / (1 - (starRingEnd ℂ) a * z) ^ 2‖
+      = (1 - ‖a‖ ^ 2) / ‖(1 : ℂ) - (starRingEnd ℂ) a * z‖ ^ 2 := by
+    rw [norm_div, norm_pow, norm_one_sub_conj_mul_self_of_norm_le_one ha.le]
+  -- Squared norm of the Moebius image.
+  have hM : 1 - ‖(z - a) / (1 - (starRingEnd ℂ) a * z)‖ ^ 2
+      = (1 - ‖z‖ ^ 2) * (1 - ‖a‖ ^ 2) / ‖(1 : ℂ) - (starRingEnd ℂ) a * z‖ ^ 2 := by
+    rw [norm_div, div_pow, ← norm_sq_one_sub_conj_mul_sub_norm_sq_sub a z, sub_div,
+      div_self hD_pos.ne']
+  rw [hnum, hM]
+  field_simp
+
+/-- **The Moebius factor is an infinitesimal isometry of the Poincaré metric.** For `‖a‖ < 1`
+the disc automorphism `z ↦ (z - a) / (1 - conj a * z)` attains equality in the infinitesimal
+Schwarz--Pick inequality `norm_deriv_div_one_sub_norm_sq_le`: at every point of the open unit
+disc its Poincaré metric distortion is exactly `1`. -/
+theorem norm_deriv_div_one_sub_norm_sq_unitDiscMoebiusFormula {a : ℂ} (ha : ‖a‖ < 1)
+    {z : ℂ} (hz : ‖z‖ < 1) :
+    ‖deriv (fun ξ : ℂ => (ξ - a) / (1 - (starRingEnd ℂ) a * ξ)) z‖
+        / (1 - ‖(z - a) / (1 - (starRingEnd ℂ) a * z)‖ ^ 2)
+      = 1 / (1 - ‖z‖ ^ 2) := by
+  have hden : (1 : ℂ) - (starRingEnd ℂ) a * z ≠ 0 :=
+    one_sub_conj_mul_ne_zero_of_norm_lt_one hz ha
+  rw [(hasDerivAt_unitDiscMoebiusFormula a z hden).deriv]
+  exact poincare_defect_quotient ha hz
+
+/-- **The standard disc automorphism is an infinitesimal isometry of the Poincaré metric.** For
+`u` on the unit circle and `‖a‖ < 1` the automorphism `z ↦ u * (z - a) / (1 - conj a * z)`
+attains equality in the infinitesimal Schwarz--Pick inequality at every disc point: its Poincaré
+metric distortion is exactly `1`.  The rotation factor `u` does not change the distortion, so the
+whole group `Aut(𝔻)` acts by Poincaré isometries. -/
+theorem norm_deriv_div_one_sub_norm_sq_unitDiscStandardAutomorphismFormula (u : Circle)
+    {a : ℂ} (ha : ‖a‖ < 1) {z : ℂ} (hz : ‖z‖ < 1) :
+    ‖deriv (fun ξ : ℂ => (u : ℂ) * ((ξ - a) / (1 - (starRingEnd ℂ) a * ξ))) z‖
+        / (1 - ‖(u : ℂ) * ((z - a) / (1 - (starRingEnd ℂ) a * z))‖ ^ 2)
+      = 1 / (1 - ‖z‖ ^ 2) := by
+  have hden : (1 : ℂ) - (starRingEnd ℂ) a * z ≠ 0 :=
+    one_sub_conj_mul_ne_zero_of_norm_lt_one hz ha
+  have hA := (hasDerivAt_unitDiscMoebiusFormula a z hden).const_mul (u : ℂ)
+  rw [hA.deriv, norm_mul, norm_mul, Circle.norm_coe, one_mul, one_mul]
+  exact poincare_defect_quotient ha hz
+
+/-- Bundled unit-disc form of the automorphism Poincaré-isometry: for disc points `a z` the
+standard automorphism formula centred at `a` has Poincaré metric distortion exactly `1` at `z`. -/
+theorem norm_deriv_div_one_sub_norm_sq_unitDiscStandardAutomorphismFormula_unitDisc
+    (u : Circle) (a z : Complex.UnitDisc) :
+    ‖deriv (fun ξ : ℂ => (u : ℂ) * (((ξ : ℂ) - (a : ℂ)) /
+          (1 - (starRingEnd ℂ) (a : ℂ) * ξ))) (z : ℂ)‖
+        / (1 - ‖(u : ℂ) * (((z : ℂ) - (a : ℂ)) /
+          (1 - (starRingEnd ℂ) (a : ℂ) * (z : ℂ)))‖ ^ 2)
+      = 1 / (1 - ‖(z : ℂ)‖ ^ 2) :=
+  norm_deriv_div_one_sub_norm_sq_unitDiscStandardAutomorphismFormula u a.norm_lt_one z.norm_lt_one
+
+end TauCeti

--- a/TauCeti/Analysis/Complex/Conformal/SchwarzPickAutomorphismIsometry.lean
+++ b/TauCeti/Analysis/Complex/Conformal/SchwarzPickAutomorphismIsometry.lean
@@ -65,20 +65,6 @@ private lemma poincare_defect_quotient {a : ℂ} (ha : ‖a‖ < 1) {z : ℂ} (h
   rw [hnum, hM]
   field_simp
 
-/-- **The Moebius factor is an infinitesimal isometry of the Poincaré metric.** For `‖a‖ < 1`
-the disc automorphism `z ↦ (z - a) / (1 - conj a * z)` attains equality in the infinitesimal
-Schwarz--Pick inequality `norm_deriv_div_one_sub_norm_sq_le`: at every point of the open unit
-disc its Poincaré metric distortion is exactly `1`. -/
-theorem norm_deriv_div_one_sub_norm_sq_unitDiscMoebiusFormula_of_norm_lt_one {a : ℂ}
-    (ha : ‖a‖ < 1) {z : ℂ} (hz : ‖z‖ < 1) :
-    ‖deriv (fun ξ : ℂ => (ξ - a) / (1 - (starRingEnd ℂ) a * ξ)) z‖
-        / (1 - ‖(z - a) / (1 - (starRingEnd ℂ) a * z)‖ ^ 2)
-      = 1 / (1 - ‖z‖ ^ 2) := by
-  have hden : (1 : ℂ) - (starRingEnd ℂ) a * z ≠ 0 :=
-    one_sub_conj_mul_ne_zero_of_norm_lt_one hz ha
-  rw [(hasDerivAt_unitDiscMoebiusFormula a z hden).deriv]
-  exact poincare_defect_quotient ha hz
-
 /-- **The standard disc automorphism is an infinitesimal isometry of the Poincaré metric.** For a
 rotation factor `u` of norm `1` and `‖a‖ < 1` the automorphism `z ↦ u * (z - a) / (1 - conj a * z)`
 attains equality in the infinitesimal Schwarz--Pick inequality at every disc point: its Poincaré
@@ -93,6 +79,20 @@ theorem norm_deriv_div_one_sub_norm_sq_unitDiscStandardAutomorphismFormula_of_no
   have hA := (hasDerivAt_unitDiscMoebiusFormula a z hden).const_mul u
   rw [hA.deriv, norm_mul, norm_mul, hu, one_mul, one_mul]
   exact poincare_defect_quotient ha hz
+
+/-- **The Moebius factor is an infinitesimal isometry of the Poincaré metric.** For `‖a‖ < 1`
+the disc automorphism `z ↦ (z - a) / (1 - conj a * z)` attains equality in the infinitesimal
+Schwarz--Pick inequality `norm_deriv_div_one_sub_norm_sq_le`: at every point of the open unit
+disc its Poincaré metric distortion is exactly `1`.  This is the `u = 1` (no rotation) case of
+`norm_deriv_div_one_sub_norm_sq_unitDiscStandardAutomorphismFormula_of_norm_lt_one`. -/
+theorem norm_deriv_div_one_sub_norm_sq_unitDiscMoebiusFormula_of_norm_lt_one {a : ℂ}
+    (ha : ‖a‖ < 1) {z : ℂ} (hz : ‖z‖ < 1) :
+    ‖deriv (fun ξ : ℂ => (ξ - a) / (1 - (starRingEnd ℂ) a * ξ)) z‖
+        / (1 - ‖(z - a) / (1 - (starRingEnd ℂ) a * z)‖ ^ 2)
+      = 1 / (1 - ‖z‖ ^ 2) := by
+  simpa only [one_mul] using
+    norm_deriv_div_one_sub_norm_sq_unitDiscStandardAutomorphismFormula_of_norm_lt_one
+      norm_one ha hz
 
 /-- Bundled unit-disc form of the automorphism Poincaré-isometry: for disc points `a z` the
 standard automorphism formula centred at `a` has Poincaré metric distortion exactly `1` at `z`. -/

--- a/TauCeti/NumberTheory/Multiquadratic/MultiquadraticSplitting.lean
+++ b/TauCeti/NumberTheory/Multiquadratic/MultiquadraticSplitting.lean
@@ -92,8 +92,8 @@ private theorem legendreSym_eq_one_of_ncard_primesOver_eq_finrank {ι : Type*} (
   let R : ι → 𝓞 K := ringGen d r hr
   rw [ncard_primesOver_eq_finrank_iff K p] at hsplit
   have hfQ : finrank (ℤ ⧸ span {(p : ℤ)}) (𝓞 K ⧸ Q) = 1 := by
-    rw [← Ideal.inertiaDeg'_algebraMap (p := span {(p : ℤ)}) (P := Q),
-      Ideal.inertiaDeg'_eq_inertiaDeg,
+    rw [← Ideal.inertiaDeg_algebraMap (p := span {(p : ℤ)}) (P := Q),
+      Ideal.inertiaDeg_eq_inertiaDeg',
       ← Ideal.inertiaDegIn_eq_inertiaDeg (span {(p : ℤ)}) Q (K ≃ₐ[ℚ] K)]
     exact hsplit.2
   letI fld : Field (ℤ ⧸ span {(p : ℤ)}) := Ideal.Quotient.field _

--- a/TauCeti/NumberTheory/Multiquadratic/MultiquadraticSplitting.lean
+++ b/TauCeti/NumberTheory/Multiquadratic/MultiquadraticSplitting.lean
@@ -92,8 +92,7 @@ private theorem legendreSym_eq_one_of_ncard_primesOver_eq_finrank {ι : Type*} (
   let R : ι → 𝓞 K := ringGen d r hr
   rw [ncard_primesOver_eq_finrank_iff K p] at hsplit
   have hfQ : finrank (ℤ ⧸ span {(p : ℤ)}) (𝓞 K ⧸ Q) = 1 := by
-    rw [← Ideal.inertiaDeg_algebraMap (p := span {(p : ℤ)}) (P := Q),
-      Ideal.inertiaDeg_eq_inertiaDeg',
+    rw [← Ideal.inertiaDeg'_eq_of_isMaximal (p := span {(p : ℤ)}) (q := Q),
       ← Ideal.inertiaDegIn_eq_inertiaDeg (span {(p : ℤ)}) Q (K ≃ₐ[ℚ] K)]
     exact hsplit.2
   letI fld : Field (ℤ ⧸ span {(p : ℤ)}) := Ideal.Quotient.field _

--- a/TauCeti/NumberTheory/Multiquadratic/MultiquadraticSplitting.lean
+++ b/TauCeti/NumberTheory/Multiquadratic/MultiquadraticSplitting.lean
@@ -92,8 +92,8 @@ private theorem legendreSym_eq_one_of_ncard_primesOver_eq_finrank {ι : Type*} (
   let R : ι → 𝓞 K := ringGen d r hr
   rw [ncard_primesOver_eq_finrank_iff K p] at hsplit
   have hfQ : finrank (ℤ ⧸ span {(p : ℤ)}) (𝓞 K ⧸ Q) = 1 := by
-    rw [← Ideal.inertiaDeg_algebraMap (p := span {(p : ℤ)}) (P := Q),
-      Ideal.inertiaDeg_eq_inertiaDeg',
+    rw [← Ideal.inertiaDeg'_algebraMap (p := span {(p : ℤ)}) (P := Q),
+      Ideal.inertiaDeg'_eq_inertiaDeg,
       ← Ideal.inertiaDegIn_eq_inertiaDeg (span {(p : ℤ)}) Q (K ≃ₐ[ℚ] K)]
     exact hsplit.2
   letI fld : Field (ℤ ⧸ span {(p : ℤ)}) := Ideal.Quotient.field _


### PR DESCRIPTION
This PR proves the equality case of the infinitesimal Schwarz--Pick inequality: the standard disc automorphisms are infinitesimal isometries of the Poincaré (hyperbolic) metric. For the automorphism formula `z ↦ u * (z - a) / (1 - conj a * z)` (with `u` on the unit circle and `‖a‖ < 1`), it establishes `‖deriv f z‖ / (1 - ‖f z‖ ^ 2) = 1 / (1 - ‖z‖ ^ 2)` at every point of the open unit disc, so the whole group `Aut(𝔻)` acts by Poincaré isometries. This is the differential counterpart of the finite Moebius invariance `pseudoHyperbolicExpr_unitDiscMoebius` already in the library, and the sharpness witness for Tau Ceti's existing infinitesimal contraction estimate `norm_deriv_div_one_sub_norm_sq_le`, which only gave the `≤` direction.

The target is the L2 Schwarz--Pick / disc-automorphism layer of the conformal-mapping roadmap (`TauCetiRoadmap/ConformalMapping/README.md`: the hyperbolic/Poincaré metric on `𝔻` and the disc automorphism group `Aut(𝔻) = {e^{iθ}(z−a)/(1−āz)}`). The proof reuses Tau Ceti's Moebius derivative `hasDerivAt_unitDiscMoebiusFormula` and denominator-norm lemma `norm_one_sub_conj_mul_self_of_norm_le_one`, together with the Pythagorean identity `‖1 - conj a * z‖ ^ 2 - ‖z - a‖ ^ 2 = (1 - ‖z‖ ^ 2) * (1 - ‖a‖ ^ 2)`, which forces the metric factors to cancel exactly rather than merely bound one another. Statements are given for the scalar Moebius factor, the rotated standard automorphism, and a bundled `Complex.UnitDisc` form.

As with the rest of the L0--L3 conformal-mapping material this is coordinated with the upstream Mathlib RMT effort (leanprover-community/mathlib4#33505, "A proof of the Riemann mapping theorem") and its supporting `Analysis/Complex/RiemannMapping.lean` / `BranchLogRoot.lean`; it should be refactored to upstream API should that work land a human-curated Schwarz--Pick theorem. No Mathlib infrastructure was vendored.

`TauCeti/Analysis/Complex/Conformal/SchwarzPickAutomorphismIsometry.lean` is the only file added (about 140 lines). `lake build` is green and `lake exe axioms` reports all declarations within the allowlist `[propext, Classical.choice, Quot.sound]`.

<!--tauceti-target:v1 {"focus":"ConformalMapping","id":"disc-automorphism-poincare-metric-isometry"}-->

🤖 Prepared with Claude Code
