### PR TITLE
docs: explain relationship to Lean Pool

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,13 @@ Humans can raise issues against the code, and leave implementation (and review) 
 - **[TauCetiReview](https://github.com/TauCetiProject/TauCetiReview)** — the review rubrics and
   the machinery that runs review.
 
+## Relationship to Lean Pool
+
+Tau Ceti and [Lean Pool](https://github.com/Vilin97/lean-pool) are complementary. Lean Pool is
+an arXiv/AfP-like archive of independent formalization projects, whether human- or AI-written.
+Tau Ceti is an integrated, AI-built mathematical library whose contents follow human-audited
+roadmaps and undergo review for coherence, reuse, and compatibility with Mathlib.
+
 ## Review
 
 Review is entirely driven by AIs. These operate according to a fixed open source rubric. Humans write the rubric, and update it as the project evolves.


### PR DESCRIPTION
## Summary

- add a concise README comparison between Tau Ceti and Lean Pool
- describe the projects as complementary while distinguishing their scope and structure

## Why

The Lean community has asked for a clear explanation of how the two projects relate. This
gives readers that context near the overview of Tau Ceti's repositories.

## Impact

Documentation only; no Lean declarations or build configuration change.

## Validation

- `git diff --check`
