### PR TITLE
feat: add the Chebyshev polynomial basis

### DIFF
--- a/TauCeti/RingTheory/Polynomial/Chebyshev/Basis.lean
+++ b/TauCeti/RingTheory/Polynomial/Chebyshev/Basis.lean
@@ -10,37 +10,29 @@ public import Mathlib.RingTheory.Polynomial.Chebyshev
 /-!
 # The Chebyshev polynomials as a basis
 
-This file packages the Chebyshev polynomials of the first kind as a basis of `R[X]` for a field
-`R` of characteristic different from two.  Mathlib
+This file packages the Chebyshev polynomials of the first kind as a basis of `R[X]` when `R` is an
+integral domain in which `2` is invertible. Mathlib
 already proves that `T R n` has degree `n`, records its leading coefficient, and bundles the
 family as `Polynomial.Chebyshev.chebyshevTsequence`.  Its generic polynomial-sequence API then
 gives a basis whenever all leading coefficients are units.
 
 The resulting basis is an algebraic prerequisite for Part C of the `OrthogonalL2Bases` roadmap.
-In the Chebyshev completeness argument, orthogonality to every `Tₙ` must imply orthogonality to
-every polynomial.  The extensionality and span lemmas below expose exactly that passage without
-repeating a triangular induction in the analytic file.
 
 ## Main declarations
 
 * `Polynomial.Chebyshev.chebyshevTBasis`: the basis `n ↦ T R n` of `R[X]`;
-* `Polynomial.Chebyshev.span_T_Iio`: the first `m` modes span the polynomials of degree `< m`;
-* `Polynomial.Chebyshev.linearMap_eq_zero_of_forall_map_T_eq_zero`: a linear map out of `R[X]`
-  vanishing on all Chebyshev modes vanishes identically.
 -/
 
 public section
 
 namespace Polynomial.Chebyshev
 
-open Submodule
-
-variable {R : Type*} [Field R] [NeZero (2 : R)]
+variable {R : Type*} [CommRing R] [IsDomain R] [Invertible (2 : R)]
 
 /-- The leading coefficient of every Chebyshev polynomial of the first kind over `R` is a unit. -/
 private lemma isUnit_leadingCoeff_T (n : ℕ) : IsUnit (T R n).leadingCoeff := by
   rw [leadingCoeff_T]
-  exact isUnit_iff_ne_zero.mpr (pow_ne_zero _ (NeZero.ne 2))
+  exact (isUnit_of_invertible (2 : R)).pow _
 
 /-- The Chebyshev polynomials of the first kind, indexed by their nonnegative degree, form a
 basis of `R[X]`. -/
@@ -51,49 +43,5 @@ noncomputable def chebyshevTBasis : Module.Basis ℕ R R[X] :=
 @[simp]
 lemma chebyshevTBasis_apply (n : ℕ) : chebyshevTBasis n = T R n :=
   Polynomial.Sequence.basis_eq_self _ _ n
-
-/-- The first `m` Chebyshev polynomials span precisely the polynomials of degree less than
-`m`.  This is the finite triangular form of `chebyshevTBasis`. -/
-lemma span_T_Iio (m : ℕ) :
-    span R ((fun n : ℕ ↦ T R n) '' Set.Iio m) = Polynomial.degreeLT R m := by
-  exact (chebyshevTsequence R).span_degreeLT fun n _ ↦ isUnit_leadingCoeff_T n
-
-/-- The Chebyshev polynomials span the polynomial ring. -/
-lemma span_range_T : span R (Set.range fun n : ℕ ↦ T R n) = ⊤ := by
-  exact (chebyshevTsequence R).span isUnit_leadingCoeff_T
-
-/-- Every polynomial is a finite linear combination of Chebyshev polynomials whose indices
-do not exceed its natural degree. -/
-lemma mem_span_T_Iic (p : R[X]) :
-    p ∈ span R ((fun n : ℕ ↦ T R n) '' Set.Iic p.natDegree) := by
-  rw [show (fun n : ℕ ↦ T R n) = chebyshevTsequence R by
-    funext n
-    simp [chebyshevTsequence]]
-  rw [(chebyshevTsequence R).span_degreeLE fun n _ ↦ isUnit_leadingCoeff_T n]
-  exact Polynomial.mem_degreeLE.mpr Polynomial.degree_le_natDegree
-
-/-- A linear map out of `R[X]` is determined by its values on the Chebyshev polynomials.
-
-This is the form used by completeness arguments: once a linear functional vanishes on every
-Chebyshev mode, it vanishes on every polynomial, hence in particular on every monomial. -/
-lemma linearMap_eq_zero_of_forall_map_T_eq_zero {M : Type*} [AddCommGroup M] [Module R M]
-    (L : R[X] →ₗ[R] M) (hL : ∀ n : ℕ, L (T R n) = 0) : L = 0 := by
-  apply chebyshevTBasis.ext
-  intro n
-  simp [hL n]
-
-/-- Elementwise form of `linearMap_eq_zero_of_forall_map_T_eq_zero`: a linear map vanishing on
-all Chebyshev polynomials vanishes on every polynomial. -/
-lemma LinearMap.map_eq_zero_of_forall_map_T_eq_zero {M : Type*} [AddCommGroup M] [Module R M]
-    (L : R[X] →ₗ[R] M) (hL : ∀ n : ℕ, L (T R n) = 0) (p : R[X]) : L p = 0 := by
-  rw [linearMap_eq_zero_of_forall_map_T_eq_zero L hL]
-  rfl
-
-/-- Two linear maps out of `R[X]` agreeing on all Chebyshev polynomials agree everywhere. -/
-lemma linearMap_ext_T {M : Type*} [AddCommGroup M] [Module R M]
-    {L₁ L₂ : R[X] →ₗ[R] M} (h : ∀ n : ℕ, L₁ (T R n) = L₂ (T R n)) : L₁ = L₂ := by
-  apply chebyshevTBasis.ext
-  intro n
-  simpa using h n
 
 end Polynomial.Chebyshev

--- a/TauCeti/RingTheory/Polynomial/Chebyshev/Basis.lean
+++ b/TauCeti/RingTheory/Polynomial/Chebyshev/Basis.lean
@@ -1,0 +1,97 @@
+module
+
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Codex
+-/
+public import Mathlib.Algebra.Polynomial.Sequence
+public import Mathlib.Data.Real.Basic
+public import Mathlib.LinearAlgebra.Basis.Basic
+public import Mathlib.RingTheory.Polynomial.Chebyshev
+
+/-!
+# The Chebyshev polynomials as a basis
+
+This file packages the Chebyshev polynomials of the first kind as a basis of `ℝ[X]`.  Mathlib
+already proves that `T ℝ n` has degree `n`, records its leading coefficient, and bundles the
+family as `Polynomial.Chebyshev.chebyshevTsequence`.  Its generic polynomial-sequence API then
+gives a basis whenever all leading coefficients are units.
+
+The resulting basis is an algebraic prerequisite for Part C of the `OrthogonalL2Bases` roadmap.
+In the Chebyshev completeness argument, orthogonality to every `Tₙ` must imply orthogonality to
+every polynomial.  The extensionality and span lemmas below expose exactly that passage without
+repeating a triangular induction in the analytic file.
+
+## Main declarations
+
+* `Polynomial.Chebyshev.chebyshevTBasis`: the basis `n ↦ T ℝ n` of `ℝ[X]`;
+* `Polynomial.Chebyshev.span_T_Iio`: the first `m` modes span the polynomials of degree `< m`;
+* `Polynomial.Chebyshev.linearMap_eq_zero_of_forall_map_T_eq_zero`: a linear map out of `ℝ[X]`
+  vanishing on all Chebyshev modes vanishes identically.
+-/
+
+public section
+
+namespace Polynomial.Chebyshev
+
+open Submodule
+
+/-- The leading coefficient of every real Chebyshev polynomial of the first kind is a unit. -/
+private lemma isUnit_leadingCoeff_T_real (n : ℕ) : IsUnit (T ℝ n).leadingCoeff := by
+  rw [leadingCoeff_T]
+  exact isUnit_iff_ne_zero.mpr (pow_ne_zero _ (by norm_num : (2 : ℝ) ≠ 0))
+
+/-- The Chebyshev polynomials of the first kind, indexed by their nonnegative degree, form a
+basis of the real polynomial ring. -/
+noncomputable def chebyshevTBasis : Module.Basis ℕ ℝ ℝ[X] :=
+  (chebyshevTsequence ℝ).basis isUnit_leadingCoeff_T_real
+
+/-- The `n`th vector of the real Chebyshev basis is `T ℝ n`. -/
+@[simp]
+lemma chebyshevTBasis_apply (n : ℕ) : chebyshevTBasis n = T ℝ n :=
+  Polynomial.Sequence.basis_eq_self _ _ n
+
+/-- The first `m` real Chebyshev polynomials span precisely the polynomials of degree less than
+`m`.  This is the finite triangular form of `chebyshevTBasis`. -/
+lemma span_T_Iio (m : ℕ) :
+    span ℝ ((fun n : ℕ ↦ T ℝ n) '' Set.Iio m) = Polynomial.degreeLT ℝ m := by
+  exact (chebyshevTsequence ℝ).span_degreeLT fun n _ ↦ isUnit_leadingCoeff_T_real n
+
+/-- The Chebyshev polynomials span the real polynomial ring. -/
+lemma span_range_T : span ℝ (Set.range fun n : ℕ ↦ T ℝ n) = ⊤ := by
+  exact (chebyshevTsequence ℝ).span isUnit_leadingCoeff_T_real
+
+/-- Every real polynomial is a finite linear combination of Chebyshev polynomials whose indices
+do not exceed its natural degree. -/
+lemma mem_span_T_Iic (p : ℝ[X]) :
+    p ∈ span ℝ ((fun n : ℕ ↦ T ℝ n) '' Set.Iic p.natDegree) := by
+  change p ∈ span ℝ ((chebyshevTsequence ℝ) '' Set.Iic p.natDegree)
+  rw [(chebyshevTsequence ℝ).span_degreeLE fun n _ ↦ isUnit_leadingCoeff_T_real n]
+  exact Polynomial.mem_degreeLE.mpr Polynomial.degree_le_natDegree
+
+/-- A linear map out of `ℝ[X]` is determined by its values on the Chebyshev polynomials.
+
+This is the form used by completeness arguments: once a linear functional vanishes on every
+Chebyshev mode, it vanishes on every polynomial, hence in particular on every monomial. -/
+lemma linearMap_eq_zero_of_forall_map_T_eq_zero {M : Type*} [AddCommGroup M] [Module ℝ M]
+    (L : ℝ[X] →ₗ[ℝ] M) (hL : ∀ n : ℕ, L (T ℝ n) = 0) : L = 0 := by
+  apply chebyshevTBasis.ext
+  intro n
+  simp [hL n]
+
+/-- Elementwise form of `linearMap_eq_zero_of_forall_map_T_eq_zero`: a linear map vanishing on
+all real Chebyshev polynomials vanishes on every real polynomial. -/
+lemma LinearMap.map_eq_zero_of_forall_map_T_eq_zero {M : Type*} [AddCommGroup M] [Module ℝ M]
+    (L : ℝ[X] →ₗ[ℝ] M) (hL : ∀ n : ℕ, L (T ℝ n) = 0) (p : ℝ[X]) : L p = 0 := by
+  rw [linearMap_eq_zero_of_forall_map_T_eq_zero L hL]
+  rfl
+
+/-- Two linear maps out of `ℝ[X]` agreeing on all Chebyshev polynomials agree everywhere. -/
+lemma linearMap_ext_T {M : Type*} [AddCommGroup M] [Module ℝ M]
+    {L₁ L₂ : ℝ[X] →ₗ[ℝ] M} (h : ∀ n : ℕ, L₁ (T ℝ n) = L₂ (T ℝ n)) : L₁ = L₂ := by
+  apply chebyshevTBasis.ext
+  intro n
+  simpa using h n
+
+end Polynomial.Chebyshev

--- a/TauCeti/RingTheory/Polynomial/Chebyshev/Basis.lean
+++ b/TauCeti/RingTheory/Polynomial/Chebyshev/Basis.lean
@@ -5,16 +5,14 @@ Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Codex
 -/
-public import Mathlib.Algebra.Polynomial.Sequence
-public import Mathlib.Data.Real.Basic
-public import Mathlib.LinearAlgebra.Basis.Basic
 public import Mathlib.RingTheory.Polynomial.Chebyshev
 
 /-!
 # The Chebyshev polynomials as a basis
 
-This file packages the Chebyshev polynomials of the first kind as a basis of `ℝ[X]`.  Mathlib
-already proves that `T ℝ n` has degree `n`, records its leading coefficient, and bundles the
+This file packages the Chebyshev polynomials of the first kind as a basis of `R[X]` for a field
+`R` of characteristic different from two.  Mathlib
+already proves that `T R n` has degree `n`, records its leading coefficient, and bundles the
 family as `Polynomial.Chebyshev.chebyshevTsequence`.  Its generic polynomial-sequence API then
 gives a basis whenever all leading coefficients are units.
 
@@ -25,9 +23,9 @@ repeating a triangular induction in the analytic file.
 
 ## Main declarations
 
-* `Polynomial.Chebyshev.chebyshevTBasis`: the basis `n ↦ T ℝ n` of `ℝ[X]`;
+* `Polynomial.Chebyshev.chebyshevTBasis`: the basis `n ↦ T R n` of `R[X]`;
 * `Polynomial.Chebyshev.span_T_Iio`: the first `m` modes span the polynomials of degree `< m`;
-* `Polynomial.Chebyshev.linearMap_eq_zero_of_forall_map_T_eq_zero`: a linear map out of `ℝ[X]`
+* `Polynomial.Chebyshev.linearMap_eq_zero_of_forall_map_T_eq_zero`: a linear map out of `R[X]`
   vanishing on all Chebyshev modes vanishes identically.
 -/
 
@@ -37,59 +35,63 @@ namespace Polynomial.Chebyshev
 
 open Submodule
 
-/-- The leading coefficient of every real Chebyshev polynomial of the first kind is a unit. -/
-private lemma isUnit_leadingCoeff_T_real (n : ℕ) : IsUnit (T ℝ n).leadingCoeff := by
+variable {R : Type*} [Field R] [NeZero (2 : R)]
+
+/-- The leading coefficient of every Chebyshev polynomial of the first kind over `R` is a unit. -/
+private lemma isUnit_leadingCoeff_T (n : ℕ) : IsUnit (T R n).leadingCoeff := by
   rw [leadingCoeff_T]
-  exact isUnit_iff_ne_zero.mpr (pow_ne_zero _ (by norm_num : (2 : ℝ) ≠ 0))
+  exact isUnit_iff_ne_zero.mpr (pow_ne_zero _ (NeZero.ne 2))
 
 /-- The Chebyshev polynomials of the first kind, indexed by their nonnegative degree, form a
-basis of the real polynomial ring. -/
-noncomputable def chebyshevTBasis : Module.Basis ℕ ℝ ℝ[X] :=
-  (chebyshevTsequence ℝ).basis isUnit_leadingCoeff_T_real
+basis of `R[X]`. -/
+noncomputable def chebyshevTBasis : Module.Basis ℕ R R[X] :=
+  (chebyshevTsequence R).basis isUnit_leadingCoeff_T
 
-/-- The `n`th vector of the real Chebyshev basis is `T ℝ n`. -/
+/-- The `n`th vector of the Chebyshev basis is `T R n`. -/
 @[simp]
-lemma chebyshevTBasis_apply (n : ℕ) : chebyshevTBasis n = T ℝ n :=
+lemma chebyshevTBasis_apply (n : ℕ) : chebyshevTBasis n = T R n :=
   Polynomial.Sequence.basis_eq_self _ _ n
 
-/-- The first `m` real Chebyshev polynomials span precisely the polynomials of degree less than
+/-- The first `m` Chebyshev polynomials span precisely the polynomials of degree less than
 `m`.  This is the finite triangular form of `chebyshevTBasis`. -/
 lemma span_T_Iio (m : ℕ) :
-    span ℝ ((fun n : ℕ ↦ T ℝ n) '' Set.Iio m) = Polynomial.degreeLT ℝ m := by
-  exact (chebyshevTsequence ℝ).span_degreeLT fun n _ ↦ isUnit_leadingCoeff_T_real n
+    span R ((fun n : ℕ ↦ T R n) '' Set.Iio m) = Polynomial.degreeLT R m := by
+  exact (chebyshevTsequence R).span_degreeLT fun n _ ↦ isUnit_leadingCoeff_T n
 
-/-- The Chebyshev polynomials span the real polynomial ring. -/
-lemma span_range_T : span ℝ (Set.range fun n : ℕ ↦ T ℝ n) = ⊤ := by
-  exact (chebyshevTsequence ℝ).span isUnit_leadingCoeff_T_real
+/-- The Chebyshev polynomials span the polynomial ring. -/
+lemma span_range_T : span R (Set.range fun n : ℕ ↦ T R n) = ⊤ := by
+  exact (chebyshevTsequence R).span isUnit_leadingCoeff_T
 
-/-- Every real polynomial is a finite linear combination of Chebyshev polynomials whose indices
+/-- Every polynomial is a finite linear combination of Chebyshev polynomials whose indices
 do not exceed its natural degree. -/
-lemma mem_span_T_Iic (p : ℝ[X]) :
-    p ∈ span ℝ ((fun n : ℕ ↦ T ℝ n) '' Set.Iic p.natDegree) := by
-  change p ∈ span ℝ ((chebyshevTsequence ℝ) '' Set.Iic p.natDegree)
-  rw [(chebyshevTsequence ℝ).span_degreeLE fun n _ ↦ isUnit_leadingCoeff_T_real n]
+lemma mem_span_T_Iic (p : R[X]) :
+    p ∈ span R ((fun n : ℕ ↦ T R n) '' Set.Iic p.natDegree) := by
+  rw [show (fun n : ℕ ↦ T R n) = chebyshevTsequence R by
+    funext n
+    simp [chebyshevTsequence]]
+  rw [(chebyshevTsequence R).span_degreeLE fun n _ ↦ isUnit_leadingCoeff_T n]
   exact Polynomial.mem_degreeLE.mpr Polynomial.degree_le_natDegree
 
-/-- A linear map out of `ℝ[X]` is determined by its values on the Chebyshev polynomials.
+/-- A linear map out of `R[X]` is determined by its values on the Chebyshev polynomials.
 
 This is the form used by completeness arguments: once a linear functional vanishes on every
 Chebyshev mode, it vanishes on every polynomial, hence in particular on every monomial. -/
-lemma linearMap_eq_zero_of_forall_map_T_eq_zero {M : Type*} [AddCommGroup M] [Module ℝ M]
-    (L : ℝ[X] →ₗ[ℝ] M) (hL : ∀ n : ℕ, L (T ℝ n) = 0) : L = 0 := by
+lemma linearMap_eq_zero_of_forall_map_T_eq_zero {M : Type*} [AddCommGroup M] [Module R M]
+    (L : R[X] →ₗ[R] M) (hL : ∀ n : ℕ, L (T R n) = 0) : L = 0 := by
   apply chebyshevTBasis.ext
   intro n
   simp [hL n]
 
 /-- Elementwise form of `linearMap_eq_zero_of_forall_map_T_eq_zero`: a linear map vanishing on
-all real Chebyshev polynomials vanishes on every real polynomial. -/
-lemma LinearMap.map_eq_zero_of_forall_map_T_eq_zero {M : Type*} [AddCommGroup M] [Module ℝ M]
-    (L : ℝ[X] →ₗ[ℝ] M) (hL : ∀ n : ℕ, L (T ℝ n) = 0) (p : ℝ[X]) : L p = 0 := by
+all Chebyshev polynomials vanishes on every polynomial. -/
+lemma LinearMap.map_eq_zero_of_forall_map_T_eq_zero {M : Type*} [AddCommGroup M] [Module R M]
+    (L : R[X] →ₗ[R] M) (hL : ∀ n : ℕ, L (T R n) = 0) (p : R[X]) : L p = 0 := by
   rw [linearMap_eq_zero_of_forall_map_T_eq_zero L hL]
   rfl
 
-/-- Two linear maps out of `ℝ[X]` agreeing on all Chebyshev polynomials agree everywhere. -/
-lemma linearMap_ext_T {M : Type*} [AddCommGroup M] [Module ℝ M]
-    {L₁ L₂ : ℝ[X] →ₗ[ℝ] M} (h : ∀ n : ℕ, L₁ (T ℝ n) = L₂ (T ℝ n)) : L₁ = L₂ := by
+/-- Two linear maps out of `R[X]` agreeing on all Chebyshev polynomials agree everywhere. -/
+lemma linearMap_ext_T {M : Type*} [AddCommGroup M] [Module R M]
+    {L₁ L₂ : R[X] →ₗ[R] M} (h : ∀ n : ℕ, L₁ (T R n) = L₂ (T R n)) : L₁ = L₂ := by
   apply chebyshevTBasis.ext
   intro n
   simpa using h n


### PR DESCRIPTION
This PR packages the real Chebyshev polynomials of the first kind as a polynomial basis and exposes the finite-degree span and linear-map extensionality lemmas needed to pass from orthogonality against every `Tₙ` to orthogonality against every polynomial.

It advances `TauCetiRoadmap/OrthogonalL2Bases/README.md`, Part C, specifically the completeness step for `chebyshevHilbertBasis`: a function orthogonal to every `Tₙ` must have all polynomial moments zero before the shared B1 moment-determinacy lemma can apply.

<!--tauceti-target:v1 {"focus":"OrthogonalL2Bases","id":"chebyshev-t-polynomial-basis"}-->

This reuses Mathlib's `Polynomial.Chebyshev.chebyshevTsequence`, `degree_T`, and `leadingCoeff_T`, together with `Polynomial.Sequence.basis`, `span_degreeLT`, and `span_degreeLE`; no Mathlib implementation is vendored.

The module builds successfully and passes the Tau Ceti axiom audit.

🤖 Prepared with Codex
