### PR TITLE
chore: drop the stale ShiftInvariantSigma simpNF baseline entry

### DIFF
--- a/scripts/lint-baseline.txt
+++ b/scripts/lint-baseline.txt
@@ -41,7 +41,6 @@ simpNF TauCeti.HopfIdeal.kerLiftBialgHom_mk
 simpNF TauCeti.IsComplexLinearMap.eq_zero_iff_apply_stdComplexLineReal
 simpNF TauCeti.Multiquadratic.forall_legendreSym_neg_four_five_eq_one_iff
 simpNF TauCeti.PDE.uniformlyEllipticOn_biUnion_iff
-simpNF TauCeti.Probability.isShiftInvariant.preimage_shift_iterate_eq
 simpNF TauCeti.Probability.permReindex_apply
 simpNF TauCeti.Subcoalgebra.map_top_toSubmodule
 simpNF TauCeti.Subcomodule.comap_id


### PR DESCRIPTION
## Summary

Follow-up to #1043: delete the now-stale grandfathered entry

```
simpNF TauCeti.Probability.isShiftInvariant.preimage_shift_iterate_eq
```

from `scripts/lint-baseline.txt`. The declaration was removed in #1043 (the
`ShiftInvariantSigma` adapter module deleted per the merged roadmap change
[TauCetiRoadmap#73](https://github.com/TauCetiProject/TauCetiRoadmap/pull/73)), so since
that merge `scripts/lint-env.sh` prints this entry as a non-failing RATCHET reminder. This
PR performs exactly the cleanup the script's header prescribes ("delete it from the
baseline in a follow-up PR").

One-line deletion; no `.lean` changes. `scripts/` is human-owned, so this is intentionally
separate from #1043 rather than bundled into it.

*Directed by Cameron Freer, written by Fable 5 high, reviewed by GPT 5.6 Sol xhigh.*
