### PR TITLE
feat: add L2 energy forms for constant coefficients

### DIFF
--- a/TauCeti/Analysis/PDE/EnergyForm/Lp.lean
+++ b/TauCeti/Analysis/PDE/EnergyForm/Lp.lean
@@ -1,0 +1,126 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+module
+
+public import Mathlib.MeasureTheory.Function.Holder
+public import TauCeti.Analysis.PDE.SymmetricEnergy
+
+/-!
+# Constant-coefficient energy forms on `L²` jets
+
+Lane D of the PDE roadmap asks for the bounded bilinear energy form used by the weak
+formulation of a divergence-form equation. This file performs the functional-analytic bundling
+for constant coefficients. A pointwise jet form
+
+`(u, ∇u), (v, ∇v) ↦ (∇v)ᵀ A ∇u + v bᵀ ∇u + c u v`
+
+induces a continuous bilinear form on square-integrable value-gradient jets. The construction
+uses Mathlib's `ContinuousLinearMap.lpPairing`, which is the continuous Hölder pairing induced
+by a continuous bilinear map.
+
+Variable coefficients will require the corresponding multiplication-operator construction.
+The constant-coefficient form here already includes the Dirichlet and shifted-Laplacian models
+and is directly consumable by Mathlib's Lax--Milgram API.
+
+## Main declarations
+
+* `TauCeti.PDE.energyFormLp`: the constant-coefficient energy form on `L²` jets.
+* `TauCeti.PDE.energyFormLp_apply`: its characterization as an integral.
+* `TauCeti.PDE.energyFormLp_one_zero_zero_apply` and
+  `TauCeti.PDE.energyFormLp_one_zero_mass_apply`: the Dirichlet and shifted-Laplacian formulas.
+* `TauCeti.PDE.energyFormLp_zero_drift_comm_of_isSymm`: symmetry when the principal matrix is
+  symmetric and the drift vanishes.
+-/
+
+public section
+
+noncomputable section
+
+namespace TauCeti
+
+namespace PDE
+
+open MeasureTheory Matrix
+open scoped InnerProductSpace
+
+variable {X n : Type*} [MeasurableSpace X] [Fintype n]
+
+noncomputable local instance energyFormLpDecidableEq : DecidableEq n := Classical.decEq n
+
+/-- The constant-coefficient divergence-form energy form on square-integrable
+value-gradient jets.
+
+This is the Hölder pairing induced by `energyIntegrand A b c`; in particular it is bundled as
+a continuous bilinear map, with no integrability hypotheses required at use sites. -/
+noncomputable def energyFormLp (μ : Measure X) (A : Matrix n n ℝ)
+    (b : EuclideanSpace ℝ n) (c : ℝ) :
+    Lp (ℝ × EuclideanSpace ℝ n) 2 μ →L[ℝ]
+      Lp (ℝ × EuclideanSpace ℝ n) 2 μ →L[ℝ] ℝ :=
+  (energyIntegrand A b c).lpPairing μ 2 2
+
+/-- The `L²` energy form is the integral of the pointwise jet energy density. -/
+@[simp]
+theorem energyFormLp_apply (μ : Measure X) (A : Matrix n n ℝ)
+    (b : EuclideanSpace ℝ n) (c : ℝ)
+    (U V : Lp (ℝ × EuclideanSpace ℝ n) 2 μ) :
+    energyFormLp μ A b c U V =
+      ∫ x, energyIntegrand A b c (U x) (V x) ∂μ := by
+  exact ContinuousLinearMap.lpPairing_eq_integral _ _ _
+
+/-- The value of the `L²` energy form is bounded by its operator norm times the two `L²` norms. -/
+theorem norm_energyFormLp_apply_le (μ : Measure X) (A : Matrix n n ℝ)
+    (b : EuclideanSpace ℝ n) (c : ℝ)
+    (U V : Lp (ℝ × EuclideanSpace ℝ n) 2 μ) :
+    ‖energyFormLp μ A b c U V‖ ≤ ‖energyFormLp μ A b c‖ * ‖U‖ * ‖V‖ := by
+  exact (energyFormLp μ A b c).le_opNorm₂ U V
+
+/-- The Dirichlet energy form pairs the gradient components of two `L²` jets. -/
+theorem energyFormLp_one_zero_zero_apply (μ : Measure X)
+    (U V : Lp (ℝ × EuclideanSpace ℝ n) 2 μ) :
+    energyFormLp μ (1 : Matrix n n ℝ) 0 0 U V =
+      ∫ x, (V x).2 ⬝ᵥ (U x).2 ∂μ := by
+  rw [energyFormLp_apply]
+  refine integral_congr_ae (Filter.Eventually.of_forall fun x => ?_)
+  simp
+
+/-- The shifted-Laplacian energy form is the sum of the gradient pairing and the mass
+pairing. -/
+theorem energyFormLp_one_zero_mass_apply (μ : Measure X) (c : ℝ)
+    (U V : Lp (ℝ × EuclideanSpace ℝ n) 2 μ) :
+    energyFormLp μ (1 : Matrix n n ℝ) 0 c U V =
+      ∫ x, ((V x).2 ⬝ᵥ (U x).2 + c * (U x).1 * (V x).1) ∂μ := by
+  rw [energyFormLp_apply]
+  refine integral_congr_ae (Filter.Eventually.of_forall fun x => ?_)
+  simp
+
+/-- Transposing the principal coefficient swaps the two arguments of a zero-drift `L²` energy
+form. -/
+theorem energyFormLp_zero_drift_transpose_apply (μ : Measure X) (A : Matrix n n ℝ) (c : ℝ)
+    (U V : Lp (ℝ × EuclideanSpace ℝ n) 2 μ) :
+    energyFormLp μ Aᵀ 0 c U V = energyFormLp μ A 0 c V U := by
+  rw [energyFormLp_apply, energyFormLp_apply]
+  refine integral_congr_ae (Filter.Eventually.of_forall fun x => ?_)
+  exact energyIntegrand_zero_drift_transpose_apply A c (U x) (V x)
+
+/-- A symmetric principal coefficient gives a symmetric zero-drift `L²` energy form. -/
+theorem energyFormLp_zero_drift_comm_of_isSymm {A : Matrix n n ℝ} (hA : A.IsSymm)
+    (μ : Measure X) (c : ℝ) (U V : Lp (ℝ × EuclideanSpace ℝ n) 2 μ) :
+    energyFormLp μ A 0 c U V = energyFormLp μ A 0 c V U := by
+  rw [energyFormLp_apply, energyFormLp_apply]
+  refine integral_congr_ae (Filter.Eventually.of_forall fun x => ?_)
+  exact energyIntegrand_zero_drift_comm_of_isSymm hA c (U x) (V x)
+
+/-- The shifted-Laplacian `L²` energy form is symmetric. -/
+theorem energyFormLp_one_zero_mass_comm (μ : Measure X) (c : ℝ)
+    (U V : Lp (ℝ × EuclideanSpace ℝ n) 2 μ) :
+    energyFormLp μ (1 : Matrix n n ℝ) 0 c U V =
+      energyFormLp μ (1 : Matrix n n ℝ) 0 c V U :=
+  energyFormLp_zero_drift_comm_of_isSymm isSymm_one μ c U V
+
+end PDE
+
+end TauCeti
+
+end

--- a/TauCeti/Analysis/PDE/EnergyForm/Lp.lean
+++ b/TauCeti/Analysis/PDE/EnergyForm/Lp.lean
@@ -146,7 +146,6 @@ theorem energyFormLp_one_zero_mass_comm (μ : Measure X) (c : ℝ)
   energyFormLp_zero_drift_comm_of_isSymm isSymm_one μ c U V
 
 /-- The shifted-Laplacian `L²` energy form is equal to its flip. -/
-@[simp]
 theorem energyFormLp_one_zero_mass_flip_eq (μ : Measure X) (c : ℝ) :
     (energyFormLp μ (1 : Matrix n n ℝ) 0 c).flip =
       energyFormLp μ (1 : Matrix n n ℝ) 0 c :=

--- a/TauCeti/Analysis/PDE/EnergyForm/Lp.lean
+++ b/TauCeti/Analysis/PDE/EnergyForm/Lp.lean
@@ -22,7 +22,8 @@ by a continuous bilinear map.
 
 Variable coefficients will require the corresponding multiplication-operator construction.
 The constant-coefficient form here already includes the Dirichlet and shifted-Laplacian models
-and is directly consumable by Mathlib's Lax--Milgram API.
+and has the bounded-bilinear-map shape needed for a later Lax--Milgram application, after
+restriction to the intended Hilbert/Sobolev space and a proof of coercivity.
 
 ## Main declarations
 
@@ -30,8 +31,10 @@ and is directly consumable by Mathlib's Lax--Milgram API.
 * `TauCeti.PDE.energyFormLp_apply`: its characterization as an integral.
 * `TauCeti.PDE.energyFormLp_one_zero_zero_apply` and
   `TauCeti.PDE.energyFormLp_one_zero_mass_apply`: the Dirichlet and shifted-Laplacian formulas.
-* `TauCeti.PDE.energyFormLp_zero_drift_comm_of_isSymm`: symmetry when the principal matrix is
-  symmetric and the drift vanishes.
+* `TauCeti.PDE.energyFormLp_one_zero_zero_self` and
+  `TauCeti.PDE.energyFormLp_one_zero_mass_self`: their diagonal formulas.
+* `TauCeti.PDE.energyFormLp_zero_drift_flip_eq_of_isSymm`: bundled symmetry when the principal
+  matrix is symmetric and the drift vanishes.
 -/
 
 public section
@@ -77,7 +80,17 @@ theorem energyFormLp_one_zero_zero_apply (μ : Measure X)
       ∫ x, (V x).2 ⬝ᵥ (U x).2 ∂μ := by
   rw [energyFormLp_apply]
   refine integral_congr_ae (Filter.Eventually.of_forall fun x => ?_)
-  simp
+  exact energyIntegrand_one_zero_zero_apply (U x) (V x)
+
+/-- The diagonal of the Dirichlet `L²` energy form is the integral of the squared gradient
+norm. -/
+theorem energyFormLp_one_zero_zero_self (μ : Measure X)
+    (U : Lp (ℝ × EuclideanSpace ℝ n) 2 μ) :
+    energyFormLp μ (1 : Matrix n n ℝ) 0 0 U U =
+      ∫ x, ‖(U x).2‖ ^ 2 ∂μ := by
+  rw [energyFormLp_apply]
+  refine integral_congr_ae (Filter.Eventually.of_forall fun x => ?_)
+  exact energyIntegrand_one_zero_zero_self (U x)
 
 /-- The shifted-Laplacian energy form is the sum of the gradient pairing and the mass
 pairing. -/
@@ -87,7 +100,17 @@ theorem energyFormLp_one_zero_mass_apply (μ : Measure X) (c : ℝ)
       ∫ x, ((V x).2 ⬝ᵥ (U x).2 + c * (U x).1 * (V x).1) ∂μ := by
   rw [energyFormLp_apply]
   refine integral_congr_ae (Filter.Eventually.of_forall fun x => ?_)
-  simp
+  exact energyIntegrand_one_zero_mass_apply c (U x) (V x)
+
+/-- The diagonal of the shifted-Laplacian `L²` energy form is the integral of the squared
+gradient norm plus the mass density. -/
+theorem energyFormLp_one_zero_mass_self (μ : Measure X) (c : ℝ)
+    (U : Lp (ℝ × EuclideanSpace ℝ n) 2 μ) :
+    energyFormLp μ (1 : Matrix n n ℝ) 0 c U U =
+      ∫ x, (‖(U x).2‖ ^ 2 + c * (U x).1 ^ 2) ∂μ := by
+  rw [energyFormLp_apply]
+  refine integral_congr_ae (Filter.Eventually.of_forall fun x => ?_)
+  exact energyIntegrand_one_zero_mass_self c (U x)
 
 /-- Transposing the principal coefficient swaps the two arguments of a zero-drift `L²` energy
 form. -/
@@ -106,12 +129,28 @@ theorem energyFormLp_zero_drift_comm_of_isSymm {A : Matrix n n ℝ} (hA : A.IsSy
   refine integral_congr_ae (Filter.Eventually.of_forall fun x => ?_)
   exact energyIntegrand_zero_drift_comm_of_isSymm hA c (U x) (V x)
 
+/-- A symmetric principal coefficient makes the zero-drift `L²` energy form equal to its
+flip. -/
+@[simp]
+theorem energyFormLp_zero_drift_flip_eq_of_isSymm {A : Matrix n n ℝ} (hA : A.IsSymm)
+    (μ : Measure X) (c : ℝ) :
+    (energyFormLp μ A 0 c).flip = energyFormLp μ A 0 c := by
+  ext U V
+  exact energyFormLp_zero_drift_comm_of_isSymm hA μ c V U
+
 /-- The shifted-Laplacian `L²` energy form is symmetric. -/
 theorem energyFormLp_one_zero_mass_comm (μ : Measure X) (c : ℝ)
     (U V : Lp (ℝ × EuclideanSpace ℝ n) 2 μ) :
     energyFormLp μ (1 : Matrix n n ℝ) 0 c U V =
       energyFormLp μ (1 : Matrix n n ℝ) 0 c V U :=
   energyFormLp_zero_drift_comm_of_isSymm isSymm_one μ c U V
+
+/-- The shifted-Laplacian `L²` energy form is equal to its flip. -/
+@[simp]
+theorem energyFormLp_one_zero_mass_flip_eq (μ : Measure X) (c : ℝ) :
+    (energyFormLp μ (1 : Matrix n n ℝ) 0 c).flip =
+      energyFormLp μ (1 : Matrix n n ℝ) 0 c :=
+  energyFormLp_zero_drift_flip_eq_of_isSymm isSymm_one μ c
 
 end PDE
 

--- a/TauCeti/Analysis/PDE/EnergyForm/Lp.lean
+++ b/TauCeti/Analysis/PDE/EnergyForm/Lp.lean
@@ -136,11 +136,13 @@ theorem energyFormLp_coefficientSymmetricPart_zero_drift_apply (μ : Measure X)
   have hVU : Integrable (fun x => energyIntegrand A 0 c (V x) (U x)) μ :=
     memLp_one_iff_integrable.mp
       ((energyIntegrand A 0 c).memLp_of_bilin 1 (Lp.memLp V) (Lp.memLp U))
-  rw [show (fun x => energyIntegrand (coefficientSymmetricPart A) 0 c (U x) (V x)) =
-      fun x => (energyIntegrand A 0 c (U x) (V x) +
-        energyIntegrand A 0 c (V x) (U x)) / 2 by
+  have hpoint :
+      (fun x => energyIntegrand (coefficientSymmetricPart A) 0 c (U x) (V x)) =
+        fun x => (energyIntegrand A 0 c (U x) (V x) +
+          energyIntegrand A 0 c (V x) (U x)) / 2 := by
     funext x
-    exact energyIntegrand_coefficientSymmetricPart_zero_drift_apply A c (U x) (V x)]
+    exact energyIntegrand_coefficientSymmetricPart_zero_drift_apply A c (U x) (V x)
+  rw [hpoint]
   rw [integral_div, integral_add hUV hVU]
 
 /-- Transposing the principal coefficient swaps the two arguments of a zero-drift `L²` energy

--- a/TauCeti/Analysis/PDE/EnergyForm/Lp.lean
+++ b/TauCeti/Analysis/PDE/EnergyForm/Lp.lean
@@ -118,10 +118,13 @@ theorem energyFormLp_one_zero_mass_self (μ : Measure X) (c : ℝ)
 theorem energyFormLp_coefficientSymmetricPart_self (μ : Measure X) (A : Matrix n n ℝ)
     (b : EuclideanSpace ℝ n) (c : ℝ)
     (U : Lp (ℝ × EuclideanSpace ℝ n) 2 μ) :
-    energyFormLp μ (coefficientSymmetricPart A) b c U U = energyFormLp μ A b c U U := by
-  rw [energyFormLp_apply, energyFormLp_apply]
+    (∫ x, (U x).2 ⬝ᵥ (coefficientSymmetricPart A).mulVec (U x).2 +
+        inner ℝ b (U x).2 * (U x).1 + c * (U x).1 * (U x).1 ∂μ) =
+      energyFormLp μ A b c U U := by
+  rw [energyFormLp_apply]
   refine integral_congr_ae (Filter.Eventually.of_forall fun x => ?_)
-  exact energyIntegrand_coefficientSymmetricPart_self A b c (U x)
+  simpa only [energyIntegrand_apply, matrixBilinearForm_apply, driftForm_apply, massForm_apply]
+    using energyIntegrand_coefficientSymmetricPart_self A b c (U x)
 
 /-- The symmetric-part zero-drift `L²` energy form is the average of the original form and
 its transpose. -/

--- a/TauCeti/Analysis/PDE/EnergyForm/Lp.lean
+++ b/TauCeti/Analysis/PDE/EnergyForm/Lp.lean
@@ -47,6 +47,7 @@ open scoped InnerProductSpace
 
 variable {X n : Type*} [MeasurableSpace X] [Fintype n]
 
+/-- The classical decidable equality used for finite-dimensional matrix computations. -/
 noncomputable local instance energyFormLpDecidableEq : DecidableEq n := Classical.decEq n
 
 /-- The constant-coefficient divergence-form energy form on square-integrable

--- a/TauCeti/Analysis/PDE/EnergyForm/Lp.lean
+++ b/TauCeti/Analysis/PDE/EnergyForm/Lp.lean
@@ -70,13 +70,6 @@ theorem energyFormLp_apply (μ : Measure X) (A : Matrix n n ℝ)
       ∫ x, energyIntegrand A b c (U x) (V x) ∂μ := by
   exact ContinuousLinearMap.lpPairing_eq_integral _ _ _
 
-/-- The value of the `L²` energy form is bounded by its operator norm times the two `L²` norms. -/
-theorem norm_energyFormLp_apply_le (μ : Measure X) (A : Matrix n n ℝ)
-    (b : EuclideanSpace ℝ n) (c : ℝ)
-    (U V : Lp (ℝ × EuclideanSpace ℝ n) 2 μ) :
-    ‖energyFormLp μ A b c U V‖ ≤ ‖energyFormLp μ A b c‖ * ‖U‖ * ‖V‖ := by
-  exact (energyFormLp μ A b c).le_opNorm₂ U V
-
 /-- The Dirichlet energy form pairs the gradient components of two `L²` jets. -/
 theorem energyFormLp_one_zero_zero_apply (μ : Measure X)
     (U V : Lp (ℝ × EuclideanSpace ℝ n) 2 μ) :

--- a/TauCeti/Analysis/PDE/EnergyForm/Lp.lean
+++ b/TauCeti/Analysis/PDE/EnergyForm/Lp.lean
@@ -118,13 +118,11 @@ theorem energyFormLp_one_zero_mass_self (μ : Measure X) (c : ℝ)
 theorem energyFormLp_coefficientSymmetricPart_self (μ : Measure X) (A : Matrix n n ℝ)
     (b : EuclideanSpace ℝ n) (c : ℝ)
     (U : Lp (ℝ × EuclideanSpace ℝ n) 2 μ) :
-    (∫ x, (U x).2 ⬝ᵥ (coefficientSymmetricPart A).mulVec (U x).2 +
-        inner ℝ b (U x).2 * (U x).1 + c * (U x).1 * (U x).1 ∂μ) =
+    energyFormLp μ (coefficientSymmetricPart A) b c U U =
       energyFormLp μ A b c U U := by
-  rw [energyFormLp_apply]
+  rw [energyFormLp_apply, energyFormLp_apply]
   refine integral_congr_ae (Filter.Eventually.of_forall fun x => ?_)
-  simpa only [energyIntegrand_apply, matrixBilinearForm_apply, driftForm_apply, massForm_apply]
-    using energyIntegrand_coefficientSymmetricPart_self A b c (U x)
+  exact energyIntegrand_coefficientSymmetricPart_self A b c (U x)
 
 /-- The symmetric-part zero-drift `L²` energy form is the average of the original form and
 its transpose. -/
@@ -171,6 +169,21 @@ theorem energyFormLp_zero_drift_flip_eq_of_isSymm {A : Matrix n n ℝ} (hA : A.I
     (energyFormLp μ A 0 c).flip = energyFormLp μ A 0 c := by
   ext U V
   exact energyFormLp_zero_drift_comm_of_isSymm hA μ c V U
+
+/-- The symmetric-part zero-drift `L²` energy form is symmetric. -/
+theorem energyFormLp_coefficientSymmetricPart_zero_drift_comm (μ : Measure X)
+    (A : Matrix n n ℝ) (c : ℝ) (U V : Lp (ℝ × EuclideanSpace ℝ n) 2 μ) :
+    energyFormLp μ (coefficientSymmetricPart A) 0 c U V =
+      energyFormLp μ (coefficientSymmetricPart A) 0 c V U :=
+  energyFormLp_zero_drift_comm_of_isSymm (coefficientSymmetricPart_isSymm A) μ c U V
+
+/-- The symmetric-part zero-drift `L²` energy form is equal to its flip. -/
+@[simp]
+theorem energyFormLp_coefficientSymmetricPart_zero_drift_flip_eq (μ : Measure X)
+    (A : Matrix n n ℝ) (c : ℝ) :
+    (energyFormLp μ (coefficientSymmetricPart A) 0 c).flip =
+      energyFormLp μ (coefficientSymmetricPart A) 0 c :=
+  energyFormLp_zero_drift_flip_eq_of_isSymm (coefficientSymmetricPart_isSymm A) μ c
 
 /-- The shifted-Laplacian `L²` energy form is symmetric. -/
 theorem energyFormLp_one_zero_mass_comm (μ : Measure X) (c : ℝ)

--- a/TauCeti/Analysis/PDE/EnergyForm/Lp.lean
+++ b/TauCeti/Analysis/PDE/EnergyForm/Lp.lean
@@ -112,6 +112,37 @@ theorem energyFormLp_one_zero_mass_self (μ : Measure X) (c : ℝ)
   refine integral_congr_ae (Filter.Eventually.of_forall fun x => ?_)
   exact energyIntegrand_one_zero_mass_self c (U x)
 
+/-- Replacing the principal coefficient by its symmetric part does not change the diagonal
+`L²` energy form. -/
+@[simp]
+theorem energyFormLp_coefficientSymmetricPart_self (μ : Measure X) (A : Matrix n n ℝ)
+    (b : EuclideanSpace ℝ n) (c : ℝ)
+    (U : Lp (ℝ × EuclideanSpace ℝ n) 2 μ) :
+    energyFormLp μ (coefficientSymmetricPart A) b c U U = energyFormLp μ A b c U U := by
+  rw [energyFormLp_apply, energyFormLp_apply]
+  refine integral_congr_ae (Filter.Eventually.of_forall fun x => ?_)
+  exact energyIntegrand_coefficientSymmetricPart_self A b c (U x)
+
+/-- The symmetric-part zero-drift `L²` energy form is the average of the original form and
+its transpose. -/
+theorem energyFormLp_coefficientSymmetricPart_zero_drift_apply (μ : Measure X)
+    (A : Matrix n n ℝ) (c : ℝ) (U V : Lp (ℝ × EuclideanSpace ℝ n) 2 μ) :
+    energyFormLp μ (coefficientSymmetricPart A) 0 c U V =
+      (energyFormLp μ A 0 c U V + energyFormLp μ A 0 c V U) / 2 := by
+  rw [energyFormLp_apply, energyFormLp_apply, energyFormLp_apply]
+  have hUV : Integrable (fun x => energyIntegrand A 0 c (U x) (V x)) μ :=
+    memLp_one_iff_integrable.mp
+      ((energyIntegrand A 0 c).memLp_of_bilin 1 (Lp.memLp U) (Lp.memLp V))
+  have hVU : Integrable (fun x => energyIntegrand A 0 c (V x) (U x)) μ :=
+    memLp_one_iff_integrable.mp
+      ((energyIntegrand A 0 c).memLp_of_bilin 1 (Lp.memLp V) (Lp.memLp U))
+  rw [show (fun x => energyIntegrand (coefficientSymmetricPart A) 0 c (U x) (V x)) =
+      fun x => (energyIntegrand A 0 c (U x) (V x) +
+        energyIntegrand A 0 c (V x) (U x)) / 2 by
+    funext x
+    exact energyIntegrand_coefficientSymmetricPart_zero_drift_apply A c (U x) (V x)]
+  rw [integral_div, integral_add hUV hVU]
+
 /-- Transposing the principal coefficient swaps the two arguments of a zero-drift `L²` energy
 form. -/
 theorem energyFormLp_zero_drift_transpose_apply (μ : Measure X) (A : Matrix n n ℝ) (c : ℝ)

--- a/TauCeti/Analysis/PDE/EnergyForm/Lp.lean
+++ b/TauCeti/Analysis/PDE/EnergyForm/Lp.lean
@@ -114,7 +114,6 @@ theorem energyFormLp_one_zero_mass_self (μ : Measure X) (c : ℝ)
 
 /-- Replacing the principal coefficient by its symmetric part does not change the diagonal
 `L²` energy form. -/
-@[simp]
 theorem energyFormLp_coefficientSymmetricPart_self (μ : Measure X) (A : Matrix n n ℝ)
     (b : EuclideanSpace ℝ n) (c : ℝ)
     (U : Lp (ℝ × EuclideanSpace ℝ n) 2 μ) :

--- a/TauCeti/Analysis/PDE/EnergyForm/Lp.lean
+++ b/TauCeti/Analysis/PDE/EnergyForm/Lp.lean
@@ -73,25 +73,6 @@ theorem energyFormLp_apply (μ : Measure X) (A : Matrix n n ℝ)
       ∫ x, energyIntegrand A b c (U x) (V x) ∂μ := by
   exact ContinuousLinearMap.lpPairing_eq_integral _ _ _
 
-/-- The Dirichlet energy form pairs the gradient components of two `L²` jets. -/
-theorem energyFormLp_one_zero_zero_apply (μ : Measure X)
-    (U V : Lp (ℝ × EuclideanSpace ℝ n) 2 μ) :
-    energyFormLp μ (1 : Matrix n n ℝ) 0 0 U V =
-      ∫ x, (V x).2 ⬝ᵥ (U x).2 ∂μ := by
-  rw [energyFormLp_apply]
-  refine integral_congr_ae (Filter.Eventually.of_forall fun x => ?_)
-  exact energyIntegrand_one_zero_zero_apply (U x) (V x)
-
-/-- The diagonal of the Dirichlet `L²` energy form is the integral of the squared gradient
-norm. -/
-theorem energyFormLp_one_zero_zero_self (μ : Measure X)
-    (U : Lp (ℝ × EuclideanSpace ℝ n) 2 μ) :
-    energyFormLp μ (1 : Matrix n n ℝ) 0 0 U U =
-      ∫ x, ‖(U x).2‖ ^ 2 ∂μ := by
-  rw [energyFormLp_apply]
-  refine integral_congr_ae (Filter.Eventually.of_forall fun x => ?_)
-  exact energyIntegrand_one_zero_zero_self (U x)
-
 /-- The shifted-Laplacian energy form is the sum of the gradient pairing and the mass
 pairing. -/
 theorem energyFormLp_one_zero_mass_apply (μ : Measure X) (c : ℝ)
@@ -102,6 +83,14 @@ theorem energyFormLp_one_zero_mass_apply (μ : Measure X) (c : ℝ)
   refine integral_congr_ae (Filter.Eventually.of_forall fun x => ?_)
   exact energyIntegrand_one_zero_mass_apply c (U x) (V x)
 
+/-- The Dirichlet energy form pairs the gradient components of two `L²` jets. -/
+theorem energyFormLp_one_zero_zero_apply (μ : Measure X)
+    (U V : Lp (ℝ × EuclideanSpace ℝ n) 2 μ) :
+    energyFormLp μ (1 : Matrix n n ℝ) 0 0 U V =
+      ∫ x, (V x).2 ⬝ᵥ (U x).2 ∂μ := by
+  rw [energyFormLp_one_zero_mass_apply]
+  simp
+
 /-- The diagonal of the shifted-Laplacian `L²` energy form is the integral of the squared
 gradient norm plus the mass density. -/
 theorem energyFormLp_one_zero_mass_self (μ : Measure X) (c : ℝ)
@@ -111,6 +100,15 @@ theorem energyFormLp_one_zero_mass_self (μ : Measure X) (c : ℝ)
   rw [energyFormLp_apply]
   refine integral_congr_ae (Filter.Eventually.of_forall fun x => ?_)
   exact energyIntegrand_one_zero_mass_self c (U x)
+
+/-- The diagonal of the Dirichlet `L²` energy form is the integral of the squared gradient
+norm. -/
+theorem energyFormLp_one_zero_zero_self (μ : Measure X)
+    (U : Lp (ℝ × EuclideanSpace ℝ n) 2 μ) :
+    energyFormLp μ (1 : Matrix n n ℝ) 0 0 U U =
+      ∫ x, ‖(U x).2‖ ^ 2 ∂μ := by
+  rw [energyFormLp_one_zero_mass_self]
+  simp
 
 /-- Replacing the principal coefficient by its symmetric part does not change the diagonal
 `L²` energy form. -/


### PR DESCRIPTION
This PR packages the constant-coefficient divergence-form energy integrand as a continuous bilinear form on `L²` value-gradient jets. Use Mathlib's `ContinuousLinearMap.lpPairing` to obtain bounded bilinearity and expose the integral characterization, the Dirichlet and shifted-Laplacian formulas, transpose compatibility, and symmetry for zero drift with symmetric principal coefficients.

This advances `TauCetiRoadmap/PDE/README.md`, Lane D, item 16, “Weak formulation,” specifically the bounded energy bilinear form `a(u,v)` needed before Lax–Milgram can consume the weak formulation. It is the lowest-hanging uncovered handoff because `main` already contains the pointwise jet integrand and raw-function integral, while no open PDE PR covers their bundling as a continuous form on the existing `L²` space; the later variable-coefficient and Sobolev-domain forms still depend on larger missing infrastructure.

No Mathlib code is vendored. The construction reuses Mathlib's `ContinuousLinearMap.lpPairing` from `Mathlib.MeasureTheory.Function.Holder`, including its integral characterization, and Tau Ceti's existing `energyIntegrand` and symmetry API.

<!--tauceti-target:v1 {"focus":"PDE","id":"continuous-integrated-energy-form-l2"}-->

🤖 Prepared with Codex
