### PR TITLE
feat(Analysis/Contour): higher-order polar principal value along an immersion

### DIFF
--- a/TauCeti/Analysis/Contour/CrossingPVAggregation.lean
+++ b/TauCeti/Analysis/Contour/CrossingPVAggregation.lean
@@ -221,7 +221,7 @@ theorem hasCauchyPVAt_of_perWindow_boundary_tendsto {γ : ℝ → ℂ} {s : ℂ}
     (h_int_tr : ∀ ε : ℝ, 0 < ε →
       IntervalIntegrable (fun t => if ‖γ t - s‖ > ε then g (γ t) * deriv γ t else 0)
         MeasureTheory.volume a b)
-    (h_plain_eq : ∀ l u : ℝ, l ≤ u → (∀ t ∈ Icc l u, γ t ≠ s) →
+    (h_plain_eq : ∀ l u : ℝ, a ≤ l → l ≤ u → u ≤ b → (∀ t ∈ Icc l u, γ t ≠ s) →
       ∫ t in l..u, g (γ t) * deriv γ t = Φ (γ u) - Φ (γ l))
     (h_win : ∀ t ∈ crossings, Tendsto (fun ε : ℝ => ∫ u in (t - r)..(t + r),
         if ‖γ u - s‖ > ε then g (γ u) * deriv γ u else 0) (𝓝[>] (0 : ℝ))
@@ -240,7 +240,7 @@ theorem hasCauchyPVAt_of_perWindow_boundary_tendsto {γ : ℝ → ℂ} {s : ℂ}
         rw [h_eq, sub_self, norm_zero] at h_bd
         linarith
       have h0 := hasCauchyPVAt_plain_piece hab hm_pos h_int_tr hA hlu hu h_far'
-      rwa [h_plain_eq l u hlu h_ne] at h0)
+      rwa [h_plain_eq l u hA hlu hu h_ne] at h0)
     (crossings.sort (· ≤ ·)) (Finset.sortedLT_sort crossings) a le_rfl hab
     (fun t ht => h_lo t ((Finset.mem_sort _).mp ht))
     (fun t ht => h_hi t ((Finset.mem_sort _).mp ht))

--- a/TauCeti/Analysis/Contour/HigherOrderCPV.lean
+++ b/TauCeti/Analysis/Contour/HigherOrderCPV.lean
@@ -1,0 +1,192 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Chris Birkbeck
+-/
+module
+
+public import Mathlib.Analysis.Calculus.Deriv.Basic
+public import Mathlib.Analysis.Complex.Basic
+public import TauCeti.Analysis.Contour.CauchyPrincipalValue
+public import TauCeti.Analysis.Contour.PwC1ImmersionOn
+public import TauCeti.Analysis.Contour.RegularityConditions
+import TauCeti.Analysis.Contour.CrossingFiniteness
+import TauCeti.Analysis.Contour.CrossingPVAggregation
+import TauCeti.Analysis.Contour.CrossingWindows
+import TauCeti.Analysis.Contour.PerWindowHigherOrder
+import TauCeti.Analysis.Contour.PiecewiseC1On
+
+/-!
+# The principal value of a higher-order polar term along an immersed curve
+
+For a piecewise-`C¹` immersed curve `γ` on `[a, b]` whose value-`s` parameters are interior,
+flat of order `n ≥ k`, and sector-compatible, the single-point Cauchy principal value of the
+order-`k ≥ 2` polar term `t ↦ c / (γ t - s) ^ k * deriv γ t` exists on `[a, b]` and equals the
+boundary difference of the antiderivative `c · (-(k-1)⁻¹ (· - s)^{-(k-1)}) ∘ γ` — in
+particular it vanishes around a closed curve, which is why only the simple-pole part of a
+polar decomposition contributes to the generalized residue theorem. The crossings are finitely
+many (`Contour.IsPwC1ImmersionOn.finite_crossings`), a common window radius separates them
+(`Contour.exists_common_window_radius`), each window integral converges to the boundary
+difference (`Contour.perWindow_higherOrder_truncated_integral_tendsto`), and the pieces
+telescope (`Contour.hasCauchyPVAt_of_perWindow_boundary_tendsto`).
+
+The flatness and sector hypotheses are the raw per-crossing forms of the Hungerbühler–Wasem
+conditions (A′) and (B) at `s` (`Contour.FlatOfOrder`; the tangent-direction power equation,
+stated for the one-sided derivative limits, which are unique).
+
+## Main results
+
+* `Contour.IsPwC1ImmersionOn.hasCauchyPVAt_pow_inv` — the single-point principal value of the
+  order-`k ≥ 2` polar term along a piecewise-`C¹` immersion is the boundary difference of its
+  antiderivative.
+
+## Provenance
+
+Migrated from the higher-order content of `hasCauchyPVOn_multiCrossing_higherOrder_corner` of
+`MultiCrossingCPV.lean` in the AINTLIB `LeanModularForms` development (there stated for the
+bundled `ClosedPwC1Immersion`). See N. Hungerbühler, M. Wasem, *Non-integer valued winding
+numbers and a generalized Residue Theorem*, arXiv:1808.00997, §3.
+-/
+
+public section
+
+noncomputable section
+
+namespace TauCeti.Contour
+
+open Filter MeasureTheory Set Topology
+
+/-- At an interior crossing that is flat of order `n ≥ k` and sector-compatible, the truncated
+window integral of the order-`k` polar term converges to the boundary difference of the
+antiderivative, at every window radius whose window lies inside `[a, b]` and contains no other
+crossing. -/
+private theorem perWindow_boundary_tendsto_of_interior {γ : ℝ → ℂ} {a b t₀ : ℝ} {s : ℂ}
+    {k n : ℕ} {P : Set ℝ} (h_imm : IsPwC1ImmersionOn γ a b) (hab : a < b)
+    (ht₀ : t₀ ∈ Ioo a b) (h_at : γ t₀ = s) (hk : 2 ≤ k) (hkn : k ≤ n)
+    (h_flat : FlatOfOrder γ t₀ n)
+    (h_B : ∀ L_R L_L : ℂ, Tendsto (deriv γ) (𝓝[>] t₀) (𝓝 L_R) →
+      Tendsto (deriv γ) (𝓝[<] t₀) (𝓝 L_L) →
+      (L_R / (‖L_R‖ : ℂ)) ^ (k - 1) = ((-L_L) / (‖L_L‖ : ℂ)) ^ (k - 1))
+    (c : ℂ) (hP : P.Countable)
+    (hγ_diffP : ∀ t ∈ Ioo (min a b) (max a b) \ P, DifferentiableAt ℝ γ t)
+    {ρ : ℝ} (hρ_pos : 0 < ρ) (h_lo : a < t₀ - ρ) (h_hi : t₀ + ρ ≤ b)
+    (h_unique : ∀ t ∈ Icc (t₀ - ρ) (t₀ + ρ), γ t = s → t = t₀) :
+    Tendsto (fun ε : ℝ => ∫ t in (t₀ - ρ)..(t₀ + ρ),
+        if ‖γ t - s‖ > ε then c / (γ t - s) ^ k * deriv γ t else 0)
+      (𝓝[>] (0 : ℝ))
+      (𝓝 (c * (-(↑(k - 1) : ℂ)⁻¹ * ((γ (t₀ + ρ) - s) ^ (k - 1))⁻¹) -
+        c * (-(↑(k - 1) : ℂ)⁻¹ * ((γ (t₀ - ρ) - s) ^ (k - 1))⁻¹))) := by
+  have hmin : min a b = a := min_eq_left hab.le
+  have hmax : max a b = b := max_eq_right hab.le
+  have ht₀' : t₀ ∈ Ioo (min a b) (max a b) := by rwa [hmin, hmax]
+  obtain ⟨L_R, hL_R, h_tend_R⟩ := h_imm.exists_deriv_right_limit
+    (by rw [hmin, hmax]; exact ⟨ht₀.1.le, ht₀.2⟩)
+  obtain ⟨L_L, hL_L, h_tend_L⟩ := h_imm.exists_deriv_left_limit
+    (by rw [hmin, hmax]; exact ⟨ht₀.1, ht₀.2.le⟩)
+  refine perWindow_higherOrder_truncated_integral_tendsto hρ_pos h_at
+    (h_imm.continuousOn.mono (by
+      rw [uIcc_of_le hab.le]
+      exact Icc_subset_Icc (by linarith) h_hi))
+    hL_R hL_L h_tend_R h_tend_L
+    (h_imm.isPiecewiseC1On.eventually_differentiableAt_right ht₀')
+    (h_imm.isPiecewiseC1On.eventually_differentiableAt_left ht₀')
+    hP
+    (fun t ht => hγ_diffP t ⟨by
+      rw [hmin, hmax]
+      exact ⟨by linarith [ht.1.1], by linarith [ht.1.2]⟩, ht.2⟩)
+    (h_imm.isPiecewiseC1On.intervalIntegrable_deriv.mono_set (by
+      rw [uIcc_of_le (by linarith : t₀ - ρ ≤ t₀ + ρ), uIcc_of_le hab.le]
+      exact Icc_subset_Icc (by linarith) h_hi))
+    h_unique h_flat hk hkn (h_B L_R L_L h_tend_R h_tend_L) c
+
+/-- On a pole-free subinterval of `[a, b]`, the integral of the order-`k` polar term along a
+piecewise-`C¹` curve is the boundary difference of its antiderivative — the plain-piece input
+to the telescoping aggregation. -/
+private theorem plain_piece_integral_eq {γ : ℝ → ℂ} {a b : ℝ} {s : ℂ} {k : ℕ}
+    (h_imm : IsPwC1ImmersionOn γ a b) (hab : a < b) (hk : 2 ≤ k) (c : ℂ)
+    {l u : ℝ} (hal : a ≤ l) (hlu : l ≤ u) (hub : u ≤ b)
+    (h_ne : ∀ t ∈ Icc l u, γ t ≠ s) :
+    ∫ t in l..u, c / (γ t - s) ^ k * deriv γ t =
+      c * (-(↑(k - 1) : ℂ)⁻¹ * ((γ u - s) ^ (k - 1))⁻¹) -
+        c * (-(↑(k - 1) : ℂ)⁻¹ * ((γ l - s) ^ (k - 1))⁻¹) := by
+  obtain ⟨p, hp⟩ := h_imm.isPiecewiseC1On.exists_finset_differentiableAt
+  refine integral_pow_inv_mul_deriv_eq_sub hk c hlu p.countable_toSet h_ne
+    (fun t ht => hp t ⟨by
+      rw [min_eq_left hab.le, max_eq_right hab.le]
+      exact ⟨lt_of_le_of_lt hal ht.1.1, lt_of_lt_of_le ht.1.2 hub⟩, ht.2⟩)
+    ((h_imm.continuousOn.mono (uIcc_of_le hab.le).ge).mono (Icc_subset_Icc hal hub))
+    (h_imm.isPiecewiseC1On.intervalIntegrable_deriv.mono_set (by
+      rw [uIcc_of_le hlu, uIcc_of_le hab.le]
+      exact Icc_subset_Icc hal hub))
+
+/-- **The principal value of a higher-order polar term along a piecewise-`C¹` immersion is the
+boundary difference of its antiderivative**: if every parameter of `[a, b]` where `γ` meets
+`s` is interior, flat of order `n ≥ k`, and sector-compatible in the tangent-direction power
+sense, then for `k ≥ 2` the single-point Cauchy principal value of
+`t ↦ c / (γ t - s) ^ k * deriv γ t` at `s` exists on `[a, b]` with value
+`c · (-(k-1)⁻¹ (· - s)^{-(k-1)}) ∘ γ` differenced at the endpoints — zero around a closed
+curve. Endpoint crossings are excluded by `h_interior`; for a closed curve this is the choice
+of a basepoint off `s`. -/
+theorem IsPwC1ImmersionOn.hasCauchyPVAt_pow_inv {γ : ℝ → ℂ} {a b : ℝ} {s : ℂ} {k n : ℕ}
+    (h_imm : IsPwC1ImmersionOn γ a b) (hab : a ≤ b)
+    (h_interior : ∀ t ∈ Icc a b, γ t = s → t ∈ Ioo a b)
+    (hk : 2 ≤ k) (hkn : k ≤ n)
+    (h_flat : ∀ t ∈ Icc a b, γ t = s → FlatOfOrder γ t n)
+    (h_B : ∀ t ∈ Icc a b, γ t = s → ∀ L_R L_L : ℂ,
+      Tendsto (deriv γ) (𝓝[>] t) (𝓝 L_R) → Tendsto (deriv γ) (𝓝[<] t) (𝓝 L_L) →
+      (L_R / (‖L_R‖ : ℂ)) ^ (k - 1) = ((-L_L) / (‖L_L‖ : ℂ)) ^ (k - 1))
+    (c : ℂ) :
+    HasCauchyPVAt γ a b (fun z => c / (z - s) ^ k) s
+      (c * (-(↑(k - 1) : ℂ)⁻¹ * ((γ b - s) ^ (k - 1))⁻¹) -
+        c * (-(↑(k - 1) : ℂ)⁻¹ * ((γ a - s) ^ (k - 1))⁻¹)) := by
+  classical
+  rcases hab.eq_or_lt with rfl | hab
+  · simpa using HasCauchyPVAt.of_eq γ rfl (fun z => c / (z - s) ^ k) s
+  set T : Finset ℝ := (h_imm.finite_crossings (z₀ := s)).toFinset with hT_def
+  have hT_mem : ∀ {t : ℝ}, t ∈ T ↔ t ∈ Icc a b ∧ γ t = s := fun {t} => by
+    rw [hT_def, Set.Finite.mem_toFinset, Set.mem_inter_iff, Set.mem_preimage,
+      Set.mem_singleton_iff, uIcc_of_le hab.le]
+  have h_complete : ∀ t ∈ Icc a b, γ t = s → t ∈ T := fun t ht h_eq => hT_mem.mpr ⟨ht, h_eq⟩
+  have h_Ioo : ∀ t ∈ T, t ∈ Ioo a b := fun t ht =>
+    h_interior t (hT_mem.mp ht).1 (hT_mem.mp ht).2
+  have hγ_cont : ContinuousOn γ (Icc a b) := h_imm.continuousOn.mono (uIcc_of_le hab.le).ge
+  obtain ⟨p, hp⟩ := h_imm.isPiecewiseC1On.exists_finset_differentiableAt
+  have h_int_tr : ∀ ε : ℝ, 0 < ε → IntervalIntegrable
+      (fun t => if ‖γ t - s‖ > ε then c / (γ t - s) ^ k * deriv γ t else 0)
+      MeasureTheory.volume a b :=
+    fun _ hε => intervalIntegrable_pow_inv_mul_deriv_truncated c k h_imm.continuousOn
+      h_imm.isPiecewiseC1On.intervalIntegrable_deriv hε
+  have h_plain := fun l u =>
+    plain_piece_integral_eq (s := s) h_imm hab hk c (l := l) (u := u)
+  rcases T.eq_empty_or_nonempty with hT_empty | hT_ne
+  · refine hasCauchyPVAt_of_perWindow_boundary_tendsto
+      (Φ := fun z => c * (-(↑(k - 1) : ℂ)⁻¹ * ((z - s) ^ (k - 1))⁻¹))
+      one_pos hab.le T ?_ ?_ ?_ h_int_tr h_plain ?_
+      (exists_complement_windows_dist_lower_bound hγ_cont h_complete (fun _ => 1)
+        fun t _ => one_pos)
+    all_goals simp [hT_empty]
+  · obtain ⟨r₀, hr₀_pos, h_endpts, h_pair₀, -⟩ := exists_common_window_radius (P := ∅)
+      hT_ne h_Ioo fun t _ => Finset.notMem_empty t
+    have hρ_pos : 0 < r₀ / 2 := half_pos hr₀_pos
+    have hρ_lt : r₀ / 2 < r₀ := half_lt_self hr₀_pos
+    refine hasCauchyPVAt_of_perWindow_boundary_tendsto
+      (Φ := fun z => c * (-(↑(k - 1) : ℂ)⁻¹ * ((z - s) ^ (k - 1))⁻¹))
+      hρ_pos hab.le T
+      (fun t ht => by linarith [(h_endpts t ht).1])
+      (fun t ht => by linarith [(h_endpts t ht).2])
+      (fun t ht t' ht' hne => by linarith [h_pair₀ t ht t' ht' hne])
+      h_int_tr h_plain
+      (fun t₀ ht₀ => perWindow_boundary_tendsto_of_interior h_imm hab (h_Ioo t₀ ht₀)
+        (hT_mem.mp ht₀).2 hk hkn (h_flat t₀ (hT_mem.mp ht₀).1 (hT_mem.mp ht₀).2)
+        (h_B t₀ (hT_mem.mp ht₀).1 (hT_mem.mp ht₀).2) c p.countable_toSet hp hρ_pos
+        (by linarith [(h_endpts t₀ ht₀).1]) (by linarith [(h_endpts t₀ ht₀).2])
+        fun t ht h_eq => eq_of_mem_window_of_eq
+          (fun u hu => ⟨by linarith [(h_endpts u hu).1], by linarith [(h_endpts u hu).2]⟩)
+          (fun u hu u' hu' hne => by linarith [h_pair₀ u hu u' hu' hne, hr₀_pos])
+          h_complete ht₀ ht h_eq)
+      (exists_complement_windows_dist_lower_bound hγ_cont h_complete (fun _ => r₀ / 2)
+        fun t _ => hρ_pos)
+
+end TauCeti.Contour
+
+end

--- a/TauCeti/Analysis/Contour/HigherOrderCPV.lean
+++ b/TauCeti/Analysis/Contour/HigherOrderCPV.lean
@@ -168,7 +168,6 @@ theorem IsPwC1ImmersionOn.hasCauchyPVAt_pow_inv {γ : ℝ → ℂ} {a b : ℝ} {
   · obtain ⟨r₀, hr₀_pos, h_endpts, h_pair₀, -⟩ := exists_common_window_radius (P := ∅)
       hT_ne h_Ioo fun t _ => Finset.notMem_empty t
     have hρ_pos : 0 < r₀ / 2 := half_pos hr₀_pos
-    have hρ_lt : r₀ / 2 < r₀ := half_lt_self hr₀_pos
     refine hasCauchyPVAt_of_perWindow_boundary_tendsto
       (Φ := fun z => c * (-(↑(k - 1) : ℂ)⁻¹ * ((z - s) ^ (k - 1))⁻¹))
       hρ_pos hab.le T

--- a/TauCeti/Analysis/Contour/PerWindowHigherOrder.lean
+++ b/TauCeti/Analysis/Contour/PerWindowHigherOrder.lean
@@ -36,6 +36,10 @@ Hungerbühler–Wasem condition (B) at a higher-order pole.
 
 * `Contour.perWindow_higherOrder_truncated_integral_tendsto` — the truncated window integral
   of the order-`k` polar term converges, with the explicit boundary-difference value.
+* `Contour.integral_pow_inv_mul_deriv_eq_sub` — the fundamental theorem of calculus for the
+  order-`k` polar term along the curve, on an interval avoiding the pole.
+* `Contour.intervalIntegrable_pow_inv_mul_deriv_truncated` — the truncated order-`k` polar
+  integrand is interval-integrable at every truncation level `ε > 0`.
 
 ## Provenance
 
@@ -69,7 +73,7 @@ private theorem intervalIntegrable_pow_inv_mul_deriv {γ : ℝ → ℂ} {s : ℂ
 
 /-- The `ε`-truncated order-`k` polar integrand is interval-integrable: off the `ε`-ball it is
 dominated by `(‖c‖ / ε^k) · ‖deriv γ‖`. -/
-private theorem intervalIntegrable_pow_inv_mul_deriv_truncated {γ : ℝ → ℂ} {s : ℂ} {a b : ℝ}
+theorem intervalIntegrable_pow_inv_mul_deriv_truncated {γ : ℝ → ℂ} {s : ℂ} {a b : ℝ}
     (c : ℂ) (k : ℕ) (hγ_cont : ContinuousOn γ (uIcc a b))
     (hderiv_int : IntervalIntegrable (fun t => deriv γ t) MeasureTheory.volume a b)
     {ε : ℝ} (hε : 0 < ε) :
@@ -111,7 +115,7 @@ private theorem intervalIntegrable_pow_inv_mul_deriv_truncated {γ : ℝ → ℂ
 /-- The fundamental theorem of calculus for the order-`k` polar term along the curve, on an
 interval avoiding the pole: the integral is the boundary difference of the antiderivative
 `c · (-(k-1)⁻¹ (· - s)^{-(k-1)}) ∘ γ`. -/
-private theorem integral_pow_inv_mul_deriv_eq_sub {γ : ℝ → ℂ} {s : ℂ} {k : ℕ} (hk : 2 ≤ k) (c : ℂ)
+theorem integral_pow_inv_mul_deriv_eq_sub {γ : ℝ → ℂ} {s : ℂ} {k : ℕ} (hk : 2 ≤ k) (c : ℂ)
     {l u : ℝ} (hlu : l ≤ u) {P : Set ℝ} (hP : P.Countable)
     (h_ne : ∀ t ∈ Icc l u, γ t ≠ s)
     (h_diff : ∀ t ∈ Ioo l u \ P, DifferentiableAt ℝ γ t)


### PR DESCRIPTION
## What

New file `TauCeti/Analysis/Contour/HigherOrderCPV.lean` whose main theorem gives the
principal value of an order-`k ≥ 2` polar term along an immersed curve, with its explicit
value:

```lean
theorem IsPwC1ImmersionOn.hasCauchyPVAt_pow_inv {γ : ℝ → ℂ} {a b : ℝ} {s : ℂ} {k n : ℕ}
    (h_imm : IsPwC1ImmersionOn γ a b) (hab : a ≤ b)
    (h_interior : ∀ t ∈ Icc a b, γ t = s → t ∈ Ioo a b)
    (hk : 2 ≤ k) (hkn : k ≤ n)
    (h_flat : ∀ t ∈ Icc a b, γ t = s → FlatOfOrder γ t n)
    (h_B : ∀ t ∈ Icc a b, γ t = s → ∀ L_R L_L : ℂ,
      Tendsto (deriv γ) (𝓝[>] t) (𝓝 L_R) → Tendsto (deriv γ) (𝓝[<] t) (𝓝 L_L) →
      (L_R / (‖L_R‖ : ℂ)) ^ (k - 1) = ((-L_L) / (‖L_L‖ : ℂ)) ^ (k - 1))
    (c : ℂ) :
    HasCauchyPVAt γ a b (fun z => c / (z - s) ^ k) s
      (c * (-(↑(k - 1) : ℂ)⁻¹ * ((γ b - s) ^ (k - 1))⁻¹) -
        c * (-(↑(k - 1) : ℂ)⁻¹ * ((γ a - s) ^ (k - 1))⁻¹))
```

Two enabling adjustments in the consumed files:

* `CrossingPVAggregation.lean` — the telescoping aggregation's `h_plain_eq` now quantifies
  only over subintervals `a ≤ l ≤ u ≤ b` (all its induction ever uses). The unrestricted form
  demanded the boundary identity on intervals where the caller has **no** regularity of `γ`,
  so no immersion-based consumer could discharge it; this is a strict generalization of the
  theorem.
* `PerWindowHigherOrder.lean` — `integral_pow_inv_mul_deriv_eq_sub` (the order-`k` FTC along
  the curve) and `intervalIntegrable_pow_inv_mul_deriv_truncated` flip from private to
  public: they are exactly the plain-piece and truncation clauses of the aggregation.

## Why

This is the vanishing half of the generalized residue theorem: around a **closed** curve the
value collapses to `Φ(γ b) - Φ(γ a) = 0`, which is why only the simple-pole coefficient of a
polar decomposition (#930) survives. The crossing hypotheses are the raw per-crossing forms
of the Hungerbühler–Wasem conditions (A′) and (B) at `s`: `FlatOfOrder` from
`RegularityConditions.lean`, and the tangent-direction power equation stated over the
one-sided derivative limits (which are unique, so the `∀`-form pins exactly one instance per
crossing). The proof is assembly: finite crossings (#942), common window radius (#935),
per-window boundary-difference limits (#943) at the half radius, in-window uniqueness (#935),
off-window distance bound (#941), telescoping aggregation (#947). Unlike the simple-pole case
there are no slit-plane radii to shrink, so no per-crossing radius choice is needed.

## Provenance

Migrated from the higher-order content of `hasCauchyPVOn_multiCrossing_higherOrder_corner` of
`MultiCrossingCPV.lean` in the AINTLIB `LeanModularForms` development (there stated for the
bundled `ClosedPwC1Immersion`). See N. Hungerbühler, M. Wasem, *Non-integer valued winding
numbers and a generalized Residue Theorem*, arXiv:1808.00997, §3.

## Roadmap

Advances `TauCetiRoadmap/ContourIntegration/Suggested.lean`: prerequisite for
`hungerbuhlerWasem_residueTheorem` and `hasCauchyPV_half_residue` (vanishing of the
higher-order polar contributions around a closed curve).

## Gates

`lake build` ✓ · `lake exe axioms` ✓ (allowlist only) · `lake exe module-system` ✓ (514/514) ·
`scripts/lint-env.sh` ✓ (no new violations)

🤖 Generated with [Claude Code](https://claude.com/claude-code)