### PR TITLE
feat(MeasureTheory): joint-kernel measurability for the conditional common ending

### DIFF
--- a/TauCeti/MeasureTheory/Measure/ProductKernel.lean
+++ b/TauCeti/MeasureTheory/Measure/ProductKernel.lean
@@ -5,8 +5,6 @@ Released under Apache 2.0 license as described in the file LICENSE.
 module
 
 public import Mathlib.MeasureTheory.Measure.FiniteMeasurePi
--- Public: `Measure.prod` appears in the joint-kernel statement.
-public import Mathlib.MeasureTheory.Measure.Prod
 
 /-!
 # Finite product probability-measure kernels
@@ -128,13 +126,10 @@ This is the joint-space companion of `measurable_probabilityMeasure_pi_const_toM
 one gives the block kernel alone, this one pairs it with a Dirac mass at the mixing measure itself,
 which is what a conditional (joint-law) reading of the de Finetti mixture identity has to speak
 about. It supplies the `Measure.bind_apply` and measure-extensionality inputs on the joint space
-(`TauCetiRoadmap/Exchangeability/README.md`, Layer 1). No hypotheses beyond measurability of `ν`.
-
-The product step is Mathlib's `ProbabilityMeasure.measurable_fun_prod` (the monoidal product is
-measurable); all this adds is that both components are measurable in `ω`. Both have to be presented
-as `ProbabilityMeasure`-valued to apply it, so the Dirac side is bundled through
-`Measure.measurable_dirac` and `Measurable.subtype_mk`, and the block side through
-`measurable_probabilityMeasure_pi`. -/
+(`TauCetiRoadmap/Exchangeability/README.md`, Layer 1). No hypotheses beyond measurability of `ν`. -/
+-- The product step is Mathlib's `ProbabilityMeasure.measurable_fun_prod`; all this adds is that
+-- both components are measurable in `ω`. Applying it needs both presented as
+-- `ProbabilityMeasure`-valued, hence the `subtype_mk` bundling of the Dirac side.
 @[fun_prop]
 theorem measurable_dirac_prod_probabilityMeasure_pi_const_toMeasure {α : Type*}
     [MeasurableSpace α] {m : ℕ} (ν : Ω → ProbabilityMeasure α) (hν : Measurable ν) :

--- a/TauCeti/MeasureTheory/Measure/ProductKernel.lean
+++ b/TauCeti/MeasureTheory/Measure/ProductKernel.lean
@@ -5,6 +5,8 @@ Released under Apache 2.0 license as described in the file LICENSE.
 module
 
 public import Mathlib.MeasureTheory.Measure.FiniteMeasurePi
+-- Public: `Measure.prod` appears in the joint-kernel statement.
+public import Mathlib.MeasureTheory.Measure.Prod
 
 /-!
 # Finite product probability-measure kernels
@@ -26,6 +28,10 @@ Measurability:
 * the constant-coordinate (`fun _ : Fin m => ν ω`) specializations
   `measurable_probabilityMeasure_pi_const_toMeasure` and
   `aemeasurable_probabilityMeasure_pi_const_toMeasure`.
+* `measurable_dirac_prod_probabilityMeasure_pi_const_toMeasure` — the **joint** kernel
+  `ω ↦ δ_{ν ω} ⊗ (ν ω)^{⊗ Fin m}`, pairing the block kernel with a Dirac mass at the mixing
+  measure. This is the joint-space input a conditional (joint-law) reading of the mixture
+  identity needs, as opposed to the block kernel alone.
 
 Bind-evaluation of the mixture `μ.bind fun ω => (ProbabilityMeasure.pi fun i => ν i ω).toMeasure`:
 * `bind_probabilityMeasure_pi_apply` — evaluation on a measurable set as the integral of the product
@@ -114,6 +120,32 @@ theorem aemeasurable_probabilityMeasure_pi_const_toMeasure {α : Type*} [Measura
     (ν : Ω → ProbabilityMeasure α) (hν : AEMeasurable ν μ) :
     AEMeasurable (fun ω => (ProbabilityMeasure.pi fun _ : Fin m => ν ω).toMeasure) μ :=
   aemeasurable_probabilityMeasure_pi_toMeasure (fun _ => ν) (fun _ => hν)
+
+/-- **Joint-kernel measurability.** The random measure
+`ω ↦ δ_{ν ω} ⊗ (ν ω)^{⊗ Fin m}` on `ProbabilityMeasure α × (Fin m → α)` is measurable.
+
+This is the joint-space companion of `measurable_probabilityMeasure_pi_const_toMeasure`: where that
+one gives the block kernel alone, this one pairs it with a Dirac mass at the mixing measure itself,
+which is what a conditional (joint-law) reading of the de Finetti mixture identity has to speak
+about. It supplies the `Measure.bind_apply` and measure-extensionality inputs on the joint space
+(`TauCetiRoadmap/Exchangeability/README.md`, Layer 1). No hypotheses beyond measurability of `ν`.
+
+The product step is Mathlib's `ProbabilityMeasure.measurable_fun_prod` (the monoidal product is
+measurable); all this adds is that both components are measurable in `ω`. Both have to be presented
+as `ProbabilityMeasure`-valued to apply it, so the Dirac side is bundled through
+`Measure.measurable_dirac` and `Measurable.subtype_mk`, and the block side through
+`measurable_probabilityMeasure_pi`. -/
+@[fun_prop]
+theorem measurable_dirac_prod_probabilityMeasure_pi_const_toMeasure {α : Type*}
+    [MeasurableSpace α] {m : ℕ} (ν : Ω → ProbabilityMeasure α) (hν : Measurable ν) :
+    Measurable fun ω =>
+      (Measure.dirac (ν ω)).prod (ProbabilityMeasure.pi fun _ : Fin m => ν ω).toMeasure := by
+  have hdirac : Measurable fun ω =>
+      (⟨Measure.dirac (ν ω), inferInstance⟩ : ProbabilityMeasure (ProbabilityMeasure α)) :=
+    (Measure.measurable_dirac.comp hν).subtype_mk
+  have hpi : Measurable fun ω => ProbabilityMeasure.pi fun _ : Fin m => ν ω :=
+    measurable_probabilityMeasure_pi.comp (measurable_pi_lambda _ fun _ => hν)
+  exact ProbabilityMeasure.measurable_fun_prod.comp (hdirac.prodMk hpi)
 
 /-- **Bind-evaluation.** Evaluating the mixture
 `μ.bind fun ω => (ProbabilityMeasure.pi fun i => ν i ω).toMeasure` on a measurable set `s` gives


### PR DESCRIPTION
## What

One lemma in `TauCeti/MeasureTheory/Measure/ProductKernel.lean`:

```lean
theorem measurable_dirac_prod_probabilityMeasure_pi_const_toMeasure
    (ν : Ω → ProbabilityMeasure α) (hν : Measurable ν) :
    Measurable fun ω =>
      (Measure.dirac (ν ω)).prod (ProbabilityMeasure.pi fun _ : Fin m => ν ω).toMeasure
```

## Why

This is the joint-space companion of the file's existing block kernel `measurable_probabilityMeasure_pi_const_toMeasure`. The block kernel alone speaks only about the *marginal* law of a finite block — which is all the mixture identity (`MixedIIDWith`) constrains. Pairing it with a Dirac mass at the mixing measure gives the joint object that a **conditional** reading of de Finetti has to talk about, and supplies the `Measure.bind_apply` and measure-extensionality inputs on the joint space.

Roadmap: [`TauCetiRoadmap/Exchangeability/README.md`](https://github.com/TauCetiProject/TauCetiRoadmap/blob/main/TauCetiRoadmap/Exchangeability/README.md), Layer 1, which records it as

> measurability of the joint kernel `ω ↦ δ_{ν ω} ⊗ (ν ω)^{⊗m}`, which the conditional common ending needs for `Measure.bind_apply` and extensionality on the joint space

It is the prerequisite for `conditionallyIID_of_jointRectangles`, which in turn gates the genuine `ConditionallyIID` predicate and the Layer 6 conditional summit (and with it the return of the `deFinetti*` handles retired in #1192).

**Scope:** the measurability lemma only. No new predicate, no change to any existing declaration.

## Proof

Reuses Mathlib's `ProbabilityMeasure.measurable_fun_prod` (measurability of the monoidal product) rather than re-running the π-system argument — that lemma's own proof *is* the π-system argument over rectangles, so duplicating it here would have been dead weight. All this adds is measurability of the two components in `ω`:

- the Dirac side bundled as `ProbabilityMeasure`-valued via `Measure.measurable_dirac` and `Measurable.subtype_mk`;
- the block side via the file's own `measurable_probabilityMeasure_pi`.

That is exactly the ingredient list the roadmap names (Giry measurable structure, measurable Dirac, the product-kernel adapter, `ProbabilityMeasure.measurable_fun_prod`), and it needs no hypotheses beyond `Measurable ν`.

Tagged `@[fun_prop]`, consistent with the file's other measurability lemmas. The `Mathlib.MeasureTheory.Measure.Prod` import is `public` because `Measure.prod` appears in the statement.

## Verification

`lake build` — full library: **5347 jobs, 0 errors, 0 warnings.** Style linters pass. Touches `TauCeti/` only.

Co-Authored-By: Claude Code <noreply@github.com>