### PR TITLE
feat: span polynomial evaluations by Chebyshev modes

### DIFF
--- a/TauCeti/Analysis/SpecialFunctions/Trigonometric/Chebyshev/Moments.lean
+++ b/TauCeti/Analysis/SpecialFunctions/Trigonometric/Chebyshev/Moments.lean
@@ -59,4 +59,20 @@ lemma memLp_two_algebraMap_eval_measureT {𝕜 : Type*} [RCLike 𝕜] (q : Polyn
   simpa only [RCLike.algebraMap_eq_ofReal] using
     (memLp_two_eval_measureT q).ofReal (K := 𝕜)
 
+/-- Evaluate a real polynomial and, casting into any `[RCLike 𝕜]` scalar field, regard the result
+as an element of `L²(Polynomial.Chebyshev.measureT)`.
+
+The map is well-defined because every polynomial has finite second moment for the Chebyshev
+measure. -/
+noncomputable def polynomialEvalChebyshevLp (𝕜 : Type*) [RCLike 𝕜] :
+    Polynomial ℝ →ₗ[ℝ] Lp 𝕜 2 Polynomial.Chebyshev.measureT :=
+  polynomialEvalLp 𝕜 integrable_pow_measureT
+
+/-- The `L²` representative of a polynomial evaluation is the expected scalar-cast pointwise
+evaluation. -/
+lemma coeFn_polynomialEvalChebyshevLp (𝕜 : Type*) [RCLike 𝕜] (q : Polynomial ℝ) :
+    ⇑(polynomialEvalChebyshevLp 𝕜 q) =ᵐ[Polynomial.Chebyshev.measureT]
+      fun x => (algebraMap ℝ 𝕜) (q.eval x) :=
+  coeFn_polynomialEvalLp 𝕜 integrable_pow_measureT q
+
 end TauCeti

--- a/TauCeti/Analysis/SpecialFunctions/Trigonometric/Chebyshev/Span.lean
+++ b/TauCeti/Analysis/SpecialFunctions/Trigonometric/Chebyshev/Span.lean
@@ -7,6 +7,7 @@ Authors: Codex
 -/
 public import TauCeti.Analysis.SpecialFunctions.Trigonometric.Chebyshev.Moments
 public import TauCeti.Analysis.SpecialFunctions.Trigonometric.Chebyshev.Measure
+public import TauCeti.MeasureTheory.Function.PolynomialMemLp
 import TauCeti.RingTheory.Polynomial.Chebyshev.Basis
 
 /-!
@@ -23,12 +24,20 @@ against every polynomial.
 
 ## Main declarations
 
-* `TauCeti.polynomialEvalChebyshevLp`: polynomial evaluation as a linear map into
-  `L²(Polynomial.Chebyshev.measureT)`.
+* `TauCeti.polynomialEvalChebyshevLp`: polynomial evaluation, cast into any `[RCLike 𝕜]` scalar
+  field, as a linear map into `L²(Polynomial.Chebyshev.measureT)`.
 * `TauCeti.polynomialEvalChebyshevLp_mem_span`: every polynomial evaluation lies in the span of
   the normalized Chebyshev modes.
 * `TauCeti.inner_polynomialEvalChebyshevLp_eq_zero`: orthogonality to all normalized modes implies
   orthogonality to every polynomial evaluation.
+* `TauCeti.inner_polynomialEvalChebyshevLp`: the inner product against a polynomial evaluation is
+  the corresponding polynomial moment `∫ x, g x * q.eval x ∂measureT`.
+* `TauCeti.integral_polynomialEval_measureT_eq_zero`: orthogonality to all normalized modes makes
+  every polynomial moment vanish.
+
+The measure- and scalar-generic bundling of polynomial evaluation lives in
+`TauCeti.MeasureTheory.Function.PolynomialMemLp` as `polynomialEvalLp`; `polynomialEvalChebyshevLp`
+is its Chebyshev specialization.
 -/
 
 public section
@@ -37,76 +46,92 @@ namespace TauCeti
 
 open MeasureTheory Polynomial.Chebyshev
 
-/-- Evaluate a real polynomial and regard the resulting function as an element of
-`L²(Polynomial.Chebyshev.measureT)`.
+/-- Evaluate a real polynomial and, casting into any `[RCLike 𝕜]` scalar field, regard the result
+as an element of `L²(Polynomial.Chebyshev.measureT)`.
 
 The map is well-defined because every polynomial has finite second moment for the Chebyshev
 measure. -/
-noncomputable def polynomialEvalChebyshevLp :
-    Polynomial ℝ →ₗ[ℝ] Lp ℝ 2 Polynomial.Chebyshev.measureT where
-  toFun q := (memLp_two_eval_measureT q).toLp fun x => q.eval x
-  map_add' q r := by
-    rw [← MemLp.toLp_add]
-    apply MemLp.toLp_congr
-    exact Filter.Eventually.of_forall fun x => by simp
-  map_smul' a q := by
-    rw [← MemLp.toLp_const_smul]
-    apply MemLp.toLp_congr
-    exact Filter.Eventually.of_forall fun x => by
-      simp [Polynomial.smul_eq_C_mul]
+noncomputable def polynomialEvalChebyshevLp (𝕜 : Type*) [RCLike 𝕜] :
+    Polynomial ℝ →ₗ[ℝ] Lp 𝕜 2 Polynomial.Chebyshev.measureT :=
+  polynomialEvalLp 𝕜 integrable_pow_measureT
 
-/-- The `L²` representative of a polynomial evaluation is the expected pointwise evaluation. -/
-lemma coeFn_polynomialEvalChebyshevLp (q : Polynomial ℝ) :
-    ⇑(polynomialEvalChebyshevLp q) =ᵐ[Polynomial.Chebyshev.measureT] fun x => q.eval x :=
-  MemLp.coeFn_toLp (memLp_two_eval_measureT q)
+/-- The `L²` representative of a polynomial evaluation is the expected scalar-cast pointwise
+evaluation. -/
+lemma coeFn_polynomialEvalChebyshevLp (𝕜 : Type*) [RCLike 𝕜] (q : Polynomial ℝ) :
+    ⇑(polynomialEvalChebyshevLp 𝕜 q) =ᵐ[Polynomial.Chebyshev.measureT]
+      fun x => (algebraMap ℝ 𝕜) (q.eval x) :=
+  coeFn_polynomialEvalLp 𝕜 integrable_pow_measureT q
 
 /-- Under the polynomial-evaluation map, the `n`th Chebyshev polynomial is the square root of its
 squared norm times the normalized `n`th Chebyshev mode. -/
-lemma polynomialEvalChebyshevLp_T (n : ℕ) :
-    polynomialEvalChebyshevLp (T ℝ n) =
-      Real.sqrt (chebyshevTNormSq n) • normalizedChebyshevTLp ℝ n := by
+lemma polynomialEvalChebyshevLp_T (𝕜 : Type*) [RCLike 𝕜] (n : ℕ) :
+    polynomialEvalChebyshevLp 𝕜 (T ℝ n) =
+      Real.sqrt (chebyshevTNormSq n) • normalizedChebyshevTLp 𝕜 n := by
   apply Lp.ext
-  filter_upwards [coeFn_polynomialEvalChebyshevLp (T ℝ n),
-    coeFn_normalizedChebyshevTLp (𝕜 := ℝ) n,
-    Lp.coeFn_smul (Real.sqrt (chebyshevTNormSq n)) (normalizedChebyshevTLp ℝ n)] with
+  filter_upwards [coeFn_polynomialEvalChebyshevLp 𝕜 (T ℝ n),
+    coeFn_normalizedChebyshevTLp (𝕜 := 𝕜) n,
+    Lp.coeFn_smul (Real.sqrt (chebyshevTNormSq n)) (normalizedChebyshevTLp 𝕜 n)] with
       x hT hnorm hsmul
   rw [hT, hsmul]
-  simp only [Pi.smul_apply, smul_eq_mul]
-  rw [hnorm]
-  simp only [Algebra.algebraMap_self_apply, normalizedChebyshevT_def]
+  simp only [Pi.smul_apply]
+  rw [hnorm, normalizedChebyshevT_def, Algebra.smul_def, ← map_mul]
+  congr 1
   field_simp [Real.sqrt_ne_zero'.mpr (chebyshevTNormSq_pos n)]
 
 /-- Every real polynomial evaluation in `L²(measureT)` belongs to the linear span of the
 normalized Chebyshev modes. -/
-theorem polynomialEvalChebyshevLp_mem_span (q : Polynomial ℝ) :
-    polynomialEvalChebyshevLp q ∈
-      Submodule.span ℝ (Set.range (normalizedChebyshevTLp ℝ)) := by
-  let S := Submodule.span ℝ (Set.range (normalizedChebyshevTLp ℝ))
+theorem polynomialEvalChebyshevLp_mem_span (𝕜 : Type*) [RCLike 𝕜] (q : Polynomial ℝ) :
+    polynomialEvalChebyshevLp 𝕜 q ∈
+      Submodule.span 𝕜 (Set.range (normalizedChebyshevTLp 𝕜)) := by
+  let S := Submodule.span 𝕜 (Set.range (normalizedChebyshevTLp 𝕜))
   have hq : q ∈ Submodule.span ℝ (Set.range (chebyshevTBasis (R := ℝ))) := by
     rw [Module.Basis.span_eq]
     exact Submodule.mem_top
   refine Submodule.span_induction ?_
-    ((polynomialEvalChebyshevLp.map_zero : polynomialEvalChebyshevLp 0 = 0).symm ▸ S.zero_mem)
+    ((polynomialEvalChebyshevLp 𝕜).map_zero ▸ S.zero_mem)
     (fun _ _ _ _ hx hy => by simpa using S.add_mem hx hy)
-    (fun _ _ _ hx => by simpa using S.smul_mem _ hx) hq
+    (fun a _ _ hx => by
+      rw [map_smul, algebra_compatible_smul 𝕜 a]
+      exact S.smul_mem _ hx) hq
   rintro p ⟨n, rfl⟩
-  rw [chebyshevTBasis_apply, polynomialEvalChebyshevLp_T]
+  rw [chebyshevTBasis_apply, polynomialEvalChebyshevLp_T, algebra_compatible_smul 𝕜]
   exact S.smul_mem _ (Submodule.subset_span (Set.mem_range_self n))
 
 /-- A vector orthogonal to every normalized Chebyshev mode is orthogonal to the `L²` evaluation
 of every real polynomial.
 
-This is the form used in the Chebyshev completeness argument: the algebraic Chebyshev basis
-converts the mode hypotheses into vanishing polynomial moments. -/
-theorem inner_polynomialEvalChebyshevLp_eq_zero
-    (g : Lp ℝ 2 Polynomial.Chebyshev.measureT)
-    (hmode : ∀ n, inner ℝ g (normalizedChebyshevTLp ℝ n) = 0) (q : Polynomial ℝ) :
-    inner ℝ g (polynomialEvalChebyshevLp q) = 0 := by
-  have hmem := polynomialEvalChebyshevLp_mem_span q
+This is the abstract form used in the Chebyshev completeness argument: the algebraic Chebyshev
+basis converts the mode hypotheses into orthogonality against every polynomial evaluation. -/
+theorem inner_polynomialEvalChebyshevLp_eq_zero (𝕜 : Type*) [RCLike 𝕜]
+    (g : Lp 𝕜 2 Polynomial.Chebyshev.measureT)
+    (hmode : ∀ n, inner 𝕜 g (normalizedChebyshevTLp 𝕜 n) = 0) (q : Polynomial ℝ) :
+    inner 𝕜 g (polynomialEvalChebyshevLp 𝕜 q) = 0 := by
+  have hmem := polynomialEvalChebyshevLp_mem_span 𝕜 q
   refine Submodule.span_induction ?_ (by simp)
     (fun _ _ _ _ hx hy => by simp [inner_add_right, hx, hy])
     (fun _ _ _ hx => by simp [inner_smul_right, hx]) hmem
   rintro v ⟨n, rfl⟩
   exact hmode n
+
+/-- The inner product of a vector with a polynomial evaluation is the corresponding polynomial
+moment against the Chebyshev measure. -/
+lemma inner_polynomialEvalChebyshevLp (g : Lp ℝ 2 Polynomial.Chebyshev.measureT)
+    (q : Polynomial ℝ) :
+    inner ℝ g (polynomialEvalChebyshevLp ℝ q) =
+      ∫ x, g x * q.eval x ∂Polynomial.Chebyshev.measureT := by
+  rw [MeasureTheory.L2.inner_def]
+  refine integral_congr_ae ?_
+  filter_upwards [coeFn_polynomialEvalChebyshevLp ℝ q] with x hx
+  rw [hx]
+  simp [RCLike.inner_apply, mul_comm]
+
+/-- A vector orthogonal to every normalized Chebyshev mode has vanishing polynomial moments: this
+is the concrete integral form of `inner_polynomialEvalChebyshevLp_eq_zero`. -/
+theorem integral_polynomialEval_measureT_eq_zero
+    (g : Lp ℝ 2 Polynomial.Chebyshev.measureT)
+    (hmode : ∀ n, inner ℝ g (normalizedChebyshevTLp ℝ n) = 0) (q : Polynomial ℝ) :
+    ∫ x, g x * q.eval x ∂Polynomial.Chebyshev.measureT = 0 := by
+  rw [← inner_polynomialEvalChebyshevLp g q]
+  exact inner_polynomialEvalChebyshevLp_eq_zero ℝ g hmode q
 
 end TauCeti

--- a/TauCeti/Analysis/SpecialFunctions/Trigonometric/Chebyshev/Span.lean
+++ b/TauCeti/Analysis/SpecialFunctions/Trigonometric/Chebyshev/Span.lean
@@ -46,22 +46,6 @@ namespace TauCeti
 
 open MeasureTheory Polynomial.Chebyshev
 
-/-- Evaluate a real polynomial and, casting into any `[RCLike 𝕜]` scalar field, regard the result
-as an element of `L²(Polynomial.Chebyshev.measureT)`.
-
-The map is well-defined because every polynomial has finite second moment for the Chebyshev
-measure. -/
-noncomputable def polynomialEvalChebyshevLp (𝕜 : Type*) [RCLike 𝕜] :
-    Polynomial ℝ →ₗ[ℝ] Lp 𝕜 2 Polynomial.Chebyshev.measureT :=
-  polynomialEvalLp 𝕜 integrable_pow_measureT
-
-/-- The `L²` representative of a polynomial evaluation is the expected scalar-cast pointwise
-evaluation. -/
-lemma coeFn_polynomialEvalChebyshevLp (𝕜 : Type*) [RCLike 𝕜] (q : Polynomial ℝ) :
-    ⇑(polynomialEvalChebyshevLp 𝕜 q) =ᵐ[Polynomial.Chebyshev.measureT]
-      fun x => (algebraMap ℝ 𝕜) (q.eval x) :=
-  coeFn_polynomialEvalLp 𝕜 integrable_pow_measureT q
-
 /-- Under the polynomial-evaluation map, the `n`th Chebyshev polynomial is the square root of its
 squared norm times the normalized `n`th Chebyshev mode. -/
 lemma polynomialEvalChebyshevLp_T (𝕜 : Type*) [RCLike 𝕜] (n : ℕ) :

--- a/TauCeti/Analysis/SpecialFunctions/Trigonometric/Chebyshev/Span.lean
+++ b/TauCeti/Analysis/SpecialFunctions/Trigonometric/Chebyshev/Span.lean
@@ -7,7 +7,6 @@ Authors: Codex
 -/
 public import TauCeti.Analysis.SpecialFunctions.Trigonometric.Chebyshev.Moments
 public import TauCeti.Analysis.SpecialFunctions.Trigonometric.Chebyshev.Measure
-public import TauCeti.MeasureTheory.Function.PolynomialMemLp
 import TauCeti.RingTheory.Polynomial.Chebyshev.Basis
 
 /-!

--- a/TauCeti/Analysis/SpecialFunctions/Trigonometric/Chebyshev/Span.lean
+++ b/TauCeti/Analysis/SpecialFunctions/Trigonometric/Chebyshev/Span.lean
@@ -1,0 +1,115 @@
+module
+
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Codex
+-/
+public import TauCeti.Analysis.SpecialFunctions.Trigonometric.Chebyshev.Moments
+public import TauCeti.Analysis.SpecialFunctions.Trigonometric.Chebyshev.Measure
+import TauCeti.RingTheory.Polynomial.Chebyshev.Basis
+
+/-!
+# Polynomial span of the Chebyshev modes
+
+This file connects the algebraic Chebyshev basis of `ℝ[X]` with the normalized Chebyshev
+functions in `L²(Polynomial.Chebyshev.measureT)`.  Evaluation followed by the canonical map into
+`L²` is bundled as a linear map.  Since every Chebyshev polynomial is a nonzero scalar multiple
+of its normalized mode, every polynomial evaluation belongs to the linear span of those modes.
+
+This is the algebra-to-analysis handoff in Part C of the `OrthogonalL2Bases` roadmap.  In the
+completeness argument, it upgrades orthogonality against every Chebyshev mode to orthogonality
+against every polynomial.
+
+## Main declarations
+
+* `TauCeti.polynomialEvalChebyshevLp`: polynomial evaluation as a linear map into
+  `L²(Polynomial.Chebyshev.measureT)`.
+* `TauCeti.polynomialEvalChebyshevLp_mem_span`: every polynomial evaluation lies in the span of
+  the normalized Chebyshev modes.
+* `TauCeti.inner_polynomialEvalChebyshevLp_eq_zero`: orthogonality to all normalized modes implies
+  orthogonality to every polynomial evaluation.
+-/
+
+public section
+
+namespace TauCeti
+
+open MeasureTheory Polynomial.Chebyshev
+
+/-- Evaluate a real polynomial and regard the resulting function as an element of
+`L²(Polynomial.Chebyshev.measureT)`.
+
+The map is well-defined because every polynomial has finite second moment for the Chebyshev
+measure. -/
+noncomputable def polynomialEvalChebyshevLp :
+    Polynomial ℝ →ₗ[ℝ] Lp ℝ 2 Polynomial.Chebyshev.measureT where
+  toFun q := (memLp_two_eval_measureT q).toLp fun x => q.eval x
+  map_add' q r := by
+    rw [← MemLp.toLp_add]
+    apply MemLp.toLp_congr
+    exact Filter.Eventually.of_forall fun x => by simp
+  map_smul' a q := by
+    rw [← MemLp.toLp_const_smul]
+    apply MemLp.toLp_congr
+    exact Filter.Eventually.of_forall fun x => by
+      change Polynomial.eval x (a • q) = a * Polynomial.eval x q
+      rw [Polynomial.smul_eq_C_mul, Polynomial.eval_C_mul]
+
+/-- The `L²` representative of a polynomial evaluation is the expected pointwise evaluation. -/
+lemma coeFn_polynomialEvalChebyshevLp (q : Polynomial ℝ) :
+    ⇑(polynomialEvalChebyshevLp q) =ᵐ[Polynomial.Chebyshev.measureT] fun x => q.eval x :=
+  MemLp.coeFn_toLp (memLp_two_eval_measureT q)
+
+/-- Under the polynomial-evaluation map, the `n`th Chebyshev polynomial is the square root of its
+squared norm times the normalized `n`th Chebyshev mode. -/
+lemma polynomialEvalChebyshevLp_T (n : ℕ) :
+    polynomialEvalChebyshevLp (T ℝ n) =
+      Real.sqrt (chebyshevTNormSq n) • normalizedChebyshevTLp ℝ n := by
+  apply Lp.ext
+  filter_upwards [coeFn_polynomialEvalChebyshevLp (T ℝ n),
+    coeFn_normalizedChebyshevTLp (𝕜 := ℝ) n,
+    Lp.coeFn_smul (Real.sqrt (chebyshevTNormSq n)) (normalizedChebyshevTLp ℝ n)] with
+      x hT hnorm hsmul
+  rw [hT, hsmul]
+  simp only [Pi.smul_apply, smul_eq_mul]
+  rw [hnorm]
+  change (T ℝ n).eval x =
+    Real.sqrt (chebyshevTNormSq n) * normalizedChebyshevT n x
+  rw [normalizedChebyshevT_def]
+  field_simp [Real.sqrt_ne_zero'.mpr (chebyshevTNormSq_pos n)]
+
+/-- Every real polynomial evaluation in `L²(measureT)` belongs to the linear span of the
+normalized Chebyshev modes. -/
+theorem polynomialEvalChebyshevLp_mem_span (q : Polynomial ℝ) :
+    polynomialEvalChebyshevLp q ∈
+      Submodule.span ℝ (Set.range (normalizedChebyshevTLp ℝ)) := by
+  let S := Submodule.span ℝ (Set.range (normalizedChebyshevTLp ℝ))
+  have hq : q ∈ Submodule.span ℝ (Set.range (chebyshevTBasis (R := ℝ))) := by
+    rw [Module.Basis.span_eq]
+    exact Submodule.mem_top
+  refine Submodule.span_induction ?_
+    ((polynomialEvalChebyshevLp.map_zero : polynomialEvalChebyshevLp 0 = 0).symm ▸ S.zero_mem)
+    (fun _ _ _ _ hx hy => by simpa using S.add_mem hx hy)
+    (fun _ _ _ hx => by simpa using S.smul_mem _ hx) hq
+  rintro p ⟨n, rfl⟩
+  rw [chebyshevTBasis_apply, polynomialEvalChebyshevLp_T]
+  exact S.smul_mem _ (Submodule.subset_span (Set.mem_range_self n))
+
+/-- A vector orthogonal to every normalized Chebyshev mode is orthogonal to the `L²` evaluation
+of every real polynomial.
+
+This is the form used in the Chebyshev completeness argument: the algebraic Chebyshev basis
+converts the mode hypotheses into vanishing polynomial moments. -/
+theorem inner_polynomialEvalChebyshevLp_eq_zero
+    (g : Lp ℝ 2 Polynomial.Chebyshev.measureT)
+    (hmode : ∀ n, inner ℝ g (normalizedChebyshevTLp ℝ n) = 0) (q : Polynomial ℝ) :
+    inner ℝ g (polynomialEvalChebyshevLp q) = 0 := by
+  have hmem := polynomialEvalChebyshevLp_mem_span q
+  refine Submodule.span_induction ?_ (by simp)
+    (fun _ _ _ _ hx hy => by simp [inner_add_right, hx, hy])
+    (fun _ _ _ hx => by simp [inner_smul_right, hx]) hmem
+  rintro v ⟨n, rfl⟩
+  exact hmode n
+
+end TauCeti

--- a/TauCeti/Analysis/SpecialFunctions/Trigonometric/Chebyshev/Span.lean
+++ b/TauCeti/Analysis/SpecialFunctions/Trigonometric/Chebyshev/Span.lean
@@ -53,8 +53,7 @@ noncomputable def polynomialEvalChebyshevLp :
     rw [← MemLp.toLp_const_smul]
     apply MemLp.toLp_congr
     exact Filter.Eventually.of_forall fun x => by
-      change Polynomial.eval x (a • q) = a * Polynomial.eval x q
-      rw [Polynomial.smul_eq_C_mul, Polynomial.eval_C_mul]
+      simp [Polynomial.smul_eq_C_mul]
 
 /-- The `L²` representative of a polynomial evaluation is the expected pointwise evaluation. -/
 lemma coeFn_polynomialEvalChebyshevLp (q : Polynomial ℝ) :
@@ -74,9 +73,7 @@ lemma polynomialEvalChebyshevLp_T (n : ℕ) :
   rw [hT, hsmul]
   simp only [Pi.smul_apply, smul_eq_mul]
   rw [hnorm]
-  change (T ℝ n).eval x =
-    Real.sqrt (chebyshevTNormSq n) * normalizedChebyshevT n x
-  rw [normalizedChebyshevT_def]
+  simp only [Algebra.algebraMap_self_apply, normalizedChebyshevT_def]
   field_simp [Real.sqrt_ne_zero'.mpr (chebyshevTNormSq_pos n)]
 
 /-- Every real polynomial evaluation in `L²(measureT)` belongs to the linear span of the

--- a/TauCeti/MeasureTheory/Function/PolynomialMemLp.lean
+++ b/TauCeti/MeasureTheory/Function/PolynomialMemLp.lean
@@ -22,6 +22,11 @@ against any measure on `ℝ` all of whose polynomial moments are finite:
 Both consume only the moment hypothesis `∀ k, Integrable (x ↦ xᵏ) μ`, with no dependence on the
 particular measure, so they apply verbatim to the Gaussian measure (all moments finite by Fernique)
 and to the compactly supported Chebyshev measure alike.
+
+Building on the `L²` membership, `polynomialEvalLp` bundles polynomial evaluation, cast into any
+`[RCLike 𝕜]` scalar field, as an `ℝ`-linear map `ℝ[X] →ₗ[ℝ] Lp 𝕜 2 μ`.  Being measure- and
+scalar-generic, it is the shared construction underlying the Gaussian and Chebyshev orthogonal-basis
+targets.
 -/
 
 public section
@@ -52,5 +57,36 @@ theorem memLp_two_eval_of_forall_integrable_pow
     ext x; rw [Polynomial.eval_pow]
   rw [hsq]
   exact integrable_eval_of_forall_integrable_pow hmom (q ^ 2)
+
+/-- A real polynomial evaluation, cast into any `RCLike` scalar field, lies in `L²` against any
+measure all of whose polynomial moments are finite. -/
+theorem memLp_two_algebraMap_eval_of_forall_integrable_pow {𝕜 : Type*} [RCLike 𝕜]
+    (hmom : ∀ k : ℕ, Integrable (fun x : ℝ => x ^ k) μ) (q : ℝ[X]) :
+    MemLp (fun x : ℝ => (algebraMap ℝ 𝕜) (q.eval x)) 2 μ := by
+  simpa only [RCLike.algebraMap_eq_ofReal] using
+    (memLp_two_eval_of_forall_integrable_pow hmom q).ofReal (K := 𝕜)
+
+/-- Polynomial evaluation, cast into any `RCLike` scalar field, bundled as an `ℝ`-linear map into
+`L²` against any measure all of whose polynomial moments are finite. -/
+noncomputable def polynomialEvalLp (𝕜 : Type*) [RCLike 𝕜]
+    (hmom : ∀ k : ℕ, Integrable (fun x : ℝ => x ^ k) μ) :
+    ℝ[X] →ₗ[ℝ] Lp 𝕜 2 μ where
+  toFun q := (memLp_two_algebraMap_eval_of_forall_integrable_pow (𝕜 := 𝕜) hmom q).toLp _
+  map_add' q r := by
+    rw [← MemLp.toLp_add]
+    apply MemLp.toLp_congr
+    exact Filter.Eventually.of_forall fun x => by simp
+  map_smul' a q := by
+    rw [← MemLp.toLp_const_smul]
+    apply MemLp.toLp_congr
+    exact Filter.Eventually.of_forall fun x => by
+      simp [Algebra.smul_def, map_mul]
+
+/-- The `L²` representative of `polynomialEvalLp` is the expected scalar-cast pointwise
+evaluation. -/
+lemma coeFn_polynomialEvalLp (𝕜 : Type*) [RCLike 𝕜]
+    (hmom : ∀ k : ℕ, Integrable (fun x : ℝ => x ^ k) μ) (q : ℝ[X]) :
+    ⇑(polynomialEvalLp 𝕜 hmom q) =ᵐ[μ] fun x : ℝ => (algebraMap ℝ 𝕜) (q.eval x) :=
+  MemLp.coeFn_toLp (memLp_two_algebraMap_eval_of_forall_integrable_pow (𝕜 := 𝕜) hmom q)
 
 end TauCeti


### PR DESCRIPTION
This PR connects the algebraic Chebyshev basis to `L²(Polynomial.Chebyshev.measureT)`: bundle polynomial evaluation as a linear map, identify the image of each `Tₙ` with its normalized mode, prove every polynomial evaluation lies in the modes' linear span, and expose the resulting orthogonality-to-polynomial corollary.

This advances `TauCetiRoadmap/OrthogonalL2Bases/README.md`, Part C, specifically the completeness step: a function orthogonal to every `Tₙ` must have all polynomial moments zero before the shared B1 moment-determinacy lemma applies. It is the lowest-hanging distinct prerequisite because the Chebyshev polynomial basis has just landed, while the finite-measure, polynomial-moment, normalized-mode, orthonormality, and exponential-moment prerequisites are already on `main`; the remaining analytic determinacy step is substantially larger.

Reuse Mathlib's `MemLp.toLp`, `Submodule.span_induction`, and generic inner-product linearity, together with Tau Ceti's `Polynomial.Chebyshev.chebyshevTBasis`, `memLp_two_eval_measureT`, and normalized Chebyshev mode API. No Mathlib infrastructure is vendored.

`lake exe cache get` reports `No files to download` and `Already decompressed 8619 file(s)`. `lake build` reports `Build completed successfully (5160 jobs).` `lake exe axioms` reports `axioms: audited 10450 TauCeti declaration(s); all within the allowlist [propext, Classical.choice, Quot.sound].`

<!--tauceti-target:v1 {"focus":"OrthogonalL2Bases","id":"polynomial-eval-span-normalized-chebyshev"}-->

🤖 Prepared with Codex
