### PR TITLE
feat: reciprocal building blocks are completely monotone

### DIFF
--- a/TauCeti/Analysis/CompletelyMonotone/Reciprocal.lean
+++ b/TauCeti/Analysis/CompletelyMonotone/Reciprocal.lean
@@ -4,9 +4,9 @@ Released under Apache 2.0 license as described in the file LICENSE.
 -/
 module
 
-public import TauCeti.Analysis.CompletelyMonotone.Closure
-public import Mathlib.Analysis.Calculus.IteratedDeriv.WithinZpow
-public import Mathlib.Analysis.Calculus.ContDiff.Operations
+public import TauCeti.Analysis.CompletelyMonotone.Basic
+import TauCeti.Analysis.CompletelyMonotone.Closure
+import Mathlib.Analysis.Calculus.IteratedDeriv.WithinZpow
 
 /-!
 # Reciprocal building blocks are completely monotone
@@ -16,30 +16,22 @@ This file adds a second family of concrete completely monotone functions to the
 `TauCeti.Analysis.CompletelyMonotone.Basic`: the **reciprocals of affine functions**
 `t ↦ (a + t)⁻¹` with `a > 0`, and their integer powers `t ↦ (a + t)^{-k}`.
 
-These are exactly the resolvent kernels `t ↦ (λ + t)⁻¹` that Part A of the roadmap builds a
-semigroup theory around, and they are the Stieltjes building blocks whose nonnegative mixtures
-generate every Stieltjes function. The acceptance example `t ↦ 1/(1 + t)` named in Part B of the
-roadmap is the special case `a = 1`; its representing measure `e^{-x} dx` is the exponential
-distribution.
-
-The proof is a direct computation of the alternating iterated derivatives. Writing `g y = y⁻¹`,
-Mathlib's `iteratedDerivWithin_one_div` gives `g⁽ⁿ⁾(y) = (-1)ⁿ · n! · y^{-1-n}` on any open set,
-and translation invariance of the iterated derivative
-(`iteratedDeriv_comp_const_add`) transports this to `t ↦ (a + t)⁻¹`. On `[0, ∞)` the base
-`a + t` is bounded below by `a > 0`, so `(-1)ⁿ` times the `n`-th derivative is
-`n! · (a + t)^{-1-n} ≥ 0`, which is the sign-alternation condition. The smoothness clause of
-`IsCompletelyMonotone` holds because the denominator never vanishes on `[0, ∞)`. The powers then
-follow from the product closure `IsCompletelyMonotone.pow`.
+These are the resolvent kernels `t ↦ (λ + t)⁻¹` that Part A of the roadmap builds a semigroup
+theory around, and they are among the basic Stieltjes (resolvent) kernels appearing in Stieltjes
+representations. The acceptance example `t ↦ 1/(1 + t)` named in Part B of the roadmap is the
+special case `a = 1`; its representing measure `e^{-x} dx` is the exponential distribution.
 
 ## Main declarations
 
-* `TauCeti.isCompletelyMonotone_inv_add_const`: for `a > 0`, the reciprocal `t ↦ (a + t)⁻¹` is
+* `TauCeti.isCompletelyMonotone_inv_const_add`: for `a > 0`, the reciprocal `t ↦ (a + t)⁻¹` is
   completely monotone.
-* `TauCeti.isCompletelyMonotone_one_div_add_const`: the same statement in `1 / (a + t)` form.
+* `TauCeti.isCompletelyMonotone_one_div_const_add`: the same statement in `1 / (a + t)` form.
 * `TauCeti.isCompletelyMonotone_one_div_one_add`: the roadmap acceptance example
   `t ↦ 1 / (1 + t)`.
-* `TauCeti.isCompletelyMonotone_inv_pow_add_const`: for `a > 0` and `k : ℕ`, the reciprocal power
-  `t ↦ (a + t)^{-k}` is completely monotone.
+* `TauCeti.isCompletelyMonotone_inv_pow_const_add`: for `a > 0` and `k : ℕ`, the reciprocal power
+  `t ↦ ((a + t) ^ k)⁻¹` is completely monotone.
+* `TauCeti.isCompletelyMonotone_zpow_neg_const_add`: the same building block in the integer-power
+  form `t ↦ (a + t) ^ (-k)`.
 
 ## References
 
@@ -54,11 +46,9 @@ open scoped ContDiff Nat
 
 namespace TauCeti
 
-/-- For `a > 0`, the reciprocal `t ↦ (a + t)⁻¹` is completely monotone: it is smooth on
-`[0, ∞)` (the denominator stays at least `a`), and its `n`-th derivative is
-`(-1)ⁿ · n! · (a + t)^{-1-n}`, so `(-1)ⁿ` times it is the nonnegative `n! · (a + t)^{-1-n}`.
-This is the resolvent kernel `t ↦ (λ + t)⁻¹` of the roadmap's semigroup theory. -/
-theorem isCompletelyMonotone_inv_add_const {a : ℝ} (ha : 0 < a) :
+/-- For `a > 0`, the reciprocal `t ↦ (a + t)⁻¹` is completely monotone. This is the resolvent
+kernel `t ↦ (λ + t)⁻¹` of the roadmap's semigroup theory. -/
+theorem isCompletelyMonotone_inv_const_add {a : ℝ} (ha : 0 < a) :
     IsCompletelyMonotone (fun t => (a + t)⁻¹) := by
   have hpos : ∀ t : ℝ, 0 ≤ t → 0 < a + t := fun t ht => by linarith
   -- The denominator never vanishes on `[0, ∞)`, so the reciprocal is smooth there.
@@ -95,27 +85,35 @@ theorem isCompletelyMonotone_inv_add_const {a : ℝ} (ha : 0 < a) :
   exact mul_nonneg (mul_nonneg (sq_nonneg _) (Nat.cast_nonneg _)) hzpow
 
 /-- For `a > 0`, the function `t ↦ 1 / (a + t)` is completely monotone (the `1 / _` phrasing of
-`isCompletelyMonotone_inv_add_const`). -/
-theorem isCompletelyMonotone_one_div_add_const {a : ℝ} (ha : 0 < a) :
+`isCompletelyMonotone_inv_const_add`). -/
+theorem isCompletelyMonotone_one_div_const_add {a : ℝ} (ha : 0 < a) :
     IsCompletelyMonotone (fun t => 1 / (a + t)) := by
   have heq : (fun t : ℝ => 1 / (a + t)) = fun t => (a + t)⁻¹ := by funext t; rw [one_div]
   rw [heq]
-  exact isCompletelyMonotone_inv_add_const ha
+  exact isCompletelyMonotone_inv_const_add ha
 
 /-- The roadmap acceptance example: `t ↦ 1 / (1 + t)` is completely monotone. Its representing
 measure under Bernstein's theorem is the exponential distribution `e^{-x} dx`. -/
 theorem isCompletelyMonotone_one_div_one_add :
     IsCompletelyMonotone (fun t => 1 / (1 + t)) :=
-  isCompletelyMonotone_one_div_add_const one_pos
+  isCompletelyMonotone_one_div_const_add one_pos
 
-/-- For `a > 0` and any natural power `k`, the reciprocal power `t ↦ (a + t)^{-k}`, written as
-`((a + t) ^ k)⁻¹`, is completely monotone. This follows from the reciprocal case together with the
-product closure `IsCompletelyMonotone.pow`. -/
-theorem isCompletelyMonotone_inv_pow_add_const {a : ℝ} (ha : 0 < a) (k : ℕ) :
+/-- For `a > 0` and any natural power `k`, the reciprocal power `t ↦ ((a + t) ^ k)⁻¹` is completely
+monotone. -/
+theorem isCompletelyMonotone_inv_pow_const_add {a : ℝ} (ha : 0 < a) (k : ℕ) :
     IsCompletelyMonotone (fun t => ((a + t) ^ k)⁻¹) := by
-  have h := (isCompletelyMonotone_inv_add_const ha).pow k
+  have h := (isCompletelyMonotone_inv_const_add ha).pow k
   have heq : ((fun t : ℝ => (a + t)⁻¹) ^ k) = fun t => ((a + t) ^ k)⁻¹ := by
     funext t; simp [Pi.pow_apply, inv_pow]
+  rwa [heq] at h
+
+/-- For `a > 0` and `k : ℕ`, the integer-power building block `t ↦ (a + t) ^ (-k)` is completely
+monotone (the `zpow` phrasing of `isCompletelyMonotone_inv_pow_const_add`). -/
+theorem isCompletelyMonotone_zpow_neg_const_add {a : ℝ} (ha : 0 < a) (k : ℕ) :
+    IsCompletelyMonotone (fun t => (a + t) ^ (-(k : ℤ))) := by
+  have h := isCompletelyMonotone_inv_pow_const_add ha k
+  have heq : (fun t : ℝ => ((a + t) ^ k)⁻¹) = fun t => (a + t) ^ (-(k : ℤ)) := by
+    funext t; rw [zpow_neg, zpow_natCast]
   rwa [heq] at h
 
 end TauCeti

--- a/TauCeti/Analysis/CompletelyMonotone/Reciprocal.lean
+++ b/TauCeti/Analysis/CompletelyMonotone/Reciprocal.lean
@@ -24,6 +24,8 @@ special case `a = 1`; its representing measure `e^{-x} dx` is the exponential di
 
 * `TauCeti.isCompletelyMonotone_inv_const_add`: for `a > 0`, the reciprocal `t ↦ (a + t)⁻¹` is
   completely monotone.
+* `TauCeti.isCompletelyMonotone_one_div_const_add`: the `t ↦ 1 / (a + t)` phrasing of the same
+  resolvent kernel.
 * `TauCeti.isCompletelyMonotone_one_div_one_add`: the roadmap acceptance example
   `t ↦ 1 / (1 + t)`.
 
@@ -78,14 +80,16 @@ theorem isCompletelyMonotone_inv_const_add {a : ℝ} (ha : 0 < a) :
   rw [hrw]
   exact mul_nonneg (mul_nonneg (sq_nonneg _) (Nat.cast_nonneg _)) hzpow
 
+/-- For `a > 0`, the reciprocal `t ↦ 1 / (a + t)` is completely monotone. This is the `1 / (a + t)`
+phrasing of the resolvent kernel `isCompletelyMonotone_inv_const_add`. -/
+theorem isCompletelyMonotone_one_div_const_add {a : ℝ} (ha : 0 < a) :
+    IsCompletelyMonotone (fun t => 1 / (a + t)) := by
+  simpa only [one_div] using isCompletelyMonotone_inv_const_add ha
+
 /-- The roadmap acceptance example: `t ↦ 1 / (1 + t)` is completely monotone. Its representing
 measure under Bernstein's theorem is the exponential distribution `e^{-x} dx`. -/
 theorem isCompletelyMonotone_one_div_one_add :
-    IsCompletelyMonotone (fun t => 1 / (1 + t)) := by
-  have heq : (fun t : ℝ => 1 / (1 + t)) = fun t => (1 + t)⁻¹ := by
-    funext t
-    rw [one_div]
-  rw [heq]
-  exact isCompletelyMonotone_inv_const_add one_pos
+    IsCompletelyMonotone (fun t => 1 / (1 + t)) :=
+  isCompletelyMonotone_one_div_const_add one_pos
 
 end TauCeti

--- a/TauCeti/Analysis/CompletelyMonotone/Reciprocal.lean
+++ b/TauCeti/Analysis/CompletelyMonotone/Reciprocal.lean
@@ -1,0 +1,121 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+module
+
+public import TauCeti.Analysis.CompletelyMonotone.Closure
+public import Mathlib.Analysis.Calculus.IteratedDeriv.WithinZpow
+public import Mathlib.Analysis.Calculus.ContDiff.Operations
+
+/-!
+# Reciprocal building blocks are completely monotone
+
+This file adds a second family of concrete completely monotone functions to the
+`OneParameterSemigroups` roadmap, alongside the exponentials `t ↦ e^{-x t}` already in
+`TauCeti.Analysis.CompletelyMonotone.Basic`: the **reciprocals of affine functions**
+`t ↦ (a + t)⁻¹` with `a > 0`, and their integer powers `t ↦ (a + t)^{-k}`.
+
+These are exactly the resolvent kernels `t ↦ (λ + t)⁻¹` that Part A of the roadmap builds a
+semigroup theory around, and they are the Stieltjes building blocks whose nonnegative mixtures
+generate every Stieltjes function. The acceptance example `t ↦ 1/(1 + t)` named in Part B of the
+roadmap is the special case `a = 1`; its representing measure `e^{-x} dx` is the exponential
+distribution.
+
+The proof is a direct computation of the alternating iterated derivatives. Writing `g y = y⁻¹`,
+Mathlib's `iteratedDerivWithin_one_div` gives `g⁽ⁿ⁾(y) = (-1)ⁿ · n! · y^{-1-n}` on any open set,
+and translation invariance of the iterated derivative
+(`iteratedDeriv_comp_const_add`) transports this to `t ↦ (a + t)⁻¹`. On `[0, ∞)` the base
+`a + t` is bounded below by `a > 0`, so `(-1)ⁿ` times the `n`-th derivative is
+`n! · (a + t)^{-1-n} ≥ 0`, which is the sign-alternation condition. The smoothness clause of
+`IsCompletelyMonotone` holds because the denominator never vanishes on `[0, ∞)`. The powers then
+follow from the product closure `IsCompletelyMonotone.pow`.
+
+## Main declarations
+
+* `TauCeti.isCompletelyMonotone_inv_add_const`: for `a > 0`, the reciprocal `t ↦ (a + t)⁻¹` is
+  completely monotone.
+* `TauCeti.isCompletelyMonotone_one_div_add_const`: the same statement in `1 / (a + t)` form.
+* `TauCeti.isCompletelyMonotone_one_div_one_add`: the roadmap acceptance example
+  `t ↦ 1 / (1 + t)`.
+* `TauCeti.isCompletelyMonotone_inv_pow_add_const`: for `a > 0` and `k : ℕ`, the reciprocal power
+  `t ↦ (a + t)^{-k}` is completely monotone.
+
+## References
+
+* R. Schilling, R. Song, Z. Vondraček, *Bernstein Functions: Theory and Applications*
+  (de Gruyter, 2nd ed. 2012).
+-/
+
+public section
+
+open Set
+open scoped ContDiff Nat
+
+namespace TauCeti
+
+/-- For `a > 0`, the reciprocal `t ↦ (a + t)⁻¹` is completely monotone: it is smooth on
+`[0, ∞)` (the denominator stays at least `a`), and its `n`-th derivative is
+`(-1)ⁿ · n! · (a + t)^{-1-n}`, so `(-1)ⁿ` times it is the nonnegative `n! · (a + t)^{-1-n}`.
+This is the resolvent kernel `t ↦ (λ + t)⁻¹` of the roadmap's semigroup theory. -/
+theorem isCompletelyMonotone_inv_add_const {a : ℝ} (ha : 0 < a) :
+    IsCompletelyMonotone (fun t => (a + t)⁻¹) := by
+  have hpos : ∀ t : ℝ, 0 ≤ t → 0 < a + t := fun t ht => by linarith
+  -- The denominator never vanishes on `[0, ∞)`, so the reciprocal is smooth there.
+  have hsmooth : ContDiffOn ℝ ∞ (fun t : ℝ => (a + t)⁻¹) (Ici 0) :=
+    ContDiffOn.inv (by fun_prop) fun x hx => (hpos x hx).ne'
+  refine ⟨hsmooth, fun n t ht => ?_⟩
+  have htpos : 0 < a + t := hpos t ht
+  -- Reduce the derivative *within* `[0, ∞)` to the ordinary iterated derivative at `t`.
+  have haff : ContDiffAt ℝ (∞ : WithTop ℕ∞) (fun t : ℝ => a + t) t := by fun_prop
+  have hcat : ContDiffAt ℝ (n : WithTop ℕ∞) (fun t : ℝ => (a + t)⁻¹) t :=
+    (haff.inv htpos.ne').of_le (by exact_mod_cast le_top)
+  rw [iteratedDerivWithin_eq_iteratedDeriv (uniqueDiffOn_Ici 0) hcat (mem_Ici.mpr ht)]
+  -- The iterated derivative of `y ↦ y⁻¹` at a positive point, from Mathlib's open-set formula.
+  have hform : ∀ s : ℝ, 0 < s → iteratedDeriv n (fun y : ℝ => y⁻¹) s
+      = (-1) ^ n * (n ! : ℝ) * s ^ (-1 - n : ℤ) := by
+    intro s hs
+    have hmem : s ∈ Ioi (0 : ℝ) := mem_Ioi.mpr hs
+    have h1 := iteratedDerivWithin_one_div (s := Ioi (0 : ℝ)) n isOpen_Ioi hmem
+    have h2 := iteratedDerivWithin_of_isOpen (𝕜 := ℝ) (f := fun y : ℝ => 1 / y) (n := n)
+      isOpen_Ioi hmem
+    have e1 : iteratedDeriv n (fun y : ℝ => (1 : ℝ) / y) s
+        = (-1) ^ n * (n ! : ℝ) * s ^ (-1 - n : ℤ) := by rw [← h2]; exact h1
+    simpa [one_div] using e1
+  -- Translation invariance: `t ↦ (a + t)⁻¹` is `y ↦ y⁻¹` shifted by `a`.
+  have hcomp : iteratedDeriv n (fun t : ℝ => (a + t)⁻¹) t
+      = iteratedDeriv n (fun y : ℝ => y⁻¹) (a + t) :=
+    congrFun (iteratedDeriv_comp_const_add n (fun y : ℝ => y⁻¹) a) t
+  rw [hcomp, hform (a + t) htpos]
+  -- The sign: `(-1)ⁿ · (-1)ⁿ = ((-1)ⁿ)² ≥ 0`, and `n! · (a + t)^{-1-n} ≥ 0`.
+  have hzpow : 0 ≤ (a + t) ^ (-1 - n : ℤ) := (zpow_pos htpos _).le
+  have hrw : (-1 : ℝ) ^ n * ((-1) ^ n * (n ! : ℝ) * (a + t) ^ (-1 - n : ℤ))
+      = ((-1 : ℝ) ^ n) ^ 2 * (n ! : ℝ) * (a + t) ^ (-1 - n : ℤ) := by ring
+  rw [hrw]
+  exact mul_nonneg (mul_nonneg (sq_nonneg _) (Nat.cast_nonneg _)) hzpow
+
+/-- For `a > 0`, the function `t ↦ 1 / (a + t)` is completely monotone (the `1 / _` phrasing of
+`isCompletelyMonotone_inv_add_const`). -/
+theorem isCompletelyMonotone_one_div_add_const {a : ℝ} (ha : 0 < a) :
+    IsCompletelyMonotone (fun t => 1 / (a + t)) := by
+  have heq : (fun t : ℝ => 1 / (a + t)) = fun t => (a + t)⁻¹ := by funext t; rw [one_div]
+  rw [heq]
+  exact isCompletelyMonotone_inv_add_const ha
+
+/-- The roadmap acceptance example: `t ↦ 1 / (1 + t)` is completely monotone. Its representing
+measure under Bernstein's theorem is the exponential distribution `e^{-x} dx`. -/
+theorem isCompletelyMonotone_one_div_one_add :
+    IsCompletelyMonotone (fun t => 1 / (1 + t)) :=
+  isCompletelyMonotone_one_div_add_const one_pos
+
+/-- For `a > 0` and any natural power `k`, the reciprocal power `t ↦ (a + t)^{-k}`, written as
+`((a + t) ^ k)⁻¹`, is completely monotone. This follows from the reciprocal case together with the
+product closure `IsCompletelyMonotone.pow`. -/
+theorem isCompletelyMonotone_inv_pow_add_const {a : ℝ} (ha : 0 < a) (k : ℕ) :
+    IsCompletelyMonotone (fun t => ((a + t) ^ k)⁻¹) := by
+  have h := (isCompletelyMonotone_inv_add_const ha).pow k
+  have heq : ((fun t : ℝ => (a + t)⁻¹) ^ k) = fun t => ((a + t) ^ k)⁻¹ := by
+    funext t; simp [Pi.pow_apply, inv_pow]
+  rwa [heq] at h
+
+end TauCeti

--- a/TauCeti/Analysis/CompletelyMonotone/Reciprocal.lean
+++ b/TauCeti/Analysis/CompletelyMonotone/Reciprocal.lean
@@ -14,7 +14,7 @@ import Mathlib.Analysis.Calculus.IteratedDeriv.WithinZpow
 This file adds a second family of concrete completely monotone functions to the
 `OneParameterSemigroups` roadmap, alongside the exponentials `t ↦ e^{-x t}` already in
 `TauCeti.Analysis.CompletelyMonotone.Basic`: the **reciprocals of affine functions**
-`t ↦ (a + t)⁻¹` with `a > 0`, and their integer powers `t ↦ (a + t)^{-k}`.
+`t ↦ (a + t)⁻¹` with `a > 0`, and their reciprocal powers `t ↦ ((a + t) ^ k)⁻¹`.
 
 These are the resolvent kernels `t ↦ (λ + t)⁻¹` that Part A of the roadmap builds a semigroup
 theory around, and they are among the basic Stieltjes (resolvent) kernels appearing in Stieltjes
@@ -25,13 +25,10 @@ special case `a = 1`; its representing measure `e^{-x} dx` is the exponential di
 
 * `TauCeti.isCompletelyMonotone_inv_const_add`: for `a > 0`, the reciprocal `t ↦ (a + t)⁻¹` is
   completely monotone.
-* `TauCeti.isCompletelyMonotone_one_div_const_add`: the same statement in `1 / (a + t)` form.
 * `TauCeti.isCompletelyMonotone_one_div_one_add`: the roadmap acceptance example
   `t ↦ 1 / (1 + t)`.
 * `TauCeti.isCompletelyMonotone_inv_pow_const_add`: for `a > 0` and `k : ℕ`, the reciprocal power
   `t ↦ ((a + t) ^ k)⁻¹` is completely monotone.
-* `TauCeti.isCompletelyMonotone_zpow_neg_const_add`: the same building block in the integer-power
-  form `t ↦ (a + t) ^ (-k)`.
 
 ## References
 
@@ -84,19 +81,15 @@ theorem isCompletelyMonotone_inv_const_add {a : ℝ} (ha : 0 < a) :
   rw [hrw]
   exact mul_nonneg (mul_nonneg (sq_nonneg _) (Nat.cast_nonneg _)) hzpow
 
-/-- For `a > 0`, the function `t ↦ 1 / (a + t)` is completely monotone (the `1 / _` phrasing of
-`isCompletelyMonotone_inv_const_add`). -/
-theorem isCompletelyMonotone_one_div_const_add {a : ℝ} (ha : 0 < a) :
-    IsCompletelyMonotone (fun t => 1 / (a + t)) := by
-  have heq : (fun t : ℝ => 1 / (a + t)) = fun t => (a + t)⁻¹ := by funext t; rw [one_div]
-  rw [heq]
-  exact isCompletelyMonotone_inv_const_add ha
-
 /-- The roadmap acceptance example: `t ↦ 1 / (1 + t)` is completely monotone. Its representing
 measure under Bernstein's theorem is the exponential distribution `e^{-x} dx`. -/
 theorem isCompletelyMonotone_one_div_one_add :
-    IsCompletelyMonotone (fun t => 1 / (1 + t)) :=
-  isCompletelyMonotone_one_div_const_add one_pos
+    IsCompletelyMonotone (fun t => 1 / (1 + t)) := by
+  have heq : (fun t : ℝ => 1 / (1 + t)) = fun t => (1 + t)⁻¹ := by
+    funext t
+    rw [one_div]
+  rw [heq]
+  exact isCompletelyMonotone_inv_const_add one_pos
 
 /-- For `a > 0` and any natural power `k`, the reciprocal power `t ↦ ((a + t) ^ k)⁻¹` is completely
 monotone. -/
@@ -105,15 +98,6 @@ theorem isCompletelyMonotone_inv_pow_const_add {a : ℝ} (ha : 0 < a) (k : ℕ) 
   have h := (isCompletelyMonotone_inv_const_add ha).pow k
   have heq : ((fun t : ℝ => (a + t)⁻¹) ^ k) = fun t => ((a + t) ^ k)⁻¹ := by
     funext t; simp [Pi.pow_apply, inv_pow]
-  rwa [heq] at h
-
-/-- For `a > 0` and `k : ℕ`, the integer-power building block `t ↦ (a + t) ^ (-k)` is completely
-monotone (the `zpow` phrasing of `isCompletelyMonotone_inv_pow_const_add`). -/
-theorem isCompletelyMonotone_zpow_neg_const_add {a : ℝ} (ha : 0 < a) (k : ℕ) :
-    IsCompletelyMonotone (fun t => (a + t) ^ (-(k : ℤ))) := by
-  have h := isCompletelyMonotone_inv_pow_const_add ha k
-  have heq : (fun t : ℝ => ((a + t) ^ k)⁻¹) = fun t => (a + t) ^ (-(k : ℤ)) := by
-    funext t; rw [zpow_neg, zpow_natCast]
   rwa [heq] at h
 
 end TauCeti

--- a/TauCeti/Analysis/CompletelyMonotone/Reciprocal.lean
+++ b/TauCeti/Analysis/CompletelyMonotone/Reciprocal.lean
@@ -5,7 +5,6 @@ Released under Apache 2.0 license as described in the file LICENSE.
 module
 
 public import TauCeti.Analysis.CompletelyMonotone.Basic
-import TauCeti.Analysis.CompletelyMonotone.Closure
 import Mathlib.Analysis.Calculus.IteratedDeriv.WithinZpow
 
 /-!
@@ -14,7 +13,7 @@ import Mathlib.Analysis.Calculus.IteratedDeriv.WithinZpow
 This file adds a second family of concrete completely monotone functions to the
 `OneParameterSemigroups` roadmap, alongside the exponentials `t ↦ e^{-x t}` already in
 `TauCeti.Analysis.CompletelyMonotone.Basic`: the **reciprocals of affine functions**
-`t ↦ (a + t)⁻¹` with `a > 0`, and their reciprocal powers `t ↦ ((a + t) ^ k)⁻¹`.
+`t ↦ (a + t)⁻¹` with `a > 0`.
 
 These are the resolvent kernels `t ↦ (λ + t)⁻¹` that Part A of the roadmap builds a semigroup
 theory around, and they are among the basic Stieltjes (resolvent) kernels appearing in Stieltjes
@@ -27,8 +26,6 @@ special case `a = 1`; its representing measure `e^{-x} dx` is the exponential di
   completely monotone.
 * `TauCeti.isCompletelyMonotone_one_div_one_add`: the roadmap acceptance example
   `t ↦ 1 / (1 + t)`.
-* `TauCeti.isCompletelyMonotone_inv_pow_const_add`: for `a > 0` and `k : ℕ`, the reciprocal power
-  `t ↦ ((a + t) ^ k)⁻¹` is completely monotone.
 
 ## References
 
@@ -90,14 +87,5 @@ theorem isCompletelyMonotone_one_div_one_add :
     rw [one_div]
   rw [heq]
   exact isCompletelyMonotone_inv_const_add one_pos
-
-/-- For `a > 0` and any natural power `k`, the reciprocal power `t ↦ ((a + t) ^ k)⁻¹` is completely
-monotone. -/
-theorem isCompletelyMonotone_inv_pow_const_add {a : ℝ} (ha : 0 < a) (k : ℕ) :
-    IsCompletelyMonotone (fun t => ((a + t) ^ k)⁻¹) := by
-  have h := (isCompletelyMonotone_inv_const_add ha).pow k
-  have heq : ((fun t : ℝ => (a + t)⁻¹) ^ k) = fun t => ((a + t) ^ k)⁻¹ := by
-    funext t; simp [Pi.pow_apply, inv_pow]
-  rwa [heq] at h
 
 end TauCeti


### PR DESCRIPTION
This PR adds a second family of concrete completely monotone functions to the `OneParameterSemigroups` roadmap, alongside the exponentials `t ↦ e^{-x t}` already present: the reciprocals of affine functions `t ↦ (a + t)⁻¹` for `a > 0`, their `1 / (a + t)` phrasing, and the named acceptance example `t ↦ 1 / (1 + t)`. These are exactly the resolvent kernels `t ↦ (λ + t)⁻¹` that Part A of the roadmap builds a semigroup theory around, and the Stieltjes building blocks out of which nonnegative mixtures generate every Stieltjes function; the case `a = 1` is the roadmap's `1/(1+t)` acceptance example, whose Bernstein representing measure is the exponential distribution `e^{-x} dx`. Higher resolvent powers `t ↦ (a + t)^{-k}` follow directly from the existing product closure `IsCompletelyMonotone.pow`, so they are not exposed as a separate named lemma.

The target is `TauCetiRoadmap/OneParameterSemigroups/README.md`, Part B ("Completely monotone (and Bernstein) functions"), which calls out the extreme-ray/building-block completely monotone functions and lists `1/(1+t)` among the acceptance examples. The proof computes the alternating iterated derivatives directly: Mathlib's `iteratedDerivWithin_one_div` gives `(y ↦ y⁻¹)⁽ⁿ⁾(y) = (-1)ⁿ · n! · y^{-1-n}` on an open set, translation invariance (`iteratedDeriv_comp_const_add`) transports it to `t ↦ (a + t)⁻¹`, and on `[0, ∞)` the base `a + t ≥ a > 0` makes `(-1)ⁿ` times the `n`-th derivative equal to the nonnegative `n! · (a + t)^{-1-n}`. The smoothness clause holds because the denominator never vanishes there.

The new file `TauCeti/Analysis/CompletelyMonotone/Reciprocal.lean` builds green against the pinned Mathlib and passes the axiom audit (`propext, Classical.choice, Quot.sound` only). It reuses Mathlib's `iteratedDerivWithin_one_div`, `iteratedDerivWithin_of_isOpen`, `iteratedDeriv_comp_const_add`, and `ContDiffOn.inv`/`ContDiffAt.inv`, and the project's `IsCompletelyMonotone` API.

<!--tauceti-target:v1 {"focus":"OneParameterSemigroups","id":"completely-monotone-reciprocal"}-->

🤖 Prepared with Claude Code
