### PR TITLE
feat: add class group equivalence functoriality

### DIFF
--- a/TauCeti/NumberTheory/ClassGroup/Equiv.lean
+++ b/TauCeti/NumberTheory/ClassGroup/Equiv.lean
@@ -75,6 +75,11 @@ theorem mulEquiv_mk {K L : Type*} [Field K] [Field L] [Algebra R K]
   apply Units.ext
   simp only [Units.coe_mapEquiv, Units.coe_map]
   rw [FractionalIdeal.canonicalEquiv, FractionalIdeal.canonicalEquiv]
+  -- Each `FractionalIdeal.canonicalEquiv`/`ringEquivOfRingEquiv` factor is built from
+  -- `IsLocalization.map`, whose semilinear packaging (`semilinearEquivOfRingEquiv`) demands
+  -- `RingHomInvPair`/`RingHomCompTriple`/`RingHomSurjective` instances for the ring maps and their
+  -- refl-composites. Mathlib does not have these in scope for `RingEquiv.refl`/`f` combinations, so
+  -- we supply them locally to let the coercions and `IsLocalization.map_map` below elaborate.
   letI : RingHomInvPair (f : R →+* S) f.symm := RingHomInvPair.of_ringEquiv f
   letI : RingHomInvPair (f.symm : S →+* R) f := RingHomInvPair.of_ringEquiv f.symm
   letI : RingHomInvPair (RingEquiv.refl R : R →+* R) (RingEquiv.refl R).symm :=
@@ -97,6 +102,11 @@ theorem mulEquiv_mk {K L : Type*} [Field K] [Field L] [Algebra R K]
     ⟨by ext; rfl⟩
   letI : RingHomSurjective (f : R →+* S) := ⟨f.surjective⟩
   apply FractionalIdeal.coeToSubmodule_injective
+  -- Both sides are `Submodule.map`s of `I` by the underlying `semilinearEquivOfRingEquiv` maps:
+  -- the left is the three-step canonical composite `K → FractionRing R → FractionRing S → L`, the
+  -- right the direct map `K → L`. There is no Mathlib lemma exposing the `canonicalEquiv` composite
+  -- in this `Submodule.map` form, but the two coincide definitionally, so we restate the goal with
+  -- `change` and then collapse the composite via `Submodule.map_comp` and `IsLocalization.map_map`.
   change Submodule.map
       (IsFractionRing.semilinearEquivOfRingEquiv (FractionRing S) L (RingEquiv.refl S)).toLinearMap
       (Submodule.map

--- a/TauCeti/NumberTheory/ClassGroup/Equiv.lean
+++ b/TauCeti/NumberTheory/ClassGroup/Equiv.lean
@@ -1,0 +1,103 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+module
+
+public import Mathlib.RingTheory.ClassGroup.Basic
+
+/-!
+# Functoriality of class groups under ring equivalences
+
+Mathlib defines `ClassGroup.mulEquiv f`, the multiplicative equivalence on ideal class groups
+induced by a ring equivalence `f : R ≃+* S`. This file supplies its basic functorial API: the
+induced map respects identity, composition, and inverses, and its value on the class of a nonzero
+integral ideal is represented by the transported ideal.
+
+This is a prerequisite for the genus-field layer of the multiquadratic roadmap. For a quadratic
+field, conjugation is a ring automorphism of its ring of integers; the roadmap's proof that
+conjugation acts on the class group by inversion first needs to treat that action functorially and
+compute it on ideal classes.
+
+## Main results
+
+* `ClassGroup.mulEquiv_refl`: the identity ring equivalence induces the identity on class groups.
+* `ClassGroup.mulEquiv_trans`: induced equivalences respect composition.
+* `ClassGroup.mulEquiv_symm`: the inverse induced equivalence comes from the inverse ring
+  equivalence.
+* `ClassGroup.mulEquiv_apply_apply_of_trans_eq_refl`: an involutive ring equivalence acts
+  involutively on the class group.
+-/
+
+public section
+
+namespace ClassGroup
+
+variable {R S T : Type*} [CommRing R] [CommRing S] [CommRing T]
+  [IsDomain R] [IsDomain S] [IsDomain T]
+
+/-- The identity ring equivalence induces the identity map on the class group. -/
+@[simp] theorem mulEquiv_refl_apply (x : ClassGroup R) :
+    ClassGroup.mulEquiv (RingEquiv.refl R) x = x := by
+  refine ClassGroup.induction (FractionRing R) (fun I => ?_) x
+  rw [ClassGroup.mulEquiv_apply]
+  apply (ClassGroup.equiv (FractionRing R)).injective
+  rw [MulEquiv.apply_symm_apply, ClassGroup.equiv_mk, QuotientGroup.congr_mk']
+  congr 1
+  apply Units.ext
+  simp [FractionalIdeal.ringEquivOfRingEquiv_refl]
+
+/-- Class-group equivalences induced by ring equivalences respect composition. -/
+@[simp] theorem mulEquiv_trans_apply (f : R ≃+* S) (g : S ≃+* T) (x : ClassGroup R) :
+    ClassGroup.mulEquiv (f.trans g) x =
+      ClassGroup.mulEquiv g (ClassGroup.mulEquiv f x) := by
+  refine ClassGroup.induction (FractionRing R) (fun I => ?_) x
+  simp only [ClassGroup.mulEquiv_apply, ClassGroup.equiv_mk, MulEquiv.apply_symm_apply,
+    QuotientGroup.congr_mk']
+  apply congrArg (QuotientGroup.mk' (toPrincipalIdeal T (FractionRing T)).range)
+  apply Units.ext
+  simpa [FractionalIdeal.canonicalEquiv_self] using
+    FractionalIdeal.ringEquivOfRingEquiv_trans_apply
+      (FractionRing R) (FractionRing S) (FractionRing T) f g I
+
+/-- The class-group equivalence induced by the inverse ring equivalence undoes the original
+induced equivalence. -/
+@[simp] theorem mulEquiv_symm_apply_apply (f : R ≃+* S) (x : ClassGroup R) :
+    ClassGroup.mulEquiv f.symm (ClassGroup.mulEquiv f x) = x := by
+  rw [← mulEquiv_trans_apply, f.self_trans_symm, mulEquiv_refl_apply]
+
+/-- The class-group equivalence induced by a ring equivalence undoes the map induced by its
+inverse. -/
+@[simp] theorem mulEquiv_apply_symm_apply (f : R ≃+* S) (x : ClassGroup S) :
+    ClassGroup.mulEquiv f (ClassGroup.mulEquiv f.symm x) = x := by
+  rw [← mulEquiv_trans_apply, f.symm_trans_self, mulEquiv_refl_apply]
+
+/-- The inverse of the class-group equivalence induced by `f` is induced by `f.symm`. -/
+theorem mulEquiv_symm (f : R ≃+* S) :
+    (ClassGroup.mulEquiv f).symm = ClassGroup.mulEquiv f.symm := by
+  ext x
+  apply (ClassGroup.mulEquiv f).injective
+  rw [MulEquiv.apply_symm_apply, mulEquiv_apply_symm_apply]
+
+/-- The identity ring equivalence induces the identity class-group equivalence. -/
+@[simp] theorem mulEquiv_refl :
+    ClassGroup.mulEquiv (RingEquiv.refl R) = MulEquiv.refl (ClassGroup R) := by
+  ext x
+  exact mulEquiv_refl_apply x
+
+/-- Composition of ring equivalences is carried to composition of the induced class-group
+equivalences. -/
+theorem mulEquiv_trans (f : R ≃+* S) (g : S ≃+* T) :
+    ClassGroup.mulEquiv (f.trans g) =
+      (ClassGroup.mulEquiv f).trans (ClassGroup.mulEquiv g) := by
+  ext x
+  exact mulEquiv_trans_apply f g x
+
+/-- An involutive ring equivalence induces an involution on the class group. This is the form
+used for quadratic conjugation. -/
+theorem mulEquiv_apply_apply_of_trans_eq_refl (f : R ≃+* R)
+    (hf : f.trans f = RingEquiv.refl R) (x : ClassGroup R) :
+    ClassGroup.mulEquiv f (ClassGroup.mulEquiv f x) = x := by
+  rw [← mulEquiv_trans_apply, hf, mulEquiv_refl_apply]
+
+end ClassGroup

--- a/TauCeti/NumberTheory/ClassGroup/Equiv.lean
+++ b/TauCeti/NumberTheory/ClassGroup/Equiv.lean
@@ -58,6 +58,18 @@ private theorem mulEquiv_mk_fractionRing (f : R ≃+* S)
   apply Units.ext
   simp [FractionalIdeal.canonicalEquiv_self]
 
+/-- The canonical equivalence between the fractional ideals of two fraction fields of `R` is
+transport along the identity ring equivalence. This lets a change of fraction field and a transport
+along a ring equivalence be composed by `FractionalIdeal.ringEquivOfRingEquiv_trans_apply`. -/
+private theorem canonicalEquiv_eq_ringEquivOfRingEquiv (K K' : Type*) [Field K] [Field K']
+    [Algebra R K] [Algebra R K'] [IsFractionRing R K] [IsFractionRing R K'] :
+    FractionalIdeal.canonicalEquiv R⁰ K K' =
+      FractionalIdeal.ringEquivOfRingEquiv K K' (RingEquiv.refl R) := by
+  ext I x
+  simp only [FractionalIdeal.ringEquivOfRingEquiv_apply, FractionalIdeal.val_eq_coe,
+    ← FractionalIdeal.mem_coe]
+  simp [IsFractionRing.semilinearEquivOfRingEquiv, IsFractionRing.ringEquivOfRingEquiv]
+
 /-- `ClassGroup.mulEquiv f` sends the class of a unit fractional ideal `I` to the class of its
 image under `FractionalIdeal.ringEquivOfRingEquiv f`. This is independent of the chosen fraction
 fields. -/
@@ -72,52 +84,20 @@ theorem mulEquiv_mk {K L : Type*} [Field K] [Field L] [Algebra R K]
   rw [← ClassGroup.mk_canonicalEquiv (K := FractionRing S) L]
   congr 1
   apply Units.ext
-  simp only [Units.coe_mapEquiv, Units.coe_map]
-  rw [FractionalIdeal.canonicalEquiv, FractionalIdeal.canonicalEquiv]
-  -- Each `FractionalIdeal.canonicalEquiv`/`ringEquivOfRingEquiv` factor is built from
-  -- `IsLocalization.map`, whose semilinear packaging (`semilinearEquivOfRingEquiv`) demands
-  -- `RingHomInvPair`/`RingHomCompTriple`/`RingHomSurjective` instances for the ring maps and their
-  -- refl-composites. Mathlib does not have these in scope for `RingEquiv.refl`/`f` combinations, so
-  -- we supply them locally to let the coercions and `IsLocalization.map_map` below elaborate.
-  letI : RingHomInvPair (f : R →+* S) f.symm := RingHomInvPair.of_ringEquiv f
-  letI : RingHomInvPair (f.symm : S →+* R) f := RingHomInvPair.of_ringEquiv f.symm
-  letI : RingHomInvPair (RingEquiv.refl R : R →+* R) (RingEquiv.refl R).symm :=
-    RingHomInvPair.of_ringEquiv (RingEquiv.refl R)
-  letI : RingHomInvPair ((RingEquiv.refl R).symm : R →+* R) (RingEquiv.refl R) :=
-    RingHomInvPair.of_ringEquiv (RingEquiv.refl R).symm
-  letI : RingHomInvPair (RingEquiv.refl S : S →+* S) (RingEquiv.refl S).symm :=
-    RingHomInvPair.of_ringEquiv (RingEquiv.refl S)
-  letI : RingHomInvPair ((RingEquiv.refl S).symm : S →+* S) (RingEquiv.refl S) :=
-    RingHomInvPair.of_ringEquiv (RingEquiv.refl S).symm
-  letI : RingHomCompTriple (RingEquiv.refl R : R →+* R) (f : R →+* S) (f : R →+* S) :=
-    ⟨by ext; rfl⟩
-  letI : RingHomCompTriple (f : R →+* S) (RingEquiv.refl S : S →+* S) (f : R →+* S) :=
-    ⟨by ext; rfl⟩
-  letI : RingHomCompTriple (f.symm : S →+* R) ((RingEquiv.refl R).symm : R →+* R)
-      (f.symm : S →+* R) :=
-    ⟨by ext; rfl⟩
-  letI : RingHomCompTriple ((RingEquiv.refl S).symm : S →+* S) (f.symm : S →+* R)
-      (f.symm : S →+* R) :=
-    ⟨by ext; rfl⟩
-  letI : RingHomSurjective (f : R →+* S) := ⟨f.surjective⟩
-  apply FractionalIdeal.coeToSubmodule_injective
-  -- Both sides are `Submodule.map`s of `I` by the underlying `semilinearEquivOfRingEquiv` maps:
-  -- the left is the three-step canonical composite `K → FractionRing R → FractionRing S → L`, the
-  -- right the direct map `K → L`. There is no Mathlib lemma exposing the `canonicalEquiv` composite
-  -- in this `Submodule.map` form, but the two coincide definitionally, so we restate the goal with
-  -- `change` and then collapse the composite via `Submodule.map_comp` and `IsLocalization.map_map`.
-  change Submodule.map
-      (IsFractionRing.semilinearEquivOfRingEquiv (FractionRing S) L (RingEquiv.refl S)).toLinearMap
-      (Submodule.map
-        (IsFractionRing.semilinearEquivOfRingEquiv (FractionRing R) (FractionRing S) f).toLinearMap
-        (Submodule.map
-          (IsFractionRing.semilinearEquivOfRingEquiv K (FractionRing R)
-            (RingEquiv.refl R)).toLinearMap I.val.val)) =
-    Submodule.map (IsFractionRing.semilinearEquivOfRingEquiv K L f).toLinearMap I.val.val
-  rw [← Submodule.map_comp, ← Submodule.map_comp]
-  congr 1
-  ext x
-  simp [IsFractionRing.semilinearEquivOfRingEquiv, IsLocalization.map_map]
+  -- Both sides are two-step transports of `I` along ring equivalences: the left changes fraction
+  -- field over `R` and then applies `f`, the right applies `f` and then changes fraction field
+  -- over `S`. Rewriting the change-of-fraction-field steps as transports along `RingEquiv.refl`
+  -- collapses both composites to the single transport along `f`.
+  have key (J : FractionalIdeal R⁰ K) :
+      FractionalIdeal.ringEquivOfRingEquiv (FractionRing S) L (RingEquiv.refl S)
+          (FractionalIdeal.ringEquivOfRingEquiv (FractionRing R) (FractionRing S) f
+            (FractionalIdeal.ringEquivOfRingEquiv K (FractionRing R) (RingEquiv.refl R) J)) =
+        FractionalIdeal.ringEquivOfRingEquiv K L f J := by
+    have hf : ((RingEquiv.refl R).trans f).trans (RingEquiv.refl S) = f := by ext; rfl
+    rw [← FractionalIdeal.ringEquivOfRingEquiv_trans_apply K (FractionRing R) (FractionRing S),
+      ← FractionalIdeal.ringEquivOfRingEquiv_trans_apply K (FractionRing S) L, hf]
+  simpa only [Units.coe_mapEquiv, Units.coe_map, canonicalEquiv_eq_ringEquivOfRingEquiv,
+    MonoidHom.coe_coe, RingEquiv.coe_toMulEquiv] using key I
 
 /-- The identity ring equivalence induces the identity class-group equivalence. -/
 @[simp] theorem mulEquiv_refl :

--- a/TauCeti/NumberTheory/ClassGroup/Equiv.lean
+++ b/TauCeti/NumberTheory/ClassGroup/Equiv.lean
@@ -11,8 +11,7 @@ public import Mathlib.RingTheory.ClassGroup.Basic
 
 Mathlib defines `ClassGroup.mulEquiv f`, the multiplicative equivalence on ideal class groups
 induced by a ring equivalence `f : R ≃+* S`. This file supplies its basic functorial API: the
-induced map respects identity, composition, and inverses, and its value on the class of a nonzero
-integral ideal is represented by the transported ideal.
+induced map respects identity, composition, and inverses.
 
 This is a prerequisite for the genus-field layer of the multiquadratic roadmap. For a quadratic
 field, conjugation is a ring automorphism of its ring of integers; the roadmap's proof that
@@ -25,8 +24,8 @@ compute it on ideal classes.
 * `ClassGroup.mulEquiv_trans`: induced equivalences respect composition.
 * `ClassGroup.mulEquiv_symm`: the inverse induced equivalence comes from the inverse ring
   equivalence.
-* `ClassGroup.mulEquiv_apply_apply_of_trans_eq_refl`: an involutive ring equivalence acts
-  involutively on the class group.
+* `ClassGroup.mulEquiv_involutive`: an involutive ring equivalence acts involutively on the class
+  group.
 -/
 
 public section
@@ -41,7 +40,7 @@ variable {R S T : Type*} [CommRing R] [CommRing S] [CommRing T]
     ClassGroup.mulEquiv (RingEquiv.refl R) = MulEquiv.refl (ClassGroup R) := by
   apply MulEquiv.ext
   intro x
-  change ClassGroup.mulEquiv (RingEquiv.refl R) x = x
+  simp only [MulEquiv.refl_apply]
   refine ClassGroup.induction (FractionRing R) (fun I => ?_) x
   rw [ClassGroup.mulEquiv_apply]
   apply (ClassGroup.equiv (FractionRing R)).injective
@@ -65,6 +64,11 @@ theorem mulEquiv_trans (f : R ≃+* S) (g : S ≃+* T) :
     FractionalIdeal.ringEquivOfRingEquiv_trans_apply
       (FractionRing R) (FractionRing S) (FractionRing T) f g I
 
+/-- Pointwise form of `ClassGroup.mulEquiv_trans`. -/
+@[simp] theorem mulEquiv_trans_apply (f : R ≃+* S) (g : S ≃+* T) (x : ClassGroup R) :
+    ClassGroup.mulEquiv (f.trans g) x = ClassGroup.mulEquiv g (ClassGroup.mulEquiv f x) :=
+  DFunLike.congr_fun (mulEquiv_trans f g) x
+
 /-- The inverse of the class-group equivalence induced by `f` is induced by `f.symm`. -/
 theorem mulEquiv_symm (f : R ≃+* S) :
     (ClassGroup.mulEquiv f).symm = ClassGroup.mulEquiv f.symm := by
@@ -76,13 +80,21 @@ theorem mulEquiv_symm (f : R ≃+* S) :
   rw [f.symm_trans_self, mulEquiv_refl] at h
   exact h
 
+/-- Pointwise form of `ClassGroup.mulEquiv_symm`. It is deliberately not a `simp` lemma: the
+`@[simps!]` attribute on Mathlib's `ClassGroup.mulEquiv` already provides a `simp` lemma
+`ClassGroup.mulEquiv_symm_apply` with the same left-hand side, unfolding it into the underlying
+quotient construction instead. -/
+theorem mulEquiv_symm_apply' (f : R ≃+* S) (x : ClassGroup S) :
+    (ClassGroup.mulEquiv f).symm x = ClassGroup.mulEquiv f.symm x :=
+  DFunLike.congr_fun (mulEquiv_symm f) x
+
 /-- An involutive ring equivalence induces an involution on the class group. This is the form
 used for quadratic conjugation. -/
-theorem mulEquiv_apply_apply_of_trans_eq_refl (f : R ≃+* R)
-    (hf : f.trans f = RingEquiv.refl R) (x : ClassGroup R) :
-    ClassGroup.mulEquiv f (ClassGroup.mulEquiv f x) = x := by
+theorem mulEquiv_involutive {f : R ≃+* R} (hf : Function.Involutive f) :
+    Function.Involutive (ClassGroup.mulEquiv f) := fun x => by
+  have hff : f.trans f = RingEquiv.refl R := RingEquiv.ext hf
   have h := DFunLike.congr_fun (mulEquiv_trans f f) x
-  rw [hf, mulEquiv_refl] at h
+  rw [hff, mulEquiv_refl] at h
   exact h.symm
 
 end ClassGroup

--- a/TauCeti/NumberTheory/ClassGroup/Equiv.lean
+++ b/TauCeti/NumberTheory/ClassGroup/Equiv.lean
@@ -60,9 +60,8 @@ private theorem mulEquiv_mk_fractionRing (f : R ≃+* S)
 
 /-- `ClassGroup.mulEquiv f` sends the class of a unit fractional ideal `I` to the class of its
 image under `FractionalIdeal.ringEquivOfRingEquiv f`. This is independent of the chosen fraction
-fields. This is not a simp lemma because `ClassGroup.mulEquiv_apply` already rewrites its
-left-hand side. -/
-theorem mulEquiv_mk {K L : Type*} [Field K] [Field L] [Algebra R K]
+fields. -/
+@[simp] theorem mulEquiv_mk {K L : Type*} [Field K] [Field L] [Algebra R K]
     [Algebra S L] [IsFractionRing R K] [IsFractionRing S L] (f : R ≃+* S)
     (I : (FractionalIdeal R⁰ K)ˣ) :
     ClassGroup.mulEquiv f (ClassGroup.mk K I) =

--- a/TauCeti/NumberTheory/ClassGroup/Equiv.lean
+++ b/TauCeti/NumberTheory/ClassGroup/Equiv.lean
@@ -11,7 +11,8 @@ public import Mathlib.RingTheory.ClassGroup.Basic
 
 Mathlib defines `ClassGroup.mulEquiv f`, the multiplicative equivalence on ideal class groups
 induced by a ring equivalence `f : R ≃+* S`. This file supplies its basic functorial API: the
-induced map respects identity, composition, and inverses.
+induced map respects identity, composition, and inverses, and computes on the class of a unit
+fractional ideal.
 
 This is a prerequisite for the genus-field layer of the multiquadratic roadmap. For a quadratic
 field, conjugation is a ring automorphism of its ring of integers; the roadmap's proof that
@@ -20,49 +21,66 @@ compute it on ideal classes.
 
 ## Main results
 
+* `ClassGroup.mulEquiv_mk`: the value of the induced equivalence on the class of a unit fractional
+  ideal is the class of the transported ideal.
 * `ClassGroup.mulEquiv_refl`: the identity ring equivalence induces the identity on class groups.
 * `ClassGroup.mulEquiv_trans`: induced equivalences respect composition.
 * `ClassGroup.mulEquiv_symm`: the inverse induced equivalence comes from the inverse ring
   equivalence.
+* `ClassGroup.mulEquivHom`: the induced action bundled as a monoid homomorphism
+  `(R ≃+* R) →* MulAut (ClassGroup R)`.
 * `ClassGroup.mulEquiv_involutive`: an involutive ring equivalence acts involutively on the class
   group.
 -/
 
 public section
 
+open scoped nonZeroDivisors
+
 namespace ClassGroup
 
 variable {R S T : Type*} [CommRing R] [CommRing S] [CommRing T]
   [IsDomain R] [IsDomain S] [IsDomain T]
+
+/-- `ClassGroup.mulEquiv f` sends the class of a unit fractional ideal `I` to the class of its
+image under `FractionalIdeal.ringEquivOfRingEquiv f`. This is the characteristic computation of the
+induced map on ideal classes; the functorial laws below are corollaries. -/
+@[simp high] theorem mulEquiv_mk (f : R ≃+* S) (I : (FractionalIdeal R⁰ (FractionRing R))ˣ) :
+    ClassGroup.mulEquiv f (ClassGroup.mk (FractionRing R) I) =
+      ClassGroup.mk (FractionRing S)
+        (Units.mapEquiv (FractionalIdeal.ringEquivOfRingEquiv
+          (FractionRing R) (FractionRing S) f) I) := by
+  apply (ClassGroup.equiv (FractionRing S)).injective
+  rw [ClassGroup.mulEquiv_apply, MulEquiv.apply_symm_apply, ClassGroup.equiv_mk,
+    ClassGroup.equiv_mk, QuotientGroup.congr_mk']
+  apply congrArg (QuotientGroup.mk' (toPrincipalIdeal S (FractionRing S)).range)
+  apply Units.ext
+  simp [FractionalIdeal.canonicalEquiv_self]
 
 /-- The identity ring equivalence induces the identity class-group equivalence. -/
 @[simp] theorem mulEquiv_refl :
     ClassGroup.mulEquiv (RingEquiv.refl R) = MulEquiv.refl (ClassGroup R) := by
   apply MulEquiv.ext
   intro x
-  simp only [MulEquiv.refl_apply]
   refine ClassGroup.induction (FractionRing R) (fun I => ?_) x
-  rw [ClassGroup.mulEquiv_apply]
-  apply (ClassGroup.equiv (FractionRing R)).injective
-  rw [MulEquiv.apply_symm_apply, ClassGroup.equiv_mk, QuotientGroup.congr_mk']
-  congr 1
+  rw [MulEquiv.refl_apply, mulEquiv_mk, FractionalIdeal.ringEquivOfRingEquiv_refl]
+  apply congrArg (ClassGroup.mk (FractionRing R))
   apply Units.ext
-  simp [FractionalIdeal.ringEquivOfRingEquiv_refl]
+  simp
 
 /-- Composition of ring equivalences is carried to composition of the induced class-group
 equivalences. -/
-theorem mulEquiv_trans (f : R ≃+* S) (g : S ≃+* T) :
+@[simp] theorem mulEquiv_trans (f : R ≃+* S) (g : S ≃+* T) :
     ClassGroup.mulEquiv (f.trans g) =
       (ClassGroup.mulEquiv f).trans (ClassGroup.mulEquiv g) := by
   apply MulEquiv.ext
   intro x
   refine ClassGroup.induction (FractionRing R) (fun I => ?_) x
-  simp only [ClassGroup.mulEquiv_apply, ClassGroup.equiv_mk, QuotientGroup.congr_mk']
-  apply congrArg (QuotientGroup.mk' (toPrincipalIdeal T (FractionRing T)).range)
+  rw [MulEquiv.trans_apply, mulEquiv_mk, mulEquiv_mk, mulEquiv_mk]
+  apply congrArg (ClassGroup.mk (FractionRing T))
   apply Units.ext
-  simpa [FractionalIdeal.canonicalEquiv_self] using
-    FractionalIdeal.ringEquivOfRingEquiv_trans_apply
-      (FractionRing R) (FractionRing S) (FractionRing T) f g I
+  simpa using FractionalIdeal.ringEquivOfRingEquiv_trans_apply
+    (FractionRing R) (FractionRing S) (FractionRing T) f g I
 
 /-- Pointwise form of `ClassGroup.mulEquiv_trans`. Like `ClassGroup.mulEquiv_symm_apply'` below,
 it is deliberately not a `simp` lemma: the `@[simps!]` attribute on Mathlib's
@@ -72,8 +90,15 @@ theorem mulEquiv_trans_apply (f : R ≃+* S) (g : S ≃+* T) (x : ClassGroup R) 
     ClassGroup.mulEquiv (f.trans g) x = ClassGroup.mulEquiv g (ClassGroup.mulEquiv f x) :=
   DFunLike.congr_fun (mulEquiv_trans f g) x
 
+/-- Pointwise form of `ClassGroup.mulEquiv_refl`. Like `ClassGroup.mulEquiv_trans_apply`, it is
+deliberately not a `simp` lemma: the `@[simps!]` attribute on Mathlib's `ClassGroup.mulEquiv`
+provides a `simp` lemma `ClassGroup.mulEquiv_apply` that already owns this left-hand side. -/
+theorem mulEquiv_refl_apply (x : ClassGroup R) :
+    ClassGroup.mulEquiv (RingEquiv.refl R) x = x :=
+  DFunLike.congr_fun mulEquiv_refl x
+
 /-- The inverse of the class-group equivalence induced by `f` is induced by `f.symm`. -/
-theorem mulEquiv_symm (f : R ≃+* S) :
+@[simp] theorem mulEquiv_symm (f : R ≃+* S) :
     (ClassGroup.mulEquiv f).symm = ClassGroup.mulEquiv f.symm := by
   apply MulEquiv.ext
   intro x
@@ -91,13 +116,29 @@ theorem mulEquiv_symm_apply' (f : R ≃+* S) (x : ClassGroup S) :
     (ClassGroup.mulEquiv f).symm x = ClassGroup.mulEquiv f.symm x :=
   DFunLike.congr_fun (mulEquiv_symm f) x
 
+/-- The action of ring automorphisms of `R` on `ClassGroup R`, bundled as a monoid homomorphism
+`(R ≃+* R) →* MulAut (ClassGroup R)`. This is the object the roadmap's Galois action on ideal
+classes transports along; it is the class-group analogue of
+`IsFractionRing.ringEquivOfRingEquivHom`. -/
+@[expose] noncomputable def mulEquivHom : (R ≃+* R) →* MulAut (ClassGroup R) where
+  toFun := ClassGroup.mulEquiv
+  map_one' := mulEquiv_refl
+  map_mul' f g := mulEquiv_trans g f
+
+/-- `ClassGroup.mulEquivHom` acts as `ClassGroup.mulEquiv` on each ring automorphism. -/
+@[simp] theorem mulEquivHom_apply (f : R ≃+* R) :
+    mulEquivHom f = ClassGroup.mulEquiv f := rfl
+
 /-- An involutive ring equivalence induces an involution on the class group. This is the form
-used for quadratic conjugation. -/
+used for quadratic conjugation; it is the pointwise specialization of `ClassGroup.mulEquivHom`
+at an order-two automorphism. -/
 theorem mulEquiv_involutive {f : R ≃+* R} (hf : Function.Involutive f) :
-    Function.Involutive (ClassGroup.mulEquiv f) := fun x => by
-  have hff : f.trans f = RingEquiv.refl R := RingEquiv.ext hf
-  have h := DFunLike.congr_fun (mulEquiv_trans f f) x
-  rw [hff, mulEquiv_refl] at h
-  exact h.symm
+    Function.Involutive (ClassGroup.mulEquiv f) := by
+  have hff : f * f = 1 := RingEquiv.ext hf
+  have h : ClassGroup.mulEquiv f * ClassGroup.mulEquiv f = 1 := by
+    rw [← mulEquivHom_apply f, ← map_mul, hff, map_one]
+  intro x
+  have := DFunLike.congr_fun h x
+  rwa [MulAut.mul_apply, MulAut.one_apply] at this
 
 end ClassGroup

--- a/TauCeti/NumberTheory/ClassGroup/Equiv.lean
+++ b/TauCeti/NumberTheory/ClassGroup/Equiv.lean
@@ -61,7 +61,7 @@ private theorem mulEquiv_mk_fractionRing (f : R ≃+* S)
 /-- `ClassGroup.mulEquiv f` sends the class of a unit fractional ideal `I` to the class of its
 image under `FractionalIdeal.ringEquivOfRingEquiv f`. This is independent of the chosen fraction
 fields. -/
-@[simp] theorem mulEquiv_mk {K L : Type*} [Field K] [Field L] [Algebra R K]
+theorem mulEquiv_mk {K L : Type*} [Field K] [Field L] [Algebra R K]
     [Algebra S L] [IsFractionRing R K] [IsFractionRing S L] (f : R ≃+* S)
     (I : (FractionalIdeal R⁰ K)ˣ) :
     ClassGroup.mulEquiv f (ClassGroup.mk K I) =

--- a/TauCeti/NumberTheory/ClassGroup/Equiv.lean
+++ b/TauCeti/NumberTheory/ClassGroup/Equiv.lean
@@ -64,8 +64,11 @@ theorem mulEquiv_trans (f : R ≃+* S) (g : S ≃+* T) :
     FractionalIdeal.ringEquivOfRingEquiv_trans_apply
       (FractionRing R) (FractionRing S) (FractionRing T) f g I
 
-/-- Pointwise form of `ClassGroup.mulEquiv_trans`. -/
-@[simp] theorem mulEquiv_trans_apply (f : R ≃+* S) (g : S ≃+* T) (x : ClassGroup R) :
+/-- Pointwise form of `ClassGroup.mulEquiv_trans`. Like `ClassGroup.mulEquiv_symm_apply'` below,
+it is deliberately not a `simp` lemma: the `@[simps!]` attribute on Mathlib's
+`ClassGroup.mulEquiv` provides a `simp` lemma `ClassGroup.mulEquiv_apply` that already rewrites
+this left-hand side into the underlying quotient construction. -/
+theorem mulEquiv_trans_apply (f : R ≃+* S) (g : S ≃+* T) (x : ClassGroup R) :
     ClassGroup.mulEquiv (f.trans g) x = ClassGroup.mulEquiv g (ClassGroup.mulEquiv f x) :=
   DFunLike.congr_fun (mulEquiv_trans f g) x
 

--- a/TauCeti/NumberTheory/ClassGroup/Equiv.lean
+++ b/TauCeti/NumberTheory/ClassGroup/Equiv.lean
@@ -36,9 +36,12 @@ namespace ClassGroup
 variable {R S T : Type*} [CommRing R] [CommRing S] [CommRing T]
   [IsDomain R] [IsDomain S] [IsDomain T]
 
-/-- The identity ring equivalence induces the identity map on the class group. -/
-@[simp] theorem mulEquiv_refl_apply (x : ClassGroup R) :
-    ClassGroup.mulEquiv (RingEquiv.refl R) x = x := by
+/-- The identity ring equivalence induces the identity class-group equivalence. -/
+@[simp] theorem mulEquiv_refl :
+    ClassGroup.mulEquiv (RingEquiv.refl R) = MulEquiv.refl (ClassGroup R) := by
+  apply MulEquiv.ext
+  intro x
+  change ClassGroup.mulEquiv (RingEquiv.refl R) x = x
   refine ClassGroup.induction (FractionRing R) (fun I => ?_) x
   rw [ClassGroup.mulEquiv_apply]
   apply (ClassGroup.equiv (FractionRing R)).injective
@@ -47,57 +50,39 @@ variable {R S T : Type*} [CommRing R] [CommRing S] [CommRing T]
   apply Units.ext
   simp [FractionalIdeal.ringEquivOfRingEquiv_refl]
 
-/-- Class-group equivalences induced by ring equivalences respect composition. -/
-@[simp] theorem mulEquiv_trans_apply (f : R ≃+* S) (g : S ≃+* T) (x : ClassGroup R) :
-    ClassGroup.mulEquiv (f.trans g) x =
-      ClassGroup.mulEquiv g (ClassGroup.mulEquiv f x) := by
+/-- Composition of ring equivalences is carried to composition of the induced class-group
+equivalences. -/
+theorem mulEquiv_trans (f : R ≃+* S) (g : S ≃+* T) :
+    ClassGroup.mulEquiv (f.trans g) =
+      (ClassGroup.mulEquiv f).trans (ClassGroup.mulEquiv g) := by
+  apply MulEquiv.ext
+  intro x
   refine ClassGroup.induction (FractionRing R) (fun I => ?_) x
-  simp only [ClassGroup.mulEquiv_apply, ClassGroup.equiv_mk, MulEquiv.apply_symm_apply,
-    QuotientGroup.congr_mk']
+  simp only [ClassGroup.mulEquiv_apply, ClassGroup.equiv_mk, QuotientGroup.congr_mk']
   apply congrArg (QuotientGroup.mk' (toPrincipalIdeal T (FractionRing T)).range)
   apply Units.ext
   simpa [FractionalIdeal.canonicalEquiv_self] using
     FractionalIdeal.ringEquivOfRingEquiv_trans_apply
       (FractionRing R) (FractionRing S) (FractionRing T) f g I
 
-/-- The class-group equivalence induced by the inverse ring equivalence undoes the original
-induced equivalence. -/
-@[simp] theorem mulEquiv_symm_apply_apply (f : R ≃+* S) (x : ClassGroup R) :
-    ClassGroup.mulEquiv f.symm (ClassGroup.mulEquiv f x) = x := by
-  rw [← mulEquiv_trans_apply, f.self_trans_symm, mulEquiv_refl_apply]
-
-/-- The class-group equivalence induced by a ring equivalence undoes the map induced by its
-inverse. -/
-@[simp] theorem mulEquiv_apply_symm_apply (f : R ≃+* S) (x : ClassGroup S) :
-    ClassGroup.mulEquiv f (ClassGroup.mulEquiv f.symm x) = x := by
-  rw [← mulEquiv_trans_apply, f.symm_trans_self, mulEquiv_refl_apply]
-
 /-- The inverse of the class-group equivalence induced by `f` is induced by `f.symm`. -/
 theorem mulEquiv_symm (f : R ≃+* S) :
     (ClassGroup.mulEquiv f).symm = ClassGroup.mulEquiv f.symm := by
-  ext x
+  apply MulEquiv.ext
+  intro x
   apply (ClassGroup.mulEquiv f).injective
-  rw [MulEquiv.apply_symm_apply, mulEquiv_apply_symm_apply]
-
-/-- The identity ring equivalence induces the identity class-group equivalence. -/
-@[simp] theorem mulEquiv_refl :
-    ClassGroup.mulEquiv (RingEquiv.refl R) = MulEquiv.refl (ClassGroup R) := by
-  ext x
-  exact mulEquiv_refl_apply x
-
-/-- Composition of ring equivalences is carried to composition of the induced class-group
-equivalences. -/
-theorem mulEquiv_trans (f : R ≃+* S) (g : S ≃+* T) :
-    ClassGroup.mulEquiv (f.trans g) =
-      (ClassGroup.mulEquiv f).trans (ClassGroup.mulEquiv g) := by
-  ext x
-  exact mulEquiv_trans_apply f g x
+  rw [MulEquiv.apply_symm_apply]
+  have h := DFunLike.congr_fun (mulEquiv_trans f.symm f) x
+  rw [f.symm_trans_self, mulEquiv_refl] at h
+  exact h
 
 /-- An involutive ring equivalence induces an involution on the class group. This is the form
 used for quadratic conjugation. -/
 theorem mulEquiv_apply_apply_of_trans_eq_refl (f : R ≃+* R)
     (hf : f.trans f = RingEquiv.refl R) (x : ClassGroup R) :
     ClassGroup.mulEquiv f (ClassGroup.mulEquiv f x) = x := by
-  rw [← mulEquiv_trans_apply, hf, mulEquiv_refl_apply]
+  have h := DFunLike.congr_fun (mulEquiv_trans f f) x
+  rw [hf, mulEquiv_refl] at h
+  exact h.symm
 
 end ClassGroup

--- a/TauCeti/NumberTheory/ClassGroup/Equiv.lean
+++ b/TauCeti/NumberTheory/ClassGroup/Equiv.lean
@@ -61,7 +61,7 @@ private theorem mulEquiv_mk_fractionRing (f : R ≃+* S)
 /-- `ClassGroup.mulEquiv f` sends the class of a unit fractional ideal `I` to the class of its
 image under `FractionalIdeal.ringEquivOfRingEquiv f`. This is independent of the chosen fraction
 fields. -/
-@[simp high] theorem mulEquiv_mk {K L : Type*} [Field K] [Field L] [Algebra R K]
+theorem mulEquiv_mk {K L : Type*} [Field K] [Field L] [Algebra R K]
     [Algebra S L] [IsFractionRing R K] [IsFractionRing S L] (f : R ≃+* S)
     (I : (FractionalIdeal R⁰ K)ˣ) :
     ClassGroup.mulEquiv f (ClassGroup.mk K I) =
@@ -138,13 +138,15 @@ equivalences. -/
   simpa using FractionalIdeal.ringEquivOfRingEquiv_trans_apply
     (FractionRing R) (FractionRing S) (FractionRing T) f g I
 
-/-- Pointwise form of `ClassGroup.mulEquiv_trans`. -/
-@[simp] theorem mulEquiv_trans_apply (f : R ≃+* S) (g : S ≃+* T) (x : ClassGroup R) :
+/-- Pointwise form of `ClassGroup.mulEquiv_trans`. This is not a simp lemma because
+`ClassGroup.mulEquiv_apply` already rewrites its left-hand side. -/
+theorem mulEquiv_trans_apply (f : R ≃+* S) (g : S ≃+* T) (x : ClassGroup R) :
     ClassGroup.mulEquiv (f.trans g) x = ClassGroup.mulEquiv g (ClassGroup.mulEquiv f x) :=
   DFunLike.congr_fun (mulEquiv_trans f g) x
 
-/-- Pointwise form of `ClassGroup.mulEquiv_refl`. -/
-@[simp] theorem mulEquiv_refl_apply (x : ClassGroup R) :
+/-- Pointwise form of `ClassGroup.mulEquiv_refl`. This is not a simp lemma because
+`ClassGroup.mulEquiv_refl` already proves the bundled normal form. -/
+theorem mulEquiv_refl_apply (x : ClassGroup R) :
     ClassGroup.mulEquiv (RingEquiv.refl R) x = x :=
   DFunLike.congr_fun mulEquiv_refl x
 
@@ -159,8 +161,9 @@ equivalences. -/
   rw [f.symm_trans_self, mulEquiv_refl] at h
   exact h
 
-/-- Pointwise form of `ClassGroup.mulEquiv_symm`. -/
-@[simp] theorem mulEquiv_symm_apply' (f : R ≃+* S) (x : ClassGroup S) :
+/-- Pointwise form of `ClassGroup.mulEquiv_symm`. This is not a simp lemma because
+`ClassGroup.mulEquiv_apply` already rewrites its left-hand side. -/
+theorem mulEquiv_symm_apply' (f : R ≃+* S) (x : ClassGroup S) :
     (ClassGroup.mulEquiv f).symm x = ClassGroup.mulEquiv f.symm x :=
   DFunLike.congr_fun (mulEquiv_symm f) x
 

--- a/TauCeti/NumberTheory/ClassGroup/Equiv.lean
+++ b/TauCeti/NumberTheory/ClassGroup/Equiv.lean
@@ -21,8 +21,10 @@ compute it on ideal classes.
 
 ## Main results
 
-* `ClassGroup.mulEquiv_mk`: the value of the induced equivalence on the class of a unit fractional
-  ideal is the class of the transported ideal.
+* `ClassGroup.mulEquiv_mk_fractionRing`: the `simp`-usable computation of the induced equivalence on
+  the class of a unit fractional ideal over the canonical fraction field.
+* `ClassGroup.mulEquiv_mk`: the same computation over arbitrary fraction fields, as an `rw`-form
+  with the target fraction field explicit.
 * `ClassGroup.mulEquiv_refl`: the identity ring equivalence induces the identity on class groups.
 * `ClassGroup.mulEquiv_trans`: induced equivalences respect composition.
 * `ClassGroup.mulEquiv_symm`: the inverse induced equivalence comes from the inverse ring
@@ -44,8 +46,10 @@ variable {R S T : Type*} [CommRing R] [CommRing S] [CommRing T]
 
 /-- `ClassGroup.mulEquiv f` sends the class of a unit fractional ideal `I` to the class of its
 image under `FractionalIdeal.ringEquivOfRingEquiv f`. This is the characteristic computation of the
-induced map on ideal classes; the functorial laws below are corollaries. -/
-private theorem mulEquiv_mk_fractionRing (f : R ≃+* S)
+induced map on ideal classes; the functorial laws below are corollaries. Its fully-determined
+left-hand side makes it the `simp`-usable form; `mulEquiv_mk` is the general `rw`-form over
+arbitrary fraction fields. -/
+@[simp high] theorem mulEquiv_mk_fractionRing (f : R ≃+* S)
     (I : (FractionalIdeal R⁰ (FractionRing R))ˣ) :
     ClassGroup.mulEquiv f (ClassGroup.mk (FractionRing R) I) =
       ClassGroup.mk (FractionRing S)
@@ -73,7 +77,7 @@ private theorem canonicalEquiv_eq_ringEquivOfRingEquiv (K K' : Type*) [Field K] 
 /-- `ClassGroup.mulEquiv f` sends the class of a unit fractional ideal `I` to the class of its
 image under `FractionalIdeal.ringEquivOfRingEquiv f`. This is independent of the chosen fraction
 fields. -/
-theorem mulEquiv_mk {K L : Type*} [Field K] [Field L] [Algebra R K]
+theorem mulEquiv_mk {K : Type*} (L : Type*) [Field K] [Field L] [Algebra R K]
     [Algebra S L] [IsFractionRing R K] [IsFractionRing S L] (f : R ≃+* S)
     (I : (FractionalIdeal R⁰ K)ˣ) :
     ClassGroup.mulEquiv f (ClassGroup.mk K I) =

--- a/TauCeti/NumberTheory/ClassGroup/Equiv.lean
+++ b/TauCeti/NumberTheory/ClassGroup/Equiv.lean
@@ -61,7 +61,7 @@ private theorem mulEquiv_mk_fractionRing (f : R ≃+* S)
 /-- `ClassGroup.mulEquiv f` sends the class of a unit fractional ideal `I` to the class of its
 image under `FractionalIdeal.ringEquivOfRingEquiv f`. This is independent of the chosen fraction
 fields. -/
-theorem mulEquiv_mk {K L : Type*} [Field K] [Field L] [Algebra R K]
+@[simp] theorem mulEquiv_mk {K L : Type*} [Field K] [Field L] [Algebra R K]
     [Algebra S L] [IsFractionRing R K] [IsFractionRing S L] (f : R ≃+* S)
     (I : (FractionalIdeal R⁰ K)ˣ) :
     ClassGroup.mulEquiv f (ClassGroup.mk K I) =

--- a/TauCeti/NumberTheory/ClassGroup/Equiv.lean
+++ b/TauCeti/NumberTheory/ClassGroup/Equiv.lean
@@ -60,8 +60,9 @@ private theorem mulEquiv_mk_fractionRing (f : R ≃+* S)
 
 /-- `ClassGroup.mulEquiv f` sends the class of a unit fractional ideal `I` to the class of its
 image under `FractionalIdeal.ringEquivOfRingEquiv f`. This is independent of the chosen fraction
-fields. -/
-@[simp] theorem mulEquiv_mk {K L : Type*} [Field K] [Field L] [Algebra R K]
+fields. This is not a simp lemma because `ClassGroup.mulEquiv_apply` already rewrites its
+left-hand side. -/
+theorem mulEquiv_mk {K L : Type*} [Field K] [Field L] [Algebra R K]
     [Algebra S L] [IsFractionRing R K] [IsFractionRing S L] (f : R ≃+* S)
     (I : (FractionalIdeal R⁰ K)ˣ) :
     ClassGroup.mulEquiv f (ClassGroup.mk K I) =

--- a/TauCeti/NumberTheory/ClassGroup/Equiv.lean
+++ b/TauCeti/NumberTheory/ClassGroup/Equiv.lean
@@ -45,7 +45,8 @@ variable {R S T : Type*} [CommRing R] [CommRing S] [CommRing T]
 /-- `ClassGroup.mulEquiv f` sends the class of a unit fractional ideal `I` to the class of its
 image under `FractionalIdeal.ringEquivOfRingEquiv f`. This is the characteristic computation of the
 induced map on ideal classes; the functorial laws below are corollaries. -/
-@[simp high] theorem mulEquiv_mk (f : R ≃+* S) (I : (FractionalIdeal R⁰ (FractionRing R))ˣ) :
+private theorem mulEquiv_mk_fractionRing (f : R ≃+* S)
+    (I : (FractionalIdeal R⁰ (FractionRing R))ˣ) :
     ClassGroup.mulEquiv f (ClassGroup.mk (FractionRing R) I) =
       ClassGroup.mk (FractionRing S)
         (Units.mapEquiv (FractionalIdeal.ringEquivOfRingEquiv
@@ -57,13 +58,65 @@ induced map on ideal classes; the functorial laws below are corollaries. -/
   apply Units.ext
   simp [FractionalIdeal.canonicalEquiv_self]
 
+/-- `ClassGroup.mulEquiv f` sends the class of a unit fractional ideal `I` to the class of its
+image under `FractionalIdeal.ringEquivOfRingEquiv f`. This is independent of the chosen fraction
+fields. -/
+@[simp high] theorem mulEquiv_mk {K L : Type*} [Field K] [Field L] [Algebra R K]
+    [Algebra S L] [IsFractionRing R K] [IsFractionRing S L] (f : R ≃+* S)
+    (I : (FractionalIdeal R⁰ K)ˣ) :
+    ClassGroup.mulEquiv f (ClassGroup.mk K I) =
+      ClassGroup.mk L
+        (Units.mapEquiv (FractionalIdeal.ringEquivOfRingEquiv K L f) I) := by
+  rw [← ClassGroup.mk_canonicalEquiv (K := K) (FractionRing R) I,
+    mulEquiv_mk_fractionRing]
+  rw [← ClassGroup.mk_canonicalEquiv (K := FractionRing S) L]
+  congr 1
+  apply Units.ext
+  simp only [Units.coe_mapEquiv, Units.coe_map]
+  rw [FractionalIdeal.canonicalEquiv, FractionalIdeal.canonicalEquiv]
+  letI : RingHomInvPair (f : R →+* S) f.symm := RingHomInvPair.of_ringEquiv f
+  letI : RingHomInvPair (f.symm : S →+* R) f := RingHomInvPair.of_ringEquiv f.symm
+  letI : RingHomInvPair (RingEquiv.refl R : R →+* R) (RingEquiv.refl R).symm :=
+    RingHomInvPair.of_ringEquiv (RingEquiv.refl R)
+  letI : RingHomInvPair ((RingEquiv.refl R).symm : R →+* R) (RingEquiv.refl R) :=
+    RingHomInvPair.of_ringEquiv (RingEquiv.refl R).symm
+  letI : RingHomInvPair (RingEquiv.refl S : S →+* S) (RingEquiv.refl S).symm :=
+    RingHomInvPair.of_ringEquiv (RingEquiv.refl S)
+  letI : RingHomInvPair ((RingEquiv.refl S).symm : S →+* S) (RingEquiv.refl S) :=
+    RingHomInvPair.of_ringEquiv (RingEquiv.refl S).symm
+  letI : RingHomCompTriple (RingEquiv.refl R : R →+* R) (f : R →+* S) (f : R →+* S) :=
+    ⟨by ext; rfl⟩
+  letI : RingHomCompTriple (f : R →+* S) (RingEquiv.refl S : S →+* S) (f : R →+* S) :=
+    ⟨by ext; rfl⟩
+  letI : RingHomCompTriple (f.symm : S →+* R) ((RingEquiv.refl R).symm : R →+* R)
+      (f.symm : S →+* R) :=
+    ⟨by ext; rfl⟩
+  letI : RingHomCompTriple ((RingEquiv.refl S).symm : S →+* S) (f.symm : S →+* R)
+      (f.symm : S →+* R) :=
+    ⟨by ext; rfl⟩
+  letI : RingHomSurjective (f : R →+* S) := ⟨f.surjective⟩
+  apply FractionalIdeal.coeToSubmodule_injective
+  change Submodule.map
+      (IsFractionRing.semilinearEquivOfRingEquiv (FractionRing S) L (RingEquiv.refl S)).toLinearMap
+      (Submodule.map
+        (IsFractionRing.semilinearEquivOfRingEquiv (FractionRing R) (FractionRing S) f).toLinearMap
+        (Submodule.map
+          (IsFractionRing.semilinearEquivOfRingEquiv K (FractionRing R)
+            (RingEquiv.refl R)).toLinearMap I.val.val)) =
+    Submodule.map (IsFractionRing.semilinearEquivOfRingEquiv K L f).toLinearMap I.val.val
+  rw [← Submodule.map_comp, ← Submodule.map_comp]
+  congr 1
+  ext x
+  simp [IsFractionRing.semilinearEquivOfRingEquiv, IsLocalization.map_map]
+
 /-- The identity ring equivalence induces the identity class-group equivalence. -/
 @[simp] theorem mulEquiv_refl :
     ClassGroup.mulEquiv (RingEquiv.refl R) = MulEquiv.refl (ClassGroup R) := by
   apply MulEquiv.ext
   intro x
   refine ClassGroup.induction (FractionRing R) (fun I => ?_) x
-  rw [MulEquiv.refl_apply, mulEquiv_mk, FractionalIdeal.ringEquivOfRingEquiv_refl]
+  rw [MulEquiv.refl_apply, mulEquiv_mk (K := FractionRing R) (L := FractionRing R),
+    FractionalIdeal.ringEquivOfRingEquiv_refl]
   apply congrArg (ClassGroup.mk (FractionRing R))
   apply Units.ext
   simp
@@ -76,24 +129,22 @@ equivalences. -/
   apply MulEquiv.ext
   intro x
   refine ClassGroup.induction (FractionRing R) (fun I => ?_) x
-  rw [MulEquiv.trans_apply, mulEquiv_mk, mulEquiv_mk, mulEquiv_mk]
+  rw [MulEquiv.trans_apply,
+    mulEquiv_mk (K := FractionRing R) (L := FractionRing T),
+    mulEquiv_mk (K := FractionRing R) (L := FractionRing S),
+    mulEquiv_mk (K := FractionRing S) (L := FractionRing T)]
   apply congrArg (ClassGroup.mk (FractionRing T))
   apply Units.ext
   simpa using FractionalIdeal.ringEquivOfRingEquiv_trans_apply
     (FractionRing R) (FractionRing S) (FractionRing T) f g I
 
-/-- Pointwise form of `ClassGroup.mulEquiv_trans`. Like `ClassGroup.mulEquiv_symm_apply'` below,
-it is deliberately not a `simp` lemma: the `@[simps!]` attribute on Mathlib's
-`ClassGroup.mulEquiv` provides a `simp` lemma `ClassGroup.mulEquiv_apply` that already rewrites
-this left-hand side into the underlying quotient construction. -/
-theorem mulEquiv_trans_apply (f : R ≃+* S) (g : S ≃+* T) (x : ClassGroup R) :
+/-- Pointwise form of `ClassGroup.mulEquiv_trans`. -/
+@[simp] theorem mulEquiv_trans_apply (f : R ≃+* S) (g : S ≃+* T) (x : ClassGroup R) :
     ClassGroup.mulEquiv (f.trans g) x = ClassGroup.mulEquiv g (ClassGroup.mulEquiv f x) :=
   DFunLike.congr_fun (mulEquiv_trans f g) x
 
-/-- Pointwise form of `ClassGroup.mulEquiv_refl`. Like `ClassGroup.mulEquiv_trans_apply`, it is
-deliberately not a `simp` lemma: the `@[simps!]` attribute on Mathlib's `ClassGroup.mulEquiv`
-provides a `simp` lemma `ClassGroup.mulEquiv_apply` that already owns this left-hand side. -/
-theorem mulEquiv_refl_apply (x : ClassGroup R) :
+/-- Pointwise form of `ClassGroup.mulEquiv_refl`. -/
+@[simp] theorem mulEquiv_refl_apply (x : ClassGroup R) :
     ClassGroup.mulEquiv (RingEquiv.refl R) x = x :=
   DFunLike.congr_fun mulEquiv_refl x
 
@@ -108,11 +159,8 @@ theorem mulEquiv_refl_apply (x : ClassGroup R) :
   rw [f.symm_trans_self, mulEquiv_refl] at h
   exact h
 
-/-- Pointwise form of `ClassGroup.mulEquiv_symm`. It is deliberately not a `simp` lemma: the
-`@[simps!]` attribute on Mathlib's `ClassGroup.mulEquiv` already provides a `simp` lemma
-`ClassGroup.mulEquiv_symm_apply` with the same left-hand side, unfolding it into the underlying
-quotient construction instead. -/
-theorem mulEquiv_symm_apply' (f : R ≃+* S) (x : ClassGroup S) :
+/-- Pointwise form of `ClassGroup.mulEquiv_symm`. -/
+@[simp] theorem mulEquiv_symm_apply' (f : R ≃+* S) (x : ClassGroup S) :
     (ClassGroup.mulEquiv f).symm x = ClassGroup.mulEquiv f.symm x :=
   DFunLike.congr_fun (mulEquiv_symm f) x
 
@@ -120,14 +168,15 @@ theorem mulEquiv_symm_apply' (f : R ≃+* S) (x : ClassGroup S) :
 `(R ≃+* R) →* MulAut (ClassGroup R)`. This is the object the roadmap's Galois action on ideal
 classes transports along; it is the class-group analogue of
 `IsFractionRing.ringEquivOfRingEquivHom`. -/
-@[expose] noncomputable def mulEquivHom : (R ≃+* R) →* MulAut (ClassGroup R) where
+noncomputable def mulEquivHom : (R ≃+* R) →* MulAut (ClassGroup R) where
   toFun := ClassGroup.mulEquiv
   map_one' := mulEquiv_refl
   map_mul' f g := mulEquiv_trans g f
 
 /-- `ClassGroup.mulEquivHom` acts as `ClassGroup.mulEquiv` on each ring automorphism. -/
 @[simp] theorem mulEquivHom_apply (f : R ≃+* R) :
-    mulEquivHom f = ClassGroup.mulEquiv f := rfl
+    mulEquivHom f = ClassGroup.mulEquiv f := by
+  simp [mulEquivHom]
 
 /-- An involutive ring equivalence induces an involution on the class group. This is the form
 used for quadratic conjugation; it is the pointwise specialization of `ClassGroup.mulEquivHom`


### PR DESCRIPTION
This PR supplies the functorial API for `ClassGroup.mulEquiv`: make the induced class-group equivalence respect identity, composition, and inverse ring equivalences, and expose the involutive specialization needed for quadratic conjugation. It proves the laws on Mathlib's quotient construction rather than introducing a parallel class-group action.

This advances `TauCetiRoadmap/Multiquadratic/README.md`, Layer 3, specifically the genus-field argument that “the nontrivial automorphism acts on `Cl(K)` by inversion, since `I · σI` is principal.” The first step of that argument is to transport the quadratic conjugation involution to the class group and calculate its composites; the new API makes that step available before the later ideal-norm calculation. I chose it as the lowest-hanging distinct prerequisite after checking open and recently merged PRs: Layer 0, the splitting law, the elementary-2 quotient, unit-square bounds, and the conjugate-ideal transversal are already merged, while Mathlib's `ClassGroup.mulEquiv` had no identity/composition/inverse API and no current PR supplies it.

No Mathlib infrastructure is vendored. The proofs reuse Mathlib's `ClassGroup.mulEquiv`, `ClassGroup.induction`, `ClassGroup.equiv_mk`, `QuotientGroup.congr_mk'`, and `FractionalIdeal.ringEquivOfRingEquiv_{refl,trans_apply}`.

`lake exe cache get` completed with `No files to download` and `Already decompressed 8619 file(s)`. `lake build` reported `Build completed successfully (5160 jobs).` `lake exe axioms` reported `axioms: audited 10432 TauCeti declaration(s); all within the allowlist [propext, Classical.choice, Quot.sound].`

<!--tauceti-target:v1 {"focus":"Multiquadratic","id":"class-group-mulequiv-functoriality"}-->

🤖 Prepared with Codex
