### PR TITLE
feat: alert stuck automation to a Zulip emergency topic

### DIFF
--- a/.github/workflows/stuck-alerts.yml
+++ b/.github/workflows/stuck-alerts.yml
@@ -1,0 +1,52 @@
+name: Stuck-automation alerts
+
+# Post EMERGENCY alerts to Zulip (Tau Ceti > "Stuck PRs") when a piece of Tau
+# Ceti's own automation wedged and cannot unstick itself: a bump that will not
+# cross a breaking change, a green PR the merge machinery never merged, a
+# scheduled job that stopped firing, main gone red, an unresolved mathlib
+# incompatibility. Every alert means "go FIX THE INFRASTRUCTURE", not "a human
+# please hand-hold one PR" — see scripts/zulip/stuck_alerts.py for the full
+# contract and the list of states deliberately NOT alerted (normal backlog).
+#
+# The alerts live in Zulip and are idempotent (one message per active alert,
+# edited to a checkmark when it clears), so the run's own red/green is NOT the
+# signal: a run that checks and posts successfully is green even with ten alerts
+# open. Only a persistent Zulip config break (bad key, forbidden bot, not
+# subscribed) fails the run — if we cannot post, the emergency channel itself is
+# down and that must be loud (mirrors zulip-healthcheck.yml).
+
+on:
+  schedule:
+  - cron: "50 * * * *"   # hourly, offset from merge-sweep (:40) and housekeeping (:20)
+  workflow_dispatch: {}
+
+permissions:
+  contents: read          # checkout the script
+  issues: read            # review-stuck / first-known-bad issues
+  pull-requests: read     # stuck-bump / stranded-PR detection
+  actions: read           # dead-scheduler / main-red (workflow runs)
+  statuses: read          # build / bump-guard commit statuses
+  checks: read
+
+concurrency:
+  group: stuck-alerts
+  cancel-in-progress: true
+
+jobs:
+  stuck-alerts:
+    if: github.repository == 'TauCetiProject/TauCeti'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          sparse-checkout: scripts/zulip
+      - name: Reconcile stuck-automation alerts
+        # No continue-on-error: a broken Zulip integration must go red here too.
+        env:
+          GH_TOKEN: ${{ github.token }}
+          ZULIP_API_KEY: ${{ secrets.ZULIP_API_KEY }}
+          ZULIP_EMAIL: ${{ secrets.ZULIP_EMAIL }}
+          ZULIP_SITE: https://leanprover.zulipchat.com
+          ZULIP_CHANNEL: Tau Ceti
+          ZULIP_TOPIC: Stuck PRs
+        run: python3 scripts/zulip/stuck_alerts.py

--- a/.github/workflows/stuck-alerts.yml
+++ b/.github/workflows/stuck-alerts.yml
@@ -14,6 +14,11 @@ name: Stuck-automation alerts
 # open. Only a persistent Zulip config break (bad key, forbidden bot, not
 # subscribed) fails the run — if we cannot post, the emergency channel itself is
 # down and that must be loud (mirrors zulip-healthcheck.yml).
+#
+# Known limitation: a watchdog cannot fully watch itself — if THIS workflow's own
+# cron stops firing (GitHub 60-day disable, org-level pause), it cannot alert on
+# its own silence. That gap is best closed by an external check (e.g. teaching
+# zulip-healthcheck.yml to assert stuck-alerts ran recently); left as a follow-up.
 
 on:
   schedule:
@@ -30,12 +35,15 @@ permissions:
 
 concurrency:
   group: stuck-alerts
-  cancel-in-progress: true
+  # Don't cancel a run mid-post: cancelling while it is editing/sending Zulip
+  # messages could leave the topic half-reconciled. timeout-minutes bounds a hung run.
+  cancel-in-progress: false
 
 jobs:
   stuck-alerts:
     if: github.repository == 'TauCetiProject/TauCeti'
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - uses: actions/checkout@v4
         with:

--- a/scripts/zulip/README.md
+++ b/scripts/zulip/README.md
@@ -36,6 +36,30 @@ Three workflows drive it:
   schedule (every 6h) that runs `check` to probe the credentials, so a broken
   key is caught even during quiet periods with no PR activity.
 
+## Stuck-automation alerts (Tau Ceti > "Stuck PRs")
+
+[`stuck_alerts.py`](stuck_alerts.py), driven by
+[`stuck-alerts.yml`](../../.github/workflows/stuck-alerts.yml) hourly, posts to a
+second topic — **Stuck PRs** — whenever Tau Ceti's own automation wedges and
+cannot recover on its own. It reuses this directory's Zulip client (pointed at
+the topic via `ZULIP_TOPIC`) and is idempotent the same way: one bot message per
+active alert, tagged with a hidden `<!--stuck:v1 <key>-->` marker, edited to a
+✅ checkmark when the situation clears and never re-posted while it persists.
+
+This is an **emergency channel, not a help queue.** Every alert means a piece of
+infrastructure needs fixing so the wedge cannot recur — not that a human should
+hand-hold one PR. It fires on: a red, stale last-known-good bump PR; a mathlib pin
+that has stopped advancing; an in-scope, fully-green PR the merge path never
+merged; an open `Review stuck: PR #…` issue; a scheduled workflow that is disabled
+or overdue; `main` gone red; and a long-open mathlib-incompatibility issue. It
+**deliberately does not** alert on normal backlog (a PR awaiting its first review
+verdict, changes-requested nobody addressed, open roadmap issues) — the module
+docstring lists the full catalogue and the reasoning.
+
+Run `python3 scripts/zulip/stuck_alerts.py --dry-run` (with `gh` authenticated) to
+print the alerts it would post without touching Zulip. Its run goes red only on a
+persistent Zulip config break, exactly like the healthcheck.
+
 ## One-time setup
 
 1. **Create a dedicated Zulip bot** (Zulip → Settings → Bots → Add a new bot,

--- a/scripts/zulip/stuck_alerts.py
+++ b/scripts/zulip/stuck_alerts.py
@@ -1,0 +1,503 @@
+#!/usr/bin/env python3
+"""Post *stuck-automation* alerts to a dedicated Zulip topic (Tau Ceti > Stuck PRs).
+
+This is an EMERGENCY channel, not a "ask the humans for help" queue. Every alert
+here means a piece of Tau Ceti's own automation was supposed to make progress and
+could not unstick itself: a bump that will not cross a breaking change, a green PR
+the merge machinery never merged, a scheduled job that stopped firing, main gone
+red. The expected response to any alert is to FIX THE INFRASTRUCTURE (a script, a
+workflow, a pin, a guard) so the situation cannot recur -- not to hand-hold one PR
+and move on. If an alert can only ever be resolved by a human doing a one-off
+favour, it does not belong here; see the "deliberately NOT alerted" list below.
+
+Detectors (each names the infra failure it implies):
+
+  1. stuck-bump      The last-known-good bump PR (branch hopscotch/lkg-bump) has a
+                     RED `build` check and has been open >=24h. The daily bump
+                     cannot cross a mathlib breaking change on its own; something
+                     (a proof, scripts/lint-env.sh, a guard) needs a human fix.
+  2. stale-pin       main's mathlib pin is >=4 days old. The bump has stopped
+                     advancing (a wedged PR, an unresolved first-known-bad freeze,
+                     or update.yml silently broken).
+  3. stranded-pr     A PR that is in-scope (TauCeti/ + allowed roots, bump-guard
+                     green for any pin change), `build` green, every blocking
+                     rubric green at HEAD, not draft/hold, yet unmerged >=6h
+                     (~6 merge-sweep cycles). auto-merge / the queue / merge-sweep
+                     is broken.
+  4. review-stuck    An open issue titled "Review stuck: PR #...": the review
+                     engine self-flagged a PR it cannot resolve.
+  5. dead-scheduler  A scheduled workflow is `disabled`, or its last run is older
+                     than its cadence + slack. GitHub disabled the cron (60-day
+                     inactivity), or it errors at dispatch.
+  6. main-red        main's latest CI run concluded `failure`. The "main is always
+                     green" invariant is broken.
+  7. stale-fkb       A first-known-bad / mathlib-incompatibility tracking issue
+                     (bot-authored) has been open >=3 days. A regression against
+                     TauCeti nobody has landed the fix for.
+
+Deliberately NOT alerted (normal backlog, not stuck automation -- alerting on
+these would cheapen the topic and train people to ignore it):
+  * a PR awaiting its first review verdict -- CI review generation is off by
+    default (CI_REVIEW_ENABLED); reviews are run by humans / the worker on their
+    own cadence, so "no verdict yet" is expected, not stuck;
+  * a PR with changes-requested that nobody addressed -- housekeeping.py retires
+    these after STALE_DAYS;
+  * open roadmap / help-wanted issues -- that IS the ask-the-humans queue.
+
+Idempotent, like zulip_pr_status.py: exactly one bot-owned message per active
+alert key, tagged with a hidden `<!--stuck:v1 <key>-->` marker. Each run
+reconciles the topic against the live GitHub state -- a new alert posts a message,
+an alert that has cleared has its message edited to a resolved (checkmark) form,
+and an unchanged alert is left exactly as-is (so a persisting emergency is not
+re-posted every hour). Editing never notifies; only a genuinely NEW alert makes a
+new message appear. There are no @-mentions (the topic is watched, not pinged).
+
+Run status mirrors the healthcheck philosophy: the ALERTS are the signal, not the
+run's red/green, so a run that successfully checks and posts exits 0 even when it
+raised ten alerts. Only a persistent Zulip CONFIG break (bad key, forbidden bot,
+not subscribed) fails the run loudly -- if we cannot post, the emergency channel
+itself is down, and that must not be silent.
+
+Usage:
+    stuck_alerts.py            # reconcile all detectors against the topic
+    stuck_alerts.py --dry-run  # print the alerts it would post; touch no Zulip
+
+Environment:
+    ZULIP_API_KEY, ZULIP_EMAIL, ZULIP_SITE   bot credentials (required)
+    ZULIP_CHANNEL                            default "Tau Ceti"
+    ZULIP_TOPIC                              default "Stuck PRs"
+    GH_REPO                                  default "TauCetiProject/TauCeti"
+    GH_TOKEN / GITHUB_TOKEN                  used by `gh` for the GitHub API
+
+Only python3's standard library and an authenticated `gh` CLI are required.
+The Zulip client, credential handling, and sanitizer are reused verbatim from
+zulip_pr_status.py (same package dir); this file adds only the detectors and the
+alert-reconciliation loop. Pointing that shared client at a different topic is the
+module's own documented mechanism: ZULIP_TOPIC (set to "Stuck PRs" by the
+stuck-alerts workflow) is read at import, so send/find target this topic.
+"""
+
+import base64
+import datetime
+import json
+import os
+import re
+import sys
+
+# Reuse the proven Zulip client + helpers. Because ZULIP_TOPIC is read at import
+# time, the workflow sets it to "Stuck PRs" and every send/narrow below targets
+# this topic without any change to zulip_pr_status.py.
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+import zulip_pr_status as zp  # noqa: E402
+
+REPO = zp.REPO
+MARKER_RE = re.compile(r"<!--stuck:v1 ([^>]+)-->")
+LKG_BRANCH = "hopscotch/lkg-bump"  # keep in sync with update.yml's LKG_BRANCH
+
+# --- thresholds (hours unless noted) -----------------------------------------
+# Each scheduler threshold is ~2-3x the workflow's cadence, generous enough to
+# ride out GitHub's routine scheduled-run delays without false-firing.
+BUMP_STUCK_HOURS = 24
+PIN_STALE_DAYS = 4
+STRANDED_HOURS = 6
+FKB_STALE_DAYS = 3
+SCHEDULERS = {
+    # workflow file            (human name,               max age hours)
+    "update.yml":            ("daily mathlib bump",       30),
+    "pages.yml":             ("pages / doc-gen publish",  30),
+    "housekeeping.yml":      ("queue housekeeping",        7),
+    "zulip-healthcheck.yml": ("zulip healthcheck",        15),
+    "merge-sweep.yml":       ("merge sweep",               4),
+}
+# A PR carrying any of these labels is intentionally parked; never "stranded".
+HOLD_LABELS = {"keep", "hold", "wip", "human", "do-not-close", "blocked"}
+# First-known-bad / incompatibility tracking issue, bot-authored. Heuristic:
+# confirm against the first real occurrence and tighten if it over/under-matches.
+FKB_AUTHOR_PREFIX = "tauceti-review-bot"
+FKB_TITLE_RE = re.compile(r"incompat|first[- ]known[- ]bad|known[- ]bad", re.I)
+
+
+def now_utc():
+    # new Date() / Date.now() are fine in plain python; the workflow runs live.
+    return datetime.datetime.now(datetime.timezone.utc)
+
+
+def parse_ts(s):
+    """Parse a GitHub ISO-8601 UTC timestamp (e.g. 2026-07-20T19:06:08Z)."""
+    return datetime.datetime.fromisoformat(s.replace("Z", "+00:00"))
+
+
+def hours_since(s):
+    return (now_utc() - parse_ts(s)).total_seconds() / 3600.0
+
+
+def gh_json(path, jq=None, paginate=False):
+    """gh_api for a jq that yields a JSON object or array (parsed and returned).
+
+    `gh --jq` prints an object/array as JSON, so json.loads applies. Do NOT use
+    this for a scalar/string jq result -- gh prints those RAW (unquoted), which is
+    not JSON; use gh_scalar for those. Returns None on empty output.
+    """
+    out = zp.gh_api(path, jq=jq, paginate=paginate).strip()
+    if not out:
+        return None
+    return json.loads(out)
+
+
+def gh_scalar(path, jq, paginate=False):
+    """gh_api for a jq that yields a scalar/string, returned as a stripped str.
+
+    Mirrors how zulip_pr_status reads statuses: `gh --jq '.foo // ""'` prints the
+    raw string value, so we take it as text (never json.loads it)."""
+    return zp.gh_api(path, jq=jq, paginate=paginate).strip()
+
+
+def build_status(head):
+    """(state, updated_at) of the newest `build` commit status, or (None, None).
+
+    state is the raw GitHub status state: pending|success|failure|error.
+    """
+    rows = gh_json(
+        f"/repos/{REPO}/commits/{head}/statuses",
+        jq='[.[] | select(.context == "build")] | sort_by(.updated_at)'
+           ' | last | {state: (.state // ""), updated_at: (.updated_at // "")}',
+    )
+    if not rows or not rows.get("state"):
+        return None, None
+    return rows["state"], rows["updated_at"] or None
+
+
+def status_state(head, context):
+    """Newest commit-status state for `context` on `head` ("" if none)."""
+    return gh_scalar(
+        f"/repos/{REPO}/commits/{head}/statuses",
+        jq=f'[.[] | select(.context == "{context}")] | sort_by(.updated_at)'
+           ' | last | .state // ""',
+    )
+
+
+# ----- detectors --------------------------------------------------------------
+# Each returns a list of alert dicts {key, title, body}. `key` is stable across
+# runs so the same ongoing situation reconciles to the same Zulip message.
+
+def detect_stuck_bump():
+    prs = gh_json(
+        f"/repos/{REPO}/pulls?state=open&head=TauCetiProject:{LKG_BRANCH}&per_page=5",
+        jq='[.[] | {number, head: .head.sha, created_at}]',
+    ) or []
+    out = []
+    for pr in prs:
+        state, _ = build_status(pr["head"])
+        if state in ("failure", "error") and hours_since(pr["created_at"]) >= BUMP_STUCK_HOURS:
+            age = int(hours_since(pr["created_at"]) // 24)
+            out.append({
+                "key": f"stuck-bump/{pr['number']}",
+                "title": f"Mathlib bump wedged — PR #{pr['number']} build red",
+                "body": (
+                    f"The last-known-good bump PR "
+                    f"https://github.com/{REPO}/pull/{pr['number']} has a red `build` "
+                    f"check and has been open ~{age}d. The daily bump cannot cross a "
+                    f"mathlib breaking change on its own.\n\n"
+                    f"**Fix:** open the failing build, land the fix it needs (a proof, "
+                    f"`scripts/lint-env.sh`, a guard) together with the pin move in one "
+                    f"human-owned PR, so the bump can resume."),
+            })
+    return out
+
+
+def detect_stale_pin():
+    # Staleness is "how long since the pin last MOVED", not the age of the pinned
+    # commit: right after a bump to an LKG commit that itself lags master, the
+    # pinned commit can be days old while the bump is perfectly healthy. The daily
+    # bump rewrites lake-manifest.json whenever mathlib advances, so the manifest's
+    # last-change date on main is a direct proxy for the bump cadence.
+    date = gh_scalar(f"/repos/{REPO}/commits?path=lake-manifest.json&sha=main&per_page=1",
+                     jq='.[0].commit.committer.date // ""')
+    if not date:
+        return []
+    days = hours_since(date) / 24.0
+    if days < PIN_STALE_DAYS:
+        return []
+    rev = ""
+    content = gh_scalar(f"/repos/{REPO}/contents/lake-manifest.json?ref=main", jq='.content')
+    if content:
+        try:  # contents is base64 with embedded newlines; b64decode discards them
+            data = json.loads(base64.b64decode(content).decode())
+            rev = next((p["rev"] for p in data.get("packages", [])
+                        if p["name"] == "mathlib"), "")
+        except Exception:
+            rev = ""
+    pin = f" (mathlib `{rev[:10]}`)" if rev else ""
+    return [{
+        "key": "stale-pin",
+        "title": f"Mathlib pin has not moved in {int(days)}d",
+        "body": (
+            f"`lake-manifest.json` on main{pin} last changed ~{int(days)}d ago; the "
+            f"daily bump has stopped advancing.\n\n"
+            f"**Fix:** find why — a wedged bump PR (see any stuck-bump alert), an "
+            f"unresolved first-known-bad freeze, or `update.yml` failing — and clear "
+            f"it so `hopscotch/lkg-bump` can move forward again."),
+    }]
+
+
+def detect_stranded_prs():
+    prs = gh_json(
+        f"/repos/{REPO}/pulls?state=open&base=main&per_page=100",
+        jq='[.[] | {number, head: .head.sha, draft, '
+           'labels: [.labels[].name], title}]',
+        paginate=True,
+    ) or []
+    out = []
+    for pr in prs:
+        if pr.get("draft"):
+            continue
+        if HOLD_LABELS.intersection(n.lower() for n in pr.get("labels", [])):
+            continue
+        head = pr["head"]
+        state, updated = build_status(head)
+        if state != "success" or not updated or hours_since(updated) < STRANDED_HOURS:
+            continue
+        # Every blocking rubric green AT HEAD (mirrors auto-merge's ledger read).
+        if zp.review_emoji(zp.scoreboard_meta(pr["number"]), head) != "check":
+            continue
+        # In-scope: TauCeti/ + allowed roots only; a human-owned path legitimately
+        # does not auto-merge, so it is NOT stranded. Fail closed on any doubt.
+        files = gh_json(f"/repos/{REPO}/pulls/{pr['number']}/files?per_page=300",
+                        jq='[.[].filename]', paginate=True) or []
+        if not files:
+            continue
+        allowed_roots = {"TauCeti.lean", "lake-manifest.json", "lean-toolchain"}
+        touches_pin = any(f in ("lake-manifest.json", "lean-toolchain") for f in files)
+        if not all(f.startswith("TauCeti/") or f in allowed_roots for f in files):
+            continue
+        # A pin change must have bump-guard green, exactly as the merge gate requires.
+        if touches_pin and status_state(head, "bump-guard") != "success":
+            continue
+        age = int(hours_since(updated))
+        out.append({
+            "key": f"stranded-pr/{pr['number']}",
+            "title": f"Green PR not merging — #{pr['number']}",
+            "body": (
+                f"https://github.com/{REPO}/pull/{pr['number']} is in-scope, `build` "
+                f"green, and every blocking rubric green at HEAD, yet has sat unmerged "
+                f"~{age}h while merge-sweep runs hourly.\n\n"
+                f"**Fix:** the merge path is broken — check `auto-merge.yml`, the merge "
+                f"queue, and `merge-sweep.yml` (and the pinned TauCetiReview merge-only "
+                f"/ merge-sweep workflow) for why a ready PR is not being taken."),
+        })
+    return out
+
+
+def detect_review_stuck():
+    issues = gh_json(
+        f"/repos/{REPO}/issues?state=open&per_page=100",
+        jq='[.[] | select(.pull_request == null) '
+           '| select(.title | test("^Review stuck")) | {number, title}]',
+        paginate=True,
+    ) or []
+    return [{
+        "key": f"review-stuck/{i['number']}",
+        "title": zp.zulip_sanitize(i["title"]),
+        "body": (
+            f"The review engine self-flagged a PR it cannot resolve: "
+            f"https://github.com/{REPO}/issues/{i['number']}\n\n"
+            f"**Fix:** this is not a one-off review to nudge — the engine hit a state "
+            f"it has no rule for (a rubric contradiction, an error loop). Fix the "
+            f"review logic / rubric in TauCetiReview so it cannot re-wedge."),
+    } for i in issues]
+
+
+def detect_dead_schedulers():
+    out = []
+    for wf, (name, max_hours) in SCHEDULERS.items():
+        meta = gh_json(f"/repos/{REPO}/actions/workflows/{wf}",
+                       jq='{state: (.state // ""), id: .id}')
+        if not meta or not meta.get("state"):
+            continue
+        if meta["state"] != "active":
+            out.append({
+                "key": f"dead-scheduler/{wf}",
+                "title": f"Scheduler disabled — {name}",
+                "body": (
+                    f"`{wf}` is `{meta['state']}` (GitHub disables a cron after 60 days "
+                    f"of repo inactivity, or on repeated failure).\n\n"
+                    f"**Fix:** re-enable it (`gh workflow enable {wf}`) and address the "
+                    f"underlying cause so it stays scheduled."),
+            })
+            continue
+        last = gh_scalar(
+            f"/repos/{REPO}/actions/workflows/{wf}/runs?per_page=1",
+            jq='.workflow_runs[0].created_at // ""')
+        if not last:
+            continue
+        age = hours_since(last)
+        if age >= max_hours:
+            out.append({
+                "key": f"dead-scheduler/{wf}",
+                "title": f"Scheduler stalled — {name}",
+                "body": (
+                    f"`{wf}` last ran ~{int(age)}h ago (cadence + slack is {max_hours}h). "
+                    f"Its schedule has stopped firing.\n\n"
+                    f"**Fix:** check the Actions tab for a dispatch error or an org-level "
+                    f"disable; restore the cron so `{name}` runs on cadence again."),
+            })
+    return out
+
+
+def detect_main_red():
+    run = gh_json(
+        f"/repos/{REPO}/actions/workflows/ci.yml/runs?branch=main&status=completed&per_page=1",
+        jq='.workflow_runs[0] | {conclusion: (.conclusion // ""), sha: (.head_sha // "")}')
+    if not run or run.get("conclusion") != "failure":
+        return []
+    sha = run.get("sha") or ""
+    return [{
+        "key": "main-red",
+        "title": "main is RED",
+        "body": (
+            f"The latest CI run on `main` (`{sha[:10]}`) concluded `failure`. The "
+            f"\"main is always green\" invariant is broken.\n\n"
+            f"**Fix:** identify the merge or environment change that broke it and land a "
+            f"revert or forward-fix immediately — a red main blocks every bump and merge."),
+    }]
+
+
+def detect_stale_fkb():
+    issues = gh_json(
+        f"/repos/{REPO}/issues?state=open&per_page=100",
+        jq='[.[] | select(.pull_request == null) '
+           '| {number, title, created_at, author: (.user.login // "")}]',
+        paginate=True,
+    ) or []
+    out = []
+    for i in issues:
+        if not i["author"].startswith(FKB_AUTHOR_PREFIX):
+            continue
+        if not FKB_TITLE_RE.search(i["title"]):
+            continue
+        if hours_since(i["created_at"]) / 24.0 < FKB_STALE_DAYS:
+            continue
+        days = int(hours_since(i["created_at"]) / 24.0)
+        out.append({
+            "key": f"stale-fkb/{i['number']}",
+            "title": f"Mathlib incompatibility unresolved {days}d — #{i['number']}",
+            "body": (
+                f"A first-known-bad tracking issue has been open ~{days}d: "
+                f"https://github.com/{REPO}/issues/{i['number']}. The pin is frozen at "
+                f"the last-known-good commit until this is fixed.\n\n"
+                f"**Fix:** land the fix PR pinned at the first-known-bad commit so the "
+                f"freeze lifts and the daily bump resumes toward master."),
+        })
+    return out
+
+
+DETECTORS = [
+    detect_stuck_bump, detect_stale_pin, detect_stranded_prs, detect_review_stuck,
+    detect_dead_schedulers, detect_main_red, detect_stale_fkb,
+]
+
+
+def collect_alerts():
+    """Run every detector; a detector that errors is logged and skipped so one
+    flaky GitHub call cannot suppress every other alert."""
+    alerts = []
+    for det in DETECTORS:
+        try:
+            alerts.extend(det() or [])
+        except Exception as exc:  # transient API/parse hiccup in one detector
+            zp.log(f"detector {det.__name__} failed (non-fatal): {exc}")
+    return alerts
+
+
+# ----- reconcile against the topic -------------------------------------------
+
+def alert_content(a):
+    return f"\U0001f534 **{a['title']}**\n\n{a['body']}\n\n<!--stuck:v1 {a['key']}-->"
+
+
+def resolved_content(message):
+    """Rewrite an existing alert message to its cleared form, keeping the marker
+    so future runs recognise it as already-resolved and leave it alone."""
+    body = message["content"]
+    m = MARKER_RE.search(body)
+    key = m.group(1) if m else "?"
+    # Keep the original title line for context; swap the red circle for a check.
+    title = "(cleared)"
+    for line in body.splitlines():
+        if line.startswith("\U0001f534 **") or line.startswith("**"):
+            title = line.split("**")[1] if "**" in line else title
+            break
+    return (f"✅ **{title}** — cleared\n\n_No longer active as of the latest "
+            f"check._\n\n<!--stuck:v1 {key}-->")
+
+
+def reconcile(z, alerts, dry_run):
+    bot_id = z.my_user_id()
+    msgs = z.get_messages([
+        {"operator": "channel", "operand": zp.CHANNEL},
+        {"operator": "topic", "operand": zp.TOPIC},
+    ])
+    existing = {}
+    for m in msgs:
+        if m["sender_id"] != bot_id:
+            continue
+        mk = MARKER_RE.search(m["content"])
+        if mk:
+            existing[mk.group(1)] = m
+
+    active = {a["key"]: a for a in alerts}
+
+    for key, a in active.items():
+        content = alert_content(a)
+        msg = existing.get(key)
+        if msg is None:
+            zp.log(f"NEW alert {key}: {a['title']}")
+            if not dry_run:
+                z.send_message(content)
+        elif msg["content"] != content:
+            # Content drifted (title/body wording changed, or it was resolved and
+            # has re-fired); refresh in place so it reads correctly, no re-ping.
+            zp.log(f"refresh alert {key}")
+            if not dry_run:
+                z.update_message(msg["id"], content)
+        else:
+            zp.log(f"ongoing alert {key} (unchanged)")
+
+    for key, msg in existing.items():
+        if key in active:
+            continue
+        if msg["content"].startswith("✅"):
+            continue  # already marked resolved
+        zp.log(f"RESOLVED alert {key}")
+        if not dry_run:
+            z.update_message(msg["id"], resolved_content(msg))
+
+
+def main(argv):
+    dry_run = "--dry-run" in argv[1:]
+
+    alerts = collect_alerts()
+    zp.log(f"{len(alerts)} active alert(s): {sorted(a['key'] for a in alerts)}")
+
+    email = (os.environ.get("ZULIP_EMAIL") or "").strip()
+    api_key = (os.environ.get("ZULIP_API_KEY") or "").strip()
+    site = (os.environ.get("ZULIP_SITE") or "https://leanprover.zulipchat.com").strip()
+    if dry_run and not (email and api_key):
+        for a in alerts:
+            print("\n" + alert_content(a))
+        return 0
+    if not (email and api_key):
+        return zp.fail_config("ZULIP_EMAIL / ZULIP_API_KEY not set (no bot configured)")
+
+    z = zp.Zulip(email, api_key, site)
+    try:
+        reconcile(z, alerts, dry_run)
+    except zp.ConfigError as exc:  # emergency channel itself is down: fail loud
+        return zp.fail_config(str(exc))
+    except Exception as exc:  # a transient Zulip hiccup is cosmetic; self-heals
+        zp.log(f"reconcile failed (non-fatal): {exc}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv))

--- a/scripts/zulip/stuck_alerts.py
+++ b/scripts/zulip/stuck_alerts.py
@@ -13,27 +13,26 @@ favour, it does not belong here; see the "deliberately NOT alerted" list below.
 Detectors (each names the infra failure it implies):
 
   1. stuck-bump      The last-known-good bump PR (branch hopscotch/lkg-bump) has a
-                     RED `build` check and has been open >=24h. The daily bump
-                     cannot cross a mathlib breaking change on its own; something
-                     (a proof, scripts/lint-env.sh, a guard) needs a human fix.
-  2. stale-pin       main's mathlib pin is >=4 days old. The bump has stopped
-                     advancing (a wedged PR, an unresolved first-known-bad freeze,
-                     or update.yml silently broken).
+                     RED `build` check that has stayed red past a grace window. The
+                     daily bump cannot cross a mathlib breaking change on its own;
+                     something (a proof, scripts/lint-env.sh, a guard) needs a fix.
+  2. stale-pin       main's mathlib pin has not moved in several days. The bump has
+                     stopped advancing (a wedged PR, an unresolved first-known-bad
+                     freeze, or update.yml silently broken).
   3. stranded-pr     A PR that is in-scope (TauCeti/ + allowed roots, bump-guard
                      green for any pin change), `build` green, every blocking
-                     rubric green at HEAD, not draft/hold, yet unmerged >=6h
-                     (~6 merge-sweep cycles). auto-merge / the queue / merge-sweep
-                     is broken.
-  4. review-stuck    An open issue titled "Review stuck: PR #...": the review
-                     engine self-flagged a PR it cannot resolve.
-  5. dead-scheduler  A scheduled workflow is `disabled`, or its last run is older
-                     than its cadence + slack. GitHub disabled the cron (60-day
-                     inactivity), or it errors at dispatch.
-  6. main-red        main's latest CI run concluded `failure`. The "main is always
-                     green" invariant is broken.
-  7. stale-fkb       A first-known-bad / mathlib-incompatibility tracking issue
-                     (bot-authored) has been open >=3 days. A regression against
-                     TauCeti nobody has landed the fix for.
+                     rubric green at HEAD, not draft/hold, mergeable, and quiet for
+                     the grace window. auto-merge / the queue / merge-sweep broke.
+  4. review-stuck    An open `Review stuck: PR #N` issue: the review engine
+                     self-flagged a PR it cannot resolve.
+  5. dead-scheduler  A scheduled workflow is missing, disabled, or its last
+                     SCHEDULED run is older than its cadence + slack. GitHub
+                     disabled the cron (60-day inactivity), or it errors at dispatch.
+  6. main-red        The CI run for main's tip commit reached a non-success terminal
+                     conclusion. The "main is always green" invariant is broken.
+  7. stale-fkb       An open first-known-bad issue (label `dependency-incompatibility`)
+                     has been open past a grace window. A regression against TauCeti
+                     nobody has landed the fix for.
 
 Deliberately NOT alerted (normal backlog, not stuck automation -- alerting on
 these would cheapen the topic and train people to ignore it):
@@ -45,36 +44,45 @@ these would cheapen the topic and train people to ignore it):
   * open roadmap / help-wanted issues -- that IS the ask-the-humans queue.
 
 Idempotent, like zulip_pr_status.py: exactly one bot-owned message per active
-alert key, tagged with a hidden `<!--stuck:v1 <key>-->` marker. Each run
-reconciles the topic against the live GitHub state -- a new alert posts a message,
-an alert that has cleared has its message edited to a resolved (checkmark) form,
-and an unchanged alert is left exactly as-is (so a persisting emergency is not
-re-posted every hour). Editing never notifies; only a genuinely NEW alert makes a
-new message appear. There are no @-mentions (the topic is watched, not pinged).
+alert key, tagged with a hidden `<!--stuck:v1 <key>-->` marker on its LAST line.
+Each run reconciles the topic against live GitHub state:
+  * a NEW alert posts a message (the only event that notifies watchers);
+  * an ONGOING alert is left byte-identical, so a persisting emergency is not
+    re-edited every hour (bodies carry no live counters, only stable thresholds);
+  * a CLEARED alert has its message edited to a ✅ form (edits do not notify);
+  * a RECURRENCE (an alert whose latest message is already ✅) posts a NEW message
+    rather than editing the buried one, so a re-fired incident is actually seen.
+There are no @-mentions (the topic is watched, not pinged).
+
+FAIL CLOSED, never fail open. A detector that raises (GitHub outage, rate limit,
+bug) does NOT clear its alerts: its key-prefix is marked "unknown" for the run and
+existing messages under that prefix are left exactly as they are. The alternative
+-- treating "the check failed" as "the emergency is over" -- is the worst possible
+behaviour for a watchdog. Only a genuinely-absent alert from a detector that ran
+cleanly is resolved.
 
 Run status mirrors the healthcheck philosophy: the ALERTS are the signal, not the
-run's red/green, so a run that successfully checks and posts exits 0 even when it
-raised ten alerts. Only a persistent Zulip CONFIG break (bad key, forbidden bot,
-not subscribed) fails the run loudly -- if we cannot post, the emergency channel
-itself is down, and that must not be silent.
+run's red/green, so a run that checks and posts exits 0 even with ten alerts open.
+Only a persistent Zulip CONFIG break (bad key, forbidden bot, not subscribed --
+verified up front via zulip_pr_status.check) fails the run loudly: if we cannot
+post, the emergency channel itself is down, and that must not be silent.
 
 Usage:
     stuck_alerts.py            # reconcile all detectors against the topic
     stuck_alerts.py --dry-run  # print the alerts it would post; touch no Zulip
 
 Environment:
-    ZULIP_API_KEY, ZULIP_EMAIL, ZULIP_SITE   bot credentials (required)
+    ZULIP_API_KEY, ZULIP_EMAIL, ZULIP_SITE   bot credentials (required unless --dry-run)
     ZULIP_CHANNEL                            default "Tau Ceti"
     ZULIP_TOPIC                              default "Stuck PRs"
     GH_REPO                                  default "TauCetiProject/TauCeti"
     GH_TOKEN / GITHUB_TOKEN                  used by `gh` for the GitHub API
 
-Only python3's standard library and an authenticated `gh` CLI are required.
-The Zulip client, credential handling, and sanitizer are reused verbatim from
-zulip_pr_status.py (same package dir); this file adds only the detectors and the
-alert-reconciliation loop. Pointing that shared client at a different topic is the
-module's own documented mechanism: ZULIP_TOPIC (set to "Stuck PRs" by the
-stuck-alerts workflow) is read at import, so send/find target this topic.
+Only python3's standard library and an authenticated `gh` CLI are required. The
+Zulip client, credential handling, and sanitizer are reused from zulip_pr_status.py
+(same package dir); pointing that client at a different topic is the module's own
+documented mechanism: ZULIP_TOPIC (set to "Stuck PRs" by the workflow) is read at
+import, so send/find target this topic.
 """
 
 import base64
@@ -91,10 +99,16 @@ sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 import zulip_pr_status as zp  # noqa: E402
 
 REPO = zp.REPO
-MARKER_RE = re.compile(r"<!--stuck:v1 ([^>]+)-->")
 LKG_BRANCH = "hopscotch/lkg-bump"  # keep in sync with update.yml's LKG_BRANCH
 
-# --- thresholds (hours unless noted) -----------------------------------------
+# Keys we generate use only this alphabet; the marker is anchored to the final
+# line and its key validated against this grammar, so untrusted text that happens
+# to contain a `<!--stuck:v1 ...-->` string cannot masquerade as one of our
+# markers or hijack another alert's key.
+KEY_RE = re.compile(r"[a-z0-9][a-z0-9._/-]*")
+MARKER_RE = re.compile(r"<!--stuck:v1 (" + KEY_RE.pattern + r")-->\s*\Z")
+
+# --- thresholds --------------------------------------------------------------
 # Each scheduler threshold is ~2-3x the workflow's cadence, generous enough to
 # ride out GitHub's routine scheduled-run delays without false-firing.
 BUMP_STUCK_HOURS = 24
@@ -111,14 +125,14 @@ SCHEDULERS = {
 }
 # A PR carrying any of these labels is intentionally parked; never "stranded".
 HOLD_LABELS = {"keep", "hold", "wip", "human", "do-not-close", "blocked"}
-# First-known-bad / incompatibility tracking issue, bot-authored. Heuristic:
-# confirm against the first real occurrence and tighten if it over/under-matches.
-FKB_AUTHOR_PREFIX = "tauceti-review-bot"
-FKB_TITLE_RE = re.compile(r"incompat|first[- ]known[- ]bad|known[- ]bad", re.I)
+# The downstream-reports first-known-bad tracking issue carries this label
+# (author github-actions[bot]); the label is the stable signal, not the title.
+FKB_LABEL = "dependency-incompatibility"
+# CI conclusions that mean main is broken (not just `failure`).
+RED_CONCLUSIONS = {"failure", "timed_out", "startup_failure"}
 
 
 def now_utc():
-    # new Date() / Date.now() are fine in plain python; the workflow runs live.
     return datetime.datetime.now(datetime.timezone.utc)
 
 
@@ -131,73 +145,78 @@ def hours_since(s):
     return (now_utc() - parse_ts(s)).total_seconds() / 3600.0
 
 
-def gh_json(path, jq=None, paginate=False):
-    """gh_api for a jq that yields a JSON object or array (parsed and returned).
+# ----- gh helpers -------------------------------------------------------------
+# `gh api --jq` prints each jq result on its own line, and `--paginate` simply
+# concatenates the per-page streams, so a jq that yields ONE VALUE PER LINE gives
+# valid JSONL across any number of pages. gh_stream parses that (fixes the naive
+# single-`json.loads` that broke past one page). gh_obj is for a jq yielding a
+# single JSON value; gh_scalar is for a raw string (never JSON-decoded).
 
-    `gh --jq` prints an object/array as JSON, so json.loads applies. Do NOT use
-    this for a scalar/string jq result -- gh prints those RAW (unquoted), which is
-    not JSON; use gh_scalar for those. Returns None on empty output.
-    """
-    out = zp.gh_api(path, jq=jq, paginate=paginate).strip()
+def gh_stream(path, jq, paginate=True):
+    """Parsed list from a jq that emits one JSON value per line (e.g. `.[] | {…}`)."""
+    out = zp.gh_api(path, jq=jq, paginate=paginate)
+    return [json.loads(ln) for ln in out.splitlines() if ln.strip()]
+
+
+def gh_obj(path, jq):
+    """Single parsed JSON value from a jq that yields one object, or None."""
+    out = zp.gh_api(path, jq=jq).strip()
     if not out:
         return None
-    return json.loads(out)
+    return json.loads(out.splitlines()[0])
 
 
 def gh_scalar(path, jq, paginate=False):
-    """gh_api for a jq that yields a scalar/string, returned as a stripped str.
-
-    Mirrors how zulip_pr_status reads statuses: `gh --jq '.foo // ""'` prints the
-    raw string value, so we take it as text (never json.loads it)."""
+    """Raw stripped string from a jq that yields a scalar (never json.loads it)."""
     return zp.gh_api(path, jq=jq, paginate=paginate).strip()
 
 
-def build_status(head):
-    """(state, updated_at) of the newest `build` commit status, or (None, None).
+def newest_status(head, context):
+    """(state, updated_at) of the newest commit status for `context`, else (None, None).
 
-    state is the raw GitHub status state: pending|success|failure|error.
+    per_page=100 so a burst of unrelated status events cannot push `build` /
+    `bump-guard` off the first page and hide it.
     """
-    rows = gh_json(
-        f"/repos/{REPO}/commits/{head}/statuses",
-        jq='[.[] | select(.context == "build")] | sort_by(.updated_at)'
+    row = gh_obj(
+        f"/repos/{REPO}/commits/{head}/statuses?per_page=100",
+        jq=f'[.[] | select(.context == "{context}")] | sort_by(.updated_at)'
            ' | last | {state: (.state // ""), updated_at: (.updated_at // "")}',
     )
-    if not rows or not rows.get("state"):
+    if not row or not row.get("state"):
         return None, None
-    return rows["state"], rows["updated_at"] or None
-
-
-def status_state(head, context):
-    """Newest commit-status state for `context` on `head` ("" if none)."""
-    return gh_scalar(
-        f"/repos/{REPO}/commits/{head}/statuses",
-        jq=f'[.[] | select(.context == "{context}")] | sort_by(.updated_at)'
-           ' | last | .state // ""',
-    )
+    return row["state"], row.get("updated_at") or None
 
 
 # ----- detectors --------------------------------------------------------------
 # Each returns a list of alert dicts {key, title, body}. `key` is stable across
-# runs so the same ongoing situation reconciles to the same Zulip message.
+# runs (so the same ongoing situation reconciles to the same message) and its
+# prefix (the part before the first "/") names the detector, so a detector that
+# errors marks exactly its own keys "unknown" and never clears them.
 
 def detect_stuck_bump():
-    prs = gh_json(
+    prs = gh_stream(
         f"/repos/{REPO}/pulls?state=open&head=TauCetiProject:{LKG_BRANCH}&per_page=5",
-        jq='[.[] | {number, head: .head.sha, created_at}]',
-    ) or []
+        jq='.[] | {number, head: .head.sha, created_at}', paginate=False)
     out = []
     for pr in prs:
-        state, _ = build_status(pr["head"])
+        state, _ = newest_status(pr["head"], "build")
+        # Clock off the PR's age, not the build-status timestamp. A HEALTHY LKG
+        # bump PR merges within hours and a fresh one is created per advance, so an
+        # open LKG PR older than the window is reliably stuck. The build-status
+        # `updated_at` is the wrong clock here: the daily bump force-pushes this
+        # branch, re-running the SAME red build and resetting that timestamp every
+        # day -- which would permanently mask a genuine multi-day wedge (observed
+        # on PR #1057). Requiring the build to be currently red avoids firing on a
+        # PR that has since gone green and is merging.
         if state in ("failure", "error") and hours_since(pr["created_at"]) >= BUMP_STUCK_HOURS:
-            age = int(hours_since(pr["created_at"]) // 24)
             out.append({
                 "key": f"stuck-bump/{pr['number']}",
-                "title": f"Mathlib bump wedged — PR #{pr['number']} build red",
+                "title": "Mathlib bump wedged — LKG bump PR build stays red",
                 "body": (
                     f"The last-known-good bump PR "
-                    f"https://github.com/{REPO}/pull/{pr['number']} has a red `build` "
-                    f"check and has been open ~{age}d. The daily bump cannot cross a "
-                    f"mathlib breaking change on its own.\n\n"
+                    f"https://github.com/{REPO}/pull/{pr['number']} has had a red "
+                    f"`build` check and has been open over {BUMP_STUCK_HOURS}h. The daily bump cannot "
+                    f"cross a mathlib breaking change on its own.\n\n"
                     f"**Fix:** open the failing build, land the fix it needs (a proof, "
                     f"`scripts/lint-env.sh`, a guard) together with the pin move in one "
                     f"human-owned PR, so the bump can resume."),
@@ -213,10 +232,7 @@ def detect_stale_pin():
     # last-change date on main is a direct proxy for the bump cadence.
     date = gh_scalar(f"/repos/{REPO}/commits?path=lake-manifest.json&sha=main&per_page=1",
                      jq='.[0].commit.committer.date // ""')
-    if not date:
-        return []
-    days = hours_since(date) / 24.0
-    if days < PIN_STALE_DAYS:
+    if not date or hours_since(date) / 24.0 < PIN_STALE_DAYS:
         return []
     rev = ""
     content = gh_scalar(f"/repos/{REPO}/contents/lake-manifest.json?ref=main", jq='.content')
@@ -230,10 +246,10 @@ def detect_stale_pin():
     pin = f" (mathlib `{rev[:10]}`)" if rev else ""
     return [{
         "key": "stale-pin",
-        "title": f"Mathlib pin has not moved in {int(days)}d",
+        "title": "Mathlib pin has stopped advancing",
         "body": (
-            f"`lake-manifest.json` on main{pin} last changed ~{int(days)}d ago; the "
-            f"daily bump has stopped advancing.\n\n"
+            f"`lake-manifest.json` on main{pin} has not changed in over "
+            f"{PIN_STALE_DAYS} days; the daily bump has stalled.\n\n"
             f"**Fix:** find why — a wedged bump PR (see any stuck-bump alert), an "
             f"unresolved first-known-bad freeze, or `update.yml` failing — and clear "
             f"it so `hopscotch/lkg-bump` can move forward again."),
@@ -241,12 +257,10 @@ def detect_stale_pin():
 
 
 def detect_stranded_prs():
-    prs = gh_json(
+    prs = gh_stream(
         f"/repos/{REPO}/pulls?state=open&base=main&per_page=100",
-        jq='[.[] | {number, head: .head.sha, draft, '
-           'labels: [.labels[].name], title}]',
-        paginate=True,
-    ) or []
+        jq='.[] | {number, head: .head.sha, draft, updated_at, '
+           'labels: [.labels[].name]}')
     out = []
     for pr in prs:
         if pr.get("draft"):
@@ -254,33 +268,45 @@ def detect_stranded_prs():
         if HOLD_LABELS.intersection(n.lower() for n in pr.get("labels", [])):
             continue
         head = pr["head"]
-        state, updated = build_status(head)
-        if state != "success" or not updated or hours_since(updated) < STRANDED_HOURS:
+        state, updated = newest_status(head, "build")
+        if state != "success" or not updated:
             continue
-        # Every blocking rubric green AT HEAD (mirrors auto-merge's ledger read).
+        # Readiness clock: the LATER of the build going green and the PR's last
+        # activity. Starting only from the build time would fire instantly when a
+        # review approves a PR whose build passed yesterday (the merge path has had
+        # no chance yet); updated_at bumps on that approval/commit/label.
+        ready_since = min(hours_since(updated), hours_since(pr["updated_at"]))
+        if ready_since < STRANDED_HOURS:
+            continue
+        # NOTE: scoreboard_meta is the trusted scoreboard comment auto-merge reads
+        # to TRIGGER a re-check; it is not the authoritative merge ledger, so this
+        # is best-effort and can lag. The mergeable + in-scope + quiet-window guards
+        # below keep the false-emergency rate low; a fully authoritative read of the
+        # TauCetiReview ledger is a possible future hardening.
         if zp.review_emoji(zp.scoreboard_meta(pr["number"]), head) != "check":
             continue
-        # In-scope: TauCeti/ + allowed roots only; a human-owned path legitimately
-        # does not auto-merge, so it is NOT stranded. Fail closed on any doubt.
-        files = gh_json(f"/repos/{REPO}/pulls/{pr['number']}/files?per_page=300",
-                        jq='[.[].filename]', paginate=True) or []
+        files = gh_stream(f"/repos/{REPO}/pulls/{pr['number']}/files?per_page=300",
+                          jq='.[].filename')
         if not files:
             continue
         allowed_roots = {"TauCeti.lean", "lake-manifest.json", "lean-toolchain"}
         touches_pin = any(f in ("lake-manifest.json", "lean-toolchain") for f in files)
         if not all(f.startswith("TauCeti/") or f in allowed_roots for f in files):
+            continue  # a human-owned path legitimately does not auto-merge
+        if touches_pin and newest_status(head, "bump-guard")[0] != "success":
             continue
-        # A pin change must have bump-guard green, exactly as the merge gate requires.
-        if touches_pin and status_state(head, "bump-guard") != "success":
+        # A conflicting / non-mergeable PR is not being wrongly withheld by the
+        # machinery; only alert when GitHub itself does not say it cannot merge.
+        mergeable = gh_scalar(f"/repos/{REPO}/pulls/{pr['number']}", jq='.mergeable // "null"')
+        if mergeable == "false":
             continue
-        age = int(hours_since(updated))
         out.append({
             "key": f"stranded-pr/{pr['number']}",
-            "title": f"Green PR not merging — #{pr['number']}",
+            "title": "Green PR is not being merged",
             "body": (
                 f"https://github.com/{REPO}/pull/{pr['number']} is in-scope, `build` "
                 f"green, and every blocking rubric green at HEAD, yet has sat unmerged "
-                f"~{age}h while merge-sweep runs hourly.\n\n"
+                f"for over {STRANDED_HOURS}h while merge-sweep runs hourly.\n\n"
                 f"**Fix:** the merge path is broken — check `auto-merge.yml`, the merge "
                 f"queue, and `merge-sweep.yml` (and the pinned TauCetiReview merge-only "
                 f"/ merge-sweep workflow) for why a ready PR is not being taken."),
@@ -289,17 +315,18 @@ def detect_stranded_prs():
 
 
 def detect_review_stuck():
-    issues = gh_json(
+    # Match the exact title grammar and interpolate NOTHING from the (untrusted)
+    # title into the message: the alert renders a fixed title and links the issue
+    # by its numeric id, so a crafted title cannot inject a marker or a mention.
+    issues = gh_stream(
         f"/repos/{REPO}/issues?state=open&per_page=100",
-        jq='[.[] | select(.pull_request == null) '
-           '| select(.title | test("^Review stuck")) | {number, title}]',
-        paginate=True,
-    ) or []
+        jq='.[] | select(.pull_request == null) '
+           '| select(.title | test("^Review stuck: PR #[0-9]+")) | {number}')
     return [{
         "key": f"review-stuck/{i['number']}",
-        "title": zp.zulip_sanitize(i["title"]),
+        "title": "Review engine self-flagged a PR it cannot resolve",
         "body": (
-            f"The review engine self-flagged a PR it cannot resolve: "
+            f"An open `Review stuck` issue is unresolved: "
             f"https://github.com/{REPO}/issues/{i['number']}\n\n"
             f"**Fix:** this is not a one-off review to nudge — the engine hit a state "
             f"it has no rule for (a rubric contradiction, an error loop). Fix the "
@@ -310,52 +337,64 @@ def detect_review_stuck():
 def detect_dead_schedulers():
     out = []
     for wf, (name, max_hours) in SCHEDULERS.items():
-        meta = gh_json(f"/repos/{REPO}/actions/workflows/{wf}",
-                       jq='{state: (.state // ""), id: .id}')
-        if not meta or not meta.get("state"):
+        meta = gh_obj(f"/repos/{REPO}/actions/workflows/{wf}",
+                      jq='{state: (.state // ""), found: true}')
+        if not meta or not meta.get("found"):
+            out.append(_sched_alert(wf, name,
+                f"`{wf}` was not found via the Actions API (renamed or deleted?).",
+                "Restore the workflow (or update this watchdog's SCHEDULERS list)."))
             continue
-        if meta["state"] != "active":
-            out.append({
-                "key": f"dead-scheduler/{wf}",
-                "title": f"Scheduler disabled — {name}",
-                "body": (
-                    f"`{wf}` is `{meta['state']}` (GitHub disables a cron after 60 days "
-                    f"of repo inactivity, or on repeated failure).\n\n"
-                    f"**Fix:** re-enable it (`gh workflow enable {wf}`) and address the "
-                    f"underlying cause so it stays scheduled."),
-            })
+        if meta.get("state") and meta["state"] != "active":
+            out.append(_sched_alert(wf, name,
+                f"`{wf}` is `{meta['state']}` (GitHub disables a cron after 60 days of "
+                f"repo inactivity, or on repeated failure).",
+                f"Re-enable it (`gh workflow enable {wf}`) and fix the underlying cause."))
             continue
+        # Only SCHEDULED runs prove the cron fires; a workflow_dispatch or push run
+        # (e.g. pages.yml on a web/ change) must not make a dead schedule look alive.
         last = gh_scalar(
-            f"/repos/{REPO}/actions/workflows/{wf}/runs?per_page=1",
+            f"/repos/{REPO}/actions/workflows/{wf}/runs?event=schedule&per_page=1",
             jq='.workflow_runs[0].created_at // ""')
         if not last:
+            out.append(_sched_alert(wf, name,
+                f"`{wf}` has no scheduled run on record.",
+                "Confirm the cron is configured and firing."))
             continue
-        age = hours_since(last)
-        if age >= max_hours:
-            out.append({
-                "key": f"dead-scheduler/{wf}",
-                "title": f"Scheduler stalled — {name}",
-                "body": (
-                    f"`{wf}` last ran ~{int(age)}h ago (cadence + slack is {max_hours}h). "
-                    f"Its schedule has stopped firing.\n\n"
-                    f"**Fix:** check the Actions tab for a dispatch error or an org-level "
-                    f"disable; restore the cron so `{name}` runs on cadence again."),
-            })
+        if hours_since(last) >= max_hours:
+            out.append(_sched_alert(wf, name,
+                f"`{wf}`'s last scheduled run was over {max_hours}h ago (its cadence "
+                f"+ slack); the schedule has stopped firing.",
+                "Check the Actions tab for a dispatch error or an org-level disable."))
     return out
 
 
+def _sched_alert(wf, name, problem, fix):
+    return {
+        "key": f"dead-scheduler/{wf}",
+        "title": f"Scheduler not firing — {name}",
+        "body": f"{problem}\n\n**Fix:** {fix}",
+    }
+
+
 def detect_main_red():
-    run = gh_json(
-        f"/repos/{REPO}/actions/workflows/ci.yml/runs?branch=main&status=completed&per_page=1",
-        jq='.workflow_runs[0] | {conclusion: (.conclusion // ""), sha: (.head_sha // "")}')
-    if not run or run.get("conclusion") != "failure":
+    tip = gh_scalar(f"/repos/{REPO}/commits/main", jq='.sha // ""')
+    if not tip:
         return []
-    sha = run.get("sha") or ""
+    # Evaluate the CI run for main's CURRENT tip specifically, so an old green run
+    # cannot mask a red (or never-completed) run on the commit that is actually
+    # main right now.
+    run = gh_obj(
+        f"/repos/{REPO}/actions/workflows/ci.yml/runs?head_sha={tip}&per_page=1",
+        jq='.workflow_runs[0] | {status: (.status // ""), conclusion: (.conclusion // "")}')
+    if not run or run.get("status") != "completed":
+        return []  # in progress or not yet run — not (yet) a red-main emergency
+    if run.get("conclusion") not in RED_CONCLUSIONS:
+        return []
     return [{
         "key": "main-red",
         "title": "main is RED",
         "body": (
-            f"The latest CI run on `main` (`{sha[:10]}`) concluded `failure`. The "
+            f"CI on main's tip (`{tip[:10]}`) concluded `{run['conclusion']}`. The "
             f"\"main is always green\" invariant is broken.\n\n"
             f"**Fix:** identify the merge or environment change that broke it and land a "
             f"revert or forward-fix immediately — a red main blocks every bump and merge."),
@@ -363,100 +402,119 @@ def detect_main_red():
 
 
 def detect_stale_fkb():
-    issues = gh_json(
-        f"/repos/{REPO}/issues?state=open&per_page=100",
-        jq='[.[] | select(.pull_request == null) '
-           '| {number, title, created_at, author: (.user.login // "")}]',
-        paginate=True,
-    ) or []
+    issues = gh_stream(
+        f"/repos/{REPO}/issues?state=open&labels={FKB_LABEL}&per_page=100",
+        jq='.[] | select(.pull_request == null) | {number, created_at}')
     out = []
     for i in issues:
-        if not i["author"].startswith(FKB_AUTHOR_PREFIX):
-            continue
-        if not FKB_TITLE_RE.search(i["title"]):
-            continue
         if hours_since(i["created_at"]) / 24.0 < FKB_STALE_DAYS:
             continue
-        days = int(hours_since(i["created_at"]) / 24.0)
         out.append({
             "key": f"stale-fkb/{i['number']}",
-            "title": f"Mathlib incompatibility unresolved {days}d — #{i['number']}",
+            "title": "Mathlib incompatibility unresolved",
             "body": (
-                f"A first-known-bad tracking issue has been open ~{days}d: "
-                f"https://github.com/{REPO}/issues/{i['number']}. The pin is frozen at "
-                f"the last-known-good commit until this is fixed.\n\n"
+                f"A first-known-bad tracking issue (`{FKB_LABEL}`) has been open for "
+                f"over {FKB_STALE_DAYS} days: https://github.com/{REPO}/issues/{i['number']}. "
+                f"The pin is frozen at the last-known-good commit until it is fixed.\n\n"
                 f"**Fix:** land the fix PR pinned at the first-known-bad commit so the "
                 f"freeze lifts and the daily bump resumes toward master."),
         })
     return out
 
 
+# (prefix, detector). The prefix is the part of every key before the first "/",
+# so a detector that raises marks exactly its own alerts "unknown" for the run.
 DETECTORS = [
-    detect_stuck_bump, detect_stale_pin, detect_stranded_prs, detect_review_stuck,
-    detect_dead_schedulers, detect_main_red, detect_stale_fkb,
+    ("stuck-bump", detect_stuck_bump),
+    ("stale-pin", detect_stale_pin),
+    ("stranded-pr", detect_stranded_prs),
+    ("review-stuck", detect_review_stuck),
+    ("dead-scheduler", detect_dead_schedulers),
+    ("main-red", detect_main_red),
+    ("stale-fkb", detect_stale_fkb),
 ]
 
 
+def key_prefix(key):
+    return key.split("/", 1)[0]
+
+
 def collect_alerts():
-    """Run every detector; a detector that errors is logged and skipped so one
-    flaky GitHub call cannot suppress every other alert."""
-    alerts = []
-    for det in DETECTORS:
+    """Run every detector. Returns (alerts, failed_prefixes). A detector that
+    raises contributes no alerts AND has its prefix recorded as failed, so the
+    reconcile step leaves that prefix's existing messages untouched (fail closed)
+    instead of resolving live emergencies during an API blip."""
+    alerts, failed = [], set()
+    for prefix, det in DETECTORS:
         try:
             alerts.extend(det() or [])
-        except Exception as exc:  # transient API/parse hiccup in one detector
-            zp.log(f"detector {det.__name__} failed (non-fatal): {exc}")
-    return alerts
+        except Exception as exc:
+            zp.log(f"detector {det.__name__} [{prefix}] failed (non-fatal): {exc}")
+            failed.add(prefix)
+    return alerts, failed
 
 
 # ----- reconcile against the topic -------------------------------------------
 
+RED = "\U0001f534"   # 🔴
+GREEN = "✅"     # ✅
+
+
+def parse_marker(content):
+    """The alert key iff `content` ends with a well-formed marker whose key matches
+    the strict grammar, else None. Anchoring to the end + strict grammar means
+    untrusted text embedding a marker-like string cannot be read as one of ours."""
+    m = MARKER_RE.search(content)
+    return m.group(1) if m else None
+
+
 def alert_content(a):
-    return f"\U0001f534 **{a['title']}**\n\n{a['body']}\n\n<!--stuck:v1 {a['key']}-->"
+    return f"{RED} **{a['title']}**\n\n{a['body']}\n\n<!--stuck:v1 {a['key']}-->"
 
 
-def resolved_content(message):
-    """Rewrite an existing alert message to its cleared form, keeping the marker
-    so future runs recognise it as already-resolved and leave it alone."""
-    body = message["content"]
-    m = MARKER_RE.search(body)
-    key = m.group(1) if m else "?"
-    # Keep the original title line for context; swap the red circle for a check.
-    title = "(cleared)"
-    for line in body.splitlines():
-        if line.startswith("\U0001f534 **") or line.startswith("**"):
-            title = line.split("**")[1] if "**" in line else title
-            break
-    return (f"✅ **{title}** — cleared\n\n_No longer active as of the latest "
+def resolved_content(key, title):
+    return (f"{GREEN} **{title}** — cleared\n\n_No longer active as of the latest "
             f"check._\n\n<!--stuck:v1 {key}-->")
 
 
-def reconcile(z, alerts, dry_run):
+def newest_by_key(msgs, bot_id):
+    """key -> the bot's newest message carrying that key's marker."""
+    out = {}
+    for m in msgs:
+        if m["sender_id"] != bot_id:
+            continue
+        key = parse_marker(m["content"])
+        if key is None:
+            continue
+        if key not in out or m["id"] > out[key]["id"]:
+            out[key] = m
+    return out
+
+
+def is_resolved(msg):
+    return msg["content"].lstrip().startswith(GREEN)
+
+
+def reconcile(z, alerts, failed, dry_run):
     bot_id = z.my_user_id()
     msgs = z.get_messages([
         {"operator": "channel", "operand": zp.CHANNEL},
         {"operator": "topic", "operand": zp.TOPIC},
     ])
-    existing = {}
-    for m in msgs:
-        if m["sender_id"] != bot_id:
-            continue
-        mk = MARKER_RE.search(m["content"])
-        if mk:
-            existing[mk.group(1)] = m
-
+    existing = newest_by_key(msgs, bot_id)
     active = {a["key"]: a for a in alerts}
 
     for key, a in active.items():
         content = alert_content(a)
         msg = existing.get(key)
-        if msg is None:
-            zp.log(f"NEW alert {key}: {a['title']}")
+        if msg is None or is_resolved(msg):
+            # New, or a recurrence whose latest message is already ✅: post a fresh
+            # message so watchers actually see the (re-)fired incident. Editing the
+            # buried ✅ back to red would notify no one.
+            zp.log(f"POST alert {key}: {a['title']}")
             if not dry_run:
                 z.send_message(content)
         elif msg["content"] != content:
-            # Content drifted (title/body wording changed, or it was resolved and
-            # has re-fired); refresh in place so it reads correctly, no re-ping.
             zp.log(f"refresh alert {key}")
             if not dry_run:
                 z.update_message(msg["id"], content)
@@ -464,34 +522,47 @@ def reconcile(z, alerts, dry_run):
             zp.log(f"ongoing alert {key} (unchanged)")
 
     for key, msg in existing.items():
-        if key in active:
+        if key in active or is_resolved(msg):
             continue
-        if msg["content"].startswith("✅"):
-            continue  # already marked resolved
+        if key_prefix(key) in failed:
+            zp.log(f"detector for {key} failed this run; NOT resolving (fail closed)")
+            continue
         zp.log(f"RESOLVED alert {key}")
         if not dry_run:
-            z.update_message(msg["id"], resolved_content(msg))
+            z.update_message(msg["id"], resolved_content(key, _title_of(msg["content"], key)))
+
+
+def _title_of(content, key):
+    """Best-effort recovery of the bolded title from an existing message body."""
+    for line in content.splitlines():
+        if "**" in line:
+            parts = line.split("**")
+            if len(parts) >= 2 and parts[1].strip():
+                return parts[1].strip()
+    return key
 
 
 def main(argv):
     dry_run = "--dry-run" in argv[1:]
+    alerts, failed = collect_alerts()
+    zp.log(f"{len(alerts)} active alert(s): {sorted(a['key'] for a in alerts)}"
+           + (f"; detectors unknown this run: {sorted(failed)}" if failed else ""))
 
-    alerts = collect_alerts()
-    zp.log(f"{len(alerts)} active alert(s): {sorted(a['key'] for a in alerts)}")
+    if dry_run:  # never touches Zulip, with or without creds — consistent output
+        for a in alerts:
+            print("\n" + alert_content(a))
+        return 0
 
     email = (os.environ.get("ZULIP_EMAIL") or "").strip()
     api_key = (os.environ.get("ZULIP_API_KEY") or "").strip()
     site = (os.environ.get("ZULIP_SITE") or "https://leanprover.zulipchat.com").strip()
-    if dry_run and not (email and api_key):
-        for a in alerts:
-            print("\n" + alert_content(a))
-        return 0
     if not (email and api_key):
         return zp.fail_config("ZULIP_EMAIL / ZULIP_API_KEY not set (no bot configured)")
 
     z = zp.Zulip(email, api_key, site)
     try:
-        reconcile(z, alerts, dry_run)
+        zp.check(z)  # up-front: bad key / forbidden / not subscribed -> fail red
+        reconcile(z, alerts, failed, dry_run)
     except zp.ConfigError as exc:  # emergency channel itself is down: fail loud
         return zp.fail_config(str(exc))
     except Exception as exc:  # a transient Zulip hiccup is cosmetic; self-heals

--- a/scripts/zulip/stuck_alerts.py
+++ b/scripts/zulip/stuck_alerts.py
@@ -171,6 +171,13 @@ def gh_scalar(path, jq, paginate=False):
     return zp.gh_api(path, jq=jq, paginate=paginate).strip()
 
 
+def gh_lines(path, jq, paginate=True):
+    """List of raw (non-JSON) string lines from a jq that emits bare strings, e.g.
+    `.[].filename`. Unlike gh_stream this does NOT json.loads each line (a bare
+    filename is not valid JSON)."""
+    return [ln for ln in zp.gh_api(path, jq=jq, paginate=paginate).splitlines() if ln.strip()]
+
+
 def newest_status(head, context):
     """(state, updated_at) of the newest commit status for `context`, else (None, None).
 
@@ -285,8 +292,9 @@ def detect_stranded_prs():
         # TauCetiReview ledger is a possible future hardening.
         if zp.review_emoji(zp.scoreboard_meta(pr["number"]), head) != "check":
             continue
-        files = gh_stream(f"/repos/{REPO}/pulls/{pr['number']}/files?per_page=300",
-                          jq='.[].filename')
+        # Filenames are bare strings, not JSON -- gh_lines, not gh_stream.
+        files = gh_lines(f"/repos/{REPO}/pulls/{pr['number']}/files?per_page=300",
+                         jq='.[].filename')
         if not files:
             continue
         allowed_roots = {"TauCeti.lean", "lake-manifest.json", "lean-toolchain"}
@@ -295,10 +303,11 @@ def detect_stranded_prs():
             continue  # a human-owned path legitimately does not auto-merge
         if touches_pin and newest_status(head, "bump-guard")[0] != "success":
             continue
-        # A conflicting / non-mergeable PR is not being wrongly withheld by the
-        # machinery; only alert when GitHub itself does not say it cannot merge.
-        mergeable = gh_scalar(f"/repos/{REPO}/pulls/{pr['number']}", jq='.mergeable // "null"')
-        if mergeable == "false":
+        # Only alert when GitHub positively says the PR CAN merge. `.mergeable` is
+        # true|false|null; do NOT use jq `//` (it maps false->the default too). A
+        # conflicting PR (false) is not being wrongly withheld; an as-yet-uncomputed
+        # PR (null) we skip this run and recheck next hour (a real strand persists).
+        if gh_scalar(f"/repos/{REPO}/pulls/{pr['number']}", jq='.mergeable') != "true":
             continue
         out.append({
             "key": f"stranded-pr/{pr['number']}",
@@ -321,7 +330,7 @@ def detect_review_stuck():
     issues = gh_stream(
         f"/repos/{REPO}/issues?state=open&per_page=100",
         jq='.[] | select(.pull_request == null) '
-           '| select(.title | test("^Review stuck: PR #[0-9]+")) | {number}')
+           '| select(.title | test("^Review stuck: PR #[0-9]+$")) | {number}')
     return [{
         "key": f"review-stuck/{i['number']}",
         "title": "Review engine self-flagged a PR it cannot resolve",
@@ -337,35 +346,39 @@ def detect_review_stuck():
 def detect_dead_schedulers():
     out = []
     for wf, (name, max_hours) in SCHEDULERS.items():
-        meta = gh_obj(f"/repos/{REPO}/actions/workflows/{wf}",
-                      jq='{state: (.state // ""), found: true}')
-        if not meta or not meta.get("found"):
-            out.append(_sched_alert(wf, name,
-                f"`{wf}` was not found via the Actions API (renamed or deleted?).",
-                "Restore the workflow (or update this watchdog's SCHEDULERS list)."))
-            continue
-        if meta.get("state") and meta["state"] != "active":
-            out.append(_sched_alert(wf, name,
-                f"`{wf}` is `{meta['state']}` (GitHub disables a cron after 60 days of "
-                f"repo inactivity, or on repeated failure).",
-                f"Re-enable it (`gh workflow enable {wf}`) and fix the underlying cause."))
-            continue
-        # Only SCHEDULED runs prove the cron fires; a workflow_dispatch or push run
-        # (e.g. pages.yml on a web/ change) must not make a dead schedule look alive.
-        last = gh_scalar(
-            f"/repos/{REPO}/actions/workflows/{wf}/runs?event=schedule&per_page=1",
-            jq='.workflow_runs[0].created_at // ""')
-        if not last:
-            out.append(_sched_alert(wf, name,
-                f"`{wf}` has no scheduled run on record.",
-                "Confirm the cron is configured and firing."))
-            continue
-        if hours_since(last) >= max_hours:
-            out.append(_sched_alert(wf, name,
-                f"`{wf}`'s last scheduled run was over {max_hours}h ago (its cadence "
-                f"+ slack); the schedule has stopped firing.",
-                "Check the Actions tab for a dispatch error or an org-level disable."))
+        try:
+            out.extend(_check_scheduler(wf, name, max_hours))
+        except Exception as exc:
+            # A transient error on one workflow (or an ambiguous 404) must not abort
+            # the whole detector -- that would mark ALL schedulers "unknown" and skip
+            # the ones that are genuinely stalled. Log and move on.
+            zp.log(f"scheduler check for {wf} failed (non-fatal): {exc}")
     return out
+
+
+def _check_scheduler(wf, name, max_hours):
+    meta = gh_obj(f"/repos/{REPO}/actions/workflows/{wf}",
+                  jq='{state: (.state // "")}')
+    state = meta.get("state") if meta else ""
+    if state and state != "active":
+        return [_sched_alert(wf, name,
+            f"`{wf}` is `{state}` (GitHub disables a cron after 60 days of repo "
+            f"inactivity, or on repeated failure).",
+            f"Re-enable it (`gh workflow enable {wf}`) and fix the underlying cause.")]
+    # Only SCHEDULED runs prove the cron fires; a workflow_dispatch or push run
+    # (e.g. pages.yml on a web/ change) must not make a dead schedule look alive.
+    last = gh_scalar(
+        f"/repos/{REPO}/actions/workflows/{wf}/runs?event=schedule&per_page=1",
+        jq='.workflow_runs[0].created_at // ""')
+    if not last:
+        return [_sched_alert(wf, name, f"`{wf}` has no scheduled run on record.",
+                             "Confirm the cron is configured and firing.")]
+    if hours_since(last) >= max_hours:
+        return [_sched_alert(wf, name,
+            f"`{wf}`'s last scheduled run was over {max_hours}h ago (its cadence + "
+            f"slack); the schedule has stopped firing.",
+            "Check the Actions tab for a dispatch error or an org-level disable.")]
+    return []
 
 
 def _sched_alert(wf, name, problem, fix):

--- a/scripts/zulip/test_stuck_alerts.py
+++ b/scripts/zulip/test_stuck_alerts.py
@@ -1,0 +1,151 @@
+#!/usr/bin/env python3
+"""Unit tests for the invariants that make stuck_alerts a trustworthy watchdog.
+
+Focus on the failure modes that would make it silently wrong rather than merely
+noisy: fail-open resolution, multi-page JSON parsing, marker-injection safety, and
+recurrence visibility. Pure logic only -- GitHub and Zulip are faked, so no network
+or `gh` is needed. Run: python3 scripts/zulip/test_stuck_alerts.py
+"""
+
+import os
+import unittest
+
+os.environ.setdefault("ZULIP_CHANNEL", "Tau Ceti")
+os.environ.setdefault("ZULIP_TOPIC", "Stuck PRs")
+
+import stuck_alerts as sa  # noqa: E402
+import zulip_pr_status as zp  # noqa: E402
+
+
+class FakeZulip:
+    """Records send/update calls; returns a scripted message list from the topic."""
+
+    def __init__(self, messages, bot_id=7):
+        self._messages = messages
+        self._bot_id = bot_id
+        self.sent = []
+        self.updated = []
+
+    def my_user_id(self):
+        return self._bot_id
+
+    def get_messages(self, narrow):
+        return self._messages
+
+    def send_message(self, content):
+        self.sent.append(content)
+        return len(self.sent)
+
+    def update_message(self, mid, content):
+        self.updated.append((mid, content))
+
+
+def msg(mid, content, sender=7):
+    return {"id": mid, "content": content, "sender_id": sender}
+
+
+def active_content(key, title="T", body="B"):
+    return sa.alert_content({"key": key, "title": title, "body": body})
+
+
+class GhStreamTest(unittest.TestCase):
+    def test_parses_jsonl_across_pages(self):
+        # `gh --paginate --jq '.[] | {..}'` concatenates per-page streams: three
+        # objects over two "pages". A single json.loads would choke on line 2+.
+        pages = '{"number": 1}\n{"number": 2}\n{"number": 3}\n'
+        self.addCleanup(setattr, zp, "gh_api", zp.gh_api)
+        zp.gh_api = lambda path, jq=None, paginate=False: pages
+        got = sa.gh_stream("/x", jq=".[] | {number}")
+        self.assertEqual([r["number"] for r in got], [1, 2, 3])
+
+    def test_empty_output_is_empty_list(self):
+        self.addCleanup(setattr, zp, "gh_api", zp.gh_api)
+        zp.gh_api = lambda path, jq=None, paginate=False: "\n"
+        self.assertEqual(sa.gh_stream("/x", jq=".[]"), [])
+
+
+class FailClosedTest(unittest.TestCase):
+    def test_failing_detector_records_prefix_and_keeps_others(self):
+        self.addCleanup(setattr, sa, "DETECTORS", sa.DETECTORS)
+        def boom():
+            raise RuntimeError("api down")
+        def ok():
+            return [{"key": "main-red", "title": "t", "body": "b"}]
+        sa.DETECTORS = [("stuck-bump", boom), ("main-red", ok)]
+        alerts, failed = sa.collect_alerts()
+        self.assertEqual([a["key"] for a in alerts], ["main-red"])
+        self.assertEqual(failed, {"stuck-bump"})
+
+    def test_reconcile_does_not_resolve_failed_prefix(self):
+        # An existing stuck-bump alert is live; its detector failed this run, so it
+        # must NOT be edited to resolved (that would turn a real emergency green).
+        z = FakeZulip([msg(1, active_content("stuck-bump/1057"))])
+        sa.reconcile(z, alerts=[], failed={"stuck-bump"}, dry_run=False)
+        self.assertEqual(z.updated, [])
+        self.assertEqual(z.sent, [])
+
+    def test_reconcile_resolves_absent_alert_from_clean_detector(self):
+        z = FakeZulip([msg(1, active_content("main-red"))])
+        sa.reconcile(z, alerts=[], failed=set(), dry_run=False)
+        self.assertEqual(len(z.updated), 1)
+        self.assertTrue(z.updated[0][1].lstrip().startswith(sa.GREEN))
+
+
+class ReconcileTest(unittest.TestCase):
+    def test_new_alert_posts_message(self):
+        z = FakeZulip([])
+        sa.reconcile(z, [{"key": "main-red", "title": "t", "body": "b"}], set(), False)
+        self.assertEqual(len(z.sent), 1)
+        self.assertEqual(z.updated, [])
+
+    def test_ongoing_alert_is_untouched(self):
+        content = active_content("main-red", "t", "b")
+        z = FakeZulip([msg(1, content)])
+        sa.reconcile(z, [{"key": "main-red", "title": "t", "body": "b"}], set(), False)
+        self.assertEqual(z.sent, [])
+        self.assertEqual(z.updated, [])  # byte-identical -> no churn
+
+    def test_recurrence_posts_new_message_not_edit(self):
+        # Latest message for the key is already resolved (✅); a re-fire must post a
+        # NEW message (edits do not notify watchers on a silent topic).
+        resolved = sa.resolved_content("main-red", "main is RED")
+        z = FakeZulip([msg(5, resolved)])
+        sa.reconcile(z, [{"key": "main-red", "title": "t", "body": "b"}], set(), False)
+        self.assertEqual(len(z.sent), 1)
+        self.assertEqual(z.updated, [])
+
+
+class MarkerSafetyTest(unittest.TestCase):
+    def test_valid_trailing_marker_parses(self):
+        self.assertEqual(sa.parse_marker(active_content("stale-fkb/917")), "stale-fkb/917")
+
+    def test_marker_must_be_at_end(self):
+        # A marker followed by more text is not our trailer -> not parsed as a key.
+        body = "x <!--stuck:v1 stale-pin--> then more text"
+        self.assertIsNone(sa.parse_marker(body))
+
+    def test_injected_marker_does_not_hijack_key(self):
+        # Simulate a message whose visible text embeds a marker but whose real
+        # trailer is a different key. Only the trailing, grammar-valid key wins.
+        content = ("🔴 **Review stuck <!--stuck:v1 stale-pin-->**\n\nbody\n\n"
+                   "<!--stuck:v1 review-stuck/42-->")
+        self.assertEqual(sa.parse_marker(content), "review-stuck/42")
+
+    def test_bad_grammar_key_rejected(self):
+        self.assertIsNone(sa.parse_marker("<!--stuck:v1 Has Spaces-->"))
+
+    def test_newest_message_wins_per_key(self):
+        old = msg(1, active_content("main-red"))
+        new = msg(9, sa.resolved_content("main-red", "main is RED"))
+        got = sa.newest_by_key([old, new], bot_id=7)
+        self.assertEqual(got["main-red"]["id"], 9)
+
+    def test_other_senders_ignored(self):
+        mine = msg(1, active_content("main-red"), sender=7)
+        theirs = msg(2, active_content("main-red"), sender=99)
+        got = sa.newest_by_key([mine, theirs], bot_id=7)
+        self.assertEqual(got["main-red"]["id"], 1)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/zulip/test_stuck_alerts.py
+++ b/scripts/zulip/test_stuck_alerts.py
@@ -63,6 +63,15 @@ class GhStreamTest(unittest.TestCase):
         zp.gh_api = lambda path, jq=None, paginate=False: "\n"
         self.assertEqual(sa.gh_stream("/x", jq=".[]"), [])
 
+    def test_gh_lines_returns_raw_strings_not_json(self):
+        # `.[].filename` emits bare filenames; gh_lines must NOT json.loads them
+        # (json.loads("TauCeti/Foo.lean") would raise) -- the bug that broke
+        # stranded-pr when it used gh_stream here.
+        self.addCleanup(setattr, zp, "gh_api", zp.gh_api)
+        zp.gh_api = lambda path, jq=None, paginate=False: "TauCeti/Foo.lean\nlean-toolchain\n"
+        self.assertEqual(sa.gh_lines("/x", jq=".[].filename"),
+                         ["TauCeti/Foo.lean", "lean-toolchain"])
+
 
 class FailClosedTest(unittest.TestCase):
     def test_failing_detector_records_prefix_and_keeps_others(self):


### PR DESCRIPTION
This PR adds an hourly watchdog that posts to a dedicated Zulip topic (**Tau Ceti > Stuck PRs**) whenever a Tau Ceti pipeline wedges in a way it cannot recover from on its own, so a silent stall (like the week-long mathlib bump wedge that motivated this) surfaces within the hour instead of going unnoticed.

`scripts/zulip/stuck_alerts.py` runs seven detectors, each naming the infrastructure fix it implies: a red, stale last-known-good bump PR; a mathlib pin that has stopped advancing; an in-scope, fully-green PR the merge path never merged; an open `Review stuck: PR #…` issue; a scheduled workflow that is disabled or overdue; `main` gone red; and a long-open mathlib-incompatibility issue. This is an emergency channel, not a help queue: a report means something in the automation must be fixed so the wedge cannot recur, not that a human should hand-hold one PR. Normal backlog (a PR awaiting its first review verdict, changes-requested nobody addressed, open roadmap issues) is deliberately excluded, and the reasoning is documented in the module docstring.

The detector reuses the existing `scripts/zulip/` Zulip client, pointed at the topic via the module's own `ZULIP_TOPIC` knob, and is idempotent the same way the PR-status reactions are: one bot message per active alert, tagged with a hidden marker, edited to a ✅ when the situation clears and never re-posted while it persists. The `stuck-alerts.yml` run goes red only on a persistent Zulip config break, mirroring `zulip-healthcheck.yml` — the open alerts, not the run status, are the signal.

Verified with `stuck_alerts.py --dry-run` against the live repo: it correctly flags the currently-wedged bump PR and the open `Review stuck` issues, and correctly stays silent on `main`, the schedulers, and the freshly-moved pin (the staleness check measures when the pin last moved, not the age of the pinned commit, so a bump to an older last-known-good commit does not false-fire). The **Stuck PRs** topic has been seeded with a message stating the contract.

🤖 Prepared with Claude Code