### PR TITLE
feat: ambient isotopy preserves the range complement up to homeomorphism

### DIFF
--- a/TauCeti/Topology/Homotopy/AmbientIsotopic/Complement.lean
+++ b/TauCeti/Topology/Homotopy/AmbientIsotopic/Complement.lean
@@ -74,7 +74,6 @@ homeomorphism from `range f` onto the range of the moved map `Φ.final.comp f`. 
   (Homeomorph.image Φ.finalHomeomorph (Set.range f)).trans
     (Homeomorph.setCongr (Φ.range_final_comp f).symm)
 
-@[simp]
 theorem rangeHomeomorph_coe_apply (y : Set.range f) :
     (Φ.rangeHomeomorph f y : Y) = Φ.finalHomeomorph y := rfl
 
@@ -85,7 +84,6 @@ of knot-complement invariance under ambient isotopy. -/
     ↥(Set.range f)ᶜ ≃ₜ ↥(Set.range (Φ.final.comp f))ᶜ :=
   Φ.finalHomeomorph.subtype (Φ.notMem_range_iff f)
 
-@[simp]
 theorem complementHomeomorph_coe_apply (y : ↥(Set.range f)ᶜ) :
     (Φ.complementHomeomorph f y : Y) = Φ.finalHomeomorph y := rfl
 

--- a/TauCeti/Topology/Homotopy/AmbientIsotopic/Complement.lean
+++ b/TauCeti/Topology/Homotopy/AmbientIsotopic/Complement.lean
@@ -22,9 +22,9 @@ proved.
 
 Everything is stated for arbitrary continuous maps `f : C(X, Y)`, since the range and its
 complement make sense without an embedding hypothesis; the embedded case (knots) is the intended
-specialisation. The witnessing homeomorphism is a restriction of the ambient isotopy's final
-homeomorphism `Φ.finalHomeomorph`, so it is compatible with all the naturality already recorded
-for that homeomorphism in `TauCeti.Topology.Homotopy.Isotopy.Basic`.
+specialisation. Both witnessing homeomorphisms are restrictions of the ambient isotopy's final
+homeomorphism `Φ.finalHomeomorph`: their underlying-value maps are `Φ.finalHomeomorph` itself and
+their inverses are `Φ.finalHomeomorph.symm`, as recorded by the `coe_…_apply` lemmas below.
 
 ## Main definitions
 
@@ -59,33 +59,49 @@ map `Φ.final.comp f`: the image `Φ.finalHomeomorph '' range f` is `range (Φ.f
 theorem range_final_comp :
     Set.range (Φ.final.comp f) = Φ.finalHomeomorph '' Set.range f := by
   rw [ContinuousMap.coe_comp, Set.range_comp]
-  rfl
+  exact Set.image_congr' fun y => (Φ.finalHomeomorph_apply y).symm
+
+/-- A point lies in `range f` exactly when its image under the final homeomorphism lies in the
+range of the moved map. This is the compatibility that lets the final homeomorphism restrict to
+the ranges (and, negated, to the complements). -/
+theorem mem_range_iff (y : Y) :
+    y ∈ Set.range f ↔ Φ.finalHomeomorph y ∈ Set.range (Φ.final.comp f) := by
+  rw [range_final_comp, Φ.finalHomeomorph.injective.mem_set_image]
 
 /-- A point misses `range f` exactly when its image under the final homeomorphism misses the range
 of the moved map. This is the compatibility that lets the final homeomorphism restrict to the
 complements. -/
 theorem notMem_range_iff (y : Y) :
-    y ∉ Set.range f ↔ Φ.finalHomeomorph y ∉ Set.range (Φ.final.comp f) := by
-  rw [range_final_comp, Φ.finalHomeomorph.injective.mem_set_image]
+    y ∉ Set.range f ↔ Φ.finalHomeomorph y ∉ Set.range (Φ.final.comp f) :=
+  (Φ.mem_range_iff f y).not
 
 /-- The homeomorphism of ranges induced by an ambient isotopy: `Φ.finalHomeomorph` restricts to a
 homeomorphism from `range f` onto the range of the moved map `Φ.final.comp f`. -/
-@[expose] noncomputable def rangeHomeomorph : Set.range f ≃ₜ Set.range (Φ.final.comp f) :=
-  (Homeomorph.image Φ.finalHomeomorph (Set.range f)).trans
-    (Homeomorph.setCongr (Φ.range_final_comp f).symm)
+noncomputable def rangeHomeomorph : Set.range f ≃ₜ Set.range (Φ.final.comp f) :=
+  Φ.finalHomeomorph.subtype (Φ.mem_range_iff f)
 
-theorem rangeHomeomorph_coe_apply (y : Set.range f) :
-    (Φ.rangeHomeomorph f y : Y) = Φ.finalHomeomorph y := rfl
+theorem coe_rangeHomeomorph_apply (y : Set.range f) :
+    (Φ.rangeHomeomorph f y : Y) = Φ.finalHomeomorph y := by
+  rw [rangeHomeomorph, Homeomorph.subtype_apply_coe]
+
+theorem coe_rangeHomeomorph_symm_apply (y : Set.range (Φ.final.comp f)) :
+    ((Φ.rangeHomeomorph f).symm y : Y) = Φ.finalHomeomorph.symm y := by
+  rw [rangeHomeomorph, Homeomorph.subtype_symm_apply_coe]
 
 /-- The homeomorphism of complements induced by an ambient isotopy: `Φ.finalHomeomorph` restricts
 to a homeomorphism from `(range f)ᶜ` onto `(range (Φ.final.comp f))ᶜ`. This is the point-set core
 of knot-complement invariance under ambient isotopy. -/
-@[expose] noncomputable def complementHomeomorph :
+noncomputable def complementHomeomorph :
     ↥(Set.range f)ᶜ ≃ₜ ↥(Set.range (Φ.final.comp f))ᶜ :=
   Φ.finalHomeomorph.subtype (Φ.notMem_range_iff f)
 
-theorem complementHomeomorph_coe_apply (y : ↥(Set.range f)ᶜ) :
-    (Φ.complementHomeomorph f y : Y) = Φ.finalHomeomorph y := rfl
+theorem coe_complementHomeomorph_apply (y : ↥(Set.range f)ᶜ) :
+    (Φ.complementHomeomorph f y : Y) = Φ.finalHomeomorph y := by
+  rw [complementHomeomorph, Homeomorph.subtype_apply_coe]
+
+theorem coe_complementHomeomorph_symm_apply (y : ↥(Set.range (Φ.final.comp f))ᶜ) :
+    ((Φ.complementHomeomorph f).symm y : Y) = Φ.finalHomeomorph.symm y := by
+  rw [complementHomeomorph, Homeomorph.subtype_symm_apply_coe]
 
 end AmbientIsotopy
 

--- a/TauCeti/Topology/Homotopy/AmbientIsotopic/Complement.lean
+++ b/TauCeti/Topology/Homotopy/AmbientIsotopic/Complement.lean
@@ -1,0 +1,116 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+module
+
+public import TauCeti.Topology.Homotopy.AmbientIsotopic.Basic
+
+/-!
+# Ambient isotopy preserves the complement of the range
+
+The point of ambient isotopy, as opposed to the naive isotopy of
+`TauCeti.Topology.Homotopy.Isotopy.Basic`, is that it moves the *whole* ambient space, not just an
+embedded image. Consequently an ambient isotopy carrying a map `f` to a map `g` induces a
+homeomorphism of their complements `(range f)ᶜ ≃ₜ (range g)ᶜ`. This is exactly why the
+geometric-topology roadmap (`TauCetiRoadmap/GeometricTopology/README.md`, layer 4, "knot theory")
+insists that knot invariants be built on ambient isotopy: the complement of a knot is the basic
+invariant, and it is a homeomorphism invariant of the ambient-isotopy class precisely because of
+the theorem in this file. The module docstring of `TauCeti.Topology.Homotopy.Isotopy.Basic` states
+this fact in prose ("an ambient isotopy induces a homeomorphism of complements"); here it is
+proved.
+
+Everything is stated for arbitrary continuous maps `f : C(X, Y)`, since the range and its
+complement make sense without an embedding hypothesis; the embedded case (knots) is the intended
+specialisation. The witnessing homeomorphism is a restriction of the ambient isotopy's final
+homeomorphism `Φ.finalHomeomorph`, so it is compatible with all the naturality already recorded
+for that homeomorphism in `TauCeti.Topology.Homotopy.Isotopy.Basic`.
+
+## Main definitions
+
+* `TauCeti.AmbientIsotopy.rangeHomeomorph`: the homeomorphism `range f ≃ₜ range (Φ.final.comp f)`
+  induced on ranges by an ambient isotopy `Φ`.
+* `TauCeti.AmbientIsotopy.complementHomeomorph`: the homeomorphism
+  `(range f)ᶜ ≃ₜ (range (Φ.final.comp f))ᶜ` induced on complements.
+
+## Main results
+
+* `TauCeti.AmbientIsotopy.range_final_comp`: the final homeomorphism carries `range f` onto the
+  range of the moved map `Φ.final.comp f`.
+* `TauCeti.AmbientIsotopic.nonempty_rangeHomeomorph` /
+  `TauCeti.AmbientIsotopic.nonempty_complementHomeomorph`: ambient isotopic maps have homeomorphic
+  ranges and homeomorphic complements. The complement statement is the knot-invariance fact.
+-/
+
+public section
+
+namespace TauCeti
+
+open unitInterval ContinuousMap Topology
+
+variable {X Y : Type*} [TopologicalSpace X] [TopologicalSpace Y]
+
+namespace AmbientIsotopy
+
+variable (Φ : AmbientIsotopy Y) (f : C(X, Y))
+
+/-- The final homeomorphism of an ambient isotopy carries `range f` onto the range of the moved
+map `Φ.final.comp f`: the image `Φ.finalHomeomorph '' range f` is `range (Φ.final.comp f)`. -/
+theorem range_final_comp :
+    Set.range (Φ.final.comp f) = Φ.finalHomeomorph '' Set.range f := by
+  rw [ContinuousMap.coe_comp, Set.range_comp]
+  rfl
+
+/-- A point misses `range f` exactly when its image under the final homeomorphism misses the range
+of the moved map. This is the compatibility that lets the final homeomorphism restrict to the
+complements. -/
+theorem notMem_range_iff (y : Y) :
+    y ∉ Set.range f ↔ Φ.finalHomeomorph y ∉ Set.range (Φ.final.comp f) := by
+  rw [range_final_comp, Φ.finalHomeomorph.injective.mem_set_image]
+
+/-- The homeomorphism of ranges induced by an ambient isotopy: `Φ.finalHomeomorph` restricts to a
+homeomorphism from `range f` onto the range of the moved map `Φ.final.comp f`. -/
+@[expose] noncomputable def rangeHomeomorph : Set.range f ≃ₜ Set.range (Φ.final.comp f) :=
+  (Homeomorph.image Φ.finalHomeomorph (Set.range f)).trans
+    (Homeomorph.setCongr (Φ.range_final_comp f).symm)
+
+@[simp]
+theorem rangeHomeomorph_coe_apply (y : Set.range f) :
+    (Φ.rangeHomeomorph f y : Y) = Φ.finalHomeomorph y := rfl
+
+/-- The homeomorphism of complements induced by an ambient isotopy: `Φ.finalHomeomorph` restricts
+to a homeomorphism from `(range f)ᶜ` onto `(range (Φ.final.comp f))ᶜ`. This is the point-set core
+of knot-complement invariance under ambient isotopy. -/
+@[expose] noncomputable def complementHomeomorph :
+    ↥(Set.range f)ᶜ ≃ₜ ↥(Set.range (Φ.final.comp f))ᶜ :=
+  Φ.finalHomeomorph.subtype (Φ.notMem_range_iff f)
+
+@[simp]
+theorem complementHomeomorph_coe_apply (y : ↥(Set.range f)ᶜ) :
+    (Φ.complementHomeomorph f y : Y) = Φ.finalHomeomorph y := rfl
+
+end AmbientIsotopy
+
+namespace AmbientIsotopic
+
+variable {f g : C(X, Y)}
+
+/-- **Ambient isotopy preserves ranges up to homeomorphism.** If `f` and `g` are ambient isotopic,
+their ranges (the embedded images, for embeddings) are homeomorphic. -/
+theorem nonempty_rangeHomeomorph (hfg : AmbientIsotopic f g) :
+    Nonempty (Set.range f ≃ₜ Set.range g) := by
+  obtain ⟨Φ, rfl⟩ := hfg
+  exact ⟨Φ.rangeHomeomorph f⟩
+
+/-- **Ambient isotopy preserves complements up to homeomorphism.** If `f` and `g` are ambient
+isotopic, the complements `(range f)ᶜ` and `(range g)ᶜ` are homeomorphic. For knots (embeddings
+`S¹ ↪ M`) this is the invariance of the knot complement, the reason knot invariants are built on
+ambient isotopy rather than on the naive isotopy relation. -/
+theorem nonempty_complementHomeomorph (hfg : AmbientIsotopic f g) :
+    Nonempty (↥(Set.range f)ᶜ ≃ₜ ↥(Set.range g)ᶜ) := by
+  obtain ⟨Φ, rfl⟩ := hfg
+  exact ⟨Φ.complementHomeomorph f⟩
+
+end AmbientIsotopic
+
+end TauCeti


### PR DESCRIPTION
This PR proves that an ambient isotopy induces a homeomorphism of complements, formalizing the fact that until now lived only as prose in the isotopy module docstrings ("an ambient isotopy induces a homeomorphism of complements, so knot invariants must be built on `AmbientIsotopy`"). It targets the `GeometricTopology` roadmap's knot-theory layer (`TauCetiRoadmap/GeometricTopology/README.md`, layer 4, "knot theory, done properly"), whose encoding conventions ask that ambient isotopy be the relation underlying knot equivalence exactly because the knot complement — the basic knot invariant — is preserved by it; the theorem here is the point-set core of that complement invariance.

Building on the existing `TauCeti.AmbientIsotopy` structure and the `TauCeti.AmbientIsotopic` equivalence relation, the new module `TauCeti/Topology/Homotopy/AmbientIsotopic/Complement.lean` records, for an ambient isotopy `Φ` and a continuous map `f : C(X, Y)`, that the final homeomorphism carries `range f` onto `range (Φ.final.comp f)` (`AmbientIsotopy.range_final_comp`), restricts to a homeomorphism of ranges (`AmbientIsotopy.rangeHomeomorph`) and of complements (`AmbientIsotopy.complementHomeomorph`), and concludes at the relation level that ambient isotopic maps have homeomorphic ranges and homeomorphic complements (`AmbientIsotopic.nonempty_rangeHomeomorph`, `AmbientIsotopic.nonempty_complementHomeomorph`). Everything is stated for arbitrary continuous maps, since range and complement need no embedding hypothesis; the embedded case (knots `S¹ ↪ M`) is the intended specialisation. The witnessing homeomorphisms are restrictions of `Φ.finalHomeomorph`, built with Mathlib's `Homeomorph.subtype`, `Homeomorph.image`, and `Homeomorph.setCongr`, so they compose with the naturality already recorded for that homeomorphism.

`lake build` is green and `lake exe axioms` reports all declarations within the allowlist `[propext, Classical.choice, Quot.sound]`.

<!--tauceti-target:v1 {"focus":"GeometricTopology","id":"ambient-isotopy-complement-homeomorph"}-->

🤖 Prepared with Claude Code
