### PR TITLE
refactor(Analysis/PDE): remove unconsumed ellipticity patching API

### DIFF
--- a/TauCeti/Analysis/PDE/Uniform/Ellipticity.lean
+++ b/TauCeti/Analysis/PDE/Uniform/Ellipticity.lean
@@ -39,11 +39,6 @@ and Lax--Milgram arguments: constants are parameters, not hidden existential dat
   predicate.
 * `TauCeti.PDE.UniformlyEllipticOn.congr`: replace a coefficient field by one that agrees
   on the domain.
-* `TauCeti.PDE.UniformlyEllipticOn.union` and
-  `TauCeti.PDE.uniformlyEllipticOn_union_iff`: patch uniform ellipticity over a binary union.
-* `TauCeti.PDE.UniformlyEllipticOn.iUnion` and
-  `TauCeti.PDE.uniformlyEllipticOn_iUnion_iff`: patch over an indexed union.
-* `TauCeti.PDE.UniformlyEllipticOn.biUnion`: patch over a union indexed by points of a set.
 * `TauCeti.PDE.matrixBilinearForm`: the bounded bilinear form `η, ξ ↦ ηᵀ A ξ` attached to
   a coefficient matrix.
 * `TauCeti.PDE.matrixBilinearFormLinear`: the coefficient matrix-to-bilinear-form map as a
@@ -81,7 +76,7 @@ namespace PDE
 
 open Matrix
 
-variable {X n ι : Type*} [Fintype n] [DecidableEq n]
+variable {X n : Type*} [Fintype n] [DecidableEq n]
 
 /-- Mathlib's matrix quadratic form is the dot-product expression `ξᵀ A ξ`. -/
 lemma toQuadraticForm'_eq_dotProduct (A : Matrix n n ℝ) (ξ : EuclideanSpace ℝ n) :
@@ -472,7 +467,7 @@ lemma uniformlyEllipticOn_iff :
 
 namespace UniformlyEllipticOn
 
-variable {Ω Ω' : Set X} {Ωs : ι → Set X} {a b : X → Matrix n n ℝ}
+variable {Ω Ω' : Set X} {a b : X → Matrix n n ℝ}
   {lam Lam lam' Lam' : ℝ}
 
 /-- The lower ellipticity constant is positive. -/
@@ -553,47 +548,6 @@ lemma congr (h : UniformlyEllipticOn Ω a lam Lam) (hab : Set.EqOn b a Ω) :
     exact h.lower_bound hx ξ
   · rw [hab hx]
     exact h.upper_bound hx η ξ
-
-/-- Uniform ellipticity patches over a binary union when the same constants work on both
-pieces. -/
-lemma union (hΩ : UniformlyEllipticOn Ω a lam Lam)
-    (hΩ' : UniformlyEllipticOn Ω' a lam Lam) :
-    UniformlyEllipticOn (Ω ∪ Ω') a lam Lam := by
-  refine UniformlyEllipticOn.of_bounds hΩ.pos hΩ.le (fun {x} hx ξ => ?_)
-    (fun {x} hx η ξ => ?_)
-  · rcases hx with hx | hx
-    · exact hΩ.lower_bound hx ξ
-    · exact hΩ'.lower_bound hx ξ
-  · rcases hx with hx | hx
-    · exact hΩ.upper_bound hx η ξ
-    · exact hΩ'.upper_bound hx η ξ
-
-/-- Uniform ellipticity patches over an indexed union when the same constants work on every
-piece and the side conditions are supplied explicitly. -/
-lemma iUnion (hlam : 0 < lam) (hLam : lam ≤ Lam)
-    (h : ∀ i, UniformlyEllipticOn (Ωs i) a lam Lam) :
-    UniformlyEllipticOn (⋃ i, Ωs i) a lam Lam := by
-  classical
-  refine UniformlyEllipticOn.of_bounds hlam hLam (fun {x} hx ξ => ?_)
-    (fun {x} hx η ξ => ?_)
-  · rcases Set.mem_iUnion.mp hx with ⟨i, hi⟩
-    exact (h i).lower_bound hi ξ
-  · rcases Set.mem_iUnion.mp hx with ⟨i, hi⟩
-    exact (h i).upper_bound hi η ξ
-
-/-- Uniform ellipticity patches over a union indexed by points of a set when the same
-constants work on every piece and the side conditions are supplied explicitly. -/
-lemma biUnion {s : Set ι} {Ωs : ι → Set X} (hlam : 0 < lam) (hLam : lam ≤ Lam)
-    (h : ∀ i ∈ s, UniformlyEllipticOn (Ωs i) a lam Lam) :
-    UniformlyEllipticOn (⋃ i ∈ s, Ωs i) a lam Lam := by
-  refine UniformlyEllipticOn.of_bounds hlam hLam (fun {x} hx ξ => ?_)
-    (fun {x} hx η ξ => ?_)
-  · rcases Set.mem_iUnion.mp hx with ⟨i, hx⟩
-    rcases Set.mem_iUnion.mp hx with ⟨hi, hxi⟩
-    exact (h i hi).lower_bound hxi ξ
-  · rcases Set.mem_iUnion.mp hx with ⟨i, hx⟩
-    rcases Set.mem_iUnion.mp hx with ⟨hi, hxi⟩
-    exact (h i hi).upper_bound hxi η ξ
 
 /-- At every point of the domain, uniform ellipticity gives a norm bound for the attached
 matrix bilinear form. -/
@@ -738,7 +692,7 @@ lemma add_const_smul_one (h : UniformlyEllipticOn Ω a lam Lam) {c : ℝ} (hc : 
 
 end UniformlyEllipticOn
 
-variable {Ω Ω' : Set X} {Ωs : ι → Set X} {a b : X → Matrix n n ℝ}
+variable {Ω : Set X} {a b : X → Matrix n n ℝ}
   {lam Lam : ℝ}
 
 /-- Equal coefficient fields on the domain give equivalent uniform-ellipticity hypotheses. -/
@@ -749,41 +703,6 @@ lemma uniformlyEllipticOn_congr (hab : Set.EqOn a b Ω) :
     exact h.congr (fun x hx => (hab hx).symm)
   · intro h
     exact h.congr hab
-
-/-- Binary-union characterization of uniform ellipticity with fixed constants. -/
-@[simp]
-lemma uniformlyEllipticOn_union_iff :
-    UniformlyEllipticOn (Ω ∪ Ω') a lam Lam ↔
-      UniformlyEllipticOn Ω a lam Lam ∧ UniformlyEllipticOn Ω' a lam Lam := by
-  constructor
-  · intro h
-    exact ⟨h.mono_set Set.subset_union_left, h.mono_set Set.subset_union_right⟩
-  · rintro ⟨hΩ, hΩ'⟩
-    exact hΩ.union hΩ'
-
-/-- Indexed-union characterization of uniform ellipticity with fixed constants. -/
-@[simp]
-lemma uniformlyEllipticOn_iUnion_iff :
-    UniformlyEllipticOn (⋃ i, Ωs i) a lam Lam ↔
-      0 < lam ∧ lam ≤ Lam ∧ ∀ i, UniformlyEllipticOn (Ωs i) a lam Lam := by
-  constructor
-  · intro h
-    exact ⟨h.pos, h.le, fun i => h.mono_set (Set.subset_iUnion Ωs i)⟩
-  · rintro ⟨hlam, hLam, h⟩
-    exact UniformlyEllipticOn.iUnion hlam hLam h
-
-/-- Bounded-indexed-union characterization of uniform ellipticity with fixed constants. -/
-@[simp]
-lemma uniformlyEllipticOn_biUnion_iff {s : Set ι} {Ωs : ι → Set X} :
-    UniformlyEllipticOn (⋃ i ∈ s, Ωs i) a lam Lam ↔
-      0 < lam ∧ lam ≤ Lam ∧ ∀ i ∈ s, UniformlyEllipticOn (Ωs i) a lam Lam := by
-  constructor
-  · intro h
-    refine ⟨h.pos, h.le, fun i hi => h.mono_set ?_⟩
-    intro x hx
-    exact Set.mem_iUnion.2 ⟨i, Set.mem_iUnion.2 ⟨hi, hx⟩⟩
-  · rintro ⟨hlam, hLam, h⟩
-    exact UniformlyEllipticOn.biUnion hlam hLam h
 
 /-- The constant identity coefficient field is uniformly elliptic with any constants
 `λ ≤ 1 ≤ Λ` and `0 < λ`. This is the coefficient field of the Laplacian model problem. -/


### PR DESCRIPTION
## Summary
- Remove the unconsumed domain-patching API from `TauCeti/Analysis/PDE/Uniform/Ellipticity.lean`: `UniformlyEllipticOn.union` / `iUnion` / `biUnion` and `uniformlyEllipticOn_union_iff` / `uniformlyEllipticOn_iUnion_iff` / `uniformlyEllipticOn_biUnion_iff`.
- Drop the corresponding module-doc bullets and unused variables (`ι`, `Ωs`, and post-namespace `Ω'`).
- Keep `mono_set` / `mono_constants` / `congr`; no deprecation aliases; no other mathematical or API changes.

Partially addresses #793 (independent single-file follow-up from the Task-2 decomposition; does not close the issue).

Scope: `AGENTS.md` — improving existing code (refactor / dead-code removal) is always in scope.

## Test plan
- [x] Confirmed the six declarations existed only in the target file (no other TauCeti consumers)
- [x] `lake env lean TauCeti/Analysis/PDE/Uniform/Ellipticity.lean` (pre-edit, post-edit, and post-rebase): exit 0
- [x] `lake build`: `Build completed successfully (5250 jobs).`
- [x] `lake exe axioms`: `axioms: audited 11252 TauCeti declaration(s); all within the allowlist [propext, Classical.choice, Quot.sound].`
- [x] `lake exe module-system`: `module-system: all 630 TauCeti module(s) opt into the module system.`
- [x] `git diff --check` clean on the changed file; zero remaining name matches for the six removed declarations
- [ ] CI green on this PR

Local `scripts/lint-env.sh` reported baseline ratchet noise unrelated to this file (no Ellipticity hits); treating CI lint as authoritative after rebase onto current `main`.

## AI disclosure
Prepared with Cursor (Composer / Auto agent).

Roadmap: PDE