### PR TITLE
feat: add lower-order maximum principle

### DIFF
--- a/TauCeti/Analysis/InnerProductSpace/Laplacian/DriftMaximumPrinciple.lean
+++ b/TauCeti/Analysis/InnerProductSpace/Laplacian/DriftMaximumPrinciple.lean
@@ -173,6 +173,52 @@ section Nontrivial
 
 variable [Nontrivial E]
 
+omit [Nontrivial E] in
+/-- The normalized exponential barrier for a drift bounded by `β` is a strict subsolution of
+`Δ + b·∇`. -/
+theorem laplacian_add_fderiv_exp_inner_pos_of_norm_le {u b : E} {β : ℝ}
+    (hu : ‖u‖ = 1) (hb : ‖b‖ ≤ β) (x : E) :
+    0 < Δ (fun y => Real.exp ((β + 1) * ⟪u, y⟫)) x +
+      fderiv ℝ (fun y => Real.exp ((β + 1) * ⟪u, y⟫)) x b := by
+  have hβ0 : 0 ≤ β := (norm_nonneg b).trans hb
+  have hinner : -β ≤ ⟪u, b⟫ := by
+    have h := (abs_le.mp (abs_real_inner_le_norm u b)).1
+    rw [hu, one_mul] at h
+    exact (neg_le_neg hb).trans h
+  have hL : Δ (fun y => Real.exp ((β + 1) * ⟪u, y⟫)) x +
+      fderiv ℝ (fun y => Real.exp ((β + 1) * ⟪u, y⟫)) x b =
+        (β + 1) * (β + 1 + ⟪u, b⟫) * Real.exp ((β + 1) * ⟪u, x⟫) := by
+    rw [laplacian_exp_inner, fderiv_exp_inner_apply, hu]
+    ring
+  rw [hL]
+  have : 0 < β + 1 + ⟪u, b⟫ := by linarith
+  positivity
+
+omit [Nontrivial E] in
+/-- The operator `Δ + b·∇` is linear under addition of a constant multiple. -/
+theorem laplacian_add_fderiv_add_const_smul (f w : E → ℝ) (b : E) (ε : ℝ) (x : E)
+    (hf : ContDiffAt ℝ 2 f x) (hw : ContDiffAt ℝ 2 w x) :
+    Δ (fun y => f y + ε • w y) x + fderiv ℝ (fun y => f y + ε • w y) x b =
+      (Δ f x + fderiv ℝ f x b) + ε * (Δ w x + fderiv ℝ w x b) := by
+  have hfd : DifferentiableAt ℝ f x := hf.differentiableAt (by norm_num)
+  have hwd : DifferentiableAt ℝ w x := hw.differentiableAt (by norm_num)
+  have hΔ : Δ (fun y => f y + ε • w y) x = Δ f x + ε * Δ w x := by
+    have hadd : Δ (fun y => f y + ε • w y) x =
+        Δ f x + Δ (fun y => ε • w y) x := hf.laplacian_add (hw.const_smul ε)
+    have hsmul : Δ (fun y => ε • w y) x = ε • Δ w x := laplacian_smul ε hw
+    rw [hadd, hsmul, smul_eq_mul]
+  have hderiv : fderiv ℝ (fun y => f y + ε • w y) x b =
+      fderiv ℝ f x b + ε * fderiv ℝ w x b := by
+    have hadd : fderiv ℝ (fun y => f y + ε • w y) x =
+        fderiv ℝ f x + fderiv ℝ (fun y => ε • w y) x :=
+      fderiv_add hfd (hwd.const_smul ε)
+    have hsmul : fderiv ℝ (fun y => ε • w y) x = ε • fderiv ℝ w x :=
+      fderiv_const_smul hwd ε
+    rw [hadd, hsmul]
+    simp only [add_apply, smul_apply, smul_eq_mul]
+  rw [hΔ, hderiv]
+  ring
+
 /-- **Weak maximum principle for `Δ + b·∇` with bounded drift.**
 
 Let `K` be compact. If `f` is continuous on `K`, is `C²` on `interior K`, the drift field is
@@ -214,41 +260,14 @@ theorem le_of_laplacian_add_fderiv_nonneg_le_frontier {K : Set E} (hK : IsCompac
     -- The perturbed function is a strict subsolution of `Δ + b·∇`.
     have hgpos : ∀ ⦃y⦄, y ∈ interior K → 0 < Δ g y + fderiv ℝ g y (b y) := by
       intro y hy
-      have hΔ : Δ g y = Δ f y + ε * Δ w y := by
-        have hadd : Δ (fun z => f z + ε • w z) y = Δ f y + Δ (fun z => ε • w z) y :=
-          (hcd hy).laplacian_add ((hwcd y).const_smul ε)
-        have hsmul : Δ (fun z => ε • w z) y = ε • Δ w y := laplacian_smul ε (hwcd y)
-        rw [hgdef, hadd, hsmul, smul_eq_mul]
-      have hfd : fderiv ℝ g y (b y) = fderiv ℝ f y (b y) + ε * fderiv ℝ w y (b y) := by
-        have hd : DifferentiableAt ℝ f y := (hcd hy).differentiableAt (by norm_num)
-        have hdw : DifferentiableAt ℝ w y := (hwcd y).differentiableAt (by norm_num)
-        have hadd : fderiv ℝ (fun z => f z + ε • w z) y
-            = fderiv ℝ f y + fderiv ℝ (fun z => ε • w z) y := fderiv_add hd (hdw.const_smul ε)
-        have hsmul : fderiv ℝ (fun z => ε • w z) y = ε • fderiv ℝ w y := fderiv_const_smul hdw ε
-        rw [hgdef, hadd, hsmul]
-        simp only [add_apply, smul_apply, smul_eq_mul]
       -- The barrier's operator value is strictly positive.
-      have hbylb : -β ≤ ⟪u, b y⟫ := by
-        have h := (abs_le.mp (abs_real_inner_le_norm u (b y))).1
-        rw [hunorm, one_mul] at h
-        exact le_trans (neg_le_neg (hb hy)) h
-      have hαpos : 0 < α := by
-        have := le_trans (norm_nonneg (b y)) (hb hy)
-        rw [hαdef]; linarith
       have hLwpos : 0 < Δ w y + fderiv ℝ w y (b y) := by
-        have hLw : Δ w y + fderiv ℝ w y (b y)
-            = α * (α + ⟪u, b y⟫) * Real.exp (α * ⟪u, y⟫) := by
-          have e1 : Δ w y = α ^ 2 * ‖u‖ ^ 2 * Real.exp (α * ⟪u, y⟫) := by
-            rw [hwdef]; exact laplacian_exp_inner α u y
-          have e2 : fderiv ℝ w y (b y) = Real.exp (α * ⟪u, y⟫) * (α * ⟪u, b y⟫) := by
-            rw [hwdef]; exact fderiv_exp_inner_apply α u y (b y)
-          rw [e1, e2, hunorm]; ring
-        rw [hLw]
-        have : 0 < α + ⟪u, b y⟫ := by rw [hαdef]; linarith
-        positivity
+        rw [hwdef, hαdef]
+        exact laplacian_add_fderiv_exp_inner_pos_of_norm_le hunorm (hb hy) y
       have hcomb : Δ g y + fderiv ℝ g y (b y)
           = (Δ f y + fderiv ℝ f y (b y)) + ε * (Δ w y + fderiv ℝ w y (b y)) := by
-        rw [hΔ, hfd]; ring
+        rw [hgdef]
+        exact laplacian_add_fderiv_add_const_smul f w (b y) ε y (hcd hy) (hwcd y)
       rw [hcomb]
       have := mul_pos hε hLwpos
       linarith [hlap hy]

--- a/TauCeti/Analysis/InnerProductSpace/Laplacian/LowerOrderMaximumPrinciple.lean
+++ b/TauCeti/Analysis/InnerProductSpace/Laplacian/LowerOrderMaximumPrinciple.lean
@@ -1,0 +1,183 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+module
+
+public import TauCeti.Analysis.InnerProductSpace.Laplacian.DriftMaximumPrinciple
+
+/-!
+# Maximum principles with drift and a nonnegative zeroth-order term
+
+This file combines the two lower-order extensions of the Laplacian maximum principle.  For the
+operator `-Δ - b·∇ + c`, a nonnegative zeroth-order coefficient and a bounded drift preserve the
+weak maximum principle.  The sign condition on `c` and the nonnegativity of the frontier bound are
+explicit, as required for the standard estimate `sup u ≤ sup (u⁺|∂Ω)`.
+
+The proof perturbs a subsolution by the positive exponential barrier already used for the drift
+maximum principle.  At a positive interior maximum of the perturbation, its derivative vanishes
+and its Laplacian is nonpositive, while the subsolution inequality, `c ≥ 0`, and strict positivity
+of the barrier give the opposite strict inequality.
+
+## Main declarations
+
+* `TauCeti.le_of_mul_le_laplacian_add_fderiv_le_frontier`: the weak maximum principle for
+  `-Δ - b·∇ + c`.
+* `TauCeti.le_of_lowerOrder_le_of_le_frontier`: the corresponding comparison principle.
+* `TauCeti.eqOn_of_lowerOrder_eq_of_eqOn_frontier`: Dirichlet uniqueness for equal operator
+  values.
+-/
+
+public section
+
+noncomputable section
+
+namespace TauCeti
+
+open InnerProductSpace Laplacian Topology RealInnerProductSpace
+
+variable {E : Type*} [NormedAddCommGroup E] [InnerProductSpace ℝ E] [FiniteDimensional ℝ E]
+  [Nontrivial E]
+
+/-- **Weak maximum principle for `-Δ - b·∇ + c`.**
+
+If `c` is nonnegative, `b` has norm at most `β` on the interior of a compact set, and
+`c x * f x ≤ Δ f x + fderiv ℝ f x (b x)`, then every nonnegative frontier bound for `f` is a
+bound on the whole set. -/
+theorem le_of_mul_le_laplacian_add_fderiv_le_frontier {K : Set E} (hK : IsCompact K)
+    {c f : E → ℝ} {b : E → E} {β m : ℝ} (hm : 0 ≤ m) (hcont : ContinuousOn f K)
+    (hcd : ∀ ⦃x⦄, x ∈ interior K → ContDiffAt ℝ 2 f x)
+    (hc : ∀ ⦃x⦄, x ∈ interior K → 0 ≤ c x)
+    (hb : ∀ ⦃x⦄, x ∈ interior K → ‖b x‖ ≤ β)
+    (hsub : ∀ ⦃x⦄, x ∈ interior K → c x * f x ≤ Δ f x + fderiv ℝ f x (b x))
+    (hbdry : ∀ ⦃x⦄, x ∈ frontier K → f x ≤ m) :
+    ∀ ⦃x⦄, x ∈ K → f x ≤ m := by
+  intro x hxK
+  obtain ⟨v, hv⟩ := exists_ne (0 : E)
+  let u : E := ‖v‖⁻¹ • v
+  have hu : ‖u‖ = 1 := norm_smul_inv_norm hv
+  let α : ℝ := β + 1
+  let w : E → ℝ := fun y => Real.exp (α * ⟪u, y⟫)
+  have hwpos (y : E) : 0 < w y := Real.exp_pos _
+  have hwcd : ContDiff ℝ 2 w := by
+    have hi : ContDiff ℝ 2 (fun y : E => (⟪u, y⟫ : ℝ)) := by
+      simpa only [coe_innerSL_apply] using (innerSL ℝ u).contDiff
+    exact (by simpa only [smul_eq_mul] using hi.const_smul α : ContDiff ℝ 2 _).exp
+  obtain ⟨C, hC⟩ := hK.bddAbove_image hwcd.continuous.continuousOn
+  have hC0 : 0 ≤ C := (hwpos x).le.trans (hC (Set.mem_image_of_mem w hxK))
+  apply le_of_forall_pos_mul_le hC0
+  intro ε hε
+  let g : E → ℝ := fun y => f y + ε • w y
+  have hgcont : ContinuousOn g K := hcont.add (hwcd.continuous.continuousOn.const_smul ε)
+  obtain ⟨z, hzK, hzmax⟩ := hK.exists_isMaxOn ⟨x, hxK⟩ hgcont
+  have hfz : f z ≤ m := by
+    by_cases hzint : z ∈ interior K
+    · by_contra hn
+      have hfz0 : 0 ≤ f z := hm.trans (not_le.mp hn).le
+      have hgcd : ContDiffAt ℝ 2 g z := (hcd hzint).add (hwcd.contDiffAt.const_smul ε)
+      have hloc : IsLocalMax g z := hzmax.isLocalMax (mem_interior_iff_mem_nhds.mp hzint)
+      have hLgnonpos : Δ g z + fderiv ℝ g z (b z) ≤ 0 := by
+        rw [hloc.fderiv_eq_zero]
+        simpa using laplacian_nonpos_of_isLocalMax hgcd hloc
+      have hαpos : 0 < α := by
+        have hβ0 : 0 ≤ β := (norm_nonneg (b z)).trans (hb hzint)
+        dsimp [α]
+        linarith
+      have hinner : -β ≤ ⟪u, b z⟫ := by
+        have h := (abs_le.mp (abs_real_inner_le_norm u (b z))).1
+        rw [hu, one_mul] at h
+        exact (neg_le_neg (hb hzint)).trans h
+      have hLwpos : 0 < Δ w z + fderiv ℝ w z (b z) := by
+        have hLw : Δ w z + fderiv ℝ w z (b z) =
+            α * (α + ⟪u, b z⟫) * Real.exp (α * ⟪u, z⟫) := by
+          rw [show Δ w z = α ^ 2 * ‖u‖ ^ 2 * Real.exp (α * ⟪u, z⟫) by
+                exact laplacian_exp_inner α u z,
+            show fderiv ℝ w z (b z) = Real.exp (α * ⟪u, z⟫) * (α * ⟪u, b z⟫) by
+                exact fderiv_exp_inner_apply α u z (b z), hu]
+          ring
+        rw [hLw]
+        have : 0 < α + ⟪u, b z⟫ := by
+          dsimp [α]
+          linarith
+        positivity
+      have hLg : Δ g z + fderiv ℝ g z (b z) =
+          (Δ f z + fderiv ℝ f z (b z)) +
+            ε * (Δ w z + fderiv ℝ w z (b z)) := by
+        have hfd : DifferentiableAt ℝ f z := (hcd hzint).differentiableAt (by norm_num)
+        have hwd : DifferentiableAt ℝ w z := hwcd.differentiable (by norm_num) z
+        have hΔ : Δ g z = Δ f z + ε * Δ w z := by
+          have hadd : Δ (fun y => f y + ε • w y) z =
+              Δ f z + Δ (fun y => ε • w y) z :=
+            (hcd hzint).laplacian_add (hwcd.contDiffAt.const_smul ε)
+          have hsmul : Δ (fun y => ε • w y) z = ε • Δ w z :=
+            laplacian_smul ε hwcd.contDiffAt
+          rw [show g = fun y => f y + ε • w y from rfl, hadd, hsmul, smul_eq_mul]
+        have hderiv : fderiv ℝ g z (b z) =
+            fderiv ℝ f z (b z) + ε * fderiv ℝ w z (b z) := by
+          have hadd : fderiv ℝ (fun y => f y + ε • w y) z =
+              fderiv ℝ f z + fderiv ℝ (fun y => ε • w y) z :=
+            fderiv_add hfd (hwd.const_smul ε)
+          have hsmul : fderiv ℝ (fun y => ε • w y) z = ε • fderiv ℝ w z :=
+            fderiv_const_smul hwd ε
+          rw [show g = fun y => f y + ε • w y from rfl, hadd, hsmul]
+          simp only [add_apply, smul_apply, smul_eq_mul]
+        rw [hΔ, hderiv]
+        ring
+      have hLf0 : 0 ≤ Δ f z + fderiv ℝ f z (b z) :=
+        (mul_nonneg (hc hzint) hfz0).trans (hsub hzint)
+      rw [hLg] at hLgnonpos
+      nlinarith [mul_pos hε hLwpos]
+    · exact hbdry ⟨subset_closure hzK, hzint⟩
+  have hxle : f x + ε * w x ≤ f z + ε * w z := by
+    simpa [g, smul_eq_mul] using hzmax hxK
+  have hwzC : ε * w z ≤ ε * C :=
+    mul_le_mul_of_nonneg_left (hC (Set.mem_image_of_mem w hzK)) hε.le
+  nlinarith [mul_nonneg hε.le (hwpos x).le]
+
+/-- **Comparison principle for `-Δ - b·∇ + c`.** Functions acted on by the same lower-order
+coefficients are ordered on a compact set when their operator values and frontier values are
+ordered. -/
+theorem le_of_lowerOrder_le_of_le_frontier {K : Set E} (hK : IsCompact K) {c f g : E → ℝ}
+    {b : E → E} {β : ℝ} (hfcont : ContinuousOn f K) (hgcont : ContinuousOn g K)
+    (hfcd : ∀ ⦃x⦄, x ∈ interior K → ContDiffAt ℝ 2 f x)
+    (hgcd : ∀ ⦃x⦄, x ∈ interior K → ContDiffAt ℝ 2 g x)
+    (hc : ∀ ⦃x⦄, x ∈ interior K → 0 ≤ c x)
+    (hb : ∀ ⦃x⦄, x ∈ interior K → ‖b x‖ ≤ β)
+    (hL : ∀ ⦃x⦄, x ∈ interior K →
+      Δ g x + fderiv ℝ g x (b x) - c x * g x ≤
+        Δ f x + fderiv ℝ f x (b x) - c x * f x)
+    (hbdry : ∀ ⦃x⦄, x ∈ frontier K → f x ≤ g x) :
+    ∀ ⦃x⦄, x ∈ K → f x ≤ g x := by
+  intro x hx
+  have h := le_of_mul_le_laplacian_add_fderiv_le_frontier (c := c) (f := f - g) (b := b)
+    (β := β) (m := 0) hK le_rfl (hfcont.sub hgcont)
+    (fun y hy => (hfcd hy).sub (hgcd hy)) hc hb (fun y hy => by
+      rw [(hfcd hy).laplacian_sub (hgcd hy), fderiv_sub
+        ((hfcd hy).differentiableAt (by norm_num)) ((hgcd hy).differentiableAt (by norm_num))]
+      simp only [Pi.sub_apply, sub_apply]
+      linarith [hL hy]) (fun y hy => sub_nonpos.mpr (hbdry hy)) hx
+  exact sub_nonpos.mp h
+
+/-- **Dirichlet uniqueness for `-Δ - b·∇ + c`.** Equal operator values and equal frontier data
+force two functions to agree throughout the compact set. -/
+theorem eqOn_of_lowerOrder_eq_of_eqOn_frontier {K : Set E} (hK : IsCompact K)
+    {c f g : E → ℝ} {b : E → E} {β : ℝ} (hfcont : ContinuousOn f K)
+    (hgcont : ContinuousOn g K)
+    (hfcd : ∀ ⦃x⦄, x ∈ interior K → ContDiffAt ℝ 2 f x)
+    (hgcd : ∀ ⦃x⦄, x ∈ interior K → ContDiffAt ℝ 2 g x)
+    (hc : ∀ ⦃x⦄, x ∈ interior K → 0 ≤ c x)
+    (hb : ∀ ⦃x⦄, x ∈ interior K → ‖b x‖ ≤ β)
+    (hL : ∀ ⦃x⦄, x ∈ interior K →
+      Δ f x + fderiv ℝ f x (b x) - c x * f x =
+        Δ g x + fderiv ℝ g x (b x) - c x * g x)
+    (hbdry : Set.EqOn f g (frontier K)) : Set.EqOn f g K := by
+  intro x hx
+  apply le_antisymm
+  · exact le_of_lowerOrder_le_of_le_frontier hK hfcont hgcont hfcd hgcd hc hb
+      (fun y hy => (hL hy).ge) (fun y hy => (hbdry hy).le) hx
+  · exact le_of_lowerOrder_le_of_le_frontier hK hgcont hfcont hgcd hfcd hc hb
+      (fun y hy => (hL hy).le) (fun y hy => (hbdry hy).ge) hx
+
+end TauCeti
+
+end

--- a/TauCeti/Analysis/InnerProductSpace/Laplacian/LowerOrderMaximumPrinciple.lean
+++ b/TauCeti/Analysis/InnerProductSpace/Laplacian/LowerOrderMaximumPrinciple.lean
@@ -83,56 +83,14 @@ theorem le_of_mul_le_laplacian_add_fderiv_le_frontier {K : Set E} (hK : IsCompac
       have hLgnonpos : Δ g z + fderiv ℝ g z (b z) ≤ 0 := by
         rw [hloc.fderiv_eq_zero]
         simpa using laplacian_nonpos_of_isLocalMax hgcd hloc
-      have hαpos : 0 < α := by
-        have hβ0 : 0 ≤ β := (norm_nonneg (b z)).trans (hb hzint)
-        dsimp [α]
-        linarith
-      have hinner : -β ≤ ⟪u, b z⟫ := by
-        have h := (abs_le.mp (abs_real_inner_le_norm u (b z))).1
-        rw [hu, one_mul] at h
-        exact (neg_le_neg (hb hzint)).trans h
       have hLwpos : 0 < Δ w z + fderiv ℝ w z (b z) := by
-        have hwlap : Δ w z = α ^ 2 * ‖u‖ ^ 2 * Real.exp (α * ⟪u, z⟫) := by
-          simp only [w]
-          exact laplacian_exp_inner α u z
-        have hwderiv : fderiv ℝ w z (b z) =
-            Real.exp (α * ⟪u, z⟫) * (α * ⟪u, b z⟫) := by
-          simp only [w]
-          exact fderiv_exp_inner_apply α u z (b z)
-        have hLw : Δ w z + fderiv ℝ w z (b z) =
-            α * (α + ⟪u, b z⟫) * Real.exp (α * ⟪u, z⟫) := by
-          rw [hwlap, hwderiv, hu]
-          ring
-        rw [hLw]
-        have : 0 < α + ⟪u, b z⟫ := by
-          dsimp [α]
-          linarith
-        positivity
+        simpa only [w, α] using
+          laplacian_add_fderiv_exp_inner_pos_of_norm_le hu (hb hzint) z
       have hLg : Δ g z + fderiv ℝ g z (b z) =
           (Δ f z + fderiv ℝ f z (b z)) +
             ε * (Δ w z + fderiv ℝ w z (b z)) := by
-        have hfd : DifferentiableAt ℝ f z := (hcd hzint).differentiableAt (by norm_num)
-        have hwd : DifferentiableAt ℝ w z := hwcd.differentiable (by norm_num) z
-        have hΔ : Δ g z = Δ f z + ε * Δ w z := by
-          have hg : g = fun y => f y + ε • w y := by simp only [g]
-          have hadd : Δ (fun y => f y + ε • w y) z =
-              Δ f z + Δ (fun y => ε • w y) z :=
-            (hcd hzint).laplacian_add (hwcd.contDiffAt.const_smul ε)
-          have hsmul : Δ (fun y => ε • w y) z = ε • Δ w z :=
-            laplacian_smul ε hwcd.contDiffAt
-          rw [hg, hadd, hsmul, smul_eq_mul]
-        have hderiv : fderiv ℝ g z (b z) =
-            fderiv ℝ f z (b z) + ε * fderiv ℝ w z (b z) := by
-          have hg : g = fun y => f y + ε • w y := by simp only [g]
-          have hadd : fderiv ℝ (fun y => f y + ε • w y) z =
-              fderiv ℝ f z + fderiv ℝ (fun y => ε • w y) z :=
-            fderiv_add hfd (hwd.const_smul ε)
-          have hsmul : fderiv ℝ (fun y => ε • w y) z = ε • fderiv ℝ w z :=
-            fderiv_const_smul hwd ε
-          rw [hg, hadd, hsmul]
-          simp only [add_apply, smul_apply, smul_eq_mul]
-        rw [hΔ, hderiv]
-        ring
+        simpa only [g] using laplacian_add_fderiv_add_const_smul f w (b z) ε z
+          (hcd hzint) hwcd.contDiffAt
       have hLf0 : 0 ≤ Δ f z + fderiv ℝ f z (b z) :=
         (mul_nonneg (hc hzint) hfz0).trans (hsub hzint)
       rw [hLg] at hLgnonpos

--- a/TauCeti/Analysis/InnerProductSpace/Laplacian/LowerOrderMaximumPrinciple.lean
+++ b/TauCeti/Analysis/InnerProductSpace/Laplacian/LowerOrderMaximumPrinciple.lean
@@ -14,8 +14,9 @@ operator `-Δ - b·∇ + c`, a nonnegative zeroth-order coefficient and a bounde
 weak maximum principle.  The sign condition on `c` and the nonnegativity of the frontier bound are
 explicit, as required for the standard estimate `sup u ≤ sup (u⁺|∂Ω)`.
 
-The proof perturbs a subsolution by the positive exponential barrier already used for the drift
-maximum principle.  At a positive interior maximum of the perturbation, its derivative vanishes
+Following Gilbarg--Trudinger, *Elliptic Partial Differential Equations of Second Order*, Chapter 3,
+the proof adapts the weak-principle argument from `DriftMaximumPrinciple`: it perturbs a subsolution
+by the same positive exponential barrier. At a positive interior maximum, its derivative vanishes
 and its Laplacian is nonpositive, while the subsolution inequality, `c ≥ 0`, and strict positivity
 of the barrier give the opposite strict inequality.
 
@@ -23,9 +24,12 @@ of the barrier give the opposite strict inequality.
 
 * `TauCeti.le_of_mul_le_laplacian_add_fderiv_le_frontier`: the weak maximum principle for
   `-Δ - b·∇ + c`.
-* `TauCeti.le_of_lowerOrder_le_of_le_frontier`: the corresponding comparison principle.
-* `TauCeti.eqOn_of_lowerOrder_eq_of_eqOn_frontier`: Dirichlet uniqueness for equal operator
-  values.
+* `TauCeti.ge_of_laplacian_add_fderiv_le_mul_ge_frontier` and
+  `TauCeti.abs_le_of_laplacian_add_fderiv_eq_mul_abs_le_frontier`: its lower and two-sided forms.
+* `TauCeti.le_of_laplacian_add_fderiv_sub_mul_le_laplacian_add_fderiv_sub_mul_of_le_frontier`:
+  the corresponding comparison principle.
+* `TauCeti.eqOn_of_laplacian_add_fderiv_sub_mul_eq_of_eqOn_frontier`: Dirichlet uniqueness for
+  equal operator values.
 -/
 
 public section
@@ -88,12 +92,16 @@ theorem le_of_mul_le_laplacian_add_fderiv_le_frontier {K : Set E} (hK : IsCompac
         rw [hu, one_mul] at h
         exact (neg_le_neg (hb hzint)).trans h
       have hLwpos : 0 < Δ w z + fderiv ℝ w z (b z) := by
+        have hwlap : Δ w z = α ^ 2 * ‖u‖ ^ 2 * Real.exp (α * ⟪u, z⟫) := by
+          simp only [w]
+          exact laplacian_exp_inner α u z
+        have hwderiv : fderiv ℝ w z (b z) =
+            Real.exp (α * ⟪u, z⟫) * (α * ⟪u, b z⟫) := by
+          simp only [w]
+          exact fderiv_exp_inner_apply α u z (b z)
         have hLw : Δ w z + fderiv ℝ w z (b z) =
             α * (α + ⟪u, b z⟫) * Real.exp (α * ⟪u, z⟫) := by
-          rw [show Δ w z = α ^ 2 * ‖u‖ ^ 2 * Real.exp (α * ⟪u, z⟫) by
-                exact laplacian_exp_inner α u z,
-            show fderiv ℝ w z (b z) = Real.exp (α * ⟪u, z⟫) * (α * ⟪u, b z⟫) by
-                exact fderiv_exp_inner_apply α u z (b z), hu]
+          rw [hwlap, hwderiv, hu]
           ring
         rw [hLw]
         have : 0 < α + ⟪u, b z⟫ := by
@@ -106,20 +114,22 @@ theorem le_of_mul_le_laplacian_add_fderiv_le_frontier {K : Set E} (hK : IsCompac
         have hfd : DifferentiableAt ℝ f z := (hcd hzint).differentiableAt (by norm_num)
         have hwd : DifferentiableAt ℝ w z := hwcd.differentiable (by norm_num) z
         have hΔ : Δ g z = Δ f z + ε * Δ w z := by
+          have hg : g = fun y => f y + ε • w y := by simp only [g]
           have hadd : Δ (fun y => f y + ε • w y) z =
               Δ f z + Δ (fun y => ε • w y) z :=
             (hcd hzint).laplacian_add (hwcd.contDiffAt.const_smul ε)
           have hsmul : Δ (fun y => ε • w y) z = ε • Δ w z :=
             laplacian_smul ε hwcd.contDiffAt
-          rw [show g = fun y => f y + ε • w y from rfl, hadd, hsmul, smul_eq_mul]
+          rw [hg, hadd, hsmul, smul_eq_mul]
         have hderiv : fderiv ℝ g z (b z) =
             fderiv ℝ f z (b z) + ε * fderiv ℝ w z (b z) := by
+          have hg : g = fun y => f y + ε • w y := by simp only [g]
           have hadd : fderiv ℝ (fun y => f y + ε • w y) z =
               fderiv ℝ f z + fderiv ℝ (fun y => ε • w y) z :=
             fderiv_add hfd (hwd.const_smul ε)
           have hsmul : fderiv ℝ (fun y => ε • w y) z = ε • fderiv ℝ w z :=
             fderiv_const_smul hwd ε
-          rw [show g = fun y => f y + ε • w y from rfl, hadd, hsmul]
+          rw [hg, hadd, hsmul]
           simp only [add_apply, smul_apply, smul_eq_mul]
         rw [hΔ, hderiv]
         ring
@@ -134,10 +144,52 @@ theorem le_of_mul_le_laplacian_add_fderiv_le_frontier {K : Set E} (hK : IsCompac
     mul_le_mul_of_nonneg_left (hC (Set.mem_image_of_mem w hzK)) hε.le
   nlinarith [mul_nonneg hε.le (hwpos x).le]
 
+/-- **Weak minimum principle for `-Δ - b·∇ + c`.** This is the negation-dual of
+`le_of_mul_le_laplacian_add_fderiv_le_frontier`. -/
+theorem ge_of_laplacian_add_fderiv_le_mul_ge_frontier {K : Set E} (hK : IsCompact K)
+    {c f : E → ℝ} {b : E → E} {β m : ℝ} (hm : m ≤ 0) (hcont : ContinuousOn f K)
+    (hcd : ∀ ⦃x⦄, x ∈ interior K → ContDiffAt ℝ 2 f x)
+    (hc : ∀ ⦃x⦄, x ∈ interior K → 0 ≤ c x)
+    (hb : ∀ ⦃x⦄, x ∈ interior K → ‖b x‖ ≤ β)
+    (hsuper : ∀ ⦃x⦄, x ∈ interior K →
+      Δ f x + fderiv ℝ f x (b x) ≤ c x * f x)
+    (hbdry : ∀ ⦃x⦄, x ∈ frontier K → m ≤ f x) :
+    ∀ ⦃x⦄, x ∈ K → m ≤ f x := by
+  intro x hx
+  have h := le_of_mul_le_laplacian_add_fderiv_le_frontier (c := c) (f := -f) (b := b)
+    (β := β) (m := -m) hK (neg_nonneg.mpr hm) hcont.neg
+    (fun y hy => (hcd hy).neg) hc hb (fun y hy => by
+      have h1 : Δ (-f) y = -Δ f y := by rw [congrFun laplacian_neg y, Pi.neg_apply]
+      have h2 : fderiv ℝ (-f) y (b y) = -fderiv ℝ f y (b y) := by
+        rw [fderiv_neg, neg_apply]
+      rw [h1, h2, Pi.neg_apply, mul_neg]
+      linarith [hsuper hy]) (fun y hy => by simpa using neg_le_neg (hbdry hy)) hx
+  simpa using neg_le_neg h
+
+/-- A solution of `-Δ f - b·∇f + c f = 0` is bounded in absolute value by every
+nonnegative bound for its absolute value on the frontier. -/
+theorem abs_le_of_laplacian_add_fderiv_eq_mul_abs_le_frontier {K : Set E} (hK : IsCompact K)
+    {c f : E → ℝ} {b : E → E} {β M : ℝ} (hM : 0 ≤ M) (hcont : ContinuousOn f K)
+    (hcd : ∀ ⦃x⦄, x ∈ interior K → ContDiffAt ℝ 2 f x)
+    (hc : ∀ ⦃x⦄, x ∈ interior K → 0 ≤ c x)
+    (hb : ∀ ⦃x⦄, x ∈ interior K → ‖b x‖ ≤ β)
+    (hsol : ∀ ⦃x⦄, x ∈ interior K →
+      Δ f x + fderiv ℝ f x (b x) = c x * f x)
+    (hbdry : ∀ ⦃x⦄, x ∈ frontier K → |f x| ≤ M) :
+    ∀ ⦃x⦄, x ∈ K → |f x| ≤ M := by
+  intro x hx
+  rw [abs_le]
+  constructor
+  · exact ge_of_laplacian_add_fderiv_le_mul_ge_frontier hK (neg_nonpos.mpr hM) hcont hcd hc hb
+      (fun y hy => (hsol hy).le) (fun y hy => (abs_le.mp (hbdry hy)).1) hx
+  · exact le_of_mul_le_laplacian_add_fderiv_le_frontier hK hM hcont hcd hc hb
+      (fun y hy => (hsol hy).ge) (fun y hy => (abs_le.mp (hbdry hy)).2) hx
+
 /-- **Comparison principle for `-Δ - b·∇ + c`.** Functions acted on by the same lower-order
 coefficients are ordered on a compact set when their operator values and frontier values are
 ordered. -/
-theorem le_of_lowerOrder_le_of_le_frontier {K : Set E} (hK : IsCompact K) {c f g : E → ℝ}
+theorem le_of_laplacian_add_fderiv_sub_mul_le_laplacian_add_fderiv_sub_mul_of_le_frontier
+    {K : Set E} (hK : IsCompact K) {c f g : E → ℝ}
     {b : E → E} {β : ℝ} (hfcont : ContinuousOn f K) (hgcont : ContinuousOn g K)
     (hfcd : ∀ ⦃x⦄, x ∈ interior K → ContDiffAt ℝ 2 f x)
     (hgcd : ∀ ⦃x⦄, x ∈ interior K → ContDiffAt ℝ 2 g x)
@@ -160,7 +212,7 @@ theorem le_of_lowerOrder_le_of_le_frontier {K : Set E} (hK : IsCompact K) {c f g
 
 /-- **Dirichlet uniqueness for `-Δ - b·∇ + c`.** Equal operator values and equal frontier data
 force two functions to agree throughout the compact set. -/
-theorem eqOn_of_lowerOrder_eq_of_eqOn_frontier {K : Set E} (hK : IsCompact K)
+theorem eqOn_of_laplacian_add_fderiv_sub_mul_eq_of_eqOn_frontier {K : Set E} (hK : IsCompact K)
     {c f g : E → ℝ} {b : E → E} {β : ℝ} (hfcont : ContinuousOn f K)
     (hgcont : ContinuousOn g K)
     (hfcd : ∀ ⦃x⦄, x ∈ interior K → ContDiffAt ℝ 2 f x)
@@ -173,9 +225,11 @@ theorem eqOn_of_lowerOrder_eq_of_eqOn_frontier {K : Set E} (hK : IsCompact K)
     (hbdry : Set.EqOn f g (frontier K)) : Set.EqOn f g K := by
   intro x hx
   apply le_antisymm
-  · exact le_of_lowerOrder_le_of_le_frontier hK hfcont hgcont hfcd hgcd hc hb
+  · exact le_of_laplacian_add_fderiv_sub_mul_le_laplacian_add_fderiv_sub_mul_of_le_frontier
+      hK hfcont hgcont hfcd hgcd hc hb
       (fun y hy => (hL hy).ge) (fun y hy => (hbdry hy).le) hx
-  · exact le_of_lowerOrder_le_of_le_frontier hK hgcont hfcont hgcd hfcd hc hb
+  · exact le_of_laplacian_add_fderiv_sub_mul_le_laplacian_add_fderiv_sub_mul_of_le_frontier
+      hK hgcont hfcont hgcd hfcd hc hb
       (fun y hy => (hL hy).le) (fun y hy => (hbdry hy).ge) hx
 
 end TauCeti


### PR DESCRIPTION
This PR combines the bounded-drift and nonnegative-zeroth-order extensions of the Laplacian maximum principle into the weak maximum principle for `-Δ - b·∇ + c`, and derives its comparison principle and Dirichlet uniqueness. It advances `TauCetiRoadmap/PDE/README.md`, Lane C, item 13: “The weak and strong maximum principles for `Δ` and then for general elliptic `L` (sign condition `c ≥ 0`); … the comparison principle.” This is the lowest-hanging distinct continuation because the drift-only and zeroth-order-only principles have landed, while their combined lower-order operator is not in Mathlib, TauCeti, or an open PR and directly approaches the roadmap’s general elliptic operator without depending on the missing weak-derivative Sobolev stack.

Use the existing exponential barrier for the bounded drift. At a positive interior maximum of the perturbed subsolution, its derivative vanishes and its Laplacian is nonpositive, whereas the subsolution inequality, `c ≥ 0`, and the strictly positive barrier force the combined second- and first-order expression to be positive. Let the perturbation tend to zero, then apply the resulting estimate to a difference to obtain comparison and uniqueness.

Reuse Tau Ceti’s `laplacian_exp_inner`, `fderiv_exp_inner_apply`, `laplacian_nonpos_of_isLocalMax`, and `le_of_forall_pos_mul_le`, together with Mathlib’s compact extreme-value and Fréchet-derivative APIs. No Mathlib infrastructure is vendored and no external formalization is adapted.

Add `TauCeti/Analysis/InnerProductSpace/Laplacian/LowerOrderMaximumPrinciple.lean` (183 lines). `lake build` completes successfully (5228 jobs), and `lake exe axioms` audits 10937 TauCeti declarations, all within `[propext, Classical.choice, Quot.sound]`.

<!--tauceti-target:v1 {"focus":"PDE","id":"laplacian-drift-zeroth-order-maximum-principle"}-->

🤖 Prepared with Codex
