### PR TITLE
feat: determinant-power representations

### DIFF
--- a/TauCeti/RepresentationTheory/ClassicalGroups/Determinant.lean
+++ b/TauCeti/RepresentationTheory/ClassicalGroups/Determinant.lean
@@ -116,14 +116,18 @@ theorem detPowerRep_neg_apply (m : ℤ) (g : GL (Fin n) k) (x : k) :
 theorem char_detPowerRep (m : ℤ) (g : GL (Fin n) k) :
     (detPowerRep k n m).character g = (↑((Matrix.GeneralLinearGroup.det g) ^ m) : k) := by
   rw [Representation.character]
-  change LinearMap.trace k k
-      (LinearMap.lsmul k k (↑((Matrix.GeneralLinearGroup.det g) ^ m) : k)) =
-    (↑((Matrix.GeneralLinearGroup.det g) ^ m) : k)
-  rw [show LinearMap.lsmul k k (↑((Matrix.GeneralLinearGroup.det g) ^ m) : k) =
-      LinearMap.id.smulRight (↑((Matrix.GeneralLinearGroup.det g) ^ m) : k) by
+  have haction : detPowerRep k n m g =
+      LinearMap.lsmul k k (↑((Matrix.GeneralLinearGroup.det g) ^ m) : k) := by
     apply LinearMap.ext
     intro x
-    simp [LinearMap.lsmul_apply, mul_comm]]
+    simp only [detPowerRep_apply, LinearMap.lsmul_apply, smul_eq_mul]
+  rw [haction]
+  have hlsmul : LinearMap.lsmul k k (↑((Matrix.GeneralLinearGroup.det g) ^ m) : k) =
+      LinearMap.id.smulRight (↑((Matrix.GeneralLinearGroup.det g) ^ m) : k) := by
+    apply LinearMap.ext
+    intro x
+    simp [LinearMap.lsmul_apply, mul_comm]
+  rw [hlsmul]
   simp only [LinearMap.trace_smulRight, LinearMap.id_apply]
 
 /-- The bundled determinant-power character is the corresponding determinant power. -/

--- a/TauCeti/RepresentationTheory/ClassicalGroups/Determinant.lean
+++ b/TauCeti/RepresentationTheory/ClassicalGroups/Determinant.lean
@@ -111,21 +111,20 @@ theorem detPowerRep_neg_apply (m : ℤ) (g : GL (Fin n) k) (x : k) :
     detPowerRep k n (-m) g x = (↑((Matrix.GeneralLinearGroup.det g) ^ m) : k)⁻¹ * x := by
   simp only [detPowerRep_apply, zpow_neg, Units.val_inv_eq_inv_val]
 
-private theorem trace_lsmul_self (a : k) :
-    LinearMap.trace k k (LinearMap.lsmul k k a) = a := by
-  have h : LinearMap.lsmul k k a = a • (1 : k →ₗ[k] k) := by
-    apply LinearMap.ext
-    intro x
-    simp [LinearMap.lsmul_apply]
-  rw [h, map_smul, LinearMap.trace_one]
-  simp [Module.finrank_self]
-
 /-- The character of the determinant-power representation is the corresponding determinant power. -/
 @[simp]
 theorem char_detPowerRep (m : ℤ) (g : GL (Fin n) k) :
     (detPowerRep k n m).character g = (↑((Matrix.GeneralLinearGroup.det g) ^ m) : k) := by
   rw [Representation.character]
-  exact trace_lsmul_self k (↑((Matrix.GeneralLinearGroup.det g) ^ m) : k)
+  change LinearMap.trace k k
+      (LinearMap.lsmul k k (↑((Matrix.GeneralLinearGroup.det g) ^ m) : k)) =
+    (↑((Matrix.GeneralLinearGroup.det g) ^ m) : k)
+  rw [show LinearMap.lsmul k k (↑((Matrix.GeneralLinearGroup.det g) ^ m) : k) =
+      LinearMap.id.smulRight (↑((Matrix.GeneralLinearGroup.det g) ^ m) : k) by
+    apply LinearMap.ext
+    intro x
+    simp [LinearMap.lsmul_apply, mul_comm]]
+  simp only [LinearMap.trace_smulRight, LinearMap.id_apply]
 
 /-- The bundled determinant-power character is the corresponding determinant power. -/
 @[simp]

--- a/TauCeti/RepresentationTheory/ClassicalGroups/Determinant.lean
+++ b/TauCeti/RepresentationTheory/ClassicalGroups/Determinant.lean
@@ -87,10 +87,7 @@ theorem detPowerRep_comp_toGL (m : ℤ) :
   -- Unfolding the two composed monoid homomorphisms exposes the scalar-action formula.
   change detPowerRep k n m (Matrix.SpecialLinearGroup.toGL g) x = x
   rw [detPowerRep_apply]
-  have hdet : Matrix.GeneralLinearGroup.det (Matrix.SpecialLinearGroup.toGL g) = 1 := by
-    apply Units.ext
-    exact g.det_coe
-  simp [hdet]
+  simp
 
 /-- The determinant-power representation as a finite-dimensional representation. -/
 noncomputable abbrev detPowerFDRep (m : ℤ) : FDRep k (GL (Fin n) k) :=

--- a/TauCeti/RepresentationTheory/ClassicalGroups/Determinant.lean
+++ b/TauCeti/RepresentationTheory/ClassicalGroups/Determinant.lean
@@ -5,8 +5,8 @@ Authors: Codex
 -/
 module
 
-public import TauCeti.RepresentationTheory.ClassicalGroups.Standard
 public import Mathlib.LinearAlgebra.Matrix.SpecialLinearGroup
+public import Mathlib.RepresentationTheory.Character
 
 /-!
 # Determinant-power representations of the general linear group
@@ -76,7 +76,8 @@ theorem detPowerRep_add_apply (m l : ℤ) (g : GL (Fin n) k) (x : k) :
   rw [mul_assoc]
 
 /-- Every determinant-power representation restricts to the trivial representation of `SL n k`. -/
-theorem detPowerRep_comp_specialLinear (m : ℤ) :
+@[simp]
+theorem detPowerRep_comp_toGL (m : ℤ) :
     (detPowerRep k n m).comp Matrix.SpecialLinearGroup.toGL =
       Representation.trivial k (Matrix.SpecialLinearGroup (Fin n) k) k := by
   apply MonoidHom.ext
@@ -91,6 +92,14 @@ theorem detPowerRep_comp_specialLinear (m : ℤ) :
     exact g.det_coe
   simp [hdet]
 
+/-- The determinant-power representation as a finite-dimensional representation. -/
+noncomputable abbrev detPowerFDRep (m : ℤ) : FDRep k (GL (Fin n) k) :=
+  FDRep.of (detPowerRep k n m)
+
+/-- The determinant representation as a finite-dimensional representation. -/
+noncomputable abbrev detFDRep : FDRep k (GL (Fin n) k) :=
+  FDRep.of (detRep k n)
+
 end CommRing
 
 section Field
@@ -102,27 +111,21 @@ theorem detPowerRep_neg_apply (m : ℤ) (g : GL (Fin n) k) (x : k) :
     detPowerRep k n (-m) g x = (↑((Matrix.GeneralLinearGroup.det g) ^ m) : k)⁻¹ * x := by
   simp only [detPowerRep_apply, zpow_neg, Units.val_inv_eq_inv_val]
 
-/-- The determinant-power representation as a finite-dimensional representation. -/
-noncomputable abbrev detPowerFDRep (m : ℤ) : FDRep k (GL (Fin n) k) :=
-  FDRep.of (detPowerRep k n m)
-
-/-- The determinant representation as a finite-dimensional representation. -/
-noncomputable abbrev detFDRep : FDRep k (GL (Fin n) k) :=
-  FDRep.of (detRep k n)
+private theorem trace_lsmul_self (a : k) :
+    LinearMap.trace k k (LinearMap.lsmul k k a) = a := by
+  have h : LinearMap.lsmul k k a = a • (1 : k →ₗ[k] k) := by
+    apply LinearMap.ext
+    intro x
+    simp [LinearMap.lsmul_apply]
+  rw [h, map_smul, LinearMap.trace_one]
+  simp [Module.finrank_self]
 
 /-- The character of the determinant-power representation is the corresponding determinant power. -/
 @[simp]
 theorem char_detPowerRep (m : ℤ) (g : GL (Fin n) k) :
     (detPowerRep k n m).character g = (↑((Matrix.GeneralLinearGroup.det g) ^ m) : k) := by
   rw [Representation.character]
-  change (LinearMap.trace k k)
-    (LinearMap.lsmul k k (↑((Matrix.GeneralLinearGroup.det g) ^ m) : k)) = _
-  rw [show LinearMap.lsmul k k (↑((Matrix.GeneralLinearGroup.det g) ^ m) : k) =
-      (↑((Matrix.GeneralLinearGroup.det g) ^ m) : k) • (1 : k →ₗ[k] k) by
-    apply LinearMap.ext
-    intro x
-    simp [LinearMap.lsmul_apply]]
-  simp [Module.finrank_self]
+  exact trace_lsmul_self k (↑((Matrix.GeneralLinearGroup.det g) ^ m) : k)
 
 /-- The bundled determinant-power character is the corresponding determinant power. -/
 @[simp]
@@ -131,6 +134,7 @@ theorem char_detPowerFDRep (m : ℤ) (g : GL (Fin n) k) :
   simpa only [FDRep.character, FDRep.of_ρ', Representation.character] using char_detPowerRep k n m g
 
 /-- The bundled determinant character is the determinant. -/
+@[simp]
 theorem char_detFDRep (g : GL (Fin n) k) :
     (detFDRep k n).character g = (Matrix.GeneralLinearGroup.det g : k) := by
   simpa only [zpow_one, Matrix.GeneralLinearGroup.val_det_apply] using char_detPowerFDRep k n 1 g

--- a/TauCeti/RepresentationTheory/ClassicalGroups/Determinant.lean
+++ b/TauCeti/RepresentationTheory/ClassicalGroups/Determinant.lean
@@ -60,12 +60,6 @@ theorem detPowerRep_apply (m : ℤ) (g : GL (Fin n) k) (x : k) :
     detPowerRep k n m g x = (↑((Matrix.GeneralLinearGroup.det g) ^ m) : k) * x := by
   simp [detPowerRep, smul_eq_mul]
 
-/-- The determinant action is scalar multiplication by the determinant. -/
-@[simp]
-theorem detRep_apply (g : GL (Fin n) k) (x : k) :
-    detRep k n g x = (Matrix.GeneralLinearGroup.det g : k) * x := by
-  simp
-
 /-- The zero determinant power is the trivial representation. -/
 @[simp]
 theorem detPowerRep_zero : detPowerRep k n 0 = 1 := by
@@ -130,12 +124,6 @@ theorem char_detPowerRep (m : ℤ) (g : GL (Fin n) k) :
     simp [LinearMap.lsmul_apply]]
   simp [Module.finrank_self]
 
-/-- The determinant is the character of the determinant representation. -/
-@[simp]
-theorem char_detRep (g : GL (Fin n) k) :
-    (detRep k n).character g = (Matrix.GeneralLinearGroup.det g : k) := by
-  simp
-
 /-- The bundled determinant-power character is the corresponding determinant power. -/
 @[simp]
 theorem char_detPowerFDRep (m : ℤ) (g : GL (Fin n) k) :
@@ -143,10 +131,9 @@ theorem char_detPowerFDRep (m : ℤ) (g : GL (Fin n) k) :
   simpa only [FDRep.character, FDRep.of_ρ', Representation.character] using char_detPowerRep k n m g
 
 /-- The bundled determinant character is the determinant. -/
-@[simp]
 theorem char_detFDRep (g : GL (Fin n) k) :
     (detFDRep k n).character g = (Matrix.GeneralLinearGroup.det g : k) := by
-  simpa only [FDRep.character, FDRep.of_ρ', Representation.character] using char_detRep k n g
+  simpa only [zpow_one, Matrix.GeneralLinearGroup.val_det_apply] using char_detPowerFDRep k n 1 g
 
 end Field
 

--- a/TauCeti/RepresentationTheory/ClassicalGroups/Determinant.lean
+++ b/TauCeti/RepresentationTheory/ClassicalGroups/Determinant.lean
@@ -1,0 +1,153 @@
+/-
+Copyright (c) 2026 Tau Ceti. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Codex
+-/
+module
+
+public import TauCeti.RepresentationTheory.ClassicalGroups.Standard
+public import Mathlib.LinearAlgebra.Matrix.SpecialLinearGroup
+
+/-!
+# Determinant-power representations of the general linear group
+
+This file packages the determinant and its integral powers as one-dimensional representations of
+the general linear group. These are the rational characters used to form determinant twists of
+polynomial representations.
+
+## Main definitions
+
+* `TauCeti.detPowerRep` is the representation on the scalar module with action by `det(g)^m`.
+* `TauCeti.detRep` is the determinant representation, the case `m = 1`.
+
+## References
+
+* [Classical groups roadmap](https://github.com/TauCetiProject/TauCetiRoadmap/blob/main/TauCetiRoadmap/RepresentationTheory/ClassicalGroups/README.md)
+-/
+
+public section
+
+open Matrix
+
+universe u
+
+namespace TauCeti
+
+variable (k : Type u) (n : ℕ)
+
+section CommRing
+
+variable [CommRing k]
+
+/-- The one-dimensional representation of `GL n k` on which `g` acts by `det(g)^m`. -/
+def detPowerRep (m : ℤ) : Representation k (GL (Fin n) k) k where
+  toFun g := LinearMap.lsmul k k (↑((Matrix.GeneralLinearGroup.det g) ^ m) : k)
+  map_one' := by
+    apply LinearMap.ext
+    intro x
+    simp
+  map_mul' g h := by
+    apply LinearMap.ext
+    intro x
+    simp [mul_zpow, mul_assoc]
+
+/-- The determinant representation of `GL n k`. -/
+abbrev detRep : Representation k (GL (Fin n) k) k := detPowerRep k n 1
+
+/-- The determinant-power action is scalar multiplication by the indicated determinant power. -/
+@[simp]
+theorem detPowerRep_apply (m : ℤ) (g : GL (Fin n) k) (x : k) :
+    detPowerRep k n m g x = (↑((Matrix.GeneralLinearGroup.det g) ^ m) : k) * x := by
+  simp [detPowerRep, smul_eq_mul]
+
+/-- The determinant action is scalar multiplication by the determinant. -/
+@[simp]
+theorem detRep_apply (g : GL (Fin n) k) (x : k) :
+    detRep k n g x = (Matrix.GeneralLinearGroup.det g : k) * x := by
+  simp
+
+/-- The zero determinant power is the trivial representation. -/
+@[simp]
+theorem detPowerRep_zero : detPowerRep k n 0 = 1 := by
+  apply MonoidHom.ext
+  intro g
+  apply LinearMap.ext
+  intro x
+  simp
+
+/-- Adding exponents composes the corresponding determinant actions. -/
+theorem detPowerRep_add_apply (m l : ℤ) (g : GL (Fin n) k) (x : k) :
+    detPowerRep k n (m + l) g x = detPowerRep k n m g (detPowerRep k n l g x) := by
+  simp only [detPowerRep_apply, zpow_add, Units.val_mul]
+  rw [mul_assoc]
+
+/-- Every determinant-power representation restricts to the trivial representation of `SL n k`. -/
+theorem detPowerRep_comp_specialLinear (m : ℤ) :
+    (detPowerRep k n m).comp Matrix.SpecialLinearGroup.toGL =
+      Representation.trivial k (Matrix.SpecialLinearGroup (Fin n) k) k := by
+  apply MonoidHom.ext
+  intro g
+  apply LinearMap.ext
+  intro x
+  -- Unfolding the two composed monoid homomorphisms exposes the scalar-action formula.
+  change detPowerRep k n m (Matrix.SpecialLinearGroup.toGL g) x = x
+  rw [detPowerRep_apply]
+  have hdet : Matrix.GeneralLinearGroup.det (Matrix.SpecialLinearGroup.toGL g) = 1 := by
+    apply Units.ext
+    exact g.det_coe
+  simp [hdet]
+
+end CommRing
+
+section Field
+
+variable [Field k]
+
+/-- A negative determinant power acts by the inverse of the corresponding positive scalar. -/
+theorem detPowerRep_neg_apply (m : ℤ) (g : GL (Fin n) k) (x : k) :
+    detPowerRep k n (-m) g x = (↑((Matrix.GeneralLinearGroup.det g) ^ m) : k)⁻¹ * x := by
+  simp only [detPowerRep_apply, zpow_neg, Units.val_inv_eq_inv_val]
+
+/-- The determinant-power representation as a finite-dimensional representation. -/
+noncomputable abbrev detPowerFDRep (m : ℤ) : FDRep k (GL (Fin n) k) :=
+  FDRep.of (detPowerRep k n m)
+
+/-- The determinant representation as a finite-dimensional representation. -/
+noncomputable abbrev detFDRep : FDRep k (GL (Fin n) k) :=
+  FDRep.of (detRep k n)
+
+/-- The character of the determinant-power representation is the corresponding determinant power. -/
+@[simp]
+theorem char_detPowerRep (m : ℤ) (g : GL (Fin n) k) :
+    (detPowerRep k n m).character g = (↑((Matrix.GeneralLinearGroup.det g) ^ m) : k) := by
+  rw [Representation.character]
+  change (LinearMap.trace k k)
+    (LinearMap.lsmul k k (↑((Matrix.GeneralLinearGroup.det g) ^ m) : k)) = _
+  rw [show LinearMap.lsmul k k (↑((Matrix.GeneralLinearGroup.det g) ^ m) : k) =
+      (↑((Matrix.GeneralLinearGroup.det g) ^ m) : k) • (1 : k →ₗ[k] k) by
+    apply LinearMap.ext
+    intro x
+    simp [LinearMap.lsmul_apply]]
+  simp [Module.finrank_self]
+
+/-- The determinant is the character of the determinant representation. -/
+@[simp]
+theorem char_detRep (g : GL (Fin n) k) :
+    (detRep k n).character g = (Matrix.GeneralLinearGroup.det g : k) := by
+  simp
+
+/-- The bundled determinant-power character is the corresponding determinant power. -/
+@[simp]
+theorem char_detPowerFDRep (m : ℤ) (g : GL (Fin n) k) :
+    (detPowerFDRep k n m).character g = (↑((Matrix.GeneralLinearGroup.det g) ^ m) : k) := by
+  simpa only [FDRep.character, FDRep.of_ρ', Representation.character] using char_detPowerRep k n m g
+
+/-- The bundled determinant character is the determinant. -/
+@[simp]
+theorem char_detFDRep (g : GL (Fin n) k) :
+    (detFDRep k n).character g = (Matrix.GeneralLinearGroup.det g : k) := by
+  simpa only [FDRep.character, FDRep.of_ρ', Representation.character] using char_detRep k n g
+
+end Field
+
+end TauCeti

--- a/TauCeti/RepresentationTheory/ClassicalGroups/Determinant.lean
+++ b/TauCeti/RepresentationTheory/ClassicalGroups/Determinant.lean
@@ -103,7 +103,7 @@ section Field
 
 variable [Field k]
 
-/-- A negative determinant power acts by the inverse of the corresponding positive scalar. -/
+/-- Negating the exponent makes the determinant scalar the inverse of the original power. -/
 theorem detPowerRep_neg_apply (m : ℤ) (g : GL (Fin n) k) (x : k) :
     detPowerRep k n (-m) g x = (↑((Matrix.GeneralLinearGroup.det g) ^ m) : k)⁻¹ * x := by
   simp only [detPowerRep_apply, zpow_neg, Units.val_inv_eq_inv_val]

--- a/TauCeti/RepresentationTheory/ClassicalGroups/Determinant.lean
+++ b/TauCeti/RepresentationTheory/ClassicalGroups/Determinant.lean
@@ -134,6 +134,7 @@ theorem char_detPowerFDRep (m : ℤ) (g : GL (Fin n) k) :
   simpa only [FDRep.character, FDRep.of_ρ', Representation.character] using char_detPowerRep k n m g
 
 /-- The bundled determinant character is the determinant. -/
+@[simp]
 theorem char_detFDRep (g : GL (Fin n) k) :
     (detFDRep k n).character g = (Matrix.GeneralLinearGroup.det g : k) := by
   simpa only [zpow_one, Matrix.GeneralLinearGroup.val_det_apply] using char_detPowerFDRep k n 1 g

--- a/TauCeti/RepresentationTheory/ClassicalGroups/Determinant.lean
+++ b/TauCeti/RepresentationTheory/ClassicalGroups/Determinant.lean
@@ -134,7 +134,6 @@ theorem char_detPowerFDRep (m : ℤ) (g : GL (Fin n) k) :
   simpa only [FDRep.character, FDRep.of_ρ', Representation.character] using char_detPowerRep k n m g
 
 /-- The bundled determinant character is the determinant. -/
-@[simp]
 theorem char_detFDRep (g : GL (Fin n) k) :
     (detFDRep k n).character g = (Matrix.GeneralLinearGroup.det g : k) := by
   simpa only [zpow_one, Matrix.GeneralLinearGroup.val_det_apply] using char_detPowerFDRep k n 1 g


### PR DESCRIPTION
This PR adds the one-dimensional determinant-power representations of `GL n k`: `detPowerRep m` acts on `k` by `det(g)^m`, `detRep` is its `m = 1` specialization, and their `FDRep` forms have exactly these character values. It also proves exponent addition at the action level, identifies negative powers over a field, and shows every determinant power restricts trivially along `SL n k → GL n k`.

This advances `TauCetiRoadmap/RepresentationTheory/ClassicalGroups/README.md`, Layer 0, item “Rational and polynomial representations”, specifically “`det` and its powers are the one-dimensional rational representations `det^m`”. It is the direct foundation for the determinant twists that express general rational irreducibles as `det^m ⊗ V_μ`, and is a small independent next step after the existing standard and restricted-standard representations.

The new `TauCeti/RepresentationTheory/ClassicalGroups/Determinant.lean` has 153 lines. It reuses Mathlib's `Matrix.GeneralLinearGroup.det`, `Matrix.SpecialLinearGroup.toGL`, scalar linear maps, and trace API; no Mathlib code or supplementary-source material is vendored.

<!--tauceti-target:v1 {"focus":"RepresentationTheory","id":"determinant-power-representations"}-->

🤖 Prepared with Codex
