### PR TITLE
fix: stop review-stuck alerting on an issue whose PR already finished

### DIFF
--- a/scripts/pr_status/stuck_alerts.py
+++ b/scripts/pr_status/stuck_alerts.py
@@ -25,8 +25,10 @@ Detectors (each names the infra failure it implies):
                      green for any pin change), `build` green, every blocking
                      rubric green at HEAD, not draft/hold, mergeable, and quiet for
                      the grace window. auto-merge / the queue / merge-sweep broke.
-  4. review-stuck    An open `Review stuck: PR #N` issue: the review engine
-                     self-flagged a PR it cannot resolve.
+  4. review-stuck    An open `Review stuck: PR #N` issue whose PR #N is also still
+                     open: the review engine self-flagged a PR it cannot resolve.
+                     An issue left open after its PR merged or closed is stale
+                     bookkeeping by the (out-of-repo) worker, not a live wedge.
   5. dead-scheduler  A scheduled workflow is missing, disabled, or its last
                      SCHEDULED run is older than its cadence + slack. GitHub
                      disabled the cron (60-day inactivity), or it errors at dispatch.
@@ -317,24 +319,57 @@ def detect_stranded_prs():
     return out
 
 
+REVIEW_STUCK_TITLE_RE = re.compile(r"Review stuck: PR #([0-9]+)")
+
+
+def flagged_pr_is_finished(number):
+    """True iff the PR the issue flagged is definitely merged or closed.
+
+    Any doubt (an API error, a number that is not a PR, an unexpected state) is
+    False, so the caller keeps alerting. Fail closed: a live wedge must never be
+    silenced by a lookup that did not work.
+    """
+    try:
+        return gh_scalar(f"/repos/{REPO}/pulls/{number}", jq='.state // ""') == "closed"
+    except Exception as exc:
+        zp.log(f"review-stuck: state of PR #{number} unreadable ({exc}); alerting anyway")
+        return False
+
+
 def detect_review_stuck():
     # Match the exact title grammar and interpolate NOTHING from the (untrusted)
     # title into the message: the alert renders a fixed title and links the issue
     # by its numeric id, so a crafted title cannot inject a marker or a mention.
+    # The flagged PR's number is recovered from that same grammar and re-checked
+    # here against a digits-only pattern before it reaches an API path.
     issues = gh_stream(
         f"/repos/{REPO}/issues?state=open&per_page=100",
         jq='.[] | select(.pull_request == null) '
-           '| select(.title | test("^Review stuck: PR #[0-9]+$")) | {number}')
-    return [{
-        "key": f"review-stuck/{i['number']}",
-        "title": "Review engine self-flagged a PR it cannot resolve",
-        "body": (
-            f"An open `Review stuck` issue is unresolved: "
-            f"https://github.com/{REPO}/issues/{i['number']}\n\n"
-            f"**Fix:** this is not a one-off review to nudge — the engine hit a state "
-            f"it has no rule for (a rubric contradiction, an error loop). Fix the "
-            f"review logic / rubric in TauCetiReview so it cannot re-wedge."),
-    } for i in issues]
+           '| select(.title | test("^Review stuck: PR #[0-9]+$")) | {number, title}')
+    out = []
+    for i in issues:
+        # The engine is wedged only while the PR it flagged is still open. The
+        # worker that files these issues closes them once their PR merges or is
+        # closed, but that self-close is out of this repo and has been observed to
+        # miss: issue #1137's PR #1134 merged 16 minutes later and the alert still
+        # fired for two days. An issue outliving its PR is stale bookkeeping, not
+        # an emergency, and the topic is worthless once it cries wolf.
+        m = REVIEW_STUCK_TITLE_RE.fullmatch(i.get("title") or "")
+        if m and flagged_pr_is_finished(m.group(1)):
+            zp.log(f"review-stuck: issue #{i['number']} names finished PR #{m.group(1)}; skipping")
+            continue
+        out.append({
+            "key": f"review-stuck/{i['number']}",
+            "title": "Review engine self-flagged a PR it cannot resolve",
+            "body": (
+                f"An open `Review stuck` issue is unresolved: "
+                f"https://github.com/{REPO}/issues/{i['number']}\n\n"
+                f"**Fix:** this is not a one-off review to nudge. The engine hit a "
+                f"state it has no rule for, e.g. a rubric contradiction or an error "
+                f"loop. Fix the review logic / rubric in TauCetiReview so it cannot "
+                f"re-wedge."),
+        })
+    return out
 
 
 def detect_dead_schedulers():

--- a/scripts/pr_status/test_stuck_alerts.py
+++ b/scripts/pr_status/test_stuck_alerts.py
@@ -125,6 +125,48 @@ class ReconcileTest(unittest.TestCase):
         self.assertEqual(z.updated, [])
 
 
+class ReviewStuckTest(unittest.TestCase):
+    """An issue outliving its PR must not alert; anything unreadable still must."""
+
+    ISSUES = '{"number": 1137, "title": "Review stuck: PR #1134"}\n'
+
+    def fake_gh(self, pr_state):
+        """Serve the issue list, then `pr_state` for the PR lookup (or raise)."""
+        def gh_api(path, jq=None, paginate=False):
+            if path.startswith("/repos/") and "/pulls/" in path:
+                if isinstance(pr_state, Exception):
+                    raise pr_state
+                return pr_state + "\n"
+            return self.ISSUES
+        self.addCleanup(setattr, core, "gh_api", core.gh_api)
+        core.gh_api = gh_api
+
+    def test_open_pr_alerts(self):
+        self.fake_gh("open")
+        self.assertEqual([a["key"] for a in sa.detect_review_stuck()],
+                         ["review-stuck/1137"])
+
+    def test_finished_pr_does_not_alert(self):
+        # The exact shape of issue #1137: its PR #1134 merged, the worker never
+        # closed the issue, and the alert fired for two days.
+        self.fake_gh("closed")
+        self.assertEqual(sa.detect_review_stuck(), [])
+
+    def test_unreadable_pr_state_still_alerts(self):
+        # Fail closed: an API blip must never silence a live wedge.
+        self.fake_gh(RuntimeError("gh api failed: 502"))
+        self.assertEqual([a["key"] for a in sa.detect_review_stuck()],
+                         ["review-stuck/1137"])
+
+    def test_alert_body_names_only_the_issue(self):
+        # The PR number reaches an API path and nothing else: no untrusted title
+        # text, and no PR reference, may enter the rendered message.
+        self.fake_gh("open")
+        body = sa.detect_review_stuck()[0]["body"]
+        self.assertIn("/issues/1137", body)
+        self.assertNotIn("1134", body)
+
+
 class MarkerSafetyTest(unittest.TestCase):
     def test_valid_trailing_marker_parses(self):
         self.assertEqual(sa.parse_marker(active_content("stale-fkb/917")), "stale-fkb/917")


### PR DESCRIPTION
This PR makes the `review-stuck` detector read the state of the PR an issue flagged, and skip the alert once that PR has merged or closed.

`Review stuck: PR #N` issues are filed by a worker outside this repo. The issue text promises "the worker re-checks each round and will close this issue's PR-side concern once #N merges or is closed", but that self-close is not something this repo controls and it has been observed to miss. https://github.com/TauCetiProject/TauCeti/issues/1137 flagged https://github.com/TauCetiProject/TauCeti/pull/1134, which merged sixteen minutes later; the issue stayed open and the alert stayed red for two days. An issue outliving its PR is stale bookkeeping, not a live wedge, and the emergency topic is worthless once it cries wolf.

The PR number is recovered from the same title grammar the detector already validates, and re-checked against a digits-only pattern before it reaches an API path. It is used for the lookup and nothing else: the rendered message is byte-identical in shape and still names only the issue, so the injection properties the original comment describes are preserved. A test asserts the flagged PR number never appears in the body.

An unreadable state fails closed and alerts, matching the module's rule that no API blip may silence a live emergency.

Two smaller things ride along. The `Fix:` line in this same body dropped its parenthetical example list for an "e.g.", finishing the sweep started in https://github.com/TauCetiProject/TauCeti/pull/1173 which missed this one; the lines were being rewritten anyway. And the docstring's detector entry now states the open-PR condition.

Noticed but deliberately not fixed here: the pre-existing `addCleanup` calls in `test_stuck_alerts.py` restore `core.gh_api` onto the `zulip` module rather than onto `core`, so those fakes are never actually torn down. The new tests set and restore `core.gh_api` correctly and do not depend on ordering, but that cleanup bug is worth its own PR.

🤖 Prepared with Claude Code