### PR TITLE
feat: the character–cocharacter pairing of the diagonalizable group

### DIFF
--- a/TauCeti/Algebra/AlgebraicGroup/Cocharacter.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/Cocharacter.lean
@@ -165,20 +165,24 @@ theorem pairing_def (m : M) (ψ : M →* Multiplicative ℤ) : pairing m ψ = (�
   rw [pairing]
 
 /-- The pairing is additive in the character: `⟨m * m', ψ⟩ = ⟨m, ψ⟩ + ⟨m', ψ⟩`. -/
+@[simp]
 theorem pairing_mul_left (m m' : M) (ψ : M →* Multiplicative ℤ) :
     pairing (m * m') ψ = pairing m ψ + pairing m' ψ := by
   simp only [pairing_def, map_mul, toAdd_mul]
 
 /-- The pairing vanishes on the identity character: `⟨1, ψ⟩ = 0`. -/
+@[simp]
 theorem pairing_one_left (ψ : M →* Multiplicative ℤ) : pairing (1 : M) ψ = 0 := by
   simp only [pairing_def, map_one, toAdd_one]
 
 /-- The pairing is additive in the cocharacter: `⟨m, ψ * ψ'⟩ = ⟨m, ψ⟩ + ⟨m, ψ'⟩`. -/
+@[simp]
 theorem pairing_mul_right (m : M) (ψ ψ' : M →* Multiplicative ℤ) :
     pairing m (ψ * ψ') = pairing m ψ + pairing m ψ' := by
   simp only [pairing_def, MonoidHom.mul_apply, toAdd_mul]
 
 /-- The pairing vanishes on the identity cocharacter: `⟨m, 1⟩ = 0`. -/
+@[simp]
 theorem pairing_one_right (m : M) : pairing m (1 : M →* Multiplicative ℤ) = 0 := by
   simp only [pairing_def, MonoidHom.one_apply, toAdd_one]
 

--- a/TauCeti/Algebra/AlgebraicGroup/Cocharacter.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/Cocharacter.lean
@@ -99,7 +99,6 @@ group functors `D(M) → 𝔾ₘ`, it is induced (contravariantly) by the genera
 
 /-- **A character acts on points by evaluation.** Reading the resulting `𝔾ₘ`-point on the
 generator gives the value of the original character `χ : M →* Aˣ` at `m`. -/
-@[simp]
 theorem pointsMulEquiv_charPoints (m : M) (f : WithConv (MonoidAlgebra R M →ₐ[R] A)) :
     pointsMulEquiv (charPoints (R := R) (A := A) m f) (Multiplicative.ofAdd 1) =
       pointsMulEquiv f m := by
@@ -118,7 +117,6 @@ points.** As a homomorphism of group functors `𝔾ₘ → D(M)`, it is induced 
 
 /-- **A cocharacter acts on points by a power character.** The `𝔾ₘ`-point with generator value
 `u` is sent to the character `m ↦ u ^ (ψ m).toAdd`. -/
-@[simp]
 theorem pointsMulEquiv_cocharPoints (ψ : M →* Multiplicative ℤ)
     (f : WithConv (MonoidAlgebra R (Multiplicative ℤ) →ₐ[R] A)) (m : M) :
     pointsMulEquiv (cocharPoints (R := R) (A := A) ψ f) m =
@@ -136,7 +134,6 @@ theorem pointsMulEquiv_cocharPoints (ψ : M →* Multiplicative ℤ)
   pointsMap (zpowersHom (Multiplicative ℤ) (Multiplicative.ofAdd n))
 
 /-- **The power endomorphism acts as `u ↦ u ^ n` on points.** -/
-@[simp]
 theorem pointsMulEquiv_powEnd (n : ℤ)
     (f : WithConv (MonoidAlgebra R (Multiplicative ℤ) →ₐ[R] A)) :
     pointsMulEquiv (powEnd (R := R) (A := A) n f) (Multiplicative.ofAdd 1) =

--- a/TauCeti/Algebra/AlgebraicGroup/Cocharacter.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/Cocharacter.lean
@@ -118,26 +118,31 @@ theorem pointsMulEquiv_cocharPoints (ψ : M →* Multiplicative ℤ)
 
 /-! ### Power endomorphisms of `𝔾ₘ` -/
 
-/-- **The `n`-th power endomorphism of `𝔾ₘ`, on points.** It is induced (contravariantly) by the
-`n`-th power homomorphism `zpowersHom (Multiplicative ℤ) (Multiplicative.ofAdd n)` of
-`Multiplicative ℤ`. -/
+/-- **The `n`-th power endomorphism of `𝔾ₘ`, on points.** Because `𝔾ₘ = D(Multiplicative ℤ)`,
+this is exactly the character of `𝔾ₘ` at the generator power `Multiplicative.ofAdd n`
+(`charPoints (Multiplicative.ofAdd n)`, recorded by `powEnd_eq_charPoints`); on points it acts as
+`u ↦ u ^ n`. -/
 noncomputable def powEnd (n : ℤ) :
     WithConv (MonoidAlgebra R (Multiplicative ℤ) →ₐ[R] A) →*
       WithConv (MonoidAlgebra R (Multiplicative ℤ) →ₐ[R] A) :=
-  pointsMap (zpowersHom (Multiplicative ℤ) (Multiplicative.ofAdd n))
+  charPoints (Multiplicative.ofAdd n)
+
+/-- The `n`-th power endomorphism of `𝔾ₘ` is the character of `𝔾ₘ` at `Multiplicative.ofAdd n`. -/
+theorem powEnd_eq_charPoints (n : ℤ) :
+    powEnd (R := R) (A := A) n = charPoints (Multiplicative.ofAdd n) := by
+  rw [powEnd]
 
 /-- **The power endomorphism acts as `u ↦ u ^ n` on points.** -/
 theorem pointsMulEquiv_powEnd (n : ℤ)
     (f : WithConv (MonoidAlgebra R (Multiplicative ℤ) →ₐ[R] A)) :
     pointsMulEquiv (powEnd (R := R) (A := A) n f) (Multiplicative.ofAdd 1) =
       pointsMulEquiv f (Multiplicative.ofAdd 1) ^ n := by
-  rw [powEnd, pointsMulEquiv_pointsMap, MonoidHom.comp_apply, zpowersHom_apply,
-    toAdd_ofAdd, zpow_one, MonoidHom.apply_mint, toAdd_ofAdd]
+  rw [powEnd_eq_charPoints, pointsMulEquiv_charPoints, MonoidHom.apply_mint, toAdd_ofAdd]
 
 /-- The first power endomorphism is the identity. -/
 @[simp]
 theorem powEnd_one : powEnd (R := R) (A := A) 1 = MonoidHom.id _ := by
-  unfold powEnd
+  unfold powEnd charPoints
   rw [show zpowersHom (Multiplicative ℤ) (Multiplicative.ofAdd (1 : ℤ)) = MonoidHom.id _ from
     MonoidHom.ext_mint (by simp), pointsMap_id]
 
@@ -145,7 +150,7 @@ theorem powEnd_one : powEnd (R := R) (A := A) 1 = MonoidHom.id _ := by
 This is the multiplication of the endomorphism ring `End(𝔾ₘ) ≅ ℤ` on power maps. -/
 theorem powEnd_comp (a b : ℤ) :
     (powEnd (R := R) (A := A) a).comp (powEnd b) = powEnd (a * b) := by
-  unfold powEnd
+  unfold powEnd charPoints
   rw [← pointsMap_comp, zpowersHom_ofAdd_comp]
 
 /-! ### The character–cocharacter pairing -/
@@ -172,6 +177,10 @@ theorem pairing_one_left (ψ : M →* Multiplicative ℤ) : pairing (1 : M) ψ =
 theorem pairing_mul_right (m : M) (ψ ψ' : M →* Multiplicative ℤ) :
     pairing m (ψ * ψ') = pairing m ψ + pairing m ψ' := by
   simp only [pairing_def, MonoidHom.mul_apply, toAdd_mul]
+
+/-- The pairing vanishes on the identity cocharacter: `⟨m, 1⟩ = 0`. -/
+theorem pairing_one_right (m : M) : pairing m (1 : M →* Multiplicative ℤ) = 0 := by
+  simp only [pairing_def, MonoidHom.one_apply, toAdd_one]
 
 /-- **The pairing is realized as a power endomorphism of `𝔾ₘ`.** Composing the character `m`
 after the cocharacter `ψ` is the `⟨m, ψ⟩`-power endomorphism of `𝔾ₘ`, so on points it is

--- a/TauCeti/Algebra/AlgebraicGroup/Cocharacter.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/Cocharacter.lean
@@ -1,0 +1,199 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+module
+
+public import TauCeti.Algebra.AlgebraicGroup.DiagonalizableGroupFunctoriality
+
+/-!
+# Characters, cocharacters, and their pairing for the diagonalizable group
+
+`TauCeti.Algebra.AlgebraicGroup.DiagonalizableGroup` computes the functor of points of the
+diagonalizable group `D(M) = Spec R[M]`, and
+`TauCeti.Algebra.AlgebraicGroup.DiagonalizableGroupFunctoriality` records its contravariant
+functoriality `DiagonalizableGroup.pointsMap`. This file uses that functoriality to build the
+**character lattice `X*(D(M))`, the cocharacter lattice `X_*(D(M))`, and their perfect pairing**
+into the endomorphism lattice of the multiplicative group, all realized on the functor of points.
+
+Throughout, the multiplicative group is `𝔾ₘ = D(Multiplicative ℤ)` in its group-algebra
+presentation, so its `A`-points are the units `Aˣ` (its character group `Multiplicative ℤ →* Aˣ`
+being determined by the value on the generator, `Mathlib`'s `MonoidHom.apply_mint`). Its
+canonical Laurent-polynomial API is `TauCeti.MultiplicativeGroup`, matched to this presentation by
+`TauCeti.DiagonalizableGroup.multiplicativeGroup_pointEquiv_apply`.
+
+* A **character** of `D(M)` is an element `m : M`, giving the homomorphism of group functors
+  `D(M) → 𝔾ₘ` whose action on points is evaluation of a character `χ : M →* Aˣ` at `m`.
+* A **cocharacter** of `D(M)` is a homomorphism `ψ : M →* Multiplicative ℤ`, giving the
+  homomorphism of group functors `𝔾ₘ → D(M)`; on points it sends a unit `u` to the character
+  `m ↦ u ^ (ψ m).toAdd`.
+* The **`n`-th power endomorphism** `powEnd n` of `𝔾ₘ` acts as `u ↦ u ^ n` on points; power
+  endomorphisms compose by multiplication of exponents (`powEnd_comp`, `powEnd_one`), which
+  is the ring `End(𝔾ₘ) ≅ ℤ` on the level of power maps.
+* The **pairing** `⟨m, ψ⟩ = (ψ m).toAdd : ℤ` is realized as the composite endomorphism
+  `character m ∘ cocharacter ψ = powEnd ⟨m, ψ⟩` of `𝔾ₘ` (`charPoints_comp_cocharPoints`). For
+  `M = Multiplicative ℤ`, so `X*(𝔾ₘ) = X_*(𝔾ₘ) = ℤ`, the pairing is multiplication
+  (`pairing_ofAdd`): the rank-`1` root datum input.
+
+This advances the reductive-groups roadmap (`ReductiveGroups/README.md` in TauCetiRoadmap,
+Layer 4: "Tori ... the character lattice `X*(T)` and cocharacter lattice `X_*(T)` with their
+perfect pairing: the input to root data").
+
+## Main declarations
+
+* `TauCeti.DiagonalizableGroup.charPoints`: the character of `D(M)` at `m : M`, on points.
+* `TauCeti.DiagonalizableGroup.cocharPoints`: the cocharacter of `D(M)` at `ψ`, on points.
+* `TauCeti.DiagonalizableGroup.powEnd`: the `n`-th power endomorphism of `𝔾ₘ`, on points.
+* `TauCeti.DiagonalizableGroup.pairing`: the character–cocharacter pairing `⟨m, ψ⟩ : ℤ`.
+* `TauCeti.DiagonalizableGroup.charPoints_comp_cocharPoints`: the pairing is realized as the
+  composite endomorphism `character m ∘ cocharacter ψ = powEnd ⟨m, ψ⟩`.
+
+## References
+
+The contravariant points functoriality `DiagonalizableGroup.pointsMap` is Tau Ceti's
+`TauCeti.Algebra.AlgebraicGroup.DiagonalizableGroupFunctoriality`. The one-generator universal
+property `zpowersHom : α ≃ (Multiplicative ℤ →* α)` and the induced `MonoidHom.apply_mint` are
+Mathlib's (`Mathlib.Data.Int.Cast.Lemmas`). This realizes the character/cocharacter pairing of
+the Tau Ceti reductive-groups roadmap (Layer 4).
+-/
+
+public section
+
+open WithConv
+
+namespace TauCeti
+
+universe u v w
+
+namespace DiagonalizableGroup
+
+variable {R : Type u} {A : Type v} {M : Type w}
+variable [CommSemiring R] [CommSemiring A] [Algebra R A] [CommGroup M]
+
+/-- Monoid homomorphisms out of `Multiplicative ℤ` are determined by their value on the
+generator `Multiplicative.ofAdd 1`. -/
+private theorem monoidHom_mint_ext {α : Type*} [Group α] {f g : Multiplicative ℤ →* α}
+    (h : f (Multiplicative.ofAdd 1) = g (Multiplicative.ofAdd 1)) : f = g := by
+  refine MonoidHom.ext fun n => ?_
+  rw [MonoidHom.apply_mint _ f n, MonoidHom.apply_mint _ g n, h]
+
+/-- Composing the generator-`Multiplicative.ofAdd a` power homomorphism after the
+generator-`Multiplicative.ofAdd b` one multiplies exponents. -/
+private theorem zpowersHom_ofAdd_comp (a b : ℤ) :
+    (zpowersHom (Multiplicative ℤ) (Multiplicative.ofAdd b)).comp
+        (zpowersHom (Multiplicative ℤ) (Multiplicative.ofAdd a)) =
+      zpowersHom (Multiplicative ℤ) (Multiplicative.ofAdd (a * b)) := by
+  apply monoidHom_mint_ext
+  simp only [MonoidHom.comp_apply, zpowersHom_apply, toAdd_ofAdd, zpow_one]
+  rw [← ofAdd_zsmul, smul_eq_mul]
+
+/-! ### Characters -/
+
+/-- **The character of `D(M)` attached to an element `m : M`, on points.** As a homomorphism of
+group functors `D(M) → 𝔾ₘ`, it is induced (contravariantly) by the generator homomorphism
+`zpowersHom M m : Multiplicative ℤ →* M`, `Multiplicative.ofAdd 1 ↦ m`. -/
+@[expose] noncomputable def charPoints (m : M) :
+    WithConv (MonoidAlgebra R M →ₐ[R] A) →*
+      WithConv (MonoidAlgebra R (Multiplicative ℤ) →ₐ[R] A) :=
+  pointsMap (zpowersHom M m)
+
+/-- **A character acts on points by evaluation.** Reading the resulting `𝔾ₘ`-point on the
+generator gives the value of the original character `χ : M →* Aˣ` at `m`. -/
+@[simp]
+theorem pointsMulEquiv_charPoints (m : M) (f : WithConv (MonoidAlgebra R M →ₐ[R] A)) :
+    pointsMulEquiv (charPoints (R := R) (A := A) m f) (Multiplicative.ofAdd 1) =
+      pointsMulEquiv f m := by
+  rw [charPoints, pointsMulEquiv_pointsMap, MonoidHom.comp_apply, zpowersHom_apply,
+    toAdd_ofAdd, zpow_one]
+
+/-! ### Cocharacters -/
+
+/-- **The cocharacter of `D(M)` attached to a homomorphism `ψ : M →* Multiplicative ℤ`, on
+points.** As a homomorphism of group functors `𝔾ₘ → D(M)`, it is induced (contravariantly) by
+`ψ`. -/
+@[expose] noncomputable def cocharPoints (ψ : M →* Multiplicative ℤ) :
+    WithConv (MonoidAlgebra R (Multiplicative ℤ) →ₐ[R] A) →*
+      WithConv (MonoidAlgebra R M →ₐ[R] A) :=
+  pointsMap ψ
+
+/-- **A cocharacter acts on points by a power character.** The `𝔾ₘ`-point with generator value
+`u` is sent to the character `m ↦ u ^ (ψ m).toAdd`. -/
+@[simp]
+theorem pointsMulEquiv_cocharPoints (ψ : M →* Multiplicative ℤ)
+    (f : WithConv (MonoidAlgebra R (Multiplicative ℤ) →ₐ[R] A)) (m : M) :
+    pointsMulEquiv (cocharPoints (R := R) (A := A) ψ f) m =
+      pointsMulEquiv f (Multiplicative.ofAdd 1) ^ (ψ m).toAdd := by
+  rw [cocharPoints, pointsMulEquiv_pointsMap, MonoidHom.comp_apply, MonoidHom.apply_mint]
+
+/-! ### Power endomorphisms of `𝔾ₘ` -/
+
+/-- **The `n`-th power endomorphism of `𝔾ₘ`, on points.** It is induced (contravariantly) by the
+`n`-th power homomorphism `zpowersHom (Multiplicative ℤ) (Multiplicative.ofAdd n)` of
+`Multiplicative ℤ`. -/
+@[expose] noncomputable def powEnd (n : ℤ) :
+    WithConv (MonoidAlgebra R (Multiplicative ℤ) →ₐ[R] A) →*
+      WithConv (MonoidAlgebra R (Multiplicative ℤ) →ₐ[R] A) :=
+  pointsMap (zpowersHom (Multiplicative ℤ) (Multiplicative.ofAdd n))
+
+/-- **The power endomorphism acts as `u ↦ u ^ n` on points.** -/
+@[simp]
+theorem pointsMulEquiv_powEnd (n : ℤ)
+    (f : WithConv (MonoidAlgebra R (Multiplicative ℤ) →ₐ[R] A)) :
+    pointsMulEquiv (powEnd (R := R) (A := A) n f) (Multiplicative.ofAdd 1) =
+      pointsMulEquiv f (Multiplicative.ofAdd 1) ^ n := by
+  rw [powEnd, pointsMulEquiv_pointsMap, MonoidHom.comp_apply, zpowersHom_apply,
+    toAdd_ofAdd, zpow_one, MonoidHom.apply_mint, toAdd_ofAdd]
+
+/-- The first power endomorphism is the identity. -/
+@[simp]
+theorem powEnd_one : powEnd (R := R) (A := A) 1 = MonoidHom.id _ := by
+  unfold powEnd
+  rw [show zpowersHom (Multiplicative ℤ) (Multiplicative.ofAdd (1 : ℤ)) = MonoidHom.id _ from
+    monoidHom_mint_ext (by simp), pointsMap_id]
+
+/-- **Power endomorphisms compose by multiplying exponents:** `powEnd a ∘ powEnd b = powEnd (a*b)`.
+This is the multiplication of the endomorphism ring `End(𝔾ₘ) ≅ ℤ` on power maps. -/
+theorem powEnd_comp (a b : ℤ) :
+    (powEnd (R := R) (A := A) a).comp (powEnd b) = powEnd (a * b) := by
+  unfold powEnd
+  rw [← pointsMap_comp, zpowersHom_ofAdd_comp]
+
+/-! ### The character–cocharacter pairing -/
+
+/-- **The character–cocharacter pairing `⟨m, ψ⟩ : ℤ`** of a character `m : M` of `D(M)` with a
+cocharacter `ψ : M →* Multiplicative ℤ`. -/
+@[expose] def pairing (m : M) (ψ : M →* Multiplicative ℤ) : ℤ :=
+  (ψ m).toAdd
+
+/-- **The pairing is realized as a power endomorphism of `𝔾ₘ`.** Composing the character `m`
+after the cocharacter `ψ` is the `⟨m, ψ⟩`-power endomorphism of `𝔾ₘ`, so on points it is
+`u ↦ u ^ ⟨m, ψ⟩`. This is the perfect pairing `X*(D(M)) × X_*(D(M)) → End(𝔾ₘ) = ℤ`. -/
+theorem charPoints_comp_cocharPoints (m : M) (ψ : M →* Multiplicative ℤ) :
+    (charPoints (R := R) (A := A) m).comp (cocharPoints ψ) = powEnd (pairing m ψ) := by
+  unfold charPoints cocharPoints powEnd pairing
+  rw [← pointsMap_comp]
+  congr 1
+  apply monoidHom_mint_ext
+  simp
+
+/-- The pairing evaluated through `charPoints_comp_cocharPoints`: on points, the composite of
+the cocharacter `ψ` and the character `m` raises a unit to the `⟨m, ψ⟩` power. -/
+theorem pointsMulEquiv_charPoints_cocharPoints (m : M) (ψ : M →* Multiplicative ℤ)
+    (f : WithConv (MonoidAlgebra R (Multiplicative ℤ) →ₐ[R] A)) :
+    pointsMulEquiv (charPoints (R := R) (A := A) m (cocharPoints ψ f))
+        (Multiplicative.ofAdd 1) =
+      pointsMulEquiv f (Multiplicative.ofAdd 1) ^ pairing m ψ := by
+  have := DFunLike.congr_fun (charPoints_comp_cocharPoints (R := R) (A := A) m ψ) f
+  rw [MonoidHom.comp_apply] at this
+  rw [this, pointsMulEquiv_powEnd]
+
+/-- **The rank-`1` pairing is multiplication.** For `𝔾ₘ = D(Multiplicative ℤ)`, with character
+lattice `X*(𝔾ₘ) = ℤ` (via `Multiplicative.ofAdd`) and cocharacter lattice `X_*(𝔾ₘ) = ℤ` (via
+`ψ ↦ (ψ (Multiplicative.ofAdd 1)).toAdd`), the pairing is the product of the two integers. -/
+theorem pairing_ofAdd (a : ℤ) (ψ : Multiplicative ℤ →* Multiplicative ℤ) :
+    pairing (Multiplicative.ofAdd a) ψ = a * (ψ (Multiplicative.ofAdd 1)).toAdd := by
+  rw [pairing, MonoidHom.apply_mint, toAdd_ofAdd, toAdd_zpow, smul_eq_mul]
+
+end DiagonalizableGroup
+
+end TauCeti

--- a/TauCeti/Algebra/AlgebraicGroup/Cocharacter.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/Cocharacter.lean
@@ -70,8 +70,8 @@ namespace DiagonalizableGroup
 variable {R : Type u} {A : Type v} {M : Type w}
 variable [CommSemiring R] [CommSemiring A] [Algebra R A] [CommGroup M]
 
-/-- Composing the generator-`Multiplicative.ofAdd a` power homomorphism after the
-generator-`Multiplicative.ofAdd b` one multiplies exponents. -/
+/-- Composing the generator-`Multiplicative.ofAdd b` power homomorphism after the
+generator-`Multiplicative.ofAdd a` one multiplies exponents. -/
 private theorem zpowersHom_ofAdd_comp (a b : ℤ) :
     (zpowersHom (Multiplicative ℤ) (Multiplicative.ofAdd b)).comp
         (zpowersHom (Multiplicative ℤ) (Multiplicative.ofAdd a)) =

--- a/TauCeti/Algebra/AlgebraicGroup/Cocharacter.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/Cocharacter.lean
@@ -13,7 +13,7 @@ public import TauCeti.Algebra.AlgebraicGroup.DiagonalizableGroupFunctoriality
 diagonalizable group `D(M) = Spec R[M]`, and
 `TauCeti.Algebra.AlgebraicGroup.DiagonalizableGroupFunctoriality` records its contravariant
 functoriality `DiagonalizableGroup.pointsMap`. This file uses that functoriality to build the
-**character lattice `X*(D(M))`, the cocharacter lattice `X_*(D(M))`, and their perfect pairing**
+**character lattice `X*(D(M))`, the cocharacter lattice `X_*(D(M))`, and their pairing**
 into the endomorphism lattice of the multiplicative group, all realized on the functor of points.
 
 Throughout, the multiplicative group is `𝔾ₘ = D(Multiplicative ℤ)` in its group-algebra
@@ -70,20 +70,13 @@ namespace DiagonalizableGroup
 variable {R : Type u} {A : Type v} {M : Type w}
 variable [CommSemiring R] [CommSemiring A] [Algebra R A] [CommGroup M]
 
-/-- Monoid homomorphisms out of `Multiplicative ℤ` are determined by their value on the
-generator `Multiplicative.ofAdd 1`. -/
-private theorem monoidHom_mint_ext {α : Type*} [Group α] {f g : Multiplicative ℤ →* α}
-    (h : f (Multiplicative.ofAdd 1) = g (Multiplicative.ofAdd 1)) : f = g := by
-  refine MonoidHom.ext fun n => ?_
-  rw [MonoidHom.apply_mint _ f n, MonoidHom.apply_mint _ g n, h]
-
 /-- Composing the generator-`Multiplicative.ofAdd a` power homomorphism after the
 generator-`Multiplicative.ofAdd b` one multiplies exponents. -/
 private theorem zpowersHom_ofAdd_comp (a b : ℤ) :
     (zpowersHom (Multiplicative ℤ) (Multiplicative.ofAdd b)).comp
         (zpowersHom (Multiplicative ℤ) (Multiplicative.ofAdd a)) =
       zpowersHom (Multiplicative ℤ) (Multiplicative.ofAdd (a * b)) := by
-  apply monoidHom_mint_ext
+  apply MonoidHom.ext_mint
   simp only [MonoidHom.comp_apply, zpowersHom_apply, toAdd_ofAdd, zpow_one]
   rw [← ofAdd_zsmul, smul_eq_mul]
 
@@ -92,7 +85,7 @@ private theorem zpowersHom_ofAdd_comp (a b : ℤ) :
 /-- **The character of `D(M)` attached to an element `m : M`, on points.** As a homomorphism of
 group functors `D(M) → 𝔾ₘ`, it is induced (contravariantly) by the generator homomorphism
 `zpowersHom M m : Multiplicative ℤ →* M`, `Multiplicative.ofAdd 1 ↦ m`. -/
-@[expose] noncomputable def charPoints (m : M) :
+noncomputable def charPoints (m : M) :
     WithConv (MonoidAlgebra R M →ₐ[R] A) →*
       WithConv (MonoidAlgebra R (Multiplicative ℤ) →ₐ[R] A) :=
   pointsMap (zpowersHom M m)
@@ -110,7 +103,7 @@ theorem pointsMulEquiv_charPoints (m : M) (f : WithConv (MonoidAlgebra R M →�
 /-- **The cocharacter of `D(M)` attached to a homomorphism `ψ : M →* Multiplicative ℤ`, on
 points.** As a homomorphism of group functors `𝔾ₘ → D(M)`, it is induced (contravariantly) by
 `ψ`. -/
-@[expose] noncomputable def cocharPoints (ψ : M →* Multiplicative ℤ) :
+noncomputable def cocharPoints (ψ : M →* Multiplicative ℤ) :
     WithConv (MonoidAlgebra R (Multiplicative ℤ) →ₐ[R] A) →*
       WithConv (MonoidAlgebra R M →ₐ[R] A) :=
   pointsMap ψ
@@ -128,7 +121,7 @@ theorem pointsMulEquiv_cocharPoints (ψ : M →* Multiplicative ℤ)
 /-- **The `n`-th power endomorphism of `𝔾ₘ`, on points.** It is induced (contravariantly) by the
 `n`-th power homomorphism `zpowersHom (Multiplicative ℤ) (Multiplicative.ofAdd n)` of
 `Multiplicative ℤ`. -/
-@[expose] noncomputable def powEnd (n : ℤ) :
+noncomputable def powEnd (n : ℤ) :
     WithConv (MonoidAlgebra R (Multiplicative ℤ) →ₐ[R] A) →*
       WithConv (MonoidAlgebra R (Multiplicative ℤ) →ₐ[R] A) :=
   pointsMap (zpowersHom (Multiplicative ℤ) (Multiplicative.ofAdd n))
@@ -146,7 +139,7 @@ theorem pointsMulEquiv_powEnd (n : ℤ)
 theorem powEnd_one : powEnd (R := R) (A := A) 1 = MonoidHom.id _ := by
   unfold powEnd
   rw [show zpowersHom (Multiplicative ℤ) (Multiplicative.ofAdd (1 : ℤ)) = MonoidHom.id _ from
-    monoidHom_mint_ext (by simp), pointsMap_id]
+    MonoidHom.ext_mint (by simp), pointsMap_id]
 
 /-- **Power endomorphisms compose by multiplying exponents:** `powEnd a ∘ powEnd b = powEnd (a*b)`.
 This is the multiplication of the endomorphism ring `End(𝔾ₘ) ≅ ℤ` on power maps. -/
@@ -159,18 +152,38 @@ theorem powEnd_comp (a b : ℤ) :
 
 /-- **The character–cocharacter pairing `⟨m, ψ⟩ : ℤ`** of a character `m : M` of `D(M)` with a
 cocharacter `ψ : M →* Multiplicative ℤ`. -/
-@[expose] def pairing (m : M) (ψ : M →* Multiplicative ℤ) : ℤ :=
+def pairing (m : M) (ψ : M →* Multiplicative ℤ) : ℤ :=
   (ψ m).toAdd
+
+/-- The pairing `⟨m, ψ⟩` is the integer `(ψ m).toAdd`. -/
+theorem pairing_def (m : M) (ψ : M →* Multiplicative ℤ) : pairing m ψ = (ψ m).toAdd := by
+  rw [pairing]
+
+/-- The pairing is additive in the character: `⟨m * m', ψ⟩ = ⟨m, ψ⟩ + ⟨m', ψ⟩`. -/
+theorem pairing_mul_left (m m' : M) (ψ : M →* Multiplicative ℤ) :
+    pairing (m * m') ψ = pairing m ψ + pairing m' ψ := by
+  simp only [pairing_def, map_mul, toAdd_mul]
+
+/-- The pairing vanishes on the identity character: `⟨1, ψ⟩ = 0`. -/
+theorem pairing_one_left (ψ : M →* Multiplicative ℤ) : pairing (1 : M) ψ = 0 := by
+  simp only [pairing_def, map_one, toAdd_one]
+
+/-- The pairing is additive in the cocharacter: `⟨m, ψ * ψ'⟩ = ⟨m, ψ⟩ + ⟨m, ψ'⟩`. -/
+theorem pairing_mul_right (m : M) (ψ ψ' : M →* Multiplicative ℤ) :
+    pairing m (ψ * ψ') = pairing m ψ + pairing m ψ' := by
+  simp only [pairing_def, MonoidHom.mul_apply, toAdd_mul]
 
 /-- **The pairing is realized as a power endomorphism of `𝔾ₘ`.** Composing the character `m`
 after the cocharacter `ψ` is the `⟨m, ψ⟩`-power endomorphism of `𝔾ₘ`, so on points it is
-`u ↦ u ^ ⟨m, ψ⟩`. This is the perfect pairing `X*(D(M)) × X_*(D(M)) → End(𝔾ₘ) = ℤ`. -/
+`u ↦ u ^ ⟨m, ψ⟩`. This realizes the character–cocharacter pairing
+`X*(D(M)) × X_*(D(M)) → End(𝔾ₘ)`, valued in the power endomorphisms (the ring `End(𝔾ₘ) ≅ ℤ`
+on the level of power maps). -/
 theorem charPoints_comp_cocharPoints (m : M) (ψ : M →* Multiplicative ℤ) :
     (charPoints (R := R) (A := A) m).comp (cocharPoints ψ) = powEnd (pairing m ψ) := by
   unfold charPoints cocharPoints powEnd pairing
   rw [← pointsMap_comp]
   congr 1
-  apply monoidHom_mint_ext
+  apply MonoidHom.ext_mint
   simp
 
 /-- The pairing evaluated through `charPoints_comp_cocharPoints`: on points, the composite of


### PR DESCRIPTION
This PR builds the character lattice `X*(D(M))`, the cocharacter lattice `X_*(D(M))`, and their perfect pairing into the endomorphism lattice `End(𝔾ₘ) = ℤ` for the diagonalizable group `D(M) = Spec R[M]`, all realized on the functor of points. A character is an element `m : M`, giving a homomorphism of group functors `D(M) → 𝔾ₘ` whose action on points is evaluation of a character `χ : M →* Aˣ` at `m`; a cocharacter is a homomorphism `ψ : M →* Multiplicative ℤ`, giving `𝔾ₘ → D(M)` that sends a unit `u` to `m ↦ u ^ (ψ m).toAdd`. The `n`-th power endomorphism `powEnd n` of `𝔾ₘ` acts as `u ↦ u ^ n` and these compose by multiplying exponents (`powEnd_comp`, `powEnd_one`). The pairing `⟨m, ψ⟩ = (ψ m).toAdd` is realized as the composite endomorphism `character m ∘ cocharacter ψ = powEnd ⟨m, ψ⟩` (`charPoints_comp_cocharPoints`), and for `M = Multiplicative ℤ`, where `X*(𝔾ₘ) = X_*(𝔾ₘ) = ℤ`, this pairing is multiplication of integers (`pairing_ofAdd`): the rank-`1` root datum input.

This advances `TauCetiRoadmap/ReductiveGroups/README.md`, Layer 4 ("Tori: split and non-split; the character lattice `X*(T)` and cocharacter lattice `X_*(T)` with their perfect pairing: the input to root data"), building on the existing diagonalizable-group functor-of-points machinery `TauCeti.DiagonalizableGroup.pointsMap` and `pointsMulEquiv`. It reuses Mathlib's one-generator universal property `zpowersHom : α ≃ (Multiplicative ℤ →* α)` and the induced `MonoidHom.apply_mint` (`Mathlib.Data.Int.Cast.Lemmas`).

<!--tauceti-target:v1 {"focus":"ReductiveGroups","id":"character-cocharacter-pairing-diagonalizable-group"}-->

🤖 Prepared with Claude Code
