### PR TITLE
feat: add Haar averaging

### DIFF
--- a/TauCeti/RepresentationTheory/Compact/Averaging.lean
+++ b/TauCeti/RepresentationTheory/Compact/Averaging.lean
@@ -55,8 +55,11 @@ noncomputable def haarAverage [CompleteSpace V] : C(G, V) →L[𝕜] V :=
       simpa using norm_integral_le_of_norm_le_const
         (μ := haarProb G) (Filter.Eventually.of_forall f.norm_coe_le_norm)
 
-/-- The Haar average is the Bochner integral against normalized Haar measure. -/
-@[simp]
+/-- The Haar average is the Bochner integral against normalized Haar measure.
+
+Not a `simp` lemma: `haarAverage` is the normal form here, so that the constant, translation
+and inversion lemmas below can be `simp` lemmas. Unfold explicitly with `rw`/`simp` when the
+underlying integral is wanted. -/
 theorem haarAverage_apply [CompleteSpace V] (f : C(G, V)) :
     haarAverage G (𝕜 := 𝕜) f = ∫ g, f g ∂haarProb G :=
   (rfl)

--- a/TauCeti/RepresentationTheory/Compact/Averaging.lean
+++ b/TauCeti/RepresentationTheory/Compact/Averaging.lean
@@ -90,14 +90,14 @@ theorem norm_haarAverage_eq_one [Nontrivial V] [CompleteSpace V] :
   apply le_antisymm (norm_haarAverage_le_one G) _
   obtain ⟨v, hv⟩ := exists_ne (0 : V)
   have hnorm : ‖ContinuousMap.const G v‖ = ‖v‖ := by
-    apply le_antisymm
-    · exact (ContinuousMap.const G v).norm_le (norm_nonneg v) |>.2 fun _ ↦ le_rfl
-    · simpa using (ContinuousMap.const G v).norm_coe_le_norm (1 : G)
+    rw [← (ContinuousMap.linearIsometryBoundedOfCompact G V 𝕜).norm_map]
+    exact BoundedContinuousFunction.norm_const_eq v
   have h := (haarAverage G (𝕜 := 𝕜) (V := V)).ratio_le_opNorm
     (ContinuousMap.const G v)
   simpa [haarAverage_const, hnorm, norm_ne_zero_iff.mpr hv] using h
 
 /-- Continuous linear maps commute with Haar averaging. -/
+@[simp]
 theorem haarAverage_comp_comm {W : Type*} [NormedAddCommGroup W] [NormedSpace ℝ W]
     [NormedSpace 𝕜 W] [SMulCommClass ℝ 𝕜 W] [CompleteSpace V] [CompleteSpace W]
     (L : V →L[𝕜] W) (f : C(G, V)) :

--- a/TauCeti/RepresentationTheory/Compact/Averaging.lean
+++ b/TauCeti/RepresentationTheory/Compact/Averaging.lean
@@ -31,13 +31,14 @@ namespace TauCeti
 section CompactGroup
 
 variable (G : Type*) [Group G] [TopologicalSpace G] [IsTopologicalGroup G]
-  [CompactSpace G] [T2Space G] [MeasurableSpace G] [BorelSpace G]
+  [CompactSpace G] [MeasurableSpace G] [BorelSpace G]
 variable {V : Type*} [NormedAddCommGroup V]
 
 private theorem integrable_continuousMap (f : C(G, V)) :
     Integrable f (haarProb G) := by
   simpa only [integrableOn_univ] using
-    f.continuous.continuousOn.integrableOn_compact (μ := haarProb G) isCompact_univ
+    f.continuous.continuousOn.integrableOn_compact' (μ := haarProb G) isCompact_univ
+      MeasurableSet.univ
 
 variable {𝕜 : Type*} [RCLike 𝕜] [NormedSpace ℝ V] [NormedSpace 𝕜 V]
   [SMulCommClass ℝ 𝕜 V]
@@ -84,7 +85,7 @@ theorem haarAverage_const [CompleteSpace V] (v : V) :
   simp [haarAverage_apply]
 
 /-- On a nonzero target, Haar averaging has operator norm one. -/
-theorem norm_haarAverage [Nontrivial V] [CompleteSpace V] :
+theorem norm_haarAverage_eq_one [Nontrivial V] [CompleteSpace V] :
     ‖haarAverage G (𝕜 := 𝕜) (V := V)‖ = 1 := by
   apply le_antisymm (norm_haarAverage_le_one G) _
   obtain ⟨v, hv⟩ := exists_ne (0 : V)
@@ -100,10 +101,9 @@ theorem norm_haarAverage [Nontrivial V] [CompleteSpace V] :
 theorem haarAverage_comp_comm {W : Type*} [NormedAddCommGroup W] [NormedSpace ℝ W]
     [NormedSpace 𝕜 W] [SMulCommClass ℝ 𝕜 W] [CompleteSpace V] [CompleteSpace W]
     (L : V →L[𝕜] W) (f : C(G, V)) :
-    haarAverage G (𝕜 := 𝕜)
-        ⟨fun g ↦ L (f g), L.continuous.comp f.continuous⟩ =
-      L (haarAverage G (𝕜 := 𝕜) f) := by
-  rw [haarAverage_apply, haarAverage_apply]
+    haarAverage G (𝕜 := 𝕜) ((L : C(V, W)).comp f) = L (haarAverage G (𝕜 := 𝕜) f) := by
+  simp only [haarAverage_apply, ContinuousMap.coe_comp, Function.comp_apply,
+    ContinuousMap.coe_coe]
   exact L.integral_comp_comm (integrable_continuousMap G f)
 
 /-- Haar averaging is unchanged by left translation of the argument. -/
@@ -127,10 +127,10 @@ theorem haarAverage_comp_mulRight [CompleteSpace V] (f : C(G, V)) (g : G) :
 /-- Haar averaging is unchanged by inversion of the argument. -/
 @[simp]
 theorem haarAverage_comp_inv [CompleteSpace V] (f : C(G, V)) :
-    haarAverage G (𝕜 := 𝕜)
-        ⟨fun g ↦ f g⁻¹, f.continuous.comp continuous_inv⟩ =
+    haarAverage G (𝕜 := 𝕜) (f.comp (Homeomorph.inv G : C(G, G))) =
       haarAverage G (𝕜 := 𝕜) f := by
-  rw [haarAverage_apply, haarAverage_apply]
+  simp only [haarAverage_apply, ContinuousMap.coe_comp, Function.comp_apply,
+    ContinuousMap.coe_coe, Homeomorph.coe_inv]
   exact integral_inv_eq_self f (haarProb G)
 
 end CompactGroup

--- a/TauCeti/RepresentationTheory/Compact/Averaging.lean
+++ b/TauCeti/RepresentationTheory/Compact/Averaging.lean
@@ -40,7 +40,9 @@ private theorem integrable_continuousMap (f : C(G, V)) :
     f.continuous.continuousOn.integrableOn_compact' (μ := haarProb G) isCompact_univ
       MeasurableSet.univ
 
-variable {𝕜 : Type*} [RCLike 𝕜] [NormedSpace ℝ V] [NormedSpace 𝕜 V]
+section NormedFieldScalars
+
+variable {𝕜 : Type*} [NontriviallyNormedField 𝕜] [NormedSpace ℝ V] [NormedSpace 𝕜 V]
   [SMulCommClass ℝ 𝕜 V]
 
 /-- Averaging a continuous vector-valued function against normalized Haar measure, as a
@@ -65,18 +67,15 @@ theorem haarAverage_apply [CompleteSpace V] (f : C(G, V)) :
     haarAverage G (𝕜 := 𝕜) f = ∫ g, f g ∂haarProb G :=
   (rfl)
 
-/-- Haar averaging is norm-nonincreasing for the uniform norm on continuous maps. -/
-theorem norm_haarAverage_apply_le [CompleteSpace V] (f : C(G, V)) :
-    ‖haarAverage G (𝕜 := 𝕜) f‖ ≤ ‖f‖ := by
-  rw [haarAverage_apply]
-  simpa using norm_integral_le_of_norm_le_const
-    (μ := haarProb G) (Filter.Eventually.of_forall f.norm_coe_le_norm)
-
 /-- The operator norm of Haar averaging is at most one. -/
 theorem norm_haarAverage_le_one [CompleteSpace V] :
     ‖haarAverage G (𝕜 := 𝕜) (V := V)‖ ≤ 1 :=
-  ContinuousLinearMap.opNorm_le_bound _ zero_le_one fun f ↦ by
-    simpa using norm_haarAverage_apply_le G (𝕜 := 𝕜) f
+  LinearMap.mkContinuous_norm_le _ zero_le_one _
+
+/-- Haar averaging is norm-nonincreasing for the uniform norm on continuous maps. -/
+theorem norm_haarAverage_apply_le [CompleteSpace V] (f : C(G, V)) :
+    ‖haarAverage G (𝕜 := 𝕜) f‖ ≤ ‖f‖ := by
+  simpa using (haarAverage G (𝕜 := 𝕜) (V := V)).le_of_opNorm_le (norm_haarAverage_le_one G) f
 
 /-- The Haar average of a constant function is that constant. -/
 @[simp]
@@ -95,16 +94,6 @@ theorem norm_haarAverage_eq_one [Nontrivial V] [CompleteSpace V] :
   have h := (haarAverage G (𝕜 := 𝕜) (V := V)).ratio_le_opNorm
     (ContinuousMap.const G v)
   simpa [haarAverage_const, hnorm, norm_ne_zero_iff.mpr hv] using h
-
-/-- Continuous linear maps commute with Haar averaging. -/
-@[simp]
-theorem haarAverage_comp_comm {W : Type*} [NormedAddCommGroup W] [NormedSpace ℝ W]
-    [NormedSpace 𝕜 W] [SMulCommClass ℝ 𝕜 W] [CompleteSpace V] [CompleteSpace W]
-    (L : V →L[𝕜] W) (f : C(G, V)) :
-    haarAverage G (𝕜 := 𝕜) ((L : C(V, W)).comp f) = L (haarAverage G (𝕜 := 𝕜) f) := by
-  simp only [haarAverage_apply, ContinuousMap.coe_comp, Function.comp_apply,
-    ContinuousMap.coe_coe]
-  exact L.integral_comp_comm (integrable_continuousMap G f)
 
 /-- Haar averaging is unchanged by left translation of the argument. -/
 @[simp]
@@ -132,6 +121,27 @@ theorem haarAverage_comp_inv [CompleteSpace V] (f : C(G, V)) :
   simp only [haarAverage_apply, ContinuousMap.coe_comp, Function.comp_apply,
     ContinuousMap.coe_coe, Homeomorph.coe_inv]
   exact integral_inv_eq_self f (haarProb G)
+
+end NormedFieldScalars
+
+section RCLikeScalars
+
+variable {𝕜 : Type*} [RCLike 𝕜] [NormedSpace ℝ V] [NormedSpace 𝕜 V] [SMulCommClass ℝ 𝕜 V]
+
+/-- Continuous linear maps commute with Haar averaging.
+
+The scalars are assumed to be `RCLike` because Mathlib states
+`ContinuousLinearMap.integral_comp_comm` under that hypothesis. -/
+@[simp]
+theorem _root_.ContinuousLinearMap.haarAverage_comp_comm {W : Type*} [NormedAddCommGroup W]
+    [NormedSpace ℝ W] [NormedSpace 𝕜 W] [SMulCommClass ℝ 𝕜 W] [CompleteSpace V] [CompleteSpace W]
+    (L : V →L[𝕜] W) (f : C(G, V)) :
+    haarAverage G (𝕜 := 𝕜) ((L : C(V, W)).comp f) = L (haarAverage G (𝕜 := 𝕜) f) := by
+  simp only [haarAverage_apply, ContinuousMap.coe_comp, Function.comp_apply,
+    ContinuousMap.coe_coe]
+  exact L.integral_comp_comm (integrable_continuousMap G f)
+
+end RCLikeScalars
 
 end CompactGroup
 

--- a/TauCeti/RepresentationTheory/Compact/Averaging.lean
+++ b/TauCeti/RepresentationTheory/Compact/Averaging.lean
@@ -1,0 +1,135 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+module
+
+public import TauCeti.RepresentationTheory.Compact.Haar
+public import Mathlib.Topology.ContinuousMap.Compact
+import Mathlib.MeasureTheory.Integral.Bochner.ContinuousLinearMap
+
+/-!
+# Averaging over compact groups
+
+This file bundles integration against normalized Haar measure as a continuous linear map on
+continuous vector-valued functions. It records the norm bound, constants, and invariance under left
+and right translation needed for averaging representations.
+
+The implementation reuses Mathlib's Bochner integral, its commutation with continuous linear maps,
+and the generic left-, right-, and inversion-invariance lemmas for integrals on groups.
+
+The construction is the averaging operator from Layer 0 of the
+[compact-groups roadmap](https://github.com/TauCetiProject/TauCetiRoadmap/blob/roadmap/representation-theory/TauCetiRoadmap/RepresentationTheory/CompactGroups/README.md).
+-/
+
+public section
+
+open MeasureTheory
+
+namespace TauCeti
+
+section CompactGroup
+
+variable (G : Type*) [Group G] [TopologicalSpace G] [IsTopologicalGroup G]
+  [CompactSpace G] [T2Space G] [MeasurableSpace G] [BorelSpace G]
+variable {V : Type*} [NormedAddCommGroup V]
+
+private theorem integrable_continuousMap (f : C(G, V)) :
+    Integrable f (haarProb G) := by
+  simpa only [integrableOn_univ] using
+    f.continuous.continuousOn.integrableOn_compact (μ := haarProb G) isCompact_univ
+
+variable {𝕜 : Type*} [RCLike 𝕜] [NormedSpace ℝ V] [NormedSpace 𝕜 V]
+  [SMulCommClass ℝ 𝕜 V]
+
+/-- Averaging a continuous vector-valued function against normalized Haar measure, as a
+continuous linear map. -/
+noncomputable def haarAverage [CompleteSpace V] : C(G, V) →L[𝕜] V :=
+  LinearMap.mkContinuous
+    { toFun := fun f ↦ ∫ g, f g ∂haarProb G
+      map_add' := fun f h ↦ integral_add
+        (integrable_continuousMap G f) (integrable_continuousMap G h)
+      map_smul' := fun c f ↦ integral_smul c f }
+    1 fun f ↦ by
+      rw [one_mul]
+      simpa using norm_integral_le_of_norm_le_const
+        (μ := haarProb G) (Filter.Eventually.of_forall f.norm_coe_le_norm)
+
+/-- The Haar average is the Bochner integral against normalized Haar measure. -/
+@[simp]
+theorem haarAverage_apply [CompleteSpace V] (f : C(G, V)) :
+    haarAverage G (𝕜 := 𝕜) f = ∫ g, f g ∂haarProb G :=
+  (rfl)
+
+/-- Haar averaging is norm-nonincreasing for the uniform norm on continuous maps. -/
+theorem norm_haarAverage_apply_le [CompleteSpace V] (f : C(G, V)) :
+    ‖haarAverage G (𝕜 := 𝕜) f‖ ≤ ‖f‖ := by
+  rw [haarAverage_apply]
+  simpa using norm_integral_le_of_norm_le_const
+    (μ := haarProb G) (Filter.Eventually.of_forall f.norm_coe_le_norm)
+
+/-- The operator norm of Haar averaging is at most one. -/
+theorem norm_haarAverage_le_one [CompleteSpace V] :
+    ‖haarAverage G (𝕜 := 𝕜) (V := V)‖ ≤ 1 :=
+  ContinuousLinearMap.opNorm_le_bound _ zero_le_one fun f ↦ by
+    simpa using norm_haarAverage_apply_le G (𝕜 := 𝕜) f
+
+/-- The Haar average of a constant function is that constant. -/
+@[simp]
+theorem haarAverage_const [CompleteSpace V] (v : V) :
+    haarAverage G (𝕜 := 𝕜) (ContinuousMap.const G v) = v := by
+  simp [haarAverage_apply]
+
+/-- On a nonzero target, Haar averaging has operator norm one. -/
+theorem norm_haarAverage [Nontrivial V] [CompleteSpace V] :
+    ‖haarAverage G (𝕜 := 𝕜) (V := V)‖ = 1 := by
+  apply le_antisymm (norm_haarAverage_le_one G) _
+  obtain ⟨v, hv⟩ := exists_ne (0 : V)
+  have hnorm : ‖ContinuousMap.const G v‖ = ‖v‖ := by
+    apply le_antisymm
+    · exact (ContinuousMap.const G v).norm_le (norm_nonneg v) |>.2 fun _ ↦ le_rfl
+    · simpa using (ContinuousMap.const G v).norm_coe_le_norm (1 : G)
+  have h := (haarAverage G (𝕜 := 𝕜) (V := V)).ratio_le_opNorm
+    (ContinuousMap.const G v)
+  simpa [haarAverage_const, hnorm, norm_ne_zero_iff.mpr hv] using h
+
+/-- Continuous linear maps commute with Haar averaging. -/
+theorem haarAverage_comp_comm {W : Type*} [NormedAddCommGroup W] [NormedSpace ℝ W]
+    [NormedSpace 𝕜 W] [SMulCommClass ℝ 𝕜 W] [CompleteSpace V] [CompleteSpace W]
+    (L : V →L[𝕜] W) (f : C(G, V)) :
+    haarAverage G (𝕜 := 𝕜)
+        ⟨fun g ↦ L (f g), L.continuous.comp f.continuous⟩ =
+      L (haarAverage G (𝕜 := 𝕜) f) := by
+  rw [haarAverage_apply, haarAverage_apply]
+  exact L.integral_comp_comm (integrable_continuousMap G f)
+
+/-- Haar averaging is unchanged by left translation of the argument. -/
+@[simp]
+theorem haarAverage_comp_mulLeft [CompleteSpace V] (f : C(G, V)) (g : G) :
+    haarAverage G (𝕜 := 𝕜) (f.comp (ContinuousMap.mulLeft g)) =
+      haarAverage G (𝕜 := 𝕜) f := by
+  simp only [haarAverage_apply, ContinuousMap.coe_comp, Function.comp_apply,
+    ContinuousMap.coe_mulLeft]
+  exact integral_mul_left_eq_self f g
+
+/-- Haar averaging is unchanged by right translation of the argument. -/
+@[simp]
+theorem haarAverage_comp_mulRight [CompleteSpace V] (f : C(G, V)) (g : G) :
+    haarAverage G (𝕜 := 𝕜) (f.comp (ContinuousMap.mulRight g)) =
+      haarAverage G (𝕜 := 𝕜) f := by
+  simp only [haarAverage_apply, ContinuousMap.coe_comp, Function.comp_apply,
+    ContinuousMap.coe_mulRight]
+  exact integral_mul_right_eq_self f g
+
+/-- Haar averaging is unchanged by inversion of the argument. -/
+@[simp]
+theorem haarAverage_comp_inv [CompleteSpace V] (f : C(G, V)) :
+    haarAverage G (𝕜 := 𝕜)
+        ⟨fun g ↦ f g⁻¹, f.continuous.comp continuous_inv⟩ =
+      haarAverage G (𝕜 := 𝕜) f := by
+  rw [haarAverage_apply, haarAverage_apply]
+  exact integral_inv_eq_self f (haarProb G)
+
+end CompactGroup
+
+end TauCeti


### PR DESCRIPTION
This PR bundles integration against normalized Haar probability measure as a continuous linear map on continuous vector-valued functions. Characterize its Bochner-integral value, prove its contraction bound and exact operator norm on nonzero targets, show it fixes constants and commutes with continuous linear maps, and record invariance under left translation, right translation, and inversion.

This advances `TauCetiRoadmap/RepresentationTheory/CompactGroups/README.md`, Layer 0, item “The averaging operator,” specifically the average `∫ g, F g ∂(haarProb G)` with linearity, constants, and translation invariance. It is the lowest-hanging distinct continuation because normalized Haar measure and all three invariance instances have merged, no open PR covers averaging, and the roadmap makes this operator the immediate input to the unitarian trick and every later orthogonality argument.

Reuse Mathlib’s Bochner integral, `ContinuousLinearMap.integral_comp_comm`, `integral_mul_left_eq_self`, `integral_mul_right_eq_self`, `integral_inv_eq_self`, and continuous-map uniform norm API; vendor no Mathlib infrastructure and adapt no supplementary-source or external formalization material.

Add `TauCeti/RepresentationTheory/Compact/Averaging.lean` (135 lines). `lake exe cache get` reports `No files to download` and `Already decompressed 8640 file(s)`. `lake build` reports `Build completed successfully (5541 jobs).` `lake exe axioms` reports `axioms: audited 12473 TauCeti declaration(s); all within the allowlist [propext, Classical.choice, Quot.sound].`

<!--tauceti-target:v1 {"focus":"RepresentationTheory","id":"haar-averaging-operator"}-->

🤖 Prepared with Codex
