### PR TITLE
feat: add bounded observable L2 bridge

### DIFF
--- a/TauCeti/MeasureTheory/Function/BoundedMemLp.lean
+++ b/TauCeti/MeasureTheory/Function/BoundedMemLp.lean
@@ -1,0 +1,41 @@
+module
+
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Claude
+-/
+public import Mathlib.MeasureTheory.Function.LpSeminorm.Basic
+
+/-!
+# `Lᵖ` membership of a bounded observable of an a.e.-measurable map
+
+On a finite measure space, a bounded measurable observable of an a.e.-measurable map lies in every
+`Lᵖ`.  This is the pointwise composition fact underlying the bounded-observable entry point to the
+L² lane of the Exchangeability roadmap; it carries no probabilistic content and applies to a single
+map.
+
+* `memLp_comp_of_bound` — if `f` is measurable, `g` is a.e. measurable, and `f ∘ g` is a.e. bounded,
+  then `fun ω => f (g ω)` is in `Lᵖ` for every exponent.
+
+Credit for the reused material goes to Mathlib's `MemLp.of_bound`.
+-/
+
+public section
+
+namespace TauCeti
+
+open MeasureTheory
+
+variable {Ω α E : Type*} [MeasurableSpace Ω] [MeasurableSpace α] [MeasurableSpace E]
+  [NormedAddCommGroup E] [BorelSpace E] [SecondCountableTopology E]
+
+/-- A bounded measurable observable of an a.e.-measurable map belongs to every `Lᵖ` on a finite
+measure space: if `f` is measurable, `g` is a.e. measurable, and `f ∘ g` is a.e. bounded, then
+`fun ω => f (g ω)` is in `Lᵖ` for every exponent. -/
+theorem memLp_comp_of_bound {μ : Measure Ω} [IsFiniteMeasure μ] {g : Ω → α} {f : α → E}
+    (hf : Measurable f) (hg : AEMeasurable g μ) (C : ℝ) (hbound : ∀ᵐ ω ∂μ, ‖f (g ω)‖ ≤ C)
+    (p : ENNReal) : MemLp (fun ω => f (g ω)) p μ :=
+  MemLp.of_bound (hf.comp_aemeasurable hg).aestronglyMeasurable C hbound
+
+end TauCeti

--- a/TauCeti/Probability/Exchangeability/L2/BoundedObservable.lean
+++ b/TauCeti/Probability/Exchangeability/L2/BoundedObservable.lean
@@ -14,8 +14,8 @@ contractable process therefore has the uniform covariance structure established 
 
 The result discharges the worked-example check in
 `TauCetiRoadmap/Exchangeability/README.md`, "In the real-valued L² lane, bounded observables give
-`MemLp 2` automatically."  The proof uses Mathlib's `MemLp.of_bound`; no material from
-`cameronfreer/exchangeability` is used.
+`MemLp 2` automatically."  Credit for the reused material goes to Mathlib's `MemLp.of_bound` and
+to the Tau Ceti covariance and map APIs; no material from `cameronfreer/exchangeability` is used.
 -/
 
 public section
@@ -42,8 +42,8 @@ theorem memLp_comp_process_of_bound {μ : Measure Ω} [IsFiniteMeasure μ]
     (ae_of_all μ fun ω => hf_bound (X i ω))
 
 /-- A bounded real-valued observable of a contractable process has uniform means, variances, and
-off-diagonal covariances.  This is `contractable_covariance_structure` with its coordinatewise
-`L²` hypothesis discharged by boundedness. -/
+off-diagonal covariances: the means agree across all coordinates, so do the variances, and every
+covariance of two distinct coordinates takes the same value. -/
 theorem Contractable.covariance_structure_map_values_of_bound {μ : Measure Ω}
     [IsFiniteMeasure μ] {X : ℕ → Ω → α} (hX_contractable : Contractable μ X)
     (hX_meas : ∀ i, AEMeasurable (X i) μ) {f : α → ℝ} (hf : Measurable f)

--- a/TauCeti/Probability/Exchangeability/L2/BoundedObservable.lean
+++ b/TauCeti/Probability/Exchangeability/L2/BoundedObservable.lean
@@ -2,20 +2,27 @@ module
 
 public import TauCeti.Probability.Exchangeability.L2.Covariance
 import TauCeti.Probability.Exchangeability.Map
+import TauCeti.MeasureTheory.Function.BoundedMemLp
 
 /-!
-# Bounded observables of processes in Lᵖ
+# Bounded observables of contractable processes in L²
 
 This file supplies the bounded-observable entry point to the L² lane of the Exchangeability
-roadmap.  On a finite measure space, composing every coordinate of a measurable process with a
-bounded measurable observable gives an `Lᵖ` process for every exponent.  At exponent two, a
-contractable process therefore has the uniform covariance structure established in
-`TauCeti.Probability.Exchangeability.L2.Covariance`.
+roadmap.  Applying a measurable real-valued observable coordinatewise to a contractable process
+preserves contractability, so whenever the mapped coordinates are square-integrable the process
+inherits the uniform covariance structure of
+`TauCeti.Probability.Exchangeability.L2.Covariance`: the means agree across all coordinates, so do
+the variances, and every off-diagonal covariance takes a single common value.
 
-The result discharges the worked-example check in
-`TauCetiRoadmap/Exchangeability/README.md`, "In the real-valued L² lane, bounded observables give
-`MemLp 2` automatically."  Credit for the reused material goes to Mathlib's `MemLp.of_bound` and
-to the Tau Ceti covariance and map APIs; no material from `cameronfreer/exchangeability` is used.
+* `Contractable.covariance_structure_comp` records this for any observable whose coordinates lie in
+  L².
+* `Contractable.covariance_structure_comp_of_bound` specializes it to a bounded observable, whose
+  coordinates are square-integrable automatically on a finite measure space.
+
+The bounded case discharges the worked-example check in `TauCetiRoadmap/Exchangeability/README.md`,
+"In the real-valued L² lane, bounded observables give `MemLp 2` automatically."  Credit for the
+reused material goes to the Tau Ceti covariance and map APIs; no material from
+`cameronfreer/exchangeability` is used.
 -/
 
 public section
@@ -28,35 +35,35 @@ namespace TauCeti
 
 namespace Probability
 
-variable {Ω α E : Type*} [MeasurableSpace Ω] [MeasurableSpace α] [MeasurableSpace E]
-  [NormedAddCommGroup E] [BorelSpace E] [SecondCountableTopology E]
+variable {Ω α : Type*} [MeasurableSpace Ω] [MeasurableSpace α]
 
-/-- A bounded measurable observable, applied coordinatewise to a measurable process on a finite
-measure space, belongs to every `Lᵖ`. -/
-theorem memLp_comp_process_of_bound {μ : Measure Ω} [IsFiniteMeasure μ]
-    {X : ℕ → Ω → α} {f : α → E} (hf : Measurable f) (hX : ∀ i, AEMeasurable (X i) μ)
-    (C : ℝ) (hf_bound : ∀ x, ‖f x‖ ≤ C) (p : ENNReal) :
-    ∀ i, MemLp (fun ω => f (X i ω)) p μ := by
-  intro i
-  exact MemLp.of_bound (hf.comp_aemeasurable (hX i)).aestronglyMeasurable C
-    (ae_of_all μ fun ω => hf_bound (X i ω))
-
-/-- A bounded real-valued observable of a contractable process has uniform means, variances, and
-off-diagonal covariances: the means agree across all coordinates, so do the variances, and every
-covariance of two distinct coordinates takes the same value. -/
-theorem Contractable.covariance_structure_map_values_of_bound {μ : Measure Ω}
-    [IsFiniteMeasure μ] {X : ℕ → Ω → α} (hX_contractable : Contractable μ X)
-    (hX_meas : ∀ i, AEMeasurable (X i) μ) {f : α → ℝ} (hf : Measurable f)
-    (C : ℝ) (hf_bound : ∀ x, |f x| ≤ C) :
+/-- A measurable real-valued observable with square-integrable coordinates, applied coordinatewise
+to a contractable process, gives uniform means, variances, and off-diagonal covariances: the means
+agree across all coordinates, so do the variances, and every covariance of two distinct coordinates
+takes the same value. -/
+theorem Contractable.covariance_structure_comp {μ : Measure Ω} {X : ℕ → Ω → α}
+    (hX_contractable : Contractable μ X) (hX_meas : ∀ i, AEMeasurable (X i) μ) {f : α → ℝ}
+    (hf : Measurable f) (hL2 : ∀ i, MemLp (fun ω => f (X i ω)) 2 μ) :
     (∀ i j, μ[fun ω => f (X i ω)] = μ[fun ω => f (X j ω)]) ∧
       (∀ i j, Var[fun ω => f (X i ω); μ] = Var[fun ω => f (X j ω); μ]) ∧
       (∀ i j k l, i ≠ j → k ≠ l →
         cov[fun ω => f (X i ω), fun ω => f (X j ω); μ] =
-          cov[fun ω => f (X k ω), fun ω => f (X l ω); μ]) := by
-  have hmap : Contractable μ (fun i ω => f (X i ω)) :=
-    hX_contractable.map_values hf hX_meas
-  exact contractable_covariance_structure hmap
-    (memLp_comp_process_of_bound hf hX_meas C (by simpa only [Real.norm_eq_abs] using hf_bound) 2)
+          cov[fun ω => f (X k ω), fun ω => f (X l ω); μ]) :=
+  contractable_covariance_structure (hX_contractable.map_values hf hX_meas) hL2
+
+/-- A bounded measurable real-valued observable of a contractable process has uniform means,
+variances, and off-diagonal covariances.  On a finite measure space the square-integrability of the
+mapped coordinates is automatic, so only an a.e. bound on each coordinate is required. -/
+theorem Contractable.covariance_structure_comp_of_bound {μ : Measure Ω} [IsFiniteMeasure μ]
+    {X : ℕ → Ω → α} (hX_contractable : Contractable μ X) (hX_meas : ∀ i, AEMeasurable (X i) μ)
+    {f : α → ℝ} (hf : Measurable f) (C : ℝ) (hf_bound : ∀ i, ∀ᵐ ω ∂μ, |f (X i ω)| ≤ C) :
+    (∀ i j, μ[fun ω => f (X i ω)] = μ[fun ω => f (X j ω)]) ∧
+      (∀ i j, Var[fun ω => f (X i ω); μ] = Var[fun ω => f (X j ω); μ]) ∧
+      (∀ i j k l, i ≠ j → k ≠ l →
+        cov[fun ω => f (X i ω), fun ω => f (X j ω); μ] =
+          cov[fun ω => f (X k ω), fun ω => f (X l ω); μ]) :=
+  hX_contractable.covariance_structure_comp hX_meas hf fun i =>
+    memLp_comp_of_bound hf (hX_meas i) C (by simpa only [Real.norm_eq_abs] using hf_bound i) 2
 
 end Probability
 

--- a/TauCeti/Probability/Exchangeability/L2/BoundedObservable.lean
+++ b/TauCeti/Probability/Exchangeability/L2/BoundedObservable.lean
@@ -1,0 +1,63 @@
+module
+
+public import TauCeti.Probability.Exchangeability.L2.Covariance
+import TauCeti.Probability.Exchangeability.Map
+
+/-!
+# Bounded observables of processes in Lᵖ
+
+This file supplies the bounded-observable entry point to the L² lane of the Exchangeability
+roadmap.  On a finite measure space, composing every coordinate of a measurable process with a
+bounded measurable observable gives an `Lᵖ` process for every exponent.  At exponent two, a
+contractable process therefore has the uniform covariance structure established in
+`TauCeti.Probability.Exchangeability.L2.Covariance`.
+
+The result discharges the worked-example check in
+`TauCetiRoadmap/Exchangeability/README.md`, "In the real-valued L² lane, bounded observables give
+`MemLp 2` automatically."  The proof uses Mathlib's `MemLp.of_bound`; no material from
+`cameronfreer/exchangeability` is used.
+-/
+
+public section
+
+noncomputable section
+
+open MeasureTheory ProbabilityTheory
+
+namespace TauCeti
+
+namespace Probability
+
+variable {Ω α E : Type*} [MeasurableSpace Ω] [MeasurableSpace α] [MeasurableSpace E]
+  [NormedAddCommGroup E] [BorelSpace E] [SecondCountableTopology E]
+
+/-- A bounded measurable observable, applied coordinatewise to a measurable process on a finite
+measure space, belongs to every `Lᵖ`. -/
+theorem memLp_comp_process_of_bound {μ : Measure Ω} [IsFiniteMeasure μ]
+    {X : ℕ → Ω → α} {f : α → E} (hf : Measurable f) (hX : ∀ i, AEMeasurable (X i) μ)
+    (C : ℝ) (hf_bound : ∀ x, ‖f x‖ ≤ C) (p : ENNReal) :
+    ∀ i, MemLp (fun ω => f (X i ω)) p μ := by
+  intro i
+  exact MemLp.of_bound (hf.comp_aemeasurable (hX i)).aestronglyMeasurable C
+    (ae_of_all μ fun ω => hf_bound (X i ω))
+
+/-- A bounded real-valued observable of a contractable process has uniform means, variances, and
+off-diagonal covariances.  This is `contractable_covariance_structure` with its coordinatewise
+`L²` hypothesis discharged by boundedness. -/
+theorem Contractable.covariance_structure_map_values_of_bound {μ : Measure Ω}
+    [IsFiniteMeasure μ] {X : ℕ → Ω → α} (hX_contractable : Contractable μ X)
+    (hX_meas : ∀ i, AEMeasurable (X i) μ) {f : α → ℝ} (hf : Measurable f)
+    (C : ℝ) (hf_bound : ∀ x, |f x| ≤ C) :
+    (∀ i j, μ[fun ω => f (X i ω)] = μ[fun ω => f (X j ω)]) ∧
+      (∀ i j, Var[fun ω => f (X i ω); μ] = Var[fun ω => f (X j ω); μ]) ∧
+      (∀ i j k l, i ≠ j → k ≠ l →
+        cov[fun ω => f (X i ω), fun ω => f (X j ω); μ] =
+          cov[fun ω => f (X k ω), fun ω => f (X l ω); μ]) := by
+  have hmap : Contractable μ (fun i ω => f (X i ω)) :=
+    hX_contractable.map_values hf hX_meas
+  exact contractable_covariance_structure hmap
+    (memLp_comp_process_of_bound hf hX_meas C (by simpa only [Real.norm_eq_abs] using hf_bound) 2)
+
+end Probability
+
+end TauCeti


### PR DESCRIPTION
This PR adds the bounded-observable entry point to the exchangeability L² lane: prove that applying a bounded measurable observable coordinatewise to a measurable process on a finite measure space produces `MemLp` coordinates at every exponent, then use the `p = 2` case to give a contractable mapped process uniform means, variances, and off-diagonal covariances. This directly advances `TauCetiRoadmap/Exchangeability/README.md`, Worked examples, specifically “In the real-valued L² lane, bounded observables give `MemLp 2` automatically.” It is the lowest-hanging uncovered Exchangeability target because the contractable covariance structure is already on `main`, while the roadmap's bounded-observable bridge to its `L²` hypothesis was absent and no open PR covers Exchangeability.

No Mathlib infrastructure is vendored. Reuse Mathlib's `MemLp.of_bound` and Tau Ceti's `Contractable.map_values` and `contractable_covariance_structure`; the module explicitly records that no material from `cameronfreer/exchangeability` is used.

`lake exe cache get` reports `No files to download` and `Already decompressed 8619 file(s)`. `lake build` reports `Build completed successfully (5165 jobs).` `lake exe axioms` reports `axioms: audited 10493 TauCeti declaration(s); all within the allowlist [propext, Classical.choice, Quot.sound].`

<!--tauceti-target:v1 {"focus":"Exchangeability","id":"bounded-observables-memlp-two"}-->

🤖 Prepared with Codex
