### PR TITLE
refactor(Analysis/PDE): remove redundant symmetry specializations

### DIFF
--- a/TauCeti/Analysis/PDE/SymmetricEnergy.lean
+++ b/TauCeti/Analysis/PDE/SymmetricEnergy.lean
@@ -89,13 +89,6 @@ lemma energyIntegrand_zero_drift_flip_eq_of_isSymm {A : Matrix n n ℝ} (hA : A.
   intro V
   exact energyIntegrand_zero_drift_comm_of_isSymm hA c V U
 
-/-- The identity principal coefficient gives a symmetric zero-drift jet form. -/
-lemma energyIntegrand_one_zero_drift_comm (c : ℝ)
-    (U V : ℝ × EuclideanSpace ℝ n) :
-    energyIntegrand (1 : Matrix n n ℝ) 0 c U V =
-      energyIntegrand (1 : Matrix n n ℝ) 0 c V U :=
-  energyIntegrand_zero_drift_comm_of_isSymm isSymm_one c U V
-
 /-- The symmetric part's zero-drift jet form is the average of the original form and its
 transpose. -/
 lemma energyIntegrand_coefficientSymmetricPart_zero_drift_apply (A : Matrix n n ℝ)
@@ -115,13 +108,6 @@ lemma energyIntegrand_coefficientSymmetricPart_self (A : Matrix n n ℝ)
       energyIntegrand A b c U U := by
   classical
   rw [energyIntegrand_self, energyIntegrand_self, toQuadraticForm'_coefficientSymmetricPart]
-
-/-- The symmetric part always gives a symmetric zero-drift jet form. -/
-lemma energyIntegrand_coefficientSymmetricPart_zero_drift_comm (A : Matrix n n ℝ)
-    (c : ℝ) (U V : ℝ × EuclideanSpace ℝ n) :
-    energyIntegrand (coefficientSymmetricPart A) 0 c U V =
-      energyIntegrand (coefficientSymmetricPart A) 0 c V U :=
-  energyIntegrand_zero_drift_comm_of_isSymm (coefficientSymmetricPart_isSymm A) c U V
 
 /-- Bundled-map form of symmetry for the symmetric-part zero-drift jet integrand. -/
 @[simp]


### PR DESCRIPTION
## What
Delete two unused pointwise symmetry specializations from `TauCeti/Analysis/PDE/SymmetricEnergy.lean`:
- `energyIntegrand_one_zero_drift_comm`
- `energyIntegrand_coefficientSymmetricPart_zero_drift_comm`

## Why
Both are one-line wrappers of `energyIntegrand_zero_drift_comm_of_isSymm` with `isSymm_one` / `coefficientSymmetricPart_isSymm`. Pre-edit search found no external consumers (defs only). Mechanical cleanup slice of Task 3C.

## Scope
- One file: `TauCeti/Analysis/PDE/SymmetricEnergy.lean`
- Diff: 0 insertions / 14 deletions
- Does **not** touch `Integrated/SymmetricEnergy.lean`, Main declarations list, deferred APIs, or add aliases / 3B-style helpers
- Does **not** close #793

## Replacement
Callers should use (already present):
- `energyIntegrand_zero_drift_comm_of_isSymm`
- with `isSymm_one` or `coefficientSymmetricPart_isSymm` as appropriate

Kept: `zero_drift_transpose_apply`, `zero_drift_comm_of_isSymm`, `zero_drift_flip_eq_of_isSymm`, CSP apply/self/flip_eq, `_comm_on`, `_flip_eq_on`, `one_zero_mass_flip_eq`.

## Verification (actual)
- Pre-edit consumer `rg`: exactly 2 matches, both defs in `SymmetricEnergy.lean`; no external consumers
- Post-edit consumer `rg`: empty
- `lake env lean` OK for:
  - `TauCeti/Analysis/PDE/SymmetricEnergy.lean`
  - `TauCeti/Analysis/PDE/Integrated/SymmetricEnergy.lean`
  - `TauCeti/Analysis/PDE/EnergyForm/Lp.lean`
  - `TauCeti/Analysis/PDE/EnergyForm/VariableLp.lean`
  (all direct importers of `TauCeti.Analysis.PDE.SymmetricEnergy`)
- `lake build`: completed successfully (5346 jobs)
- `lake exe axioms`: audited 11425 TauCeti declaration(s); all within allowlist
- `lake exe module-system`: all 637 TauCeti module(s) opt into the module system
- `git diff --check`: clean
- Local `scripts/lint-env.sh`: FAIL with 55 "new" violations unrelated to this diff (no SymmetricEnergy hits); docstring scan 917/917 documented; baseline ratchet reported 57 stale entries. Treat as local baseline/env drift — CI is authoritative.

Partially addresses #793 (Task 3C mechanical deletion slice only; deferred APIs remain out of scope).

Roadmap: PDE