### PR TITLE
feat: prove winding vanishes on the unbounded component

### DIFF
--- a/TauCeti/Analysis/Contour/Winding/LocallyConstant.lean
+++ b/TauCeti/Analysis/Contour/Winding/LocallyConstant.lean
@@ -121,9 +121,12 @@ theorem windingNumber_eq_of_mem_connectedComponentIn {γ : ℝ → ℂ} {a b : �
     (hclosed : γ a = γ b) (hP : P.Countable) (hγ_cont : ContinuousOn γ (uIcc a b))
     (hγ_diff : ∀ t ∈ Ioo (min a b) (max a b) \ P, DifferentiableAt ℝ γ t)
     (hderiv_int : IntervalIntegrable (fun t ↦ deriv γ t) volume a b)
-    {w₀ w₁ : ℂ} (hw₀ : w₀ ∈ (γ '' uIcc a b)ᶜ)
-    (hw₁ : w₁ ∈ connectedComponentIn ((γ '' uIcc a b)ᶜ) w₀) :
+    {w₀ w₁ : ℂ} (hw₁ : w₁ ∈ connectedComponentIn ((γ '' uIcc a b)ᶜ) w₀) :
     windingNumber γ a b w₁ = windingNumber γ a b w₀ := by
+  have hw₀ : w₀ ∈ (γ '' uIcc a b)ᶜ := by
+    by_contra hw₀
+    rw [connectedComponentIn_eq_empty hw₀] at hw₁
+    exact hw₁
   rw [← setOf_forall_ne_eq_compl_image] at hw₀ hw₁
   rw [connectedComponentIn_eq_image hw₀] at hw₁
   obtain ⟨w₁, hw₁, rfl⟩ := hw₁
@@ -136,12 +139,11 @@ theorem windingNumber_eq_of_mem_connectedComponentIn {γ : ℝ → ℂ} {a b : �
 points in the same connected component of the curve complement have the same winding number. -/
 theorem IsPiecewiseC1On.windingNumber_eq_of_mem_connectedComponentIn
     {γ : ℝ → ℂ} {a b : ℝ} (hγ : IsPiecewiseC1On γ a b) (hclosed : γ a = γ b)
-    {w₀ w₁ : ℂ} (hw₀ : w₀ ∈ (γ '' uIcc a b)ᶜ)
-    (hw₁ : w₁ ∈ connectedComponentIn ((γ '' uIcc a b)ᶜ) w₀) :
+    {w₀ w₁ : ℂ} (hw₁ : w₁ ∈ connectedComponentIn ((γ '' uIcc a b)ᶜ) w₀) :
     windingNumber γ a b w₁ = windingNumber γ a b w₀ := by
   obtain ⟨P, hP, hγ_diff⟩ := hγ.exists_countable_differentiableAt
   exact TauCeti.Contour.windingNumber_eq_of_mem_connectedComponentIn hclosed hP
-    hγ.continuousOn hγ_diff hγ.intervalIntegrable_deriv hw₀ hw₁
+    hγ.continuousOn hγ_diff hγ.intervalIntegrable_deriv hw₁
 
 /-- **The winding number vanishes on a ball around an off-curve null point.** For a closed curve
 `γ` (differentiable off a countable set, continuous on `uIcc a b`, with interval-integrable

--- a/TauCeti/Analysis/Contour/Winding/LocallyConstant.lean
+++ b/TauCeti/Analysis/Contour/Winding/LocallyConstant.lean
@@ -7,6 +7,7 @@ module
 
 public import TauCeti.Analysis.Contour.Winding.Number.Basic
 public import Mathlib.Topology.LocallyConstant.Basic
+public import TauCeti.Analysis.Contour.PiecewiseC1On
 import TauCeti.Analysis.Contour.Curve.Distance
 import TauCeti.Analysis.Contour.Winding.Continuity
 import TauCeti.Analysis.Contour.Winding.Integer
@@ -19,6 +20,7 @@ countable set, with interval-integrable derivative, the generalized winding numb
 `fun w ↦ windingNumber γ a b w`, viewed as a function on the points off the curve, is locally
 constant (`isLocallyConstant_windingNumber_of_closed`). It is the ingredient Dixon's argument uses
 for the homology form of Cauchy's theorem (roadmap `homologyCauchyTheorem`). As a corollary,
+the winding number is constant on every connected component of the curve complement. Also,
 `exists_ball_windingNumber_zero` packages the local matching data Dixon needs: around an off-curve
 point where the winding number vanishes, it vanishes on a whole ball that stays off the curve.
 
@@ -26,6 +28,10 @@ point where the winding number vanishes, it vanishes on a whole ball that stays 
 
 * `TauCeti.Contour.isLocallyConstant_windingNumber_of_closed` — the winding number is locally
   constant on the complement of a closed curve.
+* `TauCeti.Contour.windingNumber_eq_of_mem_connectedComponentIn` — the winding number is constant
+  on each connected component of the curve complement.
+* `TauCeti.Contour.IsPiecewiseC1On.windingNumber_eq_of_mem_connectedComponentIn` — the direct
+  piecewise-`C¹` form.
 * `TauCeti.Contour.exists_ball_windingNumber_zero` — around an off-curve point where the winding
   number vanishes, it vanishes on a whole ball that stays off the curve.
 
@@ -97,6 +103,45 @@ theorem isLocallyConstant_windingNumber_of_closed {γ : ℝ → ℂ} {a b : ℝ}
   have hval : Filter.Tendsto (Subtype.val : {w : ℂ // ∀ t ∈ uIcc a b, γ t ≠ w} → ℂ)
       (𝓝 ⟨w₀, hw₀⟩) (𝓝 w₀) := continuous_subtype_val.continuousAt
   exact hval.eventually hball
+
+/-- The points avoided by `γ` on `[[a, b]]` are exactly the complement of its image there. -/
+private theorem setOf_forall_ne_eq_compl_image {γ : ℝ → ℂ} {a b : ℝ} :
+    {w : ℂ | ∀ t ∈ uIcc a b, γ t ≠ w} = (γ '' uIcc a b)ᶜ := by
+  ext w
+  simp only [mem_setOf_eq, mem_compl_iff, mem_image, not_exists, not_and]
+
+/-- **The winding number is constant on a connected component of the curve complement.**
+For a closed curve that is continuous on `[[a, b]]`, differentiable away from a countable set,
+and has interval-integrable derivative, two points in the same connected component of
+`ℂ \ γ '' [[a, b]]` have the same winding number.
+
+This is the connected-component form of homotopy invariance in the point: it follows from local
+constancy of the integer-valued winding number off the curve. -/
+theorem windingNumber_eq_of_mem_connectedComponentIn {γ : ℝ → ℂ} {a b : ℝ} {P : Set ℝ}
+    (hclosed : γ a = γ b) (hP : P.Countable) (hγ_cont : ContinuousOn γ (uIcc a b))
+    (hγ_diff : ∀ t ∈ Ioo (min a b) (max a b) \ P, DifferentiableAt ℝ γ t)
+    (hderiv_int : IntervalIntegrable (fun t ↦ deriv γ t) volume a b)
+    {w₀ w₁ : ℂ} (hw₀ : w₀ ∈ (γ '' uIcc a b)ᶜ)
+    (hw₁ : w₁ ∈ connectedComponentIn ((γ '' uIcc a b)ᶜ) w₀) :
+    windingNumber γ a b w₁ = windingNumber γ a b w₀ := by
+  rw [← setOf_forall_ne_eq_compl_image] at hw₀ hw₁
+  rw [connectedComponentIn_eq_image hw₀] at hw₁
+  obtain ⟨w₁, hw₁, rfl⟩ := hw₁
+  exact
+    (isLocallyConstant_windingNumber_of_closed hclosed hP hγ_cont hγ_diff
+      hderiv_int).apply_eq_of_isPreconnected isPreconnected_connectedComponent hw₁
+        mem_connectedComponent
+
+/-- **Piecewise-`C¹` form of componentwise constancy.** For a closed piecewise-`C¹` curve, two
+points in the same connected component of the curve complement have the same winding number. -/
+theorem IsPiecewiseC1On.windingNumber_eq_of_mem_connectedComponentIn
+    {γ : ℝ → ℂ} {a b : ℝ} (hγ : IsPiecewiseC1On γ a b) (hclosed : γ a = γ b)
+    {w₀ w₁ : ℂ} (hw₀ : w₀ ∈ (γ '' uIcc a b)ᶜ)
+    (hw₁ : w₁ ∈ connectedComponentIn ((γ '' uIcc a b)ᶜ) w₀) :
+    windingNumber γ a b w₁ = windingNumber γ a b w₀ := by
+  obtain ⟨P, hP, hγ_diff⟩ := hγ.exists_countable_differentiableAt
+  exact TauCeti.Contour.windingNumber_eq_of_mem_connectedComponentIn hclosed hP
+    hγ.continuousOn hγ_diff hγ.intervalIntegrable_deriv hw₀ hw₁
 
 /-- **The winding number vanishes on a ball around an off-curve null point.** For a closed curve
 `γ` (differentiable off a countable set, continuous on `uIcc a b`, with interval-integrable

--- a/TauCeti/Analysis/Contour/Winding/UnboundedComponent.lean
+++ b/TauCeti/Analysis/Contour/Winding/UnboundedComponent.lean
@@ -5,7 +5,6 @@ Released under Apache 2.0 license as described in the file LICENSE.
 module
 
 public import Mathlib.Topology.MetricSpace.Bounded
-public import TauCeti.Analysis.Contour.PiecewiseC1On
 public import TauCeti.Analysis.Contour.Winding.LocallyConstant
 public import TauCeti.Analysis.Contour.Winding.Vanishing
 
@@ -23,8 +22,6 @@ integration roadmap: the winding number is zero on the unbounded component.
 
 ## Main results
 
-* `TauCeti.Contour.windingNumber_eq_of_mem_connectedComponentIn` — the winding number is constant
-  on each connected component of the curve complement.
 * `TauCeti.Contour.windingNumber_eq_zero_of_unbounded_component` — the winding number vanishes on
   every unbounded component of the curve complement.
 * `TauCeti.Contour.IsPiecewiseC1On.windingNumber_eq_zero_of_unbounded_component` — the direct
@@ -44,38 +41,10 @@ open scoped Topology
 
 namespace TauCeti.Contour
 
-/-- The points avoided by `γ` on `[[a, b]]` are exactly the complement of its image there. -/
-private theorem setOf_forall_ne_eq_compl_image {γ : ℝ → ℂ} {a b : ℝ} :
-    {w : ℂ | ∀ t ∈ uIcc a b, γ t ≠ w} = (γ '' uIcc a b)ᶜ := by
-  ext w
-  simp only [mem_setOf_eq, mem_compl_iff, mem_image, not_exists, not_and]
-
-/-- **The winding number is constant on a connected component of the curve complement.**
-For a closed curve that is continuous on `[[a, b]]`, differentiable away from a countable set,
-and has interval-integrable derivative, two points in the same connected component of
-`ℂ \ γ '' [[a, b]]` have the same winding number.
-
-This is the connected-component form of homotopy invariance in the point: it follows from local
-constancy of the integer-valued winding number off the curve. -/
-theorem windingNumber_eq_of_mem_connectedComponentIn {γ : ℝ → ℂ} {a b : ℝ} {P : Set ℝ}
-    (hclosed : γ a = γ b) (hP : P.Countable) (hγ_cont : ContinuousOn γ (uIcc a b))
-    (hγ_diff : ∀ t ∈ Ioo (min a b) (max a b) \ P, DifferentiableAt ℝ γ t)
-    (hderiv_int : IntervalIntegrable (fun t ↦ deriv γ t) volume a b)
-    {w₀ w₁ : ℂ} (hw₀ : w₀ ∈ (γ '' uIcc a b)ᶜ)
-    (hw₁ : w₁ ∈ connectedComponentIn ((γ '' uIcc a b)ᶜ) w₀) :
-    windingNumber γ a b w₁ = windingNumber γ a b w₀ := by
-  rw [← setOf_forall_ne_eq_compl_image] at hw₀ hw₁
-  rw [connectedComponentIn_eq_image hw₀] at hw₁
-  obtain ⟨w₁, hw₁, rfl⟩ := hw₁
-  exact
-    (isLocallyConstant_windingNumber_of_closed hclosed hP hγ_cont hγ_diff
-      hderiv_int).apply_eq_of_isPreconnected isPreconnected_connectedComponent hw₁
-        mem_connectedComponent
-
 /-- **The winding number vanishes on every unbounded component of the curve complement.**
-For a closed curve with the usual off-curve regularity, let `w` lie outside the curve. If the
-connected component of `w` in `ℂ \ γ '' [[a, b]]` is unbounded, then the winding number about `w`
-is zero.
+For a closed curve with the usual off-curve regularity, if the connected component of `w` in
+`ℂ \ γ '' [[a, b]]` is unbounded, then the winding number about `w` is zero. Unboundedness also
+ensures that `w` lies outside the curve.
 
 Indeed, far-field vanishing holds outside some compact set. An unbounded component cannot be
 contained in that compact set, so it contains a far-field point with winding number zero; the
@@ -84,9 +53,13 @@ theorem windingNumber_eq_zero_of_unbounded_component {γ : ℝ → ℂ} {a b : �
     (hclosed : γ a = γ b) (hP : P.Countable) (hγ_cont : ContinuousOn γ (uIcc a b))
     (hγ_diff : ∀ t ∈ Ioo (min a b) (max a b) \ P, DifferentiableAt ℝ γ t)
     (hderiv_int : IntervalIntegrable (fun t ↦ deriv γ t) volume a b)
-    {w : ℂ} (hw : w ∈ (γ '' uIcc a b)ᶜ)
-    (hcomp : ¬IsBounded (connectedComponentIn ((γ '' uIcc a b)ᶜ) w)) :
+    {w : ℂ} (hcomp : ¬IsBounded (connectedComponentIn ((γ '' uIcc a b)ᶜ) w)) :
     windingNumber γ a b w = 0 := by
+  have hw : w ∈ (γ '' uIcc a b)ᶜ := by
+    by_contra hw
+    apply hcomp
+    rw [connectedComponentIn_eq_empty hw]
+    exact isBounded_empty
   obtain ⟨K, hK_compact, hK_good⟩ :=
     Filter.mem_cocompact.mp
       (windingNumber_eventually_zero_cocompact hclosed hP hγ_cont hγ_diff hderiv_int)
@@ -98,17 +71,16 @@ theorem windingNumber_eq_zero_of_unbounded_component {γ : ℝ → ℂ} {a b : �
     (windingNumber_eq_of_mem_connectedComponentIn hclosed hP hγ_cont hγ_diff hderiv_int
       hw hw'_comp).symm.trans hw'_zero
 
-/-- **Piecewise-`C¹` form of vanishing on the unbounded component.** If a closed piecewise-`C¹`
-curve avoids `w` and the component of `w` in the curve complement is unbounded, its winding number
-about `w` is zero. The finite breakpoint set supplies all raw regularity hypotheses of
+/-- **Piecewise-`C¹` form of vanishing on the unbounded component.** If the component of `w` in the
+complement of a closed piecewise-`C¹` curve is unbounded, its winding number about `w` is zero. The
+finite breakpoint set supplies all raw regularity hypotheses of
 `windingNumber_eq_zero_of_unbounded_component`. -/
 theorem IsPiecewiseC1On.windingNumber_eq_zero_of_unbounded_component {γ : ℝ → ℂ} {a b : ℝ}
     (hγ : IsPiecewiseC1On γ a b) (hclosed : γ a = γ b)
-    {w : ℂ} (hw : w ∈ (γ '' uIcc a b)ᶜ)
-    (hcomp : ¬IsBounded (connectedComponentIn ((γ '' uIcc a b)ᶜ) w)) :
+    {w : ℂ} (hcomp : ¬IsBounded (connectedComponentIn ((γ '' uIcc a b)ᶜ) w)) :
     windingNumber γ a b w = 0 := by
   obtain ⟨P, hP, hγ_diff⟩ := hγ.exists_countable_differentiableAt
   exact TauCeti.Contour.windingNumber_eq_zero_of_unbounded_component hclosed hP
-    hγ.continuousOn hγ_diff hγ.intervalIntegrable_deriv hw hcomp
+    hγ.continuousOn hγ_diff hγ.intervalIntegrable_deriv hcomp
 
 end TauCeti.Contour

--- a/TauCeti/Analysis/Contour/Winding/UnboundedComponent.lean
+++ b/TauCeti/Analysis/Contour/Winding/UnboundedComponent.lean
@@ -1,0 +1,114 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+module
+
+public import Mathlib.Topology.MetricSpace.Bounded
+public import TauCeti.Analysis.Contour.PiecewiseC1On
+public import TauCeti.Analysis.Contour.Winding.LocallyConstant
+public import TauCeti.Analysis.Contour.Winding.Vanishing
+
+/-!
+# The winding number on the unbounded component
+
+For a closed curve `γ`, the winding number is constant on every connected component of the
+complement of the curve. If such a component is unbounded, it contains a point outside the compact
+set on which the far-field vanishing theorem gives no information. At that point the winding
+number is zero, and componentwise constancy transports the value back to every point of the
+component.
+
+This proves the final part of the classical off-curve winding package in Layer 0 of the contour
+integration roadmap: the winding number is zero on the unbounded component.
+
+## Main results
+
+* `TauCeti.Contour.windingNumber_eq_of_mem_connectedComponentIn` — the winding number is constant
+  on each connected component of the curve complement.
+* `TauCeti.Contour.windingNumber_eq_zero_of_unbounded_component` — the winding number vanishes on
+  every unbounded component of the curve complement.
+* `TauCeti.Contour.IsPiecewiseC1On.windingNumber_eq_zero_of_unbounded_component` — the direct
+  piecewise-`C¹` form.
+
+## References
+
+* N. Hungerbühler and M. Wasem, *Non-integer valued winding numbers and a generalized Residue
+  Theorem*, arXiv:1808.00997 (2018), Section 2.
+-/
+
+public section
+
+open Bornology Complex MeasureTheory Set
+
+open scoped Topology
+
+namespace TauCeti.Contour
+
+/-- The points avoided by `γ` on `[[a, b]]` are exactly the complement of its image there. -/
+private theorem setOf_forall_ne_eq_compl_image {γ : ℝ → ℂ} {a b : ℝ} :
+    {w : ℂ | ∀ t ∈ uIcc a b, γ t ≠ w} = (γ '' uIcc a b)ᶜ := by
+  ext w
+  simp only [mem_setOf_eq, mem_compl_iff, mem_image, not_exists, not_and]
+
+/-- **The winding number is constant on a connected component of the curve complement.**
+For a closed curve that is continuous on `[[a, b]]`, differentiable away from a countable set,
+and has interval-integrable derivative, two points in the same connected component of
+`ℂ \ γ '' [[a, b]]` have the same winding number.
+
+This is the connected-component form of homotopy invariance in the point: it follows from local
+constancy of the integer-valued winding number off the curve. -/
+theorem windingNumber_eq_of_mem_connectedComponentIn {γ : ℝ → ℂ} {a b : ℝ} {P : Set ℝ}
+    (hclosed : γ a = γ b) (hP : P.Countable) (hγ_cont : ContinuousOn γ (uIcc a b))
+    (hγ_diff : ∀ t ∈ Ioo (min a b) (max a b) \ P, DifferentiableAt ℝ γ t)
+    (hderiv_int : IntervalIntegrable (fun t ↦ deriv γ t) volume a b)
+    {w₀ w₁ : ℂ} (hw₀ : w₀ ∈ (γ '' uIcc a b)ᶜ)
+    (hw₁ : w₁ ∈ connectedComponentIn ((γ '' uIcc a b)ᶜ) w₀) :
+    windingNumber γ a b w₁ = windingNumber γ a b w₀ := by
+  rw [← setOf_forall_ne_eq_compl_image] at hw₀ hw₁
+  rw [connectedComponentIn_eq_image hw₀] at hw₁
+  obtain ⟨w₁, hw₁, rfl⟩ := hw₁
+  exact
+    (isLocallyConstant_windingNumber_of_closed hclosed hP hγ_cont hγ_diff
+      hderiv_int).apply_eq_of_isPreconnected isPreconnected_connectedComponent hw₁
+        mem_connectedComponent
+
+/-- **The winding number vanishes on every unbounded component of the curve complement.**
+For a closed curve with the usual off-curve regularity, let `w` lie outside the curve. If the
+connected component of `w` in `ℂ \ γ '' [[a, b]]` is unbounded, then the winding number about `w`
+is zero.
+
+Indeed, far-field vanishing holds outside some compact set. An unbounded component cannot be
+contained in that compact set, so it contains a far-field point with winding number zero; the
+winding number is constant on the component. -/
+theorem windingNumber_eq_zero_of_unbounded_component {γ : ℝ → ℂ} {a b : ℝ} {P : Set ℝ}
+    (hclosed : γ a = γ b) (hP : P.Countable) (hγ_cont : ContinuousOn γ (uIcc a b))
+    (hγ_diff : ∀ t ∈ Ioo (min a b) (max a b) \ P, DifferentiableAt ℝ γ t)
+    (hderiv_int : IntervalIntegrable (fun t ↦ deriv γ t) volume a b)
+    {w : ℂ} (hw : w ∈ (γ '' uIcc a b)ᶜ)
+    (hcomp : ¬IsBounded (connectedComponentIn ((γ '' uIcc a b)ᶜ) w)) :
+    windingNumber γ a b w = 0 := by
+  obtain ⟨K, hK_compact, hK_good⟩ :=
+    Filter.mem_cocompact.mp
+      (windingNumber_eventually_zero_cocompact hclosed hP hγ_cont hγ_diff hderiv_int)
+  have hnot_subset : ¬connectedComponentIn ((γ '' uIcc a b)ᶜ) w ⊆ K :=
+    fun hsubset ↦ hcomp (hK_compact.isBounded.subset hsubset)
+  obtain ⟨w', hw'_comp, hw'_notK⟩ := Set.not_subset.mp hnot_subset
+  have hw'_zero : windingNumber γ a b w' = 0 := (hK_good hw'_notK).2
+  exact
+    (windingNumber_eq_of_mem_connectedComponentIn hclosed hP hγ_cont hγ_diff hderiv_int
+      hw hw'_comp).symm.trans hw'_zero
+
+/-- **Piecewise-`C¹` form of vanishing on the unbounded component.** If a closed piecewise-`C¹`
+curve avoids `w` and the component of `w` in the curve complement is unbounded, its winding number
+about `w` is zero. The finite breakpoint set supplies all raw regularity hypotheses of
+`windingNumber_eq_zero_of_unbounded_component`. -/
+theorem IsPiecewiseC1On.windingNumber_eq_zero_of_unbounded_component {γ : ℝ → ℂ} {a b : ℝ}
+    (hγ : IsPiecewiseC1On γ a b) (hclosed : γ a = γ b)
+    {w : ℂ} (hw : w ∈ (γ '' uIcc a b)ᶜ)
+    (hcomp : ¬IsBounded (connectedComponentIn ((γ '' uIcc a b)ᶜ) w)) :
+    windingNumber γ a b w = 0 := by
+  obtain ⟨P, hP, hγ_diff⟩ := hγ.exists_countable_differentiableAt
+  exact TauCeti.Contour.windingNumber_eq_zero_of_unbounded_component hclosed hP
+    hγ.continuousOn hγ_diff hγ.intervalIntegrable_deriv hw hcomp
+
+end TauCeti.Contour

--- a/TauCeti/Analysis/Contour/Winding/UnboundedComponent.lean
+++ b/TauCeti/Analysis/Contour/Winding/UnboundedComponent.lean
@@ -55,11 +55,6 @@ theorem windingNumber_eq_zero_of_unbounded_component {γ : ℝ → ℂ} {a b : �
     (hderiv_int : IntervalIntegrable (fun t ↦ deriv γ t) volume a b)
     {w : ℂ} (hcomp : ¬IsBounded (connectedComponentIn ((γ '' uIcc a b)ᶜ) w)) :
     windingNumber γ a b w = 0 := by
-  have hw : w ∈ (γ '' uIcc a b)ᶜ := by
-    by_contra hw
-    apply hcomp
-    rw [connectedComponentIn_eq_empty hw]
-    exact isBounded_empty
   obtain ⟨K, hK_compact, hK_good⟩ :=
     Filter.mem_cocompact.mp
       (windingNumber_eventually_zero_cocompact hclosed hP hγ_cont hγ_diff hderiv_int)
@@ -69,7 +64,7 @@ theorem windingNumber_eq_zero_of_unbounded_component {γ : ℝ → ℂ} {a b : �
   have hw'_zero : windingNumber γ a b w' = 0 := (hK_good hw'_notK).2
   exact
     (windingNumber_eq_of_mem_connectedComponentIn hclosed hP hγ_cont hγ_diff hderiv_int
-      hw hw'_comp).symm.trans hw'_zero
+      hw'_comp).symm.trans hw'_zero
 
 /-- **Piecewise-`C¹` form of vanishing on the unbounded component.** If the component of `w` in the
 complement of a closed piecewise-`C¹` curve is unbounded, its winding number about `w` is zero. The


### PR DESCRIPTION
This PR proves that the winding number of a closed piecewise-`C¹` curve vanishes at every point in an unbounded connected component of the curve complement, and packages the componentwise constancy lemma that makes the conclusion reusable.

It advances `TauCetiRoadmap/ContourIntegration/README.md`, Layer 0, “The classical case,” specifically the final requirement that the winding number is “`0` on the unbounded component.” This is the lowest-hanging unfinished target because the integer-valuedness, local constancy, and eventual far-field vanishing inputs are already on `main`, while no open or recent merged PR turns them into the stated component theorem.

The proof extracts the compact exceptional set from `windingNumber_eventually_zero_cocompact`. An unbounded connected component cannot lie inside that compact set, so it contains a point where the winding number is zero; `isLocallyConstant_windingNumber_of_closed` and Mathlib’s `IsLocallyConstant.apply_eq_of_isPreconnected` transport the value through the component. The direct `IsPiecewiseC1On` corollary supplies the countable exceptional set and derivative integrability from the existing curve API.

Add `TauCeti/Analysis/Contour/Winding/UnboundedComponent.lean` (114 lines). Reuse Mathlib’s connected-component, local-constancy, cocompact-filter, and boundedness infrastructure. No Mathlib infrastructure is vendored and no external formalization is copied or adapted; the module documents the Hungerbühler–Wasem Section 2 context.

`lake build` reports `Build completed successfully (5618 jobs).` `lake exe axioms` reports `axioms: audited 13038 TauCeti declaration(s); all within the allowlist [propext, Classical.choice, Quot.sound].` `lake exe module-system` reports that all 744 TauCeti modules opt into the module system.

<!--tauceti-target:v1 {"focus":"ContourIntegration","id":"winding-number-zero-unbounded-component"}-->

🤖 Prepared with Codex
