### PR TITLE
fix: validate trusted bot lakefile bumps

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -26,7 +26,8 @@
 # The review bot's exact first-known-bad Mathlib pin also needs to enter the merge queue. GitHub
 # cannot make CODEOWNERS conditional on the PR author, so this file has no owner here; the trusted
 # author-aware scope status and bump guard remain the load-bearing gates. Any other lakefile change
-# is refused by auto-merge and still needs a human merge decision.
+# is refused by auto-merge and still needs a human merge decision; its red `scope` status is the
+# explicit signal that the human must inspect the config rather than treating green build as review.
 /lakefile.toml
 /lake-manifest.json
 /lean-toolchain

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -23,8 +23,10 @@
 # bump-guard check plus the sandboxed build, so they need no human review. As with /TauCeti.lean,
 # leaving them human-owned would also block the merge queue from enqueuing a bump PR (the App
 # bypasses code-owner review for a direct merge, but not at enqueue time), so they are AI-gated.
-# `lakefile.toml` stays human-owned. The review bot's exact first-known-bad Mathlib pin remains
-# covered here too; its App identity bypasses this ownership rule only after the author-aware scope
-# policy and bump guard validate the one-line config change. No ordinary lakefile PR auto-merges.
+# The review bot's exact first-known-bad Mathlib pin also needs to enter the merge queue. GitHub
+# cannot make CODEOWNERS conditional on the PR author, so this file has no owner here; the trusted
+# author-aware scope status and bump guard remain the load-bearing gates. Any other lakefile change
+# is refused by auto-merge and still needs a human merge decision.
+/lakefile.toml
 /lake-manifest.json
 /lean-toolchain

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -23,7 +23,8 @@
 # bump-guard check plus the sandboxed build, so they need no human review. As with /TauCeti.lean,
 # leaving them human-owned would also block the merge queue from enqueuing a bump PR (the App
 # bypasses code-owner review for a direct merge, but not at enqueue time), so they are AI-gated.
-# `lakefile.toml` stays human-owned: a build-config change is not a pin and bump-guard does not
-# cover it.
+# `lakefile.toml` stays human-owned. The review bot's exact first-known-bad Mathlib pin remains
+# covered here too; its App identity bypasses this ownership rule only after the author-aware scope
+# policy and bump guard validate the one-line config change. No ordinary lakefile PR auto-merges.
 /lake-manifest.json
 /lean-toolchain

--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -64,9 +64,10 @@ jobs:
     if: ${{ needs.resolve.outputs.pr != '' }}
     # Pinned to a TauCetiReview commit; bump deliberately. The reusable workflow receives the App
     # secrets, so a floating @main would be a supply-chain risk.
-    uses: TauCetiProject/TauCetiReview/.github/workflows/merge-only.yml@6375e7b54f691ae805c78bf060b4d883d7b5f5e9
+    uses: TauCetiProject/TauCetiReview/.github/workflows/merge-only.yml@eeed9637d7e2af319a04de8120b35f0c52318f0d
     with:
       pr: ${{ needs.resolve.outputs.pr }}
+      review_ref: eeed9637d7e2af319a04de8120b35f0c52318f0d
     # Pass only the App credentials merge-only needs, not all of TauCeti's secrets.
     secrets:
       APP_ID: ${{ secrets.APP_ID }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,6 +15,14 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - name: Infrastructure policy unit tests
+        run: |
+          PYTHONPATH=scripts python3 scripts/test_check_bot_lakefile.py
+          python3 scripts/pr_status/test_stuck_alerts.py
+          python3 scripts/test_roadmap_label.py
+          python3 scripts/pr_status/test_pr_labels.py
+          python3 scripts/test_structure_nudge.py
+
       # The two-library split is build convenience, not a trust boundary.
       # This guard is what actually stops the AI-owned library from inheriting
       # sorried declarations: TauCeti/ may not import the roadmap/review trees.

--- a/.github/workflows/merge-sweep.yml
+++ b/.github/workflows/merge-sweep.yml
@@ -32,9 +32,10 @@ jobs:
   sweep:
     # Pinned to a TauCetiReview commit; bump deliberately. The reusable workflow receives the App
     # secrets, so a floating @main would be a supply-chain risk.
-    uses: TauCetiProject/TauCetiReview/.github/workflows/merge-sweep.yml@6375e7b54f691ae805c78bf060b4d883d7b5f5e9
+    uses: TauCetiProject/TauCetiReview/.github/workflows/merge-sweep.yml@eeed9637d7e2af319a04de8120b35f0c52318f0d
     with:
       dry_run: ${{ inputs.dry-run || false }}
+      review_ref: eeed9637d7e2af319a04de8120b35f0c52318f0d
     secrets:
       APP_ID: ${{ secrets.APP_ID }}
       APP_PRIVATE_KEY: ${{ secrets.APP_PRIVATE_KEY }}

--- a/.github/workflows/pr-build.yml
+++ b/.github/workflows/pr-build.yml
@@ -161,6 +161,9 @@ jobs:
             echo "BUMP=1" >> "$GITHUB_ENV"
             echo "::notice::trusted review-bot Mathlib lakefile pin detected — validating the exact config and manifest relationship"
           elif echo "$files" | grep -vqE '^TauCeti/|^TauCeti\.lean$|^lake-manifest\.json$|^lean-toolchain$'; then
+            if echo "$files" | grep -qE '^lakefile\.toml$'; then
+              echo "HUMAN_LAKEFILE=1" >> "$GITHUB_ENV"
+            fi
             echo "OUT_OF_SCOPE=1" >> "$GITHUB_ENV"
             echo "::warning::PR changes paths outside TauCeti/ + Lake pins — its TauCeti/ is still sandbox-built against the trusted base (so the build result is visible), but merging needs human review"
           elif echo "$files" | grep -qE '^lake-manifest\.json$|^lean-toolchain$'; then
@@ -272,6 +275,16 @@ jobs:
           fi
           if bash base/scripts/check-bump.sh "${args[@]}"; then
             echo "Lake-pin bump validated — building with the PR's pins."
+          elif [ "${{ github.event_name }}" = "merge_group" ] \
+              && [ "${BOT_LAKEFILE:-}" = "1" ]; then
+            # A human-reviewed arbitrary lakefile change can enter the queue too. It is not eligible
+            # for the bot exception, so preserve the pre-exception behavior: build with trusted base
+            # config, keep scope red, and let the human decision (not automation) authorize landing.
+            echo "BOT_LAKEFILE=" >> "$GITHUB_ENV"
+            echo "BUMP=" >> "$GITHUB_ENV"
+            echo "HUMAN_LAKEFILE=1" >> "$GITHUB_ENV"
+            echo "OUT_OF_SCOPE=1" >> "$GITHUB_ENV"
+            echo "::warning::merge-group lakefile is not the exact bot pin — building trusted base config for the human merge path"
           else
             echo "BUMP_BAD=1" >> "$GITHUB_ENV"
             echo "INFRA=1" >> "$GITHUB_ENV"
@@ -458,6 +471,8 @@ jobs:
           # both required statuses land together, before the auto-merge workflow_run fires.
           if [ "${{ env.BUMP_BAD }}" = "1" ]; then
             bg_state=failure; bg_desc="Lake pin/config change is not a validated forward bump — needs human review"
+          elif [ "${{ env.HUMAN_LAKEFILE }}" = "1" ]; then
+            bg_state=success; bg_desc="lakefile not auto-validated; trusted base config built — human merge required"
           else
             bg_state=success; bg_desc="validated forward Lake pin/config bump (or no pin change)"
           fi

--- a/.github/workflows/pr-build.yml
+++ b/.github/workflows/pr-build.yml
@@ -2,9 +2,12 @@ name: pr-build
 
 # Builds untrusted PR code in a TRUSTED, base-branch-defined workflow. A PR cannot change what
 # runs here (pull_request_target uses the base definition). The build/audit configuration
-# (lakefile, scripts/, manifest, toolchain) is always the TRUSTED base's: we overlay only the
-# PR's `TauCeti/` sources onto a base checkout and build that. Any PR touching anything outside
-# `TauCeti/` is routed to a human (it can't be validated with trusted config). PR `TauCeti/` code
+# (lakefile, scripts/, manifest, toolchain) is the TRUSTED base's: we overlay only the PR's
+# `TauCeti/` sources and validated Lake pins onto a base checkout. The sole config exception is a
+# PR opened by tauceti-review-bot[bot] that changes exactly Mathlib's lakefile rev to the matching
+# immutable manifest SHA, or restores it to `master`; the trusted bump validator proves and
+# overlays that exact change. Any other PR touching anything outside the allowed paths is routed
+# to a human. PR `TauCeti/` code
 # compiles only under landrun (offline; writes confined to base/.lake; no secrets or token in
 # reach). The `build` commit status on the PR head SHA is the required merge check.
 #
@@ -79,18 +82,21 @@ jobs:
             BASE_REF='${{ github.event.merge_group.base_sha }}'
             STATUS_SHA='${{ github.event.merge_group.head_sha }}'
             NUM="merge-group"   # not a single PR; scope/diff use the combined base..head diff below
+            AUTHOR=""           # author was checked before enqueue; strict config validation repeats below
           elif [ "${{ github.event_name }}" = "pull_request_target" ]; then
             NUM='${{ github.event.pull_request.number }}'
             SHA='${{ github.event.pull_request.head.sha }}'
             REPO='${{ github.event.pull_request.head.repo.full_name }}'
             BASE_REF='${{ github.event.pull_request.base.ref }}'
             STATUS_SHA="$SHA"
+            AUTHOR='${{ github.event.pull_request.user.login }}'
           else
             NUM='${{ inputs.pr }}'
             SHA=$(gh api "repos/${{ github.repository }}/pulls/$NUM"  --jq .head.sha)
             REPO=$(gh api "repos/${{ github.repository }}/pulls/$NUM" --jq .head.repo.full_name)
             BASE_REF=$(gh api "repos/${{ github.repository }}/pulls/$NUM" --jq .base.ref)
             STATUS_SHA="$SHA"
+            AUTHOR=$(gh api "repos/${{ github.repository }}/pulls/$NUM" --jq .user.login)
           fi
           # Merge-base with the target branch, for the Lake-pin bump validation below:
           # check-bump.sh uses it to scope the PR's own pin delta. owner:sha for forks;
@@ -100,16 +106,22 @@ jobs:
           MB=$(gh api "repos/${{ github.repository }}/compare/${BASE_REF}...${OWNER}:${SHA}" \
                  --jq '.merge_base_commit.sha' 2>/dev/null || true)
           [ -n "$MB" ] || { MB="$BASE_REF"; echo "::warning::merge-base unresolved; falling back to $BASE_REF tip"; }
-          echo "num=$NUM"             >> "$GITHUB_OUTPUT"
-          echo "sha=$SHA"             >> "$GITHUB_OUTPUT"
-          echo "repo=$REPO"           >> "$GITHUB_OUTPUT"
-          echo "base_ref=$BASE_REF"   >> "$GITHUB_OUTPUT"
-          echo "mergebase=$MB"        >> "$GITHUB_OUTPUT"
-          echo "status_sha=$STATUS_SHA" >> "$GITHUB_OUTPUT"
-          echo "Building PR #$NUM @ $SHA from $REPO (status -> $STATUS_SHA, bump delta vs merge-base $MB)"
+          {
+            echo "num=$NUM"
+            echo "sha=$SHA"
+            echo "repo=$REPO"
+            echo "base_ref=$BASE_REF"
+            echo "mergebase=$MB"
+            echo "status_sha=$STATUS_SHA"
+            echo "author=$AUTHOR"
+          } >> "$GITHUB_OUTPUT"
+          echo "Building PR #$NUM @ $SHA from $REPO (author=${AUTHOR:-merge-group}, status -> $STATUS_SHA, bump delta vs merge-base $MB)"
 
-      - name: Scope guard — PR must touch only TauCeti/ or the root TauCeti.lean (from the trusted GitHub file list)
-        env: { GH_TOKEN: "${{ github.token }}" }
+      - name: Scope guard — allow TauCeti sources, validated pins, and the review bot's exact lakefile pin
+        env:
+          GH_TOKEN: "${{ github.token }}"
+          PR_AUTHOR: "${{ steps.pr.outputs.author }}"
+          EVENT_NAME: "${{ github.event_name }}"
         run: |
           if [ "${{ github.event_name }}" = "merge_group" ]; then
             # The whole batch's combined change set vs the trusted base (every batched PR).
@@ -128,16 +140,26 @@ jobs:
           # The root TauCeti.lean is allowed alongside TauCeti/: it is the (intentionally
           # empty) library root, normally untouched, but a PR may edit it. It is overlaid
           # into the sandbox below and the import-boundary guard covers it. Everything else
-          # outside TauCeti/ (lakefile, scripts/, .github/) stays trusted-base-only and
-          # routes to a human.
+          # outside TauCeti/ (scripts/, .github/, arbitrary Lake config) stays trusted-base-only and
+          # routes to a human. lakefile.toml has one narrow exception: the review bot may pin Mathlib
+          # to the exact immutable SHA in the manifest, then restore `master` in the next compatible
+          # bump. The trusted bump validator proves the single-line relationship before that config
+          # is overlaid or built. A merge group has no
+          # single author, but it can contain this path only after the author-aware enqueue gate; the
+          # same strict content validation is repeated here.
           # lake-manifest.json and lean-toolchain are also permitted, but ONLY as a
           # machine-validated forward bump: the "Validate the Lake-pin bump" step below
           # runs the trusted base scripts/check-bump.sh and routes to a human if it is
           # anything other than a forward move (mathlib forward on its nominated branch,
-          # transitive pins derived from mathlib, toolchain monotonic). lakefile.* stays
-          # human-owned (and check-bump fails if it changed).
+          # transitive pins derived from mathlib, toolchain monotonic).
           if [ -z "$files" ]; then
             echo "INFRA=1" >> "$GITHUB_ENV"; echo "::warning::no files / unable to list — cannot determine the overlay, routing to human"
+          elif echo "$files" | grep -qE '^lakefile\.toml$' \
+            && ! echo "$files" | grep -vqE '^TauCeti/|^TauCeti\.lean$|^lake-manifest\.json$|^lean-toolchain$|^lakefile\.toml$' \
+            && { [ "$PR_AUTHOR" = "tauceti-review-bot[bot]" ] || [ "$EVENT_NAME" = "merge_group" ]; }; then
+            echo "BOT_LAKEFILE=1" >> "$GITHUB_ENV"
+            echo "BUMP=1" >> "$GITHUB_ENV"
+            echo "::notice::trusted review-bot Mathlib lakefile pin detected — validating the exact config and manifest relationship"
           elif echo "$files" | grep -vqE '^TauCeti/|^TauCeti\.lean$|^lake-manifest\.json$|^lean-toolchain$'; then
             echo "OUT_OF_SCOPE=1" >> "$GITHUB_ENV"
             echo "::warning::PR changes paths outside TauCeti/ + Lake pins — its TauCeti/ is still sandbox-built against the trusted base (so the build result is visible), but merging needs human review"
@@ -241,7 +263,11 @@ jobs:
         if: ${{ env.INFRA != '1' && env.BUMP == '1' }}
         env: { GH_TOKEN: "${{ github.token }}" }
         run: |
-          if bash base/scripts/check-bump.sh base mergebase pr; then
+          args=(base mergebase pr)
+          if [ "${BOT_LAKEFILE:-}" = "1" ]; then
+            args+=(--allow-bot-lakefile)
+          fi
+          if bash base/scripts/check-bump.sh "${args[@]}"; then
             echo "Lake-pin bump validated — building with the PR's pins."
           else
             echo "BUMP_BAD=1" >> "$GITHUB_ENV"
@@ -266,13 +292,19 @@ jobs:
             cp -a pr/TauCeti.lean base/TauCeti.lean
           fi
           # For a validated forward bump, overlay the PR's Lake pins too, so the build
-          # below actually exercises the new mathlib/toolchain (check-bump already
-          # verified these are a safe forward move; lakefile.* is unchanged).
+          # below actually exercises the new mathlib/toolchain.
           if [ "${BUMP:-}" = "1" ]; then
             for f in lake-manifest.json lean-toolchain; do
               if [ -L "pr/$f" ]; then echo "::error::$f must not be a symlink"; exit 1; fi
               [ -e "pr/$f" ] && cp -a "pr/$f" "base/$f"
             done
+          fi
+          # The trusted-bot exception is an exact, validator-proven Mathlib rev replacement.
+          # Overlay that lakefile only after check-bump accepted it; arbitrary Lake config remains
+          # base-trusted and can never reach the build through this path.
+          if [ "${BOT_LAKEFILE:-}" = "1" ]; then
+            test ! -L pr/lakefile.toml || { echo "::error::lakefile.toml must not be a symlink"; exit 1; }
+            cp -a pr/lakefile.toml base/lakefile.toml
           fi
 
       - name: Import-boundary guard (TauCeti/ and TauCeti.lean ⊬ roadmap/review)
@@ -418,13 +450,13 @@ jobs:
           # bump-guard: this job already ran the trusted base scripts/check-bump.sh inline
           # (the "Validate the Lake-pin bump" step), so we post the required `bump-guard`
           # status from its result here rather than from a separate workflow. BUMP_BAD is set
-          # only when a manifest/toolchain change failed that validator; anything else (no pin
+          # only when a manifest/toolchain/config change failed that validator; anything else (no pin
           # change, or a validated forward bump) is a pass. Posting it from this job also means
           # both required statuses land together, before the auto-merge workflow_run fires.
           if [ "${{ env.BUMP_BAD }}" = "1" ]; then
-            bg_state=failure; bg_desc="manifest/toolchain change is not a validated forward bump — needs human review"
+            bg_state=failure; bg_desc="Lake pin/config change is not a validated forward bump — needs human review"
           else
-            bg_state=success; bg_desc="forward-only Lake-pin / toolchain bump (or no pin change)"
+            bg_state=success; bg_desc="validated forward Lake pin/config bump (or no pin change)"
           fi
           gh api -X POST "repos/${{ github.repository }}/statuses/${{ steps.pr.outputs.status_sha }}" \
             -f state="$bg_state" -f context="bump-guard" -f description="$bg_desc" \
@@ -459,6 +491,8 @@ jobs:
           # auto-merge; a human merges it once they have seen its now-visible build.
           if [ "${{ env.OUT_OF_SCOPE }}" = "1" ]; then
             sc_state=failure; sc_desc="changes outside TauCeti/ — human review + merge required"
+          elif [ "${{ env.BUMP_BAD }}" = "1" ]; then
+            sc_state=failure; sc_desc="Lake pin/config change failed the trusted bump validator"
           elif [ "${{ env.INFRA }}" = "1" ]; then
             sc_state=failure; sc_desc="could not determine the changed files — human review + merge required"
           elif [ "${{ env.TOO_LARGE }}" = "1" ]; then
@@ -467,6 +501,8 @@ jobs:
             sc_state=failure; sc_desc="could not read PR diff totals from the GitHub API — re-run pr-build"
           elif [ "${{ env.NEWFILE_TOO_LONG }}" = "1" ]; then
             sc_state=failure; sc_desc="a newly added .lean file exceeds 1000 lines — split it (existing files may grow to 1500)"
+          elif [ "${{ env.BOT_LAKEFILE }}" = "1" ]; then
+            sc_state=success; sc_desc="trusted review-bot Mathlib lakefile pin validated and in scope"
           else
             sc_state=success; sc_desc="changes are in scope (TauCeti/ and the allowed root files only)"
           fi

--- a/.github/workflows/pr-build.yml
+++ b/.github/workflows/pr-build.yml
@@ -167,6 +167,9 @@ jobs:
             echo "BUMP=1" >> "$GITHUB_ENV"
             echo "::notice::PR changes Lake pins — validating as a forward bump before building"
           fi
+          # The report step runs under `if: always()`. Mark successful completion explicitly so an
+          # API or shell failure above cannot be misreported as a green scope decision.
+          echo "SCOPE_OK=1" >> "$GITHUB_ENV"
 
       - name: Diff size guard — additions, deletions, and changed files each ≤ 2000 (trusted GitHub PR totals)
         # Per-PR cap, enforced when each PR is built on pull_request_target (its entry condition to the
@@ -486,10 +489,12 @@ jobs:
           # scope: the merge-policy verdict, posted as its OWN status so a policy issue never hides the
           # build result (the bug this split fixes — an out-of-scope PR used to post its "human review"
           # verdict as a red `build`, so fix-ci churned on it and you could not see whether it compiled).
-          # Informational, NOT a required check: auto-merge's own "every changed path under TauCeti/"
-          # rule and the required bump-guard are the merge gate, so an out-of-scope PR still cannot
-          # auto-merge; a human merges it once they have seen its now-visible build.
-          if [ "${{ env.OUT_OF_SCOPE }}" = "1" ]; then
+          # Kept separate from the required GitHub checks so a human-owned infrastructure PR can be
+          # merged after review, but required green by TauCetiReview's automatic merge policy. This
+          # status is therefore a trusted, fail-closed input to every automatic merge decision.
+          if [ "${{ env.SCOPE_OK }}" != "1" ]; then
+            sc_state=failure; sc_desc="trusted scope guard did not complete — re-run pr-build"
+          elif [ "${{ env.OUT_OF_SCOPE }}" = "1" ]; then
             sc_state=failure; sc_desc="changes outside TauCeti/ — human review + merge required"
           elif [ "${{ env.BUMP_BAD }}" = "1" ]; then
             sc_state=failure; sc_desc="Lake pin/config change failed the trusted bump validator"

--- a/.github/workflows/review.yml
+++ b/.github/workflows/review.yml
@@ -79,10 +79,11 @@ jobs:
     if: ${{ vars.CI_REVIEW_ENABLED == 'true' && needs.resolve.outputs.pr != '' }}
     # Pinned to a TauCetiReview commit; bump deliberately (an unpinned @main lets an upstream change
     # break every contributor's review at once, and this workflow inherits TauCeti's secrets).
-    uses: TauCetiProject/TauCetiReview/.github/workflows/review.yml@6375e7b54f691ae805c78bf060b4d883d7b5f5e9
+    uses: TauCetiProject/TauCetiReview/.github/workflows/review.yml@eeed9637d7e2af319a04de8120b35f0c52318f0d
     with:
       pr: ${{ needs.resolve.outputs.pr }}
       trigger: ${{ github.event_name }}
+      review_ref: eeed9637d7e2af319a04de8120b35f0c52318f0d
       # Merging is handled by auto-merge.yml (the single merge path), so generation never merges.
       enable_automerge: false
     secrets: inherit

--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -8,8 +8,9 @@ name: Update Dependencies
 #     place — not for merging as-is), and close the LKG bump PR until resolved.
 # PRs and pushes use the tauceti-review-bot App token so pr-build/review trigger
 # normally. The LKG bump is de-pinned below to a manifest- and toolchain-only forward move,
-# so bump-guard validates it and it auto-merges; the first-known-bad fix PR still edits the
-# Lake config and is human-owned.
+# so bump-guard validates it and it auto-merges. A first-known-bad fix PR keeps its exact
+# lakefile pin; the author-aware bump guard validates that one bot-only config change so the
+# repair PR can merge without human intervention once its build and reviews are green.
 
 on:
   schedule:
@@ -52,17 +53,36 @@ jobs:
 
       # TauCeti tracks mathlib `master` and lets bump-guard (scripts/check-bump.sh) validate
       # each bump as a forward move and auto-merge it. bump-to-latest pins the lakefile `rev`
-      # and the manifest `inputRev` to the bumped commit; bump-guard rejects that (lakefile
-      # edits are human-owned; inputRev must stay the nominated branch) and routes it to a
-      # human. De-pin both — restore the human-owned lakefile and reset mathlib's inputRev to
-      # "master" — leaving a manifest- and toolchain-only forward move that validates and
-      # merges without a human. The manifest `rev` still carries the actual pin.
+      # and manifest `inputRev` to the bumped commit. Restore both nominations to `master` while
+      # retaining the manifest's actual SHA pin. This is normally a manifest/toolchain-only bump;
+      # after an incompatibility PR temporarily pinned the base lakefile, it also performs the
+      # trusted bot's validated one-line de-pin back to `master`.
       - name: De-pin to keep tracking master (so bump-guard can auto-merge)
         if: steps.fkb.outputs.commit == '' && steps.bump.outputs.updated == 'true'
         run: |
           set -euo pipefail
-          # Discard the bot's pinned rev in the human-owned lakefile(s); keep everything else.
-          git checkout -- lakefile.toml
+          # Restore only Mathlib's nominated rev to master. `git checkout -- lakefile.toml` is not
+          # enough when main is temporarily pinned at a first-known-bad SHA: it would restore that
+          # SHA and leave the next LKG PR unable to resume tracking master.
+          python3 - <<'PY'
+          from pathlib import Path
+          import re
+
+          path = Path("lakefile.toml")
+          parts = path.read_text().split("[[require]]")
+          changed = 0
+          for index in range(1, len(parts)):
+              if re.search(
+                      r'^[ \t]*name[ \t]*=[ \t]*"mathlib"[ \t]*$',
+                      parts[index], re.MULTILINE):
+                  parts[index], count = re.subn(
+                      r'^[ \t]*rev[ \t]*=[ \t]*"[^"]+"[ \t]*$', 'rev = "master"', parts[index],
+                      count=1, flags=re.MULTILINE)
+                  changed += count
+          if changed != 1:
+              raise SystemExit(f"expected one Mathlib rev in lakefile.toml; changed {changed}")
+          path.write_text("[[require]]".join(parts))
+          PY
           git checkout -- lakefile.lean 2>/dev/null || true
           # Reset mathlib's inputRev back to "master". It is the only 40-hex inputRev in the
           # manifest (every other dep nominates a branch/tag), so this targets mathlib alone

--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -42,14 +42,14 @@ jobs:
       # should be the fix one pinned at the first-known-bad commit.
       - name: Check whether an incompatibility is reported
         id: fkb
-        uses: leanprover-community/downstream-reports/.github/actions/query-latest@main
+        uses: leanprover-community/downstream-reports/.github/actions/query-latest@43df0aa23fd0d157988f154b9e636c2d0efe2822
         with:
           query-type: first-known-bad
 
       - name: Bump to latest mathlib
         id: bump
         if: steps.fkb.outputs.commit == ''
-        uses: leanprover-community/downstream-reports/.github/actions/bump-to-latest@main
+        uses: leanprover-community/downstream-reports/.github/actions/bump-to-latest@43df0aa23fd0d157988f154b9e636c2d0efe2822
 
       # TauCeti tracks mathlib `master` and lets bump-guard (scripts/check-bump.sh) validate
       # each bump as a forward move and auto-merge it. bump-to-latest pins the lakefile `rev`
@@ -92,7 +92,7 @@ jobs:
 
       - name: Open or update PR
         if: steps.fkb.outputs.commit == '' && steps.bump.outputs.updated == 'true'
-        uses: leanprover-community/downstream-reports/.github/actions/open-bump-pr@main
+        uses: leanprover-community/downstream-reports/.github/actions/open-bump-pr@43df0aa23fd0d157988f154b9e636c2d0efe2822
         with:
           branch: ${{ env.LKG_BRANCH }}
           title: "chore: ${{ steps.bump.outputs.pr-title }}"
@@ -121,7 +121,7 @@ jobs:
 
       - name: Open or update incompatibility issue and fix PR
         id: track
-        uses: leanprover-community/downstream-reports/.github/actions/track-incompatibility@main
+        uses: leanprover-community/downstream-reports/.github/actions/track-incompatibility@43df0aa23fd0d157988f154b9e636c2d0efe2822
         with:
           open-pr: true
           token: ${{ steps.app-token.outputs.token }}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -30,7 +30,11 @@ what new mathematics gets *added*, not whether already-merged code may be made b
   `lake-manifest.json` and `lean-toolchain` — are an exception: a **forward-only** bump of
   them (Mathlib moving forward on the branch the lakefile nominates, with the toolchain moving
   monotonically forward) is machine-validated by the `bump-guard` check and is welcome, but
-  never edit the lakefile or move a pin backward.
+  never edit the lakefile or move a pin backward. The sole automated exception is an
+  incompatibility PR opened by `tauceti-review-bot[bot]`: it may pin Mathlib's lakefile `rev`
+  to the same immutable first-known-bad SHA recorded in the manifest, and the following compatible
+  bot bump may restore that line to `master`. The trusted bump guard validates those exact one-line
+  transitions before either can build or merge.
 - **Never delete a PR's human-owned changes to get it past the build gate.** When a PR
   *intentionally* touches `scripts/`, `.github/`, or the lakefile (for example, a PR that adds
   a new CI check), those changes are the deliverable, not an obstacle. The gate routes such a
@@ -60,8 +64,10 @@ and round). Explain why both cannot hold. Show the contradiction; do not just as
 When every rubric approves on the current commit and the PR changes only `TauCeti/` (with CI
 green), it **merges automatically**. A PR that *also* changes `lake-manifest.json` and/or
 `lean-toolchain` can auto-merge too, but only once the `bump-guard` check confirms it is a
-forward-only bump and the sandboxed build passes against the new pins. A PR that touches any
-other human-owned path (`scripts/`, `.github/`, the lakefile) always needs a human review. The
+forward-only bump and the sandboxed build passes against the new pins. The exact review-bot
+first-known-bad lakefile pin described above can auto-merge under the same checks. A PR that
+touches any other human-owned path (`scripts/`, `.github/`, or any other lakefile change) always
+needs a human review. The
 review pipeline is sandboxed so it can run on untrusted PRs; see
 [`SECURITY.md`](https://github.com/TauCetiProject/TauCetiReview/blob/main/SECURITY.md) in
 TauCetiReview.

--- a/lakefile.toml
+++ b/lakefile.toml
@@ -7,9 +7,10 @@ defaultTargets = ["TauCeti"]
 # the platform-independent mapping automatically.
 platformIndependent = true
 
-# mathlib's `rev` below stays on "master", never a pinned commit. The actual revision is
-# pinned in lake-manifest.json; "master" is only the branch the daily bump moves forward
-# along, and bump-guard (scripts/check-bump.sh) requires it to validate and auto-merge a bump.
+# mathlib's `rev` below normally stays on "master"; lake-manifest.json carries the actual pin.
+# An incompatibility PR opened by tauceti-review-bot may temporarily replace it with the exact
+# first-known-bad SHA so the repair builds reproducibly. bump-guard (scripts/check-bump.sh)
+# validates that single-line exception and the next compatible LKG bump restores "master".
 [[require]]
 name = "mathlib"
 git = "https://github.com/leanprover-community/mathlib4"

--- a/scripts/check-bump.sh
+++ b/scripts/check-bump.sh
@@ -3,18 +3,23 @@
 # safe, machine-checkable *forward* bump, and nothing else.
 #
 # This is the trust anchor that lets a PR touching `lake-manifest.json` and/or
-# `lean-toolchain` (but NOT the lakefile) be built and auto-merged without a human:
+# `lean-toolchain` be built and auto-merged without a human. The sole lakefile exception is
+# `--allow-bot-lakefile`: the trusted review bot may replace Mathlib's nominated branch with the
+# immutable first-known-bad SHA (or restore that one field to `master` after the fix), provided
+# check_bot_lakefile.py proves that is the only Lake-config change and the manifest agrees.
 # the worry is a PR that re-points a dependency at a malicious fork/commit or a
 # malicious toolchain and then gets auto-built. We reduce the whole manifest to a
 # deterministic function of one validated fact — "mathlib moved forward on the
 # branch nominated in lakefile.toml" — and require the toolchain to move forward
 # and match mathlib's:
 #
-#   1. lakefile.toml / lakefile.lean are byte-identical to base (lakefile edits
-#      stay human-owned; they change which branch/dep is even nominated).
+#   1. lakefile.toml / lakefile.lean are byte-identical to base, except for the narrow validated
+#      review-bot mode above (lakefile.lean is never excepted).
 #   2. The nominated require (mathlib) is the ONLY package named "mathlib", is a
-#      `git` package pinned to a 40-hex commit SHA, keeps its url + inputRev
-#      (master), and its new rev is a *descendant of the old rev* AND *on
+#      `git` package pinned to a 40-hex commit SHA, keeps its url, and normally keeps
+#      inputRev at `master` (the bot exception may temporarily set inputRev to the exact same SHA,
+#      then restore it to `master`).
+#      Its new rev is a *descendant of the old rev* AND *on the trusted base
 #      inputRev's history* — a genuine forward move on the nominated branch (via
 #      the GitHub compare API; the SHA requirement makes the compared revs
 #      immutable, so what we validate is exactly what Lake will resolve and build).
@@ -28,7 +33,7 @@
 # It does NO build and runs NONE of the PR's code — only reads/parses two text
 # files and queries the trusted upstream via `gh api`. Usage:
 #
-#   check-bump.sh <base_dir> <merge_base_dir> <pr_dir>
+#   check-bump.sh <base_dir> <merge_base_dir> <pr_dir> [--allow-bot-lakefile]
 #
 # where each dir holds the repo's lean-toolchain, lake-manifest.json, lakefile.toml
 # (and optionally lakefile.lean). base_dir is the CURRENT target-branch tip — the
@@ -42,6 +47,9 @@ set -uo pipefail
 BASE="${1:?usage: check-bump.sh <base_dir> <merge_base_dir> <pr_dir>}"
 MERGE_BASE="${2:?usage: check-bump.sh <base_dir> <merge_base_dir> <pr_dir>}"
 PR="${3:?usage: check-bump.sh <base_dir> <merge_base_dir> <pr_dir>}"
+MODE="${4:-}"
+[ -z "$MODE" ] || [ "$MODE" = "--allow-bot-lakefile" ] \
+  || { echo "usage: check-bump.sh <base_dir> <merge_base_dir> <pr_dir> [--allow-bot-lakefile]"; exit 2; }
 
 fail() { echo "::error::bump-guard: $*"; echo "BUMP-GUARD: FAIL — $*"; exit 1; }
 ok()   { echo "BUMP-GUARD: PASS — $*"; exit 0; }
@@ -62,16 +70,27 @@ for f in lakefile.toml lakefile.lean lake-manifest.json lean-toolchain; do
 done
 [ "$pin_changed" = 0 ] && ok "no lakefile or Lake-pin change relative to the merge-base"
 
-# --- 1. lakefile is human-owned: it must not change ---------------------------
-for f in lakefile.toml lakefile.lean; do
-  b="$BASE/$f"; p="$PR/$f"
-  # Treat an absent file the same on both sides; a file appearing/vanishing is a change.
+# --- 1. lakefile is human-owned; validate the one trusted-bot exception -------
+f=lakefile.lean
+b="$BASE/$f"; p="$PR/$f"
+# Treat an absent file the same on both sides; a file appearing/vanishing is a change.
+[ -f "$b" ] || b=/dev/null
+[ -f "$p" ] || p=/dev/null
+if ! diff -q "$b" "$p" >/dev/null 2>&1; then
+  fail "$f differs from base — lakefile edits are human-owned and never auto-merge"
+fi
+if [ "$MODE" = "--allow-bot-lakefile" ]; then
+  python3 "$BASE/scripts/check_bot_lakefile.py" \
+    "$BASE/lakefile.toml" "$PR/lakefile.toml" "$PR/lake-manifest.json" \
+    || fail "review-bot lakefile pin is not the exact validated Mathlib revision change"
+else
+  b="$BASE/lakefile.toml"; p="$PR/lakefile.toml"
   [ -f "$b" ] || b=/dev/null
   [ -f "$p" ] || p=/dev/null
   if ! diff -q "$b" "$p" >/dev/null 2>&1; then
-    fail "$f differs from base — lakefile edits are human-owned and never auto-merge"
+    fail "lakefile.toml differs from base — only the trusted review bot's exact Mathlib pin may auto-merge"
   fi
-done
+fi
 
 # --- helpers ------------------------------------------------------------------
 # owner/repo slug from a github url
@@ -109,7 +128,23 @@ IFS=$'\t' read -r ML_URL_B ML_REV_B ML_IR_B <<<"$ml_base"
 IFS=$'\t' read -r ML_URL_P ML_REV_P ML_IR_P <<<"$ml_pr"
 
 [ "$ML_URL_B" = "$ML_URL_P" ] || fail "mathlib url changed ($ML_URL_B -> $ML_URL_P) — repo swap is human-owned"
-[ "$ML_IR_B"  = "$ML_IR_P"  ] || fail "mathlib inputRev (nominated branch) changed ($ML_IR_B -> $ML_IR_P) — human-owned"
+if [ "$MODE" = "--allow-bot-lakefile" ]; then
+  if [ "$ML_IR_P" = "$ML_REV_P" ]; then
+    [ "$ML_IR_B" = "master" ] \
+      || fail "an exact review-bot pin may only start from the trusted master nomination (base inputRev=$ML_IR_B)"
+    NOMINATED_BRANCH="$ML_IR_B"
+  elif [ "$ML_IR_P" = "master" ]; then
+    [ "$ML_IR_B" = "$ML_REV_B" ] \
+      || fail "review-bot de-pin to master requires an exact pinned base ($ML_IR_B != $ML_REV_B)"
+    NOMINATED_BRANCH="$ML_IR_P"
+  else
+    fail "review-bot manifest inputRev must be its exact Mathlib rev or master (got $ML_IR_P)"
+  fi
+else
+  [ "$ML_IR_B" = "$ML_IR_P" ] \
+    || fail "mathlib inputRev (nominated branch) changed ($ML_IR_B -> $ML_IR_P) — human-owned"
+  NOMINATED_BRANCH="$ML_IR_B"
+fi
 ML_SLUG="$(slug "$ML_URL_P")"
 
 # --- 2. mathlib moved forward on the nominated branch -------------------------
@@ -126,13 +161,15 @@ else
     ahead) : ;;  # new strictly descends from old — forward
     *) fail "mathlib rev is not a forward move from base (compare status: ${st_fwd:-unknown}); old=$ML_REV_B new=$ML_REV_P" ;;
   esac
-  st_branch="$(gh api "repos/$ML_SLUG/compare/$ML_REV_P...$ML_IR_P" --jq '.status' 2>/dev/null)" \
-    || fail "compare API failed for $ML_SLUG $ML_REV_P...$ML_IR_P"
+  # Membership is checked against the trusted branch: normally the base nomination; `master` from
+  # the bot PR itself only when it is undoing an exact-SHA base nomination.
+  st_branch="$(gh api "repos/$ML_SLUG/compare/$ML_REV_P...$NOMINATED_BRANCH" --jq '.status' 2>/dev/null)" \
+    || fail "compare API failed for $ML_SLUG $ML_REV_P...$NOMINATED_BRANCH"
   case "$st_branch" in
     ahead|identical) : ;;  # the nominated branch tip is at-or-ahead of new — new is on its history
-    *) fail "mathlib new rev $ML_REV_P is not on branch '$ML_IR_P' (compare status: ${st_branch:-unknown})" ;;
+    *) fail "mathlib new rev $ML_REV_P is not on branch '$NOMINATED_BRANCH' (compare status: ${st_branch:-unknown})" ;;
   esac
-  echo "bump-guard: mathlib $ML_REV_B -> $ML_REV_P is a forward move on '$ML_IR_P'."
+  echo "bump-guard: mathlib $ML_REV_B -> $ML_REV_P is a forward move on '$NOMINATED_BRANCH'."
 fi
 
 # --- 3. the rest of the manifest is EXACTLY mathlib's own manifest at the new rev
@@ -203,4 +240,4 @@ ML_TC="$(gh api "repos/$ML_SLUG/contents/lean-toolchain?ref=$ML_REV_P" --jq '.co
 [ "$TC_P" = "$ML_TC" ] || fail "PR lean-toolchain ($TC_P) != mathlib@$ML_REV_P's ($ML_TC)"
 echo "bump-guard: toolchain $TC_B -> $TC_P is forward and matches mathlib@$ML_REV_P."
 
-ok "forward-only bump validated (mathlib on '$ML_IR_P', derived transitive pins, toolchain consistent)"
+ok "forward-only bump validated (mathlib on '$NOMINATED_BRANCH', derived transitive pins, toolchain consistent)"

--- a/scripts/check_bot_lakefile.py
+++ b/scripts/check_bot_lakefile.py
@@ -6,8 +6,9 @@ the trusted base.  The incompatibility tracker is the one exception: its PR
 replaces Mathlib's nominated branch with the immutable first-known-bad SHA so the
 PR builds against the commit it is meant to repair.  Once compatible again, the
 same bot changes that line back to ``master`` while advancing the manifest pin.
-This helper proves that the single lakefile line and the corresponding manifest
-input are the only configuration changes before the trusted workflow overlays them.
+This helper proves that the sole lakefile change is Mathlib's revision and that
+Mathlib's manifest ``rev``/``inputRev`` fields agree with it.  ``check-bump.sh``
+validates the rest of the manifest and the direction of the pin transition.
 """
 
 from __future__ import annotations
@@ -25,6 +26,8 @@ REV_LINE_RE = re.compile(r'^(\s*rev\s*=\s*)"([^"]*)"(\s*(?:#.*)?(?:\n)?)$')
 
 
 class ValidationError(ValueError):
+    """Raised when a proposed review-bot lakefile pin has an invalid shape."""
+
     pass
 
 
@@ -55,6 +58,16 @@ def _single_changed_line(base_text: str, pr_text: str) -> tuple[str, str]:
 
 def validate(base_lakefile: pathlib.Path, pr_lakefile: pathlib.Path,
              pr_manifest: pathlib.Path) -> str:
+    """Validate the lakefile/Mathlib-manifest relationship for a bot pin or de-pin.
+
+    The PR must change only Mathlib's ``rev`` line, to either a 40-hex commit or
+    ``master``.  An exact pin must equal the manifest's Mathlib ``rev``, and the
+    manifest's Mathlib ``inputRev`` must always equal the proposed lakefile value.
+    Return that proposed value.  Raise ``ValidationError`` for invalid contents
+    and ``OSError`` when an input cannot be read; ``check-bump.sh`` performs the
+    remaining manifest and forward-transition validation.
+    """
+
     base_text = base_lakefile.read_text()
     pr_text = pr_lakefile.read_text()
     before, after = _single_changed_line(base_text, pr_text)

--- a/scripts/check_bot_lakefile.py
+++ b/scripts/check_bot_lakefile.py
@@ -1,0 +1,120 @@
+#!/usr/bin/env python3
+"""Validate the review bot's exact-commit Mathlib pin in lakefile.toml.
+
+The ordinary bump guard requires the Lake configuration to be byte-identical to
+the trusted base.  The incompatibility tracker is the one exception: its PR
+replaces Mathlib's nominated branch with the immutable first-known-bad SHA so the
+PR builds against the commit it is meant to repair.  Once compatible again, the
+same bot changes that line back to ``master`` while advancing the manifest pin.
+This helper proves that the single lakefile line and the corresponding manifest
+input are the only configuration changes before the trusted workflow overlays them.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import pathlib
+import re
+import sys
+import tomllib
+
+
+SHA_RE = re.compile(r"[0-9a-f]{40}")
+REV_LINE_RE = re.compile(r'^(\s*rev\s*=\s*)"([^"]*)"(\s*(?:#.*)?(?:\n)?)$')
+
+
+class ValidationError(ValueError):
+    pass
+
+
+def _load_toml(path: pathlib.Path) -> dict:
+    try:
+        return tomllib.loads(path.read_text())
+    except (OSError, tomllib.TOMLDecodeError) as exc:
+        raise ValidationError(f"cannot parse {path.name}: {exc}") from exc
+
+
+def _mathlib_require(config: dict, source: str) -> dict:
+    requires = config.get("require") or []
+    matches = [item for item in requires if item.get("name") == "mathlib"]
+    if len(matches) != 1:
+        raise ValidationError(
+            f"{source} must contain exactly one [[require]] named mathlib; found {len(matches)}")
+    return matches[0]
+
+
+def _single_changed_line(base_text: str, pr_text: str) -> tuple[str, str]:
+    base_lines = base_text.splitlines(keepends=True)
+    pr_lines = pr_text.splitlines(keepends=True)
+    changed = [(before, after) for before, after in zip(base_lines, pr_lines) if before != after]
+    if len(base_lines) != len(pr_lines) or len(changed) != 1:
+        raise ValidationError("lakefile.toml must change exactly one existing line")
+    return changed[0]
+
+
+def validate(base_lakefile: pathlib.Path, pr_lakefile: pathlib.Path,
+             pr_manifest: pathlib.Path) -> str:
+    base_text = base_lakefile.read_text()
+    pr_text = pr_lakefile.read_text()
+    before, after = _single_changed_line(base_text, pr_text)
+    before_match = REV_LINE_RE.fullmatch(before)
+    after_match = REV_LINE_RE.fullmatch(after)
+    if not before_match or not after_match:
+        raise ValidationError("the sole lakefile.toml change must be a rev = \"...\" line")
+
+    base_config = _load_toml(base_lakefile)
+    pr_config = _load_toml(pr_lakefile)
+    base_mathlib = _mathlib_require(base_config, "base lakefile.toml")
+    pr_mathlib = _mathlib_require(pr_config, "PR lakefile.toml")
+    base_rev = base_mathlib.get("rev") or ""
+    pr_rev = pr_mathlib.get("rev") or ""
+    if before_match.group(2) != base_rev or after_match.group(2) != pr_rev:
+        raise ValidationError("the changed rev line is not Mathlib's [[require]] revision")
+    if pr_rev != "master" and not SHA_RE.fullmatch(pr_rev):
+        raise ValidationError(f"PR Mathlib rev {pr_rev!r} is neither master nor a 40-hex SHA")
+
+    # Semantic backstop: after restoring only Mathlib.rev, every parsed Lake setting must match.
+    pr_mathlib["rev"] = base_rev
+    if pr_config != base_config:
+        raise ValidationError("lakefile.toml changes settings other than Mathlib's rev")
+
+    try:
+        manifest = json.loads(pr_manifest.read_text())
+    except (OSError, json.JSONDecodeError) as exc:
+        raise ValidationError(f"cannot parse {pr_manifest.name}: {exc}") from exc
+    packages = manifest.get("packages") or []
+    mathlib = [item for item in packages if item.get("name") == "mathlib"]
+    if len(mathlib) != 1:
+        raise ValidationError(
+            f"PR manifest must contain exactly one package named mathlib; found {len(mathlib)}")
+    manifest_rev = mathlib[0].get("rev") or ""
+    manifest_input = mathlib[0].get("inputRev") or ""
+    if not SHA_RE.fullmatch(manifest_rev):
+        raise ValidationError(f"manifest Mathlib rev {manifest_rev!r} is not a 40-hex SHA")
+    if pr_rev != "master" and manifest_rev != pr_rev:
+        raise ValidationError(
+            f"lakefile Mathlib rev {pr_rev} does not match manifest rev {manifest_rev}")
+    if manifest_input != pr_rev:
+        raise ValidationError(
+            f"manifest inputRev {manifest_input!r} must equal the bot's lakefile rev {pr_rev!r}")
+    return pr_rev
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("base_lakefile", type=pathlib.Path)
+    parser.add_argument("pr_lakefile", type=pathlib.Path)
+    parser.add_argument("pr_manifest", type=pathlib.Path)
+    args = parser.parse_args()
+    try:
+        rev = validate(args.base_lakefile, args.pr_lakefile, args.pr_manifest)
+    except (OSError, ValidationError) as exc:
+        print(f"bot lakefile validation failed: {exc}", file=sys.stderr)
+        return 1
+    print(f"bot lakefile validation passed: Mathlib lakefile rev set to {rev}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/pr_status/stuck_alerts.py
+++ b/scripts/pr_status/stuck_alerts.py
@@ -259,11 +259,21 @@ def detect_stale_pin():
     }]
 
 
+def is_automerge_scope(files, author):
+    """Mirror the author-aware path exception enforced by pr-build and TauCetiReview."""
+    if not files:
+        return False
+    allowed_roots = {"TauCeti.lean", "lake-manifest.json", "lean-toolchain"}
+    if author == "tauceti-review-bot[bot]":
+        allowed_roots.add("lakefile.toml")
+    return all(path.startswith("TauCeti/") or path in allowed_roots for path in files)
+
+
 def detect_stranded_prs():
     prs = gh_stream(
         f"/repos/{REPO}/pulls?state=open&base=main&per_page=100",
         jq='.[] | {number, head: .head.sha, draft, updated_at, '
-           'labels: [.labels[].name]}')
+           'author: .user.login, labels: [.labels[].name]}')
     out = []
     for pr in prs:
         if pr.get("draft"):
@@ -293,9 +303,9 @@ def detect_stranded_prs():
                          jq='.[].filename')
         if not files:
             continue
-        allowed_roots = {"TauCeti.lean", "lake-manifest.json", "lean-toolchain"}
-        touches_pin = any(f in ("lake-manifest.json", "lean-toolchain") for f in files)
-        if not all(f.startswith("TauCeti/") or f in allowed_roots for f in files):
+        touches_pin = any(
+            f in ("lake-manifest.json", "lean-toolchain", "lakefile.toml") for f in files)
+        if not is_automerge_scope(files, pr.get("author")):
             continue  # a human-owned path legitimately does not auto-merge
         if touches_pin and newest_status(head, "bump-guard")[0] != "success":
             continue

--- a/scripts/pr_status/test_stuck_alerts.py
+++ b/scripts/pr_status/test_stuck_alerts.py
@@ -101,6 +101,17 @@ class FailClosedTest(unittest.TestCase):
         self.assertTrue(z.updated[0][1].lstrip().startswith(sa.GREEN))
 
 
+class AutoMergeScopeTest(unittest.TestCase):
+    def test_lakefile_exception_is_exact_author_only(self):
+        files = ["lakefile.toml", "lake-manifest.json"]
+        self.assertTrue(sa.is_automerge_scope(files, "tauceti-review-bot[bot]"))
+        self.assertFalse(sa.is_automerge_scope(files, "someone-else"))
+
+    def test_bot_authorship_does_not_allow_other_infrastructure(self):
+        self.assertFalse(sa.is_automerge_scope(
+            ["lakefile.toml", ".github/workflows/x.yml"], "tauceti-review-bot[bot]"))
+
+
 class ReconcileTest(unittest.TestCase):
     def test_new_alert_posts_message(self):
         z = FakeZulip([])

--- a/scripts/roadmap_label.py
+++ b/scripts/roadmap_label.py
@@ -10,10 +10,10 @@ second, structured field.
 
 A PR gets exactly one label, decided in this order:
 
-1. `roadmap/none` -- the diff touches a path CI does not let an AI PR touch on its
-   own (anything outside `TauCeti/`, the root `TauCeti.lean`, and the two Lake
-   pins; the exact set the `pr-build` scope guard uses). Such a PR only merged
-   because a human overrode the check, so it is infrastructure, not roadmap work.
+1. `roadmap/none` -- the diff touches an infrastructure path (anything outside
+   `TauCeti/`, the root `TauCeti.lean`, and the two ordinary Lake pins). This also
+   covers the review bot's narrowly validated first-known-bad lakefile exception:
+   either way it is infrastructure, not roadmap work.
 2. `roadmap/<Area>` -- the body cites exactly one canonical roadmap, e.g.
    `TauCetiRoadmap/OneParameterSemigroups/README.md` or `ContourIntegration/README.md`.
    `<Area>` is the roadmap directory name, the same source of truth
@@ -72,8 +72,9 @@ UNKNOWN_COLOR = "fbca04"   # yellow: needs a citation
 
 # A PR whose files all match this is one an AI author may land without a human
 # override: `TauCeti/`, the root aggregator, and the two bump-guarded Lake pins.
-# This is the same predicate the `pr-build` scope guard applies before it decides
-# a PR is "infra" and routes it to a human (see .github/workflows/pr-build.yml).
+# The build workflow has one author-aware extension to this set: a PR opened by the
+# trusted review bot may pin Mathlib's lakefile rev to an exactly validated SHA. It
+# remains an infrastructure PR and therefore still belongs under roadmap/none here.
 _ALLOWED_PATH = re.compile(r"^(?:TauCeti/|TauCeti\.lean$|lake-manifest\.json$|lean-toolchain$)")
 
 # Titles that, by convention, rework existing material rather than add new

--- a/scripts/test_check_bot_lakefile.py
+++ b/scripts/test_check_bot_lakefile.py
@@ -1,0 +1,115 @@
+#!/usr/bin/env python3
+"""Tests for the review-bot-only lakefile pin validator."""
+
+from __future__ import annotations
+
+import json
+import pathlib
+import tempfile
+
+from check_bot_lakefile import ValidationError, validate
+
+
+OLD = "1" * 40
+NEW = "2" * 40
+BASE = '''name = "TauCeti"
+
+[[require]]
+name = "mathlib"
+git = "https://github.com/leanprover-community/mathlib4"
+rev = "master"
+
+[[lean_lib]]
+name = "TauCeti"
+'''
+
+
+def _case(pr_text: str, *, manifest_rev: str = NEW, input_rev: str = NEW):
+    tmp = tempfile.TemporaryDirectory()
+    root = pathlib.Path(tmp.name)
+    base = root / "base.toml"
+    pr = root / "pr.toml"
+    manifest = root / "lake-manifest.json"
+    base.write_text(BASE)
+    pr.write_text(pr_text)
+    manifest.write_text(json.dumps({"packages": [{
+        "name": "mathlib", "type": "git", "rev": manifest_rev, "inputRev": input_rev,
+    }]}))
+    return tmp, base, pr, manifest
+
+
+def _valid_text() -> str:
+    return BASE.replace('rev = "master"', f'rev = "{NEW}"')
+
+
+def test_accepts_the_exact_bot_pin():
+    tmp, base, pr, manifest = _case(_valid_text())
+    with tmp:
+        assert validate(base, pr, manifest) == NEW
+
+
+def test_accepts_depinning_back_to_master_with_a_forward_manifest_pin():
+    pinned_base = BASE.replace('rev = "master"', f'rev = "{OLD}"')
+    tmp, base, pr, manifest = _case(BASE, manifest_rev=NEW, input_rev="master")
+    with tmp:
+        base.write_text(pinned_base)
+        assert validate(base, pr, manifest) == "master"
+
+
+def test_rejects_any_second_lakefile_change():
+    text = _valid_text().replace('name = "TauCeti"', 'name = "Other"', 1)
+    tmp, base, pr, manifest = _case(text)
+    with tmp:
+        try:
+            validate(base, pr, manifest)
+        except ValidationError as exc:
+            assert "exactly one" in str(exc)
+        else:
+            raise AssertionError("accepted a second lakefile change")
+
+
+def test_rejects_a_branch_or_tag_instead_of_an_immutable_sha():
+    tmp, base, pr, manifest = _case(BASE.replace('rev = "master"', 'rev = "stable"'),
+                                    manifest_rev="stable", input_rev="stable")
+    with tmp:
+        try:
+            validate(base, pr, manifest)
+        except ValidationError as exc:
+            assert "neither master nor a 40-hex" in str(exc)
+        else:
+            raise AssertionError("accepted a mutable revision")
+
+
+def test_rejects_manifest_revision_mismatch():
+    tmp, base, pr, manifest = _case(_valid_text(), manifest_rev=OLD)
+    with tmp:
+        try:
+            validate(base, pr, manifest)
+        except ValidationError as exc:
+            assert "does not match manifest" in str(exc)
+        else:
+            raise AssertionError("accepted a mismatched manifest revision")
+
+
+def test_rejects_a_non_exact_manifest_input():
+    tmp, base, pr, manifest = _case(_valid_text(), input_rev="master")
+    with tmp:
+        try:
+            validate(base, pr, manifest)
+        except ValidationError as exc:
+            assert "inputRev" in str(exc)
+        else:
+            raise AssertionError("accepted a non-exact manifest inputRev")
+
+
+def run():
+    tests = [value for name, value in sorted(globals().items())
+             if name.startswith("test_") and callable(value)]
+    for test in tests:
+        test()
+        print(f"ok  {test.__name__}")
+    print(f"\n{len(tests)} passed")
+
+
+if __name__ == "__main__":
+    run()

--- a/scripts/test_check_bot_lakefile.py
+++ b/scripts/test_check_bot_lakefile.py
@@ -102,6 +102,32 @@ def test_rejects_a_non_exact_manifest_input():
             raise AssertionError("accepted a non-exact manifest inputRev")
 
 
+def test_rejects_editing_another_dependency_rev():
+    other = '''\n[[require]]\nname = "other"\ngit = "https://example.com/other"\nrev = "stable"\n'''
+    tmp, base, pr, manifest = _case(BASE + other)
+    with tmp:
+        base.write_text(BASE + other)
+        pr.write_text((BASE + other).replace('rev = "stable"', f'rev = "{NEW}"'))
+        try:
+            validate(base, pr, manifest)
+        except ValidationError as exc:
+            assert "not Mathlib" in str(exc)
+        else:
+            raise AssertionError("accepted another dependency's rev change")
+
+
+def test_rejects_adding_or_removing_a_lakefile_line():
+    for text in (_valid_text() + "# extra\n", _valid_text().replace('name = "TauCeti"\n', "", 1)):
+        tmp, base, pr, manifest = _case(text)
+        with tmp:
+            try:
+                validate(base, pr, manifest)
+            except ValidationError as exc:
+                assert "exactly one existing line" in str(exc)
+            else:
+                raise AssertionError("accepted a lakefile line addition/removal")
+
+
 def run():
     tests = [value for name, value in sorted(globals().items())
              if name.startswith("test_") and callable(value)]


### PR DESCRIPTION
## Summary

- recognize `tauceti-review-bot[bot]` as a narrow exception to the human-owned lakefile scope gate
- accept only a single Mathlib `rev` change, with exact manifest consistency and no other lakefile semantic change
- extend bump guard for forward first-known-bad pins and the subsequent return to `master`
- overlay the bot lakefile only after trusted base-side validation, then run the normal sandboxed build
- restore `master` explicitly in the daily update workflow after an exact emergency pin
- make roadmap and stuck-PR classification author-aware for the same narrow case
- document the exception in CODEOWNERS and AGENTS.md

## Why

#1215 demonstrated the gap: the trusted bot prepared a valid first-known-bad Mathlib repair, and both the sandboxed build and bump guard passed, but `scope` failed solely because the PR changed `lakefile.toml`. A human had to merge it.

That merge left main exact-pinned at `e0824fd`. The old update workflow's `git checkout -- lakefile.toml` would restore that exact base pin while changing the manifest's `inputRev` to `master`; the existing bump guard rejects that inconsistent transition. This change validates both the emergency exact pin and its forward-only return to branch tracking.

The exception is deliberately identity- and shape-bound. Any other author, additional lakefile edit, other human-owned path, non-SHA pin, manifest mismatch, backward move, or off-master revision remains blocked.

Companion merge-policy change: TauCetiProject/TauCetiReview#104. Either deployment order fails closed: old Review rejects the lakefile, while new Review requires TauCeti's trusted `scope` status.

## Validation

- `python3 scripts/test_check_bot_lakefile.py` — 6 passed
- `python3 scripts/test_roadmap_label.py` — 14/14 passed
- `python3 scripts/pr_status/test_pr_labels.py` — 32 passed
- `python3 scripts/pr_status/test_stuck_alerts.py` — 21 passed
- `python3 scripts/test_structure_nudge.py` — 11 passed
- `bash -n scripts/check-bump.sh`
- `shellcheck scripts/check-bump.sh`
- YAML parsing of changed workflows
- `git diff --check`
- replayed the full bump guard against historical #1215: `81a5d257c8… → e0824fdc1c…`, including derived manifest and Lean toolchain validation
