### PR TITLE
feat(Contour): the winding number depends on the curve only on the open interval

### DIFF
--- a/TauCeti/Analysis/Contour/Cauchy/PrincipalValue/Basic.lean
+++ b/TauCeti/Analysis/Contour/Cauchy/PrincipalValue/Basic.lean
@@ -244,6 +244,23 @@ private theorem aeEq_restrict_uIoc_of_eqOn_uIoo {u v : ℝ → ℂ} {a b : ℝ}
   rw [hrestrict]
   exact h.aeEq_restrict measurableSet_Ioo
 
+/-- The `ε`-truncated integrands of two curves that agree almost everywhere — with derivatives
+agreeing almost everywhere off `z₀` — are themselves equal almost everywhere, for every positive
+`ε`. Positivity is what makes the derivative hypothesis enough: at a point with `γ₁ t = z₀` the
+truncation deletes both integrands. -/
+private theorem truncated_integrand_congr_ae {γ₁ γ₂ : ℝ → ℂ} {a b : ℝ} {f : ℂ → ℂ} {z₀ : ℂ}
+    (h_eq : γ₁ =ᵐ[MeasureTheory.volume.restrict (Set.uIoc a b)] γ₂)
+    (h_deriv : ∀ᵐ t ∂MeasureTheory.volume.restrict (Set.uIoc a b),
+      γ₁ t ≠ z₀ → deriv γ₁ t = deriv γ₂ t)
+    {ε : ℝ} (hε : 0 < ε) :
+    (fun t => if ‖γ₁ t - z₀‖ > ε then f (γ₁ t) * deriv γ₁ t else 0)
+      =ᵐ[MeasureTheory.volume.restrict (Set.uIoc a b)]
+    (fun t => if ‖γ₂ t - z₀‖ > ε then f (γ₂ t) * deriv γ₂ t else 0) := by
+  filter_upwards [h_eq, h_deriv] with t ht htd
+  by_cases hz : γ₁ t = z₀
+  · rw [if_neg, if_neg] <;> simp [hz, ← ht, hε.not_gt]
+  · simp only [ht, htd hz]
+
 /-- **The principal value depends on the curve only up to null sets.** If `γ₁` and `γ₂` agree
 almost everywhere on the integration interval, and their derivatives agree almost everywhere
 *where the curve misses `z₀`*, their contour principal values agree.
@@ -258,22 +275,14 @@ theorem HasCauchyPVAt.congr_curve_ae {γ₁ γ₂ : ℝ → ℂ} {a b : ℝ} {f 
     (h_deriv : ∀ᵐ t ∂MeasureTheory.volume.restrict (Set.uIoc a b),
       γ₁ t ≠ z₀ → deriv γ₁ t = deriv γ₂ t) :
     HasCauchyPVAt γ₂ a b f z₀ L := by
-  have hfun : ∀ ε : ℝ, 0 < ε →
-      (fun t => if ‖γ₁ t - z₀‖ > ε then f (γ₁ t) * deriv γ₁ t else 0)
-        =ᵐ[MeasureTheory.volume.restrict (Set.uIoc a b)]
-      (fun t => if ‖γ₂ t - z₀‖ > ε then f (γ₂ t) * deriv γ₂ t else 0) := by
-    intro ε hε
-    filter_upwards [h_eq, h_deriv] with t ht htd
-    by_cases hz : γ₁ t = z₀
-    · -- The truncation deletes this point for both curves, so the derivative is irrelevant.
-      rw [if_neg, if_neg] <;> simp [hz, ← ht, hε.not_gt]
-    · simp only [ht, htd hz]
   refine ⟨?_, ?_⟩
   · filter_upwards [h.1, self_mem_nhdsWithin] with ε hε hpos
-    exact (intervalIntegrable_congr_ae (hfun ε (Set.mem_Ioi.mp hpos))).mp hε
+    exact (intervalIntegrable_congr_ae
+      (truncated_integrand_congr_ae h_eq h_deriv (Set.mem_Ioi.mp hpos))).mp hε
   · refine Filter.Tendsto.congr' ?_ h.2
     filter_upwards [self_mem_nhdsWithin] with ε hε
-    exact intervalIntegral.integral_congr_ae_restrict (hfun ε (Set.mem_Ioi.mp hε))
+    exact intervalIntegral.integral_congr_ae_restrict
+      (truncated_integrand_congr_ae h_eq h_deriv (Set.mem_Ioi.mp hε))
 
 /-- The principal value depends on the **curve** only through its values on the open interval
 between `a` and `b`. Agreement on the *open* interval is enough even though the integrand involves
@@ -314,12 +323,8 @@ theorem cauchyPVAt_congr_curve_ae {γ₁ γ₂ : ℝ → ℂ} {a b : ℝ} {f : �
       =ᶠ[nhdsWithin (0 : ℝ) (Set.Ioi 0)]
       (fun ε => ∫ t in a..b, if ‖γ₂ t - z₀‖ > ε then f (γ₂ t) * deriv γ₂ t else 0) := by
     filter_upwards [self_mem_nhdsWithin] with ε hε
-    have hpos : (0 : ℝ) < ε := Set.mem_Ioi.mp hε
-    refine intervalIntegral.integral_congr_ae_restrict ?_
-    filter_upwards [h_eq, h_deriv] with t ht htd
-    by_cases hz : γ₁ t = z₀
-    · rw [if_neg, if_neg] <;> simp [hz, ← ht, hpos.not_gt]
-    · simp only [ht, htd hz]
+    exact intervalIntegral.integral_congr_ae_restrict
+      (truncated_integrand_congr_ae h_eq h_deriv (Set.mem_Ioi.mp hε))
   unfold cauchyPVAt Filter.limUnder
   rw [Filter.map_congr hev]
 

--- a/TauCeti/Analysis/Contour/Cauchy/PrincipalValue/Basic.lean
+++ b/TauCeti/Analysis/Contour/Cauchy/PrincipalValue/Basic.lean
@@ -227,10 +227,21 @@ theorem cauchyPVAt_congr_along_curve {γ : ℝ → ℂ} {a b : ℝ} {f g : ℂ �
   refine intervalIntegral.integral_congr_uIoo fun t ht => ?_
   simp only [h_eq t ht]
 
+/-- `EqOn` on the open interval gives almost-everywhere equality on the half-open integration
+interval: the two differ only at the right endpoint, which is null. -/
+private theorem aeEq_restrict_uIoc_of_eqOn_uIoo {u v : ℝ → ℂ} {a b : ℝ}
+    (h : Set.EqOn u v (Set.uIoo a b)) :
+    u =ᵐ[MeasureTheory.volume.restrict (Set.uIoc a b)] v := by
+  rw [show MeasureTheory.volume.restrict (Set.uIoc a b)
+      = MeasureTheory.volume.restrict (Set.uIoo a b) from
+    (MeasureTheory.Measure.restrict_congr_set
+      (MeasureTheory.Ioo_ae_eq_Ioc (μ := MeasureTheory.volume))).symm]
+  exact h.aeEq_restrict measurableSet_Ioo
+
 /-- **The principal value depends on the curve only up to null sets.** If `γ₁` and `γ₂` agree
-almost everywhere on the integration interval, and so do their derivatives, their index principal
-values agree. Both hypotheses are needed separately: almost-everywhere equality of the curves says
-nothing about their derivatives. -/
+almost everywhere on the integration interval, and so do their derivatives, their contour
+principal values agree. Both hypotheses are needed separately: almost-everywhere equality of the
+curves says nothing about their derivatives. -/
 theorem HasCauchyPVAt.congr_curve_ae {γ₁ γ₂ : ℝ → ℂ} {a b : ℝ} {f : ℂ → ℂ} {z₀ : ℂ} {L : ℂ}
     (h : HasCauchyPVAt γ₁ a b f z₀ L)
     (h_eq : γ₁ =ᵐ[MeasureTheory.volume.restrict (Set.uIoc a b)] γ₂)
@@ -250,33 +261,51 @@ theorem HasCauchyPVAt.congr_curve_ae {γ₁ γ₂ : ℝ → ℂ} {a b : ℝ} {f 
     exact (MeasureTheory.ae_restrict_iff' measurableSet_uIoc).mp (hfun ε)
 
 /-- The principal value depends on the **curve** only through its values on the open interval
-between `a` and `b`: if `γ₁ = γ₂` there, their principal values agree. Agreement on the *open*
-interval is enough even though the integrand involves `deriv γ`, because an open set is a
-neighbourhood of each of its points (`Set.EqOn.deriv`), and the endpoints are invisible to the
-interval integral. -/
+between `a` and `b`. Agreement on the *open* interval is enough even though the integrand involves
+`deriv γ`, because an open set is a neighbourhood of each of its points (`Set.EqOn.deriv`), and
+the endpoints are invisible to the interval integral. -/
 theorem HasCauchyPVAt.congr_curve {γ₁ γ₂ : ℝ → ℂ} {a b : ℝ} {f : ℂ → ℂ} {z₀ : ℂ} {L : ℂ}
     (h : HasCauchyPVAt γ₁ a b f z₀ L) (h_eq : Set.EqOn γ₁ γ₂ (Set.uIoo a b)) :
-    HasCauchyPVAt γ₂ a b f z₀ L := by
-  have hae : ∀ {u v : ℝ → ℂ}, Set.EqOn u v (Set.uIoo a b) →
-      u =ᵐ[MeasureTheory.volume.restrict (Set.uIoc a b)] v := by
-    intro u v huv
-    rw [Filter.EventuallyEq, MeasureTheory.ae_restrict_iff' measurableSet_uIoc]
-    filter_upwards [MeasureTheory.Ioo_ae_eq_Ioc (μ := MeasureTheory.volume)
-      (a := min a b) (b := max a b)] with t ht hmem
-    exact huv (ht.mpr hmem)
-  exact h.congr_curve_ae (hae h_eq) (hae (h_eq.deriv isOpen_Ioo))
+    HasCauchyPVAt γ₂ a b f z₀ L :=
+  h.congr_curve_ae (aeEq_restrict_uIoc_of_eqOn_uIoo h_eq)
+    (aeEq_restrict_uIoc_of_eqOn_uIoo (h_eq.deriv isOpen_Ioo))
 
-/-- Value form of `HasCauchyPVAt.congr_curve`: the raw `cauchyPVAt` value depends on the curve
-only through its values on the open interval between `a` and `b`. -/
-theorem cauchyPVAt_congr_curve {γ₁ γ₂ : ℝ → ℂ} {a b : ℝ} {f : ℂ → ℂ} {z₀ : ℂ}
-    (h_eq : Set.EqOn γ₁ γ₂ (Set.uIoo a b)) :
+/-- Existence form of `HasCauchyPVAt.congr_curve_ae`. -/
+theorem CauchyPVExistsAt.congr_curve_ae {γ₁ γ₂ : ℝ → ℂ} {a b : ℝ} {f : ℂ → ℂ} {z₀ : ℂ}
+    (h : CauchyPVExistsAt γ₁ a b f z₀)
+    (h_eq : γ₁ =ᵐ[MeasureTheory.volume.restrict (Set.uIoc a b)] γ₂)
+    (h_deriv : deriv γ₁ =ᵐ[MeasureTheory.volume.restrict (Set.uIoc a b)] deriv γ₂) :
+    CauchyPVExistsAt γ₂ a b f z₀ :=
+  let ⟨_, hL⟩ := h
+  CauchyPVExistsAt.intro (hL.congr_curve_ae h_eq h_deriv)
+
+/-- Existence form of `HasCauchyPVAt.congr_curve`. -/
+theorem CauchyPVExistsAt.congr_curve {γ₁ γ₂ : ℝ → ℂ} {a b : ℝ} {f : ℂ → ℂ} {z₀ : ℂ}
+    (h : CauchyPVExistsAt γ₁ a b f z₀) (h_eq : Set.EqOn γ₁ γ₂ (Set.uIoo a b)) :
+    CauchyPVExistsAt γ₂ a b f z₀ :=
+  let ⟨_, hL⟩ := h
+  CauchyPVExistsAt.intro (hL.congr_curve h_eq)
+
+/-- Value form of `HasCauchyPVAt.congr_curve_ae`: the raw `cauchyPVAt` value depends on the curve
+only up to null sets. -/
+theorem cauchyPVAt_congr_curve_ae {γ₁ γ₂ : ℝ → ℂ} {a b : ℝ} {f : ℂ → ℂ} {z₀ : ℂ}
+    (h_eq : γ₁ =ᵐ[MeasureTheory.volume.restrict (Set.uIoc a b)] γ₂)
+    (h_deriv : deriv γ₁ =ᵐ[MeasureTheory.volume.restrict (Set.uIoc a b)] deriv γ₂) :
     cauchyPVAt γ₁ a b f z₀ = cauchyPVAt γ₂ a b f z₀ := by
-  have hderiv : Set.EqOn (deriv γ₁) (deriv γ₂) (Set.uIoo a b) := h_eq.deriv isOpen_Ioo
   unfold cauchyPVAt
   congr 1
   ext ε
-  refine intervalIntegral.integral_congr_uIoo fun t ht => ?_
-  simp only [h_eq ht, hderiv ht]
+  refine intervalIntegral.integral_congr_ae
+    ((MeasureTheory.ae_restrict_iff' measurableSet_uIoc).mp ?_)
+  filter_upwards [h_eq, h_deriv] with t ht htd
+  simp only [ht, htd]
+
+/-- Value form of `HasCauchyPVAt.congr_curve`. -/
+theorem cauchyPVAt_congr_curve {γ₁ γ₂ : ℝ → ℂ} {a b : ℝ} {f : ℂ → ℂ} {z₀ : ℂ}
+    (h_eq : Set.EqOn γ₁ γ₂ (Set.uIoo a b)) :
+    cauchyPVAt γ₁ a b f z₀ = cauchyPVAt γ₂ a b f z₀ :=
+  cauchyPVAt_congr_curve_ae (aeEq_restrict_uIoc_of_eqOn_uIoo h_eq)
+    (aeEq_restrict_uIoc_of_eqOn_uIoo (h_eq.deriv isOpen_Ioo))
 
 /-- Scalar multiplication: if the principal value of `f` is `L`, that of `c • f` is `c • L`. -/
 theorem HasCauchyPVAt.const_mul {γ : ℝ → ℂ} {a b : ℝ} {f : ℂ → ℂ} {z₀ : ℂ} {L : ℂ}

--- a/TauCeti/Analysis/Contour/Cauchy/PrincipalValue/Basic.lean
+++ b/TauCeti/Analysis/Contour/Cauchy/PrincipalValue/Basic.lean
@@ -227,35 +227,56 @@ theorem cauchyPVAt_congr_along_curve {γ : ℝ → ℂ} {a b : ℝ} {f g : ℂ �
   refine intervalIntegral.integral_congr_uIoo fun t ht => ?_
   simp only [h_eq t ht]
 
+/-- **The principal value depends on the curve only up to null sets.** If `γ₁` and `γ₂` agree
+almost everywhere on the integration interval, and so do their derivatives, their index principal
+values agree. Both hypotheses are needed separately: almost-everywhere equality of the curves says
+nothing about their derivatives. -/
+theorem HasCauchyPVAt.congr_curve_ae {γ₁ γ₂ : ℝ → ℂ} {a b : ℝ} {f : ℂ → ℂ} {z₀ : ℂ} {L : ℂ}
+    (h : HasCauchyPVAt γ₁ a b f z₀ L)
+    (h_eq : γ₁ =ᵐ[MeasureTheory.volume.restrict (Set.uIoc a b)] γ₂)
+    (h_deriv : deriv γ₁ =ᵐ[MeasureTheory.volume.restrict (Set.uIoc a b)] deriv γ₂) :
+    HasCauchyPVAt γ₂ a b f z₀ L := by
+  have hfun : ∀ ε : ℝ,
+      (fun t => if ‖γ₁ t - z₀‖ > ε then f (γ₁ t) * deriv γ₁ t else 0)
+        =ᵐ[MeasureTheory.volume.restrict (Set.uIoc a b)]
+      (fun t => if ‖γ₂ t - z₀‖ > ε then f (γ₂ t) * deriv γ₂ t else 0) := by
+    intro ε
+    filter_upwards [h_eq, h_deriv] with t ht htd
+    simp only [ht, htd]
+  refine ⟨?_, ?_⟩
+  · filter_upwards [h.1] with ε hε
+    exact (intervalIntegrable_congr_ae (hfun ε)).mp hε
+  · refine Filter.Tendsto.congr (fun ε => intervalIntegral.integral_congr_ae ?_) h.2
+    exact (MeasureTheory.ae_restrict_iff' measurableSet_uIoc).mp (hfun ε)
+
 /-- The principal value depends on the **curve** only through its values on the open interval
 between `a` and `b`: if `γ₁ = γ₂` there, their principal values agree. Agreement on the *open*
-interval is enough even though the integrand involves `deriv γ`: the open interval is a
-neighbourhood of each of its points, so the two curves are eventually equal at every such point
-and their derivatives agree, while the endpoints are invisible to the interval integral. -/
+interval is enough even though the integrand involves `deriv γ`, because an open set is a
+neighbourhood of each of its points (`Set.EqOn.deriv`), and the endpoints are invisible to the
+interval integral. -/
 theorem HasCauchyPVAt.congr_curve {γ₁ γ₂ : ℝ → ℂ} {a b : ℝ} {f : ℂ → ℂ} {z₀ : ℂ} {L : ℂ}
     (h : HasCauchyPVAt γ₁ a b f z₀ L) (h_eq : Set.EqOn γ₁ γ₂ (Set.uIoo a b)) :
     HasCauchyPVAt γ₂ a b f z₀ L := by
-  have hderiv : ∀ t ∈ Set.uIoo a b, deriv γ₁ t = deriv γ₂ t := fun t ht =>
-    (h_eq.eventuallyEq_of_mem (isOpen_Ioo.mem_nhds ht)).deriv_eq
-  refine ⟨?_, ?_⟩
-  · filter_upwards [h.1] with ε hε
-    refine (intervalIntegrable_congr_uIoo fun t ht => ?_).mp hε
-    simp only [h_eq ht, hderiv t ht]
-  · refine Filter.Tendsto.congr (fun ε => intervalIntegral.integral_congr_uIoo fun t ht => ?_) h.2
-    simp only [h_eq ht, hderiv t ht]
+  have hae : ∀ {u v : ℝ → ℂ}, Set.EqOn u v (Set.uIoo a b) →
+      u =ᵐ[MeasureTheory.volume.restrict (Set.uIoc a b)] v := by
+    intro u v huv
+    rw [Filter.EventuallyEq, MeasureTheory.ae_restrict_iff' measurableSet_uIoc]
+    filter_upwards [MeasureTheory.Ioo_ae_eq_Ioc (μ := MeasureTheory.volume)
+      (a := min a b) (b := max a b)] with t ht hmem
+    exact huv (ht.mpr hmem)
+  exact h.congr_curve_ae (hae h_eq) (hae (h_eq.deriv isOpen_Ioo))
 
 /-- Value form of `HasCauchyPVAt.congr_curve`: the raw `cauchyPVAt` value depends on the curve
 only through its values on the open interval between `a` and `b`. -/
 theorem cauchyPVAt_congr_curve {γ₁ γ₂ : ℝ → ℂ} {a b : ℝ} {f : ℂ → ℂ} {z₀ : ℂ}
     (h_eq : Set.EqOn γ₁ γ₂ (Set.uIoo a b)) :
     cauchyPVAt γ₁ a b f z₀ = cauchyPVAt γ₂ a b f z₀ := by
-  have hderiv : ∀ t ∈ Set.uIoo a b, deriv γ₁ t = deriv γ₂ t := fun t ht =>
-    (h_eq.eventuallyEq_of_mem (isOpen_Ioo.mem_nhds ht)).deriv_eq
+  have hderiv : Set.EqOn (deriv γ₁) (deriv γ₂) (Set.uIoo a b) := h_eq.deriv isOpen_Ioo
   unfold cauchyPVAt
   congr 1
   ext ε
   refine intervalIntegral.integral_congr_uIoo fun t ht => ?_
-  simp only [h_eq ht, hderiv t ht]
+  simp only [h_eq ht, hderiv ht]
 
 /-- Scalar multiplication: if the principal value of `f` is `L`, that of `c • f` is `c • L`. -/
 theorem HasCauchyPVAt.const_mul {γ : ℝ → ℂ} {a b : ℝ} {f : ℂ → ℂ} {z₀ : ℂ} {L : ℂ}

--- a/TauCeti/Analysis/Contour/Cauchy/PrincipalValue/Basic.lean
+++ b/TauCeti/Analysis/Contour/Cauchy/PrincipalValue/Basic.lean
@@ -232,10 +232,11 @@ interval: the two differ only at the right endpoint, which is null. -/
 private theorem aeEq_restrict_uIoc_of_eqOn_uIoo {u v : ℝ → ℂ} {a b : ℝ}
     (h : Set.EqOn u v (Set.uIoo a b)) :
     u =ᵐ[MeasureTheory.volume.restrict (Set.uIoc a b)] v := by
-  rw [show MeasureTheory.volume.restrict (Set.uIoc a b)
-      = MeasureTheory.volume.restrict (Set.uIoo a b) from
-    (MeasureTheory.Measure.restrict_congr_set
-      (MeasureTheory.Ioo_ae_eq_Ioc (μ := MeasureTheory.volume))).symm]
+  -- `uIoc` and `uIoo` differ only at the right endpoint, so they restrict the measure equally.
+  have hrestrict : MeasureTheory.volume.restrict (Set.uIoc a b)
+      = MeasureTheory.volume.restrict (Set.uIoo a b) :=
+    MeasureTheory.restrict_Ioo_eq_restrict_Ioc.symm
+  rw [hrestrict]
   exact h.aeEq_restrict measurableSet_Ioo
 
 /-- **The principal value depends on the curve only up to null sets.** If `γ₁` and `γ₂` agree
@@ -257,8 +258,8 @@ theorem HasCauchyPVAt.congr_curve_ae {γ₁ γ₂ : ℝ → ℂ} {a b : ℝ} {f 
   refine ⟨?_, ?_⟩
   · filter_upwards [h.1] with ε hε
     exact (intervalIntegrable_congr_ae (hfun ε)).mp hε
-  · refine Filter.Tendsto.congr (fun ε => intervalIntegral.integral_congr_ae ?_) h.2
-    exact (MeasureTheory.ae_restrict_iff' measurableSet_uIoc).mp (hfun ε)
+  · exact Filter.Tendsto.congr
+      (fun ε => intervalIntegral.integral_congr_ae_restrict (hfun ε)) h.2
 
 /-- The principal value depends on the **curve** only through its values on the open interval
 between `a` and `b`. Agreement on the *open* interval is enough even though the integrand involves
@@ -286,8 +287,9 @@ theorem CauchyPVExistsAt.congr_curve {γ₁ γ₂ : ℝ → ℂ} {a b : ℝ} {f 
   let ⟨_, hL⟩ := h
   CauchyPVExistsAt.intro (hL.congr_curve h_eq)
 
-/-- Value form of `HasCauchyPVAt.congr_curve_ae`: the raw `cauchyPVAt` value depends on the curve
-only up to null sets. -/
+/-- Value form of `HasCauchyPVAt.congr_curve_ae`: the raw `cauchyPVAt` value is unchanged when
+both the curves *and* their derivatives agree almost everywhere on the integration interval.
+Curve equality alone does not suffice — the integrand contains `deriv γ`. -/
 theorem cauchyPVAt_congr_curve_ae {γ₁ γ₂ : ℝ → ℂ} {a b : ℝ} {f : ℂ → ℂ} {z₀ : ℂ}
     (h_eq : γ₁ =ᵐ[MeasureTheory.volume.restrict (Set.uIoc a b)] γ₂)
     (h_deriv : deriv γ₁ =ᵐ[MeasureTheory.volume.restrict (Set.uIoc a b)] deriv γ₂) :
@@ -295,8 +297,7 @@ theorem cauchyPVAt_congr_curve_ae {γ₁ γ₂ : ℝ → ℂ} {a b : ℝ} {f : �
   unfold cauchyPVAt
   congr 1
   ext ε
-  refine intervalIntegral.integral_congr_ae
-    ((MeasureTheory.ae_restrict_iff' measurableSet_uIoc).mp ?_)
+  refine intervalIntegral.integral_congr_ae_restrict ?_
   filter_upwards [h_eq, h_deriv] with t ht htd
   simp only [ht, htd]
 

--- a/TauCeti/Analysis/Contour/Cauchy/PrincipalValue/Basic.lean
+++ b/TauCeti/Analysis/Contour/Cauchy/PrincipalValue/Basic.lean
@@ -55,6 +55,11 @@ versus `MeromorphicOn` (on a set).
   package/unpack existence and recover the predicate at `cauchyPVAt`.
 * `HasCauchyPVAt.congr_along_curve`, `cauchyPVAt_congr_along_curve` — the integrand only matters
   along `γ` on `[a, b]`;
+* `HasCauchyPVAt.congr_curve_ae`, `CauchyPVExistsAt.congr_curve_ae`, `cauchyPVAt_congr_curve_ae`
+  — the *curve* only matters up to null sets: the principal value is unchanged when both the
+  curves and their derivatives agree almost everywhere on the integration interval;
+  `HasCauchyPVAt.congr_curve`, `CauchyPVExistsAt.congr_curve`, `cauchyPVAt_congr_curve` — the
+  pointwise corollaries, needing agreement only on the open interval `Set.uIoo a b`;
   `HasCauchyPVAt.zero`, `HasCauchyPVAt.const_mul`, `HasCauchyPVAt.add`, `HasCauchyPVAt.sum` (and the
   `CauchyPVExistsAt` forms) — the principal value is `ℂ`-linear in the integrand, including over
   finite sums.

--- a/TauCeti/Analysis/Contour/Cauchy/PrincipalValue/Basic.lean
+++ b/TauCeti/Analysis/Contour/Cauchy/PrincipalValue/Basic.lean
@@ -227,6 +227,36 @@ theorem cauchyPVAt_congr_along_curve {γ : ℝ → ℂ} {a b : ℝ} {f g : ℂ �
   refine intervalIntegral.integral_congr_uIoo fun t ht => ?_
   simp only [h_eq t ht]
 
+/-- The principal value depends on the **curve** only through its values on the open interval
+between `a` and `b`: if `γ₁ = γ₂` there, their principal values agree. Agreement on the *open*
+interval is enough even though the integrand involves `deriv γ`: the open interval is a
+neighbourhood of each of its points, so the two curves are eventually equal at every such point
+and their derivatives agree, while the endpoints are invisible to the interval integral. -/
+theorem HasCauchyPVAt.congr_curve {γ₁ γ₂ : ℝ → ℂ} {a b : ℝ} {f : ℂ → ℂ} {z₀ : ℂ} {L : ℂ}
+    (h : HasCauchyPVAt γ₁ a b f z₀ L) (h_eq : Set.EqOn γ₁ γ₂ (Set.uIoo a b)) :
+    HasCauchyPVAt γ₂ a b f z₀ L := by
+  have hderiv : ∀ t ∈ Set.uIoo a b, deriv γ₁ t = deriv γ₂ t := fun t ht =>
+    (h_eq.eventuallyEq_of_mem (isOpen_Ioo.mem_nhds ht)).deriv_eq
+  refine ⟨?_, ?_⟩
+  · filter_upwards [h.1] with ε hε
+    refine (intervalIntegrable_congr_uIoo fun t ht => ?_).mp hε
+    simp only [h_eq ht, hderiv t ht]
+  · refine Filter.Tendsto.congr (fun ε => intervalIntegral.integral_congr_uIoo fun t ht => ?_) h.2
+    simp only [h_eq ht, hderiv t ht]
+
+/-- Value form of `HasCauchyPVAt.congr_curve`: the raw `cauchyPVAt` value depends on the curve
+only through its values on the open interval between `a` and `b`. -/
+theorem cauchyPVAt_congr_curve {γ₁ γ₂ : ℝ → ℂ} {a b : ℝ} {f : ℂ → ℂ} {z₀ : ℂ}
+    (h_eq : Set.EqOn γ₁ γ₂ (Set.uIoo a b)) :
+    cauchyPVAt γ₁ a b f z₀ = cauchyPVAt γ₂ a b f z₀ := by
+  have hderiv : ∀ t ∈ Set.uIoo a b, deriv γ₁ t = deriv γ₂ t := fun t ht =>
+    (h_eq.eventuallyEq_of_mem (isOpen_Ioo.mem_nhds ht)).deriv_eq
+  unfold cauchyPVAt
+  congr 1
+  ext ε
+  refine intervalIntegral.integral_congr_uIoo fun t ht => ?_
+  simp only [h_eq ht, hderiv t ht]
+
 /-- Scalar multiplication: if the principal value of `f` is `L`, that of `c • f` is `c • L`. -/
 theorem HasCauchyPVAt.const_mul {γ : ℝ → ℂ} {a b : ℝ} {f : ℂ → ℂ} {z₀ : ℂ} {L : ℂ}
     (h : HasCauchyPVAt γ a b f z₀ L) (c : ℂ) :

--- a/TauCeti/Analysis/Contour/Cauchy/PrincipalValue/Basic.lean
+++ b/TauCeti/Analysis/Contour/Cauchy/PrincipalValue/Basic.lean
@@ -56,8 +56,9 @@ versus `MeromorphicOn` (on a set).
 * `HasCauchyPVAt.congr_along_curve`, `cauchyPVAt_congr_along_curve` — the integrand only matters
   along `γ` on `[a, b]`;
 * `HasCauchyPVAt.congr_curve_ae`, `CauchyPVExistsAt.congr_curve_ae`, `cauchyPVAt_congr_curve_ae`
-  — the *curve* only matters up to null sets: the principal value is unchanged when both the
-  curves and their derivatives agree almost everywhere on the integration interval;
+  — the *curve* only matters up to null sets: the principal value is unchanged when the curves
+  agree almost everywhere on the integration interval and their derivatives agree almost
+  everywhere *where the curve misses `z₀`* (the truncation deletes the integrand at `z₀`);
   `HasCauchyPVAt.congr_curve`, `CauchyPVExistsAt.congr_curve`, `cauchyPVAt_congr_curve` — the
   pointwise corollaries, needing agreement only on the open interval `Set.uIoo a b`;
   `HasCauchyPVAt.zero`, `HasCauchyPVAt.const_mul`, `HasCauchyPVAt.add`, `HasCauchyPVAt.sum` (and the
@@ -311,9 +312,10 @@ theorem CauchyPVExistsAt.congr_curve {γ₁ γ₂ : ℝ → ℂ} {a b : ℝ} {f 
   let ⟨_, hL⟩ := h
   CauchyPVExistsAt.intro (hL.congr_curve h_eq)
 
-/-- Value form of `HasCauchyPVAt.congr_curve_ae`: the raw `cauchyPVAt` value is unchanged when
-both the curves *and* their derivatives agree almost everywhere on the integration interval.
-Curve equality alone does not suffice — the integrand contains `deriv γ`. -/
+/-- Value form of `HasCauchyPVAt.congr_curve_ae`: the raw `cauchyPVAt` value is unchanged when the
+curves agree almost everywhere on the integration interval and their derivatives agree almost
+everywhere where the curve misses `z₀`. Curve equality alone does not suffice — the integrand
+contains `deriv γ`. -/
 theorem cauchyPVAt_congr_curve_ae {γ₁ γ₂ : ℝ → ℂ} {a b : ℝ} {f : ℂ → ℂ} {z₀ : ℂ}
     (h_eq : γ₁ =ᵐ[MeasureTheory.volume.restrict (Set.uIoc a b)] γ₂)
     (h_deriv : ∀ᵐ t ∂MeasureTheory.volume.restrict (Set.uIoc a b),

--- a/TauCeti/Analysis/Contour/Cauchy/PrincipalValue/Basic.lean
+++ b/TauCeti/Analysis/Contour/Cauchy/PrincipalValue/Basic.lean
@@ -245,26 +245,35 @@ private theorem aeEq_restrict_uIoc_of_eqOn_uIoo {u v : ℝ → ℂ} {a b : ℝ}
   exact h.aeEq_restrict measurableSet_Ioo
 
 /-- **The principal value depends on the curve only up to null sets.** If `γ₁` and `γ₂` agree
-almost everywhere on the integration interval, and so do their derivatives, their contour
-principal values agree. Both hypotheses are needed separately: almost-everywhere equality of the
-curves says nothing about their derivatives. -/
+almost everywhere on the integration interval, and their derivatives agree almost everywhere
+*where the curve misses `z₀`*, their contour principal values agree.
+
+Derivative agreement is only needed off `z₀`: the `ε`-truncation deletes the integrand wherever
+`‖γ t - z₀‖ ≤ ε`, so for the positive `ε` the principal value ranges over, a point with
+`γ₁ t = z₀` contributes `0` whatever the derivative there is. Curve agreement alone is still not
+enough — the integrand contains `deriv γ`. -/
 theorem HasCauchyPVAt.congr_curve_ae {γ₁ γ₂ : ℝ → ℂ} {a b : ℝ} {f : ℂ → ℂ} {z₀ : ℂ} {L : ℂ}
     (h : HasCauchyPVAt γ₁ a b f z₀ L)
     (h_eq : γ₁ =ᵐ[MeasureTheory.volume.restrict (Set.uIoc a b)] γ₂)
-    (h_deriv : deriv γ₁ =ᵐ[MeasureTheory.volume.restrict (Set.uIoc a b)] deriv γ₂) :
+    (h_deriv : ∀ᵐ t ∂MeasureTheory.volume.restrict (Set.uIoc a b),
+      γ₁ t ≠ z₀ → deriv γ₁ t = deriv γ₂ t) :
     HasCauchyPVAt γ₂ a b f z₀ L := by
-  have hfun : ∀ ε : ℝ,
+  have hfun : ∀ ε : ℝ, 0 < ε →
       (fun t => if ‖γ₁ t - z₀‖ > ε then f (γ₁ t) * deriv γ₁ t else 0)
         =ᵐ[MeasureTheory.volume.restrict (Set.uIoc a b)]
       (fun t => if ‖γ₂ t - z₀‖ > ε then f (γ₂ t) * deriv γ₂ t else 0) := by
-    intro ε
+    intro ε hε
     filter_upwards [h_eq, h_deriv] with t ht htd
-    simp only [ht, htd]
+    by_cases hz : γ₁ t = z₀
+    · -- The truncation deletes this point for both curves, so the derivative is irrelevant.
+      rw [if_neg, if_neg] <;> simp [hz, ← ht, hε.not_gt]
+    · simp only [ht, htd hz]
   refine ⟨?_, ?_⟩
-  · filter_upwards [h.1] with ε hε
-    exact (intervalIntegrable_congr_ae (hfun ε)).mp hε
-  · exact Filter.Tendsto.congr
-      (fun ε => intervalIntegral.integral_congr_ae_restrict (hfun ε)) h.2
+  · filter_upwards [h.1, self_mem_nhdsWithin] with ε hε hpos
+    exact (intervalIntegrable_congr_ae (hfun ε (Set.mem_Ioi.mp hpos))).mp hε
+  · refine Filter.Tendsto.congr' ?_ h.2
+    filter_upwards [self_mem_nhdsWithin] with ε hε
+    exact intervalIntegral.integral_congr_ae_restrict (hfun ε (Set.mem_Ioi.mp hε))
 
 /-- The principal value depends on the **curve** only through its values on the open interval
 between `a` and `b`. Agreement on the *open* interval is enough even though the integrand involves
@@ -274,13 +283,14 @@ theorem HasCauchyPVAt.congr_curve {γ₁ γ₂ : ℝ → ℂ} {a b : ℝ} {f : �
     (h : HasCauchyPVAt γ₁ a b f z₀ L) (h_eq : Set.EqOn γ₁ γ₂ (Set.uIoo a b)) :
     HasCauchyPVAt γ₂ a b f z₀ L :=
   h.congr_curve_ae (aeEq_restrict_uIoc_of_eqOn_uIoo h_eq)
-    (aeEq_restrict_uIoc_of_eqOn_uIoo (h_eq.deriv isOpen_Ioo))
+    ((aeEq_restrict_uIoc_of_eqOn_uIoo (h_eq.deriv isOpen_Ioo)).mono fun _ ht _ => ht)
 
 /-- Existence form of `HasCauchyPVAt.congr_curve_ae`. -/
 theorem CauchyPVExistsAt.congr_curve_ae {γ₁ γ₂ : ℝ → ℂ} {a b : ℝ} {f : ℂ → ℂ} {z₀ : ℂ}
     (h : CauchyPVExistsAt γ₁ a b f z₀)
     (h_eq : γ₁ =ᵐ[MeasureTheory.volume.restrict (Set.uIoc a b)] γ₂)
-    (h_deriv : deriv γ₁ =ᵐ[MeasureTheory.volume.restrict (Set.uIoc a b)] deriv γ₂) :
+    (h_deriv : ∀ᵐ t ∂MeasureTheory.volume.restrict (Set.uIoc a b),
+      γ₁ t ≠ z₀ → deriv γ₁ t = deriv γ₂ t) :
     CauchyPVExistsAt γ₂ a b f z₀ :=
   let ⟨_, hL⟩ := h
   CauchyPVExistsAt.intro (hL.congr_curve_ae h_eq h_deriv)
@@ -297,21 +307,28 @@ both the curves *and* their derivatives agree almost everywhere on the integrati
 Curve equality alone does not suffice — the integrand contains `deriv γ`. -/
 theorem cauchyPVAt_congr_curve_ae {γ₁ γ₂ : ℝ → ℂ} {a b : ℝ} {f : ℂ → ℂ} {z₀ : ℂ}
     (h_eq : γ₁ =ᵐ[MeasureTheory.volume.restrict (Set.uIoc a b)] γ₂)
-    (h_deriv : deriv γ₁ =ᵐ[MeasureTheory.volume.restrict (Set.uIoc a b)] deriv γ₂) :
+    (h_deriv : ∀ᵐ t ∂MeasureTheory.volume.restrict (Set.uIoc a b),
+      γ₁ t ≠ z₀ → deriv γ₁ t = deriv γ₂ t) :
     cauchyPVAt γ₁ a b f z₀ = cauchyPVAt γ₂ a b f z₀ := by
-  unfold cauchyPVAt
-  congr 1
-  ext ε
-  refine intervalIntegral.integral_congr_ae_restrict ?_
-  filter_upwards [h_eq, h_deriv] with t ht htd
-  simp only [ht, htd]
+  have hev : (fun ε => ∫ t in a..b, if ‖γ₁ t - z₀‖ > ε then f (γ₁ t) * deriv γ₁ t else 0)
+      =ᶠ[nhdsWithin (0 : ℝ) (Set.Ioi 0)]
+      (fun ε => ∫ t in a..b, if ‖γ₂ t - z₀‖ > ε then f (γ₂ t) * deriv γ₂ t else 0) := by
+    filter_upwards [self_mem_nhdsWithin] with ε hε
+    have hpos : (0 : ℝ) < ε := Set.mem_Ioi.mp hε
+    refine intervalIntegral.integral_congr_ae_restrict ?_
+    filter_upwards [h_eq, h_deriv] with t ht htd
+    by_cases hz : γ₁ t = z₀
+    · rw [if_neg, if_neg] <;> simp [hz, ← ht, hpos.not_gt]
+    · simp only [ht, htd hz]
+  unfold cauchyPVAt Filter.limUnder
+  rw [Filter.map_congr hev]
 
 /-- Value form of `HasCauchyPVAt.congr_curve`. -/
 theorem cauchyPVAt_congr_curve {γ₁ γ₂ : ℝ → ℂ} {a b : ℝ} {f : ℂ → ℂ} {z₀ : ℂ}
     (h_eq : Set.EqOn γ₁ γ₂ (Set.uIoo a b)) :
     cauchyPVAt γ₁ a b f z₀ = cauchyPVAt γ₂ a b f z₀ :=
   cauchyPVAt_congr_curve_ae (aeEq_restrict_uIoc_of_eqOn_uIoo h_eq)
-    (aeEq_restrict_uIoc_of_eqOn_uIoo (h_eq.deriv isOpen_Ioo))
+    ((aeEq_restrict_uIoc_of_eqOn_uIoo (h_eq.deriv isOpen_Ioo)).mono fun _ ht _ => ht)
 
 /-- Scalar multiplication: if the principal value of `f` is `L`, that of `c • f` is `c • L`. -/
 theorem HasCauchyPVAt.const_mul {γ : ℝ → ℂ} {a b : ℝ} {f : ℂ → ℂ} {z₀ : ℂ} {L : ℂ}

--- a/TauCeti/Analysis/Contour/Winding/Number/Basic.lean
+++ b/TauCeti/Analysis/Contour/Winding/Number/Basic.lean
@@ -88,7 +88,9 @@ theorem windingNumber_same (γ : ℝ → ℂ) (a : ℝ) (z₀ : ℂ) :
     (HasCauchyPVAt.refl γ a (fun z : ℂ => (z - z₀)⁻¹) z₀)]
   ring
 
-/-- **The generalized winding number depends on the curve only up to null sets.** -/
+/-- **The generalized winding number is unchanged when both the curves and their derivatives
+agree almost everywhere** on the integration interval. Curve equality alone does not suffice: the
+index integrand contains `deriv γ`. -/
 theorem windingNumber_congr_curve_ae {γ₁ γ₂ : ℝ → ℂ} {a b : ℝ} {z₀ : ℂ}
     (h_eq : γ₁ =ᵐ[MeasureTheory.volume.restrict (Set.uIoc a b)] γ₂)
     (h_deriv : deriv γ₁ =ᵐ[MeasureTheory.volume.restrict (Set.uIoc a b)] deriv γ₂) :

--- a/TauCeti/Analysis/Contour/Winding/Number/Basic.lean
+++ b/TauCeti/Analysis/Contour/Winding/Number/Basic.lean
@@ -28,6 +28,11 @@ value does not exist.
   `cauchyPVAt` defining value.
 * `TauCeti.Contour.windingNumber_eq_of_hasCauchyPVAt` — evaluate `windingNumber` from a Cauchy
   principal-value witness, without unfolding the definition.
+* `TauCeti.Contour.windingNumber_congr_curve_ae` — the winding number is unchanged when both the
+  curves and their derivatives agree almost everywhere on the integration interval;
+  `TauCeti.Contour.windingNumber_congr_curve` — the pointwise corollary, needing agreement only on
+  the open interval `Set.uIoo a b`. This is what lets a piecewise contour be evaluated one piece
+  at a time.
 * `TauCeti.Contour.windingNumber_same` — the generalized winding number on `[a, a]` is `0`.
 * `TauCeti.Contour.isNullHomologous_iff` — restates `IsNullHomologous` as its vanishing condition,
   so consumers use the predicate without unfolding its hidden body.

--- a/TauCeti/Analysis/Contour/Winding/Number/Basic.lean
+++ b/TauCeti/Analysis/Contour/Winding/Number/Basic.lean
@@ -88,6 +88,17 @@ theorem windingNumber_same (γ : ℝ → ℂ) (a : ℝ) (z₀ : ℂ) :
     (HasCauchyPVAt.refl γ a (fun z : ℂ => (z - z₀)⁻¹) z₀)]
   ring
 
+/-- **The generalized winding number depends on the curve only through its values on the open
+interval between `a` and `b`.** Agreement on the open interval suffices even though the index
+integrand involves `deriv γ`, since the open interval is a neighbourhood of each of its points.
+This is what lets a piecewise contour be evaluated one piece at a time: on each piece the
+assembled curve agrees with the simple curve computing that piece's contribution. -/
+theorem windingNumber_congr_curve {γ₁ γ₂ : ℝ → ℂ} {a b : ℝ} {z₀ : ℂ}
+    (h_eq : Set.EqOn γ₁ γ₂ (Set.uIoo a b)) :
+    windingNumber γ₁ a b z₀ = windingNumber γ₂ a b z₀ := by
+  unfold windingNumber
+  rw [cauchyPVAt_congr_curve h_eq]
+
 /-- If the two endpoints are equal, the generalized winding number is `0`. -/
 theorem windingNumber_eq_zero_of_eq (γ : ℝ → ℂ) {a b : ℝ} (hab : a = b) (z₀ : ℂ) :
     windingNumber γ a b z₀ = 0 := by

--- a/TauCeti/Analysis/Contour/Winding/Number/Basic.lean
+++ b/TauCeti/Analysis/Contour/Winding/Number/Basic.lean
@@ -28,8 +28,9 @@ value does not exist.
   `cauchyPVAt` defining value.
 * `TauCeti.Contour.windingNumber_eq_of_hasCauchyPVAt` — evaluate `windingNumber` from a Cauchy
   principal-value witness, without unfolding the definition.
-* `TauCeti.Contour.windingNumber_congr_curve_ae` — the winding number is unchanged when both the
-  curves and their derivatives agree almost everywhere on the integration interval;
+* `TauCeti.Contour.windingNumber_congr_curve_ae` — the winding number is unchanged when the curves
+  agree almost everywhere on the integration interval and their derivatives agree almost everywhere
+  where the curve misses `z₀`;
   `TauCeti.Contour.windingNumber_congr_curve` — the pointwise corollary, needing agreement only on
   the open interval `Set.uIoo a b`. This is what lets a piecewise contour be evaluated one piece
   at a time.

--- a/TauCeti/Analysis/Contour/Winding/Number/Basic.lean
+++ b/TauCeti/Analysis/Contour/Winding/Number/Basic.lean
@@ -93,12 +93,14 @@ theorem windingNumber_same (γ : ℝ → ℂ) (a : ℝ) (z₀ : ℂ) :
     (HasCauchyPVAt.refl γ a (fun z : ℂ => (z - z₀)⁻¹) z₀)]
   ring
 
-/-- **The generalized winding number is unchanged when both the curves and their derivatives
-agree almost everywhere** on the integration interval. Curve equality alone does not suffice: the
-index integrand contains `deriv γ`. -/
+/-- **The generalized winding number is unchanged when the curves agree almost everywhere and
+their derivatives agree almost everywhere off `z₀`.** Derivative agreement is only needed where
+the curve misses `z₀`: the `ε`-truncation deletes the integrand at `z₀` for every positive `ε`.
+Curve equality alone does not suffice — the index integrand contains `deriv γ`. -/
 theorem windingNumber_congr_curve_ae {γ₁ γ₂ : ℝ → ℂ} {a b : ℝ} {z₀ : ℂ}
     (h_eq : γ₁ =ᵐ[MeasureTheory.volume.restrict (Set.uIoc a b)] γ₂)
-    (h_deriv : deriv γ₁ =ᵐ[MeasureTheory.volume.restrict (Set.uIoc a b)] deriv γ₂) :
+    (h_deriv : ∀ᵐ t ∂MeasureTheory.volume.restrict (Set.uIoc a b),
+      γ₁ t ≠ z₀ → deriv γ₁ t = deriv γ₂ t) :
     windingNumber γ₁ a b z₀ = windingNumber γ₂ a b z₀ := by
   unfold windingNumber
   rw [cauchyPVAt_congr_curve_ae h_eq h_deriv]

--- a/TauCeti/Analysis/Contour/Winding/Number/Basic.lean
+++ b/TauCeti/Analysis/Contour/Winding/Number/Basic.lean
@@ -88,11 +88,19 @@ theorem windingNumber_same (γ : ℝ → ℂ) (a : ℝ) (z₀ : ℂ) :
     (HasCauchyPVAt.refl γ a (fun z : ℂ => (z - z₀)⁻¹) z₀)]
   ring
 
+/-- **The generalized winding number depends on the curve only up to null sets.** -/
+theorem windingNumber_congr_curve_ae {γ₁ γ₂ : ℝ → ℂ} {a b : ℝ} {z₀ : ℂ}
+    (h_eq : γ₁ =ᵐ[MeasureTheory.volume.restrict (Set.uIoc a b)] γ₂)
+    (h_deriv : deriv γ₁ =ᵐ[MeasureTheory.volume.restrict (Set.uIoc a b)] deriv γ₂) :
+    windingNumber γ₁ a b z₀ = windingNumber γ₂ a b z₀ := by
+  unfold windingNumber
+  rw [cauchyPVAt_congr_curve_ae h_eq h_deriv]
+
 /-- **The generalized winding number depends on the curve only through its values on the open
 interval between `a` and `b`.** Agreement on the open interval suffices even though the index
-integrand involves `deriv γ`, since the open interval is a neighbourhood of each of its points.
-This is what lets a piecewise contour be evaluated one piece at a time: on each piece the
-assembled curve agrees with the simple curve computing that piece's contribution. -/
+integrand involves `deriv γ`, since an open set is a neighbourhood of each of its points. This is
+what lets a piecewise contour be evaluated one piece at a time: on each piece the assembled curve
+agrees with the simple curve computing that piece's contribution. -/
 theorem windingNumber_congr_curve {γ₁ γ₂ : ℝ → ℂ} {a b : ℝ} {z₀ : ℂ}
     (h_eq : Set.EqOn γ₁ γ₂ (Set.uIoo a b)) :
     windingNumber γ₁ a b z₀ = windingNumber γ₂ a b z₀ := by


### PR DESCRIPTION
## Roadmap

`TauCetiRoadmap/ContourIntegration/README.md`, section **"Worked examples (acceptance criteria,
keeping the theory honest)"** — the outstanding fifth bullet:

> **An improper integral** (e.g. a Cauchy principal value along the real axis with a simple pole
> at `0`) evaluated by HW Thm 3.3 where the classical theorem does not apply — HW's motivating
> example.

All 18 targets in `ContourIntegration/Suggested.lean` are already proven; that bullet is the one
remaining item of the roadmap, and this PR is its second prerequisite (after #1196).

## Why

Building the half-disc contour for the roadmap's outstanding improper-integral acceptance
criterion means evaluating a **piecewise** curve one piece at a time: the diameter contributes `0`
(`windingNumber_eq_zero_segment`, #1196) and the semicircular arc contributes `½`
(`windingNumber_at_i`), and `windingNumber_concat` adds them.

That needs a step the library does not have. The existing `congr_along_curve` family varies the
*integrand* along a fixed curve; to transfer a known winding number to a piece of an assembled
contour one needs congruence in the **curve**. Today the only way to move between curves is
reparametrization (`Winding/Number/Reparam.lean`, `Curve/Reparam.lean`) — same curve, different
parameter — never pointwise agreement on an interval.

## What

The primitive is the **almost-everywhere** statement — the interval integral only sees the curve
up to null sets — with the pointwise `EqOn` versions derived from it. Both a.e. hypotheses are
needed separately: a.e. equality of the curves says nothing about their derivatives.


| Declaration | Statement |
|---|---|
| `HasCauchyPVAt.congr_curve_ae` | if `γ₁ = γ₂` and `deriv γ₁ = deriv γ₂` a.e. on `Set.uIoc a b`, the index principal value transfers |
| `HasCauchyPVAt.congr_curve` | the `Set.EqOn γ₁ γ₂ (Set.uIoo a b)` corollary |
| `cauchyPVAt_congr_curve` | value form |
| `windingNumber_congr_curve` | hence the winding numbers agree |

**Why the open interval is enough.** The index integrand is
`if ‖γ t - z₀‖ > ε then f (γ t) * deriv γ t else 0`, which involves `deriv γ` — a
*neighbourhood*-dependent quantity, so agreement on a bare set would not obviously suffice. But
`Set.uIoo a b` is open, hence a neighbourhood of each of its points, so the two curves are
eventually equal at every such point and `Set.EqOn.deriv` gives equal derivatives there. The endpoints are invisible to the interval integral, which is why the hypothesis is stated
on `uIoo` rather than `uIcc` — matching the existing `congr_along_curve` lemmas in the same file.

Placed alongside the other principal-value congruence lemmas in
`Cauchy/PrincipalValue/Basic.lean`, with the winding-number corollary next to the other
`windingNumber` value lemmas in `Winding/Number/Basic.lean`.

Gates: `lake build` (5349 jobs) ✓, `lake exe axioms` (11473 decls, allowlist) ✓,
`lake exe module-system` (640 modules) ✓, `scripts/lint-env.sh` PASS ✓.
