### PR TITLE
feat: add finite-type diagonalizable coordinate functor

### DIFF
--- a/TauCeti/Algebra/AlgebraicGroup/DiagonalizableGroup/FiniteType.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/DiagonalizableGroup/FiniteType.lean
@@ -1,0 +1,193 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+module
+
+public import Mathlib.GroupTheory.Finiteness
+public import Mathlib.RingTheory.FiniteType
+public import TauCeti.Algebra.AlgebraicGroup.DiagonalizableGroup.Functoriality
+public import TauCeti.Algebra.AlgebraicGroup.FiniteType.CommHopfAlgCat
+
+/-!
+# Finite-type diagonalizable groups
+
+The diagonalizable group attached to a commutative group `G` has coordinate Hopf algebra
+`R[G]`. It is of finite type over `R` precisely when `G` is finitely generated (over a
+nontrivial base). This file packages the forward direction categorically: finitely generated
+commutative groups form `FGCommGrpCat`, and the group-algebra construction gives a functor
+from this category to finite-type commutative Hopf algebras.
+
+On affine schemes the variance reverses once more under `Spec`, so this covariant coordinate
+ring functor is the algebraic side of the contravariant assignment `G ↦ D(G)`. Its morphism
+part is `MonoidAlgebra.mapDomainBialgHom`; the existing diagonalizable-group points API shows
+that the resulting map of represented groups acts by precomposition on characters.
+
+This advances the reductive-groups roadmap Layer 4 target constructing the anti-equivalence
+between finitely generated abelian groups and diagonalizable groups. It supplies the
+finite-type source and coordinate-algebra functor needed before essential surjectivity and
+full faithfulness can be formulated.
+
+## Main declarations
+
+* `TauCeti.FGCommGrpCat`: the category of finitely generated commutative groups.
+* `TauCeti.DiagonalizableGroup.coordinateRing`: `R[G]` as a finite-type commutative Hopf
+  algebra.
+* `TauCeti.DiagonalizableGroup.coordinateMap`: the coordinate morphism induced by a group
+  homomorphism.
+* `TauCeti.DiagonalizableGroup.coordinateRingFunctor`: the group-algebra functor from
+  finitely generated commutative groups to finite-type commutative Hopf algebras.
+
+## References
+
+The mathematical construction is the diagonalizable-group correspondence in Waterhouse,
+*Introduction to Affine Group Schemes*, Chapter 2. The finite-type input is Mathlib's
+`MonoidAlgebra.finiteType_of_fg`, and the Hopf morphism is Mathlib's
+`MonoidAlgebra.mapDomainBialgHom`.
+-/
+
+public section
+
+open CategoryTheory
+
+namespace TauCeti
+
+universe u v
+
+/-- The object property of being a finitely generated commutative group. -/
+@[expose] def fgCommGrpProperty : ObjectProperty CommGrpCat.{v} :=
+  fun G => Group.FG G
+
+/-- Membership in the finitely generated commutative-group object property. -/
+@[simp]
+theorem fgCommGrpProperty_iff (G : CommGrpCat.{v}) :
+    fgCommGrpProperty G ↔ Group.FG G :=
+  Iff.rfl
+
+/-- The category of finitely generated commutative groups.
+
+This is the source of the coordinate-ring functor for finite-type diagonalizable groups. -/
+abbrev FGCommGrpCat :=
+  fgCommGrpProperty.FullSubcategory
+
+namespace FGCommGrpCat
+
+/-- The underlying type of a finitely generated commutative group. -/
+@[expose, reducible]
+def carrier (G : FGCommGrpCat.{v}) : Type v :=
+  G.obj
+
+instance : CoeSort FGCommGrpCat.{v} (Type v) :=
+  ⟨carrier⟩
+
+attribute [coe] carrier
+
+instance (G : FGCommGrpCat.{v}) : CommGroup G :=
+  inferInstanceAs (CommGroup G.obj)
+
+/-- The underlying group of an object of `FGCommGrpCat` is finitely generated. -/
+instance (G : FGCommGrpCat.{v}) : Group.FG G :=
+  G.property
+
+/-- Construct an object of `FGCommGrpCat` from a finitely generated commutative group. -/
+abbrev of (G : Type v) [CommGroup G] [Group.FG G] : FGCommGrpCat.{v} :=
+  ⟨CommGrpCat.of G, inferInstanceAs (Group.FG G)⟩
+
+/-- Lift a group homomorphism between finitely generated commutative groups to
+`FGCommGrpCat`. -/
+abbrev ofHom {G H : Type v} [CommGroup G] [Group.FG G] [CommGroup H] [Group.FG H]
+    (φ : G →* H) : of G ⟶ of H :=
+  ObjectProperty.homMk (CommGrpCat.ofHom φ)
+
+/-- The group homomorphism underlying a morphism in `FGCommGrpCat`. -/
+abbrev toMonoidHom {G H : FGCommGrpCat.{v}} (φ : G ⟶ H) : G →* H :=
+  φ.hom.hom
+
+/-- Two morphisms in `FGCommGrpCat` are equal when their underlying group homomorphisms
+are equal. -/
+@[ext]
+theorem hom_ext {G H : FGCommGrpCat.{v}} {φ ψ : G ⟶ H}
+    (h : toMonoidHom φ = toMonoidHom ψ) : φ = ψ :=
+  ObjectProperty.hom_ext (P := fgCommGrpProperty) (CommGrpCat.hom_ext h)
+
+@[simp]
+theorem toMonoidHom_id {G : FGCommGrpCat.{v}} :
+    toMonoidHom (𝟙 G) = MonoidHom.id G :=
+  rfl
+
+@[simp]
+theorem toMonoidHom_comp {G H K : FGCommGrpCat.{v}} (φ : G ⟶ H) (ψ : H ⟶ K) :
+    toMonoidHom (φ ≫ ψ) = (toMonoidHom ψ).comp (toMonoidHom φ) :=
+  rfl
+
+end FGCommGrpCat
+
+namespace DiagonalizableGroup
+
+variable (R : Type u) [CommRing R]
+
+/-- The coordinate Hopf algebra `R[G]` of the diagonalizable group `D(G)`, bundled as a
+finite-type commutative Hopf algebra when `G` is finitely generated. -/
+noncomputable abbrev coordinateRing (G : FGCommGrpCat.{v}) :
+    FiniteTypeCommHopfAlgCat.{u, max u v} R :=
+  FiniteTypeCommHopfAlgCat.of R (MonoidAlgebra R G)
+
+/-- A homomorphism `G → G'` induces the coordinate Hopf-algebra morphism
+`R[G] → R[G']` between the corresponding finite-type diagonalizable groups. -/
+noncomputable abbrev coordinateMap {G H : FGCommGrpCat.{v}} (φ : G ⟶ H) :
+    coordinateRing R G ⟶ coordinateRing R H :=
+  FiniteTypeCommHopfAlgCat.ofHom
+    (MonoidAlgebra.mapDomainBialgHom R (FGCommGrpCat.toMonoidHom φ))
+
+/-- The bialgebra morphism underlying `coordinateMap φ` is the group-algebra map induced
+by the underlying group homomorphism. -/
+@[simp]
+theorem coordinateMap_toBialgHom {G H : FGCommGrpCat.{v}} (φ : G ⟶ H) :
+    FiniteTypeCommHopfAlgCat.toBialgHom (coordinateMap R φ) =
+      MonoidAlgebra.mapDomainBialgHom R (FGCommGrpCat.toMonoidHom φ) :=
+  rfl
+
+/-- On a group-algebra basis element, `coordinateMap φ` applies `φ` to its index. -/
+@[simp]
+theorem coordinateMap_single {G H : FGCommGrpCat.{v}} (φ : G ⟶ H) (g : G) (r : R) :
+    FiniteTypeCommHopfAlgCat.toBialgHom (coordinateMap R φ)
+        (MonoidAlgebra.single g r) =
+      MonoidAlgebra.single (FGCommGrpCat.toMonoidHom φ g) r := by
+  rw [coordinateMap_toBialgHom]
+  simp [MonoidAlgebra.mapDomainBialgHom, MonoidAlgebra.mapDomainAlgHom_apply]
+
+/-- The coordinate-ring construction for finite-type diagonalizable groups.
+
+It is covariant on coordinate Hopf algebras. After applying the contravariant spectrum
+functor, it becomes the usual contravariant assignment `G ↦ D(G)`. -/
+@[expose] noncomputable def coordinateRingFunctor :
+    FGCommGrpCat.{v} ⥤ FiniteTypeCommHopfAlgCat.{u, max u v} R where
+  obj := coordinateRing R
+  map := coordinateMap R
+  map_id G := by
+    apply FiniteTypeCommHopfAlgCat.hom_ext
+    rw [coordinateMap_toBialgHom, FGCommGrpCat.toMonoidHom_id]
+    exact MonoidAlgebra.mapDomainBialgHom_id (R := R) (M := G)
+  map_comp φ ψ := by
+    apply FiniteTypeCommHopfAlgCat.hom_ext
+    rw [coordinateMap_toBialgHom, FGCommGrpCat.toMonoidHom_comp,
+      FiniteTypeCommHopfAlgCat.toBialgHom_comp, coordinateMap_toBialgHom,
+      coordinateMap_toBialgHom]
+    exact MonoidAlgebra.mapDomainBialgHom_comp (R := R)
+      (FGCommGrpCat.toMonoidHom ψ) (FGCommGrpCat.toMonoidHom φ)
+
+/-- The object part of `coordinateRingFunctor` is the group algebra `R[G]`. -/
+@[simp]
+theorem coordinateRingFunctor_obj (G : FGCommGrpCat.{v}) :
+    (coordinateRingFunctor R).obj G = coordinateRing R G :=
+  rfl
+
+/-- The morphism part of `coordinateRingFunctor` is the group-algebra bialgebra map. -/
+@[simp]
+theorem coordinateRingFunctor_map {G H : FGCommGrpCat.{v}} (φ : G ⟶ H) :
+    (coordinateRingFunctor R).map φ = coordinateMap R φ :=
+  rfl
+
+end DiagonalizableGroup
+
+end TauCeti

--- a/TauCeti/Algebra/AlgebraicGroup/DiagonalizableGroup/FiniteType.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/DiagonalizableGroup/FiniteType.lean
@@ -4,7 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 -/
 module
 
-public import TauCeti.Algebra.AlgebraicGroup.DiagonalizableGroup.Functoriality
+public import Mathlib.RingTheory.HopfAlgebra.MonoidAlgebra
 public import TauCeti.Algebra.AlgebraicGroup.FiniteType.CommHopfAlgCat
 public import TauCeti.Algebra.Category.CommGrpCat.FiniteGeneration
 
@@ -19,8 +19,9 @@ from this category to finite-type commutative Hopf algebras.
 
 On affine schemes the variance reverses once more under `Spec`, so this covariant coordinate
 ring functor is the algebraic side of the contravariant assignment `G ↦ D(G)`. Its morphism
-part is `MonoidAlgebra.mapDomainBialgHom`; the existing diagonalizable-group points API shows
-that the resulting map of represented groups acts by precomposition on characters.
+part is `MonoidAlgebra.mapDomainBialgHom`; the `DiagonalizableGroup.Functoriality` module
+separately shows that the resulting map of represented groups acts by precomposition on
+characters.
 
 This advances the reductive-groups roadmap Layer 4 target constructing the anti-equivalence
 between finitely generated abelian groups and diagonalizable groups. It supplies the
@@ -79,11 +80,13 @@ theorem toBialgHom_coordinateMap {G H : FGCommGrpCat.{v}} (φ : G ⟶ H) :
   rfl
 
 /-- The coordinate map sends a group-algebra basis element to the basis element indexed
-by its image under the underlying group homomorphism. -/
-@[simp]
+by its image under the underlying group homomorphism.
+
+This is deliberately not a `simp` lemma: `FiniteTypeCommHopfAlgCat.toBialgHom_ofHom`
+already rewrites the left-hand side to `MonoidAlgebra.mapDomainBialgHom`, so `simp` would
+never see this form. -/
 theorem coordinateMap_single {G H : FGCommGrpCat.{v}} (φ : G ⟶ H) (g : G) (r : R) :
-    MonoidAlgebra.mapDomainBialgHom R (FGCommGrpCat.toMonoidHom φ)
-        (MonoidAlgebra.single g r) =
+    FiniteTypeCommHopfAlgCat.toBialgHom (coordinateMap R φ) (MonoidAlgebra.single g r) =
       MonoidAlgebra.single (FGCommGrpCat.toMonoidHom φ g) r := by
   exact MonoidAlgebra.mapDomain_single
 
@@ -91,7 +94,7 @@ theorem coordinateMap_single {G H : FGCommGrpCat.{v}} (φ : G ⟶ H) (g : G) (r 
 
 It is covariant on coordinate Hopf algebras. After applying the contravariant spectrum
 functor, it becomes the usual contravariant assignment `G ↦ D(G)`. -/
-noncomputable def coordinateRingFunctor :
+@[expose] noncomputable def coordinateRingFunctor :
     FGCommGrpCat.{v} ⥤ FiniteTypeCommHopfAlgCat.{u, max u v} R where
   obj := coordinateRing R
   map := coordinateMap R
@@ -106,6 +109,20 @@ noncomputable def coordinateRingFunctor :
       toBialgHom_coordinateMap]
     exact MonoidAlgebra.mapDomainBialgHom_comp (R := R)
       (FGCommGrpCat.toMonoidHom ψ) (FGCommGrpCat.toMonoidHom φ)
+
+/-- The coordinate-ring functor sends a finitely generated commutative group to its
+coordinate Hopf algebra. -/
+@[simp]
+theorem coordinateRingFunctor_obj (G : FGCommGrpCat.{v}) :
+    (coordinateRingFunctor R).obj G = coordinateRing R G :=
+  rfl
+
+/-- The coordinate-ring functor sends a group homomorphism to the induced coordinate
+Hopf-algebra morphism. -/
+@[simp]
+theorem coordinateRingFunctor_map {G H : FGCommGrpCat.{v}} (φ : G ⟶ H) :
+    (coordinateRingFunctor R).map φ = coordinateMap R φ :=
+  rfl
 
 end DiagonalizableGroup
 

--- a/TauCeti/Algebra/AlgebraicGroup/DiagonalizableGroup/FiniteType.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/DiagonalizableGroup/FiniteType.lean
@@ -82,10 +82,9 @@ theorem toBialgHom_coordinateMap {G H : FGCommGrpCat.{v}} (φ : G ⟶ H) :
 by its image under the underlying group homomorphism. -/
 @[simp]
 theorem coordinateMap_single {G H : FGCommGrpCat.{v}} (φ : G ⟶ H) (g : G) (r : R) :
-    FiniteTypeCommHopfAlgCat.toBialgHom (coordinateMap R φ)
+    MonoidAlgebra.mapDomainBialgHom R (FGCommGrpCat.toMonoidHom φ)
         (MonoidAlgebra.single g r) =
       MonoidAlgebra.single (FGCommGrpCat.toMonoidHom φ g) r := by
-  rw [toBialgHom_coordinateMap]
   exact MonoidAlgebra.mapDomain_single
 
 /-- The coordinate-ring construction for finite-type diagonalizable groups.

--- a/TauCeti/Algebra/AlgebraicGroup/DiagonalizableGroup/FiniteType.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/DiagonalizableGroup/FiniteType.lean
@@ -4,7 +4,6 @@ Released under Apache 2.0 license as described in the file LICENSE.
 -/
 module
 
-public import Mathlib.RingTheory.FiniteType
 public import TauCeti.Algebra.AlgebraicGroup.DiagonalizableGroup.Functoriality
 public import TauCeti.Algebra.AlgebraicGroup.FiniteType.CommHopfAlgCat
 public import TauCeti.Algebra.Category.CommGrpCat.FiniteGeneration
@@ -74,10 +73,20 @@ noncomputable abbrev coordinateMap {G H : FGCommGrpCat.{v}} (φ : G ⟶ H) :
 /-- The bialgebra morphism underlying `coordinateMap φ` is the group-algebra map induced
 by the underlying group homomorphism. -/
 @[simp]
-theorem coordinateMap_toBialgHom {G H : FGCommGrpCat.{v}} (φ : G ⟶ H) :
+theorem toBialgHom_coordinateMap {G H : FGCommGrpCat.{v}} (φ : G ⟶ H) :
     FiniteTypeCommHopfAlgCat.toBialgHom (coordinateMap R φ) =
       MonoidAlgebra.mapDomainBialgHom R (FGCommGrpCat.toMonoidHom φ) :=
   rfl
+
+/-- The coordinate map sends a group-algebra basis element to the basis element indexed
+by its image under the underlying group homomorphism. -/
+@[simp]
+theorem coordinateMap_single {G H : FGCommGrpCat.{v}} (φ : G ⟶ H) (g : G) (r : R) :
+    FiniteTypeCommHopfAlgCat.toBialgHom (coordinateMap R φ)
+        (MonoidAlgebra.single g r) =
+      MonoidAlgebra.single (FGCommGrpCat.toMonoidHom φ g) r := by
+  rw [toBialgHom_coordinateMap]
+  exact MonoidAlgebra.mapDomain_single
 
 /-- The coordinate-ring construction for finite-type diagonalizable groups.
 
@@ -89,29 +98,15 @@ noncomputable def coordinateRingFunctor :
   map := coordinateMap R
   map_id G := by
     apply FiniteTypeCommHopfAlgCat.hom_ext
-    rw [coordinateMap_toBialgHom, FGCommGrpCat.toMonoidHom_id]
+    rw [toBialgHom_coordinateMap, FGCommGrpCat.toMonoidHom_id]
     exact MonoidAlgebra.mapDomainBialgHom_id (R := R) (M := G)
   map_comp φ ψ := by
     apply FiniteTypeCommHopfAlgCat.hom_ext
-    rw [coordinateMap_toBialgHom, FGCommGrpCat.toMonoidHom_comp,
-      FiniteTypeCommHopfAlgCat.toBialgHom_comp, coordinateMap_toBialgHom,
-      coordinateMap_toBialgHom]
+    rw [toBialgHom_coordinateMap, FGCommGrpCat.toMonoidHom_comp,
+      FiniteTypeCommHopfAlgCat.toBialgHom_comp, toBialgHom_coordinateMap,
+      toBialgHom_coordinateMap]
     exact MonoidAlgebra.mapDomainBialgHom_comp (R := R)
       (FGCommGrpCat.toMonoidHom ψ) (FGCommGrpCat.toMonoidHom φ)
-
-/-- The object part of `coordinateRingFunctor` is the group algebra `R[G]`. -/
-@[simp]
-theorem coordinateRingFunctor_obj (G : FGCommGrpCat.{v}) :
-    (coordinateRingFunctor R).obj G = coordinateRing R G :=
-  (rfl)
-
-/-- The morphism part of `coordinateRingFunctor` is the group-algebra bialgebra map. -/
-@[simp]
-theorem coordinateRingFunctor_map {G H : FGCommGrpCat.{v}} (φ : G ⟶ H) :
-    (coordinateRingFunctor R).map φ =
-      eqToHom (coordinateRingFunctor_obj R G) ≫ coordinateMap R φ ≫
-        eqToHom (coordinateRingFunctor_obj R H).symm :=
-  (rfl)
 
 end DiagonalizableGroup
 

--- a/TauCeti/Algebra/AlgebraicGroup/DiagonalizableGroup/FiniteType.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/DiagonalizableGroup/FiniteType.lean
@@ -150,10 +150,9 @@ theorem coordinateMap_toBialgHom {G H : FGCommGrpCat.{v}} (φ : G ⟶ H) :
 /-- On a group-algebra basis element, `coordinateMap φ` applies `φ` to its index. -/
 @[simp]
 theorem coordinateMap_single {G H : FGCommGrpCat.{v}} (φ : G ⟶ H) (g : G) (r : R) :
-    FiniteTypeCommHopfAlgCat.toBialgHom (coordinateMap R φ)
+    MonoidAlgebra.mapDomainBialgHom R (FGCommGrpCat.toMonoidHom φ)
         (MonoidAlgebra.single g r) =
       MonoidAlgebra.single (FGCommGrpCat.toMonoidHom φ g) r := by
-  rw [coordinateMap_toBialgHom]
   simp [MonoidAlgebra.mapDomainBialgHom, MonoidAlgebra.mapDomainAlgHom_apply]
 
 /-- The coordinate-ring construction for finite-type diagonalizable groups.

--- a/TauCeti/Algebra/AlgebraicGroup/DiagonalizableGroup/FiniteType.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/DiagonalizableGroup/FiniteType.lean
@@ -4,10 +4,10 @@ Released under Apache 2.0 license as described in the file LICENSE.
 -/
 module
 
-public import Mathlib.GroupTheory.Finiteness
 public import Mathlib.RingTheory.FiniteType
 public import TauCeti.Algebra.AlgebraicGroup.DiagonalizableGroup.Functoriality
 public import TauCeti.Algebra.AlgebraicGroup.FiniteType.CommHopfAlgCat
+public import TauCeti.Algebra.Category.CommGrpCat.FiniteGeneration
 
 /-!
 # Finite-type diagonalizable groups
@@ -54,74 +54,6 @@ namespace TauCeti
 
 universe u v
 
-/-- The object property of being a finitely generated commutative group. -/
-@[expose] def fgCommGrpProperty : ObjectProperty CommGrpCat.{v} :=
-  fun G => Group.FG G
-
-/-- Membership in the finitely generated commutative-group object property. -/
-@[simp]
-theorem fgCommGrpProperty_iff (G : CommGrpCat.{v}) :
-    fgCommGrpProperty G ↔ Group.FG G :=
-  Iff.rfl
-
-/-- The category of finitely generated commutative groups.
-
-This is the source of the coordinate-ring functor for finite-type diagonalizable groups. -/
-abbrev FGCommGrpCat :=
-  fgCommGrpProperty.FullSubcategory
-
-namespace FGCommGrpCat
-
-/-- The underlying type of a finitely generated commutative group. -/
-@[expose, reducible]
-def carrier (G : FGCommGrpCat.{v}) : Type v :=
-  G.obj
-
-instance : CoeSort FGCommGrpCat.{v} (Type v) :=
-  ⟨carrier⟩
-
-attribute [coe] carrier
-
-instance (G : FGCommGrpCat.{v}) : CommGroup G :=
-  inferInstanceAs (CommGroup G.obj)
-
-/-- The underlying group of an object of `FGCommGrpCat` is finitely generated. -/
-instance (G : FGCommGrpCat.{v}) : Group.FG G :=
-  G.property
-
-/-- Construct an object of `FGCommGrpCat` from a finitely generated commutative group. -/
-abbrev of (G : Type v) [CommGroup G] [Group.FG G] : FGCommGrpCat.{v} :=
-  ⟨CommGrpCat.of G, inferInstanceAs (Group.FG G)⟩
-
-/-- Lift a group homomorphism between finitely generated commutative groups to
-`FGCommGrpCat`. -/
-abbrev ofHom {G H : Type v} [CommGroup G] [Group.FG G] [CommGroup H] [Group.FG H]
-    (φ : G →* H) : of G ⟶ of H :=
-  ObjectProperty.homMk (CommGrpCat.ofHom φ)
-
-/-- The group homomorphism underlying a morphism in `FGCommGrpCat`. -/
-abbrev toMonoidHom {G H : FGCommGrpCat.{v}} (φ : G ⟶ H) : G →* H :=
-  φ.hom.hom
-
-/-- Two morphisms in `FGCommGrpCat` are equal when their underlying group homomorphisms
-are equal. -/
-@[ext]
-theorem hom_ext {G H : FGCommGrpCat.{v}} {φ ψ : G ⟶ H}
-    (h : toMonoidHom φ = toMonoidHom ψ) : φ = ψ :=
-  ObjectProperty.hom_ext (P := fgCommGrpProperty) (CommGrpCat.hom_ext h)
-
-@[simp]
-theorem toMonoidHom_id {G : FGCommGrpCat.{v}} :
-    toMonoidHom (𝟙 G) = MonoidHom.id G :=
-  rfl
-
-@[simp]
-theorem toMonoidHom_comp {G H K : FGCommGrpCat.{v}} (φ : G ⟶ H) (ψ : H ⟶ K) :
-    toMonoidHom (φ ≫ ψ) = (toMonoidHom ψ).comp (toMonoidHom φ) :=
-  rfl
-
-end FGCommGrpCat
-
 namespace DiagonalizableGroup
 
 variable (R : Type u) [CommRing R]
@@ -147,19 +79,11 @@ theorem coordinateMap_toBialgHom {G H : FGCommGrpCat.{v}} (φ : G ⟶ H) :
       MonoidAlgebra.mapDomainBialgHom R (FGCommGrpCat.toMonoidHom φ) :=
   rfl
 
-/-- On a group-algebra basis element, `coordinateMap φ` applies `φ` to its index. -/
-@[simp]
-theorem coordinateMap_single {G H : FGCommGrpCat.{v}} (φ : G ⟶ H) (g : G) (r : R) :
-    MonoidAlgebra.mapDomainBialgHom R (FGCommGrpCat.toMonoidHom φ)
-        (MonoidAlgebra.single g r) =
-      MonoidAlgebra.single (FGCommGrpCat.toMonoidHom φ g) r := by
-  simp [MonoidAlgebra.mapDomainBialgHom, MonoidAlgebra.mapDomainAlgHom_apply]
-
 /-- The coordinate-ring construction for finite-type diagonalizable groups.
 
 It is covariant on coordinate Hopf algebras. After applying the contravariant spectrum
 functor, it becomes the usual contravariant assignment `G ↦ D(G)`. -/
-@[expose] noncomputable def coordinateRingFunctor :
+noncomputable def coordinateRingFunctor :
     FGCommGrpCat.{v} ⥤ FiniteTypeCommHopfAlgCat.{u, max u v} R where
   obj := coordinateRing R
   map := coordinateMap R
@@ -179,13 +103,15 @@ functor, it becomes the usual contravariant assignment `G ↦ D(G)`. -/
 @[simp]
 theorem coordinateRingFunctor_obj (G : FGCommGrpCat.{v}) :
     (coordinateRingFunctor R).obj G = coordinateRing R G :=
-  rfl
+  (rfl)
 
 /-- The morphism part of `coordinateRingFunctor` is the group-algebra bialgebra map. -/
 @[simp]
 theorem coordinateRingFunctor_map {G H : FGCommGrpCat.{v}} (φ : G ⟶ H) :
-    (coordinateRingFunctor R).map φ = coordinateMap R φ :=
-  rfl
+    (coordinateRingFunctor R).map φ =
+      eqToHom (coordinateRingFunctor_obj R G) ≫ coordinateMap R φ ≫
+        eqToHom (coordinateRingFunctor_obj R H).symm :=
+  (rfl)
 
 end DiagonalizableGroup
 

--- a/TauCeti/Algebra/AlgebraicGroup/DiagonalizableGroup/FiniteType.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/DiagonalizableGroup/FiniteType.lean
@@ -88,6 +88,7 @@ never see this form. -/
 theorem coordinateMap_single {G H : FGCommGrpCat.{v}} (φ : G ⟶ H) (g : G) (r : R) :
     FiniteTypeCommHopfAlgCat.toBialgHom (coordinateMap R φ) (MonoidAlgebra.single g r) =
       MonoidAlgebra.single (FGCommGrpCat.toMonoidHom φ g) r := by
+  rw [toBialgHom_coordinateMap]
   exact MonoidAlgebra.mapDomain_single
 
 /-- The coordinate-ring construction for finite-type diagonalizable groups.

--- a/TauCeti/Algebra/AlgebraicGroup/DiagonalizableGroup/FiniteType.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/DiagonalizableGroup/FiniteType.lean
@@ -26,7 +26,8 @@ characters.
 This advances the reductive-groups roadmap Layer 4 target constructing the anti-equivalence
 between finitely generated abelian groups and diagonalizable groups. It supplies the
 finite-type source and coordinate-algebra functor needed before essential surjectivity and
-full faithfulness can be formulated.
+full faithfulness can be formulated; it does not construct the scheme-side functor or depend
+on the general Hopf-algebra/affine-group-scheme anti-equivalence.
 
 ## Main declarations
 

--- a/TauCeti/Algebra/Category/CommGrpCat/FiniteGeneration.lean
+++ b/TauCeti/Algebra/Category/CommGrpCat/FiniteGeneration.lean
@@ -15,6 +15,7 @@ This file packages finitely generated commutative groups as a full subcategory o
 
 ## Main declarations
 
+* `TauCeti.CommGrpCat.isFG`: the object property of being finitely generated.
 * `TauCeti.FGCommGrpCat`: the category of finitely generated commutative groups.
 -/
 
@@ -26,19 +27,23 @@ namespace TauCeti
 
 universe v
 
+namespace CommGrpCat
+
 /-- The object property of being a finitely generated commutative group. -/
-def fgCommGrpProperty : ObjectProperty CommGrpCat.{v} :=
+def isFG : ObjectProperty CommGrpCat.{v} :=
   fun G => Group.FG G
 
 /-- Membership in the finitely generated commutative-group object property. -/
 @[simp]
-theorem fgCommGrpProperty_iff (G : CommGrpCat.{v}) :
-    fgCommGrpProperty G ↔ Group.FG G :=
+theorem isFG_iff (G : CommGrpCat.{v}) :
+    isFG G ↔ Group.FG G :=
   Iff.rfl
+
+end CommGrpCat
 
 /-- The category of finitely generated commutative groups. -/
 abbrev FGCommGrpCat :=
-  fgCommGrpProperty.FullSubcategory
+  CommGrpCat.isFG.FullSubcategory
 
 namespace FGCommGrpCat
 
@@ -64,7 +69,7 @@ instance (G : FGCommGrpCat.{v}) : Group.FG G :=
 
 /-- Construct an object of `FGCommGrpCat` from a finitely generated commutative group. -/
 abbrev of (G : Type v) [CommGroup G] [Group.FG G] : FGCommGrpCat.{v} :=
-  ⟨CommGrpCat.of G, (fgCommGrpProperty_iff _).2 inferInstance⟩
+  ⟨CommGrpCat.of G, (CommGrpCat.isFG_iff _).2 inferInstance⟩
 
 /-- Lift a group homomorphism between finitely generated commutative groups to
 `FGCommGrpCat`. -/
@@ -92,7 +97,7 @@ are equal. -/
 @[ext]
 theorem hom_ext {G H : FGCommGrpCat.{v}} {φ ψ : G ⟶ H}
     (h : toMonoidHom φ = toMonoidHom ψ) : φ = ψ :=
-  ObjectProperty.hom_ext (P := fgCommGrpProperty) (CommGrpCat.hom_ext h)
+  ObjectProperty.hom_ext (P := CommGrpCat.isFG) (CommGrpCat.hom_ext h)
 
 @[simp]
 theorem toMonoidHom_id {G : FGCommGrpCat.{v}} :

--- a/TauCeti/Algebra/Category/CommGrpCat/FiniteGeneration.lean
+++ b/TauCeti/Algebra/Category/CommGrpCat/FiniteGeneration.lean
@@ -27,7 +27,7 @@ namespace TauCeti
 universe v
 
 /-- The object property of being a finitely generated commutative group. -/
-@[expose] def fgCommGrpProperty : ObjectProperty CommGrpCat.{v} :=
+def fgCommGrpProperty : ObjectProperty CommGrpCat.{v} :=
   fun G => Group.FG G
 
 /-- Membership in the finitely generated commutative-group object property. -/
@@ -47,11 +47,14 @@ namespace FGCommGrpCat
 def carrier (G : FGCommGrpCat.{v}) : Type v :=
   G.obj
 
+/-- Objects of `FGCommGrpCat` coerce to their underlying type. -/
 instance : CoeSort FGCommGrpCat.{v} (Type v) :=
   ⟨carrier⟩
 
 attribute [coe] carrier
 
+/-- An object of `FGCommGrpCat` inherits the commutative-group structure of its
+underlying group. -/
 instance (G : FGCommGrpCat.{v}) : CommGroup G :=
   inferInstanceAs (CommGroup G.obj)
 
@@ -61,7 +64,7 @@ instance (G : FGCommGrpCat.{v}) : Group.FG G :=
 
 /-- Construct an object of `FGCommGrpCat` from a finitely generated commutative group. -/
 abbrev of (G : Type v) [CommGroup G] [Group.FG G] : FGCommGrpCat.{v} :=
-  ⟨CommGrpCat.of G, inferInstanceAs (Group.FG G)⟩
+  ⟨CommGrpCat.of G, (fgCommGrpProperty_iff _).2 inferInstance⟩
 
 /-- Lift a group homomorphism between finitely generated commutative groups to
 `FGCommGrpCat`. -/
@@ -72,6 +75,17 @@ abbrev ofHom {G H : Type v} [CommGroup G] [Group.FG G] [CommGroup H] [Group.FG H
 /-- The group homomorphism underlying a morphism in `FGCommGrpCat`. -/
 abbrev toMonoidHom {G H : FGCommGrpCat.{v}} (φ : G ⟶ H) : G →* H :=
   φ.hom.hom
+
+@[simp]
+theorem ofHom_toMonoidHom {G H : FGCommGrpCat.{v}} (φ : G ⟶ H) :
+    ofHom (toMonoidHom φ) = φ :=
+  rfl
+
+@[simp]
+theorem toMonoidHom_ofHom {G H : Type v} [CommGroup G] [Group.FG G]
+    [CommGroup H] [Group.FG H] (φ : G →* H) :
+    toMonoidHom (ofHom φ) = φ :=
+  rfl
 
 /-- Two morphisms in `FGCommGrpCat` are equal when their underlying group homomorphisms
 are equal. -/

--- a/TauCeti/Algebra/Category/CommGrpCat/FiniteGeneration.lean
+++ b/TauCeti/Algebra/Category/CommGrpCat/FiniteGeneration.lean
@@ -1,0 +1,95 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+module
+
+public import Mathlib.Algebra.Category.Grp.Basic
+public import Mathlib.GroupTheory.Finiteness
+
+/-!
+# Finitely generated commutative groups
+
+This file packages finitely generated commutative groups as a full subcategory of
+`CommGrpCat`.
+
+## Main declarations
+
+* `TauCeti.FGCommGrpCat`: the category of finitely generated commutative groups.
+-/
+
+public section
+
+open CategoryTheory
+
+namespace TauCeti
+
+universe v
+
+/-- The object property of being a finitely generated commutative group. -/
+@[expose] def fgCommGrpProperty : ObjectProperty CommGrpCat.{v} :=
+  fun G => Group.FG G
+
+/-- Membership in the finitely generated commutative-group object property. -/
+@[simp]
+theorem fgCommGrpProperty_iff (G : CommGrpCat.{v}) :
+    fgCommGrpProperty G ↔ Group.FG G :=
+  Iff.rfl
+
+/-- The category of finitely generated commutative groups. -/
+abbrev FGCommGrpCat :=
+  fgCommGrpProperty.FullSubcategory
+
+namespace FGCommGrpCat
+
+/-- The underlying type of a finitely generated commutative group. -/
+@[expose, reducible]
+def carrier (G : FGCommGrpCat.{v}) : Type v :=
+  G.obj
+
+instance : CoeSort FGCommGrpCat.{v} (Type v) :=
+  ⟨carrier⟩
+
+attribute [coe] carrier
+
+instance (G : FGCommGrpCat.{v}) : CommGroup G :=
+  inferInstanceAs (CommGroup G.obj)
+
+/-- The underlying group of an object of `FGCommGrpCat` is finitely generated. -/
+instance (G : FGCommGrpCat.{v}) : Group.FG G :=
+  G.property
+
+/-- Construct an object of `FGCommGrpCat` from a finitely generated commutative group. -/
+abbrev of (G : Type v) [CommGroup G] [Group.FG G] : FGCommGrpCat.{v} :=
+  ⟨CommGrpCat.of G, inferInstanceAs (Group.FG G)⟩
+
+/-- Lift a group homomorphism between finitely generated commutative groups to
+`FGCommGrpCat`. -/
+abbrev ofHom {G H : Type v} [CommGroup G] [Group.FG G] [CommGroup H] [Group.FG H]
+    (φ : G →* H) : of G ⟶ of H :=
+  ObjectProperty.homMk (CommGrpCat.ofHom φ)
+
+/-- The group homomorphism underlying a morphism in `FGCommGrpCat`. -/
+abbrev toMonoidHom {G H : FGCommGrpCat.{v}} (φ : G ⟶ H) : G →* H :=
+  φ.hom.hom
+
+/-- Two morphisms in `FGCommGrpCat` are equal when their underlying group homomorphisms
+are equal. -/
+@[ext]
+theorem hom_ext {G H : FGCommGrpCat.{v}} {φ ψ : G ⟶ H}
+    (h : toMonoidHom φ = toMonoidHom ψ) : φ = ψ :=
+  ObjectProperty.hom_ext (P := fgCommGrpProperty) (CommGrpCat.hom_ext h)
+
+@[simp]
+theorem toMonoidHom_id {G : FGCommGrpCat.{v}} :
+    toMonoidHom (𝟙 G) = MonoidHom.id G :=
+  rfl
+
+@[simp]
+theorem toMonoidHom_comp {G H K : FGCommGrpCat.{v}} (φ : G ⟶ H) (ψ : H ⟶ K) :
+    toMonoidHom (φ ≫ ψ) = (toMonoidHom ψ).comp (toMonoidHom φ) :=
+  rfl
+
+end FGCommGrpCat
+
+end TauCeti


### PR DESCRIPTION
This PR packages finitely generated commutative groups as `FGCommGrpCat` and constructs the group-algebra coordinate-ring functor into finite-type commutative Hopf algebras. It records the action on morphisms and group-algebra basis elements, so the algebraic side of `G ↦ D(G)` is available without unfolding categorical wrappers. This advances `TauCetiRoadmap/ReductiveGroups/README.md`, Layer 4, specifically “the anti-equivalence `M ↦ D(M) = Spec k[M]` between finitely generated abelian groups and diagonalizable groups.” It is the lowest-hanging uncovered step because the functor of points and its contravariant character action already exist, while the missing finite-type categorical restriction is immediate from the pinned Mathlib infrastructure and is required before the stated anti-equivalence can be formulated at the roadmap’s intended generality.

Reuse Mathlib’s `Group.FG`, `MonoidAlgebra.finiteType_of_fg`, `MonoidAlgebra.mapDomainBialgHom`, and its identity/composition laws; vendor no Mathlib infrastructure. Follow Waterhouse, *Introduction to Affine Group Schemes*, Chapter 2, for the diagonalizable-group correspondence.

Add `TauCeti/Algebra/AlgebraicGroup/DiagonalizableGroup/FiniteType.lean` (193 lines). `lake exe cache get` reports `No files to download` and `Already decompressed 8639 file(s)`. `lake build` reports `Build completed successfully (5384 jobs).` `lake exe axioms` reports `axioms: audited 11798 TauCeti declaration(s); all within the allowlist [propext, Classical.choice, Quot.sound].`

<!--tauceti-target:v1 {"focus":"ReductiveGroups","id":"diagonalizable-group-finite-type-finitely-generated-character-group"}-->

🤖 Prepared with Codex
