### PR TITLE
feat(Analysis/Contour): the truncated polar-part integrand is interval-integrable

### DIFF
--- a/TauCeti/Analysis/Contour/PolarPartDecomposition.lean
+++ b/TauCeti/Analysis/Contour/PolarPartDecomposition.lean
@@ -34,10 +34,10 @@ parts.
 * `Contour.PolarPartDecomposition.intervalIntegral_deriv_smul_analyticRemainder_eq_zero` — the
   contour integral of the analytic remainder along a closed null-homologous piecewise-`C¹` curve
   in `U` vanishes, by the homology Cauchy theorem.
-* `Contour.PolarPartDecomposition.intervalIntegrable_polarPart_truncated` — the `ε`-truncated
-  polar-part integrand along a measurable curve with interval-integrable derivative is
-  interval-integrable, for every `ε > 0` — the integrability clause of `HasCauchyPVAt` for a
-  polar part.
+* `Contour.PolarPartDecomposition.intervalIntegrable_polarPart_mul_deriv_truncated` — the
+  `ε`-truncated polar-part integrand along a measurable curve with interval-integrable
+  derivative is interval-integrable, for every `ε > 0` — the integrability clause of
+  `HasCauchyPVAt` for a polar part.
 
 ## Provenance
 
@@ -46,7 +46,10 @@ AINTLIB `LeanModularForms` development; the remainder-integral theorem is its
 `analyticRemainder_contourIntegral_zero`, which there re-runs Dixon's argument inline and here is
 a direct application of `Contour.homologyCauchyTheorem`. The constructor is migrated from
 `polarPartDecomposition_of_meromorphic` of `LaurentExtraction.lean` there, with the ℂ-indexed
-case splits replaced by `S`-indexed data throughout. See N. Hungerbühler, M. Wasem, *Non-integer
+case splits replaced by `S`-indexed data throughout; the truncated-integrand integrability
+lemma is adapted from `cpvIntegrand_polarPart_intervalIntegrable` of `MultiPoleDCT.lean`, with
+the Lipschitz bound on the curve replaced by interval-integrability of the derivative. See
+N. Hungerbühler, M. Wasem, *Non-integer
 valued winding numbers and a generalized Residue Theorem*, arXiv:1808.00997, §3.
 -/
 
@@ -285,7 +288,7 @@ theorem ofMeromorphic_analyticRemainder {z : ℂ} (hz : z ∉ (↑S : Set ℂ)) 
 `ε`-ball around the pole, the Laurent tail is bounded by `∑ k, ‖coeff s k‖ / ε ^ (k+1)`, so the
 integrand is dominated by a constant multiple of `‖deriv γ‖` — the integrability clause of
 `HasCauchyPVAt` for a polar part along a curve crossing the pole. -/
-theorem intervalIntegrable_polarPart_truncated (decomp : PolarPartDecomposition f S U)
+theorem intervalIntegrable_polarPart_mul_deriv_truncated (decomp : PolarPartDecomposition f S U)
     (s : S) {γ : ℝ → ℂ} {a b : ℝ} (hγ_meas : Measurable γ)
     (hderiv_int : IntervalIntegrable (fun t => deriv γ t) MeasureTheory.volume a b)
     {ε : ℝ} (hε : 0 < ε) :
@@ -294,8 +297,6 @@ theorem intervalIntegrable_polarPart_truncated (decomp : PolarPartDecomposition 
       MeasureTheory.volume a b := by
   classical
   set M : ℝ := ∑ k : Fin (decomp.order s), ‖decomp.coeff s k‖ / ε ^ (k.val + 1) with hM_def
-  have hM_nonneg : 0 ≤ M :=
-    Finset.sum_nonneg fun k _ => div_nonneg (norm_nonneg _) (pow_nonneg hε.le _)
   have h_meas : Measurable (fun t =>
       if ‖γ t - (s : ℂ)‖ > ε then decomp.polarPart s (γ t) * deriv γ t else 0) := by
     have hA : MeasurableSet {t : ℝ | ε < ‖γ t - (s : ℂ)‖} :=
@@ -320,8 +321,7 @@ theorem intervalIntegrable_polarPart_truncated (decomp : PolarPartDecomposition 
       rw [decomp.polarPart_eq s (γ t), hM_def]
       refine (norm_sum_le _ _).trans (Finset.sum_le_sum fun k _ => ?_)
       rw [norm_div, norm_pow]
-      exact div_le_div_of_nonneg_left (norm_nonneg _) (pow_pos hε _)
-        (pow_le_pow_left₀ hε.le h_far.le _)
+      gcongr
     calc ‖decomp.polarPart s (γ t) * deriv γ t‖
         = ‖decomp.polarPart s (γ t)‖ * ‖deriv γ t‖ := norm_mul _ _
       _ ≤ M * ‖deriv γ t‖ :=

--- a/TauCeti/Analysis/Contour/PolarPartDecomposition.lean
+++ b/TauCeti/Analysis/Contour/PolarPartDecomposition.lean
@@ -7,6 +7,7 @@ module
 
 public import TauCeti.Analysis.Contour.HomologyCauchy
 public import TauCeti.Analysis.Contour.MeromorphicLaurent
+import Mathlib.Analysis.Calculus.FDeriv.Measurable
 
 /-!
 # Polar-part decompositions
@@ -33,6 +34,10 @@ parts.
 * `Contour.PolarPartDecomposition.intervalIntegral_deriv_smul_analyticRemainder_eq_zero` — the
   contour integral of the analytic remainder along a closed null-homologous piecewise-`C¹` curve
   in `U` vanishes, by the homology Cauchy theorem.
+* `Contour.PolarPartDecomposition.intervalIntegrable_polarPart_truncated` — the `ε`-truncated
+  polar-part integrand along a measurable curve with interval-integrable derivative is
+  interval-integrable, for every `ε > 0` — the integrability clause of `HasCauchyPVAt` for a
+  polar part.
 
 ## Provenance
 
@@ -275,6 +280,55 @@ theorem ofMeromorphic_analyticRemainder {z : ℂ} (hz : z ∉ (↑S : Set ℂ)) 
       f z - meromorphicPolarPartTotal hMero z := by
   unfold ofMeromorphic
   exact if_neg hz
+
+/-- **The truncated polar-part integrand is interval-integrable** for every `ε > 0`: off the
+`ε`-ball around the pole, the Laurent tail is bounded by `∑ k, ‖coeff s k‖ / ε ^ (k+1)`, so the
+integrand is dominated by a constant multiple of `‖deriv γ‖` — the integrability clause of
+`HasCauchyPVAt` for a polar part along a curve crossing the pole. -/
+theorem intervalIntegrable_polarPart_truncated (decomp : PolarPartDecomposition f S U)
+    (s : S) {γ : ℝ → ℂ} {a b : ℝ} (hγ_meas : Measurable γ)
+    (hderiv_int : IntervalIntegrable (fun t => deriv γ t) MeasureTheory.volume a b)
+    {ε : ℝ} (hε : 0 < ε) :
+    IntervalIntegrable
+      (fun t => if ‖γ t - (s : ℂ)‖ > ε then decomp.polarPart s (γ t) * deriv γ t else 0)
+      MeasureTheory.volume a b := by
+  classical
+  set M : ℝ := ∑ k : Fin (decomp.order s), ‖decomp.coeff s k‖ / ε ^ (k.val + 1) with hM_def
+  have hM_nonneg : 0 ≤ M :=
+    Finset.sum_nonneg fun k _ => div_nonneg (norm_nonneg _) (pow_nonneg hε.le _)
+  have h_meas : Measurable (fun t =>
+      if ‖γ t - (s : ℂ)‖ > ε then decomp.polarPart s (γ t) * deriv γ t else 0) := by
+    have hA : MeasurableSet {t : ℝ | ε < ‖γ t - (s : ℂ)‖} :=
+      measurableSet_lt measurable_const ((hγ_meas.sub_const _).norm)
+    refine Measurable.ite hA ?_ measurable_const
+    have h_polar : Measurable fun t => decomp.polarPart s (γ t) := by
+      have h_eq : (fun t => decomp.polarPart s (γ t)) = fun t =>
+          ∑ k : Fin (decomp.order s), decomp.coeff s k / (γ t - (s : ℂ)) ^ (k.val + 1) :=
+        funext fun t => decomp.polarPart_eq s (γ t)
+      rw [h_eq]
+      exact Finset.measurable_sum _ fun k _ =>
+        (((hγ_meas.sub_const _).pow_const _).const_div _)
+    exact h_polar.mul (measurable_deriv _)
+  refine (hderiv_int.norm.const_mul M).mono_fun h_meas.aestronglyMeasurable ?_
+  refine Filter.Eventually.of_forall fun t => ?_
+  -- β-reduce the two sides of the a.e. bound
+  change ‖if ‖γ t - (s : ℂ)‖ > ε then decomp.polarPart s (γ t) * deriv γ t else 0‖ ≤
+    ‖M * ‖deriv γ t‖‖
+  by_cases h_far : ‖γ t - (s : ℂ)‖ > ε
+  · rw [if_pos h_far]
+    have h_polar_bound : ‖decomp.polarPart s (γ t)‖ ≤ M := by
+      rw [decomp.polarPart_eq s (γ t), hM_def]
+      refine (norm_sum_le _ _).trans (Finset.sum_le_sum fun k _ => ?_)
+      rw [norm_div, norm_pow]
+      exact div_le_div_of_nonneg_left (norm_nonneg _) (pow_pos hε _)
+        (pow_le_pow_left₀ hε.le h_far.le _)
+    calc ‖decomp.polarPart s (γ t) * deriv γ t‖
+        = ‖decomp.polarPart s (γ t)‖ * ‖deriv γ t‖ := norm_mul _ _
+      _ ≤ M * ‖deriv γ t‖ :=
+          mul_le_mul_of_nonneg_right h_polar_bound (norm_nonneg _)
+      _ ≤ ‖M * ‖deriv γ t‖‖ := le_abs_self _
+  · rw [if_neg h_far, norm_zero]
+    positivity
 
 end PolarPartDecomposition
 


### PR DESCRIPTION
## What

**The truncated polar-part integrand is interval-integrable** — one lemma appended to
`TauCeti/Analysis/Contour/PolarPartDecomposition.lean`:

```lean
theorem PolarPartDecomposition.intervalIntegrable_polarPart_truncated
    (decomp : PolarPartDecomposition f S U) (s : S) {γ : ℝ → ℂ} {a b : ℝ}
    (hγ_meas : Measurable γ)
    (hderiv_int : IntervalIntegrable (fun t => deriv γ t) MeasureTheory.volume a b)
    {ε : ℝ} (hε : 0 < ε) :
    IntervalIntegrable
      (fun t => if ‖γ t - (s : ℂ)‖ > ε then decomp.polarPart s (γ t) * deriv γ t else 0)
      MeasureTheory.volume a b
```

Off the `ε`-ball the Laurent tail is bounded by `∑ k, ‖coeff s k‖ / ε^(k+1)`, so the truncated
integrand is dominated by a constant multiple of `‖deriv γ‖`.

## Why

The integrand shape is exactly the integrability clause of `Contour.HasCauchyPVAt`: when the
crossing analysis constructs the singleton principal value of a polar part at its pole (toward
`hasCauchyPV_half_residue` / `hungerbuhlerWasem_residueTheorem`), this lemma discharges the
eventual-integrability half of the predicate for every truncation radius.

Two deviations from the AINTLIB source:

- the Lipschitz hypothesis on the curve is replaced by
  `IntervalIntegrable (deriv γ)` — the majorant argument only needs `‖deriv γ‖ ∈ L¹`, and this
  is the hypothesis shape the roadmap targets already carry;
- the **rest of AINTLIB's `MultiPoleDCT.lean` is deliberately not ported**: its
  dominated-convergence apparatus (`badSetIcc` volumes, immersion measure-zero preimages)
  existed to lift a singleton CPV to the explicit-set multi-pole form, and TauCeti's
  existentially-excised `HasCauchyPV` design already provides that lift through the merged
  `HasCauchyPVAt.hasCauchyPV` and the union-reconciled `HasCauchyPV.add`/`sum`.

## Provenance

Adapted from `cpvIntegrand_polarPart_intervalIntegrable` of `MultiPoleDCT.lean` in the AINTLIB
`LeanModularForms` development. See N. Hungerbühler, M. Wasem, *Non-integer valued winding
numbers and a generalized Residue Theorem*, arXiv:1808.00997, §3.

## Roadmap

Advances `TauCetiRoadmap/ContourIntegration/Suggested.lean`: prerequisite for
`hasCauchyPV_half_residue` and `hungerbuhlerWasem_residueTheorem` (integrability clause of the
principal value of a polar part).

## Gates

`lake build` ✓ · `lake exe axioms` ✓ (allowlist only) · `lake exe module-system` ✓ (505/505) ·
`scripts/lint-env.sh` ✓ (no new violations)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
