### PR TITLE
feat: add the simple-pole decomposition

### DIFF
--- a/TauCeti/Analysis/Contour/MeromorphicLaurent.lean
+++ b/TauCeti/Analysis/Contour/MeromorphicLaurent.lean
@@ -119,6 +119,23 @@ theorem meromorphicOrderAt_lt_neg_one_of_one_lt_meromorphicPolarOrderAt {f : ℂ
   rw [meromorphicOrderAt_eq_neg_of_meromorphicPolarOrderAt_pos (by omega)]
   exact_mod_cast WithTop.coe_lt_coe.mpr (by omega)
 
+/-- The canonical polar order is at most one exactly when the meromorphic order is at least
+`-1`. This includes analytic and removable points (polar order zero) as well as genuine simple
+poles (polar order one). -/
+@[simp]
+theorem meromorphicPolarOrderAt_le_one_iff {f : ℂ → ℂ} {s : ℂ} :
+    meromorphicPolarOrderAt f s ≤ 1 ↔
+      ((-1 : ℤ) : WithTop ℤ) ≤ meromorphicOrderAt f s := by
+  constructor
+  · intro h
+    have hneg : (-1 : ℤ) ≤ -(meromorphicPolarOrderAt f s : ℤ) := by omega
+    exact (WithTop.coe_le_coe.mpr hneg).trans (neg_meromorphicPolarOrderAt_le f s)
+  · intro h
+    by_contra hle
+    have hlt : meromorphicOrderAt f s < ((-1 : ℤ) : WithTop ℤ) :=
+      meromorphicOrderAt_lt_neg_one_of_one_lt_meromorphicPolarOrderAt (by omega)
+    exact (not_lt_of_ge h) hlt
+
 /-- Taylor decomposition of an analytic function to order `k`:
 `g z = ∑ j < k, c j * (z - s)^j + (z - s)^k * R z` with `R` analytic at `s`. Mathlib's
 `AnalyticAt.exists_eventuallyEq_sum_add_pow_mul` at the translate `g (· + s)`. -/

--- a/TauCeti/Analysis/Contour/PolarPart/SimplePole.lean
+++ b/TauCeti/Analysis/Contour/PolarPart/SimplePole.lean
@@ -1,0 +1,118 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import TauCeti.Analysis.Contour.PolarPart.Decomposition
+
+/-!
+# Decomposition at finitely many simple poles
+
+A meromorphic function whose poles in a finite set `S` have order at most one splits, away from
+`S`, as a function holomorphic on the ambient open set plus the sum of its elementary principal
+parts
+
+`∑ s ∈ S, residue f s / (z - s)`.
+
+This is the simple-pole decomposition from Layer 2 of the contour-integration roadmap. The general
+canonical Laurent decomposition is already provided by `PolarPartDecomposition.ofMeromorphic`.
+Here the order bound collapses every finite Laurent tail to its order-`(-1)` coefficient, which is
+the residue.
+
+## Main results
+
+* `meromorphicPolarOrderAt_le_one_iff` identifies “polar order at most one” with the
+  `meromorphicOrderAt` condition `-1 ≤ meromorphicOrderAt f s`.
+* `PolarPartDecomposition.polarPart_eq_residue_div_of_order_le_one` collapses an abstract polar
+  part of order at most one to its residue term.
+* `PolarPartDecomposition.f_eq_analyticRemainder_add_residue_div` specializes a bundled
+  decomposition pointwise.
+* `exists_simplePoleDecomposition` gives the textbook existence statement: a differentiable
+  remainder on `U` and an explicit sum of simple principal parts off `S`.
+
+## Provenance
+
+The target corresponds to `simple_poles_decomposition` in the AINTLIB `LeanModularForms`
+development. The proof here is a direct specialization of Tau Ceti's canonical
+`PolarPartDecomposition`; no external code is copied.
+-/
+
+public section
+
+noncomputable section
+
+namespace TauCeti.Contour
+
+open Set
+
+namespace PolarPartDecomposition
+
+variable {f : ℂ → ℂ} {S : Finset ℂ} {U : Set ℂ}
+
+/-- A polar part of order at most one is its residue divided by the simple factor. For order zero,
+both sides vanish; for order one, the unique Laurent coefficient is the residue. -/
+theorem polarPart_eq_residue_div_of_order_le_one
+    (decomp : PolarPartDecomposition f S U) (s : S) (horder : decomp.order s ≤ 1) (z : ℂ) :
+    decomp.polarPart s z = residue f s / (z - (s : ℂ)) := by
+  rw [decomp.polarPart_eq, decomp.residue_eq]
+  by_cases hpos : 0 < decomp.order s
+  · rw [dif_pos hpos]
+    have huniv : (Finset.univ : Finset (Fin (decomp.order s))) = {⟨0, hpos⟩} := by
+      ext k
+      simp only [Finset.mem_univ, Finset.mem_singleton, true_iff]
+      apply Fin.ext
+      omega
+    rw [huniv, Finset.sum_singleton]
+    simp
+  · rw [dif_neg hpos, zero_div]
+    apply Finset.sum_eq_zero
+    intro k _
+    exact (hpos (Nat.zero_lt_of_lt k.isLt)).elim
+
+/-- Pointwise simple-pole form of a polar-part decomposition. If every bundled polar order is at
+most one, then off `S` the function is its analytic remainder plus the sum of the residue terms. -/
+theorem f_eq_analyticRemainder_add_residue_div
+    (decomp : PolarPartDecomposition f S U) (horder : ∀ s, decomp.order s ≤ 1)
+    {z : ℂ} (hz : z ∈ U \ (↑S : Set ℂ)) :
+    f z = decomp.analyticRemainder z + ∑ s ∈ S, residue f s / (z - s) := by
+  calc
+    f z = decomp.analyticRemainder z + ∑ s ∈ S.attach, decomp.polarPart s z :=
+      decomp.f_eq z hz
+    _ = decomp.analyticRemainder z + ∑ s ∈ S, residue f s / (z - s) := by
+      congr 1
+      calc
+        ∑ s ∈ S.attach, decomp.polarPart s z =
+            ∑ s ∈ S.attach, residue f (s : ℂ) / (z - (s : ℂ)) :=
+          Finset.sum_congr rfl fun s _ =>
+            decomp.polarPart_eq_residue_div_of_order_le_one s (horder s) z
+        _ = ∑ s ∈ S, residue f s / (z - s) :=
+          Finset.sum_attach S (fun s => residue f s / (z - s))
+
+end PolarPartDecomposition
+
+/-- **Simple-pole decomposition.** Let `U` be open and `S` finite. If `f` is differentiable on
+`U \ S`, meromorphic at every point of `S`, and has at most a simple pole there, then there is a
+function `g` differentiable throughout `U` such that, away from `S`,
+
+`f z = g z + ∑ s ∈ S, residue f s / (z - s)`.
+
+Points of `S` where `f` is analytic are allowed: their residue terms are zero. -/
+theorem exists_simplePoleDecomposition {f : ℂ → ℂ} {S : Finset ℂ} {U : Set ℂ}
+    (hU : IsOpen U) (hf : DifferentiableOn ℂ f (U \ (↑S : Set ℂ)))
+    (hmero : ∀ s ∈ S, MeromorphicAt f s)
+    (horder : ∀ s ∈ S, ((-1 : ℤ) : WithTop ℤ) ≤ meromorphicOrderAt f s) :
+    ∃ g : ℂ → ℂ, DifferentiableOn ℂ g U ∧
+      ∀ z ∈ U \ (↑S : Set ℂ),
+        f z = g z + ∑ s ∈ S, residue f s / (z - s) := by
+  let decomp := PolarPartDecomposition.ofMeromorphic hU hf hmero
+  refine ⟨decomp.analyticRemainder, decomp.analyticRemainder_differentiableOn, fun z hz => ?_⟩
+  refine decomp.f_eq_analyticRemainder_add_residue_div (z := z) ?_ hz
+  intro s
+  rw [PolarPartDecomposition.ofMeromorphic_order]
+  exact meromorphicPolarOrderAt_le_one_iff.mpr (horder s s.2)
+
+end TauCeti.Contour
+
+end


### PR DESCRIPTION
This PR adds the finite simple-pole decomposition: characterize canonical polar order at most one, collapse each such Laurent tail to `residue f s / (z - s)`, and package the existence of a remainder differentiable throughout the ambient open set.

It advances `TauCetiRoadmap/ContourIntegration/README.md`, Layer 2, item “the **simple-pole decomposition** `f = (holomorphic) + Σ_s (Res_s f)/(z − s)`.” This is the lowest-hanging distinct target because `PolarPartDecomposition.ofMeromorphic` already constructs the general finite Laurent decomposition on `main`; the missing step is precisely its at-most-simple specialization. Open PRs #1312 and #1313 concern the Layer 0 far-field winding value and Layer 1 crossing aggregation, respectively, so this work does not overlap either.

Add `TauCeti/Analysis/Contour/PolarPart/SimplePole.lean` (118 lines) with the abstract polar-part reduction, the pointwise bundled formula, and `exists_simplePoleDecomposition`. Add the adjacent characterization `meromorphicPolarOrderAt_le_one_iff` to `MeromorphicLaurent.lean`, where the canonical polar order is defined.

The target corresponds to AINTLIB `LeanModularForms`’s `simple_poles_decomposition`; the implementation here is a direct specialization of Tau Ceti’s canonical `PolarPartDecomposition`, with no external code copied. It reuses `PolarPartDecomposition.ofMeromorphic`, `meromorphicOrderAt`, and the canonical Laurent coefficient/residue identification. It vendors no Mathlib infrastructure.

<!--tauceti-target:v1 {"focus":"ContourIntegration","id":"simple-pole-decomposition"}-->

`lake build` reports `Build completed successfully (5618 jobs).` `lake exe axioms` reports `axioms: audited 13040 TauCeti declaration(s); all within the allowlist [propext, Classical.choice, Quot.sound].`

🤖 Prepared with Codex
