### PR TITLE
feat(NumberTheory/GeometryOfNumbers): strengthen the doubling factor to 49 and decompose the box-count bound

### DIFF
--- a/TauCeti/NumberTheory/GeometryOfNumbers/Doubling.lean
+++ b/TauCeti/NumberTheory/GeometryOfNumbers/Doubling.lean
@@ -25,8 +25,8 @@ rather than consuming it.
   `(4·c/ε) ^ (2·#ι)` points.
 
 * **Doubling** (`ncard_inter_box_two_le_pow_mul_ncard_inter_box_one`): passing from the unit
-  box to the double box multiplies the lattice-point count by at most `64 ^ #ι`, i.e.
-  `#(Λ ∩ box r 2) ≤ 64 ^ #ι · #(Λ ∩ box r 1)`, given that `Λ ∩ box r 2` is finite.
+  box to the double box multiplies the lattice-point count by at most `49 ^ #ι`, i.e.
+  `#(Λ ∩ box r 2) ≤ 49 ^ #ι · #(Λ ∩ box r 1)`, given that `Λ ∩ box r 2` is finite.
 
 ## Reconciliation with `ZLattice`
 
@@ -41,7 +41,7 @@ The roadmap asks that Layer 0 keep only the genuinely measure-free content. Acco
   what a `ZLattice`'s discreteness supplies (a discrete subgroup meets a bounded set in a
   finite set); the packing lemma here is one self-contained way to discharge it.
 
-The doubling factor `64 ^ #ι` and the packing count are explicit and have no upstream
+The doubling factor `49 ^ #ι` and the packing count are explicit and have no upstream
 analogue: Mathlib's geometry of numbers is volumetric (Minkowski's convex-body theorem), not
 a cardinal doubling estimate.
 
@@ -270,76 +270,89 @@ private theorem coarseCell_mem_Icc {ri : ℝ} (hri : 0 < ri) {t : ℝ} (ht : |t|
   · rw [le_div_iff₀ hpos]; push_cast; nlinarith [abs_le.mp ht]
   · rw [div_lt_iff₀ hpos]; push_cast; nlinarith [abs_le.mp ht]
 
+omit [Fintype ι] in
+/-- The coarse cell index of `x` for the grid of side `2·r i/3`: per coordinate, the pair of
+floor indices of the real and imaginary parts. -/
+private noncomputable def coarseCellMap (r : ι → ℝ) (x : ι → ℂ) : ι → ℤ × ℤ :=
+  fun i => (⌊(x i).re / (2 * r i / 3)⌋, ⌊(x i).im / (2 * r i / 3)⌋)
+
+omit [Fintype ι] in
+/-- Two points sharing every coarse cell `coarseCellMap r` differ by at most `r i` in each
+coordinate, so their difference lies in `box r 1`. -/
+private theorem sub_mem_box_one_of_coarseCellMap_eq {r : ι → ℝ} (hr : ∀ i, 0 < r i) {y x : ι → ℂ}
+    (h : coarseCellMap r y = coarseCellMap r x) : y - x ∈ box r 1 := by
+  rw [mem_box]
+  intro i
+  rw [one_mul, Pi.sub_apply]
+  have hc := congr_fun h i
+  exact norm_sub_le_of_coarseCell_eq (hr i) (congr_arg Prod.fst hc) (congr_arg Prod.snd hc)
+
+/-- A `g`-fibre of `sA` has at most `sB.card` elements when the difference of any two
+same-fibre points of `sA` lies in `sB`: translating the fibre to a fixed representative
+injects it into `sB`. -/
+private theorem card_filter_le_of_sub_mem {G : Type*} [AddGroup G] {σ : Type*} [DecidableEq σ]
+    {sA sB : Finset G} {g : G → σ}
+    (h : ∀ y ∈ sA, ∀ x ∈ sA, g y = g x → y - x ∈ sB) (b : σ) :
+    (sA.filter (fun a => g a = b)).card ≤ sB.card := by
+  rcases (sA.filter (fun a => g a = b)).eq_empty_or_nonempty with he | ⟨x₀, hx₀⟩
+  · simp [he]
+  · rw [Finset.mem_filter] at hx₀
+    exact Finset.card_le_card_of_injOn (· - x₀)
+      (fun y hy => h y (Finset.mem_filter.1 (Finset.mem_coe.1 hy)).1 x₀ hx₀.1
+        ((Finset.mem_filter.1 (Finset.mem_coe.1 hy)).2.trans hx₀.2.symm))
+      (fun a _ c _ hac => by simpa using congrArg (· + x₀) hac)
+
+/-- If `s` is contained in `box r 2`, its image under `coarseCellMap r` has at most `49 ^ #ι`
+elements: each coordinate part lands in the 7 cells `Icc (-3) 3`, so `7² = 49` cells per
+coordinate and `49 ^ #ι` overall. -/
+private theorem card_image_coarseCellMap_le {r : ι → ℝ} (hr : ∀ i, 0 < r i)
+    {s : Finset (ι → ℂ)} (hs : ∀ x ∈ s, x ∈ box r 2) :
+    (s.image (coarseCellMap r)).card ≤ 49 ^ Fintype.card ι := by
+  set T : Finset (ι → ℤ × ℤ) :=
+    Fintype.piFinset (fun _ : ι => Finset.Icc (-3 : ℤ) 3 ×ˢ Finset.Icc (-3 : ℤ) 3) with hTdef
+  have himage : s.image (coarseCellMap r) ⊆ T := by
+    intro b hb
+    obtain ⟨y, hy, rfl⟩ := Finset.mem_image.mp hb
+    rw [hTdef, Fintype.mem_piFinset]
+    intro i
+    have hy2 := hs y hy
+    rw [Finset.mem_product]
+    exact ⟨coarseCell_mem_Icc (hr i) ((Complex.abs_re_le_norm _).trans (hy2 i)),
+      coarseCell_mem_Icc (hr i) ((Complex.abs_im_le_norm _).trans (hy2 i))⟩
+  have hTeq : T.card = 49 ^ Fintype.card ι := by
+    have hcard7 : (Finset.Icc (-3 : ℤ) 3).card = 7 := by rw [Int.card_Icc]; rfl
+    rw [hTdef, Fintype.card_piFinset, Finset.prod_const, Finset.card_univ,
+      Finset.card_product, hcard7]
+  exact hTeq ▸ Finset.card_le_card himage
+
 /-- **Doubling.** Assuming `Λ ∩ box r 2` is finite, counting lattice points in the double box
-loses at most `64 ^ #ι` against the unit box:
-`#(Λ ∩ box r 2) ≤ 64 ^ #ι · #(Λ ∩ box r 1)`. -/
+loses at most `49 ^ #ι` against the unit box:
+`#(Λ ∩ box r 2) ≤ 49 ^ #ι · #(Λ ∩ box r 1)`. -/
 theorem ncard_inter_box_two_le_pow_mul_ncard_inter_box_one (r : ι → ℝ) (hr : ∀ i, 0 < r i)
     (Λ : AddSubgroup (ι → ℂ)) (hfin : ((Λ : Set (ι → ℂ)) ∩ box r 2).Finite) :
     (((Λ : Set (ι → ℂ)) ∩ box r 2).ncard : ℝ) ≤
-      64 ^ Fintype.card ι * ((Λ : Set (ι → ℂ)) ∩ box r 1).ncard := by
+      49 ^ Fintype.card ι * ((Λ : Set (ι → ℂ)) ∩ box r 1).ncard := by
   set A : Set (ι → ℂ) := (Λ : Set (ι → ℂ)) ∩ box r 2
   set B : Set (ι → ℂ) := (Λ : Set (ι → ℂ)) ∩ box r 1
-  have hBA : B ⊆ A := fun x hx => ⟨hx.1, box_mono (fun i => (hr i).le) one_le_two hx.2⟩
-  have hBfin : B.Finite := hfin.subset hBA
+  have hBfin : B.Finite :=
+    hfin.subset fun x hx => ⟨hx.1, box_mono (fun i => (hr i).le) one_le_two hx.2⟩
   set sA : Finset (ι → ℂ) := hfin.toFinset with hsA
   set sB : Finset (ι → ℂ) := hBfin.toFinset with hsB
-  set f : (ι → ℂ) → (ι → ℤ × ℤ) :=
-    fun x i => (⌊(x i).re / (2 * r i / 3)⌋, ⌊(x i).im / (2 * r i / 3)⌋)
-  have hfiber : ∀ b ∈ sA.image f, (sA.filter (fun a => f a = b)).card ≤ sB.card := by
-    intro b hb
-    obtain ⟨x₀, hx₀A, hx₀b⟩ := Finset.mem_image.mp hb
-    have hmaps : ∀ y ∈ sA.filter (fun a => f a = b), y - x₀ ∈ sB := by
-      intro y hy
-      rw [Finset.mem_filter] at hy
-      have hyb : f y = f x₀ := hy.2.trans hx₀b.symm
-      have hdiff : ∀ i, ‖(y - x₀) i‖ ≤ r i := by
-        intro i
-        have hcell := congr_fun hyb i
-        rw [Pi.sub_apply]
-        exact norm_sub_le_of_coarseCell_eq (hr i) (congr_arg Prod.fst hcell)
-          (congr_arg Prod.snd hcell)
-      have hyA : y ∈ A := (hfin.mem_toFinset).mp hy.1
-      have hx₀A' : x₀ ∈ A := (hfin.mem_toFinset).mp hx₀A
-      rw [hsB, hBfin.mem_toFinset]
-      exact ⟨Λ.sub_mem hyA.1 hx₀A'.1, fun i => by rw [one_mul]; exact hdiff i⟩
-    have hinj : Set.InjOn (fun y => y - x₀) ↑(sA.filter (fun a => f a = b)) :=
-      fun a _ b _ h => by have h2 := congrArg (· + x₀) h; simpa using h2
-    calc (sA.filter (fun a => f a = b)).card
-        = ((sA.filter (fun a => f a = b)).image (fun y => y - x₀)).card :=
-          (Finset.card_image_of_injOn hinj).symm
-      _ ≤ sB.card := Finset.card_le_card (fun z hz => by
-          obtain ⟨y, hy, rfl⟩ := Finset.mem_image.mp hz; exact hmaps y hy)
-  set T : Finset (ι → ℤ × ℤ) :=
-    Fintype.piFinset (fun _ : ι => Finset.Icc (-3 : ℤ) 3 ×ˢ Finset.Icc (-3 : ℤ) 3) with hTdef
-  have himage : sA.image f ⊆ T := by
-    intro b hb
-    obtain ⟨y, hyA, rfl⟩ := Finset.mem_image.mp hb
-    have hyA' : y ∈ A := (hfin.mem_toFinset).mp hyA
-    rw [hTdef, Fintype.mem_piFinset]
-    intro i
-    have hbre : |(y i).re| ≤ 2 * r i := (Complex.abs_re_le_norm _).trans (hyA'.2 i)
-    have hbim : |(y i).im| ≤ 2 * r i := (Complex.abs_im_le_norm _).trans (hyA'.2 i)
-    rw [Finset.mem_product]
-    exact ⟨coarseCell_mem_Icc (hr i) hbre, coarseCell_mem_Icc (hr i) hbim⟩
-  have hTcard : (T.card : ℝ) ≤ 64 ^ Fintype.card ι := by
-    have hcard7 : (Finset.Icc (-3 : ℤ) 3).card = 7 := by rw [Int.card_Icc]; rfl
-    have hTeq : T.card = 49 ^ Fintype.card ι := by
-      rw [hTdef, Fintype.card_piFinset, Finset.prod_const, Finset.card_univ,
-        Finset.card_product, hcard7]
-    rw [hTeq]; push_cast
-    exact pow_le_pow_left₀ (by norm_num) (by norm_num) _
-  have hmul : sA.card ≤ sB.card * (sA.image f).card :=
-    Finset.card_le_mul_card_image sA sB.card hfiber
-  have hAcard : A.ncard = sA.card := by rw [hsA]; exact Set.ncard_eq_toFinset_card A hfin
-  have hBcard : B.ncard = sB.card := by rw [hsB]; exact Set.ncard_eq_toFinset_card B hBfin
-  rw [hAcard, hBcard]
-  have h64 : ((sA.image f).card : ℝ) ≤ 64 ^ Fintype.card ι :=
-    le_trans (by exact_mod_cast Finset.card_le_card himage) hTcard
+  -- Translating a coarse-cell fibre of `sA` to a representative injects it into `sB`.
+  have hsub : ∀ y ∈ sA, ∀ x ∈ sA, coarseCellMap r y = coarseCellMap r x → y - x ∈ sB := by
+    intro y hy x hx hyx
+    rw [hsB, hBfin.mem_toFinset]
+    exact ⟨Λ.sub_mem (hfin.mem_toFinset.mp hy).1 (hfin.mem_toFinset.mp hx).1,
+      sub_mem_box_one_of_coarseCellMap_eq hr hyx⟩
+  have hmul : sA.card ≤ sB.card * (sA.image (coarseCellMap r)).card :=
+    Finset.card_le_mul_card_image sA sB.card fun b _ => card_filter_le_of_sub_mem hsub b
+  have h49 : ((sA.image (coarseCellMap r)).card : ℝ) ≤ 49 ^ Fintype.card ι := by
+    exact_mod_cast card_image_coarseCellMap_le hr fun z hz => (hfin.mem_toFinset.mp hz).2
+  rw [Set.ncard_eq_toFinset_card A hfin, Set.ncard_eq_toFinset_card B hBfin, ← hsA, ← hsB]
   calc (sA.card : ℝ)
-      ≤ (sB.card : ℝ) * ((sA.image f).card : ℝ) := by exact_mod_cast hmul
-    _ ≤ (sB.card : ℝ) * (64 ^ Fintype.card ι) := by
-        exact mul_le_mul_of_nonneg_left h64 (by positivity)
-    _ = 64 ^ Fintype.card ι * (sB.card : ℝ) := by ring
+      ≤ (sB.card : ℝ) * ((sA.image (coarseCellMap r)).card : ℝ) := by exact_mod_cast hmul
+    _ ≤ (sB.card : ℝ) * 49 ^ Fintype.card ι := mul_le_mul_of_nonneg_left h49 (by positivity)
+    _ = 49 ^ Fintype.card ι * (sB.card : ℝ) := by ring
 
 end Doubling
 

--- a/TauCeti/NumberTheory/GeometryOfNumbers/RankTwoDoubling.lean
+++ b/TauCeti/NumberTheory/GeometryOfNumbers/RankTwoDoubling.lean
@@ -29,9 +29,9 @@ with separation scale `ρ = 1/2` and produces a finite intersection with the box
   the radius-two box form a finite set (the packing lemma discharges discreteness).
 * `TauCeti.GeometryOfNumbers.gaussianLattice_inter_box_two_ncard_le`: at most `256` of
   them, the explicit packing count `(8/ρ)^(2·#ι)` at `ρ = 1/2`, `#ι = 1`.
-* `gaussianLattice_ncard_inter_box_two_le_sixtyFour_mul_ncard_inter_box_one`:
-  the doubling instance `#(Λ ∩ box 2) ≤ 64 · #(Λ ∩ box 1)`, a round bound for the engine's
-  sharp factor `49^{#ι} = 49` at `#ι = 1`.
+* `gaussianLattice_ncard_inter_box_two_le_fortyNine_mul_ncard_inter_box_one`:
+  the doubling instance `#(Λ ∩ box 2) ≤ 49 · #(Λ ∩ box 1)`, the engine's proved factor
+  `49^{#ι} = 49` at `#ι = 1`; `…_le_sixtyFour_…` is the rounder `64`-factor corollary.
 
 These exercise both halves of the engine — `addSubgroup_inter_box_finite_and_ncard_le_of_separated`
 and `ncard_inter_box_two_le_pow_mul_ncard_inter_box_one` — on a genuine rank-two lattice,
@@ -124,15 +124,23 @@ theorem gaussianLattice_inter_box_two_ncard_le :
   rw [Fintype.card_fin]
   norm_num
 
-/-- **A concrete doubling instance.** Passing from the unit box to the double box multiplies
-the Gaussian-lattice point count by at most `64`, a round bound for the engine's sharp factor
-`49^{#ι} = 49` at `#ι = 1`: `#(Λ ∩ box 2) ≤ 64 · #(Λ ∩ box 1)`. -/
+/-- **A concrete doubling instance.** Passing from the unit box to the double box multiplies the
+Gaussian-lattice point count by at most the engine's proved factor `49^{#ι} = 49` at `#ι = 1`:
+`#(Λ ∩ box 2) ≤ 49 · #(Λ ∩ box 1)`. -/
+theorem gaussianLattice_ncard_inter_box_two_le_fortyNine_mul_ncard_inter_box_one :
+    (((gaussianLattice : Set (Fin 1 → ℂ)) ∩ box (fun _ => 1) 2).ncard : ℝ) ≤
+      49 * (((gaussianLattice : Set (Fin 1 → ℂ)) ∩ box (fun _ => 1) 1).ncard : ℝ) := by
+  simpa [Fintype.card_fin, pow_one] using
+    ncard_inter_box_two_le_pow_mul_ncard_inter_box_one (ι := Fin 1) (fun _ => 1)
+      (fun _ => one_pos) gaussianLattice gaussianLattice_inter_box_two_finite
+
+/-- The same doubling instance with the rounder factor `64` — a compatibility corollary of
+`gaussianLattice_ncard_inter_box_two_le_fortyNine_mul_ncard_inter_box_one`, weakening `49 ≤ 64`:
+`#(Λ ∩ box 2) ≤ 64 · #(Λ ∩ box 1)`. -/
 theorem gaussianLattice_ncard_inter_box_two_le_sixtyFour_mul_ncard_inter_box_one :
     (((gaussianLattice : Set (Fin 1 → ℂ)) ∩ box (fun _ => 1) 2).ncard : ℝ) ≤
-      64 * (((gaussianLattice : Set (Fin 1 → ℂ)) ∩ box (fun _ => 1) 1).ncard : ℝ) := by
-  have h := ncard_inter_box_two_le_pow_mul_ncard_inter_box_one (ι := Fin 1) (fun _ => 1)
-    (fun _ => one_pos) gaussianLattice gaussianLattice_inter_box_two_finite
-  rw [Fintype.card_fin, pow_one] at h
-  exact h.trans (mul_le_mul_of_nonneg_right (by norm_num) (by positivity))
+      64 * (((gaussianLattice : Set (Fin 1 → ℂ)) ∩ box (fun _ => 1) 1).ncard : ℝ) :=
+  gaussianLattice_ncard_inter_box_two_le_fortyNine_mul_ncard_inter_box_one.trans
+    (mul_le_mul_of_nonneg_right (by norm_num) (by positivity))
 
 end TauCeti.GeometryOfNumbers

--- a/TauCeti/NumberTheory/GeometryOfNumbers/RankTwoDoubling.lean
+++ b/TauCeti/NumberTheory/GeometryOfNumbers/RankTwoDoubling.lean
@@ -30,8 +30,8 @@ with separation scale `ρ = 1/2` and produces a finite intersection with the box
 * `TauCeti.GeometryOfNumbers.gaussianLattice_inter_box_two_ncard_le`: at most `256` of
   them, the explicit packing count `(8/ρ)^(2·#ι)` at `ρ = 1/2`, `#ι = 1`.
 * `gaussianLattice_ncard_inter_box_two_le_sixtyFour_mul_ncard_inter_box_one`:
-  the doubling instance `#(Λ ∩ box 2) ≤ 64 · #(Λ ∩ box 1)`, the engine's factor
-  `64^{#ι}` at `#ι = 1`.
+  the doubling instance `#(Λ ∩ box 2) ≤ 64 · #(Λ ∩ box 1)`, a round bound for the engine's
+  sharp factor `49^{#ι} = 49` at `#ι = 1`.
 
 These exercise both halves of the engine — `addSubgroup_inter_box_finite_and_ncard_le_of_separated`
 and `ncard_inter_box_two_le_pow_mul_ncard_inter_box_one` — on a genuine rank-two lattice,
@@ -125,13 +125,14 @@ theorem gaussianLattice_inter_box_two_ncard_le :
   norm_num
 
 /-- **A concrete doubling instance.** Passing from the unit box to the double box multiplies
-the Gaussian-lattice point count by at most `64`, the engine's factor `64^{#ι}` at `#ι = 1`:
-`#(Λ ∩ box 2) ≤ 64 · #(Λ ∩ box 1)`. -/
+the Gaussian-lattice point count by at most `64`, a round bound for the engine's sharp factor
+`49^{#ι} = 49` at `#ι = 1`: `#(Λ ∩ box 2) ≤ 64 · #(Λ ∩ box 1)`. -/
 theorem gaussianLattice_ncard_inter_box_two_le_sixtyFour_mul_ncard_inter_box_one :
     (((gaussianLattice : Set (Fin 1 → ℂ)) ∩ box (fun _ => 1) 2).ncard : ℝ) ≤
       64 * (((gaussianLattice : Set (Fin 1 → ℂ)) ∩ box (fun _ => 1) 1).ncard : ℝ) := by
   have h := ncard_inter_box_two_le_pow_mul_ncard_inter_box_one (ι := Fin 1) (fun _ => 1)
     (fun _ => one_pos) gaussianLattice gaussianLattice_inter_box_two_finite
-  simpa [Fintype.card_fin] using h
+  rw [Fintype.card_fin, pow_one] at h
+  exact h.trans (mul_le_mul_of_nonneg_right (by norm_num) (by positivity))
 
 end TauCeti.GeometryOfNumbers


### PR DESCRIPTION
## What

- **Decomposes** the doubling box-count bound `ncard_inter_box_two_le_pow_mul_ncard_inter_box_one` into per-fibre / per-cell helpers (`card_filter_le_of_sub_mem`, `card_image_coarseCellMap_le`, `sub_mem_box_one_of_coarseCellMap_eq`).
- **Strengthens** the doubling factor from `64^{#ι}` to the natural `49^{#ι}`: the coarse-cell grid has exactly `49 = 7²` index pairs per coordinate, not `64`, so `card_image_coarseCellMap_le` is stated ℕ-natively as `≤ 49^{#ι}` and the main theorem inherits the tighter constant.
- Exposes the concrete rank-two instance at the natural factor — `gaussianLattice_ncard_inter_box_two_le_fortyNine_mul_ncard_inter_box_one` (`≤ 49 · #(Λ ∩ box 1)`) — with the rounder `…_le_sixtyFour_…` retained as a compatibility corollary.

## Scope / roadmap

This is **not solely a refactor**: the `64 → 49` change is a strictly stronger constant on the Layer-0 geometry-of-numbers engine, and the rank-two Gaussian-lattice instance is the roadmap's worked acceptance-criterion example for that engine. Both advance the **EffectiveBounds Layer 0** target — `TauCetiRoadmap/Completed/EffectiveBounds/README.md`, "Layer 0: the geometry-of-numbers engine", whose acceptance criteria include "A concrete lattice-doubling instance for a rank-2 lattice in ℝ², exercising the Layer-0 engine" — a tightening of what the layer already delivers, not new roadmap scope.

(An earlier `reuse` finding asking to remove the 49-factor theorem contradicted the `generality` finding that required adding it — contested in-thread and since resolved: `reuse` is green as of round 4.)

## Notes

Gates green locally: `lake build`, `lake exe axioms`, `lake exe module-system`, `scripts/lint-env.sh` → `LINT-ENV: PASS`.
