### PR TITLE
chore: ban set_option in TauCeti/ via a textual CI guard

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,6 +25,17 @@ jobs:
             exit 1
           fi
 
+      # No-set_option guard. `set_option` is an escape hatch (it can raise maxHeartbeats,
+      # silence linters, bump maxRecDepth, ...), so TauCeti/ source may not use it. Like the
+      # import guard it is a textual scan that needs no elaboration, so it runs trusted and
+      # outside the sandbox.
+      - name: No-set_option guard (TauCeti/ and TauCeti.lean use no set_option)
+        run: |
+          if grep -rIn '^set_option ' TauCeti/ TauCeti.lean; then
+            echo "::error::TauCeti/ and TauCeti.lean may not use set_option (it can weaken maxHeartbeats, linters, maxRecDepth, ...); remove it"
+            exit 1
+          fi
+
       # No aggregator check: the root TauCeti.lean is intentionally empty and imports nothing.
       # The build globs every TauCeti/ module directly, so nothing depends on a root that
       # re-exports the library.

--- a/.github/workflows/pr-build.yml
+++ b/.github/workflows/pr-build.yml
@@ -265,6 +265,17 @@ jobs:
             echo "::error::TauCeti/ must not import TauCetiRoadmap or TauCetiReview"; exit 1
           fi
 
+      # No-set_option guard. `set_option` is an escape hatch (it can raise maxHeartbeats,
+      # silence linters, bump maxRecDepth, ...), so the overlaid TauCeti/ may not use it. Like
+      # the import guard it is a textual scan that needs no elaboration, so it runs trusted (on
+      # the overlaid base/TauCeti/) outside the landrun sandbox.
+      - name: No-set_option guard (TauCeti/ and TauCeti.lean use no set_option)
+        if: ${{ env.INFRA != '1' }}
+        run: |
+          if grep -rIn '^set_option ' base/TauCeti/ base/TauCeti.lean; then
+            echo "::error::TauCeti/ may not use set_option (it can weaken maxHeartbeats, linters, maxRecDepth, ...); remove it"; exit 1
+          fi
+
       - name: Install elan (trusted)
         if: ${{ env.INFRA != '1' }}
         run: |


### PR DESCRIPTION
This PR adds a No-set_option guard that fails CI if any line beginning with `set_option ` appears under `TauCeti/` (or the root `TauCeti.lean`): `set_option` is an escape hatch that can raise `maxHeartbeats`, silence linters, or bump `maxRecDepth`, so the AI-owned library may not use it. The guard is modeled on the existing import-boundary guard and lives inline in both `ci.yml` (the post-merge health check on `main`) and `pr-build.yml` (a trusted PR-time step on the overlaid `base/TauCeti/`, outside the landrun sandbox — a textual scan needs no elaboration). There are zero `set_option` uses under `TauCeti/` today, so the guard starts green.

This touches `.github/` (human-owned), so it routes to human review and merge, as CI-infrastructure changes should.

🤖 Prepared with Claude Code