### PR TITLE
feat(Analysis/Contour): assemble the generalized residue sum

### DIFF
--- a/TauCeti/Analysis/Contour/CauchyPrincipalValueOn.lean
+++ b/TauCeti/Analysis/Contour/CauchyPrincipalValueOn.lean
@@ -638,6 +638,41 @@ theorem HasCauchyPV.sum {ι : Type*} {γ : ℝ → ℂ} {a b : ℝ} {f : ι → 
     exact (h j (Finset.mem_insert_self j s)).add hγ_cont
       (ih fun i hi => h i (Finset.mem_insert_of_mem hi))
 
+/-- **Congruence along the curve off excised points**: if `f` and `g` agree along `γ` at every
+parameter where `γ` avoids the finite set `P`, a principal value of `f` is one of `g` — the
+witnessing excision enlarges to include `P`, and off the enlarged excision the curve avoids
+`P`. Needs the curve continuous on `[[a, b]]` for the enlargement. -/
+theorem HasCauchyPV.congr_along_curve_off {γ : ℝ → ℂ} {a b : ℝ} {f g : ℂ → ℂ} {v : ℂ}
+    (hγ_cont : ContinuousOn γ (Set.uIcc a b)) (P : Finset ℂ)
+    (h : HasCauchyPV γ a b f v)
+    (h_eq : ∀ t ∈ Set.uIoo a b, γ t ∉ (P : Set ℂ) → f (γ t) = g (γ t)) :
+    HasCauchyPV γ a b g v := by
+  obtain ⟨T, hint, htend⟩ := h
+  have hint' : ∀ᶠ ε in 𝓝[>] (0 : ℝ),
+      IntervalIntegrable (truncatedIntegrand γ f T ε) MeasureTheory.volume a b := hint
+  have hI : ∀ᶠ ε in 𝓝[>] (0 : ℝ),
+      IntervalIntegrable (truncatedIntegrand γ f (T ∪ P) ε) MeasureTheory.volume a b :=
+    hint'.mono fun ε hε => truncatedIntegrand_union_integrable hγ_cont P hε
+  have hT : Tendsto (fun ε => ∫ t in a..b, truncatedIntegrand γ f (T ∪ P) ε t)
+      (𝓝[>] (0 : ℝ)) (𝓝 v) := by
+    have htend' : Tendsto (fun ε => ∫ t in a..b, truncatedIntegrand γ f T ε t)
+        (𝓝[>] (0 : ℝ)) (𝓝 v) := htend
+    simpa using htend'.sub (tendsto_integral_truncatedIntegrand_sub T (T ∪ P) hint' hI)
+  have h_body : ∀ ε : ℝ, 0 < ε → ∀ t ∈ Set.uIoo a b,
+      truncatedIntegrand γ f (T ∪ P) ε t = truncatedIntegrand γ g (T ∪ P) ε t := by
+    intro ε hε t ht
+    by_cases hex : ∃ s ∈ T ∪ P, ‖γ t - s‖ ≤ ε
+    · simp only [truncatedIntegrand, if_pos hex]
+    · have h_off : γ t ∉ (P : Set ℂ) := fun hp =>
+        hex ⟨γ t, Finset.mem_union_right _ (Finset.mem_coe.mp hp), by simp [hε.le]⟩
+      simp only [truncatedIntegrand, if_neg hex, h_eq t ht h_off]
+  refine ⟨T ∪ P, ?_, ?_⟩
+  · filter_upwards [hI, self_mem_nhdsWithin] with ε hε hε_pos
+    exact (intervalIntegrable_congr_uIoo fun t ht => h_body ε hε_pos t ht).mp hε
+  · refine hT.congr' ?_
+    filter_upwards [self_mem_nhdsWithin] with ε hε_pos
+    exact intervalIntegral.integral_congr_uIoo fun t ht => h_body ε hε_pos t ht
+
 /-- Existence form of `HasCauchyPV.add`. -/
 theorem CauchyPVExists.add {γ : ℝ → ℂ} {a b : ℝ} {f g : ℂ → ℂ}
     (hγ_cont : ContinuousOn γ (Set.uIcc a b))

--- a/TauCeti/Analysis/Contour/ResidueAssembly.lean
+++ b/TauCeti/Analysis/Contour/ResidueAssembly.lean
@@ -1,0 +1,102 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Chris Birkbeck
+-/
+module
+
+public import Mathlib.Analysis.Calculus.Deriv.Basic
+public import Mathlib.Analysis.Complex.Basic
+public import TauCeti.Analysis.Contour.CauchyPrincipalValueOn
+public import TauCeti.Analysis.Contour.PolarPartDecomposition
+public import TauCeti.Analysis.Contour.PwC1ImmersionOn
+public import TauCeti.Analysis.Contour.RegularityConditions
+public import TauCeti.Analysis.Contour.WindingNumber
+import TauCeti.Analysis.Contour.PolarPartCPV
+
+/-!
+# Assembling the generalized residue sum
+
+The engine of the Hungerbühler–Wasem generalized residue theorem, over an explicit polar
+decomposition: along a **closed, null-homologous** piecewise-`C¹` immersion in `U` whose
+crossings of each pole are interior and (at every surviving higher-order coefficient) flat and
+sector-compatible, the set-level Cauchy principal value of `f` exists and equals
+`2πi · Σ_{s ∈ S} n_s(γ) · Res_s f`. The analytic remainder integrates to zero around the
+null-homologous cycle (the homology Cauchy theorem through the decomposition), each polar part
+contributes its winding-weighted residue, the contributions add across the singular set, and
+`f` is identified with the assembled sum along the curve away from the poles — which is all
+the excised principal value sees.
+
+## Main results
+
+* `Contour.PolarPartDecomposition.hasCauchyPV_residue_sum` — the set-level principal value of
+  `f` along the cycle is `2πi · Σ_{s ∈ S} n_s(γ) · Res_s f`.
+
+## Provenance
+
+Migrated from `residueTheorem_crossing_compositional` of `Crossing.lean` in the AINTLIB
+`LeanModularForms` development (there taking the per-pole principal values as data; here they
+are produced by the polar-part theorem). See N. Hungerbühler, M. Wasem, *Non-integer valued
+winding numbers and a generalized Residue Theorem*, arXiv:1808.00997, §3.
+-/
+
+public section
+
+noncomputable section
+
+namespace TauCeti.Contour
+
+namespace PolarPartDecomposition
+
+open Filter Set Topology
+
+/-- **The generalized residue sum over a polar decomposition**: along a closed,
+null-homologous piecewise-`C¹` immersion in `U` whose crossings of each pole are interior and
+gated-flat and gated-sector-compatible, the set-level principal value of `f` is
+`2πi · Σ_{s ∈ S} n_s(γ) · Res_s f`. -/
+theorem hasCauchyPV_residue_sum {f : ℂ → ℂ} {S : Finset ℂ} {U : Set ℂ}
+    (decomp : PolarPartDecomposition f S U) (hU : IsOpen U)
+    {γ : ℝ → ℂ} {a b : ℝ} (h_imm : IsPwC1ImmersionOn γ a b) (hab : a ≤ b)
+    (hclosed : γ a = γ b) (hγU : ∀ t ∈ uIcc a b, γ t ∈ U)
+    (hnull : IsNullHomologous γ a b U)
+    (h_interior : ∀ s : S, ∀ t ∈ Icc a b, γ t = (s : ℂ) → t ∈ Ioo a b)
+    (h_flat : ∀ s : S, ∀ k : Fin (decomp.order s), 1 ≤ k.val → decomp.coeff s k ≠ 0 →
+      ∀ t ∈ Icc a b, γ t = (s : ℂ) → FlatOfOrder γ t (k.val + 1))
+    (h_B : ∀ s : S, ∀ k : Fin (decomp.order s), 1 ≤ k.val → decomp.coeff s k ≠ 0 →
+      ∀ t ∈ Icc a b, γ t = (s : ℂ) → ∀ L_R L_L : ℂ,
+        Tendsto (deriv γ) (𝓝[>] t) (𝓝 L_R) → Tendsto (deriv γ) (𝓝[<] t) (𝓝 L_L) →
+        (L_R / (‖L_R‖ : ℂ)) ^ k.val = ((-L_L) / (‖L_L‖ : ℂ)) ^ k.val) :
+    HasCauchyPV γ a b f
+      (2 * (Real.pi : ℂ) * Complex.I * ∑ s ∈ S, windingNumber γ a b s * residue f s) := by
+  classical
+  have h_rem_int : IntervalIntegrable
+      (fun t => decomp.analyticRemainder (γ t) * deriv γ t) MeasureTheory.volume a b :=
+    h_imm.isPiecewiseC1On.intervalIntegrable_deriv.continuousOn_mul
+      (decomp.analyticRemainder_differentiableOn.continuousOn.comp h_imm.continuousOn hγU)
+  have h_rem : HasCauchyPV γ a b decomp.analyticRemainder 0 := by
+    have h0 := HasCauchyPV.of_integrable h_rem_int
+    rwa [show (∫ t in a..b, decomp.analyticRemainder (γ t) * deriv γ t) = 0 from by
+      rw [← decomp.intervalIntegral_deriv_smul_analyticRemainder_eq_zero hU
+        h_imm.isPiecewiseC1On hγU hclosed hnull]
+      exact intervalIntegral.integral_congr fun t _ => by rw [smul_eq_mul, mul_comm]] at h0
+  have h_polar : ∀ s ∈ S.attach, HasCauchyPV γ a b (decomp.polarPart s)
+      (2 * (Real.pi : ℂ) * Complex.I * windingNumber γ a b ↑s * residue f ↑s) := fun s _ =>
+    (decomp.hasCauchyPVAt_polarPart s h_imm hab hclosed (h_interior s) (h_flat s)
+      (h_B s)).hasCauchyPV
+  have h_sum := h_rem.add h_imm.continuousOn (HasCauchyPV.sum h_imm.continuousOn h_polar)
+  have h_total := h_sum.congr_along_curve_off h_imm.continuousOn S fun t ht h_off =>
+    (decomp.f_eq (γ t) ⟨hγU t (uIoo_subset_uIcc_self ht), h_off⟩).symm
+  have h_val : (0 : ℂ) + ∑ s ∈ S.attach,
+      2 * (Real.pi : ℂ) * Complex.I * windingNumber γ a b ↑s * residue f ↑s
+      = 2 * (Real.pi : ℂ) * Complex.I * ∑ s ∈ S, windingNumber γ a b s * residue f s := by
+    rw [zero_add, Finset.mul_sum, ← Finset.sum_attach S
+      fun s => 2 * (Real.pi : ℂ) * Complex.I * (windingNumber γ a b s * residue f s)]
+    exact Finset.sum_congr rfl fun s _ => by ring
+  rw [← h_val]
+  exact h_total
+
+end PolarPartDecomposition
+
+end TauCeti.Contour
+
+end


### PR DESCRIPTION
## What

New file `TauCeti/Analysis/Contour/ResidueAssembly.lean` with the engine of the
Hungerbühler–Wasem generalized residue theorem over an explicit polar decomposition:

```lean
theorem PolarPartDecomposition.hasCauchyPV_residue_sum
    (decomp : PolarPartDecomposition f S U) (hU : IsOpen U)
    (h_imm : IsPwC1ImmersionOn γ a b) (hab : a ≤ b) (hclosed : γ a = γ b)
    (hγU : ∀ t ∈ uIcc a b, γ t ∈ U) (hnull : IsNullHomologous γ a b U)
    (h_interior : …) (h_flat : … gated …) (h_B : … gated …) :
    HasCauchyPV γ a b f
      (2 * (Real.pi : ℂ) * Complex.I * ∑ s ∈ S, windingNumber γ a b s * residue f s)
```

plus one supporting lemma in `CauchyPrincipalValueOn.lean`:
`HasCauchyPV.congr_along_curve_off` — congruence along the curve *off a finite point set*:
the witnessing excision enlarges by `P` (through the union-integrability and
enlargement-inertness engine), and off the enlarged excision the curve avoids `P`, so
integrands that agree away from `P` have the same principal value.

## Why

This is the residue theorem's whole analytic content in one statement, assembled from the
merged pillars with no new estimates: the analytic remainder integrates to zero around the
null-homologous cycle (#930's homology-Cauchy consequence), each polar part contributes its
winding-weighted residue (#953), the contributions add across the singular set (#956's
continuity-based additivity — this is its first consumer), and `f` is identified with
`remainder + Σ polar parts` along the curve away from the poles, which is all the excised
principal value ever sees: at crossing times the excision zeroes both integrands, and off the
excision the curve is off `S`, where the decomposition's `f_eq` applies. The congruence
lemma packages exactly that argument.

The summits are now hypothesis plumbing over this theorem: instantiate
`decomp := ofMeromorphic`, discharge the gated hypotheses from conditions (A′)/(B) (#958),
and reduce `a > b` by the orientation lemmas.

## Provenance

Migrated from `residueTheorem_crossing_compositional` of `Crossing.lean` in the AINTLIB
`LeanModularForms` development (there taking the per-pole principal values as data; here they
are produced by the polar-part theorem). See N. Hungerbühler, M. Wasem, *Non-integer valued
winding numbers and a generalized Residue Theorem*, arXiv:1808.00997, §3.

## Roadmap

Advances `TauCetiRoadmap/ContourIntegration/Suggested.lean`: the direct engine of
`hungerbuhlerWasem_residueTheorem` and `hasCauchyPV_half_residue`.

## Gates

`lake build` ✓ · `lake exe axioms` ✓ (allowlist only) · `lake exe module-system` ✓ (518/518) ·
`scripts/lint-env.sh` ✓ (no new violations)

🤖 Generated with [Claude Code](https://claude.com/claude-code)