### PR TITLE
feat: compute the planar Newtonian circle flux

### DIFF
--- a/TauCeti/Analysis/PDE/FundamentalSolution/Flux.lean
+++ b/TauCeti/Analysis/PDE/FundamentalSolution/Flux.lean
@@ -79,7 +79,6 @@ theorem fderiv_planarNewtonianKernel_sub_circle_normal {a : ℂ} {r θ : ℝ} (h
 
 /-- The arclength-weighted normal derivative of the planar Newtonian kernel is constant on every
 positively oriented circle around its pole. -/
-@[simp]
 theorem radius_mul_fderiv_planarNewtonianKernel_sub_circle_normal
     {a : ℂ} {r θ : ℝ} (hr : 0 < r) :
     r * fderiv ℝ (fun w ↦ planarNewtonianKernel (w - a)) (circleMap a r θ)
@@ -89,7 +88,6 @@ theorem radius_mul_fderiv_planarNewtonianKernel_sub_circle_normal
 
 /-- The outward flux of the planar Newtonian kernel through any circle centered at its pole is
 `-1`. The factor `r` is the arclength Jacobian in the angular parametrization. -/
-@[simp]
 theorem integral_fderiv_planarNewtonianKernel_sub_circle_normal {a : ℂ} {r : ℝ} (hr : 0 < r) :
     r * ∫ θ : ℝ in 0..2 * Real.pi,
         fderiv ℝ (fun w ↦ planarNewtonianKernel (w - a)) (circleMap a r θ)

--- a/TauCeti/Analysis/PDE/FundamentalSolution/Flux.lean
+++ b/TauCeti/Analysis/PDE/FundamentalSolution/Flux.lean
@@ -19,8 +19,9 @@ calculation needed for its later distributional identity `-Δ G = δ₀`.
 ## Main declarations
 
 * `TauCeti.fderiv_planarNewtonianKernel_self`: the radial derivative of the kernel.
-* `TauCeti.fderiv_planarNewtonianKernel_circle_normal`: its outward normal derivative on a circle.
-* `TauCeti.integral_fderiv_planarNewtonianKernel_circle_normal`: the total circle flux is `-1`.
+* `TauCeti.fderiv_planarNewtonianKernel_sub_circle_normal`: its outward normal derivative on a
+  circle centered at the pole.
+* `TauCeti.integral_fderiv_planarNewtonianKernel_sub_circle_normal`: the total circle flux is `-1`.
 -/
 
 public section
@@ -79,6 +80,7 @@ theorem fderiv_planarNewtonianKernel_sub_self {z a : ℂ} (hza : z ≠ a) :
 
 /-- On the circle of radius `r`, the outward normal derivative of the planar Newtonian kernel is
 `-(2πr)⁻¹`. -/
+@[simp]
 theorem fderiv_planarNewtonianKernel_sub_circle_normal {a : ℂ} {r θ : ℝ} (hr : 0 < r) :
     fderiv ℝ (fun w ↦ planarNewtonianKernel (w - a)) (circleMap a r θ)
         ((r : ℂ)⁻¹ * circleMap 0 r θ) = -(2 * Real.pi * r)⁻¹ := by
@@ -91,14 +93,6 @@ theorem fderiv_planarNewtonianKernel_sub_circle_normal {a : ℂ} {r θ : ℝ} (h
   simp only [smul_eq_mul]
   field_simp
 
-/-- On an origin-centered circle of radius `r`, the outward normal derivative of the planar
-Newtonian kernel is `-(2πr)⁻¹`. -/
-theorem fderiv_planarNewtonianKernel_circle_normal {r θ : ℝ} (hr : 0 < r) :
-    fderiv ℝ planarNewtonianKernel (circleMap 0 r θ) ((r : ℂ)⁻¹ * circleMap 0 r θ) =
-      -(2 * Real.pi * r)⁻¹ := by
-  simpa only [sub_zero] using
-    (fderiv_planarNewtonianKernel_sub_circle_normal (a := 0) hr)
-
 /-- The arclength-weighted normal derivative of the planar Newtonian kernel is constant on every
 positively oriented circle around its pole. -/
 @[simp]
@@ -108,15 +102,6 @@ theorem radius_mul_fderiv_planarNewtonianKernel_sub_circle_normal
         ((r : ℂ)⁻¹ * circleMap 0 r θ) = -(2 * Real.pi)⁻¹ := by
   rw [fderiv_planarNewtonianKernel_sub_circle_normal hr]
   field_simp
-
-/-- The arclength-weighted normal derivative of the planar Newtonian kernel is constant on every
-positively oriented origin-centered circle. -/
-@[simp]
-theorem radius_mul_fderiv_planarNewtonianKernel_circle_normal {r θ : ℝ} (hr : 0 < r) :
-    r * fderiv ℝ planarNewtonianKernel (circleMap 0 r θ) ((r : ℂ)⁻¹ * circleMap 0 r θ) =
-      -(2 * Real.pi)⁻¹ := by
-  simpa only [sub_zero] using
-    (radius_mul_fderiv_planarNewtonianKernel_sub_circle_normal (a := 0) hr)
 
 /-- The outward flux of the planar Newtonian kernel through any circle centered at its pole is
 `-1`. The factor `r` is the arclength Jacobian in the angular parametrization. -/
@@ -129,16 +114,6 @@ theorem integral_fderiv_planarNewtonianKernel_sub_circle_normal {a : ℂ} {r : �
   rw [intervalIntegral.integral_const]
   simp only [sub_zero, smul_eq_mul]
   field_simp
-
-/-- The outward flux of the planar Newtonian kernel through any origin-centered circle is `-1`.
-The factor `r` is the arclength Jacobian in the angular parametrization. -/
-@[simp]
-theorem integral_fderiv_planarNewtonianKernel_circle_normal {r : ℝ} (hr : 0 < r) :
-    r * ∫ θ : ℝ in 0..2 * Real.pi,
-        fderiv ℝ planarNewtonianKernel (circleMap 0 r θ)
-          ((r : ℂ)⁻¹ * circleMap 0 r θ) = -1 := by
-  simpa only [sub_zero] using
-    (integral_fderiv_planarNewtonianKernel_sub_circle_normal (a := 0) hr)
 
 end TauCeti
 

--- a/TauCeti/Analysis/PDE/FundamentalSolution/Flux.lean
+++ b/TauCeti/Analysis/PDE/FundamentalSolution/Flux.lean
@@ -5,7 +5,8 @@ Released under Apache 2.0 license as described in the file LICENSE.
 module
 
 public import TauCeti.Analysis.PDE.FundamentalSolution.Planar
-public import Mathlib.MeasureTheory.Integral.CircleIntegral
+public import Mathlib.Analysis.SpecialFunctions.Complex.CircleMap
+public import Mathlib.MeasureTheory.Integral.IntervalIntegral.Basic
 
 /-!
 # Flux of the planar Newtonian kernel
@@ -31,6 +32,7 @@ namespace TauCeti
 open scoped Interval
 
 /-- The derivative of the planar Newtonian kernel in the radial direction is `-(2π)⁻¹`. -/
+@[simp]
 theorem fderiv_planarNewtonianKernel_self {z : ℂ} (hz : z ≠ 0) :
     fderiv ℝ planarNewtonianKernel z z = -(2 * Real.pi)⁻¹ := by
   let line : ℝ →L[ℝ] ℂ := (ContinuousLinearMap.id ℝ ℝ).smulRight z
@@ -66,11 +68,22 @@ theorem fderiv_planarNewtonianKernel_self {z : ℂ} (hz : z ≠ 0) :
         (-(2 * Real.pi)⁻¹)
   exact hcomp.unique (hformula.congr_of_eventuallyEq heq)
 
+/-- The derivative of a translated planar Newtonian kernel in the radial direction from its pole
+is `-(2π)⁻¹`. -/
+@[simp]
+theorem fderiv_planarNewtonianKernel_sub_self {z a : ℂ} (hza : z ≠ a) :
+    fderiv ℝ (fun w ↦ planarNewtonianKernel (w - a)) z (z - a) =
+      -(2 * Real.pi)⁻¹ := by
+  rw [fderiv_comp_sub]
+  exact fderiv_planarNewtonianKernel_self (sub_ne_zero.mpr hza)
+
 /-- On the circle of radius `r`, the outward normal derivative of the planar Newtonian kernel is
 `-(2πr)⁻¹`. -/
-theorem fderiv_planarNewtonianKernel_circle_normal {r θ : ℝ} (hr : 0 < r) :
-    fderiv ℝ planarNewtonianKernel (circleMap 0 r θ) (r⁻¹ • circleMap 0 r θ) =
-      -(2 * Real.pi * r)⁻¹ := by
+@[simp]
+theorem fderiv_planarNewtonianKernel_sub_circle_normal {a : ℂ} {r θ : ℝ} (hr : 0 < r) :
+    fderiv ℝ (fun w ↦ planarNewtonianKernel (w - a)) (circleMap a r θ)
+        (r⁻¹ • (circleMap a r θ - a)) = -(2 * Real.pi * r)⁻¹ := by
+  rw [fderiv_comp_sub, circleMap_sub_center]
   have hz : circleMap 0 r θ ≠ 0 := by
     rw [ne_eq, ← norm_eq_zero, norm_circleMap_zero, abs_of_pos hr]
     exact hr.ne'
@@ -78,23 +91,54 @@ theorem fderiv_planarNewtonianKernel_circle_normal {r θ : ℝ} (hr : 0 < r) :
   simp only [smul_eq_mul]
   field_simp
 
+/-- On an origin-centered circle of radius `r`, the outward normal derivative of the planar
+Newtonian kernel is `-(2πr)⁻¹`. -/
+@[simp]
+theorem fderiv_planarNewtonianKernel_circle_normal {r θ : ℝ} (hr : 0 < r) :
+    fderiv ℝ planarNewtonianKernel (circleMap 0 r θ) (r⁻¹ • circleMap 0 r θ) =
+      -(2 * Real.pi * r)⁻¹ := by
+  simpa only [sub_zero] using
+    (fderiv_planarNewtonianKernel_sub_circle_normal (a := 0) hr)
+
 /-- The arclength-weighted normal derivative of the planar Newtonian kernel is constant on every
 positively oriented circle around its pole. -/
+@[simp]
+theorem radius_mul_fderiv_planarNewtonianKernel_sub_circle_normal
+    {a : ℂ} {r θ : ℝ} (hr : 0 < r) :
+    r * fderiv ℝ (fun w ↦ planarNewtonianKernel (w - a)) (circleMap a r θ)
+        (r⁻¹ • (circleMap a r θ - a)) = -(2 * Real.pi)⁻¹ := by
+  rw [fderiv_planarNewtonianKernel_sub_circle_normal hr]
+  field_simp
+
+/-- The arclength-weighted normal derivative of the planar Newtonian kernel is constant on every
+positively oriented origin-centered circle. -/
+@[simp]
 theorem radius_mul_fderiv_planarNewtonianKernel_circle_normal {r θ : ℝ} (hr : 0 < r) :
     r * fderiv ℝ planarNewtonianKernel (circleMap 0 r θ) (r⁻¹ • circleMap 0 r θ) =
       -(2 * Real.pi)⁻¹ := by
-  rw [fderiv_planarNewtonianKernel_circle_normal hr]
-  field_simp
+  simpa only [sub_zero] using
+    (radius_mul_fderiv_planarNewtonianKernel_sub_circle_normal (a := 0) hr)
 
 /-- The outward flux of the planar Newtonian kernel through any circle centered at its pole is
 `-1`. The factor `r` is the arclength Jacobian in the angular parametrization. -/
-theorem integral_fderiv_planarNewtonianKernel_circle_normal {r : ℝ} (hr : 0 < r) :
+@[simp]
+theorem integral_fderiv_planarNewtonianKernel_sub_circle_normal {a : ℂ} {r : ℝ} (hr : 0 < r) :
     ∫ θ : ℝ in 0..2 * Real.pi,
-        r * fderiv ℝ planarNewtonianKernel (circleMap 0 r θ) (r⁻¹ • circleMap 0 r θ) = -1 := by
-  simp_rw [radius_mul_fderiv_planarNewtonianKernel_circle_normal hr]
+        r * fderiv ℝ (fun w ↦ planarNewtonianKernel (w - a)) (circleMap a r θ)
+          (r⁻¹ • (circleMap a r θ - a)) = -1 := by
+  simp_rw [radius_mul_fderiv_planarNewtonianKernel_sub_circle_normal hr]
   rw [intervalIntegral.integral_const]
   simp only [sub_zero, smul_eq_mul]
   field_simp
+
+/-- The outward flux of the planar Newtonian kernel through any origin-centered circle is `-1`.
+The factor `r` is the arclength Jacobian in the angular parametrization. -/
+@[simp]
+theorem integral_fderiv_planarNewtonianKernel_circle_normal {r : ℝ} (hr : 0 < r) :
+    ∫ θ : ℝ in 0..2 * Real.pi,
+        r * fderiv ℝ planarNewtonianKernel (circleMap 0 r θ) (r⁻¹ • circleMap 0 r θ) = -1 := by
+  simpa only [sub_zero] using
+    (integral_fderiv_planarNewtonianKernel_sub_circle_normal (a := 0) hr)
 
 end TauCeti
 

--- a/TauCeti/Analysis/PDE/FundamentalSolution/Flux.lean
+++ b/TauCeti/Analysis/PDE/FundamentalSolution/Flux.lean
@@ -44,10 +44,10 @@ theorem fderiv_planarNewtonianKernel_self {z : ℂ} (hz : z ≠ 0) :
       HasFDerivAt (fun w : ℂ ↦ Real.log ‖w‖)
         ((‖z‖ : ℝ)⁻¹ • fderiv ℝ (fun w : ℂ ↦ ‖w‖) z) z :=
     hnorm.hasFDerivAt.log (norm_ne_zero_iff.mpr hz)
-  rw [show planarNewtonianKernel =
-    fun w : ℂ ↦ -(2 * Real.pi)⁻¹ * Real.log ‖w‖ by
-      ext w
-      exact planarNewtonianKernel_def w]
+  have hkernel :
+      planarNewtonianKernel = fun w : ℂ ↦ -(2 * Real.pi)⁻¹ * Real.log ‖w‖ :=
+    funext planarNewtonianKernel_def
+  rw [hkernel]
   rw [(hlog.const_mul (-(2 * Real.pi)⁻¹)).fderiv]
   simp only [smul_apply, smul_eq_mul]
   rw [DifferentiableAt.fderiv_norm_self hnorm]

--- a/TauCeti/Analysis/PDE/FundamentalSolution/Flux.lean
+++ b/TauCeti/Analysis/PDE/FundamentalSolution/Flux.lean
@@ -5,6 +5,8 @@ Released under Apache 2.0 license as described in the file LICENSE.
 module
 
 public import TauCeti.Analysis.PDE.FundamentalSolution.Planar
+public import Mathlib.Analysis.Calculus.FDeriv.Norm
+public import Mathlib.Analysis.InnerProductSpace.Calculus
 public import Mathlib.Analysis.SpecialFunctions.Complex.CircleMap
 public import Mathlib.MeasureTheory.Integral.IntervalIntegral.Basic
 
@@ -36,38 +38,20 @@ open scoped Interval
 @[simp]
 theorem fderiv_planarNewtonianKernel_self {z : ℂ} (hz : z ≠ 0) :
     fderiv ℝ planarNewtonianKernel z z = -(2 * Real.pi)⁻¹ := by
-  let line : ℝ →L[ℝ] ℂ := (ContinuousLinearMap.id ℝ ℝ).smulRight z
-  have hline_one : line 1 = z := by
-    simp [line]
-  have hdiff : DifferentiableAt ℝ planarNewtonianKernel z :=
-    (contDiffAt_planarNewtonianKernel hz).differentiableAt (by norm_num)
-  have hcomp :
-      HasDerivAt (planarNewtonianKernel ∘ line)
-        (fderiv ℝ planarNewtonianKernel z z) 1 := by
-    have hline : HasDerivAt line z 1 := by
-      simpa only [hline_one] using line.hasFDerivAt.hasDerivAt
-    have hdiff' :
-        HasFDerivAt planarNewtonianKernel (fderiv ℝ planarNewtonianKernel z) (line 1) := by
-      rw [hline_one]
-      exact hdiff.hasFDerivAt
-    exact hdiff'.comp_hasDerivAt 1 hline
-  have heq :
-      (planarNewtonianKernel ∘ line) =ᶠ[nhds 1]
-        fun t ↦ (Real.log t + Real.log ‖z‖) * -(2 * Real.pi)⁻¹ := by
-    filter_upwards [eventually_gt_nhds zero_lt_one] with t ht
-    simp only [Function.comp_apply]
-    rw [planarNewtonianKernel_def]
-    simp only [line, ContinuousLinearMap.smulRight_apply, ContinuousLinearMap.id_apply,
-      norm_smul, Real.norm_eq_abs, abs_of_pos ht]
-    rw [Real.log_mul ht.ne' (norm_ne_zero_iff.mpr hz)]
-    ring
-  have hformula :
-      HasDerivAt (fun t : ℝ ↦ (Real.log t + Real.log ‖z‖) * -(2 * Real.pi)⁻¹)
-        (-(2 * Real.pi)⁻¹) 1 := by
-    simpa only [inv_one, one_mul] using
-      ((Real.hasDerivAt_log one_ne_zero).add_const (Real.log ‖z‖)).mul_const
-        (-(2 * Real.pi)⁻¹)
-  exact hcomp.unique (hformula.congr_of_eventuallyEq heq)
+  have hnorm : DifferentiableAt ℝ (fun w : ℂ ↦ ‖w‖) z :=
+    (differentiableAt_fun_id : DifferentiableAt ℝ (fun w : ℂ ↦ w) z).norm ℂ hz
+  have hlog :
+      HasFDerivAt (fun w : ℂ ↦ Real.log ‖w‖)
+        ((‖z‖ : ℝ)⁻¹ • fderiv ℝ (fun w : ℂ ↦ ‖w‖) z) z :=
+    hnorm.hasFDerivAt.log (norm_ne_zero_iff.mpr hz)
+  rw [show planarNewtonianKernel =
+    fun w : ℂ ↦ -(2 * Real.pi)⁻¹ * Real.log ‖w‖ by
+      ext w
+      exact planarNewtonianKernel_def w]
+  rw [(hlog.const_mul (-(2 * Real.pi)⁻¹)).fderiv]
+  simp only [smul_apply, smul_eq_mul]
+  rw [DifferentiableAt.fderiv_norm_self hnorm]
+  rw [inv_mul_cancel₀ (norm_ne_zero_iff.mpr hz), mul_one]
 
 /-- The derivative of a translated planar Newtonian kernel in the radial direction from its pole
 is `-(2π)⁻¹`. -/
@@ -95,6 +79,7 @@ theorem fderiv_planarNewtonianKernel_sub_circle_normal {a : ℂ} {r θ : ℝ} (h
 
 /-- The arclength-weighted normal derivative of the planar Newtonian kernel is constant on every
 positively oriented circle around its pole. -/
+@[simp]
 theorem radius_mul_fderiv_planarNewtonianKernel_sub_circle_normal
     {a : ℂ} {r θ : ℝ} (hr : 0 < r) :
     r * fderiv ℝ (fun w ↦ planarNewtonianKernel (w - a)) (circleMap a r θ)
@@ -104,6 +89,7 @@ theorem radius_mul_fderiv_planarNewtonianKernel_sub_circle_normal
 
 /-- The outward flux of the planar Newtonian kernel through any circle centered at its pole is
 `-1`. The factor `r` is the arclength Jacobian in the angular parametrization. -/
+@[simp]
 theorem integral_fderiv_planarNewtonianKernel_sub_circle_normal {a : ℂ} {r : ℝ} (hr : 0 < r) :
     r * ∫ θ : ℝ in 0..2 * Real.pi,
         fderiv ℝ (fun w ↦ planarNewtonianKernel (w - a)) (circleMap a r θ)

--- a/TauCeti/Analysis/PDE/FundamentalSolution/Flux.lean
+++ b/TauCeti/Analysis/PDE/FundamentalSolution/Flux.lean
@@ -1,0 +1,101 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+module
+
+public import TauCeti.Analysis.PDE.FundamentalSolution.Planar
+public import Mathlib.MeasureTheory.Integral.CircleIntegral
+
+/-!
+# Flux of the planar Newtonian kernel
+
+This file computes the outward normal derivative of the planar Newtonian kernel on a circle.
+The resulting flux is `-1`, as required for the fundamental solution of the negative Laplacian.
+This calculation fixes the normalization of `planarNewtonianKernel` and is the boundary
+calculation needed for its later distributional identity `-Δ G = δ₀`.
+
+## Main declarations
+
+* `TauCeti.fderiv_planarNewtonianKernel_self`: the radial derivative of the kernel.
+* `TauCeti.fderiv_planarNewtonianKernel_circle_normal`: its outward normal derivative on a circle.
+* `TauCeti.integral_fderiv_planarNewtonianKernel_circle_normal`: the total circle flux is `-1`.
+-/
+
+public section
+
+noncomputable section
+
+namespace TauCeti
+
+open scoped Interval
+
+/-- The derivative of the planar Newtonian kernel in the radial direction is `-(2π)⁻¹`. -/
+theorem fderiv_planarNewtonianKernel_self {z : ℂ} (hz : z ≠ 0) :
+    fderiv ℝ planarNewtonianKernel z z = -(2 * Real.pi)⁻¹ := by
+  let line : ℝ →L[ℝ] ℂ := (ContinuousLinearMap.id ℝ ℝ).smulRight z
+  have hline_one : line 1 = z := by
+    simp [line]
+  have hdiff : DifferentiableAt ℝ planarNewtonianKernel z :=
+    (contDiffAt_planarNewtonianKernel hz).differentiableAt (by norm_num)
+  have hcomp :
+      HasDerivAt (planarNewtonianKernel ∘ line)
+        (fderiv ℝ planarNewtonianKernel z z) 1 := by
+    have hline : HasDerivAt line z 1 := by
+      simpa only [hline_one] using line.hasFDerivAt.hasDerivAt
+    have hdiff' :
+        HasFDerivAt planarNewtonianKernel (fderiv ℝ planarNewtonianKernel z) (line 1) := by
+      rw [hline_one]
+      exact hdiff.hasFDerivAt
+    exact hdiff'.comp_hasDerivAt 1 hline
+  have heq :
+      (planarNewtonianKernel ∘ line) =ᶠ[nhds 1]
+        fun t ↦ (Real.log t + Real.log ‖z‖) * -(2 * Real.pi)⁻¹ := by
+    filter_upwards [eventually_gt_nhds zero_lt_one] with t ht
+    simp only [Function.comp_apply]
+    rw [planarNewtonianKernel_def]
+    simp only [line, ContinuousLinearMap.smulRight_apply, ContinuousLinearMap.id_apply,
+      norm_smul, Real.norm_eq_abs, abs_of_pos ht]
+    rw [Real.log_mul ht.ne' (norm_ne_zero_iff.mpr hz)]
+    ring
+  have hformula :
+      HasDerivAt (fun t : ℝ ↦ (Real.log t + Real.log ‖z‖) * -(2 * Real.pi)⁻¹)
+        (-(2 * Real.pi)⁻¹) 1 := by
+    simpa only [inv_one, one_mul] using
+      ((Real.hasDerivAt_log one_ne_zero).add_const (Real.log ‖z‖)).mul_const
+        (-(2 * Real.pi)⁻¹)
+  exact hcomp.unique (hformula.congr_of_eventuallyEq heq)
+
+/-- On the circle of radius `r`, the outward normal derivative of the planar Newtonian kernel is
+`-(2πr)⁻¹`. -/
+theorem fderiv_planarNewtonianKernel_circle_normal {r θ : ℝ} (hr : 0 < r) :
+    fderiv ℝ planarNewtonianKernel (circleMap 0 r θ) (r⁻¹ • circleMap 0 r θ) =
+      -(2 * Real.pi * r)⁻¹ := by
+  have hz : circleMap 0 r θ ≠ 0 := by
+    rw [ne_eq, ← norm_eq_zero, norm_circleMap_zero, abs_of_pos hr]
+    exact hr.ne'
+  rw [map_smul, fderiv_planarNewtonianKernel_self hz]
+  simp only [smul_eq_mul]
+  field_simp
+
+/-- The arclength-weighted normal derivative of the planar Newtonian kernel is constant on every
+positively oriented circle around its pole. -/
+theorem radius_mul_fderiv_planarNewtonianKernel_circle_normal {r θ : ℝ} (hr : 0 < r) :
+    r * fderiv ℝ planarNewtonianKernel (circleMap 0 r θ) (r⁻¹ • circleMap 0 r θ) =
+      -(2 * Real.pi)⁻¹ := by
+  rw [fderiv_planarNewtonianKernel_circle_normal hr]
+  field_simp
+
+/-- The outward flux of the planar Newtonian kernel through any circle centered at its pole is
+`-1`. The factor `r` is the arclength Jacobian in the angular parametrization. -/
+theorem integral_fderiv_planarNewtonianKernel_circle_normal {r : ℝ} (hr : 0 < r) :
+    ∫ θ : ℝ in 0..2 * Real.pi,
+        r * fderiv ℝ planarNewtonianKernel (circleMap 0 r θ) (r⁻¹ • circleMap 0 r θ) = -1 := by
+  simp_rw [radius_mul_fderiv_planarNewtonianKernel_circle_normal hr]
+  rw [intervalIntegral.integral_const]
+  simp only [sub_zero, smul_eq_mul]
+  field_simp
+
+end TauCeti
+
+end

--- a/TauCeti/Analysis/PDE/FundamentalSolution/Flux.lean
+++ b/TauCeti/Analysis/PDE/FundamentalSolution/Flux.lean
@@ -79,23 +79,22 @@ theorem fderiv_planarNewtonianKernel_sub_self {z a : ℂ} (hza : z ≠ a) :
 
 /-- On the circle of radius `r`, the outward normal derivative of the planar Newtonian kernel is
 `-(2πr)⁻¹`. -/
-@[simp]
 theorem fderiv_planarNewtonianKernel_sub_circle_normal {a : ℂ} {r θ : ℝ} (hr : 0 < r) :
     fderiv ℝ (fun w ↦ planarNewtonianKernel (w - a)) (circleMap a r θ)
-        (r⁻¹ • (circleMap a r θ - a)) = -(2 * Real.pi * r)⁻¹ := by
+        ((r : ℂ)⁻¹ * circleMap 0 r θ) = -(2 * Real.pi * r)⁻¹ := by
   rw [fderiv_comp_sub, circleMap_sub_center]
   have hz : circleMap 0 r θ ≠ 0 := by
     rw [ne_eq, ← norm_eq_zero, norm_circleMap_zero, abs_of_pos hr]
     exact hr.ne'
+  rw [← Complex.ofReal_inv, ← Complex.real_smul]
   rw [map_smul, fderiv_planarNewtonianKernel_self hz]
   simp only [smul_eq_mul]
   field_simp
 
 /-- On an origin-centered circle of radius `r`, the outward normal derivative of the planar
 Newtonian kernel is `-(2πr)⁻¹`. -/
-@[simp]
 theorem fderiv_planarNewtonianKernel_circle_normal {r θ : ℝ} (hr : 0 < r) :
-    fderiv ℝ planarNewtonianKernel (circleMap 0 r θ) (r⁻¹ • circleMap 0 r θ) =
+    fderiv ℝ planarNewtonianKernel (circleMap 0 r θ) ((r : ℂ)⁻¹ * circleMap 0 r θ) =
       -(2 * Real.pi * r)⁻¹ := by
   simpa only [sub_zero] using
     (fderiv_planarNewtonianKernel_sub_circle_normal (a := 0) hr)
@@ -106,7 +105,7 @@ positively oriented circle around its pole. -/
 theorem radius_mul_fderiv_planarNewtonianKernel_sub_circle_normal
     {a : ℂ} {r θ : ℝ} (hr : 0 < r) :
     r * fderiv ℝ (fun w ↦ planarNewtonianKernel (w - a)) (circleMap a r θ)
-        (r⁻¹ • (circleMap a r θ - a)) = -(2 * Real.pi)⁻¹ := by
+        ((r : ℂ)⁻¹ * circleMap 0 r θ) = -(2 * Real.pi)⁻¹ := by
   rw [fderiv_planarNewtonianKernel_sub_circle_normal hr]
   field_simp
 
@@ -114,7 +113,7 @@ theorem radius_mul_fderiv_planarNewtonianKernel_sub_circle_normal
 positively oriented origin-centered circle. -/
 @[simp]
 theorem radius_mul_fderiv_planarNewtonianKernel_circle_normal {r θ : ℝ} (hr : 0 < r) :
-    r * fderiv ℝ planarNewtonianKernel (circleMap 0 r θ) (r⁻¹ • circleMap 0 r θ) =
+    r * fderiv ℝ planarNewtonianKernel (circleMap 0 r θ) ((r : ℂ)⁻¹ * circleMap 0 r θ) =
       -(2 * Real.pi)⁻¹ := by
   simpa only [sub_zero] using
     (radius_mul_fderiv_planarNewtonianKernel_sub_circle_normal (a := 0) hr)
@@ -123,10 +122,10 @@ theorem radius_mul_fderiv_planarNewtonianKernel_circle_normal {r θ : ℝ} (hr :
 `-1`. The factor `r` is the arclength Jacobian in the angular parametrization. -/
 @[simp]
 theorem integral_fderiv_planarNewtonianKernel_sub_circle_normal {a : ℂ} {r : ℝ} (hr : 0 < r) :
-    ∫ θ : ℝ in 0..2 * Real.pi,
-        r * fderiv ℝ (fun w ↦ planarNewtonianKernel (w - a)) (circleMap a r θ)
-          (r⁻¹ • (circleMap a r θ - a)) = -1 := by
-  simp_rw [radius_mul_fderiv_planarNewtonianKernel_sub_circle_normal hr]
+    r * ∫ θ : ℝ in 0..2 * Real.pi,
+        fderiv ℝ (fun w ↦ planarNewtonianKernel (w - a)) (circleMap a r θ)
+          ((r : ℂ)⁻¹ * circleMap 0 r θ) = -1 := by
+  simp_rw [fderiv_planarNewtonianKernel_sub_circle_normal hr]
   rw [intervalIntegral.integral_const]
   simp only [sub_zero, smul_eq_mul]
   field_simp
@@ -135,8 +134,9 @@ theorem integral_fderiv_planarNewtonianKernel_sub_circle_normal {a : ℂ} {r : �
 The factor `r` is the arclength Jacobian in the angular parametrization. -/
 @[simp]
 theorem integral_fderiv_planarNewtonianKernel_circle_normal {r : ℝ} (hr : 0 < r) :
-    ∫ θ : ℝ in 0..2 * Real.pi,
-        r * fderiv ℝ planarNewtonianKernel (circleMap 0 r θ) (r⁻¹ • circleMap 0 r θ) = -1 := by
+    r * ∫ θ : ℝ in 0..2 * Real.pi,
+        fderiv ℝ planarNewtonianKernel (circleMap 0 r θ)
+          ((r : ℂ)⁻¹ * circleMap 0 r θ) = -1 := by
   simpa only [sub_zero] using
     (integral_fderiv_planarNewtonianKernel_sub_circle_normal (a := 0) hr)
 

--- a/TauCeti/Analysis/PDE/FundamentalSolution/Flux.lean
+++ b/TauCeti/Analysis/PDE/FundamentalSolution/Flux.lean
@@ -6,7 +6,6 @@ module
 
 public import TauCeti.Analysis.PDE.FundamentalSolution.Planar
 public import Mathlib.Analysis.Calculus.FDeriv.Norm
-public import Mathlib.Analysis.InnerProductSpace.Calculus
 public import Mathlib.Analysis.SpecialFunctions.Complex.CircleMap
 public import Mathlib.MeasureTheory.Integral.IntervalIntegral.Basic
 
@@ -77,6 +76,15 @@ theorem fderiv_planarNewtonianKernel_sub_circle_normal {a : ℂ} {r θ : ℝ} (h
   simp only [smul_eq_mul]
   field_simp
 
+/-- On the circle of radius `r` centered at the origin, the outward normal derivative of the
+planar Newtonian kernel is `-(2πr)⁻¹`. -/
+@[simp]
+theorem fderiv_planarNewtonianKernel_circle_normal {r θ : ℝ} (hr : 0 < r) :
+    fderiv ℝ planarNewtonianKernel (circleMap 0 r θ)
+        ((r : ℂ)⁻¹ * circleMap 0 r θ) = -(2 * Real.pi * r)⁻¹ := by
+  simpa only [sub_zero] using
+    fderiv_planarNewtonianKernel_sub_circle_normal (a := 0) (θ := θ) hr
+
 /-- The arclength-weighted normal derivative of the planar Newtonian kernel is constant on every
 positively oriented circle around its pole. -/
 theorem radius_mul_fderiv_planarNewtonianKernel_sub_circle_normal
@@ -85,6 +93,15 @@ theorem radius_mul_fderiv_planarNewtonianKernel_sub_circle_normal
         ((r : ℂ)⁻¹ * circleMap 0 r θ) = -(2 * Real.pi)⁻¹ := by
   rw [fderiv_planarNewtonianKernel_sub_circle_normal hr]
   field_simp
+
+/-- The arclength-weighted normal derivative of the planar Newtonian kernel is constant on every
+positively oriented circle centered at the origin. -/
+theorem radius_mul_fderiv_planarNewtonianKernel_circle_normal
+    {r θ : ℝ} (hr : 0 < r) :
+    r * fderiv ℝ planarNewtonianKernel (circleMap 0 r θ)
+        ((r : ℂ)⁻¹ * circleMap 0 r θ) = -(2 * Real.pi)⁻¹ := by
+  simpa only [sub_zero] using
+    radius_mul_fderiv_planarNewtonianKernel_sub_circle_normal (a := 0) (θ := θ) hr
 
 /-- The outward flux of the planar Newtonian kernel through any circle centered at its pole is
 `-1`. The factor `r` is the arclength Jacobian in the angular parametrization. -/
@@ -96,6 +113,15 @@ theorem integral_fderiv_planarNewtonianKernel_sub_circle_normal {a : ℂ} {r : �
   rw [intervalIntegral.integral_const]
   simp only [sub_zero, smul_eq_mul]
   field_simp
+
+/-- The outward flux of the planar Newtonian kernel through any circle centered at the origin is
+`-1`. The factor `r` is the arclength Jacobian in the angular parametrization. -/
+theorem integral_fderiv_planarNewtonianKernel_circle_normal {r : ℝ} (hr : 0 < r) :
+    r * ∫ θ : ℝ in 0..2 * Real.pi,
+        fderiv ℝ planarNewtonianKernel (circleMap 0 r θ)
+          ((r : ℂ)⁻¹ * circleMap 0 r θ) = -1 := by
+  simpa only [sub_zero] using
+    integral_fderiv_planarNewtonianKernel_sub_circle_normal (a := 0) hr
 
 end TauCeti
 

--- a/TauCeti/Analysis/PDE/FundamentalSolution/Flux.lean
+++ b/TauCeti/Analysis/PDE/FundamentalSolution/Flux.lean
@@ -95,7 +95,6 @@ theorem fderiv_planarNewtonianKernel_sub_circle_normal {a : ℂ} {r θ : ℝ} (h
 
 /-- The arclength-weighted normal derivative of the planar Newtonian kernel is constant on every
 positively oriented circle around its pole. -/
-@[simp]
 theorem radius_mul_fderiv_planarNewtonianKernel_sub_circle_normal
     {a : ℂ} {r θ : ℝ} (hr : 0 < r) :
     r * fderiv ℝ (fun w ↦ planarNewtonianKernel (w - a)) (circleMap a r θ)
@@ -105,7 +104,6 @@ theorem radius_mul_fderiv_planarNewtonianKernel_sub_circle_normal
 
 /-- The outward flux of the planar Newtonian kernel through any circle centered at its pole is
 `-1`. The factor `r` is the arclength Jacobian in the angular parametrization. -/
-@[simp]
 theorem integral_fderiv_planarNewtonianKernel_sub_circle_normal {a : ℂ} {r : ℝ} (hr : 0 < r) :
     r * ∫ θ : ℝ in 0..2 * Real.pi,
         fderiv ℝ (fun w ↦ planarNewtonianKernel (w - a)) (circleMap a r θ)


### PR DESCRIPTION
This PR computes the outward flux of the planar Newtonian kernel through every positive-radius circle centered at its pole. Prove first that the Fréchet derivative in the radial direction is `-(2π)⁻¹`, identify the outward unit normal under the standard angular parametrization, and integrate the arclength-weighted normal derivative to obtain total flux `-1`. This fixes the kernel normalization and supplies the boundary calculation needed for the later distributional identity `-Δ G = δ₀`.

This advances `TauCetiRoadmap/PDE/README.md`, Lane C, item 15: “Fundamental solution / Newtonian potential of `Δ` on `ℝⁿ`.” It is the lowest-hanging distinct continuation because the planar kernel and its pointwise harmonicity away from the pole have just landed, while the missing flux computation is the immediate prerequisite for promoting that classical off-pole result to the honest distributional fundamental solution. The only open PDE PR addresses the separate Lane D variable-energy coercivity target.

Reuse Mathlib’s `ContinuousLinearMap` Fréchet derivative API, `circleMap` normalization, and `intervalIntegral.integral_const`; no Mathlib infrastructure or external formalization is vendored.

Add `TauCeti/Analysis/PDE/FundamentalSolution/Flux.lean` (101 lines). `lake exe cache get` reports `No files to download` and `Already decompressed 8639 file(s)`. `lake build` reports `Build completed successfully (5365 jobs).` `lake exe axioms` reports `axioms: audited 11635 TauCeti declaration(s); all within the allowlist [propext, Classical.choice, Quot.sound].`

<!--tauceti-target:v1 {"focus":"PDE","id":"planar-newtonian-kernel-circle-flux"}-->

🤖 Prepared with Codex
