### PR TITLE
refactor: remove six dead private declarations

### DIFF
--- a/TauCeti/Algebra/AlgebraicGroup/HopfIdeal/Points/Naturality.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/HopfIdeal/Points/Naturality.lean
@@ -178,17 +178,6 @@ private lemma liftQuotientPointHom_apply (H : _root_.CommHopfAlgCat.{v} R)
         ((mem_quotientPointsSubgroup_iff H I A g).mp g.property))
   rw [MonoidHom.apply_ofInjective_symm, quotientPointsHom_liftQuotientPoint]
 
-private lemma liftQuotientPointHom_naturality (H : _root_.CommHopfAlgCat.{v} R)
-    (I : HopfIdeal R H) {A B : CommAlgCat.{w} R} (χ : A ⟶ B)
-    (g : quotientPointsSubgroup H I A) :
-    HopfAlgebra.mapPoints (H := quotient H I) χ (liftQuotientPointHom H I A g) =
-      liftQuotientPointHom H I B (mapQuotientPointsSubgroup H I χ g) := by
-  apply quotientPointsHom_injective H I B
-  rw [← mapPoints_quotientPointsHom H I χ]
-  rw [liftQuotientPointHom_apply, liftQuotientPointHom_apply]
-  rw [quotientPointsHom_liftQuotientPoint, quotientPointsHom_liftQuotientPoint]
-  rfl
-
 /-- The component isomorphism between quotient points and the cut-out subgroup. -/
 @[expose] noncomputable def quotientPointsSubgroupIso (H : _root_.CommHopfAlgCat.{v} R)
     (I : HopfIdeal R H) (A : CommAlgCat.{w} R) :

--- a/TauCeti/Algebra/Group/ElementaryTwoQuotient/Prod.lean
+++ b/TauCeti/Algebra/Group/ElementaryTwoQuotient/Prod.lean
@@ -71,12 +71,6 @@ private theorem bridgeModRangeNSMul_mk (G : Type*) [CommGroup G] (g : G) :
     bridgeModRangeNSMul G (elementaryTwoQuotientMk g) = QuotientAddGroup.mk (Additive.ofMul g) := by
   rw [elementaryTwoQuotientMk_eq_mkQ]; rfl
 
-/-- The inverse bridge sends the coset of `Additive.ofMul g` to the class of `g`. -/
-private theorem bridgeModRangeNSMul_symm_mk (G : Type*) [CommGroup G] (g : G) :
-    (bridgeModRangeNSMul G).symm (QuotientAddGroup.mk (Additive.ofMul g)) =
-      elementaryTwoQuotientMk g := by
-  rw [AddEquiv.symm_apply_eq, bridgeModRangeNSMul_mk]
-
 section Prod
 
 variable (G H : Type*) [CommGroup G] [CommGroup H]

--- a/TauCeti/AlgebraicGeometry/WeilDivisor/AbelJacobi/Sum/BasepointChange.lean
+++ b/TauCeti/AlgebraicGeometry/WeilDivisor/AbelJacobi/Sum/BasepointChange.lean
@@ -46,19 +46,6 @@ namespace OrderSystem
 
 variable (S : OrderSystem X G)
 
-private lemma sub_zsmul_ofPoint_add_zsmul_pointDifference
-    (D : WeilDivisor X) (n : ℤ) (x₀ y₀ : X) :
-    D - n • ofPoint x₀ + n • pointDifference x₀ y₀ = D - n • ofPoint y₀ := by
-  rw [pointDifference, zsmul_sub, sub_eq_add_neg]
-  abel
-
-private lemma sub_sub_zsmul_ofPoint_eq_zsmul_pointDifference
-    (D : WeilDivisor X) (n : ℤ) (x₀ y₀ : X) :
-    (D - n • ofPoint y₀) - (D - n • ofPoint x₀) =
-      n • pointDifference x₀ y₀ := by
-  rw [pointDifference, zsmul_sub, sub_eq_add_neg]
-  abel
-
 /-! ### Weighted base-point change for divisor sums -/
 
 /-- Changing the base point in the weighted Abel-Jacobi sum adds the weighted degree times the

--- a/TauCeti/Analysis/PositiveDefinite/SemigroupGroup/Basic.lean
+++ b/TauCeti/Analysis/PositiveDefinite/SemigroupGroup/Basic.lean
@@ -159,12 +159,6 @@ Berg--Christensen--Ressel sense, if all finite quadratic forms formed using the 
 def IsSemigroupGroupPD (F : ℝ≥0 × V → ℂ) : Prop :=
   IsPositiveDefinite fun p : BCRPoint V => F (p.time, p.point)
 
-/-- The BCR predicate is the generic positive-definite-function predicate on the local
-`BCRPoint` wrapper carrying the involution `(t, v) ↦ (t, -v)`. -/
-private theorem isSemigroupGroupPD_iff_isPositiveDefinite :
-    IsSemigroupGroupPD F ↔ IsPositiveDefinite (fun p : BCRPoint V => F (p.time, p.point)) :=
-  Iff.rfl
-
 /-- The bridge from semigroup-group positive definiteness to the associated positive-definite
 kernel. -/
 theorem isSemigroupGroupPD_iff_isPositiveDefiniteKernel :

--- a/TauCeti/Analysis/SpecialFunctions/Hermite/Function/Basic.lean
+++ b/TauCeti/Analysis/SpecialFunctions/Hermite/Function/Basic.lean
@@ -65,9 +65,6 @@ private lemma gaussianEnvelope_def (x : ℝ) :
     gaussianEnvelope x = Real.exp (-(x ^ 2 / 2)) :=
   gaussianEnvelope.eq_1 x
 
-private lemma gaussianEnvelope_pos (x : ℝ) : 0 < gaussianEnvelope x := by
-  exact Real.exp_pos _
-
 private lemma continuous_gaussianEnvelope : Continuous gaussianEnvelope := by
   unfold gaussianEnvelope
   exact Real.continuous_exp.comp (((continuous_id.pow 2).div_const 2).neg)


### PR DESCRIPTION
A repo-wide audit for unconsumed declarations (the same class of finding as #1161, "remove
unconsumed ellipticity patching API") turned up **six `private` declarations that nothing
references** — not from another file (impossible: they are `private`), and not from within
their own file either.

Removed:

| Declaration | File |
|---|---|
| `liftQuotientPointHom_naturality` | `Algebra/AlgebraicGroup/HopfIdeal/Points/Naturality.lean` |
| `bridgeModRangeNSMul_symm_mk` | `Algebra/Group/ElementaryTwoQuotient/Prod.lean` |
| `sub_zsmul_ofPoint_add_zsmul_pointDifference` | `AlgebraicGeometry/WeilDivisor/AbelJacobi/Sum/BasepointChange.lean` |
| `sub_sub_zsmul_ofPoint_eq_zsmul_pointDifference` | `AlgebraicGeometry/WeilDivisor/AbelJacobi/Sum/BasepointChange.lean` |
| `isSemigroupGroupPD_iff_isPositiveDefinite` | `Analysis/PositiveDefinite/SemigroupGroup/Basic.lean` |
| `gaussianEnvelope_pos` | `Analysis/SpecialFunctions/Hermite/Function/Basic.lean` |

`isSemigroupGroupPD_iff_isPositiveDefinite` is additionally a `:= Iff.rfl` restatement of the
definition immediately above it, so it carried no content even if it had been used.

**Why these six and not more.** The raw scan found 22 unreferenced `private` declarations, but
**16 of them are `@[simp]`** — a `private @[simp]` lemma is genuinely live, applied by `simp`
calls in its own file with no textual reference to its name. Those were kept. Only the six
that are both unreferenced **and** carry no attribute are removed here.

Public declarations were deliberately **not** touched. 1,506 of them are unreferenced elsewhere
in the repo, but that is what a library's API surface looks like (`_apply` / `_mk` / `simp`
lemmas exist for downstream use); absence of an in-repo call site says nothing about whether
they should exist.

The build is the proof: nothing depended on any of these.

Gates: `lake build` ✓, `lake exe axioms` (allowlist) ✓, `lake exe module-system` ✓,
`scripts/lint-env.sh` PASS ✓.
