### PR TITLE
feat: expose abelian variety isomorphisms

### DIFF
--- a/TauCeti/AlgebraicGeometry/AbelianVariety/Hom/Iso.lean
+++ b/TauCeti/AlgebraicGeometry/AbelianVariety/Hom/Iso.lean
@@ -1,0 +1,131 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+module
+
+public import TauCeti.AlgebraicGeometry.AbelianVariety.Hom.Basic
+
+/-!
+# Isomorphisms of abelian varieties
+
+This file supplies the scheme-level interface to isomorphisms in the category of abelian
+varieties. An isomorphism `e : A ≅ B` forgets first to an isomorphism of schemes over `Spec K`,
+then to an isomorphism of the underlying schemes. The resulting isomorphisms are characterized
+by their forward and inverse morphisms and are functorial under identity, inverse, and
+composition.
+
+As a first geometric consequence, isomorphic abelian varieties have the same dimension. This is
+the interface needed to compare constructions characterized by the Jacobian's universal property
+and to state its base-change compatibility as an isomorphism of abelian varieties.
+
+This advances `TauCetiRoadmap/JacobianChallenge/README.md`, Layer E, “Abelian variety = smooth,
+proper, geometrically connected group scheme over `k`; basic API, dim,” and prepares the
+isomorphisms in the end goal and Layer F. No external mathematics is vendored. The implementation
+reuses Mathlib's `Functor.mapIso`, `Over.isoMk`, and invariance of topological Krull dimension
+under homeomorphism.
+-/
+
+public section
+
+open CategoryTheory AlgebraicGeometry
+
+namespace TauCeti
+
+namespace AlgebraicGeometry
+
+universe u
+
+namespace AbelianVariety
+
+variable {K : Type u} [Field K]
+
+noncomputable section
+
+/-- The isomorphism of schemes over `Spec K` underlying an isomorphism of abelian varieties. -/
+abbrev isoToOver {A B : AbelianVariety K} (e : A ≅ B) : A.toOver ≅ B.toOver :=
+  Hom.toOverFunctor.mapIso e
+
+/-- The isomorphism of schemes underlying an isomorphism of abelian varieties. -/
+abbrev isoToScheme {A B : AbelianVariety K} (e : A ≅ B) : A.toScheme ≅ B.toScheme :=
+  (Over.forget (Spec (.of K))).mapIso (isoToOver e)
+
+/-- The forward map of the underlying `Over` isomorphism is the underlying homomorphism of the
+forward abelian-variety isomorphism. -/
+@[simp]
+lemma isoToOver_hom {A B : AbelianVariety K} (e : A ≅ B) :
+    (isoToOver e).hom = Hom.toOverHom e.hom :=
+  rfl
+
+/-- The inverse map of the underlying `Over` isomorphism is the underlying homomorphism of the
+inverse abelian-variety isomorphism. -/
+@[simp]
+lemma isoToOver_inv {A B : AbelianVariety K} (e : A ≅ B) :
+    (isoToOver e).inv = Hom.toOverHom e.inv :=
+  rfl
+
+/-- The forward map of the underlying scheme isomorphism is the underlying scheme morphism of
+the forward abelian-variety isomorphism. -/
+@[simp]
+lemma isoToScheme_hom {A B : AbelianVariety K} (e : A ≅ B) :
+    (isoToScheme e).hom = Hom.toSchemeHom e.hom :=
+  rfl
+
+/-- The inverse map of the underlying scheme isomorphism is the underlying scheme morphism of
+the inverse abelian-variety isomorphism. -/
+@[simp]
+lemma isoToScheme_inv {A B : AbelianVariety K} (e : A ≅ B) :
+    (isoToScheme e).inv = Hom.toSchemeHom e.inv :=
+  rfl
+
+/-- The underlying `Over` isomorphism of the identity isomorphism is the identity. -/
+@[simp]
+lemma isoToOver_refl (A : AbelianVariety K) :
+    isoToOver (Iso.refl A) = Iso.refl A.toOver :=
+  (Hom.toOverFunctor.mapIso_refl A)
+
+/-- Forgetting an inverse isomorphism to schemes over the base commutes with taking inverses. -/
+@[simp]
+lemma isoToOver_symm {A B : AbelianVariety K} (e : A ≅ B) :
+    isoToOver e.symm = (isoToOver e).symm :=
+  rfl
+
+/-- Forgetting a composite isomorphism to schemes over the base commutes with composition. -/
+@[simp]
+lemma isoToOver_trans {A B C : AbelianVariety K} (e : A ≅ B) (f : B ≅ C) :
+    isoToOver (e.trans f) = (isoToOver e).trans (isoToOver f) :=
+  (Hom.toOverFunctor.mapIso_trans e f)
+
+/-- The underlying scheme isomorphism of the identity isomorphism is the identity. -/
+@[simp]
+lemma isoToScheme_refl (A : AbelianVariety K) :
+    isoToScheme (Iso.refl A) = Iso.refl A.toScheme := by
+  apply Iso.ext
+  exact Hom.toSchemeHom_id A
+
+/-- Forgetting an inverse isomorphism to schemes commutes with taking inverses. -/
+@[simp]
+lemma isoToScheme_symm {A B : AbelianVariety K} (e : A ≅ B) :
+    isoToScheme e.symm = (isoToScheme e).symm := by
+  apply Iso.ext
+  rfl
+
+/-- Forgetting a composite isomorphism to schemes commutes with composition. -/
+@[simp]
+lemma isoToScheme_trans {A B C : AbelianVariety K} (e : A ≅ B) (f : B ≅ C) :
+    isoToScheme (e.trans f) = (isoToScheme e).trans (isoToScheme f) := by
+  apply Iso.ext
+  exact Hom.toSchemeHom_comp e.hom f.hom
+
+/-- Isomorphic abelian varieties have equal topological Krull dimension. -/
+lemma dim_eq_of_iso {A B : AbelianVariety K} (e : A ≅ B) :
+    A.dim = B.dim :=
+  (isoToScheme e).hom.homeomorph.isHomeomorph.topologicalKrullDim_eq
+
+end
+
+end AbelianVariety
+
+end AlgebraicGeometry
+
+end TauCeti

--- a/TauCeti/AlgebraicGeometry/AbelianVariety/Hom/Iso.lean
+++ b/TauCeti/AlgebraicGeometry/AbelianVariety/Hom/Iso.lean
@@ -20,8 +20,8 @@ and to state its base-change compatibility as an isomorphism of abelian varietie
 This advances `TauCetiRoadmap/JacobianChallenge/README.md`, Layer E, “Abelian variety = smooth,
 proper, geometrically connected group scheme over `k`; basic API, dim,” and prepares the
 isomorphisms in the end goal and Layer F. No external mathematics is vendored. The implementation
-reuses Mathlib's `Functor.mapIso`, `Over.isoMk`, and invariance of topological Krull dimension
-under homeomorphism.
+reuses Mathlib's `Functor.mapIso`, `Over.forget.mapIso`, and invariance of topological Krull
+dimension under homeomorphism.
 -/
 
 public section
@@ -41,12 +41,76 @@ variable {K : Type u} [Field K]
 noncomputable section
 
 /-- The isomorphism of schemes over `Spec K` underlying an isomorphism of abelian varieties. -/
-abbrev isoToOver {A B : AbelianVariety K} (e : A ≅ B) : A.toOver ≅ B.toOver :=
+def isoToOver {A B : AbelianVariety K} (e : A ≅ B) : A.toOver ≅ B.toOver :=
   Hom.toOverFunctor.mapIso e
 
 /-- The isomorphism of schemes underlying an isomorphism of abelian varieties. -/
-abbrev isoToScheme {A B : AbelianVariety K} (e : A ≅ B) : A.toScheme ≅ B.toScheme :=
+def isoToScheme {A B : AbelianVariety K} (e : A ≅ B) : A.toScheme ≅ B.toScheme :=
   (Over.forget (Spec (.of K))).mapIso (isoToOver e)
+
+/-- The forward map of the underlying `Over` isomorphism is the underlying homomorphism. -/
+@[simp]
+lemma isoToOver_hom {A B : AbelianVariety K} (e : A ≅ B) :
+    (isoToOver e).hom = Hom.toOverHom e.hom := by
+  simp [isoToOver]
+
+/-- The inverse map of the underlying `Over` isomorphism is the underlying homomorphism. -/
+@[simp]
+lemma isoToOver_inv {A B : AbelianVariety K} (e : A ≅ B) :
+    (isoToOver e).inv = Hom.toOverHom e.inv := by
+  simp [isoToOver]
+
+/-- The forward map of the underlying scheme isomorphism is the underlying scheme morphism. -/
+@[simp]
+lemma isoToScheme_hom {A B : AbelianVariety K} (e : A ≅ B) :
+    (isoToScheme e).hom = Hom.toSchemeHom e.hom := by
+  simp [isoToScheme]
+
+/-- The inverse map of the underlying scheme isomorphism is the underlying scheme morphism. -/
+@[simp]
+lemma isoToScheme_inv {A B : AbelianVariety K} (e : A ≅ B) :
+    (isoToScheme e).inv = Hom.toSchemeHom e.inv := by
+  simp [isoToScheme]
+
+/-- The underlying `Over` isomorphism of the identity isomorphism is the identity. -/
+@[simp]
+lemma isoToOver_refl (A : AbelianVariety K) :
+    isoToOver (Iso.refl A) = Iso.refl A.toOver :=
+  Hom.toOverFunctor.mapIso_refl A
+
+/-- Forgetting an inverse isomorphism over the base commutes with taking inverses. -/
+@[simp]
+lemma isoToOver_symm {A B : AbelianVariety K} (e : A ≅ B) :
+    isoToOver e.symm = (isoToOver e).symm := by
+  apply Iso.ext
+  simp
+
+/-- Forgetting a composite isomorphism over the base commutes with composition. -/
+@[simp]
+lemma isoToOver_trans {A B C : AbelianVariety K} (e : A ≅ B) (f : B ≅ C) :
+    isoToOver (e.trans f) = (isoToOver e).trans (isoToOver f) :=
+  Hom.toOverFunctor.mapIso_trans e f
+
+/-- The underlying scheme isomorphism of the identity isomorphism is the identity. -/
+@[simp]
+lemma isoToScheme_refl (A : AbelianVariety K) :
+    isoToScheme (Iso.refl A) = Iso.refl A.toScheme := by
+  apply Iso.ext
+  exact Hom.toSchemeHom_id A
+
+/-- Forgetting an inverse isomorphism of schemes commutes with taking inverses. -/
+@[simp]
+lemma isoToScheme_symm {A B : AbelianVariety K} (e : A ≅ B) :
+    isoToScheme e.symm = (isoToScheme e).symm := by
+  apply Iso.ext
+  rfl
+
+/-- Forgetting a composite isomorphism of schemes commutes with composition. -/
+@[simp]
+lemma isoToScheme_trans {A B C : AbelianVariety K} (e : A ≅ B) (f : B ≅ C) :
+    isoToScheme (e.trans f) = (isoToScheme e).trans (isoToScheme f) := by
+  apply Iso.ext
+  exact Hom.toSchemeHom_comp e.hom f.hom
 
 /-- Isomorphic abelian varieties have equal topological Krull dimension. -/
 lemma dim_eq_of_iso {A B : AbelianVariety K} (e : A ≅ B) :

--- a/TauCeti/AlgebraicGeometry/AbelianVariety/Hom/Iso.lean
+++ b/TauCeti/AlgebraicGeometry/AbelianVariety/Hom/Iso.lean
@@ -11,9 +11,7 @@ public import TauCeti.AlgebraicGeometry.AbelianVariety.Hom.Basic
 
 This file supplies the scheme-level interface to isomorphisms in the category of abelian
 varieties. An isomorphism `e : A ≅ B` forgets first to an isomorphism of schemes over `Spec K`,
-then to an isomorphism of the underlying schemes. The resulting isomorphisms are characterized
-by their forward and inverse morphisms and are functorial under identity, inverse, and
-composition.
+then to an isomorphism of the underlying schemes.
 
 As a first geometric consequence, isomorphic abelian varieties have the same dimension. This is
 the interface needed to compare constructions characterized by the Jacobian's universal property
@@ -49,71 +47,6 @@ abbrev isoToOver {A B : AbelianVariety K} (e : A ≅ B) : A.toOver ≅ B.toOver 
 /-- The isomorphism of schemes underlying an isomorphism of abelian varieties. -/
 abbrev isoToScheme {A B : AbelianVariety K} (e : A ≅ B) : A.toScheme ≅ B.toScheme :=
   (Over.forget (Spec (.of K))).mapIso (isoToOver e)
-
-/-- The forward map of the underlying `Over` isomorphism is the underlying homomorphism of the
-forward abelian-variety isomorphism. -/
-@[simp]
-lemma isoToOver_hom {A B : AbelianVariety K} (e : A ≅ B) :
-    (isoToOver e).hom = Hom.toOverHom e.hom :=
-  rfl
-
-/-- The inverse map of the underlying `Over` isomorphism is the underlying homomorphism of the
-inverse abelian-variety isomorphism. -/
-@[simp]
-lemma isoToOver_inv {A B : AbelianVariety K} (e : A ≅ B) :
-    (isoToOver e).inv = Hom.toOverHom e.inv :=
-  rfl
-
-/-- The forward map of the underlying scheme isomorphism is the underlying scheme morphism of
-the forward abelian-variety isomorphism. -/
-@[simp]
-lemma isoToScheme_hom {A B : AbelianVariety K} (e : A ≅ B) :
-    (isoToScheme e).hom = Hom.toSchemeHom e.hom :=
-  rfl
-
-/-- The inverse map of the underlying scheme isomorphism is the underlying scheme morphism of
-the inverse abelian-variety isomorphism. -/
-@[simp]
-lemma isoToScheme_inv {A B : AbelianVariety K} (e : A ≅ B) :
-    (isoToScheme e).inv = Hom.toSchemeHom e.inv :=
-  rfl
-
-/-- The underlying `Over` isomorphism of the identity isomorphism is the identity. -/
-lemma isoToOver_refl (A : AbelianVariety K) :
-    isoToOver (Iso.refl A) = Iso.refl A.toOver :=
-  (Hom.toOverFunctor.mapIso_refl A)
-
-/-- Forgetting an inverse isomorphism to schemes over the base commutes with taking inverses. -/
-@[simp]
-lemma isoToOver_symm {A B : AbelianVariety K} (e : A ≅ B) :
-    isoToOver e.symm = (isoToOver e).symm :=
-  rfl
-
-/-- Forgetting a composite isomorphism to schemes over the base commutes with composition. -/
-lemma isoToOver_trans {A B C : AbelianVariety K} (e : A ≅ B) (f : B ≅ C) :
-    isoToOver (e.trans f) = (isoToOver e).trans (isoToOver f) :=
-  (Hom.toOverFunctor.mapIso_trans e f)
-
-/-- The underlying scheme isomorphism of the identity isomorphism is the identity. -/
-@[simp]
-lemma isoToScheme_refl (A : AbelianVariety K) :
-    isoToScheme (Iso.refl A) = Iso.refl A.toScheme := by
-  apply Iso.ext
-  exact Hom.toSchemeHom_id A
-
-/-- Forgetting an inverse isomorphism to schemes commutes with taking inverses. -/
-@[simp]
-lemma isoToScheme_symm {A B : AbelianVariety K} (e : A ≅ B) :
-    isoToScheme e.symm = (isoToScheme e).symm := by
-  apply Iso.ext
-  rfl
-
-/-- Forgetting a composite isomorphism to schemes commutes with composition. -/
-@[simp]
-lemma isoToScheme_trans {A B C : AbelianVariety K} (e : A ≅ B) (f : B ≅ C) :
-    isoToScheme (e.trans f) = (isoToScheme e).trans (isoToScheme f) := by
-  apply Iso.ext
-  exact Hom.toSchemeHom_comp e.hom f.hom
 
 /-- Isomorphic abelian varieties have equal topological Krull dimension. -/
 lemma dim_eq_of_iso {A B : AbelianVariety K} (e : A ≅ B) :

--- a/TauCeti/AlgebraicGeometry/AbelianVariety/Hom/Iso.lean
+++ b/TauCeti/AlgebraicGeometry/AbelianVariety/Hom/Iso.lean
@@ -103,7 +103,7 @@ lemma isoToScheme_refl (A : AbelianVariety K) :
 lemma isoToScheme_symm {A B : AbelianVariety K} (e : A ≅ B) :
     isoToScheme e.symm = (isoToScheme e).symm := by
   apply Iso.ext
-  rfl
+  simp only [isoToScheme_hom, Iso.symm_hom, isoToScheme_inv]
 
 /-- Forgetting a composite isomorphism of schemes commutes with composition. -/
 @[simp]

--- a/TauCeti/AlgebraicGeometry/AbelianVariety/Hom/Iso.lean
+++ b/TauCeti/AlgebraicGeometry/AbelianVariety/Hom/Iso.lean
@@ -79,7 +79,6 @@ lemma isoToScheme_inv {A B : AbelianVariety K} (e : A ≅ B) :
   rfl
 
 /-- The underlying `Over` isomorphism of the identity isomorphism is the identity. -/
-@[simp]
 lemma isoToOver_refl (A : AbelianVariety K) :
     isoToOver (Iso.refl A) = Iso.refl A.toOver :=
   (Hom.toOverFunctor.mapIso_refl A)
@@ -91,7 +90,6 @@ lemma isoToOver_symm {A B : AbelianVariety K} (e : A ≅ B) :
   rfl
 
 /-- Forgetting a composite isomorphism to schemes over the base commutes with composition. -/
-@[simp]
 lemma isoToOver_trans {A B C : AbelianVariety K} (e : A ≅ B) (f : B ≅ C) :
     isoToOver (e.trans f) = (isoToOver e).trans (isoToOver f) :=
   (Hom.toOverFunctor.mapIso_trans e f)


### PR DESCRIPTION
This PR exposes an isomorphism of abelian varieties as an isomorphism of schemes over the base and as an isomorphism of the underlying schemes. Characterize both forgetful constructions by their forward and inverse maps, prove compatibility with identity, symmetry, and composition, and deduce that isomorphic abelian varieties have equal topological Krull dimension.

This advances `TauCetiRoadmap/JacobianChallenge/README.md`, Layer E, specifically “Abelian variety = smooth, proper, geometrically connected group scheme over `k`; basic API, dim.” It is the lowest-hanging distinct prerequisite because the abelian-variety category and its homomorphism forgetful functor have landed, while the eventual universal-property comparison and the roadmap’s base-change compatibility both require abelian-variety isomorphisms to expose their scheme-level content.

Reuse Mathlib’s `Functor.mapIso`, the forgetful functor from `Over`, and `IsHomeomorph.topologicalKrullDim_eq`, together with Tau Ceti’s existing `AbelianVariety.Hom.toOverFunctor` and scheme-morphism API; vendor no Mathlib infrastructure or external formalization.

Add `TauCeti/AlgebraicGeometry/AbelianVariety/Hom/Iso.lean` (131 lines). `lake exe cache get` reports `No files to download` and `Already decompressed 8639 file(s)`. `lake build` reports `Build completed successfully (5250 jobs).` `lake exe axioms` reports `axioms: audited 11258 TauCeti declaration(s); all within the allowlist [propext, Classical.choice, Quot.sound].`

<!--tauceti-target:v1 {"focus":"JacobianChallenge","id":"abelian-variety-isomorphism-underlying-scheme"}-->

🤖 Prepared with Codex
