### PR TITLE
style: add the missing copyright headers to 58 files

### DIFF
--- a/TauCeti/Algebra/GroupAction/FiniteSupportPerm.lean
+++ b/TauCeti/Algebra/GroupAction/FiniteSupportPerm.lean
@@ -1,3 +1,7 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
 module
 
 public import Mathlib.GroupTheory.GroupAction.FixedPoints

--- a/TauCeti/Analysis/Contour/LogDerivFTC.lean
+++ b/TauCeti/Analysis/Contour/LogDerivFTC.lean
@@ -1,3 +1,7 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
 module
 
 public import Mathlib.Analysis.Calculus.Deriv.Basic

--- a/TauCeti/Analysis/Contour/Winding/Continuity.lean
+++ b/TauCeti/Analysis/Contour/Winding/Continuity.lean
@@ -1,3 +1,7 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
 module
 
 public import TauCeti.Analysis.Contour.Winding.Number.Basic

--- a/TauCeti/Analysis/Contour/Winding/Integer.lean
+++ b/TauCeti/Analysis/Contour/Winding/Integer.lean
@@ -1,3 +1,7 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
 module
 
 public import TauCeti.Analysis.Contour.Winding.Number.Basic

--- a/TauCeti/Analysis/Contour/Winding/SegmentSum.lean
+++ b/TauCeti/Analysis/Contour/Winding/SegmentSum.lean
@@ -1,3 +1,7 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
 module
 
 public import Mathlib.Analysis.Calculus.Deriv.Basic

--- a/TauCeti/Analysis/SpecialFunctions/Trigonometric/Chebyshev/CosineTransfer.lean
+++ b/TauCeti/Analysis/SpecialFunctions/Trigonometric/Chebyshev/CosineTransfer.lean
@@ -1,3 +1,7 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
 module
 
 public import TauCeti.Analysis.SpecialFunctions.Trigonometric.Chebyshev.Measure

--- a/TauCeti/Analysis/SpecialFunctions/Trigonometric/Chebyshev/Measure.lean
+++ b/TauCeti/Analysis/SpecialFunctions/Trigonometric/Chebyshev/Measure.lean
@@ -1,3 +1,7 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
 module
 
 public import Mathlib.Analysis.SpecialFunctions.Trigonometric.Chebyshev.Orthogonality

--- a/TauCeti/LinearAlgebra/TotallyReal.lean
+++ b/TauCeti/LinearAlgebra/TotallyReal.lean
@@ -1,3 +1,7 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
 module
 
 public import Mathlib.LinearAlgebra.Prod

--- a/TauCeti/MeasureTheory/Function/AEStronglyMeasurable.lean
+++ b/TauCeti/MeasureTheory/Function/AEStronglyMeasurable.lean
@@ -1,3 +1,7 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
 module
 
 public import Mathlib.MeasureTheory.Function.StronglyMeasurable.AEStronglyMeasurable

--- a/TauCeti/MeasureTheory/Function/ConditionalExpectation.lean
+++ b/TauCeti/MeasureTheory/Function/ConditionalExpectation.lean
@@ -1,3 +1,7 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
 module
 
 public import Mathlib.MeasureTheory.Function.ConditionalExpectation.Basic

--- a/TauCeti/MeasureTheory/Measure/ProductKernel.lean
+++ b/TauCeti/MeasureTheory/Measure/ProductKernel.lean
@@ -1,3 +1,7 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
 module
 
 public import Mathlib.MeasureTheory.Measure.FiniteMeasurePi

--- a/TauCeti/Probability/DeFinetti/BlockFactorization.lean
+++ b/TauCeti/Probability/DeFinetti/BlockFactorization.lean
@@ -1,3 +1,7 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
 module
 
 public import TauCeti.Probability.DeFinetti.DirectingMeasure.Coord

--- a/TauCeti/Probability/DeFinetti/CommonEnding.lean
+++ b/TauCeti/Probability/DeFinetti/CommonEnding.lean
@@ -1,3 +1,7 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
 module
 
 public import TauCeti.Probability.Exchangeability.ConditionallyIID.Basic

--- a/TauCeti/Probability/DeFinetti/CondExpConvergence.lean
+++ b/TauCeti/Probability/DeFinetti/CondExpConvergence.lean
@@ -1,3 +1,7 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
 module
 
 public import TauCeti.MeasureTheory.Function.ConditionalExpectation

--- a/TauCeti/Probability/DeFinetti/DirectingMeasure/Basic.lean
+++ b/TauCeti/Probability/DeFinetti/DirectingMeasure/Basic.lean
@@ -1,3 +1,7 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
 module
 
 public import TauCeti.Probability.Process.Tail.Basic

--- a/TauCeti/Probability/DeFinetti/DirectingMeasure/Coord.lean
+++ b/TauCeti/Probability/DeFinetti/DirectingMeasure/Coord.lean
@@ -1,3 +1,7 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
 module
 
 import TauCeti.Probability.DeFinetti.CondExpConvergence

--- a/TauCeti/Probability/DeFinetti/FutureFactorization.lean
+++ b/TauCeti/Probability/DeFinetti/FutureFactorization.lean
@@ -1,3 +1,7 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
 module
 
 public import Mathlib.MeasureTheory.Function.ConditionalExpectation.Basic

--- a/TauCeti/Probability/DeFinetti/PrefixDeletion.lean
+++ b/TauCeti/Probability/DeFinetti/PrefixDeletion.lean
@@ -1,3 +1,7 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
 module
 
 public import Mathlib.MeasureTheory.Function.ConditionalExpectation.Basic

--- a/TauCeti/Probability/DeFinetti/TailFactorization.lean
+++ b/TauCeti/Probability/DeFinetti/TailFactorization.lean
@@ -1,3 +1,7 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
 module
 
 -- Public: the modules whose symbols appear in the exported statement.

--- a/TauCeti/Probability/DeFinetti/Theorem.lean
+++ b/TauCeti/Probability/DeFinetti/Theorem.lean
@@ -1,3 +1,7 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
 module
 
 public import TauCeti.Probability.DeFinetti.BlockFactorization

--- a/TauCeti/Probability/Ergodic/FixedSpace.lean
+++ b/TauCeti/Probability/Ergodic/FixedSpace.lean
@@ -1,3 +1,7 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
 module
 
 public import Mathlib.MeasureTheory.Function.LpSpace.Basic

--- a/TauCeti/Probability/Ergodic/KoopmanMarkov.lean
+++ b/TauCeti/Probability/Ergodic/KoopmanMarkov.lean
@@ -1,3 +1,7 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
 module
 
 public import Mathlib.MeasureTheory.Function.AEEqFun

--- a/TauCeti/Probability/Exchangeability/AdjacentTranspositions.lean
+++ b/TauCeti/Probability/Exchangeability/AdjacentTranspositions.lean
@@ -1,3 +1,7 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
 module
 
 public import TauCeti.Probability.Exchangeability.Basic

--- a/TauCeti/Probability/Exchangeability/Basic.lean
+++ b/TauCeti/Probability/Exchangeability/Basic.lean
@@ -1,3 +1,7 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
 module
 
 public import Mathlib.MeasureTheory.Measure.Map

--- a/TauCeti/Probability/Exchangeability/ConditionallyIID/Basic.lean
+++ b/TauCeti/Probability/Exchangeability/ConditionallyIID/Basic.lean
@@ -1,3 +1,7 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
 module
 
 public import TauCeti.Probability.Exchangeability.Basic

--- a/TauCeti/Probability/Exchangeability/ConditionallyIID/Implications.lean
+++ b/TauCeti/Probability/Exchangeability/ConditionallyIID/Implications.lean
@@ -1,3 +1,7 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
 module
 
 public import TauCeti.Probability.Exchangeability.ConditionallyIID.Basic

--- a/TauCeti/Probability/Exchangeability/ConditionallyIID/Map.lean
+++ b/TauCeti/Probability/Exchangeability/ConditionallyIID/Map.lean
@@ -1,3 +1,7 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
 module
 
 public import TauCeti.Probability.Exchangeability.ConditionallyIID.Basic

--- a/TauCeti/Probability/Exchangeability/Contractability.lean
+++ b/TauCeti/Probability/Exchangeability/Contractability.lean
@@ -1,3 +1,7 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
 module
 
 public import TauCeti.Probability.Exchangeability.Basic

--- a/TauCeti/Probability/Exchangeability/Cylinder.lean
+++ b/TauCeti/Probability/Exchangeability/Cylinder.lean
@@ -1,3 +1,7 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
 module
 
 public import TauCeti.Probability.Exchangeability.Basic

--- a/TauCeti/Probability/Exchangeability/ExchangeableAtMonotone.lean
+++ b/TauCeti/Probability/Exchangeability/ExchangeableAtMonotone.lean
@@ -1,3 +1,7 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
 module
 
 public import TauCeti.Probability.Exchangeability.Basic

--- a/TauCeti/Probability/Exchangeability/FiniteMarginals.lean
+++ b/TauCeti/Probability/Exchangeability/FiniteMarginals.lean
@@ -1,3 +1,7 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
 module
 
 public import TauCeti.Probability.Exchangeability.Basic

--- a/TauCeti/Probability/Exchangeability/FullyExchangeable.lean
+++ b/TauCeti/Probability/Exchangeability/FullyExchangeable.lean
@@ -1,3 +1,7 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
 module
 
 public import TauCeti.Probability.Exchangeability.Basic

--- a/TauCeti/Probability/Exchangeability/IID.lean
+++ b/TauCeti/Probability/Exchangeability/IID.lean
@@ -1,3 +1,7 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
 module
 
 public import TauCeti.Probability.Exchangeability.ConditionallyIID.Implications

--- a/TauCeti/Probability/Exchangeability/L2/BlockAverages.lean
+++ b/TauCeti/Probability/Exchangeability/L2/BlockAverages.lean
@@ -1,3 +1,7 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
 module
 
 public import TauCeti.Probability.Exchangeability.L2.Covariance

--- a/TauCeti/Probability/Exchangeability/L2/BoundedObservable.lean
+++ b/TauCeti/Probability/Exchangeability/L2/BoundedObservable.lean
@@ -1,3 +1,7 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
 module
 
 public import TauCeti.Probability.Exchangeability.L2.Covariance

--- a/TauCeti/Probability/Exchangeability/L2/Covariance.lean
+++ b/TauCeti/Probability/Exchangeability/L2/Covariance.lean
@@ -1,3 +1,7 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
 module
 
 public import TauCeti.Probability.Exchangeability.Contractability

--- a/TauCeti/Probability/Exchangeability/L2/LongTailAverages.lean
+++ b/TauCeti/Probability/Exchangeability/L2/LongTailAverages.lean
@@ -1,3 +1,7 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
 module
 
 public import TauCeti.Probability.Exchangeability.L2.BlockAverages

--- a/TauCeti/Probability/Exchangeability/Map.lean
+++ b/TauCeti/Probability/Exchangeability/Map.lean
@@ -1,3 +1,7 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
 module
 
 public import TauCeti.Probability.Exchangeability.Contractability

--- a/TauCeti/Probability/Exchangeability/PathSpace/ContractableLaw.lean
+++ b/TauCeti/Probability/Exchangeability/PathSpace/ContractableLaw.lean
@@ -1,3 +1,7 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
 module
 
 public import TauCeti.Probability.Exchangeability.FiniteMarginals

--- a/TauCeti/Probability/Exchangeability/PathSpace/Exchangeable/Sigma.lean
+++ b/TauCeti/Probability/Exchangeability/PathSpace/Exchangeable/Sigma.lean
@@ -1,3 +1,7 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
 module
 
 public import TauCeti.Algebra.GroupAction.FiniteSupportPerm

--- a/TauCeti/Probability/Exchangeability/PathSpace/Exchangeable/ToContractable.lean
+++ b/TauCeti/Probability/Exchangeability/PathSpace/Exchangeable/ToContractable.lean
@@ -1,3 +1,7 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
 module
 
 public import TauCeti.Probability.Exchangeability.PathSpace.ContractableLaw

--- a/TauCeti/Probability/Exchangeability/PathSpace/Law/Basic.lean
+++ b/TauCeti/Probability/Exchangeability/PathSpace/Law/Basic.lean
@@ -1,3 +1,7 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
 module
 
 public import TauCeti.Probability.Exchangeability.Basic

--- a/TauCeti/Probability/Exchangeability/PathSpace/Law/Bridge.lean
+++ b/TauCeti/Probability/Exchangeability/PathSpace/Law/Bridge.lean
@@ -1,3 +1,7 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
 module
 
 public import TauCeti.Probability.Exchangeability.Contractability

--- a/TauCeti/Probability/Exchangeability/PathSpace/ProcessShift.lean
+++ b/TauCeti/Probability/Exchangeability/PathSpace/ProcessShift.lean
@@ -1,3 +1,7 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
 module
 
 public import TauCeti.Probability.Exchangeability.PathSpace.Shift

--- a/TauCeti/Probability/Exchangeability/PathSpace/Shift.lean
+++ b/TauCeti/Probability/Exchangeability/PathSpace/Shift.lean
@@ -1,3 +1,7 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
 module
 
 public import TauCeti.Probability.Exchangeability.Basic

--- a/TauCeti/Probability/Exchangeability/PermutationExtension.lean
+++ b/TauCeti/Probability/Exchangeability/PermutationExtension.lean
@@ -1,3 +1,7 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
 module
 
 public import Mathlib.Logic.Equiv.Fintype

--- a/TauCeti/Probability/Exchangeability/Stationary.lean
+++ b/TauCeti/Probability/Exchangeability/Stationary.lean
@@ -1,3 +1,7 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
 module
 
 public import TauCeti.Probability.Exchangeability.Contractability

--- a/TauCeti/Probability/Exchangeability/ThreeCycle.lean
+++ b/TauCeti/Probability/Exchangeability/ThreeCycle.lean
@@ -1,3 +1,7 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
 module
 
 public import TauCeti.Probability.Exchangeability.Contractability

--- a/TauCeti/Probability/Independence/Conditional.lean
+++ b/TauCeti/Probability/Independence/Conditional.lean
@@ -1,3 +1,7 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
 module
 
 public import Mathlib.Probability.Independence.Conditional

--- a/TauCeti/Probability/Martingale/AntitoneLimit.lean
+++ b/TauCeti/Probability/Martingale/AntitoneLimit.lean
@@ -1,3 +1,7 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
 module
 
 public import Mathlib.Probability.Martingale.Convergence

--- a/TauCeti/Probability/Martingale/Convergence.lean
+++ b/TauCeti/Probability/Martingale/Convergence.lean
@@ -1,3 +1,7 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
 module
 
 public import Mathlib.Probability.Martingale.Convergence

--- a/TauCeti/Probability/Martingale/Crossings/Bounds.lean
+++ b/TauCeti/Probability/Martingale/Crossings/Bounds.lean
@@ -1,3 +1,7 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
 module
 
 public import Mathlib.Probability.Martingale.Upcrossing

--- a/TauCeti/Probability/Martingale/Crossings/Pathwise.lean
+++ b/TauCeti/Probability/Martingale/Crossings/Pathwise.lean
@@ -1,3 +1,7 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
 module
 
 public import TauCeti.Probability.Martingale.Crossings.TimeReversal

--- a/TauCeti/Probability/Martingale/Crossings/TimeReversal.lean
+++ b/TauCeti/Probability/Martingale/Crossings/TimeReversal.lean
@@ -1,3 +1,7 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
 module
 
 public import Mathlib.Algebra.Polynomial.Reverse

--- a/TauCeti/Probability/Martingale/LevyDownwardEventuallyConst.lean
+++ b/TauCeti/Probability/Martingale/LevyDownwardEventuallyConst.lean
@@ -1,3 +1,7 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
 module
 
 public import TauCeti.Probability.Martingale.Convergence

--- a/TauCeti/Probability/Martingale/Reverse.lean
+++ b/TauCeti/Probability/Martingale/Reverse.lean
@@ -1,3 +1,7 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
 module
 
 public import Mathlib.Probability.Martingale.Basic

--- a/TauCeti/Probability/Process/Tail/Basic.lean
+++ b/TauCeti/Probability/Process/Tail/Basic.lean
@@ -1,3 +1,7 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
 module
 
 public import Mathlib.MeasureTheory.MeasurableSpace.Constructions

--- a/TauCeti/Probability/Process/Tail/ReverseFiltration.lean
+++ b/TauCeti/Probability/Process/Tail/ReverseFiltration.lean
@@ -1,3 +1,7 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
 module
 
 public import TauCeti.Probability.Process.Tail.Basic


### PR DESCRIPTION
A repo-wide `/cleanup` Phase-2 style audit over all 629 files found that **58 of
them carry no copyright header at all**, while the other 571 do.

Nothing catches this: `scripts/lint-env.sh` runs the *environment* linters
(`#lint`), and Mathlib's copyright check lives in its **text-style** linter,
which this project does not run. So the gap accumulated silently as files were
added.

This PR prepends the project's own dominant header form — the 314-file variant,
which carries **no `Authors:` line**, so no attribution is invented for anyone:

```lean
/-
Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
Released under Apache 2.0 license as described in the file LICENSE.
-/
```

placed **above `module`**, matching where every existing header sits in these
module-system files.

Scope: header text only. No declaration, statement, proof, import, or docstring
is touched — the diff is exactly `58 files changed, 232 insertions(+)`, four
lines per file. After this, all 629 files carry the header.

Gates: `lake build` (5250 jobs) ✓, `lake exe axioms` (11256 decls, allowlist) ✓,
`lake exe module-system` (630 modules) ✓, `scripts/lint-env.sh` PASS ✓.
