### PR TITLE
chore(ElementaryTwoQuotient): remove an unreferenced private lemma

### DIFF
--- a/TauCeti/Algebra/Group/ElementaryTwoQuotient/Prod.lean
+++ b/TauCeti/Algebra/Group/ElementaryTwoQuotient/Prod.lean
@@ -66,11 +66,6 @@ private noncomputable def bridgeModRangeNSMul (G : Type*) [CommGroup G] :
     ElementaryTwoQuotient G ≃+ Additive G ⧸ (nsmulAddMonoidHom (α := Additive G) 2).range :=
   QuotientAddGroup.quotientAddEquivOfEq (range_lsmul_two_toAddSubgroup_eq_range_nsmul G)
 
-/-- The bridge sends the class of `g` to the coset of `Additive.ofMul g`. -/
-private theorem bridgeModRangeNSMul_mk (G : Type*) [CommGroup G] (g : G) :
-    bridgeModRangeNSMul G (elementaryTwoQuotientMk g) = QuotientAddGroup.mk (Additive.ofMul g) := by
-  rw [elementaryTwoQuotientMk_eq_mkQ]; rfl
-
 section Prod
 
 variable (G H : Type*) [CommGroup G] [CommGroup H]


### PR DESCRIPTION
`bridgeModRangeNSMul_mk` has no callers. It is `private`, so nothing outside
`ElementaryTwoQuotient/Prod.lean` can reach it either, and the only mention of the name in the
repository is its own declaration.

The definition it characterises, `bridgeModRangeNSMul`, is alive — used three times, at lines 99,
159 and 161 — so only the characterisation lemma goes.

## How it was found

A sweep for `private` declarations whose name appears nowhere but their own declaration line. Two
things that sweep has to get right, both learned the hard way:

* dot-notation uses (`S.foo`) must count, or almost every private lemma in the semigroup files
  looks dead;
* attribute-tagged declarations (`@[simp]` and friends) must be excluded, since they are used by
  tactics rather than by name.

With both corrections the repository has exactly one unreferenced private declaration, this one.

## Scope

Deletion only — no statement changes, no new mathematics, no public API affected.

## Gates

`lake build` · `lake exe axioms` · `lake exe module-system` · `scripts/lint-env.sh` — all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
