### PR TITLE
feat: add products of Fredholm operators

### DIFF
--- a/TauCeti/Analysis/Fredholm/Prod.lean
+++ b/TauCeti/Analysis/Fredholm/Prod.lean
@@ -5,7 +5,6 @@ Released under Apache 2.0 license as described in the file LICENSE.
 module
 
 public import TauCeti.Analysis.Fredholm.Basic
-public import Mathlib.Analysis.Normed.Operator.Prod
 
 /-!
 # Products of Fredholm operators
@@ -64,7 +63,10 @@ private noncomputable def quotientProdEquiv (p : Submodule K F₁) (q : Submodul
   · exact LinearMap.ker_eq_bot.mp
       (Submodule.ker_liftQ_eq_bot (p.prod q) f hker.ge hker.le)
   · rintro ⟨⟨x⟩, ⟨y⟩⟩
-    exact ⟨(p.prod q).mkQ (x, y), rfl⟩
+    refine ⟨(p.prod q).mkQ (x, y), ?_⟩
+    change (((p.prod q).liftQ f hker.ge).comp (p.prod q).mkQ) (x, y) = _
+    rw [(p.prod q).liftQ_mkQ, LinearMap.prodMap_apply]
+    rfl
 
 /-- The cokernel of a product submodule has dimension equal to the sum of the dimensions of the
 two cokernels. -/
@@ -102,15 +104,15 @@ namespace ContinuousLinearMap
 
 /-- The index is additive under Cartesian products when both kernels and cokernels are finite
 dimensional. -/
-lemma index_prodMap_of_finiteDimensional (T : E₁ →L[K] F₁) (S : E₂ →L[K] F₂)
+private lemma index_prodMap_of_finiteDimensional (T : E₁ →L[K] F₁) (S : E₂ →L[K] F₂)
     [FiniteDimensional K (LinearMap.ker (T : E₁ →ₗ[K] F₁))]
     [FiniteDimensional K (LinearMap.ker (S : E₂ →ₗ[K] F₂))]
     [FiniteDimensional K (F₁ ⧸ LinearMap.range (T : E₁ →ₗ[K] F₁))]
     [FiniteDimensional K (F₂ ⧸ LinearMap.range (S : E₂ →ₗ[K] F₂))] :
     index (T.prodMap S) = index T + index S := by
-  rw [index_eq_finrank_sub, index_eq_finrank_sub, index_eq_finrank_sub, coe_prodMap,
-    LinearMap.ker_prodMap, LinearMap.range_prodMap,
-    (Submodule.prodSubtypeEquiv _ _).finrank_eq,
+  simp only [index_eq_finrank_sub]
+  rw [coe_prodMap, LinearMap.ker_prodMap, LinearMap.range_prodMap]
+  simp only [(Submodule.prodSubtypeEquiv _ _).finrank_eq,
     Submodule.finrank_quotient_prod, finrank_prod]
   omega
 

--- a/TauCeti/Analysis/Fredholm/Prod.lean
+++ b/TauCeti/Analysis/Fredholm/Prod.lean
@@ -100,7 +100,22 @@ lemma IsFredholm.prodMap (hT : IsFredholm T) (hS : IsFredholm S) :
 
 namespace ContinuousLinearMap
 
+/-- The index is additive under Cartesian products when both kernels and cokernels are finite
+dimensional. -/
+lemma index_prodMap_of_finiteDimensional (T : E₁ →L[K] F₁) (S : E₂ →L[K] F₂)
+    [FiniteDimensional K (LinearMap.ker (T : E₁ →ₗ[K] F₁))]
+    [FiniteDimensional K (LinearMap.ker (S : E₂ →ₗ[K] F₂))]
+    [FiniteDimensional K (F₁ ⧸ LinearMap.range (T : E₁ →ₗ[K] F₁))]
+    [FiniteDimensional K (F₂ ⧸ LinearMap.range (S : E₂ →ₗ[K] F₂))] :
+    index (T.prodMap S) = index T + index S := by
+  rw [index_eq_finrank_sub, index_eq_finrank_sub, index_eq_finrank_sub, coe_prodMap,
+    LinearMap.ker_prodMap, LinearMap.range_prodMap,
+    (Submodule.prodSubtypeEquiv _ _).finrank_eq,
+    Submodule.finrank_quotient_prod, finrank_prod]
+  omega
+
 /-- The Fredholm index is additive under Cartesian products of Fredholm operators. -/
+@[simp]
 lemma index_prodMap (T : E₁ →L[K] F₁) (S : E₂ →L[K] F₂)
     (hT : IsFredholm T) (hS : IsFredholm S) :
     index (T.prodMap S) = index T + index S := by
@@ -108,11 +123,7 @@ lemma index_prodMap (T : E₁ →L[K] F₁) (S : E₂ →L[K] F₂)
   letI := hS.finiteDimensional_ker
   letI := hT.finiteDimensional_coker
   letI := hS.finiteDimensional_coker
-  rw [index_eq_finrank_sub, index_eq_finrank_sub, index_eq_finrank_sub, coe_prodMap,
-    LinearMap.ker_prodMap, LinearMap.range_prodMap,
-    (Submodule.prodSubtypeEquiv _ _).finrank_eq,
-    Submodule.finrank_quotient_prod, finrank_prod]
-  omega
+  exact index_prodMap_of_finiteDimensional T S
 
 end ContinuousLinearMap
 

--- a/TauCeti/Analysis/Fredholm/Prod.lean
+++ b/TauCeti/Analysis/Fredholm/Prod.lean
@@ -21,6 +21,8 @@ cokernel of a product submodule and the product of the two cokernels.
 ## Main declarations
 
 * `TauCeti.IsFredholm.prodMap`: a product of Fredholm operators is Fredholm.
+* `TauCeti.ContinuousLinearMap.index_prodMap_of_finiteDimensional`: the index is additive under
+  products when the kernels and cokernels are finite-dimensional.
 * `TauCeti.ContinuousLinearMap.index_prodMap`: the Fredholm index is additive under products.
 -/
 
@@ -64,9 +66,9 @@ private noncomputable def quotientProdEquiv (p : Submodule K F₁) (q : Submodul
       (Submodule.ker_liftQ_eq_bot (p.prod q) f hker.ge hker.le)
   · rintro ⟨⟨x⟩, ⟨y⟩⟩
     refine ⟨(p.prod q).mkQ (x, y), ?_⟩
-    change (((p.prod q).liftQ f hker.ge).comp (p.prod q).mkQ) (x, y) = _
-    rw [(p.prod q).liftQ_mkQ, LinearMap.prodMap_apply]
-    rfl
+    dsimp [g]
+    simp only [f, LinearMap.prodMap_apply, Submodule.mkQ_apply,
+      Submodule.Quotient.quot_mk_eq_mk]
 
 /-- The cokernel of a product submodule has dimension equal to the sum of the dimensions of the
 two cokernels. -/
@@ -79,12 +81,6 @@ end Submodule
 
 variable {T : E₁ →L[K] F₁} {S : E₂ →L[K] F₂}
 
-/-- The underlying linear map of the Cartesian product of two continuous linear maps is the
-Cartesian product of their underlying linear maps. -/
-private lemma coe_prodMap :
-    ((T.prodMap S : E₁ × E₂ →L[K] F₁ × F₂) : E₁ × E₂ →ₗ[K] F₁ × F₂) =
-      (T : E₁ →ₗ[K] F₁).prodMap (S : E₂ →ₗ[K] F₂) := rfl
-
 /-- The Cartesian product of two Fredholm operators is Fredholm. -/
 lemma IsFredholm.prodMap (hT : IsFredholm T) (hS : IsFredholm S) :
     IsFredholm (T.prodMap S) := by
@@ -93,25 +89,25 @@ lemma IsFredholm.prodMap (hT : IsFredholm T) (hS : IsFredholm S) :
   haveI := hT.finiteDimensional_coker
   haveI := hS.finiteDimensional_coker
   refine ⟨?_, ?_, ?_⟩
-  · rw [coe_prodMap, LinearMap.ker_prodMap]
+  · rw [ContinuousLinearMap.coe_prodMap T S, LinearMap.ker_prodMap]
     exact (Submodule.prodSubtypeEquiv _ _).symm.finiteDimensional
-  · rw [coe_prodMap, LinearMap.range_prodMap]
+  · rw [ContinuousLinearMap.coe_prodMap T S, LinearMap.range_prodMap]
     exact hT.isClosed_range.prod hS.isClosed_range
-  · rw [coe_prodMap, LinearMap.range_prodMap]
+  · rw [ContinuousLinearMap.coe_prodMap T S, LinearMap.range_prodMap]
     exact (Submodule.quotientProdEquiv _ _).symm.finiteDimensional
 
 namespace ContinuousLinearMap
 
 /-- The index is additive under Cartesian products when both kernels and cokernels are finite
 dimensional. -/
-private lemma index_prodMap_of_finiteDimensional (T : E₁ →L[K] F₁) (S : E₂ →L[K] F₂)
+lemma index_prodMap_of_finiteDimensional (T : E₁ →L[K] F₁) (S : E₂ →L[K] F₂)
     [FiniteDimensional K (LinearMap.ker (T : E₁ →ₗ[K] F₁))]
     [FiniteDimensional K (LinearMap.ker (S : E₂ →ₗ[K] F₂))]
     [FiniteDimensional K (F₁ ⧸ LinearMap.range (T : E₁ →ₗ[K] F₁))]
     [FiniteDimensional K (F₂ ⧸ LinearMap.range (S : E₂ →ₗ[K] F₂))] :
     index (T.prodMap S) = index T + index S := by
   simp only [index_eq_finrank_sub]
-  rw [coe_prodMap, LinearMap.ker_prodMap, LinearMap.range_prodMap]
+  rw [ContinuousLinearMap.coe_prodMap T S, LinearMap.ker_prodMap, LinearMap.range_prodMap]
   simp only [(Submodule.prodSubtypeEquiv _ _).finrank_eq,
     Submodule.finrank_quotient_prod, finrank_prod]
   omega

--- a/TauCeti/Analysis/Fredholm/Prod.lean
+++ b/TauCeti/Analysis/Fredholm/Prod.lean
@@ -1,0 +1,119 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+module
+
+public import TauCeti.Analysis.Fredholm.Basic
+public import Mathlib.Analysis.Normed.Operator.Prod
+
+/-!
+# Products of Fredholm operators
+
+This file proves that the Cartesian product of two Fredholm operators is Fredholm and that its
+index is the sum of the two indices. This is elementary bookkeeping needed for the block
+decompositions and finite-dimensional reductions in the Fredholm substrate of the analytic
+Heegaard Floer roadmap.
+
+The proof identifies the kernel and range of the product operator with the products of the
+individual kernels and ranges. It also records the corresponding linear equivalence between the
+cokernel of a product submodule and the product of the two cokernels.
+
+## Main declarations
+
+* `TauCeti.IsFredholm.prodMap`: a product of Fredholm operators is Fredholm.
+* `TauCeti.ContinuousLinearMap.index_prodMap`: the Fredholm index is additive under products.
+-/
+
+public section
+
+namespace TauCeti
+
+open Module
+
+variable {K E₁ E₂ F₁ F₂ : Type*}
+variable [NontriviallyNormedField K]
+variable [NormedAddCommGroup E₁] [NormedSpace K E₁]
+variable [NormedAddCommGroup E₂] [NormedSpace K E₂]
+variable [NormedAddCommGroup F₁] [NormedSpace K F₁]
+variable [NormedAddCommGroup F₂] [NormedSpace K F₂]
+
+namespace Submodule
+
+/-- A product submodule, as a module, is the product of the two submodules. -/
+private def prodSubtypeEquiv (p : Submodule K F₁) (q : Submodule K F₂) :
+    ↥(p.prod q) ≃ₗ[K] p × q where
+  toFun x := (⟨x.1.1, x.2.1⟩, ⟨x.1.2, x.2.2⟩)
+  invFun x := ⟨(x.1.1, x.2.1), x.1.2, x.2.2⟩
+  left_inv _ := rfl
+  right_inv _ := rfl
+  map_add' _ _ := rfl
+  map_smul' _ _ := rfl
+
+/-- The quotient by a product of submodules is linearly equivalent to the product of the
+quotients. This is kept private because the construction is general Mathlib infrastructure; only
+its Fredholm consequences form the public API of this file. -/
+private noncomputable def quotientProdEquiv (p : Submodule K F₁) (q : Submodule K F₂) :
+    ((F₁ × F₂) ⧸ p.prod q) ≃ₗ[K] (F₁ ⧸ p) × (F₂ ⧸ q) := by
+  let f : F₁ × F₂ →ₗ[K] (F₁ ⧸ p) × (F₂ ⧸ q) := p.mkQ.prodMap q.mkQ
+  have hker : LinearMap.ker f = p.prod q := by
+    simp [f]
+  let g : ((F₁ × F₂) ⧸ p.prod q) →ₗ[K] (F₁ ⧸ p) × (F₂ ⧸ q) :=
+    (p.prod q).liftQ f hker.ge
+  refine LinearEquiv.ofBijective g ⟨?_, ?_⟩
+  · exact LinearMap.ker_eq_bot.mp
+      (Submodule.ker_liftQ_eq_bot (p.prod q) f hker.ge hker.le)
+  · rintro ⟨⟨x⟩, ⟨y⟩⟩
+    exact ⟨(p.prod q).mkQ (x, y), rfl⟩
+
+/-- The cokernel of a product submodule has dimension equal to the sum of the dimensions of the
+two cokernels. -/
+private lemma finrank_quotient_prod (p : Submodule K F₁) (q : Submodule K F₂)
+    [FiniteDimensional K (F₁ ⧸ p)] [FiniteDimensional K (F₂ ⧸ q)] :
+    finrank K ((F₁ × F₂) ⧸ p.prod q) = finrank K (F₁ ⧸ p) + finrank K (F₂ ⧸ q) := by
+  rw [(quotientProdEquiv p q).finrank_eq, finrank_prod]
+
+end Submodule
+
+variable {T : E₁ →L[K] F₁} {S : E₂ →L[K] F₂}
+
+/-- The underlying linear map of the Cartesian product of two continuous linear maps is the
+Cartesian product of their underlying linear maps. -/
+private lemma coe_prodMap :
+    ((T.prodMap S : E₁ × E₂ →L[K] F₁ × F₂) : E₁ × E₂ →ₗ[K] F₁ × F₂) =
+      (T : E₁ →ₗ[K] F₁).prodMap (S : E₂ →ₗ[K] F₂) := rfl
+
+/-- The Cartesian product of two Fredholm operators is Fredholm. -/
+lemma IsFredholm.prodMap (hT : IsFredholm T) (hS : IsFredholm S) :
+    IsFredholm (T.prodMap S) := by
+  haveI := hT.finiteDimensional_ker
+  haveI := hS.finiteDimensional_ker
+  haveI := hT.finiteDimensional_coker
+  haveI := hS.finiteDimensional_coker
+  refine ⟨?_, ?_, ?_⟩
+  · rw [coe_prodMap, LinearMap.ker_prodMap]
+    exact (Submodule.prodSubtypeEquiv _ _).symm.finiteDimensional
+  · rw [coe_prodMap, LinearMap.range_prodMap]
+    exact hT.isClosed_range.prod hS.isClosed_range
+  · rw [coe_prodMap, LinearMap.range_prodMap]
+    exact (Submodule.quotientProdEquiv _ _).symm.finiteDimensional
+
+namespace ContinuousLinearMap
+
+/-- The Fredholm index is additive under Cartesian products of Fredholm operators. -/
+lemma index_prodMap (T : E₁ →L[K] F₁) (S : E₂ →L[K] F₂)
+    (hT : IsFredholm T) (hS : IsFredholm S) :
+    index (T.prodMap S) = index T + index S := by
+  letI := hT.finiteDimensional_ker
+  letI := hS.finiteDimensional_ker
+  letI := hT.finiteDimensional_coker
+  letI := hS.finiteDimensional_coker
+  rw [index_eq_finrank_sub, index_eq_finrank_sub, index_eq_finrank_sub, coe_prodMap,
+    LinearMap.ker_prodMap, LinearMap.range_prodMap,
+    (Submodule.prodSubtypeEquiv _ _).finrank_eq,
+    Submodule.finrank_quotient_prod, finrank_prod]
+  omega
+
+end ContinuousLinearMap
+
+end TauCeti

--- a/TauCeti/Analysis/Fredholm/Prod.lean
+++ b/TauCeti/Analysis/Fredholm/Prod.lean
@@ -66,8 +66,7 @@ private noncomputable def quotientProdEquiv (p : Submodule K F₁) (q : Submodul
       (Submodule.ker_liftQ_eq_bot (p.prod q) f hker.ge hker.le)
   · rintro ⟨⟨x⟩, ⟨y⟩⟩
     refine ⟨(p.prod q).mkQ (x, y), ?_⟩
-    dsimp [g]
-    simp only [f, LinearMap.prodMap_apply, Submodule.mkQ_apply,
+    simp only [g, Submodule.mkQ_apply, Submodule.liftQ_apply, f, LinearMap.prodMap_apply,
       Submodule.Quotient.quot_mk_eq_mk]
 
 /-- The cokernel of a product submodule has dimension equal to the sum of the dimensions of the

--- a/TauCeti/Analysis/Fredholm/Prod.lean
+++ b/TauCeti/Analysis/Fredholm/Prod.lean
@@ -21,8 +21,6 @@ cokernel of a product submodule and the product of the two cokernels.
 ## Main declarations
 
 * `TauCeti.IsFredholm.prodMap`: a product of Fredholm operators is Fredholm.
-* `TauCeti.ContinuousLinearMap.index_prodMap_of_finiteDimensional`: the index is additive under
-  products when the kernels and cokernels are finite-dimensional.
 * `TauCeti.ContinuousLinearMap.index_prodMap`: the Fredholm index is additive under products.
 -/
 
@@ -99,7 +97,7 @@ namespace ContinuousLinearMap
 
 /-- The index is additive under Cartesian products when both kernels and cokernels are finite
 dimensional. -/
-lemma index_prodMap_of_finiteDimensional (T : E₁ →L[K] F₁) (S : E₂ →L[K] F₂)
+private lemma index_prodMap_of_finiteDimensional (T : E₁ →L[K] F₁) (S : E₂ →L[K] F₂)
     [FiniteDimensional K (LinearMap.ker (T : E₁ →ₗ[K] F₁))]
     [FiniteDimensional K (LinearMap.ker (S : E₂ →ₗ[K] F₂))]
     [FiniteDimensional K (F₁ ⧸ LinearMap.range (T : E₁ →ₗ[K] F₁))]


### PR DESCRIPTION
This PR adds Cartesian products to the Fredholm operator API: prove that a product of Fredholm operators is Fredholm and that its index is the sum of the factor indices. Keep the general product-submodule and quotient equivalences private while exposing the two operator-level results needed downstream.

This advances `TauCetiRoadmap/HeegaardFloer/README.md`, Lane F0, specifically “Fredholm operators (index, stability under compact and small perturbations, kernel/cokernel splitting).” It is the lowest-hanging distinct prerequisite after the Fredholm foundation landed and while kernel/cokernel splitting is already in flight: block decompositions and finite-dimensional reductions repeatedly combine Fredholm operators, so closure and index additivity for Cartesian products are immediate bookkeeping needed by those constructions without overlapping the claimed splitting work.

Reuse Mathlib’s `ContinuousLinearMap.prodMap`, `LinearMap.ker_prodMap`, `LinearMap.range_prodMap`, `Submodule.liftQ`, and `LinearEquiv.ofBijective`. The private cokernel equivalence is assembled from these APIs; no Mathlib infrastructure is vendored and no external formalization is adapted.

Add `TauCeti/Analysis/Fredholm/Prod.lean` (119 lines). `lake exe cache get` reports `No files to download` and `Already decompressed 8639 file(s)`. `lake build` reports `Build completed successfully (5230 jobs).` `lake exe axioms` reports `axioms: audited 10978 TauCeti declaration(s); all within the allowlist [propext, Classical.choice, Quot.sound].`

<!--tauceti-target:v1 {"focus":"HeegaardFloer","id":"fredholm-product"}-->

🤖 Prepared with Codex
