### PR TITLE
feat: add dominance order on partitions

### DIFF
--- a/TauCeti/Combinatorics/Enumerative/Partition/Dominance.lean
+++ b/TauCeti/Combinatorics/Enumerative/Partition/Dominance.lean
@@ -8,7 +8,7 @@ public import Mathlib.Data.List.Lex
 
 This file defines dominance of partitions of a fixed natural number by comparing all partial
 sums of their decreasingly sorted parts. It proves that dominance is a partial order and that
-strict dominance implies the corresponding strict lexicographic comparison.
+dominance implies the corresponding lexicographic comparison, strictly for strict dominance.
 
 The dominance order is the triangular order governing Kostka numbers and the occurrence of
 Specht modules in permutation modules. It is the “Orders on partitions” target in Layer 0 of
@@ -235,6 +235,12 @@ theorem lex_lt_of_strictlyDominates {n : ℕ} {μ ν : n.Partition}
   rw [PartitionLex.partition_lt_iff]
   rw [strictlyDominates_iff] at h
   exact lex_lt_of_dominates_of_ne h.1 h.2
+
+/-- Dominance refines the lexicographic linear order on partitions. -/
+theorem lex_le_of_dominates {n : ℕ} {μ ν : n.Partition} (h : Dominates μ ν) : ν ≤ μ := by
+  rcases eq_or_ne μ ν with rfl | hne
+  · exact le_rfl
+  · exact (lex_lt_of_strictlyDominates (strictlyDominates_iff.mpr ⟨h, hne⟩)).le
 
 /-- The one-part partition dominates every partition of the same natural number. -/
 @[simp]

--- a/TauCeti/RepresentationTheory/Symmetric/Dominance.lean
+++ b/TauCeti/RepresentationTheory/Symmetric/Dominance.lean
@@ -2,7 +2,6 @@ module
 
 public import Mathlib.Combinatorics.Enumerative.Partition.Basic
 public import Mathlib.Data.List.Lex
-import Lean.Elab.Tactic.Omega
 
 /-!
 # Dominance order on partitions
@@ -76,8 +75,8 @@ def Dominates {n : ℕ} (μ ν : n.Partition) : Prop :=
   ∀ k : Fin (n + 1),
     ((ν.parts.sort (· ≥ ·)).take k).sum ≤ ((μ.parts.sort (· ≥ ·)).take k).sum
 
-/-- Dominance can be checked on the first `n + 1` partial sums. -/
-theorem dominates_fin_iff {n : ℕ} {μ ν : n.Partition} :
+/-- By definition, dominance compares the first `n + 1` partial sums. -/
+theorem dominates_def {n : ℕ} {μ ν : n.Partition} :
     Dominates μ ν ↔
       ∀ k : Fin (n + 1),
         ((ν.parts.sort (· ≥ ·)).take k).sum ≤
@@ -105,7 +104,7 @@ instance {n : ℕ} (μ ν : n.Partition) : Decidable (Dominates μ ν) := by
   exact decidable_of_iff
     (∀ k : Fin (n + 1),
       ((ν.parts.sort (· ≥ ·)).take k).sum ≤
-        ((μ.parts.sort (· ≥ ·)).take k).sum) dominates_fin_iff.symm
+        ((μ.parts.sort (· ≥ ·)).take k).sum) dominates_def.symm
 
 /-- Every partition dominates itself. -/
 @[simp, refl]

--- a/TauCeti/RepresentationTheory/Symmetric/Dominance.lean
+++ b/TauCeti/RepresentationTheory/Symmetric/Dominance.lean
@@ -196,7 +196,6 @@ instance {n : ℕ} (μ ν : n.Partition) : Decidable (StrictlyDominates μ ν) :
   infer_instance
 
 /-- Strict dominance is irreflexive. -/
-@[simp]
 theorem strictlyDominates_irrefl {n : ℕ} (μ : n.Partition) :
     ¬StrictlyDominates μ μ := by
   letI := DominanceOrder.partitionPartialOrder (n := n)

--- a/TauCeti/RepresentationTheory/Symmetric/Dominance.lean
+++ b/TauCeti/RepresentationTheory/Symmetric/Dominance.lean
@@ -2,7 +2,7 @@ module
 
 public import Mathlib.Combinatorics.Enumerative.Partition.Basic
 public import Mathlib.Data.List.Lex
-import Mathlib.Tactic.Order
+import Lean.Elab.Tactic.Omega
 
 /-!
 # Dominance order on partitions
@@ -39,11 +39,26 @@ private theorem sortedParts_length_le {n : ℕ} (μ : n.Partition) :
         μ.parts_pos ((Multiset.mem_sort (· ≥ ·)).mp hi)
     _ = n := sortedParts_sum μ
 
+namespace PartitionLex
+
+/-- The lexicographic linear order on partitions, obtained from their decreasingly sorted parts.
+Activate it with `open scoped TauCeti.PartitionLex`. -/
+scoped instance partitionLinearOrder {n : ℕ} : LinearOrder n.Partition :=
+  LinearOrder.lift' (fun μ => μ.parts.sort (· ≥ ·)) (by
+    intro μ ν h
+    apply Nat.Partition.ext
+    calc
+      μ.parts = ↑(μ.parts.sort (· ≥ ·)) := (Multiset.sort_eq μ.parts (· ≥ ·)).symm
+      _ = ↑(ν.parts.sort (· ≥ ·)) := congrArg (fun l : List ℕ => (l : Multiset ℕ)) h
+      _ = ν.parts := Multiset.sort_eq ν.parts (· ≥ ·))
+
+end PartitionLex
+
 /-- A partition `μ` dominates a partition `ν` when every partial sum of the decreasingly
 sorted parts of `μ` is at least the corresponding partial sum of `ν`. -/
 def Dominates {n : ℕ} (μ ν : n.Partition) : Prop :=
   ∀ k : Fin (n + 1),
-    ((sortedParts ν).take k).sum ≤ ((sortedParts μ).take k).sum
+    ((ν.parts.sort (· ≥ ·)).take k).sum ≤ ((μ.parts.sort (· ≥ ·)).take k).sum
 
 /-- Dominance can be checked on the first `n + 1` partial sums. -/
 theorem dominates_fin_iff {n : ℕ} {μ ν : n.Partition} :
@@ -51,7 +66,7 @@ theorem dominates_fin_iff {n : ℕ} {μ ν : n.Partition} :
       ∀ k : Fin (n + 1),
         ((ν.parts.sort (· ≥ ·)).take k).sum ≤
           ((μ.parts.sort (· ≥ ·)).take k).sum :=
-  (Iff.rfl)
+  Iff.rfl
 
 /-- The defining partial-sum characterization of dominance. -/
 theorem dominates_iff {n : ℕ} {μ ν : n.Partition} :
@@ -77,7 +92,7 @@ instance {n : ℕ} (μ ν : n.Partition) : Decidable (Dominates μ ν) := by
         ((μ.parts.sort (· ≥ ·)).take k).sum) dominates_fin_iff.symm
 
 /-- Every partition dominates itself. -/
-@[refl]
+@[simp, refl]
 theorem dominates_refl {n : ℕ} (μ : n.Partition) : Dominates μ μ :=
   (dominates_iff.mpr fun _ => le_rfl)
 
@@ -86,18 +101,6 @@ theorem dominates_refl {n : ℕ} (μ : n.Partition) : Dominates μ μ :=
 theorem Dominates.trans {n : ℕ} {μ ν ξ : n.Partition}
     (hμν : Dominates μ ν) (hνξ : Dominates ν ξ) : Dominates μ ξ :=
   dominates_iff.mpr fun k => (dominates_iff.mp hνξ k).trans (dominates_iff.mp hμν k)
-
-/-- Strict dominance is dominance between unequal partitions. -/
-def StrictlyDominates {n : ℕ} (μ ν : n.Partition) : Prop :=
-  Dominates μ ν ∧ μ ≠ ν
-
-/-- The defining characterization of strict dominance. -/
-theorem strictlyDominates_iff {n : ℕ} {μ ν : n.Partition} :
-    StrictlyDominates μ ν ↔ Dominates μ ν ∧ μ ≠ ν :=
-  Iff.rfl
-
-instance {n : ℕ} (μ ν : n.Partition) : Decidable (StrictlyDominates μ ν) := by
-  exact decidable_of_iff (Dominates μ ν ∧ μ ≠ ν) strictlyDominates_iff.symm
 
 private theorem lex_lt_of_prefix_sum_le {l₁ l₂ : List ℕ}
     (hsum : l₁.sum = l₂.sum)
@@ -138,65 +141,76 @@ private theorem lex_lt_of_prefix_sum_le {l₁ l₂ : List ℕ}
               exact hne (congrArg (List.cons a) h)
           · exact List.Lex.rel hba
 
-/-- Strict dominance refines the decreasing lexicographic order on sorted parts. -/
-theorem sortedParts_lt_of_strictlyDominates {n : ℕ} {μ ν : n.Partition}
-    (h : StrictlyDominates μ ν) :
-    ν.parts.sort (· ≥ ·) < μ.parts.sort (· ≥ ·) := by
+private theorem lex_lt_of_dominates_of_ne {n : ℕ} {μ ν : n.Partition}
+    (hdom : Dominates μ ν) (hne : μ ≠ ν) :
+    sortedParts ν < sortedParts μ := by
   apply lex_lt_of_prefix_sum_le (sortedParts_sum μ |>.trans (sortedParts_sum ν).symm)
   · intro i hi
     exact μ.parts_pos ((Multiset.mem_sort (· ≥ ·)).mp hi)
   · intro i hi
     exact ν.parts_pos ((Multiset.mem_sort (· ≥ ·)).mp hi)
-  · exact dominates_iff.mp h.1
-  · intro hs
-    apply h.2
+  · exact dominates_iff.mp hdom
+  · intro h
+    apply hne
     apply Nat.Partition.ext
     calc
-      μ.parts = ↑(μ.parts.sort (· ≥ ·)) :=
-        (Multiset.sort_eq μ.parts (· ≥ ·)).symm
-      _ = ↑(ν.parts.sort (· ≥ ·)) := congrArg (fun l : List ℕ => (l : Multiset ℕ)) hs
+      μ.parts = ↑(sortedParts μ) := (Multiset.sort_eq μ.parts (· ≥ ·)).symm
+      _ = ↑(sortedParts ν) := congrArg (fun l : List ℕ => (l : Multiset ℕ)) h
       _ = ν.parts := Multiset.sort_eq ν.parts (· ≥ ·)
 
 /-- Dominance is antisymmetric. -/
 theorem Dominates.antisymm {n : ℕ} {μ ν : n.Partition}
     (hμν : Dominates μ ν) (hνμ : Dominates ν μ) : μ = ν := by
   by_contra hne
-  have hν_lt_μ := sortedParts_lt_of_strictlyDominates
-    (show StrictlyDominates μ ν from ⟨hμν, hne⟩)
-  have hμ_lt_ν := sortedParts_lt_of_strictlyDominates
-    (show StrictlyDominates ν μ from ⟨hνμ, Ne.symm hne⟩)
+  have hν_lt_μ := lex_lt_of_dominates_of_ne hμν hne
+  have hμ_lt_ν := lex_lt_of_dominates_of_ne hνμ (Ne.symm hne)
   exact hν_lt_μ.asymm hμ_lt_ν
 
-/-- A dominance comparison is either equality or strict dominance. -/
-theorem dominates_iff_eq_or_strictlyDominates {n : ℕ} {μ ν : n.Partition} :
-    Dominates μ ν ↔ μ = ν ∨ StrictlyDominates μ ν := by
-  constructor
-  · intro h
-    rcases eq_or_ne μ ν with rfl | hne
-    · exact Or.inl rfl
-    · exact Or.inr ⟨h, hne⟩
-  · rintro (rfl | h)
-    · exact dominates_refl _
-    · exact h.1
+namespace DominanceOrder
+
+/-- The dominance partial order on partitions, oriented so that `ν ≤ μ` means that `μ`
+dominates `ν`. Activate it with `open scoped TauCeti.DominanceOrder`. -/
+scoped instance partitionPartialOrder {n : ℕ} : PartialOrder n.Partition where
+  le μ ν := Dominates ν μ
+  le_refl μ := dominates_refl μ
+  le_trans _ _ _ hμν hνξ := hνξ.trans hμν
+  le_antisymm _ _ hμν hνμ := hνμ.antisymm hμν
+
+end DominanceOrder
+
+/-- Strict dominance is the strict relation of the dominance partial order. -/
+abbrev StrictlyDominates {n : ℕ} (μ ν : n.Partition) : Prop :=
+  DominanceOrder.partitionPartialOrder.lt ν μ
+
+/-- Strict dominance is dominance between unequal partitions. -/
+@[simp]
+theorem strictlyDominates_iff {n : ℕ} {μ ν : n.Partition} :
+    StrictlyDominates μ ν ↔ Dominates μ ν ∧ μ ≠ ν := by
+  letI := DominanceOrder.partitionPartialOrder (n := n)
+  change ν < μ ↔ Dominates μ ν ∧ μ ≠ ν
+  rw [lt_iff_le_and_ne]
+  exact and_congr Iff.rfl ne_comm
+
+instance {n : ℕ} (μ ν : n.Partition) : Decidable (StrictlyDominates μ ν) := by
+  rw [strictlyDominates_iff]
+  infer_instance
 
 /-- Strict dominance is irreflexive. -/
+@[simp]
 theorem strictlyDominates_irrefl {n : ℕ} (μ : n.Partition) :
-    ¬StrictlyDominates μ μ :=
-  fun h => h.2 rfl
+    ¬StrictlyDominates μ μ := by
+  letI := DominanceOrder.partitionPartialOrder (n := n)
+  change ¬μ < μ
+  exact lt_irrefl μ
 
-/-- Strict dominance is transitive. -/
-theorem StrictlyDominates.trans {n : ℕ} {μ ν ξ : n.Partition}
-    (hμν : StrictlyDominates μ ν) (hνξ : StrictlyDominates ν ξ) :
-    StrictlyDominates μ ξ := by
-  refine ⟨hμν.1.trans hνξ.1, ?_⟩
-  intro hμξ
-  apply hμν.2
-  exact hμν.1.antisymm (hμξ ▸ hνξ.1)
+open scoped PartitionLex
 
-/-- Strict dominance is asymmetric. -/
-theorem StrictlyDominates.asymm {n : ℕ} {μ ν : n.Partition}
-    (hμν : StrictlyDominates μ ν) : ¬StrictlyDominates ν μ :=
-  fun hνμ => hμν.2 (hμν.1.antisymm hνμ.1)
+/-- Strict dominance refines the lexicographic linear order on partitions. -/
+theorem lex_lt_of_strictlyDominates {n : ℕ} {μ ν : n.Partition}
+    (h : StrictlyDominates μ ν) : ν < μ := by
+  change sortedParts ν < sortedParts μ
+  rw [strictlyDominates_iff] at h
+  exact lex_lt_of_dominates_of_ne h.1 h.2
 
 /-- The one-part partition dominates every partition of the same natural number. -/
 theorem indiscrete_dominates {n : ℕ} (μ : n.Partition) :
@@ -216,6 +230,7 @@ theorem indiscrete_dominates {n : ℕ} (μ : n.Partition) :
     omega
 
 /-- A partition dominates the one-part partition only when it is that partition. -/
+@[simp]
 theorem dominates_indiscrete_iff {n : ℕ} {μ : n.Partition} :
     Dominates μ (Nat.Partition.indiscrete n) ↔ μ = Nat.Partition.indiscrete n := by
   constructor

--- a/TauCeti/RepresentationTheory/Symmetric/Dominance.lean
+++ b/TauCeti/RepresentationTheory/Symmetric/Dominance.lean
@@ -218,6 +218,12 @@ theorem strictlyDominates_iff {n : ℕ} {μ ν : n.Partition} :
     StrictlyDominates μ ν ↔ Dominates μ ν ∧ μ ≠ ν := by
   exact DominanceOrder.partition_lt_iff.trans (and_congr Iff.rfl ne_comm)
 
+/-- Strict dominance is a strict order on partitions. -/
+instance {n : ℕ} : IsStrictOrder n.Partition StrictlyDominates := by
+  letI := DominanceOrder.partitionPartialOrder (n := n)
+  change IsStrictOrder n.Partition (Function.swap (· < ·))
+  infer_instance
+
 instance {n : ℕ} (μ ν : n.Partition) : Decidable (StrictlyDominates μ ν) := by
   rw [strictlyDominates_iff]
   infer_instance

--- a/TauCeti/RepresentationTheory/Symmetric/Dominance.lean
+++ b/TauCeti/RepresentationTheory/Symmetric/Dominance.lean
@@ -1,0 +1,227 @@
+module
+
+public import Mathlib.Combinatorics.Enumerative.Partition.Basic
+public import Mathlib.Data.List.Lex
+import Mathlib.Tactic.Order
+
+/-!
+# Dominance order on partitions
+
+This file defines dominance of partitions of a fixed natural number by comparing all partial
+sums of their decreasingly sorted parts. It proves that dominance is a partial order and that
+strict dominance implies the corresponding strict lexicographic comparison.
+
+The dominance order is the triangular order governing Kostka numbers and the occurrence of
+Specht modules in permutation modules. It is the “Orders on partitions” target in Layer 0 of
+the symmetric-group and Schur–Weyl roadmap.
+-/
+
+public section
+
+namespace TauCeti
+
+private abbrev sortedParts {n : ℕ} (μ : n.Partition) : List ℕ :=
+  μ.parts.sort (· ≥ ·)
+
+private theorem sortedParts_sum {n : ℕ} (μ : n.Partition) :
+    (sortedParts μ).sum = n := by
+  calc
+    (sortedParts μ).sum = (↑(sortedParts μ) : Multiset ℕ).sum :=
+      (Multiset.sum_coe _).symm
+    _ = μ.parts.sum := congrArg Multiset.sum (Multiset.sort_eq μ.parts (· ≥ ·))
+    _ = n := μ.parts_sum
+
+private theorem sortedParts_length_le {n : ℕ} (μ : n.Partition) :
+    (sortedParts μ).length ≤ n := by
+  calc
+    (sortedParts μ).length ≤ (sortedParts μ).sum :=
+      List.length_le_sum_of_one_le _ fun i hi =>
+        μ.parts_pos ((Multiset.mem_sort (· ≥ ·)).mp hi)
+    _ = n := sortedParts_sum μ
+
+/-- A partition `μ` dominates a partition `ν` when every partial sum of the decreasingly
+sorted parts of `μ` is at least the corresponding partial sum of `ν`. -/
+def Dominates {n : ℕ} (μ ν : n.Partition) : Prop :=
+  ∀ k : Fin (n + 1),
+    ((sortedParts ν).take k).sum ≤ ((sortedParts μ).take k).sum
+
+/-- Dominance can be checked on the first `n + 1` partial sums. -/
+theorem dominates_fin_iff {n : ℕ} {μ ν : n.Partition} :
+    Dominates μ ν ↔
+      ∀ k : Fin (n + 1),
+        ((ν.parts.sort (· ≥ ·)).take k).sum ≤
+          ((μ.parts.sort (· ≥ ·)).take k).sum :=
+  (Iff.rfl)
+
+/-- The defining partial-sum characterization of dominance. -/
+theorem dominates_iff {n : ℕ} {μ ν : n.Partition} :
+    Dominates μ ν ↔
+      ∀ k : ℕ,
+        ((ν.parts.sort (· ≥ ·)).take k).sum ≤
+          ((μ.parts.sort (· ≥ ·)).take k).sum := by
+  constructor
+  · intro h k
+    by_cases hk : k ≤ n
+    · exact h ⟨k, Nat.lt_succ_iff.mpr hk⟩
+    · have hn_lt_k : n < k := Nat.lt_of_not_ge hk
+      rw [List.take_of_length_le ((sortedParts_length_le ν).trans hn_lt_k.le),
+        List.take_of_length_le ((sortedParts_length_le μ).trans hn_lt_k.le),
+        sortedParts_sum, sortedParts_sum]
+  · intro h k
+    exact h k
+
+instance {n : ℕ} (μ ν : n.Partition) : Decidable (Dominates μ ν) := by
+  exact decidable_of_iff
+    (∀ k : Fin (n + 1),
+      ((ν.parts.sort (· ≥ ·)).take k).sum ≤
+        ((μ.parts.sort (· ≥ ·)).take k).sum) dominates_fin_iff.symm
+
+/-- Every partition dominates itself. -/
+@[refl]
+theorem dominates_refl {n : ℕ} (μ : n.Partition) : Dominates μ μ :=
+  (dominates_iff.mpr fun _ => le_rfl)
+
+/-- Dominance is transitive. -/
+@[trans]
+theorem Dominates.trans {n : ℕ} {μ ν ξ : n.Partition}
+    (hμν : Dominates μ ν) (hνξ : Dominates ν ξ) : Dominates μ ξ :=
+  dominates_iff.mpr fun k => (dominates_iff.mp hνξ k).trans (dominates_iff.mp hμν k)
+
+/-- Strict dominance is dominance between unequal partitions. -/
+def StrictlyDominates {n : ℕ} (μ ν : n.Partition) : Prop :=
+  Dominates μ ν ∧ μ ≠ ν
+
+/-- The defining characterization of strict dominance. -/
+theorem strictlyDominates_iff {n : ℕ} {μ ν : n.Partition} :
+    StrictlyDominates μ ν ↔ Dominates μ ν ∧ μ ≠ ν :=
+  Iff.rfl
+
+instance {n : ℕ} (μ ν : n.Partition) : Decidable (StrictlyDominates μ ν) := by
+  exact decidable_of_iff (Dominates μ ν ∧ μ ≠ ν) strictlyDominates_iff.symm
+
+private theorem lex_lt_of_prefix_sum_le {l₁ l₂ : List ℕ}
+    (hsum : l₁.sum = l₂.sum)
+    (hpos₁ : ∀ i ∈ l₁, 0 < i) (hpos₂ : ∀ i ∈ l₂, 0 < i)
+    (hle : ∀ k : ℕ, (l₂.take k).sum ≤ (l₁.take k).sum)
+    (hne : l₁ ≠ l₂) : l₂ < l₁ := by
+  induction l₁ generalizing l₂ with
+  | nil =>
+      cases l₂ with
+      | nil => exact (hne rfl).elim
+      | cons b l₂ =>
+          have hb : 0 < b := hpos₂ b (by simp)
+          simp only [List.sum_nil, List.sum_cons] at hsum
+          omega
+  | cons a l₁ ih =>
+      cases l₂ with
+      | nil =>
+          have ha : 0 < a := hpos₁ a (by simp)
+          simp only [List.sum_cons, List.sum_nil] at hsum
+          omega
+      | cons b l₂ =>
+          have hba : b ≤ a := by
+            simpa only [List.take_succ_cons, List.take_zero, List.sum_cons, List.sum_nil,
+              add_zero] using hle 1
+          rcases hba.eq_or_lt with hba | hba
+          · subst b
+            apply List.Lex.cons
+            apply ih
+            · simpa only [List.sum_cons, Nat.add_left_cancel_iff] using hsum
+            · intro i hi
+              exact hpos₁ i (by simp [hi])
+            · intro i hi
+              exact hpos₂ i (by simp [hi])
+            · intro k
+              simpa only [List.take_succ_cons, List.sum_cons, Nat.add_le_add_iff_left] using
+                hle (k + 1)
+            · intro h
+              exact hne (congrArg (List.cons a) h)
+          · exact List.Lex.rel hba
+
+/-- Strict dominance refines the decreasing lexicographic order on sorted parts. -/
+theorem sortedParts_lt_of_strictlyDominates {n : ℕ} {μ ν : n.Partition}
+    (h : StrictlyDominates μ ν) :
+    ν.parts.sort (· ≥ ·) < μ.parts.sort (· ≥ ·) := by
+  apply lex_lt_of_prefix_sum_le (sortedParts_sum μ |>.trans (sortedParts_sum ν).symm)
+  · intro i hi
+    exact μ.parts_pos ((Multiset.mem_sort (· ≥ ·)).mp hi)
+  · intro i hi
+    exact ν.parts_pos ((Multiset.mem_sort (· ≥ ·)).mp hi)
+  · exact dominates_iff.mp h.1
+  · intro hs
+    apply h.2
+    apply Nat.Partition.ext
+    calc
+      μ.parts = ↑(μ.parts.sort (· ≥ ·)) :=
+        (Multiset.sort_eq μ.parts (· ≥ ·)).symm
+      _ = ↑(ν.parts.sort (· ≥ ·)) := congrArg (fun l : List ℕ => (l : Multiset ℕ)) hs
+      _ = ν.parts := Multiset.sort_eq ν.parts (· ≥ ·)
+
+/-- Dominance is antisymmetric. -/
+theorem Dominates.antisymm {n : ℕ} {μ ν : n.Partition}
+    (hμν : Dominates μ ν) (hνμ : Dominates ν μ) : μ = ν := by
+  by_contra hne
+  have hν_lt_μ := sortedParts_lt_of_strictlyDominates
+    (show StrictlyDominates μ ν from ⟨hμν, hne⟩)
+  have hμ_lt_ν := sortedParts_lt_of_strictlyDominates
+    (show StrictlyDominates ν μ from ⟨hνμ, Ne.symm hne⟩)
+  exact hν_lt_μ.asymm hμ_lt_ν
+
+/-- A dominance comparison is either equality or strict dominance. -/
+theorem dominates_iff_eq_or_strictlyDominates {n : ℕ} {μ ν : n.Partition} :
+    Dominates μ ν ↔ μ = ν ∨ StrictlyDominates μ ν := by
+  constructor
+  · intro h
+    rcases eq_or_ne μ ν with rfl | hne
+    · exact Or.inl rfl
+    · exact Or.inr ⟨h, hne⟩
+  · rintro (rfl | h)
+    · exact dominates_refl _
+    · exact h.1
+
+/-- Strict dominance is irreflexive. -/
+theorem strictlyDominates_irrefl {n : ℕ} (μ : n.Partition) :
+    ¬StrictlyDominates μ μ :=
+  fun h => h.2 rfl
+
+/-- Strict dominance is transitive. -/
+theorem StrictlyDominates.trans {n : ℕ} {μ ν ξ : n.Partition}
+    (hμν : StrictlyDominates μ ν) (hνξ : StrictlyDominates ν ξ) :
+    StrictlyDominates μ ξ := by
+  refine ⟨hμν.1.trans hνξ.1, ?_⟩
+  intro hμξ
+  apply hμν.2
+  exact hμν.1.antisymm (hμξ ▸ hνξ.1)
+
+/-- Strict dominance is asymmetric. -/
+theorem StrictlyDominates.asymm {n : ℕ} {μ ν : n.Partition}
+    (hμν : StrictlyDominates μ ν) : ¬StrictlyDominates ν μ :=
+  fun hνμ => hμν.2 (hμν.1.antisymm hνμ.1)
+
+/-- The one-part partition dominates every partition of the same natural number. -/
+theorem indiscrete_dominates {n : ℕ} (μ : n.Partition) :
+    Dominates (Nat.Partition.indiscrete n) μ := by
+  rw [dominates_iff]
+  intro k
+  rcases k with _ | k
+  · simp
+  by_cases hn : n = 0
+  · subst n
+    simp
+  · rw [Nat.Partition.indiscrete_parts hn]
+    simp only [Multiset.sort_singleton, List.take_succ_cons, List.sum_cons]
+    have hsplit := congrArg List.sum
+      (List.take_append_drop (k + 1) (μ.parts.sort (· ≥ ·)))
+    rw [List.sum_append, sortedParts_sum] at hsplit
+    omega
+
+/-- A partition dominates the one-part partition only when it is that partition. -/
+theorem dominates_indiscrete_iff {n : ℕ} {μ : n.Partition} :
+    Dominates μ (Nat.Partition.indiscrete n) ↔ μ = Nat.Partition.indiscrete n := by
+  constructor
+  · intro h
+    exact h.antisymm (indiscrete_dominates μ)
+  · rintro rfl
+    exact dominates_refl _
+
+end TauCeti

--- a/TauCeti/RepresentationTheory/Symmetric/Dominance.lean
+++ b/TauCeti/RepresentationTheory/Symmetric/Dominance.lean
@@ -209,7 +209,7 @@ theorem partition_lt_iff {n : ℕ} {μ ν : n.Partition} :
 end DominanceOrder
 
 /-- Strict dominance is the strict relation of the dominance partial order. -/
-abbrev StrictlyDominates {n : ℕ} (μ ν : n.Partition) : Prop :=
+def StrictlyDominates {n : ℕ} (μ ν : n.Partition) : Prop :=
   DominanceOrder.partitionPartialOrder.lt ν μ
 
 /-- Strict dominance is dominance between unequal partitions. -/

--- a/TauCeti/RepresentationTheory/Symmetric/Dominance.lean
+++ b/TauCeti/RepresentationTheory/Symmetric/Dominance.lean
@@ -219,10 +219,12 @@ theorem strictlyDominates_iff {n : ℕ} {μ ν : n.Partition} :
   exact DominanceOrder.partition_lt_iff.trans (and_congr Iff.rfl ne_comm)
 
 /-- Strict dominance is a strict order on partitions. -/
-instance {n : ℕ} : IsStrictOrder n.Partition StrictlyDominates := by
-  letI := DominanceOrder.partitionPartialOrder (n := n)
-  change IsStrictOrder n.Partition (Function.swap (· < ·))
-  infer_instance
+instance {n : ℕ} : IsStrictOrder n.Partition StrictlyDominates where
+  irrefl μ h := (strictlyDominates_iff.mp h).2 rfl
+  trans μ ν ξ hμν hνξ := by
+    rw [strictlyDominates_iff] at hμν hνξ ⊢
+    refine ⟨hμν.1.trans hνξ.1, fun hμξ => hμν.2 ?_⟩
+    exact hμν.1.antisymm (by simpa only [← hμξ] using hνξ.1)
 
 instance {n : ℕ} (μ ν : n.Partition) : Decidable (StrictlyDominates μ ν) := by
   rw [strictlyDominates_iff]

--- a/TauCeti/RepresentationTheory/Symmetric/Dominance.lean
+++ b/TauCeti/RepresentationTheory/Symmetric/Dominance.lean
@@ -60,6 +60,14 @@ theorem partition_lt_iff {n : ℕ} {μ ν : n.Partition} :
       μ.parts.sort (· ≥ ·) < ν.parts.sort (· ≥ ·) :=
   Iff.rfl
 
+/-- Partition comparison in the non-strict lexicographic order is comparison of the decreasingly
+sorted parts. -/
+@[simp]
+theorem partition_le_iff {n : ℕ} {μ ν : n.Partition} :
+    @LE.le n.Partition partitionLinearOrder.toLE μ ν ↔
+      μ.parts.sort (· ≥ ·) ≤ ν.parts.sort (· ≥ ·) :=
+  Iff.rfl
+
 end PartitionLex
 
 /-- A partition `μ` dominates a partition `ν` when every partial sum of the decreasingly
@@ -190,6 +198,14 @@ theorem partition_le_iff {n : ℕ} {μ ν : n.Partition} :
     @LE.le n.Partition partitionPartialOrder.toLE μ ν ↔ Dominates ν μ :=
   Iff.rfl
 
+/-- Strict partition comparison in the dominance order is strict dominance in the reverse
+direction. -/
+@[simp]
+theorem partition_lt_iff {n : ℕ} {μ ν : n.Partition} :
+    @LT.lt n.Partition partitionPartialOrder.toLT μ ν ↔ Dominates ν μ ∧ μ ≠ ν := by
+  letI := partitionPartialOrder (n := n)
+  exact lt_iff_le_and_ne.trans (and_congr partition_le_iff Iff.rfl)
+
 end DominanceOrder
 
 /-- Strict dominance is the strict relation of the dominance partial order. -/
@@ -200,10 +216,7 @@ abbrev StrictlyDominates {n : ℕ} (μ ν : n.Partition) : Prop :=
 @[simp]
 theorem strictlyDominates_iff {n : ℕ} {μ ν : n.Partition} :
     StrictlyDominates μ ν ↔ Dominates μ ν ∧ μ ≠ ν := by
-  letI := DominanceOrder.partitionPartialOrder (n := n)
-  rw [show StrictlyDominates μ ν ↔ ν < μ from Iff.rfl, lt_iff_le_and_ne,
-    DominanceOrder.partition_le_iff]
-  exact and_congr Iff.rfl ne_comm
+  exact DominanceOrder.partition_lt_iff.trans (and_congr Iff.rfl ne_comm)
 
 instance {n : ℕ} (μ ν : n.Partition) : Decidable (StrictlyDominates μ ν) := by
   rw [strictlyDominates_iff]
@@ -219,6 +232,7 @@ theorem lex_lt_of_strictlyDominates {n : ℕ} {μ ν : n.Partition}
   exact lex_lt_of_dominates_of_ne h.1 h.2
 
 /-- The one-part partition dominates every partition of the same natural number. -/
+@[simp]
 theorem indiscrete_dominates {n : ℕ} (μ : n.Partition) :
     Dominates (Nat.Partition.indiscrete n) μ := by
   rw [dominates_iff]

--- a/TauCeti/RepresentationTheory/Symmetric/Dominance.lean
+++ b/TauCeti/RepresentationTheory/Symmetric/Dominance.lean
@@ -217,13 +217,11 @@ theorem strictlyDominates_iff {n : ℕ} {μ ν : n.Partition} :
     StrictlyDominates μ ν ↔ Dominates μ ν ∧ μ ≠ ν := by
   exact DominanceOrder.partition_lt_iff.trans (and_congr Iff.rfl ne_comm)
 
-/-- Strict dominance is a strict order on partitions. -/
-instance {n : ℕ} : IsStrictOrder n.Partition StrictlyDominates where
-  irrefl μ h := (strictlyDominates_iff.mp h).2 rfl
-  trans μ ν ξ hμν hνξ := by
-    rw [strictlyDominates_iff] at hμν hνξ ⊢
-    refine ⟨hμν.1.trans hνξ.1, fun hμξ => hμν.2 ?_⟩
-    exact hμν.1.antisymm (by simpa only [← hμξ] using hνξ.1)
+/-- Strict dominance is a strict order on partitions, inherited from the dominance partial
+order. -/
+instance {n : ℕ} : IsStrictOrder n.Partition StrictlyDominates :=
+  letI := DominanceOrder.partitionPartialOrder (n := n)
+  inferInstanceAs (IsStrictOrder n.Partition (Function.swap (· < ·)))
 
 instance {n : ℕ} (μ ν : n.Partition) : Decidable (StrictlyDominates μ ν) := by
   rw [strictlyDominates_iff]

--- a/TauCeti/RepresentationTheory/Symmetric/Dominance.lean
+++ b/TauCeti/RepresentationTheory/Symmetric/Dominance.lean
@@ -52,6 +52,14 @@ scoped instance partitionLinearOrder {n : ℕ} : LinearOrder n.Partition :=
       _ = ↑(ν.parts.sort (· ≥ ·)) := congrArg (fun l : List ℕ => (l : Multiset ℕ)) h
       _ = ν.parts := Multiset.sort_eq ν.parts (· ≥ ·))
 
+/-- Partition comparison in the lexicographic order is comparison of the decreasingly sorted
+parts. -/
+@[simp]
+theorem partition_lt_iff {n : ℕ} {μ ν : n.Partition} :
+    @LT.lt n.Partition partitionLinearOrder.toLT μ ν ↔
+      μ.parts.sort (· ≥ ·) < ν.parts.sort (· ≥ ·) :=
+  Iff.rfl
+
 end PartitionLex
 
 /-- A partition `μ` dominates a partition `ν` when every partial sum of the decreasingly
@@ -176,6 +184,12 @@ scoped instance partitionPartialOrder {n : ℕ} : PartialOrder n.Partition where
   le_trans _ _ _ hμν hνξ := hνξ.trans hμν
   le_antisymm _ _ hμν hνμ := hνμ.antisymm hμν
 
+/-- Partition comparison in the dominance order is dominance in the reverse direction. -/
+@[simp]
+theorem partition_le_iff {n : ℕ} {μ ν : n.Partition} :
+    @LE.le n.Partition partitionPartialOrder.toLE μ ν ↔ Dominates ν μ :=
+  Iff.rfl
+
 end DominanceOrder
 
 /-- Strict dominance is the strict relation of the dominance partial order. -/
@@ -187,27 +201,20 @@ abbrev StrictlyDominates {n : ℕ} (μ ν : n.Partition) : Prop :=
 theorem strictlyDominates_iff {n : ℕ} {μ ν : n.Partition} :
     StrictlyDominates μ ν ↔ Dominates μ ν ∧ μ ≠ ν := by
   letI := DominanceOrder.partitionPartialOrder (n := n)
-  change ν < μ ↔ Dominates μ ν ∧ μ ≠ ν
-  rw [lt_iff_le_and_ne]
+  rw [show StrictlyDominates μ ν ↔ ν < μ from Iff.rfl, lt_iff_le_and_ne,
+    DominanceOrder.partition_le_iff]
   exact and_congr Iff.rfl ne_comm
 
 instance {n : ℕ} (μ ν : n.Partition) : Decidable (StrictlyDominates μ ν) := by
   rw [strictlyDominates_iff]
   infer_instance
 
-/-- Strict dominance is irreflexive. -/
-theorem strictlyDominates_irrefl {n : ℕ} (μ : n.Partition) :
-    ¬StrictlyDominates μ μ := by
-  letI := DominanceOrder.partitionPartialOrder (n := n)
-  change ¬μ < μ
-  exact lt_irrefl μ
-
 open scoped PartitionLex
 
 /-- Strict dominance refines the lexicographic linear order on partitions. -/
 theorem lex_lt_of_strictlyDominates {n : ℕ} {μ ν : n.Partition}
     (h : StrictlyDominates μ ν) : ν < μ := by
-  change sortedParts ν < sortedParts μ
+  rw [PartitionLex.partition_lt_iff]
   rw [strictlyDominates_iff] at h
   exact lex_lt_of_dominates_of_ne h.1 h.2
 


### PR DESCRIPTION
This PR defines the dominance and strict-dominance relations on partitions by partial sums of decreasingly sorted parts. Prove the unbounded partial-sum characterization, decidability from the first `n + 1` sums, reflexivity, transitivity, antisymmetry, strict-order laws, refinement by decreasing lexicographic order, and the greatest-element property of the one-part partition.

This advances `TauCetiRoadmap/RepresentationTheory/SchurWeyl/README.md`, Layer 0, item “Orders on partitions,” specifically the dominance partial order and the lexicographic linear order refining it. The later conjugation-reverses-dominance statement remains a separate continuation once the open partition/Young-diagram dictionary lands.

This is the lowest-hanging distinct RepresentationTheory target because open PR #1264 covers the separate partition/diagram/class dictionary, while dominance depends only on Mathlib’s existing `Nat.Partition` and immediately supplies the triangular order required by the roadmap’s Kostka-number and Specht-module layers.

Reuse Mathlib’s `Nat.Partition`, `Multiset.sort`, `List.Lex`, `List.length_le_sum_of_one_le`, and list take/sum API. Vendor no Mathlib infrastructure, and copy or adapt no material from the supplementary source snapshot or another formalization.

Add `TauCeti/Combinatorics/Enumerative/Partition/Dominance.lean` (273 lines). `lake exe cache get` reports `No files to download` and `Already decompressed 8640 file(s)`. `lake build` reports `Build completed successfully (5551 jobs).` `lake exe axioms` reports `axioms: audited 12567 TauCeti declaration(s); all within the allowlist [propext, Classical.choice, Quot.sound].`

<!--tauceti-target:v1 {"focus":"RepresentationTheory","id":"dominance-order-on-partitions"}-->

🤖 Prepared with Codex

