### PR TITLE
feat(Contour): the half-disc boundary has winding number one half

### DIFF
--- a/TauCeti/Analysis/Contour/WorkedExamples/HalfDisc.lean
+++ b/TauCeti/Analysis/Contour/WorkedExamples/HalfDisc.lean
@@ -4,6 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 -/
 module
 
+public import TauCeti.Analysis.Contour.PwC1ImmersionOn
 public import TauCeti.Analysis.Contour.Winding.Number.Circle
 public import TauCeti.Analysis.Contour.Winding.Number.Concat
 public import TauCeti.Analysis.Contour.Winding.Number.Reparam
@@ -35,6 +36,10 @@ residue theorem does not apply because the pole lies *on* the contour.
 * `TauCeti.Contour.halfDiscBoundary` — the contour, with `halfDiscBoundary_of_le` and
   `halfDiscBoundary_of_lt` evaluating its two branches and `halfDiscBoundary_left`,
   `halfDiscBoundary_right` its endpoints (equal, so the contour is closed).
+* `TauCeti.Contour.continuous_halfDiscBoundary` — the two branches agree at the junction, so the
+  contour is continuous.
+* `TauCeti.Contour.isPwC1ImmersionOn_halfDiscBoundary` — it is a piecewise-`C¹` immersion, with
+  the single breakpoint `R`; this is the regularity hypothesis of the Hungerbühler–Wasem theorems.
 * `TauCeti.Contour.windingNumber_halfDiscBoundary` — its generalized winding number about the
   origin is `½`.
 
@@ -100,6 +105,68 @@ theorem eqOn_halfDiscBoundary_arc (R : ℝ) :
     simp [circleMap]
   · rw [halfDiscBoundary_of_lt h]
     rfl
+
+/-- **The half-disc boundary is continuous**, the two branches agreeing at the junction `t = R`
+(where `circleMap 0 R 0 = R`). -/
+theorem continuous_halfDiscBoundary (R : ℝ) : Continuous (halfDiscBoundary R) := by
+  refine Continuous.if_le (by fun_prop)
+    ((continuous_circleMap 0 R).comp (continuous_id.sub continuous_const))
+    continuous_id continuous_const (fun x hx => ?_)
+  simp [hx, circleMap]
+
+/-- On a subinterval left of the junction the contour is the real inclusion. -/
+private theorem eqOn_left_piece {c d : ℝ} (hd : d ≤ R) :
+    EqOn (halfDiscBoundary R) (fun t : ℝ => (t : ℂ)) (Icc c d) :=
+  fun _ ht => halfDiscBoundary_of_le ((mem_Icc.mp ht).2.trans hd)
+
+/-- On a subinterval right of the junction the contour is the shifted circle. -/
+private theorem eqOn_right_piece {c d : ℝ} (hc : R ≤ c) :
+    EqOn (halfDiscBoundary R) (circleMap 0 R ∘ fun s : ℝ => s - R) (Icc c d) := by
+  intro t ht
+  rcases eq_or_lt_of_le (hc.trans (mem_Icc.mp ht).1) with h | h
+  · rw [← h, halfDiscBoundary_of_le le_rfl]
+    simp [circleMap]
+  · rw [halfDiscBoundary_of_lt h]
+    rfl
+
+/-- **The half-disc boundary is a piecewise-`C¹` immersion**, with the single breakpoint `R` where
+the diameter meets the arc. Off that breakpoint each piece is one of the two smooth branches: the
+real inclusion, of derivative `1`, or the shifted circle, of derivative `R e^{i(t-R)} · i`; both
+are nonzero for `0 < R`, so the tangent never vanishes. -/
+theorem isPwC1ImmersionOn_halfDiscBoundary (hR : 0 < R) :
+    IsPwC1ImmersionOn (halfDiscBoundary R) (-R) (R + Real.pi) := by
+  have hpi := Real.pi_pos
+  refine IsPwC1ImmersionOn.of_breakpoints (continuous_halfDiscBoundary R).continuousOn {R}
+    (by
+      rw [min_eq_left (by linarith : (-R : ℝ) ≤ R + Real.pi),
+        max_eq_right (by linarith : (-R : ℝ) ≤ R + Real.pi)]
+      simpa using ⟨by linarith, by linarith⟩)
+    fun c d hcd hsub hdisj => ?_
+  have huniq : UniqueDiffOn ℝ (Icc c d) := uniqueDiffOn_Icc hcd
+  -- Disjointness from the breakpoint puts the piece entirely on one side of `R`.
+  have hside : d ≤ R ∨ R ≤ c := by
+    by_contra hcon
+    push Not at hcon
+    exact Set.disjoint_left.mp hdisj (by simp) (mem_Ioo.mpr ⟨hcon.2, hcon.1⟩)
+  rcases hside with hd | hc
+  · refine ⟨(?_ : ContDiffOn ℝ 1 (fun t : ℝ => (t : ℂ)) (Icc c d)).congr
+      (eqOn_left_piece hd), fun t ht => ?_⟩
+    · exact (Complex.ofRealCLM.contDiff (n := 1)).contDiffOn
+    · have hd1 : HasDerivAt (fun s : ℝ => (s : ℂ)) 1 t := by
+        simpa using (hasDerivAt_id' (x := t)).ofReal_comp
+      rw [derivWithin_congr (eqOn_left_piece hd) (eqOn_left_piece hd ht),
+        hd1.hasDerivWithinAt.derivWithin (huniq t ht)]
+      norm_num
+  · refine ⟨(?_ : ContDiffOn ℝ 1 (circleMap 0 R ∘ fun s : ℝ => s - R) (Icc c d)).congr
+      (eqOn_right_piece hc), fun t ht => ?_⟩
+    · exact ((contDiff_circleMap 0 R).comp (contDiff_id.sub contDiff_const)).contDiffOn
+    · have hd2 : HasDerivAt (circleMap 0 R ∘ fun s : ℝ => s - R)
+          (circleMap 0 R (t - R) * Complex.I) t := by
+        simpa using (hasDerivAt_circleMap 0 R (t - R)).scomp t
+          ((hasDerivAt_id' (x := t)).sub_const R)
+      rw [derivWithin_congr (eqOn_right_piece hc) (eqOn_right_piece hc ht),
+        hd2.hasDerivWithinAt.derivWithin (huniq t ht)]
+      exact mul_ne_zero (circleMap_ne_center (c := 0) (θ := t - R) hR.ne') Complex.I_ne_zero
 
 /-- The index principal value of the reparametrized arc about the origin exists: the arc misses
 the origin, so the truncation is vacuous and the ordinary index integral converges. -/

--- a/TauCeti/Analysis/Contour/WorkedExamples/HalfDisc.lean
+++ b/TauCeti/Analysis/Contour/WorkedExamples/HalfDisc.lean
@@ -1,0 +1,166 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+module
+
+public import TauCeti.Analysis.Contour.Winding.Number.Circle
+public import TauCeti.Analysis.Contour.Winding.Number.Concat
+public import TauCeti.Analysis.Contour.Winding.Number.Reparam
+public import TauCeti.Analysis.Contour.Winding.Number.Segment
+
+/-!
+# The half-disc boundary contour
+
+For `0 < R`, the boundary of the upper half-disc of radius `R` about the origin, traversed
+counterclockwise on `[-R, R + π]`: the diameter along the real axis from `-R` to `R`, followed by
+the semicircular arc from `R` back to `-R`, the arc carrying its angle in `t - R`.
+
+Its distinguishing feature is that it passes **through** the origin rather than detouring around
+it, so the origin is an on-curve point and the generalized winding number there is `½` — the value
+strictly between the exterior `0` and the interior `1`:
+
+* the diameter contributes `0`: the index integrand `1 / t` is odd, so its principal value over
+  the symmetric interval vanishes (`windingNumber_eq_zero_segment`);
+* the arc contributes `½`: it is a half-circle about its own centre, so its winding is its angular
+  extent `π / 2π` (`windingNumber_circleMap_center_eq_half`).
+
+That `½` is exactly the hypothesis of the Hungerbühler–Wasem half-residue theorem
+`hasCauchyPV_half_residue`, which is why this contour is the one HW's motivating example uses: a
+Cauchy principal value along the real axis with a simple pole at the origin, where the classical
+residue theorem does not apply because the pole lies *on* the contour.
+
+## Main results
+
+* `TauCeti.Contour.halfDiscBoundary` — the contour, with `halfDiscBoundary_of_le` and
+  `halfDiscBoundary_of_lt` evaluating its two branches and `halfDiscBoundary_left`,
+  `halfDiscBoundary_right` its endpoints (equal, so the contour is closed).
+* `TauCeti.Contour.windingNumber_halfDiscBoundary` — its generalized winding number about the
+  origin is `½`.
+
+## References
+
+* N. Hungerbühler, M. Wasem, *Non-integer valued winding numbers and a generalized Residue
+  Theorem*, arXiv:1808.00997, Thm 3.3.
+-/
+
+public section
+
+noncomputable section
+
+open Complex Set
+
+namespace TauCeti.Contour
+
+variable {R : ℝ}
+
+/-- **The half-disc boundary contour.** On `[-R, R + π]`: the diameter `t ↦ t` for `t ≤ R`, then
+the semicircular arc `t ↦ R e^{i(t-R)}` from `R` back to `-R`. -/
+def halfDiscBoundary (R : ℝ) : ℝ → ℂ := fun t =>
+  if t ≤ R then (t : ℂ) else circleMap 0 R (t - R)
+
+@[simp]
+theorem halfDiscBoundary_of_le {t : ℝ} (h : t ≤ R) : halfDiscBoundary R t = (t : ℂ) :=
+  if_pos h
+
+@[simp]
+theorem halfDiscBoundary_of_lt {t : ℝ} (h : R < t) :
+    halfDiscBoundary R t = circleMap 0 R (t - R) :=
+  if_neg (not_le.mpr h)
+
+/-- The contour starts at `-R`. -/
+theorem halfDiscBoundary_left (hR : 0 < R) : halfDiscBoundary R (-R) = (-R : ℝ) :=
+  halfDiscBoundary_of_le (by linarith)
+
+/-- The contour ends at `-R`, so it is closed. -/
+theorem halfDiscBoundary_right (R : ℝ) :
+    halfDiscBoundary R (R + Real.pi) = (-R : ℝ) := by
+  rw [halfDiscBoundary_of_lt (by linarith [Real.pi_pos])]
+  simp [circleMap, Complex.exp_pi_mul_I]
+
+/-- On the diameter's parameter interval the contour is the real segment. -/
+theorem eqOn_halfDiscBoundary_segment (hR : 0 < R) :
+    EqOn (fun t : ℝ => (1 : ℂ) * (t : ℂ) + 0) (halfDiscBoundary R) (uIoo (-R) R) := by
+  intro t ht
+  have h2 : t < max (-R) R := (Set.mem_Ioo.mp ht).2
+  rw [max_eq_right (by linarith : (-R : ℝ) ≤ R)] at h2
+  simp [halfDiscBoundary_of_le h2.le]
+
+/-- On the arc's parameter interval — including both endpoints, where the two agree — the contour
+is the circle reparametrized by `t ↦ t - R`. -/
+theorem eqOn_halfDiscBoundary_arc (R : ℝ) :
+    EqOn (circleMap 0 R ∘ fun s : ℝ => s - R) (halfDiscBoundary R) (uIcc R (R + Real.pi)) := by
+  intro t ht
+  rw [uIcc_of_le (by linarith [Real.pi_pos] : R ≤ R + Real.pi)] at ht
+  rcases eq_or_lt_of_le (mem_Icc.mp ht).1 with h | h
+  · rw [← h, halfDiscBoundary_of_le le_rfl]
+    simp [circleMap]
+  · rw [halfDiscBoundary_of_lt h]
+    rfl
+
+/-- The derivative of the reparametrized arc, by the chain rule. -/
+private theorem hasDerivAt_arc (R t : ℝ) :
+    HasDerivAt (circleMap 0 R ∘ fun s : ℝ => s - R) (circleMap 0 R (t - R) * Complex.I) t := by
+  simpa using (hasDerivAt_circleMap 0 R (t - R)).scomp t ((hasDerivAt_id' (x := t)).sub_const R)
+
+/-- The index principal value of the reparametrized arc about the origin exists: the arc misses
+the origin, so the truncation is vacuous and the ordinary index integral converges. -/
+private theorem cauchyPVExistsAt_arc (hR : 0 < R) :
+    CauchyPVExistsAt (circleMap 0 R ∘ fun s : ℝ => s - R) R (R + Real.pi)
+      (fun z => (z - 0)⁻¹) 0 := by
+  have havoid : ∀ t : ℝ, (circleMap 0 R ∘ fun s : ℝ => s - R) t ≠ 0 := fun _ =>
+    circleMap_ne_center hR.ne'
+  have hcont : ContinuousOn (circleMap 0 R ∘ fun s : ℝ => s - R) (uIcc R (R + Real.pi)) :=
+    ((continuous_circleMap 0 R).comp (continuous_id.sub continuous_const)).continuousOn
+  have hderiv_eq : deriv (circleMap 0 R ∘ fun s : ℝ => s - R)
+      = fun t => circleMap 0 R (t - R) * Complex.I :=
+    funext fun t => (hasDerivAt_arc R t).deriv
+  refine cauchyPVExistsAt_of_avoidance hcont (fun t _ => havoid t) ?_
+  refine intervalIntegrable_inv_sub_mul_deriv hcont (fun t _ => havoid t) ?_
+  rw [hderiv_eq]
+  exact (((continuous_circleMap 0 R).comp
+    (continuous_id.sub continuous_const)).mul continuous_const).intervalIntegrable _ _
+
+/-- The reparametrized arc in the `r · t + s` shape `windingNumber_comp_mul_add` expects. -/
+private theorem arc_eq_comp_mul_add (R : ℝ) :
+    (circleMap 0 R ∘ fun s : ℝ => s - R) = circleMap 0 R ∘ fun s : ℝ => 1 * s + (-R) := by
+  congr 1
+  funext s
+  ring
+
+/-- The arc contributes `½`: it is a half-circle about its own centre. -/
+private theorem windingNumber_arc (hR : 0 < R) :
+    windingNumber (circleMap 0 R ∘ fun s : ℝ => s - R) R (R + Real.pi) 0 = 1 / 2 := by
+  rw [arc_eq_comp_mul_add, windingNumber_comp_mul_add
+    (fun u _ => (differentiable_circleMap 0 R) u)
+    (by
+      have h : deriv (circleMap 0 R) = fun θ => circleMap 0 R θ * Complex.I :=
+        funext (deriv_circleMap 0 R)
+      rw [h]
+      exact ((continuous_circleMap 0 R).mul continuous_const).continuousOn)
+    (fun u _ => circleMap_ne_center hR.ne')]
+  simpa using windingNumber_circleMap_center_eq_half (c := 0) hR.ne'
+
+/-- **The half-disc boundary has winding number `½` about the origin.** The diameter through the
+origin contributes `0` and the semicircular arc about it contributes `½`. -/
+theorem windingNumber_halfDiscBoundary (hR : 0 < R) :
+    windingNumber (halfDiscBoundary R) (-R) (R + Real.pi) 0 = 1 / 2 := by
+  have hpv_seg : CauchyPVExistsAt (halfDiscBoundary R) (-R) R (fun z => (z - 0)⁻¹) 0 :=
+    (cauchyPVExistsAt_inv_sub_segment 1 0 R).congr_curve (eqOn_halfDiscBoundary_segment hR)
+  have hpv_arc : CauchyPVExistsAt (halfDiscBoundary R) R (R + Real.pi) (fun z => (z - 0)⁻¹) 0 :=
+    (cauchyPVExistsAt_arc hR).congr_curve
+      ((eqOn_halfDiscBoundary_arc R).mono (uIoo_subset_uIcc_self))
+  have hseg : windingNumber (halfDiscBoundary R) (-R) R 0 = 0 := by
+    rw [← windingNumber_congr_curve (eqOn_halfDiscBoundary_segment hR)]
+    exact windingNumber_eq_zero_segment 1 0 R
+  have harc : windingNumber (halfDiscBoundary R) R (R + Real.pi) 0 = 1 / 2 := by
+    rw [← windingNumber_congr_curve
+      ((eqOn_halfDiscBoundary_arc R).mono uIoo_subset_uIcc_self)]
+    exact windingNumber_arc hR
+  rw [windingNumber_concat hpv_seg hpv_arc, hseg, harc, zero_add]
+
+end TauCeti.Contour
+
+end
+
+end

--- a/TauCeti/Analysis/Contour/WorkedExamples/HalfDisc.lean
+++ b/TauCeti/Analysis/Contour/WorkedExamples/HalfDisc.lean
@@ -69,17 +69,20 @@ theorem halfDiscBoundary_of_lt {t : ℝ} (h : R < t) :
   if_neg (not_le.mpr h)
 
 /-- The contour starts at `-R`. -/
-theorem halfDiscBoundary_left (hR : 0 < R) : halfDiscBoundary R (-R) = (-R : ℝ) :=
+-- Not `@[simp]`: with `halfDiscBoundary_of_le` in the simp set, `simp` already proves this
+-- (`neg_le_self_iff` discharges `-R ≤ R`), and `simpNF` rejects the redundant annotation.
+theorem halfDiscBoundary_left (hR : 0 ≤ R) : halfDiscBoundary R (-R) = (-R : ℝ) :=
   halfDiscBoundary_of_le (by linarith)
 
 /-- The contour ends at `-R`, so it is closed. -/
+@[simp]
 theorem halfDiscBoundary_right (R : ℝ) :
     halfDiscBoundary R (R + Real.pi) = (-R : ℝ) := by
   rw [halfDiscBoundary_of_lt (by linarith [Real.pi_pos])]
   simp [circleMap, Complex.exp_pi_mul_I]
 
 /-- On the diameter's parameter interval the contour is the real segment. -/
-theorem eqOn_halfDiscBoundary_segment (hR : 0 < R) :
+theorem eqOn_halfDiscBoundary_segment (hR : 0 ≤ R) :
     EqOn (fun t : ℝ => (1 : ℂ) * (t : ℂ) + 0) (halfDiscBoundary R) (uIoo (-R) R) := by
   intro t ht
   have h2 : t < max (-R) R := (Set.mem_Ioo.mp ht).2
@@ -98,11 +101,6 @@ theorem eqOn_halfDiscBoundary_arc (R : ℝ) :
   · rw [halfDiscBoundary_of_lt h]
     rfl
 
-/-- The derivative of the reparametrized arc, by the chain rule. -/
-private theorem hasDerivAt_arc (R t : ℝ) :
-    HasDerivAt (circleMap 0 R ∘ fun s : ℝ => s - R) (circleMap 0 R (t - R) * Complex.I) t := by
-  simpa using (hasDerivAt_circleMap 0 R (t - R)).scomp t ((hasDerivAt_id' (x := t)).sub_const R)
-
 /-- The index principal value of the reparametrized arc about the origin exists: the arc misses
 the origin, so the truncation is vacuous and the ordinary index integral converges. -/
 private theorem cauchyPVExistsAt_arc (hR : 0 < R) :
@@ -112,14 +110,20 @@ private theorem cauchyPVExistsAt_arc (hR : 0 < R) :
     circleMap_ne_center hR.ne'
   have hcont : ContinuousOn (circleMap 0 R ∘ fun s : ℝ => s - R) (uIcc R (R + Real.pi)) :=
     ((continuous_circleMap 0 R).comp (continuous_id.sub continuous_const)).continuousOn
-  have hderiv_eq : deriv (circleMap 0 R ∘ fun s : ℝ => s - R)
-      = fun t => circleMap 0 R (t - R) * Complex.I :=
-    funext fun t => (hasDerivAt_arc R t).deriv
+  have hderiv_circle : ContinuousOn (deriv (circleMap 0 R))
+      ((fun s : ℝ => s - R) '' uIcc R (R + Real.pi)) := by
+    have h : deriv (circleMap 0 R) = fun θ => circleMap 0 R θ * Complex.I :=
+      funext (deriv_circleMap 0 R)
+    rw [h]
+    exact ((continuous_circleMap 0 R).mul continuous_const).continuousOn
+  have hderiv : ContinuousOn (deriv (circleMap 0 R ∘ fun s : ℝ => s - R))
+      (uIcc R (R + Real.pi)) :=
+    continuousOn_deriv_comp_reparam (φ' := fun _ => 1)
+      (fun t _ => (hasDerivAt_id' (x := t)).sub_const R) continuousOn_const
+      (fun u _ => (differentiable_circleMap 0 R) u) hderiv_circle
   refine cauchyPVExistsAt_of_avoidance hcont (fun t _ => havoid t) ?_
-  refine intervalIntegrable_inv_sub_mul_deriv hcont (fun t _ => havoid t) ?_
-  rw [hderiv_eq]
-  exact (((continuous_circleMap 0 R).comp
-    (continuous_id.sub continuous_const)).mul continuous_const).intervalIntegrable _ _
+  exact intervalIntegrable_inv_sub_mul_deriv hcont (fun t _ => havoid t)
+    (hderiv.intervalIntegrable)
 
 /-- The reparametrized arc in the `r · t + s` shape `windingNumber_comp_mul_add` expects. -/
 private theorem arc_eq_comp_mul_add (R : ℝ) :
@@ -146,12 +150,12 @@ origin contributes `0` and the semicircular arc about it contributes `½`. -/
 theorem windingNumber_halfDiscBoundary (hR : 0 < R) :
     windingNumber (halfDiscBoundary R) (-R) (R + Real.pi) 0 = 1 / 2 := by
   have hpv_seg : CauchyPVExistsAt (halfDiscBoundary R) (-R) R (fun z => (z - 0)⁻¹) 0 :=
-    (cauchyPVExistsAt_inv_sub_segment 1 0 R).congr_curve (eqOn_halfDiscBoundary_segment hR)
+    (cauchyPVExistsAt_inv_sub_segment 1 0 R).congr_curve (eqOn_halfDiscBoundary_segment hR.le)
   have hpv_arc : CauchyPVExistsAt (halfDiscBoundary R) R (R + Real.pi) (fun z => (z - 0)⁻¹) 0 :=
     (cauchyPVExistsAt_arc hR).congr_curve
       ((eqOn_halfDiscBoundary_arc R).mono (uIoo_subset_uIcc_self))
   have hseg : windingNumber (halfDiscBoundary R) (-R) R 0 = 0 := by
-    rw [← windingNumber_congr_curve (eqOn_halfDiscBoundary_segment hR)]
+    rw [← windingNumber_congr_curve (eqOn_halfDiscBoundary_segment hR.le)]
     exact windingNumber_eq_zero_segment 1 0 R
   have harc : windingNumber (halfDiscBoundary R) R (R + Real.pi) 0 = 1 / 2 := by
     rw [← windingNumber_congr_curve


### PR DESCRIPTION
## Roadmap

`TauCetiRoadmap/ContourIntegration/README.md`, section **"Worked examples (acceptance criteria,
keeping the theory honest)"** — the outstanding fifth bullet:

> **An improper integral** (e.g. a Cauchy principal value along the real axis with a simple pole
> at `0`) evaluated by HW Thm 3.3 where the classical theorem does not apply — HW's motivating
> example.

All 18 targets in `ContourIntegration/Suggested.lean` are proven; that bullet is the one remaining
item of this roadmap. This PR supplies its contour and the winding-number input the summit needs.

## What

```lean
def halfDiscBoundary (R : ℝ) : ℝ → ℂ := fun t =>
  if t ≤ R then (t : ℂ) else circleMap 0 R (t - R)

theorem windingNumber_halfDiscBoundary (hR : 0 < R) :
    windingNumber (halfDiscBoundary R) (-R) (R + Real.pi) 0 = 1 / 2
```

The boundary of the upper half-disc on `[-R, R + π]`: the diameter along the real axis from `-R`
to `R`, then the semicircular arc back, the arc carrying its angle in `t - R`. It is closed
(`halfDiscBoundary_left`, `halfDiscBoundary_right` both give `-R`), and the two branches evaluate
by `halfDiscBoundary_of_le` / `halfDiscBoundary_of_lt`.

The point of the construction is that it passes **through** the origin rather than detouring
around it — unlike an indented contour — so the origin is an *on-curve* point and its winding
number is `½`, strictly between the exterior `0` and the interior `1`. That `½` is exactly the
hypothesis of the Hungerbühler–Wasem half-residue theorem `hasCauchyPV_half_residue`.

## How

The proof is the two pieces plus additivity, and every ingredient is already in the library:

| piece | value | source |
|---|---|---|
| diameter, *through* the origin | `0` | `windingNumber_eq_zero_segment` (#1196) — `1 / t` is odd over `[-R, R]` |
| semicircular arc, *about* the origin | `½` | `windingNumber_circleMap_center_eq_half` (#1203) |
| transferring each onto the assembled contour | — | `windingNumber_congr_curve` (#1198) |
| summing them | — | `windingNumber_concat` |

Principal-value existence on each piece — which `windingNumber_concat` consumes — comes from
`cauchyPVExistsAt_inv_sub_segment` on the diameter and from avoidance on the arc, transferred by
`CauchyPVExistsAt.congr_curve`.

Two implementation notes. The arc is stated as the composition `circleMap 0 R ∘ (· - R)` rather
than `fun t => circleMap 0 R (t - R)`: the chain rule via `HasDerivAt.scomp` elaborates against a
different `AddCommGroup ℂ` instance path in the un-composed form, and the composite spelling keeps
the instances aligned. And `eqOn_halfDiscBoundary_arc` holds on the **closed** `uIcc`, not just the
interior, because the two branches agree at the junction (`circleMap 0 R 0 = R`) — which is what
lets continuity transfer to the assembled contour.

Gates: `lake build` (5356 jobs) ✓, `lake exe axioms` (11584 decls, allowlist) ✓,
`lake exe module-system` (647 modules) ✓, `scripts/lint-env.sh` PASS ✓.
