### PR TITLE
feat: finite Weyl groups

### DIFF
--- a/TauCeti/LinearAlgebra/RootSystem/WeylGroup.lean
+++ b/TauCeti/LinearAlgebra/RootSystem/WeylGroup.lean
@@ -19,9 +19,9 @@ group, is finite when the root index type is finite.
 
 * `TauCeti.RootPairing.Equiv.indexHom_injective` says that an automorphism of a root system is
   determined by its permutation of the roots.
-* `TauCeti.finite_subgroup_aut` proves that every subgroup of the automorphism group of a finite
-  root system is finite.
-* `TauCeti.finite_weylGroup` is the resulting finiteness theorem for the Weyl group.
+* `TauCeti.RootPairing.finite_subgroup_aut` proves that every subgroup of the automorphism group of
+  a finite root system is finite.
+* `TauCeti.RootPairing.finite_weylGroup` is the resulting finiteness theorem for the Weyl group.
 
 ## References
 
@@ -65,15 +65,17 @@ theorem indexHom_injective [P.IsRootSystem] :
 
 end RootPairing.Equiv
 
+namespace RootPairing
+
 /-- If the roots span, the action of the Weyl group on root indices is faithful. -/
 theorem weylGroupToPerm_injective_of_span_eq_top
     (hspan : Submodule.span R (range P.root) = ⊤) :
     Function.Injective P.weylGroupToPerm :=
-  (RootPairing.Equiv.indexHom_injective_of_span_eq_top P hspan).comp Subtype.val_injective
+  (Equiv.indexHom_injective_of_span_eq_top P hspan).comp Subtype.val_injective
 
 /-- The action of the Weyl group on root indices is faithful. -/
 theorem weylGroupToPerm_injective [P.IsRootSystem] : Function.Injective P.weylGroupToPerm :=
-  (RootPairing.Equiv.indexHom_injective P).comp Subtype.val_injective
+  (Equiv.indexHom_injective P).comp Subtype.val_injective
 
 variable [Finite ι]
 
@@ -82,7 +84,7 @@ is finite. -/
 theorem finite_subgroup_aut_of_span_eq_top (hspan : Submodule.span R (range P.root) = ⊤)
     (G : Subgroup P.Aut) : Finite G :=
   Finite.of_injective ((_root_.RootPairing.Equiv.indexHom P).restrict G)
-    ((RootPairing.Equiv.indexHom_injective_of_span_eq_top P hspan).comp Subtype.val_injective)
+    ((Equiv.indexHom_injective_of_span_eq_top P hspan).comp Subtype.val_injective)
 
 /-- Every subgroup of the automorphism group of a finite root system is finite. -/
 theorem finite_subgroup_aut [P.IsRootSystem] (G : Subgroup P.Aut) : Finite G :=
@@ -90,14 +92,14 @@ theorem finite_subgroup_aut [P.IsRootSystem] (G : Subgroup P.Aut) : Finite G :=
     (_root_.RootPairing.IsRootSystem.span_root_eq_top (P := P)) G
 
 /-- If the roots span, the automorphism group is finite when the root index type is finite. -/
-theorem finite_rootPairing_aut_of_span_eq_top
+theorem finite_aut_of_span_eq_top
     (hspan : Submodule.span R (range P.root) = ⊤) : Finite P.Aut :=
   Finite.of_injective (_root_.RootPairing.Equiv.indexHom P)
-    (RootPairing.Equiv.indexHom_injective_of_span_eq_top P hspan)
+    (Equiv.indexHom_injective_of_span_eq_top P hspan)
 
 /-- The automorphism group of a finite root system is finite. -/
-theorem finite_rootSystem_aut [P.IsRootSystem] : Finite P.Aut :=
-  finite_rootPairing_aut_of_span_eq_top P
+theorem finite_aut [P.IsRootSystem] : Finite P.Aut :=
+  finite_aut_of_span_eq_top P
     (_root_.RootPairing.IsRootSystem.span_root_eq_top (P := P))
 
 /-- If the roots span, every subgroup of the automorphism group has order at most the factorial of
@@ -108,7 +110,7 @@ theorem card_subgroup_aut_le_factorial_of_span_eq_top
   calc
     Nat.card G ≤ Nat.card (ι ≃ ι) := Nat.card_le_card_of_injective
       ((_root_.RootPairing.Equiv.indexHom P).restrict G)
-        ((RootPairing.Equiv.indexHom_injective_of_span_eq_top P hspan).comp
+        ((Equiv.indexHom_injective_of_span_eq_top P hspan).comp
           Subtype.val_injective)
     _ = Nat.factorial (Nat.card ι) := Nat.card_perm
 
@@ -121,20 +123,20 @@ theorem card_subgroup_aut_le_factorial [P.IsRootSystem] (G : Subgroup P.Aut) :
 
 /-- If the roots span, the automorphism group has order at most the factorial of the number of
 roots. -/
-theorem card_rootPairing_aut_le_factorial_of_span_eq_top
+theorem card_aut_le_factorial_of_span_eq_top
     (hspan : Submodule.span R (range P.root) = ⊤) :
     Nat.card P.Aut ≤ Nat.factorial (Nat.card ι) :=
   calc
     Nat.card P.Aut ≤ Nat.card (ι ≃ ι) := Nat.card_le_card_of_injective
       (_root_.RootPairing.Equiv.indexHom P)
-        (RootPairing.Equiv.indexHom_injective_of_span_eq_top P hspan)
+        (Equiv.indexHom_injective_of_span_eq_top P hspan)
     _ = Nat.factorial (Nat.card ι) := Nat.card_perm
 
 /-- The automorphism group of a finite root system has order at most the factorial of the number
 of roots. -/
-theorem card_rootSystem_aut_le_factorial [P.IsRootSystem] :
+theorem card_aut_le_factorial [P.IsRootSystem] :
     Nat.card P.Aut ≤ Nat.factorial (Nat.card ι) :=
-  card_rootPairing_aut_le_factorial_of_span_eq_top P
+  card_aut_le_factorial_of_span_eq_top P
     (_root_.RootPairing.IsRootSystem.span_root_eq_top (P := P))
 
 /-- If the roots span, the Weyl group is finite when the root index type is finite. -/
@@ -158,6 +160,8 @@ roots. -/
 theorem card_weylGroup_le_factorial [P.IsRootSystem] :
     Nat.card P.weylGroup ≤ Nat.factorial (Nat.card ι) :=
   card_subgroup_aut_le_factorial P P.weylGroup
+
+end RootPairing
 
 end RootSystem
 

--- a/TauCeti/RepresentationTheory/RootSystems/WeylGroup.lean
+++ b/TauCeti/RepresentationTheory/RootSystems/WeylGroup.lean
@@ -64,23 +64,16 @@ theorem rootSystem_indexHom_injective :
   | add x y _ _ hx hy => simpa only [LinearMap.map_add] using congrArg₂ (· + ·) hx hy
   | smul r x _ hx => simpa only [LinearMap.map_smul] using congrArg (r • ·) hx
 
-/-- The root permutation representation is faithful on every subgroup of root-system
-automorphisms. -/
-theorem indexHom_restrict_injective (G : Subgroup P.Aut) :
-    Function.Injective ((_root_.RootPairing.Equiv.indexHom P).restrict G) := by
-  intro f g hfg
-  exact Subtype.ext <| rootSystem_indexHom_injective P hfg
-
 /-- The action of the Weyl group on root indices is faithful. -/
 theorem weylGroupToPerm_injective : Function.Injective P.weylGroupToPerm :=
-  indexHom_restrict_injective P P.weylGroup
+  (rootSystem_indexHom_injective P).comp Subtype.val_injective
 
 variable [Finite ι]
 
 /-- Every subgroup of the automorphism group of a finite root system is finite. -/
 theorem finite_subgroup_aut (G : Subgroup P.Aut) : Finite G :=
   Finite.of_injective ((_root_.RootPairing.Equiv.indexHom P).restrict G)
-    (indexHom_restrict_injective P G)
+    ((rootSystem_indexHom_injective P).comp Subtype.val_injective)
 
 /-- The automorphism group of a finite root system is finite. -/
 theorem finite_rootSystem_aut : Finite P.Aut :=
@@ -92,7 +85,8 @@ theorem card_subgroup_aut_le_factorial (G : Subgroup P.Aut) :
     Nat.card G ≤ Nat.factorial (Nat.card ι) := by
   calc
     Nat.card G ≤ Nat.card (ι ≃ ι) := Nat.card_le_card_of_injective
-      ((_root_.RootPairing.Equiv.indexHom P).restrict G) (indexHom_restrict_injective P G)
+      ((_root_.RootPairing.Equiv.indexHom P).restrict G)
+        ((rootSystem_indexHom_injective P).comp Subtype.val_injective)
     _ = Nat.factorial (Nat.card ι) := Nat.card_perm
 
 /-- The automorphism group of a finite root system has order at most the factorial of the number

--- a/TauCeti/RepresentationTheory/RootSystems/WeylGroup.lean
+++ b/TauCeti/RepresentationTheory/RootSystems/WeylGroup.lean
@@ -17,8 +17,8 @@ group, is finite when the root index type is finite.
 
 ## Main results
 
-* `TauCeti.rootSystem_indexHom_injective` says that an automorphism of a root system is determined
-  by its permutation of the roots.
+* `TauCeti.RootPairing.Equiv.indexHom_injective` says that an automorphism of a root system is
+  determined by its permutation of the roots.
 * `TauCeti.finite_subgroup_aut` proves that every subgroup of the automorphism group of a finite
   root system is finite.
 * `TauCeti.finite_weylGroup` is the resulting finiteness theorem for the Weyl group.
@@ -41,43 +41,42 @@ section RootSystem
 variable [CommRing R] [AddCommGroup M] [Module R M] [AddCommGroup N] [Module R N]
   (P : _root_.RootPairing ι R M N) [P.IsRootSystem]
 
+namespace RootPairing.Equiv
+
 /-- An automorphism of a root system is determined by its permutation of the root indices. -/
-theorem rootSystem_indexHom_injective :
+theorem indexHom_injective :
     Function.Injective (_root_.RootPairing.Equiv.indexHom P) := by
   intro f g hfg
   apply _root_.RootPairing.Equiv.weightHom_injective P
   apply LinearEquiv.toLinearMap_injective
-  ext x
-  have hx : x ∈ Submodule.span R (range P.root) := by simp
-  induction hx using Submodule.span_induction with
-  | mem x hx =>
-      obtain ⟨i, rfl⟩ := hx
-      have hfg' : f.indexEquiv i = g.indexEquiv i :=
-        congrFun (congrArg DFunLike.coe hfg) i
-      calc
-        _ = f • P.root i := rfl
-        _ = P.root (f.indexEquiv i) := (_root_.RootPairing.Equiv.root_indexEquiv_eq_smul P i f).symm
-        _ = P.root (g.indexEquiv i) := congrArg P.root hfg'
-        _ = g • P.root i := _root_.RootPairing.Equiv.root_indexEquiv_eq_smul P i g
-        _ = _ := rfl
-  | zero => simp
-  | add x y _ _ hx hy => simpa only [LinearMap.map_add] using congrArg₂ (· + ·) hx hy
-  | smul r x _ hx => simpa only [LinearMap.map_smul] using congrArg (r • ·) hx
+  refine LinearMap.ext_on_range
+    (_root_.RootPairing.IsRootSystem.span_root_eq_top (P := P)) fun i ↦ ?_
+  have hfg' : f.indexEquiv i = g.indexEquiv i :=
+    congrFun (congrArg DFunLike.coe hfg) i
+  calc
+    _ = f • P.root i := rfl
+    _ = P.root (f.indexEquiv i) := (_root_.RootPairing.Equiv.root_indexEquiv_eq_smul P i f).symm
+    _ = P.root (g.indexEquiv i) := congrArg P.root hfg'
+    _ = g • P.root i := _root_.RootPairing.Equiv.root_indexEquiv_eq_smul P i g
+    _ = _ := rfl
+
+end RootPairing.Equiv
 
 /-- The action of the Weyl group on root indices is faithful. -/
 theorem weylGroupToPerm_injective : Function.Injective P.weylGroupToPerm :=
-  (rootSystem_indexHom_injective P).comp Subtype.val_injective
+  (RootPairing.Equiv.indexHom_injective P).comp Subtype.val_injective
 
 variable [Finite ι]
 
 /-- Every subgroup of the automorphism group of a finite root system is finite. -/
 theorem finite_subgroup_aut (G : Subgroup P.Aut) : Finite G :=
   Finite.of_injective ((_root_.RootPairing.Equiv.indexHom P).restrict G)
-    ((rootSystem_indexHom_injective P).comp Subtype.val_injective)
+    ((RootPairing.Equiv.indexHom_injective P).comp Subtype.val_injective)
 
 /-- The automorphism group of a finite root system is finite. -/
 theorem finite_rootSystem_aut : Finite P.Aut :=
-  Finite.of_injective (_root_.RootPairing.Equiv.indexHom P) (rootSystem_indexHom_injective P)
+  Finite.of_injective (_root_.RootPairing.Equiv.indexHom P)
+    (RootPairing.Equiv.indexHom_injective P)
 
 /-- Every subgroup of the automorphism group of a finite root system has order at most the
 factorial of the number of roots. -/
@@ -86,7 +85,7 @@ theorem card_subgroup_aut_le_factorial (G : Subgroup P.Aut) :
   calc
     Nat.card G ≤ Nat.card (ι ≃ ι) := Nat.card_le_card_of_injective
       ((_root_.RootPairing.Equiv.indexHom P).restrict G)
-        ((rootSystem_indexHom_injective P).comp Subtype.val_injective)
+        ((RootPairing.Equiv.indexHom_injective P).comp Subtype.val_injective)
     _ = Nat.factorial (Nat.card ι) := Nat.card_perm
 
 /-- The automorphism group of a finite root system has order at most the factorial of the number
@@ -94,7 +93,7 @@ of roots. -/
 theorem card_rootSystem_aut_le_factorial : Nat.card P.Aut ≤ Nat.factorial (Nat.card ι) :=
   calc
     Nat.card P.Aut ≤ Nat.card (ι ≃ ι) := Nat.card_le_card_of_injective
-      (_root_.RootPairing.Equiv.indexHom P) (rootSystem_indexHom_injective P)
+      (_root_.RootPairing.Equiv.indexHom P) (RootPairing.Equiv.indexHom_injective P)
     _ = Nat.factorial (Nat.card ι) := Nat.card_perm
 
 /-- The Weyl group of a finite root system is finite. -/

--- a/TauCeti/RepresentationTheory/RootSystems/WeylGroup.lean
+++ b/TauCeti/RepresentationTheory/RootSystems/WeylGroup.lean
@@ -1,0 +1,122 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Codex
+-/
+module
+
+public import Mathlib.Data.Finite.Perm
+public import Mathlib.LinearAlgebra.RootSystem.WeylGroup
+
+/-!
+# Faithful permutation actions of Weyl groups
+
+This file proves that the action of the automorphism group of a root system on its root indices is
+faithful.  Consequently, every subgroup of that automorphism group, and in particular the Weyl
+group, is finite when the root index type is finite.
+
+## Main results
+
+* `TauCeti.rootSystem_indexHom_injective` says that an automorphism of a root system is determined
+  by its permutation of the roots.
+* `TauCeti.finite_subgroup_aut` proves that every subgroup of the automorphism group of a finite
+  root system is finite.
+* `TauCeti.finite_weylGroup` is the resulting finiteness theorem for the Weyl group.
+
+## References
+
+* [Root systems roadmap](https://github.com/TauCetiProject/TauCetiRoadmap/blob/main/TauCetiRoadmap/RepresentationTheory/RootSystems/README.md)
+-/
+
+public section
+
+open Function Set
+
+namespace TauCeti
+
+variable {ι R M N : Type*}
+
+section RootSystem
+
+variable [CommRing R] [AddCommGroup M] [Module R M] [AddCommGroup N] [Module R N]
+  (P : _root_.RootPairing ι R M N) [P.IsRootSystem]
+
+/-- An automorphism of a root system is determined by its permutation of the root indices. -/
+theorem rootSystem_indexHom_injective :
+    Function.Injective (_root_.RootPairing.Equiv.indexHom P) := by
+  intro f g hfg
+  apply _root_.RootPairing.Equiv.weightHom_injective P
+  apply LinearEquiv.toLinearMap_injective
+  ext x
+  have hx : x ∈ Submodule.span R (range P.root) := by simp
+  induction hx using Submodule.span_induction with
+  | mem x hx =>
+      obtain ⟨i, rfl⟩ := hx
+      have hfg' : f.indexEquiv i = g.indexEquiv i :=
+        congrFun (congrArg DFunLike.coe hfg) i
+      calc
+        _ = f • P.root i := rfl
+        _ = P.root (f.indexEquiv i) := (_root_.RootPairing.Equiv.root_indexEquiv_eq_smul P i f).symm
+        _ = P.root (g.indexEquiv i) := congrArg P.root hfg'
+        _ = g • P.root i := _root_.RootPairing.Equiv.root_indexEquiv_eq_smul P i g
+        _ = _ := rfl
+  | zero => simp
+  | add x y _ _ hx hy => simpa only [LinearMap.map_add] using congrArg₂ (· + ·) hx hy
+  | smul r x _ hx => simpa only [LinearMap.map_smul] using congrArg (r • ·) hx
+
+/-- Two root-system automorphisms are equal exactly when they induce the same root permutation. -/
+theorem rootSystem_indexHom_eq_iff {f g : P.Aut} :
+    _root_.RootPairing.Equiv.indexHom P f = _root_.RootPairing.Equiv.indexHom P g ↔ f = g :=
+  ⟨fun h ↦ rootSystem_indexHom_injective P h,
+    fun h ↦ congrArg (_root_.RootPairing.Equiv.indexHom P) h⟩
+
+/-- The root permutation representation is faithful on every subgroup of root-system
+automorphisms. -/
+theorem indexHom_restrict_injective (G : Subgroup P.Aut) :
+    Function.Injective ((_root_.RootPairing.Equiv.indexHom P).restrict G) := by
+  intro f g hfg
+  exact Subtype.ext <| rootSystem_indexHom_injective P hfg
+
+/-- The action of the Weyl group on root indices is faithful. -/
+theorem weylGroupToPerm_injective : Function.Injective P.weylGroupToPerm :=
+  indexHom_restrict_injective P P.weylGroup
+
+variable [Finite ι]
+
+/-- Every subgroup of the automorphism group of a finite root system is finite. -/
+theorem finite_subgroup_aut (G : Subgroup P.Aut) : Finite G :=
+  Finite.of_injective ((_root_.RootPairing.Equiv.indexHom P).restrict G)
+    (indexHom_restrict_injective P G)
+
+/-- The automorphism group of a finite root system is finite. -/
+theorem finite_rootSystem_aut : Finite P.Aut :=
+  Finite.of_injective (_root_.RootPairing.Equiv.indexHom P) (rootSystem_indexHom_injective P)
+
+/-- Every subgroup of the automorphism group of a finite root system has order at most the
+factorial of the number of roots. -/
+theorem card_subgroup_aut_le_factorial (G : Subgroup P.Aut) :
+    Nat.card G ≤ Nat.factorial (Nat.card ι) := by
+  calc
+    Nat.card G ≤ Nat.card (ι ≃ ι) := Nat.card_le_card_of_injective
+      ((_root_.RootPairing.Equiv.indexHom P).restrict G) (indexHom_restrict_injective P G)
+    _ = Nat.factorial (Nat.card ι) := Nat.card_perm
+
+/-- The automorphism group of a finite root system has order at most the factorial of the number
+of roots. -/
+theorem card_rootSystem_aut_le_factorial : Nat.card P.Aut ≤ Nat.factorial (Nat.card ι) :=
+  calc
+    Nat.card P.Aut ≤ Nat.card (ι ≃ ι) := Nat.card_le_card_of_injective
+      (_root_.RootPairing.Equiv.indexHom P) (rootSystem_indexHom_injective P)
+    _ = Nat.factorial (Nat.card ι) := Nat.card_perm
+
+/-- The Weyl group of a finite root system is finite. -/
+theorem finite_weylGroup : Finite P.weylGroup :=
+  finite_subgroup_aut P P.weylGroup
+
+/-- The order of a finite Weyl group is at most the factorial of the number of roots. -/
+theorem card_weylGroup_le_factorial : Nat.card P.weylGroup ≤ Nat.factorial (Nat.card ι) := by
+  exact card_subgroup_aut_le_factorial P P.weylGroup
+
+end RootSystem
+
+end TauCeti

--- a/TauCeti/RepresentationTheory/RootSystems/WeylGroup.lean
+++ b/TauCeti/RepresentationTheory/RootSystems/WeylGroup.lean
@@ -64,12 +64,6 @@ theorem rootSystem_indexHom_injective :
   | add x y _ _ hx hy => simpa only [LinearMap.map_add] using congrArg₂ (· + ·) hx hy
   | smul r x _ hx => simpa only [LinearMap.map_smul] using congrArg (r • ·) hx
 
-/-- Two root-system automorphisms are equal exactly when they induce the same root permutation. -/
-theorem rootSystem_indexHom_eq_iff {f g : P.Aut} :
-    _root_.RootPairing.Equiv.indexHom P f = _root_.RootPairing.Equiv.indexHom P g ↔ f = g :=
-  ⟨fun h ↦ rootSystem_indexHom_injective P h,
-    fun h ↦ congrArg (_root_.RootPairing.Equiv.indexHom P) h⟩
-
 /-- The root permutation representation is faithful on every subgroup of root-system
 automorphisms. -/
 theorem indexHom_restrict_injective (G : Subgroup P.Aut) :

--- a/TauCeti/RepresentationTheory/RootSystems/WeylGroup.lean
+++ b/TauCeti/RepresentationTheory/RootSystems/WeylGroup.lean
@@ -153,7 +153,8 @@ theorem card_weylGroup_le_factorial_of_span_eq_top
     Nat.card P.weylGroup ≤ Nat.factorial (Nat.card ι) :=
   card_subgroup_aut_le_factorial_of_span_eq_top P hspan P.weylGroup
 
-/-- The order of a finite Weyl group is at most the factorial of the number of roots. -/
+/-- The order of the Weyl group of a finite root system is at most the factorial of the number of
+roots. -/
 theorem card_weylGroup_le_factorial [P.IsRootSystem] :
     Nat.card P.weylGroup ≤ Nat.factorial (Nat.card ι) :=
   card_subgroup_aut_le_factorial P P.weylGroup

--- a/TauCeti/RepresentationTheory/RootSystems/WeylGroup.lean
+++ b/TauCeti/RepresentationTheory/RootSystems/WeylGroup.lean
@@ -53,12 +53,9 @@ theorem indexHom_injective_of_span_eq_top (hspan : Submodule.span R (range P.roo
   refine LinearMap.ext_on_range hspan fun i ↦ ?_
   have hfg' : f.indexEquiv i = g.indexEquiv i :=
     congrFun (congrArg DFunLike.coe hfg) i
-  calc
-    _ = f • P.root i := rfl
-    _ = P.root (f.indexEquiv i) := (_root_.RootPairing.Equiv.root_indexEquiv_eq_smul P i f).symm
-    _ = P.root (g.indexEquiv i) := congrArg P.root hfg'
-    _ = g • P.root i := _root_.RootPairing.Equiv.root_indexEquiv_eq_smul P i g
-    _ = _ := rfl
+  simp only [_root_.RootPairing.Equiv.weightHom_apply, LinearEquiv.coe_coe,
+    _root_.RootPairing.Equiv.weightEquiv_apply,
+    _root_.RootPairing.Hom.root_weightMap_apply, hfg']
 
 /-- An automorphism of a root system is determined by its permutation of the root indices. -/
 theorem indexHom_injective [P.IsRootSystem] :

--- a/TauCeti/RepresentationTheory/RootSystems/WeylGroup.lean
+++ b/TauCeti/RepresentationTheory/RootSystems/WeylGroup.lean
@@ -39,18 +39,18 @@ variable {ι R M N : Type*}
 section RootSystem
 
 variable [CommRing R] [AddCommGroup M] [Module R M] [AddCommGroup N] [Module R N]
-  (P : _root_.RootPairing ι R M N) [P.IsRootSystem]
+  (P : _root_.RootPairing ι R M N)
 
 namespace RootPairing.Equiv
 
-/-- An automorphism of a root system is determined by its permutation of the root indices. -/
-theorem indexHom_injective :
+/-- If the roots span, an automorphism of a root pairing is determined by its permutation of the
+root indices. -/
+theorem indexHom_injective_of_span_eq_top (hspan : Submodule.span R (range P.root) = ⊤) :
     Function.Injective (_root_.RootPairing.Equiv.indexHom P) := by
   intro f g hfg
   apply _root_.RootPairing.Equiv.weightHom_injective P
   apply LinearEquiv.toLinearMap_injective
-  refine LinearMap.ext_on_range
-    (_root_.RootPairing.IsRootSystem.span_root_eq_top (P := P)) fun i ↦ ?_
+  refine LinearMap.ext_on_range hspan fun i ↦ ?_
   have hfg' : f.indexEquiv i = g.indexEquiv i :=
     congrFun (congrArg DFunLike.coe hfg) i
   calc
@@ -60,49 +60,106 @@ theorem indexHom_injective :
     _ = g • P.root i := _root_.RootPairing.Equiv.root_indexEquiv_eq_smul P i g
     _ = _ := rfl
 
+/-- An automorphism of a root system is determined by its permutation of the root indices. -/
+theorem indexHom_injective [P.IsRootSystem] :
+    Function.Injective (_root_.RootPairing.Equiv.indexHom P) :=
+  indexHom_injective_of_span_eq_top P
+    (_root_.RootPairing.IsRootSystem.span_root_eq_top (P := P))
+
 end RootPairing.Equiv
 
+/-- If the roots span, the action of the Weyl group on root indices is faithful. -/
+theorem weylGroupToPerm_injective_of_span_eq_top
+    (hspan : Submodule.span R (range P.root) = ⊤) :
+    Function.Injective P.weylGroupToPerm :=
+  (RootPairing.Equiv.indexHom_injective_of_span_eq_top P hspan).comp Subtype.val_injective
+
 /-- The action of the Weyl group on root indices is faithful. -/
-theorem weylGroupToPerm_injective : Function.Injective P.weylGroupToPerm :=
+theorem weylGroupToPerm_injective [P.IsRootSystem] : Function.Injective P.weylGroupToPerm :=
   (RootPairing.Equiv.indexHom_injective P).comp Subtype.val_injective
 
 variable [Finite ι]
 
-/-- Every subgroup of the automorphism group of a finite root system is finite. -/
-theorem finite_subgroup_aut (G : Subgroup P.Aut) : Finite G :=
+/-- If the roots span, every subgroup of the automorphism group is finite when the root index type
+is finite. -/
+theorem finite_subgroup_aut_of_span_eq_top (hspan : Submodule.span R (range P.root) = ⊤)
+    (G : Subgroup P.Aut) : Finite G :=
   Finite.of_injective ((_root_.RootPairing.Equiv.indexHom P).restrict G)
-    ((RootPairing.Equiv.indexHom_injective P).comp Subtype.val_injective)
+    ((RootPairing.Equiv.indexHom_injective_of_span_eq_top P hspan).comp Subtype.val_injective)
+
+/-- Every subgroup of the automorphism group of a finite root system is finite. -/
+theorem finite_subgroup_aut [P.IsRootSystem] (G : Subgroup P.Aut) : Finite G :=
+  finite_subgroup_aut_of_span_eq_top P
+    (_root_.RootPairing.IsRootSystem.span_root_eq_top (P := P)) G
+
+/-- If the roots span, the automorphism group is finite when the root index type is finite. -/
+theorem finite_rootPairing_aut_of_span_eq_top
+    (hspan : Submodule.span R (range P.root) = ⊤) : Finite P.Aut :=
+  Finite.of_injective (_root_.RootPairing.Equiv.indexHom P)
+    (RootPairing.Equiv.indexHom_injective_of_span_eq_top P hspan)
 
 /-- The automorphism group of a finite root system is finite. -/
-theorem finite_rootSystem_aut : Finite P.Aut :=
-  Finite.of_injective (_root_.RootPairing.Equiv.indexHom P)
-    (RootPairing.Equiv.indexHom_injective P)
+theorem finite_rootSystem_aut [P.IsRootSystem] : Finite P.Aut :=
+  finite_rootPairing_aut_of_span_eq_top P
+    (_root_.RootPairing.IsRootSystem.span_root_eq_top (P := P))
 
-/-- Every subgroup of the automorphism group of a finite root system has order at most the
-factorial of the number of roots. -/
-theorem card_subgroup_aut_le_factorial (G : Subgroup P.Aut) :
-    Nat.card G ≤ Nat.factorial (Nat.card ι) := by
+/-- If the roots span, every subgroup of the automorphism group has order at most the factorial of
+the number of roots. -/
+theorem card_subgroup_aut_le_factorial_of_span_eq_top
+    (hspan : Submodule.span R (range P.root) = ⊤)
+    (G : Subgroup P.Aut) : Nat.card G ≤ Nat.factorial (Nat.card ι) := by
   calc
     Nat.card G ≤ Nat.card (ι ≃ ι) := Nat.card_le_card_of_injective
       ((_root_.RootPairing.Equiv.indexHom P).restrict G)
-        ((RootPairing.Equiv.indexHom_injective P).comp Subtype.val_injective)
+        ((RootPairing.Equiv.indexHom_injective_of_span_eq_top P hspan).comp
+          Subtype.val_injective)
+    _ = Nat.factorial (Nat.card ι) := Nat.card_perm
+
+/-- Every subgroup of the automorphism group of a finite root system has order at most the
+factorial of the number of roots. -/
+theorem card_subgroup_aut_le_factorial [P.IsRootSystem] (G : Subgroup P.Aut) :
+    Nat.card G ≤ Nat.factorial (Nat.card ι) :=
+  card_subgroup_aut_le_factorial_of_span_eq_top P
+    (_root_.RootPairing.IsRootSystem.span_root_eq_top (P := P)) G
+
+/-- If the roots span, the automorphism group has order at most the factorial of the number of
+roots. -/
+theorem card_rootPairing_aut_le_factorial_of_span_eq_top
+    (hspan : Submodule.span R (range P.root) = ⊤) :
+    Nat.card P.Aut ≤ Nat.factorial (Nat.card ι) :=
+  calc
+    Nat.card P.Aut ≤ Nat.card (ι ≃ ι) := Nat.card_le_card_of_injective
+      (_root_.RootPairing.Equiv.indexHom P)
+        (RootPairing.Equiv.indexHom_injective_of_span_eq_top P hspan)
     _ = Nat.factorial (Nat.card ι) := Nat.card_perm
 
 /-- The automorphism group of a finite root system has order at most the factorial of the number
 of roots. -/
-theorem card_rootSystem_aut_le_factorial : Nat.card P.Aut ≤ Nat.factorial (Nat.card ι) :=
-  calc
-    Nat.card P.Aut ≤ Nat.card (ι ≃ ι) := Nat.card_le_card_of_injective
-      (_root_.RootPairing.Equiv.indexHom P) (RootPairing.Equiv.indexHom_injective P)
-    _ = Nat.factorial (Nat.card ι) := Nat.card_perm
+theorem card_rootSystem_aut_le_factorial [P.IsRootSystem] :
+    Nat.card P.Aut ≤ Nat.factorial (Nat.card ι) :=
+  card_rootPairing_aut_le_factorial_of_span_eq_top P
+    (_root_.RootPairing.IsRootSystem.span_root_eq_top (P := P))
+
+/-- If the roots span, the Weyl group is finite when the root index type is finite. -/
+theorem finite_weylGroup_of_span_eq_top (hspan : Submodule.span R (range P.root) = ⊤) :
+    Finite P.weylGroup :=
+  finite_subgroup_aut_of_span_eq_top P hspan P.weylGroup
 
 /-- The Weyl group of a finite root system is finite. -/
-theorem finite_weylGroup : Finite P.weylGroup :=
+theorem finite_weylGroup [P.IsRootSystem] : Finite P.weylGroup :=
   finite_subgroup_aut P P.weylGroup
 
+/-- If the roots span, the order of the Weyl group is at most the factorial of the number of
+roots. -/
+theorem card_weylGroup_le_factorial_of_span_eq_top
+    (hspan : Submodule.span R (range P.root) = ⊤) :
+    Nat.card P.weylGroup ≤ Nat.factorial (Nat.card ι) :=
+  card_subgroup_aut_le_factorial_of_span_eq_top P hspan P.weylGroup
+
 /-- The order of a finite Weyl group is at most the factorial of the number of roots. -/
-theorem card_weylGroup_le_factorial : Nat.card P.weylGroup ≤ Nat.factorial (Nat.card ι) := by
-  exact card_subgroup_aut_le_factorial P P.weylGroup
+theorem card_weylGroup_le_factorial [P.IsRootSystem] :
+    Nat.card P.weylGroup ≤ Nat.factorial (Nat.card ι) :=
+  card_subgroup_aut_le_factorial P P.weylGroup
 
 end RootSystem
 


### PR DESCRIPTION
This PR establishes the faithful action of a root system's automorphism group on its root indices, and derives finite subgroup, finite Weyl group, and factorial cardinality bounds from the resulting embedding into the finite permutation group.

This advances `TauCetiRoadmap/RepresentationTheory/RootSystems/README.md`, Layer 1, item “Finiteness of the Weyl group”: prove `weylGroupToPerm_injective`, hence `Finite P.weylGroup` when the root index type is finite. It is the lowest-hanging unclaimed independent target after the active positive-root API: it uses only Mathlib's existing root-system spanning axiom and Weyl-group permutation action, while directly supplying the finite Weyl group required by the roadmap's longest-element layer.

Add `TauCeti/RepresentationTheory/RootSystems/WeylGroup.lean` (122 lines). The implementation reuses Mathlib's `RootPairing.Equiv.indexHom`, `weightHom_injective`, root-action identity, root-span API, `Finite.of_injective`, and `Nat.card_perm`; no Mathlib infrastructure or supplementary-source material is vendored.

<!--tauceti-target:v1 {"focus":"RepresentationTheory","id":"finite-weyl-group"}-->

`lake exe cache get` reports `No files to download`. `lake build` reports `Build completed successfully (5518 jobs).` `lake exe axioms` reports `axioms: audited 12261 TauCeti declaration(s); all within the allowlist [propext, Classical.choice, Quot.sound].`

🤖 Prepared with Codex
