### PR TITLE
feat: extend generator orbit right derivatives

### DIFF
--- a/TauCeti/Analysis/Semigroups/Generator/OrbitDerivative.lean
+++ b/TauCeti/Analysis/Semigroups/Generator/OrbitDerivative.lean
@@ -128,7 +128,7 @@ theorem realOperator_hasDerivWithinAt (S : StronglyContinuousSemigroup X)
 
 /-- At every nonnegative time, the right derivative of the orbit is the semigroup operator
 applied to the generator. -/
-theorem realOperator_hasDerivWithinAt_eq_map_generator
+theorem realOperator_hasDerivWithinAt_map_generator
     (S : StronglyContinuousSemigroup X) (x : S.domain) {t : ℝ} (ht : 0 ≤ t) :
     HasDerivWithinAt (fun s : ℝ => S.realOperator s (x : X))
       (S.realOperator t (S.generator ⟨x, by
@@ -145,13 +145,14 @@ theorem realOperator_differentiableWithinAt (S : StronglyContinuousSemigroup X)
 
 /-- The right derivative of the orbit at a nonnegative time is the semigroup operator applied
 to the generator. -/
+@[simp]
 theorem realOperator_derivWithin (S : StronglyContinuousSemigroup X)
     (x : S.domain) {t : ℝ} (ht : 0 ≤ t) :
     derivWithin (fun s : ℝ => S.realOperator s (x : X)) (Set.Ici t) t =
       S.realOperator t (S.generator ⟨x, by
         rw [S.generator_domain]
         exact x.property⟩) :=
-  (S.realOperator_hasDerivWithinAt_eq_map_generator x ht).derivWithin
+  (S.realOperator_hasDerivWithinAt_map_generator x ht).derivWithin
     (uniqueDiffWithinAt_Ici t)
 
 end StronglyContinuousSemigroup

--- a/TauCeti/Analysis/Semigroups/Generator/OrbitDerivative.lean
+++ b/TauCeti/Analysis/Semigroups/Generator/OrbitDerivative.lean
@@ -96,15 +96,14 @@ theorem mem_domain_iff_differentiableWithinAt_realOperator_zero
 
 /-! ## Right derivatives at nonnegative times -/
 
-/-- At every nonnegative time, the right derivative of the orbit of a generator-domain vector
-is the generator evaluated on the evolved vector. -/
+/-- At every nonnegative time, if the evolved vector belongs to the generator domain, then the
+right derivative of the orbit is the generator evaluated on that evolved vector. -/
 theorem realOperator_hasDerivWithinAt (S : StronglyContinuousSemigroup X)
-    (x : S.domain) {t : ℝ} (ht : 0 ≤ t) :
-    HasDerivWithinAt (fun s : ℝ => S.realOperator s (x : X))
-      (S.generator ⟨S.realOperator t x, by
-        rw [S.generator_domain]
-        exact S.realOperator_mem_domain ht x.property⟩) (Set.Ici t) t := by
-  let y : S.domain := ⟨S.realOperator t x, S.realOperator_mem_domain ht x.property⟩
+    {x : X} {t : ℝ} (ht : 0 ≤ t) (hxt : S.realOperator t x ∈ S.domain) :
+    HasDerivWithinAt (fun s : ℝ => S.realOperator s x)
+      (S.generator ⟨S.realOperator t x, by rw [S.generator_domain]; exact hxt⟩)
+      (Set.Ici t) t := by
+  let y : S.domain := ⟨S.realOperator t x, hxt⟩
   have htranslate : HasDerivWithinAt (fun s : ℝ => S.realOperator (s - t) (y : X))
       (S.generator ⟨y, by rw [S.generator_domain]; exact y.property⟩) (Set.Ici t) t := by
     have hinner : HasDerivWithinAt (fun s : ℝ => s - t) 1 (Set.Ici t) t := by
@@ -134,13 +133,22 @@ theorem realOperator_hasDerivWithinAt_map_generator
         rw [S.generator_domain]
         exact x.property⟩)) (Set.Ici t) t := by
   rw [← S.realOperator_generator_map ht x]
-  exact S.realOperator_hasDerivWithinAt x ht
+  exact S.realOperator_hasDerivWithinAt ht (S.realOperator_mem_domain ht x.property)
 
 /-- The orbit of a generator-domain vector is right-differentiable at every nonnegative time. -/
 theorem realOperator_differentiableWithinAt (S : StronglyContinuousSemigroup X)
     (x : S.domain) {t : ℝ} (ht : 0 ≤ t) :
     DifferentiableWithinAt ℝ (fun s : ℝ => S.realOperator s (x : X)) (Set.Ici t) t :=
-  (S.realOperator_hasDerivWithinAt x ht).differentiableWithinAt
+  (S.realOperator_hasDerivWithinAt ht
+    (S.realOperator_mem_domain ht x.property)).differentiableWithinAt
+
+/-- The right derivative of an orbit at a nonnegative time is the generator evaluated on the
+evolved vector, provided that vector belongs to the generator domain. -/
+theorem realOperator_derivWithin_generator (S : StronglyContinuousSemigroup X)
+    {x : X} {t : ℝ} (ht : 0 ≤ t) (hxt : S.realOperator t x ∈ S.domain) :
+    derivWithin (fun s : ℝ => S.realOperator s x) (Set.Ici t) t =
+      S.generator ⟨S.realOperator t x, by rw [S.generator_domain]; exact hxt⟩ :=
+  (S.realOperator_hasDerivWithinAt ht hxt).derivWithin (uniqueDiffWithinAt_Ici t)
 
 /-- The right derivative of the orbit at a nonnegative time is the semigroup operator applied
 to the generator. -/

--- a/TauCeti/Analysis/Semigroups/Generator/OrbitDerivative.lean
+++ b/TauCeti/Analysis/Semigroups/Generator/OrbitDerivative.lean
@@ -145,7 +145,7 @@ theorem realOperator_differentiableWithinAt (S : StronglyContinuousSemigroup X)
 
 /-- The right derivative of an orbit at a nonnegative time is the generator evaluated on the
 evolved vector, provided that vector belongs to the generator domain. -/
-theorem realOperator_derivWithin_generator (S : StronglyContinuousSemigroup X)
+theorem realOperator_derivWithin (S : StronglyContinuousSemigroup X)
     {x : X} {t : ℝ} (ht : 0 ≤ t) (hxt : S.realOperator t x ∈ S.domain) :
     derivWithin (fun s : ℝ => S.realOperator s x) (Set.Ici t) t =
       S.generator ⟨S.realOperator t x, by rw [S.generator_domain]; exact hxt⟩ :=
@@ -153,7 +153,7 @@ theorem realOperator_derivWithin_generator (S : StronglyContinuousSemigroup X)
 
 /-- The right derivative of the orbit at a nonnegative time is the semigroup operator applied
 to the generator. -/
-theorem realOperator_derivWithin (S : StronglyContinuousSemigroup X)
+theorem realOperator_derivWithin_map_generator (S : StronglyContinuousSemigroup X)
     (x : S.domain) {t : ℝ} (ht : 0 ≤ t) :
     derivWithin (fun s : ℝ => S.realOperator s (x : X)) (Set.Ici t) t =
       S.realOperator t (S.generator ⟨x, by

--- a/TauCeti/Analysis/Semigroups/Generator/OrbitDerivative.lean
+++ b/TauCeti/Analysis/Semigroups/Generator/OrbitDerivative.lean
@@ -4,15 +4,16 @@ Released under Apache 2.0 license as described in the file LICENSE.
 -/
 module
 
-public import TauCeti.Analysis.Semigroups.Generator.Basic
+public import TauCeti.Analysis.Semigroups.Generator.Invariance
 import Mathlib.Analysis.Calculus.Deriv.Slope
 
 /-!
 # Differentiability of semigroup orbits
 
 This file characterizes membership in the infinitesimal generator domain by right
-differentiability of the orbit at zero, and identifies the right derivative there with the
-generator.
+differentiability of the orbit at zero. For a vector in the generator domain, it then computes
+the right derivative at every nonnegative time in the equivalent forms `A (S t x)` and
+`S t (A x)`.
 
 ## References
 
@@ -93,6 +94,66 @@ theorem mem_domain_iff_differentiableWithinAt_realOperator_zero
     rw [hasDerivWithinAt_iff_tendsto_slope] at hy'
     unfold slope at hy'
     simpa [S.realOperator_zero_apply] using hy'
+
+/-! ## Right derivatives at nonnegative times -/
+
+/-- At every nonnegative time, the right derivative of the orbit of a generator-domain vector
+is the generator evaluated on the evolved vector. -/
+theorem realOperator_hasDerivWithinAt (S : StronglyContinuousSemigroup X)
+    (x : S.domain) {t : ℝ} (ht : 0 ≤ t) :
+    HasDerivWithinAt (fun s : ℝ => S.realOperator s (x : X))
+      (S.generator ⟨S.realOperator t x, by
+        rw [S.generator_domain]
+        exact S.realOperator_mem_domain ht x.property⟩) (Set.Ici t) t := by
+  let y : S.domain := ⟨S.realOperator t x, S.realOperator_mem_domain ht x.property⟩
+  have htranslate : HasDerivWithinAt (fun s : ℝ => S.realOperator (s - t) (y : X))
+      (S.generator ⟨y, by rw [S.generator_domain]; exact y.property⟩) (Set.Ici t) t := by
+    have hinner : HasDerivWithinAt (fun s : ℝ => s - t) 1 (Set.Ici t) t := by
+      simpa using (hasDerivWithinAt_id t (Set.Ici t)).sub_const t
+    have hmaps : Set.MapsTo (fun s : ℝ => s - t) (Set.Ici t) (Set.Ici 0) := by
+      intro s hs
+      simpa only [Set.mem_Ici, sub_nonneg] using hs
+    have hcomp :=
+      (S.realOperator_hasDerivWithinAt_zero y).scomp_of_eq t hinner hmaps (by ring)
+    exact (hcomp.congr (fun _ _ => rfl) rfl).congr_deriv (one_smul ℝ _)
+  refine htranslate.congr (fun s hs => ?_) ?_
+  · have hst : 0 ≤ s - t := sub_nonneg.mpr hs
+    calc
+      S.realOperator s x = S.realOperator ((s - t) + t) x := by ring_nf
+      _ = S.realOperator (s - t) (S.realOperator t x) := by
+        rw [S.realOperator_add _ _ hst ht]
+        rfl
+      _ = S.realOperator (s - t) y := rfl
+  · simp only [sub_self, S.realOperator_zero_apply, y]
+
+/-- At every nonnegative time, the right derivative of the orbit is the semigroup operator
+applied to the generator. -/
+theorem realOperator_hasDerivWithinAt_eq_map_generator
+    (S : StronglyContinuousSemigroup X) (x : S.domain) {t : ℝ} (ht : 0 ≤ t) :
+    HasDerivWithinAt (fun s : ℝ => S.realOperator s (x : X))
+      (S.realOperator t (S.generator ⟨x, by
+        rw [S.generator_domain]
+        exact x.property⟩)) (Set.Ici t) t := by
+  rw [← S.realOperator_generator_map ht x]
+  exact S.realOperator_hasDerivWithinAt x ht
+
+/-- The orbit of a generator-domain vector is right-differentiable at every nonnegative time. -/
+theorem realOperator_differentiableWithinAt (S : StronglyContinuousSemigroup X)
+    (x : S.domain) {t : ℝ} (ht : 0 ≤ t) :
+    DifferentiableWithinAt ℝ (fun s : ℝ => S.realOperator s (x : X)) (Set.Ici t) t :=
+  (S.realOperator_hasDerivWithinAt x ht).differentiableWithinAt
+
+/-- The right derivative of the orbit at a nonnegative time is the semigroup operator applied
+to the generator. -/
+@[simp]
+theorem realOperator_derivWithin (S : StronglyContinuousSemigroup X)
+    (x : S.domain) {t : ℝ} (ht : 0 ≤ t) :
+    derivWithin (fun s : ℝ => S.realOperator s (x : X)) (Set.Ici t) t =
+      S.realOperator t (S.generator ⟨x, by
+        rw [S.generator_domain]
+        exact x.property⟩) :=
+  (S.realOperator_hasDerivWithinAt_eq_map_generator x ht).derivWithin
+    (uniqueDiffWithinAt_Ici t)
 
 end StronglyContinuousSemigroup
 

--- a/TauCeti/Analysis/Semigroups/Generator/OrbitDerivative.lean
+++ b/TauCeti/Analysis/Semigroups/Generator/OrbitDerivative.lean
@@ -51,7 +51,6 @@ theorem realOperator_differentiableWithinAt_zero (S : StronglyContinuousSemigrou
   (S.realOperator_hasDerivWithinAt_zero x).differentiableWithinAt
 
 /-- The right derivative at zero of the orbit of a generator-domain vector is its generator. -/
-@[simp]
 theorem realOperator_derivWithin_zero (S : StronglyContinuousSemigroup X)
     (x : S.domain) :
     derivWithin (fun s : ℝ => S.realOperator s (x : X)) (Set.Ici 0) 0 =

--- a/TauCeti/Analysis/Semigroups/Generator/OrbitDerivative.lean
+++ b/TauCeti/Analysis/Semigroups/Generator/OrbitDerivative.lean
@@ -145,7 +145,6 @@ theorem realOperator_differentiableWithinAt (S : StronglyContinuousSemigroup X)
 
 /-- The right derivative of the orbit at a nonnegative time is the semigroup operator applied
 to the generator. -/
-@[simp]
 theorem realOperator_derivWithin (S : StronglyContinuousSemigroup X)
     (x : S.domain) {t : ℝ} (ht : 0 ≤ t) :
     derivWithin (fun s : ℝ => S.realOperator s (x : X)) (Set.Ici t) t =

--- a/TauCeti/Analysis/Semigroups/Generator/OrbitDerivative.lean
+++ b/TauCeti/Analysis/Semigroups/Generator/OrbitDerivative.lean
@@ -51,6 +51,7 @@ theorem realOperator_differentiableWithinAt_zero (S : StronglyContinuousSemigrou
   (S.realOperator_hasDerivWithinAt_zero x).differentiableWithinAt
 
 /-- The right derivative at zero of the orbit of a generator-domain vector is its generator. -/
+@[simp]
 theorem realOperator_derivWithin_zero (S : StronglyContinuousSemigroup X)
     (x : S.domain) :
     derivWithin (fun s : ℝ => S.realOperator s (x : X)) (Set.Ici 0) 0 =
@@ -152,7 +153,6 @@ theorem realOperator_derivWithin_generator (S : StronglyContinuousSemigroup X)
 
 /-- The right derivative of the orbit at a nonnegative time is the semigroup operator applied
 to the generator. -/
-@[simp]
 theorem realOperator_derivWithin (S : StronglyContinuousSemigroup X)
     (x : S.domain) {t : ℝ} (ht : 0 ≤ t) :
     derivWithin (fun s : ℝ => S.realOperator s (x : X)) (Set.Ici t) t =


### PR DESCRIPTION
This PR extends the generator-orbit calculus from time zero to every nonnegative time: compute the right derivative of `s ↦ S(s)x` for `x ∈ D(A)` as both `A(S(t)x)` and `S(t)(Ax)`, and expose the corresponding differentiability and `derivWithin` statements. This advances `TauCetiRoadmap/OneParameterSemigroups/README.md`, Part A — Strongly continuous semigroups, API item “`t ↦ S(t)x` differentiable for `x ∈ D(A)`”, as a clean prerequisite that supplies the right derivative at every nonnegative time. It is the lowest-hanging distinct target because the zero-time derivative and generator-domain invariance are already merged, while the completely-monotone representation milestone is covered by open PR #575.

Follow Engel–Nagel, *One-Parameter Semigroups for Linear Evolution Equations*, Lemma II.1.3(ii). Reuse Tau Ceti’s `realOperator_hasDerivWithinAt_zero`, `realOperator_mem_domain`, and `realOperator_generator_map`, together with Mathlib’s `HasDerivWithinAt.scomp_of_eq`; no Mathlib infrastructure is vendored.

`lake exe cache get` reported `No files to download` and `Already decompressed 8619 file(s)`. `lake build` reported `Build completed successfully (5150 jobs).` `lake exe axioms` reported `axioms: audited 10285 TauCeti declaration(s); all within the allowlist [propext, Classical.choice, Quot.sound].`

<!--tauceti-target:v1 {"focus":"OneParameterSemigroups","id":"generator-orbit-right-derivative"}-->

🤖 Prepared with Codex
