### PR TITLE
refactor(Analysis/Contour): golf HasCauchyPVAt.zero

### DIFF
--- a/TauCeti/Analysis/Contour/Cauchy/PrincipalValue/Basic.lean
+++ b/TauCeti/Analysis/Contour/Cauchy/PrincipalValue/Basic.lean
@@ -263,10 +263,8 @@ theorem HasCauchyPVAt.zero {γ : ℝ → ℂ} {a b : ℝ} {z₀ : ℂ} :
     HasCauchyPVAt γ a b (fun _ => 0) z₀ 0 := by
   refine ⟨?_, ?_⟩
   · filter_upwards with ε
-    simp only [zero_mul, ite_self]
-    exact intervalIntegrable_const
-  · simp only [zero_mul, ite_self, intervalIntegral.integral_zero]
-    exact tendsto_const_nhds
+    simpa only [zero_mul, ite_self] using intervalIntegrable_const
+  · simpa only [zero_mul, ite_self, intervalIntegral.integral_zero] using tendsto_const_nhds
 
 /-- The value form of `HasCauchyPVAt.zero`: the principal value of the zero integrand is `0`. -/
 @[simp]


### PR DESCRIPTION
## What

Small `/cleanup` golf on `TauCeti/Analysis/Contour/Cauchy/PrincipalValue/Basic.lean`: `HasCauchyPVAt.zero`'s two `simp only [...]; exact ...` steps become a single `simpa only [...] using ...` (−2 lines). No statement/signature change.

Found by a `/cleanup` pass on the Cauchy-principal-value file; the rest of the file was already at mathlib quality (two other golf candidates turned out to be load-bearing — a `Decidable`-instance subtlety in the `const_mul`/`add` proofs — and were left as-is).

Gates green locally: full `lake build` (5186 jobs), `lake exe axioms`, `lake exe module-system`, `scripts/lint-env.sh` → `LINT-ENV: PASS`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)