### PR TITLE
docs(Analysis/Contour): correct the author initial: N. Hungerbühler

### DIFF
--- a/TauCeti/Analysis/Contour/CrossingFiniteness.lean
+++ b/TauCeti/Analysis/Contour/CrossingFiniteness.lean
@@ -37,7 +37,7 @@ lemmas) of the AINTLIB `LeanModularForms` development, restated for the raw curv
 `[[a, b]]`: the one-sided tangent data carried there by the `left_deriv_limit` /
 `right_deriv_limit` fields of the bundled `PwC1Immersion` comes from the `IsPwC1ImmersionOn`
 tangent-limit API (`PwC1ImmersionOn.lean`), which uniformises the smooth-point and breakpoint
-cases of the isolation argument. See K. Hungerbühler, M. Wasem, *Non-integer valued
+cases of the isolation argument. See N. Hungerbühler, M. Wasem, *Non-integer valued
 winding numbers and a generalized Residue Theorem*, arXiv:1808.00997, Proposition 2.2.
 -/
 

--- a/TauCeti/Analysis/Contour/DixonDef.lean
+++ b/TauCeti/Analysis/Contour/DixonDef.lean
@@ -42,7 +42,7 @@ These are the building blocks of the `homologyCauchyTheorem` roadmap target
 Adapted from `dixonH1`, `dixonH2`, `dixonFunction`, and `dixonH1_eq_dixonH2_sub_winding_f` in
 `DixonDef.lean` of the AINTLIB `LeanModularForms` development, restated for a raw `γ : ℝ → ℂ` on an
 oriented interval with endpoints `a` and `b`. See J. D. Dixon, *A brief proof of Cauchy's integral
-theorem*, Proc. Amer. Math. Soc. 29 (1971), and N. Hungerbühler, J. Wasem, *A generalized notion of
+theorem*, Proc. Amer. Math. Soc. 29 (1971), and N. Hungerbühler, M. Wasem, *A generalized notion of
 winding numbers*.
 -/
 

--- a/TauCeti/Analysis/Contour/DixonDef.lean
+++ b/TauCeti/Analysis/Contour/DixonDef.lean
@@ -42,7 +42,7 @@ These are the building blocks of the `homologyCauchyTheorem` roadmap target
 Adapted from `dixonH1`, `dixonH2`, `dixonFunction`, and `dixonH1_eq_dixonH2_sub_winding_f` in
 `DixonDef.lean` of the AINTLIB `LeanModularForms` development, restated for a raw `γ : ℝ → ℂ` on an
 oriented interval with endpoints `a` and `b`. See J. D. Dixon, *A brief proof of Cauchy's integral
-theorem*, Proc. Amer. Math. Soc. 29 (1971), and K. Hungerbühler, J. Wasem, *A generalized notion of
+theorem*, Proc. Amer. Math. Soc. 29 (1971), and N. Hungerbühler, J. Wasem, *A generalized notion of
 winding numbers*.
 -/
 

--- a/TauCeti/Analysis/Contour/FlatnessOne.lean
+++ b/TauCeti/Analysis/Contour/FlatnessOne.lean
@@ -30,7 +30,7 @@ simple poles a theorem about immersions rather than a hypothesis.
 Migrated from `isFlatOfOrder_one` of `FlatnessConditions.lean` in the AINTLIB `LeanModularForms`
 development, restated for the raw curve on `[[a, b]]`: the one-sided derivatives recovered there
 from tendsto limits are here the within-piece derivatives of `IsPwC1ImmersionOn` at the piece
-endpoints. See K. Hungerbühler, M. Wasem, *Non-integer valued winding numbers and a generalized
+endpoints. See N. Hungerbühler, M. Wasem, *Non-integer valued winding numbers and a generalized
 Residue Theorem*, arXiv:1808.00997, §3 (condition (A′) at simple poles).
 -/
 

--- a/TauCeti/Analysis/Contour/PolarPartDecomposition.lean
+++ b/TauCeti/Analysis/Contour/PolarPartDecomposition.lean
@@ -35,7 +35,7 @@ parts.
 The structure is migrated from `PolarPartDecomposition` of `HungerbuhlerWasem.lean` in the
 AINTLIB `LeanModularForms` development; the remainder-integral theorem is its
 `analyticRemainder_contourIntegral_zero`, which there re-runs Dixon's argument inline and here is
-a direct application of `Contour.homologyCauchyTheorem`. See K. Hungerbühler, M. Wasem,
+a direct application of `Contour.homologyCauchyTheorem`. See N. Hungerbühler, M. Wasem,
 *Non-integer valued winding numbers and a generalized Residue Theorem*, arXiv:1808.00997, §3.
 -/
 


### PR DESCRIPTION
Docs-only: the arXiv:1808.00997 references in `CrossingFiniteness.lean` and `DixonDef.lean` credited **K.** Hungerbühler; the author is **Norbert** Hungerbühler, as `RegularityConditions.lean` already cites. Caught by the attribution review on #923; this fixes the same error in the two already-merged files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)