### PR TITLE
feat: add pointed homotopy invariance

### DIFF
--- a/TauCeti/Topology/Homotopy/HomotopyGroup/Homotopy.lean
+++ b/TauCeti/Topology/Homotopy/HomotopyGroup/Homotopy.lean
@@ -1,0 +1,75 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+module
+
+public import TauCeti.Topology.Homotopy.HomotopyGroup.Map
+
+/-!
+# Pointed homotopy invariance of homotopy groups
+
+A homotopy between based maps must remain fixed at the basepoint in order to induce a
+homotopy between their postcompositions with a generalized loop. This file makes that
+construction explicit and proves that pointed-homotopic maps induce the same map on every
+homotopy group. In positive dimensions it also gives the corresponding equality of bundled
+monoid homomorphisms.
+
+This supplies the pointed-homotopy part of the higher-homotopy API requested in Stage 3,
+item 9 of the Tau Ceti universal-covers roadmap.
+-/
+
+public section
+
+namespace TauCeti
+
+open scoped unitInterval Topology Topology.Homotopy
+open Topology.Homotopy
+
+namespace GenLoop
+
+variable {N X Y : Type*} [TopologicalSpace X] [TopologicalSpace Y]
+  {x : X} {y : Y}
+
+/-- Postcomposing a generalized loop with pointed-homotopic maps gives homotopic generalized
+loops. The homotopy is relative to the cube boundary because the original homotopy is fixed at
+the basepoint. -/
+theorem map_homotopic_of_homotopicRel {f g : C(X, Y)} (hf : f x = y) (hg : g x = y)
+    (H : f.HomotopicRel g {x}) (p : Ω^ N X x) :
+    _root_.GenLoop.Homotopic (map f hf p) (map g hg p) := by
+  obtain ⟨H⟩ := H
+  refine ⟨⟨⟨⟨fun tp ↦ H (tp.1, p.1 tp.2), ?_⟩, ?_, ?_⟩, ?_⟩⟩
+  · fun_prop
+  · intro t
+    simpa only [map, ContinuousMap.comp_apply, _root_.GenLoop.mk_apply] using H.apply_zero (p.1 t)
+  · intro t
+    simpa only [map, ContinuousMap.comp_apply, _root_.GenLoop.mk_apply] using H.apply_one (p.1 t)
+  · intro t u hu
+    convert H.eq_fst t (Set.mem_singleton_iff.mpr (p.2 u hu)) using 1 <;>
+      rfl
+
+end GenLoop
+
+namespace HomotopyGroup
+
+variable {N X Y : Type*} [TopologicalSpace X] [TopologicalSpace Y]
+  {x : X} {y : Y}
+
+/-- Pointed-homotopic continuous maps induce the same function on homotopy groups. -/
+theorem map_eq_of_homotopicRel {f g : C(X, Y)} (hf : f x = y) (hg : g x = y)
+    (H : f.HomotopicRel g {x}) : map (N := N) f hf = map g hg := by
+  funext a
+  refine Quotient.inductionOn a ?_
+  intro p
+  exact Quotient.sound (GenLoop.map_homotopic_of_homotopicRel hf hg H p)
+
+/-- Pointed-homotopic continuous maps have equal induced monoid homomorphisms on
+positive-dimensional homotopy groups. -/
+theorem mapHom_eq_of_homotopicRel [DecidableEq N] [Nonempty N] {f g : C(X, Y)}
+    (hf : f x = y) (hg : g x = y) (H : f.HomotopicRel g {x}) :
+    mapHom (N := N) f hf = mapHom g hg :=
+  MonoidHom.ext fun a ↦ congrFun (map_eq_of_homotopicRel hf hg H) a
+
+end HomotopyGroup
+
+end TauCeti

--- a/TauCeti/Topology/Homotopy/HomotopyGroup/Homotopy.lean
+++ b/TauCeti/Topology/Homotopy/HomotopyGroup/Homotopy.lean
@@ -31,11 +31,11 @@ namespace GenLoop
 variable {N X Y : Type*} [TopologicalSpace X] [TopologicalSpace Y]
   {x : X} {y : Y}
 
-/-- Postcomposing a generalized loop with pointed-homotopic maps gives homotopic generalized
-loops. The homotopy is relative to the cube boundary because the original homotopy is fixed at
-the basepoint. -/
+/-- Postcomposing a generalized loop with maps homotopic relative to a set containing the
+basepoint gives homotopic generalized loops. The resulting homotopy is relative to the cube
+boundary. -/
 theorem map_homotopic_of_homotopicRel {f g : C(X, Y)} (hf : f x = y) (hg : g x = y)
-    (H : f.HomotopicRel g {x}) (p : Ω^ N X x) :
+    {S : Set X} (hx : x ∈ S) (H : f.HomotopicRel g S) (p : Ω^ N X x) :
     _root_.GenLoop.Homotopic (map f hf p) (map g hg p) := by
   obtain ⟨H⟩ := H
   refine ⟨⟨⟨⟨fun tp ↦ H (tp.1, p.1 tp.2), ?_⟩, ?_, ?_⟩, ?_⟩⟩
@@ -45,8 +45,7 @@ theorem map_homotopic_of_homotopicRel {f g : C(X, Y)} (hf : f x = y) (hg : g x =
   · intro t
     simpa only [map, ContinuousMap.comp_apply, _root_.GenLoop.mk_apply] using H.apply_one (p.1 t)
   · intro t u hu
-    change H (t, p u) = f (p u)
-    exact H.eq_fst t (Set.mem_singleton_iff.mpr (p.2 u hu))
+    exact H.eq_fst t (by rw [p.2 u hu]; exact hx)
 
 end GenLoop
 
@@ -55,20 +54,21 @@ namespace HomotopyGroup
 variable {N X Y : Type*} [TopologicalSpace X] [TopologicalSpace Y]
   {x : X} {y : Y}
 
-/-- Pointed-homotopic continuous maps induce the same function on homotopy groups. -/
+/-- Continuous maps homotopic relative to a set containing the basepoint induce the same
+function on homotopy groups. -/
 theorem map_eq_of_homotopicRel {f g : C(X, Y)} (hf : f x = y) (hg : g x = y)
-    (H : f.HomotopicRel g {x}) : map (N := N) f hf = map g hg := by
+    {S : Set X} (hx : x ∈ S) (H : f.HomotopicRel g S) : map (N := N) f hf = map g hg := by
   funext a
   refine Quotient.inductionOn a ?_
   intro p
-  exact Quotient.sound (GenLoop.map_homotopic_of_homotopicRel hf hg H p)
+  exact Quotient.sound (GenLoop.map_homotopic_of_homotopicRel hf hg hx H p)
 
-/-- Pointed-homotopic continuous maps have equal induced monoid homomorphisms on
-positive-dimensional homotopy groups. -/
+/-- Continuous maps homotopic relative to a set containing the basepoint have equal induced
+monoid homomorphisms on positive-dimensional homotopy groups. -/
 theorem mapHom_eq_of_homotopicRel [DecidableEq N] [Nonempty N] {f g : C(X, Y)}
-    (hf : f x = y) (hg : g x = y) (H : f.HomotopicRel g {x}) :
+    (hf : f x = y) (hg : g x = y) {S : Set X} (hx : x ∈ S) (H : f.HomotopicRel g S) :
     mapHom (N := N) f hf = mapHom g hg :=
-  MonoidHom.ext fun a ↦ congrFun (map_eq_of_homotopicRel hf hg H) a
+  MonoidHom.ext fun a ↦ congrFun (map_eq_of_homotopicRel hf hg hx H) a
 
 end HomotopyGroup
 

--- a/TauCeti/Topology/Homotopy/HomotopyGroup/Homotopy.lean
+++ b/TauCeti/Topology/Homotopy/HomotopyGroup/Homotopy.lean
@@ -34,9 +34,9 @@ variable {N X Y : Type*} [TopologicalSpace X] [TopologicalSpace Y]
 /-- Postcomposing a generalized loop with maps homotopic relative to a set containing the
 basepoint gives homotopic generalized loops. The resulting homotopy is relative to the cube
 boundary. -/
-theorem map_homotopic_of_homotopicRel {f g : C(X, Y)} (hf : f x = y) (hg : g x = y)
-    {S : Set X} (hx : x ∈ S) (H : f.HomotopicRel g S) (p : Ω^ N X x) :
-    _root_.GenLoop.Homotopic (map f hf p) (map g hg p) := by
+theorem map_homotopic_of_homotopicRel {f g : C(X, Y)} (hf : f x = y) {S : Set X}
+    (hx : x ∈ S) (H : f.HomotopicRel g S) (p : Ω^ N X x) :
+    _root_.GenLoop.Homotopic (map f hf p) (map g ((H.fst_eq_snd hx).symm.trans hf) p) := by
   obtain ⟨H⟩ := H
   refine ⟨⟨⟨⟨fun tp ↦ H (tp.1, p.1 tp.2), ?_⟩, ?_, ?_⟩, ?_⟩⟩
   · fun_prop
@@ -56,19 +56,20 @@ variable {N X Y : Type*} [TopologicalSpace X] [TopologicalSpace Y]
 
 /-- Continuous maps homotopic relative to a set containing the basepoint induce the same
 function on homotopy groups. -/
-theorem map_eq_of_homotopicRel {f g : C(X, Y)} (hf : f x = y) (hg : g x = y)
-    {S : Set X} (hx : x ∈ S) (H : f.HomotopicRel g S) : map (N := N) f hf = map g hg := by
+theorem map_eq_of_homotopicRel {f g : C(X, Y)} (hf : f x = y) {S : Set X}
+    (hx : x ∈ S) (H : f.HomotopicRel g S) :
+    map (N := N) f hf = map g ((H.fst_eq_snd hx).symm.trans hf) := by
   funext a
   refine Quotient.inductionOn a ?_
   intro p
-  exact Quotient.sound (GenLoop.map_homotopic_of_homotopicRel hf hg hx H p)
+  exact Quotient.sound (GenLoop.map_homotopic_of_homotopicRel hf hx H p)
 
 /-- Continuous maps homotopic relative to a set containing the basepoint have equal induced
 monoid homomorphisms on positive-dimensional homotopy groups. -/
 theorem mapHom_eq_of_homotopicRel [DecidableEq N] [Nonempty N] {f g : C(X, Y)}
-    (hf : f x = y) (hg : g x = y) {S : Set X} (hx : x ∈ S) (H : f.HomotopicRel g S) :
-    mapHom (N := N) f hf = mapHom g hg :=
-  MonoidHom.ext fun a ↦ congrFun (map_eq_of_homotopicRel hf hg hx H) a
+    (hf : f x = y) {S : Set X} (hx : x ∈ S) (H : f.HomotopicRel g S) :
+    mapHom (N := N) f hf = mapHom g ((H.fst_eq_snd hx).symm.trans hf) :=
+  MonoidHom.ext fun a ↦ congrFun (map_eq_of_homotopicRel hf hx H) a
 
 end HomotopyGroup
 

--- a/TauCeti/Topology/Homotopy/HomotopyGroup/Homotopy.lean
+++ b/TauCeti/Topology/Homotopy/HomotopyGroup/Homotopy.lean
@@ -45,8 +45,8 @@ theorem map_homotopic_of_homotopicRel {f g : C(X, Y)} (hf : f x = y) (hg : g x =
   · intro t
     simpa only [map, ContinuousMap.comp_apply, _root_.GenLoop.mk_apply] using H.apply_one (p.1 t)
   · intro t u hu
-    convert H.eq_fst t (Set.mem_singleton_iff.mpr (p.2 u hu)) using 1 <;>
-      rfl
+    change H (t, p u) = f (p u)
+    exact H.eq_fst t (Set.mem_singleton_iff.mpr (p.2 u hu))
 
 end GenLoop
 


### PR DESCRIPTION
This PR proves that pointed-homotopic continuous maps induce the same map on every homotopy group. Precompose the pointed homotopy with a generalized loop; because the homotopy is fixed at the basepoint and a generalized loop sends the cube boundary there, this gives a homotopy relative to the cube boundary. Expose the resulting equality both for the underlying induced functions and, in positive dimensions, for the bundled monoid homomorphisms.

This advances `TauCetiRoadmap/UniversalCovers/README.md`, Stage 3 item 9, specifically the requested pointed-maps and boundary-relative homotopy API on `Ω^N`, which is needed before proving in item 10 that a covering map induces an isomorphism on `π_n` for `n ≥ 2`. It is the lowest-hanging uncovered target because induced-map functoriality is already on `main`, the open PR #1003 separately packages homeomorphism invariance, and pointed homotopy invariance was still absent.

No Mathlib infrastructure is vendored. Reuse Mathlib's `ContinuousMap.HomotopicRel`, `GenLoop.Homotopic`, and quotient API together with Tau Ceti's existing `GenLoop.map` and `HomotopyGroup.map` constructions.

`lake exe cache get` reports `No files to download` and `Already decompressed 8619 file(s)`. `lake build` reports `Build completed successfully (5147 jobs).` `lake exe axioms` reports `axioms: audited 10234 TauCeti declaration(s); all within the allowlist [propext, Classical.choice, Quot.sound].`

<!--tauceti-target:v1 {"focus":"UniversalCovers","id":"pointed-homotopic-maps"}-->

🤖 Prepared with Codex
