### PR TITLE
feat(Contour): an improper integral evaluated by the generalized residue theorem

### DIFF
--- a/TauCeti/Analysis/Contour/Residue/SimplePole.lean
+++ b/TauCeti/Analysis/Contour/Residue/SimplePole.lean
@@ -146,12 +146,8 @@ in practice to read off a residue. -/
 theorem residue_eq_of_tendsto_sub_mul {L : ℂ} (hf : MeromorphicAt f z₀)
     (h : Tendsto (fun z => (z - z₀) * f z) (𝓝[≠] z₀) (𝓝 L)) :
     residue f z₀ = L := by
-  have hg : MeromorphicAt (fun z : ℂ => (z - z₀) * f z) z₀ :=
-    ((analyticAt_id.sub analyticAt_const).meromorphicAt).mul hf
-  have hgnn : 0 ≤ meromorphicOrderAt (fun z => (z - z₀) * f z) z₀ :=
-    (tendsto_nhds_iff_meromorphicOrderAt_nonneg hg).1 ⟨L, h⟩
-  rw [meromorphicOrderAt_sub_mul hf] at hgnn
-  exact tendsto_nhds_unique (tendsto_sub_mul_nhds_residue hf (neg_one_le_of_zero_le_one_add hgnn)) h
+  exact tendsto_nhds_unique
+    (tendsto_sub_mul_nhds_residue hf (neg_one_le_meromorphicOrderAt_of_tendsto_sub_mul hf h)) h
 
 /-- The reciprocal `(· − z₀)⁻¹` of the simple factor `(· − z₀)` is meromorphic at `z₀`. -/
 theorem meromorphicAt_sub_inv (z₀ : ℂ) : MeromorphicAt (fun z => (z - z₀)⁻¹) z₀ :=

--- a/TauCeti/Analysis/Contour/Residue/SimplePole.lean
+++ b/TauCeti/Analysis/Contour/Residue/SimplePole.lean
@@ -37,6 +37,8 @@ direction one uses in practice to read off a residue.
   f z₀` (at most a simple pole); the analytic case gives the limit `0 = residue f z₀`.
 * `TauCeti.Contour.residue_eq_of_tendsto_sub_mul` — the converse: if `f` is meromorphic at `z₀` and
   `(z − z₀) · f z` converges to `L`, then `residue f z₀ = L`.
+* `TauCeti.Contour.neg_one_le_meromorphicOrderAt_of_tendsto_sub_mul` — a punctured limit of
+  `(z − z₀) · f z` forces the pole to be at worst simple.
 * `TauCeti.Contour.residue_sub_inv` — `residue (fun z => (z − z₀)⁻¹) z₀ = 1`, and
   `TauCeti.Contour.residue_const_mul_sub_inv` — `residue (fun z => c · (z − z₀)⁻¹) z₀ = c`: the
   elementary simple-pole residues, read off from the converse rule.
@@ -94,6 +96,20 @@ private theorem neg_one_le_of_zero_le_one_add {x : WithTop ℤ} (h : 0 ≤ 1 + x
     have h' : (0 : ℤ) ≤ 1 + n := by exact_mod_cast h
     rw [hc1, WithTop.coe_le_coe]
     omega
+
+/-- **A punctured limit of `(z − z₀) · f z` forces the pole to be at worst simple.** If that
+product converges, the order of `(z − z₀) · f z` is nonnegative, hence the order of `f` is at
+least `−1` — the hypothesis the Hungerbühler–Wasem half-residue theorem consumes. The same limit
+also computes the residue, via `residue_eq_of_tendsto_sub_mul`. -/
+theorem neg_one_le_meromorphicOrderAt_of_tendsto_sub_mul {L : ℂ} (hf : MeromorphicAt f z₀)
+    (h : Tendsto (fun z => (z - z₀) * f z) (𝓝[≠] z₀) (𝓝 L)) :
+    ((-1 : ℤ) : WithTop ℤ) ≤ meromorphicOrderAt f z₀ := by
+  have hg : MeromorphicAt (fun z : ℂ => (z - z₀) * f z) z₀ :=
+    ((analyticAt_id.sub analyticAt_const).meromorphicAt).mul hf
+  have hgnn : 0 ≤ meromorphicOrderAt (fun z => (z - z₀) * f z) z₀ :=
+    (tendsto_nhds_iff_meromorphicOrderAt_nonneg hg).1 ⟨L, h⟩
+  rw [meromorphicOrderAt_sub_mul hf] at hgnn
+  simpa using neg_one_le_of_zero_le_one_add hgnn
 
 /-- **The residue at a simple pole is `lim_{z→z₀} (z − z₀) · f z`.** If `f` has a simple pole at
 `z₀` (`meromorphicOrderAt f z₀ = −1`), then `(z − z₀) · f z` converges to `residue f z₀` as

--- a/TauCeti/Analysis/Contour/WorkedExamples/HalfDisc.lean
+++ b/TauCeti/Analysis/Contour/WorkedExamples/HalfDisc.lean
@@ -6,9 +6,11 @@ module
 
 public import TauCeti.Analysis.Contour.WorkedExamples.HalfDisc.Basic
 public import TauCeti.Analysis.Contour.WorkedExamples.HalfDisc.HalfResidue
+public import TauCeti.Analysis.Contour.WorkedExamples.HalfDisc.Dirichlet
 
 /-!
 # The half-disc worked example
 
-This module re-exports the half-disc contour and the half-residue evaluation along it.
+This module re-exports the half-disc contour, the half-residue evaluation along it, and the
+improper-integral worked example that evaluation supports.
 -/

--- a/TauCeti/Analysis/Contour/WorkedExamples/HalfDisc/Dirichlet.lean
+++ b/TauCeti/Analysis/Contour/WorkedExamples/HalfDisc/Dirichlet.lean
@@ -23,9 +23,12 @@ Running the half-disc contour of `HalfDisc/Basic.lean` and letting the radius gr
   line, leaving the segment alone;
 * Jordan's lemma kills the arc as `R → ∞`, since `‖1/z‖ = 1/R → 0` on it.
 
-The oscillatory factor is essential rather than cosmetic: for `f z = z⁻¹` alone (`a = 0`) the
-arc integral is `i π` for **every** `R` and never vanishes, so no limit exists to take. That is
-exactly the regime the naive `ML` bound cannot reach and Jordan's lemma can.
+The oscillatory factor is essential rather than cosmetic. At `a = 0` the integrand is `z⁻¹` and
+the arc integral equals `i π` for **every** `R`; it converges, but not to `0`, so Jordan's lemma
+does not apply and the argument cannot deliver `π i`. The identity itself still holds there, and
+reading it off gives `π i - i π = 0` — consistent with the symmetric principal values of `1/x`
+all vanishing by oddness. Positive frequency is what forces the arc to zero, and the decay it
+supplies is exactly the regime the naive `ML` bound cannot reach.
 
 ## Main results
 

--- a/TauCeti/Analysis/Contour/WorkedExamples/HalfDisc/Dirichlet.lean
+++ b/TauCeti/Analysis/Contour/WorkedExamples/HalfDisc/Dirichlet.lean
@@ -32,13 +32,13 @@ supplies is exactly the regime the naive `ML` bound cannot reach.
 
 ## Main results
 
-* `TauCeti.Contour.residue_exp_mul_I_div_self` — `Res₀ (e^{iaz}/z) = 1`, for every frequency.
+* `TauCeti.Contour.residue_dirichletIntegrand` — `Res₀ (e^{iaz}/z) = 1`, for every frequency.
 * `TauCeti.Contour.neg_one_le_meromorphicOrderAt_dirichletIntegrand` — the pole is at worst
   simple, the hypothesis the half-residue theorem consumes.
 * `TauCeti.Contour.hasCauchyPV_realSegment_dirichlet` — for each radius, the principal value
   along `[-R, R]` on the real axis is `π i` minus the arc contribution.
 * `TauCeti.Contour.tendsto_integral_arc_dirichlet_atTop` — the arc contribution vanishes, by
-  Jordan's lemma at `a = 1`.
+  Jordan's lemma for any positive frequency `a > 0`.
 * `TauCeti.Contour.tendsto_cauchyPV_realSegment_dirichlet` — hence the principal values
   themselves, `cauchyPV` along `[-R, R]` on the real axis, converge to `π i`.
 
@@ -71,9 +71,9 @@ theorem meromorphicAt_dirichletIntegrand (a : ℝ) :
       (analyticAt_id.meromorphicAt.inv)
   exact h.congr (Filter.Eventually.of_forall fun z => (dirichletIntegrand_eq a z).symm)
 
-/-- Near the origin `z · e^{iz}/z = e^{iz} → 1`. This single limit yields both the residue and
+/-- Near the origin `z · e^{iaz}/z = e^{iaz} → 1`. This single limit yields both the residue and
 the simplicity of the pole. -/
-theorem tendsto_sub_mul_dirichletIntegrand (a : ℝ) :
+private theorem tendsto_sub_mul_dirichletIntegrand (a : ℝ) :
     Tendsto (fun z : ℂ => (z - 0) * dirichletIntegrand a z) (𝓝[≠] 0) (𝓝 1) := by
   have hlim : Tendsto (fun z : ℂ => Complex.exp (Complex.I * (a : ℂ) * z)) (𝓝[≠] 0) (𝓝 1) := by
     have hc : Continuous fun z : ℂ => Complex.exp (Complex.I * (a : ℂ) * z) := by fun_prop
@@ -84,8 +84,8 @@ theorem tendsto_sub_mul_dirichletIntegrand (a : ℝ) :
   rw [dirichletIntegrand_eq, sub_zero]
   field_simp
 
-/-- **The residue of `e^{iz}/z` at the origin is `1`.** -/
-theorem residue_exp_mul_I_div_self (a : ℝ) : residue (dirichletIntegrand a) 0 = 1 :=
+/-- **The residue of `e^{iaz}/z` at the origin is `1`**, for every frequency. -/
+theorem residue_dirichletIntegrand (a : ℝ) : residue (dirichletIntegrand a) 0 = 1 :=
   residue_eq_of_tendsto_sub_mul (meromorphicAt_dirichletIntegrand a)
     (tendsto_sub_mul_dirichletIntegrand a)
 
@@ -97,27 +97,14 @@ theorem differentiableOn_dirichletIntegrand (a : ℝ) :
   refine (DifferentiableAt.div ?_ differentiableAt_id hz0).differentiableWithinAt
   exact (Complex.differentiable_exp _).comp z (by fun_prop)
 
-/-- **The pole at the origin is at worst simple.** Multiplying by `z` gives a function with a
-limit there, so the order of `e^{iz}/z` is at least `-1` — the hypothesis the half-residue
+/-- **The pole at the origin is at worst simple**, for every frequency: the punctured limit of
+`z · e^{iaz}/z` exists, which is exactly the criterion of
+`neg_one_le_meromorphicOrderAt_of_tendsto_sub_mul`. This is the hypothesis the half-residue
 theorem consumes. -/
 theorem neg_one_le_meromorphicOrderAt_dirichletIntegrand (a : ℝ) :
-    ((-1 : ℤ) : WithTop ℤ) ≤ meromorphicOrderAt (dirichletIntegrand a) 0 := by
-  have hid : MeromorphicAt (fun z : ℂ => z - 0) 0 :=
-    (analyticAt_id.sub analyticAt_const).meromorphicAt
-  have hprod : meromorphicOrderAt (fun z : ℂ => (z - 0) * dirichletIntegrand a z) 0
-      = 1 + meromorphicOrderAt (dirichletIntegrand a) 0 := by
-    have h := meromorphicOrderAt_mul hid (meromorphicAt_dirichletIntegrand a)
-    rwa [meromorphicOrderAt_id_sub_const] at h
-  have hnn : 0 ≤ meromorphicOrderAt (fun z : ℂ => (z - 0) * dirichletIntegrand a z) 0 :=
-    (tendsto_nhds_iff_meromorphicOrderAt_nonneg
-      (hid.mul (meromorphicAt_dirichletIntegrand a))).1 ⟨1, tendsto_sub_mul_dirichletIntegrand a⟩
-  rw [hprod] at hnn
-  induction hord : meromorphicOrderAt (dirichletIntegrand a) 0 using WithTop.recTopCoe with
-  | top => exact le_top
-  | coe n =>
-      rw [hord] at hnn
-      norm_cast at hnn ⊢
-      omega
+    ((-1 : ℤ) : WithTop ℤ) ≤ meromorphicOrderAt (dirichletIntegrand a) 0 :=
+  neg_one_le_meromorphicOrderAt_of_tendsto_sub_mul (meromorphicAt_dirichletIntegrand a)
+    (tendsto_sub_mul_dirichletIntegrand a)
 
 /-- **The identity along the real segment.** For each positive radius the principal value of
 `e^{iaz}/z` along `[-R, R]` on the real axis is `π i` minus the arc contribution. The pole sits on
@@ -127,7 +114,7 @@ theorem hasCauchyPV_realSegment_dirichlet (a : ℝ) {R : ℝ} (hR : 0 < R) :
       ((Real.pi : ℂ) * Complex.I -
         ∫ θ in (0 : ℝ)..Real.pi,
           dirichletIntegrand a (circleMap 0 R θ) * deriv (circleMap 0 R) θ) := by
-  simpa [residue_exp_mul_I_div_self a] using
+  simpa [residue_dirichletIntegrand a] using
     hasCauchyPV_realSegment_diameter hR (differentiableOn_dirichletIntegrand a)
       (meromorphicAt_dirichletIntegrand a) (neg_one_le_meromorphicOrderAt_dirichletIntegrand a)
 

--- a/TauCeti/Analysis/Contour/WorkedExamples/HalfDisc/Dirichlet.lean
+++ b/TauCeti/Analysis/Contour/WorkedExamples/HalfDisc/Dirichlet.lean
@@ -36,8 +36,8 @@ exactly the regime the naive `ML` bound cannot reach and Jordan's lemma can.
   along `[-R, R]` on the real axis is `π i` minus the arc contribution.
 * `TauCeti.Contour.tendsto_integral_arc_dirichlet_atTop` — the arc contribution vanishes, by
   Jordan's lemma at `a = 1`.
-* `TauCeti.Contour.tendsto_diameter_halfDiscBoundary_dirichlet` — hence the diameter principal
-  values converge to `π i`.
+* `TauCeti.Contour.tendsto_cauchyPV_realSegment_dirichlet` — hence the principal values
+  themselves, `cauchyPV` along `[-R, R]` on the real axis, converge to `π i`.
 
 ## References
 
@@ -139,15 +139,27 @@ theorem tendsto_integral_arc_dirichlet_atTop {a : ℝ} (ha : 0 < a) :
   rw [dirichletIntegrand_eq]
   ring
 
-/-- **The improper limit.** As the radius grows, the diameter principal values converge to `π i`
-— the half-residue, evaluated by the Hungerbühler–Wasem theorem on a contour through the pole,
-where the classical residue theorem does not apply. -/
-theorem tendsto_diameter_halfDiscBoundary_dirichlet {a : ℝ} (ha : 0 < a) :
+/-- The auxiliary limit: `π i` minus the arc contribution converges to `π i`. -/
+private theorem tendsto_sub_integral_arc_dirichlet {a : ℝ} (ha : 0 < a) :
     Tendsto (fun R : ℝ => (Real.pi : ℂ) * Complex.I -
       ∫ θ in (0 : ℝ)..Real.pi,
         dirichletIntegrand a (circleMap 0 R θ) * deriv (circleMap 0 R) θ)
       atTop (𝓝 ((Real.pi : ℂ) * Complex.I)) := by
   simpa using tendsto_const_nhds.sub (tendsto_integral_arc_dirichlet_atTop ha)
+
+/-- **The improper principal value.** As the radius grows, the Cauchy principal values of
+`e^{iaz}/z` along `[-R, R]` on the real axis converge to `π i` — the half-residue, evaluated by
+the Hungerbühler–Wasem theorem on a contour running through the pole, where the classical residue
+theorem does not apply.
+
+This is the roadmap's improper-integral acceptance criterion: the statement is about `cauchyPV`
+along the real line, with no reference to the auxiliary half-disc contour used to prove it. -/
+theorem tendsto_cauchyPV_realSegment_dirichlet {a : ℝ} (ha : 0 < a) :
+    Tendsto (fun R : ℝ => cauchyPV (fun t : ℝ => (t : ℂ)) (-R) R (dirichletIntegrand a))
+      atTop (𝓝 ((Real.pi : ℂ) * Complex.I)) := by
+  refine (tendsto_sub_integral_arc_dirichlet ha).congr' ?_
+  filter_upwards [eventually_gt_atTop (0 : ℝ)] with R hR
+  exact ((hasCauchyPV_realSegment_dirichlet a hR).cauchyPV_eq).symm
 
 end TauCeti.Contour
 

--- a/TauCeti/Analysis/Contour/WorkedExamples/HalfDisc/Dirichlet.lean
+++ b/TauCeti/Analysis/Contour/WorkedExamples/HalfDisc/Dirichlet.lean
@@ -1,0 +1,156 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+module
+
+public import TauCeti.Analysis.Contour.JordanLemma
+public import TauCeti.Analysis.Contour.Residue.SimplePole
+public import TauCeti.Analysis.Contour.WorkedExamples.HalfDisc.HalfResidue
+
+/-!
+# An improper integral evaluated by the generalized residue theorem
+
+The Hungerbühler–Wasem motivating example: the integrand `e^{iaz} / z` (`a > 0`) has a simple
+pole sitting **on** the contour, so the classical residue theorem does not apply, and the
+integral along the real axis exists only as a Cauchy principal value.
+
+Running the half-disc contour of `HalfDisc/Basic.lean` and letting the radius grow:
+
+* the half-residue theorem gives `∮ = π i · Res₀ f` — half the enclosed-pole answer, because the
+  generalized winding number at a smooth crossing is `½`;
+* `hasCauchyPV_realSegment_diameter` subtracts the arc and restates the result along the real
+  line, leaving the segment alone;
+* Jordan's lemma kills the arc as `R → ∞`, since `‖1/z‖ = 1/R → 0` on it.
+
+The oscillatory factor is essential rather than cosmetic: for `f z = z⁻¹` alone (`a = 0`) the
+arc integral is `i π` for **every** `R` and never vanishes, so no limit exists to take. That is
+exactly the regime the naive `ML` bound cannot reach and Jordan's lemma can.
+
+## Main results
+
+* `TauCeti.Contour.residue_exp_mul_I_div_self` — `Res₀ (e^{iaz}/z) = 1`, for every frequency.
+* `TauCeti.Contour.neg_one_le_meromorphicOrderAt_dirichletIntegrand` — the pole is at worst
+  simple, the hypothesis the half-residue theorem consumes.
+* `TauCeti.Contour.hasCauchyPV_realSegment_dirichlet` — for each radius, the principal value
+  along `[-R, R]` on the real axis is `π i` minus the arc contribution.
+* `TauCeti.Contour.tendsto_integral_arc_dirichlet_atTop` — the arc contribution vanishes, by
+  Jordan's lemma at `a = 1`.
+* `TauCeti.Contour.tendsto_diameter_halfDiscBoundary_dirichlet` — hence the diameter principal
+  values converge to `π i`.
+
+## References
+
+* N. Hungerbühler, M. Wasem, *Non-integer valued winding numbers and a generalized Residue
+  Theorem*, arXiv:1808.00997, Thm 3.3.
+-/
+
+public section
+
+noncomputable section
+
+open Complex Filter Topology Set
+
+namespace TauCeti.Contour
+
+/-- The oscillatory Dirichlet integrand `e^{iaz} / z`, for a frequency `a`. -/
+def dirichletIntegrand (a : ℝ) (z : ℂ) : ℂ := Complex.exp (Complex.I * (a : ℂ) * z) / z
+
+theorem dirichletIntegrand_eq (a : ℝ) (z : ℂ) :
+    dirichletIntegrand a z = Complex.exp (Complex.I * (a : ℂ) * z) * z⁻¹ := by
+  rw [dirichletIntegrand, div_eq_mul_inv]
+
+theorem meromorphicAt_dirichletIntegrand (a : ℝ) :
+    MeromorphicAt (dirichletIntegrand a) 0 := by
+  have h : MeromorphicAt (fun z : ℂ => Complex.exp (Complex.I * (a : ℂ) * z) * z⁻¹) 0 :=
+    (((analyticAt_cexp (z := Complex.I * (a : ℂ) * 0)).comp
+      (analyticAt_const.mul analyticAt_id)).meromorphicAt).mul
+      (analyticAt_id.meromorphicAt.inv)
+  exact h.congr (Filter.Eventually.of_forall fun z => (dirichletIntegrand_eq a z).symm)
+
+/-- Near the origin `z · e^{iz}/z = e^{iz} → 1`. This single limit yields both the residue and
+the simplicity of the pole. -/
+theorem tendsto_sub_mul_dirichletIntegrand (a : ℝ) :
+    Tendsto (fun z : ℂ => (z - 0) * dirichletIntegrand a z) (𝓝[≠] 0) (𝓝 1) := by
+  have hlim : Tendsto (fun z : ℂ => Complex.exp (Complex.I * (a : ℂ) * z)) (𝓝[≠] 0) (𝓝 1) := by
+    have hc : Continuous fun z : ℂ => Complex.exp (Complex.I * (a : ℂ) * z) := by fun_prop
+    simpa using (hc.continuousAt (x := (0 : ℂ))).continuousWithinAt.tendsto
+  refine hlim.congr' ?_
+  filter_upwards [self_mem_nhdsWithin] with z hz
+  have hz0 : z ≠ 0 := by simpa using hz
+  rw [dirichletIntegrand_eq, sub_zero]
+  field_simp
+
+/-- **The residue of `e^{iz}/z` at the origin is `1`.** -/
+theorem residue_exp_mul_I_div_self (a : ℝ) : residue (dirichletIntegrand a) 0 = 1 :=
+  residue_eq_of_tendsto_sub_mul (meromorphicAt_dirichletIntegrand a)
+    (tendsto_sub_mul_dirichletIntegrand a)
+
+/-- The Dirichlet integrand is holomorphic away from the origin. -/
+theorem differentiableOn_dirichletIntegrand (a : ℝ) :
+    DifferentiableOn ℂ (dirichletIntegrand a) (univ \ {0}) := by
+  intro z hz
+  have hz0 : z ≠ 0 := by simpa using hz.2
+  refine (DifferentiableAt.div ?_ differentiableAt_id hz0).differentiableWithinAt
+  exact (Complex.differentiable_exp _).comp z (by fun_prop)
+
+/-- **The pole at the origin is at worst simple.** Multiplying by `z` gives a function with a
+limit there, so the order of `e^{iz}/z` is at least `-1` — the hypothesis the half-residue
+theorem consumes. -/
+theorem neg_one_le_meromorphicOrderAt_dirichletIntegrand (a : ℝ) :
+    ((-1 : ℤ) : WithTop ℤ) ≤ meromorphicOrderAt (dirichletIntegrand a) 0 := by
+  have hid : MeromorphicAt (fun z : ℂ => z - 0) 0 :=
+    (analyticAt_id.sub analyticAt_const).meromorphicAt
+  have hprod : meromorphicOrderAt (fun z : ℂ => (z - 0) * dirichletIntegrand a z) 0
+      = 1 + meromorphicOrderAt (dirichletIntegrand a) 0 := by
+    have h := meromorphicOrderAt_mul hid (meromorphicAt_dirichletIntegrand a)
+    rwa [meromorphicOrderAt_id_sub_const] at h
+  have hnn : 0 ≤ meromorphicOrderAt (fun z : ℂ => (z - 0) * dirichletIntegrand a z) 0 :=
+    (tendsto_nhds_iff_meromorphicOrderAt_nonneg
+      (hid.mul (meromorphicAt_dirichletIntegrand a))).1 ⟨1, tendsto_sub_mul_dirichletIntegrand a⟩
+  rw [hprod] at hnn
+  induction hord : meromorphicOrderAt (dirichletIntegrand a) 0 using WithTop.recTopCoe with
+  | top => exact le_top
+  | coe n =>
+      rw [hord] at hnn
+      norm_cast at hnn ⊢
+      omega
+
+/-- **The identity along the real segment.** For each positive radius the principal value of
+`e^{iaz}/z` along `[-R, R]` on the real axis is `π i` minus the arc contribution. The pole sits on
+the path of integration, so this is a genuine principal value, not an ordinary integral. -/
+theorem hasCauchyPV_realSegment_dirichlet (a : ℝ) {R : ℝ} (hR : 0 < R) :
+    HasCauchyPV (fun t : ℝ => (t : ℂ)) (-R) R (dirichletIntegrand a)
+      ((Real.pi : ℂ) * Complex.I -
+        ∫ θ in (0 : ℝ)..Real.pi,
+          dirichletIntegrand a (circleMap 0 R θ) * deriv (circleMap 0 R) θ) := by
+  simpa [residue_exp_mul_I_div_self a] using
+    hasCauchyPV_realSegment_diameter hR (differentiableOn_dirichletIntegrand a)
+      (meromorphicAt_dirichletIntegrand a) (neg_one_le_meromorphicOrderAt_dirichletIntegrand a)
+
+/-- **The arc contribution vanishes** for a positive frequency. This is Jordan's lemma: on the
+semicircle the amplitude bound is `‖1/z‖ = 1/R → 0`, which the naive `ML` bound could not
+exploit. -/
+theorem tendsto_integral_arc_dirichlet_atTop {a : ℝ} (ha : 0 < a) :
+    Tendsto (fun R : ℝ => ∫ θ in (0 : ℝ)..Real.pi,
+      dirichletIntegrand a (circleMap 0 R θ) * deriv (circleMap 0 R) θ) atTop (𝓝 0) := by
+  refine (tendsto_integral_semicircle_exp_div_atTop_nhds_zero (a := a) ha).congr fun R => ?_
+  refine intervalIntegral.integral_congr fun θ _ => ?_
+  rw [dirichletIntegrand_eq]
+  ring
+
+/-- **The improper limit.** As the radius grows, the diameter principal values converge to `π i`
+— the half-residue, evaluated by the Hungerbühler–Wasem theorem on a contour through the pole,
+where the classical residue theorem does not apply. -/
+theorem tendsto_diameter_halfDiscBoundary_dirichlet {a : ℝ} (ha : 0 < a) :
+    Tendsto (fun R : ℝ => (Real.pi : ℂ) * Complex.I -
+      ∫ θ in (0 : ℝ)..Real.pi,
+        dirichletIntegrand a (circleMap 0 R θ) * deriv (circleMap 0 R) θ)
+      atTop (𝓝 ((Real.pi : ℂ) * Complex.I)) := by
+  simpa using tendsto_const_nhds.sub (tendsto_integral_arc_dirichlet_atTop ha)
+
+end TauCeti.Contour
+
+end
+
+end


### PR DESCRIPTION
Closes the ContourIntegration roadmap's improper-integral acceptance criterion — the Hungerbühler–Wasem motivating example, end to end.

## The example

For `f z = e^{iaz} / z` the simple pole sits **on** the path of integration. The classical residue theorem does not apply, and the real-axis integral exists only as a Cauchy principal value. What replaces it is the **half-residue**: the generalized winding number at a smooth crossing is `½`, so the principal value picks up `π i · Res` rather than `2π i · Res`.

$$\mathrm{PV}\!\int_{-R}^{R} \frac{e^{iax}}{x}\,dx \;=\; \pi i \;-\; \int_{C_R} \frac{e^{iaz}}{z}\,dz \qquad (R > 0), \qquad\qquad \int_{C_R} \longrightarrow 0 \quad (R \to \infty)$$

so the principal values converge to `π i`.

## Contents

* `dirichletIntegrand a z = e^{iaz}/z`, with `differentiableOn_dirichletIntegrand` and `meromorphicAt_dirichletIntegrand`.
* `tendsto_sub_mul_dirichletIntegrand` — the single limit `z · e^{iaz}/z → 1`, from which both facts below follow.
* `residue_exp_mul_I_div_self` — `Res₀ = 1`.
* `neg_one_le_meromorphicOrderAt_dirichletIntegrand` — the pole is at worst simple, the hypothesis the half-residue theorem consumes.
* `hasCauchyPV_realSegment_dirichlet` — the identity above, stated along the curve `t ↦ t`, so it is a statement about the real axis with no mention of the auxiliary contour.
* `tendsto_integral_arc_dirichlet_atTop` — the arc vanishes, by Jordan's lemma.
* `tendsto_cauchyPV_realSegment_dirichlet` — hence the **principal values themselves** converge:

  ```
  Tendsto (fun R => cauchyPV (fun t : ℝ => (t : ℂ)) (-R) R (dirichletIntegrand a))
    atTop (𝓝 (π * I))
  ```

  The conclusion is about `cauchyPV` along the real line, not about an auxiliary expression that happens to have the right limit.

The frequency is arbitrary: the residue is `1` and the pole simple for every `a`, and only the arc estimate needs `a > 0`. The `a = 0` case is instructive: the arc integral is `i π` for **every** `R`, so it converges but not to `0`, and Jordan's lemma does not apply — the argument cannot deliver `π i`. The identity still holds there and reads `π i - i π = 0`, consistent with the symmetric principal values of `1/x` vanishing by oddness. Positive frequency is exactly what forces the arc to zero, in a regime the naive `ML` bound cannot reach.

## Roadmap

Closes the criterion in `TauCetiRoadmap/ContourIntegration/README.md`, heading **"Worked examples (acceptance criteria, keeping the theory honest)"**:

> **An improper integral** (e.g. a Cauchy principal value along the real axis with a simple pole at `0`) evaluated by HW Thm 3.3 where the classical theorem does not apply — HW's motivating example.

Built on Jordan's lemma (#1244), the concatenation API (#1253), the any-witness integrability result (#1259), the arc change of variables (#1260) and the half-disc split (#1268).

**Scope note.** This establishes the limit of the *principal values*. Recovering the Dirichlet integral `∫ sin x / x = π` in its classical form would require taking imaginary parts and relating the principal value to an improper Riemann integral; that is not done here.

## Gates

`lake build` · `lake exe axioms` · `lake exe module-system` · `scripts/lint-env.sh` — all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
