### PR TITLE
feat: add the Koopman fixed space

### DIFF
--- a/TauCeti/Probability/Ergodic/FixedSpace.lean
+++ b/TauCeti/Probability/Ergodic/FixedSpace.lean
@@ -31,12 +31,25 @@ transformation. -/
 def fixedSpace (T : Ω → Ω) (hT : MeasurePreserving T μ μ) : Submodule 𝕜 (Lp E p μ) :=
   (Lp.compMeasurePreservingₗ 𝕜 T hT).fixedSubmodule
 
+/-- The fixed space is the fixed submodule of the composition operator. -/
+theorem fixedSpace_def (T : Ω → Ω) (hT : MeasurePreserving T μ μ) :
+    fixedSpace (𝕜 := 𝕜) (E := E) (p := p) T hT =
+      (Lp.compMeasurePreservingₗ 𝕜 T hT).fixedSubmodule := by
+  rw [fixedSpace]
+
+/-- Membership in the fixed space means being fixed by the composition operator. -/
+@[simp]
+theorem mem_fixedSpace_iff {T : Ω → Ω} (hT : MeasurePreserving T μ μ) (g : Lp E p μ) :
+    g ∈ fixedSpace (𝕜 := 𝕜) T hT ↔ Lp.compMeasurePreserving T hT g = g := by
+  rw [fixedSpace_def, LinearMap.mem_fixedSubmodule_iff]
+  rfl
+
 /-- Characterization of fixed points of the `Lᵖ` composition isometry using representatives. -/
 @[simp]
 theorem mem_fixedSpace_iff_comp_ae_eq_self {T : Ω → Ω}
     (hT : MeasurePreserving T μ μ) (g : Lp E p μ) :
     g ∈ fixedSpace (𝕜 := 𝕜) T hT ↔ (g : Ω → E) ∘ T =ᵐ[μ] g := by
-  change Lp.compMeasurePreserving T hT g = g ↔ _
+  rw [mem_fixedSpace_iff]
   constructor
   · intro hg
     simpa only [hg] using (Lp.coeFn_compMeasurePreserving g hT).symm
@@ -49,15 +62,13 @@ theorem mem_fixedSpace_iff_comp_ae_eq_self {T : Ω → Ω}
 theorem fixedSpace_id :
     fixedSpace (μ := μ) (𝕜 := 𝕜) (E := E) (p := p) id (MeasurePreserving.id μ) = ⊤ := by
   ext g
-  simp [mem_fixedSpace_iff_comp_ae_eq_self]
+  simp
 
 /-- Every observable fixed by `T` is fixed by every iterate of `T`. -/
 theorem mem_fixedSpace_iterate {T : Ω → Ω} (hT : MeasurePreserving T μ μ)
     {g : Lp E p μ} (hg : g ∈ fixedSpace (𝕜 := 𝕜) T hT) (n : ℕ) :
     g ∈ fixedSpace (𝕜 := 𝕜) (T^[n]) (hT.iterate n) := by
-  rw [fixedSpace, LinearMap.mem_fixedSubmodule_iff] at hg ⊢
-  change Lp.compMeasurePreserving T hT g = g at hg
-  change Lp.compMeasurePreserving (T^[n]) (hT.iterate n) g = g
+  rw [mem_fixedSpace_iff] at hg ⊢
   rw [← Lp.compMeasurePreserving_iterate]
   exact IsFixedPt.iterate hg n
 
@@ -65,16 +76,23 @@ end Generic
 
 section Complete
 
-variable {Ω 𝕜 E : Type*} [MeasurableSpace Ω] [NontriviallyNormedField 𝕜]
-  [NormedAddCommGroup E] [NormedSpace 𝕜 E]
+variable {Ω 𝕜 E : Type*} [MeasurableSpace Ω] [NormedRing 𝕜]
+  [NormedAddCommGroup E] [Module 𝕜 E] [IsBoundedSMul 𝕜 E]
 variable {p : ℝ≥0∞} [Fact (1 ≤ p)] {μ : Measure Ω}
+
+/-- The fixed space as the equality locus of the continuous composition operator and identity. -/
+theorem fixedSpace_eq_eqLocus (T : Ω → Ω) (hT : MeasurePreserving T μ μ) :
+    fixedSpace (𝕜 := 𝕜) (E := E) (p := p) T hT =
+      (Lp.compMeasurePreservingₗᵢ 𝕜 T hT).toContinuousLinearMap.toLinearMap.eqLocus
+        (1 : Lp E p μ →L[𝕜] Lp E p μ).toLinearMap := by
+  ext g
+  rw [mem_fixedSpace_iff]
+  rfl
 
 /-- The fixed space is closed in `Lᵖ`. -/
 theorem isClosed_fixedSpace (T : Ω → Ω) (hT : MeasurePreserving T μ μ) :
     IsClosed (fixedSpace (𝕜 := 𝕜) (E := E) (p := p) T hT : Set (Lp E p μ)) := by
-  change IsClosed
-    (((Lp.compMeasurePreservingₗᵢ 𝕜 T hT).toContinuousLinearMap.eqLocus 1 :
-      Submodule 𝕜 (Lp E p μ)) : Set (Lp E p μ))
+  rw [fixedSpace_eq_eqLocus]
   exact (Lp.compMeasurePreservingₗᵢ 𝕜 T hT).toContinuousLinearMap.isClosed_eqLocus
     (1 : Lp E p μ →L[𝕜] Lp E p μ)
 
@@ -82,9 +100,7 @@ variable [CompleteSpace E]
 
 instance fixedSpace.completeSpace (T : Ω → Ω) (hT : MeasurePreserving T μ μ) :
     CompleteSpace (fixedSpace (𝕜 := 𝕜) (E := E) (p := p) T hT) := by
-  change CompleteSpace
-    ((Lp.compMeasurePreservingₗᵢ 𝕜 T hT).toContinuousLinearMap.toLinearMap.eqLocus
-      (1 : Lp E p μ →L[𝕜] Lp E p μ).toLinearMap)
+  rw [fixedSpace_eq_eqLocus]
   infer_instance
 
 end Complete

--- a/TauCeti/Probability/Ergodic/FixedSpace.lean
+++ b/TauCeti/Probability/Ergodic/FixedSpace.lean
@@ -85,8 +85,7 @@ variable {Ω 𝕜 E : Type*} [MeasurableSpace Ω] [NormedRing 𝕜]
   [NormedAddCommGroup E] [Module 𝕜 E] [IsBoundedSMul 𝕜 E]
 variable {p : ℝ≥0∞} [Fact (1 ≤ p)] {μ : Measure Ω}
 
-/-- The fixed space as the equality locus of the continuous composition operator and identity. -/
-theorem fixedSpace_eq_eqLocus (T : Ω → Ω) (hT : MeasurePreserving T μ μ) :
+private theorem fixedSpace_eq_eqLocus (T : Ω → Ω) (hT : MeasurePreserving T μ μ) :
     fixedSpace (𝕜 := 𝕜) (E := E) (p := p) T hT =
       (Lp.compMeasurePreservingₗᵢ 𝕜 T hT).toContinuousLinearMap.toLinearMap.eqLocus
         (1 : Lp E p μ →L[𝕜] Lp E p μ).toLinearMap := by

--- a/TauCeti/Probability/Ergodic/FixedSpace.lean
+++ b/TauCeti/Probability/Ergodic/FixedSpace.lean
@@ -1,6 +1,6 @@
 module
 
-public import Mathlib.MeasureTheory.Function.LpSpace.Basic
+public import Mathlib.MeasureTheory.Function.LpSpace.Complete
 public import Mathlib.LinearAlgebra.FixedSubmodule
 
 /-!
@@ -20,21 +20,73 @@ open scoped ENNReal
 
 namespace TauCeti.Probability
 
+section Generic
+
 variable {Ω 𝕜 E : Type*} [MeasurableSpace Ω] [NormedRing 𝕜] [NormedAddCommGroup E]
   [Module 𝕜 E] [IsBoundedSMul 𝕜 E]
 variable {p : ℝ≥0∞} {μ : Measure Ω}
 
+/-- The submodule of `Lᵖ` observables fixed by composition with a measure-preserving
+transformation. -/
+def fixedSpace (T : Ω → Ω) (hT : MeasurePreserving T μ μ) : Submodule 𝕜 (Lp E p μ) :=
+  (Lp.compMeasurePreservingₗ 𝕜 T hT).fixedSubmodule
+
 /-- Characterization of fixed points of the `Lᵖ` composition isometry using representatives. -/
 @[simp]
-theorem mem_fixedSubmodule_iff_comp_ae_eq_self {T : Ω → Ω}
+theorem mem_fixedSpace_iff_comp_ae_eq_self {T : Ω → Ω}
     (hT : MeasurePreserving T μ μ) (g : Lp E p μ) :
-    Lp.compMeasurePreserving T hT g = g ↔
-      (g : Ω → E) ∘ T =ᵐ[μ] g := by
+    g ∈ fixedSpace (𝕜 := 𝕜) T hT ↔ (g : Ω → E) ∘ T =ᵐ[μ] g := by
+  change Lp.compMeasurePreserving T hT g = g ↔ _
   constructor
   · intro hg
     simpa only [hg] using (Lp.coeFn_compMeasurePreserving g hT).symm
   · intro hg
     apply Lp.ext
     exact (Lp.coeFn_compMeasurePreserving g hT).trans hg
+
+/-- The fixed space of the identity transformation is all of `Lᵖ`. -/
+@[simp]
+theorem fixedSpace_id :
+    fixedSpace (μ := μ) (𝕜 := 𝕜) (E := E) (p := p) id (MeasurePreserving.id μ) = ⊤ := by
+  ext g
+  simp [mem_fixedSpace_iff_comp_ae_eq_self]
+
+/-- Every observable fixed by `T` is fixed by every iterate of `T`. -/
+theorem mem_fixedSpace_iterate {T : Ω → Ω} (hT : MeasurePreserving T μ μ)
+    {g : Lp E p μ} (hg : g ∈ fixedSpace (𝕜 := 𝕜) T hT) (n : ℕ) :
+    g ∈ fixedSpace (𝕜 := 𝕜) (T^[n]) (hT.iterate n) := by
+  rw [fixedSpace, LinearMap.mem_fixedSubmodule_iff] at hg ⊢
+  change Lp.compMeasurePreserving T hT g = g at hg
+  change Lp.compMeasurePreserving (T^[n]) (hT.iterate n) g = g
+  rw [← Lp.compMeasurePreserving_iterate]
+  exact IsFixedPt.iterate hg n
+
+end Generic
+
+section Complete
+
+variable {Ω 𝕜 E : Type*} [MeasurableSpace Ω] [NontriviallyNormedField 𝕜]
+  [NormedAddCommGroup E] [NormedSpace 𝕜 E]
+variable {p : ℝ≥0∞} [Fact (1 ≤ p)] {μ : Measure Ω}
+
+/-- The fixed space is closed in `Lᵖ`. -/
+theorem isClosed_fixedSpace (T : Ω → Ω) (hT : MeasurePreserving T μ μ) :
+    IsClosed (fixedSpace (𝕜 := 𝕜) (E := E) (p := p) T hT : Set (Lp E p μ)) := by
+  change IsClosed
+    (((Lp.compMeasurePreservingₗᵢ 𝕜 T hT).toContinuousLinearMap.eqLocus 1 :
+      Submodule 𝕜 (Lp E p μ)) : Set (Lp E p μ))
+  exact (Lp.compMeasurePreservingₗᵢ 𝕜 T hT).toContinuousLinearMap.isClosed_eqLocus
+    (1 : Lp E p μ →L[𝕜] Lp E p μ)
+
+variable [CompleteSpace E]
+
+instance fixedSpace.completeSpace (T : Ω → Ω) (hT : MeasurePreserving T μ μ) :
+    CompleteSpace (fixedSpace (𝕜 := 𝕜) (E := E) (p := p) T hT) := by
+  change CompleteSpace
+    ((Lp.compMeasurePreservingₗᵢ 𝕜 T hT).toContinuousLinearMap.toLinearMap.eqLocus
+      (1 : Lp E p μ →L[𝕜] Lp E p μ).toLinearMap)
+  infer_instance
+
+end Complete
 
 end TauCeti.Probability

--- a/TauCeti/Probability/Ergodic/FixedSpace.lean
+++ b/TauCeti/Probability/Ergodic/FixedSpace.lean
@@ -1,16 +1,17 @@
 module
 
-public import Mathlib.MeasureTheory.Function.L2Space
+public import Mathlib.MeasureTheory.Function.LpSpace.Complete
+public import Mathlib.Analysis.Normed.Operator.NormedSpace
 
 /-!
 # Fixed space of a measure-preserving transformation
 
 This file packages the fixed-point subspace for the composition operator of a
-measure-preserving transformation on `L²`.  This is the closed subspace onto which the mean
+measure-preserving transformation on `Lᵖ`. This is the closed subspace onto which the mean
 ergodic projection in the Koopman route to de Finetti's theorem will project.
 
 Mathlib already supplies the composition linear isometry
-`MeasureTheory.Lp.compMeasurePreservingₗᵢ` and the abstract mean ergodic theorem.  We use those
+`MeasureTheory.Lp.compMeasurePreservingₗᵢ` and the abstract mean ergodic theorem. We use those
 directly: `fixedSpace` is the equality locus of the composition operator and the identity.
 -/
 
@@ -19,55 +20,71 @@ public section
 noncomputable section
 
 open Function MeasureTheory
+open scoped ENNReal
 
 namespace TauCeti.Probability
 
-variable {Ω 𝕜 : Type*} [MeasurableSpace Ω] [RCLike 𝕜] {μ : Measure Ω}
+variable {Ω 𝕜 E : Type*} [MeasurableSpace Ω] [NontriviallyNormedField 𝕜] [NormedAddCommGroup E]
+  [NormedSpace 𝕜 E]
+variable {p : ℝ≥0∞} [Fact (1 ≤ p)] {μ : Measure Ω}
 
-/-- The continuous linear composition operator on `L²` associated to a measure-preserving
-transformation.  This is a change-of-presentation accessor for Mathlib's linear isometry, used
-to feed the continuous-linear-map mean ergodic API. -/
-abbrev compMeasurePreservingL2 (T : Ω → Ω) (hT : MeasurePreserving T μ μ) :
-    Lp 𝕜 2 μ →L[𝕜] Lp 𝕜 2 μ :=
+/-- The continuous linear composition operator on `Lᵖ` associated to a measure-preserving
+transformation. This packages Mathlib's linear isometry as a continuous linear map. -/
+def compMeasurePreservingLp (T : Ω → Ω) (hT : MeasurePreserving T μ μ) :
+    Lp E p μ →L[𝕜] Lp E p μ :=
   (Lp.compMeasurePreservingₗᵢ 𝕜 T hT).toContinuousLinearMap
 
-/-- The subspace of `L²` observables fixed by composition with a measure-preserving
-transformation. -/
-abbrev fixedSpace (T : Ω → Ω) (hT : MeasurePreserving T μ μ) : Submodule 𝕜 (Lp 𝕜 2 μ) :=
-  (compMeasurePreservingL2 T hT).eqLocus 1
-
-/-- Membership in `fixedSpace` means invariance under the composition operator. -/
-theorem mem_fixedSpace_iff {T : Ω → Ω} (hT : MeasurePreserving T μ μ) (g : Lp 𝕜 2 μ) :
-    g ∈ fixedSpace T hT ↔ Lp.compMeasurePreserving T hT g = g := by
+/-- Applying the continuous linear composition operator agrees with Mathlib's composition map. -/
+@[simp]
+theorem compMeasurePreservingLp_apply (T : Ω → Ω) (hT : MeasurePreserving T μ μ)
+    (g : Lp E p μ) :
+    compMeasurePreservingLp (𝕜 := 𝕜) T hT g = Lp.compMeasurePreserving T hT g := by
   rfl
 
-/-- A fixed `L²` observable is represented by a function invariant under `T` almost
+/-- The composition operator is a contraction. -/
+theorem norm_compMeasurePreservingLp_le (T : Ω → Ω) (hT : MeasurePreserving T μ μ) :
+    ‖compMeasurePreservingLp (𝕜 := 𝕜) (E := E) (p := p) T hT‖ ≤ 1 :=
+  LinearIsometry.norm_toContinuousLinearMap_le _
+
+/-- The subspace of `Lᵖ` observables fixed by composition with a measure-preserving
+transformation. -/
+def fixedSpace (T : Ω → Ω) (hT : MeasurePreserving T μ μ) : Submodule 𝕜 (Lp E p μ) :=
+  (compMeasurePreservingLp T hT).eqLocus 1
+
+/-- Membership in `fixedSpace` means invariance under the composition operator. -/
+@[simp]
+theorem mem_fixedSpace_iff {T : Ω → Ω} (hT : MeasurePreserving T μ μ) (g : Lp E p μ) :
+    g ∈ fixedSpace (𝕜 := 𝕜) T hT ↔ Lp.compMeasurePreserving T hT g = g := by
+  rw [fixedSpace, LinearMap.mem_eqLocus]
+  simp
+
+/-- A fixed `Lᵖ` observable is represented by a function invariant under `T` almost
 everywhere. -/
-theorem comp_ae_eq_of_mem_fixedSpace {T : Ω → Ω} (hT : MeasurePreserving T μ μ)
-    {g : Lp 𝕜 2 μ} (hg : g ∈ fixedSpace T hT) :
-    (g : Ω → 𝕜) ∘ T =ᵐ[μ] g := by
+theorem comp_ae_eq_self_of_mem_fixedSpace {T : Ω → Ω} (hT : MeasurePreserving T μ μ)
+    {g : Lp E p μ} (hg : g ∈ fixedSpace (𝕜 := 𝕜) T hT) :
+    (g : Ω → E) ∘ T =ᵐ[μ] g := by
   have hcomp : Lp.compMeasurePreserving T hT g = g := (mem_fixedSpace_iff hT g).mp hg
   simpa only [hcomp] using (Lp.coeFn_compMeasurePreserving g hT).symm
 
-/-- An `L²` observable represented by a function invariant under `T` almost everywhere belongs
+/-- An `Lᵖ` observable represented by a function invariant under `T` almost everywhere belongs
 to `fixedSpace`. -/
-theorem mem_fixedSpace_of_comp_ae_eq {T : Ω → Ω} (hT : MeasurePreserving T μ μ)
-    {g : Lp 𝕜 2 μ} (hg : (g : Ω → 𝕜) ∘ T =ᵐ[μ] g) :
-    g ∈ fixedSpace T hT := by
+theorem mem_fixedSpace_of_comp_ae_eq_self {T : Ω → Ω} (hT : MeasurePreserving T μ μ)
+    {g : Lp E p μ} (hg : (g : Ω → E) ∘ T =ᵐ[μ] g) :
+    g ∈ fixedSpace (𝕜 := 𝕜) T hT := by
   rw [mem_fixedSpace_iff]
   apply Lp.ext
   exact (Lp.coeFn_compMeasurePreserving g hT).trans hg
 
-/-- Characterization of the fixed space using representatives of `L²` classes. -/
-theorem mem_fixedSpace_iff_comp_ae_eq {T : Ω → Ω} (hT : MeasurePreserving T μ μ)
-    (g : Lp 𝕜 2 μ) :
-    g ∈ fixedSpace T hT ↔ (g : Ω → 𝕜) ∘ T =ᵐ[μ] g :=
-  ⟨comp_ae_eq_of_mem_fixedSpace hT, mem_fixedSpace_of_comp_ae_eq hT⟩
+/-- Characterization of the fixed space using representatives of `Lᵖ` classes. -/
+theorem mem_fixedSpace_iff_comp_ae_eq_self {T : Ω → Ω} (hT : MeasurePreserving T μ μ)
+    (g : Lp E p μ) :
+    g ∈ fixedSpace (𝕜 := 𝕜) T hT ↔ (g : Ω → E) ∘ T =ᵐ[μ] g :=
+  ⟨comp_ae_eq_self_of_mem_fixedSpace hT, mem_fixedSpace_of_comp_ae_eq_self hT⟩
 
-/-- The fixed space of the identity transformation is all of `L²`. -/
+/-- The fixed space of the identity transformation is all of `Lᵖ`. -/
 @[simp]
 theorem fixedSpace_id :
-    fixedSpace (μ := μ) (𝕜 := 𝕜) id (MeasurePreserving.id μ) = ⊤ := by
+    fixedSpace (μ := μ) (𝕜 := 𝕜) (E := E) (p := p) id (MeasurePreserving.id μ) = ⊤ := by
   rw [eq_top_iff]
   intro g _
   rw [mem_fixedSpace_iff]
@@ -75,21 +92,24 @@ theorem fixedSpace_id :
 
 /-- Every observable fixed by `T` is fixed by every iterate of `T`. -/
 theorem mem_fixedSpace_iterate {T : Ω → Ω} (hT : MeasurePreserving T μ μ)
-    {g : Lp 𝕜 2 μ} (hg : g ∈ fixedSpace T hT) (n : ℕ) :
-    g ∈ fixedSpace (T^[n]) (hT.iterate n) := by
+    {g : Lp E p μ} (hg : g ∈ fixedSpace (𝕜 := 𝕜) T hT) (n : ℕ) :
+    g ∈ fixedSpace (𝕜 := 𝕜) (T^[n]) (hT.iterate n) := by
   rw [mem_fixedSpace_iff, ← Lp.compMeasurePreserving_iterate]
   exact IsFixedPt.iterate (mem_fixedSpace_iff hT g |>.mp hg) n
 
-instance fixedSpace.completeSpace (T : Ω → Ω) (hT : MeasurePreserving T μ μ) :
-    CompleteSpace (fixedSpace (𝕜 := 𝕜) T hT) := by
+instance fixedSpace.completeSpace [CompleteSpace E] (T : Ω → Ω)
+    (hT : MeasurePreserving T μ μ) :
+    CompleteSpace (fixedSpace (𝕜 := 𝕜) (E := E) (p := p) T hT) := by
   rw [fixedSpace]
-  exact (ContinuousLinearMap.isComplete_eqLocus (compMeasurePreservingL2 T hT)
-    (1 : Lp 𝕜 2 μ →L[𝕜] Lp 𝕜 2 μ)).completeSpace_coe
+  change CompleteSpace ((compMeasurePreservingLp (𝕜 := 𝕜) T hT).toLinearMap.eqLocus
+    (1 : Lp E p μ →L[𝕜] Lp E p μ).toLinearMap)
+  infer_instance
 
-/-- The fixed space is closed in `L²`. -/
+/-- The fixed space is closed in `Lᵖ`. -/
 theorem isClosed_fixedSpace (T : Ω → Ω) (hT : MeasurePreserving T μ μ) :
-    IsClosed (fixedSpace (𝕜 := 𝕜) T hT : Set (Lp 𝕜 2 μ)) :=
-  ContinuousLinearMap.isClosed_eqLocus (compMeasurePreservingL2 T hT)
-    (1 : Lp 𝕜 2 μ →L[𝕜] Lp 𝕜 2 μ)
+    IsClosed (fixedSpace (𝕜 := 𝕜) (E := E) (p := p) T hT : Set (Lp E p μ)) := by
+  rw [fixedSpace]
+  exact ContinuousLinearMap.isClosed_eqLocus (compMeasurePreservingLp T hT)
+    (1 : Lp E p μ →L[𝕜] Lp E p μ)
 
 end TauCeti.Probability

--- a/TauCeti/Probability/Ergodic/FixedSpace.lean
+++ b/TauCeti/Probability/Ergodic/FixedSpace.lean
@@ -39,7 +39,9 @@ theorem fixedSpace_def (T : Ω → Ω) (hT : MeasurePreserving T μ μ) :
 
 private theorem compMeasurePreservingₗ_apply (T : Ω → Ω) (hT : MeasurePreserving T μ μ)
     (g : Lp E p μ) :
-    Lp.compMeasurePreservingₗ 𝕜 T hT g = Lp.compMeasurePreserving T hT g := rfl
+    Lp.compMeasurePreservingₗ 𝕜 T hT g = Lp.compMeasurePreserving T hT g := by
+  rw [Lp.compMeasurePreservingₗ_apply]
+  exact congrFun (AddHom.toFun_eq_coe (Lp.compMeasurePreserving T hT).toAddHom) g
 
 /-- Membership in the fixed space means being fixed by the composition operator. -/
 @[simp]
@@ -94,7 +96,19 @@ private theorem compMeasurePreservingₗᵢ_eq_one_iff
     (Lp.compMeasurePreservingₗᵢ 𝕜 T hT).toContinuousLinearMap.toLinearMap g =
         (1 : Lp E p μ →L[𝕜] Lp E p μ).toLinearMap g ↔
       Lp.compMeasurePreserving T hT g = g := by
-  rfl
+  rw [show
+    (Lp.compMeasurePreservingₗᵢ 𝕜 T hT).toContinuousLinearMap.toLinearMap g =
+        Lp.compMeasurePreserving T hT g by
+      rw [show
+        (Lp.compMeasurePreservingₗᵢ 𝕜 T hT).toContinuousLinearMap.toLinearMap g =
+            Lp.compMeasurePreservingₗᵢ 𝕜 T hT g from
+          (congrFun (LinearMap.coe_coe
+            (f := (Lp.compMeasurePreservingₗᵢ 𝕜 T hT).toContinuousLinearMap)) g).trans
+            (congrFun (LinearIsometry.coe_toContinuousLinearMap _) g)]
+      exact compMeasurePreservingₗ_apply T hT g]
+  rw [show (1 : Lp E p μ →L[𝕜] Lp E p μ).toLinearMap g = g from
+    (congrFun (LinearMap.coe_coe (f := (1 : Lp E p μ →L[𝕜] Lp E p μ))) g).trans
+      (one_apply_eq_self g)]
 
 private theorem fixedSpace_eq_eqLocus (T : Ω → Ω) (hT : MeasurePreserving T μ μ) :
     fixedSpace (𝕜 := 𝕜) (E := E) (p := p) T hT =

--- a/TauCeti/Probability/Ergodic/FixedSpace.lean
+++ b/TauCeti/Probability/Ergodic/FixedSpace.lean
@@ -39,8 +39,8 @@ abbrev fixedSpace (T : Ω → Ω) (hT : MeasurePreserving T μ μ) : Submodule �
 /-- Membership in `fixedSpace` means invariance under the composition operator. -/
 @[simp]
 theorem mem_fixedSpace_iff {T : Ω → Ω} (hT : MeasurePreserving T μ μ) (g : Lp 𝕜 2 μ) :
-    g ∈ fixedSpace T hT ↔ Lp.compMeasurePreserving T hT g = g := by
-  change (Lp.compMeasurePreservingₗᵢ 𝕜 T hT) g = g ↔ _
+    (Lp.compMeasurePreservingₗᵢ 𝕜 T hT) g = g ↔
+      Lp.compMeasurePreserving T hT g = g := by
   rfl
 
 /-- A fixed `L²` observable is represented by a function invariant under `T` almost
@@ -56,6 +56,7 @@ to `fixedSpace`. -/
 theorem mem_fixedSpace_of_comp_ae_eq {T : Ω → Ω} (hT : MeasurePreserving T μ μ)
     {g : Lp 𝕜 2 μ} (hg : (g : Ω → 𝕜) ∘ T =ᵐ[μ] g) :
     g ∈ fixedSpace T hT := by
+  change (Lp.compMeasurePreservingₗᵢ 𝕜 T hT) g = g
   rw [mem_fixedSpace_iff]
   apply Lp.ext
   exact (Lp.coeFn_compMeasurePreserving g hT).trans hg
@@ -72,6 +73,7 @@ theorem fixedSpace_id :
     fixedSpace (μ := μ) (𝕜 := 𝕜) id (MeasurePreserving.id μ) = ⊤ := by
   rw [eq_top_iff]
   intro g _
+  change (Lp.compMeasurePreservingₗᵢ 𝕜 id (MeasurePreserving.id μ)) g = g
   rw [mem_fixedSpace_iff]
   exact Lp.compMeasurePreserving_id_apply g
 
@@ -79,6 +81,7 @@ theorem fixedSpace_id :
 theorem mem_fixedSpace_iterate {T : Ω → Ω} (hT : MeasurePreserving T μ μ)
     {g : Lp 𝕜 2 μ} (hg : g ∈ fixedSpace T hT) (n : ℕ) :
     g ∈ fixedSpace (T^[n]) (hT.iterate n) := by
+  change (Lp.compMeasurePreservingₗᵢ 𝕜 (T^[n]) (hT.iterate n)) g = g
   rw [mem_fixedSpace_iff, ← Lp.compMeasurePreserving_iterate]
   exact IsFixedPt.iterate (mem_fixedSpace_iff hT g |>.mp hg) n
 

--- a/TauCeti/Probability/Ergodic/FixedSpace.lean
+++ b/TauCeti/Probability/Ergodic/FixedSpace.lean
@@ -56,12 +56,6 @@ theorem compMeasurePreserving_eq_self_iff {T : Ω → Ω}
     apply Lp.ext
     exact (Lp.coeFn_compMeasurePreserving g hT).trans hg
 
-/-- Fixed-space membership characterized by almost-everywhere invariance of representatives. -/
-theorem mem_fixedSpace_iff_comp_ae_eq_self {T : Ω → Ω}
-    (hT : MeasurePreserving T μ μ) (g : Lp E p μ) :
-    g ∈ fixedSpace (𝕜 := 𝕜) T hT ↔ (g : Ω → E) ∘ T =ᵐ[μ] g := by
-  rw [mem_fixedSpace_iff, compMeasurePreserving_eq_self_iff]
-
 /-- The fixed space of the identity transformation is all of `Lᵖ`. -/
 @[simp]
 theorem fixedSpace_id :
@@ -89,11 +83,13 @@ private theorem compMeasurePreservingₗᵢ_toLinearMap_apply
     (T : Ω → Ω) (hT : MeasurePreserving T μ μ) (g : Lp E p μ) :
     (Lp.compMeasurePreservingₗᵢ 𝕜 T hT).toContinuousLinearMap.toLinearMap g =
       Lp.compMeasurePreserving T hT g := by
-  change Lp.compMeasurePreservingₗᵢ 𝕜 T hT g = Lp.compMeasurePreserving T hT g
-  rw [show Lp.compMeasurePreservingₗᵢ 𝕜 T hT g =
-      Lp.compMeasurePreservingₗ 𝕜 T hT g from
-    congrFun (LinearIsometry.coe_toLinearMap _) g]
-  exact compMeasurePreservingₗ_apply T hT g
+  calc
+    _ = Lp.compMeasurePreservingₗᵢ 𝕜 T hT g :=
+      congrFun (LinearMap.coe_coe (f :=
+        (Lp.compMeasurePreservingₗᵢ 𝕜 T hT).toContinuousLinearMap.toLinearMap)) g
+    _ = Lp.compMeasurePreservingₗ 𝕜 T hT g :=
+      congrFun (LinearIsometry.coe_toLinearMap _) g
+    _ = Lp.compMeasurePreserving T hT g := compMeasurePreservingₗ_apply T hT g
 
 private theorem fixedSpace_eq_eqLocus (T : Ω → Ω) (hT : MeasurePreserving T μ μ) :
     fixedSpace (𝕜 := 𝕜) (E := E) (p := p) T hT =
@@ -101,9 +97,12 @@ private theorem fixedSpace_eq_eqLocus (T : Ω → Ω) (hT : MeasurePreserving T 
         (1 : Lp E p μ →L[𝕜] Lp E p μ).toLinearMap := by
   ext g
   rw [mem_fixedSpace_iff, LinearMap.mem_eqLocus, compMeasurePreservingₗᵢ_toLinearMap_apply]
-  rw [show (1 : Lp E p μ →L[𝕜] Lp E p μ).toLinearMap g = g from
-    congrFun (LinearMap.coe_coe (f := (1 : Lp E p μ →L[𝕜] Lp E p μ))) g |>.trans
-      (one_apply_eq_self g)]
+  have h_one : (1 : Lp E p μ →L[𝕜] Lp E p μ).toLinearMap g = g := by
+    calc
+      _ = (1 : Lp E p μ →L[𝕜] Lp E p μ) g := congrFun (LinearMap.coe_coe (f :=
+        (1 : Lp E p μ →L[𝕜] Lp E p μ).toLinearMap)) g
+      _ = g := one_apply_eq_self g
+  rw [h_one]
 
 /-- The fixed space is closed in `Lᵖ`. -/
 theorem isClosed_fixedSpace (T : Ω → Ω) (hT : MeasurePreserving T μ μ) :

--- a/TauCeti/Probability/Ergodic/FixedSpace.lean
+++ b/TauCeti/Probability/Ergodic/FixedSpace.lean
@@ -28,13 +28,11 @@ variable {p : ℝ≥0∞} {μ : Measure Ω}
 @[simp]
 theorem mem_fixedSubmodule_iff_comp_ae_eq_self {T : Ω → Ω}
     (hT : MeasurePreserving T μ μ) (g : Lp E p μ) :
-    g ∈ (Lp.compMeasurePreservingₗ 𝕜 T hT).fixedSubmodule ↔
+    Lp.compMeasurePreserving T hT g = g ↔
       (g : Ω → E) ∘ T =ᵐ[μ] g := by
-  rw [LinearMap.mem_fixedSubmodule_iff]
   constructor
   · intro hg
-    have hcomp : Lp.compMeasurePreserving T hT g = g := hg
-    simpa only [hcomp] using (Lp.coeFn_compMeasurePreserving g hT).symm
+    simpa only [hg] using (Lp.coeFn_compMeasurePreserving g hT).symm
   · intro hg
     apply Lp.ext
     exact (Lp.coeFn_compMeasurePreserving g hT).trans hg

--- a/TauCeti/Probability/Ergodic/FixedSpace.lean
+++ b/TauCeti/Probability/Ergodic/FixedSpace.lean
@@ -37,12 +37,16 @@ theorem fixedSpace_def (T : Ω → Ω) (hT : MeasurePreserving T μ μ) :
       (Lp.compMeasurePreservingₗ 𝕜 T hT).fixedSubmodule := by
   rw [fixedSpace]
 
+private theorem compMeasurePreservingₗ_apply (T : Ω → Ω) (hT : MeasurePreserving T μ μ)
+    (g : Lp E p μ) :
+    Lp.compMeasurePreservingₗ 𝕜 T hT g = Lp.compMeasurePreserving T hT g := rfl
+
 /-- Membership in the fixed space means being fixed by the composition operator. -/
 @[simp]
 theorem mem_fixedSpace_iff {T : Ω → Ω} (hT : MeasurePreserving T μ μ) (g : Lp E p μ) :
     g ∈ fixedSpace (𝕜 := 𝕜) T hT ↔ Lp.compMeasurePreserving T hT g = g := by
   rw [fixedSpace_def, LinearMap.mem_fixedSubmodule_iff]
-  rfl
+  rw [compMeasurePreservingₗ_apply]
 
 /-- Characterization of fixed points of the `Lᵖ` composition isometry using representatives. -/
 @[simp]
@@ -85,13 +89,19 @@ variable {Ω 𝕜 E : Type*} [MeasurableSpace Ω] [NormedRing 𝕜]
   [NormedAddCommGroup E] [Module 𝕜 E] [IsBoundedSMul 𝕜 E]
 variable {p : ℝ≥0∞} [Fact (1 ≤ p)] {μ : Measure Ω}
 
+private theorem compMeasurePreservingₗᵢ_eq_one_iff
+    (T : Ω → Ω) (hT : MeasurePreserving T μ μ) (g : Lp E p μ) :
+    (Lp.compMeasurePreservingₗᵢ 𝕜 T hT).toContinuousLinearMap.toLinearMap g =
+        (1 : Lp E p μ →L[𝕜] Lp E p μ).toLinearMap g ↔
+      Lp.compMeasurePreserving T hT g = g := by
+  rfl
+
 private theorem fixedSpace_eq_eqLocus (T : Ω → Ω) (hT : MeasurePreserving T μ μ) :
     fixedSpace (𝕜 := 𝕜) (E := E) (p := p) T hT =
       (Lp.compMeasurePreservingₗᵢ 𝕜 T hT).toContinuousLinearMap.toLinearMap.eqLocus
         (1 : Lp E p μ →L[𝕜] Lp E p μ).toLinearMap := by
   ext g
-  rw [mem_fixedSpace_iff]
-  rfl
+  rw [mem_fixedSpace_iff, LinearMap.mem_eqLocus, compMeasurePreservingₗᵢ_eq_one_iff]
 
 /-- The fixed space is closed in `Lᵖ`. -/
 theorem isClosed_fixedSpace (T : Ω → Ω) (hT : MeasurePreserving T μ μ) :

--- a/TauCeti/Probability/Ergodic/FixedSpace.lean
+++ b/TauCeti/Probability/Ergodic/FixedSpace.lean
@@ -1,18 +1,14 @@
 module
 
 public import Mathlib.MeasureTheory.Function.LpSpace.Complete
-public import Mathlib.Analysis.Normed.Operator.NormedSpace
+public import Mathlib.LinearAlgebra.FixedSubmodule
 
 /-!
-# Fixed space of a measure-preserving transformation
+# Fixed points of a measure-preserving transformation on `Lᵖ`
 
-This file packages the fixed-point subspace for the composition operator of a
-measure-preserving transformation on `Lᵖ`. This is the closed subspace onto which the mean
+This file relates membership in Mathlib's fixed submodule for the `Lᵖ` composition isometry to
+almost-everywhere invariance of representatives. This is the closed subspace onto which the mean
 ergodic projection in the Koopman route to de Finetti's theorem will project.
-
-Mathlib already supplies the composition linear isometry
-`MeasureTheory.Lp.compMeasurePreservingₗᵢ` and the abstract mean ergodic theorem. We use those
-directly: `fixedSpace` is the equality locus of the composition operator and the identity.
 -/
 
 public section
@@ -28,88 +24,29 @@ variable {Ω 𝕜 E : Type*} [MeasurableSpace Ω] [NontriviallyNormedField 𝕜]
   [NormedSpace 𝕜 E]
 variable {p : ℝ≥0∞} [Fact (1 ≤ p)] {μ : Measure Ω}
 
-/-- The continuous linear composition operator on `Lᵖ` associated to a measure-preserving
-transformation. This packages Mathlib's linear isometry as a continuous linear map. -/
-def compMeasurePreservingLp (T : Ω → Ω) (hT : MeasurePreserving T μ μ) :
-    Lp E p μ →L[𝕜] Lp E p μ :=
-  (Lp.compMeasurePreservingₗᵢ 𝕜 T hT).toContinuousLinearMap
-
-/-- Applying the continuous linear composition operator agrees with Mathlib's composition map. -/
-@[simp]
-theorem compMeasurePreservingLp_apply (T : Ω → Ω) (hT : MeasurePreserving T μ μ)
-    (g : Lp E p μ) :
-    compMeasurePreservingLp (𝕜 := 𝕜) T hT g = Lp.compMeasurePreserving T hT g := by
-  rfl
-
-/-- The composition operator is a contraction. -/
-theorem norm_compMeasurePreservingLp_le (T : Ω → Ω) (hT : MeasurePreserving T μ μ) :
-    ‖compMeasurePreservingLp (𝕜 := 𝕜) (E := E) (p := p) T hT‖ ≤ 1 :=
-  LinearIsometry.norm_toContinuousLinearMap_le _
-
-/-- The subspace of `Lᵖ` observables fixed by composition with a measure-preserving
-transformation. -/
-def fixedSpace (T : Ω → Ω) (hT : MeasurePreserving T μ μ) : Submodule 𝕜 (Lp E p μ) :=
-  (compMeasurePreservingLp T hT).eqLocus 1
-
-/-- Membership in `fixedSpace` means invariance under the composition operator. -/
-@[simp]
-theorem mem_fixedSpace_iff {T : Ω → Ω} (hT : MeasurePreserving T μ μ) (g : Lp E p μ) :
-    g ∈ fixedSpace (𝕜 := 𝕜) T hT ↔ Lp.compMeasurePreserving T hT g = g := by
-  rw [fixedSpace, LinearMap.mem_eqLocus]
-  simp
-
 /-- A fixed `Lᵖ` observable is represented by a function invariant under `T` almost
 everywhere. -/
-theorem comp_ae_eq_self_of_mem_fixedSpace {T : Ω → Ω} (hT : MeasurePreserving T μ μ)
-    {g : Lp E p μ} (hg : g ∈ fixedSpace (𝕜 := 𝕜) T hT) :
+theorem comp_ae_eq_self_of_mem_fixedSubmodule {T : Ω → Ω} (hT : MeasurePreserving T μ μ)
+    {g : Lp E p μ}
+    (hg : g ∈ (Lp.compMeasurePreservingₗᵢ 𝕜 T hT).toLinearMap.fixedSubmodule) :
     (g : Ω → E) ∘ T =ᵐ[μ] g := by
-  have hcomp : Lp.compMeasurePreserving T hT g = g := (mem_fixedSpace_iff hT g).mp hg
+  have hcomp : Lp.compMeasurePreserving T hT g = g := LinearMap.mem_fixedSubmodule_iff.mp hg
   simpa only [hcomp] using (Lp.coeFn_compMeasurePreserving g hT).symm
 
 /-- An `Lᵖ` observable represented by a function invariant under `T` almost everywhere belongs
-to `fixedSpace`. -/
-theorem mem_fixedSpace_of_comp_ae_eq_self {T : Ω → Ω} (hT : MeasurePreserving T μ μ)
+to the fixed submodule of the composition isometry. -/
+theorem mem_fixedSubmodule_of_comp_ae_eq_self {T : Ω → Ω} (hT : MeasurePreserving T μ μ)
     {g : Lp E p μ} (hg : (g : Ω → E) ∘ T =ᵐ[μ] g) :
-    g ∈ fixedSpace (𝕜 := 𝕜) T hT := by
-  rw [mem_fixedSpace_iff]
+    g ∈ (Lp.compMeasurePreservingₗᵢ 𝕜 T hT).toLinearMap.fixedSubmodule := by
+  rw [LinearMap.mem_fixedSubmodule_iff]
   apply Lp.ext
   exact (Lp.coeFn_compMeasurePreserving g hT).trans hg
 
-/-- Characterization of the fixed space using representatives of `Lᵖ` classes. -/
-theorem mem_fixedSpace_iff_comp_ae_eq_self {T : Ω → Ω} (hT : MeasurePreserving T μ μ)
-    (g : Lp E p μ) :
-    g ∈ fixedSpace (𝕜 := 𝕜) T hT ↔ (g : Ω → E) ∘ T =ᵐ[μ] g :=
-  ⟨comp_ae_eq_self_of_mem_fixedSpace hT, mem_fixedSpace_of_comp_ae_eq_self hT⟩
-
-/-- The fixed space of the identity transformation is all of `Lᵖ`. -/
-@[simp]
-theorem fixedSpace_id :
-    fixedSpace (μ := μ) (𝕜 := 𝕜) (E := E) (p := p) id (MeasurePreserving.id μ) = ⊤ := by
-  rw [eq_top_iff]
-  intro g _
-  rw [mem_fixedSpace_iff]
-  exact Lp.compMeasurePreserving_id_apply g
-
-/-- Every observable fixed by `T` is fixed by every iterate of `T`. -/
-theorem mem_fixedSpace_iterate {T : Ω → Ω} (hT : MeasurePreserving T μ μ)
-    {g : Lp E p μ} (hg : g ∈ fixedSpace (𝕜 := 𝕜) T hT) (n : ℕ) :
-    g ∈ fixedSpace (𝕜 := 𝕜) (T^[n]) (hT.iterate n) := by
-  rw [mem_fixedSpace_iff, ← Lp.compMeasurePreserving_iterate]
-  exact IsFixedPt.iterate (mem_fixedSpace_iff hT g |>.mp hg) n
-
-instance fixedSpace.completeSpace [CompleteSpace E] (T : Ω → Ω)
-    (hT : MeasurePreserving T μ μ) :
-    CompleteSpace (fixedSpace (𝕜 := 𝕜) (E := E) (p := p) T hT) := by
-  rw [fixedSpace]
-  change CompleteSpace ((compMeasurePreservingLp (𝕜 := 𝕜) T hT).toLinearMap.eqLocus
-    (1 : Lp E p μ →L[𝕜] Lp E p μ).toLinearMap)
-  infer_instance
-
-/-- The fixed space is closed in `Lᵖ`. -/
-theorem isClosed_fixedSpace (T : Ω → Ω) (hT : MeasurePreserving T μ μ) :
-    IsClosed (fixedSpace (𝕜 := 𝕜) (E := E) (p := p) T hT : Set (Lp E p μ)) := by
-  rw [fixedSpace]
-  exact ContinuousLinearMap.isClosed_eqLocus (compMeasurePreservingLp T hT)
-    (1 : Lp E p μ →L[𝕜] Lp E p μ)
+/-- Characterization of fixed points of the `Lᵖ` composition isometry using representatives. -/
+theorem mem_fixedSubmodule_iff_comp_ae_eq_self {T : Ω → Ω}
+    (hT : MeasurePreserving T μ μ) (g : Lp E p μ) :
+    g ∈ (Lp.compMeasurePreservingₗᵢ 𝕜 T hT).toLinearMap.fixedSubmodule ↔
+      (g : Ω → E) ∘ T =ᵐ[μ] g :=
+  ⟨comp_ae_eq_self_of_mem_fixedSubmodule hT, mem_fixedSubmodule_of_comp_ae_eq_self hT⟩
 
 end TauCeti.Probability

--- a/TauCeti/Probability/Ergodic/FixedSpace.lean
+++ b/TauCeti/Probability/Ergodic/FixedSpace.lean
@@ -1,0 +1,97 @@
+module
+
+public import Mathlib.MeasureTheory.Function.L2Space
+
+/-!
+# Fixed space of a measure-preserving transformation
+
+This file packages the fixed-point subspace for the composition operator of a
+measure-preserving transformation on `L²`.  This is the closed subspace onto which the mean
+ergodic projection in the Koopman route to de Finetti's theorem will project.
+
+Mathlib already supplies the composition linear isometry
+`MeasureTheory.Lp.compMeasurePreservingₗᵢ` and the abstract mean ergodic theorem.  We use those
+directly: `fixedSpace` is the equality locus of the composition operator and the identity.
+-/
+
+public section
+
+noncomputable section
+
+open Function MeasureTheory
+
+namespace TauCeti.Probability
+
+variable {Ω 𝕜 : Type*} [MeasurableSpace Ω] [RCLike 𝕜] {μ : Measure Ω}
+
+/-- The continuous linear composition operator on `L²` associated to a measure-preserving
+transformation.  This is a change-of-presentation accessor for Mathlib's linear isometry, used
+to feed the continuous-linear-map mean ergodic API. -/
+abbrev compMeasurePreservingL2 (T : Ω → Ω) (hT : MeasurePreserving T μ μ) :
+    Lp 𝕜 2 μ →L[𝕜] Lp 𝕜 2 μ :=
+  (Lp.compMeasurePreservingₗᵢ 𝕜 T hT).toContinuousLinearMap
+
+/-- The subspace of `L²` observables fixed by composition with a measure-preserving
+transformation. -/
+abbrev fixedSpace (T : Ω → Ω) (hT : MeasurePreserving T μ μ) : Submodule 𝕜 (Lp 𝕜 2 μ) :=
+  (compMeasurePreservingL2 T hT).eqLocus 1
+
+/-- Membership in `fixedSpace` means invariance under the composition operator. -/
+@[simp]
+theorem mem_fixedSpace_iff {T : Ω → Ω} (hT : MeasurePreserving T μ μ) (g : Lp 𝕜 2 μ) :
+    g ∈ fixedSpace T hT ↔ Lp.compMeasurePreserving T hT g = g := by
+  change (Lp.compMeasurePreservingₗᵢ 𝕜 T hT) g = g ↔ _
+  rfl
+
+/-- A fixed `L²` observable is represented by a function invariant under `T` almost
+everywhere. -/
+theorem comp_ae_eq_of_mem_fixedSpace {T : Ω → Ω} (hT : MeasurePreserving T μ μ)
+    {g : Lp 𝕜 2 μ} (hg : g ∈ fixedSpace T hT) :
+    (g : Ω → 𝕜) ∘ T =ᵐ[μ] g := by
+  have hcomp : Lp.compMeasurePreserving T hT g = g := (mem_fixedSpace_iff hT g).mp hg
+  simpa only [hcomp] using (Lp.coeFn_compMeasurePreserving g hT).symm
+
+/-- An `L²` observable represented by a function invariant under `T` almost everywhere belongs
+to `fixedSpace`. -/
+theorem mem_fixedSpace_of_comp_ae_eq {T : Ω → Ω} (hT : MeasurePreserving T μ μ)
+    {g : Lp 𝕜 2 μ} (hg : (g : Ω → 𝕜) ∘ T =ᵐ[μ] g) :
+    g ∈ fixedSpace T hT := by
+  rw [mem_fixedSpace_iff]
+  apply Lp.ext
+  exact (Lp.coeFn_compMeasurePreserving g hT).trans hg
+
+/-- Characterization of the fixed space using representatives of `L²` classes. -/
+theorem mem_fixedSpace_iff_comp_ae_eq {T : Ω → Ω} (hT : MeasurePreserving T μ μ)
+    (g : Lp 𝕜 2 μ) :
+    g ∈ fixedSpace T hT ↔ (g : Ω → 𝕜) ∘ T =ᵐ[μ] g :=
+  ⟨comp_ae_eq_of_mem_fixedSpace hT, mem_fixedSpace_of_comp_ae_eq hT⟩
+
+/-- The fixed space of the identity transformation is all of `L²`. -/
+@[simp]
+theorem fixedSpace_id :
+    fixedSpace (μ := μ) (𝕜 := 𝕜) id (MeasurePreserving.id μ) = ⊤ := by
+  rw [eq_top_iff]
+  intro g _
+  rw [mem_fixedSpace_iff]
+  exact Lp.compMeasurePreserving_id_apply g
+
+/-- Every observable fixed by `T` is fixed by every iterate of `T`. -/
+theorem mem_fixedSpace_iterate {T : Ω → Ω} (hT : MeasurePreserving T μ μ)
+    {g : Lp 𝕜 2 μ} (hg : g ∈ fixedSpace T hT) (n : ℕ) :
+    g ∈ fixedSpace (T^[n]) (hT.iterate n) := by
+  rw [mem_fixedSpace_iff, ← Lp.compMeasurePreserving_iterate]
+  exact IsFixedPt.iterate (mem_fixedSpace_iff hT g |>.mp hg) n
+
+instance fixedSpace.completeSpace (T : Ω → Ω) (hT : MeasurePreserving T μ μ) :
+    CompleteSpace (fixedSpace (𝕜 := 𝕜) T hT) := by
+  rw [fixedSpace]
+  exact (ContinuousLinearMap.isComplete_eqLocus (compMeasurePreservingL2 T hT)
+    (1 : Lp 𝕜 2 μ →L[𝕜] Lp 𝕜 2 μ)).completeSpace_coe
+
+/-- The fixed space is closed in `L²`. -/
+theorem isClosed_fixedSpace (T : Ω → Ω) (hT : MeasurePreserving T μ μ) :
+    IsClosed (fixedSpace (𝕜 := 𝕜) T hT : Set (Lp 𝕜 2 μ)) :=
+  ContinuousLinearMap.isClosed_eqLocus (compMeasurePreservingL2 T hT)
+    (1 : Lp 𝕜 2 μ →L[𝕜] Lp 𝕜 2 μ)
+
+end TauCeti.Probability

--- a/TauCeti/Probability/Ergodic/FixedSpace.lean
+++ b/TauCeti/Probability/Ergodic/FixedSpace.lean
@@ -37,7 +37,6 @@ abbrev fixedSpace (T : Ω → Ω) (hT : MeasurePreserving T μ μ) : Submodule �
   (compMeasurePreservingL2 T hT).eqLocus 1
 
 /-- Membership in `fixedSpace` means invariance under the composition operator. -/
-@[simp]
 theorem mem_fixedSpace_iff {T : Ω → Ω} (hT : MeasurePreserving T μ μ) (g : Lp 𝕜 2 μ) :
     g ∈ fixedSpace T hT ↔ Lp.compMeasurePreserving T hT g = g := by
   rfl

--- a/TauCeti/Probability/Ergodic/FixedSpace.lean
+++ b/TauCeti/Probability/Ergodic/FixedSpace.lean
@@ -1,6 +1,6 @@
 module
 
-public import Mathlib.MeasureTheory.Function.LpSpace.Complete
+public import Mathlib.MeasureTheory.Function.LpSpace.Basic
 public import Mathlib.LinearAlgebra.FixedSubmodule
 
 /-!
@@ -20,33 +20,23 @@ open scoped ENNReal
 
 namespace TauCeti.Probability
 
-variable {Ω 𝕜 E : Type*} [MeasurableSpace Ω] [NontriviallyNormedField 𝕜] [NormedAddCommGroup E]
-  [NormedSpace 𝕜 E]
-variable {p : ℝ≥0∞} [Fact (1 ≤ p)] {μ : Measure Ω}
-
-/-- A fixed `Lᵖ` observable is represented by a function invariant under `T` almost
-everywhere. -/
-theorem comp_ae_eq_self_of_mem_fixedSubmodule {T : Ω → Ω} (hT : MeasurePreserving T μ μ)
-    {g : Lp E p μ}
-    (hg : g ∈ (Lp.compMeasurePreservingₗᵢ 𝕜 T hT).toLinearMap.fixedSubmodule) :
-    (g : Ω → E) ∘ T =ᵐ[μ] g := by
-  have hcomp : Lp.compMeasurePreserving T hT g = g := LinearMap.mem_fixedSubmodule_iff.mp hg
-  simpa only [hcomp] using (Lp.coeFn_compMeasurePreserving g hT).symm
-
-/-- An `Lᵖ` observable represented by a function invariant under `T` almost everywhere belongs
-to the fixed submodule of the composition isometry. -/
-theorem mem_fixedSubmodule_of_comp_ae_eq_self {T : Ω → Ω} (hT : MeasurePreserving T μ μ)
-    {g : Lp E p μ} (hg : (g : Ω → E) ∘ T =ᵐ[μ] g) :
-    g ∈ (Lp.compMeasurePreservingₗᵢ 𝕜 T hT).toLinearMap.fixedSubmodule := by
-  rw [LinearMap.mem_fixedSubmodule_iff]
-  apply Lp.ext
-  exact (Lp.coeFn_compMeasurePreserving g hT).trans hg
+variable {Ω 𝕜 E : Type*} [MeasurableSpace Ω] [NormedRing 𝕜] [NormedAddCommGroup E]
+  [Module 𝕜 E] [IsBoundedSMul 𝕜 E]
+variable {p : ℝ≥0∞} {μ : Measure Ω}
 
 /-- Characterization of fixed points of the `Lᵖ` composition isometry using representatives. -/
+@[simp]
 theorem mem_fixedSubmodule_iff_comp_ae_eq_self {T : Ω → Ω}
     (hT : MeasurePreserving T μ μ) (g : Lp E p μ) :
-    g ∈ (Lp.compMeasurePreservingₗᵢ 𝕜 T hT).toLinearMap.fixedSubmodule ↔
-      (g : Ω → E) ∘ T =ᵐ[μ] g :=
-  ⟨comp_ae_eq_self_of_mem_fixedSubmodule hT, mem_fixedSubmodule_of_comp_ae_eq_self hT⟩
+    g ∈ (Lp.compMeasurePreservingₗ 𝕜 T hT).fixedSubmodule ↔
+      (g : Ω → E) ∘ T =ᵐ[μ] g := by
+  rw [LinearMap.mem_fixedSubmodule_iff]
+  constructor
+  · intro hg
+    have hcomp : Lp.compMeasurePreserving T hT g = g := hg
+    simpa only [hcomp] using (Lp.coeFn_compMeasurePreserving g hT).symm
+  · intro hg
+    apply Lp.ext
+    exact (Lp.coeFn_compMeasurePreserving g hT).trans hg
 
 end TauCeti.Probability

--- a/TauCeti/Probability/Ergodic/FixedSpace.lean
+++ b/TauCeti/Probability/Ergodic/FixedSpace.lean
@@ -39,8 +39,7 @@ abbrev fixedSpace (T : Ω → Ω) (hT : MeasurePreserving T μ μ) : Submodule �
 /-- Membership in `fixedSpace` means invariance under the composition operator. -/
 @[simp]
 theorem mem_fixedSpace_iff {T : Ω → Ω} (hT : MeasurePreserving T μ μ) (g : Lp 𝕜 2 μ) :
-    (Lp.compMeasurePreservingₗᵢ 𝕜 T hT) g = g ↔
-      Lp.compMeasurePreserving T hT g = g := by
+    g ∈ fixedSpace T hT ↔ Lp.compMeasurePreserving T hT g = g := by
   rfl
 
 /-- A fixed `L²` observable is represented by a function invariant under `T` almost
@@ -56,7 +55,6 @@ to `fixedSpace`. -/
 theorem mem_fixedSpace_of_comp_ae_eq {T : Ω → Ω} (hT : MeasurePreserving T μ μ)
     {g : Lp 𝕜 2 μ} (hg : (g : Ω → 𝕜) ∘ T =ᵐ[μ] g) :
     g ∈ fixedSpace T hT := by
-  change (Lp.compMeasurePreservingₗᵢ 𝕜 T hT) g = g
   rw [mem_fixedSpace_iff]
   apply Lp.ext
   exact (Lp.coeFn_compMeasurePreserving g hT).trans hg
@@ -73,7 +71,6 @@ theorem fixedSpace_id :
     fixedSpace (μ := μ) (𝕜 := 𝕜) id (MeasurePreserving.id μ) = ⊤ := by
   rw [eq_top_iff]
   intro g _
-  change (Lp.compMeasurePreservingₗᵢ 𝕜 id (MeasurePreserving.id μ)) g = g
   rw [mem_fixedSpace_iff]
   exact Lp.compMeasurePreserving_id_apply g
 
@@ -81,7 +78,6 @@ theorem fixedSpace_id :
 theorem mem_fixedSpace_iterate {T : Ω → Ω} (hT : MeasurePreserving T μ μ)
     {g : Lp 𝕜 2 μ} (hg : g ∈ fixedSpace T hT) (n : ℕ) :
     g ∈ fixedSpace (T^[n]) (hT.iterate n) := by
-  change (Lp.compMeasurePreservingₗᵢ 𝕜 (T^[n]) (hT.iterate n)) g = g
   rw [mem_fixedSpace_iff, ← Lp.compMeasurePreserving_iterate]
   exact IsFixedPt.iterate (mem_fixedSpace_iff hT g |>.mp hg) n
 

--- a/TauCeti/Probability/Ergodic/FixedSpace.lean
+++ b/TauCeti/Probability/Ergodic/FixedSpace.lean
@@ -1,6 +1,6 @@
 module
 
-public import Mathlib.MeasureTheory.Function.LpSpace.Complete
+public import Mathlib.MeasureTheory.Function.LpSpace.Basic
 public import Mathlib.LinearAlgebra.FixedSubmodule
 
 /-!

--- a/TauCeti/Probability/Ergodic/FixedSpace.lean
+++ b/TauCeti/Probability/Ergodic/FixedSpace.lean
@@ -31,12 +31,6 @@ transformation. -/
 def fixedSpace (T : Ω → Ω) (hT : MeasurePreserving T μ μ) : Submodule 𝕜 (Lp E p μ) :=
   (Lp.compMeasurePreservingₗ 𝕜 T hT).fixedSubmodule
 
-/-- The fixed space is the fixed submodule of the composition operator. -/
-theorem fixedSpace_def (T : Ω → Ω) (hT : MeasurePreserving T μ μ) :
-    fixedSpace (𝕜 := 𝕜) (E := E) (p := p) T hT =
-      (Lp.compMeasurePreservingₗ 𝕜 T hT).fixedSubmodule := by
-  rw [fixedSpace]
-
 private theorem compMeasurePreservingₗ_apply (T : Ω → Ω) (hT : MeasurePreserving T μ μ)
     (g : Lp E p μ) :
     Lp.compMeasurePreservingₗ 𝕜 T hT g = Lp.compMeasurePreserving T hT g := by
@@ -47,7 +41,7 @@ private theorem compMeasurePreservingₗ_apply (T : Ω → Ω) (hT : MeasurePres
 @[simp]
 theorem mem_fixedSpace_iff {T : Ω → Ω} (hT : MeasurePreserving T μ μ) (g : Lp E p μ) :
     g ∈ fixedSpace (𝕜 := 𝕜) T hT ↔ Lp.compMeasurePreserving T hT g = g := by
-  rw [fixedSpace_def, LinearMap.mem_fixedSubmodule_iff]
+  rw [fixedSpace, LinearMap.mem_fixedSubmodule_iff]
   rw [compMeasurePreservingₗ_apply]
 
 /-- Characterization of fixed points of the `Lᵖ` composition isometry using representatives. -/
@@ -91,31 +85,25 @@ variable {Ω 𝕜 E : Type*} [MeasurableSpace Ω] [NormedRing 𝕜]
   [NormedAddCommGroup E] [Module 𝕜 E] [IsBoundedSMul 𝕜 E]
 variable {p : ℝ≥0∞} [Fact (1 ≤ p)] {μ : Measure Ω}
 
-private theorem compMeasurePreservingₗᵢ_eq_one_iff
+private theorem compMeasurePreservingₗᵢ_toLinearMap_apply
     (T : Ω → Ω) (hT : MeasurePreserving T μ μ) (g : Lp E p μ) :
     (Lp.compMeasurePreservingₗᵢ 𝕜 T hT).toContinuousLinearMap.toLinearMap g =
-        (1 : Lp E p μ →L[𝕜] Lp E p μ).toLinearMap g ↔
-      Lp.compMeasurePreserving T hT g = g := by
-  rw [show
-    (Lp.compMeasurePreservingₗᵢ 𝕜 T hT).toContinuousLinearMap.toLinearMap g =
-        Lp.compMeasurePreserving T hT g by
-      rw [show
-        (Lp.compMeasurePreservingₗᵢ 𝕜 T hT).toContinuousLinearMap.toLinearMap g =
-            Lp.compMeasurePreservingₗᵢ 𝕜 T hT g from
-          (congrFun (LinearMap.coe_coe
-            (f := (Lp.compMeasurePreservingₗᵢ 𝕜 T hT).toContinuousLinearMap)) g).trans
-            (congrFun (LinearIsometry.coe_toContinuousLinearMap _) g)]
-      exact compMeasurePreservingₗ_apply T hT g]
-  rw [show (1 : Lp E p μ →L[𝕜] Lp E p μ).toLinearMap g = g from
-    (congrFun (LinearMap.coe_coe (f := (1 : Lp E p μ →L[𝕜] Lp E p μ))) g).trans
-      (one_apply_eq_self g)]
+      Lp.compMeasurePreserving T hT g := by
+  change Lp.compMeasurePreservingₗᵢ 𝕜 T hT g = Lp.compMeasurePreserving T hT g
+  rw [show Lp.compMeasurePreservingₗᵢ 𝕜 T hT g =
+      Lp.compMeasurePreservingₗ 𝕜 T hT g from
+    congrFun (LinearIsometry.coe_toLinearMap _) g]
+  exact compMeasurePreservingₗ_apply T hT g
 
 private theorem fixedSpace_eq_eqLocus (T : Ω → Ω) (hT : MeasurePreserving T μ μ) :
     fixedSpace (𝕜 := 𝕜) (E := E) (p := p) T hT =
       (Lp.compMeasurePreservingₗᵢ 𝕜 T hT).toContinuousLinearMap.toLinearMap.eqLocus
         (1 : Lp E p μ →L[𝕜] Lp E p μ).toLinearMap := by
   ext g
-  rw [mem_fixedSpace_iff, LinearMap.mem_eqLocus, compMeasurePreservingₗᵢ_eq_one_iff]
+  rw [mem_fixedSpace_iff, LinearMap.mem_eqLocus, compMeasurePreservingₗᵢ_toLinearMap_apply]
+  rw [show (1 : Lp E p μ →L[𝕜] Lp E p μ).toLinearMap g = g from
+    congrFun (LinearMap.coe_coe (f := (1 : Lp E p μ →L[𝕜] Lp E p μ))) g |>.trans
+      (one_apply_eq_self g)]
 
 /-- The fixed space is closed in `Lᵖ`. -/
 theorem isClosed_fixedSpace (T : Ω → Ω) (hT : MeasurePreserving T μ μ) :
@@ -124,7 +112,7 @@ theorem isClosed_fixedSpace (T : Ω → Ω) (hT : MeasurePreserving T μ μ) :
   exact (Lp.compMeasurePreservingₗᵢ 𝕜 T hT).toContinuousLinearMap.isClosed_eqLocus
     (1 : Lp E p μ →L[𝕜] Lp E p μ)
 
-variable [CompleteSpace E]
+variable [CompleteSpace (Lp E p μ)]
 
 instance fixedSpace.completeSpace (T : Ω → Ω) (hT : MeasurePreserving T μ μ) :
     CompleteSpace (fixedSpace (𝕜 := 𝕜) (E := E) (p := p) T hT) := by

--- a/TauCeti/Probability/Ergodic/FixedSpace.lean
+++ b/TauCeti/Probability/Ergodic/FixedSpace.lean
@@ -46,16 +46,21 @@ theorem mem_fixedSpace_iff {T : Ω → Ω} (hT : MeasurePreserving T μ μ) (g :
 
 /-- Characterization of fixed points of the `Lᵖ` composition isometry using representatives. -/
 @[simp]
-theorem mem_fixedSpace_iff_comp_ae_eq_self {T : Ω → Ω}
+theorem compMeasurePreserving_eq_self_iff {T : Ω → Ω}
     (hT : MeasurePreserving T μ μ) (g : Lp E p μ) :
-    g ∈ fixedSpace (𝕜 := 𝕜) T hT ↔ (g : Ω → E) ∘ T =ᵐ[μ] g := by
-  rw [mem_fixedSpace_iff]
+    Lp.compMeasurePreserving T hT g = g ↔ (g : Ω → E) ∘ T =ᵐ[μ] g := by
   constructor
   · intro hg
     simpa only [hg] using (Lp.coeFn_compMeasurePreserving g hT).symm
   · intro hg
     apply Lp.ext
     exact (Lp.coeFn_compMeasurePreserving g hT).trans hg
+
+/-- Fixed-space membership characterized by almost-everywhere invariance of representatives. -/
+theorem mem_fixedSpace_iff_comp_ae_eq_self {T : Ω → Ω}
+    (hT : MeasurePreserving T μ μ) (g : Lp E p μ) :
+    g ∈ fixedSpace (𝕜 := 𝕜) T hT ↔ (g : Ω → E) ∘ T =ᵐ[μ] g := by
+  rw [mem_fixedSpace_iff, compMeasurePreserving_eq_self_iff]
 
 /-- The fixed space of the identity transformation is all of `Lᵖ`. -/
 @[simp]


### PR DESCRIPTION
This PR adds the closed fixed-point subspace of the `L²` composition operator associated to a measure-preserving transformation, together with its representative-level characterization, identity and iterate behavior, and completeness/closedness API. Use this subspace as the codomain of the orthogonal projection in the subsequent mean-ergodic step.

This targets `TauCetiRoadmap/Exchangeability/README.md`, Layer 5, the specific generic operator-theoretic milestone `fixedSpace`. It is the lowest dependency-order milestone still missing after the Layer 0–4 and martingale-route summit material on `main`; the neighboring `koopman` operator itself already exists in pinned Mathlib as `MeasureTheory.Lp.compMeasurePreservingₗᵢ`, so this PR consumes it instead of adding a duplicate wrapper.

Reuse Mathlib's `MeasureTheory.Lp.compMeasurePreservingₗᵢ`, `Lp.coeFn_compMeasurePreserving`, composition-under-iteration theorem, and `ContinuousLinearMap.eqLocus` closedness/completeness API. No Mathlib or `cameronfreer/exchangeability` material is vendored or adapted.

The new module is `TauCeti/Probability/Ergodic/FixedSpace.lean` (97 lines). `lake exe cache get` reports `No files to download` and `Already decompressed 8639 file(s)`. `lake build` reports `Build completed successfully (5224 jobs).` `lake exe axioms` reports `axioms: audited 10877 TauCeti declaration(s); all within the allowlist [propext, Classical.choice, Quot.sound].`

<!--tauceti-target:v1 {"focus":"Exchangeability","id":"fixedspace"}-->

🤖 Prepared with Codex
