### PR TITLE
feat: reparametrization invariance of contour integrals and winding numbers

### DIFF
--- a/TauCeti/Analysis/Contour/Curve/Reparam.lean
+++ b/TauCeti/Analysis/Contour/Curve/Reparam.lean
@@ -12,8 +12,8 @@ public import Mathlib.Analysis.Complex.Basic
 # Reparametrization invariance of the contour integral
 
 A contour integral `∫ t in a..b, deriv γ t • f (γ t)` is unchanged when the curve `γ` is
-precomposed with a `C¹` change of parameter `φ`, the parameter interval `[[c, d]]` being replaced
-by `[[φ c, φ d]]`. This file proves that invariance, together with the chain rule for the
+precomposed with a `C¹` change of parameter `φ`, the parameter interval `[[a, b]]` being replaced
+by `[[φ a, φ b]]`. This file proves that invariance, together with the chain rule for the
 reparametrized curve that it rests on.
 
 The proof is the interval-integral change-of-variables formula
@@ -21,22 +21,30 @@ The proof is the interval-integral change-of-variables formula
 `g u = deriv γ u • f (γ u)`, together with the chain rule
 `deriv (γ ∘ φ) t = φ' t • deriv γ (φ t)`.
 
-Two design points are worth flagging.
+Three design points are worth flagging.
 
-* The regularity hypotheses are placed on the **image** `φ '' [[c, d]]`, not on `[[φ c, φ d]]`.
+* Regularity is asked for as **ambient** pointwise derivatives, not `ContDiffOn`: `φ` satisfies
+  `HasDerivAt φ (φ' t) t` at each `t ∈ [[a, b]]` and `γ` satisfies `DifferentiableAt ℝ γ` on the
+  image, both two-sided in the ambient sense rather than merely within the set. This matches the
+  global `deriv γ` of the roadmap's raw-function curve layer, which the chain rule identifying
+  `deriv (γ ∘ φ)` needs pointwise. "`C¹`" in the docstrings below is shorthand for exactly this
+  data.
+* The regularity hypotheses are placed on the **image** `φ '' [[a, b]]`, not on `[[φ a, φ b]]`.
   This is the honest domain: `φ` is not assumed monotone, so the composite curve may sweep past the
-  endpoints `φ c`, `φ d` and back. The intermediate value theorem
-  (`intermediate_value_uIcc`) supplies `[[φ c, φ d]] ⊆ φ '' [[c, d]]`, so the hypotheses on the
+  endpoints `φ a`, `φ b` and back. The intermediate value theorem
+  (`intermediate_value_uIcc`) supplies `[[φ a, φ b]] ⊆ φ '' [[a, b]]`, so the hypotheses on the
   image also cover the reparametrized interval, and no monotonicity is needed anywhere.
-* `deriv γ` is the *global* derivative, matching the raw-function design of the roadmap's curve
-  layer. Differentiability of `γ` on the image is therefore an explicit hypothesis rather than a
-  consequence of continuity, since the chain rule identifying `deriv (γ ∘ φ)` needs it pointwise.
+* The curve `γ` is asked to be `C¹` with no breakpoints, one level above the piecewise-`C¹` class of
+  the roadmap's curve layer. The piecewise case — split `[[a, b]]` at the preimages of the finitely
+  many breakpoints and reassemble — is a separate increment, as is the on-curve principal-value
+  case in the winding-number file.
 
 ## Main results
 
-* `TauCeti.Contour.deriv_comp_reparam` — the chain rule for a reparametrized curve, in the
-  `deriv` form used by the contour integrand.
-* `TauCeti.Contour.eqOn_deriv_comp_reparam` — its set-level form on `[[c, d]]`.
+* `TauCeti.Contour.eqOn_deriv_comp_reparam` — the chain rule for a reparametrized curve on
+  `[[a, b]]`, in the `deriv` form used by the contour integrand.
+* `TauCeti.Contour.continuousOn_deriv_comp_reparam` — continuity of `deriv (γ ∘ φ)` on `[[a, b]]`,
+  the regularity every consumer of the reparametrized contour integrand needs for integrability.
 * `TauCeti.Contour.integral_deriv_smul_comp_reparam` — reparametrization invariance of the contour
   integral `∫ t in a..b, deriv γ t • f (γ t)`.
 
@@ -55,48 +63,64 @@ noncomputable section
 
 namespace TauCeti.Contour
 
-variable {γ : ℝ → ℂ} {φ φ' : ℝ → ℝ} {c d : ℝ} {f : ℂ → ℂ}
+variable {γ : ℝ → ℂ} {φ φ' : ℝ → ℝ} {a b : ℝ} {f : ℂ → ℂ}
 
-/-- **Chain rule for a reparametrized curve**, in `deriv` form: the derivative of `γ ∘ φ` is the
-speed of the parameter change times the derivative of the curve. This is the identity that turns
-the contour integrand of `γ ∘ φ` into the change-of-variables integrand `φ' • (g ∘ φ)`. -/
-theorem deriv_comp_reparam {t : ℝ} (hφ : HasDerivAt φ (φ' t) t)
+/-- Chain rule for a reparametrized curve, in `deriv` form:
+`deriv (γ ∘ φ) t = φ' t • deriv γ (φ t)`. A one-step restatement of Mathlib's `HasDerivAt.scomp`,
+kept private as the internal step behind the set-level `eqOn_deriv_comp_reparam`. -/
+private theorem deriv_comp_reparam {t : ℝ} (hφ : HasDerivAt φ (φ' t) t)
     (hγ : DifferentiableAt ℝ γ (φ t)) :
     deriv (γ ∘ φ) t = φ' t • deriv γ (φ t) :=
   (hγ.hasDerivAt.scomp t hφ).deriv
 
 section Regularity
 
-variable (hφ : ∀ t ∈ Set.uIcc c d, HasDerivAt φ (φ' t) t)
-  (hγ : ∀ u ∈ φ '' Set.uIcc c d, DifferentiableAt ℝ γ u)
+variable (hφ : ∀ t ∈ Set.uIcc a b, HasDerivAt φ (φ' t) t)
+  (hγ : ∀ u ∈ φ '' Set.uIcc a b, DifferentiableAt ℝ γ u)
 
 include hφ hγ
 
-/-- On `[[c, d]]`, the derivative of the reparametrized curve is `φ' • (deriv γ ∘ φ)`. The
-set-level form of `deriv_comp_reparam`, packaged for `ContinuousOn` and integral congruences. -/
+/-- On `[[a, b]]`, the derivative of the reparametrized curve is `φ' • (deriv γ ∘ φ)`. This is the
+set-level chain rule, packaged for `ContinuousOn` and integral congruences. Here `φ` has an ambient
+derivative `φ' t` at each `t ∈ [[a, b]]` and `γ` is ambient-differentiable on the swept image. -/
 theorem eqOn_deriv_comp_reparam :
-    Set.EqOn (deriv (γ ∘ φ)) (fun t => φ' t • deriv γ (φ t)) (Set.uIcc c d) :=
+    Set.EqOn (deriv (γ ∘ φ)) (fun t => φ' t • deriv γ (φ t)) (Set.uIcc a b) :=
   fun t ht => deriv_comp_reparam (hφ t ht) (hγ (φ t) ⟨t, ht, rfl⟩)
 
 end Regularity
 
-/-- **Reparametrization invariance of the contour integral.** If `φ` is `C¹` on `[[c, d]]`, the
-curve `γ` is `C¹` on the swept image `φ '' [[c, d]]`, and `f` is continuous on the image of the
-curve, then integrating `f` along the reparametrized curve `γ ∘ φ` over `[[c, d]]` gives the same
-value as integrating along `γ` over `[[φ c, φ d]]`. -/
+/-- Continuity of the derivative of the reparametrized curve on `[[a, b]]`, the regularity every
+consumer of the reparametrized contour integrand needs for integrability. As elsewhere, `φ` has an
+ambient derivative `φ' t` at each `t ∈ [[a, b]]` with `φ'` continuous there, and `γ` is
+ambient-differentiable with continuous derivative on the swept image `φ '' [[a, b]]`. -/
+theorem continuousOn_deriv_comp_reparam
+    (hφ : ∀ t ∈ Set.uIcc a b, HasDerivAt φ (φ' t) t)
+    (hφ' : ContinuousOn φ' (Set.uIcc a b))
+    (hγ : ∀ u ∈ φ '' Set.uIcc a b, DifferentiableAt ℝ γ u)
+    (hγ' : ContinuousOn (deriv γ) (φ '' Set.uIcc a b)) :
+    ContinuousOn (deriv (γ ∘ φ)) (Set.uIcc a b) := by
+  have hφcont : ContinuousOn φ (Set.uIcc a b) :=
+    fun t ht => (hφ t ht).continuousAt.continuousWithinAt
+  exact (hφ'.smul (hγ'.comp hφcont (Set.mapsTo_image φ _))).congr (eqOn_deriv_comp_reparam hφ hγ)
+
+/-- **Reparametrization invariance of the contour integral.** If `φ` has an ambient derivative
+`φ' t` at each `t ∈ [[a, b]]` with `φ'` continuous there, `γ` is ambient-differentiable with
+continuous derivative on the swept image `φ '' [[a, b]]`, and `f` is continuous on the image of the
+curve, then integrating `f` along the reparametrized curve `γ ∘ φ` over `[[a, b]]` gives the same
+value as integrating along `γ` over `[[φ a, φ b]]`. -/
 theorem integral_deriv_smul_comp_reparam
-    (hφ : ∀ t ∈ Set.uIcc c d, HasDerivAt φ (φ' t) t)
-    (hφ' : ContinuousOn φ' (Set.uIcc c d))
-    (hγ : ∀ u ∈ φ '' Set.uIcc c d, DifferentiableAt ℝ γ u)
-    (hγ' : ContinuousOn (deriv γ) (φ '' Set.uIcc c d))
-    (hf : ContinuousOn f (γ '' (φ '' Set.uIcc c d))) :
-    ∫ t in c..d, deriv (γ ∘ φ) t • f ((γ ∘ φ) t) = ∫ u in φ c..φ d, deriv γ u • f (γ u) := by
-  have hγcont : ContinuousOn γ (φ '' Set.uIcc c d) :=
+    (hφ : ∀ t ∈ Set.uIcc a b, HasDerivAt φ (φ' t) t)
+    (hφ' : ContinuousOn φ' (Set.uIcc a b))
+    (hγ : ∀ u ∈ φ '' Set.uIcc a b, DifferentiableAt ℝ γ u)
+    (hγ' : ContinuousOn (deriv γ) (φ '' Set.uIcc a b))
+    (hf : ContinuousOn f (γ '' (φ '' Set.uIcc a b))) :
+    ∫ t in a..b, deriv (γ ∘ φ) t • f ((γ ∘ φ) t) = ∫ u in φ a..φ b, deriv γ u • f (γ u) := by
+  have hγcont : ContinuousOn γ (φ '' Set.uIcc a b) :=
     fun u hu => (hγ u hu).continuousAt.continuousWithinAt
-  have hgcont : ContinuousOn (fun u => deriv γ u • f (γ u)) (φ '' Set.uIcc c d) :=
+  have hgcont : ContinuousOn (fun u => deriv γ u • f (γ u)) (φ '' Set.uIcc a b) :=
     hγ'.smul (hf.comp hγcont (Set.mapsTo_image γ _))
   have hcongr : Set.EqOn (fun t => deriv (γ ∘ φ) t • f ((γ ∘ φ) t))
-      (fun t => φ' t • ((fun u => deriv γ u • f (γ u)) ∘ φ) t) (Set.uIcc c d) := by
+      (fun t => φ' t • ((fun u => deriv γ u • f (γ u)) ∘ φ) t) (Set.uIcc a b) := by
     intro t ht
     simp only [Function.comp_apply, eqOn_deriv_comp_reparam hφ hγ ht, smul_assoc]
   rw [intervalIntegral.integral_congr hcongr]

--- a/TauCeti/Analysis/Contour/Curve/Reparam.lean
+++ b/TauCeti/Analysis/Contour/Curve/Reparam.lean
@@ -1,0 +1,107 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Chris Birkbeck
+-/
+module
+
+public import Mathlib.MeasureTheory.Integral.IntervalIntegral.IntegrationByParts
+public import Mathlib.Analysis.Complex.Basic
+
+/-!
+# Reparametrization invariance of the contour integral
+
+A contour integral `∫ t in a..b, deriv γ t • f (γ t)` is unchanged when the curve `γ` is
+precomposed with a `C¹` change of parameter `φ`, the parameter interval `[[c, d]]` being replaced
+by `[[φ c, φ d]]`. This file proves that invariance, together with the chain rule for the
+reparametrized curve that it rests on.
+
+The proof is the interval-integral change-of-variables formula
+`intervalIntegral.integral_deriv_smul_comp'` applied to the contour integrand
+`g u = deriv γ u • f (γ u)`, together with the chain rule
+`deriv (γ ∘ φ) t = φ' t • deriv γ (φ t)`.
+
+Two design points are worth flagging.
+
+* The regularity hypotheses are placed on the **image** `φ '' [[c, d]]`, not on `[[φ c, φ d]]`.
+  This is the honest domain: `φ` is not assumed monotone, so the composite curve may sweep past the
+  endpoints `φ c`, `φ d` and back. The intermediate value theorem
+  (`intermediate_value_uIcc`) supplies `[[φ c, φ d]] ⊆ φ '' [[c, d]]`, so the hypotheses on the
+  image also cover the reparametrized interval, and no monotonicity is needed anywhere.
+* `deriv γ` is the *global* derivative, matching the raw-function design of the roadmap's curve
+  layer. Differentiability of `γ` on the image is therefore an explicit hypothesis rather than a
+  consequence of continuity, since the chain rule identifying `deriv (γ ∘ φ)` needs it pointwise.
+
+## Main results
+
+* `TauCeti.Contour.deriv_comp_reparam` — the chain rule for a reparametrized curve, in the
+  `deriv` form used by the contour integrand.
+* `TauCeti.Contour.eqOn_deriv_comp_reparam` — its set-level form on `[[c, d]]`.
+* `TauCeti.Contour.integral_deriv_smul_comp_reparam` — reparametrization invariance of the contour
+  integral `∫ t in a..b, deriv γ t • f (γ t)`.
+
+The winding-number consequences live in `TauCeti/Analysis/Contour/Winding/Number/Reparam.lean`.
+
+## Provenance
+
+This is routine API around the contour integrand of the contour integration roadmap; no formal
+source is vendored. The change-of-variables input `intervalIntegral.integral_deriv_smul_comp'` is
+Mathlib's.
+-/
+
+public section
+
+noncomputable section
+
+namespace TauCeti.Contour
+
+variable {γ : ℝ → ℂ} {φ φ' : ℝ → ℝ} {c d : ℝ} {f : ℂ → ℂ}
+
+/-- **Chain rule for a reparametrized curve**, in `deriv` form: the derivative of `γ ∘ φ` is the
+speed of the parameter change times the derivative of the curve. This is the identity that turns
+the contour integrand of `γ ∘ φ` into the change-of-variables integrand `φ' • (g ∘ φ)`. -/
+theorem deriv_comp_reparam {t : ℝ} (hφ : HasDerivAt φ (φ' t) t)
+    (hγ : DifferentiableAt ℝ γ (φ t)) :
+    deriv (γ ∘ φ) t = φ' t • deriv γ (φ t) :=
+  (hγ.hasDerivAt.scomp t hφ).deriv
+
+section Regularity
+
+variable (hφ : ∀ t ∈ Set.uIcc c d, HasDerivAt φ (φ' t) t)
+  (hγ : ∀ u ∈ φ '' Set.uIcc c d, DifferentiableAt ℝ γ u)
+
+include hφ hγ
+
+/-- On `[[c, d]]`, the derivative of the reparametrized curve is `φ' • (deriv γ ∘ φ)`. The
+set-level form of `deriv_comp_reparam`, packaged for `ContinuousOn` and integral congruences. -/
+theorem eqOn_deriv_comp_reparam :
+    Set.EqOn (deriv (γ ∘ φ)) (fun t => φ' t • deriv γ (φ t)) (Set.uIcc c d) :=
+  fun t ht => deriv_comp_reparam (hφ t ht) (hγ (φ t) ⟨t, ht, rfl⟩)
+
+end Regularity
+
+/-- **Reparametrization invariance of the contour integral.** If `φ` is `C¹` on `[[c, d]]`, the
+curve `γ` is `C¹` on the swept image `φ '' [[c, d]]`, and `f` is continuous on the image of the
+curve, then integrating `f` along the reparametrized curve `γ ∘ φ` over `[[c, d]]` gives the same
+value as integrating along `γ` over `[[φ c, φ d]]`. -/
+theorem integral_deriv_smul_comp_reparam
+    (hφ : ∀ t ∈ Set.uIcc c d, HasDerivAt φ (φ' t) t)
+    (hφ' : ContinuousOn φ' (Set.uIcc c d))
+    (hγ : ∀ u ∈ φ '' Set.uIcc c d, DifferentiableAt ℝ γ u)
+    (hγ' : ContinuousOn (deriv γ) (φ '' Set.uIcc c d))
+    (hf : ContinuousOn f (γ '' (φ '' Set.uIcc c d))) :
+    ∫ t in c..d, deriv (γ ∘ φ) t • f ((γ ∘ φ) t) = ∫ u in φ c..φ d, deriv γ u • f (γ u) := by
+  have hγcont : ContinuousOn γ (φ '' Set.uIcc c d) :=
+    fun u hu => (hγ u hu).continuousAt.continuousWithinAt
+  have hgcont : ContinuousOn (fun u => deriv γ u • f (γ u)) (φ '' Set.uIcc c d) :=
+    hγ'.smul (hf.comp hγcont (Set.mapsTo_image γ _))
+  have hcongr : Set.EqOn (fun t => deriv (γ ∘ φ) t • f ((γ ∘ φ) t))
+      (fun t => φ' t • ((fun u => deriv γ u • f (γ u)) ∘ φ) t) (Set.uIcc c d) := by
+    intro t ht
+    simp only [Function.comp_apply, eqOn_deriv_comp_reparam hφ hγ ht, smul_assoc]
+  rw [intervalIntegral.integral_congr hcongr]
+  exact intervalIntegral.integral_deriv_smul_comp' hφ hφ' hgcont
+
+end TauCeti.Contour
+
+end

--- a/TauCeti/Analysis/Contour/Winding/Number/Reparam.lean
+++ b/TauCeti/Analysis/Contour/Winding/Number/Reparam.lean
@@ -1,0 +1,225 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Chris Birkbeck
+-/
+module
+
+public import Mathlib.MeasureTheory.Integral.IntervalIntegral.IntegrationByParts
+public import TauCeti.Analysis.Contour.NullHomologous
+
+/-!
+# Reparametrization invariance for contour integrals and winding numbers
+
+A contour integral `∫ t in a..b, deriv γ t • f (γ t)` depends on the curve `γ` only through its
+oriented image: precomposing `γ` with a `C¹` change of parameter `φ` and integrating over a
+parameter interval `[c, d]` with `φ c = a`, `φ d = b` gives the same value. This file records that
+invariance and its consequence for the generalized winding number of Hungerbühler–Wasem Def 2.1.
+
+The proof is the interval-integral change-of-variables formula
+`intervalIntegral.integral_deriv_smul_comp'` applied to the contour integrand
+`g u = deriv γ u • f (γ u)`, together with the chain rule
+`deriv (γ ∘ φ) t = φ' t • deriv γ (φ t)`.
+
+Two design points are worth flagging.
+
+* The regularity hypotheses are placed on the **image** `φ '' [[c, d]]`, not on `[[φ c, φ d]]`.
+  This is the honest domain: `φ` is not assumed monotone, so the composite curve may sweep past the
+  endpoints `φ c`, `φ d` and back. The intermediate value theorem
+  (`intermediate_value_uIcc`) supplies `[[φ c, φ d]] ⊆ φ '' [[c, d]]`, so the hypotheses on the
+  image also cover the reparametrized interval, and no monotonicity is needed anywhere.
+* `deriv γ` is the *global* derivative, matching the raw-function design of the roadmap's curve
+  layer. Differentiability of `γ` on the image is therefore an explicit hypothesis rather than a
+  consequence of continuity, since the chain rule identifying `deriv (γ ∘ φ)` needs it pointwise.
+
+Only the off-curve case is treated: when `z₀` lies on the curve the winding number is a Cauchy
+principal value, whose symmetric excision windows are themselves reparametrized, and transporting
+them is a separate argument. This is the case that the roadmap's cycle bookkeeping consumes.
+
+## Main results
+
+* `TauCeti.Contour.deriv_comp_reparam` — the chain rule for a reparametrized curve, in the
+  `deriv` form used by the contour integrand.
+* `TauCeti.Contour.integral_deriv_smul_comp_reparam` — reparametrization invariance of the contour
+  integral `∫ t in a..b, deriv γ t • f (γ t)`.
+* `TauCeti.Contour.windingNumber_comp_reparam` — the generalized winding number about a point off
+  the curve is unchanged by a `C¹` reparametrization.
+* `TauCeti.Contour.windingNumber_comp_affine` — the affine special case `φ t = α * t + β`.
+* `TauCeti.Contour.IsNullHomologous.comp_reparam` — null-homology transports along a `C¹`
+  reparametrization of a curve lying in the ambient set.
+
+This is Layer 0 of the Hungerbühler–Wasem generalized residue theorem (HW Thm 3.3): the
+reparametrization-invariance API that the cycle layer needs in order to treat a closed curve
+independently of its parametrization.
+
+## Provenance
+
+This is routine API around the Hungerbühler--Wasem generalized winding number from the contour
+integration roadmap; no formal source is vendored. The change-of-variables input
+`intervalIntegral.integral_deriv_smul_comp'` is Mathlib's.
+
+## References
+
+* N. Hungerbühler, M. Wasem, *Non-integer valued winding numbers and a generalized Residue
+  Theorem*, arXiv:1808.00997 — Def 2.1.
+-/
+
+public section
+
+noncomputable section
+
+open MeasureTheory
+
+namespace TauCeti.Contour
+
+variable {γ : ℝ → ℂ} {φ φ' : ℝ → ℝ} {c d : ℝ} {z₀ : ℂ} {f : ℂ → ℂ} {Ω : Set ℂ}
+
+/-- **Chain rule for a reparametrized curve.** If `φ` has derivative `φ' t` at `t` and `γ` is
+differentiable at `φ t`, then the composite curve `γ ∘ φ` has derivative `φ' t • deriv γ (φ t)`.
+Stated with `HasDerivAt` so that callers can extract either the derivative value or the
+differentiability. -/
+theorem hasDerivAt_comp_reparam {t : ℝ} (hφ : HasDerivAt φ (φ' t) t)
+    (hγ : DifferentiableAt ℝ γ (φ t)) :
+    HasDerivAt (γ ∘ φ) (φ' t • deriv γ (φ t)) t :=
+  hγ.hasDerivAt.scomp t hφ
+
+/-- The `deriv` form of `hasDerivAt_comp_reparam`: the derivative of a reparametrized curve is the
+speed of the parameter change times the derivative of the curve. This is the identity that turns the
+contour integrand of `γ ∘ φ` into the change-of-variables integrand `φ' • (g ∘ φ)`. -/
+theorem deriv_comp_reparam {t : ℝ} (hφ : HasDerivAt φ (φ' t) t)
+    (hγ : DifferentiableAt ℝ γ (φ t)) :
+    deriv (γ ∘ φ) t = φ' t • deriv γ (φ t) :=
+  (hasDerivAt_comp_reparam hφ hγ).deriv
+
+section Regularity
+
+variable (hφ : ∀ t ∈ Set.uIcc c d, HasDerivAt φ (φ' t) t)
+  (hγ : ∀ u ∈ φ '' Set.uIcc c d, DifferentiableAt ℝ γ u)
+
+include hφ
+
+/-- A parameter change with a derivative everywhere on `[[c, d]]` is continuous there. -/
+private theorem continuousOn_of_hasDerivAt : ContinuousOn φ (Set.uIcc c d) :=
+  fun t ht => (hφ t ht).continuousAt.continuousWithinAt
+
+/-- The reparametrized interval `[[φ c, φ d]]` is contained in the image `φ '' [[c, d]]`, by the
+intermediate value theorem. Hypotheses stated on the image therefore also apply on `[[φ c, φ d]]`;
+no monotonicity of `φ` is needed. -/
+theorem uIcc_endpoints_subset_image : Set.uIcc (φ c) (φ d) ⊆ φ '' Set.uIcc c d :=
+  intermediate_value_uIcc (continuousOn_of_hasDerivAt hφ)
+
+include hγ
+
+omit hφ in
+/-- A curve differentiable on the image of the parameter change is continuous there. -/
+private theorem continuousOn_of_differentiableAt : ContinuousOn γ (φ '' Set.uIcc c d) :=
+  fun u hu => (hγ u hu).continuousAt.continuousWithinAt
+
+/-- On `[[c, d]]`, the derivative of the reparametrized curve is `φ' • (deriv γ ∘ φ)`. The
+set-level form of `deriv_comp_reparam`, packaged for `ContinuousOn` and integral congruences. -/
+theorem eqOn_deriv_comp_reparam :
+    Set.EqOn (deriv (γ ∘ φ)) (fun t => φ' t • deriv γ (φ t)) (Set.uIcc c d) :=
+  fun t ht => deriv_comp_reparam (hφ t ht) (hγ (φ t) ⟨t, ht, rfl⟩)
+
+end Regularity
+
+/-- **Reparametrization invariance of the contour integral.** If `φ` is `C¹` on `[[c, d]]`, the
+curve `γ` is `C¹` on the swept image `φ '' [[c, d]]`, and `f` is continuous on the image of the
+curve, then integrating `f` along the reparametrized curve `γ ∘ φ` over `[[c, d]]` gives the same
+value as integrating along `γ` over `[[φ c, φ d]]`. This is Mathlib's change-of-variables formula
+applied to the contour integrand `u ↦ deriv γ u • f (γ u)`. -/
+theorem integral_deriv_smul_comp_reparam
+    (hφ : ∀ t ∈ Set.uIcc c d, HasDerivAt φ (φ' t) t)
+    (hφ' : ContinuousOn φ' (Set.uIcc c d))
+    (hγ : ∀ u ∈ φ '' Set.uIcc c d, DifferentiableAt ℝ γ u)
+    (hγ' : ContinuousOn (deriv γ) (φ '' Set.uIcc c d))
+    (hf : ContinuousOn f (γ '' (φ '' Set.uIcc c d))) :
+    ∫ t in c..d, deriv (γ ∘ φ) t • f (γ (φ t)) = ∫ u in φ c..φ d, deriv γ u • f (γ u) := by
+  have hgcont : ContinuousOn (fun u => deriv γ u • f (γ u)) (φ '' Set.uIcc c d) :=
+    hγ'.smul ((hf.comp (continuousOn_of_differentiableAt hγ) (Set.mapsTo_image γ _)))
+  have hcongr : Set.EqOn (fun t => deriv (γ ∘ φ) t • f (γ (φ t)))
+      (fun t => φ' t • ((fun u => deriv γ u • f (γ u)) ∘ φ) t) (Set.uIcc c d) := by
+    intro t ht
+    simp only [Function.comp_apply, eqOn_deriv_comp_reparam hφ hγ ht, smul_assoc]
+  rw [intervalIntegral.integral_congr hcongr]
+  exact intervalIntegral.integral_deriv_smul_comp' hφ hφ' hgcont
+
+/-- **Reparametrization invariance of the generalized winding number** (HW Def 2.1), for a point
+`z₀` off the curve. A `C¹` change of parameter `φ` leaves the winding number unchanged, the
+parameter interval `[[c, d]]` being replaced by `[[φ c, φ d]]`.
+
+All hypotheses are stated on the swept image `φ '' [[c, d]]`, which contains `[[φ c, φ d]]` by the
+intermediate value theorem, so `φ` need not be monotone. Off-curve is essential: on the curve the
+winding number is a principal value, whose excision windows are themselves reparametrized. -/
+theorem windingNumber_comp_reparam
+    (hφ : ∀ t ∈ Set.uIcc c d, HasDerivAt φ (φ' t) t)
+    (hφ' : ContinuousOn φ' (Set.uIcc c d))
+    (hγ : ∀ u ∈ φ '' Set.uIcc c d, DifferentiableAt ℝ γ u)
+    (hγ' : ContinuousOn (deriv γ) (φ '' Set.uIcc c d))
+    (havoid : ∀ u ∈ φ '' Set.uIcc c d, γ u ≠ z₀) :
+    windingNumber (γ ∘ φ) c d z₀ = windingNumber γ (φ c) (φ d) z₀ := by
+  have hφcont : ContinuousOn φ (Set.uIcc c d) := continuousOn_of_hasDerivAt hφ
+  have hγcont : ContinuousOn γ (φ '' Set.uIcc c d) := continuousOn_of_differentiableAt hγ
+  have hsub : Set.uIcc (φ c) (φ d) ⊆ φ '' Set.uIcc c d := uIcc_endpoints_subset_image hφ
+  have hmaps : Set.MapsTo φ (Set.uIcc c d) (φ '' Set.uIcc c d) := Set.mapsTo_image φ _
+  -- the kernel `(· - z₀)⁻¹` is continuous along the curve, since `γ` avoids `z₀`
+  have hker : ContinuousOn (fun z : ℂ => (z - z₀)⁻¹) (γ '' (φ '' Set.uIcc c d)) := by
+    refine (continuousOn_id.sub continuousOn_const).inv₀ ?_
+    rintro _ ⟨u, hu, rfl⟩
+    exact sub_ne_zero.mpr (havoid u hu)
+  -- the index integrand along the reparametrized curve is continuous, hence integrable
+  have hderivcont : ContinuousOn (deriv (γ ∘ φ)) (Set.uIcc c d) :=
+    ContinuousOn.congr (hφ'.smul (hγ'.comp hφcont hmaps)) (eqOn_deriv_comp_reparam hφ hγ)
+  have hcompcont : ContinuousOn (γ ∘ φ) (Set.uIcc c d) := hγcont.comp hφcont hmaps
+  have hcompavoid : ∀ t ∈ Set.uIcc c d, (γ ∘ φ) t ≠ z₀ := fun t ht => havoid (φ t) ⟨t, ht, rfl⟩
+  have hintL : IntervalIntegrable
+      (fun t => ((γ ∘ φ) t - z₀)⁻¹ * deriv (γ ∘ φ) t) volume c d :=
+    (((hcompcont.sub continuousOn_const).inv₀
+      fun t ht => sub_ne_zero.mpr (hcompavoid t ht)).mul hderivcont).intervalIntegrable
+  have hintR : IntervalIntegrable
+      (fun u => (γ u - z₀)⁻¹ * deriv γ u) volume (φ c) (φ d) :=
+    ((((hγcont.mono hsub).sub continuousOn_const).inv₀
+      fun u hu => sub_ne_zero.mpr (havoid u (hsub hu))).mul (hγ'.mono hsub)).intervalIntegrable
+  rw [windingNumber_eq_integral_of_avoidance hcompcont hcompavoid hintL,
+    windingNumber_eq_integral_of_avoidance (hγcont.mono hsub)
+      (fun u hu => havoid u (hsub hu)) hintR]
+  congr 1
+  have := integral_deriv_smul_comp_reparam (f := fun z : ℂ => (z - z₀)⁻¹) hφ hφ' hγ hγ' hker
+  simpa only [smul_eq_mul, mul_comm, Function.comp_apply] using this
+
+/-- The affine special case of `windingNumber_comp_reparam`: precomposing a curve with
+`t ↦ α * t + β` moves the parameter interval to `[[α * c + β, α * d + β]]` and leaves the winding
+number about an off-curve point unchanged. Unlike the general statement this needs no separate
+continuity hypothesis on the parameter speed, the derivative being the constant `α`. -/
+theorem windingNumber_comp_affine {α β : ℝ}
+    (hγ : ∀ u ∈ (fun t => α * t + β) '' Set.uIcc c d, DifferentiableAt ℝ γ u)
+    (hγ' : ContinuousOn (deriv γ) ((fun t => α * t + β) '' Set.uIcc c d))
+    (havoid : ∀ u ∈ (fun t => α * t + β) '' Set.uIcc c d, γ u ≠ z₀) :
+    windingNumber (fun t => γ (α * t + β)) c d z₀
+      = windingNumber γ (α * c + β) (α * d + β) z₀ :=
+  windingNumber_comp_reparam (φ' := fun _ => α)
+    (fun t _ => by simpa using ((hasDerivAt_id t).const_mul α).add_const β)
+    continuousOn_const hγ hγ' havoid
+
+/-- **Null-homology transports along a reparametrization.** If a curve lies in `Ω` and is
+null-homologous there, then so is any `C¹` reparametrization of it: every point outside `Ω` is
+automatically off the curve, so `windingNumber_comp_reparam` applies at each such point. -/
+theorem IsNullHomologous.comp_reparam
+    (h : IsNullHomologous γ (φ c) (φ d) Ω)
+    (hφ : ∀ t ∈ Set.uIcc c d, HasDerivAt φ (φ' t) t)
+    (hφ' : ContinuousOn φ' (Set.uIcc c d))
+    (hγ : ∀ u ∈ φ '' Set.uIcc c d, DifferentiableAt ℝ γ u)
+    (hγ' : ContinuousOn (deriv γ) (φ '' Set.uIcc c d))
+    (hγΩ : ∀ u ∈ φ '' Set.uIcc c d, γ u ∈ Ω) :
+    IsNullHomologous (γ ∘ φ) c d Ω := by
+  rw [isNullHomologous_iff] at h ⊢
+  intro z hz
+  have havoid : ∀ u ∈ φ '' Set.uIcc c d, γ u ≠ z := by
+    intro u hu huz
+    exact hz (huz ▸ hγΩ u hu)
+  rw [windingNumber_comp_reparam (φ' := φ') hφ hφ' hγ hγ' havoid]
+  exact h z hz
+
+end TauCeti.Contour
+
+end

--- a/TauCeti/Analysis/Contour/Winding/Number/Reparam.lean
+++ b/TauCeti/Analysis/Contour/Winding/Number/Reparam.lean
@@ -13,13 +13,15 @@ public import TauCeti.Analysis.Contour.NullHomologous
 
 Precomposing a curve `γ` with a `C¹` change of parameter `φ` leaves the generalized winding number
 of Hungerbühler–Wasem (Def 2.1) about a point off the curve unchanged, the parameter interval
-`[[c, d]]` being replaced by `[[φ c, φ d]]`; null-homology in an ambient set transports the same
+`[[a, b]]` being replaced by `[[φ a, φ b]]`; null-homology in an ambient set transports the same
 way. These are consequences of the reparametrization invariance of the contour integral proved in
-`TauCeti/Analysis/Contour/Curve/Reparam.lean`.
+`TauCeti/Analysis/Contour/Curve/Reparam.lean`. As there, "`C¹`" is shorthand for ambient pointwise
+`HasDerivAt`/`DifferentiableAt` data, and the curve is asked to be `C¹` with no breakpoints — the
+piecewise-`C¹` case is a separate increment.
 
-As there, the regularity hypotheses are placed on the swept image `φ '' [[c, d]]` rather than on
-`[[φ c, φ d]]`: `φ` is not assumed monotone, and `intermediate_value_uIcc` gives
-`[[φ c, φ d]] ⊆ φ '' [[c, d]]`, so hypotheses on the image also cover the reparametrized interval.
+As there, the regularity hypotheses on `γ` are placed on the swept image `φ '' [[a, b]]` rather than
+on `[[φ a, φ b]]`: `φ` is not assumed monotone, and `intermediate_value_uIcc` gives
+`[[φ a, φ b]] ⊆ φ '' [[a, b]]`, so hypotheses on the image also cover the reparametrized interval.
 
 Only the off-curve case is treated: when `z₀` lies on the curve the winding number is a Cauchy
 principal value, whose symmetric excision windows are themselves reparametrized, and transporting
@@ -29,7 +31,7 @@ them is a separate argument. This is the case that the roadmap's cycle bookkeepi
 
 * `TauCeti.Contour.windingNumber_comp_reparam` — the generalized winding number about a point off
   the curve is unchanged by a `C¹` reparametrization.
-* `TauCeti.Contour.windingNumber_comp_reparam_affine` — the affine special case `φ t = α * t + β`.
+* `TauCeti.Contour.windingNumber_comp_mul_add` — the affine special case `φ t = r * t + s`.
 * `TauCeti.Contour.IsNullHomologous.comp_reparam` — null-homology transports along a `C¹`
   reparametrization of a curve lying in the ambient set.
 
@@ -56,38 +58,40 @@ open MeasureTheory
 
 namespace TauCeti.Contour
 
-variable {γ : ℝ → ℂ} {φ φ' : ℝ → ℝ} {c d : ℝ} {z₀ : ℂ} {Ω : Set ℂ}
+variable {γ : ℝ → ℂ} {φ φ' : ℝ → ℝ} {a b : ℝ} {z₀ : ℂ} {Ω : Set ℂ}
 
 /-- **Reparametrization invariance of the generalized winding number** (HW Def 2.1), for a point
-`z₀` off the curve. A `C¹` change of parameter `φ` leaves the winding number unchanged, the
-parameter interval `[[c, d]]` being replaced by `[[φ c, φ d]]`.
+`z₀` off the curve. Precomposing with a change of parameter `φ` that has an ambient derivative
+`φ' t` at each `t ∈ [[a, b]]`, with `φ'` continuous, leaves the winding number unchanged, the
+parameter interval `[[a, b]]` being replaced by `[[φ a, φ b]]`.
 
-All hypotheses are stated on the swept image `φ '' [[c, d]]`, which contains `[[φ c, φ d]]` by the
-intermediate value theorem, so `φ` need not be monotone. Off-curve is essential: on the curve the
-winding number is a principal value, whose excision windows are themselves reparametrized. -/
+The hypotheses on `γ` are stated on the swept image `φ '' [[a, b]]`, which contains `[[φ a, φ b]]`
+by the intermediate value theorem, so `φ` need not be monotone. Off-curve is essential: on the
+curve the winding number is a principal value, whose excision windows are themselves
+reparametrized. -/
 theorem windingNumber_comp_reparam
-    (hφ : ∀ t ∈ Set.uIcc c d, HasDerivAt φ (φ' t) t)
-    (hφ' : ContinuousOn φ' (Set.uIcc c d))
-    (hγ : ∀ u ∈ φ '' Set.uIcc c d, DifferentiableAt ℝ γ u)
-    (hγ' : ContinuousOn (deriv γ) (φ '' Set.uIcc c d))
-    (havoid : ∀ u ∈ φ '' Set.uIcc c d, γ u ≠ z₀) :
-    windingNumber (γ ∘ φ) c d z₀ = windingNumber γ (φ c) (φ d) z₀ := by
-  have hφcont : ContinuousOn φ (Set.uIcc c d) :=
+    (hφ : ∀ t ∈ Set.uIcc a b, HasDerivAt φ (φ' t) t)
+    (hφ' : ContinuousOn φ' (Set.uIcc a b))
+    (hγ : ∀ u ∈ φ '' Set.uIcc a b, DifferentiableAt ℝ γ u)
+    (hγ' : ContinuousOn (deriv γ) (φ '' Set.uIcc a b))
+    (havoid : ∀ u ∈ φ '' Set.uIcc a b, γ u ≠ z₀) :
+    windingNumber (γ ∘ φ) a b z₀ = windingNumber γ (φ a) (φ b) z₀ := by
+  have hφcont : ContinuousOn φ (Set.uIcc a b) :=
     fun t ht => (hφ t ht).continuousAt.continuousWithinAt
-  have hγcont : ContinuousOn γ (φ '' Set.uIcc c d) :=
+  have hγcont : ContinuousOn γ (φ '' Set.uIcc a b) :=
     fun u hu => (hγ u hu).continuousAt.continuousWithinAt
-  have hsub : Set.uIcc (φ c) (φ d) ⊆ φ '' Set.uIcc c d := intermediate_value_uIcc hφcont
-  have hmaps : Set.MapsTo φ (Set.uIcc c d) (φ '' Set.uIcc c d) := Set.mapsTo_image φ _
+  have hsub : Set.uIcc (φ a) (φ b) ⊆ φ '' Set.uIcc a b := intermediate_value_uIcc hφcont
+  have hmaps : Set.MapsTo φ (Set.uIcc a b) (φ '' Set.uIcc a b) := Set.mapsTo_image φ _
   -- the kernel `(· - z₀)⁻¹` is continuous along the curve, since `γ` avoids `z₀`
-  have hker : ContinuousOn (fun z : ℂ => (z - z₀)⁻¹) (γ '' (φ '' Set.uIcc c d)) := by
+  have hker : ContinuousOn (fun z : ℂ => (z - z₀)⁻¹) (γ '' (φ '' Set.uIcc a b)) := by
     refine (continuousOn_id.sub continuousOn_const).inv₀ ?_
     rintro _ ⟨u, hu, rfl⟩
     exact sub_ne_zero.mpr (havoid u hu)
   -- the index integrand along the reparametrized curve is continuous, hence integrable
-  have hderivcont : ContinuousOn (deriv (γ ∘ φ)) (Set.uIcc c d) :=
-    ContinuousOn.congr (hφ'.smul (hγ'.comp hφcont hmaps)) (eqOn_deriv_comp_reparam hφ hγ)
-  have hcompcont : ContinuousOn (γ ∘ φ) (Set.uIcc c d) := hγcont.comp hφcont hmaps
-  have hcompavoid : ∀ t ∈ Set.uIcc c d, (γ ∘ φ) t ≠ z₀ := fun t ht => havoid (φ t) ⟨t, ht, rfl⟩
+  have hderivcont : ContinuousOn (deriv (γ ∘ φ)) (Set.uIcc a b) :=
+    continuousOn_deriv_comp_reparam hφ hφ' hγ hγ'
+  have hcompcont : ContinuousOn (γ ∘ φ) (Set.uIcc a b) := hγcont.comp hφcont hmaps
+  have hcompavoid : ∀ t ∈ Set.uIcc a b, (γ ∘ φ) t ≠ z₀ := fun t ht => havoid (φ t) ⟨t, ht, rfl⟩
   rw [windingNumber_eq_integral_of_avoidance hcompcont hcompavoid
       (intervalIntegrable_inv_sub_mul_deriv hcompcont hcompavoid hderivcont.intervalIntegrable),
     windingNumber_eq_integral_of_avoidance (hγcont.mono hsub)
@@ -97,46 +101,47 @@ theorem windingNumber_comp_reparam
   congr 1
   -- both index integrands are the contour integrand of the kernel `(· - z₀)⁻¹`, with the two
   -- factors in the opposite order
-  have hL : ∫ t in c..d, ((γ ∘ φ) t - z₀)⁻¹ * deriv (γ ∘ φ) t
-      = ∫ t in c..d, deriv (γ ∘ φ) t • ((γ ∘ φ) t - z₀)⁻¹ :=
+  have hL : ∫ t in a..b, ((γ ∘ φ) t - z₀)⁻¹ * deriv (γ ∘ φ) t
+      = ∫ t in a..b, deriv (γ ∘ φ) t • ((γ ∘ φ) t - z₀)⁻¹ :=
     intervalIntegral.integral_congr fun t _ => by rw [smul_eq_mul, mul_comm]
-  have hR : ∫ u in φ c..φ d, (γ u - z₀)⁻¹ * deriv γ u
-      = ∫ u in φ c..φ d, deriv γ u • (γ u - z₀)⁻¹ :=
+  have hR : ∫ u in φ a..φ b, (γ u - z₀)⁻¹ * deriv γ u
+      = ∫ u in φ a..φ b, deriv γ u • (γ u - z₀)⁻¹ :=
     intervalIntegral.integral_congr fun u _ => by rw [smul_eq_mul, mul_comm]
   rw [hL, hR]
   exact integral_deriv_smul_comp_reparam (f := fun z : ℂ => (z - z₀)⁻¹) hφ hφ' hγ hγ' hker
 
 /-- The affine special case of `windingNumber_comp_reparam`: precomposing a curve with
-`t ↦ α * t + β` moves the parameter interval to `[[α * c + β, α * d + β]]` and leaves the winding
+`t ↦ r * t + s` moves the parameter interval to `[[r * a + s, r * b + s]]` and leaves the winding
 number about an off-curve point unchanged. Unlike the general statement this needs no separate
-continuity hypothesis on the parameter speed, the derivative being the constant `α`. -/
-theorem windingNumber_comp_reparam_affine {α β : ℝ}
-    (hγ : ∀ u ∈ Set.uIcc (α * c + β) (α * d + β), DifferentiableAt ℝ γ u)
-    (hγ' : ContinuousOn (deriv γ) (Set.uIcc (α * c + β) (α * d + β)))
-    (havoid : ∀ u ∈ Set.uIcc (α * c + β) (α * d + β), γ u ≠ z₀) :
-    windingNumber (γ ∘ fun t => α * t + β) c d z₀
-      = windingNumber γ (α * c + β) (α * d + β) z₀ := by
-  have himg : (fun t => α * t + β) '' Set.uIcc c d = Set.uIcc (α * c + β) (α * d + β) := by
-    rw [show (fun t : ℝ => α * t + β) = (fun x => x + β) ∘ (α * ·) from funext fun _ => rfl,
+continuity hypothesis on the parameter speed, the derivative being the constant `r`. -/
+theorem windingNumber_comp_mul_add {r s : ℝ}
+    (hγ : ∀ u ∈ Set.uIcc (r * a + s) (r * b + s), DifferentiableAt ℝ γ u)
+    (hγ' : ContinuousOn (deriv γ) (Set.uIcc (r * a + s) (r * b + s)))
+    (havoid : ∀ u ∈ Set.uIcc (r * a + s) (r * b + s), γ u ≠ z₀) :
+    windingNumber (γ ∘ fun t => r * t + s) a b z₀
+      = windingNumber γ (r * a + s) (r * b + s) z₀ := by
+  have himg : (fun t => r * t + s) '' Set.uIcc a b = Set.uIcc (r * a + s) (r * b + s) := by
+    rw [show (fun t : ℝ => r * t + s) = (fun x => x + s) ∘ (r * ·) from funext fun _ => rfl,
       Set.image_comp, Set.image_const_mul_uIcc, Set.image_add_const_uIcc]
-  refine windingNumber_comp_reparam (φ' := fun _ => α)
-    (fun t _ => by simpa using ((hasDerivAt_id t).const_mul α).add_const β)
+  refine windingNumber_comp_reparam (φ' := fun _ => r)
+    (fun t _ => by simpa using ((hasDerivAt_id t).const_mul r).add_const s)
     continuousOn_const ?_ ?_ ?_ <;> rw [himg]
   exacts [hγ, hγ', havoid]
 
 /-- **Null-homology transports along a reparametrization.** If a curve lies in `Ω` and is
-null-homologous there, then so is any `C¹` reparametrization of it. -/
+null-homologous there, then so is its precomposition with any change of parameter `φ` that has an
+ambient derivative `φ' t` at each `t ∈ [[a, b]]`, with `φ'` continuous. -/
 theorem IsNullHomologous.comp_reparam
-    (h : IsNullHomologous γ (φ c) (φ d) Ω)
-    (hφ : ∀ t ∈ Set.uIcc c d, HasDerivAt φ (φ' t) t)
-    (hφ' : ContinuousOn φ' (Set.uIcc c d))
-    (hγ : ∀ u ∈ φ '' Set.uIcc c d, DifferentiableAt ℝ γ u)
-    (hγ' : ContinuousOn (deriv γ) (φ '' Set.uIcc c d))
-    (hγΩ : ∀ u ∈ φ '' Set.uIcc c d, γ u ∈ Ω) :
-    IsNullHomologous (γ ∘ φ) c d Ω := by
+    (h : IsNullHomologous γ (φ a) (φ b) Ω)
+    (hφ : ∀ t ∈ Set.uIcc a b, HasDerivAt φ (φ' t) t)
+    (hφ' : ContinuousOn φ' (Set.uIcc a b))
+    (hγ : ∀ u ∈ φ '' Set.uIcc a b, DifferentiableAt ℝ γ u)
+    (hγ' : ContinuousOn (deriv γ) (φ '' Set.uIcc a b))
+    (hγΩ : ∀ u ∈ φ '' Set.uIcc a b, γ u ∈ Ω) :
+    IsNullHomologous (γ ∘ φ) a b Ω := by
   rw [isNullHomologous_iff] at h ⊢
   intro z hz
-  have havoid : ∀ u ∈ φ '' Set.uIcc c d, γ u ≠ z := by
+  have havoid : ∀ u ∈ φ '' Set.uIcc a b, γ u ≠ z := by
     intro u hu huz
     exact hz (huz ▸ hγΩ u hu)
   rw [windingNumber_comp_reparam (φ' := φ') hφ hφ' hγ hγ' havoid]

--- a/TauCeti/Analysis/Contour/Winding/Number/Reparam.lean
+++ b/TauCeti/Analysis/Contour/Winding/Number/Reparam.lean
@@ -5,32 +5,21 @@ Authors: Chris Birkbeck
 -/
 module
 
-public import Mathlib.MeasureTheory.Integral.IntervalIntegral.IntegrationByParts
+public import TauCeti.Analysis.Contour.Curve.Reparam
 public import TauCeti.Analysis.Contour.NullHomologous
 
 /-!
-# Reparametrization invariance for contour integrals and winding numbers
+# Reparametrization invariance of the generalized winding number
 
-A contour integral `∫ t in a..b, deriv γ t • f (γ t)` depends on the curve `γ` only through its
-oriented image: precomposing `γ` with a `C¹` change of parameter `φ` and integrating over a
-parameter interval `[c, d]` with `φ c = a`, `φ d = b` gives the same value. This file records that
-invariance and its consequence for the generalized winding number of Hungerbühler–Wasem Def 2.1.
+Precomposing a curve `γ` with a `C¹` change of parameter `φ` leaves the generalized winding number
+of Hungerbühler–Wasem (Def 2.1) about a point off the curve unchanged, the parameter interval
+`[[c, d]]` being replaced by `[[φ c, φ d]]`; null-homology in an ambient set transports the same
+way. These are consequences of the reparametrization invariance of the contour integral proved in
+`TauCeti/Analysis/Contour/Curve/Reparam.lean`.
 
-The proof is the interval-integral change-of-variables formula
-`intervalIntegral.integral_deriv_smul_comp'` applied to the contour integrand
-`g u = deriv γ u • f (γ u)`, together with the chain rule
-`deriv (γ ∘ φ) t = φ' t • deriv γ (φ t)`.
-
-Two design points are worth flagging.
-
-* The regularity hypotheses are placed on the **image** `φ '' [[c, d]]`, not on `[[φ c, φ d]]`.
-  This is the honest domain: `φ` is not assumed monotone, so the composite curve may sweep past the
-  endpoints `φ c`, `φ d` and back. The intermediate value theorem
-  (`intermediate_value_uIcc`) supplies `[[φ c, φ d]] ⊆ φ '' [[c, d]]`, so the hypotheses on the
-  image also cover the reparametrized interval, and no monotonicity is needed anywhere.
-* `deriv γ` is the *global* derivative, matching the raw-function design of the roadmap's curve
-  layer. Differentiability of `γ` on the image is therefore an explicit hypothesis rather than a
-  consequence of continuity, since the chain rule identifying `deriv (γ ∘ φ)` needs it pointwise.
+As there, the regularity hypotheses are placed on the swept image `φ '' [[c, d]]` rather than on
+`[[φ c, φ d]]`: `φ` is not assumed monotone, and `intermediate_value_uIcc` gives
+`[[φ c, φ d]] ⊆ φ '' [[c, d]]`, so hypotheses on the image also cover the reparametrized interval.
 
 Only the off-curve case is treated: when `z₀` lies on the curve the winding number is a Cauchy
 principal value, whose symmetric excision windows are themselves reparametrized, and transporting
@@ -38,13 +27,9 @@ them is a separate argument. This is the case that the roadmap's cycle bookkeepi
 
 ## Main results
 
-* `TauCeti.Contour.deriv_comp_reparam` — the chain rule for a reparametrized curve, in the
-  `deriv` form used by the contour integrand.
-* `TauCeti.Contour.integral_deriv_smul_comp_reparam` — reparametrization invariance of the contour
-  integral `∫ t in a..b, deriv γ t • f (γ t)`.
 * `TauCeti.Contour.windingNumber_comp_reparam` — the generalized winding number about a point off
   the curve is unchanged by a `C¹` reparametrization.
-* `TauCeti.Contour.windingNumber_comp_affine` — the affine special case `φ t = α * t + β`.
+* `TauCeti.Contour.windingNumber_comp_reparam_affine` — the affine special case `φ t = α * t + β`.
 * `TauCeti.Contour.IsNullHomologous.comp_reparam` — null-homology transports along a `C¹`
   reparametrization of a curve lying in the ambient set.
 
@@ -55,8 +40,7 @@ independently of its parametrization.
 ## Provenance
 
 This is routine API around the Hungerbühler--Wasem generalized winding number from the contour
-integration roadmap; no formal source is vendored. The change-of-variables input
-`intervalIntegral.integral_deriv_smul_comp'` is Mathlib's.
+integration roadmap; no formal source is vendored.
 
 ## References
 
@@ -72,77 +56,7 @@ open MeasureTheory
 
 namespace TauCeti.Contour
 
-variable {γ : ℝ → ℂ} {φ φ' : ℝ → ℝ} {c d : ℝ} {z₀ : ℂ} {f : ℂ → ℂ} {Ω : Set ℂ}
-
-/-- **Chain rule for a reparametrized curve.** If `φ` has derivative `φ' t` at `t` and `γ` is
-differentiable at `φ t`, then the composite curve `γ ∘ φ` has derivative `φ' t • deriv γ (φ t)`.
-Stated with `HasDerivAt` so that callers can extract either the derivative value or the
-differentiability. -/
-theorem hasDerivAt_comp_reparam {t : ℝ} (hφ : HasDerivAt φ (φ' t) t)
-    (hγ : DifferentiableAt ℝ γ (φ t)) :
-    HasDerivAt (γ ∘ φ) (φ' t • deriv γ (φ t)) t :=
-  hγ.hasDerivAt.scomp t hφ
-
-/-- The `deriv` form of `hasDerivAt_comp_reparam`: the derivative of a reparametrized curve is the
-speed of the parameter change times the derivative of the curve. This is the identity that turns the
-contour integrand of `γ ∘ φ` into the change-of-variables integrand `φ' • (g ∘ φ)`. -/
-theorem deriv_comp_reparam {t : ℝ} (hφ : HasDerivAt φ (φ' t) t)
-    (hγ : DifferentiableAt ℝ γ (φ t)) :
-    deriv (γ ∘ φ) t = φ' t • deriv γ (φ t) :=
-  (hasDerivAt_comp_reparam hφ hγ).deriv
-
-section Regularity
-
-variable (hφ : ∀ t ∈ Set.uIcc c d, HasDerivAt φ (φ' t) t)
-  (hγ : ∀ u ∈ φ '' Set.uIcc c d, DifferentiableAt ℝ γ u)
-
-include hφ
-
-/-- A parameter change with a derivative everywhere on `[[c, d]]` is continuous there. -/
-private theorem continuousOn_of_hasDerivAt : ContinuousOn φ (Set.uIcc c d) :=
-  fun t ht => (hφ t ht).continuousAt.continuousWithinAt
-
-/-- The reparametrized interval `[[φ c, φ d]]` is contained in the image `φ '' [[c, d]]`, by the
-intermediate value theorem. Hypotheses stated on the image therefore also apply on `[[φ c, φ d]]`;
-no monotonicity of `φ` is needed. -/
-theorem uIcc_endpoints_subset_image : Set.uIcc (φ c) (φ d) ⊆ φ '' Set.uIcc c d :=
-  intermediate_value_uIcc (continuousOn_of_hasDerivAt hφ)
-
-include hγ
-
-omit hφ in
-/-- A curve differentiable on the image of the parameter change is continuous there. -/
-private theorem continuousOn_of_differentiableAt : ContinuousOn γ (φ '' Set.uIcc c d) :=
-  fun u hu => (hγ u hu).continuousAt.continuousWithinAt
-
-/-- On `[[c, d]]`, the derivative of the reparametrized curve is `φ' • (deriv γ ∘ φ)`. The
-set-level form of `deriv_comp_reparam`, packaged for `ContinuousOn` and integral congruences. -/
-theorem eqOn_deriv_comp_reparam :
-    Set.EqOn (deriv (γ ∘ φ)) (fun t => φ' t • deriv γ (φ t)) (Set.uIcc c d) :=
-  fun t ht => deriv_comp_reparam (hφ t ht) (hγ (φ t) ⟨t, ht, rfl⟩)
-
-end Regularity
-
-/-- **Reparametrization invariance of the contour integral.** If `φ` is `C¹` on `[[c, d]]`, the
-curve `γ` is `C¹` on the swept image `φ '' [[c, d]]`, and `f` is continuous on the image of the
-curve, then integrating `f` along the reparametrized curve `γ ∘ φ` over `[[c, d]]` gives the same
-value as integrating along `γ` over `[[φ c, φ d]]`. This is Mathlib's change-of-variables formula
-applied to the contour integrand `u ↦ deriv γ u • f (γ u)`. -/
-theorem integral_deriv_smul_comp_reparam
-    (hφ : ∀ t ∈ Set.uIcc c d, HasDerivAt φ (φ' t) t)
-    (hφ' : ContinuousOn φ' (Set.uIcc c d))
-    (hγ : ∀ u ∈ φ '' Set.uIcc c d, DifferentiableAt ℝ γ u)
-    (hγ' : ContinuousOn (deriv γ) (φ '' Set.uIcc c d))
-    (hf : ContinuousOn f (γ '' (φ '' Set.uIcc c d))) :
-    ∫ t in c..d, deriv (γ ∘ φ) t • f (γ (φ t)) = ∫ u in φ c..φ d, deriv γ u • f (γ u) := by
-  have hgcont : ContinuousOn (fun u => deriv γ u • f (γ u)) (φ '' Set.uIcc c d) :=
-    hγ'.smul ((hf.comp (continuousOn_of_differentiableAt hγ) (Set.mapsTo_image γ _)))
-  have hcongr : Set.EqOn (fun t => deriv (γ ∘ φ) t • f (γ (φ t)))
-      (fun t => φ' t • ((fun u => deriv γ u • f (γ u)) ∘ φ) t) (Set.uIcc c d) := by
-    intro t ht
-    simp only [Function.comp_apply, eqOn_deriv_comp_reparam hφ hγ ht, smul_assoc]
-  rw [intervalIntegral.integral_congr hcongr]
-  exact intervalIntegral.integral_deriv_smul_comp' hφ hφ' hgcont
+variable {γ : ℝ → ℂ} {φ φ' : ℝ → ℝ} {c d : ℝ} {z₀ : ℂ} {Ω : Set ℂ}
 
 /-- **Reparametrization invariance of the generalized winding number** (HW Def 2.1), for a point
 `z₀` off the curve. A `C¹` change of parameter `φ` leaves the winding number unchanged, the
@@ -158,9 +72,11 @@ theorem windingNumber_comp_reparam
     (hγ' : ContinuousOn (deriv γ) (φ '' Set.uIcc c d))
     (havoid : ∀ u ∈ φ '' Set.uIcc c d, γ u ≠ z₀) :
     windingNumber (γ ∘ φ) c d z₀ = windingNumber γ (φ c) (φ d) z₀ := by
-  have hφcont : ContinuousOn φ (Set.uIcc c d) := continuousOn_of_hasDerivAt hφ
-  have hγcont : ContinuousOn γ (φ '' Set.uIcc c d) := continuousOn_of_differentiableAt hγ
-  have hsub : Set.uIcc (φ c) (φ d) ⊆ φ '' Set.uIcc c d := uIcc_endpoints_subset_image hφ
+  have hφcont : ContinuousOn φ (Set.uIcc c d) :=
+    fun t ht => (hφ t ht).continuousAt.continuousWithinAt
+  have hγcont : ContinuousOn γ (φ '' Set.uIcc c d) :=
+    fun u hu => (hγ u hu).continuousAt.continuousWithinAt
+  have hsub : Set.uIcc (φ c) (φ d) ⊆ φ '' Set.uIcc c d := intermediate_value_uIcc hφcont
   have hmaps : Set.MapsTo φ (Set.uIcc c d) (φ '' Set.uIcc c d) := Set.mapsTo_image φ _
   -- the kernel `(· - z₀)⁻¹` is continuous along the curve, since `γ` avoids `z₀`
   have hker : ContinuousOn (fun z : ℂ => (z - z₀)⁻¹) (γ '' (φ '' Set.uIcc c d)) := by
@@ -172,38 +88,44 @@ theorem windingNumber_comp_reparam
     ContinuousOn.congr (hφ'.smul (hγ'.comp hφcont hmaps)) (eqOn_deriv_comp_reparam hφ hγ)
   have hcompcont : ContinuousOn (γ ∘ φ) (Set.uIcc c d) := hγcont.comp hφcont hmaps
   have hcompavoid : ∀ t ∈ Set.uIcc c d, (γ ∘ φ) t ≠ z₀ := fun t ht => havoid (φ t) ⟨t, ht, rfl⟩
-  have hintL : IntervalIntegrable
-      (fun t => ((γ ∘ φ) t - z₀)⁻¹ * deriv (γ ∘ φ) t) volume c d :=
-    (((hcompcont.sub continuousOn_const).inv₀
-      fun t ht => sub_ne_zero.mpr (hcompavoid t ht)).mul hderivcont).intervalIntegrable
-  have hintR : IntervalIntegrable
-      (fun u => (γ u - z₀)⁻¹ * deriv γ u) volume (φ c) (φ d) :=
-    ((((hγcont.mono hsub).sub continuousOn_const).inv₀
-      fun u hu => sub_ne_zero.mpr (havoid u (hsub hu))).mul (hγ'.mono hsub)).intervalIntegrable
-  rw [windingNumber_eq_integral_of_avoidance hcompcont hcompavoid hintL,
+  rw [windingNumber_eq_integral_of_avoidance hcompcont hcompavoid
+      (intervalIntegrable_inv_sub_mul_deriv hcompcont hcompavoid hderivcont.intervalIntegrable),
     windingNumber_eq_integral_of_avoidance (hγcont.mono hsub)
-      (fun u hu => havoid u (hsub hu)) hintR]
+      (fun u hu => havoid u (hsub hu))
+      (intervalIntegrable_inv_sub_mul_deriv (hγcont.mono hsub) (fun u hu => havoid u (hsub hu))
+        (hγ'.mono hsub).intervalIntegrable)]
   congr 1
-  have := integral_deriv_smul_comp_reparam (f := fun z : ℂ => (z - z₀)⁻¹) hφ hφ' hγ hγ' hker
-  simpa only [smul_eq_mul, mul_comm, Function.comp_apply] using this
+  -- both index integrands are the contour integrand of the kernel `(· - z₀)⁻¹`, with the two
+  -- factors in the opposite order
+  have hL : ∫ t in c..d, ((γ ∘ φ) t - z₀)⁻¹ * deriv (γ ∘ φ) t
+      = ∫ t in c..d, deriv (γ ∘ φ) t • ((γ ∘ φ) t - z₀)⁻¹ :=
+    intervalIntegral.integral_congr fun t _ => by rw [smul_eq_mul, mul_comm]
+  have hR : ∫ u in φ c..φ d, (γ u - z₀)⁻¹ * deriv γ u
+      = ∫ u in φ c..φ d, deriv γ u • (γ u - z₀)⁻¹ :=
+    intervalIntegral.integral_congr fun u _ => by rw [smul_eq_mul, mul_comm]
+  rw [hL, hR]
+  exact integral_deriv_smul_comp_reparam (f := fun z : ℂ => (z - z₀)⁻¹) hφ hφ' hγ hγ' hker
 
 /-- The affine special case of `windingNumber_comp_reparam`: precomposing a curve with
 `t ↦ α * t + β` moves the parameter interval to `[[α * c + β, α * d + β]]` and leaves the winding
 number about an off-curve point unchanged. Unlike the general statement this needs no separate
 continuity hypothesis on the parameter speed, the derivative being the constant `α`. -/
-theorem windingNumber_comp_affine {α β : ℝ}
-    (hγ : ∀ u ∈ (fun t => α * t + β) '' Set.uIcc c d, DifferentiableAt ℝ γ u)
-    (hγ' : ContinuousOn (deriv γ) ((fun t => α * t + β) '' Set.uIcc c d))
-    (havoid : ∀ u ∈ (fun t => α * t + β) '' Set.uIcc c d, γ u ≠ z₀) :
-    windingNumber (fun t => γ (α * t + β)) c d z₀
-      = windingNumber γ (α * c + β) (α * d + β) z₀ :=
-  windingNumber_comp_reparam (φ' := fun _ => α)
+theorem windingNumber_comp_reparam_affine {α β : ℝ}
+    (hγ : ∀ u ∈ Set.uIcc (α * c + β) (α * d + β), DifferentiableAt ℝ γ u)
+    (hγ' : ContinuousOn (deriv γ) (Set.uIcc (α * c + β) (α * d + β)))
+    (havoid : ∀ u ∈ Set.uIcc (α * c + β) (α * d + β), γ u ≠ z₀) :
+    windingNumber (γ ∘ fun t => α * t + β) c d z₀
+      = windingNumber γ (α * c + β) (α * d + β) z₀ := by
+  have himg : (fun t => α * t + β) '' Set.uIcc c d = Set.uIcc (α * c + β) (α * d + β) := by
+    rw [show (fun t : ℝ => α * t + β) = (fun x => x + β) ∘ (α * ·) from funext fun _ => rfl,
+      Set.image_comp, Set.image_const_mul_uIcc, Set.image_add_const_uIcc]
+  refine windingNumber_comp_reparam (φ' := fun _ => α)
     (fun t _ => by simpa using ((hasDerivAt_id t).const_mul α).add_const β)
-    continuousOn_const hγ hγ' havoid
+    continuousOn_const ?_ ?_ ?_ <;> rw [himg]
+  exacts [hγ, hγ', havoid]
 
 /-- **Null-homology transports along a reparametrization.** If a curve lies in `Ω` and is
-null-homologous there, then so is any `C¹` reparametrization of it: every point outside `Ω` is
-automatically off the curve, so `windingNumber_comp_reparam` applies at each such point. -/
+null-homologous there, then so is any `C¹` reparametrization of it. -/
 theorem IsNullHomologous.comp_reparam
     (h : IsNullHomologous γ (φ c) (φ d) Ω)
     (hφ : ∀ t ∈ Set.uIcc c d, HasDerivAt φ (φ' t) t)


### PR DESCRIPTION
This PR adds reparametrization invariance for contour integrals and for the generalized winding number, in `TauCeti/Analysis/Contour/Winding/Number/Reparam.lean`. Precomposing a curve `γ` with a `C¹` change of parameter `φ` on `[[c, d]]` leaves the contour integral `∫ t in a..b, deriv γ t • f (γ t)` unchanged, the parameter interval being replaced by `[[φ c, φ d]]`; the winding number about a point off the curve, and null-homology in an ambient set, transport along the same reparametrization.

The roadmap target is `TauCetiRoadmap/ContourIntegration/README.md`, Layer 0 ("curves, cycles, and the generalized winding number"). `Suggested.lean` names this API explicitly as the missing piece behind the basepoint hypothesis of the summit: the off-poles basepoint of `hungerbuhlerWasem_residueTheorem` "is mathematically removable by cyclic reparametrization, but it remains a formalization residual until a reparametrization-invariance API exists". This supplies that API for the off-curve case. It sits beside the existing translation, scaling, affine, reversal and concatenation invariances in `TauCeti/Analysis/Contour/Winding/Number/`, which cover coordinate changes of the *target* but none of the *parameter*.

Two design points, both recorded in the module docstring. Regularity hypotheses are stated on the swept image `φ '' [[c, d]]` rather than on `[[φ c, φ d]]`, since `φ` is not assumed monotone; `intermediate_value_uIcc` supplies `[[φ c, φ d]] ⊆ φ '' [[c, d]]`, so the image hypotheses also cover the reparametrized interval and no monotonicity is needed. And because the roadmap's raw-function curve layer uses the global `deriv γ`, differentiability of `γ` on the image is an explicit hypothesis, not a consequence of continuity: the chain rule identifying `deriv (γ ∘ φ)` needs it pointwise. Only the off-curve case is treated; on the curve the winding number is a Cauchy principal value whose symmetric excision windows are themselves reparametrized, which is a separate argument.

No Mathlib infrastructure is vendored. The change-of-variables input is Mathlib's `intervalIntegral.integral_deriv_smul_comp'`, and the containment of the reparametrized interval in the image is Mathlib's `intermediate_value_uIcc`.

`lake build` and `lake exe axioms` are green (`audited 10569 TauCeti declaration(s); all within the allowlist`).

<!--tauceti-target:v1 {"focus":"ContourIntegration","id":"reparametrization-invariance-winding-number"}-->

🤖 Prepared with Claude Code
