### PR TITLE
feat(MeasureTheory): measurability of the countable product in the measure argument

### DIFF
--- a/TauCeti/MeasureTheory/Measure/ProductKernel.lean
+++ b/TauCeti/MeasureTheory/Measure/ProductKernel.lean
@@ -5,6 +5,8 @@ Released under Apache 2.0 license as described in the file LICENSE.
 module
 
 public import Mathlib.MeasureTheory.Measure.FiniteMeasurePi
+-- Public: `Measure.infinitePi` appears in the infinite-product statement.
+public import Mathlib.Probability.ProductMeasure
 
 /-!
 # Finite product probability-measure kernels
@@ -141,6 +143,32 @@ theorem measurable_dirac_prod_probabilityMeasure_pi_const_toMeasure {α : Type*}
   have hpi : Measurable fun ω => ProbabilityMeasure.pi fun _ : Fin m => ν ω :=
     measurable_probabilityMeasure_pi.comp (measurable_pi_lambda _ fun _ => hν)
   exact ProbabilityMeasure.measurable_fun_prod.comp (hdirac.prodMk hpi)
+
+/-- **Infinite-product measurability.** The countable product `p ↦ p^{⊗ℕ}` is a measurable map
+`ProbabilityMeasure α → Measure (ℕ → α)`.
+
+This is the countable-index companion of `measurable_probabilityMeasure_pi_const_toMeasure`. It is
+what lets `Measure.infinitePi` appear under a `Measure.bind`, i.e. lets a mixture of infinite
+product laws be formed — the shape the de Finetti mixture representation takes. Mathlib supplies
+`Measure.infinitePi` and its projective-limit API but not its measurability in the measure
+argument. -/
+@[fun_prop]
+theorem measurable_infinitePi_const {α : Type*} [MeasurableSpace α] :
+    Measurable fun p : ProbabilityMeasure α =>
+      Measure.infinitePi (fun _ : ℕ => (p : Measure α)) := by
+  refine Measurable.measure_of_isPiSystem_of_isProbabilityMeasure
+    (S := measurableCylinders (fun _ : ℕ => α)) generateFrom_measurableCylinders.symm
+    isSetRing_measurableCylinders.isSetSemiring.isPiSystem ?_
+  intro t ht
+  obtain ⟨s, S, hS, rfl⟩ := (mem_measurableCylinders t).mp ht
+  have hval : ∀ p : ProbabilityMeasure α,
+      Measure.infinitePi (fun _ : ℕ => (p : Measure α)) (cylinder s S)
+        = Measure.pi (fun _ : s => (p : Measure α)) S :=
+    fun p => Measure.infinitePi_cylinder _ hS
+  simp_rw [hval]
+  exact (Measure.measurable_coe hS).comp
+    (measurable_probabilityMeasure_pi_toMeasure (fun _ : s => (id : ProbabilityMeasure α → _))
+      fun _ => measurable_id)
 
 /-- **Bind-evaluation.** Evaluating the mixture
 `μ.bind fun ω => (ProbabilityMeasure.pi fun i => ν i ω).toMeasure` on a measurable set `s` gives

--- a/TauCeti/MeasureTheory/Measure/ProductKernel.lean
+++ b/TauCeti/MeasureTheory/Measure/ProductKernel.lean
@@ -32,10 +32,12 @@ Measurability:
   `ω ↦ δ_{ν ω} ⊗ (ν ω)^{⊗ Fin m}`, pairing the block kernel with a Dirac mass at the mixing
   measure. This is the joint-space input a conditional (joint-law) reading of the mixture
   identity needs, as opposed to the block kernel alone.
-* `measurable_infinitePi` — the **countable** product `p ↦ ⊗ᵢ p i` is measurable in the measure
-  argument, with `measurable_infinitePi_const` the `ℕ`-constant power `p ↦ p^{⊗ℕ}`. Mathlib
-  supplies `Measure.infinitePi` and its projective-limit API but not this measurability, without
-  which an infinite product cannot appear under a `Measure.bind` at all.
+* `measurable_infinitePi` — the product `p ↦ ⊗ᵢ p i` over an **arbitrary** index type, of a
+  dependent family of probability measures, is measurable in the measure argument;
+  `measurable_infinitePi_const` is the `ℕ`-constant-power specialization `p ↦ p^{⊗ℕ}`. Mathlib
+  supplies `Measure.infinitePi` and its projective-limit API but not this measurability, which is
+  what a mixture of such products needs for `Measure.bind_apply` and the expected evaluation of
+  the mixture as an integral.
 
 Bind-evaluation of the mixture `μ.bind fun ω => (ProbabilityMeasure.pi fun i => ν i ω).toMeasure`:
 * `bind_probabilityMeasure_pi_apply` — evaluation on a measurable set as the integral of the product
@@ -148,14 +150,15 @@ theorem measurable_dirac_prod_probabilityMeasure_pi_const_toMeasure {α : Type*}
     measurable_probabilityMeasure_pi.comp (measurable_pi_lambda _ fun _ => hν)
   exact ProbabilityMeasure.measurable_fun_prod.comp (hdirac.prodMk hpi)
 
-/-- **Infinite-product measurability.** The countable product `p ↦ p^{⊗ℕ}` is a measurable map
-`ProbabilityMeasure α → Measure (ℕ → α)`.
+/-- **Product measurability in the measure argument.** For an arbitrary index type and a dependent
+family of measurable spaces, `p ↦ ⊗ᵢ p i` is a measurable map
+`(∀ i, ProbabilityMeasure (β i)) → Measure (∀ i, β i)`.
 
-This is the countable-index companion of `measurable_probabilityMeasure_pi_const_toMeasure`. It is
-what lets `Measure.infinitePi` appear under a `Measure.bind`, i.e. lets a mixture of infinite
-product laws be formed — the shape the de Finetti mixture representation takes. Mathlib supplies
-`Measure.infinitePi` and its projective-limit API but not its measurability in the measure
-argument. -/
+This is the arbitrary-index companion of `measurable_probabilityMeasure_pi_toMeasure`, which covers
+the finite case through `ProbabilityMeasure.pi`. Mathlib supplies `Measure.infinitePi` and its
+projective-limit API but not this measurability, which is what a mixture of such products needs for
+`Measure.bind_apply` and for evaluating the mixture as an integral — the shape the de Finetti
+mixture representation takes. -/
 @[fun_prop]
 theorem measurable_infinitePi {ι' : Type*} {β : ι' → Type*} [∀ i, MeasurableSpace (β i)] :
     Measurable fun p : ∀ i, ProbabilityMeasure (β i) =>
@@ -170,10 +173,11 @@ theorem measurable_infinitePi {ι' : Type*} {β : ι' → Type*} [∀ i, Measura
         = Measure.pi (fun i : s => (p i : Measure (β i))) S :=
     fun p => Measure.infinitePi_cylinder _ hS
   simp_rw [hval]
-  exact (Measure.measurable_coe hS).comp
-    (measurable_probabilityMeasure_pi_toMeasure
-      (fun i : s => fun p : ∀ j, ProbabilityMeasure (β j) => p i.1)
-      fun i => measurable_pi_apply i.1)
+  simpa only [ProbabilityMeasure.toMeasure_pi, Function.comp_def] using
+    (Measure.measurable_coe hS).comp
+      (measurable_probabilityMeasure_pi_toMeasure
+        (fun i : s => fun p : ∀ j, ProbabilityMeasure (β j) => p i.1)
+        fun i => measurable_pi_apply i.1)
 
 /-- Constant-coordinate `ℕ` specialization of `measurable_infinitePi`: the countable power
 `p ↦ p^{⊗ℕ}` is measurable. -/

--- a/TauCeti/MeasureTheory/Measure/ProductKernel.lean
+++ b/TauCeti/MeasureTheory/Measure/ProductKernel.lean
@@ -9,11 +9,11 @@ public import Mathlib.MeasureTheory.Measure.FiniteMeasurePi
 public import Mathlib.Probability.ProductMeasure
 
 /-!
-# Finite product probability-measure kernels
+# Product probability-measure kernels
 
-This file provides the basic theory of the finite product of probability measures over a finite
-index type, phrased directly over Mathlib's `ProbabilityMeasure.pi`: measurability of the product
-kernel, and `Measure.bind`-evaluation of the mixture it induces.
+This file provides the basic theory of products of probability measures, phrased directly over
+Mathlib's `ProbabilityMeasure.pi` and `Measure.infinitePi`: measurability of the product kernel —
+finite and countable — and `Measure.bind`-evaluation of the mixture the finite product induces.
 
 Measurability:
 * `measurable_probabilityMeasure_pi` — the product combinator
@@ -32,6 +32,10 @@ Measurability:
   `ω ↦ δ_{ν ω} ⊗ (ν ω)^{⊗ Fin m}`, pairing the block kernel with a Dirac mass at the mixing
   measure. This is the joint-space input a conditional (joint-law) reading of the mixture
   identity needs, as opposed to the block kernel alone.
+* `measurable_infinitePi` — the **countable** product `p ↦ ⊗ᵢ p i` is measurable in the measure
+  argument, with `measurable_infinitePi_const` the `ℕ`-constant power `p ↦ p^{⊗ℕ}`. Mathlib
+  supplies `Measure.infinitePi` and its projective-limit API but not this measurability, without
+  which an infinite product cannot appear under a `Measure.bind` at all.
 
 Bind-evaluation of the mixture `μ.bind fun ω => (ProbabilityMeasure.pi fun i => ν i ω).toMeasure`:
 * `bind_probabilityMeasure_pi_apply` — evaluation on a measurable set as the integral of the product
@@ -153,22 +157,31 @@ product laws be formed — the shape the de Finetti mixture representation takes
 `Measure.infinitePi` and its projective-limit API but not its measurability in the measure
 argument. -/
 @[fun_prop]
-theorem measurable_infinitePi_const {α : Type*} [MeasurableSpace α] :
-    Measurable fun p : ProbabilityMeasure α =>
-      Measure.infinitePi (fun _ : ℕ => (p : Measure α)) := by
+theorem measurable_infinitePi {ι' : Type*} {β : ι' → Type*} [∀ i, MeasurableSpace (β i)] :
+    Measurable fun p : ∀ i, ProbabilityMeasure (β i) =>
+      Measure.infinitePi fun i => (p i : Measure (β i)) := by
   refine Measurable.measure_of_isPiSystem_of_isProbabilityMeasure
-    (S := measurableCylinders (fun _ : ℕ => α)) generateFrom_measurableCylinders.symm
+    (S := measurableCylinders β) generateFrom_measurableCylinders.symm
     isSetRing_measurableCylinders.isSetSemiring.isPiSystem ?_
   intro t ht
   obtain ⟨s, S, hS, rfl⟩ := (mem_measurableCylinders t).mp ht
-  have hval : ∀ p : ProbabilityMeasure α,
-      Measure.infinitePi (fun _ : ℕ => (p : Measure α)) (cylinder s S)
-        = Measure.pi (fun _ : s => (p : Measure α)) S :=
+  have hval : ∀ p : ∀ i, ProbabilityMeasure (β i),
+      Measure.infinitePi (fun i => (p i : Measure (β i))) (cylinder s S)
+        = Measure.pi (fun i : s => (p i : Measure (β i))) S :=
     fun p => Measure.infinitePi_cylinder _ hS
   simp_rw [hval]
   exact (Measure.measurable_coe hS).comp
-    (measurable_probabilityMeasure_pi_toMeasure (fun _ : s => (id : ProbabilityMeasure α → _))
-      fun _ => measurable_id)
+    (measurable_probabilityMeasure_pi_toMeasure
+      (fun i : s => fun p : ∀ j, ProbabilityMeasure (β j) => p i.1)
+      fun i => measurable_pi_apply i.1)
+
+/-- Constant-coordinate `ℕ` specialization of `measurable_infinitePi`: the countable power
+`p ↦ p^{⊗ℕ}` is measurable. -/
+@[fun_prop]
+theorem measurable_infinitePi_const {α : Type*} [MeasurableSpace α] :
+    Measurable fun p : ProbabilityMeasure α =>
+      Measure.infinitePi (fun _ : ℕ => (p : Measure α)) :=
+  measurable_infinitePi.comp (measurable_pi_lambda _ fun _ => measurable_id)
 
 /-- **Bind-evaluation.** Evaluating the mixture
 `μ.bind fun ω => (ProbabilityMeasure.pi fun i => ν i ω).toMeasure` on a measurable set `s` gives


### PR DESCRIPTION
**Roadmap:** `TauCetiRoadmap/Exchangeability/README.md`, **Layer 6** — a prerequisite for the mixture-of-product-measures form

> the mixture-of-product-measures form: `pathLaw X = ∫ p^{⊗ℕ} dπ(p)` with `π` the unique law of `ν` on `P(α)`

Prerequisite work for [TauCetiRoadmap#89](https://github.com/TauCetiProject/TauCetiRoadmap/issues/89), which claims that target; this PR does **not** close it.

## What

Two lemmas in `TauCeti/MeasureTheory/Measure/ProductKernel.lean`:

```lean
@[fun_prop]
theorem measurable_infinitePi {ι' : Type*} {β : ι' → Type*} [∀ i, MeasurableSpace (β i)] :
    Measurable fun p : ∀ i, ProbabilityMeasure (β i) =>
      Measure.infinitePi fun i => (p i : Measure (β i))

@[fun_prop]
theorem measurable_infinitePi_const {α : Type*} [MeasurableSpace α] :
    Measurable fun p : ProbabilityMeasure α => Measure.infinitePi (fun _ : ℕ => (p : Measure α))
```

## Why

Mathlib supplies `Measure.infinitePi` and its projective-limit API (`isProjectiveLimit_infinitePi`, `infinitePi_map_restrict`, `eq_infinitePi`, `infinitePi_pi`, `infinitePi_cylinder`) but **not** its measurability in the measure argument. Without that, an infinite product cannot appear under a `Measure.bind` at all — so a mixture of infinite product laws cannot even be *stated*, which is exactly the shape the de Finetti mixture representation takes.

This is the countable-index companion of the file's existing `measurable_probabilityMeasure_pi_const_toMeasure`, and stands in the same relation to the mixture representation as #1193's joint-kernel measurability did to the conditional predicate in #1211.

## Proof

The same π-system argument the file's finite-product lemmas use, run over `measurableCylinders` rather than boxes: `Measure.infinitePi_cylinder` reduces each cylinder to a finite `Measure.pi`, which `measurable_probabilityMeasure_pi_toMeasure` already handles. No new machinery.

Two notes on the shape:

- The binders are `ι'`/`β` rather than `ι`/`α` because the file's section variables bind `ι` with `[Fintype ι]` — precisely the instance an infinite product must not inherit. Shadowing would compile but reads as a trap.
- `Mathlib.Probability.ProductMeasure` is a **public** import, since `Measure.infinitePi` appears in the statements.

The module heading and overview are updated accordingly: the file is no longer only about finite products.

## Scope

`TauCeti/` only, one file. No existing declaration changed apart from the module docstring.

## Verification

- `lake build` — full library: **5394 jobs, 0 errors, 0 warnings.** Style linters pass.
- `#print axioms` on both new theorems: `[propext, Classical.choice, Quot.sound]`.

Co-Authored-By: Claude Code <noreply@github.com>