### PR TITLE
feat: add a "Read the docs" button to the front page

### DIFF
--- a/web/Site/Theme.lean
+++ b/web/Site/Theme.lean
@@ -61,7 +61,10 @@ def theme : Theme := { Theme.default with
             <h1 class="hero-title">"Tau Ceti"</h1>
             <p class="hero-tag">"Let’s do lots of maths."</p>
             <p class="hero-sub">"AI-authored Lean mathematics, directed by a human-owned roadmap and gated by open, adversarial review."</p>
-            <a class="cta" href="https://github.com/TauCetiProject/TauCeti">"Explore the code →"</a>
+            <div class="cta-row">
+              <a class="cta" href="https://github.com/TauCetiProject/TauCeti">"Explore the code →"</a>
+              <a class="cta secondary" href="docs/">"Read the docs →"</a>
+            </div>
           </div>
         </section>
 

--- a/web/static_files/style.css
+++ b/web/static_files/style.css
@@ -111,6 +111,13 @@ main { max-width: var(--max); margin: 0 auto; padding: 0 1.25rem; }
 }
 .cta:hover { text-decoration: none; filter: brightness(1.07); }
 
+.cta-row { display: flex; flex-wrap: wrap; gap: 0.75rem; align-items: center; }
+.cta-row .cta { margin-top: 0; }
+
+/* Secondary call to action: outlined amber pill sitting beside the filled one. */
+.cta.secondary { color: var(--text); background: transparent; box-shadow: inset 0 0 0 2px var(--amber-2); }
+.cta.secondary:hover { background: rgba(255, 157, 77, 0.12); filter: none; }
+
 /* ---- pillars ---- */
 .pillars {
   display: grid;


### PR DESCRIPTION
This PR adds a secondary "Read the docs →" call to action beside "Explore the code →" in the hero, linking to the published API reference at `/docs`. It is styled as an outlined amber pill so the two buttons read as a primary/secondary pair.

🤖 Prepared with Claude Code