### PR TITLE
feat: μ_n is the kernel of the n-th power endomorphism of 𝔾ₘ

### DIFF
--- a/TauCeti/Algebra/AlgebraicGroup/Cocharacter.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/Cocharacter.lean
@@ -122,6 +122,7 @@ theorem pointsMulEquiv_cocharPoints (ψ : M →* Multiplicative ℤ)
 off the same unit on the group-algebra generator `Multiplicative.ofAdd 1`: a character of
 `Multiplicative ℤ` is determined by its value at the generator (`MonoidHom.ext_mint`), and points
 are equivalent to characters. -/
+@[ext]
 theorem pointsMulEquiv_ext {f g : WithConv (MonoidAlgebra R (Multiplicative ℤ) →ₐ[R] A)}
     (h : pointsMulEquiv f (Multiplicative.ofAdd (1 : ℤ)) =
         pointsMulEquiv g (Multiplicative.ofAdd (1 : ℤ))) :

--- a/TauCeti/Algebra/AlgebraicGroup/Cocharacter.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/Cocharacter.lean
@@ -118,6 +118,16 @@ theorem pointsMulEquiv_cocharPoints (ψ : M →* Multiplicative ℤ)
 
 /-! ### Power endomorphisms of `𝔾ₘ` -/
 
+/-- **Extensionality for `𝔾ₘ = D(Multiplicative ℤ)` points.** Two points are equal once they read
+off the same unit on the group-algebra generator `Multiplicative.ofAdd 1`: a character of
+`Multiplicative ℤ` is determined by its value at the generator (`MonoidHom.ext_mint`), and points
+are equivalent to characters. -/
+theorem pointsMulEquiv_ext {f g : WithConv (MonoidAlgebra R (Multiplicative ℤ) →ₐ[R] A)}
+    (h : pointsMulEquiv f (Multiplicative.ofAdd (1 : ℤ)) =
+        pointsMulEquiv g (Multiplicative.ofAdd (1 : ℤ))) :
+    f = g :=
+  (pointsMulEquiv (R := R) (A := A) (G := Multiplicative ℤ)).injective (MonoidHom.ext_mint h)
+
 /-- **The `n`-th power endomorphism of `𝔾ₘ`, on points.** Because `𝔾ₘ = D(Multiplicative ℤ)`,
 this is exactly the character of `𝔾ₘ` at the generator power `Multiplicative.ofAdd n`
 (`charPoints (Multiplicative.ofAdd n)`, recorded by `powEnd_eq_charPoints`); on points it acts as

--- a/TauCeti/Algebra/AlgebraicGroup/RootsOfUnityKernel.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/RootsOfUnityKernel.lean
@@ -20,12 +20,12 @@ exactly the set of points killed by the `n`th power, so `μ_n` is the (scheme-th
 
 The mechanism is the worked-example points dictionary. A point of `𝔾ₘ = D(Multiplicative ℤ)` is
 determined by the unit it reads off on the generator `Multiplicative.ofAdd 1`
-(`RootsOfUnityGroup.gm_ext`). The `n`th power endomorphism raises that unit to the `n`th power
-(`DiagonalizableGroup.pointsMulEquiv_powEnd`), while an included `μ_n`-point reads off the
-underlying unit of an `n`th root of unity (`RootsOfUnityGroup.charOfPoint_inclusion_ofAdd_one`,
-here restated as `RootsOfUnityGroup.pointsMulEquiv_inclusion_ofAdd_one`), whose `n`th power is
-`1`. Conversely a `𝔾ₘ`-point read off as a unit `u` with `u ^ n = 1` is `u ∈ rootsOfUnity n A`,
-hence the image of the `μ_n`-point attached to it.
+(`DiagonalizableGroup.pointsMulEquiv_ext`). The `n`th power endomorphism raises that unit to the
+`n`th power (`DiagonalizableGroup.pointsMulEquiv_powEnd`), while an included `μ_n`-point reads off
+the underlying unit of an `n`th root of unity
+(`RootsOfUnityGroup.charOfPoint_inclusion_ofAdd_one`), whose `n`th power is `1`. Conversely a
+`𝔾ₘ`-point read off as a unit `u` with `u ^ n = 1` is `u ∈ rootsOfUnity n A`, hence the image of
+the `μ_n`-point attached to it.
 
 This is a worked-example check for the reductive-groups roadmap
 (`ReductiveGroups/README.md` in TauCetiRoadmap, Layer 4: "`μ_n = D(ℤ/n)`", "`𝔾_m = D(ℤ)`", and
@@ -36,8 +36,6 @@ description of `μ_n` as a kernel.
 
 ## Main results
 
-* `TauCeti.RootsOfUnityGroup.pointsMulEquiv_inclusion_ofAdd_one`: the included `μ_n`-point reads
-  off, on the `𝔾ₘ` generator, the underlying unit of the corresponding root of unity.
 * `TauCeti.RootsOfUnityGroup.powEnd_comp_inclusion`: the `n`th power endomorphism annihilates
   `μ_n`, i.e. `powEnd n ∘ inclusion n` is trivial.
 * `TauCeti.RootsOfUnityGroup.mem_range_inclusion`: a `𝔾ₘ`-point killed by the `n`th power lies
@@ -66,28 +64,6 @@ universe u v
 
 variable {R : Type u} {A : Type v} [CommSemiring R] [CommSemiring A] [Algebra R A]
 
-/-- Two points of `𝔾ₘ = D(Multiplicative ℤ)` are equal once they read off the same unit on the
-group-algebra generator `Multiplicative.ofAdd 1`: a character of `Multiplicative ℤ` is
-determined by its value at the generator (`MonoidHom.ext_mint`), and points are equivalent to
-characters. -/
-theorem gm_ext {f g : WithConv (MonoidAlgebra R (Multiplicative ℤ) →ₐ[R] A)}
-    (h : DiagonalizableGroup.pointsMulEquiv f (Multiplicative.ofAdd (1 : ℤ)) =
-        DiagonalizableGroup.pointsMulEquiv g (Multiplicative.ofAdd (1 : ℤ))) :
-    f = g :=
-  (DiagonalizableGroup.pointsMulEquiv (R := R) (A := A) (G := Multiplicative ℤ)).injective
-    (MonoidHom.ext_mint h)
-
-/-- **Reading an included `μ_n`-point on the `𝔾ₘ` generator.** The `𝔾ₘ`-point `inclusion n f`
-reads off, on the generator `Multiplicative.ofAdd 1`, the underlying unit of the root of unity
-`RootsOfUnityGroup.pointsMulEquiv n f`. This is `charOfPoint_inclusion_ofAdd_one` restated
-through the `𝔾ₘ` points equivalence `DiagonalizableGroup.pointsMulEquiv`. -/
-theorem pointsMulEquiv_inclusion_ofAdd_one (n : ℕ)
-    (f : WithConv (MonoidAlgebra R (Multiplicative (ZMod n)) →ₐ[R] A)) :
-    DiagonalizableGroup.pointsMulEquiv (inclusion n f) (Multiplicative.ofAdd (1 : ℤ)) =
-      (pointsMulEquiv (R := R) (A := A) n f : Aˣ) := by
-  rw [DiagonalizableGroup.pointsMulEquiv_apply]
-  exact charOfPoint_inclusion_ofAdd_one n f
-
 /-- **The `n`th power endomorphism of `𝔾ₘ` annihilates `μ_n`.** Composing the power endomorphism
 `DiagonalizableGroup.powEnd n` after the inclusion `μ_n ↪ 𝔾ₘ` is the trivial homomorphism of
 group functors: every `μ_n`-point maps to a root of unity, whose `n`th power is `1`. -/
@@ -95,9 +71,9 @@ theorem powEnd_comp_inclusion (n : ℕ) :
     (DiagonalizableGroup.powEnd (R := R) (A := A) (n : ℤ)).comp (inclusion n) = 1 := by
   refine MonoidHom.ext fun f => ?_
   rw [MonoidHom.comp_apply, MonoidHom.one_apply]
-  apply gm_ext
-  rw [DiagonalizableGroup.pointsMulEquiv_powEnd, pointsMulEquiv_inclusion_ofAdd_one,
-    map_one, MonoidHom.one_apply, zpow_natCast]
+  apply DiagonalizableGroup.pointsMulEquiv_ext
+  rw [DiagonalizableGroup.pointsMulEquiv_powEnd, DiagonalizableGroup.pointsMulEquiv_apply,
+    charOfPoint_inclusion_ofAdd_one, map_one, MonoidHom.one_apply, zpow_natCast]
   exact (mem_rootsOfUnity n _).mp (SetLike.coe_mem (pointsMulEquiv (R := R) (A := A) n f))
 
 /-- The `n`th power endomorphism annihilates every `μ_n`-point, in element form. -/
@@ -122,8 +98,9 @@ theorem mem_range_inclusion (n : ℕ)
   refine ⟨(pointsMulEquiv (R := R) (A := A) n).symm
       ⟨DiagonalizableGroup.pointsMulEquiv g (Multiplicative.ofAdd (1 : ℤ)),
         (mem_rootsOfUnity n _).mpr hun⟩, ?_⟩
-  apply gm_ext
-  rw [pointsMulEquiv_inclusion_ofAdd_one, MulEquiv.apply_symm_apply]
+  apply DiagonalizableGroup.pointsMulEquiv_ext
+  rw [DiagonalizableGroup.pointsMulEquiv_apply, charOfPoint_inclusion_ofAdd_one,
+    MulEquiv.apply_symm_apply]
 
 /-- **`μ_n` is the kernel of the `n`th power endomorphism of `𝔾ₘ`.** The image of the inclusion
 `μ_n ↪ 𝔾ₘ` on points equals the set of points killed by the `n`th power endomorphism

--- a/TauCeti/Algebra/AlgebraicGroup/RootsOfUnityKernel.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/RootsOfUnityKernel.lean
@@ -1,0 +1,143 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+module
+
+public import TauCeti.Algebra.AlgebraicGroup.Cocharacter
+public import TauCeti.Algebra.AlgebraicGroup.RootsOfUnityInclusion
+
+/-!
+# `μ_n` is the kernel of the `n`th power endomorphism of `𝔾ₘ`
+
+The group scheme of `n`th roots of unity `μ_n = D(ℤ/n)` sits inside the multiplicative group
+`𝔾ₘ = D(ℤ)` through the inclusion `TauCeti.RootsOfUnityGroup.inclusion`, the contravariant
+image of the quotient `ℤ ↠ ℤ/n`. On the other side, `TauCeti.DiagonalizableGroup.powEnd n` is
+the `n`th power endomorphism `u ↦ u ^ n` of `𝔾ₘ`. This file identifies `μ_n` with the kernel of
+that endomorphism: on every commutative `R`-algebra `A`, the image of `μ_n(A) → 𝔾ₘ(A)` is
+exactly the set of points killed by the `n`th power, so `μ_n` is the (scheme-theoretic) kernel
+`ker(𝔾ₘ --u ↦ uⁿ--> 𝔾ₘ)`.
+
+The mechanism is the worked-example points dictionary. A point of `𝔾ₘ = D(Multiplicative ℤ)` is
+determined by the unit it reads off on the generator `Multiplicative.ofAdd 1`
+(`RootsOfUnityGroup.gm_ext`). The `n`th power endomorphism raises that unit to the `n`th power
+(`DiagonalizableGroup.pointsMulEquiv_powEnd`), while an included `μ_n`-point reads off the
+underlying unit of an `n`th root of unity (`RootsOfUnityGroup.charOfPoint_inclusion_ofAdd_one`,
+here restated as `RootsOfUnityGroup.pointsMulEquiv_inclusion_ofAdd_one`), whose `n`th power is
+`1`. Conversely a `𝔾ₘ`-point read off as a unit `u` with `u ^ n = 1` is `u ∈ rootsOfUnity n A`,
+hence the image of the `μ_n`-point attached to it.
+
+This is a worked-example check for the reductive-groups roadmap
+(`ReductiveGroups/README.md` in TauCetiRoadmap, Layer 4: "`μ_n = D(ℤ/n)`", "`𝔾_m = D(ℤ)`", and
+the diagonalizable anti-equivalence `M ↦ D(M)`), assembling the `μ_n` inclusion
+`TauCeti.RootsOfUnityGroup.inclusion` and the power endomorphism
+`TauCeti.DiagonalizableGroup.powEnd` of the character/cocharacter file into the classical
+description of `μ_n` as a kernel.
+
+## Main results
+
+* `TauCeti.RootsOfUnityGroup.pointsMulEquiv_inclusion_ofAdd_one`: the included `μ_n`-point reads
+  off, on the `𝔾ₘ` generator, the underlying unit of the corresponding root of unity.
+* `TauCeti.RootsOfUnityGroup.powEnd_comp_inclusion`: the `n`th power endomorphism annihilates
+  `μ_n`, i.e. `powEnd n ∘ inclusion n` is trivial.
+* `TauCeti.RootsOfUnityGroup.mem_range_inclusion`: a `𝔾ₘ`-point killed by the `n`th power lies
+  in the image of the `μ_n` inclusion.
+* `TauCeti.RootsOfUnityGroup.range_inclusion`: the image of `μ_n ↪ 𝔾ₘ` is the kernel of the
+  `n`th power endomorphism of `𝔾ₘ`.
+
+## References
+
+The `μ_n` inclusion and `𝔾ₘ` points calculation are Tau Ceti's
+`TauCeti.RootsOfUnityGroup.inclusion` and `TauCeti.RootsOfUnityGroup.pointsMulEquiv`; the power
+endomorphism of `𝔾ₘ` is `TauCeti.DiagonalizableGroup.powEnd`. The subgroup of `n`th roots of
+unity and `mem_rootsOfUnity` are Mathlib's (`Mathlib.RingTheory.RootsOfUnity.Basic`), and the
+one-generator extensionality `MonoidHom.ext_mint` is from `Mathlib.Data.Int.Cast.Lemmas`.
+-/
+
+public section
+
+open WithConv
+
+namespace TauCeti
+
+namespace RootsOfUnityGroup
+
+universe u v
+
+variable {R : Type u} {A : Type v} [CommSemiring R] [CommSemiring A] [Algebra R A]
+
+/-- Two points of `𝔾ₘ = D(Multiplicative ℤ)` are equal once they read off the same unit on the
+group-algebra generator `Multiplicative.ofAdd 1`: a character of `Multiplicative ℤ` is
+determined by its value at the generator (`MonoidHom.ext_mint`), and points are equivalent to
+characters. -/
+theorem gm_ext {f g : WithConv (MonoidAlgebra R (Multiplicative ℤ) →ₐ[R] A)}
+    (h : DiagonalizableGroup.pointsMulEquiv f (Multiplicative.ofAdd (1 : ℤ)) =
+        DiagonalizableGroup.pointsMulEquiv g (Multiplicative.ofAdd (1 : ℤ))) :
+    f = g :=
+  (DiagonalizableGroup.pointsMulEquiv (R := R) (A := A) (G := Multiplicative ℤ)).injective
+    (MonoidHom.ext_mint h)
+
+/-- **Reading an included `μ_n`-point on the `𝔾ₘ` generator.** The `𝔾ₘ`-point `inclusion n f`
+reads off, on the generator `Multiplicative.ofAdd 1`, the underlying unit of the root of unity
+`RootsOfUnityGroup.pointsMulEquiv n f`. This is `charOfPoint_inclusion_ofAdd_one` restated
+through the `𝔾ₘ` points equivalence `DiagonalizableGroup.pointsMulEquiv`. -/
+theorem pointsMulEquiv_inclusion_ofAdd_one (n : ℕ)
+    (f : WithConv (MonoidAlgebra R (Multiplicative (ZMod n)) →ₐ[R] A)) :
+    DiagonalizableGroup.pointsMulEquiv (inclusion n f) (Multiplicative.ofAdd (1 : ℤ)) =
+      (pointsMulEquiv (R := R) (A := A) n f : Aˣ) := by
+  rw [DiagonalizableGroup.pointsMulEquiv_apply]
+  exact charOfPoint_inclusion_ofAdd_one n f
+
+/-- **The `n`th power endomorphism of `𝔾ₘ` annihilates `μ_n`.** Composing the power endomorphism
+`DiagonalizableGroup.powEnd n` after the inclusion `μ_n ↪ 𝔾ₘ` is the trivial homomorphism of
+group functors: every `μ_n`-point maps to a root of unity, whose `n`th power is `1`. -/
+theorem powEnd_comp_inclusion (n : ℕ) :
+    (DiagonalizableGroup.powEnd (R := R) (A := A) (n : ℤ)).comp (inclusion n) = 1 := by
+  refine MonoidHom.ext fun f => ?_
+  rw [MonoidHom.comp_apply, MonoidHom.one_apply]
+  apply gm_ext
+  rw [DiagonalizableGroup.pointsMulEquiv_powEnd, pointsMulEquiv_inclusion_ofAdd_one,
+    map_one, MonoidHom.one_apply, zpow_natCast]
+  exact (mem_rootsOfUnity n _).mp (SetLike.coe_mem (pointsMulEquiv (R := R) (A := A) n f))
+
+/-- The `n`th power endomorphism annihilates every `μ_n`-point, in element form. -/
+theorem powEnd_inclusion (n : ℕ)
+    (f : WithConv (MonoidAlgebra R (Multiplicative (ZMod n)) →ₐ[R] A)) :
+    DiagonalizableGroup.powEnd (R := R) (A := A) (n : ℤ) (inclusion n f) = 1 := by
+  have := DFunLike.congr_fun (powEnd_comp_inclusion (R := R) (A := A) n) f
+  simpa using this
+
+/-- **A `𝔾ₘ`-point killed by the `n`th power lies in the image of `μ_n`.** If the `n`th power
+endomorphism sends `g` to the identity, then `g` reads off a unit `u` with `u ^ n = 1`, i.e. an
+`n`th root of unity, and `g` is the image of the `μ_n`-point attached to it. -/
+theorem mem_range_inclusion (n : ℕ)
+    {g : WithConv (MonoidAlgebra R (Multiplicative ℤ) →ₐ[R] A)}
+    (hg : DiagonalizableGroup.powEnd (R := R) (A := A) (n : ℤ) g = 1) :
+    g ∈ Set.range (inclusion (R := R) (A := A) n) := by
+  have hun : DiagonalizableGroup.pointsMulEquiv g (Multiplicative.ofAdd (1 : ℤ)) ^ n = 1 := by
+    have h1 :
+        DiagonalizableGroup.pointsMulEquiv g (Multiplicative.ofAdd (1 : ℤ)) ^ (n : ℤ) = 1 := by
+      rw [← DiagonalizableGroup.pointsMulEquiv_powEnd, hg, map_one, MonoidHom.one_apply]
+    rwa [zpow_natCast] at h1
+  refine ⟨(pointsMulEquiv (R := R) (A := A) n).symm
+      ⟨DiagonalizableGroup.pointsMulEquiv g (Multiplicative.ofAdd (1 : ℤ)),
+        (mem_rootsOfUnity n _).mpr hun⟩, ?_⟩
+  apply gm_ext
+  rw [pointsMulEquiv_inclusion_ofAdd_one, MulEquiv.apply_symm_apply]
+
+/-- **`μ_n` is the kernel of the `n`th power endomorphism of `𝔾ₘ`.** The image of the inclusion
+`μ_n ↪ 𝔾ₘ` on points equals the set of points killed by the `n`th power endomorphism
+`DiagonalizableGroup.powEnd n`: a `𝔾ₘ`-point comes from `μ_n` exactly when its `n`th power is
+trivial. This realizes `μ_n = ker(𝔾ₘ --u ↦ uⁿ--> 𝔾ₘ)` on the functor of points. -/
+theorem range_inclusion (n : ℕ) :
+    Set.range (inclusion (R := R) (A := A) n) =
+      {g | DiagonalizableGroup.powEnd (R := R) (A := A) (n : ℤ) g = 1} := by
+  ext g
+  constructor
+  · rintro ⟨f, rfl⟩
+    exact powEnd_inclusion n f
+  · exact fun hg => mem_range_inclusion n hg
+
+end RootsOfUnityGroup
+
+end TauCeti

--- a/TauCeti/Algebra/AlgebraicGroup/RootsOfUnityKernel.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/RootsOfUnityKernel.lean
@@ -77,6 +77,7 @@ theorem powEnd_comp_inclusion (n : ℕ) :
   exact (mem_rootsOfUnity n _).mp (SetLike.coe_mem (pointsMulEquiv (R := R) (A := A) n f))
 
 /-- The `n`th power endomorphism annihilates every `μ_n`-point, in element form. -/
+@[simp]
 theorem powEnd_inclusion (n : ℕ)
     (f : WithConv (MonoidAlgebra R (Multiplicative (ZMod n)) →ₐ[R] A)) :
     DiagonalizableGroup.powEnd (R := R) (A := A) (n : ℤ) (inclusion n f) = 1 := by

--- a/TauCeti/Algebra/AlgebraicGroup/RootsOfUnityKernel.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/RootsOfUnityKernel.lean
@@ -87,7 +87,7 @@ theorem powEnd_inclusion (n : ℕ)
 /-- **A `𝔾ₘ`-point killed by the `n`th power lies in the image of `μ_n`.** If the `n`th power
 endomorphism sends `g` to the identity, then `g` reads off a unit `u` with `u ^ n = 1`, i.e. an
 `n`th root of unity, and `g` is the image of the `μ_n`-point attached to it. -/
-theorem mem_range_inclusion (n : ℕ)
+private theorem mem_range_inclusion (n : ℕ)
     {g : WithConv (MonoidAlgebra R (Multiplicative ℤ) →ₐ[R] A)}
     (hg : DiagonalizableGroup.powEnd (R := R) (A := A) (n : ℤ) g = 1) :
     g ∈ MonoidHom.range (G := WithConv (MonoidAlgebra R (Multiplicative (ZMod n)) →ₐ[R] A))

--- a/TauCeti/Algebra/AlgebraicGroup/RootsOfUnityKernel.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/RootsOfUnityKernel.lean
@@ -38,10 +38,10 @@ description of `μ_n` as a kernel.
 
 * `TauCeti.RootsOfUnityGroup.powEnd_comp_inclusion`: the `n`th power endomorphism annihilates
   `μ_n`, i.e. `powEnd n ∘ inclusion n` is trivial.
-* `TauCeti.RootsOfUnityGroup.mem_range_inclusion`: a `𝔾ₘ`-point killed by the `n`th power lies
-  in the image of the `μ_n` inclusion.
-* `TauCeti.RootsOfUnityGroup.range_inclusion`: the image of `μ_n ↪ 𝔾ₘ` is the kernel of the
-  `n`th power endomorphism of `𝔾ₘ`.
+* `TauCeti.RootsOfUnityGroup.mem_range_inclusion_iff`: a `𝔾ₘ`-point lies in the image of the
+  `μ_n` inclusion iff the `n`th power endomorphism kills it.
+* `TauCeti.RootsOfUnityGroup.range_inclusion`: as subgroups of the `𝔾ₘ`-points, the image of
+  `μ_n ↪ 𝔾ₘ` is the kernel of the `n`th power endomorphism of `𝔾ₘ`.
 
 ## References
 
@@ -90,7 +90,9 @@ endomorphism sends `g` to the identity, then `g` reads off a unit `u` with `u ^ 
 theorem mem_range_inclusion (n : ℕ)
     {g : WithConv (MonoidAlgebra R (Multiplicative ℤ) →ₐ[R] A)}
     (hg : DiagonalizableGroup.powEnd (R := R) (A := A) (n : ℤ) g = 1) :
-    g ∈ Set.range (inclusion (R := R) (A := A) n) := by
+    g ∈ MonoidHom.range (G := WithConv (MonoidAlgebra R (Multiplicative (ZMod n)) →ₐ[R] A))
+      (N := WithConv (MonoidAlgebra R (Multiplicative ℤ) →ₐ[R] A))
+      (inclusion (R := R) (A := A) n) := by
   have hun : DiagonalizableGroup.pointsMulEquiv g (Multiplicative.ofAdd (1 : ℤ)) ^ n = 1 := by
     have h1 :
         DiagonalizableGroup.pointsMulEquiv g (Multiplicative.ofAdd (1 : ℤ)) ^ (n : ℤ) = 1 := by
@@ -103,18 +105,31 @@ theorem mem_range_inclusion (n : ℕ)
   rw [DiagonalizableGroup.pointsMulEquiv_apply, charOfPoint_inclusion_ofAdd_one,
     MulEquiv.apply_symm_apply]
 
-/-- **`μ_n` is the kernel of the `n`th power endomorphism of `𝔾ₘ`.** The image of the inclusion
-`μ_n ↪ 𝔾ₘ` on points equals the set of points killed by the `n`th power endomorphism
-`DiagonalizableGroup.powEnd n`: a `𝔾ₘ`-point comes from `μ_n` exactly when its `n`th power is
-trivial. This realizes `μ_n = ker(𝔾ₘ --u ↦ uⁿ--> 𝔾ₘ)` on the functor of points. -/
+/-- **Membership in the image of `μ_n ↪ 𝔾ₘ`.** A `𝔾ₘ`-point lies in the image of the `μ_n`
+inclusion exactly when the `n`th power endomorphism kills it: `g` comes from `μ_n` iff `gⁿ = 1`. -/
+theorem mem_range_inclusion_iff (n : ℕ)
+    {g : WithConv (MonoidAlgebra R (Multiplicative ℤ) →ₐ[R] A)} :
+    g ∈ MonoidHom.range (G := WithConv (MonoidAlgebra R (Multiplicative (ZMod n)) →ₐ[R] A))
+        (N := WithConv (MonoidAlgebra R (Multiplicative ℤ) →ₐ[R] A))
+        (inclusion (R := R) (A := A) n) ↔
+      DiagonalizableGroup.powEnd (R := R) (A := A) (n : ℤ) g = 1 := by
+  refine ⟨?_, mem_range_inclusion n⟩
+  rintro ⟨f, rfl⟩
+  exact powEnd_inclusion n f
+
+/-- **`μ_n` is the kernel of the `n`th power endomorphism of `𝔾ₘ`.** As subgroups of the group of
+`𝔾ₘ`-points, the image of the inclusion `μ_n ↪ 𝔾ₘ` equals the kernel of the `n`th power
+endomorphism `DiagonalizableGroup.powEnd n`: a `𝔾ₘ`-point comes from `μ_n` exactly when its `n`th
+power is trivial. This realizes `μ_n = ker(𝔾ₘ --u ↦ uⁿ--> 𝔾ₘ)` on the functor of points. -/
 theorem range_inclusion (n : ℕ) :
-    Set.range (inclusion (R := R) (A := A) n) =
-      {g | DiagonalizableGroup.powEnd (R := R) (A := A) (n : ℤ) g = 1} := by
+    MonoidHom.range (G := WithConv (MonoidAlgebra R (Multiplicative (ZMod n)) →ₐ[R] A))
+        (N := WithConv (MonoidAlgebra R (Multiplicative ℤ) →ₐ[R] A))
+        (inclusion (R := R) (A := A) n) =
+      MonoidHom.ker (G := WithConv (MonoidAlgebra R (Multiplicative ℤ) →ₐ[R] A))
+        (M := WithConv (MonoidAlgebra R (Multiplicative ℤ) →ₐ[R] A))
+        (DiagonalizableGroup.powEnd (R := R) (A := A) (n : ℤ)) := by
   ext g
-  constructor
-  · rintro ⟨f, rfl⟩
-    exact powEnd_inclusion n f
-  · exact fun hg => mem_range_inclusion n hg
+  rw [MonoidHom.mem_ker, mem_range_inclusion_iff]
 
 end RootsOfUnityGroup
 


### PR DESCRIPTION
This PR identifies the group scheme of `n`th roots of unity `μ_n = D(ℤ/n)` with the kernel of the `n`th power endomorphism of the multiplicative group `𝔾ₘ = D(ℤ)`, on the functor of points. Assembling the existing `μ_n ↪ 𝔾ₘ` inclusion (`TauCeti.RootsOfUnityGroup.inclusion`) and the power endomorphism `u ↦ uⁿ` of `𝔾ₘ` (`TauCeti.DiagonalizableGroup.powEnd`), it proves that on every commutative `R`-algebra `A` the image of `μ_n(A) → 𝔾ₘ(A)` is exactly the set of `𝔾ₘ`-points killed by the `n`th power, so `μ_n = ker(𝔾ₘ --u ↦ uⁿ--> 𝔾ₘ)`. A `𝔾ₘ`-point is determined by the unit it reads off on the group-algebra generator, the power endomorphism raises that unit to the `n`th power, an included `μ_n`-point reads off the underlying unit of a root of unity (`nth` power `1`), and conversely a unit with `uⁿ = 1` is a root of unity and comes from `μ_n`. The statements are polymorphic in `n : ℕ`, covering the degenerate `n = 0` case (`μ_0 = 𝔾ₘ`, killed by the trivial power map) uniformly.

This advances the reductive-groups roadmap (`TauCetiRoadmap/ReductiveGroups/README.md`, Layer 4: "Diagonalizable groups and groups of multiplicative type ... `μ_n = D(ℤ/n)`; `𝔾_m = D(ℤ)`" and the anti-equivalence `M ↦ D(M)`), in the same worked-example spirit as the existing `𝔾ₘ`, `μ_n`, and character/cocharacter files, giving the classical description of `μ_n` as a kernel that the earlier files did not record.

It adds one file, `TauCeti/Algebra/AlgebraicGroup/RootsOfUnityKernel.lean` (about 145 lines), building only on Tau Ceti's own `TauCeti.RootsOfUnityGroup.inclusion`, `TauCeti.RootsOfUnityGroup.pointsMulEquiv`, and `TauCeti.DiagonalizableGroup.powEnd`, together with Mathlib's subgroup of roots of unity (`Mathlib.RingTheory.RootsOfUnity.Basic`, `mem_rootsOfUnity`) and the one-generator extensionality `MonoidHom.ext_mint` (`Mathlib.Data.Int.Cast.Lemmas`).

<!--tauceti-target:v1 {"focus":"ReductiveGroups","id":"mu-n-kernel-power-endomorphism"}-->

🤖 Prepared with Claude Code
