### PR TITLE
feat: add tensor powers of representations

### DIFF
--- a/TauCeti/RepresentationTheory/ClassicalGroups/TensorPower.lean
+++ b/TauCeti/RepresentationTheory/ClassicalGroups/TensorPower.lean
@@ -64,14 +64,6 @@ theorem char_tensorPowerRep (g : GL (Fin n) k) :
       Matrix.trace (g : Matrix (Fin n) (Fin n) k) ^ d := by
   rw [Representation.char_tensorPower, char_stdRep]
 
-/-- The bundled tensor-power representation has character equal to the trace power. -/
-@[simp]
-theorem char_tensorPowerFDRep (g : GL (Fin n) k) :
-    (tensorPowerFDRep k n d).character g =
-      Matrix.trace (g : Matrix (Fin n) (Fin n) k) ^ d := by
-  simpa only [FDRep.character, FDRep.of_ρ', Representation.character] using
-    char_tensorPowerRep k n d g
-
 end Field
 
 end TauCeti

--- a/TauCeti/RepresentationTheory/ClassicalGroups/TensorPower.lean
+++ b/TauCeti/RepresentationTheory/ClassicalGroups/TensorPower.lean
@@ -45,28 +45,9 @@ noncomputable abbrev tensorPowerRep :
     Representation k (GL (Fin n) k) (⨂[k]^d (Fin n → k)) :=
   (stdRep k n).tensorPower d
 
-/-- The tensor-power standard action sends a pure tensor to the tensor of its matrix actions. -/
-@[simp]
-theorem tensorPowerRep_apply_tprod (g : GL (Fin n) k) (v : Fin d → Fin n → k) :
-    tensorPowerRep k n d g (PiTensorProduct.tprod k v) =
-      PiTensorProduct.tprod k (fun i => (g : Matrix (Fin n) (Fin n) k) *ᵥ v i) := by
-  simp only [tensorPowerRep, Representation.tensorPower_apply_tprod, stdRep_apply_apply]
-
-/-- The zero-fold tensor-power standard representation is trivial. -/
-@[simp]
-theorem tensorPowerRep_zero_apply (g : GL (Fin n) k) :
-    tensorPowerRep k n 0 g = LinearMap.id :=
-  Representation.tensorPower_zero_apply (stdRep k n) g
-
 /-- The `d`-fold tensor power of the standard representation, bundled as an `FDRep`. -/
 noncomputable abbrev tensorPowerFDRep : FDRep k (GL (Fin n) k) :=
   (stdRep k n).tensorPowerFDRep d
-
-/-- The finite-dimensional tensor-power standard action agrees with the tensor-power action. -/
-@[simp]
-theorem tensorPowerFDRep_ρ :
-    (tensorPowerFDRep k n d).ρ = tensorPowerRep k n d :=
-  rfl
 
 end CommRing
 

--- a/TauCeti/RepresentationTheory/ClassicalGroups/TensorPower.lean
+++ b/TauCeti/RepresentationTheory/ClassicalGroups/TensorPower.lean
@@ -1,0 +1,73 @@
+/-
+Copyright (c) 2026 Tau Ceti. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Codex
+-/
+module
+
+public import TauCeti.RepresentationTheory.ClassicalGroups.Standard
+public import TauCeti.RepresentationTheory.TensorPower
+
+/-!
+# Tensor powers of the standard representation
+
+This file specializes the diagonal tensor-power construction to the standard representation of
+the general linear group. It supplies the tensor powers that underpin the Weyl construction for
+polynomial representations.
+
+## Main definitions
+
+* `TauCeti.tensorPowerRep` is the `d`-fold tensor power of `stdRep`.
+* `TauCeti.tensorPowerFDRep` is its bundled finite-dimensional form.
+
+## References
+
+* [Classical groups roadmap](https://github.com/TauCetiProject/TauCetiRoadmap/blob/main/TauCetiRoadmap/RepresentationTheory/ClassicalGroups/README.md), Layer 1, “The tensor power representation”.
+-/
+
+public section
+
+open Matrix
+open scoped TensorProduct
+
+universe u
+
+namespace TauCeti
+
+variable (k : Type u) (n d : ℕ)
+
+section CommRing
+
+variable [CommRing k]
+
+/-- The diagonal action of `GL n k` on the `d`-fold tensor power of its standard representation. -/
+noncomputable abbrev tensorPowerRep :
+    Representation k (GL (Fin n) k) (⨂[k]^d (Fin n → k)) :=
+  (stdRep k n).tensorPower d
+
+/-- The tensor-power standard action sends a pure tensor to the tensor of its matrix actions. -/
+@[simp]
+theorem tensorPowerRep_apply_tprod (g : GL (Fin n) k) (v : Fin d → Fin n → k) :
+    tensorPowerRep k n d g (PiTensorProduct.tprod k v) =
+      PiTensorProduct.tprod k (fun i => (g : Matrix (Fin n) (Fin n) k) *ᵥ v i) := by
+  simp only [tensorPowerRep, Representation.tensorPower_apply_tprod, stdRep_apply_apply]
+
+/-- The zero-fold tensor-power standard representation is trivial. -/
+@[simp]
+theorem tensorPowerRep_zero_apply (g : GL (Fin n) k) :
+    tensorPowerRep k n 0 g = LinearMap.id :=
+  Representation.tensorPower_zero_apply (stdRep k n) g
+
+/-- The `d`-fold tensor power of the standard representation, bundled as an `FDRep`. -/
+noncomputable abbrev tensorPowerFDRep : FDRep k (GL (Fin n) k) :=
+  (stdRep k n).tensorPowerFDRep d
+
+/-- The finite-dimensional tensor-power standard action agrees with the tensor-power action. -/
+@[simp]
+theorem tensorPowerFDRep_ρ :
+    (tensorPowerFDRep k n d).ρ = tensorPowerRep k n d :=
+  rfl
+
+end CommRing
+
+end TauCeti

--- a/TauCeti/RepresentationTheory/ClassicalGroups/TensorPower.lean
+++ b/TauCeti/RepresentationTheory/ClassicalGroups/TensorPower.lean
@@ -55,7 +55,10 @@ section Field
 
 variable [Field k]
 
-/-- The character of the tensor power is the corresponding power of the standard character. -/
+/-- The character of the tensor power is the corresponding power of the standard character.
+
+This is intentionally not a simp lemma: `Representation.char_tensorPower` and `char_stdRep`
+already normalize its left-hand side, so registering this specialization would violate `simpNF`. -/
 theorem char_tensorPowerRep (g : GL (Fin n) k) :
     (tensorPowerRep k n d).character g =
       Matrix.trace (g : Matrix (Fin n) (Fin n) k) ^ d := by

--- a/TauCeti/RepresentationTheory/ClassicalGroups/TensorPower.lean
+++ b/TauCeti/RepresentationTheory/ClassicalGroups/TensorPower.lean
@@ -18,7 +18,6 @@ polynomial representations.
 ## Main definitions
 
 * `TauCeti.tensorPowerRep` is the `d`-fold tensor power of `stdRep`.
-* `TauCeti.tensorPowerFDRep` is its bundled finite-dimensional form.
 
 ## References
 
@@ -44,10 +43,6 @@ variable [CommRing k]
 noncomputable abbrev tensorPowerRep :
     Representation k (GL (Fin n) k) (⨂[k]^d (Fin n → k)) :=
   (stdRep k n).tensorPower d
-
-/-- The `d`-fold tensor power of the standard representation, bundled as an `FDRep`. -/
-noncomputable abbrev tensorPowerFDRep : FDRep k (GL (Fin n) k) :=
-  (stdRep k n).tensorPowerFDRep d
 
 end CommRing
 

--- a/TauCeti/RepresentationTheory/ClassicalGroups/TensorPower.lean
+++ b/TauCeti/RepresentationTheory/ClassicalGroups/TensorPower.lean
@@ -64,6 +64,14 @@ theorem char_tensorPowerRep (g : GL (Fin n) k) :
       Matrix.trace (g : Matrix (Fin n) (Fin n) k) ^ d := by
   rw [Representation.char_tensorPower, char_stdRep]
 
+/-- The character of the bundled tensor power is the corresponding power of the matrix trace. -/
+@[simp]
+theorem char_tensorPowerFDRep (g : GL (Fin n) k) :
+    (tensorPowerFDRep k n d).character g =
+      Matrix.trace (g : Matrix (Fin n) (Fin n) k) ^ d := by
+  simpa only [FDRep.character, FDRep.of_ρ', Representation.character] using
+    char_tensorPowerRep k n d g
+
 end Field
 
 end TauCeti

--- a/TauCeti/RepresentationTheory/ClassicalGroups/TensorPower.lean
+++ b/TauCeti/RepresentationTheory/ClassicalGroups/TensorPower.lean
@@ -51,7 +51,6 @@ section Field
 variable [Field k]
 
 /-- The character of the tensor power is the corresponding power of the standard character. -/
-@[simp]
 theorem char_tensorPowerRep (g : GL (Fin n) k) :
     (tensorPowerRep k n d).character g = ((stdRep k n).character g) ^ d := by
   exact Representation.char_tensorPower (stdRep k n) d g

--- a/TauCeti/RepresentationTheory/ClassicalGroups/TensorPower.lean
+++ b/TauCeti/RepresentationTheory/ClassicalGroups/TensorPower.lean
@@ -7,8 +7,6 @@ module
 
 public import TauCeti.RepresentationTheory.ClassicalGroups.Standard
 public import TauCeti.RepresentationTheory.TensorPower
-public import Mathlib.LinearAlgebra.PiTensorProduct.Basis
-public import Mathlib.RepresentationTheory.Character
 
 /-!
 # Tensor powers of the standard representation
@@ -37,44 +35,6 @@ namespace TauCeti
 
 variable (k : Type u) (n d : ℕ)
 
-private theorem trace_map_tensorPower {M : Type u} [Field k] [AddCommGroup M] [Module k M]
-    [FiniteDimensional k M] (f : M →ₗ[k] M) (d : ℕ) :
-    LinearMap.trace k (⨂[k]^d M) (PiTensorProduct.map fun _ : Fin d => f) =
-      (LinearMap.trace k M f) ^ d := by
-  classical
-  letI (d : ℕ) : FiniteDimensional k (⨂[k]^d M) :=
-    (Basis.piTensorProduct fun _ : Fin d => Module.finBasis k M).finiteDimensional_of_finite
-  induction d with
-  | zero =>
-    have hmap : PiTensorProduct.map (fun _ : Fin 0 => f) = LinearMap.id := by
-      rw [← PiTensorProduct.map_id]
-      congr
-      funext i
-      exact Fin.elim0 i
-    rw [hmap]
-    let e := PiTensorProduct.isEmptyEquiv (Fin 0) (R := k) (s := fun _ => M)
-    rw [← LinearMap.trace_conj' (LinearMap.id : (⨂[k]^0 M) →ₗ[k] _) e]
-    simp [e]
-  | succ d ih =>
-    let e : (⨂[k]^d M) ⊗[k] (⨂[k]^1 M) ≃ₗ[k] (⨂[k]^(d + 1) M) :=
-      TensorPower.mulEquiv
-    have he : e.conj
-        (TensorProduct.map (PiTensorProduct.map fun _ : Fin d => f)
-          (PiTensorProduct.map fun _ : Fin 1 => f)) =
-        PiTensorProduct.map (fun _ : Fin (d + 1) => f) := by
-      ext x
-      apply e.symm.injective
-      simp [LinearEquiv.conj_apply_apply, e, TensorPower.mulEquiv]
-    rw [← he, LinearMap.trace_conj', LinearMap.trace_tensorProduct']
-    have h_one : LinearMap.trace k (⨂[k]^1 M) (PiTensorProduct.map fun _ : Fin 1 => f) =
-        LinearMap.trace k M f := by
-      let e₁ := PiTensorProduct.subsingletonEquiv (R := k) (s := fun _ : Fin 1 => M) 0
-      rw [← LinearMap.trace_conj' (PiTensorProduct.map fun _ : Fin 1 => f) e₁]
-      congr 1
-      ext x
-      simp [LinearEquiv.conj_apply_apply, e₁]
-    rw [ih, h_one, pow_succ]
-
 section CommRing
 
 variable [CommRing k]
@@ -90,13 +50,11 @@ section Field
 
 variable [Field k]
 
-/- The finite-dimensionality instance for tensor powers is constructed locally in the proof below
-from Mathlib's `Basis.piTensorProduct`, since Mathlib does not provide it globally. -/
 /-- The character of the tensor power is the corresponding power of the standard character. -/
+@[simp]
 theorem char_tensorPowerRep (g : GL (Fin n) k) :
     (tensorPowerRep k n d).character g = ((stdRep k n).character g) ^ d := by
-  simp only [Representation.character, tensorPowerRep, Representation.tensorPower_apply]
-  exact trace_map_tensorPower k ((stdRep k n) g) d
+  exact Representation.char_tensorPower (stdRep k n) d g
 
 end Field
 

--- a/TauCeti/RepresentationTheory/ClassicalGroups/TensorPower.lean
+++ b/TauCeti/RepresentationTheory/ClassicalGroups/TensorPower.lean
@@ -56,9 +56,19 @@ section Field
 variable [Field k]
 
 /-- The character of the tensor power is the corresponding power of the standard character. -/
+@[simp]
 theorem char_tensorPowerRep (g : GL (Fin n) k) :
-    (tensorPowerRep k n d).character g = ((stdRep k n).character g) ^ d := by
-  exact Representation.char_tensorPower (stdRep k n) d g
+    (tensorPowerRep k n d).character g =
+      Matrix.trace (g : Matrix (Fin n) (Fin n) k) ^ d := by
+  rw [Representation.char_tensorPower, char_stdRep]
+
+/-- The bundled tensor-power representation has character equal to the trace power. -/
+@[simp]
+theorem char_tensorPowerFDRep (g : GL (Fin n) k) :
+    (tensorPowerFDRep k n d).character g =
+      Matrix.trace (g : Matrix (Fin n) (Fin n) k) ^ d := by
+  simpa only [FDRep.character, FDRep.of_ρ', Representation.character] using
+    char_tensorPowerRep k n d g
 
 end Field
 

--- a/TauCeti/RepresentationTheory/ClassicalGroups/TensorPower.lean
+++ b/TauCeti/RepresentationTheory/ClassicalGroups/TensorPower.lean
@@ -7,6 +7,8 @@ module
 
 public import TauCeti.RepresentationTheory.ClassicalGroups.Standard
 public import TauCeti.RepresentationTheory.TensorPower
+public import Mathlib.LinearAlgebra.PiTensorProduct.Basis
+public import Mathlib.RepresentationTheory.Character
 
 /-!
 # Tensor powers of the standard representation
@@ -35,6 +37,44 @@ namespace TauCeti
 
 variable (k : Type u) (n d : ℕ)
 
+private theorem trace_map_tensorPower {M : Type u} [Field k] [AddCommGroup M] [Module k M]
+    [FiniteDimensional k M] (f : M →ₗ[k] M) (d : ℕ) :
+    LinearMap.trace k (⨂[k]^d M) (PiTensorProduct.map fun _ : Fin d => f) =
+      (LinearMap.trace k M f) ^ d := by
+  classical
+  letI (d : ℕ) : FiniteDimensional k (⨂[k]^d M) :=
+    (Basis.piTensorProduct fun _ : Fin d => Module.finBasis k M).finiteDimensional_of_finite
+  induction d with
+  | zero =>
+    have hmap : PiTensorProduct.map (fun _ : Fin 0 => f) = LinearMap.id := by
+      rw [← PiTensorProduct.map_id]
+      congr
+      funext i
+      exact Fin.elim0 i
+    rw [hmap]
+    let e := PiTensorProduct.isEmptyEquiv (Fin 0) (R := k) (s := fun _ => M)
+    rw [← LinearMap.trace_conj' (LinearMap.id : (⨂[k]^0 M) →ₗ[k] _) e]
+    simp [e]
+  | succ d ih =>
+    let e : (⨂[k]^d M) ⊗[k] (⨂[k]^1 M) ≃ₗ[k] (⨂[k]^(d + 1) M) :=
+      TensorPower.mulEquiv
+    have he : e.conj
+        (TensorProduct.map (PiTensorProduct.map fun _ : Fin d => f)
+          (PiTensorProduct.map fun _ : Fin 1 => f)) =
+        PiTensorProduct.map (fun _ : Fin (d + 1) => f) := by
+      ext x
+      apply e.symm.injective
+      simp [LinearEquiv.conj_apply_apply, e, TensorPower.mulEquiv]
+    rw [← he, LinearMap.trace_conj', LinearMap.trace_tensorProduct']
+    have h_one : LinearMap.trace k (⨂[k]^1 M) (PiTensorProduct.map fun _ : Fin 1 => f) =
+        LinearMap.trace k M f := by
+      let e₁ := PiTensorProduct.subsingletonEquiv (R := k) (s := fun _ : Fin 1 => M) 0
+      rw [← LinearMap.trace_conj' (PiTensorProduct.map fun _ : Fin 1 => f) e₁]
+      congr 1
+      ext x
+      simp [LinearEquiv.conj_apply_apply, e₁]
+    rw [ih, h_one, pow_succ]
+
 section CommRing
 
 variable [CommRing k]
@@ -45,5 +85,19 @@ noncomputable abbrev tensorPowerRep :
   (stdRep k n).tensorPower d
 
 end CommRing
+
+section Field
+
+variable [Field k]
+
+/- The finite-dimensionality instance for tensor powers is constructed locally in the proof below
+from Mathlib's `Basis.piTensorProduct`, since Mathlib does not provide it globally. -/
+/-- The character of the tensor power is the corresponding power of the standard character. -/
+theorem char_tensorPowerRep (g : GL (Fin n) k) :
+    (tensorPowerRep k n d).character g = ((stdRep k n).character g) ^ d := by
+  simp only [Representation.character, tensorPowerRep, Representation.tensorPower_apply]
+  exact trace_map_tensorPower k ((stdRep k n) g) d
+
+end Field
 
 end TauCeti

--- a/TauCeti/RepresentationTheory/ClassicalGroups/TensorPower.lean
+++ b/TauCeti/RepresentationTheory/ClassicalGroups/TensorPower.lean
@@ -18,6 +18,7 @@ polynomial representations.
 ## Main definitions
 
 * `TauCeti.tensorPowerRep` is the `d`-fold tensor power of `stdRep`.
+* `TauCeti.tensorPowerFDRep` is its bundled finite-dimensional form.
 
 ## References
 
@@ -43,6 +44,10 @@ variable [CommRing k]
 noncomputable abbrev tensorPowerRep :
     Representation k (GL (Fin n) k) (⨂[k]^d (Fin n → k)) :=
   (stdRep k n).tensorPower d
+
+/-- The tensor power of the standard representation, bundled as an object of `FDRep`. -/
+noncomputable abbrev tensorPowerFDRep : FDRep k (GL (Fin n) k) :=
+  FDRep.of (tensorPowerRep k n d)
 
 end CommRing
 

--- a/TauCeti/RepresentationTheory/ClassicalGroups/TensorPower.lean
+++ b/TauCeti/RepresentationTheory/ClassicalGroups/TensorPower.lean
@@ -56,7 +56,6 @@ section Field
 variable [Field k]
 
 /-- The character of the tensor power is the corresponding power of the standard character. -/
-@[simp]
 theorem char_tensorPowerRep (g : GL (Fin n) k) :
     (tensorPowerRep k n d).character g =
       Matrix.trace (g : Matrix (Fin n) (Fin n) k) ^ d := by

--- a/TauCeti/RepresentationTheory/TensorPower.lean
+++ b/TauCeti/RepresentationTheory/TensorPower.lean
@@ -7,7 +7,6 @@ module
 
 public import Mathlib.LinearAlgebra.TensorPower.Basic
 public import Mathlib.LinearAlgebra.PiTensorProduct.Finite
-public import Mathlib.RepresentationTheory.Basic
 public import Mathlib.RepresentationTheory.Character
 
 /-!
@@ -87,6 +86,8 @@ theorem char_tensorPower (ρ : Representation R G M) (d : ℕ) (g : G) :
         PiTensorProduct.map (fun _ : Fin (d + 1) => ρ g) := by
       ext x
       simp only [LinearMap.compMultilinearMap_apply]
+      -- `ext` leaves the pure tensor behind the defining multilinear map; expose it so the
+      -- public apply lemmas below can rewrite the action without unfolding `TensorPower.mulEquiv`.
       change e.conj _ (⨂ₜ[R] i, x i) = _
       rw [LinearEquiv.conj_apply_apply]
       let a : Fin d → M := fun i => x (Fin.castAdd 1 i)
@@ -102,11 +103,15 @@ theorem char_tensorPower (ρ : Representation R G M) (d : ℕ) (g : G) :
           (⨂ₜ[R] i, a i) ⊗ₜ[R] (⨂ₜ[R] i, b i) := by
         apply e.injective
         rw [e.apply_symm_apply]
+        -- Rewriting cannot match through the local name `e`; this conversion exposes exactly the
+        -- public `tprod_mul_tprod` equation without unfolding the equivalence.
         rw [show e ((⨂ₜ[R] i, a i) ⊗ₜ[R] (⨂ₜ[R] i, b i)) =
           ⨂ₜ[R] i, Fin.append a b i from TensorPower.tprod_mul_tprod R a b]
         rw [hx]
       rw [hsplit, TensorProduct.map_tmul, PiTensorProduct.map_tprod,
         PiTensorProduct.map_tprod]
+      -- As above, make the let-bound equivalence transparent only through its public pure-tensor
+      -- equation, which lets `rw` avoid the implementation of `TensorPower.mulEquiv`.
       rw [show e ((⨂ₜ[R] i, (ρ g) (a i)) ⊗ₜ[R] (⨂ₜ[R] i, (ρ g) (b i))) =
         ⨂ₜ[R] i, Fin.append (fun i => (ρ g) (a i)) (fun i => (ρ g) (b i)) i from
           TensorPower.tprod_mul_tprod R _ _]

--- a/TauCeti/RepresentationTheory/TensorPower.lean
+++ b/TauCeti/RepresentationTheory/TensorPower.lean
@@ -49,7 +49,9 @@ noncomputable def tensorPower (ρ : Representation R G M) (d : ℕ) :
 @[simp]
 theorem tensorPower_apply (ρ : Representation R G M) (d : ℕ) (g : G) :
     ρ.tensorPower d g = PiTensorProduct.map fun _ : Fin d => ρ g :=
-  by unfold tensorPower; rfl
+  by
+    simp only [tensorPower, MonoidHom.comp_apply, PiTensorProduct.mapMonoidHom_apply]
+    congr 1
 
 end CommSemiring
 
@@ -73,8 +75,10 @@ theorem char_tensorPower (ρ : Representation R G M) (d : ℕ) (g : G) :
     rw [hmap]
     let e := PiTensorProduct.isEmptyEquiv (Fin 0) (R := R) (s := fun _ => M)
     rw [← LinearMap.trace_conj' (LinearMap.id : (⨂[R]^0 M) →ₗ[R] _) e]
-    simp [e]
+    rw [LinearEquiv.conj_id, LinearMap.trace_id, Module.finrank_self, Nat.cast_one]
+    simp only [pow_zero]
   | succ d ih =>
+    -- Split `Fin (d + 1)` into `Fin d` and `Fin 1`, then use multiplicativity of trace.
     let e : (⨂[R]^d M) ⊗[R] (⨂[R]^1 M) ≃ₗ[R] (⨂[R]^(d + 1) M) :=
       TensorPower.mulEquiv
     have he : e.conj
@@ -82,8 +86,39 @@ theorem char_tensorPower (ρ : Representation R G M) (d : ℕ) (g : G) :
           (PiTensorProduct.map fun _ : Fin 1 => ρ g)) =
         PiTensorProduct.map (fun _ : Fin (d + 1) => ρ g) := by
       ext x
-      apply e.symm.injective
-      simp [LinearEquiv.conj_apply_apply, e, TensorPower.mulEquiv]
+      simp only [LinearMap.compMultilinearMap_apply]
+      change e.conj _ (⨂ₜ[R] i, x i) = _
+      rw [LinearEquiv.conj_apply_apply]
+      let a : Fin d → M := fun i => x (Fin.castAdd 1 i)
+      let b : Fin 1 → M := fun i => x (Fin.natAdd d i)
+      have hx : Fin.append a b = x := by
+        ext i
+        refine Fin.addCases ?_ ?_ i
+        · intro j
+          simp only [a, Fin.append_left]
+        · intro j
+          simp only [b, Fin.append_right]
+      have hsplit : e.symm (⨂ₜ[R] i, x i) =
+          (⨂ₜ[R] i, a i) ⊗ₜ[R] (⨂ₜ[R] i, b i) := by
+        apply e.injective
+        rw [e.apply_symm_apply]
+        rw [show e ((⨂ₜ[R] i, a i) ⊗ₜ[R] (⨂ₜ[R] i, b i)) =
+          ⨂ₜ[R] i, Fin.append a b i from TensorPower.tprod_mul_tprod R a b]
+        rw [hx]
+      rw [hsplit, TensorProduct.map_tmul, PiTensorProduct.map_tprod,
+        PiTensorProduct.map_tprod]
+      rw [show e ((⨂ₜ[R] i, (ρ g) (a i)) ⊗ₜ[R] (⨂ₜ[R] i, (ρ g) (b i))) =
+        ⨂ₜ[R] i, Fin.append (fun i => (ρ g) (a i)) (fun i => (ρ g) (b i)) i from
+          TensorPower.tprod_mul_tprod R _ _]
+      rw [PiTensorProduct.map_tprod]
+      congr 1
+      rw [← hx]
+      ext i
+      refine Fin.addCases ?_ ?_ i
+      · intro j
+        simp only [Fin.append_left]
+      · intro j
+        simp only [Fin.append_right]
     rw [← he, LinearMap.trace_conj', LinearMap.trace_tensorProduct']
     have h_one : LinearMap.trace R (⨂[R]^1 M) (PiTensorProduct.map fun _ : Fin 1 => ρ g) =
         LinearMap.trace R M (ρ g) := by
@@ -91,7 +126,11 @@ theorem char_tensorPower (ρ : Representation R G M) (d : ℕ) (g : G) :
       rw [← LinearMap.trace_conj' (PiTensorProduct.map fun _ : Fin 1 => ρ g) e₁]
       congr 1
       ext x
-      simp [LinearEquiv.conj_apply_apply, e₁]
+      rw [LinearEquiv.conj_apply_apply]
+      have he₁ : e₁.symm x = ⨂ₜ[R] _ : Fin 1, x := by
+        simpa only using
+          (PiTensorProduct.subsingletonEquiv_symm_apply' (R := R) (ι := Fin 1) 0 x)
+      rw [he₁, PiTensorProduct.map_tprod, PiTensorProduct.subsingletonEquiv_apply_tprod]
     rw [ih, h_one, pow_succ]
 
 end Field

--- a/TauCeti/RepresentationTheory/TensorPower.lean
+++ b/TauCeti/RepresentationTheory/TensorPower.lean
@@ -6,7 +6,9 @@ Authors: Codex
 module
 
 public import Mathlib.LinearAlgebra.TensorPower.Basic
+public import Mathlib.LinearAlgebra.PiTensorProduct.Basis
 public import Mathlib.RepresentationTheory.Basic
+public import Mathlib.RepresentationTheory.Character
 
 /-!
 # Tensor powers of representations
@@ -50,5 +52,50 @@ theorem tensorPower_apply (ρ : Representation R G M) (d : ℕ) (g : G) :
   by unfold tensorPower; rfl
 
 end CommSemiring
+
+section Field
+
+variable [Field R] [Monoid G] [AddCommGroup M] [Module R M] [FiniteDimensional R M]
+
+/-- The character of a tensor-power representation is the corresponding power of the character. -/
+@[simp]
+theorem char_tensorPower (ρ : Representation R G M) (d : ℕ) (g : G) :
+    (ρ.tensorPower d).character g = (ρ.character g) ^ d := by
+  classical
+  letI (d : ℕ) : FiniteDimensional R (⨂[R]^d M) :=
+    (Basis.piTensorProduct fun _ : Fin d => Module.finBasis R M).finiteDimensional_of_finite
+  simp only [Representation.character, tensorPower_apply]
+  induction d with
+  | zero =>
+    have hmap : PiTensorProduct.map (fun _ : Fin 0 => ρ g) = LinearMap.id := by
+      rw [← PiTensorProduct.map_id]
+      congr
+      funext i
+      exact Fin.elim0 i
+    rw [hmap]
+    let e := PiTensorProduct.isEmptyEquiv (Fin 0) (R := R) (s := fun _ => M)
+    rw [← LinearMap.trace_conj' (LinearMap.id : (⨂[R]^0 M) →ₗ[R] _) e]
+    simp [e]
+  | succ d ih =>
+    let e : (⨂[R]^d M) ⊗[R] (⨂[R]^1 M) ≃ₗ[R] (⨂[R]^(d + 1) M) :=
+      TensorPower.mulEquiv
+    have he : e.conj
+        (TensorProduct.map (PiTensorProduct.map fun _ : Fin d => ρ g)
+          (PiTensorProduct.map fun _ : Fin 1 => ρ g)) =
+        PiTensorProduct.map (fun _ : Fin (d + 1) => ρ g) := by
+      ext x
+      apply e.symm.injective
+      simp [LinearEquiv.conj_apply_apply, e, TensorPower.mulEquiv]
+    rw [← he, LinearMap.trace_conj', LinearMap.trace_tensorProduct']
+    have h_one : LinearMap.trace R (⨂[R]^1 M) (PiTensorProduct.map fun _ : Fin 1 => ρ g) =
+        LinearMap.trace R M (ρ g) := by
+      let e₁ := PiTensorProduct.subsingletonEquiv (R := R) (s := fun _ : Fin 1 => M) 0
+      rw [← LinearMap.trace_conj' (PiTensorProduct.map fun _ : Fin 1 => ρ g) e₁]
+      congr 1
+      ext x
+      simp [LinearEquiv.conj_apply_apply, e₁]
+    rw [ih, h_one, pow_succ]
+
+end Field
 
 end Representation

--- a/TauCeti/RepresentationTheory/TensorPower.lean
+++ b/TauCeti/RepresentationTheory/TensorPower.lean
@@ -29,11 +29,66 @@ public section
 
 open scoped TensorProduct
 
-namespace Representation
-
 universe u v w
 
 variable {R : Type u} {G : Type v} {M : Type w}
+
+namespace TauCeti.TensorPower
+
+section CommSemiring
+
+variable [CommSemiring R] [AddCommMonoid M] [Module R M]
+
+/-- Splitting a tensor power intertwines the tensor product of diagonal maps with the
+diagonal map on the combined tensor power. -/
+theorem mulEquiv_conj_map (f : M →ₗ[R] M) (d e : ℕ) :
+    (_root_.TensorPower.mulEquiv :
+      (⨂[R]^d M) ⊗[R] (⨂[R]^e M) ≃ₗ[R] (⨂[R]^(d + e) M)).conj
+        (TensorProduct.map (PiTensorProduct.map fun _ : Fin d => f)
+          (PiTensorProduct.map fun _ : Fin e => f)) =
+      PiTensorProduct.map (fun _ : Fin (d + e) => f) := by
+  let equiv : (⨂[R]^d M) ⊗[R] (⨂[R]^e M) ≃ₗ[R] (⨂[R]^(d + e) M) :=
+    _root_.TensorPower.mulEquiv
+  ext x
+  simp only [LinearMap.compMultilinearMap_apply]
+  change equiv.conj _ (⨂ₜ[R] i, x i) = _
+  rw [LinearEquiv.conj_apply_apply]
+  let a : Fin d → M := fun i => x (Fin.castAdd e i)
+  let b : Fin e → M := fun i => x (Fin.natAdd d i)
+  have hx : Fin.append a b = x := by
+    ext i
+    refine Fin.addCases ?_ ?_ i
+    · intro j
+      simp only [a, Fin.append_left]
+    · intro j
+      simp only [b, Fin.append_right]
+  have hsplit : equiv.symm (⨂ₜ[R] i, x i) =
+      (⨂ₜ[R] i, a i) ⊗ₜ[R] (⨂ₜ[R] i, b i) := by
+    apply equiv.injective
+    rw [equiv.apply_symm_apply]
+    rw [show equiv ((⨂ₜ[R] i, a i) ⊗ₜ[R] (⨂ₜ[R] i, b i)) =
+      ⨂ₜ[R] i, Fin.append a b i from _root_.TensorPower.tprod_mul_tprod R a b]
+    rw [hx]
+  rw [hsplit, TensorProduct.map_tmul, PiTensorProduct.map_tprod,
+    PiTensorProduct.map_tprod]
+  rw [show equiv ((⨂ₜ[R] i, f (a i)) ⊗ₜ[R] (⨂ₜ[R] i, f (b i))) =
+    ⨂ₜ[R] i, Fin.append (fun i => f (a i)) (fun i => f (b i)) i from
+      _root_.TensorPower.tprod_mul_tprod R _ _]
+  rw [PiTensorProduct.map_tprod]
+  congr 1
+  rw [← hx]
+  ext i
+  refine Fin.addCases ?_ ?_ i
+  · intro j
+    simp only [Fin.append_left]
+  · intro j
+    simp only [Fin.append_right]
+
+end CommSemiring
+
+end TauCeti.TensorPower
+
+namespace Representation
 
 section CommSemiring
 
@@ -80,51 +135,8 @@ theorem char_tensorPower (ρ : Representation R G M) (d : ℕ) (g : G) :
     -- Split `Fin (d + 1)` into `Fin d` and `Fin 1`, then use multiplicativity of trace.
     let e : (⨂[R]^d M) ⊗[R] (⨂[R]^1 M) ≃ₗ[R] (⨂[R]^(d + 1) M) :=
       TensorPower.mulEquiv
-    have he : e.conj
-        (TensorProduct.map (PiTensorProduct.map fun _ : Fin d => ρ g)
-          (PiTensorProduct.map fun _ : Fin 1 => ρ g)) =
-        PiTensorProduct.map (fun _ : Fin (d + 1) => ρ g) := by
-      ext x
-      simp only [LinearMap.compMultilinearMap_apply]
-      -- `ext` leaves the pure tensor behind the defining multilinear map; expose it so the
-      -- public apply lemmas below can rewrite the action without unfolding `TensorPower.mulEquiv`.
-      change e.conj _ (⨂ₜ[R] i, x i) = _
-      rw [LinearEquiv.conj_apply_apply]
-      let a : Fin d → M := fun i => x (Fin.castAdd 1 i)
-      let b : Fin 1 → M := fun i => x (Fin.natAdd d i)
-      have hx : Fin.append a b = x := by
-        ext i
-        refine Fin.addCases ?_ ?_ i
-        · intro j
-          simp only [a, Fin.append_left]
-        · intro j
-          simp only [b, Fin.append_right]
-      have hsplit : e.symm (⨂ₜ[R] i, x i) =
-          (⨂ₜ[R] i, a i) ⊗ₜ[R] (⨂ₜ[R] i, b i) := by
-        apply e.injective
-        rw [e.apply_symm_apply]
-        -- Rewriting cannot match through the local name `e`; this conversion exposes exactly the
-        -- public `tprod_mul_tprod` equation without unfolding the equivalence.
-        rw [show e ((⨂ₜ[R] i, a i) ⊗ₜ[R] (⨂ₜ[R] i, b i)) =
-          ⨂ₜ[R] i, Fin.append a b i from TensorPower.tprod_mul_tprod R a b]
-        rw [hx]
-      rw [hsplit, TensorProduct.map_tmul, PiTensorProduct.map_tprod,
-        PiTensorProduct.map_tprod]
-      -- As above, make the let-bound equivalence transparent only through its public pure-tensor
-      -- equation, which lets `rw` avoid the implementation of `TensorPower.mulEquiv`.
-      rw [show e ((⨂ₜ[R] i, (ρ g) (a i)) ⊗ₜ[R] (⨂ₜ[R] i, (ρ g) (b i))) =
-        ⨂ₜ[R] i, Fin.append (fun i => (ρ g) (a i)) (fun i => (ρ g) (b i)) i from
-          TensorPower.tprod_mul_tprod R _ _]
-      rw [PiTensorProduct.map_tprod]
-      congr 1
-      rw [← hx]
-      ext i
-      refine Fin.addCases ?_ ?_ i
-      · intro j
-        simp only [Fin.append_left]
-      · intro j
-        simp only [Fin.append_right]
-    rw [← he, LinearMap.trace_conj', LinearMap.trace_tensorProduct']
+    rw [← TauCeti.TensorPower.mulEquiv_conj_map, LinearMap.trace_conj',
+      LinearMap.trace_tensorProduct']
     have h_one : LinearMap.trace R (⨂[R]^1 M) (PiTensorProduct.map fun _ : Fin 1 => ρ g) =
         LinearMap.trace R M (ρ g) := by
       let e₁ := PiTensorProduct.subsingletonEquiv (R := R) (s := fun _ : Fin 1 => M) 0

--- a/TauCeti/RepresentationTheory/TensorPower.lean
+++ b/TauCeti/RepresentationTheory/TensorPower.lean
@@ -39,6 +39,16 @@ section CommSemiring
 
 variable [CommSemiring R] [AddCommMonoid M] [Module R M]
 
+/-- A family of linear maps indexed by `Fin 0` acts as the identity on the zero-fold tensor
+power. -/
+@[simp]
+theorem map_fin_zero (f : Fin 0 → M →ₗ[R] M) :
+    PiTensorProduct.map f = LinearMap.id := by
+  rw [← PiTensorProduct.map_id]
+  congr
+  funext i
+  exact Fin.elim0 i
+
 private theorem append_const {α : Type*} {d e : ℕ} (x : α) :
     Fin.append (fun _ : Fin d => x) (fun _ : Fin e => x) = fun _ : Fin (d + e) => x := by
   ext i
@@ -101,14 +111,13 @@ theorem tensorPower_apply (ρ : Representation R G M) (d : ℕ) (g : G) :
   simp only [tensorPower, MonoidHom.comp_apply, PiTensorProduct.mapMonoidHom_apply]
   exact congrArg PiTensorProduct.map (funext fun i => MonoidHom.pi_apply _ g i)
 
-/-- The action on the zero-fold tensor power is the identity. -/
-@[simp]
+/-- The action on the zero-fold tensor power is the identity.
+
+This is intentionally not a simp lemma: `tensorPower_apply` followed by
+`TauCeti.TensorPower.map_fin_zero` already performs this simplification. -/
 theorem tensorPower_zero_apply (ρ : Representation R G M) (g : G) :
     ρ.tensorPower 0 g = LinearMap.id := by
-  rw [tensorPower_apply, ← PiTensorProduct.map_id]
-  congr
-  funext i
-  exact Fin.elim0 i
+  simp
 
 /-- Splitting the factors gives an equivalence from the tensor product of two tensor-power
 representations to the tensor power indexed by their sum. -/

--- a/TauCeti/RepresentationTheory/TensorPower.lean
+++ b/TauCeti/RepresentationTheory/TensorPower.lean
@@ -98,10 +98,9 @@ noncomputable def tensorPower (ρ : Representation R G M) (d : ℕ) :
 /-- The tensor-power action applies the original action in every tensor factor. -/
 @[simp]
 theorem tensorPower_apply (ρ : Representation R G M) (d : ℕ) (g : G) :
-    ρ.tensorPower d g = PiTensorProduct.map fun _ : Fin d => ρ g :=
-  by
-    simp only [tensorPower, MonoidHom.comp_apply, PiTensorProduct.mapMonoidHom_apply]
-    congr 1
+    ρ.tensorPower d g = PiTensorProduct.map fun _ : Fin d => ρ g := by
+  simp only [tensorPower, MonoidHom.comp_apply, PiTensorProduct.mapMonoidHom_apply]
+  exact congrArg PiTensorProduct.map (funext fun i => MonoidHom.pi_apply _ g i)
 
 end CommSemiring
 
@@ -129,8 +128,6 @@ theorem char_tensorPower (ρ : Representation R G M) (d : ℕ) (g : G) :
     simp only [pow_zero]
   | succ d ih =>
     -- Split `Fin (d + 1)` into `Fin d` and `Fin 1`, then use multiplicativity of trace.
-    let e : (⨂[R]^d M) ⊗[R] (⨂[R]^1 M) ≃ₗ[R] (⨂[R]^(d + 1) M) :=
-      TensorPower.mulEquiv
     rw [← TauCeti.TensorPower.mulEquiv_conj_map, LinearMap.trace_conj',
       LinearMap.trace_tensorProduct']
     have h_one : LinearMap.trace R (⨂[R]^1 M) (PiTensorProduct.map fun _ : Fin 1 => ρ g) =

--- a/TauCeti/RepresentationTheory/TensorPower.lean
+++ b/TauCeti/RepresentationTheory/TensorPower.lean
@@ -1,0 +1,104 @@
+/-
+Copyright (c) 2026 Tau Ceti. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Codex
+-/
+module
+
+public import Mathlib.LinearAlgebra.PiTensorProduct.Finite
+public import Mathlib.LinearAlgebra.TensorPower.Basic
+public import Mathlib.RepresentationTheory.Character
+
+/-!
+# Tensor powers of representations
+
+This file equips the tensor power of a representation with its diagonal action. The action on a
+pure tensor applies the original action in every factor. This construction is used by the
+classical-groups roadmap to form tensor powers of the standard representation.
+
+## Main definitions
+
+* `Representation.tensorPower` is the diagonal action on `⨂[R]^d M`.
+* `Representation.tensorPowerFDRep` is the corresponding finite-dimensional representation.
+
+## References
+
+* [Classical groups roadmap](https://github.com/TauCetiProject/TauCetiRoadmap/blob/main/TauCetiRoadmap/RepresentationTheory/ClassicalGroups/README.md), Layer 1.
+-/
+
+public section
+
+open scoped TensorProduct
+
+namespace Representation
+
+universe u v
+
+variable {R : Type u} {G : Type v} {M : Type u}
+
+section CommSemiring
+
+variable [CommSemiring R] [Monoid G] [AddCommMonoid M] [Module R M]
+
+/-- The diagonal action of `G` on the `d`-fold tensor power of a representation. -/
+noncomputable def tensorPower (ρ : Representation R G M) (d : ℕ) :
+    Representation R G (⨂[R]^d M) where
+  toFun g := PiTensorProduct.map fun _ : Fin d => ρ g
+  map_one' := by
+    change PiTensorProduct.map (fun _ : Fin d => ρ 1) = 1
+    simpa only [map_one] using (PiTensorProduct.map_one (R := R) (s := fun _ : Fin d => M))
+  map_mul' g h := by
+    change PiTensorProduct.map (fun _ : Fin d => ρ (g * h)) =
+      PiTensorProduct.map (fun _ : Fin d => ρ g) * PiTensorProduct.map (fun _ : Fin d => ρ h)
+    simpa only [map_mul] using
+      (PiTensorProduct.map_mul (R := R) (s := fun _ : Fin d => M)
+        (fun _ : Fin d => ρ g) (fun _ : Fin d => ρ h))
+
+/-- The tensor-power action applies the original action in every tensor factor. -/
+@[simp]
+theorem tensorPower_apply (ρ : Representation R G M) (d : ℕ) (g : G) :
+    ρ.tensorPower d g = PiTensorProduct.map fun _ : Fin d => ρ g :=
+  by unfold tensorPower; rfl
+
+/-- The tensor-power action on a pure tensor is the pure tensor of the factorwise actions. -/
+@[simp]
+theorem tensorPower_apply_tprod (ρ : Representation R G M) (d : ℕ) (g : G) (m : Fin d → M) :
+    ρ.tensorPower d g (PiTensorProduct.tprod R m) =
+      PiTensorProduct.tprod R (fun i => ρ g (m i)) := by
+  rw [tensorPower_apply, PiTensorProduct.map_tprod]
+
+/-- The zero-fold tensor-power action is the identity. -/
+@[simp]
+theorem tensorPower_zero_apply (ρ : Representation R G M) (g : G) :
+    ρ.tensorPower 0 g = LinearMap.id := by
+  rw [tensorPower_apply]
+  have h : (fun _ : Fin 0 => ρ g) = (fun _ : Fin 0 => LinearMap.id) := Subsingleton.elim _ _
+  rw [h, PiTensorProduct.map_id]
+
+end CommSemiring
+
+section CommRing
+
+variable [CommRing R] [Group G] [AddCommGroup M] [Module R M] [Module.Finite R M]
+
+/-- The tensor power of a finite representation, bundled as an object of `FDRep`. -/
+noncomputable abbrev tensorPowerFDRep (ρ : Representation R G M) (d : ℕ) : FDRep R G :=
+  FDRep.of (ρ.tensorPower d)
+
+/-- The action of `tensorPowerFDRep` is the diagonal tensor-power action. -/
+@[simp]
+theorem tensorPowerFDRep_ρ (ρ : Representation R G M) (d : ℕ) :
+    (ρ.tensorPowerFDRep d).ρ = ρ.tensorPower d :=
+  rfl
+
+/-- The tensor-power finite-dimensional representation acts factorwise on pure tensors. -/
+@[simp]
+theorem tensorPowerFDRep_apply_tprod (ρ : Representation R G M) (d : ℕ) (g : G)
+    (m : Fin d → M) :
+    (ρ.tensorPowerFDRep d).ρ g (PiTensorProduct.tprod R m) =
+      PiTensorProduct.tprod R (fun i => ρ g (m i)) :=
+  tensorPower_apply_tprod ρ d g m
+
+end CommRing
+
+end Representation

--- a/TauCeti/RepresentationTheory/TensorPower.lean
+++ b/TauCeti/RepresentationTheory/TensorPower.lean
@@ -47,11 +47,8 @@ theorem mulEquiv_conj_map (f : M →ₗ[R] M) (d e : ℕ) :
         (TensorProduct.map (PiTensorProduct.map fun _ : Fin d => f)
           (PiTensorProduct.map fun _ : Fin e => f)) =
       PiTensorProduct.map (fun _ : Fin (d + e) => f) := by
-  let equiv : (⨂[R]^d M) ⊗[R] (⨂[R]^e M) ≃ₗ[R] (⨂[R]^(d + e) M) :=
-    _root_.TensorPower.mulEquiv
   ext x
   simp only [LinearMap.compMultilinearMap_apply]
-  change equiv.conj _ (⨂ₜ[R] i, x i) = _
   rw [LinearEquiv.conj_apply_apply]
   let a : Fin d → M := fun i => x (Fin.castAdd e i)
   let b : Fin e → M := fun i => x (Fin.natAdd d i)
@@ -62,18 +59,17 @@ theorem mulEquiv_conj_map (f : M →ₗ[R] M) (d e : ℕ) :
       simp only [a, Fin.append_left]
     · intro j
       simp only [b, Fin.append_right]
-  have hsplit : equiv.symm (⨂ₜ[R] i, x i) =
+  have hsplit : (_root_.TensorPower.mulEquiv :
+      (⨂[R]^d M) ⊗[R] (⨂[R]^e M) ≃ₗ[R] (⨂[R]^(d + e) M)).symm (⨂ₜ[R] i, x i) =
       (⨂ₜ[R] i, a i) ⊗ₜ[R] (⨂ₜ[R] i, b i) := by
-    apply equiv.injective
-    rw [equiv.apply_symm_apply]
-    rw [show equiv ((⨂ₜ[R] i, a i) ⊗ₜ[R] (⨂ₜ[R] i, b i)) =
-      ⨂ₜ[R] i, Fin.append a b i from _root_.TensorPower.tprod_mul_tprod R a b]
+    apply (_root_.TensorPower.mulEquiv :
+      (⨂[R]^d M) ⊗[R] (⨂[R]^e M) ≃ₗ[R] (⨂[R]^(d + e) M)).injective
+    rw [LinearEquiv.apply_symm_apply]
+    rw [← _root_.TensorPower.gMul_def, _root_.TensorPower.tprod_mul_tprod]
     rw [hx]
   rw [hsplit, TensorProduct.map_tmul, PiTensorProduct.map_tprod,
     PiTensorProduct.map_tprod]
-  rw [show equiv ((⨂ₜ[R] i, f (a i)) ⊗ₜ[R] (⨂ₜ[R] i, f (b i))) =
-    ⨂ₜ[R] i, Fin.append (fun i => f (a i)) (fun i => f (b i)) i from
-      _root_.TensorPower.tprod_mul_tprod R _ _]
+  rw [← _root_.TensorPower.gMul_def, _root_.TensorPower.tprod_mul_tprod]
   rw [PiTensorProduct.map_tprod]
   congr 1
   rw [← hx]

--- a/TauCeti/RepresentationTheory/TensorPower.lean
+++ b/TauCeti/RepresentationTheory/TensorPower.lean
@@ -5,9 +5,8 @@ Authors: Codex
 -/
 module
 
-public import Mathlib.LinearAlgebra.PiTensorProduct.Finite
 public import Mathlib.LinearAlgebra.TensorPower.Basic
-public import Mathlib.RepresentationTheory.Character
+public import Mathlib.RepresentationTheory.Basic
 
 /-!
 # Tensor powers of representations
@@ -19,7 +18,6 @@ classical-groups roadmap to form tensor powers of the standard representation.
 ## Main definitions
 
 * `Representation.tensorPower` is the diagonal action on `⨂[R]^d M`.
-* `Representation.tensorPowerFDRep` is the corresponding finite-dimensional representation.
 
 ## References
 
@@ -32,9 +30,9 @@ open scoped TensorProduct
 
 namespace Representation
 
-universe u v
+universe u v w
 
-variable {R : Type u} {G : Type v} {M : Type u}
+variable {R : Type u} {G : Type v} {M : Type w}
 
 section CommSemiring
 
@@ -42,17 +40,8 @@ variable [CommSemiring R] [Monoid G] [AddCommMonoid M] [Module R M]
 
 /-- The diagonal action of `G` on the `d`-fold tensor power of a representation. -/
 noncomputable def tensorPower (ρ : Representation R G M) (d : ℕ) :
-    Representation R G (⨂[R]^d M) where
-  toFun g := PiTensorProduct.map fun _ : Fin d => ρ g
-  map_one' := by
-    change PiTensorProduct.map (fun _ : Fin d => ρ 1) = 1
-    simpa only [map_one] using (PiTensorProduct.map_one (R := R) (s := fun _ : Fin d => M))
-  map_mul' g h := by
-    change PiTensorProduct.map (fun _ : Fin d => ρ (g * h)) =
-      PiTensorProduct.map (fun _ : Fin d => ρ g) * PiTensorProduct.map (fun _ : Fin d => ρ h)
-    simpa only [map_mul] using
-      (PiTensorProduct.map_mul (R := R) (s := fun _ : Fin d => M)
-        (fun _ : Fin d => ρ g) (fun _ : Fin d => ρ h))
+    Representation R G (⨂[R]^d M) :=
+  PiTensorProduct.mapMonoidHom.comp (MonoidHom.pi fun _ : Fin d => ρ)
 
 /-- The tensor-power action applies the original action in every tensor factor. -/
 @[simp]
@@ -61,15 +50,5 @@ theorem tensorPower_apply (ρ : Representation R G M) (d : ℕ) (g : G) :
   by unfold tensorPower; rfl
 
 end CommSemiring
-
-section CommRing
-
-variable [CommRing R] [Group G] [AddCommGroup M] [Module R M] [Module.Finite R M]
-
-/-- The tensor power of a finite representation, bundled as an object of `FDRep`. -/
-noncomputable abbrev tensorPowerFDRep (ρ : Representation R G M) (d : ℕ) : FDRep R G :=
-  FDRep.of (ρ.tensorPower d)
-
-end CommRing
 
 end Representation

--- a/TauCeti/RepresentationTheory/TensorPower.lean
+++ b/TauCeti/RepresentationTheory/TensorPower.lean
@@ -6,7 +6,7 @@ Authors: Codex
 module
 
 public import Mathlib.LinearAlgebra.TensorPower.Basic
-import Mathlib.LinearAlgebra.PiTensorProduct.Basis
+public import Mathlib.LinearAlgebra.PiTensorProduct.Finite
 public import Mathlib.RepresentationTheory.Basic
 public import Mathlib.RepresentationTheory.Character
 
@@ -62,8 +62,6 @@ variable [Field R] [Monoid G] [AddCommGroup M] [Module R M] [FiniteDimensional R
 theorem char_tensorPower (ρ : Representation R G M) (d : ℕ) (g : G) :
     (ρ.tensorPower d).character g = (ρ.character g) ^ d := by
   classical
-  letI (d : ℕ) : FiniteDimensional R (⨂[R]^d M) :=
-    (Basis.piTensorProduct fun _ : Fin d => Module.finBasis R M).finiteDimensional_of_finite
   simp only [Representation.character, tensorPower_apply]
   induction d with
   | zero =>

--- a/TauCeti/RepresentationTheory/TensorPower.lean
+++ b/TauCeti/RepresentationTheory/TensorPower.lean
@@ -6,7 +6,7 @@ Authors: Codex
 module
 
 public import Mathlib.LinearAlgebra.TensorPower.Basic
-public import Mathlib.LinearAlgebra.PiTensorProduct.Basis
+import Mathlib.LinearAlgebra.PiTensorProduct.Basis
 public import Mathlib.RepresentationTheory.Basic
 public import Mathlib.RepresentationTheory.Character
 

--- a/TauCeti/RepresentationTheory/TensorPower.lean
+++ b/TauCeti/RepresentationTheory/TensorPower.lean
@@ -60,21 +60,6 @@ theorem tensorPower_apply (ρ : Representation R G M) (d : ℕ) (g : G) :
     ρ.tensorPower d g = PiTensorProduct.map fun _ : Fin d => ρ g :=
   by unfold tensorPower; rfl
 
-/-- The tensor-power action on a pure tensor is the pure tensor of the factorwise actions. -/
-@[simp]
-theorem tensorPower_apply_tprod (ρ : Representation R G M) (d : ℕ) (g : G) (m : Fin d → M) :
-    ρ.tensorPower d g (PiTensorProduct.tprod R m) =
-      PiTensorProduct.tprod R (fun i => ρ g (m i)) := by
-  rw [tensorPower_apply, PiTensorProduct.map_tprod]
-
-/-- The zero-fold tensor-power action is the identity. -/
-@[simp]
-theorem tensorPower_zero_apply (ρ : Representation R G M) (g : G) :
-    ρ.tensorPower 0 g = LinearMap.id := by
-  rw [tensorPower_apply]
-  have h : (fun _ : Fin 0 => ρ g) = (fun _ : Fin 0 => LinearMap.id) := Subsingleton.elim _ _
-  rw [h, PiTensorProduct.map_id]
-
 end CommSemiring
 
 section CommRing
@@ -84,20 +69,6 @@ variable [CommRing R] [Group G] [AddCommGroup M] [Module R M] [Module.Finite R M
 /-- The tensor power of a finite representation, bundled as an object of `FDRep`. -/
 noncomputable abbrev tensorPowerFDRep (ρ : Representation R G M) (d : ℕ) : FDRep R G :=
   FDRep.of (ρ.tensorPower d)
-
-/-- The action of `tensorPowerFDRep` is the diagonal tensor-power action. -/
-@[simp]
-theorem tensorPowerFDRep_ρ (ρ : Representation R G M) (d : ℕ) :
-    (ρ.tensorPowerFDRep d).ρ = ρ.tensorPower d :=
-  rfl
-
-/-- The tensor-power finite-dimensional representation acts factorwise on pure tensors. -/
-@[simp]
-theorem tensorPowerFDRep_apply_tprod (ρ : Representation R G M) (d : ℕ) (g : G)
-    (m : Fin d → M) :
-    (ρ.tensorPowerFDRep d).ρ g (PiTensorProduct.tprod R m) =
-      PiTensorProduct.tprod R (fun i => ρ g (m i)) :=
-  tensorPower_apply_tprod ρ d g m
 
 end CommRing
 

--- a/TauCeti/RepresentationTheory/TensorPower.lean
+++ b/TauCeti/RepresentationTheory/TensorPower.lean
@@ -39,46 +39,45 @@ section CommSemiring
 
 variable [CommSemiring R] [AddCommMonoid M] [Module R M]
 
-/-- Splitting a tensor power intertwines the tensor product of diagonal maps with the
-diagonal map on the combined tensor power. -/
-theorem mulEquiv_conj_map (f : M →ₗ[R] M) (d e : ℕ) :
+private theorem append_const {α : Type*} {d e : ℕ} (x : α) :
+    Fin.append (fun _ : Fin d => x) (fun _ : Fin e => x) = fun _ : Fin (d + e) => x := by
+  ext i
+  refine Fin.addCases ?_ ?_ i <;> simp
+
+private theorem mulEquiv_map {d e : ℕ} (f : Fin d → M →ₗ[R] M)
+    (g : Fin e → M →ₗ[R] M) :
+    (_root_.TensorPower.mulEquiv :
+      (⨂[R]^d M) ⊗[R] (⨂[R]^e M) ≃ₗ[R] (⨂[R]^(d + e) M)).toLinearMap ∘ₗ
+        TensorProduct.map (PiTensorProduct.map f) (PiTensorProduct.map g) =
+      PiTensorProduct.map (Fin.append f g) ∘ₗ
+        (_root_.TensorPower.mulEquiv :
+          (⨂[R]^d M) ⊗[R] (⨂[R]^e M) ≃ₗ[R] (⨂[R]^(d + e) M)).toLinearMap := by
+  ext x y
+  simp only [LinearMap.compMultilinearMap_apply, TensorProduct.AlgebraTensorModule.curry_apply,
+    LinearMap.restrictScalars_self, TensorProduct.curry_apply, LinearMap.coe_comp,
+    LinearEquiv.coe_coe, Function.comp_apply, TensorProduct.map_tmul,
+    PiTensorProduct.map_tprod]
+  rw [← _root_.TensorPower.gMul_def, _root_.TensorPower.tprod_mul_tprod,
+    ← _root_.TensorPower.gMul_def, _root_.TensorPower.tprod_mul_tprod,
+    PiTensorProduct.map_tprod]
+  congr 1 with i
+  refine Fin.addCases ?_ ?_ i <;> intro j <;> simp [Fin.append]
+
+/-- Splitting a tensor power intertwines separate families of maps on the two factors with
+their appended family on the combined tensor power. -/
+theorem mulEquiv_conj_map {d e : ℕ} (f : Fin d → M →ₗ[R] M) (g : Fin e → M →ₗ[R] M) :
     (_root_.TensorPower.mulEquiv :
       (⨂[R]^d M) ⊗[R] (⨂[R]^e M) ≃ₗ[R] (⨂[R]^(d + e) M)).conj
-        (TensorProduct.map (PiTensorProduct.map fun _ : Fin d => f)
-          (PiTensorProduct.map fun _ : Fin e => f)) =
-      PiTensorProduct.map (fun _ : Fin (d + e) => f) := by
-  ext x
-  simp only [LinearMap.compMultilinearMap_apply]
+        (TensorProduct.map (PiTensorProduct.map f) (PiTensorProduct.map g)) =
+      PiTensorProduct.map (Fin.append f g) := by
+  apply LinearMap.ext
+  intro x
   rw [LinearEquiv.conj_apply_apply]
-  let a : Fin d → M := fun i => x (Fin.castAdd e i)
-  let b : Fin e → M := fun i => x (Fin.natAdd d i)
-  have hx : Fin.append a b = x := by
-    ext i
-    refine Fin.addCases ?_ ?_ i
-    · intro j
-      simp only [a, Fin.append_left]
-    · intro j
-      simp only [b, Fin.append_right]
-  have hsplit : (_root_.TensorPower.mulEquiv :
-      (⨂[R]^d M) ⊗[R] (⨂[R]^e M) ≃ₗ[R] (⨂[R]^(d + e) M)).symm (⨂ₜ[R] i, x i) =
-      (⨂ₜ[R] i, a i) ⊗ₜ[R] (⨂ₜ[R] i, b i) := by
-    apply (_root_.TensorPower.mulEquiv :
-      (⨂[R]^d M) ⊗[R] (⨂[R]^e M) ≃ₗ[R] (⨂[R]^(d + e) M)).injective
-    rw [LinearEquiv.apply_symm_apply]
-    rw [← _root_.TensorPower.gMul_def, _root_.TensorPower.tprod_mul_tprod]
-    rw [hx]
-  rw [hsplit, TensorProduct.map_tmul, PiTensorProduct.map_tprod,
-    PiTensorProduct.map_tprod]
-  rw [← _root_.TensorPower.gMul_def, _root_.TensorPower.tprod_mul_tprod]
-  rw [PiTensorProduct.map_tprod]
-  congr 1
-  rw [← hx]
-  ext i
-  refine Fin.addCases ?_ ?_ i
-  · intro j
-    simp only [Fin.append_left]
-  · intro j
-    simp only [Fin.append_right]
+  have h := LinearMap.congr_fun (mulEquiv_map f g)
+    ((_root_.TensorPower.mulEquiv :
+      (⨂[R]^d M) ⊗[R] (⨂[R]^e M) ≃ₗ[R] (⨂[R]^(d + e) M)).symm x)
+  simpa only [LinearMap.comp_apply, LinearEquiv.apply_symm_apply,
+    LinearEquiv.coe_coe] using h
 
 end CommSemiring
 
@@ -101,6 +100,24 @@ theorem tensorPower_apply (ρ : Representation R G M) (d : ℕ) (g : G) :
     ρ.tensorPower d g = PiTensorProduct.map fun _ : Fin d => ρ g := by
   simp only [tensorPower, MonoidHom.comp_apply, PiTensorProduct.mapMonoidHom_apply]
   exact congrArg PiTensorProduct.map (funext fun i => MonoidHom.pi_apply _ g i)
+
+/-- The action on the zero-fold tensor power is the identity. -/
+@[simp]
+theorem tensorPower_zero_apply (ρ : Representation R G M) (g : G) :
+    ρ.tensorPower 0 g = LinearMap.id := by
+  rw [tensorPower_apply, ← PiTensorProduct.map_id]
+  congr
+  funext i
+  exact Fin.elim0 i
+
+/-- Splitting the factors gives an equivalence from the tensor product of two tensor-power
+representations to the tensor power indexed by their sum. -/
+noncomputable def tensorPowerAddEquiv (ρ : Representation R G M) (d e : ℕ) :
+    ((ρ.tensorPower d).tprod (ρ.tensorPower e)).Equiv (ρ.tensorPower (d + e)) :=
+  .mk (_root_.TensorPower.mulEquiv) fun g => by
+    rw [tprod_apply, tensorPower_apply, tensorPower_apply, tensorPower_apply]
+    simpa only [TauCeti.TensorPower.append_const] using
+      TauCeti.TensorPower.mulEquiv_map (fun _ : Fin d => ρ g) (fun _ : Fin e => ρ g)
 
 end CommSemiring
 
@@ -128,7 +145,9 @@ theorem char_tensorPower (ρ : Representation R G M) (d : ℕ) (g : G) :
     simp only [pow_zero]
   | succ d ih =>
     -- Split `Fin (d + 1)` into `Fin d` and `Fin 1`, then use multiplicativity of trace.
-    rw [← TauCeti.TensorPower.mulEquiv_conj_map, LinearMap.trace_conj',
+    rw [← TauCeti.TensorPower.append_const (d := d) (e := 1) (ρ g),
+      ← TauCeti.TensorPower.mulEquiv_conj_map (fun _ : Fin d => ρ g)
+      (fun _ : Fin 1 => ρ g), LinearMap.trace_conj',
       LinearMap.trace_tensorProduct']
     have h_one : LinearMap.trace R (⨂[R]^1 M) (PiTensorProduct.map fun _ : Fin 1 => ρ g) =
         LinearMap.trace R M (ρ g) := by

--- a/TauCeti/RepresentationTheory/TensorPower.lean
+++ b/TauCeti/RepresentationTheory/TensorPower.lean
@@ -142,12 +142,7 @@ theorem char_tensorPower (ρ : Representation R G M) (d : ℕ) (g : G) :
   simp only [Representation.character, tensorPower_apply]
   induction d with
   | zero =>
-    have hmap : PiTensorProduct.map (fun _ : Fin 0 => ρ g) = LinearMap.id := by
-      rw [← PiTensorProduct.map_id]
-      congr
-      funext i
-      exact Fin.elim0 i
-    rw [hmap]
+    rw [TauCeti.TensorPower.map_fin_zero]
     let e := PiTensorProduct.isEmptyEquiv (Fin 0) (R := R) (s := fun _ => M)
     rw [← LinearMap.trace_conj' (LinearMap.id : (⨂[R]^0 M) →ₗ[R] _) e]
     rw [LinearEquiv.conj_id, LinearMap.trace_id, Module.finrank_self, Nat.cast_one]


### PR DESCRIPTION
This PR adds the diagonal tensor-power construction for representations and specializes it to the standard representation of `GL n k`. It supplies pure-tensor action formulas, the zero-fold action, and bundled finite-dimensional forms, giving the Layer 1 tensor-power representation a reusable foundation.

This advances `TauCetiRoadmap/RepresentationTheory/ClassicalGroups/README.md`, Layer 1, item “The tensor power representation”: `tensorPowerRep n d : Representation ℂ (GL n ℂ) (⨂[ℂ]^d (Fin n → ℂ))`. The general `Representation.tensorPower` is the direct prerequisite that equips the requested standard tensor power with its diagonal action, while the specialization is stated over a commutative ring so later applications are not needlessly restricted to `ℂ`.

No Mathlib infrastructure or supplementary-source material is vendored. The implementation reuses Mathlib's `PiTensorProduct.map`, its pure-tensor API, and `FDRep.of`.

<!--tauceti-target:v1 {"focus":"RepresentationTheory","id":"tensor-power-representation"}-->

🤖 Prepared with Codex
