### PR TITLE
fix: rename the pr-build job so its check-run stops colliding with the required build status

### DIFF
--- a/.github/workflows/pr-build.yml
+++ b/.github/workflows/pr-build.yml
@@ -8,6 +8,14 @@ name: pr-build
 # compiles only under landrun (offline; writes confined to base/.lake; no secrets or token in
 # reach). The `build` commit status on the PR head SHA is the required merge check.
 #
+# The job below is deliberately NOT named `build`: GitHub Actions auto-creates a check-run named
+# after the job, and a check-run named `build` would collide with the required `build` STATUS this
+# job posts. Branch protection matches the required context `build` against BOTH commit statuses and
+# check-runs by name, so two `build` results (a green status + a red job check-run) wedge the PR as
+# BLOCKED even though the authoritative build passed — e.g. when the job's final report step exits
+# nonzero on a transient "could not list files" (INFRA) hiccup while a healthy re-run posts the green
+# status. Keeping the job name distinct leaves exactly one `build` (the status) as the merge gate.
+#
 # Live on pull_request_target (fires for all PRs, incl. forks, from the trusted base definition).
 # workflow_dispatch is also kept for ad-hoc re-testing of a given PR number.
 
@@ -35,7 +43,9 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  build:
+  # Name kept distinct from `build` on purpose — see the header note. The required merge check is the
+  # `build` commit STATUS posted in the final step, not this job's auto-created check-run.
+  sandboxed-build:
     runs-on: ubuntu-24.04
     env:
       LANDRUN_SHA256: 645178e3239cd33760560834e50efea0864183a2a8a82faf199760dffee6dd71


### PR DESCRIPTION
This PR renames the `pr-build` workflow's job from `build` to `sandboxed-build` so GitHub Actions no longer auto-creates a check-run named `build` alongside the `build` commit status the job posts. Branch protection matches the required `build` context against both commit statuses and check-runs by name, so when the job's check-run fails (for example its final report step exiting nonzero on a transient could-not-list-files INFRA hiccup) while a healthy re-run posts a green `build` status, the two `build` results wedge the PR as BLOCKED even though the authoritative sandboxed build passed. This is what has left [#1047](https://github.com/TauCetiProject/TauCeti/pull/1047) permanently unmergeable despite a green build status and a `ready-to-merge` label. Keeping the job name distinct leaves exactly one `build` under that name, the commit status, as the merge gate; the status itself is posted unchanged, so branch protection, the merge queue, and the `workflow_run` consumers that key off the workflow name `pr-build` are unaffected.

Note this touches `.github/` so the scope check reports it out of scope and it needs a human merge; that is expected for a workflow change.

🤖 Prepared with Claude Code