### PR TITLE
refactor(Independence): decompose the contraction-independence identity

### DIFF
--- a/TauCeti/Probability/Independence/Conditional.lean
+++ b/TauCeti/Probability/Independence/Conditional.lean
@@ -328,7 +328,7 @@ private lemma integral_sq_condExp_eq_of_pair_law [IsFiniteMeasure μ]
               | MeasurableSpace.comap W' inferInstance]) ω ∂μ := by
   have hρ_eq : Measure.map W μ = Measure.map W' μ :=
     marginal_law_eq_of_pair_law X W W' hX hW hW' h_law
-  let φ : Ω → ℝ := (X ⁻¹' A).indicator (fun _ => (1 : ℝ))
+  set φ : Ω → ℝ := (X ⁻¹' A).indicator (fun _ => (1 : ℝ)) with hφ_def
   let μ₁ : Ω → ℝ := μ[φ | MeasurableSpace.comap W inferInstance]
   let μ₂ : Ω → ℝ := μ[φ | MeasurableSpace.comap W' inferInstance]
   have hφ_int : Integrable φ μ := Integrable.indicator (integrable_const 1) (hX hA)
@@ -406,6 +406,17 @@ private lemma ae_eq_of_integral_mul_eq_of_integral_sq_eq {Ω : Type*} {mΩ : Mea
   filter_upwards [h_diff_zero] with ω hω
   nlinarith [sq_nonneg (g₂ ω - g₁ ω)]
 
+/-- The conditional expectation of a `0/1` indicator is bounded by `1` in norm almost everywhere,
+on any sub-σ-algebra: the indicator itself is, and conditioning does not increase the bound. -/
+private lemma ae_norm_condExp_indicator_le_one {Ω : Type*} {m0 : MeasurableSpace Ω}
+    {μ : Measure Ω} (m' : MeasurableSpace Ω) {s : Set Ω} :
+    ∀ᵐ ω ∂μ, ‖μ[s.indicator (fun _ => (1 : ℝ)) | m'] ω‖ ≤ 1 := by
+  have habs : ∀ᵐ ω ∂μ, |s.indicator (fun _ => (1 : ℝ)) ω| ≤ 1 := by
+    filter_upwards with ω
+    by_cases hω : ω ∈ s <;> simp [hω]
+  filter_upwards [ae_bdd_abs_condExp_of_ae_bdd_abs (m := m') (R := (1 : ℝ)) habs] with ω hω
+  rwa [Real.norm_eq_abs]
+
 /-- **Kallenberg Lemma 1.3 (contraction-independence).** If `(X, W) =ᵈ (X, W')` and
 `σ(W) ≤ σ(W')` (so `W` is a contraction of `W'`), then conditioning the indicator of `X` on the
 finer `σ(W')` equals conditioning on the coarser `σ(W)`, almost everywhere. -/
@@ -419,7 +430,7 @@ theorem condExp_indicator_eq_of_law_eq_of_comap_le [IsFiniteMeasure μ]
       =ᵐ[μ]
     μ[(X ⁻¹' A).indicator (fun _ => (1 : ℝ)) | MeasurableSpace.comap W inferInstance] := by
   have h_sq_eq_raw := integral_sq_condExp_eq_of_pair_law X W W' hX hW hW' h_law hA
-  let φ : Ω → ℝ := (X ⁻¹' A).indicator (fun _ => (1 : ℝ))
+  set φ : Ω → ℝ := (X ⁻¹' A).indicator (fun _ => (1 : ℝ)) with hφ_def
   let mW : MeasurableSpace Ω := MeasurableSpace.comap W inferInstance
   let mW' : MeasurableSpace Ω := MeasurableSpace.comap W' inferInstance
   have hmW_le : mW ≤ _ := measurable_iff_comap_le.mp hW
@@ -432,25 +443,12 @@ theorem condExp_indicator_eq_of_law_eq_of_comap_le [IsFiniteMeasure μ]
   set μ₁ := μ[φ | mW] with hμ₁_def
   set μ₂ := μ[φ | mW'] with hμ₂_def
   have h_tower : μ[μ₂ | mW] =ᵐ[μ] μ₁ := condExp_condExp_of_le h_le hmW'_le
-  have hφ_bdd : ∀ ω, 0 ≤ φ ω ∧ φ ω ≤ 1 := fun ω => by
-    by_cases hω : ω ∈ X ⁻¹' A
-    · have h : φ ω = 1 := Set.indicator_of_mem hω _
-      rw [h]; exact ⟨zero_le_one, le_rfl⟩
-    · have h : φ ω = 0 := Set.indicator_of_notMem hω _
-      rw [h]; exact ⟨le_rfl, zero_le_one⟩
-  -- `|φ| ≤ 1` a.e., so each conditional expectation `μ[φ | ·]` inherits the same bound via
-  -- Mathlib's conditional-expectation bound; the helper is applied once per σ-algebra below.
-  have hφ_abs : ∀ᵐ ω ∂μ, |φ ω| ≤ (1 : ℝ) := by
-    filter_upwards with ω
-    rw [abs_of_nonneg (hφ_bdd ω).1]; exact (hφ_bdd ω).2
-  have condExp_abs_le : ∀ m' : MeasurableSpace Ω, ∀ᵐ ω ∂μ, |μ[φ | m'] ω| ≤ 1 := fun m' => by
-    simpa using ae_bdd_abs_condExp_of_ae_bdd_abs (m := m') (R := (1 : ℝ)) hφ_abs
   have hμ₁_int : Integrable μ₁ μ := integrable_condExp
   have hμ₂_int : Integrable μ₂ μ := integrable_condExp
   have hμ₁_bound : ∀ᵐ ω ∂μ, ‖μ₁ ω‖ ≤ 1 := by
-    filter_upwards [condExp_abs_le mW] with ω hω; rwa [Real.norm_eq_abs, hμ₁_def]
+    rw [hμ₁_def, hφ_def]; exact ae_norm_condExp_indicator_le_one mW
   have hμ₂_bound : ∀ᵐ ω ∂μ, ‖μ₂ ω‖ ≤ 1 := by
-    filter_upwards [condExp_abs_le mW'] with ω hω; rwa [Real.norm_eq_abs, hμ₂_def]
+    rw [hμ₂_def, hφ_def]; exact ae_norm_condExp_indicator_le_one mW'
   have hμ₁sq_int : Integrable (fun ω => μ₁ ω * μ₁ ω) μ :=
     hμ₁_int.bdd_mul hμ₁_int.aestronglyMeasurable hμ₁_bound
   have hμ₂sq_int : Integrable (fun ω => μ₂ ω * μ₂ ω) μ :=

--- a/TauCeti/Probability/Independence/Conditional.lean
+++ b/TauCeti/Probability/Independence/Conditional.lean
@@ -413,7 +413,7 @@ private lemma ae_norm_condExp_indicator_le_one {Ω : Type*} {m0 : MeasurableSpac
     ∀ᵐ ω ∂μ, ‖μ[s.indicator (fun _ => (1 : ℝ)) | m'] ω‖ ≤ 1 := by
   have habs : ∀ᵐ ω ∂μ, |s.indicator (fun _ => (1 : ℝ)) ω| ≤ 1 := by
     filter_upwards with ω
-    by_cases hω : ω ∈ s <;> simp [hω]
+    simpa only [Real.norm_eq_abs, norm_one] using norm_indicator_le_norm_self (fun _ => (1 : ℝ)) ω
   filter_upwards [ae_bdd_abs_condExp_of_ae_bdd_abs (m := m') (R := (1 : ℝ)) habs] with ω hω
   rwa [Real.norm_eq_abs]
 

--- a/TauCeti/Probability/Independence/Conditional.lean
+++ b/TauCeti/Probability/Independence/Conditional.lean
@@ -410,12 +410,9 @@ private lemma ae_eq_of_integral_mul_eq_of_integral_sq_eq {Ω : Type*} {mΩ : Mea
 on any sub-σ-algebra: the indicator itself is, and conditioning does not increase the bound. -/
 private lemma ae_norm_condExp_indicator_le_one {Ω : Type*} {m0 : MeasurableSpace Ω}
     {μ : Measure Ω} (m' : MeasurableSpace Ω) {s : Set Ω} :
-    ∀ᵐ ω ∂μ, ‖μ[s.indicator (fun _ => (1 : ℝ)) | m'] ω‖ ≤ 1 := by
-  have habs : ∀ᵐ ω ∂μ, |s.indicator (fun _ => (1 : ℝ)) ω| ≤ 1 := by
-    filter_upwards with ω
-    simpa only [Real.norm_eq_abs, norm_one] using norm_indicator_le_norm_self (fun _ => (1 : ℝ)) ω
-  filter_upwards [ae_bdd_abs_condExp_of_ae_bdd_abs (m := m') (R := (1 : ℝ)) habs] with ω hω
-  rwa [Real.norm_eq_abs]
+    ∀ᵐ ω ∂μ, ‖μ[s.indicator (fun _ => (1 : ℝ)) | m'] ω‖ ≤ 1 :=
+  ae_bdd_norm_condExp_of_ae_bdd_norm (m := m') <| Filter.Eventually.of_forall fun ω => by
+    simpa only [norm_one] using norm_indicator_le_norm_self (fun _ => (1 : ℝ)) ω
 
 /-- **Kallenberg Lemma 1.3 (contraction-independence).** If `(X, W) =ᵈ (X, W')` and
 `σ(W) ≤ σ(W')` (so `W` is a contraction of `W'`), then conditioning the indicator of `X` on the


### PR DESCRIPTION
`condExp_indicator_eq_of_law_eq_of_comap_le` ran 53 lines. Nineteen of them established that the
two conditional expectations are bounded by `1` — a pointwise `0 ≤ φ ≤ 1` case split, its
restatement as `|φ| ≤ 1`, the appeal to Mathlib's conditional-expectation bound, and then a
`filter_upwards` per σ-algebra to convert `|·|` into `‖·‖`.

## Extracted

* `ae_norm_condExp_indicator_le_one` — the conditional expectation of a `0/1` indicator is bounded
  by `1` in norm almost everywhere, on any sub-σ-algebra.

Stated for an arbitrary set and an arbitrary σ-algebra, so both uses are one application. Nothing
in it refers to the two σ-algebras of the theorem, or to the indicator being of `X ⁻¹' A`.

The whole `0 ≤ φ ≤ 1` / `|·|` detour turned out to be unnecessary: Mathlib states both halves in
norms already, so the helper is `norm_indicator_le_norm_self` fed straight into
`ae_bdd_norm_condExp_of_ae_bdd_norm`, in term mode.

One binder is worth noting: the helper takes the ambient σ-algebra as a plain implicit
`{m0 : MeasurableSpace Ω}` rather than instance-implicit. The theorem introduces `mW` and `mW'` as
local `MeasurableSpace Ω` definitions, which are themselves instance candidates, so an
instance-implicit ambient argument gets synthesized to `mW'` instead of the measure's own
σ-algebra. Taking it as a plain implicit lets it be determined by `μ`'s type, which is the
convention Mathlib's own conditional-expectation files use (`variable {m m0 : MeasurableSpace α}`).

## Sizes

| | proof body |
|---|---|
| `condExp_indicator_eq_of_law_eq_of_comap_le` | 53 → **40** |
| `ae_norm_condExp_indicator_le_one` | **2** |

Both under the repository's 50-line proof policy.

## Scope

Refactoring only — no statement changes, no new mathematics, nothing added to the public API (the
helper is `private`). The one incidental change is `let φ` → `set φ`, so the definition is
available as a rewrite when discharging the two bounds.

## Gates

`lake build` · `lake exe axioms` · `lake exe module-system` · `scripts/lint-env.sh` — all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
