### PR TITLE
refactor(FieldTheory): extract the quadratic cross-term lemma and dedup its consumers

### DIFF
--- a/TauCeti/FieldTheory/IntermediateField/Quadratic.lean
+++ b/TauCeti/FieldTheory/IntermediateField/Quadratic.lean
@@ -100,6 +100,32 @@ theorem mem_sup_adjoin_sq {F : IntermediateField K L} {x : L}
       ∃ a b : L, a ∈ F ∧ b ∈ F ∧ y = a + b * x :=
   ⟨exists_add_mul_of_mem_sup_adjoin_sq hx2, mem_sup_adjoin_sq_of_exists⟩
 
+omit K [Field K] [Algebra K L] in
+/-- **Vanishing cross term in a quadratic step.** If `x² ∈ F` but `x ∉ F`, then a square
+`(a + b * x) ^ 2` of a normal-form element that lands back in `F` has no cross term: `a * b = 0`.
+This is where characteristic not two enters, through `2 ≠ 0` in `L`. It holds for an arbitrary
+subfield `F` of `L`; no ambient base field or algebra tower is needed. -/
+theorem mul_eq_zero_of_add_mul_sq_mem {S : Type*} [SetLike S L] [SubfieldClass S L] {F : S} {x : L}
+    (hx2 : x ^ 2 ∈ F) (hxF : x ∉ F) [NeZero (2 : L)] {a b : L}
+    (ha : a ∈ F) (hb : b ∈ F) (hab_mem : (a + b * x) ^ 2 ∈ F) :
+    a * b = 0 := by
+  by_contra hab
+  refine hxF ?_
+  -- Expanding `(a + b * x) ^ 2` and using `x² ∈ F`, the cross term `2 * a * b * x` lies in `F`.
+  have hcross_mem : 2 * a * b * x ∈ F := by
+    have hEq : 2 * a * b * x = (a + b * x) ^ 2 - a ^ 2 - b ^ 2 * x ^ 2 := by ring
+    rw [hEq]
+    exact sub_mem (sub_mem hab_mem (pow_mem ha 2)) (mul_mem (pow_mem hb 2) hx2)
+  -- The coefficient `2 * a * b` lies in `F` and is nonzero, so `x` is recovered by dividing it out.
+  have hcoef_mem : 2 * a * b ∈ F := mul_mem (mul_mem (natCast_mem (s := F) 2) ha) hb
+  have hcoef_ne : 2 * a * b ≠ 0 := by
+    have h2ab : (2 : L) * (a * b) ≠ 0 := mul_ne_zero (NeZero.ne (2 : L)) hab
+    simpa [mul_assoc] using h2ab
+  have hxeq : (2 * a * b)⁻¹ * (2 * a * b * x) = x := by
+    rw [← mul_assoc, inv_mul_cancel₀ hcoef_ne, one_mul]
+  rw [← hxeq]
+  exact mul_mem (inv_mem hcoef_mem) hcross_mem
+
 /-- If `x² ∈ F` but `x ∉ F`, then the simple extension `F⟮x⟯` has finrank two over `F`. -/
 theorem finrank_adjoin_simple_eq_two_of_sq_mem_notMem (F : IntermediateField K L) {x : L}
     (hx2 : x ^ 2 ∈ F) (hxF : x ∉ F) :
@@ -156,57 +182,45 @@ theorem isSquare_mul_of_adjoin_simple_eq [NeZero (2 : K)] {a c : K} {x y : L}
     (hxb : x ∉ (⊥ : IntermediateField K L))
     (hxy : IntermediateField.adjoin K {x} = IntermediateField.adjoin K {y}) :
     IsSquare (a * c) := by
-  -- Write `y` in the normal form `p + q * x` over the base field.
+  haveI : NeZero (2 : L) :=
+    NeZero.nat_of_injective (n := 2) (f := algebraMap K L) (algebraMap K L).injective
+  -- Write `y` in the base-field normal form `algebraMap p₀ + algebraMap q₀ * x`.
   have hx2 : x ^ 2 ∈ (⊥ : IntermediateField K L) := by
     rw [hx]; exact IntermediateField.algebraMap_mem _ _
   have hy_mem : y ∈ (⊥ : IntermediateField K L) ⊔ IntermediateField.adjoin K {x} := by
     rw [bot_sup_eq, hxy]; exact IntermediateField.mem_adjoin_simple_self K y
   obtain ⟨p, q, hp, hq, hy_eq⟩ := (mem_sup_adjoin_sq hx2).mp hy_mem
   rw [IntermediateField.mem_bot] at hp hq
-  obtain ⟨p₀, hp₀⟩ := hp
-  obtain ⟨q₀, hq₀⟩ := hq
-  -- The `x`-coefficient of `y²` in this normal form.
-  have hkey : algebraMap K L (2 * p₀ * q₀) * x = algebraMap K L (c - p₀ ^ 2 - q₀ ^ 2 * a) := by
+  obtain ⟨p₀, rfl⟩ := hp
+  obtain ⟨q₀, rfl⟩ := hq
+  -- The square `y² = c` lands in `⊥`, so the shared cross-term lemma forces `p₀ * q₀ = 0`.
+  have hab_mem :
+      (algebraMap K L p₀ + algebraMap K L q₀ * x) ^ 2 ∈ (⊥ : IntermediateField K L) := by
+    rw [← hy_eq, hy]; exact IntermediateField.algebraMap_mem _ _
+  have hpq : algebraMap K L p₀ * algebraMap K L q₀ = 0 :=
+    mul_eq_zero_of_add_mul_sq_mem hx2 hxb (IntermediateField.algebraMap_mem _ _)
+      (IntermediateField.algebraMap_mem _ _) hab_mem
+  have hpq0 : p₀ * q₀ = 0 := by
+    apply FaithfulSMul.algebraMap_injective K L
+    rw [map_mul, map_zero]
+    exact hpq
+  -- The vanishing cross term forces `c = p₀² + q₀² * a`.
+  have hc : c = p₀ ^ 2 + q₀ ^ 2 * a := by
     have hy2 : (algebraMap K L p₀ + algebraMap K L q₀ * x) ^ 2 = algebraMap K L c := by
-      rw [hp₀, hq₀, ← hy_eq]; exact hy
-    simp only [map_mul, map_sub, map_pow, map_ofNat]
-    linear_combination hy2 - (algebraMap K L q₀) ^ 2 * hx
-  by_cases hz : 2 * p₀ * q₀ = 0
-  · -- The `x`-coefficient vanishes, so `c = p₀² + q₀² a` and `p₀ q₀ = 0`.
-    have hmc : c - p₀ ^ 2 - q₀ ^ 2 * a = 0 := by
-      have : algebraMap K L (c - p₀ ^ 2 - q₀ ^ 2 * a) = 0 := by
-        rw [← hkey, hz, map_zero, zero_mul]
-      exact FaithfulSMul.algebraMap_injective K L (by rw [this, map_zero])
-    have hc : c = p₀ ^ 2 + q₀ ^ 2 * a := by linear_combination hmc
-    have hpq : p₀ = 0 ∨ q₀ = 0 := by
-      rcases mul_eq_zero.mp hz with h | h
-      · rcases mul_eq_zero.mp h with h2 | h2
-        · exact absurd h2 (NeZero.ne (2 : K))
-        · exact Or.inl h2
-      · exact Or.inr h
-    rcases hpq with hp0 | hq0
-    · -- `p₀ = 0`, so `c = q₀² a` and `a c = (q₀ a)²`.
-      refine ⟨q₀ * a, ?_⟩
-      rw [hc, hp0]; ring
-    · -- `q₀ = 0` forces `y` into the base field, contradicting `x ∉ ⊥`.
-      exfalso
-      apply hxb
-      have hyb : y ∈ (⊥ : IntermediateField K L) := by
-        rw [hy_eq, ← hq₀, hq0, map_zero, zero_mul, add_zero, ← hp₀]
-        exact IntermediateField.algebraMap_mem _ _
-      have hyadjoin : IntermediateField.adjoin K {y} = ⊥ :=
-        IntermediateField.adjoin_eq_bot_iff.mpr (Set.singleton_subset_iff.mpr hyb)
-      rw [← hxy] at hyadjoin
-      rw [← hyadjoin]
-      exact IntermediateField.mem_adjoin_simple_self K x
-  · -- The `x`-coefficient is nonzero, so `x` lies in the base field, a contradiction.
-    exfalso
-    apply hxb
-    have hne : algebraMap K L (2 * p₀ * q₀) ≠ 0 :=
-      (map_ne_zero_iff _ (FaithfulSMul.algebraMap_injective K L)).mpr hz
-    have hxeq : x = algebraMap K L (c - p₀ ^ 2 - q₀ ^ 2 * a) / algebraMap K L (2 * p₀ * q₀) := by
-      rw [eq_div_iff hne, mul_comm]; exact hkey
-    rw [hxeq]
-    exact div_mem (IntermediateField.algebraMap_mem _ _) (IntermediateField.algebraMap_mem _ _)
+      rw [← hy_eq]; exact hy
+    apply FaithfulSMul.algebraMap_injective K L
+    rw [map_add, map_pow, map_mul, map_pow]
+    linear_combination -hy2 + (algebraMap K L q₀) ^ 2 * hx + 2 * x * hpq
+  -- Either `p₀ = 0`, giving `a * c = (q₀ * a)²`, or `q₀ = 0`, forcing `x ∈ K`, a contradiction.
+  rcases mul_eq_zero.mp hpq0 with hp0 | hq0
+  · -- `p₀ = 0`, so `c = q₀² * a` and `a * c = (q₀ * a)²`.
+    exact ⟨q₀ * a, by rw [hc, hp0]; ring⟩
+  · -- `q₀ = 0` puts `y` in the base field, forcing `x ∈ K`, a contradiction.
+    refine absurd ?_ hxb
+    have hyb : y ∈ (⊥ : IntermediateField K L) := by
+      rw [hy_eq, hq0, map_zero, zero_mul, add_zero]
+      exact IntermediateField.algebraMap_mem _ _
+    exact IntermediateField.adjoin_simple_eq_bot_iff.mp
+      (hxy.trans (IntermediateField.adjoin_simple_eq_bot_iff.mpr hyb))
 
 end TauCeti.IntermediateField

--- a/TauCeti/NumberTheory/Multiquadratic/SquareClass/Basic.lean
+++ b/TauCeti/NumberTheory/Multiquadratic/SquareClass/Basic.lean
@@ -172,78 +172,53 @@ theorem squareClass_of_sq_mem (d : ℕ → K) (root : ℕ → L)
           exact (sqrtTower (K := K) root n).algebraMap_mem (d n)
         obtain ⟨a, b, ha, hb, heq⟩ :=
           TauCeti.IntermediateField.exists_add_mul_of_mem_sup_adjoin_sq hx2 hmem
-        have hsq :
-            algebraMap K L r =
-              a ^ 2 + b ^ 2 * algebraMap K L (d n) + 2 * a * b * root n := by
-          calc
-            algebraMap K L r = y ^ 2 := hy.symm
-            _ = (a + b * root n) ^ 2 := by rw [heq]
-            _ = a ^ 2 + b ^ 2 * algebraMap K L (d n) + 2 * a * b * root n := by
-              rw [← hroot n]
-              ring
-        have hcross_eq :
-            2 * a * b * root n =
-              algebraMap K L r - a ^ 2 - b ^ 2 * algebraMap K L (d n) := by
-          rw [hsq]
-          ring
-        have hcross_mem : 2 * a * b * root n ∈ sqrtTower (K := K) root n := by
-          rw [hcross_eq]
-          exact sub_mem
-            (sub_mem ((sqrtTower (K := K) root n).algebraMap_mem r) (pow_mem ha 2))
-            (mul_mem (pow_mem hb 2) ((sqrtTower (K := K) root n).algebraMap_mem (d n)))
-        by_cases hab : a * b = 0
-        · rcases mul_eq_zero.mp hab with ha0 | hb0
-          · have hy_mul_mem : y * root n ∈ sqrtTower (K := K) root n := by
-              have hy_mul_eq : y * root n = b * algebraMap K L (d n) := by
-                calc
-                  y * root n = (b * root n) * root n := by rw [heq, ha0, zero_add]
-                  _ = b * (root n ^ 2) := by ring
-                  _ = b * algebraMap K L (d n) := by rw [hroot n]
-              rw [hy_mul_eq]
-              exact mul_mem hb ((sqrtTower (K := K) root n).algebraMap_mem (d n))
-            have hy_mul_sq : (y * root n) ^ 2 = algebraMap K L (r * d n) := by
-              rw [map_mul, ← hy, ← hroot n]
-              ring
-            obtain ⟨T, s, hT, hmul⟩ := ih (r * d n) (y * root n) hy_mul_sq hy_mul_mem
-            have hnT : n ∉ T := fun hn => Nat.lt_irrefl n (hT hn)
-            refine ⟨insert n T, s / d n, ?_, ?_⟩
-            · intro j hj
-              rw [Finset.mem_coe, Finset.mem_insert] at hj
-              rw [Set.mem_Iio]
-              rcases hj with rfl | hj
-              · omega
-              · exact Nat.lt_trans (hT hj) n.lt_succ_self
-            · have hdn0 : d n ≠ 0 := by
-                intro hdn
-                apply hnext
-                have hroot_zero : root n = 0 := by
-                  apply eq_zero_of_pow_eq_zero
-                  rw [hroot n, hdn, map_zero]
-                rw [hroot_zero]
-                exact zero_mem _
-              rw [Finset.prod_insert hnT]
+        -- `(a + b·root n)² = y² = algebraMap K L r ∈ sqrtTower`, while `root n ∉ sqrtTower`; hence
+        -- the cross-term coefficient vanishes (`Quadratic.mul_eq_zero_of_add_mul_sq_mem`).
+        have hab_mem : (a + b * root n) ^ 2 ∈ sqrtTower (K := K) root n := by
+          rw [← heq, hy]
+          exact (sqrtTower (K := K) root n).algebraMap_mem r
+        have hab : a * b = 0 :=
+          TauCeti.IntermediateField.mul_eq_zero_of_add_mul_sq_mem hx2 hnext ha hb hab_mem
+        rcases mul_eq_zero.mp hab with ha0 | hb0
+        · have hy_mul_mem : y * root n ∈ sqrtTower (K := K) root n := by
+            have hy_mul_eq : y * root n = b * algebraMap K L (d n) := by
               calc
-                r = (r * d n) / d n := by field_simp [hdn0]
-                _ = (s ^ 2 * ∏ j ∈ T, d j) / d n := by rw [hmul]
-                _ = (s / d n) ^ 2 * (d n * ∏ j ∈ T, d j) := by
-                  field_simp [hdn0]
-          · have hy_mem : y ∈ sqrtTower (K := K) root n := by
-              rw [heq, hb0, zero_mul, add_zero]
-              exact ha
-            obtain ⟨T, s, hT, hres⟩ := ih r y hy hy_mem
-            exact ⟨T, s, hT.trans (Set.Iio_subset_Iio n.le_succ), hres⟩
-        · have hcoef_mem : 2 * a * b ∈ sqrtTower (K := K) root n :=
-            mul_mem (mul_mem ((sqrtTower (K := K) root n).natCast_mem 2) ha) hb
-          have hcoef_ne : 2 * a * b ≠ 0 := by
-            have h2ab : (2 : L) * (a * b) ≠ 0 := mul_ne_zero (NeZero.ne (2 : L)) hab
-            simpa [mul_assoc] using h2ab
-          have hroot_mem : root n ∈ sqrtTower (K := K) root n := by
-            have hmem' := mul_mem (inv_mem hcoef_mem) hcross_mem
-            have hEq : (2 * a * b)⁻¹ * (2 * a * b * root n) = root n := by
-              rw [← mul_assoc, inv_mul_cancel₀ hcoef_ne, one_mul]
-            rw [← hEq]
-            exact hmem'
-          exact (hnext hroot_mem).elim
+                y * root n = (b * root n) * root n := by rw [heq, ha0, zero_add]
+                _ = b * (root n ^ 2) := by ring
+                _ = b * algebraMap K L (d n) := by rw [hroot n]
+            rw [hy_mul_eq]
+            exact mul_mem hb ((sqrtTower (K := K) root n).algebraMap_mem (d n))
+          have hy_mul_sq : (y * root n) ^ 2 = algebraMap K L (r * d n) := by
+            rw [map_mul, ← hy, ← hroot n]
+            ring
+          obtain ⟨T, s, hT, hmul⟩ := ih (r * d n) (y * root n) hy_mul_sq hy_mul_mem
+          have hnT : n ∉ T := fun hn => Nat.lt_irrefl n (hT hn)
+          refine ⟨insert n T, s / d n, ?_, ?_⟩
+          · intro j hj
+            rw [Finset.mem_coe, Finset.mem_insert] at hj
+            rw [Set.mem_Iio]
+            rcases hj with rfl | hj
+            · omega
+            · exact Nat.lt_trans (hT hj) n.lt_succ_self
+          · have hdn0 : d n ≠ 0 := by
+              intro hdn
+              apply hnext
+              have hroot_zero : root n = 0 := by
+                apply eq_zero_of_pow_eq_zero
+                rw [hroot n, hdn, map_zero]
+              rw [hroot_zero]
+              exact zero_mem _
+            rw [Finset.prod_insert hnT]
+            calc
+              r = (r * d n) / d n := by field_simp [hdn0]
+              _ = (s ^ 2 * ∏ j ∈ T, d j) / d n := by rw [hmul]
+              _ = (s / d n) ^ 2 * (d n * ∏ j ∈ T, d j) := by
+                field_simp [hdn0]
+        · have hy_mem : y ∈ sqrtTower (K := K) root n := by
+            rw [heq, hb0, zero_mul, add_zero]
+            exact ha
+          obtain ⟨T, s, hT, hres⟩ := ih r y hy hy_mem
+          exact ⟨T, s, hT.trans (Set.Iio_subset_Iio n.le_succ), hres⟩
 
 /-- **Finite-index square-class descent.** If `y² = r` over `K` and
 `y ∈ K(root i | i : Fin n)`, where `root i` is a chosen square root of `d i`, then `r`


### PR DESCRIPTION
## What

Factors the cross-term-vanishing step of `isSquare_mul_of_adjoin_simple_eq` (in `TauCeti/FieldTheory/IntermediateField/Quadratic.lean`) into a named, **public** lemma, and routes the two sites that duplicate that argument through it.

## Extracted

- **`mul_eq_zero_of_add_mul_sq_mem`** — for `x` with `x² ∈ F`, `x ∉ F`, `NeZero (2 : L)`, and `a b ∈ F` with `(a + b·x)² ∈ F`, the cross term vanishes: `a · b = 0`. This is the "a square in a quadratic adjunction has no cross term" fact (where characteristic `≠ 2` enters). It is **public** because it has a concrete cross-file consumer (`squareClass_of_sq_mem`, below), so it is the shared home for the argument rather than a duplicated block.

## Reused (duplicates removed)

- **`isSquare_mul_of_adjoin_simple_eq`** now routes its cross-term-vanishing step through the lemma; the two thin single-use private helpers it previously carried are removed.
- **`squareClass_of_sq_mem`** (`TauCeti/NumberTheory/Multiquadratic/SquareClass/Basic.lean`) previously re-derived the same cross-term expansion + coefficient-inversion argument inline — a `by_cases a·b = 0` whose nonzero branch reconstructed `x` by dividing out `2·a·b`. It now obtains `a · b = 0` directly from the shared lemma, deleting the duplicated derivation and the impossible branch. Its statement and descent structure are unchanged.

## Notes

- Touches `Quadratic.lean` (extraction) and `SquareClass/Basic.lean` (dedup of the shared argument); net line reduction.
- Gates green locally: `lake build`, `lake exe axioms`, `lake exe module-system`, `scripts/lint-env.sh` → `LINT-ENV: PASS`.

Roadmap: Multiquadratic