### PR TITLE
refactor(Laplacian): extract the shared perturbation engine of the weak maximum principles

### DIFF
--- a/TauCeti/Analysis/InnerProductSpace/Laplacian/WeakMaximumPrinciple.lean
+++ b/TauCeti/Analysis/InnerProductSpace/Laplacian/WeakMaximumPrinciple.lean
@@ -87,6 +87,27 @@ theorem laplacian_add_const_smul_norm_sq {f : E → ℝ} {x : E} (ε : ℝ) (hf 
     laplacian_smul ε (contDiff_norm_sq ℝ).contDiffAt
   rw [hadd, hsmul, laplacian_norm_sq, smul_eq_mul]
 
+omit [InnerProductSpace ℝ E] [FiniteDimensional ℝ E] in
+/-- **The `ε → 0` perturbation engine of the weak maximum principles.** To bound `f x ≤ m` on a
+compact set `K`, it suffices to produce, for every `ε > 0`, a point `z ∈ K` at which the
+perturbation `f + ε‖·‖²` attains its maximum over `K` and where `f z ≤ m`: bounding `‖·‖²` by a
+constant on the compact `K` and letting `ε → 0` then gives `f x ≤ m`. The bare-Laplacian and
+`-Δ + c` weak maximum principles differ only in how they produce such a maximizer, so this lemma
+packages everything they share. -/
+theorem le_of_forall_pos_exists_isMaxOn_perturbation {K : Set E} (hK : IsCompact K) {f : E → ℝ}
+    {m : ℝ} {x : E} (hxK : x ∈ K)
+    (H : ∀ ε : ℝ, 0 < ε → ∃ z ∈ K, IsMaxOn (fun y : E => f y + ε • ‖y‖ ^ 2) K z ∧ f z ≤ m) :
+    f x ≤ m := by
+  obtain ⟨C, hCub⟩ := hK.bddAbove_image (f := fun y : E => ‖y‖ ^ 2) (by fun_prop)
+  have hCnonneg : 0 ≤ C := le_trans (sq_nonneg _) (hCub ⟨x, hxK, rfl⟩)
+  refine le_of_forall_pos_mul_le hCnonneg fun ε hε => ?_
+  obtain ⟨z, hzK, hzmax, hfz⟩ := H ε hε
+  have hxz : f x + ε * ‖x‖ ^ 2 ≤ f z + ε * ‖z‖ ^ 2 := by simpa [smul_eq_mul] using hzmax hxK
+  have hzC : ‖z‖ ^ 2 ≤ C := hCub ⟨z, hzK, rfl⟩
+  have hεzC : ε * ‖z‖ ^ 2 ≤ ε * C := mul_le_mul_of_nonneg_left hzC hε.le
+  have hεx : 0 ≤ ε * ‖x‖ ^ 2 := mul_nonneg hε.le (sq_nonneg _)
+  linarith
+
 section Nontrivial
 
 variable [Nontrivial E]
@@ -99,38 +120,25 @@ theorem le_of_laplacian_nonneg_le_frontier {K : Set E} (hK : IsCompact K) {f : E
     (hcont : ContinuousOn f K) (hcd : ∀ ⦃x⦄, x ∈ interior K → ContDiffAt ℝ 2 f x)
     (hlap : ∀ ⦃x⦄, x ∈ interior K → 0 ≤ Δ f x) (hbdry : ∀ ⦃x⦄, x ∈ frontier K → f x ≤ m) :
     ∀ ⦃x⦄, x ∈ K → f x ≤ m := by
-  -- Perturb `f` to the strictly subharmonic `f + ε‖·‖²`, apply the strict boundary maximum
-  -- principle, and let `ε → 0`.
+  -- Perturb `f` to the strictly subharmonic `f + ε‖·‖²`, whose maximum over `K` is forced onto the
+  -- frontier by the strict boundary maximum principle; then let `ε → 0`.
   intro x hxK
-  -- `‖·‖²` is bounded above by some `C ≥ 0` on the compact set `K`.
-  obtain ⟨C, hCub⟩ := hK.bddAbove_image (f := fun y : E => ‖y‖ ^ 2) (by fun_prop)
-  have hCnonneg : 0 ≤ C := le_trans (sq_nonneg _) (hCub ⟨x, hxK, rfl⟩)
   have hfrpos : (0 : ℝ) < Module.finrank ℝ E := by exact_mod_cast Module.finrank_pos
-  -- Perturbation estimate: `f x ≤ m + ε C` for every `ε > 0`.
-  have key : ∀ ε : ℝ, 0 < ε → f x ≤ m + ε * C := by
-    intro ε hε
-    have hεsq : ∀ y : E, ContDiffAt ℝ 2 (fun z : E => ε • ‖z‖ ^ 2) y :=
-      fun y => ((contDiff_norm_sq ℝ).contDiffAt).const_smul ε
-    have hgcont : ContinuousOn (fun y : E => f y + ε • ‖y‖ ^ 2) K := hcont.add (by fun_prop)
-    have hgcd : ∀ ⦃y⦄, y ∈ interior K → ContDiffAt ℝ 2 (fun y : E => f y + ε • ‖y‖ ^ 2) y :=
-      fun y hy => (hcd hy).add (hεsq y)
-    have hglap : ∀ ⦃y⦄, y ∈ interior K → 0 < Δ (fun y : E => f y + ε • ‖y‖ ^ 2) y := by
-      intro y hy
-      rw [laplacian_add_const_smul_norm_sq ε (hcd hy)]
-      have hpos : 0 < ε * (2 * (Module.finrank ℝ E : ℝ)) := mul_pos hε (mul_pos two_pos hfrpos)
-      linarith [hlap hy]
-    -- Strict boundary maximum principle applied to the perturbed function.
-    obtain ⟨z, hzfr, hzmax⟩ :=
-      exists_mem_frontier_isMaxOn_of_laplacian_pos hK ⟨x, hxK⟩ hgcont hgcd hglap
-    have hzK : z ∈ K := hK.isClosed.frontier_subset hzfr
-    have hxle : f x + ε * ‖x‖ ^ 2 ≤ f z + ε * ‖z‖ ^ 2 := by
-      simpa [smul_eq_mul] using hzmax hxK
-    have hzC : ‖z‖ ^ 2 ≤ C := hCub ⟨z, hzK, rfl⟩
-    have := mul_le_mul_of_nonneg_left hzC hε.le
-    have := mul_nonneg hε.le (sq_nonneg ‖x‖)
-    linarith [hbdry hzfr]
-  -- Let `ε → 0`.
-  exact le_of_forall_pos_mul_le hCnonneg key
+  refine le_of_forall_pos_exists_isMaxOn_perturbation hK hxK fun ε hε => ?_
+  have hεsq : ∀ y : E, ContDiffAt ℝ 2 (fun z : E => ε • ‖z‖ ^ 2) y :=
+    fun y => ((contDiff_norm_sq ℝ).contDiffAt).const_smul ε
+  have hgcont : ContinuousOn (fun y : E => f y + ε • ‖y‖ ^ 2) K := hcont.add (by fun_prop)
+  have hgcd : ∀ ⦃y⦄, y ∈ interior K → ContDiffAt ℝ 2 (fun y : E => f y + ε • ‖y‖ ^ 2) y :=
+    fun y hy => (hcd hy).add (hεsq y)
+  have hglap : ∀ ⦃y⦄, y ∈ interior K → 0 < Δ (fun y : E => f y + ε • ‖y‖ ^ 2) y := by
+    intro y hy
+    rw [laplacian_add_const_smul_norm_sq ε (hcd hy)]
+    have hpos : 0 < ε * (2 * (Module.finrank ℝ E : ℝ)) := mul_pos hε (mul_pos two_pos hfrpos)
+    linarith [hlap hy]
+  -- Strict boundary maximum principle: the maximizer lies on the frontier, where `f ≤ m`.
+  obtain ⟨z, hzfr, hzmax⟩ :=
+    exists_mem_frontier_isMaxOn_of_laplacian_pos hK ⟨x, hxK⟩ hgcont hgcd hglap
+  exact ⟨z, hK.isClosed.frontier_subset hzfr, hzmax, hbdry hzfr⟩
 
 /-- **Weak minimum principle for superharmonic functions.**
 

--- a/TauCeti/Analysis/InnerProductSpace/Laplacian/WeakMaximumPrinciple.lean
+++ b/TauCeti/Analysis/InnerProductSpace/Laplacian/WeakMaximumPrinciple.lean
@@ -89,22 +89,21 @@ theorem laplacian_add_const_smul_norm_sq {f : E → ℝ} {x : E} (ε : ℝ) (hf 
 
 omit [InnerProductSpace ℝ E] [FiniteDimensional ℝ E] in
 /-- **The `ε → 0` perturbation engine of the weak maximum principles.** To bound `f x ≤ m` on a
-compact set `K`, it suffices to produce, for every `ε > 0`, a point `z ∈ K` at which the
+bounded set `K`, it suffices to produce, for every `ε > 0`, a point `z ∈ K` at which the
 perturbation `f + ε‖·‖²` attains its maximum over `K` and where `f z ≤ m`: bounding `‖·‖²` by a
-constant on the compact `K` and letting `ε → 0` then gives `f x ≤ m`. The bare-Laplacian and
+constant on the bounded `K` and letting `ε → 0` then gives `f x ≤ m`. The bare-Laplacian and
 `-Δ + c` weak maximum principles differ only in how they produce such a maximizer, so this lemma
 packages everything they share. -/
-theorem le_of_forall_pos_exists_isMaxOn_perturbation {K : Set E} (hK : IsCompact K) {f : E → ℝ}
-    {m : ℝ} {x : E} (hxK : x ∈ K)
+theorem le_of_forall_pos_exists_isMaxOn_perturbation {K : Set E} (hK : Bornology.IsBounded K)
+    {f : E → ℝ} {m : ℝ} {x : E} (hxK : x ∈ K)
     (H : ∀ ε : ℝ, 0 < ε → ∃ z ∈ K, IsMaxOn (fun y : E => f y + ε • ‖y‖ ^ 2) K z ∧ f z ≤ m) :
     f x ≤ m := by
-  obtain ⟨C, hCub⟩ := hK.bddAbove_image (f := fun y : E => ‖y‖ ^ 2) (by fun_prop)
-  have hCnonneg : 0 ≤ C := le_trans (sq_nonneg _) (hCub ⟨x, hxK, rfl⟩)
-  refine le_of_forall_pos_mul_le hCnonneg fun ε hε => ?_
+  obtain ⟨M, hM⟩ := hK.exists_norm_le
+  refine le_of_forall_pos_mul_le (sq_nonneg M) fun ε hε => ?_
   obtain ⟨z, hzK, hzmax, hfz⟩ := H ε hε
   have hxz : f x + ε * ‖x‖ ^ 2 ≤ f z + ε * ‖z‖ ^ 2 := by simpa [smul_eq_mul] using hzmax hxK
-  have hzC : ‖z‖ ^ 2 ≤ C := hCub ⟨z, hzK, rfl⟩
-  have hεzC : ε * ‖z‖ ^ 2 ≤ ε * C := mul_le_mul_of_nonneg_left hzC hε.le
+  have hzC : ‖z‖ ^ 2 ≤ M ^ 2 := by nlinarith [hM z hzK, norm_nonneg z]
+  have hεzC : ε * ‖z‖ ^ 2 ≤ ε * M ^ 2 := mul_le_mul_of_nonneg_left hzC hε.le
   have hεx : 0 ≤ ε * ‖x‖ ^ 2 := mul_nonneg hε.le (sq_nonneg _)
   linarith
 
@@ -124,7 +123,7 @@ theorem le_of_laplacian_nonneg_le_frontier {K : Set E} (hK : IsCompact K) {f : E
   -- frontier by the strict boundary maximum principle; then let `ε → 0`.
   intro x hxK
   have hfrpos : (0 : ℝ) < Module.finrank ℝ E := by exact_mod_cast Module.finrank_pos
-  refine le_of_forall_pos_exists_isMaxOn_perturbation hK hxK fun ε hε => ?_
+  refine le_of_forall_pos_exists_isMaxOn_perturbation hK.isBounded hxK fun ε hε => ?_
   have hεsq : ∀ y : E, ContDiffAt ℝ 2 (fun z : E => ε • ‖z‖ ^ 2) y :=
     fun y => ((contDiff_norm_sq ℝ).contDiffAt).const_smul ε
   have hgcont : ContinuousOn (fun y : E => f y + ε • ‖y‖ ^ 2) K := hcont.add (by fun_prop)

--- a/TauCeti/Analysis/InnerProductSpace/Laplacian/ZerothOrderMaximumPrinciple.lean
+++ b/TauCeti/Analysis/InnerProductSpace/Laplacian/ZerothOrderMaximumPrinciple.lean
@@ -76,7 +76,7 @@ theorem le_of_mul_le_laplacian_le_frontier {K : Set E} (hK : IsCompact K) {c f :
     ∀ ⦃x⦄, x ∈ K → f x ≤ m := by
   intro x hxK
   have hfrpos : (0 : ℝ) < Module.finrank ℝ E := by exact_mod_cast Module.finrank_pos
-  refine le_of_forall_pos_exists_isMaxOn_perturbation hK hxK fun ε hε => ?_
+  refine le_of_forall_pos_exists_isMaxOn_perturbation hK.isBounded hxK fun ε hε => ?_
   have hεsq : ∀ y : E, ContDiffAt ℝ 2 (fun z : E => ε • ‖z‖ ^ 2) y :=
     fun y => ((contDiff_norm_sq ℝ).contDiffAt).const_smul ε
   have hgcont : ContinuousOn (fun y : E => f y + ε • ‖y‖ ^ 2) K := hcont.add (by fun_prop)

--- a/TauCeti/Analysis/InnerProductSpace/Laplacian/ZerothOrderMaximumPrinciple.lean
+++ b/TauCeti/Analysis/InnerProductSpace/Laplacian/ZerothOrderMaximumPrinciple.lean
@@ -75,44 +75,31 @@ theorem le_of_mul_le_laplacian_le_frontier {K : Set E} (hK : IsCompact K) {c f :
     (hbdry : ∀ ⦃x⦄, x ∈ frontier K → f x ≤ m) :
     ∀ ⦃x⦄, x ∈ K → f x ≤ m := by
   intro x hxK
-  -- `‖·‖²` is bounded above by some `C ≥ 0` on the compact set `K`.
-  obtain ⟨C, hCub⟩ := hK.bddAbove_image (f := fun y : E => ‖y‖ ^ 2) (by fun_prop)
-  have hCnonneg : 0 ≤ C := le_trans (sq_nonneg _) (hCub ⟨x, hxK, rfl⟩)
   have hfrpos : (0 : ℝ) < Module.finrank ℝ E := by exact_mod_cast Module.finrank_pos
-  -- Perturbation estimate: `f x ≤ m + ε C` for every `ε > 0`.
-  have key : ∀ ε : ℝ, 0 < ε → f x ≤ m + ε * C := by
-    intro ε hε
-    have hεsq : ∀ y : E, ContDiffAt ℝ 2 (fun z : E => ε • ‖z‖ ^ 2) y :=
-      fun y => ((contDiff_norm_sq ℝ).contDiffAt).const_smul ε
-    have hgcont : ContinuousOn (fun y : E => f y + ε • ‖y‖ ^ 2) K := hcont.add (by fun_prop)
-    -- The perturbation attains its maximum over `K` at some point `z`.
-    obtain ⟨z, hzK, hzmax⟩ := hK.exists_isMaxOn ⟨x, hxK⟩ hgcont
-    have hxz : f x + ε * ‖x‖ ^ 2 ≤ f z + ε * ‖z‖ ^ 2 := by
-      simpa [smul_eq_mul] using hzmax hxK
-    have hzC : ‖z‖ ^ 2 ≤ C := hCub ⟨z, hzK, rfl⟩
-    have hεzC : ε * ‖z‖ ^ 2 ≤ ε * C := mul_le_mul_of_nonneg_left hzC hε.le
-    have hεx : 0 ≤ ε * ‖x‖ ^ 2 := mul_nonneg hε.le (sq_nonneg _)
-    -- At the maximizer either `f z ≤ m` (boundary or negative value) or we reach a contradiction.
-    have hfz : f z ≤ m := by
-      by_cases hzint : z ∈ interior K
-      · -- Interior maximizer: rule out `0 ≤ f z` via the second-derivative obstruction.
-        by_contra hcon
-        rw [not_le] at hcon
-        have hfz0 : 0 ≤ f z := le_trans hm hcon.le
-        have hloc : IsLocalMax (fun y : E => f y + ε • ‖y‖ ^ 2) z :=
-          hzmax.isLocalMax (mem_interior_iff_mem_nhds.mp hzint)
-        have hgcd : ContDiffAt ℝ 2 (fun y : E => f y + ε • ‖y‖ ^ 2) z := (hcd hzint).add (hεsq z)
-        have hΔle : Δ (fun y : E => f y + ε • ‖y‖ ^ 2) z ≤ 0 :=
-          laplacian_nonpos_of_isLocalMax hgcd hloc
-        rw [laplacian_add_const_smul_norm_sq ε (hcd hzint)] at hΔle
-        have hΔf : 0 ≤ Δ f z := le_trans (mul_nonneg (hc hzint) hfz0) (hsub hzint)
-        have hpos : 0 < ε * (2 * (Module.finrank ℝ E : ℝ)) := mul_pos hε (mul_pos two_pos hfrpos)
-        linarith
-      · -- Boundary maximizer: `z ∈ frontier K`.
-        exact hbdry ⟨subset_closure hzK, hzint⟩
+  refine le_of_forall_pos_exists_isMaxOn_perturbation hK hxK fun ε hε => ?_
+  have hεsq : ∀ y : E, ContDiffAt ℝ 2 (fun z : E => ε • ‖z‖ ^ 2) y :=
+    fun y => ((contDiff_norm_sq ℝ).contDiffAt).const_smul ε
+  have hgcont : ContinuousOn (fun y : E => f y + ε • ‖y‖ ^ 2) K := hcont.add (by fun_prop)
+  -- The perturbation attains its maximum over `K` at some point `z`.
+  obtain ⟨z, hzK, hzmax⟩ := hK.exists_isMaxOn ⟨x, hxK⟩ hgcont
+  refine ⟨z, hzK, hzmax, ?_⟩
+  -- At the maximizer either `f z ≤ m` (boundary or negative value) or we reach a contradiction.
+  by_cases hzint : z ∈ interior K
+  · -- Interior maximizer: rule out `0 ≤ f z` via the second-derivative obstruction.
+    by_contra hcon
+    rw [not_le] at hcon
+    have hfz0 : 0 ≤ f z := le_trans hm hcon.le
+    have hloc : IsLocalMax (fun y : E => f y + ε • ‖y‖ ^ 2) z :=
+      hzmax.isLocalMax (mem_interior_iff_mem_nhds.mp hzint)
+    have hgcd : ContDiffAt ℝ 2 (fun y : E => f y + ε • ‖y‖ ^ 2) z := (hcd hzint).add (hεsq z)
+    have hΔle : Δ (fun y : E => f y + ε • ‖y‖ ^ 2) z ≤ 0 :=
+      laplacian_nonpos_of_isLocalMax hgcd hloc
+    rw [laplacian_add_const_smul_norm_sq ε (hcd hzint)] at hΔle
+    have hΔf : 0 ≤ Δ f z := le_trans (mul_nonneg (hc hzint) hfz0) (hsub hzint)
+    have hpos : 0 < ε * (2 * (Module.finrank ℝ E : ℝ)) := mul_pos hε (mul_pos two_pos hfrpos)
     linarith
-  -- Let `ε → 0`.
-  exact le_of_forall_pos_mul_le hCnonneg key
+  · -- Boundary maximizer: `z ∈ frontier K`.
+    exact hbdry ⟨subset_closure hzK, hzint⟩
 
 /-- **Comparison principle for `-Δ + c` with `c ≥ 0`.**
 


### PR DESCRIPTION
Both weak maximum principles in the Laplacian development ran the **same `ε → 0`
perturbation argument**:

* `le_of_laplacian_nonneg_le_frontier` — bare Laplacian, subharmonic (`0 ≤ Δ f`);
* `le_of_mul_le_laplacian_le_frontier` — `-Δ + c` with `c ≥ 0` (`c·f ≤ Δ f`).

In both, the skeleton is identical: bound `‖·‖²` by a constant `C` on the compact `K`,
then for every `ε > 0` produce a maximizer `z` of the perturbation `f + ε‖·‖²` over `K`
with `f z ≤ m`, and close via `le_of_forall_pos_mul_le`. The constant-bound setup, the
maximizer-value inequality `f x + ε‖x‖² ≤ f z + ε‖z‖²`, and the tail arithmetic were
**verbatim-identical** between the two proofs — only the *production of the maximizer*
differs (the strict boundary principle for the bare Laplacian; an interior/boundary
case-split for `-Δ + c`).

This PR factors out that shared engine:

```lean
theorem le_of_forall_pos_exists_isMaxOn_perturbation {K : Set E} (hK : IsCompact K)
    {f : E → ℝ} {m : ℝ} {x : E} (hxK : x ∈ K)
    (H : ∀ ε : ℝ, 0 < ε → ∃ z ∈ K, IsMaxOn (fun y => f y + ε • ‖y‖ ^ 2) K z ∧ f z ≤ m) :
    f x ≤ m
```

stated with `omit [InnerProductSpace ℝ E] [FiniteDimensional ℝ E]` — the engine needs only
the norm and compactness of `K`, nothing about the inner product or finite dimension.
Each principle now supplies only its maximizer step; the duplicated constant-bound + tail
arithmetic is gone.

- `le_of_laplacian_nonneg_le_frontier`: proof body 32 → 19 lines
- `le_of_mul_le_laplacian_le_frontier`: proof body 39 → 24 lines
- net **−5 lines** across the two files even after adding the (documented) shared lemma.

No declaration signatures change. All downstream consumers — the dual minimum principles,
the comparison principle, the abs-bound for solutions, Dirichlet uniqueness, and the
`∃`-forms — are untouched and rebuild green.
