### PR TITLE
feat: report build and scope as separate checks

### DIFF
--- a/.github/workflows/pr-build.yml
+++ b/.github/workflows/pr-build.yml
@@ -127,10 +127,10 @@ jobs:
           # transitive pins derived from mathlib, toolchain monotonic). lakefile.* stays
           # human-owned (and check-bump fails if it changed).
           if [ -z "$files" ]; then
-            echo "INFRA=1" >> "$GITHUB_ENV"; echo "::warning::no files / unable to list — routing to human"
+            echo "INFRA=1" >> "$GITHUB_ENV"; echo "::warning::no files / unable to list — cannot determine the overlay, routing to human"
           elif echo "$files" | grep -vqE '^TauCeti/|^TauCeti\.lean$|^lake-manifest\.json$|^lean-toolchain$'; then
-            echo "INFRA=1" >> "$GITHUB_ENV"
-            echo "::warning::PR changes paths outside TauCeti/ + Lake pins (infra) — not sandbox-built; needs human review"
+            echo "OUT_OF_SCOPE=1" >> "$GITHUB_ENV"
+            echo "::warning::PR changes paths outside TauCeti/ + Lake pins — its TauCeti/ is still sandbox-built against the trusted base (so the build result is visible), but merging needs human review"
           elif echo "$files" | grep -qE '^lake-manifest\.json$|^lean-toolchain$'; then
             echo "BUMP=1" >> "$GITHUB_ENV"
             echo "::notice::PR changes Lake pins — validating as a forward bump before building"
@@ -421,16 +421,16 @@ jobs:
             -f target_url="${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
           echo "posted bump-guard=$bg_state ($bg_desc) to ${{ steps.pr.outputs.status_sha }}"
 
-          if [ "${{ env.BUMP_BAD }}" = "1" ]; then
-            state=failure; desc="Lake-pin change is not a validated forward bump — human review + merge required"
-          elif [ "${{ env.INFRA }}" = "1" ]; then
-            state=failure; desc="changes outside TauCeti/ — human review + merge required"
-          elif [ "${{ env.TOO_LARGE }}" = "1" ]; then
-            state=failure; desc="diff exceeds 2000 added/removed lines or 2000 files — split into smaller PRs to keep review manageable"
-          elif [ "${{ env.DIFF_UNKNOWN }}" = "1" ]; then
-            state=failure; desc="could not read PR diff totals from the GitHub API — re-run pr-build"
-          elif [ "${{ env.NEWFILE_TOO_LONG }}" = "1" ]; then
-            state=failure; desc="a newly added .lean file exceeds 1000 lines — split it (existing files may grow to 1500)"
+          # build: the real sandboxed-build result ONLY — never a policy verdict. The build now runs even
+          # for an out-of-scope PR (its TauCeti/ is overlaid onto the trusted base and built), so a red
+          # `build` always means the code did not compile or an audit/lint failed, and fix-ci can trust
+          # it. It is reported as not-run only when we genuinely could not build: an indeterminate file
+          # list (INFRA), an unvalidated pin bump (BUMP_BAD — the overlay would need the PR's pins), or a
+          # diff guard that failed closed (TOO_LARGE / DIFF_UNKNOWN both exit before the build). Those
+          # post a failure so this required check still blocks merge; the reason lives in `scope` below.
+          if [ "${{ env.BUMP_BAD }}" = "1" ] || [ "${{ env.INFRA }}" = "1" ] \
+             || [ "${{ env.TOO_LARGE }}" = "1" ] || [ "${{ env.DIFF_UNKNOWN }}" = "1" ]; then
+            state=failure; desc="build not run — see the scope check"
           elif [ "${{ steps.build.outcome }}" = "success" ]; then
             state=success; desc="sandboxed build, audits, and simp-NF lint passed (trusted config)"
           else
@@ -440,4 +440,28 @@ jobs:
             -f state="$state" -f context="build" -f description="$desc" \
             -f target_url="${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
           echo "posted build=$state ($desc) to ${{ steps.pr.outputs.status_sha }}"
+
+          # scope: the merge-policy verdict, posted as its OWN status so a policy issue never hides the
+          # build result (the bug this split fixes — an out-of-scope PR used to post its "human review"
+          # verdict as a red `build`, so fix-ci churned on it and you could not see whether it compiled).
+          # Informational, NOT a required check: auto-merge's own "every changed path under TauCeti/"
+          # rule and the required bump-guard are the merge gate, so an out-of-scope PR still cannot
+          # auto-merge; a human merges it once they have seen its now-visible build.
+          if [ "${{ env.OUT_OF_SCOPE }}" = "1" ]; then
+            sc_state=failure; sc_desc="changes outside TauCeti/ — human review + merge required"
+          elif [ "${{ env.INFRA }}" = "1" ]; then
+            sc_state=failure; sc_desc="could not determine the changed files — human review + merge required"
+          elif [ "${{ env.TOO_LARGE }}" = "1" ]; then
+            sc_state=failure; sc_desc="diff exceeds 2000 added/removed lines or 2000 files — split into smaller PRs to keep review manageable"
+          elif [ "${{ env.DIFF_UNKNOWN }}" = "1" ]; then
+            sc_state=failure; sc_desc="could not read PR diff totals from the GitHub API — re-run pr-build"
+          elif [ "${{ env.NEWFILE_TOO_LONG }}" = "1" ]; then
+            sc_state=failure; sc_desc="a newly added .lean file exceeds 1000 lines — split it (existing files may grow to 1500)"
+          else
+            sc_state=success; sc_desc="changes are in scope (TauCeti/ and the allowed root files only)"
+          fi
+          gh api -X POST "repos/${{ github.repository }}/statuses/${{ steps.pr.outputs.status_sha }}" \
+            -f state="$sc_state" -f context="scope" -f description="$sc_desc" \
+            -f target_url="${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+          echo "posted scope=$sc_state ($sc_desc) to ${{ steps.pr.outputs.status_sha }}"
           [ "$state" = "success" ]


### PR DESCRIPTION
This PR stops the scope guard from hijacking the `build` status. A PR that touches files outside `TauCeti/` now still has its `TauCeti/` overlaid onto the trusted base and sandbox-built, and `build` reports only that result — so the build outcome is always visible, even for an "infra" PR, and fix-ci can treat a red `build` as a genuine build failure rather than a policy verdict. The human-merge policy reason (changes outside `TauCeti/`, too large, over-long new file, unreadable diff, unvalidated bump) moves to a separate `scope` status.

`scope` is informational, not a required check: `auto-merge.yml` already refuses to merge any PR whose changed paths leave `TauCeti/`, and `bump-guard` gates pin changes, so an out-of-scope PR still cannot auto-merge — a human merges it once they have seen the build. `build` is reported not-run (a failing required check) only when we genuinely cannot build: an indeterminate file list, an unvalidated pin bump (the overlay would need the PR's pins), or a diff guard that exits before the build.

This is the root-cause fix for the fix-ci churn on infra PRs: the worker was treating the scope-guard's red `build` as a fixable failure and burning agent launches on PRs nothing could green.

Note: this PR itself changes only `.github/`, so under the current workflow its own `build` is the old scope-guard red; it needs an admin merge, after which the split takes effect for subsequent PRs.

🤖 Prepared with Claude Code