### PR TITLE
refactor(Analysis/PDE): deduplicate integrated energy-form proofs

### DIFF
--- a/TauCeti/Analysis/PDE/Integrated/EnergyForm.lean
+++ b/TauCeti/Analysis/PDE/Integrated/EnergyForm.lean
@@ -292,7 +292,7 @@ lemma energyFormIntegral_principal_drift_mass
     _ = energyFormIntegral μ a (fun _ => 0) (fun _ => 0) U V +
           energyFormIntegral μ (fun _ => 0) b (fun _ => 0) U V +
             energyFormIntegral μ (fun _ => 0) (fun _ => 0) c U V := by
-      abel
+      rw [add_assoc]
 
 /-- The integrated full energy form is a shifted-Laplacian model plus the residual
 coefficient perturbation. -/

--- a/TauCeti/Analysis/PDE/Integrated/EnergyForm.lean
+++ b/TauCeti/Analysis/PDE/Integrated/EnergyForm.lean
@@ -106,42 +106,44 @@ lemma energyFormIntegral_zero_coefficients :
     energyFormIntegral μ (fun _ => 0) (fun _ => 0) (fun _ => 0) U V = 0 := by
   simp [energyFormIntegral_def]
 
+-- Pointwise equality of scalar integrands lifts to Bochner integrals (file-local only).
+private lemma integral_congr_forall {f g : X → ℝ} (h : ∀ x, f x = g x) :
+    ∫ x, f x ∂μ = ∫ x, g x ∂μ :=
+  integral_congr_ae (Filter.Eventually.of_forall h)
+
 /-- Negating the left jet field negates the integrated energy form. -/
 @[simp]
 lemma energyFormIntegral_neg_left :
     energyFormIntegral μ a b c (fun x => -U x) V = -energyFormIntegral μ a b c U V := by
-  rw [energyFormIntegral_def, energyFormIntegral_def]
-  have hpoint :
-      (fun x => energyIntegrand (a x) (b x) (c x) (-U x) (V x))
-        = fun x => -energyIntegrand (a x) (b x) (c x) (U x) (V x) := by
-    funext x
-    simp
-  rw [hpoint, MeasureTheory.integral_neg]
+  simp only [energyFormIntegral_def]
+  rw [integral_congr_forall (μ := μ)
+      (f := fun x => energyIntegrand (a x) (b x) (c x) (-U x) (V x))
+      (g := fun x => -energyIntegrand (a x) (b x) (c x) (U x) (V x))
+      (fun x => by simp),
+    MeasureTheory.integral_neg]
 
 /-- Negating the right jet field negates the integrated energy form. -/
 @[simp]
 lemma energyFormIntegral_neg_right :
     energyFormIntegral μ a b c U (fun x => -V x) = -energyFormIntegral μ a b c U V := by
-  rw [energyFormIntegral_def, energyFormIntegral_def]
-  have hpoint :
-      (fun x => energyIntegrand (a x) (b x) (c x) (U x) (-V x))
-        = fun x => -energyIntegrand (a x) (b x) (c x) (U x) (V x) := by
-    funext x
-    exact map_neg (energyIntegrand (a x) (b x) (c x) (U x)) (V x)
-  rw [hpoint, MeasureTheory.integral_neg]
+  simp only [energyFormIntegral_def]
+  rw [integral_congr_forall (μ := μ)
+      (f := fun x => energyIntegrand (a x) (b x) (c x) (U x) (-V x))
+      (g := fun x => -energyIntegrand (a x) (b x) (c x) (U x) (V x))
+      (fun x => map_neg (energyIntegrand (a x) (b x) (c x) (U x)) (V x)),
+    MeasureTheory.integral_neg]
 
 /-- Negating the coefficient triple negates the integrated energy form. -/
 @[simp]
 lemma energyFormIntegral_neg_coefficients :
     energyFormIntegral μ (fun x => -a x) (fun x => -b x) (fun x => -c x) U V =
       -energyFormIntegral μ a b c U V := by
-  rw [energyFormIntegral_def, energyFormIntegral_def]
-  have hpoint :
-      (fun x => energyIntegrand (-a x) (-b x) (-c x) (U x) (V x))
-        = fun x => -energyIntegrand (a x) (b x) (c x) (U x) (V x) := by
-    funext x
-    exact energyIntegrand_neg_apply (a x) (b x) (c x) (U x) (V x)
-  rw [hpoint, MeasureTheory.integral_neg]
+  simp only [energyFormIntegral_def]
+  rw [integral_congr_forall (μ := μ)
+      (f := fun x => energyIntegrand (-a x) (-b x) (-c x) (U x) (V x))
+      (g := fun x => -energyIntegrand (a x) (b x) (c x) (U x) (V x))
+      (fun x => by simp),
+    MeasureTheory.integral_neg]
 
 /-- Additivity in the left jet field, assuming the two summand energy densities are
 integrable. -/
@@ -150,15 +152,13 @@ lemma energyFormIntegral_add_left
     (hW : Integrable (fun x => energyIntegrand (a x) (b x) (c x) (W x) (V x)) μ) :
     energyFormIntegral μ a b c (fun x => U x + W x) V =
       energyFormIntegral μ a b c U V + energyFormIntegral μ a b c W V := by
-  rw [energyFormIntegral_def, energyFormIntegral_def, energyFormIntegral_def]
-  have hpoint :
-      (fun x => energyIntegrand (a x) (b x) (c x) (U x + W x) (V x))
-        = fun x => energyIntegrand (a x) (b x) (c x) (U x) (V x) +
-            energyIntegrand (a x) (b x) (c x) (W x) (V x) := by
-    funext x
-    simp
-  rw [hpoint]
-  exact integral_add hU hW
+  simp only [energyFormIntegral_def]
+  rw [integral_congr_forall (μ := μ)
+      (f := fun x => energyIntegrand (a x) (b x) (c x) (U x + W x) (V x))
+      (g := fun x => energyIntegrand (a x) (b x) (c x) (U x) (V x) +
+          energyIntegrand (a x) (b x) (c x) (W x) (V x))
+      (fun x => by simp),
+    integral_add hU hW]
 
 /-- Additivity in the right jet field, assuming the two summand energy densities are
 integrable. -/
@@ -167,42 +167,36 @@ lemma energyFormIntegral_add_right
     (hW : Integrable (fun x => energyIntegrand (a x) (b x) (c x) (U x) (W x)) μ) :
     energyFormIntegral μ a b c U (fun x => V x + W x) =
       energyFormIntegral μ a b c U V + energyFormIntegral μ a b c U W := by
-  rw [energyFormIntegral_def, energyFormIntegral_def, energyFormIntegral_def]
-  have hpoint :
-      (fun x => energyIntegrand (a x) (b x) (c x) (U x) (V x + W x))
-        = fun x => energyIntegrand (a x) (b x) (c x) (U x) (V x) +
-            energyIntegrand (a x) (b x) (c x) (U x) (W x) := by
-    funext x
-    exact map_add (energyIntegrand (a x) (b x) (c x) (U x)) (V x) (W x)
-  rw [hpoint]
-  exact integral_add hV hW
+  simp only [energyFormIntegral_def]
+  rw [integral_congr_forall (μ := μ)
+      (f := fun x => energyIntegrand (a x) (b x) (c x) (U x) (V x + W x))
+      (g := fun x => energyIntegrand (a x) (b x) (c x) (U x) (V x) +
+          energyIntegrand (a x) (b x) (c x) (U x) (W x))
+      (fun x => map_add (energyIntegrand (a x) (b x) (c x) (U x)) (V x) (W x)),
+    integral_add hV hW]
 
 /-- Homogeneity in the left jet field. -/
 lemma energyFormIntegral_smul_left (r : ℝ) :
     energyFormIntegral μ a b c (fun x => r • U x) V =
       r * energyFormIntegral μ a b c U V := by
-  rw [energyFormIntegral_def, energyFormIntegral_def]
-  have hpoint :
-      (fun x => energyIntegrand (a x) (b x) (c x) (r • U x) (V x))
-        = fun x => r • energyIntegrand (a x) (b x) (c x) (U x) (V x) := by
-    funext x
-    simp
-  rw [hpoint]
-  rw [MeasureTheory.integral_smul]
+  simp only [energyFormIntegral_def]
+  rw [integral_congr_forall (μ := μ)
+      (f := fun x => energyIntegrand (a x) (b x) (c x) (r • U x) (V x))
+      (g := fun x => r • energyIntegrand (a x) (b x) (c x) (U x) (V x))
+      (fun x => by simp),
+    MeasureTheory.integral_smul]
   simp [smul_eq_mul]
 
 /-- Homogeneity in the right jet field. -/
 lemma energyFormIntegral_smul_right (r : ℝ) :
     energyFormIntegral μ a b c U (fun x => r • V x) =
       r * energyFormIntegral μ a b c U V := by
-  rw [energyFormIntegral_def, energyFormIntegral_def]
-  have hpoint :
-      (fun x => energyIntegrand (a x) (b x) (c x) (U x) (r • V x))
-        = fun x => r • energyIntegrand (a x) (b x) (c x) (U x) (V x) := by
-    funext x
-    simp
-  rw [hpoint]
-  rw [MeasureTheory.integral_smul]
+  simp only [energyFormIntegral_def]
+  rw [integral_congr_forall (μ := μ)
+      (f := fun x => energyIntegrand (a x) (b x) (c x) (U x) (r • V x))
+      (g := fun x => r • energyIntegrand (a x) (b x) (c x) (U x) (V x))
+      (fun x => by simp),
+    MeasureTheory.integral_smul]
   simp [smul_eq_mul]
 
 variable (a' : X → Matrix n n ℝ) (b' : X → EuclideanSpace ℝ n) (c' : X → ℝ)
@@ -216,15 +210,13 @@ lemma energyFormIntegral_add
     energyFormIntegral μ (fun x => a x + a' x) (fun x => b x + b' x) (fun x => c x + c' x)
         U V =
       energyFormIntegral μ a b c U V + energyFormIntegral μ a' b' c' U V := by
-  rw [energyFormIntegral_def, energyFormIntegral_def, energyFormIntegral_def]
-  have hpoint :
-      (fun x => energyIntegrand (a x + a' x) (b x + b' x) (c x + c' x) (U x) (V x))
-        = fun x => energyIntegrand (a x) (b x) (c x) (U x) (V x) +
-            energyIntegrand (a' x) (b' x) (c' x) (U x) (V x) := by
-    funext x
-    exact energyIntegrand_add_apply (a x) (a' x) (b x) (b' x) (c x) (c' x) (U x) (V x)
-  rw [hpoint]
-  exact integral_add h h'
+  simp only [energyFormIntegral_def]
+  rw [integral_congr_forall (μ := μ)
+      (f := fun x => energyIntegrand (a x + a' x) (b x + b' x) (c x + c' x) (U x) (V x))
+      (g := fun x => energyIntegrand (a x) (b x) (c x) (U x) (V x) +
+          energyIntegrand (a' x) (b' x) (c' x) (U x) (V x))
+      (fun x => by simp),
+    integral_add h h']
 
 /-- The integrated energy form is subtractive in the coefficient triple, under the
 corresponding integrability assumptions for the two densities. -/
@@ -234,28 +226,24 @@ lemma energyFormIntegral_sub
     energyFormIntegral μ (fun x => a x - a' x) (fun x => b x - b' x) (fun x => c x - c' x)
         U V =
       energyFormIntegral μ a b c U V - energyFormIntegral μ a' b' c' U V := by
-  rw [energyFormIntegral_def, energyFormIntegral_def, energyFormIntegral_def]
-  have hpoint :
-      (fun x => energyIntegrand (a x - a' x) (b x - b' x) (c x - c' x) (U x) (V x))
-        = fun x => energyIntegrand (a x) (b x) (c x) (U x) (V x) -
-            energyIntegrand (a' x) (b' x) (c' x) (U x) (V x) := by
-    funext x
-    exact energyIntegrand_sub_apply (a x) (a' x) (b x) (b' x) (c x) (c' x) (U x) (V x)
-  rw [hpoint]
-  exact integral_sub h h'
+  simp only [energyFormIntegral_def]
+  rw [integral_congr_forall (μ := μ)
+      (f := fun x => energyIntegrand (a x - a' x) (b x - b' x) (c x - c' x) (U x) (V x))
+      (g := fun x => energyIntegrand (a x) (b x) (c x) (U x) (V x) -
+          energyIntegrand (a' x) (b' x) (c' x) (U x) (V x))
+      (fun x => by simp),
+    integral_sub h h']
 
 /-- The integrated energy form is homogeneous in the coefficient triple. -/
 lemma energyFormIntegral_smul :
     energyFormIntegral μ (fun x => r • a x) (fun x => r • b x) (fun x => r * c x) U V =
       r * energyFormIntegral μ a b c U V := by
-  rw [energyFormIntegral_def, energyFormIntegral_def]
-  have hpoint :
-      (fun x => energyIntegrand (r • a x) (r • b x) (r * c x) (U x) (V x))
-        = fun x => r • energyIntegrand (a x) (b x) (c x) (U x) (V x) := by
-    funext x
-    simp
-  rw [hpoint]
-  rw [MeasureTheory.integral_smul]
+  simp only [energyFormIntegral_def]
+  rw [integral_congr_forall (μ := μ)
+      (f := fun x => energyIntegrand (r • a x) (r • b x) (r * c x) (U x) (V x))
+      (g := fun x => r • energyIntegrand (a x) (b x) (c x) (U x) (V x))
+      (fun x => by simp),
+    MeasureTheory.integral_smul]
   simp [smul_eq_mul]
 
 /-- The integrated full energy form splits into its principal and lower-order parts. -/
@@ -278,21 +266,12 @@ lemma energyFormIntegral_principal_drift_mass
       energyFormIntegral μ a (fun _ => 0) (fun _ => 0) U V +
         energyFormIntegral μ (fun _ => 0) b (fun _ => 0) U V +
           energyFormIntegral μ (fun _ => 0) (fun _ => 0) c U V := by
+  -- Integrability of the combined lower-order density from drift + mass.
   have hlower :
       Integrable (fun x => energyIntegrand 0 (b x) (c x) (U x) (V x)) μ := by
-    have hpoint :
-        (fun x => energyIntegrand 0 (b x) (c x) (U x) (V x))
-          = fun x => energyIntegrand 0 (b x) 0 (U x) (V x) +
-              energyIntegrand 0 0 (c x) (U x) (V x) := by
-      funext x
-      conv_lhs =>
-        rw [← zero_add (0 : Matrix n n ℝ), ← add_zero (b x), ← zero_add (c x)]
-      exact energyIntegrand_add_apply (0 : Matrix n n ℝ) 0 (b x) 0 0 (c x) (U x) (V x)
-    have hsum : Integrable
-        (fun x => energyIntegrand 0 (b x) 0 (U x) (V x) +
-          energyIntegrand 0 0 (c x) (U x) (V x)) μ := by
-      exact (hdrift.add hmass).congr (Filter.Eventually.of_forall fun _ => rfl)
-    exact hsum.congr (Filter.Eventually.of_forall fun x => congrFun hpoint.symm x)
+    refine (hdrift.add hmass).congr (Filter.Eventually.of_forall fun x => ?_)
+    simp [Pi.add_apply]
+  -- Lower-order additivity: drift + mass.
   have hlower_eq :
       energyFormIntegral μ (fun _ => 0) b c U V =
         energyFormIntegral μ (fun _ => 0) b (fun _ => 0) U V +
@@ -300,6 +279,7 @@ lemma energyFormIntegral_principal_drift_mass
     simpa using
       energyFormIntegral_add μ (fun _ => 0) b (fun _ => 0) U V
         (fun _ => 0) (fun _ => 0) c hdrift hmass
+  -- Principal + lower-order, then algebra.
   calc
     energyFormIntegral μ a b c U V =
         energyFormIntegral μ a (fun _ => 0) (fun _ => 0) U V +
@@ -312,7 +292,7 @@ lemma energyFormIntegral_principal_drift_mass
     _ = energyFormIntegral μ a (fun _ => 0) (fun _ => 0) U V +
           energyFormIntegral μ (fun _ => 0) b (fun _ => 0) U V +
             energyFormIntegral μ (fun _ => 0) (fun _ => 0) c U V := by
-      rw [add_assoc]
+      abel
 
 /-- The integrated full energy form is a shifted-Laplacian model plus the residual
 coefficient perturbation. -/
@@ -324,21 +304,14 @@ lemma energyFormIntegral_eq_one_zero_baseMass_add_perturbation
     energyFormIntegral μ a b c U V =
       energyFormIntegral μ (fun _ => (1 : Matrix n n ℝ)) (fun _ => 0) m U V +
         energyFormIntegral μ (fun x => a x - 1) b (fun x => c x - m x) U V := by
-  rw [energyFormIntegral_def, energyFormIntegral_def, energyFormIntegral_def]
-  have hpoint :
-      (fun x => energyIntegrand (a x) (b x) (c x) (U x) (V x))
-        = fun x => energyIntegrand (1 : Matrix n n ℝ) 0 (m x) (U x) (V x) +
-            energyIntegrand (a x - 1) (b x) (c x - m x) (U x) (V x) := by
-    funext x
-    exact energyIntegrand_eq_one_zero_baseMass_add_perturbation_apply
-      (a x) (b x) (c x) (m x) (U x) (V x)
-  -- After unfolding all three forms, expose the left integrand as a function application so
-  -- the pointwise function equality `hpoint` rewrites the integral before `integral_add`.
-  change ∫ x, (fun x => energyIntegrand (a x) (b x) (c x) (U x) (V x)) x ∂μ =
-      energyFormIntegral μ (fun _ => (1 : Matrix n n ℝ)) (fun _ => 0) m U V +
-        energyFormIntegral μ (fun x => a x - 1) b (fun x => c x - m x) U V
-  rw [hpoint]
-  exact integral_add hmodel hpert
+  simp only [energyFormIntegral_def]
+  rw [integral_congr_forall (μ := μ)
+      (f := fun x => energyIntegrand (a x) (b x) (c x) (U x) (V x))
+      (g := fun x => energyIntegrand (1 : Matrix n n ℝ) 0 (m x) (U x) (V x) +
+          energyIntegrand (a x - 1) (b x) (c x - m x) (U x) (V x))
+      (fun x => energyIntegrand_eq_one_zero_baseMass_add_perturbation_apply
+        (a x) (b x) (c x) (m x) (U x) (V x)),
+    integral_add hmodel hpert]
 
 /-- The integrated full energy form is the shifted-Laplacian form with the same mass plus the
 principal-and-drift perturbation. -/


### PR DESCRIPTION
## Summary

- Proof-only cleanup of `TauCeti/Analysis/PDE/Integrated/EnergyForm.lean`: remove repetitive integral-lifting scaffolding (`funext` / named `hpoint` / rewrite / `integral_*`) from the integrated-linearity family.
- **All public integrated theorems remain** with unchanged names, signatures, attributes, and integrability / a.e. hypotheses. No public declarations added or removed. No changes to `EnergyForm/Linearity.lean`, SymmetricEnergy, or Task 3C.
- Direct `simpa [energyFormIntegral_def] using integral_*` over-unfolded `energyIntegrand` and was unstable. The chosen pattern is `simp only [energyFormIntegral_def]` plus one **private** local helper `integral_congr_forall` (scalar integrand equality → Bochner integral equality; PDE-independent; not in the module doc) followed by `integral_add` / `integral_sub` / `integral_neg` / `integral_smul`.
- Integrable hypotheses and a.e. interfaces stay because they are part of the public API contract for Bochner linearity; this PR only shortens proofs.

### Proofs rewritten

- High-confidence: `energyFormIntegral_neg_left`, `neg_right`, `neg_coefficients`, `add_left`, `add_right`, `smul_left`, `smul_right`, `add`, `sub`, `smul`
- Medium: `energyFormIntegral_principal_drift_mass` (kept visible phases: lower-order integrability, lower-order add, principal_add_lowerOrder, algebra via `abel`)
- Consumer-sensitive: `energyFormIntegral_eq_one_zero_baseMass_add_perturbation` (same helper + `integral_add`; retained `_apply` pointwise lemma)

`principal_add_lowerOrder` unchanged (already a thin `simpa` wrapper).

### Diff

- 1 file: `TauCeti/Analysis/PDE/Integrated/EnergyForm.lean` (+83 / −110)
- Private helper used: yes (`integral_congr_forall`)
- BASE: `0d562b3c4c5424a60cf77fc755a08536bb73d776`
- HEAD: `2e89a79a38b9321cb8b974388350ab0a40faf9e5`
- Pre-edit blob `EnergyForm.lean`: `7b1f411287f79d784a2dddc6f69febe84ba4ac56` (matched audit)

### Scope

- Task 3C (symmetry interface triage) is **out of scope**.
- Partially addresses #793
- This PR does **not** close #793 (do not use Closes/Fixes/Resolves).

### Validation (actual)

```
lake env lean TauCeti/Analysis/PDE/Integrated/EnergyForm.lean
# exit 0

lake env lean TauCeti/Analysis/PDE/Integrated/SymmetricEnergy.lean
# exit 0

lake env lean TauCeti/Analysis/PDE/ShiftedLaplacianEnergy.lean
# exit 0 (direct importer)

lake exe cache get
# Already decompressed 8639 file(s)

lake build
# Build completed successfully (5256 jobs).

lake exe axioms
# axioms: audited 11292 TauCeti declaration(s); all within the allowlist [propext, Classical.choice, Quot.sound].

lake exe module-system
# module-system: all 634 TauCeti module(s) opt into the module system.

git diff --check
# clean

git diff --stat
# TauCeti/Analysis/PDE/Integrated/EnergyForm.lean | 193 ++++++++++--------------
# 1 file changed, 83 insertions(+), 110 deletions(-)
```

`bash scripts/lint-env.sh`: docstring scan passed (897/897). Driver reported pre-existing simpNF/checkType findings in unrelated modules (Comodule, HopfIdeal, etc.); **none** mention `Integrated/EnergyForm`. Same class of baseline noise expected on CI for this pin.

### AI disclosure

Authored with Cursor / Composer assistance.

## Test plan

- [ ] CI green on this PR
- [ ] Confirm diff is proof bodies + one private helper only
- [ ] Confirm no public API / signature / attribute changes
- [ ] Rubric review after CI

Roadmap: PDE