### PR TITLE
refactor(NumberTheory/Multiquadratic): decompose decompositionGroup_fixes_gen

### DIFF
--- a/TauCeti/NumberTheory/Multiquadratic/MultiquadraticSplitting.lean
+++ b/TauCeti/NumberTheory/Multiquadratic/MultiquadraticSplitting.lean
@@ -7,7 +7,6 @@ module
 public import Mathlib.NumberTheory.LegendreSymbol.Basic
 public import Mathlib.LinearAlgebra.Dimension.FreeAndStrongRankCondition
 public import Mathlib.LinearAlgebra.Dimension.DivisionRing
-public import Mathlib.RingTheory.IntegralClosure.IntegralRestrict
 public import TauCeti.NumberTheory.Multiquadratic.Galois.Basic
 public import TauCeti.NumberTheory.NumberField.SplitsCompletely
 
@@ -36,34 +35,33 @@ public section
 variable {K : Type*} [Field K] [NumberField K]
 
 omit [NumberField K] in
-/-- Each generator `r i` is integral over `ℤ`. -/
-private theorem mq_isIntegral_gen {ι : Type*} (d : ι → ℤ) (r : ι → K)
-    (hr : ∀ i, r i ^ 2 = algebraMap ℤ K (d i)) (i : ι) : IsIntegral ℤ (r i) :=
-  -- `r i` is a root of the monic `X² - d i`.
-  ⟨X ^ 2 - C (d i), monic_X_pow_sub_C (d i) (by norm_num), by
-    rw [eval₂_sub, eval₂_X_pow, eval₂_C, hr i, sub_self]⟩
+/-- The generator `r` is integral over `ℤ`. -/
+private theorem mq_isIntegral_gen (d : ℤ) (r : K)
+    (hr : r ^ 2 = algebraMap ℤ K d) : IsIntegral ℤ r :=
+  -- `r² = algebraMap d` is integral, so `r` is too.
+  IsIntegral.of_pow (n := 2) (by norm_num) (hr ▸ isIntegral_algebraMap)
 
-/-- The generator `r i`, as an element of the ring of integers `𝓞 K`. -/
-private noncomputable def ringGen {ι : Type*} (d : ι → ℤ) (r : ι → K)
-    (hr : ∀ i, r i ^ 2 = algebraMap ℤ K (d i)) (i : ι) : 𝓞 K :=
-  ⟨r i, mq_isIntegral_gen d r hr i⟩
+/-- The generator `r`, as an element of the ring of integers `𝓞 K`. -/
+private noncomputable def ringGen (d : ℤ) (r : K)
+    (hr : r ^ 2 = algebraMap ℤ K d) : 𝓞 K :=
+  ⟨r, mq_isIntegral_gen d r hr⟩
 
 omit [NumberField K] in
-/-- Under `𝓞 K ↪ K`, `ringGen d r hr i` maps to the generator `r i`. -/
-private theorem algebraMap_ringGen {ι : Type*} (d : ι → ℤ) (r : ι → K)
-    (hr : ∀ i, r i ^ 2 = algebraMap ℤ K (d i)) (i : ι) :
-    algebraMap (𝓞 K) K (ringGen d r hr i) = r i :=
-  -- `ringGen d r hr i = ⟨r i, _⟩`, so its image is the definitional coercion back to `K`
+/-- Under `𝓞 K ↪ K`, `ringGen d r hr` maps to the generator `r`. -/
+private theorem algebraMap_ringGen (d : ℤ) (r : K)
+    (hr : r ^ 2 = algebraMap ℤ K d) :
+    algebraMap (𝓞 K) K (ringGen d r hr) = r :=
+  -- `ringGen d r hr = ⟨r, _⟩`, so its image is the definitional coercion back to `K`
   -- (cf. `RingOfIntegers.coe_mk`).
   rfl
 
 omit [NumberField K] in
-/-- `ringGen` squares to the radicand `d i` in `𝓞 K`. -/
-private theorem ringGen_sq {ι : Type*} (d : ι → ℤ) (r : ι → K)
-    (hr : ∀ i, r i ^ 2 = algebraMap ℤ K (d i)) (i : ι) :
-    ringGen d r hr i ^ 2 = algebraMap ℤ (𝓞 K) (d i) := by
+/-- `ringGen` squares to the radicand `d` in `𝓞 K`. -/
+private theorem ringGen_sq (d : ℤ) (r : K)
+    (hr : r ^ 2 = algebraMap ℤ K d) :
+    ringGen d r hr ^ 2 = algebraMap ℤ (𝓞 K) d := by
   apply FaithfulSMul.algebraMap_injective (𝓞 K) K
-  rw [map_pow, algebraMap_ringGen, hr i, ← IsScalarTower.algebraMap_apply ℤ (𝓞 K) K]
+  rw [map_pow, algebraMap_ringGen, hr, ← IsScalarTower.algebraMap_apply ℤ (𝓞 K) K]
 
 omit [NumberField K] in
 /-- For an ideal `Q` lying over the integer ideal `(a)`, an integer `m` maps into `Q` under
@@ -89,7 +87,7 @@ private theorem legendreSym_eq_one_of_ncard_primesOver_eq_finrank {ι : Type*} (
       ((Ideal.span_singleton_prime hpne).mpr (Nat.prime_iff_prime_int.mp Fact.out))
       (by simpa [Ideal.span_singleton_eq_bot] using hpne)
   haveI : Q.IsMaximal := Ideal.IsMaximal.of_liesOver_isMaximal Q (span {(p : ℤ)})
-  let R : ι → 𝓞 K := ringGen d r hr
+  let R : 𝓞 K := ringGen (d i) (r i) (hr i)
   rw [ncard_primesOver_eq_finrank_iff K p] at hsplit
   have hfQ : finrank (ℤ ⧸ span {(p : ℤ)}) (𝓞 K ⧸ Q) = 1 := by
     rw [← Ideal.inertiaDeg'_algebraMap (p := span {(p : ℤ)}) (P := Q),
@@ -102,21 +100,21 @@ private theorem legendreSym_eq_one_of_ncard_primesOver_eq_finrank {ι : Type*} (
     @Module.Free.of_divisionRing _ _ fld.toDivisionRing _ _
   have hbij := (Algebra.finrank_eq_one_iff_bijective_algebraMap
     (F := ℤ ⧸ span {(p : ℤ)}) (E := 𝓞 K ⧸ Q)).mp hfQ
-  -- Lift the residue of `R i` to an integer `a`, so `R i ≡ a (mod Q)`.
-  obtain ⟨c, hc⟩ := hbij.surjective (Ideal.Quotient.mk Q (R i))
+  -- Lift the residue of `R` to an integer `a`, so `R ≡ a (mod Q)`.
+  obtain ⟨c, hc⟩ := hbij.surjective (Ideal.Quotient.mk Q R)
   obtain ⟨a, rfl⟩ := Ideal.Quotient.mk_surjective c
   -- The algebra map `ℤ ⧸ (p) → 𝓞 K ⧸ Q` is `Ideal.quotientMap`, which sends `mk a` to
   -- `mk (algebraMap ℤ (𝓞 K) a)`.
   have hcompat : algebraMap (ℤ ⧸ span {(p : ℤ)}) (𝓞 K ⧸ Q) (Ideal.Quotient.mk _ a)
       = Ideal.Quotient.mk Q (algebraMap ℤ (𝓞 K) a) := Ideal.quotientMap_mk
   rw [hcompat] at hc
-  have hdiff : algebraMap ℤ (𝓞 K) a - R i ∈ Q := Ideal.Quotient.eq.mp hc
-  -- `(algebraMap a - R i)(algebraMap a + R i) = algebraMap (a² - d i) ∈ Q`, so `p ∣ a² - d i`.
+  have hdiff : algebraMap ℤ (𝓞 K) a - R ∈ Q := Ideal.Quotient.eq.mp hc
+  -- `(algebraMap a - R)(algebraMap a + R) = algebraMap (a² - d i) ∈ Q`, so `p ∣ a² - d i`.
   have hpd : (p : ℤ) ∣ a ^ 2 - d i := by
     rw [← algebraMap_int_mem_iff_dvd_of_liesOver Q]
     have hfac : algebraMap ℤ (𝓞 K) (a ^ 2 - d i) =
-        (algebraMap ℤ (𝓞 K) a - R i) * (algebraMap ℤ (𝓞 K) a + R i) := by
-      rw [map_sub, map_pow, ← ringGen_sq d r hr i]; ring
+        (algebraMap ℤ (𝓞 K) a - R) * (algebraMap ℤ (𝓞 K) a + R) := by
+      rw [map_sub, map_pow, ← ringGen_sq (d i) (r i) (hr i)]; ring
     rw [hfac]
     exact Ideal.mul_mem_right _ _ hdiff
   rw [legendreSym.eq_one_iff p (by rw [Ne, ZMod.intCast_zmod_eq_zero_iff_dvd]; exact hcop_i)]
@@ -124,106 +122,107 @@ private theorem legendreSym_eq_one_of_ncard_primesOver_eq_finrank {ι : Type*} (
   push_cast at hpd
   exact ⟨(a : ZMod p), by linear_combination -hpd⟩
 
-/-- Backward core (pointwise): for `K` Galois over `ℚ`, if `p` is odd, `p ∤ d i`, and `d i` is a
-quadratic residue mod `p`, then every `σ` in the decomposition group of `Q` fixes the generator
-`r i`. -/
-private theorem decompositionGroup_fixes_gen {ι : Type*} (d : ι → ℤ) (r : ι → K)
-    (hr : ∀ i, r i ^ 2 = algebraMap ℤ K (d i)) [IsGalois ℚ K]
-    {p : ℕ} [Fact p.Prime] (hodd : p ≠ 2) {i : ι} (hcop_i : ¬ (p : ℤ) ∣ d i)
-    (hqr_i : legendreSym p (d i) = 1)
-    (Q : Ideal (𝓞 K)) [Q.IsPrime] [Q.LiesOver (span {(p : ℤ)})]
-    {σ : K ≃ₐ[ℚ] K} (hσ : σ ∈ stabilizer (K ≃ₐ[ℚ] K) Q) : σ (r i) = r i := by
-  -- From `σ (r i)² = r i²` we get `σ (r i) = ± r i`; the `-` sign, combined with a residue
-  -- `a² ≡ d i (mod p)`, would force `2 a ∈ Q` and hence `p ∣ 2 a`, contradicting `p` odd and
-  -- `p ∤ a`.
-  have hr' : ∀ i, r i ^ 2 = algebraMap ℚ K ((d i : ℚ)) := by
-    intro i; rw [hr i]; simp
-  let R : ι → 𝓞 K := ringGen d r hr
-  -- The Galois action on `𝓞 K` is the restriction of the action on `K`: it agrees with
-  -- `galRestrict ℤ ℚ K (𝓞 K) σ` (both restrict `σ` and are pinned by injectivity of the algebra
-  -- map), so compatibility is `algebraMap_galRestrict_apply`.
-  have hgal : ∀ x : 𝓞 K, galRestrict ℤ ℚ K (𝓞 K) σ x = σ • x := fun x => by
-    apply FaithfulSMul.algebraMap_injective (𝓞 K) K
-    rw [algebraMap_galRestrict_apply (A := ℤ) σ x]
-    -- The remaining equality is the definitional agreement between the integral-closure action
-    -- `σ • x = ⟨σ • (x : K), _⟩` and `σ` acting on `K`; `integralClosure.coe_smul` names it.
-    exact (integralClosure.coe_smul σ x).symm
-  have hact : ∀ x : 𝓞 K, algebraMap (𝓞 K) K (σ • x) = σ (algebraMap (𝓞 K) K x) := fun x => by
-    rw [← hgal x, algebraMap_galRestrict_apply (A := ℤ) σ x]
-  have hstab : σ • Q = Q := mem_stabilizer_iff.mp hσ
-  have hmapQ : ∀ x ∈ Q, σ • x ∈ Q := by
-    intro x hx; rw [← hstab]; exact Ideal.smul_mem_pointwise_smul σ x Q hx
-  have h2 : σ (r i) ^ 2 = r i ^ 2 := by rw [← map_pow, hr' i, AlgEquiv.commutes]
-  have hfac : (σ (r i) - r i) * (σ (r i) + r i) = 0 := by
-    have h1 : (σ (r i) - r i) * (σ (r i) + r i) = σ (r i) ^ 2 - r i ^ 2 := by ring
-    rw [h1, h2, sub_self]
-  rcases mul_eq_zero.mp hfac with h | h
-  · exact sub_eq_zero.mp h
-  · exfalso
-    have hflip : σ (r i) = - r i := eq_neg_of_add_eq_zero_left h
-    -- `d i` is a residue: `a² ≡ d i (mod p)` with `p ∤ a`.
-    obtain ⟨b, hb⟩ := (legendreSym.eq_one_iff p (by
-      rw [Ne, ZMod.intCast_zmod_eq_zero_iff_dvd]; exact hcop_i)).mp hqr_i
-    obtain ⟨a, rfl⟩ := ZMod.intCast_surjective b
-    have hpa : (p : ℤ) ∣ a ^ 2 - d i := by
-      rw [← ZMod.intCast_zmod_eq_zero_iff_dvd]; push_cast; rw [hb]; ring
-    have hpa' : ¬ (p : ℤ) ∣ a := fun hd => hcop_i (by
-      have h2a : (p : ℤ) ∣ a ^ 2 := dvd_pow hd (by norm_num)
-      have h3 := dvd_sub h2a hpa
-      -- `a² - (a² - d i) = d i`, so `p ∣ d i`, contradicting `hcop_i`.
-      have hdiff : a ^ 2 - (a ^ 2 - d i) = d i := by ring
-      rwa [hdiff] at h3)
-    set A : 𝓞 K := algebraMap ℤ (𝓞 K) a with hAdef
-    -- `(R i - A)(R i + A) = d i - a² ∈ Q`, so one factor lies in the prime `Q`.
-    have hAsq : A ^ 2 = algebraMap ℤ (𝓞 K) (a ^ 2) := by rw [hAdef, ← map_pow]
-    have heq : (R i - A) * (R i + A) = algebraMap ℤ (𝓞 K) (d i - a ^ 2) := by
-      have h1 : (R i - A) * (R i + A) = R i ^ 2 - A ^ 2 := by ring
-      rw [h1, ringGen_sq d r hr i, hAsq, ← map_sub]
-    have hfacQ : (R i - A) * (R i + A) ∈ Q := by
-      rw [heq]; exact (algebraMap_int_mem_iff_dvd_of_liesOver Q _).mpr (dvd_sub_comm.mp hpa)
-    -- `σ` sends `R i ↦ -R i` and fixes the integer `A`.
-    have hsR : σ • R i = - R i := by
-      apply FaithfulSMul.algebraMap_injective (𝓞 K) K
-      rw [hact, map_neg, algebraMap_ringGen, hflip]
-    have hsA : σ • A = A := by
-      apply FaithfulSMul.algebraMap_injective (𝓞 K) K
-      rw [hact, hAdef, ← IsScalarTower.algebraMap_apply ℤ (𝓞 K) K,
-        IsScalarTower.algebraMap_apply ℤ ℚ K, AlgEquiv.commutes]
-    -- Applying `σ` to whichever factor lies in `Q` and adding the two gives `2 A ∈ Q`.
-    have h2A : (2 : 𝓞 K) * A ∈ Q := by
-      rcases (‹Q.IsPrime›).mem_or_mem hfacQ with hca | hca
-      · have h1 : σ • (R i - A) ∈ Q := hmapQ _ hca
-        rw [smul_sub, hsR, hsA] at h1
-        have hs := Q.add_mem hca h1
-        -- Adding the factor `R i - A` and its image `-R i - A` cancels `R i`, leaving `-(2 A)`.
-        have hsum : (R i - A) + (-R i - A) = -(2 * A) := by ring
-        rw [hsum] at hs
-        exact neg_mem_iff.mp hs
-      · have h1 : σ • (R i + A) ∈ Q := hmapQ _ hca
-        rw [smul_add, hsR, hsA] at h1
-        have hs := Q.add_mem hca h1
-        -- Adding the factor `R i + A` and its image `-R i + A` cancels `R i`, leaving `2 A`.
-        have hsum : (R i + A) + (-R i + A) = 2 * A := by ring
-        rw [hsum] at hs
-        exact hs
-    -- `2 A = algebraMap (2 a) ∈ Q` forces `p ∣ 2 a`, hence (as `p` is odd) `p ∣ a` — absurd.
-    have h2a : algebraMap ℤ (𝓞 K) (2 * a) ∈ Q := by
-      -- `algebraMap ℤ (𝓞 K) 2` is the numeral `2` in `𝓞 K`, so `2 A = algebraMap (2 a)`.
-      have halg_two : algebraMap ℤ (𝓞 K) 2 = 2 := by norm_num
-      rw [map_mul, halg_two, ← hAdef]
-      exact h2A
-    have hpint : Prime (p : ℤ) := Nat.prime_iff_prime_int.mp Fact.out
-    rcases hpint.dvd_mul.mp ((algebraMap_int_mem_iff_dvd_of_liesOver Q _).mp h2a) with h2 | ha
-    · exact hodd ((Nat.prime_dvd_prime_iff_eq Fact.out Nat.prime_two).mp (by exact_mod_cast h2))
-    · exact hpa' ha
+/-- A nonzero quadratic residue `d` mod a prime `p` (`legendreSym p d = 1`, `p ∤ d`) has an integer
+square root modulo `p`: some `a` with `p ∣ a² - d` and `p ∤ a`. -/
+private theorem exists_dvd_sq_sub_and_not_dvd_of_legendreSym_eq_one (p : ℕ) [Fact p.Prime]
+    {d : ℤ} (hqr : legendreSym p d = 1) :
+    ∃ a : ℤ, (p : ℤ) ∣ a ^ 2 - d ∧ ¬ (p : ℤ) ∣ a := by
+  -- `legendreSym p d = 1 ≠ 0`, and `legendreSym p d = 0 ↔ p ∣ d`, so `p ∤ d`.
+  have hcop : ¬ (p : ℤ) ∣ d := by
+    rw [← ZMod.intCast_zmod_eq_zero_iff_dvd, ← legendreSym.eq_zero_iff p d, hqr]
+    exact one_ne_zero
+  obtain ⟨b, hb⟩ := (legendreSym.eq_one_iff p (by
+    rw [Ne, ZMod.intCast_zmod_eq_zero_iff_dvd]; exact hcop)).mp hqr
+  obtain ⟨a, rfl⟩ := ZMod.intCast_surjective b
+  have hpa : (p : ℤ) ∣ a ^ 2 - d := by
+    rw [← ZMod.intCast_zmod_eq_zero_iff_dvd]; push_cast; rw [hb]; ring
+  refine ⟨a, hpa, fun hd => hcop ?_⟩
+  -- `a² - (a² - d) = d`, so `p ∣ d` follows from `p ∣ a²` and `p ∣ a² - d`.
+  have hsub : a ^ 2 - (a ^ 2 - d) = d := by ring
+  rw [← hsub]
+  exact dvd_sub (dvd_pow hd (by norm_num)) hpa
 
-/-- Backward wrapper: for `K` Galois over `ℚ` generated by the `r i` (`ℚ(rᵢ) = K`), if `p` is odd,
-`p ∤ d i` for every `i`, and every `d i` is a quadratic residue mod `p`, then the decomposition
-group of `Q` is trivial. -/
+/-- If `d` is a quadratic residue mod the odd prime `p` (with `p ∤ d`), no element `σ` of the
+decomposition group of a prime `Q` above `p` sends the generator `r` to its negation. -/
+private theorem map_ne_neg_of_legendreSym_eq_one (d : ℤ) (r : K)
+    (hr : r ^ 2 = algebraMap ℤ K d)
+    {p : ℕ} [Fact p.Prime] (hodd : p ≠ 2)
+    (hqr : legendreSym p d = 1)
+    (Q : Ideal (𝓞 K)) [Q.IsPrime] [Q.LiesOver (span {(p : ℤ)})]
+    {σ : K ≃ₐ[ℚ] K} (hσ : σ ∈ stabilizer (K ≃ₐ[ℚ] K) Q) : σ r ≠ - r := by
+  intro hflip
+  obtain ⟨a, hpa, hpa'⟩ := exists_dvd_sq_sub_and_not_dvd_of_legendreSym_eq_one p hqr
+  let R : 𝓞 K := ringGen d r hr
+  -- `algebraMap` intertwines the Galois action on `𝓞 K` with that on `K` (used for `hsR`/`hsA`).
+  have hbridge (x : 𝓞 K) : algebraMap (𝓞 K) K (σ • x) = σ (algebraMap (𝓞 K) K x) := by
+    have hcoe : algebraMap (𝓞 K) K (σ • x) = σ • algebraMap (𝓞 K) K x :=
+      integralClosure.coe_smul σ x
+    rw [hcoe, AlgEquiv.smul_def]
+  have hmapQ : ∀ x ∈ Q, σ • x ∈ Q := by
+    intro x hx; rw [← mem_stabilizer_iff.mp hσ]; exact Ideal.smul_mem_pointwise_smul σ x Q hx
+  set A : 𝓞 K := algebraMap ℤ (𝓞 K) a with hAdef
+  -- `(R - A)(R + A) = d - a² ∈ Q`, so one factor lies in the prime `Q`.
+  have hAsq : A ^ 2 = algebraMap ℤ (𝓞 K) (a ^ 2) := by rw [hAdef, ← map_pow]
+  have heq : (R - A) * (R + A) = algebraMap ℤ (𝓞 K) (d - a ^ 2) := by
+    have h1 : (R - A) * (R + A) = R ^ 2 - A ^ 2 := by ring
+    rw [h1, ringGen_sq d r hr, hAsq, ← map_sub]
+  have hfacQ : (R - A) * (R + A) ∈ Q := by
+    rw [heq]; exact (algebraMap_int_mem_iff_dvd_of_liesOver Q _).mpr (dvd_sub_comm.mp hpa)
+  -- `σ` sends `R ↦ -R` and fixes the integer `A`.
+  have hsR : σ • R = - R := by
+    apply FaithfulSMul.algebraMap_injective (𝓞 K) K
+    rw [hbridge R, map_neg, algebraMap_ringGen, hflip]
+  have hsA : σ • A = A := by
+    apply FaithfulSMul.algebraMap_injective (𝓞 K) K
+    rw [hbridge A, hAdef, ← IsScalarTower.algebraMap_apply ℤ (𝓞 K) K,
+      IsScalarTower.algebraMap_apply ℤ ℚ K, AlgEquiv.commutes]
+  -- Applying `σ` to whichever factor lies in `Q` and adding the two gives `2 A ∈ Q`.
+  have h2A : (2 : 𝓞 K) * A ∈ Q := by
+    rcases (‹Q.IsPrime›).mem_or_mem hfacQ with hca | hca
+    · have h1 : σ • (R - A) ∈ Q := hmapQ _ hca
+      rw [smul_sub, hsR, hsA] at h1
+      have hs := Q.add_mem hca h1
+      have hsum : (R - A) + (-R - A) = -(2 * A) := by ring
+      rw [hsum] at hs
+      exact neg_mem_iff.mp hs
+    · have h1 : σ • (R + A) ∈ Q := hmapQ _ hca
+      rw [smul_add, hsR, hsA] at h1
+      have hs := Q.add_mem hca h1
+      have hsum : (R + A) + (-R + A) = 2 * A := by ring
+      rw [hsum] at hs
+      exact hs
+  -- `2 A = algebraMap (2 a) ∈ Q` forces `p ∣ 2 a`, hence (as `p` is odd) `p ∣ a` — absurd.
+  have h2a : algebraMap ℤ (𝓞 K) (2 * a) ∈ Q := by
+    have halg_two : algebraMap ℤ (𝓞 K) 2 = 2 := by norm_num
+    rw [map_mul, halg_two, ← hAdef]
+    exact h2A
+  have hpint : Prime (p : ℤ) := Nat.prime_iff_prime_int.mp Fact.out
+  rcases hpint.dvd_mul.mp ((algebraMap_int_mem_iff_dvd_of_liesOver Q _).mp h2a) with h2 | ha
+  · exact hodd ((Nat.prime_dvd_prime_iff_eq Fact.out Nat.prime_two).mp (by exact_mod_cast h2))
+  · exact hpa' ha
+
+/-- Backward core (pointwise): if `p` is odd and `d` is a quadratic residue mod `p`, then every
+`σ` in the decomposition group of `Q` fixes the generator `r`. -/
+private theorem decompositionGroup_fixes_gen (d : ℤ) (r : K)
+    (hr : r ^ 2 = algebraMap ℤ K d)
+    {p : ℕ} [Fact p.Prime] (hodd : p ≠ 2)
+    (hqr : legendreSym p d = 1)
+    (Q : Ideal (𝓞 K)) [Q.IsPrime] [Q.LiesOver (span {(p : ℤ)})]
+    {σ : K ≃ₐ[ℚ] K} (hσ : σ ∈ stabilizer (K ≃ₐ[ℚ] K) Q) : σ r = r := by
+  -- From `σ r² = r²`, `σ r = ± r`; the `+` case is immediate and the `-` case is
+  -- excluded by `map_ne_neg_of_legendreSym_eq_one`.
+  have hr' : r ^ 2 = algebraMap ℚ K ((d : ℚ)) := by rw [hr]; simp
+  have h2 : σ r ^ 2 = r ^ 2 := by rw [← map_pow, hr', AlgEquiv.commutes]
+  rcases eq_or_eq_neg_of_sq_eq_sq (σ r) r h2 with h | h
+  · exact h
+  · exact absurd h (map_ne_neg_of_legendreSym_eq_one d r hr hodd hqr Q hσ)
+
+/-- Backward wrapper: for `K` generated over `ℚ` by the `r i` (`ℚ(rᵢ) = K`), if `p` is odd and
+every `d i` is a quadratic residue mod `p`, then the decomposition group of `Q` is trivial. -/
 private theorem stabilizer_eq_bot_of_forall_legendreSym_eq_one {ι : Type*} (d : ι → ℤ) (r : ι → K)
     (hr : ∀ i, r i ^ 2 = algebraMap ℤ K (d i))
-    (htop : IntermediateField.adjoin ℚ (Set.range r) = ⊤) [IsGalois ℚ K]
-    {p : ℕ} [Fact p.Prime] (hodd : p ≠ 2) (hcop : ∀ i, ¬ (p : ℤ) ∣ d i)
+    (htop : IntermediateField.adjoin ℚ (Set.range r) = ⊤)
+    {p : ℕ} [Fact p.Prime] (hodd : p ≠ 2)
     (hqr : ∀ i, legendreSym p (d i) = 1)
     (Q : Ideal (𝓞 K)) [Q.IsPrime] [Q.LiesOver (span {(p : ℤ)})] :
     stabilizer (K ≃ₐ[ℚ] K) Q = ⊥ := by
@@ -233,7 +232,7 @@ private theorem stabilizer_eq_bot_of_forall_legendreSym_eq_one {ι : Type*} (d :
   -- Each `σ` in the stabilizer fixes every generator `r i`, and these generate `K = ℚ(rᵢ)`,
   -- so `σ = 1` by an adjoin induction.
   have hfix : ∀ i, σ (r i) = r i :=
-    fun i => decompositionGroup_fixes_gen d r hr hodd (hcop i) (hqr i) Q hσ
+    fun i => decompositionGroup_fixes_gen (d i) (r i) (hr i) hodd (hqr i) Q hσ
   refine AlgEquiv.ext fun x => ?_
   rw [AlgEquiv.one_apply]
   have hx : x ∈ (⊤ : IntermediateField ℚ K) := IntermediateField.mem_top
@@ -275,7 +274,7 @@ theorem ncard_primesOver_multiquadratic_iff {ι : Type*} [Finite ι] (d : ι →
   refine ⟨fun hsplit i =>
     legendreSym_eq_one_of_ncard_primesOver_eq_finrank d r hr (hcop i) Q hsplit, fun hqr => ?_⟩
   rw [ncard_primesOver_eq_finrank_iff_stabilizer_eq_bot K Q]
-  exact stabilizer_eq_bot_of_forall_legendreSym_eq_one d r hr htop hodd hcop hqr Q
+  exact stabilizer_eq_bot_of_forall_legendreSym_eq_one d r hr htop hodd hqr Q
 
 end
 


### PR DESCRIPTION
## What

Decomposes `decompositionGroup_fixes_gen` in `TauCeti/NumberTheory/Multiquadratic/MultiquadraticSplitting.lean` — the proof that an element `σ` of the decomposition group of a prime `Q` (over an odd `(p)`) fixes each square-root generator `r i` when every `d i` is a quadratic residue mod `p`. The main proof drops from **~83 lines to ~11**, and now-redundant hypotheses exposed by the refactor are dropped.

## Helpers extracted (both `private`, minimal hypotheses)

- **`exists_dvd_sq_sub_and_not_dvd_of_legendreSym_eq_one`** — a pure integer fact: a quadratic residue mod an odd prime has a square root `a` with `p ∤ a` (no `K`/Galois data).
- **`map_ne_neg_of_legendreSym_eq_one`** — the sign obstruction `σ r ≠ -r` under the Legendre hypothesis (the `-` case of the `σ r = ± r` dichotomy); stated for a scalar generator `r` with `r² = algebraMap ℤ K d`.

The `𝓞 K`/`K` action-compatibility step is used inline via Mathlib's `integralClosure.coe_smul` (factored to a single local `have` in the sign-obstruction proof — no wrapper lemma).

## Hypotheses dropped (redundant / unused)

- `hcop : ¬ (p:ℤ) ∣ d` is derivable from `legendreSym p d = 1` (a residue is nonzero mod `p`), so it is removed from the helper chain, `decompositionGroup_fixes_gen`, and `stabilizer_eq_bot_of_forall_legendreSym_eq_one`.
- `[IsGalois ℚ K]` is unused by `decompositionGroup_fixes_gen` and `stabilizer_eq_bot_…` (the latter's triviality argument needs only `htop` + `AlgEquiv.commutes`), so it is dropped from both.

## Notes

- Pure refactor: all declarations remain `private`; the top-level `ncard_primesOver_multiquadratic_iff` keeps its interface (only its internal call to `stabilizer_eq_bot_…` drops the redundant `hcop`). Change confined to this one file.
- Statement-level docstrings updated to match the reduced hypotheses.
- Gates green locally: full `lake build` (5186 jobs), `lake exe axioms`, `lake exe module-system`, `scripts/lint-env.sh` → `LINT-ENV: PASS`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Roadmap: Multiquadratic