### PR TITLE
refactor(MeasureTheory): promote bind naturality to shared infrastructure

### DIFF
--- a/TauCeti/MeasureTheory/Measure/GiryMonad.lean
+++ b/TauCeti/MeasureTheory/Measure/GiryMonad.lean
@@ -39,7 +39,7 @@ commutes with the bind: the pushforward of the mixture is the mixture of the pus
 the Giry-monad identity `map F ∘ bind g = bind (map F ∘ g)`.
 
 Obtained from associativity of `bind` together with `bind_dirac_eq_map`. -/
-theorem map_bind_comm {μ : Measure S} {g : S → Measure γ} (hg : AEMeasurable g μ)
+theorem map_bind {μ : Measure S} {g : S → Measure γ} (hg : AEMeasurable g μ)
     {F : γ → δ} (hF : Measurable F) :
     (μ.bind g).map F = μ.bind fun ω => (g ω).map F := by
   have hdirac : AEMeasurable (fun x : γ => Measure.dirac (F x)) (μ.bind g) :=

--- a/TauCeti/MeasureTheory/Measure/GiryMonad.lean
+++ b/TauCeti/MeasureTheory/Measure/GiryMonad.lean
@@ -1,0 +1,52 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+module
+
+public import Mathlib.MeasureTheory.Measure.GiryMonad
+
+/-!
+# Naturality of the Giry monad's `bind`
+
+Pushing a `Measure.bind` mixture forward by a measurable map commutes with the bind: the
+pushforward of a mixture is the mixture of the pushforwards.
+
+Mathlib carries this naturality for `PMF` (`PMF.map_bind`) but not for `Measure`, although all
+of its ingredients — `Measure.bind_bind` and `Measure.bind_dirac_eq_map` — are there. This file
+supplies the missing `Measure` form.
+
+It is stated for an a.e.-measurable kernel `g`, which is the hypothesis `Measure.bind_bind`
+needs, and it is the shape mixture arguments want: `bind` is how a random measure is integrated
+against its mixing law, so pushing a mixture forward along a coordinate map — a marginal — is a
+routine step.
+-/
+
+public section
+
+noncomputable section
+
+open MeasureTheory
+
+namespace TauCeti
+
+namespace MeasureTheory
+
+variable {S γ δ : Type*} [MeasurableSpace S] [MeasurableSpace γ] [MeasurableSpace δ]
+
+/-- **Naturality of `bind`.** Pushing a `Measure.bind` mixture forward by a measurable map
+commutes with the bind: the pushforward of the mixture is the mixture of the pushforwards, i.e.
+the Giry-monad identity `map F ∘ bind g = bind (map F ∘ g)`.
+
+Obtained from associativity of `bind` together with `bind_dirac_eq_map`. -/
+theorem map_bind_comm {μ : Measure S} {g : S → Measure γ} (hg : AEMeasurable g μ)
+    {F : γ → δ} (hF : Measurable F) :
+    (μ.bind g).map F = μ.bind fun ω => (g ω).map F := by
+  have hdirac : AEMeasurable (fun x : γ => Measure.dirac (F x)) (μ.bind g) :=
+    (Measure.measurable_dirac.comp hF).aemeasurable
+  rw [← Measure.bind_dirac_eq_map (μ.bind g) hF, Measure.bind_bind hg hdirac]
+  simp_rw [Measure.bind_dirac_eq_map _ hF]
+
+end MeasureTheory
+
+end TauCeti

--- a/TauCeti/Probability/Exchangeability/MixedIID/Map.lean
+++ b/TauCeti/Probability/Exchangeability/MixedIID/Map.lean
@@ -5,7 +5,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 module
 
 public import TauCeti.Probability.Exchangeability.MixedIID.Basic
--- Non-public: `map_bind_comm` is used only inside the proof below.
+-- Non-public: `map_bind` is used only inside the proof below.
 import TauCeti.MeasureTheory.Measure.GiryMonad
 
 /-!
@@ -26,7 +26,7 @@ mapped process is the original identity with each product factor pushed forward 
 The proof runs at the level of the finite-block mixture identity. It reuses `map_blockLaw`
 (the coordinatewise pushforward of a block law), the random-product measurability of
 `TauCeti.MeasureTheory.Measure.ProductKernel`, the naturality of `bind`
-(`TauCeti.MeasureTheory.map_bind_comm`), and Mathlib's product pushforward `Measure.pi_map_pi`.
+(`TauCeti.MeasureTheory.map_bind`), and Mathlib's product pushforward `Measure.pi_map_pi`.
 It needs no material from `cameronfreer/exchangeability` beyond the existing `MixedIIDWith` API
 this repository already carries.
 -/
@@ -72,7 +72,7 @@ theorem MixedIIDWith.map_values {μ : Measure Ω} {X : ℕ → Ω → α}
             fun x : Fin m → α => fun i => f (x i) := by rw [h.blockLaw_eq_mixture k hk]
       _ = μ.bind fun ω =>
             ((ProbabilityMeasure.pi fun _ : Fin m => ν ω).toMeasure).map
-              fun x : Fin m → α => fun i => f (x i) := TauCeti.MeasureTheory.map_bind_comm hg hFmeas
+              fun x : Fin m → α => fun i => f (x i) := TauCeti.MeasureTheory.map_bind hg hFmeas
       _ = μ.bind fun ω =>
             (ProbabilityMeasure.pi fun _ : Fin m => (ν ω).map hf.aemeasurable).toMeasure := by
             refine congrArg (μ.bind ·) (funext fun ω => ?_)

--- a/TauCeti/Probability/Exchangeability/MixedIID/Map.lean
+++ b/TauCeti/Probability/Exchangeability/MixedIID/Map.lean
@@ -5,6 +5,8 @@ Released under Apache 2.0 license as described in the file LICENSE.
 module
 
 public import TauCeti.Probability.Exchangeability.MixedIID.Basic
+-- Non-public: `map_bind_comm` is used only inside the proof below.
+import TauCeti.MeasureTheory.Measure.GiryMonad
 
 /-!
 # Coordinatewise maps of mixed i.i.d. sequences
@@ -22,11 +24,11 @@ transformation of the mixing representative is the expected one: the mixture ide
 mapped process is the original identity with each product factor pushed forward by `f`.
 
 The proof runs at the level of the finite-block mixture identity. It reuses `map_blockLaw`
-(the coordinatewise pushforward of a block law) and the random-product measurability of
-`TauCeti.MeasureTheory.Measure.ProductKernel`, together with the Giry-monad laws
-`Measure.bind_bind` and `Measure.bind_dirac_eq_map` and Mathlib's product pushforward
-`Measure.pi_map_pi`.  It needs no material from `cameronfreer/exchangeability` beyond the
-existing `MixedIIDWith` API this repository already carries.
+(the coordinatewise pushforward of a block law), the random-product measurability of
+`TauCeti.MeasureTheory.Measure.ProductKernel`, the naturality of `bind`
+(`TauCeti.MeasureTheory.map_bind_comm`), and Mathlib's product pushforward `Measure.pi_map_pi`.
+It needs no material from `cameronfreer/exchangeability` beyond the existing `MixedIIDWith` API
+this repository already carries.
 -/
 
 public section
@@ -40,19 +42,6 @@ namespace TauCeti
 namespace Probability
 
 variable {Ω α β : Type*} [MeasurableSpace Ω] [MeasurableSpace α] [MeasurableSpace β]
-
-/-- Pushing a `Measure.bind` mixture forward by a measurable map commutes with the bind: the
-pushforward of the mixture is the mixture of the pushforwards. This is the Giry-monad identity
-`map F ∘ bind g = bind (map F ∘ g)`, obtained from associativity of `bind` and
-`bind_dirac_eq_map`. -/
-private theorem map_bind_comm {S γ δ : Type*} [MeasurableSpace S] [MeasurableSpace γ]
-    [MeasurableSpace δ] {μ : Measure S} {g : S → Measure γ} (hg : AEMeasurable g μ)
-    {F : γ → δ} (hF : Measurable F) :
-    (μ.bind g).map F = μ.bind fun ω => (g ω).map F := by
-  have hdirac : AEMeasurable (fun x : γ => Measure.dirac (F x)) (μ.bind g) :=
-    (Measure.measurable_dirac.comp hF).aemeasurable
-  rw [← Measure.bind_dirac_eq_map (μ.bind g) hF, Measure.bind_bind hg hdirac]
-  simp_rw [Measure.bind_dirac_eq_map _ hF]
 
 /-- Mixed i.i.d.-ness with a named mixing representative is preserved by a coordinatewise
 measurable map of the value space: if `X` is mixed i.i.d. with mixing representative `ν`, then
@@ -83,7 +72,7 @@ theorem MixedIIDWith.map_values {μ : Measure Ω} {X : ℕ → Ω → α}
             fun x : Fin m → α => fun i => f (x i) := by rw [h.blockLaw_eq_mixture k hk]
       _ = μ.bind fun ω =>
             ((ProbabilityMeasure.pi fun _ : Fin m => ν ω).toMeasure).map
-              fun x : Fin m → α => fun i => f (x i) := map_bind_comm hg hFmeas
+              fun x : Fin m → α => fun i => f (x i) := TauCeti.MeasureTheory.map_bind_comm hg hFmeas
       _ = μ.bind fun ω =>
             (ProbabilityMeasure.pi fun _ : Fin m => (ν ω).map hf.aemeasurable).toMeasure := by
             refine congrArg (μ.bind ·) (funext fun ω => ?_)


### PR DESCRIPTION
Pure relocation of an existing lemma. **No new mathematics**, so no roadmap target or intention applies — the statement and proof are unchanged, only their home and visibility.

## What

`map_bind_comm` — pushing a `Measure.bind` mixture forward by a measurable map commutes with the bind:

```lean
theorem map_bind_comm {μ : Measure S} {g : S → Measure γ} (hg : AEMeasurable g μ)
    {F : γ → δ} (hF : Measurable F) :
    (μ.bind g).map F = μ.bind fun ω => (g ω).map F
```

It was `private` in `TauCeti/Probability/Exchangeability/MixedIID/Map.lean`, so nothing else could use it. Moved verbatim to a new `TauCeti/MeasureTheory/Measure/GiryMonad.lean` and made public; `MixedIID/Map.lean` now consumes it through a proof-only import.

## Why

The lemma is a general Giry-monad fact with no exchangeability content, so its home under `Exchangeability/` was accidental — it lived there because that is where it was first needed.

Mathlib carries this naturality for `PMF` (`PMF.map_bind`) but not for `Measure`, even though both ingredients (`Measure.bind_bind`, `Measure.bind_dirac_eq_map`) are present. `bind` is how a random measure is integrated against its mixing law, so pushing a mixture forward along a coordinate map — taking a marginal — is a routine step in any mixture argument, and it should not require re-deriving the identity or duplicating the lemma.

**Concretely**, this unblocks a review finding on #1211: the `reuse` rubric there asks that `mixedIIDWith_of_conditionallyIIDWith` project the joint law using this lemma with `Prod.snd` rather than evaluate rectangles by hand. That fix requires the lemma to be reusable, which requires this relocation. Shipping it separately follows the repo's one-topic-per-PR rule; #1211 will be rebased onto it.

## Scope

`TauCeti/` only. One new file, one existing file rewired. The statement, proof term, and hypotheses are identical to what was already reviewed and merged as part of the `MixedIID` API — this PR only changes where it lives and that it is public.

## Verification

`lake build` — full library: **5365 jobs, 0 errors, 0 warnings.** Style linters pass.

Co-Authored-By: Claude Code <noreply@github.com>