### PR TITLE
feat(Contour): integrable pieces have principal value the ordinary integral, for any excision set

### DIFF
--- a/TauCeti/Analysis/Contour/Cauchy/PrincipalValue/On.lean
+++ b/TauCeti/Analysis/Contour/Cauchy/PrincipalValue/On.lean
@@ -52,6 +52,9 @@ of `f` (which fails at an on-curve singularity), never silently identifying the 
 * `HasCauchyPVAt.hasCauchyPV`, `CauchyPVExistsAt.cauchyPVExists` — the single-point principal value
   at `z₀` is the set-level principal value with `S = {z₀}`: the excision `‖γ t − z₀‖ > ε` is exactly
   the `S = {z₀}` case of the set excision.
+* `hasCauchyPVWith_of_integrable` — where the integrand is integrable and the curve meets each
+  excised point finitely often, the principal value is the ordinary integral **for any prescribed
+  excision set**
 * `HasCauchyPV.of_integrable` — if the ordinary contour integrand is interval-integrable, the empty
   excision witnesses that the principal value is the ordinary integral (as when no on-curve
   singularity of `f` obstructs integrability).
@@ -215,6 +218,63 @@ theorem HasCauchyPV.of_integrable {γ : ℝ → ℂ} {a b : ℝ} {f : ℂ → �
     simpa using hf_int
   · refine tendsto_const_nhds.congr fun ε => ?_
     exact intervalIntegral.integral_congr fun t _ => by simp
+
+/-- **An integrable integrand has principal value the ordinary integral, for *any* prescribed
+excision set.** Where the contour integrand is interval-integrable and the curve meets each
+excised point only finitely often, shrinking the excised neighbourhoods recovers the ordinary
+integral — the excision is a null perturbation.
+
+The strength here is that `S` is arbitrary: the conclusion holds for whatever excision set another
+principal value happens to be witnessed by, which is what lets an arc carrying no singularity be
+subtracted off via `HasCauchyPVWith.sub_right` without knowing that witness. Compare
+`HasCauchyPV.of_integrable`, which proves the weaker existential form by exhibiting `S = ∅`. -/
+theorem hasCauchyPVWith_of_integrable {γ : ℝ → ℂ} {a b : ℝ} {f : ℂ → ℂ} (S : Finset ℂ)
+    (hγ : Measurable γ)
+    (h_int : IntervalIntegrable (fun t => f (γ t) * deriv γ t) MeasureTheory.volume a b)
+    (h_fin : ∀ s ∈ S, (Set.uIcc a b ∩ γ ⁻¹' {s}).Finite) :
+    HasCauchyPVWith γ a b f S (∫ t in a..b, f (γ t) * deriv γ t) := by
+  classical
+  set g : ℝ → ℂ := fun t => f (γ t) * deriv γ t with hg
+  have hmeas : ∀ ε : ℝ, MeasurableSet {t | ∃ s ∈ S, ‖γ t - s‖ ≤ ε} := fun ε => by
+    have hset : {t | ∃ s ∈ S, ‖γ t - s‖ ≤ ε} = ⋃ s ∈ S, {t | ‖γ t - s‖ ≤ ε} := by ext t; simp
+    exact hset ▸ S.measurableSet_biUnion fun s _ =>
+      measurableSet_le ((hγ.sub measurable_const).norm) measurable_const
+  have hsm : ∀ ε : ℝ, MeasureTheory.AEStronglyMeasurable
+      (fun t => if ∃ s ∈ S, ‖γ t - s‖ ≤ ε then 0 else g t)
+      (MeasureTheory.volume.restrict (Set.uIoc a b)) := fun ε =>
+    (h_int.def'.aestronglyMeasurable.indicator (hmeas ε).compl).congr
+      (Filter.Eventually.of_forall fun t => by
+        dsimp only
+        by_cases h : ∃ s ∈ S, ‖γ t - s‖ ≤ ε
+        · rw [Set.indicator_of_notMem (by simpa using h), if_pos h]
+        · rw [Set.indicator_of_mem (by simpa using h), if_neg h])
+  have hle : ∀ ε : ℝ, ∀ t : ℝ,
+      ‖(if ∃ s ∈ S, ‖γ t - s‖ ≤ ε then 0 else g t)‖ ≤ ‖g t‖ := fun ε t => by
+    by_cases h : ∃ s ∈ S, ‖γ t - s‖ ≤ ε <;> simp [h]
+  -- Off the finite crossing set the excision is eventually inactive, so the excised integrand
+  -- agrees with the original there for every small `ε`.
+  have hnull : MeasureTheory.volume (⋃ s ∈ S, Set.uIcc a b ∩ γ ⁻¹' {s}) = 0 :=
+    (S.finite_toSet.biUnion fun s hs => h_fin s hs).measure_zero _
+  have hae : ∀ᵐ t ∂MeasureTheory.volume, t ∈ Set.uIoc a b →
+      Filter.Tendsto (fun ε : ℝ => if ∃ s ∈ S, ‖γ t - s‖ ≤ ε then 0 else g t)
+        (𝓝[>] 0) (𝓝 (g t)) := by
+    have hnot : ∀ᵐ t ∂MeasureTheory.volume, t ∉ ⋃ s ∈ S, Set.uIcc a b ∩ γ ⁻¹' {s} :=
+      MeasureTheory.measure_eq_zero_iff_ae_notMem.mp hnull
+    filter_upwards [hnot] with t ht htI
+    have hne : ∀ s ∈ S, 0 < ‖γ t - s‖ := fun s hs => by
+      rw [norm_pos_iff, sub_ne_zero]
+      exact fun hst => ht (Set.mem_biUnion hs ⟨Set.uIoc_subset_uIcc htI, hst⟩)
+    refine Filter.Tendsto.congr' ?_ tendsto_const_nhds
+    filter_upwards [(S.eventually_all (l := 𝓝[>] (0 : ℝ))
+      (p := fun s ε => ε < ‖γ t - s‖)).mpr fun s hs =>
+      Filter.eventually_of_mem (Ioo_mem_nhdsGT (hne s hs)) fun ε hε => hε.2] with ε hε
+    exact (if_neg (by push Not; exact fun s hs => hε s hs)).symm
+  refine ⟨Filter.Eventually.of_forall fun ε =>
+      h_int.mono_fun (hsm ε) (Filter.Eventually.of_forall (hle ε)), ?_⟩
+  exact intervalIntegral.tendsto_integral_filter_of_dominated_convergence (fun t => ‖g t‖)
+    (Filter.Eventually.of_forall hsm)
+    (Filter.Eventually.of_forall fun ε => Filter.Eventually.of_forall fun t _ => hle ε t)
+    h_int.norm hae
 
 /-- **Zero integrand.** The principal value of the zero integrand is `0`, witnessed by the empty
 excision: the truncated integrand is identically `0`, hence integrable with vanishing integral. -/

--- a/TauCeti/Analysis/Contour/Cauchy/PrincipalValue/On.lean
+++ b/TauCeti/Analysis/Contour/Cauchy/PrincipalValue/On.lean
@@ -287,16 +287,16 @@ theorem HasCauchyPVWith.of_integrable_of_crossings_measure_zero {γ : ℝ → �
 
 /-- Finite-crossings form of `HasCauchyPVWith.of_integrable_of_crossings_measure_zero`: a curve
 meeting each excised point only finitely often meets them on a null set of parameters. This is
-the form contour arguments consume, since `IsPwC1ImmersionOn.finite_crossings` (HW Prop 2.2)
-supplies exactly this. -/
+the form contour arguments consume: `IsPwC1ImmersionOn.finite_crossings` (HW Prop 2.2) supplies
+finiteness on the closed interval, from which this follows by `Set.Finite.subset` along
+`Set.uIoc_subset_uIcc`. -/
 theorem HasCauchyPVWith.of_integrable_of_finite_crossings {γ : ℝ → ℂ} {a b : ℝ} {f : ℂ → ℂ}
     (S : Finset ℂ) (hγ : AEMeasurable γ (MeasureTheory.volume.restrict (Set.uIoc a b)))
     (h_int : IntervalIntegrable (fun t => f (γ t) * deriv γ t) MeasureTheory.volume a b)
-    (h_fin : ∀ s ∈ S, (Set.uIcc a b ∩ γ ⁻¹' {s}).Finite) :
+    (h_fin : ∀ s ∈ S, (Set.uIoc a b ∩ γ ⁻¹' {s}).Finite) :
     HasCauchyPVWith γ a b f S (∫ t in a..b, f (γ t) * deriv γ t) :=
   .of_integrable_of_crossings_measure_zero S hγ h_int
-    ((S.finite_toSet.biUnion fun s hs => (h_fin s hs).subset
-      (Set.inter_subset_inter_left _ Set.uIoc_subset_uIcc)).measure_zero _)
+    ((S.finite_toSet.biUnion fun s hs => h_fin s hs).measure_zero _)
 
 /-- **Zero integrand.** The principal value of the zero integrand is `0`, witnessed by the empty
 excision: the truncated integrand is identically `0`, hence integrable with vanishing integral. -/

--- a/TauCeti/Analysis/Contour/Cauchy/PrincipalValue/On.lean
+++ b/TauCeti/Analysis/Contour/Cauchy/PrincipalValue/On.lean
@@ -248,7 +248,7 @@ subtracted off via `HasCauchyPVWith.sub_right` without knowing that witness. Com
 theorem HasCauchyPVWith.of_integrable_of_crossings_measure_zero {γ : ℝ → ℂ} {a b : ℝ} {f : ℂ → ℂ}
     (S : Finset ℂ) (hγ : AEMeasurable γ (MeasureTheory.volume.restrict (Set.uIoc a b)))
     (h_int : IntervalIntegrable (fun t => f (γ t) * deriv γ t) MeasureTheory.volume a b)
-    (h_null : MeasureTheory.volume (⋃ s ∈ S, Set.uIcc a b ∩ γ ⁻¹' {s}) = 0) :
+    (h_null : MeasureTheory.volume (⋃ s ∈ S, Set.uIoc a b ∩ γ ⁻¹' {s}) = 0) :
     HasCauchyPVWith γ a b f S (∫ t in a..b, f (γ t) * deriv γ t) := by
   classical
   set g : ℝ → ℂ := fun t => f (γ t) * deriv γ t with hg
@@ -274,7 +274,7 @@ theorem HasCauchyPVWith.of_integrable_of_crossings_measure_zero {γ : ℝ → �
         (𝓝[>] 0) (𝓝 (g t)) := by
     filter_upwards [MeasureTheory.measure_eq_zero_iff_ae_notMem.mp h_null] with t ht htI
     have hne : ∀ s ∈ S, γ t ≠ s := fun s hs hst =>
-      ht (Set.mem_biUnion hs ⟨Set.uIoc_subset_uIcc htI, hst⟩)
+      ht (Set.mem_biUnion hs ⟨htI, hst⟩)
     refine Filter.Tendsto.congr' ?_ tendsto_const_nhds
     filter_upwards [eventually_not_exists_mem_le (γ t) S hne] with ε hε
     exact (if_neg hε).symm
@@ -295,7 +295,8 @@ theorem HasCauchyPVWith.of_integrable_of_finite_crossings {γ : ℝ → ℂ} {a 
     (h_fin : ∀ s ∈ S, (Set.uIcc a b ∩ γ ⁻¹' {s}).Finite) :
     HasCauchyPVWith γ a b f S (∫ t in a..b, f (γ t) * deriv γ t) :=
   .of_integrable_of_crossings_measure_zero S hγ h_int
-    ((S.finite_toSet.biUnion fun s hs => h_fin s hs).measure_zero _)
+    ((S.finite_toSet.biUnion fun s hs => (h_fin s hs).subset
+      (Set.inter_subset_inter_left _ Set.uIoc_subset_uIcc)).measure_zero _)
 
 /-- **Zero integrand.** The principal value of the zero integrand is `0`, witnessed by the empty
 excision: the truncated integrand is identically `0`, hence integrable with vanishing integral. -/

--- a/TauCeti/Analysis/Contour/Cauchy/PrincipalValue/On.lean
+++ b/TauCeti/Analysis/Contour/Cauchy/PrincipalValue/On.lean
@@ -236,7 +236,7 @@ private theorem eventually_not_exists_mem_le (z : ℂ) (S : Finset ℂ) (h : ∀
 /-- **An integrable integrand has principal value the ordinary integral, for *any* prescribed
 excision set.** Where the contour integrand is interval-integrable and the curve meets the excised
 points only on a null set of parameters, shrinking the excised neighbourhoods recovers the ordinary
-integral: for each fixed `ε` the excision does perturb the integrand on a set of positive measure,
+integral: for each fixed `ε` the excision may perturb the integrand on a set of positive measure,
 but as `ε → 0⁺` the excised integrands converge almost everywhere to the original one, since the
 limiting crossing set is null.
 
@@ -245,20 +245,21 @@ principal value happens to be witnessed by, which is what lets an arc carrying n
 subtracted off via `HasCauchyPVWith.sub_right` without knowing that witness. Compare
 `HasCauchyPV.of_integrable`, which proves the weaker existential form by exhibiting `S = ∅`. -/
 theorem HasCauchyPVWith.of_integrable {γ : ℝ → ℂ} {a b : ℝ} {f : ℂ → ℂ} (S : Finset ℂ)
-    (hγ : Measurable γ)
+    (hγ : AEMeasurable γ (MeasureTheory.volume.restrict (Set.uIoc a b)))
     (h_int : IntervalIntegrable (fun t => f (γ t) * deriv γ t) MeasureTheory.volume a b)
     (h_null : MeasureTheory.volume (⋃ s ∈ S, Set.uIcc a b ∩ γ ⁻¹' {s}) = 0) :
     HasCauchyPVWith γ a b f S (∫ t in a..b, f (γ t) * deriv γ t) := by
   classical
   set g : ℝ → ℂ := fun t => f (γ t) * deriv γ t with hg
-  have hmeas : ∀ ε : ℝ, MeasurableSet {t | ∃ s ∈ S, ‖γ t - s‖ ≤ ε} := fun ε => by
+  have hmeas : ∀ ε : ℝ, MeasureTheory.NullMeasurableSet {t | ∃ s ∈ S, ‖γ t - s‖ ≤ ε}
+      (MeasureTheory.volume.restrict (Set.uIoc a b)) := fun ε => by
     have hset : {t | ∃ s ∈ S, ‖γ t - s‖ ≤ ε} = ⋃ s ∈ S, {t | ‖γ t - s‖ ≤ ε} := by ext t; simp
-    exact hset ▸ S.measurableSet_biUnion fun s _ =>
-      measurableSet_le ((hγ.sub measurable_const).norm) measurable_const
+    refine hset ▸ MeasureTheory.NullMeasurableSet.biUnion S.countable_toSet fun s _ => ?_
+    exact nullMeasurableSet_le ((hγ.sub_const s).norm) aemeasurable_const
   have hsm : ∀ ε : ℝ, MeasureTheory.AEStronglyMeasurable
       (fun t => if ∃ s ∈ S, ‖γ t - s‖ ≤ ε then 0 else g t)
       (MeasureTheory.volume.restrict (Set.uIoc a b)) := fun ε =>
-    (h_int.def'.aestronglyMeasurable.indicator (hmeas ε).compl).congr
+    (h_int.def'.aestronglyMeasurable.indicator₀ (hmeas ε).compl).congr
       (Filter.Eventually.of_forall fun t => by
         dsimp only
         by_cases h : ∃ s ∈ S, ‖γ t - s‖ ≤ ε
@@ -287,7 +288,7 @@ theorem HasCauchyPVWith.of_integrable {γ : ℝ → ℂ} {a b : ℝ} {f : ℂ �
 only finitely often meets them on a null set of parameters. This is the form contour arguments
 consume, since `IsPwC1ImmersionOn.finite_crossings` (HW Prop 2.2) supplies exactly this. -/
 theorem HasCauchyPVWith.of_integrable_of_finite_crossings {γ : ℝ → ℂ} {a b : ℝ} {f : ℂ → ℂ}
-    (S : Finset ℂ) (hγ : Measurable γ)
+    (S : Finset ℂ) (hγ : AEMeasurable γ (MeasureTheory.volume.restrict (Set.uIoc a b)))
     (h_int : IntervalIntegrable (fun t => f (γ t) * deriv γ t) MeasureTheory.volume a b)
     (h_fin : ∀ s ∈ S, (Set.uIcc a b ∩ γ ⁻¹' {s}).Finite) :
     HasCauchyPVWith γ a b f S (∫ t in a..b, f (γ t) * deriv γ t) :=

--- a/TauCeti/Analysis/Contour/Cauchy/PrincipalValue/On.lean
+++ b/TauCeti/Analysis/Contour/Cauchy/PrincipalValue/On.lean
@@ -52,7 +52,8 @@ of `f` (which fails at an on-curve singularity), never silently identifying the 
 * `HasCauchyPVAt.hasCauchyPV`, `CauchyPVExistsAt.cauchyPVExists` — the single-point principal value
   at `z₀` is the set-level principal value with `S = {z₀}`: the excision `‖γ t − z₀‖ > ε` is exactly
   the `S = {z₀}` case of the set excision.
-* `HasCauchyPVWith.of_integrable` and `HasCauchyPVWith.of_integrable_of_finite_crossings` — where
+* `HasCauchyPVWith.of_integrable_of_crossings_measure_zero` and its finite-crossings wrapper
+  `HasCauchyPVWith.of_integrable_of_finite_crossings` — where
   the integrand is integrable and the curve meets the excised points on a null set of parameters
   (in particular, finitely often), the principal value is the ordinary integral **for any
   prescribed excision set**
@@ -244,8 +245,8 @@ The strength here is that `S` is arbitrary: the conclusion holds for whatever ex
 principal value happens to be witnessed by, which is what lets an arc carrying no singularity be
 subtracted off via `HasCauchyPVWith.sub_right` without knowing that witness. Compare
 `HasCauchyPV.of_integrable`, which proves the weaker existential form by exhibiting `S = ∅`. -/
-theorem HasCauchyPVWith.of_integrable {γ : ℝ → ℂ} {a b : ℝ} {f : ℂ → ℂ} (S : Finset ℂ)
-    (hγ : AEMeasurable γ (MeasureTheory.volume.restrict (Set.uIoc a b)))
+theorem HasCauchyPVWith.of_integrable_of_crossings_measure_zero {γ : ℝ → ℂ} {a b : ℝ} {f : ℂ → ℂ}
+    (S : Finset ℂ) (hγ : AEMeasurable γ (MeasureTheory.volume.restrict (Set.uIoc a b)))
     (h_int : IntervalIntegrable (fun t => f (γ t) * deriv γ t) MeasureTheory.volume a b)
     (h_null : MeasureTheory.volume (⋃ s ∈ S, Set.uIcc a b ∩ γ ⁻¹' {s}) = 0) :
     HasCauchyPVWith γ a b f S (∫ t in a..b, f (γ t) * deriv γ t) := by
@@ -284,15 +285,17 @@ theorem HasCauchyPVWith.of_integrable {γ : ℝ → ℂ} {a b : ℝ} {f : ℂ �
     (Filter.Eventually.of_forall fun ε => Filter.Eventually.of_forall fun t _ => hle ε t)
     h_int.norm hae
 
-/-- Finite-crossings form of `HasCauchyPVWith.of_integrable`: a curve meeting each excised point
-only finitely often meets them on a null set of parameters. This is the form contour arguments
-consume, since `IsPwC1ImmersionOn.finite_crossings` (HW Prop 2.2) supplies exactly this. -/
+/-- Finite-crossings form of `HasCauchyPVWith.of_integrable_of_crossings_measure_zero`: a curve
+meeting each excised point only finitely often meets them on a null set of parameters. This is
+the form contour arguments consume, since `IsPwC1ImmersionOn.finite_crossings` (HW Prop 2.2)
+supplies exactly this. -/
 theorem HasCauchyPVWith.of_integrable_of_finite_crossings {γ : ℝ → ℂ} {a b : ℝ} {f : ℂ → ℂ}
     (S : Finset ℂ) (hγ : AEMeasurable γ (MeasureTheory.volume.restrict (Set.uIoc a b)))
     (h_int : IntervalIntegrable (fun t => f (γ t) * deriv γ t) MeasureTheory.volume a b)
     (h_fin : ∀ s ∈ S, (Set.uIcc a b ∩ γ ⁻¹' {s}).Finite) :
     HasCauchyPVWith γ a b f S (∫ t in a..b, f (γ t) * deriv γ t) :=
-  .of_integrable S hγ h_int ((S.finite_toSet.biUnion fun s hs => h_fin s hs).measure_zero _)
+  .of_integrable_of_crossings_measure_zero S hγ h_int
+    ((S.finite_toSet.biUnion fun s hs => h_fin s hs).measure_zero _)
 
 /-- **Zero integrand.** The principal value of the zero integrand is `0`, witnessed by the empty
 excision: the truncated integrand is identically `0`, hence integrable with vanishing integral. -/

--- a/TauCeti/Analysis/Contour/Cauchy/PrincipalValue/On.lean
+++ b/TauCeti/Analysis/Contour/Cauchy/PrincipalValue/On.lean
@@ -52,9 +52,10 @@ of `f` (which fails at an on-curve singularity), never silently identifying the 
 * `HasCauchyPVAt.hasCauchyPV`, `CauchyPVExistsAt.cauchyPVExists` — the single-point principal value
   at `z₀` is the set-level principal value with `S = {z₀}`: the excision `‖γ t − z₀‖ > ε` is exactly
   the `S = {z₀}` case of the set excision.
-* `hasCauchyPVWith_of_integrable` — where the integrand is integrable and the curve meets each
-  excised point finitely often, the principal value is the ordinary integral **for any prescribed
-  excision set**
+* `HasCauchyPVWith.of_integrable` and `HasCauchyPVWith.of_integrable_of_finite_crossings` — where
+  the integrand is integrable and the curve meets the excised points on a null set of parameters
+  (in particular, finitely often), the principal value is the ordinary integral **for any
+  prescribed excision set**
 * `HasCauchyPV.of_integrable` — if the ordinary contour integrand is interval-integrable, the empty
   excision witnesses that the principal value is the ordinary integral (as when no on-curve
   singularity of `f` obstructs integrability).
@@ -219,19 +220,34 @@ theorem HasCauchyPV.of_integrable {γ : ℝ → ℂ} {a b : ℝ} {f : ℂ → �
   · refine tendsto_const_nhds.congr fun ε => ?_
     exact intervalIntegral.integral_congr fun t _ => by simp
 
+/-- If `z` is none of the finitely many points of `S`, then for all small enough `ε > 0` the point
+`z` is farther than `ε` from every point of `S`; i.e. the excision at `S` eventually keeps `z`. -/
+private theorem eventually_not_exists_mem_le (z : ℂ) (S : Finset ℂ) (h : ∀ s ∈ S, z ≠ s) :
+    ∀ᶠ ε in 𝓝[>] (0 : ℝ), ¬ ∃ s ∈ S, ‖z - s‖ ≤ ε := by
+  have key : ∀ᶠ ε in 𝓝[>] (0 : ℝ), ∀ s ∈ S, ε < ‖z - s‖ := by
+    rw [Filter.eventually_all_finset]
+    intro s hs
+    have hpos : (0 : ℝ) < ‖z - s‖ := by rw [norm_pos_iff, sub_ne_zero]; exact h s hs
+    exact nhdsWithin_le_nhds (Iio_mem_nhds hpos)
+  filter_upwards [key] with ε hε
+  rintro ⟨s, hs, hle⟩
+  exact absurd hle (not_le.mpr (hε s hs))
+
 /-- **An integrable integrand has principal value the ordinary integral, for *any* prescribed
-excision set.** Where the contour integrand is interval-integrable and the curve meets each
-excised point only finitely often, shrinking the excised neighbourhoods recovers the ordinary
-integral — the excision is a null perturbation.
+excision set.** Where the contour integrand is interval-integrable and the curve meets the excised
+points only on a null set of parameters, shrinking the excised neighbourhoods recovers the ordinary
+integral: for each fixed `ε` the excision does perturb the integrand on a set of positive measure,
+but as `ε → 0⁺` the excised integrands converge almost everywhere to the original one, since the
+limiting crossing set is null.
 
 The strength here is that `S` is arbitrary: the conclusion holds for whatever excision set another
 principal value happens to be witnessed by, which is what lets an arc carrying no singularity be
 subtracted off via `HasCauchyPVWith.sub_right` without knowing that witness. Compare
 `HasCauchyPV.of_integrable`, which proves the weaker existential form by exhibiting `S = ∅`. -/
-theorem hasCauchyPVWith_of_integrable {γ : ℝ → ℂ} {a b : ℝ} {f : ℂ → ℂ} (S : Finset ℂ)
+theorem HasCauchyPVWith.of_integrable {γ : ℝ → ℂ} {a b : ℝ} {f : ℂ → ℂ} (S : Finset ℂ)
     (hγ : Measurable γ)
     (h_int : IntervalIntegrable (fun t => f (γ t) * deriv γ t) MeasureTheory.volume a b)
-    (h_fin : ∀ s ∈ S, (Set.uIcc a b ∩ γ ⁻¹' {s}).Finite) :
+    (h_null : MeasureTheory.volume (⋃ s ∈ S, Set.uIcc a b ∩ γ ⁻¹' {s}) = 0) :
     HasCauchyPVWith γ a b f S (∫ t in a..b, f (γ t) * deriv γ t) := by
   classical
   set g : ℝ → ℂ := fun t => f (γ t) * deriv γ t with hg
@@ -251,30 +267,31 @@ theorem hasCauchyPVWith_of_integrable {γ : ℝ → ℂ} {a b : ℝ} {f : ℂ �
   have hle : ∀ ε : ℝ, ∀ t : ℝ,
       ‖(if ∃ s ∈ S, ‖γ t - s‖ ≤ ε then 0 else g t)‖ ≤ ‖g t‖ := fun ε t => by
     by_cases h : ∃ s ∈ S, ‖γ t - s‖ ≤ ε <;> simp [h]
-  -- Off the finite crossing set the excision is eventually inactive, so the excised integrand
-  -- agrees with the original there for every small `ε`.
-  have hnull : MeasureTheory.volume (⋃ s ∈ S, Set.uIcc a b ∩ γ ⁻¹' {s}) = 0 :=
-    (S.finite_toSet.biUnion fun s hs => h_fin s hs).measure_zero _
   have hae : ∀ᵐ t ∂MeasureTheory.volume, t ∈ Set.uIoc a b →
       Filter.Tendsto (fun ε : ℝ => if ∃ s ∈ S, ‖γ t - s‖ ≤ ε then 0 else g t)
         (𝓝[>] 0) (𝓝 (g t)) := by
-    have hnot : ∀ᵐ t ∂MeasureTheory.volume, t ∉ ⋃ s ∈ S, Set.uIcc a b ∩ γ ⁻¹' {s} :=
-      MeasureTheory.measure_eq_zero_iff_ae_notMem.mp hnull
-    filter_upwards [hnot] with t ht htI
-    have hne : ∀ s ∈ S, 0 < ‖γ t - s‖ := fun s hs => by
-      rw [norm_pos_iff, sub_ne_zero]
-      exact fun hst => ht (Set.mem_biUnion hs ⟨Set.uIoc_subset_uIcc htI, hst⟩)
+    filter_upwards [MeasureTheory.measure_eq_zero_iff_ae_notMem.mp h_null] with t ht htI
+    have hne : ∀ s ∈ S, γ t ≠ s := fun s hs hst =>
+      ht (Set.mem_biUnion hs ⟨Set.uIoc_subset_uIcc htI, hst⟩)
     refine Filter.Tendsto.congr' ?_ tendsto_const_nhds
-    filter_upwards [(S.eventually_all (l := 𝓝[>] (0 : ℝ))
-      (p := fun s ε => ε < ‖γ t - s‖)).mpr fun s hs =>
-      Filter.eventually_of_mem (Ioo_mem_nhdsGT (hne s hs)) fun ε hε => hε.2] with ε hε
-    exact (if_neg (by push Not; exact fun s hs => hε s hs)).symm
+    filter_upwards [eventually_not_exists_mem_le (γ t) S hne] with ε hε
+    exact (if_neg hε).symm
   refine ⟨Filter.Eventually.of_forall fun ε =>
       h_int.mono_fun (hsm ε) (Filter.Eventually.of_forall (hle ε)), ?_⟩
   exact intervalIntegral.tendsto_integral_filter_of_dominated_convergence (fun t => ‖g t‖)
     (Filter.Eventually.of_forall hsm)
     (Filter.Eventually.of_forall fun ε => Filter.Eventually.of_forall fun t _ => hle ε t)
     h_int.norm hae
+
+/-- Finite-crossings form of `HasCauchyPVWith.of_integrable`: a curve meeting each excised point
+only finitely often meets them on a null set of parameters. This is the form contour arguments
+consume, since `IsPwC1ImmersionOn.finite_crossings` (HW Prop 2.2) supplies exactly this. -/
+theorem HasCauchyPVWith.of_integrable_of_finite_crossings {γ : ℝ → ℂ} {a b : ℝ} {f : ℂ → ℂ}
+    (S : Finset ℂ) (hγ : Measurable γ)
+    (h_int : IntervalIntegrable (fun t => f (γ t) * deriv γ t) MeasureTheory.volume a b)
+    (h_fin : ∀ s ∈ S, (Set.uIcc a b ∩ γ ⁻¹' {s}).Finite) :
+    HasCauchyPVWith γ a b f S (∫ t in a..b, f (γ t) * deriv γ t) :=
+  .of_integrable S hγ h_int ((S.finite_toSet.biUnion fun s hs => h_fin s hs).measure_zero _)
 
 /-- **Zero integrand.** The principal value of the zero integrand is `0`, witnessed by the empty
 excision: the truncated integrand is identically `0`, hence integrable with vanishing integral. -/
@@ -366,19 +383,6 @@ private theorem countable_setOf_deriv_ne_zero_on_fiber (g : ℝ → ℂ) (c : �
     nhdsWithin_mono x (fun y hy => ne_of_lt hy) hfreq
   rw [Set.inter_comm, nhdsWithin_inter']
   exact Filter.inf_principal_eq_bot.mpr h2
-
-/-- If `z` is none of the finitely many points of `S`, then for all small enough `ε > 0` the point
-`z` is farther than `ε` from every point of `S`; i.e. the excision at `S` eventually keeps `z`. -/
-private theorem eventually_not_exists_mem_le (z : ℂ) (S : Finset ℂ) (h : ∀ s ∈ S, z ≠ s) :
-    ∀ᶠ ε in 𝓝[>] (0 : ℝ), ¬ ∃ s ∈ S, ‖z - s‖ ≤ ε := by
-  have key : ∀ᶠ ε in 𝓝[>] (0 : ℝ), ∀ s ∈ S, ε < ‖z - s‖ := by
-    rw [Filter.eventually_all_finset]
-    intro s hs
-    have hpos : (0 : ℝ) < ‖z - s‖ := by rw [norm_pos_iff, sub_ne_zero]; exact h s hs
-    exact nhdsWithin_le_nhds (Iio_mem_nhds hpos)
-  filter_upwards [key] with ε hε
-  rintro ⟨s, hs, hle⟩
-  exact absurd hle (not_le.mpr (hε s hs))
 
 /-- **A separating, integrable excision radius.** If the truncated integrands for `S₁` and `S₂` are
 eventually integrable as `ε → 0⁺`, there is a single `ε₀ > 0` at which both are integrable and at


### PR DESCRIPTION
Closes the last structural gap before the improper-integral acceptance criterion.

## The lemma

`hasCauchyPVWith_of_integrable` — where the contour integrand is interval-integrable and the curve meets each excised point only finitely often, the `ε`-excised integrals converge to the ordinary integral, **for an arbitrary prescribed excision set `S`**.

The arbitrariness of `S` is the whole point. `HasCauchyPV` binds its excision set existentially, so when the Hungerbühler–Wasem summit hands back a principal value along a closed contour, its witness is unknown. Splitting off an arc via `HasCauchyPVWith.sub_right` (#1253) requires both pieces to share that witness — and this lemma supplies the arc piece for *whatever* the witness turns out to be. Finiteness of the crossings comes from `IsPwC1ImmersionOn.finite_crossings` (HW Prop 2.2).

Compare `HasCauchyPV.of_integrable`, which proves the weaker existential form by exhibiting `S = ∅`; that form cannot be concatenated.

## Proof

Dominated convergence over the `𝓝[>] 0` filter. Off the crossing set — finite, hence null — the excision is eventually inactive, so the excised integrand converges pointwise a.e. to the integrand, dominated by its norm. Integrability of the excised integrand comes from `IntervalIntegrable.mono_fun` against the same bound.

Only `Measurable γ` is assumed: measurability of `{t | ∃ s ∈ S, ‖γ t - s‖ ≤ ε}` is all the excision needs, so continuity is not required.

## Roadmap

With Jordan's lemma (#1244) and the concatenation API (#1253) already on `main`, this is the final prerequisite for *"an improper integral … evaluated by HW Thm 3.3 where the classical theorem does not apply"*. The remaining step is assembly: split the half-disc into diameter and arc, then let the arc vanish as `R → ∞`.

## Gates

`lake build` · `lake exe axioms` · `lake exe module-system` · `scripts/lint-env.sh` — all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)