### PR TITLE
feat: add joins of simplicial complexes

### DIFF
--- a/TauCeti/AlgebraicTopology/SimplicialComplex/Basic.lean
+++ b/TauCeti/AlgebraicTopology/SimplicialComplex/Basic.lean
@@ -1,0 +1,32 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+module
+
+public import Mathlib.AlgebraicTopology.SimplicialComplex.Basic
+
+/-!
+# Basic abstract simplicial complex API
+
+This file contains general-purpose lemmas supplementing Mathlib's basic abstract simplicial
+complex API.
+-/
+
+public section
+
+namespace TauCeti
+
+namespace AbstractSimplicialComplex
+
+/-- A finite set is a face of the underlying precomplex exactly when it is a face of the abstract
+simplicial complex itself. This is the single place where the two `SetLike` instances are
+identified. -/
+@[simp]
+theorem mem_toPreAbstractSimplicialComplex {ι : Type*} {K : AbstractSimplicialComplex ι}
+    {σ : Finset ι} : σ ∈ K.toPreAbstractSimplicialComplex ↔ σ ∈ K :=
+  Iff.rfl
+
+end AbstractSimplicialComplex
+
+end TauCeti

--- a/TauCeti/AlgebraicTopology/SimplicialComplex/Join.lean
+++ b/TauCeti/AlgebraicTopology/SimplicialComplex/Join.lean
@@ -5,7 +5,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 module
 
 public import Mathlib.Data.Finset.Sum
-public import Mathlib.AlgebraicTopology.SimplicialComplex.Basic
+public import TauCeti.AlgebraicTopology.SimplicialComplex.Basic
 
 /-!
 # Joins of abstract simplicial complexes
@@ -117,14 +117,6 @@ end PreAbstractSimplicialComplex
 namespace AbstractSimplicialComplex
 
 variable {α β : Type*}
-
-/-- A finite set is a face of the underlying precomplex exactly when it is a face of the abstract
-simplicial complex itself. This is the single place where the two `SetLike` instances are
-identified. -/
-@[simp]
-theorem mem_toPreAbstractSimplicialComplex {ι : Type*} {K : AbstractSimplicialComplex ι}
-    {σ : Finset ι} : σ ∈ K.toPreAbstractSimplicialComplex ↔ σ ∈ K :=
-  Iff.rfl
 
 /-- The join of two abstract simplicial complexes, with vertices in the disjoint sum. -/
 def join (K : AbstractSimplicialComplex α) (L : AbstractSimplicialComplex β) :

--- a/TauCeti/AlgebraicTopology/SimplicialComplex/Join.lean
+++ b/TauCeti/AlgebraicTopology/SimplicialComplex/Join.lean
@@ -83,7 +83,6 @@ theorem mem_join_iff {σ : Finset (α ⊕ β)} :
 
 /-- A disjoint union is a face of the join exactly when it is nonempty and each nonempty
 component is a face of its original complex. -/
-@[simp]
 theorem disjSum_mem_join_iff {s : Finset α} {t : Finset β} :
     s.disjSum t ∈ join K L ↔
       (s.Nonempty ∨ t.Nonempty) ∧ (s = ∅ ∨ s ∈ K) ∧ (t = ∅ ∨ t ∈ L) := by
@@ -153,7 +152,6 @@ theorem mem_join_iff {σ : Finset (α ⊕ β)} :
 
 /-- A disjoint union is a face of the abstract join exactly when it is nonempty and each
 nonempty component is a face of its original complex. -/
-@[simp]
 theorem disjSum_mem_join_iff {s : Finset α} {t : Finset β} :
     s.disjSum t ∈ join K L ↔
       (s.Nonempty ∨ t.Nonempty) ∧ (s = ∅ ∨ s ∈ K) ∧ (t = ∅ ∨ t ∈ L) := by

--- a/TauCeti/AlgebraicTopology/SimplicialComplex/Join.lean
+++ b/TauCeti/AlgebraicTopology/SimplicialComplex/Join.lean
@@ -83,6 +83,7 @@ theorem mem_join_iff {σ : Finset (α ⊕ β)} :
 
 /-- A disjoint union is a face of the join exactly when it is nonempty and each nonempty
 component is a face of its original complex. -/
+@[simp]
 theorem disjSum_mem_join_iff {s : Finset α} {t : Finset β} :
     s.disjSum t ∈ join K L ↔
       (s.Nonempty ∨ t.Nonempty) ∧ (s = ∅ ∨ s ∈ K) ∧ (t = ∅ ∨ t ∈ L) := by
@@ -159,6 +160,7 @@ theorem mem_join_iff {σ : Finset (α ⊕ β)} :
 
 /-- A disjoint union is a face of the abstract join exactly when it is nonempty and each
 nonempty component is a face of its original complex. -/
+@[simp]
 theorem disjSum_mem_join_iff {s : Finset α} {t : Finset β} :
     s.disjSum t ∈ join K L ↔
       (s.Nonempty ∨ t.Nonempty) ∧ (s = ∅ ∨ s ∈ K) ∧ (t = ∅ ∨ t ∈ L) := by

--- a/TauCeti/AlgebraicTopology/SimplicialComplex/Join.lean
+++ b/TauCeti/AlgebraicTopology/SimplicialComplex/Join.lean
@@ -1,0 +1,157 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+module
+
+public import Mathlib.Data.Finset.Sum
+public import Mathlib.AlgebraicTopology.SimplicialComplex.Basic
+
+/-!
+# Joins of abstract simplicial complexes
+
+The join of complexes `K` and `L` has the disjoint sum of their vertex types as vertices. Its
+faces are the nonempty disjoint unions of a face of `K` and a face of `L`, allowing either side to
+be empty. This file constructs the join first for `PreAbstractSimplicialComplex` and then for
+`AbstractSimplicialComplex`.
+
+Joins are standard infrastructure for the combinatorial-manifold part of the geometric-topology
+roadmap (`TauCetiRoadmap/GeometricTopology/README.md`, layer 11). In particular, combinatorial
+spheres are generated from the boundary of a simplex using subdivision and joins, links interact
+with joins, and the simplicial cylinder appearing in collapse arguments is built from closely
+related product constructions.
+
+The construction follows Rourke--Sanderson, *Introduction to Piecewise-Linear Topology*, Chapter
+2. The use of the sum type makes the two vertex sets disjoint by construction.
+
+## Main definitions
+
+* `TauCeti.PreAbstractSimplicialComplex.join`: the join of two precomplexes.
+* `TauCeti.AbstractSimplicialComplex.join`: the join of two abstract complexes.
+
+## Main results
+
+* `mem_join_iff`: membership is characterized by the two projected faces.
+* `mem_join_disjSum_iff`: a disjoint union is a face exactly when each nonempty component is.
+* `join_mono`: join is monotone in both arguments.
+-/
+
+public section
+
+namespace TauCeti
+
+open Finset Function Sum
+
+namespace PreAbstractSimplicialComplex
+
+variable {α β : Type*} [DecidableEq α] [DecidableEq β]
+
+/-- The join of two pre-abstract simplicial complexes, on the disjoint sum of their vertex types.
+A nonempty finite set is a face when each of its nonempty left and right projections is a face of
+the corresponding complex. -/
+def join (K : PreAbstractSimplicialComplex α) (L : PreAbstractSimplicialComplex β) :
+    PreAbstractSimplicialComplex (α ⊕ β) where
+  faces := {σ | σ.Nonempty ∧
+    (σ.toLeft = ∅ ∨ σ.toLeft ∈ K) ∧ (σ.toRight = ∅ ∨ σ.toRight ∈ L)}
+  isRelLowerSet_faces := by
+    rintro σ ⟨hσ, hK, hL⟩
+    refine ⟨hσ, fun {τ} hτσ hτ => ⟨hτ, ?_, ?_⟩⟩
+    · rcases hK with hK | hK
+      · left
+        exact subset_empty.mp ((toLeft_subset_toLeft hτσ).trans (subset_of_eq hK))
+      · by_cases hτl : τ.toLeft = ∅
+        · exact Or.inl hτl
+        · exact Or.inr <| (K.isRelLowerSet_faces hK).2 (toLeft_subset_toLeft hτσ)
+            (Finset.nonempty_iff_ne_empty.mpr hτl)
+    · rcases hL with hL | hL
+      · left
+        exact subset_empty.mp ((toRight_subset_toRight hτσ).trans (subset_of_eq hL))
+      · by_cases hτr : τ.toRight = ∅
+        · exact Or.inl hτr
+        · exact Or.inr <| (L.isRelLowerSet_faces hL).2 (toRight_subset_toRight hτσ)
+            (Finset.nonempty_iff_ne_empty.mpr hτr)
+
+variable {K K' : PreAbstractSimplicialComplex α} {L L' : PreAbstractSimplicialComplex β}
+
+@[simp]
+theorem mem_join_iff {σ : Finset (α ⊕ β)} :
+    σ ∈ join K L ↔ σ.Nonempty ∧
+      (σ.toLeft = ∅ ∨ σ.toLeft ∈ K) ∧ (σ.toRight = ∅ ∨ σ.toRight ∈ L) :=
+  Iff.rfl
+
+/-- A disjoint union is a face of the join exactly when it is nonempty and each nonempty
+component is a face of its original complex. -/
+@[simp]
+theorem mem_join_disjSum_iff {s : Finset α} {t : Finset β} :
+    s.disjSum t ∈ join K L ↔
+      (s.Nonempty ∨ t.Nonempty) ∧ (s = ∅ ∨ s ∈ K) ∧ (t = ∅ ∨ t ∈ L) := by
+  simp only [mem_join_iff, toLeft_disjSum, toRight_disjSum]
+  simp only [Finset.nonempty_iff_ne_empty, ne_eq, Finset.disjSum_eq_empty, not_and_or]
+
+/-- A left face, tagged into the sum type, is a face of the join. -/
+theorem map_inl_mem_join {s : Finset α} (hs : s ∈ K) :
+    s.map Embedding.inl ∈ join K L := by
+  rw [← disjSum_empty, mem_join_disjSum_iff]
+  exact ⟨Or.inl (K.isRelLowerSet_faces hs).1, Or.inr hs, Or.inl rfl⟩
+
+/-- A right face, tagged into the sum type, is a face of the join. -/
+theorem map_inr_mem_join {t : Finset β} (ht : t ∈ L) :
+    t.map Embedding.inr ∈ join K L := by
+  rw [← empty_disjSum, mem_join_disjSum_iff]
+  exact ⟨Or.inr (L.isRelLowerSet_faces ht).1, Or.inl rfl, Or.inr ht⟩
+
+/-- The disjoint union of a left face and a right face is a face of the join. -/
+theorem disjSum_mem_join {s : Finset α} {t : Finset β} (hs : s ∈ K) (ht : t ∈ L) :
+    s.disjSum t ∈ join K L := by
+  rw [mem_join_disjSum_iff]
+  exact ⟨Or.inl (K.isRelLowerSet_faces hs).1, Or.inr hs, Or.inr ht⟩
+
+/-- Join is monotone in both complexes. -/
+theorem join_mono (hK : K ≤ K') (hL : L ≤ L') : join K L ≤ join K' L' := by
+  rintro σ ⟨hσ, hs, ht⟩
+  exact ⟨hσ, hs.imp_right (fun h => hK h), ht.imp_right (fun h => hL h)⟩
+
+end PreAbstractSimplicialComplex
+
+namespace AbstractSimplicialComplex
+
+variable {α β : Type*} [DecidableEq α] [DecidableEq β]
+
+/-- The join of two abstract simplicial complexes, with vertices in the disjoint sum. -/
+def join (K : AbstractSimplicialComplex α) (L : AbstractSimplicialComplex β) :
+    AbstractSimplicialComplex (α ⊕ β) :=
+  PreAbstractSimplicialComplex.toAbstractSimplicialComplex
+    (α ⊕ β)
+    (PreAbstractSimplicialComplex.join K.toPreAbstractSimplicialComplex
+      L.toPreAbstractSimplicialComplex) fun v => by
+      cases v with
+      | inl a => exact PreAbstractSimplicialComplex.map_inl_mem_join (K.singleton_mem a)
+      | inr b => exact PreAbstractSimplicialComplex.map_inr_mem_join (L.singleton_mem b)
+
+variable {K K' : AbstractSimplicialComplex α} {L L' : AbstractSimplicialComplex β}
+
+@[simp]
+theorem mem_join_iff {σ : Finset (α ⊕ β)} :
+    σ ∈ join K L ↔ σ.Nonempty ∧
+      (σ.toLeft = ∅ ∨ σ.toLeft ∈ K) ∧ (σ.toRight = ∅ ∨ σ.toRight ∈ L) :=
+  Iff.rfl
+
+@[simp]
+theorem mem_join_disjSum_iff {s : Finset α} {t : Finset β} :
+    s.disjSum t ∈ join K L ↔
+      (s.Nonempty ∨ t.Nonempty) ∧ (s = ∅ ∨ s ∈ K) ∧ (t = ∅ ∨ t ∈ L) :=
+  PreAbstractSimplicialComplex.mem_join_disjSum_iff
+
+/-- The disjoint union of faces is a face of the join. -/
+theorem disjSum_mem_join {s : Finset α} {t : Finset β} (hs : s ∈ K) (ht : t ∈ L) :
+    s.disjSum t ∈ join K L :=
+  PreAbstractSimplicialComplex.disjSum_mem_join hs ht
+
+/-- Join is monotone in both abstract simplicial complexes. -/
+theorem join_mono (hK : K ≤ K') (hL : L ≤ L') :
+    join K L ≤ join K' L' :=
+  PreAbstractSimplicialComplex.join_mono hK hL
+
+end AbstractSimplicialComplex
+
+end TauCeti

--- a/TauCeti/AlgebraicTopology/SimplicialComplex/Join.lean
+++ b/TauCeti/AlgebraicTopology/SimplicialComplex/Join.lean
@@ -44,7 +44,7 @@ open Finset Function Sum
 
 namespace PreAbstractSimplicialComplex
 
-variable {α β : Type*} [DecidableEq α] [DecidableEq β]
+variable {α β : Type*}
 
 /-- The join of two pre-abstract simplicial complexes, on the disjoint sum of their vertex types.
 A nonempty finite set is a face when each of its nonempty left and right projections is a face of
@@ -73,6 +73,8 @@ def join (K : PreAbstractSimplicialComplex α) (L : PreAbstractSimplicialComplex
 
 variable {K K' : PreAbstractSimplicialComplex α} {L L' : PreAbstractSimplicialComplex β}
 
+/-- Membership in a precomplex join is equivalent to nonemptiness together with the left and
+right projection face conditions. -/
 @[simp]
 theorem mem_join_iff {σ : Finset (α ⊕ β)} :
     σ ∈ join K L ↔ σ.Nonempty ∧
@@ -89,13 +91,13 @@ theorem mem_join_disjSum_iff {s : Finset α} {t : Finset β} :
 
 /-- A left face, tagged into the sum type, is a face of the join. -/
 theorem map_inl_mem_join {s : Finset α} (hs : s ∈ K) :
-    s.map Embedding.inl ∈ join K L := by
+    s.map (Embedding.inl : α ↪ α ⊕ β) ∈ join K L := by
   rw [← disjSum_empty, mem_join_disjSum_iff]
   exact ⟨Or.inl (K.isRelLowerSet_faces hs).1, Or.inr hs, Or.inl rfl⟩
 
 /-- A right face, tagged into the sum type, is a face of the join. -/
 theorem map_inr_mem_join {t : Finset β} (ht : t ∈ L) :
-    t.map Embedding.inr ∈ join K L := by
+    t.map (Embedding.inr : β ↪ α ⊕ β) ∈ join K L := by
   rw [← empty_disjSum, mem_join_disjSum_iff]
   exact ⟨Or.inr (L.isRelLowerSet_faces ht).1, Or.inl rfl, Or.inr ht⟩
 
@@ -114,7 +116,7 @@ end PreAbstractSimplicialComplex
 
 namespace AbstractSimplicialComplex
 
-variable {α β : Type*} [DecidableEq α] [DecidableEq β]
+variable {α β : Type*}
 
 /-- The join of two abstract simplicial complexes, with vertices in the disjoint sum. -/
 def join (K : AbstractSimplicialComplex α) (L : AbstractSimplicialComplex β) :
@@ -129,16 +131,30 @@ def join (K : AbstractSimplicialComplex α) (L : AbstractSimplicialComplex β) :
 
 variable {K K' : AbstractSimplicialComplex α} {L L' : AbstractSimplicialComplex β}
 
+/-- Membership in an abstract join is equivalent to nonemptiness together with the left and
+right projection face conditions. -/
 @[simp]
 theorem mem_join_iff {σ : Finset (α ⊕ β)} :
     σ ∈ join K L ↔ σ.Nonempty ∧
       (σ.toLeft = ∅ ∨ σ.toLeft ∈ K) ∧ (σ.toRight = ∅ ∨ σ.toRight ∈ L) :=
   Iff.rfl
 
+/-- A disjoint union is a face of the abstract join exactly when it is nonempty and each
+nonempty component is a face of its original complex. -/
 theorem mem_join_disjSum_iff {s : Finset α} {t : Finset β} :
     s.disjSum t ∈ join K L ↔
       (s.Nonempty ∨ t.Nonempty) ∧ (s = ∅ ∨ s ∈ K) ∧ (t = ∅ ∨ t ∈ L) :=
   PreAbstractSimplicialComplex.mem_join_disjSum_iff
+
+/-- A left face, tagged into the sum type, is a face of the join. -/
+theorem map_inl_mem_join {s : Finset α} (hs : s ∈ K) :
+    s.map (Embedding.inl : α ↪ α ⊕ β) ∈ join K L :=
+  PreAbstractSimplicialComplex.map_inl_mem_join hs
+
+/-- A right face, tagged into the sum type, is a face of the join. -/
+theorem map_inr_mem_join {t : Finset β} (ht : t ∈ L) :
+    t.map (Embedding.inr : β ↪ α ⊕ β) ∈ join K L :=
+  PreAbstractSimplicialComplex.map_inr_mem_join ht
 
 /-- The disjoint union of faces is a face of the join. -/
 theorem disjSum_mem_join {s : Finset α} {t : Finset β} (hs : s ∈ K) (ht : t ∈ L) :

--- a/TauCeti/AlgebraicTopology/SimplicialComplex/Join.lean
+++ b/TauCeti/AlgebraicTopology/SimplicialComplex/Join.lean
@@ -83,7 +83,6 @@ theorem mem_join_iff {σ : Finset (α ⊕ β)} :
 
 /-- A disjoint union is a face of the join exactly when it is nonempty and each nonempty
 component is a face of its original complex. -/
-@[simp]
 theorem disjSum_mem_join_iff {s : Finset α} {t : Finset β} :
     s.disjSum t ∈ join K L ↔
       (s.Nonempty ∨ t.Nonempty) ∧ (s = ∅ ∨ s ∈ K) ∧ (t = ∅ ∨ t ∈ L) := by
@@ -160,7 +159,6 @@ theorem mem_join_iff {σ : Finset (α ⊕ β)} :
 
 /-- A disjoint union is a face of the abstract join exactly when it is nonempty and each
 nonempty component is a face of its original complex. -/
-@[simp]
 theorem disjSum_mem_join_iff {s : Finset α} {t : Finset β} :
     s.disjSum t ∈ join K L ↔
       (s.Nonempty ∨ t.Nonempty) ∧ (s = ∅ ∨ s ∈ K) ∧ (t = ∅ ∨ t ∈ L) := by

--- a/TauCeti/AlgebraicTopology/SimplicialComplex/Join.lean
+++ b/TauCeti/AlgebraicTopology/SimplicialComplex/Join.lean
@@ -118,6 +118,14 @@ namespace AbstractSimplicialComplex
 
 variable {α β : Type*}
 
+/-- A finite set is a face of the underlying precomplex exactly when it is a face of the abstract
+simplicial complex itself. This is the single place where the two `SetLike` instances are
+identified. -/
+@[simp]
+theorem mem_toPreAbstractSimplicialComplex {ι : Type*} {K : AbstractSimplicialComplex ι}
+    {σ : Finset ι} : σ ∈ K.toPreAbstractSimplicialComplex ↔ σ ∈ K :=
+  Iff.rfl
+
 /-- The join of two abstract simplicial complexes, with vertices in the disjoint sum. -/
 def join (K : AbstractSimplicialComplex α) (L : AbstractSimplicialComplex β) :
     AbstractSimplicialComplex (α ⊕ β) :=
@@ -146,8 +154,7 @@ right projection face conditions. -/
 theorem mem_join_iff {σ : Finset (α ⊕ β)} :
     σ ∈ join K L ↔ σ.Nonempty ∧
       (σ.toLeft = ∅ ∨ σ.toLeft ∈ K) ∧ (σ.toRight = ∅ ∨ σ.toRight ∈ L) := by
-  change σ ∈ (join K L).toPreAbstractSimplicialComplex ↔ _
-  rw [join_toPreAbstractSimplicialComplex]
+  simp only [← mem_toPreAbstractSimplicialComplex, join_toPreAbstractSimplicialComplex]
   exact PreAbstractSimplicialComplex.mem_join_iff
 
 /-- A disjoint union is a face of the abstract join exactly when it is nonempty and each
@@ -155,29 +162,25 @@ nonempty component is a face of its original complex. -/
 theorem disjSum_mem_join_iff {s : Finset α} {t : Finset β} :
     s.disjSum t ∈ join K L ↔
       (s.Nonempty ∨ t.Nonempty) ∧ (s = ∅ ∨ s ∈ K) ∧ (t = ∅ ∨ t ∈ L) := by
-  change s.disjSum t ∈ (join K L).toPreAbstractSimplicialComplex ↔ _
-  rw [join_toPreAbstractSimplicialComplex]
+  simp only [← mem_toPreAbstractSimplicialComplex, join_toPreAbstractSimplicialComplex]
   exact PreAbstractSimplicialComplex.disjSum_mem_join_iff
 
 /-- A left face, tagged into the sum type, is a face of the join. -/
 theorem map_inl_mem_join {s : Finset α} (hs : s ∈ K) :
     s.map (Embedding.inl : α ↪ α ⊕ β) ∈ join K L := by
-  change s.map (Embedding.inl : α ↪ α ⊕ β) ∈ (join K L).toPreAbstractSimplicialComplex
-  rw [join_toPreAbstractSimplicialComplex]
+  rw [← mem_toPreAbstractSimplicialComplex, join_toPreAbstractSimplicialComplex]
   exact PreAbstractSimplicialComplex.map_inl_mem_join hs
 
 /-- A right face, tagged into the sum type, is a face of the join. -/
 theorem map_inr_mem_join {t : Finset β} (ht : t ∈ L) :
     t.map (Embedding.inr : β ↪ α ⊕ β) ∈ join K L := by
-  change t.map (Embedding.inr : β ↪ α ⊕ β) ∈ (join K L).toPreAbstractSimplicialComplex
-  rw [join_toPreAbstractSimplicialComplex]
+  rw [← mem_toPreAbstractSimplicialComplex, join_toPreAbstractSimplicialComplex]
   exact PreAbstractSimplicialComplex.map_inr_mem_join ht
 
 /-- The disjoint union of faces is a face of the join. -/
 theorem disjSum_mem_join {s : Finset α} {t : Finset β} (hs : s ∈ K) (ht : t ∈ L) :
     s.disjSum t ∈ join K L := by
-  change s.disjSum t ∈ (join K L).toPreAbstractSimplicialComplex
-  rw [join_toPreAbstractSimplicialComplex]
+  rw [← mem_toPreAbstractSimplicialComplex, join_toPreAbstractSimplicialComplex]
   exact PreAbstractSimplicialComplex.disjSum_mem_join hs ht
 
 /-- Join is monotone in both abstract simplicial complexes. -/

--- a/TauCeti/AlgebraicTopology/SimplicialComplex/Join.lean
+++ b/TauCeti/AlgebraicTopology/SimplicialComplex/Join.lean
@@ -81,7 +81,6 @@ theorem mem_join_iff {σ : Finset (α ⊕ β)} :
 
 /-- A disjoint union is a face of the join exactly when it is nonempty and each nonempty
 component is a face of its original complex. -/
-@[simp]
 theorem mem_join_disjSum_iff {s : Finset α} {t : Finset β} :
     s.disjSum t ∈ join K L ↔
       (s.Nonempty ∨ t.Nonempty) ∧ (s = ∅ ∨ s ∈ K) ∧ (t = ∅ ∨ t ∈ L) := by
@@ -136,7 +135,6 @@ theorem mem_join_iff {σ : Finset (α ⊕ β)} :
       (σ.toLeft = ∅ ∨ σ.toLeft ∈ K) ∧ (σ.toRight = ∅ ∨ σ.toRight ∈ L) :=
   Iff.rfl
 
-@[simp]
 theorem mem_join_disjSum_iff {s : Finset α} {t : Finset β} :
     s.disjSum t ∈ join K L ↔
       (s.Nonempty ∨ t.Nonempty) ∧ (s = ∅ ∨ s ∈ K) ∧ (t = ∅ ∨ t ∈ L) :=

--- a/TauCeti/AlgebraicTopology/SimplicialComplex/Join.lean
+++ b/TauCeti/AlgebraicTopology/SimplicialComplex/Join.lean
@@ -32,7 +32,7 @@ The construction follows Rourke--Sanderson, *Introduction to Piecewise-Linear To
 ## Main results
 
 * `mem_join_iff`: membership is characterized by the two projected faces.
-* `mem_join_disjSum_iff`: a disjoint union is a face exactly when each nonempty component is.
+* `disjSum_mem_join_iff`: a disjoint union is a face exactly when each nonempty component is.
 * `join_mono`: join is monotone in both arguments.
 -/
 
@@ -83,7 +83,8 @@ theorem mem_join_iff {σ : Finset (α ⊕ β)} :
 
 /-- A disjoint union is a face of the join exactly when it is nonempty and each nonempty
 component is a face of its original complex. -/
-theorem mem_join_disjSum_iff {s : Finset α} {t : Finset β} :
+@[simp]
+theorem disjSum_mem_join_iff {s : Finset α} {t : Finset β} :
     s.disjSum t ∈ join K L ↔
       (s.Nonempty ∨ t.Nonempty) ∧ (s = ∅ ∨ s ∈ K) ∧ (t = ∅ ∨ t ∈ L) := by
   simp only [mem_join_iff, toLeft_disjSum, toRight_disjSum]
@@ -92,19 +93,19 @@ theorem mem_join_disjSum_iff {s : Finset α} {t : Finset β} :
 /-- A left face, tagged into the sum type, is a face of the join. -/
 theorem map_inl_mem_join {s : Finset α} (hs : s ∈ K) :
     s.map (Embedding.inl : α ↪ α ⊕ β) ∈ join K L := by
-  rw [← disjSum_empty, mem_join_disjSum_iff]
+  rw [← disjSum_empty, disjSum_mem_join_iff]
   exact ⟨Or.inl (K.isRelLowerSet_faces hs).1, Or.inr hs, Or.inl rfl⟩
 
 /-- A right face, tagged into the sum type, is a face of the join. -/
 theorem map_inr_mem_join {t : Finset β} (ht : t ∈ L) :
     t.map (Embedding.inr : β ↪ α ⊕ β) ∈ join K L := by
-  rw [← empty_disjSum, mem_join_disjSum_iff]
+  rw [← empty_disjSum, disjSum_mem_join_iff]
   exact ⟨Or.inr (L.isRelLowerSet_faces ht).1, Or.inl rfl, Or.inr ht⟩
 
 /-- The disjoint union of a left face and a right face is a face of the join. -/
 theorem disjSum_mem_join {s : Finset α} {t : Finset β} (hs : s ∈ K) (ht : t ∈ L) :
     s.disjSum t ∈ join K L := by
-  rw [mem_join_disjSum_iff]
+  rw [disjSum_mem_join_iff]
   exact ⟨Or.inl (K.isRelLowerSet_faces hs).1, Or.inr hs, Or.inr ht⟩
 
 /-- Join is monotone in both complexes. -/
@@ -131,40 +132,62 @@ def join (K : AbstractSimplicialComplex α) (L : AbstractSimplicialComplex β) :
 
 variable {K K' : AbstractSimplicialComplex α} {L L' : AbstractSimplicialComplex β}
 
+/-- Forgetting that the join contains every singleton recovers the underlying precomplex join. -/
+@[simp]
+theorem join_toPreAbstractSimplicialComplex :
+    (join K L).toPreAbstractSimplicialComplex =
+      PreAbstractSimplicialComplex.join K.toPreAbstractSimplicialComplex
+        L.toPreAbstractSimplicialComplex := by
+  ext σ
+  rfl
+
 /-- Membership in an abstract join is equivalent to nonemptiness together with the left and
 right projection face conditions. -/
 @[simp]
 theorem mem_join_iff {σ : Finset (α ⊕ β)} :
     σ ∈ join K L ↔ σ.Nonempty ∧
-      (σ.toLeft = ∅ ∨ σ.toLeft ∈ K) ∧ (σ.toRight = ∅ ∨ σ.toRight ∈ L) :=
-  Iff.rfl
+      (σ.toLeft = ∅ ∨ σ.toLeft ∈ K) ∧ (σ.toRight = ∅ ∨ σ.toRight ∈ L) := by
+  change σ ∈ (join K L).toPreAbstractSimplicialComplex ↔ _
+  rw [join_toPreAbstractSimplicialComplex]
+  exact PreAbstractSimplicialComplex.mem_join_iff
 
 /-- A disjoint union is a face of the abstract join exactly when it is nonempty and each
 nonempty component is a face of its original complex. -/
-theorem mem_join_disjSum_iff {s : Finset α} {t : Finset β} :
+@[simp]
+theorem disjSum_mem_join_iff {s : Finset α} {t : Finset β} :
     s.disjSum t ∈ join K L ↔
-      (s.Nonempty ∨ t.Nonempty) ∧ (s = ∅ ∨ s ∈ K) ∧ (t = ∅ ∨ t ∈ L) :=
-  PreAbstractSimplicialComplex.mem_join_disjSum_iff
+      (s.Nonempty ∨ t.Nonempty) ∧ (s = ∅ ∨ s ∈ K) ∧ (t = ∅ ∨ t ∈ L) := by
+  change s.disjSum t ∈ (join K L).toPreAbstractSimplicialComplex ↔ _
+  rw [join_toPreAbstractSimplicialComplex]
+  exact PreAbstractSimplicialComplex.disjSum_mem_join_iff
 
 /-- A left face, tagged into the sum type, is a face of the join. -/
 theorem map_inl_mem_join {s : Finset α} (hs : s ∈ K) :
-    s.map (Embedding.inl : α ↪ α ⊕ β) ∈ join K L :=
-  PreAbstractSimplicialComplex.map_inl_mem_join hs
+    s.map (Embedding.inl : α ↪ α ⊕ β) ∈ join K L := by
+  change s.map (Embedding.inl : α ↪ α ⊕ β) ∈ (join K L).toPreAbstractSimplicialComplex
+  rw [join_toPreAbstractSimplicialComplex]
+  exact PreAbstractSimplicialComplex.map_inl_mem_join hs
 
 /-- A right face, tagged into the sum type, is a face of the join. -/
 theorem map_inr_mem_join {t : Finset β} (ht : t ∈ L) :
-    t.map (Embedding.inr : β ↪ α ⊕ β) ∈ join K L :=
-  PreAbstractSimplicialComplex.map_inr_mem_join ht
+    t.map (Embedding.inr : β ↪ α ⊕ β) ∈ join K L := by
+  change t.map (Embedding.inr : β ↪ α ⊕ β) ∈ (join K L).toPreAbstractSimplicialComplex
+  rw [join_toPreAbstractSimplicialComplex]
+  exact PreAbstractSimplicialComplex.map_inr_mem_join ht
 
 /-- The disjoint union of faces is a face of the join. -/
 theorem disjSum_mem_join {s : Finset α} {t : Finset β} (hs : s ∈ K) (ht : t ∈ L) :
-    s.disjSum t ∈ join K L :=
-  PreAbstractSimplicialComplex.disjSum_mem_join hs ht
+    s.disjSum t ∈ join K L := by
+  change s.disjSum t ∈ (join K L).toPreAbstractSimplicialComplex
+  rw [join_toPreAbstractSimplicialComplex]
+  exact PreAbstractSimplicialComplex.disjSum_mem_join hs ht
 
 /-- Join is monotone in both abstract simplicial complexes. -/
 theorem join_mono (hK : K ≤ K') (hL : L ≤ L') :
-    join K L ≤ join K' L' :=
-  PreAbstractSimplicialComplex.join_mono hK hL
+    join K L ≤ join K' L' := by
+  rw [← AbstractSimplicialComplex.toPreAbstractSimplicialComplex_le_iff]
+  rw [join_toPreAbstractSimplicialComplex, join_toPreAbstractSimplicialComplex]
+  exact PreAbstractSimplicialComplex.join_mono hK hL
 
 end AbstractSimplicialComplex
 


### PR DESCRIPTION
This PR adds joins of pre-abstract and abstract simplicial complexes on disjoint-sum vertex types, characterizes faces through their left and right projections, embeds faces from either factor, combines pairs of faces, and proves monotonicity in both inputs.

This advances `TauCetiRoadmap/GeometricTopology/README.md`, Layer 11, “Triangulations, PL structures, and collapse,” specifically the “Combinatorial manifolds via the link condition” item requiring recursive combinatorial spheres and balls up to subdivision. Joins are the standard finite-complex operation used to build combinatorial spheres and balls and to calculate their links. It is the lowest-hanging distinct prerequisite after checking open and recently merged PRs: `main` already supplies stars, links, and deletion, while the open elementary-collapse work concerns free-pair deletion rather than joins.

The construction follows Rourke--Sanderson, *Introduction to Piecewise-Linear Topology*, Chapter 2. No Mathlib infrastructure is vendored. It reuses Mathlib’s `Finset.disjSum`, `toLeft`, `toRight`, and `PreAbstractSimplicialComplex` downward-closure API.

`lake exe cache get` reports `No files to download` and `Already decompressed 8619 file(s)`. `lake build` reports `Build completed successfully (5149 jobs).` `lake exe axioms` reports `axioms: audited 10262 TauCeti declaration(s); all within the allowlist [propext, Classical.choice, Quot.sound].`

<!--tauceti-target:v1 {"focus":"GeometricTopology","id":"simplicial-complex-join"}-->

🤖 Prepared with Codex
