### PR TITLE
feat: add abelian variety homomorphisms

### DIFF
--- a/TauCeti/AlgebraicGeometry/AbelianVariety/Hom.lean
+++ b/TauCeti/AlgebraicGeometry/AbelianVariety/Hom.lean
@@ -58,22 +58,32 @@ def Hom.mk' {A B : AbelianVariety K} (f : A.toOver ⟶ B.toOver)
 abbrev Hom.toOverHom {A B : AbelianVariety K} (f : A ⟶ B) : A.toOver ⟶ B.toOver :=
   f.hom.hom.hom.hom
 
+private lemma Hom.grpHom_id (A : AbelianVariety K) :
+    (𝟙 A : A ⟶ A).hom.hom = 𝟙 (Grp.mk A.toOver) :=
+  (congrArg (fun h : CommGrp.mk A.toOver ⟶ CommGrp.mk A.toOver ↦ h.hom)
+    (InducedCategory.id_hom A)).trans
+    (CommGrp.id_hom (CommGrp.mk A.toOver))
+
+private lemma Hom.grpHom_comp {A B C : AbelianVariety K} (f : A ⟶ B) (g : B ⟶ C) :
+    (f ≫ g).hom.hom = f.hom.hom ≫ g.hom.hom :=
+  (congrArg (fun h : CommGrp.mk A.toOver ⟶ CommGrp.mk C.toOver ↦ h.hom)
+    (InducedCategory.comp_hom f g)).trans
+    (CommGrp.comp_hom f.hom g.hom)
+
 /-- `toOverHom` sends the identity homomorphism to the identity over `Spec K`. -/
 @[simp]
 lemma Hom.toOverHom_id (A : AbelianVariety K) : Hom.toOverHom (𝟙 A) = 𝟙 A.toOver :=
   by
-    exact (congrArg (fun h ↦ h.hom.hom.hom) (InducedCategory.id_hom (F := fun A ↦
-      CommGrp.mk A.toOver) A)).trans ((congrArg (fun h ↦ h.hom.hom)
-        (CommGrp.id_hom (CommGrp.mk A.toOver))).trans (Grp.id_hom_hom (Grp.mk A.toOver)))
+    exact (congrArg (fun h ↦ h.hom.hom) (Hom.grpHom_id A)).trans
+      (Grp.id_hom_hom (Grp.mk A.toOver))
 
 /-- `toOverHom` sends composition to composition over `Spec K`. -/
 @[simp, reassoc]
 lemma Hom.toOverHom_comp {A B C : AbelianVariety K} (f : A ⟶ B) (g : B ⟶ C) :
     Hom.toOverHom (f ≫ g) = Hom.toOverHom f ≫ Hom.toOverHom g :=
   by
-    exact (congrArg (fun h ↦ h.hom.hom.hom) (InducedCategory.comp_hom f g)).trans
-      ((congrArg (fun h ↦ h.hom.hom) (CommGrp.comp_hom f.hom g.hom)).trans
-        (Grp.comp_hom_hom f.hom.hom g.hom.hom))
+    exact (congrArg (fun h ↦ h.hom.hom) (Hom.grpHom_comp f g)).trans
+      (Grp.comp_hom_hom f.hom.hom g.hom.hom)
 
 /-- The underlying morphism over `Spec K` of a homomorphism built by `Hom.mk'` is the supplied
 morphism. -/
@@ -88,20 +98,20 @@ lemma Hom.toOverHom_mk' {A B : AbelianVariety K} (f : A.toOver ⟶ B.toOver)
         (one_f := one_f) (mul_f := mul_f))
 
 /-- A homomorphism of abelian varieties preserves the unit section. -/
-@[reassoc]
+@[simp, reassoc]
 lemma Hom.one_hom {A B : AbelianVariety K} (f : A ⟶ B) :
     η[A.toOver] ≫ Hom.toOverHom f = η[B.toOver] :=
   IsMonHom.one_hom f.hom.hom.hom.hom
 
 /-- A homomorphism of abelian varieties preserves multiplication. -/
-@[reassoc]
+@[simp, reassoc]
 lemma Hom.mul_hom {A B : AbelianVariety K} (f : A ⟶ B) :
     μ[A.toOver] ≫ Hom.toOverHom f =
       (Hom.toOverHom f ⊗ₘ Hom.toOverHom f) ≫ μ[B.toOver] :=
   IsMonHom.mul_hom f.hom.hom.hom.hom
 
 /-- A homomorphism of abelian varieties preserves inverses. -/
-@[reassoc]
+@[simp, reassoc]
 lemma Hom.inv_hom {A B : AbelianVariety K} (f : A ⟶ B) :
     ι[A.toOver] ≫ Hom.toOverHom f = Hom.toOverHom f ≫ ι[B.toOver] :=
   GrpObj.inv_hom f.hom.hom.hom.hom
@@ -133,7 +143,7 @@ lemma Hom.toSchemeHom_comp {A B C : AbelianVariety K} (f : A ⟶ B) (g : B ⟶ C
 
 /-- The underlying scheme morphism of an abelian-variety homomorphism commutes with the structure
 morphisms to `Spec K`. -/
-@[reassoc]
+@[simp, reassoc]
 lemma Hom.toSchemeHom_comp_hom {A B : AbelianVariety K} (f : A ⟶ B) :
     Hom.toSchemeHom f ≫ B.toOver.hom = A.toOver.hom :=
   (Hom.toOverHom f).w

--- a/TauCeti/AlgebraicGeometry/AbelianVariety/Hom.lean
+++ b/TauCeti/AlgebraicGeometry/AbelianVariety/Hom.lean
@@ -74,6 +74,17 @@ lemma Hom.toOverHom_comp {A B C : AbelianVariety K} (f : A ⟶ B) (g : B ⟶ C) 
     Hom.toOverHom (f ≫ g) = Hom.toOverHom f ≫ Hom.toOverHom g :=
   (Hom.toOverFunctor).map_comp f g
 
+/-- `toOverHom` is definitionally the iterated underlying-morphism projection through the two
+induced categories, `CommGrp`, and `Grp`. -/
+private lemma Hom.toOverHom_def {A B : AbelianVariety K} (f : A ⟶ B) :
+    Hom.toOverHom f = f.hom.hom.hom.hom :=
+  rfl
+
+/-- The underlying morphism of an abelian-variety homomorphism preserves the group-object
+structure. -/
+instance {A B : AbelianVariety K} (f : A ⟶ B) : IsMonHom (Hom.toOverHom f) :=
+  inferInstanceAs (IsMonHom (f.hom.hom.hom.hom))
+
 /-- The underlying morphism over `Spec K` of a homomorphism built by `Hom.mk'` is the supplied
 morphism. -/
 @[simp]
@@ -82,20 +93,8 @@ lemma Hom.toOverHom_mk' {A B : AbelianVariety K} (f : A.toOver ⟶ B.toOver)
     (mul_f : μ[A.toOver] ≫ f = (f ⊗ₘ f) ≫ μ[B.toOver] := by cat_disch) :
     Hom.toOverHom (Hom.mk' f one_f mul_f) = f :=
   by
-    -- `Hom.mk'` is wrapped by two induced categories; reduce those wrappers here so that all
-    -- clients can use this projection lemma without depending on their definitional equality.
-    change (Grp.homMk'' (A := Grp.mk A.toOver) (B := Grp.mk B.toOver)
-      f one_f mul_f).hom.hom = f
+    rw [Hom.toOverHom_def]
     exact Grp.homMk''_hom_hom (A := Grp.mk A.toOver) (B := Grp.mk B.toOver) f one_f mul_f
-
-/-- `toOverHom` is the iterated underlying-morphism projection of the wrappers stacking up to
-`A ⟶ B`: two induced categories, `CommGrp` and `Grp`. This is `rfl` because `inducedFunctor` and
-`CommGrp.forget` both act as the identity on the underlying morphism, so this lemma is the single
-place recording that definitional equality; other proofs should go through it rather than unfolding
-the wrappers again. -/
-lemma Hom.toOverHom_def {A B : AbelianVariety K} (f : A ⟶ B) :
-    Hom.toOverHom f = f.hom.hom.hom.hom :=
-  rfl
 
 /-- A homomorphism of abelian varieties preserves the unit section. -/
 @[reassoc (attr := simp)]

--- a/TauCeti/AlgebraicGeometry/AbelianVariety/Hom.lean
+++ b/TauCeti/AlgebraicGeometry/AbelianVariety/Hom.lean
@@ -97,14 +97,14 @@ lemma Hom.toOverHom_mk' {A B : AbelianVariety K} (f : A.toOver ⟶ B.toOver)
     exact Grp.homMk''_hom_hom (A := Grp.mk A.toOver) (B := Grp.mk B.toOver) f one_f mul_f
 
 /-- A homomorphism of abelian varieties preserves the unit section. -/
-@[reassoc (attr := simp)]
+@[reassoc]
 lemma Hom.one_hom {A B : AbelianVariety K} (f : A ⟶ B) :
     η[A.toOver] ≫ Hom.toOverHom f = η[B.toOver] := by
   rw [Hom.toOverHom_def]
   exact IsMonHom.one_hom _
 
 /-- A homomorphism of abelian varieties preserves multiplication. -/
-@[reassoc (attr := simp)]
+@[reassoc]
 lemma Hom.mul_hom {A B : AbelianVariety K} (f : A ⟶ B) :
     μ[A.toOver] ≫ Hom.toOverHom f =
       (Hom.toOverHom f ⊗ₘ Hom.toOverHom f) ≫ μ[B.toOver] := by
@@ -112,7 +112,7 @@ lemma Hom.mul_hom {A B : AbelianVariety K} (f : A ⟶ B) :
   exact IsMonHom.mul_hom _
 
 /-- A homomorphism of abelian varieties preserves inverses. -/
-@[reassoc (attr := simp)]
+@[reassoc]
 lemma Hom.inv_hom {A B : AbelianVariety K} (f : A ⟶ B) :
     ι[A.toOver] ≫ Hom.toOverHom f = Hom.toOverHom f ≫ ι[B.toOver] := by
   rw [Hom.toOverHom_def]

--- a/TauCeti/AlgebraicGeometry/AbelianVariety/Hom.lean
+++ b/TauCeti/AlgebraicGeometry/AbelianVariety/Hom.lean
@@ -88,24 +88,36 @@ lemma Hom.toOverHom_mk' {A B : AbelianVariety K} (f : A.toOver ⟶ B.toOver)
       f one_f mul_f).hom.hom = f
     exact Grp.homMk''_hom_hom (A := Grp.mk A.toOver) (B := Grp.mk B.toOver) f one_f mul_f
 
+/-- `toOverHom` is the iterated underlying-morphism projection of the wrappers stacking up to
+`A ⟶ B`: two induced categories, `CommGrp` and `Grp`. This is `rfl` because `inducedFunctor` and
+`CommGrp.forget` both act as the identity on the underlying morphism, so this lemma is the single
+place recording that definitional equality; other proofs should go through it rather than unfolding
+the wrappers again. -/
+lemma Hom.toOverHom_def {A B : AbelianVariety K} (f : A ⟶ B) :
+    Hom.toOverHom f = f.hom.hom.hom.hom :=
+  rfl
+
 /-- A homomorphism of abelian varieties preserves the unit section. -/
 @[reassoc (attr := simp)]
 lemma Hom.one_hom {A B : AbelianVariety K} (f : A ⟶ B) :
-    η[A.toOver] ≫ Hom.toOverHom f = η[B.toOver] :=
-  IsMonHom.one_hom f.hom.hom.hom.hom
+    η[A.toOver] ≫ Hom.toOverHom f = η[B.toOver] := by
+  rw [Hom.toOverHom_def]
+  exact IsMonHom.one_hom _
 
 /-- A homomorphism of abelian varieties preserves multiplication. -/
 @[reassoc (attr := simp)]
 lemma Hom.mul_hom {A B : AbelianVariety K} (f : A ⟶ B) :
     μ[A.toOver] ≫ Hom.toOverHom f =
-      (Hom.toOverHom f ⊗ₘ Hom.toOverHom f) ≫ μ[B.toOver] :=
-  IsMonHom.mul_hom f.hom.hom.hom.hom
+      (Hom.toOverHom f ⊗ₘ Hom.toOverHom f) ≫ μ[B.toOver] := by
+  rw [Hom.toOverHom_def]
+  exact IsMonHom.mul_hom _
 
 /-- A homomorphism of abelian varieties preserves inverses. -/
 @[reassoc (attr := simp)]
 lemma Hom.inv_hom {A B : AbelianVariety K} (f : A ⟶ B) :
-    ι[A.toOver] ≫ Hom.toOverHom f = Hom.toOverHom f ≫ ι[B.toOver] :=
-  GrpObj.inv_hom f.hom.hom.hom.hom
+    ι[A.toOver] ≫ Hom.toOverHom f = Hom.toOverHom f ≫ ι[B.toOver] := by
+  rw [Hom.toOverHom_def]
+  exact GrpObj.inv_hom _
 
 /-- The underlying morphism between the schemes of two abelian varieties. -/
 abbrev Hom.toSchemeHom {A B : AbelianVariety K} (f : A ⟶ B) : A.toScheme ⟶ B.toScheme :=
@@ -145,6 +157,7 @@ equal. -/
 @[ext]
 lemma Hom.ext {A B : AbelianVariety K} {f g : A ⟶ B}
     (h : Hom.toSchemeHom f = Hom.toSchemeHom g) : f = g := by
+  simp only [Hom.toSchemeHom, Hom.toOverHom_def] at h
   apply InducedCategory.hom_ext
   apply CommGrp.hom_ext
   exact Over.OverMorphism.ext h

--- a/TauCeti/AlgebraicGeometry/AbelianVariety/Hom.lean
+++ b/TauCeti/AlgebraicGeometry/AbelianVariety/Hom.lean
@@ -82,6 +82,8 @@ lemma Hom.toOverHom_mk' {A B : AbelianVariety K} (f : A.toOver ⟶ B.toOver)
     (mul_f : μ[A.toOver] ≫ f = (f ⊗ₘ f) ≫ μ[B.toOver] := by cat_disch) :
     Hom.toOverHom (Hom.mk' f one_f mul_f) = f :=
   by
+    -- `Hom.mk'` is wrapped by two induced categories; reduce those wrappers here so that all
+    -- clients can use this projection lemma without depending on their definitional equality.
     change (Grp.homMk'' (A := Grp.mk A.toOver) (B := Grp.mk B.toOver)
       f one_f mul_f).hom.hom = f
     exact Grp.homMk''_hom_hom (A := Grp.mk A.toOver) (B := Grp.mk B.toOver) f one_f mul_f
@@ -132,7 +134,7 @@ lemma Hom.toSchemeHom_comp {A B C : AbelianVariety K} (f : A ⟶ B) (g : B ⟶ C
 
 /-- The underlying scheme morphism of an abelian-variety homomorphism commutes with the structure
 morphisms to `Spec K`. -/
-@[reassoc]
+@[reassoc (attr := simp)]
 lemma Hom.toSchemeHom_comp_hom {A B : AbelianVariety K} (f : A ⟶ B) :
     Hom.toSchemeHom f ≫ B.toOver.hom = A.toOver.hom :=
   (Hom.toOverHom f).w

--- a/TauCeti/AlgebraicGeometry/AbelianVariety/Hom.lean
+++ b/TauCeti/AlgebraicGeometry/AbelianVariety/Hom.lean
@@ -54,36 +54,26 @@ def Hom.mk' {A B : AbelianVariety K} (f : A.toOver ⟶ B.toOver)
     (mul_f : μ[A.toOver] ≫ f = (f ⊗ₘ f) ≫ μ[B.toOver] := by cat_disch) : A ⟶ B :=
   InducedCategory.homMk (InducedCategory.homMk (Grp.homMk'' f one_f mul_f))
 
+/-- The forgetful functor from abelian varieties to schemes over `Spec K`. -/
+@[expose] noncomputable def Hom.toOverFunctor :
+    AbelianVariety K ⥤ Over (Spec (.of K)) :=
+  inducedFunctor (fun A : AbelianVariety K ↦ CommGrp.mk A.toOver) ⋙
+    CommGrp.forget (Over (Spec (.of K)))
+
 /-- The underlying morphism of group schemes over `Spec K`. -/
 abbrev Hom.toOverHom {A B : AbelianVariety K} (f : A ⟶ B) : A.toOver ⟶ B.toOver :=
-  f.hom.hom.hom.hom
-
-private lemma Hom.grpHom_id (A : AbelianVariety K) :
-    (𝟙 A : A ⟶ A).hom.hom = 𝟙 (Grp.mk A.toOver) :=
-  (congrArg (fun h : CommGrp.mk A.toOver ⟶ CommGrp.mk A.toOver ↦ h.hom)
-    (InducedCategory.id_hom A)).trans
-    (CommGrp.id_hom (CommGrp.mk A.toOver))
-
-private lemma Hom.grpHom_comp {A B C : AbelianVariety K} (f : A ⟶ B) (g : B ⟶ C) :
-    (f ≫ g).hom.hom = f.hom.hom ≫ g.hom.hom :=
-  (congrArg (fun h : CommGrp.mk A.toOver ⟶ CommGrp.mk C.toOver ↦ h.hom)
-    (InducedCategory.comp_hom f g)).trans
-    (CommGrp.comp_hom f.hom g.hom)
+  (Hom.toOverFunctor).map f
 
 /-- `toOverHom` sends the identity homomorphism to the identity over `Spec K`. -/
 @[simp]
 lemma Hom.toOverHom_id (A : AbelianVariety K) : Hom.toOverHom (𝟙 A) = 𝟙 A.toOver :=
-  by
-    exact (congrArg (fun h ↦ h.hom.hom) (Hom.grpHom_id A)).trans
-      (Grp.id_hom_hom (Grp.mk A.toOver))
+  (Hom.toOverFunctor).map_id A
 
 /-- `toOverHom` sends composition to composition over `Spec K`. -/
 @[simp, reassoc]
 lemma Hom.toOverHom_comp {A B C : AbelianVariety K} (f : A ⟶ B) (g : B ⟶ C) :
     Hom.toOverHom (f ≫ g) = Hom.toOverHom f ≫ Hom.toOverHom g :=
-  by
-    exact (congrArg (fun h ↦ h.hom.hom) (Hom.grpHom_comp f g)).trans
-      (Grp.comp_hom_hom f.hom.hom g.hom.hom)
+  (Hom.toOverFunctor).map_comp f g
 
 /-- The underlying morphism over `Spec K` of a homomorphism built by `Hom.mk'` is the supplied
 morphism. -/
@@ -93,25 +83,25 @@ lemma Hom.toOverHom_mk' {A B : AbelianVariety K} (f : A.toOver ⟶ B.toOver)
     (mul_f : μ[A.toOver] ≫ f = (f ⊗ₘ f) ≫ μ[B.toOver] := by cat_disch) :
     Hom.toOverHom (Hom.mk' f one_f mul_f) = f :=
   by
-    simpa only [Hom.toOverHom, Hom.mk', InducedCategory.homMk_hom] using
-      (Grp.homMk''_hom_hom (A := Grp.mk A.toOver) (B := Grp.mk B.toOver) f
-        (one_f := one_f) (mul_f := mul_f))
+    change (Grp.homMk'' (A := Grp.mk A.toOver) (B := Grp.mk B.toOver)
+      f one_f mul_f).hom.hom = f
+    exact Grp.homMk''_hom_hom (A := Grp.mk A.toOver) (B := Grp.mk B.toOver) f one_f mul_f
 
 /-- A homomorphism of abelian varieties preserves the unit section. -/
-@[reassoc]
+@[reassoc (attr := simp)]
 lemma Hom.one_hom {A B : AbelianVariety K} (f : A ⟶ B) :
     η[A.toOver] ≫ Hom.toOverHom f = η[B.toOver] :=
   IsMonHom.one_hom f.hom.hom.hom.hom
 
 /-- A homomorphism of abelian varieties preserves multiplication. -/
-@[reassoc]
+@[reassoc (attr := simp)]
 lemma Hom.mul_hom {A B : AbelianVariety K} (f : A ⟶ B) :
     μ[A.toOver] ≫ Hom.toOverHom f =
       (Hom.toOverHom f ⊗ₘ Hom.toOverHom f) ≫ μ[B.toOver] :=
   IsMonHom.mul_hom f.hom.hom.hom.hom
 
 /-- A homomorphism of abelian varieties preserves inverses. -/
-@[reassoc]
+@[reassoc (attr := simp)]
 lemma Hom.inv_hom {A B : AbelianVariety K} (f : A ⟶ B) :
     ι[A.toOver] ≫ Hom.toOverHom f = Hom.toOverHom f ≫ ι[B.toOver] :=
   GrpObj.inv_hom f.hom.hom.hom.hom
@@ -143,7 +133,7 @@ lemma Hom.toSchemeHom_comp {A B C : AbelianVariety K} (f : A ⟶ B) (g : B ⟶ C
 
 /-- The underlying scheme morphism of an abelian-variety homomorphism commutes with the structure
 morphisms to `Spec K`. -/
-@[reassoc]
+@[reassoc (attr := simp)]
 lemma Hom.toSchemeHom_comp_hom {A B : AbelianVariety K} (f : A ⟶ B) :
     Hom.toSchemeHom f ≫ B.toOver.hom = A.toOver.hom :=
   (Hom.toOverHom f).w

--- a/TauCeti/AlgebraicGeometry/AbelianVariety/Hom.lean
+++ b/TauCeti/AlgebraicGeometry/AbelianVariety/Hom.lean
@@ -88,13 +88,13 @@ lemma Hom.toOverHom_mk' {A B : AbelianVariety K} (f : A.toOver ⟶ B.toOver)
         (one_f := one_f) (mul_f := mul_f))
 
 /-- A homomorphism of abelian varieties preserves the unit section. -/
-@[simp, reassoc]
+@[reassoc]
 lemma Hom.one_hom {A B : AbelianVariety K} (f : A ⟶ B) :
     η[A.toOver] ≫ Hom.toOverHom f = η[B.toOver] :=
   IsMonHom.one_hom f.hom.hom.hom.hom
 
 /-- A homomorphism of abelian varieties preserves multiplication. -/
-@[simp, reassoc]
+@[reassoc]
 lemma Hom.mul_hom {A B : AbelianVariety K} (f : A ⟶ B) :
     μ[A.toOver] ≫ Hom.toOverHom f =
       (Hom.toOverHom f ⊗ₘ Hom.toOverHom f) ≫ μ[B.toOver] :=

--- a/TauCeti/AlgebraicGeometry/AbelianVariety/Hom.lean
+++ b/TauCeti/AlgebraicGeometry/AbelianVariety/Hom.lean
@@ -98,20 +98,20 @@ lemma Hom.toOverHom_mk' {A B : AbelianVariety K} (f : A.toOver ⟶ B.toOver)
         (one_f := one_f) (mul_f := mul_f))
 
 /-- A homomorphism of abelian varieties preserves the unit section. -/
-@[simp, reassoc]
+@[reassoc]
 lemma Hom.one_hom {A B : AbelianVariety K} (f : A ⟶ B) :
     η[A.toOver] ≫ Hom.toOverHom f = η[B.toOver] :=
   IsMonHom.one_hom f.hom.hom.hom.hom
 
 /-- A homomorphism of abelian varieties preserves multiplication. -/
-@[simp, reassoc]
+@[reassoc]
 lemma Hom.mul_hom {A B : AbelianVariety K} (f : A ⟶ B) :
     μ[A.toOver] ≫ Hom.toOverHom f =
       (Hom.toOverHom f ⊗ₘ Hom.toOverHom f) ≫ μ[B.toOver] :=
   IsMonHom.mul_hom f.hom.hom.hom.hom
 
 /-- A homomorphism of abelian varieties preserves inverses. -/
-@[simp, reassoc]
+@[reassoc]
 lemma Hom.inv_hom {A B : AbelianVariety K} (f : A ⟶ B) :
     ι[A.toOver] ≫ Hom.toOverHom f = Hom.toOverHom f ≫ ι[B.toOver] :=
   GrpObj.inv_hom f.hom.hom.hom.hom
@@ -143,7 +143,7 @@ lemma Hom.toSchemeHom_comp {A B C : AbelianVariety K} (f : A ⟶ B) (g : B ⟶ C
 
 /-- The underlying scheme morphism of an abelian-variety homomorphism commutes with the structure
 morphisms to `Spec K`. -/
-@[simp, reassoc]
+@[reassoc]
 lemma Hom.toSchemeHom_comp_hom {A B : AbelianVariety K} (f : A ⟶ B) :
     Hom.toSchemeHom f ≫ B.toOver.hom = A.toOver.hom :=
   (Hom.toOverHom f).w

--- a/TauCeti/AlgebraicGeometry/AbelianVariety/Hom.lean
+++ b/TauCeti/AlgebraicGeometry/AbelianVariety/Hom.lean
@@ -86,19 +86,19 @@ lemma comp_hom {A B C : AbelianVariety K} (f : A ⟶ B) (g : B ⟶ C) :
   rfl
 
 /-- A homomorphism of abelian varieties preserves the unit section. -/
-@[reassoc (attr := simp)]
+@[reassoc]
 lemma Hom.one_hom {A B : AbelianVariety K} (f : A ⟶ B) :
     η[A.toOver] ≫ f.hom = η[B.toOver] :=
   IsMonHom.one_hom f.hom
 
 /-- A homomorphism of abelian varieties preserves multiplication. -/
-@[reassoc (attr := simp)]
+@[reassoc]
 lemma Hom.mul_hom {A B : AbelianVariety K} (f : A ⟶ B) :
     μ[A.toOver] ≫ f.hom = (f.hom ⊗ₘ f.hom) ≫ μ[B.toOver] :=
   IsMonHom.mul_hom f.hom
 
 /-- A homomorphism of abelian varieties preserves inverses. -/
-@[reassoc (attr := simp)]
+@[reassoc]
 lemma Hom.inv_hom {A B : AbelianVariety K} (f : A ⟶ B) :
     ι[A.toOver] ≫ f.hom = f.hom ≫ ι[B.toOver] :=
   GrpObj.inv_hom f.hom
@@ -119,7 +119,7 @@ lemma Hom.toSchemeHom_comp {A B C : AbelianVariety K} (f : A ⟶ B) (g : B ⟶ C
 
 /-- The underlying scheme morphism of an abelian-variety homomorphism commutes with the structure
 morphisms to `Spec K`. -/
-@[reassoc (attr := simp)]
+@[reassoc]
 lemma Hom.toSchemeHom_comp_hom {A B : AbelianVariety K} (f : A ⟶ B) :
     f.toSchemeHom ≫ B.toOver.hom = A.toOver.hom :=
   f.hom.w

--- a/TauCeti/AlgebraicGeometry/AbelianVariety/Hom.lean
+++ b/TauCeti/AlgebraicGeometry/AbelianVariety/Hom.lean
@@ -49,7 +49,6 @@ noncomputable instance : Category (AbelianVariety K) :=
 
 /-- Construct a homomorphism of abelian varieties from a morphism over `Spec K` and proofs that it
 preserves the unit and multiplication. -/
-@[expose]
 def Hom.mk' {A B : AbelianVariety K} (f : A.toOver ⟶ B.toOver)
     (one_f : η[A.toOver] ≫ f = η[B.toOver] := by cat_disch)
     (mul_f : μ[A.toOver] ≫ f = (f ⊗ₘ f) ≫ μ[B.toOver] := by cat_disch) : A ⟶ B :=
@@ -62,13 +61,19 @@ abbrev Hom.toOverHom {A B : AbelianVariety K} (f : A ⟶ B) : A.toOver ⟶ B.toO
 /-- `toOverHom` sends the identity homomorphism to the identity over `Spec K`. -/
 @[simp]
 lemma Hom.toOverHom_id (A : AbelianVariety K) : Hom.toOverHom (𝟙 A) = 𝟙 A.toOver :=
-  rfl
+  by
+    exact (congrArg (fun h ↦ h.hom.hom.hom) (InducedCategory.id_hom (F := fun A ↦
+      CommGrp.mk A.toOver) A)).trans ((congrArg (fun h ↦ h.hom.hom)
+        (CommGrp.id_hom (CommGrp.mk A.toOver))).trans (Grp.id_hom_hom (Grp.mk A.toOver)))
 
 /-- `toOverHom` sends composition to composition over `Spec K`. -/
 @[simp, reassoc]
 lemma Hom.toOverHom_comp {A B C : AbelianVariety K} (f : A ⟶ B) (g : B ⟶ C) :
     Hom.toOverHom (f ≫ g) = Hom.toOverHom f ≫ Hom.toOverHom g :=
-  rfl
+  by
+    exact (congrArg (fun h ↦ h.hom.hom.hom) (InducedCategory.comp_hom f g)).trans
+      ((congrArg (fun h ↦ h.hom.hom) (CommGrp.comp_hom f.hom g.hom)).trans
+        (Grp.comp_hom_hom f.hom.hom g.hom.hom))
 
 /-- The underlying morphism over `Spec K` of a homomorphism built by `Hom.mk'` is the supplied
 morphism. -/
@@ -77,16 +82,19 @@ lemma Hom.toOverHom_mk' {A B : AbelianVariety K} (f : A.toOver ⟶ B.toOver)
     (one_f : η[A.toOver] ≫ f = η[B.toOver] := by cat_disch)
     (mul_f : μ[A.toOver] ≫ f = (f ⊗ₘ f) ≫ μ[B.toOver] := by cat_disch) :
     Hom.toOverHom (Hom.mk' f one_f mul_f) = f :=
-  rfl
+  by
+    simpa only [Hom.toOverHom, Hom.mk', InducedCategory.homMk_hom] using
+      (Grp.homMk''_hom_hom (A := Grp.mk A.toOver) (B := Grp.mk B.toOver) f
+        (one_f := one_f) (mul_f := mul_f))
 
 /-- A homomorphism of abelian varieties preserves the unit section. -/
-@[reassoc]
+@[simp, reassoc]
 lemma Hom.one_hom {A B : AbelianVariety K} (f : A ⟶ B) :
     η[A.toOver] ≫ Hom.toOverHom f = η[B.toOver] :=
   IsMonHom.one_hom f.hom.hom.hom.hom
 
 /-- A homomorphism of abelian varieties preserves multiplication. -/
-@[reassoc]
+@[simp, reassoc]
 lemma Hom.mul_hom {A B : AbelianVariety K} (f : A ⟶ B) :
     μ[A.toOver] ≫ Hom.toOverHom f =
       (Hom.toOverHom f ⊗ₘ Hom.toOverHom f) ≫ μ[B.toOver] :=

--- a/TauCeti/AlgebraicGeometry/AbelianVariety/Hom.lean
+++ b/TauCeti/AlgebraicGeometry/AbelianVariety/Hom.lean
@@ -5,16 +5,17 @@ Released under Apache 2.0 license as described in the file LICENSE.
 module
 
 public import TauCeti.AlgebraicGeometry.AbelianVariety.Basic
+public import Mathlib.CategoryTheory.Monoidal.CommGrp_
 
 /-!
 # Homomorphisms of abelian varieties
 
 This file supplies the morphism part of the basic abelian-variety API. A homomorphism of abelian
 varieties over `K` is a morphism over `Spec K` preserving the unit and multiplication of the
-underlying group schemes. Such morphisms form a category, inherited from Mathlib's category of
-group objects.
+underlying group schemes. Such morphisms form the category `AbelianVariety K`, inherited from
+Mathlib's category of commutative group objects.
 
-The bundled `AbelianVariety.Hom` is the type required by the Jacobian's universal property: the
+The category morphism type `A ⟶ B` is the type required by the Jacobian's universal property: the
 factorization from the Jacobian to another abelian variety must preserve the group law, rather than
 being only a morphism of the underlying schemes. The characteristic lemmas expose preservation of
 the unit, multiplication, and inverse, as well as the underlying morphism of schemes.
@@ -22,8 +23,8 @@ the unit, multiplication, and inverse, as well as the underlying morphism of sch
 This advances `TauCetiRoadmap/JacobianChallenge/README.md`, Layer E, "Abelian variety = smooth,
 proper, geometrically connected group scheme over `k`; basic API", and prepares Layer F's unique
 "homomorphism of abelian varieties". No external mathematics is vendored; the implementation
-reuses Mathlib's `Grp` category and its `IsMonHom` API for group objects in a cartesian monoidal
-category.
+reuses Mathlib's `CommGrp` category and its `IsMonHom` API for group objects in a cartesian
+monoidal category.
 -/
 
 public section
@@ -42,67 +43,85 @@ variable {K : Type u} [Field K]
 
 noncomputable section
 
-/-- The group object over `Spec K` underlying an abelian variety. -/
-@[expose]
-def toGrp (A : AbelianVariety K) : Grp (Over (Spec (.of K))) :=
-  ⟨A.toOver⟩
-
 /-- Abelian varieties over a fixed field form a category with group-scheme homomorphisms. -/
 noncomputable instance : Category (AbelianVariety K) :=
-  inferInstanceAs (Category (InducedCategory _ toGrp))
+  inferInstanceAs (Category (InducedCategory _ (fun A ↦ CommGrp.mk A.toOver)))
 
 /-- Construct a homomorphism of abelian varieties from a morphism over `Spec K` and proofs that it
 preserves the unit and multiplication. -/
+@[expose]
 def Hom.mk' {A B : AbelianVariety K} (f : A.toOver ⟶ B.toOver)
     (one_f : η[A.toOver] ≫ f = η[B.toOver] := by cat_disch)
     (mul_f : μ[A.toOver] ≫ f = (f ⊗ₘ f) ≫ μ[B.toOver] := by cat_disch) : A ⟶ B :=
-  InducedCategory.homMk (Grp.homMk'' f one_f mul_f)
+  InducedCategory.homMk (InducedCategory.homMk (Grp.homMk'' f one_f mul_f))
 
 /-- The underlying morphism of group schemes over `Spec K`. -/
 abbrev Hom.toOverHom {A B : AbelianVariety K} (f : A ⟶ B) : A.toOver ⟶ B.toOver :=
-  f.hom.hom.hom
+  f.hom.hom.hom.hom
 
+/-- `toOverHom` sends the identity homomorphism to the identity over `Spec K`. -/
 @[simp]
-lemma id_hom (A : AbelianVariety K) : Hom.toOverHom (CategoryStruct.id A) = 𝟙 A.toOver :=
-  Grp.id_hom_hom _
+lemma Hom.toOverHom_id (A : AbelianVariety K) : Hom.toOverHom (𝟙 A) = 𝟙 A.toOver :=
+  rfl
 
+/-- `toOverHom` sends composition to composition over `Spec K`. -/
 @[simp, reassoc]
-lemma comp_hom {A B C : AbelianVariety K} (f : A ⟶ B) (g : B ⟶ C) :
+lemma Hom.toOverHom_comp {A B C : AbelianVariety K} (f : A ⟶ B) (g : B ⟶ C) :
     Hom.toOverHom (f ≫ g) = Hom.toOverHom f ≫ Hom.toOverHom g :=
-  Grp.comp_hom_hom _ _
+  rfl
+
+/-- The underlying morphism over `Spec K` of a homomorphism built by `Hom.mk'` is the supplied
+morphism. -/
+@[simp]
+lemma Hom.toOverHom_mk' {A B : AbelianVariety K} (f : A.toOver ⟶ B.toOver)
+    (one_f : η[A.toOver] ≫ f = η[B.toOver] := by cat_disch)
+    (mul_f : μ[A.toOver] ≫ f = (f ⊗ₘ f) ≫ μ[B.toOver] := by cat_disch) :
+    Hom.toOverHom (Hom.mk' f one_f mul_f) = f :=
+  rfl
 
 /-- A homomorphism of abelian varieties preserves the unit section. -/
 @[reassoc]
 lemma Hom.one_hom {A B : AbelianVariety K} (f : A ⟶ B) :
     η[A.toOver] ≫ Hom.toOverHom f = η[B.toOver] :=
-  IsMonHom.one_hom f.hom.hom.hom
+  IsMonHom.one_hom f.hom.hom.hom.hom
 
 /-- A homomorphism of abelian varieties preserves multiplication. -/
 @[reassoc]
 lemma Hom.mul_hom {A B : AbelianVariety K} (f : A ⟶ B) :
     μ[A.toOver] ≫ Hom.toOverHom f =
       (Hom.toOverHom f ⊗ₘ Hom.toOverHom f) ≫ μ[B.toOver] :=
-  IsMonHom.mul_hom f.hom.hom.hom
+  IsMonHom.mul_hom f.hom.hom.hom.hom
 
 /-- A homomorphism of abelian varieties preserves inverses. -/
 @[reassoc]
 lemma Hom.inv_hom {A B : AbelianVariety K} (f : A ⟶ B) :
     ι[A.toOver] ≫ Hom.toOverHom f = Hom.toOverHom f ≫ ι[B.toOver] :=
-  GrpObj.inv_hom f.hom.hom.hom
+  GrpObj.inv_hom f.hom.hom.hom.hom
 
 /-- The underlying morphism between the schemes of two abelian varieties. -/
 abbrev Hom.toSchemeHom {A B : AbelianVariety K} (f : A ⟶ B) : A.toScheme ⟶ B.toScheme :=
   (Hom.toOverHom f).left
 
+/-- The underlying scheme morphism of a homomorphism built by `Hom.mk'` is the supplied morphism's
+left component. -/
+@[simp]
+lemma Hom.toSchemeHom_mk' {A B : AbelianVariety K} (f : A.toOver ⟶ B.toOver)
+    (one_f : η[A.toOver] ≫ f = η[B.toOver] := by cat_disch)
+    (mul_f : μ[A.toOver] ≫ f = (f ⊗ₘ f) ≫ μ[B.toOver] := by cat_disch) :
+    Hom.toSchemeHom (Hom.mk' f one_f mul_f) = f.left := by
+  exact congrArg Over.Hom.left (Hom.toOverHom_mk' f one_f mul_f)
+
+/-- `toSchemeHom` sends the identity homomorphism to the identity scheme morphism. -/
 @[simp]
 lemma Hom.toSchemeHom_id (A : AbelianVariety K) :
     Hom.toSchemeHom (𝟙 A) = 𝟙 A.toScheme :=
-  rfl
+  congrArg Over.Hom.left (Hom.toOverHom_id A)
 
+/-- `toSchemeHom` sends composition to composition of scheme morphisms. -/
 @[simp, reassoc]
 lemma Hom.toSchemeHom_comp {A B C : AbelianVariety K} (f : A ⟶ B) (g : B ⟶ C) :
     Hom.toSchemeHom (f ≫ g) = Hom.toSchemeHom f ≫ Hom.toSchemeHom g :=
-  rfl
+  congrArg Over.Hom.left (Hom.toOverHom_comp f g)
 
 /-- The underlying scheme morphism of an abelian-variety homomorphism commutes with the structure
 morphisms to `Spec K`. -/
@@ -113,10 +132,11 @@ lemma Hom.toSchemeHom_comp_hom {A B : AbelianVariety K} (f : A ⟶ B) :
 
 /-- Two homomorphisms of abelian varieties are equal when their underlying scheme morphisms are
 equal. -/
-lemma Hom.ext_toSchemeHom {A B : AbelianVariety K} {f g : A ⟶ B}
+@[ext]
+lemma Hom.ext {A B : AbelianVariety K} {f g : A ⟶ B}
     (h : Hom.toSchemeHom f = Hom.toSchemeHom g) : f = g := by
   apply InducedCategory.hom_ext
-  apply Grp.hom_ext
+  apply CommGrp.hom_ext
   exact Over.OverMorphism.ext h
 
 end

--- a/TauCeti/AlgebraicGeometry/AbelianVariety/Hom.lean
+++ b/TauCeti/AlgebraicGeometry/AbelianVariety/Hom.lean
@@ -65,12 +65,11 @@ abbrev Hom.toOverHom {A B : AbelianVariety K} (f : A ⟶ B) : A.toOver ⟶ B.toO
   (Hom.toOverFunctor).map f
 
 /-- `toOverHom` sends the identity homomorphism to the identity over `Spec K`. -/
-@[simp]
 lemma Hom.toOverHom_id (A : AbelianVariety K) : Hom.toOverHom (𝟙 A) = 𝟙 A.toOver :=
   (Hom.toOverFunctor).map_id A
 
 /-- `toOverHom` sends composition to composition over `Spec K`. -/
-@[simp, reassoc]
+@[reassoc]
 lemma Hom.toOverHom_comp {A B C : AbelianVariety K} (f : A ⟶ B) (g : B ⟶ C) :
     Hom.toOverHom (f ≫ g) = Hom.toOverHom f ≫ Hom.toOverHom g :=
   (Hom.toOverFunctor).map_comp f g
@@ -133,7 +132,7 @@ lemma Hom.toSchemeHom_comp {A B C : AbelianVariety K} (f : A ⟶ B) (g : B ⟶ C
 
 /-- The underlying scheme morphism of an abelian-variety homomorphism commutes with the structure
 morphisms to `Spec K`. -/
-@[reassoc (attr := simp)]
+@[reassoc]
 lemma Hom.toSchemeHom_comp_hom {A B : AbelianVariety K} (f : A ⟶ B) :
     Hom.toSchemeHom f ≫ B.toOver.hom = A.toOver.hom :=
   (Hom.toOverHom f).w

--- a/TauCeti/AlgebraicGeometry/AbelianVariety/Hom.lean
+++ b/TauCeti/AlgebraicGeometry/AbelianVariety/Hom.lean
@@ -83,7 +83,7 @@ private lemma Hom.toOverHom_def {A B : AbelianVariety K} (f : A ⟶ B) :
 /-- The underlying morphism of an abelian-variety homomorphism preserves the group-object
 structure. -/
 instance {A B : AbelianVariety K} (f : A ⟶ B) : IsMonHom (Hom.toOverHom f) :=
-  inferInstanceAs (IsMonHom (f.hom.hom.hom.hom))
+  Hom.toOverHom_def f ▸ inferInstance
 
 /-- The underlying morphism over `Spec K` of a homomorphism built by `Hom.mk'` is the supplied
 morphism. -/

--- a/TauCeti/AlgebraicGeometry/AbelianVariety/Hom.lean
+++ b/TauCeti/AlgebraicGeometry/AbelianVariety/Hom.lean
@@ -134,7 +134,8 @@ lemma Hom.toSchemeHom_comp {A B C : AbelianVariety K} (f : A ⟶ B) (g : B ⟶ C
 
 /-- The underlying scheme morphism of an abelian-variety homomorphism commutes with the structure
 morphisms to `Spec K`. -/
-@[reassoc (attr := simp)]
+-- Not `@[simp]`: `CategoryTheory.Over.w` is already a simp lemma and discharges this goal.
+@[reassoc]
 lemma Hom.toSchemeHom_comp_hom {A B : AbelianVariety K} (f : A ⟶ B) :
     Hom.toSchemeHom f ≫ B.toOver.hom = A.toOver.hom :=
   (Hom.toOverHom f).w

--- a/TauCeti/AlgebraicGeometry/AbelianVariety/Hom.lean
+++ b/TauCeti/AlgebraicGeometry/AbelianVariety/Hom.lean
@@ -1,0 +1,140 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+module
+
+public import TauCeti.AlgebraicGeometry.AbelianVariety.Basic
+
+/-!
+# Homomorphisms of abelian varieties
+
+This file supplies the morphism part of the basic abelian-variety API. A homomorphism of abelian
+varieties over `K` is a morphism over `Spec K` preserving the unit and multiplication of the
+underlying group schemes. Such morphisms form a category, inherited from Mathlib's category of
+group objects.
+
+The bundled `AbelianVariety.Hom` is the type required by the Jacobian's universal property: the
+factorization from the Jacobian to another abelian variety must preserve the group law, rather than
+being only a morphism of the underlying schemes. The characteristic lemmas expose preservation of
+the unit, multiplication, and inverse, as well as the underlying morphism of schemes.
+
+This advances `TauCetiRoadmap/JacobianChallenge/README.md`, Layer E, "Abelian variety = smooth,
+proper, geometrically connected group scheme over `k`; basic API", and prepares Layer F's unique
+"homomorphism of abelian varieties". No external mathematics is vendored; the implementation
+reuses Mathlib's `Grp` category and its `IsMonHom` API for group objects in a cartesian monoidal
+category.
+-/
+
+public section
+
+open CategoryTheory MonoidalCategory CartesianMonoidalCategory AlgebraicGeometry MonObj
+
+namespace TauCeti
+
+namespace AlgebraicGeometry
+
+universe u
+
+namespace AbelianVariety
+
+variable {K : Type u} [Field K]
+
+noncomputable section
+
+/-- A homomorphism of abelian varieties over `K`: a morphism over `Spec K` preserving the group
+law. Preservation of inverses follows from preservation of the unit and multiplication. -/
+@[ext]
+structure Hom (A B : AbelianVariety K) where
+  /-- The underlying morphism of group schemes over `Spec K`. -/
+  hom : A.toOver ⟶ B.toOver
+  [isMonHom_hom : IsMonHom hom]
+
+attribute [instance] Hom.isMonHom_hom
+
+/-- Construct a homomorphism of abelian varieties from a morphism over `Spec K` and proofs that it
+preserves the unit and multiplication. -/
+def Hom.mk' {A B : AbelianVariety K} (f : A.toOver ⟶ B.toOver)
+    (one_f : η[A.toOver] ≫ f = η[B.toOver] := by cat_disch)
+    (mul_f : μ[A.toOver] ≫ f = (f ⊗ₘ f) ≫ μ[B.toOver] := by cat_disch) : A.Hom B :=
+  haveI : IsMonHom f := ⟨one_f, mul_f⟩
+  ⟨f⟩
+
+/-- The identity homomorphism of an abelian variety. -/
+@[expose]
+noncomputable def Hom.id (A : AbelianVariety K) : A.Hom A :=
+  ⟨𝟙 A.toOver⟩
+
+/-- Composition of homomorphisms of abelian varieties. -/
+@[expose]
+noncomputable def Hom.comp {A B C : AbelianVariety K} (f : A.Hom B) (g : B.Hom C) : A.Hom C :=
+  ⟨f.hom ≫ g.hom⟩
+
+/-- Abelian varieties over a fixed field form a category with group-scheme homomorphisms. -/
+noncomputable instance : Category (AbelianVariety K) where
+  Hom := Hom
+  id := Hom.id
+  comp := Hom.comp
+
+@[simp]
+lemma id_hom (A : AbelianVariety K) : (CategoryStruct.id A : A.Hom A).hom = 𝟙 A.toOver :=
+  rfl
+
+@[simp, reassoc]
+lemma comp_hom {A B C : AbelianVariety K} (f : A ⟶ B) (g : B ⟶ C) :
+    (f ≫ g).hom = f.hom ≫ g.hom :=
+  rfl
+
+/-- A homomorphism of abelian varieties preserves the unit section. -/
+@[reassoc (attr := simp)]
+lemma Hom.one_hom {A B : AbelianVariety K} (f : A ⟶ B) :
+    η[A.toOver] ≫ f.hom = η[B.toOver] :=
+  IsMonHom.one_hom f.hom
+
+/-- A homomorphism of abelian varieties preserves multiplication. -/
+@[reassoc (attr := simp)]
+lemma Hom.mul_hom {A B : AbelianVariety K} (f : A ⟶ B) :
+    μ[A.toOver] ≫ f.hom = (f.hom ⊗ₘ f.hom) ≫ μ[B.toOver] :=
+  IsMonHom.mul_hom f.hom
+
+/-- A homomorphism of abelian varieties preserves inverses. -/
+@[reassoc (attr := simp)]
+lemma Hom.inv_hom {A B : AbelianVariety K} (f : A ⟶ B) :
+    ι[A.toOver] ≫ f.hom = f.hom ≫ ι[B.toOver] :=
+  GrpObj.inv_hom f.hom
+
+/-- The underlying morphism between the schemes of two abelian varieties. -/
+abbrev Hom.toSchemeHom {A B : AbelianVariety K} (f : A ⟶ B) : A.toScheme ⟶ B.toScheme :=
+  f.hom.left
+
+@[simp]
+lemma Hom.toSchemeHom_id (A : AbelianVariety K) :
+    Hom.toSchemeHom (𝟙 A) = 𝟙 A.toScheme :=
+  rfl
+
+@[simp, reassoc]
+lemma Hom.toSchemeHom_comp {A B C : AbelianVariety K} (f : A ⟶ B) (g : B ⟶ C) :
+    (f ≫ g).toSchemeHom = f.toSchemeHom ≫ g.toSchemeHom :=
+  rfl
+
+/-- The underlying scheme morphism of an abelian-variety homomorphism commutes with the structure
+morphisms to `Spec K`. -/
+@[reassoc (attr := simp)]
+lemma Hom.toSchemeHom_comp_hom {A B : AbelianVariety K} (f : A ⟶ B) :
+    f.toSchemeHom ≫ B.toOver.hom = A.toOver.hom :=
+  f.hom.w
+
+/-- Two homomorphisms of abelian varieties are equal when their underlying scheme morphisms are
+equal. -/
+lemma Hom.ext_toSchemeHom {A B : AbelianVariety K} {f g : A ⟶ B}
+    (h : f.toSchemeHom = g.toSchemeHom) : f = g := by
+  apply Hom.ext
+  exact Over.OverMorphism.ext h
+
+end
+
+end AbelianVariety
+
+end AlgebraicGeometry
+
+end TauCeti

--- a/TauCeti/AlgebraicGeometry/AbelianVariety/Hom.lean
+++ b/TauCeti/AlgebraicGeometry/AbelianVariety/Hom.lean
@@ -42,70 +42,57 @@ variable {K : Type u} [Field K]
 
 noncomputable section
 
-/-- A homomorphism of abelian varieties over `K`: a morphism over `Spec K` preserving the group
-law. Preservation of inverses follows from preservation of the unit and multiplication. -/
-@[ext]
-structure Hom (A B : AbelianVariety K) where
-  /-- The underlying morphism of group schemes over `Spec K`. -/
-  hom : A.toOver ⟶ B.toOver
-  [isMonHom_hom : IsMonHom hom]
+/-- The group object over `Spec K` underlying an abelian variety. -/
+@[expose]
+def toGrp (A : AbelianVariety K) : Grp (Over (Spec (.of K))) :=
+  ⟨A.toOver⟩
 
-attribute [instance] Hom.isMonHom_hom
+/-- Abelian varieties over a fixed field form a category with group-scheme homomorphisms. -/
+noncomputable instance : Category (AbelianVariety K) :=
+  inferInstanceAs (Category (InducedCategory _ toGrp))
 
 /-- Construct a homomorphism of abelian varieties from a morphism over `Spec K` and proofs that it
 preserves the unit and multiplication. -/
 def Hom.mk' {A B : AbelianVariety K} (f : A.toOver ⟶ B.toOver)
     (one_f : η[A.toOver] ≫ f = η[B.toOver] := by cat_disch)
-    (mul_f : μ[A.toOver] ≫ f = (f ⊗ₘ f) ≫ μ[B.toOver] := by cat_disch) : A.Hom B :=
-  haveI : IsMonHom f := ⟨one_f, mul_f⟩
-  ⟨f⟩
+    (mul_f : μ[A.toOver] ≫ f = (f ⊗ₘ f) ≫ μ[B.toOver] := by cat_disch) : A ⟶ B :=
+  InducedCategory.homMk (Grp.homMk'' f one_f mul_f)
 
-/-- The identity homomorphism of an abelian variety. -/
-@[expose]
-noncomputable def Hom.id (A : AbelianVariety K) : A.Hom A :=
-  ⟨𝟙 A.toOver⟩
-
-/-- Composition of homomorphisms of abelian varieties. -/
-@[expose]
-noncomputable def Hom.comp {A B C : AbelianVariety K} (f : A.Hom B) (g : B.Hom C) : A.Hom C :=
-  ⟨f.hom ≫ g.hom⟩
-
-/-- Abelian varieties over a fixed field form a category with group-scheme homomorphisms. -/
-noncomputable instance : Category (AbelianVariety K) where
-  Hom := Hom
-  id := Hom.id
-  comp := Hom.comp
+/-- The underlying morphism of group schemes over `Spec K`. -/
+abbrev Hom.toOverHom {A B : AbelianVariety K} (f : A ⟶ B) : A.toOver ⟶ B.toOver :=
+  f.hom.hom.hom
 
 @[simp]
-lemma id_hom (A : AbelianVariety K) : (CategoryStruct.id A : A.Hom A).hom = 𝟙 A.toOver :=
-  rfl
+lemma id_hom (A : AbelianVariety K) : Hom.toOverHom (CategoryStruct.id A) = 𝟙 A.toOver :=
+  Grp.id_hom_hom _
 
 @[simp, reassoc]
 lemma comp_hom {A B C : AbelianVariety K} (f : A ⟶ B) (g : B ⟶ C) :
-    (f ≫ g).hom = f.hom ≫ g.hom :=
-  rfl
+    Hom.toOverHom (f ≫ g) = Hom.toOverHom f ≫ Hom.toOverHom g :=
+  Grp.comp_hom_hom _ _
 
 /-- A homomorphism of abelian varieties preserves the unit section. -/
 @[reassoc]
 lemma Hom.one_hom {A B : AbelianVariety K} (f : A ⟶ B) :
-    η[A.toOver] ≫ f.hom = η[B.toOver] :=
-  IsMonHom.one_hom f.hom
+    η[A.toOver] ≫ Hom.toOverHom f = η[B.toOver] :=
+  IsMonHom.one_hom f.hom.hom.hom
 
 /-- A homomorphism of abelian varieties preserves multiplication. -/
 @[reassoc]
 lemma Hom.mul_hom {A B : AbelianVariety K} (f : A ⟶ B) :
-    μ[A.toOver] ≫ f.hom = (f.hom ⊗ₘ f.hom) ≫ μ[B.toOver] :=
-  IsMonHom.mul_hom f.hom
+    μ[A.toOver] ≫ Hom.toOverHom f =
+      (Hom.toOverHom f ⊗ₘ Hom.toOverHom f) ≫ μ[B.toOver] :=
+  IsMonHom.mul_hom f.hom.hom.hom
 
 /-- A homomorphism of abelian varieties preserves inverses. -/
 @[reassoc]
 lemma Hom.inv_hom {A B : AbelianVariety K} (f : A ⟶ B) :
-    ι[A.toOver] ≫ f.hom = f.hom ≫ ι[B.toOver] :=
-  GrpObj.inv_hom f.hom
+    ι[A.toOver] ≫ Hom.toOverHom f = Hom.toOverHom f ≫ ι[B.toOver] :=
+  GrpObj.inv_hom f.hom.hom.hom
 
 /-- The underlying morphism between the schemes of two abelian varieties. -/
 abbrev Hom.toSchemeHom {A B : AbelianVariety K} (f : A ⟶ B) : A.toScheme ⟶ B.toScheme :=
-  f.hom.left
+  (Hom.toOverHom f).left
 
 @[simp]
 lemma Hom.toSchemeHom_id (A : AbelianVariety K) :
@@ -114,21 +101,22 @@ lemma Hom.toSchemeHom_id (A : AbelianVariety K) :
 
 @[simp, reassoc]
 lemma Hom.toSchemeHom_comp {A B C : AbelianVariety K} (f : A ⟶ B) (g : B ⟶ C) :
-    (f ≫ g).toSchemeHom = f.toSchemeHom ≫ g.toSchemeHom :=
+    Hom.toSchemeHom (f ≫ g) = Hom.toSchemeHom f ≫ Hom.toSchemeHom g :=
   rfl
 
 /-- The underlying scheme morphism of an abelian-variety homomorphism commutes with the structure
 morphisms to `Spec K`. -/
 @[reassoc]
 lemma Hom.toSchemeHom_comp_hom {A B : AbelianVariety K} (f : A ⟶ B) :
-    f.toSchemeHom ≫ B.toOver.hom = A.toOver.hom :=
-  f.hom.w
+    Hom.toSchemeHom f ≫ B.toOver.hom = A.toOver.hom :=
+  (Hom.toOverHom f).w
 
 /-- Two homomorphisms of abelian varieties are equal when their underlying scheme morphisms are
 equal. -/
 lemma Hom.ext_toSchemeHom {A B : AbelianVariety K} {f g : A ⟶ B}
-    (h : f.toSchemeHom = g.toSchemeHom) : f = g := by
-  apply Hom.ext
+    (h : Hom.toSchemeHom f = Hom.toSchemeHom g) : f = g := by
+  apply InducedCategory.hom_ext
+  apply Grp.hom_ext
   exact Over.OverMorphism.ext h
 
 end


### PR DESCRIPTION
This PR equips abelian varieties over a fixed field with their natural category of group-scheme homomorphisms. Bundle a morphism over `Spec K` with preservation of the unit and multiplication, and expose identity, composition, unit, multiplication, inverse, underlying-scheme, base-compatibility, and extensionality lemmas.

This advances `TauCetiRoadmap/JacobianChallenge/README.md`, Layer E, specifically “Abelian variety = smooth, proper, geometrically connected group scheme over `k`; basic API,” and supplies the homomorphism type explicitly required by Layer F’s universal property: a unique homomorphism of abelian varieties from the Jacobian.

No Mathlib infrastructure is vendored. Reuse Mathlib’s `GrpObj`, `IsMonHom`, `GrpObj.inv_hom`, cartesian monoidal structure on `Over (Spec K)`, and `Over.OverMorphism.ext`.

`lake exe cache get` reports `No files to download` and `Already decompressed 8619 file(s)`. `lake build` reports `Build completed successfully (5147 jobs).` `lake exe axioms` reports `axioms: audited 10278 TauCeti declaration(s); all within the allowlist [propext, Classical.choice, Quot.sound].`

<!--tauceti-target:v1 {"focus":"JacobianChallenge","id":"abelian-variety-homomorphisms"}-->

🤖 Prepared with Codex
