### PR TITLE
feat(Exchangeability): the conditional i.i.d. predicate and its easy projection

### DIFF
--- a/TauCeti/Probability/Exchangeability/ConditionallyIID/Basic.lean
+++ b/TauCeti/Probability/Exchangeability/ConditionallyIID/Basic.lean
@@ -136,15 +136,16 @@ theorem ConditionallyIID.exists_directing {μ : Measure Ω} {X : ℕ → Ω → 
 identity is the joint disintegration with the `ν` coordinate integrated out.
 
 Concretely, evaluating the joint identity on the rectangle `univ ×ˢ B` reads off the block's
-marginal law, because `δ_{ν ω}` contributes a factor `1` on `univ`. -/
+marginal law, because `δ_{ν ω}` contributes a factor `1` on `univ`.
+
+No measurability hypothesis on the coordinates is needed: `ConditionallyIIDWith` already forces it.
+Each mixing kernel is a probability measure, so the mixture has the same total mass as `μ`; if the
+pair map failed to be a.e. measurable then `Measure.map` would collapse the left side to `0`, and
+the identity would force `μ = 0`. -/
 theorem mixedIIDWith_of_conditionallyIIDWith {μ : Measure Ω} {X : ℕ → Ω → α}
-    (hX : ∀ n, AEMeasurable (X n) μ) {ν : Ω → ProbabilityMeasure α}
-    (h : ConditionallyIIDWith μ X ν) : MixedIIDWith μ X ν := by
+    {ν : Ω → ProbabilityMeasure α} (h : ConditionallyIIDWith μ X ν) : MixedIIDWith μ X ν := by
   refine MixedIIDWith.intro h.measurable_directing fun m k hk => ?_
-  have hblock : AEMeasurable (fun ω => fun i : Fin m => X (k i) ω) μ :=
-    aemeasurable_pi_lambda _ fun i => hX (k i)
-  have hpair : AEMeasurable (fun ω => (ν ω, fun i : Fin m => X (k i) ω)) μ :=
-    h.measurable_directing.aemeasurable.prodMk hblock
+  have hjoint := h.jointLaw_eq_disintegration k hk
   have hK : AEMeasurable (fun ω =>
       (Measure.dirac (ν ω)).prod (ProbabilityMeasure.pi fun _ : Fin m => ν ω).toMeasure) μ :=
     (TauCeti.MeasureTheory.measurable_dirac_prod_probabilityMeasure_pi_const_toMeasure ν
@@ -153,6 +154,23 @@ theorem mixedIIDWith_of_conditionallyIIDWith {μ : Measure Ω} {X : ℕ → Ω �
       (fun ω => (ProbabilityMeasure.pi fun _ : Fin m => ν ω).toMeasure) μ :=
     TauCeti.MeasureTheory.aemeasurable_probabilityMeasure_pi_const_toMeasure ν
       h.measurable_directing.aemeasurable
+  -- each mixing kernel is a probability measure, so the mixture carries the total mass of `μ`
+  have hbindUniv : (μ.bind fun ω => (Measure.dirac (ν ω)).prod
+      (ProbabilityMeasure.pi fun _ : Fin m => ν ω).toMeasure) Set.univ = μ Set.univ := by
+    rw [Measure.bind_apply MeasurableSet.univ hK]
+    simp
+  -- so the joint identity itself forces the pair map to be a.e. measurable: were it not,
+  -- `Measure.map` would collapse the left side to `0`, forcing `μ = 0`
+  have hpair : AEMeasurable (fun ω => (ν ω, fun i : Fin m => X (k i) ω)) μ := by
+    rcases eq_or_ne μ 0 with rfl | hμ
+    · simp
+    · by_contra hcon
+      rw [Measure.map_of_not_aemeasurable hcon] at hjoint
+      refine hμ (Measure.measure_univ_eq_zero.mp ?_)
+      rw [← hbindUniv, ← hjoint]
+      simp
+  have hblock : AEMeasurable (fun ω => fun i : Fin m => X (k i) ω) μ :=
+    measurable_snd.comp_aemeasurable hpair
   refine Measure.ext fun B hB => ?_
   calc blockLaw μ X k B
       = μ.map (fun ω => (ν ω, fun i : Fin m => X (k i) ω)) (Set.univ ×ˢ B) := by
@@ -163,7 +181,7 @@ theorem mixedIIDWith_of_conditionallyIIDWith {μ : Measure Ω} {X : ℕ → Ω �
         simp
     _ = (μ.bind fun ω => (Measure.dirac (ν ω)).prod
           (ProbabilityMeasure.pi fun _ : Fin m => ν ω).toMeasure) (Set.univ ×ˢ B) := by
-        rw [h.jointLaw_eq_disintegration k hk]
+        rw [hjoint]
     _ = ∫⁻ ω, (ProbabilityMeasure.pi fun _ : Fin m => ν ω).toMeasure B ∂μ := by
         rw [Measure.bind_apply (MeasurableSet.univ.prod hB) hK]
         simp [Measure.prod_prod]
@@ -172,9 +190,9 @@ theorem mixedIIDWith_of_conditionallyIIDWith {μ : Measure Ω} {X : ℕ → Ω �
 
 /-- The existential form of the easy arrow. -/
 theorem mixedIID_of_conditionallyIID {μ : Measure Ω} {X : ℕ → Ω → α}
-    (hX : ∀ n, AEMeasurable (X n) μ) (h : ConditionallyIID μ X) : MixedIID μ X := by
+    (h : ConditionallyIID μ X) : MixedIID μ X := by
   obtain ⟨ν, hν⟩ := h.exists_directing
-  exact MixedIID.of_mixingRepresentative (mixedIIDWith_of_conditionallyIIDWith hX hν)
+  exact MixedIID.of_mixingRepresentative (mixedIIDWith_of_conditionallyIIDWith hν)
 
 end Probability
 

--- a/TauCeti/Probability/Exchangeability/ConditionallyIID/Basic.lean
+++ b/TauCeti/Probability/Exchangeability/ConditionallyIID/Basic.lean
@@ -138,10 +138,13 @@ identity is the joint disintegration with the `ν` coordinate integrated out.
 Concretely, evaluating the joint identity on the rectangle `univ ×ˢ B` reads off the block's
 marginal law, because `δ_{ν ω}` contributes a factor `1` on `univ`.
 
-No measurability hypothesis on the coordinates is needed: `ConditionallyIIDWith` already forces it.
-Each mixing kernel is a probability measure, so the mixture has the same total mass as `μ`; if the
-pair map failed to be a.e. measurable then `Measure.map` would collapse the left side to `0`, and
-the identity would force `μ = 0`. -/
+No measurability hypothesis on the coordinates is needed. What `ConditionallyIIDWith` forces is
+that each selected block map — and hence each individual coordinate — is `μ`-**a.e.** measurable;
+it says nothing about pointwise measurability, which can fail on a non-measurable null set. That
+is enough here. Each mixing kernel is a probability measure, so the mixture has the same total
+mass as `μ`; if the pair map failed to be a.e. measurable then `Measure.map` would collapse the
+left side to `0`, and the identity would force `μ = 0`, which is the degenerate case where the
+conclusion holds anyway. -/
 theorem mixedIIDWith_of_conditionallyIIDWith {μ : Measure Ω} {X : ℕ → Ω → α}
     {ν : Ω → ProbabilityMeasure α} (h : ConditionallyIIDWith μ X ν) : MixedIIDWith μ X ν := by
   refine MixedIIDWith.intro h.measurable_directing fun m k hk => ?_

--- a/TauCeti/Probability/Exchangeability/ConditionallyIID/Basic.lean
+++ b/TauCeti/Probability/Exchangeability/ConditionallyIID/Basic.lean
@@ -1,0 +1,156 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+module
+
+public import TauCeti.Probability.Exchangeability.MixedIID.Basic
+
+/-!
+# Conditionally i.i.d. sequences
+
+The **conditional** strengthening of the mixture identity: a process is *conditionally i.i.d.*
+with directing measure `ν` when, along every finite selection of distinct coordinates, the
+**joint** law of `(ν, block)` is the disintegration `∫ δ_{ν ω} ⊗ (ν ω)^{⊗m} dμ(ω)` — conditionally
+on `ν`, the block is i.i.d. `ν` (Kallenberg 2005, §1.1 eq. (2)).
+
+Stating it as a joint-law identity means the definition needs no conditional expectations, and
+sits in the same `bind`/`pi` vocabulary as `MixedIIDWith`.
+
+## Why this is stronger than `MixedIIDWith`
+
+`MixedIIDWith μ X ν` constrains only each block's **marginal** law. It therefore does not pin down
+how `X` relates to `ν`: for a nondegenerate mixing law, an *independent copy* of a directing
+measure also witnesses `MixedIIDWith`, while the process is not conditionally i.i.d. given that
+copy. The arrow runs one way only, and `mixedIIDWith_of_conditionallyIIDWith` is that arrow —
+obtained by integrating the `ν` coordinate out.
+
+Terminology follows the roadmap: a `ν` witnessing only the mixture identity is a *mixing
+representative*, whereas `ν` here is a genuine **directing measure**.
+
+## Main results
+
+* `ConditionallyIIDWith`, `ConditionallyIID` — the predicate and its existential wrapper.
+* `mixedIIDWith_of_conditionallyIIDWith`, `mixedIID_of_conditionallyIID` — the easy arrow down to
+  the mixture identity.
+
+This advances `TauCetiRoadmap/Exchangeability/README.md`, Layer 0/1: the conditional predicate the
+roadmap reserves the `ConditionallyIID` name for, and the easy arrow it pins alongside. The
+summit theorems that *conclude* it (`conditionallyIID_of_contractable` and the `deFinetti*`
+handles) remain open.
+-/
+
+public section
+
+noncomputable section
+
+open MeasureTheory Set
+
+namespace TauCeti
+
+namespace Probability
+
+variable {Ω α : Type*} [MeasurableSpace Ω] [MeasurableSpace α]
+
+/-- Conditional i.i.d.-ness with a specified directing measure `ν`: the random measure `ν` is
+measurable, and along every finite selection `k` of **distinct** coordinates the *joint* law of
+`(ν, block)` is the `ν`-disintegration `∫ δ_{ν ω} ⊗ (ν ω)^{⊗m} dμ(ω)`.
+
+Constraining the joint law, rather than just the block's marginal, is exactly what makes this the
+conditional statement: see `MixedIIDWith` for the marginal-only version and
+`mixedIIDWith_of_conditionallyIIDWith` for the arrow between them. -/
+def ConditionallyIIDWith (μ : Measure Ω) (X : ℕ → Ω → α) (ν : Ω → ProbabilityMeasure α) : Prop :=
+  Measurable ν ∧
+    ∀ (m : ℕ) (k : Fin m → ℕ), Function.Injective k →
+      μ.map (fun ω => (ν ω, fun i : Fin m => X (k i) ω)) =
+        μ.bind fun ω =>
+          (Measure.dirac (ν ω)).prod (ProbabilityMeasure.pi fun _ : Fin m => ν ω).toMeasure
+
+/-- Constructor: a measurable directing measure together with the joint-law disintegration. -/
+theorem ConditionallyIIDWith.intro {μ : Measure Ω} {X : ℕ → Ω → α} {ν : Ω → ProbabilityMeasure α}
+    (hν : Measurable ν)
+    (h : ∀ (m : ℕ) (k : Fin m → ℕ), Function.Injective k →
+      μ.map (fun ω => (ν ω, fun i : Fin m => X (k i) ω)) =
+        μ.bind fun ω =>
+          (Measure.dirac (ν ω)).prod (ProbabilityMeasure.pi fun _ : Fin m => ν ω).toMeasure) :
+    ConditionallyIIDWith μ X ν :=
+  ⟨hν, h⟩
+
+/-- Conditional i.i.d.-ness: existence of a directing measure. -/
+def ConditionallyIID (μ : Measure Ω) (X : ℕ → Ω → α) : Prop :=
+  ∃ ν : Ω → ProbabilityMeasure α, ConditionallyIIDWith μ X ν
+
+/-- Constructor from a directing measure together with its witness. -/
+theorem ConditionallyIID.of_directing {μ : Measure Ω} {X : ℕ → Ω → α}
+    {ν : Ω → ProbabilityMeasure α} (h : ConditionallyIIDWith μ X ν) : ConditionallyIID μ X :=
+  ⟨ν, h⟩
+
+/-- The directing measure of a `ConditionallyIIDWith` witness is measurable. -/
+@[grind →]
+theorem ConditionallyIIDWith.measurable_directing {μ : Measure Ω} {X : ℕ → Ω → α}
+    {ν : Ω → ProbabilityMeasure α} (h : ConditionallyIIDWith μ X ν) : Measurable ν :=
+  h.1
+
+/-- The defining joint-law disintegration of a `ConditionallyIIDWith` witness. -/
+@[grind =>]
+theorem ConditionallyIIDWith.jointLaw_eq_disintegration {μ : Measure Ω} {X : ℕ → Ω → α}
+    {ν : Ω → ProbabilityMeasure α} (h : ConditionallyIIDWith μ X ν)
+    {m : ℕ} (k : Fin m → ℕ) (hk : Function.Injective k) :
+    μ.map (fun ω => (ν ω, fun i : Fin m => X (k i) ω)) =
+      μ.bind fun ω =>
+        (Measure.dirac (ν ω)).prod (ProbabilityMeasure.pi fun _ : Fin m => ν ω).toMeasure :=
+  h.2 m k hk
+
+/-- A `ConditionallyIID` process has a directing measure. -/
+theorem ConditionallyIID.exists_directing {μ : Measure Ω} {X : ℕ → Ω → α}
+    (h : ConditionallyIID μ X) :
+    ∃ ν : Ω → ProbabilityMeasure α, ConditionallyIIDWith μ X ν :=
+  h
+
+/-- **The easy arrow.** A directing measure is in particular a mixing representative: the mixture
+identity is the joint disintegration with the `ν` coordinate integrated out.
+
+Concretely, evaluating the joint identity on the rectangle `univ ×ˢ B` reads off the block's
+marginal law, because `δ_{ν ω}` contributes a factor `1` on `univ`. -/
+theorem mixedIIDWith_of_conditionallyIIDWith {μ : Measure Ω} {X : ℕ → Ω → α}
+    (hX : ∀ n, AEMeasurable (X n) μ) {ν : Ω → ProbabilityMeasure α}
+    (h : ConditionallyIIDWith μ X ν) : MixedIIDWith μ X ν := by
+  refine MixedIIDWith.intro h.measurable_directing fun m k hk => ?_
+  have hblock : AEMeasurable (fun ω => fun i : Fin m => X (k i) ω) μ :=
+    aemeasurable_pi_lambda _ fun i => hX (k i)
+  have hpair : AEMeasurable (fun ω => (ν ω, fun i : Fin m => X (k i) ω)) μ :=
+    h.measurable_directing.aemeasurable.prodMk hblock
+  have hK : AEMeasurable (fun ω =>
+      (Measure.dirac (ν ω)).prod (ProbabilityMeasure.pi fun _ : Fin m => ν ω).toMeasure) μ :=
+    (TauCeti.MeasureTheory.measurable_dirac_prod_probabilityMeasure_pi_const_toMeasure ν
+      h.measurable_directing).aemeasurable
+  have hpi : AEMeasurable
+      (fun ω => (ProbabilityMeasure.pi fun _ : Fin m => ν ω).toMeasure) μ :=
+    TauCeti.MeasureTheory.aemeasurable_probabilityMeasure_pi_const_toMeasure ν
+      h.measurable_directing.aemeasurable
+  refine Measure.ext fun B hB => ?_
+  calc blockLaw μ X k B
+      = μ.map (fun ω => (ν ω, fun i : Fin m => X (k i) ω)) (Set.univ ×ˢ B) := by
+        rw [blockLaw_def, Measure.map_apply_of_aemeasurable hblock hB,
+          Measure.map_apply_of_aemeasurable hpair (MeasurableSet.univ.prod hB)]
+        congr 1
+        ext ω
+        simp
+    _ = (μ.bind fun ω => (Measure.dirac (ν ω)).prod
+          (ProbabilityMeasure.pi fun _ : Fin m => ν ω).toMeasure) (Set.univ ×ˢ B) := by
+        rw [h.jointLaw_eq_disintegration k hk]
+    _ = ∫⁻ ω, (ProbabilityMeasure.pi fun _ : Fin m => ν ω).toMeasure B ∂μ := by
+        rw [Measure.bind_apply (MeasurableSet.univ.prod hB) hK]
+        simp [Measure.prod_prod]
+    _ = (μ.bind fun ω => (ProbabilityMeasure.pi fun _ : Fin m => ν ω).toMeasure) B := by
+        rw [Measure.bind_apply hB hpi]
+
+/-- The existential form of the easy arrow. -/
+theorem mixedIID_of_conditionallyIID {μ : Measure Ω} {X : ℕ → Ω → α}
+    (hX : ∀ n, AEMeasurable (X n) μ) (h : ConditionallyIID μ X) : MixedIID μ X := by
+  obtain ⟨ν, hν⟩ := h.exists_directing
+  exact MixedIID.of_mixingRepresentative (mixedIIDWith_of_conditionallyIIDWith hX hν)
+
+end Probability
+
+end TauCeti

--- a/TauCeti/Probability/Exchangeability/ConditionallyIID/Basic.lean
+++ b/TauCeti/Probability/Exchangeability/ConditionallyIID/Basic.lean
@@ -5,6 +5,8 @@ Released under Apache 2.0 license as described in the file LICENSE.
 module
 
 public import TauCeti.Probability.Exchangeability.MixedIID.Basic
+-- Non-public: `map_bind` is used only inside the projection proof.
+import TauCeti.MeasureTheory.Measure.GiryMonad
 
 /-!
 # Conditionally i.i.d. sequences
@@ -135,61 +137,27 @@ theorem ConditionallyIID.exists_directing {μ : Measure Ω} {X : ℕ → Ω → 
 /-- **The easy arrow.** A directing measure is in particular a mixing representative: the mixture
 identity is the joint disintegration with the `ν` coordinate integrated out.
 
-Concretely, evaluating the joint identity on the rectangle `univ ×ˢ B` reads off the block's
-marginal law, because `δ_{ν ω}` contributes a factor `1` on `univ`.
-
-No measurability hypothesis on the coordinates is needed. What `ConditionallyIIDWith` forces is
-that each selected block map — and hence each individual coordinate — is `μ`-**a.e.** measurable;
-it says nothing about pointwise measurability, which can fail on a non-measurable null set. That
-is enough here. Each mixing kernel is a probability measure, so the mixture has the same total
-mass as `μ`; if the pair map failed to be a.e. measurable then `Measure.map` would collapse the
-left side to `0`, and the identity would force `μ = 0`, which is the degenerate case where the
-conclusion holds anyway. -/
+Taking the second marginal of both sides does exactly that. On the left, `Measure.snd_map_prodMk₀`
+discards the `ν` coordinate needing only measurability of `ν` itself — which the predicate
+supplies — so no hypothesis on the coordinates of `X` is required. On the right, naturality of
+`bind` pushes the marginal inside the mixture, where each `δ_{ν ω}` factor integrates away. -/
 theorem mixedIIDWith_of_conditionallyIIDWith {μ : Measure Ω} {X : ℕ → Ω → α}
     {ν : Ω → ProbabilityMeasure α} (h : ConditionallyIIDWith μ X ν) : MixedIIDWith μ X ν := by
   refine MixedIIDWith.intro h.measurable_directing fun m k hk => ?_
-  have hjoint := h.jointLaw_eq_disintegration k hk
   have hK : AEMeasurable (fun ω =>
       (Measure.dirac (ν ω)).prod (ProbabilityMeasure.pi fun _ : Fin m => ν ω).toMeasure) μ :=
     (TauCeti.MeasureTheory.measurable_dirac_prod_probabilityMeasure_pi_const_toMeasure ν
       h.measurable_directing).aemeasurable
-  have hpi : AEMeasurable
-      (fun ω => (ProbabilityMeasure.pi fun _ : Fin m => ν ω).toMeasure) μ :=
-    TauCeti.MeasureTheory.aemeasurable_probabilityMeasure_pi_const_toMeasure ν
-      h.measurable_directing.aemeasurable
-  -- each mixing kernel is a probability measure, so the mixture carries the total mass of `μ`
-  have hbindUniv : (μ.bind fun ω => (Measure.dirac (ν ω)).prod
-      (ProbabilityMeasure.pi fun _ : Fin m => ν ω).toMeasure) Set.univ = μ Set.univ := by
-    rw [Measure.bind_apply MeasurableSet.univ hK]
-    simp
-  -- so the joint identity itself forces the pair map to be a.e. measurable: were it not,
-  -- `Measure.map` would collapse the left side to `0`, forcing `μ = 0`
-  have hpair : AEMeasurable (fun ω => (ν ω, fun i : Fin m => X (k i) ω)) μ := by
-    rcases eq_or_ne μ 0 with rfl | hμ
-    · simp
-    · by_contra hcon
-      rw [Measure.map_of_not_aemeasurable hcon] at hjoint
-      refine hμ (Measure.measure_univ_eq_zero.mp ?_)
-      rw [← hbindUniv, ← hjoint]
-      simp
-  have hblock : AEMeasurable (fun ω => fun i : Fin m => X (k i) ω) μ :=
-    measurable_snd.comp_aemeasurable hpair
-  refine Measure.ext fun B hB => ?_
-  calc blockLaw μ X k B
-      = μ.map (fun ω => (ν ω, fun i : Fin m => X (k i) ω)) (Set.univ ×ˢ B) := by
-        rw [blockLaw_def, Measure.map_apply_of_aemeasurable hblock hB,
-          Measure.map_apply_of_aemeasurable hpair (MeasurableSet.univ.prod hB)]
-        congr 1
-        ext ω
-        simp
+  calc blockLaw μ X k
+      = (μ.map fun ω => (ν ω, fun i : Fin m => X (k i) ω)).snd := by
+        rw [blockLaw_def, Measure.snd_map_prodMk₀ h.measurable_directing.aemeasurable]
     _ = (μ.bind fun ω => (Measure.dirac (ν ω)).prod
-          (ProbabilityMeasure.pi fun _ : Fin m => ν ω).toMeasure) (Set.univ ×ˢ B) := by
-        rw [hjoint]
-    _ = ∫⁻ ω, (ProbabilityMeasure.pi fun _ : Fin m => ν ω).toMeasure B ∂μ := by
-        rw [Measure.bind_apply (MeasurableSet.univ.prod hB) hK]
-        simp [Measure.prod_prod]
-    _ = (μ.bind fun ω => (ProbabilityMeasure.pi fun _ : Fin m => ν ω).toMeasure) B := by
-        rw [Measure.bind_apply hB hpi]
+          (ProbabilityMeasure.pi fun _ : Fin m => ν ω).toMeasure).snd := by
+        rw [h.jointLaw_eq_disintegration k hk]
+    _ = μ.bind fun ω => (ProbabilityMeasure.pi fun _ : Fin m => ν ω).toMeasure := by
+        simp only [Measure.snd]
+        rw [TauCeti.MeasureTheory.map_bind hK measurable_snd]
+        simp
 
 /-- The existential form of the easy arrow. -/
 theorem mixedIID_of_conditionallyIID {μ : Measure Ω} {X : ℕ → Ω → α}

--- a/TauCeti/Probability/Exchangeability/ConditionallyIID/Basic.lean
+++ b/TauCeti/Probability/Exchangeability/ConditionallyIID/Basic.lean
@@ -30,14 +30,20 @@ representative*, whereas `ν` here is a genuine **directing measure**.
 
 ## Main results
 
-* `ConditionallyIIDWith`, `ConditionallyIID` — the predicate and its existential wrapper.
-* `mixedIIDWith_of_conditionallyIIDWith`, `mixedIID_of_conditionallyIID` — the easy arrow down to
-  the mixture identity.
+* `ConditionallyIIDWith`, `ConditionallyIID` — the predicate and its existential wrapper, with
+  their constructor, accessor, and simp-normal-form API.
+* `mixedIIDWith_of_conditionallyIIDWith`, `mixedIID_of_conditionallyIID` — the easy projection down
+  to the mixture identity.
 
-This advances `TauCetiRoadmap/Exchangeability/README.md`, Layer 0/1: the conditional predicate the
-roadmap reserves the `ConditionallyIID` name for, and the easy arrow it pins alongside. The
-summit theorems that *conclude* it (`conditionallyIID_of_contractable` and the `deFinetti*`
-handles) remain open.
+This is a **Layer 0** contribution to `TauCetiRoadmap/Exchangeability/README.md` — the conditional
+predicate for which the roadmap reserves the `ConditionallyIID` name, together with the easy
+projection it pins alongside — which consumes the already-landed Layer 1 joint-kernel lemma
+`measurable_dirac_prod_probabilityMeasure_pi_const_toMeasure`.
+
+Still open, and not attempted here: the Layer 1 joint-rectangle common ending
+`conditionallyIID_of_jointRectangles`; the Layer 6 summit theorems that *conclude* this predicate,
+`conditionallyIID_of_contractable` and `conditionallyIID_of_exchangeable`; the `deFinetti*` handles
+that return with them; and directing-measure uniqueness (`conditionallyIID_ae_unique`).
 -/
 
 public section
@@ -76,6 +82,19 @@ theorem ConditionallyIIDWith.intro {μ : Measure Ω} {X : ℕ → Ω → α} {ν
     ConditionallyIIDWith μ X ν :=
   ⟨hν, h⟩
 
+/-- Simp normal form for `ConditionallyIIDWith`. -/
+@[simp]
+theorem conditionallyIIDWith_iff {μ : Measure Ω} {X : ℕ → Ω → α}
+    {ν : Ω → ProbabilityMeasure α} :
+    ConditionallyIIDWith μ X ν ↔
+      Measurable ν ∧
+        ∀ (m : ℕ) (k : Fin m → ℕ), Function.Injective k →
+          μ.map (fun ω => (ν ω, fun i : Fin m => X (k i) ω)) =
+            μ.bind fun ω =>
+              (Measure.dirac (ν ω)).prod
+                (ProbabilityMeasure.pi fun _ : Fin m => ν ω).toMeasure :=
+  Iff.rfl
+
 /-- Conditional i.i.d.-ness: existence of a directing measure. -/
 def ConditionallyIID (μ : Measure Ω) (X : ℕ → Ω → α) : Prop :=
   ∃ ν : Ω → ProbabilityMeasure α, ConditionallyIIDWith μ X ν
@@ -84,6 +103,12 @@ def ConditionallyIID (μ : Measure Ω) (X : ℕ → Ω → α) : Prop :=
 theorem ConditionallyIID.of_directing {μ : Measure Ω} {X : ℕ → Ω → α}
     {ν : Ω → ProbabilityMeasure α} (h : ConditionallyIIDWith μ X ν) : ConditionallyIID μ X :=
   ⟨ν, h⟩
+
+/-- Simp normal form for the existential wrapper `ConditionallyIID`. -/
+@[simp]
+theorem conditionallyIID_iff {μ : Measure Ω} {X : ℕ → Ω → α} :
+    ConditionallyIID μ X ↔ ∃ ν : Ω → ProbabilityMeasure α, ConditionallyIIDWith μ X ν :=
+  Iff.rfl
 
 /-- The directing measure of a `ConditionallyIIDWith` witness is measurable. -/
 @[grind →]


### PR DESCRIPTION
**Roadmap:** `TauCetiRoadmap/Exchangeability/README.md`, **Layer 0** — the conditional predicate for which the roadmap reserves the `ConditionallyIID` name, plus the easy projection it pins alongside. Consumes the already-landed Layer 1 joint-kernel lemma.

Closes TauCetiProject/TauCetiRoadmap#87 — the intention claiming exactly this slice.

## What

One new file, `TauCeti/Probability/Exchangeability/ConditionallyIID/Basic.lean`:

```lean
def ConditionallyIIDWith (μ : Measure Ω) (X : ℕ → Ω → α) (ν : Ω → ProbabilityMeasure α) : Prop :=
  Measurable ν ∧
    ∀ (m : ℕ) (k : Fin m → ℕ), Function.Injective k →
      μ.map (fun ω => (ν ω, fun i : Fin m => X (k i) ω)) =
        μ.bind fun ω =>
          (Measure.dirac (ν ω)).prod (ProbabilityMeasure.pi fun _ : Fin m => ν ω).toMeasure
```

plus `ConditionallyIID`, the constructor/accessor API, the two `Iff.rfl` simp normal forms mirroring `MixedIID/Basic.lean`, and the easy projections `mixedIIDWith_of_conditionallyIIDWith` / `mixedIID_of_conditionallyIID`.

## Why it is the genuine conditional notion

`MixedIIDWith μ X ν` constrains only each finite block's **marginal** law, so it does not pin down how `X` relates to `ν`: for a nondegenerate mixing law an *independent copy* of a directing measure also witnesses it, while the process is not conditionally i.i.d. given that copy. Constraining the **joint** law of `(ν, block)` is what closes that gap, and stating it as a joint-law identity means the definition needs no conditional expectations — it stays in the same `bind`/`pi` vocabulary as `MixedIIDWith`.

The arrow therefore runs one way only, and `mixedIIDWith_of_conditionallyIIDWith` is that arrow.

## The prerequisite this cashes in

The right-hand side is a `Measure.bind` of the joint kernel `ω ↦ δ_{ν ω} ⊗ (ν ω)^{⊗m}`, whose measurability landed as `measurable_dirac_prod_probabilityMeasure_pi_const_toMeasure` in #1193 — added for precisely this bind. This PR is its first consumer.

## Proof note

The easy projection is the second marginal of the joint identity — which is precisely "integrate the `ν` coordinate out". On the left, `Measure.snd_map_prodMk₀` discards that coordinate; on the right, `TauCeti.MeasureTheory.map_bind` pushes the marginal inside the mixture, where `Measure.map_snd_prod` integrates each Dirac factor away. Three `calc` steps.

That route depends on `map_bind`, the `Measure` form of Giry naturality, which Mathlib lacks (its `map_bind` lemmas are for `PMF`/`Multiset`/`Option`) and TauCeti previously carried only as a `private` lemma inside `MixedIID/Map.lean`. #1212 relocated it to shared measure infrastructure so it could be reused here; this branch merges that in.

## Generality

The projections need **no** hypothesis on the coordinates of `X` and **no** probability-measure instance on `μ` — weaker than the roadmap's suggested signature, which assumes pointwise measurable coordinates. `Measure.snd_map_prodMk₀` needs only measurability of `ν`, and `ConditionallyIIDWith` supplies that directly. The predicate itself stays hypothesis-light, as the roadmap prescribes.

## Scope

`TauCeti/` only, one new file, no existing declaration changed. Deliberately **excluded**, and not claimed by #87:

- `conditionallyIID_of_jointRectangles` — the Layer 1 joint-rectangle ending, which belongs in `DeFinetti/CommonEnding.lean` beside `mixedIID_of_mixingRepresentative`; a distinct topic, with its own intention to follow
- the Layer 6 summit (`conditionallyIID_of_contractable`, `conditionallyIID_of_exchangeable`) and the `deFinetti*` handles that return with it
- directing-measure uniqueness (`conditionallyIID_ae_unique`)

## Verification

`lake build` — full library: **5365 jobs, 0 errors, 0 warnings.** No `sorry`. Style linters pass.

Co-Authored-By: Claude Code <noreply@github.com>
