### PR TITLE
refactor(Analysis/PDE): collapse redundant energy-estimate wrappers

### DIFF
--- a/TauCeti/Analysis/PDE/EnergyForm/Basic.lean
+++ b/TauCeti/Analysis/PDE/EnergyForm/Basic.lean
@@ -57,8 +57,7 @@ explicit (never hidden in a `∃ C`):
 * `TauCeti.PDE.garding_energyIntegrand_self_of_bounds`: the pointwise Gårding lower bound
   on the diagonal.
 
-The main estimates take single coefficients and inline bounds (`‖b₀‖ ≤ β`, and so on);
-the `_on` wrappers specialize them to coefficient fields on a domain.
+The main estimates take single coefficients and inline bounds (`‖b₀‖ ≤ β`, and so on).
 -/
 
 public section
@@ -70,7 +69,7 @@ namespace PDE
 open Matrix
 open scoped InnerProductSpace
 
-variable {X n : Type*} [Fintype n]
+variable {n : Type*} [Fintype n]
 
 /-- Local classical decidable equality for finite coordinate indices in energy-form proofs. -/
 noncomputable local instance energyFormDecidableEq : DecidableEq n := Classical.decEq n
@@ -139,7 +138,6 @@ lemma energyIntegrand_one_zero_mass_self (c : ℝ)
   rw [energyIntegrand_self, toQuadraticForm'_one]
   simp
 
-variable {Ω : Set X} {a : X → Matrix n n ℝ} {b : X → EuclideanSpace ℝ n} {c : X → ℝ}
 variable {lam Lam beta gamma : ℝ}
 
 /-- Weighted Young inequality in the form used to absorb the first-order drift term into
@@ -215,17 +213,6 @@ lemma norm_energyIntegrand_apply_le_of_bounds (hLam : 0 ≤ Lam)
         add_le_add (add_le_add hmat hdrift) hmass
     _ = (Lam + beta + gamma) * ‖U‖ * ‖V‖ := by ring
 
-/-- Pointwise boundedness on a domain, obtained by applying
-`norm_energyIntegrand_apply_le_of_bounds` at `x`. -/
-lemma norm_energyIntegrand_apply_le_of_bounds_on (hLam : 0 ≤ Lam)
-    (ha : ∀ ⦃x⦄, x ∈ Ω → ∀ η ξ : EuclideanSpace ℝ n,
-      |η ⬝ᵥ (a x *ᵥ ξ)| ≤ Lam * ‖η‖ * ‖ξ‖)
-    (hb : ∀ ⦃x⦄, x ∈ Ω → ‖b x‖ ≤ beta)
-    (hc : ∀ ⦃x⦄, x ∈ Ω → ‖c x‖ ≤ gamma) {x : X} (hx : x ∈ Ω)
-    (U V : ℝ × EuclideanSpace ℝ n) :
-    ‖energyIntegrand (a x) (b x) (c x) U V‖ ≤ (Lam + beta + gamma) * ‖U‖ * ‖V‖ :=
-  norm_energyIntegrand_apply_le_of_bounds hLam (ha hx) (hb hx) (hc hx) U V
-
 /-- The operator norm of the pointwise jet form is at most `Λ + β + γ`.
 
 This finite-dimensional estimate is consumed after integration to prove boundedness of the
@@ -260,16 +247,6 @@ lemma opNorm_energyIntegrand_one_zero_mass_le (c : ℝ) :
       (gamma := ‖c‖) zero_le_one
       (fun η ξ => abs_dotProduct_one_mulVec_le η ξ) (by simp) le_rfl
 
-/-- Operator-norm boundedness on a domain, obtained by applying
-`opNorm_energyIntegrand_le_of_bounds` at `x`. -/
-lemma opNorm_energyIntegrand_le_of_bounds_on (hLam : 0 ≤ Lam)
-    (ha : ∀ ⦃x⦄, x ∈ Ω → ∀ η ξ : EuclideanSpace ℝ n,
-      |η ⬝ᵥ (a x *ᵥ ξ)| ≤ Lam * ‖η‖ * ‖ξ‖)
-    (hb : ∀ ⦃x⦄, x ∈ Ω → ‖b x‖ ≤ beta)
-    (hc : ∀ ⦃x⦄, x ∈ Ω → ‖c x‖ ≤ gamma) {x : X} (hx : x ∈ Ω) :
-    ‖energyIntegrand (a x) (b x) (c x)‖ ≤ Lam + beta + gamma :=
-  opNorm_energyIntegrand_le_of_bounds hLam (ha hx) (hb hx) (hc hx)
-
 /-- **Pointwise Gårding inequality.** With a nonnegative mass coefficient (`c ≥ 0`), the
 diagonal of the jet form is bounded below by `(λ/2)‖∇u‖² − (β²/2λ)|u|²`. The ellipticity
 floor `λ‖∇u‖²` pays for the drift term via Young's inequality, leaving half the floor and a
@@ -298,18 +275,6 @@ lemma garding_energyIntegrand_self_of_bounds (hlam : 0 < lam)
       lam / 2 * ‖U.2‖ ^ 2 + beta ^ 2 / (2 * lam) * U.1 ^ 2 :=
     mul_norm_abs_le_half_mul_sq_add hlam beta U.1 ‖U.2‖
   nlinarith [hQ', hM, hD, hYoung]
-
-/-- Pointwise Gårding inequality on a domain, obtained by applying
-`garding_energyIntegrand_self_of_bounds` at `x`. -/
-lemma garding_energyIntegrand_self_of_bounds_on (hlam : 0 < lam)
-    (hQ : ∀ ⦃x⦄, x ∈ Ω → ∀ ξ : EuclideanSpace ℝ n,
-      lam * ‖ξ‖ ^ 2 ≤ (a x).toQuadraticForm' ξ)
-    (hb : ∀ ⦃x⦄, x ∈ Ω → ‖b x‖ ≤ beta)
-    (hc : ∀ ⦃x⦄, x ∈ Ω → 0 ≤ c x) {x : X} (hx : x ∈ Ω)
-    (U : ℝ × EuclideanSpace ℝ n) :
-    lam / 2 * ‖U.2‖ ^ 2 - beta ^ 2 / (2 * lam) * U.1 ^ 2
-      ≤ energyIntegrand (a x) (b x) (c x) U U :=
-  garding_energyIntegrand_self_of_bounds hlam (hQ hx) (hb hx) (hc hx) U
 
 end PDE
 

--- a/TauCeti/Analysis/PDE/EnergyLowerBounds.lean
+++ b/TauCeti/Analysis/PDE/EnergyLowerBounds.lean
@@ -56,7 +56,7 @@ namespace PDE
 open Matrix
 open scoped InnerProductSpace
 
-variable {X n : Type*} [Fintype n]
+variable {n : Type*} [Fintype n]
 
 /-- Local classical decidable equality for finite coordinate indices in lower-bound proofs. -/
 noncomputable local instance energyLowerBoundsDecidableEq : DecidableEq n := Classical.decEq n
@@ -106,19 +106,6 @@ lemma garding_energyIntegrand_self_of_mass_lower_bound_of_bounds (hlam : 0 < lam
   rw [hrw]
   linarith [hgard]
 
-/-- Pointwise Gårding lower bound with a mass floor on a domain, obtained by applying
-`garding_energyIntegrand_self_of_mass_lower_bound_of_bounds` at `x`. -/
-lemma garding_energyIntegrand_self_of_mass_lower_bound_of_bounds_on {Ω : Set X}
-    {a : X → Matrix n n ℝ} {b : X → EuclideanSpace ℝ n} {c : X → ℝ} (hlam : 0 < lam)
-    (hA : ∀ ⦃x⦄, x ∈ Ω → ∀ ξ : EuclideanSpace ℝ n,
-      lam * ‖ξ‖ ^ 2 ≤ (a x).toQuadraticForm' ξ)
-    (hb : ∀ ⦃x⦄, x ∈ Ω → ‖b x‖ ≤ beta)
-    (hc : ∀ ⦃x⦄, x ∈ Ω → mu ≤ c x) {x : X} (hx : x ∈ Ω)
-    (U : ℝ × EuclideanSpace ℝ n) :
-    lam / 2 * ‖U.2‖ ^ 2 + (mu - beta ^ 2 / (2 * lam)) * U.1 ^ 2
-      ≤ energyIntegrand (a x) (b x) (c x) U U :=
-  garding_energyIntegrand_self_of_mass_lower_bound_of_bounds hlam (hA hx) (hb hx) (hc hx) U
-
 /-- The mass-floor Gårding lower bound implies the explicit diagonal estimate with constant
 `min (λ / 2) (μ - β² / (2λ))`, assuming this second coefficient is nonnegative. -/
 lemma min_diagonal_lower_bound_mul_norm_sq_le_energyIntegrand_self (hlam : 0 < lam)
@@ -134,20 +121,6 @@ lemma min_diagonal_lower_bound_mul_norm_sq_le_energyIntegrand_self (hlam : 0 < l
   rw [Real.norm_eq_abs, sq_abs] at hnorm
   exact hnorm.trans
     (garding_energyIntegrand_self_of_mass_lower_bound_of_bounds hlam hA hb hc U)
-
-/-- Explicit diagonal lower bound on a domain, obtained by applying
-`min_diagonal_lower_bound_mul_norm_sq_le_energyIntegrand_self` at `x`. -/
-lemma min_diagonal_lower_bound_mul_norm_sq_le_energyIntegrand_self_on {Ω : Set X}
-    {a : X → Matrix n n ℝ} {b : X → EuclideanSpace ℝ n} {c : X → ℝ} (hlam : 0 < lam)
-    (hA : ∀ ⦃x⦄, x ∈ Ω → ∀ ξ : EuclideanSpace ℝ n,
-      lam * ‖ξ‖ ^ 2 ≤ (a x).toQuadraticForm' ξ)
-    (hb : ∀ ⦃x⦄, x ∈ Ω → ‖b x‖ ≤ beta)
-    (hc : ∀ ⦃x⦄, x ∈ Ω → mu ≤ c x) (hmu : beta ^ 2 / (2 * lam) ≤ mu)
-    {x : X} (hx : x ∈ Ω) (U : ℝ × EuclideanSpace ℝ n) :
-    min (lam / 2) (mu - beta ^ 2 / (2 * lam)) * ‖U‖ ^ 2
-      ≤ energyIntegrand (a x) (b x) (c x) U U :=
-  min_diagonal_lower_bound_mul_norm_sq_le_energyIntegrand_self hlam
-    (hA hx) (hb hx) (hc hx) hmu U
 
 /-- Zero-drift diagonal lower bound from a principal quadratic lower bound and nonnegative
 mass coefficient. -/

--- a/TauCeti/Analysis/PDE/EnergyLowerBounds.lean
+++ b/TauCeti/Analysis/PDE/EnergyLowerBounds.lean
@@ -24,10 +24,11 @@ inequality `∫ (min (λ/2) (μ − β²/2λ)) · ‖U‖² ≤ energyFormIntegr
 `TauCeti.Analysis.PDE.Integrated.EnergyForm`, obtained by integrating them; no
 finite-dimensional jet fibre is fed into Lax--Milgram.
 
-The ellipticity floor, the drift bound, and the mass lower bound are all stated inline, as
-`∀ x ∈ Ω, λ‖ξ‖² ≤ (a x).toQuadraticForm' ξ`, `∀ x ∈ Ω, ‖b x‖ ≤ β`, and `∀ x ∈ Ω, μ ≤ c x`; a
-caller holding a `UniformlyEllipticOn` hypothesis passes its lower-bound projection for the
-first.
+The lower-bound theorems below take a single principal coefficient `A`, drift coefficient
+`b₀`, and mass coefficient `c₀`, together with their pointwise bounds. Callers holding a
+field-level `UniformlyEllipticOn Ω a λ Λ` hypothesis should use the pointwise specializations
+in `TauCeti.Analysis.PDE.Uniform.EllipticEnergy`, which supply the principal lower bound at a
+chosen point `x ∈ Ω`.
 
 Symmetry of the same zero-drift integrand is recorded in
 `TauCeti.Analysis.PDE.SymmetricEnergy`.  Consumers that need the hypotheses side by side

--- a/TauCeti/Analysis/PDE/Uniform/EllipticEnergy.lean
+++ b/TauCeti/Analysis/PDE/Uniform/EllipticEnergy.lean
@@ -46,8 +46,6 @@ the same symmetry lemmas.
   drift defect.
 * `TauCeti.PDE.UniformlyEllipticOn.min_lam_mass_mul_norm_sq_le_energyIntegrand_zero_drift_self`:
   the zero-drift diagonal estimate from uniform ellipticity and nonnegative mass.
-* The corresponding `_on` lemmas apply these estimates to coefficient fields
-  `b : X → EuclideanSpace ℝ n` and `c : X → ℝ` on `Ω`.
 -/
 
 public section
@@ -79,16 +77,6 @@ grind_pattern norm_energyIntegrand_apply_le =>
   UniformlyEllipticOn Ω a lam Lam, x ∈ Ω, ‖b₀‖ ≤ beta, ‖c₀‖ ≤ gamma,
   energyIntegrand (a x) b₀ c₀ U V
 
-/-- Pointwise boundedness on a domain for coefficient fields, from uniform ellipticity of the
-principal coefficient and pointwise bounds on the drift and mass fields. -/
-lemma norm_energyIntegrand_apply_le_on (h : UniformlyEllipticOn Ω a lam Lam)
-    {b : X → EuclideanSpace ℝ n} {c : X → ℝ}
-    (hb : ∀ ⦃x⦄, x ∈ Ω → ‖b x‖ ≤ beta)
-    (hc : ∀ ⦃x⦄, x ∈ Ω → ‖c x‖ ≤ gamma) {x : X} (hx : x ∈ Ω)
-    (U V : ℝ × EuclideanSpace ℝ n) :
-    ‖energyIntegrand (a x) (b x) (c x) U V‖ ≤ (Lam + beta + gamma) * ‖U‖ * ‖V‖ :=
-  h.norm_energyIntegrand_apply_le hx (hb hx) (hc hx) U V
-
 /-- Operator-norm boundedness of the energy integrand from uniform ellipticity of the
 principal coefficient and pointwise bounds on the drift and mass coefficients. -/
 lemma opNorm_energyIntegrand_le (h : UniformlyEllipticOn Ω a lam Lam)
@@ -100,15 +88,6 @@ lemma opNorm_energyIntegrand_le (h : UniformlyEllipticOn Ω a lam Lam)
 grind_pattern opNorm_energyIntegrand_le =>
   UniformlyEllipticOn Ω a lam Lam, x ∈ Ω, ‖b₀‖ ≤ beta, ‖c₀‖ ≤ gamma,
   ‖energyIntegrand (a x) b₀ c₀‖
-
-/-- Operator-norm boundedness on a domain for coefficient fields, from uniform ellipticity of
-the principal coefficient and pointwise bounds on the drift and mass fields. -/
-lemma opNorm_energyIntegrand_le_on (h : UniformlyEllipticOn Ω a lam Lam)
-    {b : X → EuclideanSpace ℝ n} {c : X → ℝ}
-    (hb : ∀ ⦃x⦄, x ∈ Ω → ‖b x‖ ≤ beta)
-    (hc : ∀ ⦃x⦄, x ∈ Ω → ‖c x‖ ≤ gamma) {x : X} (hx : x ∈ Ω) :
-    ‖energyIntegrand (a x) (b x) (c x)‖ ≤ Lam + beta + gamma :=
-  h.opNorm_energyIntegrand_le hx (hb hx) (hc hx)
 
 /-- Pointwise Gårding inequality for a uniformly elliptic principal coefficient.
 
@@ -126,19 +105,6 @@ grind_pattern garding_energyIntegrand_self =>
   UniformlyEllipticOn Ω a lam Lam, x ∈ Ω, ‖b₀‖ ≤ beta, 0 ≤ c₀,
   energyIntegrand (a x) b₀ c₀ U U
 
-/-- Pointwise Gårding inequality on a domain for coefficient fields.
-
-With nonnegative mass field and drift bound `β`, the diagonal energy density at every
-`x ∈ Ω` is bounded below by `(λ/2)‖∇u‖² - (β²/2λ)|u|²`. -/
-lemma garding_energyIntegrand_self_on (h : UniformlyEllipticOn Ω a lam Lam)
-    {b : X → EuclideanSpace ℝ n} {c : X → ℝ}
-    (hb : ∀ ⦃x⦄, x ∈ Ω → ‖b x‖ ≤ beta)
-    (hc : ∀ ⦃x⦄, x ∈ Ω → 0 ≤ c x) {x : X} (hx : x ∈ Ω)
-    (U : ℝ × EuclideanSpace ℝ n) :
-    lam / 2 * ‖U.2‖ ^ 2 - beta ^ 2 / (2 * lam) * U.1 ^ 2
-      ≤ energyIntegrand (a x) (b x) (c x) U U :=
-  h.garding_energyIntegrand_self hx (hb hx) (hc hx) U
-
 /-- Pointwise Gårding lower bound with a mass floor for a uniformly elliptic principal
 coefficient.
 
@@ -154,18 +120,6 @@ lemma garding_energyIntegrand_self_of_mass_lower_bound (h : UniformlyEllipticOn 
 grind_pattern garding_energyIntegrand_self_of_mass_lower_bound =>
   UniformlyEllipticOn Ω a lam Lam, x ∈ Ω, ‖b₀‖ ≤ beta, mu ≤ c₀,
   energyIntegrand (a x) b₀ c₀ U U
-
-/-- Pointwise Gårding lower bound with a mass floor on a domain for coefficient fields,
-from uniform ellipticity of the principal coefficient. -/
-lemma garding_energyIntegrand_self_of_mass_lower_bound_on
-    (h : UniformlyEllipticOn Ω a lam Lam)
-    {b : X → EuclideanSpace ℝ n} {c : X → ℝ}
-    (hb : ∀ ⦃x⦄, x ∈ Ω → ‖b x‖ ≤ beta)
-    (hc : ∀ ⦃x⦄, x ∈ Ω → mu ≤ c x) {x : X} (hx : x ∈ Ω)
-    (U : ℝ × EuclideanSpace ℝ n) :
-    lam / 2 * ‖U.2‖ ^ 2 + (mu - beta ^ 2 / (2 * lam)) * U.1 ^ 2
-      ≤ energyIntegrand (a x) (b x) (c x) U U :=
-  h.garding_energyIntegrand_self_of_mass_lower_bound hx (hb hx) (hc hx) U
 
 /-- The lower-bound estimate implies the explicit diagonal estimate with constant
 `min (λ / 2) (μ - β² / (2λ))`, assuming this second coefficient is nonnegative. -/
@@ -183,19 +137,6 @@ grind_pattern min_diagonal_lower_bound_mul_norm_sq_le_energyIntegrand_self =>
   UniformlyEllipticOn Ω a lam Lam, x ∈ Ω, ‖b₀‖ ≤ beta, mu ≤ c₀,
   energyIntegrand (a x) b₀ c₀ U U
 
-/-- The coefficient-field version of the explicit diagonal lower-bound estimate from
-uniform ellipticity and a mass floor. -/
-lemma min_diagonal_lower_bound_mul_norm_sq_le_energyIntegrand_self_on
-    (h : UniformlyEllipticOn Ω a lam Lam)
-    {b : X → EuclideanSpace ℝ n} {c : X → ℝ}
-    (hb : ∀ ⦃x⦄, x ∈ Ω → ‖b x‖ ≤ beta)
-    (hc : ∀ ⦃x⦄, x ∈ Ω → mu ≤ c x)
-    (hmu : beta ^ 2 / (2 * lam) ≤ mu) {x : X} (hx : x ∈ Ω)
-    (U : ℝ × EuclideanSpace ℝ n) :
-    min (lam / 2) (mu - beta ^ 2 / (2 * lam)) * ‖U‖ ^ 2
-      ≤ energyIntegrand (a x) (b x) (c x) U U :=
-  h.min_diagonal_lower_bound_mul_norm_sq_le_energyIntegrand_self hx (hb hx) (hc hx) hmu U
-
 /-- Zero-drift diagonal lower bound for a uniformly elliptic principal coefficient and a
 nonnegative mass coefficient. -/
 lemma min_lam_mass_mul_norm_sq_le_energyIntegrand_zero_drift_self
@@ -208,15 +149,6 @@ lemma min_lam_mass_mul_norm_sq_le_energyIntegrand_zero_drift_self
 
 grind_pattern min_lam_mass_mul_norm_sq_le_energyIntegrand_zero_drift_self =>
   UniformlyEllipticOn Ω a lam Lam, x ∈ Ω, 0 ≤ c₀, energyIntegrand (a x) 0 c₀ U U
-
-/-- The coefficient-field version of the zero-drift diagonal lower bound from uniform
-ellipticity and nonnegative mass. -/
-lemma min_lam_mass_mul_norm_sq_le_energyIntegrand_zero_drift_self_on
-    (h : UniformlyEllipticOn Ω a lam Lam)
-    {c : X → ℝ} (hc : ∀ ⦃x⦄, x ∈ Ω → 0 ≤ c x) {x : X} (hx : x ∈ Ω)
-    (U : ℝ × EuclideanSpace ℝ n) :
-    min lam (c x) * ‖U‖ ^ 2 ≤ energyIntegrand (a x) 0 (c x) U U :=
-  h.min_lam_mass_mul_norm_sq_le_energyIntegrand_zero_drift_self hx (hc hx) U
 
 end UniformlyEllipticOn
 


### PR DESCRIPTION
## What

Delete the unused Level-3 coefficient-field `_on` energy-estimate wrappers that only evaluate `b x` / `c x` at `hx`. Retain the Level-1 raw `_of_bounds` / min_* engines and the Level-2 `UniformlyEllipticOn` pointwise specializations.

**Deleted (11):**
- `EnergyForm/Basic.lean`: `norm_energyIntegrand_apply_le_of_bounds_on`, `opNorm_energyIntegrand_le_of_bounds_on`, `garding_energyIntegrand_self_of_bounds_on`
- `EnergyLowerBounds.lean`: `garding_energyIntegrand_self_of_mass_lower_bound_of_bounds_on`, `min_diagonal_lower_bound_mul_norm_sq_le_energyIntegrand_self_on`
- `Uniform/EllipticEnergy.lean`: six `UniformlyEllipticOn.*_on` wrappers

Module docs that advertised the `_on` field wrappers were updated. No renames, no new decls, no deprecation aliases.

## Why

Partially addresses #793 (Task 2 remainder: wrapper collapse). These wrappers add no mathematical content beyond specializing already-stated pointwise engines at a domain point; callers can apply Level 1 / Level 2 directly. Task 3 (symmetric / integrated wrappers) is intentionally out of scope.

## Scope

- Exactly three files: `TauCeti/Analysis/PDE/EnergyForm/Basic.lean`, `EnergyLowerBounds.lean`, `Uniform/EllipticEnergy.lean`
- Diff: +3 / −133
- Does **not** touch `Integrated/EnergyForm`, `EnergyForm/Integrability`, `SymmetricEnergy`, or any human-owned path
- No `tauceti-target` / roadmap marker (deletion-only refactor of existing code)
- **Does not close #793**

## Verification

Targeted:
```
lake env lean TauCeti/Analysis/PDE/EnergyForm/Basic.lean
lake env lean TauCeti/Analysis/PDE/EnergyLowerBounds.lean
lake env lean TauCeti/Analysis/PDE/Uniform/EllipticEnergy.lean
lake env lean TauCeti/Analysis/PDE/EnergyForm/Integrability.lean
lake env lean TauCeti/Analysis/PDE/Integrated/EnergyForm.lean
```
All five exited 0.

Full gates (actual lines):
- `lake exe cache get`: `No files to download` / `Already decompressed 8639 file(s)`
- `lake build`: `Build completed successfully (5250 jobs).`
- `lake exe axioms`: `axioms: audited 11248 TauCeti declaration(s); all within the allowlist [propext, Classical.choice, Quot.sound].`
- `lake exe module-system`: `module-system: all 630 TauCeti module(s) opt into the module system.`
- `git diff --check`: clean
- Post-edit grep for all 11 deleted names: zero matches under `TauCeti/`
- `bash scripts/lint-env.sh` (Git Bash): docstring scan `894 scanned, 894 documented, 0 undocumented`; same 55 pre-existing unrelated linter reports as on `main` (none in the three touched PDE files)

BASE_SHA: `7bed92cec0676990638e16f2920a98505bdd61ef`

## AI disclosure

Prepared with Cursor (Composer / Auto).

Roadmap: PDE