### PR TITLE
feat(MeasureTheory): finite evaluation laws determine a measure on ProbabilityMeasure

### DIFF
--- a/TauCeti/MeasureTheory/Measure/ProbabilityMeasureExt.lean
+++ b/TauCeti/MeasureTheory/Measure/ProbabilityMeasureExt.lean
@@ -79,7 +79,8 @@ private theorem measurableSpace_measure_eq_comap_eval :
   rw [Measure.instMeasurableSpace, iSup_subtype]
   simp only [← BorelSpace.measurable_eq (α := ENNReal)]
 
-/-- Each `ℝ≥0∞`-valued evaluation is a measurable function of the real-valued ones. -/
+/-- Expresses the `ℝ≥0∞`-valued evaluation `P ↦ (P : Measure α) s` as `ENNReal.ofReal` of its
+real-valued counterpart `evalReal`. -/
 private theorem coe_apply_eq_ofReal_evalReal (s : MeasIdx α) :
     (fun P : ProbabilityMeasure α => (P : Measure α) s.1)
       = fun P => ENNReal.ofReal (evalReal P s) := by
@@ -131,7 +132,7 @@ theorem Measure.ext_of_forall_map_probabilityMeasure_eval_eq
       generateFrom_measurableCylinders.symm isPiSystem_measurableCylinders ?_ ?_
     · rintro t ht
       obtain ⟨I, S, hS, rfl⟩ := (mem_measurableCylinders t).mp ht
-      set e := I.equivFin with he
+      set e := I.equivFin
       set B : Fin I.card → Set α := fun j => ((e.symm j : MeasIdx α) : Set α) with hB
       have hBm : ∀ j, MeasurableSet (B j) := fun j => (e.symm j : MeasIdx α).2
       set Φ : (Fin I.card → ℝ) → (I → ℝ) := fun x i => x (e i) with hΦ
@@ -158,7 +159,7 @@ theorem Measure.ext_of_forall_map_probabilityMeasure_eval_eq
   obtain ⟨U, hU, rfl⟩ : ∃ U, MeasurableSet U ∧ (evalReal (α := α)) ⁻¹' U = T := by
     have hT' : MeasurableSet[MeasurableSpace.comap (evalReal (α := α)) MeasurableSpace.pi] T := by
       rwa [← measurableSpace_probabilityMeasure_eq_comap]
-    exact hT'
+    exact MeasurableSpace.measurableSet_comap.1 hT'
   rw [← Measure.map_apply measurable_evalReal hU, ← Measure.map_apply measurable_evalReal hU, key]
 
 

--- a/TauCeti/MeasureTheory/Measure/ProbabilityMeasureExt.lean
+++ b/TauCeti/MeasureTheory/Measure/ProbabilityMeasureExt.lean
@@ -1,0 +1,48 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Claude
+-/
+module
+
+public import Mathlib.MeasureTheory.Measure.ProbabilityMeasure
+public import Mathlib.MeasureTheory.Measure.GiryMonad
+import Mathlib.MeasureTheory.Constructions.Cylinders
+
+/-!
+# Finite evaluation laws determine a measure on `ProbabilityMeasure α`
+
+Work in progress.
+-/
+
+public section
+
+noncomputable section
+
+open MeasureTheory Set MeasurableSpace
+
+namespace TauCeti
+
+namespace MeasureTheory
+
+variable {α : Type*} [MeasurableSpace α]
+
+/-- The Giry σ-algebra on `Measure α` is the σ-algebra pulled back from the product σ-algebra
+along the all-evaluations map `μ ↦ (s ↦ μ s)`, indexed by the measurable sets.
+
+This is a repackaging of the definition: the instance is already an `iSup` of comaps of the
+individual evaluations, and `comap_iSup` turns the comap of the product σ-algebra into that same
+`iSup`. -/
+theorem measurableSpace_measure_eq_comap_eval :
+    (Measure.instMeasurableSpace : MeasurableSpace (Measure α))
+      = MeasurableSpace.comap
+          (fun μ : Measure α => fun s : {s : Set α // MeasurableSet s} => μ s.1)
+          MeasurableSpace.pi := by
+  rw [MeasurableSpace.pi, MeasurableSpace.comap_iSup]
+  simp only [MeasurableSpace.comap_comp, Function.comp_def]
+  rw [Measure.instMeasurableSpace, iSup_subtype]
+  simp only [← BorelSpace.measurable_eq (α := ENNReal)]
+
+end MeasureTheory
+
+end TauCeti

--- a/TauCeti/MeasureTheory/Measure/ProbabilityMeasureExt.lean
+++ b/TauCeti/MeasureTheory/Measure/ProbabilityMeasureExt.lean
@@ -94,7 +94,14 @@ private theorem measurableSpace_probabilityMeasure_eq_comap :
     (inferInstance : MeasurableSpace (ProbabilityMeasure α))
       = MeasurableSpace.comap (evalReal (α := α)) MeasurableSpace.pi := by
   refine le_antisymm ?_ measurable_evalReal.comap_le
-  change MeasurableSpace.comap Subtype.val Measure.instMeasurableSpace ≤ _
+  -- `ProbabilityMeasure α` is a subtype of `Measure α`, and its instance is
+  -- `inferInstanceAs (MeasurableSpace (Subtype _))`, i.e. `Subtype.instMeasurableSpace`, which is
+  -- itself `Measure.instMeasurableSpace.comap Subtype.val`. Neither is accompanied by an equation
+  -- lemma in Mathlib, so the unfolding is available only definitionally; naming it as an explicit
+  -- `rfl` confines that to one step and keeps the rest of the proof propositional.
+  have hinst : (inferInstance : MeasurableSpace (ProbabilityMeasure α))
+      = MeasurableSpace.comap Subtype.val Measure.instMeasurableSpace := rfl
+  rw [hinst]
   rw [measurableSpace_measure_eq_comap_eval, MeasurableSpace.comap_comp, MeasurableSpace.pi,
     MeasurableSpace.comap_iSup]
   refine iSup_le fun s => ?_

--- a/TauCeti/MeasureTheory/Measure/ProbabilityMeasureExt.lean
+++ b/TauCeti/MeasureTheory/Measure/ProbabilityMeasureExt.lean
@@ -6,13 +6,33 @@ Authors: Claude
 module
 
 public import Mathlib.MeasureTheory.Measure.ProbabilityMeasure
-public import Mathlib.MeasureTheory.Measure.GiryMonad
 import Mathlib.MeasureTheory.Constructions.Cylinders
 
 /-!
 # Finite evaluation laws determine a measure on `ProbabilityMeasure α`
 
-Work in progress.
+A finite measure on `ProbabilityMeasure α` is determined by the laws of its finite evaluation
+families `P ↦ (P (B 0), …, P (B (n-1)))`.
+
+## Main results
+
+* `Measure.ext_of_forall_map_probabilityMeasure_eval_eq` — two measures on `ProbabilityMeasure α`
+  agree as soon as every finite family of measurable sets induces the same pushforward law.
+
+## Implementation
+
+The Giry σ-algebra on `Measure α` is *defined* as an `iSup` of comaps of the individual
+evaluations `μ ↦ μ s`, so it is already the pullback of a product σ-algebra along the
+all-evaluations map; `comap_iSup` is all that is needed to see this. Transporting along
+`Subtype.val` and replacing the `ℝ≥0∞`-valued evaluations by their real-valued counterparts —
+each is measurable in terms of the other, so the two pullbacks coincide — puts the σ-algebra on
+`ProbabilityMeasure α` in the same form.
+
+Once the σ-algebra is a pullback, equality of the two measures reduces to equality of their
+pushforwards under the all-evaluations map, and that is a statement about a product σ-algebra:
+`measurableCylinders` is a π-system generating it, and a measurable cylinder is exactly the event
+that a *finite* evaluation family lands in a measurable set. So the hypothesis applies directly,
+and no π-system has to be built by hand.
 -/
 
 public section
@@ -27,21 +47,113 @@ namespace MeasureTheory
 
 variable {α : Type*} [MeasurableSpace α]
 
-/-- The Giry σ-algebra on `Measure α` is the σ-algebra pulled back from the product σ-algebra
-along the all-evaluations map `μ ↦ (s ↦ μ s)`, indexed by the measurable sets.
+/-- The index type for the all-evaluations map: the measurable subsets of `α`. -/
+private abbrev MeasIdx (α : Type*) [MeasurableSpace α] := {s : Set α // MeasurableSet s}
 
-This is a repackaging of the definition: the instance is already an `iSup` of comaps of the
-individual evaluations, and `comap_iSup` turns the comap of the product σ-algebra into that same
-`iSup`. -/
-theorem measurableSpace_measure_eq_comap_eval :
+/-- The all-evaluations map, sending a probability measure to its vector of real-valued
+measures of the measurable sets. -/
+private def evalReal (P : ProbabilityMeasure α) : MeasIdx α → ℝ := fun s => (P s.1 : ℝ)
+
+private theorem measurable_evalReal_apply (s : MeasIdx α) :
+    Measurable fun P : ProbabilityMeasure α => evalReal P s :=
+  ENNReal.measurable_toReal.comp
+    ((Measure.measurable_coe s.2).comp measurable_subtype_coe)
+
+private theorem measurable_evalReal : Measurable (evalReal (α := α)) :=
+  measurable_pi_lambda _ measurable_evalReal_apply
+
+private theorem measurable_eval_family {n : ℕ} (B : Fin n → Set α)
+    (hB : ∀ i, MeasurableSet (B i)) :
+    Measurable fun P : ProbabilityMeasure α => fun i => (P (B i) : ℝ) :=
+  measurable_pi_lambda _ fun i => measurable_evalReal_apply ⟨B i, hB i⟩
+
+/-- The Giry σ-algebra on `Measure α` is the pullback of the product σ-algebra along the
+all-evaluations map. This is a repackaging of the definition: the instance is already an `iSup`
+of comaps of the individual evaluations. -/
+private theorem measurableSpace_measure_eq_comap_eval :
     (Measure.instMeasurableSpace : MeasurableSpace (Measure α))
-      = MeasurableSpace.comap
-          (fun μ : Measure α => fun s : {s : Set α // MeasurableSet s} => μ s.1)
+      = MeasurableSpace.comap (fun μ : Measure α => fun s : MeasIdx α => μ s.1)
           MeasurableSpace.pi := by
   rw [MeasurableSpace.pi, MeasurableSpace.comap_iSup]
   simp only [MeasurableSpace.comap_comp, Function.comp_def]
   rw [Measure.instMeasurableSpace, iSup_subtype]
   simp only [← BorelSpace.measurable_eq (α := ENNReal)]
+
+/-- Each `ℝ≥0∞`-valued evaluation is a measurable function of the real-valued ones. -/
+private theorem coe_apply_eq_ofReal_evalReal (s : MeasIdx α) :
+    (fun P : ProbabilityMeasure α => (P : Measure α) s.1)
+      = fun P => ENNReal.ofReal (evalReal P s) := by
+  funext P
+  rw [evalReal, ← ProbabilityMeasure.ennreal_coeFn_eq_coeFn_toMeasure]
+  simp
+
+/-- The σ-algebra on `ProbabilityMeasure α` is the pullback of the product σ-algebra along
+`evalReal`. The real-valued evaluations generate the same σ-algebra as the `ℝ≥0∞`-valued ones
+defining the Giry structure, since each is measurable in terms of the other. -/
+private theorem measurableSpace_probabilityMeasure_eq_comap :
+    (inferInstance : MeasurableSpace (ProbabilityMeasure α))
+      = MeasurableSpace.comap (evalReal (α := α)) MeasurableSpace.pi := by
+  refine le_antisymm ?_ measurable_evalReal.comap_le
+  change MeasurableSpace.comap Subtype.val Measure.instMeasurableSpace ≤ _
+  rw [measurableSpace_measure_eq_comap_eval, MeasurableSpace.comap_comp, MeasurableSpace.pi,
+    MeasurableSpace.comap_iSup]
+  refine iSup_le fun s => ?_
+  rw [MeasurableSpace.comap_comp]
+  refine (measurable_iff_comap_le (f := fun P : ProbabilityMeasure α => (P : Measure α) s.1)).1 ?_
+  rw [coe_apply_eq_ofReal_evalReal]
+  have hev : Measurable[MeasurableSpace.comap (evalReal (α := α)) MeasurableSpace.pi]
+      (evalReal (α := α)) := Measurable.of_comap_le le_rfl
+  exact ENNReal.measurable_ofReal.comp ((measurable_pi_apply s).comp hev)
+
+/-- **Finite evaluation laws determine the measure.** Two measures on `ProbabilityMeasure α` are
+equal as soon as, for every finite family `B` of measurable subsets of `α`, the pushforwards under
+the evaluation map `P ↦ (P (B 0), …, P (B (n-1)))` agree.
+
+Only `π₁` need be assumed finite: the `n = 0` instance of the hypothesis equates the total
+masses. -/
+theorem Measure.ext_of_forall_map_probabilityMeasure_eval_eq
+    {π₁ π₂ : Measure (ProbabilityMeasure α)} [IsFiniteMeasure π₁]
+    (h : ∀ (n : ℕ) (B : Fin n → Set α), (∀ i, MeasurableSet (B i)) →
+      π₁.map (fun P => fun i => (P (B i) : ℝ))
+        = π₂.map (fun P => fun i => (P (B i) : ℝ))) :
+    π₁ = π₂ := by
+  have hmapfin : IsFiniteMeasure (π₁.map (evalReal (α := α))) :=
+    Measure.isFiniteMeasure_map _ _
+  have key : π₁.map (evalReal (α := α)) = π₂.map (evalReal (α := α)) := by
+    refine ext_of_generate_finite (measurableCylinders fun _ : MeasIdx α => ℝ)
+      generateFrom_measurableCylinders.symm isPiSystem_measurableCylinders ?_ ?_
+    · rintro t ht
+      obtain ⟨I, S, hS, rfl⟩ := (mem_measurableCylinders t).mp ht
+      set e := I.equivFin with he
+      set B : Fin I.card → Set α := fun j => ((e.symm j : MeasIdx α) : Set α) with hB
+      have hBm : ∀ j, MeasurableSet (B j) := fun j => (e.symm j : MeasIdx α).2
+      set Φ : (Fin I.card → ℝ) → (I → ℝ) := fun x i => x (e i) with hΦ
+      have hΦm : Measurable Φ := measurable_pi_lambda _ fun i => measurable_pi_apply _
+      have hfam := measurable_eval_family B hBm
+      have hpre : (evalReal (α := α)) ⁻¹' cylinder I S
+          = (fun P : ProbabilityMeasure α => fun j => (P (B j) : ℝ)) ⁻¹' (Φ ⁻¹' S) := by
+        ext P
+        simp only [Set.mem_preimage, mem_cylinder, hΦ, hB]
+        congr! 2 with i
+        simp [evalReal, Finset.restrict]
+      rw [Measure.map_apply measurable_evalReal hS.cylinder,
+        Measure.map_apply measurable_evalReal hS.cylinder, hpre,
+        ← Measure.map_apply hfam (hΦm hS), ← Measure.map_apply hfam (hΦm hS), h _ B hBm]
+    · have hfam0 := measurable_eval_family (α := α) (fun i : Fin 0 => i.elim0)
+        (fun i => i.elim0)
+      have h0 := congrArg (fun ρ : Measure (Fin 0 → ℝ) => ρ Set.univ)
+        (h 0 (fun i => i.elim0) (fun i => i.elim0))
+      simp only [Measure.map_apply hfam0 MeasurableSet.univ, Set.preimage_univ] at h0
+      rw [Measure.map_apply measurable_evalReal MeasurableSet.univ,
+        Measure.map_apply measurable_evalReal MeasurableSet.univ, Set.preimage_univ]
+      exact h0
+  refine Measure.ext fun T hT => ?_
+  obtain ⟨U, hU, rfl⟩ : ∃ U, MeasurableSet U ∧ (evalReal (α := α)) ⁻¹' U = T := by
+    have hT' : MeasurableSet[MeasurableSpace.comap (evalReal (α := α)) MeasurableSpace.pi] T := by
+      rwa [← measurableSpace_probabilityMeasure_eq_comap]
+    exact hT'
+  rw [← Measure.map_apply measurable_evalReal hU, ← Measure.map_apply measurable_evalReal hU, key]
+
 
 end MeasureTheory
 

--- a/TauCeti/MeasureTheory/Measure/ProbabilityMeasureExt.lean
+++ b/TauCeti/MeasureTheory/Measure/ProbabilityMeasureExt.lean
@@ -6,7 +6,7 @@ Authors: Claude
 module
 
 public import Mathlib.MeasureTheory.Measure.ProbabilityMeasure
-import Mathlib.MeasureTheory.Constructions.Cylinders
+import Mathlib.MeasureTheory.Constructions.Projective
 
 /-!
 # Finite evaluation laws determine a measure on `ProbabilityMeasure α`
@@ -29,10 +29,11 @@ each is measurable in terms of the other, so the two pullbacks coincide — puts
 `ProbabilityMeasure α` in the same form.
 
 Once the σ-algebra is a pullback, equality of the two measures reduces to equality of their
-pushforwards under the all-evaluations map, and that is a statement about a product σ-algebra:
-`measurableCylinders` is a π-system generating it, and a measurable cylinder is exactly the event
-that a *finite* evaluation family lands in a measurable set. So the hypothesis applies directly,
-and no π-system has to be built by hand.
+pushforwards under the all-evaluations map. Those pushforwards live on a product space, and the
+hypothesis says exactly that their restrictions to every finite set of coordinates agree — so both
+are projective limits of the same family and `MeasureTheory.IsProjectiveLimit.unique` concludes.
+No π-system is built here: that lemma already performs the `measurableCylinders` argument. The only
+work is reindexing a `Finset` of coordinates by `Fin` via `Finset.equivFin`.
 -/
 
 public section
@@ -125,36 +126,35 @@ theorem Measure.ext_of_forall_map_probabilityMeasure_eval_eq
       π₁.map (fun P => fun i => (P (B i) : ℝ))
         = π₂.map (fun P => fun i => (P (B i) : ℝ))) :
     π₁ = π₂ := by
-  have hmapfin : IsFiniteMeasure (π₁.map (evalReal (α := α))) :=
-    Measure.isFiniteMeasure_map _ _
   have key : π₁.map (evalReal (α := α)) = π₂.map (evalReal (α := α)) := by
-    refine ext_of_generate_finite (measurableCylinders fun _ : MeasIdx α => ℝ)
-      generateFrom_measurableCylinders.symm isPiSystem_measurableCylinders ?_ ?_
-    · rintro t ht
-      obtain ⟨I, S, hS, rfl⟩ := (mem_measurableCylinders t).mp ht
+    haveI : ∀ I : Finset (MeasIdx α),
+        IsFiniteMeasure ((π₁.map (evalReal (α := α))).map I.restrict) :=
+      fun I => Measure.isFiniteMeasure_map _ _
+    -- Each finite restriction of the two pushforwards agrees, so both are projective limits of
+    -- the same family and `IsProjectiveLimit.unique` finishes.
+    have hstep : ∀ I : Finset (MeasIdx α),
+        (π₂.map (evalReal (α := α))).map I.restrict
+          = (π₁.map (evalReal (α := α))).map I.restrict := by
+      intro I
       set e := I.equivFin
       set B : Fin I.card → Set α := fun j => ((e.symm j : MeasIdx α) : Set α) with hB
       have hBm : ∀ j, MeasurableSet (B j) := fun j => (e.symm j : MeasIdx α).2
       set Φ : (Fin I.card → ℝ) → (I → ℝ) := fun x i => x (e i) with hΦ
       have hΦm : Measurable Φ := measurable_pi_lambda _ fun i => measurable_pi_apply _
       have hfam := measurable_eval_family B hBm
-      have hpre : (evalReal (α := α)) ⁻¹' cylinder I S
-          = (fun P : ProbabilityMeasure α => fun j => (P (B j) : ℝ)) ⁻¹' (Φ ⁻¹' S) := by
-        ext P
-        simp only [Set.mem_preimage, mem_cylinder, hΦ, hB]
-        congr! 2 with i
-        simp [evalReal, Finset.restrict]
-      rw [Measure.map_apply measurable_evalReal hS.cylinder,
-        Measure.map_apply measurable_evalReal hS.cylinder, hpre,
-        ← Measure.map_apply hfam (hΦm hS), ← Measure.map_apply hfam (hΦm hS), h _ B hBm]
-    · have hfam0 := measurable_eval_family (α := α) (fun i : Fin 0 => i.elim0)
-        (fun i => i.elim0)
-      have h0 := congrArg (fun ρ : Measure (Fin 0 → ℝ) => ρ Set.univ)
-        (h 0 (fun i => i.elim0) (fun i => i.elim0))
-      simp only [Measure.map_apply hfam0 MeasurableSet.univ, Set.preimage_univ] at h0
-      rw [Measure.map_apply measurable_evalReal MeasurableSet.univ,
-        Measure.map_apply measurable_evalReal MeasurableSet.univ, Set.preimage_univ]
-      exact h0
+      have hfun : I.restrict ∘ (evalReal (α := α))
+          = Φ ∘ fun P : ProbabilityMeasure α => fun j => (P (B j) : ℝ) := by
+        funext P i
+        simp [Finset.restrict, evalReal, hΦ, hB]
+      have hcomp : ∀ π : Measure (ProbabilityMeasure α),
+          (π.map (evalReal (α := α))).map I.restrict
+            = (π.map fun P : ProbabilityMeasure α => fun j => (P (B j) : ℝ)).map Φ := by
+        intro π
+        rw [Measure.map_map (Finset.measurable_restrict I) measurable_evalReal,
+          Measure.map_map hΦm hfam, hfun]
+      rw [hcomp, hcomp, h _ B hBm]
+    exact (IsProjectiveLimit.unique
+      (P := fun I => (π₁.map (evalReal (α := α))).map I.restrict) hstep fun _ => rfl).symm
   refine Measure.ext fun T hT => ?_
   obtain ⟨U, hU, rfl⟩ : ∃ U, MeasurableSet U ∧ (evalReal (α := α)) ⁻¹' U = T := by
     have hT' : MeasurableSet[MeasurableSpace.comap (evalReal (α := α)) MeasurableSpace.pi] T := by


### PR DESCRIPTION
A finite measure on `ProbabilityMeasure α` is determined by the laws of its finite evaluation
families.

```lean
theorem Measure.ext_of_forall_map_probabilityMeasure_eval_eq
    {π₁ π₂ : Measure (ProbabilityMeasure α)} [IsFiniteMeasure π₁]
    (h : ∀ (n : ℕ) (B : Fin n → Set α), (∀ i, MeasurableSet (B i)) →
      π₁.map (fun P => fun i => (P (B i) : ℝ))
        = π₂.map (fun P => fun i => (P (B i) : ℝ))) :
    π₁ = π₂
```

## Roadmap

`TauCetiRoadmap/Exchangeability/README.md`, **Layer 6: directing measures and de Finetti
representation**.

This is a **prerequisite PR**, not a target. It is the identifiability half of
`mixedIID_mixingLaw_unique` (Layer 6): moment determinacy (landed in #1251) pins down each finite
evaluation law, and this theorem turns that into equality of the mixing measures. It deliberately
does **not** close
[TauCetiProject/TauCetiRoadmap#95](https://github.com/TauCetiProject/TauCetiRoadmap/issues/95) —
that intention stays open for the uniqueness theorem itself, which lands after the mixture
injectivity PR that consumes this one.

## Design notes

**Why only `π₁` is assumed finite.** The `n = 0` instance of the hypothesis equates the total
masses, so finiteness of `π₂` follows rather than being assumed. `ext_of_generate_finite` likewise
needs the instance on only one side.

**Why the σ-algebra argument is short.** The Giry σ-algebra on `Measure α` is *defined* as
`⨆ s, ⨆ _ : MeasurableSet s, (borel ℝ≥0∞).comap (fun μ => μ s)` — already an `iSup` of comaps of
the individual evaluations. So it is the pullback of a product σ-algebra along the all-evaluations
map, and `MeasurableSpace.comap_iSup` plus `iSup_subtype` is the whole proof; the only residue is
that the Giry instance names `borel ENNReal` where the product σ-algebra names the `ENNReal`
instance, closed by `BorelSpace.measurable_eq`.

**Why real-valued evaluations.** The Giry structure is stated with `ℝ≥0∞`-valued evaluations, but
the consumer-facing statement should be real-valued, since that is what feeds moment determinacy.
The two generate the same σ-algebra because each is a measurable function of the other
(`ENNReal.toReal` one way, `ENNReal.ofReal` the other), so the pullbacks coincide — no Borel
isomorphism argument is needed.

**No hand-rolled π-system.** Once the σ-algebra is a pullback, equality reduces to equality of the
pushforwards under the all-evaluations map, which is a statement about a product σ-algebra.
`measurableCylinders` is already known to be a π-system (`isPiSystem_measurableCylinders`)
generating it (`generateFrom_measurableCylinders`), and a measurable cylinder is exactly the event
that a finite evaluation family lands in a measurable set — which is the hypothesis. The only work
is reindexing the cylinder's `Finset` of coordinates by `Fin` via `Finset.equivFin`.

**API surface.** All eight supporting declarations — the index type, the all-evaluations map, its
measurability, the two σ-algebra identities, and the `ℝ≥0∞`/`ℝ` bridge — are `private`. Only the
extensionality theorem is public.

## Placement

New file `TauCeti/MeasureTheory/Measure/ProbabilityMeasureExt.lean`. There is no existing home for
extensionality-by-evaluation in the tree; `ProductKernel.lean` is the only other file mentioning
`ProbabilityMeasure` in `TauCeti/MeasureTheory/`, and it is about measurability and bind-evaluation
of product kernels, a different topic.

## Verification

* Full `lake build` green.
* `lake exe axioms`: the public theorem depends only on `propext`, `Classical.choice`, `Quot.sound`.
* `lake exe module-system` and `scripts/lint-env.sh` pass with no new violations.
* Smoke-tested from a module importing only this one.
* Imports tested individually for necessity; `GiryMonad` proved transitively available and was
  dropped, leaving one `public import` (the vocabulary in the statement) and one private import.
