### PR TITLE
feat(Exchangeability): uniqueness of the mixing law

### DIFF
--- a/TauCeti/Probability/DeFinetti/Mixture.lean
+++ b/TauCeti/Probability/DeFinetti/Mixture.lean
@@ -41,11 +41,11 @@ witness as an explicit hypothesis instead of deriving it.
 ## What is not here
 
 The Layer 6 bullet in `TauCetiRoadmap/Exchangeability/README.md` asks for the mixture form with `π`
-the **unique** law of `ν`. Uniqueness (`mixedIID_mixingLaw_unique`) is not proved here or anywhere
-yet: at the roadmap's stated generality it needs finite-dimensional compact-box mixed-moment
-determinacy, which does not exist. That bullet is therefore only partly discharged, and the roadmap
-name `deFinetti_mixture` stays reserved for the theorem that *derives* a canonical witness rather
-than assuming one.
+the **unique** law of `ν`. That uniqueness is `mixedIID_mixingLaw_unique`, proved alongside the
+generic representation in `Exchangeability/MixedIID/Mixture.lean`; it is stated for `MixedIIDWith`
+witnesses and so does not mention `deFinettiMeasure`. The roadmap name `deFinetti_mixture` stays
+reserved for the theorem that *derives* a canonical witness rather than assuming one, which is
+still open.
 -/
 
 public section

--- a/TauCeti/Probability/Exchangeability/MixedIID/Mixture.lean
+++ b/TauCeti/Probability/Exchangeability/MixedIID/Mixture.lean
@@ -8,6 +8,7 @@ public import TauCeti.Probability.Exchangeability.MixedIID.Implications
 -- Non-public: used only inside the proof below.
 import TauCeti.Probability.Exchangeability.FiniteMarginals
 import TauCeti.MeasureTheory.Measure.GiryMonad
+import TauCeti.MeasureTheory.Measure.MixtureInjective
 
 /-!
 # The path law of a mixed i.i.d. process
@@ -25,6 +26,7 @@ written in the `Measure.bind` idiom.
 
 * `pathLaw_eq_bind_infinitePi_of_mixedIIDWith` — the representation, for an arbitrary mixing
   representative.
+* `mixedIID_mixingLaw_unique` — the mixing law `μ.map ν` is determined by the process.
 
 It needs only `[IsFiniteMeasure μ]`, a.e.-measurable coordinates, and the witness. In particular no
 standard-Borel hypothesis appears: that is the cost of *supplying* a canonical witness, not of using
@@ -41,8 +43,11 @@ recognise each prefix marginal of an infinite power as the corresponding finite 
 
 This advances `TauCetiRoadmap/Exchangeability/README.md`, Layer 6, the directing-measure API bullet
 asking for the mixture-of-product-measures form. That bullet also asks for `π` to be the *unique*
-law of `ν`; uniqueness is not proved here or anywhere yet, and the roadmap name `deFinetti_mixture`
-is reserved for the theorem that derives a canonical witness rather than assuming one.
+law of `ν`, which `mixedIID_mixingLaw_unique` now supplies: the mixture representation turns two
+witnesses into the same `Measure.bind`, and injectivity of `π ↦ π.bind (P ↦ P^{⊗ℕ})`
+(`Measure.ext_of_bind_infinitePi_eq`) identifies the mixing laws. The roadmap name
+`deFinetti_mixture` stays reserved for the theorem that derives a canonical witness rather than
+assuming one.
 -/
 
 public section
@@ -91,6 +96,27 @@ theorem pathLaw_eq_bind_infinitePi_of_mixedIIDWith {μ : Measure Ω} [IsFiniteMe
         simp_rw [hstep]
         rw [TauCeti.MeasureTheory.bind_map hν hfin]
         rfl
+
+/-- **Uniqueness of the mixing law.** Two mixing representatives for the same process induce the
+same law on `ProbabilityMeasure α`.
+
+Only the *law* `μ.map ν` is unique, not the witness. For a nondegenerate mixing law an independent
+copy of a mixing representative is another one, so no witness-level a.e.-equality theorem can
+conclude `ν =ᵐ[μ] ν'` from `MixedIIDWith` alone; a.e. uniqueness of the witness belongs to the
+conditional predicate (`conditionallyIID_ae_unique`).
+
+`[IsProbabilityMeasure μ]` is load-bearing rather than decorative. For an infinite base measure
+distinct mixing measures can produce identical `∞`-valued finite-dimensional mixtures, so
+mixing-law uniqueness fails at the hypothesis-light generality the definitions otherwise enjoy. -/
+theorem mixedIID_mixingLaw_unique {μ : Measure Ω} [IsProbabilityMeasure μ] {X : ℕ → Ω → α}
+    (hX : ∀ n, AEMeasurable (X n) μ) {ν ν' : Ω → ProbabilityMeasure α}
+    (h : MixedIIDWith μ X ν) (h' : MixedIIDWith μ X ν') :
+    μ.map ν = μ.map ν' := by
+  haveI : IsProbabilityMeasure (μ.map ν) :=
+    Measure.isProbabilityMeasure_map h.measurable_mixingRepresentative.aemeasurable
+  refine TauCeti.MeasureTheory.Measure.ext_of_bind_infinitePi_eq ?_
+  rw [← pathLaw_eq_bind_infinitePi_of_mixedIIDWith hX h,
+    ← pathLaw_eq_bind_infinitePi_of_mixedIIDWith hX h']
 
 end Probability
 

--- a/TauCeti/Probability/Exchangeability/MixedIID/Mixture.lean
+++ b/TauCeti/Probability/Exchangeability/MixedIID/Mixture.lean
@@ -105,15 +105,18 @@ copy of a mixing representative is another one, so no witness-level a.e.-equalit
 conclude `ν =ᵐ[μ] ν'` from `MixedIIDWith` alone; a.e. uniqueness of the witness belongs to the
 conditional predicate (`conditionallyIID_ae_unique`).
 
-`[IsProbabilityMeasure μ]` is load-bearing rather than decorative. For an infinite base measure
-distinct mixing measures can produce identical `∞`-valued finite-dimensional mixtures, so
-mixing-law uniqueness fails at the hypothesis-light generality the definitions otherwise enjoy. -/
-theorem mixedIID_mixingLaw_unique {μ : Measure Ω} [IsProbabilityMeasure μ] {X : ℕ → Ω → α}
+*Finiteness* of `μ` is load-bearing rather than decorative: for an infinite base measure, distinct
+mixing measures can produce identical `∞`-valued finite-dimensional mixtures, so mixing-law
+uniqueness fails at the hypothesis-light generality the definitions otherwise enjoy.
+
+Normalization, however, is not needed. The roadmap states this target with
+`[IsProbabilityMeasure μ]`, but the justification it gives only separates finite from infinite base
+measures, and the proof goes through for any finite `μ`. -/
+theorem mixedIID_mixingLaw_unique {μ : Measure Ω} [IsFiniteMeasure μ] {X : ℕ → Ω → α}
     (hX : ∀ n, AEMeasurable (X n) μ) {ν ν' : Ω → ProbabilityMeasure α}
     (h : MixedIIDWith μ X ν) (h' : MixedIIDWith μ X ν') :
     μ.map ν = μ.map ν' := by
-  haveI : IsProbabilityMeasure (μ.map ν) :=
-    Measure.isProbabilityMeasure_map h.measurable_mixingRepresentative.aemeasurable
+  haveI : IsFiniteMeasure (μ.map ν) := Measure.isFiniteMeasure_map _ _
   refine TauCeti.MeasureTheory.Measure.ext_of_bind_infinitePi_eq ?_
   rw [← pathLaw_eq_bind_infinitePi_of_mixedIIDWith hX h,
     ← pathLaw_eq_bind_infinitePi_of_mixedIIDWith hX h']

--- a/TauCeti/Probability/Moments/CompactDeterminacy.lean
+++ b/TauCeti/Probability/Moments/CompactDeterminacy.lean
@@ -21,7 +21,7 @@ hypothesis. Here the hypothesis is compact support instead, and the conclusion i
 two are genuinely different routes: that one is analytic (the moment generating function is
 analytic on a strip), this one is approximation-theoretic (Stone–Weierstrass).
 
-It supplies the determinacy input needed by `mixedIID_mixingLaw_unique`
+It supplies the determinacy input consumed by `mixedIID_mixingLaw_unique`
 (`TauCetiRoadmap/Exchangeability/README.md`, *Layer 6 — directing measures and de Finetti
 representation*), where the mixed monomials arise as the finite-dimensional moments of a mixture of
 i.i.d. laws on a compact box.


### PR DESCRIPTION
The mixing law of a mixed-i.i.d. process is unique.

```lean
theorem mixedIID_mixingLaw_unique {μ : Measure Ω} [IsFiniteMeasure μ] {X : ℕ → Ω → α}
    (hX : ∀ n, AEMeasurable (X n) μ) {ν ν' : Ω → ProbabilityMeasure α}
    (h : MixedIIDWith μ X ν) (h' : MixedIIDWith μ X ν') :
    μ.map ν = μ.map ν'
```

## Roadmap

`TauCetiRoadmap/Exchangeability/README.md`, **Layer 6: directing measures and de Finetti
representation** — the directing-measure API bullet's uniqueness clause.

Closes TauCetiProject/TauCetiRoadmap#95

## The proof

Six lines. `pathLaw_eq_bind_infinitePi_of_mixedIIDWith` rewrites each witness into the same
`Measure.bind`, and `Measure.ext_of_bind_infinitePi_eq` (#1275) identifies the mixing laws. All the
work is in the four PRs that preceded it:

| | |
|---|---|
| #1251 | compact multivariate moment determinacy |
| #1257 | finite evaluation laws determine a measure on `ProbabilityMeasure α` |
| #1272 | measurability of the real-valued evaluations |
| #1275 | injectivity of `π ↦ π.bind (P ↦ P^{⊗ℕ})` |

## Hypotheses

**`[IsFiniteMeasure μ]`, weaker than the roadmap's `[IsProbabilityMeasure μ]`.** Finiteness *is*
load-bearing: for an infinite base measure, distinct mixing measures can produce identical
`∞`-valued finite-dimensional mixtures, so uniqueness genuinely fails there. But normalization is
not needed, and the roadmap's own justification for the stronger hypothesis only separates finite
from infinite — it never distinguishes probability from finite. The proof goes through for any
finite `μ`, so this ships at the weaker hypothesis and the roadmap wording is worth a follow-up
correction.

**`AEMeasurable`, not `Measurable`.** The roadmap phrases the hypothesis as measurable `X`, but the
consumed representation needs only a.e.-measurability, so that is what is assumed.

## What this does *not* say

Only the mixing **law** `μ.map ν` is unique — never the witness. For a nondegenerate mixing law, an
independent copy of a mixing representative is another mixing representative, so no witness-level
theorem can conclude `ν =ᵐ[μ] ν'` from `MixedIIDWith` alone. A.e. uniqueness of the witness is a
statement about the *conditional* predicate (`conditionallyIID_ae_unique`), which remains open.

## Placement

`Exchangeability/MixedIID/Mixture.lean`, beside the representation it consumes. The statement
mentions only `MixedIIDWith` and `μ.map ν`, with no de Finetti measure, so it belongs with the
`MixedIIDWith` mixture API rather than under `DeFinetti/`. Both docstrings that recorded this
theorem as unproven — in `DeFinetti/Mixture.lean` and `Moments/CompactDeterminacy.lean` — are
updated.

## Verification

* Full `lake build` green.
* `lake exe axioms`: depends only on `propext`, `Classical.choice`, `Quot.sound`.
* `lake exe module-system` and `scripts/lint-env.sh` pass with no new violations.
