### PR TITLE
chore: rename the Pages build job to build-site to avoid the required-status name

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -56,7 +56,11 @@ env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
 
 jobs:
-  build:
+  # Named `build-site`, not `build`, to keep every job name distinct from the required `build` commit
+  # status context (see pr-build.yml's header note on that collision). This workflow only runs on
+  # push-to-main / schedule, never on a PR, so its check-run can't wedge a PR today — the distinct name
+  # is hygiene so a future PR trigger here could never reintroduce the collision.
+  build-site:
     runs-on: ubuntu-latest
     defaults:
       run:
@@ -221,7 +225,7 @@ jobs:
           path: web/_out
 
   deploy:
-    needs: build
+    needs: build-site
     runs-on: ubuntu-latest
     environment:
       name: github-pages


### PR DESCRIPTION
This PR renames the Pages workflow's `build` job to `build-site` (updating `deploy`'s `needs`) so no job named `build` remains anywhere in the repo. A job named `build` auto-creates a check-run named `build`, which collides with the required `build` commit status context, the same collision [#1156](https://github.com/TauCetiProject/TauCeti/pull/1156) fixed in `pr-build.yml`. Pages runs only on push-to-main and the daily schedule, never on a PR, so its check-run cannot wedge a PR today; this is hygiene so a future PR trigger here could never reintroduce the collision.

Note this touches `.github/` so the scope check reports it out of scope and it needs a human merge; that is expected for a workflow change.

🤖 Prepared with Claude Code