### PR TITLE
refactor(UniversalCover): decompose exists_open_nhds_pathComponent_preimage

### DIFF
--- a/TauCeti/AlgebraicTopology/UniversalCover/BasedPath.lean
+++ b/TauCeti/AlgebraicTopology/UniversalCover/BasedPath.lean
@@ -548,7 +548,8 @@ theorem isOpen_refined_tubeNeighborhood
 smaller one again gives a family that is open, path-connected, contained in `T.V` pointwise, and
 through which `α` still passes at every partition point. -/
 private theorem exists_refined_vertex_family {n' : ℕ} {part : IntervalPartition (n' + 1)}
-    {T : TubeData X (n' + 1)} {α : BasedPath x₀} (hα_tube : PathInTube α.toPath part T)
+    {T : TubeData X (n' + 1)} {α : BasedPath x₀}
+    (hα_passes : ∀ j, α.toPath (part.t j) ∈ T.V j)
     {V_last' : Set X} (hV'_open : IsOpen V_last') (hV'_pathConn : IsPathConnected V_last')
     (hα_V' : endpoint α ∈ V_last') (hV'_sub_V : V_last' ⊆ T.V (Fin.last (n' + 1))) :
     ∃ V' : Fin (n' + 2) → Set X,
@@ -573,17 +574,19 @@ private theorem exists_refined_vertex_family {n' : ℕ} {part : IntervalPartitio
   · exact fun j ↦ by
       induction j using Fin.lastCases with
       | last => rw [Fin.snoc_last, hα_at_last]; exact hα_V'
-      | cast k => rw [Fin.snoc_castSucc]; exact hα_tube.passes_through_V _
+      | cast k => rw [Fin.snoc_castSucc]; exact hα_passes _
 
 /-- **A path through the refined tube is joined to `α`.** If `β` runs through the same tube as `α`
 with refined vertex sets `V'` whose terminal member lies in `U`, then `β` is joined to `α` inside
 `endpoint ⁻¹' U`. -/
-private theorem joinedIn_endpoint_preimage_of_pathInTube [LocallyPathConnectedSpace X] {n' : ℕ}
-    {U : Set X} {V' : Fin (n' + 2) → Set X} {part : IntervalPartition (n' + 1)}
+private theorem joinedIn_endpoint_preimage_of_pathInTube {n' : ℕ} {U : Set X}
+    {V' : Fin (n' + 2) → Set X} {part : IntervalPartition (n' + 1)}
     {T : TubeData X (n' + 1)} (hV'_open : ∀ j, IsOpen (V' j))
     (hV'_pathConn : ∀ j, IsPathConnected (V' j)) (hV'_sub_TV : ∀ j, V' j ⊆ T.V j)
     (hV'_last_sub_U : V' (Fin.last (n' + 1)) ⊆ U) {α β : BasedPath x₀}
-    (hα_tube : PathInTube α.toPath part T) (hα_passes : ∀ j, α.toPath (part.t j) ∈ V' j)
+    (hα_stays : ∀ (i : Fin (n' + 1)) (s : I),
+      (part.t i.castSucc : ℝ) ≤ s ∧ s ≤ (part.t i.succ : ℝ) → α.toPath s ∈ T.U i)
+    (hα_passes : ∀ j, α.toPath (part.t j) ∈ V' j)
     (hβ_stays : ∀ (i : Fin (n' + 1)) (s : I),
       (part.t i.castSucc : ℝ) ≤ s ∧ s ≤ (part.t i.succ : ℝ) → β.1 s ∈ T.U i)
     (hβ_passes : ∀ j, β.1 (part.t j) ∈ V' j) :
@@ -601,14 +604,13 @@ private theorem joinedIn_endpoint_preimage_of_pathInTube [LocallyPathConnectedSp
   have hβ_end_U : endpoint β ∈ U :=
     hV'_last_sub_U (by simpa [part.t_last] using! hβ_passes (Fin.last (n' + 1)))
   obtain ⟨ρ_final, hρ_final_range_V, h_paste⟩ :=
-    Path.tube_subset_homotopy_class_source α.toPath part T' ⟨hα_tube.stays_in_U, hα_passes⟩
+    Path.tube_subset_homotopy_class_source α.toPath part T' ⟨hα_stays, hα_passes⟩
       β.toPath ⟨hβ_stays, hβ_passes⟩
   refine (joinedIn_preimage_of_append α ρ_final
     (hρ_final_range_V.trans hV'_last_sub_U)).trans ?_
   obtain ⟨γ, hγ⟩ :=
     (joinedIn_endpoint_preimage_of_homotopic (x₀ := x₀) (U := ({endpoint β} : Set X))
-      (show endpoint β ∈ ({endpoint β} : Set X) from rfl)
-      (show Path.Homotopic (α.toPath.trans ρ_final) β.toPath from h_paste)).mono
+      (Set.mem_singleton _) h_paste).mono
       (Set.preimage_mono (Set.singleton_subset_iff.mpr hβ_end_U))
   exact ⟨γ.cast rfl (by ext t; rfl), hγ⟩
 
@@ -635,7 +637,8 @@ public theorem exists_open_nhds_pathComponent_preimage
   obtain ⟨V_last', hV'_open, hV'_pathConn, hα_V', hV'_sub_V, hV'_sub_U⟩ :=
     exists_refined_terminal_vertex hU_open α hα part T hα_tube
   obtain ⟨V', hV'_open_all, hV'_pathConn_all, hV'_sub_TV, hV'_last_eq, hα_passes_V'⟩ :=
-    exists_refined_vertex_family hα_tube hV'_open hV'_pathConn hα_V' hV'_sub_V
+    exists_refined_vertex_family hα_tube.passes_through_V hV'_open hV'_pathConn hα_V'
+      hV'_sub_V
   have hV'_last_sub_U : V' (Fin.last (n' + 1)) ⊆ U := hV'_last_eq ▸ hV'_sub_U
   -- The neighborhood `N` of `α`: based paths satisfying the refined tube conditions.
   set N : Set (BasedPath x₀) := {β : BasedPath x₀ |
@@ -651,7 +654,7 @@ public theorem exists_open_nhds_pathComponent_preimage
       hV'_last_sub_U (by simpa [part.t_last] using! hβ.2 (Fin.last (n' + 1)))
   · -- Every `β ∈ N` is `JoinedIn (endpoint ⁻¹' U)` to `α`.
     exact fun β hβ ↦ joinedIn_endpoint_preimage_of_pathInTube hV'_open_all hV'_pathConn_all
-      hV'_sub_TV hV'_last_sub_U hα_tube hα_passes_V' hβ.1 hβ.2
+      hV'_sub_TV hV'_last_sub_U hα_tube.stays_in_U hα_passes_V' hβ.1 hβ.2
 
 
 /-- For an open neighborhood `U`, path components of `endpoint ⁻¹' U` are open. -/

--- a/TauCeti/AlgebraicTopology/UniversalCover/BasedPath.lean
+++ b/TauCeti/AlgebraicTopology/UniversalCover/BasedPath.lean
@@ -544,9 +544,10 @@ theorem isOpen_refined_tubeNeighborhood
     exact isOpen_iInter_of_finite fun j ↦
       (hV_open j).preimage ((continuous_eval_const (part.t j)).comp continuous_subtype_val)
 
-/-- **Refining the terminal vertex set of a tube.** Replacing the last vertex set of `T` by a
-smaller one again gives a family that is open, path-connected, contained in `T.V` pointwise, and
-through which `α` still passes at every partition point. -/
+/-- **Refining the terminal vertex set of a tube.** If the last vertex set of `T` is replaced by a
+smaller `V_last'` that is itself open, path-connected and contains `endpoint α`, the resulting
+family is again open and path-connected, is contained in `T.V` pointwise, and `α` still passes
+through it at every partition point. -/
 private theorem exists_refined_vertex_family {n' : ℕ} {part : IntervalPartition (n' + 1)}
     {T : TubeData X (n' + 1)} {α : BasedPath x₀}
     (hα_passes : ∀ j, α.toPath (part.t j) ∈ T.V j)
@@ -577,8 +578,8 @@ private theorem exists_refined_vertex_family {n' : ℕ} {part : IntervalPartitio
       | cast k => rw [Fin.snoc_castSucc]; exact hα_passes _
 
 /-- **A path through the refined tube is joined to `α`.** If `β` runs through the same tube as `α`
-with refined vertex sets `V'` whose terminal member lies in `U`, then `β` is joined to `α` inside
-`endpoint ⁻¹' U`. -/
+with refined vertex sets `V'` whose terminal member is contained in `U`, then `β` is joined to `α`
+inside `endpoint ⁻¹' U`. -/
 private theorem joinedIn_endpoint_preimage_of_pathInTube {n' : ℕ} {U : Set X}
     {V' : Fin (n' + 2) → Set X} {part : IntervalPartition (n' + 1)}
     {T : TubeData X (n' + 1)} (hV'_open : ∀ j, IsOpen (V' j))

--- a/TauCeti/AlgebraicTopology/UniversalCover/BasedPath.lean
+++ b/TauCeti/AlgebraicTopology/UniversalCover/BasedPath.lean
@@ -544,6 +544,74 @@ theorem isOpen_refined_tubeNeighborhood
     exact isOpen_iInter_of_finite fun j ↦
       (hV_open j).preimage ((continuous_eval_const (part.t j)).comp continuous_subtype_val)
 
+/-- **Refining the terminal vertex set of a tube.** Replacing the last vertex set of `T` by a
+smaller one again gives a family that is open, path-connected, contained in `T.V` pointwise, and
+through which `α` still passes at every partition point. -/
+private theorem exists_refined_vertex_family {n' : ℕ} {part : IntervalPartition (n' + 1)}
+    {T : TubeData X (n' + 1)} {α : BasedPath x₀} (hα_tube : PathInTube α.toPath part T)
+    {V_last' : Set X} (hV'_open : IsOpen V_last') (hV'_pathConn : IsPathConnected V_last')
+    (hα_V' : endpoint α ∈ V_last') (hV'_sub_V : V_last' ⊆ T.V (Fin.last (n' + 1))) :
+    ∃ V' : Fin (n' + 2) → Set X,
+      (∀ j, IsOpen (V' j)) ∧ (∀ j, IsPathConnected (V' j)) ∧ (∀ j, V' j ⊆ T.V j) ∧
+        V' (Fin.last (n' + 1)) = V_last' ∧ ∀ j, α.toPath (part.t j) ∈ V' j := by
+  have hα_at_last : α.toPath (part.t (Fin.last (n' + 1))) = endpoint α := by
+    rw [part.t_last]; exact α.toPath.target
+  refine ⟨Fin.snoc (fun j : Fin (n' + 1) ↦ T.V j.castSucc) V_last', ?_, ?_, ?_,
+    Fin.snoc_last .., ?_⟩
+  · exact fun j ↦ by
+      induction j using Fin.lastCases with
+      | last => rw [Fin.snoc_last]; exact hV'_open
+      | cast k => rw [Fin.snoc_castSucc]; exact T.V_open _
+  · exact fun j ↦ by
+      induction j using Fin.lastCases with
+      | last => rw [Fin.snoc_last]; exact hV'_pathConn
+      | cast k => rw [Fin.snoc_castSucc]; exact T.V_pathConn _
+  · exact fun j ↦ by
+      induction j using Fin.lastCases with
+      | last => rw [Fin.snoc_last]; exact hV'_sub_V
+      | cast k => rw [Fin.snoc_castSucc]
+  · exact fun j ↦ by
+      induction j using Fin.lastCases with
+      | last => rw [Fin.snoc_last, hα_at_last]; exact hα_V'
+      | cast k => rw [Fin.snoc_castSucc]; exact hα_tube.passes_through_V _
+
+/-- **A path through the refined tube is joined to `α`.** If `β` runs through the same tube as `α`
+with refined vertex sets `V'` whose terminal member lies in `U`, then `β` is joined to `α` inside
+`endpoint ⁻¹' U`. -/
+private theorem joinedIn_endpoint_preimage_of_pathInTube [LocallyPathConnectedSpace X] {n' : ℕ}
+    {U : Set X} {V' : Fin (n' + 2) → Set X} {part : IntervalPartition (n' + 1)}
+    {T : TubeData X (n' + 1)} (hV'_open : ∀ j, IsOpen (V' j))
+    (hV'_pathConn : ∀ j, IsPathConnected (V' j)) (hV'_sub_TV : ∀ j, V' j ⊆ T.V j)
+    (hV'_last_sub_U : V' (Fin.last (n' + 1)) ⊆ U) {α β : BasedPath x₀}
+    (hα_tube : PathInTube α.toPath part T) (hα_passes : ∀ j, α.toPath (part.t j) ∈ V' j)
+    (hβ_stays : ∀ (i : Fin (n' + 1)) (s : I),
+      (part.t i.castSucc : ℝ) ≤ s ∧ s ≤ (part.t i.succ : ℝ) → β.1 s ∈ T.U i)
+    (hβ_passes : ∀ j, β.1 (part.t j) ∈ V' j) :
+    JoinedIn (endpoint (x₀ := x₀) ⁻¹' U) α β := by
+  let T' : TubeData X (n' + 1) := {
+    U := T.U
+    V := V'
+    U_open := T.U_open
+    U_slsc := T.U_slsc
+    V_open := hV'_open
+    V_pathConn := hV'_pathConn
+    V_left_subset := fun i ↦ (hV'_sub_TV i.castSucc).trans (T.V_left_subset i)
+    V_right_subset := fun i ↦ (hV'_sub_TV i.succ).trans (T.V_right_subset i)
+  }
+  have hβ_end_U : endpoint β ∈ U :=
+    hV'_last_sub_U (by simpa [part.t_last] using! hβ_passes (Fin.last (n' + 1)))
+  obtain ⟨ρ_final, hρ_final_range_V, h_paste⟩ :=
+    Path.tube_subset_homotopy_class_source α.toPath part T' ⟨hα_tube.stays_in_U, hα_passes⟩
+      β.toPath ⟨hβ_stays, hβ_passes⟩
+  refine (joinedIn_preimage_of_append α ρ_final
+    (hρ_final_range_V.trans hV'_last_sub_U)).trans ?_
+  obtain ⟨γ, hγ⟩ :=
+    (joinedIn_endpoint_preimage_of_homotopic (x₀ := x₀) (U := ({endpoint β} : Set X))
+      (show endpoint β ∈ ({endpoint β} : Set X) from rfl)
+      (show Path.Homotopic (α.toPath.trans ρ_final) β.toPath from h_paste)).mono
+      (Set.preimage_mono (Set.singleton_subset_iff.mpr hβ_end_U))
+  exact ⟨γ.cast rfl (by ext t; rfl), hγ⟩
+
 /-- Variable-endpoint tube/component theorem.
 
 In a locally path-connected space, if semilocal simple connectivity holds along `α.toPath` and
@@ -564,47 +632,11 @@ public theorem exists_open_nhds_pathComponent_preimage
   match n, part, T, hα_tube with
   | 0, part, _, _ => exact isEmptyElim part
   | n' + 1, part, T, hα_tube =>
-  -- Endpoint of α at the last partition point equals `endpoint α`.
-  have hα_at_last : α.toPath (part.t (Fin.last (n' + 1))) = endpoint α := by
-    rw [part.t_last]; exact α.toPath.target
   obtain ⟨V_last', hV'_open, hV'_pathConn, hα_V', hV'_sub_V, hV'_sub_U⟩ :=
     exists_refined_terminal_vertex hU_open α hα part T hα_tube
-  -- Refined V function: `V_last'` at the last partition point, `T.V` elsewhere.
-  set V' : Fin (n' + 2) → Set X :=
-    Fin.snoc (fun j : Fin (n' + 1) ↦ T.V j.castSucc) V_last' with hV'_def
-  have hV'_last_eq : V' (Fin.last (n' + 1)) = V_last' := Fin.snoc_last ..
-  have hV'_castSucc_eq : ∀ j : Fin (n' + 1), V' j.castSucc = T.V j.castSucc := fun j ↦
-    Fin.snoc_castSucc ..
-  have hV'_sub_TV : ∀ j : Fin (n' + 2), V' j ⊆ T.V j := by
-    intro j
-    induction j using Fin.lastCases with
-    | last => rw [hV'_last_eq]; exact hV'_sub_V
-    | cast k => rw [hV'_castSucc_eq]
-  have hV'_open_all : ∀ j, IsOpen (V' j) := by
-    intro j
-    induction j using Fin.lastCases with
-    | last => rw [hV'_last_eq]; exact hV'_open
-    | cast k => rw [hV'_castSucc_eq]; exact T.V_open _
-  have hV'_pathConn_all : ∀ j, IsPathConnected (V' j) := by
-    intro j
-    induction j using Fin.lastCases with
-    | last => rw [hV'_last_eq]; exact hV'_pathConn
-    | cast k => rw [hV'_castSucc_eq]; exact T.V_pathConn _
-  have hα_passes_V' : ∀ j, α.toPath (part.t j) ∈ V' j := by
-    intro j
-    induction j using Fin.lastCases with
-    | last => rw [hV'_last_eq, hα_at_last]; exact hα_V'
-    | cast k => rw [hV'_castSucc_eq]; exact hα_tube.passes_through_V _
-  let T' : TubeData X (n' + 1) := {
-    U := T.U
-    V := V'
-    U_open := T.U_open
-    U_slsc := T.U_slsc
-    V_open := hV'_open_all
-    V_pathConn := hV'_pathConn_all
-    V_left_subset := fun i ↦ (hV'_sub_TV i.castSucc).trans (T.V_left_subset i)
-    V_right_subset := fun i ↦ (hV'_sub_TV i.succ).trans (T.V_right_subset i)
-  }
+  obtain ⟨V', hV'_open_all, hV'_pathConn_all, hV'_sub_TV, hV'_last_eq, hα_passes_V'⟩ :=
+    exists_refined_vertex_family hα_tube hV'_open hV'_pathConn hα_V' hV'_sub_V
+  have hV'_last_sub_U : V' (Fin.last (n' + 1)) ⊆ U := hV'_last_eq ▸ hV'_sub_U
   -- The neighborhood `N` of `α`: based paths satisfying the refined tube conditions.
   set N : Set (BasedPath x₀) := {β : BasedPath x₀ |
       (∀ (i : Fin (n' + 1)) (s : I),
@@ -615,38 +647,12 @@ public theorem exists_open_nhds_pathComponent_preimage
   · -- `α ∈ N`.
     exact ⟨hα_tube.stays_in_U, hα_passes_V'⟩
   · -- `N ⊆ endpoint ⁻¹' U`.
-    intro β hβ
-    have h1 : β.1 (part.t (Fin.last (n' + 1))) ∈ V' (Fin.last (n' + 1)) := hβ.2 _
-    rw [hV'_last_eq] at h1
-    exact hV'_sub_U (by simpa [part.t_last] using! h1)
+    exact fun β hβ ↦
+      hV'_last_sub_U (by simpa [part.t_last] using! hβ.2 (Fin.last (n' + 1)))
   · -- Every `β ∈ N` is `JoinedIn (endpoint ⁻¹' U)` to `α`.
-    intro β hβ
-    obtain ⟨hβ_stays, hβ_passes⟩ := hβ
-    -- Endpoint of `β` lies in `U`.
-    have hβ_end_U : endpoint β ∈ U := by
-      have h1 : β.1 (part.t (Fin.last (n' + 1))) ∈ V' (Fin.last (n' + 1)) := hβ_passes _
-      rw [hV'_last_eq] at h1
-      exact hV'_sub_U (by simpa [part.t_last] using! h1)
-    have hβ_tube : PathInTube β.toPath part T' :=
-      ⟨hβ_stays, hβ_passes⟩
-    have hα_tube' : PathInTube α.toPath part T' :=
-      ⟨hα_tube.stays_in_U, hα_passes_V'⟩
-    obtain ⟨ρ_final, hρ_final_range_V, h_paste⟩ :=
-      Path.tube_subset_homotopy_class_source α.toPath part T' hα_tube' β.toPath hβ_tube
-    have hρ_final_range : Set.range ρ_final ⊆ U :=
-      hρ_final_range_V.trans (by
-        -- `T'.V` is defeq to the local family `V'`; expose it so `hV'_last_eq` rewrites.
-        change V' (Fin.last (n' + 1)) ⊆ U
-        rw [hV'_last_eq]
-        exact hV'_sub_U)
-    -- Join `α` to `append α ρ_final`, then deform `append α ρ_final` to `β` via `h_paste`.
-    refine (joinedIn_preimage_of_append α ρ_final hρ_final_range).trans ?_
-    obtain ⟨γ, hγ⟩ :=
-      (joinedIn_endpoint_preimage_of_homotopic (x₀ := x₀) (U := ({endpoint β} : Set X))
-        (show endpoint β ∈ ({endpoint β} : Set X) from rfl)
-        (show Path.Homotopic (α.toPath.trans ρ_final) β.toPath from h_paste)).mono
-        (Set.preimage_mono (Set.singleton_subset_iff.mpr hβ_end_U))
-    exact ⟨γ.cast rfl (by ext t; rfl), hγ⟩
+    exact fun β hβ ↦ joinedIn_endpoint_preimage_of_pathInTube hV'_open_all hV'_pathConn_all
+      hV'_sub_TV hV'_last_sub_U hα_tube hα_passes_V' hβ.1 hβ.2
+
 
 /-- For an open neighborhood `U`, path components of `endpoint ⁻¹' U` are open. -/
 public theorem isOpen_pathComponent_preimage


### PR DESCRIPTION
`exists_open_nhds_pathComponent_preimage` ran 91 lines, interleaving three separate jobs: refining
the tube's terminal vertex set, assembling the neighbourhood `N`, and showing every member of `N`
is joined to `α`.

## Extracted

* `exists_refined_vertex_family` — replacing the last vertex set of a tube `T` by a smaller one
  again gives a family that is open, path-connected, contained in `T.V` pointwise, and through
  which `α` still passes at every partition point.
* `joinedIn_endpoint_preimage_of_pathInTube` — if `β` runs through the same tube as `α` with
  refined vertex sets `V'` whose terminal member lies in `U`, then `β` is joined to `α` inside
  `endpoint ⁻¹' U`.

The first returns the family existentially rather than exposing the `Fin.snoc` that builds it, so
the four `Fin.lastCases` property proofs — which were four near-identical five-line blocks in the
caller — live in one place and the caller never mentions `Fin.snoc` at all.

The second absorbs the `TubeData` record that was being assembled inline purely to feed
`Path.tube_subset_homotopy_class_source`. Taking `V'` abstractly rather than as a `set` local also
removes the `change`/`rw` step the old proof needed to see past the local definition when matching
`T'.V (Fin.last _)` against `U`.

Both take only what they use, and that is finer than the bundled `PathInTube`: the first needs
only its `passes_through_V` field, the second only `stays_in_U`, so each takes that field rather
than the structure. Neither sees `hU_open`, `N`, or the semilocal-simple-connectivity hypothesis;
the second needs no `[LocallyPathConnectedSpace X]` either, and does not need `V'` to be a
refinement of anything in particular — only that its terminal member sits inside `U`.

The `V' (Fin.last _) ⊆ U` fact is now named once in the caller and serves both the
`N ⊆ endpoint ⁻¹' U` goal and the join argument, replacing two copies of the same four-line
derivation.

## Sizes

| | proof body |
|---|---|
| `exists_open_nhds_pathComponent_preimage` | 91 → **30** |
| `exists_refined_vertex_family` | **21** |
| `joinedIn_endpoint_preimage_of_pathInTube` | **23** |

All under the repository's 50-line proof policy.

## Scope

Refactoring only — no statement changes, no new mathematics, nothing added to the public API (both
helpers are `private`). Note `toPath_homotopic_of_joinedIn_pathHomotopyTrivial` in the same file
also has a long body (87 lines); it is left for a separate PR, one target per PR.

## Gates

`lake build` · `lake exe axioms` · `lake exe module-system` · `scripts/lint-env.sh` — all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
