### PR TITLE
feat: add Weyl inversion exchange

### DIFF
--- a/TauCeti/LinearAlgebra/RootSystem/Inversions.lean
+++ b/TauCeti/LinearAlgebra/RootSystem/Inversions.lean
@@ -1,0 +1,14 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+module
+
+public import TauCeti.LinearAlgebra.RootSystem.Inversions.Basic
+
+/-!
+# Inversion sets in a Weyl group
+
+This compatibility module preserves the original import path for the basic API for inversion sets.
+New imports may use `TauCeti.LinearAlgebra.RootSystem.Inversions.Basic`.
+-/

--- a/TauCeti/LinearAlgebra/RootSystem/Inversions/Basic.lean
+++ b/TauCeti/LinearAlgebra/RootSystem/Inversions/Basic.lean
@@ -126,6 +126,18 @@ lemma ncard_inversions_one : (inversions P b 1).ncard = 0 := by
 
 variable [Finite ι] [IsDomain R] [P.IsCrystallographic] [P.IsReduced]
 
+omit [CharZero R] [Finite ι] [IsDomain R] [P.IsCrystallographic] [P.IsReduced] in
+/-- The Weyl-group permutation of a simple reflection is the corresponding root-index
+reflection. -/
+lemma weylGroupToPerm_ofIdx_apply (i j : ι) :
+    P.weylGroupToPerm (RootPairing.weylGroup.ofIdx P i) j =
+      P.reflectionPerm i j := by
+  -- Mathlib exposes the underlying reflection equivalence, but not its restriction to the
+  -- Weyl group. Unfolding just those two wrappers connects the APIs.
+  change (RootPairing.Equiv.reflection P i).indexEquiv j = P.reflectionPerm i j
+  exact congrArg (fun e : ι ≃ ι => e j)
+    (RootPairing.Equiv.reflection_indexEquiv P i)
+
 /-- A simple reflection has exactly its defining simple root as an inversion. -/
 @[simp]
 theorem inversions_ofIdx {i : ι} (hi : i ∈ b.support) :
@@ -138,15 +150,7 @@ theorem inversions_ofIdx {i : ι} (hi : i ∈ b.support) :
     exact hneg (hj.reflectionPerm hi hji)
   · rintro rfl
     refine ⟨b.isPos_of_mem_support hi, ?_⟩
-    have hofIdx :
-        P.weylGroupToPerm (RootPairing.weylGroup.ofIdx P j) j =
-          P.reflectionPerm j j := by
-      -- Mathlib has no `weylGroupToPerm_ofIdx` lemma: expose the restriction and `ofIdx`
-      -- wrappers definitionally, then use its named theorem for the underlying reflection.
-      change (RootPairing.Equiv.reflection P j).indexEquiv j = P.reflectionPerm j j
-      exact congrArg (fun e : ι ≃ ι => e j)
-        (RootPairing.Equiv.reflection_indexEquiv P j)
-    rw [hofIdx, ← mem_negRoots,
+    rw [weylGroupToPerm_ofIdx_apply, ← mem_negRoots,
       reflectionPerm_self_mem_negRoots_iff_mem_posRoots, mem_posRoots]
     exact b.isPos_of_mem_support hi
 

--- a/TauCeti/LinearAlgebra/RootSystem/Inversions/Basic.lean
+++ b/TauCeti/LinearAlgebra/RootSystem/Inversions/Basic.lean
@@ -5,8 +5,8 @@ Released under Apache 2.0 license as described in the file LICENSE.
 module
 
 public import Mathlib.Data.Set.Card
-public import Mathlib.LinearAlgebra.RootSystem.WeylGroup
 public import TauCeti.LinearAlgebra.RootSystem.Positive
+public import TauCeti.LinearAlgebra.RootSystem.WeylGroup
 
 public section
 
@@ -126,18 +126,6 @@ lemma ncard_inversions_one : (inversions P b 1).ncard = 0 := by
 
 variable [Finite ι] [IsDomain R] [P.IsCrystallographic] [P.IsReduced]
 
-omit [CharZero R] [Finite ι] [IsDomain R] [P.IsCrystallographic] [P.IsReduced] in
-/-- The Weyl-group permutation of a simple reflection is the corresponding root-index
-reflection. -/
-lemma weylGroupToPerm_ofIdx_apply (i j : ι) :
-    P.weylGroupToPerm (RootPairing.weylGroup.ofIdx P i) j =
-      P.reflectionPerm i j := by
-  -- Mathlib exposes the underlying reflection equivalence, but not its restriction to the
-  -- Weyl group. Unfolding just those two wrappers connects the APIs.
-  change (RootPairing.Equiv.reflection P i).indexEquiv j = P.reflectionPerm i j
-  exact congrArg (fun e : ι ≃ ι => e j)
-    (RootPairing.Equiv.reflection_indexEquiv P i)
-
 /-- A simple reflection has exactly its defining simple root as an inversion. -/
 @[simp]
 theorem inversions_ofIdx {i : ι} (hi : i ∈ b.support) :
@@ -150,7 +138,7 @@ theorem inversions_ofIdx {i : ι} (hi : i ∈ b.support) :
     exact hneg (hj.reflectionPerm hi hji)
   · rintro rfl
     refine ⟨b.isPos_of_mem_support hi, ?_⟩
-    rw [weylGroupToPerm_ofIdx_apply, ← mem_negRoots,
+    rw [RootPairing.weylGroupToPerm_ofIdx_apply, ← mem_negRoots,
       reflectionPerm_self_mem_negRoots_iff_mem_posRoots, mem_posRoots]
     exact b.isPos_of_mem_support hi
 

--- a/TauCeti/LinearAlgebra/RootSystem/Inversions/Exchange.lean
+++ b/TauCeti/LinearAlgebra/RootSystem/Inversions/Exchange.lean
@@ -57,29 +57,33 @@ private lemma reflectionPerm_ne_of_isPos {i j : ι} (hi : i ∈ b.support)
 
 variable [Finite ι] [IsDomain R] [P.IsCrystallographic] [P.IsReduced]
 
+/-- Membership criterion for the punctured inversion sets: a positive root other than the
+reflecting one stays positive and away from it, so only its image needs to be negative. -/
+private lemma reflectionPerm_mem_inversions_sdiff (v : P.weylGroup) {i j : ι}
+    (hi : i ∈ b.support) (hj : b.IsPos j) (hji : j ≠ i)
+    (hneg : ¬ b.IsPos (P.weylGroupToPerm v (P.reflectionPerm i j))) :
+    P.reflectionPerm i j ∈ inversions P b v \ {i} :=
+  ⟨(mem_inversions P b _ _).mpr ⟨hj.reflectionPerm hi hji, hneg⟩, by
+    simpa using reflectionPerm_ne_of_isPos P b hi hj⟩
+
 /-- Away from the distinguished simple root, reflection bijects the inversion sets before and
 after right multiplication by that simple reflection. -/
 private noncomputable def puncturedInversionsEquiv {i : ι} (hi : i ∈ b.support) :
     ↥(inversions P b (w * RootPairing.weylGroup.ofIdx P i) \ {i}) ≃
       ↥(inversions P b w \ {i}) where
-  toFun x := by
-    refine ⟨P.reflectionPerm i x.1, ?_⟩
+  toFun x := ⟨P.reflectionPerm i x.1, by
     obtain ⟨hx, hxi⟩ := x.2
     have hx' := (mem_inversions P b _ _).mp hx
-    have hx_ne : x.1 ≠ i := by simpa using hxi
-    refine ⟨(mem_inversions P b _ _).mpr ⟨hx'.1.reflectionPerm hi hx_ne, ?_⟩, ?_⟩
-    · rw [RootPairing.weylGroupToPerm_mul_ofIdx_apply] at hx'
-      exact hx'.2
-    · simpa using reflectionPerm_ne_of_isPos P b hi hx'.1
-  invFun x := by
-    refine ⟨P.reflectionPerm i x.1, ?_⟩
+    refine reflectionPerm_mem_inversions_sdiff P b w hi hx'.1 (by simpa using hxi) ?_
+    rw [RootPairing.weylGroupToPerm_mul_ofIdx_apply] at hx'
+    exact hx'.2⟩
+  invFun x := ⟨P.reflectionPerm i x.1, by
     obtain ⟨hx, hxi⟩ := x.2
     have hx' := (mem_inversions P b _ _).mp hx
-    have hx_ne : x.1 ≠ i := by simpa using hxi
-    refine ⟨(mem_inversions P b _ _).mpr ⟨hx'.1.reflectionPerm hi hx_ne, ?_⟩, ?_⟩
-    · rw [RootPairing.weylGroupToPerm_mul_ofIdx_apply, P.reflectionPerm_self]
-      exact hx'.2
-    · simpa using reflectionPerm_ne_of_isPos P b hi hx'.1
+    refine reflectionPerm_mem_inversions_sdiff P b (w * RootPairing.weylGroup.ofIdx P i) hi
+      hx'.1 (by simpa using hxi) ?_
+    rw [RootPairing.weylGroupToPerm_mul_ofIdx_apply, P.reflectionPerm_self]
+    exact hx'.2⟩
   left_inv x := by
     apply Subtype.ext
     exact P.reflectionPerm_self i x.1
@@ -133,8 +137,5 @@ theorem ncard_inversions_mul_ofIdx {i : ι} (hi : i ∈ b.support) :
       _ = (inversions P b w \ {i}).ncard + 1 := congrArg (· + 1) hpunctured
       _ = (inversions P b w).ncard + 1 := by
         rw [Set.sdiff_singleton_eq_self hiw]
-
-@[deprecated (since := "2026-07-27")]
-alias inversions_ncard_mul_ofIdx := ncard_inversions_mul_ofIdx
 
 end TauCeti

--- a/TauCeti/LinearAlgebra/RootSystem/Inversions/Exchange.lean
+++ b/TauCeti/LinearAlgebra/RootSystem/Inversions/Exchange.lean
@@ -1,0 +1,165 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+module
+
+public import TauCeti.LinearAlgebra.RootSystem.Inversions.Basic
+
+public section
+
+/-!
+# The root-level exchange step
+
+Right multiplication by a simple reflection changes the number of positive roots sent to
+negative roots by exactly one. Reflection bijects the two inversion sets away from its defining
+simple root, while that root itself changes sides.
+
+This is the exchange step that underlies the Coxeter presentation of a Weyl group and the later
+identification of Coxeter length with the number of inversions.
+
+## Main results
+
+* `TauCeti.mem_inversions_mul_ofIdx_iff_not_mem` shows that the defining simple root toggles
+  membership in the inversion set.
+* `TauCeti.inversions_ncard_mul_ofIdx` proves that the inversion count changes by one.
+
+## References
+
+This file implements the exchange target in Layer 1 of
+`TauCetiRoadmap/RepresentationTheory/RootSystems/README.md`. The mathematical convention follows
+Bourbaki, *Lie Groups and Lie Algebras*, Chapters 4--6.
+-/
+
+namespace TauCeti
+
+universe u v w x
+
+variable {ι : Type u} {R : Type v} {M : Type w} {N : Type x}
+  [CommRing R] [AddCommGroup M] [Module R M] [AddCommGroup N] [Module R N]
+  (P : RootPairing ι R M N) (w : P.weylGroup)
+
+/-- Right multiplication by a simple reflection acts by first reflecting the root index. -/
+lemma weylGroupToPerm_mul_ofIdx_apply (i j : ι) :
+    P.weylGroupToPerm (w * RootPairing.weylGroup.ofIdx P i) j =
+      P.weylGroupToPerm w (P.reflectionPerm i j) := by
+  rw [map_mul]
+  exact congrArg (P.weylGroupToPerm w)
+    (weylGroupToPerm_ofIdx_apply P i j)
+
+/-- The Weyl-group action on root indices commutes with root negation. -/
+lemma weylGroupToPerm_neg (j : ι) :
+    letI := P.indexNeg
+    P.weylGroupToPerm w (-j) = -(P.weylGroupToPerm w j) := by
+  letI := P.indexNeg
+  apply P.root.injective
+  calc
+    P.root (P.weylGroupToPerm w (-j)) = w • P.root (-j) :=
+      (P.weylGroup_apply_root w (-j)).symm
+    _ = w • (-P.root j) := by rw [show P.root (-j) = -P.root j by simp]
+    _ = -(w • P.root j) := by rw [smul_neg]
+    _ = -P.root (P.weylGroupToPerm w j) :=
+      congrArg Neg.neg (P.weylGroup_apply_root w j)
+    _ = P.root (-(P.weylGroupToPerm w j)) := by
+      rw [show -(P.weylGroupToPerm w j) =
+        P.reflectionPerm (P.weylGroupToPerm w j) (P.weylGroupToPerm w j) from rfl,
+        P.root_reflectionPerm, P.reflection_apply_self]
+
+variable [CharZero R] (b : P.Base)
+
+private lemma reflectionPerm_ne_of_isPos {i j : ι} (hi : i ∈ b.support)
+    (hj : b.IsPos j) :
+    P.reflectionPerm i j ≠ i := by
+  intro h
+  have hji : j = P.reflectionPerm i i := by
+    calc
+      j = P.reflectionPerm i (P.reflectionPerm i j) :=
+        (P.reflectionPerm_self i j).symm
+      _ = P.reflectionPerm i i := congrArg (P.reflectionPerm i) h
+  have hneg : ¬ b.IsPos (P.reflectionPerm i i) := by
+    letI := P.indexNeg
+    rw [show P.reflectionPerm i i = -i from rfl,
+      RootPairing.Base.IsPos.neg_iff_not]
+    exact not_not_intro (b.isPos_of_mem_support hi)
+  exact hneg (hji ▸ hj)
+
+variable [Finite ι] [IsDomain R] [P.IsCrystallographic] [P.IsReduced]
+
+/-- Away from the distinguished simple root, reflection bijects the inversion sets before and
+after right multiplication by that simple reflection. -/
+private noncomputable def puncturedInversionsEquiv {i : ι} (hi : i ∈ b.support) :
+    ↥(inversions P b (w * RootPairing.weylGroup.ofIdx P i) \ {i}) ≃
+      ↥(inversions P b w \ {i}) where
+  toFun x := by
+    refine ⟨P.reflectionPerm i x.1, ?_⟩
+    obtain ⟨hx, hxi⟩ := x.2
+    have hx' := (mem_inversions P b _ _).mp hx
+    have hx_ne : x.1 ≠ i := by simpa using hxi
+    refine ⟨(mem_inversions P b _ _).mpr ⟨hx'.1.reflectionPerm hi hx_ne, ?_⟩, ?_⟩
+    · rw [weylGroupToPerm_mul_ofIdx_apply] at hx'
+      exact hx'.2
+    · simpa using reflectionPerm_ne_of_isPos P b hi hx'.1
+  invFun x := by
+    refine ⟨P.reflectionPerm i x.1, ?_⟩
+    obtain ⟨hx, hxi⟩ := x.2
+    have hx' := (mem_inversions P b _ _).mp hx
+    have hx_ne : x.1 ≠ i := by simpa using hxi
+    refine ⟨(mem_inversions P b _ _).mpr ⟨hx'.1.reflectionPerm hi hx_ne, ?_⟩, ?_⟩
+    · rw [weylGroupToPerm_mul_ofIdx_apply, P.reflectionPerm_self]
+      exact hx'.2
+    · simpa using reflectionPerm_ne_of_isPos P b hi hx'.1
+  left_inv x := by
+    apply Subtype.ext
+    exact P.reflectionPerm_self i x.1
+  right_inv x := by
+    apply Subtype.ext
+    exact P.reflectionPerm_self i x.1
+
+omit [Finite ι] [IsDomain R] [P.IsCrystallographic] [P.IsReduced] in
+/-- Right multiplication by a simple reflection toggles whether its defining simple root is an
+inversion. -/
+lemma mem_inversions_mul_ofIdx_iff_not_mem {i : ι} (hi : i ∈ b.support) :
+    i ∈ inversions P b (w * RootPairing.weylGroup.ofIdx P i) ↔
+      i ∉ inversions P b w := by
+  classical
+  letI := P.indexNeg
+  simp only [mem_inversions, b.isPos_of_mem_support hi, true_and,
+    weylGroupToPerm_mul_ofIdx_apply, show P.reflectionPerm i i = -i from rfl,
+    weylGroupToPerm_neg, RootPairing.Base.IsPos.neg_iff_not]
+
+/-- Right multiplication by a simple reflection changes the number of inversions by exactly
+one. -/
+theorem inversions_ncard_mul_ofIdx {i : ι} (hi : i ∈ b.support) :
+    (inversions P b (w * RootPairing.weylGroup.ofIdx P i)).ncard =
+        (inversions P b w).ncard + 1 ∨
+      (inversions P b (w * RootPairing.weylGroup.ofIdx P i)).ncard + 1 =
+        (inversions P b w).ncard := by
+  classical
+  have hpunctured :
+      (inversions P b (w * RootPairing.weylGroup.ofIdx P i) \ {i}).ncard =
+        (inversions P b w \ {i}).ncard :=
+    Set.ncard_congr' (puncturedInversionsEquiv P w b hi)
+  by_cases hiw : i ∈ inversions P b w
+  · right
+    have hiws : i ∉ inversions P b (w * RootPairing.weylGroup.ofIdx P i) := by
+      intro h
+      exact (mem_inversions_mul_ofIdx_iff_not_mem P w b hi).mp h hiw
+    calc
+      (inversions P b (w * RootPairing.weylGroup.ofIdx P i)).ncard + 1 =
+          (inversions P b (w * RootPairing.weylGroup.ofIdx P i) \ {i}).ncard + 1 := by
+            rw [Set.sdiff_singleton_eq_self hiws]
+      _ = (inversions P b w \ {i}).ncard + 1 := congrArg (· + 1) hpunctured
+      _ = (inversions P b w).ncard :=
+        Set.ncard_sdiff_singleton_add_one hiw
+  · left
+    have hiws : i ∈ inversions P b (w * RootPairing.weylGroup.ofIdx P i) :=
+      (mem_inversions_mul_ofIdx_iff_not_mem P w b hi).mpr hiw
+    calc
+      (inversions P b (w * RootPairing.weylGroup.ofIdx P i)).ncard =
+          (inversions P b (w * RootPairing.weylGroup.ofIdx P i) \ {i}).ncard + 1 :=
+        (Set.ncard_sdiff_singleton_add_one hiws).symm
+      _ = (inversions P b w \ {i}).ncard + 1 := congrArg (· + 1) hpunctured
+      _ = (inversions P b w).ncard + 1 := by
+        rw [Set.sdiff_singleton_eq_self hiw]
+
+end TauCeti

--- a/TauCeti/LinearAlgebra/RootSystem/Inversions/Exchange.lean
+++ b/TauCeti/LinearAlgebra/RootSystem/Inversions/Exchange.lean
@@ -134,4 +134,7 @@ theorem ncard_inversions_mul_ofIdx {i : ι} (hi : i ∈ b.support) :
       _ = (inversions P b w).ncard + 1 := by
         rw [Set.sdiff_singleton_eq_self hiw]
 
+@[deprecated (since := "2026-07-27")]
+alias inversions_ncard_mul_ofIdx := ncard_inversions_mul_ofIdx
+
 end TauCeti

--- a/TauCeti/LinearAlgebra/RootSystem/Inversions/Exchange.lean
+++ b/TauCeti/LinearAlgebra/RootSystem/Inversions/Exchange.lean
@@ -22,7 +22,7 @@ identification of Coxeter length with the number of inversions.
 
 * `TauCeti.mem_inversions_mul_ofIdx_iff_not_mem` shows that the defining simple root toggles
   membership in the inversion set.
-* `TauCeti.inversions_ncard_mul_ofIdx` proves that the inversion count changes by one.
+* `TauCeti.ncard_inversions_mul_ofIdx` proves that the inversion count changes by one.
 
 ## References
 
@@ -39,32 +39,6 @@ variable {ι : Type u} {R : Type v} {M : Type w} {N : Type x}
   [CommRing R] [AddCommGroup M] [Module R M] [AddCommGroup N] [Module R N]
   (P : RootPairing ι R M N) (w : P.weylGroup)
 
-/-- Right multiplication by a simple reflection acts by first reflecting the root index. -/
-lemma weylGroupToPerm_mul_ofIdx_apply (i j : ι) :
-    P.weylGroupToPerm (w * RootPairing.weylGroup.ofIdx P i) j =
-      P.weylGroupToPerm w (P.reflectionPerm i j) := by
-  rw [map_mul]
-  exact congrArg (P.weylGroupToPerm w)
-    (weylGroupToPerm_ofIdx_apply P i j)
-
-/-- The Weyl-group action on root indices commutes with root negation. -/
-lemma weylGroupToPerm_neg (j : ι) :
-    letI := P.indexNeg
-    P.weylGroupToPerm w (-j) = -(P.weylGroupToPerm w j) := by
-  letI := P.indexNeg
-  apply P.root.injective
-  calc
-    P.root (P.weylGroupToPerm w (-j)) = w • P.root (-j) :=
-      (P.weylGroup_apply_root w (-j)).symm
-    _ = w • (-P.root j) := by rw [show P.root (-j) = -P.root j by simp]
-    _ = -(w • P.root j) := by rw [smul_neg]
-    _ = -P.root (P.weylGroupToPerm w j) :=
-      congrArg Neg.neg (P.weylGroup_apply_root w j)
-    _ = P.root (-(P.weylGroupToPerm w j)) := by
-      rw [show -(P.weylGroupToPerm w j) =
-        P.reflectionPerm (P.weylGroupToPerm w j) (P.weylGroupToPerm w j) from rfl,
-        P.root_reflectionPerm, P.reflection_apply_self]
-
 variable [CharZero R] (b : P.Base)
 
 private lemma reflectionPerm_ne_of_isPos {i j : ι} (hi : i ∈ b.support)
@@ -77,9 +51,7 @@ private lemma reflectionPerm_ne_of_isPos {i j : ι} (hi : i ∈ b.support)
         (P.reflectionPerm_self i j).symm
       _ = P.reflectionPerm i i := congrArg (P.reflectionPerm i) h
   have hneg : ¬ b.IsPos (P.reflectionPerm i i) := by
-    letI := P.indexNeg
-    rw [show P.reflectionPerm i i = -i from rfl,
-      RootPairing.Base.IsPos.neg_iff_not]
+    rw [isPos_reflectionPerm_self_iff_mem_negRoots, mem_negRoots]
     exact not_not_intro (b.isPos_of_mem_support hi)
   exact hneg (hji ▸ hj)
 
@@ -96,7 +68,7 @@ private noncomputable def puncturedInversionsEquiv {i : ι} (hi : i ∈ b.suppor
     have hx' := (mem_inversions P b _ _).mp hx
     have hx_ne : x.1 ≠ i := by simpa using hxi
     refine ⟨(mem_inversions P b _ _).mpr ⟨hx'.1.reflectionPerm hi hx_ne, ?_⟩, ?_⟩
-    · rw [weylGroupToPerm_mul_ofIdx_apply] at hx'
+    · rw [RootPairing.weylGroupToPerm_mul_ofIdx_apply] at hx'
       exact hx'.2
     · simpa using reflectionPerm_ne_of_isPos P b hi hx'.1
   invFun x := by
@@ -105,7 +77,7 @@ private noncomputable def puncturedInversionsEquiv {i : ι} (hi : i ∈ b.suppor
     have hx' := (mem_inversions P b _ _).mp hx
     have hx_ne : x.1 ≠ i := by simpa using hxi
     refine ⟨(mem_inversions P b _ _).mpr ⟨hx'.1.reflectionPerm hi hx_ne, ?_⟩, ?_⟩
-    · rw [weylGroupToPerm_mul_ofIdx_apply, P.reflectionPerm_self]
+    · rw [RootPairing.weylGroupToPerm_mul_ofIdx_apply, P.reflectionPerm_self]
       exact hx'.2
     · simpa using reflectionPerm_ne_of_isPos P b hi hx'.1
   left_inv x := by
@@ -124,12 +96,12 @@ lemma mem_inversions_mul_ofIdx_iff_not_mem {i : ι} (hi : i ∈ b.support) :
   classical
   letI := P.indexNeg
   simp only [mem_inversions, b.isPos_of_mem_support hi, true_and,
-    weylGroupToPerm_mul_ofIdx_apply, show P.reflectionPerm i i = -i from rfl,
-    weylGroupToPerm_neg, RootPairing.Base.IsPos.neg_iff_not]
+    RootPairing.weylGroupToPerm_mul_ofIdx_apply, ← RootPairing.indexNeg_neg,
+    RootPairing.weylGroupToPerm_neg, RootPairing.Base.IsPos.neg_iff_not]
 
 /-- Right multiplication by a simple reflection changes the number of inversions by exactly
 one. -/
-theorem inversions_ncard_mul_ofIdx {i : ι} (hi : i ∈ b.support) :
+theorem ncard_inversions_mul_ofIdx {i : ι} (hi : i ∈ b.support) :
     (inversions P b (w * RootPairing.weylGroup.ofIdx P i)).ncard =
         (inversions P b w).ncard + 1 ∨
       (inversions P b (w * RootPairing.weylGroup.ofIdx P i)).ncard + 1 =

--- a/TauCeti/LinearAlgebra/RootSystem/WeylGroup.lean
+++ b/TauCeti/LinearAlgebra/RootSystem/WeylGroup.lean
@@ -9,16 +9,19 @@ public import Mathlib.Data.Finite.Perm
 public import Mathlib.LinearAlgebra.RootSystem.WeylGroup
 
 /-!
-# Faithful permutation actions of Weyl groups
+# Permutation actions of Weyl groups
 
 This file proves that the action of the automorphism group of a root system on its root indices is
 faithful.  Consequently, every subgroup of that automorphism group, and in particular the Weyl
-group, is finite when the root index type is finite.
+group, is finite when the root index type is finite.  It also records how that action evaluates on
+simple reflections and how it interacts with root negation.
 
 ## Main results
 
 * `TauCeti.RootPairing.Equiv.indexHom_injective` says that an automorphism of a root system is
   determined by its permutation of the roots.
+* `TauCeti.RootPairing.weylGroupToPerm_ofIdx_apply` evaluates the action of a simple reflection.
+* `TauCeti.RootPairing.weylGroupToPerm_neg` says the action commutes with root negation.
 * `TauCeti.RootPairing.finite_subgroup_aut` proves that every subgroup of the automorphism group of
   a finite root system is finite.
 * `TauCeti.RootPairing.finite_weylGroup` is the resulting finiteness theorem for the Weyl group.
@@ -76,6 +79,41 @@ theorem weylGroupToPerm_injective_of_span_eq_top
 /-- The action of the Weyl group on root indices is faithful. -/
 theorem weylGroupToPerm_injective [P.IsRootSystem] : Function.Injective P.weylGroupToPerm :=
   (Equiv.indexHom_injective P).comp Subtype.val_injective
+
+/-- The Weyl-group permutation of a simple reflection is the corresponding root-index
+reflection. -/
+lemma weylGroupToPerm_ofIdx_apply (i j : ι) :
+    P.weylGroupToPerm (_root_.RootPairing.weylGroup.ofIdx P i) j =
+      P.reflectionPerm i j := by
+  -- Mathlib exposes the underlying reflection equivalence, but not its restriction to the
+  -- Weyl group. Unfolding just those two wrappers connects the APIs.
+  change (_root_.RootPairing.Equiv.reflection P i).indexEquiv j = P.reflectionPerm i j
+  exact congrArg (fun e : ι ≃ ι => e j)
+    (_root_.RootPairing.Equiv.reflection_indexEquiv P i)
+
+/-- Right multiplication by a simple reflection acts by first reflecting the root index. -/
+lemma weylGroupToPerm_mul_ofIdx_apply (w : P.weylGroup) (i j : ι) :
+    P.weylGroupToPerm (w * _root_.RootPairing.weylGroup.ofIdx P i) j =
+      P.weylGroupToPerm w (P.reflectionPerm i j) := by
+  rw [map_mul]
+  exact congrArg (P.weylGroupToPerm w) (weylGroupToPerm_ofIdx_apply P i j)
+
+/-- The Weyl-group action on root indices commutes with root negation. -/
+lemma weylGroupToPerm_neg (w : P.weylGroup) (j : ι) :
+    letI := P.indexNeg
+    P.weylGroupToPerm w (-j) = -(P.weylGroupToPerm w j) := by
+  letI := P.indexNeg
+  apply P.root.injective
+  calc
+    P.root (P.weylGroupToPerm w (-j)) = w • P.root (-j) :=
+      (P.weylGroup_apply_root w (-j)).symm
+    _ = w • (-P.root j) := by
+      rw [_root_.RootPairing.indexNeg_neg, P.root_reflectionPerm, P.reflection_apply_self]
+    _ = -(w • P.root j) := smul_neg _ _
+    _ = -P.root (P.weylGroupToPerm w j) :=
+      congrArg Neg.neg (P.weylGroup_apply_root w j)
+    _ = P.root (-(P.weylGroupToPerm w j)) := by
+      rw [_root_.RootPairing.indexNeg_neg, P.root_reflectionPerm, P.reflection_apply_self]
 
 variable [Finite ι]
 


### PR DESCRIPTION
This PR proves the root-level exchange step for Weyl-group inversion sets: right multiplication by a simple reflection changes the inversion count by exactly one. Establish the result by constructing the reflection equivalence between the two inversion sets away from the defining simple root, then prove that this root itself toggles membership.

This advances `TauCetiRoadmap/RepresentationTheory/RootSystems/README.md`, Layer 1, item “Inversion sets and the exchange step,” specifically the target `inversions_ncard_mul_ofIdx`. It is the lowest-hanging distinct continuation because positive and negative roots, inversion sets, and finite Weyl groups have merged, no open RepresentationTheory PR covers exchange, and this is the next stated dependency for generation and the Coxeter presentation.

Reuse Mathlib’s `RootPairing.Base.IsPos.reflectionPerm`, `RootPairing.Base.IsPos.neg_iff_not`, `RootPairing.weylGroup_apply_root`, `Set.ncard_congr'`, and `Set.ncard_sdiff_singleton_add_one`; vendor no Mathlib infrastructure and adapt no supplementary-source material. Follow Bourbaki, *Lie Groups and Lie Algebras*, Chapters 4–6, as cited by the roadmap.

Add `TauCeti/LinearAlgebra/RootSystem/Inversions/Exchange.lean` (165 lines) and move the foundational inversion-set module under the required prefix directory:

| Old module | New module |
| --- | --- |
| `TauCeti.LinearAlgebra.RootSystem.Inversions` | `TauCeti.LinearAlgebra.RootSystem.Inversions.Basic` |

`lake exe cache get` reports `No files to download` and `Already decompressed 8640 file(s)`. `lake build` reports `Build completed successfully (5546 jobs).` `lake exe axioms` reports `axioms: audited 12509 TauCeti declaration(s); all within the allowlist [propext, Classical.choice, Quot.sound].`

<!--tauceti-target:v1 {"focus":"RepresentationTheory","id":"inversions-ncard-mul-ofidx"}-->

🤖 Prepared with Codex
