### PR TITLE
feat: the based-path space over a semilocally simply connected base

### DIFF
--- a/TauCeti/AlgebraicTopology/UniversalCover/BasedPath.lean
+++ b/TauCeti/AlgebraicTopology/UniversalCover/BasedPath.lean
@@ -193,97 +193,11 @@ private theorem endpoint_deformTerminal {u v : X} (γ : BasedPath x₀) (hu : en
   rw [hone]
   simp [δ.extend_one]
 
-end BasedPath
-
-namespace Path
-
-public theorem truncateOfLE_range_subset_preimage {a b : X} (γ : Path a b) {t₀ t₁ : ℝ}
-    (h : t₀ ≤ t₁) {U : Set X} (hU : Set.Icc t₀ t₁ ⊆ γ.extend ⁻¹' U) :
-    Set.range (γ.truncateOfLE h) ⊆ U := by
-  rintro _ ⟨s, rfl⟩
-  dsimp [truncateOfLE, truncate]
-  apply hU
-  constructor
-  · exact le_min (le_max_right _ _) h
-  · exact min_le_right _ _
-
-/-- The family of initial segments of `γ : Path a b`: at parameter `t : I`, the path
-`s ↦ γ.extend (min s t)` from `a` to `γ t` (`initialSegmentFamily_apply`). At `t = 0` this is
-the constant path at `a` (`initialSegmentFamily_zero`); at `t = 1` it is `γ` itself, up to a
-trivial right-endpoint cast (`initialSegmentFamily_one`). The property consumers actually need
-is joint continuity in `(t, s)`, recorded as `continuous_initialSegmentFamily_uncurry` and used
-to build the rung homotopy in `joinedIn_preimage_of_append`. -/
-public noncomputable def initialSegmentFamily {a b : X} (γ : Path a b) (t : I) :
-    Path a (γ t) :=
-  (γ.truncate 0 t).cast (by rw [min_eq_left t.2.1, γ.extend_zero]) (γ.extend_apply t.2).symm
-
-public theorem continuous_initialSegmentFamily_uncurry {a b : X} (γ : Path a b) :
-    Continuous ↿(initialSegmentFamily γ) := by
-  have htrunc : Continuous (fun ts : I × I ↦ γ.truncate 0 ts.1 ts.2 : I × I → X) := by
-    let key : I × I → ℝ × ℝ × I := fun ts ↦ (0, ts.1, ts.2)
-    have hkey : Continuous key := by fun_prop
-    simpa [key] using! γ.truncate_continuous_family.comp hkey
-  simpa [initialSegmentFamily] using! htrunc
-
-@[simp] public theorem initialSegmentFamily_apply {a b : X} (γ : Path a b) (t s : I) :
-    initialSegmentFamily γ t s = γ.extend (min (s : ℝ) t) := by
-  simp [initialSegmentFamily, Path.truncate, max_eq_left s.2.1]
-
-@[simp] public theorem initialSegmentFamily_zero {a b : X} (γ : Path a b) :
-    initialSegmentFamily γ 0 = (Path.refl a).cast rfl (by simp) := by
-  ext s
-  simp [initialSegmentFamily_apply, γ.extend_zero, Path.refl, min_eq_right s.2.1]
-
-@[simp] public theorem initialSegmentFamily_one {a b : X} (γ : Path a b) :
-    initialSegmentFamily γ 1 = γ.cast rfl (by simp) := by
-  ext s
-  simp [initialSegmentFamily_apply, min_eq_left s.2.2, γ.extend_apply s.2]
-
-end Path
-
-namespace BasedPath
-
-/-- The family of initial segments of a based path, defined as
-`ofPath (γ.toPath.initialSegmentFamily t)`. At `t = 0` this is the constant based path at `x₀`;
-at `t = 1` it is `γ` itself. Joint continuity in `t` is `continuous_initialSegmentFamily`. -/
--- This wrapper is exposed for the same reason as `append`: exported endpoint and `toPath`
--- normal forms need its body to align the endpoint-indexed path types.
-@[expose] public noncomputable def initialSegmentFamily {x₀ : X} (γ : BasedPath x₀) (t : I) :
-    BasedPath x₀ :=
-  ofPath (γ.toPath.initialSegmentFamily t)
-
-@[simp] public theorem initialSegmentFamily_zero {x₀ : X} (γ : BasedPath x₀) :
-    γ.initialSegmentFamily 0 = ofPath (Path.refl x₀) := by
-  simp [initialSegmentFamily, Path.initialSegmentFamily_zero]
-
-@[simp] public theorem initialSegmentFamily_one {x₀ : X} (γ : BasedPath x₀) :
-    γ.initialSegmentFamily 1 = γ := by
-  rw [initialSegmentFamily, Path.initialSegmentFamily_one, ofPath_cast, ofPath_toPath_self]
-
-@[simp] public theorem toPath_initialSegmentFamily {x₀ : X} (γ : BasedPath x₀) (t : I) :
-    (γ.initialSegmentFamily t).toPath =
-      (γ.toPath.initialSegmentFamily t).cast rfl (γ.toPath.initialSegmentFamily t).target := by
-  -- The wrapper is endpoint-indexed, so expose its definitional `ofPath` value before using
-  -- the public `toPath_ofPath` normal form.
-  change (ofPath (γ.toPath.initialSegmentFamily t)).toPath =
-    (γ.toPath.initialSegmentFamily t).cast rfl (γ.toPath.initialSegmentFamily t).target
-  exact toPath_ofPath (γ.toPath.initialSegmentFamily t)
-
-@[simp] public theorem endpoint_initialSegmentFamily {x₀ : X} (γ : BasedPath x₀) (t : I) :
-    endpoint (γ.initialSegmentFamily t) = γ.1 t := by
-  simp [initialSegmentFamily]
-
-public theorem continuous_initialSegmentFamily {x₀ : X} (γ : BasedPath x₀) :
-    Continuous γ.initialSegmentFamily := by
-  refine Continuous.subtype_mk ?_ _
-  refine ContinuousMap.continuous_of_continuous_uncurry _ ?_
-  simpa only using! γ.toPath.continuous_initialSegmentFamily_uncurry
-
 /-- Appending a fixed terminal path's initial-segment family to a fixed based path is jointly
 continuous in the family parameter. This packages the boilerplate for using
 `Path.trans_continuous_family` to lift `append γ ∘ Path.initialSegmentFamily δ` to a continuous
 map `I → BasedPath x₀`. -/
-public theorem continuous_append_initialSegmentFamily {x₀ z : X}
+private theorem continuous_append_initialSegmentFamily {x₀ z : X}
     (γ : BasedPath x₀) (δ : Path (endpoint γ) z) :
     Continuous fun t : I ↦ γ.append (Path.initialSegmentFamily δ t) := by
   apply Continuous.subtype_mk
@@ -896,7 +810,7 @@ public theorem toPath_homotopic_of_joinedIn_pathHomotopyTrivial
 /-- Path components of `endpoint ⁻¹' U` are invariant under endpoint-preserving homotopy:
 if `p ≃ q` are homotopic paths from `x₀` to `y ∈ U`, then the based paths `ofPath p` and
 `ofPath q` lie in the same path component of `endpoint ⁻¹' U`. -/
-public theorem pathComponent_preimage_saturated
+public theorem pathComponentIn_ofPath_eq_of_homotopic
     {U : Set X} {y : X} (hy : y ∈ U)
     {p q : Path x₀ y} (h : Path.Homotopic p q) :
     pathComponentIn (endpoint (x₀ := x₀) ⁻¹' U) (ofPath p) =

--- a/TauCeti/AlgebraicTopology/UniversalCover/BasedPath.lean
+++ b/TauCeti/AlgebraicTopology/UniversalCover/BasedPath.lean
@@ -286,7 +286,7 @@ theorem exists_deformTerminal_mem_basicNeighborhood
     · have hat : a < (t : ℝ) := lt_of_not_ge hta
       by_cases htb : (t : ℝ) ≤ b
       · have hrange : Set.range (terminalTail γ rfl a (by linarith)) ⊆ W := by
-          apply Path.truncateOfLE_range_subset_preimage (h := ha1)
+          apply Path.truncateOfLE_range_subset (h := ha1)
           intro s hs
           have hs01 : s ∈ (Set.Icc 0 1 : Set ℝ) := ⟨le_trans ha0 hs.1, hs.2⟩
           simp only [Set.mem_preimage]

--- a/TauCeti/AlgebraicTopology/UniversalCover/BasedPath.lean
+++ b/TauCeti/AlgebraicTopology/UniversalCover/BasedPath.lean
@@ -1,0 +1,906 @@
+/-
+Copyright (c) 2026 Lean FRO, LLC. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Kim Morrison
+-/
+module
+
+public import TauCeti.AlgebraicTopology.UniversalCover.PathHomotopyDiscreteness
+public import Mathlib.Topology.CompactOpen
+public import Mathlib.Topology.Constructions
+public import Mathlib.Topology.Order.Basic
+
+/-!
+# Based paths
+
+This file introduces the compact-open based-path space `BasedPath x₀` and the path-component
+machinery of `endpoint ⁻¹' U` used in the universal-cover construction. It is adapted from
+[#38292](https://github.com/leanprover-community/mathlib4/pull/38292) by Kim Morrison.
+-/
+
+open scoped unitInterval
+open Topology TauCeti
+
+variable {X : Type*} [TopologicalSpace X]
+
+/-- The compact-open based-path space out of `x₀`. -/
+@[expose] public def BasedPath (x₀ : X) :=
+  { γ : C(I, X) // γ 0 = x₀ }
+
+namespace BasedPath
+
+variable {x₀ : X}
+
+public instance : TopologicalSpace (BasedPath x₀) :=
+  inferInstanceAs (TopologicalSpace { γ : C(I, X) // γ 0 = x₀ })
+
+/-- The endpoint of a based path. -/
+@[expose] public def endpoint (γ : BasedPath x₀) : X := γ.1 1
+
+/-- The endpoint map from based paths to their terminal point is continuous. -/
+public theorem continuous_endpoint : Continuous (endpoint (x₀ := x₀)) :=
+  (continuous_eval_const (1 : I)).comp continuous_induced_dom
+
+/-- View a based path as a path to its endpoint. -/
+@[expose] public def toPath (γ : BasedPath x₀) : Path x₀ (endpoint γ) where
+  toContinuousMap := γ.1
+  source' := γ.2
+  target' := rfl
+
+/-- Definitional unfolding of `endpoint`. Not a global simp lemma: it overlaps with
+`endpoint_refl` (and other `endpoint_…` lemmas) on the simp normal form, so we instead include it
+explicitly in `simp [endpoint_def, …]` at each site that wants to bridge between the named
+`endpoint γ = u` API and the underlying `γ.1 1` evaluation. -/
+public theorem endpoint_def (γ : BasedPath x₀) : endpoint γ = γ.1 1 := rfl
+@[simp] public theorem toPath_apply (γ : BasedPath x₀) (t : I) : toPath γ t = γ.1 t := rfl
+public theorem toPath_source (γ : BasedPath x₀) : toPath γ 0 = x₀ := γ.2
+public theorem toPath_target (γ : BasedPath x₀) : toPath γ 1 = endpoint γ := rfl
+
+@[ext] public theorem ext {γ γ' : BasedPath x₀} (h : ∀ t, γ.1 t = γ'.1 t) : γ = γ' := by
+  cases γ with
+  | mk γ hγ =>
+    cases γ' with
+    | mk γ' hγ' =>
+      simp only at h
+      have hfun : γ = γ' := by
+        ext t
+        exact h t
+      subst hfun
+      simp
+
+/-- The canonical inclusion `Path x₀ y → BasedPath x₀`: package an ordinary path out of `x₀` as a
+based path, forgetting `y` at the type level. The endpoint is recovered as
+`endpoint (ofPath γ) = y` via `endpoint_ofPath`. The map `toPath` is a partial inverse:
+`ofPath γ.toPath = γ` (`ofPath_toPath_self`), and conversely `(ofPath γ).toPath` is `γ` with its
+right endpoint cast to `endpoint (ofPath γ)` (`toPath_ofPath`). -/
+@[expose] public def ofPath {y : X} (γ : Path x₀ y) : BasedPath x₀ :=
+  ⟨γ.toContinuousMap, γ.source⟩
+
+@[simp] public theorem toPath_ofPath {y : X} (γ : Path x₀ y) :
+    (ofPath γ).toPath = γ.cast rfl γ.target := by
+  ext t
+  rfl
+
+@[simp] public theorem endpoint_ofPath {y : X} (γ : Path x₀ y) : endpoint (ofPath γ) = y :=
+  γ.target
+
+/-- The round-trip `ofPath ∘ toPath` is the identity on `BasedPath x₀`. -/
+@[simp] public theorem ofPath_toPath_self (γ : BasedPath x₀) : ofPath γ.toPath = γ := rfl
+
+/-- `ofPath` is invariant under reindexing the right endpoint via `Path.cast`. -/
+@[simp] public theorem ofPath_cast {y y' : X} (γ : Path x₀ y) (h : y' = y) :
+    ofPath (γ.cast rfl h) = ofPath γ := rfl
+
+/-- The constant based path at `x₀`. -/
+@[expose] public def refl (x₀ : X) : BasedPath x₀ :=
+  ofPath (Path.refl x₀)
+
+@[simp] public theorem endpoint_refl (x₀ : X) : endpoint (refl x₀) = x₀ :=
+  endpoint_ofPath _
+
+@[simp] public theorem toPath_refl (x₀ : X) :
+    (refl x₀).toPath = Path.refl x₀ := by
+  apply Path.ext; funext t; rfl
+
+@[simp] public theorem ofPath_refl (x₀ : X) :
+    ofPath (Path.refl x₀) = refl x₀ := rfl
+
+/-- Append a path `δ` at the endpoint of a based path `γ`, defined as
+`ofPath (γ.toPath.trans δ)`: the half `s ∈ [0, ½]` traverses `γ` at double speed and the half
+`s ∈ [½, 1]` traverses `δ` at double speed (`Path.trans_apply`). The new endpoint is the endpoint
+of `δ` (`endpoint_append`). This is the move used by `joinedIn_preimage_of_append` to slide a
+based path within a path component of `endpoint ⁻¹' U`. -/
+-- `append` is exposed so the exported endpoint and `toPath` normal-form lemmas can typecheck
+-- across the module boundary; their result types identify endpoints by unfolding this wrapper.
+@[expose] public noncomputable def append {y : X} (γ : BasedPath x₀)
+    (δ : Path (endpoint γ) y) : BasedPath x₀ :=
+  ofPath (γ.toPath.trans δ)
+
+@[simp] public theorem toPath_append {y : X} (γ : BasedPath x₀) (δ : Path (endpoint γ) y) :
+    (append γ δ).toPath = (γ.toPath.trans δ).cast rfl (γ.toPath.trans δ).target := by
+  simp [append, toPath_ofPath]
+
+@[simp] public theorem endpoint_append {y : X} (γ : BasedPath x₀) (δ : Path (endpoint γ) y) :
+    endpoint (append γ δ) = y := endpoint_ofPath _
+
+/-- The tail of a based path past time `a`, viewed as a `Path (γ.toPath.extend a) u` where
+`u = endpoint γ`. Concretely it is `γ.toPath.truncateOfLE` between `a` and `1`, cast on the right
+to land at `u`; the only hypothesis required is `a ≤ 1` (for `a < 0` the source is clamped
+through `Path.extend`). This is the "compressed tail" piece used by `deformTerminal` to splice
+a new endpoint path onto `γ` while preserving its image on `[0, a]`. -/
+private noncomputable def terminalTail {u : X} (γ : BasedPath x₀)
+    (hu : endpoint γ = u) (a : ℝ) (ha1 : a ≤ 1) :
+    Path (γ.toPath.extend a) u :=
+  (γ.toPath.truncateOfLE (t₀ := a) (t₁ := 1) ha1).cast rfl
+    (by simpa using! hu.symm)
+
+/-- Replace the terminal interval of a based path by first traversing a compressed tail of the
+original path and then a new endpoint path. -/
+private noncomputable def deformTerminal {u v : X} (γ : BasedPath x₀)
+    (hu : endpoint γ = u)
+    (δ : Path u v) {a b : ℝ} (ha : 0 ≤ a) (hab : a < b) (hb : b < 1) : BasedPath x₀ := by
+  let tail : Path (γ.toPath.extend a) u := terminalTail γ hu a (by linarith)
+  let f : ℝ → X := fun t ↦
+    if hta : t ≤ a then γ.toPath.extend t else
+      if htb : t ≤ b then tail.extend ((t - a) / (b - a)) else δ.extend ((t - b) / (1 - b))
+  have hf_cont : Continuous f := by
+    refine Continuous.if_le γ.toPath.continuous_extend ?_ continuous_id continuous_const ?_
+    · refine Continuous.if_le
+        (tail.continuous_extend.comp (by fun_prop))
+        (δ.continuous_extend.comp (by fun_prop))
+        continuous_id continuous_const ?_
+      · intro t htb
+        have hba : b - a ≠ 0 := sub_ne_zero.mpr hab.ne.symm
+        subst t
+        simp [tail, hba]
+    · intro t hta
+      subst t
+      simp [tail, hab.le]
+  refine ⟨ContinuousMap.mk
+    (fun t : I ↦ f t)
+    (hf_cont.comp continuous_subtype_val), ?_⟩
+  simpa [f, ha, endpoint_def] using! γ.toPath.source
+
+private theorem deformTerminal_apply_of_le {u v : X} (γ : BasedPath x₀) (hu : endpoint γ = u)
+    (δ : Path u v) {a b : ℝ} (ha : 0 ≤ a) (hab : a < b) (hb : b < 1)
+    (t : I) (ht : (t : ℝ) ≤ a) :
+    (deformTerminal γ hu δ ha hab hb).1 t = γ.toPath.extend t := by
+  simp [deformTerminal, endpoint_def, ht]
+
+private theorem deformTerminal_apply_of_lt_of_le {u v : X} (γ : BasedPath x₀)
+    (hu : endpoint γ = u) (δ : Path u v) {a b : ℝ} (ha : 0 ≤ a) (hab : a < b) (hb : b < 1)
+    (t : I) (hta : a < (t : ℝ)) (htb : (t : ℝ) ≤ b) :
+    (deformTerminal γ hu δ ha hab hb).1 t =
+      (terminalTail γ hu a (by linarith)).extend (((t : ℝ) - a) / (b - a)) := by
+  simp [deformTerminal, endpoint_def, not_le_of_gt hta, htb]
+
+private theorem deformTerminal_apply_of_lt {u v : X} (γ : BasedPath x₀) (hu : endpoint γ = u)
+    (δ : Path u v) {a b : ℝ} (ha : 0 ≤ a) (hab : a < b) (hb : b < 1)
+    (t : I) (ht : b < (t : ℝ)) :
+    (deformTerminal γ hu δ ha hab hb).1 t = δ.extend (((t : ℝ) - b) / (1 - b)) := by
+  simp [deformTerminal, endpoint_def, not_le_of_gt (lt_trans hab ht), not_le_of_gt ht]
+
+/-- The endpoint of `deformTerminal γ hu δ ha hab hb` is the endpoint of `δ`. -/
+private theorem endpoint_deformTerminal {u v : X} (γ : BasedPath x₀) (hu : endpoint γ = u)
+    (δ : Path u v) {a b : ℝ} (ha : 0 ≤ a) (hab : a < b) (hb : b < 1) :
+    endpoint (deformTerminal γ hu δ ha hab hb) = v := by
+  simp only [endpoint_def]
+  rw [deformTerminal_apply_of_lt γ hu δ ha hab hb 1 hb]
+  have hbne : (1 : ℝ) - b ≠ 0 := sub_ne_zero.mpr hb.ne'
+  have hone : (((1 : I) : ℝ) - b) / (1 - b) = 1 := by
+    have : ((1 : I) : ℝ) = 1 := rfl
+    rw [this]; field_simp
+  rw [hone]
+  simp [δ.extend_one]
+
+end BasedPath
+
+namespace Path
+
+public theorem truncateOfLE_range_subset_preimage {a b : X} (γ : Path a b) {t₀ t₁ : ℝ}
+    (h : t₀ ≤ t₁) {U : Set X} (hU : Set.Icc t₀ t₁ ⊆ γ.extend ⁻¹' U) :
+    Set.range (γ.truncateOfLE h) ⊆ U := by
+  rintro _ ⟨s, rfl⟩
+  dsimp [truncateOfLE, truncate]
+  apply hU
+  constructor
+  · exact le_min (le_max_right _ _) h
+  · exact min_le_right _ _
+
+/-- The family of initial segments of `γ : Path a b`: at parameter `t : I`, the path
+`s ↦ γ.extend (min s t)` from `a` to `γ t` (`initialSegmentFamily_apply`). At `t = 0` this is
+the constant path at `a` (`initialSegmentFamily_zero`); at `t = 1` it is `γ` itself, up to a
+trivial right-endpoint cast (`initialSegmentFamily_one`). The property consumers actually need
+is joint continuity in `(t, s)`, recorded as `continuous_initialSegmentFamily_uncurry` and used
+to build the rung homotopy in `joinedIn_preimage_of_append`. -/
+public noncomputable def initialSegmentFamily {a b : X} (γ : Path a b) (t : I) :
+    Path a (γ t) :=
+  (γ.truncate 0 t).cast (by rw [min_eq_left t.2.1, γ.extend_zero]) (γ.extend_apply t.2).symm
+
+public theorem continuous_initialSegmentFamily_uncurry {a b : X} (γ : Path a b) :
+    Continuous ↿(initialSegmentFamily γ) := by
+  have htrunc : Continuous (fun ts : I × I ↦ γ.truncate 0 ts.1 ts.2 : I × I → X) := by
+    let key : I × I → ℝ × ℝ × I := fun ts ↦ (0, ts.1, ts.2)
+    have hkey : Continuous key := by fun_prop
+    simpa [key] using! γ.truncate_continuous_family.comp hkey
+  simpa [initialSegmentFamily] using! htrunc
+
+@[simp] public theorem initialSegmentFamily_apply {a b : X} (γ : Path a b) (t s : I) :
+    initialSegmentFamily γ t s = γ.extend (min (s : ℝ) t) := by
+  simp [initialSegmentFamily, Path.truncate, max_eq_left s.2.1]
+
+@[simp] public theorem initialSegmentFamily_zero {a b : X} (γ : Path a b) :
+    initialSegmentFamily γ 0 = (Path.refl a).cast rfl (by simp) := by
+  ext s
+  simp [initialSegmentFamily_apply, γ.extend_zero, Path.refl, min_eq_right s.2.1]
+
+@[simp] public theorem initialSegmentFamily_one {a b : X} (γ : Path a b) :
+    initialSegmentFamily γ 1 = γ.cast rfl (by simp) := by
+  ext s
+  simp [initialSegmentFamily_apply, min_eq_left s.2.2, γ.extend_apply s.2]
+
+end Path
+
+namespace BasedPath
+
+/-- The family of initial segments of a based path, defined as
+`ofPath (γ.toPath.initialSegmentFamily t)`. At `t = 0` this is the constant based path at `x₀`;
+at `t = 1` it is `γ` itself. Joint continuity in `t` is `continuous_initialSegmentFamily`. -/
+-- This wrapper is exposed for the same reason as `append`: exported endpoint and `toPath`
+-- normal forms need its body to align the endpoint-indexed path types.
+@[expose] public noncomputable def initialSegmentFamily {x₀ : X} (γ : BasedPath x₀) (t : I) :
+    BasedPath x₀ :=
+  ofPath (γ.toPath.initialSegmentFamily t)
+
+@[simp] public theorem initialSegmentFamily_zero {x₀ : X} (γ : BasedPath x₀) :
+    γ.initialSegmentFamily 0 = ofPath (Path.refl x₀) := by
+  simp [initialSegmentFamily, Path.initialSegmentFamily_zero]
+
+@[simp] public theorem initialSegmentFamily_one {x₀ : X} (γ : BasedPath x₀) :
+    γ.initialSegmentFamily 1 = γ := by
+  rw [initialSegmentFamily, Path.initialSegmentFamily_one, ofPath_cast, ofPath_toPath_self]
+
+@[simp] public theorem toPath_initialSegmentFamily {x₀ : X} (γ : BasedPath x₀) (t : I) :
+    (γ.initialSegmentFamily t).toPath =
+      (γ.toPath.initialSegmentFamily t).cast rfl (γ.toPath.initialSegmentFamily t).target := by
+  -- The wrapper is endpoint-indexed, so expose its definitional `ofPath` value before using
+  -- the public `toPath_ofPath` normal form.
+  change (ofPath (γ.toPath.initialSegmentFamily t)).toPath =
+    (γ.toPath.initialSegmentFamily t).cast rfl (γ.toPath.initialSegmentFamily t).target
+  exact toPath_ofPath (γ.toPath.initialSegmentFamily t)
+
+@[simp] public theorem endpoint_initialSegmentFamily {x₀ : X} (γ : BasedPath x₀) (t : I) :
+    endpoint (γ.initialSegmentFamily t) = γ.1 t := by
+  simp [initialSegmentFamily]
+
+public theorem continuous_initialSegmentFamily {x₀ : X} (γ : BasedPath x₀) :
+    Continuous γ.initialSegmentFamily := by
+  refine Continuous.subtype_mk ?_ _
+  refine ContinuousMap.continuous_of_continuous_uncurry _ ?_
+  simpa only using! γ.toPath.continuous_initialSegmentFamily_uncurry
+
+/-- Appending a fixed terminal path's initial-segment family to a fixed based path is jointly
+continuous in the family parameter. This packages the boilerplate for using
+`Path.trans_continuous_family` to lift `append γ ∘ Path.initialSegmentFamily δ` to a continuous
+map `I → BasedPath x₀`. -/
+public theorem continuous_append_initialSegmentFamily {x₀ z : X}
+    (γ : BasedPath x₀) (δ : Path (endpoint γ) z) :
+    Continuous fun t : I ↦ γ.append (Path.initialSegmentFamily δ t) := by
+  apply Continuous.subtype_mk
+  refine ContinuousMap.continuous_of_continuous_uncurry _ ?_
+  simpa using!
+    Path.trans_continuous_family (fun _ : I ↦ γ.toPath)
+      (Path.continuous_uncurry_iff.mpr continuous_const) (Path.initialSegmentFamily δ)
+      (Path.continuous_initialSegmentFamily_uncurry δ)
+
+/-- Extract an open path-connected endpoint neighborhood and a terminal interval avoiding the
+subbasic compact sets that do not contain `1`. -/
+theorem exists_endpointNeighborhood_of_basicNeighborhood [LocallyPathConnectedSpace X]
+    {x₀ : X} (γ : BasedPath x₀) (Tgood Tbad : Finset (Set I × Set X))
+    (hTgood_open_mem : ∀ KU ∈ Tgood, IsOpen KU.2 ∧ endpoint γ ∈ KU.2)
+    (hTbad_closed : ∀ KU ∈ Tbad, IsClosed KU.1)
+    (hTbad_not_mem : ∀ KU ∈ Tbad, (1 : I) ∉ KU.1) :
+    ∃ (W : Set X) (a₀ : I) (a b : ℝ),
+      IsOpen W ∧ endpoint γ ∈ W ∧ IsPathConnected W ∧
+      (∀ KU ∈ Tgood, W ⊆ KU.2) ∧
+      Set.Ioc a₀ 1 ⊆ γ.toPath ⁻¹' W ∩ ⋂ KU ∈ Tbad, KU.1ᶜ ∧
+      ((a₀ : I) : ℝ) < a ∧ 0 ≤ a ∧ a ≤ 1 ∧ a < b ∧ b < 1 := by
+  let O : Set X := ⋂ KU ∈ Tgood, KU.2
+  have hOopen : IsOpen O :=
+    isOpen_biInter_finset fun KU hKU ↦ (hTgood_open_mem KU hKU).1
+  have huO : endpoint γ ∈ O := by
+    simp only [O, Set.mem_iInter]
+    exact fun KU hKU ↦ (hTgood_open_mem KU hKU).2
+  rcases (isOpen_isPathConnected_basis (x := endpoint γ)).mem_iff.mp
+      (hOopen.mem_nhds huO) with ⟨W, ⟨hWopen, huW, hWpath⟩, hWO⟩
+  let N : Set I := γ.toPath ⁻¹' W ∩ ⋂ KU ∈ Tbad, KU.1ᶜ
+  have hNnhds : N ∈ 𝓝 (1 : I) := by
+    refine Filter.inter_mem
+      ((hWopen.preimage γ.toPath.continuous).mem_nhds (by simpa using! huW)) ?_
+    refine (isOpen_biInter_finset ?_).mem_nhds ?_
+    · exact fun KU hKU ↦ (hTbad_closed KU hKU).isOpen_compl
+    · simp only [Set.mem_iInter]
+      intro KU hKU
+      exact hTbad_not_mem KU hKU
+  rcases exists_Ioc_subset_of_mem_nhds' hNnhds (show (0 : I) < 1 by simp) with ⟨a₀, ha₀, hIoc⟩
+  let a : ℝ := (((a₀ : I) : ℝ) + 1) / 2
+  let b : ℝ := (a + 1) / 2
+  have ha₀_nonneg : 0 ≤ ((a₀ : I) : ℝ) := a₀.2.1
+  have ha₀_lt_one : ((a₀ : I) : ℝ) < 1 := ha₀.2
+  have ha₀_lt_a : ((a₀ : I) : ℝ) < a := by dsimp [a]; nlinarith
+  have ha0 : 0 ≤ a := by dsimp [a]; nlinarith
+  have ha1 : a ≤ 1 := by dsimp [a]; nlinarith
+  have hab : a < b := by dsimp [a, b]; nlinarith
+  have hb1 : b < 1 := by dsimp [a, b]; nlinarith
+  refine ⟨W, a₀, a, b, hWopen, huW, hWpath, ?_, hIoc, ha₀_lt_a, ha0, ha1, hab, hb1⟩
+  intro KU hKU z hz
+  have hz' : ∀ KU ∈ Tgood, z ∈ KU.2 := by simpa [O] using! hWO hz
+  exact hz' KU hKU
+
+/-- Any point in the chosen path-connected endpoint neighborhood is realized by a deformed based
+path that still lies in the original compact-open basic neighborhood. -/
+theorem exists_deformTerminal_mem_basicNeighborhood
+    {x₀ : X} (γ : BasedPath x₀) {V : Set (C(I, X))} {S : Set (Set I × Set X)}
+    {T Tgood Tbad : Finset (Set I × Set X)}
+    (hSdata : ∀ K U, (K, U) ∈ S → IsCompact K ∧ IsOpen U ∧ Set.MapsTo γ.1 K U)
+    (hT_of_S : ∀ KU, KU ∈ S → KU ∈ T)
+    (hSV : {g : C(I, X) | ∀ K U, (K, U) ∈ S → Set.MapsTo g K U} ⊆ V)
+    (hTgood_iff : ∀ KU, KU ∈ Tgood ↔ KU ∈ T ∧ (1 : I) ∈ KU.1)
+    (hTbad_iff : ∀ KU, KU ∈ Tbad ↔ KU ∈ T ∧ (1 : I) ∉ KU.1)
+    {W : Set X} (huW : endpoint γ ∈ W) (hWpath : IsPathConnected W)
+    (hW_good : ∀ KU ∈ Tgood, W ⊆ KU.2)
+    {a₀ : I} {a b : ℝ}
+    (hIoc : Set.Ioc a₀ 1 ⊆ γ.toPath ⁻¹' W ∩ ⋂ KU ∈ Tbad, KU.1ᶜ)
+    (ha₀_lt_a : ((a₀ : I) : ℝ) < a) (ha0 : 0 ≤ a) (ha1 : a ≤ 1) (hab : a < b) (hb1 : b < 1) :
+    ∀ v ∈ W, ∃ η : BasedPath x₀, η.1 ∈ V ∧ endpoint η = v := by
+  classical
+  intro v hvW
+  obtain ⟨δ, hδ⟩ := hWpath.joinedIn _ huW _ hvW
+  have hδW : Set.range δ ⊆ W := Set.range_subset_iff.mpr hδ
+  refine ⟨deformTerminal γ rfl δ ha0 hab hb1, ?_,
+    endpoint_deformTerminal γ rfl δ ha0 hab hb1⟩
+  apply hSV
+  intro K U hKU
+  have hKUT : (K, U) ∈ T := hT_of_S (K, U) hKU
+  intro t ht
+  by_cases h1K : (1 : I) ∈ K
+  · have hKUgood : (K, U) ∈ Tgood := (hTgood_iff (K, U)).2 ⟨hKUT, h1K⟩
+    by_cases hta : (t : ℝ) ≤ a
+    · rw [BasedPath.deformTerminal_apply_of_le γ rfl δ ha0 hab hb1 t hta,
+          Path.extend_apply _ t.2]
+      exact (hSdata K U hKU).2.2 ht
+    · have hat : a < (t : ℝ) := lt_of_not_ge hta
+      by_cases htb : (t : ℝ) ≤ b
+      · have hrange : Set.range (terminalTail γ rfl a (by linarith)) ⊆ W := by
+          apply Path.truncateOfLE_range_subset_preimage (h := ha1)
+          intro s hs
+          have hs01 : s ∈ (Set.Icc 0 1 : Set ℝ) := ⟨le_trans ha0 hs.1, hs.2⟩
+          simp only [Set.mem_preimage]
+          rw [Path.extend_apply _ hs01]
+          refine (hIoc ?_).1
+          refine ⟨?_, ?_⟩
+          · -- No interval-order lemma matches this mixed subtype/real goal directly.
+            change ((a₀ : I) : ℝ) < s
+            exact lt_of_lt_of_le ha₀_lt_a hs.1
+          · -- No interval-order lemma matches this mixed subtype/real goal directly.
+            change s ≤ 1
+            exact hs.2
+        have hparam : (((t : ℝ) - a) / (b - a)) ∈ (Set.Icc 0 1 : Set ℝ) := by
+          have hba : 0 < b - a := sub_pos.mpr hab
+          exact ⟨div_nonneg (sub_nonneg.mpr hat.le) hba.le,
+            (div_le_one hba).2 <| sub_le_sub_right htb a⟩
+        have htailW :
+            (terminalTail γ rfl a (by linarith)).extend (((t : ℝ) - a) / (b - a)) ∈ W := by
+          rw [Path.extend_apply _ hparam]
+          exact hrange ⟨⟨((t : ℝ) - a) / (b - a), hparam⟩, rfl⟩
+        rw [BasedPath.deformTerminal_apply_of_lt_of_le γ rfl δ ha0 hab hb1 t hat htb]
+        exact hW_good (K, U) hKUgood htailW
+      · have hbt : b < (t : ℝ) := lt_of_not_ge htb
+        have hparam : (((t : ℝ) - b) / (1 - b)) ∈ (Set.Icc 0 1 : Set ℝ) := by
+          have hb : 0 < 1 - b := sub_pos.mpr hb1
+          exact ⟨div_nonneg (sub_nonneg.mpr hbt.le) hb.le,
+            (div_le_one hb).2 <| sub_le_sub_right t.2.2 b⟩
+        have hδt : δ.extend (((t : ℝ) - b) / (1 - b)) ∈ W := by
+          rw [Path.extend_apply _ hparam]
+          exact hδW ⟨⟨((t : ℝ) - b) / (1 - b), hparam⟩, rfl⟩
+        rw [BasedPath.deformTerminal_apply_of_lt γ rfl δ ha0 hab hb1 t hbt]
+        exact hW_good (K, U) hKUgood hδt
+  · have hKUbad : (K, U) ∈ Tbad := (hTbad_iff (K, U)).2 ⟨hKUT, h1K⟩
+    have ht_not_Ioc : t ∉ Set.Ioc a₀ 1 := fun htIoc ↦ by
+      have htN : t ∈ γ.toPath ⁻¹' W ∩ ⋂ KU ∈ Tbad, KU.1ᶜ := hIoc htIoc
+      have htN' : ∀ KU ∈ Tbad, t ∉ KU.1 := by simpa using! htN.2
+      exact htN' (K, U) hKUbad ht
+    have htle : (t : ℝ) ≤ a := by
+      by_contra hgt
+      have hat : a < (t : ℝ) := lt_of_not_ge hgt
+      have hat₀ : ((a₀ : I) : ℝ) < t := lt_trans ha₀_lt_a hat
+      exact ht_not_Ioc ⟨hat₀, t.2.2⟩
+    rw [BasedPath.deformTerminal_apply_of_le γ rfl δ ha0 hab hb1 t htle,
+        Path.extend_apply _ t.2]
+    exact (hSdata K U hKU).2.2 ht
+
+/-- The endpoint map `BasedPath x₀ → X` is an open map when `X` is locally path-connected. -/
+public theorem isOpenMap_endpoint [LocallyPathConnectedSpace X] (x₀ : X) :
+    IsOpenMap (endpoint (x₀ := x₀)) := by
+  classical
+  refine IsOpenMap.of_nhds_le ?_
+  intro γ
+  rw [Filter.le_def]
+  intro s hs
+  rw [Filter.mem_map'] at hs
+  have hsub := mem_nhds_subtype (s := {γ : C(I, X) | γ 0 = x₀}) γ
+    ({η : BasedPath x₀ | endpoint η ∈ s})
+  rcases hsub.mp hs with ⟨V, hVγ, hVs⟩
+  rcases ContinuousMap.mem_nhds_iff.1 hVγ with ⟨S, hSfin, hSdata, hSV⟩
+  let T : Finset (Set I × Set X) := hSfin.toFinset
+  let Tgood : Finset (Set I × Set X) := T.filter fun KU ↦ (1 : I) ∈ KU.1
+  let Tbad : Finset (Set I × Set X) := T.filter fun KU ↦ (1 : I) ∉ KU.1
+  have hS_of_T : ∀ KU, KU ∈ T → KU ∈ S := fun _ ↦ hSfin.mem_toFinset.mp
+  have hT_of_S : ∀ KU, KU ∈ S → KU ∈ T := fun _ ↦ hSfin.mem_toFinset.mpr
+  have hgood : ∀ KU ∈ Tgood, KU ∈ S ∧ (1 : I) ∈ KU.1 := fun KU hKU ↦
+    let ⟨hT, h1⟩ := Finset.mem_filter.mp hKU
+    ⟨hS_of_T KU hT, h1⟩
+  have hbad : ∀ KU ∈ Tbad, KU ∈ S ∧ (1 : I) ∉ KU.1 := fun KU hKU ↦
+    let ⟨hT, h1⟩ := Finset.mem_filter.mp hKU
+    ⟨hS_of_T KU hT, h1⟩
+  obtain ⟨W, a₀, a, b, hWopen, huW, hWpath, hW_good, hIoc, ha₀_lt_a, ha0, ha1, hab, hb1⟩ :=
+    exists_endpointNeighborhood_of_basicNeighborhood γ Tgood Tbad
+      (fun KU hKU ↦ ⟨(hSdata KU.1 KU.2 (hgood KU hKU).1).2.1,
+        (hSdata KU.1 KU.2 (hgood KU hKU).1).2.2 (hgood KU hKU).2⟩)
+      (fun KU hKU ↦ (hSdata KU.1 KU.2 (hbad KU hKU).1).1.isClosed)
+      (fun KU hKU ↦ (hbad KU hKU).2)
+  refine mem_nhds_iff.mpr ⟨W, ?_, hWopen, huW⟩
+  intro v hvW
+  obtain ⟨η, hηV, hend⟩ :=
+    exists_deformTerminal_mem_basicNeighborhood γ hSdata hT_of_S hSV
+      (fun KU ↦ by simp [Tgood])
+      (fun KU ↦ by simp [Tbad])
+      huW hWpath hW_good hIoc ha₀_lt_a ha0 ha1 hab hb1 v hvW
+  have hηs : endpoint η ∈ s := hVs hηV
+  rw [hend] at hηs
+  exact hηs
+
+variable {x₀ : X}
+
+/-- Endpoint-preserving homotopic paths to a point `y ∈ U` give joined based paths inside the
+endpoint preimage of `U`. -/
+public theorem joinedIn_endpoint_preimage_of_homotopic (x₀ : X) {y : X} {U : Set X}
+    (hy : y ∈ U) {p q : Path x₀ y} (h : Path.Homotopic p q) :
+    JoinedIn (endpoint (x₀ := x₀) ⁻¹' U) (ofPath p) (ofPath q) := by
+  rcases h with ⟨H⟩
+  let γ : Path (ofPath p) (ofPath q) :=
+    { toFun := fun t ↦ ofPath (H.eval t)
+      continuous_toFun := by
+        apply Continuous.subtype_mk
+        exact continuous_induced_dom.comp <| (Path.continuous_uncurry_iff.mp <| by
+          -- `Path.continuous_uncurry_iff` leaves the homotopy as its coercion; name that
+          -- defeq form so `H.continuous` applies.
+          change Continuous fun ts : I × I ↦ H ts
+          exact H.continuous)
+      source' := by
+        ext s
+        simp
+      target' := by
+        ext s
+        simp }
+  refine ⟨γ, fun t ↦ ?_⟩
+  -- `γ` is a let-bound path, so expose its definitional value before using endpoint API.
+  change endpoint (ofPath (H.eval t)) ∈ U
+  rw [endpoint_ofPath]
+  exact hy
+
+/-- Appending a path that stays inside `U` moves a based path within the same path component of
+the endpoint preimage of `U`. -/
+public theorem joinedIn_preimage_of_append {U : Set X} {z : X} (γ : BasedPath x₀)
+    (δ : Path (endpoint γ) z) (hδU : Set.range δ ⊆ U) :
+    JoinedIn (endpoint (x₀ := x₀) ⁻¹' U) γ (append γ δ) := by
+  have hγU : endpoint γ ∈ U := by
+    simpa [δ.source] using hδU ⟨0, rfl⟩
+  let γrefl : Path (endpoint γ) (endpoint γ) := Path.refl (endpoint γ)
+  have h_start :
+      JoinedIn (endpoint (x₀ := x₀) ⁻¹' U) γ (append γ γrefl) := by
+    simpa [γrefl] using!
+      (joinedIn_endpoint_preimage_of_homotopic (x₀ := x₀) (U := U) hγU
+        (p := γ.toPath.trans (Path.refl (endpoint γ))) (q := γ.toPath)
+        (Path.Homotopic.trans_refl γ.toPath)).symm
+  have h_move :
+      JoinedIn (endpoint (x₀ := x₀) ⁻¹' U) (append γ γrefl) (append γ δ) := by
+    let η : Path (append γ γrefl) (append γ δ) := {
+      toFun := fun t ↦ append γ (Path.initialSegmentFamily δ t)
+      continuous_toFun := continuous_append_initialSegmentFamily γ δ
+      source' := by
+        rw [Path.initialSegmentFamily_zero]
+        ext s
+        -- The endpoint casts come from `Path.initialSegmentFamily_zero`; expose the appended
+        -- path values so `Path.cast_coe` can remove them pointwise.
+        change (γ.toPath.trans ((Path.refl (endpoint γ)).cast _ _)) s =
+          (γ.toPath.trans γrefl) s
+        rw [Path.trans_apply, Path.trans_apply]
+        split_ifs <;> simp only [γrefl, Path.cast_coe]
+      target' := by
+        rw [Path.initialSegmentFamily_one]
+        ext s
+        -- As above, the final segment differs only by endpoint casts introduced by the
+        -- initial-segment normal form.
+        change (γ.toPath.trans (δ.cast _ _)) s = (γ.toPath.trans δ) s
+        rw [Path.trans_apply, Path.trans_apply]
+        split_ifs <;> simp only [Path.cast_coe] }
+    refine ⟨η, fun t ↦ ?_⟩
+    -- `η` is a let-bound path, so expose its definitional value before using endpoint API.
+    change endpoint (append γ (Path.initialSegmentFamily δ t)) ∈ U
+    rw [BasedPath.endpoint_append]
+    exact hδU ⟨t, rfl⟩
+  exact h_start.trans h_move
+
+theorem exists_refined_terminal_vertex
+    [LocallyPathConnectedSpace X]
+    {x₀ : X} {n' : ℕ} {U : Set X} (hU_open : IsOpen U)
+    (α : BasedPath x₀) (hα : endpoint α ∈ U)
+    (part : IntervalPartition (n' + 1)) (T : TubeData X (n' + 1))
+    (hα_tube : PathInTube α.toPath part T) :
+    ∃ V_last' : Set X,
+      IsOpen V_last' ∧ IsPathConnected V_last' ∧ endpoint α ∈ V_last' ∧
+      V_last' ⊆ T.V (Fin.last (n' + 1)) ∧ V_last' ⊆ U := by
+  have hα_at_last : α.toPath (part.t (Fin.last (n' + 1))) = endpoint α := by
+    rw [part.t_last]
+    exact α.toPath.target
+  let V_last := T.V (Fin.last (n' + 1))
+  have hα_V_last : endpoint α ∈ V_last := hα_at_last ▸ hα_tube.passes_through_V _
+  let W : Set X := V_last ∩ U
+  have hW_open : IsOpen W := (T.V_open _).inter hU_open
+  have hα_W : endpoint α ∈ W := ⟨hα_V_last, hα⟩
+  refine ⟨pathComponentIn W (endpoint α), hW_open.pathComponentIn _,
+    isPathConnected_pathComponentIn hα_W, mem_pathComponentIn_self hα_W, ?_, ?_⟩
+  · exact pathComponentIn_subset.trans Set.inter_subset_left
+  · exact pathComponentIn_subset.trans Set.inter_subset_right
+
+theorem isOpen_refined_tubeNeighborhood
+    {x₀ : X} {n' : ℕ} (part : IntervalPartition (n' + 1))
+    {U : Fin (n' + 1) → Set X} {V : Fin (n' + 2) → Set X}
+    (hU_open : ∀ i, IsOpen (U i)) (hV_open : ∀ j, IsOpen (V j)) :
+    IsOpen {β : BasedPath x₀ |
+      (∀ (i : Fin (n' + 1)) (s : I),
+          (part.t i.castSucc : ℝ) ≤ s ∧ s ≤ (part.t i.succ : ℝ) → β.1 s ∈ U i) ∧
+      (∀ j, β.1 (part.t j) ∈ V j)} := by
+  have h_split : {β : BasedPath x₀ |
+        (∀ (i : Fin (n' + 1)) (s : I),
+            (part.t i.castSucc : ℝ) ≤ s ∧ s ≤ (part.t i.succ : ℝ) → β.1 s ∈ U i) ∧
+        (∀ j, β.1 (part.t j) ∈ V j)} =
+      {β : BasedPath x₀ | ∀ (i : Fin (n' + 1)) (s : I),
+          (part.t i.castSucc : ℝ) ≤ s ∧ s ≤ (part.t i.succ : ℝ) → β.1 s ∈ U i} ∩
+      {β : BasedPath x₀ | ∀ j, β.1 (part.t j) ∈ V j} := by ext β; simp
+  rw [h_split]
+  refine IsOpen.inter ?_ ?_
+  · have h_U_iInter : {β : BasedPath x₀ | ∀ (i : Fin (n' + 1)) (s : I),
+          (part.t i.castSucc : ℝ) ≤ s ∧ s ≤ (part.t i.succ : ℝ) → β.1 s ∈ U i} =
+        ⋂ i : Fin (n' + 1), {β : BasedPath x₀ | ∀ s : I,
+            (part.t i.castSucc : ℝ) ≤ s ∧ s ≤ (part.t i.succ : ℝ) → β.1 s ∈ U i} := by
+      ext β; simp
+    rw [h_U_iInter]
+    refine isOpen_iInter_of_finite fun i ↦ ?_
+    have h_U_preimage : {β : BasedPath x₀ | ∀ s : I,
+          (part.t i.castSucc : ℝ) ≤ s ∧ s ≤ (part.t i.succ : ℝ) → β.1 s ∈ U i} =
+        (fun β : BasedPath x₀ ↦ (β.1 : C(I, X))) ⁻¹'
+          {f : C(I, X) | Set.MapsTo f
+            (Set.Icc (part.t i.castSucc) (part.t i.succ) : Set I) (U i)} := by
+      ext β; simp [Set.MapsTo, Set.mem_Icc]
+    rw [h_U_preimage]
+    exact (ContinuousMap.isOpen_setOf_mapsTo isCompact_Icc (hU_open i)).preimage
+      continuous_subtype_val
+  · have h_V_iInter : {β : BasedPath x₀ | ∀ j, β.1 (part.t j) ∈ V j} =
+        ⋂ j : Fin (n' + 2), {β : BasedPath x₀ | β.1 (part.t j) ∈ V j} := by ext β; simp
+    rw [h_V_iInter]
+    exact isOpen_iInter_of_finite fun j ↦
+      (hV_open j).preimage ((continuous_eval_const (part.t j)).comp continuous_subtype_val)
+
+/-- Variable-endpoint tube/component theorem.
+
+In a locally path-connected space, if semilocal simple connectivity holds along `α.toPath` and
+`α : BasedPath x₀` has endpoint in an open set `U`, then `α` has an open neighborhood `N` in
+`BasedPath x₀` such that every element of `N` has endpoint in `U` and lies in the same path
+component of `endpoint ⁻¹' U` as `α`. -/
+public theorem exists_open_nhd_pathComponent_preimage
+    [LocallyPathConnectedSpace X] {U : Set X} (hU_open : IsOpen U)
+    (α : BasedPath x₀) (hslsc : SemilocallySimplyConnectedOn (Set.range α.toPath))
+    (hα : endpoint α ∈ U) :
+    ∃ N : Set (BasedPath x₀), IsOpen N ∧ α ∈ N ∧
+      N ⊆ endpoint (x₀ := x₀) ⁻¹' U ∧
+      ∀ β ∈ N, JoinedIn (endpoint (x₀ := x₀) ⁻¹' U) α β := by
+  classical
+  obtain ⟨n, part, T, hα_tube⟩ :=
+    α.toPath.exists_pathHomotopyTrivial_tube hslsc
+  -- Rule out `n = 0`; the rest of the proof assumes `n = n' + 1`.
+  match n, part, T, hα_tube with
+  | 0, part, _, _ => exact isEmptyElim part
+  | n' + 1, part, T, hα_tube =>
+  -- Endpoint of α at the last partition point equals `endpoint α`.
+  have hα_at_last : α.toPath (part.t (Fin.last (n' + 1))) = endpoint α := by
+    rw [part.t_last]; exact α.toPath.target
+  obtain ⟨V_last', hV'_open, hV'_pathConn, hα_V', hV'_sub_V, hV'_sub_U⟩ :=
+    exists_refined_terminal_vertex hU_open α hα part T hα_tube
+  -- Refined V function: `V_last'` at the last partition point, `T.V` elsewhere.
+  set V' : Fin (n' + 2) → Set X :=
+    Fin.snoc (fun j : Fin (n' + 1) ↦ T.V j.castSucc) V_last' with hV'_def
+  have hV'_last_eq : V' (Fin.last (n' + 1)) = V_last' := Fin.snoc_last ..
+  have hV'_castSucc_eq : ∀ j : Fin (n' + 1), V' j.castSucc = T.V j.castSucc := fun j ↦
+    Fin.snoc_castSucc ..
+  have hV'_sub_TV : ∀ j : Fin (n' + 2), V' j ⊆ T.V j := by
+    intro j
+    induction j using Fin.lastCases with
+    | last => rw [hV'_last_eq]; exact hV'_sub_V
+    | cast k => rw [hV'_castSucc_eq]
+  have hV'_open_all : ∀ j, IsOpen (V' j) := by
+    intro j
+    induction j using Fin.lastCases with
+    | last => rw [hV'_last_eq]; exact hV'_open
+    | cast k => rw [hV'_castSucc_eq]; exact T.V_open _
+  have hV'_pathConn_all : ∀ j, IsPathConnected (V' j) := by
+    intro j
+    induction j using Fin.lastCases with
+    | last => rw [hV'_last_eq]; exact hV'_pathConn
+    | cast k => rw [hV'_castSucc_eq]; exact T.V_pathConn _
+  have hα_passes_V' : ∀ j, α.toPath (part.t j) ∈ V' j := by
+    intro j
+    induction j using Fin.lastCases with
+    | last => rw [hV'_last_eq, hα_at_last]; exact hα_V'
+    | cast k => rw [hV'_castSucc_eq]; exact hα_tube.passes_through_V _
+  let T' : TubeData X (n' + 1) := {
+    U := T.U
+    V := V'
+    U_open := T.U_open
+    U_slsc := T.U_slsc
+    V_open := hV'_open_all
+    V_pathConn := hV'_pathConn_all
+    V_left_subset := fun i ↦ (hV'_sub_TV i.castSucc).trans (T.V_left_subset i)
+    V_right_subset := fun i ↦ (hV'_sub_TV i.succ).trans (T.V_right_subset i)
+  }
+  -- The neighborhood `N` of `α`: based paths satisfying the refined tube conditions.
+  set N : Set (BasedPath x₀) := {β : BasedPath x₀ |
+      (∀ (i : Fin (n' + 1)) (s : I),
+          (part.t i.castSucc : ℝ) ≤ s ∧ s ≤ (part.t i.succ : ℝ) → β.1 s ∈ T.U i) ∧
+      (∀ j, β.1 (part.t j) ∈ V' j)} with hN_def
+  refine ⟨N, ?_, ?_, ?_, ?_⟩
+  · simpa [hN_def] using! isOpen_refined_tubeNeighborhood part T.U_open hV'_open_all
+  · -- `α ∈ N`.
+    exact ⟨hα_tube.stays_in_U, hα_passes_V'⟩
+  · -- `N ⊆ endpoint ⁻¹' U`.
+    intro β hβ
+    have h1 : β.1 (part.t (Fin.last (n' + 1))) ∈ V' (Fin.last (n' + 1)) := hβ.2 _
+    rw [hV'_last_eq] at h1
+    exact hV'_sub_U (by simpa [part.t_last] using! h1)
+  · -- Every `β ∈ N` is `JoinedIn (endpoint ⁻¹' U)` to `α`.
+    intro β hβ
+    obtain ⟨hβ_stays, hβ_passes⟩ := hβ
+    -- Endpoint of `β` lies in `U`.
+    have hβ_end_U : endpoint β ∈ U := by
+      have h1 : β.1 (part.t (Fin.last (n' + 1))) ∈ V' (Fin.last (n' + 1)) := hβ_passes _
+      rw [hV'_last_eq] at h1
+      exact hV'_sub_U (by simpa [part.t_last] using! h1)
+    have hβ_tube : PathInTube β.toPath part T' :=
+      ⟨hβ_stays, hβ_passes⟩
+    have hα_tube' : PathInTube α.toPath part T' :=
+      ⟨hα_tube.stays_in_U, hα_passes_V'⟩
+    obtain ⟨ρ_final, hρ_final_range_V, h_paste⟩ :=
+      Path.tube_subset_homotopy_class_source α.toPath part T' hα_tube' β.toPath hβ_tube
+    have hρ_final_range : Set.range ρ_final ⊆ U :=
+      hρ_final_range_V.trans (by
+        -- `T'.V` is defeq to the local family `V'`; expose it so `hV'_last_eq` rewrites.
+        change V' (Fin.last (n' + 1)) ⊆ U
+        rw [hV'_last_eq]
+        exact hV'_sub_U)
+    -- Join `α` to `append α ρ_final`, then deform `append α ρ_final` to `β` via `h_paste`.
+    refine (joinedIn_preimage_of_append α ρ_final hρ_final_range).trans ?_
+    obtain ⟨γ, hγ⟩ :=
+      (joinedIn_endpoint_preimage_of_homotopic (x₀ := x₀) (U := ({endpoint β} : Set X))
+        (show endpoint β ∈ ({endpoint β} : Set X) from rfl)
+        (show Path.Homotopic (α.toPath.trans ρ_final) β.toPath from h_paste)).mono
+        (Set.preimage_mono (Set.singleton_subset_iff.mpr hβ_end_U))
+    exact ⟨γ.cast rfl (by ext t; rfl), hγ⟩
+
+/-- For an open neighborhood `U`, path components of `endpoint ⁻¹' U` are open. -/
+public theorem isOpen_pathComponent_preimage
+    [SemilocallySimplyConnectedSpace X] [LocallyPathConnectedSpace X]
+    {U : Set X} (hU_open : IsOpen U) (α : BasedPath x₀) :
+    IsOpen (pathComponentIn (endpoint (x₀ := x₀) ⁻¹' U) α) := by
+  apply isOpen_iff_mem_nhds.mpr
+  intro β hβ
+  have hβ_end_U : endpoint β ∈ U := hβ.target_mem
+  obtain ⟨N, hN_open, hβ_N, _, hN_joined⟩ :=
+    exists_open_nhd_pathComponent_preimage hU_open
+      β
+      (SemilocallySimplyConnectedOn.of_semilocallySimplyConnectedSpace (Set.range β.toPath))
+      hβ_end_U
+  refine mem_nhds_iff.mpr ⟨N, ?_, hN_open, hβ_N⟩
+  intro γ hγ_N
+  exact hβ.trans (hN_joined γ hγ_N)
+
+section joinedInSLSC
+
+/-! Reparametrisation helpers for
+`toPath_homotopic_of_joinedIn_pathHomotopyTrivial` (private to this section). -/
+
+private def joinedInSLSC_uReal (ts : ℝ × ℝ) : ℝ :=
+  ts.1 + max 0 (2 * ts.2 - 1) * (1 - ts.1)
+
+private def joinedInSLSC_vReal (ts : ℝ × ℝ) : ℝ :=
+  min (2 * ts.2) 1
+
+private theorem joinedInSLSC_uReal_mem (t s : I) :
+    joinedInSLSC_uReal ((t : ℝ), (s : ℝ)) ∈ I := by
+  simp only [joinedInSLSC_uReal]
+  have hm_nn : (0 : ℝ) ≤ max 0 (2 * (s : ℝ) - 1) := le_max_left _ _
+  have hm_le : max 0 (2 * (s : ℝ) - 1) ≤ 1 := max_le zero_le_one (by linarith [s.2.2])
+  refine ⟨?_, ?_⟩
+  · have h0 : 0 ≤ max 0 (2 * (s : ℝ) - 1) * (1 - (t : ℝ)) :=
+      mul_nonneg hm_nn (by linarith [t.2.2])
+    linarith [t.2.1]
+  · nlinarith [t.2.1, t.2.2]
+
+private theorem joinedInSLSC_vReal_mem (t s : I) :
+    joinedInSLSC_vReal ((t : ℝ), (s : ℝ)) ∈ I := by
+  refine ⟨le_min (by linarith [s.2.1]) zero_le_one, min_le_right _ _⟩
+
+private def joinedInSLSC_uFn : I × I → I := fun ts ↦
+  ⟨joinedInSLSC_uReal ((ts.1 : ℝ), (ts.2 : ℝ)), joinedInSLSC_uReal_mem ts.1 ts.2⟩
+
+private def joinedInSLSC_vFn : I × I → I := fun ts ↦
+  ⟨joinedInSLSC_vReal ((ts.1 : ℝ), (ts.2 : ℝ)), joinedInSLSC_vReal_mem ts.1 ts.2⟩
+
+private theorem joinedInSLSC_uFn_zero_left (s : I) :
+    (joinedInSLSC_uFn (0, s) : ℝ) = max 0 (2 * (s : ℝ) - 1) := by
+  simp [joinedInSLSC_uFn, joinedInSLSC_uReal]
+
+private theorem joinedInSLSC_uFn_one_left (s : I) : joinedInSLSC_uFn (1, s) = 1 :=
+  Subtype.ext (by simp [joinedInSLSC_uFn, joinedInSLSC_uReal])
+
+private theorem joinedInSLSC_uFn_one_right (t : I) : joinedInSLSC_uFn (t, 1) = 1 :=
+  Subtype.ext (by simp [joinedInSLSC_uFn, joinedInSLSC_uReal]; ring)
+
+private theorem joinedInSLSC_vFn_left (t s : I) :
+    (joinedInSLSC_vFn (t, s) : ℝ) = min (2 * (s : ℝ)) 1 := by
+  simp [joinedInSLSC_vFn, joinedInSLSC_vReal]
+
+private theorem joinedInSLSC_vFn_zero_right (t : I) : joinedInSLSC_vFn (t, 0) = 0 :=
+  Subtype.ext (by simp [joinedInSLSC_vFn, joinedInSLSC_vReal])
+
+private theorem joinedInSLSC_vFn_one_right (t : I) : joinedInSLSC_vFn (t, 1) = 1 :=
+  Subtype.ext (by simp [joinedInSLSC_vFn, joinedInSLSC_vReal])
+
+private theorem joinedInSLSC_uFn_zero_left_eq_zero_of_le_half {s : I}
+    (hs : (s : ℝ) ≤ 1 / 2) : joinedInSLSC_uFn (0, s) = 0 :=
+  Subtype.ext <| by
+    rw [joinedInSLSC_uFn_zero_left, max_eq_left (by linarith)]; rfl
+
+private theorem joinedInSLSC_uFn_zero_left_eq_two_mul_sub_one_of_half_le
+    {s : I} (hs : 1 / 2 ≤ (s : ℝ)) :
+    joinedInSLSC_uFn (0, s) =
+      ⟨2 * (s : ℝ) - 1,
+        unitInterval.two_mul_sub_one_mem_iff.2 ⟨hs, s.2.2⟩⟩ :=
+  Subtype.ext <| by
+    rw [joinedInSLSC_uFn_zero_left, max_eq_right (by linarith)]
+
+private theorem joinedInSLSC_vFn_eq_two_mul_of_le_half {t s : I}
+    (hs : (s : ℝ) ≤ 1 / 2) :
+    joinedInSLSC_vFn (t, s) =
+      ⟨2 * (s : ℝ),
+        (unitInterval.mul_pos_mem_iff zero_lt_two).2 ⟨s.2.1, hs⟩⟩ :=
+  Subtype.ext <| by rw [joinedInSLSC_vFn_left, min_eq_left (by linarith)]
+
+private theorem joinedInSLSC_vFn_eq_one_of_half_le {t s : I}
+    (hs : 1 / 2 ≤ (s : ℝ)) : joinedInSLSC_vFn (t, s) = 1 :=
+  Subtype.ext <| by
+    rw [joinedInSLSC_vFn_left, min_eq_right (by linarith)]; rfl
+
+end joinedInSLSC
+
+/-- If `α` and `β` are based paths with the same endpoint `v ∈ U`, joined inside
+`endpoint ⁻¹' U`, and `U` has the SLSC uniqueness property, then their associated paths
+`α.toPath` and `β.toPath` are homotopic (after casting to a common endpoint).
+
+This is the heart of the sheet-injectivity argument: a path in the based-path space descends
+to a free homotopy of paths in `X` whose endpoint trace is a loop in `U`, which is killed by
+the SLSC hypothesis. -/
+public theorem toPath_homotopic_of_joinedIn_pathHomotopyTrivial
+    {U : Set X} (hU_slsc : IsPathHomotopyTrivial U)
+    {α β : BasedPath x₀}
+    (heq : endpoint α = endpoint β)
+    (hAB : JoinedIn (endpoint (x₀ := x₀) ⁻¹' U) α β) :
+    Path.Homotopic (α.toPath.cast rfl heq.symm) β.toPath := by
+  obtain ⟨F, hF_U⟩ := hAB
+  set v : X := endpoint β with hv_def
+  -- Uncurry F to get a continuous map (t, s) ↦ (F t).1 s.
+  have hFv_cont : Continuous (fun ts : I × I ↦ (F ts.1).1 ts.2) := by
+    have h1 : Continuous (fun t : I ↦ ((F t).1 : C(I, X))) :=
+      continuous_subtype_val.comp F.continuous
+    exact ContinuousMap.continuous_uncurry_of_continuous ⟨_, h1⟩
+  -- The endpoint-trace loop `L : Path v v`.
+  have hF0_eq : (F (0 : I)).1 = α.1 := congrArg Subtype.val F.source
+  have hF1_eq : (F (1 : I)).1 = β.1 := congrArg Subtype.val F.target
+  have hv : v ∈ U := by
+    simpa [v, hv_def, endpoint_def, hF1_eq] using hF_U 1
+  let L : Path v v :=
+    { toFun := fun t ↦ (F t).1 1
+      continuous_toFun := by
+        simpa using! hFv_cont.comp (continuous_id.prodMk (continuous_const (y := (1 : I))))
+      source' := by rw [hF0_eq]; exact heq
+      target' := by rw [hF1_eq]; rfl }
+  have hL_refl : L.Homotopic (Path.refl v) :=
+    hU_slsc.apply L (Path.refl v) (by rintro _ ⟨t, rfl⟩; exact hF_U t) (by
+      rintro _ ⟨_, rfl⟩; simpa using! hv)
+  -- Cast α.toPath to target `v`.
+  let α' : Path x₀ v := α.toPath.cast rfl heq.symm
+  have hu_cont : Continuous joinedInSLSC_uReal :=
+    (continuous_fst).add <|
+      (Continuous.max continuous_const (by fun_prop)).mul (by fun_prop)
+  have hv_cont_real : Continuous joinedInSLSC_vReal :=
+    Continuous.min (by fun_prop) continuous_const
+  have hu_fn_cont : Continuous joinedInSLSC_uFn :=
+    Continuous.subtype_mk (hu_cont.comp (by fun_prop)) _
+  have hv_fn_cont : Continuous joinedInSLSC_vFn :=
+    Continuous.subtype_mk (hv_cont_real.comp (by fun_prop)) _
+  -- The rectangle homotopy.
+  let K_fn : I × I → X := fun ts ↦ (F (joinedInSLSC_uFn ts)).1 (joinedInSLSC_vFn ts)
+  have K_fn_apply : ∀ ts : I × I, K_fn ts = (F (joinedInSLSC_uFn ts)).1 (joinedInSLSC_vFn ts) :=
+    fun _ ↦ rfl
+  have hK_cont : Continuous K_fn :=
+    hFv_cont.comp (hu_fn_cont.prodMk hv_fn_cont)
+  -- Auxiliary identities evaluating K at corners/edges.
+  have hK_zero : ∀ s : I, K_fn (0, s) = (α'.trans L) s := by
+    intro s
+    rw [K_fn_apply, Path.trans_apply]
+    by_cases hs : (s : ℝ) ≤ 1 / 2
+    · rw [dif_pos hs,
+        joinedInSLSC_uFn_zero_left_eq_zero_of_le_half hs,
+        joinedInSLSC_vFn_eq_two_mul_of_le_half hs, hF0_eq]; rfl
+    · rw [dif_neg hs,
+        joinedInSLSC_uFn_zero_left_eq_two_mul_sub_one_of_half_le (not_le.mp hs).le,
+        joinedInSLSC_vFn_eq_one_of_half_le (not_le.mp hs).le]; rfl
+  have hK_one : ∀ s : I, K_fn (1, s) = (β.toPath.trans (Path.refl v)) s := by
+    intro s
+    rw [K_fn_apply, Path.trans_apply, joinedInSLSC_uFn_one_left]
+    by_cases hs : (s : ℝ) ≤ 1 / 2
+    · rw [dif_pos hs, joinedInSLSC_vFn_eq_two_mul_of_le_half hs, hF1_eq]; rfl
+    · rw [dif_neg hs,
+        joinedInSLSC_vFn_eq_one_of_half_le (not_le.mp hs).le, hF1_eq]; rfl
+  have hK_at_zero : ∀ t : I, K_fn (t, 0) = x₀ := fun t ↦ by
+    rw [K_fn_apply, joinedInSLSC_vFn_zero_right]
+    exact (F (joinedInSLSC_uFn (t, 0))).2
+  have hK_at_one : ∀ t : I, K_fn (t, 1) = v := fun t ↦ by
+    rw [K_fn_apply, joinedInSLSC_uFn_one_right, joinedInSLSC_vFn_one_right, hF1_eq]
+    rfl
+  let K : Path.Homotopy (α'.trans L) (β.toPath.trans (Path.refl v)) :=
+    { toFun := K_fn
+      continuous_toFun := hK_cont
+      map_zero_left := hK_zero
+      map_one_left := hK_one
+      prop' := by
+        intro t s hs
+        rcases hs with rfl | hs
+        -- `prop'` only exposes an edge evaluation goal; name the let-bound `K_fn` form.
+        · change K_fn (t, (0 : I)) = (α'.trans L) 0
+          rw [hK_at_zero, (α'.trans L).source]
+        · rw [Set.mem_singleton_iff] at hs
+          subst hs
+          -- `prop'` only exposes an edge evaluation goal; name the let-bound `K_fn` form.
+          change K_fn (t, (1 : I)) = (α'.trans L) 1
+          rw [hK_at_one, (α'.trans L).target] }
+  have h_rect : (α'.trans L).Homotopic (β.toPath.trans (Path.refl v)) := ⟨K⟩
+  -- Combine: α' ≃ α'.trans (refl v) ≃ α'.trans L ≃ β.trans (refl v) ≃ β.
+  have h_α_trans_refl : (α'.trans (Path.refl v)).Homotopic α' := Path.Homotopic.trans_refl α'
+  have h_α_L_refl : (α'.trans (Path.refl v)).Homotopic (α'.trans L) :=
+    Path.Homotopic.hcomp (Path.Homotopic.refl α') hL_refl.symm
+  have h_β_trans_refl : (β.toPath.trans (Path.refl v)).Homotopic β.toPath :=
+    Path.Homotopic.trans_refl β.toPath
+  exact h_α_trans_refl.symm.trans <| h_α_L_refl.trans <| h_rect.trans h_β_trans_refl
+
+/-- Path components of `endpoint ⁻¹' U` are invariant under endpoint-preserving homotopy:
+if `p ≃ q` are homotopic paths from `x₀` to `y ∈ U`, then the based paths `ofPath p` and
+`ofPath q` lie in the same path component of `endpoint ⁻¹' U`. -/
+public theorem pathComponent_preimage_saturated
+    {U : Set X} {y : X} (hy : y ∈ U)
+    {p q : Path x₀ y} (h : Path.Homotopic p q) :
+    pathComponentIn (endpoint (x₀ := x₀) ⁻¹' U) (ofPath p) =
+      pathComponentIn (endpoint (x₀ := x₀) ⁻¹' U) (ofPath q) :=
+  pathComponentIn_congr (joinedIn_endpoint_preimage_of_homotopic x₀ hy h).symm
+
+end BasedPath

--- a/TauCeti/AlgebraicTopology/UniversalCover/BasedPath.lean
+++ b/TauCeti/AlgebraicTopology/UniversalCover/BasedPath.lean
@@ -513,7 +513,7 @@ In a locally path-connected space, if semilocal simple connectivity holds along 
 `α : BasedPath x₀` has endpoint in an open set `U`, then `α` has an open neighborhood `N` in
 `BasedPath x₀` such that every element of `N` has endpoint in `U` and lies in the same path
 component of `endpoint ⁻¹' U` as `α`. -/
-public theorem exists_open_nhd_pathComponent_preimage
+public theorem exists_open_nhds_pathComponent_preimage
     [LocallyPathConnectedSpace X] {U : Set X} (hU_open : IsOpen U)
     (α : BasedPath x₀) (hslsc : SemilocallySimplyConnectedOn (Set.range α.toPath))
     (hα : endpoint α ∈ U) :
@@ -620,7 +620,7 @@ public theorem isOpen_pathComponent_preimage
   intro β hβ
   have hβ_end_U : endpoint β ∈ U := hβ.target_mem
   obtain ⟨N, hN_open, hβ_N, _, hN_joined⟩ :=
-    exists_open_nhd_pathComponent_preimage hU_open
+    exists_open_nhds_pathComponent_preimage hU_open
       β
       (SemilocallySimplyConnectedOn.of_semilocallySimplyConnectedSpace (Set.range β.toPath))
       hβ_end_U

--- a/TauCeti/AlgebraicTopology/UniversalCover/PathHomotopyDiscreteness.lean
+++ b/TauCeti/AlgebraicTopology/UniversalCover/PathHomotopyDiscreteness.lean
@@ -46,8 +46,12 @@ namespace IntervalPartition
 attribute [simp, grind =] t_zero t_last
 
 /-- `IntervalPartition 0` is empty: a single partition point cannot be simultaneously
-`0` and `1`. -/
-instance : IsEmpty (IntervalPartition 0) where
+`0` and `1`.
+
+`public` because the based-path openness argument in
+`TauCeti.AlgebraicTopology.UniversalCover.BasedPath` rules out the `n = 0` tube by
+`isEmptyElim` on the partition. -/
+public instance : IsEmpty (IntervalPartition 0) where
   false part := by
     have h0 : part.t 0 = 0 := part.t_zero
     have h1 : part.t 0 = 1 := part.t_last
@@ -80,8 +84,13 @@ public structure TubeData (X : Type*) [TopologicalSpace X] (n : ℕ) : Type _ wh
 /-- A path γ is in the tube defined by partition `part` and tube data T.
 This means:
 1. γ stays in the segment neighborhoods U[i] on each interval [t[i], t[i+1]]
-2. γ passes through the point neighborhoods V[j] at ALL partition points -/
-structure PathInTube {X : Type*} [TopologicalSpace X] {x y : X} {n : ℕ}
+2. γ passes through the point neighborhoods V[j] at ALL partition points
+
+`public` because the variable-endpoint based-path openness argument in
+`TauCeti.AlgebraicTopology.UniversalCover.BasedPath` builds and destructures tube membership
+directly (it refines the terminal vertex neighborhood before appealing to
+`Path.tube_subset_homotopy_class_source`); it is not otherwise part of the reusable API. -/
+public structure PathInTube {X : Type*} [TopologicalSpace X] {x y : X} {n : ℕ}
     (γ : Path x y) (part : IntervalPartition n) (T : TubeData X n) : Prop where
   /-- γ stays in the segment neighborhoods U[i] on each interval [t[i], t[i+1]] -/
   stays_in_U : ∀ i (s : unitInterval),
@@ -191,8 +200,11 @@ private theorem Path.exists_vertexNeighborhood_family [LocallyPathConnectedSpace
     exact hV_right i.succ i rfl
 
 /-- If `X` is locally path-connected and SLSC along the range of `γ`, then `γ` lies in a
-path-homotopy-trivial tube. -/
-theorem Path.exists_pathHomotopyTrivial_tube
+path-homotopy-trivial tube.
+
+`public` because `TauCeti.AlgebraicTopology.UniversalCover.BasedPath` consumes the tube (partition
+and tube data) around a based path to build an open endpoint-preimage neighborhood. -/
+public theorem Path.exists_pathHomotopyTrivial_tube
     [LocallyPathConnectedSpace X] {x y : X}
     (γ : Path x y) (hslsc : SemilocallySimplyConnectedOn (Set.range γ)) :
     ∃ (n : ℕ) (part : IntervalPartition n) (T : TubeData X n), PathInTube γ part T := by
@@ -530,8 +542,12 @@ theorem Path.paste_segment_homotopies_pathHomotopyTrivial_source {x y y' : X} {n
   exact h_paste.trans <| Path.Homotopic.trans_left_of_nullhomotopic h_α₀_null
 
 /-- Variable-endpoint tube theorem: paths in the same tube as `γ` are homotopic to `γ`
-followed by the final endpoint rung. -/
-theorem Path.tube_subset_homotopy_class_source {x y y' : X} {n : ℕ}
+followed by the final endpoint rung.
+
+`public` because `TauCeti.AlgebraicTopology.UniversalCover.BasedPath` uses exactly this
+variable-endpoint statement to move between based paths with distinct endpoints inside a common
+path component of `endpoint ⁻¹' U`; the fixed-endpoint public API does not suffice there. -/
+public theorem Path.tube_subset_homotopy_class_source {x y y' : X} {n : ℕ}
     (γ : Path x y) (part : IntervalPartition n) (T : TubeData X n)
     (hγ : PathInTube γ part T)
     (γ' : Path x y') (hγ' : PathInTube γ' part T) :

--- a/TauCeti/Topology/Homotopy/Path.lean
+++ b/TauCeti/Topology/Homotopy/Path.lean
@@ -51,6 +51,48 @@ theorem map_codRestrict {s : Set X} {x y : s} (γ : Path x.val y.val)
   ext t
   simp
 
+/-- If the extended path stays inside `U` throughout `[t₀, t₁]`, then the truncated subpath has
+range in `U`. -/
+theorem truncateOfLE_range_subset_preimage {a b : X} (γ : Path a b) {t₀ t₁ : ℝ}
+    (h : t₀ ≤ t₁) {U : Set X} (hU : Set.Icc t₀ t₁ ⊆ γ.extend ⁻¹' U) :
+    Set.range (γ.truncateOfLE h) ⊆ U := by
+  rintro _ ⟨s, rfl⟩
+  dsimp [truncateOfLE, truncate]
+  apply hU
+  constructor
+  · exact le_min (le_max_right _ _) h
+  · exact min_le_right _ _
+
+/-- The family of initial segments of `γ : Path a b`: at parameter `t : I`, the path
+`s ↦ γ.extend (min s t)` from `a` to `γ t` (`initialSegmentFamily_apply`). At `t = 0` this is
+the constant path at `a` (`initialSegmentFamily_zero`); at `t = 1` it is `γ` itself, up to a
+trivial right-endpoint cast (`initialSegmentFamily_one`). The property consumers actually need
+is joint continuity in `(t, s)`, recorded as `continuous_initialSegmentFamily_uncurry`. -/
+noncomputable def initialSegmentFamily {a b : X} (γ : Path a b) (t : I) :
+    Path a (γ t) :=
+  (γ.truncate 0 t).cast (by rw [min_eq_left t.2.1, γ.extend_zero]) (γ.extend_apply t.2).symm
+
+theorem continuous_initialSegmentFamily_uncurry {a b : X} (γ : Path a b) :
+    Continuous ↿(initialSegmentFamily γ) := by
+  have hincl : Continuous (fun ts : I × I ↦ ((ts.1 : ℝ), ts.2) : I × I → ℝ × I) := by fun_prop
+  have htrunc : Continuous (fun ts : I × I ↦ γ.truncate 0 ts.1 ts.2 : I × I → X) :=
+    (γ.truncate_const_continuous_family 0).comp hincl
+  simpa [initialSegmentFamily] using! htrunc
+
+@[simp] private theorem initialSegmentFamily_apply {a b : X} (γ : Path a b) (t s : I) :
+    initialSegmentFamily γ t s = γ.extend (min (s : ℝ) t) := by
+  simp [initialSegmentFamily, Path.truncate, max_eq_left s.2.1]
+
+@[simp] theorem initialSegmentFamily_zero {a b : X} (γ : Path a b) :
+    initialSegmentFamily γ 0 = (Path.refl a).cast rfl (by simp) := by
+  ext s
+  simp [initialSegmentFamily_apply, γ.extend_zero, Path.refl, min_eq_right s.2.1]
+
+@[simp] theorem initialSegmentFamily_one {a b : X} (γ : Path a b) :
+    initialSegmentFamily γ 1 = γ.cast rfl (by simp) := by
+  ext s
+  simp [initialSegmentFamily_apply, min_eq_left s.2.2, γ.extend_apply s.2]
+
 end Path
 
 namespace Path

--- a/TauCeti/Topology/Homotopy/Path.lean
+++ b/TauCeti/Topology/Homotopy/Path.lean
@@ -53,7 +53,7 @@ theorem map_codRestrict {s : Set X} {x y : s} (γ : Path x.val y.val)
 
 /-- If the extended path stays inside `U` throughout `[t₀, t₁]`, then the truncated subpath has
 range in `U`. -/
-theorem truncateOfLE_range_subset_preimage {a b : X} (γ : Path a b) {t₀ t₁ : ℝ}
+theorem truncateOfLE_range_subset {a b : X} (γ : Path a b) {t₀ t₁ : ℝ}
     (h : t₀ ≤ t₁) {U : Set X} (hU : Set.Icc t₀ t₁ ⊆ γ.extend ⁻¹' U) :
     Set.range (γ.truncateOfLE h) ⊆ U := by
   rintro _ ⟨s, rfl⟩


### PR DESCRIPTION
This PR ports the compact-open based-path space from [leanprover-community/mathlib4#38292](https://github.com/leanprover-community/mathlib4/pull/38292): it adds `BasedPath x₀` (continuous based paths out of `x₀`), the `endpoint` map and its openness for locally path-connected `X`, and the path-component machinery of `endpoint ⁻¹' U` — culminating in `BasedPath.isOpen_pathComponent_preimage` (path components of `endpoint ⁻¹' U` are open under semilocal simple connectivity) and `pathComponent_preimage_saturated` (those components are invariant under endpoint-preserving homotopy). This is the second half of the split of [#814](https://github.com/TauCetiProject/TauCeti/pull/814), whose first half — discreteness of the homotopy-class fibres — landed as [#990](https://github.com/TauCetiProject/TauCeti/pull/990).

It advances [TauCetiRoadmap/UniversalCovers/README.md](https://github.com/TauCetiProject/TauCetiRoadmap/blob/main/TauCetiRoadmap/UniversalCovers/README.md) Stage 0 item 0.2, "the based-path space and the cover", specifically its first sub-bullet: `BasedPath x₀` and the path-component machinery of `endpoint ⁻¹' U`.

The variable-endpoint openness argument consumes tube data that #990's review had left module-private. Rather than re-publicizing the scaffold wholesale, this PR makes public only the four declarations `BasedPath` actually needs — the `PathInTube` predicate, the `IsEmpty (IntervalPartition 0)` instance, `Path.exists_pathHomotopyTrivial_tube`, and the variable-endpoint `Path.tube_subset_homotopy_class_source` — each with a docstring justifying the exposure. The fixed-endpoint public API (`Path.isOpen_setOf_homotopic`) does not suffice here, since neighbouring based paths have distinct endpoints joined by a terminal rung.

Full `lake build` completes successfully (5145 jobs); `lake exe axioms` audits 10161 declarations, all within the allowlist `[propext, Classical.choice, Quot.sound]`; `lake exe module-system` confirms all 550 modules opt into the module system.

<!--tauceti-target:v1 {"focus":"UniversalCovers","id":"stage0-based-path"}-->

🤖 Prepared with Claude Code
