### PR TITLE
feat: add induction in stages

### DIFF
--- a/TauCeti/RepresentationTheory/Induction/Transitivity.lean
+++ b/TauCeti/RepresentationTheory/Induction/Transitivity.lean
@@ -20,10 +20,13 @@ open CategoryTheory
 
 universe u v w x
 
-variable {k : Type u} [CommRing k]
-  {G : Type v} {H : Type w} {K : Type x} [Group G] [Group H] [Group K]
+variable {k : Type u} {G : Type v} {H : Type w} {K : Type x}
 
 namespace Rep
+
+section Restriction
+
+variable [Semiring k] [Monoid G] [Monoid H] [Monoid K]
 
 /-- Restriction along two composable group homomorphisms is naturally isomorphic to restriction
 along their composite. -/
@@ -41,7 +44,7 @@ noncomputable def resFunctorCompIso (φ : G →* H) (ψ : H →* K) :
 
 /-- The forward component of `resFunctorCompIso` acts as the identity on vectors. -/
 @[simp↓]
-lemma resFunctorCompIso_hom_app (φ : G →* H) (ψ : H →* K) (A : _root_.Rep k K) (x : A.V) :
+lemma resFunctorCompIso_hom_app_apply (φ : G →* H) (ψ : H →* K) (A : _root_.Rep k K) (x : A.V) :
     ((resFunctorCompIso φ ψ).hom.app A) x = x :=
   by
     unfold resFunctorCompIso
@@ -49,11 +52,17 @@ lemma resFunctorCompIso_hom_app (φ : G →* H) (ψ : H →* K) (A : _root_.Rep 
 
 /-- The inverse component of `resFunctorCompIso` acts as the identity on vectors. -/
 @[simp↓]
-lemma resFunctorCompIso_inv_app (φ : G →* H) (ψ : H →* K) (A : _root_.Rep k K) (x : A.V) :
+lemma resFunctorCompIso_inv_app_apply (φ : G →* H) (ψ : H →* K) (A : _root_.Rep k K) (x : A.V) :
     ((resFunctorCompIso φ ψ).inv.app A) x = x :=
   by
     unfold resFunctorCompIso
     rfl
+
+end Restriction
+
+section Induction
+
+variable [CommRing k] [Group G] [Group H] [Group K]
 
 /-- Induction in stages: induction along a composite is naturally isomorphic to successive
 inductions along the two group homomorphisms. -/
@@ -77,6 +86,8 @@ lemma conjugateEquiv_indFunctorCompIso_inv (φ : G →* H) (ψ : H →* K) :
       (indFunctorCompIso φ ψ).inv =
         (resFunctorCompIso φ ψ).hom :=
   Adjunction.conjugateEquiv_leftAdjointCompIso_inv _ _ _ _
+
+end Induction
 
 end Rep
 

--- a/TauCeti/RepresentationTheory/Induction/Transitivity.lean
+++ b/TauCeti/RepresentationTheory/Induction/Transitivity.lean
@@ -1,5 +1,7 @@
-import Mathlib.CategoryTheory.Adjunction.CompositionIso
-import Mathlib.RepresentationTheory.Induced
+module
+
+public import Mathlib.CategoryTheory.Adjunction.CompositionIso
+public import Mathlib.RepresentationTheory.Induced
 
 /-!
 # Transitivity of induction
@@ -9,6 +11,8 @@ It obtains the natural isomorphism from the functoriality of restriction and Mat
 restriction adjunction.  This is the categorical core used by the subgroup form of induction in
 the induction and Mackey-theory roadmap.
 -/
+
+@[expose] public section
 
 namespace TauCeti
 

--- a/TauCeti/RepresentationTheory/Induction/Transitivity.lean
+++ b/TauCeti/RepresentationTheory/Induction/Transitivity.lean
@@ -23,14 +23,6 @@ universe u v w x
 variable {k : Type u} [CommRing k]
   {G : Type v} {H : Type w} {K : Type x} [Group G] [Group H] [Group K]
 
-/-- Restricting a representation along two composable group homomorphisms is naturally
-isomorphic to restriction along their composite. -/
-noncomputable def resFunctorCompIso (φ : G →* H) (ψ : H →* K) :
-    _root_.Rep.resFunctor.{max u v w x} (k := k) ψ ⋙
-      _root_.Rep.resFunctor.{max u v w x} φ ≅
-        _root_.Rep.resFunctor.{max u v w x} (ψ.comp φ) :=
-  Iso.refl _
-
 /-- Induction in stages: induction along a composite is naturally isomorphic to successive
 inductions along the two group homomorphisms. -/
 noncomputable def indFunctorCompIso (φ : G →* H) (ψ : H →* K) :
@@ -40,6 +32,6 @@ noncomputable def indFunctorCompIso (φ : G →* H) (ψ : H →* K) :
   Adjunction.leftAdjointCompIso (_root_.Rep.indResAdjunction.{max u v w x} k φ)
     (_root_.Rep.indResAdjunction.{max u v w x} k ψ)
     (_root_.Rep.indResAdjunction.{max u v w x} k (ψ.comp φ))
-    (resFunctorCompIso φ ψ)
+    (Iso.refl _)
 
 end TauCeti

--- a/TauCeti/RepresentationTheory/Induction/Transitivity.lean
+++ b/TauCeti/RepresentationTheory/Induction/Transitivity.lean
@@ -27,7 +27,7 @@ namespace Rep
 
 /-- Restriction along two composable group homomorphisms is naturally isomorphic to restriction
 along their composite. -/
-@[expose] noncomputable def resFunctorCompIso (φ : G →* H) (ψ : H →* K) :
+noncomputable def resFunctorCompIso (φ : G →* H) (ψ : H →* K) :
     _root_.Rep.resFunctor.{max u v w x} (k := k) ψ ⋙
       _root_.Rep.resFunctor.{max u v w x} (k := k) φ ≅
         _root_.Rep.resFunctor.{max u v w x} (k := k) (ψ.comp φ) :=

--- a/TauCeti/RepresentationTheory/Induction/Transitivity.lean
+++ b/TauCeti/RepresentationTheory/Induction/Transitivity.lean
@@ -1,0 +1,38 @@
+import Mathlib.CategoryTheory.Adjunction.CompositionIso
+import Mathlib.RepresentationTheory.Induced
+
+/-!
+# Transitivity of induction
+
+This file records induction in stages for representations along composable group homomorphisms.
+It obtains the natural isomorphism from the functoriality of restriction and Mathlib's induction--
+restriction adjunction.  This is the categorical core used by the subgroup form of induction in
+the induction and Mackey-theory roadmap.
+-/
+
+namespace TauCeti
+
+open CategoryTheory
+
+universe u v w
+
+variable {k : Type u} [CommRing k]
+  {G : Type v} {H : Type v} {K : Type v} [Group G] [Group H] [Group K]
+
+/-- Restricting a representation along two composable group homomorphisms is naturally
+isomorphic to restriction along their composite. -/
+noncomputable def resFunctorCompIso (φ : G →* H) (ψ : H →* K) :
+    _root_.Rep.resFunctor (k := k) ψ ⋙ _root_.Rep.resFunctor φ ≅
+      _root_.Rep.resFunctor (ψ.comp φ) :=
+  Iso.refl _
+
+/-- Induction in stages: induction along a composite is naturally isomorphic to successive
+inductions along the two group homomorphisms. -/
+noncomputable def indFunctorCompIso (φ : G →* H) (ψ : H →* K) :
+    _root_.Rep.indFunctor k φ ⋙ _root_.Rep.indFunctor k ψ ≅
+      _root_.Rep.indFunctor k (ψ.comp φ) :=
+  Adjunction.leftAdjointCompIso (_root_.Rep.indResAdjunction k φ)
+    (_root_.Rep.indResAdjunction k ψ) (_root_.Rep.indResAdjunction k (ψ.comp φ))
+    (resFunctorCompIso φ ψ)
+
+end TauCeti

--- a/TauCeti/RepresentationTheory/Induction/Transitivity.lean
+++ b/TauCeti/RepresentationTheory/Induction/Transitivity.lean
@@ -18,25 +18,28 @@ namespace TauCeti
 
 open CategoryTheory
 
-universe u v w
+universe u v w x
 
 variable {k : Type u} [CommRing k]
-  {G : Type v} {H : Type v} {K : Type v} [Group G] [Group H] [Group K]
+  {G : Type v} {H : Type w} {K : Type x} [Group G] [Group H] [Group K]
 
 /-- Restricting a representation along two composable group homomorphisms is naturally
 isomorphic to restriction along their composite. -/
 noncomputable def resFunctorCompIso (φ : G →* H) (ψ : H →* K) :
-    _root_.Rep.resFunctor (k := k) ψ ⋙ _root_.Rep.resFunctor φ ≅
-      _root_.Rep.resFunctor (ψ.comp φ) :=
+    _root_.Rep.resFunctor.{max u v w x} (k := k) ψ ⋙
+      _root_.Rep.resFunctor.{max u v w x} φ ≅
+        _root_.Rep.resFunctor.{max u v w x} (ψ.comp φ) :=
   Iso.refl _
 
 /-- Induction in stages: induction along a composite is naturally isomorphic to successive
 inductions along the two group homomorphisms. -/
 noncomputable def indFunctorCompIso (φ : G →* H) (ψ : H →* K) :
-    _root_.Rep.indFunctor k φ ⋙ _root_.Rep.indFunctor k ψ ≅
-      _root_.Rep.indFunctor k (ψ.comp φ) :=
-  Adjunction.leftAdjointCompIso (_root_.Rep.indResAdjunction k φ)
-    (_root_.Rep.indResAdjunction k ψ) (_root_.Rep.indResAdjunction k (ψ.comp φ))
+    _root_.Rep.indFunctor.{max u v w x} k φ ⋙
+      _root_.Rep.indFunctor.{max u v w x} k ψ ≅
+        _root_.Rep.indFunctor.{max u v w x} k (ψ.comp φ) :=
+  Adjunction.leftAdjointCompIso (_root_.Rep.indResAdjunction.{max u v w x} k φ)
+    (_root_.Rep.indResAdjunction.{max u v w x} k ψ)
+    (_root_.Rep.indResAdjunction.{max u v w x} k (ψ.comp φ))
     (resFunctorCompIso φ ψ)
 
 end TauCeti

--- a/TauCeti/RepresentationTheory/Induction/Transitivity.lean
+++ b/TauCeti/RepresentationTheory/Induction/Transitivity.lean
@@ -12,7 +12,7 @@ restriction adjunction.  This is the categorical core used by the subgroup form 
 the induction and Mackey-theory roadmap.
 -/
 
-@[expose] public section
+public section
 
 namespace TauCeti
 
@@ -23,6 +23,22 @@ universe u v w x
 variable {k : Type u} [CommRing k]
   {G : Type v} {H : Type w} {K : Type x} [Group G] [Group H] [Group K]
 
+namespace Rep
+
+/-- Restriction along two composable group homomorphisms is naturally isomorphic to restriction
+along their composite. -/
+noncomputable def resFunctorCompIso (φ : G →* H) (ψ : H →* K) :
+    _root_.Rep.resFunctor.{max u v w x} (k := k) ψ ⋙
+      _root_.Rep.resFunctor.{max u v w x} (k := k) φ ≅
+        _root_.Rep.resFunctor.{max u v w x} (k := k) (ψ.comp φ) :=
+  NatIso.ofComponents
+    (fun A ↦ _root_.Rep.mkIso <|
+      Representation.Equiv.mk (LinearEquiv.refl k A.V) fun _ ↦ by rfl)
+    (by
+      intro _ _ f
+      ext
+      rfl)
+
 /-- Induction in stages: induction along a composite is naturally isomorphic to successive
 inductions along the two group homomorphisms. -/
 noncomputable def indFunctorCompIso (φ : G →* H) (ψ : H →* K) :
@@ -32,6 +48,20 @@ noncomputable def indFunctorCompIso (φ : G →* H) (ψ : H →* K) :
   Adjunction.leftAdjointCompIso (_root_.Rep.indResAdjunction.{max u v w x} k φ)
     (_root_.Rep.indResAdjunction.{max u v w x} k ψ)
     (_root_.Rep.indResAdjunction.{max u v w x} k (ψ.comp φ))
-    (Iso.refl _)
+    (resFunctorCompIso φ ψ)
+
+/-- The induction-in-stages isomorphism is characterized by the restriction-composition
+isomorphism under the adjunction equivalence. -/
+@[simp]
+lemma conjugateEquiv_indFunctorCompIso_inv (φ : G →* H) (ψ : H →* K) :
+    conjugateEquiv
+      ((_root_.Rep.indResAdjunction.{max u v w x} k φ).comp
+        (_root_.Rep.indResAdjunction.{max u v w x} k ψ))
+      (_root_.Rep.indResAdjunction.{max u v w x} k (ψ.comp φ))
+      (indFunctorCompIso φ ψ).inv =
+        (resFunctorCompIso φ ψ).hom :=
+  Adjunction.conjugateEquiv_leftAdjointCompIso_inv _ _ _ _
+
+end Rep
 
 end TauCeti

--- a/TauCeti/RepresentationTheory/Induction/Transitivity.lean
+++ b/TauCeti/RepresentationTheory/Induction/Transitivity.lean
@@ -27,7 +27,7 @@ namespace Rep
 
 /-- Restriction along two composable group homomorphisms is naturally isomorphic to restriction
 along their composite. -/
-noncomputable def resFunctorCompIso (φ : G →* H) (ψ : H →* K) :
+@[expose] noncomputable def resFunctorCompIso (φ : G →* H) (ψ : H →* K) :
     _root_.Rep.resFunctor.{max u v w x} (k := k) ψ ⋙
       _root_.Rep.resFunctor.{max u v w x} (k := k) φ ≅
         _root_.Rep.resFunctor.{max u v w x} (k := k) (ψ.comp φ) :=
@@ -38,6 +38,22 @@ noncomputable def resFunctorCompIso (φ : G →* H) (ψ : H →* K) :
       intro _ _ f
       ext
       rfl)
+
+/-- The forward component of `resFunctorCompIso` acts as the identity on vectors. -/
+@[simp↓]
+lemma resFunctorCompIso_hom_app (φ : G →* H) (ψ : H →* K) (A : _root_.Rep k K) (x : A.V) :
+    ((resFunctorCompIso φ ψ).hom.app A) x = x :=
+  by
+    unfold resFunctorCompIso
+    rfl
+
+/-- The inverse component of `resFunctorCompIso` acts as the identity on vectors. -/
+@[simp↓]
+lemma resFunctorCompIso_inv_app (φ : G →* H) (ψ : H →* K) (A : _root_.Rep k K) (x : A.V) :
+    ((resFunctorCompIso φ ψ).inv.app A) x = x :=
+  by
+    unfold resFunctorCompIso
+    rfl
 
 /-- Induction in stages: induction along a composite is naturally isomorphic to successive
 inductions along the two group homomorphisms. -/


### PR DESCRIPTION
This PR adds the categorical induction-in-stages isomorphism for composable group homomorphisms, together with the corresponding functoriality isomorphism for restriction. It is a clean prerequisite for the representative-level formula: downstream work can now use the canonical natural isomorphism without rebuilding the adjunction comparison.

This advances `TauCetiRoadmap/RepresentationTheory/InductionRestriction/README.md`, Layer 0, item “Transitivity of induction.” It is the lowest-hanging distinct RepresentationTheory target after the active class-functions, class-sum, acyclicity, normalized-Haar, conjugate-representation, and standard-representation PRs: Mathlib already supplies induction, restriction, and their adjunction, while the roadmap identifies their composition comparison as missing.

Reuse Mathlib's `Rep.resFunctor`, `Rep.indFunctor`, `Rep.indResAdjunction`, and `Adjunction.leftAdjointCompIso`; no Mathlib infrastructure is vendored and no external formalization is adapted. Add `TauCeti/RepresentationTheory/Induction/Transitivity.lean` (38 lines).

`lake exe cache get` reports `No files to download` and `Already decompressed 8640 file(s)`. `lake build` reports `Build completed successfully (5459 jobs).` `lake exe axioms` reports `axioms: audited 11975 TauCeti declaration(s); all within the allowlist [propext, Classical.choice, Quot.sound].`

<!--tauceti-target:v1 {"focus":"RepresentationTheory","id":"induction-transitivity"}-->

🤖 Prepared with Codex
