### PR TITLE
feat(Analysis/Contour): bridges for consuming the HW conditions

### DIFF
--- a/TauCeti/Analysis/Contour/ArgumentLift.lean
+++ b/TauCeti/Analysis/Contour/ArgumentLift.lean
@@ -34,6 +34,8 @@ API does not expose.
   on `[a, b]`, for a curve continuous there and avoiding `w`, plus a monotone partition witness.
 * `TauCeti.Contour.segRatio` and its evaluation lemmas — the segment-ratio building block used to
   assemble the index integral downstream.
+* `TauCeti.Contour.div_norm_eq_exp_arg_mul_I` — the unit direction of a nonzero complex number
+  in polar form, shared with the sector-resonance bridges.
 
 ## Provenance
 
@@ -276,15 +278,19 @@ private theorem continuousOn_im_log_segRatio {γ : ℝ → ℂ} {a b : ℝ}
   exact (continuousOn_segRatio hγ hsj hsjp1 h_le).clog
     fun t _ ↦ segRatio_mem_slitPlane hρ_pos h_dist_lb h_unif hsj hsjp1 h_le h_mesh t
 
-/-! ### Helper: `exp(I · Im(log z)) = z / ‖z‖` -/
+/-! ### The unit direction in polar form -/
+
+/-- **A nonzero complex number over its norm is the exponential of its argument**:
+`w / ↑‖w‖ = exp(arg w · I)`. -/
+theorem div_norm_eq_exp_arg_mul_I {w : ℂ} (hw : w ≠ 0) :
+    w / (‖w‖ : ℂ) = Complex.exp ((Complex.arg w : ℂ) * Complex.I) := by
+  rw [div_eq_iff (Complex.ofReal_ne_zero.mpr (norm_ne_zero_iff.mpr hw)), mul_comm]
+  exact (Complex.norm_mul_exp_arg_mul_I w).symm
 
 /-- For a nonzero complex number `z`, `exp(I · Im(log z)) = z / ↑‖z‖`. -/
 private lemma exp_I_log_im_eq_div_norm {z : ℂ} (hz : z ≠ 0) :
     Complex.exp (Complex.I * ((Complex.log z).im : ℂ)) = z / (‖z‖ : ℂ) := by
-  have hz' : (‖z‖ : ℂ) ≠ 0 := Complex.ofReal_ne_zero.mpr (norm_ne_zero_iff.mpr hz)
-  rw [eq_div_iff hz', Complex.log_im, mul_comm Complex.I (Complex.arg z : ℂ)]
-  conv_rhs => rw [← Complex.norm_mul_exp_arg_mul_I z]
-  ring
+  rw [Complex.log_im, mul_comm, ← div_norm_eq_exp_arg_mul_I hz]
 
 /-! ### Polar form of a product -/
 

--- a/TauCeti/Analysis/Contour/RegularityConditions.lean
+++ b/TauCeti/Analysis/Contour/RegularityConditions.lean
@@ -11,6 +11,7 @@ public import Mathlib.Analysis.Analytic.Basic
 public import Mathlib.Analysis.Meromorphic.Order
 public import Mathlib.Algebra.Order.ToIntervalMod
 import Mathlib.Analysis.SpecialFunctions.Complex.Log
+import TauCeti.Analysis.Contour.ArgumentLift
 
 /-!
 # The Hungerbühler–Wasem crossing angle and regularity conditions (A′) and (B)
@@ -50,9 +51,11 @@ pole — and that it meet each `s` only finitely often. Condition (B) governs po
 * `ConditionB γ a b f` — HW condition (B), a structure imposing `SectorCompatible` at every
   higher-order (order `> 1`) on-curve pole of `f`: at each interior crossing (`ConditionB.interior`)
   and at the basepoint (`ConditionB.basepoint`).
-* `FlatOfOrder.of_le` and `pow_unit_tangent_eq_of_resonance` — the consuming bridges: flatness
-  restricts downward in the order, and the sector resonance `k · θ ∈ 2π · ℤ` at the crossing
-  angle is the power equation of the unit tangent directions.
+* `FlatOfOrder.of_le` / `FlatOfOrderBasepoint.of_le` and `pow_unit_tangent_eq_of_resonance` /
+  `pow_unit_tangent_eq_of_basepoint_resonance` — the consuming bridges, at interior crossings
+  and at the join: flatness restricts downward in the order, and the sector resonance
+  `k · θ ∈ 2π · ℤ` at the crossing angle is the power equation of the unit tangent
+  directions.
 
 Both conditions read the on-curve pole orders of `f` from `meromorphicOrderAt`. Condition (B) needs
 no explicit singular set — it fires **intrinsically** at the times `t₀` where
@@ -337,29 +340,74 @@ The two bridges from the conditions' data to the raw hypotheses the principal-va
 take: flatness restricts downward in the order, and the sector resonance `k · θ ∈ 2π · ℤ` at
 the crossing angle is the power equation of the unit tangent directions. -/
 
+/-- One-sided core of the downward restrictions: near `c` the chord is small, so on any
+filter within `𝓝 c` an `o(‖γ · - γ c‖ ^ n)` bound is an `o(‖γ · - γ c‖ ^ m)` bound for
+`m ≤ n`. -/
+private theorem isLittleO_chord_pow_of_le {γ : ℝ → ℂ} {c : ℝ} {u : ℝ → ℝ} {m n : ℕ}
+    {l : Filter ℝ} (hmn : m ≤ n) (h_le : l ≤ 𝓝 c) (h_cont : ContinuousAt γ c)
+    (h : u =o[l] fun t => ‖γ t - γ c‖ ^ n) : u =o[l] fun t => ‖γ t - γ c‖ ^ m := by
+  refine h.trans_isBigO (Asymptotics.IsBigO.of_bound 1 ?_)
+  have h_ev : ∀ᶠ t in 𝓝 c, ‖γ t - γ c‖ ≤ 1 := by
+    have h1 : Filter.Tendsto (fun t => γ t - γ c) (𝓝 c) (𝓝 (γ c - γ c)) :=
+      (h_cont.sub continuousAt_const).tendsto
+    rw [sub_self] at h1
+    have h0 : Filter.Tendsto (fun t => ‖γ t - γ c‖) (𝓝 c) (𝓝 0) := by
+      simpa using h1.norm
+    exact h0.eventually_le_const one_pos
+  filter_upwards [h_le h_ev] with t ht
+  rw [one_mul, Real.norm_of_nonneg (pow_nonneg (norm_nonneg _) _),
+    Real.norm_of_nonneg (pow_nonneg (norm_nonneg _) _)]
+  exact pow_le_pow_of_le_one (norm_nonneg _) ht hmn
+
 /-- **Flatness restricts downward**: a curve flat of order `n` at `t₀` is flat of every order
 `m ≤ n` — near the crossing the chord is small, so a higher power of it is the stronger
 bound. -/
 theorem FlatOfOrder.of_le {γ : ℝ → ℂ} {t₀ : ℝ} {m n : ℕ} (h : FlatOfOrder γ t₀ n)
     (hmn : m ≤ n) (h_cont : ContinuousAt γ t₀) : FlatOfOrder γ t₀ m := by
   obtain ⟨v_p, v_m, hv_p, hv_m, h_right, h_left⟩ := h
-  have h_ev : ∀ᶠ t in 𝓝 t₀, ‖γ t - γ t₀‖ ≤ 1 := by
-    have h0 : Filter.Tendsto (fun t => ‖γ t - γ t₀‖) (𝓝 t₀) (𝓝 0) := by
-      have h1 : Filter.Tendsto (fun t => γ t - γ t₀) (𝓝 t₀) (𝓝 (γ t₀ - γ t₀)) :=
-        (h_cont.sub continuousAt_const).tendsto
-      rw [sub_self] at h1
-      simpa using h1.norm
-    exact h0.eventually_le_const one_pos
-  have h_pow : ∀ t, ‖γ t - γ t₀‖ ≤ 1 →
-      ‖‖γ t - γ t₀‖ ^ n‖ ≤ 1 * ‖‖γ t - γ t₀‖ ^ m‖ := fun t ht => by
-    rw [one_mul, Real.norm_of_nonneg (pow_nonneg (norm_nonneg _) _),
-      Real.norm_of_nonneg (pow_nonneg (norm_nonneg _) _)]
-    exact pow_le_pow_of_le_one (norm_nonneg _) ht hmn
-  refine ⟨v_p, v_m, hv_p, hv_m,
-    h_right.trans_isBigO (Asymptotics.IsBigO.of_bound 1 ?_),
-    h_left.trans_isBigO (Asymptotics.IsBigO.of_bound 1 ?_)⟩ <;>
-    · filter_upwards [nhdsWithin_le_nhds h_ev] with t ht
-      exact h_pow t ht
+  exact ⟨v_p, v_m, hv_p, hv_m,
+    isLittleO_chord_pow_of_le hmn nhdsWithin_le_nhds h_cont h_right,
+    isLittleO_chord_pow_of_le hmn nhdsWithin_le_nhds h_cont h_left⟩
+
+/-- **Basepoint flatness restricts downward**: a closed curve flat of order `n` across the
+join is flat of every order `m ≤ n` there. -/
+theorem FlatOfOrderBasepoint.of_le {γ : ℝ → ℂ} {a b : ℝ} {m n : ℕ}
+    (h : FlatOfOrderBasepoint γ a b n) (hmn : m ≤ n)
+    (h_cont_a : ContinuousAt γ a) (h_cont_b : ContinuousAt γ b) :
+    FlatOfOrderBasepoint γ a b m := by
+  obtain ⟨v_p, v_m, hv_p, hv_m, h_right, h_left⟩ := h
+  exact ⟨v_p, v_m, hv_p, hv_m,
+    isLittleO_chord_pow_of_le hmn nhdsWithin_le_nhds h_cont_a h_right,
+    isLittleO_chord_pow_of_le hmn nhdsWithin_le_nhds h_cont_b h_left⟩
+
+/-- The `[0, 2π)` representative differs from its argument by an integer multiple of `2π`. -/
+private theorem toIcoMod_two_pi_sub_witness (θ : ℝ) :
+    ∃ j : ℤ, toIcoMod Real.two_pi_pos 0 θ = θ - (j : ℝ) * (2 * Real.pi) := by
+  refine ⟨toIcoDiv Real.two_pi_pos 0 θ, ?_⟩
+  have h_sub := self_sub_toIcoMod Real.two_pi_pos 0 θ
+  rw [zsmul_eq_mul] at h_sub
+  linarith
+
+/-- Angle core of the resonance bridges: if `θ` is the angle from `-L_L` to `L_R` up to
+`2πℤ` and `k · θ ∈ 2π · ℤ`, the `k`-th powers of the unit directions agree. -/
+private theorem pow_unit_eq_of_angle_resonance {L_R L_L : ℂ} {θ : ℝ} {k : ℕ}
+    (hL_R : L_R ≠ 0) (hL_L : L_L ≠ 0)
+    (hθ : ∃ j : ℤ, θ = (Complex.arg L_R - Complex.arg (-L_L)) - (j : ℝ) * (2 * Real.pi))
+    (h_res : ∃ m : ℤ, (k : ℝ) * θ = (m : ℝ) * (2 * Real.pi)) :
+    (L_R / (‖L_R‖ : ℂ)) ^ k = ((-L_L) / (‖L_L‖ : ℂ)) ^ k := by
+  obtain ⟨j, hj⟩ := hθ
+  obtain ⟨m, hm⟩ := h_res
+  rw [hj] at hm
+  have h_real : (k : ℝ) * Complex.arg L_R
+      = (k : ℝ) * Complex.arg (-L_L) + ((m : ℝ) + (k : ℝ) * (j : ℝ)) * (2 * Real.pi) := by
+    linear_combination hm
+  rw [div_norm_eq_exp_arg_mul_I hL_R, show (‖L_L‖ : ℂ) = (‖-L_L‖ : ℂ) by rw [norm_neg],
+    div_norm_eq_exp_arg_mul_I (neg_ne_zero.mpr hL_L), ← Complex.exp_nat_mul,
+    ← Complex.exp_nat_mul, Complex.exp_eq_exp_iff_exists_int]
+  refine ⟨m + (k : ℤ) * j, ?_⟩
+  have hC := congrArg (fun x : ℝ => (x : ℂ) * Complex.I) h_real
+  push_cast at hC ⊢
+  linear_combination hC
 
 /-- **Resonance to tangent powers**: if `k · crossingAngle γ t₀` is a multiple of `2π` and the
 one-sided derivative limits at `t₀` are `L_R` and `L_L`, both non-zero, then the `k`-th powers
@@ -371,33 +419,25 @@ theorem pow_unit_tangent_eq_of_resonance {γ : ℝ → ℂ} {t₀ : ℝ} {L_R L_
     (h_L : Filter.Tendsto (deriv γ) (𝓝[<] t₀) (𝓝 L_L))
     (h_res : ∃ m : ℤ, (k : ℝ) * crossingAngle γ t₀ = (m : ℝ) * (2 * Real.pi)) :
     (L_R / (‖L_R‖ : ℂ)) ^ k = ((-L_L) / (‖L_L‖ : ℂ)) ^ k := by
-  obtain ⟨m, hm⟩ := h_res
-  have h_mod : crossingAngle γ t₀
-      = (Complex.arg L_R - Complex.arg (-L_L))
-        - toIcoDiv Real.two_pi_pos 0 (Complex.arg L_R - Complex.arg (-L_L)) * (2 * Real.pi) := by
-    have h_sub := self_sub_toIcoMod Real.two_pi_pos 0
-      (Complex.arg L_R - Complex.arg (-L_L))
-    rw [zsmul_eq_mul] at h_sub
-    unfold crossingAngle
-    rw [h_R.limUnder_eq, h_L.limUnder_eq]
-    linarith
-  rw [h_mod] at hm
-  have h_real : (k : ℝ) * Complex.arg L_R
-      = (k : ℝ) * Complex.arg (-L_L)
-        + ((m : ℝ) + (k : ℝ) * (toIcoDiv Real.two_pi_pos 0
-            (Complex.arg L_R - Complex.arg (-L_L)) : ℤ)) * (2 * Real.pi) := by
-    linear_combination hm
-  have h_unit : ∀ w : ℂ, w ≠ 0 → w / (‖w‖ : ℂ) = Complex.exp (w.arg * Complex.I) :=
-    fun w hw => by
-      rw [div_eq_iff (by exact_mod_cast norm_ne_zero_iff.mpr hw), mul_comm]
-      exact (Complex.norm_mul_exp_arg_mul_I w).symm
-  rw [h_unit L_R hL_R, show (‖L_L‖ : ℂ) = (‖-L_L‖ : ℂ) by rw [norm_neg],
-    h_unit (-L_L) (neg_ne_zero.mpr hL_L), ← Complex.exp_nat_mul,
-    ← Complex.exp_nat_mul, Complex.exp_eq_exp_iff_exists_int]
-  refine ⟨m + (k : ℤ) * toIcoDiv Real.two_pi_pos 0
-    (Complex.arg L_R - Complex.arg (-L_L)), ?_⟩
-  have hC := congrArg (fun x : ℝ => (x : ℂ) * Complex.I) h_real
-  push_cast at hC ⊢
-  linear_combination hC
+  obtain ⟨j, hj⟩ := toIcoMod_two_pi_sub_witness (Complex.arg L_R - Complex.arg (-L_L))
+  refine pow_unit_eq_of_angle_resonance hL_R hL_L ⟨j, ?_⟩ h_res
+  unfold crossingAngle
+  rw [h_R.limUnder_eq, h_L.limUnder_eq]
+  exact hj
+
+/-- **Basepoint resonance to tangent powers**: the join analogue of
+`pow_unit_tangent_eq_of_resonance`, with the outgoing tangent limit at `a` and the incoming
+tangent limit at `b` — the raw sector equation at the basepoint of a closed curve. -/
+theorem pow_unit_tangent_eq_of_basepoint_resonance {γ : ℝ → ℂ} {a b : ℝ} {L_R L_L : ℂ}
+    {k : ℕ} (hL_R : L_R ≠ 0) (hL_L : L_L ≠ 0)
+    (h_R : Filter.Tendsto (deriv γ) (𝓝[>] a) (𝓝 L_R))
+    (h_L : Filter.Tendsto (deriv γ) (𝓝[<] b) (𝓝 L_L))
+    (h_res : ∃ m : ℤ, (k : ℝ) * basepointAngle γ a b = (m : ℝ) * (2 * Real.pi)) :
+    (L_R / (‖L_R‖ : ℂ)) ^ k = ((-L_L) / (‖L_L‖ : ℂ)) ^ k := by
+  obtain ⟨j, hj⟩ := toIcoMod_two_pi_sub_witness (Complex.arg L_R - Complex.arg (-L_L))
+  refine pow_unit_eq_of_angle_resonance hL_R hL_L ⟨j, ?_⟩ h_res
+  unfold basepointAngle
+  rw [h_R.limUnder_eq, h_L.limUnder_eq]
+  exact hj
 
 end TauCeti.Contour

--- a/TauCeti/Analysis/Contour/RegularityConditions.lean
+++ b/TauCeti/Analysis/Contour/RegularityConditions.lean
@@ -10,6 +10,7 @@ public import Mathlib.Analysis.Calculus.Deriv.Basic
 public import Mathlib.Analysis.Analytic.Basic
 public import Mathlib.Analysis.Meromorphic.Order
 public import Mathlib.Algebra.Order.ToIntervalMod
+import Mathlib.Analysis.SpecialFunctions.Complex.Log
 
 /-!
 # The Hungerbühler–Wasem crossing angle and regularity conditions (A′) and (B)
@@ -49,6 +50,9 @@ pole — and that it meet each `s` only finitely often. Condition (B) governs po
 * `ConditionB γ a b f` — HW condition (B), a structure imposing `SectorCompatible` at every
   higher-order (order `> 1`) on-curve pole of `f`: at each interior crossing (`ConditionB.interior`)
   and at the basepoint (`ConditionB.basepoint`).
+* `FlatOfOrder.of_le` and `pow_unit_tangent_eq_of_resonance` — the consuming bridges: flatness
+  restricts downward in the order, and the sector resonance `k · θ ∈ 2π · ℤ` at the crossing
+  angle is the power equation of the unit tangent directions.
 
 Both conditions read the on-curve pole orders of `f` from `meromorphicOrderAt`. Condition (B) needs
 no explicit singular set — it fires **intrinsically** at the times `t₀` where
@@ -326,5 +330,74 @@ theorem conditionB_iff {γ : ℝ → ℂ} {a b : ℝ} {f : ℂ → ℂ} :
 theorem conditionB_comm {γ : ℝ → ℂ} {a b : ℝ} {f : ℂ → ℂ} :
     ConditionB γ a b f ↔ ConditionB γ b a f := by
   rw [conditionB_iff, conditionB_iff, min_comm a b, max_comm a b]
+
+/-! ### Consuming the conditions
+
+The two bridges from the conditions' data to the raw hypotheses the principal-value theorems
+take: flatness restricts downward in the order, and the sector resonance `k · θ ∈ 2π · ℤ` at
+the crossing angle is the power equation of the unit tangent directions. -/
+
+/-- **Flatness restricts downward**: a curve flat of order `n` at `t₀` is flat of every order
+`m ≤ n` — near the crossing the chord is small, so a higher power of it is the stronger
+bound. -/
+theorem FlatOfOrder.of_le {γ : ℝ → ℂ} {t₀ : ℝ} {m n : ℕ} (h : FlatOfOrder γ t₀ n)
+    (hmn : m ≤ n) (h_cont : ContinuousAt γ t₀) : FlatOfOrder γ t₀ m := by
+  obtain ⟨v_p, v_m, hv_p, hv_m, h_right, h_left⟩ := h
+  have h_ev : ∀ᶠ t in 𝓝 t₀, ‖γ t - γ t₀‖ ≤ 1 := by
+    have h0 : Filter.Tendsto (fun t => ‖γ t - γ t₀‖) (𝓝 t₀) (𝓝 0) := by
+      have h1 : Filter.Tendsto (fun t => γ t - γ t₀) (𝓝 t₀) (𝓝 (γ t₀ - γ t₀)) :=
+        (h_cont.sub continuousAt_const).tendsto
+      rw [sub_self] at h1
+      simpa using h1.norm
+    exact h0.eventually_le_const one_pos
+  have h_pow : ∀ t, ‖γ t - γ t₀‖ ≤ 1 →
+      ‖‖γ t - γ t₀‖ ^ n‖ ≤ 1 * ‖‖γ t - γ t₀‖ ^ m‖ := fun t ht => by
+    rw [one_mul, Real.norm_of_nonneg (pow_nonneg (norm_nonneg _) _),
+      Real.norm_of_nonneg (pow_nonneg (norm_nonneg _) _)]
+    exact pow_le_pow_of_le_one (norm_nonneg _) ht hmn
+  refine ⟨v_p, v_m, hv_p, hv_m,
+    h_right.trans_isBigO (Asymptotics.IsBigO.of_bound 1 ?_),
+    h_left.trans_isBigO (Asymptotics.IsBigO.of_bound 1 ?_)⟩ <;>
+    · filter_upwards [nhdsWithin_le_nhds h_ev] with t ht
+      exact h_pow t ht
+
+/-- **Resonance to tangent powers**: if `k · crossingAngle γ t₀` is a multiple of `2π` and the
+one-sided derivative limits at `t₀` are `L_R` and `L_L`, both non-zero, then the `k`-th powers
+of the unit tangent directions agree — the raw sector equation the higher-order
+principal-value theorems consume. -/
+theorem pow_unit_tangent_eq_of_resonance {γ : ℝ → ℂ} {t₀ : ℝ} {L_R L_L : ℂ} {k : ℕ}
+    (hL_R : L_R ≠ 0) (hL_L : L_L ≠ 0)
+    (h_R : Filter.Tendsto (deriv γ) (𝓝[>] t₀) (𝓝 L_R))
+    (h_L : Filter.Tendsto (deriv γ) (𝓝[<] t₀) (𝓝 L_L))
+    (h_res : ∃ m : ℤ, (k : ℝ) * crossingAngle γ t₀ = (m : ℝ) * (2 * Real.pi)) :
+    (L_R / (‖L_R‖ : ℂ)) ^ k = ((-L_L) / (‖L_L‖ : ℂ)) ^ k := by
+  obtain ⟨m, hm⟩ := h_res
+  have h_mod : crossingAngle γ t₀
+      = (Complex.arg L_R - Complex.arg (-L_L))
+        - toIcoDiv Real.two_pi_pos 0 (Complex.arg L_R - Complex.arg (-L_L)) * (2 * Real.pi) := by
+    have h_sub := self_sub_toIcoMod Real.two_pi_pos 0
+      (Complex.arg L_R - Complex.arg (-L_L))
+    rw [zsmul_eq_mul] at h_sub
+    unfold crossingAngle
+    rw [h_R.limUnder_eq, h_L.limUnder_eq]
+    linarith
+  rw [h_mod] at hm
+  have h_real : (k : ℝ) * Complex.arg L_R
+      = (k : ℝ) * Complex.arg (-L_L)
+        + ((m : ℝ) + (k : ℝ) * (toIcoDiv Real.two_pi_pos 0
+            (Complex.arg L_R - Complex.arg (-L_L)) : ℤ)) * (2 * Real.pi) := by
+    linear_combination hm
+  have h_unit : ∀ w : ℂ, w ≠ 0 → w / (‖w‖ : ℂ) = Complex.exp (w.arg * Complex.I) :=
+    fun w hw => by
+      rw [div_eq_iff (by exact_mod_cast norm_ne_zero_iff.mpr hw), mul_comm]
+      exact (Complex.norm_mul_exp_arg_mul_I w).symm
+  rw [h_unit L_R hL_R, show (‖L_L‖ : ℂ) = (‖-L_L‖ : ℂ) by rw [norm_neg],
+    h_unit (-L_L) (neg_ne_zero.mpr hL_L), ← Complex.exp_nat_mul,
+    ← Complex.exp_nat_mul, Complex.exp_eq_exp_iff_exists_int]
+  refine ⟨m + (k : ℤ) * toIcoDiv Real.two_pi_pos 0
+    (Complex.arg L_R - Complex.arg (-L_L)), ?_⟩
+  have hC := congrArg (fun x : ℝ => (x : ℂ) * Complex.I) h_real
+  push_cast at hC ⊢
+  linear_combination hC
 
 end TauCeti.Contour


### PR DESCRIPTION
## What

Two theorems appended to `TauCeti/Analysis/Contour/RegularityConditions.lean`:

```lean
theorem FlatOfOrder.of_le (h : FlatOfOrder γ t₀ n) (hmn : m ≤ n)
    (h_cont : ContinuousAt γ t₀) : FlatOfOrder γ t₀ m

theorem pow_unit_tangent_eq_of_resonance
    (hL_R : L_R ≠ 0) (hL_L : L_L ≠ 0)
    (h_R : Tendsto (deriv γ) (𝓝[>] t₀) (𝓝 L_R))
    (h_L : Tendsto (deriv γ) (𝓝[<] t₀) (𝓝 L_L))
    (h_res : ∃ m : ℤ, (k : ℝ) * crossingAngle γ t₀ = (m : ℝ) * (2 * Real.pi)) :
    (L_R / (‖L_R‖ : ℂ)) ^ k = ((-L_L) / (‖L_L‖ : ℂ)) ^ k
```

## Why

These are the two analytic bridges from this file's condition structures to the raw
per-crossing hypotheses of the merged principal-value theorems. `SectorCompatible` speaks the
angle language — resonance `k · θ ∈ 2π · ℤ` at `crossingAngle γ t₀` — while
`IsPwC1ImmersionOn.hasCauchyPVAt_pow_inv` (#950) and the polar-part theorem (#953) consume
the tangent-power equation `(L_R/‖L_R‖)^k = ((-L_L)/‖L_L‖)^k`; the bridge identifies the two
through `z/‖z‖ = exp(arg z · I)` and `exp_eq_exp_iff_exists_int`, with `crossingAngle`'s
`toIcoMod` normalization absorbed into the integer. `FlatOfOrder.of_le` is what discharges the
flatness hypothesis at a pole of order lower than the flatness the curve carries — in
particular order `0` (no pole) from the order-`1` flatness every immersion has
(`FlatnessOne.lean`). Stated where `crossingAngle` and `FlatOfOrder` live, so the angle
unfolds in-module.

## Provenance

The bridge content corresponds to `condB_to_h_B_at_crossings_corner` of `Crossing.lean` in
the AINTLIB `LeanModularForms` development (there against the chosen tangent functions of the
bundled immersion; here against the one-sided limits, which are unique). See N. Hungerbühler,
M. Wasem, *Non-integer valued winding numbers and a generalized Residue Theorem*,
arXiv:1808.00997, §3.

## Roadmap

Advances `TauCetiRoadmap/ContourIntegration/Suggested.lean`: prerequisite for
`hungerbuhlerWasem_residueTheorem` and `hasCauchyPV_half_residue` (conditions (A′)/(B) are
their hypotheses; these bridges let the summit discharge the raw per-crossing forms).

## Gates

`lake build` ✓ · `lake exe axioms` ✓ (allowlist only) · `lake exe module-system` ✓ (515/515) ·
`scripts/lint-env.sh` ✓ (no new violations)

🤖 Generated with [Claude Code](https://claude.com/claude-code)