### PR TITLE
feat: add coinduction in stages

### DIFF
--- a/TauCeti/RepresentationTheory/Induction/Transitivity.lean
+++ b/TauCeti/RepresentationTheory/Induction/Transitivity.lean
@@ -7,8 +7,9 @@ public import Mathlib.RepresentationTheory.Induced
 /-!
 # Transitivity of induction and coinduction
 
-This file records induction and coinduction in stages for representations along composable group
-homomorphisms. It obtains the natural isomorphisms from the functoriality of restriction and
+This file records restriction and coinduction in stages for representations along composable monoid
+homomorphisms, and induction in stages along composable group homomorphisms. It obtains the natural
+isomorphisms from the functoriality of restriction and
 Mathlib's induction--restriction and restriction--coinduction adjunctions. This is the categorical
 core used by the subgroup form of induction in the induction and Mackey-theory roadmap.
 -/

--- a/TauCeti/RepresentationTheory/Induction/Transitivity.lean
+++ b/TauCeti/RepresentationTheory/Induction/Transitivity.lean
@@ -106,6 +106,19 @@ noncomputable def coindFunctorCompIso (φ : G →* H) (ψ : H →* K) :
   let adjψφ := _root_.Rep.resCoindAdjunction.{max u v w x} k (ψ.comp φ)
   exact conjugateIsoEquiv adjφψ adjψφ (resFunctorCompIso φ ψ).symm
 
+/-- The coinduction-in-stages isomorphism is characterized by the inverse
+restriction-composition isomorphism under the inverse adjunction equivalence. -/
+@[simp]
+lemma conjugateEquiv_symm_coindFunctorCompIso_hom (φ : G →* H) (ψ : H →* K) :
+    ((conjugateEquiv
+      ((_root_.Rep.resCoindAdjunction.{max u v w x} k ψ).comp
+        (_root_.Rep.resCoindAdjunction.{max u v w x} k φ))
+      (_root_.Rep.resCoindAdjunction.{max u v w x} k (ψ.comp φ))).symm
+      (coindFunctorCompIso φ ψ).hom) =
+    (resFunctorCompIso φ ψ).inv := by
+  unfold coindFunctorCompIso
+  exact Equiv.symm_apply_apply _ _
+
 end Coinduction
 
 end Rep

--- a/TauCeti/RepresentationTheory/Induction/Transitivity.lean
+++ b/TauCeti/RepresentationTheory/Induction/Transitivity.lean
@@ -1,15 +1,16 @@
 module
 
 public import Mathlib.CategoryTheory.Adjunction.CompositionIso
+public import Mathlib.RepresentationTheory.Coinduced
 public import Mathlib.RepresentationTheory.Induced
 
 /-!
-# Transitivity of induction
+# Transitivity of induction and coinduction
 
-This file records induction in stages for representations along composable group homomorphisms.
-It obtains the natural isomorphism from the functoriality of restriction and Mathlib's induction--
-restriction adjunction.  This is the categorical core used by the subgroup form of induction in
-the induction and Mackey-theory roadmap.
+This file records induction and coinduction in stages for representations along composable group
+homomorphisms. It obtains the natural isomorphisms from the functoriality of restriction and
+Mathlib's induction--restriction and restriction--coinduction adjunctions. This is the categorical
+core used by the subgroup form of induction in the induction and Mackey-theory roadmap.
 -/
 
 public section
@@ -88,6 +89,24 @@ lemma conjugateEquiv_indFunctorCompIso_inv (φ : G →* H) (ψ : H →* K) :
   Adjunction.conjugateEquiv_leftAdjointCompIso_inv _ _ _ _
 
 end Induction
+
+section Coinduction
+
+variable [CommRing k] [Monoid G] [Monoid H] [Monoid K]
+
+/-- Coinduction in stages: successive coinductions are naturally isomorphic to coinduction along
+the composite homomorphism. -/
+noncomputable def coindFunctorCompIso (φ : G →* H) (ψ : H →* K) :
+    _root_.Rep.coindFunctor.{max u v w x} k φ ⋙
+      _root_.Rep.coindFunctor.{max u v w x} k ψ ≅
+        _root_.Rep.coindFunctor.{max u v w x} k (ψ.comp φ) := by
+  let adjφ := _root_.Rep.resCoindAdjunction.{max u v w x} k φ
+  let adjψ := _root_.Rep.resCoindAdjunction.{max u v w x} k ψ
+  let adjφψ := adjψ.comp adjφ
+  let adjψφ := _root_.Rep.resCoindAdjunction.{max u v w x} k (ψ.comp φ)
+  exact conjugateIsoEquiv adjφψ adjψφ (resFunctorCompIso φ ψ).symm
+
+end Coinduction
 
 end Rep
 


### PR DESCRIPTION
This PR adds coinduction in stages: for composable group homomorphisms `φ : G →* H` and `ψ : H →* K`, it provides the natural isomorphism `Coind φ ⋙ Coind ψ ≅ Coind (ψ.comp φ)`. It obtains this right-adjoint comparison from the existing restriction-composition isomorphism through Mathlib's `resCoindAdjunction`, completing the coinduction half of the functorial core without adding a competing explicit model of coinduction.

This advances `TauCetiRoadmap/RepresentationTheory/InductionRestriction/README.md`, Layer 0, “Transitivity of induction”, specifically its named dual target “transitivity of coinduction, `Coind_T^G ∘ Coind_S^T ≅ Coind_S^G`”. It is the lowest-hanging unclaimed continuation of merged PR #1235: that PR supplied induction in stages and restriction composition in the same canonical module, while no open RepresentationTheory PR covers the dual coinduction isomorphism.

It reuses Mathlib's `Rep.resCoindAdjunction`, `CategoryTheory.conjugateIsoEquiv`, and the existing `TauCeti.Rep.resFunctorCompIso`; no Mathlib infrastructure or external formalization is vendored. The change extends `TauCeti/RepresentationTheory/Induction/Transitivity.lean` from 89 to 113 lines.

`lake exe cache get` reports `No files to download` and `Already decompressed 8640 file(s)`. `lake build` reports `Build completed successfully (5498 jobs).` `lake exe axioms` reports `axioms: audited 12173 TauCeti declaration(s); all within the allowlist [propext, Classical.choice, Quot.sound].`

<!--tauceti-target:v1 {"focus":"RepresentationTheory","id":"coinduction-transitivity"}-->

🤖 Prepared with Codex
