### PR TITLE
feat: the fundamental group is a homeomorphism invariant

### DIFF
--- a/TauCeti/AlgebraicTopology/FundamentalGroup/Homeomorph.lean
+++ b/TauCeti/AlgebraicTopology/FundamentalGroup/Homeomorph.lean
@@ -1,0 +1,137 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+module
+
+public import Mathlib.AlgebraicTopology.FundamentalGroupoid.FundamentalGroup
+public import Mathlib.Topology.Homeomorph.Defs
+
+/-!
+# The fundamental group is a homeomorphism invariant
+
+Mathlib records the homomorphism `FundamentalGroup.map` induced by a continuous map and the
+variant `FundamentalGroup.mapOfEq` that adjusts the target basepoint along an equality, but it
+stops short of packaging a homeomorphism as an *isomorphism* of fundamental groups. This file
+supplies that: a homeomorphism `e : X ≃ₜ Y` induces a group isomorphism
+`π₁(X, x) ≃* π₁(Y, e x)`, and more generally `π₁(X, x) ≃* π₁(Y, y)` whenever `e x = y`.
+
+The forward map is `FundamentalGroup.mapOfEq` of `e`; the inverse is `FundamentalGroup.mapOfEq`
+of `e.symm`. The two round trips are the composition law `mapOfEq_comp` (the induced maps of two
+continuous maps compose to the induced map of their composite) applied to `e.symm ∘ e = id` and
+`e ∘ e.symm = id`, together with `mapOfEq_id` (the induced map of the identity is the identity).
+Both auxiliary lemmas are proved once here from Mathlib's `FundamentalGroup.mapOfEq_apply` and the
+`Path.Homotopic.Quotient` transport lemmas (`map_comp`, `map_cast`, `cast_cast`), and are useful
+on their own.
+
+Transporting a fundamental-group computation across a homeomorphism is the group-level input the
+universal-covers roadmap needs for its Stage 4 applications: for example the fundamental group of
+the unit circle `Circle ⊆ ℂ`, obtained from the additive-circle computation through Mathlib's
+`AddCircle.homeomorphCircle`, and later `π₁(ℝPⁿ)`. This mirrors the way
+`TauCeti.FundamentalGroup.prodMulEquiv` supplied the product formula the torus computation needs.
+
+## Main declarations
+
+* `TauCeti.FundamentalGroup.mapOfEq_comp`: `mapOfEq g hg (mapOfEq f hf p) = mapOfEq (g.comp f) _ p`.
+* `TauCeti.FundamentalGroup.mapOfEq_id`: `mapOfEq (ContinuousMap.id X) h = id`.
+* `TauCeti.FundamentalGroup.mulEquivOfHomeomorphOfEq`: `π₁(X, x) ≃* π₁(Y, y)` from `e : X ≃ₜ Y`
+  with `e x = y`.
+* `TauCeti.FundamentalGroup.mulEquivOfHomeomorph`: `π₁(X, x) ≃* π₁(Y, e x)`.
+-/
+
+public section
+
+namespace TauCeti
+
+namespace FundamentalGroup
+
+open Path.Homotopic
+
+variable {X Y Z : Type*} [TopologicalSpace X] [TopologicalSpace Y] [TopologicalSpace Z]
+variable {x : X} {y : Y} {z : Z}
+
+/-- The maps induced on fundamental groups by two continuous maps compose to the map induced by
+their composite: `mapOfEq g hg (mapOfEq f hf p) = mapOfEq (g.comp f) _ p`. -/
+theorem mapOfEq_comp (g : C(Y, Z)) (f : C(X, Y)) (hf : f x = y) (hg : g y = z)
+    (p : _root_.FundamentalGroup X x) :
+    _root_.FundamentalGroup.mapOfEq g hg (_root_.FundamentalGroup.mapOfEq f hf p) =
+      _root_.FundamentalGroup.mapOfEq (g.comp f)
+        (show (g.comp f) x = z by rw [ContinuousMap.comp_apply, hf, hg]) p := by
+  simp only [_root_.FundamentalGroup.mapOfEq_apply]
+  rw [Path.Homotopic.Quotient.map_cast, Path.Homotopic.Quotient.cast_cast,
+    ← Path.Homotopic.Quotient.map_comp]
+  rfl
+
+/-- The map induced on fundamental groups by the identity continuous map is the identity. -/
+theorem mapOfEq_id (h : (ContinuousMap.id X) x = x) (p : _root_.FundamentalGroup X x) :
+    _root_.FundamentalGroup.mapOfEq (ContinuousMap.id X) h p = p := by
+  have key : ∀ q : Path.Homotopic.Quotient x x,
+      Path.Homotopic.Quotient.map q (ContinuousMap.id X) = q := by
+    intro q
+    induction q using Quotient.inductionOn with
+    | h γ => exact congrArg _ (Path.map_id γ)
+  rw [_root_.FundamentalGroup.mapOfEq_apply, key]
+  exact Path.Homotopic.Quotient.cast_rfl_rfl p
+
+/-- The induced map `mapOfEq` depends only on the underlying continuous map, not on the chosen
+proof of the basepoint equation: two equal continuous maps induce the same map. -/
+theorem mapOfEq_congr {f₁ f₂ : C(X, Y)} (hfe : f₁ = f₂) (h₁ : f₁ x = y) (h₂ : f₂ x = y)
+    (p : _root_.FundamentalGroup X x) :
+    _root_.FundamentalGroup.mapOfEq f₁ h₁ p = _root_.FundamentalGroup.mapOfEq f₂ h₂ p := by
+  subst hfe
+  rfl
+
+/-- If `g ∘ f` is the identity, then the induced map of `g` undoes the induced map of `f`. -/
+theorem mapOfEq_mapOfEq (g : C(Y, X)) (f : C(X, Y)) (hf : f x = y) (hg : g y = x)
+    (hgf : g.comp f = ContinuousMap.id X) (p : _root_.FundamentalGroup X x) :
+    _root_.FundamentalGroup.mapOfEq g hg (_root_.FundamentalGroup.mapOfEq f hf p) = p := by
+  rw [mapOfEq_comp g f hf hg]
+  exact (mapOfEq_congr hgf _ rfl p).trans (mapOfEq_id rfl p)
+
+/-- A homeomorphism `e : X ≃ₜ Y` carrying `x` to `y` induces an isomorphism of fundamental groups
+`π₁(X, x) ≃* π₁(Y, y)`. The forward map is `FundamentalGroup.mapOfEq` of `e`; the inverse is
+`FundamentalGroup.mapOfEq` of `e.symm`. -/
+@[expose] noncomputable def mulEquivOfHomeomorphOfEq (e : X ≃ₜ Y) (h : e x = y) :
+    _root_.FundamentalGroup X x ≃* _root_.FundamentalGroup Y y where
+  toFun := _root_.FundamentalGroup.mapOfEq ⟨e, e.continuous⟩ h
+  invFun := _root_.FundamentalGroup.mapOfEq ⟨e.symm, e.symm.continuous⟩
+    (show e.symm y = x by rw [← h, e.symm_apply_apply])
+  left_inv p :=
+    mapOfEq_mapOfEq ⟨e.symm, e.symm.continuous⟩ ⟨e, e.continuous⟩ h
+      (show e.symm y = x by rw [← h, e.symm_apply_apply])
+      (ContinuousMap.ext fun t => e.symm_apply_apply t) p
+  right_inv q :=
+    mapOfEq_mapOfEq ⟨e, e.continuous⟩ ⟨e.symm, e.symm.continuous⟩
+      (show e.symm y = x by rw [← h, e.symm_apply_apply]) h
+      (ContinuousMap.ext fun t => e.apply_symm_apply t) q
+  map_mul' := (_root_.FundamentalGroup.mapOfEq ⟨e, e.continuous⟩ h).map_mul
+
+@[simp]
+theorem mulEquivOfHomeomorphOfEq_apply (e : X ≃ₜ Y) (h : e x = y)
+    (p : _root_.FundamentalGroup X x) :
+    mulEquivOfHomeomorphOfEq e h p = _root_.FundamentalGroup.mapOfEq ⟨e, e.continuous⟩ h p :=
+  rfl
+
+@[simp]
+theorem mulEquivOfHomeomorphOfEq_symm_apply (e : X ≃ₜ Y) (h : e x = y)
+    (q : _root_.FundamentalGroup Y y) :
+    (mulEquivOfHomeomorphOfEq e h).symm q =
+      _root_.FundamentalGroup.mapOfEq ⟨e.symm, e.symm.continuous⟩
+        (show e.symm y = x by rw [← h, e.symm_apply_apply]) q :=
+  rfl
+
+/-- A homeomorphism `e : X ≃ₜ Y` induces an isomorphism of fundamental groups
+`π₁(X, x) ≃* π₁(Y, e x)`. -/
+@[expose] noncomputable def mulEquivOfHomeomorph (e : X ≃ₜ Y) (x : X) :
+    _root_.FundamentalGroup X x ≃* _root_.FundamentalGroup Y (e x) :=
+  mulEquivOfHomeomorphOfEq e rfl
+
+@[simp]
+theorem mulEquivOfHomeomorph_apply (e : X ≃ₜ Y) (x : X) (p : _root_.FundamentalGroup X x) :
+    mulEquivOfHomeomorph e x p =
+      _root_.FundamentalGroup.mapOfEq ⟨e, e.continuous⟩ rfl p :=
+  rfl
+
+end FundamentalGroup
+
+end TauCeti

--- a/TauCeti/AlgebraicTopology/FundamentalGroup/Homeomorph.lean
+++ b/TauCeti/AlgebraicTopology/FundamentalGroup/Homeomorph.lean
@@ -83,7 +83,7 @@ theorem mapOfEq_congr {f₁ f₂ : C(X, Y)} (hfe : f₁ = f₂) (h₁ : f₁ x =
   rfl
 
 /-- If `g ∘ f` is the identity, then the induced map of `g` undoes the induced map of `f`. -/
-theorem mapOfEq_mapOfEq (g : C(Y, X)) (f : C(X, Y)) (hf : f x = y) (hg : g y = x)
+theorem mapOfEq_mapOfEq_of_comp_eq_id (g : C(Y, X)) (f : C(X, Y)) (hf : f x = y) (hg : g y = x)
     (hgf : g.comp f = ContinuousMap.id X) (p : _root_.FundamentalGroup X x) :
     _root_.FundamentalGroup.mapOfEq g hg (_root_.FundamentalGroup.mapOfEq f hf p) = p := by
   rw [mapOfEq_comp g f hf hg]
@@ -98,11 +98,11 @@ theorem mapOfEq_mapOfEq (g : C(Y, X)) (f : C(X, Y)) (hf : f x = y) (hg : g y = x
   invFun := _root_.FundamentalGroup.mapOfEq ⟨e.symm, e.symm.continuous⟩
     (show e.symm y = x by rw [← h, e.symm_apply_apply])
   left_inv p :=
-    mapOfEq_mapOfEq ⟨e.symm, e.symm.continuous⟩ ⟨e, e.continuous⟩ h
+    mapOfEq_mapOfEq_of_comp_eq_id ⟨e.symm, e.symm.continuous⟩ ⟨e, e.continuous⟩ h
       (show e.symm y = x by rw [← h, e.symm_apply_apply])
       (ContinuousMap.ext fun t => e.symm_apply_apply t) p
   right_inv q :=
-    mapOfEq_mapOfEq ⟨e, e.continuous⟩ ⟨e.symm, e.symm.continuous⟩
+    mapOfEq_mapOfEq_of_comp_eq_id ⟨e, e.continuous⟩ ⟨e.symm, e.symm.continuous⟩
       (show e.symm y = x by rw [← h, e.symm_apply_apply]) h
       (ContinuousMap.ext fun t => e.apply_symm_apply t) q
   map_mul' := (_root_.FundamentalGroup.mapOfEq ⟨e, e.continuous⟩ h).map_mul

--- a/TauCeti/AlgebraicTopology/FundamentalGroup/Homeomorph.lean
+++ b/TauCeti/AlgebraicTopology/FundamentalGroup/Homeomorph.lean
@@ -34,9 +34,9 @@ the unit circle `Circle ⊆ ℂ`, obtained from the additive-circle computation 
 
 * `TauCeti.FundamentalGroup.mapOfEq_comp`: `mapOfEq g hg (mapOfEq f hf p) = mapOfEq (g.comp f) _ p`.
 * `TauCeti.FundamentalGroup.mapOfEq_id`: `mapOfEq (ContinuousMap.id X) h = id`.
-* `TauCeti.FundamentalGroup.mulEquivOfHomeomorphOfEq`: `π₁(X, x) ≃* π₁(Y, y)` from `e : X ≃ₜ Y`
+* `TauCeti.FundamentalGroup.homeomorphMulEquivOfEq`: `π₁(X, x) ≃* π₁(Y, y)` from `e : X ≃ₜ Y`
   with `e x = y`.
-* `TauCeti.FundamentalGroup.mulEquivOfHomeomorph`: `π₁(X, x) ≃* π₁(Y, e x)`.
+* `TauCeti.FundamentalGroup.homeomorphMulEquiv`: `π₁(X, x) ≃* π₁(Y, e x)`.
 -/
 
 public section
@@ -63,6 +63,7 @@ theorem mapOfEq_comp (g : C(Y, Z)) (f : C(X, Y)) (hf : f x = y) (hg : g y = z)
   rfl
 
 /-- The map induced on fundamental groups by the identity continuous map is the identity. -/
+@[simp]
 theorem mapOfEq_id (h : (ContinuousMap.id X) x = x) (p : _root_.FundamentalGroup X x) :
     _root_.FundamentalGroup.mapOfEq (ContinuousMap.id X) h p = p := by
   have key : ∀ q : Path.Homotopic.Quotient x x,
@@ -91,7 +92,7 @@ theorem mapOfEq_mapOfEq (g : C(Y, X)) (f : C(X, Y)) (hf : f x = y) (hg : g y = x
 /-- A homeomorphism `e : X ≃ₜ Y` carrying `x` to `y` induces an isomorphism of fundamental groups
 `π₁(X, x) ≃* π₁(Y, y)`. The forward map is `FundamentalGroup.mapOfEq` of `e`; the inverse is
 `FundamentalGroup.mapOfEq` of `e.symm`. -/
-@[expose] noncomputable def mulEquivOfHomeomorphOfEq (e : X ≃ₜ Y) (h : e x = y) :
+@[expose] noncomputable def homeomorphMulEquivOfEq (e : X ≃ₜ Y) (h : e x = y) :
     _root_.FundamentalGroup X x ≃* _root_.FundamentalGroup Y y where
   toFun := _root_.FundamentalGroup.mapOfEq ⟨e, e.continuous⟩ h
   invFun := _root_.FundamentalGroup.mapOfEq ⟨e.symm, e.symm.continuous⟩
@@ -107,29 +108,36 @@ theorem mapOfEq_mapOfEq (g : C(Y, X)) (f : C(X, Y)) (hf : f x = y) (hg : g y = x
   map_mul' := (_root_.FundamentalGroup.mapOfEq ⟨e, e.continuous⟩ h).map_mul
 
 @[simp]
-theorem mulEquivOfHomeomorphOfEq_apply (e : X ≃ₜ Y) (h : e x = y)
+theorem homeomorphMulEquivOfEq_apply (e : X ≃ₜ Y) (h : e x = y)
     (p : _root_.FundamentalGroup X x) :
-    mulEquivOfHomeomorphOfEq e h p = _root_.FundamentalGroup.mapOfEq ⟨e, e.continuous⟩ h p :=
+    homeomorphMulEquivOfEq e h p = _root_.FundamentalGroup.mapOfEq ⟨e, e.continuous⟩ h p :=
   rfl
 
 @[simp]
-theorem mulEquivOfHomeomorphOfEq_symm_apply (e : X ≃ₜ Y) (h : e x = y)
+theorem homeomorphMulEquivOfEq_symm_apply (e : X ≃ₜ Y) (h : e x = y)
     (q : _root_.FundamentalGroup Y y) :
-    (mulEquivOfHomeomorphOfEq e h).symm q =
+    (homeomorphMulEquivOfEq e h).symm q =
       _root_.FundamentalGroup.mapOfEq ⟨e.symm, e.symm.continuous⟩
         (show e.symm y = x by rw [← h, e.symm_apply_apply]) q :=
   rfl
 
 /-- A homeomorphism `e : X ≃ₜ Y` induces an isomorphism of fundamental groups
 `π₁(X, x) ≃* π₁(Y, e x)`. -/
-@[expose] noncomputable def mulEquivOfHomeomorph (e : X ≃ₜ Y) (x : X) :
+@[expose] noncomputable def homeomorphMulEquiv (e : X ≃ₜ Y) (x : X) :
     _root_.FundamentalGroup X x ≃* _root_.FundamentalGroup Y (e x) :=
-  mulEquivOfHomeomorphOfEq e rfl
+  homeomorphMulEquivOfEq e rfl
 
 @[simp]
-theorem mulEquivOfHomeomorph_apply (e : X ≃ₜ Y) (x : X) (p : _root_.FundamentalGroup X x) :
-    mulEquivOfHomeomorph e x p =
+theorem homeomorphMulEquiv_apply (e : X ≃ₜ Y) (x : X) (p : _root_.FundamentalGroup X x) :
+    homeomorphMulEquiv e x p =
       _root_.FundamentalGroup.mapOfEq ⟨e, e.continuous⟩ rfl p :=
+  rfl
+
+@[simp]
+theorem homeomorphMulEquiv_symm_apply (e : X ≃ₜ Y) (x : X)
+    (q : _root_.FundamentalGroup Y (e x)) :
+    (homeomorphMulEquiv e x).symm q =
+      _root_.FundamentalGroup.mapOfEq ⟨e.symm, e.symm.continuous⟩ (e.symm_apply_apply x) q :=
   rfl
 
 end FundamentalGroup


### PR DESCRIPTION
This PR adds the group isomorphism induced on fundamental groups by a homeomorphism: a homeomorphism `e : X ≃ₜ Y` gives `π₁(X, x) ≃* π₁(Y, e x)`, and more generally `π₁(X, x) ≃* π₁(Y, y)` whenever `e x = y`. Mathlib records the homomorphism `FundamentalGroup.map` induced by a continuous map and the basepoint-adjusting variant `FundamentalGroup.mapOfEq`, but stops short of packaging a homeomorphism as an isomorphism of fundamental groups; this file supplies it, together with the general `mapOfEq` composition (`mapOfEq_comp`), identity (`mapOfEq_id`), and map-argument congruence (`mapOfEq_congr`) lemmas the construction rests on.

Transporting a fundamental-group computation across a homeomorphism is the group-level input the universal-covers roadmap calls for in its Stage 4 applications ([`TauCetiRoadmap/UniversalCovers/README.md`](https://github.com/TauCetiProject/TauCetiRoadmap/blob/main/UniversalCovers/README.md), Stage 4, "applications"): the fundamental group of the unit circle `Circle ⊆ ℂ`, obtained from the additive-circle computation through Mathlib's `AddCircle.homeomorphCircle`, and later `π₁(ℝPⁿ)`. This mirrors the way `TauCeti.FundamentalGroup.prodMulEquiv` supplied the product formula the torus computation needs, and is landed on its own as a reusable prerequisite.

The forward map is `FundamentalGroup.mapOfEq` of `e`, the inverse is `FundamentalGroup.mapOfEq` of `e.symm`, and the two round trips reduce, via `mapOfEq_comp`, to `e.symm ∘ e = id` and `e ∘ e.symm = id`. The `mapOfEq` lemmas are proved from Mathlib's `FundamentalGroup.mapOfEq_apply` and the `Path.Homotopic.Quotient` transport lemmas (`map_comp`, `map_cast`, `cast_cast`, `cast_rfl_rfl`), building directly on the fundamental-group API of Mark Lavrentyev and the path-homotopy API in `Mathlib.Topology.Homotopy.Path`.

<!--tauceti-target:v1 {"focus":"UniversalCovers","id":"fundamental-group-homeomorphism-invariant"}-->

🤖 Prepared with Claude Code
