### PR TITLE
feat(Contour): concatenation for set-level Cauchy principal values

### DIFF
--- a/TauCeti/Analysis/Contour/Cauchy/PrincipalValue/Concat.lean
+++ b/TauCeti/Analysis/Contour/Cauchy/PrincipalValue/Concat.lean
@@ -12,8 +12,9 @@ public import TauCeti.Analysis.Contour.Cauchy.PrincipalValue.On
 `HasCauchyPV` binds its finite excision set **existentially**, which is the right interface for
 consumers but is too weak to concatenate: two principal values along adjacent subcurves may be
 witnessed by *different* excision sets, and passing to their union changes the excised integrand.
-Recovering the union form would need the added points to be met on a null set of parameters, which
-the definition does not supply.
+Recovering the union form needs extra control that `HasCauchyPV` does not supply — the added
+points being met on a null set of parameters is one sufficient condition, though not a necessary
+one, since enlargement is also harmless wherever the integrand's contribution already vanishes.
 
 This file therefore works with the prescribed-witness form `HasCauchyPVWith` of
 `PrincipalValue/On.lean`, in which the excision set is an explicit parameter, and concatenates

--- a/TauCeti/Analysis/Contour/Cauchy/PrincipalValue/Concat.lean
+++ b/TauCeti/Analysis/Contour/Cauchy/PrincipalValue/Concat.lean
@@ -1,0 +1,110 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+module
+
+public import TauCeti.Analysis.Contour.Cauchy.PrincipalValue.On
+
+/-!
+# Concatenating set-level Cauchy principal values
+
+`HasCauchyPV` binds its finite excision set **existentially**, which is the right interface for
+consumers but is too weak to concatenate: two principal values along adjacent subcurves may be
+witnessed by *different* excision sets, and passing to their union changes the excised integrand.
+Recovering the union form needs the extra points to be met on a null set of parameters — a genuine
+side condition, since a curve that is *constant* at an added point meets it on a set of positive
+measure.
+
+This file therefore exposes the prescribed-witness form `HasCauchyPVWith`, in which the excision
+set is an explicit parameter, and concatenates there. Adjacent subcurves sharing one excision set
+add (`HasCauchyPVWith.concat`), and the complementary piece can be subtracted off
+(`HasCauchyPVWith.sub_right`) — the direction that splits a principal value along a closed contour
+into its constituent arcs. Both are the set-level analogues of `HasCauchyPVAt.concat`, whose single
+excised point is automatically shared.
+
+## Main definitions
+
+* `TauCeti.Contour.HasCauchyPVWith` — `HasCauchyPV` with the excision set prescribed rather than
+  existentially bound.
+
+## Main results
+
+* `TauCeti.Contour.hasCauchyPV_iff_exists_hasCauchyPVWith` — the two forms agree after
+  existentially quantifying the witness.
+* `TauCeti.Contour.HasCauchyPVWith.concat` — principal values along `[a, b]` and `[b, c]` sharing
+  an excision set add to the one along `[a, c]`.
+* `TauCeti.Contour.HasCauchyPVWith.sub_right` — the converse split: removing the `[b, c]` piece
+  from the `[a, c]` principal value leaves the `[a, b]` one.
+-/
+
+public section
+
+open Filter Topology MeasureTheory
+
+namespace TauCeti.Contour
+
+/-- **The Cauchy principal value with a prescribed excision set.** Identical to `HasCauchyPV`
+except that the finite set `S` of excised points is an explicit parameter rather than
+existentially bound, which is what makes the principal values along adjacent subcurves
+concatenable. -/
+def HasCauchyPVWith (γ : ℝ → ℂ) (a b : ℝ) (f : ℂ → ℂ) (S : Finset ℂ) (v : ℂ) : Prop :=
+  (∀ᶠ ε in 𝓝[>] (0 : ℝ), IntervalIntegrable
+      (fun t => if ∃ s ∈ S, ‖γ t - s‖ ≤ ε then 0 else f (γ t) * deriv γ t) volume a b) ∧
+    Tendsto (fun ε ↦ ∫ t in a..b, if ∃ s ∈ S, ‖γ t - s‖ ≤ ε then 0 else f (γ t) * deriv γ t)
+      (𝓝[>] 0) (𝓝 v)
+
+/-- `HasCauchyPVWith` unfolded into its two clauses — eventual integrability of the excised
+integrand and convergence of the excised integrals — so consumers need not unfold the
+definition. -/
+theorem hasCauchyPVWith_iff {γ : ℝ → ℂ} {a b : ℝ} {f : ℂ → ℂ} {S : Finset ℂ} {v : ℂ} :
+    HasCauchyPVWith γ a b f S v ↔
+      (∀ᶠ ε in 𝓝[>] (0 : ℝ), IntervalIntegrable
+          (fun t => if ∃ s ∈ S, ‖γ t - s‖ ≤ ε then 0 else f (γ t) * deriv γ t) volume a b) ∧
+        Tendsto (fun ε ↦ ∫ t in a..b, if ∃ s ∈ S, ‖γ t - s‖ ≤ ε then 0 else f (γ t) * deriv γ t)
+          (𝓝[>] 0) (𝓝 v) :=
+  Iff.rfl
+
+/-- Forgetting the witness recovers the existentially-bound form. -/
+theorem HasCauchyPVWith.hasCauchyPV {γ : ℝ → ℂ} {a b : ℝ} {f : ℂ → ℂ} {S : Finset ℂ} {v : ℂ}
+    (h : HasCauchyPVWith γ a b f S v) : HasCauchyPV γ a b f v :=
+  HasCauchyPV.intro S h.1 h.2
+
+/-- `HasCauchyPV` is exactly `HasCauchyPVWith` with the excision set existentially quantified. -/
+theorem hasCauchyPV_iff_exists_hasCauchyPVWith {γ : ℝ → ℂ} {a b : ℝ} {f : ℂ → ℂ} {v : ℂ} :
+    HasCauchyPV γ a b f v ↔ ∃ S : Finset ℂ, HasCauchyPVWith γ a b f S v := by
+  rw [hasCauchyPV_iff]
+  exact Iff.rfl
+
+/-- **Concatenation.** Principal values along the adjacent subcurves `[a, b]` and `[b, c]` that
+excise the *same* finite set add to the principal value along `[a, c]`. As for
+`HasCauchyPVAt.concat`, the integrability of the excised integrand across `[a, c]` and the
+additivity of the integral both follow from the two given principal values, so no ordering or
+separate integrability hypothesis is needed. -/
+theorem HasCauchyPVWith.concat {γ : ℝ → ℂ} {a b c : ℝ} {f : ℂ → ℂ} {S : Finset ℂ} {L₁ L₂ : ℂ}
+    (h_ab : HasCauchyPVWith γ a b f S L₁) (h_bc : HasCauchyPVWith γ b c f S L₂) :
+    HasCauchyPVWith γ a c f S (L₁ + L₂) := by
+  refine ⟨?_, ?_⟩
+  · filter_upwards [h_ab.1, h_bc.1] with ε hab hbc
+    exact hab.trans hbc
+  · refine Filter.Tendsto.congr' ?_ (h_ab.2.add h_bc.2)
+    filter_upwards [h_ab.1, h_bc.1] with ε hab hbc
+    exact intervalIntegral.integral_add_adjacent_intervals hab hbc
+
+/-- **Splitting off the far piece.** If the principal value along `[a, c]` and the one along
+`[b, c]` excise the same finite set, then their difference is the principal value along `[a, b]`.
+This is the direction that decomposes a contour: knowing the whole and one arc gives the rest. -/
+theorem HasCauchyPVWith.sub_right {γ : ℝ → ℂ} {a b c : ℝ} {f : ℂ → ℂ} {S : Finset ℂ} {L L₂ : ℂ}
+    (h_ac : HasCauchyPVWith γ a c f S L) (h_bc : HasCauchyPVWith γ b c f S L₂) :
+    HasCauchyPVWith γ a b f S (L - L₂) := by
+  refine ⟨?_, ?_⟩
+  · filter_upwards [h_ac.1, h_bc.1] with ε hac hbc
+    exact hac.trans hbc.symm
+  · refine Filter.Tendsto.congr' ?_ (h_ac.2.sub h_bc.2)
+    filter_upwards [h_ac.1, h_bc.1] with ε hac hbc
+    rw [← intervalIntegral.integral_add_adjacent_intervals (b := b) (hac.trans hbc.symm) hbc]
+    ring
+
+end TauCeti.Contour
+
+end

--- a/TauCeti/Analysis/Contour/Cauchy/PrincipalValue/Concat.lean
+++ b/TauCeti/Analysis/Contour/Cauchy/PrincipalValue/Concat.lean
@@ -12,26 +12,19 @@ public import TauCeti.Analysis.Contour.Cauchy.PrincipalValue.On
 `HasCauchyPV` binds its finite excision set **existentially**, which is the right interface for
 consumers but is too weak to concatenate: two principal values along adjacent subcurves may be
 witnessed by *different* excision sets, and passing to their union changes the excised integrand.
-Recovering the union form needs the extra points to be met on a null set of parameters — a genuine
-side condition, since a curve that is *constant* at an added point meets it on a set of positive
-measure.
+Recovering the union form would need the added points to be met on a null set of parameters, which
+the definition does not supply.
 
-This file therefore exposes the prescribed-witness form `HasCauchyPVWith`, in which the excision
-set is an explicit parameter, and concatenates there. Adjacent subcurves sharing one excision set
+This file therefore works with the prescribed-witness form `HasCauchyPVWith` of
+`PrincipalValue/On.lean`, in which the excision set is an explicit parameter, and concatenates
+there. Adjacent subcurves sharing one excision set
 add (`HasCauchyPVWith.concat`), and the complementary piece can be subtracted off
 (`HasCauchyPVWith.sub_right`) — the direction that splits a principal value along a closed contour
 into its constituent arcs. Both are the set-level analogues of `HasCauchyPVAt.concat`, whose single
 excised point is automatically shared.
 
-## Main definitions
-
-* `TauCeti.Contour.HasCauchyPVWith` — `HasCauchyPV` with the excision set prescribed rather than
-  existentially bound.
-
 ## Main results
 
-* `TauCeti.Contour.hasCauchyPV_iff_exists_hasCauchyPVWith` — the two forms agree after
-  existentially quantifying the witness.
 * `TauCeti.Contour.HasCauchyPVWith.concat` — principal values along `[a, b]` and `[b, c]` sharing
   an excision set add to the one along `[a, c]`.
 * `TauCeti.Contour.HasCauchyPVWith.sub_right` — the converse split: removing the `[b, c]` piece
@@ -44,38 +37,6 @@ open Filter Topology MeasureTheory
 
 namespace TauCeti.Contour
 
-/-- **The Cauchy principal value with a prescribed excision set.** Identical to `HasCauchyPV`
-except that the finite set `S` of excised points is an explicit parameter rather than
-existentially bound, which is what makes the principal values along adjacent subcurves
-concatenable. -/
-def HasCauchyPVWith (γ : ℝ → ℂ) (a b : ℝ) (f : ℂ → ℂ) (S : Finset ℂ) (v : ℂ) : Prop :=
-  (∀ᶠ ε in 𝓝[>] (0 : ℝ), IntervalIntegrable
-      (fun t => if ∃ s ∈ S, ‖γ t - s‖ ≤ ε then 0 else f (γ t) * deriv γ t) volume a b) ∧
-    Tendsto (fun ε ↦ ∫ t in a..b, if ∃ s ∈ S, ‖γ t - s‖ ≤ ε then 0 else f (γ t) * deriv γ t)
-      (𝓝[>] 0) (𝓝 v)
-
-/-- `HasCauchyPVWith` unfolded into its two clauses — eventual integrability of the excised
-integrand and convergence of the excised integrals — so consumers need not unfold the
-definition. -/
-theorem hasCauchyPVWith_iff {γ : ℝ → ℂ} {a b : ℝ} {f : ℂ → ℂ} {S : Finset ℂ} {v : ℂ} :
-    HasCauchyPVWith γ a b f S v ↔
-      (∀ᶠ ε in 𝓝[>] (0 : ℝ), IntervalIntegrable
-          (fun t => if ∃ s ∈ S, ‖γ t - s‖ ≤ ε then 0 else f (γ t) * deriv γ t) volume a b) ∧
-        Tendsto (fun ε ↦ ∫ t in a..b, if ∃ s ∈ S, ‖γ t - s‖ ≤ ε then 0 else f (γ t) * deriv γ t)
-          (𝓝[>] 0) (𝓝 v) :=
-  Iff.rfl
-
-/-- Forgetting the witness recovers the existentially-bound form. -/
-theorem HasCauchyPVWith.hasCauchyPV {γ : ℝ → ℂ} {a b : ℝ} {f : ℂ → ℂ} {S : Finset ℂ} {v : ℂ}
-    (h : HasCauchyPVWith γ a b f S v) : HasCauchyPV γ a b f v :=
-  HasCauchyPV.intro S h.1 h.2
-
-/-- `HasCauchyPV` is exactly `HasCauchyPVWith` with the excision set existentially quantified. -/
-theorem hasCauchyPV_iff_exists_hasCauchyPVWith {γ : ℝ → ℂ} {a b : ℝ} {f : ℂ → ℂ} {v : ℂ} :
-    HasCauchyPV γ a b f v ↔ ∃ S : Finset ℂ, HasCauchyPVWith γ a b f S v := by
-  rw [hasCauchyPV_iff]
-  exact Iff.rfl
-
 /-- **Concatenation.** Principal values along the adjacent subcurves `[a, b]` and `[b, c]` that
 excise the *same* finite set add to the principal value along `[a, c]`. As for
 `HasCauchyPVAt.concat`, the integrability of the excised integrand across `[a, c]` and the
@@ -84,6 +45,7 @@ separate integrability hypothesis is needed. -/
 theorem HasCauchyPVWith.concat {γ : ℝ → ℂ} {a b c : ℝ} {f : ℂ → ℂ} {S : Finset ℂ} {L₁ L₂ : ℂ}
     (h_ab : HasCauchyPVWith γ a b f S L₁) (h_bc : HasCauchyPVWith γ b c f S L₂) :
     HasCauchyPVWith γ a c f S (L₁ + L₂) := by
+  rw [hasCauchyPVWith_iff] at h_ab h_bc ⊢
   refine ⟨?_, ?_⟩
   · filter_upwards [h_ab.1, h_bc.1] with ε hab hbc
     exact hab.trans hbc
@@ -97,13 +59,14 @@ This is the direction that decomposes a contour: knowing the whole and one arc g
 theorem HasCauchyPVWith.sub_right {γ : ℝ → ℂ} {a b c : ℝ} {f : ℂ → ℂ} {S : Finset ℂ} {L L₂ : ℂ}
     (h_ac : HasCauchyPVWith γ a c f S L) (h_bc : HasCauchyPVWith γ b c f S L₂) :
     HasCauchyPVWith γ a b f S (L - L₂) := by
+  rw [hasCauchyPVWith_iff] at h_ac h_bc ⊢
   refine ⟨?_, ?_⟩
   · filter_upwards [h_ac.1, h_bc.1] with ε hac hbc
     exact hac.trans hbc.symm
   · refine Filter.Tendsto.congr' ?_ (h_ac.2.sub h_bc.2)
     filter_upwards [h_ac.1, h_bc.1] with ε hac hbc
-    rw [← intervalIntegral.integral_add_adjacent_intervals (b := b) (hac.trans hbc.symm) hbc]
-    ring
+    simpa using
+      intervalIntegral.integral_interval_sub_interval_comm hac hbc (hac.trans hbc.symm)
 
 end TauCeti.Contour
 

--- a/TauCeti/Analysis/Contour/Cauchy/PrincipalValue/On.lean
+++ b/TauCeti/Analysis/Contour/Cauchy/PrincipalValue/On.lean
@@ -153,12 +153,6 @@ theorem HasCauchyPVWith.hasCauchyPV {γ : ℝ → ℂ} {a b : ℝ} {f : ℂ → 
     (h : HasCauchyPVWith γ a b f S v) : HasCauchyPV γ a b f v :=
   HasCauchyPV.intro S h.1 h.2
 
-/-- `HasCauchyPV` is exactly `HasCauchyPVWith` with the excision set existentially quantified. -/
-theorem hasCauchyPV_iff_exists_hasCauchyPVWith {γ : ℝ → ℂ} {a b : ℝ} {f : ℂ → ℂ} {v : ℂ} :
-    HasCauchyPV γ a b f v ↔ ∃ S : Finset ℂ, HasCauchyPVWith γ a b f S v := by
-  rw [hasCauchyPV_iff]
-  exact Iff.rfl
-
 /-- The Cauchy principal value on a set exists: shorthand for `∃ v, HasCauchyPV γ a b f v`. -/
 def CauchyPVExists (γ : ℝ → ℂ) (a b : ℝ) (f : ℂ → ℂ) : Prop :=
   ∃ v : ℂ, HasCauchyPV γ a b f v

--- a/TauCeti/Analysis/Contour/Cauchy/PrincipalValue/On.lean
+++ b/TauCeti/Analysis/Contour/Cauchy/PrincipalValue/On.lean
@@ -153,6 +153,16 @@ theorem HasCauchyPVWith.hasCauchyPV {γ : ℝ → ℂ} {a b : ℝ} {f : ℂ → 
     (h : HasCauchyPVWith γ a b f S v) : HasCauchyPV γ a b f v :=
   HasCauchyPV.intro S h.1 h.2
 
+/-- `HasCauchyPV` is exactly `HasCauchyPVWith` with the excision set existentially quantified.
+
+This is the abstraction-preserving bridge between the two forms, and is **not** redundant with
+the definition: under the module system `HasCauchyPV`'s body is not exposed outside this file,
+so `Iff.rfl` proves this only here and consumers elsewhere cannot unfold their way across. The
+sibling `hasCauchyPV_iff` expands the truncation body instead, which loses the abstraction. -/
+theorem hasCauchyPV_iff_exists_hasCauchyPVWith {γ : ℝ → ℂ} {a b : ℝ} {f : ℂ → ℂ} {v : ℂ} :
+    HasCauchyPV γ a b f v ↔ ∃ S : Finset ℂ, HasCauchyPVWith γ a b f S v :=
+  Iff.rfl
+
 /-- The Cauchy principal value on a set exists: shorthand for `∃ v, HasCauchyPV γ a b f v`. -/
 def CauchyPVExists (γ : ℝ → ℂ) (a b : ℝ) (f : ℂ → ℂ) : Prop :=
   ∃ v : ℂ, HasCauchyPV γ a b f v

--- a/TauCeti/Analysis/Contour/Cauchy/PrincipalValue/On.lean
+++ b/TauCeti/Analysis/Contour/Cauchy/PrincipalValue/On.lean
@@ -89,6 +89,29 @@ open Filter Topology
 
 namespace TauCeti.Contour
 
+/-- **The Cauchy principal value with a prescribed excision set.** Identical to `HasCauchyPV`
+except that the finite set `S` of excised points is an explicit parameter rather than
+existentially bound, which is what makes the principal values along adjacent subcurves
+concatenable. -/
+def HasCauchyPVWith (γ : ℝ → ℂ) (a b : ℝ) (f : ℂ → ℂ) (S : Finset ℂ) (v : ℂ) : Prop :=
+  (∀ᶠ ε in 𝓝[>] (0 : ℝ), IntervalIntegrable
+      (fun t => if ∃ s ∈ S, ‖γ t - s‖ ≤ ε then 0 else f (γ t) * deriv γ t)
+        MeasureTheory.volume a b) ∧
+    Tendsto (fun ε ↦ ∫ t in a..b, if ∃ s ∈ S, ‖γ t - s‖ ≤ ε then 0 else f (γ t) * deriv γ t)
+      (𝓝[>] 0) (𝓝 v)
+
+/-- `HasCauchyPVWith` unfolded into its two clauses — eventual integrability of the excised
+integrand and convergence of the excised integrals — so consumers need not unfold the
+definition. -/
+theorem hasCauchyPVWith_iff {γ : ℝ → ℂ} {a b : ℝ} {f : ℂ → ℂ} {S : Finset ℂ} {v : ℂ} :
+    HasCauchyPVWith γ a b f S v ↔
+      (∀ᶠ ε in 𝓝[>] (0 : ℝ), IntervalIntegrable
+          (fun t => if ∃ s ∈ S, ‖γ t - s‖ ≤ ε then 0 else f (γ t) * deriv γ t)
+        MeasureTheory.volume a b) ∧
+        Tendsto (fun ε ↦ ∫ t in a..b, if ∃ s ∈ S, ‖γ t - s‖ ≤ ε then 0 else f (γ t) * deriv γ t)
+          (𝓝[>] 0) (𝓝 v) :=
+  Iff.rfl
+
 /-- The **Cauchy principal value on a set** of the contour integral `∮_γ f` exists with value `v`:
 there is a finite set `S ⊆ ℂ` such that the truncated integrand along `γ` over `[a, b]`, zeroed
 within a symmetric `ε`-ball of any point of `S`, is eventually `IntervalIntegrable` and its integral
@@ -97,12 +120,7 @@ tends to `v` as `ε → 0⁺`. The set is existential so the predicate stays `S`
 the convention that a Bochner integral of a non-integrable function is `0`. Set-level companion of
 `HasCauchyPVAt` (raw `γ : ℝ → ℂ`, `[a, b]`). -/
 def HasCauchyPV (γ : ℝ → ℂ) (a b : ℝ) (f : ℂ → ℂ) (v : ℂ) : Prop :=
-  ∃ S : Finset ℂ,
-    (∀ᶠ ε in 𝓝[>] (0 : ℝ), IntervalIntegrable
-        (fun t => if ∃ s ∈ S, ‖γ t - s‖ ≤ ε then 0 else f (γ t) * deriv γ t)
-        MeasureTheory.volume a b) ∧
-      Tendsto (fun ε ↦ ∫ t in a..b, if ∃ s ∈ S, ‖γ t - s‖ ≤ ε then 0 else f (γ t) * deriv γ t)
-        (𝓝[>] 0) (𝓝 v)
+  ∃ S : Finset ℂ, HasCauchyPVWith γ a b f S v
 
 /-- Restatement of `HasCauchyPV` as the existence of a finite excision set making the excised
 integrand eventually integrable and its integrals convergent, so consumers can characterize the
@@ -129,29 +147,6 @@ theorem HasCauchyPV.intro {γ : ℝ → ℂ} {a b : ℝ} {f : ℂ → ℂ} {v : 
         (𝓝[>] 0) (𝓝 v)) :
     HasCauchyPV γ a b f v :=
   ⟨S, h_int, h_tendsto⟩
-
-/-- **The Cauchy principal value with a prescribed excision set.** Identical to `HasCauchyPV`
-except that the finite set `S` of excised points is an explicit parameter rather than
-existentially bound, which is what makes the principal values along adjacent subcurves
-concatenable. -/
-def HasCauchyPVWith (γ : ℝ → ℂ) (a b : ℝ) (f : ℂ → ℂ) (S : Finset ℂ) (v : ℂ) : Prop :=
-  (∀ᶠ ε in 𝓝[>] (0 : ℝ), IntervalIntegrable
-      (fun t => if ∃ s ∈ S, ‖γ t - s‖ ≤ ε then 0 else f (γ t) * deriv γ t)
-        MeasureTheory.volume a b) ∧
-    Tendsto (fun ε ↦ ∫ t in a..b, if ∃ s ∈ S, ‖γ t - s‖ ≤ ε then 0 else f (γ t) * deriv γ t)
-      (𝓝[>] 0) (𝓝 v)
-
-/-- `HasCauchyPVWith` unfolded into its two clauses — eventual integrability of the excised
-integrand and convergence of the excised integrals — so consumers need not unfold the
-definition. -/
-theorem hasCauchyPVWith_iff {γ : ℝ → ℂ} {a b : ℝ} {f : ℂ → ℂ} {S : Finset ℂ} {v : ℂ} :
-    HasCauchyPVWith γ a b f S v ↔
-      (∀ᶠ ε in 𝓝[>] (0 : ℝ), IntervalIntegrable
-          (fun t => if ∃ s ∈ S, ‖γ t - s‖ ≤ ε then 0 else f (γ t) * deriv γ t)
-        MeasureTheory.volume a b) ∧
-        Tendsto (fun ε ↦ ∫ t in a..b, if ∃ s ∈ S, ‖γ t - s‖ ≤ ε then 0 else f (γ t) * deriv γ t)
-          (𝓝[>] 0) (𝓝 v) :=
-  Iff.rfl
 
 /-- Forgetting the witness recovers the existentially-bound form. -/
 theorem HasCauchyPVWith.hasCauchyPV {γ : ℝ → ℂ} {a b : ℝ} {f : ℂ → ℂ} {S : Finset ℂ} {v : ℂ}

--- a/TauCeti/Analysis/Contour/Cauchy/PrincipalValue/On.lean
+++ b/TauCeti/Analysis/Contour/Cauchy/PrincipalValue/On.lean
@@ -37,6 +37,8 @@ of `f` (which fails at an on-curve singularity), never silently identifying the 
 
 ## Main definitions
 
+* `HasCauchyPVWith γ a b f S v` — the same with the excision set `S` **prescribed**; the form
+  that concatenates, since adjacent subcurves must share it (`PrincipalValue/Concat.lean`)
 * `HasCauchyPV γ a b f v` — some finite excision set makes the truncated integrals converge to `v`
   (the primary predicate).
 * `CauchyPVExists γ a b f` — the principal value exists (`∃ v, HasCauchyPV γ a b f v`).
@@ -127,6 +129,40 @@ theorem HasCauchyPV.intro {γ : ℝ → ℂ} {a b : ℝ} {f : ℂ → ℂ} {v : 
         (𝓝[>] 0) (𝓝 v)) :
     HasCauchyPV γ a b f v :=
   ⟨S, h_int, h_tendsto⟩
+
+/-- **The Cauchy principal value with a prescribed excision set.** Identical to `HasCauchyPV`
+except that the finite set `S` of excised points is an explicit parameter rather than
+existentially bound, which is what makes the principal values along adjacent subcurves
+concatenable. -/
+def HasCauchyPVWith (γ : ℝ → ℂ) (a b : ℝ) (f : ℂ → ℂ) (S : Finset ℂ) (v : ℂ) : Prop :=
+  (∀ᶠ ε in 𝓝[>] (0 : ℝ), IntervalIntegrable
+      (fun t => if ∃ s ∈ S, ‖γ t - s‖ ≤ ε then 0 else f (γ t) * deriv γ t)
+        MeasureTheory.volume a b) ∧
+    Tendsto (fun ε ↦ ∫ t in a..b, if ∃ s ∈ S, ‖γ t - s‖ ≤ ε then 0 else f (γ t) * deriv γ t)
+      (𝓝[>] 0) (𝓝 v)
+
+/-- `HasCauchyPVWith` unfolded into its two clauses — eventual integrability of the excised
+integrand and convergence of the excised integrals — so consumers need not unfold the
+definition. -/
+theorem hasCauchyPVWith_iff {γ : ℝ → ℂ} {a b : ℝ} {f : ℂ → ℂ} {S : Finset ℂ} {v : ℂ} :
+    HasCauchyPVWith γ a b f S v ↔
+      (∀ᶠ ε in 𝓝[>] (0 : ℝ), IntervalIntegrable
+          (fun t => if ∃ s ∈ S, ‖γ t - s‖ ≤ ε then 0 else f (γ t) * deriv γ t)
+        MeasureTheory.volume a b) ∧
+        Tendsto (fun ε ↦ ∫ t in a..b, if ∃ s ∈ S, ‖γ t - s‖ ≤ ε then 0 else f (γ t) * deriv γ t)
+          (𝓝[>] 0) (𝓝 v) :=
+  Iff.rfl
+
+/-- Forgetting the witness recovers the existentially-bound form. -/
+theorem HasCauchyPVWith.hasCauchyPV {γ : ℝ → ℂ} {a b : ℝ} {f : ℂ → ℂ} {S : Finset ℂ} {v : ℂ}
+    (h : HasCauchyPVWith γ a b f S v) : HasCauchyPV γ a b f v :=
+  HasCauchyPV.intro S h.1 h.2
+
+/-- `HasCauchyPV` is exactly `HasCauchyPVWith` with the excision set existentially quantified. -/
+theorem hasCauchyPV_iff_exists_hasCauchyPVWith {γ : ℝ → ℂ} {a b : ℝ} {f : ℂ → ℂ} {v : ℂ} :
+    HasCauchyPV γ a b f v ↔ ∃ S : Finset ℂ, HasCauchyPVWith γ a b f S v := by
+  rw [hasCauchyPV_iff]
+  exact Iff.rfl
 
 /-- The Cauchy principal value on a set exists: shorthand for `∃ v, HasCauchyPV γ a b f v`. -/
 def CauchyPVExists (γ : ℝ → ℂ) (a b : ℝ) (f : ℂ → ℂ) : Prop :=


### PR DESCRIPTION
Supplies the missing concatenation API for `HasCauchyPV`, the prerequisite for splitting a closed-contour principal value into its arcs.

## Why a new form is needed

`HasCauchyPV` binds its finite excision set **existentially**. That is the right interface for consumers, but it cannot concatenate: the principal values along two adjacent subcurves may be witnessed by *different* excision sets, and passing to their union changes the excised integrand. Recovering the union form requires the added points to be met on a null set of parameters — a genuine side condition, not a technicality, since a curve that is **constant** at an added point meets it on a set of positive measure.

`HasCauchyPVAt` does not have this problem: its single excised point is automatically shared, which is why `HasCauchyPVAt.concat` already exists.

## Contents

* `HasCauchyPVWith γ a b f S v` — `HasCauchyPV` with the excision set prescribed rather than existentially bound.
* `hasCauchyPV_iff_exists_hasCauchyPVWith` — the two forms agree after quantifying the witness, so nothing is lost.
* `HasCauchyPVWith.concat` — adjacent pieces sharing an excision set add. As with the `At` version, integrability across `[a, c]` and additivity both follow from the two given principal values, so no separate hypothesis is needed.
* `HasCauchyPVWith.sub_right` — the converse split: knowing the whole and one arc gives the rest. This is the direction the improper-integral limit consumes.

## Roadmap

Prerequisite for the ContourIntegration acceptance criterion *"an improper integral … evaluated by HW Thm 3.3"*: with Jordan's lemma (#1244) now on `main`, the remaining step is to split `hasCauchyPV_halfDiscBoundary_of_simple_pole` into diameter and arc, and let the arc vanish as `R → ∞`.

## Gates

`lake build` · `lake exe axioms` · `lake exe module-system` · `scripts/lint-env.sh` — all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)