### PR TITLE
feat: add maps of simplicial complexes

### DIFF
--- a/TauCeti/AlgebraicTopology/SimplicialComplex/Maps.lean
+++ b/TauCeti/AlgebraicTopology/SimplicialComplex/Maps.lean
@@ -1,0 +1,179 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+module
+
+public import TauCeti.AlgebraicTopology.SimplicialComplex.Basic
+
+/-!
+# Maps of abstract simplicial complexes
+
+This file bundles simplicial maps between pre-abstract simplicial complexes. A simplicial map is
+a map of vertices which sends every face to a face. The file supplies the identity, composition,
+restriction to subcomplexes, and corestriction to a larger complex, together with the connection
+to Mathlib's image complex `PreAbstractSimplicialComplex.map`.
+
+These maps are basic infrastructure for subdivision and geometric realization in the geometric
+topology roadmap. We work with `PreAbstractSimplicialComplex`, since constructions such as links
+and elementary collapses naturally change the set of vertices represented by singleton faces.
+-/
+
+public section
+
+namespace TauCeti
+
+namespace PreAbstractSimplicialComplex
+
+variable {α β γ δ : Type*} [DecidableEq β] [DecidableEq γ]
+variable {K K' : PreAbstractSimplicialComplex α}
+variable {L L' : PreAbstractSimplicialComplex β}
+variable {P : PreAbstractSimplicialComplex γ}
+variable {P' : PreAbstractSimplicialComplex δ}
+
+/-- A simplicial map between pre-abstract simplicial complexes is a map of vertices which sends
+faces to faces. -/
+@[ext]
+structure SimplicialMap (K : PreAbstractSimplicialComplex α)
+    (L : PreAbstractSimplicialComplex β) where
+  /-- The map on vertices. -/
+  toFun : α → β
+  /-- The image of every face is a face. -/
+  map_face' : ∀ ⦃σ : Finset α⦄, σ ∈ K → σ.image toFun ∈ L
+
+namespace SimplicialMap
+
+instance : FunLike (SimplicialMap K L) α β where
+  coe := toFun
+  coe_injective f g h := by
+    cases f
+    cases g
+    simp_all
+
+@[simp]
+theorem coe_mk (f : α → β) (hf) : ⇑(SimplicialMap.mk f hf : SimplicialMap K L) = f :=
+  (rfl)
+
+/-- A simplicial map sends a face to a face. -/
+theorem map_face (f : SimplicialMap K L) {σ : Finset α} (hσ : σ ∈ K) :
+    σ.image f ∈ L :=
+  f.map_face' hσ
+
+/-- A vertex map is simplicial exactly when its image complex is a subcomplex of the codomain. -/
+theorem map_le_iff (f : α → β) :
+    K.map f ≤ L ↔ ∀ ⦃σ : Finset α⦄, σ ∈ K → σ.image f ∈ L := by
+  constructor
+  · intro h σ hσ
+    exact h ⟨σ, hσ, rfl⟩
+  · rintro h τ ⟨σ, hσ, rfl⟩
+    exact h hσ
+
+/-- Construct a simplicial map from containment of the image complex in the codomain. -/
+def ofMapLE (f : α → β) (h : K.map f ≤ L) : SimplicialMap K L where
+  toFun := f
+  map_face' := map_le_iff f |>.mp h
+
+@[simp]
+theorem coe_ofMapLE (f : α → β) (h : K.map f ≤ L) : ⇑(ofMapLE f h) = f :=
+  (rfl)
+
+/-- The image complex of a simplicial map is contained in its codomain. -/
+theorem map_le (f : SimplicialMap K L) : K.map f ≤ L :=
+  map_le_iff f |>.mpr fun _ hσ ↦ f.map_face hσ
+
+/-- The identity simplicial map. -/
+def id [DecidableEq α] (K : PreAbstractSimplicialComplex α) : SimplicialMap K K where
+  toFun := _root_.id
+  map_face' := by simp
+
+@[simp]
+theorem coe_id [DecidableEq α] : ⇑(id K) = _root_.id :=
+  (rfl)
+
+@[simp]
+theorem id_apply [DecidableEq α] (x : α) : id K x = x :=
+  (rfl)
+
+/-- Composition of simplicial maps. -/
+def comp (g : SimplicialMap L P) (f : SimplicialMap K L) : SimplicialMap K P where
+  toFun := g ∘ f
+  map_face' := by
+    intro σ hσ
+    rw [Finset.image_comp]
+    exact g.map_face (f.map_face hσ)
+
+@[simp]
+theorem coe_comp (g : SimplicialMap L P) (f : SimplicialMap K L) :
+    ⇑(g.comp f) = g ∘ f :=
+  (rfl)
+
+@[simp]
+theorem comp_apply (g : SimplicialMap L P) (f : SimplicialMap K L) (x : α) :
+    g.comp f x = g (f x) :=
+  (rfl)
+
+@[simp]
+theorem comp_id [DecidableEq α] (f : SimplicialMap K L) : f.comp (id K) = f := by
+  apply DFunLike.coe_injective
+  rw [coe_comp, coe_id, Function.comp_id]
+
+@[simp]
+theorem id_comp (f : SimplicialMap K L) : (id L).comp f = f := by
+  apply DFunLike.coe_injective
+  rw [coe_comp, coe_id, Function.id_comp]
+
+@[simp]
+theorem comp_assoc [DecidableEq δ] (h : SimplicialMap P P') (g : SimplicialMap L P)
+    (f : SimplicialMap K L) : (h.comp g).comp f = h.comp (g.comp f) := by
+  apply DFunLike.coe_injective
+  simp only [coe_comp, Function.comp_def]
+
+/-- Restrict the domain of a simplicial map to a subcomplex. -/
+def domainRestrict (f : SimplicialMap K L) (h : K' ≤ K) : SimplicialMap K' L where
+  toFun := f
+  map_face' := fun _ hσ ↦ f.map_face (h hσ)
+
+@[simp]
+theorem coe_domainRestrict (f : SimplicialMap K L) (h : K' ≤ K) :
+    ⇑(f.domainRestrict h) = f :=
+  (rfl)
+
+/-- Regard a simplicial map as landing in a larger complex. -/
+def codomainRestrict (f : SimplicialMap K L) (h : L ≤ L') : SimplicialMap K L' where
+  toFun := f
+  map_face' := fun _ hσ ↦ h (f.map_face hσ)
+
+@[simp]
+theorem coe_codomainRestrict (f : SimplicialMap K L) (h : L ≤ L') :
+    ⇑(f.codomainRestrict h) = f :=
+  (rfl)
+
+/-- Every vertex map is simplicial into its image complex. -/
+def toMap (K : PreAbstractSimplicialComplex α) (f : α → β) : SimplicialMap K (K.map f) where
+  toFun := f
+  map_face' := fun σ hσ ↦ ⟨σ, hσ, rfl⟩
+
+@[simp]
+theorem coe_toMap (K : PreAbstractSimplicialComplex α) (f : α → β) : ⇑(toMap K f) = f :=
+  (rfl)
+
+/-- The inclusion of a subcomplex, acting as the identity on the ambient vertex type. -/
+def inclusion [DecidableEq α] (h : K ≤ K') : SimplicialMap K K' where
+  toFun := _root_.id
+  map_face' := fun _ hσ ↦ by
+    simp only [Finset.image_id]
+    exact h hσ
+
+@[simp]
+theorem coe_inclusion [DecidableEq α] (h : K ≤ K') : ⇑(inclusion h) = _root_.id :=
+  (rfl)
+
+@[simp]
+theorem inclusion_apply [DecidableEq α] (h : K ≤ K') (x : α) : inclusion h x = x :=
+  (rfl)
+
+end SimplicialMap
+
+end PreAbstractSimplicialComplex
+
+end TauCeti

--- a/TauCeti/AlgebraicTopology/SimplicialComplex/Maps.lean
+++ b/TauCeti/AlgebraicTopology/SimplicialComplex/Maps.lean
@@ -11,7 +11,7 @@ public import TauCeti.AlgebraicTopology.SimplicialComplex.Basic
 
 This file bundles simplicial maps between pre-abstract simplicial complexes. A simplicial map is
 a map of vertices which sends every face to a face. The file supplies the identity, composition,
-restriction to subcomplexes, and corestriction to a larger complex, together with the connection
+restriction to subcomplexes, and extension to a larger complex, together with the connection
 to Mathlib's image complex `PreAbstractSimplicialComplex.map`.
 
 These maps are basic infrastructure for subdivision and geometric realization in the geometric
@@ -62,11 +62,8 @@ theorem map_face (f : SimplicialMap K L) {σ : Finset α} (hσ : σ ∈ K) :
 /-- A vertex map is simplicial exactly when its image complex is a subcomplex of the codomain. -/
 theorem map_le_iff (f : α → β) :
     K.map f ≤ L ↔ ∀ ⦃σ : Finset α⦄, σ ∈ K → σ.image f ∈ L := by
-  constructor
-  · intro h σ hσ
-    exact h ⟨σ, hσ, rfl⟩
-  · rintro h τ ⟨σ, hσ, rfl⟩
-    exact h hσ
+  change (fun σ : Finset α ↦ σ.image f) '' K.faces ⊆ L.faces ↔ _
+  exact Set.image_subset_iff
 
 /-- Construct a simplicial map from containment of the image complex in the codomain. -/
 def ofMapLE (f : α → β) (h : K.map f ≤ L) : SimplicialMap K L where
@@ -112,16 +109,19 @@ theorem comp_apply (g : SimplicialMap L P) (f : SimplicialMap K L) (x : α) :
     g.comp f x = g (f x) :=
   (rfl)
 
+/-- Composing a simplicial map on the right with the identity leaves it unchanged. -/
 @[simp]
 theorem comp_id [DecidableEq α] (f : SimplicialMap K L) : f.comp (id K) = f := by
   apply DFunLike.coe_injective
   rw [coe_comp, coe_id, Function.comp_id]
 
+/-- Composing a simplicial map on the left with the identity leaves it unchanged. -/
 @[simp]
 theorem id_comp (f : SimplicialMap K L) : (id L).comp f = f := by
   apply DFunLike.coe_injective
   rw [coe_comp, coe_id, Function.id_comp]
 
+/-- Composition of simplicial maps is associative. -/
 @[simp]
 theorem comp_assoc [DecidableEq δ] (h : SimplicialMap P P') (g : SimplicialMap L P)
     (f : SimplicialMap K L) : (h.comp g).comp f = h.comp (g.comp f) := by
@@ -139,13 +139,13 @@ theorem coe_domainRestrict (f : SimplicialMap K L) (h : K' ≤ K) :
   (rfl)
 
 /-- Regard a simplicial map as landing in a larger complex. -/
-def codomainRestrict (f : SimplicialMap K L) (h : L ≤ L') : SimplicialMap K L' where
+def codomainExtend (f : SimplicialMap K L) (h : L ≤ L') : SimplicialMap K L' where
   toFun := f
   map_face' := fun _ hσ ↦ h (f.map_face hσ)
 
 @[simp]
-theorem coe_codomainRestrict (f : SimplicialMap K L) (h : L ≤ L') :
-    ⇑(f.codomainRestrict h) = f :=
+theorem coe_codomainExtend (f : SimplicialMap K L) (h : L ≤ L') :
+    ⇑(f.codomainExtend h) = f :=
   (rfl)
 
 /-- Every vertex map is simplicial into its image complex. -/

--- a/TauCeti/AlgebraicTopology/SimplicialComplex/Maps.lean
+++ b/TauCeti/AlgebraicTopology/SimplicialComplex/Maps.lean
@@ -63,8 +63,11 @@ theorem map_face (f : SimplicialMap K L) {σ : Finset α} (hσ : σ ∈ K) :
 /-- A vertex map is simplicial exactly when its image complex is a subcomplex of the codomain. -/
 theorem map_le_iff (f : α → β) :
     K.map f ≤ L ↔ ∀ ⦃σ : Finset α⦄, σ ∈ K → σ.image f ∈ L := by
-  change (fun σ : Finset α ↦ σ.image f) '' K.faces ⊆ L.faces ↔ _
-  exact Set.image_subset_iff
+  constructor
+  · intro h σ hσ
+    exact h ⟨σ, hσ, rfl⟩
+  · rintro h _ ⟨σ, hσ, rfl⟩
+    exact h hσ
 
 /-- Construct a simplicial map from containment of the image complex in the codomain. -/
 def ofMapLE (f : α → β) (h : K.map f ≤ L) : SimplicialMap K L where
@@ -150,11 +153,11 @@ theorem coe_codomainExtend (f : SimplicialMap K L) (h : L ≤ L') :
   (rfl)
 
 /-- Every vertex map is simplicial into its image complex. -/
-def toMap (K : PreAbstractSimplicialComplex α) (f : α → β) : SimplicialMap K (K.map f) :=
+def toImage (K : PreAbstractSimplicialComplex α) (f : α → β) : SimplicialMap K (K.map f) :=
   ofMapLE f le_rfl
 
 @[simp]
-theorem coe_toMap (K : PreAbstractSimplicialComplex α) (f : α → β) : ⇑(toMap K f) = f :=
+theorem coe_toImage (K : PreAbstractSimplicialComplex α) (f : α → β) : ⇑(toImage K f) = f :=
   (rfl)
 
 /-- The inclusion of a subcomplex, acting as the identity on the ambient vertex type. -/

--- a/TauCeti/AlgebraicTopology/SimplicialComplex/Maps.lean
+++ b/TauCeti/AlgebraicTopology/SimplicialComplex/Maps.lean
@@ -10,9 +10,9 @@ public import Mathlib.AlgebraicTopology.SimplicialComplex.Basic
 # Maps of abstract simplicial complexes
 
 This file bundles simplicial maps between pre-abstract simplicial complexes. A simplicial map is
-a map of vertices which sends every face to a face. The file supplies the identity, composition,
-restriction to subcomplexes, and extension to a larger complex, together with the connection
-to Mathlib's image complex `PreAbstractSimplicialComplex.map`.
+a map of ambient vertex types which sends every face to a face. The file supplies the identity,
+composition, restriction to subcomplexes, and extension to a larger complex, together with the
+connection to Mathlib's image complex `PreAbstractSimplicialComplex.map`.
 
 These maps are basic infrastructure for subdivision and geometric realization in the geometric
 topology roadmap. We work with `PreAbstractSimplicialComplex`, since constructions such as links
@@ -31,12 +31,12 @@ variable {L L' : PreAbstractSimplicialComplex β}
 variable {P : PreAbstractSimplicialComplex γ}
 variable {P' : PreAbstractSimplicialComplex δ}
 
-/-- A simplicial map between pre-abstract simplicial complexes is a map of vertices which sends
-faces to faces. -/
+/-- A simplicial map between pre-abstract simplicial complexes is a map of their ambient vertex
+types which sends faces to faces. -/
 @[ext]
 structure SimplicialMap (K : PreAbstractSimplicialComplex α)
     (L : PreAbstractSimplicialComplex β) where
-  /-- The map on vertices. -/
+  /-- The map on the ambient vertex types. -/
   toFun : α → β
   /-- The image of every face is a face. -/
   map_face' : ∀ ⦃σ : Finset α⦄, σ ∈ K → σ.image toFun ∈ L

--- a/TauCeti/AlgebraicTopology/SimplicialComplex/Maps.lean
+++ b/TauCeti/AlgebraicTopology/SimplicialComplex/Maps.lean
@@ -4,7 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 -/
 module
 
-public import TauCeti.AlgebraicTopology.SimplicialComplex.Basic
+public import Mathlib.AlgebraicTopology.SimplicialComplex.Basic
 
 /-!
 # Maps of abstract simplicial complexes

--- a/TauCeti/AlgebraicTopology/SimplicialComplex/Maps.lean
+++ b/TauCeti/AlgebraicTopology/SimplicialComplex/Maps.lean
@@ -62,12 +62,8 @@ theorem map_face (f : SimplicialMap K L) {σ : Finset α} (hσ : σ ∈ K) :
 
 /-- A vertex map is simplicial exactly when its image complex is a subcomplex of the codomain. -/
 theorem map_le_iff (f : α → β) :
-    K.map f ≤ L ↔ ∀ ⦃σ : Finset α⦄, σ ∈ K → σ.image f ∈ L := by
-  constructor
-  · intro h σ hσ
-    exact h ⟨σ, hσ, rfl⟩
-  · rintro h _ ⟨σ, hσ, rfl⟩
-    exact h hσ
+    K.map f ≤ L ↔ ∀ ⦃σ : Finset α⦄, σ ∈ K → σ.image f ∈ L :=
+  Set.image_subset_iff
 
 /-- Construct a simplicial map from containment of the image complex in the codomain. -/
 def ofMapLE (f : α → β) (h : K.map f ≤ L) : SimplicialMap K L where

--- a/TauCeti/AlgebraicTopology/SimplicialComplex/Maps.lean
+++ b/TauCeti/AlgebraicTopology/SimplicialComplex/Maps.lean
@@ -55,6 +55,7 @@ theorem coe_mk (f : α → β) (hf) : ⇑(SimplicialMap.mk f hf : SimplicialMap 
   (rfl)
 
 /-- A simplicial map sends a face to a face. -/
+@[grind =>]
 theorem map_face (f : SimplicialMap K L) {σ : Finset α} (hσ : σ ∈ K) :
     σ.image f ∈ L :=
   f.map_face' hσ
@@ -149,20 +150,16 @@ theorem coe_codomainExtend (f : SimplicialMap K L) (h : L ≤ L') :
   (rfl)
 
 /-- Every vertex map is simplicial into its image complex. -/
-def toMap (K : PreAbstractSimplicialComplex α) (f : α → β) : SimplicialMap K (K.map f) where
-  toFun := f
-  map_face' := fun σ hσ ↦ ⟨σ, hσ, rfl⟩
+def toMap (K : PreAbstractSimplicialComplex α) (f : α → β) : SimplicialMap K (K.map f) :=
+  ofMapLE f le_rfl
 
 @[simp]
 theorem coe_toMap (K : PreAbstractSimplicialComplex α) (f : α → β) : ⇑(toMap K f) = f :=
   (rfl)
 
 /-- The inclusion of a subcomplex, acting as the identity on the ambient vertex type. -/
-def inclusion [DecidableEq α] (h : K ≤ K') : SimplicialMap K K' where
-  toFun := _root_.id
-  map_face' := fun _ hσ ↦ by
-    simp only [Finset.image_id]
-    exact h hσ
+def inclusion [DecidableEq α] (h : K ≤ K') : SimplicialMap K K' :=
+  (id K).codomainExtend h
 
 @[simp]
 theorem coe_inclusion [DecidableEq α] (h : K ≤ K') : ⇑(inclusion h) = _root_.id :=


### PR DESCRIPTION
This PR adds face-preserving maps of pre-abstract simplicial complexes and exposes their core functorial API. Bundle a simplicial map as a vertex function carrying faces to faces; characterize this condition by containment of Mathlib's image complex; and provide identity, composition, domain restriction, codomain enlargement, canonical maps to image complexes, and subcomplex inclusions.

This advances `TauCetiRoadmap/GeometricTopology/README.md`, Layer 11, item “Geometric realization of an abstract simplicial complex … with the basic API … subdivision.” Simplicial maps are the clean prerequisite through which subdivision and realization become functorial. It is the lowest-hanging distinct target after the landed star, link, join, simplex, and collapse work and the open cone work: pinned Mathlib supplies `PreAbstractSimplicialComplex.map`, but no face-preserving map object or identity/composition API.

No Mathlib infrastructure is vendored. The implementation reuses Mathlib's `PreAbstractSimplicialComplex.map`, `Finset.image`, and subcomplex order.

`lake exe cache get` reports `No files to download` and `Already decompressed 8639 file(s)`. `lake build` reports `Build completed successfully (5230 jobs).` `lake exe axioms` reports `axioms: audited 11007 TauCeti declaration(s); all within the allowlist [propext, Classical.choice, Quot.sound].`

<!--tauceti-target:v1 {"focus":"GeometricTopology","id":"simplicial-complex-maps"}-->

🤖 Prepared with Codex
