### PR TITLE
refactor(Analysis/Contour): decompose the argument-principle proof

### DIFF
--- a/TauCeti/Analysis/Contour/Argument/Principle.lean
+++ b/TauCeti/Analysis/Contour/Argument/Principle.lean
@@ -120,6 +120,82 @@ theorem logDeriv_eventuallyEq_principalPart {F : ℂ → ℂ} {s : ℂ} {n : ℤ
   rw [logDeriv_eq_of_eventuallyEq hz_FH, hmul]
   exact logDeriv_zpow_sub_mul hz_ne hz_gne hz_gan.differentiableAt
 
+/-- Passing to the meromorphic normal form leaves the log-derivative's circle integral unchanged:
+the two functions agree off a discrete set, which the circle integral does not see. -/
+private theorem circleIntegral_logDeriv_toMeromorphicNFOn {f : ℂ → ℂ} {c : ℂ} {R : ℝ} (hR : 0 < R)
+    (hf : MeromorphicOn f (Metric.closedBall c R)) :
+    circleIntegral (logDeriv f) c R
+      = circleIntegral (logDeriv (toMeromorphicNFOn f (Metric.closedBall c R))) c R := by
+  set F := toMeromorphicNFOn f (Metric.closedBall c R) with hF_def
+  refine circleIntegral.circleIntegral_congr_codiscreteWithin ?_ hR.ne'
+  have hspU : Metric.sphere c |R| ⊆ Metric.closedBall c R := by
+    rw [abs_of_pos hR]; exact Metric.sphere_subset_closedBall
+  filter_upwards [(toMeromorphicNFOn_eqOn_codiscrete hf).filter_mono
+      (Filter.codiscreteWithin_mono hspU), self_mem_codiscreteWithin (Metric.sphere c |R|)]
+    with z hz_eq hz_mem
+  have hne : f =ᶠ[𝓝[≠] z] F := (hf.toMeromorphicNFOn_eq_self_on_nhdsNE (hspU hz_mem)).symm
+  exact logDeriv_eq_of_eventuallyEq (eventuallyEq_nhds_of_eventuallyEq_nhdsNE hne hz_eq)
+
+/-- The circle integral of the principal part `∑_{s∈S} ord s · (z − s)⁻¹`, with all poles `s`
+strictly inside the disc, is `2πi · ∑_{s∈S} ord s` (each simple pole contributes `2πi · ord s`). -/
+private theorem circleIntegral_principalPart {c : ℂ} {R : ℝ} (hR : 0 < R) (S : Finset ℂ)
+    (ord : ℂ → ℤ) (hS : (S : Set ℂ) ⊆ Metric.ball c R) :
+    circleIntegral (fun z => ∑ s ∈ S, (ord s : ℂ) * (z - s)⁻¹) c R
+      = 2 * (Real.pi : ℂ) * Complex.I * (∑ z ∈ S, (ord z : ℂ)) := by
+  have hzs_ne : ∀ z ∈ Metric.sphere c R, ∀ s ∈ S, z ≠ s := by
+    intro z hz s hsS h; subst h
+    rw [Metric.mem_sphere] at hz
+    exact absurd hz (ne_of_lt (Metric.mem_ball.1 (hS (Finset.mem_coe.2 hsS))))
+  have hP_intble : ∀ s ∈ S, CircleIntegrable (fun z => (ord s : ℂ) * (z - s)⁻¹) c R := fun s hsS =>
+    ContinuousOn.circleIntegrable hR.le (continuousOn_const.mul
+      ((continuousOn_id.sub continuousOn_const).inv₀
+        fun z hz => sub_ne_zero.2 (hzs_ne z hz s hsS)))
+  have hterm : ∀ s ∈ S, (∮ z in C(c, R), (ord s : ℂ) * (z - s)⁻¹)
+      = (ord s : ℂ) * (2 * (Real.pi : ℂ) * Complex.I) := fun s hsS => by
+    rw [circleIntegral.integral_const_mul,
+      circleIntegral.integral_sub_inv_of_mem_ball (hS (Finset.mem_coe.2 hsS))]
+  rw [circleIntegral.integral_fun_sum hP_intble, Finset.sum_congr rfl hterm, ← Finset.sum_mul]
+  ring
+
+/-- Subtracting the principal part cancels every simple pole of `logDeriv F`: if `F` is meromorphic
+on the disc with order `ord z` at each `z ∈ S` and is analytic and non-vanishing off `S`, then
+`logDeriv F − ∑_{s∈S} ord s · (· − s)⁻¹` is pole-free, so its circle integral vanishes. -/
+private theorem circleIntegral_logDeriv_sub_principalPart_eq_zero {F : ℂ → ℂ} {c : ℂ} {R : ℝ}
+    (hR : 0 < R) (S : Finset ℂ) (ord : ℂ → ℤ)
+    (hF_mero : MeromorphicOn F (Metric.closedBall c R))
+    (hord_F : ∀ z ∈ S, meromorphicOrderAt F z = (ord z : WithTop ℤ))
+    (hoffF : ∀ z ∈ Metric.closedBall c R, z ∉ S → AnalyticAt ℂ F z ∧ F z ≠ 0) :
+    circleIntegral (fun z => logDeriv F z - ∑ s ∈ S, (ord s : ℂ) * (z - s)⁻¹) c R = 0 := by
+  have hP_mero : MeromorphicOn (fun z => ∑ s ∈ S, (ord s : ℂ) * (z - s)⁻¹)
+      (Metric.closedBall c R) := by
+    refine MeromorphicOn.fun_sum fun s z _ => ?_
+    exact (MeromorphicAt.const (ord s : ℂ) z).mul
+      (((MeromorphicAt.id z).sub (MeromorphicAt.const s z)).inv)
+  refine circleIntegral_eq_zero_of_meromorphicOrderAt_nonneg hR.le (hF_mero.logDeriv.sub hP_mero) ?_
+  intro z hz
+  by_cases hzS : z ∈ S
+  · have hz_ord : meromorphicOrderAt F z = (ord z : WithTop ℤ) := hord_F z hzS
+    obtain ⟨g, hg_an, hg_ne, hg_germ⟩ :=
+      logDeriv_eventuallyEq_principalPart (hF_mero z hz) hz_ord
+    have hA_eq : (fun w => logDeriv F w - ∑ s ∈ S, (ord s : ℂ) * (w - s)⁻¹) =ᶠ[𝓝[≠] z]
+        fun w => logDeriv g w - ∑ s ∈ S.erase z, (ord s : ℂ) * (w - s)⁻¹ := by
+      filter_upwards [hg_germ] with w hw
+      simp only [← Finset.add_sum_erase S (fun s => (ord s : ℂ) * (w - s)⁻¹) hzS]
+      rw [hw]; ring
+    have hrest_an : AnalyticAt ℂ (fun w => ∑ s ∈ S.erase z, (ord s : ℂ) * (w - s)⁻¹) z :=
+      Finset.analyticAt_fun_sum _ fun s hs =>
+        analyticAt_const.mul ((analyticAt_id.sub analyticAt_const).inv
+          (sub_ne_zero.2 (Ne.symm (Finset.ne_of_mem_erase hs))))
+    rw [meromorphicOrderAt_congr hA_eq]
+    exact ((analyticAt_logDeriv_of_analyticAt hg_an hg_ne).sub hrest_an).meromorphicOrderAt_nonneg
+  · have hz_off := hoffF z hz hzS
+    have hP_an : AnalyticAt ℂ (fun z => ∑ s ∈ S, (ord s : ℂ) * (z - s)⁻¹) z := by
+      refine Finset.analyticAt_fun_sum _ fun s hsS =>
+        analyticAt_const.mul ((analyticAt_id.sub analyticAt_const).inv (sub_ne_zero.2 ?_))
+      rintro rfl; exact hzS hsS
+    exact ((analyticAt_logDeriv_of_analyticAt hz_off.1 hz_off.2).sub
+      hP_an).meromorphicOrderAt_nonneg
+
 /-- **The argument principle.** If `f` is meromorphic on the closed disc `C(c, R)` (`R > 0`) with
 all its nonzero-order points contained in a finite set `S` inside the open disc, with orders `ord`,
 then the contour integral of the logarithmic derivative counts the zeros minus the poles with
@@ -131,104 +207,37 @@ theorem argumentPrinciple {f : ℂ → ℂ} {c : ℂ} {R : ℝ} (hR : 0 < R) (S 
     (hsupp : ∀ z ∈ Metric.closedBall c R, meromorphicOrderAt f z ≠ 0 → z ∈ S)
     (hord : ∀ z ∈ S, meromorphicOrderAt f z = (ord z : WithTop ℤ)) :
     circleIntegral (logDeriv f) c R = 2 * (Real.pi : ℂ) * Complex.I * (∑ z ∈ S, (ord z : ℂ)) := by
-  -- Pass to the meromorphic normal form `F` of `f` (genuinely analytic and non-vanishing off `S`,
-  -- whereas raw `f` may take isolated "wrong values"; the circle integral sees `f` up to a discrete
-  -- set, so it is unchanged).
-  set F := toMeromorphicNFOn f (closedBall c R) with hF_def
-  have hF_nf : MeromorphicNFOn F (closedBall c R) := meromorphicNFOn_toMeromorphicNFOn f _
-  have hF_mero : MeromorphicOn F (closedBall c R) := hF_nf.meromorphicOn
-  have hordF : ∀ z ∈ closedBall c R, meromorphicOrderAt F z = meromorphicOrderAt f z :=
+  set F := toMeromorphicNFOn f (Metric.closedBall c R) with hF_def
+  have hF_nf : MeromorphicNFOn F (Metric.closedBall c R) := meromorphicNFOn_toMeromorphicNFOn f _
+  have hF_mero : MeromorphicOn F (Metric.closedBall c R) := hF_nf.meromorphicOn
+  have hordF : ∀ z ∈ Metric.closedBall c R, meromorphicOrderAt F z = meromorphicOrderAt f z :=
     fun z hz => meromorphicOrderAt_toMeromorphicNFOn hf hz
-  -- Off `S`, `F` is analytic and non-vanishing.
-  have hoffF : ∀ z ∈ closedBall c R, z ∉ S → AnalyticAt ℂ F z ∧ F z ≠ 0 := by
+  have hoffF : ∀ z ∈ Metric.closedBall c R, z ∉ S → AnalyticAt ℂ F z ∧ F z ≠ 0 := by
     intro z hz hzS
     have h0 : meromorphicOrderAt F z = 0 := by
       rw [hordF z hz]; by_contra h; exact hzS (hsupp z hz h)
     exact ⟨(hF_nf hz).meromorphicOrderAt_nonneg_iff_analyticAt.1 h0.symm.le,
       (hF_nf hz).meromorphicOrderAt_eq_zero_iff.1 h0⟩
-  -- Reduce to `F` by circle congruence off a discrete set.
-  have htransfer : circleIntegral (logDeriv f) c R = circleIntegral (logDeriv F) c R := by
-    refine circleIntegral.circleIntegral_congr_codiscreteWithin ?_ hR.ne'
-    have hspU : sphere c |R| ⊆ closedBall c R := by
-      rw [abs_of_pos hR]; exact sphere_subset_closedBall
-    filter_upwards [(toMeromorphicNFOn_eqOn_codiscrete hf).filter_mono
-        (Filter.codiscreteWithin_mono hspU), self_mem_codiscreteWithin (sphere c |R|)]
-      with z hz_eq hz_mem
-    have hne : f =ᶠ[𝓝[≠] z] F := (hf.toMeromorphicNFOn_eq_self_on_nhdsNE (hspU hz_mem)).symm
-    exact logDeriv_eq_of_eventuallyEq (eventuallyEq_nhds_of_eventuallyEq_nhdsNE hne hz_eq)
-  rw [htransfer]
-  -- Sphere points avoid the (interior) pole set `S`.
-  have hsphere_notS : ∀ z ∈ sphere c R, z ∉ S := by
-    intro z hz hzS
+  have hord_F : ∀ z ∈ S, meromorphicOrderAt F z = (ord z : WithTop ℤ) := fun z hzS =>
+    (hordF z (Metric.ball_subset_closedBall (hS (Finset.mem_coe.2 hzS)))).trans (hord z hzS)
+  have hsphere_notS : ∀ z ∈ Metric.sphere c R, z ∉ S := fun z hz hzS => by
     rw [Metric.mem_sphere] at hz
     exact absurd hz (ne_of_lt (Metric.mem_ball.1 (hS (Finset.mem_coe.2 hzS))))
-  have hzs_ne : ∀ z ∈ sphere c R, ∀ s ∈ S, z ≠ s := by
-    intro z hz s hsS h; subst h; exact absurd hsS (hsphere_notS z hz)
-  -- Principal part `P` and its meromorphy.
-  set P : ℂ → ℂ := fun z => ∑ s ∈ S, (ord s : ℂ) * (z - s)⁻¹ with hP_def
-  have hP_mero : MeromorphicOn P (closedBall c R) := by
-    rw [hP_def]
-    refine MeromorphicOn.fun_sum fun s z _ => ?_
-    exact (MeromorphicAt.const (ord s : ℂ) z).mul
-      (((MeromorphicAt.id z).sub (MeromorphicAt.const s z)).inv)
-  have hlogF_mero : MeromorphicOn (logDeriv F) (closedBall c R) := hF_mero.logDeriv
-  -- `A := logDeriv F - P` is pole-free (the principal part cancels each simple pole of
-  -- `logDeriv F`), so its circle integral vanishes.
-  have hA0 : circleIntegral (fun z => logDeriv F z - P z) c R = 0 := by
-    refine circleIntegral_eq_zero_of_meromorphicOrderAt_nonneg hR.le (hlogF_mero.sub hP_mero) ?_
-    intro z hz
-    by_cases hzS : z ∈ S
-    · -- Pole point: the principal part cancels the simple pole of `logDeriv F`.
-      have hz_ord : meromorphicOrderAt F z = (ord z : WithTop ℤ) := (hordF z hz).trans (hord z hzS)
-      obtain ⟨g, hg_an, hg_ne, hg_germ⟩ :=
-        logDeriv_eventuallyEq_principalPart (hF_mero z hz) hz_ord
-      have hA_eq : (fun w => logDeriv F w - P w) =ᶠ[𝓝[≠] z]
-          fun w => logDeriv g w - ∑ s ∈ S.erase z, (ord s : ℂ) * (w - s)⁻¹ := by
-        filter_upwards [hg_germ] with w hw
-        simp only [hP_def, ← Finset.add_sum_erase S (fun s => (ord s : ℂ) * (w - s)⁻¹) hzS]
-        rw [hw]; ring
-      have hrest_an : AnalyticAt ℂ (fun w => ∑ s ∈ S.erase z, (ord s : ℂ) * (w - s)⁻¹) z :=
-        Finset.analyticAt_fun_sum _ fun s hs =>
-          analyticAt_const.mul ((analyticAt_id.sub analyticAt_const).inv
-            (sub_ne_zero.2 (Ne.symm (Finset.ne_of_mem_erase hs))))
-      rw [meromorphicOrderAt_congr hA_eq]
-      exact ((analyticAt_logDeriv_of_analyticAt hg_an hg_ne).sub hrest_an).meromorphicOrderAt_nonneg
-    · -- Regular point: `A` is analytic there.
-      have hz_off := hoffF z hz hzS
-      have hP_an : AnalyticAt ℂ P z := by
-        rw [hP_def]
-        refine Finset.analyticAt_fun_sum _ fun s hsS =>
-          analyticAt_const.mul ((analyticAt_id.sub analyticAt_const).inv (sub_ne_zero.2 ?_))
-        rintro rfl; exact hzS hsS
-      exact ((analyticAt_logDeriv_of_analyticAt hz_off.1 hz_off.2).sub
-        hP_an).meromorphicOrderAt_nonneg
-  -- `∮ P = 2πi · ∑ ord`.
-  have hP_intble : ∀ s ∈ S, CircleIntegrable (fun z => (ord s : ℂ) * (z - s)⁻¹) c R := fun s hsS =>
-    ContinuousOn.circleIntegrable hR.le (continuousOn_const.mul
-      ((continuousOn_id.sub continuousOn_const).inv₀
-        fun z hz => sub_ne_zero.2 (hzs_ne z hz s hsS)))
-  have hPint : circleIntegral P c R = 2 * (Real.pi : ℂ) * Complex.I * (∑ z ∈ S, (ord z : ℂ)) := by
-    have hterm : ∀ s ∈ S, (∮ z in C(c, R), (ord s : ℂ) * (z - s)⁻¹)
-        = (ord s : ℂ) * (2 * (Real.pi : ℂ) * Complex.I) := fun s hsS => by
-      rw [circleIntegral.integral_const_mul,
-        circleIntegral.integral_sub_inv_of_mem_ball (hS (Finset.mem_coe.2 hsS))]
-    rw [hP_def, circleIntegral.integral_fun_sum hP_intble, Finset.sum_congr rfl hterm,
-      ← Finset.sum_mul]
-    ring
-  -- Continuity on the circle gives integrability, then split the integral.
-  have hlogF_cont : ContinuousOn (logDeriv F) (sphere c R) := fun z hz =>
+  rw [circleIntegral_logDeriv_toMeromorphicNFOn hR hf, ← hF_def]
+  have hlogF_cont : ContinuousOn (logDeriv F) (Metric.sphere c R) := fun z hz =>
     (analyticAt_logDeriv_of_analyticAt
       (hoffF z (sphere_subset_closedBall hz) (hsphere_notS z hz)).1
       (hoffF z (sphere_subset_closedBall hz) (hsphere_notS z hz)).2).continuousAt.continuousWithinAt
-  have hP_cont : ContinuousOn P (sphere c R) := by
-    rw [hP_def]
-    exact continuousOn_finsetSum S fun s hsS => continuousOn_const.mul
+  have hzs_ne : ∀ z ∈ Metric.sphere c R, ∀ s ∈ S, z ≠ s := by
+    intro z hz s hsS h; subst h; exact absurd hsS (hsphere_notS z hz)
+  have hP_cont : ContinuousOn (fun z => ∑ s ∈ S, (ord s : ℂ) * (z - s)⁻¹) (Metric.sphere c R) :=
+    continuousOn_finsetSum S fun s hsS => continuousOn_const.mul
       ((continuousOn_id.sub continuousOn_const).inv₀ fun z hz => sub_ne_zero.2 (hzs_ne z hz s hsS))
-  -- `∮ logDeriv F = ∮ (logDeriv F - P) + ∮ P = 0 + ∮ P`.
-  have hsub := (circleIntegral.integral_sub (ContinuousOn.circleIntegrable hR.le hlogF_cont)
-    (ContinuousOn.circleIntegrable hR.le hP_cont)).symm
-  rw [hA0, sub_eq_zero] at hsub
-  rw [hsub, hPint]
+  have hsub := (circleIntegral.integral_sub (hlogF_cont.circleIntegrable hR.le)
+    (hP_cont.circleIntegrable hR.le)).symm
+  rw [circleIntegral_logDeriv_sub_principalPart_eq_zero hR S ord hF_mero hord_F hoffF,
+    sub_eq_zero] at hsub
+  rw [hsub, circleIntegral_principalPart hR S ord hS]
 
 /-- **Local argument principle.** If `f` is meromorphic on the closed disc `C(c, R)` (`R > 0`) and
 the centre `c` is the only point of the disc that may have nonzero meromorphic order — every other


### PR DESCRIPTION
## Summary

Decompose the headline `argumentPrinciple` (a 98-line proof, well over the 50-LOC guideline) into three documented `private` helpers + a 31-line assembly. Pure structural refactor.

## The three helpers

The argument principle counts zeros − poles by `∮ f'/f = 2πi·∑ ord`. The proof splits cleanly:

- **`circleIntegral_logDeriv_toMeromorphicNFOn`** — passing to the meromorphic normal form `F` leaves `∮ logDeriv f` unchanged (the two agree off a discrete set the circle integral doesn't see).
- **`circleIntegral_principalPart`** — `∮ (∑_{s∈S} ord s·(z−s)⁻¹) = 2πi·∑ ord` (each interior simple pole `s` contributes `2πi·ord s`).
- **`circleIntegral_logDeriv_sub_principalPart_eq_zero`** — subtracting the principal part cancels every simple pole of `logDeriv F`, so the difference is pole-free and `∮ = 0`.

The main assembly reads as: normal-form invariance → `∮ logDeriv F = ∮ P` (pole cancellation) → `∮ P = 2πi·∑ ord`.

## Scope / safety

- **No statement or public-API changes**: `argumentPrinciple`'s signature is byte-identical and `argumentPrinciple_local` is untouched. Extracted proof text is lifted from the original.
- All proofs under 50 lines. Builds clean; single file, single topic.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
