### PR TITLE
feat(L2Product): product Hilbert basis of L² on a product measure (roadmap B3)

### DIFF
--- a/TauCeti/Analysis/InnerProductSpace/L2Product.lean
+++ b/TauCeti/Analysis/InnerProductSpace/L2Product.lean
@@ -32,7 +32,7 @@ index types. It runs in three moves:
 1. `TauCeti.inner_L2prodMul_eq_zero_of_forall_basis` — orthogonality to the *basis* tensors upgrades
    to orthogonality to *every* elementary tensor. This is pure Hilbert-space geometry: expand a
    vector along a basis and push the sum through the continuous linear map
-   `TauCeti.L2prodMulRightL`.
+   `TauCeti.L2prodMulL`.
 2. `TauCeti.setIntegral_prod_eq_zero_of_forall_inner` — testing against indicators, since
    `1ₐ ⊗ 1_b` is the indicator of the rectangle `a ×ˢ b`.
 3. `TauCeti.setIntegral_eq_zero_of_forall_prod` — the Dynkin (π-λ) step, upgrading rectangles to
@@ -209,35 +209,23 @@ theorem norm_L2prodMul [SFinite μ] [SFinite ν] (F : Lp 𝕜 2 μ) (G : Lp 𝕜
     _ = Real.sqrt ((‖F‖ * ‖G‖) ^ 2) := by rw [h3]
     _ = ‖F‖ * ‖G‖ := Real.sqrt_sq (by positivity)
 
-/-- Tensoring on the right with a fixed `L²(ν)` vector, as a continuous linear map. -/
-noncomputable def L2prodMulLeftL [SFinite μ] [SFinite ν] (G : Lp 𝕜 2 ν) :
-    Lp 𝕜 2 μ →L[𝕜] Lp 𝕜 2 (μ.prod ν) :=
-  LinearMap.mkContinuous
-    { toFun := fun F => L2prodMul F G
-      map_add' := fun F₁ F₂ => L2prodMul_add_left F₁ F₂ G
-      map_smul' := fun c F => L2prodMul_smul_left c F G }
-    ‖G‖ fun F => by simp [mul_comm]
+/-- **The tensor as a bounded bilinear map.** `L2prodMulL F G = L2prodMul F G`, packaged so that
+either operand can be fixed: `L2prodMulL F` fixes the left factor, `L2prodMulL.flip G` the right.
+The operator norm bound is `1`, since `norm_L2prodMul` is an equality. -/
+noncomputable def L2prodMulL [SFinite μ] [SFinite ν] :
+    Lp 𝕜 2 μ →L[𝕜] Lp 𝕜 2 ν →L[𝕜] Lp 𝕜 2 (μ.prod ν) :=
+  LinearMap.mkContinuous₂
+    (LinearMap.mk₂ 𝕜 L2prodMul
+      (fun F₁ F₂ G => L2prodMul_add_left F₁ F₂ G)
+      (fun c F G => L2prodMul_smul_left c F G)
+      (fun F G₁ G₂ => L2prodMul_add_right F G₁ G₂)
+      (fun c F G => L2prodMul_smul_right c F G))
+    1 fun F G => by simp [norm_L2prodMul]
 
-/-- Tensoring on the left with a fixed `L²(μ)` vector, as a continuous linear map. -/
-noncomputable def L2prodMulRightL [SFinite μ] [SFinite ν] (F : Lp 𝕜 2 μ) :
-    Lp 𝕜 2 ν →L[𝕜] Lp 𝕜 2 (μ.prod ν) :=
-  LinearMap.mkContinuous
-    { toFun := fun G => L2prodMul F G
-      map_add' := fun G₁ G₂ => L2prodMul_add_right F G₁ G₂
-      map_smul' := fun c G => L2prodMul_smul_right c F G }
-    ‖F‖ fun G => le_of_eq (norm_L2prodMul F G)
-
-/-- `L2prodMulLeftL` applies as the tensor. -/
 @[simp]
-theorem L2prodMulLeftL_apply [SFinite μ] [SFinite ν] (G : Lp 𝕜 2 ν) (F : Lp 𝕜 2 μ) :
-    L2prodMulLeftL G F = L2prodMul F G :=
-  LinearMap.mkContinuous_apply _ _ _ _
-
-/-- `L2prodMulRightL` applies as the tensor. -/
-@[simp]
-theorem L2prodMulRightL_apply [SFinite μ] [SFinite ν] (F : Lp 𝕜 2 μ) (G : Lp 𝕜 2 ν) :
-    L2prodMulRightL F G = L2prodMul F G :=
-  LinearMap.mkContinuous_apply _ _ _ _
+theorem L2prodMulL_apply [SFinite μ] [SFinite ν] (F : Lp 𝕜 2 μ) (G : Lp 𝕜 2 ν) :
+    L2prodMulL F G = L2prodMul F G :=
+  LinearMap.mkContinuous₂_apply _ _ _ _
 
 /-- **Basis tensors detect all tensors.** A vector orthogonal to every tensor built from two Hilbert
 bases is orthogonal to *every* elementary tensor. This is the countability-free half of the
@@ -248,15 +236,15 @@ theorem inner_L2prodMul_eq_zero_of_forall_basis [SFinite μ] [SFinite ν] {ι₁
     (F : Lp 𝕜 2 μ) (G : Lp 𝕜 2 ν) : inner 𝕜 h (L2prodMul F G) = 0 := by
   have step : ∀ i : ι₁, ∀ G' : Lp 𝕜 2 ν, inner 𝕜 h (L2prodMul (b₁ i) G') = 0 := by
     intro i G'
-    have hsum := ((b₂.hasSum_repr G').mapL ((innerSL 𝕜 h).comp (L2prodMulRightL (b₁ i))))
+    have hsum := ((b₂.hasSum_repr G').mapL ((innerSL 𝕜 h).comp (L2prodMulL (b₁ i))))
     have hzero : HasSum (fun _ : ι₂ => (0 : 𝕜))
-        ((innerSL 𝕜 h).comp (L2prodMulRightL (b₁ i)) G') := by
+        ((innerSL 𝕜 h).comp (L2prodMulL (b₁ i)) G') := by
       refine hsum.congr_fun fun j => ?_
       simp [hz i j]
     simpa using (hasSum_zero.unique hzero).symm
-  have hsum := ((b₁.hasSum_repr F).mapL ((innerSL 𝕜 h).comp (L2prodMulLeftL G)))
+  have hsum := ((b₁.hasSum_repr F).mapL ((innerSL 𝕜 h).comp (L2prodMulL.flip G)))
   have hzero : HasSum (fun _ : ι₁ => (0 : 𝕜))
-      ((innerSL 𝕜 h).comp (L2prodMulLeftL G) F) := by
+      ((innerSL 𝕜 h).comp (L2prodMulL.flip G) F) := by
     refine hsum.congr_fun fun i => ?_
     simp [step i G]
   simpa using (hasSum_zero.unique hzero).symm

--- a/TauCeti/Analysis/InnerProductSpace/L2Product.lean
+++ b/TauCeti/Analysis/InnerProductSpace/L2Product.lean
@@ -59,7 +59,8 @@ complex `L²` spaces.
 * `TauCeti.orthonormal_L2prodMul` — products of orthonormal families are orthonormal.
 * `TauCeti.orthogonal_span_range_L2prodMul_eq_bot` — the completeness half: the basis tensors have
   trivial orthogonal complement.
-* `TauCeti.coeFn_prodHilbertBasis` — the `(i, j)` basis vector is a.e. the product `b₁ i ⊗ b₂ j`.
+* `TauCeti.prodHilbertBasis_apply` — the `(i, j)` basis vector is the tensor `b₁ i ⊗ b₂ j`;
+  `TauCeti.coeFn_prodHilbertBasis` gives its a.e. representative.
 -/
 
 public section
@@ -367,11 +368,19 @@ noncomputable def prodHilbertBasis [SigmaFinite μ] [SigmaFinite ν] {ι₁ ι�
     (orthonormal_L2prodMul b₁.orthonormal b₂.orthonormal)
     (orthogonal_span_range_L2prodMul_eq_bot b₁ b₂)
 
+/-- The `(i, j)` vector of `prodHilbertBasis` is the tensor of the `i`-th and `j`-th basis
+vectors. -/
+@[simp]
+theorem prodHilbertBasis_apply [SigmaFinite μ] [SigmaFinite ν] {ι₁ ι₂ : Type*}
+    (b₁ : HilbertBasis ι₁ 𝕜 (Lp 𝕜 2 μ)) (b₂ : HilbertBasis ι₂ 𝕜 (Lp 𝕜 2 ν)) (i : ι₁) (j : ι₂) :
+    prodHilbertBasis b₁ b₂ (i, j) = L2prodMul (b₁ i) (b₂ j) := by
+  rw [prodHilbertBasis, HilbertBasis.coe_mkOfOrthogonalEqBot]
+
 /-- The `(i, j)` vector of `prodHilbertBasis` is a.e. the pointwise product `b₁ i ⊗ b₂ j`. -/
 theorem coeFn_prodHilbertBasis [SigmaFinite μ] [SigmaFinite ν] {ι₁ ι₂ : Type*}
     (b₁ : HilbertBasis ι₁ 𝕜 (Lp 𝕜 2 μ)) (b₂ : HilbertBasis ι₂ 𝕜 (Lp 𝕜 2 ν)) (i : ι₁) (j : ι₂) :
     ⇑(prodHilbertBasis b₁ b₂ (i, j)) =ᵐ[μ.prod ν] fun q : α × β => b₁ i q.1 * b₂ j q.2 := by
-  rw [prodHilbertBasis, HilbertBasis.coe_mkOfOrthogonalEqBot]
+  rw [prodHilbertBasis_apply]
   exact coeFn_L2prodMul _ _
 
 end TauCeti

--- a/TauCeti/Analysis/InnerProductSpace/L2Product.lean
+++ b/TauCeti/Analysis/InnerProductSpace/L2Product.lean
@@ -6,6 +6,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Claude
 -/
 public import Mathlib.Analysis.InnerProductSpace.l2Space
+public import Mathlib.MeasureTheory.Function.AEEqOfIntegral
 public import Mathlib.MeasureTheory.Function.L2Space
 public import Mathlib.MeasureTheory.Integral.Prod
 
@@ -18,13 +19,25 @@ as a tensor:
 `⟪f₁ ⊗ g₁, f₂ ⊗ g₂⟫ = ⟪f₁, f₂⟫ * ⟪g₁, g₂⟫`.
 Consequently the products of two orthonormal families are an orthonormal family of `L²(μ ⊗ ν)`.
 
-This is the Fubini orthonormality half of Part B3 of the `OrthogonalL2Bases` roadmap (the product
-`L²`-basis milestone): the elementary tensors are orthonormal, and their inner products separate.
+This is Part B3 of the `OrthogonalL2Bases` roadmap (the product `L²`-basis milestone), in both
+halves: the elementary tensors are orthonormal *and* they span, so for σ-finite factors the
+products of two Hilbert bases form a Hilbert basis `TauCeti.prodHilbertBasis` of `L²(μ ⊗ ν)`.
 It is a genuine gap in Mathlib, which provides only `MemLp.comp_fst`/`MemLp.comp_snd`
 (single-factor membership, and only for finite measures) and the finite-dimensional
-`OrthonormalBasis.tensorProduct`; there is no `L²(μ.prod ν)` product API. The completeness half —
-that these tensors *span* `L²(μ ⊗ ν)`, hence form a Hilbert basis — is left to a separate
-construction; this file supplies the orthonormality input it consumes.
+`OrthonormalBasis.tensorProduct`; there is no `L²(μ.prod ν)` product API.
+
+The completeness half avoids any slicing argument, and with it any countability assumption on the
+index types. It runs in three moves:
+
+1. `TauCeti.inner_L2prodMul_eq_zero_of_forall_basis` — orthogonality to the *basis* tensors upgrades
+   to orthogonality to *every* elementary tensor. This is pure Hilbert-space geometry: expand a
+   vector along a basis and push the sum through the continuous linear map
+   `TauCeti.L2prodMulRightL`.
+2. `TauCeti.setIntegral_prod_eq_zero_of_forall_inner` — testing against indicators, since
+   `1ₐ ⊗ 1_b` is the indicator of the rectangle `a ×ˢ b`.
+3. `TauCeti.setIntegral_eq_zero_of_forall_prod` — the Dynkin (π-λ) step, upgrading rectangles to
+   arbitrary measurable sets inside a finite box, followed by a monotone exhaustion of the space by
+   the boxes `spanningSets μ n ×ˢ spanningSets ν n`.
 
 The scalars are generic over `[RCLike 𝕜]`, so a single construction serves both the real and
 complex `L²` spaces.
@@ -33,6 +46,8 @@ complex `L²` spaces.
 
 * `TauCeti.L2prodMul` — the pointwise product `(x, y) ↦ f x * g y` of `F : L²(μ)` and `G : L²(ν)`
   as a vector of `L²(μ ⊗ ν)`.
+* `TauCeti.prodHilbertBasis` — the Hilbert basis of `L²(μ ⊗ ν)` built from Hilbert bases of the
+  factors.
 
 ## Main statements
 
@@ -41,6 +56,9 @@ complex `L²` spaces.
 * `TauCeti.inner_L2prodMul` — the inner product of two tensors factors as a product of inner
   products.
 * `TauCeti.orthonormal_L2prodMul` — products of orthonormal families are orthonormal.
+* `TauCeti.orthogonal_span_range_L2prodMul_eq_bot` — the completeness half: the basis tensors have
+  trivial orthogonal complement.
+* `TauCeti.coeFn_prodHilbertBasis` — the `(i, j)` basis vector is a.e. the product `b₁ i ⊗ b₂ j`.
 -/
 
 public section
@@ -221,14 +239,6 @@ theorem inner_L2prodMul_eq_zero_of_forall_basis [SFinite μ] [SFinite ν] {ι₁
     simp [step i G]
   simpa using (hasSum_zero.unique hzero).symm
 
-/-- **Completeness of the tensor family.** The elementary tensors built from two Hilbert bases have
-trivial orthogonal complement in `L²(μ ⊗ ν)`. -/
-theorem orthogonal_span_range_L2prodMul_eq_bot [SFinite μ] [SFinite ν] {ι₁ ι₂ : Type*}
-    (b₁ : HilbertBasis ι₁ 𝕜 (Lp 𝕜 2 μ)) (b₂ : HilbertBasis ι₂ 𝕜 (Lp 𝕜 2 ν)) :
-    (Submodule.span 𝕜
-      (Set.range (fun ij : ι₁ × ι₂ => L2prodMul (b₁ ij.1) (b₂ ij.2))))ᗮ = ⊥ := by
-  sorry
-
 /-- **The Dynkin (π-λ) step.** On a finite measure over a product space, a function whose integral
 vanishes on every measurable rectangle has vanishing integral on every measurable set. Rectangles
 are a π-system generating the product σ-algebra, so `MeasurableSpace.induction_on_inter` applies. -/
@@ -275,9 +285,91 @@ theorem setIntegral_prod_eq_zero_of_forall_inner [SFinite μ] [SFinite ν]
     _ = inner 𝕜 (L2prodMul F G) h := (L2.inner_def _ _).symm
     _ = 0 := hz F G
 
+/-- An `L²` function is integrable on any set of finite measure. -/
+theorem integrableOn_of_measure_lt_top [SFinite μ] [SFinite ν] (h : Lp 𝕜 2 (μ.prod ν))
+    {s : Set (α × β)} (hfin : (μ.prod ν) s < ⊤) : IntegrableOn (⇑h) s (μ.prod ν) := by
+  have : IsFiniteMeasure ((μ.prod ν).restrict s) := ⟨by rwa [Measure.restrict_apply_univ]⟩
+  exact ((Lp.memLp h).restrict s).integrable one_le_two
+
+/-- **Orthogonality kills every finite-measure set integral.** Exhaust the product space by finite
+boxes `spanningSets μ n ×ˢ spanningSets ν n`, run the Dynkin step inside each box, and pass to the
+monotone limit. -/
+theorem setIntegral_eq_zero_of_forall_inner [SigmaFinite μ] [SigmaFinite ν]
+    {h : Lp 𝕜 2 (μ.prod ν)}
+    (hz : ∀ (F : Lp 𝕜 2 μ) (G : Lp 𝕜 2 ν), inner 𝕜 (L2prodMul F G) h = 0)
+    (u : Set (α × β)) (hu : MeasurableSet u) (hfin : (μ.prod ν) u < ⊤) :
+    ∫ p in u, h p ∂(μ.prod ν) = 0 := by
+  have hAm : ∀ n, MeasurableSet (spanningSets μ n) := measurableSet_spanningSets μ
+  have hBm : ∀ n, MeasurableSet (spanningSets ν n) := measurableSet_spanningSets ν
+  have hboxfin : ∀ n, (μ.prod ν) (spanningSets μ n ×ˢ spanningSets ν n) < ⊤ := by
+    intro n
+    rw [Measure.prod_prod]
+    exact ENNReal.mul_lt_top (measure_spanningSets_lt_top μ n) (measure_spanningSets_lt_top ν n)
+  have hbox : ∀ n, ∫ p in u ∩ (spanningSets μ n ×ˢ spanningSets ν n), h p ∂(μ.prod ν) = 0 := by
+    intro n
+    have hfm : IsFiniteMeasure
+        ((μ.prod ν).restrict (spanningSets μ n ×ˢ spanningSets ν n)) :=
+      ⟨by rw [Measure.restrict_apply_univ]; exact hboxfin n⟩
+    have hrect : ∀ s, MeasurableSet s → ∀ t, MeasurableSet t →
+        ∫ p in s ×ˢ t, h p ∂((μ.prod ν).restrict
+          (spanningSets μ n ×ˢ spanningSets ν n)) = 0 := by
+      intro s hs t ht
+      rw [Measure.restrict_restrict (hs.prod ht), Set.prod_inter_prod]
+      exact setIntegral_prod_eq_zero_of_forall_inner hz (hs.inter (hAm n))
+        (lt_of_le_of_lt (measure_mono Set.inter_subset_right)
+          (measure_spanningSets_lt_top μ n)).ne
+        (ht.inter (hBm n))
+        (lt_of_le_of_lt (measure_mono Set.inter_subset_right)
+          (measure_spanningSets_lt_top ν n)).ne
+    have hdyn := setIntegral_eq_zero_of_forall_prod
+      (integrableOn_of_measure_lt_top h (hboxfin n)) hrect u hu
+    rwa [Measure.restrict_restrict hu] at hdyn
+  have hmono : Monotone fun n => u ∩ (spanningSets μ n ×ˢ spanningSets ν n) := fun m n hmn =>
+    Set.inter_subset_inter_right _
+      (Set.prod_mono (monotone_spanningSets μ hmn) (monotone_spanningSets ν hmn))
+  have hcover : ⋃ n, u ∩ (spanningSets μ n ×ˢ spanningSets ν n) = u := by
+    rw [← Set.inter_iUnion]
+    have huniv : ⋃ n, (spanningSets μ n ×ˢ spanningSets ν n) = Set.univ := by
+      refine Set.eq_univ_of_forall fun p => ?_
+      have h1 : p.1 ∈ ⋃ n, spanningSets μ n := by rw [iUnion_spanningSets]; trivial
+      have h2 : p.2 ∈ ⋃ n, spanningSets ν n := by rw [iUnion_spanningSets]; trivial
+      obtain ⟨i, hi⟩ := Set.mem_iUnion.1 h1
+      obtain ⟨j, hj⟩ := Set.mem_iUnion.1 h2
+      exact Set.mem_iUnion.2 ⟨max i j, monotone_spanningSets μ (le_max_left i j) hi,
+        monotone_spanningSets ν (le_max_right i j) hj⟩
+    rw [huniv, Set.inter_univ]
+  have htend := tendsto_setIntegral_of_monotone
+    (fun n => hu.inter ((hAm n).prod (hBm n))) hmono
+    (by rw [hcover]; exact integrableOn_of_measure_lt_top h hfin)
+  rw [hcover] at htend
+  simp only [hbox] at htend
+  exact tendsto_nhds_unique htend tendsto_const_nhds
+
+/-- **Completeness of the tensor family.** The elementary tensors built from two Hilbert bases have
+trivial orthogonal complement in `L²(μ ⊗ ν)`: a vector orthogonal to all of them is orthogonal to
+every elementary tensor, hence integrates to zero on every rectangle, hence on every finite-measure
+set, hence vanishes. -/
+theorem orthogonal_span_range_L2prodMul_eq_bot [SigmaFinite μ] [SigmaFinite ν] {ι₁ ι₂ : Type*}
+    (b₁ : HilbertBasis ι₁ 𝕜 (Lp 𝕜 2 μ)) (b₂ : HilbertBasis ι₂ 𝕜 (Lp 𝕜 2 ν)) :
+    (Submodule.span 𝕜
+      (Set.range (fun ij : ι₁ × ι₂ => L2prodMul (b₁ ij.1) (b₂ ij.2))))ᗮ = ⊥ := by
+  refine (Submodule.eq_bot_iff _).2 fun h hh => ?_
+  rw [Submodule.mem_orthogonal] at hh
+  have hz : ∀ (F : Lp 𝕜 2 μ) (G : Lp 𝕜 2 ν), inner 𝕜 (L2prodMul F G) h = 0 := by
+    intro F G
+    rw [inner_eq_zero_symm]
+    refine inner_L2prodMul_eq_zero_of_forall_basis b₁ b₂ (fun i j => ?_) F G
+    rw [inner_eq_zero_symm]
+    exact hh _ (Submodule.subset_span ⟨(i, j), rfl⟩)
+  have hae := Lp.ae_eq_zero_of_forall_setIntegral_eq_zero h (by norm_num) (by norm_num)
+    (fun s _ hs' => integrableOn_of_measure_lt_top h hs')
+    (fun s hs hs' => setIntegral_eq_zero_of_forall_inner hz s hs hs')
+  rw [Lp.ext_iff]
+  exact hae.trans (Lp.coeFn_zero 𝕜 2 (μ.prod ν)).symm
+
 /-- **The product Hilbert basis.** Pointwise products of two Hilbert bases form a Hilbert basis of
 `L²(μ ⊗ ν)`, indexed by the product of the index types. -/
-noncomputable def prodHilbertBasis [SFinite μ] [SFinite ν] {ι₁ ι₂ : Type*}
+noncomputable def prodHilbertBasis [SigmaFinite μ] [SigmaFinite ν] {ι₁ ι₂ : Type*}
     (b₁ : HilbertBasis ι₁ 𝕜 (Lp 𝕜 2 μ)) (b₂ : HilbertBasis ι₂ 𝕜 (Lp 𝕜 2 ν)) :
     HilbertBasis (ι₁ × ι₂) 𝕜 (Lp 𝕜 2 (μ.prod ν)) :=
   HilbertBasis.mkOfOrthogonalEqBot
@@ -285,7 +377,7 @@ noncomputable def prodHilbertBasis [SFinite μ] [SFinite ν] {ι₁ ι₂ : Type
     (orthogonal_span_range_L2prodMul_eq_bot b₁ b₂)
 
 /-- The `(i, j)` vector of `prodHilbertBasis` is a.e. the pointwise product `b₁ i ⊗ b₂ j`. -/
-theorem coeFn_prodHilbertBasis [SFinite μ] [SFinite ν] {ι₁ ι₂ : Type*}
+theorem coeFn_prodHilbertBasis [SigmaFinite μ] [SigmaFinite ν] {ι₁ ι₂ : Type*}
     (b₁ : HilbertBasis ι₁ 𝕜 (Lp 𝕜 2 μ)) (b₂ : HilbertBasis ι₂ 𝕜 (Lp 𝕜 2 ν)) (i : ι₁) (j : ι₂) :
     ⇑(prodHilbertBasis b₁ b₂ (i, j)) =ᵐ[μ.prod ν] fun q : α × β => b₁ i q.1 * b₂ j q.2 := by
   rw [prodHilbertBasis, HilbertBasis.coe_mkOfOrthogonalEqBot]

--- a/TauCeti/Analysis/InnerProductSpace/L2Product.lean
+++ b/TauCeti/Analysis/InnerProductSpace/L2Product.lean
@@ -107,6 +107,7 @@ theorem ae_of_ae_snd [SFinite μ] [SFinite ν] {p : β → Prop} (hp : ∀ᵐ y 
     ∀ᵐ q : α × β ∂(μ.prod ν), p q.2 :=
   Measure.quasiMeasurePreserving_snd.tendsto_ae.eventually hp
 
+/-- The tensor is additive in its first argument. -/
 theorem L2prodMul_add_left [SFinite μ] [SFinite ν] (F₁ F₂ : Lp 𝕜 2 μ) (G : Lp 𝕜 2 ν) :
     L2prodMul (F₁ + F₂) G = L2prodMul F₁ G + L2prodMul F₂ G := by
   rw [Lp.ext_iff]
@@ -115,6 +116,7 @@ theorem L2prodMul_add_left [SFinite μ] [SFinite ν] (F₁ F₂ : Lp 𝕜 2 μ) 
     ae_of_ae_fst (β := β) (ν := ν) (Lp.coeFn_add F₁ F₂)] with q h h1 h2 hadd hf
   rw [h, hadd, Pi.add_apply, h1, h2, hf, Pi.add_apply, add_mul]
 
+/-- The tensor is additive in its second argument. -/
 theorem L2prodMul_add_right [SFinite μ] [SFinite ν] (F : Lp 𝕜 2 μ) (G₁ G₂ : Lp 𝕜 2 ν) :
     L2prodMul F (G₁ + G₂) = L2prodMul F G₁ + L2prodMul F G₂ := by
   rw [Lp.ext_iff]
@@ -123,6 +125,7 @@ theorem L2prodMul_add_right [SFinite μ] [SFinite ν] (F : Lp 𝕜 2 μ) (G₁ G
     ae_of_ae_snd (α := α) (μ := μ) (Lp.coeFn_add G₁ G₂)] with q h h1 h2 hadd hg
   rw [h, hadd, Pi.add_apply, h1, h2, hg, Pi.add_apply, mul_add]
 
+/-- The tensor is homogeneous in its first argument. -/
 theorem L2prodMul_smul_left [SFinite μ] [SFinite ν] (c : 𝕜) (F : Lp 𝕜 2 μ) (G : Lp 𝕜 2 ν) :
     L2prodMul (c • F) G = c • L2prodMul F G := by
   rw [Lp.ext_iff]
@@ -131,6 +134,7 @@ theorem L2prodMul_smul_left [SFinite μ] [SFinite ν] (c : 𝕜) (F : Lp 𝕜 2 
     ae_of_ae_fst (β := β) (ν := ν) (Lp.coeFn_smul c F)] with q h h1 hsmul hf
   rw [h, hsmul, Pi.smul_apply, h1, hf, Pi.smul_apply, smul_eq_mul, smul_eq_mul, mul_assoc]
 
+/-- The tensor is homogeneous in its second argument. -/
 theorem L2prodMul_smul_right [SFinite μ] [SFinite ν] (c : 𝕜) (F : Lp 𝕜 2 μ) (G : Lp 𝕜 2 ν) :
     L2prodMul F (c • G) = c • L2prodMul F G := by
   rw [Lp.ext_iff]
@@ -209,10 +213,12 @@ theorem norm_L2prodMul [SFinite μ] [SFinite ν] (F : Lp 𝕜 2 μ) (G : Lp 𝕜
       map_smul' := fun c G => L2prodMul_smul_right c F G }
     ‖F‖ fun G => le_of_eq (norm_L2prodMul F G)
 
+/-- `L2prodMulLeftL` applies as the tensor. -/
 @[simp]
 theorem L2prodMulLeftL_apply [SFinite μ] [SFinite ν] (G : Lp 𝕜 2 ν) (F : Lp 𝕜 2 μ) :
     L2prodMulLeftL G F = L2prodMul F G := rfl
 
+/-- `L2prodMulRightL` applies as the tensor. -/
 @[simp]
 theorem L2prodMulRightL_apply [SFinite μ] [SFinite ν] (F : Lp 𝕜 2 μ) (G : Lp 𝕜 2 ν) :
     L2prodMulRightL F G = L2prodMul F G := rfl

--- a/TauCeti/Analysis/InnerProductSpace/L2Product.lean
+++ b/TauCeti/Analysis/InnerProductSpace/L2Product.lean
@@ -8,7 +8,6 @@ Authors: Claude
 public import Mathlib.Analysis.InnerProductSpace.l2Space
 public import Mathlib.MeasureTheory.Function.AEEqOfIntegral
 public import Mathlib.MeasureTheory.Function.L2Space
-public import Mathlib.MeasureTheory.Integral.Prod
 public import TauCeti.MeasureTheory.Integral.Prod
 
 /-!
@@ -100,6 +99,7 @@ theorem coeFn_L2prodMul [SFinite μ] [SFinite ν] (F : Lp 𝕜 2 μ) (G : Lp �
   MemLp.coeFn_toLp _
 
 /-- The tensor is additive in its first argument. -/
+@[simp]
 theorem L2prodMul_add_left [SFinite μ] [SFinite ν] (F₁ F₂ : Lp 𝕜 2 μ) (G : Lp 𝕜 2 ν) :
     L2prodMul (F₁ + F₂) G = L2prodMul F₁ G + L2prodMul F₂ G := by
   rw [Lp.ext_iff]
@@ -109,6 +109,7 @@ theorem L2prodMul_add_left [SFinite μ] [SFinite ν] (F₁ F₂ : Lp 𝕜 2 μ) 
   rw [h, hadd, Pi.add_apply, h1, h2, hf, Pi.add_apply, add_mul]
 
 /-- The tensor is additive in its second argument. -/
+@[simp]
 theorem L2prodMul_add_right [SFinite μ] [SFinite ν] (F : Lp 𝕜 2 μ) (G₁ G₂ : Lp 𝕜 2 ν) :
     L2prodMul F (G₁ + G₂) = L2prodMul F G₁ + L2prodMul F G₂ := by
   rw [Lp.ext_iff]
@@ -118,6 +119,7 @@ theorem L2prodMul_add_right [SFinite μ] [SFinite ν] (F : Lp 𝕜 2 μ) (G₁ G
   rw [h, hadd, Pi.add_apply, h1, h2, hg, Pi.add_apply, mul_add]
 
 /-- The tensor is homogeneous in its first argument. -/
+@[simp]
 theorem L2prodMul_smul_left [SFinite μ] [SFinite ν] (c : 𝕜) (F : Lp 𝕜 2 μ) (G : Lp 𝕜 2 ν) :
     L2prodMul (c • F) G = c • L2prodMul F G := by
   rw [Lp.ext_iff]
@@ -127,6 +129,7 @@ theorem L2prodMul_smul_left [SFinite μ] [SFinite ν] (c : 𝕜) (F : Lp 𝕜 2 
   rw [h, hsmul, Pi.smul_apply, h1, hf, Pi.smul_apply, smul_eq_mul, smul_eq_mul, mul_assoc]
 
 /-- The tensor is homogeneous in its second argument. -/
+@[simp]
 theorem L2prodMul_smul_right [SFinite μ] [SFinite ν] (c : 𝕜) (F : Lp 𝕜 2 μ) (G : Lp 𝕜 2 ν) :
     L2prodMul F (c • G) = c • L2prodMul F G := by
   rw [Lp.ext_iff]
@@ -134,6 +137,24 @@ theorem L2prodMul_smul_right [SFinite μ] [SFinite ν] (c : 𝕜) (F : Lp 𝕜 2
     Lp.coeFn_smul c (L2prodMul F G),
     ae_of_ae_snd (α := α) (μ := μ) (Lp.coeFn_smul c G)] with q h h1 hsmul hg
   rw [h, hsmul, Pi.smul_apply, h1, hg, Pi.smul_apply, smul_eq_mul, smul_eq_mul, mul_left_comm]
+
+/-- The tensor vanishes when its first argument does. -/
+@[simp]
+theorem L2prodMul_zero_left [SFinite μ] [SFinite ν] (G : Lp 𝕜 2 ν) :
+    L2prodMul (0 : Lp 𝕜 2 μ) G = 0 := by
+  rw [Lp.ext_iff]
+  filter_upwards [coeFn_L2prodMul (0 : Lp 𝕜 2 μ) G, Lp.coeFn_zero 𝕜 2 (μ.prod ν),
+    ae_of_ae_fst (β := β) (ν := ν) (Lp.coeFn_zero 𝕜 2 μ)] with q h hz hf
+  rw [h, hz, hf, Pi.zero_apply, Pi.zero_apply, zero_mul]
+
+/-- The tensor vanishes when its second argument does. -/
+@[simp]
+theorem L2prodMul_zero_right [SFinite μ] [SFinite ν] (F : Lp 𝕜 2 μ) :
+    L2prodMul F (0 : Lp 𝕜 2 ν) = 0 := by
+  rw [Lp.ext_iff]
+  filter_upwards [coeFn_L2prodMul F (0 : Lp 𝕜 2 ν), Lp.coeFn_zero 𝕜 2 (μ.prod ν),
+    ae_of_ae_snd (α := α) (μ := μ) (Lp.coeFn_zero 𝕜 2 ν)] with q h hz hg
+  rw [h, hz, hg, Pi.zero_apply, Pi.zero_apply, mul_zero]
 
 /-- **The tensor inner-product identity.** The inner product of two pointwise-product vectors in
 `L²(μ ⊗ ν)` factors as the product of the inner products of the factors. -/

--- a/TauCeti/Analysis/InnerProductSpace/L2Product.lean
+++ b/TauCeti/Analysis/InnerProductSpace/L2Product.lean
@@ -5,6 +5,7 @@ Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Claude
 -/
+public import Mathlib.Analysis.InnerProductSpace.l2Space
 public import Mathlib.MeasureTheory.Function.L2Space
 public import Mathlib.MeasureTheory.Integral.Prod
 
@@ -78,6 +79,48 @@ theorem coeFn_L2prodMul [SFinite μ] [SFinite ν] (F : Lp 𝕜 2 μ) (G : Lp �
     ⇑(L2prodMul F G) =ᵐ[μ.prod ν] fun p : α × β => F p.1 * G p.2 :=
   MemLp.coeFn_toLp _
 
+/-- An a.e. statement on the first factor transfers to the product measure. -/
+theorem ae_of_ae_fst [SFinite μ] [SFinite ν] {p : α → Prop} (hp : ∀ᵐ x ∂μ, p x) :
+    ∀ᵐ q : α × β ∂(μ.prod ν), p q.1 :=
+  Measure.quasiMeasurePreserving_fst.tendsto_ae.eventually hp
+
+/-- An a.e. statement on the second factor transfers to the product measure. -/
+theorem ae_of_ae_snd [SFinite μ] [SFinite ν] {p : β → Prop} (hp : ∀ᵐ y ∂ν, p y) :
+    ∀ᵐ q : α × β ∂(μ.prod ν), p q.2 :=
+  Measure.quasiMeasurePreserving_snd.tendsto_ae.eventually hp
+
+theorem L2prodMul_add_left [SFinite μ] [SFinite ν] (F₁ F₂ : Lp 𝕜 2 μ) (G : Lp 𝕜 2 ν) :
+    L2prodMul (F₁ + F₂) G = L2prodMul F₁ G + L2prodMul F₂ G := by
+  rw [Lp.ext_iff]
+  filter_upwards [coeFn_L2prodMul (F₁ + F₂) G, coeFn_L2prodMul F₁ G, coeFn_L2prodMul F₂ G,
+    Lp.coeFn_add (L2prodMul F₁ G) (L2prodMul F₂ G),
+    ae_of_ae_fst (β := β) (ν := ν) (Lp.coeFn_add F₁ F₂)] with q h h1 h2 hadd hf
+  rw [h, hadd, Pi.add_apply, h1, h2, hf, Pi.add_apply, add_mul]
+
+theorem L2prodMul_add_right [SFinite μ] [SFinite ν] (F : Lp 𝕜 2 μ) (G₁ G₂ : Lp 𝕜 2 ν) :
+    L2prodMul F (G₁ + G₂) = L2prodMul F G₁ + L2prodMul F G₂ := by
+  rw [Lp.ext_iff]
+  filter_upwards [coeFn_L2prodMul F (G₁ + G₂), coeFn_L2prodMul F G₁, coeFn_L2prodMul F G₂,
+    Lp.coeFn_add (L2prodMul F G₁) (L2prodMul F G₂),
+    ae_of_ae_snd (α := α) (μ := μ) (Lp.coeFn_add G₁ G₂)] with q h h1 h2 hadd hg
+  rw [h, hadd, Pi.add_apply, h1, h2, hg, Pi.add_apply, mul_add]
+
+theorem L2prodMul_smul_left [SFinite μ] [SFinite ν] (c : 𝕜) (F : Lp 𝕜 2 μ) (G : Lp 𝕜 2 ν) :
+    L2prodMul (c • F) G = c • L2prodMul F G := by
+  rw [Lp.ext_iff]
+  filter_upwards [coeFn_L2prodMul (c • F) G, coeFn_L2prodMul F G,
+    Lp.coeFn_smul c (L2prodMul F G),
+    ae_of_ae_fst (β := β) (ν := ν) (Lp.coeFn_smul c F)] with q h h1 hsmul hf
+  rw [h, hsmul, Pi.smul_apply, h1, hf, Pi.smul_apply, smul_eq_mul, smul_eq_mul, mul_assoc]
+
+theorem L2prodMul_smul_right [SFinite μ] [SFinite ν] (c : 𝕜) (F : Lp 𝕜 2 μ) (G : Lp 𝕜 2 ν) :
+    L2prodMul F (c • G) = c • L2prodMul F G := by
+  rw [Lp.ext_iff]
+  filter_upwards [coeFn_L2prodMul F (c • G), coeFn_L2prodMul F G,
+    Lp.coeFn_smul c (L2prodMul F G),
+    ae_of_ae_snd (α := α) (μ := μ) (Lp.coeFn_smul c G)] with q h h1 hsmul hg
+  rw [h, hsmul, Pi.smul_apply, h1, hg, Pi.smul_apply, smul_eq_mul, smul_eq_mul, mul_left_comm]
+
 /-- **The tensor inner-product identity.** The inner product of two pointwise-product vectors in
 `L²(μ ⊗ ν)` factors as the product of the inner products of the factors. -/
 @[simp]
@@ -113,5 +156,93 @@ theorem orthonormal_L2prodMul [SFinite μ] [SFinite ν] {ι₁ ι₂ : Type*}
   rw [inner_L2prodMul, hb, hc]
   by_cases h1 : ij.1 = kl.1 <;> by_cases h2 : ij.2 = kl.2 <;>
     simp [h1, h2, Prod.ext_iff]
+
+/-- The tensor construction is norm-multiplicative. -/
+@[simp]
+theorem norm_L2prodMul [SFinite μ] [SFinite ν] (F : Lp 𝕜 2 μ) (G : Lp 𝕜 2 ν) :
+    ‖L2prodMul F G‖ = ‖F‖ * ‖G‖ := by
+  have h : ((‖L2prodMul F G‖ : ℝ) : 𝕜) ^ 2 = ((‖F‖ : ℝ) : 𝕜) ^ 2 * ((‖G‖ : ℝ) : 𝕜) ^ 2 := by
+    simpa only [inner_self_eq_norm_sq_to_K] using inner_L2prodMul (𝕜 := 𝕜) F F G G
+  have h3 : ‖L2prodMul F G‖ ^ 2 = (‖F‖ * ‖G‖) ^ 2 := by
+    have hc : ((‖L2prodMul F G‖ ^ 2 : ℝ) : 𝕜) = (((‖F‖ * ‖G‖) ^ 2 : ℝ) : 𝕜) := by
+      push_cast
+      rw [h]
+      ring
+    exact_mod_cast hc
+  calc ‖L2prodMul F G‖ = Real.sqrt (‖L2prodMul F G‖ ^ 2) := (Real.sqrt_sq (norm_nonneg _)).symm
+    _ = Real.sqrt ((‖F‖ * ‖G‖) ^ 2) := by rw [h3]
+    _ = ‖F‖ * ‖G‖ := Real.sqrt_sq (by positivity)
+
+/-- Tensoring on the right with a fixed `L²(ν)` vector, as a continuous linear map. -/
+@[expose] noncomputable def L2prodMulLeftL [SFinite μ] [SFinite ν] (G : Lp 𝕜 2 ν) :
+    Lp 𝕜 2 μ →L[𝕜] Lp 𝕜 2 (μ.prod ν) :=
+  LinearMap.mkContinuous
+    { toFun := fun F => L2prodMul F G
+      map_add' := fun F₁ F₂ => L2prodMul_add_left F₁ F₂ G
+      map_smul' := fun c F => L2prodMul_smul_left c F G }
+    ‖G‖ fun F => by simp [mul_comm]
+
+/-- Tensoring on the left with a fixed `L²(μ)` vector, as a continuous linear map. -/
+@[expose] noncomputable def L2prodMulRightL [SFinite μ] [SFinite ν] (F : Lp 𝕜 2 μ) :
+    Lp 𝕜 2 ν →L[𝕜] Lp 𝕜 2 (μ.prod ν) :=
+  LinearMap.mkContinuous
+    { toFun := fun G => L2prodMul F G
+      map_add' := fun G₁ G₂ => L2prodMul_add_right F G₁ G₂
+      map_smul' := fun c G => L2prodMul_smul_right c F G }
+    ‖F‖ fun G => le_of_eq (norm_L2prodMul F G)
+
+@[simp]
+theorem L2prodMulLeftL_apply [SFinite μ] [SFinite ν] (G : Lp 𝕜 2 ν) (F : Lp 𝕜 2 μ) :
+    L2prodMulLeftL G F = L2prodMul F G := rfl
+
+@[simp]
+theorem L2prodMulRightL_apply [SFinite μ] [SFinite ν] (F : Lp 𝕜 2 μ) (G : Lp 𝕜 2 ν) :
+    L2prodMulRightL F G = L2prodMul F G := rfl
+
+/-- **Basis tensors detect all tensors.** A vector orthogonal to every tensor built from two Hilbert
+bases is orthogonal to *every* elementary tensor. This is the countability-free half of the
+completeness argument: it is pure Hilbert-space geometry, with no null-set bookkeeping. -/
+theorem inner_L2prodMul_eq_zero_of_forall_basis [SFinite μ] [SFinite ν] {ι₁ ι₂ : Type*}
+    (b₁ : HilbertBasis ι₁ 𝕜 (Lp 𝕜 2 μ)) (b₂ : HilbertBasis ι₂ 𝕜 (Lp 𝕜 2 ν))
+    {h : Lp 𝕜 2 (μ.prod ν)} (hz : ∀ i j, inner 𝕜 h (L2prodMul (b₁ i) (b₂ j)) = 0)
+    (F : Lp 𝕜 2 μ) (G : Lp 𝕜 2 ν) : inner 𝕜 h (L2prodMul F G) = 0 := by
+  have step : ∀ i : ι₁, ∀ G' : Lp 𝕜 2 ν, inner 𝕜 h (L2prodMul (b₁ i) G') = 0 := by
+    intro i G'
+    have hsum := ((b₂.hasSum_repr G').mapL ((innerSL 𝕜 h).comp (L2prodMulRightL (b₁ i))))
+    have hzero : HasSum (fun _ : ι₂ => (0 : 𝕜))
+        ((innerSL 𝕜 h).comp (L2prodMulRightL (b₁ i)) G') := by
+      refine hsum.congr_fun fun j => ?_
+      simp [hz i j]
+    simpa using (hasSum_zero.unique hzero).symm
+  have hsum := ((b₁.hasSum_repr F).mapL ((innerSL 𝕜 h).comp (L2prodMulLeftL G)))
+  have hzero : HasSum (fun _ : ι₁ => (0 : 𝕜))
+      ((innerSL 𝕜 h).comp (L2prodMulLeftL G) F) := by
+    refine hsum.congr_fun fun i => ?_
+    simp [step i G]
+  simpa using (hasSum_zero.unique hzero).symm
+
+/-- **Completeness of the tensor family.** The elementary tensors built from two Hilbert bases have
+trivial orthogonal complement in `L²(μ ⊗ ν)`. -/
+theorem orthogonal_span_range_L2prodMul_eq_bot [SFinite μ] [SFinite ν] {ι₁ ι₂ : Type*}
+    (b₁ : HilbertBasis ι₁ 𝕜 (Lp 𝕜 2 μ)) (b₂ : HilbertBasis ι₂ 𝕜 (Lp 𝕜 2 ν)) :
+    (Submodule.span 𝕜
+      (Set.range (fun ij : ι₁ × ι₂ => L2prodMul (b₁ ij.1) (b₂ ij.2))))ᗮ = ⊥ := by
+  sorry
+
+/-- **The product Hilbert basis.** Pointwise products of two Hilbert bases form a Hilbert basis of
+`L²(μ ⊗ ν)`, indexed by the product of the index types. -/
+noncomputable def prodHilbertBasis [SFinite μ] [SFinite ν] {ι₁ ι₂ : Type*}
+    (b₁ : HilbertBasis ι₁ 𝕜 (Lp 𝕜 2 μ)) (b₂ : HilbertBasis ι₂ 𝕜 (Lp 𝕜 2 ν)) :
+    HilbertBasis (ι₁ × ι₂) 𝕜 (Lp 𝕜 2 (μ.prod ν)) :=
+  HilbertBasis.mkOfOrthogonalEqBot
+    (orthonormal_L2prodMul b₁.orthonormal b₂.orthonormal)
+    (orthogonal_span_range_L2prodMul_eq_bot b₁ b₂)
+
+/-- The `(i, j)` vector of `prodHilbertBasis` is a.e. the pointwise product `b₁ i ⊗ b₂ j`. -/
+theorem coeFn_prodHilbertBasis [SFinite μ] [SFinite ν] {ι₁ ι₂ : Type*}
+    (b₁ : HilbertBasis ι₁ 𝕜 (Lp 𝕜 2 μ)) (b₂ : HilbertBasis ι₂ 𝕜 (Lp 𝕜 2 ν)) (i : ι₁) (j : ι₂) :
+    ⇑(prodHilbertBasis b₁ b₂ (i, j)) =ᵐ[μ.prod ν] fun q : α × β => b₁ i q.1 * b₂ j q.2 := by
+  rw [prodHilbertBasis, HilbertBasis.coe_mkOfOrthogonalEqBot]
+  exact coeFn_L2prodMul _ _
 
 end TauCeti

--- a/TauCeti/Analysis/InnerProductSpace/L2Product.lean
+++ b/TauCeti/Analysis/InnerProductSpace/L2Product.lean
@@ -291,12 +291,6 @@ theorem setIntegral_prod_eq_zero_of_forall_inner [SFinite μ] [SFinite ν]
     _ = inner 𝕜 (L2prodMul F G) h := (L2.inner_def _ _).symm
     _ = 0 := hz F G
 
-/-- An `L²` function is integrable on any set of finite measure. -/
-theorem integrableOn_of_measure_lt_top [SFinite μ] [SFinite ν] (h : Lp 𝕜 2 (μ.prod ν))
-    {s : Set (α × β)} (hfin : (μ.prod ν) s < ⊤) : IntegrableOn (⇑h) s (μ.prod ν) := by
-  have : IsFiniteMeasure ((μ.prod ν).restrict s) := ⟨by rwa [Measure.restrict_apply_univ]⟩
-  exact ((Lp.memLp h).restrict s).integrable one_le_two
-
 /-- **Orthogonality kills every finite-measure set integral.** Exhaust the product space by finite
 boxes `spanningSets μ n ×ˢ spanningSets ν n`, run the Dynkin step inside each box, and pass to the
 monotone limit. -/
@@ -328,7 +322,7 @@ theorem setIntegral_eq_zero_of_forall_inner [SigmaFinite μ] [SigmaFinite ν]
         (lt_of_le_of_lt (measure_mono Set.inter_subset_right)
           (measure_spanningSets_lt_top ν n)).ne
     have hdyn := setIntegral_eq_zero_of_forall_prod
-      (integrableOn_of_measure_lt_top h (hboxfin n)) hrect u hu
+      (integrableOn_Lp_of_measure_ne_top h one_le_two (hboxfin n).ne) hrect u hu
     rwa [Measure.restrict_restrict hu] at hdyn
   have hmono : Monotone fun n => u ∩ (spanningSets μ n ×ˢ spanningSets ν n) := fun m n hmn =>
     Set.inter_subset_inter_right _
@@ -346,7 +340,7 @@ theorem setIntegral_eq_zero_of_forall_inner [SigmaFinite μ] [SigmaFinite ν]
     rw [huniv, Set.inter_univ]
   have htend := tendsto_setIntegral_of_monotone
     (fun n => hu.inter ((hAm n).prod (hBm n))) hmono
-    (by rw [hcover]; exact integrableOn_of_measure_lt_top h hfin)
+    (by rw [hcover]; exact integrableOn_Lp_of_measure_ne_top h one_le_two hfin.ne)
   rw [hcover] at htend
   simp only [hbox] at htend
   exact tendsto_nhds_unique htend tendsto_const_nhds
@@ -368,7 +362,7 @@ theorem orthogonal_span_range_L2prodMul_eq_bot [SigmaFinite μ] [SigmaFinite ν]
     rw [inner_eq_zero_symm]
     exact hh _ (Submodule.subset_span ⟨(i, j), rfl⟩)
   have hae := Lp.ae_eq_zero_of_forall_setIntegral_eq_zero h (by norm_num) (by norm_num)
-    (fun s _ hs' => integrableOn_of_measure_lt_top h hs')
+    (fun s _ hs' => integrableOn_Lp_of_measure_ne_top h one_le_two hs'.ne)
     (fun s hs hs' => setIntegral_eq_zero_of_forall_inner hz s hs hs')
   rw [Lp.ext_iff]
   exact hae.trans (Lp.coeFn_zero 𝕜 2 (μ.prod ν)).symm

--- a/TauCeti/Analysis/InnerProductSpace/L2Product.lean
+++ b/TauCeti/Analysis/InnerProductSpace/L2Product.lean
@@ -229,6 +229,52 @@ theorem orthogonal_span_range_L2prodMul_eq_bot [SFinite μ] [SFinite ν] {ι₁ 
       (Set.range (fun ij : ι₁ × ι₂ => L2prodMul (b₁ ij.1) (b₂ ij.2))))ᗮ = ⊥ := by
   sorry
 
+/-- **The Dynkin (π-λ) step.** On a finite measure over a product space, a function whose integral
+vanishes on every measurable rectangle has vanishing integral on every measurable set. Rectangles
+are a π-system generating the product σ-algebra, so `MeasurableSpace.induction_on_inter` applies. -/
+theorem setIntegral_eq_zero_of_forall_prod {ρ : Measure (α × β)} [IsFiniteMeasure ρ]
+    {f : α × β → 𝕜} (hf : Integrable f ρ)
+    (hrect : ∀ s, MeasurableSet s → ∀ t, MeasurableSet t → ∫ p in s ×ˢ t, f p ∂ρ = 0) :
+    ∀ u, MeasurableSet u → ∫ p in u, f p ∂ρ = 0 := by
+  have huniv : ∫ p, f p ∂ρ = 0 := by
+    have h := hrect Set.univ MeasurableSet.univ Set.univ MeasurableSet.univ
+    rwa [Set.univ_prod_univ, setIntegral_univ] at h
+  refine MeasurableSpace.induction_on_inter (C := fun u _ => ∫ p in u, f p ∂ρ = 0)
+    generateFrom_prod.symm isPiSystem_prod ?_ ?_ ?_ ?_
+  · simp
+  · rintro _ ⟨s, hs, t, ht, rfl⟩
+    exact hrect s hs t ht
+  · intro u hu ih
+    rw [setIntegral_compl hu hf, huniv, ih, sub_zero]
+  · intro u hd hm ih
+    rw [integral_iUnion hm hd hf.integrableOn]
+    simp [ih]
+
+/-- The tensor of two indicators is the indicator of the rectangle, so orthogonality to every
+elementary tensor makes the integral over every finite-measure rectangle vanish. -/
+theorem setIntegral_prod_eq_zero_of_forall_inner [SFinite μ] [SFinite ν]
+    {h : Lp 𝕜 2 (μ.prod ν)}
+    (hz : ∀ (F : Lp 𝕜 2 μ) (G : Lp 𝕜 2 ν), inner 𝕜 (L2prodMul F G) h = 0)
+    {A : Set α} (hA : MeasurableSet A) (hμA : μ A ≠ ⊤)
+    {B : Set β} (hB : MeasurableSet B) (hνB : ν B ≠ ⊤) :
+    ∫ p in A ×ˢ B, h p ∂(μ.prod ν) = 0 := by
+  set F : Lp 𝕜 2 μ := indicatorConstLp 2 hA hμA (1 : 𝕜) with hFdef
+  set G : Lp 𝕜 2 ν := indicatorConstLp 2 hB hνB (1 : 𝕜) with hGdef
+  have hFc : ⇑F =ᵐ[μ] A.indicator fun _ => (1 : 𝕜) := indicatorConstLp_coeFn
+  have hGc : ⇑G =ᵐ[ν] B.indicator fun _ => (1 : 𝕜) := indicatorConstLp_coeFn
+  calc ∫ p in A ×ˢ B, h p ∂(μ.prod ν)
+      = ∫ p, (A ×ˢ B).indicator (fun q => h q) p ∂(μ.prod ν) :=
+        (integral_indicator (hA.prod hB)).symm
+    _ = ∫ p, inner 𝕜 ((L2prodMul F G) p) (h p) ∂(μ.prod ν) := by
+        refine integral_congr_ae ?_
+        filter_upwards [coeFn_L2prodMul F G, ae_of_ae_fst (β := β) (ν := ν) hFc,
+          ae_of_ae_snd (α := α) (μ := μ) hGc] with p hp hpF hpG
+        rw [hp, hpF, hpG]
+        by_cases h1 : p.1 ∈ A <;> by_cases h2 : p.2 ∈ B <;>
+          simp [Set.mem_prod, h1, h2]
+    _ = inner 𝕜 (L2prodMul F G) h := (L2.inner_def _ _).symm
+    _ = 0 := hz F G
+
 /-- **The product Hilbert basis.** Pointwise products of two Hilbert bases form a Hilbert basis of
 `L²(μ ⊗ ν)`, indexed by the product of the index types. -/
 noncomputable def prodHilbertBasis [SFinite μ] [SFinite ν] {ι₁ ι₂ : Type*}

--- a/TauCeti/Analysis/InnerProductSpace/L2Product.lean
+++ b/TauCeti/Analysis/InnerProductSpace/L2Product.lean
@@ -9,6 +9,7 @@ public import Mathlib.Analysis.InnerProductSpace.l2Space
 public import Mathlib.MeasureTheory.Function.AEEqOfIntegral
 public import Mathlib.MeasureTheory.Function.L2Space
 public import Mathlib.MeasureTheory.Integral.Prod
+public import TauCeti.MeasureTheory.Integral.Prod
 
 /-!
 # Pointwise products of `L²` functions on a product measure
@@ -36,8 +37,9 @@ index types. It runs in three moves:
 2. `TauCeti.setIntegral_prod_eq_zero_of_forall_inner` — testing against indicators, since
    `1ₐ ⊗ 1_b` is the indicator of the rectangle `a ×ˢ b`.
 3. `TauCeti.setIntegral_eq_zero_of_forall_prod` — the Dynkin (π-λ) step, upgrading rectangles to
-   arbitrary measurable sets inside a finite box, followed by a monotone exhaustion of the space by
-   the boxes `spanningSets μ n ×ˢ spanningSets ν n`.
+   arbitrary measurable sets. It is applied inside a finite box; the monotone exhaustion of the
+   space by the boxes `spanningSets μ n ×ˢ spanningSets ν n` is then done in
+   `TauCeti.setIntegral_eq_zero_of_forall_inner`.
 
 The scalars are generic over `[RCLike 𝕜]`, so a single construction serves both the real and
 complex `L²` spaces.
@@ -96,16 +98,6 @@ noncomputable def L2prodMul [SFinite μ] [SFinite ν] (F : Lp 𝕜 2 μ) (G : Lp
 theorem coeFn_L2prodMul [SFinite μ] [SFinite ν] (F : Lp 𝕜 2 μ) (G : Lp 𝕜 2 ν) :
     ⇑(L2prodMul F G) =ᵐ[μ.prod ν] fun p : α × β => F p.1 * G p.2 :=
   MemLp.coeFn_toLp _
-
-/-- An a.e. statement on the first factor transfers to the product measure. -/
-theorem ae_of_ae_fst [SFinite μ] [SFinite ν] {p : α → Prop} (hp : ∀ᵐ x ∂μ, p x) :
-    ∀ᵐ q : α × β ∂(μ.prod ν), p q.1 :=
-  Measure.quasiMeasurePreserving_fst.tendsto_ae.eventually hp
-
-/-- An a.e. statement on the second factor transfers to the product measure. -/
-theorem ae_of_ae_snd [SFinite μ] [SFinite ν] {p : β → Prop} (hp : ∀ᵐ y ∂ν, p y) :
-    ∀ᵐ q : α × β ∂(μ.prod ν), p q.2 :=
-  Measure.quasiMeasurePreserving_snd.tendsto_ae.eventually hp
 
 /-- The tensor is additive in its first argument. -/
 theorem L2prodMul_add_left [SFinite μ] [SFinite ν] (F₁ F₂ : Lp 𝕜 2 μ) (G : Lp 𝕜 2 ν) :
@@ -196,7 +188,7 @@ theorem norm_L2prodMul [SFinite μ] [SFinite ν] (F : Lp 𝕜 2 μ) (G : Lp 𝕜
     _ = ‖F‖ * ‖G‖ := Real.sqrt_sq (by positivity)
 
 /-- Tensoring on the right with a fixed `L²(ν)` vector, as a continuous linear map. -/
-@[expose] noncomputable def L2prodMulLeftL [SFinite μ] [SFinite ν] (G : Lp 𝕜 2 ν) :
+noncomputable def L2prodMulLeftL [SFinite μ] [SFinite ν] (G : Lp 𝕜 2 ν) :
     Lp 𝕜 2 μ →L[𝕜] Lp 𝕜 2 (μ.prod ν) :=
   LinearMap.mkContinuous
     { toFun := fun F => L2prodMul F G
@@ -205,7 +197,7 @@ theorem norm_L2prodMul [SFinite μ] [SFinite ν] (F : Lp 𝕜 2 μ) (G : Lp 𝕜
     ‖G‖ fun F => by simp [mul_comm]
 
 /-- Tensoring on the left with a fixed `L²(μ)` vector, as a continuous linear map. -/
-@[expose] noncomputable def L2prodMulRightL [SFinite μ] [SFinite ν] (F : Lp 𝕜 2 μ) :
+noncomputable def L2prodMulRightL [SFinite μ] [SFinite ν] (F : Lp 𝕜 2 μ) :
     Lp 𝕜 2 ν →L[𝕜] Lp 𝕜 2 (μ.prod ν) :=
   LinearMap.mkContinuous
     { toFun := fun G => L2prodMul F G
@@ -216,12 +208,14 @@ theorem norm_L2prodMul [SFinite μ] [SFinite ν] (F : Lp 𝕜 2 μ) (G : Lp 𝕜
 /-- `L2prodMulLeftL` applies as the tensor. -/
 @[simp]
 theorem L2prodMulLeftL_apply [SFinite μ] [SFinite ν] (G : Lp 𝕜 2 ν) (F : Lp 𝕜 2 μ) :
-    L2prodMulLeftL G F = L2prodMul F G := rfl
+    L2prodMulLeftL G F = L2prodMul F G :=
+  LinearMap.mkContinuous_apply _ _ _ _
 
 /-- `L2prodMulRightL` applies as the tensor. -/
 @[simp]
 theorem L2prodMulRightL_apply [SFinite μ] [SFinite ν] (F : Lp 𝕜 2 μ) (G : Lp 𝕜 2 ν) :
-    L2prodMulRightL F G = L2prodMul F G := rfl
+    L2prodMulRightL F G = L2prodMul F G :=
+  LinearMap.mkContinuous_apply _ _ _ _
 
 /-- **Basis tensors detect all tensors.** A vector orthogonal to every tensor built from two Hilbert
 bases is orthogonal to *every* elementary tensor. This is the countability-free half of the
@@ -244,27 +238,6 @@ theorem inner_L2prodMul_eq_zero_of_forall_basis [SFinite μ] [SFinite ν] {ι₁
     refine hsum.congr_fun fun i => ?_
     simp [step i G]
   simpa using (hasSum_zero.unique hzero).symm
-
-/-- **The Dynkin (π-λ) step.** On a finite measure over a product space, a function whose integral
-vanishes on every measurable rectangle has vanishing integral on every measurable set. Rectangles
-are a π-system generating the product σ-algebra, so `MeasurableSpace.induction_on_inter` applies. -/
-theorem setIntegral_eq_zero_of_forall_prod {ρ : Measure (α × β)} [IsFiniteMeasure ρ]
-    {f : α × β → 𝕜} (hf : Integrable f ρ)
-    (hrect : ∀ s, MeasurableSet s → ∀ t, MeasurableSet t → ∫ p in s ×ˢ t, f p ∂ρ = 0) :
-    ∀ u, MeasurableSet u → ∫ p in u, f p ∂ρ = 0 := by
-  have huniv : ∫ p, f p ∂ρ = 0 := by
-    have h := hrect Set.univ MeasurableSet.univ Set.univ MeasurableSet.univ
-    rwa [Set.univ_prod_univ, setIntegral_univ] at h
-  refine MeasurableSpace.induction_on_inter (C := fun u _ => ∫ p in u, f p ∂ρ = 0)
-    generateFrom_prod.symm isPiSystem_prod ?_ ?_ ?_ ?_
-  · simp
-  · rintro _ ⟨s, hs, t, ht, rfl⟩
-    exact hrect s hs t ht
-  · intro u hu ih
-    rw [setIntegral_compl hu hf, huniv, ih, sub_zero]
-  · intro u hd hm ih
-    rw [integral_iUnion hm hd hf.integrableOn]
-    simp [ih]
 
 /-- The tensor of two indicators is the indicator of the rectangle, so orthogonality to every
 elementary tensor makes the integral over every finite-measure rectangle vanish. -/
@@ -307,9 +280,6 @@ theorem setIntegral_eq_zero_of_forall_inner [SigmaFinite μ] [SigmaFinite ν]
     exact ENNReal.mul_lt_top (measure_spanningSets_lt_top μ n) (measure_spanningSets_lt_top ν n)
   have hbox : ∀ n, ∫ p in u ∩ (spanningSets μ n ×ˢ spanningSets ν n), h p ∂(μ.prod ν) = 0 := by
     intro n
-    have hfm : IsFiniteMeasure
-        ((μ.prod ν).restrict (spanningSets μ n ×ˢ spanningSets ν n)) :=
-      ⟨by rw [Measure.restrict_apply_univ]; exact hboxfin n⟩
     have hrect : ∀ s, MeasurableSet s → ∀ t, MeasurableSet t →
         ∫ p in s ×ˢ t, h p ∂((μ.prod ν).restrict
           (spanningSets μ n ×ˢ spanningSets ν n)) = 0 := by

--- a/TauCeti/MeasureTheory/Integral/Prod.lean
+++ b/TauCeti/MeasureTheory/Integral/Prod.lean
@@ -1,0 +1,65 @@
+module
+
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Claude
+-/
+public import Mathlib.MeasureTheory.Integral.Prod
+
+/-!
+# Product-measure helpers: a.e. transfer along the projections, and a Dynkin step for integrals
+
+Two small pieces of product-measure theory with no `L²` or inner-product content.
+
+* `TauCeti.ae_of_ae_fst` / `TauCeti.ae_of_ae_snd` transfer an a.e. statement about one factor to the
+  product measure, along `Measure.quasiMeasurePreserving_fst` / `_snd`.
+* `TauCeti.setIntegral_eq_zero_of_forall_prod` is the Dynkin (π-λ) step for Bochner integrals: a
+  function whose integral vanishes on every measurable rectangle has vanishing integral on every
+  measurable set. Rectangles are a π-system generating the product σ-algebra
+  (`MeasureTheory.isPiSystem_prod`, `MeasureTheory.generateFrom_prod`), so
+  `MeasurableSpace.induction_on_inter` applies. This is the Bochner counterpart of Mathlib's
+  `ℝ≥0∞`-valued `MeasureTheory.lintegral_eq_lintegral_of_isPiSystem`.
+-/
+
+public section
+
+namespace TauCeti
+
+open MeasureTheory
+
+variable {α β E : Type*} {mα : MeasurableSpace α} {mβ : MeasurableSpace β}
+  {μ : Measure α} {ν : Measure β}
+  [NormedAddCommGroup E] [NormedSpace ℝ E]
+
+/-- An a.e. statement on the first factor transfers to the product measure. -/
+theorem ae_of_ae_fst {p : α → Prop} (hp : ∀ᵐ x ∂μ, p x) :
+    ∀ᵐ q : α × β ∂(μ.prod ν), p q.1 :=
+  Measure.quasiMeasurePreserving_fst.tendsto_ae.eventually hp
+
+/-- An a.e. statement on the second factor transfers to the product measure. -/
+theorem ae_of_ae_snd {p : β → Prop} (hp : ∀ᵐ y ∂ν, p y) :
+    ∀ᵐ q : α × β ∂(μ.prod ν), p q.2 :=
+  Measure.quasiMeasurePreserving_snd.tendsto_ae.eventually hp
+
+/-- **The Dynkin (π-λ) step for Bochner integrals on a product space.** A function whose integral
+vanishes on every measurable rectangle has vanishing integral on every measurable set. -/
+theorem setIntegral_eq_zero_of_forall_prod {ρ : Measure (α × β)} {f : α × β → E}
+    (hf : Integrable f ρ)
+    (hrect : ∀ s, MeasurableSet s → ∀ t, MeasurableSet t → ∫ p in s ×ˢ t, f p ∂ρ = 0) :
+    ∀ u, MeasurableSet u → ∫ p in u, f p ∂ρ = 0 := by
+  have huniv : ∫ p, f p ∂ρ = 0 := by
+    have h := hrect Set.univ MeasurableSet.univ Set.univ MeasurableSet.univ
+    rwa [Set.univ_prod_univ, setIntegral_univ] at h
+  refine MeasurableSpace.induction_on_inter (C := fun u _ => ∫ p in u, f p ∂ρ = 0)
+    generateFrom_prod.symm isPiSystem_prod ?_ ?_ ?_ ?_
+  · simp
+  · rintro _ ⟨s, hs, t, ht, rfl⟩
+    exact hrect s hs t ht
+  · intro u hu ih
+    rw [setIntegral_compl hu hf, huniv, ih, sub_zero]
+  · intro u hd hm ih
+    rw [integral_iUnion hm hd hf.integrableOn]
+    simp [ih]
+
+end TauCeti


### PR DESCRIPTION
Completes **Part B3 of the `OrthogonalL2Bases` roadmap**: the product Hilbert basis of `L²(μ ⊗ ν)`.

`TauCeti/Analysis/InnerProductSpace/L2Product.lean` already proved the orthonormality half, and its
module docstring stated that the completeness half "is left to a separate construction". This PR
supplies that construction, in the same file, and delivers the roadmap targets:

- `prodHilbertBasis` — matches `TauCetiRoadmap/OrthogonalL2Bases/Suggested.lean` verbatim.
- `coeFn_prodHilbertBasis` — the roadmap's `prodHilbertBasis_apply`, renamed to the `coeFn_`
  convention this file and Mathlib already use for a.e.-representative lemmas. Statement identical.

This unblocks the roadmap's `piHilbertBasis` and `gaussianHermitePiBasis`.

## The completeness argument

The obvious route is a Fubini slice: fix `i`, show `y ↦ ∫ conj (b₁ i x) · h (x, y) ∂μ` vanishes a.e.
That needs a null set per index, so it silently requires `ι₁` countable — which the statement does
not assume. Instead the proof splits so that no null-set bookkeeping is indexed by `ι₁` or `ι₂` at
all:

1. `inner_L2prodMul_eq_zero_of_forall_basis` — orthogonality to the *basis* tensors upgrades to
   orthogonality to *every* elementary tensor `F ⊗ G`. Pure Hilbert-space geometry: expand along
   the basis with `HilbertBasis.hasSum_repr` and push the sum through the continuous linear map
   `L2prodMulRightL`, then again in the other slot. No countability, no measure theory.
2. `setIntegral_prod_eq_zero_of_forall_inner` — with `F`, `G` now arbitrary, take indicators:
   `1ₐ ⊗ 1_b` is the indicator of `a ×ˢ b`, so every rectangle integral vanishes.
3. `setIntegral_eq_zero_of_forall_prod` — the Dynkin (π-λ) step over `isPiSystem_prod` /
   `generateFrom_prod`, run inside a finite box, then a monotone exhaustion along
   `spanningSets μ n ×ˢ spanningSets ν n` to reach every finite-measure set. `SigmaFinite` is used
   exactly here, and is what the roadmap signature already assumes.

Conclusion via `Lp.ae_eq_zero_of_forall_setIntegral_eq_zero`.

## Reuse

Everything routes through existing API rather than re-deriving it: `HilbertBasis.mkOfOrthogonalEqBot`
and `HilbertBasis.coe_mkOfOrthogonalEqBot` (which makes the characterization lemma three lines),
`MeasurableSpace.induction_on_inter` with Mathlib's own rectangle π-system, `tendsto_setIntegral_of_monotone`,
and the file's pre-existing `inner_L2prodMul` / `orthonormal_L2prodMul`. The bilinearity, norm and
bundled-operator lemmas added along the way are the general-purpose `L²` tensor API this file was
missing, not one-off proof scaffolding.

## Verification

- `lake build TauCeti.Analysis.InnerProductSpace.L2Product` — succeeds, no `sorry`.
- `#print axioms` on `prodHilbertBasis`, `coeFn_prodHilbertBasis`,
  `orthogonal_span_range_L2prodMul_eq_bot` and `inner_L2prodMul_eq_zero_of_forall_basis`:
  `[propext, Classical.choice, Quot.sound]` only.
- Anti-vacuity: `coeFn_prodHilbertBasis` pins the basis vectors to the actual pointwise products.
- Single file, entirely under `TauCeti/`; no baseline or script changes.
