### PR TITLE
feat(OrthogonalL2Bases): the Chebyshev T polynomials are a Hilbert basis of L²(measureT)

### DIFF
--- a/TauCeti/Analysis/SpecialFunctions/Trigonometric/Chebyshev/HilbertBasis.lean
+++ b/TauCeti/Analysis/SpecialFunctions/Trigonometric/Chebyshev/HilbertBasis.lean
@@ -42,18 +42,6 @@ open MeasureTheory Polynomial Polynomial.Chebyshev
 
 variable (𝕜 : Type*) [RCLike 𝕜]
 
-/-- The Chebyshev measure has a finite exponential moment: `e^{|x|}` is integrable against
-`measureT`, immediate from compact support `[-1,1]` (there `|x| ≤ 1`, so the integrand is bounded)
-and finiteness of `measureT`. This is the hypothesis the completeness engine consumes.
-
-Both halves are already packaged by `TauCeti.integrable_exp_mul_abs_smul_measureT`, applied here to
-the constant function `1`, which is integrable because `measureT` is finite. -/
-theorem exp_moment_measureT :
-    ∃ a : ℝ, 0 < a ∧ Integrable (fun x : ℝ => Real.exp (a * |x|)) measureT :=
-  ⟨1, one_pos, by
-    simpa using integrable_exp_mul_abs_smul_measureT (𝕜 := ℝ) (g := fun _ : ℝ => (1 : ℝ)) 1
-      (integrable_const 1)⟩
-
 /-- **Monomial-orthogonality from mode-orthogonality.** A vector of `L²(measureT)` orthogonal to
 every normalized Chebyshev mode has every scalar-cast monomial moment `∫ (x : 𝕜)ⁿ · g` vanishing.
 This threads `inner_polynomialEvalChebyshevLp_eq_zero` (orthogonality to every polynomial
@@ -86,8 +74,14 @@ theorem orthogonal_span_normalizedChebyshevTLp_eq_bot :
     intro n
     exact inner_eq_zero_symm.mpr
       ((Submodule.mem_orthogonal _ _).mp hg _ (Submodule.subset_span ⟨n, rfl⟩))
+  -- The exponential moment at rate `a = 1`: `measureT` has compact support `[-1,1]`, so
+  -- `integrable_exp_mul_abs_smul_measureT` applied to the constant `1` already packages both
+  -- the boundedness of `e^{|x|}` there and the finiteness of `measureT`.
   have hae := ae_eq_zero_of_forall_moment_eq_zero_of_exists_integrable_exp (ν := measureT)
-    exp_moment_measureT (Lp.memLp g) (monomial_moment_measureT_eq_zero 𝕜 g hmode)
+    ⟨1, one_pos, by
+      simpa using integrable_exp_mul_abs_smul_measureT (𝕜 := ℝ) (g := fun _ : ℝ => (1 : ℝ)) 1
+        (integrable_const 1)⟩
+    (Lp.memLp g) (monomial_moment_measureT_eq_zero 𝕜 g hmode)
   exact (Lp.eq_zero_iff_ae_eq_zero).mpr hae
 
 /-- **Roadmap Part C: the Chebyshev `T` polynomials are a Hilbert basis of `L²(measureT)`.**

--- a/TauCeti/Analysis/SpecialFunctions/Trigonometric/Chebyshev/HilbertBasis.lean
+++ b/TauCeti/Analysis/SpecialFunctions/Trigonometric/Chebyshev/HilbertBasis.lean
@@ -1,0 +1,108 @@
+module
+
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Claude
+-/
+public import Mathlib.Analysis.InnerProductSpace.l2Space
+public import TauCeti.Analysis.SpecialFunctions.Trigonometric.Chebyshev.Span
+public import TauCeti.Probability.Moments.VanishingMoments
+
+/-!
+# The Chebyshev `T` polynomials as a Hilbert basis of `L²(measureT)`
+
+Roadmap **Part C**: the normalized Chebyshev `T` modes `Tₙ/√‖Tₙ‖²` are a Hilbert basis of
+`L²([-1,1]; measureT)`, where `measureT` is Mathlib's Chebyshev orthogonality measure (weight
+`(1-x²)^{-1/2}`).
+
+Every input is already merged; this file only supplies the missing assembly. Orthonormality is
+`TauCeti.orthonormal_normalizedChebyshevTLp`; completeness is the one step that had been left open,
+because it needs the **function-level** moment-determinacy theorem
+`TauCeti.ae_eq_zero_of_forall_moment_eq_zero_of_exists_integrable_exp` (a vector of `L²(measureT)`
+orthogonal to every monomial is a.e. `0`). That theorem asks only for a *single* positive rate `a`
+with `e^{a|x|}` integrable, which is free here: the Chebyshev measure has compact support `[-1,1]`,
+so `e^{|x|}` is integrable against it and `a = 1` works.
+
+The bridge from mode-orthogonality to monomial-orthogonality is
+`TauCeti.inner_polynomialEvalChebyshevLp_eq_zero`.
+
+## Main statements
+
+* `TauCeti.chebyshevTHilbertBasis` — the Chebyshev `T` Hilbert basis of `L²(measureT)`.
+* `TauCeti.coe_chebyshevTHilbertBasis` — the anti-vacuity pin: the `n`-th basis vector is the
+  normalized mode `Tₙ/√‖Tₙ‖²`.
+-/
+
+public section
+
+namespace TauCeti
+
+open MeasureTheory Polynomial Polynomial.Chebyshev
+
+variable (𝕜 : Type*) [RCLike 𝕜]
+
+/-- The Chebyshev measure has a finite exponential moment: `e^{|x|}` is integrable against
+`measureT`, immediate from compact support `[-1,1]` (there `|x| ≤ 1`, so the integrand is bounded)
+and finiteness of `measureT`. This is the hypothesis the completeness engine consumes.
+
+Both halves are already packaged by `TauCeti.integrable_exp_mul_abs_smul_measureT`, applied here to
+the constant function `1`, which is integrable because `measureT` is finite. -/
+theorem exp_moment_measureT :
+    ∃ a : ℝ, 0 < a ∧ Integrable (fun x : ℝ => Real.exp (a * |x|)) measureT :=
+  ⟨1, one_pos, by
+    simpa using integrable_exp_mul_abs_smul_measureT (𝕜 := ℝ) (g := fun _ : ℝ => (1 : ℝ)) 1
+      (integrable_const 1)⟩
+
+/-- **Monomial-orthogonality from mode-orthogonality.** A vector of `L²(measureT)` orthogonal to
+every normalized Chebyshev mode has every scalar-cast monomial moment `∫ (x : 𝕜)ⁿ · g` vanishing.
+This threads `inner_polynomialEvalChebyshevLp_eq_zero` (orthogonality to every polynomial
+evaluation) through the `L²` inner product at `q = Xⁿ`. -/
+theorem monomial_moment_measureT_eq_zero (g : Lp 𝕜 2 measureT)
+    (hmode : ∀ n, inner 𝕜 g (normalizedChebyshevTLp 𝕜 n) = 0) (n : ℕ) :
+    ∫ x, (algebraMap ℝ 𝕜 x) ^ n * g x ∂measureT = 0 := by
+  -- Orthogonal to every polynomial evaluation, at the monomial `Xⁿ`.
+  have hpoly : inner 𝕜 g (polynomialEvalChebyshevLp 𝕜 (X ^ n)) = 0 :=
+    inner_polynomialEvalChebyshevLp_eq_zero 𝕜 g hmode (X ^ n)
+  -- Flip the inner product; the monomial side is real, so its conjugate is itself.
+  have hflip : inner 𝕜 (polynomialEvalChebyshevLp 𝕜 (X ^ n)) g = 0 :=
+    inner_eq_zero_symm.mpr hpoly
+  rw [MeasureTheory.L2.inner_def] at hflip
+  rw [← hflip]
+  refine integral_congr_ae ?_
+  filter_upwards [coeFn_polynomialEvalChebyshevLp 𝕜 (X ^ n)] with x hx
+  rw [hx, RCLike.inner_apply, Polynomial.eval_pow, Polynomial.eval_X,
+    RCLike.algebraMap_eq_ofReal, RCLike.conj_ofReal, RCLike.ofReal_pow]
+  ring
+
+/-- **Completeness of the Chebyshev family.** The orthogonal complement of the span of the
+normalized modes is trivial: a vector orthogonal to all of them has vanishing monomial moments and
+is therefore a.e. `0` by moment determinacy. -/
+theorem orthogonal_span_normalizedChebyshevTLp_eq_bot :
+    (Submodule.span 𝕜 (Set.range (normalizedChebyshevTLp 𝕜)))ᗮ = ⊥ := by
+  rw [Submodule.eq_bot_iff]
+  intro g hg
+  have hmode : ∀ n, inner 𝕜 g (normalizedChebyshevTLp 𝕜 n) = 0 := by
+    intro n
+    exact inner_eq_zero_symm.mpr
+      ((Submodule.mem_orthogonal _ _).mp hg _ (Submodule.subset_span ⟨n, rfl⟩))
+  have hae := ae_eq_zero_of_forall_moment_eq_zero_of_exists_integrable_exp (ν := measureT)
+    exp_moment_measureT (Lp.memLp g) (monomial_moment_measureT_eq_zero 𝕜 g hmode)
+  exact (Lp.eq_zero_iff_ae_eq_zero).mpr hae
+
+/-- **Roadmap Part C: the Chebyshev `T` polynomials are a Hilbert basis of `L²(measureT)`.**
+Orthonormality is `orthonormal_normalizedChebyshevTLp`; completeness is
+`orthogonal_span_normalizedChebyshevTLp_eq_bot`, which is where the shipped Chebyshev groundwork had
+stopped, one step short of the function-level moment-determinacy theorem. -/
+noncomputable def chebyshevTHilbertBasis : HilbertBasis ℕ 𝕜 (Lp 𝕜 2 measureT) :=
+  HilbertBasis.mkOfOrthogonalEqBot orthonormal_normalizedChebyshevTLp
+    (orthogonal_span_normalizedChebyshevTLp_eq_bot 𝕜)
+
+/-- **The basis vectors are the normalized Chebyshev modes.** Without this the construction would
+only exhibit *some* Hilbert basis of `L²(measureT)`; here each vector is pinned to `Tₙ/√‖Tₙ‖²`. -/
+@[simp]
+theorem coe_chebyshevTHilbertBasis :
+    ⇑(chebyshevTHilbertBasis 𝕜) = normalizedChebyshevTLp 𝕜 :=
+  HilbertBasis.coe_mkOfOrthogonalEqBot _ _
+
+end TauCeti


### PR DESCRIPTION
This PR completes Part C of `TauCetiRoadmap/OrthogonalL2Bases/README.md`: the normalized Chebyshev `T` modes `Tₙ/√‖Tₙ‖²` are a Hilbert basis of `L²([-1,1]; measureT)`, where `measureT` is Mathlib's Chebyshev orthogonality measure with weight `(1-x²)^{-1/2}`. Every input was already merged and orthonormality was already available as `TauCeti.orthonormal_normalizedChebyshevTLp`; the one step the shipped Chebyshev groundwork stopped short of was completeness, and this supplies it.

<!--tauceti-target:v1 {"focus":"OrthogonalL2Bases","id":"chebyshev-t-hilbert-basis"}-->

Split out of #1283 at the reviewer's request. The `scope` thread there asked to "split the general completeness prerequisite from its applications, and submit the Chebyshev and Hermite/Gaussian basis chains as separate PRs". This is the Chebyshev chain, one new file of 108 lines and nothing else. It does **not** depend on the completeness prerequisite in #1283 and is not waiting on it: it reaches determinacy directly through the already-merged function-level theorem `TauCeti.ae_eq_zero_of_forall_moment_eq_zero_of_exists_integrable_exp`, and it builds green against current `main` with `TauCeti/Probability/Moments/VanishingMoments.lean` untouched.

The completeness argument is short because that theorem asks only for a *single* positive rate `a` with `e^{a|x|}` integrable, which is free here: `measureT` is finite with compact support `[-1,1]`, so `|x| ≤ 1` bounds the integrand and `a = 1` works. `exp_moment_measureT` gets both halves from the existing `TauCeti.integrable_exp_mul_abs_smul_measureT` applied to the constant function `1`, rather than re-deriving the integrability. The bridge from mode-orthogonality to monomial-orthogonality is the merged `TauCeti.inner_polynomialEvalChebyshevLp_eq_zero`, threaded through the `L²` inner product at `q = Xⁿ` in `monomial_moment_measureT_eq_zero`. Those two feed `orthogonal_span_normalizedChebyshevTLp_eq_bot`, and `HilbertBasis.mkOfOrthogonalEqBot` packages it as `chebyshevTHilbertBasis`.

`coe_chebyshevTHilbertBasis` pins the basis vectors to the normalized modes; without it the construction would only exhibit *some* Hilbert basis of `L²(measureT)`. It is named `coe_` rather than `coeFn_` to match the adjacent basis-to-family coercions `TauCeti.coe_hilbertBasisOfWeightedMeasure` and `TauCeti.coe_hilbertBasisOfOrthogonalSystem`, and the Mathlib lemma that proves it, `HilbertBasis.coe_mkOfOrthogonalEqBot`. The `coeFn_` spelling in this area is used for a.e. equalities of a coerced `L²` element, which this is not.

No Mathlib infrastructure was vendored. Verified with `lake exe cache get` and `lake build TauCeti.Analysis.SpecialFunctions.Trigonometric.Chebyshev.HilbertBasis`: `Build completed successfully (3071 jobs)`.

🤖 Prepared with Claude
