### PR TITLE
refactor(Contour): dedup the winding-integrand inv-mul=div rewrite

### DIFF
--- a/TauCeti/Analysis/Contour/LogDerivFTC.lean
+++ b/TauCeti/Analysis/Contour/LogDerivFTC.lean
@@ -84,11 +84,6 @@ theorem integral_deriv_div_sub_eq_log {γ γ' : ℝ → ℂ} {w : ℂ} {a b : �
     (fun t ht ↦ ((hγ_diff t ht).sub_const w).div_const _) h_slit (by rw [hfun]; exact h_int)
   rwa [hfun, div_self h_a_ne, Complex.log_one, sub_zero] at hgen
 
-/-- The winding integrand `(γ t - w)⁻¹ · γ'(t)` rewritten as the quotient `γ'(t) / (γ t - w)`. -/
-lemma inv_sub_mul_deriv_eq_deriv_div (γ : ℝ → ℂ) (w : ℂ) :
-    (fun t ↦ (γ t - w)⁻¹ * deriv γ t) = fun t ↦ deriv γ t / (γ t - w) := by
-  funext t; rw [div_eq_mul_inv, mul_comm]
-
 /-- **Winding-integrand form of the contour log-derivative FTC.** The `γ' = deriv γ` specialization
 of `integral_deriv_div_sub_eq_log`, stated with the winding-integral integrand
 `(γ t - w)⁻¹ * deriv γ t` in both the integrability hypothesis and the conclusion (matching the
@@ -100,9 +95,8 @@ theorem integral_inv_sub_mul_deriv_eq_log {γ : ℝ → ℂ} {w : ℂ} {a b : �
     (h_slit : ∀ t ∈ uIcc a b, (γ t - w) / (γ a - w) ∈ slitPlane)
     (h_int : IntervalIntegrable (fun t ↦ (γ t - w)⁻¹ * deriv γ t) volume a b) :
     ∫ t in a..b, (γ t - w)⁻¹ * deriv γ t = Complex.log ((γ b - w) / (γ a - w)) := by
-  have hfun := inv_sub_mul_deriv_eq_deriv_div γ w
-  rw [hfun]
+  simp only [inv_mul_eq_div]
   exact integral_deriv_div_sub_eq_log (γ' := deriv γ) hP hγ_cont
-    (fun t ht ↦ (hγ_diff t ht).hasDerivAt) h_slit (hfun ▸ h_int)
+    (fun t ht ↦ (hγ_diff t ht).hasDerivAt) h_slit (by simpa only [inv_mul_eq_div] using h_int)
 
 end TauCeti.Contour

--- a/TauCeti/Analysis/Contour/LogDerivFTC.lean
+++ b/TauCeti/Analysis/Contour/LogDerivFTC.lean
@@ -84,6 +84,11 @@ theorem integral_deriv_div_sub_eq_log {γ γ' : ℝ → ℂ} {w : ℂ} {a b : �
     (fun t ht ↦ ((hγ_diff t ht).sub_const w).div_const _) h_slit (by rw [hfun]; exact h_int)
   rwa [hfun, div_self h_a_ne, Complex.log_one, sub_zero] at hgen
 
+/-- The winding integrand `(γ t - w)⁻¹ · γ'(t)` rewritten as the quotient `γ'(t) / (γ t - w)`. -/
+lemma inv_sub_mul_deriv_eq_deriv_div (γ : ℝ → ℂ) (w : ℂ) :
+    (fun t ↦ (γ t - w)⁻¹ * deriv γ t) = fun t ↦ deriv γ t / (γ t - w) := by
+  funext t; rw [div_eq_mul_inv, mul_comm]
+
 /-- **Winding-integrand form of the contour log-derivative FTC.** The `γ' = deriv γ` specialization
 of `integral_deriv_div_sub_eq_log`, stated with the winding-integral integrand
 `(γ t - w)⁻¹ * deriv γ t` in both the integrability hypothesis and the conclusion (matching the
@@ -95,8 +100,7 @@ theorem integral_inv_sub_mul_deriv_eq_log {γ : ℝ → ℂ} {w : ℂ} {a b : �
     (h_slit : ∀ t ∈ uIcc a b, (γ t - w) / (γ a - w) ∈ slitPlane)
     (h_int : IntervalIntegrable (fun t ↦ (γ t - w)⁻¹ * deriv γ t) volume a b) :
     ∫ t in a..b, (γ t - w)⁻¹ * deriv γ t = Complex.log ((γ b - w) / (γ a - w)) := by
-  have hfun : (fun t ↦ (γ t - w)⁻¹ * deriv γ t) = fun t ↦ deriv γ t / (γ t - w) := by
-    funext t; rw [div_eq_mul_inv, mul_comm]
+  have hfun := inv_sub_mul_deriv_eq_deriv_div γ w
   rw [hfun]
   exact integral_deriv_div_sub_eq_log (γ' := deriv γ) hP hγ_cont
     (fun t ht ↦ (hγ_diff t ht).hasDerivAt) h_slit (hfun ▸ h_int)

--- a/TauCeti/Analysis/Contour/Winding/SegmentSum.lean
+++ b/TauCeti/Analysis/Contour/Winding/SegmentSum.lean
@@ -99,8 +99,7 @@ theorem integral_inv_sub_mul_deriv_eq_sum_log {γ : ℝ → ℂ} {w : ℂ} {a b 
     (h_int : IntervalIntegrable (fun t ↦ (γ t - w)⁻¹ * deriv γ t) volume a b) :
     ∫ t in a..b, (γ t - w)⁻¹ * deriv γ t
       = ∑ j ∈ Finset.range N, Complex.log ((γ (s (j + 1)) - w) / (γ (s j) - w)) := by
-  have hfun : (fun t ↦ (γ t - w)⁻¹ * deriv γ t) = fun t ↦ deriv γ t / (γ t - w) := by
-    funext t; rw [div_eq_mul_inv, mul_comm]
+  have hfun := inv_sub_mul_deriv_eq_deriv_div γ w
   rw [hfun]
   exact integral_deriv_div_sub_eq_sum_log (γ' := deriv γ) hP hs_zero hs_N hs_mono hγ_cont
     (fun t ht ↦ (hγ_diff t ht).hasDerivAt) h_slit (hfun ▸ h_int)
@@ -163,8 +162,7 @@ theorem integral_inv_sub_mul_deriv_eq_log_norm_add_I_mul_sum_log_im {γ : ℝ �
       = ((Real.log ‖γ b - w‖ - Real.log ‖γ a - w‖ : ℝ) : ℂ)
         + Complex.I * ((∑ j ∈ Finset.range N,
             (Complex.log ((γ (s (j + 1)) - w) / (γ (s j) - w))).im : ℝ) : ℂ) := by
-  have hfun : (fun t ↦ (γ t - w)⁻¹ * deriv γ t) = fun t ↦ deriv γ t / (γ t - w) := by
-    funext t; rw [div_eq_mul_inv, mul_comm]
+  have hfun := inv_sub_mul_deriv_eq_deriv_div γ w
   rw [hfun]
   exact integral_deriv_div_sub_eq_log_norm_add_I_mul_sum_log_im (γ' := deriv γ) hP hs_zero hs_N
     hs_mono hγ_cont (fun t ht ↦ (hγ_diff t ht).hasDerivAt) h_slit (hfun ▸ h_int)

--- a/TauCeti/Analysis/Contour/Winding/SegmentSum.lean
+++ b/TauCeti/Analysis/Contour/Winding/SegmentSum.lean
@@ -99,10 +99,9 @@ theorem integral_inv_sub_mul_deriv_eq_sum_log {γ : ℝ → ℂ} {w : ℂ} {a b 
     (h_int : IntervalIntegrable (fun t ↦ (γ t - w)⁻¹ * deriv γ t) volume a b) :
     ∫ t in a..b, (γ t - w)⁻¹ * deriv γ t
       = ∑ j ∈ Finset.range N, Complex.log ((γ (s (j + 1)) - w) / (γ (s j) - w)) := by
-  have hfun := inv_sub_mul_deriv_eq_deriv_div γ w
-  rw [hfun]
+  simp only [inv_mul_eq_div]
   exact integral_deriv_div_sub_eq_sum_log (γ' := deriv γ) hP hs_zero hs_N hs_mono hγ_cont
-    (fun t ht ↦ (hγ_diff t ht).hasDerivAt) h_slit (hfun ▸ h_int)
+    (fun t ht ↦ (hγ_diff t ht).hasDerivAt) h_slit (by simpa only [inv_mul_eq_div] using h_int)
 
 /-- **Real/imaginary decomposition of the index integral (explicit velocity).** Refining
 `integral_deriv_div_sub_eq_sum_log`, over the same slit-compatible monotone partition the integral
@@ -162,9 +161,9 @@ theorem integral_inv_sub_mul_deriv_eq_log_norm_add_I_mul_sum_log_im {γ : ℝ �
       = ((Real.log ‖γ b - w‖ - Real.log ‖γ a - w‖ : ℝ) : ℂ)
         + Complex.I * ((∑ j ∈ Finset.range N,
             (Complex.log ((γ (s (j + 1)) - w) / (γ (s j) - w))).im : ℝ) : ℂ) := by
-  have hfun := inv_sub_mul_deriv_eq_deriv_div γ w
-  rw [hfun]
+  simp only [inv_mul_eq_div]
   exact integral_deriv_div_sub_eq_log_norm_add_I_mul_sum_log_im (γ' := deriv γ) hP hs_zero hs_N
-    hs_mono hγ_cont (fun t ht ↦ (hγ_diff t ht).hasDerivAt) h_slit (hfun ▸ h_int)
+    hs_mono hγ_cont (fun t ht ↦ (hγ_diff t ht).hasDerivAt) h_slit
+    (by simpa only [inv_mul_eq_div] using h_int)
 
 end TauCeti.Contour


### PR DESCRIPTION
## What

De-duplicate the winding-integrand rewrite `(fun t ↦ (γ t - w)⁻¹ * deriv γ t) = fun t ↦ deriv γ t / (γ t - w)`, which was proved inline with the identical `funext t; rw [div_eq_mul_inv, mul_comm]` in **three** places (`LogDerivFTC.integral_inv_sub_mul_deriv_eq_log`, and both `SegmentSum` index-integral lemmas).

## Changes
- New `lemma TauCeti.Contour.inv_sub_mul_deriv_eq_deriv_div (γ : ℝ → ℂ) (w : ℂ)` in `LogDerivFTC.lean` (generic in `γ`, `w`).
- The 3 inline `have hfun : … := by funext t; rw […]` become `have hfun := inv_sub_mul_deriv_eq_deriv_div γ w`.

Found by a repo-wide inline-`have` duplication scan (env-type + proof-body clustering). It's a small dedup, but a genuine one — the same trivial rewrite was re-proved verbatim three times. No statement changes; build, axioms, module-system, lint-env all pass locally.
