### PR TITLE
feat: compute the planar Newtonian kernel gradient

### DIFF
--- a/TauCeti/Analysis/PDE/FundamentalSolution/Flux.lean
+++ b/TauCeti/Analysis/PDE/FundamentalSolution/Flux.lean
@@ -4,8 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 -/
 module
 
-public import TauCeti.Analysis.PDE.FundamentalSolution.Planar
-public import Mathlib.Analysis.Calculus.FDeriv.Norm
+public import TauCeti.Analysis.PDE.FundamentalSolution.Gradient
 public import Mathlib.Analysis.SpecialFunctions.Complex.CircleMap
 public import Mathlib.MeasureTheory.Integral.IntervalIntegral.Basic
 
@@ -37,20 +36,8 @@ open scoped Interval
 @[simp]
 theorem fderiv_planarNewtonianKernel_self {z : ℂ} (hz : z ≠ 0) :
     fderiv ℝ planarNewtonianKernel z z = -(2 * Real.pi)⁻¹ := by
-  have hnorm : DifferentiableAt ℝ (fun w : ℂ ↦ ‖w‖) z :=
-    (differentiableAt_fun_id : DifferentiableAt ℝ (fun w : ℂ ↦ w) z).norm ℂ hz
-  have hlog :
-      HasFDerivAt (fun w : ℂ ↦ Real.log ‖w‖)
-        ((‖z‖ : ℝ)⁻¹ • fderiv ℝ (fun w : ℂ ↦ ‖w‖) z) z :=
-    hnorm.hasFDerivAt.log (norm_ne_zero_iff.mpr hz)
-  have hkernel :
-      planarNewtonianKernel = fun w : ℂ ↦ -(2 * Real.pi)⁻¹ * Real.log ‖w‖ :=
-    funext planarNewtonianKernel_def
-  rw [hkernel]
-  rw [(hlog.const_mul (-(2 * Real.pi)⁻¹)).fderiv]
-  simp only [smul_apply, smul_eq_mul]
-  rw [DifferentiableAt.fderiv_norm_self hnorm]
-  rw [inv_mul_cancel₀ (norm_ne_zero_iff.mpr hz), mul_one]
+  rw [fderiv_planarNewtonianKernel_apply hz, real_inner_self_eq_norm_sq]
+  field_simp
 
 /-- The derivative of a translated planar Newtonian kernel in the radial direction from its pole
 is `-(2π)⁻¹`. -/

--- a/TauCeti/Analysis/PDE/FundamentalSolution/Gradient.lean
+++ b/TauCeti/Analysis/PDE/FundamentalSolution/Gradient.lean
@@ -72,7 +72,6 @@ theorem hasFDerivAt_planarNewtonianKernel {z : ℂ} (hz : z ≠ 0) :
   exact hlog.const_mul (-(2 * Real.pi)⁻¹ / 2)
 
 /-- The Fréchet derivative of the planar Newtonian kernel as a continuous linear functional. -/
-@[simp]
 theorem fderiv_planarNewtonianKernel {z : ℂ} (hz : z ≠ 0) :
     fderiv ℝ planarNewtonianKernel z =
       (-(2 * Real.pi)⁻¹ * (‖z‖ ^ 2)⁻¹) • innerSL ℝ z :=
@@ -80,7 +79,6 @@ theorem fderiv_planarNewtonianKernel {z : ℂ} (hz : z ≠ 0) :
 
 /-- The directional derivative of the planar Newtonian kernel is the radial inner-product
 covector scaled by `-(2π ‖z‖²)⁻¹`. -/
-@[simp]
 theorem fderiv_planarNewtonianKernel_apply {z : ℂ} (hz : z ≠ 0) (v : ℂ) :
     fderiv ℝ planarNewtonianKernel z v =
       (-(2 * Real.pi)⁻¹ * (‖z‖ ^ 2)⁻¹) * ⟪z, v⟫_ℝ := by
@@ -106,14 +104,12 @@ theorem hasFDerivAt_planarNewtonianKernel_sub {z a : ℂ} (hza : z ≠ a) :
   exact hasFDerivAt_planarNewtonianKernel (sub_ne_zero.mpr hza)
 
 /-- The Fréchet derivative of a planar Newtonian kernel with pole at `a`. -/
-@[simp]
 theorem fderiv_planarNewtonianKernel_sub {z a : ℂ} (hza : z ≠ a) :
     fderiv ℝ (fun w : ℂ ↦ planarNewtonianKernel (w - a)) z =
       (-(2 * Real.pi)⁻¹ * (‖z - a‖ ^ 2)⁻¹) • innerSL ℝ (z - a) :=
   (hasFDerivAt_planarNewtonianKernel_sub hza).fderiv
 
 /-- The directional derivative of a planar Newtonian kernel with pole at `a`. -/
-@[simp]
 theorem fderiv_planarNewtonianKernel_sub_apply {z a : ℂ} (hza : z ≠ a) (v : ℂ) :
     fderiv ℝ (fun w : ℂ ↦ planarNewtonianKernel (w - a)) z v =
       (-(2 * Real.pi)⁻¹ * (‖z - a‖ ^ 2)⁻¹) * ⟪z - a, v⟫_ℝ := by

--- a/TauCeti/Analysis/PDE/FundamentalSolution/Gradient.lean
+++ b/TauCeti/Analysis/PDE/FundamentalSolution/Gradient.lean
@@ -23,11 +23,15 @@ The calculation uses Mathlib's derivative of the squared norm and the Fréchet c
 real logarithm.  It complements `FundamentalSolution.Flux`, which computes only the derivative in
 the radial direction needed for the circle flux.
 
+The normalization and inverse-distance gradient formula follow Evans, *Partial Differential
+Equations*, Section 2.2.
+
 ## Main declarations
 
 * `TauCeti.hasFDerivAt_planarNewtonianKernel`: the full derivative at a nonzero point.
 * `TauCeti.fderiv_planarNewtonianKernel_apply`: its value in an arbitrary direction.
 * `TauCeti.norm_fderiv_planarNewtonianKernel`: its inverse-distance operator norm.
+* `TauCeti.hasFDerivAt_planarNewtonianKernel_sub`: the translated full derivative.
 * `TauCeti.fderiv_planarNewtonianKernel_sub_apply`: the corresponding translated formula.
 -/
 
@@ -68,6 +72,7 @@ theorem hasFDerivAt_planarNewtonianKernel {z : ℂ} (hz : z ≠ 0) :
   exact hlog.const_mul (-(2 * Real.pi)⁻¹ / 2)
 
 /-- The Fréchet derivative of the planar Newtonian kernel as a continuous linear functional. -/
+@[simp]
 theorem fderiv_planarNewtonianKernel {z : ℂ} (hz : z ≠ 0) :
     fderiv ℝ planarNewtonianKernel z =
       (-(2 * Real.pi)⁻¹ * (‖z‖ ^ 2)⁻¹) • innerSL ℝ z :=
@@ -75,6 +80,7 @@ theorem fderiv_planarNewtonianKernel {z : ℂ} (hz : z ≠ 0) :
 
 /-- The directional derivative of the planar Newtonian kernel is the radial inner-product
 covector scaled by `-(2π ‖z‖²)⁻¹`. -/
+@[simp]
 theorem fderiv_planarNewtonianKernel_apply {z : ℂ} (hz : z ≠ 0) (v : ℂ) :
     fderiv ℝ planarNewtonianKernel z v =
       (-(2 * Real.pi)⁻¹ * (‖z‖ ^ 2)⁻¹) * ⟪z, v⟫_ℝ := by
@@ -82,6 +88,7 @@ theorem fderiv_planarNewtonianKernel_apply {z : ℂ} (hz : z ≠ 0) (v : ℂ) :
   simp only [smul_apply, smul_eq_mul, innerSL_apply_apply]
 
 /-- The derivative of the planar Newtonian kernel has inverse-distance operator norm. -/
+@[simp]
 theorem norm_fderiv_planarNewtonianKernel {z : ℂ} (hz : z ≠ 0) :
     ‖fderiv ℝ planarNewtonianKernel z‖ = (2 * Real.pi * ‖z‖)⁻¹ := by
   rw [fderiv_planarNewtonianKernel hz, norm_smul, innerSL_apply_norm]
@@ -91,13 +98,22 @@ theorem norm_fderiv_planarNewtonianKernel {z : ℂ} (hz : z ≠ 0) :
     abs_of_pos hpi, abs_inv, abs_pow, abs_of_pos hn]
   field_simp
 
+/-- A planar Newtonian kernel with pole at `a` has the translated Fréchet derivative. -/
+theorem hasFDerivAt_planarNewtonianKernel_sub {z a : ℂ} (hza : z ≠ a) :
+    HasFDerivAt (fun w : ℂ ↦ planarNewtonianKernel (w - a))
+      ((-(2 * Real.pi)⁻¹ * (‖z - a‖ ^ 2)⁻¹) • innerSL ℝ (z - a)) z := by
+  rw [hasFDerivAt_comp_sub]
+  exact hasFDerivAt_planarNewtonianKernel (sub_ne_zero.mpr hza)
+
 /-- The Fréchet derivative of a planar Newtonian kernel with pole at `a`. -/
+@[simp]
 theorem fderiv_planarNewtonianKernel_sub {z a : ℂ} (hza : z ≠ a) :
     fderiv ℝ (fun w : ℂ ↦ planarNewtonianKernel (w - a)) z =
-      (-(2 * Real.pi)⁻¹ * (‖z - a‖ ^ 2)⁻¹) • innerSL ℝ (z - a) := by
-  rw [fderiv_comp_sub, fderiv_planarNewtonianKernel (sub_ne_zero.mpr hza)]
+      (-(2 * Real.pi)⁻¹ * (‖z - a‖ ^ 2)⁻¹) • innerSL ℝ (z - a) :=
+  (hasFDerivAt_planarNewtonianKernel_sub hza).fderiv
 
 /-- The directional derivative of a planar Newtonian kernel with pole at `a`. -/
+@[simp]
 theorem fderiv_planarNewtonianKernel_sub_apply {z a : ℂ} (hza : z ≠ a) (v : ℂ) :
     fderiv ℝ (fun w : ℂ ↦ planarNewtonianKernel (w - a)) z v =
       (-(2 * Real.pi)⁻¹ * (‖z - a‖ ^ 2)⁻¹) * ⟪z - a, v⟫_ℝ := by
@@ -105,15 +121,12 @@ theorem fderiv_planarNewtonianKernel_sub_apply {z a : ℂ} (hza : z ≠ a) (v : 
   simp only [smul_apply, smul_eq_mul, innerSL_apply_apply]
 
 /-- The derivative of a planar Newtonian kernel with pole at `a` has inverse-distance norm. -/
+@[simp]
 theorem norm_fderiv_planarNewtonianKernel_sub {z a : ℂ} (hza : z ≠ a) :
     ‖fderiv ℝ (fun w : ℂ ↦ planarNewtonianKernel (w - a)) z‖ =
       (2 * Real.pi * ‖z - a‖)⁻¹ := by
-  rw [fderiv_planarNewtonianKernel_sub hza, norm_smul, innerSL_apply_norm]
-  have hpi : 0 < Real.pi := Real.pi_pos
-  have hn : 0 < ‖z - a‖ := norm_pos_iff.mpr (sub_ne_zero.mpr hza)
-  rw [Real.norm_eq_abs, abs_mul, abs_neg, abs_inv, abs_mul, abs_of_pos (by positivity),
-    abs_of_pos hpi, abs_inv, abs_pow, abs_of_pos hn]
-  field_simp
+  rw [fderiv_comp_sub]
+  exact norm_fderiv_planarNewtonianKernel (sub_ne_zero.mpr hza)
 
 end TauCeti
 

--- a/TauCeti/Analysis/PDE/FundamentalSolution/Gradient.lean
+++ b/TauCeti/Analysis/PDE/FundamentalSolution/Gradient.lean
@@ -1,0 +1,120 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+module
+
+public import TauCeti.Analysis.PDE.FundamentalSolution.Planar
+public import Mathlib.Analysis.InnerProductSpace.Calculus
+
+/-!
+# Gradient of the planar Newtonian kernel
+
+This file computes the full Fréchet derivative of the planar Newtonian kernel away from its
+pole.  The result is the covector
+
+`-(2π ‖z‖²)⁻¹ ⟪z, ·⟫`,
+
+whose operator norm is `(2π ‖z‖)⁻¹`.  Translated versions give the corresponding formulas for a
+pole at an arbitrary point.  These inverse-distance estimates are the pointwise kernel input for
+forming and differentiating planar Newtonian potentials.
+
+The calculation uses Mathlib's derivative of the squared norm and the Fréchet chain rule for the
+real logarithm.  It complements `FundamentalSolution.Flux`, which computes only the derivative in
+the radial direction needed for the circle flux.
+
+## Main declarations
+
+* `TauCeti.hasFDerivAt_planarNewtonianKernel`: the full derivative at a nonzero point.
+* `TauCeti.fderiv_planarNewtonianKernel_apply`: its value in an arbitrary direction.
+* `TauCeti.norm_fderiv_planarNewtonianKernel`: its inverse-distance operator norm.
+* `TauCeti.fderiv_planarNewtonianKernel_sub_apply`: the corresponding translated formula.
+-/
+
+public section
+
+noncomputable section
+
+namespace TauCeti
+
+open InnerProductSpace
+
+/-- Away from the origin, the planar Newtonian kernel has derivative
+`-(2π)⁻¹ ‖z‖⁻² ⟪z, ·⟫`. -/
+theorem hasFDerivAt_planarNewtonianKernel {z : ℂ} (hz : z ≠ 0) :
+    HasFDerivAt planarNewtonianKernel
+      ((-(2 * Real.pi)⁻¹ * (‖z‖ ^ 2)⁻¹) • innerSL ℝ z) z := by
+  have hsq :
+      HasFDerivAt (fun w : ℂ ↦ ‖w‖ ^ 2) (2 • innerSL ℝ z) z := by
+    simpa only [id_eq, one_apply_eq_self, one_smul, ContinuousLinearMap.comp_id] using
+      (hasFDerivAt_id z).norm_sq
+  have hlog :
+      HasFDerivAt (fun w : ℂ ↦ Real.log (‖w‖ ^ 2))
+        ((‖z‖ ^ 2)⁻¹ • (2 • innerSL ℝ z)) z :=
+    hsq.log (pow_ne_zero 2 (norm_ne_zero_iff.mpr hz))
+  have heq :
+      planarNewtonianKernel =
+        fun w : ℂ ↦ (-(2 * Real.pi)⁻¹ / 2) * Real.log (‖w‖ ^ 2) := by
+    funext w
+    rw [planarNewtonianKernel_def, Real.log_pow]
+    ring
+  have hmap :
+      ((-(2 * Real.pi)⁻¹ / 2) • ((‖z‖ ^ 2)⁻¹ • (2 • innerSL ℝ z))) =
+        ((-(2 * Real.pi)⁻¹ * (‖z‖ ^ 2)⁻¹) • innerSL ℝ z) := by
+    ext v
+    simp only [smul_apply, innerSL_apply_apply]
+    ring
+  rw [heq, ← hmap]
+  exact hlog.const_mul (-(2 * Real.pi)⁻¹ / 2)
+
+/-- The Fréchet derivative of the planar Newtonian kernel as a continuous linear functional. -/
+theorem fderiv_planarNewtonianKernel {z : ℂ} (hz : z ≠ 0) :
+    fderiv ℝ planarNewtonianKernel z =
+      (-(2 * Real.pi)⁻¹ * (‖z‖ ^ 2)⁻¹) • innerSL ℝ z :=
+  (hasFDerivAt_planarNewtonianKernel hz).fderiv
+
+/-- The directional derivative of the planar Newtonian kernel is the radial inner-product
+covector scaled by `-(2π ‖z‖²)⁻¹`. -/
+theorem fderiv_planarNewtonianKernel_apply {z : ℂ} (hz : z ≠ 0) (v : ℂ) :
+    fderiv ℝ planarNewtonianKernel z v =
+      (-(2 * Real.pi)⁻¹ * (‖z‖ ^ 2)⁻¹) * ⟪z, v⟫_ℝ := by
+  rw [fderiv_planarNewtonianKernel hz]
+  simp only [smul_apply, smul_eq_mul, innerSL_apply_apply]
+
+/-- The derivative of the planar Newtonian kernel has inverse-distance operator norm. -/
+theorem norm_fderiv_planarNewtonianKernel {z : ℂ} (hz : z ≠ 0) :
+    ‖fderiv ℝ planarNewtonianKernel z‖ = (2 * Real.pi * ‖z‖)⁻¹ := by
+  rw [fderiv_planarNewtonianKernel hz, norm_smul, innerSL_apply_norm]
+  have hpi : 0 < Real.pi := Real.pi_pos
+  have hn : 0 < ‖z‖ := norm_pos_iff.mpr hz
+  rw [Real.norm_eq_abs, abs_mul, abs_neg, abs_inv, abs_mul, abs_of_pos (by positivity),
+    abs_of_pos hpi, abs_inv, abs_pow, abs_of_pos hn]
+  field_simp
+
+/-- The Fréchet derivative of a planar Newtonian kernel with pole at `a`. -/
+theorem fderiv_planarNewtonianKernel_sub {z a : ℂ} (hza : z ≠ a) :
+    fderiv ℝ (fun w : ℂ ↦ planarNewtonianKernel (w - a)) z =
+      (-(2 * Real.pi)⁻¹ * (‖z - a‖ ^ 2)⁻¹) • innerSL ℝ (z - a) := by
+  rw [fderiv_comp_sub, fderiv_planarNewtonianKernel (sub_ne_zero.mpr hza)]
+
+/-- The directional derivative of a planar Newtonian kernel with pole at `a`. -/
+theorem fderiv_planarNewtonianKernel_sub_apply {z a : ℂ} (hza : z ≠ a) (v : ℂ) :
+    fderiv ℝ (fun w : ℂ ↦ planarNewtonianKernel (w - a)) z v =
+      (-(2 * Real.pi)⁻¹ * (‖z - a‖ ^ 2)⁻¹) * ⟪z - a, v⟫_ℝ := by
+  rw [fderiv_planarNewtonianKernel_sub hza]
+  simp only [smul_apply, smul_eq_mul, innerSL_apply_apply]
+
+/-- The derivative of a planar Newtonian kernel with pole at `a` has inverse-distance norm. -/
+theorem norm_fderiv_planarNewtonianKernel_sub {z a : ℂ} (hza : z ≠ a) :
+    ‖fderiv ℝ (fun w : ℂ ↦ planarNewtonianKernel (w - a)) z‖ =
+      (2 * Real.pi * ‖z - a‖)⁻¹ := by
+  rw [fderiv_planarNewtonianKernel_sub hza, norm_smul, innerSL_apply_norm]
+  have hpi : 0 < Real.pi := Real.pi_pos
+  have hn : 0 < ‖z - a‖ := norm_pos_iff.mpr (sub_ne_zero.mpr hza)
+  rw [Real.norm_eq_abs, abs_mul, abs_neg, abs_inv, abs_mul, abs_of_pos (by positivity),
+    abs_of_pos hpi, abs_inv, abs_pow, abs_of_pos hn]
+  field_simp
+
+end TauCeti
+
+end


### PR DESCRIPTION
This PR computes the full Fréchet derivative of the planar Newtonian kernel away from its pole, its directional form, and the exact inverse-distance operator norm, together with the corresponding formulas for a translated pole. It advances `TauCetiRoadmap/PDE/README.md`, Lane C, item 15, specifically “Fundamental solution / Newtonian potential of `Δ` on `ℝⁿ`”: differentiating the kernel under the source integral needs the full covector and its `1 / ‖z - a‖` bound, whereas the landed flux calculation supplied only its radial specialization.

This is the lowest-hanging distinct continuation because the planar kernel, off-pole harmonicity, and circle flux are already on `main`, while the only open PDE PR addresses Lane D variable-energy coercivity. The new API derives the kernel derivative from Mathlib’s `HasFDerivAt.norm_sq`, logarithm chain rule, and `innerSL`, and the existing flux module now consumes the arbitrary-direction formula instead of retaining a separate derivative proof. No Mathlib infrastructure is vendored. Follow Evans, *Partial Differential Equations*, Section 2.2, for the planar fundamental-solution normalization and its inverse-distance gradient.

Add `TauCeti/Analysis/PDE/FundamentalSolution/Gradient.lean` (120 lines) and simplify `TauCeti/Analysis/PDE/FundamentalSolution/Flux.lean` by 16 net lines. `lake exe cache get` reports `No files to download` and `Already decompressed 8639 file(s)`. On the committed source, `lake build` reports `Build completed successfully (5386 jobs).` and `lake exe axioms` reports `axioms: audited 11814 TauCeti declaration(s); all within the allowlist [propext, Classical.choice, Quot.sound].`

<!--tauceti-target:v1 {"focus":"PDE","id":"planar-newtonian-kernel-gradient"}-->

🤖 Prepared with Codex
