### PR TITLE
feat: add residue-degree composition

### DIFF
--- a/TauCeti/AlgebraicGeometry/ResidueDegree.lean
+++ b/TauCeti/AlgebraicGeometry/ResidueDegree.lean
@@ -1,0 +1,92 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+module
+
+public import Mathlib.AlgebraicGeometry.ResidueField
+public import Mathlib.LinearAlgebra.Dimension.FreeAndStrongRankCondition
+
+/-!
+# Residue degrees of scheme morphisms
+
+This file develops the elementary functorial API for Mathlib's
+`AlgebraicGeometry.Scheme.Hom.residueDegree`. For a scheme morphism `f : X ⟶ Y` and a point
+`x : X`, this is the degree `[κ(x) : κ(f(x))]`, with value zero when the field extension is
+infinite.
+
+The main result is the tower law `residueDegree_comp`. It identifies the residue degree of a
+composite with the product of the two successive residue degrees. We also characterize when a
+residue degree is positive and when it is one. These facts supply the residue-field weights used
+in the degree and pushforward parts of Layer A of the Jacobian challenge roadmap.
+
+The construction follows the residue-degree convention for pushforward of cycles in the
+[Stacks Project, Tag 02R4](https://stacks.math.columbia.edu/tag/02R4). The proofs reuse
+Mathlib's residue-field maps and the field-extension tower law `Module.finrank_mul_finrank`.
+-/
+
+public section
+
+open CategoryTheory AlgebraicGeometry
+
+namespace TauCeti
+
+namespace AlgebraicGeometry
+
+universe u
+
+variable {X Y Z : Scheme.{u}}
+
+/-- The residue degree of a composite is the product of the successive residue degrees:
+`[κ(x) : κ(g(f(x)))] = [κ(f(x)) : κ(g(f(x)))] [κ(x) : κ(f(x))]`. -/
+theorem residueDegree_comp (f : X ⟶ Y) (g : Y ⟶ Z) (x : X) :
+    (f ≫ g).residueDegree x = g.residueDegree (f x) * f.residueDegree x := by
+  letI : Algebra (Z.residueField (g (f x))) (Y.residueField (f x)) :=
+    (g.residueFieldMap (f x)).hom.toAlgebra
+  letI : Algebra (Y.residueField (f x)) (X.residueField x) :=
+    (f.residueFieldMap x).hom.toAlgebra
+  letI : Algebra (Z.residueField (g (f x))) (X.residueField x) :=
+    ((f ≫ g).residueFieldMap x).hom.toAlgebra
+  letI : IsScalarTower (Z.residueField (g (f x))) (Y.residueField (f x))
+      (X.residueField x) :=
+    IsScalarTower.of_algebraMap_eq' <| by
+      rw [RingHom.algebraMap_toAlgebra]
+      exact congrArg CommRingCat.Hom.hom (Scheme.residueFieldMap_comp f g x)
+  exact (Module.finrank_mul_finrank (Z.residueField (g (f x)))
+    (Y.residueField (f x)) (X.residueField x)).symm
+
+/-- A residue degree is positive exactly when the associated residue-field extension is finite. -/
+theorem residueDegree_pos_iff (f : X ⟶ Y) (x : X) :
+    0 < f.residueDegree x ↔
+      (f.residueFieldMap x).hom.Finite := by
+  letI : Algebra (Y.residueField (f x)) (X.residueField x) :=
+    (f.residueFieldMap x).hom.toAlgebra
+  rw [Scheme.Hom.residueDegree, RingHom.Finite]
+  constructor
+  · exact Module.finite_of_finrank_pos
+  · intro h
+    letI : Module.Finite (Y.residueField (f x)) (X.residueField x) := h
+    exact Module.finrank_pos
+
+/-- A residue degree is nonzero exactly when the associated residue-field extension is finite. -/
+theorem residueDegree_ne_zero_iff (f : X ⟶ Y) (x : X) :
+    f.residueDegree x ≠ 0 ↔
+      (f.residueFieldMap x).hom.Finite := by
+  rw [← residueDegree_pos_iff f x, Nat.pos_iff_ne_zero]
+
+/-- A residue-field map is bijective exactly when its residue degree is one. -/
+theorem residueDegree_eq_one_iff (f : X ⟶ Y) (x : X) :
+    f.residueDegree x = 1 ↔ Function.Bijective (f.residueFieldMap x) := by
+  letI : Algebra (Y.residueField (f x)) (X.residueField x) :=
+    (f.residueFieldMap x).hom.toAlgebra
+  rw [Scheme.Hom.residueDegree, Algebra.finrank_eq_one_iff_bijective_algebraMap,
+    RingHom.algebraMap_toAlgebra]
+
+/-- An isomorphism of schemes has residue degree one at every point. -/
+theorem residueDegree_eq_one_of_isIso (f : X ⟶ Y) [IsIso f] (x : X) :
+    f.residueDegree x = 1 :=
+  (residueDegree_eq_one_iff f x).mpr (ConcreteCategory.bijective_of_isIso _)
+
+end AlgebraicGeometry
+
+end TauCeti

--- a/TauCeti/AlgebraicGeometry/ResidueDegree.lean
+++ b/TauCeti/AlgebraicGeometry/ResidueDegree.lean
@@ -39,6 +39,7 @@ variable {X Y Z : Scheme.{u}}
 
 /-- The residue degree of a composite is the product of the successive residue degrees:
 `[κ(x) : κ(g(f(x)))] = [κ(f(x)) : κ(g(f(x)))] [κ(x) : κ(f(x))]`. -/
+@[simp]
 theorem residueDegree_comp (f : X ⟶ Y) (g : Y ⟶ Z) (x : X) :
     (f ≫ g).residueDegree x = g.residueDegree (f x) * f.residueDegree x := by
   letI : Algebra (Z.residueField (g (f x))) (Y.residueField (f x)) :=
@@ -52,6 +53,7 @@ theorem residueDegree_comp (f : X ⟶ Y) (g : Y ⟶ Z) (x : X) :
     IsScalarTower.of_algebraMap_eq' <| by
       rw [RingHom.algebraMap_toAlgebra]
       exact congrArg CommRingCat.Hom.hom (Scheme.residueFieldMap_comp f g x)
+  rw [Scheme.Hom.residueDegree]
   exact (Module.finrank_mul_finrank (Z.residueField (g (f x)))
     (Y.residueField (f x)) (X.residueField x)).symm
 
@@ -83,6 +85,7 @@ theorem residueDegree_eq_one_iff (f : X ⟶ Y) (x : X) :
     RingHom.algebraMap_toAlgebra]
 
 /-- An isomorphism of schemes has residue degree one at every point. -/
+@[simp]
 theorem residueDegree_eq_one_of_isIso (f : X ⟶ Y) [IsIso f] (x : X) :
     f.residueDegree x = 1 :=
   (residueDegree_eq_one_iff f x).mpr (ConcreteCategory.bijective_of_isIso _)

--- a/TauCeti/AlgebraicGeometry/WeilDivisor/Scheme/Degree.lean
+++ b/TauCeti/AlgebraicGeometry/WeilDivisor/Scheme/Degree.lean
@@ -1,0 +1,68 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+module
+
+public import TauCeti.AlgebraicGeometry.ResidueDegree
+public import TauCeti.AlgebraicGeometry.WeilDivisor.Scheme.Basic
+
+/-!
+# Relative degrees of scheme-theoretic Weil divisors
+
+This file specializes `WeilDivisor.weightedDegree` to the residue-degree weights associated to a
+scheme morphism. For a curve over a field, applied to its structure morphism, this is the divisor
+degree `Σ_x [κ(x) : k] · ord_x`.
+
+The composition formula records how these weights change through successive scheme morphisms.
+This supplies the residue-field-weighted divisor degree required in Layer A of the Jacobian
+challenge roadmap.
+-/
+
+public section
+
+open CategoryTheory AlgebraicGeometry
+
+namespace TauCeti
+
+namespace AlgebraicGeometry
+
+universe u
+
+namespace SchemeWeilDivisor
+
+variable {X Y Z : Scheme.{u}}
+
+noncomputable section
+
+/-- The degree of a scheme-theoretic Weil divisor weighted by the residue degrees of `f`. -/
+def relativeDegree (f : X ⟶ Y) : SchemeWeilDivisor X →+ ℤ :=
+  WeilDivisor.weightedDegree fun x : CodimensionOnePoint X ↦ (f.residueDegree x : ℤ)
+
+/-- The relative degree is the finite sum of coefficients times residue degrees. -/
+lemma relativeDegree_apply (f : X ⟶ Y) (D : SchemeWeilDivisor X) :
+    relativeDegree f D = D.sum fun x n ↦ n * (f.residueDegree x : ℤ) := by
+  rw [relativeDegree, WeilDivisor.weightedDegree_apply]
+
+/-- A prime divisor has relative degree equal to the residue degree of its generic point. -/
+@[simp]
+lemma relativeDegree_ofPoint (f : X ⟶ Y) (x : CodimensionOnePoint X) :
+    relativeDegree f (WeilDivisor.ofPoint x) = (f.residueDegree x : ℤ) := by
+  simp [relativeDegree]
+
+/-- Relative degree along a composite uses the product of the successive residue degrees. -/
+@[simp]
+lemma relativeDegree_comp (f : X ⟶ Y) (g : Y ⟶ Z) (D : SchemeWeilDivisor X) :
+    relativeDegree (f ≫ g) D =
+      WeilDivisor.weightedDegree
+        (fun x : CodimensionOnePoint X ↦
+          (g.residueDegree (f x) : ℤ) * f.residueDegree x) D := by
+  simp only [relativeDegree, residueDegree_comp, Nat.cast_mul]
+
+end
+
+end SchemeWeilDivisor
+
+end AlgebraicGeometry
+
+end TauCeti


### PR DESCRIPTION
This PR adds the composition law for Mathlib’s scheme-theoretic residue degree and the characteristic API needed to use it: positivity and nonvanishing are equivalent to finiteness of the residue-field extension, degree one is equivalent to bijectivity of the residue-field map, and scheme isomorphisms have residue degree one.

It advances `TauCetiRoadmap/JacobianChallenge/README.md`, Layer A, the specific “Degree” item defining divisor degree with the residue-field weights `[κ(x) : k]`. The tower law makes those weights compatible with successive scheme morphisms, a prerequisite for geometric divisor and cycle pushforward. This is the lowest-hanging distinct target because Mathlib already defines `Scheme.Hom.residueDegree` and its identity law, but not composition; the two open JacobianChallenge PRs cover the separate invertible-sheaf and scheme-theoretic Weil-divisor types, while later Layer A comparisons depend on those open constructions.

Add `TauCeti/AlgebraicGeometry/ResidueDegree.lean` (92 lines). Reuse Mathlib’s `Scheme.Hom.residueFieldMap_comp`, `Module.finrank_mul_finrank`, `RingHom.Finite`, and `Algebra.finrank_eq_one_iff_bijective_algebraMap`. Vendor no Mathlib infrastructure and copy or adapt no external formalization. Follow the residue-degree convention for cycle pushforward in the Stacks Project, Tag 02R4, as already cited by Mathlib’s algebraic-cycle implementation.

`lake build` reports `Build completed successfully (5613 jobs).` `lake exe axioms` reports `axioms: audited 12982 TauCeti declaration(s); all within the allowlist [propext, Classical.choice, Quot.sound].`

<!--tauceti-target:v1 {"focus":"JacobianChallenge","id":"residue-degree-composition"}-->

🤖 Prepared with Codex
