### PR TITLE
feat(Contour): identify the half-disc arc piece with the semicircle integral

### DIFF
--- a/TauCeti/Analysis/Contour/WorkedExamples/HalfDisc/Basic.lean
+++ b/TauCeti/Analysis/Contour/WorkedExamples/HalfDisc/Basic.lean
@@ -46,6 +46,10 @@ residue theorem does not apply because the pole lies *on* the contour.
   origin is `½`.
 * `TauCeti.Contour.halfDiscBoundary_eq_zero_iff` — the contour meets the origin exactly once,
   at `t = 0`.
+* `TauCeti.Contour.deriv_halfDiscBoundary_of_lt` — strictly beyond the junction the derivative is
+  the circle map's, at the shifted parameter.
+* `TauCeti.Contour.integral_arc_halfDiscBoundary` — the `[R, R + π]` piece of the contour integral
+  is the upper-semicircle integral, the form Jordan's lemma bounds.
 * `TauCeti.Contour.flatOfOrder_halfDiscBoundary` — both one-sided branches at the origin lie on
   the real line, so the contour is flat there to every order.
 * `TauCeti.Contour.conditionAprime_halfDiscBoundary` — Hungerbühler–Wasem condition (A′) at the
@@ -101,6 +105,45 @@ theorem eqOn_halfDiscBoundary_segment (hR : 0 ≤ R) :
   have h2 : t < max (-R) R := (Set.mem_Ioo.mp ht).2
   rw [max_eq_right (by linarith : (-R : ℝ) ≤ R)] at h2
   simp [halfDiscBoundary_of_le h2.le]
+
+/-- **The derivative on the open arc.** Strictly beyond the junction the half-disc boundary
+coincides with the shifted circle map on a whole neighbourhood, so its derivative is the circle
+map's, evaluated at the shifted parameter. (At the junction `t = R` itself the contour has a
+corner, and no such identity is claimed.) -/
+theorem deriv_halfDiscBoundary_of_lt {R t : ℝ} (h : R < t) :
+    deriv (halfDiscBoundary R) t = deriv (circleMap 0 R) (t - R) := by
+  have hev : halfDiscBoundary R =ᶠ[nhds t] (circleMap 0 R ∘ fun s : ℝ => s - R) := by
+    filter_upwards [Ioi_mem_nhds h] with s hs
+    exact halfDiscBoundary_of_lt hs
+  rw [hev.deriv_eq]
+  have hd : HasDerivAt (circleMap 0 R ∘ fun s : ℝ => s - R)
+      (deriv (circleMap 0 R) (t - R)) t := by
+    have hc : HasDerivAt (circleMap 0 R) (deriv (circleMap 0 R) (t - R)) (t - R) :=
+      (differentiable_circleMap 0 R (t - R)).hasDerivAt
+    have hsub : HasDerivAt (fun s : ℝ => s - R) 1 t := by
+      simpa using (hasDerivAt_id t).sub_const R
+    simpa using hc.scomp t hsub
+  exact hd.deriv
+
+/-- **The arc piece of the contour integral is the semicircle integral.** Beyond the junction the
+half-disc boundary is the circle map shifted by `R`, so translating the parameter identifies the
+`[R, R + π]` piece of `∮_γ f` with the integral over the upper semicircle traversed from `0` to
+`π` — the form Jordan's lemma bounds. The junction `t = R` itself, where the contour has a corner,
+is a single point and does not affect the integral. -/
+theorem integral_arc_halfDiscBoundary (f : ℂ → ℂ) (R : ℝ) :
+    (∫ t in R..(R + Real.pi), f (halfDiscBoundary R t) * deriv (halfDiscBoundary R) t)
+      = ∫ θ in (0 : ℝ)..Real.pi, f (circleMap 0 R θ) * deriv (circleMap 0 R) θ := by
+  have hshift : (∫ t in R..(R + Real.pi),
+      f (circleMap 0 R (t - R)) * deriv (circleMap 0 R) (t - R))
+      = ∫ θ in (0 : ℝ)..Real.pi, f (circleMap 0 R θ) * deriv (circleMap 0 R) θ := by
+    have h := intervalIntegral.integral_comp_sub_right
+      (fun θ => f (circleMap 0 R θ) * deriv (circleMap 0 R) θ) (a := R) (b := R + Real.pi) R
+    simpa using h
+  rw [← hshift]
+  refine intervalIntegral.integral_congr_ae' (Filter.Eventually.of_forall fun t ht => ?_)
+    (Filter.Eventually.of_forall fun t ht => ?_)
+  · rw [halfDiscBoundary_of_lt ht.1, deriv_halfDiscBoundary_of_lt ht.1]
+  · exact absurd (ht.1.trans_le ht.2) (by simp [Real.pi_pos.le])
 
 /-- On the arc's parameter interval — including both endpoints, where the two agree — the contour
 is the circle reparametrized by `t ↦ t - R`. -/

--- a/TauCeti/Analysis/Contour/WorkedExamples/HalfDisc/Basic.lean
+++ b/TauCeti/Analysis/Contour/WorkedExamples/HalfDisc/Basic.lean
@@ -49,7 +49,7 @@ residue theorem does not apply because the pole lies *on* the contour.
 * `TauCeti.Contour.deriv_halfDiscBoundary_of_lt` — strictly beyond the junction the derivative is
   the circle map's, at the shifted parameter.
 * `TauCeti.Contour.integral_halfDiscBoundary_arc` — the `[R, R + π]` piece of the contour integral
-  is the `circleMap 0 R` integral over `[0, π]`; for `0 ≤ R` that is the upper semicircle, the
+  is the `circleMap 0 R` integral over `[0, π]`; for `0 < R` that is the upper semicircle, the
   form Jordan's lemma bounds.
 * `TauCeti.Contour.flatOfOrder_halfDiscBoundary` — both one-sided branches at the origin lie on
   the real line, so the contour is flat there to every order.
@@ -118,13 +118,11 @@ theorem deriv_halfDiscBoundary_of_lt {R t : ℝ} (h : R < t) :
     filter_upwards [Ioi_mem_nhds h] with s hs
     exact halfDiscBoundary_of_lt hs
   rw [hev.deriv_eq]
+  have hsub : HasDerivAt (fun s : ℝ => s - R) 1 t := by
+    simpa using (hasDerivAt_id t).sub_const R
   have hd : HasDerivAt (circleMap 0 R ∘ fun s : ℝ => s - R)
       (deriv (circleMap 0 R) (t - R)) t := by
-    have hc : HasDerivAt (circleMap 0 R) (deriv (circleMap 0 R) (t - R)) (t - R) :=
-      (differentiable_circleMap 0 R (t - R)).hasDerivAt
-    have hsub : HasDerivAt (fun s : ℝ => s - R) 1 t := by
-      simpa using (hasDerivAt_id t).sub_const R
-    simpa using hc.scomp t hsub
+    simpa [deriv_circleMap] using (hasDerivAt_circleMap 0 R (t - R)).scomp t hsub
   exact hd.deriv
 
 /-- **The arc piece of the contour integral is the circle-map integral.** Beyond the junction the
@@ -132,9 +130,10 @@ half-disc boundary is the circle map shifted by `R`, so translating the paramete
 `[R, R + π]` piece of `∮_γ f` with the integral of `circleMap 0 R` over `[0, π]`. The junction
 `t = R` itself, where the contour has a corner, is a single point and does not affect the integral.
 
-The identity holds for every `R`. For `0 ≤ R` the right-hand side is the *upper* semicircle
+The identity holds for every `R`. For `0 < R` the right-hand side is the *upper* semicircle
 traversed counterclockwise — the form Jordan's lemma bounds; for `R < 0` the same parametrization
-traces the lower semicircle instead. -/
+traces the lower semicircle instead, and `R = 0` is degenerate, `circleMap 0 0` being the constant
+path at the origin. -/
 theorem integral_halfDiscBoundary_arc (f : ℂ → ℂ) (R : ℝ) :
     (∫ t in R..(R + Real.pi), f (halfDiscBoundary R t) * deriv (halfDiscBoundary R) t)
       = ∫ θ in (0 : ℝ)..Real.pi, f (circleMap 0 R θ) * deriv (circleMap 0 R) θ := by

--- a/TauCeti/Analysis/Contour/WorkedExamples/HalfDisc/Basic.lean
+++ b/TauCeti/Analysis/Contour/WorkedExamples/HalfDisc/Basic.lean
@@ -48,8 +48,9 @@ residue theorem does not apply because the pole lies *on* the contour.
   at `t = 0`.
 * `TauCeti.Contour.deriv_halfDiscBoundary_of_lt` — strictly beyond the junction the derivative is
   the circle map's, at the shifted parameter.
-* `TauCeti.Contour.integral_arc_halfDiscBoundary` — the `[R, R + π]` piece of the contour integral
-  is the upper-semicircle integral, the form Jordan's lemma bounds.
+* `TauCeti.Contour.integral_halfDiscBoundary_arc` — the `[R, R + π]` piece of the contour integral
+  is the `circleMap 0 R` integral over `[0, π]`; for `0 ≤ R` that is the upper semicircle, the
+  form Jordan's lemma bounds.
 * `TauCeti.Contour.flatOfOrder_halfDiscBoundary` — both one-sided branches at the origin lie on
   the real line, so the contour is flat there to every order.
 * `TauCeti.Contour.conditionAprime_halfDiscBoundary` — Hungerbühler–Wasem condition (A′) at the
@@ -110,6 +111,7 @@ theorem eqOn_halfDiscBoundary_segment (hR : 0 ≤ R) :
 coincides with the shifted circle map on a whole neighbourhood, so its derivative is the circle
 map's, evaluated at the shifted parameter. (At the junction `t = R` itself the contour has a
 corner, and no such identity is claimed.) -/
+@[simp]
 theorem deriv_halfDiscBoundary_of_lt {R t : ℝ} (h : R < t) :
     deriv (halfDiscBoundary R) t = deriv (circleMap 0 R) (t - R) := by
   have hev : halfDiscBoundary R =ᶠ[nhds t] (circleMap 0 R ∘ fun s : ℝ => s - R) := by
@@ -125,12 +127,15 @@ theorem deriv_halfDiscBoundary_of_lt {R t : ℝ} (h : R < t) :
     simpa using hc.scomp t hsub
   exact hd.deriv
 
-/-- **The arc piece of the contour integral is the semicircle integral.** Beyond the junction the
+/-- **The arc piece of the contour integral is the circle-map integral.** Beyond the junction the
 half-disc boundary is the circle map shifted by `R`, so translating the parameter identifies the
-`[R, R + π]` piece of `∮_γ f` with the integral over the upper semicircle traversed from `0` to
-`π` — the form Jordan's lemma bounds. The junction `t = R` itself, where the contour has a corner,
-is a single point and does not affect the integral. -/
-theorem integral_arc_halfDiscBoundary (f : ℂ → ℂ) (R : ℝ) :
+`[R, R + π]` piece of `∮_γ f` with the integral of `circleMap 0 R` over `[0, π]`. The junction
+`t = R` itself, where the contour has a corner, is a single point and does not affect the integral.
+
+The identity holds for every `R`. For `0 ≤ R` the right-hand side is the *upper* semicircle
+traversed counterclockwise — the form Jordan's lemma bounds; for `R < 0` the same parametrization
+traces the lower semicircle instead. -/
+theorem integral_halfDiscBoundary_arc (f : ℂ → ℂ) (R : ℝ) :
     (∫ t in R..(R + Real.pi), f (halfDiscBoundary R t) * deriv (halfDiscBoundary R) t)
       = ∫ θ in (0 : ℝ)..Real.pi, f (circleMap 0 R θ) * deriv (circleMap 0 R) θ := by
   have hshift : (∫ t in R..(R + Real.pi),


### PR DESCRIPTION
Connects the half-disc contour to Jordan's lemma (#1244), which is stated for the circle map.

* `deriv_halfDiscBoundary_of_lt` — strictly beyond the junction the half-disc boundary agrees with the shifted circle map on a whole neighbourhood, so its derivative is the circle map's at the shifted parameter. Nothing is claimed at `t = R` itself, where the contour has a corner.
* `integral_halfDiscBoundary_arc` — translating the parameter identifies the `[R, R + π]` piece of the contour integral with the integral of `circleMap 0 R` over `[0, π]`. The junction is a single point, so it does not affect the integral (`integral_congr_ae'` over `Ioc`). The identity holds for every `R`; for `0 < R` the right-hand side is the upper semicircle traversed counterclockwise, which is the form Jordan's lemma bounds, while for `R < 0` the same parametrization traces the lower semicircle and `R = 0` is the degenerate constant path.

## Roadmap

Prerequisite for `TauCetiRoadmap/ContourIntegration/README.md`, heading **"Worked examples (acceptance criteria, keeping the theory honest)"**, and specifically its improper-integral criterion:

> **An improper integral** (e.g. a Cauchy principal value along the real axis with a simple pole at `0`) evaluated by HW Thm 3.3 where the classical theorem does not apply — HW's motivating example.

With Jordan's lemma (#1244) and the concatenation API (#1253) on `main`, and the any-witness integrability result in review (#1259), this supplies the change of variables the final assembly needs: the arc term of the split half-disc is literally the integral Jordan bounds, so it vanishes as `R → ∞`.

## Gates

`lake build` · `lake exe axioms` · `lake exe module-system` · `scripts/lint-env.sh` — all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
