### PR TITLE
fix: opt in to fork PR checkout under the hardened actions/checkout

### DIFF
--- a/.github/workflows/pr-build.yml
+++ b/.github/workflows/pr-build.yml
@@ -212,6 +212,13 @@ jobs:
           ref: ${{ steps.pr.outputs.sha }}
           path: pr
           persist-credentials: false
+          # actions/checkout now refuses to fetch fork PR code under
+          # pull_request_target unless this opt-in is set. Fetching the fork's
+          # sources is exactly this workflow's job; it is safe here because the
+          # checkout carries no credentials (persist-credentials: false) and the
+          # fork's code is only ever executed under landrun below (offline, no
+          # token in reach), never in the trusted context this guard warns about.
+          allow-unsafe-pr-checkout: true
 
       # For a Lake-pin PR, validate it is a safe forward bump BEFORE overlaying its
       # pins or building. The validator and the BASE config it judges against are the


### PR DESCRIPTION
This PR sets `allow-unsafe-pr-checkout: true` on `pr-build.yml`'s untrusted PR-head checkout, restoring CI. On 2026-07-20 GitHub hardened `actions/checkout` to refuse fetching fork PR code from a `pull_request_target` workflow unless that input is set, so every PR's `build` check began failing at the checkout step with "Refusing to check out fork pull request code from a 'pull_request_target' workflow".

Fetching the fork's sources is precisely what this workflow exists to do, and the opt-in is safe here for the reasons the design already relies on: the checkout carries no credentials (`persist-credentials: false`), and the fork's code is only ever executed under landrun (offline, writes confined to `base/.lake`, no token in the passed `--env` list), never in the trusted context the new guard warns about. Only the fork-head checkout is changed; the trusted base and merge-base checkouts are untouched.

`pr-build.yml` is the only workflow on `main` that checks out fork head; the other `pull_request_target` workflows check out the trusted base or another trusted repo, or no code at all.

Because CI itself is down, this cannot pass the required `build` check it repairs, so it needs a human admin merge.

🤖 Prepared with Claude Code