### PR TITLE
refactor(Conformal): decompose hurwitz

### DIFF
--- a/TauCeti/Analysis/Complex/Conformal/Hurwitz.lean
+++ b/TauCeti/Analysis/Complex/Conformal/Hurwitz.lean
@@ -91,26 +91,20 @@ private lemma le_count {g : ℂ → ℂ} (hg : AnalyticOnNhd ℂ g (closedBall c
     · exact absurd (by simp [hzb]) hz
   simpa [hz₀] using single_le_finsum z₀ hfin (fun _ => Nat.zero_le _)
 
-/-- **A zero-free circle about an isolated zero.** If `g` is zero-free on some punctured
-neighbourhood of `z₀ ∈ Ω` with `Ω` open, there is a radius whose *closed* ball lies in `Ω` and on
-whose bounding circle `g` does not vanish — the circle Rouché's theorem is applied to. -/
-private lemma exists_radius_zeroFree_sphere {Ω : Set ℂ} (hΩ : IsOpen Ω) {g : ℂ → ℂ} {z₀ : ℂ}
+/-- **A circle on which `g` does not vanish.** If `g` is zero-free on some punctured
+neighbourhood of `z₀ ∈ Ω` with `Ω` open — `z₀` itself may be a zero, or not — there is a radius
+whose *closed* ball lies in `Ω` and on whose bounding circle `g` does not vanish. That circle is
+what Rouché's theorem is applied to. -/
+private lemma exists_radius_sphere_ne_zero {Ω : Set ℂ} (hΩ : IsOpen Ω) {g : ℂ → ℂ} {z₀ : ℂ}
     (hz₀Ω : z₀ ∈ Ω) (hpunct : ∀ᶠ z in 𝓝[≠] z₀, g z ≠ 0) :
     ∃ r > 0, closedBall z₀ r ⊆ Ω ∧ ∀ z ∈ sphere z₀ r, g z ≠ 0 := by
-  obtain ⟨ε₁, hε₁, hne₁⟩ := Metric.eventually_nhds_iff.mp (eventually_nhdsWithin_iff.mp hpunct)
-  obtain ⟨ε₂, hε₂, hball₂⟩ := Metric.isOpen_iff.mp hΩ z₀ hz₀Ω
-  have hrpos : 0 < min (ε₁ / 2) (ε₂ / 2) := lt_min (by linarith) (by linarith)
-  refine ⟨min (ε₁ / 2) (ε₂ / 2), hrpos, fun z hz => ?_, ?_⟩
-  · exact hball₂ (mem_ball.mpr (lt_of_le_of_lt (mem_closedBall.mp hz)
-      (lt_of_le_of_lt (min_le_right _ _) (by linarith))))
-  · intro z hz
-    have hdz : dist z z₀ = min (ε₁ / 2) (ε₂ / 2) := mem_sphere.mp hz
-    refine hne₁ ?_ ?_
-    · rw [hdz]; exact lt_of_le_of_lt (min_le_left _ _) (by linarith)
-    · simp only [Set.mem_compl_iff, Set.mem_singleton_iff]
-      intro h
-      rw [h, dist_self] at hdz
-      exact absurd hdz.symm (ne_of_gt hrpos)
+  have hev : ∀ᶠ z in 𝓝 z₀, z ∈ Ω ∧ (z ≠ z₀ → g z ≠ 0) :=
+    (hΩ.eventually_mem hz₀Ω).and (eventually_nhdsWithin_iff.mp hpunct)
+  obtain ⟨r, hr, hball⟩ := Metric.nhds_basis_closedBall.eventually_iff.1 hev
+  refine ⟨r, hr, fun z hz => (hball hz).1, fun z hz => ?_⟩
+  have hdz : dist z z₀ = r := mem_sphere.mp hz
+  exact (hball (sphere_subset_closedBall hz)).2 fun h => by
+    rw [h, dist_self] at hdz; exact absurd hdz.symm hr.ne'
 
 /-- **Hurwitz's theorem.** On a connected open set, a locally uniform limit of holomorphic
 functions that are nowhere zero is itself either nowhere zero or identically zero.
@@ -140,7 +134,7 @@ theorem hurwitz {ι : Type*} {l : Filter ι} [l.NeBot] {Ω : Set ℂ} (hΩ : IsO
     rcases (hgA z₀ hz₀Ω).eventually_eq_zero_or_eventually_ne_zero with h | h
     · exact absurd (analyticOrderAt_eq_top.mpr h) htop
     · exact h
-  obtain ⟨r, hr, hcb, hgne⟩ := exists_radius_zeroFree_sphere hΩ hz₀Ω hpunct
+  obtain ⟨r, hr, hcb, hgne⟩ := exists_radius_sphere_ne_zero hΩ hz₀Ω hpunct
   have hsph : sphere z₀ r ⊆ closedBall z₀ r := sphere_subset_closedBall
   -- `‖g‖` attains a positive minimum on the circle
   have hcpt : IsCompact (sphere z₀ r) := isCompact_sphere _ _

--- a/TauCeti/Analysis/Complex/Conformal/Hurwitz.lean
+++ b/TauCeti/Analysis/Complex/Conformal/Hurwitz.lean
@@ -101,10 +101,8 @@ private lemma exists_radius_sphere_ne_zero {Ω : Set ℂ} (hΩ : IsOpen Ω) {g :
   have hev : ∀ᶠ z in 𝓝 z₀, z ∈ Ω ∧ (z ≠ z₀ → g z ≠ 0) :=
     (hΩ.eventually_mem hz₀Ω).and (eventually_nhdsWithin_iff.mp hpunct)
   obtain ⟨r, hr, hball⟩ := Metric.nhds_basis_closedBall.eventually_iff.1 hev
-  refine ⟨r, hr, fun z hz => (hball hz).1, fun z hz => ?_⟩
-  have hdz : dist z z₀ = r := mem_sphere.mp hz
-  exact (hball (sphere_subset_closedBall hz)).2 fun h => by
-    rw [h, dist_self] at hdz; exact absurd hdz.symm hr.ne'
+  exact ⟨r, hr, fun z hz => (hball hz).1, fun z hz =>
+    (hball (sphere_subset_closedBall hz)).2 (Metric.ne_of_mem_sphere hz hr.ne')⟩
 
 /-- **Hurwitz's theorem.** On a connected open set, a locally uniform limit of holomorphic
 functions that are nowhere zero is itself either nowhere zero or identically zero.

--- a/TauCeti/Analysis/Complex/Conformal/Hurwitz.lean
+++ b/TauCeti/Analysis/Complex/Conformal/Hurwitz.lean
@@ -91,6 +91,27 @@ private lemma le_count {g : ℂ → ℂ} (hg : AnalyticOnNhd ℂ g (closedBall c
     · exact absurd (by simp [hzb]) hz
   simpa [hz₀] using single_le_finsum z₀ hfin (fun _ => Nat.zero_le _)
 
+/-- **A zero-free circle about an isolated zero.** If `g` is zero-free on some punctured
+neighbourhood of `z₀ ∈ Ω` with `Ω` open, there is a radius whose *closed* ball lies in `Ω` and on
+whose bounding circle `g` does not vanish — the circle Rouché's theorem is applied to. -/
+private lemma exists_radius_zeroFree_sphere {Ω : Set ℂ} (hΩ : IsOpen Ω) {g : ℂ → ℂ} {z₀ : ℂ}
+    (hz₀Ω : z₀ ∈ Ω) (hpunct : ∀ᶠ z in 𝓝[≠] z₀, g z ≠ 0) :
+    ∃ r > 0, closedBall z₀ r ⊆ Ω ∧ ∀ z ∈ sphere z₀ r, g z ≠ 0 := by
+  obtain ⟨ε₁, hε₁, hne₁⟩ := Metric.eventually_nhds_iff.mp (eventually_nhdsWithin_iff.mp hpunct)
+  obtain ⟨ε₂, hε₂, hball₂⟩ := Metric.isOpen_iff.mp hΩ z₀ hz₀Ω
+  have hrpos : 0 < min (ε₁ / 2) (ε₂ / 2) := lt_min (by linarith) (by linarith)
+  refine ⟨min (ε₁ / 2) (ε₂ / 2), hrpos, fun z hz => ?_, ?_⟩
+  · exact hball₂ (mem_ball.mpr (lt_of_le_of_lt (mem_closedBall.mp hz)
+      (lt_of_le_of_lt (min_le_right _ _) (by linarith))))
+  · intro z hz
+    have hdz : dist z z₀ = min (ε₁ / 2) (ε₂ / 2) := mem_sphere.mp hz
+    refine hne₁ ?_ ?_
+    · rw [hdz]; exact lt_of_le_of_lt (min_le_left _ _) (by linarith)
+    · simp only [Set.mem_compl_iff, Set.mem_singleton_iff]
+      intro h
+      rw [h, dist_self] at hdz
+      exact absurd hdz.symm (ne_of_gt hrpos)
+
 /-- **Hurwitz's theorem.** On a connected open set, a locally uniform limit of holomorphic
 functions that are nowhere zero is itself either nowhere zero or identically zero.
 
@@ -119,24 +140,8 @@ theorem hurwitz {ι : Type*} {l : Filter ι} [l.NeBot] {Ω : Set ℂ} (hΩ : IsO
     rcases (hgA z₀ hz₀Ω).eventually_eq_zero_or_eventually_ne_zero with h | h
     · exact absurd (analyticOrderAt_eq_top.mpr h) htop
     · exact h
-  obtain ⟨ε₁, hε₁, hne₁⟩ := Metric.eventually_nhds_iff.mp (eventually_nhdsWithin_iff.mp hpunct)
-  obtain ⟨ε₂, hε₂, hball₂⟩ := Metric.isOpen_iff.mp hΩ z₀ hz₀Ω
-  set r := min (ε₁ / 2) (ε₂ / 2) with hr_def
-  have hr : 0 < r := lt_min (by linarith) (by linarith)
-  have hcb : closedBall z₀ r ⊆ Ω := fun z hz =>
-    hball₂ (mem_ball.mpr (lt_of_le_of_lt (mem_closedBall.mp hz)
-      (lt_of_le_of_lt (min_le_right _ _) (by linarith))))
+  obtain ⟨r, hr, hcb, hgne⟩ := exists_radius_zeroFree_sphere hΩ hz₀Ω hpunct
   have hsph : sphere z₀ r ⊆ closedBall z₀ r := sphere_subset_closedBall
-  have hgne : ∀ z ∈ sphere z₀ r, g z ≠ 0 := by
-    intro z hz
-    have hdz : dist z z₀ = r := mem_sphere.mp hz
-    refine hne₁ ?_ ?_
-    · rw [hdz]; exact lt_of_le_of_lt (min_le_left _ _) (by linarith)
-    · simp only [Set.mem_compl_iff, Set.mem_singleton_iff]
-      intro h
-      rw [h] at hdz
-      simp only [dist_self] at hdz
-      linarith
   -- `‖g‖` attains a positive minimum on the circle
   have hcpt : IsCompact (sphere z₀ r) := isCompact_sphere _ _
   have hsne : (sphere z₀ r).Nonempty := NormedSpace.sphere_nonempty.mpr hr.le


### PR DESCRIPTION
`hurwitz` carried seventeen lines of `ε`-juggling inline — choosing a radius small enough that the closed ball sits inside `Ω` *and* the bounding circle avoids the zeros of `g` — wedged between the identity-theorem step and the Rouché application.

## Extracted

* `exists_radius_sphere_ne_zero` — given `g` zero-free on a punctured neighbourhood of `z₀ ∈ Ω` with `Ω` open, there is a radius whose **closed** ball lies in `Ω` and on whose bounding circle `g` does not vanish. Note `z₀` itself need not be a zero of `g`; only the punctured neighbourhood matters.

That circle is exactly what Rouché's theorem is applied to, so the main proof now reads as its argument: identity theorem ⟹ isolate a zero-free circle ⟹ minimum of `‖g‖` on it ⟹ Rouché.

The helper takes only openness of `Ω`, membership of `z₀`, and the punctured-neighbourhood fact. Analyticity of `g` was in scope at the extraction site but plays no part in the construction, so it is not a hypothesis.

## Sizes

| | proof body |
|---|---|
| `hurwitz` | 62 → **46** |
| `exists_radius_sphere_ne_zero` | **8** |

Both under the repository's 50-line proof policy.

## Scope

Refactoring only — no statement changes, no new mathematics, nothing added to the public API (the helper is `private`). Placing a private helper above the theorem does not affect its signature or any call site.

Note `eventually_exists_eq` in the same file also has a 51-line body; it is left for a separate PR, one target per PR.

## Gates

`lake build` · `lake exe axioms` · `lake exe module-system` · `scripts/lint-env.sh` — all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
