### PR TITLE
feat: add Bernstein primitives of completely monotone functions

### DIFF
--- a/TauCeti/Analysis/Calculus/HalfLinePrimitive.lean
+++ b/TauCeti/Analysis/Calculus/HalfLinePrimitive.lean
@@ -69,10 +69,11 @@ theorem halfLinePrimitive_eq_integral_of_nonneg (ht : 0 ≤ t) :
 /-- On the nonpositive half-line, `halfLinePrimitive` is the linear extension `t ↦ t * f 0`. -/
 theorem halfLinePrimitive_of_nonpos (ht : t ≤ 0) : halfLinePrimitive f t = t * f 0 := by
   rw [halfLinePrimitive_def]
-  rw [show (∫ x in (0 : ℝ)..t, f (max x 0)) = ∫ _ in (0 : ℝ)..t, f 0 from
-    intervalIntegral.integral_congr fun x hx => by
+  have hconst : (∫ x in (0 : ℝ)..t, f (max x 0)) = ∫ _ in (0 : ℝ)..t, f 0 :=
+    intervalIntegral.integral_congr fun x hx ↦ by
       simp only [uIcc_of_ge ht] at hx
-      simp only [max_eq_right hx.2]]
+      simp only [max_eq_right hx.2]
+  rw [hconst]
   simp
 
 /-- The value of `halfLinePrimitive f` at the origin is `0`. -/

--- a/TauCeti/Analysis/Calculus/HalfLinePrimitive.lean
+++ b/TauCeti/Analysis/Calculus/HalfLinePrimitive.lean
@@ -1,0 +1,110 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+module
+
+public import Mathlib.MeasureTheory.Integral.IntervalIntegral.FundThmCalculus
+
+/-!
+# The primitive of a function on the nonnegative half-line
+
+Given `f : ℝ → ℝ`, this file constructs `TauCeti.halfLinePrimitive f`, the primitive `t ↦ ∫₀ᵗ f`
+of `f` on `[0, ∞)`. To make the function total on `ℝ`, the integrand is composed with `max · 0`,
+so on `[0, ∞)` the value is the ordinary integral `∫₀ᵗ f` and on `(-∞, 0]` it is the linear
+extension `t ↦ t * f 0`.
+
+The construction is generic calculus: it depends only on Mathlib's fundamental theorem of
+calculus and knows nothing about complete monotonicity or Bernstein functions.
+
+## Main declarations
+
+* `TauCeti.halfLinePrimitive`: the primitive `∫₀ᵗ f` of `f` on the nonnegative half-line.
+* `TauCeti.halfLinePrimitive_def`: the unconditional defining equation
+  `halfLinePrimitive f t = ∫₀ᵗ f (max x 0)`.
+* `TauCeti.halfLinePrimitive_eq_integral_of_nonneg`, `TauCeti.halfLinePrimitive_of_nonpos`: the
+  value of the primitive on each half-line.
+* `TauCeti.continuous_halfLinePrimitive`: the primitive is continuous on all of `ℝ` whenever `f`
+  is continuous on `[0, ∞)`.
+* `TauCeti.hasDerivAt_halfLinePrimitive`, `TauCeti.deriv_halfLinePrimitive`: its derivative is
+  `f` at every nonnegative point.
+-/
+
+public section
+
+open Set intervalIntegral
+
+namespace TauCeti
+
+variable {f : ℝ → ℝ} {t : ℝ}
+
+/-- The primitive of `f` on the nonnegative half-line. The `max` canonically extends the
+integrand to negative arguments; on `[0, ∞)` this is `∫₀ᵗ f`. -/
+@[expose] noncomputable def halfLinePrimitive (f : ℝ → ℝ) (t : ℝ) : ℝ :=
+  ∫ x in (0 : ℝ)..t, f (max x 0)
+
+/-- The unconditional defining equation of `halfLinePrimitive`, usable in downstream files where
+the body of the definition is not available. -/
+theorem halfLinePrimitive_def (f : ℝ → ℝ) (t : ℝ) :
+    halfLinePrimitive f t = ∫ x in (0 : ℝ)..t, f (max x 0) := rfl
+
+/-- If `f` is continuous on `[0, ∞)`, then its extension `x ↦ f (max x 0)` is continuous on all
+of `ℝ`. -/
+private theorem continuous_comp_max_zero (hf : ContinuousOn f (Ici 0)) :
+    Continuous fun x : ℝ ↦ f (max x 0) := by
+  simpa [Function.comp_def] using
+    hf.comp_continuous (continuous_id'.max continuous_const) fun x ↦ mem_Ici.mpr (le_max_right x 0)
+
+/-- On the nonnegative half-line, `halfLinePrimitive` is the ordinary integral of `f` from
+zero. -/
+@[grind =>]
+theorem halfLinePrimitive_eq_integral_of_nonneg (ht : 0 ≤ t) :
+    halfLinePrimitive f t = ∫ x in (0 : ℝ)..t, f x := by
+  rw [halfLinePrimitive_def]
+  apply intervalIntegral.integral_congr
+  intro x hx
+  simp only [uIcc_of_le ht] at hx
+  simp only [max_eq_left hx.1]
+
+/-- On the nonpositive half-line, `halfLinePrimitive` is the linear extension `t ↦ t * f 0`. -/
+theorem halfLinePrimitive_of_nonpos (ht : t ≤ 0) : halfLinePrimitive f t = t * f 0 := by
+  rw [halfLinePrimitive_def]
+  rw [show (∫ x in (0 : ℝ)..t, f (max x 0)) = ∫ _ in (0 : ℝ)..t, f 0 from
+    intervalIntegral.integral_congr fun x hx => by
+      simp only [uIcc_of_ge ht] at hx
+      simp only [max_eq_right hx.2]]
+  simp
+
+/-- The value of `halfLinePrimitive f` at the origin is `0`. -/
+@[simp]
+theorem halfLinePrimitive_zero (f : ℝ → ℝ) : halfLinePrimitive f 0 = 0 := by
+  simp [halfLinePrimitive_def]
+
+/-- If `f` is continuous on `[0, ∞)`, then `halfLinePrimitive f` is continuous on all of `ℝ`; the
+`max` extension of the integrand makes the primitive continuous through the origin. -/
+theorem continuous_halfLinePrimitive (hf : ContinuousOn f (Ici 0)) :
+    Continuous (halfLinePrimitive f) := by
+  unfold halfLinePrimitive
+  exact intervalIntegral.continuous_primitive
+    (fun a b ↦ (continuous_comp_max_zero hf).intervalIntegrable a b) 0
+
+/-- If `f` is continuous on `[0, ∞)`, then `halfLinePrimitive f` has derivative `f t` at every
+`t ≥ 0`. The `max` extension of the integrand makes the derivative at `t = 0` two-sided. -/
+theorem hasDerivAt_halfLinePrimitive (hf : ContinuousOn f (Ici 0)) (ht : 0 ≤ t) :
+    HasDerivAt (halfLinePrimitive f) (f t) t := by
+  have hcont := continuous_comp_max_zero hf
+  unfold halfLinePrimitive
+  simpa only [max_eq_left ht] using
+    intervalIntegral.integral_hasDerivAt_right (a := (0 : ℝ)) (hcont.intervalIntegrable 0 t)
+      hcont.aestronglyMeasurable.stronglyMeasurableAtFilter hcont.continuousAt
+
+/-- If `f` is continuous on `[0, ∞)`, then the derivative of `halfLinePrimitive f` is `f` at
+every `t ≥ 0`. -/
+@[grind =>]
+theorem deriv_halfLinePrimitive (hf : ContinuousOn f (Ici 0)) (ht : 0 ≤ t) :
+    deriv (halfLinePrimitive f) t = f t :=
+  (hasDerivAt_halfLinePrimitive hf ht).deriv
+
+end TauCeti
+
+end

--- a/TauCeti/Analysis/Calculus/HalfLinePrimitive.lean
+++ b/TauCeti/Analysis/Calculus/HalfLinePrimitive.lean
@@ -40,13 +40,13 @@ variable {f : ℝ → ℝ} {t : ℝ}
 
 /-- The primitive of `f` on the nonnegative half-line. The `max` canonically extends the
 integrand to negative arguments; on `[0, ∞)` this is `∫₀ᵗ f`. -/
-@[expose] noncomputable def halfLinePrimitive (f : ℝ → ℝ) (t : ℝ) : ℝ :=
+noncomputable def halfLinePrimitive (f : ℝ → ℝ) (t : ℝ) : ℝ :=
   ∫ x in (0 : ℝ)..t, f (max x 0)
 
 /-- The unconditional defining equation of `halfLinePrimitive`, usable in downstream files where
 the body of the definition is not available. -/
 theorem halfLinePrimitive_def (f : ℝ → ℝ) (t : ℝ) :
-    halfLinePrimitive f t = ∫ x in (0 : ℝ)..t, f (max x 0) := rfl
+    halfLinePrimitive f t = ∫ x in (0 : ℝ)..t, f (max x 0) := by rfl
 
 /-- If `f` is continuous on `[0, ∞)`, then its extension `x ↦ f (max x 0)` is continuous on all
 of `ℝ`. -/

--- a/TauCeti/Analysis/CompletelyMonotone/Basic.lean
+++ b/TauCeti/Analysis/CompletelyMonotone/Basic.lean
@@ -292,6 +292,18 @@ lemma neg_one_pow_mul_iteratedDeriv_nonneg (hf : IsCompletelyMonotoneOnIoi f) (n
 lemma nonneg (hf : IsCompletelyMonotoneOnIoi f) {t : ℝ} (ht : 0 < t) : 0 ≤ f t := by
   simpa [iteratedDeriv_zero] using hf.neg_one_pow_mul_iteratedDeriv_nonneg 0 ht
 
+/-- A function completely monotone on `(0, ∞)` that is continuous within `[0, ∞)` at the origin
+is nonnegative on all of `[0, ∞)`: nonnegativity on `(0, ∞)` passes to the boundary point `0` in
+the limit. -/
+lemma nonneg_of_continuousWithinAt (hf : IsCompletelyMonotoneOnIoi f)
+    (hcont : ContinuousWithinAt f (Ici 0) 0) {t : ℝ} (ht : 0 ≤ t) : 0 ≤ f t := by
+  rcases ht.lt_or_eq with h | h
+  · exact hf.nonneg h
+  · subst h
+    have htends : Filter.Tendsto f (𝓝[>] (0 : ℝ)) (nhds (f 0)) :=
+      hcont.tendsto.mono_left (nhdsWithin_mono _ Ioi_subset_Ici_self)
+    exact ge_of_tendsto htends (eventually_mem_nhdsWithin.mono fun x hx => hf.nonneg hx)
+
 /-- The derivative of a completely monotone function on `(0, ∞)` is nonpositive there. -/
 @[grind =>]
 lemma deriv_nonpos (hf : IsCompletelyMonotoneOnIoi f) {t : ℝ} (ht : 0 < t) :

--- a/TauCeti/Analysis/CompletelyMonotone/Bernstein/Basic.lean
+++ b/TauCeti/Analysis/CompletelyMonotone/Bernstein/Basic.lean
@@ -41,8 +41,8 @@ nonnegative scalar multiples, and the basic catalogue — constants, the identit
   `[0, ∞)`.
 * `TauCeti.IsBernsteinFunction.congr`: the property depends only on the values on `[0, ∞)`.
 * `TauCeti.IsBernsteinFunction.add`, `TauCeti.IsBernsteinFunction.smul`,
-  `TauCeti.IsBernsteinFunction.sum`: closure under sums, nonnegative scalar multiples, and finite
-  sums.
+  `TauCeti.IsBernsteinFunction.const_add`, `TauCeti.IsBernsteinFunction.sum`: closure under sums,
+  nonnegative scalar multiples, adding a nonnegative constant, and finite sums.
 * `TauCeti.isBernsteinFunction_const`, `TauCeti.isBernsteinFunction_id`,
   `TauCeti.isBernsteinFunction_affine`, `TauCeti.isBernsteinFunction_one_sub_exp_neg_mul`: the
   basic examples.
@@ -177,6 +177,11 @@ theorem isBernsteinFunction_zero : IsBernsteinFunction (fun _ : ℝ => (0 : ℝ)
   isBernsteinFunction_const le_rfl
 
 namespace IsBernsteinFunction
+
+/-- Adding a nonnegative constant to a Bernstein function again gives a Bernstein function. -/
+theorem const_add {f : ℝ → ℝ} (hf : IsBernsteinFunction f) {c : ℝ} (hc : 0 ≤ c) :
+    IsBernsteinFunction (fun t => c + f t) :=
+  ((isBernsteinFunction_const hc).add hf).congr fun _ _ => by simp [Pi.add_apply]
 
 /-- Bernstein functions are closed under finite sums. -/
 theorem sum {ι : Type*} {s : Finset ι} {f : ι → ℝ → ℝ}

--- a/TauCeti/Analysis/CompletelyMonotone/Bernstein/Basic.lean
+++ b/TauCeti/Analysis/CompletelyMonotone/Bernstein/Basic.lean
@@ -67,6 +67,14 @@ def IsBernsteinFunction (f : ℝ → ℝ) : Prop :=
   ContinuousOn f (Ici 0) ∧ ContDiffOn ℝ ∞ f (Ioi 0) ∧
     (∀ t : ℝ, 0 ≤ t → 0 ≤ f t) ∧ IsCompletelyMonotoneOnIoi (deriv f)
 
+/-- A function is Bernstein exactly when it is continuous and nonnegative on `[0, ∞)`, smooth
+on `(0, ∞)`, and has completely monotone derivative there. -/
+theorem isBernsteinFunction_iff {f : ℝ → ℝ} :
+    IsBernsteinFunction f ↔
+      ContinuousOn f (Ici 0) ∧ ContDiffOn ℝ ∞ f (Ioi 0) ∧
+        (∀ t : ℝ, 0 ≤ t → 0 ≤ f t) ∧ IsCompletelyMonotoneOnIoi (deriv f) :=
+  Iff.rfl
+
 namespace IsBernsteinFunction
 
 variable {f g : ℝ → ℝ}

--- a/TauCeti/Analysis/CompletelyMonotone/Bernstein/Basic.lean
+++ b/TauCeti/Analysis/CompletelyMonotone/Bernstein/Basic.lean
@@ -39,6 +39,7 @@ nonnegative scalar multiples, and the basic catalogue — constants, the identit
   `TauCeti.IsBernsteinFunction.monotoneOn`, `TauCeti.IsBernsteinFunction.concaveOn`: a Bernstein
   function is nonnegative, has nonnegative derivative, is nondecreasing, and is concave on
   `[0, ∞)`.
+* `TauCeti.IsBernsteinFunction.congr`: the property depends only on the values on `[0, ∞)`.
 * `TauCeti.IsBernsteinFunction.add`, `TauCeti.IsBernsteinFunction.smul`,
   `TauCeti.IsBernsteinFunction.sum`: closure under sums, nonnegative scalar multiples, and finite
   sums.
@@ -68,7 +69,8 @@ def IsBernsteinFunction (f : ℝ → ℝ) : Prop :=
     (∀ t : ℝ, 0 ≤ t → 0 ≤ f t) ∧ IsCompletelyMonotoneOnIoi (deriv f)
 
 /-- A function is Bernstein exactly when it is continuous and nonnegative on `[0, ∞)`, smooth
-on `(0, ∞)`, and has completely monotone derivative there. -/
+on `(0, ∞)`, and has completely monotone derivative there. The body of `IsBernsteinFunction` is
+not `@[expose]`d, so this is how downstream files build the predicate from its four clauses. -/
 theorem isBernsteinFunction_iff {f : ℝ → ℝ} :
     IsBernsteinFunction f ↔
       ContinuousOn f (Ici 0) ∧ ContDiffOn ℝ ∞ f (Ioi 0) ∧
@@ -122,6 +124,17 @@ lemma concaveOn (hf : IsBernsteinFunction f) : ConcaveOn ℝ (Ici 0) f := by
   rw [interior_Ici] at hx
   simpa [Function.iterate_succ, Function.iterate_zero, Function.comp_def] using
     hf.deriv_isCompletelyMonotoneOnIoi.deriv_nonpos hx
+
+/-- Being a Bernstein function depends only on the values on `[0, ∞)`. -/
+theorem congr (hf : IsBernsteinFunction f) (h : Set.EqOn g f (Ici 0)) :
+    IsBernsteinFunction g := by
+  have hIoi : Set.EqOn g f (Ioi 0) := h.mono Ioi_subset_Ici_self
+  have hderiv : Set.EqOn (deriv g) (deriv f) (Ioi 0) := fun x hx =>
+    (hIoi.eventuallyEq_of_mem (isOpen_Ioi.mem_nhds hx)).deriv_eq
+  refine ⟨hf.continuousOn.congr h, hf.contDiffOn.congr fun x hx => hIoi hx, fun t ht => ?_, ?_⟩
+  · rw [h ht]
+    exact hf.nonneg ht
+  · exact hf.deriv_isCompletelyMonotoneOnIoi.congr hderiv
 
 /-- Bernstein functions are closed under addition. -/
 theorem add (hf : IsBernsteinFunction f) (hg : IsBernsteinFunction g) :

--- a/TauCeti/Analysis/CompletelyMonotone/Bernstein/Integral.lean
+++ b/TauCeti/Analysis/CompletelyMonotone/Bernstein/Integral.lean
@@ -17,8 +17,7 @@ then
 `t ↦ ∫ x in 0..t, f x` for `t ≥ 0`
 
 is a Bernstein function. Its derivative on `(0, ∞)` is `f`, so complete monotonicity of the
-derivative is inherited directly from `f`. Shifting by a nonnegative constant preserves the
-Bernstein property through the general closure lemma `TauCeti.IsBernsteinFunction.const_add`.
+derivative is inherited directly from `f`.
 
 The primitive is packaged as `TauCeti.halfLinePrimitive` (in
 `TauCeti.Analysis.Calculus.HalfLinePrimitive`), which integrates `f (max x 0)` so that the

--- a/TauCeti/Analysis/CompletelyMonotone/Bernstein/Integral.lean
+++ b/TauCeti/Analysis/CompletelyMonotone/Bernstein/Integral.lean
@@ -1,0 +1,132 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+module
+
+public import TauCeti.Analysis.CompletelyMonotone.Bernstein.Basic
+public import Mathlib.MeasureTheory.Integral.IntervalIntegral.FundThmCalculus
+
+/-!
+# Bernstein primitives of completely monotone functions
+
+This file establishes one direction of the standard correspondence between completely monotone
+and Bernstein functions. If `f` is completely monotone on `[0, ∞)`, then
+
+`t ↦ c + ∫ x in 0..t, f x` for `t ≥ 0`
+
+is a Bernstein function whenever `c ≥ 0`. Its derivative on `(0, ∞)` is `f`, so complete
+monotonicity of the derivative is inherited directly from `f`. The special case `c = 0` gives
+the canonical primitive vanishing at the origin.
+
+## Main declarations
+
+* `TauCeti.bernsteinPrimitive`: the primitive `c + ∫₀ᵗ f`.
+* `TauCeti.hasDerivAt_bernsteinPrimitive`: its derivative is `f` at every nonnegative point.
+* `TauCeti.IsCompletelyMonotone.isBernsteinFunction_bernsteinPrimitive`: a nonnegative
+  primitive of a completely monotone function is Bernstein.
+* `TauCeti.IsCompletelyMonotone.isBernsteinFunction_integral`: the primitive vanishing at zero
+  is Bernstein.
+
+## References
+
+* R. Schilling, R. Song, Z. Vondraček, *Bernstein Functions: Theory and Applications*
+  (de Gruyter, 2nd ed. 2012), Chapter 3.
+-/
+
+public section
+
+open Set intervalIntegral
+open scoped ContDiff
+
+namespace TauCeti
+
+/-- The primitive of `f` on the nonnegative half-line with initial value `c`. The `max`
+canonically extends the integrand to negative arguments; on `[0, ∞)` this is `c + ∫₀ᵗ f`. -/
+noncomputable def bernsteinPrimitive (c : ℝ) (f : ℝ → ℝ) (t : ℝ) : ℝ :=
+  c + ∫ x in (0 : ℝ)..t, f (max x 0)
+
+/-- On the nonnegative half-line, `bernsteinPrimitive` is the ordinary integral of `f` from
+zero, with initial value `c`. -/
+theorem bernsteinPrimitive_eq {c : ℝ} {f : ℝ → ℝ} {t : ℝ} (ht : 0 ≤ t) :
+    bernsteinPrimitive c f t = c + ∫ x in (0 : ℝ)..t, f x := by
+  rw [bernsteinPrimitive]
+  congr 1
+  apply intervalIntegral.integral_congr
+  intro x hx
+  simp only [uIcc_of_le ht] at hx
+  simp only [max_eq_left hx.1]
+
+/-- The value of `bernsteinPrimitive c f` at the origin is `c`. -/
+@[simp]
+theorem bernsteinPrimitive_zero (c : ℝ) (f : ℝ → ℝ) :
+    bernsteinPrimitive c f 0 = c := by
+  simp [bernsteinPrimitive]
+
+/-- A primitive built from a continuous function has derivative `f t` at every nonnegative
+point. -/
+theorem hasDerivAt_bernsteinPrimitive {c : ℝ} {f : ℝ → ℝ} {t : ℝ}
+    (hf : ContinuousOn f (Ici 0)) (ht : 0 ≤ t) :
+    HasDerivAt (bernsteinPrimitive c f) (f t) t := by
+  have hcontinuous : Continuous (fun x : ℝ ↦ f (max x 0)) := by
+    convert hf.comp_continuous (continuous_id.max continuous_const)
+      (fun x ↦ mem_Ici.mpr (le_max_right x 0)) using 1
+    ext x
+    rfl
+  -- Expose the primitive here so the FTC theorem sees its defining integral.
+  change HasDerivAt (fun u ↦ c + ∫ x in (0 : ℝ)..u, f (max x 0)) (f t) t
+  simpa only [bernsteinPrimitive, max_eq_left ht] using
+    (intervalIntegral.integral_hasDerivAt_right (a := (0 : ℝ))
+      (hcontinuous.intervalIntegrable 0 t)
+      hcontinuous.aestronglyMeasurable.stronglyMeasurableAtFilter
+      hcontinuous.continuousAt).const_add c
+
+/-- The derivative of a primitive built from a continuous function is its integrand at every
+nonnegative point. -/
+theorem deriv_bernsteinPrimitive {c : ℝ} {f : ℝ → ℝ} {t : ℝ}
+    (hf : ContinuousOn f (Ici 0)) (ht : 0 ≤ t) :
+    deriv (bernsteinPrimitive c f) t = f t :=
+  (hasDerivAt_bernsteinPrimitive hf ht).deriv
+
+namespace IsCompletelyMonotone
+
+variable {f : ℝ → ℝ}
+
+/-- A nonnegative primitive of a completely monotone function is a Bernstein function. -/
+theorem isBernsteinFunction_bernsteinPrimitive (hf : IsCompletelyMonotone f) {c : ℝ}
+    (hc : 0 ≤ c) : IsBernsteinFunction (bernsteinPrimitive c f) := by
+  have hintegrand : Continuous (fun x : ℝ ↦ f (max x 0)) := by
+    convert hf.contDiffOn.continuousOn.comp_continuous
+      (continuous_id.max continuous_const) (fun x ↦ mem_Ici.mpr (le_max_right x 0)) using 1
+    ext x
+    rfl
+  have hcontinuous : ContinuousOn (bernsteinPrimitive c f) (Ici 0) :=
+    (continuous_const.add
+      (intervalIntegral.continuous_primitive
+        (fun a b ↦ hintegrand.intervalIntegrable a b) 0)).continuousOn
+  have hcontDiff : ContDiffOn ℝ ∞ (bernsteinPrimitive c f) (Ioi 0) := by
+    rw [contDiffOn_infty_iff_deriv_of_isOpen isOpen_Ioi]
+    refine ⟨fun t ht ↦ (hasDerivAt_bernsteinPrimitive hf.contDiffOn.continuousOn
+      ht.le).differentiableAt.differentiableWithinAt, ?_⟩
+    exact (hf.contDiffOn.mono Ioi_subset_Ici_self).congr fun t ht ↦
+      deriv_bernsteinPrimitive hf.contDiffOn.continuousOn ht.le
+  rw [isBernsteinFunction_iff]
+  refine ⟨hcontinuous, hcontDiff, fun t ht ↦ ?_, ?_⟩
+  · rw [bernsteinPrimitive]
+    exact add_nonneg hc
+      (intervalIntegral.integral_nonneg ht fun x _ ↦ hf.nonneg (le_max_right x 0))
+  · apply hf.isCompletelyMonotoneOnIoi.congr
+    intro t ht
+    exact deriv_bernsteinPrimitive hf.contDiffOn.continuousOn ht.le
+
+/-- The primitive of a completely monotone function that vanishes at the origin is a Bernstein
+function. -/
+theorem isBernsteinFunction_integral (hf : IsCompletelyMonotone f) :
+    IsBernsteinFunction (bernsteinPrimitive 0 f) :=
+  hf.isBernsteinFunction_bernsteinPrimitive le_rfl
+
+end IsCompletelyMonotone
+
+end TauCeti
+
+end

--- a/TauCeti/Analysis/CompletelyMonotone/Bernstein/Integral.lean
+++ b/TauCeti/Analysis/CompletelyMonotone/Bernstein/Integral.lean
@@ -5,7 +5,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 module
 
 public import TauCeti.Analysis.CompletelyMonotone.Bernstein.Basic
-public import Mathlib.MeasureTheory.Integral.IntervalIntegral.FundThmCalculus
+public import TauCeti.Analysis.Calculus.HalfLinePrimitive
 
 /-!
 # Primitives of completely monotone functions are Bernstein functions
@@ -16,27 +16,24 @@ then
 
 `t ↦ ∫ x in 0..t, f x` for `t ≥ 0`
 
-is a Bernstein function, and so is `t ↦ c + ∫ x in 0..t, f x` for every `c ≥ 0`. Its derivative
-on `(0, ∞)` is `f`, so complete monotonicity of the derivative is inherited directly from `f`.
+is a Bernstein function. Its derivative on `(0, ∞)` is `f`, so complete monotonicity of the
+derivative is inherited directly from `f`. Shifting by a nonnegative constant preserves the
+Bernstein property through the general closure lemma `TauCeti.IsBernsteinFunction.const_add`.
 
-The primitive is packaged as `TauCeti.halfLinePrimitive`, which integrates `f (max x 0)` so that
-the function is defined on all of `ℝ`; on `[0, ∞)` this agrees with `∫₀ᵗ f` by
-`TauCeti.halfLinePrimitive_eq_integral_of_nonneg`, and on `(-∞, 0]` it is the linear
-extension `t ↦ t * f 0` by `TauCeti.halfLinePrimitive_of_nonpos`.
+The primitive is packaged as `TauCeti.halfLinePrimitive` (in
+`TauCeti.Analysis.Calculus.HalfLinePrimitive`), which integrates `f (max x 0)` so that the
+function is defined on all of `ℝ`; on `[0, ∞)` this agrees with `∫₀ᵗ f` by
+`TauCeti.halfLinePrimitive_eq_integral_of_nonneg`.
 
 ## Main declarations
 
-* `TauCeti.halfLinePrimitive`: the primitive `∫₀ᵗ f` of `f` on the nonnegative half-line.
-* `TauCeti.halfLinePrimitive_eq_integral_of_nonneg`,
-  `TauCeti.halfLinePrimitive_of_nonpos`: the value of the primitive on each half-line.
-* `TauCeti.hasDerivAt_halfLinePrimitive`, `TauCeti.deriv_halfLinePrimitive`: its derivative is
-  `f` at every nonnegative point.
-* `TauCeti.IsCompletelyMonotoneOnIoi.isBernsteinFunction_halfLinePrimitive`,
-  `TauCeti.IsCompletelyMonotoneOnIoi.isBernsteinFunction_const_add_halfLinePrimitive`: the
-  primitive of a completely monotone function, and its shifts by a nonnegative constant, are
-  Bernstein.
+* `TauCeti.IsCompletelyMonotoneOnIoi.isBernsteinFunction_halfLinePrimitive`: the primitive of a
+  function that is completely monotone on `(0, ∞)` and continuous on `[0, ∞)` is Bernstein.
 * `TauCeti.IsCompletelyMonotoneOnIoi.isBernsteinFunction_integral`: the same statement written
   directly in terms of `∫ x in 0..t, f x`.
+* `TauCeti.IsCompletelyMonotone.isBernsteinFunction_halfLinePrimitive`,
+  `TauCeti.IsCompletelyMonotone.isBernsteinFunction_integral`: the corresponding statements for
+  the closed-half-line predicate `IsCompletelyMonotone`.
 
 ## References
 
@@ -53,80 +50,14 @@ namespace TauCeti
 
 variable {f : ℝ → ℝ} {t : ℝ}
 
-/-- The primitive of `f` on the nonnegative half-line. The `max` canonically extends the
-integrand to negative arguments; on `[0, ∞)` this is `∫₀ᵗ f`. -/
-noncomputable def halfLinePrimitive (f : ℝ → ℝ) (t : ℝ) : ℝ :=
-  ∫ x in (0 : ℝ)..t, f (max x 0)
-
-/-- If `f` is continuous on `[0, ∞)`, then its extension `x ↦ f (max x 0)` is continuous on all
-of `ℝ`. -/
-private theorem continuous_comp_max_zero (hf : ContinuousOn f (Ici 0)) :
-    Continuous fun x : ℝ ↦ f (max x 0) := by
-  simpa [Function.comp_def] using
-    hf.comp_continuous (continuous_id'.max continuous_const) fun x ↦ mem_Ici.mpr (le_max_right x 0)
-
-/-- On the nonnegative half-line, `halfLinePrimitive` is the ordinary integral of `f` from
-zero. -/
-@[grind =>]
-theorem halfLinePrimitive_eq_integral_of_nonneg (ht : 0 ≤ t) :
-    halfLinePrimitive f t = ∫ x in (0 : ℝ)..t, f x := by
-  rw [halfLinePrimitive]
-  apply intervalIntegral.integral_congr
-  intro x hx
-  simp only [uIcc_of_le ht] at hx
-  simp only [max_eq_left hx.1]
-
-/-- On the nonpositive half-line, `halfLinePrimitive` is the linear extension `t ↦ t * f 0`. -/
-theorem halfLinePrimitive_of_nonpos (ht : t ≤ 0) : halfLinePrimitive f t = t * f 0 := by
-  rw [halfLinePrimitive]
-  rw [show (∫ x in (0 : ℝ)..t, f (max x 0)) = ∫ _ in (0 : ℝ)..t, f 0 from
-    intervalIntegral.integral_congr fun x hx => by
-      simp only [uIcc_of_ge ht] at hx
-      simp only [max_eq_right hx.2]]
-  simp
-
-/-- The value of `halfLinePrimitive f` at the origin is `0`. -/
-@[simp]
-theorem halfLinePrimitive_zero (f : ℝ → ℝ) : halfLinePrimitive f 0 = 0 := by
-  simp [halfLinePrimitive]
-
-/-- If `f` is continuous on `[0, ∞)`, then `halfLinePrimitive f` has derivative `f t` at every
-`t ≥ 0`. The `max` extension of the integrand makes the derivative at `t = 0` two-sided. -/
-theorem hasDerivAt_halfLinePrimitive (hf : ContinuousOn f (Ici 0)) (ht : 0 ≤ t) :
-    HasDerivAt (halfLinePrimitive f) (f t) t := by
-  have hcont := continuous_comp_max_zero hf
-  -- Expose the defining integral, which is what the fundamental theorem of calculus is about.
-  change HasDerivAt (fun u ↦ ∫ x in (0 : ℝ)..u, f (max x 0)) (f t) t
-  simpa only [max_eq_left ht] using
-    intervalIntegral.integral_hasDerivAt_right (a := (0 : ℝ)) (hcont.intervalIntegrable 0 t)
-      hcont.aestronglyMeasurable.stronglyMeasurableAtFilter hcont.continuousAt
-
-/-- If `f` is continuous on `[0, ∞)`, then the derivative of `halfLinePrimitive f` is `f` at
-every `t ≥ 0`. -/
-@[grind =>]
-theorem deriv_halfLinePrimitive (hf : ContinuousOn f (Ici 0)) (ht : 0 ≤ t) :
-    deriv (halfLinePrimitive f) t = f t :=
-  (hasDerivAt_halfLinePrimitive hf ht).deriv
-
 namespace IsCompletelyMonotoneOnIoi
-
-/-- A function that is completely monotone on `(0, ∞)` and continuous on `[0, ∞)` is
-nonnegative on `[0, ∞)`. -/
-theorem nonneg_of_continuousOn (hf : IsCompletelyMonotoneOnIoi f)
-    (hcont : ContinuousOn f (Ici 0)) (ht : 0 ≤ t) : 0 ≤ f t := by
-  rcases ht.lt_or_eq with h | h
-  · exact hf.nonneg h
-  · subst h
-    have htends : Filter.Tendsto f (𝓝[>] (0 : ℝ)) (nhds (f 0)) :=
-      (hcont 0 self_mem_Ici).tendsto.mono_left (nhdsWithin_mono _ Ioi_subset_Ici_self)
-    exact ge_of_tendsto htends (eventually_mem_nhdsWithin.mono fun x hx => hf.nonneg hx)
 
 /-- The primitive on `[0, ∞)` of a function that is completely monotone on `(0, ∞)` and
 continuous on `[0, ∞)` is a Bernstein function. -/
 theorem isBernsteinFunction_halfLinePrimitive (hf : IsCompletelyMonotoneOnIoi f)
     (hcont : ContinuousOn f (Ici 0)) : IsBernsteinFunction (halfLinePrimitive f) := by
-  have hcontinuous : ContinuousOn (halfLinePrimitive f) (Ici 0) := fun t ht ↦
-    (hasDerivAt_halfLinePrimitive hcont ht).continuousAt.continuousWithinAt
+  have hcontinuous : ContinuousOn (halfLinePrimitive f) (Ici 0) :=
+    (continuous_halfLinePrimitive hcont).continuousOn
   have hcontDiff : ContDiffOn ℝ ∞ (halfLinePrimitive f) (Ioi 0) := by
     rw [contDiffOn_infty_iff_deriv_of_isOpen isOpen_Ioi]
     refine ⟨fun t ht ↦
@@ -134,20 +65,13 @@ theorem isBernsteinFunction_halfLinePrimitive (hf : IsCompletelyMonotoneOnIoi f)
     exact hf.contDiffOn.congr fun t ht ↦ deriv_halfLinePrimitive hcont ht.le
   rw [isBernsteinFunction_iff]
   refine ⟨hcontinuous, hcontDiff, fun t ht ↦ ?_, ?_⟩
-  · rw [halfLinePrimitive]
+  · rw [halfLinePrimitive_def]
     exact intervalIntegral.integral_nonneg ht fun x hx ↦
-      hf.nonneg_of_continuousOn hcont (le_max_right x 0)
+      hf.nonneg_of_continuousWithinAt (hcont 0 self_mem_Ici) (le_max_right x 0)
   · exact hf.congr fun t ht ↦ deriv_halfLinePrimitive hcont ht.le
 
-/-- Shifting the primitive of a completely monotone function by a nonnegative constant again
-gives a Bernstein function. -/
-theorem isBernsteinFunction_const_add_halfLinePrimitive (hf : IsCompletelyMonotoneOnIoi f)
-    (hcont : ContinuousOn f (Ici 0)) {c : ℝ} (hc : 0 ≤ c) :
-    IsBernsteinFunction (fun t ↦ c + halfLinePrimitive f t) :=
-  ((isBernsteinFunction_const hc).add
-    (hf.isBernsteinFunction_halfLinePrimitive hcont)).congr fun _ _ ↦ rfl
-
-/-- The primitive `t ↦ ∫₀ᵗ f` of a completely monotone function is a Bernstein function. -/
+/-- The primitive `t ↦ ∫₀ᵗ f` of a function that is completely monotone on `(0, ∞)` and
+continuous on `[0, ∞)` is a Bernstein function. -/
 theorem isBernsteinFunction_integral (hf : IsCompletelyMonotoneOnIoi f)
     (hcont : ContinuousOn f (Ici 0)) :
     IsBernsteinFunction fun t ↦ ∫ x in (0 : ℝ)..t, f x :=
@@ -162,13 +86,6 @@ namespace IsCompletelyMonotone
 theorem isBernsteinFunction_halfLinePrimitive (hf : IsCompletelyMonotone f) :
     IsBernsteinFunction (halfLinePrimitive f) :=
   hf.isCompletelyMonotoneOnIoi.isBernsteinFunction_halfLinePrimitive hf.contDiffOn.continuousOn
-
-/-- Shifting the primitive of a completely monotone function by a nonnegative constant again
-gives a Bernstein function. -/
-theorem isBernsteinFunction_const_add_halfLinePrimitive (hf : IsCompletelyMonotone f) {c : ℝ}
-    (hc : 0 ≤ c) : IsBernsteinFunction (fun t ↦ c + halfLinePrimitive f t) :=
-  hf.isCompletelyMonotoneOnIoi.isBernsteinFunction_const_add_halfLinePrimitive
-    hf.contDiffOn.continuousOn hc
 
 /-- The primitive `t ↦ ∫₀ᵗ f` of a completely monotone function is a Bernstein function. -/
 theorem isBernsteinFunction_integral (hf : IsCompletelyMonotone f) :

--- a/TauCeti/Analysis/CompletelyMonotone/Bernstein/Integral.lean
+++ b/TauCeti/Analysis/CompletelyMonotone/Bernstein/Integral.lean
@@ -8,25 +8,35 @@ public import TauCeti.Analysis.CompletelyMonotone.Bernstein.Basic
 public import Mathlib.MeasureTheory.Integral.IntervalIntegral.FundThmCalculus
 
 /-!
-# Bernstein primitives of completely monotone functions
+# Primitives of completely monotone functions are Bernstein functions
 
 This file establishes one direction of the standard correspondence between completely monotone
-and Bernstein functions. If `f` is completely monotone on `[0, ∞)`, then
+and Bernstein functions. If `f` is completely monotone on `(0, ∞)` and continuous on `[0, ∞)`,
+then
 
-`t ↦ c + ∫ x in 0..t, f x` for `t ≥ 0`
+`t ↦ ∫ x in 0..t, f x` for `t ≥ 0`
 
-is a Bernstein function whenever `c ≥ 0`. Its derivative on `(0, ∞)` is `f`, so complete
-monotonicity of the derivative is inherited directly from `f`. The special case `c = 0` gives
-the canonical primitive vanishing at the origin.
+is a Bernstein function, and so is `t ↦ c + ∫ x in 0..t, f x` for every `c ≥ 0`. Its derivative
+on `(0, ∞)` is `f`, so complete monotonicity of the derivative is inherited directly from `f`.
+
+The primitive is packaged as `TauCeti.halfLinePrimitive`, which integrates `f (max x 0)` so that
+the function is defined on all of `ℝ`; on `[0, ∞)` this agrees with `∫₀ᵗ f` by
+`TauCeti.halfLinePrimitive_eq_integral_of_nonneg`, and on `(-∞, 0]` it is the linear
+extension `t ↦ t * f 0` by `TauCeti.halfLinePrimitive_of_nonpos`.
 
 ## Main declarations
 
-* `TauCeti.bernsteinPrimitive`: the primitive `c + ∫₀ᵗ f`.
-* `TauCeti.hasDerivAt_bernsteinPrimitive`: its derivative is `f` at every nonnegative point.
-* `TauCeti.IsCompletelyMonotone.isBernsteinFunction_bernsteinPrimitive`: a nonnegative
-  primitive of a completely monotone function is Bernstein.
-* `TauCeti.IsCompletelyMonotone.isBernsteinFunction_integral`: the primitive vanishing at zero
-  is Bernstein.
+* `TauCeti.halfLinePrimitive`: the primitive `∫₀ᵗ f` of `f` on the nonnegative half-line.
+* `TauCeti.halfLinePrimitive_eq_integral_of_nonneg`,
+  `TauCeti.halfLinePrimitive_of_nonpos`: the value of the primitive on each half-line.
+* `TauCeti.hasDerivAt_halfLinePrimitive`, `TauCeti.deriv_halfLinePrimitive`: its derivative is
+  `f` at every nonnegative point.
+* `TauCeti.IsCompletelyMonotoneOnIoi.isBernsteinFunction_halfLinePrimitive`,
+  `TauCeti.IsCompletelyMonotoneOnIoi.isBernsteinFunction_const_add_halfLinePrimitive`: the
+  primitive of a completely monotone function, and its shifts by a nonnegative constant, are
+  Bernstein.
+* `TauCeti.IsCompletelyMonotoneOnIoi.isBernsteinFunction_integral`: the same statement written
+  directly in terms of `∫ x in 0..t, f x`.
 
 ## References
 
@@ -37,93 +47,133 @@ the canonical primitive vanishing at the origin.
 public section
 
 open Set intervalIntegral
-open scoped ContDiff
+open scoped ContDiff Topology
 
 namespace TauCeti
 
-/-- The primitive of `f` on the nonnegative half-line with initial value `c`. The `max`
-canonically extends the integrand to negative arguments; on `[0, ∞)` this is `c + ∫₀ᵗ f`. -/
-noncomputable def bernsteinPrimitive (c : ℝ) (f : ℝ → ℝ) (t : ℝ) : ℝ :=
-  c + ∫ x in (0 : ℝ)..t, f (max x 0)
+variable {f : ℝ → ℝ} {t : ℝ}
 
-/-- On the nonnegative half-line, `bernsteinPrimitive` is the ordinary integral of `f` from
-zero, with initial value `c`. -/
-theorem bernsteinPrimitive_eq {c : ℝ} {f : ℝ → ℝ} {t : ℝ} (ht : 0 ≤ t) :
-    bernsteinPrimitive c f t = c + ∫ x in (0 : ℝ)..t, f x := by
-  rw [bernsteinPrimitive]
-  congr 1
+/-- The primitive of `f` on the nonnegative half-line. The `max` canonically extends the
+integrand to negative arguments; on `[0, ∞)` this is `∫₀ᵗ f`. -/
+noncomputable def halfLinePrimitive (f : ℝ → ℝ) (t : ℝ) : ℝ :=
+  ∫ x in (0 : ℝ)..t, f (max x 0)
+
+/-- If `f` is continuous on `[0, ∞)`, then its extension `x ↦ f (max x 0)` is continuous on all
+of `ℝ`. -/
+private theorem continuous_comp_max_zero (hf : ContinuousOn f (Ici 0)) :
+    Continuous fun x : ℝ ↦ f (max x 0) := by
+  simpa [Function.comp_def] using
+    hf.comp_continuous (continuous_id'.max continuous_const) fun x ↦ mem_Ici.mpr (le_max_right x 0)
+
+/-- On the nonnegative half-line, `halfLinePrimitive` is the ordinary integral of `f` from
+zero. -/
+@[grind =>]
+theorem halfLinePrimitive_eq_integral_of_nonneg (ht : 0 ≤ t) :
+    halfLinePrimitive f t = ∫ x in (0 : ℝ)..t, f x := by
+  rw [halfLinePrimitive]
   apply intervalIntegral.integral_congr
   intro x hx
   simp only [uIcc_of_le ht] at hx
   simp only [max_eq_left hx.1]
 
-/-- The value of `bernsteinPrimitive c f` at the origin is `c`. -/
+/-- On the nonpositive half-line, `halfLinePrimitive` is the linear extension `t ↦ t * f 0`. -/
+theorem halfLinePrimitive_of_nonpos (ht : t ≤ 0) : halfLinePrimitive f t = t * f 0 := by
+  rw [halfLinePrimitive]
+  rw [show (∫ x in (0 : ℝ)..t, f (max x 0)) = ∫ _ in (0 : ℝ)..t, f 0 from
+    intervalIntegral.integral_congr fun x hx => by
+      simp only [uIcc_of_ge ht] at hx
+      simp only [max_eq_right hx.2]]
+  simp
+
+/-- The value of `halfLinePrimitive f` at the origin is `0`. -/
 @[simp]
-theorem bernsteinPrimitive_zero (c : ℝ) (f : ℝ → ℝ) :
-    bernsteinPrimitive c f 0 = c := by
-  simp [bernsteinPrimitive]
+theorem halfLinePrimitive_zero (f : ℝ → ℝ) : halfLinePrimitive f 0 = 0 := by
+  simp [halfLinePrimitive]
 
-/-- A primitive built from a continuous function has derivative `f t` at every nonnegative
-point. -/
-theorem hasDerivAt_bernsteinPrimitive {c : ℝ} {f : ℝ → ℝ} {t : ℝ}
-    (hf : ContinuousOn f (Ici 0)) (ht : 0 ≤ t) :
-    HasDerivAt (bernsteinPrimitive c f) (f t) t := by
-  have hcontinuous : Continuous (fun x : ℝ ↦ f (max x 0)) := by
-    convert hf.comp_continuous (continuous_id.max continuous_const)
-      (fun x ↦ mem_Ici.mpr (le_max_right x 0)) using 1
-    ext x
-    rfl
-  -- Expose the primitive here so the FTC theorem sees its defining integral.
-  change HasDerivAt (fun u ↦ c + ∫ x in (0 : ℝ)..u, f (max x 0)) (f t) t
-  simpa only [bernsteinPrimitive, max_eq_left ht] using
-    (intervalIntegral.integral_hasDerivAt_right (a := (0 : ℝ))
-      (hcontinuous.intervalIntegrable 0 t)
-      hcontinuous.aestronglyMeasurable.stronglyMeasurableAtFilter
-      hcontinuous.continuousAt).const_add c
+/-- If `f` is continuous on `[0, ∞)`, then `halfLinePrimitive f` has derivative `f t` at every
+`t ≥ 0`. The `max` extension of the integrand makes the derivative at `t = 0` two-sided. -/
+theorem hasDerivAt_halfLinePrimitive (hf : ContinuousOn f (Ici 0)) (ht : 0 ≤ t) :
+    HasDerivAt (halfLinePrimitive f) (f t) t := by
+  have hcont := continuous_comp_max_zero hf
+  -- Expose the defining integral, which is what the fundamental theorem of calculus is about.
+  change HasDerivAt (fun u ↦ ∫ x in (0 : ℝ)..u, f (max x 0)) (f t) t
+  simpa only [max_eq_left ht] using
+    intervalIntegral.integral_hasDerivAt_right (a := (0 : ℝ)) (hcont.intervalIntegrable 0 t)
+      hcont.aestronglyMeasurable.stronglyMeasurableAtFilter hcont.continuousAt
 
-/-- The derivative of a primitive built from a continuous function is its integrand at every
-nonnegative point. -/
-theorem deriv_bernsteinPrimitive {c : ℝ} {f : ℝ → ℝ} {t : ℝ}
-    (hf : ContinuousOn f (Ici 0)) (ht : 0 ≤ t) :
-    deriv (bernsteinPrimitive c f) t = f t :=
-  (hasDerivAt_bernsteinPrimitive hf ht).deriv
+/-- If `f` is continuous on `[0, ∞)`, then the derivative of `halfLinePrimitive f` is `f` at
+every `t ≥ 0`. -/
+@[grind =>]
+theorem deriv_halfLinePrimitive (hf : ContinuousOn f (Ici 0)) (ht : 0 ≤ t) :
+    deriv (halfLinePrimitive f) t = f t :=
+  (hasDerivAt_halfLinePrimitive hf ht).deriv
+
+namespace IsCompletelyMonotoneOnIoi
+
+/-- A function that is completely monotone on `(0, ∞)` and continuous on `[0, ∞)` is
+nonnegative on `[0, ∞)`. -/
+theorem nonneg_of_continuousOn (hf : IsCompletelyMonotoneOnIoi f)
+    (hcont : ContinuousOn f (Ici 0)) (ht : 0 ≤ t) : 0 ≤ f t := by
+  rcases ht.lt_or_eq with h | h
+  · exact hf.nonneg h
+  · subst h
+    have htends : Filter.Tendsto f (𝓝[>] (0 : ℝ)) (nhds (f 0)) :=
+      (hcont 0 self_mem_Ici).tendsto.mono_left (nhdsWithin_mono _ Ioi_subset_Ici_self)
+    exact ge_of_tendsto htends (eventually_mem_nhdsWithin.mono fun x hx => hf.nonneg hx)
+
+/-- The primitive on `[0, ∞)` of a function that is completely monotone on `(0, ∞)` and
+continuous on `[0, ∞)` is a Bernstein function. -/
+theorem isBernsteinFunction_halfLinePrimitive (hf : IsCompletelyMonotoneOnIoi f)
+    (hcont : ContinuousOn f (Ici 0)) : IsBernsteinFunction (halfLinePrimitive f) := by
+  have hcontinuous : ContinuousOn (halfLinePrimitive f) (Ici 0) := fun t ht ↦
+    (hasDerivAt_halfLinePrimitive hcont ht).continuousAt.continuousWithinAt
+  have hcontDiff : ContDiffOn ℝ ∞ (halfLinePrimitive f) (Ioi 0) := by
+    rw [contDiffOn_infty_iff_deriv_of_isOpen isOpen_Ioi]
+    refine ⟨fun t ht ↦
+      (hasDerivAt_halfLinePrimitive hcont ht.le).differentiableAt.differentiableWithinAt, ?_⟩
+    exact hf.contDiffOn.congr fun t ht ↦ deriv_halfLinePrimitive hcont ht.le
+  rw [isBernsteinFunction_iff]
+  refine ⟨hcontinuous, hcontDiff, fun t ht ↦ ?_, ?_⟩
+  · rw [halfLinePrimitive]
+    exact intervalIntegral.integral_nonneg ht fun x hx ↦
+      hf.nonneg_of_continuousOn hcont (le_max_right x 0)
+  · exact hf.congr fun t ht ↦ deriv_halfLinePrimitive hcont ht.le
+
+/-- Shifting the primitive of a completely monotone function by a nonnegative constant again
+gives a Bernstein function. -/
+theorem isBernsteinFunction_const_add_halfLinePrimitive (hf : IsCompletelyMonotoneOnIoi f)
+    (hcont : ContinuousOn f (Ici 0)) {c : ℝ} (hc : 0 ≤ c) :
+    IsBernsteinFunction (fun t ↦ c + halfLinePrimitive f t) :=
+  ((isBernsteinFunction_const hc).add
+    (hf.isBernsteinFunction_halfLinePrimitive hcont)).congr fun _ _ ↦ rfl
+
+/-- The primitive `t ↦ ∫₀ᵗ f` of a completely monotone function is a Bernstein function. -/
+theorem isBernsteinFunction_integral (hf : IsCompletelyMonotoneOnIoi f)
+    (hcont : ContinuousOn f (Ici 0)) :
+    IsBernsteinFunction fun t ↦ ∫ x in (0 : ℝ)..t, f x :=
+  (hf.isBernsteinFunction_halfLinePrimitive hcont).congr fun _ ht ↦
+    (halfLinePrimitive_eq_integral_of_nonneg ht).symm
+
+end IsCompletelyMonotoneOnIoi
 
 namespace IsCompletelyMonotone
 
-variable {f : ℝ → ℝ}
+/-- The primitive on `[0, ∞)` of a completely monotone function is a Bernstein function. -/
+theorem isBernsteinFunction_halfLinePrimitive (hf : IsCompletelyMonotone f) :
+    IsBernsteinFunction (halfLinePrimitive f) :=
+  hf.isCompletelyMonotoneOnIoi.isBernsteinFunction_halfLinePrimitive hf.contDiffOn.continuousOn
 
-/-- A nonnegative primitive of a completely monotone function is a Bernstein function. -/
-theorem isBernsteinFunction_bernsteinPrimitive (hf : IsCompletelyMonotone f) {c : ℝ}
-    (hc : 0 ≤ c) : IsBernsteinFunction (bernsteinPrimitive c f) := by
-  have hintegrand : Continuous (fun x : ℝ ↦ f (max x 0)) := by
-    convert hf.contDiffOn.continuousOn.comp_continuous
-      (continuous_id.max continuous_const) (fun x ↦ mem_Ici.mpr (le_max_right x 0)) using 1
-    ext x
-    rfl
-  have hcontinuous : ContinuousOn (bernsteinPrimitive c f) (Ici 0) :=
-    (continuous_const.add
-      (intervalIntegral.continuous_primitive
-        (fun a b ↦ hintegrand.intervalIntegrable a b) 0)).continuousOn
-  have hcontDiff : ContDiffOn ℝ ∞ (bernsteinPrimitive c f) (Ioi 0) := by
-    rw [contDiffOn_infty_iff_deriv_of_isOpen isOpen_Ioi]
-    refine ⟨fun t ht ↦ (hasDerivAt_bernsteinPrimitive hf.contDiffOn.continuousOn
-      ht.le).differentiableAt.differentiableWithinAt, ?_⟩
-    exact (hf.contDiffOn.mono Ioi_subset_Ici_self).congr fun t ht ↦
-      deriv_bernsteinPrimitive hf.contDiffOn.continuousOn ht.le
-  rw [isBernsteinFunction_iff]
-  refine ⟨hcontinuous, hcontDiff, fun t ht ↦ ?_, ?_⟩
-  · rw [bernsteinPrimitive]
-    exact add_nonneg hc
-      (intervalIntegral.integral_nonneg ht fun x _ ↦ hf.nonneg (le_max_right x 0))
-  · apply hf.isCompletelyMonotoneOnIoi.congr
-    intro t ht
-    exact deriv_bernsteinPrimitive hf.contDiffOn.continuousOn ht.le
+/-- Shifting the primitive of a completely monotone function by a nonnegative constant again
+gives a Bernstein function. -/
+theorem isBernsteinFunction_const_add_halfLinePrimitive (hf : IsCompletelyMonotone f) {c : ℝ}
+    (hc : 0 ≤ c) : IsBernsteinFunction (fun t ↦ c + halfLinePrimitive f t) :=
+  hf.isCompletelyMonotoneOnIoi.isBernsteinFunction_const_add_halfLinePrimitive
+    hf.contDiffOn.continuousOn hc
 
-/-- The primitive of a completely monotone function that vanishes at the origin is a Bernstein
-function. -/
+/-- The primitive `t ↦ ∫₀ᵗ f` of a completely monotone function is a Bernstein function. -/
 theorem isBernsteinFunction_integral (hf : IsCompletelyMonotone f) :
-    IsBernsteinFunction (bernsteinPrimitive 0 f) :=
-  hf.isBernsteinFunction_bernsteinPrimitive le_rfl
+    IsBernsteinFunction fun t ↦ ∫ x in (0 : ℝ)..t, f x :=
+  hf.isCompletelyMonotoneOnIoi.isBernsteinFunction_integral hf.contDiffOn.continuousOn
 
 end IsCompletelyMonotone
 


### PR DESCRIPTION
This PR adds the canonical nonnegative primitive of a completely monotone function and proves it is a Bernstein function, exposing its value and derivative API together with the characteristic `isBernsteinFunction_iff` constructor for the existing opaque predicate. The primitive uses `f (max x 0)` as a canonical continuous extension outside the half-line and agrees with `c + ∫₀ᵗ f` for every `t ≥ 0`.

This advances `TauCetiRoadmap/OneParameterSemigroups/README.md`, Part B — Completely monotone (and Bernstein) functions, specifically “the Stieltjes / Bernstein-function relationships (completely monotone ↔ Bernstein via the standard correspondences).” It is the lowest-hanging uncovered correspondence because the completely-monotone and Bernstein predicates, their basic closure APIs, and Mathlib’s interval-integral FTC are already available, while open PR #575 addresses the distinct Hausdorff–Bernstein–Widder representation milestone.

Follow Schilling–Song–Vondraček, *Bernstein Functions: Theory and Applications*, Chapter 3. Reuse Mathlib’s `intervalIntegral.integral_hasDerivAt_right`, `intervalIntegral.continuous_primitive`, and `contDiffOn_infty_iff_deriv_of_isOpen`; no Mathlib infrastructure is vendored.

`lake exe cache get` reported `No files to download` and `Already decompressed 8619 file(s)`. `lake build` reported `Build completed successfully (5160 jobs).` `lake exe axioms` reported `axioms: audited 10441 TauCeti declaration(s); all within the allowlist [propext, Classical.choice, Quot.sound].`

<!--tauceti-target:v1 {"focus":"OneParameterSemigroups","id":"integral-completely-monotone-bernstein"}-->

🤖 Prepared with Codex
