### PR TITLE
feat(Contour): Jordan's lemma

### DIFF
--- a/TauCeti/Analysis/Contour/JordanLemma.lean
+++ b/TauCeti/Analysis/Contour/JordanLemma.lean
@@ -1,0 +1,115 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+module
+
+public import TauCeti.Analysis.SpecialFunctions.JordanIntegral
+public import Mathlib.MeasureTheory.Integral.CircleIntegral
+
+/-!
+# Jordan's lemma
+
+The contribution of a large semicircular arc to a contour integral vanishes, for integrands
+carrying an oscillatory factor `e^{iaz}` with `a > 0`:
+
+$$\left\|\int_{C_R} f(z)\,e^{iaz}\,dz\right\| \;\le\; \frac{\pi}{a}\,M_R,
+\qquad M_R = \sup_{C_R} \|f\|,$$
+
+where `C_R` is the upper semicircle of radius `R` traversed counterclockwise.
+
+The point is that this needs **no decay of `f` beyond boundedness**, whereas the naive `ML`
+estimate `‖∫‖ ≤ (πR) · M_R` would need `M_R = o(1/R)`. The gain comes from
+`|e^{iaz}| = e^{-aR\sin θ}` on the arc together with `TauCeti.integral_exp_neg_mul_sin_le`,
+whose `1/(aR)` cancels the arc length `πR`.
+
+The estimate is sharp enough for the standard application: `f z = z⁻¹` has `M_R = 1/R → 0`, so
+the arc term dies and the half-disc identity of `WorkedExamples/HalfDisc/HalfResidue.lean`
+survives the limit `R → ∞`. Note that *without* the oscillatory factor the arc term does not
+vanish at all — `∫ dz/z` over the arc is `iπ` for every `R` — so the factor is essential, not a
+convenience.
+
+## Main results
+
+* `TauCeti.Contour.norm_integral_semicircle_exp_mul_le` — Jordan's lemma as an explicit bound.
+* `TauCeti.Contour.tendsto_integral_semicircle_exp_mul_nhds_zero` — the arc contribution tends
+  to `0` along any radius filter on which the sup bound tends to `0`.
+
+## References
+
+* C. Jordan, *Cours d'analyse de l'École Polytechnique*, vol. 2 (1894), §270.
+* P. Henrici, *Applied and Computational Complex Analysis*, vol. 1, §4.8.
+-/
+
+public section
+
+noncomputable section
+
+open Real Complex intervalIntegral MeasureTheory Set Filter Topology
+
+namespace TauCeti.Contour
+
+/-- On the circle of radius `R`, the oscillatory factor has norm `e^{-aR sin θ}`. -/
+private theorem norm_exp_mul_circleMap (a R θ : ℝ) :
+    ‖Complex.exp (Complex.I * (a : ℂ) * circleMap 0 R θ)‖
+      = Real.exp (-(a * R) * Real.sin θ) := by
+  rw [Complex.norm_exp]
+  congr 1
+  simp [circleMap, Complex.mul_re, Complex.mul_im]
+  ring
+
+/-- **Jordan's lemma.** If `‖f‖ ≤ M` on the upper semicircle of radius `R > 0`, then for `a > 0`
+the arc contribution of `f z · e^{iaz}` is at most `π M / a` in norm — a bound independent of
+`R`, obtained without assuming any decay of `f`. -/
+theorem norm_integral_semicircle_exp_mul_le {f : ℂ → ℂ} {a R M : ℝ} (ha : 0 < a) (hR : 0 < R)
+    (hM : ∀ θ ∈ Icc (0 : ℝ) π, ‖f (circleMap 0 R θ)‖ ≤ M) :
+    ‖∫ θ in (0 : ℝ)..π, f (circleMap 0 R θ) *
+        Complex.exp (Complex.I * (a : ℂ) * circleMap 0 R θ) * deriv (circleMap 0 R) θ‖
+      ≤ π * M / a := by
+  have hM0 : 0 ≤ M := le_trans (norm_nonneg _) (hM 0 ⟨le_rfl, Real.pi_nonneg⟩)
+  have hbound : ∀ᵐ θ ∂volume, θ ∈ Ioc (0 : ℝ) π →
+      ‖f (circleMap 0 R θ) * Complex.exp (Complex.I * (a : ℂ) * circleMap 0 R θ) *
+          deriv (circleMap 0 R) θ‖ ≤ M * R * Real.exp (-(a * R) * Real.sin θ) := by
+    refine Filter.Eventually.of_forall fun θ hθ => ?_
+    rw [norm_mul, norm_mul, norm_exp_mul_circleMap, deriv_circleMap, norm_mul,
+      norm_circleMap_zero, Complex.norm_I, mul_one, abs_of_pos hR]
+    have h1 := hM θ ⟨hθ.1.le, hθ.2⟩
+    nlinarith [mul_nonneg (mul_nonneg (sub_nonneg.mpr h1) hR.le)
+      (Real.exp_pos (-(a * R) * Real.sin θ)).le]
+  have hintb : IntervalIntegrable
+      (fun θ => M * R * Real.exp (-(a * R) * Real.sin θ)) volume 0 π := by
+    apply Continuous.intervalIntegrable
+    fun_prop
+  calc ‖∫ θ in (0 : ℝ)..π, f (circleMap 0 R θ) *
+          Complex.exp (Complex.I * (a : ℂ) * circleMap 0 R θ) * deriv (circleMap 0 R) θ‖
+      ≤ ∫ θ in (0 : ℝ)..π, M * R * Real.exp (-(a * R) * Real.sin θ) :=
+        intervalIntegral.norm_integral_le_of_norm_le Real.pi_nonneg hbound hintb
+    _ = M * R * ∫ θ in (0 : ℝ)..π, Real.exp (-(a * R) * Real.sin θ) :=
+        intervalIntegral.integral_const_mul _ _
+    _ ≤ M * R * (π / (a * R)) :=
+        mul_le_mul_of_nonneg_left (TauCeti.integral_exp_neg_mul_sin_le (a * R) (by positivity))
+          (mul_nonneg hM0 hR.le)
+    _ = π * M / a := by field_simp
+
+/-- **The arc contribution vanishes.** Along any filter of radii on which `f` admits a sup bound
+tending to `0` — the typical case `M R = 1/R` for `f z = z⁻¹` — the semicircular arc integral of
+`f z · e^{iaz}` tends to `0`. This is the form the improper-integral limit consumes. -/
+theorem tendsto_integral_semicircle_exp_mul_nhds_zero {f : ℂ → ℂ} {a : ℝ} {l : Filter ℝ}
+    {M : ℝ → ℝ} (ha : 0 < a) (hpos : ∀ᶠ R in l, 0 < R)
+    (hM : ∀ᶠ R in l, ∀ θ ∈ Icc (0 : ℝ) π, ‖f (circleMap 0 R θ)‖ ≤ M R)
+    (hM0 : Tendsto M l (𝓝 0)) :
+    Tendsto (fun R => ∫ θ in (0 : ℝ)..π, f (circleMap 0 R θ) *
+        Complex.exp (Complex.I * (a : ℂ) * circleMap 0 R θ) * deriv (circleMap 0 R) θ)
+      l (𝓝 0) := by
+  have hb : ∀ᶠ R in l, ‖∫ θ in (0 : ℝ)..π, f (circleMap 0 R θ) *
+      Complex.exp (Complex.I * (a : ℂ) * circleMap 0 R θ) * deriv (circleMap 0 R) θ‖
+      ≤ π * M R / a := by
+    filter_upwards [hpos, hM] with R hR hMR
+    exact norm_integral_semicircle_exp_mul_le ha hR hMR
+  exact squeeze_zero_norm' hb (by simpa using (hM0.const_mul π).div_const a)
+
+end TauCeti.Contour
+
+end
+
+end

--- a/TauCeti/Analysis/Contour/JordanLemma.lean
+++ b/TauCeti/Analysis/Contour/JordanLemma.lean
@@ -36,6 +36,8 @@ convenience.
 * `TauCeti.Contour.norm_integral_semicircle_exp_mul_le` — Jordan's lemma as an explicit bound.
 * `TauCeti.Contour.tendsto_integral_semicircle_exp_mul_nhds_zero` — the arc contribution tends
   to `0` along any radius filter on which the sup bound tends to `0`.
+* `TauCeti.Contour.tendsto_integral_semicircle_exp_div_nhds_zero` — the canonical instance
+  `f z = z⁻¹`, where `M_R = 1/R`.
 
 ## References
 
@@ -114,6 +116,23 @@ theorem tendsto_integral_semicircle_exp_mul_nhds_zero {E : Type*} [NormedAddComm
     filter_upwards [hpos, hM] with R hR hMR
     exact norm_integral_semicircle_exp_mul_le ha hR hMR
   exact squeeze_zero_norm' hb (by simpa using (hM0.const_mul π).div_const a)
+
+/-- On the circle of radius `R > 0` the reciprocal is bounded by `1 / R` — the sup bound that
+makes `z⁻¹` the canonical instance of Jordan's lemma. -/
+theorem norm_inv_circleMap_le {R : ℝ} (hR : 0 < R) (θ : ℝ) : ‖(circleMap 0 R θ)⁻¹‖ ≤ 1 / R := by
+  rw [norm_inv, norm_circleMap_zero, abs_of_pos hR, one_div]
+
+/-- **The canonical instance of Jordan's lemma**: the arc contribution of `e^{iaz} / z` vanishes
+as `R → ∞`. Here `M_R = 1/R → 0`, which is precisely the regime the naive `ML` bound cannot
+reach — it would give `πR · (1/R) = π`, a constant. -/
+theorem tendsto_integral_semicircle_exp_div_nhds_zero {a : ℝ} (ha : 0 < a) :
+    Tendsto (fun R => ∫ θ in (0 : ℝ)..π, (Complex.exp (Complex.I * (a : ℂ) * circleMap 0 R θ) *
+        deriv (circleMap 0 R) θ) • (circleMap 0 R θ)⁻¹) atTop (𝓝 0) := by
+  refine tendsto_integral_semicircle_exp_mul_nhds_zero (M := fun R => 1 / R) ha ?_ ?_ ?_
+  · filter_upwards [eventually_gt_atTop (0 : ℝ)] with R hR using hR.le
+  · filter_upwards [eventually_gt_atTop (0 : ℝ)] with R hR θ _
+    exact norm_inv_circleMap_le hR θ
+  · simpa [one_div] using tendsto_inv_atTop_zero
 
 end TauCeti.Contour
 

--- a/TauCeti/Analysis/Contour/JordanLemma.lean
+++ b/TauCeti/Analysis/Contour/JordanLemma.lean
@@ -63,9 +63,15 @@ private theorem norm_exp_mul_circleMap (a R θ : ℝ) :
     zero_sub, neg_mul, neg_inj]
   ring
 
-/-- **Jordan's lemma.** If `‖f‖ ≤ M` on the upper semicircle of radius `R > 0`, then for `a > 0`
+/-- **Jordan's lemma.** If `‖f‖ ≤ M` on the upper semicircle of radius `R`, then for `a > 0`
 the arc contribution of `f z · e^{iaz}` is at most `π M / a` in norm — a bound independent of
-`R`, obtained without assuming any decay of `f`. -/
+`R`, obtained without assuming any decay of `f`.
+
+No integrability hypothesis is imposed on the integrand, matching the Mathlib norm-of-integral
+idiom (`intervalIntegral.norm_integral_le_of_norm_le` constrains only the dominating function).
+When the parameterized integrand fails to be integrable the interval integral totalizes to `0`
+and the bound reads `0 ≤ π M / a`, which holds since `0 ≤ M`; the content of the lemma is
+therefore unchanged, and callers are not obliged to discharge integrability. -/
 theorem norm_integral_semicircle_exp_mul_le {E : Type*} [NormedAddCommGroup E] [NormedSpace ℂ E]
     {f : ℂ → E} {a R M : ℝ} (ha : 0 < a) (hR : 0 ≤ R)
     (hM : ∀ θ ∈ Icc (0 : ℝ) π, ‖f (circleMap 0 R θ)‖ ≤ M) :
@@ -104,7 +110,10 @@ theorem norm_integral_semicircle_exp_mul_le {E : Type*} [NormedAddCommGroup E] [
 
 /-- **The arc contribution vanishes.** Along any filter of radii on which `f` admits a sup bound
 tending to `0` — the typical case `M R = 1/R` for `f z = z⁻¹` — the semicircular arc integral of
-`f z · e^{iaz}` tends to `0`. This is the form the improper-integral limit consumes. -/
+`f z · e^{iaz}` tends to `0`. This is the form the improper-integral limit consumes.
+
+As with the estimate it specialises, no integrability hypothesis is imposed; see
+`norm_integral_semicircle_exp_mul_le` for why the degenerate case is harmless. -/
 theorem tendsto_integral_semicircle_exp_mul_nhds_zero {E : Type*} [NormedAddCommGroup E]
     [NormedSpace ℂ E] {f : ℂ → E} {a : ℝ} {l : Filter ℝ}
     {M : ℝ → ℝ} (ha : 0 < a) (hpos : ∀ᶠ R in l, 0 ≤ R)

--- a/TauCeti/Analysis/Contour/JordanLemma.lean
+++ b/TauCeti/Analysis/Contour/JordanLemma.lean
@@ -64,22 +64,23 @@ private theorem norm_exp_mul_circleMap (a R θ : ℝ) :
 /-- **Jordan's lemma.** If `‖f‖ ≤ M` on the upper semicircle of radius `R > 0`, then for `a > 0`
 the arc contribution of `f z · e^{iaz}` is at most `π M / a` in norm — a bound independent of
 `R`, obtained without assuming any decay of `f`. -/
-theorem norm_integral_semicircle_exp_mul_le {f : ℂ → ℂ} {a R M : ℝ} (ha : 0 < a) (hR : 0 ≤ R)
+theorem norm_integral_semicircle_exp_mul_le {E : Type*} [NormedAddCommGroup E] [NormedSpace ℂ E]
+    {f : ℂ → E} {a R M : ℝ} (ha : 0 < a) (hR : 0 ≤ R)
     (hM : ∀ θ ∈ Icc (0 : ℝ) π, ‖f (circleMap 0 R θ)‖ ≤ M) :
-    ‖∫ θ in (0 : ℝ)..π, f (circleMap 0 R θ) *
-        Complex.exp (Complex.I * (a : ℂ) * circleMap 0 R θ) * deriv (circleMap 0 R) θ‖
-      ≤ π * M / a := by
+    ‖∫ θ in (0 : ℝ)..π, (Complex.exp (Complex.I * (a : ℂ) * circleMap 0 R θ) *
+        deriv (circleMap 0 R) θ) • f (circleMap 0 R θ)‖ ≤ π * M / a := by
   have hM0 : 0 ≤ M := le_trans (norm_nonneg _) (hM 0 ⟨le_rfl, Real.pi_nonneg⟩)
   rcases hR.eq_or_lt with rfl | hR
   · -- Degenerate radius: the arc is a point, `deriv (circleMap 0 0) = 0`, so the integral is `0`.
     have hderiv : ∀ θ : ℝ, deriv (circleMap 0 0) θ = 0 := by simp [circleMap_zero_radius]
-    simp only [hderiv, mul_zero, intervalIntegral.integral_zero, norm_zero]
+    simp only [hderiv, mul_zero, zero_smul, intervalIntegral.integral_zero, norm_zero]
     exact div_nonneg (mul_nonneg Real.pi_nonneg hM0) ha.le
   have hbound : ∀ᵐ θ ∂volume, θ ∈ Ioc (0 : ℝ) π →
-      ‖f (circleMap 0 R θ) * Complex.exp (Complex.I * (a : ℂ) * circleMap 0 R θ) *
-          deriv (circleMap 0 R) θ‖ ≤ M * R * Real.exp (-(a * R) * Real.sin θ) := by
+      ‖(Complex.exp (Complex.I * (a : ℂ) * circleMap 0 R θ) *
+          deriv (circleMap 0 R) θ) • f (circleMap 0 R θ)‖
+        ≤ M * R * Real.exp (-(a * R) * Real.sin θ) := by
     refine Filter.Eventually.of_forall fun θ hθ => ?_
-    rw [norm_mul, norm_mul, norm_exp_mul_circleMap, deriv_circleMap, norm_mul,
+    rw [norm_smul, norm_mul, norm_exp_mul_circleMap, deriv_circleMap, norm_mul,
       norm_circleMap_zero, Complex.norm_I, mul_one, abs_of_pos hR]
     have h1 := hM θ ⟨hθ.1.le, hθ.2⟩
     nlinarith [mul_nonneg (mul_nonneg (sub_nonneg.mpr h1) hR.le)
@@ -88,8 +89,8 @@ theorem norm_integral_semicircle_exp_mul_le {f : ℂ → ℂ} {a R M : ℝ} (ha 
       (fun θ => M * R * Real.exp (-(a * R) * Real.sin θ)) volume 0 π := by
     apply Continuous.intervalIntegrable
     fun_prop
-  calc ‖∫ θ in (0 : ℝ)..π, f (circleMap 0 R θ) *
-          Complex.exp (Complex.I * (a : ℂ) * circleMap 0 R θ) * deriv (circleMap 0 R) θ‖
+  calc ‖∫ θ in (0 : ℝ)..π, (Complex.exp (Complex.I * (a : ℂ) * circleMap 0 R θ) *
+          deriv (circleMap 0 R) θ) • f (circleMap 0 R θ)‖
       ≤ ∫ θ in (0 : ℝ)..π, M * R * Real.exp (-(a * R) * Real.sin θ) :=
         intervalIntegral.norm_integral_le_of_norm_le Real.pi_nonneg hbound hintb
     _ = M * R * ∫ θ in (0 : ℝ)..π, Real.exp (-(a * R) * Real.sin θ) :=
@@ -102,14 +103,14 @@ theorem norm_integral_semicircle_exp_mul_le {f : ℂ → ℂ} {a R M : ℝ} (ha 
 /-- **The arc contribution vanishes.** Along any filter of radii on which `f` admits a sup bound
 tending to `0` — the typical case `M R = 1/R` for `f z = z⁻¹` — the semicircular arc integral of
 `f z · e^{iaz}` tends to `0`. This is the form the improper-integral limit consumes. -/
-theorem tendsto_integral_semicircle_exp_mul_nhds_zero {f : ℂ → ℂ} {a : ℝ} {l : Filter ℝ}
+theorem tendsto_integral_semicircle_exp_mul_nhds_zero {E : Type*} [NormedAddCommGroup E]
+    [NormedSpace ℂ E] {f : ℂ → E} {a : ℝ} {l : Filter ℝ}
     {M : ℝ → ℝ} (ha : 0 < a) (hpos : ∀ᶠ R in l, 0 ≤ R)
     (hM : ∀ᶠ R in l, ∀ θ ∈ Icc (0 : ℝ) π, ‖f (circleMap 0 R θ)‖ ≤ M R) (hM0 : Tendsto M l (𝓝 0)) :
-    Tendsto (fun R => ∫ θ in (0 : ℝ)..π, f (circleMap 0 R θ) *
-        Complex.exp (Complex.I * (a : ℂ) * circleMap 0 R θ) * deriv (circleMap 0 R) θ) l (𝓝 0) := by
-  have hb : ∀ᶠ R in l, ‖∫ θ in (0 : ℝ)..π, f (circleMap 0 R θ) *
-      Complex.exp (Complex.I * (a : ℂ) * circleMap 0 R θ) * deriv (circleMap 0 R) θ‖
-      ≤ π * M R / a := by
+    Tendsto (fun R => ∫ θ in (0 : ℝ)..π, (Complex.exp (Complex.I * (a : ℂ) * circleMap 0 R θ) *
+        deriv (circleMap 0 R) θ) • f (circleMap 0 R θ)) l (𝓝 0) := by
+  have hb : ∀ᶠ R in l, ‖∫ θ in (0 : ℝ)..π, (Complex.exp (Complex.I * (a : ℂ) *
+      circleMap 0 R θ) * deriv (circleMap 0 R) θ) • f (circleMap 0 R θ)‖ ≤ π * M R / a := by
     filter_upwards [hpos, hM] with R hR hMR
     exact norm_integral_semicircle_exp_mul_le ha hR hMR
   exact squeeze_zero_norm' hb (by simpa using (hM0.const_mul π).div_const a)

--- a/TauCeti/Analysis/Contour/JordanLemma.lean
+++ b/TauCeti/Analysis/Contour/JordanLemma.lean
@@ -10,16 +10,18 @@ public import Mathlib.MeasureTheory.Integral.CircleIntegral
 /-!
 # Jordan's lemma
 
-The contribution of a large semicircular arc to a contour integral vanishes, for integrands
-carrying an oscillatory factor `e^{iaz}` with `a > 0`:
+A large semicircular arc contributes little to a contour integral whose integrand carries an
+oscillatory factor `e^{iaz}` with `a > 0`:
 
 $$\left\|\int_{C_R} f(z)\,e^{iaz}\,dz\right\| \;\le\; \frac{\pi}{a}\,M_R,
 \qquad M_R = \sup_{C_R} \|f\|,$$
 
 where `C_R` is the upper semicircle of radius `R` traversed counterclockwise.
 
-The point is that this needs **no decay of `f` beyond boundedness**, whereas the naive `ML`
-estimate `‖∫‖ ≤ (πR) · M_R` would need `M_R = o(1/R)`. The gain comes from
+The point is that the **estimate** needs no decay of `f` beyond boundedness, whereas the naive
+`ML` estimate `‖∫‖ ≤ (πR) · M_R` would need `M_R = o(1/R)` even to stay bounded. Concluding that
+the arc contribution actually **vanishes** is a further step, and does require `M_R → 0` — that
+is the hypothesis of `tendsto_integral_semicircle_exp_mul_nhds_zero`. The gain comes from
 `|e^{iaz}| = e^{-aR\sin θ}` on the arc together with `TauCeti.integral_exp_neg_mul_sin_le`,
 whose `1/(aR)` cancels the arc length `πR`.
 
@@ -45,28 +47,34 @@ public section
 
 noncomputable section
 
-open Real Complex intervalIntegral MeasureTheory Set Filter Topology
+open Real Complex MeasureTheory Set Filter Topology
 
 namespace TauCeti.Contour
 
 /-- On the circle of radius `R`, the oscillatory factor has norm `e^{-aR sin θ}`. -/
 private theorem norm_exp_mul_circleMap (a R θ : ℝ) :
-    ‖Complex.exp (Complex.I * (a : ℂ) * circleMap 0 R θ)‖
-      = Real.exp (-(a * R) * Real.sin θ) := by
+    ‖Complex.exp (Complex.I * (a : ℂ) * circleMap 0 R θ)‖ = Real.exp (-(a * R) * Real.sin θ) := by
   rw [Complex.norm_exp]
   congr 1
-  simp [circleMap, Complex.mul_re, Complex.mul_im]
+  simp only [circleMap, zero_add, mul_re, I_re, ofReal_re, zero_mul, I_im, ofReal_im, mul_zero,
+    sub_self, exp_ofReal_mul_I_re, exp_ofReal_mul_I_im, sub_zero, mul_im, one_mul, add_zero,
+    zero_sub, neg_mul, neg_inj]
   ring
 
 /-- **Jordan's lemma.** If `‖f‖ ≤ M` on the upper semicircle of radius `R > 0`, then for `a > 0`
 the arc contribution of `f z · e^{iaz}` is at most `π M / a` in norm — a bound independent of
 `R`, obtained without assuming any decay of `f`. -/
-theorem norm_integral_semicircle_exp_mul_le {f : ℂ → ℂ} {a R M : ℝ} (ha : 0 < a) (hR : 0 < R)
+theorem norm_integral_semicircle_exp_mul_le {f : ℂ → ℂ} {a R M : ℝ} (ha : 0 < a) (hR : 0 ≤ R)
     (hM : ∀ θ ∈ Icc (0 : ℝ) π, ‖f (circleMap 0 R θ)‖ ≤ M) :
     ‖∫ θ in (0 : ℝ)..π, f (circleMap 0 R θ) *
         Complex.exp (Complex.I * (a : ℂ) * circleMap 0 R θ) * deriv (circleMap 0 R) θ‖
       ≤ π * M / a := by
   have hM0 : 0 ≤ M := le_trans (norm_nonneg _) (hM 0 ⟨le_rfl, Real.pi_nonneg⟩)
+  rcases hR.eq_or_lt with rfl | hR
+  · -- Degenerate radius: the arc is a point, `deriv (circleMap 0 0) = 0`, so the integral is `0`.
+    have hderiv : ∀ θ : ℝ, deriv (circleMap 0 0) θ = 0 := by simp [circleMap_zero_radius]
+    simp only [hderiv, mul_zero, intervalIntegral.integral_zero, norm_zero]
+    exact div_nonneg (mul_nonneg Real.pi_nonneg hM0) ha.le
   have hbound : ∀ᵐ θ ∂volume, θ ∈ Ioc (0 : ℝ) π →
       ‖f (circleMap 0 R θ) * Complex.exp (Complex.I * (a : ℂ) * circleMap 0 R θ) *
           deriv (circleMap 0 R) θ‖ ≤ M * R * Real.exp (-(a * R) * Real.sin θ) := by
@@ -95,12 +103,10 @@ theorem norm_integral_semicircle_exp_mul_le {f : ℂ → ℂ} {a R M : ℝ} (ha 
 tending to `0` — the typical case `M R = 1/R` for `f z = z⁻¹` — the semicircular arc integral of
 `f z · e^{iaz}` tends to `0`. This is the form the improper-integral limit consumes. -/
 theorem tendsto_integral_semicircle_exp_mul_nhds_zero {f : ℂ → ℂ} {a : ℝ} {l : Filter ℝ}
-    {M : ℝ → ℝ} (ha : 0 < a) (hpos : ∀ᶠ R in l, 0 < R)
-    (hM : ∀ᶠ R in l, ∀ θ ∈ Icc (0 : ℝ) π, ‖f (circleMap 0 R θ)‖ ≤ M R)
-    (hM0 : Tendsto M l (𝓝 0)) :
+    {M : ℝ → ℝ} (ha : 0 < a) (hpos : ∀ᶠ R in l, 0 ≤ R)
+    (hM : ∀ᶠ R in l, ∀ θ ∈ Icc (0 : ℝ) π, ‖f (circleMap 0 R θ)‖ ≤ M R) (hM0 : Tendsto M l (𝓝 0)) :
     Tendsto (fun R => ∫ θ in (0 : ℝ)..π, f (circleMap 0 R θ) *
-        Complex.exp (Complex.I * (a : ℂ) * circleMap 0 R θ) * deriv (circleMap 0 R) θ)
-      l (𝓝 0) := by
+        Complex.exp (Complex.I * (a : ℂ) * circleMap 0 R θ) * deriv (circleMap 0 R) θ) l (𝓝 0) := by
   have hb : ∀ᶠ R in l, ‖∫ θ in (0 : ℝ)..π, f (circleMap 0 R θ) *
       Complex.exp (Complex.I * (a : ℂ) * circleMap 0 R θ) * deriv (circleMap 0 R) θ‖
       ≤ π * M R / a := by

--- a/TauCeti/Analysis/Contour/JordanLemma.lean
+++ b/TauCeti/Analysis/Contour/JordanLemma.lean
@@ -36,8 +36,8 @@ convenience.
 * `TauCeti.Contour.norm_integral_semicircle_exp_mul_le` — Jordan's lemma as an explicit bound.
 * `TauCeti.Contour.tendsto_integral_semicircle_exp_mul_nhds_zero` — the arc contribution tends
   to `0` along any radius filter on which the sup bound tends to `0`.
-* `TauCeti.Contour.tendsto_integral_semicircle_exp_div_nhds_zero` — the canonical instance
-  `f z = z⁻¹`, where `M_R = 1/R`.
+* `TauCeti.Contour.tendsto_integral_semicircle_exp_div_atTop_nhds_zero` — the canonical
+  instance `f z = z⁻¹`, where `M_R = 1/R`.
 
 ## References
 
@@ -56,11 +56,10 @@ namespace TauCeti.Contour
 /-- On the circle of radius `R`, the oscillatory factor has norm `e^{-aR sin θ}`. -/
 private theorem norm_exp_mul_circleMap (a R θ : ℝ) :
     ‖Complex.exp (Complex.I * (a : ℂ) * circleMap 0 R θ)‖ = Real.exp (-(a * R) * Real.sin θ) := by
-  rw [Complex.norm_exp]
+  have hre : (Complex.I * (a : ℂ) * circleMap 0 R θ).re = -(a * (circleMap 0 R θ).im) := by
+    simp [Complex.mul_re, Complex.mul_im]
+  rw [Complex.norm_exp, hre, circleMap_zero_im]
   congr 1
-  simp only [circleMap, zero_add, mul_re, I_re, ofReal_re, zero_mul, I_im, ofReal_im, mul_zero,
-    sub_self, exp_ofReal_mul_I_re, exp_ofReal_mul_I_im, sub_zero, mul_im, one_mul, add_zero,
-    zero_sub, neg_mul, neg_inj]
   ring
 
 /-- **Jordan's lemma.** If `‖f‖ ≤ M` on the upper semicircle of radius `R`, then for `a > 0`
@@ -126,21 +125,16 @@ theorem tendsto_integral_semicircle_exp_mul_nhds_zero {E : Type*} [NormedAddComm
     exact norm_integral_semicircle_exp_mul_le ha hR hMR
   exact squeeze_zero_norm' hb (by simpa using (hM0.const_mul π).div_const a)
 
-/-- On the circle of radius `R > 0` the reciprocal is bounded by `1 / R` — the sup bound that
-makes `z⁻¹` the canonical instance of Jordan's lemma. -/
-theorem norm_inv_circleMap_le {R : ℝ} (hR : 0 < R) (θ : ℝ) : ‖(circleMap 0 R θ)⁻¹‖ ≤ 1 / R := by
-  rw [norm_inv, norm_circleMap_zero, abs_of_pos hR, one_div]
-
 /-- **The canonical instance of Jordan's lemma**: the arc contribution of `e^{iaz} / z` vanishes
 as `R → ∞`. Here `M_R = 1/R → 0`, which is precisely the regime the naive `ML` bound cannot
 reach — it would give `πR · (1/R) = π`, a constant. -/
-theorem tendsto_integral_semicircle_exp_div_nhds_zero {a : ℝ} (ha : 0 < a) :
+theorem tendsto_integral_semicircle_exp_div_atTop_nhds_zero {a : ℝ} (ha : 0 < a) :
     Tendsto (fun R => ∫ θ in (0 : ℝ)..π, (Complex.exp (Complex.I * (a : ℂ) * circleMap 0 R θ) *
         deriv (circleMap 0 R) θ) • (circleMap 0 R θ)⁻¹) atTop (𝓝 0) := by
   refine tendsto_integral_semicircle_exp_mul_nhds_zero (M := fun R => 1 / R) ha ?_ ?_ ?_
   · filter_upwards [eventually_gt_atTop (0 : ℝ)] with R hR using hR.le
   · filter_upwards [eventually_gt_atTop (0 : ℝ)] with R hR θ _
-    exact norm_inv_circleMap_le hR θ
+    simp [norm_inv, norm_circleMap_zero, abs_of_pos hR]
   · simpa [one_div] using tendsto_inv_atTop_zero
 
 end TauCeti.Contour

--- a/TauCeti/Analysis/SpecialFunctions/JordanIntegral.lean
+++ b/TauCeti/Analysis/SpecialFunctions/JordanIntegral.lean
@@ -20,16 +20,14 @@ estimate on the whole interval; what makes it work is **Jordan's inequality**
 `sin θ ≥ (2/π) θ` on `[0, π/2]` (Mathlib's `Real.mul_le_sin`), which forces enough decay near
 the endpoint to make the whole integral `O(1/c)`.
 
-That `1/c` is exactly what cancels the length of a semicircular arc of radius `c` when this is
-applied to `|e^{iaz}| = e^{-aR\sin\theta}`, and it is why Jordan's lemma beats the naive
-`ML` bound: the latter would need the integrand to decay faster than `1/R`, while this needs
-no decay at all beyond boundedness.
+Applied to `|e^{iaz}| = e^{-aR\sin\theta}` on an arc of radius `R`, the relevant instance is
+`c = aR`, giving the bound `1/(aR)`; its `1/R` factor is what cancels the `R` in the arc length
+`πR`. That is why Jordan's lemma beats the naive `ML` bound, which would instead need the
+integrand itself to decay faster than `1/R`.
 
 ## Main results
 
 * `TauCeti.integral_exp_neg_mul_sin_le` — the bound above.
-* `TauCeti.integral_exp_neg_mul_sin_nonneg` — the integral is nonnegative, so the bound pins it
-  to `[0, π/c]`.
 
 ## References
 
@@ -39,7 +37,7 @@ no decay at all beyond boundedness.
 
 public section
 
-open Real intervalIntegral MeasureTheory Set
+open Real MeasureTheory Set
 
 namespace TauCeti
 
@@ -59,20 +57,15 @@ private theorem integral_exp_neg_mul (k b : ℝ) (hk : k ≠ 0) :
   ring
 
 /-- On `[0, π/2]` Jordan's inequality bounds the integrand by a decaying exponential. -/
-private theorem exp_neg_mul_sin_le (c : ℝ) (hc : 0 < c) {θ : ℝ} (hθ : θ ∈ Icc (0 : ℝ) (π / 2)) :
+private theorem exp_neg_mul_sin_le (c : ℝ) (hc : 0 ≤ c) {θ : ℝ} (hθ : θ ∈ Icc (0 : ℝ) (π / 2)) :
     Real.exp (-c * Real.sin θ) ≤ Real.exp (-(2 * c / π) * θ) := by
   refine Real.exp_le_exp.mpr ?_
   have hjordan : 2 / π * θ ≤ Real.sin θ := Real.mul_le_sin hθ.1 hθ.2
   have : 2 * c / π * θ ≤ c * Real.sin θ := by
-    have := mul_le_mul_of_nonneg_left hjordan hc.le
+    have := mul_le_mul_of_nonneg_left hjordan hc
     calc 2 * c / π * θ = c * (2 / π * θ) := by ring
       _ ≤ c * Real.sin θ := this
   linarith
-
-/-- The integrand is positive, so the integral over `[0, π]` is nonnegative. -/
-theorem integral_exp_neg_mul_sin_nonneg (c : ℝ) :
-    0 ≤ ∫ θ in (0 : ℝ)..π, Real.exp (-c * Real.sin θ) :=
-  intervalIntegral.integral_nonneg Real.pi_nonneg fun _ _ => (Real.exp_pos _).le
 
 /-- Half the interval carries half the integral: `θ ↦ π - θ` exchanges `[0, π/2]` and
 `[π/2, π]` and fixes `sin`. -/
@@ -91,9 +84,13 @@ private theorem integral_exp_neg_mul_sin_eq_two_mul (c : ℝ) :
         = ∫ θ in (π / 2)..π, Real.exp (-c * Real.sin (π - θ)) :=
           intervalIntegral.integral_congr fun x _ => by rw [Real.sin_pi_sub]
       _ = ∫ θ in (0 : ℝ)..(π / 2), Real.exp (-c * Real.sin θ) := by
+          -- Reflection sends `[π/2, π]` to `[π - π, π - π/2]`; those endpoints are equal to
+          -- `0` and `π/2` only propositionally, so they are rewritten explicitly.
           have h := intervalIntegral.integral_comp_sub_left
             (fun θ => Real.exp (-c * Real.sin θ)) (a := π / 2) (b := π) π
-          rw [show π - π = (0 : ℝ) by ring, show π - π / 2 = π / 2 by ring] at h
+          have hlo : π - π = (0 : ℝ) := sub_self π
+          have hhi : π - π / 2 = π / 2 := by ring
+          rw [hlo, hhi] at h
           exact h
   rw [hsplit, hrefl]
   ring
@@ -109,7 +106,7 @@ theorem integral_exp_neg_mul_sin_le (c : ℝ) (hc : 0 < c) :
       refine intervalIntegral.integral_mono_on (by positivity)
         (intervalIntegrable_exp_neg_mul_sin c 0 (π / 2))
         ((Real.continuous_exp.comp (continuous_const.mul continuous_id)).intervalIntegrable _ _)
-        fun θ hθ => exp_neg_mul_sin_le c hc hθ
+        fun θ hθ => exp_neg_mul_sin_le c hc.le hθ
     refine hmono.trans ?_
     rw [integral_exp_neg_mul _ _ hk]
     have hpi : π * (2 * c / π) = 2 * c := by field_simp

--- a/TauCeti/Analysis/SpecialFunctions/JordanIntegral.lean
+++ b/TauCeti/Analysis/SpecialFunctions/JordanIntegral.lean
@@ -1,0 +1,125 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+module
+
+public import Mathlib.Analysis.SpecialFunctions.Integrals.Basic
+public import Mathlib.Analysis.SpecialFunctions.Trigonometric.Bounds
+
+/-!
+# Jordan's integral bound
+
+The estimate
+
+$$\int_0^\pi e^{-c\sin\theta}\,d\theta \;\le\; \frac{\pi}{c} \qquad (c > 0)$$
+
+which is the analytic engine of **Jordan's lemma** in contour integration. The integrand is
+close to `1` near the endpoints `θ = 0, π`, so the bound is not obtained by a pointwise
+estimate on the whole interval; what makes it work is **Jordan's inequality**
+`sin θ ≥ (2/π) θ` on `[0, π/2]` (Mathlib's `Real.mul_le_sin`), which forces enough decay near
+the endpoint to make the whole integral `O(1/c)`.
+
+That `1/c` is exactly what cancels the length of a semicircular arc of radius `c` when this is
+applied to `|e^{iaz}| = e^{-aR\sin\theta}`, and it is why Jordan's lemma beats the naive
+`ML` bound: the latter would need the integrand to decay faster than `1/R`, while this needs
+no decay at all beyond boundedness.
+
+## Main results
+
+* `TauCeti.integral_exp_neg_mul_sin_le` — the bound above.
+* `TauCeti.integral_exp_neg_mul_sin_nonneg` — the integral is nonnegative, so the bound pins it
+  to `[0, π/c]`.
+
+## References
+
+* C. Jordan, *Cours d'analyse de l'École Polytechnique*, vol. 2 (1894), §270.
+* P. Henrici, *Applied and Computational Complex Analysis*, vol. 1, §4.8.
+-/
+
+public section
+
+open Real intervalIntegral MeasureTheory Set
+
+namespace TauCeti
+
+/-- The exponential of a negative multiple of the sine is continuous, hence integrable on any
+interval. -/
+private theorem intervalIntegrable_exp_neg_mul_sin (c a b : ℝ) :
+    IntervalIntegrable (fun θ => Real.exp (-c * Real.sin θ)) volume a b :=
+  (Real.continuous_exp.comp (continuous_const.mul Real.continuous_sin)).intervalIntegrable a b
+
+/-- The elementary decaying exponential integral `∫₀^b e^{-kθ} dθ = (1 - e^{-kb})/k`. -/
+private theorem integral_exp_neg_mul (k b : ℝ) (hk : k ≠ 0) :
+    ∫ θ in (0 : ℝ)..b, Real.exp (-k * θ) = (1 - Real.exp (-k * b)) / k := by
+  rw [intervalIntegral.integral_comp_mul_left (f := Real.exp) (c := -k) (neg_ne_zero.mpr hk),
+    integral_exp]
+  simp only [mul_zero, Real.exp_zero, smul_eq_mul]
+  field_simp
+  ring
+
+/-- On `[0, π/2]` Jordan's inequality bounds the integrand by a decaying exponential. -/
+private theorem exp_neg_mul_sin_le (c : ℝ) (hc : 0 < c) {θ : ℝ} (hθ : θ ∈ Icc (0 : ℝ) (π / 2)) :
+    Real.exp (-c * Real.sin θ) ≤ Real.exp (-(2 * c / π) * θ) := by
+  refine Real.exp_le_exp.mpr ?_
+  have hjordan : 2 / π * θ ≤ Real.sin θ := Real.mul_le_sin hθ.1 hθ.2
+  have : 2 * c / π * θ ≤ c * Real.sin θ := by
+    have := mul_le_mul_of_nonneg_left hjordan hc.le
+    calc 2 * c / π * θ = c * (2 / π * θ) := by ring
+      _ ≤ c * Real.sin θ := this
+  linarith
+
+/-- The integrand is positive, so the integral over `[0, π]` is nonnegative. -/
+theorem integral_exp_neg_mul_sin_nonneg (c : ℝ) :
+    0 ≤ ∫ θ in (0 : ℝ)..π, Real.exp (-c * Real.sin θ) :=
+  intervalIntegral.integral_nonneg Real.pi_nonneg fun _ _ => (Real.exp_pos _).le
+
+/-- Half the interval carries half the integral: `θ ↦ π - θ` exchanges `[0, π/2]` and
+`[π/2, π]` and fixes `sin`. -/
+private theorem integral_exp_neg_mul_sin_eq_two_mul (c : ℝ) :
+    ∫ θ in (0 : ℝ)..π, Real.exp (-c * Real.sin θ)
+      = 2 * ∫ θ in (0 : ℝ)..(π / 2), Real.exp (-c * Real.sin θ) := by
+  have hsplit : ∫ θ in (0 : ℝ)..π, Real.exp (-c * Real.sin θ)
+      = (∫ θ in (0 : ℝ)..(π / 2), Real.exp (-c * Real.sin θ))
+        + ∫ θ in (π / 2)..π, Real.exp (-c * Real.sin θ) :=
+    (intervalIntegral.integral_add_adjacent_intervals
+      (intervalIntegrable_exp_neg_mul_sin c 0 (π / 2))
+      (intervalIntegrable_exp_neg_mul_sin c (π / 2) π)).symm
+  have hrefl : ∫ θ in (π / 2)..π, Real.exp (-c * Real.sin θ)
+      = ∫ θ in (0 : ℝ)..(π / 2), Real.exp (-c * Real.sin θ) := by
+    calc ∫ θ in (π / 2)..π, Real.exp (-c * Real.sin θ)
+        = ∫ θ in (π / 2)..π, Real.exp (-c * Real.sin (π - θ)) :=
+          intervalIntegral.integral_congr fun x _ => by rw [Real.sin_pi_sub]
+      _ = ∫ θ in (0 : ℝ)..(π / 2), Real.exp (-c * Real.sin θ) := by
+          have h := intervalIntegral.integral_comp_sub_left
+            (fun θ => Real.exp (-c * Real.sin θ)) (a := π / 2) (b := π) π
+          rw [show π - π = (0 : ℝ) by ring, show π - π / 2 = π / 2 by ring] at h
+          exact h
+  rw [hsplit, hrefl]
+  ring
+
+/-- **Jordan's integral bound.** For `c > 0`,
+`∫₀^π e^{-c sin θ} dθ ≤ π / c`. -/
+theorem integral_exp_neg_mul_sin_le (c : ℝ) (hc : 0 < c) :
+    (∫ θ in (0 : ℝ)..π, Real.exp (-c * Real.sin θ)) ≤ π / c := by
+  have hk : 2 * c / π ≠ 0 := by positivity
+  have hhalf : (∫ θ in (0 : ℝ)..(π / 2), Real.exp (-c * Real.sin θ)) ≤ π / (2 * c) := by
+    have hmono : (∫ θ in (0 : ℝ)..(π / 2), Real.exp (-c * Real.sin θ))
+        ≤ ∫ θ in (0 : ℝ)..(π / 2), Real.exp (-(2 * c / π) * θ) := by
+      refine intervalIntegral.integral_mono_on (by positivity)
+        (intervalIntegrable_exp_neg_mul_sin c 0 (π / 2))
+        ((Real.continuous_exp.comp (continuous_const.mul continuous_id)).intervalIntegrable _ _)
+        fun θ hθ => exp_neg_mul_sin_le c hc hθ
+    refine hmono.trans ?_
+    rw [integral_exp_neg_mul _ _ hk]
+    have hpi : π * (2 * c / π) = 2 * c := by field_simp
+    rw [div_le_div_iff₀ (by positivity) (by positivity), hpi]
+    nlinarith [Real.exp_pos (-(2 * c / π) * (π / 2)), hc]
+  rw [integral_exp_neg_mul_sin_eq_two_mul]
+  calc 2 * ∫ θ in (0 : ℝ)..(π / 2), Real.exp (-c * Real.sin θ)
+      ≤ 2 * (π / (2 * c)) := by linarith
+    _ = π / c := by field_simp
+
+end TauCeti
+
+end


### PR DESCRIPTION
Adds **Jordan's lemma** — the estimate that makes a large semicircular arc contribute nothing to a contour integral carrying an oscillatory factor.

$$\left\|\int_{C_R} f(z)\,e^{iaz}\,dz\right\| \le \frac{\pi}{a} M_R, \qquad M_R = \sup_{C_R}\|f\|, \quad a > 0.$$

## Why this rather than an `ML` bound

The naive estimate is `‖∫‖ ≤ length × sup = (πR)·M_R`, which needs `M_R = o(1/R)`. That is too weak for the cases that matter — for `f z = z⁻¹` one has `M_R = 1/R` exactly, and `πR·(1/R) = π ↛ 0`. Jordan's lemma needs only `M_R → 0`, recovering the extra factor of `R` from the exponential.

## Contents

**`Analysis/SpecialFunctions/JordanIntegral.lean`** — the analytic core:

* `integral_exp_neg_mul_sin_le` — `∫₀^π e^{-c sin θ} dθ ≤ π/c` for `c > 0`.

This is where Mathlib's Jordan *inequality* `Real.mul_le_sin` (`sin θ ≥ (2/π)θ`) does the work. The integrand is close to `1` at both endpoints, so there is no pointwise bound to be had on the whole interval; the estimate comes from splitting at `π/2` (the substitution `θ ↦ π - θ` identifies the halves) and dominating by a decaying exponential on `[0, π/2]`.

**`Analysis/Contour/JordanLemma.lean`** — the contour-level estimate:

* `norm_integral_semicircle_exp_mul_le` — the displayed bound, in TauCeti's `f (γ t) * deriv γ t` convention. The `1/(aR)` from the core cancels the arc length `πR`, leaving a bound independent of `R`.
* `tendsto_integral_semicircle_exp_mul_nhds_zero` — the vanishing-limit form, along any filter of radii carrying a sup bound that tends to `0`. This is what the improper-integral limit will consume.

No integrability hypothesis is needed for the bound: if the integrand fails to be integrable the interval integral is `0` and the estimate holds trivially, so the statement is left at the weaker form.

## Roadmap

Supports the ContourIntegration roadmap's acceptance criterion *"an improper integral … evaluated by HW Thm 3.3 where the classical theorem does not apply"*. It is the missing ingredient for taking `R → ∞` in `hasCauchyPV_halfDiscBoundary_of_simple_pole`; note that limit genuinely requires the oscillatory factor, since `∫ dz/z` over the arc is `iπ` for every `R`.

## Gates

`lake build` · `lake exe axioms` · `lake exe module-system` · `scripts/lint-env.sh` — all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)