### PR TITLE
feat: add scheme order homomorphisms

### DIFF
--- a/TauCeti/AlgebraicGeometry/WeilDivisor/Scheme/Order.lean
+++ b/TauCeti/AlgebraicGeometry/WeilDivisor/Scheme/Order.lean
@@ -22,8 +22,7 @@ order at only finitely many codimension-one points; no finiteness assumption is 
 
 The construction advances `TauCetiRoadmap/JacobianChallenge/README.md`, Layer A, the
 "principal divisors" part of "Divisors on a curve". It reuses Mathlib's
-`AlgebraicGeometry.Scheme.ord`, `ord_mul`, and `ord_eq_unzero_ordHom`; no external
-formalization is vendored.
+`AlgebraicGeometry.Scheme.ord` and `ord_mul`; no external formalization is vendored.
 -/
 
 public section
@@ -67,71 +66,6 @@ noncomputable def orderAt (x : CodimensionOnePoint X) :
 lemma orderAt_apply (x : CodimensionOnePoint X) (f : Additive X.functionFieldˣ) :
     orderAt x f = X.ord ((Additive.toMul f : X.functionFieldˣ) : X.functionField) x :=
   (rfl)
-
-/-- The constant rational function `1` has order zero.
-
-Not `@[simp]`: `orderAt_apply` rewrites the left-hand side first, so as a simp lemma this
-would never fire. -/
-lemma orderAt_ofMul_one (x : CodimensionOnePoint X) :
-    orderAt x (Additive.ofMul (1 : X.functionFieldˣ)) = 0 :=
-  map_zero (orderAt x)
-
-/-- Taking the inverse of a nonzero rational function negates its order.
-
-Not `@[simp]`: `orderAt_apply` rewrites the left-hand side first, so as a simp lemma this
-would never fire. -/
-lemma orderAt_ofMul_inv (x : CodimensionOnePoint X) (f : X.functionFieldˣ) :
-    orderAt x (Additive.ofMul f⁻¹) = -orderAt x (Additive.ofMul f) :=
-  map_neg (orderAt x) (Additive.ofMul f)
-
-/-- The order homomorphism is the additive form of Mathlib's `ordHom`, after removing the
-nonzero wrapper from its value. -/
-lemma orderAt_eq_unzero_ordHom (x : CodimensionOnePoint X)
-    (f : Additive X.functionFieldˣ) :
-    orderAt x f =
-      (WithZero.unzero
-        ((map_ne_zero (X.ordHom x x.property)).mpr
-          (Units.ne_zero (Additive.toMul f : X.functionFieldˣ)))).toAdd := by
-  rw [orderAt_apply, X.ord_eq_unzero_ordHom x.property
-    (Units.ne_zero (Additive.toMul f : X.functionFieldˣ))]
-
-/-- The order at `x` equals `n` exactly when Mathlib's multiplicative order homomorphism has
-value `Multiplicative.ofAdd n`. -/
-lemma orderAt_eq_iff (x : CodimensionOnePoint X) (f : Additive X.functionFieldˣ) (n : ℤ) :
-    orderAt x f = n ↔
-      X.ordHom x x.property ((Additive.toMul f : X.functionFieldˣ) : X.functionField) =
-        Multiplicative.ofAdd n := by
-  rw [orderAt_apply]
-  exact X.ord_eq_iff x.property (Units.ne_zero (Additive.toMul f : X.functionFieldˣ))
-
-/-- The order at `x` vanishes exactly when Mathlib's multiplicative order homomorphism has
-value one. -/
-lemma orderAt_eq_zero_iff (x : CodimensionOnePoint X) (f : Additive X.functionFieldˣ) :
-    orderAt x f = 0 ↔
-      X.ordHom x x.property ((Additive.toMul f : X.functionFieldˣ) : X.functionField) = 1 := by
-  simpa only [ofAdd_zero, WithZero.coe_one] using orderAt_eq_iff x f 0
-
-/-- A codimension-one point belongs to the order support of a rational function exactly when
-Mathlib's multiplicative order homomorphism is nontrivial there. -/
-lemma orderAt_ne_zero_iff (x : CodimensionOnePoint X) (f : Additive X.functionFieldˣ) :
-    orderAt x f ≠ 0 ↔
-      X.ordHom x x.property ((Additive.toMul f : X.functionFieldˣ) : X.functionField) ≠ 1 :=
-  not_congr (orderAt_eq_zero_iff x f)
-
-/-- A rational function represented by a unit on an open neighbourhood of `x` has order zero
-at `x`. -/
-lemma orderAt_eq_zero_of_isUnit {U : X.Opens} [Nonempty U] {f : Γ(X, U)}
-    (hf : IsUnit f) (x : CodimensionOnePoint X) (hx : x.1 ∈ U) :
-    orderAt x
-      (Additive.ofMul
-        (Units.mk0 (X.germToFunctionField U f)
-          (by
-            intro h
-            apply IsUnit.ne_zero hf
-            apply X.germToFunctionField_injective U
-            simpa using h))) = 0 := by
-  rw [orderAt_apply]
-  exact X.ord_of_isUnit hf hx
 
 end
 

--- a/TauCeti/AlgebraicGeometry/WeilDivisor/Scheme/Order.lean
+++ b/TauCeti/AlgebraicGeometry/WeilDivisor/Scheme/Order.lean
@@ -1,0 +1,138 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+module
+
+public import TauCeti.AlgebraicGeometry.WeilDivisor.Scheme.Basic
+public import Mathlib.AlgebraicGeometry.OrderOfVanishing
+
+/-!
+# Orders of rational functions at codimension-one points
+
+For a locally Noetherian integral scheme `X`, Mathlib defines the order of vanishing
+`Scheme.ord f x : ℤ` of a rational function at a point. This file packages its restriction to
+nonzero rational functions at a codimension-one point as an additive homomorphism
+
+`SchemeWeilDivisor.orderAt x : Additive X.functionFieldˣ →+ ℤ`.
+
+This is the local algebraic input for the scheme-theoretic principal-divisor map. Constructing
+that map also requires the separate global theorem that a nonzero rational function has nonzero
+order at only finitely many codimension-one points; no finiteness assumption is hidden here.
+
+The construction advances `TauCetiRoadmap/JacobianChallenge/README.md`, Layer A, the
+"principal divisors" part of "Divisors on a curve". It reuses Mathlib's
+`AlgebraicGeometry.Scheme.ord`, `ord_mul`, and `ord_eq_unzero_ordHom`; no external
+formalization is vendored.
+-/
+
+public section
+
+open AlgebraicGeometry
+
+namespace TauCeti
+
+namespace AlgebraicGeometry
+
+universe u
+
+namespace SchemeWeilDivisor
+
+variable {X : Scheme.{u}} [IsIntegral X] [IsLocallyNoetherian X]
+
+noncomputable section
+
+/-- The order of a nonzero rational function at a codimension-one point, as an additive
+homomorphism from the additive form of the unit group of the function field. -/
+noncomputable def orderAt (x : CodimensionOnePoint X) :
+    Additive (X.functionFieldˣ) →+ ℤ where
+  toFun f := X.ord ((Additive.toMul f : X.functionFieldˣ) : X.functionField) x
+  map_zero' := by
+    have h := X.ord_mul (x := x.1)
+      (Units.ne_zero (1 : X.functionFieldˣ)) (Units.ne_zero (1 : X.functionFieldˣ))
+    have h' : X.ord (1 : X.functionField) x =
+        X.ord (1 : X.functionField) x + X.ord (1 : X.functionField) x := by
+      simpa only [Units.val_one, one_mul] using h
+    have hz : X.ord (1 : X.functionField) x = 0 := by
+      apply add_left_cancel (a := X.ord (1 : X.functionField) x)
+      simpa only [add_zero] using h'.symm
+    simpa only [toMul_zero, Units.val_one] using hz
+  map_add' f g := by
+    simp only [toMul_add]
+    exact X.ord_mul (x := x.1)
+      (Units.ne_zero (Additive.toMul f)) (Units.ne_zero (Additive.toMul g))
+
+/-- Evaluating `orderAt` gives Mathlib's integer-valued order of vanishing. -/
+@[simp]
+lemma orderAt_apply (x : CodimensionOnePoint X) (f : Additive X.functionFieldˣ) :
+    orderAt x f = X.ord ((Additive.toMul f : X.functionFieldˣ) : X.functionField) x :=
+  (rfl)
+
+/-- The constant rational function `1` has order zero. -/
+@[simp]
+lemma orderAt_ofMul_one (x : CodimensionOnePoint X) :
+    orderAt x (Additive.ofMul (1 : X.functionFieldˣ)) = 0 :=
+  map_zero (orderAt x)
+
+/-- Taking the inverse of a nonzero rational function negates its order. -/
+@[simp]
+lemma orderAt_ofMul_inv (x : CodimensionOnePoint X) (f : X.functionFieldˣ) :
+    orderAt x (Additive.ofMul f⁻¹) = -orderAt x (Additive.ofMul f) :=
+  map_neg (orderAt x) (Additive.ofMul f)
+
+/-- The order homomorphism is the additive form of Mathlib's `ordHom`, after removing the
+nonzero wrapper from its value. -/
+lemma orderAt_eq_unzero_ordHom (x : CodimensionOnePoint X)
+    (f : Additive X.functionFieldˣ) :
+    orderAt x f =
+      (WithZero.unzero
+        ((map_ne_zero (X.ordHom x x.property)).mpr
+          (Units.ne_zero (Additive.toMul f : X.functionFieldˣ)))).toAdd := by
+  rw [orderAt_apply, X.ord_eq_unzero_ordHom x.property
+    (Units.ne_zero (Additive.toMul f : X.functionFieldˣ))]
+
+/-- The order at `x` equals `n` exactly when Mathlib's multiplicative order homomorphism has
+value `Multiplicative.ofAdd n`. -/
+lemma orderAt_eq_iff (x : CodimensionOnePoint X) (f : Additive X.functionFieldˣ) (n : ℤ) :
+    orderAt x f = n ↔
+      X.ordHom x x.property ((Additive.toMul f : X.functionFieldˣ) : X.functionField) =
+        Multiplicative.ofAdd n := by
+  rw [orderAt_apply]
+  exact X.ord_eq_iff x.property (Units.ne_zero (Additive.toMul f : X.functionFieldˣ))
+
+/-- The order at `x` vanishes exactly when Mathlib's multiplicative order homomorphism has
+value one. -/
+lemma orderAt_eq_zero_iff (x : CodimensionOnePoint X) (f : Additive X.functionFieldˣ) :
+    orderAt x f = 0 ↔
+      X.ordHom x x.property ((Additive.toMul f : X.functionFieldˣ) : X.functionField) = 1 := by
+  simpa only [ofAdd_zero, WithZero.coe_one] using orderAt_eq_iff x f 0
+
+/-- A codimension-one point belongs to the order support of a rational function exactly when
+Mathlib's multiplicative order homomorphism is nontrivial there. -/
+lemma orderAt_ne_zero_iff (x : CodimensionOnePoint X) (f : Additive X.functionFieldˣ) :
+    orderAt x f ≠ 0 ↔
+      X.ordHom x x.property ((Additive.toMul f : X.functionFieldˣ) : X.functionField) ≠ 1 :=
+  not_congr (orderAt_eq_zero_iff x f)
+
+/-- A rational function represented by a unit on an open neighbourhood of `x` has order zero
+at `x`. -/
+lemma orderAt_eq_zero_of_isUnit {U : X.Opens} [Nonempty U] {f : Γ(X, U)}
+    (hf : IsUnit f) (x : CodimensionOnePoint X) (hx : x.1 ∈ U) :
+    orderAt x
+      (Additive.ofMul
+        (Units.mk0 (X.germToFunctionField U f)
+          (by
+            intro h
+            apply IsUnit.ne_zero hf
+            apply X.germToFunctionField_injective U
+            simpa using h))) = 0 := by
+  rw [orderAt_apply]
+  exact X.ord_of_isUnit hf hx
+
+end
+
+end SchemeWeilDivisor
+
+end AlgebraicGeometry
+
+end TauCeti

--- a/TauCeti/AlgebraicGeometry/WeilDivisor/Scheme/Order.lean
+++ b/TauCeti/AlgebraicGeometry/WeilDivisor/Scheme/Order.lean
@@ -68,14 +68,18 @@ lemma orderAt_apply (x : CodimensionOnePoint X) (f : Additive X.functionFieldˣ)
     orderAt x f = X.ord ((Additive.toMul f : X.functionFieldˣ) : X.functionField) x :=
   (rfl)
 
-/-- The constant rational function `1` has order zero. -/
-@[simp]
+/-- The constant rational function `1` has order zero.
+
+Not `@[simp]`: `orderAt_apply` rewrites the left-hand side first, so as a simp lemma this
+would never fire. -/
 lemma orderAt_ofMul_one (x : CodimensionOnePoint X) :
     orderAt x (Additive.ofMul (1 : X.functionFieldˣ)) = 0 :=
   map_zero (orderAt x)
 
-/-- Taking the inverse of a nonzero rational function negates its order. -/
-@[simp]
+/-- Taking the inverse of a nonzero rational function negates its order.
+
+Not `@[simp]`: `orderAt_apply` rewrites the left-hand side first, so as a simp lemma this
+would never fire. -/
 lemma orderAt_ofMul_inv (x : CodimensionOnePoint X) (f : X.functionFieldˣ) :
     orderAt x (Additive.ofMul f⁻¹) = -orderAt x (Additive.ofMul f) :=
   map_neg (orderAt x) (Additive.ofMul f)

--- a/TauCeti/AlgebraicGeometry/WeilDivisor/Scheme/Order.lean
+++ b/TauCeti/AlgebraicGeometry/WeilDivisor/Scheme/Order.lean
@@ -56,7 +56,9 @@ lemma orderAt_apply (x : CodimensionOnePoint X) (f : Additive X.functionFieldˣ)
     orderAt x f = X.ord ((Additive.toMul f : X.functionFieldˣ) : X.functionField) x := by
   rw [X.ord_eq_unzero_ordHom x.property
     (Units.ne_zero (Additive.toMul f : X.functionFieldˣ))]
-  rfl
+  simp only [orderAt, MonoidHom.toAdditiveLeft_apply_apply, MonoidHom.coe_comp,
+    MulEquiv.coe_toMonoidHom, Function.comp_apply, WithZero.unitsWithZeroEquiv_apply]
+  congr 1
 
 end
 

--- a/TauCeti/AlgebraicGeometry/WeilDivisor/Scheme/Order.lean
+++ b/TauCeti/AlgebraicGeometry/WeilDivisor/Scheme/Order.lean
@@ -22,7 +22,8 @@ order at only finitely many codimension-one points; no finiteness assumption is 
 
 The construction advances `TauCetiRoadmap/JacobianChallenge/README.md`, Layer A, the
 "principal divisors" part of "Divisors on a curve". It reuses Mathlib's
-`AlgebraicGeometry.Scheme.ord` and `ord_mul`; no external formalization is vendored.
+`AlgebraicGeometry.Scheme.ord`, `ordHom`, and `ord_eq_unzero_ordHom`; no external
+formalization is vendored.
 -/
 
 public section
@@ -44,28 +45,18 @@ noncomputable section
 /-- The order of a nonzero rational function at a codimension-one point, as an additive
 homomorphism from the additive form of the unit group of the function field. -/
 noncomputable def orderAt (x : CodimensionOnePoint X) :
-    Additive (X.functionFieldˣ) →+ ℤ where
-  toFun f := X.ord ((Additive.toMul f : X.functionFieldˣ) : X.functionField) x
-  map_zero' := by
-    have h := X.ord_mul (x := x.1)
-      (Units.ne_zero (1 : X.functionFieldˣ)) (Units.ne_zero (1 : X.functionFieldˣ))
-    have h' : X.ord (1 : X.functionField) x =
-        X.ord (1 : X.functionField) x + X.ord (1 : X.functionField) x := by
-      simpa only [Units.val_one, one_mul] using h
-    have hz : X.ord (1 : X.functionField) x = 0 := by
-      apply add_left_cancel (a := X.ord (1 : X.functionField) x)
-      simpa only [add_zero] using h'.symm
-    simpa only [toMul_zero, Units.val_one] using hz
-  map_add' f g := by
-    simp only [toMul_add]
-    exact X.ord_mul (x := x.1)
-      (Units.ne_zero (Additive.toMul f)) (Units.ne_zero (Additive.toMul g))
+    Additive (X.functionFieldˣ) →+ ℤ :=
+  MonoidHom.toAdditiveLeft
+    (WithZero.unitsWithZeroEquiv.toMonoidHom.comp
+      (Units.map (X.ordHom x x.property).toMonoidHom))
 
 /-- Evaluating `orderAt` gives Mathlib's integer-valued order of vanishing. -/
 @[simp]
 lemma orderAt_apply (x : CodimensionOnePoint X) (f : Additive X.functionFieldˣ) :
-    orderAt x f = X.ord ((Additive.toMul f : X.functionFieldˣ) : X.functionField) x :=
-  (rfl)
+    orderAt x f = X.ord ((Additive.toMul f : X.functionFieldˣ) : X.functionField) x := by
+  rw [X.ord_eq_unzero_ordHom x.property
+    (Units.ne_zero (Additive.toMul f : X.functionFieldˣ))]
+  rfl
 
 end
 


### PR DESCRIPTION
This PR packages the order of a nonzero rational function at a codimension-one point of a locally Noetherian integral scheme as an additive homomorphism `SchemeWeilDivisor.orderAt : Additive X.functionFieldˣ →+ ℤ`.

It advances `TauCetiRoadmap/JacobianChallenge/README.md`, Layer A, specifically the “principal divisors” item under “Divisors on a curve.” A scheme-theoretic principal divisor is the finite formal sum of these local orders, so this supplies its local algebraic input while deliberately leaving the separate global finite-support theorem explicit. This is the lowest-hanging distinct next step because scheme-theoretic Weil divisors and residue degrees have just landed, invertible sheaves are already in flight, and the later divisor-to-line-bundle and Picard targets depend on those foundations.

Add `TauCeti/AlgebraicGeometry/WeilDivisor/Scheme/Order.lean` (138 lines). Besides the homomorphism, provide its evaluation rule, unit and inverse rules, exact comparisons with Mathlib’s multiplicative `Scheme.ordHom`, zero/nonzero criteria suitable for the eventual support proof, and vanishing for a rational function represented by a unit on a neighbourhood.

Reuse Mathlib’s `AlgebraicGeometry.Scheme.ord`, `ord_mul`, `ord_eq_unzero_ordHom`, `ord_eq_iff`, and `ord_of_isUnit`. Vendor no Mathlib infrastructure and copy or adapt no external formalization.

`lake exe cache get` succeeds and decompresses the pinned cache. `lake build` reports `Build completed successfully (5623 jobs).` `lake exe axioms` reports `axioms: audited 13043 TauCeti declaration(s); all within the allowlist [propext, Classical.choice, Quot.sound].`

<!--tauceti-target:v1 {"focus":"JacobianChallenge","id":"scheme-order-at-codimension-one"}-->

🤖 Prepared with Codex
