### PR TITLE
refactor(Conformal): decompose exists_differentiableOn_injOn_mapsTo_unitBall

### DIFF
--- a/TauCeti/Analysis/Complex/Conformal/DiscInjection.lean
+++ b/TauCeti/Analysis/Complex/Conformal/DiscInjection.lean
@@ -92,12 +92,13 @@ private lemma exists_sq_eq_sub_injOn_ne_zero {U : Set ℂ} (hUc : IsSimplyConnec
   · have hza : z - a = 0 := by rw [← hsq z hz, hz0]; ring
     exact ha (by rwa [sub_eq_zero.mp hza] at hz)
 
-/-- **The square root avoids its own negation, quantitatively.** If `h² = z - a` on `U` with `h`
-nonvanishing there, and a ball of radius `r` about `w₀` lies inside `h '' U`, then `-h z` stays
-outside that ball for every `z ∈ U`: otherwise `-h z = h z'` for some `z' ∈ U`, and squaring forces
-`z' = z`, hence `h z = 0`. -/
-private lemma le_norm_add_of_ball_subset_image {U : Set ℂ} {h : ℂ → ℂ} {a w₀ : ℂ} {r : ℝ}
-    (hsq : ∀ z ∈ U, h z ^ 2 = z - a) (hne : ∀ z ∈ U, h z ≠ 0) (hball : ball w₀ r ⊆ h '' U) :
+/-- **A square-injective function avoids its own negation, quantitatively.** If squaring `h` is
+injective on `U` and `h` is nonvanishing there, and a ball of radius `r` about `w₀` lies inside
+`h '' U`, then `-h z` stays outside that ball for every `z ∈ U`: otherwise `-h z = h z'` for some
+`z' ∈ U`, and equal squares force `z' = z`, hence `h z = 0`. -/
+private lemma le_norm_add_of_ball_subset_image {U : Set ℂ} {h : ℂ → ℂ} {w₀ : ℂ} {r : ℝ}
+    (hsq_inj : Set.InjOn (fun z => h z ^ 2) U) (hne : ∀ z ∈ U, h z ≠ 0)
+    (hball : ball w₀ r ⊆ h '' U) :
     ∀ z ∈ U, r ≤ ‖h z + w₀‖ := by
   intro z hz
   by_contra hcon
@@ -107,10 +108,7 @@ private lemma le_norm_add_of_ball_subset_image {U : Set ℂ} {h : ℂ → ℂ} {
     rw [hrw, norm_neg]
     exact lt_of_not_ge hcon
   obtain ⟨z', hz', hz'eq⟩ := hball hmem
-  have hsq' : z' - a = z - a := by
-    rw [← hsq z' hz', ← hsq z hz, hz'eq]
-    ring
-  have hzz : z' = z := by linear_combination hsq'
+  have hzz : z' = z := hsq_inj hz' hz (by simp only; rw [hz'eq]; ring)
   rw [hzz] at hz'eq
   exact hne z hz (by linear_combination hz'eq / 2)
 
@@ -139,7 +137,11 @@ theorem exists_differentiableOn_injOn_mapsTo_unitBall {U : Set ℂ} (hUc : IsSim
   -- The image contains a ball around `h z₀`, and `-h` avoids it.
   obtain ⟨r, hr, hball⟩ := Metric.isOpen_iff.mp hopen (h z₀) ⟨z₀, hz₀, rfl⟩
   set w₀ : ℂ := h z₀ with hw₀
-  have havoid : ∀ z ∈ U, r ≤ ‖h z + w₀‖ := le_norm_add_of_ball_subset_image hsq hne hball
+  have hsq_inj : Set.InjOn (fun z => h z ^ 2) U := fun z₁ hz₁ z₂ hz₂ he => by
+    have : z₁ - a = z₂ - a := by rw [← hsq z₁ hz₁, ← hsq z₂ hz₂]; exact he
+    linear_combination this
+  have havoid : ∀ z ∈ U, r ≤ ‖h z + w₀‖ :=
+    le_norm_add_of_ball_subset_image hsq_inj hne hball
   -- Every denominator is nonzero, `r` being positive.
   have hden : ∀ z ∈ U, h z + w₀ ≠ 0 := by
     intro z hz hzero'

--- a/TauCeti/Analysis/Complex/Conformal/DiscInjection.lean
+++ b/TauCeti/Analysis/Complex/Conformal/DiscInjection.lean
@@ -71,12 +71,13 @@ namespace TauCeti
 open Complex Set Metric
 
 /-- **A holomorphic square root of `z - a`.** On a simply connected open `U` avoiding `a` the
-function `z - a` is nonvanishing, so it has a holomorphic square root; any such root is injective,
-because squaring recovers `z`, and nonvanishing, because its square is. -/
+function `z - a` is nonvanishing, so it has a holomorphic square root. Squaring such a root
+recovers `z`, so `z ↦ h z ^ 2` is injective on `U`; and `h` is nonvanishing, because its square
+is. -/
 private lemma exists_sq_eq_sub_injOn_ne_zero {U : Set ℂ} (hUc : IsSimplyConnected U)
     (hUo : IsOpen U) {a : ℂ} (ha : a ∉ U) :
-    ∃ h : ℂ → ℂ, DifferentiableOn ℂ h U ∧ (∀ z ∈ U, h z ^ 2 = z - a) ∧ InjOn h U ∧
-      ∀ z ∈ U, h z ≠ 0 := by
+    ∃ h : ℂ → ℂ, DifferentiableOn ℂ h U ∧ (∀ z ∈ U, h z ^ 2 = z - a) ∧
+      InjOn (fun z => h z ^ 2) U ∧ ∀ z ∈ U, h z ≠ 0 := by
   have hsub : DifferentiableOn ℂ (fun z : ℂ => z - a) U :=
     (differentiable_id.sub_const a).differentiableOn
   have hzero : (0 : ℂ) ∉ (fun z : ℂ => z - a) '' U := by
@@ -87,7 +88,7 @@ private lemma exists_sq_eq_sub_injOn_ne_zero {U : Set ℂ} (hUc : IsSimplyConnec
     exists_differentiableOn_pow_eq hUc hUo hsub hzero (n := 2) two_ne_zero
   have hsq : ∀ z ∈ U, h z ^ 2 = z - a := fun z hz => hheq hz
   refine ⟨h, hhd, hsq, fun z₁ hz₁ z₂ hz₂ hEq => ?_, fun z hz hz0 => ?_⟩
-  · have hdiff : z₁ - a = z₂ - a := by rw [← hsq z₁ hz₁, ← hsq z₂ hz₂, hEq]
+  · have hdiff : z₁ - a = z₂ - a := by rw [← hsq z₁ hz₁, ← hsq z₂ hz₂]; exact hEq
     linear_combination hdiff
   · have hza : z - a = 0 := by rw [← hsq z hz, hz0]; ring
     exact ha (by rwa [sub_eq_zero.mp hza] at hz)
@@ -122,7 +123,8 @@ theorem exists_differentiableOn_injOn_mapsTo_unitBall {U : Set ℂ} (hUc : IsSim
     exact hUne (eq_univ_of_forall (by simpa using hcon))
   -- `z - a` is nonvanishing on `U`, so it has a holomorphic square root there, injective and
   -- itself nonvanishing.
-  obtain ⟨h, hhd, hsq, hinj, hne⟩ := exists_sq_eq_sub_injOn_ne_zero hUc hUo ha
+  obtain ⟨h, hhd, hsq, hsq_inj, hne⟩ := exists_sq_eq_sub_injOn_ne_zero hUc hUo ha
+  have hinj : InjOn h U := fun z₁ hz₁ z₂ hz₂ he => hsq_inj hz₁ hz₂ (by simp only; rw [he])
   -- `h '' U` is open: `h` is injective, hence nonconstant, on the connected `U`.
   have hconn : IsPreconnected U := hUc.isPathConnected.isConnected.isPreconnected
   have hanal : AnalyticOnNhd ℂ h U := hhd.analyticOnNhd hUo
@@ -137,9 +139,6 @@ theorem exists_differentiableOn_injOn_mapsTo_unitBall {U : Set ℂ} (hUc : IsSim
   -- The image contains a ball around `h z₀`, and `-h` avoids it.
   obtain ⟨r, hr, hball⟩ := Metric.isOpen_iff.mp hopen (h z₀) ⟨z₀, hz₀, rfl⟩
   set w₀ : ℂ := h z₀ with hw₀
-  have hsq_inj : Set.InjOn (fun z => h z ^ 2) U := fun z₁ hz₁ z₂ hz₂ he => by
-    have : z₁ - a = z₂ - a := by rw [← hsq z₁ hz₁, ← hsq z₂ hz₂]; exact he
-    linear_combination this
   have havoid : ∀ z ∈ U, r ≤ ‖h z + w₀‖ :=
     le_norm_add_of_ball_subset_image hsq_inj hne hball
   -- Every denominator is nonzero, `r` being positive.

--- a/TauCeti/Analysis/Complex/Conformal/DiscInjection.lean
+++ b/TauCeti/Analysis/Complex/Conformal/DiscInjection.lean
@@ -70,15 +70,24 @@ namespace TauCeti
 
 open Complex Set Metric
 
-/-- **A simply connected proper domain injects into the unit disc.** The Riemann mapping theorem's
-competing family — injective holomorphic maps `U → 𝔻` — is nonempty. -/
-theorem exists_differentiableOn_injOn_mapsTo_unitBall {U : Set ℂ} (hUc : IsSimplyConnected U)
-    (hUo : IsOpen U) (hUne : U ≠ univ) :
-    ∃ f : ℂ → ℂ, DifferentiableOn ℂ f U ∧ InjOn f U ∧ MapsTo f U (ball (0 : ℂ) 1) := by
-  obtain ⟨a, ha⟩ : ∃ a, a ∉ U := by
-    by_contra hcon
-    exact hUne (eq_univ_of_forall (by simpa using hcon))
-  -- `z - a` is nonvanishing on `U`, so it has a holomorphic square root there.
+/-- An open subset of `ℂ` containing a point contains a second, distinct one. -/
+private lemma exists_mem_ne_of_isOpen {U : Set ℂ} (hUo : IsOpen U) {z₀ : ℂ} (hz₀ : z₀ ∈ U) :
+    ∃ z ∈ U, z ≠ z₀ := by
+  obtain ⟨ε, hε, hball⟩ := Metric.isOpen_iff.mp hUo z₀ hz₀
+  refine ⟨z₀ + ((ε / 2 : ℝ) : ℂ), hball ?_, ?_⟩
+  · rw [mem_ball, dist_eq_norm, add_sub_cancel_left, Complex.norm_real, Real.norm_eq_abs,
+      abs_of_pos (half_pos hε)]
+    linarith
+  · simp only [ne_eq, add_eq_left, Complex.ofReal_eq_zero]
+    exact (half_pos hε).ne'
+
+/-- **A holomorphic square root of `z - a`.** On a simply connected open `U` avoiding `a` the
+function `z - a` is nonvanishing, so it has a holomorphic square root; any such root is injective,
+because squaring recovers `z`, and nonvanishing, because its square is. -/
+private lemma exists_sq_eq_sub_injOn_ne_zero {U : Set ℂ} (hUc : IsSimplyConnected U)
+    (hUo : IsOpen U) {a : ℂ} (ha : a ∉ U) :
+    ∃ h : ℂ → ℂ, DifferentiableOn ℂ h U ∧ (∀ z ∈ U, h z ^ 2 = z - a) ∧ InjOn h U ∧
+      ∀ z ∈ U, h z ≠ 0 := by
   have hsub : DifferentiableOn ℂ (fun z : ℂ => z - a) U :=
     (differentiable_id.sub_const a).differentiableOn
   have hzero : (0 : ℂ) ∉ (fun z : ℂ => z - a) '' U := by
@@ -88,58 +97,59 @@ theorem exists_differentiableOn_injOn_mapsTo_unitBall {U : Set ℂ} (hUc : IsSim
   obtain ⟨h, hhd, hheq⟩ :=
     exists_differentiableOn_pow_eq hUc hUo hsub hzero (n := 2) two_ne_zero
   have hsq : ∀ z ∈ U, h z ^ 2 = z - a := fun z hz => hheq hz
-  -- `h` never vanishes on `U`, since its square is `z - a ≠ 0`.
-  have hne : ∀ z ∈ U, h z ≠ 0 := by
-    intro z hz hz0
-    have hza : z - a = 0 := by rw [← hsq z hz, hz0]; ring
-    exact ha (by rwa [sub_eq_zero.mp hza] at hz)
-  -- Squaring makes `h` injective.
-  have hinj : InjOn h U := by
-    intro z₁ hz₁ z₂ hz₂ hEq
-    have hdiff : z₁ - a = z₂ - a := by rw [← hsq z₁ hz₁, ← hsq z₂ hz₂, hEq]
+  refine ⟨h, hhd, hsq, fun z₁ hz₁ z₂ hz₂ hEq => ?_, fun z hz hz0 => ?_⟩
+  · have hdiff : z₁ - a = z₂ - a := by rw [← hsq z₁ hz₁, ← hsq z₂ hz₂, hEq]
     linear_combination hdiff
+  · have hza : z - a = 0 := by rw [← hsq z hz, hz0]; ring
+    exact ha (by rwa [sub_eq_zero.mp hza] at hz)
+
+/-- **The square root avoids its own negation, quantitatively.** If `h² = z - a` on `U` with `h`
+nonvanishing there, and a ball of radius `r` about `w₀` lies inside `h '' U`, then `-h z` stays
+outside that ball for every `z ∈ U`: otherwise `-h z = h z'` for some `z' ∈ U`, and squaring forces
+`z' = z`, hence `h z = 0`. -/
+private lemma le_norm_add_of_ball_subset_image {U : Set ℂ} {h : ℂ → ℂ} {a w₀ : ℂ} {r : ℝ}
+    (hsq : ∀ z ∈ U, h z ^ 2 = z - a) (hne : ∀ z ∈ U, h z ≠ 0) (hball : ball w₀ r ⊆ h '' U) :
+    ∀ z ∈ U, r ≤ ‖h z + w₀‖ := by
+  intro z hz
+  by_contra hcon
+  have hmem : -h z ∈ ball w₀ r := by
+    rw [mem_ball, dist_eq_norm]
+    have hrw : -h z - w₀ = -(h z + w₀) := by ring
+    rw [hrw, norm_neg]
+    exact lt_of_not_ge hcon
+  obtain ⟨z', hz', hz'eq⟩ := hball hmem
+  have hsq' : z' - a = z - a := by
+    rw [← hsq z' hz', ← hsq z hz, hz'eq]
+    ring
+  have hzz : z' = z := by linear_combination hsq'
+  rw [hzz] at hz'eq
+  exact hne z hz (by linear_combination hz'eq / 2)
+
+/-- **A simply connected proper domain injects into the unit disc.** The Riemann mapping theorem's
+competing family — injective holomorphic maps `U → 𝔻` — is nonempty. -/
+theorem exists_differentiableOn_injOn_mapsTo_unitBall {U : Set ℂ} (hUc : IsSimplyConnected U)
+    (hUo : IsOpen U) (hUne : U ≠ univ) :
+    ∃ f : ℂ → ℂ, DifferentiableOn ℂ f U ∧ InjOn f U ∧ MapsTo f U (ball (0 : ℂ) 1) := by
+  obtain ⟨a, ha⟩ : ∃ a, a ∉ U := by
+    by_contra hcon
+    exact hUne (eq_univ_of_forall (by simpa using hcon))
+  -- `z - a` is nonvanishing on `U`, so it has a holomorphic square root there, injective and
+  -- itself nonvanishing.
+  obtain ⟨h, hhd, hsq, hinj, hne⟩ := exists_sq_eq_sub_injOn_ne_zero hUc hUo ha
   -- `h '' U` is open: `h` is injective, hence nonconstant, on the connected `U`.
   have hconn : IsPreconnected U := hUc.isPathConnected.isConnected.isPreconnected
   have hanal : AnalyticOnNhd ℂ h U := hhd.analyticOnNhd hUo
   obtain ⟨z₀, hz₀⟩ := hUc.nonempty
   have hopen : IsOpen (h '' U) := by
     rcases hanal.is_constant_or_isOpen hconn with hconst | hopenmap
-    · exfalso
-      obtain ⟨w, hw⟩ := hconst
-      obtain ⟨ε, hε, hball⟩ := Metric.isOpen_iff.mp hUo z₀ hz₀
-      have hhalf : (0 : ℝ) < ε / 2 := by linarith
-      have hz₁ : z₀ + ((ε / 2 : ℝ) : ℂ) ∈ U := by
-        refine hball ?_
-        have hnorm : ‖z₀ + ((ε / 2 : ℝ) : ℂ) - z₀‖ = ε / 2 := by
-          have hcancel : z₀ + ((ε / 2 : ℝ) : ℂ) - z₀ = ((ε / 2 : ℝ) : ℂ) := by ring
-          rw [hcancel, Complex.norm_real, Real.norm_eq_abs, abs_of_pos hhalf]
-        rw [mem_ball, dist_eq_norm, hnorm]
-        linarith
-      have heq : z₀ + ((ε / 2 : ℝ) : ℂ) = z₀ :=
-        hinj hz₁ hz₀ (by rw [hw _ hz₁, hw _ hz₀])
-      have : ((ε / 2 : ℝ) : ℂ) = 0 := by linear_combination heq
-      exact absurd (by exact_mod_cast this) (ne_of_gt hhalf)
+    · obtain ⟨w, hw⟩ := hconst
+      obtain ⟨z₁, hz₁, hz₁ne⟩ := exists_mem_ne_of_isOpen hUo hz₀
+      exact absurd (hinj hz₁ hz₀ (by rw [hw _ hz₁, hw _ hz₀])) hz₁ne
     · exact hopenmap U (subset_refl U) hUo
   -- The image contains a ball around `h z₀`, and `-h` avoids it.
   obtain ⟨r, hr, hball⟩ := Metric.isOpen_iff.mp hopen (h z₀) ⟨z₀, hz₀, rfl⟩
   set w₀ : ℂ := h z₀ with hw₀
-  have havoid : ∀ z ∈ U, r ≤ ‖h z + w₀‖ := by
-    intro z hz
-    by_contra hcon
-    have hlt : ‖h z + w₀‖ < r := lt_of_not_ge hcon
-    have hmem : -h z ∈ ball w₀ r := by
-      rw [mem_ball, dist_eq_norm]
-      have hrw : -h z - w₀ = -(h z + w₀) := by ring
-      rw [hrw, norm_neg]
-      exact hlt
-    obtain ⟨z', hz', hz'eq⟩ := hball hmem
-    -- Squaring `h z' = -h z` gives `z' = z`, forcing `h z = 0`.
-    have hsq' : z' - a = z - a := by
-      rw [← hsq z' hz', ← hsq z hz, hz'eq]
-      ring
-    have hzz : z' = z := by linear_combination hsq'
-    rw [hzz] at hz'eq
-    exact hne z hz (by linear_combination hz'eq / 2)
+  have havoid : ∀ z ∈ U, r ≤ ‖h z + w₀‖ := le_norm_add_of_ball_subset_image hsq hne hball
   -- Every denominator is nonzero, `r` being positive.
   have hden : ∀ z ∈ U, h z + w₀ ≠ 0 := by
     intro z hz hzero'

--- a/TauCeti/Analysis/Complex/Conformal/DiscInjection.lean
+++ b/TauCeti/Analysis/Complex/Conformal/DiscInjection.lean
@@ -70,17 +70,6 @@ namespace TauCeti
 
 open Complex Set Metric
 
-/-- An open subset of `ℂ` containing a point contains a second, distinct one. -/
-private lemma exists_mem_ne_of_isOpen {U : Set ℂ} (hUo : IsOpen U) {z₀ : ℂ} (hz₀ : z₀ ∈ U) :
-    ∃ z ∈ U, z ≠ z₀ := by
-  obtain ⟨ε, hε, hball⟩ := Metric.isOpen_iff.mp hUo z₀ hz₀
-  refine ⟨z₀ + ((ε / 2 : ℝ) : ℂ), hball ?_, ?_⟩
-  · rw [mem_ball, dist_eq_norm, add_sub_cancel_left, Complex.norm_real, Real.norm_eq_abs,
-      abs_of_pos (half_pos hε)]
-    linarith
-  · simp only [ne_eq, add_eq_left, Complex.ofReal_eq_zero]
-    exact (half_pos hε).ne'
-
 /-- **A holomorphic square root of `z - a`.** On a simply connected open `U` avoiding `a` the
 function `z - a` is nonvanishing, so it has a holomorphic square root; any such root is injective,
 because squaring recovers `z`, and nonvanishing, because its square is. -/
@@ -143,7 +132,8 @@ theorem exists_differentiableOn_injOn_mapsTo_unitBall {U : Set ℂ} (hUc : IsSim
   have hopen : IsOpen (h '' U) := by
     rcases hanal.is_constant_or_isOpen hconn with hconst | hopenmap
     · obtain ⟨w, hw⟩ := hconst
-      obtain ⟨z₁, hz₁, hz₁ne⟩ := exists_mem_ne_of_isOpen hUo hz₀
+      obtain ⟨z₁, hz₁, hz₁ne⟩ :=
+        (infinite_of_mem_nhds z₀ (hUo.mem_nhds hz₀)).nontrivial.exists_ne z₀
       exact absurd (hinj hz₁ hz₀ (by rw [hw _ hz₁, hw _ hz₀])) hz₁ne
     · exact hopenmap U (subset_refl U) hUo
   -- The image contains a ball around `h z₀`, and `-h` avoids it.

--- a/TauCeti/Analysis/Complex/Conformal/DiscInjection.lean
+++ b/TauCeti/Analysis/Complex/Conformal/DiscInjection.lean
@@ -72,8 +72,8 @@ open Complex Set Metric
 
 /-- **A holomorphic square root of `z - a`.** On a simply connected open `U` avoiding `a` the
 function `z - a` is nonvanishing, so it has a holomorphic square root. Squaring such a root
-recovers `z`, so `z ↦ h z ^ 2` is injective on `U`; and `h` is nonvanishing, because its square
-is. -/
+recovers `z - a`, which pins down `z` because `a` is fixed, so `z ↦ h z ^ 2` is injective on `U`;
+and `h` is nonvanishing, because its square is. -/
 private lemma exists_sq_eq_sub_injOn_ne_zero {U : Set ℂ} (hUc : IsSimplyConnected U)
     (hUo : IsOpen U) {a : ℂ} (ha : a ∉ U) :
     ∃ h : ℂ → ℂ, DifferentiableOn ℂ h U ∧ (∀ z ∈ U, h z ^ 2 = z - a) ∧


### PR DESCRIPTION
`exists_differentiableOn_injOn_mapsTo_unitBall` ran 89 lines. Three mathematically separate steps
were interleaved in it.

## Extracted

* `exists_sq_eq_sub_injOn_ne_zero` — on a simply connected open `U` avoiding `a`, the function
  `z - a` has a holomorphic square root, and any such root is injective and nonvanishing.
  Injectivity and nonvanishing both follow from `h² = z - a` alone, so they belong with the
  construction rather than after it.
* `le_norm_add_of_ball_subset_image` — if squaring `h` is injective on `U` and `h` is nonvanishing
  there, and a ball of radius `r` about `w₀` lies inside `h '' U`, then `-h z` stays outside that
  ball for every `z ∈ U`. This is the geometric heart: the image misses its own negation, with a
  quantitative gap.

The third takes `h`, `w₀` and `r` as bare data — it never uses that `w₀ = h z₀` or that `r` came
from openness of the image, only that the ball sits inside the image. Nor does it need the square
root's defining equation: `a` and `h² = z - a` entered only to conclude `z' = z` from equal
squares, so the hypothesis is injectivity of `z ↦ h z ^ 2`, which the caller derives.

The fourteen lines that produced a second point of `U` to contradict constancy are
`(infinite_of_mem_nhds z₀ (hUo.mem_nhds hz₀)).nontrivial.exists_ne z₀` — Mathlib already knows a
neighbourhood in `ℂ` is infinite.

What remains in the parent is the argument's outline: build the square root, show its image is
open, extract a ball, invert.

## Sizes

| | proof body |
|---|---|
| `exists_differentiableOn_injOn_mapsTo_unitBall` | 89 → **49** |
| `exists_sq_eq_sub_injOn_ne_zero` | **15** |
| `le_norm_add_of_ball_subset_image` | **12** |

All under the repository's 50-line proof policy.

## Scope

Refactoring only — no statement changes, no new mathematics, nothing added to the public API (all
three helpers are `private`).

## Gates

`lake build` · `lake exe axioms` · `lake exe module-system` · `scripts/lint-env.sh` — all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
