### PR TITLE
feat: add affine winding coordinate changes

### DIFF
--- a/TauCeti/Analysis/Contour/WindingNumberAffine.lean
+++ b/TauCeti/Analysis/Contour/WindingNumberAffine.lean
@@ -47,6 +47,13 @@ variable {γ : ℝ → ℂ} {a b : ℝ} {z₀ z c d : ℂ} {Ω : Set ℂ}
 abbreviation keeps the affine principal-value statements readable. -/
 local notation "κ[" z "]" => (fun w : ℂ => (w - z)⁻¹)
 
+private lemma affine_apply_preimage (hc : c ≠ 0) (z d : ℂ) :
+    c * (c⁻¹ * (z - d)) + d = z := by
+  have hmul : c * (c⁻¹ * (z - d)) = z - d := by
+    field_simp [hc]
+  rw [hmul]
+  ring
+
 /-- **Index principal value under an affine coordinate change.** If `c ≠ 0`, applying
 `z ↦ c * z + d` to both the curve and the distinguished point transports the single-point Cauchy
 principal value of the winding kernel without changing its value. This is the composed
@@ -84,11 +91,7 @@ number of the affine image about an arbitrary point. -/
 theorem windingNumber_affine_preimage (hc : c ≠ 0) :
     windingNumber (fun t => c * γ t + d) a b z =
       windingNumber γ a b (c⁻¹ * (z - d)) := by
-  have hz : z = c * (c⁻¹ * (z - d)) + d := by
-    have hmul : c * (c⁻¹ * (z - d)) = z - d := by
-      field_simp [hc]
-    rw [hmul]
-    ring
+  have hz : z = c * (c⁻¹ * (z - d)) + d := (affine_apply_preimage hc z d).symm
   calc
     windingNumber (fun t => c * γ t + d) a b z
         = windingNumber (fun t => c * γ t + d) a b (c * (c⁻¹ * (z - d)) + d) := by
@@ -96,40 +99,14 @@ theorem windingNumber_affine_preimage (hc : c ≠ 0) :
     _ = windingNumber γ a b (c⁻¹ * (z - d)) :=
       windingNumber_affine (γ := γ) (a := a) (b := b) (z₀ := c⁻¹ * (z - d)) hc
 
-/-- Pointwise vanishing of a winding number is preserved by a simultaneous affine coordinate
-change with nonzero linear coefficient. -/
-theorem windingNumber_eq_zero_affine
-    (hzero : windingNumber γ a b z₀ = 0) (hc : c ≠ 0) :
-    windingNumber (fun t => c * γ t + d) a b (c * z₀ + d) = 0 := by
-  rw [windingNumber_affine (γ := γ) (a := a) (b := b) (z₀ := z₀) hc, hzero]
-
-/-- Pointwise vanishing of a winding number of an affine image can be checked at the inverse
-image of the target point. -/
-theorem windingNumber_eq_zero_affine_preimage
-    (hzero : windingNumber γ a b (c⁻¹ * (z - d)) = 0) (hc : c ≠ 0) :
-    windingNumber (fun t => c * γ t + d) a b z = 0 := by
-  rw [windingNumber_affine_preimage (γ := γ) (a := a) (b := b) (c := c) (d := d) hc, hzero]
-
 /-- Null-homology is preserved by affine coordinate change of the curve and ambient set, provided
 the linear coefficient is nonzero. -/
 theorem IsNullHomologous.affine (h : IsNullHomologous γ a b Ω) (hc : c ≠ 0) :
     IsNullHomologous (fun t => c * γ t + d) a b ((fun z => c * z + d) '' Ω) := by
-  rw [isNullHomologous_iff] at h ⊢
-  intro z hz
-  have hpre_not_mem : c⁻¹ * (z - d) ∉ Ω := by
-    intro hzΩ
-    exact hz ⟨c⁻¹ * (z - d), hzΩ, by
-      change c * (c⁻¹ * (z - d)) + d = z
-      have hmul : c * (c⁻¹ * (z - d)) = z - d := by
-        field_simp [hc]
-      rw [hmul]
-      ring⟩
-  rw [windingNumber_affine_preimage (γ := γ) (a := a) (b := b) (c := c) (d := d) hc]
-  exact h (c⁻¹ * (z - d)) hpre_not_mem
+  simpa [Set.image_image, Function.comp_def] using (h.const_mul hc).translate d
 
 /-- If the affine image of a curve is null-homologous in the affine image of a set, then the
-original curve is null-homologous in the original set. This is the reverse direction of
-`IsNullHomologous.affine`, using injectivity of `z ↦ c * z + d` when `c ≠ 0`. -/
+original curve is null-homologous in the original set. -/
 theorem IsNullHomologous.of_affine
     (h : IsNullHomologous (fun t => c * γ t + d) a b ((fun z => c * z + d) '' Ω))
     (hc : c ≠ 0) :

--- a/TauCeti/Analysis/Contour/WindingNumberAffine.lean
+++ b/TauCeti/Analysis/Contour/WindingNumberAffine.lean
@@ -1,0 +1,155 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Chris Birkbeck
+-/
+module
+
+public import TauCeti.Analysis.Contour.WindingNumberScale
+public import TauCeti.Analysis.Contour.WindingNumberTranslate
+
+/-!
+# Affine coordinate changes for contour winding numbers
+
+This file packages the translation and nonzero-scaling invariance of the generalized winding
+number into the affine-coordinate form used by local contour geometry. A sector or crossing is
+typically normalized by sending its distinguished point to the origin and rescaling the tangent
+direction; the results here let downstream finite-decomposition arguments use the single map
+`z ↦ c * z + d` rather than manually alternating the separate translation and scaling lemmas.
+
+## Main results
+
+* `Contour.windingNumber_affine` — simultaneous affine change of the curve and base point
+  preserves the generalized winding number when the linear coefficient is nonzero.
+* `Contour.windingNumber_affine_preimage` — the same statement with an arbitrary target point,
+  pulled back through the inverse affine map.
+* `Contour.IsNullHomologous.affine` — null-homology is preserved by affine image of the curve and
+  ambient set.
+* `Contour.isNullHomologous_affine_iff` — the corresponding equivalence for nondegenerate affine
+  coordinate changes.
+
+## Provenance
+
+This is routine API around the Hungerbühler--Wasem generalized winding number from the contour
+integration roadmap; no formal source is vendored. It combines the existing Tau Ceti translation
+and scaling invariance lemmas.
+-/
+
+public section
+
+noncomputable section
+
+namespace TauCeti.Contour
+
+variable {γ : ℝ → ℂ} {a b : ℝ} {z₀ z c d : ℂ} {Ω : Set ℂ}
+
+/-- The kernel integrand used to define the generalized winding number about `z₀`. This local
+abbreviation keeps the affine principal-value statements readable. -/
+local notation "κ[" z "]" => (fun w : ℂ => (w - z)⁻¹)
+
+/-- **Index principal value under an affine coordinate change.** If `c ≠ 0`, applying
+`z ↦ c * z + d` to both the curve and the distinguished point transports the single-point Cauchy
+principal value of the winding kernel without changing its value. This is the composed
+translation/scaling form of `hasCauchyPVAt_inv_sub_const_mul`. -/
+theorem hasCauchyPVAt_inv_sub_affine
+    (h : HasCauchyPVAt γ a b κ[z₀] z₀ L) (hc : c ≠ 0) :
+    HasCauchyPVAt (fun t => c * γ t + d) a b κ[c * z₀ + d] (c * z₀ + d) L := by
+  refine ((hasCauchyPVAt_inv_sub_const_mul (c := c) h hc).translate d).congr_along_curve ?_
+  intro t _ht
+  congr 1
+  ring
+
+/-- Existence form of `hasCauchyPVAt_inv_sub_affine`: affine coordinate changes with nonzero
+linear coefficient preserve existence of the index principal value. -/
+theorem cauchyPVExistsAt_inv_sub_affine
+    (h : CauchyPVExistsAt γ a b κ[z₀] z₀) (hc : c ≠ 0) :
+    CauchyPVExistsAt (fun t => c * γ t + d) a b κ[c * z₀ + d] (c * z₀ + d) :=
+  let ⟨_, hL⟩ := cauchyPVExistsAt_iff.mp h
+  CauchyPVExistsAt.intro (hasCauchyPVAt_inv_sub_affine (d := d) hL hc)
+
+/-- The generalized winding number is invariant under simultaneous affine coordinate change of
+the curve and base point, provided the linear coefficient is nonzero. -/
+theorem windingNumber_affine (hc : c ≠ 0) :
+    windingNumber (fun t => c * γ t + d) a b (c * z₀ + d) = windingNumber γ a b z₀ := by
+  calc
+    windingNumber (fun t => c * γ t + d) a b (c * z₀ + d)
+        = windingNumber (fun t => c * γ t) a b (c * z₀) := by
+          exact windingNumber_translate (γ := fun t => c * γ t) (a := a) (b := b)
+            (z₀ := c * z₀) d
+    _ = windingNumber γ a b z₀ := windingNumber_const_mul (γ := γ) (a := a) (b := b)
+      (z₀ := z₀) hc
+
+/-- Pulling the base point back through a nondegenerate affine map gives the value of the winding
+number of the affine image about an arbitrary point. -/
+theorem windingNumber_affine_preimage (hc : c ≠ 0) :
+    windingNumber (fun t => c * γ t + d) a b z =
+      windingNumber γ a b (c⁻¹ * (z - d)) := by
+  have hz : z = c * (c⁻¹ * (z - d)) + d := by
+    have hmul : c * (c⁻¹ * (z - d)) = z - d := by
+      field_simp [hc]
+    rw [hmul]
+    ring
+  calc
+    windingNumber (fun t => c * γ t + d) a b z
+        = windingNumber (fun t => c * γ t + d) a b (c * (c⁻¹ * (z - d)) + d) := by
+          exact congrArg (fun w => windingNumber (fun t => c * γ t + d) a b w) hz
+    _ = windingNumber γ a b (c⁻¹ * (z - d)) :=
+      windingNumber_affine (γ := γ) (a := a) (b := b) (z₀ := c⁻¹ * (z - d)) hc
+
+/-- Pointwise vanishing of a winding number is preserved by a simultaneous affine coordinate
+change with nonzero linear coefficient. -/
+theorem windingNumber_eq_zero_affine
+    (hzero : windingNumber γ a b z₀ = 0) (hc : c ≠ 0) :
+    windingNumber (fun t => c * γ t + d) a b (c * z₀ + d) = 0 := by
+  rw [windingNumber_affine (γ := γ) (a := a) (b := b) (z₀ := z₀) hc, hzero]
+
+/-- Pointwise vanishing of a winding number of an affine image can be checked at the inverse
+image of the target point. -/
+theorem windingNumber_eq_zero_affine_preimage
+    (hzero : windingNumber γ a b (c⁻¹ * (z - d)) = 0) (hc : c ≠ 0) :
+    windingNumber (fun t => c * γ t + d) a b z = 0 := by
+  rw [windingNumber_affine_preimage (γ := γ) (a := a) (b := b) (c := c) (d := d) hc, hzero]
+
+/-- Null-homology is preserved by affine coordinate change of the curve and ambient set, provided
+the linear coefficient is nonzero. -/
+theorem IsNullHomologous.affine (h : IsNullHomologous γ a b Ω) (hc : c ≠ 0) :
+    IsNullHomologous (fun t => c * γ t + d) a b ((fun z => c * z + d) '' Ω) := by
+  rw [isNullHomologous_iff] at h ⊢
+  intro z hz
+  have hpre_not_mem : c⁻¹ * (z - d) ∉ Ω := by
+    intro hzΩ
+    exact hz ⟨c⁻¹ * (z - d), hzΩ, by
+      change c * (c⁻¹ * (z - d)) + d = z
+      have hmul : c * (c⁻¹ * (z - d)) = z - d := by
+        field_simp [hc]
+      rw [hmul]
+      ring⟩
+  rw [windingNumber_affine_preimage (γ := γ) (a := a) (b := b) (c := c) (d := d) hc]
+  exact h (c⁻¹ * (z - d)) hpre_not_mem
+
+/-- If the affine image of a curve is null-homologous in the affine image of a set, then the
+original curve is null-homologous in the original set. This is the reverse direction of
+`IsNullHomologous.affine`, using injectivity of `z ↦ c * z + d` when `c ≠ 0`. -/
+theorem IsNullHomologous.of_affine
+    (h : IsNullHomologous (fun t => c * γ t + d) a b ((fun z => c * z + d) '' Ω))
+    (hc : c ≠ 0) :
+    IsNullHomologous γ a b Ω := by
+  rw [isNullHomologous_iff] at h ⊢
+  intro z hz
+  have himage_not_mem : c * z + d ∉ (fun z => c * z + d) '' Ω := by
+    rintro ⟨w, hwΩ, hw⟩
+    have hcz : c * z = c * w := by
+      exact (add_right_cancel hw).symm
+    exact hz ((mul_left_cancel₀ hc hcz).symm ▸ hwΩ)
+  have hzero := h (c * z + d) himage_not_mem
+  rwa [windingNumber_affine (γ := γ) (a := a) (b := b) (z₀ := z) hc] at hzero
+
+/-- A nondegenerate affine coordinate change preserves and reflects null-homology. -/
+theorem isNullHomologous_affine_iff (hc : c ≠ 0) :
+    IsNullHomologous (fun t => c * γ t + d) a b ((fun z => c * z + d) '' Ω)
+      ↔ IsNullHomologous γ a b Ω :=
+  ⟨fun h => h.of_affine hc, fun h => h.affine hc⟩
+
+end TauCeti.Contour
+
+end


### PR DESCRIPTION
This PR adds affine-coordinate transport for the generalized contour winding number: nonzero maps `z ↦ c * z + d` preserve the single-point principal value of the winding kernel, the winding number itself, pointwise vanishing, and null-homology, with both forward and reflected null-homology forms. It packages the already-merged translation and nonzero-scaling APIs into the coordinate-change form used when local sector and crossing arguments normalize a distinguished point and tangent direction.

This advances `TauCetiRoadmap/ContourIntegration/README.md`, Layer 1, “the geometry of the generalized winding number (HW §2),” especially the finite-crossing/model-sector decomposition in HW Proposition 2.2 where local pieces are translated and rescaled before applying the sector computation. I chose it as the lowest-hanging distinct ContourIntegration prerequisite after checking open and recently merged PRs: main already has separate translation, scaling, sector-value, residue, argument-principle, and Dixon/Liouville work, but not the composed affine API needed by normalization steps.

No Mathlib infrastructure is vendored. The implementation reuses Tau Ceti’s `Contour.windingNumber_translate`, `Contour.windingNumber_const_mul`, `Contour.hasCauchyPVAt_inv_sub_const_mul`, and null-homology API, plus elementary complex-field cancellation.

`lake exe cache get` completed with `No files to download` and `Already decompressed 8619 file(s)`. `lake build` reported `Build completed successfully (5078 jobs).` `lake exe axioms` reported `axioms: audited 9158 TauCeti declaration(s); all within the allowlist [propext, Classical.choice, Quot.sound].`

<!--tauceti-target:v1 {"focus":"ContourIntegration","id":"winding-number-affine-change"}-->

🤖 Prepared with Codex
