### PR TITLE
feat: connect symmetric-group partition indices

### DIFF
--- a/TauCeti/Combinatorics/Enumerative/Partition/Basic.lean
+++ b/TauCeti/Combinatorics/Enumerative/Partition/Basic.lean
@@ -1,0 +1,60 @@
+/-
+Copyright (c) 2026 Tau Ceti. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Codex
+-/
+module
+
+public import Mathlib.Combinatorics.Enumerative.Partition.Basic
+
+/-!
+# Partitions as decreasing lists of positive parts
+
+Mathlib's `Nat.Partition n` records the parts of a partition of `n` as a multiset.  This file
+provides the equivalence `Nat.Partition.equivSortedParts` between partitions of `n` and weakly
+decreasing lists of positive natural numbers summing to `n`, obtained by sorting the parts.
+-/
+
+public section
+
+namespace TauCeti
+
+namespace Nat.Partition
+
+/-- A partition is equivalent to its decreasing list of positive parts. -/
+@[expose] noncomputable def equivSortedParts (n : ℕ) :
+    n.Partition ≃
+      {w : List ℕ // (w.SortedGE ∧ ∀ x ∈ w, 0 < x) ∧ w.sum = n} where
+  toFun p :=
+    ⟨p.parts.sort (· ≥ ·),
+      ⟨(Multiset.pairwise_sort p.parts (· ≥ ·)).sortedGE,
+        fun x hx => p.parts_pos ((Multiset.mem_sort (r := (· ≥ ·))).mp hx)⟩, by
+        rw [← Multiset.sum_coe, Multiset.sort_eq, p.parts_sum]⟩
+  invFun w :=
+    ⟨w.1, fun {_} hx => w.2.1.2 _ hx, by
+      simpa only [Multiset.sum_coe] using w.2.2⟩
+  left_inv p := by
+    apply Nat.Partition.ext
+    exact Multiset.sort_eq p.parts (· ≥ ·)
+  right_inv w := by
+    apply Subtype.ext
+    exact List.Perm.eq_of_sortedGE
+      (Multiset.pairwise_sort (↑w.1 : Multiset ℕ) (· ≥ ·)).sortedGE w.2.1.1
+      (Multiset.coe_eq_coe.mp (Multiset.sort_eq (↑w.1 : Multiset ℕ) (· ≥ ·)))
+
+/-- Sorting the parts is the forward map of `equivSortedParts`. -/
+@[simp]
+theorem equivSortedParts_apply_parts (n : ℕ) (p : n.Partition) :
+    (equivSortedParts n p).1 = p.parts.sort (· ≥ ·) := by
+  simp [equivSortedParts]
+
+/-- The inverse of `equivSortedParts` has the given list as its multiset of parts. -/
+@[simp]
+theorem equivSortedParts_symm_apply_parts (n : ℕ)
+    (w : {w : List ℕ // (w.SortedGE ∧ ∀ x ∈ w, 0 < x) ∧ w.sum = n}) :
+    ((equivSortedParts n).symm w).parts = w.1 := by
+  simp [equivSortedParts]
+
+end Nat.Partition
+
+end TauCeti

--- a/TauCeti/Combinatorics/Enumerative/Partition/Basic.lean
+++ b/TauCeti/Combinatorics/Enumerative/Partition/Basic.lean
@@ -22,7 +22,7 @@ namespace TauCeti
 namespace Nat.Partition
 
 /-- A partition is equivalent to its decreasing list of positive parts. -/
-@[expose] noncomputable def equivSortedParts (n : ℕ) :
+noncomputable def equivSortedParts (n : ℕ) :
     n.Partition ≃
       {w : List ℕ // (w.SortedGE ∧ ∀ x ∈ w, 0 < x) ∧ w.sum = n} where
   toFun p :=
@@ -44,7 +44,7 @@ namespace Nat.Partition
 
 /-- Sorting the parts is the forward map of `equivSortedParts`. -/
 @[simp]
-theorem equivSortedParts_apply_parts (n : ℕ) (p : n.Partition) :
+theorem equivSortedParts_apply_coe (n : ℕ) (p : n.Partition) :
     (equivSortedParts n p).1 = p.parts.sort (· ≥ ·) := by
   simp [equivSortedParts]
 

--- a/TauCeti/Combinatorics/Young/Partitions.lean
+++ b/TauCeti/Combinatorics/Young/Partitions.lean
@@ -1,0 +1,86 @@
+/-
+Copyright (c) 2026 Tau Ceti. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Codex
+-/
+module
+
+public import TauCeti.Combinatorics.Enumerative.Partition.Basic
+public import TauCeti.Combinatorics.Young.YoungDiagram
+
+/-!
+# Partitions and Young diagrams
+
+This file gives the equivalence between partitions of `n` and Young diagrams with `n` cells.  It
+sorts the multiset of parts into decreasing row lengths, using
+`TauCeti.Nat.Partition.equivSortedParts` and `TauCeti.YoungDiagram.sum_rowLens`.
+-/
+
+public section
+
+namespace TauCeti
+
+/-- Partitions of `n` are equivalent to Young diagrams with `n` cells. -/
+noncomputable def partitionEquivYoungDiagram (n : ℕ) :
+    n.Partition ≃ {μ : YoungDiagram // μ.card = n} :=
+  (Nat.Partition.equivSortedParts n).trans
+    ((Equiv.subtypeSubtypeEquivSubtypeInter
+      (fun w : List ℕ => w.SortedGE ∧ ∀ x ∈ w, 0 < x)
+        (fun w => w.sum = n)).symm.trans
+      (YoungDiagram.equivListRowLens.symm.subtypeEquiv
+        (q := fun μ => μ.card = n) fun w => by
+          rw [← YoungDiagram.sum_rowLens, _root_.YoungDiagram.equivListRowLens_symm_apply,
+            _root_.YoungDiagram.rowLens_ofRowLens_eq_self w.2.2]))
+
+/-- The Young diagram associated to a partition is the one built from its decreasing parts by
+`YoungDiagram.ofRowLens`. -/
+theorem partitionEquivYoungDiagram_apply_coe (n : ℕ) (p : n.Partition)
+    (hw : (p.parts.sort (· ≥ ·)).SortedGE) :
+    (partitionEquivYoungDiagram n p).1 =
+      _root_.YoungDiagram.ofRowLens (p.parts.sort (· ≥ ·)) hw := by
+  simp only [partitionEquivYoungDiagram, Equiv.trans_apply, Equiv.subtypeEquiv_apply,
+    _root_.YoungDiagram.equivListRowLens_symm_apply]
+  have hinter :
+      ↑↑((Equiv.subtypeSubtypeEquivSubtypeInter
+          (fun w : List ℕ => w.SortedGE ∧ ∀ x ∈ w, 0 < x)
+          (fun w => w.sum = n)).symm (Nat.Partition.equivSortedParts n p)) =
+        (Nat.Partition.equivSortedParts n p).1 := by
+    symm
+    simpa only [Equiv.apply_symm_apply] using
+      (Equiv.subtypeSubtypeEquivSubtypeInter_apply_coe
+        (fun w : List ℕ => w.SortedGE ∧ ∀ x ∈ w, 0 < x)
+        (fun w => w.sum = n)
+        ((Equiv.subtypeSubtypeEquivSubtypeInter
+          (fun w : List ℕ => w.SortedGE ∧ ∀ x ∈ w, 0 < x)
+          (fun w => w.sum = n)).symm (Nat.Partition.equivSortedParts n p)))
+  have hlists := hinter.trans (Nat.Partition.equivSortedParts_apply_coe n p)
+  apply _root_.YoungDiagram.ext
+  ext c
+  rw [_root_.YoungDiagram.mem_cells, _root_.YoungDiagram.mem_cells,
+    _root_.YoungDiagram.mem_ofRowLens, _root_.YoungDiagram.mem_ofRowLens]
+  rw [hlists]
+
+/-- The Young diagram associated to a partition has its decreasing parts as row lengths. -/
+@[simp]
+theorem partitionEquivYoungDiagram_apply_rowLens (n : ℕ) (p : n.Partition) :
+    (partitionEquivYoungDiagram n p).1.rowLens = p.parts.sort (· ≥ ·) := by
+  rw [partitionEquivYoungDiagram_apply_coe n p
+    (Multiset.pairwise_sort p.parts (· ≥ ·)).sortedGE]
+  exact _root_.YoungDiagram.rowLens_ofRowLens_eq_self fun x hx =>
+    p.parts_pos ((Multiset.mem_sort (r := (· ≥ ·))).mp hx)
+
+/-- Reading the row lengths of a sized Young diagram recovers the partition's parts. -/
+@[simp]
+theorem partitionEquivYoungDiagram_symm_apply_parts (n : ℕ)
+    (μ : {μ : YoungDiagram // μ.card = n}) :
+    ((partitionEquivYoungDiagram n).symm μ).parts = μ.1.rowLens := by
+  have h := partitionEquivYoungDiagram_apply_rowLens n
+    ((partitionEquivYoungDiagram n).symm μ)
+  rw [Equiv.apply_symm_apply] at h
+  calc
+    ((partitionEquivYoungDiagram n).symm μ).parts =
+        ↑(((partitionEquivYoungDiagram n).symm μ).parts.sort (· ≥ ·)) :=
+      (Multiset.sort_eq _ _).symm
+    _ = ↑μ.1.rowLens := congrArg (fun w : List ℕ => (↑w : Multiset ℕ)) h.symm
+
+end TauCeti

--- a/TauCeti/Combinatorics/Young/Partitions.lean
+++ b/TauCeti/Combinatorics/Young/Partitions.lean
@@ -34,10 +34,10 @@ noncomputable def partitionEquivYoungDiagram (n : ℕ) :
 
 /-- The Young diagram associated to a partition is the one built from its decreasing parts by
 `YoungDiagram.ofRowLens`. -/
-theorem partitionEquivYoungDiagram_apply_coe (n : ℕ) (p : n.Partition)
-    (hw : (p.parts.sort (· ≥ ·)).SortedGE) :
+theorem partitionEquivYoungDiagram_apply_coe (n : ℕ) (p : n.Partition) :
     (partitionEquivYoungDiagram n p).1 =
-      _root_.YoungDiagram.ofRowLens (p.parts.sort (· ≥ ·)) hw := by
+      _root_.YoungDiagram.ofRowLens (p.parts.sort (· ≥ ·))
+        (Multiset.pairwise_sort p.parts (· ≥ ·)).sortedGE := by
   simp only [partitionEquivYoungDiagram, Equiv.trans_apply, Equiv.subtypeEquiv_apply,
     _root_.YoungDiagram.equivListRowLens_symm_apply]
   have hinter :
@@ -64,8 +64,7 @@ theorem partitionEquivYoungDiagram_apply_coe (n : ℕ) (p : n.Partition)
 @[simp]
 theorem partitionEquivYoungDiagram_apply_rowLens (n : ℕ) (p : n.Partition) :
     (partitionEquivYoungDiagram n p).1.rowLens = p.parts.sort (· ≥ ·) := by
-  rw [partitionEquivYoungDiagram_apply_coe n p
-    (Multiset.pairwise_sort p.parts (· ≥ ·)).sortedGE]
+  rw [partitionEquivYoungDiagram_apply_coe n p]
   exact _root_.YoungDiagram.rowLens_ofRowLens_eq_self fun x hx =>
     p.parts_pos ((Multiset.mem_sort (r := (· ≥ ·))).mp hx)
 

--- a/TauCeti/Combinatorics/Young/YoungDiagram.lean
+++ b/TauCeti/Combinatorics/Young/YoungDiagram.lean
@@ -1,0 +1,47 @@
+/-
+Copyright (c) 2026 Tau Ceti. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Codex
+-/
+module
+
+public import Mathlib.Algebra.BigOperators.Group.Finset.Basic
+public import Mathlib.Combinatorics.Young.YoungDiagram
+
+/-!
+# The row lengths of a Young diagram add up to its size
+
+Mathlib's `YoungDiagram.rowLens` records the lengths of the rows of a Young diagram.  This file
+proves that these lengths sum to the number of cells of the diagram.
+-/
+
+public section
+
+namespace TauCeti
+
+namespace YoungDiagram
+
+/-- The sum of the row lengths of a Young diagram is its number of cells. -/
+@[simp]
+theorem sum_rowLens (μ : YoungDiagram) : μ.rowLens.sum = μ.card := by
+  have hrange : μ.rowLens.sum = ∑ i ∈ Finset.range (μ.colLen 0), μ.rowLen i := by
+    simp [_root_.YoungDiagram.rowLens, Finset.sum, Finset.range_val, Multiset.range]
+  rw [hrange]
+  symm
+  calc
+    μ.card =
+        ∑ i ∈ Finset.range (μ.colLen 0),
+          (μ.cells.filter fun c => c.fst = i).card := by
+      apply Finset.card_eq_sum_card_fiberwise
+      intro c hc
+      simpa using
+        (_root_.YoungDiagram.mem_iff_lt_colLen.mp hc).trans_le
+          (μ.colLen_anti 0 c.snd c.snd.zero_le)
+    _ = ∑ i ∈ Finset.range (μ.colLen 0), μ.rowLen i := by
+      apply Finset.sum_congr rfl
+      intro i _
+      exact (μ.rowLen_eq_card (i := i)).symm
+
+end YoungDiagram
+
+end TauCeti

--- a/TauCeti/Combinatorics/Young/YoungDiagram.lean
+++ b/TauCeti/Combinatorics/Young/YoungDiagram.lean
@@ -24,8 +24,16 @@ namespace YoungDiagram
 /-- The sum of the row lengths of a Young diagram is its number of cells. -/
 @[simp]
 theorem sum_rowLens (μ : YoungDiagram) : μ.rowLens.sum = μ.card := by
+  have sum_list_range (f : ℕ → ℕ) :
+      ∀ n, ((List.range n).map f).sum = ∑ i ∈ Finset.range n, f i := by
+    intro n
+    induction n with
+    | zero => simp
+    | succ n ih =>
+      rw [List.range_succ, List.map_append, List.sum_append, ih, Finset.sum_range_succ]
+      simp
   have hrange : μ.rowLens.sum = ∑ i ∈ Finset.range (μ.colLen 0), μ.rowLen i := by
-    simp [_root_.YoungDiagram.rowLens, Finset.sum, Finset.range_val, Multiset.range]
+    rw [_root_.YoungDiagram.rowLens, sum_list_range]
   rw [hrange]
   symm
   calc

--- a/TauCeti/RepresentationTheory/Symmetric/Partitions.lean
+++ b/TauCeti/RepresentationTheory/Symmetric/Partitions.lean
@@ -1,0 +1,240 @@
+/-
+Copyright (c) 2026 Tau Ceti. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Codex
+-/
+module
+
+public import Mathlib.Algebra.Group.ConjFinite
+public import Mathlib.Combinatorics.Young.YoungDiagram
+public import Mathlib.GroupTheory.Perm.Cycle.PossibleTypes
+
+/-!
+# Partitions, Young diagrams, and conjugacy classes
+
+This file connects three indexing types used in the representation theory of the symmetric group:
+partitions of `n`, Young diagrams with `n` cells, and conjugacy classes of `Equiv.Perm (Fin n)`.
+
+The equivalence with Young diagrams sorts the multiset of parts into decreasing row lengths.  The
+equivalence with conjugacy classes uses Mathlib's partition of a permutation, including the fixed
+points as parts of size one.
+
+## References
+
+* [Schur--Weyl roadmap](https://github.com/TauCetiProject/TauCetiRoadmap/blob/main/TauCetiRoadmap/RepresentationTheory/SchurWeyl/README.md),
+  Layer 0.
+-/
+
+public section
+
+namespace TauCeti
+
+open Equiv
+
+namespace YoungDiagram
+
+/-- The sum of the row lengths of a Young diagram is its number of cells. -/
+theorem sum_rowLens (μ : YoungDiagram) : μ.rowLens.sum = μ.card := by
+  rw [_root_.YoungDiagram.rowLens]
+  change (∑ i ∈ Finset.range (μ.colLen 0), μ.rowLen i) = μ.card
+  symm
+  calc
+    μ.card =
+        ∑ i ∈ Finset.range (μ.colLen 0),
+          (μ.cells.filter fun c => c.fst = i).card := by
+      apply Finset.card_eq_sum_card_fiberwise
+      intro c hc
+      simpa using
+        (_root_.YoungDiagram.mem_iff_lt_colLen.mp hc).trans_le
+          (μ.colLen_anti 0 c.snd c.snd.zero_le)
+    _ = ∑ i ∈ Finset.range (μ.colLen 0), μ.rowLen i := by
+      apply Finset.sum_congr rfl
+      intro i _
+      exact (μ.rowLen_eq_card (i := i)).symm
+
+end YoungDiagram
+
+namespace Nat.Partition
+
+/-- A partition is equivalent to its decreasing list of positive parts. -/
+noncomputable def equivSortedParts (n : ℕ) :
+    n.Partition ≃
+      {w : List ℕ // (w.SortedGE ∧ ∀ x ∈ w, 0 < x) ∧ w.sum = n} where
+  toFun p :=
+    ⟨p.parts.sort (· ≥ ·),
+      ⟨(Multiset.pairwise_sort p.parts (· ≥ ·)).sortedGE,
+        fun x hx => p.parts_pos ((Multiset.mem_sort (r := (· ≥ ·))).mp hx)⟩, by
+        rw [← Multiset.sum_coe, Multiset.sort_eq, p.parts_sum]⟩
+  invFun w :=
+    ⟨w.1, fun {_} hx => w.2.1.2 _ hx, by
+      simpa only [Multiset.sum_coe] using w.2.2⟩
+  left_inv p := by
+    apply Nat.Partition.ext
+    exact Multiset.sort_eq p.parts (· ≥ ·)
+  right_inv w := by
+    apply Subtype.ext
+    exact List.Perm.eq_of_sortedGE
+      (Multiset.pairwise_sort (↑w.1 : Multiset ℕ) (· ≥ ·)).sortedGE w.2.1.1
+      (Multiset.coe_eq_coe.mp (Multiset.sort_eq (↑w.1 : Multiset ℕ) (· ≥ ·)))
+
+/-- Sorting the parts is the forward map of `equivSortedParts`. -/
+@[simp]
+theorem equivSortedParts_apply_parts (n : ℕ) (p : n.Partition) :
+    (equivSortedParts n p).1 = p.parts.sort (· ≥ ·) := by
+  simp [equivSortedParts]
+
+/-- The inverse of `equivSortedParts` has the given list as its multiset of parts. -/
+@[simp]
+theorem equivSortedParts_symm_apply_parts (n : ℕ)
+    (w : {w : List ℕ // (w.SortedGE ∧ ∀ x ∈ w, 0 < x) ∧ w.sum = n}) :
+    ((equivSortedParts n).symm w).parts = w.1 := by
+  simp [equivSortedParts]
+
+end Nat.Partition
+
+/-- Partitions of `n` are equivalent to Young diagrams with `n` cells. -/
+noncomputable def partitionEquivYoungDiagram (n : ℕ) :
+    n.Partition ≃ {μ : YoungDiagram // μ.card = n} :=
+  (Nat.Partition.equivSortedParts n).trans
+    ((Equiv.subtypeSubtypeEquivSubtypeInter
+      (fun w : List ℕ => w.SortedGE ∧ ∀ x ∈ w, 0 < x)
+        (fun w => w.sum = n)).symm.trans
+      (YoungDiagram.equivListRowLens.symm.subtypeEquiv
+        (q := fun μ => μ.card = n) fun w => by
+          rw [← YoungDiagram.sum_rowLens,
+            show (YoungDiagram.equivListRowLens.symm w).rowLens = w.1 from
+              congrArg Subtype.val (YoungDiagram.equivListRowLens.apply_symm_apply w)]))
+
+/-- The Young diagram associated to a partition has its decreasing parts as row lengths. -/
+@[simp]
+theorem partitionEquivYoungDiagram_apply_rowLens (n : ℕ) (p : n.Partition) :
+    (partitionEquivYoungDiagram n p).1.rowLens = p.parts.sort (· ≥ ·) := by
+  change
+    (_root_.YoungDiagram.ofRowLens (p.parts.sort (· ≥ ·))
+      (Multiset.pairwise_sort p.parts (· ≥ ·)).sortedGE).rowLens =
+      p.parts.sort (· ≥ ·)
+  exact _root_.YoungDiagram.rowLens_ofRowLens_eq_self fun x hx =>
+    p.parts_pos ((Multiset.mem_sort (r := (· ≥ ·))).mp hx)
+
+/-- Reading the row lengths of a sized Young diagram recovers the partition's parts. -/
+@[simp]
+theorem partitionEquivYoungDiagram_symm_apply_parts (n : ℕ)
+    (μ : {μ : YoungDiagram // μ.card = n}) :
+    ((partitionEquivYoungDiagram n).symm μ).parts = μ.1.rowLens := by
+  have h := partitionEquivYoungDiagram_apply_rowLens n
+    ((partitionEquivYoungDiagram n).symm μ)
+  rw [Equiv.apply_symm_apply] at h
+  calc
+    ((partitionEquivYoungDiagram n).symm μ).parts =
+        ↑(((partitionEquivYoungDiagram n).symm μ).parts.sort (· ≥ ·)) :=
+      (Multiset.sort_eq _ _).symm
+    _ = ↑μ.1.rowLens := congrArg (fun w : List ℕ => (↑w : Multiset ℕ)) h.symm
+
+/-- The partition of `n` obtained from a permutation of `Fin n`. -/
+def finPermPartition (n : ℕ) (σ : Equiv.Perm (Fin n)) : n.Partition where
+  parts := σ.partition.parts
+  parts_pos := σ.partition.parts_pos
+  parts_sum := by simpa using σ.partition.parts_sum
+
+/-- Two permutations of `Fin n` have the same sized partition exactly when their Mathlib
+partitions agree. -/
+theorem finPermPartition_eq_iff (n : ℕ) (σ τ : Equiv.Perm (Fin n)) :
+    finPermPartition n σ = finPermPartition n τ ↔ σ.partition = τ.partition := by
+  constructor <;> intro h <;> apply Nat.Partition.ext
+  · simpa only [finPermPartition] using congrArg Nat.Partition.parts h
+  · simpa only [finPermPartition] using congrArg Nat.Partition.parts h
+
+/-- Every partition of `n` is the partition of a permutation of `Fin n`. -/
+theorem exists_perm_partition_eq {n : ℕ} (p : n.Partition) :
+    ∃ σ : Equiv.Perm (Fin n), finPermPartition n σ = p := by
+  let largeParts := p.parts.filter fun a => 2 ≤ a
+  let unitParts := p.parts.filter fun a => ¬2 ≤ a
+  have hsplit : largeParts + unitParts = p.parts := by
+    exact Multiset.filter_add_not (p := fun a : ℕ => 2 ≤ a) p.parts
+  have hunit : unitParts = Multiset.replicate unitParts.card 1 := by
+    apply Multiset.eq_replicate_card.mpr
+    intro a ha
+    have ha' := Multiset.mem_filter.mp ha
+    have hpos := p.parts_pos ha'.1
+    omega
+  have hunitSum : unitParts.sum = unitParts.card := by
+    calc
+      unitParts.sum = (Multiset.replicate unitParts.card 1).sum :=
+        congrArg Multiset.sum hunit
+      _ = unitParts.card := by
+        rw [Multiset.sum_replicate, nsmul_eq_mul, Nat.cast_id, mul_one]
+  have hsum : largeParts.sum + unitParts.card = n := by
+    rw [← p.parts_sum, ← hsplit, Multiset.sum_add, hunitSum]
+  have hlarge : largeParts.sum ≤ Fintype.card (Fin n) := by
+    simp only [Fintype.card_fin]
+    omega
+  have hlarge_mem : ∀ a ∈ largeParts, 2 ≤ a := by
+    intro a ha
+    exact (Multiset.mem_filter.mp ha).2
+  obtain ⟨σ, hσ⟩ :=
+    (Equiv.Perm.exists_with_cycleType_iff (Fin n)).mpr ⟨hlarge, hlarge_mem⟩
+  refine ⟨σ, ?_⟩
+  apply Nat.Partition.ext
+  have hsupport : σ.support.card = largeParts.sum := by
+    rw [← Equiv.Perm.sum_cycleType, hσ]
+  have hremaining : n - largeParts.sum = unitParts.card := by
+    omega
+  change σ.partition.parts = p.parts
+  rw [Equiv.Perm.parts_partition, hσ, Fintype.card_fin, hsupport, hremaining, ← hunit,
+    hsplit]
+
+/-- The partition of a conjugacy class of permutations. -/
+def permConjClassPartition (n : ℕ) :
+    ConjClasses (Equiv.Perm (Fin n)) → n.Partition :=
+  Quotient.lift (finPermPartition n) fun σ τ h =>
+    (finPermPartition_eq_iff n σ τ).mpr (Equiv.Perm.partition_eq_of_isConj.mp h)
+
+/-- Taking the partition of the class of a permutation recovers its partition. -/
+@[simp]
+theorem permConjClassPartition_mk (n : ℕ) (σ : Equiv.Perm (Fin n)) :
+    permConjClassPartition n (ConjClasses.mk σ) = finPermPartition n σ := by
+  simp [permConjClassPartition, ConjClasses.mk]
+
+/-- The partition distinguishes conjugacy classes of permutations. -/
+theorem permConjClassPartition_injective (n : ℕ) :
+    Function.Injective (permConjClassPartition n) := by
+  intro C D h
+  obtain ⟨σ, rfl⟩ := ConjClasses.exists_rep C
+  obtain ⟨τ, rfl⟩ := ConjClasses.exists_rep D
+  rw [ConjClasses.mk_eq_mk_iff_isConj]
+  apply Equiv.Perm.partition_eq_of_isConj.mpr
+  apply (finPermPartition_eq_iff n σ τ).mp
+  simpa only [permConjClassPartition_mk] using h
+
+/-- Every partition is attained by a conjugacy class of permutations. -/
+theorem permConjClassPartition_surjective (n : ℕ) :
+    Function.Surjective (permConjClassPartition n) := by
+  intro p
+  obtain ⟨σ, hσ⟩ := exists_perm_partition_eq p
+  exact ⟨ConjClasses.mk σ, by simpa using hσ⟩
+
+/-- Partitions of `n` are equivalent to conjugacy classes of the symmetric group on `Fin n`. -/
+noncomputable def partitionEquivConjClasses (n : ℕ) :
+    n.Partition ≃ ConjClasses (Equiv.Perm (Fin n)) :=
+  (Equiv.ofBijective (permConjClassPartition n)
+    ⟨permConjClassPartition_injective n, permConjClassPartition_surjective n⟩).symm
+
+/-- The conjugacy class associated to a partition has that partition. -/
+@[simp]
+theorem permConjClassPartition_partitionEquivConjClasses (n : ℕ) (p : n.Partition) :
+    permConjClassPartition n (partitionEquivConjClasses n p) = p := by
+  exact (partitionEquivConjClasses n).symm_apply_apply p
+
+/-- The inverse class-to-partition map sends a representative to its permutation partition. -/
+@[simp]
+theorem partitionEquivConjClasses_symm_mk (n : ℕ) (σ : Equiv.Perm (Fin n)) :
+    (partitionEquivConjClasses n).symm (ConjClasses.mk σ) = finPermPartition n σ := by
+  change permConjClassPartition n (ConjClasses.mk σ) = finPermPartition n σ
+  exact permConjClassPartition_mk n σ
+
+/-- The number of conjugacy classes of `Sₙ` is the number of partitions of `n`. -/
+theorem card_conjClasses_perm_eq_card_partition (n : ℕ) :
+    Fintype.card (ConjClasses (Equiv.Perm (Fin n))) = Fintype.card n.Partition :=
+  Fintype.card_congr (partitionEquivConjClasses n).symm
+
+end TauCeti

--- a/TauCeti/RepresentationTheory/Symmetric/Partitions.lean
+++ b/TauCeti/RepresentationTheory/Symmetric/Partitions.lean
@@ -148,4 +148,10 @@ theorem card_conjClasses_perm_eq_card_partition (α : Type*) [Fintype α] [Decid
       Fintype.card (Fintype.card α).Partition :=
   Fintype.card_congr (partitionEquivPermConjClasses α).symm
 
+/-- The number of conjugacy classes of the symmetric group on `Fin n` is the number of partitions
+of `n`. -/
+theorem card_conjClasses_perm (n : ℕ) :
+    Fintype.card (ConjClasses (Equiv.Perm (Fin n))) = Fintype.card n.Partition := by
+  simpa using card_conjClasses_perm_eq_card_partition (Fin n)
+
 end TauCeti

--- a/TauCeti/RepresentationTheory/Symmetric/Partitions.lean
+++ b/TauCeti/RepresentationTheory/Symmetric/Partitions.lean
@@ -20,6 +20,10 @@ API.  Mathlib's partition of a permutation includes the fixed points as parts of
 
 * [Schur--Weyl roadmap](https://github.com/TauCetiProject/TauCetiRoadmap/blob/main/TauCetiRoadmap/RepresentationTheory/SchurWeyl/README.md),
   Layer 0.
+* Mathlib's `Mathlib.GroupTheory.Perm.Cycle.Type`, for `Equiv.Perm.partition` and
+  `Equiv.Perm.partition_eq_of_isConj`.
+* Mathlib's `Mathlib.GroupTheory.Perm.Cycle.PossibleTypes`, for
+  `Equiv.Perm.exists_with_cycleType_iff`.
 -/
 
 public section
@@ -96,7 +100,7 @@ theorem permConjClassPartition_surjective {α : Type*} [Fintype α] [DecidableEq
 
 /-- Partitions of the cardinality of a finite type are equivalent to conjugacy classes of its
 permutations. -/
-noncomputable def permEquivConjClasses (α : Type*) [Fintype α] [DecidableEq α] :
+noncomputable def partitionEquivPermConjClasses (α : Type*) [Fintype α] [DecidableEq α] :
     (Fintype.card α).Partition ≃ ConjClasses (Equiv.Perm α) :=
   (Equiv.ofBijective (permConjClassPartition (α := α))
     ⟨permConjClassPartition_injective, permConjClassPartition_surjective⟩).symm
@@ -105,14 +109,14 @@ noncomputable def permEquivConjClasses (α : Type*) [Fintype α] [DecidableEq α
 noncomputable def partitionEquivConjClasses (n : ℕ) :
     n.Partition ≃ ConjClasses (Equiv.Perm (Fin n)) :=
   (Equiv.cast (congrArg Nat.Partition (Fintype.card_fin n).symm)).trans
-    (permEquivConjClasses (Fin n))
+    (partitionEquivPermConjClasses (Fin n))
 
 /-- The conjugacy class associated to a partition has that partition. -/
 @[simp]
-theorem permConjClassPartition_permEquivConjClasses (α : Type*) [Fintype α]
+theorem permConjClassPartition_partitionEquivPermConjClasses (α : Type*) [Fintype α]
     [DecidableEq α] (p : (Fintype.card α).Partition) :
-    permConjClassPartition (permEquivConjClasses α p) = p :=
-  (permEquivConjClasses α).symm_apply_apply p
+    permConjClassPartition (partitionEquivPermConjClasses α p) = p :=
+  (partitionEquivPermConjClasses α).symm_apply_apply p
 
 /-- The conjugacy class associated to a partition of `n` has that partition. -/
 @[simp]
@@ -123,10 +127,10 @@ theorem permConjClassPartition_partitionEquivConjClasses (n : ℕ) (p : n.Partit
 
 /-- The inverse class-to-partition map sends a representative to its permutation partition. -/
 @[simp]
-theorem permEquivConjClasses_symm_mk (α : Type*) [Fintype α] [DecidableEq α]
+theorem partitionEquivPermConjClasses_symm_mk (α : Type*) [Fintype α] [DecidableEq α]
     (σ : Equiv.Perm α) :
-    (permEquivConjClasses α).symm (ConjClasses.mk σ) = σ.partition := by
-  rw [permEquivConjClasses, Equiv.symm_symm, Equiv.ofBijective_apply,
+    (partitionEquivPermConjClasses α).symm (ConjClasses.mk σ) = σ.partition := by
+  rw [partitionEquivPermConjClasses, Equiv.symm_symm, Equiv.ofBijective_apply,
     permConjClassPartition_mk]
 
 /-- The inverse class-to-partition map for `Fin n` sends a representative to its permutation
@@ -143,6 +147,6 @@ of its cardinality. -/
 theorem card_conjClasses_perm_eq_card_partition (α : Type*) [Fintype α] [DecidableEq α] :
     Fintype.card (ConjClasses (Equiv.Perm α)) =
       Fintype.card (Fintype.card α).Partition :=
-  Fintype.card_congr (permEquivConjClasses α).symm
+  Fintype.card_congr (partitionEquivPermConjClasses α).symm
 
 end TauCeti

--- a/TauCeti/RepresentationTheory/Symmetric/Partitions.lean
+++ b/TauCeti/RepresentationTheory/Symmetric/Partitions.lean
@@ -6,8 +6,9 @@ Authors: Codex
 module
 
 public import Mathlib.Algebra.Group.ConjFinite
-public import Mathlib.Combinatorics.Young.YoungDiagram
 public import Mathlib.GroupTheory.Perm.Cycle.PossibleTypes
+public import TauCeti.Combinatorics.Enumerative.Partition.Basic
+public import TauCeti.Combinatorics.Young.YoungDiagram
 
 /-!
 # Partitions, Young diagrams, and conjugacy classes
@@ -15,9 +16,10 @@ public import Mathlib.GroupTheory.Perm.Cycle.PossibleTypes
 This file connects three indexing types used in the representation theory of the symmetric group:
 partitions of `n`, Young diagrams with `n` cells, and conjugacy classes of `Equiv.Perm (Fin n)`.
 
-The equivalence with Young diagrams sorts the multiset of parts into decreasing row lengths.  The
-equivalence with conjugacy classes uses Mathlib's partition of a permutation, including the fixed
-points as parts of size one.
+The equivalence with Young diagrams sorts the multiset of parts into decreasing row lengths, using
+`TauCeti.Nat.Partition.equivSortedParts` and `TauCeti.YoungDiagram.sum_rowLens`.  The equivalence
+with conjugacy classes uses Mathlib's partition of a permutation, including the fixed points as
+parts of size one.
 
 ## References
 
@@ -31,69 +33,8 @@ namespace TauCeti
 
 open Equiv
 
-namespace YoungDiagram
-
-/-- The sum of the row lengths of a Young diagram is its number of cells. -/
-theorem sum_rowLens (μ : YoungDiagram) : μ.rowLens.sum = μ.card := by
-  rw [_root_.YoungDiagram.rowLens]
-  change (∑ i ∈ Finset.range (μ.colLen 0), μ.rowLen i) = μ.card
-  symm
-  calc
-    μ.card =
-        ∑ i ∈ Finset.range (μ.colLen 0),
-          (μ.cells.filter fun c => c.fst = i).card := by
-      apply Finset.card_eq_sum_card_fiberwise
-      intro c hc
-      simpa using
-        (_root_.YoungDiagram.mem_iff_lt_colLen.mp hc).trans_le
-          (μ.colLen_anti 0 c.snd c.snd.zero_le)
-    _ = ∑ i ∈ Finset.range (μ.colLen 0), μ.rowLen i := by
-      apply Finset.sum_congr rfl
-      intro i _
-      exact (μ.rowLen_eq_card (i := i)).symm
-
-end YoungDiagram
-
-namespace Nat.Partition
-
-/-- A partition is equivalent to its decreasing list of positive parts. -/
-noncomputable def equivSortedParts (n : ℕ) :
-    n.Partition ≃
-      {w : List ℕ // (w.SortedGE ∧ ∀ x ∈ w, 0 < x) ∧ w.sum = n} where
-  toFun p :=
-    ⟨p.parts.sort (· ≥ ·),
-      ⟨(Multiset.pairwise_sort p.parts (· ≥ ·)).sortedGE,
-        fun x hx => p.parts_pos ((Multiset.mem_sort (r := (· ≥ ·))).mp hx)⟩, by
-        rw [← Multiset.sum_coe, Multiset.sort_eq, p.parts_sum]⟩
-  invFun w :=
-    ⟨w.1, fun {_} hx => w.2.1.2 _ hx, by
-      simpa only [Multiset.sum_coe] using w.2.2⟩
-  left_inv p := by
-    apply Nat.Partition.ext
-    exact Multiset.sort_eq p.parts (· ≥ ·)
-  right_inv w := by
-    apply Subtype.ext
-    exact List.Perm.eq_of_sortedGE
-      (Multiset.pairwise_sort (↑w.1 : Multiset ℕ) (· ≥ ·)).sortedGE w.2.1.1
-      (Multiset.coe_eq_coe.mp (Multiset.sort_eq (↑w.1 : Multiset ℕ) (· ≥ ·)))
-
-/-- Sorting the parts is the forward map of `equivSortedParts`. -/
-@[simp]
-theorem equivSortedParts_apply_parts (n : ℕ) (p : n.Partition) :
-    (equivSortedParts n p).1 = p.parts.sort (· ≥ ·) := by
-  simp [equivSortedParts]
-
-/-- The inverse of `equivSortedParts` has the given list as its multiset of parts. -/
-@[simp]
-theorem equivSortedParts_symm_apply_parts (n : ℕ)
-    (w : {w : List ℕ // (w.SortedGE ∧ ∀ x ∈ w, 0 < x) ∧ w.sum = n}) :
-    ((equivSortedParts n).symm w).parts = w.1 := by
-  simp [equivSortedParts]
-
-end Nat.Partition
-
 /-- Partitions of `n` are equivalent to Young diagrams with `n` cells. -/
-noncomputable def partitionEquivYoungDiagram (n : ℕ) :
+@[expose] noncomputable def partitionEquivYoungDiagram (n : ℕ) :
     n.Partition ≃ {μ : YoungDiagram // μ.card = n} :=
   (Nat.Partition.equivSortedParts n).trans
     ((Equiv.subtypeSubtypeEquivSubtypeInter
@@ -101,18 +42,23 @@ noncomputable def partitionEquivYoungDiagram (n : ℕ) :
         (fun w => w.sum = n)).symm.trans
       (YoungDiagram.equivListRowLens.symm.subtypeEquiv
         (q := fun μ => μ.card = n) fun w => by
-          rw [← YoungDiagram.sum_rowLens,
-            show (YoungDiagram.equivListRowLens.symm w).rowLens = w.1 from
-              congrArg Subtype.val (YoungDiagram.equivListRowLens.apply_symm_apply w)]))
+          rw [← YoungDiagram.sum_rowLens, _root_.YoungDiagram.equivListRowLens_symm_apply,
+            _root_.YoungDiagram.rowLens_ofRowLens_eq_self w.2.2]))
+
+/-- The Young diagram associated to a partition is the one built from its decreasing parts by
+`YoungDiagram.ofRowLens`. -/
+theorem partitionEquivYoungDiagram_apply_coe (n : ℕ) (p : n.Partition)
+    (hw : (p.parts.sort (· ≥ ·)).SortedGE) :
+    (partitionEquivYoungDiagram n p).1 =
+      _root_.YoungDiagram.ofRowLens (p.parts.sort (· ≥ ·)) hw :=
+  rfl
 
 /-- The Young diagram associated to a partition has its decreasing parts as row lengths. -/
 @[simp]
 theorem partitionEquivYoungDiagram_apply_rowLens (n : ℕ) (p : n.Partition) :
     (partitionEquivYoungDiagram n p).1.rowLens = p.parts.sort (· ≥ ·) := by
-  change
-    (_root_.YoungDiagram.ofRowLens (p.parts.sort (· ≥ ·))
-      (Multiset.pairwise_sort p.parts (· ≥ ·)).sortedGE).rowLens =
-      p.parts.sort (· ≥ ·)
+  rw [partitionEquivYoungDiagram_apply_coe n p
+    (Multiset.pairwise_sort p.parts (· ≥ ·)).sortedGE]
   exact _root_.YoungDiagram.rowLens_ofRowLens_eq_self fun x hx =>
     p.parts_pos ((Multiset.mem_sort (r := (· ≥ ·))).mp hx)
 
@@ -131,18 +77,25 @@ theorem partitionEquivYoungDiagram_symm_apply_parts (n : ℕ)
     _ = ↑μ.1.rowLens := congrArg (fun w : List ℕ => (↑w : Multiset ℕ)) h.symm
 
 /-- The partition of `n` obtained from a permutation of `Fin n`. -/
-def finPermPartition (n : ℕ) (σ : Equiv.Perm (Fin n)) : n.Partition where
+@[expose] def finPermPartition (n : ℕ) (σ : Equiv.Perm (Fin n)) : n.Partition where
   parts := σ.partition.parts
   parts_pos := σ.partition.parts_pos
   parts_sum := by simpa using σ.partition.parts_sum
 
+/-- The parts of `finPermPartition n σ` are the parts of Mathlib's partition of `σ`. -/
+@[simp]
+theorem finPermPartition_parts (n : ℕ) (σ : Equiv.Perm (Fin n)) :
+    (finPermPartition n σ).parts = σ.partition.parts :=
+  rfl
+
 /-- Two permutations of `Fin n` have the same sized partition exactly when their Mathlib
 partitions agree. -/
+@[simp]
 theorem finPermPartition_eq_iff (n : ℕ) (σ τ : Equiv.Perm (Fin n)) :
     finPermPartition n σ = finPermPartition n τ ↔ σ.partition = τ.partition := by
   constructor <;> intro h <;> apply Nat.Partition.ext
-  · simpa only [finPermPartition] using congrArg Nat.Partition.parts h
-  · simpa only [finPermPartition] using congrArg Nat.Partition.parts h
+  · simpa only [finPermPartition_parts] using congrArg Nat.Partition.parts h
+  · simpa only [finPermPartition_parts] using congrArg Nat.Partition.parts h
 
 /-- Every partition of `n` is the partition of a permutation of `Fin n`. -/
 theorem exists_perm_partition_eq {n : ℕ} (p : n.Partition) :
@@ -179,9 +132,8 @@ theorem exists_perm_partition_eq {n : ℕ} (p : n.Partition) :
     rw [← Equiv.Perm.sum_cycleType, hσ]
   have hremaining : n - largeParts.sum = unitParts.card := by
     omega
-  change σ.partition.parts = p.parts
-  rw [Equiv.Perm.parts_partition, hσ, Fintype.card_fin, hsupport, hremaining, ← hunit,
-    hsplit]
+  rw [finPermPartition_parts, Equiv.Perm.parts_partition, hσ, Fintype.card_fin, hsupport,
+    hremaining, ← hunit, hsplit]
 
 /-- The partition of a conjugacy class of permutations. -/
 def permConjClassPartition (n : ℕ) :
@@ -229,8 +181,8 @@ theorem permConjClassPartition_partitionEquivConjClasses (n : ℕ) (p : n.Partit
 @[simp]
 theorem partitionEquivConjClasses_symm_mk (n : ℕ) (σ : Equiv.Perm (Fin n)) :
     (partitionEquivConjClasses n).symm (ConjClasses.mk σ) = finPermPartition n σ := by
-  change permConjClassPartition n (ConjClasses.mk σ) = finPermPartition n σ
-  exact permConjClassPartition_mk n σ
+  rw [partitionEquivConjClasses, Equiv.symm_symm, Equiv.ofBijective_apply,
+    permConjClassPartition_mk]
 
 /-- The number of conjugacy classes of `Sₙ` is the number of partitions of `n`. -/
 theorem card_conjClasses_perm_eq_card_partition (n : ℕ) :

--- a/TauCeti/RepresentationTheory/Symmetric/Partitions.lean
+++ b/TauCeti/RepresentationTheory/Symmetric/Partitions.lean
@@ -7,21 +7,14 @@ module
 
 public import Mathlib.Algebra.Group.ConjFinite
 public import Mathlib.GroupTheory.Perm.Cycle.PossibleTypes
-public import TauCeti.Combinatorics.Enumerative.Partition.Basic
-public import TauCeti.Combinatorics.Young.YoungDiagram
+public import TauCeti.Combinatorics.Young.Partitions
 
 /-!
-# Partitions, Young diagrams, and conjugacy classes
+# Partitions and conjugacy classes of permutations
 
-This file connects three indexing types used in the representation theory of the symmetric group:
-partitions of `n`, Young diagrams with `n` cells, and conjugacy classes of permutations.  The
-conjugacy-class equivalence is proved for permutations of any finite type and specialized to
-`Equiv.Perm (Fin n)` for the roadmap API.
-
-The equivalence with Young diagrams sorts the multiset of parts into decreasing row lengths, using
-`TauCeti.Nat.Partition.equivSortedParts` and `TauCeti.YoungDiagram.sum_rowLens`.  The equivalence
-with conjugacy classes uses Mathlib's partition of a permutation, including the fixed points as
-parts of size one.
+This file gives the equivalence between partitions and conjugacy classes of permutations.  It is
+proved for permutations of any finite type and specialized to `Equiv.Perm (Fin n)` for the roadmap
+API.  Mathlib's partition of a permutation includes the fixed points as parts of size one.
 
 ## References
 
@@ -34,69 +27,6 @@ public section
 namespace TauCeti
 
 open Equiv
-
-/-- Partitions of `n` are equivalent to Young diagrams with `n` cells. -/
-noncomputable def partitionEquivYoungDiagram (n : ℕ) :
-    n.Partition ≃ {μ : YoungDiagram // μ.card = n} :=
-  (Nat.Partition.equivSortedParts n).trans
-    ((Equiv.subtypeSubtypeEquivSubtypeInter
-      (fun w : List ℕ => w.SortedGE ∧ ∀ x ∈ w, 0 < x)
-        (fun w => w.sum = n)).symm.trans
-      (YoungDiagram.equivListRowLens.symm.subtypeEquiv
-        (q := fun μ => μ.card = n) fun w => by
-          rw [← YoungDiagram.sum_rowLens, _root_.YoungDiagram.equivListRowLens_symm_apply,
-            _root_.YoungDiagram.rowLens_ofRowLens_eq_self w.2.2]))
-
-/-- The Young diagram associated to a partition is the one built from its decreasing parts by
-`YoungDiagram.ofRowLens`. -/
-theorem partitionEquivYoungDiagram_apply_coe (n : ℕ) (p : n.Partition)
-    (hw : (p.parts.sort (· ≥ ·)).SortedGE) :
-    (partitionEquivYoungDiagram n p).1 =
-      _root_.YoungDiagram.ofRowLens (p.parts.sort (· ≥ ·)) hw := by
-  simp only [partitionEquivYoungDiagram, Equiv.trans_apply, Equiv.subtypeEquiv_apply,
-    _root_.YoungDiagram.equivListRowLens_symm_apply]
-  have hinter :
-      ↑↑((Equiv.subtypeSubtypeEquivSubtypeInter
-          (fun w : List ℕ => w.SortedGE ∧ ∀ x ∈ w, 0 < x)
-          (fun w => w.sum = n)).symm (Nat.Partition.equivSortedParts n p)) =
-        (Nat.Partition.equivSortedParts n p).1 := by
-    symm
-    simpa only [Equiv.apply_symm_apply] using
-      (Equiv.subtypeSubtypeEquivSubtypeInter_apply_coe
-        (fun w : List ℕ => w.SortedGE ∧ ∀ x ∈ w, 0 < x)
-        (fun w => w.sum = n)
-        ((Equiv.subtypeSubtypeEquivSubtypeInter
-          (fun w : List ℕ => w.SortedGE ∧ ∀ x ∈ w, 0 < x)
-          (fun w => w.sum = n)).symm (Nat.Partition.equivSortedParts n p)))
-  have hlists := hinter.trans (Nat.Partition.equivSortedParts_apply_coe n p)
-  apply _root_.YoungDiagram.ext
-  ext c
-  rw [_root_.YoungDiagram.mem_cells, _root_.YoungDiagram.mem_cells,
-    _root_.YoungDiagram.mem_ofRowLens, _root_.YoungDiagram.mem_ofRowLens]
-  rw [hlists]
-
-/-- The Young diagram associated to a partition has its decreasing parts as row lengths. -/
-@[simp]
-theorem partitionEquivYoungDiagram_apply_rowLens (n : ℕ) (p : n.Partition) :
-    (partitionEquivYoungDiagram n p).1.rowLens = p.parts.sort (· ≥ ·) := by
-  rw [partitionEquivYoungDiagram_apply_coe n p
-    (Multiset.pairwise_sort p.parts (· ≥ ·)).sortedGE]
-  exact _root_.YoungDiagram.rowLens_ofRowLens_eq_self fun x hx =>
-    p.parts_pos ((Multiset.mem_sort (r := (· ≥ ·))).mp hx)
-
-/-- Reading the row lengths of a sized Young diagram recovers the partition's parts. -/
-@[simp]
-theorem partitionEquivYoungDiagram_symm_apply_parts (n : ℕ)
-    (μ : {μ : YoungDiagram // μ.card = n}) :
-    ((partitionEquivYoungDiagram n).symm μ).parts = μ.1.rowLens := by
-  have h := partitionEquivYoungDiagram_apply_rowLens n
-    ((partitionEquivYoungDiagram n).symm μ)
-  rw [Equiv.apply_symm_apply] at h
-  calc
-    ((partitionEquivYoungDiagram n).symm μ).parts =
-        ↑(((partitionEquivYoungDiagram n).symm μ).parts.sort (· ≥ ·)) :=
-      (Multiset.sort_eq _ _).symm
-    _ = ↑μ.1.rowLens := congrArg (fun w : List ℕ => (↑w : Multiset ℕ)) h.symm
 
 /-- Every partition of the cardinality of a finite type is the partition of a permutation. -/
 theorem exists_perm_partition_eq {α : Type*} [Fintype α] [DecidableEq α]
@@ -173,8 +103,9 @@ noncomputable def permEquivConjClasses (α : Type*) [Fintype α] [DecidableEq α
 
 /-- Partitions of `n` are equivalent to conjugacy classes of the symmetric group on `Fin n`. -/
 noncomputable def partitionEquivConjClasses (n : ℕ) :
-    n.Partition ≃ ConjClasses (Equiv.Perm (Fin n)) := by
-  simpa only [Fintype.card_fin] using permEquivConjClasses (Fin n)
+    n.Partition ≃ ConjClasses (Equiv.Perm (Fin n)) :=
+  (Equiv.cast (congrArg Nat.Partition (Fintype.card_fin n).symm)).trans
+    (permEquivConjClasses (Fin n))
 
 /-- The conjugacy class associated to a partition has that partition. -/
 @[simp]
@@ -183,6 +114,13 @@ theorem permConjClassPartition_permEquivConjClasses (α : Type*) [Fintype α]
     permConjClassPartition (permEquivConjClasses α p) = p :=
   (permEquivConjClasses α).symm_apply_apply p
 
+/-- The conjugacy class associated to a partition of `n` has that partition. -/
+@[simp]
+theorem permConjClassPartition_partitionEquivConjClasses (n : ℕ) (p : n.Partition) :
+    permConjClassPartition (partitionEquivConjClasses n p) =
+      Equiv.cast (congrArg Nat.Partition (Fintype.card_fin n).symm) p := by
+  simp [partitionEquivConjClasses]
+
 /-- The inverse class-to-partition map sends a representative to its permutation partition. -/
 @[simp]
 theorem permEquivConjClasses_symm_mk (α : Type*) [Fintype α] [DecidableEq α]
@@ -190,6 +128,15 @@ theorem permEquivConjClasses_symm_mk (α : Type*) [Fintype α] [DecidableEq α]
     (permEquivConjClasses α).symm (ConjClasses.mk σ) = σ.partition := by
   rw [permEquivConjClasses, Equiv.symm_symm, Equiv.ofBijective_apply,
     permConjClassPartition_mk]
+
+/-- The inverse class-to-partition map for `Fin n` sends a representative to its permutation
+partition. -/
+@[simp]
+theorem partitionEquivConjClasses_symm_mk (n : ℕ) (σ : Equiv.Perm (Fin n)) :
+    (partitionEquivConjClasses n).symm (ConjClasses.mk σ) =
+      (Equiv.cast (congrArg Nat.Partition (Fintype.card_fin n).symm)).symm
+        σ.partition := by
+  simp [partitionEquivConjClasses]
 
 /-- The number of conjugacy classes of permutations of a finite type is the number of partitions
 of its cardinality. -/

--- a/TauCeti/RepresentationTheory/Symmetric/Partitions.lean
+++ b/TauCeti/RepresentationTheory/Symmetric/Partitions.lean
@@ -7,7 +7,6 @@ module
 
 public import Mathlib.Algebra.Group.ConjFinite
 public import Mathlib.GroupTheory.Perm.Cycle.PossibleTypes
-public import TauCeti.Combinatorics.Young.Partitions
 
 /-!
 # Partitions and conjugacy classes of permutations

--- a/TauCeti/RepresentationTheory/Symmetric/Partitions.lean
+++ b/TauCeti/RepresentationTheory/Symmetric/Partitions.lean
@@ -14,7 +14,9 @@ public import TauCeti.Combinatorics.Young.YoungDiagram
 # Partitions, Young diagrams, and conjugacy classes
 
 This file connects three indexing types used in the representation theory of the symmetric group:
-partitions of `n`, Young diagrams with `n` cells, and conjugacy classes of `Equiv.Perm (Fin n)`.
+partitions of `n`, Young diagrams with `n` cells, and conjugacy classes of permutations.  The
+conjugacy-class equivalence is proved for permutations of any finite type and specialized to
+`Equiv.Perm (Fin n)` for the roadmap API.
 
 The equivalence with Young diagrams sorts the multiset of parts into decreasing row lengths, using
 `TauCeti.Nat.Partition.equivSortedParts` and `TauCeti.YoungDiagram.sum_rowLens`.  The equivalence
@@ -34,7 +36,7 @@ namespace TauCeti
 open Equiv
 
 /-- Partitions of `n` are equivalent to Young diagrams with `n` cells. -/
-@[expose] noncomputable def partitionEquivYoungDiagram (n : ℕ) :
+noncomputable def partitionEquivYoungDiagram (n : ℕ) :
     n.Partition ≃ {μ : YoungDiagram // μ.card = n} :=
   (Nat.Partition.equivSortedParts n).trans
     ((Equiv.subtypeSubtypeEquivSubtypeInter
@@ -50,8 +52,28 @@ open Equiv
 theorem partitionEquivYoungDiagram_apply_coe (n : ℕ) (p : n.Partition)
     (hw : (p.parts.sort (· ≥ ·)).SortedGE) :
     (partitionEquivYoungDiagram n p).1 =
-      _root_.YoungDiagram.ofRowLens (p.parts.sort (· ≥ ·)) hw :=
-  rfl
+      _root_.YoungDiagram.ofRowLens (p.parts.sort (· ≥ ·)) hw := by
+  simp only [partitionEquivYoungDiagram, Equiv.trans_apply, Equiv.subtypeEquiv_apply,
+    _root_.YoungDiagram.equivListRowLens_symm_apply]
+  have hinter :
+      ↑↑((Equiv.subtypeSubtypeEquivSubtypeInter
+          (fun w : List ℕ => w.SortedGE ∧ ∀ x ∈ w, 0 < x)
+          (fun w => w.sum = n)).symm (Nat.Partition.equivSortedParts n p)) =
+        (Nat.Partition.equivSortedParts n p).1 := by
+    symm
+    simpa only [Equiv.apply_symm_apply] using
+      (Equiv.subtypeSubtypeEquivSubtypeInter_apply_coe
+        (fun w : List ℕ => w.SortedGE ∧ ∀ x ∈ w, 0 < x)
+        (fun w => w.sum = n)
+        ((Equiv.subtypeSubtypeEquivSubtypeInter
+          (fun w : List ℕ => w.SortedGE ∧ ∀ x ∈ w, 0 < x)
+          (fun w => w.sum = n)).symm (Nat.Partition.equivSortedParts n p)))
+  have hlists := hinter.trans (Nat.Partition.equivSortedParts_apply_coe n p)
+  apply _root_.YoungDiagram.ext
+  ext c
+  rw [_root_.YoungDiagram.mem_cells, _root_.YoungDiagram.mem_cells,
+    _root_.YoungDiagram.mem_ofRowLens, _root_.YoungDiagram.mem_ofRowLens]
+  rw [hlists]
 
 /-- The Young diagram associated to a partition has its decreasing parts as row lengths. -/
 @[simp]
@@ -76,30 +98,10 @@ theorem partitionEquivYoungDiagram_symm_apply_parts (n : ℕ)
       (Multiset.sort_eq _ _).symm
     _ = ↑μ.1.rowLens := congrArg (fun w : List ℕ => (↑w : Multiset ℕ)) h.symm
 
-/-- The partition of `n` obtained from a permutation of `Fin n`. -/
-@[expose] def finPermPartition (n : ℕ) (σ : Equiv.Perm (Fin n)) : n.Partition where
-  parts := σ.partition.parts
-  parts_pos := σ.partition.parts_pos
-  parts_sum := by simpa using σ.partition.parts_sum
-
-/-- The parts of `finPermPartition n σ` are the parts of Mathlib's partition of `σ`. -/
-@[simp]
-theorem finPermPartition_parts (n : ℕ) (σ : Equiv.Perm (Fin n)) :
-    (finPermPartition n σ).parts = σ.partition.parts :=
-  rfl
-
-/-- Two permutations of `Fin n` have the same sized partition exactly when their Mathlib
-partitions agree. -/
-@[simp]
-theorem finPermPartition_eq_iff (n : ℕ) (σ τ : Equiv.Perm (Fin n)) :
-    finPermPartition n σ = finPermPartition n τ ↔ σ.partition = τ.partition := by
-  constructor <;> intro h <;> apply Nat.Partition.ext
-  · simpa only [finPermPartition_parts] using congrArg Nat.Partition.parts h
-  · simpa only [finPermPartition_parts] using congrArg Nat.Partition.parts h
-
-/-- Every partition of `n` is the partition of a permutation of `Fin n`. -/
-theorem exists_perm_partition_eq {n : ℕ} (p : n.Partition) :
-    ∃ σ : Equiv.Perm (Fin n), finPermPartition n σ = p := by
+/-- Every partition of the cardinality of a finite type is the partition of a permutation. -/
+theorem exists_perm_partition_eq {α : Type*} [Fintype α] [DecidableEq α]
+    (p : (Fintype.card α).Partition) :
+    ∃ σ : Equiv.Perm α, σ.partition = p := by
   let largeParts := p.parts.filter fun a => 2 ≤ a
   let unitParts := p.parts.filter fun a => ¬2 ≤ a
   have hsplit : largeParts + unitParts = p.parts := by
@@ -116,77 +118,84 @@ theorem exists_perm_partition_eq {n : ℕ} (p : n.Partition) :
         congrArg Multiset.sum hunit
       _ = unitParts.card := by
         rw [Multiset.sum_replicate, nsmul_eq_mul, Nat.cast_id, mul_one]
-  have hsum : largeParts.sum + unitParts.card = n := by
+  have hsum : largeParts.sum + unitParts.card = Fintype.card α := by
     rw [← p.parts_sum, ← hsplit, Multiset.sum_add, hunitSum]
-  have hlarge : largeParts.sum ≤ Fintype.card (Fin n) := by
-    simp only [Fintype.card_fin]
-    omega
+  have hlarge : largeParts.sum ≤ Fintype.card α := by omega
   have hlarge_mem : ∀ a ∈ largeParts, 2 ≤ a := by
     intro a ha
     exact (Multiset.mem_filter.mp ha).2
   obtain ⟨σ, hσ⟩ :=
-    (Equiv.Perm.exists_with_cycleType_iff (Fin n)).mpr ⟨hlarge, hlarge_mem⟩
+    (Equiv.Perm.exists_with_cycleType_iff α).mpr ⟨hlarge, hlarge_mem⟩
   refine ⟨σ, ?_⟩
   apply Nat.Partition.ext
   have hsupport : σ.support.card = largeParts.sum := by
     rw [← Equiv.Perm.sum_cycleType, hσ]
-  have hremaining : n - largeParts.sum = unitParts.card := by
+  have hremaining : Fintype.card α - largeParts.sum = unitParts.card := by
     omega
-  rw [finPermPartition_parts, Equiv.Perm.parts_partition, hσ, Fintype.card_fin, hsupport,
-    hremaining, ← hunit, hsplit]
+  rw [Equiv.Perm.parts_partition, hσ, hsupport, hremaining, ← hunit, hsplit]
 
 /-- The partition of a conjugacy class of permutations. -/
-def permConjClassPartition (n : ℕ) :
-    ConjClasses (Equiv.Perm (Fin n)) → n.Partition :=
-  Quotient.lift (finPermPartition n) fun σ τ h =>
-    (finPermPartition_eq_iff n σ τ).mpr (Equiv.Perm.partition_eq_of_isConj.mp h)
+def permConjClassPartition {α : Type*} [Fintype α] [DecidableEq α] :
+    ConjClasses (Equiv.Perm α) → (Fintype.card α).Partition :=
+  Quotient.lift Equiv.Perm.partition fun _ _ h =>
+    Equiv.Perm.partition_eq_of_isConj.mp h
 
 /-- Taking the partition of the class of a permutation recovers its partition. -/
 @[simp]
-theorem permConjClassPartition_mk (n : ℕ) (σ : Equiv.Perm (Fin n)) :
-    permConjClassPartition n (ConjClasses.mk σ) = finPermPartition n σ := by
+theorem permConjClassPartition_mk {α : Type*} [Fintype α] [DecidableEq α]
+    (σ : Equiv.Perm α) :
+    permConjClassPartition (ConjClasses.mk σ) = σ.partition := by
   simp [permConjClassPartition, ConjClasses.mk]
 
 /-- The partition distinguishes conjugacy classes of permutations. -/
-theorem permConjClassPartition_injective (n : ℕ) :
-    Function.Injective (permConjClassPartition n) := by
+theorem permConjClassPartition_injective {α : Type*} [Fintype α] [DecidableEq α] :
+    Function.Injective (permConjClassPartition (α := α)) := by
   intro C D h
   obtain ⟨σ, rfl⟩ := ConjClasses.exists_rep C
   obtain ⟨τ, rfl⟩ := ConjClasses.exists_rep D
   rw [ConjClasses.mk_eq_mk_iff_isConj]
   apply Equiv.Perm.partition_eq_of_isConj.mpr
-  apply (finPermPartition_eq_iff n σ τ).mp
   simpa only [permConjClassPartition_mk] using h
 
 /-- Every partition is attained by a conjugacy class of permutations. -/
-theorem permConjClassPartition_surjective (n : ℕ) :
-    Function.Surjective (permConjClassPartition n) := by
+theorem permConjClassPartition_surjective {α : Type*} [Fintype α] [DecidableEq α] :
+    Function.Surjective (permConjClassPartition (α := α)) := by
   intro p
   obtain ⟨σ, hσ⟩ := exists_perm_partition_eq p
   exact ⟨ConjClasses.mk σ, by simpa using hσ⟩
 
+/-- Partitions of the cardinality of a finite type are equivalent to conjugacy classes of its
+permutations. -/
+noncomputable def permEquivConjClasses (α : Type*) [Fintype α] [DecidableEq α] :
+    (Fintype.card α).Partition ≃ ConjClasses (Equiv.Perm α) :=
+  (Equiv.ofBijective (permConjClassPartition (α := α))
+    ⟨permConjClassPartition_injective, permConjClassPartition_surjective⟩).symm
+
 /-- Partitions of `n` are equivalent to conjugacy classes of the symmetric group on `Fin n`. -/
 noncomputable def partitionEquivConjClasses (n : ℕ) :
-    n.Partition ≃ ConjClasses (Equiv.Perm (Fin n)) :=
-  (Equiv.ofBijective (permConjClassPartition n)
-    ⟨permConjClassPartition_injective n, permConjClassPartition_surjective n⟩).symm
+    n.Partition ≃ ConjClasses (Equiv.Perm (Fin n)) := by
+  simpa only [Fintype.card_fin] using permEquivConjClasses (Fin n)
 
 /-- The conjugacy class associated to a partition has that partition. -/
 @[simp]
-theorem permConjClassPartition_partitionEquivConjClasses (n : ℕ) (p : n.Partition) :
-    permConjClassPartition n (partitionEquivConjClasses n p) = p := by
-  exact (partitionEquivConjClasses n).symm_apply_apply p
+theorem permConjClassPartition_permEquivConjClasses (α : Type*) [Fintype α]
+    [DecidableEq α] (p : (Fintype.card α).Partition) :
+    permConjClassPartition (permEquivConjClasses α p) = p :=
+  (permEquivConjClasses α).symm_apply_apply p
 
 /-- The inverse class-to-partition map sends a representative to its permutation partition. -/
 @[simp]
-theorem partitionEquivConjClasses_symm_mk (n : ℕ) (σ : Equiv.Perm (Fin n)) :
-    (partitionEquivConjClasses n).symm (ConjClasses.mk σ) = finPermPartition n σ := by
-  rw [partitionEquivConjClasses, Equiv.symm_symm, Equiv.ofBijective_apply,
+theorem permEquivConjClasses_symm_mk (α : Type*) [Fintype α] [DecidableEq α]
+    (σ : Equiv.Perm α) :
+    (permEquivConjClasses α).symm (ConjClasses.mk σ) = σ.partition := by
+  rw [permEquivConjClasses, Equiv.symm_symm, Equiv.ofBijective_apply,
     permConjClassPartition_mk]
 
-/-- The number of conjugacy classes of `Sₙ` is the number of partitions of `n`. -/
-theorem card_conjClasses_perm_eq_card_partition (n : ℕ) :
-    Fintype.card (ConjClasses (Equiv.Perm (Fin n))) = Fintype.card n.Partition :=
-  Fintype.card_congr (partitionEquivConjClasses n).symm
+/-- The number of conjugacy classes of permutations of a finite type is the number of partitions
+of its cardinality. -/
+theorem card_conjClasses_perm_eq_card_partition (α : Type*) [Fintype α] [DecidableEq α] :
+    Fintype.card (ConjClasses (Equiv.Perm α)) =
+      Fintype.card (Fintype.card α).Partition :=
+  Fintype.card_congr (permEquivConjClasses α).symm
 
 end TauCeti


### PR DESCRIPTION
This PR connects partitions of `n`, Young diagrams with `n` cells, and conjugacy classes of `Equiv.Perm (Fin n)`. It adds the two indexing equivalences, their characteristic lemmas, an explicit realization of every partition by a permutation, and the resulting equality between the number of conjugacy classes and the partition number.

This advances `TauCetiRoadmap/RepresentationTheory/SchurWeyl/README.md`, Layer 0, item “The partition/diagram/class dictionary,” specifically `partitionEquivYoungDiagram n`, `partitionEquivConjClasses n`, and the conjugacy-class/partition cardinality identity.

The implementation directly reuses Mathlib’s `YoungDiagram.equivListRowLens`, `Equiv.Perm.partition`, `Equiv.Perm.partition_eq_of_isConj`, and `Equiv.Perm.exists_with_cycleType_iff`. No Mathlib code and no material from the supplementary source snapshot is copied.

Validation passes with `lake exe cache get`, `lake build`, and `lake exe axioms`.

<!--tauceti-target:v1 {"focus":"RepresentationTheory","id":"partition-diagram-conjugacy-class-dictionary"}-->

🤖 Prepared with Codex
