### PR TITLE
feat: add variable-coefficient L2 energy forms

### DIFF
--- a/TauCeti/Analysis/PDE/EnergyForm/VariableLp.lean
+++ b/TauCeti/Analysis/PDE/EnergyForm/VariableLp.lean
@@ -1,0 +1,155 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+module
+
+public import Mathlib.MeasureTheory.Function.Holder
+public import TauCeti.Analysis.PDE.EnergyForm.Basic
+
+/-!
+# Variable-coefficient energy forms on `L²` jets
+
+Lane D, item 16 of the PDE roadmap asks for the bounded bilinear form associated to a
+divergence-form operator.  `TauCeti.Analysis.PDE.EnergyForm.Lp` treats constant coefficients;
+this file supplies the variable-coefficient construction.  An essentially bounded field of
+pointwise continuous bilinear forms acts by Hölder multiplication
+
+`L∞(X; J →L J →L ℝ) × L²(X; J) → L²(X; J →L ℝ)`,
+
+and the result pairs with a second `L²` jet.  Both operations are Mathlib's
+`ContinuousLinearMap.holderL` and `ContinuousLinearMap.lpPairing`.
+
+For PDE coefficients `a`, `b`, and `c`, the pointwise form is
+`energyIntegrand (a x) (b x) (c x)`.  Requiring this field to belong to `L∞` is the precise
+boundedness and measurability hypothesis needed by the construction.  The resulting form is
+bundled and continuous, so later Sobolev value-gradient jets can feed it without carrying
+integrability proofs at each use site.
+
+## Main declarations
+
+* `TauCeti.PDE.lpBilinearForm`: integrate an `L∞` field of bilinear forms against two `L²`
+  functions.
+* `TauCeti.PDE.lpBilinearForm_apply`: its integral characterization.
+* `TauCeti.PDE.energyFormLpVariable`: the variable-coefficient divergence-form energy form.
+* `TauCeti.PDE.energyFormLpVariable_apply`: its characterization by the expected energy
+  integral.
+
+No formal source is vendored.  The construction directly composes Mathlib's Hölder map and
+`Lᵖ` pairing from `Mathlib.MeasureTheory.Function.Holder`.
+-/
+
+public section
+
+noncomputable section
+
+namespace TauCeti
+
+namespace PDE
+
+open ENNReal MeasureTheory
+
+variable {X J : Type*} [MeasurableSpace X]
+variable [NormedAddCommGroup J] [NormedSpace ℝ J]
+
+/-- The continuous bilinear form obtained by integrating an essentially bounded field of
+continuous bilinear forms against two square-integrable functions.
+
+This is the abstract functional-analytic construction underlying variable-coefficient energy
+forms. -/
+noncomputable def lpBilinearForm (μ : Measure X)
+    (B : Lp (J →L[ℝ] J →L[ℝ] ℝ) ⊤ μ) :
+    Lp J 2 μ →L[ℝ] Lp J 2 μ →L[ℝ] ℝ :=
+  ((ContinuousLinearMap.apply ℝ ℝ (E := J)).flip.lpPairing μ 2 2).comp
+    (((ContinuousLinearMap.apply ℝ (J →L[ℝ] ℝ) (E := J)).flip.holderL
+      μ ⊤ 2 2) B)
+
+/-- The `L∞`-coefficient bilinear form is the integral of its pointwise action. -/
+@[simp]
+theorem lpBilinearForm_apply (μ : Measure X) (B : Lp (J →L[ℝ] J →L[ℝ] ℝ) ⊤ μ)
+    (U V : Lp J 2 μ) :
+    lpBilinearForm μ B U V = ∫ x, B x (U x) (V x) ∂μ := by
+  rw [lpBilinearForm, ContinuousLinearMap.comp_apply,
+    ContinuousLinearMap.lpPairing_eq_integral]
+  apply integral_congr_ae
+  filter_upwards
+      [((ContinuousLinearMap.apply ℝ (J →L[ℝ] ℝ)
+        (E := J)).flip.coeFn_holder (r := 2) B U)] with x hx
+  simp [hx]
+
+/-- Replacing an `L∞` coefficient field by an almost-everywhere equal field does not change
+the associated bilinear form. -/
+theorem lpBilinearForm_congr_ae {μ : Measure X}
+    {B B' : Lp (J →L[ℝ] J →L[ℝ] ℝ) ⊤ μ} (hB : B =ᵐ[μ] B') :
+    lpBilinearForm μ B = lpBilinearForm μ B' := by
+  ext U V
+  rw [lpBilinearForm_apply, lpBilinearForm_apply]
+  apply integral_congr_ae
+  filter_upwards [hB] with x hx
+  rw [hx]
+
+section Energy
+
+open Matrix
+
+variable {n : Type*} [Fintype n]
+
+/-- The variable-coefficient divergence-form energy form on square-integrable value-gradient
+jets.
+
+The `MemLp ... ⊤ μ` argument records exactly that the pointwise energy forms are strongly
+measurable and essentially bounded.  Its proof is irrelevant to the resulting form. -/
+noncomputable def energyFormLpVariable (μ : Measure X) (a : X → Matrix n n ℝ)
+    (b : X → EuclideanSpace ℝ n) (c : X → ℝ)
+    (hcoeff : MemLp (fun x => energyIntegrand (a x) (b x) (c x)) ⊤ μ) :
+    Lp (ℝ × EuclideanSpace ℝ n) 2 μ →L[ℝ]
+      Lp (ℝ × EuclideanSpace ℝ n) 2 μ →L[ℝ] ℝ :=
+  lpBilinearForm μ (hcoeff.toLp (fun x => energyIntegrand (a x) (b x) (c x)))
+
+/-- The variable-coefficient `L²` energy form is the integral of the pointwise jet energy
+density. -/
+@[simp]
+theorem energyFormLpVariable_apply (μ : Measure X) (a : X → Matrix n n ℝ)
+    (b : X → EuclideanSpace ℝ n) (c : X → ℝ)
+    (hcoeff : MemLp (fun x => energyIntegrand (a x) (b x) (c x)) ⊤ μ)
+    (U V : Lp (ℝ × EuclideanSpace ℝ n) 2 μ) :
+    energyFormLpVariable μ a b c hcoeff U V =
+      ∫ x, energyIntegrand (a x) (b x) (c x) (U x) (V x) ∂μ := by
+  rw [energyFormLpVariable, lpBilinearForm_apply]
+  apply integral_congr_ae
+  have hcoe :
+      (hcoeff.toLp (fun x => energyIntegrand (a x) (b x) (c x)) :
+        X → ℝ × EuclideanSpace ℝ n →L[ℝ] ℝ × EuclideanSpace ℝ n →L[ℝ] ℝ) =ᵐ[μ]
+          fun x => energyIntegrand (a x) (b x) (c x) := hcoeff.coeFn_toLp
+  filter_upwards [hcoe] with x hx
+  rw [hx]
+
+/-- The variable-coefficient energy form is independent of the proof that its coefficient
+field belongs to `L∞`. -/
+theorem energyFormLpVariable_proof_irrel (μ : Measure X) (a : X → Matrix n n ℝ)
+    (b : X → EuclideanSpace ℝ n) (c : X → ℝ)
+    (hcoeff hcoeff' : MemLp (fun x => energyIntegrand (a x) (b x) (c x)) ⊤ μ) :
+    energyFormLpVariable μ a b c hcoeff = energyFormLpVariable μ a b c hcoeff' := by
+  congr
+
+/-- Almost-everywhere equal coefficient fields induce the same variable-coefficient energy
+form. -/
+theorem energyFormLpVariable_congr_ae {μ : Measure X}
+    {a a' : X → Matrix n n ℝ} {b b' : X → EuclideanSpace ℝ n} {c c' : X → ℝ}
+    (ha : a =ᵐ[μ] a') (hb : b =ᵐ[μ] b') (hc : c =ᵐ[μ] c')
+    (hcoeff : MemLp (fun x => energyIntegrand (a x) (b x) (c x)) ⊤ μ)
+    (hcoeff' : MemLp (fun x => energyIntegrand (a' x) (b' x) (c' x)) ⊤ μ) :
+    energyFormLpVariable μ a b c hcoeff = energyFormLpVariable μ a' b' c' hcoeff' := by
+  ext U V
+  rw [energyFormLpVariable_apply, energyFormLpVariable_apply]
+  apply integral_congr_ae
+  filter_upwards [ha, hb, hc] with x hax hbx hcx
+  rw [hax, hbx, hcx]
+
+end Energy
+
+end PDE
+
+end TauCeti
+
+end

--- a/TauCeti/Analysis/PDE/EnergyForm/VariableLp.lean
+++ b/TauCeti/Analysis/PDE/EnergyForm/VariableLp.lean
@@ -4,8 +4,8 @@ Released under Apache 2.0 license as described in the file LICENSE.
 -/
 module
 
-public import Mathlib.MeasureTheory.Function.Holder
-public import TauCeti.Analysis.PDE.EnergyForm.Basic
+public import TauCeti.Analysis.PDE.SymmetricEnergy
+public import TauCeti.MeasureTheory.Function.LpBilinearForm
 
 /-!
 # Variable-coefficient energy forms on `L²` jets
@@ -28,9 +28,6 @@ integrability proofs at each use site.
 
 ## Main declarations
 
-* `TauCeti.PDE.lpBilinearForm`: integrate an `L∞` field of bilinear forms against two `L²`
-  functions.
-* `TauCeti.PDE.lpBilinearForm_apply`: its integral characterization.
 * `TauCeti.PDE.energyFormLpVariable`: the variable-coefficient divergence-form energy form.
 * `TauCeti.PDE.energyFormLpVariable_apply`: its characterization by the expected energy
   integral.
@@ -49,44 +46,7 @@ namespace PDE
 
 open ENNReal MeasureTheory
 
-variable {X J : Type*} [MeasurableSpace X]
-variable [NormedAddCommGroup J] [NormedSpace ℝ J]
-
-/-- The continuous bilinear form obtained by integrating an essentially bounded field of
-continuous bilinear forms against two square-integrable functions.
-
-This is the abstract functional-analytic construction underlying variable-coefficient energy
-forms. -/
-noncomputable def lpBilinearForm (μ : Measure X)
-    (B : Lp (J →L[ℝ] J →L[ℝ] ℝ) ⊤ μ) :
-    Lp J 2 μ →L[ℝ] Lp J 2 μ →L[ℝ] ℝ :=
-  ((ContinuousLinearMap.apply ℝ ℝ (E := J)).flip.lpPairing μ 2 2).comp
-    (((ContinuousLinearMap.apply ℝ (J →L[ℝ] ℝ) (E := J)).flip.holderL
-      μ ⊤ 2 2) B)
-
-/-- The `L∞`-coefficient bilinear form is the integral of its pointwise action. -/
-@[simp]
-theorem lpBilinearForm_apply (μ : Measure X) (B : Lp (J →L[ℝ] J →L[ℝ] ℝ) ⊤ μ)
-    (U V : Lp J 2 μ) :
-    lpBilinearForm μ B U V = ∫ x, B x (U x) (V x) ∂μ := by
-  rw [lpBilinearForm, ContinuousLinearMap.comp_apply,
-    ContinuousLinearMap.lpPairing_eq_integral]
-  apply integral_congr_ae
-  filter_upwards
-      [((ContinuousLinearMap.apply ℝ (J →L[ℝ] ℝ)
-        (E := J)).flip.coeFn_holder (r := 2) B U)] with x hx
-  simp [hx]
-
-/-- Replacing an `L∞` coefficient field by an almost-everywhere equal field does not change
-the associated bilinear form. -/
-theorem lpBilinearForm_congr_ae {μ : Measure X}
-    {B B' : Lp (J →L[ℝ] J →L[ℝ] ℝ) ⊤ μ} (hB : B =ᵐ[μ] B') :
-    lpBilinearForm μ B = lpBilinearForm μ B' := by
-  ext U V
-  rw [lpBilinearForm_apply, lpBilinearForm_apply]
-  apply integral_congr_ae
-  filter_upwards [hB] with x hx
-  rw [hx]
+variable {X : Type*} [MeasurableSpace X]
 
 section Energy
 
@@ -145,6 +105,82 @@ theorem energyFormLpVariable_congr_ae {μ : Measure X}
   apply integral_congr_ae
   filter_upwards [ha, hb, hc] with x hax hbx hcx
   rw [hax, hbx, hcx]
+
+/-- Transposing the principal coefficient swaps the arguments of a variable zero-drift energy
+form. -/
+theorem energyFormLpVariable_zero_drift_transpose_apply (μ : Measure X)
+    (a : X → Matrix n n ℝ) (c : X → ℝ)
+    (hcoeff : MemLp (fun x => energyIntegrand (a x)ᵀ 0 (c x)) ⊤ μ)
+    (hcoeff' : MemLp (fun x => energyIntegrand (a x) 0 (c x)) ⊤ μ)
+    (U V : Lp (ℝ × EuclideanSpace ℝ n) 2 μ) :
+    energyFormLpVariable μ (fun x => (a x)ᵀ) (fun _ => 0) c hcoeff U V =
+      energyFormLpVariable μ a (fun _ => 0) c hcoeff' V U := by
+  rw [energyFormLpVariable_apply, energyFormLpVariable_apply]
+  apply integral_congr_ae
+  exact Filter.Eventually.of_forall fun x =>
+    energyIntegrand_zero_drift_transpose_apply (a x) (c x) (U x) (V x)
+
+/-- An a.e. symmetric principal coefficient gives a symmetric variable zero-drift energy
+form. -/
+theorem energyFormLpVariable_zero_drift_comm_of_isSymm_ae {μ : Measure X}
+    {a : X → Matrix n n ℝ} (ha : ∀ᵐ x ∂μ, (a x).IsSymm) (c : X → ℝ)
+    (hcoeff : MemLp (fun x => energyIntegrand (a x) 0 (c x)) ⊤ μ)
+    (U V : Lp (ℝ × EuclideanSpace ℝ n) 2 μ) :
+    energyFormLpVariable μ a (fun _ => 0) c hcoeff U V =
+      energyFormLpVariable μ a (fun _ => 0) c hcoeff V U := by
+  rw [energyFormLpVariable_apply, energyFormLpVariable_apply]
+  apply integral_congr_ae
+  filter_upwards [ha] with x hx
+  exact energyIntegrand_zero_drift_comm_of_isSymm hx (c x) (U x) (V x)
+
+/-- An a.e. symmetric principal coefficient makes the variable zero-drift energy form equal
+to its flip. -/
+@[simp]
+theorem energyFormLpVariable_zero_drift_flip_eq_of_isSymm_ae {μ : Measure X}
+    {a : X → Matrix n n ℝ} (ha : ∀ᵐ x ∂μ, (a x).IsSymm) (c : X → ℝ)
+    (hcoeff : MemLp (fun x => energyIntegrand (a x) 0 (c x)) ⊤ μ) :
+    (energyFormLpVariable μ a (fun _ => 0) c hcoeff).flip =
+      energyFormLpVariable μ a (fun _ => 0) c hcoeff := by
+  ext U V
+  exact energyFormLpVariable_zero_drift_comm_of_isSymm_ae ha c hcoeff V U
+
+/-- Replacing the principal coefficient by its symmetric part does not change the diagonal
+variable energy form. -/
+theorem energyFormLpVariable_coefficientSymmetricPart_self (μ : Measure X)
+    (a : X → Matrix n n ℝ) (b : X → EuclideanSpace ℝ n) (c : X → ℝ)
+    (hcoeff : MemLp (fun x => energyIntegrand (coefficientSymmetricPart (a x))
+      (b x) (c x)) ⊤ μ)
+    (hcoeff' : MemLp (fun x => energyIntegrand (a x) (b x) (c x)) ⊤ μ)
+    (U : Lp (ℝ × EuclideanSpace ℝ n) 2 μ) :
+    energyFormLpVariable μ (fun x => coefficientSymmetricPart (a x)) b c hcoeff U U =
+      energyFormLpVariable μ a b c hcoeff' U U := by
+  rw [energyFormLpVariable_apply, energyFormLpVariable_apply]
+  apply integral_congr_ae
+  exact Filter.Eventually.of_forall fun x =>
+    energyIntegrand_coefficientSymmetricPart_self (a x) (b x) (c x) (U x)
+
+/-- The symmetric-part variable zero-drift energy form is the average of the original form and
+its transpose. -/
+theorem energyFormLpVariable_coefficientSymmetricPart_zero_drift_apply (μ : Measure X)
+    (a : X → Matrix n n ℝ) (c : X → ℝ)
+    (hsymm : MemLp (fun x => energyIntegrand (coefficientSymmetricPart (a x)) 0
+      (c x)) ⊤ μ)
+    (hcoeff : MemLp (fun x => energyIntegrand (a x) 0 (c x)) ⊤ μ)
+    (U V : Lp (ℝ × EuclideanSpace ℝ n) 2 μ) :
+    energyFormLpVariable μ (fun x => coefficientSymmetricPart (a x))
+        (fun _ => 0) c hsymm U V =
+      (energyFormLpVariable μ a (fun _ => 0) c hcoeff U V +
+        energyFormLpVariable μ a (fun _ => 0) c hcoeff V U) / 2 := by
+  rw [energyFormLpVariable_apply, energyFormLpVariable_apply,
+    energyFormLpVariable_apply]
+  have hUV : Integrable (fun x => energyIntegrand (a x) 0 (c x) (U x) (V x)) μ :=
+    integrable_bilinear_apply_of_memLp hcoeff U V
+  have hVU : Integrable (fun x => energyIntegrand (a x) 0 (c x) (V x) (U x)) μ :=
+    integrable_bilinear_apply_of_memLp hcoeff V U
+  rw [← integral_add hUV hVU, ← integral_div]
+  apply integral_congr_ae
+  exact Filter.Eventually.of_forall fun x =>
+    energyIntegrand_coefficientSymmetricPart_zero_drift_apply (a x) (c x) (U x) (V x)
 
 end Energy
 

--- a/TauCeti/Analysis/PDE/EnergyForm/VariableLp.lean
+++ b/TauCeti/Analysis/PDE/EnergyForm/VariableLp.lean
@@ -182,6 +182,32 @@ theorem energyFormLpVariable_coefficientSymmetricPart_zero_drift_apply (μ : Mea
   exact Filter.Eventually.of_forall fun x =>
     energyIntegrand_coefficientSymmetricPart_zero_drift_apply (a x) (c x) (U x) (V x)
 
+/-- The symmetric-part variable zero-drift energy form is symmetric. -/
+theorem energyFormLpVariable_coefficientSymmetricPart_zero_drift_comm (μ : Measure X)
+    (a : X → Matrix n n ℝ) (c : X → ℝ)
+    (hcoeff : MemLp (fun x => energyIntegrand (coefficientSymmetricPart (a x)) 0
+      (c x)) ⊤ μ)
+    (U V : Lp (ℝ × EuclideanSpace ℝ n) 2 μ) :
+    energyFormLpVariable μ (fun x => coefficientSymmetricPart (a x))
+        (fun _ => 0) c hcoeff U V =
+      energyFormLpVariable μ (fun x => coefficientSymmetricPart (a x))
+        (fun _ => 0) c hcoeff V U :=
+  energyFormLpVariable_zero_drift_comm_of_isSymm_ae
+    (Filter.Eventually.of_forall fun _ => coefficientSymmetricPart_isSymm _) c hcoeff U V
+
+/-- The symmetric-part variable zero-drift energy form is equal to its flip. -/
+@[simp]
+theorem energyFormLpVariable_coefficientSymmetricPart_zero_drift_flip_eq (μ : Measure X)
+    (a : X → Matrix n n ℝ) (c : X → ℝ)
+    (hcoeff : MemLp (fun x => energyIntegrand (coefficientSymmetricPart (a x)) 0
+      (c x)) ⊤ μ) :
+    (energyFormLpVariable μ (fun x => coefficientSymmetricPart (a x))
+      (fun _ => 0) c hcoeff).flip =
+      energyFormLpVariable μ (fun x => coefficientSymmetricPart (a x))
+        (fun _ => 0) c hcoeff :=
+  energyFormLpVariable_zero_drift_flip_eq_of_isSymm_ae
+    (Filter.Eventually.of_forall fun _ => coefficientSymmetricPart_isSymm _) c hcoeff
+
 end Energy
 
 end PDE

--- a/TauCeti/MeasureTheory/Function/LpBilinearForm.lean
+++ b/TauCeti/MeasureTheory/Function/LpBilinearForm.lean
@@ -1,0 +1,81 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+module
+
+public import Mathlib.MeasureTheory.Function.Holder
+
+/-!
+# Bilinear forms with `L∞` coefficients on `L²`
+
+An essentially bounded field of continuous bilinear forms acts on two square-integrable
+functions by pointwise evaluation and integration.  This file packages that operation as a
+continuous bilinear form using Mathlib's Hölder multiplication and `Lᵖ` pairing.
+
+## Main declarations
+
+* `TauCeti.lpBilinearForm`: the continuous bilinear form associated to an `L∞` field.
+* `TauCeti.lpBilinearForm_apply`: its integral characterization.
+* `TauCeti.lpBilinearForm_congr_ae`: invariance under a.e. equality of coefficient fields.
+-/
+
+public section
+
+noncomputable section
+
+namespace TauCeti
+
+open ENNReal MeasureTheory
+
+variable {X J : Type*} [MeasurableSpace X]
+variable [NormedAddCommGroup J] [NormedSpace ℝ J]
+
+/-- The continuous bilinear form obtained by integrating an essentially bounded field of
+continuous bilinear forms against two square-integrable functions. -/
+noncomputable def lpBilinearForm (μ : Measure X)
+    (B : Lp (J →L[ℝ] J →L[ℝ] ℝ) ⊤ μ) :
+    Lp J 2 μ →L[ℝ] Lp J 2 μ →L[ℝ] ℝ :=
+  ((ContinuousLinearMap.apply ℝ ℝ (E := J)).flip.lpPairing μ 2 2).comp
+    (((ContinuousLinearMap.apply ℝ (J →L[ℝ] ℝ) (E := J)).flip.holderL
+      μ ⊤ 2 2) B)
+
+/-- The `L∞`-coefficient bilinear form is the integral of its pointwise action. -/
+@[simp]
+theorem lpBilinearForm_apply (μ : Measure X) (B : Lp (J →L[ℝ] J →L[ℝ] ℝ) ⊤ μ)
+    (U V : Lp J 2 μ) :
+    lpBilinearForm μ B U V = ∫ x, B x (U x) (V x) ∂μ := by
+  rw [lpBilinearForm, ContinuousLinearMap.comp_apply,
+    ContinuousLinearMap.lpPairing_eq_integral]
+  apply integral_congr_ae
+  filter_upwards
+      [((ContinuousLinearMap.apply ℝ (J →L[ℝ] ℝ)
+        (E := J)).flip.coeFn_holder (r := 2) B U)] with x hx
+  simp [hx]
+
+/-- Replacing an `L∞` coefficient field by an almost-everywhere equal field does not change
+the associated bilinear form. -/
+theorem lpBilinearForm_congr_ae {μ : Measure X}
+    {B B' : Lp (J →L[ℝ] J →L[ℝ] ℝ) ⊤ μ} (hB : B =ᵐ[μ] B') :
+    lpBilinearForm μ B = lpBilinearForm μ B' := by
+  ext U V
+  rw [lpBilinearForm_apply, lpBilinearForm_apply]
+  apply integral_congr_ae
+  filter_upwards [hB] with x hx
+  rw [hx]
+
+/-- Applying an `L∞` field of bilinear forms to two `L²` functions gives an integrable
+scalar-valued function. -/
+theorem integrable_bilinear_apply_of_memLp {μ : Measure X}
+    {B : X → J →L[ℝ] J →L[ℝ] ℝ} (hB : MemLp B ⊤ μ) (U V : Lp J 2 μ) :
+    Integrable (fun x => B x (U x) (V x)) μ := by
+  have hBU : MemLp (fun x => B x (U x)) 2 μ :=
+    (ContinuousLinearMap.apply ℝ (J →L[ℝ] ℝ) (E := J)).flip.memLp_of_bilin
+      (f := B) (g := fun x => U x) 2 hB (Lp.memLp U)
+  exact memLp_one_iff_integrable.mp
+    ((ContinuousLinearMap.apply ℝ ℝ (E := J)).flip.memLp_of_bilin
+      (f := fun x => B x (U x)) (g := fun x => V x) 1 hBU (Lp.memLp V))
+
+end TauCeti
+
+end


### PR DESCRIPTION
This PR packages an essentially bounded field of pointwise continuous bilinear forms as a continuous bilinear form on `L²`, and specializes the construction to the variable-coefficient divergence-form energy integrand. Use Mathlib's Hölder multiplication `L∞ × L² → L²` followed by its `L²` pairing, so later Sobolev value-gradient jets can consume the form without carrying integrability proofs at each use site.

This advances `TauCetiRoadmap/PDE/README.md`, Lane D, item 16, “Weak formulation,” specifically the bounded variable-coefficient energy bilinear form `a(u,v)` needed before Lax–Milgram. It is the lowest-hanging distinct handoff because the constant-coefficient `L²` form and raw variable-coefficient integral are already merged, while the open PDE PR #1011 covers the separate Lane C mean-value normalization target and the Sobolev-domain restriction still awaits Lane A.

No Mathlib infrastructure is vendored. Reuse `ContinuousLinearMap.holderL`, `ContinuousLinearMap.lpPairing`, and `MemLp.toLp` from `Mathlib.MeasureTheory.Function.Holder`, together with Tau Ceti's existing `energyIntegrand`.

`lake exe cache get` reports `No files to download` and `Already decompressed 8619 file(s)`. `lake build` reports `Build completed successfully (5151 jobs).` `lake exe axioms` reports `axioms: audited 10313 TauCeti declaration(s); all within the allowlist [propext, Classical.choice, Quot.sound].`

<!--tauceti-target:v1 {"focus":"PDE","id":"variable-coefficient-energy-form-l2"}-->

🤖 Prepared with Codex
