### PR TITLE
feat: advisory heartbeat profile comment for PRs

### DIFF
--- a/.github/workflows/pr-profile.yml
+++ b/.github/workflows/pr-profile.yml
@@ -1,0 +1,284 @@
+name: pr-profile
+
+# Advisory heartbeat profile for a PR's TauCeti/ changes. Posts (and updates) a
+# sticky PR comment; it NEVER blocks merge and posts no commit status. The
+# metric is Mathlib's `countHeartbeats` linter (in `maxHeartbeats` units),
+# which is deterministic and machine-independent, so a base -> head comparison
+# is meaningful. New files get an absolute count; modified files get a
+# base -> head comparison and are flagged when a refactor makes a file at least
+# 1.5x more expensive to elaborate (see scripts/profile/render.py).
+#
+# Trust model mirrors pr-build.yml: this is a base-branch-defined workflow
+# (pull_request_target / issue_comment / workflow_dispatch all take the base
+# definition), it overlays ONLY the PR's TauCeti/ sources onto a trusted base
+# checkout, and it elaborates that untrusted code solely under landrun (offline,
+# no secrets or token in reach). The GITHUB_TOKEN is never passed into the
+# sandbox; the sticky comment is posted by the trusted step AFTER the sandbox
+# has exited, reading only the rendered Markdown the sandbox left behind. The
+# measurement and render scripts come from the trusted base (scripts/ is never
+# overlaid from the PR), so a PR cannot alter how it is measured.
+#
+# Cost control: to avoid re-profiling on every push, this runs on PR open, on a
+# `/profile` comment from the PR author or a collaborator, and on manual
+# dispatch. It builds only the changed modules and their dependency cones, not
+# the whole library.
+
+on:
+  pull_request_target:
+    types: [opened]
+  issue_comment:
+    types: [created]
+  workflow_dispatch:
+    inputs:
+      pr: { description: "PR number to profile", required: true, type: string }
+
+permissions:
+  contents: read
+  pull-requests: write
+
+# Route non-`/profile` comment events (e.g. `/review`) into a unique per-run
+# group so they cannot cancel an in-flight profile before the job `if` below
+# short-circuits them; real triggers share the per-PR group.
+concurrency:
+  group: >-
+    ${{
+      (github.event_name == 'pull_request_target' ||
+       github.event_name == 'workflow_dispatch' ||
+       (github.event_name == 'issue_comment' &&
+        startsWith(github.event.comment.body, '/profile')))
+      && format('pr-profile-{0}',
+           github.event.pull_request.number ||
+           github.event.issue.number ||
+           inputs.pr)
+      || format('pr-profile-noop-{0}', github.run_id)
+    }}
+  cancel-in-progress: true
+
+jobs:
+  profile:
+    runs-on: ubuntu-24.04
+    # Fresh PR or manual dispatch: always. Comment: only `/profile` on a PR from
+    # the PR author or someone with write access — the same code-execution
+    # surface as the auto-profile on `opened`, just re-triggered by a trusted
+    # user, so it adds no new trust.
+    if: >-
+      github.event_name == 'pull_request_target' ||
+      github.event_name == 'workflow_dispatch' ||
+      (github.event_name == 'issue_comment' &&
+       github.event.issue.pull_request != null &&
+       startsWith(github.event.comment.body, '/profile') &&
+       (github.event.comment.user.login == github.event.issue.user.login ||
+        contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.comment.author_association)))
+    env:
+      LANDRUN_SHA256: 645178e3239cd33760560834e50efea0864183a2a8a82faf199760dffee6dd71
+      LANDRUN_VER: v0.1.14
+    steps:
+      # --- Trusted setup: no PR code runs until the landrun measurement phase.
+      - name: Resolve PR head and base
+        id: pr
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+          case "${{ github.event_name }}" in
+            pull_request_target)
+              NUM='${{ github.event.pull_request.number }}'
+              SHA='${{ github.event.pull_request.head.sha }}'
+              HEAD_REPO='${{ github.event.pull_request.head.repo.full_name }}'
+              BASE_REF='${{ github.event.pull_request.base.ref }}'
+              ;;
+            issue_comment)  NUM='${{ github.event.issue.number }}' ;;
+            workflow_dispatch) NUM='${{ inputs.pr }}' ;;
+          esac
+          if [ "${{ github.event_name }}" != "pull_request_target" ]; then
+            read -r SHA HEAD_REPO BASE_REF < <(gh api "repos/$REPO/pulls/$NUM" \
+              --jq '"\(.head.sha) \(.head.repo.full_name) \(.base.ref)"')
+          fi
+          {
+            echo "num=$NUM"
+            echo "sha=$SHA"
+            echo "head_repo=$HEAD_REPO"
+            echo "base_ref=$BASE_REF"
+          } >> "$GITHUB_OUTPUT"
+          echo "Profiling PR #$NUM @ $SHA from $HEAD_REPO (base $BASE_REF)"
+
+      - name: List added and modified TauCeti/ Lean files (trusted GitHub file list)
+        id: files
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+          NUM: ${{ steps.pr.outputs.num }}
+        run: |
+          set -euo pipefail
+          # From the trusted API file list, keep only .lean files under TauCeti/
+          # (plus the root TauCeti.lean). `added`/`copied` count as new; anything
+          # else that still exists at base counts as modified. Paths outside
+          # TauCeti/ are ignored here: only TauCeti/ is overlaid and profiled.
+          json=$(gh api --paginate "repos/$REPO/pulls/$NUM/files" \
+            --jq '.[] | select((.filename | endswith(".lean")) and
+                               ((.filename | startswith("TauCeti/")) or .filename == "TauCeti.lean"))
+                      | "\(.status)\t\(.filename)"')
+          added=$(printf '%s\n' "$json" | awk -F'\t' '$1=="added" || $1=="copied" {print $2}' | tr '\n' ' ')
+          modified=$(printf '%s\n' "$json" | awk -F'\t' '$1=="modified" || $1=="renamed" || $1=="changed" {print $2}' | tr '\n' ' ')
+          echo "added=$added" >> "$GITHUB_OUTPUT"
+          echo "modified=$modified" >> "$GITHUB_OUTPUT"
+          if [ -z "${added// }" ] && [ -z "${modified// }" ]; then
+            echo "none=1" >> "$GITHUB_OUTPUT"
+            echo "No TauCeti/ Lean files changed; nothing to profile."
+          else
+            echo "added: $added"
+            echo "modified: $modified"
+          fi
+
+      - name: Checkout base (trusted)
+        if: ${{ steps.files.outputs.none != '1' }}
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ steps.pr.outputs.base_ref }}
+          path: base
+          persist-credentials: false
+          fetch-depth: 1
+
+      - name: Checkout PR head (untrusted, no credentials)
+        if: ${{ steps.files.outputs.none != '1' }}
+        uses: actions/checkout@v4
+        with:
+          repository: ${{ steps.pr.outputs.head_repo }}
+          ref: ${{ steps.pr.outputs.sha }}
+          path: pr
+          persist-credentials: false
+
+      - name: Overlay PR TauCeti/ and root TauCeti.lean onto the trusted base (reject symlinks)
+        if: ${{ steps.files.outputs.none != '1' }}
+        run: |
+          set -euo pipefail
+          if find pr/TauCeti -type l -print | grep -q .; then
+            echo "::error::symlinks are not allowed under TauCeti/"; exit 1
+          fi
+          test -d pr/TauCeti && test ! -L pr/TauCeti
+          rm -rf base/TauCeti
+          cp -a pr/TauCeti base/TauCeti
+          if [ -e pr/TauCeti.lean ]; then
+            test ! -L pr/TauCeti.lean || { echo "::error::TauCeti.lean must not be a symlink"; exit 1; }
+            cp -a pr/TauCeti.lean base/TauCeti.lean
+          fi
+
+      # Prepare the measurement inputs OUTSIDE the sandbox (no Lean runs here):
+      # the head source is the overlaid working-tree file; the base source comes
+      # from `git show` of the base tip. Both are written under base/.lake (the
+      # sandbox's only writable mount) so the landrun measurement can read them.
+      - name: Prepare measurement sources
+        id: prep
+        if: ${{ steps.files.outputs.none != '1' }}
+        env:
+          ADDED: ${{ steps.files.outputs.added }}
+          MODIFIED: ${{ steps.files.outputs.modified }}
+        run: |
+          set -euo pipefail
+          PREP="$PWD/base/.lake/tmp/profile"
+          rm -rf "$PREP"
+          mkdir -p "$PREP/src/added" "$PREP/src/base" "$PREP/src/head"
+          : > "$PREP/manifest.tsv"
+          modules=""
+          i=0
+          for path in $ADDED; do
+            slug=$(printf 'a%03d' "$i"); i=$((i + 1))
+            cp "base/$path" "$PREP/src/added/$slug.lean"
+            printf 'added\t%s\t%s\n' "$slug" "$path" >> "$PREP/manifest.tsv"
+            modules="$modules $(printf '%s' "$path" | sed -e 's/\.lean$//' -e 's#/#.#g')"
+          done
+          j=0
+          for path in $MODIFIED; do
+            slug=$(printf 'm%03d' "$j"); j=$((j + 1))
+            cp "base/$path" "$PREP/src/head/$slug.lean"
+            # base source; if it does not exist at base (should not for a
+            # modified file) the comparison for it is simply skipped.
+            git -C base show "HEAD:$path" > "$PREP/src/base/$slug.lean" 2>/dev/null \
+              || rm -f "$PREP/src/base/$slug.lean"
+            printf 'modified\t%s\t%s\n' "$slug" "$path" >> "$PREP/manifest.tsv"
+            modules="$modules $(printf '%s' "$path" | sed -e 's/\.lean$//' -e 's#/#.#g')"
+          done
+          echo "modules=${modules# }" >> "$GITHUB_OUTPUT"
+          echo "Prepared $(grep -c . "$PREP/manifest.tsv") file(s); build targets:${modules}"
+
+      - name: Install elan (trusted)
+        if: ${{ steps.files.outputs.none != '1' }}
+        run: |
+          curl -sSfL https://elan.lean-lang.org/elan-init.sh -o elan-init.sh
+          chmod +x elan-init.sh && ./elan-init.sh -y --default-toolchain none
+          echo "$HOME/.elan/bin" >> "$GITHUB_PATH"
+
+      - name: Install landrun (pinned + checksum) and self-test (fail closed)
+        if: ${{ steps.files.outputs.none != '1' }}
+        run: |
+          set -euo pipefail
+          curl -sSL -H "Accept: application/octet-stream" \
+            "https://github.com/Zouuup/landrun/releases/download/${LANDRUN_VER}/landrun-linux-amd64" -o landrun
+          echo "${LANDRUN_SHA256}  landrun" | sha256sum -c -
+          mkdir -p "$HOME/.local/bin"; install -m 0755 landrun "$HOME/.local/bin/landrun"
+          echo "$HOME/.local/bin" >> "$GITHUB_PATH"
+          export PATH="$HOME/.local/bin:$PATH"
+          landrun --version || true
+          set +e
+          landrun --rox /usr --rox /etc --rw /dev/null -- bash -c 'echo ok' >/dev/null 2>&1; ok=$?
+          landrun --rox /usr --rox /etc --rw /dev/null -- bash -c 'echo x > /etc/landrun-probe' >/dev/null 2>&1; wr=$?
+          landrun --rox /usr --rox /etc --rw /dev/null -- bash -c 'echo x > /dev/shm/landrun-probe' >/dev/null 2>&1; shm=$?
+          landrun --rox /usr --rox /etc --rw /dev/null -- bash -c 'curl -sS --max-time 8 https://example.com >/dev/null' >/dev/null 2>&1; net=$?
+          set -e
+          echo "self-test: run=$ok write=$wr shm=$shm net=$net (nonzero = denied for w/shm/net)"
+          if [ $ok -ne 0 ] || [ $wr -eq 0 ] || [ $shm -eq 0 ] || [ $net -eq 0 ]; then
+            echo "::error::landrun not enforcing (run=$ok write=$wr shm=$shm net=$net); refusing to run PR code"; exit 1
+          fi
+
+      - name: Fetch Mathlib oleans (network, no token; no PR code)
+        if: ${{ steps.files.outputs.none != '1' }}
+        run: ( cd base && lake exe cache get ) && mkdir -p base/.lake/tmp
+
+      # Build the changed modules (their dependency cones) and measure every
+      # prepared source, entirely under landrun: offline, writes confined to
+      # base/.lake, and with no token in the passed --env list. This is the only
+      # phase that runs the PR's Lean code. Building is tolerant (|| true) so a
+      # file that fails to compile still yields a profile for the rest; the
+      # per-file measurement (scripts/profile/measure.sh) is tolerant too.
+      - name: Build changed modules and measure heartbeats (landrun, offline)
+        if: ${{ steps.files.outputs.none != '1' }}
+        env:
+          LAKE_NO_CACHE: "true"
+          MODULES: ${{ steps.prep.outputs.modules }}
+        run: |
+          export PATH="$HOME/.local/bin:$HOME/.elan/bin:$PATH"
+          landrun --rox /usr --rox /etc \
+            --rw /dev/null --rox /dev/zero --rox /dev/urandom --rox /dev/random \
+            --rox "$HOME/.elan" --rox "$PWD/base" --rw "$PWD/base/.lake" \
+            --env PATH --env HOME --env CI --env LAKE_NO_CACHE --env MODULES \
+            -- bash -euxo pipefail -c 'cd base && lake build $MODULES || true; exec bash scripts/profile/measure.sh .lake/tmp/profile'
+
+      - name: Render the profile comment (trusted; sandbox has exited)
+        id: render
+        if: ${{ steps.files.outputs.none != '1' }}
+        env:
+          PREP: ${{ github.workspace }}/base/.lake/tmp/profile
+          OUTPUT: ${{ github.workspace }}/profile.md
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: python3 base/scripts/profile/render.py
+
+      - name: Post or update the sticky profile comment
+        if: ${{ steps.files.outputs.none != '1' }}
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+          NUM: ${{ steps.pr.outputs.num }}
+        run: |
+          set -euo pipefail
+          marker="<!-- proof-profile-comment -->"
+          existing=$(gh api "repos/$REPO/issues/$NUM/comments" --paginate \
+            --jq "[.[] | select(.body | startswith(\"$marker\"))] | first | .id // empty")
+          if [ -n "$existing" ]; then
+            jq -n --rawfile body profile.md '{body: $body}' \
+              | gh api -X PATCH "repos/$REPO/issues/comments/$existing" --input -
+            echo "Updated comment $existing on PR #$NUM."
+          else
+            gh pr comment "$NUM" --repo "$REPO" --body-file profile.md
+            echo "Posted profile comment on PR #$NUM."
+          fi

--- a/scripts/profile/measure.sh
+++ b/scripts/profile/measure.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+# Runs INSIDE the landrun sandbox (offline, no token, writes confined to
+# base/.lake). For every prepared Lean source under <prep>/src, elaborate it
+# with Mathlib's countHeartbeats linter and write the linter's output next to
+# it as <name>.hb. The library has already been built by the caller, so a
+# file's imports resolve from the built oleans and only these single files are
+# re-elaborated (out of tree, like Lean Pool's proof profiler).
+#
+# Advisory: a file that fails to elaborate records the failure in its own .hb
+# log (the caller's render step reports it) and never fails this script, so one
+# bad file cannot sink the whole profile.
+#
+# Usage: measure.sh <prep-dir>   (with the working directory at the built base)
+set -uo pipefail
+prep="${1:?usage: measure.sh <prep-dir>}"
+
+jobs="$(nproc)"
+[ "$jobs" -gt 1 ] && jobs=$((jobs - 1))
+
+# One file per worker: elaborate it and capture stdout+stderr as its .hb log.
+# `|| true` keeps a failing elaboration from tripping the run; the .hb log
+# still holds whatever the linter and any error printed.
+find "$prep/src" -name '*.lean' -print0 \
+  | xargs -0 -P "$jobs" -I{} bash -c '
+      f="$1"
+      out="${f%.lean}.hb"
+      lake env lean -Dlinter.countHeartbeats=true "$f" > "$out" 2>&1 || true
+    ' _ {}
+
+echo "Measured $(find "$prep/src" -name '*.hb' | wc -l) file(s)."

--- a/scripts/profile/render.py
+++ b/scripts/profile/render.py
@@ -1,0 +1,219 @@
+#!/usr/bin/env python3
+"""Render the proof-profile PR comment from countHeartbeats measurement logs.
+
+Called by .github/workflows/pr-profile.yml, in the trusted step that runs
+*after* the sandboxed measurement finishes. Inputs are environment variables
+and the per-file `.hb` logs the sandbox wrote under $PREP/src; the output is
+the Markdown comment body written to $OUTPUT.
+
+The metric is heartbeats, from Mathlib's `linter.countHeartbeats` (reported in
+`maxHeartbeats` units), summed over a file's declarations. Heartbeats are
+deterministic and machine-independent, so they are the signal we compare and
+flag on; wall time is not measured here.
+
+New (added) files get an absolute per-file count. Modified files get a
+base -> head comparison: a file is flagged as a build-cost regression when its
+head cost is at least FLAG_RATIO times its base cost, provided the absolute
+rise clears FLAG_MIN_ABS_HB (so a tiny file cannot flag on a few heartbeats).
+The default ratio is 1.5, i.e. a refactor may not make a file half again as
+expensive to elaborate. The comment is advisory and never fails the build.
+
+A modified file's base and head sources are both elaborated against the same
+built (head) environment. That is sound when a change is local to the file's
+own proofs and definition bodies; a base source that no longer elaborates
+there (typically because a statement it depends on changed) is reported and
+left out of the comparison rather than mismeasured.
+"""
+
+import os
+import re
+from pathlib import Path
+
+# Matches both `'Foo.bar' used 1234 heartbeats, ...` (named declaration) and
+# `Used 25 heartbeats, ...` (anonymous, e.g. an `example`).
+HEARTBEAT_RE = re.compile(
+    r"(?:'[^']+'\s+)?[Uu]sed\s+(?:approximately\s+)?(?P<heartbeats>[0-9]+)\s+heartbeats"
+)
+
+FLAG_RATIO = float(os.environ.get("FLAG_RATIO", "1.5"))
+FLAG_MIN_ABS_HB = float(os.environ.get("FLAG_MIN_ABS_HB", "1000"))
+
+prep = Path(os.environ["PREP"])
+output = Path(os.environ.get("OUTPUT", "profile.md"))
+run_url = os.environ.get("RUN_URL", "")
+
+MARKER = "<!-- proof-profile-comment -->"
+
+
+def parse_hb(log_path: Path) -> dict | None:
+    """Total heartbeats, declaration count, and error state for one `.hb` log.
+
+    Returns None when the log is absent (the file was not measured on this side).
+    """
+    if not log_path.exists():
+        return None
+    heartbeats = 0.0
+    declarations = 0
+    errored = False
+    for line in log_path.read_text(errors="replace").splitlines():
+        if re.search(r"\berror:", line):
+            errored = True
+        match = HEARTBEAT_RE.search(line)
+        if match:
+            heartbeats += float(match.group("heartbeats"))
+            declarations += 1
+    return {"heartbeats": heartbeats, "declarations": declarations, "errored": errored}
+
+
+def fmt(value: float) -> str:
+    return f"{value:,.0f}"
+
+
+def fmt_signed(value: float) -> str:
+    return f"{value:+,.0f}"
+
+
+def fmt_pct(delta: float, base: float) -> str:
+    if base <= 0:
+        return "—"
+    return f"{delta / base * 100:+.1f}%"
+
+
+def fmt_ratio(head: float, base: float) -> str:
+    if base <= 0:
+        return "—"
+    return f"{head / base:.2f}×"
+
+
+# The prep step writes one manifest row per profiled file: side, slug, path.
+# The slug names the file's `.hb` log(s); reading it here (rather than
+# recomputing it) keeps this in lockstep with prep however slugs are formed.
+added: list[tuple[str, str]] = []
+modified: list[tuple[str, str]] = []
+manifest = prep / "manifest.tsv"
+if manifest.exists():
+    for row in manifest.read_text().splitlines():
+        parts = row.split("\t")
+        if len(parts) != 3:
+            continue
+        side, slug, path = parts
+        (added if side == "added" else modified).append((slug, path))
+
+out: list[str] = [f"{MARKER}\n", "## Proof profile (heartbeats)\n\n"]
+out.append(
+    "Advisory only; this never blocks merge. Heartbeats come from Mathlib's "
+    "`countHeartbeats` linter, in `maxHeartbeats` units, summed over each "
+    "file's declarations.\n\n"
+)
+
+# --- Modified files: base -> head comparison, with the regression flag. ------
+comparison_rows = []
+uncompared = []
+for slug, path in modified:
+    base = parse_hb(prep / "src" / "base" / f"{slug}.hb")
+    head = parse_hb(prep / "src" / "head" / f"{slug}.hb")
+    if head is None:
+        continue
+    if base is None or base["errored"] or base["heartbeats"] <= 0:
+        uncompared.append(path)
+        continue
+    base_hb = base["heartbeats"]
+    head_hb = head["heartbeats"]
+    delta = head_hb - base_hb
+    flagged = head_hb >= FLAG_RATIO * base_hb and delta >= FLAG_MIN_ABS_HB
+    comparison_rows.append(
+        {
+            "path": path,
+            "base": base_hb,
+            "head": head_hb,
+            "delta": delta,
+            "flagged": flagged,
+            "head_err": head["errored"],
+        }
+    )
+
+comparison_rows.sort(key=lambda r: (-r["delta"], r["path"]))
+flagged_rows = [r for r in comparison_rows if r["flagged"]]
+
+if comparison_rows:
+    total_base = sum(r["base"] for r in comparison_rows)
+    total_head = sum(r["head"] for r in comparison_rows)
+    total_delta = total_head - total_base
+    total_flag = total_head >= FLAG_RATIO * total_base and total_delta >= FLAG_MIN_ABS_HB
+
+    out.append("### Modified files — base → head\n\n")
+    if flagged_rows or total_flag:
+        names = ", ".join(f"`{r['path']}`" for r in flagged_rows) or "the total"
+        out.append(
+            f"⚠️ **Build-cost regression:** {names} grew by at least "
+            f"{FLAG_RATIO:g}× in heartbeats (floor {fmt(FLAG_MIN_ABS_HB)} HB). "
+            "A refactor should not make a file half again as expensive to "
+            "elaborate; please check whether this is intended.\n\n"
+        )
+    else:
+        out.append(
+            f"No modified file crossed the {FLAG_RATIO:g}× regression flag "
+            f"(floor {fmt(FLAG_MIN_ABS_HB)} HB).\n\n"
+        )
+    out.append("| File | HB base | HB head | Δ HB | Δ % | ×base |\n")
+    out.append("|---|---:|---:|---:|---:|---:|\n")
+    for r in comparison_rows:
+        mark = " ⚠️" if r["flagged"] else ""
+        note = " (head errored)" if r["head_err"] else ""
+        out.append(
+            f"| `{r['path']}`{mark}{note} | {fmt(r['base'])} | {fmt(r['head'])} "
+            f"| {fmt_signed(r['delta'])} | {fmt_pct(r['delta'], r['base'])} "
+            f"| {fmt_ratio(r['head'], r['base'])} |\n"
+        )
+    out.append(
+        f"| **Total** | **{fmt(total_base)}** | **{fmt(total_head)}** "
+        f"| **{fmt_signed(total_delta)}** | **{fmt_pct(total_delta, total_base)}** "
+        f"| **{fmt_ratio(total_head, total_base)}** |\n\n"
+    )
+
+if uncompared:
+    out.append(
+        "_Not compared (the base source no longer elaborates against the "
+        "built environment, usually because a statement it depends on "
+        "changed): "
+        + ", ".join(f"`{p}`" for p in uncompared)
+        + "._\n\n"
+    )
+
+# --- Added files: absolute cost. ---------------------------------------------
+added_rows = []
+for slug, path in added:
+    head = parse_hb(prep / "src" / "added" / f"{slug}.hb")
+    if head is None:
+        continue
+    added_rows.append(
+        {
+            "path": path,
+            "heartbeats": head["heartbeats"],
+            "declarations": head["declarations"],
+            "errored": head["errored"],
+        }
+    )
+added_rows.sort(key=lambda r: (-r["heartbeats"], r["path"]))
+
+if added_rows:
+    out.append("### New files — absolute cost\n\n")
+    out.append("| File | Heartbeats | Declarations |\n")
+    out.append("|---|---:|---:|\n")
+    for r in added_rows:
+        note = " ⚠️ (errored)" if r["errored"] else ""
+        out.append(
+            f"| `{r['path']}`{note} | {fmt(r['heartbeats'])} "
+            f"| {fmt(r['declarations'])} |\n"
+        )
+    out.append("\n")
+
+if not comparison_rows and not added_rows and not uncompared:
+    out.append("_No new or modified `TauCeti/` Lean files to profile._\n\n")
+
+if run_url:
+    out.append(f"<sub>[measurement run]({run_url}) · re-run with `/profile`</sub>\n")
+
+output.write_text("".join(out))
+print(f"Wrote {output} ({len(comparison_rows)} compared, {len(added_rows)} new, "
+      f"{len(flagged_rows)} flagged)")


### PR DESCRIPTION
This PR adds an advisory `pr-profile` workflow that posts (and updates) a sticky PR comment reporting the elaboration cost of a PR's `TauCeti/` changes, measured with Mathlib's `countHeartbeats` linter in `maxHeartbeats` units. New files get an absolute per-file count; modified files get a base to head comparison, and a file is flagged when a refactor makes it at least 1.5x more expensive to elaborate (subject to a 1,000-heartbeat floor so tiny files cannot flag on noise). The comment never blocks merge and posts no commit status.

Heartbeats are the metric because they are deterministic and machine-independent, so the base to head delta is meaningful in a way wall-clock is not; this is the signal that answers "did this golf change compile cost?" from the build-time-profiling thread, and it borrows Lean Pool's per-PR profiling methodology without needing radar or any insider access.

The trust model follows `pr-build.yml`: this is a base-branch-defined workflow, it overlays only the PR's `TauCeti/` sources onto a trusted base checkout, and it elaborates that untrusted code solely under landrun (offline, writes confined to `base/.lake`, no token in the passed `--env` list). The measurement and render scripts come from the trusted base, so a PR cannot alter how it is measured, and the sticky comment is posted by the trusted step only after the sandbox has exited. To keep cost down it builds just the changed modules and their dependency cones, and runs on PR open, on a `/profile` comment from the PR author or a collaborator, and on manual dispatch rather than on every push.

A modified file's base and head sources are both elaborated against the same built environment, which is sound when a change is local to the file's own proofs and definition bodies; a base source that no longer elaborates there (usually because a statement it depends on changed) is reported and left out of the comparison rather than mismeasured. The measurement, extraction, and render steps were exercised end to end locally against a real `module`-system `TauCeti/` file.

This is separate from the no-`set_option` rule discussed in the same thread, which `pr-build.yml` already enforces.

Because it touches `.github/` and `scripts/`, this needs human review and merge.

🤖 Prepared with Claude Code