### PR TITLE
feat(Analysis/Contour): polar-part decomposition of a meromorphic integrand

### DIFF
--- a/TauCeti/Analysis/Contour/MeromorphicLaurent.lean
+++ b/TauCeti/Analysis/Contour/MeromorphicLaurent.lean
@@ -78,6 +78,19 @@ theorem meromorphicPolarOrderAt_eq_one {f : ℂ → ℂ} {s : ℂ}
   rw [meromorphicPolarOrderAt_eq_of_order_eq h]
   rfl
 
+/-- The canonical polar order bounds the meromorphic order from below:
+`-(meromorphicPolarOrderAt f s) ≤ meromorphicOrderAt f s`. In particular, polar order `0` means
+the meromorphic order is nonnegative. -/
+theorem neg_meromorphicPolarOrderAt_le (f : ℂ → ℂ) (s : ℂ) :
+    (-(meromorphicPolarOrderAt f s : ℤ) : WithTop ℤ) ≤ meromorphicOrderAt f s := by
+  rcases eq_or_ne (meromorphicOrderAt f s) ⊤ with h | h
+  · rw [h]; exact le_top
+  · rw [← WithTop.coe_untop₀_of_ne_top h]
+    rw [show (-(meromorphicPolarOrderAt f s : ℤ) : WithTop ℤ) =
+        ((-(meromorphicPolarOrderAt f s : ℤ) : ℤ) : WithTop ℤ) by push_cast; ring,
+      WithTop.coe_le_coe, meromorphicPolarOrderAt]
+    omega
+
 /-- Taylor decomposition of an analytic function to order `k`:
 `g z = ∑ j < k, c j * (z - s)^j + (z - s)^k * R z` with `R` analytic at `s`. Mathlib's
 `AnalyticAt.exists_eventuallyEq_sum_add_pow_mul` at the translate `g (· + s)`. -/
@@ -170,15 +183,8 @@ theorem exists_laurent_data_of_meromorphicAt {f : ℂ → ℂ} {s : ℂ} (hMero 
       AnalyticAt ℂ g s ∧
       ∀ᶠ z in 𝓝[≠] s,
         f z = g z + ∑ k : Fin (meromorphicPolarOrderAt f s), a k / (z - s) ^ (k.val + 1) := by
-  have hm : (-(meromorphicPolarOrderAt f s : ℤ) : WithTop ℤ) ≤ meromorphicOrderAt f s := by
-    rcases eq_or_ne (meromorphicOrderAt f s) ⊤ with h | h
-    · rw [h]; exact le_top
-    · rw [← WithTop.coe_untop₀_of_ne_top h]
-      rw [show (-(meromorphicPolarOrderAt f s : ℤ) : WithTop ℤ) =
-          ((-(meromorphicPolarOrderAt f s : ℤ) : ℤ) : WithTop ℤ) by push_cast; ring,
-        WithTop.coe_le_coe, meromorphicPolarOrderAt]
-      omega
-  obtain ⟨g₀, hg₀_an, hg₀_eq⟩ := exists_analyticAt_eventuallyEq_zpow_smul hMero hm
+  obtain ⟨g₀, hg₀_an, hg₀_eq⟩ :=
+    exists_analyticAt_eventuallyEq_zpow_smul hMero (neg_meromorphicPolarOrderAt_le f s)
   exact laurent_data_of_zpow_factor _ hg₀_an hg₀_eq
 
 /-- The `k`-th canonical Laurent coefficient of `f` at `s`. -/

--- a/TauCeti/Analysis/Contour/PolarPartDecomposition.lean
+++ b/TauCeti/Analysis/Contour/PolarPartDecomposition.lean
@@ -102,7 +102,7 @@ end PolarPartDecomposition
 
 /-- **The total polar part** over the singular set: the sum of the canonical per-point polar
 parts. -/
-@[expose] def meromorphicPolarPartTotal {f : ℂ → ℂ} {S : Finset ℂ}
+def meromorphicPolarPartTotal {f : ℂ → ℂ} {S : Finset ℂ}
     (hMero : ∀ s ∈ S, MeromorphicAt f s) (z : ℂ) : ℂ :=
   ∑ s ∈ S.attach, meromorphicPolarPartAt (hMero s.1 s.2) z
 
@@ -110,7 +110,9 @@ parts. -/
 theorem meromorphicPolarPartTotal_eq {f : ℂ → ℂ} {S : Finset ℂ}
     (hMero : ∀ s ∈ S, MeromorphicAt f s) (z : ℂ) :
     meromorphicPolarPartTotal hMero z =
-      ∑ s ∈ S.attach, meromorphicPolarPartAt (hMero s.1 s.2) z := rfl
+      ∑ s ∈ S.attach, meromorphicPolarPartAt (hMero s.1 s.2) z := by
+  unfold meromorphicPolarPartTotal
+  rfl
 
 /-- The polar parts of the other poles are analytic at `s`. -/
 private theorem otherPolar_analyticAt {f : ℂ → ℂ} {S : Finset ℂ}
@@ -205,7 +207,7 @@ meromorphic at each `s ∈ S`, the canonical Laurent data assembles into a
 `PolarPartDecomposition f S U`: the orders are the canonical polar orders — so they are
 evaluable by callers, in particular `1` at simple poles — and the analytic remainder is
 `f` minus the total polar part, extended across the poles by its limits. -/
-@[expose] noncomputable def ofMeromorphic {f : ℂ → ℂ} {S : Finset ℂ} {U : Set ℂ} (hU : IsOpen U)
+noncomputable def ofMeromorphic {f : ℂ → ℂ} {S : Finset ℂ} {U : Set ℂ} (hU : IsOpen U)
     (hf : DifferentiableOn ℂ f (U \ (↑S : Set ℂ))) (hMero : ∀ s ∈ S, MeromorphicAt f s) :
     PolarPartDecomposition f S U where
   order s := meromorphicPolarOrderAt f s
@@ -248,21 +250,31 @@ variable {f : ℂ → ℂ} {S : Finset ℂ} {U : Set ℂ} {hU : IsOpen U}
 /-- The constructed order is the canonical polar order — evaluable by callers, in particular
 `1` at simple poles (`meromorphicPolarOrderAt_eq_one`). -/
 @[simp] theorem ofMeromorphic_order (s : S) :
-    (ofMeromorphic hU hf hMero).order s = meromorphicPolarOrderAt f s := rfl
+    (ofMeromorphic hU hf hMero).order s = meromorphicPolarOrderAt f s := by
+  unfold ofMeromorphic
+  rfl
 
-/-- The constructed coefficients are the canonical Laurent coefficients. -/
+/-- The constructed coefficients are the canonical Laurent coefficients, along the index
+identification `ofMeromorphic_order`. -/
 @[simp] theorem ofMeromorphic_coeff (s : S) (k : Fin ((ofMeromorphic hU hf hMero).order s)) :
-    (ofMeromorphic hU hf hMero).coeff s k = meromorphicPolarCoeffAt (hMero s s.2) k := rfl
+    (ofMeromorphic hU hf hMero).coeff s k =
+      meromorphicPolarCoeffAt (hMero s s.2) (Fin.cast (ofMeromorphic_order s) k) := by
+  unfold ofMeromorphic
+  rfl
 
 /-- The constructed polar part is the canonical polar part. -/
 @[simp] theorem ofMeromorphic_polarPart (s : S) (z : ℂ) :
-    (ofMeromorphic hU hf hMero).polarPart s z = meromorphicPolarPartAt (hMero s s.2) z := rfl
+    (ofMeromorphic hU hf hMero).polarPart s z = meromorphicPolarPartAt (hMero s s.2) z := by
+  unfold ofMeromorphic
+  rfl
 
 /-- Off the singular set, the constructed analytic remainder is `f` minus the total polar
 part. -/
 theorem ofMeromorphic_analyticRemainder {z : ℂ} (hz : z ∉ (↑S : Set ℂ)) :
     (ofMeromorphic hU hf hMero).analyticRemainder z =
-      f z - meromorphicPolarPartTotal hMero z := if_neg hz
+      f z - meromorphicPolarPartTotal hMero z := by
+  unfold ofMeromorphic
+  exact if_neg hz
 
 end PolarPartDecomposition
 

--- a/TauCeti/Analysis/Contour/PolarPartDecomposition.lean
+++ b/TauCeti/Analysis/Contour/PolarPartDecomposition.lean
@@ -6,7 +6,7 @@ Authors: Chris Birkbeck
 module
 
 public import TauCeti.Analysis.Contour.HomologyCauchy
-public import TauCeti.Analysis.Contour.Residue
+public import TauCeti.Analysis.Contour.MeromorphicLaurent
 
 /-!
 # Polar-part decompositions
@@ -23,6 +23,10 @@ parts.
 
 * `Contour.PolarPartDecomposition f S U` — the decomposition data: polar parts, orders, Laurent
   coefficients, the residue identification, and the analytic remainder.
+* `Contour.meromorphicPolarPartTotal` — the sum of the canonical per-point polar parts over `S`.
+* `Contour.PolarPartDecomposition.ofMeromorphic` — every `f` differentiable on `U \ S` and
+  meromorphic at each `s ∈ S` has a polar-part decomposition, built from the canonical Laurent
+  data of `MeromorphicLaurent.lean`.
 
 ## Main results
 
@@ -35,8 +39,10 @@ parts.
 The structure is migrated from `PolarPartDecomposition` of `HungerbuhlerWasem.lean` in the
 AINTLIB `LeanModularForms` development; the remainder-integral theorem is its
 `analyticRemainder_contourIntegral_zero`, which there re-runs Dixon's argument inline and here is
-a direct application of `Contour.homologyCauchyTheorem`. See N. Hungerbühler, M. Wasem,
-*Non-integer valued winding numbers and a generalized Residue Theorem*, arXiv:1808.00997, §3.
+a direct application of `Contour.homologyCauchyTheorem`. The constructor is migrated from
+`polarPartDecomposition_of_meromorphic` of `LaurentExtraction.lean` there, with the ℂ-indexed
+case splits replaced by `S`-indexed data throughout. See N. Hungerbühler, M. Wasem, *Non-integer
+valued winding numbers and a generalized Residue Theorem*, arXiv:1808.00997, §3.
 -/
 
 public section
@@ -45,7 +51,7 @@ noncomputable section
 
 namespace TauCeti.Contour
 
-open MeasureTheory Set
+open Filter MeasureTheory Set Topology
 
 open scoped Interval
 
@@ -91,6 +97,144 @@ theorem intervalIntegral_deriv_smul_analyticRemainder_eq_zero
     (hnull : IsNullHomologous γ a b U) :
     ∫ t in a..b, deriv γ t • decomp.analyticRemainder (γ t) = 0 :=
   homologyCauchyTheorem hU γ a b hγ_pc1 hγ hclosed decomp.analyticRemainder_differentiableOn hnull
+
+end PolarPartDecomposition
+
+/-- **The total polar part** over the singular set: the sum of the canonical per-point polar
+parts. -/
+def meromorphicPolarPartTotal {f : ℂ → ℂ} {S : Finset ℂ}
+    (hMero : ∀ s ∈ S, MeromorphicAt f s) (z : ℂ) : ℂ :=
+  ∑ s ∈ S.attach, meromorphicPolarPartAt (hMero s.1 s.2) z
+
+/-- The polar parts of the other poles are analytic at `s`. -/
+private theorem otherPolar_analyticAt {f : ℂ → ℂ} {S : Finset ℂ}
+    (hMero : ∀ s ∈ S, MeromorphicAt f s) {s : ℂ} (_hs : s ∈ S) :
+    AnalyticAt ℂ (fun z => ∑ s' ∈ S.attach.filter (fun s' => s'.1 ≠ s),
+      meromorphicPolarPartAt (hMero s'.1 s'.2) z) s := by
+  refine Finset.analyticAt_fun_sum _ fun s' hs' => ?_
+  exact meromorphicPolarPartAt_analyticAt_of_ne (hMero s'.1 s'.2)
+    ((Finset.mem_filter.mp hs').2).symm
+
+/-- Near each pole, `f` minus the total polar part has an analytic germ: the per-point analytic
+part minus the other poles' (locally analytic) polar parts. -/
+private theorem exists_analyticAt_sub_polarPartTotal {f : ℂ → ℂ} {S : Finset ℂ}
+    (hMero : ∀ s ∈ S, MeromorphicAt f s) {s : ℂ} (hs : s ∈ S) :
+    ∃ g : ℂ → ℂ, AnalyticAt ℂ g s ∧
+      ∀ᶠ z in 𝓝[≠] s, f z - meromorphicPolarPartTotal hMero z = g z := by
+  refine ⟨fun z => meromorphicAnalyticPartAt (hMero s hs) z -
+      ∑ s' ∈ S.attach.filter (fun s' => s'.1 ≠ s),
+        meromorphicPolarPartAt (hMero s'.1 s'.2) z,
+    (meromorphicAnalyticPartAt_analyticAt (hMero s hs)).sub
+      (otherPolar_analyticAt hMero hs), ?_⟩
+  filter_upwards [eventuallyEq_meromorphicAnalyticPartAt_add_meromorphicPolarPartAt
+    (hMero s hs)] with z hz
+  rw [hz]
+  suffices h_total : meromorphicPolarPartTotal hMero z =
+      meromorphicPolarPartAt (hMero s hs) z +
+        ∑ s' ∈ S.attach.filter (fun s' => s'.1 ≠ s),
+          meromorphicPolarPartAt (hMero s'.1 s'.2) z by
+    rw [h_total]
+    ring
+  unfold meromorphicPolarPartTotal
+  rw [← Finset.sum_filter_add_sum_filter_not S.attach (fun s' => s'.1 = s)]
+  congr 1
+  rw [show S.attach.filter (fun s' => s'.1 = s) = {⟨s, hs⟩} from by
+    ext s'
+    simp only [Finset.mem_filter, Finset.mem_attach, true_and, Finset.mem_singleton]
+    exact ⟨fun h => Subtype.ext h, fun h => by rw [h]⟩]
+  rw [Finset.sum_singleton]
+
+/-- Off the singular set, the extended remainder is `f` minus the total polar part. -/
+private theorem remainder_eventuallyEq_off {f : ℂ → ℂ} {S : Finset ℂ}
+    (hMero : ∀ s ∈ S, MeromorphicAt f s) {z : ℂ} (hz : z ∉ (↑S : Set ℂ)) :
+    (fun w => if w ∈ (↑S : Set ℂ) then
+        limUnder (𝓝[≠] w) (fun u => f u - meromorphicPolarPartTotal hMero u)
+      else f w - meromorphicPolarPartTotal hMero w) =ᶠ[𝓝 z]
+      fun w => f w - meromorphicPolarPartTotal hMero w := by
+  filter_upwards [(S.finite_toSet.isClosed.isOpen_compl).mem_nhds hz] with w hw
+  rw [if_neg hw]
+
+/-- A punctured neighbourhood eventually avoids a finite set. -/
+private theorem eventually_notMem_nhdsNE (S : Finset ℂ) (z : ℂ) :
+    ∀ᶠ w in 𝓝[≠] z, w ∉ (↑S : Set ℂ) := by
+  have hcl : IsClosed ((↑S \ {z} : Set ℂ)) := (S.finite_toSet.subset sdiff_subset).isClosed
+  filter_upwards [eventually_nhdsWithin_of_eventually_nhds
+    (hcl.isOpen_compl.mem_nhds (by simp)), self_mem_nhdsWithin] with w hwc hwne hwS
+  exact hwc ⟨hwS, hwne⟩
+
+/-- At a singular point, the limit-patched remainder is differentiable: on a punctured
+neighbourhood it agrees with the analytic germ of `f` minus the total polar part
+(`exists_analyticAt_sub_polarPartTotal`), and at the point itself it takes the germ's value. -/
+private theorem remainder_differentiableAt_mem {f : ℂ → ℂ} {S : Finset ℂ}
+    (hMero : ∀ s ∈ S, MeromorphicAt f s) {z : ℂ} (hzS : z ∈ (↑S : Set ℂ)) :
+    DifferentiableAt ℂ (fun w => if w ∈ (↑S : Set ℂ) then
+        limUnder (𝓝[≠] w) (fun u => f u - meromorphicPolarPartTotal hMero u)
+      else f w - meromorphicPolarPartTotal hMero w) z := by
+  obtain ⟨g, hg_an, hg_eq⟩ := exists_analyticAt_sub_polarPartTotal hMero hzS
+  have h1 : ∀ᶠ w in 𝓝[≠] z, (if w ∈ (↑S : Set ℂ) then
+      limUnder (𝓝[≠] w) (fun u => f u - meromorphicPolarPartTotal hMero u)
+    else f w - meromorphicPolarPartTotal hMero w) = g w := by
+    filter_upwards [eventually_notMem_nhdsNE S z, hg_eq] with w hwS hwg
+    rw [if_neg hwS]
+    exact hwg
+  have h2 : (if z ∈ (↑S : Set ℂ) then
+      limUnder (𝓝[≠] z) (fun u => f u - meromorphicPolarPartTotal hMero u)
+    else f z - meromorphicPolarPartTotal hMero z) = g z := by
+    rw [if_pos hzS]
+    refine Filter.Tendsto.limUnder_eq ?_
+    refine Filter.Tendsto.congr' ?_
+      (hg_an.continuousAt.tendsto.mono_left nhdsWithin_le_nhds)
+    filter_upwards [hg_eq] with u hu using hu.symm
+  have h_full : (fun w => if w ∈ (↑S : Set ℂ) then
+      limUnder (𝓝[≠] w) (fun u => f u - meromorphicPolarPartTotal hMero u)
+    else f w - meromorphicPolarPartTotal hMero w) =ᶠ[𝓝 z] g := by
+    rw [Filter.EventuallyEq, ← nhdsNE_sup_pure z, Filter.eventually_sup]
+    exact ⟨h1, Filter.eventually_pure.mpr h2⟩
+  exact h_full.differentiableAt_iff.mpr hg_an.differentiableAt
+
+namespace PolarPartDecomposition
+
+/-- **The decomposition of a meromorphic integrand.** From `f` differentiable on `U \ S` and
+meromorphic at each `s ∈ S`, the canonical Laurent data assembles into a
+`PolarPartDecomposition f S U`: the orders are the canonical polar orders — so they are
+evaluable by callers, in particular `1` at simple poles — and the analytic remainder is
+`f` minus the total polar part, extended across the poles by its limits. -/
+noncomputable def ofMeromorphic {f : ℂ → ℂ} {S : Finset ℂ} {U : Set ℂ} (hU : IsOpen U)
+    (hf : DifferentiableOn ℂ f (U \ (↑S : Set ℂ))) (hMero : ∀ s ∈ S, MeromorphicAt f s) :
+    PolarPartDecomposition f S U where
+  order s := meromorphicPolarOrderAt f s
+  coeff s k := meromorphicPolarCoeffAt (hMero s s.2) k
+  polarPart s z := meromorphicPolarPartAt (hMero s s.2) z
+  polarPart_eq s z := meromorphicPolarPartAt_eq_sum (hMero s s.2) z
+  residue_eq s := by
+    rcases Nat.eq_zero_or_pos (meromorphicPolarOrderAt f s) with h0 | hpos
+    · rw [dif_neg (by omega)]
+      refine residue_eq_zero_of_meromorphicOrderAt_nonneg ?_
+      have hle := neg_meromorphicPolarOrderAt_le f (s : ℂ)
+      rw [h0] at hle
+      simpa using hle
+    · rw [dif_pos hpos]
+      exact (meromorphicPolarCoeffAt_zero_eq_residue (hMero s s.2) hpos).symm
+  analyticRemainder := fun z => if z ∈ (↑S : Set ℂ) then
+      limUnder (𝓝[≠] z) (fun u => f u - meromorphicPolarPartTotal hMero u)
+    else f z - meromorphicPolarPartTotal hMero z
+  analyticRemainder_differentiableOn := by
+    intro z hzU
+    by_cases hzS : z ∈ (↑S : Set ℂ)
+    · exact (remainder_differentiableAt_mem hMero hzS).differentiableWithinAt
+    · have h_diff : DifferentiableAt ℂ
+          (fun w => f w - meromorphicPolarPartTotal hMero w) z := by
+        refine ((hf z ⟨hzU, hzS⟩).differentiableAt ?_).sub ?_
+        · exact (hU.sdiff S.finite_toSet.isClosed).mem_nhds ⟨hzU, hzS⟩
+        · refine DifferentiableAt.fun_sum fun s' _ => ?_
+          exact (meromorphicPolarPartAt_analyticAt_of_ne (hMero s'.1 s'.2)
+            (fun h => hzS (by rw [h]; exact Finset.mem_coe.mpr s'.2))).differentiableAt
+      exact (h_diff.congr_of_eventuallyEq
+        (remainder_eventuallyEq_off hMero hzS)).differentiableWithinAt
+  f_eq z hz := by
+    rw [if_neg hz.2]
+    unfold meromorphicPolarPartTotal
+    ring
 
 end PolarPartDecomposition
 

--- a/TauCeti/Analysis/Contour/PolarPartDecomposition.lean
+++ b/TauCeti/Analysis/Contour/PolarPartDecomposition.lean
@@ -102,13 +102,19 @@ end PolarPartDecomposition
 
 /-- **The total polar part** over the singular set: the sum of the canonical per-point polar
 parts. -/
-def meromorphicPolarPartTotal {f : ℂ → ℂ} {S : Finset ℂ}
+@[expose] def meromorphicPolarPartTotal {f : ℂ → ℂ} {S : Finset ℂ}
     (hMero : ∀ s ∈ S, MeromorphicAt f s) (z : ℂ) : ℂ :=
   ∑ s ∈ S.attach, meromorphicPolarPartAt (hMero s.1 s.2) z
 
+/-- The total polar part, unfolded to the sum of the canonical per-point polar parts. -/
+theorem meromorphicPolarPartTotal_eq {f : ℂ → ℂ} {S : Finset ℂ}
+    (hMero : ∀ s ∈ S, MeromorphicAt f s) (z : ℂ) :
+    meromorphicPolarPartTotal hMero z =
+      ∑ s ∈ S.attach, meromorphicPolarPartAt (hMero s.1 s.2) z := rfl
+
 /-- The polar parts of the other poles are analytic at `s`. -/
 private theorem otherPolar_analyticAt {f : ℂ → ℂ} {S : Finset ℂ}
-    (hMero : ∀ s ∈ S, MeromorphicAt f s) {s : ℂ} (_hs : s ∈ S) :
+    (hMero : ∀ s ∈ S, MeromorphicAt f s) (s : ℂ) :
     AnalyticAt ℂ (fun z => ∑ s' ∈ S.attach.filter (fun s' => s'.1 ≠ s),
       meromorphicPolarPartAt (hMero s'.1 s'.2) z) s := by
   refine Finset.analyticAt_fun_sum _ fun s' hs' => ?_
@@ -125,7 +131,7 @@ private theorem exists_analyticAt_sub_polarPartTotal {f : ℂ → ℂ} {S : Fins
       ∑ s' ∈ S.attach.filter (fun s' => s'.1 ≠ s),
         meromorphicPolarPartAt (hMero s'.1 s'.2) z,
     (meromorphicAnalyticPartAt_analyticAt (hMero s hs)).sub
-      (otherPolar_analyticAt hMero hs), ?_⟩
+      (otherPolar_analyticAt hMero s), ?_⟩
   filter_upwards [eventuallyEq_meromorphicAnalyticPartAt_add_meromorphicPolarPartAt
     (hMero s hs)] with z hz
   rw [hz]
@@ -199,7 +205,7 @@ meromorphic at each `s ∈ S`, the canonical Laurent data assembles into a
 `PolarPartDecomposition f S U`: the orders are the canonical polar orders — so they are
 evaluable by callers, in particular `1` at simple poles — and the analytic remainder is
 `f` minus the total polar part, extended across the poles by its limits. -/
-noncomputable def ofMeromorphic {f : ℂ → ℂ} {S : Finset ℂ} {U : Set ℂ} (hU : IsOpen U)
+@[expose] noncomputable def ofMeromorphic {f : ℂ → ℂ} {S : Finset ℂ} {U : Set ℂ} (hU : IsOpen U)
     (hf : DifferentiableOn ℂ f (U \ (↑S : Set ℂ))) (hMero : ∀ s ∈ S, MeromorphicAt f s) :
     PolarPartDecomposition f S U where
   order s := meromorphicPolarOrderAt f s
@@ -235,6 +241,28 @@ noncomputable def ofMeromorphic {f : ℂ → ℂ} {S : Finset ℂ} {U : Set ℂ}
     rw [if_neg hz.2]
     unfold meromorphicPolarPartTotal
     ring
+
+variable {f : ℂ → ℂ} {S : Finset ℂ} {U : Set ℂ} {hU : IsOpen U}
+  {hf : DifferentiableOn ℂ f (U \ (↑S : Set ℂ))} {hMero : ∀ s ∈ S, MeromorphicAt f s}
+
+/-- The constructed order is the canonical polar order — evaluable by callers, in particular
+`1` at simple poles (`meromorphicPolarOrderAt_eq_one`). -/
+@[simp] theorem ofMeromorphic_order (s : S) :
+    (ofMeromorphic hU hf hMero).order s = meromorphicPolarOrderAt f s := rfl
+
+/-- The constructed coefficients are the canonical Laurent coefficients. -/
+@[simp] theorem ofMeromorphic_coeff (s : S) (k : Fin ((ofMeromorphic hU hf hMero).order s)) :
+    (ofMeromorphic hU hf hMero).coeff s k = meromorphicPolarCoeffAt (hMero s s.2) k := rfl
+
+/-- The constructed polar part is the canonical polar part. -/
+@[simp] theorem ofMeromorphic_polarPart (s : S) (z : ℂ) :
+    (ofMeromorphic hU hf hMero).polarPart s z = meromorphicPolarPartAt (hMero s s.2) z := rfl
+
+/-- Off the singular set, the constructed analytic remainder is `f` minus the total polar
+part. -/
+theorem ofMeromorphic_analyticRemainder {z : ℂ} (hz : z ∉ (↑S : Set ℂ)) :
+    (ofMeromorphic hU hf hMero).analyticRemainder z =
+      f z - meromorphicPolarPartTotal hMero z := if_neg hz
 
 end PolarPartDecomposition
 

--- a/TauCeti/Analysis/Contour/PolarPartDecomposition.lean
+++ b/TauCeti/Analysis/Contour/PolarPartDecomposition.lean
@@ -107,7 +107,7 @@ def meromorphicPolarPartTotal {f : ℂ → ℂ} {S : Finset ℂ}
   ∑ s ∈ S.attach, meromorphicPolarPartAt (hMero s.1 s.2) z
 
 /-- The total polar part, unfolded to the sum of the canonical per-point polar parts. -/
-theorem meromorphicPolarPartTotal_eq {f : ℂ → ℂ} {S : Finset ℂ}
+theorem meromorphicPolarPartTotal_eq_sum {f : ℂ → ℂ} {S : Finset ℂ}
     (hMero : ∀ s ∈ S, MeromorphicAt f s) (z : ℂ) :
     meromorphicPolarPartTotal hMero z =
       ∑ s ∈ S.attach, meromorphicPolarPartAt (hMero s.1 s.2) z := by


### PR DESCRIPTION
## What

**Every meromorphic integrand has a polar-part decomposition** — the constructor for the
structure of #924:

```lean
noncomputable def PolarPartDecomposition.ofMeromorphic (hU : IsOpen U)
    (hf : DifferentiableOn ℂ f (U \ (↑S : Set ℂ))) (hMero : ∀ s ∈ S, MeromorphicAt f s) :
    PolarPartDecomposition f S U
```

plus the total polar part it decomposes against:

```lean
def meromorphicPolarPartTotal (hMero : ∀ s ∈ S, MeromorphicAt f s) (z : ℂ) : ℂ :=
  ∑ s ∈ S.attach, meromorphicPolarPartAt (hMero s.1 s.2) z
```

and one supporting lemma in `MeromorphicLaurent.lean`:

```lean
theorem neg_meromorphicPolarOrderAt_le (f : ℂ → ℂ) (s : ℂ) :
    (-(meromorphicPolarOrderAt f s : ℤ) : WithTop ℤ) ≤ meromorphicOrderAt f s
```

— the order bound extracted from the inline proof in `exists_laurent_data_of_meromorphicAt`,
now reused by both that theorem and the constructor's residue field.

## Why

`PolarPartDecomposition` (#924) bundles the data the generalized residue theorem manipulates,
and its remainder-integral theorem already kills the analytic remainder around any
null-homologous curve. What was missing is that the hypotheses of the residue-theorem targets
(`hungerbuhlerWasem_residueTheorem`, `hasCauchyPV_half_residue`) actually *produce* such a
decomposition: they supply only differentiability off `S` and meromorphy at `S`. This PR closes
that gap with the canonical Laurent data of #928:

- `order s := meromorphicPolarOrderAt f s` — computed, not chosen, so callers can evaluate it:
  at a simple pole it is `1` (`meromorphicPolarOrderAt_eq_one`), which is what the half-residue
  target needs to identify the surviving coefficient.
- `residue_eq` — by `meromorphicPolarCoeffAt_zero_eq_residue` at positive order, and
  `residue_eq_zero_of_meromorphicOrderAt_nonneg` (via the new order bound) at order zero.
- `analyticRemainder` — `f` minus the total polar part, extended across each pole by its limit:
  near `s ∈ S` the difference agrees with the germ `meromorphicAnalyticPartAt` minus the other
  poles' (locally analytic) polar parts, so the limit-patched extension is differentiable on all
  of `U`.

## Provenance

Migrated from `polarPartDecomposition_of_meromorphic` of `LaurentExtraction.lean` in the AINTLIB
`LeanModularForms` development, with the ℂ-indexed case splits replaced by `S`-indexed data
throughout. See N. Hungerbühler, M. Wasem, *Non-integer valued winding numbers and a generalized
Residue Theorem*, arXiv:1808.00997, §3.

## Gates

`lake build` ✓ · `lake exe axioms` ✓ (allowlist only) · `lake exe module-system` ✓ (501/501) ·
`scripts/lint-env.sh` ✓ (no new violations)

## Roadmap

Advances `TauCetiRoadmap/ContourIntegration/Suggested.lean`: prerequisite for
`hungerbuhlerWasem_residueTheorem` and `hasCauchyPV_half_residue` (their hypotheses supply
meromorphy, and this constructor turns that into the `PolarPartDecomposition` the residue
argument manipulates).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

