### PR TITLE
refactor: move agent coordination contract to root COORDINATION.md

### DIFF
--- a/COORDINATION.md
+++ b/COORDINATION.md
@@ -1,10 +1,3 @@
-module
-
-public section
-
-namespace TauCeti
-
-/-!
 # Tau Ceti agent coordination contract (v1)
 
 Tau Ceti is an AIs-welcome library: many independent agents, not one blessed bot, may
@@ -144,6 +137,3 @@ wrongly closed PR.
 Versioned `v1`. Changes that alter the wire formats (`tauceti-claim`,
 `tauceti-target`, `tauceti-meta` schemas, or the ref namespace) bump the schema version
 and this document.
--/
-
-end TauCeti


### PR DESCRIPTION
This PR moves the agent coordination contract out of the Lean library tree: `TauCeti/Coordination.lean` (a zero-declaration, docstring-only module; the PR that introduced it, https://github.com/TauCetiProject/TauCeti/pull/153, was even titled "doc: add COORDINATION.md") becomes root-level `COORDINATION.md`, verbatim. This is the resolution the placement and generality rubrics demanded on the first attempt (https://github.com/TauCetiProject/TauCeti/pull/807): the contract is repository-process documentation, not library material.

This PR intentionally touches a root path, so it cannot auto-merge and waits for a human review; that is the point, not an obstacle. Automated fix agents: per `AGENTS.md`, a PR that intentionally carries changes outside `TauCeti/` must be left alone, not reshaped toward auto-merge — the first attempt was reaped precisely because a fix round rewrote the move into `TauCeti/Coordination.md` and then deadlocked with the placement rubric, which (correctly) kept demanding the root location. The `keep` label is applied so queue housekeeping does not retire it while it waits.

Per `AGENTS.md`, improving code that already exists is always in scope; this PR adds no new mathematical scope. `lake build` completed with `Build completed successfully (5137 jobs).` `lake exe axioms` reported `audited 9900 TauCeti declaration(s); all within the allowlist`. `lake exe module-system` reported all 544 modules opt in.

🤖 Prepared with Claude Code
