### PR TITLE
feat: characterize the zero Fredholm operator

### DIFF
--- a/TauCeti/Analysis/Fredholm/Zero.lean
+++ b/TauCeti/Analysis/Fredholm/Zero.lean
@@ -1,0 +1,90 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+module
+
+public import TauCeti.Analysis.Fredholm.Basic
+
+/-!
+# The zero Fredholm operator
+
+This file characterizes when the zero continuous linear map is Fredholm. Its kernel is the whole
+domain and its cokernel is the whole codomain, so it is Fredholm exactly when both spaces are
+finite dimensional. In that case its index is `dim E - dim F`.
+
+The result is the boundary case for finite-dimensional reductions in the Fredholm substrate of the
+analytic Heegaard Floer roadmap: after an infinite-dimensional invertible block is split off, a
+remaining zero block records precisely the finite-dimensional kernel and cokernel.
+
+## Main declarations
+
+* `TauCeti.isFredholm_zero_iff`: the zero operator is Fredholm exactly when its domain and
+  codomain are finite dimensional.
+* `TauCeti.ContinuousLinearMap.index_zero`: the index of the zero operator is the difference of
+  the dimensions of its domain and codomain.
+
+The conventions follow McDuff--Salamon, *J-holomorphic Curves and Symplectic Topology*, Appendix
+A.1.
+-/
+
+public section
+
+namespace TauCeti
+
+open Module
+
+variable {𝕜 E F : Type*}
+variable [NontriviallyNormedField 𝕜]
+variable [NormedAddCommGroup E] [NormedSpace 𝕜 E]
+variable [NormedAddCommGroup F] [NormedSpace 𝕜 F]
+
+private lemma finiteDimensional_domain_of_isFredholm_zero
+    (hT : IsFredholm (0 : E →L[𝕜] F)) : FiniteDimensional 𝕜 E := by
+  letI := hT.finiteDimensional_ker
+  exact
+    ((LinearEquiv.ofEq (LinearMap.ker (0 : E →ₗ[𝕜] F)) (⊤ : Submodule 𝕜 E)
+        LinearMap.ker_zero) ≪≫ₗ
+      (Submodule.topEquiv : (⊤ : Submodule 𝕜 E) ≃ₗ[𝕜] E)).finiteDimensional
+
+private lemma finiteDimensional_codomain_of_isFredholm_zero
+    (hT : IsFredholm (0 : E →L[𝕜] F)) : FiniteDimensional 𝕜 F := by
+  letI := hT.finiteDimensional_coker
+  exact
+    (LinearMap.range (0 : E →ₗ[𝕜] F)).quotEquivOfEqBot LinearMap.range_zero
+      |>.finiteDimensional
+
+/-- The zero continuous linear map is Fredholm exactly when its domain and codomain are both
+finite dimensional. -/
+lemma isFredholm_zero_iff :
+    IsFredholm (0 : E →L[𝕜] F) ↔
+      Nonempty (FiniteDimensional 𝕜 E) ∧ Nonempty (FiniteDimensional 𝕜 F) := by
+  constructor
+  · intro h
+    exact ⟨⟨finiteDimensional_domain_of_isFredholm_zero h⟩,
+      ⟨finiteDimensional_codomain_of_isFredholm_zero h⟩⟩
+  · rintro ⟨⟨hE⟩, ⟨hF⟩⟩
+    letI := hE
+    letI := hF
+    exact
+      { finiteDimensional_ker := inferInstance
+        isClosed_range := by simp
+        finiteDimensional_coker := inferInstance }
+
+namespace ContinuousLinearMap
+
+/-- The index of the zero continuous linear map is the dimension of its domain minus the
+dimension of its codomain. -/
+@[simp]
+lemma index_zero :
+    index (0 : E →L[𝕜] F) = (finrank 𝕜 E : ℤ) - finrank 𝕜 F := by
+  rw [index_eq_finrank_sub]
+  rw [ContinuousLinearMap.toLinearMap_zero, LinearMap.ker_zero, LinearMap.range_zero]
+  rw [LinearEquiv.finrank_eq Submodule.topEquiv,
+    LinearEquiv.finrank_eq ((⊥ : Submodule 𝕜 F).quotEquivOfEqBot rfl)]
+
+end ContinuousLinearMap
+
+end TauCeti
+
+end

--- a/TauCeti/Analysis/Fredholm/Zero.lean
+++ b/TauCeti/Analysis/Fredholm/Zero.lean
@@ -56,6 +56,7 @@ private lemma finiteDimensional_codomain_of_isFredholm_zero
 
 /-- The zero continuous linear map is Fredholm exactly when its domain and codomain are both
 finite dimensional. -/
+@[simp]
 lemma isFredholm_zero_iff :
     IsFredholm (0 : E →L[𝕜] F) ↔
       Nonempty (FiniteDimensional 𝕜 E) ∧ Nonempty (FiniteDimensional 𝕜 F) := by
@@ -79,9 +80,8 @@ dimension of its codomain. -/
 lemma index_zero :
     index (0 : E →L[𝕜] F) = (finrank 𝕜 E : ℤ) - finrank 𝕜 F := by
   rw [index_eq_finrank_sub]
-  rw [ContinuousLinearMap.toLinearMap_zero, LinearMap.ker_zero, LinearMap.range_zero]
-  rw [LinearEquiv.finrank_eq Submodule.topEquiv,
-    LinearEquiv.finrank_eq ((⊥ : Submodule 𝕜 F).quotEquivOfEqBot rfl)]
+  simpa only [ContinuousLinearMap.toLinearMap_zero, LinearMap.index_eq_finrank_sub] using
+    (LinearMap.index_zero (R := 𝕜) (M := E) (N := F))
 
 end ContinuousLinearMap
 


### PR DESCRIPTION
This PR characterizes the zero continuous linear map as Fredholm exactly when both its domain and codomain are finite dimensional, and computes its index as `dim E - dim F`. Keep the extraction of finite dimensionality private and expose only the characteristic equivalence and index formula.

This advances `TauCetiRoadmap/HeegaardFloer/README.md`, Lane F0, specifically “Fredholm operators (index, stability under compact and small perturbations, kernel/cokernel splitting).” It is the lowest-hanging distinct edge case of the Fredholm foundation: the kernel and cokernel of zero are the entire domain and codomain, so this supplies the canonical finite-dimensional residual block used after an invertible infinite-dimensional block is split off. It does not overlap the open injective/surjective criteria or closed-range PRs.

Follow McDuff--Salamon, *J-holomorphic Curves and Symplectic Topology*, Appendix A.1. Reuse Mathlib’s `LinearMap.ker_zero`, `LinearMap.range_zero`, `Submodule.topEquiv`, and `Submodule.quotEquivOfEqBot`, together with Tau Ceti’s existing `IsFredholm` and continuous-linear-map index API; vendor no Mathlib infrastructure or external formalization.

Add `TauCeti/Analysis/Fredholm/Zero.lean` (90 lines). `lake exe cache get` reports `No files to download` and `Already decompressed 8639 file(s)`. `lake build` reports `Build completed successfully (5250 jobs).` `lake exe axioms` reports `axioms: audited 11249 TauCeti declaration(s); all within the allowlist [propext, Classical.choice, Quot.sound].`

<!--tauceti-target:v1 {"focus":"HeegaardFloer","id":"fredholm-zero-operator"}-->

🤖 Prepared with Codex
