### PR TITLE
feat: compute higher homotopy groups of the circle

### DIFF
--- a/TauCeti/AlgebraicTopology/UniversalCover/Circle/HigherHomotopy.lean
+++ b/TauCeti/AlgebraicTopology/UniversalCover/Circle/HigherHomotopy.lean
@@ -7,6 +7,7 @@ module
 public import Mathlib.Topology.Covering.AddCircle
 public import Mathlib.Topology.Instances.ZMultiples
 public import TauCeti.Topology.Homotopy.HomotopyGroup.Covering
+public import TauCeti.Topology.Homotopy.HomotopyGroup.TopologicalVectorSpace
 
 /-!
 # Higher homotopy groups of the circle
@@ -16,23 +17,21 @@ covering with the invariance of higher homotopy groups under covering maps to sh
 homotopy groups of a circle in dimensions at least two are trivial.
 
 The only calculation needed in the total space is elementary: any two generalized loops in a
-real normed vector space are homotopic relative to the cube boundary by pointwise linear
-interpolation. Consequently all homotopy groups of such a space are subsingletons. Applying
-the covering-map isomorphism for `ℝ → AddCircle p` gives the circle calculation.
+real topological vector space are homotopic relative to the cube boundary, so all homotopy
+groups of such a space are subsingletons
+(`TauCeti.HomotopyGroup.subsingleton_of_topologicalVectorSpace`). Applying the covering-map
+isomorphism for `ℝ → AddCircle p` gives the circle calculation.
 
 This proves Stage 4, item 11 of the Tau Ceti universal-covers roadmap
 (`TauCetiRoadmap/UniversalCovers/README.md`): `π_n(S¹) = 0` for `n ≥ 2`.
 
 ## Main declarations
 
-* `TauCeti.GenLoop.homotopic_of_topologicalVectorSpace`: generalized loops in a real
-  topological vector space
-  with the same basepoint are homotopic.
-* `TauCeti.HomotopyGroup.subsingleton_of_topologicalVectorSpace`: all homotopy groups of a real
-  topological vector space are subsingletons.
-* `TauCeti.AddCircle.homotopyGroup_subsingleton`: `π_N(AddCircle p)` is trivial when `N` has
+* `TauCeti.AddCircle.subsingleton_homotopyGroup`: `π_N(AddCircle p)` is trivial when `N` has
   at least two elements.
-* `TauCeti.AddCircle.homotopyGroupPi_subsingleton`: the `π_(n + 2)` form.
+* `TauCeti.AddCircle.subsingleton_homotopyGroupPi`: the `π_(n + 2)` form.
+* `TauCeti.AddCircle.homotopyGroup_eq_one`, `TauCeti.AddCircle.homotopyGroupPi_eq_one`: the
+  corresponding equalities.
 
 The covering map is Junyan Xu's `AddCircle.isCoveringMap_coe` in
 `Mathlib.Topology.Covering.AddCircle`.
@@ -45,67 +44,32 @@ namespace TauCeti
 open scoped unitInterval Topology Topology.Homotopy
 open Topology.Homotopy
 
-namespace GenLoop
-
-variable {N E : Type*} [AddCommGroup E] [Module ℝ E] [TopologicalSpace E]
-  [IsTopologicalAddGroup E] [ContinuousSMul ℝ E] {x : E}
-
-/-- Any two generalized loops based at the same point in a real topological vector space are
-homotopic relative to the cube boundary. The homotopy is pointwise linear interpolation. -/
-theorem homotopic_of_topologicalVectorSpace (f g : Ω^ N E x) :
-    _root_.GenLoop.Homotopic f g := by
-  refine ⟨⟨⟨⟨fun tu ↦ (1 - (tu.1 : ℝ)) • f tu.2 + (tu.1 : ℝ) • g tu.2, ?_⟩, ?_, ?_⟩, ?_⟩⟩
-  · fun_prop
-  · intro u
-    simp
-  · intro u
-    simp
-  · intro t u hu
-    -- Expose the value hidden by the nested `HomotopyRel` and `ContinuousMap` coercions.
-    change (1 - (t : ℝ)) • f u + (t : ℝ) • g u = f u
-    rw [_root_.GenLoop.boundary f u hu, _root_.GenLoop.boundary g u hu]
-    module
-
-end GenLoop
-
-namespace HomotopyGroup
-
-variable {N E : Type*} [AddCommGroup E] [Module ℝ E] [TopologicalSpace E]
-  [IsTopologicalAddGroup E] [ContinuousSMul ℝ E] {x : E}
-
-/-- Every homotopy group of a real topological vector space is a subsingleton. This includes
-dimension zero: a real topological vector space is path connected. -/
-theorem subsingleton_of_topologicalVectorSpace : Subsingleton (HomotopyGroup N E x) := by
-  constructor
-  intro a b
-  refine Quotient.inductionOn₂ a b fun f g ↦ ?_
-  exact Quotient.sound (GenLoop.homotopic_of_topologicalVectorSpace f g)
-
-end HomotopyGroup
-
 namespace AddCircle
+
+variable {N : Type*} [Nontrivial N] (p : ℝ) (x : AddCircle p)
 
 /-- Every higher homotopy group of a real circle is trivial. The index type `N` being
 nontrivial expresses that the dimension is at least two. -/
-theorem homotopyGroup_subsingleton {N : Type*} [Nontrivial N]
-    (p x : ℝ) : Subsingleton (HomotopyGroup N (AddCircle p) (x : AddCircle p)) := by
+theorem subsingleton_homotopyGroup : Subsingleton (HomotopyGroup N (AddCircle p) x) := by
   classical
+  obtain ⟨x, rfl⟩ := QuotientAddGroup.mk_surjective x
   letI : Subsingleton (HomotopyGroup N ℝ x) :=
     HomotopyGroup.subsingleton_of_topologicalVectorSpace
-  let e :=
-    TauCeti.IsCoveringMap.homotopyGroupMulEquiv (N := N)
-      (_root_.AddCircle.isCoveringMap_coe p) x
-  exact e.toEquiv.subsingleton_congr.mp inferInstance
+  exact (TauCeti.IsCoveringMap.homotopyGroupMulEquiv (N := N)
+    (_root_.AddCircle.isCoveringMap_coe p) x).toEquiv.subsingleton_congr.mp inferInstance
+
+/-- Every higher homotopy class of a real circle is the identity. -/
+theorem homotopyGroup_eq_one [DecidableEq N] (a : HomotopyGroup N (AddCircle p) x) : a = 1 :=
+  @Subsingleton.elim _ (subsingleton_homotopyGroup p x) _ _
 
 /-- The homotopy group `π_(n + 2)` of a real circle is trivial, for every `n`. -/
-theorem homotopyGroupPi_subsingleton (p x : ℝ) (n : ℕ) :
-    Subsingleton (π_ (n + 2) (AddCircle p) (x : AddCircle p)) :=
-  homotopyGroup_subsingleton p x
+theorem subsingleton_homotopyGroupPi (n : ℕ) :
+    Subsingleton (π_ (n + 2) (AddCircle p) x) :=
+  subsingleton_homotopyGroup p x
 
 /-- Every element of `π_(n + 2)` of a real circle is the identity. -/
-theorem homotopyGroupPi_eq_one (p x : ℝ) (n : ℕ)
-    (a : π_ (n + 2) (AddCircle p) (x : AddCircle p)) : a = 1 :=
-  @Subsingleton.elim _ (homotopyGroupPi_subsingleton p x n) _ _
+theorem homotopyGroupPi_eq_one (n : ℕ) (a : π_ (n + 2) (AddCircle p) x) : a = 1 :=
+  homotopyGroup_eq_one p x a
 
 end AddCircle
 

--- a/TauCeti/AlgebraicTopology/UniversalCover/Circle/HigherHomotopy.lean
+++ b/TauCeti/AlgebraicTopology/UniversalCover/Circle/HigherHomotopy.lean
@@ -1,0 +1,112 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+module
+
+public import Mathlib.Topology.Covering.AddCircle
+public import Mathlib.Topology.Instances.ZMultiples
+public import TauCeti.Topology.Homotopy.HomotopyGroup.Covering
+
+/-!
+# Higher homotopy groups of the circle
+
+The real line covers every real additive circle `AddCircle p`. This file combines that
+covering with the invariance of higher homotopy groups under covering maps to show that all
+homotopy groups of a circle in dimensions at least two are trivial.
+
+The only calculation needed in the total space is elementary: any two generalized loops in a
+real normed vector space are homotopic relative to the cube boundary by pointwise linear
+interpolation. Consequently all homotopy groups of such a space are subsingletons. Applying
+the covering-map isomorphism for `ℝ → AddCircle p` gives the circle calculation.
+
+This proves Stage 4, item 11 of the Tau Ceti universal-covers roadmap
+(`TauCetiRoadmap/UniversalCovers/README.md`): `π_n(S¹) = 0` for `n ≥ 2`.
+
+## Main declarations
+
+* `TauCeti.GenLoop.homotopic_of_topologicalVectorSpace`: generalized loops in a real
+  topological vector space
+  with the same basepoint are homotopic.
+* `TauCeti.HomotopyGroup.subsingleton_of_topologicalVectorSpace`: all homotopy groups of a real
+  topological vector space are subsingletons.
+* `TauCeti.AddCircle.homotopyGroup_subsingleton`: `π_N(AddCircle p)` is trivial when `N` has
+  at least two elements.
+* `TauCeti.AddCircle.homotopyGroupPi_subsingleton`: the `π_(n + 2)` form.
+
+The covering map is Junyan Xu's `AddCircle.isCoveringMap_coe` in
+`Mathlib.Topology.Covering.AddCircle`.
+-/
+
+public section
+
+namespace TauCeti
+
+open scoped unitInterval Topology Topology.Homotopy
+open Topology.Homotopy
+
+namespace GenLoop
+
+variable {N E : Type*} [AddCommGroup E] [Module ℝ E] [TopologicalSpace E]
+  [IsTopologicalAddGroup E] [ContinuousSMul ℝ E] {x : E}
+
+/-- Any two generalized loops based at the same point in a real topological vector space are
+homotopic relative to the cube boundary. The homotopy is pointwise linear interpolation. -/
+theorem homotopic_of_topologicalVectorSpace (f g : Ω^ N E x) :
+    _root_.GenLoop.Homotopic f g := by
+  refine ⟨⟨⟨⟨fun tu ↦ (1 - (tu.1 : ℝ)) • f tu.2 + (tu.1 : ℝ) • g tu.2, ?_⟩, ?_, ?_⟩, ?_⟩⟩
+  · fun_prop
+  · intro u
+    simp
+  · intro u
+    simp
+  · intro t u hu
+    -- Expose the value hidden by the nested `HomotopyRel` and `ContinuousMap` coercions.
+    change (1 - (t : ℝ)) • f u + (t : ℝ) • g u = f u
+    rw [_root_.GenLoop.boundary f u hu, _root_.GenLoop.boundary g u hu]
+    module
+
+end GenLoop
+
+namespace HomotopyGroup
+
+variable {N E : Type*} [AddCommGroup E] [Module ℝ E] [TopologicalSpace E]
+  [IsTopologicalAddGroup E] [ContinuousSMul ℝ E] {x : E}
+
+/-- Every homotopy group of a real topological vector space is a subsingleton. This includes
+dimension zero: a real topological vector space is path connected. -/
+theorem subsingleton_of_topologicalVectorSpace : Subsingleton (HomotopyGroup N E x) := by
+  constructor
+  intro a b
+  refine Quotient.inductionOn₂ a b fun f g ↦ ?_
+  exact Quotient.sound (GenLoop.homotopic_of_topologicalVectorSpace f g)
+
+end HomotopyGroup
+
+namespace AddCircle
+
+/-- Every higher homotopy group of a real circle is trivial. The index type `N` being
+nontrivial expresses that the dimension is at least two. -/
+theorem homotopyGroup_subsingleton {N : Type*} [Nontrivial N]
+    (p x : ℝ) : Subsingleton (HomotopyGroup N (AddCircle p) (x : AddCircle p)) := by
+  classical
+  letI : Subsingleton (HomotopyGroup N ℝ x) :=
+    HomotopyGroup.subsingleton_of_topologicalVectorSpace
+  let e :=
+    TauCeti.IsCoveringMap.homotopyGroupMulEquiv (N := N)
+      (_root_.AddCircle.isCoveringMap_coe p) x
+  exact e.toEquiv.subsingleton_congr.mp inferInstance
+
+/-- The homotopy group `π_(n + 2)` of a real circle is trivial, for every `n`. -/
+theorem homotopyGroupPi_subsingleton (p x : ℝ) (n : ℕ) :
+    Subsingleton (π_ (n + 2) (AddCircle p) (x : AddCircle p)) :=
+  homotopyGroup_subsingleton p x
+
+/-- Every element of `π_(n + 2)` of a real circle is the identity. -/
+theorem homotopyGroupPi_eq_one (p x : ℝ) (n : ℕ)
+    (a : π_ (n + 2) (AddCircle p) (x : AddCircle p)) : a = 1 :=
+  @Subsingleton.elim _ (homotopyGroupPi_subsingleton p x n) _ _
+
+end AddCircle
+
+end TauCeti

--- a/TauCeti/AlgebraicTopology/UniversalCover/Circle/HigherHomotopy.lean
+++ b/TauCeti/AlgebraicTopology/UniversalCover/Circle/HigherHomotopy.lean
@@ -50,20 +50,18 @@ variable {N : Type*} [Nontrivial N] (p : ℝ) (x : AddCircle p)
 
 /-- Every higher homotopy group of a real circle is trivial. The index type `N` being
 nontrivial expresses that the dimension is at least two. -/
-theorem subsingleton_homotopyGroup : Subsingleton (HomotopyGroup N (AddCircle p) x) := by
+instance subsingleton_homotopyGroup : Subsingleton (HomotopyGroup N (AddCircle p) x) := by
   classical
   obtain ⟨x, rfl⟩ := QuotientAddGroup.mk_surjective x
-  letI : Subsingleton (HomotopyGroup N ℝ x) :=
-    HomotopyGroup.subsingleton_of_topologicalVectorSpace
   exact (TauCeti.IsCoveringMap.homotopyGroupMulEquiv (N := N)
     (_root_.AddCircle.isCoveringMap_coe p) x).toEquiv.subsingleton_congr.mp inferInstance
 
 /-- Every higher homotopy class of a real circle is the identity. -/
 theorem homotopyGroup_eq_one [DecidableEq N] (a : HomotopyGroup N (AddCircle p) x) : a = 1 :=
-  @Subsingleton.elim _ (subsingleton_homotopyGroup p x) _ _
+  Subsingleton.elim _ _
 
 /-- The homotopy group `π_(n + 2)` of a real circle is trivial, for every `n`. -/
-theorem subsingleton_homotopyGroupPi (n : ℕ) :
+instance subsingleton_homotopyGroupPi (n : ℕ) :
     Subsingleton (π_ (n + 2) (AddCircle p) x) :=
   subsingleton_homotopyGroup p x
 

--- a/TauCeti/AlgebraicTopology/UniversalCover/Circle/HigherHomotopy.lean
+++ b/TauCeti/AlgebraicTopology/UniversalCover/Circle/HigherHomotopy.lean
@@ -28,8 +28,7 @@ This proves Stage 4, item 11 of the Tau Ceti universal-covers roadmap
 ## Main declarations
 
 * `TauCeti.AddCircle.subsingleton_homotopyGroup`: `π_N(AddCircle p)` is trivial when `N` has
-  at least two elements.
-* `TauCeti.AddCircle.subsingleton_homotopyGroupPi`: the `π_(n + 2)` form.
+  at least two elements; instance resolution specializes it to `π_(n + 2)`.
 * `TauCeti.AddCircle.homotopyGroup_eq_one`, `TauCeti.AddCircle.homotopyGroupPi_eq_one`: the
   corresponding equalities.
 
@@ -59,11 +58,6 @@ instance subsingleton_homotopyGroup : Subsingleton (HomotopyGroup N (AddCircle p
 /-- Every higher homotopy class of a real circle is the identity. -/
 theorem homotopyGroup_eq_one [DecidableEq N] (a : HomotopyGroup N (AddCircle p) x) : a = 1 :=
   Subsingleton.elim _ _
-
-/-- The homotopy group `π_(n + 2)` of a real circle is trivial, for every `n`. -/
-instance subsingleton_homotopyGroupPi (n : ℕ) :
-    Subsingleton (π_ (n + 2) (AddCircle p) x) :=
-  subsingleton_homotopyGroup p x
 
 /-- Every element of `π_(n + 2)` of a real circle is the identity. -/
 theorem homotopyGroupPi_eq_one (n : ℕ) (a : π_ (n + 2) (AddCircle p) x) : a = 1 :=

--- a/TauCeti/Topology/Homotopy/HomotopyGroup/TopologicalVectorSpace.lean
+++ b/TauCeti/Topology/Homotopy/HomotopyGroup/TopologicalVectorSpace.lean
@@ -49,7 +49,7 @@ namespace HomotopyGroup
 
 /-- Every homotopy group of a real topological vector space is a subsingleton. This includes
 dimension zero: a real topological vector space is path connected. -/
-theorem subsingleton_of_topologicalVectorSpace : Subsingleton (HomotopyGroup N E x) := by
+instance subsingleton_of_topologicalVectorSpace : Subsingleton (HomotopyGroup N E x) := by
   constructor
   intro a b
   refine Quotient.inductionOn₂ a b fun f g ↦ ?_

--- a/TauCeti/Topology/Homotopy/HomotopyGroup/TopologicalVectorSpace.lean
+++ b/TauCeti/Topology/Homotopy/HomotopyGroup/TopologicalVectorSpace.lean
@@ -1,0 +1,60 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+module
+
+public import Mathlib.Topology.Homotopy.Affine
+public import Mathlib.Topology.Homotopy.HomotopyGroup
+
+/-!
+# Homotopy groups of a real topological vector space
+
+Any two generalized loops with the same basepoint in a real topological vector space are
+homotopic relative to the cube boundary: Mathlib's affine homotopy
+`ContinuousMap.Homotopy.affine`, which interpolates linearly at each point of the cube, is
+constant at the basepoint on the boundary. Consequently every homotopy group of such a space
+is a subsingleton.
+
+## Main declarations
+
+* `TauCeti.GenLoop.homotopic_of_topologicalVectorSpace`: generalized loops in a real
+  topological vector space with the same basepoint are homotopic.
+* `TauCeti.HomotopyGroup.subsingleton_of_topologicalVectorSpace`: all homotopy groups of a
+  real topological vector space are subsingletons.
+-/
+
+public section
+
+namespace TauCeti
+
+open scoped unitInterval Topology Topology.Homotopy
+
+variable {N E : Type*} [AddCommGroup E] [Module ℝ E] [TopologicalSpace E]
+  [IsTopologicalAddGroup E] [ContinuousSMul ℝ E] {x : E}
+
+namespace GenLoop
+
+/-- Any two generalized loops based at the same point in a real topological vector space are
+homotopic relative to the cube boundary. The homotopy is pointwise linear interpolation. -/
+theorem homotopic_of_topologicalVectorSpace (f g : Ω^ N E x) :
+    _root_.GenLoop.Homotopic f g :=
+  ⟨{ toHomotopy := .affine f.1 g.1
+     prop' := fun _ u hu ↦ by
+       simp [_root_.GenLoop.boundary f u hu, _root_.GenLoop.boundary g u hu] }⟩
+
+end GenLoop
+
+namespace HomotopyGroup
+
+/-- Every homotopy group of a real topological vector space is a subsingleton. This includes
+dimension zero: a real topological vector space is path connected. -/
+theorem subsingleton_of_topologicalVectorSpace : Subsingleton (HomotopyGroup N E x) := by
+  constructor
+  intro a b
+  refine Quotient.inductionOn₂ a b fun f g ↦ ?_
+  exact Quotient.sound (GenLoop.homotopic_of_topologicalVectorSpace f g)
+
+end HomotopyGroup
+
+end TauCeti


### PR DESCRIPTION
This PR proves that every higher homotopy group of a real circle `AddCircle p` is trivial. First show that pointwise linear interpolation makes any two generalized loops in a real topological vector space homotopic relative to the cube boundary, hence every homotopy group of the space is a subsingleton. Then transfer this calculation across the covering `ℝ → AddCircle p`, exposing both the general nontrivial-index form and the `π_(n + 2)` specialization.

This advances `TauCetiRoadmap/UniversalCovers/README.md`, Stage 4, item 11, specifically “`π_n(S¹) = 0` for `n ≥ 2` (universal cover `ℝ` is contractible).” It is the lowest-hanging uncovered target because the required Stage 3 covering-map isomorphism is already on `main`, Mathlib supplies the real additive-circle covering, and the remaining total-space calculation is the elementary relative linear contraction formalized here.

Consume Junyan Xu’s `AddCircle.isCoveringMap_coe` from `Mathlib.Topology.Covering.AddCircle` and Tau Ceti’s landed `IsCoveringMap.homotopyGroupMulEquiv`; no infrastructure is vendored. Add `TauCeti/AlgebraicTopology/UniversalCover/Circle/HigherHomotopy.lean` (112 lines). `lake exe cache get` reports `No files to download` and `Already decompressed 8639 file(s)`. `lake build` reports `Build completed successfully (5388 jobs).` `lake exe axioms` reports `axioms: audited 11812 TauCeti declaration(s); all within the allowlist [propext, Classical.choice, Quot.sound].`

<!--tauceti-target:v1 {"focus":"UniversalCovers","id":"homotopy-groups-circle-vanish"}-->

🤖 Prepared with Codex
