### PR TITLE
feat: abstract simplices and their boundaries

### DIFF
--- a/TauCeti/AlgebraicTopology/SimplicialComplex/Collapse.lean
+++ b/TauCeti/AlgebraicTopology/SimplicialComplex/Collapse.lean
@@ -5,6 +5,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 module
 
 public import TauCeti.AlgebraicTopology.SimplicialComplex.ElementaryCollapse
+public import TauCeti.AlgebraicTopology.SimplicialComplex.Simplex
 
 /-!
 # Simplicial collapse
@@ -74,6 +75,18 @@ theorem point_inj {v w : ι} : point v = point w ↔ v = w := by
     have : ({v} : Finset ι) ∈ point w := h ▸ (mem_point.mpr rfl : ({v} : Finset ι) ∈ point v)
     exact singleton_mem_point.mp this
   · exact fun h => h ▸ rfl
+
+/-- The abstract simplex spanned by a single vertex is the one-vertex complex at that vertex. -/
+@[simp]
+theorem simplex_singleton (v : ι) : simplex {v} = point v := by
+  refine SetLike.ext fun σ => ?_
+  rw [mem_simplex, mem_point, Finset.subset_singleton_iff]
+  constructor
+  · rintro ⟨hne, rfl | rfl⟩
+    · exact absurd rfl hne.ne_empty
+    · rfl
+  · rintro rfl
+    exact ⟨Finset.singleton_nonempty v, Or.inr rfl⟩
 
 /-- `K` collapses to `L` when a finite, possibly empty, sequence of elementary collapses takes
 `K` to `L`. -/

--- a/TauCeti/AlgebraicTopology/SimplicialComplex/Simplex.lean
+++ b/TauCeti/AlgebraicTopology/SimplicialComplex/Simplex.lean
@@ -49,7 +49,7 @@ def simplexBoundary (V : Finset ι) : _root_.PreAbstractSimplicialComplex ι whe
     rintro σ ⟨hσ, hσV⟩
     refine ⟨hσ, fun _ hτσ hτ => ⟨hτ, hτσ.trans_ssubset hσV⟩⟩
 
-variable {V W σ : Finset ι}
+variable {K : _root_.PreAbstractSimplicialComplex ι} {V W σ : Finset ι}
 
 /-- A finite set is a face of a simplex exactly when it is nonempty and contained in the
 spanning vertex set. -/
@@ -77,7 +77,7 @@ theorem singleton_mem_simplex {v : ι} : {v} ∈ simplex V ↔ v ∈ V := by
 
 /-- A singleton is a boundary face exactly when its vertex belongs to a spanning set containing
 at least one other vertex. -/
-theorem singleton_mem_simplexBoundary_iff {v : ι} :
+theorem singleton_mem_simplexBoundary {v : ι} :
     {v} ∈ simplexBoundary V ↔ v ∈ V ∧ V ≠ {v} := by
   simp only [mem_simplexBoundary, Finset.singleton_nonempty, true_and]
   rw [Finset.ssubset_iff_subset_ne, Finset.singleton_subset_iff]
@@ -89,7 +89,7 @@ theorem singleton_mem_simplexBoundary_iff {v : ι} :
 theorem simplexBoundary_le_simplex : simplexBoundary V ≤ simplex V :=
   fun _ hσ => ⟨hσ.1, hσ.2.subset⟩
 
-/-- A nonempty simplex boundary is a strict subcomplex of its simplex. -/
+/-- The boundary of a simplex with nonempty spanning set is a strict subcomplex of the simplex. -/
 theorem simplexBoundary_lt_simplex (hV : V.Nonempty) : simplexBoundary V < simplex V := by
   refine lt_of_le_of_ne simplexBoundary_le_simplex ?_
   intro h
@@ -123,13 +123,17 @@ theorem simplexBoundary_singleton (v : ι) : simplexBoundary {v} = ⊥ := by
     exact hσ.1.ne_empty (Finset.ssubset_singleton_iff.mp hσ.2)
   · exact False.elim
 
+/-- The simplex on a nonempty spanning set is contained in a complex exactly when that spanning
+set is a face of the complex. -/
+theorem simplex_le_iff (hV : V.Nonempty) : simplex V ≤ K ↔ V ∈ K := by
+  constructor
+  · exact fun h => h (self_mem_simplex.mpr hV)
+  · exact fun hVₖ _ hσ => (K.isRelLowerSet_faces hVₖ).2 hσ.2 hσ.1
+
 /-- Simplices are ordered exactly when their spanning vertex sets are ordered, provided the
 smaller spanning set is nonempty. -/
 theorem simplex_le_simplex_iff (hV : V.Nonempty) : simplex V ≤ simplex W ↔ V ⊆ W := by
-  constructor
-  · intro h
-    exact (mem_simplex.mp (h (self_mem_simplex.mpr hV))).2
-  · exact fun h _ hσ => ⟨hσ.1, hσ.2.trans h⟩
+  simpa [mem_simplex, hV] using (simplex_le_iff (K := simplex W) hV)
 
 /-- Enlarging the spanning vertex set enlarges the simplex. -/
 theorem simplex_mono (h : V ⊆ W) : simplex V ≤ simplex W :=
@@ -148,7 +152,7 @@ theorem mem_simplexBoundary_iff_mem_simplex_ne :
   tauto
 
 /-- The faces of a simplex split into its boundary faces and its unique maximal face. -/
-theorem mem_simplex_iff_mem_boundary_or_eq :
+theorem mem_simplex_iff_mem_simplexBoundary_or_eq :
     σ ∈ simplex V ↔ σ ∈ simplexBoundary V ∨ V.Nonempty ∧ σ = V := by
   rw [mem_simplexBoundary_iff_mem_simplex_ne]
   constructor

--- a/TauCeti/AlgebraicTopology/SimplicialComplex/Simplex.lean
+++ b/TauCeti/AlgebraicTopology/SimplicialComplex/Simplex.lean
@@ -123,17 +123,24 @@ theorem simplexBoundary_singleton (v : ι) : simplexBoundary {v} = ⊥ := by
     exact hσ.1.ne_empty (Finset.ssubset_singleton_iff.mp hσ.2)
   · exact False.elim
 
-/-- The simplex on a nonempty spanning set is contained in a complex exactly when that spanning
-set is a face of the complex. -/
-theorem simplex_le_iff (hV : V.Nonempty) : simplex V ≤ K ↔ V ∈ K := by
+/-- The simplex on `V` is contained in a complex exactly when `V` is a face of the complex
+whenever `V` is nonempty.  For `V = ∅` the simplex is `⊥`, so it is contained in every complex. -/
+theorem simplex_le_iff : simplex V ≤ K ↔ (V.Nonempty → V ∈ K) := by
   constructor
-  · exact fun h => h (self_mem_simplex.mpr hV)
-  · exact fun hVₖ _ hσ => (K.isRelLowerSet_faces hVₖ).2 hσ.2 hσ.1
+  · exact fun h hV => h (self_mem_simplex.mpr hV)
+  · intro h σ hσ
+    obtain ⟨x, hx⟩ := hσ.1
+    exact (K.isRelLowerSet_faces (h ⟨x, hσ.2 hx⟩)).2 hσ.2 hσ.1
 
-/-- Simplices are ordered exactly when their spanning vertex sets are ordered, provided the
-smaller spanning set is nonempty. -/
-theorem simplex_le_simplex_iff (hV : V.Nonempty) : simplex V ≤ simplex W ↔ V ⊆ W := by
-  simpa [mem_simplex, hV] using (simplex_le_iff (K := simplex W) hV)
+/-- Simplices are ordered exactly when their spanning vertex sets are ordered. -/
+theorem simplex_le_simplex_iff : simplex V ≤ simplex W ↔ V ⊆ W := by
+  rw [simplex_le_iff]
+  constructor
+  · intro h
+    rcases V.eq_empty_or_nonempty with rfl | hV
+    · exact Finset.empty_subset W
+    · exact (mem_simplex.mp (h hV)).2
+  · exact fun h hV => mem_simplex.mpr ⟨hV, h⟩
 
 /-- Enlarging the spanning vertex set enlarges the simplex. -/
 theorem simplex_mono (h : V ⊆ W) : simplex V ≤ simplex W :=
@@ -145,13 +152,14 @@ theorem simplexBoundary_mono (h : V ⊆ W) : simplexBoundary V ≤ simplexBounda
   refine ⟨hσ.1, ?_⟩
   exact hσ.2.trans_le h
 
-/-- Every face of a simplex other than its maximal face lies in the boundary. -/
+/-- A face of a simplex lies in its boundary exactly when it is not the whole spanning set. -/
 theorem mem_simplexBoundary_iff_mem_simplex_ne :
     σ ∈ simplexBoundary V ↔ σ ∈ simplex V ∧ σ ≠ V := by
   simp only [mem_simplexBoundary, mem_simplex, Finset.ssubset_iff_subset_ne]
   tauto
 
-/-- The faces of a simplex split into its boundary faces and its unique maximal face. -/
+/-- The faces of a simplex are its boundary faces together with the spanning set itself, the
+latter only when the spanning set is nonempty. -/
 theorem mem_simplex_iff_mem_simplexBoundary_or_eq :
     σ ∈ simplex V ↔ σ ∈ simplexBoundary V ∨ V.Nonempty ∧ σ = V := by
   rw [mem_simplexBoundary_iff_mem_simplex_ne]

--- a/TauCeti/AlgebraicTopology/SimplicialComplex/Simplex.lean
+++ b/TauCeti/AlgebraicTopology/SimplicialComplex/Simplex.lean
@@ -64,17 +64,14 @@ theorem mem_simplexBoundary : σ ∈ simplexBoundary V ↔ σ.Nonempty ∧ σ �
   Iff.rfl
 
 /-- The spanning vertex set is a face of its simplex exactly when it is nonempty. -/
-@[simp]
 theorem self_mem_simplex : V ∈ simplex V ↔ V.Nonempty := by
   simp
 
 /-- The spanning vertex set is not a face of its own boundary. -/
-@[simp]
 theorem self_notMem_simplexBoundary : V ∉ simplexBoundary V := by
   simp
 
 /-- A vertex belongs to the spanning set exactly when its singleton is a face of the simplex. -/
-@[simp]
 theorem singleton_mem_simplex {v : ι} : {v} ∈ simplex V ↔ v ∈ V := by
   simp
 

--- a/TauCeti/AlgebraicTopology/SimplicialComplex/Simplex.lean
+++ b/TauCeti/AlgebraicTopology/SimplicialComplex/Simplex.lean
@@ -1,0 +1,168 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+module
+
+public import TauCeti.AlgebraicTopology.SimplicialComplex.Basic
+
+/-!
+# Abstract simplices and their boundaries
+
+This file defines the abstract simplex spanned by a finite set of vertices and its boundary.
+Both are `PreAbstractSimplicialComplex`es on the original ambient vertex type: this lets the
+construction remember exactly which vertices occur, unlike `AbstractSimplicialComplex`, which
+must contain every singleton of its ambient type.
+
+The boundary consists of the nonempty proper subsets of the spanning vertex set. These
+constructions provide the standard models needed for the recursive definitions of combinatorial
+spheres and balls in layer 11 of the geometric-topology roadmap.
+
+The definitions follow Rourke--Sanderson, *Introduction to Piecewise-Linear Topology*, Chapter 2.
+
+## Main definitions
+
+* `PreAbstractSimplicialComplex.simplex`: the complex of nonempty subsets of a finite vertex set.
+* `PreAbstractSimplicialComplex.simplexBoundary`: its proper faces.
+-/
+
+public section
+
+namespace TauCeti
+
+namespace PreAbstractSimplicialComplex
+
+variable {ι : Type*}
+
+/-- The abstract simplex spanned by `V`: its faces are the nonempty subsets of `V`. -/
+def simplex (V : Finset ι) : _root_.PreAbstractSimplicialComplex ι where
+  faces := {σ | σ.Nonempty ∧ σ ⊆ V}
+  isRelLowerSet_faces := by
+    rintro σ ⟨hσ, hσV⟩
+    exact ⟨hσ, fun _ hτσ hτ => ⟨hτ, hτσ.trans hσV⟩⟩
+
+/-- The boundary of the abstract simplex spanned by `V`: its faces are the nonempty proper
+subsets of `V`. -/
+def simplexBoundary (V : Finset ι) : _root_.PreAbstractSimplicialComplex ι where
+  faces := {σ | σ.Nonempty ∧ σ ⊂ V}
+  isRelLowerSet_faces := by
+    rintro σ ⟨hσ, hσV⟩
+    refine ⟨hσ, fun _ hτσ hτ => ⟨hτ, hτσ.trans_ssubset hσV⟩⟩
+
+variable {V W σ : Finset ι}
+
+/-- A finite set is a face of a simplex exactly when it is nonempty and contained in the
+spanning vertex set. -/
+@[simp]
+theorem mem_simplex : σ ∈ simplex V ↔ σ.Nonempty ∧ σ ⊆ V :=
+  Iff.rfl
+
+/-- A finite set is a face of a simplex boundary exactly when it is a nonempty proper subset of
+the spanning vertex set. -/
+@[simp]
+theorem mem_simplexBoundary : σ ∈ simplexBoundary V ↔ σ.Nonempty ∧ σ ⊂ V :=
+  Iff.rfl
+
+/-- The spanning vertex set is a face of its simplex exactly when it is nonempty. -/
+@[simp]
+theorem self_mem_simplex : V ∈ simplex V ↔ V.Nonempty := by
+  simp
+
+/-- The spanning vertex set is not a face of its own boundary. -/
+@[simp]
+theorem self_notMem_simplexBoundary : V ∉ simplexBoundary V := by
+  simp
+
+/-- A vertex belongs to the spanning set exactly when its singleton is a face of the simplex. -/
+@[simp]
+theorem singleton_mem_simplex {v : ι} : {v} ∈ simplex V ↔ v ∈ V := by
+  simp
+
+/-- A singleton is a boundary face exactly when its vertex belongs to a spanning set containing
+at least one other vertex. -/
+theorem singleton_mem_simplexBoundary_iff {v : ι} :
+    {v} ∈ simplexBoundary V ↔ v ∈ V ∧ V ≠ {v} := by
+  simp only [mem_simplexBoundary, Finset.singleton_nonempty, true_and]
+  rw [Finset.ssubset_iff_subset_ne, Finset.singleton_subset_iff]
+  constructor
+  · exact fun ⟨hv, hne⟩ => ⟨hv, hne.symm⟩
+  · exact fun ⟨hv, hne⟩ => ⟨hv, hne.symm⟩
+
+/-- The boundary is a subcomplex of the simplex. -/
+theorem simplexBoundary_le_simplex : simplexBoundary V ≤ simplex V :=
+  fun _ hσ => ⟨hσ.1, hσ.2.subset⟩
+
+/-- A nonempty simplex boundary is a strict subcomplex of its simplex. -/
+theorem simplexBoundary_lt_simplex (hV : V.Nonempty) : simplexBoundary V < simplex V := by
+  refine lt_of_le_of_ne simplexBoundary_le_simplex ?_
+  intro h
+  have : V ∈ simplexBoundary V := h ▸ (self_mem_simplex.mpr hV : V ∈ simplex V)
+  exact self_notMem_simplexBoundary this
+
+/-- The simplex on the empty spanning set has no faces. -/
+@[simp]
+theorem simplex_empty : simplex (∅ : Finset ι) = ⊥ := by
+  ext σ
+  constructor
+  · intro hσ
+    exact hσ.1.ne_empty (Finset.subset_empty.mp hσ.2)
+  · exact False.elim
+
+/-- The boundary of the empty simplex has no faces. -/
+@[simp]
+theorem simplexBoundary_empty : simplexBoundary (∅ : Finset ι) = ⊥ := by
+  ext σ
+  constructor
+  · intro hσ
+    exact hσ.1.ne_empty (Finset.subset_empty.mp hσ.2.subset)
+  · exact False.elim
+
+/-- The boundary of a one-vertex simplex is empty. -/
+@[simp]
+theorem simplexBoundary_singleton (v : ι) : simplexBoundary {v} = ⊥ := by
+  ext σ
+  constructor
+  · intro hσ
+    exact hσ.1.ne_empty (Finset.ssubset_singleton_iff.mp hσ.2)
+  · exact False.elim
+
+/-- Simplices are ordered exactly when their spanning vertex sets are ordered, provided the
+smaller spanning set is nonempty. -/
+theorem simplex_le_simplex_iff (hV : V.Nonempty) : simplex V ≤ simplex W ↔ V ⊆ W := by
+  constructor
+  · intro h
+    exact (mem_simplex.mp (h (self_mem_simplex.mpr hV))).2
+  · exact fun h _ hσ => ⟨hσ.1, hσ.2.trans h⟩
+
+/-- Enlarging the spanning vertex set enlarges the simplex. -/
+theorem simplex_mono (h : V ⊆ W) : simplex V ≤ simplex W :=
+  fun _ hσ => ⟨hσ.1, hσ.2.trans h⟩
+
+/-- Enlarging the spanning vertex set enlarges the boundary. -/
+theorem simplexBoundary_mono (h : V ⊆ W) : simplexBoundary V ≤ simplexBoundary W := by
+  intro σ hσ
+  refine ⟨hσ.1, ?_⟩
+  exact hσ.2.trans_le h
+
+/-- Every face of a simplex other than its maximal face lies in the boundary. -/
+theorem mem_simplexBoundary_iff_mem_simplex_ne :
+    σ ∈ simplexBoundary V ↔ σ ∈ simplex V ∧ σ ≠ V := by
+  simp only [mem_simplexBoundary, mem_simplex, Finset.ssubset_iff_subset_ne]
+  tauto
+
+/-- The faces of a simplex split into its boundary faces and its unique maximal face. -/
+theorem mem_simplex_iff_mem_boundary_or_eq :
+    σ ∈ simplex V ↔ σ ∈ simplexBoundary V ∨ V.Nonempty ∧ σ = V := by
+  rw [mem_simplexBoundary_iff_mem_simplex_ne]
+  constructor
+  · intro hσ
+    rcases eq_or_ne σ V with rfl | hne
+    · exact Or.inr ⟨hσ.1, rfl⟩
+    · exact Or.inl ⟨hσ, hne⟩
+  · rintro (⟨hσ, -⟩ | ⟨hV, rfl⟩)
+    · exact hσ
+    · exact self_mem_simplex.mpr hV
+
+end PreAbstractSimplicialComplex
+
+end TauCeti


### PR DESCRIPTION
This PR defines the abstract simplex spanned by a finite vertex set and its boundary, as `PreAbstractSimplicialComplex`es on the ambient vertex type: `PreAbstractSimplicialComplex.simplex V` has the nonempty subsets of `V` as faces, and `PreAbstractSimplicialComplex.simplexBoundary V` its nonempty proper subsets. Alongside the definitions come the membership `simp` lemmas, the degenerate cases (empty and singleton spanning sets), monotonicity in the spanning set, `simplexBoundary_le_simplex` and its strictness for nonempty `V`, and the decomposition of a simplex's faces into boundary faces plus the unique maximal face. These are the standard models that the recursive definitions of combinatorial spheres and balls need in layer 11 of the geometric-topology roadmap ("Layer 11: triangulations, PL structures, and collapse", `TauCetiRoadmap/GeometricTopology/README.md`). The definitions follow Rourke–Sanderson, *Introduction to Piecewise-Linear Topology*, Chapter 2; no Mathlib infrastructure was vendored. One new module, `TauCeti/AlgebraicTopology/SimplicialComplex/Simplex.lean` (168 lines); `lake build` completed successfully (5201 jobs) and `lake exe axioms` audited all declarations within the allowlist on the pinned toolchain.

<!--tauceti-target:v1 {"focus":"GeometricTopology","id":"abstract-simplex-boundary"}-->

🤖 Prepared with Codex
