### PR TITLE
feat(Analysis/Contour): pairwise-disjoint windows around a finite crossing set

### DIFF
--- a/TauCeti/Analysis/Contour/CrossingWindows.lean
+++ b/TauCeti/Analysis/Contour/CrossingWindows.lean
@@ -1,0 +1,190 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Chris Birkbeck
+-/
+module
+
+public import Mathlib.Analysis.Complex.Basic
+public import Mathlib.Data.Finset.Lattice.Fold
+public import Mathlib.Order.Interval.Set.Defs
+import TauCeti.Analysis.Contour.CurveDistance
+import Mathlib.Order.Interval.Set.UnorderedInterval
+
+/-!
+# Pairwise-disjoint windows around a finite set of crossings
+
+For a finite set of crossing parameters in an open interval `(a, b)`, off a finite exceptional
+set, there is a common radius `r > 0` whose closed windows `[t_i - r, t_i + r]` stay inside
+`(a, b)`, are pairwise disjoint, and avoid the exceptional set
+(`exists_common_window_radius`). Inside such a window, completeness of the crossing set makes
+the crossing unique (`eq_of_mem_window_of_eq`), and the distance from the curve to the crossed
+point is bounded below off the crossing (`exists_window_dist_lower_bound`) — the geometric
+scaffolding that localizes the principal-value analysis to one crossing per window.
+
+## Main results
+
+* `Contour.exists_common_window_radius` — the common window radius.
+* `Contour.eq_of_mem_window_of_eq` — in-window uniqueness of the crossing.
+* `Contour.exists_window_dist_lower_bound` — a positive lower bound for `‖γ t - s‖` on the two
+  closed half-windows excluding the crossing.
+
+## Provenance
+
+Migrated from `multi_pole_common_radius`, `multi_pole_local_uniqueness`, and
+`multi_pole_local_far_bound` of `CPVExistenceMulti.lean` in the AINTLIB `LeanModularForms`
+development, restated for a raw curve over an arbitrary interval `(a, b)` (there the domain is
+the bundled `[0, 1]` of a `ClosedPwC1Immersion`), with the half-window bounds obtained from
+`Contour.exists_curve_dist_lower_bound` rather than a bespoke compactness argument. See
+N. Hungerbühler, M. Wasem, *Non-integer valued winding numbers and a generalized Residue
+Theorem*, arXiv:1808.00997, §3.
+-/
+
+public section
+
+noncomputable section
+
+namespace TauCeti.Contour
+
+open Set
+
+/-- The minimum pairwise distance of a finite set with at least two elements is positive. -/
+private theorem min_pairwise_distance_pos {crossings : Finset ℝ}
+    (h_card : 2 ≤ crossings.card) :
+    ∃ d > 0, ∀ t₁ ∈ crossings, ∀ t₂ ∈ crossings, t₁ ≠ t₂ → d ≤ |t₁ - t₂| := by
+  obtain ⟨p, hp, q, hq, hpq⟩ := Finset.one_lt_card.mp h_card
+  obtain ⟨m, hm_mem, hm⟩ :=
+    Finset.exists_min_image ((crossings ×ˢ crossings).filter (fun p => p.1 ≠ p.2))
+      (fun p => |p.1 - p.2|)
+      ⟨(p, q), Finset.mem_filter.mpr ⟨Finset.mem_product.mpr ⟨hp, hq⟩, hpq⟩⟩
+  rw [Finset.mem_filter, Finset.mem_product] at hm_mem
+  refine ⟨|m.1 - m.2|, abs_pos.mpr (sub_ne_zero.mpr hm_mem.2), ?_⟩
+  exact fun t₁ ht₁ t₂ ht₂ ht_ne =>
+    hm (t₁, t₂) <| Finset.mem_filter.mpr ⟨Finset.mem_product.mpr ⟨ht₁, ht₂⟩, ht_ne⟩
+
+/-- A finite subset of the open interval `(a, b)` is uniformly separated from both
+endpoints. -/
+private theorem crossings_bounded_from_endpoints {a b : ℝ} {crossings : Finset ℝ}
+    (h_nonempty : crossings.Nonempty)
+    (h_Ioo : ∀ t ∈ crossings, t ∈ Ioo a b) :
+    ∃ c > 0, ∀ t ∈ crossings, a + c ≤ t ∧ t ≤ b - c := by
+  obtain ⟨t_min, ht_min_mem, ht_min⟩ :=
+    Finset.exists_min_image crossings (fun t => min (t - a) (b - t)) h_nonempty
+  have h0 := h_Ioo t_min ht_min_mem
+  refine ⟨min (t_min - a) (b - t_min),
+    lt_min (by linarith [h0.1]) (by linarith [h0.2]), fun t ht => ?_⟩
+  have h_ge := ht_min t ht
+  exact ⟨by linarith [h_ge.trans (min_le_left (t - a) (b - t))],
+    by linarith [h_ge.trans (min_le_right (t - a) (b - t))]⟩
+
+/-- A finite set disjoint from a finite exceptional set is uniformly separated from it. -/
+private theorem crossings_bounded_from_exceptional {crossings P : Finset ℝ}
+    (h_nonempty : crossings.Nonempty)
+    (h_off : ∀ t ∈ crossings, t ∉ P) :
+    ∃ c > 0, ∀ t ∈ crossings, ∀ p ∈ P, c ≤ |t - p| := by
+  by_cases hP : P = ∅
+  · exact ⟨1, one_pos, fun _ _ p hp => absurd (hP ▸ hp) (Finset.notMem_empty p)⟩
+  · obtain ⟨p₀, hp₀⟩ := Finset.nonempty_iff_ne_empty.mpr hP
+    obtain ⟨t₀, ht₀⟩ := h_nonempty
+    obtain ⟨m, hm_mem, hm⟩ :=
+      Finset.exists_min_image (crossings ×ˢ P) (fun q => |q.1 - q.2|)
+        ⟨(t₀, p₀), Finset.mem_product.mpr ⟨ht₀, hp₀⟩⟩
+    rw [Finset.mem_product] at hm_mem
+    refine ⟨|m.1 - m.2|, abs_pos.mpr fun h_eq =>
+      h_off m.1 hm_mem.1 (sub_eq_zero.mp h_eq ▸ hm_mem.2), ?_⟩
+    exact fun t ht p hp => hm (t, p) (Finset.mem_product.mpr ⟨ht, hp⟩)
+
+/-- **The common window radius**: for a finite set of crossings in `(a, b)` avoiding a finite
+exceptional set `P`, there is `r > 0` such that every window `[t_i - r, t_i + r]` stays inside
+`(a, b)`, distinct crossings are more than `2r` apart (so the windows are pairwise disjoint),
+and no exceptional point comes within `r` of a crossing. -/
+theorem exists_common_window_radius {a b : ℝ} {crossings P : Finset ℝ}
+    (h_nonempty : crossings.Nonempty)
+    (h_Ioo : ∀ t ∈ crossings, t ∈ Ioo a b)
+    (h_off : ∀ t ∈ crossings, t ∉ P) :
+    ∃ r > 0,
+      (∀ t ∈ crossings, a + r ≤ t ∧ t ≤ b - r) ∧
+      (∀ t ∈ crossings, ∀ t' ∈ crossings, t' ≠ t → 2 * r < |t - t'|) ∧
+      (∀ t ∈ crossings, ∀ p ∈ P, r < |t - p|) := by
+  obtain ⟨c, hc_pos, h_endpts⟩ := crossings_bounded_from_endpoints h_nonempty h_Ioo
+  obtain ⟨e, he_pos, h_exc⟩ := crossings_bounded_from_exceptional h_nonempty h_off
+  by_cases h_card_one : crossings.card = 1
+  · refine ⟨min c (e / 2), lt_min hc_pos (by linarith), fun t ht => ?_, ?_, fun t ht p hp => ?_⟩
+    · obtain ⟨h1, h2⟩ := h_endpts t ht
+      exact ⟨by linarith [min_le_left c (e / 2)], by linarith [min_le_left c (e / 2)]⟩
+    · intro t ht t' ht' ht_ne
+      obtain ⟨u, hu⟩ := Finset.card_eq_one.mp h_card_one
+      rw [hu, Finset.mem_singleton] at ht ht'
+      exact absurd (ht'.trans ht.symm) ht_ne
+    · linarith [h_exc t ht p hp, min_le_right c (e / 2)]
+  · have h_card : 2 ≤ crossings.card := by
+      have := Finset.card_pos.mpr h_nonempty
+      omega
+    obtain ⟨d, hd_pos, h_dist⟩ := min_pairwise_distance_pos h_card
+    refine ⟨min c (min (e / 2) (d / 4)),
+      lt_min hc_pos (lt_min (by linarith) (by linarith)),
+      fun t ht => ?_, fun t ht t' ht' ht_ne => ?_, fun t ht p hp => ?_⟩
+    · obtain ⟨h1, h2⟩ := h_endpts t ht
+      exact ⟨by linarith [min_le_left c (min (e / 2) (d / 4))],
+        by linarith [min_le_left c (min (e / 2) (d / 4))]⟩
+    · have h_d := h_dist t' ht' t ht ht_ne
+      rw [abs_sub_comm] at h_d
+      linarith [(min_le_right c (min (e / 2) (d / 4))).trans (min_le_right (e / 2) (d / 4))]
+    · linarith [h_exc t ht p hp,
+        (min_le_right c (min (e / 2) (d / 4))).trans (min_le_left (e / 2) (d / 4))]
+
+/-- **In-window uniqueness of the crossing**: with windows inside `[a, b]`, distinct crossings
+more than `2r` apart, and completeness — every parameter of `[a, b]` where `γ` takes the value
+`s` is a listed crossing — the only parameter of the window `[t_i - r, t_i + r]` where `γ`
+takes the value `s` is `t_i` itself. Stated for a bare function; no regularity is used. -/
+theorem eq_of_mem_window_of_eq {α : Type*} {γ : ℝ → α} {s : α} {a b : ℝ}
+    {crossings : Finset ℝ} {r : ℝ}
+    (h_endpts : ∀ t ∈ crossings, a + r ≤ t ∧ t ≤ b - r)
+    (h_pairwise : ∀ t ∈ crossings, ∀ t' ∈ crossings, t' ≠ t → 2 * r < |t - t'|)
+    (h_complete : ∀ t ∈ Icc a b, γ t = s → t ∈ crossings)
+    {t_i : ℝ} (ht_i : t_i ∈ crossings)
+    {t : ℝ} (ht : t ∈ Icc (t_i - r) (t_i + r)) (h_eq : γ t = s) :
+    t = t_i := by
+  obtain ⟨h_ge, h_le⟩ := h_endpts t_i ht_i
+  have h_t_cross : t ∈ crossings :=
+    h_complete t ⟨by linarith [ht.1], by linarith [ht.2]⟩ h_eq
+  by_contra h_ne
+  have h_dist := h_pairwise t_i ht_i t h_t_cross h_ne
+  have : |t_i - t| ≤ r := by
+    rw [abs_sub_comm, abs_le]
+    exact ⟨by linarith [ht.1], by linarith [ht.2]⟩
+  linarith [abs_nonneg (t_i - t)]
+
+/-- **Positive distance bound on the half-windows**: when the crossing is unique in its window,
+`‖γ t - s‖` is bounded below by a common `m > 0` on the two closed half-windows
+`[t_i - r, t_i - r']` and `[t_i + r', t_i + r]` excluding the crossing. -/
+theorem exists_window_dist_lower_bound {γ : ℝ → ℂ} {s : ℂ} {t_i r : ℝ}
+    (hγ_cont : ContinuousOn γ (Icc (t_i - r) (t_i + r)))
+    (h_unique : ∀ t ∈ Icc (t_i - r) (t_i + r), γ t = s → t = t_i)
+    {r' : ℝ} (hr'_pos : 0 < r') (hr'_le : r' ≤ r) :
+    ∃ m > 0,
+      (∀ t ∈ Icc (t_i - r) (t_i - r'), m ≤ ‖γ t - s‖) ∧
+      (∀ t ∈ Icc (t_i + r') (t_i + r), m ≤ ‖γ t - s‖) := by
+  have h_sub_l : uIcc (t_i - r) (t_i - r') ⊆ Icc (t_i - r) (t_i + r) := by
+    rw [uIcc_of_le (by linarith)]
+    exact Icc_subset_Icc le_rfl (by linarith)
+  have h_sub_r : uIcc (t_i + r') (t_i + r) ⊆ Icc (t_i - r) (t_i + r) := by
+    rw [uIcc_of_le (by linarith)]
+    exact Icc_subset_Icc (by linarith) le_rfl
+  obtain ⟨ml, hml_pos, hml⟩ := exists_curve_dist_lower_bound (hγ_cont.mono h_sub_l)
+    fun t ht h_eq => by
+      have h_t := h_unique t (h_sub_l ht) h_eq
+      rw [uIcc_of_le (by linarith)] at ht
+      linarith [ht.2]
+  obtain ⟨mr, hmr_pos, hmr⟩ := exists_curve_dist_lower_bound (hγ_cont.mono h_sub_r)
+    fun t ht h_eq => by
+      have h_t := h_unique t (h_sub_r ht) h_eq
+      rw [uIcc_of_le (by linarith)] at ht
+      linarith [ht.1]
+  refine ⟨min ml mr, lt_min hml_pos hmr_pos, fun t ht => ?_, fun t ht => ?_⟩
+  · exact (min_le_left _ _).trans (hml t (by rwa [uIcc_of_le (by linarith)]))
+  · exact (min_le_right _ _).trans (hmr t (by rwa [uIcc_of_le (by linarith)]))
+
+end TauCeti.Contour
+
+end

--- a/TauCeti/Analysis/Contour/CrossingWindows.lean
+++ b/TauCeti/Analysis/Contour/CrossingWindows.lean
@@ -6,17 +6,18 @@ Authors: Chris Birkbeck
 module
 
 public import Mathlib.Analysis.Complex.Basic
-public import Mathlib.Data.Finset.Lattice.Fold
+public import Mathlib.Data.Finset.Max
 public import Mathlib.Order.Interval.Set.Defs
 import TauCeti.Analysis.Contour.CurveDistance
 import Mathlib.Order.Interval.Set.UnorderedInterval
+import Mathlib.Topology.MetricSpace.Infsep
 
 /-!
 # Pairwise-disjoint windows around a finite set of crossings
 
 For a finite set of crossing parameters in an open interval `(a, b)`, off a finite exceptional
-set, there is a common radius `r > 0` whose closed windows `[t_i - r, t_i + r]` stay inside
-`(a, b)`, are pairwise disjoint, and avoid the exceptional set
+set, there is a common radius `r > 0` whose closed windows `[t_i - r, t_i + r]` stay within
+`[a, b]`, are pairwise disjoint, and avoid the exceptional set
 (`exists_common_window_radius`). Inside such a window, completeness of the crossing set makes
 the crossing unique (`eq_of_mem_window_of_eq`), and the distance from the curve to the crossed
 point is bounded below off the crossing (`exists_window_dist_lower_bound`) — the geometric
@@ -48,19 +49,20 @@ namespace TauCeti.Contour
 
 open Set
 
-/-- The minimum pairwise distance of a finite set with at least two elements is positive. -/
+/-- The minimum pairwise distance of a finite set with at least two elements is positive:
+`Set.infsep` positivity for finite sets. -/
 private theorem min_pairwise_distance_pos {crossings : Finset ℝ}
     (h_card : 2 ≤ crossings.card) :
     ∃ d > 0, ∀ t₁ ∈ crossings, ∀ t₂ ∈ crossings, t₁ ≠ t₂ → d ≤ |t₁ - t₂| := by
-  obtain ⟨p, hp, q, hq, hpq⟩ := Finset.one_lt_card.mp h_card
-  obtain ⟨m, hm_mem, hm⟩ :=
-    Finset.exists_min_image ((crossings ×ˢ crossings).filter (fun p => p.1 ≠ p.2))
-      (fun p => |p.1 - p.2|)
-      ⟨(p, q), Finset.mem_filter.mpr ⟨Finset.mem_product.mpr ⟨hp, hq⟩, hpq⟩⟩
-  rw [Finset.mem_filter, Finset.mem_product] at hm_mem
-  refine ⟨|m.1 - m.2|, abs_pos.mpr (sub_ne_zero.mpr hm_mem.2), ?_⟩
-  exact fun t₁ ht₁ t₂ ht₂ ht_ne =>
-    hm (t₁, t₂) <| Finset.mem_filter.mpr ⟨Finset.mem_product.mpr ⟨ht₁, ht₂⟩, ht_ne⟩
+  have h_nt : (↑crossings : Set ℝ).Nontrivial := by
+    obtain ⟨p, hp, q, hq, hpq⟩ := Finset.one_lt_card.mp h_card
+    exact ⟨p, hp, q, hq, hpq⟩
+  refine ⟨(↑crossings : Set ℝ).infsep,
+    Set.infsep_pos.mpr ⟨crossings.finite_toSet.einfsep_pos, h_nt.einfsep_lt_top⟩,
+    fun t₁ ht₁ t₂ ht₂ ht_ne => ?_⟩
+  have h := Set.infsep_le_dist_of_mem (s := (↑crossings : Set ℝ))
+    (Finset.mem_coe.mpr ht₁) (Finset.mem_coe.mpr ht₂) ht_ne
+  rwa [Real.dist_eq] at h
 
 /-- A finite subset of the open interval `(a, b)` is uniformly separated from both
 endpoints. -/
@@ -95,8 +97,8 @@ private theorem crossings_bounded_from_exceptional {crossings P : Finset ℝ}
     exact fun t ht p hp => hm (t, p) (Finset.mem_product.mpr ⟨ht, hp⟩)
 
 /-- **The common window radius**: for a finite set of crossings in `(a, b)` avoiding a finite
-exceptional set `P`, there is `r > 0` such that every window `[t_i - r, t_i + r]` stays inside
-`(a, b)`, distinct crossings are more than `2r` apart (so the windows are pairwise disjoint),
+exceptional set `P`, there is `r > 0` such that every window `[t_i - r, t_i + r]` stays within
+`[a, b]`, distinct crossings are more than `2r` apart (so the windows are pairwise disjoint),
 and no exceptional point comes within `r` of a crossing. -/
 theorem exists_common_window_radius {a b : ℝ} {crossings P : Finset ℝ}
     (h_nonempty : crossings.Nonempty)
@@ -134,13 +136,13 @@ theorem exists_common_window_radius {a b : ℝ} {crossings P : Finset ℝ}
         (min_le_right c (min (e / 2) (d / 4))).trans (min_le_left (e / 2) (d / 4))]
 
 /-- **In-window uniqueness of the crossing**: with windows inside `[a, b]`, distinct crossings
-more than `2r` apart, and completeness — every parameter of `[a, b]` where `γ` takes the value
+more than `r` apart, and completeness — every parameter of `[a, b]` where `γ` takes the value
 `s` is a listed crossing — the only parameter of the window `[t_i - r, t_i + r]` where `γ`
 takes the value `s` is `t_i` itself. Stated for a bare function; no regularity is used. -/
 theorem eq_of_mem_window_of_eq {α : Type*} {γ : ℝ → α} {s : α} {a b : ℝ}
     {crossings : Finset ℝ} {r : ℝ}
     (h_endpts : ∀ t ∈ crossings, a + r ≤ t ∧ t ≤ b - r)
-    (h_pairwise : ∀ t ∈ crossings, ∀ t' ∈ crossings, t' ≠ t → 2 * r < |t - t'|)
+    (h_pairwise : ∀ t ∈ crossings, ∀ t' ∈ crossings, t' ≠ t → r < |t - t'|)
     (h_complete : ∀ t ∈ Icc a b, γ t = s → t ∈ crossings)
     {t_i : ℝ} (ht_i : t_i ∈ crossings)
     {t : ℝ} (ht : t ∈ Icc (t_i - r) (t_i + r)) (h_eq : γ t = s) :


### PR DESCRIPTION
## What

**Pairwise-disjoint windows around a finite set of crossings** — new file
`TauCeti/Analysis/Contour/CrossingWindows.lean`:

```lean
theorem exists_common_window_radius {a b : ℝ} {crossings P : Finset ℝ}
    (h_nonempty : crossings.Nonempty) (h_Ioo : ∀ t ∈ crossings, t ∈ Ioo a b)
    (h_off : ∀ t ∈ crossings, t ∉ P) :
    ∃ r > 0, (∀ t ∈ crossings, a + r ≤ t ∧ t ≤ b - r) ∧
      (∀ t ∈ crossings, ∀ t' ∈ crossings, t' ≠ t → 2 * r < |t - t'|) ∧
      (∀ t ∈ crossings, ∀ p ∈ P, r < |t - p|)

theorem eq_of_mem_window_of_eq {α : Type*} {γ : ℝ → α} {s : α} ... :
    t = t_i        -- the only window parameter with γ t = s, under completeness

theorem exists_window_dist_lower_bound {γ : ℝ → ℂ} {s : ℂ} ... :
    ∃ m > 0, (∀ t ∈ Icc (t_i - r) (t_i - r'), m ≤ ‖γ t - s‖) ∧
      (∀ t ∈ Icc (t_i + r') (t_i + r), m ≤ ‖γ t - s‖)
```

## Why

The multi-crossing principal value localizes to one crossing per window: the common radius
makes the windows `[t_i - r, t_i + r]` pairwise disjoint, interior to the parameter interval,
and clear of the exceptional (partition) set; completeness of the crossing set then forces
in-window uniqueness, and off the crossing the curve keeps a positive distance from the pole —
the far bounds under which the per-window excision integrals of the crossing analysis
(`hasCauchyPV_half_residue`, `hungerbuhlerWasem_residueTheorem`) are well-behaved.

Restatements relative to the AINTLIB original: the interval is an arbitrary `(a, b)` rather
than the bundled `[0, 1]`; the uniqueness lemma is for a **bare function** into any type (its
proof is window arithmetic — no continuity, no immersion); and the half-window far bounds come
from the repo's `Contour.exists_curve_dist_lower_bound` instead of a bespoke
compactness-minimum argument.

## Provenance

Migrated from `multi_pole_common_radius`, `multi_pole_local_uniqueness`, and
`multi_pole_local_far_bound` of `CPVExistenceMulti.lean` in the AINTLIB `LeanModularForms`
development. See N. Hungerbühler, M. Wasem, *Non-integer valued winding numbers and a
generalized Residue Theorem*, arXiv:1808.00997, §3.

## Roadmap

Advances `TauCetiRoadmap/ContourIntegration/Suggested.lean`: prerequisite for
`hungerbuhlerWasem_residueTheorem` and `hasCauchyPV_half_residue` (per-window localization of
the principal value at finitely many on-curve poles).

## Gates

`lake build` ✓ · `lake exe axioms` ✓ (allowlist only) · `lake exe module-system` ✓ (505/505) ·
`scripts/lint-env.sh` ✓ (no new violations)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
