### PR TITLE
feat: add the L¹ form of Lévy's downward theorem

### DIFF
--- a/TauCeti/Probability/DeFinetti/TailFactorization.lean
+++ b/TauCeti/Probability/DeFinetti/TailFactorization.lean
@@ -60,26 +60,17 @@ lemma condExp_blockIndicatorProd_tailProcess_ae_eq_prod
       μ[Set.indicator (C i) (fun _ => (1 : ℝ)) ∘ X 0 | tailProcess X] ω) := by
   classical
   -- Reverse-martingale convergence: `μ[f | tailFamily X (m+1)] → μ[f | tailProcess X]` a.e.
-  have hconv : ∀ f : Ω → ℝ, Integrable f μ → ∀ᵐ ω ∂μ,
+  have hconv : ∀ f : Ω → ℝ, ∀ᵐ ω ∂μ,
       Tendsto (fun m => μ[f | tailFamily X (m + 1)] ω) atTop
         (𝓝 (μ[f | tailProcess X] ω)) := by
-    intro f hf
-    -- `tendsto_ae_condExp_iInf` takes the index-0 bound `𝔽 0 ≤ m₀` (antitonicity supplies the rest)
-    -- and the integrability of `f`.
+    intro f
+    -- `tendsto_ae_condExp_iInf` takes the index-0 bound `𝔽 0 ≤ m₀`; antitonicity supplies the rest.
     have h := tendsto_ae_condExp_iInf (μ := μ) (tailFamily_antitone X)
-      (tailFamily_le_ambient 0 fun k _ => hX_meas k) f hf
+      (tailFamily_le_ambient 0 fun k _ => hX_meas k) f
     rw [← tailProcess_eq_iInf_tailFamily X] at h
     filter_upwards [h] with ω hω using hω.comp (tendsto_add_atTop_nat 1)
-  -- The integrands are bounded indicators, hence integrable under the finite measure.
-  have hint_coord : ∀ i : Fin r, Integrable (Set.indicator (C i) (fun _ => (1 : ℝ)) ∘ X 0) μ := by
-    intro i
-    have heq : (Set.indicator (C i) (fun _ => (1 : ℝ)) ∘ X 0)
-        = (X 0 ⁻¹' C i).indicator (fun _ => (1 : ℝ)) := by
-      ext ω; simp only [Function.comp_apply, Set.indicator, Set.mem_preimage]
-    rw [heq]; exact (integrable_const (1 : ℝ)).indicator ((hX_meas 0) (hC i))
   -- LHS converges to the tail conditional expectation of the block.
   have h_lhs := hconv (blockIndicatorProd X (fun i : Fin r => (i : ℕ)) C)
-    (integrable_blockIndicatorProd (fun i => (hX_meas _).aemeasurable) hC)
   -- RHS: the finite product of the convergent single-coordinate factors converges.
   have h_rhs : ∀ᵐ ω ∂μ,
       Tendsto (fun m => ∏ i : Fin r,
@@ -90,7 +81,7 @@ lemma condExp_blockIndicatorProd_tailProcess_ae_eq_prod
         Tendsto (fun m => μ[Set.indicator (C i) (fun _ => (1 : ℝ)) ∘ X 0
             | tailFamily X (m + 1)] ω) atTop
           (𝓝 (μ[Set.indicator (C i) (fun _ => (1 : ℝ)) ∘ X 0 | tailProcess X] ω)) :=
-      ae_all_iff.mpr fun i => hconv _ (hint_coord i)
+      ae_all_iff.mpr fun i => hconv _
     filter_upwards [hfac] with ω hω using tendsto_finsetProd _ fun i _ => hω i
   -- Equality of the two sequences at each finite level `m ≥ r`.
   have h_fact : ∀ᵐ ω ∂μ, ∀ m, r ≤ m →

--- a/TauCeti/Probability/Martingale/Convergence.lean
+++ b/TauCeti/Probability/Martingale/Convergence.lean
@@ -145,18 +145,23 @@ theorem tendsto_ae_condExp_iInf
 /-- **Conditional expectation converges in `L¹` along a decreasing filtration (Lévy's downward
 theorem, `L¹` form).**
 
-For a decreasing filtration `𝔽ₙ` and integrable `f`, the sequence `μ[f | 𝔽ₙ]` converges in `L¹`
-to `μ[f | ⨅ₙ 𝔽ₙ]`. This upgrades the almost-everywhere statement `tendsto_ae_condExp_iInf`: the
-conditional expectations `μ[f | 𝔽ₙ]` of a fixed integrable function form a uniformly integrable
-family, so their a.e. convergence is convergence in `L¹` by Vitali's theorem. It is the downward
-analogue of Mathlib's upward `MeasureTheory.tendsto_eLpNorm_condExp`. -/
+For a decreasing filtration `𝔽ₙ`, the sequence `μ[f | 𝔽ₙ]` converges in `L¹` to `μ[f | ⨅ₙ 𝔽ₙ]`.
+This upgrades the almost-everywhere statement `tendsto_ae_condExp_iInf`: the conditional
+expectations `μ[f | 𝔽ₙ]` of a fixed integrable function form a uniformly integrable family, so
+their a.e. convergence is convergence in `L¹` by Vitali's theorem. As in Mathlib's upward
+`MeasureTheory.tendsto_eLpNorm_condExp`, which this is the downward analogue of, no integrability
+hypothesis is needed: `condExp` vanishes on non-integrable arguments, so the statement is trivial
+there. -/
 theorem tendsto_eLpNorm_condExp_iInf
     [IsFiniteMeasure μ]
     {𝔽 : ℕ → MeasurableSpace Ω}
     (h_filtration : Antitone 𝔽)
     (h_le0 : 𝔽 0 ≤ (inferInstance : MeasurableSpace Ω))
-    (f : Ω → ℝ) (h_f_int : Integrable f μ) :
-    Tendsto (fun n => eLpNorm (μ[f | 𝔽 n] - μ[f | ⨅ n, 𝔽 n]) 1 μ) atTop (𝓝 0) :=
-  (tendsto_ae_and_eLpNorm_condExp_iInf h_filtration h_le0 f h_f_int).2
+    (f : Ω → ℝ) :
+    Tendsto (fun n => eLpNorm (μ[f | 𝔽 n] - μ[f | ⨅ n, 𝔽 n]) 1 μ) atTop (𝓝 0) := by
+  by_cases h_f_int : Integrable f μ
+  · exact (tendsto_ae_and_eLpNorm_condExp_iInf h_filtration h_le0 f h_f_int).2
+  · -- Every term is `eLpNorm (0 - 0) 1 μ = 0`, since `condExp` is `0` on non-integrable arguments.
+    simp [condExp_of_not_integrable h_f_int]
 
 end MeasureTheory

--- a/TauCeti/Probability/Martingale/Convergence.lean
+++ b/TauCeti/Probability/Martingale/Convergence.lean
@@ -24,6 +24,12 @@ result (`Martingale/AntitoneLimit.lean`) all feed into `tendsto_ae_condExp_iInf`
   sequence `μ[f | 𝔽 n]` converges a.e. to `μ[f | ⨅ n, 𝔽 n]` (the reverse-martingale limit). This is
   the roadmap Layer-4 target, spelled in the Mathlib convergence-API grammar (conclusion-first)
   required by the naming convention.
+- `tendsto_eLpNorm_condExp_iInf`: the L¹ form of the same theorem — the convergence also holds in
+  `L¹`, i.e. `eLpNorm (μ[f | 𝔽 n] - μ[f | ⨅ n, 𝔽 n]) 1 μ → 0`. This is the follow-up Layer-4
+  target and the form most downstream analytic uses want; it mirrors Mathlib's upward
+  `MeasureTheory.tendsto_eLpNorm_condExp`.
+- `tendsto_integral_norm_condExp_iInf`: the same L¹ statement written as convergence of the
+  concrete `L¹` distance `∫ ω, ‖μ[f | 𝔽 n] ω - μ[f | ⨅ n, 𝔽 n] ω‖ ∂μ → 0`.
 
 ## References
 
@@ -112,5 +118,53 @@ theorem tendsto_ae_condExp_iInf
   filter_upwards [h_tendsto, hXlim_eq] with ω h_tend h_eq
   rw [h_eq]
   exact h_tend
+
+/-- **Conditional expectation converges in `L¹` along a decreasing filtration (Lévy's downward
+theorem, `L¹` form).**
+
+For a decreasing filtration `𝔽ₙ` and integrable `f`, the sequence `μ[f | 𝔽ₙ]` converges in `L¹`
+to `μ[f | ⨅ₙ 𝔽ₙ]`. This upgrades the almost-everywhere statement `tendsto_ae_condExp_iInf`: the
+conditional expectations `μ[f | 𝔽ₙ]` of a fixed integrable function form a uniformly integrable
+family, so their a.e. convergence is convergence in `L¹` by Vitali's theorem. It is the downward
+analogue of Mathlib's upward `MeasureTheory.tendsto_eLpNorm_condExp`. -/
+theorem tendsto_eLpNorm_condExp_iInf
+    [IsFiniteMeasure μ]
+    {𝔽 : ℕ → MeasurableSpace Ω}
+    (h_filtration : Antitone 𝔽)
+    (h_le0 : 𝔽 0 ≤ (inferInstance : MeasurableSpace Ω))
+    (f : Ω → ℝ) (h_f_int : Integrable f μ) :
+    Tendsto (fun n => eLpNorm (μ[f | 𝔽 n] - μ[f | ⨅ n, 𝔽 n]) 1 μ) atTop (𝓝 0) := by
+  -- Antitonicity upgrades `𝔽 0 ≤ m₀` to `𝔽 n ≤ m₀`, as needed by the uniform-integrability input.
+  have h_le : ∀ n, 𝔽 n ≤ (inferInstance : MeasurableSpace Ω) :=
+    fun n => (h_filtration (Nat.zero_le n)).trans h_le0
+  -- Vitali: a.e. convergence of a uniformly integrable sequence is `L¹` convergence.
+  exact tendsto_Lp_finite_of_tendsto_ae (hp := le_refl 1) (hp' := ENNReal.one_ne_top)
+    (fun _ => integrable_condExp.aestronglyMeasurable)
+    (memLp_one_iff_integrable.2 integrable_condExp)
+    (h_f_int.uniformIntegrable_condExp h_le).unifIntegrable
+    (tendsto_ae_condExp_iInf h_filtration h_le0 f h_f_int)
+
+/-- **Conditional expectation converges in `L¹` along a decreasing filtration**, phrased as
+convergence of the concrete `L¹` distance `∫ ω, ‖μ[f | 𝔽ₙ] ω - μ[f | ⨅ₙ 𝔽ₙ] ω‖ ∂μ` to `0`. This
+is `tendsto_eLpNorm_condExp_iInf` rewritten through `∫ ‖g‖ = (eLpNorm g 1 μ).toReal`. -/
+theorem tendsto_integral_norm_condExp_iInf
+    [IsFiniteMeasure μ]
+    {𝔽 : ℕ → MeasurableSpace Ω}
+    (h_filtration : Antitone 𝔽)
+    (h_le0 : 𝔽 0 ≤ (inferInstance : MeasurableSpace Ω))
+    (f : Ω → ℝ) (h_f_int : Integrable f μ) :
+    Tendsto (fun n => ∫ ω, ‖μ[f | 𝔽 n] ω - μ[f | ⨅ n, 𝔽 n] ω‖ ∂μ) atTop (𝓝 0) := by
+  have h_int : ∀ n, Integrable (μ[f | 𝔽 n] - μ[f | ⨅ n, 𝔽 n]) μ :=
+    fun _ => integrable_condExp.sub integrable_condExp
+  have h_eq : ∀ n, ∫ ω, ‖μ[f | 𝔽 n] ω - μ[f | ⨅ n, 𝔽 n] ω‖ ∂μ
+      = (eLpNorm (μ[f | 𝔽 n] - μ[f | ⨅ n, 𝔽 n]) 1 μ).toReal := by
+    intro n
+    have hpi : ∫ ω, ‖μ[f | 𝔽 n] ω - μ[f | ⨅ n, 𝔽 n] ω‖ ∂μ
+        = ∫ ω, ‖(μ[f | 𝔽 n] - μ[f | ⨅ n, 𝔽 n]) ω‖ ∂μ := rfl
+    rw [hpi, integral_norm_eq_lintegral_enorm (h_int n).aestronglyMeasurable,
+      eLpNorm_one_eq_lintegral_enorm]
+  simp_rw [h_eq]
+  simpa [Function.comp_def] using (ENNReal.tendsto_toReal ENNReal.zero_ne_top).comp
+    (tendsto_eLpNorm_condExp_iInf h_filtration h_le0 f h_f_int)
 
 end MeasureTheory

--- a/TauCeti/Probability/Martingale/Convergence.lean
+++ b/TauCeti/Probability/Martingale/Convergence.lean
@@ -53,20 +53,24 @@ namespace MeasureTheory
 
 variable {Ω : Type*} [MeasurableSpace Ω] {μ : Measure Ω}
 
-/-- **Conditional expectation converges along a decreasing filtration (Lévy's downward theorem).**
+/-- Lévy's downward theorem, proving the almost-everywhere and `L¹` forms together.
 
-For a decreasing filtration `𝔽ₙ` and integrable `f`, the sequence `μ[f | 𝔽ₙ]` converges almost
-surely to `μ[f | ⨅ₙ 𝔽ₙ]` — the reverse-martingale (Lévy downward) limit. -/
-theorem tendsto_ae_condExp_iInf
+The `L¹` convergence is not an afterthought of the a.e. convergence: the Vitali step that upgrades
+a.e. convergence of the uniformly integrable family `μ[f | 𝔽ₙ]` to `L¹` convergence is what
+identifies the a.e. limit as `μ[f | ⨅ₙ 𝔽ₙ]` in the first place. Proving the two conclusions in one
+pass avoids running that step twice; the public `tendsto_ae_condExp_iInf` and
+`tendsto_eLpNorm_condExp_iInf` are its two projections. -/
+private theorem tendsto_ae_and_eLpNorm_condExp_iInf
     [IsFiniteMeasure μ]
     {𝔽 : ℕ → MeasurableSpace Ω}
     (h_filtration : Antitone 𝔽)
     (h_le0 : 𝔽 0 ≤ (inferInstance : MeasurableSpace Ω))
     (f : Ω → ℝ) (h_f_int : Integrable f μ) :
-    ∀ᵐ ω ∂μ, Tendsto
-      (fun n => μ[f | 𝔽 n] ω)
-      atTop
-      (𝓝 (μ[f | ⨅ n, 𝔽 n] ω)) := by
+    (∀ᵐ ω ∂μ, Tendsto
+        (fun n => μ[f | 𝔽 n] ω)
+        atTop
+        (𝓝 (μ[f | ⨅ n, 𝔽 n] ω))) ∧
+      Tendsto (fun n => eLpNorm (μ[f | 𝔽 n] - μ[f | ⨅ n, 𝔽 n]) 1 μ) atTop (𝓝 0) := by
   classical
   -- Only `𝔽 0 ≤ m₀` is assumed; antitonicity upgrades it to `𝔽 n ≤ m₀` for every `n`.
   have h_le : ∀ n, 𝔽 n ≤ (inferInstance : MeasurableSpace Ω) :=
@@ -97,25 +101,46 @@ theorem tendsto_ae_condExp_iInf
     fun n => condExp_condExp_of_le (iInf_le 𝔽 n) (h_le n)
   have hiInf_le : (⨅ n, 𝔽 n) ≤ (inferInstance : MeasurableSpace Ω) :=
     le_trans (iInf_le 𝔽 0) (h_le 0)
-  set Xn : ℕ → Ω → ℝ := fun n => μ[f | 𝔽 n] with hXn_def
-  -- Rephrase the L¹ convergence with the `Xn` abbreviation.
-  have hL1_conv_Xn : Tendsto (fun n => eLpNorm (Xlim - Xn n) 1 μ) atTop (𝓝 0) := by
-    simpa [hXn_def, eLpNorm_sub_comm] using hL1_conv
+  -- Rephrase the L¹ convergence with the subtraction in the other order.
+  have hL1_conv' : Tendsto (fun n => eLpNorm (Xlim - μ[f | 𝔽 n]) 1 μ) atTop (𝓝 0) := by
+    simpa [eLpNorm_sub_comm] using hL1_conv
   -- Identify `μ[Xlim | ⨅ n, 𝔽 n]` with `μ[f | ⨅ n, 𝔽 n]` by L¹-continuity of conditional
   -- expectation (the tower property gives `μ[Xn n | ⨅ n, 𝔽 n] =ᵐ μ[f | ⨅ n, 𝔽 n]`).
   have hCE_eqY : μ[Xlim | ⨅ n, 𝔽 n] =ᵐ[μ] μ[f | ⨅ n, 𝔽 n] :=
     condExp_ae_eq_of_forall_condExp_ae_eq_of_tendsto_eLpNorm hXlimint
-      (fun _ => integrable_condExp) h_tower hL1_conv_Xn
+      (fun _ => integrable_condExp) h_tower hL1_conv'
   -- `Xlim` is `AEStronglyMeasurable[⨅ n, 𝔽 n]` (a.e. limit of `⨅ n, 𝔽 n`-measurable functions), so
   -- `μ[Xlim | ⨅ n, 𝔽 n] =ᵐ Xlim`; combined with `hCE_eqY` this identifies `μ[f | ⨅ n, 𝔽 n]`.
   have hXlim_eq : μ[f | ⨅ n, 𝔽 n] =ᵐ[μ] Xlim := by
     have hXlim_condExp_self : μ[Xlim | ⨅ n, 𝔽 n] =ᵐ[μ] Xlim :=
       condExp_of_aestronglyMeasurable' hiInf_le hXlim_iInf_meas hXlimint
     exact hCE_eqY.symm.trans hXlim_condExp_self
-  -- Combine `h_tendsto : μ[f | 𝔽 n] → Xlim` with `hXlim_eq : μ[f | ⨅ n, 𝔽 n] =ᵐ Xlim`.
-  filter_upwards [h_tendsto, hXlim_eq] with ω h_tend h_eq
-  rw [h_eq]
-  exact h_tend
+  refine ⟨?_, ?_⟩
+  · -- Combine `h_tendsto : μ[f | 𝔽 n] → Xlim` with `hXlim_eq : μ[f | ⨅ n, 𝔽 n] =ᵐ Xlim`.
+    filter_upwards [h_tendsto, hXlim_eq] with ω h_tend h_eq
+    rw [h_eq]
+    exact h_tend
+  · -- Transport the L¹ convergence `μ[f | 𝔽 n] → Xlim` along `hXlim_eq`.
+    have h_eLp : ∀ n, eLpNorm (μ[f | 𝔽 n] - μ[f | ⨅ n, 𝔽 n]) 1 μ
+        = eLpNorm (μ[f | 𝔽 n] - Xlim) 1 μ := fun n =>
+      eLpNorm_congr_ae (by filter_upwards [hXlim_eq] with ω h_eq using by simp [h_eq])
+    simpa only [h_eLp] using hL1_conv
+
+/-- **Conditional expectation converges along a decreasing filtration (Lévy's downward theorem).**
+
+For a decreasing filtration `𝔽ₙ` and integrable `f`, the sequence `μ[f | 𝔽ₙ]` converges almost
+surely to `μ[f | ⨅ₙ 𝔽ₙ]` — the reverse-martingale (Lévy downward) limit. -/
+theorem tendsto_ae_condExp_iInf
+    [IsFiniteMeasure μ]
+    {𝔽 : ℕ → MeasurableSpace Ω}
+    (h_filtration : Antitone 𝔽)
+    (h_le0 : 𝔽 0 ≤ (inferInstance : MeasurableSpace Ω))
+    (f : Ω → ℝ) (h_f_int : Integrable f μ) :
+    ∀ᵐ ω ∂μ, Tendsto
+      (fun n => μ[f | 𝔽 n] ω)
+      atTop
+      (𝓝 (μ[f | ⨅ n, 𝔽 n] ω)) :=
+  (tendsto_ae_and_eLpNorm_condExp_iInf h_filtration h_le0 f h_f_int).1
 
 /-- **Conditional expectation converges in `L¹` along a decreasing filtration (Lévy's downward
 theorem, `L¹` form).**
@@ -131,15 +156,7 @@ theorem tendsto_eLpNorm_condExp_iInf
     (h_filtration : Antitone 𝔽)
     (h_le0 : 𝔽 0 ≤ (inferInstance : MeasurableSpace Ω))
     (f : Ω → ℝ) (h_f_int : Integrable f μ) :
-    Tendsto (fun n => eLpNorm (μ[f | 𝔽 n] - μ[f | ⨅ n, 𝔽 n]) 1 μ) atTop (𝓝 0) := by
-  -- Antitonicity upgrades `𝔽 0 ≤ m₀` to `𝔽 n ≤ m₀`, as needed by the uniform-integrability input.
-  have h_le : ∀ n, 𝔽 n ≤ (inferInstance : MeasurableSpace Ω) :=
-    fun n => (h_filtration (Nat.zero_le n)).trans h_le0
-  -- Vitali: a.e. convergence of a uniformly integrable sequence is `L¹` convergence.
-  exact tendsto_Lp_finite_of_tendsto_ae (hp := le_refl 1) (hp' := ENNReal.one_ne_top)
-    (fun _ => integrable_condExp.aestronglyMeasurable)
-    (memLp_one_iff_integrable.2 integrable_condExp)
-    (h_f_int.uniformIntegrable_condExp h_le).unifIntegrable
-    (tendsto_ae_condExp_iInf h_filtration h_le0 f h_f_int)
+    Tendsto (fun n => eLpNorm (μ[f | 𝔽 n] - μ[f | ⨅ n, 𝔽 n]) 1 μ) atTop (𝓝 0) :=
+  (tendsto_ae_and_eLpNorm_condExp_iInf h_filtration h_le0 f h_f_int).2
 
 end MeasureTheory

--- a/TauCeti/Probability/Martingale/Convergence.lean
+++ b/TauCeti/Probability/Martingale/Convergence.lean
@@ -20,8 +20,8 @@ result (`Martingale/AntitoneLimit.lean`) all feed into `tendsto_ae_condExp_iInf`
 
 ## Main results
 
-- `tendsto_ae_condExp_iInf`: Lévy's downward theorem — for antitone `𝔽` and integrable `f`, the
-  sequence `μ[f | 𝔽 n]` converges a.e. to `μ[f | ⨅ n, 𝔽 n]` (the reverse-martingale limit). This is
+- `tendsto_ae_condExp_iInf`: Lévy's downward theorem — for antitone `𝔽`, the sequence
+  `μ[f | 𝔽 n]` converges a.e. to `μ[f | ⨅ n, 𝔽 n]` (the reverse-martingale limit). This is
   the roadmap Layer-4 target, spelled in the Mathlib convergence-API grammar (conclusion-first)
   required by the naming convention.
 - `tendsto_eLpNorm_condExp_iInf`: the L¹ form of the same theorem — the convergence also holds in
@@ -65,13 +65,18 @@ private theorem tendsto_ae_and_eLpNorm_condExp_iInf
     {𝔽 : ℕ → MeasurableSpace Ω}
     (h_filtration : Antitone 𝔽)
     (h_le0 : 𝔽 0 ≤ (inferInstance : MeasurableSpace Ω))
-    (f : Ω → ℝ) (h_f_int : Integrable f μ) :
+    (f : Ω → ℝ) :
     (∀ᵐ ω ∂μ, Tendsto
         (fun n => μ[f | 𝔽 n] ω)
         atTop
         (𝓝 (μ[f | ⨅ n, 𝔽 n] ω))) ∧
       Tendsto (fun n => eLpNorm (μ[f | 𝔽 n] - μ[f | ⨅ n, 𝔽 n]) 1 μ) atTop (𝓝 0) := by
   classical
+  -- No integrability hypothesis is needed: `condExp` vanishes on non-integrable arguments, so
+  -- every term of both sequences is `0` and both conclusions are trivial there.
+  by_cases h_f_int : Integrable f μ
+  swap
+  · simp [condExp_of_not_integrable h_f_int]
   -- Only `𝔽 0 ≤ m₀` is assumed; antitonicity upgrades it to `𝔽 n ≤ m₀` for every `n`.
   have h_le : ∀ n, 𝔽 n ≤ (inferInstance : MeasurableSpace Ω) :=
     fun n => (h_filtration (Nat.zero_le n)).trans h_le0
@@ -128,19 +133,21 @@ private theorem tendsto_ae_and_eLpNorm_condExp_iInf
 
 /-- **Conditional expectation converges along a decreasing filtration (Lévy's downward theorem).**
 
-For a decreasing filtration `𝔽ₙ` and integrable `f`, the sequence `μ[f | 𝔽ₙ]` converges almost
-surely to `μ[f | ⨅ₙ 𝔽ₙ]` — the reverse-martingale (Lévy downward) limit. -/
+For a decreasing filtration `𝔽ₙ`, the sequence `μ[f | 𝔽ₙ]` converges almost surely to
+`μ[f | ⨅ₙ 𝔽ₙ]` — the reverse-martingale (Lévy downward) limit. As in Mathlib's upward
+`MeasureTheory.tendsto_ae_condExp`, no integrability hypothesis is needed: `condExp` vanishes on
+non-integrable arguments, so the statement is trivial there. -/
 theorem tendsto_ae_condExp_iInf
     [IsFiniteMeasure μ]
     {𝔽 : ℕ → MeasurableSpace Ω}
     (h_filtration : Antitone 𝔽)
     (h_le0 : 𝔽 0 ≤ (inferInstance : MeasurableSpace Ω))
-    (f : Ω → ℝ) (h_f_int : Integrable f μ) :
+    (f : Ω → ℝ) :
     ∀ᵐ ω ∂μ, Tendsto
       (fun n => μ[f | 𝔽 n] ω)
       atTop
       (𝓝 (μ[f | ⨅ n, 𝔽 n] ω)) :=
-  (tendsto_ae_and_eLpNorm_condExp_iInf h_filtration h_le0 f h_f_int).1
+  (tendsto_ae_and_eLpNorm_condExp_iInf h_filtration h_le0 f).1
 
 /-- **Conditional expectation converges in `L¹` along a decreasing filtration (Lévy's downward
 theorem, `L¹` form).**
@@ -158,10 +165,7 @@ theorem tendsto_eLpNorm_condExp_iInf
     (h_filtration : Antitone 𝔽)
     (h_le0 : 𝔽 0 ≤ (inferInstance : MeasurableSpace Ω))
     (f : Ω → ℝ) :
-    Tendsto (fun n => eLpNorm (μ[f | 𝔽 n] - μ[f | ⨅ n, 𝔽 n]) 1 μ) atTop (𝓝 0) := by
-  by_cases h_f_int : Integrable f μ
-  · exact (tendsto_ae_and_eLpNorm_condExp_iInf h_filtration h_le0 f h_f_int).2
-  · -- Every term is `eLpNorm (0 - 0) 1 μ = 0`, since `condExp` is `0` on non-integrable arguments.
-    simp [condExp_of_not_integrable h_f_int]
+    Tendsto (fun n => eLpNorm (μ[f | 𝔽 n] - μ[f | ⨅ n, 𝔽 n]) 1 μ) atTop (𝓝 0) :=
+  (tendsto_ae_and_eLpNorm_condExp_iInf h_filtration h_le0 f).2
 
 end MeasureTheory

--- a/TauCeti/Probability/Martingale/Convergence.lean
+++ b/TauCeti/Probability/Martingale/Convergence.lean
@@ -28,8 +28,6 @@ result (`Martingale/AntitoneLimit.lean`) all feed into `tendsto_ae_condExp_iInf`
   `L¹`, i.e. `eLpNorm (μ[f | 𝔽 n] - μ[f | ⨅ n, 𝔽 n]) 1 μ → 0`. This is the follow-up Layer-4
   target and the form most downstream analytic uses want; it mirrors Mathlib's upward
   `MeasureTheory.tendsto_eLpNorm_condExp`.
-- `tendsto_integral_norm_condExp_iInf`: the same L¹ statement written as convergence of the
-  concrete `L¹` distance `∫ ω, ‖μ[f | 𝔽 n] ω - μ[f | ⨅ n, 𝔽 n] ω‖ ∂μ → 0`.
 
 ## References
 
@@ -143,28 +141,5 @@ theorem tendsto_eLpNorm_condExp_iInf
     (memLp_one_iff_integrable.2 integrable_condExp)
     (h_f_int.uniformIntegrable_condExp h_le).unifIntegrable
     (tendsto_ae_condExp_iInf h_filtration h_le0 f h_f_int)
-
-/-- **Conditional expectation converges in `L¹` along a decreasing filtration**, phrased as
-convergence of the concrete `L¹` distance `∫ ω, ‖μ[f | 𝔽ₙ] ω - μ[f | ⨅ₙ 𝔽ₙ] ω‖ ∂μ` to `0`. This
-is `tendsto_eLpNorm_condExp_iInf` rewritten through `∫ ‖g‖ = (eLpNorm g 1 μ).toReal`. -/
-theorem tendsto_integral_norm_condExp_iInf
-    [IsFiniteMeasure μ]
-    {𝔽 : ℕ → MeasurableSpace Ω}
-    (h_filtration : Antitone 𝔽)
-    (h_le0 : 𝔽 0 ≤ (inferInstance : MeasurableSpace Ω))
-    (f : Ω → ℝ) (h_f_int : Integrable f μ) :
-    Tendsto (fun n => ∫ ω, ‖μ[f | 𝔽 n] ω - μ[f | ⨅ n, 𝔽 n] ω‖ ∂μ) atTop (𝓝 0) := by
-  have h_int : ∀ n, Integrable (μ[f | 𝔽 n] - μ[f | ⨅ n, 𝔽 n]) μ :=
-    fun _ => integrable_condExp.sub integrable_condExp
-  have h_eq : ∀ n, ∫ ω, ‖μ[f | 𝔽 n] ω - μ[f | ⨅ n, 𝔽 n] ω‖ ∂μ
-      = (eLpNorm (μ[f | 𝔽 n] - μ[f | ⨅ n, 𝔽 n]) 1 μ).toReal := by
-    intro n
-    have hpi : ∫ ω, ‖μ[f | 𝔽 n] ω - μ[f | ⨅ n, 𝔽 n] ω‖ ∂μ
-        = ∫ ω, ‖(μ[f | 𝔽 n] - μ[f | ⨅ n, 𝔽 n]) ω‖ ∂μ := rfl
-    rw [hpi, integral_norm_eq_lintegral_enorm (h_int n).aestronglyMeasurable,
-      eLpNorm_one_eq_lintegral_enorm]
-  simp_rw [h_eq]
-  simpa [Function.comp_def] using (ENNReal.tendsto_toReal ENNReal.zero_ne_top).comp
-    (tendsto_eLpNorm_condExp_iInf h_filtration h_le0 f h_f_int)
 
 end MeasureTheory

--- a/TauCeti/Probability/Martingale/LevyDownwardEventuallyConst.lean
+++ b/TauCeti/Probability/Martingale/LevyDownwardEventuallyConst.lean
@@ -91,9 +91,9 @@ value the sequence already reaches by the elementary
 theorem tendsto_ae_condExp_of_eventually_const [IsFiniteMeasure μ]
     (h_anti : Antitone 𝔽) (h_le0 : 𝔽 0 ≤ (inferInstance : MeasurableSpace Ω))
     {N : ℕ} (h_const : ∀ n, N ≤ n → 𝔽 n = 𝔽 N)
-    (f : Ω → ℝ) (h_int : Integrable f μ) :
+    (f : Ω → ℝ) :
     ∀ᵐ ω ∂μ, Tendsto (fun n => μ[f | 𝔽 n] ω) atTop (𝓝 (μ[f | 𝔽 N] ω)) := by
-  have h := tendsto_ae_condExp_iInf h_anti h_le0 f h_int
+  have h := tendsto_ae_condExp_iInf (μ := μ) h_anti h_le0 f
   rwa [condExp_iInf_eq_of_eventually_const h_anti h_const f] at h
 
 end Probability


### PR DESCRIPTION
This PR adds the L¹ convergence form of Lévy's downward theorem for conditional expectations along a decreasing filtration, the follow-up Layer 4 target called for in `TauCetiRoadmap/Exchangeability/README.md` (Layer 4: "The L¹ and Lᵖ convergence forms ... are follow-up Layer 4 targets; the L¹ form is what most uses want"). The a.e. statement `tendsto_ae_condExp_iInf` already lives in `TauCeti/Probability/Martingale/Convergence.lean`; this PR upgrades it to `L¹`.

It adds one theorem, beside the a.e. version and mirroring the way Mathlib co-locates the a.e. and L¹ forms of the upward Lévy theorem in `Mathlib/Probability/Martingale/Convergence.lean`:

- `tendsto_eLpNorm_condExp_iInf`: for antitone `𝔽`, `eLpNorm (μ[f | 𝔽 n] - μ[f | ⨅ n, 𝔽 n]) 1 μ → 0`. As in Mathlib's upward form, no integrability hypothesis is needed: `condExp` vanishes on non-integrable arguments, so the statement is trivial there. This is the downward analogue of Mathlib's upward `MeasureTheory.tendsto_eLpNorm_condExp`.

The L¹ conclusion is not a separate derivation: the uniform-integrability + Vitali step that upgrades a.e. convergence to L¹ convergence (`MeasureTheory.Integrable.uniformIntegrable_condExp` and `MeasureTheory.tendsto_Lp_finite_of_tendsto_ae`) is already what identifies the a.e. limit as `μ[f | ⨅ n, 𝔽 n]` inside the existing proof. So this PR restates that proof as a private lemma proving the a.e. and L¹ conclusions together, and both `tendsto_ae_condExp_iInf` and the new `tendsto_eLpNorm_condExp_iInf` become its two projections. No new Mathlib dependency is introduced.

The enclosing file is adapted from `cameronfreer/exchangeability`; these additions are new and Mathlib-shaped for eventual upstreaming.

`lake build` is green and `lake exe axioms` reports all declarations within the allowlist `[propext, Classical.choice, Quot.sound]`.

<!--tauceti-target:v1 {"focus":"Exchangeability","id":"levy-downward-l1-condexp-convergence"}-->

🤖 Prepared with Claude Code

