### PR TITLE
Namespace card_nonempty_finset

### DIFF
--- a/TauCeti/Data/Finset/Basic.lean
+++ b/TauCeti/Data/Finset/Basic.lean
@@ -15,6 +15,8 @@ This file records the count of nonempty finsets of a finite type.
 
 public section
 
+namespace TauCeti
+
 /-- **The number of nonempty subsets of a finite type is `2ⁿ - 1`.** The `2ⁿ` subsets of an
 `n`-element type are the nonempty ones together with the empty set, so the nonempty ones number
 `2ⁿ - 1`. -/
@@ -28,3 +30,5 @@ theorem card_nonempty_finset {ι : Type*} [Finite ι] :
     rw [Finset.filter_ne', Finset.card_erase_of_mem (Finset.mem_univ _), Finset.card_univ,
       Fintype.card_finset]
   rw [Nat.card_eq_fintype_card, Nat.card_eq_fintype_card, h]
+
+end TauCeti


### PR DESCRIPTION
## What changed

Moves `card_nonempty_finset` into the `TauCeti` namespace.

## Why

The generic theorem was unintentionally declared in the root namespace, creating avoidable collision risk with Mathlib and downstream libraries. Its existing consumer already lives in the `TauCeti` namespace, so no call-site change is needed.

## Impact

The public name becomes `TauCeti.card_nonempty_finset`; unqualified use inside `TauCeti` continues to work.

## Validation

- `lake build TauCeti.Data.Finset.Basic TauCeti.NumberTheory.Multiquadratic.SubfieldClassification`
- `git diff --check`
