### PR TITLE
feat: higher homotopy groups are homeomorphism invariants

### DIFF
--- a/TauCeti/Topology/Homotopy/HomotopyGroup/Homeomorph.lean
+++ b/TauCeti/Topology/Homotopy/HomotopyGroup/Homeomorph.lean
@@ -1,0 +1,158 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+module
+
+public import Mathlib.Topology.Homeomorph.Defs
+public import TauCeti.Topology.Homotopy.HomotopyGroup.Map
+
+/-!
+# Higher homotopy groups are homeomorphism invariants
+
+The functoriality API in `TauCeti.Topology.Homotopy.HomotopyGroup.Map` records the map
+`HomotopyGroup.map` on homotopy classes induced by a based continuous map (a monoid
+homomorphism `HomotopyGroup.mapHom` in positive dimensions), but it stops short of packaging a
+homeomorphism as an *isomorphism* of homotopy groups. This file supplies that: a homeomorphism
+`e : X ≃ₜ Y` induces an equivalence `π_N(X, x) ≃ π_N(Y, e x)` in every dimension, and a group
+isomorphism `π_N(X, x) ≃* π_N(Y, e x)` in positive dimensions, and more generally the versions
+sending `x` to any `y` with `e x = y`.
+
+The forward map is `HomotopyGroup.map` of `e`; the inverse is `HomotopyGroup.map` of `e.symm`.
+The two round trips come from the composition law `map_comp_apply` (the induced maps of two
+continuous maps compose to the induced map of their composite) applied to `e.symm ∘ e = id` and
+`e ∘ e.symm = id`, together with `map_id_apply` (the induced map of the identity is the
+identity) and `map_congr` (the induced map depends only on the underlying continuous map, not on
+the chosen proof of the basepoint equation); `map_congr` is proved once here and is useful on its
+own. Multiplicativity in positive dimensions is `map_mul`.
+
+Transporting a homotopy-group computation across a homeomorphism is the dimension-`N` analogue of
+`TauCeti.FundamentalGroup.homeomorphMulEquiv`, and is part of the higher-homotopy-group API the
+universal-covers roadmap asks for in Stage 3 item 9 (`TauCetiRoadmap/UniversalCovers/README.md`),
+before proving that a covering map induces isomorphisms on `π_n` for `n ≥ 2`.
+
+## Main declarations
+
+* `TauCeti.HomotopyGroup.map_congr`: `map f₁ h₁ a = map f₂ h₂ a` when `f₁ = f₂`.
+* `TauCeti.HomotopyGroup.homeomorphEquivOfEq`: `π_N(X, x) ≃ π_N(Y, y)` from `e : X ≃ₜ Y` with
+  `e x = y`.
+* `TauCeti.HomotopyGroup.homeomorphEquiv`: `π_N(X, x) ≃ π_N(Y, e x)`.
+* `TauCeti.HomotopyGroup.homeomorphMulEquivOfEq`: the positive-dimensional group isomorphism
+  `π_N(X, x) ≃* π_N(Y, y)`.
+* `TauCeti.HomotopyGroup.homeomorphMulEquiv`: `π_N(X, x) ≃* π_N(Y, e x)`.
+-/
+
+public section
+
+namespace TauCeti
+
+namespace HomotopyGroup
+
+variable {N X Y Z : Type*} [TopologicalSpace X] [TopologicalSpace Y] [TopologicalSpace Z]
+variable {x : X} {y : Y}
+
+/-- The induced map `HomotopyGroup.map` depends only on the underlying continuous map, not on the
+chosen proof of the basepoint equation: two equal continuous maps induce the same map on homotopy
+classes. -/
+theorem map_congr {f₁ f₂ : C(X, Y)} (hfe : f₁ = f₂) (h₁ : f₁ x = y) (h₂ : f₂ x = y)
+    (a : HomotopyGroup N X x) :
+    map f₁ h₁ a = map f₂ h₂ a := by
+  subst hfe
+  rfl
+
+/-- If `g ∘ f` is the identity, then the induced map of `g` undoes the induced map of `f` on
+homotopy classes. -/
+theorem map_map_of_comp_eq_id (g : C(Y, X)) (f : C(X, Y)) (hf : f x = y) (hg : g y = x)
+    (hgf : g.comp f = ContinuousMap.id X) (a : HomotopyGroup N X x) :
+    map g hg (map f hf a) = a := by
+  rw [map_comp_apply]
+  exact (map_congr hgf _ rfl a).trans (map_id_apply a)
+
+/-- A homeomorphism `e : X ≃ₜ Y` carrying `x` to `y` induces an equivalence of homotopy groups
+`π_N(X, x) ≃ π_N(Y, y)`. The forward map is `HomotopyGroup.map` of `e`; the inverse is
+`HomotopyGroup.map` of `e.symm`. This holds in every dimension `N`. -/
+@[expose] noncomputable def homeomorphEquivOfEq (e : X ≃ₜ Y) (h : e x = y) :
+    HomotopyGroup N X x ≃ HomotopyGroup N Y y where
+  toFun := map ⟨e, e.continuous⟩ h
+  invFun := map ⟨e.symm, e.symm.continuous⟩ (show e.symm y = x by rw [← h, e.symm_apply_apply])
+  left_inv a :=
+    map_map_of_comp_eq_id ⟨e.symm, e.symm.continuous⟩ ⟨e, e.continuous⟩ h
+      (show e.symm y = x by rw [← h, e.symm_apply_apply])
+      (ContinuousMap.ext fun t => e.symm_apply_apply t) a
+  right_inv b :=
+    map_map_of_comp_eq_id ⟨e, e.continuous⟩ ⟨e.symm, e.symm.continuous⟩
+      (show e.symm y = x by rw [← h, e.symm_apply_apply]) h
+      (ContinuousMap.ext fun t => e.apply_symm_apply t) b
+
+@[simp]
+theorem homeomorphEquivOfEq_apply (e : X ≃ₜ Y) (h : e x = y) (a : HomotopyGroup N X x) :
+    homeomorphEquivOfEq e h a = map ⟨e, e.continuous⟩ h a :=
+  rfl
+
+@[simp]
+theorem homeomorphEquivOfEq_symm_apply (e : X ≃ₜ Y) (h : e x = y) (b : HomotopyGroup N Y y) :
+    (homeomorphEquivOfEq e h).symm b =
+      map ⟨e.symm, e.symm.continuous⟩ (show e.symm y = x by rw [← h, e.symm_apply_apply]) b :=
+  rfl
+
+/-- A homeomorphism `e : X ≃ₜ Y` induces an equivalence of homotopy groups
+`π_N(X, x) ≃ π_N(Y, e x)`, in every dimension `N`. -/
+@[expose] noncomputable def homeomorphEquiv (e : X ≃ₜ Y) (x : X) :
+    HomotopyGroup N X x ≃ HomotopyGroup N Y (e x) :=
+  homeomorphEquivOfEq e rfl
+
+@[simp]
+theorem homeomorphEquiv_apply (e : X ≃ₜ Y) (x : X) (a : HomotopyGroup N X x) :
+    homeomorphEquiv e x a = map ⟨e, e.continuous⟩ rfl a :=
+  rfl
+
+@[simp]
+theorem homeomorphEquiv_symm_apply (e : X ≃ₜ Y) (x : X) (b : HomotopyGroup N Y (e x)) :
+    (homeomorphEquiv e x).symm b =
+      map ⟨e.symm, e.symm.continuous⟩ (e.symm_apply_apply x) b :=
+  rfl
+
+/-- A homeomorphism `e : X ≃ₜ Y` carrying `x` to `y` induces an isomorphism of homotopy groups
+`π_N(X, x) ≃* π_N(Y, y)` in positive dimensions. The underlying equivalence is
+`homeomorphEquivOfEq`; multiplicativity is `HomotopyGroup.map_mul`. -/
+@[expose] noncomputable def homeomorphMulEquivOfEq [DecidableEq N] [Nonempty N]
+    (e : X ≃ₜ Y) (h : e x = y) :
+    HomotopyGroup N X x ≃* HomotopyGroup N Y y :=
+  { homeomorphEquivOfEq e h with
+    map_mul' := map_mul ⟨e, e.continuous⟩ h }
+
+@[simp]
+theorem homeomorphMulEquivOfEq_apply [DecidableEq N] [Nonempty N] (e : X ≃ₜ Y) (h : e x = y)
+    (a : HomotopyGroup N X x) :
+    homeomorphMulEquivOfEq e h a = map ⟨e, e.continuous⟩ h a :=
+  rfl
+
+@[simp]
+theorem homeomorphMulEquivOfEq_symm_apply [DecidableEq N] [Nonempty N] (e : X ≃ₜ Y) (h : e x = y)
+    (b : HomotopyGroup N Y y) :
+    (homeomorphMulEquivOfEq e h).symm b =
+      map ⟨e.symm, e.symm.continuous⟩ (show e.symm y = x by rw [← h, e.symm_apply_apply]) b :=
+  rfl
+
+/-- A homeomorphism `e : X ≃ₜ Y` induces an isomorphism of homotopy groups
+`π_N(X, x) ≃* π_N(Y, e x)` in positive dimensions. -/
+@[expose] noncomputable def homeomorphMulEquiv [DecidableEq N] [Nonempty N] (e : X ≃ₜ Y) (x : X) :
+    HomotopyGroup N X x ≃* HomotopyGroup N Y (e x) :=
+  homeomorphMulEquivOfEq e rfl
+
+@[simp]
+theorem homeomorphMulEquiv_apply [DecidableEq N] [Nonempty N] (e : X ≃ₜ Y) (x : X)
+    (a : HomotopyGroup N X x) :
+    homeomorphMulEquiv e x a = map ⟨e, e.continuous⟩ rfl a :=
+  rfl
+
+@[simp]
+theorem homeomorphMulEquiv_symm_apply [DecidableEq N] [Nonempty N] (e : X ≃ₜ Y) (x : X)
+    (b : HomotopyGroup N Y (e x)) :
+    (homeomorphMulEquiv e x).symm b =
+      map ⟨e.symm, e.symm.continuous⟩ (e.symm_apply_apply x) b :=
+  rfl
+
+end HomotopyGroup
+
+end TauCeti

--- a/TauCeti/Topology/Homotopy/HomotopyGroup/Homeomorph.lean
+++ b/TauCeti/Topology/Homotopy/HomotopyGroup/Homeomorph.lean
@@ -18,13 +18,8 @@ homeomorphism as an *isomorphism* of homotopy groups. This file supplies that: a
 isomorphism `π_N(X, x) ≃* π_N(Y, e x)` in positive dimensions, and more generally the versions
 sending `x` to any `y` with `e x = y`.
 
-The forward map is `HomotopyGroup.map` of `e`; the inverse is `HomotopyGroup.map` of `e.symm`.
-The two round trips come from the composition law `map_comp_apply` (the induced maps of two
-continuous maps compose to the induced map of their composite) applied to `e.symm ∘ e = id` and
-`e ∘ e.symm = id`, together with `map_id_apply` (the induced map of the identity is the
-identity) and `map_congr` (the induced map depends only on the underlying continuous map, not on
-the chosen proof of the basepoint equation); `map_congr` is proved once here and is useful on its
-own. Multiplicativity in positive dimensions is `map_mul`.
+The forward and inverse application lemmas characterize these equivalences as
+`HomotopyGroup.map` for `e` and `e.symm`, respectively.
 
 Transporting a homotopy-group computation across a homeomorphism is the dimension-`N` analogue of
 `TauCeti.FundamentalGroup.homeomorphMulEquiv`, and is part of the higher-homotopy-group API the
@@ -33,7 +28,6 @@ before proving that a covering map induces isomorphisms on `π_n` for `n ≥ 2`.
 
 ## Main declarations
 
-* `TauCeti.HomotopyGroup.map_congr`: `map f₁ h₁ a = map f₂ h₂ a` when `f₁ = f₂`.
 * `TauCeti.HomotopyGroup.homeomorphEquivOfEq`: `π_N(X, x) ≃ π_N(Y, y)` from `e : X ≃ₜ Y` with
   `e x = y`.
 * `TauCeti.HomotopyGroup.homeomorphEquiv`: `π_N(X, x) ≃ π_N(Y, e x)`.
@@ -51,37 +45,20 @@ namespace HomotopyGroup
 variable {N X Y Z : Type*} [TopologicalSpace X] [TopologicalSpace Y] [TopologicalSpace Z]
 variable {x : X} {y : Y}
 
-/-- The induced map `HomotopyGroup.map` depends only on the underlying continuous map, not on the
-chosen proof of the basepoint equation: two equal continuous maps induce the same map on homotopy
-classes. -/
-theorem map_congr {f₁ f₂ : C(X, Y)} (hfe : f₁ = f₂) (h₁ : f₁ x = y) (h₂ : f₂ x = y)
-    (a : HomotopyGroup N X x) :
-    map f₁ h₁ a = map f₂ h₂ a := by
-  subst hfe
-  rfl
-
-/-- If `g ∘ f` is the identity, then the induced map of `g` undoes the induced map of `f` on
-homotopy classes. -/
-theorem map_map_of_comp_eq_id (g : C(Y, X)) (f : C(X, Y)) (hf : f x = y) (hg : g y = x)
-    (hgf : g.comp f = ContinuousMap.id X) (a : HomotopyGroup N X x) :
-    map g hg (map f hf a) = a := by
-  rw [map_comp_apply]
-  exact (map_congr hgf _ rfl a).trans (map_id_apply a)
-
 /-- A homeomorphism `e : X ≃ₜ Y` carrying `x` to `y` induces an equivalence of homotopy groups
 `π_N(X, x) ≃ π_N(Y, y)`. The forward map is `HomotopyGroup.map` of `e`; the inverse is
 `HomotopyGroup.map` of `e.symm`. This holds in every dimension `N`. -/
 @[expose] noncomputable def homeomorphEquivOfEq (e : X ≃ₜ Y) (h : e x = y) :
     HomotopyGroup N X x ≃ HomotopyGroup N Y y where
   toFun := map ⟨e, e.continuous⟩ h
-  invFun := map ⟨e.symm, e.symm.continuous⟩ (show e.symm y = x by rw [← h, e.symm_apply_apply])
+  invFun := map ⟨e.symm, e.symm.continuous⟩ (e.symm_apply_eq.mpr h.symm)
   left_inv a :=
     map_map_of_comp_eq_id ⟨e.symm, e.symm.continuous⟩ ⟨e, e.continuous⟩ h
-      (show e.symm y = x by rw [← h, e.symm_apply_apply])
+      (e.symm_apply_eq.mpr h.symm)
       (ContinuousMap.ext fun t => e.symm_apply_apply t) a
   right_inv b :=
     map_map_of_comp_eq_id ⟨e, e.continuous⟩ ⟨e.symm, e.symm.continuous⟩
-      (show e.symm y = x by rw [← h, e.symm_apply_apply]) h
+      (e.symm_apply_eq.mpr h.symm) h
       (ContinuousMap.ext fun t => e.apply_symm_apply t) b
 
 @[simp]
@@ -92,7 +69,7 @@ theorem homeomorphEquivOfEq_apply (e : X ≃ₜ Y) (h : e x = y) (a : HomotopyGr
 @[simp]
 theorem homeomorphEquivOfEq_symm_apply (e : X ≃ₜ Y) (h : e x = y) (b : HomotopyGroup N Y y) :
     (homeomorphEquivOfEq e h).symm b =
-      map ⟨e.symm, e.symm.continuous⟩ (show e.symm y = x by rw [← h, e.symm_apply_apply]) b :=
+      map ⟨e.symm, e.symm.continuous⟩ (e.symm_apply_eq.mpr h.symm) b :=
   rfl
 
 /-- A homeomorphism `e : X ≃ₜ Y` induces an equivalence of homotopy groups
@@ -113,8 +90,7 @@ theorem homeomorphEquiv_symm_apply (e : X ≃ₜ Y) (x : X) (b : HomotopyGroup N
   rfl
 
 /-- A homeomorphism `e : X ≃ₜ Y` carrying `x` to `y` induces an isomorphism of homotopy groups
-`π_N(X, x) ≃* π_N(Y, y)` in positive dimensions. The underlying equivalence is
-`homeomorphEquivOfEq`; multiplicativity is `HomotopyGroup.map_mul`. -/
+`π_N(X, x) ≃* π_N(Y, y)` in positive dimensions. -/
 @[expose] noncomputable def homeomorphMulEquivOfEq [DecidableEq N] [Nonempty N]
     (e : X ≃ₜ Y) (h : e x = y) :
     HomotopyGroup N X x ≃* HomotopyGroup N Y y :=
@@ -131,7 +107,7 @@ theorem homeomorphMulEquivOfEq_apply [DecidableEq N] [Nonempty N] (e : X ≃ₜ 
 theorem homeomorphMulEquivOfEq_symm_apply [DecidableEq N] [Nonempty N] (e : X ≃ₜ Y) (h : e x = y)
     (b : HomotopyGroup N Y y) :
     (homeomorphMulEquivOfEq e h).symm b =
-      map ⟨e.symm, e.symm.continuous⟩ (show e.symm y = x by rw [← h, e.symm_apply_apply]) b :=
+      map ⟨e.symm, e.symm.continuous⟩ (e.symm_apply_eq.mpr h.symm) b :=
   rfl
 
 /-- A homeomorphism `e : X ≃ₜ Y` induces an isomorphism of homotopy groups

--- a/TauCeti/Topology/Homotopy/HomotopyGroup/Homeomorph.lean
+++ b/TauCeti/Topology/Homotopy/HomotopyGroup/Homeomorph.lean
@@ -4,7 +4,6 @@ Released under Apache 2.0 license as described in the file LICENSE.
 -/
 module
 
-public import Mathlib.Topology.Homeomorph.Defs
 public import TauCeti.Topology.Homotopy.HomotopyGroup.Map
 
 /-!

--- a/TauCeti/Topology/Homotopy/HomotopyGroup/Map.lean
+++ b/TauCeti/Topology/Homotopy/HomotopyGroup/Map.lean
@@ -126,6 +126,22 @@ theorem map_comp_apply (g : C(Y, Z)) (hg : g y = z) (f : C(X, Y)) (hf : f x = y)
   intro p
   simp
 
+/-- The induced map `HomotopyGroup.map` depends only on the underlying continuous map, not on the
+chosen proof of the basepoint equation. -/
+theorem map_congr {f₁ f₂ : C(X, Y)} (hfe : f₁ = f₂) (h₁ : f₁ x = y) (h₂ : f₂ x = y)
+    (a : HomotopyGroup N X x) :
+    map f₁ h₁ a = map f₂ h₂ a := by
+  subst hfe
+  rfl
+
+/-- If `g ∘ f` is the identity, then the induced map of `g` undoes the induced map of `f` on
+homotopy classes. -/
+theorem map_map_of_comp_eq_id (g : C(Y, X)) (f : C(X, Y)) (hf : f x = y) (hg : g y = x)
+    (hgf : g.comp f = ContinuousMap.id X) (a : HomotopyGroup N X x) :
+    map g hg (map f hf a) = a := by
+  rw [map_comp_apply]
+  exact (map_congr hgf _ rfl a).trans (map_id_apply a)
+
 /-- In positive dimensions, the map induced by a based continuous map is a monoid
 homomorphism for the standard group structure on homotopy groups. -/
 @[expose] def mapHom [DecidableEq N] [Nonempty N] (f : C(X, Y)) (hf : f x = y) :


### PR DESCRIPTION
This PR packages a homeomorphism as an isomorphism of higher homotopy groups: for `e : X ≃ₜ Y`, it constructs an equivalence `π_N(X, x) ≃ π_N(Y, e x)` in every dimension `N`, and a group isomorphism `π_N(X, x) ≃* π_N(Y, e x)` in positive dimensions, together with the versions carrying `x` to any `y` with `e x = y`. The forward map is `HomotopyGroup.map` of `e` and the inverse is `HomotopyGroup.map` of `e.symm`; the round trips come from the composition and identity laws in the existing functoriality API, and multiplicativity in positive dimensions is `HomotopyGroup.map_mul`. Along the way it adds `HomotopyGroup.map_congr` (the induced map depends only on the underlying continuous map, not on the chosen proof of the basepoint equation), which is useful on its own.

This realises part of the higher-homotopy-group API the universal-covers roadmap asks for in Stage 3 item 9 (`TauCetiRoadmap/UniversalCovers/README.md`: "functoriality (`π_n` of a continuous map) ... and basepoint-change isomorphisms"), the prerequisite for proving that a covering map induces isomorphisms on `π_n` for `n ≥ 2`. It is the dimension-`N` analogue of `TauCeti.FundamentalGroup.homeomorphMulEquiv`, and builds directly on `TauCeti.Topology.Homotopy.HomotopyGroup.Map` (functoriality of homotopy groups) with Mathlib's `HomotopyGroup` and homeomorphism API.

<!--tauceti-target:v1 {"focus":"UniversalCovers","id":"homotopy-group-homeomorph-invariant"}-->

🤖 Prepared with Claude Code
