### PR TITLE
feat: add elementary simplicial collapses

### DIFF
--- a/TauCeti/AlgebraicTopology/SimplicialComplex/ElementaryCollapse.lean
+++ b/TauCeti/AlgebraicTopology/SimplicialComplex/ElementaryCollapse.lean
@@ -57,10 +57,6 @@ namespace IsFreePair
 
 variable {K} {σ τ : Finset ι}
 
-/-- The two members of a free pair are distinct. -/
-theorem lower_ne_upper (h : IsFreePair K σ τ) : σ ≠ τ :=
-  h.lower_ssubset_upper.ne
-
 /-- The upper face of a free pair is maximal in the complex. -/
 theorem upper_maximal (h : IsFreePair K σ τ) {ω : Finset ι} (hω : ω ∈ K) (hτω : τ ⊆ ω) :
     ω = τ := by
@@ -97,12 +93,6 @@ theorem mem_deletion_of_isFreePair {σ τ ω : Finset ι} (h : IsFreePair K σ �
 free pair. -/
 def ElementaryCollapsesTo (L : _root_.PreAbstractSimplicialComplex ι) : Prop :=
   ∃ (σ τ : Finset ι), IsFreePair K σ τ ∧ L = deletion K σ
-
-/-- Characterization of an elementary collapse by its free pair. -/
-theorem elementaryCollapsesTo_iff {L : _root_.PreAbstractSimplicialComplex ι} :
-    ElementaryCollapsesTo K L ↔
-      ∃ (σ τ : Finset ι), IsFreePair K σ τ ∧ L = deletion K σ :=
-  Iff.rfl
 
 namespace ElementaryCollapsesTo
 

--- a/TauCeti/AlgebraicTopology/SimplicialComplex/ElementaryCollapse.lean
+++ b/TauCeti/AlgebraicTopology/SimplicialComplex/ElementaryCollapse.lean
@@ -98,6 +98,11 @@ namespace ElementaryCollapsesTo
 
 variable {K L : _root_.PreAbstractSimplicialComplex ι}
 
+/-- A free pair determines an elementary collapse to its deletion. -/
+theorem of_isFreePair {σ τ : Finset ι} (hfree : IsFreePair K σ τ)
+    (hL : L = deletion K σ) : ElementaryCollapsesTo K L :=
+  ⟨σ, τ, hfree, hL⟩
+
 /-- An elementary collapse produces a subcomplex. -/
 theorem le (h : ElementaryCollapsesTo K L) : L ≤ K := by
   obtain ⟨σ, τ, hfree, rfl⟩ := h

--- a/TauCeti/AlgebraicTopology/SimplicialComplex/ElementaryCollapse.lean
+++ b/TauCeti/AlgebraicTopology/SimplicialComplex/ElementaryCollapse.lean
@@ -68,6 +68,16 @@ theorem upper_maximal (h : IsFreePair K σ τ) {ω : Finset ι} (hω : ω ∈ K)
   · exact (h.lower_ssubset_upper.not_subset hτω).elim
   · exact h_eq
 
+/-- The lower face of a free pair has codimension one in the upper face. -/
+theorem covBy (h : IsFreePair K σ τ) : σ ⋖ τ := by
+  refine ⟨h.lower_ssubset_upper, fun ω hσω hωτ => ?_⟩
+  have hω : ω ∈ K :=
+    (K.isRelLowerSet_faces h.upper_mem).2 hωτ.le
+      ((K.isRelLowerSet_faces h.lower_mem).1.mono hσω.le)
+  rcases h.eq_lower_or_eq_upper hω hσω.le with rfl | rfl
+  · exact hσω.false
+  · exact hωτ.false
+
 end IsFreePair
 
 /-- Deleting the lower face of a free pair retains exactly the original faces other than the
@@ -84,14 +94,14 @@ theorem mem_deletion_of_isFreePair {σ τ ω : Finset ι} (h : IsFreePair K σ �
     · exact hωτ rfl
 
 /-- One complex elementarily collapses to another when the latter is obtained by deleting a
-codimension-one free pair. -/
+free pair. -/
 def ElementaryCollapsesTo (L : _root_.PreAbstractSimplicialComplex ι) : Prop :=
-  ∃ (σ τ : Finset ι) (_h : IsFreePair K σ τ), σ ⋖ τ ∧ L = deletion K σ
+  ∃ (σ τ : Finset ι), IsFreePair K σ τ ∧ L = deletion K σ
 
-/-- Characterization of an elementary collapse by its codimension-one free pair. -/
+/-- Characterization of an elementary collapse by its free pair. -/
 theorem elementaryCollapsesTo_iff {L : _root_.PreAbstractSimplicialComplex ι} :
     ElementaryCollapsesTo K L ↔
-      ∃ (σ τ : Finset ι) (_h : IsFreePair K σ τ), σ ⋖ τ ∧ L = deletion K σ :=
+      ∃ (σ τ : Finset ι), IsFreePair K σ τ ∧ L = deletion K σ :=
   Iff.rfl
 
 namespace ElementaryCollapsesTo
@@ -100,13 +110,13 @@ variable {K L : _root_.PreAbstractSimplicialComplex ι}
 
 /-- An elementary collapse produces a subcomplex. -/
 theorem le (h : ElementaryCollapsesTo K L) : L ≤ K := by
-  obtain ⟨σ, τ, hfree, _, rfl⟩ := h
+  obtain ⟨σ, τ, hfree, rfl⟩ := h
   exact deletion_le
 
 /-- An elementary collapse is strict: its lower free face is lost. -/
 theorem lt (h : ElementaryCollapsesTo K L) : L < K := by
   refine lt_of_le_of_ne h.le ?_
-  obtain ⟨σ, τ, hfree, _, rfl⟩ := h
+  obtain ⟨σ, τ, hfree, rfl⟩ := h
   intro h_eq
   have : σ ∈ deletion K σ := h_eq.symm ▸ hfree.lower_mem
   exact (mem_deletion.mp this).2 Finset.Subset.rfl
@@ -116,8 +126,8 @@ away from the selected free pair. -/
 theorem exists_pair (h : ElementaryCollapsesTo K L) :
     ∃ (σ τ : Finset ι) (_hfree : IsFreePair K σ τ), σ ⋖ τ ∧
       ∀ ω, ω ∈ L ↔ ω ∈ K ∧ ω ≠ σ ∧ ω ≠ τ := by
-  obtain ⟨σ, τ, hfree, hcodim, rfl⟩ := h
-  exact ⟨σ, τ, hfree, hcodim, fun ω => by
+  obtain ⟨σ, τ, hfree, rfl⟩ := h
+  exact ⟨σ, τ, hfree, hfree.covBy, fun ω => by
     simpa only [mem_deletion] using mem_deletion_of_isFreePair K hfree⟩
 
 end ElementaryCollapsesTo

--- a/TauCeti/AlgebraicTopology/SimplicialComplex/ElementaryCollapse.lean
+++ b/TauCeti/AlgebraicTopology/SimplicialComplex/ElementaryCollapse.lean
@@ -70,6 +70,8 @@ theorem upper_maximal (h : IsFreePair K σ τ) {ω : Finset ι} (hω : ω ∈ K)
 
 end IsFreePair
 
+/-- Deleting the lower face of a free pair retains exactly the original faces other than the
+lower and upper faces. -/
 theorem mem_deletion_of_isFreePair {σ τ ω : Finset ι} (h : IsFreePair K σ τ) :
     (ω ∈ K ∧ ¬σ ⊆ ω) ↔ ω ∈ K ∧ ω ≠ σ ∧ ω ≠ τ := by
   constructor
@@ -85,6 +87,12 @@ theorem mem_deletion_of_isFreePair {σ τ ω : Finset ι} (h : IsFreePair K σ �
 codimension-one free pair. -/
 def ElementaryCollapsesTo (L : _root_.PreAbstractSimplicialComplex ι) : Prop :=
   ∃ (σ τ : Finset ι) (_h : IsFreePair K σ τ), σ ⋖ τ ∧ L = deletion K σ
+
+/-- Characterization of an elementary collapse by its codimension-one free pair. -/
+theorem elementaryCollapsesTo_iff {L : _root_.PreAbstractSimplicialComplex ι} :
+    ElementaryCollapsesTo K L ↔
+      ∃ (σ τ : Finset ι) (_h : IsFreePair K σ τ), σ ⋖ τ ∧ L = deletion K σ :=
+  Iff.rfl
 
 namespace ElementaryCollapsesTo
 

--- a/TauCeti/Topology/PL/ElementaryCollapse.lean
+++ b/TauCeti/Topology/PL/ElementaryCollapse.lean
@@ -4,7 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 -/
 module
 
-public import Mathlib.AlgebraicTopology.SimplicialComplex.Basic
+public import TauCeti.AlgebraicTopology.SimplicialComplex.LinkStar
 
 /-!
 # Elementary collapses of simplicial complexes
@@ -82,40 +82,28 @@ theorem card_sdiff_eq_one [DecidableEq ι] (h : IsFreePair K σ τ) (hcodim : h.
 
 end IsFreePair
 
-/-- Delete the two faces in a free pair.  Uniqueness of the coface ensures that the remaining
-faces are still downward closed. -/
-def eraseFreePair {σ τ : Finset ι} (h : IsFreePair K σ τ) :
-    _root_.PreAbstractSimplicialComplex ι where
-  faces := K.faces \ {σ, τ}
-  isRelLowerSet_faces := by
-    rintro ω ⟨hω, hω_ne⟩
-    constructor
-    · exact (K.isRelLowerSet_faces hω).1
-    · intro υ hυω hυ
-      refine ⟨(K.isRelLowerSet_faces hω).2 hυω hυ, ?_⟩
-      simp only [Set.mem_insert_iff, Set.mem_singleton_iff, not_or]
-      constructor
-      · intro hυσ
-        subst υ
-        rcases h.eq_lower_or_eq_upper hω hυω with hωσ | hωτ
-        · exact hω_ne (by simp [hωσ])
-        · exact hω_ne (by simp [hωτ])
-      · intro hυτ
-        subst υ
-        have hωτ := h.upper_maximal hω hυω
-        exact hω_ne (by simp [hωτ])
+/-- Delete the two faces in a free pair. -/
+def eraseFreePair {σ τ : Finset ι} (_h : IsFreePair K σ τ) :
+    _root_.PreAbstractSimplicialComplex ι :=
+  deletion K σ
 
 @[simp]
 theorem mem_eraseFreePair {σ τ ω : Finset ι} (h : IsFreePair K σ τ) :
     ω ∈ eraseFreePair K h ↔ ω ∈ K ∧ ω ≠ σ ∧ ω ≠ τ := by
-  change ω ∈ K.faces \ {σ, τ} ↔ ω ∈ K.faces ∧ ω ≠ σ ∧ ω ≠ τ
-  simp only [Set.mem_sdiff, Set.mem_insert_iff, Set.mem_singleton_iff, not_or]
+  rw [eraseFreePair, mem_deletion]
+  constructor
+  · rintro ⟨hω, hσ⟩
+    exact ⟨hω, fun hωσ => hσ hωσ.ge, fun hωτ => hσ (hωτ ▸ h.lower_ssubset_upper.subset)⟩
+  · rintro ⟨hω, hωσ, hωτ⟩
+    refine ⟨hω, fun hσω => ?_⟩
+    rcases h.eq_lower_or_eq_upper hω hσω with rfl | rfl
+    · exact hωσ rfl
+    · exact hωτ rfl
 
 /-- Deleting a free pair only removes faces. -/
 theorem eraseFreePair_le {σ τ : Finset ι} (h : IsFreePair K σ τ) :
-    eraseFreePair K h ≤ K := by
-  intro ω hω
-  exact (mem_eraseFreePair (K := K) h).mp hω |>.1
+    eraseFreePair K h ≤ K :=
+  deletion_le
 
 theorem lower_not_mem_eraseFreePair {σ τ : Finset ι} (h : IsFreePair K σ τ) :
     σ ∉ eraseFreePair K h := by

--- a/TauCeti/Topology/PL/ElementaryCollapse.lean
+++ b/TauCeti/Topology/PL/ElementaryCollapse.lean
@@ -27,7 +27,6 @@ pre-complex type.
 ## Main definitions
 
 * `PreAbstractSimplicialComplex.IsFreePair`: a face and its unique proper coface.
-* `PreAbstractSimplicialComplex.eraseFreePair`: the complex obtained by deleting a free pair.
 * `PreAbstractSimplicialComplex.ElementaryCollapsesTo`: the relation of one elementary collapse.
 -/
 
@@ -82,15 +81,10 @@ theorem card_sdiff_eq_one [DecidableEq ι] (h : IsFreePair K σ τ) (hcodim : h.
 
 end IsFreePair
 
-/-- Delete the two faces in a free pair. -/
-def eraseFreePair {σ τ : Finset ι} (_h : IsFreePair K σ τ) :
-    _root_.PreAbstractSimplicialComplex ι :=
-  deletion K σ
-
 @[simp]
-theorem mem_eraseFreePair {σ τ ω : Finset ι} (h : IsFreePair K σ τ) :
-    ω ∈ eraseFreePair K h ↔ ω ∈ K ∧ ω ≠ σ ∧ ω ≠ τ := by
-  rw [eraseFreePair, mem_deletion]
+theorem mem_deletion_of_isFreePair {σ τ ω : Finset ι} (h : IsFreePair K σ τ) :
+    ω ∈ deletion K σ ↔ ω ∈ K ∧ ω ≠ σ ∧ ω ≠ τ := by
+  rw [mem_deletion]
   constructor
   · rintro ⟨hω, hσ⟩
     exact ⟨hω, fun hωσ => hσ hωσ.ge, fun hωτ => hσ (hωτ ▸ h.lower_ssubset_upper.subset)⟩
@@ -100,23 +94,10 @@ theorem mem_eraseFreePair {σ τ ω : Finset ι} (h : IsFreePair K σ τ) :
     · exact hωσ rfl
     · exact hωτ rfl
 
-/-- Deleting a free pair only removes faces. -/
-theorem eraseFreePair_le {σ τ : Finset ι} (h : IsFreePair K σ τ) :
-    eraseFreePair K h ≤ K :=
-  deletion_le
-
-theorem lower_not_mem_eraseFreePair {σ τ : Finset ι} (h : IsFreePair K σ τ) :
-    σ ∉ eraseFreePair K h := by
-  simp
-
-theorem upper_not_mem_eraseFreePair {σ τ : Finset ι} (h : IsFreePair K σ τ) :
-    τ ∉ eraseFreePair K h := by
-  simp
-
 /-- One complex elementarily collapses to another when the latter is obtained by deleting a
 codimension-one free pair. -/
 def ElementaryCollapsesTo (L : _root_.PreAbstractSimplicialComplex ι) : Prop :=
-  ∃ (σ τ : Finset ι) (h : IsFreePair K σ τ), h.IsCodimensionOne ∧ L = eraseFreePair K h
+  ∃ (σ τ : Finset ι) (h : IsFreePair K σ τ), h.IsCodimensionOne ∧ L = deletion K σ
 
 namespace ElementaryCollapsesTo
 
@@ -125,15 +106,15 @@ variable {K L : _root_.PreAbstractSimplicialComplex ι}
 /-- An elementary collapse produces a subcomplex. -/
 theorem le (h : ElementaryCollapsesTo K L) : L ≤ K := by
   obtain ⟨σ, τ, hfree, _, rfl⟩ := h
-  exact eraseFreePair_le K hfree
+  exact deletion_le
 
 /-- An elementary collapse is strict: its lower free face is lost. -/
 theorem lt (h : ElementaryCollapsesTo K L) : L < K := by
   refine lt_of_le_of_ne h.le ?_
   obtain ⟨σ, τ, hfree, _, rfl⟩ := h
   intro h_eq
-  have : σ ∈ eraseFreePair K hfree := h_eq.symm ▸ hfree.lower_mem
-  exact (lower_not_mem_eraseFreePair K hfree) this
+  have : σ ∈ deletion K σ := h_eq.symm ▸ hfree.lower_mem
+  exact (mem_deletion.mp this).2 Finset.Subset.rfl
 
 /-- Membership in the result of an elementary collapse is membership in the original complex
 away from the selected free pair. -/
@@ -141,7 +122,7 @@ theorem exists_pair (h : ElementaryCollapsesTo K L) :
     ∃ (σ τ : Finset ι) (hfree : IsFreePair K σ τ), hfree.IsCodimensionOne ∧
       ∀ ω, ω ∈ L ↔ ω ∈ K ∧ ω ≠ σ ∧ ω ≠ τ := by
   obtain ⟨σ, τ, hfree, hcodim, rfl⟩ := h
-  exact ⟨σ, τ, hfree, hcodim, fun ω => mem_eraseFreePair K hfree⟩
+  exact ⟨σ, τ, hfree, hcodim, fun ω => mem_deletion_of_isFreePair K hfree⟩
 
 end ElementaryCollapsesTo
 

--- a/TauCeti/Topology/PL/ElementaryCollapse.lean
+++ b/TauCeti/Topology/PL/ElementaryCollapse.lean
@@ -16,8 +16,8 @@ collapse track in layer 11 of the geometric-topology roadmap.
 
 Following Rourke--Sanderson, *Introduction to Piecewise-Linear Topology*, Chapter 3, the pair
 `(σ, τ)` is free when `σ` is a proper face of `τ` and every face containing `σ` is either `σ` or
-`τ`.  The usual codimension-one condition is recorded separately; uniqueness already suffices to
-prove that deleting the pair leaves a simplicial complex.
+`τ`.  The usual codimension-one condition is expressed by Mathlib's finset cover relation;
+uniqueness already suffices to prove that deleting the pair leaves a simplicial complex.
 
 `PreAbstractSimplicialComplex` is intentional here.  Mathlib's `AbstractSimplicialComplex ι`
 contains every singleton of the fixed ambient vertex type `ι`, so deleting a free vertex would
@@ -68,17 +68,6 @@ theorem upper_maximal (h : IsFreePair K σ τ) {ω : Finset ι} (hω : ω ∈ K)
   · exact (h.lower_ssubset_upper.not_subset hτω).elim
   · exact h_eq
 
-/-- A free pair in which the upper face has one additional vertex is a classical elementary
-collapse pair. -/
-def IsCodimensionOne (_h : IsFreePair K σ τ) : Prop :=
-  τ.card = σ.card + 1
-
-/-- A codimension-one free pair has a unique vertex in its upper-minus-lower difference. -/
-theorem card_sdiff_eq_one [DecidableEq ι] (h : IsFreePair K σ τ) (hcodim : h.IsCodimensionOne) :
-    (τ \ σ).card = 1 := by
-  rw [Finset.card_sdiff_of_subset h.lower_ssubset_upper.subset, hcodim]
-  omega
-
 end IsFreePair
 
 theorem mem_deletion_of_isFreePair {σ τ ω : Finset ι} (h : IsFreePair K σ τ) :
@@ -95,7 +84,7 @@ theorem mem_deletion_of_isFreePair {σ τ ω : Finset ι} (h : IsFreePair K σ �
 /-- One complex elementarily collapses to another when the latter is obtained by deleting a
 codimension-one free pair. -/
 def ElementaryCollapsesTo (L : _root_.PreAbstractSimplicialComplex ι) : Prop :=
-  ∃ (σ τ : Finset ι) (h : IsFreePair K σ τ), h.IsCodimensionOne ∧ L = deletion K σ
+  ∃ (σ τ : Finset ι) (_h : IsFreePair K σ τ), σ ⋖ τ ∧ L = deletion K σ
 
 namespace ElementaryCollapsesTo
 
@@ -117,7 +106,7 @@ theorem lt (h : ElementaryCollapsesTo K L) : L < K := by
 /-- Membership in the result of an elementary collapse is membership in the original complex
 away from the selected free pair. -/
 theorem exists_pair (h : ElementaryCollapsesTo K L) :
-    ∃ (σ τ : Finset ι) (hfree : IsFreePair K σ τ), hfree.IsCodimensionOne ∧
+    ∃ (σ τ : Finset ι) (_hfree : IsFreePair K σ τ), σ ⋖ τ ∧
       ∀ ω, ω ∈ L ↔ ω ∈ K ∧ ω ≠ σ ∧ ω ≠ τ := by
   obtain ⟨σ, τ, hfree, hcodim, rfl⟩ := h
   exact ⟨σ, τ, hfree, hcodim, fun ω => by

--- a/TauCeti/Topology/PL/ElementaryCollapse.lean
+++ b/TauCeti/Topology/PL/ElementaryCollapse.lean
@@ -117,12 +117,10 @@ theorem eraseFreePair_le {σ τ : Finset ι} (h : IsFreePair K σ τ) :
   intro ω hω
   exact (mem_eraseFreePair (K := K) h).mp hω |>.1
 
-@[simp]
 theorem lower_not_mem_eraseFreePair {σ τ : Finset ι} (h : IsFreePair K σ τ) :
     σ ∉ eraseFreePair K h := by
   simp
 
-@[simp]
 theorem upper_not_mem_eraseFreePair {σ τ : Finset ι} (h : IsFreePair K σ τ) :
     τ ∉ eraseFreePair K h := by
   simp

--- a/TauCeti/Topology/PL/ElementaryCollapse.lean
+++ b/TauCeti/Topology/PL/ElementaryCollapse.lean
@@ -1,0 +1,164 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+module
+
+public import Mathlib.AlgebraicTopology.SimplicialComplex.Basic
+
+/-!
+# Elementary collapses of simplicial complexes
+
+An elementary simplicial collapse deletes a free face together with its unique proper coface.
+This file supplies that local move for `PreAbstractSimplicialComplex`, Mathlib's type of
+downward-closed collections of nonempty finite faces.  This is the elementary substrate for the
+collapse track in layer 11 of the geometric-topology roadmap.
+
+Following Rourke--Sanderson, *Introduction to Piecewise-Linear Topology*, Chapter 3, the pair
+`(σ, τ)` is free when `σ` is a proper face of `τ` and every face containing `σ` is either `σ` or
+`τ`.  The usual codimension-one condition is recorded separately; uniqueness already suffices to
+prove that deleting the pair leaves a simplicial complex.
+
+`PreAbstractSimplicialComplex` is intentional here.  Mathlib's `AbstractSimplicialComplex ι`
+contains every singleton of the fixed ambient vertex type `ι`, so deleting a free vertex would
+leave that type.  A collapse changes the used vertex set and therefore naturally lives in the
+pre-complex type.
+
+## Main definitions
+
+* `PreAbstractSimplicialComplex.IsFreePair`: a face and its unique proper coface.
+* `PreAbstractSimplicialComplex.eraseFreePair`: the complex obtained by deleting a free pair.
+* `PreAbstractSimplicialComplex.ElementaryCollapsesTo`: the relation of one elementary collapse.
+-/
+
+public section
+
+namespace TauCeti
+
+namespace PreAbstractSimplicialComplex
+
+variable {ι : Type*} (K : _root_.PreAbstractSimplicialComplex ι)
+
+/-- A pair `(σ, τ)` of faces is free when `σ` is a proper face of `τ` and `τ` is the only
+face other than `σ` that contains `σ`.
+
+This formulation includes maximality of `τ`: applying the last field to a face containing `τ`
+forces that face to equal `τ`. -/
+structure IsFreePair (σ τ : Finset ι) : Prop where
+  /-- The lower face belongs to the complex. -/
+  lower_mem : σ ∈ K
+  /-- The upper face belongs to the complex. -/
+  upper_mem : τ ∈ K
+  /-- The lower face is properly contained in the upper face. -/
+  lower_ssubset_upper : σ ⊂ τ
+  /-- These are the only faces of the complex containing the lower face. -/
+  eq_lower_or_eq_upper : ∀ ⦃ω : Finset ι⦄, ω ∈ K → σ ⊆ ω → ω = σ ∨ ω = τ
+
+namespace IsFreePair
+
+variable {K} {σ τ : Finset ι}
+
+/-- The two members of a free pair are distinct. -/
+theorem lower_ne_upper (h : IsFreePair K σ τ) : σ ≠ τ :=
+  h.lower_ssubset_upper.ne
+
+/-- The upper face of a free pair is maximal in the complex. -/
+theorem upper_maximal (h : IsFreePair K σ τ) {ω : Finset ι} (hω : ω ∈ K) (hτω : τ ⊆ ω) :
+    ω = τ := by
+  rcases h.eq_lower_or_eq_upper hω (h.lower_ssubset_upper.subset.trans hτω) with rfl | h_eq
+  · exact (h.lower_ssubset_upper.not_subset hτω).elim
+  · exact h_eq
+
+/-- A free pair in which the upper face has one additional vertex is a classical elementary
+collapse pair. -/
+def IsCodimensionOne (_h : IsFreePair K σ τ) : Prop :=
+  τ.card = σ.card + 1
+
+/-- A codimension-one free pair has a unique vertex in its upper-minus-lower difference. -/
+theorem card_sdiff_eq_one [DecidableEq ι] (h : IsFreePair K σ τ) (hcodim : h.IsCodimensionOne) :
+    (τ \ σ).card = 1 := by
+  rw [Finset.card_sdiff_of_subset h.lower_ssubset_upper.subset, hcodim]
+  omega
+
+end IsFreePair
+
+/-- Delete the two faces in a free pair.  Uniqueness of the coface ensures that the remaining
+faces are still downward closed. -/
+def eraseFreePair {σ τ : Finset ι} (h : IsFreePair K σ τ) :
+    _root_.PreAbstractSimplicialComplex ι where
+  faces := K.faces \ {σ, τ}
+  isRelLowerSet_faces := by
+    rintro ω ⟨hω, hω_ne⟩
+    constructor
+    · exact (K.isRelLowerSet_faces hω).1
+    · intro υ hυω hυ
+      refine ⟨(K.isRelLowerSet_faces hω).2 hυω hυ, ?_⟩
+      simp only [Set.mem_insert_iff, Set.mem_singleton_iff, not_or]
+      constructor
+      · intro hυσ
+        subst υ
+        rcases h.eq_lower_or_eq_upper hω hυω with hωσ | hωτ
+        · exact hω_ne (by simp [hωσ])
+        · exact hω_ne (by simp [hωτ])
+      · intro hυτ
+        subst υ
+        have hωτ := h.upper_maximal hω hυω
+        exact hω_ne (by simp [hωτ])
+
+@[simp]
+theorem mem_eraseFreePair {σ τ ω : Finset ι} (h : IsFreePair K σ τ) :
+    ω ∈ eraseFreePair K h ↔ ω ∈ K ∧ ω ≠ σ ∧ ω ≠ τ := by
+  change ω ∈ K.faces \ {σ, τ} ↔ ω ∈ K.faces ∧ ω ≠ σ ∧ ω ≠ τ
+  simp only [Set.mem_sdiff, Set.mem_insert_iff, Set.mem_singleton_iff, not_or]
+
+/-- Deleting a free pair only removes faces. -/
+theorem eraseFreePair_le {σ τ : Finset ι} (h : IsFreePair K σ τ) :
+    eraseFreePair K h ≤ K := by
+  intro ω hω
+  exact (mem_eraseFreePair (K := K) h).mp hω |>.1
+
+@[simp]
+theorem lower_not_mem_eraseFreePair {σ τ : Finset ι} (h : IsFreePair K σ τ) :
+    σ ∉ eraseFreePair K h := by
+  simp
+
+@[simp]
+theorem upper_not_mem_eraseFreePair {σ τ : Finset ι} (h : IsFreePair K σ τ) :
+    τ ∉ eraseFreePair K h := by
+  simp
+
+/-- One complex elementarily collapses to another when the latter is obtained by deleting a
+codimension-one free pair. -/
+def ElementaryCollapsesTo (L : _root_.PreAbstractSimplicialComplex ι) : Prop :=
+  ∃ (σ τ : Finset ι) (h : IsFreePair K σ τ), h.IsCodimensionOne ∧ L = eraseFreePair K h
+
+namespace ElementaryCollapsesTo
+
+variable {K L : _root_.PreAbstractSimplicialComplex ι}
+
+/-- An elementary collapse produces a subcomplex. -/
+theorem le (h : ElementaryCollapsesTo K L) : L ≤ K := by
+  obtain ⟨σ, τ, hfree, _, rfl⟩ := h
+  exact eraseFreePair_le K hfree
+
+/-- An elementary collapse is strict: its lower free face is lost. -/
+theorem lt (h : ElementaryCollapsesTo K L) : L < K := by
+  refine lt_of_le_of_ne h.le ?_
+  obtain ⟨σ, τ, hfree, _, rfl⟩ := h
+  intro h_eq
+  have : σ ∈ eraseFreePair K hfree := h_eq.symm ▸ hfree.lower_mem
+  exact (lower_not_mem_eraseFreePair K hfree) this
+
+/-- Membership in the result of an elementary collapse is membership in the original complex
+away from the selected free pair. -/
+theorem exists_pair (h : ElementaryCollapsesTo K L) :
+    ∃ (σ τ : Finset ι) (hfree : IsFreePair K σ τ), hfree.IsCodimensionOne ∧
+      ∀ ω, ω ∈ L ↔ ω ∈ K ∧ ω ≠ σ ∧ ω ≠ τ := by
+  obtain ⟨σ, τ, hfree, hcodim, rfl⟩ := h
+  exact ⟨σ, τ, hfree, hcodim, fun ω => mem_eraseFreePair K hfree⟩
+
+end ElementaryCollapsesTo
+
+end PreAbstractSimplicialComplex
+
+end TauCeti

--- a/TauCeti/Topology/PL/ElementaryCollapse.lean
+++ b/TauCeti/Topology/PL/ElementaryCollapse.lean
@@ -81,10 +81,8 @@ theorem card_sdiff_eq_one [DecidableEq ι] (h : IsFreePair K σ τ) (hcodim : h.
 
 end IsFreePair
 
-@[simp]
 theorem mem_deletion_of_isFreePair {σ τ ω : Finset ι} (h : IsFreePair K σ τ) :
-    ω ∈ deletion K σ ↔ ω ∈ K ∧ ω ≠ σ ∧ ω ≠ τ := by
-  rw [mem_deletion]
+    (ω ∈ K ∧ ¬σ ⊆ ω) ↔ ω ∈ K ∧ ω ≠ σ ∧ ω ≠ τ := by
   constructor
   · rintro ⟨hω, hσ⟩
     exact ⟨hω, fun hωσ => hσ hωσ.ge, fun hωτ => hσ (hωτ ▸ h.lower_ssubset_upper.subset)⟩
@@ -122,7 +120,8 @@ theorem exists_pair (h : ElementaryCollapsesTo K L) :
     ∃ (σ τ : Finset ι) (hfree : IsFreePair K σ τ), hfree.IsCodimensionOne ∧
       ∀ ω, ω ∈ L ↔ ω ∈ K ∧ ω ≠ σ ∧ ω ≠ τ := by
   obtain ⟨σ, τ, hfree, hcodim, rfl⟩ := h
-  exact ⟨σ, τ, hfree, hcodim, fun ω => mem_deletion_of_isFreePair K hfree⟩
+  exact ⟨σ, τ, hfree, hcodim, fun ω => by
+    simpa only [mem_deletion] using mem_deletion_of_isFreePair K hfree⟩
 
 end ElementaryCollapsesTo
 


### PR DESCRIPTION
This PR adds the elementary simplicial-collapse move: it packages a free face with its unique proper coface, deletes that pair while proving the remaining faces stay downward closed, imposes the classical codimension-one condition, and records that every elementary collapse produces a strict subcomplex.

This advances `TauCetiRoadmap/GeometricTopology/README.md`, Layer 11, “Triangulations, PL structures, and collapse,” specifically the item “Simplicial collapse (an elementary collapse removes a free face; `K` is collapsible if it collapses to a point).” It is the lowest-hanging uncovered target because pinned Mathlib already supplies downward-closed pre-simplicial complexes but contains no free-pair or collapse API, while the later transitive collapse relation and Zeeman statement depend on this local move.

Use `PreAbstractSimplicialComplex` intentionally: Mathlib’s `AbstractSimplicialComplex ι` includes every singleton of its fixed ambient vertex type, whereas an elementary collapse may delete a free vertex. Follow Rourke–Sanderson, *Introduction to Piecewise-Linear Topology*, Chapter 3, for the free-face and elementary-collapse convention. No Mathlib implementation is vendored; the construction reuses Mathlib’s `PreAbstractSimplicialComplex` downward-closure API.

`lake exe cache get` reported `No files to download` and `Already decompressed 8619 file(s)`. `lake build` reported `Build completed successfully (5144 jobs).` `lake exe axioms` reported `axioms: audited 10250 TauCeti declaration(s); all within the allowlist [propext, Classical.choice, Quot.sound].`

<!--tauceti-target:v1 {"focus":"GeometricTopology","id":"elementary-simplicial-collapse"}-->

🤖 Prepared with Codex
