### PR TITLE
feat: positive and negative roots

### DIFF
--- a/TauCeti/LinearAlgebra/RootSystem/Positive.lean
+++ b/TauCeti/LinearAlgebra/RootSystem/Positive.lean
@@ -22,7 +22,8 @@ and negative root indices. It records their partition and their exchange under r
 ## References
 
 This file implements the “Positive and negative roots” item in Layer 1 of
-`TauCetiRoadmap/RepresentationTheory/RootSystems/README.md`.
+`TauCetiRoadmap/RepresentationTheory/RootSystems/README.md`, following the target signatures in
+`TauCetiRoadmap/RepresentationTheory/RootSystems/Suggested.lean`.
 -/
 
 namespace TauCeti
@@ -98,17 +99,11 @@ lemma posRoots_nonempty [Nonempty ι] : (posRoots P b).Nonempty := by
   · exact ⟨i, hi⟩
   · exact ⟨-i, hi⟩
 
-omit [CharZero R] in
-/-- The root-negation index is the self-reflection index. -/
-private lemma reflectionPerm_self_eq_neg (i : ι) :
-    letI := P.indexNeg
-    P.reflectionPerm i i = -i := rfl
-
 /-- The negative of a positive root is negative. -/
 lemma reflectionPerm_self_mem_negRoots_iff_mem_posRoots (i : ι) :
     P.reflectionPerm i i ∈ negRoots P b ↔ i ∈ posRoots P b := by
   letI := P.indexNeg
-  rw [reflectionPerm_self_eq_neg, mem_negRoots, mem_posRoots,
+  rw [← RootPairing.indexNeg_neg, mem_negRoots, mem_posRoots,
     RootPairing.Base.IsPos.neg_iff_not]
   exact not_not
 
@@ -117,7 +112,7 @@ lemma reflectionPerm_self_mem_negRoots_iff_mem_posRoots (i : ι) :
 lemma isPos_reflectionPerm_self_iff_mem_negRoots (i : ι) :
     b.IsPos (P.reflectionPerm i i) ↔ i ∈ negRoots P b := by
   letI := P.indexNeg
-  rw [reflectionPerm_self_eq_neg, mem_negRoots]
+  rw [← RootPairing.indexNeg_neg, mem_negRoots]
   exact RootPairing.Base.IsPos.neg_iff_not b i
 
 /-- The negative of a negative root is positive. -/
@@ -147,7 +142,7 @@ lemma exists_root_eq_sum_nat_of_mem_posRoots {i : ι} (hi : i ∈ posRoots P b) 
 theorem image_reflectionPerm_self_posRoots :
     (fun i ↦ P.reflectionPerm i i) '' posRoots P b = negRoots P b := by
   letI := P.indexNeg
-  simp_rw [reflectionPerm_self_eq_neg P]
+  simp_rw [← RootPairing.indexNeg_neg]
   ext i
   constructor
   · rintro ⟨j, hj, rfl⟩
@@ -165,10 +160,7 @@ theorem image_reflectionPerm_self_negRoots :
   letI := P.indexNeg
   have hinv : Function.Involutive (fun i : ι ↦ P.reflectionPerm i i) := by
     intro i
-    have hneg : (fun j : ι ↦ P.reflectionPerm j j) = fun j ↦ -j :=
-      funext (reflectionPerm_self_eq_neg P)
-    rw [hneg]
-    exact neg_neg i
+    simp only [← RootPairing.indexNeg_neg, neg_neg]
   calc
     (fun i ↦ P.reflectionPerm i i) '' negRoots P b =
         (fun i ↦ P.reflectionPerm i i) '' (posRoots P b)ᶜ := by rw [negRoots_eq_compl]

--- a/TauCeti/RepresentationTheory/RootSystems/Positive.lean
+++ b/TauCeti/RepresentationTheory/RootSystems/Positive.lean
@@ -105,7 +105,6 @@ private lemma reflectionPerm_self_eq_neg (i : ι) :
     P.reflectionPerm i i = -i := rfl
 
 /-- The negative of a positive root is negative. -/
-@[simp]
 lemma reflectionPerm_self_mem_negRoots_iff_mem_posRoots (i : ι) :
     P.reflectionPerm i i ∈ negRoots P b ↔ i ∈ posRoots P b := by
   letI := P.indexNeg
@@ -116,9 +115,9 @@ lemma reflectionPerm_self_mem_negRoots_iff_mem_posRoots (i : ι) :
 /-- The negative of a negative root is positive. -/
 @[simp]
 lemma reflectionPerm_self_mem_posRoots_iff_mem_negRoots (i : ι) :
-    P.reflectionPerm i i ∈ posRoots P b ↔ i ∈ negRoots P b := by
+    b.IsPos (P.reflectionPerm i i) ↔ i ∈ negRoots P b := by
   letI := P.indexNeg
-  rw [reflectionPerm_self_eq_neg, mem_posRoots, mem_negRoots]
+  rw [reflectionPerm_self_eq_neg, mem_negRoots]
   exact RootPairing.Base.IsPos.neg_iff_not b i
 
 /-- A positive root is a nonnegative natural-number combination of simple roots. -/

--- a/TauCeti/RepresentationTheory/RootSystems/Positive.lean
+++ b/TauCeti/RepresentationTheory/RootSystems/Positive.lean
@@ -36,11 +36,9 @@ variable {ι : Type u} {R : Type v} {M : Type w} {N : Type x}
   (P : RootPairing ι R M N)
 
 /-- The positive roots relative to a base. -/
-@[expose]
 def posRoots [CharZero R] (b : P.Base) : Set ι := {i | b.IsPos i}
 
 /-- The negative roots relative to a base. -/
-@[expose]
 def negRoots [CharZero R] (b : P.Base) : Set ι := {i | ¬ b.IsPos i}
 
 variable [CharZero R] (b : P.Base)
@@ -54,10 +52,12 @@ lemma mem_posRoots (i : ι) : i ∈ posRoots P b ↔ b.IsPos i := Iff.rfl
 lemma mem_negRoots (i : ι) : i ∈ negRoots P b ↔ ¬ b.IsPos i := Iff.rfl
 
 /-- The negative roots are the complement of the positive roots. -/
-lemma posRoots_compl : (posRoots P b)ᶜ = negRoots P b := rfl
+lemma posRoots_compl : (posRoots P b)ᶜ = negRoots P b := by
+  ext i
+  simp only [Set.mem_compl_iff, mem_posRoots, mem_negRoots]
 
 /-- The negative roots are the complement of the positive roots. -/
-lemma negRoots_compl : negRoots P b = (posRoots P b)ᶜ := rfl
+lemma negRoots_compl : negRoots P b = (posRoots P b)ᶜ := posRoots_compl P b |>.symm
 
 /-- No root is both positive and negative. -/
 lemma disjoint_posRoots_negRoots : Disjoint (posRoots P b) (negRoots P b) := by
@@ -98,20 +98,46 @@ lemma posRoots_nonempty [Nonempty ι] : (posRoots P b).Nonempty := by
   · exact ⟨i, hi⟩
   · exact ⟨-i, hi⟩
 
+omit [CharZero R] in
+/-- The root-negation index is the self-reflection index. -/
+private lemma reflectionPerm_self_eq_neg (i : ι) :
+    letI := P.indexNeg
+    P.reflectionPerm i i = -i := rfl
+
 /-- The negative of a positive root is negative. -/
+@[simp]
 lemma reflectionPerm_self_mem_negRoots_iff_mem_posRoots (i : ι) :
     P.reflectionPerm i i ∈ negRoots P b ↔ i ∈ posRoots P b := by
   letI := P.indexNeg
-  change ¬ b.IsPos (-i) ↔ b.IsPos i
-  rw [RootPairing.Base.IsPos.neg_iff_not b i]
+  rw [reflectionPerm_self_eq_neg, mem_negRoots, mem_posRoots,
+    RootPairing.Base.IsPos.neg_iff_not]
   exact not_not
 
 /-- The negative of a negative root is positive. -/
+@[simp]
 lemma reflectionPerm_self_mem_posRoots_iff_mem_negRoots (i : ι) :
     P.reflectionPerm i i ∈ posRoots P b ↔ i ∈ negRoots P b := by
   letI := P.indexNeg
-  change b.IsPos (-i) ↔ ¬ b.IsPos i
+  rw [reflectionPerm_self_eq_neg, mem_posRoots, mem_negRoots]
   exact RootPairing.Base.IsPos.neg_iff_not b i
+
+/-- A positive root is a nonnegative natural-number combination of simple roots. -/
+lemma exists_root_eq_sum_nat_of_mem_posRoots {i : ι} (hi : i ∈ posRoots P b) :
+    ∃ f : ι → ℕ, f.support ⊆ b.support ∧
+      P.root i = ∑ j ∈ b.support, f j • P.root j := by
+  obtain ⟨f, hf, hpos | hneg⟩ := b.exists_root_eq_sum_nat_or_neg i
+  · exact ⟨f, hf, hpos⟩
+  · exfalso
+    let g : ι → ℤ := fun j ↦ -(f j : ℤ)
+    have hroot : P.root i = ∑ j ∈ b.support, g j • P.root j := by
+      rw [hneg]
+      simp only [g, Finset.sum_neg_distrib, neg_smul, Nat.cast_smul_eq_nsmul]
+    have hheight : b.height i = ∑ j ∈ b.support, g j := b.height_eq_sum hroot
+    rw [mem_posRoots, RootPairing.Base.isPos_iff] at hi
+    rw [hheight] at hi
+    have hnonpos : ∑ j ∈ b.support, g j ≤ 0 :=
+      Finset.sum_nonpos fun j _ ↦ by simp [g]
+    exact (not_lt_of_ge hnonpos hi).elim
 
 /-- Root negation exchanges positive and negative roots. -/
 theorem image_reflectionPerm_self_posRoots :
@@ -120,26 +146,30 @@ theorem image_reflectionPerm_self_posRoots :
   ext i
   constructor
   · rintro ⟨j, hj, rfl⟩
-    change ¬ b.IsPos (-j)
+    simp only [mem_negRoots, mem_posRoots] at hj ⊢
     intro hneg
     exact (RootPairing.Base.IsPos.neg_iff_not b j).mp hneg hj
   · intro hi
     refine ⟨-i, ?_, neg_neg i⟩
+    simp only [mem_negRoots, mem_posRoots] at hi ⊢
     exact (RootPairing.Base.IsPos.neg_iff_not b i).mpr hi
 
 /-- Root negation exchanges negative and positive roots. -/
 theorem image_reflectionPerm_self_negRoots :
     (fun i ↦ P.reflectionPerm i i) '' negRoots P b = posRoots P b := by
   letI := P.indexNeg
-  ext i
-  constructor
-  · rintro ⟨j, hj, rfl⟩
-    change b.IsPos (-j)
-    exact (RootPairing.Base.IsPos.neg_iff_not b j).mpr hj
-  · intro hi
-    refine ⟨-i, ?_, neg_neg i⟩
-    change ¬ b.IsPos (-i)
-    intro hneg
-    exact (RootPairing.Base.IsPos.neg_iff_not b i).mp hneg hi
+  have hinv : Function.Involutive (fun i : ι ↦ P.reflectionPerm i i) := by
+    intro i
+    exact neg_neg i
+  calc
+    (fun i ↦ P.reflectionPerm i i) '' negRoots P b =
+        (fun i ↦ P.reflectionPerm i i) '' (posRoots P b)ᶜ := by rw [negRoots_compl]
+    _ = ((fun i ↦ P.reflectionPerm i i) '' posRoots P b)ᶜ :=
+      Set.image_compl_eq hinv.bijective
+    _ = (negRoots P b)ᶜ := by rw [image_reflectionPerm_self_posRoots]
+    _ = posRoots P b := by
+      ext i
+      simp only [Set.mem_compl_iff, mem_negRoots, mem_posRoots]
+      tauto
 
 end TauCeti

--- a/TauCeti/RepresentationTheory/RootSystems/Positive.lean
+++ b/TauCeti/RepresentationTheory/RootSystems/Positive.lean
@@ -165,8 +165,9 @@ theorem image_reflectionPerm_self_negRoots :
   letI := P.indexNeg
   have hinv : Function.Involutive (fun i : ι ↦ P.reflectionPerm i i) := by
     intro i
-    rw [show (fun j : ι ↦ P.reflectionPerm j j) = fun j ↦ -j from
-      funext (reflectionPerm_self_eq_neg P)]
+    have hneg : (fun j : ι ↦ P.reflectionPerm j j) = fun j ↦ -j :=
+      funext (reflectionPerm_self_eq_neg P)
+    rw [hneg]
     exact neg_neg i
   calc
     (fun i ↦ P.reflectionPerm i i) '' negRoots P b =

--- a/TauCeti/RepresentationTheory/RootSystems/Positive.lean
+++ b/TauCeti/RepresentationTheory/RootSystems/Positive.lean
@@ -52,12 +52,12 @@ lemma mem_posRoots (i : ι) : i ∈ posRoots P b ↔ b.IsPos i := Iff.rfl
 lemma mem_negRoots (i : ι) : i ∈ negRoots P b ↔ ¬ b.IsPos i := Iff.rfl
 
 /-- The negative roots are the complement of the positive roots. -/
-lemma posRoots_compl : (posRoots P b)ᶜ = negRoots P b := by
+lemma compl_posRoots : (posRoots P b)ᶜ = negRoots P b := by
   ext i
   simp only [Set.mem_compl_iff, mem_posRoots, mem_negRoots]
 
 /-- The negative roots are the complement of the positive roots. -/
-lemma negRoots_compl : negRoots P b = (posRoots P b)ᶜ := posRoots_compl P b |>.symm
+lemma negRoots_eq_compl : negRoots P b = (posRoots P b)ᶜ := compl_posRoots P b |>.symm
 
 /-- No root is both positive and negative. -/
 lemma disjoint_posRoots_negRoots : Disjoint (posRoots P b) (negRoots P b) := by
@@ -66,7 +66,7 @@ lemma disjoint_posRoots_negRoots : Disjoint (posRoots P b) (negRoots P b) := by
 
 /-- Every root is either positive or negative. -/
 lemma posRoots_union_negRoots : posRoots P b ∪ negRoots P b = Set.univ := by
-  rw [negRoots_compl]
+  rw [negRoots_eq_compl]
   exact Set.union_compl_self _
 
 /-- Every root is either positive or negative. -/
@@ -105,6 +105,7 @@ private lemma reflectionPerm_self_eq_neg (i : ι) :
     P.reflectionPerm i i = -i := rfl
 
 /-- The negative of a positive root is negative. -/
+@[simp]
 lemma reflectionPerm_self_mem_negRoots_iff_mem_posRoots (i : ι) :
     P.reflectionPerm i i ∈ negRoots P b ↔ i ∈ posRoots P b := by
   letI := P.indexNeg
@@ -115,9 +116,9 @@ lemma reflectionPerm_self_mem_negRoots_iff_mem_posRoots (i : ι) :
 /-- The negative of a negative root is positive. -/
 @[simp]
 lemma reflectionPerm_self_mem_posRoots_iff_mem_negRoots (i : ι) :
-    b.IsPos (P.reflectionPerm i i) ↔ i ∈ negRoots P b := by
+    P.reflectionPerm i i ∈ posRoots P b ↔ i ∈ negRoots P b := by
   letI := P.indexNeg
-  rw [reflectionPerm_self_eq_neg, mem_negRoots]
+  rw [reflectionPerm_self_eq_neg, mem_posRoots, mem_negRoots]
   exact RootPairing.Base.IsPos.neg_iff_not b i
 
 /-- A positive root is a nonnegative natural-number combination of simple roots. -/
@@ -142,6 +143,7 @@ lemma exists_root_eq_sum_nat_of_mem_posRoots {i : ι} (hi : i ∈ posRoots P b) 
 theorem image_reflectionPerm_self_posRoots :
     (fun i ↦ P.reflectionPerm i i) '' posRoots P b = negRoots P b := by
   letI := P.indexNeg
+  simp_rw [reflectionPerm_self_eq_neg P]
   ext i
   constructor
   · rintro ⟨j, hj, rfl⟩
@@ -159,10 +161,12 @@ theorem image_reflectionPerm_self_negRoots :
   letI := P.indexNeg
   have hinv : Function.Involutive (fun i : ι ↦ P.reflectionPerm i i) := by
     intro i
+    rw [show (fun j : ι ↦ P.reflectionPerm j j) = fun j ↦ -j from
+      funext (reflectionPerm_self_eq_neg P)]
     exact neg_neg i
   calc
     (fun i ↦ P.reflectionPerm i i) '' negRoots P b =
-        (fun i ↦ P.reflectionPerm i i) '' (posRoots P b)ᶜ := by rw [negRoots_compl]
+        (fun i ↦ P.reflectionPerm i i) '' (posRoots P b)ᶜ := by rw [negRoots_eq_compl]
     _ = ((fun i ↦ P.reflectionPerm i i) '' posRoots P b)ᶜ :=
       Set.image_compl_eq hinv.bijective
     _ = (negRoots P b)ᶜ := by rw [image_reflectionPerm_self_posRoots]

--- a/TauCeti/RepresentationTheory/RootSystems/Positive.lean
+++ b/TauCeti/RepresentationTheory/RootSystems/Positive.lean
@@ -1,0 +1,164 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+module
+
+public import Mathlib.LinearAlgebra.RootSystem.Base
+
+public section
+
+/-!
+# Positive and negative roots
+
+This file packages Mathlib's positivity predicate for a root-pairing base as the sets of positive
+and negative root indices. It records their partition, their exchange under root negation, and the
+positive-root induction principle used to study Weyl-group inversion sets.
+
+## Main definitions
+
+* `TauCeti.posRoots` is the set of positive roots relative to a base.
+* `TauCeti.negRoots` is its complementary set of negative roots.
+
+## References
+
+This file implements the “Positive and negative roots” item in Layer 1 of
+`TauCetiRoadmap/RepresentationTheory/RootSystems/README.md`.
+-/
+
+namespace TauCeti
+
+open Set
+
+universe u v w x
+
+variable {ι : Type u} {R : Type v} {M : Type w} {N : Type x}
+  [CommRing R] [AddCommGroup M] [Module R M] [AddCommGroup N] [Module R N]
+  (P : RootPairing ι R M N)
+
+/-- The positive roots relative to a base. -/
+@[expose]
+def posRoots [CharZero R] (b : P.Base) : Set ι := {i | b.IsPos i}
+
+/-- The negative roots relative to a base. -/
+@[expose]
+def negRoots [CharZero R] (b : P.Base) : Set ι := {i | ¬ b.IsPos i}
+
+variable [CharZero R] (b : P.Base)
+
+/-- Membership in the set of positive roots. -/
+@[simp]
+lemma mem_posRoots (i : ι) : i ∈ posRoots P b ↔ b.IsPos i := Iff.rfl
+
+/-- Membership in the set of negative roots. -/
+@[simp]
+lemma mem_negRoots (i : ι) : i ∈ negRoots P b ↔ ¬ b.IsPos i := Iff.rfl
+
+/-- The negative roots are the complement of the positive roots. -/
+lemma posRoots_compl : (posRoots P b)ᶜ = negRoots P b := rfl
+
+/-- The negative roots are the complement of the positive roots. -/
+lemma negRoots_compl : negRoots P b = (posRoots P b)ᶜ := rfl
+
+/-- No root is both positive and negative. -/
+lemma disjoint_posRoots_negRoots : Disjoint (posRoots P b) (negRoots P b) := by
+  rw [Set.disjoint_left]
+  simp
+
+/-- Every root is either positive or negative. -/
+lemma posRoots_union_negRoots : posRoots P b ∪ negRoots P b = Set.univ := by
+  rw [negRoots_compl]
+  exact Set.union_compl_self _
+
+/-- Every root is either positive or negative. -/
+lemma mem_posRoots_or_mem_negRoots (i : ι) : i ∈ posRoots P b ∨ i ∈ negRoots P b := by
+  classical
+  exact em _
+
+/-- A root is negative exactly when it is not positive. -/
+lemma not_mem_posRoots_iff_mem_negRoots (i : ι) :
+    i ∉ posRoots P b ↔ i ∈ negRoots P b := by
+  rfl
+
+/-- The positive roots form a finite set when the root index type is finite. -/
+lemma posRoots_finite [Finite ι] : (posRoots P b).Finite := Set.toFinite _
+
+/-- The negative roots form a finite set when the root index type is finite. -/
+lemma negRoots_finite [Finite ι] : (negRoots P b).Finite := Set.toFinite _
+
+/-- Every simple root is positive. -/
+lemma support_subset_posRoots : ↑b.support ⊆ posRoots P b := by
+  intro i hi
+  exact b.isPos_of_mem_support hi
+
+/-- A nonempty root index type has a positive root. -/
+lemma posRoots_nonempty [Nonempty ι] : (posRoots P b).Nonempty := by
+  letI := P.indexNeg
+  obtain ⟨i⟩ := ‹Nonempty ι›
+  rcases RootPairing.Base.IsPos.or_neg b i with hi | hi
+  · exact ⟨i, hi⟩
+  · exact ⟨-i, hi⟩
+
+/-- The negative of a positive root is negative. -/
+lemma reflectionPerm_self_mem_negRoots_iff_mem_posRoots (i : ι) :
+    P.reflectionPerm i i ∈ negRoots P b ↔ i ∈ posRoots P b := by
+  letI := P.indexNeg
+  change ¬ b.IsPos (-i) ↔ b.IsPos i
+  rw [RootPairing.Base.IsPos.neg_iff_not b i]
+  exact not_not
+
+/-- The negative of a negative root is positive. -/
+lemma reflectionPerm_self_mem_posRoots_iff_mem_negRoots (i : ι) :
+    P.reflectionPerm i i ∈ posRoots P b ↔ i ∈ negRoots P b := by
+  letI := P.indexNeg
+  change b.IsPos (-i) ↔ ¬ b.IsPos i
+  exact RootPairing.Base.IsPos.neg_iff_not b i
+
+/-- Root negation exchanges positive and negative roots. -/
+theorem image_reflectionPerm_self_posRoots :
+    (fun i ↦ P.reflectionPerm i i) '' posRoots P b = negRoots P b := by
+  letI := P.indexNeg
+  ext i
+  constructor
+  · rintro ⟨j, hj, rfl⟩
+    change ¬ b.IsPos (-j)
+    intro hneg
+    exact (RootPairing.Base.IsPos.neg_iff_not b j).mp hneg hj
+  · intro hi
+    refine ⟨-i, ?_, neg_neg i⟩
+    exact (RootPairing.Base.IsPos.neg_iff_not b i).mpr hi
+
+/-- Root negation exchanges negative and positive roots. -/
+theorem image_reflectionPerm_self_negRoots :
+    (fun i ↦ P.reflectionPerm i i) '' negRoots P b = posRoots P b := by
+  letI := P.indexNeg
+  ext i
+  constructor
+  · rintro ⟨j, hj, rfl⟩
+    change b.IsPos (-j)
+    exact (RootPairing.Base.IsPos.neg_iff_not b j).mpr hj
+  · intro hi
+    refine ⟨-i, ?_, neg_neg i⟩
+    change ¬ b.IsPos (-i)
+    intro hneg
+    exact (RootPairing.Base.IsPos.neg_iff_not b i).mp hneg hi
+
+/-- A positive root is a sum of simple roots whose partial sums are roots. -/
+theorem exists_sum_support_of_mem_posRoots [Finite ι] [IsDomain R] [P.IsCrystallographic]
+    {i : ι} (hi : i ∈ posRoots P b) :
+    ∃ n, ∃ f : Fin n → ι,
+      Set.range f ⊆ b.support ∧
+      P.root i = ∑ m, P.root (f m) ∧
+      ∀ m, ∑ m' ≤ m, P.root (f m') ∈ Set.range P.root :=
+  RootPairing.Base.exists_eq_sum_and_forall_sum_mem_of_isPos (b := b) hi
+
+/-- To prove a predicate on positive roots, it suffices to prove it for simple roots and show that
+it is preserved by the simple reflections used in positive-root lowering. -/
+theorem posRoots_induction_on_reflect [Finite ι] [IsDomain R] [P.IsCrystallographic]
+    [P.IsReduced] {i : ι} (hi : i ∈ posRoots P b) {p : ι → Prop}
+    (hbase : ∀ j ∈ b.support, p j)
+    (hreflect : ∀ j k, p j → k ∈ b.support → p (P.reflectionPerm k j)) :
+    p i :=
+  hi.induction_on_reflect hbase hreflect
+
+end TauCeti

--- a/TauCeti/RepresentationTheory/RootSystems/Positive.lean
+++ b/TauCeti/RepresentationTheory/RootSystems/Positive.lean
@@ -105,7 +105,6 @@ private lemma reflectionPerm_self_eq_neg (i : ι) :
     P.reflectionPerm i i = -i := rfl
 
 /-- The negative of a positive root is negative. -/
-@[simp]
 lemma reflectionPerm_self_mem_negRoots_iff_mem_posRoots (i : ι) :
     P.reflectionPerm i i ∈ negRoots P b ↔ i ∈ posRoots P b := by
   letI := P.indexNeg
@@ -113,13 +112,18 @@ lemma reflectionPerm_self_mem_negRoots_iff_mem_posRoots (i : ι) :
     RootPairing.Base.IsPos.neg_iff_not]
   exact not_not
 
-/-- The negative of a negative root is positive. -/
+/-- The self-reflection of a root is positive exactly when the root is negative. -/
 @[simp]
+lemma isPos_reflectionPerm_self_iff_mem_negRoots (i : ι) :
+    b.IsPos (P.reflectionPerm i i) ↔ i ∈ negRoots P b := by
+  letI := P.indexNeg
+  rw [reflectionPerm_self_eq_neg, mem_negRoots]
+  exact RootPairing.Base.IsPos.neg_iff_not b i
+
+/-- The negative of a negative root is positive. -/
 lemma reflectionPerm_self_mem_posRoots_iff_mem_negRoots (i : ι) :
     P.reflectionPerm i i ∈ posRoots P b ↔ i ∈ negRoots P b := by
-  letI := P.indexNeg
-  rw [reflectionPerm_self_eq_neg, mem_posRoots, mem_negRoots]
-  exact RootPairing.Base.IsPos.neg_iff_not b i
+  exact (mem_posRoots P b _).trans (isPos_reflectionPerm_self_iff_mem_negRoots P b i)
 
 /-- A positive root is a nonnegative natural-number combination of simple roots. -/
 lemma exists_root_eq_sum_nat_of_mem_posRoots {i : ι} (hi : i ∈ posRoots P b) :

--- a/TauCeti/RepresentationTheory/RootSystems/Positive.lean
+++ b/TauCeti/RepresentationTheory/RootSystems/Positive.lean
@@ -12,8 +12,7 @@ public section
 # Positive and negative roots
 
 This file packages Mathlib's positivity predicate for a root-pairing base as the sets of positive
-and negative root indices. It records their partition, their exchange under root negation, and the
-positive-root induction principle used to study Weyl-group inversion sets.
+and negative root indices. It records their partition and their exchange under root negation.
 
 ## Main definitions
 
@@ -142,23 +141,5 @@ theorem image_reflectionPerm_self_negRoots :
     change ¬ b.IsPos (-i)
     intro hneg
     exact (RootPairing.Base.IsPos.neg_iff_not b i).mp hneg hi
-
-/-- A positive root is a sum of simple roots whose partial sums are roots. -/
-theorem exists_sum_support_of_mem_posRoots [Finite ι] [IsDomain R] [P.IsCrystallographic]
-    {i : ι} (hi : i ∈ posRoots P b) :
-    ∃ n, ∃ f : Fin n → ι,
-      Set.range f ⊆ b.support ∧
-      P.root i = ∑ m, P.root (f m) ∧
-      ∀ m, ∑ m' ≤ m, P.root (f m') ∈ Set.range P.root :=
-  RootPairing.Base.exists_eq_sum_and_forall_sum_mem_of_isPos (b := b) hi
-
-/-- To prove a predicate on positive roots, it suffices to prove it for simple roots and show that
-it is preserved by the simple reflections used in positive-root lowering. -/
-theorem posRoots_induction_on_reflect [Finite ι] [IsDomain R] [P.IsCrystallographic]
-    [P.IsReduced] {i : ι} (hi : i ∈ posRoots P b) {p : ι → Prop}
-    (hbase : ∀ j ∈ b.support, p j)
-    (hreflect : ∀ j k, p j → k ∈ b.support → p (P.reflectionPerm k j)) :
-    p i :=
-  hi.induction_on_reflect hbase hreflect
 
 end TauCeti


### PR DESCRIPTION
This PR packages positive and negative root indices relative to a `RootPairing.Base`, proves that they partition the roots and are exchanged by root negation, and exposes the finite, simple-root, sum, and induction interfaces that the next inversion-set milestone consumes.

This advances `TauCetiRoadmap/RepresentationTheory/RootSystems/README.md`, Layer 1, item “Positive and negative roots”: `posRoots b = {i | b.IsPos i}`, `negRoots b = {i | ¬ b.IsPos i}`, their partition and exchange by root negation, and finiteness of `posRoots`. It is the lowest-hanging unclaimed RepresentationTheory target because Mathlib already provides the underlying positivity and lowering theorems but neither the set-level API nor an open PR supplies it; the resulting API is the direct prerequisite for the roadmap’s inversion sets and Coxeter presentation.

Add `TauCeti/RepresentationTheory/RootSystems/Positive.lean` (164 lines). The implementation reuses Mathlib’s `RootPairing.Base.IsPos`, its root-negation and simple-root API, and its positive-root induction theorem; no Mathlib infrastructure or supplementary-source material is vendored.

<!--tauceti-target:v1 {"focus":"RepresentationTheory","id":"positive-negative-roots"}-->

`lake exe cache get` reports `No files to download`. `lake build` reports `Build completed successfully (5524 jobs).` `lake exe axioms` reports `axioms: audited 12275 TauCeti declaration(s); all within the allowlist [propext, Classical.choice, Quot.sound].`

🤖 Prepared with Codex
