### PR TITLE
feat: add class-algebra structure constants

### DIFF
--- a/TauCeti/RepresentationTheory/CharacterTable/ClassSum/StructureConstants.lean
+++ b/TauCeti/RepresentationTheory/CharacterTable/ClassSum/StructureConstants.lean
@@ -65,7 +65,7 @@ def structureConstant (Cᵢ Cⱼ Cₖ : ConjClasses G) : ℕ :=
 
 /-- The structure constant at the conjugacy class of `g` counts the corresponding
 factorizations of `g`. -/
-theorem structureConstant_mk (Cᵢ Cⱼ : ConjClasses G) (g : G) :
+@[simp] theorem structureConstant_mk (Cᵢ Cⱼ : ConjClasses G) (g : G) :
     structureConstant Cᵢ Cⱼ (ConjClasses.mk g) =
       ((Finset.univ ×ˢ Finset.univ).filter
         fun p : Cᵢ.carrier × Cⱼ.carrier => (p.1.1 : G) * p.2.1 = g).card := by
@@ -79,7 +79,7 @@ theorem structureConstant_mk (Cᵢ Cⱼ : ConjClasses G) (g : G) :
       rfl)
 
 /-- Multiplication of class sums is governed by the structure constants. -/
-theorem classSum_mul (k : Type*) [CommRing k] (Cᵢ Cⱼ : ConjClasses G) :
+theorem classSum_mul (k : Type*) [Semiring k] (Cᵢ Cⱼ : ConjClasses G) :
     classSum k Cᵢ * classSum k Cⱼ =
       ∑ Cₖ : ConjClasses G, (structureConstant Cᵢ Cⱼ Cₖ : k) • classSum k Cₖ := by
   ext g

--- a/TauCeti/RepresentationTheory/CharacterTable/ClassSum/StructureConstants.lean
+++ b/TauCeti/RepresentationTheory/CharacterTable/ClassSum/StructureConstants.lean
@@ -1,0 +1,102 @@
+module
+
+public import TauCeti.RepresentationTheory.CharacterTable.ClassSum.Basis
+
+/-!
+# Structure constants of the class algebra
+
+For conjugacy classes `Cᵢ`, `Cⱼ`, and `Cₖ` of a finite group, the structure constant
+`structureConstant Cᵢ Cⱼ Cₖ` counts factorizations `x * y = g`, where `x ∈ Cᵢ`, `y ∈ Cⱼ`, and
+`g` is any representative of `Cₖ`. Conjugating both factors proves that this count is independent
+of the representative.
+
+These natural numbers are the coefficients for multiplication in the class-sum basis of the center
+of the group algebra. They are the integral input to the Dixon--Schneider character-table
+algorithm.
+-/
+
+public section
+
+namespace TauCeti
+
+open scoped BigOperators
+
+variable {G : Type*} [Group G] [Fintype G] [DecidableEq G]
+
+/-- The type of factorizations of `g` with first factor in `Cᵢ` and second factor in `Cⱼ`. -/
+private def StructureConstantFiber (Cᵢ Cⱼ : ConjClasses G) (g : G) :=
+  {p : Cᵢ.carrier × Cⱼ.carrier // (p.1.1 : G) * p.2.1 = g}
+
+private instance (Cᵢ Cⱼ : ConjClasses G) (g : G) :
+    Fintype (StructureConstantFiber Cᵢ Cⱼ g) :=
+  by
+    unfold StructureConstantFiber
+    infer_instance
+
+private def structureConstantFiberEquiv (Cᵢ Cⱼ : ConjClasses G) {g h : G}
+    (s : G) (hs : s * g * s⁻¹ = h) :
+    StructureConstantFiber Cᵢ Cⱼ g ≃ StructureConstantFiber Cᵢ Cⱼ h where
+  toFun p := ⟨
+    (conjugateCarrierEquiv s Cᵢ p.1.1, conjugateCarrierEquiv s Cⱼ p.1.2),
+    by simpa [conj_mul, p.2] using hs⟩
+  invFun p := ⟨
+    (conjugateCarrierEquiv s⁻¹ Cᵢ p.1.1, conjugateCarrierEquiv s⁻¹ Cⱼ p.1.2),
+    by
+      rw [conjugateCarrierEquiv_apply, conjugateCarrierEquiv_apply, conj_mul, p.2]
+      rw [← hs]
+      simp [mul_assoc]⟩
+  left_inv p := by
+    apply Subtype.ext
+    apply Prod.ext <;> apply Subtype.ext <;>
+      simp [conjugateCarrierEquiv_apply, mul_assoc]
+  right_inv p := by
+    apply Subtype.ext
+    apply Prod.ext <;> apply Subtype.ext <;>
+      simp [conjugateCarrierEquiv_apply, mul_assoc]
+
+/-- The number of factorizations `x * y = g`, for `x ∈ Cᵢ`, `y ∈ Cⱼ`, and any representative
+`g` of `Cₖ`. This is independent of the representative by simultaneous conjugation. -/
+def structureConstant (Cᵢ Cⱼ Cₖ : ConjClasses G) : ℕ :=
+  Quotient.liftOn Cₖ
+    (fun g => Fintype.card (StructureConstantFiber Cᵢ Cⱼ g))
+    fun g h hgh => by
+      obtain ⟨s, hs⟩ := isConj_iff.mp hgh
+      exact Fintype.card_congr (structureConstantFiberEquiv Cᵢ Cⱼ s hs)
+
+/-- The structure constant at the conjugacy class of `g` counts the corresponding
+factorizations of `g`. -/
+theorem structureConstant_mk (Cᵢ Cⱼ : ConjClasses G) (g : G) :
+    structureConstant Cᵢ Cⱼ (ConjClasses.mk g) =
+      ((Finset.univ ×ˢ Finset.univ).filter
+        fun p : Cᵢ.carrier × Cⱼ.carrier => (p.1.1 : G) * p.2.1 = g).card := by
+  calc
+    structureConstant Cᵢ Cⱼ (ConjClasses.mk g) =
+        Fintype.card {p : Cᵢ.carrier × Cⱼ.carrier //
+          (p.1.1 : G) * p.2.1 = g} := rfl
+    _ = _ := Fintype.card_ofFinset _ (by
+      intro p
+      simp only [Finset.mem_filter, Finset.mem_univ, true_and]
+      rfl)
+
+/-- Multiplication of class sums is governed by the structure constants. -/
+theorem classSum_mul (k : Type*) [CommRing k] (Cᵢ Cⱼ : ConjClasses G) :
+    classSum k Cᵢ * classSum k Cⱼ =
+      ∑ Cₖ : ConjClasses G, (structureConstant Cᵢ Cⱼ Cₖ : k) • classSum k Cₖ := by
+  ext g
+  rw [classSum_eq_sum, classSum_eq_sum, Finset.sum_mul]
+  simp_rw [Finset.mul_sum]
+  simp only [classSum_coeff, MonoidAlgebra.coeff_sum, Finsupp.finsetSum_apply,
+    MonoidAlgebra.coeff_smul_apply, smul_eq_mul, MonoidAlgebra.of_apply,
+    MonoidAlgebra.single_mul_single, mul_one, MonoidAlgebra.coeff_single,
+    Finsupp.single_apply]
+  rw [Finset.sum_eq_single (ConjClasses.mk g)]
+  · rw [if_pos rfl, mul_one, structureConstant_mk]
+    simpa only [Finset.sum_product] using
+      (Finset.sum_boole (R := k)
+        (fun p : Cᵢ.carrier × Cⱼ.carrier => (p.1.1 : G) * p.2.1 = g)
+        (Finset.univ ×ˢ Finset.univ))
+  · intro Cₖ _ hCₖ
+    rw [if_neg hCₖ.symm, mul_zero]
+  · simp
+
+end TauCeti


### PR DESCRIPTION
This PR adds the computable natural-number structure constants of the finite-group class algebra and proves the class-sum multiplication formula. Define each coefficient as the number of factorizations `x * y = g` with factors in the specified conjugacy classes, descend that count through `ConjClasses` by simultaneous conjugation, expose its finite-filter formula at `ConjClasses.mk g`, and identify it with multiplication in the landed class-sum basis.

This advances `TauCetiRoadmap/RepresentationTheory/CharacterTheory/README.md`, Layer 1, item “Structure constants”: `structureConstant : ConjClasses G → ConjClasses G → ConjClasses G → ℕ` together with `classSum Cᵢ * classSum Cⱼ = ∑ Cₖ, aᵢⱼₖ • classSum Cₖ`. It is the immediate lowest-hanging continuation of the landed class-sum definition and basis: those provide the basis elements, while this PR supplies their multiplication table, which is the stated integer input to Dixon–Schneider.

Reuse Mathlib’s `ConjClasses` quotient, finite conjugacy-class carriers, `Quotient.liftOn`, `Fintype.card_congr`, `Finset.sum_boole`, and `MonoidAlgebra` coefficient API. No Mathlib infrastructure or external formalization is vendored.

Add `TauCeti/RepresentationTheory/CharacterTable/ClassSum/StructureConstants.lean` (102 lines). `lake exe cache get` reports `No files to download` and `Already decompressed 8641 file(s)`. `lake build` reports `Build completed successfully (5618 jobs).` `lake exe axioms` reports `axioms: audited 13046 TauCeti declaration(s); all within the allowlist [propext, Classical.choice, Quot.sound].`

<!--tauceti-target:v1 {"focus":"RepresentationTheory","id":"structure-constant"}-->

🤖 Prepared with Codex
