### PR TITLE
feat(Analysis/Contour): interior differentiability API for immersions

### DIFF
--- a/TauCeti/Analysis/Contour/CrossingFiniteness.lean
+++ b/TauCeti/Analysis/Contour/CrossingFiniteness.lean
@@ -27,10 +27,6 @@ compact `[[a, b]]` would have an accumulation point.
 ## Main results
 
 * `Contour.IsPwC1ImmersionOn.eventually_ne_nhdsNE` — crossings of an immersion are isolated.
-* `Contour.IsPwC1ImmersionOn.exists_finset_differentiableAt` — an immersion is differentiable
-  at every interior parameter off a finite exceptional set.
-* `Contour.IsPwC1ImmersionOn.eventually_differentiableAt_right` / `_left` — eventual one-sided
-  differentiability at an interior parameter.
 * `Contour.IsPwC1ImmersionOn.finite_crossings` — **HW Proposition 2.2**: the crossing set
   `[[a, b]] ∩ γ ⁻¹' {z₀}` of an immersion is finite.
 
@@ -195,37 +191,6 @@ theorem IsPwC1ImmersionOn.eventually_ne_nhdsNE (h : IsPwC1ImmersionOn γ a b) {t
   rw [punctured_nhds_eq_nhdsWithin_sup_nhdsWithin, Filter.eventually_sup]
   exact ⟨crossing_isolated_left h ⟨ht₀.1, ht₀.2.le⟩ hcross,
     crossing_isolated_right h ⟨ht₀.1.le, ht₀.2⟩ hcross⟩
-
-/-- **Interior differentiability off a finite set**: an immersion is differentiable at every
-interior parameter off some finite exceptional set — the countable-exception hypothesis of the
-logarithmic fundamental theorem of calculus along the curve. -/
-theorem IsPwC1ImmersionOn.exists_finset_differentiableAt (h : IsPwC1ImmersionOn γ a b) :
-    ∃ p : Finset ℝ, ∀ t ∈ Ioo (min a b) (max a b) \ (↑p : Set ℝ), DifferentiableAt ℝ γ t := by
-  obtain ⟨p, -, hpieces⟩ := h.exists_breakpoints
-  exact ⟨p, fun t ht => (deriv_ne_zero_off_breakpoints hpieces ht.1 ht.2).1⟩
-
-/-- **Eventual differentiability near an interior parameter**, on any within-filter avoiding
-the parameter itself. -/
-theorem IsPwC1ImmersionOn.eventually_differentiableAt (h : IsPwC1ImmersionOn γ a b) {t₀ : ℝ}
-    (ht₀ : t₀ ∈ Ioo (min a b) (max a b)) {u : Set ℝ} (hu : t₀ ∉ u) :
-    ∀ᶠ t in 𝓝[u] t₀, DifferentiableAt ℝ γ t := by
-  obtain ⟨p, hp⟩ := h.exists_finset_differentiableAt
-  have hcl : IsClosed ((↑p \ {t₀} : Set ℝ)) := (p.finite_toSet.subset sdiff_subset).isClosed
-  filter_upwards [nhdsWithin_le_nhds (hcl.isOpen_compl.mem_nhds (by simp)),
-    nhdsWithin_le_nhds (isOpen_Ioo.mem_nhds ht₀), self_mem_nhdsWithin] with t htc htIoo htu
-  exact hp t ⟨htIoo, fun htp => htc ⟨htp, fun h_eq => hu (h_eq ▸ htu)⟩⟩
-
-/-- Eventual differentiability from the right at an interior parameter. -/
-theorem IsPwC1ImmersionOn.eventually_differentiableAt_right (h : IsPwC1ImmersionOn γ a b)
-    {t₀ : ℝ} (ht₀ : t₀ ∈ Ioo (min a b) (max a b)) :
-    ∀ᶠ t in 𝓝[>] t₀, DifferentiableAt ℝ γ t :=
-  h.eventually_differentiableAt ht₀ self_notMem_Ioi
-
-/-- Eventual differentiability from the left at an interior parameter. -/
-theorem IsPwC1ImmersionOn.eventually_differentiableAt_left (h : IsPwC1ImmersionOn γ a b)
-    {t₀ : ℝ} (ht₀ : t₀ ∈ Ioo (min a b) (max a b)) :
-    ∀ᶠ t in 𝓝[<] t₀, DifferentiableAt ℝ γ t :=
-  h.eventually_differentiableAt ht₀ self_notMem_Iio
 
 /-- **HW Proposition 2.2: the crossing set of a piecewise-`C¹` immersion is finite** — the
 geometric input that makes the on-cycle singularities of the generalized residue theorem a

--- a/TauCeti/Analysis/Contour/CrossingFiniteness.lean
+++ b/TauCeti/Analysis/Contour/CrossingFiniteness.lean
@@ -27,6 +27,10 @@ compact `[[a, b]]` would have an accumulation point.
 ## Main results
 
 * `Contour.IsPwC1ImmersionOn.eventually_ne_nhdsNE` — crossings of an immersion are isolated.
+* `Contour.IsPwC1ImmersionOn.exists_finset_differentiableAt` — an immersion is differentiable
+  at every interior parameter off a finite exceptional set.
+* `Contour.IsPwC1ImmersionOn.eventually_differentiableAt_right` / `_left` — eventual one-sided
+  differentiability at an interior parameter.
 * `Contour.IsPwC1ImmersionOn.finite_crossings` — **HW Proposition 2.2**: the crossing set
   `[[a, b]] ∩ γ ⁻¹' {z₀}` of an immersion is finite.
 
@@ -191,6 +195,37 @@ theorem IsPwC1ImmersionOn.eventually_ne_nhdsNE (h : IsPwC1ImmersionOn γ a b) {t
   rw [punctured_nhds_eq_nhdsWithin_sup_nhdsWithin, Filter.eventually_sup]
   exact ⟨crossing_isolated_left h ⟨ht₀.1, ht₀.2.le⟩ hcross,
     crossing_isolated_right h ⟨ht₀.1.le, ht₀.2⟩ hcross⟩
+
+/-- **Interior differentiability off a finite set**: an immersion is differentiable at every
+interior parameter off some finite exceptional set — the countable-exception hypothesis of the
+logarithmic fundamental theorem of calculus along the curve. -/
+theorem IsPwC1ImmersionOn.exists_finset_differentiableAt (h : IsPwC1ImmersionOn γ a b) :
+    ∃ p : Finset ℝ, ∀ t ∈ Ioo (min a b) (max a b) \ (↑p : Set ℝ), DifferentiableAt ℝ γ t := by
+  obtain ⟨p, -, hpieces⟩ := h.exists_breakpoints
+  exact ⟨p, fun t ht => (deriv_ne_zero_off_breakpoints hpieces ht.1 ht.2).1⟩
+
+/-- **Eventual differentiability near an interior parameter**, on any within-filter avoiding
+the parameter itself. -/
+theorem IsPwC1ImmersionOn.eventually_differentiableAt (h : IsPwC1ImmersionOn γ a b) {t₀ : ℝ}
+    (ht₀ : t₀ ∈ Ioo (min a b) (max a b)) {u : Set ℝ} (hu : t₀ ∉ u) :
+    ∀ᶠ t in 𝓝[u] t₀, DifferentiableAt ℝ γ t := by
+  obtain ⟨p, hp⟩ := h.exists_finset_differentiableAt
+  have hcl : IsClosed ((↑p \ {t₀} : Set ℝ)) := (p.finite_toSet.subset sdiff_subset).isClosed
+  filter_upwards [nhdsWithin_le_nhds (hcl.isOpen_compl.mem_nhds (by simp)),
+    nhdsWithin_le_nhds (isOpen_Ioo.mem_nhds ht₀), self_mem_nhdsWithin] with t htc htIoo htu
+  exact hp t ⟨htIoo, fun htp => htc ⟨htp, fun h_eq => hu (h_eq ▸ htu)⟩⟩
+
+/-- Eventual differentiability from the right at an interior parameter. -/
+theorem IsPwC1ImmersionOn.eventually_differentiableAt_right (h : IsPwC1ImmersionOn γ a b)
+    {t₀ : ℝ} (ht₀ : t₀ ∈ Ioo (min a b) (max a b)) :
+    ∀ᶠ t in 𝓝[>] t₀, DifferentiableAt ℝ γ t :=
+  h.eventually_differentiableAt ht₀ self_notMem_Ioi
+
+/-- Eventual differentiability from the left at an interior parameter. -/
+theorem IsPwC1ImmersionOn.eventually_differentiableAt_left (h : IsPwC1ImmersionOn γ a b)
+    {t₀ : ℝ} (ht₀ : t₀ ∈ Ioo (min a b) (max a b)) :
+    ∀ᶠ t in 𝓝[<] t₀, DifferentiableAt ℝ γ t :=
+  h.eventually_differentiableAt ht₀ self_notMem_Iio
 
 /-- **HW Proposition 2.2: the crossing set of a piecewise-`C¹` immersion is finite** — the
 geometric input that makes the on-cycle singularities of the generalized residue theorem a

--- a/TauCeti/Analysis/Contour/PiecewiseC1On.lean
+++ b/TauCeti/Analysis/Contour/PiecewiseC1On.lean
@@ -41,8 +41,11 @@ prerequisite for the homology Cauchy theorem and the generalized residue theorem
   introduce the predicate from, and eliminate it to, a finite breakpoint witness.
 * `Contour.IsPiecewiseC1On.mono` — restrict the regularity to a subinterval `[[c, d]] ⊆ [[a, b]]`.
 * `Contour.isPiecewiseC1On_comm`, `Contour.IsPiecewiseC1On.symm` — endpoint-swap invariance.
-* `Contour.IsPiecewiseC1On.exists_countable_differentiableAt` — differentiability off a countable
-  set, in the exact shape the raw contour-integral lemmas consume.
+* `Contour.IsPiecewiseC1On.exists_finset_differentiableAt`,
+  `Contour.IsPiecewiseC1On.exists_countable_differentiableAt` — differentiability off a finite
+  (hence countable) set, in the exact shapes the raw contour-integral lemmas consume.
+* `Contour.IsPiecewiseC1On.eventually_differentiableAt` (and its `_right`/`_left` one-sided
+  corollaries) — eventual differentiability near an interior parameter.
 * `Contour.IsPiecewiseC1On.intervalIntegrable_deriv` — the derivative is interval-integrable on
   `a..b`, glued across the breakpoints from the `C¹` pieces.
 

--- a/TauCeti/Analysis/Contour/PiecewiseC1On.lean
+++ b/TauCeti/Analysis/Contour/PiecewiseC1On.lean
@@ -63,7 +63,7 @@ noncomputable section
 
 namespace TauCeti.Contour
 
-open MeasureTheory Set
+open Filter MeasureTheory Set Topology
 
 variable {γ : ℝ → ℂ} {a b : ℝ}
 
@@ -163,18 +163,49 @@ private theorem exists_Icc_mem_avoiding {p : Finset ℝ} {t : ℝ}
     exact (hball (show x ∈ Ioo (t - ε) (t + ε) from
       ⟨by linarith [hx.1], by linarith [hx.2]⟩)).2
 
+/-- **Differentiability off a finite set.** A piecewise-`C¹` curve is differentiable at every
+interior parameter outside a finite set — the breakpoints. -/
+theorem IsPiecewiseC1On.exists_finset_differentiableAt (h : IsPiecewiseC1On γ a b) :
+    ∃ p : Finset ℝ,
+      ∀ t ∈ Ioo (min a b) (max a b) \ (↑p : Set ℝ), DifferentiableAt ℝ γ t := by
+  obtain ⟨p, -, hC1⟩ := h.exists_breakpoints
+  refine ⟨p, fun t ht => ?_⟩
+  obtain ⟨c, d, htcd, hsub, hdisj⟩ := exists_Icc_mem_avoiding ht.1 ht.2
+  exact ((hC1 c d hsub hdisj).differentiableOn one_ne_zero).differentiableAt
+    (Icc_mem_nhds htcd.1 htcd.2)
+
 /-- **Differentiability off a countable set.** A piecewise-`C¹` curve is differentiable at every
 interior parameter outside a countable set — the breakpoints. This is the exact regularity shape
 consumed by the raw contour-integral development (Dixon's argument and the winding-number
 machinery). -/
 theorem IsPiecewiseC1On.exists_countable_differentiableAt (h : IsPiecewiseC1On γ a b) :
     ∃ P : Set ℝ, P.Countable ∧
-      ∀ t ∈ Ioo (min a b) (max a b) \ P, DifferentiableAt ℝ γ t := by
-  obtain ⟨p, -, hC1⟩ := h.exists_breakpoints
-  refine ⟨↑p, p.countable_toSet, fun t ht => ?_⟩
-  obtain ⟨c, d, htcd, hsub, hdisj⟩ := exists_Icc_mem_avoiding ht.1 ht.2
-  exact ((hC1 c d hsub hdisj).differentiableOn one_ne_zero).differentiableAt
-    (Icc_mem_nhds htcd.1 htcd.2)
+      ∀ t ∈ Ioo (min a b) (max a b) \ P, DifferentiableAt ℝ γ t :=
+  let ⟨p, hp⟩ := h.exists_finset_differentiableAt
+  ⟨↑p, p.countable_toSet, hp⟩
+
+/-- **Eventual differentiability near an interior parameter**, on any within-filter avoiding
+the parameter itself. -/
+theorem IsPiecewiseC1On.eventually_differentiableAt (h : IsPiecewiseC1On γ a b) {t₀ : ℝ}
+    (ht₀ : t₀ ∈ Ioo (min a b) (max a b)) {u : Set ℝ} (hu : t₀ ∉ u) :
+    ∀ᶠ t in 𝓝[u] t₀, DifferentiableAt ℝ γ t := by
+  obtain ⟨p, hp⟩ := h.exists_finset_differentiableAt
+  have hcl : IsClosed ((↑p \ {t₀} : Set ℝ)) := (p.finite_toSet.subset sdiff_subset).isClosed
+  filter_upwards [nhdsWithin_le_nhds (hcl.isOpen_compl.mem_nhds (by simp)),
+    nhdsWithin_le_nhds (isOpen_Ioo.mem_nhds ht₀), self_mem_nhdsWithin] with t htc htIoo htu
+  exact hp t ⟨htIoo, fun htp => htc ⟨htp, fun h_eq => hu (h_eq ▸ htu)⟩⟩
+
+/-- Eventual differentiability from the right at an interior parameter. -/
+theorem IsPiecewiseC1On.eventually_differentiableAt_right (h : IsPiecewiseC1On γ a b)
+    {t₀ : ℝ} (ht₀ : t₀ ∈ Ioo (min a b) (max a b)) :
+    ∀ᶠ t in 𝓝[>] t₀, DifferentiableAt ℝ γ t :=
+  h.eventually_differentiableAt ht₀ self_notMem_Ioi
+
+/-- Eventual differentiability from the left at an interior parameter. -/
+theorem IsPiecewiseC1On.eventually_differentiableAt_left (h : IsPiecewiseC1On γ a b)
+    {t₀ : ℝ} (ht₀ : t₀ ∈ Ioo (min a b) (max a b)) :
+    ∀ᶠ t in 𝓝[<] t₀, DifferentiableAt ℝ γ t :=
+  h.eventually_differentiableAt ht₀ self_notMem_Iio
 
 /-- The derivative of a curve that is `C¹` on `[c, d]` is interval-integrable on `c..d`: the
 within-interval derivative is continuous on the compact piece, and agrees with `deriv` on the


### PR DESCRIPTION
## What

Three public lemmas on `IsPwC1ImmersionOn`, added to
`TauCeti/Analysis/Contour/CrossingFiniteness.lean` beside the crossing-isolation machinery
whose private proof core (`deriv_ne_zero_off_breakpoints`) they share:

```lean
theorem IsPwC1ImmersionOn.exists_finset_differentiableAt (h : IsPwC1ImmersionOn γ a b) :
    ∃ p : Finset ℝ, ∀ t ∈ Ioo (min a b) (max a b) \ (↑p : Set ℝ), DifferentiableAt ℝ γ t

theorem IsPwC1ImmersionOn.eventually_differentiableAt (h) (ht₀ : t₀ ∈ Ioo …) (hu : t₀ ∉ u) :
    ∀ᶠ t in 𝓝[u] t₀, DifferentiableAt ℝ γ t   -- + _right / _left corollaries
```

## Why

These are the remaining immersion-discharge hypotheses of the crossing chain: the eventual
one-sided differentiability feeds the crossing monotonicity (#931), the window splitting
(#939), and the per-window principal value (#940), and the finite-exception form is the
countable-exception hypothesis of the logarithmic FTC along the curve. With these, every
analytic hypothesis of the per-window machinery is dischargeable from `IsPwC1ImmersionOn` at
the assembly.

## Provenance

Migrated from `eventually_differentiable`(`_right`/`_left`) of `CrossingDataBuilder.lean` in
the AINTLIB `LeanModularForms` development, restated on the raw immersion predicate. See
N. Hungerbühler, M. Wasem, *Non-integer valued winding numbers and a generalized Residue
Theorem*, arXiv:1808.00997, §3.

## Roadmap

Advances `TauCetiRoadmap/ContourIntegration/Suggested.lean`: prerequisite for
`hasCauchyPV_half_residue` and `hungerbuhlerWasem_residueTheorem` (immersion discharge of the
per-window hypotheses).

## Gates

`lake build` ✓ · `lake exe axioms` ✓ (allowlist only) · `lake exe module-system` ✓ (509/509) ·
`scripts/lint-env.sh` ✓ (no new violations)

🤖 Generated with [Claude Code](https://claude.com/claude-code)