### PR TITLE
feat: add tensor product comodule structure

### DIFF
--- a/TauCeti/Algebra/Coalgebra/Comodule/TensorProduct.lean
+++ b/TauCeti/Algebra/Coalgebra/Comodule/TensorProduct.lean
@@ -234,6 +234,26 @@ private theorem comul_lTensor_tensorCombine [Semiring C] [Bialgebra R C]
       | add y₁ y₂ hy₁ hy₂ => simp [hy₁, hy₂, TensorProduct.tmul_add]
   | add x₁ x₂ hx₁ hx₂ => simp [hx₁, hx₂, TensorProduct.add_tmul]
 
+private theorem tensorCoact_rTensor_tensorCombine_core [Semiring C] [Bialgebra R C]
+    [AddCommMonoid M] [Module R M] [Comodule R C M]
+    [AddCommMonoid N] [Module R N] [Comodule R C N] (x : M ⊗[R] C) (y : N ⊗[R] C)
+    (c d : C) :
+    TensorProduct.assoc R (M ⊗[R] N) C C
+        (tensorCombine (R := R) (C := C) (M := M) (N := N) (x ⊗ₜ[R] y) ⊗ₜ[R] (c * d)) =
+      tensorCombine (R := R) (C := C ⊗[R] C) (M := M) (N := N)
+        (TensorProduct.assoc R M C C (x ⊗ₜ[R] c) ⊗ₜ[R]
+          TensorProduct.assoc R N C C (y ⊗ₜ[R] d)) := by
+  induction x using TensorProduct.induction_on with
+  | zero => simp
+  | tmul m c' =>
+      induction y using TensorProduct.induction_on with
+      | zero => simp
+      | tmul n d' => simp [Algebra.TensorProduct.tmul_mul_tmul]
+      | add y₁ y₂ hy₁ hy₂ =>
+          rw [TensorProduct.tmul_add, map_add, TensorProduct.add_tmul, map_add,
+            TensorProduct.add_tmul, map_add, TensorProduct.tmul_add, map_add, hy₁, hy₂]
+  | add x₁ x₂ hx₁ hx₂ => simp [hx₁, hx₂, TensorProduct.add_tmul]
+
 private theorem tensorCoact_rTensor_tensorCombine [Semiring C] [Bialgebra R C]
     [AddCommMonoid M] [Module R M] [Comodule R C M]
     [AddCommMonoid N] [Module R N] [Comodule R C N] (x : M ⊗[R] C) (y : N ⊗[R] C) :
@@ -251,22 +271,10 @@ private theorem tensorCoact_rTensor_tensorCombine [Semiring C] [Bialgebra R C]
       induction y using TensorProduct.induction_on with
       | zero => simp
       | tmul n d =>
-          simp only [tensorCombine_tmul_tmul, LinearMap.rTensor_tmul,
-            tensorCoact_tmul]
-          generalize hxm : coact (R := R) (C := C) (M := M) m = xm
-          generalize hyn : coact (R := R) (C := C) (M := N) n = yn
-          clear hxm hyn
-          induction xm using TensorProduct.induction_on with
-          | zero => simp
-          | tmul m' c' =>
-              induction yn using TensorProduct.induction_on with
-              | zero => simp
-              | tmul n' d' => simp [Algebra.TensorProduct.tmul_mul_tmul]
-              | add y₁ y₂ hy₁ hy₂ =>
-                  rw [TensorProduct.tmul_add, map_add, TensorProduct.add_tmul, map_add, hy₁,
-                    hy₂, TensorProduct.add_tmul, map_add]
-                  rw [TensorProduct.tmul_add, map_add]
-          | add x₁ x₂ hx₁ hx₂ => simp [hx₁, hx₂, TensorProduct.add_tmul]
+          simpa only [tensorCombine_tmul_tmul, LinearMap.rTensor_tmul, tensorCoact_tmul] using
+            tensorCoact_rTensor_tensorCombine_core (R := R) (C := C) (M := M) (N := N)
+              (coact (R := R) (C := C) (M := M) m)
+              (coact (R := R) (C := C) (M := N) n) c d
       | add y₁ y₂ hy₁ hy₂ => simp [hy₁, hy₂, TensorProduct.tmul_add]
   | add x₁ x₂ hx₁ hx₂ => simp [hx₁, hx₂, TensorProduct.add_tmul]
 
@@ -309,7 +317,7 @@ theorem tensorCoact_coassoc [Semiring C] [Bialgebra R C]
             (coact (R := R) (C := C) (M := N) n)).symm
 
 /-- The tensor product of two right comodules over a bialgebra, with diagonal coaction. -/
-@[expose, implicit_reducible]
+@[implicit_reducible]
 noncomputable def TensorProduct [Semiring C] [Bialgebra R C]
     [AddCommMonoid M] [Module R M] [Comodule R C M]
     [AddCommMonoid N] [Module R N] [Comodule R C N] :
@@ -320,6 +328,13 @@ noncomputable def TensorProduct [Semiring C] [Bialgebra R C]
 
 attribute [local instance] TensorProduct
 
+private theorem TensorProduct_coact_aux [Semiring C] [Bialgebra R C]
+    [AddCommMonoid M] [Module R M] [Comodule R C M]
+    [AddCommMonoid N] [Module R N] [Comodule R C N] :
+    coact (R := R) (C := C) (M := M ⊗[R] N) =
+      tensorCoact (R := R) (C := C) (M := M) (N := N) :=
+  rfl
+
 /-- The coaction in `Comodule.TensorProduct` is `Comodule.tensorCoact`. -/
 @[simp]
 theorem TensorProduct_coact [Semiring C] [Bialgebra R C]
@@ -327,14 +342,14 @@ theorem TensorProduct_coact [Semiring C] [Bialgebra R C]
     [AddCommMonoid N] [Module R N] [Comodule R C N] :
     coact (R := R) (C := C) (M := M ⊗[R] N) =
       tensorCoact (R := R) (C := C) (M := M) (N := N) :=
-  rfl
+  TensorProduct_coact_aux (R := R) (C := C) (M := M) (N := N)
 
 namespace Hom
 
 variable {M' : Type y} {N' : Type z}
 
 /-- Tensor two right-comodule morphisms over a bialgebra. -/
-@[expose] noncomputable def tensor [Semiring C] [Bialgebra R C]
+noncomputable def tensor [Semiring C] [Bialgebra R C]
     [AddCommMonoid M] [Module R M] [Comodule R C M]
     [AddCommMonoid N] [Module R N] [Comodule R C N]
     [AddCommMonoid M'] [Module R M'] [Comodule R C M']
@@ -344,6 +359,16 @@ variable {M' : Type y} {N' : Type z}
   toLinearMap := TensorProduct.map f.toLinearMap g.toLinearMap
   map_coact := tensorCoact_natural (R := R) (C := C) (M := M) (N := N)
     (M' := M') (N' := N') f g
+
+private theorem tensor_toLinearMap_aux [Semiring C] [Bialgebra R C]
+    [AddCommMonoid M] [Module R M] [Comodule R C M]
+    [AddCommMonoid N] [Module R N] [Comodule R C N]
+    [AddCommMonoid M'] [Module R M'] [Comodule R C M']
+    [AddCommMonoid N'] [Module R N'] [Comodule R C N']
+    (f : Hom R C M M') (g : Hom R C N N') :
+    (tensor (R := R) (C := C) f g).toLinearMap =
+      TensorProduct.map f.toLinearMap g.toLinearMap :=
+  rfl
 
 /-- The underlying linear map of the tensor product of comodule morphisms is the tensor
 product of the underlying linear maps. -/
@@ -356,6 +381,15 @@ theorem tensor_toLinearMap [Semiring C] [Bialgebra R C]
     (f : Hom R C M M') (g : Hom R C N N') :
     (tensor (R := R) (C := C) f g).toLinearMap =
       TensorProduct.map f.toLinearMap g.toLinearMap :=
+  tensor_toLinearMap_aux (R := R) (C := C) f g
+
+private theorem tensor_tmul_aux [Semiring C] [Bialgebra R C]
+    [AddCommMonoid M] [Module R M] [Comodule R C M]
+    [AddCommMonoid N] [Module R N] [Comodule R C N]
+    [AddCommMonoid M'] [Module R M'] [Comodule R C M']
+    [AddCommMonoid N'] [Module R N'] [Comodule R C N']
+    (f : Hom R C M M') (g : Hom R C N N') (m : M) (n : N) :
+    tensor (R := R) (C := C) f g (m ⊗ₜ[R] n) = f m ⊗ₜ[R] g n :=
   rfl
 
 /-- The tensor product of comodule morphisms acts as the tensor product of the underlying
@@ -368,7 +402,72 @@ theorem tensor_tmul [Semiring C] [Bialgebra R C]
     [AddCommMonoid N'] [Module R N'] [Comodule R C N']
     (f : Hom R C M M') (g : Hom R C N N') (m : M) (n : N) :
     tensor (R := R) (C := C) f g (m ⊗ₜ[R] n) = f m ⊗ₜ[R] g n :=
-  rfl
+  tensor_tmul_aux (R := R) (C := C) f g m n
+
+private theorem tensor_id_aux [Semiring C] [Bialgebra R C]
+    [AddCommMonoid M] [Module R M] [Comodule R C M]
+    [AddCommMonoid N] [Module R N] [Comodule R C N] :
+    tensor (R := R) (C := C) (id R C M) (id R C N) =
+      id R C (M ⊗[R] N) := by
+  ext x
+  induction x using TensorProduct.induction_on with
+  | zero => rfl
+  | tmul m n => rfl
+  | add x₁ x₂ hx₁ hx₂ =>
+      change ((tensor (R := R) (C := C) (id R C M) (id R C N)).toLinearMap (x₁ + x₂)) =
+        (id R C (M ⊗[R] N)).toLinearMap (x₁ + x₂)
+      rw [map_add, map_add]
+      simpa only [coe_toLinearMap] using congrArg₂ (fun a b => a + b) hx₁ hx₂
+
+/-- Tensoring identity comodule morphisms gives the identity on the tensor-product
+comodule. -/
+@[simp]
+theorem tensor_id [Semiring C] [Bialgebra R C]
+    [AddCommMonoid M] [Module R M] [Comodule R C M]
+    [AddCommMonoid N] [Module R N] [Comodule R C N] :
+    tensor (R := R) (C := C) (id R C M) (id R C N) =
+      id R C (M ⊗[R] N) := by
+  exact tensor_id_aux (R := R) (C := C) (M := M) (N := N)
+
+variable {M'' N'' : Type*}
+
+private theorem tensor_comp_aux [Semiring C] [Bialgebra R C]
+    [AddCommMonoid M] [Module R M] [Comodule R C M]
+    [AddCommMonoid N] [Module R N] [Comodule R C N]
+    [AddCommMonoid M'] [Module R M'] [Comodule R C M']
+    [AddCommMonoid N'] [Module R N'] [Comodule R C N']
+    [AddCommMonoid M''] [Module R M''] [Comodule R C M'']
+    [AddCommMonoid N''] [Module R N''] [Comodule R C N'']
+    (f₂ : Hom R C M' M'') (f₁ : Hom R C M M')
+    (g₂ : Hom R C N' N'') (g₁ : Hom R C N N') :
+    tensor (R := R) (C := C) (comp f₂ f₁) (comp g₂ g₁) =
+      comp (tensor (R := R) (C := C) f₂ g₂) (tensor (R := R) (C := C) f₁ g₁) := by
+  ext x
+  induction x using TensorProduct.induction_on with
+  | zero => rfl
+  | tmul m n => rfl
+  | add x₁ x₂ hx₁ hx₂ =>
+      change ((tensor (R := R) (C := C) (comp f₂ f₁) (comp g₂ g₁)).toLinearMap
+          (x₁ + x₂)) =
+        (comp (tensor (R := R) (C := C) f₂ g₂) (tensor (R := R) (C := C) f₁ g₁)).toLinearMap
+          (x₁ + x₂)
+      rw [map_add, map_add]
+      simpa only [coe_toLinearMap] using congrArg₂ (fun a b => a + b) hx₁ hx₂
+
+/-- Tensoring composite comodule morphisms gives the composite of the tensor products. -/
+@[simp]
+theorem tensor_comp [Semiring C] [Bialgebra R C]
+    [AddCommMonoid M] [Module R M] [Comodule R C M]
+    [AddCommMonoid N] [Module R N] [Comodule R C N]
+    [AddCommMonoid M'] [Module R M'] [Comodule R C M']
+    [AddCommMonoid N'] [Module R N'] [Comodule R C N']
+    [AddCommMonoid M''] [Module R M''] [Comodule R C M'']
+    [AddCommMonoid N''] [Module R N''] [Comodule R C N'']
+    (f₂ : Hom R C M' M'') (f₁ : Hom R C M M')
+    (g₂ : Hom R C N' N'') (g₁ : Hom R C N N') :
+    tensor (R := R) (C := C) (comp f₂ f₁) (comp g₂ g₁) =
+      comp (tensor (R := R) (C := C) f₂ g₂) (tensor (R := R) (C := C) f₁ g₁) := by
+  exact tensor_comp_aux (R := R) (C := C) f₂ f₁ g₂ g₁
 
 end Hom
 

--- a/TauCeti/Algebra/Coalgebra/Comodule/TensorProduct.lean
+++ b/TauCeti/Algebra/Coalgebra/Comodule/TensorProduct.lean
@@ -8,26 +8,28 @@ public import Mathlib.RingTheory.Bialgebra.Basic
 public import TauCeti.Algebra.Coalgebra.Comodule
 
 /-!
-# The tensor-product coaction map for comodules over a bialgebra
+# Tensor products of comodules over a bialgebra
 
-This file constructs the diagonal coaction map used in the tensor product of two right
-comodules over a bialgebra. If `M` and `N` are right comodules over `C`, the map on
-`M ⊗ N` is the usual formula
+This file constructs the tensor product of two right comodules over a bialgebra. If `M` and
+`N` are right comodules over `C`, the diagonal coaction on `M ⊗ N` is the usual formula
 
 `m ⊗ n ↦ m₀ ⊗ n₀ ⊗ m₁ n₁`.
 
-This is the concrete linear-map prerequisite for the full tensor-product comodule structure:
-the counit and coassociativity laws can be proved against this map, and the naturality lemma
-here is the morphism-level compatibility needed for the later categorical tensor product.
+The candidate coaction is exposed as a linear map, its counit and coassociativity laws are
+proved, and the resulting comodule structure is provided as an explicit named definition rather
+than as a global instance. The file also tensors comodule morphisms, giving the morphism-level
+compatibility needed for the later categorical tensor product.
 
 ## Main declarations
 
 * `TauCeti.Comodule.tensorCombine`: combines two coacted tensor factors.
 * `TauCeti.Comodule.tensorCoact`: the diagonal coaction on `M ⊗ N`.
+* `TauCeti.Comodule.TensorProduct`: the tensor-product comodule structure.
 * `TauCeti.Comodule.tensorCombine_natural`: naturality of the combining map in the two
   comodule carriers.
 * `TauCeti.Comodule.tensorCoact_natural`: the diagonal coaction commutes with tensoring
   comodule morphisms.
+* `TauCeti.Comodule.Hom.tensor`: the tensor product of two comodule morphisms.
 
 ## References
 
@@ -188,6 +190,187 @@ theorem tensorCoact_natural [Semiring C] [Bialgebra R C]
       (M' := M') (N' := N') f.toLinearMap g.toLinearMap)
     (coact (R := R) (C := C) (M := M) m ⊗ₜ[R] coact (R := R) (C := C) (M := N) n)
   simpa [tensorCoact_tmul, Hom.map_coact_apply] using hcombine
+
+private theorem lTensor_counit_tensorCombine [Semiring C] [Bialgebra R C]
+    [AddCommMonoid M] [Module R M]
+    [AddCommMonoid N] [Module R N] (x : M ⊗[R] C) (y : N ⊗[R] C) :
+    Coalgebra.counit.lTensor (M ⊗[R] N)
+        (tensorCombine (R := R) (C := C) (M := M) (N := N) (x ⊗ₜ[R] y)) =
+      tensorCombine (R := R) (C := R) (M := M) (N := N)
+        (Coalgebra.counit.lTensor M x ⊗ₜ[R] Coalgebra.counit.lTensor N y) := by
+  induction x using TensorProduct.induction_on with
+  | zero => simp
+  | tmul m c =>
+      induction y using TensorProduct.induction_on with
+      | zero => simp
+      | tmul n d => simp [Bialgebra.counit_mul]
+      | add y₁ y₂ hy₁ hy₂ => simp [hy₁, hy₂, TensorProduct.tmul_add]
+  | add x₁ x₂ hx₁ hx₂ => simp [hx₁, hx₂, TensorProduct.add_tmul]
+
+/-- The diagonal tensor-product coaction satisfies the counit law. -/
+theorem tensorCoact_counit [Semiring C] [Bialgebra R C]
+    [AddCommMonoid M] [Module R M] [Comodule R C M]
+    [AddCommMonoid N] [Module R N] [Comodule R C N] :
+    Coalgebra.counit.lTensor (M ⊗[R] N) ∘ₗ
+        tensorCoact (R := R) (C := C) (M := M) (N := N) =
+      (TensorProduct.mk R (M ⊗[R] N) R).flip 1 := by
+  apply TensorProduct.ext'
+  intro m n
+  simp [tensorCoact_tmul, lTensor_counit_tensorCombine]
+
+private theorem comul_lTensor_tensorCombine [Semiring C] [Bialgebra R C]
+    [AddCommMonoid M] [Module R M]
+    [AddCommMonoid N] [Module R N] (x : M ⊗[R] C) (y : N ⊗[R] C) :
+    Coalgebra.comul.lTensor (M ⊗[R] N)
+        (tensorCombine (R := R) (C := C) (M := M) (N := N) (x ⊗ₜ[R] y)) =
+      tensorCombine (R := R) (C := C ⊗[R] C) (M := M) (N := N)
+        (Coalgebra.comul.lTensor M x ⊗ₜ[R] Coalgebra.comul.lTensor N y) := by
+  induction x using TensorProduct.induction_on with
+  | zero => simp
+  | tmul m c =>
+      induction y using TensorProduct.induction_on with
+      | zero => simp
+      | tmul n d => simp [Bialgebra.comul_mul]
+      | add y₁ y₂ hy₁ hy₂ => simp [hy₁, hy₂, TensorProduct.tmul_add]
+  | add x₁ x₂ hx₁ hx₂ => simp [hx₁, hx₂, TensorProduct.add_tmul]
+
+private theorem tensorCoact_rTensor_tensorCombine [Semiring C] [Bialgebra R C]
+    [AddCommMonoid M] [Module R M] [Comodule R C M]
+    [AddCommMonoid N] [Module R N] [Comodule R C N] (x : M ⊗[R] C) (y : N ⊗[R] C) :
+    TensorProduct.assoc R (M ⊗[R] N) C C
+        ((tensorCoact (R := R) (C := C) (M := M) (N := N)).rTensor C
+          (tensorCombine (R := R) (C := C) (M := M) (N := N) (x ⊗ₜ[R] y))) =
+      tensorCombine (R := R) (C := C ⊗[R] C) (M := M) (N := N)
+        (TensorProduct.assoc R M C C
+            ((coact (R := R) (C := C) (M := M)).rTensor C x) ⊗ₜ[R]
+          TensorProduct.assoc R N C C
+            ((coact (R := R) (C := C) (M := N)).rTensor C y)) := by
+  induction x using TensorProduct.induction_on with
+  | zero => simp
+  | tmul m c =>
+      induction y using TensorProduct.induction_on with
+      | zero => simp
+      | tmul n d =>
+          simp only [tensorCombine_tmul_tmul, LinearMap.rTensor_tmul,
+            tensorCoact_tmul]
+          generalize hxm : coact (R := R) (C := C) (M := M) m = xm
+          generalize hyn : coact (R := R) (C := C) (M := N) n = yn
+          clear hxm hyn
+          induction xm using TensorProduct.induction_on with
+          | zero => simp
+          | tmul m' c' =>
+              induction yn using TensorProduct.induction_on with
+              | zero => simp
+              | tmul n' d' => simp [Algebra.TensorProduct.tmul_mul_tmul]
+              | add y₁ y₂ hy₁ hy₂ =>
+                  rw [TensorProduct.tmul_add, map_add, TensorProduct.add_tmul, map_add, hy₁,
+                    hy₂, TensorProduct.add_tmul, map_add]
+                  rw [TensorProduct.tmul_add, map_add]
+          | add x₁ x₂ hx₁ hx₂ => simp [hx₁, hx₂, TensorProduct.add_tmul]
+      | add y₁ y₂ hy₁ hy₂ => simp [hy₁, hy₂, TensorProduct.tmul_add]
+  | add x₁ x₂ hx₁ hx₂ => simp [hx₁, hx₂, TensorProduct.add_tmul]
+
+/-- The diagonal tensor-product coaction is coassociative. -/
+theorem tensorCoact_coassoc [Semiring C] [Bialgebra R C]
+    [AddCommMonoid M] [Module R M] [Comodule R C M]
+    [AddCommMonoid N] [Module R N] [Comodule R C N] :
+    TensorProduct.assoc R (M ⊗[R] N) C C ∘ₗ
+        (tensorCoact (R := R) (C := C) (M := M) (N := N)).rTensor C ∘ₗ
+          tensorCoact (R := R) (C := C) (M := M) (N := N) =
+      Coalgebra.comul.lTensor (M ⊗[R] N) ∘ₗ
+        tensorCoact (R := R) (C := C) (M := M) (N := N) := by
+  apply TensorProduct.ext'
+  intro m n
+  calc
+    TensorProduct.assoc R (M ⊗[R] N) C C
+        ((tensorCoact (R := R) (C := C) (M := M) (N := N)).rTensor C
+          (tensorCoact (R := R) (C := C) (M := M) (N := N) (m ⊗ₜ[R] n))) =
+        tensorCombine (R := R) (C := C ⊗[R] C) (M := M) (N := N)
+          (TensorProduct.assoc R M C C
+              ((coact (R := R) (C := C) (M := M)).rTensor C
+                (coact (R := R) (C := C) (M := M) m)) ⊗ₜ[R]
+            TensorProduct.assoc R N C C
+              ((coact (R := R) (C := C) (M := N)).rTensor C
+                (coact (R := R) (C := C) (M := N) n))) := by
+          rw [tensorCoact_tmul]
+          exact tensorCoact_rTensor_tensorCombine (R := R) (C := C) (M := M) (N := N)
+            (coact (R := R) (C := C) (M := M) m)
+            (coact (R := R) (C := C) (M := N) n)
+    _ = tensorCombine (R := R) (C := C ⊗[R] C) (M := M) (N := N)
+          (Coalgebra.comul.lTensor M (coact (R := R) (C := C) (M := M) m) ⊗ₜ[R]
+            Coalgebra.comul.lTensor N (coact (R := R) (C := C) (M := N) n)) := by
+          rw [coassoc_apply (R := R) (C := C) (M := M) m,
+            coassoc_apply (R := R) (C := C) (M := N) n]
+    _ = Coalgebra.comul.lTensor (M ⊗[R] N)
+          (tensorCoact (R := R) (C := C) (M := M) (N := N) (m ⊗ₜ[R] n)) := by
+          rw [tensorCoact_tmul]
+          exact (comul_lTensor_tensorCombine (R := R) (C := C) (M := M) (N := N)
+            (coact (R := R) (C := C) (M := M) m)
+            (coact (R := R) (C := C) (M := N) n)).symm
+
+/-- The tensor product of two right comodules over a bialgebra, with diagonal coaction. -/
+@[expose, implicit_reducible]
+noncomputable def TensorProduct [Semiring C] [Bialgebra R C]
+    [AddCommMonoid M] [Module R M] [Comodule R C M]
+    [AddCommMonoid N] [Module R N] [Comodule R C N] :
+    Comodule R C (M ⊗[R] N) where
+  coact := tensorCoact (R := R) (C := C) (M := M) (N := N)
+  coassoc := tensorCoact_coassoc (R := R) (C := C) (M := M) (N := N)
+  lTensor_counit_comp_coact := tensorCoact_counit (R := R) (C := C) (M := M) (N := N)
+
+attribute [local instance] TensorProduct
+
+/-- The coaction in `Comodule.TensorProduct` is `Comodule.tensorCoact`. -/
+@[simp]
+theorem TensorProduct_coact [Semiring C] [Bialgebra R C]
+    [AddCommMonoid M] [Module R M] [Comodule R C M]
+    [AddCommMonoid N] [Module R N] [Comodule R C N] :
+    coact (R := R) (C := C) (M := M ⊗[R] N) =
+      tensorCoact (R := R) (C := C) (M := M) (N := N) :=
+  rfl
+
+namespace Hom
+
+variable {M' : Type y} {N' : Type z}
+
+/-- Tensor two right-comodule morphisms over a bialgebra. -/
+@[expose] noncomputable def tensor [Semiring C] [Bialgebra R C]
+    [AddCommMonoid M] [Module R M] [Comodule R C M]
+    [AddCommMonoid N] [Module R N] [Comodule R C N]
+    [AddCommMonoid M'] [Module R M'] [Comodule R C M']
+    [AddCommMonoid N'] [Module R N'] [Comodule R C N']
+    (f : Hom R C M M') (g : Hom R C N N') :
+    Hom R C (M ⊗[R] N) (M' ⊗[R] N') where
+  toLinearMap := TensorProduct.map f.toLinearMap g.toLinearMap
+  map_coact := tensorCoact_natural (R := R) (C := C) (M := M) (N := N)
+    (M' := M') (N' := N') f g
+
+/-- The underlying linear map of the tensor product of comodule morphisms is the tensor
+product of the underlying linear maps. -/
+@[simp]
+theorem tensor_toLinearMap [Semiring C] [Bialgebra R C]
+    [AddCommMonoid M] [Module R M] [Comodule R C M]
+    [AddCommMonoid N] [Module R N] [Comodule R C N]
+    [AddCommMonoid M'] [Module R M'] [Comodule R C M']
+    [AddCommMonoid N'] [Module R N'] [Comodule R C N']
+    (f : Hom R C M M') (g : Hom R C N N') :
+    (tensor (R := R) (C := C) f g).toLinearMap =
+      TensorProduct.map f.toLinearMap g.toLinearMap :=
+  rfl
+
+/-- The tensor product of comodule morphisms acts as the tensor product of the underlying
+linear maps on pure tensors. -/
+@[simp]
+theorem tensor_tmul [Semiring C] [Bialgebra R C]
+    [AddCommMonoid M] [Module R M] [Comodule R C M]
+    [AddCommMonoid N] [Module R N] [Comodule R C N]
+    [AddCommMonoid M'] [Module R M'] [Comodule R C M']
+    [AddCommMonoid N'] [Module R N'] [Comodule R C N']
+    (f : Hom R C M M') (g : Hom R C N N') (m : M) (n : N) :
+    tensor (R := R) (C := C) f g (m ⊗ₜ[R] n) = f m ⊗ₜ[R] g n :=
+  rfl
+
+end Hom
 
 end Coact
 

--- a/TauCeti/Algebra/Coalgebra/Comodule/TensorProduct.lean
+++ b/TauCeti/Algebra/Coalgebra/Comodule/TensorProduct.lean
@@ -250,8 +250,7 @@ private theorem tensorCoact_rTensor_tensorCombine_core [Semiring C] [Bialgebra R
       | zero => simp
       | tmul n d' => simp [Algebra.TensorProduct.tmul_mul_tmul]
       | add y₁ y₂ hy₁ hy₂ =>
-          rw [TensorProduct.tmul_add, map_add, TensorProduct.add_tmul, map_add,
-            TensorProduct.add_tmul, map_add, TensorProduct.tmul_add, map_add, hy₁, hy₂]
+          simp [hy₁, hy₂, TensorProduct.tmul_add, TensorProduct.add_tmul]
   | add x₁ x₂ hx₁ hx₂ => simp [hx₁, hx₂, TensorProduct.add_tmul]
 
 private theorem tensorCoact_rTensor_tensorCombine [Semiring C] [Bialgebra R C]
@@ -409,15 +408,12 @@ private theorem tensor_id_aux [Semiring C] [Bialgebra R C]
     [AddCommMonoid N] [Module R N] [Comodule R C N] :
     tensor (R := R) (C := C) (id R C M) (id R C N) =
       id R C (M ⊗[R] N) := by
+  have h : (tensor (R := R) (C := C) (id R C M) (id R C N)).toLinearMap =
+      (id R C (M ⊗[R] N)).toLinearMap := by
+    rw [tensor_toLinearMap]
+    exact TensorProduct.map_id
   ext x
-  induction x using TensorProduct.induction_on with
-  | zero => rfl
-  | tmul m n => rfl
-  | add x₁ x₂ hx₁ hx₂ =>
-      change ((tensor (R := R) (C := C) (id R C M) (id R C N)).toLinearMap (x₁ + x₂)) =
-        (id R C (M ⊗[R] N)).toLinearMap (x₁ + x₂)
-      rw [map_add, map_add]
-      simpa only [coe_toLinearMap] using congrArg₂ (fun a b => a + b) hx₁ hx₂
+  exact LinearMap.congr_fun h x
 
 /-- Tensoring identity comodule morphisms gives the identity on the tensor-product
 comodule.
@@ -445,17 +441,12 @@ private theorem tensor_comp_aux [Semiring C] [Bialgebra R C]
     (g₂ : Hom R C N' N'') (g₁ : Hom R C N N') :
     tensor (R := R) (C := C) (comp f₂ f₁) (comp g₂ g₁) =
       comp (tensor (R := R) (C := C) f₂ g₂) (tensor (R := R) (C := C) f₁ g₁) := by
+  have h : (tensor (R := R) (C := C) (comp f₂ f₁) (comp g₂ g₁)).toLinearMap =
+      (comp (tensor (R := R) (C := C) f₂ g₂) (tensor (R := R) (C := C) f₁ g₁)).toLinearMap := by
+    rw [tensor_toLinearMap]
+    exact TensorProduct.map_comp f₂.toLinearMap g₂.toLinearMap f₁.toLinearMap g₁.toLinearMap
   ext x
-  induction x using TensorProduct.induction_on with
-  | zero => rfl
-  | tmul m n => rfl
-  | add x₁ x₂ hx₁ hx₂ =>
-      change ((tensor (R := R) (C := C) (comp f₂ f₁) (comp g₂ g₁)).toLinearMap
-          (x₁ + x₂)) =
-        (comp (tensor (R := R) (C := C) f₂ g₂) (tensor (R := R) (C := C) f₁ g₁)).toLinearMap
-          (x₁ + x₂)
-      rw [map_add, map_add]
-      simpa only [coe_toLinearMap] using congrArg₂ (fun a b => a + b) hx₁ hx₂
+  exact LinearMap.congr_fun h x
 
 /-- Tensoring composite comodule morphisms gives the composite of the tensor products. -/
 @[simp]

--- a/TauCeti/Algebra/Coalgebra/Comodule/TensorProduct.lean
+++ b/TauCeti/Algebra/Coalgebra/Comodule/TensorProduct.lean
@@ -420,8 +420,11 @@ private theorem tensor_id_aux [Semiring C] [Bialgebra R C]
       simpa only [coe_toLinearMap] using congrArg₂ (fun a b => a + b) hx₁ hx₂
 
 /-- Tensoring identity comodule morphisms gives the identity on the tensor-product
-comodule. -/
-@[simp]
+comodule.
+
+This is not a `simp` lemma: the ambient `ComoduleCat.ofHom_id` simp lemma rewrites the bare
+`Hom.id R C M` on the left-hand side to `𝟙 (ComoduleCat.of R C M)`, so the statement is never
+in `simp`-normal form. -/
 theorem tensor_id [Semiring C] [Bialgebra R C]
     [AddCommMonoid M] [Module R M] [Comodule R C M]
     [AddCommMonoid N] [Module R N] [Comodule R C N] :


### PR DESCRIPTION
This PR completes the tensor-product comodule prerequisite for right comodules over a bialgebra: it proves that the existing diagonal coaction `tensorCoact` satisfies the counit and coassociativity laws, packages it as the explicit named structure `Comodule.TensorProduct`, and adds `Comodule.Hom.tensor` for tensoring comodule morphisms. The structure is deliberately not a global instance, matching the existing explicit `Comodule.trivial`, `Comodule.cofree`, and `Comodule.Prod` pattern for carriers that may support several coactions.

This advances `TauCetiRoadmap/ReductiveGroups/README.md`, Layer 1, “Comodules over a coalgebra/Hopf algebra,” specifically the requested tensor products in the finite-dimensional comodule category. I chose it as the lowest-hanging distinct ReductiveGroups target after checking open and recently merged PRs: the open ReductiveGroups PR covers comodule invariants, and the merged tensor-product PR supplied only the candidate diagonal coaction map and naturality, leaving the actual comodule laws and morphism tensor API as the next small prerequisite.

No Mathlib infrastructure is vendored. The proof reuses Mathlib’s bialgebra identities `Bialgebra.counit_mul` and `Bialgebra.comul_mul`, tensor-product algebra multiplication on `C ⊗[R] C`, and Tau Ceti’s existing `Comodule.tensorCombine`, `Comodule.tensorCoact`, and `Comodule.tensorCoact_natural` API.

`lake exe cache get` completed with `No files to download` and `Already decompressed 8619 file(s)`. `lake build` reported `Build completed successfully (5073 jobs).` `lake exe axioms` reported `axioms: audited 9102 TauCeti declaration(s); all within the allowlist [propext, Classical.choice, Quot.sound].`

<!--tauceti-target:v1 {"focus":"ReductiveGroups","id":"tensor-product-comodule-structure"}-->

🤖 Prepared with Codex
