### PR TITLE
refactor(DedekindDomain): decompose exists_transversal_family

### DIFF
--- a/TauCeti/NumberTheory/DedekindDomain/Transversal.lean
+++ b/TauCeti/NumberTheory/DedekindDomain/Transversal.lean
@@ -135,10 +135,12 @@ private theorem mul_map_eq_prod_of_mem_image_union {R : Type*} [CommSemiring R] 
   · obtain ⟨a, ha, rfl⟩ := Finset.mem_image.mp hA
     rw [Ideal.map_mul, hmapq, hprodS, ← hprod' a ha]; ring
 
-/-- **Two shifted copies double the family.** Multiplying a family of ideals by each member of a
-conjugate pair gives images of the same size, and if those images are disjoint the union has
+/-- **Two shifted copies double the family.** Multiplying a family of ideals by each of two
+height-one primes gives images of the same size, and if those images are disjoint the union has
 twice the cardinality. That is exactly enough to carry a bound `2 ^ (m / 2)` up to `2 ^ (n / 2)`
-whenever `n ≤ m + 2` — the two primes removed from the index set at each induction step. -/
+whenever `n ≤ m + 2` — the two primes removed from the index set at each induction step. No
+relationship between the primes is assumed beyond disjointness of the images; the caller
+supplies a conjugate pair, but the estimate does not need that. -/
 private lemma two_pow_le_card_union_image_mul {G' : Finset (Ideal R)}
     {p q : IsDedekindDomain.HeightOneSpectrum R}
     (hdisj : Disjoint (G'.image (· * p.asIdeal)) (G'.image (· * q.asIdeal)))
@@ -194,7 +196,6 @@ theorem exists_transversal_family (σ : R ≃+* R)
   have hpq : q ≠ p := hfree p hpS
   have hqIdeal : q.asIdeal = Ideal.map σ p.asIdeal := by
     rw [hqdef]; exact asIdeal_equivOfRingEquiv σ p
-  have hp0 : p.asIdeal ≠ ⊥ := p.ne_bot
   have hpair : ({p, q} : Finset (IsDedekindDomain.HeightOneSpectrum R)) ⊆ S := by
     intro x hx; rcases Finset.mem_insert.mp hx with rfl | hx
     · exact hpS

--- a/TauCeti/NumberTheory/DedekindDomain/Transversal.lean
+++ b/TauCeti/NumberTheory/DedekindDomain/Transversal.lean
@@ -135,6 +135,42 @@ private theorem mul_map_eq_prod_of_mem_image_union {R : Type*} [CommSemiring R] 
   · obtain ⟨a, ha, rfl⟩ := Finset.mem_image.mp hA
     rw [Ideal.map_mul, hmapq, hprodS, ← hprod' a ha]; ring
 
+/-- **Two shifted copies double the family.** Multiplying a family of ideals by each member of a
+conjugate pair gives images of the same size, and if those images are disjoint the union has
+twice the cardinality. That is exactly enough to carry a bound `2 ^ (m / 2)` up to `2 ^ (n / 2)`
+whenever `n ≤ m + 2` — the two primes removed from the index set at each induction step. -/
+private lemma two_pow_le_card_union_image_mul {G' : Finset (Ideal R)}
+    {p q : IsDedekindDomain.HeightOneSpectrum R}
+    (hdisj : Disjoint (G'.image (· * p.asIdeal)) (G'.image (· * q.asIdeal)))
+    {n m : ℕ} (hcard' : 2 ^ (m / 2) ≤ G'.card) (hnm : n ≤ m + 2) :
+    2 ^ (n / 2) ≤ ((G'.image (· * p.asIdeal)) ∪ (G'.image (· * q.asIdeal))).card := by
+  rw [Finset.card_union_of_disjoint hdisj,
+    Finset.card_image_of_injective _ (fun _ _ h => mul_right_cancel₀ p.ne_bot h),
+    Finset.card_image_of_injective _ (fun _ _ h => mul_right_cancel₀ q.ne_bot h)]
+  calc 2 ^ (n / 2) ≤ 2 * 2 ^ (m / 2) :=
+        two_pow_div_two_le_two_mul_two_pow_div_two_of_le_add_two hnm
+    _ ≤ G'.card + G'.card := by omega
+
+omit [IsDedekindDomain R] in
+/-- **The complement of a conjugate pair is still invariant.** Removing `p` and its image `q`
+from `S` leaves a set the involution still maps to itself: an element outside the pair cannot be
+sent into it, since applying the involution twice returns it. -/
+private lemma mem_sdiff_pair_of_invariant {σ : R ≃+* R}
+    {S : Finset (IsDedekindDomain.HeightOneSpectrum R)}
+    {p q : IsDedekindDomain.HeightOneSpectrum R}
+    (hqdef : q = IsDedekindDomain.HeightOneSpectrum.equivOfRingEquiv σ p)
+    (hinv : ∀ x ∈ S, IsDedekindDomain.HeightOneSpectrum.equivOfRingEquiv σ x ∈ S)
+    (hinvol : ∀ x ∈ S, IsDedekindDomain.HeightOneSpectrum.equivOfRingEquiv σ
+      (IsDedekindDomain.HeightOneSpectrum.equivOfRingEquiv σ x) = x)
+    (hpS : p ∈ S) :
+    ∀ x ∈ S \ {p, q}, IsDedekindDomain.HeightOneSpectrum.equivOfRingEquiv σ x ∈ S \ {p, q} := by
+  intro x hx
+  have hxS := (Finset.mem_sdiff.mp hx).1
+  refine Finset.mem_sdiff.mpr ⟨hinv x hxS, ?_⟩
+  exact notMem_pair_of_apply_involutive
+    (f := IsDedekindDomain.HeightOneSpectrum.equivOfRingEquiv σ) hqdef (hinvol x hxS)
+    (hinvol p hpS) (Finset.mem_sdiff.mp hx).2
+
 /-- **Conjugate-transversal ideal family.** For a fixed-point-free involution `σ` of a finite set
 `S` of height-one primes of a Dedekind domain, there are at least `2 ^ (S.card / 2)` ideals `A`
 with `A * σ A = ∏ p ∈ S, p.asIdeal`. -/
@@ -170,12 +206,7 @@ theorem exists_transversal_family (σ : R ≃+* R)
   -- The subset `S'` still satisfies all the hypotheses.
   have hmem' : ∀ {x}, x ∈ S' → x ∈ S := fun hx => (Finset.mem_sdiff.mp hx).1
   obtain ⟨G', hcard', hprod'⟩ := ih S' hS'sub
-    (fun x hx => by
-      have hxS := hmem' hx
-      refine Finset.mem_sdiff.mpr ⟨hinv x hxS, ?_⟩
-      exact notMem_pair_of_apply_involutive
-        (f := IsDedekindDomain.HeightOneSpectrum.equivOfRingEquiv σ) hqdef (hinvol x hxS)
-        (hinvol p hpS) (Finset.mem_sdiff.mp hx).2)
+    (mem_sdiff_pair_of_invariant hqdef hinv hinvol hpS)
     (fun x hx => hinvol x (hmem' hx)) (fun x hx => hfree x (hmem' hx))
   -- The product over `S` factors through the conjugate pair we removed.
   have hprodS :
@@ -187,19 +218,11 @@ theorem exists_transversal_family (σ : R ≃+* R)
     rw [hS'def]; omega
   have hpS' : p ∉ S' := fun h => (Finset.mem_sdiff.mp h).2 (Finset.mem_insert_self _ _)
   refine ⟨(G'.image (· * p.asIdeal)) ∪ (G'.image (· * q.asIdeal)), ?_, ?_⟩
-  · -- The two images are disjoint and each has the size of `G'`.
-    have hinjp : Function.Injective (· * p.asIdeal : Ideal R → Ideal R) :=
-      fun a b h => mul_right_cancel₀ hp0 h
-    have hinjq : Function.Injective (· * q.asIdeal : Ideal R → Ideal R) :=
-      fun a b h => mul_right_cancel₀ q.ne_bot h
+  · -- The two images are disjoint, so the union doubles the family.
     have hdisj : Disjoint (G'.image (· * p.asIdeal)) (G'.image (· * q.asIdeal)) :=
       disjoint_image_mul_asIdeal hpq (fun A hA hpA =>
         isPrime_not_dvd_prod p hpS' (hprod' A hA ▸ dvd_mul_of_dvd_left hpA (Ideal.map σ A)))
-    rw [Finset.card_union_of_disjoint hdisj, Finset.card_image_of_injective _ hinjp,
-      Finset.card_image_of_injective _ hinjq]
-    calc 2 ^ (S.card / 2) ≤ 2 * 2 ^ (S'.card / 2) :=
-          two_pow_div_two_le_two_mul_two_pow_div_two_of_le_add_two (by omega)
-      _ ≤ G'.card + G'.card := by omega
+    exact two_pow_le_card_union_image_mul hdisj hcard' (by omega)
   · have hmapq : Ideal.map σ q.asIdeal = p.asIdeal := by
       rw [← asIdeal_equivOfRingEquiv σ q]
       exact congr_arg IsDedekindDomain.HeightOneSpectrum.asIdeal (hinvol p hpS)


### PR DESCRIPTION
`exists_transversal_family`'s induction step ran 59 lines, mixing the ideal-theoretic bookkeeping with a purely numeric cardinality estimate.

## Extracted

* `mem_sdiff_pair_of_invariant` — removing `p` and its image `q` from `S` leaves a set the involution still maps to itself. An element outside the pair cannot be sent into it, precisely because applying the involution twice returns it.
* `two_pow_le_card_union_image_mul` — multiplying a family of ideals by each member of a conjugate pair gives images of equal size, so a disjoint union doubles the count. That carries a bound `2 ^ (m / 2)` up to `2 ^ (n / 2)` whenever `n ≤ m + 2` — the two primes removed at each step.

The second is stated over bare naturals `n` and `m` rather than `S.card` and `S'.card`. That is deliberate: the estimate has nothing to do with ideals, and stating it abstractly keeps the arithmetic separate from the ideal theory rather than entangling the two in the induction.

`mem_sdiff_pair_of_invariant` carries `omit [IsDedekindDomain R]` — the invariance argument is about a finite set and an involution, and never uses the Dedekind hypothesis the section supplies.

## Sizes

| | proof body |
|---|---|
| `exists_transversal_family` | 59 → **46** |
| `mem_sdiff_pair_of_invariant` | **7** |
| `two_pow_le_card_union_image_mul` | **7** |

All under the repository's 50-line proof policy.

## Scope

Refactoring only — no statement changes, no new mathematics, nothing added to the public API (both helpers are `private`).

## Gates

`lake build` · `lake exe axioms` · `lake exe module-system` · `scripts/lint-env.sh` — all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
