### PR TITLE
feat: prove contour integrand integrability

### DIFF
--- a/TauCeti/Analysis/Contour/Curve/Integrability.lean
+++ b/TauCeti/Analysis/Contour/Curve/Integrability.lean
@@ -16,8 +16,7 @@ integrand. This file packages that Layer 0 conclusion of the contour-integration
 vector-valued integrands over `ℂ`.
 
 The main theorem assumes continuity on the exact image `γ '' [[a, b]]`; a companion form accepts
-continuity on any set containing that image. The scalar-valued multiplication form matches the
-integrand convention used by the arc fundamental theorem of calculus.
+continuity on any set containing that image.
 
 ## Main results
 
@@ -25,8 +24,6 @@ integrand convention used by the arc fundamental theorem of calculus.
   interval-integrable when `f` is continuous on the curve image.
 * `IsPiecewiseC1On.intervalIntegrable_deriv_smul_comp_of_mapsTo` — the same conclusion from
   continuity on an ambient set containing the curve.
-* `IsPiecewiseC1On.intervalIntegrable_comp_mul_deriv` — the scalar-valued form
-  `t ↦ f (γ t) * deriv γ t`.
 
 The proof uses Mathlib's `IntervalIntegrable.smul_continuousOn`, after
 `IsPiecewiseC1On.intervalIntegrable_deriv` supplies integrability of the velocity.
@@ -58,15 +55,6 @@ theorem IsPiecewiseC1On.intervalIntegrable_deriv_smul_comp_of_mapsTo {s : Set �
     (hγ : IsPiecewiseC1On γ a b) (hf : ContinuousOn f s) (hγs : MapsTo γ (uIcc a b) s) :
     IntervalIntegrable (fun t ↦ deriv γ t • f (γ t)) volume a b :=
   hγ.intervalIntegrable_deriv_smul_comp (hf.mono (image_subset_iff.mpr hγs))
-
-/-- Scalar-valued multiplication form of
-`IsPiecewiseC1On.intervalIntegrable_deriv_smul_comp`. This is the order of the two factors used by
-the arc-FTC integrand `t ↦ f (γ t) * deriv γ t`. -/
-theorem IsPiecewiseC1On.intervalIntegrable_comp_mul_deriv {f : ℂ → ℂ}
-    (hγ : IsPiecewiseC1On γ a b) (hf : ContinuousOn f (γ '' uIcc a b)) :
-    IntervalIntegrable (fun t ↦ f (γ t) * deriv γ t) volume a b :=
-  (hγ.intervalIntegrable_deriv_smul_comp hf).congr fun t _ ↦ by
-    rw [smul_eq_mul, mul_comm]
 
 end TauCeti.Contour
 

--- a/TauCeti/Analysis/Contour/Curve/Integrability.lean
+++ b/TauCeti/Analysis/Contour/Curve/Integrability.lean
@@ -1,0 +1,73 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import TauCeti.Analysis.Contour.PiecewiseC1On
+
+/-!
+# Integrability of contour integrands
+
+A piecewise-`C¹` curve has interval-integrable derivative. Multiplying that derivative by a
+continuous function along the compact curve image therefore gives an interval-integrable contour
+integrand. This file packages that Layer 0 conclusion of the contour-integration roadmap for
+vector-valued integrands over `ℂ`.
+
+The main theorem assumes continuity on the exact image `γ '' [[a, b]]`; a companion form accepts
+continuity on any set containing that image. The scalar-valued multiplication form matches the
+integrand convention used by the arc fundamental theorem of calculus.
+
+## Main results
+
+* `IsPiecewiseC1On.intervalIntegrable_deriv_smul_comp` — `t ↦ deriv γ t • f (γ t)` is
+  interval-integrable when `f` is continuous on the curve image.
+* `IsPiecewiseC1On.intervalIntegrable_deriv_smul_comp_of_mapsTo` — the same conclusion from
+  continuity on an ambient set containing the curve.
+* `IsPiecewiseC1On.intervalIntegrable_comp_mul_deriv` — the scalar-valued form
+  `t ↦ f (γ t) * deriv γ t`.
+
+The proof uses Mathlib's `IntervalIntegrable.smul_continuousOn`, after
+`IsPiecewiseC1On.intervalIntegrable_deriv` supplies integrability of the velocity.
+-/
+
+public section
+
+noncomputable section
+
+namespace TauCeti.Contour
+
+open MeasureTheory Set
+
+variable {E : Type*} [NormedAddCommGroup E] [NormedSpace ℂ E]
+variable {γ : ℝ → ℂ} {f : ℂ → E} {a b : ℝ}
+
+/-- Along a piecewise-`C¹` curve, the product of the curve velocity with a function continuous on
+the curve image is interval-integrable. This is the vector-valued contour integrand
+`t ↦ deriv γ t • f (γ t)` from Layer 0 of the contour-integration roadmap. -/
+theorem IsPiecewiseC1On.intervalIntegrable_deriv_smul_comp
+    (hγ : IsPiecewiseC1On γ a b) (hf : ContinuousOn f (γ '' uIcc a b)) :
+    IntervalIntegrable (fun t ↦ deriv γ t • f (γ t)) volume a b :=
+  hγ.intervalIntegrable_deriv.smul_continuousOn
+    (hf.comp hγ.continuousOn (mapsTo_image γ (uIcc a b)))
+
+/-- Ambient-set form of `IsPiecewiseC1On.intervalIntegrable_deriv_smul_comp`: it suffices for `f`
+to be continuous on a set `s` containing the curve image. -/
+theorem IsPiecewiseC1On.intervalIntegrable_deriv_smul_comp_of_mapsTo {s : Set ℂ}
+    (hγ : IsPiecewiseC1On γ a b) (hf : ContinuousOn f s) (hγs : MapsTo γ (uIcc a b) s) :
+    IntervalIntegrable (fun t ↦ deriv γ t • f (γ t)) volume a b :=
+  hγ.intervalIntegrable_deriv_smul_comp (hf.mono (image_subset_iff.mpr hγs))
+
+/-- Scalar-valued multiplication form of
+`IsPiecewiseC1On.intervalIntegrable_deriv_smul_comp`. This is the order of the two factors used by
+the arc-FTC integrand `t ↦ f (γ t) * deriv γ t`. -/
+theorem IsPiecewiseC1On.intervalIntegrable_comp_mul_deriv {f : ℂ → ℂ}
+    (hγ : IsPiecewiseC1On γ a b) (hf : ContinuousOn f (γ '' uIcc a b)) :
+    IntervalIntegrable (fun t ↦ f (γ t) * deriv γ t) volume a b :=
+  (hγ.intervalIntegrable_deriv_smul_comp hf).congr fun t _ ↦ by
+    rw [smul_eq_mul, mul_comm]
+
+end TauCeti.Contour
+
+end

--- a/TauCeti/Analysis/Contour/Residue/Assembly.lean
+++ b/TauCeti/Analysis/Contour/Residue/Assembly.lean
@@ -12,7 +12,6 @@ public import TauCeti.Analysis.Contour.PolarPart.Decomposition
 public import TauCeti.Analysis.Contour.PwC1ImmersionOn
 public import TauCeti.Analysis.Contour.RegularityConditions
 public import TauCeti.Analysis.Contour.Winding.Number.Basic
-import TauCeti.Analysis.Contour.Curve.Integrability
 import TauCeti.Analysis.Contour.PolarPart.CPV
 
 /-!
@@ -72,9 +71,8 @@ theorem hasCauchyPV_residue_sum {f : ℂ → ℂ} {S : Finset ℂ} {U : Set ℂ}
   classical
   have h_rem_int : IntervalIntegrable
       (fun t => decomp.analyticRemainder (γ t) * deriv γ t) MeasureTheory.volume a b :=
-    h_imm.isPiecewiseC1On.intervalIntegrable_comp_mul_deriv
-      (decomp.analyticRemainder_differentiableOn.continuousOn.mono
-        (image_subset_iff.mpr hγU))
+    h_imm.isPiecewiseC1On.intervalIntegrable_deriv.continuousOn_mul
+      (decomp.analyticRemainder_differentiableOn.continuousOn.comp h_imm.continuousOn hγU)
   have h_rem : HasCauchyPV γ a b decomp.analyticRemainder 0 := by
     have h0 := HasCauchyPV.of_integrable h_rem_int
     rwa [show (∫ t in a..b, decomp.analyticRemainder (γ t) * deriv γ t) = 0 from by

--- a/TauCeti/Analysis/Contour/Residue/Assembly.lean
+++ b/TauCeti/Analysis/Contour/Residue/Assembly.lean
@@ -12,6 +12,7 @@ public import TauCeti.Analysis.Contour.PolarPart.Decomposition
 public import TauCeti.Analysis.Contour.PwC1ImmersionOn
 public import TauCeti.Analysis.Contour.RegularityConditions
 public import TauCeti.Analysis.Contour.Winding.Number.Basic
+import TauCeti.Analysis.Contour.Curve.Integrability
 import TauCeti.Analysis.Contour.PolarPart.CPV
 
 /-!
@@ -71,8 +72,9 @@ theorem hasCauchyPV_residue_sum {f : ℂ → ℂ} {S : Finset ℂ} {U : Set ℂ}
   classical
   have h_rem_int : IntervalIntegrable
       (fun t => decomp.analyticRemainder (γ t) * deriv γ t) MeasureTheory.volume a b :=
-    h_imm.isPiecewiseC1On.intervalIntegrable_deriv.continuousOn_mul
-      (decomp.analyticRemainder_differentiableOn.continuousOn.comp h_imm.continuousOn hγU)
+    h_imm.isPiecewiseC1On.intervalIntegrable_comp_mul_deriv
+      (decomp.analyticRemainder_differentiableOn.continuousOn.mono
+        (image_subset_iff.mpr hγU))
   have h_rem : HasCauchyPV γ a b decomp.analyticRemainder 0 := by
     have h0 := HasCauchyPV.of_integrable h_rem_int
     rwa [show (∫ t in a..b, decomp.analyticRemainder (γ t) * deriv γ t) = 0 from by


### PR DESCRIPTION
This PR proves that a continuous vector-valued function along a piecewise-`C¹` complex curve has an interval-integrable contour integrand. It advances `TauCetiRoadmap/ContourIntegration/README.md`, Layer 0, item “interval-integrability of `γ'·(f ∘ γ)` for `f` continuous on the image.”

This is the lowest-hanging unfinished ContourIntegration target because the pinned milestones and worked examples have landed, while the existing `IsPiecewiseC1On.intervalIntegrable_deriv` stops one step before the Layer 0 conclusion. Add `TauCeti/Analysis/Contour/Curve/Integrability.lean` (73 lines) with the weakest image-continuity form, an ambient-set form, and the scalar multiplication form used by the arc FTC. Route the analytic-remainder integrability step in `Residue/Assembly.lean` through the new API as an immediate nontrivial consumer.

Reuse Mathlib's `IntervalIntegrable.smul_continuousOn` together with Tau Ceti's `IsPiecewiseC1On.intervalIntegrable_deriv`. Vendor no Mathlib infrastructure and copy or adapt no external formalization.

`lake build` reports `Build completed successfully (5595 jobs).` `lake exe axioms` reports `axioms: audited 12950 TauCeti declaration(s); all within the allowlist [propext, Classical.choice, Quot.sound].`

<!--tauceti-target:v1 {"focus":"ContourIntegration","id":"interval-integrability-contour-integrand"}-->

🤖 Prepared with Codex
