### PR TITLE
feat: compute the real winding integrand at a crossing

### DIFF
--- a/TauCeti/Analysis/Contour/Winding/CrossingValue.lean
+++ b/TauCeti/Analysis/Contour/Winding/CrossingValue.lean
@@ -6,6 +6,7 @@ Authors: The Tau Ceti contributors
 module
 
 public import TauCeti.Analysis.Contour.Winding.Integrand
+public import Mathlib.Analysis.Calculus.Deriv.Basic
 
 /-!
 # The real winding integrand at a crossing

--- a/TauCeti/Analysis/Contour/Winding/CrossingValue.lean
+++ b/TauCeti/Analysis/Contour/Winding/CrossingValue.lean
@@ -79,7 +79,7 @@ private theorem tendsto_realWindingIntegrand_mul_add {α : Type*} {l : Filter α
   convert hdiv.congr' ?_ using 1
   · ring_nf
   filter_upwards [hqr, hτ, hq_ne] with i hqi hτi hqi_ne
-  rw [realWindingIntegrand_def]
+  rw [realWindingIntegrand_eq_div]
   simp only [Complex.mul_re, Complex.mul_im, Complex.ofReal_re, Complex.ofReal_im, zero_mul,
     add_zero, Complex.add_re, Complex.add_im, Complex.normSq_mul, Complex.normSq_ofReal]
   have hτsq : τ i ^ 2 ≠ 0 := pow_ne_zero _ hτi

--- a/TauCeti/Analysis/Contour/Winding/CrossingValue.lean
+++ b/TauCeti/Analysis/Contour/Winding/CrossingValue.lean
@@ -1,0 +1,169 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import TauCeti.Analysis.Contour.Winding.RealIntegral
+
+/-!
+# The real winding integrand at a smooth crossing
+
+This file proves the local crossing-value calculation in Hungerbühler–Wasem Proposition 2.3.
+For a twice differentiable plane curve `γ` passing through `s` at `t₀`, the apparently singular
+real winding integrand
+
+`(x ẏ - y ẋ) / (x² + y²)`, where `x + iy = γ - s`,
+
+tends to
+
+`(ẋ ÿ - ẏ ẍ) / (2 (ẋ² + ẏ²))`.
+
+The theorem is stated using the two Peano expansions it actually needs. This keeps it independent
+of any particular second-derivative API and lets clients obtain the hypotheses from `C²`, strict
+second derivative, or Taylor estimates. The intermediate theorem isolates the algebraic limit and
+is useful whenever the chord and velocity expansions come from different regularity packages.
+
+Mathlib has no signed-curvature API for plane curves. Accordingly, as prescribed by the contour
+integration roadmap, the answer is given by the explicit coordinate formula. It is one half of
+signed curvature times speed.
+
+## Main results
+
+* `Contour.realWindingIntegrand` is the real integrand of Hungerbühler–Wasem Proposition 2.3.
+* `Contour.tendsto_realWindingIntegrand_mul_add` is the algebraic limit for second-order chord
+  and first-order velocity expansions.
+* `Contour.tendsto_realWindingIntegrand_at_crossing` gives the crossing value for a curve.
+
+## References
+
+N. Hungerbühler and M. Wasem, *Non-integer valued winding numbers and a generalized Residue
+Theorem*, arXiv:1808.00997 (2018), Proposition 2.3.
+-/
+
+public section
+
+noncomputable section
+
+namespace TauCeti.Contour
+
+open Complex Filter Topology
+
+/-- The real winding integrand `(x ẏ - y ẋ) / (x² + y²)` for a position `z = x + iy`
+and velocity `v = ẋ + iẏ`. It is defined to be `0` at `z = 0`, following division in `ℝ`;
+the crossing theorem below supplies its canonical continuous extension along a regular `C²`
+curve. -/
+def realWindingIntegrand (z v : ℂ) : ℝ :=
+  (z.re * v.im - z.im * v.re) / Complex.normSq z
+
+/-- The real winding integrand is the imaginary part of the complex winding integrand. -/
+theorem realWindingIntegrand_eq_im_inv_mul (z v : ℂ) :
+    realWindingIntegrand z v = (z⁻¹ * v).im := by
+  rw [realWindingIntegrand, inv_mul_eq_div, Complex.div_im]
+  ring
+
+/-- Scaling position and velocity by the same nonzero real parameter leaves the real winding
+integrand unchanged. -/
+theorem realWindingIntegrand_ofReal_mul {c : ℝ} (hc : c ≠ 0) (z v : ℂ) :
+    realWindingIntegrand ((c : ℂ) * z) ((c : ℂ) * v) = realWindingIntegrand z v := by
+  simp only [realWindingIntegrand, Complex.mul_re, Complex.mul_im, Complex.ofReal_re,
+    Complex.ofReal_im, zero_mul, add_zero, Complex.normSq_mul, Complex.normSq_ofReal]
+  field_simp
+  ring
+
+/-- Algebraic form of the smooth-crossing limit. If `q → L`, `(q - L) / τ → A/2`, and
+`d → A`, then the real winding integrand of position `τq` and velocity `L + τd` tends to
+`(L.re * A.im - L.im * A.re) / (2‖L‖²)`.
+
+The hypotheses are precisely the normalized second-order position expansion and first-order
+velocity expansion. -/
+theorem tendsto_realWindingIntegrand_mul_add {α : Type*} {l : Filter α}
+    {τ : α → ℝ} {q r d : α → ℂ} {L A : ℂ} (hL : L ≠ 0)
+    (hq : Tendsto q l (𝓝 L)) (hr : Tendsto r l (𝓝 (A / 2)))
+    (hd : Tendsto d l (𝓝 A))
+    (hqr : ∀ᶠ i in l, q i - L = ((τ i : ℝ) : ℂ) * r i)
+    (hτ : ∀ᶠ i in l, τ i ≠ 0) :
+    Tendsto (fun i ↦ realWindingIntegrand (((τ i : ℝ) : ℂ) * q i)
+      (L + ((τ i : ℝ) : ℂ) * d i)) l
+      (𝓝 ((L.re * A.im - L.im * A.re) / (2 * Complex.normSq L))) := by
+  have hnorm : Tendsto (fun i ↦ Complex.normSq (q i)) l (𝓝 (Complex.normSq L)) :=
+    (Complex.continuous_normSq.tendsto L).comp hq
+  have hq_re := (Complex.continuous_re.tendsto L).comp hq
+  have hq_im := (Complex.continuous_im.tendsto L).comp hq
+  have hr_re := (Complex.continuous_re.tendsto (A / 2)).comp hr
+  have hr_im := (Complex.continuous_im.tendsto (A / 2)).comp hr
+  have hd_re := (Complex.continuous_re.tendsto A).comp hd
+  have hd_im := (Complex.continuous_im.tendsto A).comp hd
+  have hnum : Tendsto (fun i ↦
+      (r i).re * L.im - (r i).im * L.re +
+        ((q i).re * (d i).im - (q i).im * (d i).re)) l
+      (𝓝 ((L.re * A.im - L.im * A.re) / 2)) := by
+    convert (((hr_re.mul_const L.im).sub (hr_im.mul_const L.re)).add
+      ((hq_re.mul hd_im).sub (hq_im.mul hd_re))) using 1
+    all_goals simp <;> ring_nf
+  have hdiv := hnum.div hnorm ((Complex.normSq_eq_zero.not.mpr hL))
+  have hq_ne : ∀ᶠ i in l, q i ≠ 0 :=
+    hq.eventually (isOpen_compl_singleton.mem_nhds hL)
+  convert hdiv.congr' ?_ using 1
+  · ring_nf
+  filter_upwards [hqr, hτ, hq_ne] with i hqi hτi hqi_ne
+  rw [realWindingIntegrand]
+  simp only [Complex.mul_re, Complex.mul_im, Complex.ofReal_re, Complex.ofReal_im, zero_mul,
+    add_zero, Complex.add_re, Complex.add_im, Complex.normSq_mul, Complex.normSq_ofReal]
+  have hτsq : τ i ^ 2 ≠ 0 := pow_ne_zero _ hτi
+  have hLre : L.re = (q i).re - τ i * (r i).re := by
+    have := congrArg Complex.re hqi
+    simp only [Complex.sub_re, Complex.mul_re, Complex.ofReal_re, Complex.ofReal_im, zero_mul,
+      sub_zero] at this
+    linarith
+  have hLim : L.im = (q i).im - τ i * (r i).im := by
+    have := congrArg Complex.im hqi
+    simp only [Complex.sub_im, Complex.mul_im, Complex.ofReal_re, Complex.ofReal_im, zero_mul,
+      add_zero] at this
+    linarith
+  rw [hLre, hLim]
+  simp only [Pi.div_apply]
+  field_simp [hτi, Complex.normSq_eq_zero.not.mpr hqi_ne]
+  ring
+
+/-- **Hungerbühler–Wasem Proposition 2.3, crossing value.** At a regular crossing
+`γ t₀ = s`, a second-order chord expansion with acceleration `A` and the matching first-order
+velocity expansion imply
+
+`(x ẏ - y ẋ) / (x² + y²) → (ẋ ÿ - ẏ ẍ) / (2 (ẋ² + ẏ²))`.
+
+This is the explicit form of one half of signed curvature times speed. -/
+theorem tendsto_realWindingIntegrand_at_crossing {α : Type*} {l : Filter α}
+    {t : α → ℝ} {t₀ : ℝ} {γ : ℝ → ℂ} {s L A : ℂ} (hL : L ≠ 0)
+    (hpos : Tendsto (fun i ↦ ((γ (t i) - s) / (((t i - t₀ : ℝ) : ℂ)))) l (𝓝 L))
+    (hpos₂ : Tendsto (fun i ↦
+      (((γ (t i) - s) / (((t i - t₀ : ℝ) : ℂ))) - L) /
+        (((t i - t₀ : ℝ) : ℂ))) l (𝓝 (A / 2)))
+    (hvel : Tendsto (fun i ↦ (deriv γ (t i) - L) /
+      (((t i - t₀ : ℝ) : ℂ))) l (𝓝 A))
+    (ht : ∀ᶠ i in l, t i ≠ t₀) :
+    Tendsto (fun i ↦ realWindingIntegrand (γ (t i) - s) (deriv γ (t i))) l
+      (𝓝 ((L.re * A.im - L.im * A.re) / (2 * Complex.normSq L))) := by
+  let τ : α → ℝ := fun i ↦ t i - t₀
+  let q : α → ℂ := fun i ↦ (γ (t i) - s) / ((τ i : ℝ) : ℂ)
+  let r : α → ℂ := fun i ↦ (q i - L) / ((τ i : ℝ) : ℂ)
+  let d : α → ℂ := fun i ↦ (deriv γ (t i) - L) / ((τ i : ℝ) : ℂ)
+  have hτ : ∀ᶠ i in l, τ i ≠ 0 := ht.mono fun i hi ↦ sub_ne_zero.mpr hi
+  have hqr : ∀ᶠ i in l, q i - L = ((τ i : ℝ) : ℂ) * r i := hτ.mono fun i hi ↦ by
+    simp only [r]
+    field_simp [Complex.ofReal_ne_zero.mpr hi]
+  have hmain := tendsto_realWindingIntegrand_mul_add hL hpos hpos₂ hvel hqr hτ
+  apply hmain.congr'
+  filter_upwards [hτ] with i hi
+  have hiℂ : ((τ i : ℝ) : ℂ) ≠ 0 := Complex.ofReal_ne_zero.mpr hi
+  congr 1
+  · simp only [τ] at hiℂ ⊢
+    field_simp [hiℂ]
+  · simp only [τ] at hiℂ ⊢
+    field_simp [hiℂ]
+    ring
+
+end TauCeti.Contour
+
+end

--- a/TauCeti/Analysis/Contour/Winding/CrossingValue.lean
+++ b/TauCeti/Analysis/Contour/Winding/CrossingValue.lean
@@ -50,19 +50,6 @@ namespace TauCeti.Contour
 
 open Complex Filter Topology
 
-/-- The real winding integrand `(x ẏ - y ẋ) / (x² + y²)` for a position `z = x + iy`
-and velocity `v = ẋ + iẏ`. It is defined to be `0` at `z = 0`, following division in `ℝ`;
-the crossing theorem below supplies its canonical continuous extension along a regular `C²`
-curve. -/
-def realWindingIntegrand (z v : ℂ) : ℝ :=
-  (z.re * v.im - z.im * v.re) / Complex.normSq z
-
-/-- The real winding integrand is the imaginary part of the complex winding integrand. -/
-theorem realWindingIntegrand_eq_im_inv_mul (z v : ℂ) :
-    realWindingIntegrand z v = (z⁻¹ * v).im := by
-  rw [realWindingIntegrand, inv_mul_eq_div, Complex.div_im]
-  ring
-
 /-- Scaling position and velocity by the same nonzero real parameter leaves the real winding
 integrand unchanged. -/
 theorem realWindingIntegrand_ofReal_mul {c : ℝ} (hc : c ≠ 0) (z v : ℂ) :

--- a/TauCeti/Analysis/Contour/Winding/CrossingValue.lean
+++ b/TauCeti/Analysis/Contour/Winding/CrossingValue.lean
@@ -8,32 +8,25 @@ module
 public import TauCeti.Analysis.Contour.Winding.RealIntegral
 
 /-!
-# The real winding integrand at a smooth crossing
+# The real winding integrand at a crossing
 
 This file proves the local crossing-value calculation in Hungerbühler–Wasem Proposition 2.3.
-For a twice differentiable plane curve `γ` passing through `s` at `t₀`, the apparently singular
-real winding integrand
+For a plane curve `γ` passing through `s` at `t₀` whose chord and velocity have the stated filter
+expansions, the apparently singular real winding integrand
 
 `(x ẏ - y ẋ) / (x² + y²)`, where `x + iy = γ - s`,
 
-tends to
+tends to `(L.re * A.im - L.im * A.re) / (2 * ‖L‖²)`, where `L` and `A` are the coefficients
+in those expansions.
 
-`(ẋ ÿ - ẏ ẍ) / (2 (ẋ² + ẏ²))`.
+The theorem is stated using two Peano expansions, independently of any particular
+second-derivative API.
 
-The theorem is stated using the two Peano expansions it actually needs. This keeps it independent
-of any particular second-derivative API and lets clients obtain the hypotheses from `C²`, strict
-second derivative, or Taylor estimates. The intermediate theorem isolates the algebraic limit and
-is useful whenever the chord and velocity expansions come from different regularity packages.
-
-Mathlib has no signed-curvature API for plane curves. Accordingly, as prescribed by the contour
-integration roadmap, the answer is given by the explicit coordinate formula. It is one half of
-signed curvature times speed.
+As prescribed by the contour integration roadmap, the answer is given by an explicit coordinate
+formula.
 
 ## Main results
 
-* `Contour.realWindingIntegrand` is the real integrand of Hungerbühler–Wasem Proposition 2.3.
-* `Contour.tendsto_realWindingIntegrand_mul_add` is the algebraic limit for second-order chord
-  and first-order velocity expansions.
 * `Contour.tendsto_realWindingIntegrand_at_crossing` gives the crossing value for a curve.
 
 ## References
@@ -50,22 +43,13 @@ namespace TauCeti.Contour
 
 open Complex Filter Topology
 
-/-- Scaling position and velocity by the same nonzero real parameter leaves the real winding
-integrand unchanged. -/
-theorem realWindingIntegrand_ofReal_mul {c : ℝ} (hc : c ≠ 0) (z v : ℂ) :
-    realWindingIntegrand ((c : ℂ) * z) ((c : ℂ) * v) = realWindingIntegrand z v := by
-  simp only [realWindingIntegrand, Complex.mul_re, Complex.mul_im, Complex.ofReal_re,
-    Complex.ofReal_im, zero_mul, add_zero, Complex.normSq_mul, Complex.normSq_ofReal]
-  field_simp
-  ring
-
-/-- Algebraic form of the smooth-crossing limit. If `q → L`, `(q - L) / τ → A/2`, and
+/-- Algebraic form of the crossing limit. If `q → L`, `(q - L) / τ → A/2`, and
 `d → A`, then the real winding integrand of position `τq` and velocity `L + τd` tends to
 `(L.re * A.im - L.im * A.re) / (2‖L‖²)`.
 
 The hypotheses are precisely the normalized second-order position expansion and first-order
 velocity expansion. -/
-theorem tendsto_realWindingIntegrand_mul_add {α : Type*} {l : Filter α}
+private theorem tendsto_realWindingIntegrand_mul_add {α : Type*} {l : Filter α}
     {τ : α → ℝ} {q r d : α → ℂ} {L A : ℂ} (hL : L ≠ 0)
     (hq : Tendsto q l (𝓝 L)) (hr : Tendsto r l (𝓝 (A / 2)))
     (hd : Tendsto d l (𝓝 A))
@@ -95,7 +79,7 @@ theorem tendsto_realWindingIntegrand_mul_add {α : Type*} {l : Filter α}
   convert hdiv.congr' ?_ using 1
   · ring_nf
   filter_upwards [hqr, hτ, hq_ne] with i hqi hτi hqi_ne
-  rw [realWindingIntegrand]
+  rw [realWindingIntegrand_def]
   simp only [Complex.mul_re, Complex.mul_im, Complex.ofReal_re, Complex.ofReal_im, zero_mul,
     add_zero, Complex.add_re, Complex.add_im, Complex.normSq_mul, Complex.normSq_ofReal]
   have hτsq : τ i ^ 2 ≠ 0 := pow_ne_zero _ hτi
@@ -114,17 +98,16 @@ theorem tendsto_realWindingIntegrand_mul_add {α : Type*} {l : Filter α}
   field_simp [hτi, Complex.normSq_eq_zero.not.mpr hqi_ne]
   ring
 
-/-- **Hungerbühler–Wasem Proposition 2.3, crossing value.** At a regular crossing
-`γ t₀ = s`, a second-order chord expansion with acceleration `A` and the matching first-order
-velocity expansion imply
+/-- **Hungerbühler–Wasem Proposition 2.3, crossing value.** At a crossing `γ t₀ = s`,
+a normalized second-order chord expansion with coefficients `L` and `A`, together with the
+matching first-order velocity expansion, implies
 
-`(x ẏ - y ẋ) / (x² + y²) → (ẋ ÿ - ẏ ẍ) / (2 (ẋ² + ẏ²))`.
+`(x ẏ - y ẋ) / (x² + y²) → (L.re * A.im - L.im * A.re) / (2 * ‖L‖²)`.
 
-This is the explicit form of one half of signed curvature times speed. -/
+The conclusion refers only to the coefficients in the assumed filter expansions. -/
 theorem tendsto_realWindingIntegrand_at_crossing {α : Type*} {l : Filter α}
     {t : α → ℝ} {t₀ : ℝ} {γ : ℝ → ℂ} {s L A : ℂ} (hL : L ≠ 0)
     (htend : Tendsto t l (𝓝 t₀)) (hcross : γ t₀ = s)
-    (hpos : Tendsto (fun i ↦ ((γ (t i) - s) / (((t i - t₀ : ℝ) : ℂ)))) l (𝓝 L))
     (hpos₂ : Tendsto (fun i ↦
       (((γ (t i) - s) / (((t i - t₀ : ℝ) : ℂ))) - L) /
         (((t i - t₀ : ℝ) : ℂ))) l (𝓝 (A / 2)))
@@ -134,24 +117,32 @@ theorem tendsto_realWindingIntegrand_at_crossing {α : Type*} {l : Filter α}
     Tendsto (fun i ↦ realWindingIntegrand (γ (t i) - s) (deriv γ (t i))) l
       (𝓝 ((L.re * A.im - L.im * A.re) / (2 * Complex.normSq L))) := by
   subst s
-  have hpos' := tendsto_snd.comp (Tendsto.prodMk htend hpos)
-  change Tendsto (fun i ↦ (γ (t i) - γ t₀) / (((t i - t₀ : ℝ) : ℂ))) l (𝓝 L) at hpos'
   let τ : α → ℝ := fun i ↦ t i - t₀
   let q : α → ℂ := fun i ↦ (γ (t i) - γ t₀) / ((τ i : ℝ) : ℂ)
   let r : α → ℂ := fun i ↦ (q i - L) / ((τ i : ℝ) : ℂ)
   let d : α → ℂ := fun i ↦ (deriv γ (t i) - L) / ((τ i : ℝ) : ℂ)
+  change Tendsto r l (𝓝 (A / 2)) at hpos₂
+  change Tendsto d l (𝓝 A) at hvel
   have hτ : ∀ᶠ i in l, τ i ≠ 0 := ht.mono fun i hi ↦ sub_ne_zero.mpr hi
   have hqr : ∀ᶠ i in l, q i - L = ((τ i : ℝ) : ℂ) * r i := hτ.mono fun i hi ↦ by
     simp only [r]
     field_simp [Complex.ofReal_ne_zero.mpr hi]
-  have hmain := tendsto_realWindingIntegrand_mul_add hL hpos' hpos₂ hvel hqr hτ
+  have hτ_zero : Tendsto τ l (𝓝 0) := by
+    simpa only [τ, sub_self] using htend.sub_const t₀
+  have hq : Tendsto q l (𝓝 L) := by
+    have hmul : Tendsto (fun i ↦ ((τ i : ℝ) : ℂ) * r i) l (𝓝 0) := by
+      convert ((Complex.continuous_ofReal.tendsto 0).comp hτ_zero).mul hpos₂ using 1 <;> simp
+    have hadd := hmul.add_const L
+    simpa only [zero_add] using hadd.congr' (hqr.mono fun i hi ↦ by
+      rw [← hi, sub_add_cancel])
+  have hmain := tendsto_realWindingIntegrand_mul_add hL hq hpos₂ hvel hqr hτ
   apply hmain.congr'
   filter_upwards [hτ] with i hi
   have hiℂ : ((τ i : ℝ) : ℂ) ≠ 0 := Complex.ofReal_ne_zero.mpr hi
   congr 1
-  · simp only [τ] at hiℂ ⊢
+  · simp only [q, τ] at hiℂ ⊢
     field_simp [hiℂ]
-  · simp only [τ] at hiℂ ⊢
+  · simp only [d, τ] at hiℂ ⊢
     field_simp [hiℂ]
     ring
 

--- a/TauCeti/Analysis/Contour/Winding/CrossingValue.lean
+++ b/TauCeti/Analysis/Contour/Winding/CrossingValue.lean
@@ -5,7 +5,7 @@ Authors: The Tau Ceti contributors
 -/
 module
 
-public import TauCeti.Analysis.Contour.Winding.RealIntegral
+public import TauCeti.Analysis.Contour.Winding.Integrand
 
 /-!
 # The real winding integrand at a crossing

--- a/TauCeti/Analysis/Contour/Winding/CrossingValue.lean
+++ b/TauCeti/Analysis/Contour/Winding/CrossingValue.lean
@@ -136,6 +136,7 @@ velocity expansion imply
 This is the explicit form of one half of signed curvature times speed. -/
 theorem tendsto_realWindingIntegrand_at_crossing {α : Type*} {l : Filter α}
     {t : α → ℝ} {t₀ : ℝ} {γ : ℝ → ℂ} {s L A : ℂ} (hL : L ≠ 0)
+    (htend : Tendsto t l (𝓝 t₀)) (hcross : γ t₀ = s)
     (hpos : Tendsto (fun i ↦ ((γ (t i) - s) / (((t i - t₀ : ℝ) : ℂ)))) l (𝓝 L))
     (hpos₂ : Tendsto (fun i ↦
       (((γ (t i) - s) / (((t i - t₀ : ℝ) : ℂ))) - L) /
@@ -145,15 +146,18 @@ theorem tendsto_realWindingIntegrand_at_crossing {α : Type*} {l : Filter α}
     (ht : ∀ᶠ i in l, t i ≠ t₀) :
     Tendsto (fun i ↦ realWindingIntegrand (γ (t i) - s) (deriv γ (t i))) l
       (𝓝 ((L.re * A.im - L.im * A.re) / (2 * Complex.normSq L))) := by
+  subst s
+  have hpos' := tendsto_snd.comp (Tendsto.prodMk htend hpos)
+  change Tendsto (fun i ↦ (γ (t i) - γ t₀) / (((t i - t₀ : ℝ) : ℂ))) l (𝓝 L) at hpos'
   let τ : α → ℝ := fun i ↦ t i - t₀
-  let q : α → ℂ := fun i ↦ (γ (t i) - s) / ((τ i : ℝ) : ℂ)
+  let q : α → ℂ := fun i ↦ (γ (t i) - γ t₀) / ((τ i : ℝ) : ℂ)
   let r : α → ℂ := fun i ↦ (q i - L) / ((τ i : ℝ) : ℂ)
   let d : α → ℂ := fun i ↦ (deriv γ (t i) - L) / ((τ i : ℝ) : ℂ)
   have hτ : ∀ᶠ i in l, τ i ≠ 0 := ht.mono fun i hi ↦ sub_ne_zero.mpr hi
   have hqr : ∀ᶠ i in l, q i - L = ((τ i : ℝ) : ℂ) * r i := hτ.mono fun i hi ↦ by
     simp only [r]
     field_simp [Complex.ofReal_ne_zero.mpr hi]
-  have hmain := tendsto_realWindingIntegrand_mul_add hL hpos hpos₂ hvel hqr hτ
+  have hmain := tendsto_realWindingIntegrand_mul_add hL hpos' hpos₂ hvel hqr hτ
   apply hmain.congr'
   filter_upwards [hτ] with i hi
   have hiℂ : ((τ i : ℝ) : ℂ) ≠ 0 := Complex.ofReal_ne_zero.mpr hi

--- a/TauCeti/Analysis/Contour/Winding/CrossingValue.lean
+++ b/TauCeti/Analysis/Contour/Winding/CrossingValue.lean
@@ -121,8 +121,9 @@ theorem tendsto_realWindingIntegrand_at_crossing {α : Type*} {l : Filter α}
   let q : α → ℂ := fun i ↦ (γ (t i) - γ t₀) / ((τ i : ℝ) : ℂ)
   let r : α → ℂ := fun i ↦ (q i - L) / ((τ i : ℝ) : ℂ)
   let d : α → ℂ := fun i ↦ (deriv γ (t i) - L) / ((τ i : ℝ) : ℂ)
-  change Tendsto r l (𝓝 (A / 2)) at hpos₂
-  change Tendsto d l (𝓝 A) at hvel
+  -- `r`, `d` are `hpos₂`, `hvel` with `s = γ t₀` and `τ = t - t₀` folded into the wrappers.
+  have hr : Tendsto r l (𝓝 (A / 2)) := by simpa only [r, q, τ] using hpos₂
+  have hd : Tendsto d l (𝓝 A) := by simpa only [d, τ] using hvel
   have hτ : ∀ᶠ i in l, τ i ≠ 0 := ht.mono fun i hi ↦ sub_ne_zero.mpr hi
   have hqr : ∀ᶠ i in l, q i - L = ((τ i : ℝ) : ℂ) * r i := hτ.mono fun i hi ↦ by
     simp only [r]
@@ -131,11 +132,11 @@ theorem tendsto_realWindingIntegrand_at_crossing {α : Type*} {l : Filter α}
     simpa only [τ, sub_self] using htend.sub_const t₀
   have hq : Tendsto q l (𝓝 L) := by
     have hmul : Tendsto (fun i ↦ ((τ i : ℝ) : ℂ) * r i) l (𝓝 0) := by
-      convert ((Complex.continuous_ofReal.tendsto 0).comp hτ_zero).mul hpos₂ using 1 <;> simp
+      convert ((Complex.continuous_ofReal.tendsto 0).comp hτ_zero).mul hr using 1 <;> simp
     have hadd := hmul.add_const L
     simpa only [zero_add] using hadd.congr' (hqr.mono fun i hi ↦ by
       rw [← hi, sub_add_cancel])
-  have hmain := tendsto_realWindingIntegrand_mul_add hL hq hpos₂ hvel hqr hτ
+  have hmain := tendsto_realWindingIntegrand_mul_add hL hq hr hd hqr hτ
   apply hmain.congr'
   filter_upwards [hτ] with i hi
   have hiℂ : ((τ i : ℝ) : ℂ) ≠ 0 := Complex.ofReal_ne_zero.mpr hi

--- a/TauCeti/Analysis/Contour/Winding/Integrand.lean
+++ b/TauCeti/Analysis/Contour/Winding/Integrand.lean
@@ -1,0 +1,55 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Chris Birkbeck
+-/
+module
+
+public import Mathlib.Analysis.Calculus.Deriv.Basic
+public import Mathlib.Analysis.Complex.Basic
+
+/-!
+# The real winding integrand
+
+This file defines the pointwise real winding integrand and records its coordinate formula and
+invariance under simultaneous nonzero complex scaling.
+
+## Provenance
+
+The pointwise imaginary-part decomposition is migrated and cleaned from the AINTLIB
+`LeanModularForms` generalized-winding-number development.
+-/
+
+public section
+
+namespace TauCeti.Contour
+
+/-- The real winding integrand `(x ẏ - y ẋ) / (x² + y²)` for a position `z = x + iy`
+and velocity `v = ẋ + iẏ`. It is defined as the imaginary part `(z⁻¹ * v).im` of the complex
+winding integrand; in particular it is `0` at `z = 0`. Its relation to the complex integrand is
+`realWindingIntegrand_def` and its coordinate form is `realWindingIntegrand_eq_div`. -/
+public noncomputable def realWindingIntegrand (z v : ℂ) : ℝ := (z⁻¹ * v).im
+
+/-- The real winding integrand is the imaginary part of the complex winding integrand `z⁻¹ * v`.
+This is a convenient public rewrite lemma relating the real integrand to the complex index
+integrand `(γ - w)⁻¹ * γ'`. -/
+theorem realWindingIntegrand_def (z v : ℂ) :
+    realWindingIntegrand z v = (z⁻¹ * v).im := by
+  rw [realWindingIntegrand]
+
+/-- The coordinate formula for the real winding integrand. -/
+@[simp] theorem realWindingIntegrand_eq_div (z v : ℂ) :
+    realWindingIntegrand z v =
+      (z.re * v.im - z.im * v.re) / Complex.normSq z := by
+  rw [realWindingIntegrand_def, inv_mul_eq_div, Complex.div_im]
+  ring
+
+/-- Scaling position and velocity by the same nonzero complex parameter leaves the real winding
+integrand unchanged: it is the imaginary part of `(c * z)⁻¹ * (c * v) = z⁻¹ * v`, where the two
+factors of `c` cancel in `ℂ`. -/
+theorem realWindingIntegrand_mul_mul {c : ℂ} (hc : c ≠ 0) (z v : ℂ) :
+    realWindingIntegrand (c * z) (c * v) = realWindingIntegrand z v := by
+  rw [realWindingIntegrand_def, realWindingIntegrand_def, mul_inv_rev,
+    mul_assoc, inv_mul_cancel_left₀ hc]
+
+end TauCeti.Contour

--- a/TauCeti/Analysis/Contour/Winding/Integrand.lean
+++ b/TauCeti/Analysis/Contour/Winding/Integrand.lean
@@ -5,7 +5,6 @@ Authors: Chris Birkbeck
 -/
 module
 
-public import Mathlib.Analysis.Calculus.Deriv.Basic
 public import Mathlib.Analysis.Complex.Basic
 
 /-!

--- a/TauCeti/Analysis/Contour/Winding/RealIntegral.lean
+++ b/TauCeti/Analysis/Contour/Winding/RealIntegral.lean
@@ -58,10 +58,24 @@ and velocity `v = ẋ + iẏ`. It is defined to be `0` at `z = 0`, following div
 @[expose] public noncomputable def realWindingIntegrand (z v : ℂ) : ℝ :=
   (z.re * v.im - z.im * v.re) / Complex.normSq z
 
+/-- The coordinate formula for the real winding integrand. -/
+@[simp] theorem realWindingIntegrand_def (z v : ℂ) :
+    realWindingIntegrand z v =
+      (z.re * v.im - z.im * v.re) / Complex.normSq z := rfl
+
 /-- The real winding integrand is the imaginary part of the complex winding integrand. -/
 theorem realWindingIntegrand_eq_im_inv_mul (z v : ℂ) :
     realWindingIntegrand z v = (z⁻¹ * v).im := by
   rw [realWindingIntegrand, inv_mul_eq_div, Complex.div_im]
+  ring
+
+/-- Scaling position and velocity by the same nonzero real parameter leaves the real winding
+integrand unchanged. -/
+theorem realWindingIntegrand_ofReal_mul_ofReal_mul {c : ℝ} (hc : c ≠ 0) (z v : ℂ) :
+    realWindingIntegrand ((c : ℂ) * z) ((c : ℂ) * v) = realWindingIntegrand z v := by
+  simp only [realWindingIntegrand_def, Complex.mul_re, Complex.mul_im, Complex.ofReal_re,
+    Complex.ofReal_im, zero_mul, add_zero, Complex.normSq_mul, Complex.normSq_ofReal]
+  field_simp
   ring
 
 /-- **The real bounded-integrand formula for the winding number** (Hungerbühler–Wasem Prop 2.3,

--- a/TauCeti/Analysis/Contour/Winding/RealIntegral.lean
+++ b/TauCeti/Analysis/Contour/Winding/RealIntegral.lean
@@ -17,8 +17,8 @@ the generalized winding number by the **real** integral
 
 where `x + i y = γ − w`. Writing `γ − w = x + i y` and `γ' = ẋ + i ẏ`, the winding integrand
 `(γ − w)⁻¹ · γ'` has imaginary part exactly `(x ẏ − y ẋ) / (x² + y²)` (the real integrand above,
-here with denominator `Complex.normSq (γ − w) = x² + y²`); this pointwise piece is the private
-helper `inv_mul_im`. For a point *off* the curve the
+here with denominator `Complex.normSq (γ − w) = x² + y²`); this pointwise piece is
+`realWindingIntegrand_eq_im_inv_mul`. For a point *off* the curve the
 winding number is a genuine integer (`exists_int_windingNumber_of_closed`), hence real, so the
 ordinary index integral `(2πi)⁻¹ ∮_γ dz/(z − w)` is purely imaginary: its real part vanishes and its
 imaginary part is the real integral above. This is the off-curve (no principal-value) case of the
@@ -27,6 +27,7 @@ real formula — the computational workhorse of Layer 1; the on-curve bounded-in
 
 ## Main results
 
+* `TauCeti.Contour.realWindingIntegrand` — the real coordinate winding integrand.
 * `TauCeti.Contour.windingNumber_eq_real_integral_of_closed` — the winding number of a closed curve
   off `w` equals the real bounded integral `(1 / 2π) ∫ (x ẏ − y ẋ) / (x² + y²)`.
 
@@ -52,12 +53,16 @@ open scoped Interval
 
 namespace TauCeti.Contour
 
-/-- **Imaginary part of `z⁻¹ · v`.** Writing `z = x + i y` and `v = ẋ + i ẏ`, the imaginary part of
-`z⁻¹ · v` is `(x ẏ − y ẋ) / (x² + y²)`, with `Complex.normSq z = x² + y²`. This is the Hungerbühler–
-Wasem real winding integrand (Prop 2.3). Stated for all `z`, `v` (at `z = 0` both sides are `0`). -/
-private theorem inv_mul_im (z v : ℂ) :
-    (z⁻¹ * v).im = (z.re * v.im - z.im * v.re) / Complex.normSq z := by
-  rw [inv_mul_eq_div, Complex.div_im]; ring
+/-- The real winding integrand `(x ẏ - y ẋ) / (x² + y²)` for a position `z = x + iy`
+and velocity `v = ẋ + iẏ`. It is defined to be `0` at `z = 0`, following division in `ℝ`. -/
+@[expose] public noncomputable def realWindingIntegrand (z v : ℂ) : ℝ :=
+  (z.re * v.im - z.im * v.re) / Complex.normSq z
+
+/-- The real winding integrand is the imaginary part of the complex winding integrand. -/
+theorem realWindingIntegrand_eq_im_inv_mul (z v : ℂ) :
+    realWindingIntegrand z v = (z⁻¹ * v).im := by
+  rw [realWindingIntegrand, inv_mul_eq_div, Complex.div_im]
+  ring
 
 /-- **The real bounded-integrand formula for the winding number** (Hungerbühler–Wasem Prop 2.3,
 off-curve case). For a curve `γ` on the oriented interval with endpoints `a`, `b` that returns to
@@ -70,7 +75,8 @@ avoids
 
 with bounded real integrand and no principal value. The winding number is a genuine integer here
 (`exists_int_windingNumber_of_closed`), so the index integral is purely imaginary; its imaginary
-part is this real integral (`inv_mul_im`), while its real part — the increment of `log ‖γ − w‖` —
+part is this real integral (`realWindingIntegrand_eq_im_inv_mul`), while its real part — the
+increment of `log ‖γ − w‖` —
 vanishes by closedness. -/
 theorem windingNumber_eq_real_integral_of_closed {γ : ℝ → ℂ} {w : ℂ} {a b : ℝ} {P : Set ℝ}
     (hclosed : γ a = γ b) (hP : P.Countable)
@@ -107,7 +113,7 @@ theorem windingNumber_eq_real_integral_of_closed {γ : ℝ → ℂ} {w : ℂ} {a
           / Complex.normSq (γ t - w)) = 2 * Real.pi * (n : ℝ) := by
     have hpt : ∀ t, ((γ t - w).re * (deriv γ t).im - (γ t - w).im * (deriv γ t).re)
         / Complex.normSq (γ t - w) = ((γ t - w)⁻¹ * deriv γ t).im :=
-      fun t ↦ (inv_mul_im (γ t - w) (deriv γ t)).symm
+      fun t ↦ realWindingIntegrand_eq_im_inv_mul (γ t - w) (deriv γ t)
     simp_rw [hpt, ← RCLike.im_to_complex]
     rw [intervalIntegral_im h_int, RCLike.im_to_complex, him]
   -- Assemble: `n_w(γ) = n = (1 / 2π) · (2π · n)`.

--- a/TauCeti/Analysis/Contour/Winding/RealIntegral.lean
+++ b/TauCeti/Analysis/Contour/Winding/RealIntegral.lean
@@ -6,6 +6,7 @@ Authors: Chris Birkbeck
 module
 
 public import TauCeti.Analysis.Contour.Winding.Integer
+public import TauCeti.Analysis.Contour.Winding.Integrand
 
 /-!
 # The real bounded-integrand formula for the winding number (Hungerbühler–Wasem Prop 2.3)
@@ -52,35 +53,6 @@ open Complex MeasureTheory Set intervalIntegral
 open scoped Interval
 
 namespace TauCeti.Contour
-
-/-- The real winding integrand `(x ẏ - y ẋ) / (x² + y²)` for a position `z = x + iy`
-and velocity `v = ẋ + iẏ`. It is defined as the imaginary part `(z⁻¹ * v).im` of the complex
-winding integrand; in particular it is `0` at `z = 0`. Its relation to the complex integrand is
-`realWindingIntegrand_eq_im_inv_mul` and its coordinate form is `realWindingIntegrand_eq_div`. -/
-public noncomputable def realWindingIntegrand (z v : ℂ) : ℝ := (z⁻¹ * v).im
-
-/-- The real winding integrand is the imaginary part of the complex winding integrand `z⁻¹ * v`.
-This is the defining relation between the real integrand and the complex index integrand
-`(γ - w)⁻¹ * γ'`; the definition's body is not exposed, so this is the public characterization
-downstream files rewrite through. -/
-theorem realWindingIntegrand_eq_im_inv_mul (z v : ℂ) :
-    realWindingIntegrand z v = (z⁻¹ * v).im := by
-  rw [realWindingIntegrand]
-
-/-- The coordinate formula for the real winding integrand. -/
-@[simp] theorem realWindingIntegrand_eq_div (z v : ℂ) :
-    realWindingIntegrand z v =
-      (z.re * v.im - z.im * v.re) / Complex.normSq z := by
-  rw [realWindingIntegrand_eq_im_inv_mul, inv_mul_eq_div, Complex.div_im]
-  ring
-
-/-- Scaling position and velocity by the same nonzero complex parameter leaves the real winding
-integrand unchanged: it is the imaginary part of `(c * z)⁻¹ * (c * v) = z⁻¹ * v`, where the two
-factors of `c` cancel in `ℂ`. -/
-theorem realWindingIntegrand_mul_mul {c : ℂ} (hc : c ≠ 0) (z v : ℂ) :
-    realWindingIntegrand (c * z) (c * v) = realWindingIntegrand z v := by
-  rw [realWindingIntegrand_eq_im_inv_mul, realWindingIntegrand_eq_im_inv_mul, mul_inv_rev,
-    mul_assoc, inv_mul_cancel_left₀ hc]
 
 /-- **The real bounded-integrand formula for the winding number** (Hungerbühler–Wasem Prop 2.3,
 off-curve case). For a curve `γ` on the oriented interval with endpoints `a`, `b` that returns to
@@ -131,7 +103,8 @@ theorem windingNumber_eq_real_integral_of_closed {γ : ℝ → ℂ} {w : ℂ} {a
           / Complex.normSq (γ t - w)) = 2 * Real.pi * (n : ℝ) := by
     have hpt : ∀ t, ((γ t - w).re * (deriv γ t).im - (γ t - w).im * (deriv γ t).re)
         / Complex.normSq (γ t - w) = ((γ t - w)⁻¹ * deriv γ t).im :=
-      fun t ↦ (realWindingIntegrand_eq_div (γ t - w) (deriv γ t)).symm
+      fun t ↦ (realWindingIntegrand_eq_div (γ t - w) (deriv γ t)).symm.trans
+        (realWindingIntegrand_def (γ t - w) (deriv γ t))
     simp_rw [hpt, ← RCLike.im_to_complex]
     rw [intervalIntegral_im h_int, RCLike.im_to_complex, him]
   -- Assemble: `n_w(γ) = n = (1 / 2π) · (2π · n)`.

--- a/TauCeti/Analysis/Contour/Winding/RealIntegral.lean
+++ b/TauCeti/Analysis/Contour/Winding/RealIntegral.lean
@@ -18,7 +18,7 @@ the generalized winding number by the **real** integral
 where `x + i y = γ − w`. Writing `γ − w = x + i y` and `γ' = ẋ + i ẏ`, the winding integrand
 `(γ − w)⁻¹ · γ'` has imaginary part exactly `(x ẏ − y ẋ) / (x² + y²)` (the real integrand above,
 here with denominator `Complex.normSq (γ − w) = x² + y²`); this pointwise piece is
-`realWindingIntegrand_eq_im_inv_mul`. For a point *off* the curve the
+`realWindingIntegrand_def`. For a point *off* the curve the
 winding number is a genuine integer (`exists_int_windingNumber_of_closed`), hence real, so the
 ordinary index integral `(2πi)⁻¹ ∮_γ dz/(z − w)` is purely imaginary: its real part vanishes and its
 imaginary part is the real integral above. This is the off-curve (no principal-value) case of the
@@ -55,19 +55,15 @@ namespace TauCeti.Contour
 
 /-- The real winding integrand `(x ẏ - y ẋ) / (x² + y²)` for a position `z = x + iy`
 and velocity `v = ẋ + iẏ`. It is defined as the imaginary part `(z⁻¹ * v).im` of the complex
-winding integrand (`realWindingIntegrand_eq_im_inv_mul`); in particular it is `0` at `z = 0`. -/
+winding integrand; in particular it is `0` at `z = 0`. Its coordinate form is
+`realWindingIntegrand_def`. -/
 public noncomputable def realWindingIntegrand (z v : ℂ) : ℝ := (z⁻¹ * v).im
-
-/-- The real winding integrand is the imaginary part of the complex winding integrand. -/
-theorem realWindingIntegrand_eq_im_inv_mul (z v : ℂ) :
-    realWindingIntegrand z v = (z⁻¹ * v).im := by
-  rw [realWindingIntegrand]
 
 /-- The coordinate formula for the real winding integrand. -/
 @[simp] theorem realWindingIntegrand_def (z v : ℂ) :
     realWindingIntegrand z v =
       (z.re * v.im - z.im * v.re) / Complex.normSq z := by
-  rw [realWindingIntegrand_eq_im_inv_mul, inv_mul_eq_div, Complex.div_im]
+  rw [realWindingIntegrand, inv_mul_eq_div, Complex.div_im]
   ring
 
 /-- Scaling position and velocity by the same nonzero complex parameter leaves the real winding
@@ -93,7 +89,7 @@ avoids
 
 with bounded real integrand and no principal value. The winding number is a genuine integer here
 (`exists_int_windingNumber_of_closed`), so the index integral is purely imaginary; its imaginary
-part is this real integral (`realWindingIntegrand_eq_im_inv_mul`), while its real part — the
+part is this real integral (`realWindingIntegrand_def`), while its real part — the
 increment of `log ‖γ − w‖` —
 vanishes by closedness. -/
 theorem windingNumber_eq_real_integral_of_closed {γ : ℝ → ℂ} {w : ℂ} {a b : ℝ} {P : Set ℝ}
@@ -131,8 +127,7 @@ theorem windingNumber_eq_real_integral_of_closed {γ : ℝ → ℂ} {w : ℂ} {a
           / Complex.normSq (γ t - w)) = 2 * Real.pi * (n : ℝ) := by
     have hpt : ∀ t, ((γ t - w).re * (deriv γ t).im - (γ t - w).im * (deriv γ t).re)
         / Complex.normSq (γ t - w) = ((γ t - w)⁻¹ * deriv γ t).im :=
-      fun t ↦ (realWindingIntegrand_def (γ t - w) (deriv γ t)).symm.trans
-        (realWindingIntegrand_eq_im_inv_mul (γ t - w) (deriv γ t))
+      fun t ↦ (realWindingIntegrand_def (γ t - w) (deriv γ t)).symm
     simp_rw [hpt, ← RCLike.im_to_complex]
     rw [intervalIntegral_im h_int, RCLike.im_to_complex, him]
   -- Assemble: `n_w(γ) = n = (1 / 2π) · (2π · n)`.

--- a/TauCeti/Analysis/Contour/Winding/RealIntegral.lean
+++ b/TauCeti/Analysis/Contour/Winding/RealIntegral.lean
@@ -54,29 +54,33 @@ open scoped Interval
 namespace TauCeti.Contour
 
 /-- The real winding integrand `(x ẏ - y ẋ) / (x² + y²)` for a position `z = x + iy`
-and velocity `v = ẋ + iẏ`. It is defined to be `0` at `z = 0`, following division in `ℝ`. -/
-@[expose] public noncomputable def realWindingIntegrand (z v : ℂ) : ℝ :=
-  (z.re * v.im - z.im * v.re) / Complex.normSq z
-
-/-- The coordinate formula for the real winding integrand. -/
-@[simp] theorem realWindingIntegrand_def (z v : ℂ) :
-    realWindingIntegrand z v =
-      (z.re * v.im - z.im * v.re) / Complex.normSq z := rfl
+and velocity `v = ẋ + iẏ`. It is defined as the imaginary part `(z⁻¹ * v).im` of the complex
+winding integrand (`realWindingIntegrand_eq_im_inv_mul`); in particular it is `0` at `z = 0`. -/
+public noncomputable def realWindingIntegrand (z v : ℂ) : ℝ := (z⁻¹ * v).im
 
 /-- The real winding integrand is the imaginary part of the complex winding integrand. -/
 theorem realWindingIntegrand_eq_im_inv_mul (z v : ℂ) :
     realWindingIntegrand z v = (z⁻¹ * v).im := by
-  rw [realWindingIntegrand, inv_mul_eq_div, Complex.div_im]
+  rw [realWindingIntegrand]
+
+/-- The coordinate formula for the real winding integrand. -/
+@[simp] theorem realWindingIntegrand_def (z v : ℂ) :
+    realWindingIntegrand z v =
+      (z.re * v.im - z.im * v.re) / Complex.normSq z := by
+  rw [realWindingIntegrand_eq_im_inv_mul, inv_mul_eq_div, Complex.div_im]
   ring
 
-/-- Scaling position and velocity by the same nonzero real parameter leaves the real winding
+/-- Scaling position and velocity by the same nonzero complex parameter leaves the real winding
 integrand unchanged. -/
-theorem realWindingIntegrand_ofReal_mul_ofReal_mul {c : ℝ} (hc : c ≠ 0) (z v : ℂ) :
-    realWindingIntegrand ((c : ℂ) * z) ((c : ℂ) * v) = realWindingIntegrand z v := by
-  simp only [realWindingIntegrand_def, Complex.mul_re, Complex.mul_im, Complex.ofReal_re,
-    Complex.ofReal_im, zero_mul, add_zero, Complex.normSq_mul, Complex.normSq_ofReal]
-  field_simp
-  ring
+theorem realWindingIntegrand_mul_left_mul_left {c : ℂ} (hc : c ≠ 0) (z v : ℂ) :
+    realWindingIntegrand (c * z) (c * v) = realWindingIntegrand z v := by
+  have hcs : Complex.normSq c ≠ 0 := Complex.normSq_eq_zero.not.mpr hc
+  have hnum : (c * z).re * (c * v).im - (c * z).im * (c * v).re
+      = Complex.normSq c * (z.re * v.im - z.im * v.re) := by
+    simp only [Complex.mul_re, Complex.mul_im, Complex.normSq_apply]
+    ring
+  rw [realWindingIntegrand_def, realWindingIntegrand_def, Complex.normSq_mul, hnum,
+    mul_div_mul_left _ _ hcs]
 
 /-- **The real bounded-integrand formula for the winding number** (Hungerbühler–Wasem Prop 2.3,
 off-curve case). For a curve `γ` on the oriented interval with endpoints `a`, `b` that returns to
@@ -127,7 +131,8 @@ theorem windingNumber_eq_real_integral_of_closed {γ : ℝ → ℂ} {w : ℂ} {a
           / Complex.normSq (γ t - w)) = 2 * Real.pi * (n : ℝ) := by
     have hpt : ∀ t, ((γ t - w).re * (deriv γ t).im - (γ t - w).im * (deriv γ t).re)
         / Complex.normSq (γ t - w) = ((γ t - w)⁻¹ * deriv γ t).im :=
-      fun t ↦ realWindingIntegrand_eq_im_inv_mul (γ t - w) (deriv γ t)
+      fun t ↦ (realWindingIntegrand_def (γ t - w) (deriv γ t)).symm.trans
+        (realWindingIntegrand_eq_im_inv_mul (γ t - w) (deriv γ t))
     simp_rw [hpt, ← RCLike.im_to_complex]
     rw [intervalIntegral_im h_int, RCLike.im_to_complex, him]
   -- Assemble: `n_w(γ) = n = (1 / 2π) · (2π · n)`.

--- a/TauCeti/Analysis/Contour/Winding/RealIntegral.lean
+++ b/TauCeti/Analysis/Contour/Winding/RealIntegral.lean
@@ -18,7 +18,7 @@ the generalized winding number by the **real** integral
 where `x + i y = γ − w`. Writing `γ − w = x + i y` and `γ' = ẋ + i ẏ`, the winding integrand
 `(γ − w)⁻¹ · γ'` has imaginary part exactly `(x ẏ − y ẋ) / (x² + y²)` (the real integrand above,
 here with denominator `Complex.normSq (γ − w) = x² + y²`); this pointwise piece is
-`realWindingIntegrand_def`. For a point *off* the curve the
+`realWindingIntegrand_eq_div`. For a point *off* the curve the
 winding number is a genuine integer (`exists_int_windingNumber_of_closed`), hence real, so the
 ordinary index integral `(2πi)⁻¹ ∮_γ dz/(z − w)` is purely imaginary: its real part vanishes and its
 imaginary part is the real integral above. This is the off-curve (no principal-value) case of the
@@ -55,28 +55,32 @@ namespace TauCeti.Contour
 
 /-- The real winding integrand `(x ẏ - y ẋ) / (x² + y²)` for a position `z = x + iy`
 and velocity `v = ẋ + iẏ`. It is defined as the imaginary part `(z⁻¹ * v).im` of the complex
-winding integrand; in particular it is `0` at `z = 0`. Its coordinate form is
-`realWindingIntegrand_def`. -/
+winding integrand; in particular it is `0` at `z = 0`. Its relation to the complex integrand is
+`realWindingIntegrand_eq_im_inv_mul` and its coordinate form is `realWindingIntegrand_eq_div`. -/
 public noncomputable def realWindingIntegrand (z v : ℂ) : ℝ := (z⁻¹ * v).im
 
+/-- The real winding integrand is the imaginary part of the complex winding integrand `z⁻¹ * v`.
+This is the defining relation between the real integrand and the complex index integrand
+`(γ - w)⁻¹ * γ'`; the definition's body is not exposed, so this is the public characterization
+downstream files rewrite through. -/
+theorem realWindingIntegrand_eq_im_inv_mul (z v : ℂ) :
+    realWindingIntegrand z v = (z⁻¹ * v).im := by
+  rw [realWindingIntegrand]
+
 /-- The coordinate formula for the real winding integrand. -/
-@[simp] theorem realWindingIntegrand_def (z v : ℂ) :
+@[simp] theorem realWindingIntegrand_eq_div (z v : ℂ) :
     realWindingIntegrand z v =
       (z.re * v.im - z.im * v.re) / Complex.normSq z := by
-  rw [realWindingIntegrand, inv_mul_eq_div, Complex.div_im]
+  rw [realWindingIntegrand_eq_im_inv_mul, inv_mul_eq_div, Complex.div_im]
   ring
 
 /-- Scaling position and velocity by the same nonzero complex parameter leaves the real winding
-integrand unchanged. -/
-theorem realWindingIntegrand_mul_left_mul_left {c : ℂ} (hc : c ≠ 0) (z v : ℂ) :
+integrand unchanged: it is the imaginary part of `(c * z)⁻¹ * (c * v) = z⁻¹ * v`, where the two
+factors of `c` cancel in `ℂ`. -/
+theorem realWindingIntegrand_mul_mul {c : ℂ} (hc : c ≠ 0) (z v : ℂ) :
     realWindingIntegrand (c * z) (c * v) = realWindingIntegrand z v := by
-  have hcs : Complex.normSq c ≠ 0 := Complex.normSq_eq_zero.not.mpr hc
-  have hnum : (c * z).re * (c * v).im - (c * z).im * (c * v).re
-      = Complex.normSq c * (z.re * v.im - z.im * v.re) := by
-    simp only [Complex.mul_re, Complex.mul_im, Complex.normSq_apply]
-    ring
-  rw [realWindingIntegrand_def, realWindingIntegrand_def, Complex.normSq_mul, hnum,
-    mul_div_mul_left _ _ hcs]
+  rw [realWindingIntegrand_eq_im_inv_mul, realWindingIntegrand_eq_im_inv_mul, mul_inv_rev,
+    mul_assoc, inv_mul_cancel_left₀ hc]
 
 /-- **The real bounded-integrand formula for the winding number** (Hungerbühler–Wasem Prop 2.3,
 off-curve case). For a curve `γ` on the oriented interval with endpoints `a`, `b` that returns to
@@ -89,7 +93,7 @@ avoids
 
 with bounded real integrand and no principal value. The winding number is a genuine integer here
 (`exists_int_windingNumber_of_closed`), so the index integral is purely imaginary; its imaginary
-part is this real integral (`realWindingIntegrand_def`), while its real part — the
+part is this real integral (`realWindingIntegrand_eq_div`), while its real part — the
 increment of `log ‖γ − w‖` —
 vanishes by closedness. -/
 theorem windingNumber_eq_real_integral_of_closed {γ : ℝ → ℂ} {w : ℂ} {a b : ℝ} {P : Set ℝ}
@@ -127,7 +131,7 @@ theorem windingNumber_eq_real_integral_of_closed {γ : ℝ → ℂ} {w : ℂ} {a
           / Complex.normSq (γ t - w)) = 2 * Real.pi * (n : ℝ) := by
     have hpt : ∀ t, ((γ t - w).re * (deriv γ t).im - (γ t - w).im * (deriv γ t).re)
         / Complex.normSq (γ t - w) = ((γ t - w)⁻¹ * deriv γ t).im :=
-      fun t ↦ (realWindingIntegrand_def (γ t - w) (deriv γ t)).symm
+      fun t ↦ (realWindingIntegrand_eq_div (γ t - w) (deriv γ t)).symm
     simp_rw [hpt, ← RCLike.im_to_complex]
     rw [intervalIntegral_im h_int, RCLike.im_to_complex, him]
   -- Assemble: `n_w(γ) = n = (1 / 2π) · (2π · n)`.


### PR DESCRIPTION
This PR adds the smooth-crossing value of the real winding integrand from Hungerbühler–Wasem Proposition 2.3. Define the coordinate integrand `(x ẏ - y ẋ) / (x² + y²)`, identify it with the imaginary part of the complex winding integrand, and prove that second-order position and first-order velocity expansions at a regular crossing force the limit `(ẋ ÿ - ẏ ẍ) / (2 (ẋ² + ẏ²))`. State the result at the natural filter level so clients can derive its Peano-expansion hypotheses from any suitable `C²` API.

This advances `TauCetiRoadmap/ContourIntegration/README.md`, Layer 1, specifically “HW Proposition 2.3 (the real, bounded-integrand formula)” and its crossing-value clause: “at a crossing `t̃` ... the integrand tends to `(ẋÿ − ẏẍ)/(2(ẋ² + ẏ²))`.” It is the lowest-hanging remaining target because the off-curve real-integral formula has landed and explicitly leaves this on-curve crossing value separate, while the proposition’s larger global boundedness statement still needs additional `C¹˙¹` geometry.

No Mathlib infrastructure is vendored. The proof reuses Mathlib’s filter limit algebra and complex coordinate/norm-square API. Mathlib has no signed-curvature API for plane curves, so the module follows the roadmap and Hungerbühler–Wasem in stating the explicit coordinate formula. The informal source is N. Hungerbühler and M. Wasem, *Non-integer valued winding numbers and a generalized Residue Theorem*, arXiv:1808.00997 (2018), Proposition 2.3.

Add `TauCeti/Analysis/Contour/Winding/CrossingValue.lean` (169 lines). `lake build` completes successfully (5230 jobs), and `lake exe axioms` audits 10980 TauCeti declarations within the allowlist.

<!--tauceti-target:v1 {"focus":"ContourIntegration","id":"real-winding-integrand-crossing-value"}-->

🤖 Prepared with Codex
