### PR TITLE
feat: add the Koopman Markov operator

### DIFF
--- a/TauCeti/Probability/Ergodic/KoopmanMarkov.lean
+++ b/TauCeti/Probability/Ergodic/KoopmanMarkov.lean
@@ -6,14 +6,15 @@ public import Mathlib.MeasureTheory.Function.AEEqFun
 # The Koopman Markov operator on measurable-function germs
 
 This file supplies the algebraic part of the generic Koopman lane in the Exchangeability roadmap.
-For a measure-preserving endomorphism `T`, composition `g ↦ g ∘ T` is bundled as an additive,
-unital, multiplicative operator on almost-everywhere measurable real-valued functions.  It is
-positive and monotone, and its powers are composition with the corresponding iterates of `T`.
+For a measure-preserving endomorphism `T`, composition `g ↦ g ∘ T` is bundled as an additive
+operator on almost-everywhere measurable real-valued functions.  It preserves one and
+multiplication, is positive and monotone, and its powers are composition with the corresponding
+iterates of `T`.
 
 Mathlib already provides the underlying operation as `AEEqFun.compMeasurePreserving`, as well as
-the isometric linear operator on every `Lᵖ`.  The bundle here records the extra deterministic
-Markov-operator structure: unlike a general positive unital operator, a Koopman operator is
-multiplicative.  The later `L∞` API can restrict this operator to essentially bounded germs.
+the isometric linear operator on every `Lᵖ`.  Unlike a general positive unital operator, a
+Koopman operator is multiplicative.  The later `L∞` API can restrict this operator to essentially
+bounded germs.
 -/
 
 public section
@@ -28,56 +29,18 @@ namespace Probability
 
 variable {Ω : Type*} [MeasurableSpace Ω] {μ : Measure Ω}
 
-/-- A positive-unital candidate operator on measurable real-valued germs, with the additional
-multiplicativity law enjoyed by deterministic Koopman operators.  Positivity is stated separately
-because it depends on the order of the chosen codomain. -/
-structure DeterministicMarkovOperator (Ω : Type*) [MeasurableSpace Ω] (μ : Measure Ω) where
-  /-- The underlying additive operator on measurable-function germs. -/
-  toAddMonoidHom : (Ω →ₘ[μ] ℝ) →+ (Ω →ₘ[μ] ℝ)
-  map_one' : toAddMonoidHom 1 = 1
-  map_mul' : ∀ g h, toAddMonoidHom (g * h) = toAddMonoidHom g * toAddMonoidHom h
-
-instance : CoeFun (DeterministicMarkovOperator Ω μ) fun _ =>
-    (Ω →ₘ[μ] ℝ) → (Ω →ₘ[μ] ℝ) :=
-  ⟨fun K => K.toAddMonoidHom⟩
-
-@[ext]
-theorem DeterministicMarkovOperator.ext {K L : DeterministicMarkovOperator Ω μ}
-    (h : ∀ g, K g = L g) : K = L := by
-  cases K
-  cases L
-  simp only [mk.injEq]
-  apply AddMonoidHom.ext
-  exact h
-
-theorem DeterministicMarkovOperator.map_one (K : DeterministicMarkovOperator Ω μ) : K 1 = 1 :=
-  K.map_one'
-
-theorem DeterministicMarkovOperator.map_mul (K : DeterministicMarkovOperator Ω μ)
-    (g h : Ω →ₘ[μ] ℝ) : K (g * h) = K g * K h :=
-  K.map_mul' g h
-
 /-- The deterministic Koopman Markov operator associated to a measure-preserving endomorphism.
 
-It acts on measurable-function germs by precomposition.  The bundle records additivity,
-preservation of constants, and the multiplicativity special to deterministic Markov operators. -/
+It acts on measurable-function germs by precomposition and is bundled as an additive operator. -/
 def koopmanMarkov (T : Ω → Ω) (hT : MeasurePreserving T μ μ) :
-    DeterministicMarkovOperator Ω μ where
-  toAddMonoidHom :=
-    { toFun := fun g => g.compMeasurePreserving T hT
-      map_zero' := by
-        rfl
-      map_add' := by
-        intro g h
-        change (g + h).compMeasurePreserving T hT =
-          g.compMeasurePreserving T hT + h.compMeasurePreserving T hT
-        exact AEEqFun.induction_on₂ g h fun _ _ _ _ => rfl }
-  map_one' := by
-    change (1 : Ω →ₘ[μ] ℝ).compMeasurePreserving T hT = 1
+    (Ω →ₘ[μ] ℝ) →+ (Ω →ₘ[μ] ℝ) where
+  toFun := fun g => g.compMeasurePreserving T hT
+  map_zero' := by
     rfl
-  map_mul' g h := by
-    change (g * h).compMeasurePreserving T hT =
-      g.compMeasurePreserving T hT * h.compMeasurePreserving T hT
+  map_add' := by
+    intro g h
+    change (g + h).compMeasurePreserving T hT =
+      g.compMeasurePreserving T hT + h.compMeasurePreserving T hT
     exact AEEqFun.induction_on₂ g h fun _ _ _ _ => rfl
 
 /-- A representative of `koopmanMarkov T hT g` is almost everywhere `g ∘ T`. -/
@@ -90,21 +53,23 @@ theorem coe_koopmanMarkov_ae (T : Ω → Ω) (hT : MeasurePreserving T μ μ)
 /-- The Koopman Markov operator preserves the constant function `1`. -/
 @[simp]
 theorem koopmanMarkov_one (T : Ω → Ω) (hT : MeasurePreserving T μ μ) :
-    koopmanMarkov T hT 1 = 1 :=
-  (koopmanMarkov T hT).map_one
+    koopmanMarkov T hT 1 = 1 := by
+  change (1 : Ω →ₘ[μ] ℝ).compMeasurePreserving T hT = 1
+  rfl
 
 /-- The Koopman Markov operator preserves products. -/
 @[simp]
 theorem koopmanMarkov_mul (T : Ω → Ω) (hT : MeasurePreserving T μ μ)
     (g h : Ω →ₘ[μ] ℝ) :
-    koopmanMarkov T hT (g * h) = koopmanMarkov T hT g * koopmanMarkov T hT h :=
-  (koopmanMarkov T hT).map_mul g h
+    koopmanMarkov T hT (g * h) = koopmanMarkov T hT g * koopmanMarkov T hT h := by
+  change (g * h).compMeasurePreserving T hT =
+    g.compMeasurePreserving T hT * h.compMeasurePreserving T hT
+  exact AEEqFun.induction_on₂ g h fun _ _ _ _ => rfl
 
 /-- The deterministic Koopman Markov operator is positive. -/
 theorem koopmanMarkov_nonneg (T : Ω → Ω) (hT : MeasurePreserving T μ μ)
     {g : Ω →ₘ[μ] ℝ} (hg : 0 ≤ g) :
     0 ≤ koopmanMarkov T hT g := by
-  change (0 : Ω →ₘ[μ] ℝ) ≤ (koopmanMarkov T hT).toAddMonoidHom g
   rw [← AEEqFun.coeFn_le] at hg ⊢
   have hgT := hT.quasiMeasurePreserving.tendsto_ae hg
   have hzeroT := hT.quasiMeasurePreserving.tendsto_ae

--- a/TauCeti/Probability/Ergodic/KoopmanMarkov.lean
+++ b/TauCeti/Probability/Ergodic/KoopmanMarkov.lean
@@ -32,6 +32,7 @@ variable {Ω : Type*} [MeasurableSpace Ω] {μ : Measure Ω}
 multiplicativity law enjoyed by deterministic Koopman operators.  Positivity is stated separately
 because it depends on the order of the chosen codomain. -/
 structure DeterministicMarkovOperator (Ω : Type*) [MeasurableSpace Ω] (μ : Measure Ω) where
+  /-- The underlying additive operator on measurable-function germs. -/
   toAddMonoidHom : (Ω →ₘ[μ] ℝ) →+ (Ω →ₘ[μ] ℝ)
   map_one' : toAddMonoidHom 1 = 1
   map_mul' : ∀ g h, toAddMonoidHom (g * h) = toAddMonoidHom g * toAddMonoidHom h

--- a/TauCeti/Probability/Ergodic/KoopmanMarkov.lean
+++ b/TauCeti/Probability/Ergodic/KoopmanMarkov.lean
@@ -12,7 +12,7 @@ multiplication, is positive and monotone, and its powers are composition with th
 iterates of `T`.
 
 Mathlib already provides the underlying operation as `AEEqFun.compMeasurePreserving`, as well as
-the isometric linear operator on every `Lᵖ`.  Unlike a general positive unital operator, a
+a norm-preserving additive composition map on `Lᵖ`, which is an isometry when `1 ≤ p`.  Unlike a
 Koopman operator is multiplicative.  The later `L∞` API can restrict this operator to essentially
 bounded germs.
 -/
@@ -31,30 +31,27 @@ variable {Ω : Type*} [MeasurableSpace Ω] {μ : Measure Ω}
 
 /-- The deterministic Koopman Markov operator associated to a measure-preserving endomorphism.
 
-It acts on measurable-function germs by precomposition and is bundled as an additive operator. -/
+It acts on measurable-function germs by precomposition and is bundled as a real-linear operator. -/
 def koopmanMarkov (T : Ω → Ω) (hT : MeasurePreserving T μ μ) :
-    (Ω →ₘ[μ] ℝ) →+ (Ω →ₘ[μ] ℝ) where
+    (Ω →ₘ[μ] ℝ) →ₗ[ℝ] (Ω →ₘ[μ] ℝ) where
   toFun := fun g => g.compMeasurePreserving T hT
-  map_zero' := by
-    rfl
   map_add' := by
     intro g h
-    change (g + h).compMeasurePreserving T hT =
-      g.compMeasurePreserving T hT + h.compMeasurePreserving T hT
     exact AEEqFun.induction_on₂ g h fun _ _ _ _ => rfl
+  map_smul' := by
+    intro c g
+    exact AEEqFun.induction_on g fun _ _ => rfl
 
 /-- A representative of `koopmanMarkov T hT g` is almost everywhere `g ∘ T`. -/
-theorem coe_koopmanMarkov_ae (T : Ω → Ω) (hT : MeasurePreserving T μ μ)
+theorem coeFn_koopmanMarkov (T : Ω → Ω) (hT : MeasurePreserving T μ μ)
     (g : Ω →ₘ[μ] ℝ) :
     koopmanMarkov T hT g =ᵐ[μ] g ∘ T :=
-  by change g.compMeasurePreserving T hT =ᵐ[μ] g ∘ T
-     exact AEEqFun.coeFn_compMeasurePreserving g hT
+  AEEqFun.coeFn_compMeasurePreserving g hT
 
 /-- The Koopman Markov operator preserves the constant function `1`. -/
 @[simp]
 theorem koopmanMarkov_one (T : Ω → Ω) (hT : MeasurePreserving T μ μ) :
     koopmanMarkov T hT 1 = 1 := by
-  change (1 : Ω →ₘ[μ] ℝ).compMeasurePreserving T hT = 1
   rfl
 
 /-- The Koopman Markov operator preserves products. -/
@@ -62,8 +59,6 @@ theorem koopmanMarkov_one (T : Ω → Ω) (hT : MeasurePreserving T μ μ) :
 theorem koopmanMarkov_mul (T : Ω → Ω) (hT : MeasurePreserving T μ μ)
     (g h : Ω →ₘ[μ] ℝ) :
     koopmanMarkov T hT (g * h) = koopmanMarkov T hT g * koopmanMarkov T hT h := by
-  change (g * h).compMeasurePreserving T hT =
-    g.compMeasurePreserving T hT * h.compMeasurePreserving T hT
   exact AEEqFun.induction_on₂ g h fun _ _ _ _ => rfl
 
 /-- The deterministic Koopman Markov operator is positive. -/
@@ -74,48 +69,47 @@ theorem koopmanMarkov_nonneg (T : Ω → Ω) (hT : MeasurePreserving T μ μ)
   have hgT := hT.quasiMeasurePreserving.tendsto_ae hg
   have hzeroT := hT.quasiMeasurePreserving.tendsto_ae
     (AEEqFun.coeFn_zero (α := Ω) (β := ℝ) (μ := μ))
-  filter_upwards [hgT, hzeroT, coe_koopmanMarkov_ae T hT g,
+  filter_upwards [hgT, hzeroT, coeFn_koopmanMarkov T hT g,
     AEEqFun.coeFn_zero (α := Ω) (β := ℝ) (μ := μ)] with ω hgω hzeroT hcomp hzero
+  -- Expose the AEEqFun zero representative at `T ω` so `hzeroT` can rewrite it.
   change (0 : Ω →ₘ[μ] ℝ) (T ω) = (0 : ℝ) at hzeroT
   rw [hzero, hcomp, Function.comp_apply, Pi.zero_apply, ← hzeroT]
   exact hgω
 
 /-- The deterministic Koopman Markov operator is monotone. -/
-theorem koopmanMarkov_mono (T : Ω → Ω) (hT : MeasurePreserving T μ μ) :
+theorem koopmanMarkov_monotone (T : Ω → Ω) (hT : MeasurePreserving T μ μ) :
     Monotone (koopmanMarkov T hT) := by
   intro g h hgh
   rw [← AEEqFun.coeFn_le] at hgh ⊢
   have hghT := hT.quasiMeasurePreserving.tendsto_ae hgh
-  filter_upwards [hghT, coe_koopmanMarkov_ae T hT g, coe_koopmanMarkov_ae T hT h]
+  filter_upwards [hghT, coeFn_koopmanMarkov T hT g, coeFn_koopmanMarkov T hT h]
     with ω hghω hg hh
   simpa [Function.comp_apply, hg, hh] using hghω
 
 /-- The Koopman Markov operator of the identity transformation acts as the identity. -/
 @[simp]
 theorem koopmanMarkov_id :
-    ∀ g, koopmanMarkov (μ := μ) id (MeasurePreserving.id μ) g = g := by
+    koopmanMarkov (μ := μ) id (MeasurePreserving.id μ) = LinearMap.id := by
+  apply LinearMap.ext
   intro g
-  change g.compMeasurePreserving id (MeasurePreserving.id μ) = g
   exact AEEqFun.compMeasurePreserving_id g
 
 /-- Composing transformations reverses the order of their Koopman Markov operators. -/
 theorem koopmanMarkov_comp {T S : Ω → Ω} (hT : MeasurePreserving T μ μ)
     (hS : MeasurePreserving S μ μ) :
-    ∀ g, koopmanMarkov (T ∘ S) (hT.comp hS) g =
-      koopmanMarkov S hS (koopmanMarkov T hT g) :=
-  fun g => by
-    change g.compMeasurePreserving (T ∘ S) (hT.comp hS) =
-      (g.compMeasurePreserving T hT).compMeasurePreserving S hS
-    exact AEEqFun.compMeasurePreserving_comp g hT hS
+    koopmanMarkov (T ∘ S) (hT.comp hS) =
+      (koopmanMarkov S hS).comp (koopmanMarkov T hT) := by
+  apply LinearMap.ext
+  intro g
+  exact AEEqFun.compMeasurePreserving_comp g hT hS
 
 /-- The `n`th power of a Koopman Markov operator is composition with the `n`th iterate. -/
 theorem koopmanMarkov_iterate (T : Ω → Ω) (hT : MeasurePreserving T μ μ)
-    (g : Ω →ₘ[μ] ℝ) (n : ℕ) :
-    (koopmanMarkov T hT)^[n] g = koopmanMarkov (T^[n]) (hT.iterate n) g :=
-  by
-    change (fun x => x.compMeasurePreserving T hT)^[n] g =
-      g.compMeasurePreserving (T^[n]) (hT.iterate n)
-    exact AEEqFun.compMeasurePreserving_iterate g hT n
+    (n : ℕ) :
+    (koopmanMarkov T hT : (Ω →ₘ[μ] ℝ) → (Ω →ₘ[μ] ℝ))^[n] =
+      koopmanMarkov (T^[n]) (hT.iterate n) := by
+  funext g
+  exact AEEqFun.compMeasurePreserving_iterate g hT n
 
 /-- A measurable-function germ is fixed by the Koopman Markov operator exactly when its chosen
 representative is almost everywhere invariant under the transformation. -/
@@ -124,10 +118,10 @@ theorem koopmanMarkov_eq_self_iff (T : Ω → Ω) (hT : MeasurePreserving T μ �
     koopmanMarkov T hT g = g ↔ g ∘ T =ᵐ[μ] g := by
   constructor
   · intro h
-    exact (coe_koopmanMarkov_ae T hT g).symm.trans (Filter.EventuallyEq.rfl.trans
+    exact (coeFn_koopmanMarkov T hT g).symm.trans (Filter.EventuallyEq.rfl.trans
       (Filter.Eventually.of_forall fun ω => congrArg (fun q : Ω →ₘ[μ] ℝ => q ω) h))
   · intro h
-    exact AEEqFun.ext ((coe_koopmanMarkov_ae T hT g).trans h)
+    exact AEEqFun.ext ((coeFn_koopmanMarkov T hT g).trans h)
 
 end Probability
 

--- a/TauCeti/Probability/Ergodic/KoopmanMarkov.lean
+++ b/TauCeti/Probability/Ergodic/KoopmanMarkov.lean
@@ -67,21 +67,6 @@ theorem koopmanMarkov_mul (T : Ω → Ω) (hT : MeasurePreserving T μ μ)
     simp only [koopmanMarkov, LinearMap.coe_mk, AddHom.coe_mk, AEEqFun.mk_mul_mk,
       AEEqFun.compMeasurePreserving_mk]; rfl
 
-/-- The deterministic Koopman Markov operator is positive. -/
-theorem koopmanMarkov_nonneg (T : Ω → Ω) (hT : MeasurePreserving T μ μ)
-    {g : Ω →ₘ[μ] ℝ} (hg : 0 ≤ g) :
-    0 ≤ koopmanMarkov T hT g := by
-  rw [← AEEqFun.coeFn_le] at hg ⊢
-  have hgT := hT.quasiMeasurePreserving.tendsto_ae hg
-  have hzeroT := hT.quasiMeasurePreserving.tendsto_ae
-    (AEEqFun.coeFn_zero (α := Ω) (β := ℝ) (μ := μ))
-  filter_upwards [hgT, hzeroT, coeFn_koopmanMarkov T hT g,
-    AEEqFun.coeFn_zero (α := Ω) (β := ℝ) (μ := μ)] with ω hgω hzeroT hcomp hzero
-  -- Expose the AEEqFun zero representative at `T ω` so `hzeroT` can rewrite it.
-  change (0 : Ω →ₘ[μ] ℝ) (T ω) = (0 : ℝ) at hzeroT
-  rw [hzero, hcomp, Function.comp_apply, Pi.zero_apply, ← hzeroT]
-  exact hgω
-
 /-- The deterministic Koopman Markov operator is monotone. -/
 theorem koopmanMarkov_monotone (T : Ω → Ω) (hT : MeasurePreserving T μ μ) :
     Monotone (koopmanMarkov T hT) := by
@@ -91,6 +76,13 @@ theorem koopmanMarkov_monotone (T : Ω → Ω) (hT : MeasurePreserving T μ μ) 
   filter_upwards [hghT, coeFn_koopmanMarkov T hT g, coeFn_koopmanMarkov T hT h]
     with ω hghω hg hh
   simpa [Function.comp_apply, hg, hh] using hghω
+
+/-- The deterministic Koopman Markov operator is positive. -/
+theorem koopmanMarkov_nonneg (T : Ω → Ω) (hT : MeasurePreserving T μ μ)
+    {g : Ω →ₘ[μ] ℝ} (hg : 0 ≤ g) :
+    0 ≤ koopmanMarkov T hT g := by
+  have h := koopmanMarkov_monotone T hT hg
+  rwa [map_zero] at h
 
 /-- The Koopman Markov operator of the identity transformation acts as the identity. -/
 @[simp]

--- a/TauCeti/Probability/Ergodic/KoopmanMarkov.lean
+++ b/TauCeti/Probability/Ergodic/KoopmanMarkov.lean
@@ -1,0 +1,168 @@
+module
+
+public import Mathlib.MeasureTheory.Function.AEEqFun
+
+/-!
+# The Koopman Markov operator on measurable-function germs
+
+This file supplies the algebraic part of the generic Koopman lane in the Exchangeability roadmap.
+For a measure-preserving endomorphism `T`, composition `g ↦ g ∘ T` is bundled as an additive,
+unital, multiplicative operator on almost-everywhere measurable real-valued functions.  It is
+positive and monotone, and its powers are composition with the corresponding iterates of `T`.
+
+Mathlib already provides the underlying operation as `AEEqFun.compMeasurePreserving`, as well as
+the isometric linear operator on every `Lᵖ`.  The bundle here records the extra deterministic
+Markov-operator structure: unlike a general positive unital operator, a Koopman operator is
+multiplicative.  The later `L∞` API can restrict this operator to essentially bounded germs.
+-/
+
+public section
+
+noncomputable section
+
+open MeasureTheory
+
+namespace TauCeti
+
+namespace Probability
+
+variable {Ω : Type*} [MeasurableSpace Ω] {μ : Measure Ω}
+
+/-- A positive-unital candidate operator on measurable real-valued germs, with the additional
+multiplicativity law enjoyed by deterministic Koopman operators.  Positivity is stated separately
+because it depends on the order of the chosen codomain. -/
+structure DeterministicMarkovOperator (Ω : Type*) [MeasurableSpace Ω] (μ : Measure Ω) where
+  toAddMonoidHom : (Ω →ₘ[μ] ℝ) →+ (Ω →ₘ[μ] ℝ)
+  map_one' : toAddMonoidHom 1 = 1
+  map_mul' : ∀ g h, toAddMonoidHom (g * h) = toAddMonoidHom g * toAddMonoidHom h
+
+instance : CoeFun (DeterministicMarkovOperator Ω μ) fun _ =>
+    (Ω →ₘ[μ] ℝ) → (Ω →ₘ[μ] ℝ) :=
+  ⟨fun K => K.toAddMonoidHom⟩
+
+@[ext]
+theorem DeterministicMarkovOperator.ext {K L : DeterministicMarkovOperator Ω μ}
+    (h : ∀ g, K g = L g) : K = L := by
+  cases K
+  cases L
+  simp only [mk.injEq]
+  apply AddMonoidHom.ext
+  exact h
+
+theorem DeterministicMarkovOperator.map_one (K : DeterministicMarkovOperator Ω μ) : K 1 = 1 :=
+  K.map_one'
+
+theorem DeterministicMarkovOperator.map_mul (K : DeterministicMarkovOperator Ω μ)
+    (g h : Ω →ₘ[μ] ℝ) : K (g * h) = K g * K h :=
+  K.map_mul' g h
+
+/-- The deterministic Koopman Markov operator associated to a measure-preserving endomorphism.
+
+It acts on measurable-function germs by precomposition.  The bundle records additivity,
+preservation of constants, and the multiplicativity special to deterministic Markov operators. -/
+def koopmanMarkov (T : Ω → Ω) (hT : MeasurePreserving T μ μ) :
+    DeterministicMarkovOperator Ω μ where
+  toAddMonoidHom :=
+    { toFun := fun g => g.compMeasurePreserving T hT
+      map_zero' := by
+        rfl
+      map_add' := by
+        intro g h
+        change (g + h).compMeasurePreserving T hT =
+          g.compMeasurePreserving T hT + h.compMeasurePreserving T hT
+        exact AEEqFun.induction_on₂ g h fun _ _ _ _ => rfl }
+  map_one' := by
+    change (1 : Ω →ₘ[μ] ℝ).compMeasurePreserving T hT = 1
+    rfl
+  map_mul' g h := by
+    change (g * h).compMeasurePreserving T hT =
+      g.compMeasurePreserving T hT * h.compMeasurePreserving T hT
+    exact AEEqFun.induction_on₂ g h fun _ _ _ _ => rfl
+
+/-- A representative of `koopmanMarkov T hT g` is almost everywhere `g ∘ T`. -/
+theorem coe_koopmanMarkov_ae (T : Ω → Ω) (hT : MeasurePreserving T μ μ)
+    (g : Ω →ₘ[μ] ℝ) :
+    koopmanMarkov T hT g =ᵐ[μ] g ∘ T :=
+  by change g.compMeasurePreserving T hT =ᵐ[μ] g ∘ T
+     exact AEEqFun.coeFn_compMeasurePreserving g hT
+
+/-- The Koopman Markov operator preserves the constant function `1`. -/
+@[simp]
+theorem koopmanMarkov_one (T : Ω → Ω) (hT : MeasurePreserving T μ μ) :
+    koopmanMarkov T hT 1 = 1 :=
+  (koopmanMarkov T hT).map_one
+
+/-- The Koopman Markov operator preserves products. -/
+@[simp]
+theorem koopmanMarkov_mul (T : Ω → Ω) (hT : MeasurePreserving T μ μ)
+    (g h : Ω →ₘ[μ] ℝ) :
+    koopmanMarkov T hT (g * h) = koopmanMarkov T hT g * koopmanMarkov T hT h :=
+  (koopmanMarkov T hT).map_mul g h
+
+/-- The deterministic Koopman Markov operator is positive. -/
+theorem koopmanMarkov_nonneg (T : Ω → Ω) (hT : MeasurePreserving T μ μ)
+    {g : Ω →ₘ[μ] ℝ} (hg : 0 ≤ g) :
+    0 ≤ koopmanMarkov T hT g := by
+  change (0 : Ω →ₘ[μ] ℝ) ≤ (koopmanMarkov T hT).toAddMonoidHom g
+  rw [← AEEqFun.coeFn_le] at hg ⊢
+  have hgT := hT.quasiMeasurePreserving.tendsto_ae hg
+  have hzeroT := hT.quasiMeasurePreserving.tendsto_ae
+    (AEEqFun.coeFn_zero (α := Ω) (β := ℝ) (μ := μ))
+  filter_upwards [hgT, hzeroT, coe_koopmanMarkov_ae T hT g,
+    AEEqFun.coeFn_zero (α := Ω) (β := ℝ) (μ := μ)] with ω hgω hzeroT hcomp hzero
+  change (0 : Ω →ₘ[μ] ℝ) (T ω) = (0 : ℝ) at hzeroT
+  rw [hzero, hcomp, Function.comp_apply, Pi.zero_apply, ← hzeroT]
+  exact hgω
+
+/-- The deterministic Koopman Markov operator is monotone. -/
+theorem koopmanMarkov_mono (T : Ω → Ω) (hT : MeasurePreserving T μ μ) :
+    Monotone (koopmanMarkov T hT) := by
+  intro g h hgh
+  rw [← AEEqFun.coeFn_le] at hgh ⊢
+  have hghT := hT.quasiMeasurePreserving.tendsto_ae hgh
+  filter_upwards [hghT, coe_koopmanMarkov_ae T hT g, coe_koopmanMarkov_ae T hT h]
+    with ω hghω hg hh
+  simpa [Function.comp_apply, hg, hh] using hghω
+
+/-- The Koopman Markov operator of the identity transformation acts as the identity. -/
+@[simp]
+theorem koopmanMarkov_id :
+    ∀ g, koopmanMarkov (μ := μ) id (MeasurePreserving.id μ) g = g := by
+  intro g
+  change g.compMeasurePreserving id (MeasurePreserving.id μ) = g
+  exact AEEqFun.compMeasurePreserving_id g
+
+/-- Composing transformations reverses the order of their Koopman Markov operators. -/
+theorem koopmanMarkov_comp {T S : Ω → Ω} (hT : MeasurePreserving T μ μ)
+    (hS : MeasurePreserving S μ μ) :
+    ∀ g, koopmanMarkov (T ∘ S) (hT.comp hS) g =
+      koopmanMarkov S hS (koopmanMarkov T hT g) :=
+  fun g => by
+    change g.compMeasurePreserving (T ∘ S) (hT.comp hS) =
+      (g.compMeasurePreserving T hT).compMeasurePreserving S hS
+    exact AEEqFun.compMeasurePreserving_comp g hT hS
+
+/-- The `n`th power of a Koopman Markov operator is composition with the `n`th iterate. -/
+theorem koopmanMarkov_iterate (T : Ω → Ω) (hT : MeasurePreserving T μ μ)
+    (g : Ω →ₘ[μ] ℝ) (n : ℕ) :
+    (koopmanMarkov T hT)^[n] g = koopmanMarkov (T^[n]) (hT.iterate n) g :=
+  by
+    change (fun x => x.compMeasurePreserving T hT)^[n] g =
+      g.compMeasurePreserving (T^[n]) (hT.iterate n)
+    exact AEEqFun.compMeasurePreserving_iterate g hT n
+
+/-- A measurable-function germ is fixed by the Koopman Markov operator exactly when its chosen
+representative is almost everywhere invariant under the transformation. -/
+theorem koopmanMarkov_eq_self_iff (T : Ω → Ω) (hT : MeasurePreserving T μ μ)
+    (g : Ω →ₘ[μ] ℝ) :
+    koopmanMarkov T hT g = g ↔ g ∘ T =ᵐ[μ] g := by
+  constructor
+  · intro h
+    exact (coe_koopmanMarkov_ae T hT g).symm.trans (Filter.EventuallyEq.rfl.trans
+      (Filter.Eventually.of_forall fun ω => congrArg (fun q : Ω →ₘ[μ] ℝ => q ω) h))
+  · intro h
+    exact AEEqFun.ext ((coe_koopmanMarkov_ae T hT g).trans h)
+
+end Probability
+
+end TauCeti

--- a/TauCeti/Probability/Ergodic/KoopmanMarkov.lean
+++ b/TauCeti/Probability/Ergodic/KoopmanMarkov.lean
@@ -6,15 +6,15 @@ public import Mathlib.MeasureTheory.Function.AEEqFun
 # The Koopman Markov operator on measurable-function germs
 
 This file supplies the algebraic part of the generic Koopman lane in the Exchangeability roadmap.
-For a measure-preserving endomorphism `T`, composition `g ↦ g ∘ T` is bundled as an additive
+For a measure-preserving endomorphism `T`, composition `g ↦ g ∘ T` is bundled as a real-linear
 operator on almost-everywhere measurable real-valued functions.  It preserves one and
 multiplication, is positive and monotone, and its powers are composition with the corresponding
 iterates of `T`.
 
 Mathlib already provides the underlying operation as `AEEqFun.compMeasurePreserving`, as well as
-a norm-preserving additive composition map on `Lᵖ`, which is an isometry when `1 ≤ p`.  Unlike a
-Koopman operator is multiplicative.  The later `L∞` API can restrict this operator to essentially
-bounded germs.
+a norm-preserving additive composition map on `Lᵖ`, which is an isometry when `1 ≤ p`.  Unlike
+that `Lᵖ` composition map, the Koopman operator here is also multiplicative.  The later `L∞` API
+can restrict this operator to essentially bounded germs.
 -/
 
 public section
@@ -37,10 +37,12 @@ def koopmanMarkov (T : Ω → Ω) (hT : MeasurePreserving T μ μ) :
   toFun := fun g => g.compMeasurePreserving T hT
   map_add' := by
     intro g h
-    exact AEEqFun.induction_on₂ g h fun _ _ _ _ => rfl
+    exact AEEqFun.induction_on₂ g h fun _ _ _ _ => by
+      simp only [AEEqFun.compMeasurePreserving_mk, AEEqFun.mk_add_mk]; rfl
   map_smul' := by
     intro c g
-    exact AEEqFun.induction_on g fun _ _ => rfl
+    exact AEEqFun.induction_on g fun _ _ => by
+      simp only [RingHom.id_apply, AEEqFun.compMeasurePreserving_mk, AEEqFun.smul_mk]; rfl
 
 /-- A representative of `koopmanMarkov T hT g` is almost everywhere `g ∘ T`. -/
 theorem coeFn_koopmanMarkov (T : Ω → Ω) (hT : MeasurePreserving T μ μ)
@@ -52,6 +54,8 @@ theorem coeFn_koopmanMarkov (T : Ω → Ω) (hT : MeasurePreserving T μ μ)
 @[simp]
 theorem koopmanMarkov_one (T : Ω → Ω) (hT : MeasurePreserving T μ μ) :
     koopmanMarkov T hT 1 = 1 := by
+  simp only [koopmanMarkov, LinearMap.coe_mk, AddHom.coe_mk, AEEqFun.one_def,
+    AEEqFun.compMeasurePreserving_mk]
   rfl
 
 /-- The Koopman Markov operator preserves products. -/
@@ -59,7 +63,9 @@ theorem koopmanMarkov_one (T : Ω → Ω) (hT : MeasurePreserving T μ μ) :
 theorem koopmanMarkov_mul (T : Ω → Ω) (hT : MeasurePreserving T μ μ)
     (g h : Ω →ₘ[μ] ℝ) :
     koopmanMarkov T hT (g * h) = koopmanMarkov T hT g * koopmanMarkov T hT h := by
-  exact AEEqFun.induction_on₂ g h fun _ _ _ _ => rfl
+  exact AEEqFun.induction_on₂ g h fun _ _ _ _ => by
+    simp only [koopmanMarkov, LinearMap.coe_mk, AddHom.coe_mk, AEEqFun.mk_mul_mk,
+      AEEqFun.compMeasurePreserving_mk]; rfl
 
 /-- The deterministic Koopman Markov operator is positive. -/
 theorem koopmanMarkov_nonneg (T : Ω → Ω) (hT : MeasurePreserving T μ μ)
@@ -118,8 +124,8 @@ theorem koopmanMarkov_eq_self_iff (T : Ω → Ω) (hT : MeasurePreserving T μ �
     koopmanMarkov T hT g = g ↔ g ∘ T =ᵐ[μ] g := by
   constructor
   · intro h
-    exact (coeFn_koopmanMarkov T hT g).symm.trans (Filter.EventuallyEq.rfl.trans
-      (Filter.Eventually.of_forall fun ω => congrArg (fun q : Ω →ₘ[μ] ℝ => q ω) h))
+    exact (coeFn_koopmanMarkov T hT g).symm.trans
+      (Filter.Eventually.of_forall fun ω => congrArg (fun q : Ω →ₘ[μ] ℝ => q ω) h)
   · intro h
     exact AEEqFun.ext ((coeFn_koopmanMarkov T hT g).trans h)
 


### PR DESCRIPTION
This PR adds the deterministic Koopman Markov operator on almost-everywhere measurable real-valued function germs. Bundle precomposition by a measure-preserving endomorphism as an additive, unital, multiplicative operator; prove positivity and monotonicity; and expose its representative, identity, composition, iterate, and fixed-point API. This supplies the algebraic foundation that the later `L∞` restriction inherits.

This advances `TauCetiRoadmap/Exchangeability/README.md`, Layer 5, specifically “the associated Markov operator on bounded measurable functions / `L∞`: positive and unital” and “multiplicativity for the deterministic Koopman operator on `L∞`.” It is the lowest-hanging distinct Layer 5 target because Layers 0–4 and the martingale route have landed, while open PR #1103 claims `fixedSpace`; this PR avoids that dependency and isolates the preceding deterministic Markov algebra needed by the later bounded restriction.

Reuse Mathlib's `AEEqFun.compMeasurePreserving`, its representative theorem, and its identity, composition, and iterate API. No Mathlib infrastructure or `cameronfreer/exchangeability` material is vendored or adapted.

Add `TauCeti/Probability/Ergodic/KoopmanMarkov.lean` (168 lines). `lake exe cache get` reports `No files to download` and `Already decompressed 8639 file(s)`. `lake build` reports `Build completed successfully (5234 jobs).` `lake exe axioms` reports `axioms: audited 11059 TauCeti declaration(s); all within the allowlist [propext, Classical.choice, Quot.sound].`

<!--tauceti-target:v1 {"focus":"Exchangeability","id":"koopman-markov-operator"}-->

🤖 Prepared with Codex
