### PR TITLE
feat: winding number is constant on off-curve components and zero on the unbounded one

### DIFF
--- a/TauCeti/Analysis/Contour/Curve/Distance.lean
+++ b/TauCeti/Analysis/Contour/Curve/Distance.lean
@@ -19,6 +19,8 @@ a uniform positive lower bound `ρ` on `‖γ t - w‖` over `[a, b]`.
 
 ## Main results
 
+* `TauCeti.Contour.isOpen_offCurve_of_continuousOn` — the set of points avoided by a continuous
+  curve is open.
 * `TauCeti.Contour.exists_curve_dist_lower_bound` — the uniform positive distance lower bound.
 * `TauCeti.Contour.exists_ball_dist_curve_lower_bound` — the same lower bound made uniform over a
   whole ball of points around the avoided point.
@@ -37,6 +39,16 @@ public section
 open Set
 
 namespace TauCeti.Contour
+
+/-- The set of points avoided by a curve continuous on `Set.uIcc a b` is open. -/
+theorem isOpen_offCurve_of_continuousOn {γ : ℝ → ℂ} {a b : ℝ}
+    (hγ_cont : ContinuousOn γ (uIcc a b)) :
+    IsOpen {z : ℂ | ∀ t ∈ uIcc a b, γ t ≠ z} := by
+  have hset : {z : ℂ | ∀ t ∈ uIcc a b, γ t ≠ z} = (γ '' uIcc a b)ᶜ := by
+    ext z
+    simp only [Set.mem_setOf_eq, Set.mem_compl_iff, Set.mem_image, not_exists, not_and, ne_eq]
+  rw [hset]
+  exact (isCompact_uIcc.image_of_continuousOn hγ_cont).isClosed.isOpen_compl
 
 /-- **Uniform positive distance from an avoided point to a curve.** If `γ` is continuous on the
 interval with endpoints `a`, `b` and avoids `w` there, then there is `ρ > 0` with `ρ ≤ ‖γ t - w‖`

--- a/TauCeti/Analysis/Contour/Curve/Distance.lean
+++ b/TauCeti/Analysis/Contour/Curve/Distance.lean
@@ -19,7 +19,7 @@ a uniform positive lower bound `ρ` on `‖γ t - w‖` over `[a, b]`.
 
 ## Main results
 
-* `TauCeti.Contour.isOpen_offCurve_of_continuousOn` — the set of points avoided by a continuous
+* `TauCeti.Contour.isOpen_setOf_avoidance` — the set of points avoided by a continuous
   curve is open.
 * `TauCeti.Contour.exists_curve_dist_lower_bound` — the uniform positive distance lower bound.
 * `TauCeti.Contour.exists_ball_dist_curve_lower_bound` — the same lower bound made uniform over a
@@ -41,7 +41,7 @@ open Set
 namespace TauCeti.Contour
 
 /-- The set of points avoided by a curve continuous on `Set.uIcc a b` is open. -/
-theorem isOpen_offCurve_of_continuousOn {γ : ℝ → ℂ} {a b : ℝ}
+theorem isOpen_setOf_avoidance {γ : ℝ → ℂ} {a b : ℝ}
     (hγ_cont : ContinuousOn γ (uIcc a b)) :
     IsOpen {z : ℂ | ∀ t ∈ uIcc a b, γ t ≠ z} := by
   have hset : {z : ℂ | ∀ t ∈ uIcc a b, γ t ≠ z} = (γ '' uIcc a b)ᶜ := by

--- a/TauCeti/Analysis/Contour/Winding/Component.lean
+++ b/TauCeti/Analysis/Contour/Winding/Component.lean
@@ -5,9 +5,11 @@ Authors: Chris Birkbeck, Kim Morrison
 -/
 module
 
-public import TauCeti.Analysis.Contour.Winding.LocallyConstant
-public import TauCeti.Analysis.Contour.Winding.Vanishing
-import Mathlib.Topology.Connected.Basic
+public import TauCeti.Analysis.Contour.Winding.Number.Basic
+public import Mathlib.Topology.Bornology.Basic
+public import Mathlib.Topology.Connected.Basic
+import TauCeti.Analysis.Contour.Winding.LocallyConstant
+import TauCeti.Analysis.Contour.Winding.Vanishing
 
 /-!
 # The winding number is constant on off-curve components, and zero on the unbounded one
@@ -68,17 +70,12 @@ theorem windingNumber_eq_of_isPreconnected {S : Set ℂ}
   -- The off-curve set is open (the complement of the compact curve image), so `Subtype.val` from
   -- the subtype of off-curve points is an injective open map; transport preconnectedness of `S`
   -- along its preimage.
-  have hSopen : IsOpen {z : ℂ | ∀ t ∈ uIcc a b, γ t ≠ z} := by
-    have hset : {z : ℂ | ∀ t ∈ uIcc a b, γ t ≠ z} = (γ '' uIcc a b)ᶜ := by
-      ext z
-      simp only [Set.mem_setOf_eq, Set.mem_compl_iff, Set.mem_image, not_exists, not_and, ne_eq]
-    rw [hset]
-    exact (isCompact_uIcc.image_of_continuousOn hγ_cont).isClosed.isOpen_compl
   have hrange : S ⊆ Set.range (Subtype.val : {w : ℂ // ∀ t ∈ uIcc a b, γ t ≠ w} → ℂ) := by
     rw [Subtype.range_val_subtype]; exact hSoff
   have hTconn : IsPreconnected
       (Subtype.val ⁻¹' S : Set {w : ℂ // ∀ t ∈ uIcc a b, γ t ≠ w}) :=
-    hSconn.preimage_of_isOpenMap Subtype.val_injective hSopen.isOpenMap_subtype_val hrange
+    hSconn.preimage_of_isOpenMap Subtype.val_injective
+      (isOpen_offCurve_of_continuousOn hγ_cont).isOpenMap_subtype_val hrange
   exact hlc.apply_eq_of_isPreconnected hTconn
     (x := ⟨w₁, hSoff hw₁⟩) (y := ⟨w₂, hSoff hw₂⟩) hw₁ hw₂
 

--- a/TauCeti/Analysis/Contour/Winding/Component.lean
+++ b/TauCeti/Analysis/Contour/Winding/Component.lean
@@ -1,0 +1,111 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Chris Birkbeck, Kim Morrison
+-/
+module
+
+public import TauCeti.Analysis.Contour.Winding.LocallyConstant
+public import TauCeti.Analysis.Contour.Winding.Vanishing
+import Mathlib.Topology.Connected.Basic
+
+/-!
+# The winding number is constant on off-curve components, and zero on the unbounded one
+
+For a closed curve `γ` (so `γ a = γ b`) continuous on `Set.uIcc a b`, differentiable off a countable
+set, with interval-integrable derivative, the generalized winding number
+`fun w ↦ windingNumber γ a b w` is locally constant on the complement of the curve
+(`isLocallyConstant_windingNumber_of_closed`). Locally constant functions are constant on
+preconnected sets, so the winding number takes a single value on each connected component of the
+complement (`windingNumber_eq_of_isPreconnected`). On the **unbounded** component it is that
+far-field value, which `windingNumber_eventually_zero_cocompact` pins to `0`
+(`windingNumber_eq_zero_of_unbounded`). These are the two Layer-0 geometric facts the roadmap
+records for a point off the curve — the winding number is a locally constant integer,
+homotopy-invariant within a component, and `0` on the unbounded component.
+
+## Main results
+
+* `TauCeti.Contour.windingNumber_eq_of_isPreconnected` — the winding number agrees at any two points
+  of a preconnected set that avoids the curve.
+* `TauCeti.Contour.windingNumber_eq_zero_of_unbounded` — the winding number vanishes on a
+  preconnected unbounded set that avoids the curve (the unbounded component).
+
+## Provenance
+
+Built on the AINTLIB-migrated `isLocallyConstant_windingNumber_of_closed`
+(`Winding/LocallyConstant.lean`) and `windingNumber_eventually_zero_cocompact`
+(`Winding/Vanishing.lean`), corresponding to the `WindingArgDiff.lean` and `NullHomologous.lean`
+files of the AINTLIB `LeanModularForms` development. The constancy on a component transports the
+locally-constant statement to a preconnected subset via the open inclusion of the off-curve subtype
+(`IsPreconnected.preimage_of_isOpenMap`), and the unbounded-component vanishing extracts a far-field
+point of the component from the cocompact eventual-zero statement.
+-/
+
+public section
+
+open Complex MeasureTheory Set
+
+open scoped Interval
+
+namespace TauCeti.Contour
+
+variable {γ : ℝ → ℂ} {a b : ℝ} {P : Set ℝ}
+
+/-- **The winding number is constant on a preconnected off-curve set.** For a closed curve `γ`
+(differentiable off a countable set `P`, continuous on `Set.uIcc a b`, with interval-integrable
+derivative), if `S` avoids the curve and is preconnected, then the generalized winding number takes
+the same value at any two points of `S`. In particular it is constant on each connected component of
+the complement of the curve — the homotopy-invariance-within-a-component form of the Layer-0 fact
+that the winding number off the curve is locally constant. -/
+theorem windingNumber_eq_of_isPreconnected {S : Set ℂ}
+    (hclosed : γ a = γ b) (hP : P.Countable) (hγ_cont : ContinuousOn γ (uIcc a b))
+    (hγ_diff : ∀ t ∈ Ioo (min a b) (max a b) \ P, DifferentiableAt ℝ γ t)
+    (hderiv_int : IntervalIntegrable (fun t ↦ deriv γ t) volume a b)
+    (hSoff : S ⊆ {w : ℂ | ∀ t ∈ uIcc a b, γ t ≠ w})
+    (hSconn : IsPreconnected S) {w₁ w₂ : ℂ} (hw₁ : w₁ ∈ S) (hw₂ : w₂ ∈ S) :
+    windingNumber γ a b w₁ = windingNumber γ a b w₂ := by
+  have hlc := isLocallyConstant_windingNumber_of_closed hclosed hP hγ_cont hγ_diff hderiv_int
+  -- The off-curve set is open (the complement of the compact curve image), so `Subtype.val` from
+  -- the subtype of off-curve points is an injective open map; transport preconnectedness of `S`
+  -- along its preimage.
+  have hSopen : IsOpen {z : ℂ | ∀ t ∈ uIcc a b, γ t ≠ z} := by
+    have hset : {z : ℂ | ∀ t ∈ uIcc a b, γ t ≠ z} = (γ '' uIcc a b)ᶜ := by
+      ext z
+      simp only [Set.mem_setOf_eq, Set.mem_compl_iff, Set.mem_image, not_exists, not_and, ne_eq]
+    rw [hset]
+    exact (isCompact_uIcc.image_of_continuousOn hγ_cont).isClosed.isOpen_compl
+  have hrange : S ⊆ Set.range (Subtype.val : {w : ℂ // ∀ t ∈ uIcc a b, γ t ≠ w} → ℂ) := by
+    rw [Subtype.range_val_subtype]; exact hSoff
+  have hTconn : IsPreconnected
+      (Subtype.val ⁻¹' S : Set {w : ℂ // ∀ t ∈ uIcc a b, γ t ≠ w}) :=
+    hSconn.preimage_of_isOpenMap Subtype.val_injective hSopen.isOpenMap_subtype_val hrange
+  exact hlc.apply_eq_of_isPreconnected hTconn
+    (x := ⟨w₁, hSoff hw₁⟩) (y := ⟨w₂, hSoff hw₂⟩) hw₁ hw₂
+
+/-- **The winding number vanishes on the unbounded component.** For a closed curve `γ`
+(differentiable off a countable set `P`, continuous on `Set.uIcc a b`, with interval-integrable
+derivative), if `S` avoids the curve, is preconnected, and is unbounded, then the generalized
+winding number is `0` throughout `S`. Applied to the (necessarily unbounded) exterior connected
+component of the complement, this is the Layer-0 fact that the winding number is `0` on the
+unbounded component: constancy pins the value across the component, and it must equal the far-field
+value, which the cocompact eventual-zero statement forces to be `0`. -/
+theorem windingNumber_eq_zero_of_unbounded {S : Set ℂ}
+    (hclosed : γ a = γ b) (hP : P.Countable) (hγ_cont : ContinuousOn γ (uIcc a b))
+    (hγ_diff : ∀ t ∈ Ioo (min a b) (max a b) \ P, DifferentiableAt ℝ γ t)
+    (hderiv_int : IntervalIntegrable (fun t ↦ deriv γ t) volume a b)
+    (hSoff : S ⊆ {w : ℂ | ∀ t ∈ uIcc a b, γ t ≠ w})
+    (hSconn : IsPreconnected S) (hSunb : ¬ Bornology.IsBounded S) {w : ℂ} (hw : w ∈ S) :
+    windingNumber γ a b w = 0 := by
+  -- The set where `γ` is avoided and the winding number is `0` is cocompact, so its complement is
+  -- contained in a compact — hence bounded — set `K`.
+  obtain ⟨K, hK, hKsub⟩ := Filter.mem_cocompact'.mp
+    (windingNumber_eventually_zero_cocompact hclosed hP hγ_cont hγ_diff hderiv_int)
+  -- An unbounded `S` cannot sit inside the bounded complement, so it meets the cocompact zero set.
+  have hex : ∃ w' ∈ S, (∀ t ∈ uIcc a b, γ t ≠ w') ∧ windingNumber γ a b w' = 0 := by
+    by_contra hcon
+    exact hSunb <| hK.isBounded.subset fun x hxS ↦ hKsub fun hgood ↦ hcon ⟨x, hxS, hgood⟩
+  obtain ⟨w', hw'S, _, hw'zero⟩ := hex
+  rw [windingNumber_eq_of_isPreconnected hclosed hP hγ_cont hγ_diff hderiv_int hSoff hSconn hw hw'S,
+    hw'zero]
+
+end TauCeti.Contour

--- a/TauCeti/Analysis/Contour/Winding/Component.lean
+++ b/TauCeti/Analysis/Contour/Winding/Component.lean
@@ -1,7 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors: Chris Birkbeck, Kim Morrison
+Authors: Chris Birkbeck
 -/
 module
 

--- a/TauCeti/Analysis/Contour/Winding/Component.lean
+++ b/TauCeti/Analysis/Contour/Winding/Component.lean
@@ -20,18 +20,17 @@ set, with interval-integrable derivative, the generalized winding number
 `fun w ↦ windingNumber γ a b w` is locally constant on the complement of the curve
 (`isLocallyConstant_windingNumber_of_closed`). Locally constant functions are constant on
 preconnected sets, so the winding number takes a single value on each connected component of the
-complement (`windingNumber_eq_of_subset_offCurve_of_isPreconnected`). On the **unbounded** component
-it is that far-field value, which `windingNumber_eventually_zero_cocompact` pins to `0`
-(`windingNumber_eq_zero_of_subset_offCurve_of_isPreconnected_of_unbounded`). These are the two
-Layer-0 geometric facts the roadmap
-records for a point off the curve — the winding number is a locally constant integer,
-homotopy-invariant within a component, and `0` on the unbounded component.
+complement (`windingNumber_eq_of_avoidance_of_isPreconnected`). On the **unbounded** component it is
+that far-field value, which `windingNumber_eventually_zero_cocompact` pins to `0`
+(`windingNumber_eq_zero_of_avoidance_of_isPreconnected_of_unbounded`). These are the two Layer-0
+geometric facts the roadmap records for a point off the curve — the winding number is a locally
+constant integer, homotopy-invariant within a component, and `0` on the unbounded component.
 
 ## Main results
 
-* `TauCeti.Contour.windingNumber_eq_of_subset_offCurve_of_isPreconnected` — the winding number
-  agrees at any two points of a preconnected set that avoids the curve.
-* `TauCeti.Contour.windingNumber_eq_zero_of_subset_offCurve_of_isPreconnected_of_unbounded` — the
+* `TauCeti.Contour.windingNumber_eq_of_avoidance_of_isPreconnected` — the winding number agrees at
+  any two points of a preconnected set that avoids the curve.
+* `TauCeti.Contour.windingNumber_eq_zero_of_avoidance_of_isPreconnected_of_unbounded` — the
   winding number vanishes on a preconnected unbounded set that avoids the curve (the unbounded
   component).
 
@@ -62,7 +61,7 @@ derivative), if `S` avoids the curve and is preconnected, then the generalized w
 the same value at any two points of `S`. In particular it is constant on each connected component of
 the complement of the curve — the homotopy-invariance-within-a-component form of the Layer-0 fact
 that the winding number off the curve is locally constant. -/
-theorem windingNumber_eq_of_subset_offCurve_of_isPreconnected {S : Set ℂ}
+theorem windingNumber_eq_of_avoidance_of_isPreconnected {S : Set ℂ}
     (hclosed : γ a = γ b) (hP : P.Countable) (hγ_cont : ContinuousOn γ (uIcc a b))
     (hγ_diff : ∀ t ∈ Ioo (min a b) (max a b) \ P, DifferentiableAt ℝ γ t)
     (hderiv_int : IntervalIntegrable (fun t ↦ deriv γ t) volume a b)
@@ -78,7 +77,7 @@ theorem windingNumber_eq_of_subset_offCurve_of_isPreconnected {S : Set ℂ}
   have hTconn : IsPreconnected
       (Subtype.val ⁻¹' S : Set {w : ℂ // ∀ t ∈ uIcc a b, γ t ≠ w}) :=
     hSconn.preimage_of_isOpenMap Subtype.val_injective
-      (isOpen_offCurve_of_continuousOn hγ_cont).isOpenMap_subtype_val hrange
+      (isOpen_setOf_avoidance hγ_cont).isOpenMap_subtype_val hrange
   exact hlc.apply_eq_of_isPreconnected hTconn
     (x := ⟨w₁, hSoff hw₁⟩) (y := ⟨w₂, hSoff hw₂⟩) hw₁ hw₂
 
@@ -89,7 +88,7 @@ winding number is `0` throughout `S`. Applied to the (necessarily unbounded) ext
 component of the complement, this is the Layer-0 fact that the winding number is `0` on the
 unbounded component: constancy pins the value across the component, and it must equal the far-field
 value, which the cocompact eventual-zero statement forces to be `0`. -/
-theorem windingNumber_eq_zero_of_subset_offCurve_of_isPreconnected_of_unbounded {S : Set ℂ}
+theorem windingNumber_eq_zero_of_avoidance_of_isPreconnected_of_unbounded {S : Set ℂ}
     (hclosed : γ a = γ b) (hP : P.Countable) (hγ_cont : ContinuousOn γ (uIcc a b))
     (hγ_diff : ∀ t ∈ Ioo (min a b) (max a b) \ P, DifferentiableAt ℝ γ t)
     (hderiv_int : IntervalIntegrable (fun t ↦ deriv γ t) volume a b)
@@ -105,7 +104,7 @@ theorem windingNumber_eq_zero_of_subset_offCurve_of_isPreconnected_of_unbounded 
     by_contra hcon
     exact hSunb <| hK.isBounded.subset fun x hxS ↦ hKsub fun hgood ↦ hcon ⟨x, hxS, hgood⟩
   obtain ⟨w', hw'S, _, hw'zero⟩ := hex
-  rw [windingNumber_eq_of_subset_offCurve_of_isPreconnected hclosed hP hγ_cont hγ_diff hderiv_int
+  rw [windingNumber_eq_of_avoidance_of_isPreconnected hclosed hP hγ_cont hγ_diff hderiv_int
     hSoff hSconn hw hw'S, hw'zero]
 
 end TauCeti.Contour

--- a/TauCeti/Analysis/Contour/Winding/Component.lean
+++ b/TauCeti/Analysis/Contour/Winding/Component.lean
@@ -8,6 +8,7 @@ module
 public import TauCeti.Analysis.Contour.Winding.Number.Basic
 public import Mathlib.Topology.Bornology.Basic
 public import Mathlib.Topology.Connected.Basic
+import TauCeti.Analysis.Contour.Curve.Distance
 import TauCeti.Analysis.Contour.Winding.LocallyConstant
 import TauCeti.Analysis.Contour.Winding.Vanishing
 
@@ -19,18 +20,20 @@ set, with interval-integrable derivative, the generalized winding number
 `fun w ↦ windingNumber γ a b w` is locally constant on the complement of the curve
 (`isLocallyConstant_windingNumber_of_closed`). Locally constant functions are constant on
 preconnected sets, so the winding number takes a single value on each connected component of the
-complement (`windingNumber_eq_of_isPreconnected`). On the **unbounded** component it is that
-far-field value, which `windingNumber_eventually_zero_cocompact` pins to `0`
-(`windingNumber_eq_zero_of_unbounded`). These are the two Layer-0 geometric facts the roadmap
+complement (`windingNumber_eq_of_subset_offCurve_of_isPreconnected`). On the **unbounded** component
+it is that far-field value, which `windingNumber_eventually_zero_cocompact` pins to `0`
+(`windingNumber_eq_zero_of_subset_offCurve_of_isPreconnected_of_unbounded`). These are the two
+Layer-0 geometric facts the roadmap
 records for a point off the curve — the winding number is a locally constant integer,
 homotopy-invariant within a component, and `0` on the unbounded component.
 
 ## Main results
 
-* `TauCeti.Contour.windingNumber_eq_of_isPreconnected` — the winding number agrees at any two points
-  of a preconnected set that avoids the curve.
-* `TauCeti.Contour.windingNumber_eq_zero_of_unbounded` — the winding number vanishes on a
-  preconnected unbounded set that avoids the curve (the unbounded component).
+* `TauCeti.Contour.windingNumber_eq_of_subset_offCurve_of_isPreconnected` — the winding number
+  agrees at any two points of a preconnected set that avoids the curve.
+* `TauCeti.Contour.windingNumber_eq_zero_of_subset_offCurve_of_isPreconnected_of_unbounded` — the
+  winding number vanishes on a preconnected unbounded set that avoids the curve (the unbounded
+  component).
 
 ## Provenance
 
@@ -59,7 +62,7 @@ derivative), if `S` avoids the curve and is preconnected, then the generalized w
 the same value at any two points of `S`. In particular it is constant on each connected component of
 the complement of the curve — the homotopy-invariance-within-a-component form of the Layer-0 fact
 that the winding number off the curve is locally constant. -/
-theorem windingNumber_eq_of_isPreconnected {S : Set ℂ}
+theorem windingNumber_eq_of_subset_offCurve_of_isPreconnected {S : Set ℂ}
     (hclosed : γ a = γ b) (hP : P.Countable) (hγ_cont : ContinuousOn γ (uIcc a b))
     (hγ_diff : ∀ t ∈ Ioo (min a b) (max a b) \ P, DifferentiableAt ℝ γ t)
     (hderiv_int : IntervalIntegrable (fun t ↦ deriv γ t) volume a b)
@@ -86,7 +89,7 @@ winding number is `0` throughout `S`. Applied to the (necessarily unbounded) ext
 component of the complement, this is the Layer-0 fact that the winding number is `0` on the
 unbounded component: constancy pins the value across the component, and it must equal the far-field
 value, which the cocompact eventual-zero statement forces to be `0`. -/
-theorem windingNumber_eq_zero_of_unbounded {S : Set ℂ}
+theorem windingNumber_eq_zero_of_subset_offCurve_of_isPreconnected_of_unbounded {S : Set ℂ}
     (hclosed : γ a = γ b) (hP : P.Countable) (hγ_cont : ContinuousOn γ (uIcc a b))
     (hγ_diff : ∀ t ∈ Ioo (min a b) (max a b) \ P, DifferentiableAt ℝ γ t)
     (hderiv_int : IntervalIntegrable (fun t ↦ deriv γ t) volume a b)
@@ -102,7 +105,7 @@ theorem windingNumber_eq_zero_of_unbounded {S : Set ℂ}
     by_contra hcon
     exact hSunb <| hK.isBounded.subset fun x hxS ↦ hKsub fun hgood ↦ hcon ⟨x, hxS, hgood⟩
   obtain ⟨w', hw'S, _, hw'zero⟩ := hex
-  rw [windingNumber_eq_of_isPreconnected hclosed hP hγ_cont hγ_diff hderiv_int hSoff hSconn hw hw'S,
-    hw'zero]
+  rw [windingNumber_eq_of_subset_offCurve_of_isPreconnected hclosed hP hγ_cont hγ_diff hderiv_int
+    hSoff hSconn hw hw'S, hw'zero]
 
 end TauCeti.Contour

--- a/TauCeti/Analysis/Contour/Winding/LocallyConstant.lean
+++ b/TauCeti/Analysis/Contour/Winding/LocallyConstant.lean
@@ -44,6 +44,16 @@ open scoped Topology
 
 namespace TauCeti.Contour
 
+/-- The set of points avoided by a curve continuous on `Set.uIcc a b` is open. -/
+theorem isOpen_offCurve_of_continuousOn {γ : ℝ → ℂ} {a b : ℝ}
+    (hγ_cont : ContinuousOn γ (uIcc a b)) :
+    IsOpen {z : ℂ | ∀ t ∈ uIcc a b, γ t ≠ z} := by
+  have hset : {z : ℂ | ∀ t ∈ uIcc a b, γ t ≠ z} = (γ '' uIcc a b)ᶜ := by
+    ext z
+    simp only [Set.mem_setOf_eq, Set.mem_compl_iff, Set.mem_image, not_exists, not_and, ne_eq]
+  rw [hset]
+  exact (isCompact_uIcc.image_of_continuousOn hγ_cont).isClosed.isOpen_compl
+
 /-- **The winding number is locally constant off a closed curve.** Let `γ` be a closed curve
 (`γ a = γ b`), differentiable off a countable set `P`, continuous on `Set.uIcc a b`, with
 interval-integrable derivative. Then, as a function of the point ranging over the complement of the
@@ -112,18 +122,12 @@ theorem exists_ball_windingNumber_zero {γ : ℝ → ℂ} {w : ℂ} {a b : ℝ} 
     ∃ ε > 0, ∀ w' ∈ Metric.ball w ε,
       (∀ t ∈ uIcc a b, γ t ≠ w') ∧ windingNumber γ a b w' = 0 := by
   obtain ⟨ε₁, hε₁, h_dist⟩ := exists_ball_dist_curve_lower_bound hγ_cont hoff
-  -- The off-curve set is open: it is the complement of the compact curve image.
-  have hSopen : IsOpen {z : ℂ | ∀ t ∈ uIcc a b, γ t ≠ z} := by
-    have hset : {z : ℂ | ∀ t ∈ uIcc a b, γ t ≠ z} = (γ '' uIcc a b)ᶜ := by
-      ext z
-      simp only [Set.mem_setOf_eq, Set.mem_compl_iff, Set.mem_image, not_exists, not_and, ne_eq]
-    rw [hset]
-    exact (isCompact_uIcc.image_of_continuousOn hγ_cont).isClosed.isOpen_compl
   -- The winding number is locally constant off the curve, so it is `0` on a subtype-open set
   -- around `w`; push that set forward along the open inclusion to a `ℂ`-ball.
   have hlc := isLocallyConstant_windingNumber_of_closed hclosed hP hγ_cont hγ_diff hderiv_int
   obtain ⟨V, hV_open, hwV, hV_const⟩ := hlc.exists_open ⟨w, hoff⟩
-  have hVℂ : IsOpen (Subtype.val '' V) := hSopen.isOpenMap_subtype_val V hV_open
+  have hVℂ : IsOpen (Subtype.val '' V) :=
+    (isOpen_offCurve_of_continuousOn hγ_cont).isOpenMap_subtype_val V hV_open
   obtain ⟨ε₂, hε₂, hball₂⟩ := Metric.isOpen_iff.mp hVℂ w ⟨⟨w, hoff⟩, hwV, rfl⟩
   refine ⟨min ε₁ ε₂, lt_min hε₁ hε₂, fun w' hw' ↦ ⟨fun t ht ↦ ?_, ?_⟩⟩
   · exact sub_ne_zero.mp (norm_pos_iff.mp (lt_of_lt_of_le hε₁

--- a/TauCeti/Analysis/Contour/Winding/LocallyConstant.lean
+++ b/TauCeti/Analysis/Contour/Winding/LocallyConstant.lean
@@ -44,16 +44,6 @@ open scoped Topology
 
 namespace TauCeti.Contour
 
-/-- The set of points avoided by a curve continuous on `Set.uIcc a b` is open. -/
-theorem isOpen_offCurve_of_continuousOn {γ : ℝ → ℂ} {a b : ℝ}
-    (hγ_cont : ContinuousOn γ (uIcc a b)) :
-    IsOpen {z : ℂ | ∀ t ∈ uIcc a b, γ t ≠ z} := by
-  have hset : {z : ℂ | ∀ t ∈ uIcc a b, γ t ≠ z} = (γ '' uIcc a b)ᶜ := by
-    ext z
-    simp only [Set.mem_setOf_eq, Set.mem_compl_iff, Set.mem_image, not_exists, not_and, ne_eq]
-  rw [hset]
-  exact (isCompact_uIcc.image_of_continuousOn hγ_cont).isClosed.isOpen_compl
-
 /-- **The winding number is locally constant off a closed curve.** Let `γ` be a closed curve
 (`γ a = γ b`), differentiable off a countable set `P`, continuous on `Set.uIcc a b`, with
 interval-integrable derivative. Then, as a function of the point ranging over the complement of the

--- a/TauCeti/Analysis/Contour/Winding/LocallyConstant.lean
+++ b/TauCeti/Analysis/Contour/Winding/LocallyConstant.lean
@@ -117,7 +117,7 @@ theorem exists_ball_windingNumber_zero {γ : ℝ → ℂ} {w : ℂ} {a b : ℝ} 
   have hlc := isLocallyConstant_windingNumber_of_closed hclosed hP hγ_cont hγ_diff hderiv_int
   obtain ⟨V, hV_open, hwV, hV_const⟩ := hlc.exists_open ⟨w, hoff⟩
   have hVℂ : IsOpen (Subtype.val '' V) :=
-    (isOpen_offCurve_of_continuousOn hγ_cont).isOpenMap_subtype_val V hV_open
+    (isOpen_setOf_avoidance hγ_cont).isOpenMap_subtype_val V hV_open
   obtain ⟨ε₂, hε₂, hball₂⟩ := Metric.isOpen_iff.mp hVℂ w ⟨⟨w, hoff⟩, hwV, rfl⟩
   refine ⟨min ε₁ ε₂, lt_min hε₁ hε₂, fun w' hw' ↦ ⟨fun t ht ↦ ?_, ?_⟩⟩
   · exact sub_ne_zero.mp (norm_pos_iff.mp (lt_of_lt_of_le hε₁


### PR DESCRIPTION
This PR adds the two Layer-0 geometric facts the ContourIntegration roadmap records for a point off a closed curve: the generalized winding number is constant on each connected component of the complement, and it vanishes on the unbounded component. `windingNumber_eq_of_isPreconnected` shows the winding number agrees at any two points of a preconnected set that avoids the curve — the homotopy-invariance-within-a-component form of local constancy — by transporting the existing `isLocallyConstant_windingNumber_of_closed` to a preconnected subset through the open inclusion of the off-curve subtype. `windingNumber_eq_zero_of_unbounded` then pins the value on an unbounded preconnected off-curve set to `0`, extracting a far-field point of the component from `windingNumber_eventually_zero_cocompact`. Together these discharge the roadmap's Layer-0 clause that the winding number off the curve is "homotopy-invariant in ℂ ∖ C, and `0` on the unbounded component".

Target: `TauCetiRoadmap/ContourIntegration/README.md`, Layer 0 ("The classical case `z₀ ∉ C`: ... homotopy-invariant in `ℂ ∖ C`, and `0` on the unbounded component") and the worked example "`n` is `0` outside".

The development builds only on already-landed Tau Ceti results (`isLocallyConstant_windingNumber_of_closed`, `windingNumber_eventually_zero_cocompact`) and stock Mathlib topology (`IsPreconnected.preimage_of_isOpenMap`, `IsLocallyConstant.apply_eq_of_isPreconnected`, `Filter.mem_cocompact'`); it migrates and cleans the corresponding facts from the AINTLIB `LeanModularForms` `WindingArgDiff.lean` / `NullHomologous.lean` files, credited in the module docstring.

<!--tauceti-target:v1 {"focus":"ContourIntegration","id":"winding-number-zero-unbounded-component"}-->

🤖 Prepared with Claude Code
