### PR TITLE
feat(Analysis/Contour): polar-part principal value is the winding-weighted residue

### DIFF
--- a/TauCeti/Analysis/Contour/PolarPartCPV.lean
+++ b/TauCeti/Analysis/Contour/PolarPartCPV.lean
@@ -17,9 +17,10 @@ import TauCeti.Analysis.Contour.InvSubCPVExistence
 /-!
 # The principal value of a polar part is the winding-weighted residue
 
-For a piecewise-`C¹` immersed **closed** curve whose crossings of a pole `s ∈ S` are interior,
-flat of the pole's order, and sector-compatible, the single-point Cauchy principal value of the
-polar part of `f` at `s` along the curve is `2πi · n_s(γ) · Res_s f` — the term `s` contributes
+For a piecewise-`C¹` immersed **closed** curve whose crossings of a pole `s ∈ S` are interior
+and, at every surviving higher-order coefficient, flat and sector-compatible, the single-point
+Cauchy principal value of the polar part of `f` at `s` along the curve is
+`2πi · n_s(γ) · Res_s f` — the term `s` contributes
 to the Hungerbühler–Wasem sum. The simple-pole coefficient contributes its winding-weighted
 residue by the definitional identity `windingNumber = (2πi)⁻¹ · cauchyPVAt` together with the
 existence theorem (`Contour.IsPwC1ImmersionOn.cauchyPVExistsAt_inv_sub`); every order-`k ≥ 2`
@@ -62,7 +63,8 @@ private theorem hasCauchyPVAt_polarPart_term (decomp : PolarPartDecomposition f 
     {γ : ℝ → ℂ} {a b : ℝ} (h_imm : IsPwC1ImmersionOn γ a b) (hab : a ≤ b)
     (hclosed : γ a = γ b)
     (h_interior : ∀ t ∈ Icc a b, γ t = (s : ℂ) → t ∈ Ioo a b)
-    (h_flat : ∀ t ∈ Icc a b, γ t = (s : ℂ) → FlatOfOrder γ t (decomp.order s))
+    (h_flat : ∀ k : Fin (decomp.order s), 1 ≤ k.val → decomp.coeff s k ≠ 0 →
+      ∀ t ∈ Icc a b, γ t = (s : ℂ) → FlatOfOrder γ t (k.val + 1))
     (h_B : ∀ k : Fin (decomp.order s), 1 ≤ k.val → decomp.coeff s k ≠ 0 →
       ∀ t ∈ Icc a b, γ t = (s : ℂ) → ∀ L_R L_L : ℂ,
         Tendsto (deriv γ) (𝓝[>] t) (𝓝 L_R) → Tendsto (deriv γ) (𝓝[<] t) (𝓝 L_L) →
@@ -81,13 +83,13 @@ private theorem hasCauchyPVAt_polarPart_term (decomp : PolarPartDecomposition f 
     by_cases hc : decomp.coeff s k = 0
     · exact HasCauchyPVAt.zero.congr_along_curve fun t _ => by rw [hc, zero_div]
     · have h_vanish := h_imm.hasCauchyPVAt_pow_inv hab h_interior
-        (Nat.succ_le_succ hk_pos) k.isLt h_flat
+        (Nat.succ_le_succ hk_pos) le_rfl (h_flat k hk_pos hc)
         (fun t ht h_eq => h_B k hk_pos hc t ht h_eq) (decomp.coeff s k)
       rwa [hclosed, sub_self] at h_vanish
 
 /-- **The principal value of a polar part is the winding-weighted residue**: along a closed
-piecewise-`C¹` immersion whose crossings of `s` are interior, flat of the pole's order, and
-sector-compatible at every surviving higher-order coefficient, the single-point Cauchy
+piecewise-`C¹` immersion whose crossings of `s` are interior and, at every surviving
+higher-order coefficient, flat and sector-compatible, the single-point Cauchy
 principal value of `decomp.polarPart s` at `s` is `2πi · n_s(γ) · Res_s f`. The higher-order
 coefficients contribute nothing — this is the term the Hungerbühler–Wasem sum attributes to
 `s`. -/
@@ -95,7 +97,8 @@ theorem hasCauchyPVAt_polarPart (decomp : PolarPartDecomposition f S U) (s : S)
     {γ : ℝ → ℂ} {a b : ℝ} (h_imm : IsPwC1ImmersionOn γ a b) (hab : a ≤ b)
     (hclosed : γ a = γ b)
     (h_interior : ∀ t ∈ Icc a b, γ t = (s : ℂ) → t ∈ Ioo a b)
-    (h_flat : ∀ t ∈ Icc a b, γ t = (s : ℂ) → FlatOfOrder γ t (decomp.order s))
+    (h_flat : ∀ k : Fin (decomp.order s), 1 ≤ k.val → decomp.coeff s k ≠ 0 →
+      ∀ t ∈ Icc a b, γ t = (s : ℂ) → FlatOfOrder γ t (k.val + 1))
     (h_B : ∀ k : Fin (decomp.order s), 1 ≤ k.val → decomp.coeff s k ≠ 0 →
       ∀ t ∈ Icc a b, γ t = (s : ℂ) → ∀ L_R L_L : ℂ,
         Tendsto (deriv γ) (𝓝[>] t) (𝓝 L_R) → Tendsto (deriv γ) (𝓝[<] t) (𝓝 L_L) →

--- a/TauCeti/Analysis/Contour/PolarPartCPV.lean
+++ b/TauCeti/Analysis/Contour/PolarPartCPV.lean
@@ -1,0 +1,138 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Chris Birkbeck
+-/
+module
+
+public import Mathlib.Analysis.Calculus.Deriv.Basic
+public import Mathlib.Analysis.Complex.Basic
+public import TauCeti.Analysis.Contour.PolarPartDecomposition
+public import TauCeti.Analysis.Contour.PwC1ImmersionOn
+public import TauCeti.Analysis.Contour.RegularityConditions
+public import TauCeti.Analysis.Contour.WindingNumber
+import TauCeti.Analysis.Contour.HigherOrderCPV
+import TauCeti.Analysis.Contour.InvSubCPVExistence
+
+/-!
+# The principal value of a polar part is the winding-weighted residue
+
+For a piecewise-`C¹` immersed **closed** curve whose crossings of a pole `s ∈ S` are interior,
+flat of the pole's order, and sector-compatible, the single-point Cauchy principal value of the
+polar part of `f` at `s` along the curve is `2πi · n_s(γ) · Res_s f` — the term `s` contributes
+to the Hungerbühler–Wasem sum. The simple-pole coefficient contributes its winding-weighted
+residue by the definitional identity `windingNumber = (2πi)⁻¹ · cauchyPVAt` together with the
+existence theorem (`Contour.IsPwC1ImmersionOn.cauchyPVExistsAt_inv_sub`); every order-`k ≥ 2`
+coefficient contributes zero around a closed curve
+(`Contour.IsPwC1ImmersionOn.hasCauchyPVAt_pow_inv`); the finite Laurent sum assembles by
+`ℂ`-linearity, and the leading coefficient is the residue
+(`Contour.PolarPartDecomposition.residue_eq`).
+
+## Main results
+
+* `Contour.PolarPartDecomposition.hasCauchyPVAt_polarPart` — the single-point principal value
+  of the polar part at `s` along a closed immersion is `2πi · windingNumber · residue`.
+
+## Provenance
+
+Migrated from `cpv_polarPart_at_multiCrossed_pole_under_condB_corner` of
+`MultiCrossingCPV.lean` in the AINTLIB `LeanModularForms` development, restated for a raw
+curve: the simple-pole principal value is derived from the immersion rather than assumed, and
+the sector hypothesis quantifies over the one-sided derivative limits (which are unique)
+instead of chosen tangent functions. See N. Hungerbühler, M. Wasem, *Non-integer valued
+winding numbers and a generalized Residue Theorem*, arXiv:1808.00997, §3.
+-/
+
+public section
+
+noncomputable section
+
+namespace TauCeti.Contour
+
+open Filter Set Topology
+
+namespace PolarPartDecomposition
+
+variable {f : ℂ → ℂ} {S : Finset ℂ} {U : Set ℂ}
+
+/-- One Laurent term of the polar part: the simple-pole term carries the value
+`coeff · cauchyPVAt` of the winding kernel, and every higher-order term carries zero around a
+closed curve. -/
+private theorem hasCauchyPVAt_polarPart_term (decomp : PolarPartDecomposition f S U) (s : S)
+    {γ : ℝ → ℂ} {a b : ℝ} (h_imm : IsPwC1ImmersionOn γ a b) (hab : a ≤ b)
+    (hclosed : γ a = γ b)
+    (h_interior : ∀ t ∈ Icc a b, γ t = (s : ℂ) → t ∈ Ioo a b)
+    (h_flat : ∀ t ∈ Icc a b, γ t = (s : ℂ) → FlatOfOrder γ t (decomp.order s))
+    (h_B : ∀ k : Fin (decomp.order s), 1 ≤ k.val → decomp.coeff s k ≠ 0 →
+      ∀ t ∈ Icc a b, γ t = (s : ℂ) → ∀ L_R L_L : ℂ,
+        Tendsto (deriv γ) (𝓝[>] t) (𝓝 L_R) → Tendsto (deriv γ) (𝓝[<] t) (𝓝 L_L) →
+        (L_R / (‖L_R‖ : ℂ)) ^ k.val = ((-L_L) / (‖L_L‖ : ℂ)) ^ k.val)
+    (k : Fin (decomp.order s)) :
+    HasCauchyPVAt γ a b (fun z => decomp.coeff s k / (z - (s : ℂ)) ^ (k.val + 1)) (s : ℂ)
+      (if k.val = 0 then
+        decomp.coeff s k * cauchyPVAt γ a b (fun z => (z - (s : ℂ))⁻¹) (s : ℂ) else 0) := by
+  rcases Nat.eq_zero_or_pos k.val with hk0 | hk_pos
+  · rw [if_pos hk0]
+    refine (((h_imm.cauchyPVExistsAt_inv_sub hab
+      h_interior).hasCauchyPVAt_cauchyPVAt).const_mul
+        (decomp.coeff s k)).congr_along_curve fun t _ => ?_
+    rw [hk0, zero_add, pow_one, div_eq_mul_inv]
+  · rw [if_neg (Nat.pos_iff_ne_zero.mp hk_pos)]
+    by_cases hc : decomp.coeff s k = 0
+    · exact HasCauchyPVAt.zero.congr_along_curve fun t _ => by rw [hc, zero_div]
+    · have h_vanish := h_imm.hasCauchyPVAt_pow_inv hab h_interior
+        (Nat.succ_le_succ hk_pos) k.isLt h_flat
+        (fun t ht h_eq => h_B k hk_pos hc t ht h_eq) (decomp.coeff s k)
+      rwa [hclosed, sub_self] at h_vanish
+
+/-- **The principal value of a polar part is the winding-weighted residue**: along a closed
+piecewise-`C¹` immersion whose crossings of `s` are interior, flat of the pole's order, and
+sector-compatible at every surviving higher-order coefficient, the single-point Cauchy
+principal value of `decomp.polarPart s` at `s` is `2πi · n_s(γ) · Res_s f`. The higher-order
+coefficients contribute nothing — this is the term the Hungerbühler–Wasem sum attributes to
+`s`. -/
+theorem hasCauchyPVAt_polarPart (decomp : PolarPartDecomposition f S U) (s : S)
+    {γ : ℝ → ℂ} {a b : ℝ} (h_imm : IsPwC1ImmersionOn γ a b) (hab : a ≤ b)
+    (hclosed : γ a = γ b)
+    (h_interior : ∀ t ∈ Icc a b, γ t = (s : ℂ) → t ∈ Ioo a b)
+    (h_flat : ∀ t ∈ Icc a b, γ t = (s : ℂ) → FlatOfOrder γ t (decomp.order s))
+    (h_B : ∀ k : Fin (decomp.order s), 1 ≤ k.val → decomp.coeff s k ≠ 0 →
+      ∀ t ∈ Icc a b, γ t = (s : ℂ) → ∀ L_R L_L : ℂ,
+        Tendsto (deriv γ) (𝓝[>] t) (𝓝 L_R) → Tendsto (deriv γ) (𝓝[<] t) (𝓝 L_L) →
+        (L_R / (‖L_R‖ : ℂ)) ^ k.val = ((-L_L) / (‖L_L‖ : ℂ)) ^ k.val) :
+    HasCauchyPVAt γ a b (decomp.polarPart s) (s : ℂ)
+      (2 * (Real.pi : ℂ) * Complex.I * windingNumber γ a b s * residue f s) := by
+  classical
+  have h_sum := HasCauchyPVAt.sum (s := (Finset.univ : Finset (Fin (decomp.order s))))
+    fun k _ =>
+      hasCauchyPVAt_polarPart_term decomp s h_imm hab hclosed h_interior h_flat h_B k
+  have h_pv := h_sum.congr_along_curve fun t _ => (decomp.polarPart_eq s (γ t)).symm
+  have h_val : (∑ k : Fin (decomp.order s), if k.val = 0 then
+        decomp.coeff s k * cauchyPVAt γ a b (fun z => (z - (s : ℂ))⁻¹) (s : ℂ) else 0)
+      = 2 * (Real.pi : ℂ) * Complex.I * windingNumber γ a b s * residue f s := by
+    rcases Nat.eq_zero_or_pos (decomp.order s) with h0 | h_pos
+    · rw [Finset.sum_eq_zero fun k _ => absurd k.isLt (by omega),
+        decomp.residue_eq s, dif_neg (by omega)]
+      ring
+    · have h_pick : ∀ k : Fin (decomp.order s),
+          (if k.val = 0 then
+            decomp.coeff s k * cauchyPVAt γ a b (fun z => (z - (s : ℂ))⁻¹) (s : ℂ) else 0)
+          = if k = ⟨0, h_pos⟩ then
+            decomp.coeff s ⟨0, h_pos⟩ * cauchyPVAt γ a b (fun z => (z - (s : ℂ))⁻¹) (s : ℂ)
+          else 0 := fun k => by
+        rcases eq_or_ne k ⟨0, h_pos⟩ with rfl | hk
+        · simp
+        · rw [if_neg fun h => hk (Fin.ext h), if_neg hk]
+      rw [Finset.sum_congr rfl fun k _ => h_pick k, Finset.sum_ite_eq' Finset.univ,
+        if_pos (Finset.mem_univ _), decomp.residue_eq s, dif_pos h_pos,
+        windingNumber_eq_cauchyPVAt, ← mul_assoc,
+        mul_inv_cancel₀ Complex.two_pi_I_ne_zero, one_mul]
+      ring
+  rw [← h_val]
+  exact h_pv
+
+end PolarPartDecomposition
+
+end TauCeti.Contour
+
+end


### PR DESCRIPTION
## What

New file `TauCeti/Analysis/Contour/PolarPartCPV.lean`, one public theorem:

```lean
theorem PolarPartDecomposition.hasCauchyPVAt_polarPart (decomp : PolarPartDecomposition f S U)
    (s : S) {γ : ℝ → ℂ} {a b : ℝ} (h_imm : IsPwC1ImmersionOn γ a b) (hab : a ≤ b)
    (hclosed : γ a = γ b)
    (h_interior : ∀ t ∈ Icc a b, γ t = (s : ℂ) → t ∈ Ioo a b)
    (h_flat : ∀ t ∈ Icc a b, γ t = (s : ℂ) → FlatOfOrder γ t (decomp.order s))
    (h_B : ∀ k : Fin (decomp.order s), 1 ≤ k.val → decomp.coeff s k ≠ 0 → …raw sector eq…) :
    HasCauchyPVAt γ a b (decomp.polarPart s) (s : ℂ)
      (2 * (Real.pi : ℂ) * Complex.I * windingNumber γ a b s * residue f s)
```

with one private per-Laurent-term lemma.

## Why

This is the per-pole term of the Hungerbühler–Wasem sum, assembled from the three merged
pillars with **no new analysis**: the simple-pole coefficient contributes its winding-weighted
residue because `windingNumber` is *defined* as `(2πi)⁻¹ · cauchyPVAt` and the principal value
exists (#949); every order-`k ≥ 2` coefficient contributes zero because its principal value is
the boundary difference of an antiderivative (#950) and the curve is closed; the finite
Laurent sum assembles by the `ℂ`-linearity of `HasCauchyPVAt`, and the leading coefficient is
the residue by the decomposition's `residue_eq` (#930). The flatness hypothesis is taken once
at the pole's full order — it covers every `k ≤ order` — and the sector hypothesis only binds
the surviving (`coeff ≠ 0`) higher-order coefficients, exactly HW's condition (B).

What remains for the summit is glue: sum this over `s ∈ S`, integrate the analytic remainder
to zero (`intervalIntegral_deriv_smul_analyticRemainder_eq_zero`, #930), and lift to the
set-level excision.

## Provenance

Migrated from `cpv_polarPart_at_multiCrossed_pole_under_condB_corner` of
`MultiCrossingCPV.lean` in the AINTLIB `LeanModularForms` development, restated for a raw
curve: the simple-pole principal value is derived from the immersion rather than assumed
(AINTLIB takes `h_simple_cpv` as data), and the sector hypothesis quantifies over the
one-sided derivative limits (unique) instead of chosen tangent functions. See N. Hungerbühler,
M. Wasem, *Non-integer valued winding numbers and a generalized Residue Theorem*,
arXiv:1808.00997, §3.

## Roadmap

Advances `TauCetiRoadmap/ContourIntegration/Suggested.lean`: prerequisite for
`hungerbuhlerWasem_residueTheorem` and `hasCauchyPV_half_residue` (the per-pole contribution
of the polar decomposition).

## Gates

`lake build` ✓ · `lake exe axioms` ✓ (allowlist only) · `lake exe module-system` ✓ (516/516) ·
`scripts/lint-env.sh` ✓ (no new violations)

🤖 Generated with [Claude Code](https://claude.com/claude-code)