### PR TITLE
feat: add grid link components

### DIFF
--- a/TauCeti/KnotTheory/Grid/Diagram/Components.lean
+++ b/TauCeti/KnotTheory/Grid/Diagram/Components.lean
@@ -44,7 +44,7 @@ grid states", and supplies the knot-versus-link distinction needed by the later 
 Ozsváth--Stipsicz--Szabó, *Grid Homology for Knots and Links*, Chapter 3.
 -/
 
-@[expose] public section
+public section
 
 namespace TauCeti
 
@@ -65,11 +65,11 @@ def componentPerm : Equiv.Perm (Fin n) :=
 @[simp]
 theorem componentPerm_apply (c : Fin n) :
     G.componentPerm c = XColumnOfRow G (G.O c) :=
-  rfl
+  (rfl)
 
 /-- The component permutation has no fixed columns, because an `O` and an `X` cannot occupy the
 same square. -/
-theorem componentPerm_ne (c : Fin n) : G.componentPerm c ≠ c := by
+theorem componentPerm_apply_ne_self (c : Fin n) : G.componentPerm c ≠ c := by
   intro h
   apply G.disjoint c
   simpa [componentPerm] using congrArg (fun d => G.X d) h
@@ -78,17 +78,13 @@ theorem componentPerm_ne (c : Fin n) : G.componentPerm c ≠ c := by
 @[simp]
 theorem support_componentPerm : G.componentPerm.support = Finset.univ := by
   ext c
-  simpa only [Equiv.Perm.mem_support, Finset.mem_univ, iff_true] using G.componentPerm_ne c
+  simpa only [Equiv.Perm.mem_support, Finset.mem_univ, iff_true] using
+    G.componentPerm_apply_ne_self c
 
 /-- The cycle factors of the component permutation. Each factor is one component of the
 represented link, expressed as a cyclic permutation of its `O`-marking columns. -/
 def componentCycles : Finset (Equiv.Perm (Fin n)) :=
   G.componentPerm.cycleFactorsFinset
-
-/-- The component cycles are the cycle factors of `componentPerm`. -/
-theorem componentCycles_def :
-    G.componentCycles = G.componentPerm.cycleFactorsFinset :=
-  rfl
 
 /-- A permutation is a component cycle exactly when it is a cycle agreeing with the component
 permutation throughout its support. -/
@@ -101,19 +97,9 @@ theorem mem_componentCycles_iff (c : Equiv.Perm (Fin n)) :
 def componentCycleType : Multiset ℕ :=
   G.componentPerm.cycleType
 
-/-- The component-size multiset is the cycle type of `componentPerm`. -/
-theorem componentCycleType_def :
-    G.componentCycleType = G.componentPerm.cycleType :=
-  rfl
-
 /-- The number of components of the link represented by a grid diagram. -/
 def componentCount : ℕ :=
   G.componentCycleType.card
-
-/-- The component count is the cardinality of the component-size multiset. -/
-theorem componentCount_def :
-    G.componentCount = G.componentCycleType.card :=
-  rfl
 
 /-- The number of component cycles agrees with `componentCount`. -/
 @[simp]
@@ -130,6 +116,11 @@ theorem sum_componentCycleType : G.componentCycleType.sum = n := by
 def IsKnot : Prop :=
   G.componentCount = 1
 
+/-- A grid diagram represents a knot exactly when its component count is one. -/
+@[simp]
+theorem isKnot_iff_componentCount_eq_one : G.IsKnot ↔ G.componentCount = 1 :=
+  by rw [IsKnot]
+
 /-- A grid diagram represents a knot exactly when its component permutation is a single
 nontrivial cycle. -/
 theorem isKnot_iff_componentPerm_isCycle :
@@ -143,17 +134,29 @@ theorem IsKnot.componentCycleType_eq (hG : G.IsKnot) :
   rw [componentCycleType, (G.isKnot_iff_componentPerm_isCycle.mp hG).cycleType,
     support_componentPerm, Finset.card_univ, Fintype.card_fin]
 
+/-- A grid diagram has no link components exactly when its size is zero. -/
+@[simp]
+theorem componentCount_eq_zero_iff : G.componentCount = 0 ↔ n = 0 := by
+  constructor
+  · intro h
+    rw [componentCount] at h
+    have htype : G.componentCycleType = 0 := Multiset.card_eq_zero.mp h
+    simpa [htype] using (G.sum_componentCycleType).symm
+  · intro h
+    subst n
+    rw [componentCount, componentCycleType]
+    have hperm : G.componentPerm = 1 := Subsingleton.elim _ _
+    simp [hperm]
+
 /-- The empty grid has no link components. -/
 @[simp]
 theorem componentCount_eq_zero_of_zero (G : GridDiagram 0) :
-    G.componentCount = 0 := by
-  rw [componentCount, componentCycleType]
-  have hperm : G.componentPerm = 1 := Subsingleton.elim _ _
-  simp [hperm]
+    G.componentCount = 0 :=
+  G.componentCount_eq_zero_iff.mpr rfl
 
 /-- An empty grid does not represent a knot. -/
 theorem not_isKnot_of_zero (G : GridDiagram 0) : ¬G.IsKnot := by
-  simp [IsKnot]
+  simp
 
 /-- Every `2 × 2` grid diagram represents a knot. Its fixed-point-free component permutation is
 the transposition of the two columns. -/

--- a/TauCeti/KnotTheory/Grid/Diagram/Components.lean
+++ b/TauCeti/KnotTheory/Grid/Diagram/Components.lean
@@ -117,7 +117,6 @@ def IsKnot : Prop :=
   G.componentCount = 1
 
 /-- A grid diagram represents a knot exactly when its component count is one. -/
-@[simp]
 theorem isKnot_iff_componentCount_eq_one : G.IsKnot ↔ G.componentCount = 1 :=
   by rw [IsKnot]
 
@@ -156,7 +155,8 @@ theorem componentCount_eq_zero_of_zero (G : GridDiagram 0) :
 
 /-- An empty grid does not represent a knot. -/
 theorem not_isKnot_of_zero (G : GridDiagram 0) : ¬G.IsKnot := by
-  simp
+  rw [isKnot_iff_componentCount_eq_one, componentCount_eq_zero_of_zero]
+  exact Nat.zero_ne_one
 
 /-- Every `2 × 2` grid diagram represents a knot. Its fixed-point-free component permutation is
 the transposition of the two columns. -/

--- a/TauCeti/KnotTheory/Grid/Diagram/Components.lean
+++ b/TauCeti/KnotTheory/Grid/Diagram/Components.lean
@@ -88,6 +88,7 @@ def componentCycles : Finset (Equiv.Perm (Fin n)) :=
 
 /-- A permutation is a component cycle exactly when it is a cycle agreeing with the component
 permutation throughout its support. -/
+@[simp]
 theorem mem_componentCycles_iff (c : Equiv.Perm (Fin n)) :
     c ∈ G.componentCycles ↔
       c.IsCycle ∧ ∀ a ∈ c.support, c a = G.componentPerm a := by

--- a/TauCeti/KnotTheory/Grid/Diagram/Components.lean
+++ b/TauCeti/KnotTheory/Grid/Diagram/Components.lean
@@ -117,10 +117,6 @@ theorem sum_componentCycleType : G.componentCycleType.sum = n := by
 def IsKnot : Prop :=
   G.componentCount = 1
 
-/-- A grid diagram represents a knot exactly when its component count is one. -/
-theorem isKnot_iff_componentCount_eq_one : G.IsKnot ↔ G.componentCount = 1 :=
-  by rw [IsKnot]
-
 /-- A grid diagram represents a knot exactly when its component permutation is a single
 nontrivial cycle. -/
 theorem isKnot_iff_componentPerm_isCycle :
@@ -156,7 +152,7 @@ theorem componentCount_eq_zero_of_zero (G : GridDiagram 0) :
 
 /-- An empty grid does not represent a knot. -/
 theorem not_isKnot_of_zero (G : GridDiagram 0) : ¬G.IsKnot := by
-  rw [isKnot_iff_componentCount_eq_one, componentCount_eq_zero_of_zero]
+  rw [IsKnot, componentCount_eq_zero_of_zero]
   exact Nat.zero_ne_one
 
 /-- Every `2 × 2` grid diagram represents a knot. Its fixed-point-free component permutation is

--- a/TauCeti/KnotTheory/Grid/Diagram/Components.lean
+++ b/TauCeti/KnotTheory/Grid/Diagram/Components.lean
@@ -151,12 +151,14 @@ theorem componentCount_eq_zero_of_zero (G : GridDiagram 0) :
   G.componentCount_eq_zero_iff.mpr rfl
 
 /-- An empty grid does not represent a knot. -/
+@[simp]
 theorem not_isKnot_of_zero (G : GridDiagram 0) : ¬G.IsKnot := by
   rw [IsKnot, componentCount_eq_zero_of_zero]
   exact Nat.zero_ne_one
 
 /-- Every `2 × 2` grid diagram represents a knot. Its fixed-point-free component permutation is
 the transposition of the two columns. -/
+@[simp]
 theorem isKnot_of_two (G : GridDiagram 2) : G.IsKnot := by
   rw [isKnot_iff_componentPerm_isCycle]
   apply Equiv.Perm.IsSwap.isCycle

--- a/TauCeti/KnotTheory/Grid/Diagram/Components.lean
+++ b/TauCeti/KnotTheory/Grid/Diagram/Components.lean
@@ -182,6 +182,19 @@ theorem componentPerm_relabelColumns (κ : Equiv.Perm (Fin n)) :
   ext c
   simp [componentPerm_apply]
 
+/-- Row relabeling preserves the component cycles. -/
+@[simp]
+theorem componentCycles_relabelRows (ρ : Equiv.Perm (Fin n)) :
+    (G.relabelRows ρ).componentCycles = G.componentCycles := by
+  simp [componentCycles]
+
+/-- Column relabeling transports component cycles by conjugation. -/
+theorem mem_componentCycles_relabelColumns (κ c : Equiv.Perm (Fin n)) :
+    κ * c * κ⁻¹ ∈ (G.relabelColumns κ).componentCycles ↔
+      c ∈ G.componentCycles := by
+  rw [componentCycles, componentPerm_relabelColumns, componentCycles,
+    Equiv.Perm.mem_cycleFactorsFinset_conj]
+
 /-- Row relabeling preserves the component-size multiset. -/
 @[simp]
 theorem componentCycleType_relabelRows (ρ : Equiv.Perm (Fin n)) :
@@ -201,6 +214,26 @@ theorem componentPerm_swapMarkings :
     G.swapMarkings.componentPerm = G.componentPerm⁻¹ := by
   simp [componentPerm]
 
+/-- Exchanging the marking types reverses every component cycle. -/
+theorem mem_componentCycles_swapMarkings (c : Equiv.Perm (Fin n)) :
+    c⁻¹ ∈ G.swapMarkings.componentCycles ↔ c ∈ G.componentCycles := by
+  rw [componentCycles, componentPerm_swapMarkings, componentCycles]
+  have aux : ∀ {g c : Equiv.Perm (Fin n)}, c ∈ g.cycleFactorsFinset →
+      c⁻¹ ∈ g⁻¹.cycleFactorsFinset := by
+    intro g c hmem
+    have hc := Equiv.Perm.mem_cycleFactorsFinset_iff.mp hmem
+    rw [Equiv.Perm.mem_cycleFactorsFinset_iff]
+    refine ⟨hc.1.inv, ?_⟩
+    intro a ha
+    rw [Equiv.Perm.support_inv] at ha
+    have hga : g⁻¹ a ∈ c.support := by
+      rw [← Equiv.Perm.mem_cycleFactorsFinset_support hmem (g⁻¹ a)]
+      simpa using ha
+    apply c.injective
+    simpa using (hc.2 (g⁻¹ a) hga).symm
+  refine ⟨fun h ↦ ?_, aux⟩
+  simpa using aux (g := G.componentPerm⁻¹) (c := c⁻¹) h
+
 /-- Exchanging the two marking types preserves the component-size multiset. -/
 @[simp]
 theorem componentCycleType_swapMarkings :
@@ -216,12 +249,28 @@ theorem componentPerm_transpose :
   ext c
   simp [componentPerm, GridState.transpose]
 
+/-- Diagonal reflection transports component cycles by inversion and conjugation. -/
+theorem mem_componentCycles_transpose (c : Equiv.Perm (Fin n)) :
+    G.X.toPerm * c⁻¹ * G.X.toPerm⁻¹ ∈ G.transpose.componentCycles ↔
+      c ∈ G.componentCycles := by
+  rw [componentCycles, componentPerm_transpose,
+    Equiv.Perm.mem_cycleFactorsFinset_conj]
+  simpa [componentCycles, componentPerm_swapMarkings] using
+    G.mem_componentCycles_swapMarkings c
+
 /-- Diagonal reflection preserves the component-size multiset. -/
 @[simp]
 theorem componentCycleType_transpose :
     G.transpose.componentCycleType = G.componentCycleType := by
   rw [componentCycleType, componentPerm_transpose, Equiv.Perm.cycleType_conj,
     Equiv.Perm.cycleType_inv, componentCycleType]
+
+/-- Half-turn rotation transports component cycles by coordinate-reversal conjugation. -/
+theorem mem_componentCycles_rotate (c : Equiv.Perm (Fin n)) :
+    Fin.revPerm * c * Fin.revPerm⁻¹ ∈ G.rotate.componentCycles ↔
+      c ∈ G.componentCycles := by
+  simpa [GridDiagram.rotate] using
+    G.mem_componentCycles_relabelColumns Fin.revPerm c
 
 /-- Half-turn rotation preserves the component-size multiset. -/
 @[simp]

--- a/TauCeti/KnotTheory/Grid/Diagram/Components.lean
+++ b/TauCeti/KnotTheory/Grid/Diagram/Components.lean
@@ -1,0 +1,289 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+module
+
+public import Mathlib.GroupTheory.Perm.Cycle.Type
+public import TauCeti.KnotTheory.Grid.Diagram.Relabeling
+public import TauCeti.KnotTheory.Grid.Rotation
+
+/-!
+# Link components of a grid diagram
+
+The `O`- and `X`-markings of a grid diagram determine an oriented link combinatorially. Starting
+at the `O`-marking in column `c`, follow its horizontal segment to the `X`-marking in the same
+row, then follow the vertical segment to the `O`-marking in that column. On column labels this is
+the permutation
+
+`c ↦ X⁻¹(O(c))`.
+
+Its cycles are exactly the link components. This file packages that permutation, its cycle
+decomposition and component count, and the predicate that the represented link is a knot. The
+grid-diagram disjointness condition makes the component permutation fixed-point-free, so
+Mathlib's cycle decomposition accounts for every marking.
+
+Row relabeling leaves the component permutation unchanged, while column relabeling conjugates it.
+Consequently the cycle type, component count, and knot predicate are preserved by both
+relabelings, as well as by diagonal reflection, half-turn rotation, and exchanging `O` with `X`.
+
+## Main definitions
+
+* `TauCeti.GridDiagram.componentPerm`: the permutation obtained by following one horizontal and
+  one vertical grid segment.
+* `TauCeti.GridDiagram.componentCycles`: the cycle factors representing the link components.
+* `TauCeti.GridDiagram.componentCycleType`: the multiset of component sizes.
+* `TauCeti.GridDiagram.componentCount`: the number of represented link components.
+* `TauCeti.GridDiagram.IsKnot`: the represented link has exactly one component.
+
+## References
+
+This advances `TauCetiRoadmap/CombinatorialHeegaardFloer/README.md`, Lane G.1, "Grid diagrams and
+grid states", and supplies the knot-versus-link distinction needed by the later knot invariant
+`τ` in Lane G.6 and the links stage in Lane G.9. The component traversal follows
+Ozsváth--Stipsicz--Szabó, *Grid Homology for Knots and Links*, Chapter 3.
+-/
+
+@[expose] public section
+
+namespace TauCeti
+
+namespace GridDiagram
+
+variable {n : ℕ} (G : GridDiagram n)
+
+/-- The permutation of `O`-marking columns obtained by traversing one horizontal segment from
+`O` to `X`, then the vertical segment back to `O`.
+
+Thus `componentPerm G c = XColumnOfRow G (G.O c)`. Its permutation cycles are the components of
+the oriented link represented by `G`. -/
+def componentPerm : Equiv.Perm (Fin n) :=
+  G.X.toPerm⁻¹ * G.O.toPerm
+
+/-- Applying the component permutation follows the `O`-marking's row to its unique
+`X`-marking column. -/
+@[simp]
+theorem componentPerm_apply (c : Fin n) :
+    G.componentPerm c = XColumnOfRow G (G.O c) :=
+  rfl
+
+/-- The component permutation has no fixed columns, because an `O` and an `X` cannot occupy the
+same square. -/
+theorem componentPerm_ne (c : Fin n) : G.componentPerm c ≠ c := by
+  intro h
+  apply G.disjoint c
+  simpa [componentPerm] using congrArg (fun d => G.X d) h
+
+/-- Every column belongs to the support of the component permutation. -/
+@[simp]
+theorem support_componentPerm : G.componentPerm.support = Finset.univ := by
+  ext c
+  simpa only [Equiv.Perm.mem_support, Finset.mem_univ, iff_true] using G.componentPerm_ne c
+
+/-- The cycle factors of the component permutation. Each factor is one component of the
+represented link, expressed as a cyclic permutation of its `O`-marking columns. -/
+def componentCycles : Finset (Equiv.Perm (Fin n)) :=
+  G.componentPerm.cycleFactorsFinset
+
+/-- The component cycles are the cycle factors of `componentPerm`. -/
+theorem componentCycles_def :
+    G.componentCycles = G.componentPerm.cycleFactorsFinset :=
+  rfl
+
+/-- A permutation is a component cycle exactly when it is a cycle agreeing with the component
+permutation throughout its support. -/
+theorem mem_componentCycles_iff (c : Equiv.Perm (Fin n)) :
+    c ∈ G.componentCycles ↔
+      c.IsCycle ∧ ∀ a ∈ c.support, c a = G.componentPerm a := by
+  rw [componentCycles, Equiv.Perm.mem_cycleFactorsFinset_iff]
+
+/-- The multiset of component sizes of the link represented by a grid diagram. -/
+def componentCycleType : Multiset ℕ :=
+  G.componentPerm.cycleType
+
+/-- The component-size multiset is the cycle type of `componentPerm`. -/
+theorem componentCycleType_def :
+    G.componentCycleType = G.componentPerm.cycleType :=
+  rfl
+
+/-- The number of components of the link represented by a grid diagram. -/
+def componentCount : ℕ :=
+  G.componentCycleType.card
+
+/-- The component count is the cardinality of the component-size multiset. -/
+theorem componentCount_def :
+    G.componentCount = G.componentCycleType.card :=
+  rfl
+
+/-- The number of component cycles agrees with `componentCount`. -/
+@[simp]
+theorem card_componentCycles : G.componentCycles.card = G.componentCount := by
+  simp [componentCycles, componentCount, componentCycleType, Equiv.Perm.cycleType_def]
+
+/-- The component sizes sum to the grid size: every marking belongs to exactly one component. -/
+@[simp]
+theorem sum_componentCycleType : G.componentCycleType.sum = n := by
+  rw [componentCycleType, Equiv.Perm.sum_cycleType, support_componentPerm,
+    Finset.card_univ, Fintype.card_fin]
+
+/-- A grid diagram represents a knot when its component permutation has exactly one cycle. -/
+def IsKnot : Prop :=
+  G.componentCount = 1
+
+/-- A grid diagram represents a knot exactly when its component permutation is a single
+nontrivial cycle. -/
+theorem isKnot_iff_componentPerm_isCycle :
+    G.IsKnot ↔ G.componentPerm.IsCycle := by
+  rw [IsKnot, componentCount, componentCycleType,
+    Equiv.Perm.card_cycleType_eq_one]
+
+/-- The sole component of a knot grid contains all `n` markings. -/
+theorem IsKnot.componentCycleType_eq (hG : G.IsKnot) :
+    G.componentCycleType = {n} := by
+  rw [componentCycleType, (G.isKnot_iff_componentPerm_isCycle.mp hG).cycleType,
+    support_componentPerm, Finset.card_univ, Fintype.card_fin]
+
+/-- The empty grid has no link components. -/
+@[simp]
+theorem componentCount_eq_zero_of_zero (G : GridDiagram 0) :
+    G.componentCount = 0 := by
+  rw [componentCount, componentCycleType]
+  have hperm : G.componentPerm = 1 := Subsingleton.elim _ _
+  simp [hperm]
+
+/-- An empty grid does not represent a knot. -/
+theorem not_isKnot_of_zero (G : GridDiagram 0) : ¬G.IsKnot := by
+  simp [IsKnot]
+
+/-- Every `2 × 2` grid diagram represents a knot. Its fixed-point-free component permutation is
+the transposition of the two columns. -/
+theorem isKnot_of_two (G : GridDiagram 2) : G.IsKnot := by
+  rw [isKnot_iff_componentPerm_isCycle]
+  apply Equiv.Perm.IsSwap.isCycle
+  rw [← Equiv.Perm.card_support_eq_two, support_componentPerm,
+    Finset.card_univ, Fintype.card_fin]
+
+/-! ### Naturality under grid symmetries -/
+
+/-- Relabeling rows does not change the component permutation: the common row relabeling cancels
+between the `O`- and `X`-marking permutations. -/
+@[simp]
+theorem componentPerm_relabelRows (ρ : Equiv.Perm (Fin n)) :
+    (G.relabelRows ρ).componentPerm = G.componentPerm := by
+  ext c
+  simp [componentPerm_apply]
+
+/-- Relabeling columns conjugates the component permutation by the column relabeling. -/
+theorem componentPerm_relabelColumns (κ : Equiv.Perm (Fin n)) :
+    (G.relabelColumns κ).componentPerm =
+      κ * G.componentPerm * κ⁻¹ := by
+  ext c
+  simp [componentPerm_apply]
+
+/-- Row relabeling preserves the component-size multiset. -/
+@[simp]
+theorem componentCycleType_relabelRows (ρ : Equiv.Perm (Fin n)) :
+    (G.relabelRows ρ).componentCycleType = G.componentCycleType := by
+  rw [componentCycleType, componentPerm_relabelRows, componentCycleType]
+
+/-- Column relabeling preserves the component-size multiset. -/
+@[simp]
+theorem componentCycleType_relabelColumns (κ : Equiv.Perm (Fin n)) :
+    (G.relabelColumns κ).componentCycleType = G.componentCycleType := by
+  rw [componentCycleType, componentPerm_relabelColumns, Equiv.Perm.cycleType_conj,
+    componentCycleType]
+
+/-- Exchanging the `O`- and `X`-markings inverts the component permutation. -/
+@[simp]
+theorem componentPerm_swapMarkings :
+    G.swapMarkings.componentPerm = G.componentPerm⁻¹ := by
+  simp [componentPerm]
+
+/-- Exchanging the two marking types preserves the component-size multiset. -/
+@[simp]
+theorem componentCycleType_swapMarkings :
+    G.swapMarkings.componentCycleType = G.componentCycleType := by
+  rw [componentCycleType, componentPerm_swapMarkings, Equiv.Perm.cycleType_inv,
+    componentCycleType]
+
+/-- Diagonal reflection conjugates the inverse component permutation by the `X`-marking
+permutation. -/
+theorem componentPerm_transpose :
+  G.transpose.componentPerm =
+      G.X.toPerm * G.componentPerm⁻¹ * G.X.toPerm⁻¹ := by
+  ext c
+  simp [componentPerm, GridState.transpose]
+
+/-- Diagonal reflection preserves the component-size multiset. -/
+@[simp]
+theorem componentCycleType_transpose :
+    G.transpose.componentCycleType = G.componentCycleType := by
+  rw [componentCycleType, componentPerm_transpose, Equiv.Perm.cycleType_conj,
+    Equiv.Perm.cycleType_inv, componentCycleType]
+
+/-- Half-turn rotation preserves the component-size multiset. -/
+@[simp]
+theorem componentCycleType_rotate :
+    G.rotate.componentCycleType = G.componentCycleType := by
+  rw [GridDiagram.rotate, componentCycleType_relabelRows, componentCycleType_relabelColumns]
+
+/-- Row relabeling preserves the number of represented link components. -/
+@[simp]
+theorem componentCount_relabelRows (ρ : Equiv.Perm (Fin n)) :
+    (G.relabelRows ρ).componentCount = G.componentCount := by
+  simp [componentCount]
+
+/-- Column relabeling preserves the number of represented link components. -/
+@[simp]
+theorem componentCount_relabelColumns (κ : Equiv.Perm (Fin n)) :
+    (G.relabelColumns κ).componentCount = G.componentCount := by
+  simp [componentCount]
+
+/-- Diagonal reflection preserves the number of represented link components. -/
+@[simp]
+theorem componentCount_transpose :
+    G.transpose.componentCount = G.componentCount := by
+  simp [componentCount]
+
+/-- Half-turn rotation preserves the number of represented link components. -/
+@[simp]
+theorem componentCount_rotate :
+    G.rotate.componentCount = G.componentCount := by
+  simp [componentCount]
+
+/-- Exchanging the two marking types preserves the number of represented link components. -/
+@[simp]
+theorem componentCount_swapMarkings :
+    G.swapMarkings.componentCount = G.componentCount := by
+  simp [componentCount]
+
+/-- Row relabeling preserves whether a grid diagram represents a knot. -/
+@[simp]
+theorem isKnot_relabelRows (ρ : Equiv.Perm (Fin n)) :
+    (G.relabelRows ρ).IsKnot ↔ G.IsKnot := by
+  simp [IsKnot]
+
+/-- Column relabeling preserves whether a grid diagram represents a knot. -/
+@[simp]
+theorem isKnot_relabelColumns (κ : Equiv.Perm (Fin n)) :
+    (G.relabelColumns κ).IsKnot ↔ G.IsKnot := by
+  simp [IsKnot]
+
+/-- Diagonal reflection preserves whether a grid diagram represents a knot. -/
+@[simp]
+theorem isKnot_transpose : G.transpose.IsKnot ↔ G.IsKnot := by
+  simp [IsKnot]
+
+/-- Half-turn rotation preserves whether a grid diagram represents a knot. -/
+@[simp]
+theorem isKnot_rotate : G.rotate.IsKnot ↔ G.IsKnot := by
+  simp [IsKnot]
+
+/-- Exchanging the two marking types preserves whether a grid diagram represents a knot. -/
+@[simp]
+theorem isKnot_swapMarkings : G.swapMarkings.IsKnot ↔ G.IsKnot := by
+  simp [IsKnot]
+
+end GridDiagram
+
+end TauCeti


### PR DESCRIPTION
This PR defines the link-component traversal of a grid diagram: start at the `O` marking in a column, follow the horizontal segment to the `X` marking in the same row, then follow the vertical segment back to `O`. Package the resulting fixed-point-free permutation `componentPerm`, its component cycles and cycle type, the component count, and the predicate `GridDiagram.IsKnot`.

This advances `TauCetiRoadmap/CombinatorialHeegaardFloer/README.md`, Lane G.1, item “Grid diagrams and grid states.” It supplies the missing knot-versus-link distinction required by the knot invariant `τ` in Lane G.6 and by the links stage in Lane G.9. This was the lowest-hanging distinct target because the diagram and permutation APIs are already on `main`, no open or recent merged PR defines link components, and the only open CombinatorialHeegaardFloer PR concerns fully blocked homology symmetries.

Follow Ozsváth–Stipsicz–Szabó, *Grid Homology for Knots and Links*, Chapter 3. Reuse Mathlib’s `Equiv.Perm.cycleFactorsFinset`, `cycleType`, `sum_cycleType`, `cycleType_conj`, and `cycleType_inv`; vendor no Mathlib infrastructure and copy or adapt no formalization.

Add `TauCeti/KnotTheory/Grid/Diagram/Components.lean` (289 lines). Prove that every column lies in the component permutation’s support, component sizes sum to the grid size, an empty grid has zero components, and every `2 × 2` diagram is a knot grid. Prove that cycle type, component count, and `IsKnot` are preserved by row and column relabeling, diagonal reflection, half-turn rotation, and exchanging the marking types.

`lake build` reports `Build completed successfully (5577 jobs).` `lake exe axioms` reports `axioms: audited 12739 TauCeti declaration(s); all within the allowlist [propext, Classical.choice, Quot.sound].`

<!--tauceti-target:v1 {"focus":"CombinatorialHeegaardFloer","id":"componentperm"}-->

🤖 Prepared with Codex
