### PR TITLE
fix: adapt subfield degree to Mathlib API

### DIFF
--- a/TauCeti/NumberTheory/Multiquadratic/Subfield/Degree.lean
+++ b/TauCeti/NumberTheory/Multiquadratic/Subfield/Degree.lean
@@ -109,7 +109,7 @@ theorem finrank_mul_card_intermediateFieldEquivSubmodule [Finite ι] [NeZero (2 
     Polynomial.IsSplittingField.finiteDimensional _ (definingPolynomial d)
   haveI := isGalois hroot
   rw [card_intermediateFieldEquivSubmodule_ofDual hroot hindep F,
-    IntermediateField.finrank_eq_fixingSubgroup_index F,
+    IntermediateField.finrank_eq_fixingSubgroup_index (adjoin K (Set.range root)) F,
     Subgroup.index_mul_card F.fixingSubgroup]
   exact card_aut_adjoin_range hroot hindep
 


### PR DESCRIPTION
## Summary

Pass the ambient multiquadratic extension explicitly to
`IntermediateField.finrank_eq_fixingSubgroup_index`.

## Why

The Mathlib commit pinned by #1215 changed this theorem's API so the ambient extension is now an explicit first argument. The existing call supplied only the intermediate field; a stale local Mathlib olean still accepted that shape, but a clean build against `e0824fd` fails at `Subfield/Degree.lean:112`.

This is the remaining downstream repair needed to make current main build cleanly. It was exposed while validating #1230 and is kept separate because it is a source compatibility fix, not part of that infrastructure change.

## Validation

- fresh `lake exe cache get` against `e0824fd`
- `lake build TauCeti.NumberTheory.Multiquadratic.Subfield.Degree`
  - build completed successfully (2,226 jobs)
- `git diff --check`
