### PR TITLE
feat: the fundamental group of the complex unit circle is ℤ

### DIFF
--- a/TauCeti/AlgebraicTopology/NotSimplyConnected.lean
+++ b/TauCeti/AlgebraicTopology/NotSimplyConnected.lean
@@ -1,0 +1,83 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+module
+
+public import Mathlib.AlgebraicTopology.FundamentalGroupoid.SimplyConnected
+public import Mathlib.Analysis.Convex.Contractible
+
+/-!
+# Consequences of a space not being simply connected
+
+A space whose fundamental group at some basepoint is nontrivial is not simply connected, and a
+non-simply-connected space inherits the standard topological obstructions: it is not
+contractible, and it is not homeomorphic to any simply connected space — in particular not to
+any real topological vector space nor to `ℝ`.
+
+These facts use the space only through the (non-)triviality of its fundamental group, so they
+are stated once here for an arbitrary space and then specialised to concrete circles
+(`TauCeti.AddCircle.*`, `TauCeti.UnitAddCircle.*`, `TauCeti.Circle.*`). Non-simple-connectivity
+follows because a simply connected space has a subsingleton fundamental group; the
+homeomorphism statements consume Mathlib's transfer of `SimplyConnectedSpace` along a homotopy
+equivalence (`ContinuousMap.HomotopyEquiv.simplyConnectedSpace`, via
+`Homeomorph.toHomotopyEquiv`) and the contractibility of a real topological vector space
+(`RealTopologicalVectorSpace.contractibleSpace`). No Mathlib code is vendored.
+
+## Main declarations
+
+* `TauCeti.not_simplyConnectedSpace_of_nontrivial_fundamentalGroup`: a space with a nontrivial
+  fundamental group at some basepoint is not simply connected.
+* `TauCeti.not_contractibleSpace_of_not_simplyConnectedSpace`: a non-simply-connected space is
+  not contractible.
+* `TauCeti.isEmpty_homeomorph_of_not_simplyConnectedSpace`,
+  `TauCeti.isEmpty_homeomorph_realTopologicalVectorSpace_of_not_simplyConnectedSpace`,
+  `TauCeti.isEmpty_homeomorph_real_of_not_simplyConnectedSpace`: a non-simply-connected space is
+  not homeomorphic to a simply connected space, to a real topological vector space, or to `ℝ`.
+-/
+
+public section
+
+namespace TauCeti
+
+/-- A space with a nontrivial fundamental group at some basepoint is **not simply connected**: a
+simply connected space has a subsingleton fundamental group. -/
+theorem not_simplyConnectedSpace_of_nontrivial_fundamentalGroup {X : Type*} [TopologicalSpace X]
+    (x : X) [Nontrivial (FundamentalGroup X x)] : ¬ SimplyConnectedSpace X := by
+  intro h
+  haveI := h
+  exact false_of_nontrivial_of_subsingleton (FundamentalGroup X x)
+
+/-- A **not simply connected** space is **not contractible**: a contractible space is simply
+connected. -/
+theorem not_contractibleSpace_of_not_simplyConnectedSpace {X : Type*} [TopologicalSpace X]
+    (h : ¬ SimplyConnectedSpace X) : ¬ ContractibleSpace X := by
+  intro hc
+  haveI := hc
+  exact h inferInstance
+
+/-- A **not simply connected** space is not homeomorphic to any simply connected space: a
+homeomorphism is in particular a homotopy equivalence, and simple connectivity transfers along
+homotopy equivalences. -/
+theorem isEmpty_homeomorph_of_not_simplyConnectedSpace {X : Type*} [TopologicalSpace X]
+    (h : ¬ SimplyConnectedSpace X) (Y : Type*) [TopologicalSpace Y] [SimplyConnectedSpace Y] :
+    IsEmpty (X ≃ₜ Y) := by
+  refine ⟨fun e => ?_⟩
+  exact h e.toHomotopyEquiv.simplyConnectedSpace
+
+/-- A **not simply connected** space is not homeomorphic to any real topological vector space
+(in particular, to any real normed space), since such a space is contractible, hence simply
+connected. -/
+theorem isEmpty_homeomorph_realTopologicalVectorSpace_of_not_simplyConnectedSpace
+    {X : Type*} [TopologicalSpace X] (h : ¬ SimplyConnectedSpace X) (E : Type*)
+    [AddCommGroup E] [Module ℝ E] [TopologicalSpace E] [ContinuousAdd E] [ContinuousSMul ℝ E] :
+    IsEmpty (X ≃ₜ E) :=
+  isEmpty_homeomorph_of_not_simplyConnectedSpace h E
+
+/-- A **not simply connected** space is not homeomorphic to the real line: `ℝ` is contractible,
+hence simply connected. -/
+theorem isEmpty_homeomorph_real_of_not_simplyConnectedSpace {X : Type*} [TopologicalSpace X]
+    (h : ¬ SimplyConnectedSpace X) : IsEmpty (X ≃ₜ ℝ) :=
+  isEmpty_homeomorph_realTopologicalVectorSpace_of_not_simplyConnectedSpace h ℝ
+
+end TauCeti

--- a/TauCeti/AlgebraicTopology/UniversalCover/CircleNotSimplyConnected.lean
+++ b/TauCeti/AlgebraicTopology/UniversalCover/CircleNotSimplyConnected.lean
@@ -4,6 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 -/
 module
 
+public import TauCeti.AlgebraicTopology.NotSimplyConnected
 public import TauCeti.AlgebraicTopology.UniversalCover.CircleFundamentalGroup
 
 /-!
@@ -77,28 +78,22 @@ theorem infinite_fundamentalGroup_zero (hp : p ≠ 0) :
 
 /-- The circle `AddCircle p` (`p ≠ 0`) is **not simply connected**: its fundamental group is
 nontrivial, whereas a simply connected space has a subsingleton fundamental group. -/
-theorem not_simplyConnectedSpace (hp : p ≠ 0) : ¬ SimplyConnectedSpace (AddCircle p) := by
-  intro h
-  haveI := h
+theorem not_simplyConnectedSpace (hp : p ≠ 0) : ¬ SimplyConnectedSpace (AddCircle p) :=
   haveI := nontrivial_fundamentalGroup_zero p hp
-  exact false_of_nontrivial_of_subsingleton (FundamentalGroup (AddCircle p) 0)
+  not_simplyConnectedSpace_of_nontrivial_fundamentalGroup (0 : AddCircle p)
 
 /-- The circle `AddCircle p` (`p ≠ 0`) is **not contractible**: a contractible space is simply
 connected, and the circle is not. -/
-theorem not_contractibleSpace (hp : p ≠ 0) : ¬ ContractibleSpace (AddCircle p) := by
-  intro h
-  haveI := h
-  exact not_simplyConnectedSpace p hp inferInstance
+theorem not_contractibleSpace (hp : p ≠ 0) : ¬ ContractibleSpace (AddCircle p) :=
+  not_contractibleSpace_of_not_simplyConnectedSpace (not_simplyConnectedSpace p hp)
 
 /-- The circle `AddCircle p` (`p ≠ 0`) is not homeomorphic to any simply connected space: a
 homeomorphism is in particular a homotopy equivalence, and simple connectivity transfers along
 homotopy equivalences, which the circle does not enjoy. -/
 theorem isEmpty_homeomorph_of_simplyConnectedSpace (hp : p ≠ 0)
     (Y : Type*) [TopologicalSpace Y] [SimplyConnectedSpace Y] :
-    IsEmpty (AddCircle p ≃ₜ Y) := by
-  refine ⟨fun e => ?_⟩
-  have : SimplyConnectedSpace (AddCircle p) := e.toHomotopyEquiv.simplyConnectedSpace
-  exact not_simplyConnectedSpace p hp this
+    IsEmpty (AddCircle p ≃ₜ Y) :=
+  isEmpty_homeomorph_of_not_simplyConnectedSpace (not_simplyConnectedSpace p hp) Y
 
 /-- The circle `AddCircle p` (`p ≠ 0`) is not homeomorphic to any real topological vector space
 (in particular, to any real normed space), since such a space is contractible, hence simply
@@ -106,12 +101,13 @@ connected. -/
 theorem isEmpty_homeomorph_realTopologicalVectorSpace (hp : p ≠ 0) (E : Type*)
     [AddCommGroup E] [Module ℝ E] [TopologicalSpace E] [ContinuousAdd E] [ContinuousSMul ℝ E] :
     IsEmpty (AddCircle p ≃ₜ E) :=
-  isEmpty_homeomorph_of_simplyConnectedSpace p hp E
+  isEmpty_homeomorph_realTopologicalVectorSpace_of_not_simplyConnectedSpace
+    (not_simplyConnectedSpace p hp) E
 
 /-- The circle `AddCircle p` (`p ≠ 0`) is not homeomorphic to the real line: the circle is not
 simply connected but `ℝ` is contractible. -/
 theorem isEmpty_homeomorph_real (hp : p ≠ 0) : IsEmpty (AddCircle p ≃ₜ ℝ) :=
-  isEmpty_homeomorph_realTopologicalVectorSpace p hp ℝ
+  isEmpty_homeomorph_real_of_not_simplyConnectedSpace (not_simplyConnectedSpace p hp)
 
 end AddCircle
 

--- a/TauCeti/AlgebraicTopology/UniversalCover/ComplexCircleFundamentalGroup.lean
+++ b/TauCeti/AlgebraicTopology/UniversalCover/ComplexCircleFundamentalGroup.lean
@@ -6,6 +6,7 @@ module
 
 public import Mathlib.Analysis.SpecialFunctions.Complex.Circle
 public import TauCeti.AlgebraicTopology.FundamentalGroup.Homeomorph
+public import TauCeti.AlgebraicTopology.NotSimplyConnected
 public import TauCeti.AlgebraicTopology.UniversalCover.CircleFundamentalGroup
 
 /-!
@@ -35,6 +36,8 @@ homeomorphic to the real line — follow exactly as for `AddCircle`. No Mathlib 
 ## Main declarations
 
 * `TauCeti.Circle.fundamentalGroupMulEquiv`: `π₁(Circle, 1) ≃* Multiplicative ℤ`.
+* `TauCeti.Circle.fundamentalGroupMulEquiv_def`: the factorization of that isomorphism into the
+  homeomorphism-invariance isomorphism and the additive-circle computation.
 * `TauCeti.Circle.nontrivial_fundamentalGroup`, `TauCeti.Circle.infinite_fundamentalGroup`:
   the fundamental group of `Circle`, based at `1`, is nontrivial and infinite.
 * `TauCeti.Circle.not_simplyConnectedSpace`, `TauCeti.Circle.not_contractibleSpace`:
@@ -64,6 +67,22 @@ def fundamentalGroupMulEquiv : FundamentalGroup Circle 1 ≃* Multiplicative ℤ
         AddCircle.toCircle_zero])).trans
     (AddCircle.fundamentalGroupMulEquiv_zero (2 * Real.pi) Real.two_pi_pos.ne')
 
+/-- `fundamentalGroupMulEquiv` factors as the homeomorphism-invariance isomorphism of
+`AddCircle.homeomorphCircle.symm` (based at `1 ↦ 0`) composed with the additive-circle
+computation `AddCircle.fundamentalGroupMulEquiv_zero`. This exposes the otherwise-opaque
+definition, so a downstream consumer can rewrite a loop's image in `Multiplicative ℤ` through the
+component `@[simp]` lemmas `FundamentalGroup.homeomorphMulEquivOfEq_apply` and the
+`AddCircle.fundamentalGroupMulEquiv_zero` characterization. -/
+theorem fundamentalGroupMulEquiv_def :
+    fundamentalGroupMulEquiv =
+      (FundamentalGroup.homeomorphMulEquivOfEq
+          (AddCircle.homeomorphCircle (T := 2 * Real.pi) Real.two_pi_pos.ne').symm
+          (by rw [Homeomorph.symm_apply_eq, AddCircle.homeomorphCircle_apply,
+            AddCircle.toCircle_zero])).trans
+        (AddCircle.fundamentalGroupMulEquiv_zero (2 * Real.pi) Real.two_pi_pos.ne') := by
+  unfold fundamentalGroupMulEquiv
+  rfl
+
 /-- The fundamental group of the complex unit circle `Circle`, based at `1`, is nontrivial. See
 `fundamentalGroupMulEquiv` for the full identification with `Multiplicative ℤ`. -/
 theorem nontrivial_fundamentalGroup : Nontrivial (FundamentalGroup Circle 1) :=
@@ -76,39 +95,34 @@ theorem infinite_fundamentalGroup : Infinite (FundamentalGroup Circle 1) :=
 
 /-- The complex unit circle `Circle` is **not simply connected**: its fundamental group is
 nontrivial, whereas a simply connected space has a subsingleton fundamental group. -/
-theorem not_simplyConnectedSpace : ¬ SimplyConnectedSpace Circle := by
-  intro h
-  haveI := h
+theorem not_simplyConnectedSpace : ¬ SimplyConnectedSpace Circle :=
   haveI := nontrivial_fundamentalGroup
-  exact false_of_nontrivial_of_subsingleton (FundamentalGroup Circle 1)
+  not_simplyConnectedSpace_of_nontrivial_fundamentalGroup (1 : Circle)
 
 /-- The complex unit circle `Circle` is **not contractible**: a contractible space is simply
 connected, and the circle is not. -/
-theorem not_contractibleSpace : ¬ ContractibleSpace Circle := by
-  intro h
-  haveI := h
-  exact not_simplyConnectedSpace inferInstance
+theorem not_contractibleSpace : ¬ ContractibleSpace Circle :=
+  not_contractibleSpace_of_not_simplyConnectedSpace not_simplyConnectedSpace
 
 /-- The complex unit circle `Circle` is not homeomorphic to any simply connected space: a
 homeomorphism is a homotopy equivalence, and simple connectivity transfers along homotopy
 equivalences, which the circle does not enjoy. -/
 theorem isEmpty_homeomorph_of_simplyConnectedSpace (Y : Type*) [TopologicalSpace Y]
-    [SimplyConnectedSpace Y] : IsEmpty (Circle ≃ₜ Y) := by
-  refine ⟨fun e => ?_⟩
-  have : SimplyConnectedSpace Circle := e.toHomotopyEquiv.simplyConnectedSpace
-  exact not_simplyConnectedSpace this
+    [SimplyConnectedSpace Y] : IsEmpty (Circle ≃ₜ Y) :=
+  isEmpty_homeomorph_of_not_simplyConnectedSpace not_simplyConnectedSpace Y
 
 /-- The complex unit circle `Circle` is not homeomorphic to any real topological vector space
 (in particular, to any real normed space), since such a space is contractible, hence simply
 connected. -/
 theorem isEmpty_homeomorph_realTopologicalVectorSpace (E : Type*) [AddCommGroup E] [Module ℝ E]
     [TopologicalSpace E] [ContinuousAdd E] [ContinuousSMul ℝ E] : IsEmpty (Circle ≃ₜ E) :=
-  isEmpty_homeomorph_of_simplyConnectedSpace E
+  isEmpty_homeomorph_realTopologicalVectorSpace_of_not_simplyConnectedSpace
+    not_simplyConnectedSpace E
 
 /-- The complex unit circle `Circle` is not homeomorphic to the real line: the circle is not
 simply connected but `ℝ` is contractible. -/
 theorem isEmpty_homeomorph_real : IsEmpty (Circle ≃ₜ ℝ) :=
-  isEmpty_homeomorph_realTopologicalVectorSpace ℝ
+  isEmpty_homeomorph_real_of_not_simplyConnectedSpace not_simplyConnectedSpace
 
 end
 

--- a/TauCeti/AlgebraicTopology/UniversalCover/ComplexCircleFundamentalGroup.lean
+++ b/TauCeti/AlgebraicTopology/UniversalCover/ComplexCircleFundamentalGroup.lean
@@ -1,0 +1,117 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+module
+
+public import Mathlib.Analysis.SpecialFunctions.Complex.Circle
+public import TauCeti.AlgebraicTopology.FundamentalGroup.Homeomorph
+public import TauCeti.AlgebraicTopology.UniversalCover.CircleFundamentalGroup
+
+/-!
+# The fundamental group of the complex unit circle is `ℤ`
+
+The additive-circle computation `π₁(AddCircle p) ≃* Multiplicative ℤ`
+(`TauCeti.AddCircle.fundamentalGroupMulEquiv`) lives on the quotient `ℝ ⧸ (p • ℤ)`. Mathlib's
+canonical circle is instead `Circle`, the unit sphere `{z : ℂ | ‖z‖ = 1}` with its complex
+multiplicative group structure, and the two are identified by the homeomorphism
+`AddCircle.homeomorphCircle : AddCircle (2 * π) ≃ₜ Circle` (which sends `0` to `1`).
+
+Transporting the additive-circle computation across that homeomorphism with the
+homeomorphism-invariance isomorphism
+`TauCeti.FundamentalGroup.homeomorphMulEquivOfEq` gives the fundamental group of the genuine
+complex unit circle, based at `1`:
+
+  `π₁(Circle, 1) ≃* Multiplicative ℤ`.
+
+This is the `Circle ⊆ ℂ` instance of the universal-covers roadmap Stage 4 target `π₁(S¹) ≅ ℤ`
+(`TauCetiRoadmap/UniversalCovers/README.md`, item 12), realised on the standard Mathlib circle
+that the homeomorphism-invariance API was built to reach
+(`TauCeti/AlgebraicTopology/FundamentalGroup/Homeomorph.lean` names it as the intended
+application). The qualitative corollaries — the fundamental group is nontrivial and infinite,
+so `Circle` is neither simply connected nor contractible, and in particular is not
+homeomorphic to the real line — follow exactly as for `AddCircle`. No Mathlib code is vendored.
+
+## Main declarations
+
+* `TauCeti.Circle.fundamentalGroupMulEquiv`: `π₁(Circle, 1) ≃* Multiplicative ℤ`.
+* `TauCeti.Circle.nontrivial_fundamentalGroup`, `TauCeti.Circle.infinite_fundamentalGroup`:
+  the fundamental group of `Circle`, based at `1`, is nontrivial and infinite.
+* `TauCeti.Circle.not_simplyConnectedSpace`, `TauCeti.Circle.not_contractibleSpace`:
+  `Circle` is not simply connected and not contractible.
+* `TauCeti.Circle.isEmpty_homeomorph_real`: `Circle` is not homeomorphic to `ℝ`.
+-/
+
+public section
+
+namespace TauCeti
+
+namespace Circle
+
+open scoped Real
+
+noncomputable section
+
+/-- The fundamental group of the complex unit circle `Circle = {z : ℂ | ‖z‖ = 1}`, based at
+`1`, is `Multiplicative ℤ`: `π₁(S¹) ≅ ℤ`. It is obtained by transporting the additive-circle
+computation `TauCeti.AddCircle.fundamentalGroupMulEquiv_zero` across the homeomorphism
+`AddCircle.homeomorphCircle : AddCircle (2 * π) ≃ₜ Circle`, which carries the basepoint `0` to
+`1`. -/
+def fundamentalGroupMulEquiv : FundamentalGroup Circle 1 ≃* Multiplicative ℤ :=
+  (FundamentalGroup.homeomorphMulEquivOfEq
+      (AddCircle.homeomorphCircle (T := 2 * Real.pi) Real.two_pi_pos.ne').symm
+      (by rw [Homeomorph.symm_apply_eq, AddCircle.homeomorphCircle_apply,
+        AddCircle.toCircle_zero])).trans
+    (AddCircle.fundamentalGroupMulEquiv_zero (2 * Real.pi) Real.two_pi_pos.ne')
+
+/-- The fundamental group of the complex unit circle `Circle`, based at `1`, is nontrivial. See
+`fundamentalGroupMulEquiv` for the full identification with `Multiplicative ℤ`. -/
+theorem nontrivial_fundamentalGroup : Nontrivial (FundamentalGroup Circle 1) :=
+  fundamentalGroupMulEquiv.toEquiv.nontrivial
+
+/-- The fundamental group of the complex unit circle `Circle`, based at `1`, is infinite. See
+`fundamentalGroupMulEquiv` for the full identification with `Multiplicative ℤ`. -/
+theorem infinite_fundamentalGroup : Infinite (FundamentalGroup Circle 1) :=
+  Infinite.of_injective _ fundamentalGroupMulEquiv.symm.injective
+
+/-- The complex unit circle `Circle` is **not simply connected**: its fundamental group is
+nontrivial, whereas a simply connected space has a subsingleton fundamental group. -/
+theorem not_simplyConnectedSpace : ¬ SimplyConnectedSpace Circle := by
+  intro h
+  haveI := h
+  haveI := nontrivial_fundamentalGroup
+  exact false_of_nontrivial_of_subsingleton (FundamentalGroup Circle 1)
+
+/-- The complex unit circle `Circle` is **not contractible**: a contractible space is simply
+connected, and the circle is not. -/
+theorem not_contractibleSpace : ¬ ContractibleSpace Circle := by
+  intro h
+  haveI := h
+  exact not_simplyConnectedSpace inferInstance
+
+/-- The complex unit circle `Circle` is not homeomorphic to any simply connected space: a
+homeomorphism is a homotopy equivalence, and simple connectivity transfers along homotopy
+equivalences, which the circle does not enjoy. -/
+theorem isEmpty_homeomorph_of_simplyConnectedSpace (Y : Type*) [TopologicalSpace Y]
+    [SimplyConnectedSpace Y] : IsEmpty (Circle ≃ₜ Y) := by
+  refine ⟨fun e => ?_⟩
+  have : SimplyConnectedSpace Circle := e.toHomotopyEquiv.simplyConnectedSpace
+  exact not_simplyConnectedSpace this
+
+/-- The complex unit circle `Circle` is not homeomorphic to any real topological vector space
+(in particular, to any real normed space), since such a space is contractible, hence simply
+connected. -/
+theorem isEmpty_homeomorph_realTopologicalVectorSpace (E : Type*) [AddCommGroup E] [Module ℝ E]
+    [TopologicalSpace E] [ContinuousAdd E] [ContinuousSMul ℝ E] : IsEmpty (Circle ≃ₜ E) :=
+  isEmpty_homeomorph_of_simplyConnectedSpace E
+
+/-- The complex unit circle `Circle` is not homeomorphic to the real line: the circle is not
+simply connected but `ℝ` is contractible. -/
+theorem isEmpty_homeomorph_real : IsEmpty (Circle ≃ₜ ℝ) :=
+  isEmpty_homeomorph_realTopologicalVectorSpace ℝ
+
+end
+
+end Circle
+
+end TauCeti

--- a/TauCeti/AlgebraicTopology/UniversalCover/ComplexCircleFundamentalGroup.lean
+++ b/TauCeti/AlgebraicTopology/UniversalCover/ComplexCircleFundamentalGroup.lean
@@ -55,6 +55,13 @@ open scoped Real
 
 noncomputable section
 
+/-- The homeomorphism `AddCircle.homeomorphCircle : AddCircle (2 * π) ≃ₜ Circle` carries the
+basepoint `0` to `1`, so its inverse carries `1` back to `0`. This is the basepoint hypothesis
+that transports the additive-circle computation to `Circle`. -/
+theorem homeomorphCircle_symm_one :
+    (AddCircle.homeomorphCircle (T := 2 * Real.pi) Real.two_pi_pos.ne').symm 1 = 0 := by
+  rw [Homeomorph.symm_apply_eq, AddCircle.homeomorphCircle_apply, AddCircle.toCircle_zero]
+
 /-- The fundamental group of the complex unit circle `Circle = {z : ℂ | ‖z‖ = 1}`, based at
 `1`, is `Multiplicative ℤ`: `π₁(S¹) ≅ ℤ`. It is obtained by transporting the additive-circle
 computation `TauCeti.AddCircle.fundamentalGroupMulEquiv_zero` across the homeomorphism
@@ -63,8 +70,7 @@ computation `TauCeti.AddCircle.fundamentalGroupMulEquiv_zero` across the homeomo
 def fundamentalGroupMulEquiv : FundamentalGroup Circle 1 ≃* Multiplicative ℤ :=
   (FundamentalGroup.homeomorphMulEquivOfEq
       (AddCircle.homeomorphCircle (T := 2 * Real.pi) Real.two_pi_pos.ne').symm
-      (by rw [Homeomorph.symm_apply_eq, AddCircle.homeomorphCircle_apply,
-        AddCircle.toCircle_zero])).trans
+      homeomorphCircle_symm_one).trans
     (AddCircle.fundamentalGroupMulEquiv_zero (2 * Real.pi) Real.two_pi_pos.ne')
 
 /-- `fundamentalGroupMulEquiv` factors as the homeomorphism-invariance isomorphism of
@@ -77,8 +83,7 @@ theorem fundamentalGroupMulEquiv_def :
     fundamentalGroupMulEquiv =
       (FundamentalGroup.homeomorphMulEquivOfEq
           (AddCircle.homeomorphCircle (T := 2 * Real.pi) Real.two_pi_pos.ne').symm
-          (by rw [Homeomorph.symm_apply_eq, AddCircle.homeomorphCircle_apply,
-            AddCircle.toCircle_zero])).trans
+          homeomorphCircle_symm_one).trans
         (AddCircle.fundamentalGroupMulEquiv_zero (2 * Real.pi) Real.two_pi_pos.ne') := by
   unfold fundamentalGroupMulEquiv
   rfl


### PR DESCRIPTION
This PR computes the fundamental group of the canonical complex unit circle `Circle = {z : ℂ | ‖z‖ = 1}`, based at `1`, as `π₁(Circle, 1) ≃* Multiplicative ℤ`. It transports the existing additive-circle computation `TauCeti.AddCircle.fundamentalGroupMulEquiv_zero` (`π₁(AddCircle p) ≃* Multiplicative ℤ`) across Mathlib's homeomorphism `AddCircle.homeomorphCircle : AddCircle (2 * π) ≃ₜ Circle`, using the homeomorphism-invariance isomorphism `TauCeti.FundamentalGroup.homeomorphMulEquivOfEq`; that homeomorphism carries the basepoint `0` to `1`. It also records the immediate qualitative corollaries: the fundamental group is nontrivial and infinite, so `Circle` is neither simply connected nor contractible, and in particular is not homeomorphic to the real line.

This realises the `Circle ⊆ ℂ` instance of the UniversalCovers roadmap Stage 4 "applications" target `π₁(S¹) ≅ ℤ` (`TauCetiRoadmap/UniversalCovers/README.md`, item 12) on Mathlib's standard circle. It is the application that the homeomorphism-invariance API was introduced to reach: `TauCeti/AlgebraicTopology/FundamentalGroup/Homeomorph.lean` names "the fundamental group of the unit circle `Circle ⊆ ℂ`, obtained from the additive-circle computation through Mathlib's `AddCircle.homeomorphCircle`" as its intended payoff. The qualitative corollaries mirror those already proved for `AddCircle` in `CircleNotSimplyConnected.lean`, transferred to the genuinely distinct complex-circle type. No Mathlib code is vendored.

<!--tauceti-target:v1 {"focus":"UniversalCovers","id":"circle-fundamentalgroupmulequiv"}-->

🤖 Prepared with Claude Code
