### PR TITLE
chore: add the licence header to six files that lacked it

### DIFF
--- a/TauCeti/Combinatorics/Enumerative/Partition/Dominance.lean
+++ b/TauCeti/Combinatorics/Enumerative/Partition/Dominance.lean
@@ -1,3 +1,7 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
 module
 
 public import Mathlib.Combinatorics.Enumerative.Partition.Basic

--- a/TauCeti/LinearAlgebra/TotallyReal/Basic.lean
+++ b/TauCeti/LinearAlgebra/TotallyReal/Basic.lean
@@ -1,3 +1,7 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
 module
 
 public import Mathlib.LinearAlgebra.Prod

--- a/TauCeti/RepresentationTheory/CharacterTable/ClassFunction.lean
+++ b/TauCeti/RepresentationTheory/CharacterTable/ClassFunction.lean
@@ -1,3 +1,7 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
 module
 
 public import Mathlib.Algebra.Group.ConjFinite

--- a/TauCeti/RepresentationTheory/CharacterTable/ClassSum/Basic.lean
+++ b/TauCeti/RepresentationTheory/CharacterTable/ClassSum/Basic.lean
@@ -1,3 +1,7 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
 module
 
 public import Mathlib.Algebra.Group.ConjFinite

--- a/TauCeti/RepresentationTheory/Induction/Transitivity.lean
+++ b/TauCeti/RepresentationTheory/Induction/Transitivity.lean
@@ -1,3 +1,7 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
 module
 
 public import Mathlib.CategoryTheory.Adjunction.CompositionIso

--- a/TauCeti/RepresentationTheory/Quiver/EulerForm.lean
+++ b/TauCeti/RepresentationTheory/Quiver/EulerForm.lean
@@ -1,3 +1,7 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
 module
 
 public import Mathlib.Combinatorics.Quiver.Basic


### PR DESCRIPTION
Six files were missing the licence header that the other 734 carry. They now have it, and no file
in `TauCeti/` lacks one.

| file |
|---|
| `RepresentationTheory/CharacterTable/ClassFunction.lean` |
| `RepresentationTheory/CharacterTable/ClassSum/Basic.lean` |
| `RepresentationTheory/Quiver/EulerForm.lean` |
| `RepresentationTheory/Induction/Transitivity.lean` |
| `Combinatorics/Enumerative/Partition/Dominance.lean` |
| `LinearAlgebra/TotallyReal/Basic.lean` |

## Which form

The three-line header, without an `Authors:` line:

```
/-
Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
Released under Apache 2.0 license as described in the file LICENSE.
-/
```

That is what the repository actually uses: 734 files carry a header and only 8 of them name authors,
so the `Authors:` variant is the exception rather than the template.

## Not included

Four files have no `/-!` module docstring — `Analysis/Complex/Conformal/Reflection/Circle.lean`,
`AlgebraicTopology/SimplicialComplex/Collapse.lean`, `LinearAlgebra/TotallyReal.lean`,
`Geometry/Symplectic/JHolomorphic/Prod/Map.lean`. All four are umbrella or compatibility modules:
a handful of `public import` lines, no declarations, and a one-line `--` comment saying what they
re-export. That is the established shape for those in this repository, so they are left alone
rather than given a docstring they do not need.

## Scope

Comments only — no Lean code is touched, no declaration changes, no imports moved.

## Gates

`lake build` · `lake exe axioms` · `lake exe module-system` · `scripts/lint-env.sh` — all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
