### PR TITLE
feat: fail the sandboxed build when it is not silent

### DIFF
--- a/scripts/sandbox-build.sh
+++ b/scripts/sandbox-build.sh
@@ -21,7 +21,21 @@ export TMPDIR="$PWD/.lake/tmp"
 
 # Build the overlaid TauCeti/ against the trusted base config. landrun keeps this
 # offline and confines writes to base/.lake.
-lake build
+#
+# The build must be SILENT, the way Mathlib requires: a clean elaboration prints only Lake's
+# progress. Any Lean `info:` or `warning:` diagnostic in the output — a stray `#check`/`#eval`, a
+# `simp?`/`ring_nf?`-style "Try this: …" suggestion, or a linter warning — means the overlaid
+# TauCeti/ is not clean, so fail on it here. (A compile `error:` already fails `lake build` below via
+# pipefail; this catches the non-fatal diagnostics that otherwise slip through green and, worse, can
+# masquerade as the failure when some LATER check is the real one.) We capture the build output and
+# scan it: `info:`/`warning:` at line start or in the `<file>:<line>:<col>: warning:` form. Lake's
+# per-module markers (`✔`/`ℹ`/`⚠ [n/m] …`) are not diagnostics and do not match.
+build_log="$TMPDIR/lake-build.log"
+lake build 2>&1 | tee "$build_log"
+if grep -nE '(^|[[:space:]])(warning|info): ' "$build_log"; then
+  echo "::error::build is not silent — the lines above are Lean warning/info diagnostics; a clean build must emit none. Remove the stray #check/#eval, apply or delete the suggested rewrite, or fix the warning."
+  exit 1
+fi
 
 # Axiom audit: inspect the built environment and reject any axiom outside
 # {propext, Classical.choice, Quot.sound} — catching sorry, native_decide, and


### PR DESCRIPTION
This PR makes the sandboxed PR build silent: it captures the `lake build` output and fails on any Lean `info:` or `warning:` diagnostic — a stray `#check`/`#eval`, a `simp?`/`ring_nf?`-style "Try this: …" suggestion, or a linter warning — the way Mathlib requires clean builds. A compile `error:` already fails `lake build` through `pipefail`; this closes the gap for the non-fatal diagnostics that previously slipped through green. Those diagnostics were not harmless: a stray `info: … Try this: ring_nf` line near the top of a build log recently misdirected the automated CI-fixer, which spent its whole per-PR budget chasing it while the real blocker was a missing docstring flagged far below by `lint-env`. With the build silent, such a line is simply a build failure to clean up, and there is nothing left to masquerade as the cause.

Lake's per-module progress markers (`✔`/`ℹ`/`⚠ [n/m] …`) are not diagnostics and do not trip the check; only `info:`/`warning:` at line start or in the `<file>:<line>:<col>: warning:` form does. Every `.lean` file under `TauCeti/` on `main` was scanned and none contains a suggestion tactic, debug command, or trace option, so `main` already builds silently and this does not red the current queue.

One caveat for review: a PR that touches only `scripts/` is routed to human review and is not sandbox-built, so this PR's own CI does not exercise the new check — it first runs against the next PR that changes `TauCeti/`. The detection regex was verified in isolation against representative clean and dirty build logs.

🤖 Prepared with Claude Code
