### PR TITLE
refactor(DedekindDomain): extract the transported-prime ideal identity

### DIFF
--- a/TauCeti/NumberTheory/DedekindDomain/Transversal.lean
+++ b/TauCeti/NumberTheory/DedekindDomain/Transversal.lean
@@ -80,6 +80,16 @@ private theorem notMem_pair_of_apply_involutive {α : Type*} [DecidableEq α] {f
       _ = f (f p) := by rw [hqdef]
       _ = p := hinvolp
 
+omit [IsDedekindDomain R] in
+/-- Transporting a height-one prime along a ring equivalence `σ` maps its ideal to the image
+ideal: `(equivOfRingEquiv σ p).asIdeal = Ideal.map σ p.asIdeal`. -/
+private lemma asIdeal_equivOfRingEquiv (σ : R ≃+* R)
+    (p : IsDedekindDomain.HeightOneSpectrum R) :
+    (IsDedekindDomain.HeightOneSpectrum.equivOfRingEquiv σ p).asIdeal =
+      Ideal.map σ p.asIdeal := by
+  ext x
+  simp [IsDedekindDomain.HeightOneSpectrum.equivOfRingEquiv]
+
 /-- For a distinct prime `q ≠ p` and a family `G'` no member of which is divisible by `p.asIdeal`,
 multiplying `G'` by `p.asIdeal` and by `q.asIdeal` gives disjoint images. -/
 private theorem disjoint_image_mul_asIdeal {p q : IsDedekindDomain.HeightOneSpectrum R}
@@ -147,9 +157,7 @@ theorem exists_transversal_family (σ : R ≃+* R)
   have hqS : q ∈ S := hinv p hpS
   have hpq : q ≠ p := hfree p hpS
   have hqIdeal : q.asIdeal = Ideal.map σ p.asIdeal := by
-    rw [hqdef]
-    ext x
-    simp [IsDedekindDomain.HeightOneSpectrum.equivOfRingEquiv]
+    rw [hqdef]; exact asIdeal_equivOfRingEquiv σ p
   have hp0 : p.asIdeal ≠ ⊥ := p.ne_bot
   have hpair : ({p, q} : Finset (IsDedekindDomain.HeightOneSpectrum R)) ⊆ S := by
     intro x hx; rcases Finset.mem_insert.mp hx with rfl | hx
@@ -193,12 +201,7 @@ theorem exists_transversal_family (σ : R ≃+* R)
           two_pow_div_two_le_two_mul_two_pow_div_two_of_le_add_two (by omega)
       _ ≤ G'.card + G'.card := by omega
   · have hmapq : Ideal.map σ q.asIdeal = p.asIdeal := by
-      have hσq :
-          (IsDedekindDomain.HeightOneSpectrum.equivOfRingEquiv σ q).asIdeal =
-            Ideal.map σ q.asIdeal := by
-        ext x
-        simp [IsDedekindDomain.HeightOneSpectrum.equivOfRingEquiv]
-      rw [← hσq]
+      rw [← asIdeal_equivOfRingEquiv σ q]
       exact congr_arg IsDedekindDomain.HeightOneSpectrum.asIdeal (hinvol p hpS)
     exact fun A hA =>
       mul_map_eq_prod_of_mem_image_union (σ := (σ : R →+* R)) hqIdeal hmapq hprodS hprod' hA


### PR DESCRIPTION
`exists_transversal_family` proved the same fact twice inline — once for `p` (to get
`hqIdeal`) and once for `q` (inside `hmapq`) — each time by `ext x; simp [equivOfRingEquiv]`:

> transporting a height-one prime along a ring equivalence maps its ideal to the image ideal,
> `(equivOfRingEquiv σ p).asIdeal = Ideal.map σ p.asIdeal`.

This PR extracts that as `asIdeal_equivOfRingEquiv` and uses it at both sites. The lemma needs
only `CommRing R` — `[IsDedekindDomain R]` is `omit`ted.

**On the proof length.** This declaration was on my repo-wide list of proofs over 55 lines, so I
came to it expecting to decompose it. On reading, that turned out to be the wrong call: the file
is *already* well decomposed — the author extracted five private helpers
(`isPrime_not_dvd_prod`, `notMem_pair_of_apply_involutive`, `disjoint_image_mul_asIdeal`,
`two_pow_div_two_le_two_mul_two_pow_div_two_of_le_add_two`,
`mul_map_eq_prod_of_mem_image_union`) — and what remains is the strong-induction setup
(choosing the conjugate pair `p, q`, forming `S' = S \ {p, q}`, and re-establishing the four
hypotheses for the inductive call). Those steps are mutually dependent; extracting them would
mean a helper with seven hypotheses used once, which is worse than leaving them in place.

So this is the duplication fix only, not a forced decomposition.

Gates: `lake build` (5250 jobs) ✓, `lake exe axioms` (11254 decls, allowlist) ✓,
`lake exe module-system` (630 modules) ✓, `scripts/lint-env.sh` PASS ✓.
