### PR TITLE
feat: formalize the abstract Cauchy problem

### DIFF
--- a/TauCeti/Analysis/Semigroups/CauchyProblem.lean
+++ b/TauCeti/Analysis/Semigroups/CauchyProblem.lean
@@ -1,0 +1,158 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+module
+
+public import TauCeti.Analysis.Semigroups.Generator.OrbitDerivative
+
+/-!
+# The abstract Cauchy problem for a semigroup generator
+
+This file introduces classical and mild solutions of the autonomous abstract Cauchy problem
+`u' = A u`, `u(0) = x` on the nonnegative half-line.  Since the time domain has a boundary and
+a one-parameter semigroup has no negative-time operators, the classical formulation uses the
+right derivative at every time.  A mild solution instead asks for continuity and the integrated
+identity
+
+`A (integral u on (0, t]) = u t - x`.
+
+The orbit `t ↦ S(t)x` of a strongly continuous semigroup is a mild solution for every initial
+vector.  When the initial vector lies in the generator domain, domain invariance and the orbit
+derivative formula upgrade it to a classical solution.
+
+This advances `TauCetiRoadmap/OneParameterSemigroups/README.md`, Part A, the abstract Cauchy
+problem milestone.  The definitions and proofs follow Engel--Nagel, *One-Parameter Semigroups
+for Linear Evolution Equations*, Section II.6.
+
+## Main declarations
+
+* `IsClassicalSolution`: right-classical solutions on `[0, ∞)`.
+* `IsMildSolution`: mild solutions in integrated form.
+* `StronglyContinuousSemigroup.isClassicalSolution_orbit`: generator-domain orbits are
+  classical solutions.
+* `StronglyContinuousSemigroup.isMildSolution_orbit`: all orbits are mild solutions.
+-/
+
+public section
+
+noncomputable section
+
+open MeasureTheory
+
+namespace TauCeti.Semigroups
+
+variable {X : Type*} [NormedAddCommGroup X] [NormedSpace ℝ X]
+
+/-- A right-classical solution of `u' = A u`, `u(0) = x`, on `[0, ∞)`.  Its values belong
+to the domain of `A`, and at every nonnegative time its right derivative is `A (u t)`.
+Using a right derivative is the natural one-sided formulation for a semigroup indexed by
+nonnegative time. -/
+def IsClassicalSolution (A : X →ₗ.[ℝ] X) (x : X) (u : ℝ → X) : Prop :=
+  u 0 = x ∧ ∀ t : ℝ, 0 ≤ t → ∃ hut : u t ∈ A.domain,
+    HasDerivWithinAt u (A ⟨u t, hut⟩) (Set.Ici t) t
+
+/-- Characterization of a classical solution by its initial value, domain membership, and
+right-derivative equation. -/
+theorem isClassicalSolution_iff {A : X →ₗ.[ℝ] X} {x : X} {u : ℝ → X} :
+    IsClassicalSolution A x u ↔
+      u 0 = x ∧ ∀ t : ℝ, 0 ≤ t → ∃ hut : u t ∈ A.domain,
+        HasDerivWithinAt u (A ⟨u t, hut⟩) (Set.Ici t) t :=
+  Iff.rfl
+
+/-- A classical solution takes its prescribed initial value at time zero. -/
+theorem IsClassicalSolution.apply_zero {A : X →ₗ.[ℝ] X} {x : X} {u : ℝ → X}
+    (hu : IsClassicalSolution A x u) : u 0 = x :=
+  hu.1
+
+/-- Every value of a classical solution at nonnegative time belongs to the operator domain. -/
+theorem IsClassicalSolution.mem_domain {A : X →ₗ.[ℝ] X} {x : X} {u : ℝ → X}
+    (hu : IsClassicalSolution A x u) {t : ℝ} (ht : 0 ≤ t) : u t ∈ A.domain :=
+  (hu.2 t ht).choose
+
+/-- The right derivative of a classical solution is the operator applied to its value. -/
+theorem IsClassicalSolution.hasDerivWithinAt {A : X →ₗ.[ℝ] X} {x : X} {u : ℝ → X}
+    (hu : IsClassicalSolution A x u) {t : ℝ} (ht : 0 ≤ t) :
+    HasDerivWithinAt u (A ⟨u t, hu.mem_domain ht⟩) (Set.Ici t) t := by
+  obtain ⟨hut, hderiv⟩ := hu.2 t ht
+  simpa only [Submodule.coe_mk] using hderiv
+
+/-- A mild solution of `u' = A u`, `u(0) = x`, on `[0, ∞)`.  The integral is pointwise
+Bochner integration in `X`.  Requiring the integral to lie in the domain makes the expression
+`A (∫ s in (0, t], u s)` meaningful for an unbounded operator. -/
+def IsMildSolution (A : X →ₗ.[ℝ] X) (x : X) (u : ℝ → X) : Prop :=
+  ContinuousOn u (Set.Ici 0) ∧ u 0 = x ∧
+    ∀ t : ℝ, 0 ≤ t → ∃ hut : (∫ s in Set.Ioc 0 t, u s) ∈ A.domain,
+      A ⟨∫ s in Set.Ioc 0 t, u s, hut⟩ = u t - x
+
+/-- Characterization of a mild solution by continuity, its initial value, and the integrated
+Cauchy equation. -/
+theorem isMildSolution_iff {A : X →ₗ.[ℝ] X} {x : X} {u : ℝ → X} :
+    IsMildSolution A x u ↔
+      ContinuousOn u (Set.Ici 0) ∧ u 0 = x ∧
+        ∀ t : ℝ, 0 ≤ t → ∃ hut : (∫ s in Set.Ioc 0 t, u s) ∈ A.domain,
+          A ⟨∫ s in Set.Ioc 0 t, u s, hut⟩ = u t - x :=
+  Iff.rfl
+
+/-- A mild solution is continuous on the nonnegative half-line. -/
+theorem IsMildSolution.continuousOn {A : X →ₗ.[ℝ] X} {x : X} {u : ℝ → X}
+    (hu : IsMildSolution A x u) : ContinuousOn u (Set.Ici 0) :=
+  hu.1
+
+/-- A mild solution takes its prescribed initial value at time zero. -/
+theorem IsMildSolution.apply_zero {A : X →ₗ.[ℝ] X} {x : X} {u : ℝ → X}
+    (hu : IsMildSolution A x u) : u 0 = x :=
+  hu.2.1
+
+/-- The time integral of a mild solution belongs to the operator domain. -/
+theorem IsMildSolution.integral_mem_domain {A : X →ₗ.[ℝ] X} {x : X} {u : ℝ → X}
+    (hu : IsMildSolution A x u) {t : ℝ} (ht : 0 ≤ t) :
+    (∫ s in Set.Ioc 0 t, u s) ∈ A.domain :=
+  (hu.2.2 t ht).choose
+
+/-- The integrated Cauchy equation satisfied by a mild solution. -/
+theorem IsMildSolution.map_integral {A : X →ₗ.[ℝ] X} {x : X} {u : ℝ → X}
+    (hu : IsMildSolution A x u) {t : ℝ} (ht : 0 ≤ t) :
+    A ⟨∫ s in Set.Ioc 0 t, u s, hu.integral_mem_domain ht⟩ = u t - x := by
+  obtain ⟨hut, hmap⟩ := hu.2.2 t ht
+  simpa only [Submodule.coe_mk] using hmap
+
+namespace StronglyContinuousSemigroup
+
+variable [CompleteSpace X]
+
+omit [CompleteSpace X] in
+/-- The orbit of a generator-domain vector is a classical solution of the abstract Cauchy
+problem for the generator. -/
+theorem isClassicalSolution_orbit (S : StronglyContinuousSemigroup X) (x : S.domain) :
+    IsClassicalSolution S.generator (x : X) (fun t => S.realOperator t x) := by
+  refine ⟨S.realOperator_zero_apply x, fun t ht => ?_⟩
+  let hut : S.realOperator t (x : X) ∈ S.generator.domain := by
+    rw [S.generator_domain]
+    exact S.realOperator_mem_domain ht x.property
+  refine ⟨hut, ?_⟩
+  simpa only [Submodule.coe_mk] using S.realOperator_hasDerivWithinAt ht
+    (S.realOperator_mem_domain ht x.property)
+
+/-- Every orbit is a mild solution of the abstract Cauchy problem for the generator. -/
+theorem isMildSolution_orbit (S : StronglyContinuousSemigroup X) (x : X) :
+    IsMildSolution S.generator x (fun t => S.realOperator t x) := by
+  refine ⟨S.realOperator_continuousOn_Ici x, S.realOperator_zero_apply x, fun t ht => ?_⟩
+  rcases ht.eq_or_lt with rfl | ht
+  · refine ⟨?_, ?_⟩
+    · simp
+    · have harg : (⟨∫ s in Set.Ioc 0 0, S.realOperator s x, by simp⟩ :
+          S.generator.domain) = 0 := by
+        ext
+        simp
+      rw [harg, LinearPMap.map_zero]
+      simp
+  · let hut : (∫ s in Set.Ioc 0 t, S.realOperator s x) ∈ S.generator.domain := by
+      rw [S.generator_domain]
+      exact S.integral_orbit_mem_domain x ht
+    refine ⟨hut, ?_⟩
+    simpa only [Submodule.coe_mk] using S.generator_integral_orbit x ht
+
+end StronglyContinuousSemigroup
+
+end TauCeti.Semigroups

--- a/TauCeti/Analysis/Semigroups/CauchyProblem.lean
+++ b/TauCeti/Analysis/Semigroups/CauchyProblem.lean
@@ -45,35 +45,39 @@ namespace TauCeti.Semigroups
 variable {X : Type*} [NormedAddCommGroup X] [NormedSpace ℝ X]
 
 /-- A classical solution of `u' = A u`, `u(0) = x`, on `[0, ∞)`. Its values belong to the
-domain of `A`, and its derivative within `[0, ∞)` is `A (u t)` at every nonnegative time. -/
+domain of `A`, and it has a continuous derivative within `[0, ∞)` equal to `A (u t)`. -/
 def IsClassicalSolution (A : X →ₗ.[ℝ] X) (x : X) (u : ℝ → X) : Prop :=
-  u 0 = x ∧ ∀ t : ℝ, 0 ≤ t → ∃ hut : u t ∈ A.domain,
-    HasDerivWithinAt u (A ⟨u t, hut⟩) (Set.Ici 0) t
+  u 0 = x ∧ ∃ u' : ℝ → X, ContinuousOn u' (Set.Ici 0) ∧
+    ∀ t : ℝ, 0 ≤ t → ∃ hut : u t ∈ A.domain,
+      HasDerivWithinAt u (u' t) (Set.Ici 0) t ∧ u' t = A ⟨u t, hut⟩
 
 /-- A classical solution takes its prescribed initial value at time zero. -/
 theorem IsClassicalSolution.apply_zero {A : X →ₗ.[ℝ] X} {x : X} {u : ℝ → X}
     (hu : IsClassicalSolution A x u) : u 0 = x :=
   hu.1
 
-/-- Characterization of a classical solution by its initial value and differential equation. -/
+/-- Characterization of a classical solution by its initial value and continuously
+differentiable equation. -/
 theorem isClassicalSolution_iff {A : X →ₗ.[ℝ] X} {x : X} {u : ℝ → X} :
     IsClassicalSolution A x u ↔
-      u 0 = x ∧ ∀ t : ℝ, 0 ≤ t → ∃ hut : u t ∈ A.domain,
-        HasDerivWithinAt u (A ⟨u t, hut⟩) (Set.Ici 0) t :=
+      u 0 = x ∧ ∃ u' : ℝ → X, ContinuousOn u' (Set.Ici 0) ∧
+        ∀ t : ℝ, 0 ≤ t → ∃ hut : u t ∈ A.domain,
+          HasDerivWithinAt u (u' t) (Set.Ici 0) t ∧ u' t = A ⟨u t, hut⟩ :=
   Iff.rfl
 
 /-- Every value of a classical solution at nonnegative time belongs to the operator domain. -/
 theorem IsClassicalSolution.mem_domain {A : X →ₗ.[ℝ] X} {x : X} {u : ℝ → X}
     (hu : IsClassicalSolution A x u) {t : ℝ} (ht : 0 ≤ t) : u t ∈ A.domain :=
-  (hu.2 t ht).choose
+  (hu.2.choose_spec.2 t ht).choose
 
 /-- The derivative within the nonnegative half-line of a classical solution is the operator
 applied to its value. -/
 theorem IsClassicalSolution.hasDerivWithinAt {A : X →ₗ.[ℝ] X} {x : X} {u : ℝ → X}
     (hu : IsClassicalSolution A x u) {t : ℝ} (ht : 0 ≤ t) :
     HasDerivWithinAt u (A ⟨u t, hu.mem_domain ht⟩) (Set.Ici 0) t := by
-  obtain ⟨hut, hderiv⟩ := hu.2 t ht
-  simpa only [Submodule.coe_mk] using hderiv
+  obtain ⟨hut, hderiv, heq⟩ := hu.2.choose_spec.2 t ht
+  rw [← heq]
+  simpa only using hderiv
 
 /-- A classical solution is continuous on the nonnegative half-line. -/
 theorem IsClassicalSolution.continuousOn {A : X →ₗ.[ℝ] X} {x : X} {u : ℝ → X}
@@ -130,12 +134,18 @@ problem for the generator. -/
 theorem isClassicalSolution_realOperator (S : StronglyContinuousSemigroup X) (x : S.domain) :
     IsClassicalSolution S.generator (x : X) (fun t => S.realOperator t x) := by
   rw [isClassicalSolution_iff]
-  refine ⟨S.realOperator_zero_apply x, fun t ht => ?_⟩
+  let z : X := S.generator ⟨x, by rw [S.generator_domain]; exact x.property⟩
+  refine ⟨S.realOperator_zero_apply x, fun t => S.realOperator t z,
+    S.realOperator_continuousOn_Ici z, fun t ht => ?_⟩
   let hut : S.realOperator t (x : X) ∈ S.generator.domain := by
     rw [S.generator_domain]
     exact S.realOperator_mem_domain ht x.property
   refine ⟨hut, ?_⟩
-  simpa only [Submodule.coe_mk] using S.realOperator_hasDerivWithinAt_Ici x ht
+  refine ⟨?_, ?_⟩
+  · dsimp only [z]
+    rw [← S.realOperator_generator_map ht x]
+    simpa only [Submodule.coe_mk] using S.realOperator_hasDerivWithinAt_Ici x ht
+  · simpa only [z, hut] using (S.realOperator_generator_map ht x).symm
 
 /-- Every orbit is a mild solution of the abstract Cauchy problem for the generator. -/
 theorem isMildSolution_realOperator (S : StronglyContinuousSemigroup X) (x : X) :

--- a/TauCeti/Analysis/Semigroups/CauchyProblem.lean
+++ b/TauCeti/Analysis/Semigroups/CauchyProblem.lean
@@ -79,14 +79,14 @@ theorem IsClassicalSolution.hasDerivWithinAt {A : X →ₗ.[ℝ] X} {x : X} {u :
 /-- A mild solution of `u' = A u`, `u(0) = x`, on `[0, ∞)`.  The integral is pointwise
 Bochner integration in `X`.  Requiring the integral to lie in the domain makes the expression
 `A (∫ s in (0, t], u s)` meaningful for an unbounded operator. -/
-def IsMildSolution (A : X →ₗ.[ℝ] X) (x : X) (u : ℝ → X) : Prop :=
+def IsMildSolution [CompleteSpace X] (A : X →ₗ.[ℝ] X) (x : X) (u : ℝ → X) : Prop :=
   ContinuousOn u (Set.Ici 0) ∧ u 0 = x ∧
     ∀ t : ℝ, 0 ≤ t → ∃ hut : (∫ s in Set.Ioc 0 t, u s) ∈ A.domain,
       A ⟨∫ s in Set.Ioc 0 t, u s, hut⟩ = u t - x
 
 /-- Characterization of a mild solution by continuity, its initial value, and the integrated
 Cauchy equation. -/
-theorem isMildSolution_iff {A : X →ₗ.[ℝ] X} {x : X} {u : ℝ → X} :
+theorem isMildSolution_iff [CompleteSpace X] {A : X →ₗ.[ℝ] X} {x : X} {u : ℝ → X} :
     IsMildSolution A x u ↔
       ContinuousOn u (Set.Ici 0) ∧ u 0 = x ∧
         ∀ t : ℝ, 0 ≤ t → ∃ hut : (∫ s in Set.Ioc 0 t, u s) ∈ A.domain,
@@ -94,23 +94,24 @@ theorem isMildSolution_iff {A : X →ₗ.[ℝ] X} {x : X} {u : ℝ → X} :
   Iff.rfl
 
 /-- A mild solution is continuous on the nonnegative half-line. -/
-theorem IsMildSolution.continuousOn {A : X →ₗ.[ℝ] X} {x : X} {u : ℝ → X}
+theorem IsMildSolution.continuousOn [CompleteSpace X] {A : X →ₗ.[ℝ] X} {x : X} {u : ℝ → X}
     (hu : IsMildSolution A x u) : ContinuousOn u (Set.Ici 0) :=
   hu.1
 
 /-- A mild solution takes its prescribed initial value at time zero. -/
-theorem IsMildSolution.apply_zero {A : X →ₗ.[ℝ] X} {x : X} {u : ℝ → X}
+theorem IsMildSolution.apply_zero [CompleteSpace X] {A : X →ₗ.[ℝ] X} {x : X} {u : ℝ → X}
     (hu : IsMildSolution A x u) : u 0 = x :=
   hu.2.1
 
 /-- The time integral of a mild solution belongs to the operator domain. -/
-theorem IsMildSolution.integral_mem_domain {A : X →ₗ.[ℝ] X} {x : X} {u : ℝ → X}
+theorem IsMildSolution.integral_mem_domain [CompleteSpace X]
+    {A : X →ₗ.[ℝ] X} {x : X} {u : ℝ → X}
     (hu : IsMildSolution A x u) {t : ℝ} (ht : 0 ≤ t) :
     (∫ s in Set.Ioc 0 t, u s) ∈ A.domain :=
   (hu.2.2 t ht).choose
 
 /-- The integrated Cauchy equation satisfied by a mild solution. -/
-theorem IsMildSolution.map_integral {A : X →ₗ.[ℝ] X} {x : X} {u : ℝ → X}
+theorem IsMildSolution.map_integral [CompleteSpace X] {A : X →ₗ.[ℝ] X} {x : X} {u : ℝ → X}
     (hu : IsMildSolution A x u) {t : ℝ} (ht : 0 ≤ t) :
     A ⟨∫ s in Set.Ioc 0 t, u s, hu.integral_mem_domain ht⟩ = u t - x := by
   obtain ⟨hut, hmap⟩ := hu.2.2 t ht

--- a/TauCeti/Analysis/Semigroups/CauchyProblem.lean
+++ b/TauCeti/Analysis/Semigroups/CauchyProblem.lean
@@ -29,9 +29,9 @@ for Linear Evolution Equations*, Section II.6.
 
 * `IsClassicalSolution`: classical solutions on `[0, ∞)`.
 * `IsMildSolution`: mild solutions in integrated form.
-* `StronglyContinuousSemigroup.isClassicalSolution_orbit`: generator-domain orbits are
+* `StronglyContinuousSemigroup.isClassicalSolution_realOperator`: generator-domain orbits are
   classical solutions.
-* `StronglyContinuousSemigroup.isMildSolution_orbit`: all orbits are mild solutions.
+* `StronglyContinuousSemigroup.isMildSolution_realOperator`: all orbits are mild solutions.
 -/
 
 public section
@@ -54,6 +54,13 @@ def IsClassicalSolution (A : X →ₗ.[ℝ] X) (x : X) (u : ℝ → X) : Prop :=
 theorem IsClassicalSolution.apply_zero {A : X →ₗ.[ℝ] X} {x : X} {u : ℝ → X}
     (hu : IsClassicalSolution A x u) : u 0 = x :=
   hu.1
+
+/-- Characterization of a classical solution by its initial value and differential equation. -/
+theorem isClassicalSolution_iff {A : X →ₗ.[ℝ] X} {x : X} {u : ℝ → X} :
+    IsClassicalSolution A x u ↔
+      u 0 = x ∧ ∀ t : ℝ, 0 ≤ t → ∃ hut : u t ∈ A.domain,
+        HasDerivWithinAt u (A ⟨u t, hut⟩) (Set.Ici 0) t :=
+  Iff.rfl
 
 /-- Every value of a classical solution at nonnegative time belongs to the operator domain. -/
 theorem IsClassicalSolution.mem_domain {A : X →ₗ.[ℝ] X} {x : X} {u : ℝ → X}
@@ -92,6 +99,13 @@ theorem IsMildSolution.apply_zero [CompleteSpace X] {A : X →ₗ.[ℝ] X} {x : 
     (hu : IsMildSolution A x u) : u 0 = x :=
   hu.2.1
 
+/-- Characterization of a mild solution by continuity and its integrated Cauchy equation. -/
+theorem isMildSolution_iff [CompleteSpace X] {A : X →ₗ.[ℝ] X} {x : X} {u : ℝ → X} :
+    IsMildSolution A x u ↔ ContinuousOn u (Set.Ici 0) ∧ u 0 = x ∧
+      ∀ t : ℝ, 0 ≤ t → ∃ hut : (∫ s in Set.Ioc 0 t, u s) ∈ A.domain,
+        A ⟨∫ s in Set.Ioc 0 t, u s, hut⟩ = u t - x :=
+  Iff.rfl
+
 /-- The time integral of a mild solution belongs to the operator domain. -/
 theorem IsMildSolution.integral_mem_domain [CompleteSpace X]
     {A : X →ₗ.[ℝ] X} {x : X} {u : ℝ → X}
@@ -100,7 +114,8 @@ theorem IsMildSolution.integral_mem_domain [CompleteSpace X]
   (hu.2.2 t ht).choose
 
 /-- The integrated Cauchy equation satisfied by a mild solution. -/
-theorem IsMildSolution.map_integral [CompleteSpace X] {A : X →ₗ.[ℝ] X} {x : X} {u : ℝ → X}
+theorem IsMildSolution.map_integral_eq_sub [CompleteSpace X]
+    {A : X →ₗ.[ℝ] X} {x : X} {u : ℝ → X}
     (hu : IsMildSolution A x u) {t : ℝ} (ht : 0 ≤ t) :
     A ⟨∫ s in Set.Ioc 0 t, u s, hu.integral_mem_domain ht⟩ = u t - x := by
   obtain ⟨hut, hmap⟩ := hu.2.2 t ht
@@ -112,8 +127,9 @@ variable [CompleteSpace X]
 
 /-- The orbit of a generator-domain vector is a classical solution of the abstract Cauchy
 problem for the generator. -/
-theorem isClassicalSolution_orbit (S : StronglyContinuousSemigroup X) (x : S.domain) :
+theorem isClassicalSolution_realOperator (S : StronglyContinuousSemigroup X) (x : S.domain) :
     IsClassicalSolution S.generator (x : X) (fun t => S.realOperator t x) := by
+  rw [isClassicalSolution_iff]
   refine ⟨S.realOperator_zero_apply x, fun t ht => ?_⟩
   let hut : S.realOperator t (x : X) ∈ S.generator.domain := by
     rw [S.generator_domain]
@@ -122,8 +138,9 @@ theorem isClassicalSolution_orbit (S : StronglyContinuousSemigroup X) (x : S.dom
   simpa only [Submodule.coe_mk] using S.realOperator_hasDerivWithinAt_Ici x ht
 
 /-- Every orbit is a mild solution of the abstract Cauchy problem for the generator. -/
-theorem isMildSolution_orbit (S : StronglyContinuousSemigroup X) (x : X) :
+theorem isMildSolution_realOperator (S : StronglyContinuousSemigroup X) (x : X) :
     IsMildSolution S.generator x (fun t => S.realOperator t x) := by
+  rw [isMildSolution_iff]
   refine ⟨S.realOperator_continuousOn_Ici x, S.realOperator_zero_apply x, fun t ht => ?_⟩
   rcases ht.eq_or_lt with rfl | ht
   · refine ⟨?_, ?_⟩

--- a/TauCeti/Analysis/Semigroups/CauchyProblem.lean
+++ b/TauCeti/Analysis/Semigroups/CauchyProblem.lean
@@ -50,13 +50,6 @@ def IsClassicalSolution (A : X →ₗ.[ℝ] X) (x : X) (u : ℝ → X) : Prop :=
   u 0 = x ∧ ∀ t : ℝ, 0 ≤ t → ∃ hut : u t ∈ A.domain,
     HasDerivWithinAt u (A ⟨u t, hut⟩) (Set.Ici 0) t
 
-/-- Construct a classical solution from its initial value and differential equation. -/
-theorem IsClassicalSolution.mk {A : X →ₗ.[ℝ] X} {x : X} {u : ℝ → X}
-    (hzero : u 0 = x) (hderiv : ∀ t : ℝ, 0 ≤ t → ∃ hut : u t ∈ A.domain,
-      HasDerivWithinAt u (A ⟨u t, hut⟩) (Set.Ici 0) t) :
-    IsClassicalSolution A x u :=
-  ⟨hzero, hderiv⟩
-
 /-- A classical solution takes its prescribed initial value at time zero. -/
 theorem IsClassicalSolution.apply_zero {A : X →ₗ.[ℝ] X} {x : X} {u : ℝ → X}
     (hu : IsClassicalSolution A x u) : u 0 = x :=
@@ -88,13 +81,6 @@ def IsMildSolution [CompleteSpace X] (A : X →ₗ.[ℝ] X) (x : X) (u : ℝ →
   ContinuousOn u (Set.Ici 0) ∧ u 0 = x ∧
     ∀ t : ℝ, 0 ≤ t → ∃ hut : (∫ s in Set.Ioc 0 t, u s) ∈ A.domain,
       A ⟨∫ s in Set.Ioc 0 t, u s, hut⟩ = u t - x
-
-/-- Construct a mild solution from continuity, its initial value, and the integrated equation. -/
-theorem IsMildSolution.mk [CompleteSpace X] {A : X →ₗ.[ℝ] X} {x : X} {u : ℝ → X}
-    (hcont : ContinuousOn u (Set.Ici 0)) (hzero : u 0 = x)
-    (hmap : ∀ t : ℝ, 0 ≤ t → ∃ hut : (∫ s in Set.Ioc 0 t, u s) ∈ A.domain,
-      A ⟨∫ s in Set.Ioc 0 t, u s, hut⟩ = u t - x) : IsMildSolution A x u :=
-  ⟨hcont, hzero, hmap⟩
 
 /-- A mild solution is continuous on the nonnegative half-line. -/
 theorem IsMildSolution.continuousOn [CompleteSpace X] {A : X →ₗ.[ℝ] X} {x : X} {u : ℝ → X}

--- a/TauCeti/Analysis/Semigroups/CauchyProblem.lean
+++ b/TauCeti/Analysis/Semigroups/CauchyProblem.lean
@@ -10,9 +10,9 @@ public import TauCeti.Analysis.Semigroups.Generator.OrbitDerivative
 # The abstract Cauchy problem for a semigroup generator
 
 This file introduces classical and mild solutions of the autonomous abstract Cauchy problem
-`u' = A u`, `u(0) = x` on the nonnegative half-line.  Since the time domain has a boundary and
-a one-parameter semigroup has no negative-time operators, the classical formulation uses the
-right derivative at every time.  A mild solution instead asks for continuity and the integrated
+`u' = A u`, `u(0) = x` on the nonnegative half-line.  The classical formulation uses the
+derivative within the whole nonnegative half-line, which is two-sided at positive times and
+right-sided at zero.  A mild solution instead asks for continuity and the integrated
 identity
 
 `A (integral u on (0, t]) = u t - x`.
@@ -27,7 +27,7 @@ for Linear Evolution Equations*, Section II.6.
 
 ## Main declarations
 
-* `IsClassicalSolution`: right-classical solutions on `[0, ∞)`.
+* `IsClassicalSolution`: classical solutions on `[0, ∞)`.
 * `IsMildSolution`: mild solutions in integrated form.
 * `StronglyContinuousSemigroup.isClassicalSolution_orbit`: generator-domain orbits are
   classical solutions.
@@ -44,20 +44,18 @@ namespace TauCeti.Semigroups
 
 variable {X : Type*} [NormedAddCommGroup X] [NormedSpace ℝ X]
 
-/-- A right-classical solution of `u' = A u`, `u(0) = x`, on `[0, ∞)`.  Its values belong
-to the domain of `A`, and at every nonnegative time its right derivative is `A (u t)`.
-Using a right derivative is the natural one-sided formulation for a semigroup indexed by
-nonnegative time. -/
+/-- A classical solution of `u' = A u`, `u(0) = x`, on `[0, ∞)`. Its values belong to the
+domain of `A`, and its derivative within `[0, ∞)` is `A (u t)` at every nonnegative time. -/
 def IsClassicalSolution (A : X →ₗ.[ℝ] X) (x : X) (u : ℝ → X) : Prop :=
   u 0 = x ∧ ∀ t : ℝ, 0 ≤ t → ∃ hut : u t ∈ A.domain,
-    HasDerivWithinAt u (A ⟨u t, hut⟩) (Set.Ici t) t
+    HasDerivWithinAt u (A ⟨u t, hut⟩) (Set.Ici 0) t
 
 /-- Characterization of a classical solution by its initial value, domain membership, and
-right-derivative equation. -/
+derivative equation on the nonnegative half-line. -/
 theorem isClassicalSolution_iff {A : X →ₗ.[ℝ] X} {x : X} {u : ℝ → X} :
     IsClassicalSolution A x u ↔
       u 0 = x ∧ ∀ t : ℝ, 0 ≤ t → ∃ hut : u t ∈ A.domain,
-        HasDerivWithinAt u (A ⟨u t, hut⟩) (Set.Ici t) t :=
+        HasDerivWithinAt u (A ⟨u t, hut⟩) (Set.Ici 0) t :=
   Iff.rfl
 
 /-- A classical solution takes its prescribed initial value at time zero. -/
@@ -70,10 +68,11 @@ theorem IsClassicalSolution.mem_domain {A : X →ₗ.[ℝ] X} {x : X} {u : ℝ �
     (hu : IsClassicalSolution A x u) {t : ℝ} (ht : 0 ≤ t) : u t ∈ A.domain :=
   (hu.2 t ht).choose
 
-/-- The right derivative of a classical solution is the operator applied to its value. -/
+/-- The derivative within the nonnegative half-line of a classical solution is the operator
+applied to its value. -/
 theorem IsClassicalSolution.hasDerivWithinAt {A : X →ₗ.[ℝ] X} {x : X} {u : ℝ → X}
     (hu : IsClassicalSolution A x u) {t : ℝ} (ht : 0 ≤ t) :
-    HasDerivWithinAt u (A ⟨u t, hu.mem_domain ht⟩) (Set.Ici t) t := by
+    HasDerivWithinAt u (A ⟨u t, hu.mem_domain ht⟩) (Set.Ici 0) t := by
   obtain ⟨hut, hderiv⟩ := hu.2 t ht
   simpa only [Submodule.coe_mk] using hderiv
 
@@ -121,7 +120,6 @@ namespace StronglyContinuousSemigroup
 
 variable [CompleteSpace X]
 
-omit [CompleteSpace X] in
 /-- The orbit of a generator-domain vector is a classical solution of the abstract Cauchy
 problem for the generator. -/
 theorem isClassicalSolution_orbit (S : StronglyContinuousSemigroup X) (x : S.domain) :
@@ -131,8 +129,7 @@ theorem isClassicalSolution_orbit (S : StronglyContinuousSemigroup X) (x : S.dom
     rw [S.generator_domain]
     exact S.realOperator_mem_domain ht x.property
   refine ⟨hut, ?_⟩
-  simpa only [Submodule.coe_mk] using S.realOperator_hasDerivWithinAt ht
-    (S.realOperator_mem_domain ht x.property)
+  simpa only [Submodule.coe_mk] using S.realOperator_hasDerivWithinAt_Ici x ht
 
 /-- Every orbit is a mild solution of the abstract Cauchy problem for the generator. -/
 theorem isMildSolution_orbit (S : StronglyContinuousSemigroup X) (x : X) :

--- a/TauCeti/Analysis/Semigroups/CauchyProblem.lean
+++ b/TauCeti/Analysis/Semigroups/CauchyProblem.lean
@@ -50,14 +50,6 @@ def IsClassicalSolution (A : X →ₗ.[ℝ] X) (x : X) (u : ℝ → X) : Prop :=
   u 0 = x ∧ ∀ t : ℝ, 0 ≤ t → ∃ hut : u t ∈ A.domain,
     HasDerivWithinAt u (A ⟨u t, hut⟩) (Set.Ici 0) t
 
-/-- Characterization of a classical solution by its initial value, domain membership, and
-derivative equation on the nonnegative half-line. -/
-theorem isClassicalSolution_iff {A : X →ₗ.[ℝ] X} {x : X} {u : ℝ → X} :
-    IsClassicalSolution A x u ↔
-      u 0 = x ∧ ∀ t : ℝ, 0 ≤ t → ∃ hut : u t ∈ A.domain,
-        HasDerivWithinAt u (A ⟨u t, hut⟩) (Set.Ici 0) t :=
-  Iff.rfl
-
 /-- A classical solution takes its prescribed initial value at time zero. -/
 theorem IsClassicalSolution.apply_zero {A : X →ₗ.[ℝ] X} {x : X} {u : ℝ → X}
     (hu : IsClassicalSolution A x u) : u 0 = x :=
@@ -76,6 +68,12 @@ theorem IsClassicalSolution.hasDerivWithinAt {A : X →ₗ.[ℝ] X} {x : X} {u :
   obtain ⟨hut, hderiv⟩ := hu.2 t ht
   simpa only [Submodule.coe_mk] using hderiv
 
+/-- A classical solution is continuous on the nonnegative half-line. -/
+theorem IsClassicalSolution.continuousOn {A : X →ₗ.[ℝ] X} {x : X} {u : ℝ → X}
+    (hu : IsClassicalSolution A x u) : ContinuousOn u (Set.Ici 0) := by
+  intro t ht
+  exact (hu.hasDerivWithinAt ht).continuousWithinAt
+
 /-- A mild solution of `u' = A u`, `u(0) = x`, on `[0, ∞)`.  The integral is pointwise
 Bochner integration in `X`.  Requiring the integral to lie in the domain makes the expression
 `A (∫ s in (0, t], u s)` meaningful for an unbounded operator. -/
@@ -83,15 +81,6 @@ def IsMildSolution [CompleteSpace X] (A : X →ₗ.[ℝ] X) (x : X) (u : ℝ →
   ContinuousOn u (Set.Ici 0) ∧ u 0 = x ∧
     ∀ t : ℝ, 0 ≤ t → ∃ hut : (∫ s in Set.Ioc 0 t, u s) ∈ A.domain,
       A ⟨∫ s in Set.Ioc 0 t, u s, hut⟩ = u t - x
-
-/-- Characterization of a mild solution by continuity, its initial value, and the integrated
-Cauchy equation. -/
-theorem isMildSolution_iff [CompleteSpace X] {A : X →ₗ.[ℝ] X} {x : X} {u : ℝ → X} :
-    IsMildSolution A x u ↔
-      ContinuousOn u (Set.Ici 0) ∧ u 0 = x ∧
-        ∀ t : ℝ, 0 ≤ t → ∃ hut : (∫ s in Set.Ioc 0 t, u s) ∈ A.domain,
-          A ⟨∫ s in Set.Ioc 0 t, u s, hut⟩ = u t - x :=
-  Iff.rfl
 
 /-- A mild solution is continuous on the nonnegative half-line. -/
 theorem IsMildSolution.continuousOn [CompleteSpace X] {A : X →ₗ.[ℝ] X} {x : X} {u : ℝ → X}

--- a/TauCeti/Analysis/Semigroups/CauchyProblem.lean
+++ b/TauCeti/Analysis/Semigroups/CauchyProblem.lean
@@ -50,6 +50,13 @@ def IsClassicalSolution (A : X →ₗ.[ℝ] X) (x : X) (u : ℝ → X) : Prop :=
   u 0 = x ∧ ∀ t : ℝ, 0 ≤ t → ∃ hut : u t ∈ A.domain,
     HasDerivWithinAt u (A ⟨u t, hut⟩) (Set.Ici 0) t
 
+/-- Construct a classical solution from its initial value and differential equation. -/
+theorem IsClassicalSolution.mk {A : X →ₗ.[ℝ] X} {x : X} {u : ℝ → X}
+    (hzero : u 0 = x) (hderiv : ∀ t : ℝ, 0 ≤ t → ∃ hut : u t ∈ A.domain,
+      HasDerivWithinAt u (A ⟨u t, hut⟩) (Set.Ici 0) t) :
+    IsClassicalSolution A x u :=
+  ⟨hzero, hderiv⟩
+
 /-- A classical solution takes its prescribed initial value at time zero. -/
 theorem IsClassicalSolution.apply_zero {A : X →ₗ.[ℝ] X} {x : X} {u : ℝ → X}
     (hu : IsClassicalSolution A x u) : u 0 = x :=
@@ -81,6 +88,13 @@ def IsMildSolution [CompleteSpace X] (A : X →ₗ.[ℝ] X) (x : X) (u : ℝ →
   ContinuousOn u (Set.Ici 0) ∧ u 0 = x ∧
     ∀ t : ℝ, 0 ≤ t → ∃ hut : (∫ s in Set.Ioc 0 t, u s) ∈ A.domain,
       A ⟨∫ s in Set.Ioc 0 t, u s, hut⟩ = u t - x
+
+/-- Construct a mild solution from continuity, its initial value, and the integrated equation. -/
+theorem IsMildSolution.mk [CompleteSpace X] {A : X →ₗ.[ℝ] X} {x : X} {u : ℝ → X}
+    (hcont : ContinuousOn u (Set.Ici 0)) (hzero : u 0 = x)
+    (hmap : ∀ t : ℝ, 0 ≤ t → ∃ hut : (∫ s in Set.Ioc 0 t, u s) ∈ A.domain,
+      A ⟨∫ s in Set.Ioc 0 t, u s, hut⟩ = u t - x) : IsMildSolution A x u :=
+  ⟨hcont, hzero, hmap⟩
 
 /-- A mild solution is continuous on the nonnegative half-line. -/
 theorem IsMildSolution.continuousOn [CompleteSpace X] {A : X →ₗ.[ℝ] X} {x : X} {u : ℝ → X}

--- a/TauCeti/Analysis/Semigroups/Generator/OrbitDerivative.lean
+++ b/TauCeti/Analysis/Semigroups/Generator/OrbitDerivative.lean
@@ -6,6 +6,8 @@ module
 
 public import TauCeti.Analysis.Semigroups.Generator.Invariance
 import Mathlib.Analysis.Calculus.Deriv.Slope
+import Mathlib.Analysis.Calculus.MeanValue
+import Mathlib.MeasureTheory.Integral.DominatedConvergence
 
 /-!
 # Differentiability of semigroup orbits
@@ -135,6 +137,111 @@ theorem realOperator_hasDerivWithinAt_map_generator
         exact x.property⟩)) (Set.Ici t) t := by
   rw [← S.realOperator_generator_map ht x]
   exact S.realOperator_hasDerivWithinAt ht (S.realOperator_mem_domain ht x.property)
+
+/-- On the nonnegative half-line, the orbit of a generator-domain vector has derivative equal
+to the generator evaluated on the evolved vector. At positive times this is a two-sided
+derivative; only the derivative at zero is one-sided. -/
+theorem realOperator_hasDerivWithinAt_Ici (S : StronglyContinuousSemigroup X)
+    [CompleteSpace X] (x : S.domain) {t : ℝ} (ht : 0 ≤ t) :
+    HasDerivWithinAt (fun s : ℝ => S.realOperator s (x : X))
+      (S.generator ⟨S.realOperator t x, by
+        rw [S.generator_domain]
+        exact S.realOperator_mem_domain ht x.property⟩) (Set.Ici 0) t := by
+  let z : X := S.generator ⟨x, by rw [S.generator_domain]; exact x.property⟩
+  let g : ℝ → X := fun s => (x : X) + ∫ u in (0 : ℝ)..s, S.realOperator u z
+  have hzmeas : StronglyMeasurableAtFilter (fun u : ℝ => S.realOperator u z)
+      (nhdsWithin t (Set.Ici 0)) MeasureTheory.volume := by
+    have hae : MeasureTheory.AEStronglyMeasurable (fun u : ℝ => S.realOperator u z)
+        (MeasureTheory.volume.restrict (Set.Ici 0)) :=
+      (S.realOperator_continuousOn_Ici z).aestronglyMeasurable measurableSet_Ici
+    exact AEStronglyMeasurable.stronglyMeasurableAtFilter_of_mem hae
+      self_mem_nhdsWithin
+  have horbit : ∀ s : ℝ, 0 ≤ s → S.realOperator s (x : X) = g s := by
+    intro s hs
+    let b := s + 1
+    have hb : 0 < b := by dsimp [b]; linarith
+    have hzcont : ContinuousOn (fun u : ℝ => S.realOperator u z) (Set.Icc 0 b) :=
+      (S.realOperator_continuousOn_Ici z).mono Set.Icc_subset_Ici_self
+    have hzint : IntervalIntegrable (fun u : ℝ => S.realOperator u z) MeasureTheory.volume 0 b :=
+      (by simpa [Set.uIcc_of_le hb.le] using hzcont :
+        ContinuousOn (fun u : ℝ => S.realOperator u z) (Set.uIcc 0 b)).intervalIntegrable
+    apply eq_of_has_deriv_right_eq
+        (f := fun u : ℝ => S.realOperator u (x : X))
+        (g := g) (f' := fun u => S.realOperator u z) (a := 0) (b := b)
+    · intro u hu
+      simpa [z] using S.realOperator_hasDerivWithinAt_map_generator x hu.1
+    · intro u hu
+      have hcont := S.realOperator_continuousWithinAt z u hu.1
+      have hmeas : StronglyMeasurableAtFilter (fun v : ℝ => S.realOperator v z)
+          (nhdsWithin u (Set.Ioi u)) MeasureTheory.volume := by
+        have hae : MeasureTheory.AEStronglyMeasurable (fun v : ℝ => S.realOperator v z)
+            (MeasureTheory.volume.restrict (Set.Ioi u)) :=
+          ((S.realOperator_continuousOn_Ici z).mono (by
+            intro v hv
+            exact hu.1.trans hv.le)).aestronglyMeasurable measurableSet_Ioi
+        exact AEStronglyMeasurable.stronglyMeasurableAtFilter_of_mem hae
+          self_mem_nhdsWithin
+      have huit : IntervalIntegrable (fun v : ℝ => S.realOperator v z)
+          MeasureTheory.volume 0 u := by
+        apply ContinuousOn.intervalIntegrable
+        simpa [Set.uIcc_of_le hu.1] using
+          (S.realOperator_continuousOn_Ici z).mono (by
+            intro v hv
+            exact hv.1)
+      have hint := intervalIntegral.integral_hasDerivWithinAt_right
+        (s := Set.Ici u) (t := Set.Ioi u)
+        huit hmeas (hcont.mono (by intro v hv; exact hu.1.trans hv.le))
+      change HasDerivWithinAt (fun s => (x : X) + ∫ v in (0 : ℝ)..s,
+        S.realOperator v z) (S.realOperator u z) (Set.Ici u) u
+      have h := (hasDerivWithinAt_const u (Set.Ici u) (x : X)).add hint
+      exact h.congr (fun _ _ => rfl) rfl |>.congr_deriv (zero_add _)
+    · exact (S.realOperator_continuousOn_Ici x).mono Set.Icc_subset_Ici_self
+    · intro u hu
+      exact continuousWithinAt_const.add
+        (intervalIntegral.continuousWithinAt_primitive
+          (MeasureTheory.NullSingletonClass.measure_singleton u)
+          (by simpa [max_eq_right hb.le] using hzint))
+    · simp [g]
+    · exact ⟨hs, by dsimp [b]; linarith⟩
+  have hg : HasDerivWithinAt g (S.realOperator t z) (Set.Ici 0) t := by
+    have hzint : IntervalIntegrable (fun u : ℝ => S.realOperator u z)
+        MeasureTheory.volume 0 t := by
+      apply ContinuousOn.intervalIntegrable
+      simpa [Set.uIcc_of_le ht] using
+        (S.realOperator_continuousOn_Ici z).mono (by
+          intro u hu
+          exact hu.1)
+    rcases ht.eq_or_lt with rfl | ht
+    · have hcont := S.realOperator_continuousWithinAt z 0 le_rfl
+      have hmeas : StronglyMeasurableAtFilter (fun v : ℝ => S.realOperator v z)
+          (nhdsWithin 0 (Set.Ioi 0)) MeasureTheory.volume := by
+        have hae : MeasureTheory.AEStronglyMeasurable (fun v : ℝ => S.realOperator v z)
+            (MeasureTheory.volume.restrict (Set.Ioi 0)) :=
+          ((S.realOperator_continuousOn_Ici z).mono Set.Ioi_subset_Ici_self)
+            |>.aestronglyMeasurable measurableSet_Ioi
+        exact AEStronglyMeasurable.stronglyMeasurableAtFilter_of_mem hae
+          self_mem_nhdsWithin
+      have hint := intervalIntegral.integral_hasDerivWithinAt_right
+        (s := Set.Ici 0) (t := Set.Ioi 0) hzint hmeas
+        (hcont.mono Set.Ioi_subset_Ici_self)
+      simp only [S.realOperator_zero_apply] at hint
+      rw [S.realOperator_zero_apply]
+      change HasDerivWithinAt (fun s => (x : X) + ∫ v in (0 : ℝ)..s,
+        S.realOperator v z) z (Set.Ici 0) 0
+      have h := (hasDerivWithinAt_const 0 (Set.Ici 0) (x : X)).add hint
+      exact h.congr (fun _ _ => rfl) rfl |>.congr_deriv (zero_add _)
+    · have hcont := S.realOperator_continuousAt_of_pos z ht
+      have hmeas := ContinuousOn.stronglyMeasurableAtFilter (μ := MeasureTheory.volume)
+        isOpen_Ioi ((S.realOperator_continuousOn_Ici z).mono Set.Ioi_subset_Ici_self) t ht
+      have hint := intervalIntegral.integral_hasDerivAt_right hzint
+        hmeas hcont
+      change HasDerivWithinAt (fun s => (x : X) + ∫ v in (0 : ℝ)..s,
+        S.realOperator v z) (S.realOperator t z) (Set.Ici 0) t
+      have h := ((hasDerivAt_const t (x : X)).add hint).hasDerivWithinAt
+        (s := Set.Ici 0)
+      exact h.congr (fun _ _ => rfl) rfl |>.congr_deriv (zero_add _)
+  rw [S.realOperator_generator_map ht x]
+  exact hg.congr (fun s hs => horbit s hs) (horbit t ht)
 
 /-- The orbit of a generator-domain vector is right-differentiable at every nonnegative time. -/
 theorem realOperator_differentiableWithinAt (S : StronglyContinuousSemigroup X)

--- a/TauCeti/Analysis/Semigroups/Generator/OrbitDerivative.lean
+++ b/TauCeti/Analysis/Semigroups/Generator/OrbitDerivative.lean
@@ -6,7 +6,6 @@ module
 
 public import TauCeti.Analysis.Semigroups.Generator.Invariance
 import Mathlib.Analysis.Calculus.Deriv.Slope
-import Mathlib.Analysis.Calculus.MeanValue
 
 /-!
 # Differentiability of semigroup orbits

--- a/TauCeti/Analysis/Semigroups/Generator/OrbitDerivative.lean
+++ b/TauCeti/Analysis/Semigroups/Generator/OrbitDerivative.lean
@@ -140,6 +140,57 @@ theorem realOperator_hasDerivWithinAt_map_generator
 
 /-! ## Derivatives within the nonnegative half-line -/
 
+/-- A generator-domain orbit equals its initial value plus the integral of the orbit of its
+generator. -/
+theorem realOperator_eq_add_integral_map_generator (S : StronglyContinuousSemigroup X)
+    [CompleteSpace X] (x : S.domain) {s : ℝ} (hs : 0 ≤ s) :
+    S.realOperator s (x : X) = (x : X) + ∫ u in (0 : ℝ)..s,
+      S.realOperator u (S.generator ⟨x, by rw [S.generator_domain]; exact x.property⟩) := by
+  let z : X := S.generator ⟨x, by rw [S.generator_domain]; exact x.property⟩
+  let g : ℝ → X := fun v => (x : X) + ∫ u in (0 : ℝ)..v, S.realOperator u z
+  let b := s + 1
+  have hb : 0 < b := by dsimp [b]; linarith
+  have hzcont : ContinuousOn (fun u : ℝ => S.realOperator u z) (Set.Icc 0 b) :=
+    (S.realOperator_continuousOn_Ici z).mono Set.Icc_subset_Ici_self
+  have hzint : IntervalIntegrable (fun u : ℝ => S.realOperator u z) MeasureTheory.volume 0 b :=
+    (by simpa [Set.uIcc_of_le hb.le] using hzcont :
+      ContinuousOn (fun u : ℝ => S.realOperator u z) (Set.uIcc 0 b)).intervalIntegrable
+  apply eq_of_has_deriv_right_eq
+      (f := fun u : ℝ => S.realOperator u (x : X))
+      (g := g) (f' := fun u => S.realOperator u z) (a := 0) (b := b)
+  · intro u hu
+    simpa [z] using S.realOperator_hasDerivWithinAt_map_generator x hu.1
+  · intro u hu
+    have hcont := S.realOperator_continuousWithinAt z u hu.1
+    have hmeas : StronglyMeasurableAtFilter (fun v : ℝ => S.realOperator v z)
+        (nhdsWithin u (Set.Ioi u)) MeasureTheory.volume := by
+      have hae : MeasureTheory.AEStronglyMeasurable (fun v : ℝ => S.realOperator v z)
+          (MeasureTheory.volume.restrict (Set.Ioi u)) :=
+        ((S.realOperator_continuousOn_Ici z).mono (by
+          intro v hv
+          exact hu.1.trans hv.le)).aestronglyMeasurable measurableSet_Ioi
+      exact AEStronglyMeasurable.stronglyMeasurableAtFilter_of_mem hae self_mem_nhdsWithin
+    have huit : IntervalIntegrable (fun v : ℝ => S.realOperator v z)
+        MeasureTheory.volume 0 u := by
+      apply ContinuousOn.intervalIntegrable
+      simpa [Set.uIcc_of_le hu.1] using
+        (S.realOperator_continuousOn_Ici z).mono (fun _ hv => hv.1)
+    have hint := intervalIntegral.integral_hasDerivWithinAt_right
+      (s := Set.Ici u) (t := Set.Ioi u) huit hmeas
+      (hcont.mono (fun v hv => hu.1.trans hv.le))
+    change HasDerivWithinAt (fun v => (x : X) + ∫ w in (0 : ℝ)..v,
+      S.realOperator w z) (S.realOperator u z) (Set.Ici u) u
+    have h := (hasDerivWithinAt_const u (Set.Ici u) (x : X)).add hint
+    exact h.congr (fun _ _ => rfl) rfl |>.congr_deriv (zero_add _)
+  · exact (S.realOperator_continuousOn_Ici x).mono Set.Icc_subset_Ici_self
+  · intro u hu
+    exact continuousWithinAt_const.add
+      (intervalIntegral.continuousWithinAt_primitive
+        (MeasureTheory.NullSingletonClass.measure_singleton u)
+        (by simpa [max_eq_right hb.le] using hzint))
+  · simp [g]
+  · exact ⟨hs, by dsimp [b]; linarith⟩
+
 /-- On the nonnegative half-line, the orbit of a generator-domain vector has derivative equal
 to the generator evaluated on the evolved vector. At positive times this is a two-sided
 derivative; only the derivative at zero is one-sided. -/
@@ -149,100 +200,32 @@ theorem realOperator_hasDerivWithinAt_Ici (S : StronglyContinuousSemigroup X)
       (S.generator ⟨S.realOperator t x, by
         rw [S.generator_domain]
         exact S.realOperator_mem_domain ht x.property⟩) (Set.Ici 0) t := by
+  rcases ht.eq_or_lt with rfl | ht
+  · simpa only [S.realOperator_zero_apply] using S.realOperator_hasDerivWithinAt_zero x
   let z : X := S.generator ⟨x, by rw [S.generator_domain]; exact x.property⟩
   let g : ℝ → X := fun s => (x : X) + ∫ u in (0 : ℝ)..s, S.realOperator u z
-  -- First identify the orbit with the integral primitive `g` by equality of right derivatives.
   have horbit : ∀ s : ℝ, 0 ≤ s → S.realOperator s (x : X) = g s := by
     intro s hs
-    let b := s + 1
-    have hb : 0 < b := by dsimp [b]; linarith
-    have hzcont : ContinuousOn (fun u : ℝ => S.realOperator u z) (Set.Icc 0 b) :=
-      (S.realOperator_continuousOn_Ici z).mono Set.Icc_subset_Ici_self
-    have hzint : IntervalIntegrable (fun u : ℝ => S.realOperator u z) MeasureTheory.volume 0 b :=
-      (by simpa [Set.uIcc_of_le hb.le] using hzcont :
-        ContinuousOn (fun u : ℝ => S.realOperator u z) (Set.uIcc 0 b)).intervalIntegrable
-    apply eq_of_has_deriv_right_eq
-        (f := fun u : ℝ => S.realOperator u (x : X))
-        (g := g) (f' := fun u => S.realOperator u z) (a := 0) (b := b)
-    · intro u hu
-      simpa [z] using S.realOperator_hasDerivWithinAt_map_generator x hu.1
-    · intro u hu
-      have hcont := S.realOperator_continuousWithinAt z u hu.1
-      have hmeas : StronglyMeasurableAtFilter (fun v : ℝ => S.realOperator v z)
-          (nhdsWithin u (Set.Ioi u)) MeasureTheory.volume := by
-        have hae : MeasureTheory.AEStronglyMeasurable (fun v : ℝ => S.realOperator v z)
-            (MeasureTheory.volume.restrict (Set.Ioi u)) :=
-          ((S.realOperator_continuousOn_Ici z).mono (by
-            intro v hv
-            exact hu.1.trans hv.le)).aestronglyMeasurable measurableSet_Ioi
-        exact AEStronglyMeasurable.stronglyMeasurableAtFilter_of_mem hae
-          self_mem_nhdsWithin
-      have huit : IntervalIntegrable (fun v : ℝ => S.realOperator v z)
-          MeasureTheory.volume 0 u := by
-        apply ContinuousOn.intervalIntegrable
-        simpa [Set.uIcc_of_le hu.1] using
-          (S.realOperator_continuousOn_Ici z).mono (by
-            intro v hv
-            exact hv.1)
-      have hint := intervalIntegral.integral_hasDerivWithinAt_right
-        (s := Set.Ici u) (t := Set.Ioi u)
-        huit hmeas (hcont.mono (by intro v hv; exact hu.1.trans hv.le))
-      -- Unfolding `g` exposes the constant plus primitive required by the calculus lemmas.
-      change HasDerivWithinAt (fun s => (x : X) + ∫ v in (0 : ℝ)..s,
-        S.realOperator v z) (S.realOperator u z) (Set.Ici u) u
-      have h := (hasDerivWithinAt_const u (Set.Ici u) (x : X)).add hint
-      exact h.congr (fun _ _ => rfl) rfl |>.congr_deriv (zero_add _)
-    · exact (S.realOperator_continuousOn_Ici x).mono Set.Icc_subset_Ici_self
-    · intro u hu
-      exact continuousWithinAt_const.add
-        (intervalIntegral.continuousWithinAt_primitive
-          (MeasureTheory.NullSingletonClass.measure_singleton u)
-          (by simpa [max_eq_right hb.le] using hzint))
-    · simp [g]
-    · exact ⟨hs, by dsimp [b]; linarith⟩
-  -- Next differentiate the primitive on `Ici 0`, treating its endpoint separately.
+    simpa only [g, z] using S.realOperator_eq_add_integral_map_generator x hs
   have hg : HasDerivWithinAt g (S.realOperator t z) (Set.Ici 0) t := by
     have hzint : IntervalIntegrable (fun u : ℝ => S.realOperator u z)
         MeasureTheory.volume 0 t := by
       apply ContinuousOn.intervalIntegrable
-      simpa [Set.uIcc_of_le ht] using
+      simpa [Set.uIcc_of_le ht.le] using
         (S.realOperator_continuousOn_Ici z).mono (by
           intro u hu
           exact hu.1)
-    rcases ht.eq_or_lt with rfl | ht
-    · have hcont := S.realOperator_continuousWithinAt z 0 le_rfl
-      have hmeas : StronglyMeasurableAtFilter (fun v : ℝ => S.realOperator v z)
-          (nhdsWithin 0 (Set.Ioi 0)) MeasureTheory.volume := by
-        have hae : MeasureTheory.AEStronglyMeasurable (fun v : ℝ => S.realOperator v z)
-            (MeasureTheory.volume.restrict (Set.Ioi 0)) :=
-          ((S.realOperator_continuousOn_Ici z).mono Set.Ioi_subset_Ici_self)
-            |>.aestronglyMeasurable measurableSet_Ioi
-        exact AEStronglyMeasurable.stronglyMeasurableAtFilter_of_mem hae
-          self_mem_nhdsWithin
-      have hint := intervalIntegral.integral_hasDerivWithinAt_right
-        (s := Set.Ici 0) (t := Set.Ioi 0) hzint hmeas
-        (hcont.mono Set.Ioi_subset_Ici_self)
-      simp only [S.realOperator_zero_apply] at hint
-      rw [S.realOperator_zero_apply]
-      -- Unfolding `g` exposes the constant plus primitive required by the calculus lemmas.
-      change HasDerivWithinAt (fun s => (x : X) + ∫ v in (0 : ℝ)..s,
-        S.realOperator v z) z (Set.Ici 0) 0
-      have h := (hasDerivWithinAt_const 0 (Set.Ici 0) (x : X)).add hint
-      exact h.congr (fun _ _ => rfl) rfl |>.congr_deriv (zero_add _)
-    · have hcont := S.realOperator_continuousAt_of_pos z ht
-      have hmeas := ContinuousOn.stronglyMeasurableAtFilter (μ := MeasureTheory.volume)
-        isOpen_Ioi ((S.realOperator_continuousOn_Ici z).mono Set.Ioi_subset_Ici_self) t ht
-      have hint := intervalIntegral.integral_hasDerivAt_right hzint
-        hmeas hcont
-      -- Unfolding `g` exposes the constant plus primitive required by the calculus lemmas.
-      change HasDerivWithinAt (fun s => (x : X) + ∫ v in (0 : ℝ)..s,
-        S.realOperator v z) (S.realOperator t z) (Set.Ici 0) t
-      have h := ((hasDerivAt_const t (x : X)).add hint).hasDerivWithinAt
-        (s := Set.Ici 0)
-      exact h.congr (fun _ _ => rfl) rfl |>.congr_deriv (zero_add _)
+    have hcont := S.realOperator_continuousAt_of_pos z ht
+    have hmeas := ContinuousOn.stronglyMeasurableAtFilter (μ := MeasureTheory.volume)
+      isOpen_Ioi ((S.realOperator_continuousOn_Ici z).mono Set.Ioi_subset_Ici_self) t ht
+    have hint := intervalIntegral.integral_hasDerivAt_right hzint hmeas hcont
+    change HasDerivWithinAt (fun s => (x : X) + ∫ v in (0 : ℝ)..s,
+      S.realOperator v z) (S.realOperator t z) (Set.Ici 0) t
+    have h := ((hasDerivAt_const t (x : X)).add hint).hasDerivWithinAt (s := Set.Ici 0)
+    exact h.congr (fun _ _ => rfl) rfl |>.congr_deriv (zero_add _)
   -- Finally transfer the derivative from `g` back to the orbit and commute the generator.
-  rw [S.realOperator_generator_map ht x]
-  exact hg.congr (fun s hs => horbit s hs) (horbit t ht)
+  rw [S.realOperator_generator_map ht.le x]
+  exact hg.congr (fun s hs => horbit s hs) (horbit t ht.le)
 
 /-- The orbit of a generator-domain vector is right-differentiable at every nonnegative time. -/
 theorem realOperator_differentiableWithinAt (S : StronglyContinuousSemigroup X)

--- a/TauCeti/Analysis/Semigroups/Generator/OrbitDerivative.lean
+++ b/TauCeti/Analysis/Semigroups/Generator/OrbitDerivative.lean
@@ -140,9 +140,7 @@ theorem realOperator_hasDerivWithinAt_map_generator
 
 /-! ## Derivatives within the nonnegative half-line -/
 
-/-- A generator-domain orbit equals its initial value plus the integral of the orbit of its
-generator. -/
-theorem realOperator_eq_add_integral_map_generator (S : StronglyContinuousSemigroup X)
+private theorem realOperator_eq_add_integral_map_generator (S : StronglyContinuousSemigroup X)
     [CompleteSpace X] (x : S.domain) {s : ℝ} (hs : 0 ≤ s) :
     S.realOperator s (x : X) = (x : X) + ∫ u in (0 : ℝ)..s,
       S.realOperator u (S.generator ⟨x, by rw [S.generator_domain]; exact x.property⟩) := by
@@ -178,10 +176,10 @@ theorem realOperator_eq_add_integral_map_generator (S : StronglyContinuousSemigr
     have hint := intervalIntegral.integral_hasDerivWithinAt_right
       (s := Set.Ici u) (t := Set.Ioi u) huit hmeas
       (hcont.mono (fun v hv => hu.1.trans hv.le))
-    change HasDerivWithinAt (fun v => (x : X) + ∫ w in (0 : ℝ)..v,
-      S.realOperator w z) (S.realOperator u z) (Set.Ici u) u
     have h := (hasDerivWithinAt_const u (Set.Ici u) (x : X)).add hint
-    exact h.congr (fun _ _ => rfl) rfl |>.congr_deriv (zero_add _)
+    convert h.congr (fun _ _ => rfl) rfl |>.congr_deriv (zero_add _) using 1
+    funext v
+    rfl
   · exact (S.realOperator_continuousOn_Ici x).mono Set.Icc_subset_Ici_self
   · intro u hu
     exact continuousWithinAt_const.add
@@ -219,10 +217,10 @@ theorem realOperator_hasDerivWithinAt_Ici (S : StronglyContinuousSemigroup X)
     have hmeas := ContinuousOn.stronglyMeasurableAtFilter (μ := MeasureTheory.volume)
       isOpen_Ioi ((S.realOperator_continuousOn_Ici z).mono Set.Ioi_subset_Ici_self) t ht
     have hint := intervalIntegral.integral_hasDerivAt_right hzint hmeas hcont
-    change HasDerivWithinAt (fun s => (x : X) + ∫ v in (0 : ℝ)..s,
-      S.realOperator v z) (S.realOperator t z) (Set.Ici 0) t
     have h := ((hasDerivAt_const t (x : X)).add hint).hasDerivWithinAt (s := Set.Ici 0)
-    exact h.congr (fun _ _ => rfl) rfl |>.congr_deriv (zero_add _)
+    convert h.congr (fun _ _ => rfl) rfl |>.congr_deriv (zero_add _) using 1
+    funext s
+    rfl
   -- Finally transfer the derivative from `g` back to the orbit and commute the generator.
   rw [S.realOperator_generator_map ht.le x]
   exact hg.congr (fun s hs => horbit s hs) (horbit t ht.le)

--- a/TauCeti/Analysis/Semigroups/Generator/OrbitDerivative.lean
+++ b/TauCeti/Analysis/Semigroups/Generator/OrbitDerivative.lean
@@ -145,49 +145,17 @@ private theorem realOperator_eq_add_integral_map_generator (S : StronglyContinuo
     S.realOperator s (x : X) = (x : X) + ∫ u in (0 : ℝ)..s,
       S.realOperator u (S.generator ⟨x, by rw [S.generator_domain]; exact x.property⟩) := by
   let z : X := S.generator ⟨x, by rw [S.generator_domain]; exact x.property⟩
-  let g : ℝ → X := fun v => (x : X) + ∫ u in (0 : ℝ)..v, S.realOperator u z
-  let b := s + 1
-  have hb : 0 < b := by dsimp [b]; linarith
-  have hzcont : ContinuousOn (fun u : ℝ => S.realOperator u z) (Set.Icc 0 b) :=
-    (S.realOperator_continuousOn_Ici z).mono Set.Icc_subset_Ici_self
-  have hzint : IntervalIntegrable (fun u : ℝ => S.realOperator u z) MeasureTheory.volume 0 b :=
-    (by simpa [Set.uIcc_of_le hb.le] using hzcont :
-      ContinuousOn (fun u : ℝ => S.realOperator u z) (Set.uIcc 0 b)).intervalIntegrable
-  apply eq_of_has_deriv_right_eq
-      (f := fun u : ℝ => S.realOperator u (x : X))
-      (g := g) (f' := fun u => S.realOperator u z) (a := 0) (b := b)
-  · intro u hu
-    simpa [z] using S.realOperator_hasDerivWithinAt_map_generator x hu.1
-  · intro u hu
-    have hcont := S.realOperator_continuousWithinAt z u hu.1
-    have hmeas : StronglyMeasurableAtFilter (fun v : ℝ => S.realOperator v z)
-        (nhdsWithin u (Set.Ioi u)) MeasureTheory.volume := by
-      have hae : MeasureTheory.AEStronglyMeasurable (fun v : ℝ => S.realOperator v z)
-          (MeasureTheory.volume.restrict (Set.Ioi u)) :=
-        ((S.realOperator_continuousOn_Ici z).mono (by
-          intro v hv
-          exact hu.1.trans hv.le)).aestronglyMeasurable measurableSet_Ioi
-      exact AEStronglyMeasurable.stronglyMeasurableAtFilter_of_mem hae self_mem_nhdsWithin
-    have huit : IntervalIntegrable (fun v : ℝ => S.realOperator v z)
-        MeasureTheory.volume 0 u := by
-      apply ContinuousOn.intervalIntegrable
-      simpa [Set.uIcc_of_le hu.1] using
-        (S.realOperator_continuousOn_Ici z).mono (fun _ hv => hv.1)
-    have hint := intervalIntegral.integral_hasDerivWithinAt_right
-      (s := Set.Ici u) (t := Set.Ioi u) huit hmeas
-      (hcont.mono (fun v hv => hu.1.trans hv.le))
-    have h := (hasDerivWithinAt_const u (Set.Ici u) (x : X)).add hint
-    convert h.congr (fun _ _ => rfl) rfl |>.congr_deriv (zero_add _) using 1
-    funext v
-    rfl
-  · exact (S.realOperator_continuousOn_Ici x).mono Set.Icc_subset_Ici_self
-  · intro u hu
-    exact continuousWithinAt_const.add
-      (intervalIntegral.continuousWithinAt_primitive
-        (MeasureTheory.NullSingletonClass.measure_singleton u)
-        (by simpa [max_eq_right hb.le] using hzint))
-  · simp [g]
-  · exact ⟨hs, by dsimp [b]; linarith⟩
+  have hzint : IntervalIntegrable (fun u : ℝ => S.realOperator u z)
+      MeasureTheory.volume 0 s := by
+    apply ContinuousOn.intervalIntegrable
+    simpa [Set.uIcc_of_le hs] using
+      (S.realOperator_continuousOn_Ici z).mono (fun _ hu => hu.1)
+  have hftc := intervalIntegral.integral_eq_sub_of_hasDeriv_right_of_le hs
+    ((S.realOperator_continuousOn_Ici x).mono Set.Icc_subset_Ici_self)
+    (fun u hu => (S.realOperator_hasDerivWithinAt_map_generator x hu.1.le).mono
+      Set.Ioi_subset_Ici_self) hzint
+  rw [hftc, S.realOperator_zero_apply]
+  abel
 
 /-- On the nonnegative half-line, the orbit of a generator-domain vector has derivative equal
 to the generator evaluated on the evolved vector. At positive times this is a two-sided

--- a/TauCeti/Analysis/Semigroups/Generator/OrbitDerivative.lean
+++ b/TauCeti/Analysis/Semigroups/Generator/OrbitDerivative.lean
@@ -7,15 +7,15 @@ module
 public import TauCeti.Analysis.Semigroups.Generator.Invariance
 import Mathlib.Analysis.Calculus.Deriv.Slope
 import Mathlib.Analysis.Calculus.MeanValue
-import Mathlib.MeasureTheory.Integral.DominatedConvergence
 
 /-!
 # Differentiability of semigroup orbits
 
 This file characterizes membership in the infinitesimal generator domain by right
-differentiability of the orbit at zero. For a vector in the generator domain, it then computes
-the right derivative at every nonnegative time in the equivalent forms `A (S t x)` and
-`S t (A x)`.
+differentiability of the orbit at zero. For a vector in the generator domain, it computes the
+right derivative at every nonnegative time in the equivalent forms `A (S t x)` and `S t (A x)`.
+It also proves that a generator-domain orbit has a derivative within the whole nonnegative
+half-line, hence a two-sided derivative at positive times.
 
 ## References
 
@@ -138,6 +138,8 @@ theorem realOperator_hasDerivWithinAt_map_generator
   rw [← S.realOperator_generator_map ht x]
   exact S.realOperator_hasDerivWithinAt ht (S.realOperator_mem_domain ht x.property)
 
+/-! ## Derivatives within the nonnegative half-line -/
+
 /-- On the nonnegative half-line, the orbit of a generator-domain vector has derivative equal
 to the generator evaluated on the evolved vector. At positive times this is a two-sided
 derivative; only the derivative at zero is one-sided. -/
@@ -149,13 +151,7 @@ theorem realOperator_hasDerivWithinAt_Ici (S : StronglyContinuousSemigroup X)
         exact S.realOperator_mem_domain ht x.property⟩) (Set.Ici 0) t := by
   let z : X := S.generator ⟨x, by rw [S.generator_domain]; exact x.property⟩
   let g : ℝ → X := fun s => (x : X) + ∫ u in (0 : ℝ)..s, S.realOperator u z
-  have hzmeas : StronglyMeasurableAtFilter (fun u : ℝ => S.realOperator u z)
-      (nhdsWithin t (Set.Ici 0)) MeasureTheory.volume := by
-    have hae : MeasureTheory.AEStronglyMeasurable (fun u : ℝ => S.realOperator u z)
-        (MeasureTheory.volume.restrict (Set.Ici 0)) :=
-      (S.realOperator_continuousOn_Ici z).aestronglyMeasurable measurableSet_Ici
-    exact AEStronglyMeasurable.stronglyMeasurableAtFilter_of_mem hae
-      self_mem_nhdsWithin
+  -- First identify the orbit with the integral primitive `g` by equality of right derivatives.
   have horbit : ∀ s : ℝ, 0 ≤ s → S.realOperator s (x : X) = g s := by
     intro s hs
     let b := s + 1
@@ -191,6 +187,7 @@ theorem realOperator_hasDerivWithinAt_Ici (S : StronglyContinuousSemigroup X)
       have hint := intervalIntegral.integral_hasDerivWithinAt_right
         (s := Set.Ici u) (t := Set.Ioi u)
         huit hmeas (hcont.mono (by intro v hv; exact hu.1.trans hv.le))
+      -- Unfolding `g` exposes the constant plus primitive required by the calculus lemmas.
       change HasDerivWithinAt (fun s => (x : X) + ∫ v in (0 : ℝ)..s,
         S.realOperator v z) (S.realOperator u z) (Set.Ici u) u
       have h := (hasDerivWithinAt_const u (Set.Ici u) (x : X)).add hint
@@ -203,6 +200,7 @@ theorem realOperator_hasDerivWithinAt_Ici (S : StronglyContinuousSemigroup X)
           (by simpa [max_eq_right hb.le] using hzint))
     · simp [g]
     · exact ⟨hs, by dsimp [b]; linarith⟩
+  -- Next differentiate the primitive on `Ici 0`, treating its endpoint separately.
   have hg : HasDerivWithinAt g (S.realOperator t z) (Set.Ici 0) t := by
     have hzint : IntervalIntegrable (fun u : ℝ => S.realOperator u z)
         MeasureTheory.volume 0 t := by
@@ -226,6 +224,7 @@ theorem realOperator_hasDerivWithinAt_Ici (S : StronglyContinuousSemigroup X)
         (hcont.mono Set.Ioi_subset_Ici_self)
       simp only [S.realOperator_zero_apply] at hint
       rw [S.realOperator_zero_apply]
+      -- Unfolding `g` exposes the constant plus primitive required by the calculus lemmas.
       change HasDerivWithinAt (fun s => (x : X) + ∫ v in (0 : ℝ)..s,
         S.realOperator v z) z (Set.Ici 0) 0
       have h := (hasDerivWithinAt_const 0 (Set.Ici 0) (x : X)).add hint
@@ -235,11 +234,13 @@ theorem realOperator_hasDerivWithinAt_Ici (S : StronglyContinuousSemigroup X)
         isOpen_Ioi ((S.realOperator_continuousOn_Ici z).mono Set.Ioi_subset_Ici_self) t ht
       have hint := intervalIntegral.integral_hasDerivAt_right hzint
         hmeas hcont
+      -- Unfolding `g` exposes the constant plus primitive required by the calculus lemmas.
       change HasDerivWithinAt (fun s => (x : X) + ∫ v in (0 : ℝ)..s,
         S.realOperator v z) (S.realOperator t z) (Set.Ici 0) t
       have h := ((hasDerivAt_const t (x : X)).add hint).hasDerivWithinAt
         (s := Set.Ici 0)
       exact h.congr (fun _ _ => rfl) rfl |>.congr_deriv (zero_add _)
+  -- Finally transfer the derivative from `g` back to the orbit and commute the generator.
   rw [S.realOperator_generator_map ht x]
   exact hg.congr (fun s hs => horbit s hs) (horbit t ht)
 


### PR DESCRIPTION
This PR formalizes the autonomous abstract Cauchy problem for an unbounded generator on the nonnegative half-line. Define right-classical solutions by domain membership and the equation `u' = A u`, and mild solutions by continuity and the integrated equation `A (∫₀ᵗ u(s) ds) = u(t) - x`. Prove that every strongly continuous semigroup orbit is a mild solution, and that an orbit starting in the generator domain is a classical solution.

This advances `TauCetiRoadmap/OneParameterSemigroups/README.md`, Part A — Strongly continuous semigroups, specifically the milestone “abstract Cauchy problem”: `u(t) = S(t)x` is a classical solution for `x ∈ D(A)` and a mild solution for general `x`. It is the lowest-dependency remaining piece because the required generator-domain invariance, orbit derivative, orbit continuity, and integrated-generator identity are already present.

Follow Engel--Nagel, *One-Parameter Semigroups for Linear Evolution Equations*, Section II.6. No Mathlib implementation is vendored; the development consumes Mathlib's `LinearPMap`, Bochner set integral, and one-sided derivative infrastructure, together with the existing TauCeti semigroup generator API.

<!--tauceti-target:v1 {"focus":"OneParameterSemigroups","id":"abstract-cauchy-problem"}-->

🤖 Prepared with Codex
