### PR TITLE
feat(Contour): condition (A′) for the half-disc boundary at the origin

### DIFF
--- a/TauCeti/Analysis/Contour/RegularityConditions.lean
+++ b/TauCeti/Analysis/Contour/RegularityConditions.lean
@@ -230,6 +230,7 @@ theorem flatOfOrder_of_eventually_collinear {γ : ℝ → ℂ} {t₀ : ℝ} {v_p
     (hplus : ∀ᶠ t in 𝓝[>] t₀, ((γ t - γ t₀) * star v_plus).im = 0)
     (hminus : ∀ᶠ t in 𝓝[<] t₀, ((γ t - γ t₀) * star v_minus).im = 0) :
     FlatOfOrder γ t₀ n := by
+  rw [flatOfOrder_iff]
   refine ⟨v_plus, v_minus, hv_plus, hv_minus, ?_, ?_⟩ <;>
     refine (Asymptotics.isLittleO_zero _ _).congr' ?_ Filter.EventuallyEq.rfl
   · filter_upwards [hplus] with t ht

--- a/TauCeti/Analysis/Contour/RegularityConditions.lean
+++ b/TauCeti/Analysis/Contour/RegularityConditions.lean
@@ -41,6 +41,9 @@ pole — and that it meet each `s` only finitely often. Condition (B) governs po
   Order `1` gives a one-sided tangent line; larger `n` hugs the line more tightly.
 * `FlatOfOrderBasepoint γ a b n` — the analogue at the join `γ a = γ b` of a closed curve, for the
   outgoing branch at `a` (from the right) and the incoming branch at `b` (from the left).
+* `flatOfOrder_of_eventually_collinear` — a curve whose one-sided branches at `t₀` eventually stay
+  on a line through `γ t₀` is flat there to **every** order; the two one-sided directions may
+  differ, so a corner at `t₀` is allowed.
 * `ConditionAprime γ a b f S` — HW condition (A′), a structure requiring `γ` to meet each `s ∈ S`
   finitely often (`finite_crossings`) and be flat of order `n` wherever `f` has a pole of order `n`
   there (`interior`, `basepoint`). Pole orders come from `f` via `meromorphicOrderAt`; `S` selects
@@ -215,6 +218,26 @@ theorem flatOfOrder_iff {γ : ℝ → ℂ} {t₀ : ℝ} {n : ℕ} :
         (fun t => |((γ t - γ t₀) * star v_minus).im| / ‖v_minus‖)
             =o[𝓝[<] t₀] (fun t => ‖γ t - γ t₀‖ ^ n) :=
   Iff.rfl
+
+/-- **A curve with straight one-sided branches at `t₀` is flat there to every order.** If, on each
+side of `t₀`, the curve eventually stays on the line through `γ t₀` with direction `v` — which for
+complex numbers is exactly the vanishing of `Im ((γ t - γ t₀) * conj v)` — then the perpendicular
+deviation is identically `0` near `t₀`, hence `o` of anything. The two directions are allowed to
+differ, so a curve with a *corner* at `t₀` still qualifies; this is what makes indented and
+polygonal contours satisfy Hungerbühler–Wasem condition (A′). -/
+theorem flatOfOrder_of_eventually_collinear {γ : ℝ → ℂ} {t₀ : ℝ} {v_plus v_minus : ℂ}
+    (hv_plus : v_plus ≠ 0) (hv_minus : v_minus ≠ 0) (n : ℕ)
+    (hplus : ∀ᶠ t in 𝓝[>] t₀, ((γ t - γ t₀) * star v_plus).im = 0)
+    (hminus : ∀ᶠ t in 𝓝[<] t₀, ((γ t - γ t₀) * star v_minus).im = 0) :
+    FlatOfOrder γ t₀ n := by
+  refine ⟨v_plus, v_minus, hv_plus, hv_minus, ?_, ?_⟩ <;>
+    refine (Asymptotics.isLittleO_zero _ _).congr' ?_ Filter.EventuallyEq.rfl
+  · filter_upwards [hplus] with t ht
+    rw [ht]
+    simp
+  · filter_upwards [hminus] with t ht
+    rw [ht]
+    simp
 
 /-- `FlatOfOrderBasepoint` unfolded: the two one-sided little-o clauses (outgoing at `a`, incoming
 at `b`) that build the basepoint flatness hypothesis, exposed without unfolding the definition. -/

--- a/TauCeti/Analysis/Contour/RegularityConditions.lean
+++ b/TauCeti/Analysis/Contour/RegularityConditions.lean
@@ -223,8 +223,9 @@ theorem flatOfOrder_iff {γ : ℝ → ℂ} {t₀ : ℝ} {n : ℕ} :
 side of `t₀`, the curve eventually stays on the line through `γ t₀` with direction `v` — which for
 complex numbers is exactly the vanishing of `Im ((γ t - γ t₀) * conj v)` — then the perpendicular
 deviation is identically `0` near `t₀`, hence `o` of anything. The two directions are allowed to
-differ, so a curve with a *corner* at `t₀` still qualifies; this is what makes indented and
-polygonal contours satisfy Hungerbühler–Wasem condition (A′). -/
+differ, so a curve with a *corner* at `t₀` still qualifies. This supplies the **flatness** clause
+of Hungerbühler–Wasem condition (A′) for indented and polygonal contours; the finite-crossing and
+basepoint clauses are separate and must be established independently. -/
 theorem flatOfOrder_of_eventually_collinear {γ : ℝ → ℂ} {t₀ : ℝ} {v_plus v_minus : ℂ}
     (hv_plus : v_plus ≠ 0) (hv_minus : v_minus ≠ 0) (n : ℕ)
     (hplus : ∀ᶠ t in 𝓝[>] t₀, ((γ t - γ t₀) * star v_plus).im = 0)

--- a/TauCeti/Analysis/Contour/WorkedExamples/HalfDisc.lean
+++ b/TauCeti/Analysis/Contour/WorkedExamples/HalfDisc.lean
@@ -6,6 +6,7 @@ module
 
 public import TauCeti.Analysis.Contour.PwC1ImmersionOn
 public import TauCeti.Analysis.Contour.RegularityConditions
+import TauCeti.Analysis.Contour.Crossing.Finiteness
 public import TauCeti.Analysis.Contour.Winding.Number.Circle
 public import TauCeti.Analysis.Contour.Winding.Number.Concat
 public import TauCeti.Analysis.Contour.Winding.Number.Reparam
@@ -43,9 +44,8 @@ residue theorem does not apply because the pole lies *on* the contour.
   the single breakpoint `R`; this is the regularity hypothesis of the Hungerbühler–Wasem theorems.
 * `TauCeti.Contour.windingNumber_halfDiscBoundary` — its generalized winding number about the
   origin is `½`.
-* `TauCeti.Contour.halfDiscBoundary_eq_zero_iff` and
-  `TauCeti.Contour.finite_crossings_halfDiscBoundary` — the contour meets the origin exactly
-  once, at `t = 0`.
+* `TauCeti.Contour.halfDiscBoundary_eq_zero_iff` — the contour meets the origin exactly once,
+  at `t = 0`.
 * `TauCeti.Contour.flatOfOrder_halfDiscBoundary` — near the origin the contour *is* the real
   diameter, so it is flat there to every order.
 * `TauCeti.Contour.conditionAprime_halfDiscBoundary` — Hungerbühler–Wasem condition (A′) at the
@@ -253,27 +253,31 @@ theorem halfDiscBoundary_eq_zero_iff (hR : 0 < R) {t : ℝ} :
   · rintro rfl
     simpa using halfDiscBoundary_of_le hR.le
 
-/-- The crossing set of the origin is `{0}`, hence finite. -/
-theorem finite_crossings_halfDiscBoundary (hR : 0 < R) :
-    (uIcc (-R) (R + Real.pi) ∩ halfDiscBoundary R ⁻¹' {0}).Finite :=
-  Set.Finite.subset (Set.finite_singleton 0) fun _ ht =>
-    (halfDiscBoundary_eq_zero_iff hR).mp ht.2
-
 /-- **The half-disc boundary is flat to every order at the origin.** Near `t = 0` the contour is
 the real diameter, so it lies *exactly* on the real line: with tangent direction `v = 1` the
 distance `|Im(γ t - γ 0)|` is identically zero there, which is `o` of anything. -/
-theorem flatOfOrder_halfDiscBoundary (hR : 0 < R) (n : ℕ) :
+theorem flatOfOrder_halfDiscBoundary (hR : 0 ≤ R) (n : ℕ) :
     FlatOfOrder (halfDiscBoundary R) 0 n := by
   have hzero : ∀ t : ℝ, t ≤ R →
       ((halfDiscBoundary R t - halfDiscBoundary R 0) * star (1 : ℂ)).im = 0 := by
     intro t ht
-    rw [halfDiscBoundary_of_le ht, halfDiscBoundary_of_le hR.le]
+    rw [halfDiscBoundary_of_le ht, halfDiscBoundary_of_le hR]
     simp
-  refine flatOfOrder_of_eventually_collinear one_ne_zero one_ne_zero n ?_ ?_
-  · filter_upwards [Ioo_mem_nhdsGT hR] with t ht
-    exact hzero t (mem_Ioo.mp ht).2.le
-  · filter_upwards [self_mem_nhdsWithin] with t ht
-    exact hzero t (le_trans (le_of_lt ht) hR.le)
+  rcases eq_or_lt_of_le hR with rfl | hR'
+  · -- Degenerate radius: the arc collapses to the origin, so the deviation vanishes everywhere.
+    have hall : ∀ t : ℝ, ((halfDiscBoundary 0 t - halfDiscBoundary 0 0) * star (1 : ℂ)).im = 0 := by
+      intro t
+      rcases le_or_gt t 0 with h | h
+      · exact hzero t h
+      · rw [halfDiscBoundary_of_lt h, halfDiscBoundary_of_le le_rfl]
+        simp [circleMap]
+    exact flatOfOrder_of_eventually_collinear one_ne_zero one_ne_zero n
+      (Filter.Eventually.of_forall hall) (Filter.Eventually.of_forall hall)
+  · refine flatOfOrder_of_eventually_collinear one_ne_zero one_ne_zero n ?_ ?_
+    · filter_upwards [Ioo_mem_nhdsGT hR'] with t ht
+      exact hzero t (mem_Ioo.mp ht).2.le
+    · filter_upwards [self_mem_nhdsWithin] with t ht
+      exact hzero t (le_trans (le_of_lt ht) hR)
 
 /-- **Condition (A′) holds for the half-disc boundary at the origin**, for any integrand. The
 origin is met exactly once, the contour is flat there to every order (it is locally the real
@@ -284,10 +288,10 @@ theorem conditionAprime_halfDiscBoundary (hR : 0 < R) (f : ℂ → ℂ) :
   have hmin : min (-R) (R + Real.pi) = -R := min_eq_left (by linarith)
   refine ⟨fun s hs => ?_, fun t₀ _ hmem n _ _ => ?_, fun hbase => ?_⟩
   · rw [Finset.mem_singleton.mp hs]
-    exact finite_crossings_halfDiscBoundary hR
+    exact (isPwC1ImmersionOn_halfDiscBoundary hR).finite_crossings
   · have ht₀ : t₀ = 0 := (halfDiscBoundary_eq_zero_iff hR).mp (by simpa using hmem)
     subst ht₀
-    exact flatOfOrder_halfDiscBoundary hR n
+    exact flatOfOrder_halfDiscBoundary hR.le n
   · exfalso
     rw [hmin, halfDiscBoundary_of_le (by linarith : (-R : ℝ) ≤ R)] at hbase
     have : (-R : ℝ) = 0 := by

--- a/TauCeti/Analysis/Contour/WorkedExamples/HalfDisc.lean
+++ b/TauCeti/Analysis/Contour/WorkedExamples/HalfDisc.lean
@@ -46,8 +46,8 @@ residue theorem does not apply because the pole lies *on* the contour.
   origin is `½`.
 * `TauCeti.Contour.halfDiscBoundary_eq_zero_iff` — the contour meets the origin exactly once,
   at `t = 0`.
-* `TauCeti.Contour.flatOfOrder_halfDiscBoundary` — near the origin the contour *is* the real
-  diameter, so it is flat there to every order.
+* `TauCeti.Contour.flatOfOrder_halfDiscBoundary` — both one-sided branches at the origin lie on
+  the real line, so the contour is flat there to every order.
 * `TauCeti.Contour.conditionAprime_halfDiscBoundary` — Hungerbühler–Wasem condition (A′) at the
   origin, for any integrand.
 
@@ -253,9 +253,11 @@ theorem halfDiscBoundary_eq_zero_iff (hR : 0 < R) {t : ℝ} :
   · rintro rfl
     simpa using halfDiscBoundary_of_le hR.le
 
-/-- **The half-disc boundary is flat to every order at the origin.** Near `t = 0` the contour is
-the real diameter, so it lies *exactly* on the real line: with tangent direction `v = 1` the
-distance `|Im(γ t - γ 0)|` is identically zero there, which is `o` of anything. -/
+/-- **The half-disc boundary is flat to every order at the origin.** With tangent direction
+`v = 1` the perpendicular deviation `|Im (γ t - γ 0)|` vanishes *identically* near `t = 0`, which
+is `o` of anything. For `R > 0` that is because the contour is locally the real diameter; for the
+degenerate radius `R = 0` the arc collapses to the origin, so both one-sided branches still lie on
+the real line. -/
 theorem flatOfOrder_halfDiscBoundary (hR : 0 ≤ R) (n : ℕ) :
     FlatOfOrder (halfDiscBoundary R) 0 n := by
   have hzero : ∀ t : ℝ, t ≤ R →

--- a/TauCeti/Analysis/Contour/WorkedExamples/HalfDisc.lean
+++ b/TauCeti/Analysis/Contour/WorkedExamples/HalfDisc.lean
@@ -5,6 +5,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 module
 
 public import TauCeti.Analysis.Contour.PwC1ImmersionOn
+public import TauCeti.Analysis.Contour.RegularityConditions
 public import TauCeti.Analysis.Contour.Winding.Number.Circle
 public import TauCeti.Analysis.Contour.Winding.Number.Concat
 public import TauCeti.Analysis.Contour.Winding.Number.Reparam
@@ -42,6 +43,13 @@ residue theorem does not apply because the pole lies *on* the contour.
   the single breakpoint `R`; this is the regularity hypothesis of the Hungerbühler–Wasem theorems.
 * `TauCeti.Contour.windingNumber_halfDiscBoundary` — its generalized winding number about the
   origin is `½`.
+* `TauCeti.Contour.halfDiscBoundary_eq_zero_iff` and
+  `TauCeti.Contour.finite_crossings_halfDiscBoundary` — the contour meets the origin exactly
+  once, at `t = 0`.
+* `TauCeti.Contour.flatOfOrder_halfDiscBoundary` — near the origin the contour *is* the real
+  diameter, so it is flat there to every order.
+* `TauCeti.Contour.conditionAprime_halfDiscBoundary` — Hungerbühler–Wasem condition (A′) at the
+  origin, for any integrand.
 
 ## References
 
@@ -229,6 +237,60 @@ theorem windingNumber_halfDiscBoundary (hR : 0 < R) :
       ((eqOn_halfDiscBoundary_arc R).mono uIoo_subset_uIcc_self)]
     exact windingNumber_arc hR
   rw [windingNumber_concat hpv_seg hpv_arc, hseg, harc, zero_add]
+
+/-- **The half-disc boundary meets the origin exactly once**, at `t = 0`: on the diameter
+`γ t = t` vanishes only there, and the arc stays at distance `|R|` from the origin. -/
+theorem halfDiscBoundary_eq_zero_iff (hR : 0 < R) {t : ℝ} :
+    halfDiscBoundary R t = 0 ↔ t = 0 := by
+  constructor
+  · intro h
+    by_cases hle : t ≤ R
+    · rw [halfDiscBoundary_of_le hle] at h
+      exact_mod_cast h
+    · rw [halfDiscBoundary_of_lt (not_le.mp hle)] at h
+      exact absurd h (circleMap_ne_center hR.ne')
+  · rintro rfl
+    simpa using halfDiscBoundary_of_le hR.le
+
+/-- The crossing set of the origin is `{0}`, hence finite. -/
+theorem finite_crossings_halfDiscBoundary (hR : 0 < R) :
+    (uIcc (-R) (R + Real.pi) ∩ halfDiscBoundary R ⁻¹' {0}).Finite :=
+  Set.Finite.subset (Set.finite_singleton 0) fun _ ht =>
+    (halfDiscBoundary_eq_zero_iff hR).mp ht.2
+
+/-- **The half-disc boundary is flat to every order at the origin.** Near `t = 0` the contour is
+the real diameter, so it lies *exactly* on the real line: with tangent direction `v = 1` the
+distance `|Im(γ t - γ 0)|` is identically zero there, which is `o` of anything. -/
+theorem flatOfOrder_halfDiscBoundary (hR : 0 < R) (n : ℕ) :
+    FlatOfOrder (halfDiscBoundary R) 0 n := by
+  have hzero : ∀ t : ℝ, t ≤ R →
+      ((halfDiscBoundary R t - halfDiscBoundary R 0) * star (1 : ℂ)).im = 0 := by
+    intro t ht
+    rw [halfDiscBoundary_of_le ht, halfDiscBoundary_of_le hR.le]
+    simp
+  refine flatOfOrder_of_eventually_collinear one_ne_zero one_ne_zero n ?_ ?_
+  · filter_upwards [Ioo_mem_nhdsGT hR] with t ht
+    exact hzero t (mem_Ioo.mp ht).2.le
+  · filter_upwards [self_mem_nhdsWithin] with t ht
+    exact hzero t (le_trans (le_of_lt ht) hR.le)
+
+/-- **Condition (A′) holds for the half-disc boundary at the origin**, for any integrand. The
+origin is met exactly once, the contour is flat there to every order (it is locally the real
+diameter), and the basepoint `γ(-R) = -R` is not the origin, so that clause is vacuous. -/
+theorem conditionAprime_halfDiscBoundary (hR : 0 < R) (f : ℂ → ℂ) :
+    ConditionAprime (halfDiscBoundary R) (-R) (R + Real.pi) f {0} := by
+  have hpi := Real.pi_pos
+  have hmin : min (-R) (R + Real.pi) = -R := min_eq_left (by linarith)
+  refine ⟨fun s hs => ?_, fun t₀ _ hmem n _ _ => ?_, fun hbase => ?_⟩
+  · rw [Finset.mem_singleton.mp hs]
+    exact finite_crossings_halfDiscBoundary hR
+  · rw [show t₀ = 0 from (halfDiscBoundary_eq_zero_iff hR).mp (by simpa using hmem)]
+    exact flatOfOrder_halfDiscBoundary hR n
+  · exfalso
+    rw [hmin, halfDiscBoundary_of_le (by linarith : (-R : ℝ) ≤ R)] at hbase
+    have : (-R : ℝ) = 0 := by
+      exact_mod_cast Complex.ofReal_eq_zero.mp (by simpa using hbase)
+    linarith
 
 end TauCeti.Contour
 

--- a/TauCeti/Analysis/Contour/WorkedExamples/HalfDisc.lean
+++ b/TauCeti/Analysis/Contour/WorkedExamples/HalfDisc.lean
@@ -240,6 +240,7 @@ theorem windingNumber_halfDiscBoundary (hR : 0 < R) :
 
 /-- **The half-disc boundary meets the origin exactly once**, at `t = 0`: on the diameter
 `γ t = t` vanishes only there, and the arc stays at distance `|R|` from the origin. -/
+@[simp]
 theorem halfDiscBoundary_eq_zero_iff (hR : 0 < R) {t : ℝ} :
     halfDiscBoundary R t = 0 ↔ t = 0 := by
   constructor
@@ -284,7 +285,8 @@ theorem conditionAprime_halfDiscBoundary (hR : 0 < R) (f : ℂ → ℂ) :
   refine ⟨fun s hs => ?_, fun t₀ _ hmem n _ _ => ?_, fun hbase => ?_⟩
   · rw [Finset.mem_singleton.mp hs]
     exact finite_crossings_halfDiscBoundary hR
-  · rw [show t₀ = 0 from (halfDiscBoundary_eq_zero_iff hR).mp (by simpa using hmem)]
+  · have ht₀ : t₀ = 0 := (halfDiscBoundary_eq_zero_iff hR).mp (by simpa using hmem)
+    subst ht₀
     exact flatOfOrder_halfDiscBoundary hR n
   · exfalso
     rw [hmin, halfDiscBoundary_of_le (by linarith : (-R : ℝ) ≤ R)] at hbase


### PR DESCRIPTION
Supplies the Hungerbühler–Wasem regularity hypothesis for the indented half-disc contour of `WorkedExamples/HalfDisc.lean`, which is the remaining input its worked example needs from `hasCauchyPV_half_residue`.

## What is added

`RegularityConditions.lean` gains a reusable flatness criterion:

* `flatOfOrder_of_eventually_collinear` — if on each side of `t₀` the curve eventually stays on a line through `γ t₀` with direction `v` (equivalently `Im ((γ t - γ t₀) * conj v) = 0`), then `γ` is flat at `t₀` to **every** order. The two one-sided directions are independent, so a curve with a *corner* at `t₀` still qualifies — which is what makes indented and polygonal contours satisfy condition (A′) at all.

`WorkedExamples/HalfDisc.lean` then applies it:

* `halfDiscBoundary_eq_zero_iff` — the contour meets the origin exactly once, at `t = 0`.
* `finite_crossings_halfDiscBoundary` — hence the crossing set is finite.
* `flatOfOrder_halfDiscBoundary` — near `t = 0` the contour *is* the real diameter, so with direction `v = 1` the perpendicular deviation is identically zero.
* `conditionAprime_halfDiscBoundary` — the three clauses assembled. The basepoint clause is vacuous: `γ (min (-R) (R+π)) = -R ≠ 0`.

The statement holds for an arbitrary integrand `f`: none of the three clauses constrain it, because the contour is flat to every order and so satisfies the interior clause whatever the pole order.

## Gates

`lake build` · `lake exe axioms` · `lake exe module-system` · `scripts/lint-env.sh` — all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)