### PR TITLE
feat(Analysis/Contour): canonical Laurent data of a meromorphic function

### DIFF
--- a/TauCeti/Analysis/Contour/MeromorphicLaurent.lean
+++ b/TauCeti/Analysis/Contour/MeromorphicLaurent.lean
@@ -11,7 +11,7 @@ public import TauCeti.Analysis.Contour.Residue
 # Canonical Laurent data of a meromorphic function
 
 For `f` meromorphic at `s`, this file extracts its **canonical Laurent data**: the polar order
-`meroPolarOrderAt` — computed from `meromorphicOrderAt`, not chosen — together with Laurent
+`meromorphicPolarOrderAt` — computed from `meromorphicOrderAt`, not chosen — together with Laurent
 coefficients, the finite polar part, and the analytic part, satisfying
 `f = analytic part + ∑ k, coeff k / (z - s)^(k+1)` near `s`. Because the tail length is the
 computable canonical order, downstream facts about it are provable (it is `1` at a simple pole)
@@ -20,28 +20,29 @@ generalized residue theorem be discharged at simple poles by flatness of order o
 
 ## Main definitions
 
-* `Contour.meroPolarOrderAt hMero` — the canonical polar order: the negative part of
+* `Contour.meromorphicPolarOrderAt f s` — the canonical polar order: the negative part of
   `meromorphicOrderAt f s` (`0` at an analytic-or-removable point).
-* `Contour.meroPolarCoeffAt hMero k` — the `k`-th Laurent coefficient at `s`.
-* `Contour.meroPolarPartAt hMero` — the finite polar part `∑ k, coeff k / (z - s)^(k+1)`.
-* `Contour.meroAnalyticPartAt hMero` — the analytic part at `s`.
+* `Contour.meromorphicPolarCoeffAt hMero k` — the `k`-th Laurent coefficient at `s`.
+* `Contour.meromorphicPolarPartAt hMero` — the finite polar part `∑ k, coeff k / (z - s)^(k+1)`.
+* `Contour.meromorphicAnalyticPartAt hMero` — the analytic part at `s`.
 
 ## Main results
 
-* `Contour.mero_laurent_data_exists` — the Laurent decomposition with tail length pinned to the
-  canonical order.
-* `Contour.eventuallyEq_meroAnalyticPartAt_add_meroPolarPartAt` — `f` equals analytic part plus
-  polar part near `s`.
-* `Contour.meroPolarPartAt_eq_sum` — the polar part as its explicit Laurent sum.
-* `Contour.meroPolarCoeffAt_zero_eq_residue` — the leading coefficient is the residue.
-* `Contour.meroPolarOrderAt_eq_one` — the canonical order at a simple pole is `1`.
+* `Contour.exists_laurent_data_of_meromorphicAt` — the Laurent decomposition with tail length
+  pinned to the canonical order.
+* `Contour.eventuallyEq_meromorphicAnalyticPartAt_add_meromorphicPolarPartAt` — `f` equals
+  analytic part plus polar part near `s`.
+* `Contour.meromorphicPolarPartAt_eq_sum` — the polar part as its explicit Laurent sum.
+* `Contour.meromorphicPolarCoeffAt_zero_eq_residue` — the leading coefficient is the residue.
+* `Contour.meromorphicPolarOrderAt_eq_one` — the canonical order at a simple pole is `1`.
 
 ## Provenance
 
 Migrated from the per-point Laurent-extraction block of
 `HungerbuhlerWasem/LaurentExtraction.lean` in the AINTLIB `LeanModularForms` development
-(`meroPolarOrderAt` through `meroPolarCoeffAt_zero_eq_residue`); the residue identification is
-by `Contour.residue_of_laurent_expansion` against the Taylor-coefficient residue. See
+(`meroPolarOrderAt` through `meroPolarCoeffAt_zero_eq_residue`, here with `meromorphic` spelled
+out); the residue identification is by `Contour.residue_of_laurent_expansion` against the
+Taylor-coefficient residue. See
 N. Hungerbühler, M. Wasem, *Non-integer valued winding numbers and a generalized Residue
 Theorem*, arXiv:1808.00997, §3.
 -/
@@ -56,64 +57,58 @@ open Filter Set Topology
 
 /-- **The canonical polar order** of a meromorphic function at `s`: the negative part of
 `meromorphicOrderAt f s`. For a pole of order `k` this is `k` (in particular `1` at a simple
-pole, `meroPolarOrderAt_eq_one`); at an analytic-or-removable point — including locally
+pole, `meromorphicPolarOrderAt_eq_one`); at an analytic-or-removable point — including locally
 vanishing `f` — it is `0`. Computed from `f` alone, so callers can evaluate it, unlike a
 `Classical.choose`-extracted tail length. -/
-def meroPolarOrderAt {f : ℂ → ℂ} {s : ℂ} (_hMero : MeromorphicAt f s) : ℕ :=
+def meromorphicPolarOrderAt (f : ℂ → ℂ) (s : ℂ) : ℕ :=
   (-(meromorphicOrderAt f s).untop₀).toNat
 
 /-- The canonical polar order, computed from `meromorphicOrderAt`. -/
-theorem meroPolarOrderAt_eq_of_order_eq {f : ℂ → ℂ} {s : ℂ}
-    (hMero : MeromorphicAt f s) {n : ℤ} (h : meromorphicOrderAt f s = n) :
-    meroPolarOrderAt hMero = (-n).toNat := by
-  rw [meroPolarOrderAt, h, WithTop.untop₀_coe]
+theorem meromorphicPolarOrderAt_eq_of_order_eq {f : ℂ → ℂ} {s : ℂ}
+    {n : ℤ} (h : meromorphicOrderAt f s = n) :
+    meromorphicPolarOrderAt f s = (-n).toNat := by
+  rw [meromorphicPolarOrderAt, h, WithTop.untop₀_coe]
 
 /-- **At a simple pole the canonical polar order is `1`.** With flatness of order one
 (`IsPwC1ImmersionOn.flatOfOrder_one`), this discharges condition (A′) of the generalized residue
 theorem at simple poles. -/
-theorem meroPolarOrderAt_eq_one {f : ℂ → ℂ} {s : ℂ}
-    (hMero : MeromorphicAt f s) (h : meromorphicOrderAt f s = -1) :
-    meroPolarOrderAt hMero = 1 := by
-  rw [meroPolarOrderAt_eq_of_order_eq hMero h]
+theorem meromorphicPolarOrderAt_eq_one {f : ℂ → ℂ} {s : ℂ}
+    (h : meromorphicOrderAt f s = -1) :
+    meromorphicPolarOrderAt f s = 1 := by
+  rw [meromorphicPolarOrderAt_eq_of_order_eq h]
   rfl
 
-/-- Peel one vanishing factor off an analytic function: `g z = g s + (z - s) * g₁ z` with `g₁`
-analytic at `s`. -/
-private theorem analyticAt_peel_one {g : ℂ → ℂ} {s : ℂ} (hg : AnalyticAt ℂ g s) :
-    ∃ g₁ : ℂ → ℂ, AnalyticAt ℂ g₁ s ∧
-      ∀ᶠ z in 𝓝 s, g z = g s + (z - s) * g₁ z := by
-  have h_diff : AnalyticAt ℂ (fun z => g z - g s) s := hg.sub analyticAt_const
-  have h_value : (fun z => g z - g s) s = 0 := by simp
-  have h_ord_ne : analyticOrderAt (fun z => g z - g s) s ≠ 0 := fun h_eq =>
-    (h_diff.analyticOrderAt_eq_zero).mp h_eq h_value
-  have h_ge : (1 : ℕ∞) ≤ analyticOrderAt (fun z => g z - g s) s :=
-    Order.one_le_iff_ne_zero.mpr h_ord_ne
-  obtain ⟨g₁, hg₁_an, hg₁_eq⟩ :=
-    (natCast_le_analyticOrderAt h_diff).mp (by exact_mod_cast h_ge)
-  refine ⟨g₁, hg₁_an, ?_⟩
-  filter_upwards [hg₁_eq] with z hz
-  have heq : g z - g s = (z - s) * g₁ z := by simpa using hz
-  linear_combination heq
-
 /-- Taylor decomposition of an analytic function to order `k`:
-`g z = ∑ j < k, c j * (z - s)^j + (z - s)^k * R z` with `R` analytic at `s`. -/
+`g z = ∑ j < k, c j * (z - s)^j + (z - s)^k * R z` with `R` analytic at `s`. Mathlib's
+`AnalyticAt.exists_eventuallyEq_sum_add_pow_mul` at the translate `g (· + s)`. -/
 private theorem analyticAt_taylor_decomp {g : ℂ → ℂ} {s : ℂ}
     (hg : AnalyticAt ℂ g s) (k : ℕ) :
     ∃ (c : Fin k → ℂ) (R : ℂ → ℂ), AnalyticAt ℂ R s ∧
       ∀ᶠ z in 𝓝 s, g z = (∑ j : Fin k, c j * (z - s) ^ j.val) + (z - s) ^ k * R z := by
-  induction k with
-  | zero =>
-      refine ⟨Fin.elim0, g, hg, ?_⟩
-      filter_upwards with z
-      simp
-  | succ k ih =>
-      obtain ⟨c, R, hR_an, hR_eq⟩ := ih
-      obtain ⟨R', hR'_an, hR'_eq⟩ := analyticAt_peel_one hR_an
-      refine ⟨Fin.snoc c (R s), R', hR'_an, ?_⟩
-      filter_upwards [hR_eq, hR'_eq] with z hR_eq_z hR'_eq_z
-      rw [hR_eq_z, hR'_eq_z, Fin.sum_univ_castSucc]
-      simp only [Fin.snoc_castSucc, Fin.snoc_last, Fin.val_last, Fin.val_castSucc]
-      ring
+  have h1 : AnalyticAt ℂ (fun w : ℂ => w + s) 0 := analyticAt_id.add analyticAt_const
+  have hg0 : AnalyticAt ℂ (fun w => g (w + s)) 0 := by
+    have := AnalyticAt.comp (f := fun w : ℂ => w + s) (x := (0 : ℂ)) (by simpa using hg) h1
+    exact this
+  obtain ⟨F, hF_an, hF_eq⟩ := hg0.exists_eventuallyEq_sum_add_pow_mul k
+  have h2 : AnalyticAt ℂ (fun z : ℂ => z - s) s := analyticAt_id.sub analyticAt_const
+  have hF_comp : AnalyticAt ℂ (fun z => F (z - s)) s := by
+    have := AnalyticAt.comp (f := fun z : ℂ => z - s) (x := s) (by simpa using hF_an) h2
+    exact this
+  refine ⟨fun j => iteratedDeriv j.val (fun w => g (w + s)) 0 / j.val.factorial,
+    fun z => F (z - s), hF_comp, ?_⟩
+  have h_tend : Filter.Tendsto (fun z : ℂ => z - s) (𝓝 s) (𝓝 0) := by
+    simpa using (continuous_sub_right s).tendsto s
+  filter_upwards [h_tend.eventually hF_eq] with z hz
+  have hz' : g z = ∑ i ∈ Finset.range k,
+      ((z - s) ^ i / (i.factorial : ℂ)) • iteratedDeriv i (fun w => g (w + s)) 0 +
+        (z - s) ^ k • F (z - s) := by simpa using hz
+  rw [hz', smul_eq_mul, mul_comm ((z - s) ^ k)]
+  congr 1
+  rw [Fin.sum_univ_eq_sum_range (fun j => iteratedDeriv j (fun w => g (w + s)) 0 /
+    (j.factorial : ℂ) * (z - s) ^ j)]
+  refine Finset.sum_congr rfl fun i _ => ?_
+  rw [smul_eq_mul]
+  ring
 
 private theorem pow_div_pow_neg {w : ℂ} (hw : w ≠ 0) {k j : ℕ} (hjk : j < k) :
     w ^ j * (w ^ k)⁻¹ = (w ^ (k - j))⁻¹ := by
@@ -167,109 +162,99 @@ private theorem laurent_data_of_zpow_factor {f g₀ : ℂ → ℂ} {s : ℂ} (k 
   exact reindex_sum_fin_neg c (z - s)
 
 /-- Factorisation of a meromorphic `f` at the canonical polar order:
-`f = (z - s)^(-meroPolarOrderAt) • g₀` near `s` with `g₀` analytic (nonnegative powers of
+`f = (z - s)^(-meromorphicPolarOrderAt) • g₀` near `s` with `g₀` analytic (nonnegative powers of
 `z - s` are absorbed into the cofactor; `g₀ = 0` when `f` vanishes near `s`). -/
 private theorem exists_zpow_factor_at_canonical_order {f : ℂ → ℂ} {s : ℂ}
     (hMero : MeromorphicAt f s) :
     ∃ g₀ : ℂ → ℂ, AnalyticAt ℂ g₀ s ∧
-      ∀ᶠ z in 𝓝[≠] s, f z = (z - s) ^ (-(meroPolarOrderAt hMero : ℤ)) • g₀ z := by
+      ∀ᶠ z in 𝓝[≠] s, f z = (z - s) ^ (-(meromorphicPolarOrderAt f s : ℤ)) • g₀ z := by
   by_cases h_top : meromorphicOrderAt f s = ⊤
-  · have h0 : meroPolarOrderAt hMero = 0 := by
-      rw [meroPolarOrderAt, h_top, WithTop.untop₀_top, neg_zero, Int.toNat_zero]
+  · have h0 : meromorphicPolarOrderAt f s = 0 := by
+      rw [meromorphicPolarOrderAt, h_top, WithTop.untop₀_top, neg_zero, Int.toNat_zero]
     refine ⟨fun _ => 0, analyticAt_const, ?_⟩
     filter_upwards [meromorphicOrderAt_eq_top_iff.mp h_top] with z hz
     rw [hz, smul_zero]
   · obtain ⟨n, h_ord⟩ := WithTop.ne_top_iff_exists.mp h_top
     obtain ⟨g, hg_an, _, hg_eq⟩ := (meromorphicOrderAt_eq_int_iff hMero).mp h_ord.symm
-    have h_val : (meroPolarOrderAt hMero : ℤ) = max (-n) 0 := by
-      rw [meroPolarOrderAt_eq_of_order_eq hMero h_ord.symm]
+    have h_val : (meromorphicPolarOrderAt f s : ℤ) = max (-n) 0 := by
+      rw [meromorphicPolarOrderAt_eq_of_order_eq h_ord.symm]
       omega
     rcases le_or_gt 0 n with hn | hn
     · -- no pole: absorb `(z - s)^n` into the analytic cofactor
       refine ⟨fun z => (z - s) ^ n.toNat * g z,
         ((analyticAt_id.sub analyticAt_const).pow _).mul hg_an, ?_⟩
       filter_upwards [hg_eq] with z hz
-      rw [hz, show -(meroPolarOrderAt hMero : ℤ) = 0 by omega, zpow_zero, one_smul,
+      rw [hz, show -(meromorphicPolarOrderAt f s : ℤ) = 0 by omega, zpow_zero, one_smul,
         smul_eq_mul, show n = (n.toNat : ℤ) by omega, zpow_natCast, Int.toNat_natCast]
-    · -- a pole of order `-n = meroPolarOrderAt hMero`
+    · -- a pole of order `-n = meromorphicPolarOrderAt f s`
       refine ⟨g, hg_an, ?_⟩
-      rw [show -(meroPolarOrderAt hMero : ℤ) = n by omega]
+      rw [show -(meromorphicPolarOrderAt f s : ℤ) = n by omega]
       exact hg_eq
 
 /-- **Canonical Laurent data of a meromorphic function**: near `s`,
 `f = g + ∑ k, a k / (z - s)^(k+1)` with `g` analytic at `s`, where the tail length is the
-canonical polar order `meroPolarOrderAt hMero` — pinned, not existentially chosen, so it is
+canonical polar order `meromorphicPolarOrderAt f s` — pinned, not existentially chosen, so it is
 provable (`1` at a simple pole). -/
-theorem mero_laurent_data_exists {f : ℂ → ℂ} {s : ℂ} (hMero : MeromorphicAt f s) :
-    ∃ (a : Fin (meroPolarOrderAt hMero) → ℂ) (g : ℂ → ℂ),
+theorem exists_laurent_data_of_meromorphicAt {f : ℂ → ℂ} {s : ℂ} (hMero : MeromorphicAt f s) :
+    ∃ (a : Fin (meromorphicPolarOrderAt f s) → ℂ) (g : ℂ → ℂ),
       AnalyticAt ℂ g s ∧
       ∀ᶠ z in 𝓝[≠] s,
-        f z = g z + ∑ k : Fin (meroPolarOrderAt hMero), a k / (z - s) ^ (k.val + 1) := by
+        f z = g z + ∑ k : Fin (meromorphicPolarOrderAt f s), a k / (z - s) ^ (k.val + 1) := by
   obtain ⟨g₀, hg₀_an, hg₀_eq⟩ := exists_zpow_factor_at_canonical_order hMero
   exact laurent_data_of_zpow_factor _ hg₀_an hg₀_eq
 
 /-- The `k`-th canonical Laurent coefficient of `f` at `s`. -/
-def meroPolarCoeffAt {f : ℂ → ℂ} {s : ℂ} (hMero : MeromorphicAt f s)
-    (k : Fin (meroPolarOrderAt hMero)) : ℂ :=
-  (mero_laurent_data_exists hMero).choose k
+def meromorphicPolarCoeffAt {f : ℂ → ℂ} {s : ℂ} (hMero : MeromorphicAt f s)
+    (k : Fin (meromorphicPolarOrderAt f s)) : ℂ :=
+  (exists_laurent_data_of_meromorphicAt hMero).choose k
 
 /-- The canonical finite polar part of `f` at `s`: the Laurent tail of length
-`meroPolarOrderAt hMero`. -/
-def meroPolarPartAt {f : ℂ → ℂ} {s : ℂ} (hMero : MeromorphicAt f s) (z : ℂ) : ℂ :=
-  ∑ k : Fin (meroPolarOrderAt hMero), meroPolarCoeffAt hMero k / (z - s) ^ (k.val + 1)
+`meromorphicPolarOrderAt f s`. -/
+def meromorphicPolarPartAt {f : ℂ → ℂ} {s : ℂ} (hMero : MeromorphicAt f s) (z : ℂ) : ℂ :=
+  ∑ k : Fin (meromorphicPolarOrderAt f s), meromorphicPolarCoeffAt hMero k / (z - s) ^ (k.val + 1)
 
 /-- The canonical analytic part of `f` at `s`. -/
-def meroAnalyticPartAt {f : ℂ → ℂ} {s : ℂ} (hMero : MeromorphicAt f s) : ℂ → ℂ :=
-  (mero_laurent_data_exists hMero).choose_spec.choose
+def meromorphicAnalyticPartAt {f : ℂ → ℂ} {s : ℂ} (hMero : MeromorphicAt f s) : ℂ → ℂ :=
+  (exists_laurent_data_of_meromorphicAt hMero).choose_spec.choose
 
 /-- The analytic part is analytic at `s`. -/
-theorem meroAnalyticPartAt_analyticAt {f : ℂ → ℂ} {s : ℂ}
-    (hMero : MeromorphicAt f s) : AnalyticAt ℂ (meroAnalyticPartAt hMero) s :=
-  (mero_laurent_data_exists hMero).choose_spec.choose_spec.1
+theorem meromorphicAnalyticPartAt_analyticAt {f : ℂ → ℂ} {s : ℂ}
+    (hMero : MeromorphicAt f s) : AnalyticAt ℂ (meromorphicAnalyticPartAt hMero) s :=
+  (exists_laurent_data_of_meromorphicAt hMero).choose_spec.choose_spec.1
 
 /-- **The canonical Laurent decomposition**: near `s`, `f` is the analytic part plus the polar
 part. -/
-theorem eventuallyEq_meroAnalyticPartAt_add_meroPolarPartAt {f : ℂ → ℂ} {s : ℂ}
+theorem eventuallyEq_meromorphicAnalyticPartAt_add_meromorphicPolarPartAt {f : ℂ → ℂ} {s : ℂ}
     (hMero : MeromorphicAt f s) :
-    ∀ᶠ z in 𝓝[≠] s, f z = meroAnalyticPartAt hMero z + meroPolarPartAt hMero z :=
-  (mero_laurent_data_exists hMero).choose_spec.choose_spec.2
+    ∀ᶠ z in 𝓝[≠] s, f z = meromorphicAnalyticPartAt hMero z + meromorphicPolarPartAt hMero z :=
+  (exists_laurent_data_of_meromorphicAt hMero).choose_spec.choose_spec.2
 
 /-- The polar part as its explicit Laurent sum — the characteristic unfolding of
-`meroPolarPartAt`. -/
-theorem meroPolarPartAt_eq_sum {f : ℂ → ℂ} {s : ℂ}
+`meromorphicPolarPartAt`. -/
+theorem meromorphicPolarPartAt_eq_sum {f : ℂ → ℂ} {s : ℂ}
     (hMero : MeromorphicAt f s) (z : ℂ) :
-    meroPolarPartAt hMero z =
-      ∑ k : Fin (meroPolarOrderAt hMero),
-        meroPolarCoeffAt hMero k / (z - s) ^ (k.val + 1) := by
-  unfold meroPolarPartAt
+    meromorphicPolarPartAt hMero z =
+      ∑ k : Fin (meromorphicPolarOrderAt f s),
+        meromorphicPolarCoeffAt hMero k / (z - s) ^ (k.val + 1) := by
+  unfold meromorphicPolarPartAt
   rfl
 
-/-- The polar part is differentiable away from its pole. -/
-theorem meroPolarPartAt_differentiableAt {f : ℂ → ℂ} {s : ℂ}
-    (hMero : MeromorphicAt f s) {z : ℂ} (hz : z ≠ s) :
-    DifferentiableAt ℂ (meroPolarPartAt hMero) z := by
-  unfold meroPolarPartAt
-  refine DifferentiableAt.fun_sum fun k _ => ?_
-  exact (differentiableAt_const _).div
-    ((differentiableAt_id.sub (differentiableAt_const _)).pow _)
-    (pow_ne_zero _ (sub_ne_zero.mpr hz))
-
 /-- The polar part is analytic away from its pole. -/
-theorem meroPolarPartAt_analyticAt_of_ne {f : ℂ → ℂ} {s : ℂ}
+theorem meromorphicPolarPartAt_analyticAt_of_ne {f : ℂ → ℂ} {s : ℂ}
     (hMero : MeromorphicAt f s) {w : ℂ} (hw : w ≠ s) :
-    AnalyticAt ℂ (meroPolarPartAt hMero) w := by
-  unfold meroPolarPartAt
+    AnalyticAt ℂ (meromorphicPolarPartAt hMero) w := by
+  unfold meromorphicPolarPartAt
   refine Finset.analyticAt_fun_sum _ fun k _ => ?_
   exact analyticAt_const.div ((analyticAt_id.sub analyticAt_const).pow _)
     (pow_ne_zero _ (sub_ne_zero.mpr hw))
 
 /-- **The leading canonical Laurent coefficient is the residue.** -/
-theorem meroPolarCoeffAt_zero_eq_residue {f : ℂ → ℂ} {s : ℂ}
-    (hMero : MeromorphicAt f s) (h_pos : 0 < meroPolarOrderAt hMero) :
-    meroPolarCoeffAt hMero ⟨0, h_pos⟩ = residue f s := by
+theorem meromorphicPolarCoeffAt_zero_eq_residue {f : ℂ → ℂ} {s : ℂ}
+    (hMero : MeromorphicAt f s) (h_pos : 0 < meromorphicPolarOrderAt f s) :
+    meromorphicPolarCoeffAt hMero ⟨0, h_pos⟩ = residue f s := by
   have hres := residue_of_laurent_expansion
-    (mero_laurent_data_exists hMero).choose_spec.choose_spec.1
-    (mero_laurent_data_exists hMero).choose_spec.choose_spec.2
+    (exists_laurent_data_of_meromorphicAt hMero).choose_spec.choose_spec.1
+    (exists_laurent_data_of_meromorphicAt hMero).choose_spec.choose_spec.2
   rw [dif_pos h_pos] at hres
   exact hres.symm
 

--- a/TauCeti/Analysis/Contour/MeromorphicLaurent.lean
+++ b/TauCeti/Analysis/Contour/MeromorphicLaurent.lean
@@ -1,0 +1,278 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Chris Birkbeck
+-/
+module
+
+public import TauCeti.Analysis.Contour.Residue
+
+/-!
+# Canonical Laurent data of a meromorphic function
+
+For `f` meromorphic at `s`, this file extracts its **canonical Laurent data**: the polar order
+`meroPolarOrderAt` — computed from `meromorphicOrderAt`, not chosen — together with Laurent
+coefficients, the finite polar part, and the analytic part, satisfying
+`f = analytic part + ∑ k, coeff k / (z - s)^(k+1)` near `s`. Because the tail length is the
+computable canonical order, downstream facts about it are provable (it is `1` at a simple pole)
+rather than opaque to a `Classical.choose` witness — which is what lets condition (A′) of the
+generalized residue theorem be discharged at simple poles by flatness of order one.
+
+## Main definitions
+
+* `Contour.meroPolarOrderAt hMero` — the canonical polar order: the negative part of
+  `meromorphicOrderAt f s` (`0` at an analytic-or-removable point).
+* `Contour.meroPolarCoeffAt hMero k` — the `k`-th Laurent coefficient at `s`.
+* `Contour.meroPolarPartAt hMero` — the finite polar part `∑ k, coeff k / (z - s)^(k+1)`.
+* `Contour.meroAnalyticPartAt hMero` — the analytic part at `s`.
+
+## Main results
+
+* `Contour.mero_laurent_data_exists` — the Laurent decomposition with tail length pinned to the
+  canonical order.
+* `Contour.eventuallyEq_meroAnalyticPartAt_add_meroPolarPartAt` — `f` equals analytic part plus
+  polar part near `s`.
+* `Contour.meroPolarPartAt_eq_sum` — the polar part as its explicit Laurent sum.
+* `Contour.meroPolarCoeffAt_zero_eq_residue` — the leading coefficient is the residue.
+* `Contour.meroPolarOrderAt_eq_one` — the canonical order at a simple pole is `1`.
+
+## Provenance
+
+Migrated from the per-point Laurent-extraction block of
+`HungerbuhlerWasem/LaurentExtraction.lean` in the AINTLIB `LeanModularForms` development
+(`meroPolarOrderAt` through `meroPolarCoeffAt_zero_eq_residue`); the residue identification is
+by `Contour.residue_of_laurent_expansion` against the Taylor-coefficient residue. See
+N. Hungerbühler, M. Wasem, *Non-integer valued winding numbers and a generalized Residue
+Theorem*, arXiv:1808.00997, §3.
+-/
+
+public section
+
+noncomputable section
+
+namespace TauCeti.Contour
+
+open Filter Set Topology
+
+/-- **The canonical polar order** of a meromorphic function at `s`: the negative part of
+`meromorphicOrderAt f s`. For a pole of order `k` this is `k` (in particular `1` at a simple
+pole, `meroPolarOrderAt_eq_one`); at an analytic-or-removable point — including locally
+vanishing `f` — it is `0`. Computed from `f` alone, so callers can evaluate it, unlike a
+`Classical.choose`-extracted tail length. -/
+def meroPolarOrderAt {f : ℂ → ℂ} {s : ℂ} (_hMero : MeromorphicAt f s) : ℕ :=
+  (-(meromorphicOrderAt f s).untop₀).toNat
+
+/-- The canonical polar order, computed from `meromorphicOrderAt`. -/
+theorem meroPolarOrderAt_eq_of_order_eq {f : ℂ → ℂ} {s : ℂ}
+    (hMero : MeromorphicAt f s) {n : ℤ} (h : meromorphicOrderAt f s = n) :
+    meroPolarOrderAt hMero = (-n).toNat := by
+  rw [meroPolarOrderAt, h, WithTop.untop₀_coe]
+
+/-- **At a simple pole the canonical polar order is `1`.** With flatness of order one
+(`IsPwC1ImmersionOn.flatOfOrder_one`), this discharges condition (A′) of the generalized residue
+theorem at simple poles. -/
+theorem meroPolarOrderAt_eq_one {f : ℂ → ℂ} {s : ℂ}
+    (hMero : MeromorphicAt f s) (h : meromorphicOrderAt f s = -1) :
+    meroPolarOrderAt hMero = 1 := by
+  rw [meroPolarOrderAt_eq_of_order_eq hMero h]
+  rfl
+
+/-- Peel one vanishing factor off an analytic function: `g z = g s + (z - s) * g₁ z` with `g₁`
+analytic at `s`. -/
+private theorem analyticAt_peel_one {g : ℂ → ℂ} {s : ℂ} (hg : AnalyticAt ℂ g s) :
+    ∃ g₁ : ℂ → ℂ, AnalyticAt ℂ g₁ s ∧
+      ∀ᶠ z in 𝓝 s, g z = g s + (z - s) * g₁ z := by
+  have h_diff : AnalyticAt ℂ (fun z => g z - g s) s := hg.sub analyticAt_const
+  have h_value : (fun z => g z - g s) s = 0 := by simp
+  have h_ord_ne : analyticOrderAt (fun z => g z - g s) s ≠ 0 := fun h_eq =>
+    (h_diff.analyticOrderAt_eq_zero).mp h_eq h_value
+  have h_ge : (1 : ℕ∞) ≤ analyticOrderAt (fun z => g z - g s) s :=
+    Order.one_le_iff_ne_zero.mpr h_ord_ne
+  obtain ⟨g₁, hg₁_an, hg₁_eq⟩ :=
+    (natCast_le_analyticOrderAt h_diff).mp (by exact_mod_cast h_ge)
+  refine ⟨g₁, hg₁_an, ?_⟩
+  filter_upwards [hg₁_eq] with z hz
+  have heq : g z - g s = (z - s) * g₁ z := by simpa using hz
+  linear_combination heq
+
+/-- Taylor decomposition of an analytic function to order `k`:
+`g z = ∑ j < k, c j * (z - s)^j + (z - s)^k * R z` with `R` analytic at `s`. -/
+private theorem analyticAt_taylor_decomp {g : ℂ → ℂ} {s : ℂ}
+    (hg : AnalyticAt ℂ g s) (k : ℕ) :
+    ∃ (c : Fin k → ℂ) (R : ℂ → ℂ), AnalyticAt ℂ R s ∧
+      ∀ᶠ z in 𝓝 s, g z = (∑ j : Fin k, c j * (z - s) ^ j.val) + (z - s) ^ k * R z := by
+  induction k with
+  | zero =>
+      refine ⟨Fin.elim0, g, hg, ?_⟩
+      filter_upwards with z
+      simp
+  | succ k ih =>
+      obtain ⟨c, R, hR_an, hR_eq⟩ := ih
+      obtain ⟨R', hR'_an, hR'_eq⟩ := analyticAt_peel_one hR_an
+      refine ⟨Fin.snoc c (R s), R', hR'_an, ?_⟩
+      filter_upwards [hR_eq, hR'_eq] with z hR_eq_z hR'_eq_z
+      rw [hR_eq_z, hR'_eq_z, Fin.sum_univ_castSucc]
+      simp only [Fin.snoc_castSucc, Fin.snoc_last, Fin.val_last, Fin.val_castSucc]
+      ring
+
+private theorem pow_div_pow_neg {w : ℂ} (hw : w ≠ 0) {k j : ℕ} (hjk : j < k) :
+    w ^ j * (w ^ k)⁻¹ = (w ^ (k - j))⁻¹ := by
+  have h_exp : (k - j) + j = k := by omega
+  rw [show (w ^ k)⁻¹ = (w ^ ((k - j) + j))⁻¹ by rw [h_exp], pow_add]
+  field_simp
+
+private theorem reindex_sum_fin_neg {k : ℕ} (c : Fin k → ℂ) (w : ℂ) :
+    (∑ j : Fin k, c j / w ^ (k - j.val)) =
+      ∑ i : Fin k,
+        c ⟨k - 1 - i.val, by have := i.isLt; omega⟩ / w ^ (i.val + 1) := by
+  let σ : Fin k → Fin k := fun j => ⟨k - 1 - j.val, by have := j.isLt; omega⟩
+  have hσ_invol : Function.Involutive σ := fun j => by
+    ext
+    have := j.isLt
+    simp only [σ]
+    omega
+  have h_sum_eq : (∑ i : Fin k, c (σ i) / w ^ (k - (σ i).val)) =
+      ∑ j : Fin k, c j / w ^ (k - j.val) :=
+    Equiv.sum_comp ⟨σ, σ, hσ_invol.leftInverse, hσ_invol.rightInverse⟩
+      (fun j => c j / w ^ (k - j.val))
+  rw [← h_sum_eq]
+  refine Finset.sum_congr rfl fun i _ => ?_
+  congr 2
+  simp only [σ]
+  omega
+
+/-- Laurent data of length exactly `k` from a `(z - s)^(-k)`-factorisation with analytic
+cofactor: Taylor-expand the cofactor to order `k` and divide. -/
+private theorem laurent_data_of_zpow_factor {f g₀ : ℂ → ℂ} {s : ℂ} (k : ℕ)
+    (hg₀_an : AnalyticAt ℂ g₀ s)
+    (hg₀_eq : ∀ᶠ z in 𝓝[≠] s, f z = (z - s) ^ (-(k : ℤ)) • g₀ z) :
+    ∃ (a : Fin k → ℂ) (g : ℂ → ℂ),
+      AnalyticAt ℂ g s ∧
+      ∀ᶠ z in 𝓝[≠] s, f z = g z + ∑ i : Fin k, a i / (z - s) ^ (i.val + 1) := by
+  obtain ⟨c, R, hR_an, hR_eq⟩ := analyticAt_taylor_decomp hg₀_an k
+  refine ⟨fun i : Fin k => c ⟨k - 1 - i.val, by have := i.isLt; omega⟩, R, hR_an, ?_⟩
+  filter_upwards [hg₀_eq, nhdsWithin_le_nhds hR_eq, self_mem_nhdsWithin]
+    with z hf_eq hR_eq_z hz_ne
+  have hz_sub : (z - s) ≠ 0 := sub_ne_zero.mpr hz_ne
+  rw [hf_eq, hR_eq_z, smul_eq_mul, zpow_neg, zpow_natCast, mul_add]
+  have h1 : ((z - s) ^ k)⁻¹ * ((z - s) ^ k * R z) = R z := by field_simp
+  rw [h1, add_comm]
+  congr 1
+  rw [Finset.mul_sum, show ∑ j : Fin k, ((z - s) ^ k)⁻¹ * (c j * (z - s) ^ j.val) =
+      ∑ j : Fin k, c j / (z - s) ^ (k - j.val) from
+    Finset.sum_congr rfl fun j _ => by
+      rw [div_eq_mul_inv, show ((z - s) ^ k)⁻¹ * (c j * (z - s) ^ j.val) =
+          c j * ((z - s) ^ j.val * ((z - s) ^ k)⁻¹) by ring,
+        pow_div_pow_neg hz_sub j.isLt]]
+  exact reindex_sum_fin_neg c (z - s)
+
+/-- Factorisation of a meromorphic `f` at the canonical polar order:
+`f = (z - s)^(-meroPolarOrderAt) • g₀` near `s` with `g₀` analytic (nonnegative powers of
+`z - s` are absorbed into the cofactor; `g₀ = 0` when `f` vanishes near `s`). -/
+private theorem exists_zpow_factor_at_canonical_order {f : ℂ → ℂ} {s : ℂ}
+    (hMero : MeromorphicAt f s) :
+    ∃ g₀ : ℂ → ℂ, AnalyticAt ℂ g₀ s ∧
+      ∀ᶠ z in 𝓝[≠] s, f z = (z - s) ^ (-(meroPolarOrderAt hMero : ℤ)) • g₀ z := by
+  by_cases h_top : meromorphicOrderAt f s = ⊤
+  · have h0 : meroPolarOrderAt hMero = 0 := by
+      rw [meroPolarOrderAt, h_top, WithTop.untop₀_top, neg_zero, Int.toNat_zero]
+    refine ⟨fun _ => 0, analyticAt_const, ?_⟩
+    filter_upwards [meromorphicOrderAt_eq_top_iff.mp h_top] with z hz
+    rw [hz, smul_zero]
+  · obtain ⟨n, h_ord⟩ := WithTop.ne_top_iff_exists.mp h_top
+    obtain ⟨g, hg_an, _, hg_eq⟩ := (meromorphicOrderAt_eq_int_iff hMero).mp h_ord.symm
+    have h_val : (meroPolarOrderAt hMero : ℤ) = max (-n) 0 := by
+      rw [meroPolarOrderAt_eq_of_order_eq hMero h_ord.symm]
+      omega
+    rcases le_or_gt 0 n with hn | hn
+    · -- no pole: absorb `(z - s)^n` into the analytic cofactor
+      refine ⟨fun z => (z - s) ^ n.toNat * g z,
+        ((analyticAt_id.sub analyticAt_const).pow _).mul hg_an, ?_⟩
+      filter_upwards [hg_eq] with z hz
+      rw [hz, show -(meroPolarOrderAt hMero : ℤ) = 0 by omega, zpow_zero, one_smul,
+        smul_eq_mul, show n = (n.toNat : ℤ) by omega, zpow_natCast, Int.toNat_natCast]
+    · -- a pole of order `-n = meroPolarOrderAt hMero`
+      refine ⟨g, hg_an, ?_⟩
+      rw [show -(meroPolarOrderAt hMero : ℤ) = n by omega]
+      exact hg_eq
+
+/-- **Canonical Laurent data of a meromorphic function**: near `s`,
+`f = g + ∑ k, a k / (z - s)^(k+1)` with `g` analytic at `s`, where the tail length is the
+canonical polar order `meroPolarOrderAt hMero` — pinned, not existentially chosen, so it is
+provable (`1` at a simple pole). -/
+theorem mero_laurent_data_exists {f : ℂ → ℂ} {s : ℂ} (hMero : MeromorphicAt f s) :
+    ∃ (a : Fin (meroPolarOrderAt hMero) → ℂ) (g : ℂ → ℂ),
+      AnalyticAt ℂ g s ∧
+      ∀ᶠ z in 𝓝[≠] s,
+        f z = g z + ∑ k : Fin (meroPolarOrderAt hMero), a k / (z - s) ^ (k.val + 1) := by
+  obtain ⟨g₀, hg₀_an, hg₀_eq⟩ := exists_zpow_factor_at_canonical_order hMero
+  exact laurent_data_of_zpow_factor _ hg₀_an hg₀_eq
+
+/-- The `k`-th canonical Laurent coefficient of `f` at `s`. -/
+def meroPolarCoeffAt {f : ℂ → ℂ} {s : ℂ} (hMero : MeromorphicAt f s)
+    (k : Fin (meroPolarOrderAt hMero)) : ℂ :=
+  (mero_laurent_data_exists hMero).choose k
+
+/-- The canonical finite polar part of `f` at `s`: the Laurent tail of length
+`meroPolarOrderAt hMero`. -/
+def meroPolarPartAt {f : ℂ → ℂ} {s : ℂ} (hMero : MeromorphicAt f s) (z : ℂ) : ℂ :=
+  ∑ k : Fin (meroPolarOrderAt hMero), meroPolarCoeffAt hMero k / (z - s) ^ (k.val + 1)
+
+/-- The canonical analytic part of `f` at `s`. -/
+def meroAnalyticPartAt {f : ℂ → ℂ} {s : ℂ} (hMero : MeromorphicAt f s) : ℂ → ℂ :=
+  (mero_laurent_data_exists hMero).choose_spec.choose
+
+/-- The analytic part is analytic at `s`. -/
+theorem meroAnalyticPartAt_analyticAt {f : ℂ → ℂ} {s : ℂ}
+    (hMero : MeromorphicAt f s) : AnalyticAt ℂ (meroAnalyticPartAt hMero) s :=
+  (mero_laurent_data_exists hMero).choose_spec.choose_spec.1
+
+/-- **The canonical Laurent decomposition**: near `s`, `f` is the analytic part plus the polar
+part. -/
+theorem eventuallyEq_meroAnalyticPartAt_add_meroPolarPartAt {f : ℂ → ℂ} {s : ℂ}
+    (hMero : MeromorphicAt f s) :
+    ∀ᶠ z in 𝓝[≠] s, f z = meroAnalyticPartAt hMero z + meroPolarPartAt hMero z :=
+  (mero_laurent_data_exists hMero).choose_spec.choose_spec.2
+
+/-- The polar part as its explicit Laurent sum — the characteristic unfolding of
+`meroPolarPartAt`. -/
+theorem meroPolarPartAt_eq_sum {f : ℂ → ℂ} {s : ℂ}
+    (hMero : MeromorphicAt f s) (z : ℂ) :
+    meroPolarPartAt hMero z =
+      ∑ k : Fin (meroPolarOrderAt hMero),
+        meroPolarCoeffAt hMero k / (z - s) ^ (k.val + 1) := by
+  unfold meroPolarPartAt
+  rfl
+
+/-- The polar part is differentiable away from its pole. -/
+theorem meroPolarPartAt_differentiableAt {f : ℂ → ℂ} {s : ℂ}
+    (hMero : MeromorphicAt f s) {z : ℂ} (hz : z ≠ s) :
+    DifferentiableAt ℂ (meroPolarPartAt hMero) z := by
+  unfold meroPolarPartAt
+  refine DifferentiableAt.fun_sum fun k _ => ?_
+  exact (differentiableAt_const _).div
+    ((differentiableAt_id.sub (differentiableAt_const _)).pow _)
+    (pow_ne_zero _ (sub_ne_zero.mpr hz))
+
+/-- The polar part is analytic away from its pole. -/
+theorem meroPolarPartAt_analyticAt_of_ne {f : ℂ → ℂ} {s : ℂ}
+    (hMero : MeromorphicAt f s) {w : ℂ} (hw : w ≠ s) :
+    AnalyticAt ℂ (meroPolarPartAt hMero) w := by
+  unfold meroPolarPartAt
+  refine Finset.analyticAt_fun_sum _ fun k _ => ?_
+  exact analyticAt_const.div ((analyticAt_id.sub analyticAt_const).pow _)
+    (pow_ne_zero _ (sub_ne_zero.mpr hw))
+
+/-- **The leading canonical Laurent coefficient is the residue.** -/
+theorem meroPolarCoeffAt_zero_eq_residue {f : ℂ → ℂ} {s : ℂ}
+    (hMero : MeromorphicAt f s) (h_pos : 0 < meroPolarOrderAt hMero) :
+    meroPolarCoeffAt hMero ⟨0, h_pos⟩ = residue f s := by
+  have hres := residue_of_laurent_expansion
+    (mero_laurent_data_exists hMero).choose_spec.choose_spec.1
+    (mero_laurent_data_exists hMero).choose_spec.choose_spec.2
+  rw [dif_pos h_pos] at hres
+  exact hres.symm
+
+end TauCeti.Contour
+
+end

--- a/TauCeti/Analysis/Contour/MeromorphicLaurent.lean
+++ b/TauCeti/Analysis/Contour/MeromorphicLaurent.lean
@@ -161,36 +161,6 @@ private theorem laurent_data_of_zpow_factor {f g₀ : ℂ → ℂ} {s : ℂ} (k 
         pow_div_pow_neg hz_sub j.isLt]]
   exact reindex_sum_fin_neg c (z - s)
 
-/-- Factorisation of a meromorphic `f` at the canonical polar order:
-`f = (z - s)^(-meromorphicPolarOrderAt) • g₀` near `s` with `g₀` analytic (nonnegative powers of
-`z - s` are absorbed into the cofactor; `g₀ = 0` when `f` vanishes near `s`). -/
-private theorem exists_zpow_factor_at_canonical_order {f : ℂ → ℂ} {s : ℂ}
-    (hMero : MeromorphicAt f s) :
-    ∃ g₀ : ℂ → ℂ, AnalyticAt ℂ g₀ s ∧
-      ∀ᶠ z in 𝓝[≠] s, f z = (z - s) ^ (-(meromorphicPolarOrderAt f s : ℤ)) • g₀ z := by
-  by_cases h_top : meromorphicOrderAt f s = ⊤
-  · have h0 : meromorphicPolarOrderAt f s = 0 := by
-      rw [meromorphicPolarOrderAt, h_top, WithTop.untop₀_top, neg_zero, Int.toNat_zero]
-    refine ⟨fun _ => 0, analyticAt_const, ?_⟩
-    filter_upwards [meromorphicOrderAt_eq_top_iff.mp h_top] with z hz
-    rw [hz, smul_zero]
-  · obtain ⟨n, h_ord⟩ := WithTop.ne_top_iff_exists.mp h_top
-    obtain ⟨g, hg_an, _, hg_eq⟩ := (meromorphicOrderAt_eq_int_iff hMero).mp h_ord.symm
-    have h_val : (meromorphicPolarOrderAt f s : ℤ) = max (-n) 0 := by
-      rw [meromorphicPolarOrderAt_eq_of_order_eq h_ord.symm]
-      omega
-    rcases le_or_gt 0 n with hn | hn
-    · -- no pole: absorb `(z - s)^n` into the analytic cofactor
-      refine ⟨fun z => (z - s) ^ n.toNat * g z,
-        ((analyticAt_id.sub analyticAt_const).pow _).mul hg_an, ?_⟩
-      filter_upwards [hg_eq] with z hz
-      rw [hz, show -(meromorphicPolarOrderAt f s : ℤ) = 0 by omega, zpow_zero, one_smul,
-        smul_eq_mul, show n = (n.toNat : ℤ) by omega, zpow_natCast, Int.toNat_natCast]
-    · -- a pole of order `-n = meromorphicPolarOrderAt f s`
-      refine ⟨g, hg_an, ?_⟩
-      rw [show -(meromorphicPolarOrderAt f s : ℤ) = n by omega]
-      exact hg_eq
-
 /-- **Canonical Laurent data of a meromorphic function**: near `s`,
 `f = g + ∑ k, a k / (z - s)^(k+1)` with `g` analytic at `s`, where the tail length is the
 canonical polar order `meromorphicPolarOrderAt f s` — pinned, not existentially chosen, so it is
@@ -200,7 +170,15 @@ theorem exists_laurent_data_of_meromorphicAt {f : ℂ → ℂ} {s : ℂ} (hMero 
       AnalyticAt ℂ g s ∧
       ∀ᶠ z in 𝓝[≠] s,
         f z = g z + ∑ k : Fin (meromorphicPolarOrderAt f s), a k / (z - s) ^ (k.val + 1) := by
-  obtain ⟨g₀, hg₀_an, hg₀_eq⟩ := exists_zpow_factor_at_canonical_order hMero
+  have hm : (-(meromorphicPolarOrderAt f s : ℤ) : WithTop ℤ) ≤ meromorphicOrderAt f s := by
+    rcases eq_or_ne (meromorphicOrderAt f s) ⊤ with h | h
+    · rw [h]; exact le_top
+    · rw [← WithTop.coe_untop₀_of_ne_top h]
+      rw [show (-(meromorphicPolarOrderAt f s : ℤ) : WithTop ℤ) =
+          ((-(meromorphicPolarOrderAt f s : ℤ) : ℤ) : WithTop ℤ) by push_cast; ring,
+        WithTop.coe_le_coe, meromorphicPolarOrderAt]
+      omega
+  obtain ⟨g₀, hg₀_an, hg₀_eq⟩ := exists_analyticAt_eventuallyEq_zpow_smul hMero hm
   exact laurent_data_of_zpow_factor _ hg₀_an hg₀_eq
 
 /-- The `k`-th canonical Laurent coefficient of `f` at `s`. -/

--- a/TauCeti/Analysis/Contour/Residue.lean
+++ b/TauCeti/Analysis/Contour/Residue.lean
@@ -272,8 +272,9 @@ theorem residue_eq_of_eventuallyEq_zpow_smul {f g : ℂ → ℂ} {z₀ : ℂ} {n
 /-- Any meromorphic `f` admits an analytic presentation `f z = (z − z₀) ^ m • φ z` near `z₀` at any
 exponent `m` at or below its meromorphic order (padding the reduced presentation with a nonnegative
 power of `z − z₀`). The factor `φ` is analytic but may vanish at `z₀` when `m` is strictly below the
-order. Used to bring two meromorphic functions to a common exponent before adding their residues. -/
-private lemma exists_analyticAt_eventuallyEq_zpow_smul {f : ℂ → ℂ} {z₀ : ℂ} {m : ℤ}
+order. Brings two meromorphic functions to a common exponent before adding their residues, and is
+the factorisation entry point for the canonical Laurent data (`MeromorphicLaurent.lean`). -/
+lemma exists_analyticAt_eventuallyEq_zpow_smul {f : ℂ → ℂ} {z₀ : ℂ} {m : ℤ}
     (hf : MeromorphicAt f z₀) (hm : (m : WithTop ℤ) ≤ meromorphicOrderAt f z₀) :
     ∃ φ : ℂ → ℂ, AnalyticAt ℂ φ z₀ ∧ f =ᶠ[𝓝[≠] z₀] fun z => (z - z₀) ^ m • φ z := by
   rcases eq_or_ne (meromorphicOrderAt f z₀) ⊤ with htop | htop


### PR DESCRIPTION
## What

The **canonical Laurent data** of `f` meromorphic at `s`, in one new file `TauCeti/Analysis/Contour/MeromorphicLaurent.lean`: the polar order `meroPolarOrderAt` — computed as the negative part of `meromorphicOrderAt`, not `Classical.choose`-extracted, so it is provable (`meroPolarOrderAt_eq_one` at a simple pole) — with the Laurent coefficients `meroPolarCoeffAt`, the finite polar part `meroPolarPartAt` (analytic away from its pole), and the analytic part `meroAnalyticPartAt`, satisfying `f = analytic part + ∑ k, coeff k / (z - s)^(k+1)` near `s` (`mero_laurent_data_exists`, `eventuallyEq_meroAnalyticPartAt_add_meroPolarPartAt`), and the leading coefficient identified with the residue (`meroPolarCoeffAt_zero_eq_residue`, by #926's `residue_of_laurent_expansion`).

## Why

This is the per-point data from which the `PolarPartDecomposition` (#924) of a meromorphic integrand is assembled over its singular set — the constructor is the next chain step, its `residue_eq` field discharged by the leading-coefficient lemma here and its `order` field evaluable via the canonical order. The computability of the order is load-bearing: it is what lets condition (A′) of the generalized residue theorem be discharged at simple poles by flatness of order one (#922) rather than assumed.

## Provenance

Migrated from the per-point Laurent-extraction block of `HungerbuhlerWasem/LaurentExtraction.lean` in the AINTLIB `LeanModularForms` development, with the residue identification re-based on `Contour.residue`'s Taylor-coefficient definition. See N. Hungerbühler, M. Wasem, *Non-integer valued winding numbers and a generalized Residue Theorem*, arXiv:1808.00997, §3.

🤖 Generated with [Claude Code](https://claude.com/claude-code)