### PR TITLE
feat(Analysis/Contour): polar-part decompositions

### DIFF
--- a/TauCeti/Analysis/Contour/PolarPartDecomposition.lean
+++ b/TauCeti/Analysis/Contour/PolarPartDecomposition.lean
@@ -26,9 +26,9 @@ parts.
 
 ## Main results
 
-* `Contour.PolarPartDecomposition.intervalIntegral_analyticRemainder_eq_zero` — the contour
-  integral of the analytic remainder along a closed null-homologous piecewise-`C¹` curve in `U`
-  vanishes, by the homology Cauchy theorem.
+* `Contour.PolarPartDecomposition.intervalIntegral_deriv_smul_analyticRemainder_eq_zero` — the
+  contour integral of the analytic remainder along a closed null-homologous piecewise-`C¹` curve
+  in `U` vanishes, by the homology Cauchy theorem.
 
 ## Provenance
 
@@ -51,27 +51,31 @@ open scoped Interval
 
 /-- **Polar-part decomposition** of `f` on `U` at the finite singular set `S`: explicit finite
 Laurent tails at the points of `S` whose removal from `f` leaves a function differentiable on all
-of `U`, with the residue at each `s ∈ S` read off as the first Laurent coefficient. -/
+of `U`, with the residue at each `s ∈ S` read off as the first Laurent coefficient. The data is
+indexed by `S`, so a decomposition carries nothing beyond what its laws constrain; the polar part
+is pinned for every `z` (at `z = s` the Laurent sum takes the junk value `0`, by division by
+zero in `ℂ`). -/
 structure PolarPartDecomposition (f : ℂ → ℂ) (S : Finset ℂ) (U : Set ℂ) where
-  /-- The polar part at each pole, as a function of `z`. -/
-  polarPart : ℂ → ℂ → ℂ
   /-- The order of the polar part at each pole (`0` for no pole). -/
-  order : ℂ → ℕ
+  order : S → ℕ
   /-- The Laurent coefficients of the polar part at each pole. -/
-  coeff : (s : ℂ) → Fin (order s) → ℂ
+  coeff : (s : S) → Fin (order s) → ℂ
+  /-- The polar part at each pole, as a function of `z`. -/
+  polarPart : S → ℂ → ℂ
   /-- The polar part at `s` is the explicit Laurent sum `∑ k, coeff s k / (z - s)^(k+1)`. -/
-  polarPart_eq : ∀ s ∈ S, ∀ z, z ≠ s →
-    polarPart s z = ∑ k : Fin (order s), coeff s k / (z - s) ^ (k.val + 1)
+  polarPart_eq : ∀ (s : S) (z : ℂ),
+    polarPart s z = ∑ k : Fin (order s), coeff s k / (z - (s : ℂ)) ^ (k.val + 1)
   /-- The residue at `s ∈ S` is the first Laurent coefficient, or zero for an empty polar
   part. -/
-  residue_eq : ∀ s ∈ S,
+  residue_eq : ∀ s : S,
     residue f s = if h : 0 < order s then coeff s ⟨0, h⟩ else 0
   /-- The function `f` minus the total polar part, extended to all of `U`. -/
   analyticRemainder : ℂ → ℂ
   /-- The analytic remainder is differentiable on all of `U`. -/
-  analyticRemainder_diff : DifferentiableOn ℂ analyticRemainder U
+  analyticRemainder_differentiableOn : DifferentiableOn ℂ analyticRemainder U
   /-- Off the singular set, `f` is the analytic remainder plus the total polar part. -/
-  decomp : ∀ z ∈ U \ (↑S : Set ℂ), f z = analyticRemainder z + ∑ s ∈ S, polarPart s z
+  f_eq : ∀ z ∈ U \ (↑S : Set ℂ),
+    f z = analyticRemainder z + ∑ s ∈ S.attach, polarPart s z
 
 namespace PolarPartDecomposition
 
@@ -80,12 +84,13 @@ variable {f : ℂ → ℂ} {S : Finset ℂ} {U : Set ℂ}
 /-- **The analytic remainder integrates to zero** along any closed null-homologous
 piecewise-`C¹` curve in `U` — even one passing through the poles of `f`, since the remainder
 extends differentiably to all of `U`. The homology Cauchy theorem applied to the remainder. -/
-theorem intervalIntegral_analyticRemainder_eq_zero (decomp : PolarPartDecomposition f S U)
+theorem intervalIntegral_deriv_smul_analyticRemainder_eq_zero
+    (decomp : PolarPartDecomposition f S U)
     (hU : IsOpen U) {γ : ℝ → ℂ} {a b : ℝ} (hγ_pc1 : IsPiecewiseC1On γ a b)
     (hγ : ∀ t ∈ uIcc a b, γ t ∈ U) (hclosed : γ a = γ b)
     (hnull : IsNullHomologous γ a b U) :
     ∫ t in a..b, deriv γ t • decomp.analyticRemainder (γ t) = 0 :=
-  homologyCauchyTheorem hU γ a b hγ_pc1 hγ hclosed decomp.analyticRemainder_diff hnull
+  homologyCauchyTheorem hU γ a b hγ_pc1 hγ hclosed decomp.analyticRemainder_differentiableOn hnull
 
 end PolarPartDecomposition
 

--- a/TauCeti/Analysis/Contour/PolarPartDecomposition.lean
+++ b/TauCeti/Analysis/Contour/PolarPartDecomposition.lean
@@ -1,0 +1,94 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Chris Birkbeck
+-/
+module
+
+public import TauCeti.Analysis.Contour.HomologyCauchy
+public import TauCeti.Analysis.Contour.Residue
+
+/-!
+# Polar-part decompositions
+
+A **polar-part decomposition** of `f` on `U` at the finite singular set `S`: for each `s ∈ S` an
+explicit finite Laurent tail `polarPart s z = ∑ k, coeff s k / (z - s)^(k+1)`, such that `f`
+minus the total polar part extends to a function differentiable on all of `U`, and the residue at
+each `s` is the first Laurent coefficient. This bundles exactly the data the generalized residue
+theorem manipulates: the analytic remainder integrates to zero around any null-homologous closed
+curve — even one passing through the poles — so the principal value of `∮ f` reduces to the polar
+parts.
+
+## Main definitions
+
+* `Contour.PolarPartDecomposition f S U` — the decomposition data: polar parts, orders, Laurent
+  coefficients, the residue identification, and the analytic remainder.
+
+## Main results
+
+* `Contour.PolarPartDecomposition.intervalIntegral_analyticRemainder_eq_zero` — the contour
+  integral of the analytic remainder along a closed null-homologous piecewise-`C¹` curve in `U`
+  vanishes, by the homology Cauchy theorem.
+
+## Provenance
+
+The structure is migrated from `PolarPartDecomposition` of `HungerbuhlerWasem.lean` in the
+AINTLIB `LeanModularForms` development; the remainder-integral theorem is its
+`analyticRemainder_contourIntegral_zero`, which there re-runs Dixon's argument inline and here is
+a direct application of `Contour.homologyCauchyTheorem`. See K. Hungerbühler, M. Wasem,
+*Non-integer valued winding numbers and a generalized Residue Theorem*, arXiv:1808.00997, §3.
+-/
+
+public section
+
+noncomputable section
+
+namespace TauCeti.Contour
+
+open MeasureTheory Set
+
+open scoped Interval
+
+/-- **Polar-part decomposition** of `f` on `U` at the finite singular set `S`: explicit finite
+Laurent tails at the points of `S` whose removal from `f` leaves a function differentiable on all
+of `U`, with the residue at each `s ∈ S` read off as the first Laurent coefficient. -/
+structure PolarPartDecomposition (f : ℂ → ℂ) (S : Finset ℂ) (U : Set ℂ) where
+  /-- The polar part at each pole, as a function of `z`. -/
+  polarPart : ℂ → ℂ → ℂ
+  /-- The order of the polar part at each pole (`0` for no pole). -/
+  order : ℂ → ℕ
+  /-- The Laurent coefficients of the polar part at each pole. -/
+  coeff : (s : ℂ) → Fin (order s) → ℂ
+  /-- The polar part at `s` is the explicit Laurent sum `∑ k, coeff s k / (z - s)^(k+1)`. -/
+  polarPart_eq : ∀ s ∈ S, ∀ z, z ≠ s →
+    polarPart s z = ∑ k : Fin (order s), coeff s k / (z - s) ^ (k.val + 1)
+  /-- The residue at `s ∈ S` is the first Laurent coefficient, or zero for an empty polar
+  part. -/
+  residue_eq : ∀ s ∈ S,
+    residue f s = if h : 0 < order s then coeff s ⟨0, h⟩ else 0
+  /-- The function `f` minus the total polar part, extended to all of `U`. -/
+  analyticRemainder : ℂ → ℂ
+  /-- The analytic remainder is differentiable on all of `U`. -/
+  analyticRemainder_diff : DifferentiableOn ℂ analyticRemainder U
+  /-- Off the singular set, `f` is the analytic remainder plus the total polar part. -/
+  decomp : ∀ z ∈ U \ (↑S : Set ℂ), f z = analyticRemainder z + ∑ s ∈ S, polarPart s z
+
+namespace PolarPartDecomposition
+
+variable {f : ℂ → ℂ} {S : Finset ℂ} {U : Set ℂ}
+
+/-- **The analytic remainder integrates to zero** along any closed null-homologous
+piecewise-`C¹` curve in `U` — even one passing through the poles of `f`, since the remainder
+extends differentiably to all of `U`. The homology Cauchy theorem applied to the remainder. -/
+theorem intervalIntegral_analyticRemainder_eq_zero (decomp : PolarPartDecomposition f S U)
+    (hU : IsOpen U) {γ : ℝ → ℂ} {a b : ℝ} (hγ_pc1 : IsPiecewiseC1On γ a b)
+    (hγ : ∀ t ∈ uIcc a b, γ t ∈ U) (hclosed : γ a = γ b)
+    (hnull : IsNullHomologous γ a b U) :
+    ∫ t in a..b, deriv γ t • decomp.analyticRemainder (γ t) = 0 :=
+  homologyCauchyTheorem hU γ a b hγ_pc1 hγ hclosed decomp.analyticRemainder_diff hnull
+
+end PolarPartDecomposition
+
+end TauCeti.Contour
+
+end


### PR DESCRIPTION
## What

`Contour.PolarPartDecomposition f S U` — explicit finite Laurent tails at each `s ∈ S` whose
removal from `f` leaves a function differentiable on all of `U`, with the residue at each pole
identified as the first Laurent coefficient — together with its first consequence:

```lean
theorem PolarPartDecomposition.intervalIntegral_analyticRemainder_eq_zero
    (decomp : PolarPartDecomposition f S U) (hU : IsOpen U) (hγ_pc1 : IsPiecewiseC1On γ a b)
    (hγ : ∀ t ∈ uIcc a b, γ t ∈ U) (hclosed : γ a = γ b) (hnull : IsNullHomologous γ a b U) :
    ∫ t in a..b, deriv γ t • decomp.analyticRemainder (γ t) = 0
```

One new file, `TauCeti/Analysis/Contour/PolarPartDecomposition.lean`.

## Why

This is the bundle the generalized residue theorem (roadmap `hungerbuhlerWasem_residueTheorem`,
Layer 4) manipulates: the remainder integrates to zero around any null-homologous closed curve —
**even one passing through the poles**, since the remainder extends to all of `U` — so the
principal value of `∮ f` reduces to the finitely many polar parts, which the crossing analysis
then evaluates. Sits directly on main (consumes `homologyCauchyTheorem`, #919), parallel to the
in-review chord-bound leaf (#923).

## Provenance

The structure is `PolarPartDecomposition` of `HungerbuhlerWasem.lean` in the AINTLIB
`LeanModularForms` development, field-for-field (against `Contour.residue`); the remainder
theorem is its `analyticRemainder_contourIntegral_zero`, which there re-derives Dixon's argument
inline over the bundled path type and here is a one-line application of
`Contour.homologyCauchyTheorem` to the raw curve. See K. Hungerbühler, M. Wasem, *Non-integer
valued winding numbers and a generalized Residue Theorem*, arXiv:1808.00997, §3.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
