### PR TITLE
feat: split Fredholm operators

### DIFF
--- a/TauCeti/Analysis/Fredholm/Splitting.lean
+++ b/TauCeti/Analysis/Fredholm/Splitting.lean
@@ -5,7 +5,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 module
 
 public import TauCeti.Analysis.Fredholm.Basic
-public import Mathlib.Analysis.LocallyConvex.HahnBanach
+import Mathlib.Analysis.LocallyConvex.HahnBanach
 public import Mathlib.Analysis.Normed.Module.Complemented
 
 /-!
@@ -70,10 +70,12 @@ theorem closedComplemented_range (hT : _root_.TauCeti.IsFredholm T) :
   exact Submodule.ClosedComplemented.of_finiteDimensional_quotient
     (_root_.TauCeti.IsFredholm.isClosed_range hT)
 
+omit [CompleteSpace 𝕜] [CompleteSpace E] [CompleteSpace F] in
 /-- A chosen closed complement to the kernel of a Fredholm operator. -/
 noncomputable def kerComplement : Submodule 𝕜 E :=
   hT.closedComplemented_ker.complement
 
+omit [IsRCLikeNormedField 𝕜] [CompleteSpace E] [CompleteSpace F] in
 /-- A chosen finite-dimensional complement to the range of a Fredholm operator. It represents
 the cokernel inside the codomain. -/
 noncomputable def cokerComplement : Submodule 𝕜 F :=
@@ -101,6 +103,7 @@ omit [IsRCLikeNormedField 𝕜] [CompleteSpace E] [CompleteSpace F] in
 theorem isClosed_cokerComplement : IsClosed (hT.cokerComplement : Set F) :=
   hT.closedComplemented_range.isClosed_complement
 
+omit [IsRCLikeNormedField 𝕜] [CompleteSpace E] [CompleteSpace F] in
 /-- The codomain is continuously linearly equivalent to the product of the range and a chosen
 cokernel representative. -/
 noncomputable def rangeProdCokerComplementEquiv :
@@ -124,6 +127,7 @@ theorem rangeProdCokerComplementEquiv_symm_apply (x : F) :
         hT.isTopCompl_range_cokerComplement.symm x) :=
   Submodule.prodEquivOfIsTopCompl_symm_apply hT.isTopCompl_range_cokerComplement x
 
+omit [CompleteSpace 𝕜] [CompleteSpace E] [CompleteSpace F] in
 /-- The domain is continuously linearly equivalent to the product of the kernel and a chosen
 kernel complement. -/
 noncomputable def kerProdComplementEquiv :
@@ -167,8 +171,9 @@ theorem kerComplementEquivRange_apply (x : hT.kerComplement) :
   letI : CompleteSpace (LinearMap.range (T : E →ₗ[𝕜] F)) :=
     (_root_.TauCeti.IsFredholm.isClosed_range hT).completeSpace_coe
   rw [kerComplementEquivRange, LinearEquiv.coeFn_toContinuousLinearEquivOfContinuous]
-  rfl
+  exact LinearMap.kerComplementEquivRange_apply_coe _ _ x
 
+omit [IsRCLikeNormedField 𝕜] [CompleteSpace E] [CompleteSpace F] in
 /-- The cokernel of a Fredholm operator is continuously linearly equivalent to its chosen
 complement in the codomain. -/
 noncomputable def cokerEquivComplement :
@@ -189,6 +194,7 @@ theorem cokerEquivComplement_apply_mk (x : F) :
         hT.isTopCompl_range_cokerComplement.isCompl.symm x :=
   Submodule.quotientEquivOfIsTopCompl_apply_mk hT.isTopCompl_range_cokerComplement x
 
+omit [IsRCLikeNormedField 𝕜] [CompleteSpace E] [CompleteSpace F] in
 noncomputable instance finiteDimensional_cokerComplement :
     FiniteDimensional 𝕜 hT.cokerComplement := by
   letI := _root_.TauCeti.IsFredholm.finiteDimensional_coker hT

--- a/TauCeti/Analysis/Fredholm/Splitting.lean
+++ b/TauCeti/Analysis/Fredholm/Splitting.lean
@@ -152,6 +152,7 @@ complement onto its range. -/
 noncomputable def kerComplementEquivRange :
     hT.kerComplement ≃L[𝕜] LinearMap.range (T : E →ₗ[𝕜] F) := by
   letI : CompleteSpace hT.kerComplement := hT.isClosed_kerComplement.completeSpace_coe
+  -- `toContinuousLinearEquivOfContinuous` requires both sides to be complete.
   letI : CompleteSpace (LinearMap.range (T : E →ₗ[𝕜] F)) :=
     (_root_.TauCeti.IsFredholm.isClosed_range hT).completeSpace_coe
   exact (LinearMap.kerComplementEquivRange (T : E →ₗ[𝕜] F)

--- a/TauCeti/Analysis/Fredholm/Splitting.lean
+++ b/TauCeti/Analysis/Fredholm/Splitting.lean
@@ -1,0 +1,194 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+module
+
+public import TauCeti.Analysis.Fredholm.Basic
+public import Mathlib.Analysis.LocallyConvex.HahnBanach
+public import Mathlib.Analysis.Normed.Module.Complemented
+
+/-!
+# Splittings for Fredholm operators
+
+This file proves the kernel and range splitting statements for a Fredholm operator between
+Banach spaces. Over `IsRCLikeNormedField` scalars, the finite-dimensional kernel has a closed
+complement by Hahn--Banach. The closed range has a closed complement because its quotient, the
+cokernel, is finite-dimensional. The operator restricts to a continuous linear equivalence from
+the chosen kernel complement onto its range.
+
+These are the splittings used in the local normal form of a Fredholm map and in finite-dimensional
+reduction. The complements are deliberately noncanonical; their defining properties, rather than
+their chosen values, form the public API.
+
+## Main declarations
+
+* `TauCeti.IsFredholm.kernelClosedComplemented`: the kernel of a Fredholm operator is
+  topologically complemented.
+* `TauCeti.IsFredholm.rangeClosedComplemented`: the range of a Fredholm operator is
+  topologically complemented.
+* `TauCeti.IsFredholm.kernelComplement` and `TauCeti.IsFredholm.cokernelComplement`: chosen closed
+  complements to the kernel and range.
+* `TauCeti.IsFredholm.kernelComplementEquivRange`: the restriction of the operator is a continuous
+  linear equivalence from the kernel complement to the range.
+
+The argument follows the kernel/cokernel splitting in McDuff--Salamon,
+*J-holomorphic Curves and Symplectic Topology*, Appendix A.1. The existence of a complement to a
+finite-dimensional subspace is Mathlib's Hahn--Banach theorem
+`Submodule.ClosedComplemented.of_finiteDimensional`.
+-/
+
+public section
+
+namespace TauCeti
+
+open Module
+
+variable {𝕜 E F : Type*} [NontriviallyNormedField 𝕜] [IsRCLikeNormedField 𝕜]
+  [CompleteSpace 𝕜]
+variable [NormedAddCommGroup E] [NormedSpace 𝕜 E] [CompleteSpace E]
+variable [NormedAddCommGroup F] [NormedSpace 𝕜 F] [CompleteSpace F]
+
+namespace IsFredholm
+
+variable {T : E →L[𝕜] F} (hT : _root_.TauCeti.IsFredholm T)
+
+omit [CompleteSpace 𝕜] [CompleteSpace E] [CompleteSpace F] in
+/-- The kernel of a Fredholm operator is topologically complemented. -/
+theorem kernelClosedComplemented (hT : _root_.TauCeti.IsFredholm T) :
+    (LinearMap.ker (T : E →ₗ[𝕜] F)).ClosedComplemented := by
+  letI := _root_.TauCeti.IsFredholm.finiteDimensional_ker hT
+  exact Submodule.ClosedComplemented.of_finiteDimensional _
+
+omit [IsRCLikeNormedField 𝕜] [CompleteSpace E] [CompleteSpace F] in
+/-- The range of a Fredholm operator is topologically complemented. -/
+theorem rangeClosedComplemented (hT : _root_.TauCeti.IsFredholm T) :
+    (LinearMap.range (T : E →ₗ[𝕜] F)).ClosedComplemented := by
+  letI := _root_.TauCeti.IsFredholm.finiteDimensional_coker hT
+  exact Submodule.ClosedComplemented.of_finiteDimensional_quotient
+    (_root_.TauCeti.IsFredholm.isClosed_range hT)
+
+/-- A chosen closed complement to the kernel of a Fredholm operator. -/
+noncomputable def kernelComplement : Submodule 𝕜 E :=
+  hT.kernelClosedComplemented.complement
+
+/-- A chosen finite-dimensional complement to the range of a Fredholm operator. It represents
+the cokernel inside the codomain. -/
+noncomputable def cokernelComplement : Submodule 𝕜 F :=
+  hT.rangeClosedComplemented.complement
+
+omit [CompleteSpace 𝕜] [CompleteSpace E] [CompleteSpace F] in
+/-- The kernel and its chosen complement are topological complements. -/
+theorem isTopCompl_kernel_kernelComplement :
+    Submodule.IsTopCompl (LinearMap.ker (T : E →ₗ[𝕜] F)) hT.kernelComplement :=
+  hT.kernelClosedComplemented.isTopCompl_complement
+
+omit [IsRCLikeNormedField 𝕜] [CompleteSpace E] [CompleteSpace F] in
+/-- The range and its chosen complement are topological complements. -/
+theorem isTopCompl_range_cokernelComplement :
+    Submodule.IsTopCompl (LinearMap.range (T : E →ₗ[𝕜] F)) hT.cokernelComplement :=
+  hT.rangeClosedComplemented.isTopCompl_complement
+
+omit [CompleteSpace 𝕜] [CompleteSpace E] [CompleteSpace F] in
+/-- The chosen complement to the kernel is closed. -/
+theorem isClosed_kernelComplement : IsClosed (hT.kernelComplement : Set E) :=
+  hT.kernelClosedComplemented.isClosed_complement
+
+omit [IsRCLikeNormedField 𝕜] [CompleteSpace E] [CompleteSpace F] in
+/-- The chosen complement to the range is closed. -/
+theorem isClosed_cokernelComplement : IsClosed (hT.cokernelComplement : Set F) :=
+  hT.rangeClosedComplemented.isClosed_complement
+
+/-- The codomain is continuously linearly equivalent to the product of the range and a chosen
+cokernel representative. -/
+noncomputable def rangeProdCokernelComplementEquiv :
+    (LinearMap.range (T : E →ₗ[𝕜] F) × hT.cokernelComplement) ≃L[𝕜] F :=
+  Submodule.prodEquivOfIsTopCompl _ _ hT.isTopCompl_range_cokernelComplement
+
+omit [IsRCLikeNormedField 𝕜] [CompleteSpace E] [CompleteSpace F] in
+@[simp]
+theorem rangeProdCokernelComplementEquiv_apply
+    (x : LinearMap.range (T : E →ₗ[𝕜] F) × hT.cokernelComplement) :
+    hT.rangeProdCokernelComplementEquiv x = (x.1 : F) + x.2 :=
+  Submodule.prodEquivOfIsTopCompl_apply hT.isTopCompl_range_cokernelComplement x
+
+/-- The domain is continuously linearly equivalent to the product of the kernel and a chosen
+kernel complement. -/
+noncomputable def kernelProdComplementEquiv :
+    (LinearMap.ker (T : E →ₗ[𝕜] F) × hT.kernelComplement) ≃L[𝕜] E :=
+  Submodule.prodEquivOfIsTopCompl _ _ hT.isTopCompl_kernel_kernelComplement
+
+omit [CompleteSpace 𝕜] [CompleteSpace E] [CompleteSpace F] in
+@[simp]
+theorem kernelProdComplementEquiv_apply
+    (x : LinearMap.ker (T : E →ₗ[𝕜] F) × hT.kernelComplement) :
+    hT.kernelProdComplementEquiv x = (x.1 : E) + x.2 :=
+  Submodule.prodEquivOfIsTopCompl_apply hT.isTopCompl_kernel_kernelComplement x
+
+/-- The restriction of a Fredholm operator to its chosen kernel complement, with codomain
+restricted to its range. -/
+noncomputable def kernelComplementToRange :
+    hT.kernelComplement →L[𝕜] LinearMap.range (T : E →ₗ[𝕜] F) :=
+  (T.codRestrict _ (LinearMap.mem_range_self _)).domRestrict hT.kernelComplement
+
+omit [CompleteSpace 𝕜] [CompleteSpace E] [CompleteSpace F] in
+@[simp]
+theorem kernelComplementToRange_apply (x : hT.kernelComplement) :
+    (hT.kernelComplementToRange x : F) = T x := by
+  simp [kernelComplementToRange]
+
+omit [CompleteSpace 𝕜] [CompleteSpace E] [CompleteSpace F] in
+private theorem kernelComplementToRange_injective :
+    Function.Injective hT.kernelComplementToRange := by
+  intro x y hxy
+  apply Subtype.ext
+  have hker : (x : E) - y ∈ LinearMap.ker (T : E →ₗ[𝕜] F) := by
+    rw [LinearMap.mem_ker, map_sub]
+    rw [sub_eq_zero]
+    simpa only [kernelComplementToRange_apply, ContinuousLinearMap.coe_coe] using
+      congrArg Subtype.val hxy
+  have hcomp : (x : E) - y ∈ hT.kernelComplement := sub_mem x.2 y.2
+  have hbot : (x : E) - y ∈ (⊥ : Submodule 𝕜 E) := by
+    rw [← hT.isTopCompl_kernel_kernelComplement.isCompl.disjoint.eq_bot]
+    exact ⟨hker, hcomp⟩
+  exact sub_eq_zero.mp (by simpa using hbot)
+
+omit [CompleteSpace 𝕜] [CompleteSpace E] [CompleteSpace F] in
+private theorem kernelComplementToRange_surjective :
+    Function.Surjective hT.kernelComplementToRange := by
+  intro y
+  obtain ⟨x, hx⟩ := y.2
+  let z := (hT.kernelProdComplementEquiv).symm x
+  refine ⟨z.2, Subtype.ext ?_⟩
+  have hdecomp : (z.1 : E) + z.2 = x := by
+    rw [← hT.kernelProdComplementEquiv_apply]
+    exact hT.kernelProdComplementEquiv.apply_symm_apply x
+  calc
+    (hT.kernelComplementToRange z.2 : F) = T (z.2 : E) :=
+      hT.kernelComplementToRange_apply z.2
+    _ = T ((z.1 : E) + z.2) := by simp
+    _ = T x := congrArg T hdecomp
+    _ = y := hx
+
+/-- A Fredholm operator restricts to a continuous linear equivalence from its chosen kernel
+complement onto its range. -/
+noncomputable def kernelComplementEquivRange :
+    hT.kernelComplement ≃L[𝕜] LinearMap.range (T : E →ₗ[𝕜] F) := by
+  letI : CompleteSpace hT.kernelComplement := hT.isClosed_kernelComplement.completeSpace_coe
+  letI : CompleteSpace (LinearMap.range (T : E →ₗ[𝕜] F)) :=
+    (_root_.TauCeti.IsFredholm.isClosed_range hT).completeSpace_coe
+  exact ContinuousLinearEquiv.ofBijective hT.kernelComplementToRange
+    (LinearMap.ker_eq_bot.2 hT.kernelComplementToRange_injective)
+    (LinearMap.range_eq_top.2 hT.kernelComplementToRange_surjective)
+
+omit [CompleteSpace 𝕜] in
+@[simp]
+theorem kernelComplementEquivRange_apply (x : hT.kernelComplement) :
+    (hT.kernelComplementEquivRange x : F) = T x := by
+  simp [kernelComplementEquivRange, kernelComplementToRange_apply]
+
+end IsFredholm
+
+end TauCeti
+
+end

--- a/TauCeti/Analysis/Fredholm/Splitting.lean
+++ b/TauCeti/Analysis/Fredholm/Splitting.lean
@@ -23,14 +23,16 @@ their chosen values, form the public API.
 
 ## Main declarations
 
-* `TauCeti.IsFredholm.kernelClosedComplemented`: the kernel of a Fredholm operator is
+* `TauCeti.IsFredholm.closedComplemented_ker`: the kernel of a Fredholm operator is
   topologically complemented.
-* `TauCeti.IsFredholm.rangeClosedComplemented`: the range of a Fredholm operator is
+* `TauCeti.IsFredholm.closedComplemented_range`: the range of a Fredholm operator is
   topologically complemented.
-* `TauCeti.IsFredholm.kernelComplement` and `TauCeti.IsFredholm.cokernelComplement`: chosen closed
+* `TauCeti.IsFredholm.kerComplement` and `TauCeti.IsFredholm.cokerComplement`: chosen closed
   complements to the kernel and range.
-* `TauCeti.IsFredholm.kernelComplementEquivRange`: the restriction of the operator is a continuous
+* `TauCeti.IsFredholm.kerComplementEquivRange`: the restriction of the operator is a continuous
   linear equivalence from the kernel complement to the range.
+* `TauCeti.IsFredholm.cokerEquivComplement`: the cokernel is continuously linearly equivalent to
+  its chosen complement.
 
 The argument follows the kernel/cokernel splitting in McDuff--Salamon,
 *J-holomorphic Curves and Symplectic Topology*, Appendix A.1. The existence of a complement to a
@@ -55,137 +57,109 @@ variable {T : E →L[𝕜] F} (hT : _root_.TauCeti.IsFredholm T)
 
 omit [CompleteSpace 𝕜] [CompleteSpace E] [CompleteSpace F] in
 /-- The kernel of a Fredholm operator is topologically complemented. -/
-theorem kernelClosedComplemented (hT : _root_.TauCeti.IsFredholm T) :
+theorem closedComplemented_ker (hT : _root_.TauCeti.IsFredholm T) :
     (LinearMap.ker (T : E →ₗ[𝕜] F)).ClosedComplemented := by
   letI := _root_.TauCeti.IsFredholm.finiteDimensional_ker hT
   exact Submodule.ClosedComplemented.of_finiteDimensional _
 
 omit [IsRCLikeNormedField 𝕜] [CompleteSpace E] [CompleteSpace F] in
 /-- The range of a Fredholm operator is topologically complemented. -/
-theorem rangeClosedComplemented (hT : _root_.TauCeti.IsFredholm T) :
+theorem closedComplemented_range (hT : _root_.TauCeti.IsFredholm T) :
     (LinearMap.range (T : E →ₗ[𝕜] F)).ClosedComplemented := by
   letI := _root_.TauCeti.IsFredholm.finiteDimensional_coker hT
   exact Submodule.ClosedComplemented.of_finiteDimensional_quotient
     (_root_.TauCeti.IsFredholm.isClosed_range hT)
 
 /-- A chosen closed complement to the kernel of a Fredholm operator. -/
-noncomputable def kernelComplement : Submodule 𝕜 E :=
-  hT.kernelClosedComplemented.complement
+noncomputable def kerComplement : Submodule 𝕜 E :=
+  hT.closedComplemented_ker.complement
 
 /-- A chosen finite-dimensional complement to the range of a Fredholm operator. It represents
 the cokernel inside the codomain. -/
-noncomputable def cokernelComplement : Submodule 𝕜 F :=
-  hT.rangeClosedComplemented.complement
+noncomputable def cokerComplement : Submodule 𝕜 F :=
+  hT.closedComplemented_range.complement
 
 omit [CompleteSpace 𝕜] [CompleteSpace E] [CompleteSpace F] in
 /-- The kernel and its chosen complement are topological complements. -/
-theorem isTopCompl_kernel_kernelComplement :
-    Submodule.IsTopCompl (LinearMap.ker (T : E →ₗ[𝕜] F)) hT.kernelComplement :=
-  hT.kernelClosedComplemented.isTopCompl_complement
+theorem isTopCompl_ker_kerComplement :
+    Submodule.IsTopCompl (LinearMap.ker (T : E →ₗ[𝕜] F)) hT.kerComplement :=
+  hT.closedComplemented_ker.isTopCompl_complement
 
 omit [IsRCLikeNormedField 𝕜] [CompleteSpace E] [CompleteSpace F] in
 /-- The range and its chosen complement are topological complements. -/
-theorem isTopCompl_range_cokernelComplement :
-    Submodule.IsTopCompl (LinearMap.range (T : E →ₗ[𝕜] F)) hT.cokernelComplement :=
-  hT.rangeClosedComplemented.isTopCompl_complement
+theorem isTopCompl_range_cokerComplement :
+    Submodule.IsTopCompl (LinearMap.range (T : E →ₗ[𝕜] F)) hT.cokerComplement :=
+  hT.closedComplemented_range.isTopCompl_complement
 
 omit [CompleteSpace 𝕜] [CompleteSpace E] [CompleteSpace F] in
 /-- The chosen complement to the kernel is closed. -/
-theorem isClosed_kernelComplement : IsClosed (hT.kernelComplement : Set E) :=
-  hT.kernelClosedComplemented.isClosed_complement
+theorem isClosed_kerComplement : IsClosed (hT.kerComplement : Set E) :=
+  hT.closedComplemented_ker.isClosed_complement
 
 omit [IsRCLikeNormedField 𝕜] [CompleteSpace E] [CompleteSpace F] in
 /-- The chosen complement to the range is closed. -/
-theorem isClosed_cokernelComplement : IsClosed (hT.cokernelComplement : Set F) :=
-  hT.rangeClosedComplemented.isClosed_complement
+theorem isClosed_cokerComplement : IsClosed (hT.cokerComplement : Set F) :=
+  hT.closedComplemented_range.isClosed_complement
 
 /-- The codomain is continuously linearly equivalent to the product of the range and a chosen
 cokernel representative. -/
-noncomputable def rangeProdCokernelComplementEquiv :
-    (LinearMap.range (T : E →ₗ[𝕜] F) × hT.cokernelComplement) ≃L[𝕜] F :=
-  Submodule.prodEquivOfIsTopCompl _ _ hT.isTopCompl_range_cokernelComplement
+noncomputable def rangeProdCokerComplementEquiv :
+    (LinearMap.range (T : E →ₗ[𝕜] F) × hT.cokerComplement) ≃L[𝕜] F :=
+  Submodule.prodEquivOfIsTopCompl _ _ hT.isTopCompl_range_cokerComplement
 
 omit [IsRCLikeNormedField 𝕜] [CompleteSpace E] [CompleteSpace F] in
 @[simp]
-theorem rangeProdCokernelComplementEquiv_apply
-    (x : LinearMap.range (T : E →ₗ[𝕜] F) × hT.cokernelComplement) :
-    hT.rangeProdCokernelComplementEquiv x = (x.1 : F) + x.2 :=
-  Submodule.prodEquivOfIsTopCompl_apply hT.isTopCompl_range_cokernelComplement x
+theorem rangeProdCokerComplementEquiv_apply
+    (x : LinearMap.range (T : E →ₗ[𝕜] F) × hT.cokerComplement) :
+    hT.rangeProdCokerComplementEquiv x = (x.1 : F) + x.2 :=
+  Submodule.prodEquivOfIsTopCompl_apply hT.isTopCompl_range_cokerComplement x
 
 /-- The domain is continuously linearly equivalent to the product of the kernel and a chosen
 kernel complement. -/
-noncomputable def kernelProdComplementEquiv :
-    (LinearMap.ker (T : E →ₗ[𝕜] F) × hT.kernelComplement) ≃L[𝕜] E :=
-  Submodule.prodEquivOfIsTopCompl _ _ hT.isTopCompl_kernel_kernelComplement
+noncomputable def kerProdComplementEquiv :
+    (LinearMap.ker (T : E →ₗ[𝕜] F) × hT.kerComplement) ≃L[𝕜] E :=
+  Submodule.prodEquivOfIsTopCompl _ _ hT.isTopCompl_ker_kerComplement
 
 omit [CompleteSpace 𝕜] [CompleteSpace E] [CompleteSpace F] in
 @[simp]
-theorem kernelProdComplementEquiv_apply
-    (x : LinearMap.ker (T : E →ₗ[𝕜] F) × hT.kernelComplement) :
-    hT.kernelProdComplementEquiv x = (x.1 : E) + x.2 :=
-  Submodule.prodEquivOfIsTopCompl_apply hT.isTopCompl_kernel_kernelComplement x
-
-/-- The restriction of a Fredholm operator to its chosen kernel complement, with codomain
-restricted to its range. -/
-noncomputable def kernelComplementToRange :
-    hT.kernelComplement →L[𝕜] LinearMap.range (T : E →ₗ[𝕜] F) :=
-  (T.codRestrict _ (LinearMap.mem_range_self _)).domRestrict hT.kernelComplement
-
-omit [CompleteSpace 𝕜] [CompleteSpace E] [CompleteSpace F] in
-@[simp]
-theorem kernelComplementToRange_apply (x : hT.kernelComplement) :
-    (hT.kernelComplementToRange x : F) = T x := by
-  simp [kernelComplementToRange]
-
-omit [CompleteSpace 𝕜] [CompleteSpace E] [CompleteSpace F] in
-private theorem kernelComplementToRange_injective :
-    Function.Injective hT.kernelComplementToRange := by
-  intro x y hxy
-  apply Subtype.ext
-  have hker : (x : E) - y ∈ LinearMap.ker (T : E →ₗ[𝕜] F) := by
-    rw [LinearMap.mem_ker, map_sub]
-    rw [sub_eq_zero]
-    simpa only [kernelComplementToRange_apply, ContinuousLinearMap.coe_coe] using
-      congrArg Subtype.val hxy
-  have hcomp : (x : E) - y ∈ hT.kernelComplement := sub_mem x.2 y.2
-  have hbot : (x : E) - y ∈ (⊥ : Submodule 𝕜 E) := by
-    rw [← hT.isTopCompl_kernel_kernelComplement.isCompl.disjoint.eq_bot]
-    exact ⟨hker, hcomp⟩
-  exact sub_eq_zero.mp (by simpa using hbot)
-
-omit [CompleteSpace 𝕜] [CompleteSpace E] [CompleteSpace F] in
-private theorem kernelComplementToRange_surjective :
-    Function.Surjective hT.kernelComplementToRange := by
-  intro y
-  obtain ⟨x, hx⟩ := y.2
-  let z := (hT.kernelProdComplementEquiv).symm x
-  refine ⟨z.2, Subtype.ext ?_⟩
-  have hdecomp : (z.1 : E) + z.2 = x := by
-    rw [← hT.kernelProdComplementEquiv_apply]
-    exact hT.kernelProdComplementEquiv.apply_symm_apply x
-  calc
-    (hT.kernelComplementToRange z.2 : F) = T (z.2 : E) :=
-      hT.kernelComplementToRange_apply z.2
-    _ = T ((z.1 : E) + z.2) := by simp
-    _ = T x := congrArg T hdecomp
-    _ = y := hx
+theorem kerProdComplementEquiv_apply
+    (x : LinearMap.ker (T : E →ₗ[𝕜] F) × hT.kerComplement) :
+    hT.kerProdComplementEquiv x = (x.1 : E) + x.2 :=
+  Submodule.prodEquivOfIsTopCompl_apply hT.isTopCompl_ker_kerComplement x
 
 /-- A Fredholm operator restricts to a continuous linear equivalence from its chosen kernel
 complement onto its range. -/
-noncomputable def kernelComplementEquivRange :
-    hT.kernelComplement ≃L[𝕜] LinearMap.range (T : E →ₗ[𝕜] F) := by
-  letI : CompleteSpace hT.kernelComplement := hT.isClosed_kernelComplement.completeSpace_coe
+noncomputable def kerComplementEquivRange :
+    hT.kerComplement ≃L[𝕜] LinearMap.range (T : E →ₗ[𝕜] F) := by
+  letI : CompleteSpace hT.kerComplement := hT.isClosed_kerComplement.completeSpace_coe
   letI : CompleteSpace (LinearMap.range (T : E →ₗ[𝕜] F)) :=
     (_root_.TauCeti.IsFredholm.isClosed_range hT).completeSpace_coe
-  exact ContinuousLinearEquiv.ofBijective hT.kernelComplementToRange
-    (LinearMap.ker_eq_bot.2 hT.kernelComplementToRange_injective)
-    (LinearMap.range_eq_top.2 hT.kernelComplementToRange_surjective)
+  exact (LinearMap.kerComplementEquivRange (T : E →ₗ[𝕜] F)
+    hT.isTopCompl_ker_kerComplement.isCompl.symm).toContinuousLinearEquivOfContinuous
+      ((T.continuous.comp continuous_subtype_val).subtype_mk _)
 
 omit [CompleteSpace 𝕜] in
 @[simp]
-theorem kernelComplementEquivRange_apply (x : hT.kernelComplement) :
-    (hT.kernelComplementEquivRange x : F) = T x := by
-  simp [kernelComplementEquivRange, kernelComplementToRange_apply]
+theorem kerComplementEquivRange_apply (x : hT.kerComplement) :
+    (hT.kerComplementEquivRange x : F) = T x := by
+  rfl
+
+/-- The cokernel of a Fredholm operator is continuously linearly equivalent to its chosen
+complement in the codomain. -/
+noncomputable def cokerEquivComplement :
+    (F ⧸ LinearMap.range (T : E →ₗ[𝕜] F)) ≃L[𝕜] hT.cokerComplement :=
+  Submodule.quotientEquivOfIsTopCompl _ _ hT.isTopCompl_range_cokerComplement
+
+omit [IsRCLikeNormedField 𝕜] [CompleteSpace E] [CompleteSpace F] in
+@[simp]
+theorem cokerEquivComplement_symm_apply (x : hT.cokerComplement) :
+    hT.cokerEquivComplement.symm x = (LinearMap.range (T : E →ₗ[𝕜] F)).mkQ x :=
+  Submodule.quotientEquivOfIsTopCompl_symm_apply hT.isTopCompl_range_cokerComplement x
+
+noncomputable instance finiteDimensional_cokerComplement :
+    FiniteDimensional 𝕜 hT.cokerComplement := by
+  letI := _root_.TauCeti.IsFredholm.finiteDimensional_coker hT
+  exact hT.cokerEquivComplement.toLinearEquiv.finiteDimensional
 
 end IsFredholm
 

--- a/TauCeti/Analysis/Fredholm/Splitting.lean
+++ b/TauCeti/Analysis/Fredholm/Splitting.lean
@@ -163,6 +163,10 @@ omit [CompleteSpace 𝕜] in
 @[simp]
 theorem kerComplementEquivRange_apply (x : hT.kerComplement) :
     (hT.kerComplementEquivRange x : F) = T x := by
+  letI : CompleteSpace hT.kerComplement := hT.isClosed_kerComplement.completeSpace_coe
+  letI : CompleteSpace (LinearMap.range (T : E →ₗ[𝕜] F)) :=
+    (_root_.TauCeti.IsFredholm.isClosed_range hT).completeSpace_coe
+  rw [kerComplementEquivRange, LinearEquiv.coeFn_toContinuousLinearEquivOfContinuous]
   rfl
 
 /-- The cokernel of a Fredholm operator is continuously linearly equivalent to its chosen

--- a/TauCeti/Analysis/Fredholm/Splitting.lean
+++ b/TauCeti/Analysis/Fredholm/Splitting.lean
@@ -179,7 +179,7 @@ theorem cokerEquivComplement_symm_apply (x : hT.cokerComplement) :
 omit [IsRCLikeNormedField 𝕜] [CompleteSpace E] [CompleteSpace F] in
 @[simp]
 theorem cokerEquivComplement_apply_mk (x : F) :
-    hT.cokerEquivComplement ((LinearMap.range (T : E →ₗ[𝕜] F)).mkQ x) =
+    hT.cokerEquivComplement (Submodule.Quotient.mk x) =
       hT.cokerComplement.projectionOnto (LinearMap.range (T : E →ₗ[𝕜] F))
         hT.isTopCompl_range_cokerComplement.isCompl.symm x :=
   Submodule.quotientEquivOfIsTopCompl_apply_mk hT.isTopCompl_range_cokerComplement x

--- a/TauCeti/Analysis/Fredholm/Splitting.lean
+++ b/TauCeti/Analysis/Fredholm/Splitting.lean
@@ -114,6 +114,16 @@ theorem rangeProdCokerComplementEquiv_apply
     hT.rangeProdCokerComplementEquiv x = (x.1 : F) + x.2 :=
   Submodule.prodEquivOfIsTopCompl_apply hT.isTopCompl_range_cokerComplement x
 
+omit [IsRCLikeNormedField 𝕜] [CompleteSpace E] [CompleteSpace F] in
+@[simp]
+theorem rangeProdCokerComplementEquiv_symm_apply (x : F) :
+    hT.rangeProdCokerComplementEquiv.symm x =
+      ((LinearMap.range (T : E →ₗ[𝕜] F)).projectionOntoL hT.cokerComplement
+        hT.isTopCompl_range_cokerComplement x,
+      hT.cokerComplement.projectionOntoL (LinearMap.range (T : E →ₗ[𝕜] F))
+        hT.isTopCompl_range_cokerComplement.symm x) :=
+  Submodule.prodEquivOfIsTopCompl_symm_apply hT.isTopCompl_range_cokerComplement x
+
 /-- The domain is continuously linearly equivalent to the product of the kernel and a chosen
 kernel complement. -/
 noncomputable def kerProdComplementEquiv :
@@ -126,6 +136,16 @@ theorem kerProdComplementEquiv_apply
     (x : LinearMap.ker (T : E →ₗ[𝕜] F) × hT.kerComplement) :
     hT.kerProdComplementEquiv x = (x.1 : E) + x.2 :=
   Submodule.prodEquivOfIsTopCompl_apply hT.isTopCompl_ker_kerComplement x
+
+omit [CompleteSpace 𝕜] [CompleteSpace E] [CompleteSpace F] in
+@[simp]
+theorem kerProdComplementEquiv_symm_apply (x : E) :
+    hT.kerProdComplementEquiv.symm x =
+      ((LinearMap.ker (T : E →ₗ[𝕜] F)).projectionOntoL hT.kerComplement
+        hT.isTopCompl_ker_kerComplement x,
+      hT.kerComplement.projectionOntoL (LinearMap.ker (T : E →ₗ[𝕜] F))
+        hT.isTopCompl_ker_kerComplement.symm x) :=
+  Submodule.prodEquivOfIsTopCompl_symm_apply hT.isTopCompl_ker_kerComplement x
 
 /-- A Fredholm operator restricts to a continuous linear equivalence from its chosen kernel
 complement onto its range. -/
@@ -155,6 +175,14 @@ omit [IsRCLikeNormedField 𝕜] [CompleteSpace E] [CompleteSpace F] in
 theorem cokerEquivComplement_symm_apply (x : hT.cokerComplement) :
     hT.cokerEquivComplement.symm x = (LinearMap.range (T : E →ₗ[𝕜] F)).mkQ x :=
   Submodule.quotientEquivOfIsTopCompl_symm_apply hT.isTopCompl_range_cokerComplement x
+
+omit [IsRCLikeNormedField 𝕜] [CompleteSpace E] [CompleteSpace F] in
+@[simp]
+theorem cokerEquivComplement_apply_mk (x : F) :
+    hT.cokerEquivComplement ((LinearMap.range (T : E →ₗ[𝕜] F)).mkQ x) =
+      hT.cokerComplement.projectionOnto (LinearMap.range (T : E →ₗ[𝕜] F))
+        hT.isTopCompl_range_cokerComplement.isCompl.symm x :=
+  Submodule.quotientEquivOfIsTopCompl_apply_mk hT.isTopCompl_range_cokerComplement x
 
 noncomputable instance finiteDimensional_cokerComplement :
     FiniteDimensional 𝕜 hT.cokerComplement := by


### PR DESCRIPTION
This PR adds the kernel/cokernel splitting package for Fredholm operators between Banach spaces over real-like normed fields. It proves that the finite-dimensional kernel and finite-codimensional closed range admit closed complements, chooses those complements, packages the resulting continuous product decompositions of the domain and codomain, and identifies the chosen kernel complement continuously linearly with the operator range.

This advances `TauCetiRoadmap/HeegaardFloer/README.md`, Lane F0, specifically the target “Fredholm operators (index, stability under compact and small perturbations, kernel/cokernel splitting).” It is the smallest remaining direct continuation of the merged Fredholm foundation: the splitting is needed for finite-dimensional reduction and local normal forms before the later perturbation and Sard–Smale milestones.

The construction follows McDuff–Salamon, *J-holomorphic Curves and Symplectic Topology*, Appendix A.1. It reuses Mathlib’s Hahn–Banach consequence `Submodule.ClosedComplemented.of_finiteDimensional` for the kernel, `Submodule.ClosedComplemented.of_finiteDimensional_quotient` for the range, `Submodule.prodEquivOfIsTopCompl` for the product decompositions, and `ContinuousLinearEquiv.ofBijective` for the restricted operator. No Mathlib infrastructure is vendored.

The new file is `TauCeti/Analysis/Fredholm/Splitting.lean` (194 lines). `lake exe cache get` completed with `No files to download` and `Already decompressed 8639 file(s)`. `lake build` reported `Build completed successfully (5228 jobs).` `lake exe axioms` reported `axioms: audited 10952 TauCeti declaration(s); all within the allowlist [propext, Classical.choice, Quot.sound].`

<!--tauceti-target:v1 {"focus":"HeegaardFloer","id":"fredholm-kernel-cokernel-splitting"}-->

🤖 Prepared with Codex
