### PR TITLE
Publish platform-independent Lean artifacts

### DIFF
--- a/lakefile.toml
+++ b/lakefile.toml
@@ -1,5 +1,11 @@
 name = "TauCeti"
 defaultTargets = ["TauCeti"]
+# TauCeti is a pure Lean package: its cached module outputs (.olean/.ilean/Lean IR/generated C)
+# are reusable across platforms. This deliberately excludes native libraries and precompiled
+# modules; keep it in sync if either is ever added. The axiom audit rejects native_decide, one
+# source of host-dependent elaboration. Lake filters platform-dependent executable outputs from
+# the platform-independent mapping automatically.
+platformIndependent = true
 
 # mathlib's `rev` below stays on "master", never a pinned commit. The actual revision is
 # pinned in lake-manifest.json; "master" is only the branch the daily bump moves forward


### PR DESCRIPTION
## What changed

Mark the pure Lean Tau Ceti package as `platformIndependent` for Lake's built-in artifact cache, with a comment documenting the invariant.

## Why

The cache publisher currently runs on x86_64 Linux, so Lake stores the main-built Tau Ceti mapping under an x86_64 platform scope. Bubble uses aarch64 Linux on Apple-silicon Macs and therefore misses that mapping and recompiles the full library.

Package-level `platformIndependent = true` makes Lake omit the platform from the remote mapping scope and filters platform-dependent executable outputs. Tau Ceti's cached library outputs are Lean artifacts and generated C, so the same mapping can be restored on both architectures.

## Validation

- verified the current public cache succeeds for `x86_64-unknown-linux-gnu` and misses for `aarch64-unknown-linux-gnu`
- verified the package-level behavior against Lake's cache implementation and platform-independent cache tests
- confirmed the upload secret and public/private cache endpoint variables are configured in this repository

An independent Claude Opus review confirmed that package scope is correct and that Lake excludes platform-dependent executable outputs from these mappings.
