### PR TITLE
feat: add quiver dimension vectors

### DIFF
--- a/TauCeti/RepresentationTheory/Quiver/Representation/Basic.lean
+++ b/TauCeti/RepresentationTheory/Quiver/Representation/Basic.lean
@@ -1,0 +1,38 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+module
+
+public import Mathlib.Algebra.Category.ModuleCat.Basic
+public import Mathlib.CategoryTheory.PathCategory.Basic
+
+/-!
+# Representations of a quiver
+
+A representation of a quiver over a field assigns a vector space to every vertex and a linear map
+to every arrow, compatibly with path composition. This is precisely a functor from Mathlib's free
+path category to its category of modules.
+
+This file introduces only the standard abbreviation. The equivalence with modules over the path
+algebra is developed separately.
+
+## References
+
+This implements the category-of-representations part of Layer 1 of
+`TauCetiRoadmap/RepresentationTheory/QuiverRepresentations/README.md`.
+-/
+
+public section
+
+namespace TauCeti
+
+open CategoryTheory
+
+universe u v
+
+/-- The category of representations of a quiver `Q` over a field `k`. -/
+abbrev QuiverRep (k : Type u) (Q : Type v) [Field k] [Quiver Q] :=
+  Paths Q ⥤ ModuleCat k
+
+end TauCeti

--- a/TauCeti/RepresentationTheory/Quiver/Representation/Basic.lean
+++ b/TauCeti/RepresentationTheory/Quiver/Representation/Basic.lean
@@ -15,7 +15,7 @@ to every arrow, compatibly with path composition. This is precisely a functor fr
 path category to its category of modules.
 
 This file introduces only the standard abbreviation. The equivalence with modules over the path
-algebra is developed separately.
+algebra is planned for separate development.
 
 ## References
 

--- a/TauCeti/RepresentationTheory/Quiver/Representation/DimensionVector.lean
+++ b/TauCeti/RepresentationTheory/Quiver/Representation/DimensionVector.lean
@@ -71,7 +71,6 @@ theorem dimVector_zero :
 
 /-- The dimension vector is additive on biproducts of pointwise finite-dimensional
 representations. -/
-@[simp]
 theorem dimVector_biprod (M N : QuiverRep k Q)
     (hM : ∀ i : Q, FiniteDimensional k (M.obj ((Paths.of Q).obj i)))
     (hN : ∀ i : Q, FiniteDimensional k (N.obj ((Paths.of Q).obj i))) :
@@ -92,7 +91,7 @@ theorem dimVector_biprod (M N : QuiverRep k Q)
 
 /-- In a short exact sequence of pointwise finite-dimensional quiver representations, the middle
 dimension vector is the sum of the outer dimension vectors. -/
-theorem dimVector_shortExact {S : ShortComplex (QuiverRep k Q)} (hS : S.ShortExact)
+theorem dimVector_add_of_shortExact {S : ShortComplex (QuiverRep k Q)} (hS : S.ShortExact)
     (h₁ : ∀ i : Q, FiniteDimensional k (S.X₁.obj ((Paths.of Q).obj i)))
     (h₃ : ∀ i : Q, FiniteDimensional k (S.X₃.obj ((Paths.of Q).obj i))) :
     dimVector S.X₂ = dimVector S.X₁ + dimVector S.X₃ := by

--- a/TauCeti/RepresentationTheory/Quiver/Representation/DimensionVector.lean
+++ b/TauCeti/RepresentationTheory/Quiver/Representation/DimensionVector.lean
@@ -17,9 +17,11 @@ public import Mathlib.LinearAlgebra.FiniteDimensional.Basic
 /-!
 # Dimension vectors of quiver representations
 
-The dimension vector of a representation records the dimension of its vector space at each vertex.
-This file defines dimension vectors and proves their fundamental functorial properties: invariance
-under isomorphism and additivity on biproducts and short exact sequences.
+The dimension vector of a representation records the `Module.finrank` of its vector space at each
+vertex. No finite-dimensionality is assumed in the definition, so an infinite-dimensional component
+has value `0` by the convention for `Module.finrank`. This file defines dimension vectors and proves
+their fundamental functorial properties: invariance under isomorphism and additivity on biproducts
+and short exact sequences.
 
 ## References
 
@@ -38,12 +40,13 @@ universe u v
 
 variable {k : Type u} {Q : Type v} [Field k] [Quiver Q]
 
-/-- The dimension vector of a quiver representation, indexed by the vertices of the quiver. -/
+/-- The `Module.finrank` dimension vector of a quiver representation, indexed by the vertices of the
+quiver. An infinite-dimensional component has value `0` by convention. -/
 noncomputable def dimVector (M : QuiverRep k Q) : Q → ℕ :=
   fun i ↦ Module.finrank k (M.obj ((Paths.of Q).obj i))
 
-/-- The value of the dimension vector at a vertex is the dimension of the corresponding vector
-space. -/
+/-- The value of the dimension vector at a vertex is the `Module.finrank` of the corresponding
+vector space. -/
 @[simp]
 theorem dimVector_apply (M : QuiverRep k Q) (i : Q) :
     dimVector M i = Module.finrank k (M.obj ((Paths.of Q).obj i)) :=

--- a/TauCeti/RepresentationTheory/Quiver/Representation/DimensionVector.lean
+++ b/TauCeti/RepresentationTheory/Quiver/Representation/DimensionVector.lean
@@ -17,12 +17,10 @@ public import Mathlib.LinearAlgebra.FiniteDimensional.Basic
 /-!
 # Dimension vectors of quiver representations
 
-The dimension vector of a representation records the dimension of its vector space at each vertex.
-This file defines dimension vectors and proves their fundamental functorial properties: invariance
-under isomorphism and additivity on biproducts and short exact sequences.
-
-Since Mathlib's `Module.finrank` is zero for an infinite-dimensional vector space, the additive
-statements explicitly assume finite-dimensionality at the vertices where it is needed.
+The dimension vector of a pointwise finite-dimensional representation records the dimension of its
+vector space at each vertex. This file defines dimension vectors and proves their fundamental
+functorial properties: invariance under isomorphism and additivity on biproducts and short exact
+sequences.
 
 ## References
 
@@ -41,27 +39,33 @@ universe u v
 
 variable {k : Type u} {Q : Type v} [Field k] [Quiver Q]
 
-/-- The dimension vector of a quiver representation, indexed by the vertices of the quiver. -/
-noncomputable def dimVector (M : QuiverRep k Q) : Q → ℕ :=
+/-- The dimension vector of a pointwise finite-dimensional quiver representation, indexed by the
+vertices of the quiver. -/
+noncomputable def dimVector (M : QuiverRep k Q)
+    (_hM : ∀ i : Q, FiniteDimensional k (M.obj ((Paths.of Q).obj i))) : Q → ℕ :=
   fun i ↦ Module.finrank k (M.obj ((Paths.of Q).obj i))
 
 /-- The value of the dimension vector at a vertex is the dimension of the corresponding vector
 space. -/
 @[simp]
-theorem dimVector_apply (M : QuiverRep k Q) (i : Q) :
-    dimVector M i = Module.finrank k (M.obj ((Paths.of Q).obj i)) :=
+theorem dimVector_apply (M : QuiverRep k Q)
+    (hM : ∀ i : Q, FiniteDimensional k (M.obj ((Paths.of Q).obj i))) (i : Q) :
+    dimVector M hM i = Module.finrank k (M.obj ((Paths.of Q).obj i)) :=
   (rfl)
 
 /-- Isomorphic quiver representations have the same dimension vector. -/
-theorem dimVector_eq_of_iso {M N : QuiverRep k Q} (e : M ≅ N) :
-    dimVector M = dimVector N := by
+theorem dimVector_eq_of_iso {M N : QuiverRep k Q}
+    (hM : ∀ i : Q, FiniteDimensional k (M.obj ((Paths.of Q).obj i)))
+    (hN : ∀ i : Q, FiniteDimensional k (N.obj ((Paths.of Q).obj i))) (e : M ≅ N) :
+    dimVector M hM = dimVector N hN := by
   funext i
   exact (e.app ((Paths.of Q).obj i)).toLinearEquiv.finrank_eq
 
 /-- The zero representation has zero dimension vector. -/
 @[simp]
-theorem dimVector_zero :
-    dimVector (0 : QuiverRep k Q) = 0 := by
+theorem dimVector_zero
+    (h : ∀ i : Q, FiniteDimensional k ((0 : QuiverRep k Q).obj ((Paths.of Q).obj i))) :
+    dimVector (0 : QuiverRep k Q) h = 0 := by
   funext i
   have hi : IsZero ((0 : QuiverRep k Q).obj ((Paths.of Q).obj i)) :=
     Functor.zero_obj ((Paths.of Q).obj i)
@@ -73,8 +77,9 @@ theorem dimVector_zero :
 representations. -/
 theorem dimVector_biprod (M N : QuiverRep k Q)
     (hM : ∀ i : Q, FiniteDimensional k (M.obj ((Paths.of Q).obj i)))
-    (hN : ∀ i : Q, FiniteDimensional k (N.obj ((Paths.of Q).obj i))) :
-    dimVector (M ⊞ N) = dimVector M + dimVector N := by
+    (hN : ∀ i : Q, FiniteDimensional k (N.obj ((Paths.of Q).obj i)))
+    (hMN : ∀ i : Q, FiniteDimensional k ((M ⊞ N).obj ((Paths.of Q).obj i))) :
+    dimVector (M ⊞ N) hMN = dimVector M hM + dimVector N hN := by
   funext i
   letI := hM i
   letI := hN i
@@ -93,8 +98,9 @@ theorem dimVector_biprod (M N : QuiverRep k Q)
 dimension vector is the sum of the outer dimension vectors. -/
 theorem dimVector_add_of_shortExact {S : ShortComplex (QuiverRep k Q)} (hS : S.ShortExact)
     (h₁ : ∀ i : Q, FiniteDimensional k (S.X₁.obj ((Paths.of Q).obj i)))
+    (h₂ : ∀ i : Q, FiniteDimensional k (S.X₂.obj ((Paths.of Q).obj i)))
     (h₃ : ∀ i : Q, FiniteDimensional k (S.X₃.obj ((Paths.of Q).obj i))) :
-    dimVector S.X₂ = dimVector S.X₁ + dimVector S.X₃ := by
+    dimVector S.X₂ h₂ = dimVector S.X₁ h₁ + dimVector S.X₃ h₃ := by
   funext i
   let E := (evaluation (Paths Q) (ModuleCat k)).obj ((Paths.of Q).obj i)
   letI : FiniteDimensional k (S.map E).X₁ := h₁ i

--- a/TauCeti/RepresentationTheory/Quiver/Representation/DimensionVector.lean
+++ b/TauCeti/RepresentationTheory/Quiver/Representation/DimensionVector.lean
@@ -1,0 +1,107 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+module
+
+public import TauCeti.RepresentationTheory.Quiver.Representation.Basic
+public import Mathlib.Algebra.Category.ModuleCat.Biproducts
+public import Mathlib.Algebra.Category.ModuleCat.Free
+public import Mathlib.CategoryTheory.Limits.FunctorCategory.BinaryBiproducts
+public import Mathlib.CategoryTheory.Limits.FunctorCategory.Finite
+public import Mathlib.CategoryTheory.Limits.Preserves.Shapes.Biproducts
+public import Mathlib.CategoryTheory.Limits.Shapes.ZeroMorphisms
+public import Mathlib.CategoryTheory.Preadditive.AdditiveFunctor
+public import Mathlib.LinearAlgebra.FiniteDimensional.Basic
+
+/-!
+# Dimension vectors of quiver representations
+
+The dimension vector of a representation records the dimension of its vector space at each vertex.
+This file defines dimension vectors and proves their fundamental functorial properties: invariance
+under isomorphism and additivity on biproducts and short exact sequences.
+
+Since Mathlib's `Module.finrank` is zero for an infinite-dimensional vector space, the additive
+statements explicitly assume finite-dimensionality at the vertices where it is needed.
+
+## References
+
+This implements Layer 4, item “Dimension vectors”, of
+`TauCetiRoadmap/RepresentationTheory/QuiverRepresentations/README.md`.
+-/
+
+public section
+
+namespace TauCeti
+
+open CategoryTheory CategoryTheory.Limits
+open scoped ZeroObject
+
+universe u v
+
+variable {k : Type u} {Q : Type v} [Field k] [Quiver Q]
+
+/-- The dimension vector of a quiver representation, indexed by the vertices of the quiver. -/
+noncomputable def dimVector (M : QuiverRep k Q) : Q → ℕ :=
+  fun i ↦ Module.finrank k (M.obj ((Paths.of Q).obj i))
+
+/-- The value of the dimension vector at a vertex is the dimension of the corresponding vector
+space. -/
+@[simp]
+theorem dimVector_apply (M : QuiverRep k Q) (i : Q) :
+    dimVector M i = Module.finrank k (M.obj ((Paths.of Q).obj i)) :=
+  (rfl)
+
+/-- Isomorphic quiver representations have the same dimension vector. -/
+theorem dimVector_eq_of_iso {M N : QuiverRep k Q} (e : M ≅ N) :
+    dimVector M = dimVector N := by
+  funext i
+  exact (e.app ((Paths.of Q).obj i)).toLinearEquiv.finrank_eq
+
+/-- The zero representation has zero dimension vector. -/
+@[simp]
+theorem dimVector_zero :
+    dimVector (0 : QuiverRep k Q) = 0 := by
+  funext i
+  have hi : IsZero ((0 : QuiverRep k Q).obj ((Paths.of Q).obj i)) :=
+    Functor.zero_obj ((Paths.of Q).obj i)
+  letI : Subsingleton ((0 : QuiverRep k Q).obj ((Paths.of Q).obj i)) :=
+    ModuleCat.subsingleton_of_isZero hi
+  exact Module.finrank_zero_of_subsingleton (R := k)
+
+/-- The dimension vector is additive on biproducts of pointwise finite-dimensional
+representations. -/
+@[simp]
+theorem dimVector_biprod (M N : QuiverRep k Q)
+    (hM : ∀ i : Q, FiniteDimensional k (M.obj ((Paths.of Q).obj i)))
+    (hN : ∀ i : Q, FiniteDimensional k (N.obj ((Paths.of Q).obj i))) :
+    dimVector (M ⊞ N) = dimVector M + dimVector N := by
+  funext i
+  letI := hM i
+  letI := hN i
+  simp only [Pi.add_apply, dimVector_apply]
+  let E := (evaluation (Paths Q) (ModuleCat k)).obj ((Paths.of Q).obj i)
+  letI : PreservesBinaryBiproduct M N E :=
+    preservesBinaryBiproduct_of_preservesBiproduct E M N
+  let e : (M ⊞ N).obj ((Paths.of Q).obj i) ≅
+      ModuleCat.of k (M.obj ((Paths.of Q).obj i) × N.obj ((Paths.of Q).obj i)) :=
+    E.mapBiprod M N ≪≫
+      ModuleCat.biprodIsoProd
+        (M.obj ((Paths.of Q).obj i)) (N.obj ((Paths.of Q).obj i))
+  rw [e.toLinearEquiv.finrank_eq, Module.finrank_prod]
+
+/-- In a short exact sequence of pointwise finite-dimensional quiver representations, the middle
+dimension vector is the sum of the outer dimension vectors. -/
+theorem dimVector_shortExact {S : ShortComplex (QuiverRep k Q)} (hS : S.ShortExact)
+    (h₁ : ∀ i : Q, FiniteDimensional k (S.X₁.obj ((Paths.of Q).obj i)))
+    (h₃ : ∀ i : Q, FiniteDimensional k (S.X₃.obj ((Paths.of Q).obj i))) :
+    dimVector S.X₂ = dimVector S.X₁ + dimVector S.X₃ := by
+  funext i
+  let E := (evaluation (Paths Q) (ModuleCat k)).obj ((Paths.of Q).obj i)
+  letI : FiniteDimensional k (S.map E).X₁ := h₁ i
+  letI : FiniteDimensional k (S.map E).X₃ := h₃ i
+  have hSi : (S.map E).ShortExact := hS.map_of_exact E
+  simp only [Pi.add_apply, dimVector_apply]
+  exact ModuleCat.free_shortExact_finrank_add hSi rfl rfl
+
+end TauCeti

--- a/TauCeti/RepresentationTheory/Quiver/Representation/DimensionVector.lean
+++ b/TauCeti/RepresentationTheory/Quiver/Representation/DimensionVector.lean
@@ -70,6 +70,7 @@ theorem dimVector_zero :
 
 /-- The dimension vector is additive on biproducts of pointwise finite-dimensional
 representations. -/
+@[simp]
 theorem dimVector_biprod (M N : QuiverRep k Q)
     (hM : ∀ i : Q, FiniteDimensional k (M.obj ((Paths.of Q).obj i)))
     (hN : ∀ i : Q, FiniteDimensional k (N.obj ((Paths.of Q).obj i))) :

--- a/TauCeti/RepresentationTheory/Quiver/Representation/DimensionVector.lean
+++ b/TauCeti/RepresentationTheory/Quiver/Representation/DimensionVector.lean
@@ -17,10 +17,9 @@ public import Mathlib.LinearAlgebra.FiniteDimensional.Basic
 /-!
 # Dimension vectors of quiver representations
 
-The dimension vector of a pointwise finite-dimensional representation records the dimension of its
-vector space at each vertex. This file defines dimension vectors and proves their fundamental
-functorial properties: invariance under isomorphism and additivity on biproducts and short exact
-sequences.
+The dimension vector of a representation records the dimension of its vector space at each vertex.
+This file defines dimension vectors and proves their fundamental functorial properties: invariance
+under isomorphism and additivity on biproducts and short exact sequences.
 
 ## References
 
@@ -39,34 +38,30 @@ universe u v
 
 variable {k : Type u} {Q : Type v} [Field k] [Quiver Q]
 
-/-- The dimension vector of a pointwise finite-dimensional quiver representation, indexed by the
-vertices of the quiver. -/
-noncomputable def dimVector (M : QuiverRep k Q)
-    (_hM : ∀ i : Q, FiniteDimensional k (M.obj ((Paths.of Q).obj i))) : Q → ℕ :=
+/-- The dimension vector of a quiver representation, indexed by the vertices of the quiver. -/
+noncomputable def dimVector (M : QuiverRep k Q) : Q → ℕ :=
   fun i ↦ Module.finrank k (M.obj ((Paths.of Q).obj i))
 
 /-- The value of the dimension vector at a vertex is the dimension of the corresponding vector
 space. -/
 @[simp]
-theorem dimVector_apply (M : QuiverRep k Q)
-    (hM : ∀ i : Q, FiniteDimensional k (M.obj ((Paths.of Q).obj i))) (i : Q) :
-    dimVector M hM i = Module.finrank k (M.obj ((Paths.of Q).obj i)) :=
+theorem dimVector_apply (M : QuiverRep k Q) (i : Q) :
+    dimVector M i = Module.finrank k (M.obj ((Paths.of Q).obj i)) :=
   (rfl)
 
 /-- Isomorphic quiver representations have the same dimension vector. -/
-theorem dimVector_eq_of_iso {M N : QuiverRep k Q}
-    (hM : ∀ i : Q, FiniteDimensional k (M.obj ((Paths.of Q).obj i)))
-    (hN : ∀ i : Q, FiniteDimensional k (N.obj ((Paths.of Q).obj i))) (e : M ≅ N) :
-    dimVector M hM = dimVector N hN := by
+theorem dimVector_eq_of_iso {M N : QuiverRep k Q} (e : M ≅ N) :
+    dimVector M = dimVector N := by
   funext i
+  simp only [dimVector_apply]
   exact (e.app ((Paths.of Q).obj i)).toLinearEquiv.finrank_eq
 
 /-- The zero representation has zero dimension vector. -/
 @[simp]
-theorem dimVector_zero
-    (h : ∀ i : Q, FiniteDimensional k ((0 : QuiverRep k Q).obj ((Paths.of Q).obj i))) :
-    dimVector (0 : QuiverRep k Q) h = 0 := by
+theorem dimVector_zero :
+    dimVector (0 : QuiverRep k Q) = 0 := by
   funext i
+  simp only [dimVector_apply, Pi.zero_apply]
   have hi : IsZero ((0 : QuiverRep k Q).obj ((Paths.of Q).obj i)) :=
     Functor.zero_obj ((Paths.of Q).obj i)
   letI : Subsingleton ((0 : QuiverRep k Q).obj ((Paths.of Q).obj i)) :=
@@ -77,9 +72,8 @@ theorem dimVector_zero
 representations. -/
 theorem dimVector_biprod (M N : QuiverRep k Q)
     (hM : ∀ i : Q, FiniteDimensional k (M.obj ((Paths.of Q).obj i)))
-    (hN : ∀ i : Q, FiniteDimensional k (N.obj ((Paths.of Q).obj i)))
-    (hMN : ∀ i : Q, FiniteDimensional k ((M ⊞ N).obj ((Paths.of Q).obj i))) :
-    dimVector (M ⊞ N) hMN = dimVector M hM + dimVector N hN := by
+    (hN : ∀ i : Q, FiniteDimensional k (N.obj ((Paths.of Q).obj i))) :
+    dimVector (M ⊞ N) = dimVector M + dimVector N := by
   funext i
   letI := hM i
   letI := hN i
@@ -98,15 +92,26 @@ theorem dimVector_biprod (M N : QuiverRep k Q)
 dimension vector is the sum of the outer dimension vectors. -/
 theorem dimVector_add_of_shortExact {S : ShortComplex (QuiverRep k Q)} (hS : S.ShortExact)
     (h₁ : ∀ i : Q, FiniteDimensional k (S.X₁.obj ((Paths.of Q).obj i)))
-    (h₂ : ∀ i : Q, FiniteDimensional k (S.X₂.obj ((Paths.of Q).obj i)))
     (h₃ : ∀ i : Q, FiniteDimensional k (S.X₃.obj ((Paths.of Q).obj i))) :
-    dimVector S.X₂ h₂ = dimVector S.X₁ h₁ + dimVector S.X₃ h₃ := by
+    dimVector S.X₂ = dimVector S.X₁ + dimVector S.X₃ := by
   funext i
   let E := (evaluation (Paths Q) (ModuleCat k)).obj ((Paths.of Q).obj i)
   letI : FiniteDimensional k (S.map E).X₁ := h₁ i
   letI : FiniteDimensional k (S.map E).X₃ := h₃ i
   have hSi : (S.map E).ShortExact := hS.map_of_exact E
   simp only [Pi.add_apply, dimVector_apply]
-  exact ModuleCat.free_shortExact_finrank_add hSi rfl rfl
+  have hfin₁ : Module.finrank k (S.map E).X₁ =
+      Module.finrank k (S.X₁.obj ((Paths.of Q).obj i)) :=
+    congrArg (fun X : ModuleCat k ↦ Module.finrank k X) ((ShortComplex.map_X₁ S E).trans
+      (evaluation_obj_obj (Paths Q) (ModuleCat k) ((Paths.of Q).obj i) S.X₁))
+  have hfin₂ : Module.finrank k (S.map E).X₂ =
+      Module.finrank k (S.X₂.obj ((Paths.of Q).obj i)) :=
+    congrArg (fun X : ModuleCat k ↦ Module.finrank k X) ((ShortComplex.map_X₂ S E).trans
+      (evaluation_obj_obj (Paths Q) (ModuleCat k) ((Paths.of Q).obj i) S.X₂))
+  have hfin₃ : Module.finrank k (S.map E).X₃ =
+      Module.finrank k (S.X₃.obj ((Paths.of Q).obj i)) :=
+    congrArg (fun X : ModuleCat k ↦ Module.finrank k X) ((ShortComplex.map_X₃ S E).trans
+      (evaluation_obj_obj (Paths Q) (ModuleCat k) ((Paths.of Q).obj i) S.X₃))
+  exact hfin₂.symm.trans (ModuleCat.free_shortExact_finrank_add hSi hfin₁ hfin₃)
 
 end TauCeti


### PR DESCRIPTION
This PR defines the Mathlib-native category of quiver representations and equips pointwise finite-dimensional representations with dimension vectors. Record evaluation, invariance under isomorphism, the zero case, and additivity on binary biproducts and short exact sequences.

This advances `TauCetiRoadmap/RepresentationTheory/QuiverRepresentations/README.md`, Layer 4, item “Dimension vectors”: `dimVector M v = Module.finrank k (M.obj v)`, additive on direct sums and short exact sequences. The `QuiverRep` abbreviation is the exact Layer 1 prerequisite used by that target.

This is the lowest-hanging distinct RepresentationTheory target because the Euler and Tits forms and finite-path foundation have merged, while open PRs cover the separate class-sum, Haar-averaging, tensor-power, partition-index, and Weyl-exchange targets. Dimension vectors depend only on Mathlib’s existing path category and pointwise functor-category structure, so they can land without speculating about the later path-algebra equivalence or reflection functors.

Reuse Mathlib’s `CategoryTheory.Paths`, `ModuleCat`, evaluation functors, biproduct preservation, `ModuleCat.biprodIsoProd`, `Module.finrank_prod`, and `ModuleCat.free_shortExact_finrank_add`. Vendor no Mathlib infrastructure, and copy or adapt no material from the supplementary source snapshot or another formalization.

`lake exe cache get` reports `No files to download` and `Already decompressed 8640 file(s)`. `lake build` reports `Build completed successfully (5552 jobs).` `lake exe axioms` reports `axioms: audited 12523 TauCeti declaration(s); all within the allowlist [propext, Classical.choice, Quot.sound].`

<!--tauceti-target:v1 {"focus":"RepresentationTheory","id":"dimension-vector"}-->

🤖 Prepared with Codex
