### PR TITLE
refactor(Contour): reuse Complex.two_pi_I_ne_zero for the 2πI ≠ 0 fact

### DIFF
--- a/TauCeti/Analysis/Contour/Winding/Integer.lean
+++ b/TauCeti/Analysis/Contour/Winding/Integer.lean
@@ -118,9 +118,7 @@ private theorem exists_int_windingNumber_of_closed_of_le {γ : ℝ → ℂ} {w :
   refine ⟨n, ?_⟩
   have hcont_u : ContinuousOn γ (Set.uIcc a b) := by rw [Set.uIcc_of_le hab]; exact hγ_cont
   have havoid_u : ∀ t ∈ Set.uIcc a b, γ t ≠ w := by rw [Set.uIcc_of_le hab]; exact h_avoid
-  have h2πI_ne : (2 * (Real.pi : ℂ) * Complex.I) ≠ 0 :=
-    mul_ne_zero (mul_ne_zero (by norm_num) (Complex.ofReal_ne_zero.mpr Real.pi_ne_zero))
-      Complex.I_ne_zero
+  have h2πI_ne : (2 * (Real.pi : ℂ) * Complex.I) ≠ 0 := Complex.two_pi_I_ne_zero
   rw [windingNumber_eq_integral_of_avoidance hcont_u havoid_u h_int, hint', hn,
     mul_comm (n : ℂ) (2 * (Real.pi : ℂ) * Complex.I), ← mul_assoc,
     inv_mul_cancel₀ h2πI_ne, one_mul]

--- a/TauCeti/Analysis/Contour/Winding/Number/Circle.lean
+++ b/TauCeti/Analysis/Contour/Winding/Number/Circle.lean
@@ -117,9 +117,7 @@ theorem windingNumber_circleMap_eq_one_of_dist_lt {c w : ℂ} {R : ℝ} (hw : di
   have havoid : ∀ θ, circleMap c R θ ≠ w := fun θ => circleMap_ne_mem_ball (mem_ball.mpr hw) θ
   rw [windingNumber_circleMap_eq_circleIntegral havoid,
     circleIntegral.integral_sub_inv_of_mem_ball (mem_ball.mpr hw)]
-  have h2pi : (2 * (Real.pi : ℂ) * Complex.I) ≠ 0 := by
-    simp [Real.pi_ne_zero, Complex.I_ne_zero]
-  exact inv_mul_cancel₀ h2pi
+  exact inv_mul_cancel₀ Complex.two_pi_I_ne_zero
 
 /-- **`n_c(circle) = 1`** — the closed-curve normalization at the centre. The generalized winding
 number of the counterclockwise circle `circleMap c R` (`R ≠ 0`) over `[0, 2π]` about its centre `c`

--- a/TauCeti/Analysis/Contour/Winding/RealIntegral.lean
+++ b/TauCeti/Analysis/Contour/Winding/RealIntegral.lean
@@ -88,9 +88,7 @@ theorem windingNumber_eq_real_integral_of_closed {γ : ℝ → ℂ} {w : ℂ} {a
   have hwind_int : windingNumber γ a b w
       = (2 * (Real.pi : ℂ) * Complex.I)⁻¹ * ∫ t in a..b, (γ t - w)⁻¹ * deriv γ t :=
     windingNumber_eq_integral_of_avoidance hγ_cont h_avoid h_int
-  have h2πI_ne : (2 * (Real.pi : ℂ) * Complex.I) ≠ 0 :=
-    mul_ne_zero (mul_ne_zero (by norm_num) (Complex.ofReal_ne_zero.mpr Real.pi_ne_zero))
-      Complex.I_ne_zero
+  have h2πI_ne : (2 * (Real.pi : ℂ) * Complex.I) ≠ 0 := Complex.two_pi_I_ne_zero
   -- Read off the index integral: `∮_γ dz/(z − w) = 2πi · n`.
   have hCI : (∫ t in a..b, (γ t - w)⁻¹ * deriv γ t) = 2 * (Real.pi : ℂ) * Complex.I * (n : ℂ) := by
     have key : (2 * (Real.pi : ℂ) * Complex.I)⁻¹ * ∫ t in a..b, (γ t - w)⁻¹ * deriv γ t = (n : ℂ) :=


### PR DESCRIPTION
## What

Three contour proofs re-derived `(2 * (Real.pi : ℂ) * Complex.I) ≠ 0` inline:

- `Winding/Number/Circle.lean:120` — `have h2pi … := by simp [Real.pi_ne_zero, Complex.I_ne_zero]`
- `Winding/RealIntegral.lean:91` and `Winding/Integer.lean:121` — `mul_ne_zero (mul_ne_zero (by norm_num) (Complex.ofReal_ne_zero.mpr Real.pi_ne_zero)) Complex.I_ne_zero`

Mathlib already proves exactly this as **`Complex.two_pi_I_ne_zero`** (its statement is the same literal `(2 * π * I : ℂ) ≠ 0`). Replace the three reproofs with the lemma. (Note: there is no `Complex.two_pi_I` *definition* — mathlib writes the literal too — so the many *statement*-level occurrences of `2 * π * I` are already idiomatic and are left unchanged; only the hand-rolled `≠ 0` reproofs are the reuse target.)

## Notes

- Confined to the three proofs; no statement changes.
- Gates green locally: `lake build` (5188 jobs), `lake exe axioms`, `lake exe module-system`, `scripts/lint-env.sh` → `LINT-ENV: PASS`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)