### PR TITLE
feat: add group-algebra class sums

### DIFF
--- a/TauCeti/RepresentationTheory/CharacterTable/ClassSum.lean
+++ b/TauCeti/RepresentationTheory/CharacterTable/ClassSum.lean
@@ -22,64 +22,58 @@ variable {k G : Type*} [Group G] [Fintype G] [DecidableEq G]
 
 section
 
-/-- The computable sum in `k[G]` of the elements in the conjugacy class `C`. -/
-def classSum [Semiring k] [DecidableEq k] (C : ConjClasses G) : MonoidAlgebra k G :=
-  match decEq (1 : k) 0 with
-  | isTrue _ =>
-      { coeff :=
-          { support := ∅
-            toFun := fun _ => 0
-            mem_support_toFun := by simp } }
-  | isFalse h =>
+/-- The sum in `k[G]` of the elements in the conjugacy class `C`. -/
+noncomputable def classSum [Semiring k] (C : ConjClasses G) : MonoidAlgebra k G := by
+  classical
+  by_cases h : Nontrivial k
+  · letI : Nontrivial k := h
+    exact
       { coeff :=
           { support := Finset.univ.filter (fun x => ConjClasses.mk x = C)
             toFun := fun x => if ConjClasses.mk x = C then 1 else 0
-            mem_support_toFun := by simp [h] } }
+            mem_support_toFun := by simp } }
+  · exact 0
 
 /-- A class sum is the sum of the basis elements in its conjugacy class. -/
-theorem classSum_eq_sum [Semiring k] [DecidableEq k] (C : ConjClasses G) :
+theorem classSum_eq_sum [Semiring k] (C : ConjClasses G) :
     classSum (k := k) C = ∑ x : C.carrier, MonoidAlgebra.of k G x := by
   classical
   by_cases hk : Nontrivial k
   · letI : Nontrivial k := hk
-    have hOne : (1 : k) ≠ 0 := one_ne_zero
-    unfold classSum
-    match decEq (1 : k) 0 with
-    | isTrue h => exact (hOne h).elim
-    | isFalse _ =>
-        have sum_apply (f : C.carrier → G →₀ k) (x : G) :
-            (∑ i, f i) x = ∑ i, f i x := by
-          change ((Finset.univ : Finset C.carrier).sum f) x =
-            (Finset.univ : Finset C.carrier).sum fun i => f i x
-          induction (Finset.univ : Finset C.carrier) using Finset.induction_on with
-          | empty => rfl
-          | insert a s ha ih => simp [ha, Finsupp.add_apply, ih]
-        ext x
-        rw [MonoidAlgebra.coeff_sum]
-        rw [sum_apply]
-        simp only [MonoidAlgebra.of_apply, MonoidAlgebra.coeff_single, Finsupp.single_apply]
-        simp only [Finsupp.coe_mk]
-        change (if ConjClasses.mk x = C then 1 else 0) =
-          ∑ i : C.carrier, if (i : G) = x then 1 else 0
-        by_cases hx : ConjClasses.mk x = C
-        · let xc : C.carrier := ⟨x, ConjClasses.mem_carrier_iff_mk_eq.mpr hx⟩
-          rw [if_pos hx]
-          rw [Finset.sum_eq_single xc]
-          · simp [xc]
-          · intro b _ hbx
-            rw [if_neg]
-            intro h
-            apply hbx
-            ext
-            simpa [xc] using h
-          · simp
-        · rw [if_neg hx]
-          symm
-          apply Finset.sum_eq_zero
-          intro c _
-          rw [if_neg]
-          intro h
-          exact hx (by rw [← h]; exact ConjClasses.mem_carrier_iff_mk_eq.mp c.property)
+    have sum_apply (f : C.carrier → G →₀ k) (x : G) :
+        (∑ i, f i) x = ∑ i, f i x := by
+      change ((Finset.univ : Finset C.carrier).sum f) x =
+        (Finset.univ : Finset C.carrier).sum fun i => f i x
+      induction (Finset.univ : Finset C.carrier) using Finset.induction_on with
+      | empty => rfl
+      | insert a s ha ih => simp [ha, Finsupp.add_apply, ih]
+    ext x
+    rw [MonoidAlgebra.coeff_sum]
+    rw [sum_apply]
+    simp only [MonoidAlgebra.of_apply, MonoidAlgebra.coeff_single, Finsupp.single_apply]
+    rw [classSum, dif_pos hk, MonoidAlgebra.coeff_ofCoeff]
+    simp only [Finsupp.coe_mk]
+    change (if ConjClasses.mk x = C then 1 else 0) =
+      ∑ i : C.carrier, if (i : G) = x then 1 else 0
+    by_cases hx : ConjClasses.mk x = C
+    · let xc : C.carrier := ⟨x, ConjClasses.mem_carrier_iff_mk_eq.mpr hx⟩
+      rw [if_pos hx]
+      rw [Finset.sum_eq_single xc]
+      · simp [xc]
+      · intro b _ hbx
+        rw [if_neg]
+        intro h
+        apply hbx
+        ext
+        simpa [xc] using h
+      · simp
+    · rw [if_neg hx]
+      symm
+      apply Finset.sum_eq_zero
+      intro c _
+      rw [if_neg]
+      intro h
+      exact hx (by rw [← h]; exact ConjClasses.mem_carrier_iff_mk_eq.mp c.property)
   · haveI : Subsingleton k := not_nontrivial_iff_subsingleton.mp hk
     exact Subsingleton.elim _ _
 
@@ -105,7 +99,7 @@ def conjugateCarrierEquiv (g : G) (C : ConjClasses G) : C.carrier ≃ C.carrier 
     simp [mul_assoc]
 
 /-- A class sum commutes with each group element in the group algebra. -/
-theorem classSum_commutes_of [Semiring k] [DecidableEq k] (C : ConjClasses G) (g : G) :
+theorem classSum_commutes_of [Semiring k] (C : ConjClasses G) (g : G) :
     classSum (k := k) C * MonoidAlgebra.of k G g =
       MonoidAlgebra.of k G g * classSum (k := k) C := by
   rw [classSum_eq_sum, Finset.sum_mul, Finset.mul_sum]
@@ -118,7 +112,7 @@ theorem classSum_commutes_of [Semiring k] [DecidableEq k] (C : ConjClasses G) (g
 end
 
 /-- Every class sum lies in the center of the group algebra. -/
-theorem classSum_mem_center [CommSemiring k] [DecidableEq k] (C : ConjClasses G) :
+theorem classSum_mem_center [CommSemiring k] (C : ConjClasses G) :
     classSum (k := k) C ∈ Subalgebra.center k (MonoidAlgebra k G) := by
   rw [Subalgebra.mem_center_iff]
   intro a

--- a/TauCeti/RepresentationTheory/CharacterTable/ClassSum.lean
+++ b/TauCeti/RepresentationTheory/CharacterTable/ClassSum.lean
@@ -22,11 +22,53 @@ variable {k G : Type*} [Group G] [Fintype G] [DecidableEq G]
 
 section
 
-variable [Semiring k]
+variable [Semiring k] [Nontrivial k]
 
 /-- The sum in `k[G]` of the elements in the conjugacy class `C`. -/
-noncomputable def classSum (C : ConjClasses G) : MonoidAlgebra k G :=
-  ∑ x : C.carrier, MonoidAlgebra.of k G x
+def classSum (C : ConjClasses G) : MonoidAlgebra k G :=
+  { coeff :=
+      { support := Finset.univ.filter (fun x => ConjClasses.mk x = C)
+        toFun := fun x => if ConjClasses.mk x = C then 1 else 0
+        mem_support_toFun := by simp } }
+
+/-- A class sum is the sum of the basis elements in its conjugacy class. -/
+theorem classSum_eq_sum (C : ConjClasses G) :
+    classSum (k := k) C = ∑ x : C.carrier, MonoidAlgebra.of k G x := by
+  have sum_apply (f : C.carrier → G →₀ k) (x : G) :
+      (∑ i, f i) x = ∑ i, f i x := by
+    classical
+    change ((Finset.univ : Finset C.carrier).sum f) x =
+      (Finset.univ : Finset C.carrier).sum fun i => f i x
+    induction (Finset.univ : Finset C.carrier) using Finset.induction_on with
+    | empty => rfl
+    | insert a s ha ih => simp [ha, Finsupp.add_apply, ih]
+  ext x
+  rw [MonoidAlgebra.coeff_sum]
+  rw [sum_apply]
+  simp only [MonoidAlgebra.of_apply, MonoidAlgebra.coeff_single, Finsupp.single_apply]
+  rw [classSum, MonoidAlgebra.coeff_ofCoeff]
+  simp only [Finsupp.coe_mk]
+  change (if ConjClasses.mk x = C then 1 else 0) =
+    ∑ i : C.carrier, if (i : G) = x then 1 else 0
+  by_cases hx : ConjClasses.mk x = C
+  · let xc : C.carrier := ⟨x, ConjClasses.mem_carrier_iff_mk_eq.mpr hx⟩
+    rw [if_pos hx]
+    rw [Finset.sum_eq_single xc]
+    · simp [xc]
+    · intro b _ hbx
+      rw [if_neg]
+      intro h
+      apply hbx
+      ext
+      simpa [xc] using h
+    · simp
+  · rw [if_neg hx]
+    symm
+    apply Finset.sum_eq_zero
+    intro c _
+    rw [if_neg]
+    intro h
+    exact hx (by rw [← h]; exact ConjClasses.mem_carrier_iff_mk_eq.mp c.property)
 
 /-- Conjugation by `g` permutes every conjugacy class. -/
 def conjugateCarrierEquiv (g : G) (C : ConjClasses G) : C.carrier ≃ C.carrier where
@@ -53,7 +95,7 @@ def conjugateCarrierEquiv (g : G) (C : ConjClasses G) : C.carrier ≃ C.carrier 
 theorem classSum_commutes_of (C : ConjClasses G) (g : G) :
     classSum (k := k) C * MonoidAlgebra.of k G g =
       MonoidAlgebra.of k G g * classSum (k := k) C := by
-  rw [classSum, Finset.sum_mul, Finset.mul_sum]
+  rw [classSum_eq_sum, Finset.sum_mul, Finset.mul_sum]
   simp_rw [← (MonoidAlgebra.of k G).map_mul]
   rw [← (conjugateCarrierEquiv g C).sum_comp fun x => MonoidAlgebra.of k G (x * g)]
   congr 1
@@ -63,7 +105,7 @@ theorem classSum_commutes_of (C : ConjClasses G) (g : G) :
 end
 
 /-- Every class sum lies in the center of the group algebra. -/
-theorem classSum_mem_center [CommSemiring k] (C : ConjClasses G) :
+theorem classSum_mem_center [CommSemiring k] [Nontrivial k] (C : ConjClasses G) :
     classSum (k := k) C ∈ Subalgebra.center k (MonoidAlgebra k G) := by
   rw [Subalgebra.mem_center_iff]
   intro a

--- a/TauCeti/RepresentationTheory/CharacterTable/ClassSum.lean
+++ b/TauCeti/RepresentationTheory/CharacterTable/ClassSum.lean
@@ -18,23 +18,23 @@ namespace TauCeti
 
 open scoped BigOperators
 
-variable {k G : Type*} [Group G] [Fintype G] [DecidableEq G]
+variable {G : Type*} [Group G] [Fintype G] [DecidableEq G]
 
 section
 
 /-- The sum in `k[G]` of the elements in the conjugacy class `C`. -/
-noncomputable def classSum [Semiring k] (C : ConjClasses G) : MonoidAlgebra k G :=
+noncomputable def classSum (k : Type*) [Semiring k] (C : ConjClasses G) : MonoidAlgebra k G :=
   ∑ x : C.carrier, MonoidAlgebra.of k G x
 
 /-- A class sum is the sum of the basis elements in its conjugacy class. -/
-theorem classSum_eq_sum [Semiring k] (C : ConjClasses G) :
-    classSum (k := k) C = ∑ x : C.carrier, MonoidAlgebra.of k G x := by
+theorem classSum_eq_sum {k : Type*} [Semiring k] (C : ConjClasses G) :
+    classSum k C = ∑ x : C.carrier, MonoidAlgebra.of k G x := by
   rfl
 
 /-- The coefficient of `g` in the class sum of `C` is `1` if `g` lies in `C`, and `0` otherwise. -/
 @[simp]
-theorem classSum_coeff [Semiring k] (C : ConjClasses G) (g : G) :
-    (classSum (k := k) C).coeff g = if ConjClasses.mk g = C then 1 else 0 := by
+theorem classSum_coeff {k : Type*} [Semiring k] (C : ConjClasses G) (g : G) :
+    (classSum k C).coeff g = if ConjClasses.mk g = C then 1 else 0 := by
   rw [classSum_eq_sum, MonoidAlgebra.coeff_sum, Finsupp.finsetSum_apply]
   simp only [MonoidAlgebra.of_apply, MonoidAlgebra.coeff_single, Finsupp.single_apply]
   by_cases hg : ConjClasses.mk g = C
@@ -78,9 +78,8 @@ theorem conjugateCarrierEquiv_apply (g : G) (C : ConjClasses G) (x : C.carrier) 
   simp [conjugateCarrierEquiv]
 
 /-- A class sum commutes with each group element in the group algebra. -/
-theorem classSum_commutes [Semiring k] (C : ConjClasses G) (g : G) :
-    classSum (k := k) C * MonoidAlgebra.of k G g =
-      MonoidAlgebra.of k G g * classSum (k := k) C := by
+theorem classSum_commutes {k : Type*} [Semiring k] (C : ConjClasses G) (g : G) :
+    classSum k C * MonoidAlgebra.of k G g = MonoidAlgebra.of k G g * classSum k C := by
   rw [classSum_eq_sum, Finset.sum_mul, Finset.mul_sum]
   simp_rw [← (MonoidAlgebra.of k G).map_mul]
   rw [← (conjugateCarrierEquiv g C).sum_comp fun x => MonoidAlgebra.of k G (x * g)]
@@ -91,12 +90,12 @@ theorem classSum_commutes [Semiring k] (C : ConjClasses G) (g : G) :
 end
 
 /-- Every class sum lies in the center of the group algebra. -/
-theorem classSum_mem_center [CommSemiring k] (C : ConjClasses G) :
-    classSum (k := k) C ∈ Subalgebra.center k (MonoidAlgebra k G) := by
+theorem classSum_mem_center (k : Type*) [CommSemiring k] (C : ConjClasses G) :
+    classSum k C ∈ Subalgebra.center k (MonoidAlgebra k G) := by
   rw [Subalgebra.mem_center_iff]
   intro a
   induction a using MonoidAlgebra.induction_on with
-  | hM g => exact (classSum_commutes (k := k) C g).symm
+  | hM g => exact (classSum_commutes C g).symm
   | hadd x y hx hy =>
     rw [mul_add, add_mul, hx, hy]
   | hsmul r x hx =>

--- a/TauCeti/RepresentationTheory/CharacterTable/ClassSum.lean
+++ b/TauCeti/RepresentationTheory/CharacterTable/ClassSum.lean
@@ -1,0 +1,67 @@
+import Mathlib.Algebra.Group.ConjFinite
+import Mathlib.Algebra.Central.Basic
+import Mathlib.Algebra.MonoidAlgebra.Basic
+
+/-!
+# Class sums in a finite group algebra
+
+This file defines the element of a group algebra obtained by summing the members of a conjugacy
+class.  It proves that every class sum is central, the first input to the class-algebra side of
+finite-group character theory.
+-/
+
+namespace TauCeti
+
+open scoped BigOperators
+
+variable {k G : Type*} [CommRing k] [Group G] [Fintype G] [DecidableEq G]
+
+/-- The sum in `k[G]` of the elements in the conjugacy class `C`. -/
+noncomputable def classSum (C : ConjClasses G) : MonoidAlgebra k G :=
+  ∑ x : C.carrier, MonoidAlgebra.of k G x
+
+/-- Conjugation by `g` permutes every conjugacy class. -/
+def conjugateCarrierEquiv (g : G) (C : ConjClasses G) : C.carrier ≃ C.carrier where
+  toFun x := ⟨g * x * g⁻¹, by
+    rw [ConjClasses.mem_carrier_iff_mk_eq]
+    have hx := ConjClasses.mem_carrier_iff_mk_eq.mp x.property
+    apply Eq.trans _ hx
+    apply ConjClasses.mk_eq_mk_iff_isConj.mpr
+    exact isConj_iff.mpr ⟨g⁻¹, by simp [mul_assoc]⟩⟩
+  invFun x := ⟨g⁻¹ * x * g, by
+    rw [ConjClasses.mem_carrier_iff_mk_eq]
+    have hx := ConjClasses.mem_carrier_iff_mk_eq.mp x.property
+    apply Eq.trans _ hx
+    apply ConjClasses.mk_eq_mk_iff_isConj.mpr
+    exact isConj_iff.mpr ⟨g, by simp [mul_assoc]⟩⟩
+  left_inv x := by
+    ext
+    simp [mul_assoc]
+  right_inv x := by
+    ext
+    simp [mul_assoc]
+
+/-- A class sum commutes with each group element in the group algebra. -/
+theorem classSum_commutes_of (C : ConjClasses G) (g : G) :
+    classSum (k := k) C * MonoidAlgebra.of k G g =
+      MonoidAlgebra.of k G g * classSum (k := k) C := by
+  rw [classSum, Finset.sum_mul, Finset.mul_sum]
+  simp_rw [← (MonoidAlgebra.of k G).map_mul]
+  rw [← (conjugateCarrierEquiv g C).sum_comp fun x => MonoidAlgebra.of k G (x * g)]
+  congr 1
+  ext x
+  simp [conjugateCarrierEquiv, mul_assoc]
+
+/-- Every class sum lies in the center of the group algebra. -/
+theorem classSum_mem_center (C : ConjClasses G) :
+    classSum (k := k) C ∈ Subalgebra.center k (MonoidAlgebra k G) := by
+  rw [Subalgebra.mem_center_iff]
+  intro a
+  induction a using MonoidAlgebra.induction_on with
+  | hM g => exact (classSum_commutes_of (k := k) C g).symm
+  | hadd x y hx hy =>
+    rw [mul_add, add_mul, hx, hy]
+  | hsmul r x hx =>
+    rw [Algebra.mul_smul_comm, Algebra.smul_mul_assoc, hx]
+
+end TauCeti

--- a/TauCeti/RepresentationTheory/CharacterTable/ClassSum.lean
+++ b/TauCeti/RepresentationTheory/CharacterTable/ClassSum.lean
@@ -1,7 +1,7 @@
 module
 
 public import Mathlib.Algebra.Group.ConjFinite
-public import Mathlib.Algebra.Central.Basic
+public import Mathlib.Algebra.Algebra.Subalgebra.Basic
 public import Mathlib.Algebra.MonoidAlgebra.Basic
 
 /-!
@@ -23,68 +23,30 @@ variable {k G : Type*} [Group G] [Fintype G] [DecidableEq G]
 section
 
 /-- The sum in `k[G]` of the elements in the conjugacy class `C`. -/
-noncomputable def classSum [Semiring k] (C : ConjClasses G) : MonoidAlgebra k G := by
-  classical
-  by_cases h : Nontrivial k
-  · letI : Nontrivial k := h
-    exact
-      { coeff :=
-          { support := Finset.univ.filter (fun x => ConjClasses.mk x = C)
-            toFun := fun x => if ConjClasses.mk x = C then 1 else 0
-            mem_support_toFun := by simp } }
-  · exact 0
-
-/-- The computable class sum, when equality of coefficients is decidable. -/
-def classSumOfDecidableEq [Semiring k] [DecidableEq k] (C : ConjClasses G) : MonoidAlgebra k G :=
-  { coeff :=
-      { support :=
-          Finset.univ.filter (fun x =>
-            (if ConjClasses.mk x = C then 1 else 0 : k) ≠ 0)
-        toFun := fun x => if ConjClasses.mk x = C then 1 else 0
-        mem_support_toFun := by simp } }
+noncomputable def classSum [Semiring k] (C : ConjClasses G) : MonoidAlgebra k G :=
+  ∑ x : C.carrier, MonoidAlgebra.of k G x
 
 /-- A class sum is the sum of the basis elements in its conjugacy class. -/
 theorem classSum_eq_sum [Semiring k] (C : ConjClasses G) :
     classSum (k := k) C = ∑ x : C.carrier, MonoidAlgebra.of k G x := by
-  classical
-  by_cases hk : Nontrivial k
-  · letI : Nontrivial k := hk
-    have sum_apply (f : C.carrier → G →₀ k) (x : G) :
-        (∑ i, f i) x = ∑ i, f i x := by
-      change ((Finset.univ : Finset C.carrier).sum f) x =
-        (Finset.univ : Finset C.carrier).sum fun i => f i x
-      induction (Finset.univ : Finset C.carrier) using Finset.induction_on with
-      | empty => rfl
-      | insert a s ha ih => simp [ha, Finsupp.add_apply, ih]
-    ext x
-    rw [MonoidAlgebra.coeff_sum]
-    rw [sum_apply]
-    simp only [MonoidAlgebra.of_apply, MonoidAlgebra.coeff_single, Finsupp.single_apply]
-    rw [classSum, dif_pos hk, MonoidAlgebra.coeff_ofCoeff]
-    simp only [Finsupp.coe_mk]
-    change (if ConjClasses.mk x = C then 1 else 0) =
-      ∑ i : C.carrier, if (i : G) = x then 1 else 0
-    by_cases hx : ConjClasses.mk x = C
-    · let xc : C.carrier := ⟨x, ConjClasses.mem_carrier_iff_mk_eq.mpr hx⟩
-      rw [if_pos hx]
-      rw [Finset.sum_eq_single xc]
-      · simp [xc]
-      · intro b _ hbx
-        rw [if_neg]
-        intro h
-        apply hbx
-        ext
-        simpa [xc] using h
-      · simp
-    · rw [if_neg hx]
-      symm
-      apply Finset.sum_eq_zero
-      intro c _
-      rw [if_neg]
-      intro h
-      exact hx (by rw [← h]; exact ConjClasses.mem_carrier_iff_mk_eq.mp c.property)
-  · haveI : Subsingleton k := not_nontrivial_iff_subsingleton.mp hk
-    exact Subsingleton.elim _ _
+  rw [classSum]
+
+/-- The coefficient of `g` in the class sum of `C` is `1` if `g` lies in `C`, and `0` otherwise. -/
+@[simp]
+theorem classSum_coeff [Semiring k] (C : ConjClasses G) (g : G) :
+    (classSum (k := k) C).coeff g = if ConjClasses.mk g = C then 1 else 0 := by
+  rw [classSum_eq_sum, MonoidAlgebra.coeff_sum, Finsupp.finsetSum_apply]
+  simp only [MonoidAlgebra.of_apply, MonoidAlgebra.coeff_single, Finsupp.single_apply]
+  by_cases hg : ConjClasses.mk g = C
+  · rw [if_pos hg,
+      Finset.sum_eq_single (⟨g, ConjClasses.mem_carrier_iff_mk_eq.mpr hg⟩ : C.carrier)]
+    · simp
+    · exact fun b _ hb => if_neg fun h => hb (Subtype.ext h)
+    · simp
+  · rw [if_neg hg]
+    refine Finset.sum_eq_zero fun c _ => if_neg fun h => hg ?_
+    rw [← h]
+    exact ConjClasses.mem_carrier_iff_mk_eq.mp c.property
 
 /-- Conjugation by `g` permutes every conjugacy class. -/
 def conjugateCarrierEquiv (g : G) (C : ConjClasses G) : C.carrier ≃ C.carrier where
@@ -107,8 +69,15 @@ def conjugateCarrierEquiv (g : G) (C : ConjClasses G) : C.carrier ≃ C.carrier 
     ext
     simp [mul_assoc]
 
+omit [Fintype G] [DecidableEq G] in
+/-- `conjugateCarrierEquiv g C` sends `x` to its conjugate `g * x * g⁻¹`. -/
+@[simp]
+theorem conjugateCarrierEquiv_apply (g : G) (C : ConjClasses G) (x : C.carrier) :
+    (conjugateCarrierEquiv g C x : G) = g * x * g⁻¹ := by
+  simp [conjugateCarrierEquiv]
+
 /-- A class sum commutes with each group element in the group algebra. -/
-theorem classSum_commutes_of [Semiring k] (C : ConjClasses G) (g : G) :
+theorem classSum_commutes [Semiring k] (C : ConjClasses G) (g : G) :
     classSum (k := k) C * MonoidAlgebra.of k G g =
       MonoidAlgebra.of k G g * classSum (k := k) C := by
   rw [classSum_eq_sum, Finset.sum_mul, Finset.mul_sum]
@@ -116,7 +85,7 @@ theorem classSum_commutes_of [Semiring k] (C : ConjClasses G) (g : G) :
   rw [← (conjugateCarrierEquiv g C).sum_comp fun x => MonoidAlgebra.of k G (x * g)]
   congr 1
   ext x
-  simp [conjugateCarrierEquiv, mul_assoc]
+  simp [mul_assoc]
 
 end
 
@@ -126,7 +95,7 @@ theorem classSum_mem_center [CommSemiring k] (C : ConjClasses G) :
   rw [Subalgebra.mem_center_iff]
   intro a
   induction a using MonoidAlgebra.induction_on with
-  | hM g => exact (classSum_commutes_of (k := k) C g).symm
+  | hM g => exact (classSum_commutes (k := k) C g).symm
   | hadd x y hx hy =>
     rw [mul_add, add_mul, hx, hy]
   | hsmul r x hx =>

--- a/TauCeti/RepresentationTheory/CharacterTable/ClassSum.lean
+++ b/TauCeti/RepresentationTheory/CharacterTable/ClassSum.lean
@@ -22,53 +22,60 @@ variable {k G : Type*} [Group G] [Fintype G] [DecidableEq G]
 
 section
 
-variable [Semiring k] [Nontrivial k]
-
 /-- The sum in `k[G]` of the elements in the conjugacy class `C`. -/
-def classSum (C : ConjClasses G) : MonoidAlgebra k G :=
-  { coeff :=
-      { support := Finset.univ.filter (fun x => ConjClasses.mk x = C)
-        toFun := fun x => if ConjClasses.mk x = C then 1 else 0
-        mem_support_toFun := by simp } }
+noncomputable def classSum [Semiring k] (C : ConjClasses G) : MonoidAlgebra k G := by
+  classical
+  by_cases h : Nontrivial k
+  · letI : Nontrivial k := h
+    exact
+      { coeff :=
+          { support := Finset.univ.filter (fun x => ConjClasses.mk x = C)
+            toFun := fun x => if ConjClasses.mk x = C then 1 else 0
+            mem_support_toFun := by simp } }
+  · exact 0
 
 /-- A class sum is the sum of the basis elements in its conjugacy class. -/
-theorem classSum_eq_sum (C : ConjClasses G) :
+theorem classSum_eq_sum [Semiring k] (C : ConjClasses G) :
     classSum (k := k) C = ∑ x : C.carrier, MonoidAlgebra.of k G x := by
-  have sum_apply (f : C.carrier → G →₀ k) (x : G) :
-      (∑ i, f i) x = ∑ i, f i x := by
-    classical
-    change ((Finset.univ : Finset C.carrier).sum f) x =
-      (Finset.univ : Finset C.carrier).sum fun i => f i x
-    induction (Finset.univ : Finset C.carrier) using Finset.induction_on with
-    | empty => rfl
-    | insert a s ha ih => simp [ha, Finsupp.add_apply, ih]
-  ext x
-  rw [MonoidAlgebra.coeff_sum]
-  rw [sum_apply]
-  simp only [MonoidAlgebra.of_apply, MonoidAlgebra.coeff_single, Finsupp.single_apply]
-  rw [classSum, MonoidAlgebra.coeff_ofCoeff]
-  simp only [Finsupp.coe_mk]
-  change (if ConjClasses.mk x = C then 1 else 0) =
-    ∑ i : C.carrier, if (i : G) = x then 1 else 0
-  by_cases hx : ConjClasses.mk x = C
-  · let xc : C.carrier := ⟨x, ConjClasses.mem_carrier_iff_mk_eq.mpr hx⟩
-    rw [if_pos hx]
-    rw [Finset.sum_eq_single xc]
-    · simp [xc]
-    · intro b _ hbx
+  classical
+  by_cases hk : Nontrivial k
+  · letI : Nontrivial k := hk
+    have sum_apply (f : C.carrier → G →₀ k) (x : G) :
+        (∑ i, f i) x = ∑ i, f i x := by
+      change ((Finset.univ : Finset C.carrier).sum f) x =
+        (Finset.univ : Finset C.carrier).sum fun i => f i x
+      induction (Finset.univ : Finset C.carrier) using Finset.induction_on with
+      | empty => rfl
+      | insert a s ha ih => simp [ha, Finsupp.add_apply, ih]
+    ext x
+    rw [MonoidAlgebra.coeff_sum]
+    rw [sum_apply]
+    simp only [MonoidAlgebra.of_apply, MonoidAlgebra.coeff_single, Finsupp.single_apply]
+    rw [classSum, dif_pos hk, MonoidAlgebra.coeff_ofCoeff]
+    simp only [Finsupp.coe_mk]
+    change (if ConjClasses.mk x = C then 1 else 0) =
+      ∑ i : C.carrier, if (i : G) = x then 1 else 0
+    by_cases hx : ConjClasses.mk x = C
+    · let xc : C.carrier := ⟨x, ConjClasses.mem_carrier_iff_mk_eq.mpr hx⟩
+      rw [if_pos hx]
+      rw [Finset.sum_eq_single xc]
+      · simp [xc]
+      · intro b _ hbx
+        rw [if_neg]
+        intro h
+        apply hbx
+        ext
+        simpa [xc] using h
+      · simp
+    · rw [if_neg hx]
+      symm
+      apply Finset.sum_eq_zero
+      intro c _
       rw [if_neg]
       intro h
-      apply hbx
-      ext
-      simpa [xc] using h
-    · simp
-  · rw [if_neg hx]
-    symm
-    apply Finset.sum_eq_zero
-    intro c _
-    rw [if_neg]
-    intro h
-    exact hx (by rw [← h]; exact ConjClasses.mem_carrier_iff_mk_eq.mp c.property)
+      exact hx (by rw [← h]; exact ConjClasses.mem_carrier_iff_mk_eq.mp c.property)
+  · haveI : Subsingleton k := not_nontrivial_iff_subsingleton.mp hk
+    exact Subsingleton.elim _ _
 
 /-- Conjugation by `g` permutes every conjugacy class. -/
 def conjugateCarrierEquiv (g : G) (C : ConjClasses G) : C.carrier ≃ C.carrier where
@@ -92,7 +99,7 @@ def conjugateCarrierEquiv (g : G) (C : ConjClasses G) : C.carrier ≃ C.carrier 
     simp [mul_assoc]
 
 /-- A class sum commutes with each group element in the group algebra. -/
-theorem classSum_commutes_of (C : ConjClasses G) (g : G) :
+theorem classSum_commutes_of [Semiring k] (C : ConjClasses G) (g : G) :
     classSum (k := k) C * MonoidAlgebra.of k G g =
       MonoidAlgebra.of k G g * classSum (k := k) C := by
   rw [classSum_eq_sum, Finset.sum_mul, Finset.mul_sum]
@@ -105,7 +112,7 @@ theorem classSum_commutes_of (C : ConjClasses G) (g : G) :
 end
 
 /-- Every class sum lies in the center of the group algebra. -/
-theorem classSum_mem_center [CommSemiring k] [Nontrivial k] (C : ConjClasses G) :
+theorem classSum_mem_center [CommSemiring k] (C : ConjClasses G) :
     classSum (k := k) C ∈ Subalgebra.center k (MonoidAlgebra k G) := by
   rw [Subalgebra.mem_center_iff]
   intro a

--- a/TauCeti/RepresentationTheory/CharacterTable/ClassSum.lean
+++ b/TauCeti/RepresentationTheory/CharacterTable/ClassSum.lean
@@ -1,6 +1,8 @@
-import Mathlib.Algebra.Group.ConjFinite
-import Mathlib.Algebra.Central.Basic
-import Mathlib.Algebra.MonoidAlgebra.Basic
+module
+
+public import Mathlib.Algebra.Group.ConjFinite
+public import Mathlib.Algebra.Central.Basic
+public import Mathlib.Algebra.MonoidAlgebra.Basic
 
 /-!
 # Class sums in a finite group algebra
@@ -9,6 +11,8 @@ This file defines the element of a group algebra obtained by summing the members
 class.  It proves that every class sum is central, the first input to the class-algebra side of
 finite-group character theory.
 -/
+
+public section
 
 namespace TauCeti
 

--- a/TauCeti/RepresentationTheory/CharacterTable/ClassSum.lean
+++ b/TauCeti/RepresentationTheory/CharacterTable/ClassSum.lean
@@ -34,6 +34,15 @@ noncomputable def classSum [Semiring k] (C : ConjClasses G) : MonoidAlgebra k G 
             mem_support_toFun := by simp } }
   · exact 0
 
+/-- The computable class sum, when equality of coefficients is decidable. -/
+def classSumOfDecidableEq [Semiring k] [DecidableEq k] (C : ConjClasses G) : MonoidAlgebra k G :=
+  { coeff :=
+      { support :=
+          Finset.univ.filter (fun x =>
+            (if ConjClasses.mk x = C then 1 else 0 : k) ≠ 0)
+        toFun := fun x => if ConjClasses.mk x = C then 1 else 0
+        mem_support_toFun := by simp } }
+
 /-- A class sum is the sum of the basis elements in its conjugacy class. -/
 theorem classSum_eq_sum [Semiring k] (C : ConjClasses G) :
     classSum (k := k) C = ∑ x : C.carrier, MonoidAlgebra.of k G x := by

--- a/TauCeti/RepresentationTheory/CharacterTable/ClassSum.lean
+++ b/TauCeti/RepresentationTheory/CharacterTable/ClassSum.lean
@@ -22,58 +22,64 @@ variable {k G : Type*} [Group G] [Fintype G] [DecidableEq G]
 
 section
 
-/-- The sum in `k[G]` of the elements in the conjugacy class `C`. -/
-noncomputable def classSum [Semiring k] (C : ConjClasses G) : MonoidAlgebra k G := by
-  classical
-  by_cases h : Nontrivial k
-  · letI : Nontrivial k := h
-    exact
+/-- The computable sum in `k[G]` of the elements in the conjugacy class `C`. -/
+def classSum [Semiring k] [DecidableEq k] (C : ConjClasses G) : MonoidAlgebra k G :=
+  match decEq (1 : k) 0 with
+  | isTrue _ =>
+      { coeff :=
+          { support := ∅
+            toFun := fun _ => 0
+            mem_support_toFun := by simp } }
+  | isFalse h =>
       { coeff :=
           { support := Finset.univ.filter (fun x => ConjClasses.mk x = C)
             toFun := fun x => if ConjClasses.mk x = C then 1 else 0
-            mem_support_toFun := by simp } }
-  · exact 0
+            mem_support_toFun := by simp [h] } }
 
 /-- A class sum is the sum of the basis elements in its conjugacy class. -/
-theorem classSum_eq_sum [Semiring k] (C : ConjClasses G) :
+theorem classSum_eq_sum [Semiring k] [DecidableEq k] (C : ConjClasses G) :
     classSum (k := k) C = ∑ x : C.carrier, MonoidAlgebra.of k G x := by
   classical
   by_cases hk : Nontrivial k
   · letI : Nontrivial k := hk
-    have sum_apply (f : C.carrier → G →₀ k) (x : G) :
-        (∑ i, f i) x = ∑ i, f i x := by
-      change ((Finset.univ : Finset C.carrier).sum f) x =
-        (Finset.univ : Finset C.carrier).sum fun i => f i x
-      induction (Finset.univ : Finset C.carrier) using Finset.induction_on with
-      | empty => rfl
-      | insert a s ha ih => simp [ha, Finsupp.add_apply, ih]
-    ext x
-    rw [MonoidAlgebra.coeff_sum]
-    rw [sum_apply]
-    simp only [MonoidAlgebra.of_apply, MonoidAlgebra.coeff_single, Finsupp.single_apply]
-    rw [classSum, dif_pos hk, MonoidAlgebra.coeff_ofCoeff]
-    simp only [Finsupp.coe_mk]
-    change (if ConjClasses.mk x = C then 1 else 0) =
-      ∑ i : C.carrier, if (i : G) = x then 1 else 0
-    by_cases hx : ConjClasses.mk x = C
-    · let xc : C.carrier := ⟨x, ConjClasses.mem_carrier_iff_mk_eq.mpr hx⟩
-      rw [if_pos hx]
-      rw [Finset.sum_eq_single xc]
-      · simp [xc]
-      · intro b _ hbx
-        rw [if_neg]
-        intro h
-        apply hbx
-        ext
-        simpa [xc] using h
-      · simp
-    · rw [if_neg hx]
-      symm
-      apply Finset.sum_eq_zero
-      intro c _
-      rw [if_neg]
-      intro h
-      exact hx (by rw [← h]; exact ConjClasses.mem_carrier_iff_mk_eq.mp c.property)
+    have hOne : (1 : k) ≠ 0 := one_ne_zero
+    unfold classSum
+    match decEq (1 : k) 0 with
+    | isTrue h => exact (hOne h).elim
+    | isFalse _ =>
+        have sum_apply (f : C.carrier → G →₀ k) (x : G) :
+            (∑ i, f i) x = ∑ i, f i x := by
+          change ((Finset.univ : Finset C.carrier).sum f) x =
+            (Finset.univ : Finset C.carrier).sum fun i => f i x
+          induction (Finset.univ : Finset C.carrier) using Finset.induction_on with
+          | empty => rfl
+          | insert a s ha ih => simp [ha, Finsupp.add_apply, ih]
+        ext x
+        rw [MonoidAlgebra.coeff_sum]
+        rw [sum_apply]
+        simp only [MonoidAlgebra.of_apply, MonoidAlgebra.coeff_single, Finsupp.single_apply]
+        simp only [Finsupp.coe_mk]
+        change (if ConjClasses.mk x = C then 1 else 0) =
+          ∑ i : C.carrier, if (i : G) = x then 1 else 0
+        by_cases hx : ConjClasses.mk x = C
+        · let xc : C.carrier := ⟨x, ConjClasses.mem_carrier_iff_mk_eq.mpr hx⟩
+          rw [if_pos hx]
+          rw [Finset.sum_eq_single xc]
+          · simp [xc]
+          · intro b _ hbx
+            rw [if_neg]
+            intro h
+            apply hbx
+            ext
+            simpa [xc] using h
+          · simp
+        · rw [if_neg hx]
+          symm
+          apply Finset.sum_eq_zero
+          intro c _
+          rw [if_neg]
+          intro h
+          exact hx (by rw [← h]; exact ConjClasses.mem_carrier_iff_mk_eq.mp c.property)
   · haveI : Subsingleton k := not_nontrivial_iff_subsingleton.mp hk
     exact Subsingleton.elim _ _
 
@@ -99,7 +105,7 @@ def conjugateCarrierEquiv (g : G) (C : ConjClasses G) : C.carrier ≃ C.carrier 
     simp [mul_assoc]
 
 /-- A class sum commutes with each group element in the group algebra. -/
-theorem classSum_commutes_of [Semiring k] (C : ConjClasses G) (g : G) :
+theorem classSum_commutes_of [Semiring k] [DecidableEq k] (C : ConjClasses G) (g : G) :
     classSum (k := k) C * MonoidAlgebra.of k G g =
       MonoidAlgebra.of k G g * classSum (k := k) C := by
   rw [classSum_eq_sum, Finset.sum_mul, Finset.mul_sum]
@@ -112,7 +118,7 @@ theorem classSum_commutes_of [Semiring k] (C : ConjClasses G) (g : G) :
 end
 
 /-- Every class sum lies in the center of the group algebra. -/
-theorem classSum_mem_center [CommSemiring k] (C : ConjClasses G) :
+theorem classSum_mem_center [CommSemiring k] [DecidableEq k] (C : ConjClasses G) :
     classSum (k := k) C ∈ Subalgebra.center k (MonoidAlgebra k G) := by
   rw [Subalgebra.mem_center_iff]
   intro a

--- a/TauCeti/RepresentationTheory/CharacterTable/ClassSum.lean
+++ b/TauCeti/RepresentationTheory/CharacterTable/ClassSum.lean
@@ -22,14 +22,16 @@ variable {k G : Type*} [Group G] [Fintype G] [DecidableEq G]
 
 section
 
-variable [Semiring k] [Nontrivial k]
+variable [Semiring k]
 
 /-- The sum in `k[G]` of the elements in the conjugacy class `C`. -/
-def classSum (C : ConjClasses G) : MonoidAlgebra k G :=
-  { coeff :=
-      { support := Finset.univ.filter (fun x => ConjClasses.mk x = C)
-        toFun := fun x => if ConjClasses.mk x = C then 1 else 0
-        mem_support_toFun := by simp } }
+noncomputable def classSum (C : ConjClasses G) : MonoidAlgebra k G :=
+  { coeff := Finsupp.onFinset (Finset.univ.filter fun x => ConjClasses.mk x = C)
+      (fun x => if ConjClasses.mk x = C then 1 else 0) (by
+        intro x hx
+        simp only [Finset.mem_filter, Finset.mem_univ, true_and]
+        by_contra h
+        simp [h] at hx) }
 
 /-- A class sum is the sum of the basis elements in its conjugacy class. -/
 theorem classSum_eq_sum (C : ConjClasses G) :
@@ -47,7 +49,7 @@ theorem classSum_eq_sum (C : ConjClasses G) :
   rw [sum_apply]
   simp only [MonoidAlgebra.of_apply, MonoidAlgebra.coeff_single, Finsupp.single_apply]
   rw [classSum, MonoidAlgebra.coeff_ofCoeff]
-  simp only [Finsupp.coe_mk]
+  simp only [Finsupp.onFinset_apply]
   change (if ConjClasses.mk x = C then 1 else 0) =
     ∑ i : C.carrier, if (i : G) = x then 1 else 0
   by_cases hx : ConjClasses.mk x = C
@@ -105,7 +107,7 @@ theorem classSum_commutes_of (C : ConjClasses G) (g : G) :
 end
 
 /-- Every class sum lies in the center of the group algebra. -/
-theorem classSum_mem_center [CommSemiring k] [Nontrivial k] (C : ConjClasses G) :
+theorem classSum_mem_center [CommSemiring k] (C : ConjClasses G) :
     classSum (k := k) C ∈ Subalgebra.center k (MonoidAlgebra k G) := by
   rw [Subalgebra.mem_center_iff]
   intro a

--- a/TauCeti/RepresentationTheory/CharacterTable/ClassSum.lean
+++ b/TauCeti/RepresentationTheory/CharacterTable/ClassSum.lean
@@ -29,7 +29,7 @@ noncomputable def classSum [Semiring k] (C : ConjClasses G) : MonoidAlgebra k G 
 /-- A class sum is the sum of the basis elements in its conjugacy class. -/
 theorem classSum_eq_sum [Semiring k] (C : ConjClasses G) :
     classSum (k := k) C = ∑ x : C.carrier, MonoidAlgebra.of k G x := by
-  rw [classSum]
+  rfl
 
 /-- The coefficient of `g` in the class sum of `C` is `1` if `g` lies in `C`, and `0` otherwise. -/
 @[simp]

--- a/TauCeti/RepresentationTheory/CharacterTable/ClassSum.lean
+++ b/TauCeti/RepresentationTheory/CharacterTable/ClassSum.lean
@@ -48,6 +48,7 @@ theorem classSum_coeff [Semiring k] (C : ConjClasses G) (g : G) :
     rw [← h]
     exact ConjClasses.mem_carrier_iff_mk_eq.mp c.property
 
+omit [Fintype G] [DecidableEq G] in
 /-- Conjugation by `g` permutes every conjugacy class. -/
 def conjugateCarrierEquiv (g : G) (C : ConjClasses G) : C.carrier ≃ C.carrier where
   toFun x := ⟨g * x * g⁻¹, by

--- a/TauCeti/RepresentationTheory/CharacterTable/ClassSum.lean
+++ b/TauCeti/RepresentationTheory/CharacterTable/ClassSum.lean
@@ -22,16 +22,14 @@ variable {k G : Type*} [Group G] [Fintype G] [DecidableEq G]
 
 section
 
-variable [Semiring k]
+variable [Semiring k] [Nontrivial k]
 
 /-- The sum in `k[G]` of the elements in the conjugacy class `C`. -/
-noncomputable def classSum (C : ConjClasses G) : MonoidAlgebra k G :=
-  { coeff := Finsupp.onFinset (Finset.univ.filter fun x => ConjClasses.mk x = C)
-      (fun x => if ConjClasses.mk x = C then 1 else 0) (by
-        intro x hx
-        simp only [Finset.mem_filter, Finset.mem_univ, true_and]
-        by_contra h
-        simp [h] at hx) }
+def classSum (C : ConjClasses G) : MonoidAlgebra k G :=
+  { coeff :=
+      { support := Finset.univ.filter (fun x => ConjClasses.mk x = C)
+        toFun := fun x => if ConjClasses.mk x = C then 1 else 0
+        mem_support_toFun := by simp } }
 
 /-- A class sum is the sum of the basis elements in its conjugacy class. -/
 theorem classSum_eq_sum (C : ConjClasses G) :
@@ -49,7 +47,7 @@ theorem classSum_eq_sum (C : ConjClasses G) :
   rw [sum_apply]
   simp only [MonoidAlgebra.of_apply, MonoidAlgebra.coeff_single, Finsupp.single_apply]
   rw [classSum, MonoidAlgebra.coeff_ofCoeff]
-  simp only [Finsupp.onFinset_apply]
+  simp only [Finsupp.coe_mk]
   change (if ConjClasses.mk x = C then 1 else 0) =
     ∑ i : C.carrier, if (i : G) = x then 1 else 0
   by_cases hx : ConjClasses.mk x = C
@@ -107,7 +105,7 @@ theorem classSum_commutes_of (C : ConjClasses G) (g : G) :
 end
 
 /-- Every class sum lies in the center of the group algebra. -/
-theorem classSum_mem_center [CommSemiring k] (C : ConjClasses G) :
+theorem classSum_mem_center [CommSemiring k] [Nontrivial k] (C : ConjClasses G) :
     classSum (k := k) C ∈ Subalgebra.center k (MonoidAlgebra k G) := by
   rw [Subalgebra.mem_center_iff]
   intro a

--- a/TauCeti/RepresentationTheory/CharacterTable/ClassSum.lean
+++ b/TauCeti/RepresentationTheory/CharacterTable/ClassSum.lean
@@ -18,7 +18,11 @@ namespace TauCeti
 
 open scoped BigOperators
 
-variable {k G : Type*} [CommRing k] [Group G] [Fintype G] [DecidableEq G]
+variable {k G : Type*} [Group G] [Fintype G] [DecidableEq G]
+
+section
+
+variable [Semiring k]
 
 /-- The sum in `k[G]` of the elements in the conjugacy class `C`. -/
 noncomputable def classSum (C : ConjClasses G) : MonoidAlgebra k G :=
@@ -56,8 +60,10 @@ theorem classSum_commutes_of (C : ConjClasses G) (g : G) :
   ext x
   simp [conjugateCarrierEquiv, mul_assoc]
 
+end
+
 /-- Every class sum lies in the center of the group algebra. -/
-theorem classSum_mem_center (C : ConjClasses G) :
+theorem classSum_mem_center [CommSemiring k] (C : ConjClasses G) :
     classSum (k := k) C ∈ Subalgebra.center k (MonoidAlgebra k G) := by
   rw [Subalgebra.mem_center_iff]
   intro a


### PR DESCRIPTION
This PR adds finite-group class sums to the group algebra, proves that conjugation permutes each class, and proves every class sum is central.

This advances `TauCetiRoadmap/RepresentationTheory/CharacterTheory/README.md`, Layer 1, item “The class sum `classSum k C : k[G]`”; its centrality is the direct starting point for the roadmap's class-sum basis of the group-algebra center and structure constants. It is the lowest-hanging unclaimed target after the open Layer 0 class-functions PR, and it is independent of that work.

Reuse Mathlib's `ConjClasses.carrier`, finite conjugacy-class instances, `MonoidAlgebra`, its basis-element induction principle, and `Subalgebra.center`; no Mathlib infrastructure is vendored and no external formalization is adapted.

Add `TauCeti/RepresentationTheory/CharacterTable/ClassSum.lean` (67 lines). `lake exe cache get` reports `No files to download` and `Already decompressed 8640 file(s)`. `lake build` reports `Build completed successfully (5415 jobs).` `lake exe axioms` reports `axioms: audited 11962 TauCeti declaration(s); all within the allowlist [propext, Classical.choice, Quot.sound].`

<!--tauceti-target:v1 {"focus":"RepresentationTheory","id":"class-sum"}-->

🤖 Prepared with Codex
