### PR TITLE
feat: add shifted Laplacian energy lower bounds

### DIFF
--- a/TauCeti/Analysis/PDE/IntegratedEnergyForm.lean
+++ b/TauCeti/Analysis/PDE/IntegratedEnergyForm.lean
@@ -32,6 +32,9 @@ derivative: once Lane A supplies `W^{k,p}(Ω)`, its value-gradient jets can feed
   Bochner-integrability hypotheses.
 * `TauCeti.PDE.norm_energyFormIntegral_le_of_bounds`: the integrated boundedness estimate
   obtained from the pointwise coefficient bounds.
+* `TauCeti.PDE.integral_min_lam_mass_mul_norm_sq_le_energyFormIntegral_zero_drift_self`:
+  the zero-drift integrated diagonal lower bound from a principal quadratic lower bound and
+  nonnegative mass.
 * `TauCeti.PDE.UniformlyEllipticOn.norm_energyFormIntegral_le_on`: the corresponding
   boundedness estimate from uniform ellipticity on an a.e. domain.
 -/
@@ -436,6 +439,38 @@ lemma garding_energyFormIntegral_self_of_mass_lower_bound_of_bounds (hlam : 0 < 
   filter_upwards [ha, hb, hc] with x hax hbx hcx
   exact garding_energyIntegrand_self_of_mass_lower_bound_of_bounds hlam
     (fun ξ => by simpa [toQuadraticForm'_eq_dotProduct] using hax ξ) hbx hcx (U x)
+
+/-- Integrated zero-drift diagonal lower bound from an a.e. principal quadratic lower bound
+and a.e. nonnegative mass coefficient. -/
+lemma integral_min_lam_mass_mul_norm_sq_le_energyFormIntegral_zero_drift_self
+    (hlam : 0 ≤ lam)
+    (ha : ∀ᵐ x ∂μ, ∀ ξ : EuclideanSpace ℝ n,
+      lam * ‖ξ‖ ^ 2 ≤ ξ ⬝ᵥ (a x *ᵥ ξ))
+    (hc : ∀ᵐ x ∂μ, 0 ≤ c x)
+    (hlower : Integrable (fun x => min lam (c x) * ‖U x‖ ^ 2) μ)
+    (henergy : Integrable (fun x => energyIntegrand (a x) 0 (c x) (U x) (U x)) μ) :
+    ∫ x, (min lam (c x) * ‖U x‖ ^ 2) ∂μ
+      ≤ energyFormIntegral μ a (fun _ => 0) c U U := by
+  rw [energyFormIntegral_def]
+  refine integral_mono_ae hlower henergy ?_
+  filter_upwards [ha, hc] with x hax hcx
+  exact min_lam_mass_mul_norm_sq_le_energyIntegrand_zero_drift_self hlam
+    (fun ξ => by simpa [toQuadraticForm'_eq_dotProduct] using hax ξ) hcx (U x)
+
+/-- A zero-drift diagonal integrated energy form is nonnegative when the principal quadratic
+form and mass coefficient are a.e. nonnegative. -/
+lemma energyFormIntegral_zero_drift_self_nonneg
+    (ha : ∀ᵐ x ∂μ, ∀ ξ : EuclideanSpace ℝ n, 0 ≤ ξ ⬝ᵥ (a x *ᵥ ξ))
+    (hc : ∀ᵐ x ∂μ, 0 ≤ c x) :
+    0 ≤ energyFormIntegral μ a (fun _ => 0) c U U := by
+  rw [energyFormIntegral_def]
+  refine integral_nonneg_of_ae ?_
+  filter_upwards [ha, hc] with x hax hcx
+  have hpoint :=
+    min_lam_mass_mul_norm_sq_le_energyIntegrand_zero_drift_self (lam := 0) (c₀ := c x)
+      le_rfl (fun ξ => by simpa [toQuadraticForm'_eq_dotProduct] using hax ξ)
+      hcx (U x)
+  simpa [min_eq_left hcx] using hpoint
 
 /-- Integrated explicit diagonal lower bound from a.e. lower ellipticity, a.e.
 lower-order coefficient hypotheses, and a mass floor that dominates the drift defect. -/

--- a/TauCeti/Analysis/PDE/ShiftedLaplacianEnergy.lean
+++ b/TauCeti/Analysis/PDE/ShiftedLaplacianEnergy.lean
@@ -4,7 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 -/
 module
 
-public import TauCeti.Analysis.PDE.IntegratedSymmetricEnergy
+public import TauCeti.Analysis.PDE.IntegratedEnergyForm
 
 /-!
 # Lower bounds for the shifted-Laplacian energy form
@@ -64,20 +64,24 @@ lemma integral_min_one_mass_mul_norm_sq_le_energyFormIntegral_one_zero_mass_self
       (fun x => energyIntegrand (1 : Matrix n n ℝ) 0 (m x) (U x) (U x)) μ) :
     ∫ x, (min 1 (m x) * ‖U x‖ ^ 2) ∂μ
       ≤ energyFormIntegral μ (fun _ => (1 : Matrix n n ℝ)) (fun _ => 0) m U U := by
-  rw [energyFormIntegral_def]
-  refine integral_mono_ae hlower henergy ?_
-  filter_upwards [hm] with x hmx
-  exact min_one_mass_mul_norm_sq_le_energyIntegrand_one_zero_mass_self hmx (U x)
+  refine integral_min_lam_mass_mul_norm_sq_le_energyFormIntegral_zero_drift_self
+    (μ := μ) (a := fun _ => (1 : Matrix n n ℝ)) (c := m) (U := U) zero_le_one ?_ hm
+    hlower henergy
+  filter_upwards with x
+  intro ξ
+  rw [← toQuadraticForm'_eq_dotProduct, toQuadraticForm'_one]
+  simp
 
 /-- The shifted-Laplacian diagonal form is nonnegative when the mass is a.e. nonnegative. -/
 lemma energyFormIntegral_one_zero_mass_self_nonneg
     (hm : ∀ᵐ x ∂μ, 0 ≤ m x) :
     0 ≤ energyFormIntegral μ (fun _ => (1 : Matrix n n ℝ)) (fun _ => 0) m U U := by
-  rw [energyFormIntegral_def]
-  refine integral_nonneg_of_ae ?_
-  filter_upwards [hm] with x hmx
-  exact (mul_nonneg (le_min zero_le_one hmx) (sq_nonneg ‖U x‖)).trans
-    (min_one_mass_mul_norm_sq_le_energyIntegrand_one_zero_mass_self hmx (U x))
+  refine energyFormIntegral_zero_drift_self_nonneg
+    (μ := μ) (a := fun _ => (1 : Matrix n n ℝ)) (c := m) (U := U) ?_ hm
+  filter_upwards with x
+  intro ξ
+  rw [← toQuadraticForm'_eq_dotProduct, toQuadraticForm'_one]
+  exact sq_nonneg ‖ξ‖
 
 /-- The Dirichlet model `-Δ` has nonnegative diagonal energy. -/
 lemma energyFormIntegral_one_zero_zero_self_nonneg :

--- a/TauCeti/Analysis/PDE/ShiftedLaplacianEnergy.lean
+++ b/TauCeti/Analysis/PDE/ShiftedLaplacianEnergy.lean
@@ -1,0 +1,132 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+module
+
+public import TauCeti.Analysis.PDE.IntegratedSymmetricEnergy
+
+/-!
+# Lower bounds for the shifted-Laplacian energy form
+
+The energy-method lane of the PDE roadmap uses the shifted Laplacian `-Δ + m` as the model
+coercive operator before adding variable uniformly elliptic coefficients.  The pointwise file
+`TauCeti.Analysis.PDE.EnergyLowerBounds` already proves that the jet density
+`energyIntegrand 1 0 m U U` controls the jet norm with constant `min 1 m` when `m ≥ 0`.
+This file integrates that estimate for raw value-gradient jet fields.
+
+These are still below the weak-derivative Sobolev-space layer: the inputs are arbitrary jet
+fields `U : X → ℝ × EuclideanSpace ℝ n`, and the statements carry the Bochner-integrability
+hypotheses needed to compare scalar integrals.  Once `H¹`/`W^{1,2}` jets are available, these
+lemmas become the concrete coercive lower bounds for the shifted Dirichlet form.
+
+## Main declarations
+
+* `TauCeti.PDE.integral_min_one_mass_mul_norm_sq_le_energyFormIntegral_one_zero_mass_self`:
+  a variable nonnegative mass controls the raw jet norm with coefficient `min 1 (m x)`.
+* `TauCeti.PDE.integral_min_one_const_mass_mul_norm_sq_le_energyFormIntegral_one_zero_mass_self`:
+  the constant-mass specialization.
+* `TauCeti.PDE.integral_norm_sq_le_energyFormIntegral_one_zero_mass_self_of_one_le`:
+  when the constant mass is at least `1`, the shifted-Laplacian form controls the full jet
+  norm with constant `1`.
+* `TauCeti.PDE.energyFormIntegral_one_zero_zero_self_nonneg` and
+  `TauCeti.PDE.energyFormIntegral_one_zero_mass_self_nonneg`: nonnegativity of the
+  Dirichlet and nonnegative shifted-Laplacian diagonal forms.
+-/
+
+public section
+
+namespace TauCeti
+
+namespace PDE
+
+open MeasureTheory Matrix
+
+variable {X n : Type*} [MeasurableSpace X] [Fintype n]
+
+/-- Local classical decidable equality for finite coordinate indices in shifted-Laplacian
+energy proofs. -/
+noncomputable local instance shiftedLaplacianEnergyDecidableEq : DecidableEq n :=
+  Classical.decEq n
+
+variable {μ : Measure X} {m : X → ℝ} {U : X → ℝ × EuclideanSpace ℝ n}
+
+/-- Integrated diagonal lower bound for the shifted-Laplacian model with variable
+nonnegative mass.
+
+Pointwise, `energyIntegrand 1 0 (m x) (U x) (U x)` is
+`‖(U x).2‖² + m x * (U x).1²`, so for `m x ≥ 0` it controls the full product jet norm
+with coefficient `min 1 (m x)`. -/
+lemma integral_min_one_mass_mul_norm_sq_le_energyFormIntegral_one_zero_mass_self
+    (hm : ∀ᵐ x ∂μ, 0 ≤ m x)
+    (hlower : Integrable (fun x => min 1 (m x) * ‖U x‖ ^ 2) μ)
+    (henergy : Integrable
+      (fun x => energyIntegrand (1 : Matrix n n ℝ) 0 (m x) (U x) (U x)) μ) :
+    ∫ x, (min 1 (m x) * ‖U x‖ ^ 2) ∂μ
+      ≤ energyFormIntegral μ (fun _ => (1 : Matrix n n ℝ)) (fun _ => 0) m U U := by
+  rw [energyFormIntegral_def]
+  refine integral_mono_ae hlower henergy ?_
+  filter_upwards [hm] with x hmx
+  exact min_one_mass_mul_norm_sq_le_energyIntegrand_one_zero_mass_self hmx (U x)
+
+/-- The shifted-Laplacian diagonal form is nonnegative when the mass is a.e. nonnegative. -/
+lemma energyFormIntegral_one_zero_mass_self_nonneg
+    (hm : ∀ᵐ x ∂μ, 0 ≤ m x) :
+    0 ≤ energyFormIntegral μ (fun _ => (1 : Matrix n n ℝ)) (fun _ => 0) m U U := by
+  rw [energyFormIntegral_def]
+  refine integral_nonneg_of_ae ?_
+  filter_upwards [hm] with x hmx
+  exact (mul_nonneg (le_min zero_le_one hmx) (sq_nonneg ‖U x‖)).trans
+    (min_one_mass_mul_norm_sq_le_energyIntegrand_one_zero_mass_self hmx (U x))
+
+/-- The Dirichlet model `-Δ` has nonnegative diagonal energy. -/
+lemma energyFormIntegral_one_zero_zero_self_nonneg :
+    0 ≤ energyFormIntegral μ (fun _ => (1 : Matrix n n ℝ)) (fun _ => 0) (fun _ => 0) U U :=
+  energyFormIntegral_one_zero_mass_self_nonneg
+    (m := fun _ => (0 : ℝ)) (U := U) (Filter.Eventually.of_forall fun _ => le_rfl)
+
+/-- Constant-mass specialization of the integrated shifted-Laplacian lower bound. -/
+lemma integral_min_one_const_mass_mul_norm_sq_le_energyFormIntegral_one_zero_mass_self
+    {c : ℝ} (hc : 0 ≤ c)
+    (hlower : Integrable (fun x => min 1 c * ‖U x‖ ^ 2) μ)
+    (henergy : Integrable
+      (fun x => energyIntegrand (1 : Matrix n n ℝ) 0 c (U x) (U x)) μ) :
+    ∫ x, (min 1 c * ‖U x‖ ^ 2) ∂μ
+      ≤ energyFormIntegral μ (fun _ => (1 : Matrix n n ℝ)) (fun _ => 0) (fun _ => c) U U :=
+  integral_min_one_mass_mul_norm_sq_le_energyFormIntegral_one_zero_mass_self
+    (m := fun _ => c) (U := U) (Filter.Eventually.of_forall fun _ => hc) hlower henergy
+
+/-- Constant nonnegative mass gives a nonnegative shifted-Laplacian diagonal form. -/
+lemma energyFormIntegral_one_zero_const_mass_self_nonneg {c : ℝ} (hc : 0 ≤ c) :
+    0 ≤ energyFormIntegral μ (fun _ => (1 : Matrix n n ℝ)) (fun _ => 0) (fun _ => c) U U :=
+  energyFormIntegral_one_zero_mass_self_nonneg
+    (m := fun _ => c) (U := U) (Filter.Eventually.of_forall fun _ => hc)
+
+/-- If the constant mass is at least `1`, the shifted-Laplacian diagonal form controls the
+full raw jet `L²` density with constant `1`. -/
+lemma integral_norm_sq_le_energyFormIntegral_one_zero_mass_self_of_one_le
+    {c : ℝ} (hc : 1 ≤ c)
+    (hlower : Integrable (fun x => ‖U x‖ ^ 2) μ)
+    (henergy : Integrable
+      (fun x => energyIntegrand (1 : Matrix n n ℝ) 0 c (U x) (U x)) μ) :
+    ∫ x, (‖U x‖ ^ 2) ∂μ
+      ≤ energyFormIntegral μ (fun _ => (1 : Matrix n n ℝ)) (fun _ => 0) (fun _ => c) U U := by
+  have hmin : min (1 : ℝ) c = 1 := min_eq_left hc
+  simpa [hmin] using
+    integral_min_one_const_mass_mul_norm_sq_le_energyFormIntegral_one_zero_mass_self
+      (U := U) (c := c) (zero_le_one.trans hc) (by simpa [hmin] using hlower) henergy
+
+/-- For constant mass `1`, the shifted-Laplacian diagonal form controls the full raw jet
+`L²` density with constant `1`. -/
+lemma integral_norm_sq_le_energyFormIntegral_one_zero_one_self
+    (hlower : Integrable (fun x => ‖U x‖ ^ 2) μ)
+    (henergy : Integrable
+      (fun x => energyIntegrand (1 : Matrix n n ℝ) 0 1 (U x) (U x)) μ) :
+    ∫ x, (‖U x‖ ^ 2) ∂μ
+      ≤ energyFormIntegral μ (fun _ => (1 : Matrix n n ℝ)) (fun _ => 0) (fun _ => 1) U U :=
+  integral_norm_sq_le_energyFormIntegral_one_zero_mass_self_of_one_le
+    (U := U) le_rfl hlower henergy
+
+end PDE
+
+end TauCeti


### PR DESCRIPTION
This PR adds integrated lower-bound and nonnegativity lemmas for the shifted-Laplacian raw jet energy form `-Δ + m`. It integrates the existing pointwise estimate `min 1 m * ‖U‖² ≤ energyIntegrand 1 0 m U U`, records the variable-mass and constant-mass forms, and packages the normalized `1 ≤ c` corollary saying the constant-mass shifted form controls the full raw jet `L²` density with constant `1`.

This advances `TauCetiRoadmap/PDE/README.md`, Lane D item 16, “Weak formulation,” specifically the shifted-Laplacian model energy form used before the Sobolev-space weak formulation and Lax-Milgram step. I chose it as the lowest-hanging distinct PDE prerequisite after checking open and recently merged PRs: main already has the pointwise shifted-Laplacian estimate and the integrated raw-jet energy form, while recent PDE work covered weak maximum principles, energy integrability, and finite-dimensional coercivity cleanup, not this concrete integrated model lower-bound bridge.

No Mathlib infrastructure is vendored. The implementation reuses Tau Ceti’s `min_one_mass_mul_norm_sq_le_energyIntegrand_one_zero_mass_self`, `energyFormIntegral`, and the existing integrated symmetry/energy-form API, plus Mathlib’s Bochner integral monotonicity and nonnegativity lemmas.

`lake exe cache get` completed with `No files to download` and `Already decompressed 8619 file(s)`. `lake build` reported `Build completed successfully (5081 jobs).` `lake exe axioms` reported `axioms: audited 9172 TauCeti declaration(s); all within the allowlist [propext, Classical.choice, Quot.sound].`

<!--tauceti-target:v1 {"focus":"PDE","id":"shifted-laplacian-energy-lower-bounds"}-->

🤖 Prepared with Codex
