### PR TITLE
feat: complete monotonicity under nonnegative affine reparametrization

### DIFF
--- a/TauCeti/Analysis/CompletelyMonotone/Reparametrization.lean
+++ b/TauCeti/Analysis/CompletelyMonotone/Reparametrization.lean
@@ -1,0 +1,123 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+module
+
+public import TauCeti.Analysis.CompletelyMonotone.Basic
+public import Mathlib.Analysis.Calculus.IteratedDeriv.Lemmas
+
+/-!
+# Complete monotonicity is closed under nonnegative affine reparametrization
+
+This file extends the closure API of `TauCeti.IsCompletelyMonotone` (sums, nonnegative scalar
+multiples, products and differentiation, in `TauCeti.Analysis.CompletelyMonotone.Basic` and
+`TauCeti.Analysis.CompletelyMonotone.Closure`) with closure under **reparametrizing the
+argument by a nonnegative affine map** `t ↦ c · t + a` (`c, a ≥ 0`), as called for by the
+`OneParameterSemigroups` roadmap's completely-monotone closure programme.
+
+Both nonnegativity conditions are essential and are exactly what keeps the reparametrized
+argument inside `[0, ∞)`, where the sign-alternation of `f` lives: scaling `t ↦ c · t` needs
+`c ≥ 0` so that `c · t ≥ 0`, and it multiplies the `n`-th alternating derivative by the
+nonnegative factor `cⁿ`; shifting `t ↦ t + a` needs `a ≥ 0` so that `t + a ≥ 0`, and it leaves
+the alternating derivative unchanged, only evaluated further to the right. A negative scaling
+`c < 0` reflects the half-line and turns complete monotonicity into absolute monotonicity, so
+the sign condition genuinely fails; a negative shift `a < 0` samples `f` to the left of `0`,
+where nothing is assumed.
+
+The scaling step is a direct consequence of Mathlib's `iteratedDerivWithin_comp_const_smul`; the
+shift step uses `iteratedDerivWithin_comp_add_const`, whose reparametrized set `a +ᵥ [0, ∞)` is
+`[a, ∞)`, and there the alternating derivative of `f` agrees with its value within `[0, ∞)`
+because `f` is smooth across the interior of the half-line. Combining the two gives the general
+nonnegative affine reparametrization.
+
+These closure lemmas manufacture new completely monotone functions from old: for instance
+`t ↦ e^{-x (c t + a)}` is completely monotone whenever `x, c, a ≥ 0`, and every resolvent kernel
+`t ↦ (λ + t)⁻¹` reparametrized by a nonnegative affine map stays completely monotone.
+
+## Main declarations
+
+* `TauCeti.IsCompletelyMonotone.comp_const_mul`: if `f` is completely monotone and `0 ≤ c`, then
+  `t ↦ f (c · t)` is completely monotone.
+* `TauCeti.IsCompletelyMonotone.comp_add_const`: if `f` is completely monotone and `0 ≤ a`, then
+  `t ↦ f (t + a)` is completely monotone.
+* `TauCeti.IsCompletelyMonotone.comp_affine`: if `f` is completely monotone and `0 ≤ c`, `0 ≤ a`,
+  then `t ↦ f (c · t + a)` is completely monotone.
+
+## References
+
+* R. Schilling, R. Song, Z. Vondraček, *Bernstein Functions: Theory and Applications*
+  (de Gruyter, 2nd ed. 2012).
+-/
+
+public section
+
+open Set
+open scoped ContDiff Pointwise
+
+namespace TauCeti
+
+namespace IsCompletelyMonotone
+
+variable {f : ℝ → ℝ}
+
+/-- Completely monotone functions are closed under scaling the argument by a nonnegative
+constant: if `f` is completely monotone and `0 ≤ c`, then `t ↦ f (c · t)` is completely
+monotone. The `n`-th alternating derivative is multiplied by the nonnegative factor `cⁿ`. -/
+theorem comp_const_mul (hf : IsCompletelyMonotone f) {c : ℝ} (hc : 0 ≤ c) :
+    IsCompletelyMonotone (fun t => f (c * t)) := by
+  have hmaps : Set.MapsTo (c * ·) (Ici (0 : ℝ)) (Ici 0) := fun t ht =>
+    mem_Ici.mpr (mul_nonneg hc (mem_Ici.mp ht))
+  refine ⟨hf.contDiffOn.comp (by fun_prop) hmaps, fun n t ht => ?_⟩
+  have hct : (0 : ℝ) ≤ c * t := mul_nonneg hc ht
+  rw [iteratedDerivWithin_comp_const_smul (mem_Ici.mpr ht) (uniqueDiffOn_Ici 0)
+    (hf.contDiffOn.of_le (by exact_mod_cast le_top)) c hmaps, smul_eq_mul]
+  have hsign := hf.neg_one_pow_mul_iteratedDerivWithin_nonneg n hct
+  have key : (-1 : ℝ) ^ n * (c ^ n * iteratedDerivWithin n f (Ici 0) (c * t)) =
+      c ^ n * ((-1) ^ n * iteratedDerivWithin n f (Ici 0) (c * t)) := by ring
+  rw [key]
+  exact mul_nonneg (pow_nonneg hc n) hsign
+
+/-- Completely monotone functions are closed under shifting the argument by a nonnegative
+constant: if `f` is completely monotone and `0 ≤ a`, then `t ↦ f (t + a)` is completely
+monotone. The alternating derivative is unchanged, evaluated at the shifted point. -/
+theorem comp_add_const (hf : IsCompletelyMonotone f) {a : ℝ} (ha : 0 ≤ a) :
+    IsCompletelyMonotone (fun t => f (t + a)) := by
+  have hmaps : Set.MapsTo (· + a) (Ici (0 : ℝ)) (Ici 0) := fun t ht =>
+    mem_Ici.mpr (add_nonneg (mem_Ici.mp ht) ha)
+  have hset : a +ᵥ Ici (0 : ℝ) = Ici a := by
+    ext x
+    simp only [Set.mem_vadd_set, mem_Ici, vadd_eq_add]
+    constructor
+    · rintro ⟨y, hy, rfl⟩; linarith
+    · intro hx; exact ⟨x - a, by linarith, by ring⟩
+  refine ⟨hf.contDiffOn.comp (by fun_prop) hmaps, fun n t ht => ?_⟩
+  have hval := congrFun
+    (iteratedDerivWithin_comp_add_const (f := f) (n := n) (s := Ici (0 : ℝ)) a) t
+  simp only [hset] at hval
+  rw [hval]
+  have hta : a ≤ t + a := by linarith
+  rcases eq_or_lt_of_le (show (0 : ℝ) ≤ t + a by linarith) with h0 | h0
+  · -- boundary case `t + a = 0`, forcing `t = a = 0`
+    have hta0 : t + a = (0 : ℝ) := h0.symm
+    have ha0 : a = 0 := by linarith
+    subst ha0
+    simpa [hta0] using hf.neg_one_pow_mul_iteratedDerivWithin_nonneg n (le_of_eq hta0.symm)
+  · -- interior case `t + a > 0`, where the within-derivatives agree with the ordinary one
+    have hcat : ContDiffAt ℝ (n : WithTop ℕ∞) f (t + a) :=
+      (hf.contDiffOn.contDiffAt
+        (Filter.mem_of_superset (isOpen_Ioi.mem_nhds h0) Ioi_subset_Ici_self)).of_le
+        (by exact_mod_cast le_top)
+    rw [iteratedDerivWithin_eq_iteratedDeriv (uniqueDiffOn_Ici a) hcat (mem_Ici.mpr hta)]
+    exact hf.neg_one_pow_mul_iteratedDeriv_nonneg n h0
+
+/-- Completely monotone functions are closed under nonnegative affine reparametrization of the
+argument: if `f` is completely monotone and `0 ≤ c`, `0 ≤ a`, then `t ↦ f (c · t + a)` is
+completely monotone. -/
+theorem comp_affine (hf : IsCompletelyMonotone f) {c a : ℝ} (hc : 0 ≤ c) (ha : 0 ≤ a) :
+    IsCompletelyMonotone (fun t => f (c * t + a)) :=
+  (hf.comp_add_const ha).comp_const_mul hc
+
+end IsCompletelyMonotone
+
+end TauCeti


### PR DESCRIPTION
This PR adds closure of completely monotone functions under nonnegative affine reparametrization of the argument, extending the `TauCeti.IsCompletelyMonotone` closure API. It proves that if `f` is completely monotone then so are `t ↦ f (c · t)` for `0 ≤ c`, `t ↦ f (t + a)` for `0 ≤ a`, and the combined `t ↦ f (c · t + a)` for `0 ≤ c`, `0 ≤ a`. Both nonnegativity hypotheses are exactly what keeps the reparametrized argument inside `[0, ∞)`, where the sign-alternation of `f` lives; scaling multiplies the `n`-th alternating derivative by the nonnegative factor `cⁿ`, and shifting leaves it unchanged, evaluated further to the right.

This advances the completely-monotone closure programme of `TauCetiRoadmap/OneParameterSemigroups/README.md`, Part B ("Completely monotone (and Bernstein) functions" — "Closure ... derivative/integral closure" and the surrounding basic-API bar for the object), alongside the already-merged sum, scalar-multiple, product and differentiation closures in `TauCeti/Analysis/CompletelyMonotone/`. Reparametrizing the argument is a standard member of that closure API and manufactures new completely monotone functions from old, for instance `t ↦ e^{-x (c t + a)}` for `x, c, a ≥ 0` or any nonnegative affine reparametrization of a resolvent kernel `t ↦ (λ + t)⁻¹`.

The scaling step consumes Mathlib's `iteratedDerivWithin_comp_const_smul`, and the shift step consumes `iteratedDerivWithin_comp_add_const` (both from `Mathlib.Analysis.Calculus.IteratedDeriv.Lemmas`); no infrastructure was vendored.

<!--tauceti-target:v1 {"focus":"OneParameterSemigroups","id":"completely-monotone-argument-reparametrization"}-->

🤖 Prepared with Claude Code
