### PR TITLE
feat: Lévy's downward theorem on an eventually constant filtration

### DIFF
--- a/TauCeti/Probability/Martingale/LevyDownwardEventuallyConst.lean
+++ b/TauCeti/Probability/Martingale/LevyDownwardEventuallyConst.lean
@@ -22,7 +22,7 @@ on, `𝔽 n = 𝔽 N` for `n ≥ N`. Two independent computations must agree:
   (`iInf_measurableSpace_eq_of_antitone_of_eventually_const`), so the Lévy downward limit
   `μ[f | ⨅ n, 𝔽 n]` is `μ[f | 𝔽 N]` (`condExp_iInf_eq_of_eventually_const`).
 
-The capstone `tendsto_ae_condExp_iInf_of_eventually_const` runs the general theorem and
+The capstone `tendsto_ae_condExp_of_eventually_const` runs the general theorem and
 rewrites its limit through the intersection collapse, recovering exactly the elementary limit:
 the two routes agree, which is what "specializes correctly" means.
 
@@ -46,9 +46,7 @@ variable {Ω : Type*} [MeasurableSpace Ω] {μ : Measure Ω}
 variable {𝔽 : ℕ → MeasurableSpace Ω}
 
 /-- The intersection of an antitone filtration that is constant from index `N` on collapses to
-the stabilized σ-algebra `𝔽 N`. This is the order fact behind the Lévy-downward specialization:
-`iInf_le` gives `⨅ n, 𝔽 n ≤ 𝔽 N`, and for the reverse inequality antitonicity handles `n ≤ N`
-while the eventual-constancy hypothesis handles `n ≥ N`. -/
+the stabilized σ-algebra `𝔽 N`. This is the order fact behind the Lévy-downward specialization. -/
 theorem iInf_measurableSpace_eq_of_antitone_of_eventually_const {Ω : Type*}
     {𝔽 : ℕ → MeasurableSpace Ω} (h_anti : Antitone 𝔽) {N : ℕ}
     (h_const : ∀ n, N ≤ n → 𝔽 n = 𝔽 N) :
@@ -90,7 +88,7 @@ constant from index `N` on, then collapse its limit through
 `condExp_iInf_eq_of_eventually_const`. The a.e. limit it delivers is `μ[f | 𝔽 N]` — exactly the
 value the sequence already reaches by the elementary
 `tendsto_condExp_of_eventually_const`. The general and elementary computations agree. -/
-theorem tendsto_ae_condExp_iInf_of_eventually_const [IsFiniteMeasure μ]
+theorem tendsto_ae_condExp_of_eventually_const [IsFiniteMeasure μ]
     (h_anti : Antitone 𝔽) (h_le0 : 𝔽 0 ≤ (inferInstance : MeasurableSpace Ω))
     {N : ℕ} (h_const : ∀ n, N ≤ n → 𝔽 n = 𝔽 N)
     (f : Ω → ℝ) (h_int : Integrable f μ) :

--- a/TauCeti/Probability/Martingale/LevyDownwardEventuallyConst.lean
+++ b/TauCeti/Probability/Martingale/LevyDownwardEventuallyConst.lean
@@ -1,0 +1,103 @@
+module
+
+public import TauCeti.Probability.Martingale.Convergence
+
+/-!
+# Lévy's downward theorem on an eventually constant filtration
+
+This file is the Exchangeability-roadmap worked example
+(`TauCetiRoadmap/Exchangeability/README.md`, "Worked examples"): *the Lévy downward theorem
+specializes correctly to an eventually constant decreasing filtration*. It is a consistency
+test of the flagship Layer-4 result `MeasureTheory.tendsto_ae_condExp_iInf`, not a de Finetti
+example.
+
+Fix an antitone filtration `𝔽 : ℕ → MeasurableSpace Ω` that is constant from some index `N`
+on, `𝔽 n = 𝔽 N` for `n ≥ N`. Two independent computations must agree:
+
+* **Elementary.** The sequence `n ↦ μ[f | 𝔽 n]` is literally constant past `N`
+  (`condExp_eq_of_eventually_const`), so it converges — everywhere, no integrability or
+  finiteness needed — to the value `μ[f | 𝔽 N]` it already sits at
+  (`tendsto_condExp_of_eventually_const`).
+* **General.** The intersection `⨅ n, 𝔽 n` collapses to `𝔽 N`
+  (`iInf_measurableSpace_eq_of_antitone_of_eventually_const`), so the Lévy downward limit
+  `μ[f | ⨅ n, 𝔽 n]` is `μ[f | 𝔽 N]` (`condExp_iInf_eq_of_eventually_const`).
+
+The capstone `tendsto_ae_condExp_iInf_of_eventually_const` runs the general theorem and
+rewrites its limit through the intersection collapse, recovering exactly the elementary limit:
+the two routes agree, which is what "specializes correctly" means.
+
+No material from `cameronfreer/exchangeability` is used; this is a Tau-Ceti-local check of the
+flagship theorem stated in `TauCeti.Probability.Martingale.Convergence`.
+-/
+
+public section
+
+noncomputable section
+
+open MeasureTheory Filter
+
+open scoped Topology
+
+namespace TauCeti
+
+namespace Probability
+
+variable {Ω : Type*} [MeasurableSpace Ω] {μ : Measure Ω}
+variable {𝔽 : ℕ → MeasurableSpace Ω}
+
+/-- The intersection of an antitone filtration that is constant from index `N` on collapses to
+the stabilized σ-algebra `𝔽 N`. This is the order fact behind the Lévy-downward specialization:
+`iInf_le` gives `⨅ n, 𝔽 n ≤ 𝔽 N`, and for the reverse inequality antitonicity handles `n ≤ N`
+while the eventual-constancy hypothesis handles `n ≥ N`. -/
+theorem iInf_measurableSpace_eq_of_antitone_of_eventually_const {Ω : Type*}
+    {𝔽 : ℕ → MeasurableSpace Ω} (h_anti : Antitone 𝔽) {N : ℕ}
+    (h_const : ∀ n, N ≤ n → 𝔽 n = 𝔽 N) :
+    ⨅ n, 𝔽 n = 𝔽 N := by
+  refine le_antisymm (iInf_le 𝔽 N) (le_iInf fun n => ?_)
+  rcases le_total N n with h | h
+  · exact (h_const n h).ge
+  · exact h_anti h
+
+/-- Past the stabilization index the conditional expectations are literally equal: for `N ≤ n`
+the σ-algebras `𝔽 n` and `𝔽 N` coincide, so `μ[f | 𝔽 n]` and `μ[f | 𝔽 N]` are the same term. -/
+theorem condExp_eq_of_eventually_const {N : ℕ}
+    (h_const : ∀ n, N ≤ n → 𝔽 n = 𝔽 N) (f : Ω → ℝ) {n : ℕ} (hn : N ≤ n) :
+    μ[f | 𝔽 n] = μ[f | 𝔽 N] := by
+  rw [h_const n hn]
+
+/-- **Elementary convergence.** Along a filtration constant from index `N` on, the conditional
+expectations `μ[f | 𝔽 n]` reach `μ[f | 𝔽 N]` exactly and stay there, so they converge to it at
+every point. No integrability of `f` or finiteness of `μ` is needed: the sequence is eventually
+constant. -/
+theorem tendsto_condExp_of_eventually_const {N : ℕ}
+    (h_const : ∀ n, N ≤ n → 𝔽 n = 𝔽 N) (f : Ω → ℝ) (ω : Ω) :
+    Tendsto (fun n => μ[f | 𝔽 n] ω) atTop (𝓝 (μ[f | 𝔽 N] ω)) :=
+  tendsto_atTop_of_eventually_const (i₀ := N)
+    fun _ hn => congrFun (condExp_eq_of_eventually_const h_const f hn) ω
+
+/-- **The Lévy downward limit collapses.** For an antitone filtration constant from index `N`
+on, the reverse-martingale limit `μ[f | ⨅ n, 𝔽 n]` produced by `tendsto_ae_condExp_iInf` is the
+conditional expectation onto the stabilized σ-algebra `𝔽 N`. -/
+theorem condExp_iInf_eq_of_eventually_const
+    (h_anti : Antitone 𝔽) {N : ℕ} (h_const : ∀ n, N ≤ n → 𝔽 n = 𝔽 N) (f : Ω → ℝ) :
+    μ[f | ⨅ n, 𝔽 n] = μ[f | 𝔽 N] := by
+  rw [iInf_measurableSpace_eq_of_antitone_of_eventually_const h_anti h_const]
+
+/-- **Lévy's downward theorem specializes correctly to an eventually constant filtration.**
+
+Run the flagship `MeasureTheory.tendsto_ae_condExp_iInf` on an antitone filtration that is
+constant from index `N` on, then collapse its limit through
+`condExp_iInf_eq_of_eventually_const`. The a.e. limit it delivers is `μ[f | 𝔽 N]` — exactly the
+value the sequence already reaches by the elementary
+`tendsto_condExp_of_eventually_const`. The general and elementary computations agree. -/
+theorem tendsto_ae_condExp_iInf_of_eventually_const [IsFiniteMeasure μ]
+    (h_anti : Antitone 𝔽) (h_le0 : 𝔽 0 ≤ (inferInstance : MeasurableSpace Ω))
+    {N : ℕ} (h_const : ∀ n, N ≤ n → 𝔽 n = 𝔽 N)
+    (f : Ω → ℝ) (h_int : Integrable f μ) :
+    ∀ᵐ ω ∂μ, Tendsto (fun n => μ[f | 𝔽 n] ω) atTop (𝓝 (μ[f | 𝔽 N] ω)) := by
+  have h := tendsto_ae_condExp_iInf h_anti h_le0 f h_int
+  rwa [condExp_iInf_eq_of_eventually_const h_anti h_const f] at h
+
+end Probability
+
+end TauCeti


### PR DESCRIPTION
This PR adds the Exchangeability-roadmap worked example that Lévy's downward theorem specializes correctly to an eventually constant decreasing filtration, testing the flagship Layer-4 result `MeasureTheory.tendsto_ae_condExp_iInf` (`TauCetiRoadmap/Exchangeability/README.md`, "Worked examples": *"The Lévy downward theorem specializes correctly to an eventually constant decreasing filtration (a test of `condExp_tendsto_iInf`, not a de Finetti example)."*). For an antitone filtration `𝔽 : ℕ → MeasurableSpace Ω` that is constant from some index `N` on, it checks that two independent computations of the reverse-martingale limit agree: the elementary one, where the sequence `n ↦ μ[f | 𝔽 n]` is literally constant past `N` and so reaches `μ[f | 𝔽 N]` exactly (everywhere, with no integrability or finiteness assumption), and the general one, where `tendsto_ae_condExp_iInf` delivers `μ[f | ⨅ n, 𝔽 n]` and the intersection collapses to `𝔽 N`.

The file proves the order fact `iInf_measurableSpace_eq_of_antitone_of_eventually_const` (the intersection of the eventually constant antitone filtration is the stabilized σ-algebra), the conditional-expectation specializations `condExp_eq_of_eventually_const` and `condExp_iInf_eq_of_eventually_const`, the elementary everywhere-convergence `tendsto_condExp_of_eventually_const`, and the capstone `tendsto_ae_condExp_iInf_of_eventually_const` that runs the flagship theorem and rewrites its limit through the intersection collapse to recover exactly the elementary limit. It reuses Mathlib's `tendsto_atTop_of_eventually_const` and Tau Ceti's `tendsto_ae_condExp_iInf`; no material from `cameronfreer/exchangeability` is used.

<!--tauceti-target:v1 {"focus":"Exchangeability","id":"levy-downward-eventually-const-filtration"}-->

🤖 Prepared with Claude Code
