### PR TITLE
refactor(Bernstein): extract the kernel-coefficient and continuity facts

### DIFF
--- a/TauCeti/Analysis/CompletelyMonotone/Bernstein/Measures.lean
+++ b/TauCeti/Analysis/CompletelyMonotone/Bernstein/Measures.lean
@@ -849,24 +849,12 @@ private lemma chafai_kernel_density_eq (f : ℝ → ℝ)
 
 /-- For `k ≠ 0`, dividing by `k!` and multiplying by `k` is dividing by `(k - 1)!`. This is the
 coefficient bookkeeping produced by differentiating the order-`k` kernel. -/
-private lemma div_factorial_mul_cast {k : ℕ} (hk : k ≠ 0) (c z : ℝ) :
+private lemma div_factorial_mul_natCast {k : ℕ} (hk : k ≠ 0) (c z : ℝ) :
     c / ↑k.factorial * ((k : ℝ) * z) = c / ↑(k - 1).factorial * z := by
-  have hfact : k.factorial = k * (k - 1).factorial := by
-    cases k with
-    | zero => contradiction
-    | succ n => simp [Nat.factorial_succ]
+  have hfact : k.factorial = k * (k - 1).factorial := (Nat.mul_factorial_pred hk).symm
   rw [hfact]
   push_cast
   field_simp
-
-/-- Every iterated derivative within `[0, ∞)` of a completely monotone function is continuous on
-a compact interval `[x, T]` contained in `[0, ∞)`. -/
-private lemma continuousOn_iteratedDerivWithin_uIcc (f : ℝ → ℝ) (hcm : IsCompletelyMonotone f)
-    (m : ℕ) {x T : ℝ} (hx : 0 ≤ x) (hxT : x ≤ T) :
-    ContinuousOn (iteratedDerivWithin m f (Ici 0)) (uIcc x T) := by
-  rw [uIcc_of_le hxT]
-  exact (hcm.contDiffOn.continuousOn_iteratedDerivWithin (nat_le_top m)
-    (uniqueDiffOn_Ici 0)).mono (Icc_subset_Ici_self.trans (Ici_subset_Ici.mpr hx))
 
 private lemma ibp_finite_interval (f : ℝ → ℝ) (hcm : IsCompletelyMonotone f)
     (k : ℕ) (hk : k ≠ 0) (x T : ℝ) (hx : 0 ≤ x) (hxT : x < T) :
@@ -884,11 +872,11 @@ private lemma ibp_finite_interval (f : ℝ → ℝ) (hcm : IsCompletelyMonotone 
   have hu'_eq : ∀ t, u' t =
       (-1 : ℝ) ^ (k + 1) / ↑(k - 1).factorial * (t - x) ^ (k - 1) := fun t => by
     simp only [u', c]
-    exact div_factorial_mul_cast hk _ _
+    exact div_factorial_mul_natCast hk _ _
   have hu_cont : ContinuousOn u (uIcc x T) :=
     continuousOn_const.mul ((continuousOn_id.sub continuousOn_const).pow _)
   have hg_cont : ContinuousOn g (uIcc x T) :=
-    continuousOn_iteratedDerivWithin_uIcc f hcm k hx hxT.le
+    hcm.continuousOn_iteratedDerivWithin_uIcc k hx hxT.le
   have hu_deriv : ∀ t ∈ Ioo (min x T) (max x T),
       HasDerivWithinAt u (u' t) (Ioi t) t := by
     intro t _ht
@@ -905,7 +893,7 @@ private lemma ibp_finite_interval (f : ℝ → ℝ) (hcm : IsCompletelyMonotone 
     (continuousOn_const.mul (continuousOn_const.mul
       ((continuousOn_id.sub continuousOn_const).pow _))).intervalIntegrable
   have hg'_int : IntervalIntegrable g' volume x T :=
-    (continuousOn_iteratedDerivWithin_uIcc f hcm (k + 1) hx hxT.le).intervalIntegrable
+    (hcm.continuousOn_iteratedDerivWithin_uIcc (k + 1) hx hxT.le).intervalIntegrable
   have hibp := integral_mul_deriv_eq_deriv_mul_of_hasDeriv_right
     hu_cont hg_cont hu_deriv hg_deriv hu'_int hg'_int
   have hu0 : u x = 0 := by simp [u, sub_self, zero_pow hk]

--- a/TauCeti/Analysis/CompletelyMonotone/Bernstein/Measures.lean
+++ b/TauCeti/Analysis/CompletelyMonotone/Bernstein/Measures.lean
@@ -847,6 +847,27 @@ private lemma chafai_kernel_density_eq (f : ℝ → ℝ)
           iteratedDerivWithin n f (Ici 0) t := by ring
     _ = _ := by rw [key]
 
+/-- For `k ≠ 0`, dividing by `k!` and multiplying by `k` is dividing by `(k - 1)!`. This is the
+coefficient bookkeeping produced by differentiating the order-`k` kernel. -/
+private lemma div_factorial_mul_cast {k : ℕ} (hk : k ≠ 0) (c z : ℝ) :
+    c / ↑k.factorial * ((k : ℝ) * z) = c / ↑(k - 1).factorial * z := by
+  have hfact : k.factorial = k * (k - 1).factorial := by
+    cases k with
+    | zero => contradiction
+    | succ n => simp [Nat.factorial_succ]
+  rw [hfact]
+  push_cast
+  field_simp
+
+/-- Every iterated derivative within `[0, ∞)` of a completely monotone function is continuous on
+a compact interval `[x, T]` contained in `[0, ∞)`. -/
+private lemma continuousOn_iteratedDerivWithin_uIcc (f : ℝ → ℝ) (hcm : IsCompletelyMonotone f)
+    (m : ℕ) {x T : ℝ} (hx : 0 ≤ x) (hxT : x ≤ T) :
+    ContinuousOn (iteratedDerivWithin m f (Ici 0)) (uIcc x T) := by
+  rw [uIcc_of_le hxT]
+  exact (hcm.contDiffOn.continuousOn_iteratedDerivWithin (nat_le_top m)
+    (uniqueDiffOn_Ici 0)).mono (Icc_subset_Ici_self.trans (Ici_subset_Ici.mpr hx))
+
 private lemma ibp_finite_interval (f : ℝ → ℝ) (hcm : IsCompletelyMonotone f)
     (k : ℕ) (hk : k ≠ 0) (x T : ℝ) (hx : 0 ≤ x) (hxT : x < T) :
     ∫ t in x..T, (-1 : ℝ) ^ (k + 1) / ↑k.factorial * (t - x) ^ k *
@@ -861,23 +882,13 @@ private lemma ibp_finite_interval (f : ℝ → ℝ) (hcm : IsCompletelyMonotone 
   set u := fun t : ℝ => c * (t - x) ^ k
   set u' := fun t : ℝ => c * (↑k * (t - x) ^ (k - 1))
   have hu'_eq : ∀ t, u' t =
-      (-1 : ℝ) ^ (k + 1) / ↑(k - 1).factorial * (t - x) ^ (k - 1) := by
-    intro t
+      (-1 : ℝ) ^ (k + 1) / ↑(k - 1).factorial * (t - x) ^ (k - 1) := fun t => by
     simp only [u', c]
-    have hfact : k.factorial = k * (k - 1).factorial := by
-      cases k with
-      | zero => contradiction
-      | succ n => simp [Nat.factorial_succ]
-    rw [hfact]
-    push_cast
-    field_simp
+    exact div_factorial_mul_cast hk _ _
   have hu_cont : ContinuousOn u (uIcc x T) :=
     continuousOn_const.mul ((continuousOn_id.sub continuousOn_const).pow _)
-  have hg_cont : ContinuousOn g (uIcc x T) := by
-    rw [uIcc_of_le hxT.le]
-    exact (hcm.contDiffOn.continuousOn_iteratedDerivWithin (nat_le_top k)
-      (uniqueDiffOn_Ici 0)).mono
-        (Icc_subset_Ici_self.trans (Ici_subset_Ici.mpr hx))
+  have hg_cont : ContinuousOn g (uIcc x T) :=
+    continuousOn_iteratedDerivWithin_uIcc f hcm k hx hxT.le
   have hu_deriv : ∀ t ∈ Ioo (min x T) (max x T),
       HasDerivWithinAt u (u' t) (Ioi t) t := by
     intro t _ht
@@ -893,12 +904,8 @@ private lemma ibp_finite_interval (f : ℝ → ℝ) (hcm : IsCompletelyMonotone 
   have hu'_int : IntervalIntegrable u' volume x T :=
     (continuousOn_const.mul (continuousOn_const.mul
       ((continuousOn_id.sub continuousOn_const).pow _))).intervalIntegrable
-  have hg'_int : IntervalIntegrable g' volume x T := by
-    apply ContinuousOn.intervalIntegrable
-    rw [uIcc_of_le hxT.le]
-    exact (hcm.contDiffOn.continuousOn_iteratedDerivWithin (nat_le_top (k + 1))
-      (uniqueDiffOn_Ici 0)).mono
-        (Icc_subset_Ici_self.trans (Ici_subset_Ici.mpr hx))
+  have hg'_int : IntervalIntegrable g' volume x T :=
+    (continuousOn_iteratedDerivWithin_uIcc f hcm (k + 1) hx hxT.le).intervalIntegrable
   have hibp := integral_mul_deriv_eq_deriv_mul_of_hasDeriv_right
     hu_cont hg_cont hu_deriv hg_deriv hu'_int hg'_int
   have hu0 : u x = 0 := by simp [u, sub_self, zero_pow hk]

--- a/TauCeti/Analysis/CompletelyMonotone/Bernstein/Measures.lean
+++ b/TauCeti/Analysis/CompletelyMonotone/Bernstein/Measures.lean
@@ -876,7 +876,7 @@ private lemma ibp_finite_interval (f : ℝ → ℝ) (hcm : IsCompletelyMonotone 
   have hu_cont : ContinuousOn u (uIcc x T) :=
     continuousOn_const.mul ((continuousOn_id.sub continuousOn_const).pow _)
   have hg_cont : ContinuousOn g (uIcc x T) :=
-    hcm.continuousOn_iteratedDerivWithin_uIcc k hx hxT.le
+    hcm.continuousOn_iteratedDerivWithin_uIcc k hx (hx.trans hxT.le)
   have hu_deriv : ∀ t ∈ Ioo (min x T) (max x T),
       HasDerivWithinAt u (u' t) (Ioi t) t := by
     intro t _ht
@@ -893,7 +893,7 @@ private lemma ibp_finite_interval (f : ℝ → ℝ) (hcm : IsCompletelyMonotone 
     (continuousOn_const.mul (continuousOn_const.mul
       ((continuousOn_id.sub continuousOn_const).pow _))).intervalIntegrable
   have hg'_int : IntervalIntegrable g' volume x T :=
-    (hcm.continuousOn_iteratedDerivWithin_uIcc (k + 1) hx hxT.le).intervalIntegrable
+    (hcm.continuousOn_iteratedDerivWithin_uIcc (k + 1) hx (hx.trans hxT.le)).intervalIntegrable
   have hibp := integral_mul_deriv_eq_deriv_mul_of_hasDeriv_right
     hu_cont hg_cont hu_deriv hg_deriv hu'_int hg'_int
   have hu0 : u x = 0 := by simp [u, sub_self, zero_pow hk]

--- a/TauCeti/Analysis/CompletelyMonotone/Integral.lean
+++ b/TauCeti/Analysis/CompletelyMonotone/Integral.lean
@@ -23,6 +23,8 @@ for the first derivative within `[0, ∞)`.
 
 * `TauCeti.IsCompletelyMonotone.neg_one_pow_mul_taylor_remainder_nonneg`: the Taylor integral
   remainder has sign `(-1)ⁿ`.
+* `TauCeti.IsCompletelyMonotone.continuousOn_iteratedDerivWithin_uIcc`: every iterated derivative
+  within `[0, ∞)` is continuous on a compact interval `[x, T] ⊆ [0, ∞)`.
 * `TauCeti.IsCompletelyMonotone.integral_neg_iteratedDerivWithin_one_Ici_eq_sub`: on a compact
   interval in `[0, ∞)`, the integral of `-f'` is the endpoint drop `f x - f T`.
 * `TauCeti.IsCompletelyMonotone.neg_iteratedDerivWithin_one_integrableOn`,
@@ -105,6 +107,15 @@ private lemma IsCompletelyMonotone.iteratedDerivWithin_one_nonpos
     (hf : IsCompletelyMonotone f) {t : ℝ} (ht : 0 ≤ t) :
     iteratedDerivWithin 1 f (Ici 0) t ≤ 0 := by
   rw [iteratedDerivWithin_one]; exact hf.derivWithin_nonpos ht
+
+/-- Every iterated derivative within `[0, ∞)` of a completely monotone function is continuous on
+a compact interval `[x, T]` contained in `[0, ∞)`. -/
+lemma IsCompletelyMonotone.continuousOn_iteratedDerivWithin_uIcc (hcm : IsCompletelyMonotone f)
+    (m : ℕ) {x T : ℝ} (hx : 0 ≤ x) (hxT : x ≤ T) :
+    ContinuousOn (iteratedDerivWithin m f (Ici 0)) (uIcc x T) := by
+  rw [uIcc_of_le hxT]
+  exact (hcm.contDiffOn.continuousOn_iteratedDerivWithin (nat_le_top m)
+    (uniqueDiffOn_Ici 0)).mono (Icc_subset_Ici_self.trans (Ici_subset_Ici.mpr hx))
 
 /-- On a compact interval in `[0, ∞)`, the integral of `-f'` for a completely monotone
 function is the endpoint drop, with the derivative taken within `[0, ∞)`. -/

--- a/TauCeti/Analysis/CompletelyMonotone/Integral.lean
+++ b/TauCeti/Analysis/CompletelyMonotone/Integral.lean
@@ -109,13 +109,13 @@ private lemma IsCompletelyMonotone.iteratedDerivWithin_one_nonpos
   rw [iteratedDerivWithin_one]; exact hf.derivWithin_nonpos ht
 
 /-- Every iterated derivative within `[0, ∞)` of a completely monotone function is continuous on
-a compact interval `[x, T]` contained in `[0, ∞)`. -/
+the interval spanned by any two nonnegative endpoints. The endpoints need no ordering: `uIcc` is
+the unordered interval, and `[0, ∞)` is order-connected. -/
 lemma IsCompletelyMonotone.continuousOn_iteratedDerivWithin_uIcc (hcm : IsCompletelyMonotone f)
-    (m : ℕ) {x T : ℝ} (hx : 0 ≤ x) (hxT : x ≤ T) :
-    ContinuousOn (iteratedDerivWithin m f (Ici 0)) (uIcc x T) := by
-  rw [uIcc_of_le hxT]
-  exact (hcm.contDiffOn.continuousOn_iteratedDerivWithin (nat_le_top m)
-    (uniqueDiffOn_Ici 0)).mono (Icc_subset_Ici_self.trans (Ici_subset_Ici.mpr hx))
+    (m : ℕ) {x T : ℝ} (hx : 0 ≤ x) (hT : 0 ≤ T) :
+    ContinuousOn (iteratedDerivWithin m f (Ici 0)) (uIcc x T) :=
+  (hcm.contDiffOn.continuousOn_iteratedDerivWithin (nat_le_top m)
+    (uniqueDiffOn_Ici 0)).mono (ordConnected_Ici.uIcc_subset hx hT)
 
 /-- On a compact interval in `[0, ∞)`, the integral of `-f'` for a completely monotone
 function is the endpoint drop, with the derivative taken within `[0, ∞)`. -/


### PR DESCRIPTION
`ibp_finite_interval` carried two pieces that have nothing to do with integration by parts.

**1. The kernel-coefficient identity.** An 11-line factorial computation showing that
differentiating the order-`k` kernel turns `1 / k!` into `1 / (k - 1)!`. Extracted as:

```lean
private lemma div_factorial_mul_cast {k : ℕ} (hk : k ≠ 0) (c z : ℝ) :
    c / ↑k.factorial * ((k : ℝ) * z) = c / ↑(k - 1).factorial * z
```

Stated for an **arbitrary coefficient `c`** rather than the `(-1) ^ (k + 1)` that happened to
appear at the call site — the numerator plays no part in the identity, and carrying it would have
made the lemma look specific to this kernel when it is just factorial arithmetic. (`k ≠ 0` is
genuinely needed: at `k = 0`, ℕ-subtraction gives `(k-1)! = 0! = 1` and the two sides differ.)

**2. Continuity of the iterated derivatives.** `ContinuousOn (iteratedDerivWithin m f (Ici 0))
(uIcc x T)` was spelled out twice — once for `k`, once for `k + 1` — with identical five-line
proofs. Extracted as `continuousOn_iteratedDerivWithin_uIcc` and used at both sites, the second
through `.intervalIntegrable`.

What remains in `ibp_finite_interval` is the integration-by-parts argument proper: the `set`
definitions, the derivative witnesses, the application of
`integral_mul_deriv_eq_deriv_mul_of_hasDeriv_right`, and the two `integral_congr_ae` reshapes.

`ibp_finite_interval`: **66 → 52 lines of span** (proof body ~44, since the statement itself is
eight lines). No signature changes; the integration-by-parts argument is untouched.

Gates: `lake build` (5252 jobs) ✓, `lake exe axioms` (11266 decls, allowlist) ✓,
`lake exe module-system` (632 modules) ✓, `scripts/lint-env.sh` PASS ✓.
