### PR TITLE
feat(Analysis/Contour): immersions are flat of order one

### DIFF
--- a/TauCeti/Analysis/Contour/FlatnessOne.lean
+++ b/TauCeti/Analysis/Contour/FlatnessOne.lean
@@ -1,0 +1,136 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Chris Birkbeck
+-/
+module
+
+public import TauCeti.Analysis.Contour.PwC1ImmersionOn
+public import TauCeti.Analysis.Contour.RegularityConditions
+
+/-!
+# Immersions are flat of order one
+
+A piecewise-`C¹` immersion is `FlatOfOrder γ t₀ 1` at every interior parameter, and
+`FlatOfOrderBasepoint γ a b 1` across the join: the curve leaves each point first-order tangent
+to its non-zero one-sided tangent, so the perpendicular deviation from the tangent line is
+`o(‖γ t - γ t₀‖)`. This discharges the flatness clauses of `Contour.ConditionAprime` at simple
+poles for immersed cycles — together with `IsPwC1ImmersionOn.finite_crossings` it makes (A′) at
+simple poles a theorem about immersions rather than a hypothesis.
+
+## Main results
+
+* `Contour.IsPwC1ImmersionOn.flatOfOrder_one` — an immersion is flat of order `1` at every
+  interior parameter.
+* `Contour.IsPwC1ImmersionOn.flatOfOrderBasepoint_one` — an immersion is flat of order `1`
+  across the basepoint join.
+
+## Provenance
+
+Migrated from `isFlatOfOrder_one` of `FlatnessConditions.lean` in the AINTLIB `LeanModularForms`
+development, restated for the raw curve on `[[a, b]]`: the one-sided derivatives recovered there
+from tendsto limits are here the within-piece derivatives of `IsPwC1ImmersionOn` at the piece
+endpoints. See K. Hungerbühler, M. Wasem, *Non-integer valued winding numbers and a generalized
+Residue Theorem*, arXiv:1808.00997, §3 (condition (A′) at simple poles).
+-/
+
+public section
+
+noncomputable section
+
+namespace TauCeti.Contour
+
+open Asymptotics Filter Set Topology
+
+variable {γ : ℝ → ℂ} {a b : ℝ}
+
+/-- The one-sided first-order tangency computation: if `γ` has one-sided derivative `L ≠ 0` at
+`t₀` within a set `s`, then along any filter `l ≤ 𝓝[s] t₀` with `l ≤ 𝓟 {t₀}ᶜ`, the perpendicular
+deviation of `γ t` from the tangent line through `γ t₀` in direction `L` is `o(‖γ t - γ t₀‖)`. -/
+private theorem perp_isLittleO_of_hasDerivWithinAt {s : Set ℝ} {t₀ : ℝ} {L : ℂ} (hL : L ≠ 0)
+    (hd : HasDerivWithinAt γ L s t₀) {l : Filter ℝ} (hl : l ≤ 𝓝[s] t₀) :
+    (fun t => |((γ t - γ t₀) * star L).im| / ‖L‖) =o[l] (fun t => ‖γ t - γ t₀‖ ^ 1) := by
+  have herr : (fun t => γ t - γ t₀ - (t - t₀) • L) =o[l] (fun t => t - t₀) :=
+    (hasDerivWithinAt_iff_isLittleO.mp hd).mono hl
+  -- the perpendicular part of the linear term vanishes, so perp ≤ ‖error‖
+  have hperp_le : ∀ t, |((γ t - γ t₀) * star L).im| / ‖L‖ ≤ ‖γ t - γ t₀ - (t - t₀) • L‖ := by
+    intro t
+    have hsplit : (γ t - γ t₀) * star L =
+        (γ t - γ t₀ - (t - t₀) • L) * star L + ((t - t₀) • L) * star L := by ring
+    have him : (((t - t₀) • L) * star L).im = 0 := by
+      rw [smul_mul_assoc, Complex.star_def, Complex.mul_conj]
+      simp [Complex.real_smul]
+    rw [hsplit, Complex.add_im, him, add_zero]
+    calc |((γ t - γ t₀ - (t - t₀) • L) * star L).im| / ‖L‖
+        ≤ ‖(γ t - γ t₀ - (t - t₀) • L) * star L‖ / ‖L‖ := by
+          gcongr
+          exact Complex.abs_im_le_norm _
+      _ = ‖γ t - γ t₀ - (t - t₀) • L‖ := by
+          rw [norm_mul, norm_star, mul_div_assoc,
+            div_self (norm_ne_zero_iff.mpr hL), mul_one]
+  -- perp =o (t - t₀)
+  have h1 : (fun t => |((γ t - γ t₀) * star L).im| / ‖L‖) =o[l] (fun t => t - t₀) :=
+    (isBigO_of_le l fun t => by
+      rw [Real.norm_eq_abs, abs_of_nonneg (by positivity)]
+      exact hperp_le t).trans_isLittleO herr
+  -- (t - t₀) =O ‖γ t - γ t₀‖, from the reverse triangle inequality against the error bound
+  have h2 : (fun t => t - t₀) =O[l] (fun t => ‖γ t - γ t₀‖) := by
+    rw [isBigO_iff]
+    refine ⟨2 / ‖L‖, ?_⟩
+    have hsmall := (isLittleO_iff.mp herr) (c := ‖L‖ / 2) (by positivity)
+    filter_upwards [hsmall] with t ht
+    have hpos : (0 : ℝ) < ‖L‖ := norm_pos_iff.mpr hL
+    have hb : ‖γ t - γ t₀ - (t - t₀) • L‖ ≤ ‖L‖ / 2 * |t - t₀| := by
+      simpa [Real.norm_eq_abs] using ht
+    have hnorm : |t - t₀| * ‖L‖ - ‖γ t - γ t₀ - (t - t₀) • L‖ ≤ ‖γ t - γ t₀‖ := by
+      have htri := norm_sub_norm_le ((t - t₀) • L) ((t - t₀) • L - (γ t - γ t₀))
+      rw [sub_sub_cancel, norm_smul, Real.norm_eq_abs, norm_sub_rev] at htri
+      linarith
+    rw [Real.norm_eq_abs, Real.norm_eq_abs, abs_of_nonneg (norm_nonneg _),
+      div_mul_eq_mul_div, le_div_iff₀ hpos]
+    nlinarith [hnorm, hb, abs_nonneg (t - t₀)]
+  simpa [pow_one] using h1.trans_isBigO h2
+
+/-- **An immersion is flat of order one at every interior parameter** (HW condition (A′) at a
+simple pole): the curve is first-order tangent to its non-zero one-sided tangents, so the
+perpendicular deviation from each tangent line is `o(‖γ t - γ t₀‖)`. -/
+theorem IsPwC1ImmersionOn.flatOfOrder_one (h : IsPwC1ImmersionOn γ a b) {t₀ : ℝ}
+    (ht₀ : t₀ ∈ Ioo (min a b) (max a b)) : FlatOfOrder γ t₀ 1 := by
+  obtain ⟨d, hd, hsubd, hC1d, hned⟩ := h.exists_Icc_pieces_right ⟨ht₀.1.le, ht₀.2⟩
+  obtain ⟨c, hc, hsubc, hC1c, hnec⟩ := h.exists_Icc_pieces_left ⟨ht₀.1, ht₀.2.le⟩
+  refine flatOfOrder_iff.mpr ⟨derivWithin γ (Icc t₀ d) t₀, derivWithin γ (Icc c t₀) t₀,
+    hned t₀ (left_mem_Icc.mpr hd.le), hnec t₀ (right_mem_Icc.mpr hc.le), ?_, ?_⟩
+  · refine perp_isLittleO_of_hasDerivWithinAt (hned t₀ (left_mem_Icc.mpr hd.le))
+      ((hC1d.differentiableOn one_ne_zero) t₀ (left_mem_Icc.mpr hd.le)).hasDerivWithinAt ?_
+    rw [← nhdsWithin_Ioo_eq_nhdsGT hd]
+    exact nhdsWithin_mono t₀ Ioo_subset_Icc_self
+  · refine perp_isLittleO_of_hasDerivWithinAt (hnec t₀ (right_mem_Icc.mpr hc.le))
+      ((hC1c.differentiableOn one_ne_zero) t₀ (right_mem_Icc.mpr hc.le)).hasDerivWithinAt ?_
+    rw [← nhdsWithin_Ioo_eq_nhdsLT hc]
+    exact nhdsWithin_mono t₀ Ioo_subset_Icc_self
+
+/-- **An immersion is flat of order one across the basepoint join** (`a < b`): the outgoing
+branch at `a` and the incoming branch at `b` are each first-order tangent to their non-zero
+one-sided tangents. -/
+theorem IsPwC1ImmersionOn.flatOfOrderBasepoint_one (h : IsPwC1ImmersionOn γ a b)
+    (hab : a < b) : FlatOfOrderBasepoint γ a b 1 := by
+  have hmin : min a b = a := min_eq_left hab.le
+  have hmax : max a b = b := max_eq_right hab.le
+  obtain ⟨d, hd, hsubd, hC1d, hned⟩ := h.exists_Icc_pieces_right
+    ⟨hmin.le, lt_of_lt_of_le hab hmax.ge⟩
+  obtain ⟨c, hc, hsubc, hC1c, hnec⟩ := h.exists_Icc_pieces_left
+    ⟨hmin.le.trans_lt hab, hmax.ge⟩
+  refine flatOfOrderBasepoint_iff.mpr ⟨derivWithin γ (Icc a d) a, derivWithin γ (Icc c b) b,
+    hned a (left_mem_Icc.mpr hd.le), hnec b (right_mem_Icc.mpr hc.le), ?_, ?_⟩
+  · refine perp_isLittleO_of_hasDerivWithinAt (hned a (left_mem_Icc.mpr hd.le))
+      ((hC1d.differentiableOn one_ne_zero) a (left_mem_Icc.mpr hd.le)).hasDerivWithinAt ?_
+    rw [← nhdsWithin_Ioo_eq_nhdsGT hd]
+    exact nhdsWithin_mono a Ioo_subset_Icc_self
+  · refine perp_isLittleO_of_hasDerivWithinAt (hnec b (right_mem_Icc.mpr hc.le))
+      ((hC1c.differentiableOn one_ne_zero) b (right_mem_Icc.mpr hc.le)).hasDerivWithinAt ?_
+    rw [← nhdsWithin_Ioo_eq_nhdsLT hc]
+    exact nhdsWithin_mono b Ioo_subset_Icc_self
+
+end TauCeti.Contour
+
+end

--- a/TauCeti/Analysis/Contour/FlatnessOne.lean
+++ b/TauCeti/Analysis/Contour/FlatnessOne.lean
@@ -120,8 +120,8 @@ simple pole): the curve is first-order tangent to its non-zero one-sided tangent
 perpendicular deviation from each tangent line is `o(‖γ t - γ t₀‖)`. -/
 theorem IsPwC1ImmersionOn.flatOfOrder_one (h : IsPwC1ImmersionOn γ a b) {t₀ : ℝ}
     (ht₀ : t₀ ∈ Ioo (min a b) (max a b)) : FlatOfOrder γ t₀ 1 := by
-  obtain ⟨d, hd, -, hC1d, hned⟩ := h.exists_Icc_pieces_right ⟨ht₀.1.le, ht₀.2⟩
-  obtain ⟨c, hc, -, hC1c, hnec⟩ := h.exists_Icc_pieces_left ⟨ht₀.1, ht₀.2.le⟩
+  obtain ⟨d, hd, -, hC1d, hned⟩ := h.exists_Icc_piece_right ⟨ht₀.1.le, ht₀.2⟩
+  obtain ⟨c, hc, -, hC1c, hnec⟩ := h.exists_Icc_piece_left ⟨ht₀.1, ht₀.2.le⟩
   exact flatOfOrder_iff.mpr ⟨derivWithin γ (Icc t₀ d) t₀, derivWithin γ (Icc c t₀) t₀,
     hned t₀ (left_mem_Icc.mpr hd.le), hnec t₀ (right_mem_Icc.mpr hc.le),
     perp_isLittleO_right hd hC1d (hned t₀ (left_mem_Icc.mpr hd.le)),
@@ -134,9 +134,9 @@ theorem IsPwC1ImmersionOn.flatOfOrderBasepoint_one (h : IsPwC1ImmersionOn γ a b
     (hab : a < b) : FlatOfOrderBasepoint γ a b 1 := by
   have hmin : min a b = a := min_eq_left hab.le
   have hmax : max a b = b := max_eq_right hab.le
-  obtain ⟨d, hd, -, hC1d, hned⟩ := h.exists_Icc_pieces_right
+  obtain ⟨d, hd, -, hC1d, hned⟩ := h.exists_Icc_piece_right
     ⟨hmin.le, lt_of_lt_of_le hab hmax.ge⟩
-  obtain ⟨c, hc, -, hC1c, hnec⟩ := h.exists_Icc_pieces_left
+  obtain ⟨c, hc, -, hC1c, hnec⟩ := h.exists_Icc_piece_left
     ⟨hmin.le.trans_lt hab, hmax.ge⟩
   exact flatOfOrderBasepoint_iff.mpr ⟨derivWithin γ (Icc a d) a, derivWithin γ (Icc c b) b,
     hned a (left_mem_Icc.mpr hd.le), hnec b (right_mem_Icc.mpr hc.le),

--- a/TauCeti/Analysis/Contour/FlatnessOne.lean
+++ b/TauCeti/Analysis/Contour/FlatnessOne.lean
@@ -45,7 +45,7 @@ open Asymptotics Filter Set Topology
 variable {γ : ℝ → ℂ} {a b : ℝ}
 
 /-- The one-sided first-order tangency computation: if `γ` has one-sided derivative `L ≠ 0` at
-`t₀` within a set `s`, then along any filter `l ≤ 𝓝[s] t₀` with `l ≤ 𝓟 {t₀}ᶜ`, the perpendicular
+`t₀` within a set `s`, then along any filter `l ≤ 𝓝[s] t₀`, the perpendicular
 deviation of `γ t` from the tangent line through `γ t₀` in direction `L` is `o(‖γ t - γ t₀‖)`. -/
 private theorem perp_isLittleO_of_hasDerivWithinAt {s : Set ℝ} {t₀ : ℝ} {L : ℂ} (hL : L ≠ 0)
     (hd : HasDerivWithinAt γ L s t₀) {l : Filter ℝ} (hl : l ≤ 𝓝[s] t₀) :
@@ -91,23 +91,41 @@ private theorem perp_isLittleO_of_hasDerivWithinAt {s : Set ℝ} {t₀ : ℝ} {L
     nlinarith [hnorm, hb, abs_nonneg (t - t₀)]
   simpa [pow_one] using h1.trans_isBigO h2
 
+/-- The right-piece flatness clause: on a `C¹` piece `[t₀, d]` with non-vanishing within-piece
+derivative, the perpendicular deviation from the right tangent at `t₀` is `o(‖γ t - γ t₀‖)` from
+the right. -/
+private theorem perp_isLittleO_right {t₀ d : ℝ} (hd : t₀ < d)
+    (hC1 : ContDiffOn ℝ 1 γ (Icc t₀ d)) (hne : derivWithin γ (Icc t₀ d) t₀ ≠ 0) :
+    (fun t => |((γ t - γ t₀) * star (derivWithin γ (Icc t₀ d) t₀)).im| /
+      ‖derivWithin γ (Icc t₀ d) t₀‖) =o[𝓝[>] t₀] (fun t => ‖γ t - γ t₀‖ ^ 1) := by
+  refine perp_isLittleO_of_hasDerivWithinAt hne
+    ((hC1.differentiableOn one_ne_zero) t₀ (left_mem_Icc.mpr hd.le)).hasDerivWithinAt ?_
+  rw [← nhdsWithin_Ioo_eq_nhdsGT hd]
+  exact nhdsWithin_mono t₀ Ioo_subset_Icc_self
+
+/-- The left-piece flatness clause: on a `C¹` piece `[c, t₀]` with non-vanishing within-piece
+derivative, the perpendicular deviation from the left tangent at `t₀` is `o(‖γ t - γ t₀‖)` from
+the left. -/
+private theorem perp_isLittleO_left {c t₀ : ℝ} (hc : c < t₀)
+    (hC1 : ContDiffOn ℝ 1 γ (Icc c t₀)) (hne : derivWithin γ (Icc c t₀) t₀ ≠ 0) :
+    (fun t => |((γ t - γ t₀) * star (derivWithin γ (Icc c t₀) t₀)).im| /
+      ‖derivWithin γ (Icc c t₀) t₀‖) =o[𝓝[<] t₀] (fun t => ‖γ t - γ t₀‖ ^ 1) := by
+  refine perp_isLittleO_of_hasDerivWithinAt hne
+    ((hC1.differentiableOn one_ne_zero) t₀ (right_mem_Icc.mpr hc.le)).hasDerivWithinAt ?_
+  rw [← nhdsWithin_Ioo_eq_nhdsLT hc]
+  exact nhdsWithin_mono t₀ Ioo_subset_Icc_self
+
 /-- **An immersion is flat of order one at every interior parameter** (HW condition (A′) at a
 simple pole): the curve is first-order tangent to its non-zero one-sided tangents, so the
 perpendicular deviation from each tangent line is `o(‖γ t - γ t₀‖)`. -/
 theorem IsPwC1ImmersionOn.flatOfOrder_one (h : IsPwC1ImmersionOn γ a b) {t₀ : ℝ}
     (ht₀ : t₀ ∈ Ioo (min a b) (max a b)) : FlatOfOrder γ t₀ 1 := by
-  obtain ⟨d, hd, hsubd, hC1d, hned⟩ := h.exists_Icc_pieces_right ⟨ht₀.1.le, ht₀.2⟩
-  obtain ⟨c, hc, hsubc, hC1c, hnec⟩ := h.exists_Icc_pieces_left ⟨ht₀.1, ht₀.2.le⟩
-  refine flatOfOrder_iff.mpr ⟨derivWithin γ (Icc t₀ d) t₀, derivWithin γ (Icc c t₀) t₀,
-    hned t₀ (left_mem_Icc.mpr hd.le), hnec t₀ (right_mem_Icc.mpr hc.le), ?_, ?_⟩
-  · refine perp_isLittleO_of_hasDerivWithinAt (hned t₀ (left_mem_Icc.mpr hd.le))
-      ((hC1d.differentiableOn one_ne_zero) t₀ (left_mem_Icc.mpr hd.le)).hasDerivWithinAt ?_
-    rw [← nhdsWithin_Ioo_eq_nhdsGT hd]
-    exact nhdsWithin_mono t₀ Ioo_subset_Icc_self
-  · refine perp_isLittleO_of_hasDerivWithinAt (hnec t₀ (right_mem_Icc.mpr hc.le))
-      ((hC1c.differentiableOn one_ne_zero) t₀ (right_mem_Icc.mpr hc.le)).hasDerivWithinAt ?_
-    rw [← nhdsWithin_Ioo_eq_nhdsLT hc]
-    exact nhdsWithin_mono t₀ Ioo_subset_Icc_self
+  obtain ⟨d, hd, -, hC1d, hned⟩ := h.exists_Icc_pieces_right ⟨ht₀.1.le, ht₀.2⟩
+  obtain ⟨c, hc, -, hC1c, hnec⟩ := h.exists_Icc_pieces_left ⟨ht₀.1, ht₀.2.le⟩
+  exact flatOfOrder_iff.mpr ⟨derivWithin γ (Icc t₀ d) t₀, derivWithin γ (Icc c t₀) t₀,
+    hned t₀ (left_mem_Icc.mpr hd.le), hnec t₀ (right_mem_Icc.mpr hc.le),
+    perp_isLittleO_right hd hC1d (hned t₀ (left_mem_Icc.mpr hd.le)),
+    perp_isLittleO_left hc hC1c (hnec t₀ (right_mem_Icc.mpr hc.le))⟩
 
 /-- **An immersion is flat of order one across the basepoint join** (`a < b`): the outgoing
 branch at `a` and the incoming branch at `b` are each first-order tangent to their non-zero
@@ -116,20 +134,14 @@ theorem IsPwC1ImmersionOn.flatOfOrderBasepoint_one (h : IsPwC1ImmersionOn γ a b
     (hab : a < b) : FlatOfOrderBasepoint γ a b 1 := by
   have hmin : min a b = a := min_eq_left hab.le
   have hmax : max a b = b := max_eq_right hab.le
-  obtain ⟨d, hd, hsubd, hC1d, hned⟩ := h.exists_Icc_pieces_right
+  obtain ⟨d, hd, -, hC1d, hned⟩ := h.exists_Icc_pieces_right
     ⟨hmin.le, lt_of_lt_of_le hab hmax.ge⟩
-  obtain ⟨c, hc, hsubc, hC1c, hnec⟩ := h.exists_Icc_pieces_left
+  obtain ⟨c, hc, -, hC1c, hnec⟩ := h.exists_Icc_pieces_left
     ⟨hmin.le.trans_lt hab, hmax.ge⟩
-  refine flatOfOrderBasepoint_iff.mpr ⟨derivWithin γ (Icc a d) a, derivWithin γ (Icc c b) b,
-    hned a (left_mem_Icc.mpr hd.le), hnec b (right_mem_Icc.mpr hc.le), ?_, ?_⟩
-  · refine perp_isLittleO_of_hasDerivWithinAt (hned a (left_mem_Icc.mpr hd.le))
-      ((hC1d.differentiableOn one_ne_zero) a (left_mem_Icc.mpr hd.le)).hasDerivWithinAt ?_
-    rw [← nhdsWithin_Ioo_eq_nhdsGT hd]
-    exact nhdsWithin_mono a Ioo_subset_Icc_self
-  · refine perp_isLittleO_of_hasDerivWithinAt (hnec b (right_mem_Icc.mpr hc.le))
-      ((hC1c.differentiableOn one_ne_zero) b (right_mem_Icc.mpr hc.le)).hasDerivWithinAt ?_
-    rw [← nhdsWithin_Ioo_eq_nhdsLT hc]
-    exact nhdsWithin_mono b Ioo_subset_Icc_self
+  exact flatOfOrderBasepoint_iff.mpr ⟨derivWithin γ (Icc a d) a, derivWithin γ (Icc c b) b,
+    hned a (left_mem_Icc.mpr hd.le), hnec b (right_mem_Icc.mpr hc.le),
+    perp_isLittleO_right hd hC1d (hned a (left_mem_Icc.mpr hd.le)),
+    perp_isLittleO_left hc hC1c (hnec b (right_mem_Icc.mpr hc.le))⟩
 
 end TauCeti.Contour
 

--- a/TauCeti/Analysis/Contour/PwC1ImmersionOn.lean
+++ b/TauCeti/Analysis/Contour/PwC1ImmersionOn.lean
@@ -218,6 +218,28 @@ theorem IsPwC1ImmersionOn.exists_deriv_left_limit (h : IsPwC1ImmersionOn γ a b)
   exact h1.congr' <| eventually_mem_nhdsWithin.mono fun t ht =>
     derivWithin_of_mem_nhds (Icc_mem_nhds ht.1 ht.2)
 
+/-- **The piece to the right of a parameter**: every `t₀ ∈ [min, max)` begins a breakpoint-free
+closed piece `[t₀, d] ⊆ [[a, b]]` on which the immersion is `C¹` with non-vanishing within-piece
+derivative. -/
+theorem IsPwC1ImmersionOn.exists_Icc_pieces_right (h : IsPwC1ImmersionOn γ a b) {t₀ : ℝ}
+    (ht₀ : t₀ ∈ Ico (min a b) (max a b)) :
+    ∃ d : ℝ, t₀ < d ∧ Icc t₀ d ⊆ uIcc a b ∧ ContDiffOn ℝ 1 γ (Icc t₀ d) ∧
+      ∀ t ∈ Icc t₀ d, derivWithin γ (Icc t₀ d) t ≠ 0 := by
+  obtain ⟨p, hp, hpieces⟩ := h.exists_breakpoints
+  obtain ⟨d, hlt, hsub, hdisj⟩ := exists_Icc_right_avoiding hp ht₀
+  exact ⟨d, hlt, hsub, hpieces t₀ d hlt hsub hdisj⟩
+
+/-- **The piece to the left of a parameter**: every `t₀ ∈ (min, max]` ends a breakpoint-free
+closed piece `[c, t₀] ⊆ [[a, b]]` on which the immersion is `C¹` with non-vanishing within-piece
+derivative. -/
+theorem IsPwC1ImmersionOn.exists_Icc_pieces_left (h : IsPwC1ImmersionOn γ a b) {t₀ : ℝ}
+    (ht₀ : t₀ ∈ Ioc (min a b) (max a b)) :
+    ∃ c : ℝ, c < t₀ ∧ Icc c t₀ ⊆ uIcc a b ∧ ContDiffOn ℝ 1 γ (Icc c t₀) ∧
+      ∀ t ∈ Icc c t₀, derivWithin γ (Icc c t₀) t ≠ 0 := by
+  obtain ⟨p, hp, hpieces⟩ := h.exists_breakpoints
+  obtain ⟨c, hlt, hsub, hdisj⟩ := exists_Icc_left_avoiding hp ht₀
+  exact ⟨c, hlt, hsub, hpieces c t₀ hlt hsub hdisj⟩
+
 end TauCeti.Contour
 
 end

--- a/TauCeti/Analysis/Contour/PwC1ImmersionOn.lean
+++ b/TauCeti/Analysis/Contour/PwC1ImmersionOn.lean
@@ -182,42 +182,6 @@ private theorem exists_Icc_left_avoiding {p : Finset ℝ} {t₀ : ℝ}
     exact absurd (q.le_max' x (Finset.mem_insert_of_mem
       (Finset.mem_filter.mpr ⟨Finset.mem_coe.mp hxp, hx.2⟩))) (not_le.mpr hx.1)
 
-/-- **Non-zero right tangent limit of an immersion.** At every parameter `t₀ ∈ [min, max)` a
-piecewise-`C¹` immersion has a non-zero limit of `deriv γ` from the right — the one-sided
-tangent of the piece beginning at `t₀`, namely its within-piece derivative there. -/
-theorem IsPwC1ImmersionOn.exists_deriv_right_limit (h : IsPwC1ImmersionOn γ a b) {t₀ : ℝ}
-    (ht₀ : t₀ ∈ Ico (min a b) (max a b)) :
-    ∃ L : ℂ, L ≠ 0 ∧ Tendsto (deriv γ) (𝓝[>] t₀) (𝓝 L) := by
-  obtain ⟨p, hp, hpieces⟩ := h.exists_breakpoints
-  obtain ⟨d, hlt, hsub, hdisj⟩ := exists_Icc_right_avoiding hp ht₀
-  obtain ⟨hC1, hne⟩ := hpieces t₀ d hlt hsub hdisj
-  refine ⟨derivWithin γ (Icc t₀ d) t₀, hne t₀ (left_mem_Icc.mpr hlt.le), ?_⟩
-  have h1 : Tendsto (derivWithin γ (Icc t₀ d)) (𝓝[Ioo t₀ d] t₀)
-      (𝓝 (derivWithin γ (Icc t₀ d) t₀)) :=
-    (((hC1.continuousOn_derivWithin (uniqueDiffOn_Icc hlt) le_rfl) t₀
-      (left_mem_Icc.mpr hlt.le)).tendsto).mono_left (nhdsWithin_mono t₀ Ioo_subset_Icc_self)
-  rw [← nhdsWithin_Ioo_eq_nhdsGT hlt]
-  exact h1.congr' <| eventually_mem_nhdsWithin.mono fun t ht =>
-    derivWithin_of_mem_nhds (Icc_mem_nhds ht.1 ht.2)
-
-/-- **Non-zero left tangent limit of an immersion.** At every parameter `t₀ ∈ (min, max]` a
-piecewise-`C¹` immersion has a non-zero limit of `deriv γ` from the left — the one-sided tangent
-of the piece ending at `t₀`, namely its within-piece derivative there. -/
-theorem IsPwC1ImmersionOn.exists_deriv_left_limit (h : IsPwC1ImmersionOn γ a b) {t₀ : ℝ}
-    (ht₀ : t₀ ∈ Ioc (min a b) (max a b)) :
-    ∃ L : ℂ, L ≠ 0 ∧ Tendsto (deriv γ) (𝓝[<] t₀) (𝓝 L) := by
-  obtain ⟨p, hp, hpieces⟩ := h.exists_breakpoints
-  obtain ⟨c, hlt, hsub, hdisj⟩ := exists_Icc_left_avoiding hp ht₀
-  obtain ⟨hC1, hne⟩ := hpieces c t₀ hlt hsub hdisj
-  refine ⟨derivWithin γ (Icc c t₀) t₀, hne t₀ (right_mem_Icc.mpr hlt.le), ?_⟩
-  have h1 : Tendsto (derivWithin γ (Icc c t₀)) (𝓝[Ioo c t₀] t₀)
-      (𝓝 (derivWithin γ (Icc c t₀) t₀)) :=
-    (((hC1.continuousOn_derivWithin (uniqueDiffOn_Icc hlt) le_rfl) t₀
-      (right_mem_Icc.mpr hlt.le)).tendsto).mono_left (nhdsWithin_mono t₀ Ioo_subset_Icc_self)
-  rw [← nhdsWithin_Ioo_eq_nhdsLT hlt]
-  exact h1.congr' <| eventually_mem_nhdsWithin.mono fun t ht =>
-    derivWithin_of_mem_nhds (Icc_mem_nhds ht.1 ht.2)
-
 /-- **The piece to the right of a parameter**: every `t₀ ∈ [min, max)` begins a breakpoint-free
 closed piece `[t₀, d] ⊆ [[a, b]]` on which the immersion is `C¹` with non-vanishing within-piece
 derivative. -/
@@ -239,6 +203,38 @@ theorem IsPwC1ImmersionOn.exists_Icc_pieces_left (h : IsPwC1ImmersionOn γ a b) 
   obtain ⟨p, hp, hpieces⟩ := h.exists_breakpoints
   obtain ⟨c, hlt, hsub, hdisj⟩ := exists_Icc_left_avoiding hp ht₀
   exact ⟨c, hlt, hsub, hpieces c t₀ hlt hsub hdisj⟩
+
+/-- **Non-zero right tangent limit of an immersion.** At every parameter `t₀ ∈ [min, max)` a
+piecewise-`C¹` immersion has a non-zero limit of `deriv γ` from the right — the one-sided
+tangent of the piece beginning at `t₀`, namely its within-piece derivative there. -/
+theorem IsPwC1ImmersionOn.exists_deriv_right_limit (h : IsPwC1ImmersionOn γ a b) {t₀ : ℝ}
+    (ht₀ : t₀ ∈ Ico (min a b) (max a b)) :
+    ∃ L : ℂ, L ≠ 0 ∧ Tendsto (deriv γ) (𝓝[>] t₀) (𝓝 L) := by
+  obtain ⟨d, hlt, hsub, hC1, hne⟩ := h.exists_Icc_pieces_right ht₀
+  refine ⟨derivWithin γ (Icc t₀ d) t₀, hne t₀ (left_mem_Icc.mpr hlt.le), ?_⟩
+  have h1 : Tendsto (derivWithin γ (Icc t₀ d)) (𝓝[Ioo t₀ d] t₀)
+      (𝓝 (derivWithin γ (Icc t₀ d) t₀)) :=
+    (((hC1.continuousOn_derivWithin (uniqueDiffOn_Icc hlt) le_rfl) t₀
+      (left_mem_Icc.mpr hlt.le)).tendsto).mono_left (nhdsWithin_mono t₀ Ioo_subset_Icc_self)
+  rw [← nhdsWithin_Ioo_eq_nhdsGT hlt]
+  exact h1.congr' <| eventually_mem_nhdsWithin.mono fun t ht =>
+    derivWithin_of_mem_nhds (Icc_mem_nhds ht.1 ht.2)
+
+/-- **Non-zero left tangent limit of an immersion.** At every parameter `t₀ ∈ (min, max]` a
+piecewise-`C¹` immersion has a non-zero limit of `deriv γ` from the left — the one-sided tangent
+of the piece ending at `t₀`, namely its within-piece derivative there. -/
+theorem IsPwC1ImmersionOn.exists_deriv_left_limit (h : IsPwC1ImmersionOn γ a b) {t₀ : ℝ}
+    (ht₀ : t₀ ∈ Ioc (min a b) (max a b)) :
+    ∃ L : ℂ, L ≠ 0 ∧ Tendsto (deriv γ) (𝓝[<] t₀) (𝓝 L) := by
+  obtain ⟨c, hlt, hsub, hC1, hne⟩ := h.exists_Icc_pieces_left ht₀
+  refine ⟨derivWithin γ (Icc c t₀) t₀, hne t₀ (right_mem_Icc.mpr hlt.le), ?_⟩
+  have h1 : Tendsto (derivWithin γ (Icc c t₀)) (𝓝[Ioo c t₀] t₀)
+      (𝓝 (derivWithin γ (Icc c t₀) t₀)) :=
+    (((hC1.continuousOn_derivWithin (uniqueDiffOn_Icc hlt) le_rfl) t₀
+      (right_mem_Icc.mpr hlt.le)).tendsto).mono_left (nhdsWithin_mono t₀ Ioo_subset_Icc_self)
+  rw [← nhdsWithin_Ioo_eq_nhdsLT hlt]
+  exact h1.congr' <| eventually_mem_nhdsWithin.mono fun t ht =>
+    derivWithin_of_mem_nhds (Icc_mem_nhds ht.1 ht.2)
 
 end TauCeti.Contour
 

--- a/TauCeti/Analysis/Contour/PwC1ImmersionOn.lean
+++ b/TauCeti/Analysis/Contour/PwC1ImmersionOn.lean
@@ -185,7 +185,7 @@ private theorem exists_Icc_left_avoiding {p : Finset ℝ} {t₀ : ℝ}
 /-- **The piece to the right of a parameter**: every `t₀ ∈ [min, max)` begins a breakpoint-free
 closed piece `[t₀, d] ⊆ [[a, b]]` on which the immersion is `C¹` with non-vanishing within-piece
 derivative. -/
-theorem IsPwC1ImmersionOn.exists_Icc_pieces_right (h : IsPwC1ImmersionOn γ a b) {t₀ : ℝ}
+theorem IsPwC1ImmersionOn.exists_Icc_piece_right (h : IsPwC1ImmersionOn γ a b) {t₀ : ℝ}
     (ht₀ : t₀ ∈ Ico (min a b) (max a b)) :
     ∃ d : ℝ, t₀ < d ∧ Icc t₀ d ⊆ uIcc a b ∧ ContDiffOn ℝ 1 γ (Icc t₀ d) ∧
       ∀ t ∈ Icc t₀ d, derivWithin γ (Icc t₀ d) t ≠ 0 := by
@@ -196,7 +196,7 @@ theorem IsPwC1ImmersionOn.exists_Icc_pieces_right (h : IsPwC1ImmersionOn γ a b)
 /-- **The piece to the left of a parameter**: every `t₀ ∈ (min, max]` ends a breakpoint-free
 closed piece `[c, t₀] ⊆ [[a, b]]` on which the immersion is `C¹` with non-vanishing within-piece
 derivative. -/
-theorem IsPwC1ImmersionOn.exists_Icc_pieces_left (h : IsPwC1ImmersionOn γ a b) {t₀ : ℝ}
+theorem IsPwC1ImmersionOn.exists_Icc_piece_left (h : IsPwC1ImmersionOn γ a b) {t₀ : ℝ}
     (ht₀ : t₀ ∈ Ioc (min a b) (max a b)) :
     ∃ c : ℝ, c < t₀ ∧ Icc c t₀ ⊆ uIcc a b ∧ ContDiffOn ℝ 1 γ (Icc c t₀) ∧
       ∀ t ∈ Icc c t₀, derivWithin γ (Icc c t₀) t ≠ 0 := by
@@ -210,7 +210,7 @@ tangent of the piece beginning at `t₀`, namely its within-piece derivative the
 theorem IsPwC1ImmersionOn.exists_deriv_right_limit (h : IsPwC1ImmersionOn γ a b) {t₀ : ℝ}
     (ht₀ : t₀ ∈ Ico (min a b) (max a b)) :
     ∃ L : ℂ, L ≠ 0 ∧ Tendsto (deriv γ) (𝓝[>] t₀) (𝓝 L) := by
-  obtain ⟨d, hlt, hsub, hC1, hne⟩ := h.exists_Icc_pieces_right ht₀
+  obtain ⟨d, hlt, hsub, hC1, hne⟩ := h.exists_Icc_piece_right ht₀
   refine ⟨derivWithin γ (Icc t₀ d) t₀, hne t₀ (left_mem_Icc.mpr hlt.le), ?_⟩
   have h1 : Tendsto (derivWithin γ (Icc t₀ d)) (𝓝[Ioo t₀ d] t₀)
       (𝓝 (derivWithin γ (Icc t₀ d) t₀)) :=
@@ -226,7 +226,7 @@ of the piece ending at `t₀`, namely its within-piece derivative there. -/
 theorem IsPwC1ImmersionOn.exists_deriv_left_limit (h : IsPwC1ImmersionOn γ a b) {t₀ : ℝ}
     (ht₀ : t₀ ∈ Ioc (min a b) (max a b)) :
     ∃ L : ℂ, L ≠ 0 ∧ Tendsto (deriv γ) (𝓝[<] t₀) (𝓝 L) := by
-  obtain ⟨c, hlt, hsub, hC1, hne⟩ := h.exists_Icc_pieces_left ht₀
+  obtain ⟨c, hlt, hsub, hC1, hne⟩ := h.exists_Icc_piece_left ht₀
   refine ⟨derivWithin γ (Icc c t₀) t₀, hne t₀ (right_mem_Icc.mpr hlt.le), ?_⟩
   have h1 : Tendsto (derivWithin γ (Icc c t₀)) (𝓝[Ioo c t₀] t₀)
       (𝓝 (derivWithin γ (Icc c t₀) t₀)) :=


### PR DESCRIPTION
## What

**Immersions are flat of order one** — Hungerbühler–Wasem condition (A′) at simple poles, as a
theorem about immersions:

```lean
theorem IsPwC1ImmersionOn.flatOfOrder_one (h : IsPwC1ImmersionOn γ a b) {t₀ : ℝ}
    (ht₀ : t₀ ∈ Ioo (min a b) (max a b)) : FlatOfOrder γ t₀ 1

theorem IsPwC1ImmersionOn.flatOfOrderBasepoint_one (h : IsPwC1ImmersionOn γ a b)
    (hab : a < b) : FlatOfOrderBasepoint γ a b 1
```

One new file, `TauCeti/Analysis/Contour/FlatnessOne.lean`, plus two public piece-eliminators on
the immersion predicate (`IsPwC1ImmersionOn.exists_Icc_pieces_right` / `exists_Icc_pieces_left`
in `PwC1ImmersionOn.lean`), exposing the breakpoint-free `C¹` piece with non-vanishing
within-piece derivative that begins/ends at a given parameter — the datum this proof and the
later crossing-analysis steps of the HW chain consume.

## Why

`Contour.ConditionAprime` requires `FlatOfOrder γ t₀ n` wherever the curve meets a pole of order
`n`. At **simple poles** (`n = 1`) this holds automatically for an immersion: the curve leaves
every point first-order tangent to its non-zero one-sided tangent, so the perpendicular
deviation from the tangent line is `o(‖γ t - γ t₀‖)`. Together with
`IsPwC1ImmersionOn.finite_crossings` (#921, the finiteness clause) this makes condition (A′) at
simple poles a consequence of immersion regularity rather than a hypothesis — the input the
half-residue target (`hasCauchyPV_half_residue`, winding `½` at a simple pole) needs.

The analytic core (private `perp_isLittleO_of_hasDerivWithinAt`): from the one-sided derivative
`L ≠ 0`, the perpendicular component of `γ t - γ t₀` against `L` equals that of the
differentiation error, hence is `o(t - t₀)`; and `‖γ t - γ t₀‖ ≳ (‖L‖/2)·|t - t₀|` eventually,
so `o(t - t₀) = o(‖γ t - γ t₀‖)`. The one-sided derivative at a piece endpoint is simply the
within-piece derivative of `IsPwC1ImmersionOn` — no limit-recovery is needed.

## Provenance

Migrated from `isFlatOfOrder_one` of `FlatnessConditions.lean` in the AINTLIB `LeanModularForms`
development, restated for the raw curve on `[[a, b]]` and against
`Contour.FlatOfOrder`/`FlatOfOrderBasepoint` (`RegularityConditions.lean`): AINTLIB recovers the
one-sided derivatives from tendsto limits of `deriv`, whereas here they are the within-piece
derivatives of `IsPwC1ImmersionOn` at the piece endpoints. See K. Hungerbühler, M. Wasem,
*Non-integer valued winding numbers and a generalized Residue Theorem*, arXiv:1808.00997, §3.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
