### PR TITLE
feat: require a silent build with lake build --iofail

### DIFF
--- a/scripts/sandbox-build.sh
+++ b/scripts/sandbox-build.sh
@@ -21,7 +21,12 @@ export TMPDIR="$PWD/.lake/tmp"
 
 # Build the overlaid TauCeti/ against the trusted base config. landrun keeps this
 # offline and confines writes to base/.lake.
-lake build
+#
+# --iofail requires a SILENT build, the way Mathlib does (its CI runs `lake build --iofail`): it is
+# `--fail-level=info`, so the build fails if any module logs an `info:` (or warning/error) — a stray
+# #check/#eval, a `simp?`/`ring_nf?`-style "Try this: …" suggestion, a linter note. A clean elaboration
+# logs nothing above trace, so this is exit-code enforcement, not output scraping.
+lake build --iofail
 
 # Axiom audit: inspect the built environment and reject any axiom outside
 # {propext, Classical.choice, Quot.sound} — catching sorry, native_decide, and


### PR DESCRIPTION
This PR requires the sandboxed build to be silent using the exact mechanism Mathlib's CI uses: `lake build --iofail`. `--iofail` is `--fail-level=info`, so the build fails (via its exit code, caught by `pipefail`) if any module logs an `info:` or warning — a stray `#check`/`#eval`, a `simp?`/`ring_nf?`-style "Try this: …" suggestion, or a linter note. No output scraping.

This supersedes the two earlier hand-rolled-grep attempts (reverted in #1080 and #1089). `main` is already diagnostic-clean (#1083), so this holds on main; a PR branched before a diagnostic was fixed carries the stale file and must merge main to go green — the same expectation Mathlib places on stale branches.

🤖 Prepared with Claude Code