### PR TITLE
feat: add uniform elliptic energy integrability

### DIFF
--- a/TauCeti/Analysis/PDE/EnergyFormIntegrability.lean
+++ b/TauCeti/Analysis/PDE/EnergyFormIntegrability.lean
@@ -31,6 +31,8 @@ matching the roadmap's bounded-measurable-coefficient hypotheses.
 * `TauCeti.PDE.integrable_energyIntegrand_apply₂_of_bounds`: the bounded finite-measure
   specialization.
 * `TauCeti.PDE.integrable_energyIntegrand_apply_of_bounds`: the fixed-jet specialization.
+* The corresponding `UniformlyEllipticOn.*_on` lemmas replace the raw principal coefficient
+  bound by the roadmap's named uniform-ellipticity hypothesis on an a.e.-supported domain.
 -/
 
 public section
@@ -44,6 +46,11 @@ open scoped InnerProductSpace
 
 variable {α n : Type*} [MeasurableSpace α] [Fintype n]
 variable {μ : Measure α}
+
+/-- Local classical decidable equality for finite coordinate indices in uniform-ellipticity
+wrappers. -/
+noncomputable local instance energyFormIntegrabilityDecidableEq : DecidableEq n :=
+  Classical.decEq n
 
 /-- Bounded measurable coefficient fields and an integrable product of jet norms give an
 integrable scalar energy density. -/
@@ -128,6 +135,70 @@ lemma integrable_energyIntegrand_apply_of_bounds [IsFiniteMeasure μ]
     hLam ha hb hc aestronglyMeasurable_const aestronglyMeasurable_const
     ha_bound hb_bound hc_bound (Filter.Eventually.of_forall fun _ => le_rfl)
     (Filter.Eventually.of_forall fun _ => le_rfl)
+
+namespace UniformlyEllipticOn
+
+variable {Ω : Set α} {a : α → Matrix n n ℝ}
+variable {b : α → EuclideanSpace ℝ n} {c : α → ℝ}
+variable {U V : α → ℝ × EuclideanSpace ℝ n}
+variable {lam Lam beta gamma R S : ℝ}
+
+/-- Uniform-ellipticity wrapper for scalar energy-density integrability.
+
+If `μ` is a.e. supported on `Ω`, the named principal coefficient hypothesis
+`UniformlyEllipticOn Ω a λ Λ` supplies the a.e. bilinear upper bound required by
+`integrable_energyIntegrand_apply₂_of_integrable_norm_mul`. -/
+lemma integrable_energyIntegrand_apply₂_of_integrable_norm_mul_on
+    (h : UniformlyEllipticOn Ω a lam Lam) (hΩ : ∀ᵐ x ∂μ, x ∈ Ω)
+    (ha : AEStronglyMeasurable a μ) (hb : AEStronglyMeasurable b μ)
+    (hc : AEStronglyMeasurable c μ) (hU : AEStronglyMeasurable U μ)
+    (hV : AEStronglyMeasurable V μ)
+    (hb_bound : ∀ᵐ x ∂μ, ‖b x‖ ≤ beta)
+    (hc_bound : ∀ᵐ x ∂μ, ‖c x‖ ≤ gamma)
+    (hUV : Integrable (fun x => ‖U x‖ * ‖V x‖) μ) :
+    Integrable (fun x => energyIntegrand (a x) (b x) (c x) (U x) (V x)) μ :=
+  integrable_energyIntegrand_apply₂_of_integrable_norm_mul h.upper_nonneg ha hb hc hU hV
+    (hΩ.mono fun _ hx => h.upper_bound hx) hb_bound hc_bound hUV
+
+/-- Uniform-ellipticity wrapper for the square-integrable-jet energy-density criterion. -/
+lemma integrable_energyIntegrand_apply₂_of_memLp_two_on
+    (h : UniformlyEllipticOn Ω a lam Lam) (hΩ : ∀ᵐ x ∂μ, x ∈ Ω)
+    (ha : AEStronglyMeasurable a μ) (hb : AEStronglyMeasurable b μ)
+    (hc : AEStronglyMeasurable c μ) (hU : MemLp U 2 μ) (hV : MemLp V 2 μ)
+    (hb_bound : ∀ᵐ x ∂μ, ‖b x‖ ≤ beta)
+    (hc_bound : ∀ᵐ x ∂μ, ‖c x‖ ≤ gamma) :
+    Integrable (fun x => energyIntegrand (a x) (b x) (c x) (U x) (V x)) μ :=
+  integrable_energyIntegrand_apply₂_of_memLp_two h.upper_nonneg ha hb hc hU hV
+    (hΩ.mono fun _ hx => h.upper_bound hx) hb_bound hc_bound
+
+/-- Uniform-ellipticity wrapper for bounded measurable jets on a finite-measure space. -/
+lemma integrable_energyIntegrand_apply₂_of_bounds_on [IsFiniteMeasure μ]
+    (h : UniformlyEllipticOn Ω a lam Lam) (hΩ : ∀ᵐ x ∂μ, x ∈ Ω)
+    (ha : AEStronglyMeasurable a μ) (hb : AEStronglyMeasurable b μ)
+    (hc : AEStronglyMeasurable c μ) (hU : AEStronglyMeasurable U μ)
+    (hV : AEStronglyMeasurable V μ)
+    (hb_bound : ∀ᵐ x ∂μ, ‖b x‖ ≤ beta)
+    (hc_bound : ∀ᵐ x ∂μ, ‖c x‖ ≤ gamma)
+    (hU_bound : ∀ᵐ x ∂μ, ‖U x‖ ≤ R)
+    (hV_bound : ∀ᵐ x ∂μ, ‖V x‖ ≤ S) :
+    Integrable (fun x => energyIntegrand (a x) (b x) (c x) (U x) (V x)) μ :=
+  integrable_energyIntegrand_apply₂_of_bounds h.upper_nonneg ha hb hc hU hV
+    (hΩ.mono fun _ hx => h.upper_bound hx) hb_bound hc_bound hU_bound hV_bound
+
+/-- Fixed-jet specialization of
+`UniformlyEllipticOn.integrable_energyIntegrand_apply₂_of_bounds_on`. -/
+lemma integrable_energyIntegrand_apply_of_bounds_on [IsFiniteMeasure μ]
+    (h : UniformlyEllipticOn Ω a lam Lam) (hΩ : ∀ᵐ x ∂μ, x ∈ Ω)
+    (ha : AEStronglyMeasurable a μ) (hb : AEStronglyMeasurable b μ)
+    (hc : AEStronglyMeasurable c μ)
+    (hb_bound : ∀ᵐ x ∂μ, ‖b x‖ ≤ beta)
+    (hc_bound : ∀ᵐ x ∂μ, ‖c x‖ ≤ gamma)
+    (U V : ℝ × EuclideanSpace ℝ n) :
+    Integrable (fun x => energyIntegrand (a x) (b x) (c x) U V) μ :=
+  integrable_energyIntegrand_apply_of_bounds h.upper_nonneg ha hb hc
+    (hΩ.mono fun _ hx => h.upper_bound hx) hb_bound hc_bound U V
+
+end UniformlyEllipticOn
 
 end PDE
 


### PR DESCRIPTION
This PR adds `UniformlyEllipticOn` wrappers for the existing energy-density integrability criteria. A caller with a uniform ellipticity hypothesis on `Ω` and an a.e. support hypothesis for the measure can now obtain integrability of `x ↦ energyIntegrand (a x) (b x) (c x) (U x) (V x)` without manually restating the principal bilinear upper bound; the lower-order coefficient bounds remain inline, as the PDE roadmap requests.

This advances `TauCetiRoadmap/PDE/README.md`, Lane D item 16, “Weak formulation,” specifically the bounded measurable coefficient setup for the energy bilinear form `a(u,v) = ∫ aⁱʲ ∂ᵢu ∂ⱼv + …`, and the standing-hypotheses item “Uniform ellipticity with explicit constants `0 < λ ≤ Λ`.” I chose it as the lowest-hanging distinct PDE prerequisite after checking open and recently merged PRs: main already has the raw-bound integrability lemmas and the uniform ellipticity API, but not the small handoff from the named roadmap hypothesis to those integrability lemmas.

No Mathlib infrastructure is vendored. The implementation reuses Tau Ceti’s `UniformlyEllipticOn.upper_bound` and `upper_nonneg`, plus the existing `integrable_energyIntegrand_apply₂_of_integrable_norm_mul`, `integrable_energyIntegrand_apply₂_of_memLp_two`, `integrable_energyIntegrand_apply₂_of_bounds`, and fixed-jet specialization.

`lake exe cache get` completed with `No files to download` and `Already decompressed 8619 file(s)`. `lake build` reported `Build completed successfully (5079 jobs).` `lake exe axioms` reported `axioms: audited 9158 TauCeti declaration(s); all within the allowlist [propext, Classical.choice, Quot.sound].`

<!--tauceti-target:v1 {"focus":"PDE","id":"uniformly-elliptic-energy-integrability"}-->

🤖 Prepared with Codex
