### PR TITLE
refactor(Conformal): decompose differentiableOn_lineSchwarzReflection_of_symmetric

### DIFF
--- a/TauCeti/Analysis/Complex/Conformal/Reflection/Line.lean
+++ b/TauCeti/Analysis/Complex/Conformal/Reflection/Line.lean
@@ -88,6 +88,20 @@ private lemma affineChart_reflection_coord {p a z : ℂ} (ha : a ≠ 0) :
       (starRingEnd ℂ) ((z - p) / a) :=
   affineChart_right_inv ha _
 
+/-- **The affine chart carries a pulled-back half-plane to the original one.** For any condition
+`P` on the imaginary part — `0 ≤ ·` for the closed half-plane, `0 < ·` for the open one — the
+chart `w ↦ p + a·w` maps `φ⁻¹(Ω)` cut by `P ∘ im` into `Ω` cut by `P` on the *rotated* imaginary
+part. Both the continuity and the holomorphy transports below are instances. -/
+private lemma mapsTo_affineChart_halfPlane {p a : ℂ} (ha : a ≠ 0) {Ω : Set ℂ} {P : ℝ → Prop} :
+    MapsTo (fun w : ℂ => p + a * w)
+      ((fun w : ℂ => p + a * w) ⁻¹' Ω ∩ {w : ℂ | P w.im})
+      (Ω ∩ {z : ℂ | P ((z - p) / a).im}) := by
+  intro w hw
+  refine ⟨hw.1, ?_⟩
+  change P ((p + a * w - p) / a).im
+  rw [affineChart_right_inv ha]
+  exact hw.2
+
 /-- **Schwarz reflection principle across an affine line, holomorphy form.** Let the source line
 be `p + a * ℝ`, with `a ≠ 0`. Suppose an open domain `Ω` is invariant under reflection in this
 line. If `f` is continuous on the closed positive side, holomorphic on the open positive side,
@@ -130,24 +144,12 @@ theorem differentiableOn_lineSchwarzReflection_of_symmetric
     have hreflect := hΩ hw
     simpa only [φ, ψ, hψφ] using hreflect
   have hgcont : ContinuousOn g (U ∩ {w : ℂ | 0 ≤ w.im}) := by
-    have hfcomp : ContinuousOn (f ∘ φ) (U ∩ {w : ℂ | 0 ≤ w.im}) := by
-      refine hcont.comp hφdiff.continuous.continuousOn ?_
-      intro w hw
-      refine ⟨hw.1, ?_⟩
-      -- The local chart abbreviations hide the inverse law identifying the two side conditions.
-      change 0 ≤ (ψ (φ w)).im
-      rw [hψφ]
-      exact hw.2
+    have hfcomp : ContinuousOn (f ∘ φ) (U ∩ {w : ℂ | 0 ≤ w.im}) :=
+      hcont.comp hφdiff.continuous.continuousOn (mapsTo_affineChart_halfPlane ha)
     simpa [g, Function.comp_apply] using hfcomp.sub continuousOn_const |>.div_const b
   have hgdiff : DifferentiableOn ℂ g (U ∩ {w : ℂ | 0 < w.im}) := by
-    have hfcomp : DifferentiableOn ℂ (f ∘ φ) (U ∩ {w : ℂ | 0 < w.im}) := by
-      refine hholo.comp hφdiff.differentiableOn ?_
-      intro w hw
-      refine ⟨hw.1, ?_⟩
-      -- As above, expose the coordinate composite before applying the inverse law.
-      change 0 < (ψ (φ w)).im
-      rw [hψφ]
-      exact hw.2
+    have hfcomp : DifferentiableOn ℂ (f ∘ φ) (U ∩ {w : ℂ | 0 < w.im}) :=
+      hholo.comp hφdiff.differentiableOn (mapsTo_affineChart_halfPlane ha)
     simpa only [g, Function.comp_apply] using hfcomp.sub_const q |>.div_const b
   have hgline : ∀ w ∈ U, w.im = 0 → (g w).im = 0 := by
     intro w hw hwim

--- a/TauCeti/Analysis/Complex/Conformal/Reflection/Line.lean
+++ b/TauCeti/Analysis/Complex/Conformal/Reflection/Line.lean
@@ -88,19 +88,17 @@ private lemma affineChart_reflection_coord {p a z : ℂ} (ha : a ≠ 0) :
       (starRingEnd ℂ) ((z - p) / a) :=
   affineChart_right_inv ha _
 
-/-- **The affine chart carries a pulled-back half-plane to the original one.** For any condition
-`P` on the imaginary part — `0 ≤ ·` for the closed half-plane, `0 < ·` for the open one — the
-chart `w ↦ p + a·w` maps `φ⁻¹(Ω)` cut by `P ∘ im` into `Ω` cut by `P` on the *rotated* imaginary
-part. Both the continuity and the holomorphy transports below are instances. -/
-private lemma mapsTo_affineChart_halfPlane {p a : ℂ} (ha : a ≠ 0) {Ω : Set ℂ} {P : ℝ → Prop} :
+/-- **The affine chart carries a pulled-back imaginary-coordinate cut to the original one.** For
+any predicate `P` on the imaginary part, the chart `w ↦ p + a·w` maps `φ⁻¹(Ω)` cut by `P ∘ im`
+into `Ω` cut by `P` on the *rotated* imaginary part `((z - p)/a).im`. Taking `P` to be `0 ≤ ·`
+and `0 < ·` gives the closed and open half-planes, which is how the continuity and holomorphy
+transports below use it; the statement itself constrains `P` no further. -/
+private lemma mapsTo_affineChart_inter_im {p a : ℂ} (ha : a ≠ 0) {Ω : Set ℂ} {P : ℝ → Prop} :
     MapsTo (fun w : ℂ => p + a * w)
       ((fun w : ℂ => p + a * w) ⁻¹' Ω ∩ {w : ℂ | P w.im})
       (Ω ∩ {z : ℂ | P ((z - p) / a).im}) := by
-  intro w hw
-  refine ⟨hw.1, ?_⟩
-  change P ((p + a * w - p) / a).im
-  rw [affineChart_right_inv ha]
-  exact hw.2
+  refine (Set.mapsTo_preimage _ Ω).inter_inter fun w hw => ?_
+  simpa only [Set.mem_setOf_eq, affineChart_right_inv ha] using hw
 
 /-- **Schwarz reflection principle across an affine line, holomorphy form.** Let the source line
 be `p + a * ℝ`, with `a ≠ 0`. Suppose an open domain `Ω` is invariant under reflection in this
@@ -145,11 +143,11 @@ theorem differentiableOn_lineSchwarzReflection_of_symmetric
     simpa only [φ, ψ, hψφ] using hreflect
   have hgcont : ContinuousOn g (U ∩ {w : ℂ | 0 ≤ w.im}) := by
     have hfcomp : ContinuousOn (f ∘ φ) (U ∩ {w : ℂ | 0 ≤ w.im}) :=
-      hcont.comp hφdiff.continuous.continuousOn (mapsTo_affineChart_halfPlane ha)
+      hcont.comp hφdiff.continuous.continuousOn (mapsTo_affineChart_inter_im ha)
     simpa [g, Function.comp_apply] using hfcomp.sub continuousOn_const |>.div_const b
   have hgdiff : DifferentiableOn ℂ g (U ∩ {w : ℂ | 0 < w.im}) := by
     have hfcomp : DifferentiableOn ℂ (f ∘ φ) (U ∩ {w : ℂ | 0 < w.im}) :=
-      hholo.comp hφdiff.differentiableOn (mapsTo_affineChart_halfPlane ha)
+      hholo.comp hφdiff.differentiableOn (mapsTo_affineChart_inter_im ha)
     simpa only [g, Function.comp_apply] using hfcomp.sub_const q |>.div_const b
   have hgline : ∀ w ∈ U, w.im = 0 → (g w).im = 0 := by
     intro w hw hwim


### PR DESCRIPTION
`differentiableOn_lineSchwarzReflection_of_symmetric` transports `f` through the affine chart `w ↦ p + a·w` twice — once for continuity on the closed half-plane, once for holomorphy on the open one — and each transport re-proved the same `MapsTo` argument inline, differing only in whether the condition on the imaginary part was `0 ≤ ·` or `0 < ·`.

## Extracted

* `mapsTo_affineChart_inter_im` — for any predicate `P` on the imaginary part, the chart maps `φ⁻¹(Ω)` cut by `P ∘ im` into `Ω` cut by `P` on the *rotated* imaginary part `((z - p)/a).im`. The name says `inter_im` rather than `halfPlane` because `P` is unconstrained; half-planes are what the callers instantiate, not what the lemma asserts.

Parameterising over `P` is what lets one statement serve both sides: the closed half-plane is `P = (0 ≤ ·)` and the open one `P = (0 < ·)`, and each transport becomes a single application rather than a four-line `intro`/`refine`/`change`/`rw` block.

## Sizes

| | proof body |
|---|---|
| `differentiableOn_lineSchwarzReflection_of_symmetric` | 61 → **49** |
| `mapsTo_affineChart_inter_im` | **2** |

Both under the repository's 50-line proof policy.

## Scope

Refactoring only — no statement changes, no new mathematics, nothing added to the public API (the helper is `private`). Placing a private helper above the theorem does not affect its signature or any call site.

## Gates

`lake build` · `lake exe axioms` · `lake exe module-system` · `scripts/lint-env.sh` — all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
