### PR TITLE
feat: bound contraction resolvent powers

### DIFF
--- a/TauCeti/Analysis/Semigroups/Defs.lean
+++ b/TauCeti/Analysis/Semigroups/Defs.lean
@@ -5,6 +5,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 module
 
 public import TauCeti.Analysis.Semigroups.Resolvent.Identity
+public import TauCeti.Analysis.Semigroups.Resolvent.PowerBounds
 public import TauCeti.Analysis.Semigroups.BoundedGenerator
 public import TauCeti.Analysis.Semigroups.Generator
 

--- a/TauCeti/Analysis/Semigroups/Resolvent/PowerBounds.lean
+++ b/TauCeti/Analysis/Semigroups/Resolvent/PowerBounds.lean
@@ -57,17 +57,13 @@ theorem norm_resolvent_pow_apply_le (S : ContractionSemigroup X) (lambda : ℝ)
 theorem norm_smul_resolvent_pow_le_one (S : ContractionSemigroup X) (lambda : ℝ)
     (hlambda : 0 < lambda) (n : ℕ) :
     ‖(lambda • S.resolvent lambda hlambda) ^ n‖ ≤ 1 := by
-  cases n with
-  | zero => exact ContinuousLinearMap.norm_id_le
-  | succ n =>
-      refine (norm_pow_le' _ n.succ_pos).trans ?_
-      rw [norm_smul, Real.norm_eq_abs, abs_of_pos hlambda]
-      calc
-        (lambda * ‖S.resolvent lambda hlambda‖) ^ (n + 1)
-            ≤ (lambda * (1 / lambda)) ^ (n + 1) := by
-              gcongr
-              exact S.resolvent_norm_le lambda hlambda
-        _ = 1 := by rw [one_div, mul_inv_cancel₀ hlambda.ne', one_pow]
+  rw [smul_pow, norm_smul, Real.norm_eq_abs, abs_of_nonneg (pow_nonneg hlambda.le n)]
+  calc
+    lambda ^ n * ‖S.resolvent lambda hlambda ^ n‖
+        ≤ lambda ^ n * (1 / lambda) ^ n := by
+          gcongr
+          exact S.resolvent_pow_norm_le lambda hlambda n
+    _ = 1 := by rw [← mul_pow, one_div, mul_inv_cancel₀ hlambda.ne', one_pow]
 
 /-- Pointwise form of the power bound for the scaled contraction resolvent. -/
 theorem norm_smul_resolvent_pow_apply_le (S : ContractionSemigroup X) (lambda : ℝ)

--- a/TauCeti/Analysis/Semigroups/Resolvent/PowerBounds.lean
+++ b/TauCeti/Analysis/Semigroups/Resolvent/PowerBounds.lean
@@ -35,27 +35,16 @@ variable {X : Type*} [NormedAddCommGroup X] [NormedSpace ℝ X] [CompleteSpace X
 
 namespace ContractionSemigroup
 
-omit [CompleteSpace X] in
-private theorem norm_pow_le_pow_norm (f : X →L[ℝ] X) (n : ℕ) :
-    ‖f ^ n‖ ≤ ‖f‖ ^ n := by
-  induction n with
-  | zero =>
-      have hone : (1 : X →L[ℝ] X) = ContinuousLinearMap.id ℝ X := rfl
-      simp only [pow_zero]
-      rw [hone]
-      exact ContinuousLinearMap.norm_id_le
-  | succ n ih =>
-      rw [pow_succ, pow_succ]
-      exact (ContinuousLinearMap.opNorm_comp_le _ _).trans
-        (mul_le_mul_of_nonneg_right ih (norm_nonneg f))
-
 /-- The iterated Hille--Yosida bound for a contraction semigroup:
 `‖R(lambda)^n‖ ≤ lambda⁻ⁿ`. -/
 theorem resolvent_pow_norm_le (S : ContractionSemigroup X) (lambda : ℝ) (hlambda : 0 < lambda)
     (n : ℕ) :
     ‖S.resolvent lambda hlambda ^ n‖ ≤ (1 / lambda) ^ n := by
-  exact (norm_pow_le_pow_norm _ n).trans
-    (pow_le_pow_left₀ (norm_nonneg _) (S.resolvent_norm_le lambda hlambda) n)
+  cases n with
+  | zero => exact ContinuousLinearMap.norm_id_le
+  | succ n =>
+      exact (norm_pow_le' _ n.succ_pos).trans
+        (pow_le_pow_left₀ (norm_nonneg _) (S.resolvent_norm_le lambda hlambda) (n + 1))
 
 /-- Pointwise form of the iterated contraction resolvent bound. -/
 theorem norm_resolvent_pow_apply_le (S : ContractionSemigroup X) (lambda : ℝ)
@@ -68,14 +57,17 @@ theorem norm_resolvent_pow_apply_le (S : ContractionSemigroup X) (lambda : ℝ)
 theorem norm_smul_resolvent_pow_le_one (S : ContractionSemigroup X) (lambda : ℝ)
     (hlambda : 0 < lambda) (n : ℕ) :
     ‖(lambda • S.resolvent lambda hlambda) ^ n‖ ≤ 1 := by
-  refine (norm_pow_le_pow_norm _ n).trans ?_
-  rw [norm_smul, Real.norm_eq_abs, abs_of_pos hlambda]
-  calc
-    (lambda * ‖S.resolvent lambda hlambda‖) ^ n
-        ≤ (lambda * (1 / lambda)) ^ n := by
-          gcongr
-          exact S.resolvent_norm_le lambda hlambda
-    _ = 1 := by rw [one_div, mul_inv_cancel₀ hlambda.ne', one_pow]
+  cases n with
+  | zero => exact ContinuousLinearMap.norm_id_le
+  | succ n =>
+      refine (norm_pow_le' _ n.succ_pos).trans ?_
+      rw [norm_smul, Real.norm_eq_abs, abs_of_pos hlambda]
+      calc
+        (lambda * ‖S.resolvent lambda hlambda‖) ^ (n + 1)
+            ≤ (lambda * (1 / lambda)) ^ (n + 1) := by
+              gcongr
+              exact S.resolvent_norm_le lambda hlambda
+        _ = 1 := by rw [one_div, mul_inv_cancel₀ hlambda.ne', one_pow]
 
 /-- Pointwise form of the power bound for the scaled contraction resolvent. -/
 theorem norm_smul_resolvent_pow_apply_le (S : ContractionSemigroup X) (lambda : ℝ)

--- a/TauCeti/Analysis/Semigroups/Resolvent/PowerBounds.lean
+++ b/TauCeti/Analysis/Semigroups/Resolvent/PowerBounds.lean
@@ -50,8 +50,8 @@ theorem resolvent_pow_norm_le (S : ContractionSemigroup X) (lambda : ℝ) (hlamb
 theorem norm_resolvent_pow_apply_le (S : ContractionSemigroup X) (lambda : ℝ)
     (hlambda : 0 < lambda) (n : ℕ) (x : X) :
     ‖(S.resolvent lambda hlambda ^ n) x‖ ≤ (1 / lambda) ^ n * ‖x‖ := by
-  exact (ContinuousLinearMap.le_opNorm _ x).trans
-    (mul_le_mul_of_nonneg_right (S.resolvent_pow_norm_le lambda hlambda n) (norm_nonneg x))
+  exact (S.resolvent lambda hlambda ^ n).le_of_opNorm_le
+    (S.resolvent_pow_norm_le lambda hlambda n) x
 
 /-- Every power of the scaled contraction resolvent `lambda R(lambda)` has norm at most one. -/
 theorem norm_smul_resolvent_pow_le_one (S : ContractionSemigroup X) (lambda : ℝ)
@@ -69,14 +69,8 @@ theorem norm_smul_resolvent_pow_le_one (S : ContractionSemigroup X) (lambda : �
 theorem norm_smul_resolvent_pow_apply_le (S : ContractionSemigroup X) (lambda : ℝ)
     (hlambda : 0 < lambda) (n : ℕ) (x : X) :
     ‖((lambda • S.resolvent lambda hlambda) ^ n) x‖ ≤ ‖x‖ := by
-  calc
-    ‖((lambda • S.resolvent lambda hlambda) ^ n) x‖
-        ≤ ‖(lambda • S.resolvent lambda hlambda) ^ n‖ * ‖x‖ :=
-          ContinuousLinearMap.le_opNorm _ x
-    _ ≤ 1 * ‖x‖ := by
-      gcongr
-      exact S.norm_smul_resolvent_pow_le_one lambda hlambda n
-    _ = ‖x‖ := one_mul _
+  simpa using ((lambda • S.resolvent lambda hlambda) ^ n).le_of_opNorm_le
+    (S.norm_smul_resolvent_pow_le_one lambda hlambda n) x
 
 end ContractionSemigroup
 

--- a/TauCeti/Analysis/Semigroups/Resolvent/PowerBounds.lean
+++ b/TauCeti/Analysis/Semigroups/Resolvent/PowerBounds.lean
@@ -1,0 +1,97 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+module
+
+public import TauCeti.Analysis.Semigroups.Resolvent.Basic
+
+/-!
+# Power bounds for contraction-semigroup resolvents
+
+This file proves the contraction case of the iterated Hille--Yosida estimate. If `S` is a
+contraction semigroup and `lambda > 0`, then every natural power of its Laplace-transform
+resolvent satisfies
+
+`‖R(lambda)^n‖ ≤ lambda⁻ⁿ`.
+
+The corresponding pointwise estimate and the equivalent bound for the scaled resolvent
+`lambda R(lambda)` are also recorded. These estimates are the contraction specialization of
+the power bounds used in the Hille--Yosida generation theorem.
+
+## References
+
+The estimates are the contraction case of Engel--Nagel, *One-Parameter Semigroups for Linear
+Evolution Equations*, Theorem II.3.5.
+-/
+
+public section
+
+noncomputable section
+
+namespace TauCeti.Semigroups
+
+variable {X : Type*} [NormedAddCommGroup X] [NormedSpace ℝ X] [CompleteSpace X]
+
+namespace ContractionSemigroup
+
+omit [CompleteSpace X] in
+private theorem norm_pow_le_pow_norm (f : X →L[ℝ] X) (n : ℕ) :
+    ‖f ^ n‖ ≤ ‖f‖ ^ n := by
+  induction n with
+  | zero =>
+      have hone : (1 : X →L[ℝ] X) = ContinuousLinearMap.id ℝ X := rfl
+      simp only [pow_zero]
+      rw [hone]
+      exact ContinuousLinearMap.norm_id_le
+  | succ n ih =>
+      rw [pow_succ, pow_succ]
+      exact (ContinuousLinearMap.opNorm_comp_le _ _).trans
+        (mul_le_mul_of_nonneg_right ih (norm_nonneg f))
+
+/-- The iterated Hille--Yosida bound for a contraction semigroup:
+`‖R(lambda)^n‖ ≤ lambda⁻ⁿ`. -/
+theorem resolvent_pow_norm_le (S : ContractionSemigroup X) (lambda : ℝ) (hlambda : 0 < lambda)
+    (n : ℕ) :
+    ‖S.resolvent lambda hlambda ^ n‖ ≤ (1 / lambda) ^ n := by
+  exact (norm_pow_le_pow_norm _ n).trans
+    (pow_le_pow_left₀ (norm_nonneg _) (S.resolvent_norm_le lambda hlambda) n)
+
+/-- Pointwise form of the iterated contraction resolvent bound. -/
+theorem norm_resolvent_pow_apply_le (S : ContractionSemigroup X) (lambda : ℝ)
+    (hlambda : 0 < lambda) (n : ℕ) (x : X) :
+    ‖(S.resolvent lambda hlambda ^ n) x‖ ≤ (1 / lambda) ^ n * ‖x‖ := by
+  exact (ContinuousLinearMap.le_opNorm _ x).trans
+    (mul_le_mul_of_nonneg_right (S.resolvent_pow_norm_le lambda hlambda n) (norm_nonneg x))
+
+/-- Every power of the scaled contraction resolvent `lambda R(lambda)` has norm at most one. -/
+theorem norm_smul_resolvent_pow_le_one (S : ContractionSemigroup X) (lambda : ℝ)
+    (hlambda : 0 < lambda) (n : ℕ) :
+    ‖(lambda • S.resolvent lambda hlambda) ^ n‖ ≤ 1 := by
+  refine (norm_pow_le_pow_norm _ n).trans ?_
+  rw [norm_smul, Real.norm_eq_abs, abs_of_pos hlambda]
+  calc
+    (lambda * ‖S.resolvent lambda hlambda‖) ^ n
+        ≤ (lambda * (1 / lambda)) ^ n := by
+          gcongr
+          exact S.resolvent_norm_le lambda hlambda
+    _ = 1 := by rw [one_div, mul_inv_cancel₀ hlambda.ne', one_pow]
+
+/-- Pointwise form of the power bound for the scaled contraction resolvent. -/
+theorem norm_smul_resolvent_pow_apply_le (S : ContractionSemigroup X) (lambda : ℝ)
+    (hlambda : 0 < lambda) (n : ℕ) (x : X) :
+    ‖((lambda • S.resolvent lambda hlambda) ^ n) x‖ ≤ ‖x‖ := by
+  calc
+    ‖((lambda • S.resolvent lambda hlambda) ^ n) x‖
+        ≤ ‖(lambda • S.resolvent lambda hlambda) ^ n‖ * ‖x‖ :=
+          ContinuousLinearMap.le_opNorm _ x
+    _ ≤ 1 * ‖x‖ := by
+      gcongr
+      exact S.norm_smul_resolvent_pow_le_one lambda hlambda n
+    _ = ‖x‖ := one_mul _
+
+end ContractionSemigroup
+
+end TauCeti.Semigroups
+
+end


### PR DESCRIPTION
This PR establishes the iterated Hille--Yosida bound for contraction-semigroup resolvents: prove `‖R(λ)^n‖ ≤ λ⁻ⁿ`, its pointwise form, and the equivalent operator and pointwise estimates for the scaled resolvent `λ R(λ)`. Keep the zero Banach space in scope by deriving powers directly from Mathlib's composition-norm estimate instead of requiring a nontriviality instance.

This advances `TauCetiRoadmap/OneParameterSemigroups/README.md`, Part A — Strongly continuous semigroups, Resolvent theory, specifically “the iterated-resolvent bounds” and its contraction corollary. It is the lowest-hanging distinct remaining step because `StronglyContinuousSemigroup.resolvent_norm_le` and `ContractionSemigroup.resolvent_norm_le` already supply the first-power estimate on `main`; submultiplicativity immediately yields every contraction power, while the sharper general `(M, ω)` bound still depends on the roadmap's integral power formula.

Follow Engel--Nagel, *One-Parameter Semigroups for Linear Evolution Equations*, Theorem II.3.5. Reuse Mathlib's `ContinuousLinearMap.opNorm_comp_le`, `ContinuousLinearMap.norm_id_le`, and operator-norm application estimate; no Mathlib infrastructure or external formalization is vendored.

Add `TauCeti/Analysis/Semigroups/Resolvent/PowerBounds.lean` (97 lines). `lake exe cache get` reports `No files to download` and `Already decompressed 8639 file(s)`. `lake build` reports `Build completed successfully (5234 jobs).` `lake exe axioms` reports `axioms: audited 11023 TauCeti declaration(s); all within the allowlist [propext, Classical.choice, Quot.sound].`

<!--tauceti-target:v1 {"focus":"OneParameterSemigroups","id":"contraction-resolvent-power-bound"}-->

🤖 Prepared with Codex
